### PR TITLE
[MCH] set bcWidth in digit ROFs

### DIFF
--- a/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h
+++ b/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h
@@ -37,6 +37,7 @@ class ROFRecord
  public:
   ROFRecord() = default;
   ROFRecord(const BCData& bc, int firstIdx, int nEntries) : mBCData(bc), mDataRef(firstIdx, nEntries) {}
+  ROFRecord(const BCData& bc, int firstIdx, int nEntries, int bcWidth) : mBCData(bc), mDataRef(firstIdx, nEntries), mBCWidth(bcWidth) {}
 
   /// get the interaction record
   const BCData& getBCData() const { return mBCData; }
@@ -56,8 +57,6 @@ class ROFRecord
 
   /// get the time span by this ROF, in BC unit
   int getBCWidth() const { return mBCWidth; }
-  /// set the time span by this ROF, in BC unit
-  void setBCWidth(int bcWidth);
 
   bool operator==(const ROFRecord& other) const
   {

--- a/DataFormats/Detectors/MUON/MCH/src/ROFRecord.cxx
+++ b/DataFormats/Detectors/MUON/MCH/src/ROFRecord.cxx
@@ -23,11 +23,5 @@ std::ostream& operator<<(std::ostream& os, const ROFRecord& rof)
                     rof.getBCWidth());
   return os;
 }
-void ROFRecord::setBCWidth(int bcWidth)
-{
-  if (bcWidth < 4) {
-    throw std::invalid_argument(fmt::format("bcWidth must be strictly greater than 4 bunch-crossings"));
-  }
-}
 
 } // namespace o2::mch

--- a/Detectors/MUON/MCH/DevIO/Digits/DigitIOV1.cxx
+++ b/Detectors/MUON/MCH/DevIO/Digits/DigitIOV1.cxx
@@ -53,8 +53,7 @@ bool DigitReaderV1::read(std::istream& in,
     return false;
   }
   for (auto r0 : rofsr0) {
-    ROFRecord r(r0.ir, r0.ref.getFirstEntry(), r0.ref.getEntries());
-    r.setBCWidth(4);
+    ROFRecord r(r0.ir, r0.ref.getFirstEntry(), r0.ref.getEntries(), 4);
     rofs.push_back(r);
   }
 

