### PR TITLE
[EMCAL-566]  Templated ChannelCalibrator and included time calibrator 

### DIFF
--- a/Detectors/EMCAL/calibration/CMakeLists.txt
+++ b/Detectors/EMCAL/calibration/CMakeLists.txt
@@ -10,8 +10,8 @@
 # or submit itself to any jurisdiction.
 
 o2_add_library(EMCALCalibration
-               SOURCES
-               src/EMCALChannelCalibrator.cxx
+               SOURCES  src/EMCALChannelData.cxx 
+                        src/EMCALTimeCalibData.cxx 
                PUBLIC_LINK_LIBRARIES O2::CCDB O2::EMCALBase
                                      O2::EMCALCalib
                                      O2::CommonUtils
@@ -21,10 +21,13 @@ o2_add_library(EMCALCalibration
                                      O2::Algorithm
                                      Microsoft.GSL::GSL
                                      )
-
-
+									 
+				  
+				   
 o2_target_root_dictionary(EMCALCalibration
                           HEADERS include/EMCALCalibration/EMCALChannelCalibrator.h
+                                  include/EMCALCalibration/EMCALChannelData.h
+                                  include/EMCALCalibration/EMCALTimeCalibData.h
                           LINKDEF src/EMCALCalibrationLinkDef.h)
 
 

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelCalibrator.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelCalibrator.h
@@ -18,11 +18,21 @@
 #ifndef EMCAL_CHANNEL_CALIBRATOR_H_
 #define EMCAL_CHANNEL_CALIBRATOR_H_
 
+#include "EMCALCalibration/EMCALTimeCalibData.h"
+#include "EMCALCalibration/EMCALChannelData.h"
 #include "DetectorsCalibration/TimeSlotCalibration.h"
 #include "DetectorsCalibration/TimeSlot.h"
 #include "DataFormatsEMCAL/Cell.h"
 #include "EMCALBase/Geometry.h"
 #include "CCDB/CcdbObjectInfo.h"
+
+#include "Framework/Logger.h"
+#include "CommonUtils/MemFileHelper.h"
+#include "CCDB/CcdbApi.h"
+#include "DetectorsCalibration/Utils.h"
+#include <boost/histogram.hpp>
+#include <boost/histogram/ostream.hpp>
+#include <boost/format.hpp>
 
 #include <array>
 #include <boost/histogram.hpp>
@@ -31,68 +41,14 @@ namespace o2
 {
 namespace emcal
 {
-class EMCALChannelData
-{
-  //using Slot = o2::calibration::TimeSlot<o2::emcal::EMCALChannelData>;
-  using Cells = o2::emcal::Cell;
-  using boostHisto = boost::histogram::histogram<std::tuple<boost::histogram::axis::regular<double, boost::use_default, boost::use_default, boost::use_default>, boost::histogram::axis::integer<>>, boost::histogram::unlimited_storage<std::allocator<char>>>;
-
- public:
-  // NCELLS includes DCal, treat as one calibration
-  o2::emcal::Geometry* mGeometry = o2::emcal::Geometry::GetInstanceFromRunNumber(300000);
-  int NCELLS = mGeometry->GetNCells();
-
-  EMCALChannelData(int nb, float r) : mNBins(nb), mRange(r)
-  {
-    // boost histogram with amplitude vs. cell ID, specify the range and binning of the amplitude axis
-    mHisto = boost::histogram::make_histogram(boost::histogram::axis::regular<>(mNBins, 0, mRange, "t-texp"), boost::histogram::axis::integer<>(0, NCELLS, "CELL ID"));
-  }
-
-  ~EMCALChannelData() = default;
-
-  /// \brief Print relevant info for EMCALChannelData on a given stream
-  /// \param stream Stream on which the info is printed on
-  /// The function is called in the operator<< providing direct access
-  /// to protected members. Explicit calls by the users is normally not
-  /// necessary.
-  void PrintStream(std::ostream& stream) const;
-  /// \brief Print a useful message about the container.
-  void print();
-  /// \brief Fill the container with the cell ID and amplitude.
-  void fill(const gsl::span<const o2::emcal::Cell> data);
-  /// \brief Merge the data of two slots.
-  void merge(const EMCALChannelData* prev);
-  int findBin(float v) const;
-  bool hasEnoughData() const;
-  boostHisto& getHisto() { return mHisto; }
-  const boostHisto& getHisto() const { return mHisto; }
-
-  float getRange() const { return mRange; }
-  void setRange(float r) { mRange = r; }
-
-  int getNbins() const { return mNBins; }
-  void setNbins(int nb) { mNBins = nb; }
-
-  int getNEvents() const { return mEvents; }
-  void setNEvents(int ne) { mEvents = ne; }
-
- private:
-  float mRange = 0.35; // looked at old QA plots where max was 0.35 GeV, might need to be changed
-  int mNBins = 1000;
-  boostHisto mHisto;
-  int mEvents = 1;
-
-  ClassDefNV(EMCALChannelData, 1);
-};
-/// \brief Printing EMCALChannelData on the stream
-/// \param in Stream where the EMCALChannelData is printed on
-/// \param emcdata EMCALChannelData to be printed
-std::ostream& operator<<(std::ostream& in, const EMCALChannelData& emcdata);
-
-class EMCALChannelCalibrator : public o2::calibration::TimeSlotCalibration<o2::emcal::Cell, o2::emcal::EMCALChannelData>
+/// \brief class used for managment of bad channel and time calibration
+/// template DataInput can be ChannelData or TimeData   // o2::emcal::EMCALChannelData, o2::emcal::EMCALTimeCalibData
+/// template HistContainer can be ChannelCalibInitParams or TimeCalibInitParams
+template <typename DataInput, typename HistContainer>
+class EMCALChannelCalibrator : public o2::calibration::TimeSlotCalibration<o2::emcal::Cell, DataInput>
 {
   using TFType = uint64_t;
-  using Slot = o2::calibration::TimeSlot<o2::emcal::EMCALChannelData>;
+  using Slot = o2::calibration::TimeSlot<DataInput>;
   using Cell = o2::emcal::Cell;
   using CcdbObjectInfo = o2::ccdb::CcdbObjectInfo;
   using CcdbObjectInfoVector = std::vector<CcdbObjectInfo>;
@@ -107,7 +63,7 @@ class EMCALChannelCalibrator : public o2::calibration::TimeSlotCalibration<o2::e
   /// \brief Initialize the vector of our output objects.
   void initOutput() final;
   void finalizeSlot(Slot& slot) final;
-  Slot& emplaceNewSlot(bool front, TFType tstart, TFType tend) final;
+  o2::calibration::TimeSlot<DataInput>& emplaceNewSlot(bool front, TFType tstart, TFType tend) final;
 
   void setIsTest(bool isTest) { mTest = isTest; }
   bool isTest() const { return mTest; }
@@ -122,6 +78,50 @@ class EMCALChannelCalibrator : public o2::calibration::TimeSlotCalibration<o2::e
 
   ClassDefOverride(EMCALChannelCalibrator, 1);
 };
+
+//_____________________________________________
+template <typename DataInput, typename HistContainer>
+void EMCALChannelCalibrator<DataInput, HistContainer>::initOutput()
+{
+  mInfoVector.clear();
+  return;
+}
+
+//_____________________________________________
+template <typename DataInput, typename HistContainer>
+bool EMCALChannelCalibrator<DataInput, HistContainer>::hasEnoughData(const o2::calibration::TimeSlot<DataInput>& slot) const
+{
+
+  const DataInput* c = slot.getContainer();
+  LOG(INFO) << "Checking statistics";
+  return (mTest ? true : c->hasEnoughData());
+}
+
+//_____________________________________________
+template <typename DataInput, typename HistContainer>
+void EMCALChannelCalibrator<DataInput, HistContainer>::finalizeSlot(o2::calibration::TimeSlot<DataInput>& slot)
+{
+  // Extract results for the single slot
+  DataInput* c = slot.getContainer();
+  LOG(INFO) << "Finalize slot " << slot.getTFStart() << " <= TF <= " << slot.getTFEnd();
+
+  // for the CCDB entry
+  std::map<std::string, std::string> md;
+
+  //auto clName = o2::utils::MemFileHelper::getClassName(tm);
+  //auto flName = o2::ccdb::CcdbApi::generateFileName(clName);
+  mInfoVector.emplace_back("EMCAL/ChannelCalib", "clname", "flname", md, slot.getTFStart(), 99999999999999);
+}
+
+template <typename DataInput, typename HistContainer>
+o2::calibration::TimeSlot<DataInput>& EMCALChannelCalibrator<DataInput, HistContainer>::emplaceNewSlot(bool front, TFType tstart, TFType tend)
+{
+  auto& cont = o2::calibration::TimeSlotCalibration<o2::emcal::Cell, DataInput>::getSlots();
+  auto& slot = front ? cont.emplace_front(tstart, tend) : cont.emplace_back(tstart, tend);
+  HistContainer histcont; // initialize struct with (default) ranges for time or channel calibration.
+  slot.setContainer(std::make_unique<DataInput>(histcont));
+  return slot;
+}
 
 } // end namespace emcal
 } // end namespace o2

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelData.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelData.h
@@ -1,0 +1,108 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \class EMCALChannelData
+/// \brief  Perform the EMCAL bad channel calibration
+/// \author Hannah Bossi, Yale University
+/// \ingroup EMCALCalib
+/// \since Feb 11, 2021
+
+#ifndef CHANNEL_DATA_H_
+#define CHANNEL_DATA_H_
+
+#include "DetectorsCalibration/TimeSlotCalibration.h"
+#include "DetectorsCalibration/TimeSlot.h"
+#include "DataFormatsEMCAL/Cell.h"
+#include "EMCALBase/Geometry.h"
+#include "CCDB/CcdbObjectInfo.h"
+
+#include "Framework/Logger.h"
+#include "CommonUtils/MemFileHelper.h"
+#include "CCDB/CcdbApi.h"
+#include "DetectorsCalibration/Utils.h"
+#include <boost/histogram.hpp>
+#include <boost/histogram/ostream.hpp>
+#include <boost/format.hpp>
+
+#include <array>
+#include <boost/histogram.hpp>
+
+namespace o2
+{
+namespace emcal
+{
+struct ChannelCalibInitParams {
+  unsigned int nbins = 1000;
+  std::array<float, 2> range = {0, 0.35};
+};
+
+class EMCALChannelData
+{
+  //using Slot = o2::calibration::TimeSlot<o2::emcal::EMCALChannelData>;
+  using Cells = o2::emcal::Cell;
+  using boostHisto = boost::histogram::histogram<std::tuple<boost::histogram::axis::regular<double, boost::use_default, boost::use_default, boost::use_default>, boost::histogram::axis::integer<>>, boost::histogram::unlimited_storage<std::allocator<char>>>;
+
+ public:
+  // NCELLS includes DCal, treat as one calibration
+  o2::emcal::Geometry* mGeometry = o2::emcal::Geometry::GetInstanceFromRunNumber(300000);
+  int NCELLS = mGeometry->GetNCells();
+
+  EMCALChannelData(const ChannelCalibInitParams& hist) : mNBins(hist.nbins), mRange(1)
+  {
+    // boost histogram with amplitude vs. cell ID, specify the range and binning of the amplitude axis
+    mHisto = boost::histogram::make_histogram(boost::histogram::axis::regular<>(mNBins, 0, mRange, "t-texp"), boost::histogram::axis::integer<>(0, NCELLS, "CELL ID"));
+  }
+
+  ~EMCALChannelData() = default;
+
+  /// \brief Print relevant info for EMCALChannelData on a given stream
+  /// \param stream Stream on which the info is printed on
+  /// The function is called in the operator<< providing direct access
+  /// to protected members. Explicit calls by the users is normally not
+  /// necessary.
+  void PrintStream(std::ostream& stream) const;
+  /// \brief Print a useful message about the container.
+  void print();
+  /// \brief Fill the container with the cell ID and amplitude.
+  void fill(const gsl::span<const o2::emcal::Cell> data);
+  /// \brief Merge the data of two slots.
+  void merge(const EMCALChannelData* prev);
+  int findBin(float v) const;
+  bool hasEnoughData() const;
+  boostHisto& getHisto() { return mHisto; }
+  const boostHisto& getHisto() const { return mHisto; }
+
+  float getRange() const { return mRange; }
+  void setRange(float r) { mRange = r; }
+
+  int getNbins() const { return mNBins; }
+  void setNbins(int nb) { mNBins = nb; }
+
+  int getNEvents() const { return mEvents; }
+  void setNEvents(int ne) { mEvents = ne; }
+
+ private:
+  float mRange = 0.35; // looked at old QA plots where max was 0.35 GeV, might need to be changed
+  int mNBins = 1000;
+  boostHisto mHisto;
+  int mEvents = 1;
+
+  ClassDefNV(EMCALChannelData, 1);
+};
+/// \brief Printing EMCALChannelData on the stream
+/// \param in Stream where the EMCALChannelData is printed on
+/// \param emcdata EMCALChannelData to be printed
+std::ostream& operator<<(std::ostream& in, const EMCALChannelData& emcdata);
+
+} // end namespace emcal
+} // end namespace o2
+
+#endif /*CHANNEL_DATA_H_ */

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALTimeCalibData.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALTimeCalibData.h
@@ -1,0 +1,108 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \class EMCALTimeCalibData
+/// \brief  Perform the EMCAL time calibration
+/// \author Joshua Koenig
+/// \ingroup EMCALCalib
+/// \since Jul 25, 2021
+
+#ifndef EMCAL_TIME_DATA_H_
+#define EMCAL_TIME_DATA_H_
+
+#include "DetectorsCalibration/TimeSlotCalibration.h"
+#include "DetectorsCalibration/TimeSlot.h"
+#include "DataFormatsEMCAL/Cell.h"
+#include "EMCALBase/Geometry.h"
+#include "CCDB/CcdbObjectInfo.h"
+#include "EMCALCalib/TimeCalibrationParams.h"
+
+#include "Framework/Logger.h"
+#include "CommonUtils/MemFileHelper.h"
+#include "CCDB/CcdbApi.h"
+#include "DetectorsCalibration/Utils.h"
+#include <boost/histogram.hpp>
+#include <boost/histogram/ostream.hpp>
+#include <boost/format.hpp>
+
+#include <array>
+#include <boost/histogram.hpp>
+namespace o2
+{
+namespace emcal
+{
+
+// class containing the initialization parameters for histograms (time bins/range etc.)
+struct TimeCalibInitParams {
+ public:
+  unsigned int mTimeBins = 1500;
+  std::array<float, 2> mTimeRange = {-500., 1000.}; // time range in ns
+  unsigned int mEnergyBins = 5000;
+  std::array<float, 2> mEnergyRange = {0., 50.}; // energy range in GeV
+};
+
+class EMCALTimeCalibData
+{
+ public:
+  using Cells = o2::emcal::Cell;
+  using boostHisto = boost::histogram::histogram<std::tuple<boost::histogram::axis::regular<double, boost::use_default, boost::use_default, boost::use_default>, boost::histogram::axis::integer<>>, boost::histogram::unlimited_storage<std::allocator<char>>>;
+
+  o2::emcal::Geometry* mGeometry = o2::emcal::Geometry::GetInstanceFromRunNumber(300000);
+  int NCELLS = mGeometry->GetNCells();
+
+  EMCALTimeCalibData(const TimeCalibInitParams& par)
+  {
+    // boost histogram with amplitude vs. cell ID, specify the range and binning of the amplitude axis
+    mTimeHisto = boost::histogram::make_histogram(boost::histogram::axis::regular<>(par.mTimeBins, par.mTimeRange.at(0), par.mTimeRange.at(1), "t (ns)"), boost::histogram::axis::integer<>(0, NCELLS, "CELL ID"));
+  }
+
+  ~EMCALTimeCalibData() = default;
+
+  /// \brief Fill the container with the cell ID and amplitude and time information.
+  void fill(const gsl::span<const o2::emcal::Cell> data);
+
+  /// \brief Merge the data of two slots.
+  void merge(const EMCALTimeCalibData* prev);
+
+  /// \brief Check if enough data for calibration has been accumulated
+  bool hasEnoughData() const;
+
+  /// \brief Print a useful message about the container.
+  void print();
+
+  /// \brief Get number of events currently available for calibration
+  int getNEvents() const { return mEvents; }
+
+  /// \brief Get current histogram
+  boostHisto& getHisto() { return mTimeHisto; }
+  const boostHisto& getHisto() const { return mTimeHisto; }
+
+  /// \brief Set number of events available for calibration
+  void setNEvents(int ne) { mEvents = ne; }
+
+  void PrintStream(std::ostream& stream) const;
+
+  /// \brief Actual function where calibration is done. Has to be called in has enough data when enough data is there
+  o2::emcal::TimeCalibrationParams process();
+
+ private:
+  boostHisto mTimeHisto;
+  TimeCalibInitParams mTimeCalibParams;
+
+  int mEvents = 0;
+
+  ClassDefNV(EMCALTimeCalibData, 1);
+};
+
+} // end namespace emcal
+} // end namespace o2
+
+#endif /*EMCAL_TIME_DATA_H_ */

--- a/Detectors/EMCAL/calibration/src/EMCALCalibrationLinkDef.h
+++ b/Detectors/EMCAL/calibration/src/EMCALCalibrationLinkDef.h
@@ -15,8 +15,12 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
-#pragma link C++ class o2::emcal::EMCALChannelCalibrator + ;
+#pragma link C++ class o2::emcal::EMCALChannelCalibrator <o2::emcal::EMCALChannelData, o2::emcal::ChannelCalibInitParams> + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::emcal::EMCALChannelData> + ;
 #pragma link C++ class o2::calibration::TimeSlotCalibration < o2::emcal::Cell, o2::emcal::EMCALChannelData> + ;
+
+#pragma link C++ class o2::emcal::EMCALChannelCalibrator <o2::emcal::EMCALTimeCalibData, o2::emcal::TimeCalibInitParams> + ;
+#pragma link C++ class o2::calibration::TimeSlot < o2::emcal::EMCALTimeCalibData> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::emcal::Cell, o2::emcal::EMCALTimeCalibData> + ;
 
 #endif

--- a/Detectors/EMCAL/calibration/src/EMCALChannelData.cxx
+++ b/Detectors/EMCAL/calibration/src/EMCALChannelData.cxx
@@ -9,7 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#include "EMCALCalibration/EMCALChannelCalibrator.h"
+#include "EMCALCalibration/EMCALChannelData.h"
 #include "Framework/Logger.h"
 #include "CommonUtils/MemFileHelper.h"
 #include "CCDB/CcdbApi.h"
@@ -81,47 +81,6 @@ bool EMCALChannelData::hasEnoughData() const
   bool enough;
 
   return enough;
-}
-
-//_____________________________________________
-void EMCALChannelCalibrator::initOutput()
-{
-  mInfoVector.clear();
-  return;
-}
-
-//_____________________________________________
-bool EMCALChannelCalibrator::hasEnoughData(const Slot& slot) const
-{
-
-  const o2::emcal::EMCALChannelData* c = slot.getContainer();
-  LOG(INFO) << "Checking statistics";
-  return (mTest ? true : c->hasEnoughData());
-}
-
-//_____________________________________________
-void EMCALChannelCalibrator::finalizeSlot(Slot& slot)
-{
-  // Extract results for the single slot
-  o2::emcal::EMCALChannelData* c = slot.getContainer();
-  LOG(INFO) << "Finalize slot " << slot.getTFStart() << " <= TF <= " << slot.getTFEnd();
-
-  // for the CCDB entry
-  std::map<std::string, std::string> md;
-
-  //auto clName = o2::utils::MemFileHelper::getClassName(tm);
-  //auto flName = o2::ccdb::CcdbApi::generateFileName(clName);
-  mInfoVector.emplace_back("EMCAL/ChannelCalib", "clname", "flname", md, slot.getTFStart(), 99999999999999);
-}
-
-//_____________________________________________
-Slot& EMCALChannelCalibrator::emplaceNewSlot(bool front, TFType tstart, TFType tend)
-{
-
-  auto& cont = getSlots();
-  auto& slot = front ? cont.emplace_front(tstart, tend) : cont.emplace_back(tstart, tend);
-  slot.setContainer(std::make_unique<o2::emcal::EMCALChannelData>(mNBins, mRange));
-  return slot;
 }
 
 } // end namespace emcal

