### PR TITLE
Refer ITS track cluster indices to TF start rather than ROF

### DIFF
--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
@@ -413,7 +413,7 @@ class MatchTPCITS
   int preselectChipClusters(std::vector<int>& clVecOut, const ClusRange& clRange, const ITSChipClustersRefs& itsChipClRefs,
                             float trackY, float trackZ, float tolerY, float tolerZ) const;
   void fillClustersForAfterBurner(int rofStart, int nROFs, ITSChipClustersRefs& itsChipClRefs);
-  void flagUsedITSClusters(const o2::its::TrackITS& track, int rofOffset);
+  void flagUsedITSClusters(const o2::its::TrackITS& track);
 
   void doMatching(int sec);
 

--- a/Detectors/GlobalTracking/src/MatchCosmics.cxx
+++ b/Detectors/GlobalTracking/src/MatchCosmics.cxx
@@ -114,9 +114,8 @@ void MatchCosmics::refitWinners(const o2::globaltracking::RecoContainer& data)
   auto refitITSTrack = [this, &data, &itsTracksROF, &itsClusters](o2::track::TrackParCov& trFit, GTrackID gidx, float& chi2, bool inward = false) {
     const auto& itsTrOrig = data.getITSTrack(gidx);
     int nclRefit = 0, ncl = itsTrOrig.getNumberOfClusters(), rof = itsTracksROF[gidx.getIndex()];
-    const auto& itsClustersROFRec = data.getITSClustersROFRecords();
     const auto& itsTrackClusRefs = data.getITSTracksClusterRefs();
-    int clusIndOffs = itsClustersROFRec[rof].getFirstEntry(), clEntry = itsTrOrig.getFirstClusterEntry();
+    int clEntry = itsTrOrig.getFirstClusterEntry();
     const auto propagator = o2::base::Propagator::Instance();
     const auto geomITS = o2::its::GeometryTGeo::Instance();
     int from = ncl - 1, to = -1, step = -1;
@@ -126,7 +125,7 @@ void MatchCosmics::refitWinners(const o2::globaltracking::RecoContainer& data)
       step = 1;
     }
     for (int icl = from; icl != to; icl += step) { // ITS clusters are referred in layer decreasing order
-      const auto& clus = itsClusters[clusIndOffs + itsTrackClusRefs[clEntry + icl]];
+      const auto& clus = itsClusters[itsTrackClusRefs[clEntry + icl]];
       float alpha = geomITS->getSensorRefAlpha(clus.getSensorID()), x = clus.getX();
       if (!trFit.rotate(alpha) || !propagator->propagateToX(trFit, x, propagator->getNominalBz(), this->mMatchParams->maxSnp, this->mMatchParams->maxStep, this->mMatchParams->matCorr)) {
         break;

--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -569,7 +569,6 @@ bool MatchTPCITS::prepareITSData()
       mITSTrackROFContMapping[irofCont] = irof;
     }
 
-    int cluROFOffset = mITSClusterROFRec[irof].getFirstEntry(); // clusters of this ROF start at this offset
     mITSROFTimes.emplace_back(tMin, tMax);                      // ITS ROF min/max time
 
     for (int sec = o2::constants::math::NSectors; sec--;) {         // start of sector's tracks for this ROF
@@ -580,7 +579,7 @@ bool MatchTPCITS::prepareITSData()
     for (int it = rofRec.getFirstEntry(); it < trlim; it++) {
       const auto& trcOrig = mITSTracksArray[it];
       if (mParams->runAfterBurner) {
-        flagUsedITSClusters(trcOrig, cluROFOffset);
+        flagUsedITSClusters(trcOrig);
       }
       if (trcOrig.getParamOut().getX() < 1.) {
         continue; // backward refit failed
@@ -1233,9 +1232,6 @@ bool MatchTPCITS::refitTrackTPCITS(int iTPC, int& iITS)
   float chi2 = 0.f;
   auto geom = o2::its::GeometryTGeo::Instance();
   auto propagator = o2::base::Propagator::Instance();
-  // NOTE: the ITS cluster index is stored wrt 1st cluster of relevant ROF, while here we extract clusters from the
-  // buffer for the whole TF. Therefore, we should shift the index by the entry of the ROF's 1st cluster in the global cluster buffer
-  int clusIndOffs = mITSClusterROFRec[tITS.roFrame].getFirstEntry();
   int clEntry = itsTrOrig.getFirstClusterEntry();
 
   float addErr2 = 0;
@@ -1247,7 +1243,7 @@ bool MatchTPCITS::refitTrackTPCITS(int iTPC, int& iITS)
   }
 
   for (int icl = 0; icl < ncl; icl++) {
-    const auto& clus = mITSClustersArray[clusIndOffs + mITSTrackClusIdx[clEntry++]];
+    const auto& clus = mITSClustersArray[mITSTrackClusIdx[clEntry++]];
     float alpha = geom->getSensorRefAlpha(clus.getSensorID()), x = clus.getX();
     if (!trfit.rotate(alpha) ||
         // note: here we also calculate the L,T integral (in the inward direction, but this is irrelevant)
@@ -2205,12 +2201,12 @@ void MatchTPCITS::removeITSfromTPC(int itsID, int tpcID)
 }
 
 //______________________________________________
-void MatchTPCITS::flagUsedITSClusters(const o2::its::TrackITS& track, int rofOffset)
+void MatchTPCITS::flagUsedITSClusters(const o2::its::TrackITS& track)
 {
   // flag clusters used by this track
   int clEntry = track.getFirstClusterEntry();
   for (int icl = track.getNumberOfClusters(); icl--;) {
-    mABClusterLinkIndex[rofOffset + mITSTrackClusIdx[clEntry++]] = MinusTen;
+    mABClusterLinkIndex[mITSTrackClusIdx[clEntry++]] = MinusTen;
   }
 }
 

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTracker.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTracker.h
@@ -89,7 +89,7 @@ class CookedTracker
       for (int i = 0; i < noc; i++) {
         const Cluster* c = this->getCluster(t.getClusterIndex(i));
         Int_t idx = c - &mClusterCache[0]; // Index of this cluster in event
-        clusIdx.emplace_back(idx);
+        clusIdx.emplace_back(this->mFirstInFrame + idx);
       }
       trackNew.setClusterRefs(clEntry, noc);
       trackNew.setPattern(0x7f); // this tracker finds only complete tracks

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -194,7 +194,7 @@ void TrackerDPL::run(ProcessingContext& pc)
   FastMultEst multEst;                                     // mult estimator
 
   // snippet to convert found tracks to final output tracks with separate cluster indices
-  auto copyTracks = [](auto& tracks, auto& allTracks, auto& allClusIdx, int offset = 0) {
+  auto copyTracks = [](auto& tracks, auto& allTracks, auto& allClusIdx) {
     for (auto& trc : tracks) {
       trc.setFirstClusterEntry(allClusIdx.size()); // before adding tracks, create final cluster indices
       int ncl = trc.getNumberOfClusters(), nclf = 0;
@@ -202,7 +202,7 @@ void TrackerDPL::run(ProcessingContext& pc)
       for (int ic = TrackITSExt::MaxClusters; ic--;) { // track internally keeps in->out cluster indices, but we want to store the references as out->in!!!
         auto clid = trc.getClusterIndex(ic);
         if (clid >= 0) {
-          allClusIdx.push_back(clid + offset);
+          allClusIdx.push_back(clid);
           nclf++;
           patt |= 0x1 << ic;
         }
@@ -273,10 +273,9 @@ void TrackerDPL::run(ProcessingContext& pc)
       LOG(INFO) << "Found tracks: " << tracks.size();
       int number = tracks.size();
       trackLabels.swap(mTracker->getTrackLabels()); /// FIXME: assignment ctor is not optimal.
-      int shiftIdx = -rof.getFirstEntry();          // cluster entry!!!
       rof.setFirstEntry(first);
       rof.setNEntries(number);
-      copyTracks(tracks, allTracks, allClusIdx, shiftIdx);
+      copyTracks(tracks, allTracks, allClusIdx);
       std::copy(trackLabels.begin(), trackLabels.end(), std::back_inserter(allTrackLabels));
       trackLabels.clear();
       vtxROF.setNEntries(vtxVecLoc.size());


### PR DESCRIPTION
Storing indices of ITS cluster indices attached to tracks wrt ROF start creates
extra overheads when we need to fetch/refit clusters of particular track.
All workflows are changed to store cluster indices wrt TF start.