### PR TITLE
MFT DCS Processor

### DIFF
--- a/Detectors/ITSMFT/MFT/CMakeLists.txt
+++ b/Detectors/ITSMFT/MFT/CMakeLists.txt
@@ -15,5 +15,6 @@ add_subdirectory(macros)
 add_subdirectory(tracking)
 add_subdirectory(workflow)
 add_subdirectory(calibration)
+add_subdirectory(condition)
 
 o2_data_file(COPY data DESTINATION Detectors/Geometry/MFT/)

--- a/Detectors/ITSMFT/MFT/condition/CMakeLists.txt
+++ b/Detectors/ITSMFT/MFT/condition/CMakeLists.txt
@@ -1,0 +1,33 @@
+# Copyright CERN and copyright holders of ALICE O2. This software is distributed
+# under the terms of the GNU General Public License v3 (GPL Version 3), copied
+# verbatim in the file "COPYING".
+#
+# See http://alice-o2.web.cern.ch/license for full licensing information.
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization or
+# submit itself to any jurisdiction.
+
+o2_add_library(MFTCondition
+               SOURCES src/MFTDCSProcessor.cxx
+               PUBLIC_LINK_LIBRARIES O2::CCDB
+               O2::DetectorsCalibration
+               O2::DetectorsDCS
+               ROOT::Minuit
+               Microsoft.GSL::GSL)
+
+o2_target_root_dictionary(MFTCondition
+                          HEADERS include/MFTCondition/MFTDCSProcessor.h
+                          LINKDEF src/MFTConditionLinkDef.h)
+
+o2_add_executable(mft-dcs-sim-workflow
+                  COMPONENT_NAME condition
+                  SOURCES testWorkflow/mft-dcs-sim-workflow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::DCStestWorkflow)
+
+o2_add_executable(mft-dcs-workflow
+                  COMPONENT_NAME condition
+                  SOURCES testWorkflow/mft-dcs-data-workflow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::Framework
+                                        O2::MFTCondition
+                                        O2::DetectorsDCS)

--- a/Detectors/ITSMFT/MFT/condition/README.md
+++ b/Detectors/ITSMFT/MFT/condition/README.md
@@ -1,0 +1,4 @@
+<!-- doxy
+\page refDetectorsMUONMFTConditions Conditions
+/doxy -->
+# MFT Conditions

--- a/Detectors/ITSMFT/MFT/condition/include/MFTCondition/MFTDCSProcessor.h
+++ b/Detectors/ITSMFT/MFT/condition/include/MFTCondition/MFTDCSProcessor.h
@@ -1,8 +1,9 @@
-// Copyright CERN and copyright holders of ALICE O2. This software is
-// distributed under the terms of the GNU General Public License v3 (GPL
-// Version 3), copied verbatim in the file "COPYING".
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
 //
-// See http://alice-o2.web.cern.ch/license for full licensing information.
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/Detectors/ITSMFT/MFT/condition/include/MFTCondition/MFTDCSProcessor.h
+++ b/Detectors/ITSMFT/MFT/condition/include/MFTCondition/MFTDCSProcessor.h
@@ -1,0 +1,133 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef DETECTOR_MFTDCSPROCESSOR_H_
+#define DETECTOR_MFTDCSPROCESSOR_H_
+
+#include <memory>
+#include <Rtypes.h>
+#include <unordered_map>
+#include <deque>
+#include <numeric>
+#include "Framework/Logger.h"
+#include "DetectorsDCS/DataPointCompositeObject.h"
+#include "DetectorsDCS/DataPointIdentifier.h"
+#include "DetectorsDCS/DataPointValue.h"
+#include "DetectorsDCS/DeliveryType.h"
+#include "CCDB/CcdbObjectInfo.h"
+#include "CommonUtils/MemFileHelper.h"
+#include "CCDB/CcdbApi.h"
+#include <gsl/gsl>
+
+/// @brief Class to process DCS data points
+
+namespace o2
+{
+  namespace mft
+  {
+
+    using DPID  = o2::dcs::DataPointIdentifier;
+    using DPVAL = o2::dcs::DataPointValue;
+    using DPCOM = o2::dcs::DataPointCompositeObject;
+
+    struct MFTDCSinfo {
+      std::pair<uint64_t, double> firstValue; // first value seen by the MFT DCS processor
+      std::pair<uint64_t, double> lastValue;  // last value seen by the MFT DCS processor
+      std::pair<uint64_t, double> midValue;   // mid value seen by the MFT DCS processor
+      std::pair<uint64_t, double> maxChange;  // maximum variation seen by the MFT DCS processor
+      MFTDCSinfo()
+      {
+  firstValue = std::make_pair(0, -999999999);
+  lastValue = std::make_pair(0, -999999999);
+  midValue = std::make_pair(0, -999999999);
+  maxChange = std::make_pair(0, -999999999);
+      }
+      void makeEmpty()
+      {
+  firstValue.first = lastValue.first = midValue.first = maxChange.first = 0;
+  firstValue.second = lastValue.second = midValue.second = maxChange.second = -999999999;
+      }
+      void print() const;
+
+      ClassDefNV(MFTDCSinfo, 1);
+    };
+
+    class MFTDCSProcessor
+    {
+
+    public:
+
+      using TFType = uint64_t;
+      using CcdbObjectInfo = o2::ccdb::CcdbObjectInfo;
+      using DQDoubles = std::deque<double>;
+
+      MFTDCSProcessor() = default;
+      ~MFTDCSProcessor() = default;
+
+      void init(const std::vector<DPID>& pids);
+
+      int process(const gsl::span<const DPCOM> dps);
+      int processDP(const DPCOM& dpcom);
+
+      void updateDPsCCDB();
+
+      const CcdbObjectInfo& getccdbDPsInfo() const { return mccdbDPsInfo; }
+      CcdbObjectInfo& getccdbDPsInfo() { return mccdbDPsInfo; }
+      const std::unordered_map<DPID, MFTDCSinfo>& getMFTDPsInfo() const { return mMFTDCS; }
+
+      template <typename T>
+  void prepareCCDBobjectInfo(T& obj, CcdbObjectInfo& info, const std::string& path, TFType tf, const std::map<std::string, std::string>& md);
+
+      void setTF(TFType tf) { mTF = tf; }
+      void useVerboseMode() { mVerbose = true; }
+
+      void clearDPsinfo()
+      {
+  mDpsdoublesmap.clear();
+  mMFTDCS.clear();
+      }
+
+    private:
+
+      std::unordered_map<DPID, MFTDCSinfo> mMFTDCS;                // this is the object that will go to the CCDB
+      std::unordered_map<DPID, bool> mPids;                        // contains all PIDs for the processor, the bool
+                                                                   // will be true if the DP was processed at least once
+      std::unordered_map<DPID, std::vector<DPVAL>> mDpsdoublesmap; // this is the map that will hold the DPs for the
+                                                               // double type (voltages and currents)
+      CcdbObjectInfo mccdbDPsInfo;
+
+      TFType mStartTF; // TF index for processing of first processed TF, used to store CCDB object
+      TFType mTF = 0;  // TF index for processing, used to store CCDB object
+      bool mStartTFset = false;
+
+      bool mVerbose = false;
+
+      ClassDefNV(MFTDCSProcessor, 0);
+    };
+
+    template <typename T>
+      void MFTDCSProcessor::prepareCCDBobjectInfo(T& obj, CcdbObjectInfo& info, const std::string& path, TFType tf,const std::map<std::string, std::string>& md)
+      {
+
+  // prepare all info to be sent to CCDB for object obj
+  auto clName = o2::utils::MemFileHelper::getClassName(obj);
+  auto flName = o2::ccdb::CcdbApi::generateFileName(clName);
+  info.setPath(path);
+  info.setObjectType(clName);
+  info.setFileName(flName);
+  info.setStartValidityTimestamp(tf);
+  info.setEndValidityTimestamp(99999999999999);
+  info.setMetaData(md);
+      }
+
+  } // namespace tof
+} // namespace o2
+
+#endif

