### PR TITLE
[MCH] add track MC label finder workflow and update track I/O

### DIFF
--- a/Detectors/MUON/MCH/Workflow/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Workflow/CMakeLists.txt
@@ -23,6 +23,7 @@ o2_add_library(MCHWorkflow
                    O2::CommonUtils
                    O2::DPLUtils
                    O2::DataFormatsParameters
+                   O2::SimulationDataFormat
                    O2::DetectorsRaw
                    O2::MCHCTF
                    O2::MCHClustering
@@ -79,7 +80,6 @@ o2_add_executable(
         SOURCES src/DigitReaderSpec.cxx src/sim-digits-reader-workflow.cxx
         COMPONENT_NAME mch
         PUBLIC_LINK_LIBRARIES O2::Framework O2::DataFormatsMCH O2::MCHBase O2::MCHMappingImpl3 O2::SimulationDataFormat)
-
 
 o2_add_executable(
         preclusters-sink-workflow
@@ -195,3 +195,9 @@ o2_add_executable(tracks-file-dumper
         SOURCES src/tracks-file-dumper.cxx
         COMPONENT_NAME mch
         PUBLIC_LINK_LIBRARIES Boost::program_options O2::MCHWorkflow)
+
+o2_add_executable(
+        tracks-mc-label-finder-workflow
+        SOURCES src/TrackMCLabelFinderSpec.cxx src/tracks-mc-label-finder-workflow.cxx
+        COMPONENT_NAME mch
+        PUBLIC_LINK_LIBRARIES O2::Framework O2::Steer O2::DataFormatsMCH O2::MCHBase)

--- a/Detectors/MUON/MCH/Workflow/src/TrackMCLabelFinderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackMCLabelFinderSpec.cxx
@@ -1,0 +1,197 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TrackMCLabelFinderSpec.cxx
+/// \brief Implementation of a data processor to match the reconstructed tracks with the simulated ones
+///
+/// \author Philippe Pillot, Subatech
+
+#include "TrackMCLabelFinderSpec.h"
+
+#include <string>
+#include <stdexcept>
+#include <unordered_map>
+#include <vector>
+
+#include <gsl/span>
+
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+#include "Framework/Logger.h"
+
+#include "Steer/MCKinematicsReader.h"
+
+#include "SimulationDataFormat/MCCompLabel.h"
+#include "SimulationDataFormat/MCTruthContainer.h"
+#include "SimulationDataFormat/TrackReference.h"
+
+#include "DataFormatsMCH/ROFRecord.h"
+#include "DataFormatsMCH/TrackMCH.h"
+#include "MCHBase/ClusterBlock.h"
+
+namespace o2
+{
+namespace mch
+{
+
+using namespace std;
+using namespace o2::framework;
+
+class TrackMCLabelFinderTask
+{
+ public:
+  //_________________________________________________________________________________________________
+  /// prepare the task from the context
+  void init(framework::InitContext& ic)
+  {
+    LOG(INFO) << "initializing track MC label finder";
+    if (!mMCReader.initFromDigitContext(ic.options().get<std::string>("incontext").c_str())) {
+      throw invalid_argument("initialization of MCKinematicsReader failed");
+    }
+    double sigmaCut = ic.options().get<double>("sigma-cut");
+    mMaxMatchingChi2 = 2. * sigmaCut * sigmaCut;
+  }
+
+  //_________________________________________________________________________________________________
+  /// assign every reconstructed track a MC label, pointing to the corresponding particle or fake
+  void run(framework::ProcessingContext& pc)
+  {
+    // get the input messages
+    auto digitROFs = pc.inputs().get<gsl::span<ROFRecord>>("digitrofs");
+    auto digitlabels = pc.inputs().get<const dataformats::MCTruthContainer<MCCompLabel>*>("digitlabels");
+    auto trackROFs = pc.inputs().get<gsl::span<ROFRecord>>("trackrofs");
+    auto tracks = pc.inputs().get<gsl::span<TrackMCH>>("tracks");
+    auto clusters = pc.inputs().get<gsl::span<ClusterStruct>>("clusters");
+
+    // digit and track ROFs must be synchronized
+    int nROFs = digitROFs.size();
+    if (trackROFs.size() != nROFs) {
+      throw length_error("inconsistent ROFs");
+    }
+
+    dataformats::MCTruthContainer<MCCompLabel> tracklabels;
+
+    for (int iROF = 0; iROF < nROFs; ++iROF) {
+
+      // skip interation records with no reconstructed tracks
+      auto trackROF = trackROFs[iROF];
+      if (trackROF.getNEntries() == 0) {
+        continue;
+      }
+
+      // digits and tracks must belong to the same IR
+      auto digitROF = digitROFs[iROF];
+      if (digitROF.getBCData() != trackROF.getBCData()) {
+        throw logic_error("inconsistent ROF");
+      }
+
+      // get the MC labels of every particles contributing to that IR and produce the associated MC clusters
+      std::unordered_map<MCCompLabel, std::vector<ClusterStruct>> mcClusterMap{};
+      for (int iDigit = digitROF.getFirstIdx(); iDigit <= digitROF.getLastIdx(); ++iDigit) {
+        for (const auto& label : digitlabels->getLabels(iDigit)) {
+          if (label.isCorrect() && mcClusterMap.count(label) == 0) {
+            makeMCClusters(mMCReader.getTrackRefs(label.getSourceID(), label.getEventID(), label.getTrackID()),
+                           mcClusterMap[label]);
+          }
+        }
+      }
+
+      // try to pair every reconstructed tracks with every MC tracks to set MC labels
+      for (int iTrack = trackROF.getFirstIdx(); iTrack <= trackROF.getLastIdx(); ++iTrack) {
+        for (const auto& [label, mcClusters] : mcClusterMap) {
+          if (match(clusters.subspan(tracks[iTrack].getFirstClusterIdx(), tracks[iTrack].getNClusters()), mcClusters)) {
+            tracklabels.addElement(iTrack, label);
+          }
+        }
+        if (tracklabels.getIndexedSize() != iTrack + 1) {
+          tracklabels.addElement(iTrack, MCCompLabel());
+        }
+      }
+    }
+
+    // send the track MC labels
+    pc.outputs().snapshot(OutputRef{"tracklabels"}, tracklabels);
+  }
+
+ private:
+  //_________________________________________________________________________________________________
+  /// produce the MC clusters by taking the average position of the trackRefs at the entry and exit of each DE
+  void makeMCClusters(gsl::span<const TrackReference> mcTrackRefs, std::vector<ClusterStruct>& mcClusters) const
+  {
+    int deId(-1);
+    int clusterIdx(0);
+    for (const auto& trackRef : mcTrackRefs) {
+      if (trackRef.getDetectorId() < 100 || trackRef.getDetectorId() > 1025) {
+        deId = -1;
+        continue;
+      }
+      if (trackRef.getDetectorId() == deId) {
+        auto& cluster = mcClusters.back();
+        cluster.x = (cluster.x + trackRef.X()) / 2.;
+        cluster.y = (cluster.y + trackRef.Y()) / 2.;
+        cluster.z = (cluster.z + trackRef.Z()) / 2.;
+        deId = -1; // to create a new cluster in case the track re-enter the DE (loop)
+      } else {
+        deId = trackRef.getDetectorId();
+        mcClusters.push_back({trackRef.X(), trackRef.Y(), trackRef.Z(), 0.f, 0.f,
+                              ClusterStruct::buildUniqueId(deId / 100 - 1, deId, clusterIdx++), 0u, 0u});
+      }
+    }
+  }
+
+  //_________________________________________________________________________________________________
+  /// try to match a reconstructed track with a MC track. Matching conditions:
+  /// - more than 50% of reconstructed clusters matched with MC clusters
+  /// - at least 1 matched cluster before and 1 after the dipole
+  bool match(gsl::span<const ClusterStruct> clusters, const std::vector<ClusterStruct>& mcClusters) const
+  {
+    int nMatched(0);
+    bool hasMatched[5] = {false, false, false, false, false};
+    for (const auto& cluster : clusters) {
+      for (const auto& mcCluster : mcClusters) {
+        if (cluster.getDEId() == mcCluster.getDEId()) {
+          double dx = cluster.x - mcCluster.x;
+          double dy = cluster.y - mcCluster.y;
+          double chi2 = dx * dx / (cluster.ex * cluster.ex) + dy * dy / (cluster.ey * cluster.ey);
+          if (chi2 <= mMaxMatchingChi2) {
+            hasMatched[cluster.getChamberId() / 2] = true;
+            ++nMatched;
+            break;
+          }
+        }
+      }
+    }
+    return ((hasMatched[0] || hasMatched[1]) && (hasMatched[3] || hasMatched[4]) && 2 * nMatched > clusters.size());
+  }
+
+  steer::MCKinematicsReader mMCReader{}; ///< MC reader to retrieve the trackRefs
+  double mMaxMatchingChi2 = 32.;         ///< maximum chi2 to match simulated and reconstructed clusters
+};
+
+//_________________________________________________________________________________________________
+o2::framework::DataProcessorSpec getTrackMCLabelFinderSpec(const char* name)
+{
+  return DataProcessorSpec{
+    name,
+    Inputs{InputSpec{"digitrofs", "MCH", "DIGITROFS", 0, Lifetime::Timeframe},
+           InputSpec{"digitlabels", "MCH", "DIGITLABELS", 0, Lifetime::Timeframe},
+           InputSpec{"trackrofs", "MCH", "TRACKROFS", 0, Lifetime::Timeframe},
+           InputSpec{"tracks", "MCH", "TRACKS", 0, Lifetime::Timeframe},
+           InputSpec{"clusters", "MCH", "TRACKCLUSTERS", 0, Lifetime::Timeframe}},
+    Outputs{OutputSpec{{"tracklabels"}, "MCH", "TRACKLABELS", 0, Lifetime::Timeframe}},
+    AlgorithmSpec{adaptFromTask<TrackMCLabelFinderTask>()},
+    Options{{"incontext", VariantType::String, "collisioncontext.root", {"Take collision context from this file"}},
+            {"sigma-cut", VariantType::Double, 4., {"Sigma cut to match simulated and reconstructed clusters"}}}};
+}
+
+} // end namespace mch
+} // end namespace o2

--- a/Detectors/MUON/MCH/Workflow/src/TrackMCLabelFinderSpec.h
+++ b/Detectors/MUON/MCH/Workflow/src/TrackMCLabelFinderSpec.h
@@ -1,0 +1,32 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TrackMCLabelFinderSpec.h
+/// \brief Definition of a data processor to match the reconstructed tracks with the simulated ones
+///
+/// \author Philippe Pillot, Subatech
+
+#ifndef O2_MCH_TRACKMCLABELFINDERSPEC_H_
+#define O2_MCH_TRACKMCLABELFINDERSPEC_H_
+
+#include "Framework/DataProcessorSpec.h"
+
+namespace o2
+{
+namespace mch
+{
+
+o2::framework::DataProcessorSpec getTrackMCLabelFinderSpec(const char* name = "TrackMCLabelFinder");
+
+} // end namespace mch
+} // end namespace o2
+
+#endif // O2_MCH_TRACKMCLABELFINDERSPEC_H_

--- a/Detectors/MUON/MCH/Workflow/src/TrackReaderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackReaderSpec.cxx
@@ -12,6 +12,8 @@
 #include "MCHWorkflow/TrackReaderSpec.h"
 
 #include "DPLUtils/RootTreeReader.h"
+#include "SimulationDataFormat/MCCompLabel.h"
+#include "SimulationDataFormat/MCTruthContainer.h"
 #include "DataFormatsMCH/ROFRecord.h"
 #include "DataFormatsMCH/TrackMCH.h"
 #include "Framework/ConfigParamRegistry.h"
@@ -46,25 +48,44 @@ RootTreeReader::SpecialPublishHook logging{
     if (name == "tracks") {
       printBranch<TrackMCH>(data, "TRACKS");
     }
+    if (name == "tracklabels") {
+      auto tdata = reinterpret_cast<dataformats::MCTruthContainer<MCCompLabel>*>(data);
+      LOGP(info, "MCH {:d} {:s}", tdata->getIndexedSize(), "LABELS");
+    }
     return false;
   }};
 
 struct TrackReader {
   std::unique_ptr<RootTreeReader> mTreeReader;
+  bool mUseMC = false;
+  TrackReader(bool useMC = false) : mUseMC(useMC) {}
   void init(InitContext& ic)
   {
     auto treeName = "o2sim";
     auto fileName = ic.options().get<std::string>("infile");
     auto nofEntries{-1};
-    mTreeReader = std::make_unique<RootTreeReader>(
-      treeName,
-      fileName.c_str(),
-      nofEntries,
-      RootTreeReader::PublishingMode::Single,
-      RootTreeReader::BranchDefinition<std::vector<TrackMCH>>{Output{"MCH", "TRACKS", 0}, "tracks"},
-      RootTreeReader::BranchDefinition<std::vector<ROFRecord>>{Output{"MCH", "TRACKROFS", 0}, "trackrofs"},
-      RootTreeReader::BranchDefinition<std::vector<ClusterStruct>>{Output{"MCH", "TRACKCLUSTERS", 0}, "trackclusters"},
-      &logging);
+    if (mUseMC) {
+      mTreeReader = std::make_unique<RootTreeReader>(
+        treeName,
+        fileName.c_str(),
+        nofEntries,
+        RootTreeReader::PublishingMode::Single,
+        RootTreeReader::BranchDefinition<std::vector<TrackMCH>>{Output{"MCH", "TRACKS", 0}, "tracks"},
+        RootTreeReader::BranchDefinition<std::vector<ROFRecord>>{Output{"MCH", "TRACKROFS", 0}, "trackrofs"},
+        RootTreeReader::BranchDefinition<std::vector<ClusterStruct>>{Output{"MCH", "TRACKCLUSTERS", 0}, "trackclusters"},
+        RootTreeReader::BranchDefinition<dataformats::MCTruthContainer<MCCompLabel>>{Output{"MCH", "TRACKLABELS", 0}, "tracklabels"},
+        &logging);
+    } else {
+      mTreeReader = std::make_unique<RootTreeReader>(
+        treeName,
+        fileName.c_str(),
+        nofEntries,
+        RootTreeReader::PublishingMode::Single,
+        RootTreeReader::BranchDefinition<std::vector<TrackMCH>>{Output{"MCH", "TRACKS", 0}, "tracks"},
+        RootTreeReader::BranchDefinition<std::vector<ROFRecord>>{Output{"MCH", "TRACKROFS", 0}, "trackrofs"},
+        RootTreeReader::BranchDefinition<std::vector<ClusterStruct>>{Output{"MCH", "TRACKCLUSTERS", 0}, "trackclusters"},
+        &logging);
+    }
   }
 
   void
@@ -84,9 +105,8 @@ DataProcessorSpec getTrackReaderSpec(bool useMC, const char* name)
   outputSpecs.emplace_back(OutputSpec{{"tracks"}, "MCH", "TRACKS", 0, Lifetime::Timeframe});
   outputSpecs.emplace_back(OutputSpec{{"trackrofs"}, "MCH", "TRACKROFS", 0, Lifetime::Timeframe});
   outputSpecs.emplace_back(OutputSpec{{"trackclusters"}, "MCH", "TRACKCLUSTERS", 0, Lifetime::Timeframe});
-
-  if (useMC == true) {
-    LOGP(warning, "MC handling not yet implemented");
+  if (useMC) {
+    outputSpecs.emplace_back(OutputSpec{{"tracklabels"}, "MCH", "TRACKLABELS", 0, Lifetime::Timeframe});
   }
 
   auto options = Options{
@@ -97,7 +117,7 @@ DataProcessorSpec getTrackReaderSpec(bool useMC, const char* name)
     name,
     Inputs{},
     outputSpecs,
-    adaptFromTask<TrackReader>(),
+    adaptFromTask<TrackReader>(useMC),
     options};
 }
 } // namespace o2::mch

--- a/Detectors/MUON/MCH/Workflow/src/TrackTreeReader.h
+++ b/Detectors/MUON/MCH/Workflow/src/TrackTreeReader.h
@@ -15,7 +15,10 @@
 #include "MCHBase/ClusterBlock.h"
 #include "DataFormatsMCH/TrackMCH.h"
 #include "DataFormatsMCH/ROFRecord.h"
+#include "SimulationDataFormat/MCCompLabel.h"
+#include "SimulationDataFormat/MCTruthContainer.h"
 #include <TTreeReader.h>
+#include <memory>
 #include <vector>
 
 namespace o2::mch
@@ -28,13 +31,17 @@ class TrackTreeReader
 
   bool next(ROFRecord& rof,
             std::vector<TrackMCH>& tracks,
-            std::vector<ClusterStruct>& clusters);
+            std::vector<ClusterStruct>& clusters,
+            o2::dataformats::MCTruthContainer<o2::MCCompLabel>& labels);
+
+  bool hasLabels() { return mLabels.get() != nullptr; }
 
  private:
   TTreeReader mTreeReader;
   TTreeReaderValue<std::vector<o2::mch::TrackMCH>> mTracks = {mTreeReader, "tracks"};
   TTreeReaderValue<std::vector<o2::mch::ROFRecord>> mRofs = {mTreeReader, "trackrofs"};
   TTreeReaderValue<std::vector<o2::mch::ClusterStruct>> mClusters = {mTreeReader, "trackclusters"};
