### PR TITLE
[QC-615] Data Sampling: helper for channel bind location parameter

### DIFF
--- a/Utilities/DataSampling/include/DataSampling/DataSampling.h
+++ b/Utilities/DataSampling/include/DataSampling/DataSampling.h
@@ -103,6 +103,8 @@ class DataSampling
   static std::optional<uint16_t> PortForPolicy(const boost::property_tree::ptree& policiesTree, const std::string& policyName);
   /// \brief Provides the machines where given DataSamplingPolicy is enabled. Expects the "dataSamplingPolicies" tree.
   static std::vector<std::string> MachinesForPolicy(const boost::property_tree::ptree& policiesTree, const std::string& policyName);
+  /// \brief Says if remote part (e.g. QC server) should bind the inter-machine channel, according to the configuration. Expects the "dataSamplingPolicies" tree.
+  static std::string BindLocationForPolicy(const boost::property_tree::ptree& policiesTree, const std::string& policyName);
 
  private:
   static void DoGenerateInfrastructure(Dispatcher&, framework::WorkflowSpec& workflow, boost::property_tree::ptree const& policies, size_t threads = 1, const std::string& host = "");

--- a/Utilities/DataSampling/src/DataSampling.cxx
+++ b/Utilities/DataSampling/src/DataSampling.cxx
@@ -169,4 +169,14 @@ std::vector<std::string> DataSampling::MachinesForPolicy(const boost::property_t
   throw std::runtime_error("Could not find the policy '" + policyName + "'");
 }
 
+std::string DataSampling::BindLocationForPolicy(const boost::property_tree::ptree& policiesTree, const std::string& policyName)
+{
+  for (auto&& policyConfig : policiesTree) {
+    if (policyConfig.second.get<std::string>("id") == policyName) {
+      return policyConfig.second.get_optional<std::string>("bindLocation").value_or("remote");
+    }
+  }
+  throw std::runtime_error("Could not find the policy '" + policyName + "'");
+}
+
 } // namespace o2::utilities

--- a/Utilities/DataSampling/test/test_DataSampling.cxx
+++ b/Utilities/DataSampling/test/test_DataSampling.cxx
@@ -226,6 +226,7 @@ BOOST_AUTO_TEST_CASE(MultinodeUtilities)
   {
     BOOST_CHECK_THROW(DataSampling::PortForPolicy(policiesTree, "no such policy"), std::runtime_error);
     BOOST_CHECK_THROW(DataSampling::MachinesForPolicy(policiesTree, "no such policy"), std::runtime_error);
+    BOOST_CHECK_THROW(DataSampling::BindLocationForPolicy(policiesTree, "no such policy"), std::runtime_error);
   }
   {
     auto port = DataSampling::PortForPolicy(policiesTree, "tpcclusters");
@@ -239,6 +240,10 @@ BOOST_AUTO_TEST_CASE(MultinodeUtilities)
     BOOST_CHECK_EQUAL(port.value(), 1234);
     auto machines = DataSampling::MachinesForPolicy(policiesTree, "tpcraw");
     BOOST_CHECK_EQUAL(machines.size(), 2);
+  }
+  {
+    BOOST_CHECK_EQUAL(DataSampling::BindLocationForPolicy(policiesTree, "tpcclusters"), "local");
+    BOOST_CHECK_EQUAL(DataSampling::BindLocationForPolicy(policiesTree, "tpcraw"), "remote");
   }
   {
     // empty host -> match any policy

--- a/Utilities/DataSampling/test/test_DataSampling.json
+++ b/Utilities/DataSampling/test/test_DataSampling.json
@@ -4,7 +4,8 @@
       "id" : "tpcclusters",
       "active" : "true",
       "query" : "clusters:TPC/CLUSTERS;clusters_p:TPC/CLUSTERS_P",
-      "samplingConditions" : []
+      "samplingConditions" : [],
+      "bindLocation" : "local"
     },
     {
       "id" : "tpcraw",


### PR DESCRIPTION
Binding remotely (on QC servers) will be the default.