### PR TITLE
DPL Analysis: Combinations buffer overflow

### DIFF
--- a/Framework/Core/include/Framework/ASoAHelpers.h
+++ b/Framework/Core/include/Framework/ASoAHelpers.h
@@ -20,6 +20,7 @@
 #include <iterator>
 #include <tuple>
 #include <utility>
+#include <iostream>
 
 namespace o2::soa
 {
@@ -56,6 +57,7 @@ struct NTupleType<T, 0, REST...> {
 // Group table (C++ vector of indices)
 bool sameCategory(std::pair<uint64_t, uint64_t> const& a, std::pair<uint64_t, uint64_t> const& b)
 {
+  std::cout << "Checking same category, a.first: " << a.first << " b.first: " << b.first << std::endl;
   return a.first < b.first;
 }
 bool diffCategory(std::pair<uint64_t, uint64_t> const& a, std::pair<uint64_t, uint64_t> const& b)
@@ -441,16 +443,22 @@ struct CombinationsBlockFullIndexPolicy : public CombinationsBlockIndexPolicyBas
   {
     constexpr auto k = sizeof...(Ts);
     for_<k>([&, this](auto i) {
+      std::cout << "Range at " << i.value << " current index: " << std::get<i.value>(this->mCurrentIndices) << std::endl;
+      std::cout << "Size of grouped indices: " << this->mGroupedIndices[i.value].size() << " begin position: " << (*(this->mGroupedIndices[i.value].begin())).second << std::endl; 
       auto catBegin = this->mGroupedIndices[i.value].begin() + std::get<i.value>(this->mCurrentIndices);
+      std::cout << "at " << i.value << " cat begin: " << (*catBegin).first << ", " << (*catBegin).second << std::endl;
       auto range = std::equal_range(catBegin, this->mGroupedIndices[i.value].end(), *catBegin, sameCategory);
+      //std::cout << "at " << i.value << " cat begin: " << (*catBegin).first << ", " << (*catBegin).second << " range: (" << (*(range.first)).first << ", " << (*(range.first)).second << "), (" << (*(range.second)).first << ", " << (*(range.second)).second << "), groupedIndices vector size: " << this->mGroupedIndices[i.value].size() << std::endl;
       std::get<i.value>(this->mBeginIndices) = std::distance(this->mGroupedIndices[i.value].begin(), range.first);
       std::get<i.value>(this->mMaxOffset) = std::distance(this->mGroupedIndices[i.value].begin(), range.second);
+      std::cout << "maxOffset set: " << std::get<i.value>(this->mMaxOffset) << " begin index: " << std::get<i.value>(this->mBeginIndices) << std::endl;
       std::get<i.value>(this->mCurrent).setCursor(range.first->second);
     });
   }
 
   void addOne()
   {
+    std::cout << "Adding one" << std::endl;
     constexpr auto k = sizeof...(Ts);
     bool modify = true;
     bool nextCatAvailable = true;
@@ -459,23 +467,36 @@ struct CombinationsBlockFullIndexPolicy : public CombinationsBlockIndexPolicyBas
         constexpr auto curInd = k - i.value - 1;
         std::get<curInd>(this->mCurrentIndices)++;
         uint64_t curGroupedInd = std::get<curInd>(this->mCurrentIndices);
-        std::get<curInd>(this->mCurrent).setCursor(this->mGroupedIndices[curInd][curGroupedInd].second);
+        std::cout << "i: " << i.value << " current index: " << curInd << " curGroupedInd: " << curGroupedInd << std::endl;
+        std::cout << "GroupedIndices array size: " << this->mGroupedIndices.size() << " size of vector at curInd: " << this->mGroupedIndices[curInd].size() << std::endl;
+        if (curGroupedInd < this->mGroupedIndices[curInd].size()) {
+          std::cout << "Setting position to : " << this->mGroupedIndices[curInd][curGroupedInd].second << std::endl;
+          std::get<curInd>(this->mCurrent).setCursor(this->mGroupedIndices[curInd][curGroupedInd].second);
+        }
         uint64_t windowOffset = curInd == this->mCurrentlyFixed ? 1 : this->mSlidingWindowSize;
         uint64_t maxForWindow = std::get<curInd>(this->mBeginIndices) + windowOffset;
+        std::cout << "Window offset: " << windowOffset << " max for window: " << maxForWindow << std::endl;
+        std::cout << "Currently fixd: " << this->mCurrentlyFixed << std::endl;
 
         // If we remain within the same sliding window and fixed index
         if (curGroupedInd < maxForWindow && curGroupedInd < std::get<curInd>(this->mMaxOffset)) {
+          std::cout << "Same sliding window, less than max offset" << std::endl;
           for_<i.value>([&, this](auto j) {
             constexpr auto curJ = k - i.value + j.value;
+            std::cout << "curJ: " << curJ << " current position: " << std::get<curJ>(this->mCurrentIndices) << std::endl;
             if (curJ < this->mCurrentlyFixed) { // To assure no repetitions
               std::get<curJ>(this->mCurrentIndices) = std::get<curJ>(this->mBeginIndices) + 1;
+              std::cout << "set indices to begin + 1: " << std::get<curJ>(this->mCurrentIndices) << std::endl;
             } else {
               std::get<curJ>(this->mCurrentIndices) = std::get<curJ>(this->mBeginIndices);
+              std::cout << "set indices to begin: " << std::get<curJ>(this->mCurrentIndices) << std::endl;
             }
             uint64_t curGroupedJ = std::get<curJ>(this->mCurrentIndices);
             std::get<curJ>(this->mCurrent).setCursor(this->mGroupedIndices[curJ][curGroupedJ].second);
+            std::cout << "J groupedInd: " << curGroupedJ << " setting position to: " << this->mGroupedIndices[curJ][curGroupedJ].second << std::endl;
           });
           modify = false;
+          std::cout << "Modify set to false" << std::endl;
         }
       }
     });
