### PR TITLE
Extend o2-sim --field +-5U option to arbitrary <int_kGaus>U

### DIFF
--- a/Common/Field/include/Field/MagneticField.h
+++ b/Common/Field/include/Field/MagneticField.h
@@ -78,6 +78,11 @@ class MagneticField : public FairField
   /// allow fast field param
   void AllowFastField(bool v = true);
 
+  bool fastFieldExists() const
+  {
+    return !(mMapType == MagFieldParam::k5kGUniform || mDipoleOnOffFlag == true);
+  }
+
   /// Virtual methods from FairField
 
   /// X component, avoid using since slow
@@ -106,6 +111,35 @@ class MagneticField : public FairField
   /// Method to calculate the field at point xyz
   /// Main interface from TVirtualMagField used in simulation
   void Field(const Double_t* __restrict__ point, Double_t* __restrict__ bField) override;
+
+  void field(const math_utils::Point3D<float> xyz, float bxyz[3])
+  {
+    double xyzd[3] = {xyz.X(), xyz.Y(), xyz.Z()}, bxyzd[3] = {0};
+    Field(xyzd, bxyzd);
+    bxyz[0] = bxyzd[0];
+    bxyz[1] = bxyzd[1];
+    bxyz[2] = bxyzd[2];
+  }
+
+  void field(const math_utils::Point3D<double> xyz, double bxyz[3])
+  {
+    double xyzd[3] = {xyz.X(), xyz.Y(), xyz.Z()};
+    Field(xyzd, bxyz);
+  }
+
+  void field(const double* __restrict__ point, double* __restrict__ bField)
+  {
+    Field(point, bField);
+  }
+
+  void field(const float* __restrict__ point, float* __restrict__ bField)
+  {
+    double xyz[3] = {point[0], point[1], point[2]}, bxyz[3] = {0};
+    Field(xyz, bxyz);
+    bField[0] = bxyz[0];
+    bField[1] = bxyz[1];
+    bField[2] = bxyz[2];
+  }
 
   /// 3d field query alias for Alias Method to calculate the field at point xyz
   void GetBxyz(const Double_t p[3], Double_t* b) override { MagneticField::Field(p, b); }

--- a/Common/Field/src/MagneticField.cxx
+++ b/Common/Field/src/MagneticField.cxx
@@ -151,25 +151,31 @@ MagneticField::MagneticField(const MagFieldParam& param)
 
 MagneticField* MagneticField::createNominalField(int fld, bool uniform)
 {
-  float fldCoeff;
+  float fldCoeffL3, fldCoeffDip;
   o2::field::MagFieldParam::BMap_t fldType;
-  switch (std::abs(fld)) {
-    case 5:
-      fldType = uniform ? o2::field::MagFieldParam::k5kGUniform : o2::field::MagFieldParam::k5kG;
-      fldCoeff = fld > 0 ? 1. : -1;
-      break;
-    case 0:
-      fldType = o2::field::MagFieldParam::k5kG;
-      fldCoeff = 0;
-      break;
-    case 2:
-      fldType = o2::field::MagFieldParam::k2kG;
-      fldCoeff = fld > 0 ? 1. : -1;
-      break;
-    default:
-      LOG(FATAL) << "Field option " << fld << " is not supported, use +-2, +-5 or 0";
-  };
-  return new o2::field::MagneticField("Maps", "Maps", fldCoeff, fldCoeff, fldType);
+  if (uniform) {
+    fldCoeffL3 = float(fld) / 5.;
+    fldCoeffDip = fld > 0 ? 1. : -1;
+    fldType = o2::field::MagFieldParam::k5kGUniform;
+  } else {
+    switch (std::abs(fld)) {
+      case 5:
+        fldType = o2::field::MagFieldParam::k5kG;
+        fldCoeffL3 = fldCoeffDip = fld > 0 ? 1. : -1;
+        break;
+      case 0:
+        fldType = o2::field::MagFieldParam::k5kG;
+        fldCoeffL3 = fldCoeffDip = 0;
+        break;
+      case 2:
+        fldType = o2::field::MagFieldParam::k2kG;
+        fldCoeffL3 = fldCoeffDip = fld > 0 ? 1. : -1;
+        break;
+      default:
+        LOG(FATAL) << "Field option " << fld << " is not supported, use +-2, +-5 or 0 or <int_kilogauss>U";
+    };
+  }
+  return new o2::field::MagneticField("Maps", "Maps", fldCoeffL3, fldCoeffDip, fldType);
 }
 
 void MagneticField::CreateField()