--- a/Detectors/EMCAL/calibration/src/EMCALTimeCalibData.cxx
+++ b/Detectors/EMCAL/calibration/src/EMCALTimeCalibData.cxx
@@ -1,0 +1,93 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "EMCALCalibration/EMCALTimeCalibData.h"
+#include "Framework/Logger.h"
+#include "CommonUtils/MemFileHelper.h"
+#include "CCDB/CcdbApi.h"
+#include "DetectorsCalibration/Utils.h"
+#include <boost/histogram.hpp>
+#include <boost/histogram/ostream.hpp>
+#include <boost/format.hpp>
+#include <cassert>
+#include <iostream>
+#include <sstream>
+#include <TStopwatch.h>
+
+namespace o2
+{
+namespace emcal
+{
+
+using Slot = o2::calibration::TimeSlot<o2::emcal::EMCALTimeCalibData>;
+using clbUtils = o2::calibration::Utils;
+using boost::histogram::indexed;
+
+//===================================================================
+//_____________________________________________
+void EMCALTimeCalibData::PrintStream(std::ostream& stream) const
+{
+  stream << "EMCAL Cell ID:  " << mTimeHisto << "\n";
+}
+//_____________________________________________
+void EMCALTimeCalibData::print()
+{
+  LOG(DEBUG) << *this;
+}
+//_____________________________________________
+std::ostream& operator<<(std::ostream& stream, const EMCALTimeCalibData& emcdata)
+{
+  emcdata.PrintStream(stream);
+  return stream;
+}
+//_____________________________________________
+void EMCALTimeCalibData::merge(const EMCALTimeCalibData* prev)
+{
+  mEvents += prev->getNEvents();
+  mTimeHisto += prev->getHisto();
+}
+//_____________________________________________
+bool EMCALTimeCalibData::hasEnoughData() const
+{
+  // true if we have enough data, also want to check for the sync trigger
+  // this is stil to be finalized, simply a skeletron for now
+
+  // if we have the sync trigger, finalize the slot anyway
+
+  //finalizeOldestSlot(Slot& slot);
+
+  // TODO: use event counter here to specify the value of enough
+  // guess and then adjust number of events as needed
+  // checking mEvents
+  bool enough;
+
+  return enough;
+}
+//_____________________________________________
+void EMCALTimeCalibData::fill(const gsl::span<const o2::emcal::Cell> data)
+{
+  for (auto cell : data) {
+    Double_t cellEnergy = cell.getEnergy();
+    Int_t id = cell.getTower();
+    LOG(DEBUG) << "inserting in cell ID " << id << ": energy = " << cellEnergy;
+    mTimeHisto(cellEnergy, id);
+  }
+}
+
+//_____________________________________________
+o2::emcal::TimeCalibrationParams EMCALTimeCalibData::process()
+{
+  o2::emcal::TimeCalibrationParams TimeCalibParams;
+  return TimeCalibParams;
+}
+
+} // end namespace emcal
+} // end namespace o2

