### PR TITLE
new/improved trd raw reader

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/HelperMethods.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/HelperMethods.h
@@ -77,7 +77,6 @@ struct HelperMethods {
   {
     return det % (constants::NSTACK * constants::NLAYER) / constants::NLAYER;
   }
-
   static int getLayer(int det)
   {
     return det % constants::NLAYER;

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
@@ -229,9 +229,9 @@ struct DigitHCHeader {
   // uint32_t:   00000000000000000000000000000000
   //
   union { // section 15.6.1 in tdp
-    uint32_t word0;
+    uint32_t word;
     struct {
-      uint32_t res0 : 2;
+      uint32_t res : 2;
       uint32_t side : 1;
       uint32_t stack : 3;
       uint32_t layer : 3;
@@ -242,27 +242,31 @@ struct DigitHCHeader {
       uint32_t version : 1;
     } __attribute__((__packed__));
   };
-
+};
+//The next hcheaders are all optional, there can be 8, we only have 3 for now.
+//They can all be distinguished by their res.
+struct DigitHCHeader1 {
   //             10987654321098765432109876543210
   // uint32_t:   00000000000000000000000000000000
   //
   union { //section 15.6.2 in tdp
-    uint32_t word1;
+    uint32_t word;
     struct {
-      uint32_t res1 : 2;
+      uint32_t res : 2;
       uint32_t ptrigcount : 4;
       uint32_t ptrigphase : 4;
       uint32_t bunchcrossing : 16;
       uint32_t numtimebins : 6;
     } __attribute__((__packed__));
   };
-#ifdef DIGITALHCOPTIONALHEADER
+};
+struct DigitHCHeader2 {
   //             10987654321098765432109876543210
   // uint32_t:   00000000000000000000000000000000
   union { //section 15.6.3 in tdp
-    uint32_t word2;
+    uint32_t word;
     struct {
-      uint32_t res2 : 6;
+      uint32_t res : 6;
       uint32_t dfilter : 6;
       uint32_t rfilter : 1;
       uint32_t nlfilter : 1;
@@ -272,17 +276,18 @@ struct DigitHCHeader {
       uint32_t pfilter : 6;
     } __attribute__((__packed__));
   };
+};
+struct DigitHCHeader3 {
   //             10987654321098765432109876543210
   // uint32_t:   00000000000000000000000000000000
   union { //section 15.6.4 in tdp
-    uint32_t word3;
+    uint32_t word;
     struct {
-      uint32_t res3 : 6;
+      uint32_t res : 6;
       uint32_t svnrver : 13; //readout program svn revision
       uint32_t svnver : 13;  //assember programm svn revision
     } __attribute__((__packed__));
   };
-#endif
 };
 
 struct DigitMCMHeader {
@@ -443,7 +448,8 @@ bool digitMCMHeaderSanityCheck(o2::trd::DigitMCMHeader* header);
 bool digitMCMADCMaskSanityCheck(o2::trd::DigitMCMADCMask& mask, int numberofbitsset);
 bool digitMCMWordSanityCheck(o2::trd::DigitMCMData* word, int adcchannel);
 void printDigitMCMHeader(o2::trd::DigitMCMHeader& header);
-void printDigitHCHeader(o2::trd::DigitHCHeader& header);
+int getDigitHCHeaderWordType(uint32_t word);
+void printDigitHCHeader(o2::trd::DigitHCHeader& header, uint32_t headers[3]);
 DigitMCMADCMask buildBlankADCMask();
 int getNumberofTracklets(o2::trd::TrackletMCMHeader& header);
 void setNumberOfTrackletsInHeader(o2::trd::TrackletMCMHeader& header, int numberoftracklets);

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawDataStats.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawDataStats.h
@@ -1,0 +1,130 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+// Cru raw data reader, this is the part that parses the raw data
+// it runs on the flp(pre compression) or on the epn(pre tracklet64 array generation)
+// it hands off blocks of cru pay load to the parsers.
+
+#ifndef O2_TRD_RAWDATASTATS
+#define O2_TRD_RAWDATASTATS
+
+#include <iostream>
+#include <string>
+#include <cstdint>
+#include <array>
+#include <vector>
+#include <bitset>
+#include <gsl/span>
+#include "DataFormatsTRD/Constants.h"
+
+namespace o2::trd
+{
+enum ParsingErrors { TRDParsingNoError,
+                     TRDParsingUnrecognisedVersion,
+                     TRDParsingBadDigt,
+                     TRDParsingBadTracklet,
+                     TRDParsingDigitEndMarkerWrongState,                // read a end marker but we were expecting something else due to
+                     TRDParsingDigitMCMHeaderSanityCheckFailure,        //essentially we did not see an MCM header see RawData.h for requirement
+                     TRDParsingDigitROBDecreasing,                      // sequential headers must have the same or increasing rob number
+                     TRDParsingDigitMCMNotIncreasing,                   // sequential headers must have increasing mcm number
+                     TRDParsingDigitADCMaskMismatch,                    // mask adc count does not match # of 1s in bitpattern
+                     TRDParsingDigitADCMaskAdvanceToEnd,                // in advancing to adcmask we have reached the end of the buffer
+                     TRDParsingDigitMCMHeaderBypassButStateMCMHeader,   // we are reading mcmadc data but the state is mcmheader
+                     TRDParsingDigitEndMarkerStateButReadingMCMADCData, // read the endmarker while expecting to read the mcmadcdata
+                     TRDParsingDigitADCChannel21,                       // ADCMask is zero but we are still on a digit.
+                     TRDParsingDigitADCChannelGT22,                     // error allocating digit, so digit channel has error value
+                     TRDParsingDigitGT10ADCs,                           // more than 10 adc data words seen
+                     TRDParsingDigitSanityCheck,                        // adc failed sanity check see RawData.cxx for faiulre reasons
+                     TRDParsingDigitExcessTimeBins,                     // ADC has more than 30 timebins (10 adc words)
+                     TRDParsingDigitParsingExitInWrongState,            // exiting parsing in the wrong state ... got to the end of the buffer in wrong state.
+                     TRDParsingDigitStackMisMatch,                      // mismatch between rdh and hcheader stack calculation/value
+                     TRDParsingDigitLayerMisMatch,                      // mismatch between rdh and hcheader stack calculation/value
+                     TRDParsingDigitSectorMisMatch,                     // mismatch between rdh and hcheader stack calculation/value
+                     TRDParsingTrackletCRUPaddingWhileParsingTracklets, // reading a padding word while expecting tracklet data
+                     TRDParsingTrackletBit11NotSetInTrackletHCHeader,   // bit 11 not set in hc header for tracklets.
+                     TRDParsingTrackletHCHeaderSanityCheckFailure,      // HCHeader sanity check failure, see RawData.cxx for reasons.
+                     TRDParsingTrackletMCMHeaderSanityCheckFailure,     // MCMHeader sanity check failure, see RawData.cxx for reasons.
+                     TRDParsingTrackletMCMHeaderButParsingMCMData,      // state is still MCMHeader but we are parsing MCMData
+                     TRDParsingTrackletStateMCMHeaderButParsingMCMData,
+                     TRDParsingTrackletTrackletCountGTThatDeclaredInMCMHeader, //mcmheader tracklet count does not match that in we have parsed.
+                     TRDParsingTrackletInvalidTrackletCount,                   // invalid tracklet count in header vs data
+                     TRDParsingTrackletPadRowIncreaseError,                    // subsequent padrow can not be less than previous one.
+                     TRDParsingTrackletColIncreaseError,                       // subsequent col can not be less than previous one
+                     TRDParsingTrackletNoTrackletEndMarker,                    // got to the end of the buffer with out finding a tracklet end marker.
+                     TRDParsingTrackletExitingNoTrackletEndMarker              // got to the end of the buffer exiting tracklet parsing with no tracklet end marker
+};
+
+//enumerations for the options, saves on having a long parameter list.
+enum OptionBits {
+  TRDByteSwapBit,
+  TRDVerboseBit,
+  TRDHeaderVerboseBit,
+  TRDDataVerboseBit,
+  TRDCompressedDataBit,
+  TRDFixDigitCorruptionBit,
+  TRDEnableTimeInfoBit,
+  TRDEnableStatsBit,
+  TRDIgnoreDigitHCHeaderBit,
+  TRDIgnoreTrackletHCHeaderBit,
+  TRDEnableRootOutputBit
+};
+
+class TRDDataCountersPerEvent
+{ //thisis on a per event basis
+ public:
+  //TODO this should go into a dpl message for catching by qc ?? I think.
+  uint64_t mTimeTaken;                        // time take to process an event (summed trackletparsing and digitparsing) parts not accounted for.
+  uint64_t mTimeTakenForDigits;               // time take to process tracklet data blocks [us].
+  uint64_t mTimeTakenForTracklets;            // time take to process digit data blocks [us].
+  uint64_t mDigitWordsRead;                   // digit words read in
+  uint64_t mDigitWordsSkipped;                // digit words skipped for various reasons.
+  uint64_t mTrackletWordsRead;                // tracklet words read in
+  uint64_t mTrackletWordsSkipped;             // tracklet words skipped for various reasons.
+  std::array<uint8_t, 1080> mLinkErrorFlag{}; //status of the error flags for this event, 8bit values from cru halfchamber header.
+};
+
+class TRDDataCountersPerTimeFrame
+{ //thisis on a per event basis
+ public:
+  std::array<uint32_t, 1080> mLinkNoData;                                   // Link had no data or was not present.
+  std::array<uint32_t, 1080> mLinkWords{};                                  //units of 256bits, read from the cru half chamber header
+  std::array<uint32_t, 1080> mLinkWordsRead{};                              // units of 32 bits the data words read before dumping or finishing
+  std::array<uint32_t, 1080> mLinkWordsDumped{};                            // units of 32 bits the data dumped due to some or other error
+  std::array<int64_t, o2::trd::constants::MAXMCMCOUNT> mLinkMCMsWithData{}; // and its corresponding volume of data.
+  std::array<uint32_t, constants::MAXMCMCOUNT> mMCMDigitCount{};
+  std::array<uint32_t, constants::MAXMCMCOUNT> mMCMTrackletCount{};
+  std::array<uint32_t, 30> mParsingErrors{};              // errors in parsing, indexed by enum above of ParsingErrors
+  std::array<uint32_t, 1080 * 30> mParsingErrorsByLink{}; // errors in parsing, indexed by enum above of ParsingErrors
+  uint64_t mTimeTaken;                                    // time taken to process the entire timeframe [ms].
+  uint64_t mTimeTakenForDigits;                           // time take to process tracklet data blocks [us].
+  uint64_t mTimeTakenForTracklets;                        // time take to process digit data blocks [us].
+  uint64_t mDigitsFound;                                  // digit found in the time frame.
+  uint64_t mTrackletsFound;                               // tracklets found in the time frame.
+  uint64_t mDigitWordsRead;                               // digit words read in.
+  uint64_t mDigitWordsSkipped;                            // digit words skipped for various reasons.
+  uint64_t mTrackletWordsRead;                            // tracklet words read in.
+  uint64_t mTrackletWordsSkipped;                         // tracklet words skipped for various reasons.
+  uint64_t mDataWordsRead;
+  uint64_t mDataWordsRejected;
+  //TRDDataCountersPerTimeFrame* operator=(TRDDataCountersPerTimeFrame *old){this=old;return *this;}
+};
+
+//TODO not sure this class is needed
+class TRDDataCountersRunning
+{                                                //those counters that keep counting
+  std::array<uint32_t, 1080> mLinkFreq{};        //units of 256bits "cru word"
+  std::array<bool, 1080> mLinkEmpty{};           // Link only has padding words only, probably not serious.
+  std::array<uint64_t, 65535> mDataFormatRead{}; // 7bits.7bits major.minor version read from HCHeader.
+};
+
+} // namespace o2::trd
+
+#endif

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CompressedRawReader.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CompressedRawReader.h
@@ -23,6 +23,7 @@
 #include <string>
 #include <cstdint>
 #include <array>
+#include <bitset>
 #include "Headers/RAWDataHeader.h"
 #include "Headers/RDHAny.h"
 #include "DetectorsRaw/RDHUtils.h"
@@ -31,6 +32,7 @@
 #include "DataFormatsTRD/Tracklet64.h"
 #include "DataFormatsTRD/TriggerRecord.h"
 #include "DataFormatsTRD/Digit.h"
+#include "DataFormatsTRD/RawDataStats.h"
 
 namespace o2
 {
@@ -71,12 +73,12 @@ class CompressedRawReader
   void setVerbosity(bool v) { mVerbose = v; };
   void setDataVerbosity(bool v) { mDataVerbose = v; };
   void setHeaderVerbosity(bool v) { mHeaderVerbose = v; };
-  void configure(bool byteswap, bool verbose, bool headerverbose, bool dataverbose)
+  void configure(std::bitset<16> options)
   {
-    mByteSwap = byteswap;
-    mVerbose = verbose;
-    mHeaderVerbose = headerverbose;
-    mDataVerbose = dataverbose;
+    mByteSwap = options[TRDByteSwapBit];
+    mVerbose = options[TRDVerboseBit];
+    mHeaderVerbose = options[TRDHeaderVerboseBit];
+    mDataVerbose = options[TRDDataVerboseBit];
   }
   std::vector<Tracklet64>& getTracklets() { return mEventTracklets; };
   std::vector<Digit>& getDigits() { return mEventDigits; };

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
@@ -26,12 +26,15 @@
 #include "Headers/RDHAny.h"
 #include "DetectorsRaw/RDHUtils.h"
 #include "DataFormatsTRD/RawData.h"
+#include "DataFormatsTRD/RawDataStats.h"
 #include "TRDReconstruction/DigitsParser.h"
 #include "TRDReconstruction/TrackletsParser.h"
 #include "DataFormatsTRD/Constants.h"
 #include "DataFormatsTRD/Digit.h"
 #include "CommonDataFormat/InteractionRecord.h"
 #include "TRDReconstruction/EventRecord.h"
+
+#include "TH2F.h"
 
 namespace o2::trd
 {
@@ -58,14 +61,18 @@ class CruRawReader
 
   void checkSummary();
   void resetCounters();
-  void configure(bool byteswap, bool fixdigitcorruption, int tracklethcheader, bool verbose, bool headerverbose, bool dataverbose)
+  void configure(int tracklethcheader, std::bitset<16> options)
   {
-    mByteSwap = byteswap;
-    mVerbose = verbose;
-    mHeaderVerbose = headerverbose;
-    mDataVerbose = dataverbose;
-    mFixDigitEndCorruption = fixdigitcorruption;
+    mByteSwap = options[TRDByteSwapBit];
+    mVerbose = options[TRDVerboseBit];
+    mHeaderVerbose = options[TRDHeaderVerboseBit];
+    mDataVerbose = options[TRDDataVerboseBit];
+    mFixDigitEndCorruption = options[TRDFixDigitCorruptionBit];
     mTrackletHCHeaderState = tracklethcheader;
+    mRootOutput = options[TRDEnableRootOutputBit];
+    mEnableTimeInfo = options[TRDEnableTimeInfoBit];
+    mEnableStats = options[TRDEnableStatsBit];
+    mOptions = options;
   }
   void setBlob(bool returnblob) { mReturnBlob = returnblob; }; //set class to produce blobs and not vectors. (compress vs pass through)`
   void setDataBuffer(const char* val)
@@ -100,6 +107,8 @@ class CruRawReader
   int sumDigitsFound() { return mEventRecords.sumDigits(); }
   int getWordsRead() { return mTotalDigitWordsRead; }
   int getWordsRejected() { return mTotalDigitWordsRejected; }
+
+  std::shared_ptr<EventStorage*> getEventStorage() { return std::make_shared<EventStorage*>(&mEventRecords); }
   void clearall()
   {
     mEventRecords.clear();
@@ -111,6 +120,38 @@ class CruRawReader
     mDigitsParser.clear();
   }
   void OutputHalfCruRawData();
+  // void setStats(o2::trd::TRDDataCountersPerTimeFrame* trdstats){mTimeFrameStats=trdstats;}
+  void setHistos(TH2F* h1, TH2F* h2, TH2F* h3)
+  {
+    hist1 = h1;
+    hist2 = h2;
+    hist3 = h3;
+  }; // a hack!
+  void setHistos1(TH2F* h1, TH2F* h2, TH2F* h3)
+  {
+    hist4 = h1;
+    hist5 = h2;
+    hist6 = h3;
+  }; // a hack!
+  void setHistos2(TH2F* h1, TH2F* h2)
+  {
+    hist7 = h1;
+    hist8 = h2;
+  }; // a hack!
+  void setTimeHistos(TH1F* timeframetime, TH1F* trackletparsingtime, TH1F* digitparsingtime,
+                     TH1F* crutime, TH1F* packagingtime, TH1F* versions, TH1F* versionsmajor,
+                     TH1F* parsingerrors)
+  {
+    mTimeFrameTime = timeframetime;
+    mTrackletTiming = trackletparsingtime;
+    mDigitTiming = digitparsingtime;
+    mCruTime = crutime;
+    mEventRecords.setHisto(packagingtime);
+    mDataVersions = versions;
+    mDataVersionsMajor = versionsmajor;
+    mParsingErrors = parsingerrors;
+    mTrackletsParser.setErrorHistos(parsingerrors);
+  };
 
  protected:
   bool processHBFs(int datasizealreadyread = 0, bool verbose = false);
@@ -118,6 +159,9 @@ class CruRawReader
   bool buildCRUPayLoad();
   int processHalfCRU(int cruhbfstartoffset);
   bool processCRULink();
+  int parseDigitHCHeader();
+  int checkDigitHCHeader();
+  int checkTrackletHCHeader();
   bool skipRDH();
 
   inline void rewind()
@@ -135,7 +179,10 @@ class CruRawReader
   bool mByteSwap{false};
   bool mFixDigitEndCorruption{false};
   int mTrackletHCHeaderState{0};
-
+  bool mRootOutput{0};
+  bool mEnableTimeInfo{0};
+  bool mEnableStats{0};
+  std::bitset<16> mOptions;
   const char* mDataBuffer = nullptr;
   static const uint32_t mMaxHBFBufferSize = o2::trd::constants::HBFBUFFERMAX;
   std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX> mHBFPayload; //this holds the O2 payload held with in the HBFs to pass to parsing.
@@ -165,11 +212,26 @@ class CruRawReader
 
   const o2::header::RDHAny* mDataRDH;
   HalfCRUHeader mCurrentHalfCRUHeader; // are we waiting for new header or currently parsing the payload of on
+  DigitHCHeader mDigitHCHeader;        // Digit HalfChamber header we are currently on.
+  DigitHCHeader1 mDigitHCHeader1;      // this and the next 2 are option are and variable in order, hence
+  DigitHCHeader2 mDigitHCHeader2;      // the individual seperation instead of an array.
+  DigitHCHeader3 mDigitHCHeader3;
+  TrackletHCHeader mTrackletHCHeader;  // Tracklet HalfChamber header we are currently on.
   uint16_t mCurrentLink;               // current link within the halfcru we are parsing 0-14
   uint16_t mCRUEndpoint;               // the upper or lower half of the currently parsed cru 0-14 or 15-29
   uint16_t mCRUID;
   uint16_t mHCID;
   TRDFeeID mFEEID; // current Fee ID working on
+  // the store of the 3 ways we can determine this information, link,rdh,halfchamber
+  std::array<int, 3> mDetector;
+  std::array<int, 3> mSector;
+  std::array<int, 3> mStack;
+  std::array<int, 3> mLayer;
+  std::array<int, 3> mSide;
+  std::array<int, 3> mEndPoint;
+  std::array<int, 3> mHalfChamberSide;
+  int mWhichData; // index used into the above arrays once decided on which source is "correct"
+  o2::InteractionRecord mIR;
   std::array<uint32_t, 15> mCurrentHalfCRULinkLengths;
   std::array<uint32_t, 15> mCurrentHalfCRULinkErrorFlags;
   uint32_t mCRUState; // the state of what we are expecting to read currently from the data stream, *not* what we have just read.
@@ -185,9 +247,12 @@ class CruRawReader
   uint64_t mDigitWordsRejected = 0;
   uint64_t mTotalDigitWordsRead = 0;
   uint64_t mTotalDigitWordsRejected = 0;
+  uint64_t mTrackletWordsRead = 0;
+  uint64_t mTrackletWordsRejected = 0;
+  uint64_t mTotalTrackletWordsRejected = 0;
+  uint64_t mTotalTrackletWordsRead = 0;
   //pointers to the data as we read them in, again no point in copying.
   HalfCRUHeader* mhalfcruheader;
-  o2::InteractionRecord mIR;
 
   bool checkerCheck();
   void checkerCheckRDH();
@@ -206,30 +271,17 @@ class CruRawReader
   uint32_t mErrorCounter;
 
   EventStorage mEventRecords; // store data range indexes into the above vectors.
+  EventRecord* mCurrentEvent; // the current event we are looking at, info extracted from cru half chamber header.
+
   bool mReturnBlob{0};        // whether to return blobs or vectors;
-  struct TRDDataCountersPerEvent_t { //thisis on a per event basis
-    //TODO this should go into a dpl message for catching by qc ?? I think.
-    std::array<uint32_t, 1080> mLinkWordCounts;    //units of 256bits "cru word"
-    std::array<uint32_t, 1080> mLinkPadWordCounts; // units of 32 bits the data pad word size.
-    std::array<uint32_t, 1080> mLinkFreq;          //units of 256bits "cru word"
-    std::array<uint8_t, 1080> mLinkErrorFlag;      //units of 256bits "cru word"
-    //from the above you can get the stats for supermodule and detector.
-    std::array<bool, 1080> LinkEmpty; // Link only has padding words only, probably not serious.
-    //maybe change this to actual traps ?? but it will get large.
-    std::array<uint32_t, 1080> mLinkTrackletPerTrap1; // incremented if a trap on this link has 1 tracklet
-    std::array<uint32_t, 1080> mLinkTrackletPerTrap2; // incremented if a trap on this link has 2 tracklet
-    std::array<uint32_t, 1080> mLinkTrackletPerTrap3; // incremented if a trap on this link has 3 tracklet
-    std::array<uint32_t, 1080> mLinkMCMsWithData;
-    std::array<uint16_t, 1080> MCMStatus;
-    std::array<uint16_t, constants::MAXMCMCOUNT> mMCMstats; // bit pattern for errors current event for a given mcm;
-    std::vector<uint32_t> mEmptyTraps;                      // MCM indexes of traps that are empty ?? list might better
-  } TRDStatCountersPerEvent;
+  o2::trd::TRDDataCountersRunning mStatCountersRunning;
 
-  struct TRDDataCountersRunning_t { //those counters that keep counting
-    //??
-  } TRDStatCountersRunning;
-
-  /** summary data **/
+  TH2F *hist1, *hist2, *hist3;                                      // a hack !
+  TH2F *hist4, *hist5, *hist6;                                      // a hack !
+  TH2F *hist7, *hist8;                                              // a hack !
+  TH1F *mTimeFrameTime, *mTrackletTiming, *mDigitTiming, *mCruTime; // a hack !
+  TH1F *mDataVersions, *mDataVersionsMajor;                         // a hack !
+  TH1F* mParsingErrors;                                             // a hack !
 };
 
 } // namespace o2::trd

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/EventRecord.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/EventRecord.h
@@ -14,10 +14,13 @@
 
 #include <iosfwd>
 #include "Rtypes.h"
+#include "TH2F.h"
 #include "CommonDataFormat/InteractionRecord.h"
 #include "CommonDataFormat/RangeReference.h"
 #include "FairLogger.h"
 #include "DataFormatsTRD/Tracklet64.h"
+#include "DataFormatsTRD/RawDataStats.h"
+#include "DataFormatsTRD/Digit.h"
 
 namespace o2::framework
 {
@@ -26,9 +29,6 @@ class ProcessingContext;
 
 namespace o2::trd
 {
-class Digit;
-class Tracklet64;
-class CompressedDigit;
 class TriggerRecord;
 
 /// \class EventRecord
@@ -41,7 +41,7 @@ class EventRecord
 
  public:
   EventRecord() = default;
-  EventRecord(const BCData& bunchcrossing) : mBCData(bunchcrossing)
+  EventRecord(BCData& bunchcrossing) : mBCData(bunchcrossing)
   {
     mTracklets.reserve(30);
     mDigits.reserve(20);
@@ -63,6 +63,7 @@ class EventRecord
   void addTracklet(Tracklet64& tracklet);
   void addTracklets(std::vector<Tracklet64>::iterator& start, std::vector<Tracklet64>::iterator& end);
   void addTracklets(std::vector<Tracklet64>& tracklets);
+  void popTracklets(int popcount);
   //void printStream(std::ostream& stream) const;
   void sortByHCID();
 
@@ -80,11 +81,12 @@ class EventRecord
   BCData mBCData;                       /// orbit and Bunch crossing data of the physics trigger
   std::vector<Digit> mDigits{};         /// digit data, for this event
   std::vector<Tracklet64> mTracklets{}; /// tracklet data, for this event
+  o2::trd::TRDDataCountersPerEvent mEventStats;
 };
 
 class EventStorage
 {
-  //
+  //store a timeframes events for later collating sending on as a message
  public:
   EventStorage() = default;
   ~EventStorage() = default;
@@ -98,6 +100,7 @@ class EventStorage
   void addTracklets(InteractionRecord& ir, std::vector<Tracklet64>::iterator& start, std::vector<Tracklet64>::iterator& end);
   void unpackData(std::vector<TriggerRecord>& triggers, std::vector<Tracklet64>& tracklets, std::vector<Digit>& digits);
   void sendData(o2::framework::ProcessingContext& pc, bool displaytracklets = false);
+  EventRecord& getEventRecord(InteractionRecord& ir);
   //this could replace by keeing a running total on addition TODO
   void sumTrackletsDigitsTriggers(uint64_t& tracklets, uint64_t& digits, uint64_t& triggers);
   int sumTracklets();
@@ -105,13 +108,18 @@ class EventStorage
   std::vector<Tracklet64>& getTracklets(InteractionRecord& ir);
   std::vector<Digit>& getDigits(InteractionRecord& ir);
   void printIR();
+  void setHisto(TH1F* packagetime) { mPackagingTime = packagetime; }
+  //TODO what would be nice is to write this out as a root tree event by event instead of using the sendData method where its all packaged together to then be unpackaged again.
+  TRDDataCountersPerTimeFrame mTFStats;
 
  private:
   std::vector<EventRecord> mEventRecords;
   //these 2 are hacks to be able to send bak a blank vector if interaction record is not found.
   std::vector<Tracklet64> mDummyTracklets;
   std::vector<Digit> mDummyDigits;
+  TH1F* mPackagingTime{nullptr};
 };
+
 std::ostream& operator<<(std::ostream& stream, const EventRecord& trg);
 
 } // namespace o2::trd

--- a/Detectors/TRD/reconstruction/src/CruRawReader.cxx
+++ b/Detectors/TRD/reconstruction/src/CruRawReader.cxx
@@ -143,9 +143,8 @@ bool CruRawReader::processHBFs(int datasizealreadyread, bool verbose)
     mFEEID.word = o2::raw::RDHUtils::getFEEID(rdh);       //TODO change this and just carry around the curreht RDH
     mCRUEndpoint = o2::raw::RDHUtils::getEndPointID(rdh); // the upper or lower half of the currently parsed cru 0-14 or 15-29
     mCRUID = o2::raw::RDHUtils::getCRUID(rdh);
+    mIR = o2::raw::RDHUtils::getTriggerIR(rdh);
     auto packetCount = o2::raw::RDHUtils::getPacketCounter(rdh);
-    o2::InteractionRecord a = o2::raw::RDHUtils::getTriggerIR(rdh);
-    mIR = a;
     mDataEndPointer = (const uint32_t*)((char*)rdh + offsetToNext);
     // copy the contents of the current rdh into the buffer to be parsed
     std::memcpy((char*)&mHBFPayload[0] + currentsaveddatacount, reinterpret_cast<const char*>(rdh) + headerSize, rdhpayload);
@@ -173,7 +172,7 @@ bool CruRawReader::processHBFs(int datasizealreadyread, bool verbose)
   mHBFoffset32 = 0;
 
   while ((mHBFoffset32 < ((mTotalHBFPayLoad) / 4))) { // the blank event of eeeeee at the end
-    if (mVerbose) {
+    if (mHeaderVerbose) {
       LOG(info) << "Looping over cruheaders in HBF, loop count " << counthalfcru << " current offset is" << mHBFoffset32 << " total payload is " << mTotalHBFPayLoad / 4 << "  raw :" << mTotalHBFPayLoad;
     }
     int halfcruprocess = processHalfCRU(mHBFoffset32);
@@ -207,11 +206,105 @@ bool CruRawReader::processHBFs(int datasizealreadyread, bool verbose)
   return true; //totaldataread;
 }
 
+int CruRawReader::checkTrackletHCHeader()
+{
+  // index 0 is rdh data, index 1 is ori calculated data
+  auto currentsector = mTrackletHCHeader.supermodule;
+  auto currentlayer = mTrackletHCHeader.layer;
+  auto currentstack = mTrackletHCHeader.stack;
+  auto currentside = mTrackletHCHeader.side;
+  if (!mOptions[TRDIgnoreTrackletHCHeaderBit]) { // we take half chamber header as authoritive
+    return 0;
+  }
+  return 0; // for now always ignore, something is wrong with it, yet to be determined, tdp and header dont match.  FIXME!
+}
+
+int CruRawReader::checkDigitHCHeader()
+{
+  // index 0 is rdh data, index 1 is ori calculated data
+  auto currentsector = mDigitHCHeader.supermodule;
+  auto currentlayer = mDigitHCHeader.layer;
+  auto currentstack = mDigitHCHeader.stack;
+  auto currentside = mDigitHCHeader.side;
+  //check rdh info vs half chamber header
+  if (!mOptions[TRDIgnoreDigitHCHeaderBit]) { // we take half chamber header as authoritive
+    // can use digithcheader for cross checking the sector/stack/layer
+    if (currentstack != mStack[0] || currentstack != mStack[1]) {
+      //stack mismatch
+      //count these
+      //mEventRecord.ErrorStats[TRDParsingDigitStackMismatch]++;
+    }
+    if (currentlayer != mLayer[0] || currentlayer != mLayer[1]) {
+      //layer mismatch
+      //count these
+      //mEventRecord.ErrorStats[TRDParsingDigitLayerMisMatch]++;
+    }
+    if (currentsector != mSector[0] || currentsector != mSector[1]) {
+      //sector mismatch, mDetector comes in from a construction via the feeid and ori.
+      //count these
+      //mEventRecord.ErrorStats[TRDParsingDigitSectorMisMatch]++;
+    }
+    mSector[2] = currentsector; //from hc header treating it as authoritative
+    mDetector[2] = mSector[2] * 2 + mDigitHCHeader.side;
+    mLayer[2] = currentlayer;
+    mSector[2] = currentsector;
+    return 2;
+  } else { // ignore the halfcahmber headers contents so use the rdh
+    //take mDetector, layer and stack from the rdh/cru, we have those already assigned on entry to here
+    return 0; // the index in mSector/mStack etc.
+  }
+}
+
+int CruRawReader::parseDigitHCHeader()
+{
+  //mHBFoffset is the current offset into the current buffer,
+  //
+  uint32_t dhcheader = mHBFPayload[mHBFoffset32++];
+  std::array<uint32_t, 4> headers{0};
+  if (mByteSwap) {
+    // byte swap if needed.
+    o2::trd::HelperMethods::swapByteOrder(dhcheader);
+  }
+  mDigitHCHeader.word = dhcheader;
+  int additionalHeaderWords = mDigitHCHeader.numberHCW;
+  if (additionalHeaderWords >= 3) {
+    LOG(error) << "Error parsing DigitHCHeader, too many additional words count=" << additionalHeaderWords;
+    printDigitHCHeader(mDigitHCHeader, &headers[0]);
+    return -1;
+  }
+  for (int headerwordcount = 0; headerwordcount < additionalHeaderWords; ++headerwordcount) {
+    headers[headerwordcount] = mHBFPayload[mHBFoffset32++];
+    switch (getDigitHCHeaderWordType(headers[headerwordcount])) {
+      case 1: // header header1;
+        mDigitHCHeader1.word = headers[headerwordcount];
+        if (mDigitHCHeader1.res != 0x1) {
+          LOG(error) << "Digit HC Header 1 reserved : " << std::hex << mDigitHCHeader1.res << " raw: 0x" << mDigitHCHeader1.word;
+        }
+        break;
+      case 2: // header header2;
+        mDigitHCHeader2.word = headers[headerwordcount];
+        if (mDigitHCHeader2.res != 0b110001) {
+          LOG(error) << "Digit HC Header 2 reserved : " << std::hex << mDigitHCHeader2.res << " raw: 0x" << mDigitHCHeader2.word;
+        }
+        break;
+      case 3: // header header3;
+        mDigitHCHeader3.word = headers[headerwordcount];
+        if (mDigitHCHeader3.res != 0b110101) {
+          LOG(error) << "Digit HC Header 3 reserved : " << std::hex << mDigitHCHeader3.res << " raw: 0x" << mDigitHCHeader3.word;
+        }
+        break;
+      default:
+        LOG(error) << "Error parsing DigitHCHeader at word:" << headerwordcount << " looking at 0x:" << std::hex << mHBFPayload[mHBFoffset32 - 1];
+    }
+  }
+  if (mHeaderVerbose) {
+    printDigitHCHeader(mDigitHCHeader, &headers[0]);
+  }
+  return 1;
+}
+
 int CruRawReader::processHalfCRU(int cruhbfstartoffset)
 {
-  if (mVerbose) {
-    LOG(info) << "************************ parsing HALFCRU starting at " << cruhbfstartoffset;
-  }
   //It will clean this code up *alot*
   // process a halfcru
   uint32_t currentlinkindex = 0;
@@ -222,9 +315,10 @@ int CruRawReader::processHalfCRU(int cruhbfstartoffset)
   uint32_t sumtrackletwords = 0;
   uint32_t sumdigitwords = 0;
   uint32_t sumlinklengths = 0;
-  int trackletwordsread = 0; // this will read up to the tracnklet end marker.
-  int mDigitWordsRead = 0;
-  int mDigitWordsRejected = 0;
+  mDigitWordsRead = 0;
+  mDigitWordsRejected = 0;
+  mTrackletWordsRead = 0;
+  mTrackletWordsRejected = 0;
   uint32_t cruwordsread = 9;
   //reject halfcru if it starts with padding words.
   //this should only hit that instance where the cru payload is a "blank event" of o2::trd::constants::CRUPADDING32
@@ -238,6 +332,7 @@ int CruRawReader::processHalfCRU(int cruhbfstartoffset)
     //empty payload
     return -1;
   }
+  auto crustart = std::chrono::high_resolution_clock::now();
   // well then read the halfcruheader.
   memcpy((char*)&mCurrentHalfCRUHeader, (void*)(&mHBFPayload[cruhbfstartoffset]), sizeof(mCurrentHalfCRUHeader)); //TODO remove the copy just use pointer dereferencing, doubt it will improve the speed much though.
 
@@ -248,18 +343,18 @@ int CruRawReader::processHalfCRU(int cruhbfstartoffset)
                                                decltype(mCurrentHalfCRULinkLengths)::value_type(0));
   mTotalHalfCRUDataLength = mTotalHalfCRUDataLength256 * 32; //convert to bytes.
   int mTotalHalfCRUDataLength32 = mTotalHalfCRUDataLength256 * 8; //convert to bytes.
-                                                                  //check for cru errors :
-                                                                  //  if (mHeaderVerbose) {
+  //check for cru errors :
+  //  if (mHeaderVerbose) {
   int linkerrorcounter = 0;
-  if (mHeaderVerbose) {
-    LOG(info) << "link errors";
-    for (auto& linkerror : mCurrentHalfCRULinkErrorFlags) {
-      if (linkerror != 0) {
+  for (auto& linkerror : mCurrentHalfCRULinkErrorFlags) {
+    if (linkerror != 0) {
+      if (mHeaderVerbose) {
         LOG(info) << "E link error FEEID:" << mFEEID.word << " CRUID:" << mCRUID << " Endpoint:" << mCRUEndpoint
                   << " on linkcount:" << linkerrorcounter++ << " errorval:0x" << std::hex << linkerror;
       }
     }
   }
+
   std::array<uint32_t, 1024>::iterator currentlinkstart = mHBFPayload.begin() + cruhbfstartoffset;
   if (mHeaderVerbose) { //TODO put the following if statement into a method to simplify reading
     OutputHalfCruRawData();
@@ -280,105 +375,189 @@ int CruRawReader::processHalfCRU(int cruhbfstartoffset)
   //FEEID has supermodule/layer/stack/side in it.
   //CRU has
   mHBFoffset32 += sizeof(mCurrentHalfCRUHeader) / 4;
+
+  //get eventrecord for event we are looking at
+  mIR.bc = mCurrentHalfCRUHeader.BunchCrossing; // correct mIR to have the physics trigger bunchcrossing *NOT* the heartbeat trigger bunch crossing.
+  InteractionRecord trdir(mIR);
+  mCurrentEvent = &mEventRecords.getEventRecord(trdir);
+
   linkstart = mHBFPayload.begin() + dataoffsetstart32;
   linkend = mHBFPayload.begin() + dataoffsetstart32;
   //loop over links
   for (currentlinkindex = 0; currentlinkindex < constants::NLINKSPERHALFCRU; currentlinkindex++) {
     auto linktimerstart = std::chrono::high_resolution_clock::now(); // measure total processing time
+    mSector[0] = mFEEID.supermodule;
+    mEndPoint[0] = mFEEID.endpoint;
+    mSide[0] = mFEEID.side; // side of detector A/C
+    //stack layer and side map to ori
+    // TODO !!! endpoint shoudl come from cruid, but cruid seems to always be zero ... TODO FIXME
+    int oriindex = currentlinkindex + constants::NLINKSPERHALFCRU * mEndPoint[0]; // endpoint denotes the pci side, upper or lower for the pair of 15 fibres.
+    FeeParam::unpackORI(oriindex, mSide[1], mStack[1], mLayer[1], mHalfChamberSide[1]);
+    //sadly not al the data is redundant, probably a good thing, so stack and layer and halfchamber side is derived from the ori.
+    mLayer[0] = mLayer[1];
+    mStack[0] = mStack[1];
+    mHalfChamberSide[0] = mHalfChamberSide[1];
+    mSector[1] = oriindex / 30;
+    mSide[1] = mSide[0];
+    mDetector[0] = mStack[0] * constants::NLAYER + mLayer[0] + mSector[0] * constants::NLAYER * constants::NSTACK;
+    mDetector[1] = mStack[1] * constants::NLAYER + mLayer[1] + mSector[1] * constants::NLAYER * constants::NSTACK;
+    int supermodule_half = mSector[0] * 2 + mHalfChamberSide[0]; // will just go with the rdh one here its only for the hack graphing purposes.
+    float stack_layer;
+    stack_layer = mStack[0] * constants::NLAYER + mLayer[0]; // similarly this is also only for graphing so just use the rdh ones for now.
+    if (mRootOutput) {
+      if (mCurrentHalfCRULinkErrorFlags[currentlinkindex] == 0) {
+        hist1->Fill(supermodule_half, stack_layer);
+      }
+      if (mCurrentHalfCRULinkErrorFlags[currentlinkindex] == 1) {
+        hist2->Fill(supermodule_half, stack_layer);
+      }
+      if (mCurrentHalfCRULinkErrorFlags[currentlinkindex] == 2) {
+        hist3->Fill(supermodule_half, stack_layer);
+      }
+      if (mCurrentHalfCRULinkErrorFlags[currentlinkindex] > 0) {
+        hist4->Fill(supermodule_half, stack_layer);
+      }
+      if (mCurrentHalfCRULinkLengths[currentlinkindex] > 0) {
+        hist5->Fill(supermodule_half, stack_layer);
+      }
+      if (mCurrentHalfCRULinkLengths[currentlinkindex] == 0) {
+        hist6->Fill(supermodule_half, stack_layer);
+      }
+    }
+    //mStatCountersPerEvent.mLinkErrorFlag[currentdetector] = mCurrentHalfCRULinkErrorFlags[currentlinkindex];
+
     currentlinksize = mCurrentHalfCRULinkLengths[currentlinkindex];
     currentlinksize32 = currentlinksize * 8; //x8 to go from 256 bits to 32 bit;
     linkstart = mHBFPayload.begin() + dataoffsetstart32 + linksizeAccum32;
     linkend = linkstart + currentlinksize32;
+    if (currentlinksize == 0) {
+      mEventRecords.mTFStats.mLinkNoData[oriindex]++;
+    }
     uint64_t linkzsum = 0;
     int dioffset = dataoffsetstart32 + linksizeAccum32;
     if (dioffset % 8 != 0) {
       LOG(error) << " we are not 256 bit aligned ... this should never happen";
     }
     if (mHeaderVerbose) {
-      LOG(info) << "Cru link :" << currentlinkindex << " raw dump before processing begin linkstart:" << std::hex << linkstart << " to " << linkend;
+      LOG(info) << "Cru link :" << currentlinkindex << " raw dump before processing begin linkstart:" << std::hex << linkstart << " to " << linkend << " mHBFoffset32=" << std::dec << mHBFoffset32 << " and distance from start is : " << std::distance(mHBFPayload.begin(), linkstart);
       for (int dumpoffset = dataoffsetstart32 + linksizeAccum32; dumpoffset < dataoffsetstart32 + linksizeAccum32 + currentlinksize32; dumpoffset += 8) {
         LOGP(info, "0x{0:06x} :: {1:08x} {2:08x}  {3:08x} {4:08x} {5:08x} {6:08x} {7:08x} {8:08x} ", dumpoffset, HelperMethods::swapByteOrderreturn(mHBFPayload[dumpoffset]), HelperMethods::swapByteOrderreturn(mHBFPayload[dumpoffset + 1]), HelperMethods::swapByteOrderreturn(mHBFPayload[dumpoffset + 2]), HelperMethods::swapByteOrderreturn(mHBFPayload[dumpoffset + 3]), HelperMethods::swapByteOrderreturn(mHBFPayload[dumpoffset + 4]), HelperMethods::swapByteOrderreturn(mHBFPayload[dumpoffset + 5]), HelperMethods::swapByteOrderreturn(mHBFPayload[dumpoffset + 6]), HelperMethods::swapByteOrderreturn(mHBFPayload[dumpoffset + 7]));
       }
-      LOG(info) << "Cru link :" << currentlinkindex << " raw dump before processing end";
     }
     linksizeAccum32 += currentlinksize32;
-    int supermodule = mFEEID.supermodule;
-    int endpoint = mFEEID.endpoint;
-    int side = mFEEID.side;
-    //stack layer and side map to ori
-    int stack, layer, halfchamberside;
-    int oriindex = currentlinkindex + constants::NLINKSPERHALFCRU * endpoint; // endpoint denotes the pci side, upper or lower for the pair of 15 fibres.
-    FeeParam::unpackORI(oriindex, side, stack, layer, halfchamberside);
-    int currentdetector = stack * constants::NLAYER + layer + supermodule * constants::NLAYER * constants::NSTACK;
     if (mDataVerbose) {
-      LOG(info) << "******* LINK # " << currentlinkindex << " and  starting at " << mHBFoffset32 << " unpackORI(" << oriindex << "," << side << "," << stack << "," << layer << "," << halfchamberside << ") and an FEEID:" << std::hex << mFEEID.word << " det:" << std::dec << currentdetector;
-      LOG(info) << "******* LINK # " << currentlinkindex << " an FEEID:" << std::hex << mFEEID.word << " det:" << std::dec << currentdetector << " Error Flags : " << mCurrentHalfCRULinkErrorFlags[currentlinkindex];
+      LOG(info) << "******* LINK # " << currentlinkindex << " and  starting at " << mHBFoffset32 << " unpackORI(" << oriindex << "," << mSide[1] << "," << mStack[1] << "," << mLayer[1] << "," << mHalfChamberSide[1] << ") and an FEEID:" << std::hex << mFEEID.word << " det:" << std::dec << mDetector[1];
+      LOG(info) << "******* LINK # " << currentlinkindex << " an FEEID:" << std::hex << mFEEID.word << " det:" << std::dec << mDetector[1] << " Error Flags : " << mCurrentHalfCRULinkErrorFlags[currentlinkindex];
     }
     if (linkstart != linkend) { // if link is not empty
       bool cleardigits = false; //linkstart and linkend already have the multiple cruheaderoffsets built in
-      trackletwordsread = mTrackletsParser.Parse(&mHBFPayload, linkstart, linkend, mFEEID, halfchamberside, currentdetector, stack, layer, cleardigits, mByteSwap, mTrackletHCHeaderState, mVerbose, mHeaderVerbose, mDataVerbose); // this will read up to the tracklet end marker.
-      if (mVerbose) {
-        LOG(info) << "trackletwordsread:" << trackletwordsread << "  mem copy with offset of : " << cruhbfstartoffset << " parsing with linkstart: " << linkstart << " ending at : " << linkend;
-      }
-      linkstart += trackletwordsread;
-      //now we have a tracklethcheader and a digithcheader.
-      mHBFoffset32 += trackletwordsread;
-      mTotalTrackletsFound += mTrackletsParser.getTrackletsFound();
-      //now read the digit half chamber header
-      DigitHCHeader digitHCHeader;
-      uint32_t dhcheader0 = mHBFPayload[mHBFoffset32++];
-      uint32_t dhcheader1 = mHBFPayload[mHBFoffset32++];
-      if (mByteSwap) {
-        // byte swap if needed.
-        o2::trd::HelperMethods::swapByteOrder(dhcheader0);
-        o2::trd::HelperMethods::swapByteOrder(dhcheader1);
-      }
-      digitHCHeader.word0 = dhcheader0;
-      digitHCHeader.word1 = dhcheader1;
+      auto trackletparsingstart = std::chrono::high_resolution_clock::now();
       if (mHeaderVerbose) {
-        LOG(info) << "*** HCHHeader : 0x" << std::hex << digitHCHeader.word0 << " 0x" << digitHCHeader.word1;
-        printDigitHCHeader(digitHCHeader);
+        LOG(info) << "*** Tracklet Parser : starting at " << std::hex << linkstart << " at hbfoffset: " << std::dec << mHBFoffset32;
       }
-      if (digitHCHeader.word0 == 0x0 || digitHCHeader.word1 == 0x0) {
-        LOG(warn) << "Missing DigitHCHeader, read digit end marker of zeros";
-        printDigitHCHeader(digitHCHeader);
+      // for now we are using 0 i.e. from rdh FIXME figure out which is authoritative between rdh and ori tracklethcheader if we have it enabled.
+      mTrackletWordsRead = mTrackletsParser.Parse(&mHBFPayload, linkstart, linkend, mFEEID, mHalfChamberSide[0], mDetector[0], mStack[0], mLayer[0], mCurrentEvent, mOptions, cleardigits, mTrackletHCHeaderState); // this will read up to the tracklet end marker.
+      mTrackletWordsRejected = mTrackletsParser.getDataWordsDumped();
+      std::chrono::duration<double, std::micro> trackletparsingtime = std::chrono::high_resolution_clock::now() - trackletparsingstart;
+      if (mRootOutput) {
+        mTrackletTiming->Fill((int)std::chrono::duration_cast<std::chrono::microseconds>(trackletparsingtime).count());
       }
-      //move over the DigitHCHeader mHBFoffset32 has already been moved in the reading.
-      linkstart += 2;
-      if (digitHCHeader.major == 0x47) {
+      if (mVerbose) {
+        LOG(info) << "trackletwordsread:" << mTrackletWordsRead << "  mem copy with offset of : " << cruhbfstartoffset << " parsing with linkstart: " << linkstart << " ending at : " << linkend;
+      }
+      linkstart += mTrackletWordsRead + mTrackletWordsRejected;
+      //now we have a tracklethcheader and a digithcheader.
+      mHBFoffset32 += mTrackletWordsRead + mTrackletWordsRejected;
+      mTotalTrackletsFound += mTrackletsParser.getTrackletsFound();
+      mTotalTrackletWordsRejected += mTrackletWordsRejected;
+      mTotalTrackletWordsRead += mTrackletWordsRead;
+      if (mHeaderVerbose) {
+        LOG(info) << "*** Tracklet Parser : trackletwordsread:" << mTrackletWordsRead << " ending " << std::hex << linkstart << " at hbfoffset: " << std::dec << mHBFoffset32;
+      }
+
+      // check if we are now at the end of the data due to bugs, i.e. if trackletparsing read padding words.
+      if (linkstart != linkend) {
+        // linkstart advanced all the way to the end due to trackletparser parsing crupadding words (known bug or feature )
+        auto hfboffsetbeforehcparse = mHBFoffset32;
+        //now read the digit half chamber header
+        auto hcparse = parseDigitHCHeader();
+        mWhichData = checkDigitHCHeader();
+        //move over the DigitHCHeader mHBFoffset32 has already been moved in the reading.
+        if (mHBFoffset32 - hfboffsetbeforehcparse != 1 + mDigitHCHeader.numberHCW) {
+          LOG(error) << "Seems data offset is out of sync with number of HC Headers words";
+        }
+        if (hcparse == -1) {
+          LOG(warn) << "Parsing Digit HCHeader returned a -1";
+        } else {
+          linkstart += 1 + mDigitHCHeader.numberHCW;
+        }
+
+      } else {
+        //LOG(info) << "by passing HCHeader due to tracklets already seeing crupadding";
+        //TODO replace with histogram increment
+      }
+      if (mRootOutput) {
+        mDataVersions->Fill((mDigitHCHeader.major << 7) + mDigitHCHeader.minor);
+        mDataVersionsMajor->Fill(mDigitHCHeader.major);
+      }
+      if (mDigitHCHeader.major == 0x47) {
         // config event so ignore for now and bail out of parsing.
         LOG(warn) << " HCHeader major version is 0x47 bailing out of parsing this as its a config event";
         //advance data pointers to the end;
         linkstart = linkend;
-        mHBFoffset32 = dataoffsetstart32 + currentlinksize; // go to the end of the link
+        //mHBFoffset32 = std::distance(mHBFPayload.begin(),linkend);//dataoffsetstart32 + currentlinksize; // go to the end of the link
+        mHBFoffset32 = std::distance(mHBFPayload.begin(), linkend); //currentlinksize-mTrackletWordsRead-sizeof(digitHCHeader)/4; // advance to the end of the link
+        mTotalDigitWordsRejected += std::distance(linkstart + mTrackletWordsRead + sizeof(DigitHCHeader) / 4, linkend);
       } else {
-        mDigitWordsRead = 0;
-        //linkstart and linkend already have the multiple cruheaderoffsets built in
-        mDigitWordsRead = mDigitsParser.Parse(&mHBFPayload, linkstart, linkend, currentdetector, stack, layer, digitHCHeader, mFEEID, currentlinkindex, cleardigits, mByteSwap, mVerbose, mHeaderVerbose, mDataVerbose);
-        mDigitWordsRejected = mDigitsParser.getDumpedDataCount();
-        if (mDigitsParser.getDumpedDataCount() != 0) {
-          LOG(info) << "FEEID: " << mFEEID.word << " LINK #" << oriindex << " bad datacount:" << mDigitsParser.getDataWordsParsed() << "::" << mDigitsParser.getDumpedDataCount();
-        } else {
-          LOG(info) << "FEEID: " << mFEEID.word << " LINK #" << oriindex << " good datacount:" << mDigitsParser.getDataWordsParsed() << "::" << mDigitsParser.getDumpedDataCount();
-        }
-        if (mDigitWordsRead != std::distance(linkstart, linkend)) {
-          //we have the data corruption problem of a pile of stuff at the end of a link, jump over it.
-          if (mFixDigitEndCorruption) {
-            mDigitWordsRead = std::distance(linkstart, linkend);
-          } else {
-            LOG(warn) << "read digits but data still left on the link digitwordsread:" << mDigitWordsRead << " and link length:" << std::distance(linkstart, linkend);
+        if (mDigitHCHeader.major == 0x21 || mDigitHCHeader.major == 0x32) {
+          mDigitWordsRead = 0;
+          auto digitsparsingstart = std::chrono::high_resolution_clock::now();
+          //linkstart and linkend already have the multiple cruheaderoffsets built in
+          mDigitWordsRead = mDigitsParser.Parse(&mHBFPayload, linkstart, linkend, mDetector[mWhichData], mStack[mWhichData], mLayer[mWhichData], mSide[mWhichData], mDigitHCHeader, mFEEID, currentlinkindex, mCurrentEvent, mOptions, cleardigits);
+          std::chrono::duration<double, std::micro> digitsparsingtime = std::chrono::high_resolution_clock::now() - trackletparsingstart;
+          if (mRootOutput) {
+            mDigitTiming->Fill((int)std::chrono::duration_cast<std::chrono::microseconds>(digitsparsingtime).count());
           }
+          mDigitWordsRejected = mDigitsParser.getDumpedDataCount();
+          if (mHeaderVerbose) {
+            if (mDigitsParser.getDumpedDataCount() != 0) {
+              LOG(info) << "FEEID: " << mFEEID.word << " LINK #" << oriindex << " bad datacount:" << mDigitsParser.getDataWordsParsed() << "::" << mDigitsParser.getDumpedDataCount();
+            } else {
+              LOG(info) << "FEEID: " << mFEEID.word << " LINK #" << oriindex << " good datacount:" << mDigitsParser.getDataWordsParsed() << "::" << mDigitsParser.getDumpedDataCount();
+            }
+          }
+          if (mDigitWordsRead != std::distance(linkstart, linkend)) {
+            //we have the data corruption problem of a pile of stuff at the end of a link, jump over it.
+            if (mFixDigitEndCorruption) {
+              mDigitWordsRead = std::distance(linkstart, linkend);
+            } else {
+              LOG(warn) << "read digits but data still left on the link digitwordsread:" << mDigitWordsRead << " and link length:" << std::distance(linkstart, linkend);
+            }
+          }
+          mTotalDigitsFound += mDigitsParser.getDigitsFound();
+          if (mVerbose) {
+            LOG(info) << "mDigitWordsRead : " << mDigitWordsRead << " mem copy with offset of : " << cruhbfstartoffset << " parsing digits with linkstart: " << linkstart << " ending at : " << linkend;
+          }
+          mHBFoffset32 += mDigitWordsRead + mDigitWordsRejected; // all 3 in 32bit units
+          mTotalDigitWordsRead += mDigitWordsRead;
+          mTotalDigitWordsRejected += mDigitWordsRejected;
+        } else {
+          LOG(warn) << "Digit format not configured ! major.minor in hex : " << std::hex << mDigitHCHeader.major << "." << mDigitHCHeader.minor;
+          linkstart = linkend;
+          mHBFoffset32 = std::distance(mHBFPayload.begin(), linkend); //currentlinksize-mTrackletWordsRead-sizeof(digitHCHeader)/4; // advance to the end of the link
+          mTotalDigitWordsRejected += std::distance(linkstart + mTrackletWordsRead + sizeof(DigitHCHeader) / 4, linkend);
         }
-        mTotalDigitsFound += mDigitsParser.getDigitsFound();
-        if (mVerbose) {
-          LOG(info) << "mDigitWordsRead : " << mDigitWordsRead << " mem copy with offset of : " << cruhbfstartoffset << " parsing digits with linkstart: " << linkstart << " ending at : " << linkend;
+      }
+      sumlinklengths += mCurrentHalfCRULinkLengths[currentlinkindex];
+      sumtrackletwords += mTrackletWordsRead;
+      sumdigitwords += mDigitWordsRead;
+
+      if (mDigitWordsRejected > 0) {
+        if (mRootOutput) {
+          hist7->Fill(supermodule_half, stack_layer);
         }
-        sumlinklengths += mCurrentHalfCRULinkLengths[currentlinkindex];
-        sumtrackletwords += trackletwordsread;
-        sumdigitwords += mDigitWordsRead;
-        mHBFoffset32 += mDigitWordsRead + mDigitWordsRejected; // all 3 in 32bit units
-        mTotalDigitWordsRead = mDigitWordsRead;
-        mTotalDigitWordsRejected = mDigitWordsRejected;
+      } else if (mRootOutput) {
+        hist8->Fill(supermodule_half, stack_layer);
       }
     } else {
       if (mVerbose) {
@@ -390,22 +569,21 @@ int CruRawReader::processHalfCRU(int cruhbfstartoffset)
   //digits and tracklets are sitting inside the parsing classes.
   //extract the vectors and copy them to tracklets and digits here, building the indexing(triggerrecords)
   //as this is for a single cru half chamber header all the tracklets and digits are for the same trigger defined by the bc and orbit in the rdh which we hold in mIR
-  mIR.bc = mCurrentHalfCRUHeader.BunchCrossing; // correct mIR to have the physics trigger bunchcrossing *NOT* the heartbeat trigger bunch crossing.
 
-  mEventRecords.addTracklets(mIR, mTrackletsParser.getTracklets());
   if (mVerbose) {
     LOG(info) << "inserting tracklets from parser of size : " << mTrackletsParser.getTracklets().size() << " mEventRecordsTracklets is now :" << mEventRecords.sumTracklets();
   }
-  mTrackletsParser.clear();
-  mEventRecords.addDigits(mIR, std::begin(mDigitsParser.getDigits()), std::end(mDigitsParser.getDigits()));
   if (mVerbose) {
     LOG(info) << "inserting digits from parser of size : " << mDigitsParser.getDigits().size();
   }
-  mDigitsParser.clear();
   if (mVerbose) {
     LOG(info) << "Event digits after eventi # : " << mEventRecords.sumDigits() << " having added : via sum=" << mDigitsParser.getDigits().size() << " digitsfound is " << mDigitsParser.getDigitsFound();
   }
   int lasttrigger = 0, lastdigit = 0, lasttracklet = 0;
+  std::chrono::duration<double, std::micro> cruparsingtime = std::chrono::high_resolution_clock::now() - crustart;
+  if (mRootOutput) {
+    mCruTime->Fill((int)std::chrono::duration_cast<std::chrono::microseconds>(cruparsingtime).count());
+  }
 
   //if we get here all is ok.
   return 1;
@@ -433,7 +611,7 @@ bool CruRawReader::processCRULink()
 
 void CruRawReader::resetCounters()
 {
-  TRDStatCountersPerEvent.mLinkErrorFlag.fill(0);
+  //mStatCountersPerEvent.mLinkErrorFlag.fill(0);
   mEventCounter = 0;
   mFatalCounter = 0;
   mErrorCounter = 0;
@@ -453,8 +631,10 @@ bool CruRawReader::run()
   uint32_t dowhilecount = 0;
   uint64_t totaldataread = 0;
   rewind();
-  uint64_t mTotalDigitWordsRead = 0;
-  uint64_t mTotalDigitWordsRejected = 0;
+  mTotalDigitWordsRead = 0;
+  mTotalDigitWordsRejected = 0;
+  mTotalTrackletWordsRead = 0;
+  mTotalTrackletWordsRejected = 0;
   uint32_t* bufferptr;
   bufferptr = (uint32_t*)mDataBuffer;
   do {

--- a/Detectors/TRD/reconstruction/src/DataReader.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReader.cxx
@@ -90,6 +90,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   binaryoptions[o2::trd::TRDIgnoreDigitHCHeaderBit] = cfgc.options().get<bool>("ignore-digithcheader");
   binaryoptions[o2::trd::TRDIgnoreTrackletHCHeaderBit] = cfgc.options().get<bool>("ignore-tracklethcheader");
   binaryoptions[o2::trd::TRDEnableRootOutputBit] = cfgc.options().get<bool>("enable-root-output");
+  binaryoptions[o2::trd::TRDByteSwapBit] = cfgc.options().get<bool>("trd-datareader-enablebyteswapdata");
 
   AlgorithmSpec algoSpec;
   algoSpec = AlgorithmSpec{adaptFromTask<o2::trd::DataReaderTask>(tracklethcheader, binaryoptions)};

--- a/Detectors/TRD/reconstruction/src/DataReader.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReader.cxx
@@ -24,6 +24,7 @@
 #include "DetectorsRaw/RDHUtils.h"
 #include "TRDWorkflowIO/TRDTrackletWriterSpec.h"
 #include "TRDWorkflowIO/TRDDigitWriterSpec.h"
+#include "DataFormatsTRD/RawDataStats.h"
 
 // add workflow options, note that customization needs to be declared before
 // including Framework/runDataProcessing
@@ -38,7 +39,11 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"trd-datareader-compresseddata", VariantType::Bool, false, {"The incoming data is compressed or not"}},
     {"ignore-dist-stf", VariantType::Bool, false, {"do not subscribe to FLP/DISTSUBTIMEFRAME/0 message (no lost TF recovery)"}},
     {"trd-datareader-fixdigitcorruptdata", VariantType::Bool, false, {"Fix the erroneous data at the end of digits"}},
+    {"enable-timing", VariantType::Bool, false, {"enable the timing of tracklet, digit, timeframe, cru processing"}},
+    {"enable-stats", VariantType::Bool, false, {"enable the reader stats"}},
     {"enable-root-output", VariantType::Bool, false, {"Write the data to file"}},
+    {"ignore-tracklethcheader", VariantType::Bool, false, {"Ignore the tracklethalf chamber header for cross referencing"}},
+    {"ignore-digithcheader", VariantType::Bool, false, {"Ignore the digithalf chamber header for cross referencing, take rdh/cru as authorative."}},
     {"tracklethcheader", VariantType::Int, 0, {"Status of TrackletHalfChamberHeader 0 off always, 1 iff tracklet data, 2 on always"}},
     {"trd-datareader-enablebyteswapdata", VariantType::Bool, false, {"byteswap the incoming data, raw data needs it and simulation does not."}}};
 
@@ -65,14 +70,29 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   auto askSTFDist = !cfgc.options().get<bool>("ignore-dist-stf");
   auto fixdigitcorruption = cfgc.options().get<bool>("trd-datareader-fixdigitcorruptdata");
   auto tracklethcheader = cfgc.options().get<int>("tracklethcheader");
+  auto enabletimeinfo = cfgc.options().get<bool>("enable-timing");
+  auto enablestats = cfgc.options().get<bool>("enable-stats");
+
   std::vector<OutputSpec> outputs;
   outputs.emplace_back("TRD", "TRACKLETS", 0, Lifetime::Timeframe);
   outputs.emplace_back("TRD", "DIGITS", 0, Lifetime::Timeframe);
   outputs.emplace_back("TRD", "TRKTRGRD", 0, Lifetime::Timeframe);
   //outputs.emplace_back("TRD", "FLPSTAT", 0, Lifetime::Timeframe);
-  LOG(info) << "enablebyteswap :" << byteswap;
+  //
+  std::bitset<16> binaryoptions;
+  binaryoptions[o2::trd::TRDVerboseBit] = cfgc.options().get<bool>("trd-datareader-verbose");
+  binaryoptions[o2::trd::TRDHeaderVerboseBit] = cfgc.options().get<bool>("trd-datareader-headerverbose");
+  binaryoptions[o2::trd::TRDDataVerboseBit] = cfgc.options().get<bool>("trd-datareader-dataverbose");
+  binaryoptions[o2::trd::TRDCompressedDataBit] = cfgc.options().get<bool>("trd-datareader-compresseddata");
+  binaryoptions[o2::trd::TRDFixDigitCorruptionBit] = cfgc.options().get<bool>("trd-datareader-fixdigitcorruptdata");
+  binaryoptions[o2::trd::TRDEnableTimeInfoBit] = cfgc.options().get<bool>("enable-timing");
+  binaryoptions[o2::trd::TRDEnableStatsBit] = cfgc.options().get<bool>("enable-stats");
+  binaryoptions[o2::trd::TRDIgnoreDigitHCHeaderBit] = cfgc.options().get<bool>("ignore-digithcheader");
+  binaryoptions[o2::trd::TRDIgnoreTrackletHCHeaderBit] = cfgc.options().get<bool>("ignore-tracklethcheader");
+  binaryoptions[o2::trd::TRDEnableRootOutputBit] = cfgc.options().get<bool>("enable-root-output");
+
   AlgorithmSpec algoSpec;
-  algoSpec = AlgorithmSpec{adaptFromTask<o2::trd::DataReaderTask>(compresseddata, byteswap, fixdigitcorruption, tracklethcheader, verbose, headerverbose, dataverbose)};
+  algoSpec = AlgorithmSpec{adaptFromTask<o2::trd::DataReaderTask>(tracklethcheader, binaryoptions)};
 
   WorkflowSpec workflow;
 
@@ -96,7 +116,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     Options{}});
 
   if (cfgc.options().get<bool>("enable-root-output")) {
-    workflow.emplace_back(o2::trd::getTRDDigitWriterSpec(false, true));
+    workflow.emplace_back(o2::trd::getTRDDigitWriterSpec(false, false));
     workflow.emplace_back(o2::trd::getTRDTrackletWriterSpec(false));
   }
 

--- a/Detectors/TRD/reconstruction/src/DataReaderTask.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReaderTask.cxx
@@ -26,12 +26,54 @@
 #include "DataFormatsTRD/Constants.h"
 
 #include <fairmq/FairMQDevice.h>
+#include <TH3F.h>
+#include "TH2F.h"
+#include "TFile.h"
 
 //using namespace o2::framework;
 
 namespace o2::trd
 {
 
+void DataReaderTask::setParsingErrorLabels()
+{
+
+  ///////////////////////////////////////////////////////////////////
+  mParsingErrors->GetXaxis()->SetBinLabel(TRDParsingNoError, "TRDParsingNoError");
+  mParsingErrors->GetXaxis()->SetBinLabel(TRDParsingUnrecognisedVersion, "TRDParsingUnrecognisedVersion");
+  mParsingErrors->GetXaxis()->SetBinLabel(TRDParsingBadDigt, "TRDParsingBadDigt");
+  mParsingErrors->GetXaxis()->SetBinLabel(TRDParsingBadTracklet, "TRDParsingBadTracklet");
+  mParsingErrors->GetXaxis()->SetBinLabel(TRDParsingDigitEndMarkerWrongState, "TRDParsingDigitEndMarkerWrongState");
+  mParsingErrors->GetXaxis()->SetBinLabel(TRDParsingDigitMCMHeaderSanityCheckFailure, "TRDParsingDigitMCMHeaderSanityCheckFailure");
+  mParsingErrors->GetXaxis()->SetBinLabel(TRDParsingDigitROBDecreasing, "TRDParsingDigitROBDecreasing");
+  mParsingErrors->GetXaxis()->SetBinLabel(TRDParsingDigitMCMNotIncreasing, "TRDParsingDigitMCMNotIncreasing");
+  mParsingErrors->GetXaxis()->SetBinLabel(TRDParsingDigitADCMaskMismatch, "TRDParsingDigitADCMaskMismatch");
+  mParsingErrors->GetXaxis()->SetBinLabel(TRDParsingDigitADCMaskAdvanceToEnd, "TRDParsingDigitADCMaskAdvanceToEnd");
+  mParsingErrors->GetXaxis()->SetBinLabel(TRDParsingDigitMCMHeaderBypassButStateMCMHeader, "TRDParsingDigitMCMHeaderBypassButStateMCMHeader");
+  mParsingErrors->GetXaxis()->SetBinLabel(TRDParsingDigitEndMarkerStateButReadingMCMADCData, "TRDParsingDigitEndMarkerStateButReadingMCMADCData");
+  /*                       TRDParsingDigitADCChannel21,                     
+                           TRDParsingDigitADCChannelGT22,                  
+                           TRDParsingDigitGT10ADCs,                      
+                           TRDParsingDigitSanityCheck,                  
+                           TRDParsingDigitExcessTimeBins,              
+                           TRDParsingDigitParsingExitInWrongState,    
+                           TRDParsingDigitStackMisMatch,             
+                           TRDParsingDigitLayerMisMatch,            
+                           TRDParsingDigitSectorMisMatch,         
+                           TRDParsingTrackletCRUPaddingWhileParsingTracklets, 
+                           TRDParsingTrackletBit11NotSetInTrackletHCHeader,  
+                           TRDParsingTrackletHCHeaderSanityCheckFailure,    
+                           TRDParsingTrackletMCMHeaderSanityCheckFailure,  
+                           TRDParsingTrackletMCMHeaderButParsingMCMData,  
+                           TRDParsingTrackletStateMCMHeaderButParsingMCMData,
+                           TRDParsingTrackletTrackletCountGTThatDeclaredInMCMHeader, 
+                           TRDParsingTrackletInvalidTrackletCount,                  
+                           TRDParsingTrackletPadRowIncreaseError,                  
+                           TRDParsingTrackletColIncreaseError,                    
+                           TRDParsingTrackletNoTrackletEndMarker,                
+                           TRDParsingTrackletExitingNoTrackletEndMarker         
+                           */
+}
 void DataReaderTask::init(InitContext& ic)
 {
   LOG(INFO) << "o2::trd::DataReadTask init";
@@ -42,6 +84,136 @@ void DataReaderTask::init(InitContext& ic)
 
   ic.services().get<CallbackService>().set(CallbackService::Id::Stop, finishFunction);
   mDataDesc = "RAWDATA";
+
+  if (mRootOutput) {
+    mRootFile = new TFile("histos.root", "recreate");
+
+    //lets hack this for some graphs
+    LinkError = new TH2F("linkerrors", "Count of Link had no errors during run", 36, 0, 36, 30, 0, 30);
+    LinkError1 = new TH2F("linkerrors", "Count of Linkerrors 0x1 seen during run", 36, 0, 36, 30, 0, 30);
+    LinkError2 = new TH2F("linkerrors", "Count of Linkerrors 0x2 seen during run", 36, 0, 36, 30, 0, 30);
+    LinkError3 = new TH2F("linkerrors", "Count of any Linkerror seen during run", 36, 0, 36, 30, 0, 30);
+    LinkError4 = new TH2F("linknodata", "Link was seen with no data (empty) during run", 36, 0, 36, 30, 0, 30);
+    LinkError5 = new TH2F("linkdata", "Link was seen with data seen during run", 36, 0, 36, 30, 0, 30);
+    LinkError6 = new TH2F("linkbaddata", "Links seen with corrupted data during run", 36, 0, 36, 30, 0, 30);
+    LinkError7 = new TH2F("linknobaddata", "Links seen with out corrupted data during run", 36, 0, 36, 30, 0, 30);
+    mTimeFrameTime = new TH1F("timeframetime", "Time taken per time frame", 10000, 0, 10000);
+    mTrackletParsingTime = new TH1F("tracklettime", "Time taken per time frame", 1000, 0, 1000);
+    mDigitParsingTime = new TH1F("digittime", "Time taken per time frame", 1000, 0, 1000);
+    mCruTime = new TH1F("crutime", "Time taken per time frame", 1000, 0, 1000);
+    mPackagingTime = new TH1F("packagingtime", "Time to package the eventrecord and copy the output", 1000, 0, 1000);
+    mDataVersions = new TH1F("dataversions", "Data versions major.minor seen in data", 65000, 0, 65000);
+    mDataVersionsMajor = new TH1F("dataversions", "Data versions major", 256, 0, 256);
+    mParsingErrors = new TH1F("parseerrors", "Parsing Errors", 256, 0, 256);
+    mTimeFrameTime->GetXaxis()->SetTitle("Time taken in ms");
+    mCruTime->GetXaxis()->SetTitle("Time taken in ms");
+    mTrackletParsingTime->GetXaxis()->SetTitle("Time taken in #mus");
+    mDigitParsingTime->GetXaxis()->SetTitle("Time taken in #mus");
+    mPackagingTime->GetXaxis()->SetTitle("Time taken in #mus");
+    mTimeFrameTime->GetYaxis()->SetTitle("Counts");
+    mTrackletParsingTime->GetYaxis()->SetTitle("Counts");
+    mDigitParsingTime->GetYaxis()->SetTitle("Counts");
+    mCruTime->GetYaxis()->SetTitle("Counts");
+    mPackagingTime->GetYaxis()->SetTitle("Counts");
+    mDataVersions->GetYaxis()->SetTitle("Counts");
+    mDataVersions->GetYaxis()->SetTitle("Counts");
+    mDataVersionsMajor->GetYaxis()->SetTitle("Counts");
+    mDataVersionsMajor->GetXaxis()->SetTitle("Version major");
+    mParsingErrors->GetYaxis()->SetTitle("Erorr Types");
+    mParsingErrors->GetXaxis()->SetTitle("Erorr Types");
+    for (int s = 0; s < o2::trd::constants::NSTACK; ++s) {
+      for (int l = 0; l < o2::trd::constants::NLAYER; ++l) {
+        std::string label = fmt::format("{0}_{1}", s, l);
+        int pos = s * o2::trd::constants::NLAYER + l + 1;
+        LinkError->GetYaxis()->SetBinLabel(pos, label.c_str());
+        LinkError1->GetYaxis()->SetBinLabel(pos, label.c_str());
+        LinkError2->GetYaxis()->SetBinLabel(pos, label.c_str());
+        LinkError3->GetYaxis()->SetBinLabel(pos, label.c_str());
+        LinkError4->GetYaxis()->SetBinLabel(pos, label.c_str());
+        LinkError5->GetYaxis()->SetBinLabel(pos, label.c_str());
+        LinkError6->GetYaxis()->SetBinLabel(pos, label.c_str());
+        LinkError7->GetYaxis()->SetBinLabel(pos, label.c_str());
+      }
+    }
+    LinkError->GetYaxis()->SetTitle("Stack_Layer");
+    LinkError->GetYaxis()->CenterTitle(kTRUE);
+    LinkError->GetXaxis()->CenterTitle(kTRUE);
+    LinkError->GetXaxis()->SetTitle("Supermodule");
+    LinkError1->GetYaxis()->SetTitle("Stack_Layer");
+    LinkError1->GetYaxis()->CenterTitle(kTRUE);
+    LinkError1->GetXaxis()->CenterTitle(kTRUE);
+    LinkError1->GetXaxis()->SetTitle("Supermodule");
+    LinkError2->GetYaxis()->SetTitle("Stack_Layer");
+    LinkError2->GetYaxis()->CenterTitle(kTRUE);
+    LinkError2->GetXaxis()->CenterTitle(kTRUE);
+    LinkError2->GetXaxis()->SetTitle("Supermodule");
+    LinkError3->GetYaxis()->SetTitle("Stack_Layer");
+    LinkError3->GetYaxis()->CenterTitle(kTRUE);
+    LinkError3->GetXaxis()->CenterTitle(kTRUE);
+    LinkError3->GetXaxis()->SetTitle("Supermodule");
+    LinkError4->GetYaxis()->SetTitle("Stack_Layer");
+    LinkError4->GetYaxis()->CenterTitle(kTRUE);
+    LinkError4->GetXaxis()->CenterTitle(kTRUE);
+    LinkError4->GetXaxis()->SetTitle("Supermodule");
+    LinkError5->GetYaxis()->SetTitle("Stack_Layer");
+    LinkError5->GetYaxis()->CenterTitle(kTRUE);
+    LinkError5->GetXaxis()->CenterTitle(kTRUE);
+    LinkError5->GetXaxis()->SetTitle("Supermodule");
+    LinkError6->GetYaxis()->SetTitle("Stack_Layer");
+    LinkError6->GetYaxis()->CenterTitle(kTRUE);
+    LinkError6->GetXaxis()->CenterTitle(kTRUE);
+    LinkError6->GetXaxis()->SetTitle("Supermodule");
+    LinkError7->GetYaxis()->SetTitle("Stack_Layer");
+    LinkError7->GetYaxis()->CenterTitle(kTRUE);
+    LinkError7->GetXaxis()->CenterTitle(kTRUE);
+    LinkError7->GetXaxis()->SetTitle("Supermodule");
+
+    mReader.setHistos(LinkError, LinkError1, LinkError2);
+    mReader.setHistos1(LinkError3, LinkError4, LinkError5);
+    mReader.setHistos2(LinkError6, LinkError7);
+    mReader.setTimeHistos(mTimeFrameTime, mTrackletParsingTime,
+                          mDigitParsingTime, mCruTime, mPackagingTime,
+                          mDataVersions, mDataVersionsMajor, mParsingErrors);
+  }
+}
+
+void DataReaderTask::endOfStream(o2::framework::EndOfStreamContext& ec)
+{
+  if (mRootOutput) {
+    LinkError->Draw();
+    LinkError1->Draw();
+    LinkError2->Draw();
+    LinkError3->Draw();
+    LinkError4->Draw();
+    LinkError5->Draw();
+    LinkError6->Draw();
+    LinkError7->Draw();
+    mTimeFrameTime->Draw();
+    mTrackletParsingTime->Draw();
+    mDigitParsingTime->Draw();
+    mCruTime->Draw();
+    mPackagingTime->Draw();
+    mDataVersions->Draw();
+    mDataVersionsMajor->Draw();
+    mParsingErrors->Draw();
+    LinkError->Write();
+    LinkError1->Write();
+    LinkError2->Write();
+    LinkError3->Write();
+    LinkError4->Write();
+    LinkError5->Write();
+    LinkError6->Write();
+    LinkError7->Write();
+    mTimeFrameTime->Write();
+    mTrackletParsingTime->Write();
+    mDigitParsingTime->Write();
+    mCruTime->Write();
+    mPackagingTime->Write();
+    mDataVersions->Write();
+    mDataVersionsMajor->Write();
+    mParsingErrors->Write();
+    mRootFile->Close();
+  }
 }
 
 void DataReaderTask::sendData(ProcessingContext& pc, bool blankframe)
@@ -64,10 +236,7 @@ void DataReaderTask::sendData(ProcessingContext& pc, bool blankframe)
 bool DataReaderTask::isTimeFrameEmpty(ProcessingContext& pc)
 {
   constexpr auto origin = header::gDataOriginTRD;
-  o2::framework::InputSpec dummy{"dummy",
-                                 framework::ConcreteDataMatcher{origin,
-                                                                header::gDataDescriptionRawData,
-                                                                0xDEADBEEF}};
+  o2::framework::InputSpec dummy{"dummy", framework::ConcreteDataMatcher{origin, header::gDataDescriptionRawData, 0xDEADBEEF}};
   // if we see requested data type input with 0xDEADBEEF subspec and 0 payload.
   // frame detected we have no data and send this instead
   // send empty output so as to not block workflow
@@ -84,6 +253,7 @@ bool DataReaderTask::isTimeFrameEmpty(ProcessingContext& pc)
 
 void DataReaderTask::run(ProcessingContext& pc)
 {
+  //NB this is run per time frame on the epn.
   LOG(info) << "TRD Translator Task run";
   auto dataReadStart = std::chrono::high_resolution_clock::now();
 
@@ -128,7 +298,8 @@ void DataReaderTask::run(ProcessingContext& pc)
           //          LOG(info) << "start of data is at ref.payload=0x"<< std::hex << " total1:0x" << total1 <<" total2:0x" <<total2;
           mReader.setDataBuffer(payloadIn);
           mReader.setDataBufferSize(payloadInSize);
-          mReader.configure(mByteSwap, mFixDigitEndCorruption, mTrackletHCHeaderState, mVerbose, mHeaderVerbose, mDataVerbose);
+          mReader.configure(mTrackletHCHeaderState, mOptions);
+          //mReader.setStats(&mTimeFrameStats);
           mReader.run();
           mWordsRead += mReader.getWordsRead();
           mWordsRejected += mReader.getWordsRejected();
@@ -138,27 +309,36 @@ void DataReaderTask::run(ProcessingContext& pc)
         } else { // we have compressed data coming in from flp.
           mCompressedReader.setDataBuffer(payloadIn);
           mCompressedReader.setDataBufferSize(payloadInSize);
-          mCompressedReader.configure(mByteSwap, mVerbose, mHeaderVerbose, mDataVerbose);
+          mCompressedReader.configure(mOptions);
           mCompressedReader.run();
         }
       } // ignore the input of DISTSUBTIMEFRAMEFLP
-        //      auto inputprocessingtime = std::chrono::high_resolution_clock::now() - inputprocessingstart;
-        //     LOGP(info, "Input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : processed in {} us",
-        //           dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize,std::chrono::duration_cast<std::chrono::microseconds>(inputprocessingtime).count());
+      //      auto inputprocessingtime = std::chrono::high_resolution_clock::now() - inputprocessingstart;
+      //     LOGP(info, "Input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : processed in {} us",
+      //           dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize,std::chrono::duration_cast<std::chrono::microseconds>(inputprocessingtime).count());
+    }
+
+    std::chrono::duration<double, std::milli> dataReadTime = std::chrono::high_resolution_clock::now() - dataReadStart;
+    LOG(info) << "Processing time for Data reading  " << std::chrono::duration_cast<std::chrono::milliseconds>(dataReadTime).count() << "ms";
+    if (mRootOutput) {
+      mTimeFrameTime->Fill((int)std::chrono::duration_cast<std::chrono::milliseconds>(dataReadTime).count());
+    }
+    //auto timeframe=mReader.getEventStorage();
+    // (*timeframe)->mTFStats.mTimeTaken= std::chrono::duration_cast<std::chrono::milliseconds>(dataReadTime).count();
+    // (*timeframe)->mTFStats.mDigitsFound = mReader.getDigitsFound();
+    // (*timeframe)->mTFStats.mTrackletsFound = mReader.getTrackletsFound();
+    //  (*timeframe)->mTFStats.mDataWordsRead = mWordsRead * 4;
+    // (*timeframe)->mTFStats.mDataWordsRejected = mWordsRejected * 4;
+    if (!mCompressedData) {
+      LOG(info) << "Digits found : " << mReader.getDigitsFound();
+      LOG(info) << "Tracklets found : " << mReader.getTrackletsFound();
+      LOG(info) << "DataRead in :" << mWordsRead * 4 << " bytes";
+      LOG(info) << "DataRejected in :" << mWordsRejected * 4 << " bytes";
+      LOG(info) << "DataRetention :bad/good" << (double)mWordsRejected / (double)mWordsRead << "";
+      LOG(info) << "Total % good data bad/(good+bad)" << (double)mWordsRejected / ((double)mWordsRead + (double)mWordsRejected) * 100.0 << " %";
     }
     /* output */
     sendData(pc, false);
-  }
-
-  auto dataReadTime = std::chrono::high_resolution_clock::now() - dataReadStart;
-  LOG(info) << "Processing time for Data reading  " << std::chrono::duration_cast<std::chrono::microseconds>(dataReadTime).count() << "us";
-  if (!mCompressedData) {
-    LOG(info) << "Digits found : " << mReader.getDigitsFound();
-    LOG(info) << "Tracklets found : " << mReader.getTrackletsFound();
-    LOG(info) << "DataRead in :" << mWordsRead * 4 << " bytes";
-    LOG(info) << "DataRejected in :" << mWordsRejected * 4 << " bytes";
-    LOG(info) << "DataRetention :bad/good" << (double)mWordsRejected / (double)mWordsRead << "";
-    LOG(info) << "Total % good data bad/(good+bad)" << (double)mWordsRejected / ((double)mWordsRead + (double)mWordsRejected) * 100.0 << " %";
   }
 }
 

--- a/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
+++ b/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
@@ -13,10 +13,12 @@
 /// @brief  TRD raw data parser for Tracklet data format
 
 #include "DataFormatsTRD/RawData.h"
+#include "DataFormatsTRD/RawDataStats.h"
 #include "DataFormatsTRD/Tracklet64.h"
 #include "DataFormatsTRD/HelperMethods.h"
 
 #include "TRDReconstruction/TrackletsParser.h"
+#include "TRDReconstruction/EventRecord.h"
 #include "fairlogger/Logger.h"
 
 //TODO come back and figure which of below headers I actually need.
@@ -26,6 +28,7 @@
 #include <array>
 #include <iomanip>
 #include <iostream>
+#include "TH1F.h"
 
 namespace o2::trd
 {
@@ -42,8 +45,7 @@ int TrackletsParser::Parse(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX
                            std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator start,
                            std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator end,
                            TRDFeeID feeid, int robside, int detector, int stack, int layer,
-                           bool cleardigits, bool disablebyteswap, int usetracklethcheader,
-                           bool verbose, bool headerverbose, bool dataverbose)
+                           EventRecord* eventrecord, std::bitset<16> options, bool cleardigits, int usetracklethcheader)
 {
   mStartParse = start;
   mEndParse = end;
@@ -52,14 +54,17 @@ int TrackletsParser::Parse(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX
   mRobSide = robside;
   mStack = stack;
   mLayer = layer;
+  mOptions = options;
   setData(data);
-  setVerbose(verbose, headerverbose, dataverbose);
-  setByteSwap(disablebyteswap);
+  setVerbose(options[TRDVerboseBit], options[TRDHeaderVerboseBit], options[TRDDataVerboseBit]);
+  setByteSwap(options[TRDByteSwapBit]);
   mWordsRead = 0;
-  mDataWordsParsed = 0;
+  mWordsDumped = 0;
   mTrackletsFound = 0;
   mPaddingWordsCounter = 0;
   mTrackletHCHeaderState = usetracklethcheader; //what to with the tracklet half chamber header 0,1,2
+  mIgnoreTrackletHCHeader = options[TRDIgnoreTrackletHCHeaderBit];
+  mEventRecord = eventrecord;
   //    mTracklets.clear();
   return Parse();
 }
@@ -137,14 +142,11 @@ int TrackletsParser::Parse()
   int mcmtrackletcount = 0;
   int trackletloopcount = 0;
   int headertrackletcount = 0;
-  if (mDataVerbose) {
-    LOG(info) << "distance to parse over is " << std::distance(mStartParse, mEndParse);
-  }
-  for (auto word = mStartParse; word != mEndParse; word++) { // loop over the entire data buffer (a complete link of tracklets and digits)
+  bool ignoreDataTillTrackletEndMarker = false;             // used for when we need to dump the rest of the tracklet data.
+  for (auto word = mStartParse; word < mEndParse; ++word) { // loop over the entire data buffer (a complete link of tracklets and digits)
 
     if (mState == StateFinished) {
       mTrackletparsetime += std::chrono::high_resolution_clock::now() - parsetimestart;
-      LOG(info) << "state finished so bailing out tracklet parsing having read : " << mWordsRead << " words";
       return mWordsRead;
     }
     //loop over all the words ...
@@ -164,69 +166,127 @@ int TrackletsParser::Parse()
       if (!StateTrackletEndMarker && !StateTrackletHCHeader) {
         LOG(warn) << "State should be trackletend marker current ?= end marker  ?? " << mState << " ?=" << StateTrackletEndMarker;
       }
+
+      mWordsRead += 2;
+
       if (mHeaderVerbose) {
         LOG(info) << "***TrackletEndMarker : 0x" << std::hex << *word << " and 0x" << nextwordcopy << " at offset " << std::distance(mStartParse, word);
       }
-      mWordsRead += 2;
-      //we should now have a tracklet half chamber header.
-      mState = StateTrackletHCHeader;
-      std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator hchword = word;
-      std::advance(hchword, 2);
-      uint32_t halfchamberheaderint = *hchword;
-      mState = StateTrackletEndMarker;
+
+      mState = StateFinished;
       mTrackletparsetime += std::chrono::high_resolution_clock::now() - parsetimestart;
       return mWordsRead;
     }
     if (*word == o2::trd::constants::CRUPADDING32) {
       //padding word first as it clashes with the hcheader.
-      LOG(info) << "Padding : 0x" << std::hex << *word << std::distance(mStartParse, word);
-      ;
       mState = StatePadding;
-      mWordsRead++;
-      LOG(warn) << "CRU Padding word while parsing tracklets. This should *never* happen, this should happen after the tracklet end markers when we are outside the tracklet parsing";
+      LOG(warn) << "CRU Padding word while parsing tracklets. Corrupt data dumping the rest of this link";
+      //mEventRecord.ErrorStats[TRDParsingTrackletCRUPaddingWhileParsingTracklets]++;
+      if (mOptions[TRDEnableRootOutputBit]) {
+        mParsingErrors->Fill(TRDParsingTrackletCRUPaddingWhileParsingTracklets);
+      }
+      //TOOD replace warning with stats increment
+      mWordsDumped = std::distance(word, mEndParse);
+      ignoreDataTillTrackletEndMarker = true;
+      //mWordsRead++;
+      word = mEndParse;
+      //TODO remove tracklets already added erroneously
+      continue; // bail out
+      //dumping data
+
     } else {
+      if (ignoreDataTillTrackletEndMarker) {
+        mWordsDumped++;
+        //LOG(info) << "ignoring till end marker ..... word read:0x"<<std::hex << *word << " at offset 0x"<< std::distance(mStartParse,word);
+        //TODO increment counter instead of above log message
+        continue; //go back to the start of loop, walk the data till the above code of the tracklet end marker is hit, padding is hit or we get to the end of the data.
+        //TODO might be good to check for end of digit marker as well?
+      }
       //now for Tracklet hc header
       if ((((*word) & (0x1 << 11)) != 0) && !mIgnoreTrackletHCHeader && mState == StateTrackletHCHeader) { //TrackletHCHeader has bit 11 set to 1 always. Check for state because raw data can have bit 11 set!
         if (mState != StateTrackletHCHeader) {
           LOG(warn) << "Something wrong with TrackletHCHeader bit 11 is set but state is not " << StateTrackletMCMHeader << " its :" << mState;
+          //TODO count remove warning
+          //mEventRecord.ErrorStats[TRDParsingTrackletBit11NotSetInTrackletHCHeader]++;
+          if (mOptions[TRDEnableRootOutputBit]) {
+            mParsingErrors->Fill(TRDParsingTrackletBit11NotSetInTrackletHCHeader);
+          }
         }
         //read the header
         if (mHeaderVerbose) {
-          LOG(info) << "*** TrackletHCHeader : 0x" << std::hex << *word << " at offset " << std::distance(mStartParse, word);
+          LOG(info) << "*** TrackletHCHeader : 0x" << std::hex << *word << " at offset :0x" << std::distance(mStartParse, word);
         }
         //we actually have a header word.
         mTrackletHCHeader = (TrackletHCHeader*)&word;
         //sanity check of trackletheader ??
         if (!trackletHCHeaderSanityCheck(*mTrackletHCHeader)) {
-          LOG(warn) << "Sanity check Failure HCHeader : " << std::hex << *word << std::distance(mStartParse, word);
+          LOG(warn) << "Sanity check Failure HCHeader : " << std::hex << *word << " at offset :0x" << std::distance(mStartParse, word);
+          //TODO count remove warning
+          //mEventRecord.ErrorStats[TRDParsingTrackletHCHeaderSanityCheckFailure]++;
+          if (mOptions[TRDEnableRootOutputBit]) {
+            mParsingErrors->Fill(TRDParsingTrackletHCHeaderSanityCheckFailure);
+          }
         }
         mWordsRead++;
         mState = StateTrackletMCMHeader;                                // now we should read a MCMHeader next time through loop
-      } else {                                                          //not TrackletMCMHeader
-        if ((*word) & 0x80000001 && mState == StateTrackletMCMHeader) { //TrackletMCMHeader has the bits on either end always 1
+      } else {                                                          //not TrackletHCHeader
+        if (((*word) & 0x80000001) == 0x80000001 && mState == StateTrackletMCMHeader) { //TrackletMCMHeader has the bits on either end always 1
           //mcmheader
           mTrackletMCMHeader = (TrackletMCMHeader*)&(*word);
           if (mHeaderVerbose) {
-            LOG(info) << "***TrackletMCMHeader : 0x" << std::hex << *word << std::distance(mStartParse, word);
-            ;
+            LOG(info) << "***TrackletMCMHeader : 0x" << std::hex << *word << " at offset: 0x" << std::distance(mStartParse, word);
             TrackletMCMHeader a;
             a.word = *word;
             printTrackletMCMHeader(a);
           }
+          if (!trackletMCMHeaderSanityCheck(*mTrackletMCMHeader)) {
+            LOG(warn) << "***TrackletMCMHeader SanityCheckFailure: 0x" << std::hex << *word << " at offset: 0x" << std::distance(mStartParse, word);
+            //mEventRecord.ErrorStats[TRDParsingTrackletMCMHeaderSanityCheckFailure]++;
+            if (mOptions[TRDEnableRootOutputBit]) {
+              mParsingErrors->Fill(TRDParsingTrackletMCMHeaderSanityCheckFailure);
+            }
+          }
           headertrackletcount = getNumberofTracklets(*mTrackletMCMHeader);
-          mState = StateTrackletMCMData; // afrter reading a header we should then have data for next round through the loop
+          if (headertrackletcount > 0) {
+            mState = StateTrackletMCMData; // afrter reading a header we should then have data for next round through the loop
+          } else {
+            mState = StateTrackletMCMHeader;
+          }
+
           mcmtrackletcount = 0;
           mWordsRead++;
         } else {
+          if (mState == StateTrackletMCMHeader) {
+            // if we are here something is wrong, dump the data. The else of line 227 should imply we are in StateTrackletMCMData;
+            ignoreDataTillTrackletEndMarker = true;
+            //mEventRecord.ErrorStats[
+            if (mOptions[TRDEnableRootOutputBit]) {
+              mParsingErrors->Fill(TRDParsingTrackletStateMCMHeaderButParsingMCMData);
+            }
+            mWordsRead++;
+            continue;
+          }
           mState = StateTrackletMCMData;
           //tracklet data;
           mTrackletMCMData = (TrackletMCMData*)&(*word);
+          mWordsRead++;
           if (mHeaderVerbose) {
-            LOG(info) << "*** TrackletMCMData : 0x" << std::hex << *word << std::distance(mStartParse, word);
-            ;
+            LOG(info) << "*** TrackletMCMData : 0x" << std::hex << *word << " at offset :0x" << std::distance(mStartParse, word);
             printTrackletMCMData(*mTrackletMCMData);
           }
-          mWordsRead++;
+          // do we have more tracklets than the header allows?
+          if (headertrackletcount < mcmtrackletcount) {
+            ignoreDataTillTrackletEndMarker = true;
+            //dump the rest of the data ... undo any tracklets already written?
+            //cant dump till mEndParse and digits are after the tracklets
+            //we can assume the mcmtrackletcountth (n from the end) last tracklets in the vector are to be removed.
+            //mEventRecord.ErrorStats[TRDParsingTrackletTrackletCountGTThatDeclaredInMCMHeader]++;
+            if (mOptions[TRDEnableRootOutputBit]) {
+              mParsingErrors->Fill(TRDParsingTrackletTrackletCountGTThatDeclaredInMCMHeader);
+            }
+            mEventRecord->popTracklets(mcmtrackletcount); // our format is always 4
+            //TODO count remove warning
+          }
           // take the header and this data word and build the underlying 64bit tracklet.
           int q0, q1, q2;
           int qa, qb;
@@ -242,54 +302,52 @@ int TrackletsParser::Parse()
               break;
             default:
               LOG(warn) << "mcmtrackletcount is not in [0:2] count=" << mcmtrackletcount << " headertrackletcount=" << headertrackletcount << " something very wrong parsing the TrackletMCMData fields with data of : 0x" << std::hex << mTrackletMCMData->word;
+              //mEventRecord.ErrorStats[TRDParsingTrackletInvalidTrackletCount]++;
+              if (mOptions[TRDEnableRootOutputBit]) {
+                mParsingErrors->Fill(TRDParsingTrackletInvalidTrackletCount);
+              }
+              //this should have been caught above by the headertrackletcount to mcmtrackletcount
+              ignoreDataTillTrackletEndMarker = true;
               break;
           }
-          q0 = getQFromRaw(mTrackletMCMHeader, mTrackletMCMData, 0, mcmtrackletcount);
-          q1 = getQFromRaw(mTrackletMCMHeader, mTrackletMCMData, 1, mcmtrackletcount);
-          q2 = getQFromRaw(mTrackletMCMHeader, mTrackletMCMData, 2, mcmtrackletcount);
-          int padrow = mTrackletMCMHeader->padrow;
-          int col = mTrackletMCMHeader->col;
-          int pos = mTrackletMCMData->pos;
-          int slope = mTrackletMCMData->slope;
-          int hcid = mDetector * 2 + mRobSide;
-          if (mDataVerbose) {
-            if (mTrackletHCHeaderState) {
-              LOG(info) << "Tracklet HCID : " << hcid << " mDetector:" << mDetector << " robside:" << mRobSide << " " << mTrackletMCMHeader->padrow << ":" << mTrackletMCMHeader->col << " ---- " << mTrackletHCHeader->supermodule << ":" << mTrackletHCHeader->stack << ":" << mTrackletHCHeader->layer << ":" << mTrackletHCHeader->side << " rawhcheader : 0x" << std::hex << std::hex << mTrackletHCHeader->word;
-            } else {
-              LOG(info) << "Tracklet HCID : " << hcid << " mDetector:" << mDetector << " robside:" << mRobSide << " " << mTrackletMCMHeader->padrow << ":" << mTrackletMCMHeader->col;
+          if (!ignoreDataTillTrackletEndMarker) {
+            q0 = getQFromRaw(mTrackletMCMHeader, mTrackletMCMData, 0, mcmtrackletcount);
+            q1 = getQFromRaw(mTrackletMCMHeader, mTrackletMCMData, 1, mcmtrackletcount);
+            q2 = getQFromRaw(mTrackletMCMHeader, mTrackletMCMData, 2, mcmtrackletcount);
+            int padrow = mTrackletMCMHeader->padrow;
+            int col = mTrackletMCMHeader->col;
+            int pos = mTrackletMCMData->pos;
+            int slope = mTrackletMCMData->slope;
+            int hcid = mDetector * 2 + mRobSide;
+            if (mDataVerbose) {
+              if (mTrackletHCHeaderState) {
+                LOG(info) << "Tracklet HCID : " << hcid << " mDetector:" << mDetector << " robside:" << mRobSide << " " << mTrackletMCMHeader->padrow << ":" << mTrackletMCMHeader->col << " ---- " << mTrackletHCHeader->supermodule << ":" << mTrackletHCHeader->stack << ":" << mTrackletHCHeader->layer << ":" << mTrackletHCHeader->side << " rawhcheader : 0x" << std::hex << std::hex << mTrackletHCHeader->word;
+              } else {
+                LOG(info) << "Tracklet HCID : " << hcid << " mDetector:" << mDetector << " robside:" << mRobSide << " " << mTrackletMCMHeader->padrow << ":" << mTrackletMCMHeader->col;
+              }
             }
-          }
-          //TODO cross reference hcid to somewhere for a check. mDetector is assigned at the time of parser init.
-          //
-          mTracklets.emplace_back(4, hcid, padrow, col, pos, slope, q0, q1, q2); // our format is always 4
-          if (mDataVerbose) {
-            LOG(info) << "Tracklet added:" << 4 << "-" << hcid << "-" << padrow << "-" << col << "-" << pos << "-" << slope << "-" << q0 << ":" << q1 << ":" << q2;
-          }
-          mTrackletsFound++;
-          mcmtrackletcount++;
-          if (mcmtrackletcount == headertrackletcount) { // headertrackletcount and mcmtrackletcount are not zero based counting
-            // at the end of the tracklet output of this mcm
-            // next to come can either be an mcmheaderword or a trackletendmarker.
-            // check next word if its a trackletendmarker
-            auto nextdataword = std::next(word, 1);
-            // the check is unambigous between trackletendmarker and mcmheader
-            if ((*nextdataword) == constants::TRACKLETENDMARKER) {
-              mState = StateTrackletEndMarker;
-            } else {
-              mState = StateTrackletMCMHeader;
+            //TODO cross reference hcid to somewhere for a check. mDetector is assigned at the time of parser init.
+            //
+            //mEventRecord.TrackletCounts[mcm][mcmtrackletcount]++;
+            mEventRecord->getTracklets().emplace_back(4, hcid, padrow, col, pos, slope, q0, q1, q2); // our format is always 4
+            if (mDataVerbose) {
+              LOG(info) << "Tracklet added:" << 4 << "-" << hcid << "-" << padrow << "-" << col << "-" << pos << "-" << slope << "-" << q0 << ":" << q1 << ":" << q2;
+              Tracklet64 a(4, hcid, padrow, col, pos, slope, q0, q1, q2);
+              LOG(info) << "Tracklet added:" << a;
+              LOG(info) << "Tracklet64 output ended";
             }
-          }
-          if (mcmtrackletcount > 3) {
-            LOG(warn) << "We have more than 3 Tracklets in parsing the TrackletMCMData attached to a single TrackletMCMHeader";
-            //dump out preceeding 8 words and subsequent 8 words, might help in diagnostics
-            if (mVerbose) {
-              auto debugword = std::prev(word, -4); //
-              int debugcount = -4;
-              //now output it to info
-              while (debugcount != 4) {
-                LOG(info) << "tracklet debug " << debugcount << " 0x" << std::hex << *debugword;
-                debugword++;
-                debugcount++;
+            mTrackletsFound++;
+            mcmtrackletcount++;
+            if (mcmtrackletcount == headertrackletcount) { // headertrackletcount and mcmtrackletcount are not zero based counting
+              // at the end of the tracklet output of this mcm
+              // next to come can either be an mcmheaderword or a trackletendmarker.
+              // check next word if its a trackletendmarker
+              auto nextdataword = std::next(word, 1);
+              // the check is unambigous between trackletendmarker and mcmheader
+              if ((*nextdataword) == constants::TRACKLETENDMARKER) {
+                mState = StateTrackletEndMarker;
+              } else {
+                mState = StateTrackletMCMHeader;
               }
             }
           }
@@ -300,6 +358,10 @@ int TrackletsParser::Parse()
   } //end of for loop
   //sanity check
   LOG(warn) << " end of Trackelt parsing but we are exiting with out a tracklet end marker with " << mWordsRead << " 32bit words read";
+  //mEventRecord.ErrorStats[TRDParsingTrackletExitingNoTrackletEndMarker]++;
+  if (mOptions[TRDEnableRootOutputBit]) {
+    mParsingErrors->Fill(TRDParsingTrackletExitingNoTrackletEndMarker);
+  }
   mTrackletparsetime += std::chrono::high_resolution_clock::now() - parsetimestart;
   return mWordsRead;
 }

--- a/Detectors/TRD/simulation/src/Trap2CRU.cxx
+++ b/Detectors/TRD/simulation/src/Trap2CRU.cxx
@@ -565,7 +565,8 @@ int Trap2CRU::writeDigitHCHeader(const int eventcount, const uint32_t linkid)
   int detector = linkid / 2;
 
   DigitHCHeader digitheader;
-  digitheader.res0 = 1;
+  DigitHCHeader1 digitheader1;
+  digitheader.res = 1;
   digitheader.side = (linkid % 2) ? 1 : 0;
   digitheader.stack = (detector % (o2::trd::constants::NLAYER * o2::trd::constants::NSTACK)) / o2::trd::constants::NLAYER;
   digitheader.layer = (detector % o2::trd::constants::NLAYER);
@@ -574,13 +575,15 @@ int Trap2CRU::writeDigitHCHeader(const int eventcount, const uint32_t linkid)
   digitheader.minor = 42;    // my (shtm) version, not used
   digitheader.major = 0x20;  // zero suppressed
   digitheader.version = 1;   //new version of the header. we only have 1 version
-  digitheader.res1 = 1;
-  digitheader.ptrigcount = 1;             //TODO put something more real in here?
-  digitheader.ptrigphase = 1;             //TODO put something more real in here?
-  digitheader.bunchcrossing = eventcount; //NB this is not the same as the bunchcrossing the rdh. See RawData.h for explanation
-  digitheader.numtimebins = 30;
-  memcpy(mRawDataPtr, (char*)&digitheader, 8); // 8 because we are only using the first 2 32bit words of the header, the rest are optional.
-  mRawDataPtr += 8;
+  digitheader1.res = 1;
+  digitheader1.ptrigcount = 1;             //TODO put something more real in here?
+  digitheader1.ptrigphase = 1;             //TODO put something more real in here?
+  digitheader1.bunchcrossing = eventcount; //NB this is not the same as the bunchcrossing the rdh. See RawData.h for explanation
+  digitheader1.numtimebins = 30;
+  memcpy(mRawDataPtr, (char*)&digitheader, sizeof(DigitHCHeader)); // 8 because we are only using the first 2 32bit words of the header, the rest are optional.
+  mRawDataPtr += sizeof(DigitHCHeader);
+  memcpy(mRawDataPtr, (char*)&digitheader, sizeof(DigitHCHeader1)); // 8 because we are only using the first 2 32bit words of the header, the rest are optional.
+  mRawDataPtr += sizeof(DigitHCHeader1);
   wordswritten += 2;
   return wordswritten;
 }


### PR DESCRIPTION
- fix various corruptions of data.
- add histograms for debugging, data to end up in qc
- modify headerverbose to output sequential raw data as parsed.
- enable-stats enable-timing to permit timing and stats to come out.
- RawDataStats.h in dataformats for the stats from reader to qc and where ever else it goes.
- config events ignored for now, jumps over.
- data corruption is attempted to be recovered (tracklets it will search for a tracklet end marker) else entire link will be dumped.
- only formats 0x2? 0x3? accepted, there are other invalid types 0x7? that should not be possible and are ignored (testpattern and zero suppression) 
- fixes detector number and adc channel ordering in digits parsing.
- eliminate a bunch of copies by sending the EventRecord down instead of pulling the data out of the parsing. 
- halfchamber header is no longer authoritative, and the information from rdh, ori, and halfchamber are checked and the 2 that match are taken as the value, mismatches are logged.