### PR TITLE
[QC-627] Mergers: add postDeserialization() callback and prioritize MergeInterface

### DIFF
--- a/Utilities/Mergers/include/Mergers/MergeInterface.h
+++ b/Utilities/Mergers/include/Mergers/MergeInterface.h
@@ -36,7 +36,10 @@ class MergeInterface
   /// \brief Custom merge method.
   virtual void merge(MergeInterface* const other) = 0; // const argument
 
-  ClassDef(MergeInterface, 0);
+  /// \brief Lets the child perform any routines after the object was deserialized (e.g. setting the correct ownership)
+  virtual void postDeserialization(){};
+
+  ClassDef(MergeInterface, 1);
 };
 
 } // namespace o2::mergers

--- a/Utilities/Mergers/src/ObjectStore.cxx
+++ b/Utilities/Mergers/src/ObjectStore.cxx
@@ -65,10 +65,15 @@ ObjectStore extractObjectFrom(const framework::DataRef& ref)
       errorPrefix + "Failed to read object with name '" + storedClass->GetName() + "' from message using ROOT serialization.");
   }
 
-  if (inheritsFromTObject) {
-    return TObjectPtr(static_cast<TObject*>(object), algorithm::deleteTCollections);
+  if (inheritsFromMergeInterface) {
+    MergeInterface* objectAsMergeInterface = inheritsFromTObject ? dynamic_cast<MergeInterface*>(static_cast<TObject*>(object)) : static_cast<MergeInterface*>(object);
+    if (objectAsMergeInterface == nullptr) {
+      throw std::runtime_error(errorPrefix + "Could not cast '" + storedClass->GetName() + "' to MergeInterface");
+    }
+    objectAsMergeInterface->postDeserialization();
+    return MergeInterfacePtr(objectAsMergeInterface);
   } else {
-    return MergeInterfacePtr(static_cast<MergeInterface*>(object));
+    return TObjectPtr(static_cast<TObject*>(object), algorithm::deleteTCollections);
   }
 }
 

--- a/Utilities/Mergers/test/test_ObjectStore.cxx
+++ b/Utilities/Mergers/test/test_ObjectStore.cxx
@@ -51,9 +51,9 @@ BOOST_AUTO_TEST_CASE(TestObjectExtraction)
     DataRef ref = makeDataRef(obj);
 
     auto objStore = object_store_helpers::extractObjectFrom(ref);
-    BOOST_REQUIRE(std::holds_alternative<TObjectPtr>(objStore));
+    BOOST_REQUIRE(std::holds_alternative<MergeInterfacePtr>(objStore));
 
-    auto objExtractedCustom = dynamic_cast<CustomMergeableTObject*>(std::get<TObjectPtr>(objStore).get());
+    auto objExtractedCustom = dynamic_cast<CustomMergeableTObject*>(std::get<MergeInterfacePtr>(objStore).get());
     BOOST_REQUIRE(objExtractedCustom != nullptr);
     BOOST_CHECK_EQUAL(objExtractedCustom->getSecret(), 123);
 


### PR DESCRIPTION
This lets the children of MergeInterface to perform any cleanups after ROOT deserializes the object. The main use-case is setting the valid ownership, which cannot be propely set while serializing it for any reason.
We also prioritize storing an object as `MergeInterface*` over `TObject*` when a class inherits both (`MergeInterface::merge()` was already prioritized, this does not change).