### PR TITLE
[O2-2500] revert bug in TRD digitwriter

### DIFF
--- a/Detectors/TRD/workflow/io/src/TRDDigitWriterSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDDigitWriterSpec.cxx
@@ -75,9 +75,8 @@ o2::framework::DataProcessorSpec getTRDDigitWriterSpec(bool mctruth, bool writeT
                                 // setting a custom callback for closing the writer
                                 MakeRootTreeWriterSpec::CustomClose(finishWriting),
                                 BranchDefinition<std::vector<o2::trd::Digit>>{InputSpec{"input", "TRD", "DIGITS"}, "TRDDigit"},
-                                BranchDefinition<std::vector<o2::trd::TriggerRecord>>{InputSpec{"tracklettrigs", "TRD", "TRKTRGRD"}, "TrackTrg"})();
-  //                                BranchDefinition<std::vector<o2::trd::TriggerRecord>>{InputSpec{"trinput", "TRD", "TRGRDIG"}, "TriggerRecord", (writeTrigRec ? 1 : 0)},
-  //  std::move(labelsdef))();
+                                BranchDefinition<std::vector<o2::trd::TriggerRecord>>{InputSpec{"trinput", "TRD", "TRGRDIG"}, "TriggerRecord", (writeTrigRec ? 1 : 0)},
+                                std::move(labelsdef))();
 }
 
 } // end namespace trd


### PR DESCRIPTION
Raw data produced digits do not have triggers in the digits file, hack was mistakenly not removed in previous pr. O2-2500