### PR TITLE
[MRRTF-144] [O2-2486] mch-digits-to-raw: add per cru endpoint output

### DIFF
--- a/Detectors/MUON/MCH/Raw/Encoder/Digit/DigitRawEncoder.cxx
+++ b/Detectors/MUON/MCH/Raw/Encoder/Digit/DigitRawEncoder.cxx
@@ -63,7 +63,9 @@ void setupRawFileWriter(o2::raw::RawFileWriter& fw, const std::set<LinkInfo>& li
   std::string output = fmt::format("{:s}/mch", opt.outputDir);
 
   // Register the corresponding links (might have several solars for 1 link)
-  registerLinks(fw, output, links, opt.filePerLink);
+  registerLinks(fw, output, links,
+                opt.splitMode == OutputSplit::PerLink,
+                opt.splitMode == OutputSplit::PerCruEndpoint);
 }
 
 Solar2LinkInfo getSolar2LinkInfo(bool userLogic, bool dummyElecMap, int userLogicVersion)
@@ -149,8 +151,11 @@ Digit2ElecMapper getDigit2Elec(bool dummyElecMap)
 
 std::ostream& operator<<(std::ostream& os, const DigitRawEncoderOptions& opt)
 {
-  os << fmt::format("output dir {} filePerLink {} userLogic {} dummyElecMap {} ulVersion {}\n",
-                    opt.outputDir, opt.filePerLink, opt.userLogic, opt.dummyElecMap, opt.userLogicVersion);
+  os << fmt::format("output dir {} filePerLink {} filePerCruEndpoint {} userLogic {} dummyElecMap {} ulVersion {}\n",
+                    opt.outputDir,
+                    opt.splitMode == OutputSplit::PerLink,
+                    opt.splitMode == OutputSplit::PerCruEndpoint,
+                    opt.userLogic, opt.dummyElecMap, opt.userLogicVersion);
   return os;
 }
 

--- a/Detectors/MUON/MCH/Raw/Encoder/Digit/digits-to-raw.cxx
+++ b/Detectors/MUON/MCH/Raw/Encoder/Digit/digits-to-raw.cxx
@@ -112,6 +112,8 @@ int main(int argc, char* argv[])
     opts.splitMode = OutputSplit::PerCruEndpoint;
   } else if (fileFor == "all") {
     opts.splitMode = OutputSplit::None;
+  } else {
+    throw po::validation_error(po::validation_error::invalid_option_value, "file-for");
   }
   opts.userLogic = vm["userLogic"].as<bool>();
   opts.dummyElecMap = vm["dummy-elecmap"].as<bool>();

--- a/Detectors/MUON/MCH/Raw/Encoder/Digit/digits-to-raw.cxx
+++ b/Detectors/MUON/MCH/Raw/Encoder/Digit/digits-to-raw.cxx
@@ -30,7 +30,7 @@
 *
 * Typical usage :
 *
-* o2-mch-digits-to-raw --input-file mchdigits.root --file-per-link
+* o2-mch-digits-to-raw --input-file mchdigits.root --file-for link
 *
 * Note: the dummy-elecmap adds some complexity here,
 * but is used as a mean to get the electronic mapping for the whole detector
@@ -55,7 +55,7 @@ int main(int argc, char* argv[])
       ("userLogic,u",po::bool_switch()->default_value(true),"user logic format")
       ("dummy-elecmap,d",po::bool_switch()->default_value(false),"use a dummy electronic mapping (for testing only, to be removed at some point)")
       ("output-dir,o",po::value<std::string>()->default_value("./"),"output directory for file(s)")
-      ("file-per-link,l", po::value<bool>()->default_value(false)->implicit_value(true), "produce single file per link")
+      ("file-for,f", po::value<std::string>()->default_value("all"), "output one file (file-for=all), per link (file-for=link) or per cru end point (file-for=cru)")
       ("input-file,i",po::value<std::string>(&input)->default_value("mchdigits.root"),"input file name")
       ("configKeyValues", po::value<std::string>()->default_value(""), "comma-separated configKeyValues")
       ("no-empty-hbf,e", po::value<bool>()->default_value(false), "do not create empty HBF pages (except for HBF starting TF)")
@@ -105,7 +105,14 @@ int main(int argc, char* argv[])
 
   opts.noEmptyHBF = vm["no-empty-hbf"].as<bool>();
   opts.outputDir = vm["output-dir"].as<std::string>();
-  opts.filePerLink = vm["file-per-link"].as<bool>();
+  auto fileFor = vm["file-for"].as<std::string>();
+  if (fileFor == "link") {
+    opts.splitMode = OutputSplit::PerLink;
+  } else if (fileFor == "cru") {
+    opts.splitMode = OutputSplit::PerCruEndpoint;
+  } else if (fileFor == "all") {
+    opts.splitMode = OutputSplit::None;
+  }
   opts.userLogic = vm["userLogic"].as<bool>();
   opts.dummyElecMap = vm["dummy-elecmap"].as<bool>();
   opts.rawFileWriterVerbosity = vm["raw-file-writer-verbosity"].as<int>();