--- a/Detectors/ITSMFT/MFT/condition/include/MFTCondition/MFTDCSProcessor.h
+++ b/Detectors/ITSMFT/MFT/condition/include/MFTCondition/MFTDCSProcessor.h
@@ -30,91 +30,89 @@
 
 namespace o2
 {
-  namespace mft
+namespace mft
+{
+
+using DPID = o2::dcs::DataPointIdentifier;
+using DPVAL = o2::dcs::DataPointValue;
+using DPCOM = o2::dcs::DataPointCompositeObject;
+
+struct MFTDCSinfo {
+  std::pair<uint64_t, double> firstValue; // first value seen by the MFT DCS processor
+  std::pair<uint64_t, double> lastValue;  // last value seen by the MFT DCS processor
+  std::pair<uint64_t, double> midValue;   // mid value seen by the MFT DCS processor
+  std::pair<uint64_t, double> maxChange;  // maximum variation seen by the MFT DCS processor
+  MFTDCSinfo()
   {
+    firstValue = std::make_pair(0, -999999999);
+    lastValue = std::make_pair(0, -999999999);
+    midValue = std::make_pair(0, -999999999);
+    maxChange = std::make_pair(0, -999999999);
+  }
+  void makeEmpty()
+  {
+    firstValue.first = lastValue.first = midValue.first = maxChange.first = 0;
+    firstValue.second = lastValue.second = midValue.second = maxChange.second = -999999999;
+  }
+  void print() const;
 
-    using DPID  = o2::dcs::DataPointIdentifier;
-    using DPVAL = o2::dcs::DataPointValue;
-    using DPCOM = o2::dcs::DataPointCompositeObject;
+  ClassDefNV(MFTDCSinfo, 1);
+};
 
-    struct MFTDCSinfo {
-      std::pair<uint64_t, double> firstValue; // first value seen by the MFT DCS processor
-      std::pair<uint64_t, double> lastValue;  // last value seen by the MFT DCS processor
-      std::pair<uint64_t, double> midValue;   // mid value seen by the MFT DCS processor
-      std::pair<uint64_t, double> maxChange;  // maximum variation seen by the MFT DCS processor
-      MFTDCSinfo()
-      {
-  firstValue = std::make_pair(0, -999999999);
-  lastValue = std::make_pair(0, -999999999);
-  midValue = std::make_pair(0, -999999999);
-  maxChange = std::make_pair(0, -999999999);
-      }
-      void makeEmpty()
-      {
-  firstValue.first = lastValue.first = midValue.first = maxChange.first = 0;
-  firstValue.second = lastValue.second = midValue.second = maxChange.second = -999999999;
-      }
-      void print() const;
+class MFTDCSProcessor
+{
 
-      ClassDefNV(MFTDCSinfo, 1);
-    };
+ public:
+  using TFType = uint64_t;
+  using CcdbObjectInfo = o2::ccdb::CcdbObjectInfo;
+  using DQDoubles = std::deque<double>;
 
-    class MFTDCSProcessor
-    {
+  MFTDCSProcessor() = default;
+  ~MFTDCSProcessor() = default;
 
-    public:
+  void init(const std::vector<DPID>& pids);
 
-      using TFType = uint64_t;
-      using CcdbObjectInfo = o2::ccdb::CcdbObjectInfo;
-      using DQDoubles = std::deque<double>;
+  int process(const gsl::span<const DPCOM> dps);
+  int processDP(const DPCOM& dpcom);
 
-      MFTDCSProcessor() = default;
-      ~MFTDCSProcessor() = default;
+  void updateDPsCCDB();
 
-      void init(const std::vector<DPID>& pids);
+  const CcdbObjectInfo& getccdbDPsInfo() const { return mccdbDPsInfo; }
+  CcdbObjectInfo& getccdbDPsInfo() { return mccdbDPsInfo; }
+  const std::unordered_map<DPID, MFTDCSinfo>& getMFTDPsInfo() const { return mMFTDCS; }
 
-      int process(const gsl::span<const DPCOM> dps);
-      int processDP(const DPCOM& dpcom);
-
-      void updateDPsCCDB();
-
-      const CcdbObjectInfo& getccdbDPsInfo() const { return mccdbDPsInfo; }
-      CcdbObjectInfo& getccdbDPsInfo() { return mccdbDPsInfo; }
-      const std::unordered_map<DPID, MFTDCSinfo>& getMFTDPsInfo() const { return mMFTDCS; }
-
-      template <typename T>
+  template <typename T>
   void prepareCCDBobjectInfo(T& obj, CcdbObjectInfo& info, const std::string& path, TFType tf, const std::map<std::string, std::string>& md);
 
-      void setTF(TFType tf) { mTF = tf; }
-      void useVerboseMode() { mVerbose = true; }
+  void setTF(TFType tf) { mTF = tf; }
+  void useVerboseMode() { mVerbose = true; }
 
-      void clearDPsinfo()
-      {
-  mDpsdoublesmap.clear();
-  mMFTDCS.clear();
-      }
+  void clearDPsinfo()
+  {
+    mDpsdoublesmap.clear();
+    mMFTDCS.clear();
+  }
 
-    private:
-
-      std::unordered_map<DPID, MFTDCSinfo> mMFTDCS;                // this is the object that will go to the CCDB
-      std::unordered_map<DPID, bool> mPids;                        // contains all PIDs for the processor, the bool
-                                                                   // will be true if the DP was processed at least once
-      std::unordered_map<DPID, std::vector<DPVAL>> mDpsdoublesmap; // this is the map that will hold the DPs for the
+ private:
+  std::unordered_map<DPID, MFTDCSinfo> mMFTDCS;                // this is the object that will go to the CCDB
+  std::unordered_map<DPID, bool> mPids;                        // contains all PIDs for the processor, the bool
+                                                               // will be true if the DP was processed at least once
+  std::unordered_map<DPID, std::vector<DPVAL>> mDpsdoublesmap; // this is the map that will hold the DPs for the
                                                                // double type (voltages and currents)
-      CcdbObjectInfo mccdbDPsInfo;
+  CcdbObjectInfo mccdbDPsInfo;
 
-      TFType mStartTF; // TF index for processing of first processed TF, used to store CCDB object
-      TFType mTF = 0;  // TF index for processing, used to store CCDB object
-      bool mStartTFset = false;
+  TFType mStartTF; // TF index for processing of first processed TF, used to store CCDB object
+  TFType mTF = 0;  // TF index for processing, used to store CCDB object
+  bool mStartTFset = false;
 
-      bool mVerbose = false;
+  bool mVerbose = false;
 
-      ClassDefNV(MFTDCSProcessor, 0);
-    };
+  ClassDefNV(MFTDCSProcessor, 0);
+};
 
-    template <typename T>
-      void MFTDCSProcessor::prepareCCDBobjectInfo(T& obj, CcdbObjectInfo& info, const std::string& path, TFType tf,const std::map<std::string, std::string>& md)
-      {
+template <typename T>
+void MFTDCSProcessor::prepareCCDBobjectInfo(T& obj, CcdbObjectInfo& info, const std::string& path, TFType tf, const std::map<std::string, std::string>& md)
+{
 
   // prepare all info to be sent to CCDB for object obj
   auto clName = o2::utils::MemFileHelper::getClassName(obj);
@@ -125,9 +123,9 @@ namespace o2
   info.setStartValidityTimestamp(tf);
   info.setEndValidityTimestamp(99999999999999);
   info.setMetaData(md);
-      }
+}
 
-  } // namespace tof
+} // namespace mft
 } // namespace o2
 
 #endif

