### PR TITLE
GPU: Increase global cluster buffer in case of low occupancy data

### DIFF
--- a/GPU/GPUTracking/Global/GPUChainTrackingClusterizer.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTrackingClusterizer.cxx
@@ -379,6 +379,7 @@ int GPUChainTracking::RunTPCClusterizer(bool synchronizeOutput)
   }
 
   mRec->MemoryScalers()->nTPCHits = mRec->MemoryScalers()->NTPCClusters(mRec->MemoryScalers()->nTPCdigits);
+  float tpcHitLowOccupancyScalingFactor = 1.f;
   if (mIOPtrs.settingsTF && mIOPtrs.settingsTF->hasNHBFPerTF) {
     unsigned int nHitsBase = mRec->MemoryScalers()->nTPCHits;
     unsigned int threshold = 30000000 / 256 * mIOPtrs.settingsTF->nHBFPerTF;
@@ -386,6 +387,7 @@ int GPUChainTracking::RunTPCClusterizer(bool synchronizeOutput)
     if (nHitsBase < threshold) {
       float maxFactor = mRec->MemoryScalers()->nTPCHits < threshold ? 2.0 : 1.5;
       mRec->MemoryScalers()->temporaryFactor *= std::min(maxFactor, (float)threshold / nHitsBase);
+      tpcHitLowOccupancyScalingFactor = std::min(3.f, (float)threshold / nHitsBase);
     }
   }
   for (unsigned int iSlice = 0; iSlice < NSLICES; iSlice++) {
@@ -422,7 +424,7 @@ int GPUChainTracking::RunTPCClusterizer(bool synchronizeOutput)
   bool buildNativeGPU = (mRec->GetRecoStepsGPU() & GPUDataTypes::RecoStep::TPCConversion) || (mRec->GetRecoStepsGPU() & GPUDataTypes::RecoStep::TPCSliceTracking) || (mRec->GetRecoStepsGPU() & GPUDataTypes::RecoStep::TPCMerging) || (mRec->GetRecoStepsGPU() & GPUDataTypes::RecoStep::TPCCompression);
   bool buildNativeHost = mRec->GetRecoStepsOutputs() & GPUDataTypes::InOutType::TPCClusters; // TODO: Should do this also when clusters are needed for later steps on the host but not requested as output
 
-  mInputsHost->mNClusterNative = mInputsShadow->mNClusterNative = mRec->MemoryScalers()->nTPCHits;
+  mInputsHost->mNClusterNative = mInputsShadow->mNClusterNative = mRec->MemoryScalers()->nTPCHits * tpcHitLowOccupancyScalingFactor;
   if (buildNativeGPU) {
     AllocateRegisteredMemory(mInputsHost->mResourceClusterNativeBuffer);
   }


### PR DESCRIPTION
 @wiechula : this fixes the global cluster buffer overflow you have seen when using your pedestal file.