### PR TITLE
TRD fix digit reader in ED workflow

### DIFF
--- a/Detectors/TRD/workflow/src/TRDEventDisplayFeedWorkflow.cxx
+++ b/Detectors/TRD/workflow/src/TRDEventDisplayFeedWorkflow.cxx
@@ -40,7 +40,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   if (!configcontext.options().get<bool>("disable-root-input")) {
     spec.emplace_back(o2::trd::getTRDGlobalTrackReaderSpec(useMC));
     spec.emplace_back(o2::trd::getTRDTrackletReaderSpec(useMC, false));
-    spec.emplace_back(o2::trd::getTRDDigitReaderSpec(1, useMC));
+    spec.emplace_back(o2::trd::getTRDDigitReaderSpec(useMC));
   }
 
   int nEventsMax = configcontext.options().get<int>("nEventsMax");


### PR DESCRIPTION
@davidrohr sorry I missed that #6865 which was merged just before #6729 uses the TRD digit reader spec for which I changed the interface. Since one data member was obsolete. This breaks O2 build now :/