### PR TITLE
TRD: Introduce strict matching mode + MC labels for tracks

### DIFF
--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
@@ -387,6 +387,8 @@ struct RecoContainer {
   }
   auto getITSTPCTRDTracksMCLabels() const { return getSpan<o2::MCCompLabel>(GTrackID::ITSTPCTRD, MCLABELS); }
   auto getITSTPCTRDTrackMCLabel(GTrackID id) const { return getObject<o2::MCCompLabel>(id, MCLABELS); }
+  auto getITSTPCTRDSATracksMCLabels() const { return getSpan<o2::MCCompLabel>(GTrackID::ITSTPCTRD, MCLABELSEXTRA); }
+  auto getITSTPCTRDSATrackMCLabel(GTrackID id) const { return getObject<o2::MCCompLabel>(id, MCLABELSEXTRA); }
 
   // TPC-TRD
   template <class U>
@@ -405,6 +407,8 @@ struct RecoContainer {
   }
   auto getTPCTRDTracksMCLabels() const { return getSpan<o2::MCCompLabel>(GTrackID::TPCTRD, MCLABELS); }
   auto getTPCTRDTrackMCLabel(GTrackID id) const { return getObject<o2::MCCompLabel>(id, MCLABELS); }
+  auto getTPCTRDSATracksMCLabels() const { return getSpan<o2::MCCompLabel>(GTrackID::TPCTRD, MCLABELSEXTRA); }
+  auto getTPCTRDSATrackMCLabel(GTrackID id) const { return getObject<o2::MCCompLabel>(id, MCLABELSEXTRA); }
   // TRD tracklets
   gsl::span<const o2::trd::Tracklet64> getTRDTracklets() const;
   gsl::span<const o2::trd::CalibratedTracklet> getTRDCalibratedTracklets() const;

