### PR TITLE
[EMCAL-647] Event builder for cell container from different subtimeframes

### DIFF
--- a/Detectors/EMCAL/workflow/CMakeLists.txt
+++ b/Detectors/EMCAL/workflow/CMakeLists.txt
@@ -21,12 +21,18 @@ o2_add_library(EMCALWorkflow
                        src/RawToCellConverterSpec.cxx
                        src/EntropyEncoderSpec.cxx
                        src/EntropyDecoderSpec.cxx
+                       src/EventBuilderSpec.cxx
                PUBLIC_LINK_LIBRARIES O2::Framework O2::DataFormatsEMCAL O2::EMCALSimulation O2::Steer
                                      O2::DPLUtils O2::EMCALBase O2::EMCALReconstruction O2::Algorithm)
 
 o2_add_executable(reco-workflow
                   COMPONENT_NAME emcal
                   SOURCES src/emc-reco-workflow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::EMCALWorkflow)
+
+o2_add_executable(event-builder-workflow
+                  COMPONENT_NAME emcal
+                  SOURCES src/event-builder-workflow.cxx
                   PUBLIC_LINK_LIBRARIES O2::EMCALWorkflow)
 
 o2_add_executable(entropy-encoder-workflow

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/EventBuilderSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/EventBuilderSpec.h
@@ -1,0 +1,71 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <cstdint>
+#include <set>
+#include <vector>
+
+#include "CommonDataFormat/RangeReference.h"
+#include "CommonDataFormat/InteractionRecord.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+#include "Headers/DataHeader.h"
+
+namespace o2
+{
+
+namespace emcal
+{
+class TriggerRecord;
+
+/// \class EventBuilderSpec
+/// \brief Class combining cell data from different subtimeframes into single cell range
+/// \ingroup EMCALEMCALworkflow
+/// \author Markus Fasel <markus.fasek@cern.ch>, Oak Ridge National Laboratory
+/// \since Aug 9, 2021
+///
+/// The data processor combines cells from the same trigger in different subtimeframes
+/// into a single cell container. Cells within the event range are ordered according
+/// to the tower ID. New trigger record objects indicate the combined.
+class EventBuilderSpec : public framework::Task
+{
+ public:
+  /// \brief Constructor
+  EventBuilderSpec() = default;
+
+  /// \brief Destructor
+  ~EventBuilderSpec() override = default;
+
+  void init(framework::InitContext& ctx) final;
+  void run(framework::ProcessingContext& ctx) final;
+
+ private:
+  struct RangeSubspec {
+    header::DataHeader::SubSpecificationType mSpecification;
+    dataformats::RangeReference<int, int> mDataRage;
+  };
+
+  struct RangeCollection {
+    InteractionRecord mInteractionRecord;
+    uint32_t mTriggerType;
+    std::vector<RangeSubspec> mRangesSubtimeframe;
+
+    bool operator==(const RangeCollection& other) const { return mInteractionRecord == other.mInteractionRecord; }
+    bool operator<(const RangeCollection& other) const { return mInteractionRecord < other.mInteractionRecord; }
+  };
+  std::set<RangeCollection> connectRangesFromSubtimeframes(const std::unordered_map<header::DataHeader::SubSpecificationType, gsl::span<const TriggerRecord>>& triggerrecords) const;
+};
+
+o2::framework::DataProcessorSpec getEventBuilderSpec(std::vector<unsigned int> subspecifications);
+
+} // namespace emcal
+
+} // namespace o2

--- a/Detectors/EMCAL/workflow/src/EventBuilderSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/EventBuilderSpec.cxx
@@ -1,0 +1,139 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction
+
+#include <algorithm>
+#include <iterator>
+#include <unordered_map>
+#include <gsl/span>
+
+#include "DataFormatsEMCAL/Cell.h"
+#include "DataFormatsEMCAL/TriggerRecord.h"
+#include "Framework/InputSpec.h"
+#include "Framework/Logger.h"
+#include "EMCALWorkflow/EventBuilderSpec.h"
+
+using namespace o2::emcal;
+
+void EventBuilderSpec::init(framework::InitContext& ctx)
+{
+}
+
+void EventBuilderSpec::run(framework::ProcessingContext& ctx)
+{
+  auto dataorigin = o2::header::gDataOriginEMC;
+  std::unordered_map<o2::header::DataHeader::SubSpecificationType, gsl::span<const TriggerRecord>> triggers;
+  std::unordered_map<o2::header::DataHeader::SubSpecificationType, gsl::span<const Cell>> cells;
+
+  std::vector<Cell> outputCells;
+  std::vector<TriggerRecord> outputTriggers;
+
+  auto posCells = ctx.inputs().getPos("inputcells"),
+       posTriggerRecords = ctx.inputs().getPos("inputtriggers");
+  auto numSlotsCells = ctx.inputs().getNofParts(posCells),
+       numSlotsTriggerRecords = ctx.inputs().getNofParts(posTriggerRecords);
+  for (decltype(numSlotsCells) islot = 0; islot < numSlotsCells; islot++) {
+    auto celldata = ctx.inputs().getByPos(posCells, islot);
+    auto subspecification = framework::DataRefUtils::getHeader<header::DataHeader*>(celldata)->subSpecification;
+    // Discard message if it is a deadbeaf message (empty timeframe)
+    if (subspecification == 0xDEADBEEF) {
+      continue;
+    }
+    cells[subspecification] = ctx.inputs().get<gsl::span<o2::emcal::Cell>>(celldata);
+  }
+  for (decltype(numSlotsTriggerRecords) islot = 0; islot < numSlotsTriggerRecords; islot++) {
+    auto trgrecorddata = ctx.inputs().getByPos(posTriggerRecords, islot);
+    auto subspecification = framework::DataRefUtils::getHeader<header::DataHeader*>(trgrecorddata)->subSpecification;
+    // Discard message if it is a deadbeaf message (empty timeframe)
+    if (subspecification == 0xDEADBEEF) {
+      continue;
+    }
+    triggers[subspecification] = ctx.inputs().get<gsl::span<o2::emcal::TriggerRecord>>(trgrecorddata);
+  }
+
+  for (auto interaction : connectRangesFromSubtimeframes(triggers)) {
+    int start = outputCells.size(),
+        ncellsEvent = 0;
+    for (auto [subspec, triggerrecord] : interaction.mRangesSubtimeframe) {
+      LOG(DEBUG) << interaction.mInteractionRecord.bc << " / " << interaction.mInteractionRecord.orbit << ": Receiving " << triggerrecord.getEntries() << " digits for subspec " << subspec;
+      auto cellcont = cells.find(subspec);
+      if (cellcont != cells.end()) {
+        for (auto& cell : gsl::span<const Cell>(cellcont->second.data() + triggerrecord.getFirstEntry(), triggerrecord.getEntries())) {
+          outputCells.emplace_back(cell);
+        }
+      } else {
+        LOG(ERROR) << "No cell container found for subspec " << subspec;
+      }
+    }
+    if (ncellsEvent) {
+      std::sort(outputCells.begin() + start, outputCells.begin() + start + ncellsEvent, [](const Cell& lhs, const Cell& rhs) { return lhs.getTower() < rhs.getTower(); });
+    }
+    outputTriggers.emplace_back(interaction.mInteractionRecord, interaction.mTriggerType, start, ncellsEvent);
+  }
+
+  ctx.outputs().snapshot(framework::Output{dataorigin, "CELLS", 0, framework::Lifetime::Timeframe}, outputCells);
+  ctx.outputs().snapshot(framework::Output{dataorigin, "CELLSTRGR", 0, framework::Lifetime::Timeframe}, outputTriggers);
+}
+
+std::set<EventBuilderSpec::RangeCollection> EventBuilderSpec::connectRangesFromSubtimeframes(const std::unordered_map<o2::header::DataHeader::SubSpecificationType, gsl::span<const TriggerRecord>>& triggerrecords) const
+{
+  std::set<RangeCollection> events;
+
+  // Search interaction records from all subevents
+  // build also a map with indices of the trigger record in gsl span for each subspecification
+  std::unordered_map<o2::InteractionRecord, std::unordered_map<o2::header::DataHeader::SubSpecificationType, int>> allInteractions;
+  for (auto& [subspecification, trgrec] : triggerrecords) {
+    for (decltype(trgrec.size()) trgPos = 0; trgPos < trgrec.size(); trgPos++) {
+      auto eventIR = trgrec[trgPos].getBCData();
+      auto interactionPtr = allInteractions.find(eventIR);
+      if (interactionPtr == allInteractions.end()) {
+        allInteractions[eventIR] = {{subspecification, trgPos}};
+      } else {
+        interactionPtr->second.insert({subspecification, trgPos});
+      }
+    }
+  }
+
+  // iterate over all subevents for all bunch crossings
+  for (const auto& [collisionID, subevents] : allInteractions) {
+    RangeCollection nextevent;
+    nextevent.mInteractionRecord = collisionID;
+    bool first = true;
+    for (auto& [subspecification, indexInSubevent] : subevents) {
+      auto& eventTR = triggerrecords.find(subspecification)->second[indexInSubevent];
+      if (first) {
+        nextevent.mTriggerType = eventTR.getTriggerBits();
+        first = false;
+      }
+      nextevent.mRangesSubtimeframe.push_back({subspecification, o2::dataformats::RangeReference(eventTR.getFirstEntry(), eventTR.getNumberOfObjects())});
+    }
+    events.insert(nextevent);
+  }
+  return events;
+}
+
+o2::framework::DataProcessorSpec o2::emcal::getEventBuilderSpec(std::vector<unsigned int> subspecifications)
+{
+  auto dataorigin = o2::header::gDataOriginEMC;
+  o2::framework::Inputs inputs;
+  for (auto& spec : subspecifications) {
+    inputs.push_back({"inputcells", dataorigin, "CELLS", spec, o2::framework::Lifetime::Timeframe});
+    inputs.push_back({"inputtriggers", dataorigin, "CELLSTRGR", spec, o2::framework::Lifetime::Timeframe});
+  }
+  o2::framework::Outputs outputs{
+    {dataorigin, "CELLS", 0, o2::framework::Lifetime::Timeframe},
+    {dataorigin, "CELLSTRGR", 0, o2::framework::Lifetime::Timeframe}};
+
+  return o2::framework::DataProcessorSpec{"EMCALEventBuilder",
+                                          inputs,
+                                          outputs,
+                                          o2::framework::adaptFromTask<EventBuilderSpec>(),
+                                          o2::framework::Options{}};
+}

--- a/Detectors/EMCAL/workflow/src/event-builder-workflow.cxx
+++ b/Detectors/EMCAL/workflow/src/event-builder-workflow.cxx
@@ -1,0 +1,47 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction
+
+#include <string>
+#include <sstream>
+#include <vector>
+#include "EMCALWorkflow/EventBuilderSpec.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/Logger.h"
+
+using namespace o2::framework;
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  std::vector<ConfigParamSpec> options{ConfigParamSpec{"subspecifications", VariantType::String, "", {"Comma-separated list of subspecifications"}}};
+
+  std::swap(workflowOptions, options);
+}
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  std::vector<unsigned int> specs;
+  std::stringstream parser(cfgc.options().get<std::string>("subspecifications"));
+  std::string buffer;
+  while (std::getline(parser, buffer, ',')) {
+    specs.emplace_back(std::stoi(buffer));
+  }
+  if (!specs.size()) {
+    LOG(FATAL) << "No input specs for defined";
+  }
+  WorkflowSpec wf;
+  wf.emplace_back(o2::emcal::getEventBuilderSpec(specs));
+  return wf;
+}


### PR DESCRIPTION
Combining cells from multiple subevents in a single
cell / trigger record container according to cells
belonging to the same collsion. Output is sent to
the same output type as input cell / trigger record
container but with subspecification 0 for
compatibility with existing containers.