### PR TITLE
[QC-443] Data Sampling: remove ConfigurationInterface usage, update tests

### DIFF
--- a/Utilities/DataSampling/include/DataSampling/DataSampling.h
+++ b/Utilities/DataSampling/include/DataSampling/DataSampling.h
@@ -93,31 +93,12 @@ class DataSampling
   static void CustomizeInfrastructure(std::vector<framework::CompletionPolicy>&);
   /// \brief Applies blocking/nonblocking data sampling configuration to the workflow.
   static void CustomizeInfrastructure(std::vector<framework::ChannelConfigurationPolicy>&);
-  /// \brief Provides InputSpecs to receive data for given DataSamplingPolicy
-  static std::vector<framework::InputSpec> InputSpecsForPolicy(const std::string& policiesSource, const std::string& policyName);
-  /// \brief Provides InputSpecs to receive data for given DataSamplingPolicy
-  /// @deprecated
-  static std::vector<framework::InputSpec> InputSpecsForPolicy(configuration::ConfigurationInterface* const config, const std::string& policyName);
-  /// \brief Provides InputSpecs to receive data for given DataSamplingPolicy
-  static std::vector<framework::InputSpec> InputSpecsForPolicy(std::shared_ptr<configuration::ConfigurationInterface> config, const std::string& policyName);
   /// \brief Provides InputSpecs to receive data for given DataSamplingPolicy. Expects the "dataSamplingPolicies" tree.
   static std::vector<framework::InputSpec> InputSpecsForPolicy(const boost::property_tree::ptree& policiesTree, const std::string& policyName);
-  /// \brief Provides OutputSpecs of given DataSamplingPolicy.
-  static std::vector<framework::OutputSpec> OutputSpecsForPolicy(const std::string& policiesSource, const std::string& policyName);
-  /// \brief Provides OutputSpecs of given DataSamplingPolicy.
-  static std::vector<framework::OutputSpec> OutputSpecsForPolicy(configuration::ConfigurationInterface* const config, const std::string& policyName);
   /// \brief Provides OutputSpecs of given DataSamplingPolicy. Expects the "dataSamplingPolicies" tree.
   static std::vector<framework::OutputSpec> OutputSpecsForPolicy(const boost::property_tree::ptree& policiesTree, const std::string& policyName);
-  /// \brief Provides the port to be used for a proxy of given DataSamplingPolicy.
-  static std::optional<uint16_t> PortForPolicy(configuration::ConfigurationInterface* const config, const std::string& policyName);
-  /// \brief Provides the port to be used for a proxy of given DataSamplingPolicy.
-  static std::optional<uint16_t> PortForPolicy(const std::string& policiesSource, const std::string& policyName);
   /// \brief Provides the port to be used for a proxy of given DataSamplingPolicy. Expects the "dataSamplingPolicies" tree.
   static std::optional<uint16_t> PortForPolicy(const boost::property_tree::ptree& policiesTree, const std::string& policyName);
-  /// \brief Provides the machines where given DataSamplingPolicy is enabled.
-  static std::vector<std::string> MachinesForPolicy(configuration::ConfigurationInterface* const config, const std::string& policyName);
-  /// \brief Provides the machines where given DataSamplingPolicy is enabled.
-  static std::vector<std::string> MachinesForPolicy(const std::string& policiesSource, const std::string& policyName);
   /// \brief Provides the machines where given DataSamplingPolicy is enabled. Expects the "dataSamplingPolicies" tree.
   static std::vector<std::string> MachinesForPolicy(const boost::property_tree::ptree& policiesTree, const std::string& policyName);
 

--- a/Utilities/DataSampling/src/DataSampling.cxx
+++ b/Utilities/DataSampling/src/DataSampling.cxx
@@ -104,24 +104,6 @@ void DataSampling::CustomizeInfrastructure(std::vector<ChannelConfigurationPolic
   // now it cannot be done, since matching is possible only using data processors names
 }
 