--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
@@ -240,7 +240,7 @@ struct RecoContainer {
   void addITSClusters(o2::framework::ProcessingContext& pc, bool mc);
   void addTPCClusters(o2::framework::ProcessingContext& pc, bool mc, bool shmap);
   void addTOFClusters(o2::framework::ProcessingContext& pc, bool mc);
-  void addTRDTracklets(o2::framework::ProcessingContext& pc);
+  void addTRDTracklets(o2::framework::ProcessingContext& pc, bool mc);
 
   void addFT0RecPoints(o2::framework::ProcessingContext& pc, bool mc);
 
@@ -385,6 +385,8 @@ struct RecoContainer {
   {
     return getSpan<o2::trd::TrackTriggerRecord>(GTrackID::ITSTPCTRD, TRACKREFS);
   }
+  auto getITSTPCTRDTracksMCLabels() const { return getSpan<o2::MCCompLabel>(GTrackID::ITSTPCTRD, MCLABELS); }
+  auto getITSTPCTRDTrackMCLabel(GTrackID id) const { return getObject<o2::MCCompLabel>(id, MCLABELS); }
 
   // TPC-TRD
   template <class U>
@@ -401,6 +403,8 @@ struct RecoContainer {
   {
     return getSpan<o2::trd::TrackTriggerRecord>(GTrackID::TPCTRD, TRACKREFS);
   }
+  auto getTPCTRDTracksMCLabels() const { return getSpan<o2::MCCompLabel>(GTrackID::TPCTRD, MCLABELS); }
+  auto getTPCTRDTrackMCLabel(GTrackID id) const { return getObject<o2::MCCompLabel>(id, MCLABELS); }
   // TRD tracklets
   gsl::span<const o2::trd::Tracklet64> getTRDTracklets() const;
   gsl::span<const o2::trd::CalibratedTracklet> getTRDCalibratedTracklets() const;

--- a/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
+++ b/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
@@ -115,9 +115,9 @@ void DataRequest::requestITSTPCTRDTracks(bool mc)
   addInput({"trackITSTPCTRD", "TRD", "MATCHTRD_GLO", 0, Lifetime::Timeframe});
   addInput({"trigITSTPCTRD", "TRD", "TRKTRG_GLO", 0, Lifetime::Timeframe});
   if (mc) {
-    LOG(WARNING) << "TRD Tracks does not support MC truth, dummy label will be returned";
+    addInput({"trackITSTPCTRDMCTR", "GLO", "MTCHLBL_GLO", 0, Lifetime::Timeframe});
   }
-  requestMap["trackITSTPCTRD"] = false;
+  requestMap["trackITSTPCTRD"] = mc;
 }
 
 void DataRequest::requestTPCTRDTracks(bool mc)
@@ -126,9 +126,9 @@ void DataRequest::requestTPCTRDTracks(bool mc)
   addInput({"trackTPCTRD", "TRD", "MATCHTRD_TPC", ss, Lifetime::Timeframe});
   addInput({"trigTPCTRD", "TRD", "TRKTRG_TPC", ss, Lifetime::Timeframe});
   if (mc) {
-    LOG(WARNING) << "TRD Tracks does not support MC truth, dummy label will be returned";
+    addInput({"trackTPCTRDMCTR", "GLO", "MTCHLBL_TPC", 0, Lifetime::Timeframe});
   }
-  requestMap["trackTPCTRD"] = false;
+  requestMap["trackTPCTRD"] = mc;
 }
 
 void DataRequest::requestTOFMatches(bool mc)
@@ -354,7 +354,7 @@ void RecoContainer::collectData(ProcessingContext& pc, const DataRequest& reques
 
   req = reqMap.find("trackletTRD");
   if (req != reqMap.end()) {
-    addTRDTracklets(pc);
+    addTRDTracklets(pc, req->second);
   }
 
   req = reqMap.find("Cosmics");
@@ -485,6 +485,9 @@ void RecoContainer::addITSTPCTRDTracks(ProcessingContext& pc, bool mc)
 {
   commonPool[GTrackID::ITSTPCTRD].registerContainer(pc.inputs().get<gsl::span<o2::trd::TrackTRD>>("trackITSTPCTRD"), TRACKS);
   commonPool[GTrackID::ITSTPCTRD].registerContainer(pc.inputs().get<gsl::span<o2::trd::TrackTriggerRecord>>("trigITSTPCTRD"), TRACKREFS);
+  if (mc) {
+    commonPool[GTrackID::ITSTPCTRD].registerContainer(pc.inputs().get<gsl::span<o2::MCCompLabel>>("trackITSTPCTRDMCTR"), MCLABELS);
+  }
 }
 
 //__________________________________________________________
@@ -492,6 +495,9 @@ void RecoContainer::addTPCTRDTracks(ProcessingContext& pc, bool mc)
 {
   commonPool[GTrackID::TPCTRD].registerContainer(pc.inputs().get<gsl::span<o2::trd::TrackTRD>>("trackTPCTRD"), TRACKS);
   commonPool[GTrackID::TPCTRD].registerContainer(pc.inputs().get<gsl::span<o2::trd::TrackTriggerRecord>>("trigTPCTRD"), TRACKREFS);
+  if (mc) {
+    commonPool[GTrackID::TPCTRD].registerContainer(pc.inputs().get<gsl::span<o2::MCCompLabel>>("trackTPCTRDMCTR"), MCLABELS);
+  }
 }
 
 //__________________________________________________________
@@ -534,9 +540,9 @@ void RecoContainer::addTPCClusters(ProcessingContext& pc, bool mc, bool shmap)
 }
 
 //__________________________________________________________
-void RecoContainer::addTRDTracklets(ProcessingContext& pc)
+void RecoContainer::addTRDTracklets(ProcessingContext& pc, bool mc)
 {
-  inputsTRD = o2::trd::getRecoInputContainer(pc, nullptr, this);
+  inputsTRD = o2::trd::getRecoInputContainer(pc, nullptr, this, mc);
 }
 
 //__________________________________________________________

--- a/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
+++ b/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
@@ -112,10 +112,11 @@ void DataRequest::requestTPCTOFTracks(bool mc)
 
 void DataRequest::requestITSTPCTRDTracks(bool mc)
 {
-  addInput({"trackITSTPCTRD", "TRD", "MATCHTRD_GLO", 0, Lifetime::Timeframe});
-  addInput({"trigITSTPCTRD", "TRD", "TRKTRG_GLO", 0, Lifetime::Timeframe});
+  addInput({"trackITSTPCTRD", "TRD", "MATCH_ITSTPC", 0, Lifetime::Timeframe});
+  addInput({"trigITSTPCTRD", "TRD", "TRGREC_ITSTPC", 0, Lifetime::Timeframe});
   if (mc) {
-    addInput({"trackITSTPCTRDMCTR", "GLO", "MTCHLBL_GLO", 0, Lifetime::Timeframe});
+    addInput({"trackITSTPCTRDMCTR", "TRD", "MCLB_ITSTPC", 0, Lifetime::Timeframe});
+    addInput({"trackITSTPCTRDSAMCTR", "TRD", "MCLB_ITSTPC_TRD", 0, Lifetime::Timeframe});
   }
   requestMap["trackITSTPCTRD"] = mc;
 }
@@ -123,10 +124,11 @@ void DataRequest::requestITSTPCTRDTracks(bool mc)
 void DataRequest::requestTPCTRDTracks(bool mc)
 {
   auto ss = getMatchingInputSubSpec();
-  addInput({"trackTPCTRD", "TRD", "MATCHTRD_TPC", ss, Lifetime::Timeframe});
-  addInput({"trigTPCTRD", "TRD", "TRKTRG_TPC", ss, Lifetime::Timeframe});
+  addInput({"trackTPCTRD", "TRD", "MATCH_TPC", ss, Lifetime::Timeframe});
+  addInput({"trigTPCTRD", "TRD", "TRGREC_TPC", ss, Lifetime::Timeframe});
   if (mc) {
-    addInput({"trackTPCTRDMCTR", "GLO", "MTCHLBL_TPC", 0, Lifetime::Timeframe});
+    addInput({"trackTPCTRDMCTR", "TRD", "MCLB_TPC", ss, Lifetime::Timeframe});
+    addInput({"trackTPCTRDSAMCTR", "TRD", "MCLB_TPC_TRD", ss, Lifetime::Timeframe});
   }
   requestMap["trackTPCTRD"] = mc;
 }
@@ -487,6 +489,7 @@ void RecoContainer::addITSTPCTRDTracks(ProcessingContext& pc, bool mc)
   commonPool[GTrackID::ITSTPCTRD].registerContainer(pc.inputs().get<gsl::span<o2::trd::TrackTriggerRecord>>("trigITSTPCTRD"), TRACKREFS);
   if (mc) {
     commonPool[GTrackID::ITSTPCTRD].registerContainer(pc.inputs().get<gsl::span<o2::MCCompLabel>>("trackITSTPCTRDMCTR"), MCLABELS);
+    commonPool[GTrackID::ITSTPCTRD].registerContainer(pc.inputs().get<gsl::span<o2::MCCompLabel>>("trackITSTPCTRDSAMCTR"), MCLABELSEXTRA);
   }
 }
 
@@ -497,6 +500,7 @@ void RecoContainer::addTPCTRDTracks(ProcessingContext& pc, bool mc)
   commonPool[GTrackID::TPCTRD].registerContainer(pc.inputs().get<gsl::span<o2::trd::TrackTriggerRecord>>("trigTPCTRD"), TRACKREFS);
   if (mc) {
     commonPool[GTrackID::TPCTRD].registerContainer(pc.inputs().get<gsl::span<o2::MCCompLabel>>("trackTPCTRDMCTR"), MCLABELS);
+    commonPool[GTrackID::TPCTRD].registerContainer(pc.inputs().get<gsl::span<o2::MCCompLabel>>("trackTPCTRDSAMCTR"), MCLABELSEXTRA);
   }
 }
 