--- a/Detectors/EMCAL/calibration/testWorkflow/EMCALChannelCalibratorSpec.h
+++ b/Detectors/EMCAL/calibration/testWorkflow/EMCALChannelCalibratorSpec.h
@@ -46,7 +46,7 @@ class EMCALChannelCalibDevice : public o2::framework::Task
   void init(o2::framework::InitContext& ic) final
   {
     int isTest = ic.options().get<bool>("do-EMCAL-channel-calib-in-test-mode");
-    mCalibrator = std::make_unique<o2::emcal::EMCALChannelCalibrator>();
+    mCalibrator = std::make_unique<o2::emcal::EMCALChannelCalibrator<o2::emcal::EMCALChannelData, o2::emcal::ChannelCalibInitParams>>();
     mCalibrator->setUpdateAtTheEndOfRunOnly();
     mCalibrator->setIsTest(isTest);
   }
@@ -73,7 +73,8 @@ class EMCALChannelCalibDevice : public o2::framework::Task
   }
 
  private:
-  std::unique_ptr<o2::emcal::EMCALChannelCalibrator> mCalibrator;
+  std::unique_ptr<o2::emcal::EMCALChannelCalibrator<o2::emcal::EMCALChannelData, o2::emcal::ChannelCalibInitParams>> mCalibrator;
+  std::unique_ptr<o2::emcal::EMCALChannelCalibrator<o2::emcal::EMCALTimeCalibData, o2::emcal::TimeCalibInitParams>> mTimeCalibrator;
 
   //________________________________________________________________
   void sendOutput(DataAllocator& output)


### PR DESCRIPTION
- EMCALChannelCalibrator is now templated to be used for bad channel calibration as well as time calibration (the .cxx file had to be removed as all template classes have to be defined in the .h file). The Channel calibrator has to be initialized with the Channel/Time Data class and the InitParams (simple struct with histogram ranges) for the Time/Channel Data
- Added seperate file for EMCALChannelData for better readability
- Added basic sceletton task for time calibration (EMCALTimeCalibData.h/cxx) similar to EMCALChannelData
- fixed merge confict/formatting in CMakeLists