--- a/Detectors/MUON/MCH/DevIO/Digits/DigitIOV4.cxx
+++ b/Detectors/MUON/MCH/DevIO/Digits/DigitIOV4.cxx
@@ -64,8 +64,7 @@ bool DigitReaderV4::read(std::istream& in,
     in.read(reinterpret_cast<char*>(&firstIdx), sizeof(uint32_t));
     in.read(reinterpret_cast<char*>(&nentries), sizeof(uint32_t));
     in.read(reinterpret_cast<char*>(&bcWidth), sizeof(uint32_t));
-    rofs.emplace_back(o2::InteractionRecord{bc, orbit}, firstIdx, nentries);
-    rofs.back().setBCWidth(bcWidth);
+    rofs.emplace_back(o2::InteractionRecord{bc, orbit}, firstIdx, nentries, bcWidth);
     if (in.fail()) {
       return false;
     }

--- a/Detectors/MUON/MCH/Raw/Decoder/src/ROFFinder.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/ROFFinder.cxx
@@ -37,6 +37,8 @@ namespace raw
 
 using namespace std;
 
+static constexpr int sBcInOneADCclock = 4;
+
 //_________________________________________________________________________________________________
 ROFFinder::ROFFinder(const DataDecoder::RawDigitVector& digits, uint32_t firstTForbit) : mInputDigits(digits), mFirstTForbit(firstTForbit)
 {
@@ -115,9 +117,8 @@ void ROFFinder::process(bool dummyROFs)
       std::cout << fmt::format("  checking digit {} -> {}\n", id2, inputId2);
 #endif
 
-      constexpr int oneADCclock = 4;
       auto tdiff = digit.getTime() - rofSeed.getTime();
-      if (std::abs(tdiff) < oneADCclock) {
+      if (std::abs(tdiff) < sBcInOneADCclock) {
         mEntries += 1;
 #ifdef ROFDEBUG
         std::cout << fmt::format("  digit {} -> {} added to current ROF\n", id2, inputId2);
@@ -196,7 +197,7 @@ o2::InteractionRecord ROFFinder::digitTime2IR(const RawDigit& digit)
 void ROFFinder::storeROF()
 {
   if (mEntries > 0) {
-    mOutputROFs.emplace_back(mIR, mFirstIdx, mEntries);
+    mOutputROFs.emplace_back(mIR, mFirstIdx, mEntries, sBcInOneADCclock);
   }
 }
 

--- a/Detectors/MUON/MCH/Raw/Decoder/src/testROFFinder.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/testROFFinder.cxx
@@ -76,6 +76,7 @@ BOOST_AUTO_TEST_CASE(TwoDigitsInOneROF)
   BOOST_CHECK_EQUAL(rofRecords[0].getNEntries(), 2);
 
   BOOST_CHECK_EQUAL(rofRecords[0].getBCData(), rofFinder.digitTime2IR(digits[0]));
+  BOOST_CHECK_EQUAL(rofRecords[0].getBCWidth(), 4);
 
   BOOST_CHECK_EQUAL(rofFinder.isDigitsTimeAligned(), true);
 }
@@ -103,6 +104,7 @@ BOOST_AUTO_TEST_CASE(TwoDigitsInOneROFUnaligned)
   BOOST_CHECK_EQUAL(rofRecords[0].getNEntries(), 2);
 
   BOOST_CHECK_EQUAL(rofRecords[0].getBCData(), rofFinder.digitTime2IR(digits[0]));
+  BOOST_CHECK_EQUAL(rofRecords[0].getBCWidth(), 4);
 
   BOOST_CHECK_EQUAL(rofFinder.isDigitsTimeAligned(), false);
 }
@@ -130,6 +132,7 @@ BOOST_AUTO_TEST_CASE(TwoDigitsInOneROFsConsecutiveOrbits)
   BOOST_CHECK_EQUAL(rofRecords[0].getNEntries(), 2);
 
   BOOST_CHECK_EQUAL(rofRecords[0].getBCData(), rofFinder.digitTime2IR(digits[0]));
+  BOOST_CHECK_EQUAL(rofRecords[0].getBCWidth(), 4);
 }
 
 //----------------------------------------------------------------------------
@@ -154,10 +157,12 @@ BOOST_AUTO_TEST_CASE(TwoDigitsInTwoROFs)
   BOOST_CHECK_EQUAL(rofRecords[0].getFirstIdx(), 0);
   BOOST_CHECK_EQUAL(rofRecords[0].getNEntries(), 1);
   BOOST_CHECK_EQUAL(rofRecords[0].getBCData(), rofFinder.digitTime2IR(digits[0]));
+  BOOST_CHECK_EQUAL(rofRecords[0].getBCWidth(), 4);
 
   BOOST_CHECK_EQUAL(rofRecords[1].getFirstIdx(), 1);
   BOOST_CHECK_EQUAL(rofRecords[1].getNEntries(), 1);
   BOOST_CHECK_EQUAL(rofRecords[1].getBCData(), rofFinder.digitTime2IR(digits[1]));
+  BOOST_CHECK_EQUAL(rofRecords[1].getBCWidth(), 4);
 
   const auto rofDigit1 = rofFinder.getOrderedDigit(rofRecords[0].getFirstIdx());
   const auto rofDigit2 = rofFinder.getOrderedDigit(rofRecords[1].getFirstIdx());
@@ -194,10 +199,12 @@ BOOST_AUTO_TEST_CASE(TwoDigitsInTwoROFsConsecutiveOrbits)
   BOOST_CHECK_EQUAL(rofRecords[0].getFirstIdx(), 0);
   BOOST_CHECK_EQUAL(rofRecords[0].getNEntries(), 1);
   BOOST_CHECK_EQUAL(rofRecords[0].getBCData(), rofFinder.digitTime2IR(digits[1]));
+  BOOST_CHECK_EQUAL(rofRecords[0].getBCWidth(), 4);
 
   BOOST_CHECK_EQUAL(rofRecords[1].getFirstIdx(), 1);
   BOOST_CHECK_EQUAL(rofRecords[1].getNEntries(), 1);
   BOOST_CHECK_EQUAL(rofRecords[1].getBCData(), rofFinder.digitTime2IR(digits[0]));
+  BOOST_CHECK_EQUAL(rofRecords[1].getBCWidth(), 4);
 
   const auto rofDigit1 = rofFinder.getOrderedDigit(rofRecords[0].getFirstIdx());
   const auto rofDigit2 = rofFinder.getOrderedDigit(rofRecords[1].getFirstIdx());


### PR DESCRIPTION
The width of the digit ROFs is set to a fixed width of 4 bunch crossings, corresponding to one SAMPA ADC cycle.