--- a/Detectors/ITSMFT/MFT/condition/src/MFTConditionLinkDef.h
+++ b/Detectors/ITSMFT/MFT/condition/src/MFTConditionLinkDef.h
@@ -1,3 +1,14 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 #ifdef __CLING__
 
 #pragma link off all globals;

--- a/Detectors/ITSMFT/MFT/condition/src/MFTConditionLinkDef.h
+++ b/Detectors/ITSMFT/MFT/condition/src/MFTConditionLinkDef.h
@@ -1,0 +1,10 @@
+#ifdef __CLING__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ struct o2::mft::MFTDCSinfo + ;
+#pragma link C++ class std::unordered_map < o2::dcs::DataPointIdentifier, o2::mft::MFTDCSinfo> + ;
+
+#endif

--- a/Detectors/ITSMFT/MFT/condition/src/MFTDCSProcessor.cxx
+++ b/Detectors/ITSMFT/MFT/condition/src/MFTDCSProcessor.cxx
@@ -1,8 +1,9 @@
-// Copyright CERN and copyright holders of ALICE O2. This software is
-// distributed under the terms of the GNU General Public License v3 (GPL
-// Version 3), copied verbatim in the file "COPYING".
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
 //
-// See http://alice-o2.web.cern.ch/license for full licensing information.
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/Detectors/ITSMFT/MFT/condition/src/MFTDCSProcessor.cxx
+++ b/Detectors/ITSMFT/MFT/condition/src/MFTDCSProcessor.cxx
@@ -1,0 +1,212 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <MFTCondition/MFTDCSProcessor.h>
+#include "Rtypes.h"
+#include <deque>
+#include <string>
+#include <algorithm>
+#include <iterator>
+#include <cstring>
+#include <bitset>
+
+using namespace o2::mft;
+using namespace o2::dcs;
+
+using DeliveryType = o2::dcs::DeliveryType;
+using DPID = o2::dcs::DataPointIdentifier;
+using DPVAL = o2::dcs::DataPointValue;
+
+ClassImp(o2::mft::MFTDCSinfo);
+
+void MFTDCSinfo::print() const
+{
+  LOG(INFO) << "First Value: timestamp = " << firstValue.first << ", value = " << firstValue.second;
+  LOG(INFO) << "Last Value:  timestamp = " << lastValue.first << ", value = " << lastValue.second;
+  LOG(INFO) << "Mid Value:   timestamp = " << midValue.first << ", value = " << midValue.second;
+  LOG(INFO) << "Max Change:  timestamp = " << maxChange.first << ", value = " << maxChange.second;
+}
+
+//__________________________________________________________________
+
+void MFTDCSProcessor::init(const std::vector<DPID>& pids)
+{
+  // fill the array of the DPIDs that will be used by MFT
+  // pids should be provided by CCDB
+
+  for (const auto& it : pids) {
+    mPids[it] = false;
+    mMFTDCS[it].makeEmpty();
+  }
+}
+
+//__________________________________________________________________
+
+int MFTDCSProcessor::process(const gsl::span<const DPCOM> dps)
+{
+
+  // first we check which DPs are missing - if some are, it means that
+  // the delta map was sent
+  if (mVerbose) {
+    LOG(INFO) << "\n\n\nProcessing new TF\n-----------------";
+  }
+  if (!mStartTFset) {
+    mStartTF = mTF;
+    mStartTFset = true;
+  }
+
+  std::unordered_map<DPID, DPVAL> mapin;
+  for (auto& it : dps) {
+    mapin[it.id] = it.data;
+  }
+  for (auto& it : mPids) {
+    const auto& el = mapin.find(it.first);
+    if (el == mapin.end()) {
+      LOG(DEBUG) << "DP " << it.first << " not found in map";
+    } else {
+      LOG(DEBUG) << "DP " << it.first << " found in map";
+    }
+  }
+
+  // now we process all DPs, one by one
+  for (const auto& it : dps) {
+    // we process only the DPs defined in the configuration
+    const auto& el = mPids.find(it.id);
+    if (el == mPids.end()) {
+      LOG(INFO) << "DP " << it.id << " not found in MFTDCSProcessor, we will not process it";
+      continue;
+    }
+    processDP(it);
+    mPids[it.id] = true;
+  }
+
+  //updateCurrentAnalogCCDB();
+  updateDPsCCDB();
+
+  return 0;
+}
+
+//__________________________________________________________________
+
+int MFTDCSProcessor::processDP(const DPCOM& dpcom)
+{
+
+  // processing single DP
+
+  auto& dpid = dpcom.id;
+  const auto& type = dpid.get_type();
+  auto& val = dpcom.data;
+  if (mVerbose) {
+    if (type == RAW_DOUBLE) {
+      LOG(INFO);
+      LOG(INFO) << "Processing DP = " << dpcom << ", with value = " << o2::dcs::getValue<double>(dpcom);
+    } else if (type == RAW_INT) {
+      LOG(INFO);
+      LOG(INFO) << "Processing DP = " << dpcom << ", with value = " << o2::dcs::getValue<int32_t>(dpcom);
+    }
+  }
+
+  auto flags = val.get_flags();
+
+  // now I need to access the correct element
+  if (type == RAW_DOUBLE) {
+    // for these DPs, we will store the first, last, mid value, plus the value where the maximum variation occurred
+    auto& dvect = mDpsdoublesmap[dpid];
+    LOG(INFO) << "mDpsdoublesmap[dpid].size() = " << dvect.size();
+    auto etime = val.get_epoch_time();
+    if (dvect.size() == 0 || etime != dvect.back().get_epoch_time()) { // we check
+                                                                       // that we did not get the
+                                                                       // same timestamp as the
+                                                                       // latest one
+        dvect.push_back(val);
+    }
+  }
+
+  return 0;
+}
+
+//______________________________________________________________________
+
+void MFTDCSProcessor::updateDPsCCDB()
+{
+
+  // here we create the object to then be sent to CCDB
+  LOG(INFO) << "Finalizing";
+  union Converter {
+    uint64_t raw_data;
+    double double_value;
+  } converter0, converter1;
+
+  for (const auto& it : mPids) {
+    const auto& type = it.first.get_type();
+    if (type == o2::dcs::RAW_DOUBLE) {
+      auto& mftdcs = mMFTDCS[it.first];
+      if (it.second == true) { // we processed the DP at least 1x
+        auto& dpvect = mDpsdoublesmap[it.first];
+        mftdcs.firstValue.first = dpvect[0].get_epoch_time();
+        converter0.raw_data = dpvect[0].payload_pt1;
+        mftdcs.firstValue.second = converter0.double_value;
+        mftdcs.lastValue.first = dpvect.back().get_epoch_time();
+        converter0.raw_data = dpvect.back().payload_pt1;
+        mftdcs.lastValue.second = converter0.double_value;
+        // now I will look for the max change
+        if (dpvect.size() > 1) {
+          auto deltatime = dpvect.back().get_epoch_time() - dpvect[0].get_epoch_time();
+          if (deltatime < 60000) {
+            // if we did not cover at least 1 minute,
+            // max variation is defined as the difference between first and last value
+            converter0.raw_data = dpvect[0].payload_pt1;
+            converter1.raw_data = dpvect.back().payload_pt1;
+            double delta = std::abs(converter0.double_value - converter1.double_value);
+            mftdcs.maxChange.first = deltatime; // is it ok to do like this, as in Run 2?
+            mftdcs.maxChange.second = delta;
+          } else {
+            for (auto i = 0; i < dpvect.size() - 1; ++i) {
+              for (auto j = i + 1; j < dpvect.size(); ++j) {
+                auto deltatime = dpvect[j].get_epoch_time() - dpvect[i].get_epoch_time();
+                if (deltatime >= 60000) { // we check every min; epoch_time in ms
+                  converter0.raw_data = dpvect[i].payload_pt1;
+                  converter1.raw_data = dpvect[j].payload_pt1;
+                  double delta = std::abs(converter0.double_value - converter1.double_value);
+                  if (delta > mftdcs.maxChange.second) {
+                    mftdcs.maxChange.first = deltatime; // is it ok to do like this, as in Run 2?
+                    mftdcs.maxChange.second = delta;
+                  }
+                }
+              }
+            }
+          }
+          // mid point
+          auto midIdx = dpvect.size() / 2 - 1;
+          mftdcs.midValue.first = dpvect[midIdx].get_epoch_time();
+          converter0.raw_data = dpvect[midIdx].payload_pt1;
+          mftdcs.midValue.second = converter0.double_value;
+        } else {
+          mftdcs.maxChange.first = dpvect[0].get_epoch_time();
+          converter0.raw_data = dpvect[0].payload_pt1;
+          mftdcs.maxChange.second = converter0.double_value;
+          mftdcs.midValue.first = dpvect[0].get_epoch_time();
+          converter0.raw_data = dpvect[0].payload_pt1;
+          mftdcs.midValue.second = converter0.double_value;
+        }
+      }
+      if (mVerbose) {
+        LOG(INFO) << "PID = " << it.first.get_alias();
+        mftdcs.print();
+      }
+    }
+  }
+
+  std::map<std::string, std::string> md;
+  md["responsible"] = "Satoshi Yano";
+  prepareCCDBobjectInfo(mMFTDCS, mccdbDPsInfo, "MFT/Condition/DCSDPs", mTF, md);
+
+  return;
+}

