### PR TITLE
Fix in CTF reader (for multi-TF files)

### DIFF
--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/EncodedBlocks.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/EncodedBlocks.h
@@ -16,8 +16,8 @@
 
 #ifndef ALICEO2_ENCODED_BLOCKS_H
 #define ALICEO2_ENCODED_BLOCKS_H
-//#undef NDEBUG
-//#include <cassert>
+#undef NDEBUG
+#include <cassert>
 #include <type_traits>
 #include <Rtypes.h>
 #include "rANS/rans.h"
@@ -484,7 +484,7 @@ void EncodedBlocks<H, N, W>::readFromTree(TTree& tree, const std::string& name, 
 {
   readTreeBranch(tree, o2::utils::Str::concat_string(name, "_wrapper."), *this, ev);
   for (int i = 0; i < N; i++) {
-    readTreeBranch(tree, o2::utils::Str::concat_string(name, "_block.", std::to_string(i), "."), mBlocks[i]);
+    readTreeBranch(tree, o2::utils::Str::concat_string(name, "_block.", std::to_string(i), "."), mBlocks[i], ev);
   }
 }
 
@@ -497,9 +497,13 @@ void EncodedBlocks<H, N, W>::readFromTree(VD& vec, TTree& tree, const std::strin
   auto tmp = create(vec);
   readTreeBranch(tree, o2::utils::Str::concat_string(name, "_wrapper."), *tmp, ev);
   tmp = tmp->expand(vec, tmp->estimateSizeFromMetadata());
+  const auto& meta = tmp->getMetadata();
   for (int i = 0; i < N; i++) {
     Block<W> bl;
-    readTreeBranch(tree, o2::utils::Str::concat_string(name, "_block.", std::to_string(i), "."), bl);
+    readTreeBranch(tree, o2::utils::Str::concat_string(name, "_block.", std::to_string(i), "."), bl, ev);
+    assert(meta[i].nDictWords == bl.getNDict());
+    assert(meta[i].nDataWords == bl.getNData());
+    assert(meta[i].nLiteralWords == bl.getNLiterals());
     tmp->mBlocks[i].store(bl.getNDict(), bl.getNData(), bl.getNLiterals(), bl.getDict(), bl.getData(), bl.getLiterals());
   }
 }

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/CTFCoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/CTFCoder.h
@@ -212,7 +212,7 @@ void CTFCoder::decompress(const CompressedClusters& cc, VROF& rofRecVec, VCLUS& 
   assert(chipCount == cc.header.nChips);
 
   if (clCount != cc.header.nClusters) {
-    LOG(ERROR) << "expected " << cc.header.nClusters << " but counted " << clCount << " in ROFRecords";
+    LOG(ERROR) << "expected " << cc.header.nClusters << " but counted " << clCount << " in " << cc.header.nROFs << " ROFRecords";
     throw std::runtime_error("mismatch between expected and counter number of clusters");
   }
 }


### PR DESCRIPTION
* CTFReader: fix in passing tree event entry in multi-CTF files
* ITSMFT CTFCoder: make exception message more informative

Temporarily compile EncodedBlocks w/o NDEBUG to enable asserts.