+  std::unique_ptr<TTreeReaderValue<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>> mLabels{};
   size_t mCurrentRof;
 };
 } // namespace o2::mch

--- a/Detectors/MUON/MCH/Workflow/src/TrackWriterSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackWriterSpec.cxx
@@ -12,6 +12,8 @@
 #include "MCHWorkflow/TrackWriterSpec.h"
 
 #include "DPLUtils/MakeRootTreeWriterSpec.h"
+#include "SimulationDataFormat/MCCompLabel.h"
+#include "SimulationDataFormat/MCTruthContainer.h"
 #include "DataFormatsMCH/ROFRecord.h"
 #include "DataFormatsMCH/TrackMCH.h"
 #include "Framework/Logger.h"
@@ -28,15 +30,13 @@ using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
 
 DataProcessorSpec getTrackWriterSpec(bool useMC, const char* name)
 {
-  if (useMC == true) {
-    LOGP(warning, "MC handling not yet implemented");
-  }
-  return MakeRootTreeWriterSpec("mch-tracks-writer",
-                                name,
+  return MakeRootTreeWriterSpec(name,
+                                "mchtracks.root",
                                 MakeRootTreeWriterSpec::TreeAttributes{"o2sim", "Tree MCH Standalone Tracks"},
                                 BranchDefinition<std::vector<TrackMCH>>{InputSpec{"tracks", "MCH", "TRACKS"}, "tracks"},
                                 BranchDefinition<std::vector<ROFRecord>>{InputSpec{"trackrofs", "MCH", "TRACKROFS"}, "trackrofs"},
-                                BranchDefinition<std::vector<ClusterStruct>>{InputSpec{"trackclusters", "MCH", "TRACKCLUSTERS"}, "trackclusters"})();
+                                BranchDefinition<std::vector<ClusterStruct>>{InputSpec{"trackclusters", "MCH", "TRACKCLUSTERS"}, "trackclusters"},
+                                BranchDefinition<dataformats::MCTruthContainer<MCCompLabel>>{InputSpec{"tracklabels", "MCH", "TRACKLABELS"}, "tracklabels", useMC ? 1 : 0})();
 }
 
 } // namespace o2::mch

