### PR TITLE
Send different decoded MID event types to different specs

### DIFF
--- a/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/ROFRecord.h
+++ b/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/ROFRecord.h
@@ -26,8 +26,8 @@ namespace mid
 
 enum class EventType {
   Standard = 0,
-  Noise = 1,
-  Dead = 2
+  Calib = 1,
+  FET = 2
 };
 
 /// ROFRecord class encodes the trigger interaction record of given ROF and

--- a/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/ROFRecord.h
+++ b/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/ROFRecord.h
@@ -29,6 +29,7 @@ enum class EventType {
   Calib = 1,
   FET = 2
 };
+constexpr uint32_t NEvTypes = 3;
 
 /// ROFRecord class encodes the trigger interaction record of given ROF and
 /// the reference on the 1st object (digit, cluster etc) of this ROF in the data tree
@@ -41,6 +42,7 @@ struct ROFRecord {
   ROFRecord() = default;
   ROFRecord(const o2::InteractionRecord& intRecord, const EventType& evtType, size_t first, size_t nElements) : interactionRecord(intRecord), eventType(evtType), firstEntry(first), nEntries(nElements) {}
   ROFRecord(const ROFRecord& other, size_t first, size_t nElements) : interactionRecord(other.interactionRecord), eventType(other.eventType), firstEntry(first), nEntries(nElements) {}
+  size_t getEndIndex() const { return firstEntry + nEntries; }
 
   ClassDefNV(ROFRecord, 1);
 };

--- a/Detectors/MUON/MID/CTF/src/CTFCoder.cxx
+++ b/Detectors/MUON/MID/CTF/src/CTFCoder.cxx
@@ -28,7 +28,8 @@ void CTFCoder::appendToTree(TTree& tree, CTF& ec)
 
 ///___________________________________________________________________________________
 // extract and decode data from the tree
-void CTFCoder::readFromTree(TTree& tree, int entry, std::vector<ROFRecord>& rofVec, std::vector<ColumnData>& colVec)
+void CTFCoder::readFromTree(TTree& tree, int entry, std::array<std::vector<ROFRecord>, NEvTypes>& rofVec,
+                            std::array<std::vector<ColumnData>, NEvTypes>& colVec)
 {
   assert(entry >= 0 && entry < tree.GetEntries());
   CTF ec;
@@ -66,7 +67,7 @@ void CTFCoder::createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::
   uint8_t evType = 0, deId = 0, colId = 0;
 #define MAKECODER(part, slot) createCoder<decltype(part)>(op, getFreq(slot), getProbBits(slot), int(slot))
   // clang-format off
-  MAKECODER(bcInc,    CTF::BLC_bcIncROF); 
+  MAKECODER(bcInc,    CTF::BLC_bcIncROF);
   MAKECODER(orbitInc, CTF::BLC_orbitIncROF);
   MAKECODER(entries,  CTF::BLC_entriesROF);
   MAKECODER(evType,   CTF::BLC_evtypeROF);

--- a/Detectors/MUON/MID/CTF/src/CTFHelper.cxx
+++ b/Detectors/MUON/MID/CTF/src/CTFHelper.cxx
@@ -14,3 +14,35 @@
 /// \brief  Helper for MID CTF creation
 
 #include "MIDCTF/CTFHelper.h"
+
+using namespace o2::mid;
+
+void CTFHelper::TFData::buildReferences()
+{
+  uint32_t nDone = 0, idx[NEvTypes] = {};
+  uint32_t sizes[NEvTypes] = {
+    uint32_t(rofData[size_t(EventType::Standard)].size()),
+    uint32_t(rofData[size_t(EventType::Calib)].size()),
+    uint32_t(rofData[size_t(EventType::FET)].size())};
+  uint64_t rofBC[NEvTypes] = {};
+  auto fillNextROFBC = [&nDone, &rofBC, &idx, &sizes, this](int it) {
+    if (idx[it] < sizes[it]) {
+      rofBC[it] = this->rofData[it][idx[it]].interactionRecord.toLong();
+    } else {
+      rofBC[it] = -1;
+      nDone++;
+    }
+  };
+  for (uint32_t it = 0; it < NEvTypes; it++) {
+    fillNextROFBC(it);
+  }
+  while (nDone < NEvTypes) { // find next ROFRecord with smallest BC, untill all 3 spans are traversed
+    int selT = rofBC[0] <= rofBC[1] ? (rofBC[0] <= rofBC[2] ? 0 : 2) : (rofBC[1] <= rofBC[2] ? 1 : 2);
+    rofDataRefs.emplace_back(idx[selT], selT);
+    for (uint32_t ic = rofData[selT][idx[selT]].firstEntry; ic < rofData[selT][idx[selT]].getEndIndex(); ic++) {
+      colDataRefs.emplace_back(ic, selT); // register indices of corresponding column data
+    }
+    ++idx[selT]; // increment used index
+    fillNextROFBC(selT);
+  }
+}

--- a/Detectors/MUON/MID/QC/exe/raw-checker.cxx
+++ b/Detectors/MUON/MID/QC/exe/raw-checker.cxx
@@ -122,7 +122,7 @@ int process(po::variables_map& vm)
         rofRecords.emplace_back(rof.interactionRecord, rof.eventType, rof.firstEntry + offset, rof.nEntries);
       }
       o2::InteractionRecord hb(0, iHB);