--- a/Detectors/ITSMFT/MFT/condition/src/MFTDCSProcessor.cxx
+++ b/Detectors/ITSMFT/MFT/condition/src/MFTDCSProcessor.cxx
@@ -125,7 +125,7 @@ int MFTDCSProcessor::processDP(const DPCOM& dpcom)
                                                                        // that we did not get the
                                                                        // same timestamp as the
                                                                        // latest one
-        dvect.push_back(val);
+      dvect.push_back(val);
     }
   }
 

--- a/Detectors/ITSMFT/MFT/condition/src/dcs-check-ccdb.cxx
+++ b/Detectors/ITSMFT/MFT/condition/src/dcs-check-ccdb.cxx
@@ -1,0 +1,130 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "CCDB/CcdbApi.h"
+#include "DetectorsDCS/DataPointIdentifier.h"
+#include "DetectorsDCS/DataPointValue.h"
+#include <boost/program_options.hpp>
+#include <ctime>
+#include <iostream>
+#include <numeric>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace po = boost::program_options;
+using DPID = o2::dcs::DataPointIdentifier;
+using DPVAL = o2::dcs::DataPointValue;
+using DPMAP = std::unordered_map<DPID, std::vector<DPVAL>>;
+
+int main(int argc, char** argv)
+{
+  po::variables_map vm;
+  po::options_description usage("Usage");
+
+  std::string ccdbUrl;
+  uint64_t timestamp;
+  bool lv;
+  bool hv;
+  bool vcasn;
+  bool ithr;
+  bool ibb;
+  bool verbose;
+
+  std::time_t now = std::time(nullptr);
+
+  // clang-format off
+  usage.add_options()
+    ("help,h", "produce help message")
+    ("ccdb",po::value<std::string>(&ccdbUrl)->default_value("http://localhost:6464"),"ccdb url")
+    ("timestamp,t",po::value<uint64_t>(&timestamp)->default_value(now),"timestamp to query")
+    ("hv",po::bool_switch(&hv),"query HV")
+    ("lv",po::bool_switch(&lv),"query LV")
+    ("vcasn",po::bool_switch(&vcasn),"query VCASN")
+    ("ithr",po::bool_switch(&ithr),"query ITHR")
+    ("ibb",po::bool_switch(&ibb),"query IBB")
+    ("verbose,v",po::bool_switch(&verbose),"verbose output")
+    ;
+  // clang-format on
+
+  po::options_description cmdline;
+  cmdline.add(usage);
+
+  po::store(po::command_line_parser(argc, argv).options(cmdline).run(), vm);
+
+  if (vm.count("help")) {
+    std::cout << "This program printout summary information from MFT DCS entries.\n";
+    std::cout << usage << "\n";
+    return 2;
+  }
+
+  try {
+    po::notify(vm);
+  } catch (boost::program_options::error& e) {
+    std::cout << "Error: " << e.what() << "\n";
+    exit(1);
+  }
+
+  if (!vcasn && !ithr && !ibb) {
+    std::cout << "Must specify at least one of --vcasn or --ithr or --ibb\n";
+    std::cout << usage << "\n";
+    return 3;
+  }
+
+  std::vector<std::string> what;
+  if (vcasn) {
+    what.emplace_back("MFT/Condition/VCASN");
+  }
+  if (ithr) {
+    what.emplace_back("MFT/Condition/ITHR");
+  }
+  if (ibb) {
+    what.emplace_back("MFT/Condition/IBB");
+  }
+
+  // union Converter {
+  //   uint64_t raw_data;
+  //   T t_value;
+  // };
+  // if (dpcom.id.get_type() != dt) {
+  //   throw std::runtime_error("DPCOM is of unexpected type " + o2::dcs::show(dt));
+  // }
+  // Converter converter;
+  // converter.raw_data = dpcom.data.payload_pt1;
+
+   auto sum =
+     [](float s, o2::dcs::DataPointValue v) {
+     union Converter {
+       uint64_t raw_data;
+       double value;
+     } converter;
+     converter.raw_data = v.payload_pt1;
+     return s + converter.value;
+   };
+
+   o2::ccdb::CcdbApi api;
+   api.init(ccdbUrl);
+   for (auto w : what) {
+     std::map<std::string, std::string> metadata;
+     auto* m = api.retrieveFromTFileAny<DPMAP>(w, metadata, timestamp);
+     std::cout << "size of " << w << " map = " << m->size() << std::endl;
+     if (verbose) {
+       for (auto& i : *m) {
+         auto v = i.second;
+         auto mean = std::accumulate(v.begin(), v.end(), 0.0, sum);
+         if (v.size()) {
+           mean /= v.size();
+         }
+   std::cout << fmt::format("{:64s} {:4d} values of mean {:7.2f}\n", i.first.get_alias(), v.size(),mean);
+       }
+     }
+   }
+   return 0;
+}