--- a/Detectors/MUON/MCH/Workflow/src/tracks-file-dumper.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/tracks-file-dumper.cxx
@@ -9,6 +9,8 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#include "SimulationDataFormat/MCCompLabel.h"
+#include "SimulationDataFormat/MCTruthContainer.h"
 #include "DataFormatsMCH/ROFRecord.h"
 #include "DataFormatsMCH/TrackMCH.h"
 #include "MCHBase/ClusterBlock.h"
@@ -130,12 +132,22 @@ int dumpRoot(std::string inputFile)
   ROFRecord rof;
   std::vector<TrackMCH> tracks;
   std::vector<ClusterStruct> clusters;
+  o2::dataformats::MCTruthContainer<o2::MCCompLabel> labels;
 
-  while (tr.next(rof, tracks, clusters)) {
+  while (tr.next(rof, tracks, clusters, labels)) {
     std::cout << rof << "\n";
+    if (tr.hasLabels() && labels.getIndexedSize() != tracks.size()) {
+      std::cerr << "the number of labels do not match the number of tracks\n";
+      return -1;
+    }
+    int it(0);
     for (const auto& t : tracks) {
       std::cout << "   ";
       dump(std::cout, t);
+      for (const auto& l : labels.getLabels(it++)) {
+        std::cout << "   MC label: ";
+        l.print();
+      }
     }
   }
   return 0;

--- a/Detectors/MUON/MCH/Workflow/src/tracks-mc-label-finder-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/tracks-mc-label-finder-workflow.cxx
@@ -1,0 +1,25 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file tracks-mc-label-finder-workflow.cxx
+/// \brief Implementation of a DPL device to match the reconstructed tracks with the simulated ones
+///
+/// \author Philippe Pillot, Subatech
+
+#include "TrackMCLabelFinderSpec.h"
+#include "Framework/runDataProcessing.h"
+
+using namespace o2::framework;
+
+WorkflowSpec defineDataProcessing(const ConfigContext&)
+{
+  return WorkflowSpec{o2::mch::getTrackMCLabelFinderSpec()};
+}

--- a/Detectors/MUON/MCH/Workflow/src/tracks-reader-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/tracks-reader-workflow.cxx
@@ -9,13 +9,22 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#include <vector>
+#include "Framework/ConfigParamSpec.h"
 #include "MCHWorkflow/TrackReaderSpec.h"
-#include "Framework/runDataProcessing.h"
 
 using namespace o2::framework;
 
-WorkflowSpec defineDataProcessing(const ConfigContext& configcontext)
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
-  bool useMC{false};
+  workflowOptions.emplace_back("enable-mc", VariantType::Bool, false, ConfigParamSpec::HelpString{"Propagate MC info"});
+}
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(const ConfigContext& config)
+{
+  bool useMC = config.options().get<bool>("enable-mc");
   return WorkflowSpec{o2::mch::getTrackReaderSpec(useMC)};
 }

--- a/Detectors/MUON/MCH/Workflow/src/tracks-writer-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/tracks-writer-workflow.cxx
@@ -9,13 +9,22 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#include <vector>
+#include "Framework/ConfigParamSpec.h"
 #include "MCHWorkflow/TrackWriterSpec.h"
-#include "Framework/runDataProcessing.h"
 
 using namespace o2::framework;
 
-WorkflowSpec defineDataProcessing(const ConfigContext& configcontext)
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
-  bool useMC{false};
+  workflowOptions.emplace_back("enable-mc", VariantType::Bool, false, ConfigParamSpec::HelpString{"Propagate MC info"});
+}
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(const ConfigContext& config)
+{
+  bool useMC = config.options().get<bool>("enable-mc");
   return WorkflowSpec{o2::mch::getTrackWriterSpec(useMC)};
 }


### PR DESCRIPTION
In the new workflow, the track MC labels are determined by comparing the position of the clusters attached to the track to the position of the trackRefs attached to every MC tracks contributing to the digits in this ROF.

The track reader/writer workflows are updated to read/write the MC labels if requested.