-      hbRecords.emplace_back(hb, o2::mid::EventType::Noise, offset, decoder->getData().size());
+      hbRecords.emplace_back(hb, o2::mid::EventType::Calib, offset, decoder->getData().size());
       ++iHB;
       if ((nHBs > 0 && iHB >= nHBs)) {
         break;

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/DecodedDataAggregator.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/DecodedDataAggregator.h
@@ -20,9 +20,9 @@
 #include <map>
 #include <gsl/gsl>
 #include "DataFormatsMID/ColumnData.h"
+#include "DataFormatsMID/ROBoard.h"
 #include "DataFormatsMID/ROFRecord.h"
 #include "MIDRaw/CrateMapper.h"
-#include "DataFormatsMID/ROBoard.h"
 
 namespace o2
 {
@@ -34,19 +34,20 @@ class DecodedDataAggregator
   void process(gsl::span<const ROBoard> localBoards, gsl::span<const ROFRecord> rofRecords);
 
   /// Gets the vector of data
-  const std::vector<ColumnData>& getData() { return mData; }
+  const std::vector<ColumnData>& getData(EventType eventType = EventType::Standard) { return mData[static_cast<int>(eventType)]; }
 
   /// Gets the vector of data RO frame records
-  const std::vector<ROFRecord>& getROFRecords() { return mROFRecords; }
+  const std::vector<ROFRecord>& getROFRecords(EventType eventType = EventType::Standard) { return mROFRecords[static_cast<int>(eventType)]; }
 
  private:
-  void addData(const ROBoard& col, size_t firstEntry);
-  ColumnData& FindColumnData(uint8_t deId, uint8_t columnId, size_t firstEntry);
+  void addData(const ROBoard& col, size_t firstEntry, size_t evtTypeIdx);
+  ColumnData& FindColumnData(uint8_t deId, uint8_t columnId, size_t firstEntry, size_t evtTypeIdx);
 
-  std::map<uint64_t, std::vector<size_t>> mOrderIndexes; /// Map for time ordering the entries
-  std::vector<ColumnData> mData{};                       /// Vector of output column data
-  std::vector<ROFRecord> mROFRecords{};                  /// Vector of ROF records
-  CrateMapper mCrateMapper;                              /// Mapper to convert the RO info to ColumnData
+  std::array<std::map<uint64_t, std::vector<size_t>>, 3> mEventIndexes{}; /// Event indexes
+
+  std::array<std::vector<ColumnData>, 3> mData{};      /// Vector of output column data
+  std::array<std::vector<ROFRecord>, 3> mROFRecords{}; /// Vector of ROF records
+  CrateMapper mCrateMapper;                            /// Mapper to convert the RO info to ColumnData
 };
 } // namespace mid
 } // namespace o2

--- a/Detectors/MUON/MID/Raw/src/ELinkDataShaper.cxx
+++ b/Detectors/MUON/MID/Raw/src/ELinkDataShaper.cxx
@@ -70,7 +70,7 @@ EventType ELinkDataShaper::processSelfTriggered(uint16_t localClock, uint16_t& c
   if (mReceivedCalibration && (localClock == mExpectedFETClock)) {
     // Reset the calibration flag for this e-link
     mReceivedCalibration = false;
-    return EventType::Dead;
+    return EventType::FET;
   }
   return EventType::Standard;
 }
@@ -80,7 +80,7 @@ EventType ELinkDataShaper::processCalibrationTrigger(uint16_t localClock)
   /// Processes the calibration event
   mExpectedFETClock = localClock + mElectronicsDelay.calibToFET;
   mReceivedCalibration = true;
-  return EventType::Noise;
+  return EventType::Calib;
 }
 
 void ELinkDataShaper::processOrbitTrigger(uint16_t localClock, uint8_t triggerWord)

