### PR TITLE
[EMCAL-666] Include entropy decoding into the emcal reconstruction workflow

### DIFF
--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/RecoWorkflow.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/RecoWorkflow.h
@@ -28,10 +28,11 @@ namespace reco_workflow
 /// \enum InputType
 /// \brief Input types of the workflow
 /// \ingroup EMCALworkflow
-enum struct InputType { Digits,  ///< read digits from file
-                        Cells,   ///< read compressed cells from file
-                        Raw,     ///< read data in raw page format from file
-                        Clusters ///< read native clusters from file
+enum struct InputType { Digits,   ///< read digits from file
+                        Cells,    ///< read compressed cells from file
+                        Raw,      ///< read data in raw page format from file
+                        Clusters, ///< read native clusters from file
+                        CTF       ///< Compressed Timeframes
 };
 
 /// \enum OutputType

--- a/Detectors/EMCAL/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/EMCAL/workflow/src/RecoWorkflow.cxx
@@ -25,6 +25,7 @@
 #include "EMCALWorkflow/RecoWorkflow.h"
 #include "EMCALWorkflow/CellConverterSpec.h"
 #include "EMCALWorkflow/ClusterizerSpec.h"
+#include "EMCALWorkflow/EntropyDecoderSpec.h"
 #include "EMCALWorkflow/AnalysisClusterSpec.h"
 #include "EMCALWorkflow/DigitsPrinterSpec.h"
 #include "EMCALWorkflow/PublisherSpec.h"
@@ -60,7 +61,7 @@ o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
     {"cells", InputType::Cells},
     {"raw", InputType::Raw},
     {"clusters", InputType::Clusters},
-  };
+    {"ctf", InputType::CTF}};
 
   const std::unordered_map<std::string, OutputType> OutputMap{
     {"digits", OutputType::Digits},
@@ -72,7 +73,8 @@ o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
   std::unordered_map<InputType, std::vector<OutputType>> allowedIO;
   allowedIO[InputType::Digits] = std::vector<OutputType>{OutputType::Cells, OutputType::Clusters, OutputType::AnalysisClusters};
   allowedIO[InputType::Cells] = std::vector<OutputType>{OutputType::Cells, OutputType::Clusters, OutputType::AnalysisClusters};
-  allowedIO[InputType::Raw] = std::vector<OutputType>{OutputType::Cells};
+  allowedIO[InputType::Raw] = std::vector<OutputType>{OutputType::Cells, OutputType::Clusters, OutputType::AnalysisClusters};
+  allowedIO[InputType::CTF] = std::vector<OutputType>{OutputType::Cells, OutputType::Clusters, OutputType::AnalysisClusters};
 
   InputType inputType;
 
@@ -161,6 +163,12 @@ o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
       } catch (std::runtime_error& e) {
         LOG(ERROR) << "Cannot create digits printer spec: " << e.what();
       }
+    }
+  } else if (inputType == InputType::CTF) {
+    try {
+      specs.emplace_back(o2::emcal::getEntropyDecoderSpec());
+    } catch (const std::runtime_error& e) {
+      LOG(ERROR) << "Cannot create entropy encoder spec: " << e.what();
     }
   }
 

--- a/Detectors/EMCAL/workflow/src/emc-reco-workflow.cxx
+++ b/Detectors/EMCAL/workflow/src/emc-reco-workflow.cxx
@@ -30,7 +30,7 @@
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   std::vector<o2::framework::ConfigParamSpec> options{
-    {"input-type", o2::framework::VariantType::String, "digits", {"digits, cells, raw, clusters"}},
+    {"input-type", o2::framework::VariantType::String, "digits", {"digits, cells, raw, clusters, ctf"}},
     {"output-type", o2::framework::VariantType::String, "cells", {"digits, cells, raw, clusters, analysisclusters"}},
     {"enable-digits-printer", o2::framework::VariantType::Bool, false, {"enable digits printer component"}},
     {"disable-root-input", o2::framework::VariantType::Bool, false, {"do not initialize root files readers"}},


### PR DESCRIPTION
- Add input type CTF and include entropy decoder
  spec for this input type
- Add cells and clusters as valid output types for
  input type CTF
- Add clusters as valid output type for input type raw