--- a/Detectors/GlobalTrackingWorkflow/helpers/src/InputHelper.cxx
+++ b/Detectors/GlobalTrackingWorkflow/helpers/src/InputHelper.cxx
@@ -88,10 +88,10 @@ int InputHelper::addInputSpecs(const ConfigContext& configcontext, WorkflowSpec&
     specs.emplace_back(o2::trd::getTRDTrackletReaderSpec(maskClustersMC[GID::TRD], true));
   }
   if (maskTracks[GID::ITSTPCTRD]) {
-    specs.emplace_back(o2::trd::getTRDGlobalTrackReaderSpec(false));
+    specs.emplace_back(o2::trd::getTRDGlobalTrackReaderSpec(maskTracksMC[GID::ITSTPCTRD]));
   }
   if (maskTracks[GID::TPCTRD]) {
-    specs.emplace_back(o2::trd::getTRDTPCTrackReaderSpec(false, subSpecStrict));
+    specs.emplace_back(o2::trd::getTRDTPCTrackReaderSpec(maskTracksMC[GID::TPCTRD], subSpecStrict));
   }
 
   return 0;

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDGlobalTrackingSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDGlobalTrackingSpec.h
@@ -24,6 +24,8 @@
 #include "DataFormatsGlobalTracking/RecoContainer.h"
 #include "DataFormatsTRD/TrackTRD.h"
 #include "DataFormatsTRD/TrackTriggerRecord.h"
+#include "SimulationDataFormat/MCCompLabel.h"
+#include "SimulationDataFormat/ConstMCTruthContainer.h"
 #include <memory>
 
 namespace o2
@@ -38,6 +40,7 @@ class TRDGlobalTracking : public o2::framework::Task
   ~TRDGlobalTracking() override = default;
   void init(o2::framework::InitContext& ic) final;
   void updateTimeDependentParams();
+  void fillMCTruthInfo(const TrackTRD& trk, const o2::MCCompLabel& lblSeed, std::vector<o2::MCCompLabel>& lblContainer, const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* trkltLabels) const;
   void fillTrackTriggerRecord(const std::vector<TrackTRD>& tracks, std::vector<TrackTriggerRecord>& trigRec, const gsl::span<const o2::trd::TriggerRecord>& trackletTrigRec) const;
   void run(o2::framework::ProcessingContext& pc) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDGlobalTrackingSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDGlobalTrackingSpec.h
@@ -40,7 +40,7 @@ class TRDGlobalTracking : public o2::framework::Task
   ~TRDGlobalTracking() override = default;
   void init(o2::framework::InitContext& ic) final;
   void updateTimeDependentParams();
-  void fillMCTruthInfo(const TrackTRD& trk, const o2::MCCompLabel& lblSeed, std::vector<o2::MCCompLabel>& lblContainer, const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* trkltLabels) const;
+  void fillMCTruthInfo(const TrackTRD& trk, o2::MCCompLabel lblSeed, std::vector<o2::MCCompLabel>& lblContainerTrd, std::vector<o2::MCCompLabel>& lblContainerMatch, const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* trkltLabels) const;
   void fillTrackTriggerRecord(const std::vector<TrackTRD>& tracks, std::vector<TrackTriggerRecord>& trigRec, const gsl::span<const o2::trd::TriggerRecord>& trackletTrigRec) const;
   void run(o2::framework::ProcessingContext& pc) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
@@ -22,8 +22,6 @@
 #include "TRDSimulation/TrapConfig.h"
 #include "DataFormatsTRD/Tracklet64.h"
 #include "DataFormatsTRD/Constants.h"
-#include <SimulationDataFormat/MCCompLabel.h>
-#include <SimulationDataFormat/ConstMCTruthContainer.h>
 
 class Calibrations;
 

--- a/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDCalibratedTrackletWriterSpec.h
+++ b/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDCalibratedTrackletWriterSpec.h
@@ -19,7 +19,7 @@ namespace o2
 namespace trd
 {
 
-framework::DataProcessorSpec getTRDCalibratedTrackletWriterSpec();
+framework::DataProcessorSpec getTRDCalibratedTrackletWriterSpec(bool useMC);
 
 } // end namespace trd
 } // end namespace o2

--- a/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDTrackReaderSpec.h
+++ b/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDTrackReaderSpec.h
@@ -58,7 +58,8 @@ class TRDTrackReader : public Task
   std::string mFileName = "";
   std::vector<o2::trd::TrackTRD> mTracks, *mTracksPtr = &mTracks;
   std::vector<o2::trd::TrackTriggerRecord> mTrigRec, *mTrigRecPtr = &mTrigRec;
-  std::vector<o2::MCCompLabel> mLabels, *mLabelsPtr = &mLabels;
+  std::vector<o2::MCCompLabel> mLabelsMatch, *mLabelsMatchPtr = &mLabelsMatch;
+  std::vector<o2::MCCompLabel> mLabelsTrd, *mLabelsTrdPtr = &mLabelsTrd;
 };
 
 /// read TPC-TRD matched tracks from a root file

--- a/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDTrackReaderSpec.h
+++ b/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDTrackReaderSpec.h
@@ -16,6 +16,7 @@
 
 #include "DataFormatsTRD/TrackTRD.h"
 #include "DataFormatsTRD/TrackTriggerRecord.h"
+#include "SimulationDataFormat/MCCompLabel.h"
 
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
@@ -57,6 +58,7 @@ class TRDTrackReader : public Task
   std::string mFileName = "";
   std::vector<o2::trd::TrackTRD> mTracks, *mTracksPtr = &mTracks;
   std::vector<o2::trd::TrackTriggerRecord> mTrigRec, *mTrigRecPtr = &mTrigRec;
+  std::vector<o2::MCCompLabel> mLabels, *mLabelsPtr = &mLabels;
 };
 
 /// read TPC-TRD matched tracks from a root file

--- a/Detectors/TRD/workflow/io/src/TRDCalibratedTrackletWriterSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDCalibratedTrackletWriterSpec.cxx
@@ -11,6 +11,8 @@
 
 #include "TRDWorkflowIO/TRDCalibratedTrackletWriterSpec.h"
 #include "DataFormatsTRD/CalibratedTracklet.h"
