### PR TITLE
[MCH] propagate tracks to MID

### DIFF
--- a/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h
+++ b/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h
@@ -34,7 +34,8 @@ class TrackMCH
 
  public:
   TrackMCH() = default;
-  TrackMCH(double z, const TMatrixD& param, const TMatrixD& cov, double chi2, int firstClIdx, int nClusters);
+  TrackMCH(double z, const TMatrixD& param, const TMatrixD& cov, double chi2, int firstClIdx, int nClusters,
+           double zAtMID, const TMatrixD& paramAtMID, const TMatrixD& covAtMID);
   ~TrackMCH() = default;
 
   TrackMCH(const TrackMCH& track) = default;
@@ -68,8 +69,25 @@ class TrackMCH
   const double* getCovariances() const { return mCov; }
   /// get the covariance between track parameters i and j
   double getCovariance(int i, int j) const { return mCov[SCovIdx[i][j]]; }
-  // set the track parameter covariances
-  void setCovariances(const TMatrixD& cov);
+  /// set the track parameter covariances
+  void setCovariances(const TMatrixD& cov) { setCovariances(cov, mCov); }
+
+  /// get the track z position on the MID side where the parameters are evaluated
+  double getZAtMID() const { return mZAtMID; }
+  /// set the track z position on the MID side where the parameters are evaluated
+  void setZAtMID(double z) { mZAtMID = z; }
+
+  /// get the track parameters on the MID side
+  const double* getParametersAtMID() const { return mParamAtMID; }
+  /// set the track parameters on the MID side
+  void setParametersAtMID(const TMatrixD& param) { param.GetMatrix2Array(mParamAtMID); }
+
+  /// get the track parameter covariances on the MID side
+  const double* getCovariancesAtMID() const { return mCovAtMID; }
+  /// get the covariance between track parameters i and j on the MID side
+  double getCovarianceAtMID(int i, int j) const { return mCovAtMID[SCovIdx[i][j]]; }
+  /// set the track parameter covariances on the MID side
+  void setCovariancesAtMID(const TMatrixD& cov) { setCovariances(cov, mCovAtMID); }
 
   /// get the track chi2
   double getChi2() const { return mChi2; }
@@ -99,6 +117,8 @@ class TrackMCH
                                                       {6, 7, 8, 9, 13},
                                                       {10, 11, 12, 13, 14}};
 
+  void setCovariances(const TMatrixD& src, double (&dest)[SCovSize]);
+
   double mZ = 0.;                 ///< z position where the parameters are evaluated
   double mParam[SNParams] = {0.}; ///< 5 parameters: X (cm), SlopeX, Y (cm), SlopeY, q/pYZ ((GeV/c)^-1)
   /// reduced covariance matrix of track parameters, formated as follow: <pre>
@@ -108,10 +128,16 @@ class TrackMCH
   /// [6] = <SlopeY,X>  [7] = <SlopeY,SlopeX>  [8] = <SlopeY,Y>  [9] = <SlopeY,SlopeY>
   /// [10]= <q/pYZ,X>   [11]= <q/pYZ,SlopeX>   [12]= <q/pYZ,Y>   [13]= <q/pYZ,SlopeY>   [14]= <q/pYZ,q/pYZ> </pre>
   double mCov[SCovSize] = {0.};
-  double mChi2 = 0.;  ///< chi2 of track
+
+  double mChi2 = 0.; ///< chi2 of track
+
   ClusRef mClusRef{}; ///< reference to external cluster indices
 
-  ClassDefNV(TrackMCH, 1);
+  double mZAtMID = 0.;                 ///< z position on the MID side where the parameters are evaluated
+  double mParamAtMID[SNParams] = {0.}; ///< 5 parameters: X (cm), SlopeX, Y (cm), SlopeY, q/pYZ ((GeV/c)^-1)
+  double mCovAtMID[SCovSize] = {0.};   ///< reduced covariance matrix of track parameters, formated as above
+
+  ClassDefNV(TrackMCH, 2);
 };
 
 std::ostream& operator<<(std::ostream& os, const TrackMCH& t);

