### PR TITLE
Add halfBarrels to ITS misaligner, use local CCDB as default

### DIFF
--- a/Detectors/ITSMFT/ITS/macros/test/ITSMisaligner.C
+++ b/Detectors/ITSMFT/ITS/macros/test/ITSMisaligner.C
@@ -16,9 +16,10 @@ using AlgPar = std::array<double, 6>;
 
 AlgPar generateMisalignment(double x, double y, double z, double psi, double theta, double phi);
 
-void ITSMisaligner(const std::string& ccdbHost = "http://ccdb-test.cern.ch:8080", long tmin = 0, long tmax = -1,
+void ITSMisaligner(const std::string& ccdbHost = "http://localhost:8080", long tmin = 0, long tmax = -1,
                    double xEnv = 0., double yEnv = 0., double zEnv = 0., double psiEnv = 0., double thetaEnv = 0., double phiEnv = 0.,
                    double xLay = 0., double yLay = 0., double zLay = 0., double psiLay = 0., double thetaLay = 0., double phiLay = 0.,
+                   double xHBa = 0., double yHBa = 0., double zHBa = 0., double psiHBa = 0., double thetaHBa = 0., double phiHBa = 0.,
                    double xSta = 0., double ySta = 0., double zSta = 0., double psiSta = 0., double thetaSta = 0., double phiSta = 0.,
                    double xHSt = 0., double yHSt = 0., double zHSt = 0., double psiHSt = 0., double thetaHSt = 0., double phiHSt = 0.,
                    double xMod = 0., double yMod = 0., double zMod = 0., double psiMod = 0., double thetaMod = 0., double phiMod = 0.,
@@ -47,7 +48,7 @@ void ITSMisaligner(const std::string& ccdbHost = "http://ccdb-test.cern.ch:8080"
 
     for (int ihb = 0; ihb < geom->getNumberOfHalfBarrels(); ihb++) {
       symname = geom->composeSymNameHalfBarrel(ilr, ihb);
-      pars = generateMisalignment(xSta, ySta, zSta, psiSta, thetaSta, phiSta);
+      pars = generateMisalignment(xHBa, yHBa, zHBa, psiHBa, thetaHBa, phiHBa);
       params.emplace_back(symname.c_str(), -1, pars[0], pars[1], pars[2], pars[3], pars[4], pars[5], glo);
 
       for (int ist = 0; ist < geom->getNumberOfStaves(ilr) / 2; ist++) {


### PR DESCRIPTION
trivial fix in macro only, merging.