@@ -484,26 +505,35 @@ struct CombinationsBlockFullIndexPolicy : public CombinationsBlockIndexPolicyBas
     if (modify) {
       // If we haven't finished with window starting element
       if (this->mCurrentlyFixed < k - 1 && std::get<0>(this->mBeginIndices) < std::get<0>(this->mMaxOffset) - 1) {
+        std::cout << "Not done with the starting element of the window" << std::endl;
         this->mCurrentlyFixed++;
+        std::cout << "new currently fixed: " << this->mCurrentlyFixed << std::endl;
         for_<k>([&, this](auto s) {
+          std::cout << "Current index: " << s.value << " position: " << std::get<s.value>(this->mCurrentIndices) << std::endl;
           if (s.value < this->mCurrentlyFixed) { // To assure no repetitions
             std::get<s.value>(this->mCurrentIndices) = std::get<s.value>(this->mBeginIndices) + 1;
+            std::cout << "set indices to begin + 1: " << std::get<s.value>(this->mCurrentIndices) << std::endl;
           } else {
             std::get<s.value>(this->mCurrentIndices) = std::get<s.value>(this->mBeginIndices);
+            std::cout << "set indices to begin: " << std::get<s.value>(this->mCurrentIndices) << std::endl;
           }
           uint64_t curGroupedI = std::get<s.value>(this->mCurrentIndices);
           std::get<s.value>(this->mCurrent).setCursor(this->mGroupedIndices[s.value][curGroupedI].second);
+          std::cout << "s groupedInd: " << curGroupedI << " setting position to: " << this->mGroupedIndices[s.value][curGroupedI].second << std::endl;
         });
         modify = false;
       } else {
+        std::cout << "Starting element done, setting currently fixed back to 0" << std::endl;
         this->mCurrentlyFixed = 0;
         std::get<0>(this->mBeginIndices)++;
         std::get<0>(this->mCurrentIndices) = std::get<0>(this->mBeginIndices);
-        uint64_t curGroupedInd = std::get<0>(this->mCurrentIndices);
-        std::get<0>(this->mCurrent).setCursor(this->mGroupedIndices[0][curGroupedInd].second);
 
         // If we remain within the same category - slide window
         if (std::get<0>(this->mBeginIndices) < std::get<0>(this->mMaxOffset)) {
+          std::cout << "Same category, sliding the window by 1" << std::endl;
+          uint64_t curGroupedInd = std::get<0>(this->mCurrentIndices);
+          std::get<0>(this->mCurrent).setCursor(this->mGroupedIndices[0][curGroupedInd].second);
+          std::cout << "New index at 0: " << std::get<0>(this->mCurrentIndices) << " position: " << this->mGroupedIndices[0][curGroupedInd].second << std::endl;
           modify = false;
           for_<k - 1>([&, this](auto j) {
             constexpr auto curJ = j.value + 1;
@@ -512,7 +542,9 @@ struct CombinationsBlockFullIndexPolicy : public CombinationsBlockIndexPolicyBas
               std::get<curJ>(this->mCurrentIndices) = std::get<curJ>(this->mBeginIndices);
               uint64_t curGroupedJ = std::get<curJ>(this->mCurrentIndices);
               std::get<curJ>(this->mCurrent).setCursor(this->mGroupedIndices[curJ][curGroupedJ].second);
+              std::cout << "New index at " << curJ << ": " << std::get<curJ>(this->mCurrentIndices) << " position: " << this->mGroupedIndices[curJ][curGroupedJ].second << std::endl;
             } else {
+              std::cout << "End of the category after sliding, need to change" << std::endl;
               modify = true;
             }
           });
@@ -522,18 +554,24 @@ struct CombinationsBlockFullIndexPolicy : public CombinationsBlockIndexPolicyBas
 
     // No more combinations within this category - move to the next category, if possible
     if (modify) {
+      std::cout << "Moving to the next category" << std::endl;
       for_<k>([&, this](auto m) {
+        std::cout << "At " << m.value << " setting current indices to max offset: " << std::get<m.value>(this->mMaxOffset) << std::endl;
         std::get<m.value>(this->mCurrentIndices) = std::get<m.value>(this->mMaxOffset);
         if (std::get<m.value>(this->mCurrentIndices) == this->mGroupedIndices[m.value].size()) {
+          std::cout << "At " << m.value << " no more categories, size of grouped: " << this->mGroupedIndices[m.value].size() << std::endl;
           nextCatAvailable = false;
         }
       });
       if (nextCatAvailable) {
+        std::cout << "Moved to the next category, setting ranges" << std::endl;
         setRanges();
       }
     }
 
     this->mIsEnd = modify && !nextCatAvailable;
+
+    std::cout << "=======================================================================================================" << std::endl;
   }
 
   uint64_t mCurrentlyFixed;
@@ -910,7 +948,10 @@ struct CombinationsGenerator {
   CombinationsGenerator() = delete;
   CombinationsGenerator(const P& policy) : mBegin(policy), mEnd(policy)
   {
+    std::cout << "Created iterators in the generator" << std::endl;
     mEnd.moveToEnd();
+    std::cout << "End iterator moved to the end" << std::endl;
+    std::cout << "###############################################################################################################################" << std::endl;
   }
   ~CombinationsGenerator() = default;
 

--- a/Framework/Core/include/Framework/ASoAHelpers.h
+++ b/Framework/Core/include/Framework/ASoAHelpers.h
@@ -364,13 +364,11 @@ struct CombinationsBlockUpperIndexPolicy : public CombinationsBlockIndexPolicyBa
         constexpr auto curInd = k - i.value - 1;
         std::get<curInd>(this->mCurrentIndices)++;
         uint64_t curGroupedInd = std::get<curInd>(this->mCurrentIndices);
-        if (curGroupedInd < this->mGroupedIndices[curInd].size()) {
-          std::get<curInd>(this->mCurrent).setCursor(this->mGroupedIndices[curInd][curGroupedInd].second);
-        }
         uint64_t maxForWindow = std::get<curInd>(this->mBeginIndices) + this->mSlidingWindowSize;
 
         // If we remain within the same sliding window
         if (curGroupedInd < maxForWindow && curGroupedInd < std::get<curInd>(this->mMaxOffset)) {
+          std::get<curInd>(this->mCurrent).setCursor(this->mGroupedIndices[curInd][curGroupedInd].second);
           modify = false;
           for_<i.value>([&, this](auto j) {
             constexpr auto curJ = k - i.value + j.value;
@@ -461,14 +459,12 @@ struct CombinationsBlockFullIndexPolicy : public CombinationsBlockIndexPolicyBas
         constexpr auto curInd = k - i.value - 1;
         std::get<curInd>(this->mCurrentIndices)++;
         uint64_t curGroupedInd = std::get<curInd>(this->mCurrentIndices);
-        if (curGroupedInd < this->mGroupedIndices[curInd].size()) {
-          std::get<curInd>(this->mCurrent).setCursor(this->mGroupedIndices[curInd][curGroupedInd].second);
-        }
         uint64_t windowOffset = curInd == this->mCurrentlyFixed ? 1 : this->mSlidingWindowSize;
         uint64_t maxForWindow = std::get<curInd>(this->mBeginIndices) + windowOffset;
 
         // If we remain within the same sliding window and fixed index
         if (curGroupedInd < maxForWindow && curGroupedInd < std::get<curInd>(this->mMaxOffset)) {
+          std::get<curInd>(this->mCurrent).setCursor(this->mGroupedIndices[curInd][curGroupedInd].second);
           for_<i.value>([&, this](auto j) {
             constexpr auto curJ = k - i.value + j.value;
             if (curJ < this->mCurrentlyFixed) { // To assure no repetitions
@@ -606,13 +602,11 @@ struct CombinationsBlockUpperSameIndexPolicy : public CombinationsBlockSameIndex
         constexpr auto curInd = k - i.value - 1;
         std::get<curInd>(this->mCurrentIndices)++;
         uint64_t curGroupedInd = std::get<curInd>(this->mCurrentIndices);
-        if (curGroupedInd < this->mGroupedIndices.size()) {
-          std::get<curInd>(this->mCurrent).setCursor(this->mGroupedIndices[curGroupedInd].second);
-        }
         uint64_t maxForWindow = std::get<0>(this->mCurrentIndices) + this->mSlidingWindowSize;
 
         // If we remain within the same sliding window
         if (curGroupedInd < maxForWindow && curGroupedInd < std::get<curInd>(this->mMaxOffset)) {
+          std::get<curInd>(this->mCurrent).setCursor(this->mGroupedIndices[curGroupedInd].second);
           for_<i.value>([&, this](auto j) {
             constexpr auto curJ = k - i.value + j.value;
             std::get<curJ>(this->mCurrentIndices) = std::get<curJ - 1>(this->mCurrentIndices);
@@ -686,13 +680,11 @@ struct CombinationsBlockStrictlyUpperSameIndexPolicy : public CombinationsBlockS
         constexpr auto curInd = k - i.value - 1;
         std::get<curInd>(this->mCurrentIndices)++;
         uint64_t curGroupedInd = std::get<curInd>(this->mCurrentIndices);
-        if (curGroupedInd < this->mGroupedIndices.size()) {
-          std::get<curInd>(this->mCurrent).setCursor(this->mGroupedIndices[curGroupedInd].second);
-        }
         uint64_t maxForWindow = std::get<0>(this->mCurrentIndices) + this->mSlidingWindowSize - i.value;
 
         // If we remain within the same sliding window
         if (curGroupedInd < maxForWindow && curGroupedInd < std::get<curInd>(this->mMaxOffset)) {
+          std::get<curInd>(this->mCurrent).setCursor(this->mGroupedIndices[curGroupedInd].second);
           for_<i.value>([&, this](auto j) {
             constexpr auto curJ = k - i.value + j.value;
             std::get<curJ>(this->mCurrentIndices) = std::get<curJ - 1>(this->mCurrentIndices) + 1;
@@ -770,14 +762,12 @@ struct CombinationsBlockFullSameIndexPolicy : public CombinationsBlockSameIndexP
         constexpr auto curInd = k - i.value - 1;
         std::get<curInd>(this->mCurrentIndices)++;
         uint64_t curGroupedInd = std::get<curInd>(this->mCurrentIndices);
-        if (curGroupedInd < this->mGroupedIndices.size()) {
-          std::get<curInd>(this->mCurrent).setCursor(this->mGroupedIndices[curGroupedInd].second);
-        }
         uint64_t windowOffset = curInd == this->mCurrentlyFixed ? 1 : this->mSlidingWindowSize;
         uint64_t maxForWindow = this->mBeginIndex + windowOffset;
 
         // If we remain within the same sliding window and fixed index
         if (curGroupedInd < maxForWindow && curGroupedInd < std::get<curInd>(this->mMaxOffset)) {
+          std::get<curInd>(this->mCurrent).setCursor(this->mGroupedIndices[curGroupedInd].second);
           for_<i.value>([&, this](auto j) {
             constexpr auto curJ = k - i.value + j.value;
             if (curJ < this->mCurrentlyFixed) { // To assure no repetitions

--- a/Framework/Core/include/Framework/ASoAHelpers.h
+++ b/Framework/Core/include/Framework/ASoAHelpers.h
@@ -364,7 +364,9 @@ struct CombinationsBlockUpperIndexPolicy : public CombinationsBlockIndexPolicyBa
         constexpr auto curInd = k - i.value - 1;
         std::get<curInd>(this->mCurrentIndices)++;
         uint64_t curGroupedInd = std::get<curInd>(this->mCurrentIndices);
-        std::get<curInd>(this->mCurrent).setCursor(this->mGroupedIndices[curInd][curGroupedInd].second);
+        if (curGroupedInd < this->mGroupedIndices[curInd].size()) {
+          std::get<curInd>(this->mCurrent).setCursor(this->mGroupedIndices[curInd][curGroupedInd].second);
+        }
         uint64_t maxForWindow = std::get<curInd>(this->mBeginIndices) + this->mSlidingWindowSize;
 
         // If we remain within the same sliding window
@@ -389,10 +391,10 @@ struct CombinationsBlockUpperIndexPolicy : public CombinationsBlockIndexPolicyBa
       std::get<0>(this->mCurrentIndices)++;
       std::get<0>(this->mBeginIndices)++;
       uint64_t curGroupedInd = std::get<0>(this->mCurrentIndices);
-      std::get<0>(this->mCurrent).setCursor(this->mGroupedIndices[0][curGroupedInd].second);
 
       // If we remain within the same category - slide window
       if (curGroupedInd < std::get<0>(this->mMaxOffset)) {
+        std::get<0>(this->mCurrent).setCursor(this->mGroupedIndices[0][curGroupedInd].second);
         modify = false;
         for_<k - 1>([&, this](auto j) {
           constexpr auto curJ = j.value + 1;
@@ -604,7 +606,9 @@ struct CombinationsBlockUpperSameIndexPolicy : public CombinationsBlockSameIndex
         constexpr auto curInd = k - i.value - 1;
         std::get<curInd>(this->mCurrentIndices)++;
         uint64_t curGroupedInd = std::get<curInd>(this->mCurrentIndices);
-        std::get<curInd>(this->mCurrent).setCursor(this->mGroupedIndices[curGroupedInd].second);
+        if (curGroupedInd < this->mGroupedIndices.size()) {
+          std::get<curInd>(this->mCurrent).setCursor(this->mGroupedIndices[curGroupedInd].second);
+        }
         uint64_t maxForWindow = std::get<0>(this->mCurrentIndices) + this->mSlidingWindowSize;
 
         // If we remain within the same sliding window
@@ -624,10 +628,10 @@ struct CombinationsBlockUpperSameIndexPolicy : public CombinationsBlockSameIndex
     if (modify) {
       std::get<0>(this->mCurrentIndices)++;
       uint64_t curGroupedInd = std::get<0>(this->mCurrentIndices);
-      std::get<0>(this->mCurrent).setCursor(this->mGroupedIndices[curGroupedInd].second);
 
       // If we remain within the same category - slide window
       if (curGroupedInd < std::get<0>(this->mMaxOffset)) {
+        std::get<0>(this->mCurrent).setCursor(this->mGroupedIndices[curGroupedInd].second);
         for_<k - 1>([&, this](auto j) {
           constexpr auto curJ = j.value + 1;
           std::get<curJ>(this->mCurrentIndices) = std::get<curJ - 1>(this->mCurrentIndices);
@@ -682,7 +686,9 @@ struct CombinationsBlockStrictlyUpperSameIndexPolicy : public CombinationsBlockS
         constexpr auto curInd = k - i.value - 1;
         std::get<curInd>(this->mCurrentIndices)++;
         uint64_t curGroupedInd = std::get<curInd>(this->mCurrentIndices);
-        std::get<curInd>(this->mCurrent).setCursor(this->mGroupedIndices[curGroupedInd].second);
+        if (curGroupedInd < this->mGroupedIndices.size()) {
+          std::get<curInd>(this->mCurrent).setCursor(this->mGroupedIndices[curGroupedInd].second);
+        }
         uint64_t maxForWindow = std::get<0>(this->mCurrentIndices) + this->mSlidingWindowSize - i.value;
 
         // If we remain within the same sliding window
@@ -702,10 +708,10 @@ struct CombinationsBlockStrictlyUpperSameIndexPolicy : public CombinationsBlockS
     if (modify) {
       std::get<0>(this->mCurrentIndices)++;
       uint64_t curGroupedInd = std::get<0>(this->mCurrentIndices);
-      std::get<0>(this->mCurrent).setCursor(this->mGroupedIndices[curGroupedInd].second);
 
       // If we remain within the same category - slide window
       if (curGroupedInd < std::get<0>(this->mMaxOffset)) {
+        std::get<0>(this->mCurrent).setCursor(this->mGroupedIndices[curGroupedInd].second);
         for_<k - 1>([&, this](auto j) {
           constexpr auto curJ = j.value + 1;
           std::get<curJ>(this->mCurrentIndices) = std::get<curJ - 1>(this->mCurrentIndices) + 1;
@@ -764,7 +770,9 @@ struct CombinationsBlockFullSameIndexPolicy : public CombinationsBlockSameIndexP
         constexpr auto curInd = k - i.value - 1;
         std::get<curInd>(this->mCurrentIndices)++;
         uint64_t curGroupedInd = std::get<curInd>(this->mCurrentIndices);
-        std::get<curInd>(this->mCurrent).setCursor(this->mGroupedIndices[curGroupedInd].second);
+        if (curGroupedInd < this->mGroupedIndices.size()) {
+          std::get<curInd>(this->mCurrent).setCursor(this->mGroupedIndices[curGroupedInd].second);
+        }
         uint64_t windowOffset = curInd == this->mCurrentlyFixed ? 1 : this->mSlidingWindowSize;
         uint64_t maxForWindow = this->mBeginIndex + windowOffset;
 
@@ -804,11 +812,11 @@ struct CombinationsBlockFullSameIndexPolicy : public CombinationsBlockSameIndexP
         this->mCurrentlyFixed = 0;
         this->mBeginIndex++;
         std::get<0>(this->mCurrentIndices) = this->mBeginIndex;
-        uint64_t curGroupedInd = std::get<0>(this->mCurrentIndices);
-        std::get<0>(this->mCurrent).setCursor(this->mGroupedIndices[curGroupedInd].second);
 
         // If we remain within the same category - slide window
         if (this->mBeginIndex < std::get<0>(this->mMaxOffset)) {
+          uint64_t curGroupedInd = std::get<0>(this->mCurrentIndices);
+          std::get<0>(this->mCurrent).setCursor(this->mGroupedIndices[curGroupedInd].second);
           for_<k - 1>([&, this](auto j) {
             constexpr auto curJ = j.value + 1;
             std::get<curJ>(this->mCurrentIndices) = this->mBeginIndex;


### PR DESCRIPTION
Ciao @ktf,
I could not refactor the combinations the way I planned, so here is coming directly the fix for heap buffer overflow from https://alice.its.cern.ch/jira/browse/O2-2483.
It outputs some memory leaks from the TableBuilder instead, but I can see similar leaks are also in o2-test-framework-ASoA.