### PR TITLE
Revert "ITSMFT CTFCoder: make exception message more informative"

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/CTFCoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/CTFCoder.h
@@ -212,7 +212,7 @@ void CTFCoder::decompress(const CompressedClusters& cc, VROF& rofRecVec, VCLUS& 
   assert(chipCount == cc.header.nChips);
 
   if (clCount != cc.header.nClusters) {
-    LOG(ERROR) << "expected " << cc.header.nClusters << " but counted " << clCount << " in " << cc.header.nROFs << " ROFRecords";
+    LOG(ERROR) << "expected " << cc.header.nClusters << " but counted " << clCount << " in ROFRecords";
     throw std::runtime_error("mismatch between expected and counter number of clusters");
   }
 }


### PR DESCRIPTION
This reverts commit c2c8d8cf842f113dadabf510667fb584645412d1.

Reverting accidental merge, will reopen PR to pass all tests, given that it may affect QC