### PR TITLE
MCH: remove vertex handling from reco workflow

### DIFF
--- a/Detectors/MUON/MCH/Workflow/src/reco-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/reco-workflow.cxx
@@ -20,12 +20,9 @@
 #include "MCHWorkflow/ClusterFinderOriginalSpec.h"
 #include "MCHWorkflow/PreClusterFinderSpec.h"
 #include "MCHWorkflow/TrackWriterSpec.h"
-#include "TrackAtVertexSpec.h"
-#include "TrackAtVertexSpec.h"
 #include "TrackFinderSpec.h"
 #include "TrackFitterSpec.h"
 #include "TrackMCLabelFinderSpec.h"
-#include "VertexSamplerSpec.h"
 
 using o2::framework::ConfigContext;
 using o2::framework::ConfigParamSpec;
@@ -64,8 +61,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   specs.emplace_back(o2::mch::getClusterFinderOriginalSpec("mch-cluster-finder"));
   specs.emplace_back(o2::mch::getClusterTransformerSpec());
   specs.emplace_back(o2::mch::getTrackFinderSpec("mch-track-finder"));
-  specs.emplace_back(o2::mch::getVertexSamplerSpec("mch-vertex-sampler"));
-  specs.emplace_back(o2::mch::getTrackAtVertexSpec("mch-track-at-vertex"));
+
   if (!disableRootOutput) {
     if (useMC) {
       specs.emplace_back(o2::mch::getTrackMCLabelFinderSpec("mch-track-mc-label-finder"));


### PR DESCRIPTION
Let the mch-reco-workflow last stage be the mch standalone tracks (i.e.
not extrapolated), as the vertex matching is done elsewhere (except for
Run2 tests in which case the removed connection to the vertex-sampler
can easily recovered with workflow piping)