--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -45,7 +45,7 @@ void SimConfig::initOptions(boost::program_options::options_description& options
     "chunkSize", bpo::value<unsigned int>()->default_value(500), "max size of primary chunk (subevent) distributed by server")(
     "chunkSizeI", bpo::value<int>()->default_value(-1), "internalChunkSize")(
     "seed", bpo::value<int>()->default_value(-1), "initial seed (default: -1 random)")(
-    "field", bpo::value<std::string>()->default_value("-5"), "L3 field rounded to kGauss, allowed values +-2,+-5 and 0; +-5U for uniform field ")(
+    "field", bpo::value<std::string>()->default_value("-5"), "L3 field rounded to kGauss, allowed values +-2,+-5 and 0; +-<intKGaus>U for uniform field ")(
     "nworkers,j", bpo::value<int>()->default_value(nsimworkersdefault), "number of parallel simulation workers (only for parallel mode)")(
     "noemptyevents", "only writes events with at least one hit")(
     "CCDBUrl", bpo::value<std::string>()->default_value("ccdb-test.cern.ch:8080"), "URL for CCDB to be used.")(

--- a/Detectors/Base/include/DetectorsBase/Propagator.h
+++ b/Detectors/Base/include/DetectorsBase/Propagator.h
@@ -43,6 +43,7 @@ class VertexBase;
 namespace field
 {
 class MagFieldFast;
+class MagneticField;
 }
 
 namespace gpu
@@ -155,8 +156,9 @@ class PropagatorImpl
   template <typename T>
   GPUd() void getFieldXYZImpl(const math_utils::Point3D<T> xyz, T* bxyz) const;
 
-  const o2::field::MagFieldFast* mField = nullptr; ///< External fast field (barrel only for the moment)
-  value_type mBz = 0;                              // nominal field
+  const o2::field::MagFieldFast* mFieldFast = nullptr; ///< External fast field map (barrel only for the moment)
+  o2::field::MagneticField* mField = nullptr;          ///< External nominal field map
+  value_type mBz = 0;                                  ///< nominal field
 
   const o2::base::MatLayerCylSet* mMatLUT = nullptr;           // externally set LUT
   const o2::gpu::GPUTPCGMPolynomialField* mGPUField = nullptr; // externally set GPU Field

--- a/Detectors/Base/src/Propagator.cxx
+++ b/Detectors/Base/src/Propagator.cxx
@@ -43,21 +43,22 @@ PropagatorImpl<value_T>::PropagatorImpl(bool uninitialized)
     LOG(FATAL) << "No active geometry!";
   }
 
-  o2::field::MagneticField* slowField = nullptr;
-  slowField = static_cast<o2::field::MagneticField*>(TGeoGlobalMagField::Instance()->GetField());
-  if (!slowField) {
+  mField = static_cast<o2::field::MagneticField*>(TGeoGlobalMagField::Instance()->GetField());
+  if (!mField) {
     LOG(WARNING) << "No Magnetic Field in TGeoGlobalMagField, checking legacy FairRunAna";
-    slowField = dynamic_cast<o2::field::MagneticField*>(FairRunAna::Instance()->GetField());
+    mField = dynamic_cast<o2::field::MagneticField*>(FairRunAna::Instance()->GetField());
   }
-  if (!slowField) {
+  if (!mField) {
     LOG(FATAL) << "Magnetic field is not initialized!";
   }
-  if (!slowField->getFastField()) {
-    slowField->AllowFastField(true);
-  }
-  mField = slowField->getFastField();
   const value_type xyz[3] = {0.};
-  mField->GetBz(xyz, mBz);
+  if (!mField->getFastField() && mField->fastFieldExists()) {
+    mField->AllowFastField(true);
+    mFieldFast = mField->getFastField();
+    mFieldFast->GetBz(xyz, mBz);
+  } else {
+    mBz = mField->GetBz(xyz[0], xyz[1], xyz[2]);
+  }
 }
 
 //____________________________________________________________
@@ -603,7 +604,11 @@ GPUd() void PropagatorImpl<value_T>::getFieldXYZImpl(const math_utils::Point3D<T
 
   } else {
 #ifndef GPUCA_GPUCODE
-    mField->Field(xyz, bxyz); // Must not call the host-only function in GPU compilation
+    if (mFieldFast) {
+      mFieldFast->Field(xyz, bxyz); // Must not call the host-only function in GPU compilation
+    } else {
+      mField->field(xyz, bxyz);
+    }
 #endif
   }
 }


### PR DESCRIPTION
and make sure the fastField param is invoked only when it is
consistent with full field settings.

@ddobrigk : with this you can invoke o2-sim with e.g. `--field 20U` option to obtain uniform 2T field.