### PR TITLE
Increase DEFAULT_PIPELINE_LENGTH, needed to be > 16 for async reco workflow

### DIFF
--- a/Framework/Core/src/DataRelayer.cxx
+++ b/Framework/Core/src/DataRelayer.cxx
@@ -48,7 +48,7 @@ constexpr int INVALID_INPUT = -1;
 
 // 16 is just some reasonable numer
 // The number should really be tuned at runtime for each processor.
-constexpr int DEFAULT_PIPELINE_LENGTH = 16;
+constexpr int DEFAULT_PIPELINE_LENGTH = 32;
 
 DataRelayer::DataRelayer(const CompletionPolicy& policy,
                          std::vector<InputRoute> const& routes,


### PR DESCRIPTION
@ktf : 16 is just slightly below what is needed for the full async reco workflow (the reason is the totally different processing speed of the processing steps, requiring a long pipeline.) Actually 24 or even 20 would be enough, but I put 32 to remain at a power of 2. Do you think this is OK, or should we go with 20 or 24?