--- a/Detectors/ITSMFT/MFT/condition/src/dcs-check-ccdb.cxx
+++ b/Detectors/ITSMFT/MFT/condition/src/dcs-check-ccdb.cxx
@@ -1,8 +1,9 @@
-// Copyright CERN and copyright holders of ALICE O2. This software is
-// distributed under the terms of the GNU General Public License v3 (GPL
-// Version 3), copied verbatim in the file "COPYING".
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
 //
-// See http://alice-o2.web.cern.ch/license for full licensing information.
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
@@ -88,16 +89,6 @@ int main(int argc, char** argv)
   if (ibb) {
     what.emplace_back("MFT/Condition/IBB");
   }
-
-  // union Converter {
-  //   uint64_t raw_data;
-  //   T t_value;
-  // };
-  // if (dpcom.id.get_type() != dt) {
-  //   throw std::runtime_error("DPCOM is of unexpected type " + o2::dcs::show(dt));
-  // }
-  // Converter converter;
-  // converter.raw_data = dpcom.data.payload_pt1;
 
   auto sum =
     [](float s, o2::dcs::DataPointValue v) {

--- a/Detectors/ITSMFT/MFT/condition/src/dcs-check-ccdb.cxx
+++ b/Detectors/ITSMFT/MFT/condition/src/dcs-check-ccdb.cxx
@@ -99,32 +99,32 @@ int main(int argc, char** argv)
   // Converter converter;
   // converter.raw_data = dpcom.data.payload_pt1;
 
-   auto sum =
-     [](float s, o2::dcs::DataPointValue v) {
-     union Converter {
-       uint64_t raw_data;
-       double value;
-     } converter;
-     converter.raw_data = v.payload_pt1;
-     return s + converter.value;
-   };
+  auto sum =
+    [](float s, o2::dcs::DataPointValue v) {
+      union Converter {
+        uint64_t raw_data;
+        double value;
+      } converter;
+      converter.raw_data = v.payload_pt1;
+      return s + converter.value;
+    };
 
-   o2::ccdb::CcdbApi api;
-   api.init(ccdbUrl);
-   for (auto w : what) {
-     std::map<std::string, std::string> metadata;
-     auto* m = api.retrieveFromTFileAny<DPMAP>(w, metadata, timestamp);
-     std::cout << "size of " << w << " map = " << m->size() << std::endl;
-     if (verbose) {
-       for (auto& i : *m) {
-         auto v = i.second;
-         auto mean = std::accumulate(v.begin(), v.end(), 0.0, sum);
-         if (v.size()) {
-           mean /= v.size();
-         }
-   std::cout << fmt::format("{:64s} {:4d} values of mean {:7.2f}\n", i.first.get_alias(), v.size(),mean);
-       }
-     }
-   }
-   return 0;
+  o2::ccdb::CcdbApi api;
+  api.init(ccdbUrl);
+  for (auto w : what) {
+    std::map<std::string, std::string> metadata;
+    auto* m = api.retrieveFromTFileAny<DPMAP>(w, metadata, timestamp);
+    std::cout << "size of " << w << " map = " << m->size() << std::endl;
+    if (verbose) {
+      for (auto& i : *m) {
+        auto v = i.second;
+        auto mean = std::accumulate(v.begin(), v.end(), 0.0, sum);
+        if (v.size()) {
+          mean /= v.size();
+        }
+        std::cout << fmt::format("{:64s} {:4d} values of mean {:7.2f}\n", i.first.get_alias(), v.size(), mean);
+      }
+    }
+  }
+  return 0;
 }