--- a/Detectors/MUON/MID/Raw/src/GBTOutputHandler.cxx
+++ b/Detectors/MUON/MID/Raw/src/GBTOutputHandler.cxx
@@ -55,7 +55,7 @@ EventType GBTOutputHandler::processSelfTriggered(size_t ilink, uint16_t localClo
   if ((mReceivedCalibration & linkMask) && (localClock == mExpectedFETClock[ilink])) {
     // Reset the calibration flag for this e-link
     mReceivedCalibration &= ~linkMask;
-    return EventType::Dead;
+    return EventType::FET;
   }
   return EventType::Standard;
 }
@@ -65,7 +65,7 @@ EventType GBTOutputHandler::processCalibrationTrigger(size_t ilink, uint16_t loc
   /// Processes the calibration event
   mExpectedFETClock[ilink] = localClock + mElectronicsDelay.calibToFET;
   mReceivedCalibration |= (1 << ilink);
-  return EventType::Noise;
+  return EventType::Calib;
 }
 
 void GBTOutputHandler::processOrbitTrigger(size_t ilink, uint16_t localClock, uint8_t triggerWord)

--- a/Detectors/MUON/MID/Workflow/CMakeLists.txt
+++ b/Detectors/MUON/MID/Workflow/CMakeLists.txt
@@ -1,23 +1,23 @@
-# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
-# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# Copyright 2019-2020 CERN and copyright holders of ALICE O2. See
+# https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 # All rights not expressly granted are reserved.
 #
-# This software is distributed under the terms of the GNU General Public
-# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+# This software is distributed under the terms of the GNU General Public License
+# v3 (GPL Version 3), copied verbatim in the file "COPYING".
 #
 # In applying this license CERN does not waive the privileges and immunities
-# granted to it by virtue of its status as an Intergovernmental Organization
-# or submit itself to any jurisdiction.
+# granted to it by virtue of its status as an Intergovernmental Organization or
+# submit itself to any jurisdiction.
 
 o2_add_library(
   MIDWorkflow
   TARGETVARNAME targetName
   SOURCES src/ClusterizerMCSpec.cxx
           src/ClusterizerSpec.cxx
+          src/DecodedDataAggregatorSpec.cxx
           src/DigitReaderSpec.cxx
           src/EntropyDecoderSpec.cxx
           src/EntropyEncoderSpec.cxx
-          src/RawAggregatorSpec.cxx
           src/RawCheckerSpec.cxx
           src/RawDecoderSpec.cxx
           src/RawGBTDecoderSpec.cxx

--- a/Detectors/MUON/MID/Workflow/include/MIDWorkflow/DecodedDataAggregatorSpec.h
+++ b/Detectors/MUON/MID/Workflow/include/MIDWorkflow/DecodedDataAggregatorSpec.h
@@ -9,13 +9,13 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file   MIDWorkflow/RawAggregatorSpec.h
-/// \brief  Data processor spec for MID raw data aggregator devices
+/// \file   MIDWorkflow/DecodedDataAggregatorSpec.h
+/// \brief  Data processor spec for MID decoded data aggregator devices
 /// \author Diego Stocco <Diego.Stocco at cern.ch>
 /// \date   26 February 2020
 
-#ifndef O2_MID_RAWAGGREGATORSPEC_H
-#define O2_MID_RAWAGGREGATORSPEC_H
+#ifndef O2_MID_DecodedDataAggregatorSpec_H
+#define O2_MID_DecodedDataAggregatorSpec_H
 
 #include "Framework/DataProcessorSpec.h"
 
@@ -23,8 +23,8 @@ namespace o2
 {
 namespace mid
 {
-framework::DataProcessorSpec getRawAggregatorSpec();
+framework::DataProcessorSpec getDecodedDataAggregatorSpec();
 } // namespace mid
 } // namespace o2
 
-#endif //O2_MID_RAWAGGREGATORSPEC_H
+#endif //O2_MID_DecodedDataAggregatorSpec_H

--- a/Detectors/MUON/MID/Workflow/include/MIDWorkflow/RawAggregatorSpec.h
+++ b/Detectors/MUON/MID/Workflow/include/MIDWorkflow/RawAggregatorSpec.h
@@ -1,0 +1,30 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDWorkflow/RawAggregatorSpec.h
+/// \brief  Data processor spec for MID raw data aggregator devices
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   26 February 2020
+
+#ifndef O2_MID_RAWAGGREGATORSPEC_H
+#define O2_MID_RAWAGGREGATORSPEC_H
+
+#include "Framework/DataProcessorSpec.h"
+
+namespace o2
+{
+namespace mid
+{
+framework::DataProcessorSpec getRawAggregatorSpec();
+} // namespace mid
+} // namespace o2
+
+#endif //O2_MID_RAWAGGREGATORSPEC_H

--- a/Detectors/MUON/MID/Workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/EntropyDecoderSpec.cxx
@@ -46,16 +46,22 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   mTimer.Start(false);
 
   auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
-
-  auto& rofs = pc.outputs().make<std::vector<o2::mid::ROFRecord>>(OutputRef{"rofs"});
-  auto& cols = pc.outputs().make<std::vector<o2::mid::ColumnData>>(OutputRef{"cols"});
+  std::array<std::vector<o2::mid::ROFRecord>, NEvTypes> rofs{};
+  std::array<std::vector<o2::mid::ColumnData>, NEvTypes> cols{};
 
   // since the buff is const, we cannot use EncodedBlocks::relocate directly, instead we wrap its data to another flat object
   const auto ctfImage = o2::mid::CTF::getImage(buff.data());
   mCTFCoder.decode(ctfImage, rofs, cols);
 
+  for (uint32_t it = 0; it < NEvTypes; it++) {
+    pc.outputs().snapshot(Output{o2::header::gDataOriginMID, "DATA", it, Lifetime::Timeframe}, cols[it]);
+    pc.outputs().snapshot(Output{o2::header::gDataOriginMID, "DATAROF", it, Lifetime::Timeframe}, rofs[it]);
+  }
+
   mTimer.Stop();
-  LOG(INFO) << "Decoded " << cols.size() << " MID columns in " << rofs.size() << " ROFRecords in " << mTimer.CpuTime() - cput << " s";
+  LOG(INFO) << "Decoded {" << cols[0].size() << ',' << cols[1].size() << ',' << cols[2].size()
+            << "} MID columns for {" << rofs[0].size() << ',' << rofs[1].size() << ',' << rofs[2].size()
+            << "} ROFRecords in " << mTimer.CpuTime() - cput << " s";
 }
 
 void EntropyDecoderSpec::endOfStream(EndOfStreamContext& ec)