--- a/DataFormats/Detectors/MUON/MCH/src/TrackMCH.cxx
+++ b/DataFormats/Detectors/MUON/MCH/src/TrackMCH.cxx
@@ -28,12 +28,15 @@ namespace mch
 {
 
 //__________________________________________________________________________
-TrackMCH::TrackMCH(double z, const TMatrixD& param, const TMatrixD& cov, double chi2, int firstClIdx, int nClusters)
-  : mZ(z), mChi2(chi2), mClusRef(firstClIdx, nClusters)
+TrackMCH::TrackMCH(double z, const TMatrixD& param, const TMatrixD& cov, double chi2, int firstClIdx, int nClusters,
+                   double zAtMID, const TMatrixD& paramAtMID, const TMatrixD& covAtMID)
+  : mZ(z), mChi2(chi2), mClusRef(firstClIdx, nClusters), mZAtMID(zAtMID)
 {
   /// constructor
   setParameters(param);
   setCovariances(cov);
+  setParametersAtMID(paramAtMID);
+  setCovariancesAtMID(covAtMID);
 }
 
 //__________________________________________________________________________
@@ -74,12 +77,12 @@ double TrackMCH::getP() const
 }
 
 //__________________________________________________________________________
-void TrackMCH::setCovariances(const TMatrixD& cov)
+void TrackMCH::setCovariances(const TMatrixD& src, double (&dest)[SCovSize])
 {
   /// set the track parameter covariances
   for (int i = 0; i < SNParams; i++) {
     for (int j = 0; j <= i; j++) {
-      mCov[SCovIdx[i][j]] = cov(i, j);
+      dest[SCovIdx[i][j]] = src(i, j);
     }
   }
 }

--- a/Detectors/MUON/MCH/Tracking/include/MCHTracking/TrackExtrap.h
+++ b/Detectors/MUON/MCH/Tracking/include/MCHTracking/TrackExtrap.h
@@ -83,6 +83,8 @@ class TrackExtrap
     return extrapToVertex(trackParam, 0., 0., zVtx, 0., 0., false, false);
   }
 
+  static bool extrapToMID(TrackParam* trackParam);
+
   static double getMCSAngle2(const TrackParam& param, double dZ, double x0);
   static void addMCSEffect(TrackParam* trackParam, double dZ, double x0);
 
@@ -126,6 +128,12 @@ class TrackExtrap
   /// Most probable value (GeV/c) of muon momentum in bending plane (used when B = 0)
   /// Needed to get some "reasonable" corrections for MCS and E loss even if B = 0
   static constexpr double SMostProbBendingMomentum = 2.;
+  static constexpr double SMuonFilterZBeg = -1471.;    ///< Position of the begining of the muon filter (cm)
+  static constexpr double SMuonFilterThickness = 120.; ///< Thickness of the muon filter (cm)
+  /// Position of the end of the muon filter (cm)
+  static constexpr double SMuonFilterZEnd = SMuonFilterZBeg - SMuonFilterThickness;
+  static constexpr double SMuonFilterX0 = 1.76; ///< Radiation length of the muon filter (cm)
+  static constexpr double SMIDZ = -1603.5;      ///< Position of the first MID chamber (cm)
 
   static bool sExtrapV2; ///< switch to Runge-Kutta extrapolation v2
 

--- a/Detectors/MUON/MCH/Tracking/src/TrackExtrap.cxx
+++ b/Detectors/MUON/MCH/Tracking/src/TrackExtrap.cxx
@@ -249,6 +249,32 @@ bool TrackExtrap::extrapToZCov(TrackParam* trackParam, double zEnd, bool updateP
 }
 
 //__________________________________________________________________________
+bool TrackExtrap::extrapToMID(TrackParam* trackParam)
+{
+  /// Extrapolate the track parameters and their covariances to the z position of the first MID chamber
+  /// Add to the track parameter covariances the effects of multiple Coulomb scattering in the muon filter
+
+  if (trackParam->getZ() == SMIDZ) {
+    return true; // nothing to be done
+  }
+
+  // check the track position with respect to the muon filter (spectro z<0)
+  if (trackParam->getZ() < SMuonFilterZBeg) {
+    LOG(WARNING) << "The track already passed the beginning of the muon filter";
+    return false;
+  }
+
+  // propagate through the muon filter and add MCS effets
+  if (!extrapToZCov(trackParam, SMuonFilterZEnd)) {
+    return false;
+  }
+  addMCSEffect(trackParam, -SMuonFilterThickness, SMuonFilterX0);
+
+  // propagate to the first MID chamber
+  return extrapToZCov(trackParam, SMIDZ);
+}
+
+//__________________________________________________________________________
 bool TrackExtrap::extrapToVertex(TrackParam* trackParam, double xVtx, double yVtx, double zVtx,
                                  double errXVtx, double errYVtx, bool correctForMCS, bool correctForEnergyLoss)
 {

--- a/Detectors/MUON/MCH/Workflow/src/TrackFinderOriginalSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackFinderOriginalSpec.cxx
@@ -41,6 +41,7 @@
 #include "MCHTracking/Cluster.h"
 #include "MCHTracking/Track.h"
 #include "MCHTracking/TrackFinderOriginal.h"
+#include "MCHTracking/TrackExtrap.h"
 
 namespace o2
 {
@@ -113,10 +114,9 @@ class TrackFinderTask
       mElapsedTime += tEnd - tStart;
 
       // fill the ouput messages
-      trackROFs.emplace_back(clusterROF.getBCData(), mchTracks.size(), tracks.size());
-      if (tracks.size() > 0) {
-        writeTracks(tracks, mchTracks, usedClusters);
-      }
+      int trackOffset(mchTracks.size());
+      writeTracks(tracks, mchTracks, usedClusters);
+      trackROFs.emplace_back(clusterROF.getBCData(), trackOffset, mchTracks.size() - trackOffset);
     }
   }
 