--- a/Detectors/MUON/MCH/Raw/Encoder/Digit/include/MCHRawEncoderDigit/DigitRawEncoder.h
+++ b/Detectors/MUON/MCH/Raw/Encoder/Digit/include/MCHRawEncoderDigit/DigitRawEncoder.h
@@ -29,18 +29,24 @@
 namespace o2::mch::raw
 {
 
+enum class OutputSplit : int {
+  None,          // no splitting, i.e. one file for all
+  PerLink,       // one file per link
+  PerCruEndpoint // one file per CRU endpoint
+};
+
 struct DigitRawEncoderOptions {
-  std::string outputDir = ".";    // directory where the raw data files will be written
-  bool chargeSumMode = true;      // whether to encode only charge sum or all samples (usually true)
-  bool filePerLink = true;        // whether or not to output one file per link (usually true)
-  bool userLogic = true;          // whether or not to use user logic (usually true)
-  int userLogicVersion = 1;       // UL version (only relevant if userLogic=true)
-  bool noEmptyHBF = false;        // disable writing of empty HBFs (for debug)
-  bool noGRP = false;             // do not try to read GRP information (for debug or unit tests)
-  bool dummyElecMap = false;      // use dummy electronic mapping (for debug only, temporary)
-  bool writeHB = true;            // write Heatbeat headers at start of time frame
-  int rawFileWriterVerbosity = 0; // verbosity of the RawFileWriter
-  int rdhVersion = 6;             // RDH version to use
+  std::string outputDir = ".";                  // directory where the raw data files will be written
+  bool chargeSumMode = true;                    // whether to encode only charge sum or all samples (usually true)
+  OutputSplit splitMode = OutputSplit::PerLink; // how to organize raw output file(s)
+  bool userLogic = true;                        // whether or not to use user logic (usually true)
+  int userLogicVersion = 1;                     // UL version (only relevant if userLogic=true)
+  bool noEmptyHBF = false;                      // disable writing of empty HBFs (for debug)
+  bool noGRP = false;                           // do not try to read GRP information (for debug or unit tests)
+  bool dummyElecMap = false;                    // use dummy electronic mapping (for debug only, temporary)
+  bool writeHB = true;                          // write Heatbeat headers at start of time frame
+  int rawFileWriterVerbosity = 0;               // verbosity of the RawFileWriter
+  int rdhVersion = 6;                           // RDH version to use
 };
 
 class DigitRawEncoder

--- a/Detectors/MUON/MCH/Raw/Encoder/Payload/PayloadPaginator.cxx
+++ b/Detectors/MUON/MCH/Raw/Encoder/Payload/PayloadPaginator.cxx
@@ -71,15 +71,39 @@ o2::header::RDHAny rdhFromLinkInfo(LinkInfo li)
   return rdh;
 }
 
