### PR TITLE
Account for change in ITS cluster refs (PR6835)

### DIFF
--- a/GPU/GPUTracking/display/GPUDisplay.cxx
+++ b/GPU/GPUTracking/display/GPUDisplay.cxx
@@ -975,16 +975,8 @@ GPUDisplay::vboList GPUDisplay::DrawTracks(const GPUTPCTracker& tracker, int glo
 void GPUDisplay::DrawTrackITS(int trackId, int iSlice)
 {
   const auto& trk = mIOPtrs->itsTracks[trackId];
-  unsigned int rof;
-  for (rof = 1; rof < mIOPtrs->nItsTrackROF; rof++) {
-    if (mIOPtrs->itsTrackROF[rof].getFirstEntry() > trackId) {
-      break;
-    }
-  }
-  rof--;
-  int clusIndOffs = mIOPtrs->itsClusterROF[rof].getFirstEntry();
   for (int k = 0; k < trk.getNClusters(); k++) {
-    int cid = clusIndOffs + mIOPtrs->itsTrackClusIdx[trk.getFirstClusterEntry() + k];
+    int cid = mIOPtrs->itsTrackClusIdx[trk.getFirstClusterEntry() + k];
     mVertexBuffer[iSlice].emplace_back(mGlobalPosITS[cid].x, mGlobalPosITS[cid].y, mCfgH.projectXY ? 0 : mGlobalPosITS[cid].z);
     mGlobalPosITS[cid].w = tITSATTACHED;
   }


### PR DESCRIPTION
@davidrohr this is incremental to https://github.com/AliceO2Group/AliceO2/pull/6835: now the ITS track cluster indices are counted wrt TF start rather than ROF start, no need to search for the ROF (but the ITS tracking of existing data has to be redone).