### PR TITLE
DPL: do not use ConditionalRun anymore

### DIFF
--- a/Framework/Core/include/Framework/DataProcessingDevice.h
+++ b/Framework/Core/include/Framework/DataProcessingDevice.h
@@ -121,7 +121,7 @@ class DataProcessingDevice : public FairMQDevice
   void PostRun() final;
   void Reset() final;
   void ResetTask() final;
-  bool ConditionalRun() final;
+  void Run() final;
   void SetErrorPolicy(enum TerminationPolicy policy) { mErrorPolicy = policy; }
 
   // Processing functions are now renetrant


### PR DESCRIPTION
* ConditionalRun will always exit in case of a new state transition,
  while in the future we want to be able to control when we actually
  do that, so that e.g. we can finalise sending histograms or write to
  file.
* Rate limiting was removed as the libuv event based mechanism is far
  superior and it now does not have any known 100% CPU usage bug.