--- a/Detectors/ITSMFT/MFT/condition/testWorkflow/MFTDCSDataProcessorSpec.h
+++ b/Detectors/ITSMFT/MFT/condition/testWorkflow/MFTDCSDataProcessorSpec.h
@@ -41,161 +41,159 @@ namespace o2
 namespace mft
 {
 
-  using DPID = o2::dcs::DataPointIdentifier;
-  using DPVAL = o2::dcs::DataPointValue;
-  using DPCOM = o2::dcs::DataPointCompositeObject;
-  using namespace o2::ccdb;
-  using CcdbManager = o2::ccdb::BasicCCDBManager;
-  using clbUtils = o2::calibration::Utils;
-  using HighResClock = std::chrono::high_resolution_clock;
-  using Duration = std::chrono::duration<double, std::ratio<1, 1>>;
+using DPID = o2::dcs::DataPointIdentifier;
+using DPVAL = o2::dcs::DataPointValue;
+using DPCOM = o2::dcs::DataPointCompositeObject;
+using namespace o2::ccdb;
+using CcdbManager = o2::ccdb::BasicCCDBManager;
+using clbUtils = o2::calibration::Utils;
+using HighResClock = std::chrono::high_resolution_clock;
+using Duration = std::chrono::duration<double, std::ratio<1, 1>>;
 
-  class MFTDCSDataProcessor : public o2::framework::Task
+class MFTDCSDataProcessor : public o2::framework::Task
+{
+ public:
+  //________________________________________________________________
+  void init(o2::framework::InitContext& ic) final
   {
-  public:
+    std::vector<DPID> vect;
+    mDPsUpdateInterval = ic.options().get<int64_t>("DPs-update-interval");
+    if (mDPsUpdateInterval == 0) {
+      LOG(ERROR) << "MFT DPs update interval set to zero seconds --> changed to 60";
+      mDPsUpdateInterval = 60;
+    }
+    bool useCCDBtoConfigure = ic.options().get<bool>("use-ccdb-to-configure");
 
-    //________________________________________________________________
-    void init(o2::framework::InitContext& ic) final
-    {
-      std::vector<DPID> vect;
-      mDPsUpdateInterval = ic.options().get<int64_t>("DPs-update-interval");
-      if (mDPsUpdateInterval == 0) {
-        LOG(ERROR) << "MFT DPs update interval set to zero seconds --> changed to 60";
-        mDPsUpdateInterval = 60;
+    mStart = ic.options().get<int64_t>("tstart");
+    mEnd = ic.options().get<int64_t>("tend");
+
+    if (useCCDBtoConfigure) {
+      LOG(INFO) << "Configuring via CCDB";
+      std::string ccdbpath = ic.options().get<std::string>("ccdb-path");
+      auto& mgr = CcdbManager::instance();
+      mgr.setURL(ccdbpath);
+      CcdbApi api;
+      api.init(mgr.getURL());
+      long ts = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+      std::unordered_map<DPID, std::string>* dpid2DataDesc = mgr.getForTimeStamp<std::unordered_map<DPID, std::string>>("TOF/DCSconfig", ts);
+      for (auto& i : *dpid2DataDesc) {
+        vect.push_back(i.first);
       }
-      bool useCCDBtoConfigure = ic.options().get<bool>("use-ccdb-to-configure");
+    }
 
-      mStart = ic.options().get<int64_t>("tstart");
-      mEnd = ic.options().get<int64_t>("tend");
+    else {
+      LOG(INFO) << "Configuring via hardcoded strings";
+      std::vector<std::string> aliases = {"mft_main:MFT_PSU_Zone/H[0..1]D[0..4]F[0..1]Z[0..3].Monitoirng.Current.Analog",
+                                          "mft_main:MFT_PSU_Zone/H[0..1]D[0..4]F[0..1]Z[0..3].Monitoirng.Current.Digital",
+                                          "mft_main:MFT_PSU_Zone/H[0..1]D[0..4]F[0..1]Z[0..3].Monitoirng.Current.BackBias"};
+      std::vector<std::string> expaliases = o2::dcs::expandAliases(aliases);
+      for (const auto& i : expaliases) {
+        vect.emplace_back(i, o2::dcs::RAW_DOUBLE);
+      }
+    }
 
-      if (useCCDBtoConfigure) {
-  LOG(INFO) << "Configuring via CCDB";
-  std::string ccdbpath = ic.options().get<std::string>("ccdb-path");
-  auto& mgr = CcdbManager::instance();
-  mgr.setURL(ccdbpath);
-  CcdbApi api;
-  api.init(mgr.getURL());
-  long ts = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-  std::unordered_map<DPID, std::string>* dpid2DataDesc = mgr.getForTimeStamp<std::unordered_map<DPID, std::string>>("TOF/DCSconfig", ts);
-  for (auto& i : *dpid2DataDesc) {
-    vect.push_back(i.first);
+    LOG(INFO) << "Listing Data Points for MFT:";
+    for (auto& i : vect) {
+      LOG(INFO) << i;
+    }
+
+    mProcessor = std::make_unique<o2::mft::MFTDCSProcessor>();
+    bool useVerboseMode = ic.options().get<bool>("use-verbose-mode");
+    LOG(INFO) << " ************************* Verbose?" << useVerboseMode;
+
+    if (useVerboseMode) {
+      mProcessor->useVerboseMode();
+    }
+    mProcessor->init(vect);
+
+    mTimer = HighResClock::now();
   }
-      }
 
-      else {
-        LOG(INFO) << "Configuring via hardcoded strings";
-  std::vector<std::string> aliases = {"mft_main:MFT_PSU_Zone/H[0..1]D[0..4]F[0..1]Z[0..3].Monitoirng.Current.Analog",
-                                            "mft_main:MFT_PSU_Zone/H[0..1]D[0..4]F[0..1]Z[0..3].Monitoirng.Current.Digital",
-                                            "mft_main:MFT_PSU_Zone/H[0..1]D[0..4]F[0..1]Z[0..3].Monitoirng.Current.BackBias"};
-  std::vector<std::string> expaliases = o2::dcs::expandAliases(aliases);
-  for (const auto& i : expaliases) {
-    vect.emplace_back(i, o2::dcs::RAW_DOUBLE);
+  //________________________________________________________________
+  void run(o2::framework::ProcessingContext& pc) final
+  {
+    auto tfid = o2::header::get<o2::framework::DataProcessingHeader*>(pc.inputs().get("input").header)->startTime;
+    auto dps = pc.inputs().get<gsl::span<DPCOM>>("input");
+
+    mProcessor->setTF(tfid);
+    mProcessor->process(dps);
+
+    auto timeNow = HighResClock::now();
+    Duration elapsedTime = timeNow - mTimer; // in seconds
+
+    LOG(INFO) << "mDPsUpdateInterval " << mDPsUpdateInterval << "[sec.]";
+
+    if (elapsedTime.count() >= mDPsUpdateInterval) {
+      sendDPsoutput(pc.outputs());
+      mTimer = timeNow;
+    }
   }
-      }
 
-      LOG(INFO) << "Listing Data Points for MFT:";
-      for (auto& i : vect) {
-  LOG(INFO) << i;
-      }
+  //________________________________________________________________
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final
+  {
+    sendDPsoutput(ec.outputs());
+  }
 
-      mProcessor = std::make_unique<o2::mft::MFTDCSProcessor>();
-      bool useVerboseMode = ic.options().get<bool>("use-verbose-mode");
-      LOG(INFO) << " ************************* Verbose?" << useVerboseMode;
+ private:
+  std::unique_ptr<MFTDCSProcessor> mProcessor;
+  HighResClock::time_point mTimer;
+  int64_t mDPsUpdateInterval;
 
-      if (useVerboseMode) {
-  mProcessor->useVerboseMode();
-      }
-      mProcessor->init(vect);
+  long mStart;
+  long mEnd;
 
-      mTimer = HighResClock::now();
+  //________________________________________________________________
+  void sendDPsoutput(DataAllocator& output)
+  {
+    // extract CCDB infos and calibration object for DPs
+    mProcessor->updateDPsCCDB();
+    const auto& payload = mProcessor->getMFTDPsInfo();
+    auto& info = mProcessor->getccdbDPsInfo();
 
+    long tstart = mStart;
+    long tend = mEnd;
+
+    if (tstart == -1) {
+      tstart = o2::ccdb::getCurrentTimestamp();
     }
 
-    //________________________________________________________________
-    void run(o2::framework::ProcessingContext& pc) final
-    {
-      auto tfid = o2::header::get<o2::framework::DataProcessingHeader*>(pc.inputs().get("input").header)->startTime;
-      auto dps = pc.inputs().get<gsl::span<DPCOM>>("input");
-
-      mProcessor->setTF(tfid);
-      mProcessor->process(dps);
-
-      auto timeNow = HighResClock::now();
-      Duration elapsedTime = timeNow - mTimer; // in seconds
-
-      LOG(INFO) << "mDPsUpdateInterval " <<mDPsUpdateInterval << "[sec.]";
-
-      if (elapsedTime.count() >= mDPsUpdateInterval) {
-  sendDPsoutput(pc.outputs());
-  mTimer = timeNow;
-      }
+    if (tend == -1) {
+      constexpr long SECONDSPERYEAR = 365 * 24 * 60 * 60;
+      tend = o2::ccdb::getFutureTimestamp(SECONDSPERYEAR);
     }
 
-    //________________________________________________________________
-    void endOfStream(o2::framework::EndOfStreamContext& ec) final
-    {
-      sendDPsoutput(ec.outputs());
-    }
+    info.setStartValidityTimestamp(tstart);
+    info.setEndValidityTimestamp(tend);
 
-  private:
-    std::unique_ptr<MFTDCSProcessor> mProcessor;
-    HighResClock::time_point mTimer;
-    int64_t mDPsUpdateInterval;
-
-    long mStart;
-    long mEnd;
-
-    //________________________________________________________________
-    void sendDPsoutput(DataAllocator& output)
-    {
-      // extract CCDB infos and calibration object for DPs
-      mProcessor->updateDPsCCDB();
-      const auto& payload = mProcessor->getMFTDPsInfo();
-      auto& info = mProcessor->getccdbDPsInfo();
-
-      long tstart = mStart;
-      long tend = mEnd;
-
-      if (tstart == -1) {
-  tstart = o2::ccdb::getCurrentTimestamp();
-      }
-
-      if (tend == -1) {
-  constexpr long SECONDSPERYEAR = 365 * 24 * 60 * 60;
-  tend = o2::ccdb::getFutureTimestamp(SECONDSPERYEAR);
-      }
-
-      info.setStartValidityTimestamp(tstart);
-      info.setEndValidityTimestamp(tend);
-
-      auto image = o2::ccdb::CcdbApi::createObjectImage(&payload, &info);
-      LOG(INFO) << "Sending object " << info.getPath() << "/" << info.getFileName() << " of size " << image->size()
-    << " bytes, valid for " << info.getStartValidityTimestamp() << " : " << info.getEndValidityTimestamp();
-      output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "MFT_DCSDPs", 0}, *image.get());
-      output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "MFT_DCSDPs", 0}, info);
-      mProcessor->clearDPsinfo();
-    }
-    //________________________________________________________________
-  }; // end class
+    auto image = o2::ccdb::CcdbApi::createObjectImage(&payload, &info);
+    LOG(INFO) << "Sending object " << info.getPath() << "/" << info.getFileName() << " of size " << image->size()
+              << " bytes, valid for " << info.getStartValidityTimestamp() << " : " << info.getEndValidityTimestamp();
+    output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "MFT_DCSDPs", 0}, *image.get());
+    output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "MFT_DCSDPs", 0}, info);
+    mProcessor->clearDPsinfo();
+  }
+  //________________________________________________________________
+}; // end class
 } // namespace mft
 
 namespace framework
 {
 
-  DataProcessorSpec getMFTDCSDataProcessorSpec()
-  {
+DataProcessorSpec getMFTDCSDataProcessorSpec()
+{
 
-    using clbUtils = o2::calibration::Utils;
+  using clbUtils = o2::calibration::Utils;
 
-    std::vector<OutputSpec> outputs;
+  std::vector<OutputSpec> outputs;
 
-    outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "MFT_DCSDPs"});
-    outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "MFT_DCSDPs"});
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "MFT_DCSDPs"});
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "MFT_DCSDPs"});
 