@@ -66,9 +72,11 @@ void EntropyDecoderSpec::endOfStream(EndOfStreamContext& ec)
 
 DataProcessorSpec getEntropyDecoderSpec()
 {
-  std::vector<OutputSpec> outputs{
-    OutputSpec{{"rofs"}, "MID", "DATAROF", 0, Lifetime::Timeframe},
-    OutputSpec{{"cols"}, "MID", "DATA", 0, Lifetime::Timeframe}};
+  std::vector<OutputSpec> outputs;
+  for (o2::header::DataHeader::SubSpecificationType subSpec = 0; subSpec < NEvTypes; ++subSpec) {
+    outputs.emplace_back(OutputSpec{header::gDataOriginMID, "DATA", subSpec});
+    outputs.emplace_back(OutputSpec{header::gDataOriginMID, "DATAROF", subSpec});
+  }
 
   return DataProcessorSpec{
     "mid-entropy-decoder",

--- a/Detectors/MUON/MID/Workflow/src/raw-to-digits-workflow.cxx
+++ b/Detectors/MUON/MID/Workflow/src/raw-to-digits-workflow.cxx
@@ -19,7 +19,7 @@
 #include "Framework/Variant.h"
 #include "Framework/ConfigParamSpec.h"
 #include "MIDWorkflow/RawDecoderSpec.h"
-#include "MIDWorkflow/RawAggregatorSpec.h"
+#include "MIDWorkflow/DecodedDataAggregatorSpec.h"
 #include "CommonUtils/ConfigurableParam.h"
 
 using namespace o2::framework;
@@ -64,7 +64,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   o2::framework::WorkflowSpec specs;
   specs.emplace_back(o2::mid::getRawDecoderSpec(false, feeIdConfig, crateMasks, electronicsDelay, askDISTSTF));
   if (!decodeOnly) {
-    specs.emplace_back(o2::mid::getRawAggregatorSpec());
+    specs.emplace_back(o2::mid::getDecodedDataAggregatorSpec());
   }
   return specs;
 }


### PR DESCRIPTION
During data taking MID receives software calibration triggers that are used to test noisy channels.
Few BCs after the reception of the calibration trigger, the MID returns a special event (Front-End-Test event) where all channels should anwer.
These events are used to test the dead channels.
These events are not reconstructed like the physics event, but are sent to separate workflows and used to generate masks.
Since they're not used in the standard reconstruction, they will be streamed on different specs to simplify operations.

The commits are meant to be atomic. Please do not squash.