@@ -130,9 +130,16 @@ class TrackFinderTask
 
     for (const auto& track : tracks) {
 
+      TrackParam paramAtMID(track.last());
+      if (!TrackExtrap::extrapToMID(&paramAtMID)) {
+        LOG(WARNING) << "propagation to MID failed --> track discarded";
+        continue;
+      }
+
       const auto& param = track.first();
       mchTracks.emplace_back(param.getZ(), param.getParameters(), param.getCovariances(),
-                             param.getTrackChi2(), usedClusters.size(), track.getNClusters());
+                             param.getTrackChi2(), usedClusters.size(), track.getNClusters(),
+                             paramAtMID.getZ(), paramAtMID.getParameters(), paramAtMID.getCovariances());
 
       for (const auto& param : track) {
         usedClusters.emplace_back(param.getClusterPtr()->getClusterStruct());

--- a/Detectors/MUON/MCH/Workflow/src/TrackFinderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackFinderSpec.cxx
@@ -45,6 +45,7 @@
 #include "MCHTracking/Cluster.h"
 #include "MCHTracking/Track.h"
 #include "MCHTracking/TrackFinder.h"
+#include "MCHTracking/TrackExtrap.h"
 
 namespace o2
 {
@@ -130,8 +131,9 @@ class TrackFinderTask
       mElapsedTime += tEnd - tStart;
 
       // fill the ouput messages
-      trackROFs.emplace_back(clusterROF.getBCData(), mchTracks.size(), tracks.size());
+      int trackOffset(mchTracks.size());
       writeTracks(tracks, mchTracks, usedClusters);
+      trackROFs.emplace_back(clusterROF.getBCData(), trackOffset, mchTracks.size() - trackOffset);
     }
 
     LOGP(info, "Found {:3d} MCH tracks from {:4d} clusters in {:2d} ROFs",
@@ -148,9 +150,16 @@ class TrackFinderTask
 
     for (const auto& track : tracks) {
 
+      TrackParam paramAtMID(track.last());
+      if (!TrackExtrap::extrapToMID(&paramAtMID)) {
+        LOG(WARNING) << "propagation to MID failed --> track discarded";
+        continue;
+      }
+
       const auto& param = track.first();
       mchTracks.emplace_back(param.getZ(), param.getParameters(), param.getCovariances(),
-                             param.getTrackChi2(), usedClusters.size(), track.getNClusters());
+                             param.getTrackChi2(), usedClusters.size(), track.getNClusters(),
+                             paramAtMID.getZ(), paramAtMID.getParameters(), paramAtMID.getCovariances());
 
       for (const auto& param : track) {
         usedClusters.emplace_back(param.getClusterPtr()->getClusterStruct());

--- a/Detectors/MUON/MCH/Workflow/src/TrackFitterSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackFitterSpec.cxx
@@ -103,10 +103,18 @@ class TrackFitterTask
           continue;
         }
 
+        // propagate the parameters to the MID
+        TrackParam paramAtMID(track.last());
+        if (!TrackExtrap::extrapToMID(&paramAtMID)) {
+          LOG(ERROR) << "propagation to MID failed --> track discarded";
+          continue;
+        }
+
         // write the refitted track and attached clusters (same as those of the input track)
         const auto& param = track.first();
         tracksOut.emplace_back(param.getZ(), param.getParameters(), param.getCovariances(),
-                               param.getTrackChi2(), clustersOut.size(), track.getNClusters());
+                               param.getTrackChi2(), clustersOut.size(), track.getNClusters(),
+                               paramAtMID.getZ(), paramAtMID.getParameters(), paramAtMID.getCovariances());
         clustersOut.insert(clustersOut.end(), trackClusters.begin(), trackClusters.end());
       }
 


### PR DESCRIPTION
This is the first step toward matching MCH and MID tracks. It propagates the MCH track parameters and covariances at the last attached cluster to the first MID chamber, where the matching will be performed, and store them in the TrackMCH output object.