+#include <SimulationDataFormat/MCTruthContainer.h>
+#include <SimulationDataFormat/MCCompLabel.h>
 
 #include "DPLUtils/MakeRootTreeWriterSpec.h"
 
@@ -24,7 +26,7 @@ namespace trd
 template <typename T>
 using BranchDefinition = framework::MakeRootTreeWriterSpec::BranchDefinition<T>;
 
-o2::framework::DataProcessorSpec getTRDCalibratedTrackletWriterSpec()
+o2::framework::DataProcessorSpec getTRDCalibratedTrackletWriterSpec(bool useMC)
 {
   using MakeRootTreeWriterSpec = framework::MakeRootTreeWriterSpec;
 
@@ -32,6 +34,7 @@ o2::framework::DataProcessorSpec getTRDCalibratedTrackletWriterSpec()
                                 "trdcalibratedtracklets.root",
                                 "ctracklets",
                                 BranchDefinition<std::vector<CalibratedTracklet>>{InputSpec{"ctracklets", "TRD", "CTRACKLETS"}, "CTracklets"},
+                                BranchDefinition<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>{InputSpec{"trklabels", "TRD", "TRKLABELS"}, "TRKLabels", (useMC ? 1 : 0), "TRKLABELS"},
                                 BranchDefinition<std::vector<char>>{InputSpec{"trigrecmask", "TRD", "TRIGRECMASK"}, "TrigRecMask"})();
 };
 

--- a/Detectors/TRD/workflow/io/src/TRDTrackReaderSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDTrackReaderSpec.cxx
@@ -41,19 +41,27 @@ void TRDTrackReader::run(ProcessingContext& pc)
   assert(ent < mTree->GetEntries()); // this should not happen
   mTree->GetEntry(ent);
   LOG(INFO) << "Pushing " << mTracks.size() << " tracks and " << mTrigRec.size() << " trigger records at entry " << ent;
+  if (mUseMC) {
+    if (mLabelsTrd.size() != mLabelsMatch.size()) {
+      LOG(ERROR) << "The number of labels for matches and for TRD tracks is different. " << mLabelsTrd.size() << " TRD labels vs. " << mLabelsMatch.size() << " match labels";
+    }
+    LOG(INFO) << "Pushing " << mLabelsTrd.size() << " MC labels at entry " << ent;
+  }
 
   if (mMode == Mode::TPCTRD) {
     uint32_t ss = o2::globaltracking::getSubSpec(mSubSpecStrict ? o2::globaltracking::MatchingType::Strict : o2::globaltracking::MatchingType::Standard);
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MATCHTRD_TPC", ss, Lifetime::Timeframe}, mTracks);
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRKTRG_TPC", ss, Lifetime::Timeframe}, mTrigRec);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MATCH_TPC", ss, Lifetime::Timeframe}, mTracks);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRGREC_TPC", ss, Lifetime::Timeframe}, mTrigRec);
     if (mUseMC) {
-      pc.outputs().snapshot(Output{"GLO", "MTCHLBL_TPC", ss, Lifetime::Timeframe}, mLabels);
+      pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MCLB_TPC", ss, Lifetime::Timeframe}, mLabelsMatch);
+      pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MCLB_TPC_TRD", ss, Lifetime::Timeframe}, mLabelsTrd);
     }
   } else if (mMode == Mode::ITSTPCTRD) {
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MATCHTRD_GLO", 0, Lifetime::Timeframe}, mTracks);
-    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRKTRG_GLO", 0, Lifetime::Timeframe}, mTrigRec);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MATCH_ITSTPC", 0, Lifetime::Timeframe}, mTracks);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRGREC_ITSTPC", 0, Lifetime::Timeframe}, mTrigRec);
     if (mUseMC) {
-      pc.outputs().snapshot(Output{"GLO", "MTCHLBL_GLO", 0, Lifetime::Timeframe}, mLabels);
+      pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MCLB_ITSTPC", 0, Lifetime::Timeframe}, mLabelsMatch);
+      pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MCLB_ITSTPC_TRD", 0, Lifetime::Timeframe}, mLabelsTrd);
     }
   }
 
@@ -73,7 +81,8 @@ void TRDTrackReader::connectTree(const std::string& filename)
   mTree->SetBranchAddress("tracks", &mTracksPtr);
   mTree->SetBranchAddress("trgrec", &mTrigRecPtr);
   if (mUseMC) {
-    mTree->SetBranchAddress("labels", &mLabelsPtr);
+    mTree->SetBranchAddress("labels", &mLabelsMatchPtr);
+    mTree->SetBranchAddress("labelsTRD", &mLabelsTrdPtr);
   }
   LOG(INFO) << "Loaded tree from " << filename << " with " << mTree->GetEntries() << " entries";
 }