-    return DataProcessorSpec{
-      "mft-dcs-data-processor",
-  Inputs{{"input", "DCS", "MFTDATAPOINTS"}},
-  outputs,
+  return DataProcessorSpec{
+    "mft-dcs-data-processor",
+    Inputs{{"input", "DCS", "MFTDATAPOINTS"}},
+    outputs,
     AlgorithmSpec{adaptFromTask<o2::mft::MFTDCSDataProcessor>()},
     Options{
       {"ccdb-path", VariantType::String, "http://localhost:8080", {"Path to CCDB"}},
@@ -204,7 +202,7 @@ namespace framework
       {"use-ccdb-to-configure", VariantType::Bool, false, {"Use CCDB to configure"}},
       {"use-verbose-mode", VariantType::Bool, false, {"Use verbose mode"}},
       {"DPs-update-interval", VariantType::Int64, 600ll, {"Interval (in s) after which to update the DPs CCDB entry"}}}};
-  }
+}
 
 } // namespace framework
 } // namespace o2

--- a/Detectors/ITSMFT/MFT/condition/testWorkflow/MFTDCSDataProcessorSpec.h
+++ b/Detectors/ITSMFT/MFT/condition/testWorkflow/MFTDCSDataProcessorSpec.h
@@ -1,0 +1,212 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_MFT_DATAPROCESSOR_H
+#define O2_MFT_DATAPROCESSOR_H
+
+/// @file   DCSMFTDataProcessorSpec.h
+/// @brief  MFT Processor for DCS Data Points
+
+#include <unistd.h>
+#include <TRandom.h>
+#include <TStopwatch.h>
+#include "DetectorsDCS/DataPointIdentifier.h"
+#include "DetectorsDCS/DataPointValue.h"
+#include "DetectorsDCS/DataPointCompositeObject.h"
+#include "DetectorsDCS/DeliveryType.h"
+#include "DetectorsDCS/AliasExpander.h"
+#include "MFTCondition/MFTDCSProcessor.h"
+#include "DetectorsCalibration/Utils.h"
+#include "CCDB/CcdbApi.h"
+#include "CCDB/BasicCCDBManager.h"
+#include "Framework/DeviceSpec.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "Framework/WorkflowSpec.h"
+#include "Framework/Task.h"
+#include "Framework/Logger.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace mft
+{
+
+  using DPID = o2::dcs::DataPointIdentifier;
+  using DPVAL = o2::dcs::DataPointValue;
+  using DPCOM = o2::dcs::DataPointCompositeObject;
+  using namespace o2::ccdb;
+  using CcdbManager = o2::ccdb::BasicCCDBManager;
+  using clbUtils = o2::calibration::Utils;
+  using HighResClock = std::chrono::high_resolution_clock;
+  using Duration = std::chrono::duration<double, std::ratio<1, 1>>;
+
+  class MFTDCSDataProcessor : public o2::framework::Task
+  {
+  public:
+
+    //________________________________________________________________
+    void init(o2::framework::InitContext& ic) final
+    {
+      std::vector<DPID> vect;
+      mDPsUpdateInterval = ic.options().get<int64_t>("DPs-update-interval");
+      if (mDPsUpdateInterval == 0) {
+        LOG(ERROR) << "MFT DPs update interval set to zero seconds --> changed to 60";
+        mDPsUpdateInterval = 60;
+      }
+      bool useCCDBtoConfigure = ic.options().get<bool>("use-ccdb-to-configure");
+
+      mStart = ic.options().get<int64_t>("tstart");
+      mEnd = ic.options().get<int64_t>("tend");
+
+      if (useCCDBtoConfigure) {
+  LOG(INFO) << "Configuring via CCDB";
+  std::string ccdbpath = ic.options().get<std::string>("ccdb-path");
+  auto& mgr = CcdbManager::instance();
+  mgr.setURL(ccdbpath);
+  CcdbApi api;
+  api.init(mgr.getURL());
+  long ts = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+  std::unordered_map<DPID, std::string>* dpid2DataDesc = mgr.getForTimeStamp<std::unordered_map<DPID, std::string>>("TOF/DCSconfig", ts);
+  for (auto& i : *dpid2DataDesc) {
+    vect.push_back(i.first);
+  }
+      }
+
+      else {
+        LOG(INFO) << "Configuring via hardcoded strings";
+  std::vector<std::string> aliases = {"mft_main:MFT_PSU_Zone/H[0..1]D[0..4]F[0..1]Z[0..3].Monitoirng.Current.Analog",
+                                            "mft_main:MFT_PSU_Zone/H[0..1]D[0..4]F[0..1]Z[0..3].Monitoirng.Current.Digital",
+                                            "mft_main:MFT_PSU_Zone/H[0..1]D[0..4]F[0..1]Z[0..3].Monitoirng.Current.BackBias"};
+  std::vector<std::string> expaliases = o2::dcs::expandAliases(aliases);
+  for (const auto& i : expaliases) {
+    vect.emplace_back(i, o2::dcs::RAW_DOUBLE);
+  }
+      }
+
+      LOG(INFO) << "Listing Data Points for MFT:";
+      for (auto& i : vect) {
+  LOG(INFO) << i;
+      }
+
+      mProcessor = std::make_unique<o2::mft::MFTDCSProcessor>();
+      bool useVerboseMode = ic.options().get<bool>("use-verbose-mode");
+      LOG(INFO) << " ************************* Verbose?" << useVerboseMode;
+
+      if (useVerboseMode) {
+  mProcessor->useVerboseMode();
+      }
+      mProcessor->init(vect);
+
+      mTimer = HighResClock::now();
+
+    }
+
+    //________________________________________________________________
+    void run(o2::framework::ProcessingContext& pc) final
+    {
+      auto tfid = o2::header::get<o2::framework::DataProcessingHeader*>(pc.inputs().get("input").header)->startTime;
+      auto dps = pc.inputs().get<gsl::span<DPCOM>>("input");
+
+      mProcessor->setTF(tfid);
+      mProcessor->process(dps);
+
+      auto timeNow = HighResClock::now();
+      Duration elapsedTime = timeNow - mTimer; // in seconds
+
+      LOG(INFO) << "mDPsUpdateInterval " <<mDPsUpdateInterval << "[sec.]";
+
+      if (elapsedTime.count() >= mDPsUpdateInterval) {
+  sendDPsoutput(pc.outputs());
+  mTimer = timeNow;
+      }
+    }
+
+    //________________________________________________________________
+    void endOfStream(o2::framework::EndOfStreamContext& ec) final
+    {
+      sendDPsoutput(ec.outputs());
+    }
+
+  private:
+    std::unique_ptr<MFTDCSProcessor> mProcessor;
+    HighResClock::time_point mTimer;
+    int64_t mDPsUpdateInterval;
+
+    long mStart;
+    long mEnd;
+
+    //________________________________________________________________
+    void sendDPsoutput(DataAllocator& output)
+    {
+      // extract CCDB infos and calibration object for DPs
+      mProcessor->updateDPsCCDB();
+      const auto& payload = mProcessor->getMFTDPsInfo();
+      auto& info = mProcessor->getccdbDPsInfo();
+
+      long tstart = mStart;
+      long tend = mEnd;
+
+      if (tstart == -1) {
+  tstart = o2::ccdb::getCurrentTimestamp();
+      }
+
+      if (tend == -1) {
+  constexpr long SECONDSPERYEAR = 365 * 24 * 60 * 60;
+  tend = o2::ccdb::getFutureTimestamp(SECONDSPERYEAR);
+      }
+
+      info.setStartValidityTimestamp(tstart);
+      info.setEndValidityTimestamp(tend);
+
+      auto image = o2::ccdb::CcdbApi::createObjectImage(&payload, &info);
+      LOG(INFO) << "Sending object " << info.getPath() << "/" << info.getFileName() << " of size " << image->size()
+    << " bytes, valid for " << info.getStartValidityTimestamp() << " : " << info.getEndValidityTimestamp();
+      output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "MFT_DCSDPs", 0}, *image.get());
+      output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "MFT_DCSDPs", 0}, info);
+      mProcessor->clearDPsinfo();
+    }
+    //________________________________________________________________
+  }; // end class
+} // namespace mft
+
+namespace framework
+{
+
+  DataProcessorSpec getMFTDCSDataProcessorSpec()
+  {
+
+    using clbUtils = o2::calibration::Utils;
+
+    std::vector<OutputSpec> outputs;
+
+    outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "MFT_DCSDPs"});
+    outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "MFT_DCSDPs"});
+
+    return DataProcessorSpec{
+      "mft-dcs-data-processor",
+  Inputs{{"input", "DCS", "MFTDATAPOINTS"}},
+  outputs,
+    AlgorithmSpec{adaptFromTask<o2::mft::MFTDCSDataProcessor>()},
+    Options{
+      {"ccdb-path", VariantType::String, "http://localhost:8080", {"Path to CCDB"}},
+      {"tstart", VariantType::Int64, -1ll, {"Start of validity timestamp"}},
+      {"tend", VariantType::Int64, -1ll, {"End of validity timestamp"}},
+      {"use-ccdb-to-configure", VariantType::Bool, false, {"Use CCDB to configure"}},
+      {"use-verbose-mode", VariantType::Bool, false, {"Use verbose mode"}},
+      {"DPs-update-interval", VariantType::Int64, 600ll, {"Interval (in s) after which to update the DPs CCDB entry"}}}};
+  }
+
+} // namespace framework
+} // namespace o2
+
+#endif