-std::vector<InputSpec> DataSampling::InputSpecsForPolicy(const std::string& policiesSource, const std::string& policyName)
-{
-  std::unique_ptr<ConfigurationInterface> config = ConfigurationFactory::getConfiguration(policiesSource);
-  return InputSpecsForPolicy(config.get(), policyName);
-}
-
-std::vector<InputSpec> DataSampling::InputSpecsForPolicy(ConfigurationInterface* const config, const std::string& policyName)
-{
-  auto policiesTree = config->getRecursive("dataSamplingPolicies");
-  return InputSpecsForPolicy(policiesTree, policyName);
-}
-
-std::vector<InputSpec> DataSampling::InputSpecsForPolicy(std::shared_ptr<configuration::ConfigurationInterface> config, const std::string& policyName)
-{
-  auto policiesTree = config->getRecursive("dataSamplingPolicies");
-  return InputSpecsForPolicy(policiesTree, policyName);
-}
-
 std::vector<framework::InputSpec> DataSampling::InputSpecsForPolicy(const boost::property_tree::ptree& policiesTree, const std::string& policyName)
 {
   std::vector<InputSpec> inputs;
@@ -136,18 +118,6 @@ std::vector<framework::InputSpec> DataSampling::InputSpecsForPolicy(const boost:
     }
   }
   return inputs;
-}
-
-std::vector<OutputSpec> DataSampling::OutputSpecsForPolicy(const std::string& policiesSource, const std::string& policyName)
-{
-  std::unique_ptr<ConfigurationInterface> config = ConfigurationFactory::getConfiguration(policiesSource);
-  return OutputSpecsForPolicy(config.get(), policyName);
-}
-
-std::vector<OutputSpec> DataSampling::OutputSpecsForPolicy(ConfigurationInterface* const config, const std::string& policyName)
-{
-  auto policiesTree = config->getRecursive("dataSamplingPolicies");
-  return OutputSpecsForPolicy(policiesTree, policyName);
 }
 
 std::vector<framework::OutputSpec> DataSampling::OutputSpecsForPolicy(const boost::property_tree::ptree& policiesTree, const std::string& policyName)
@@ -165,18 +135,6 @@ std::vector<framework::OutputSpec> DataSampling::OutputSpecsForPolicy(const boos
   return outputs;
 }
 
-std::optional<uint16_t> DataSampling::PortForPolicy(configuration::ConfigurationInterface* const config, const std::string& policyName)
-{
-  auto policiesTree = config->getRecursive("dataSamplingPolicies");
-  return PortForPolicy(policiesTree, policyName);
-}
-
-std::optional<uint16_t> DataSampling::PortForPolicy(const std::string& policiesSource, const std::string& policyName)
-{
-  std::unique_ptr<ConfigurationInterface> config = ConfigurationFactory::getConfiguration(policiesSource);
-  return PortForPolicy(config.get(), policyName);
-}
-
 std::optional<uint16_t> DataSampling::PortForPolicy(const boost::property_tree::ptree& policiesTree, const std::string& policyName)
 {
   for (auto&& policyConfig : policiesTree) {
@@ -186,18 +144,6 @@ std::optional<uint16_t> DataSampling::PortForPolicy(const boost::property_tree::
     }
   }
   throw std::runtime_error("Could not find the policy '" + policyName + "'");
-}
-
-std::vector<std::string> DataSampling::MachinesForPolicy(configuration::ConfigurationInterface* const config, const std::string& policyName)
-{
-  auto policiesTree = config->getRecursive("dataSamplingPolicies");
-  return MachinesForPolicy(policiesTree, policyName);
-}
-
-std::vector<std::string> DataSampling::MachinesForPolicy(const std::string& policiesSource, const std::string& policyName)
-{
-  std::unique_ptr<ConfigurationInterface> config = ConfigurationFactory::getConfiguration(policiesSource);
-  return MachinesForPolicy(config.get(), policyName);
 }
 
 std::vector<std::string> DataSampling::MachinesForPolicy(const boost::property_tree::ptree& policiesTree, const std::string& policyName)