@@ -82,11 +91,12 @@ DataProcessorSpec getTRDTPCTrackReaderSpec(bool useMC, bool subSpecStrict)
 {
   std::vector<OutputSpec> outputs;
   uint32_t sspec = o2::globaltracking::getSubSpec(subSpecStrict ? o2::globaltracking::MatchingType::Strict : o2::globaltracking::MatchingType::Standard);
-  outputs.emplace_back(o2::header::gDataOriginTRD, "MATCHTRD_TPC", sspec, Lifetime::Timeframe);
-  outputs.emplace_back(o2::header::gDataOriginTRD, "TRKTRG_TPC", sspec, Lifetime::Timeframe);
+  outputs.emplace_back(o2::header::gDataOriginTRD, "MATCH_TPC", sspec, Lifetime::Timeframe);
+  outputs.emplace_back(o2::header::gDataOriginTRD, "TRGREC_TPC", sspec, Lifetime::Timeframe);
 
   if (useMC) {
-    outputs.emplace_back(o2::header::gDataOriginTRD, "MTCHLBL_TPC", sspec, Lifetime::Timeframe);
+    outputs.emplace_back(o2::header::gDataOriginTRD, "MCLB_TPC", sspec, Lifetime::Timeframe);
+    outputs.emplace_back(o2::header::gDataOriginTRD, "MCLB_TPC_TRD", sspec, Lifetime::Timeframe);
   }
   return DataProcessorSpec{
     "tpctrd-track-reader",
@@ -101,11 +111,12 @@ DataProcessorSpec getTRDTPCTrackReaderSpec(bool useMC, bool subSpecStrict)
 DataProcessorSpec getTRDGlobalTrackReaderSpec(bool useMC)
 {
   std::vector<OutputSpec> outputs;
-  outputs.emplace_back(o2::header::gDataOriginTRD, "MATCHTRD_GLO", 0, Lifetime::Timeframe);
-  outputs.emplace_back(o2::header::gDataOriginTRD, "TRKTRG_GLO", 0, Lifetime::Timeframe);
+  outputs.emplace_back(o2::header::gDataOriginTRD, "MATCH_ITSTPC", 0, Lifetime::Timeframe);
+  outputs.emplace_back(o2::header::gDataOriginTRD, "TRGREC_ITSTPC", 0, Lifetime::Timeframe);
 
   if (useMC) {
-    outputs.emplace_back(o2::header::gDataOriginTRD, "MTCHLBL_GLO", 0, Lifetime::Timeframe);
+    outputs.emplace_back(o2::header::gDataOriginTRD, "MCLB_ITSTPC", 0, Lifetime::Timeframe);
+    outputs.emplace_back(o2::header::gDataOriginTRD, "MCLB_ITSTPC_TRD", 0, Lifetime::Timeframe);
   }
 
   return DataProcessorSpec{

--- a/Detectors/TRD/workflow/io/src/TRDTrackWriterSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDTrackWriterSpec.cxx
@@ -44,17 +44,20 @@ DataProcessorSpec getTRDGlobalTrackWriterSpec(bool useMC)
   return MakeRootTreeWriterSpec("trd-track-writer-tpcits",
                                 "trdmatches_itstpc.root",
                                 "tracksTRD",
-                                BranchDefinition<std::vector<o2::trd::TrackTRD>>{InputSpec{"tracks", o2::header::gDataOriginTRD, "MATCHTRD_GLO", 0},
+                                BranchDefinition<std::vector<o2::trd::TrackTRD>>{InputSpec{"tracks", o2::header::gDataOriginTRD, "MATCH_ITSTPC", 0},
                                                                                  "tracks",
                                                                                  "tracks-branch-name",
                                                                                  1,
                                                                                  tracksLogger},
-                                BranchDefinition<std::vector<o2::trd::TrackTriggerRecord>>{InputSpec{"trackTrig", o2::header::gDataOriginTRD, "TRKTRG_GLO", 0},
+                                BranchDefinition<std::vector<o2::trd::TrackTriggerRecord>>{InputSpec{"trackTrig", o2::header::gDataOriginTRD, "TRGREC_ITSTPC", 0},
                                                                                            "trgrec",
                                                                                            "trgrec-branch-name",
                                                                                            1},
-
-                                BranchDefinition<LabelsType>{InputSpec{"matchtpclabels", "GLO", "MTCHLBL_GLO", 0},
+                                BranchDefinition<LabelsType>{InputSpec{"trdlabels", o2::header::gDataOriginTRD, "MCLB_ITSTPC_TRD", 0},
+                                                             "labelsTRD",
+                                                             (useMC ? 1 : 0), // one branch if mc labels enabled
+                                                             "trdlabels-branch-name"},
+                                BranchDefinition<LabelsType>{InputSpec{"matchtpclabels", o2::header::gDataOriginTRD, "MCLB_ITSTPC", 0},
                                                              "labels",
                                                              (useMC ? 1 : 0), // one branch if mc labels enabled
                                                              "labels-branch-name"})();
@@ -73,16 +76,20 @@ DataProcessorSpec getTRDTPCTrackWriterSpec(bool useMC, bool strictMode)
   return MakeRootTreeWriterSpec("trd-track-writer-tpc",
                                 "trdmatches_tpc.root",
                                 "tracksTRD",
-                                BranchDefinition<std::vector<o2::trd::TrackTRD>>{InputSpec{"tracks", o2::header::gDataOriginTRD, "MATCHTRD_TPC", ss},
+                                BranchDefinition<std::vector<o2::trd::TrackTRD>>{InputSpec{"tracks", o2::header::gDataOriginTRD, "MATCH_TPC", ss},
                                                                                  "tracks",
                                                                                  "tracks-branch-name",
                                                                                  1,
                                                                                  tracksLogger},
-                                BranchDefinition<std::vector<o2::trd::TrackTriggerRecord>>{InputSpec{"trackTrig", o2::header::gDataOriginTRD, "TRKTRG_TPC", ss},
+                                BranchDefinition<std::vector<o2::trd::TrackTriggerRecord>>{InputSpec{"trackTrig", o2::header::gDataOriginTRD, "TRGREC_TPC", ss},
                                                                                            "trgrec",
                                                                                            "trgrec-branch-name",
                                                                                            1},
-                                BranchDefinition<LabelsType>{InputSpec{"matchitstpclabels", "GLO", "MTCHLBL_TPC", ss},
+                                BranchDefinition<LabelsType>{InputSpec{"trdlabels", o2::header::gDataOriginTRD, "MCLB_TPC_TRD", ss},
+                                                             "labelsTRD",
+                                                             (useMC ? 1 : 0), // one branch if mc labels enabled
+                                                             "trdlabels-branch-name"},
+                                BranchDefinition<LabelsType>{InputSpec{"matchitstpclabels", o2::header::gDataOriginTRD, "MCLB_TPC", ss},
                                                              "labels",
                                                              (useMC ? 1 : 0), // one branch if mc labels enabled
                                                              "labels-branch-name"})();

--- a/Detectors/TRD/workflow/io/src/TRDTrackWriterSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDTrackWriterSpec.cxx
@@ -17,6 +17,7 @@
 #include "ReconstructionDataFormats/MatchingType.h"
 #include "DPLUtils/MakeRootTreeWriterSpec.h"
 #include "TRDWorkflowIO/TRDTrackWriterSpec.h"
+#include "SimulationDataFormat/MCCompLabel.h"
 
 using namespace o2::framework;
 using namespace o2::gpu;
@@ -32,12 +33,7 @@ using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
 
 DataProcessorSpec getTRDGlobalTrackWriterSpec(bool useMC)
 {
-  // TODO: not clear if the writer is supposed to write MC labels at some point
-  // this is just a dummy definition for the template branch definition below
-  // define the correct type and the input specs
-  using LabelsType = std::vector<int>;
-  // force, this will disable the branch for now, can be adjusted in the future
-  useMC = false;
+  using LabelsType = std::vector<o2::MCCompLabel>;
 
   // A spectator to store the size of the data array for the logger below
   auto tracksSize = std::make_shared<int>();
@@ -57,9 +53,8 @@ DataProcessorSpec getTRDGlobalTrackWriterSpec(bool useMC)
                                                                                            "trgrec",
                                                                                            "trgrec-branch-name",
                                                                                            1},
-                                // NOTE: this branch template is to show how the conditional MC labels can
-                                // be defined, the '0' disables the branch for the moment
-                                BranchDefinition<LabelsType>{InputSpec{"matchtpclabels", "GLO", "SOME_LABELS", 0},
+
+                                BranchDefinition<LabelsType>{InputSpec{"matchtpclabels", "GLO", "MTCHLBL_GLO", 0},
                                                              "labels",
                                                              (useMC ? 1 : 0), // one branch if mc labels enabled
                                                              "labels-branch-name"})();
@@ -67,12 +62,7 @@ DataProcessorSpec getTRDGlobalTrackWriterSpec(bool useMC)
 
 DataProcessorSpec getTRDTPCTrackWriterSpec(bool useMC, bool strictMode)
 {
-  // TODO: not clear if the writer is supposed to write MC labels at some point
-  // this is just a dummy definition for the template branch definition below
-  // define the correct type and the input specs
-  using LabelsType = std::vector<int>;
-  // force, this will disable the branch for now, can be adjusted in the future
-  useMC = false;
+  using LabelsType = std::vector<o2::MCCompLabel>;
 
   // A spectator to store the size of the data array for the logger below
   auto tracksSize = std::make_shared<int>();
@@ -92,9 +82,7 @@ DataProcessorSpec getTRDTPCTrackWriterSpec(bool useMC, bool strictMode)
                                                                                            "trgrec",
                                                                                            "trgrec-branch-name",
                                                                                            1},
-                                // NOTE: this branch template is to show how the conditional MC labels can
-                                // be defined, the '0' disables the branch for the moment
-                                BranchDefinition<LabelsType>{InputSpec{"matchtpclabels", "GLO", "SOME_LABELS", ss},
+                                BranchDefinition<LabelsType>{InputSpec{"matchitstpclabels", "GLO", "MTCHLBL_TPC", ss},
                                                              "labels",
                                                              (useMC ? 1 : 0), // one branch if mc labels enabled
                                                              "labels-branch-name"})();

--- a/Detectors/TRD/workflow/io/src/TRDTrackletReaderSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDTrackletReaderSpec.cxx
@@ -85,6 +85,7 @@ void TRDTrackletReader::run(ProcessingContext& pc)
 
   pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRKTRGRD", 0, Lifetime::Timeframe}, mTriggerRecords);
   if (mUseMC) {
+    LOG(INFO) << "Pushing " << mLabels.getNElements() << " TRD tracklet labels";
     pc.outputs().snapshot(Output{"TRD", "TRKLABELS", 0, Lifetime::Timeframe}, mLabels);
   }
 

--- a/Detectors/TRD/workflow/src/TRDTrapSimulatorSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrapSimulatorSpec.cxx
@@ -298,7 +298,7 @@ void TRDDPLTrapSimulatorTask::run(o2::framework::ProcessingContext& pc)
             for (const auto& newLabel : newLabels) {
               bool alreadyIn = false;
               for (const auto& currLabel : currentLabels) {
-                if (currLabel.compare(newLabel) == 1) {
+                if (currLabel == newLabel) {
                   alreadyIn = true;
                   break;
                 }

--- a/Detectors/TRD/workflow/src/TRDTrapSimulatorSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrapSimulatorSpec.cxx
@@ -28,6 +28,8 @@
 #include "fairlogger/Logger.h"
 #include "CCDB/BasicCCDBManager.h"
 
+#include "SimulationDataFormat/MCCompLabel.h"
+#include "SimulationDataFormat/ConstMCTruthContainer.h"
 #include "TRDBase/Calibrations.h"
 #include "TRDSimulation/TRDSimParams.h"
 #include "DataFormatsTRD/Digit.h"
@@ -296,7 +298,7 @@ void TRDDPLTrapSimulatorTask::run(o2::framework::ProcessingContext& pc)
             for (const auto& newLabel : newLabels) {
               bool alreadyIn = false;
               for (const auto& currLabel : currentLabels) {
-                if (currLabel.compare(newLabel)) {
+                if (currLabel.compare(newLabel) == 1) {
                   alreadyIn = true;
                   break;
                 }

--- a/Detectors/TRD/workflow/src/trd-tracking-workflow.cxx
+++ b/Detectors/TRD/workflow/src/trd-tracking-workflow.cxx
@@ -61,10 +61,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     srcTRD = GTrackID::getSourcesMask("TPC");
   }
   o2::framework::WorkflowSpec specs;
-  bool useMC = false;
-  if (!configcontext.options().get<bool>("disable-mc") && !useMC) {
-    LOG(WARNING) << "MC is not disabled, although it is not yet supported by the workflow. It is forced off.";
-  }
+  bool useMC = !configcontext.options().get<bool>("disable-mc");
 
   // processing devices
   specs.emplace_back(o2::trd::getTRDGlobalTrackingSpec(useMC, srcTRD, trigRecFilterActive, strict));

--- a/GPU/GPUTracking/DataTypes/GPUTRDTrack.cxx
+++ b/GPU/GPUTracking/DataTypes/GPUTRDTrack.cxx
@@ -33,7 +33,7 @@ GPUd() void GPUTRDTrack_t<T>::initialize()
   mChi2 = 0.f;
   mRefGlobalTrackId = 0;
   mCollisionId = -1;
-  mIsFindable = 0;
+  mFlags = 0;
   for (int i = 0; i < kNLayers; ++i) {
     mAttachedTracklets[i] = -1;
   }
@@ -80,7 +80,7 @@ GPUd() void GPUTRDTrack_t<T>::ConvertFrom(const GPUTRDTrackDataRecord& t)
   T::set(t.fX, t.mAlpha, &(t.fY), t.fC);
   setRefGlobalTrackIdRaw(t.fTPCTrackID);
   mChi2 = 0.f;
-  mIsFindable = 0;
+  mFlags = 0;
   mCollisionId = -1;
   for (int iLayer = 0; iLayer < kNLayers; iLayer++) {
     mAttachedTracklets[iLayer] = t.fAttachedTracklets[iLayer];
@@ -109,7 +109,7 @@ GPUd() GPUTRDTrack_t<T>::GPUTRDTrack_t(const o2::tpc::TrackTPC& t) : T(t)
 
 template <typename T>
 GPUd() GPUTRDTrack_t<T>::GPUTRDTrack_t(const GPUTRDTrack_t<T>& t)
-  : T(t), mChi2(t.mChi2), mRefGlobalTrackId(t.mRefGlobalTrackId), mCollisionId(t.mCollisionId), mIsFindable(t.mIsFindable)
+  : T(t), mChi2(t.mChi2), mRefGlobalTrackId(t.mRefGlobalTrackId), mCollisionId(t.mCollisionId), mFlags(t.mFlags)
 {
   // copy constructor
   for (int i = 0; i < kNLayers; ++i) {
@@ -135,7 +135,7 @@ GPUd() GPUTRDTrack_t<T>& GPUTRDTrack_t<T>::operator=(const GPUTRDTrack_t<T>& t)
   mChi2 = t.mChi2;
   mRefGlobalTrackId = t.mRefGlobalTrackId;
   mCollisionId = t.mCollisionId;
-  mIsFindable = t.mIsFindable;
+  mFlags = t.mFlags;
   for (int i = 0; i < kNLayers; ++i) {
     mAttachedTracklets[i] = t.mAttachedTracklets[i];
   }
@@ -148,7 +148,7 @@ GPUd() int GPUTRDTrack_t<T>::getNlayersFindable() const
   // returns number of layers in which the track is in active area of TRD
   int retVal = 0;
   for (int iLy = 0; iLy < kNLayers; iLy++) {
-    if ((mIsFindable >> iLy) & 0x1) {
+    if ((mFlags >> iLy) & 0x1) {
       ++retVal;
     }
   }

--- a/GPU/GPUTracking/DataTypes/GPUTRDTrack.h
+++ b/GPU/GPUTracking/DataTypes/GPUTRDTrack.h
@@ -62,6 +62,7 @@ class GPUTRDTrack_t : public T
  public:
   enum EGPUTRDTrack {
     kNLayers = 6,
+    kAmbiguousFlag = 6,
     kStopFlag = 7
   };
 
@@ -76,7 +77,7 @@ class GPUTRDTrack_t : public T
   GPUd() GPUTRDTrack_t(const T& t);
   GPUd() GPUTRDTrack_t& operator=(const GPUTRDTrack_t& t);
 
-  // attach a tracklet to this track; this overwrites the mIsFindable flag to true for this layer
+  // attach a tracklet to this track; this overwrites the mFlags flag to true for this layer
   GPUd() void addTracklet(int iLayer, int idx) { mAttachedTracklets[iLayer] = idx; }
 
   // getters
@@ -89,8 +90,9 @@ class GPUTRDTrack_t : public T
   GPUd() int getNtracklets() const;
   GPUd() float getChi2() const { return mChi2; }
   GPUd() float getReducedChi2() const { return getNlayersFindable() == 0 ? mChi2 : mChi2 / getNlayersFindable(); }
-  GPUd() bool getIsStopped() const { return (mIsFindable >> kStopFlag) & 0x1; }
-  GPUd() bool getIsFindable(int iLayer) const { return (mIsFindable >> iLayer) & 0x1; }
+  GPUd() bool getIsStopped() const { return (mFlags >> kStopFlag) & 0x1; }
+  GPUd() bool getIsAmbiguous() const { return (mFlags >> kAmbiguousFlag) & 0x1; }
+  GPUd() bool getIsFindable(int iLayer) const { return (mFlags >> iLayer) & 0x1; }
   GPUd() int getNmissingConsecLayers(int iLayer) const;
   // for AliRoot compatibility. To be removed once HLT/global/AliHLTGlobalEsdConverterComponent.cxx does not require them anymore
   GPUd() int GetTPCtrackId() const { return mRefGlobalTrackId; }
@@ -102,8 +104,9 @@ class GPUTRDTrack_t : public T
   // This method is only defined in TrackTRD.h and is intended to be used only with that TRD track type
   GPUd() void setRefGlobalTrackId(o2::dataformats::GlobalTrackID id);
   GPUd() void setCollisionId(short id) { mCollisionId = id; }
-  GPUd() void setIsFindable(int iLayer) { mIsFindable |= (1U << iLayer); }
-  GPUd() void setIsStopped() { mIsFindable |= (1U << kStopFlag); }
+  GPUd() void setIsFindable(int iLayer) { mFlags |= (1U << iLayer); }
+  GPUd() void setIsStopped() { mFlags |= (1U << kStopFlag); }
+  GPUd() void setIsAmbiguous() { mFlags |= (1U << kAmbiguousFlag); }
   GPUd() void setChi2(float chi2) { mChi2 = chi2; }
 
   // conversion to / from HLT track structure (only for AliRoot)
@@ -115,12 +118,12 @@ class GPUTRDTrack_t : public T
   unsigned int mRefGlobalTrackId;   // raw GlobalTrackID of the seeding track (either ITS-TPC or TPC)
   int mAttachedTracklets[kNLayers]; // indices of the tracklets attached to this track; -1 means no tracklet in that layer
   short mCollisionId;               // the collision ID of the tracklets attached to this track; is used to retrieve the BC information for this track after the tracking is done
-  unsigned char mIsFindable;        // bitfield; LSB indicates whether track is findable in layer 0; MSB flags whether the track is stopped in the TRD; one bit is currently not used
+  unsigned char mFlags;             // bits 0 to 5 indicate whether track is findable in layer 0 to 5, bit 6 indicates an ambiguous track and bit 8 flags if the track is stopped in the TRD
 
  private:
   GPUd() void initialize();
 #if !defined(GPUCA_STANDALONE) && !defined(GPUCA_ALIROOT_LIB)
-  ClassDefNV(GPUTRDTrack_t, 1);
+  ClassDefNV(GPUTRDTrack_t, 2);
 #endif
 };
 

--- a/GPU/GPUTracking/Definitions/GPUSettingsList.h
+++ b/GPU/GPUTracking/Definitions/GPUSettingsList.h
@@ -83,6 +83,8 @@ BeginSubConfig(GPUSettingsRecTRD, trd, configStandalone.rec, "RECTRD", 0, "Recon
 AddOptionRTC(minTrackPt, float, .5f, "", 0, "Min Pt for tracks to be propagated through the TRD")
 AddOptionRTC(maxChi2, float, 15.f, "", 0, "Max chi2 for TRD tracklets to be matched to a track")
 AddOptionRTC(penaltyChi2, float, 12.f, "", 0, "Chi2 penalty for no available TRD tracklet (effective chi2 cut value)")
+AddOptionRTC(chi2StrictCut, float, 10.f, "", 0, "Chi2 cut for strict matching mode")
+AddOptionRTC(chi2SeparationCut, float, 3.f, "", 0, "Minimum difference between chi2 of winner match and chi2 of second best match")
 AddOptionRTC(nSigmaTerrITSTPC, float, 4.f, "", 0, "Number of sigmas for ITS-TPC track time error estimate")
 AddOptionRTC(stopTrkAfterNMissLy, unsigned char, 6, "", 0, "Abandon track following after N layers without a TRD match")
 AddHelp("help", 'h')

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -138,7 +138,7 @@ WORKFLOW+="o2-tpcits-match-workflow $ARGS_ALL --disable-root-input --disable-roo
 WORKFLOW+="o2-ft0-reco-workflow $ARGS_ALL --disable-root-input --disable-root-output $DISABLE_MC | "
 WORKFLOW+="o2-tof-reco-workflow $ARGS_ALL --input-type $TOF_INPUT --output-type $TOF_OUTPUT --disable-root-input --disable-root-output $DISABLE_MC | "
 WORKFLOW+="o2-trd-tracklet-transformer $ARGS_ALL --disable-root-input --disable-root-output $TRD_TRANSFORMER_CONFIG --pipeline TRDTRACKLETTRANSFORMER:$N_TRDTRK | "
-WORKFLOW+="o2-trd-global-tracking $ARGS_ALL --disable-root-input --disable-root-output $TRD_CONFIG | "
+WORKFLOW+="o2-trd-global-tracking $ARGS_ALL --disable-root-input --disable-root-output $DISABLE_MC $TRD_CONFIG | "
 
 # Workflows disabled in sync mode
 if [ $SYNCMODE == 0 ]; then

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -137,7 +137,7 @@ WORKFLOW+="o2-gpu-reco-workflow ${ARGS_ALL/--severity $SEVERITY/--severity $SEVE
 WORKFLOW+="o2-tpcits-match-workflow $ARGS_ALL --disable-root-input --disable-root-output $DISABLE_MC --pipeline itstpc-track-matcher:$N_TPCITS | "
 WORKFLOW+="o2-ft0-reco-workflow $ARGS_ALL --disable-root-input --disable-root-output $DISABLE_MC | "
 WORKFLOW+="o2-tof-reco-workflow $ARGS_ALL --input-type $TOF_INPUT --output-type $TOF_OUTPUT --disable-root-input --disable-root-output $DISABLE_MC | "
-WORKFLOW+="o2-trd-tracklet-transformer $ARGS_ALL --disable-root-input --disable-root-output $TRD_TRANSFORMER_CONFIG --pipeline TRDTRACKLETTRANSFORMER:$N_TRDTRK | "
+WORKFLOW+="o2-trd-tracklet-transformer $ARGS_ALL --disable-root-input --disable-root-output $DISABLE_MC $TRD_TRANSFORMER_CONFIG --pipeline TRDTRACKLETTRANSFORMER:$N_TRDTRK | "
 WORKFLOW+="o2-trd-global-tracking $ARGS_ALL --disable-root-input --disable-root-output $DISABLE_MC $TRD_CONFIG | "
 
 # Workflows disabled in sync mode


### PR DESCRIPTION
Hi @shahor02 
a simple flag is set for the TRD track after the track following in case a competitor hypothesis was found close by. The chi2 separation cut needs to be tuned. The TRD tracking can be run with:
`o2-trd-tracklet-transformer -b | o2-trd-global-tracking -b --track-sources TPC --strict-matching --configKeyValues "GPU_rec_trd.chi2SeparationCut=2;GPU_proc.trdNCandidates=3"`
Would this already be sufficient for the strict matching mode?

I see that I have in 10pp events already one tracklet which is attached to two tracks. I am looking further into that and for that I will try to add also the MC labels now to the tracking. This will come in another PR.

Cheers,
Ole