--- a/Detectors/ITSMFT/MFT/condition/testWorkflow/mft-dcs-data-workflow.cxx
+++ b/Detectors/ITSMFT/MFT/condition/testWorkflow/mft-dcs-data-workflow.cxx
@@ -1,0 +1,42 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "DetectorsDCS/DataPointIdentifier.h"
+#include "DetectorsDCS/DataPointValue.h"
+#include "Framework/TypeTraits.h"
+#include <unordered_map>
+namespace o2::framework
+{
+  template <>
+  struct has_root_dictionary<std::unordered_map<o2::dcs::DataPointIdentifier, o2::dcs::DataPointValue>, void> : std::true_type {
+  };
+} // namespace o2::framework
+#include "Framework/DataProcessorSpec.h"
+#include "MFTDCSDataProcessorSpec.h"
+
+using namespace o2::framework;
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  WorkflowSpec specs;
+  specs.emplace_back(getMFTDCSDataProcessorSpec());
+  return specs;
+}

--- a/Detectors/ITSMFT/MFT/condition/testWorkflow/mft-dcs-data-workflow.cxx
+++ b/Detectors/ITSMFT/MFT/condition/testWorkflow/mft-dcs-data-workflow.cxx
@@ -15,9 +15,9 @@
 #include <unordered_map>
 namespace o2::framework
 {
-  template <>
-  struct has_root_dictionary<std::unordered_map<o2::dcs::DataPointIdentifier, o2::dcs::DataPointValue>, void> : std::true_type {
-  };
+template <>
+struct has_root_dictionary<std::unordered_map<o2::dcs::DataPointIdentifier, o2::dcs::DataPointValue>, void> : std::true_type {
+};
 } // namespace o2::framework
 #include "Framework/DataProcessorSpec.h"
 #include "MFTDCSDataProcessorSpec.h"

--- a/Detectors/ITSMFT/MFT/condition/testWorkflow/mft-dcs-sim-workflow.cxx
+++ b/Detectors/ITSMFT/MFT/condition/testWorkflow/mft-dcs-sim-workflow.cxx
@@ -1,0 +1,37 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+// // we need to add workflow options before including Framework/runDataProcessing
+// void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+// {
+//   // option allowing to set parameters
+// }
+
+// ------------------------------------------------------------------
+
+#include "DCStestWorkflow/DCSRandomDataGeneratorSpec.h"
+#include "Framework/runDataProcessing.h"
+
+o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& configcontext)
+{
+  std::vector<o2::dcs::test::HintType> dphints;
+  // for MFT
+  // for test, we use less DPs that official ones
+
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"mft_main:MFT_PSU_Zone/H[0..1]D[0..4]F[0..1]Z[0..3].Monitoirng.Current.Analog", 0.05, 0.3});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"mft_main:MFT_PSU_Zone/H[0..1]D[0..4]F[0..1]Z[0..3].Monitoirng.Current.Digital", 0.1, 2.0});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"mft_main:MFT_PSU_Zone/H[0..1]D[0..4]F[0..1]Z[0..3].Monitoirng.Current.BackBias", 0.0, 1.0});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"mft_main:MFT_PSU_Zone/H[0..1]D[0..4]F[0..1]Z[0..3].Monitoirng.Voltage.BackBias", 0, 3.});
+
+  o2::framework::WorkflowSpec specs;
+  specs.emplace_back(o2::dcs::test::getDCSRandomDataGeneratorSpec(dphints, "MFT"));
+  return specs;
+}


### PR DESCRIPTION
The old PR has been closed because it needed many modifications to merge into the origin repo.
The following message is the same as the old PR. 

The PR is the first attempt to implement DCS processor.
The codes are contained in Detector/ITSMFT/MFT/condition.
For the test, mimic DCS DPs are generated with "o2-condition-mft-dcs-sim-workflow”.
The mimic generator generates Current.Analog, Current.Digital, Current.BackBias DPs within 0 - 3.
The DPs are packed into CCDB object with “o2-condition-mft-dcs-workflow”.
The codes, Detectors/ITSMFT/MFT/condition/testWorkflow/MFTDCSDataProcessorSpec.h, Detectors/ITSMFT/MFT/condition/src/MFTDCSProcessor.cxx, and Detectors/ITSMFT/MFT/condition/include/MFTCondition/MFTDCSProcessor.h, are the core code for the DCS processor workflow.