--- a/Utilities/DataSampling/test/test_DataSampling.cxx
+++ b/Utilities/DataSampling/test/test_DataSampling.cxx
@@ -172,39 +172,72 @@ BOOST_AUTO_TEST_CASE(DataSamplingTimePipelineFlow)
 BOOST_AUTO_TEST_CASE(InputSpecsForPolicy)
 {
   std::string configFilePath = "json:/" + std::string(getenv("O2_ROOT")) + "/share/tests/test_DataSampling.json";
-  std::vector<InputSpec> inputs = DataSampling::InputSpecsForPolicy(configFilePath, "tpcclusters");
-
-  BOOST_CHECK_EQUAL(inputs.size(), 2);
-  BOOST_CHECK(DataSpecUtils::match(inputs[0], ConcreteDataTypeMatcher{"DS", "tpcclusters0"}));
-  BOOST_CHECK_EQUAL(inputs[0].binding, "clusters");
-  BOOST_CHECK(DataSpecUtils::match(inputs[1], ConcreteDataTypeMatcher{"DS", "tpcclusters1"}));
-  BOOST_CHECK_EQUAL(inputs[1].binding, "clusters_p");
-
   std::unique_ptr<ConfigurationInterface> config = ConfigurationFactory::getConfiguration(configFilePath);
-  inputs = DataSampling::InputSpecsForPolicy(config.get(), "tpcclusters");
+  auto policiesTree = config->getRecursive("dataSamplingPolicies");
 
-  BOOST_CHECK_EQUAL(inputs.size(), 2);
+  {
+    std::vector<InputSpec> inputs = DataSampling::InputSpecsForPolicy(policiesTree, "tpcclusters");
+
+    BOOST_CHECK_EQUAL(inputs.size(), 2);
+    BOOST_CHECK(DataSpecUtils::match(inputs[0], ConcreteDataTypeMatcher{"DS", "tpcclusters0"}));
+    BOOST_CHECK_EQUAL(inputs[0].binding, "clusters");
+    BOOST_CHECK(DataSpecUtils::match(inputs[1], ConcreteDataTypeMatcher{"DS", "tpcclusters1"}));
+    BOOST_CHECK_EQUAL(inputs[1].binding, "clusters_p");
+  }
+  {
+    std::vector<InputSpec> inputs = DataSampling::InputSpecsForPolicy(policiesTree, "tpcraw");
+
+    BOOST_CHECK_EQUAL(inputs.size(), 1);
+    BOOST_CHECK(DataSpecUtils::match(inputs[0], ConcreteDataTypeMatcher{"TPC", "SMP_RAWDATA"}));
+    BOOST_CHECK_EQUAL(inputs[0].binding, "clusters");
+  }
+}
+
+BOOST_AUTO_TEST_CASE(OutputSpecsForPolicy)
+{
+  std::string configFilePath = "json:/" + std::string(getenv("O2_ROOT")) + "/share/tests/test_DataSampling.json";
+  std::unique_ptr<ConfigurationInterface> config = ConfigurationFactory::getConfiguration(configFilePath);
+  auto policiesTree = config->getRecursive("dataSamplingPolicies");
+
+  {
+    auto outputs = DataSampling::OutputSpecsForPolicy(policiesTree, "tpcclusters");
+
+    BOOST_REQUIRE_EQUAL(outputs.size(), 2);
+    BOOST_CHECK(DataSpecUtils::match(outputs[0], ConcreteDataTypeMatcher{"DS", "tpcclusters0"}));
+    BOOST_CHECK_EQUAL(outputs[0].binding.value, "clusters");
+    BOOST_CHECK(DataSpecUtils::match(outputs[1], ConcreteDataTypeMatcher{"DS", "tpcclusters1"}));
+    BOOST_CHECK_EQUAL(outputs[1].binding.value, "clusters_p");
+  }
+  {
+    auto outputs = DataSampling::OutputSpecsForPolicy(policiesTree, "tpcraw");
+
+    BOOST_REQUIRE_EQUAL(outputs.size(), 1);
+    BOOST_CHECK(DataSpecUtils::match(outputs[0], ConcreteDataTypeMatcher{"TPC", "SMP_RAWDATA"}));
+    BOOST_CHECK_EQUAL(outputs[0].binding.value, "clusters");
+  }
 }
 
 BOOST_AUTO_TEST_CASE(MultinodeUtilities)
 {
   std::string configFilePath = "json:/" + std::string(getenv("O2_ROOT")) + "/share/tests/test_DataSampling.json";
+  std::unique_ptr<ConfigurationInterface> config = ConfigurationFactory::getConfiguration(configFilePath);
+  auto policiesTree = config->getRecursive("dataSamplingPolicies");
 
   {
-    BOOST_CHECK_THROW(DataSampling::PortForPolicy(configFilePath, "no such policy"), std::runtime_error);
-    BOOST_CHECK_THROW(DataSampling::MachinesForPolicy(configFilePath, "no such policy"), std::runtime_error);
+    BOOST_CHECK_THROW(DataSampling::PortForPolicy(policiesTree, "no such policy"), std::runtime_error);
+    BOOST_CHECK_THROW(DataSampling::MachinesForPolicy(policiesTree, "no such policy"), std::runtime_error);
   }
   {
-    auto port = DataSampling::PortForPolicy(configFilePath, "tpcclusters");
+    auto port = DataSampling::PortForPolicy(policiesTree, "tpcclusters");
     BOOST_CHECK(!port.has_value());
-    auto machines = DataSampling::MachinesForPolicy(configFilePath, "tpcclusters");
+    auto machines = DataSampling::MachinesForPolicy(policiesTree, "tpcclusters");
     BOOST_CHECK(machines.empty());
   }
   {
-    auto port = DataSampling::PortForPolicy(configFilePath, "tpcraw");
+    auto port = DataSampling::PortForPolicy(policiesTree, "tpcraw");
     BOOST_REQUIRE(port.has_value());
     BOOST_CHECK_EQUAL(port.value(), 1234);
-    auto machines = DataSampling::MachinesForPolicy(configFilePath, "tpcraw");
+    auto machines = DataSampling::MachinesForPolicy(policiesTree, "tpcraw");
     BOOST_CHECK_EQUAL(machines.size(), 2);
   }
 }

--- a/Utilities/DataSampling/test/test_DataSampling.json
+++ b/Utilities/DataSampling/test/test_DataSampling.json
@@ -1,21 +1,22 @@
 {
-  "dataSamplingPolicies": [
+  "dataSamplingPolicies" : [
     {
-      "id": "tpcclusters",
-      "active": "true",
+      "id" : "tpcclusters",
+      "active" : "true",
       "query" : "clusters:TPC/CLUSTERS;clusters_p:TPC/CLUSTERS_P",
-      "samplingConditions": []
+      "samplingConditions" : []
     },
     {
-      "id": "tpcraw",
-      "active": "true",
-      "machines": [
+      "id" : "tpcraw",
+      "active" : "true",
+      "machines" : [
         "machineA",
         "machineB"
       ],
-      "port": "1234",
-      "query": "clusters:TPC/RAWDATA",
-      "samplingConditions": []
+      "port" : "1234",
+      "query" : "clusters:TPC/RAWDATA",
+      "outputs" : "clusters:TPC/SMP_RAWDATA",
+      "samplingConditions" : []
     }
   ]
 }


### PR DESCRIPTION
Needs https://github.com/AliceO2Group/QualityControl/pull/801 (and a bump) first.