+std::string flpName(LinkInfo li)
+{
+  static std::array<int, 33> cru2flp = {
+    148, 148, 148, //  0, 1, 2 // FIXME: to be x-checked for St12
+    149, 149, 149, //  3, 4, 5 // FIXME: to be x-checked for St12
+    150, 150, 150, //  6, 7, 8 // FIXME: to be x-checked for St12
+    151, 151, 151, //  9,10,11 CH5
+    152, 152, 152, // 12,13,14 CH6
+    153, 153, 153, // 15,16,17 CH7o+CH8o (L)
+    154, 154, 154, // 18,19,20 CH7i+CH8i (R)
+    155, 155, 155, // 21,22,23 CH8i+CH9i (L)
+    156, 156, 156, // 24,25,26 CH8o+CH9o (R)
+    157, 157, 0,   // 27,28,xx CH10o (L)
+    158, 158, 0    // 30,31,xx CH10i (R)
+  };
+  if (li.cruId > 32) {
+    throw std::invalid_argument("cruId should be <= 32");
+  }
+  return fmt::format("alio2-cr1-flp{}", cru2flp[li.cruId]);
+}
+
 void registerLinks(o2::raw::RawFileWriter& rawFileWriter,
                    std::string outputBase,
                    const std::set<LinkInfo>& links,
-                   bool filePerLink)
+                   bool filePerLink,
+                   bool filePerCru)
 {
   std::string output = fmt::format("{:s}.raw", outputBase);
   for (auto li : links) {
     if (filePerLink) {
       output = fmt::format("{:s}_feeid{:d}.raw", outputBase, li.feeId);
+    } else if (filePerCru) {
+      output = fmt::format("{:s}_{:s}_cru{:d}_{:d}.raw", outputBase, flpName(li), li.cruId, li.endPoint);
     }
     rawFileWriter.registerLink(rdhFromLinkInfo(li), output);
   }

--- a/Detectors/MUON/MCH/Raw/Encoder/Payload/PayloadPaginator.cxx
+++ b/Detectors/MUON/MCH/Raw/Encoder/Payload/PayloadPaginator.cxx
@@ -100,10 +100,12 @@ void registerLinks(o2::raw::RawFileWriter& rawFileWriter,
 {
   std::string output = fmt::format("{:s}.raw", outputBase);
   for (auto li : links) {
-    if (filePerLink) {
-      output = fmt::format("{:s}_feeid{:d}.raw", outputBase, li.feeId);
-    } else if (filePerCru) {
-      output = fmt::format("{:s}_{:s}_cru{:d}_{:d}.raw", outputBase, flpName(li), li.cruId, li.endPoint);
+    if (filePerLink || filePerCru) {
+      output = fmt::format("{:s}_{:s}_cru{:d}_{:d}", outputBase, flpName(li), li.cruId, li.endPoint);
+      if (filePerLink) {
+        output += fmt::format("_feedid{:d}", li.feeId);
+      }
+      output += ".raw";
     }
     rawFileWriter.registerLink(rdhFromLinkInfo(li), output);
   }

--- a/Detectors/MUON/MCH/Raw/Encoder/Payload/include/MCHRawEncoderPayload/PayloadPaginator.h
+++ b/Detectors/MUON/MCH/Raw/Encoder/Payload/include/MCHRawEncoderPayload/PayloadPaginator.h
@@ -48,7 +48,8 @@ Solar2LinkInfo createSolar2LinkInfo();
 void registerLinks(o2::raw::RawFileWriter& rawFileWriter,
                    std::string outputBase,
                    const std::set<LinkInfo>& links,
-                   bool filePerLink);
+                   bool filePerLink,
+                   bool filePerCru);
 
 void paginate(o2::raw::RawFileWriter& rawFileWriter,
               gsl::span<const std::byte> buffer,

--- a/Detectors/MUON/MCH/Raw/test/testClosureCoDec.cxx
+++ b/Detectors/MUON/MCH/Raw/test/testClosureCoDec.cxx
@@ -81,7 +81,7 @@ std::vector<std::byte> paginate(gsl::span<const std::byte> buffer, const std::st
     links.insert(solar2LinkInfo(solarId).value());
   }
 
-  registerLinks(fw, tmpbasename, links, false);
+  registerLinks(fw, tmpbasename, links, false, false);
 
   paginate(fw, buffer, links, solar2LinkInfo);
 

--- a/Detectors/MUON/MCH/Raw/test/testClosureCoDecDigit.cxx
+++ b/Detectors/MUON/MCH/Raw/test/testClosureCoDecDigit.cxx
@@ -88,11 +88,11 @@ void writeDigits(bool useDummyElecMap)
     digits.emplace_back(100, 6664, 664, 123, 1);
 
     DigitRawEncoderOptions opts;
-    opts.filePerLink = false;  // to get only one file
-    opts.noGRP = true;         // as we don't have a GRP at hand
-    opts.noEmptyHBF = true;    // as we don't want to create big files
-    opts.writeHB = false;      // as we'd like to keep it simple
-    opts.userLogicVersion = 1; // test only the latest version
+    opts.splitMode = OutputSplit::None; // to get only one file
+    opts.noGRP = true;                  // as we don't have a GRP at hand
+    opts.noEmptyHBF = true;             // as we don't want to create big files
+    opts.writeHB = false;               // as we'd like to keep it simple
+    opts.userLogicVersion = 1;          // test only the latest version
     opts.dummyElecMap = useDummyElecMap;
 
     DigitRawEncoder dre(opts);

--- a/prodtests/full_system_test.sh
+++ b/prodtests/full_system_test.sh
@@ -111,7 +111,7 @@ taskwrapper fddraw.log o2-fdd-digit2raw --file-per-link  -o raw/FDD
 taskwrapper tpcraw.log o2-tpc-digits-to-rawzs  --file-for link  -i tpcdigits.root -o raw/TPC
 taskwrapper tofraw.log o2-tof-reco-workflow ${GLOBALDPLOPT} --tof-raw-file-for link --output-type raw --tof-raw-outdir raw/TOF
 taskwrapper midraw.log o2-mid-digits-to-raw-workflow ${GLOBALDPLOPT} --mid-raw-outdir raw/MID --mid-raw-perlink
-taskwrapper mchraw.log o2-mch-digits-to-raw --input-file mchdigits.root --output-dir raw/MCH --file-per-link
+taskwrapper mchraw.log o2-mch-digits-to-raw --input-file mchdigits.root --output-dir raw/MCH --file-for link
 taskwrapper emcraw.log o2-emcal-rawcreator --file-for link -o raw/EMC
 taskwrapper phsraw.log o2-phos-digi2raw  --file-for link -o raw/PHS
 taskwrapper cpvraw.log o2-cpv-digi2raw  --file-for link -o raw/CPV


### PR DESCRIPTION
and replaces `--file-per-link` option with `--file-for (all,cru,link)`
one.