### PR TITLE
Optional fall-back dir. for CTFwriter + free space check on primary one

### DIFF
--- a/Detectors/CTF/README.md
+++ b/Detectors/CTF/README.md
@@ -21,6 +21,19 @@ For the storage optimization reason one can request multiple CTFs stored in the 
 o2-ctf-writer --min-file-size <min> --max-file-size <max> ...
 ```
 will accumulate CTFs in entries of the same tree/file until its size fits exceeds `min` and does not exceed `max` (`max` check is disabled if `max<=min`) or EOS received.
+The `--max-file-size` limit will be ignored if the very first CTF already exceeds it.
+
+The output directory (by default: `cwd`) for CTFs can be set via `--output-dir` option and must exist. Since in on the EPNs we may store the CTFs on the RAM disk of limited capacity, one can indicate the fall-back storage via `--output-dir-alt` option. The writer will switch to it if
+(i) `szCheck = max(min-file-size*1.1, max-file-size)` is positive and (ii) estimated (accounting for eventual other CTFs files written concurrently) available space on the primary storage is below the `szCheck`. The available space is estimated as:
+````
+current physically available space
+-
+number still open CTF files from concurrent writers * szCheck
++
+the current size of these files
+````
+
+Option `--ctf-dict-dir <dir>` can be provided to indicate the (existing) directory for the dictionary IO.
 
 ## CTF reader workflow
 

--- a/Detectors/CTF/workflow/include/CTFWorkflow/CTFWriterSpec.h
+++ b/Detectors/CTF/workflow/include/CTFWorkflow/CTFWriterSpec.h
@@ -25,7 +25,7 @@ namespace ctf
 
 /// create a processor spec
 framework::DataProcessorSpec getCTFWriterSpec(o2::detectors::DetID::mask_t dets, uint64_t run, bool doCTF = true,
-                                              bool doDict = false, bool dictPerDet = false, size_t smn = 0, size_t szmx = 0);
+                                              bool doDict = false, bool dictPerDet = false);
 
 } // namespace ctf
 } // namespace o2

--- a/Detectors/CTF/workflow/src/ctf-writer-workflow.cxx
+++ b/Detectors/CTF/workflow/src/ctf-writer-workflow.cxx
@@ -34,8 +34,6 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   options.push_back(ConfigParamSpec{"dict-per-det", VariantType::Bool, false, {"create dictionary file per detector"}});
   options.push_back(ConfigParamSpec{"grpfile", VariantType::String, o2::base::NameConf::getGRPFileName(), {"name of the grp file"}});
   options.push_back(ConfigParamSpec{"no-grp", VariantType::Bool, false, {"do not read GRP file"}});
-  options.push_back(ConfigParamSpec{"min-file-size", VariantType::Int64, 0l, {"accumulate CTFs until given file size reached"}});
-  options.push_back(ConfigParamSpec{"max-file-size", VariantType::Int64, 0l, {"if > 0, avoid exceeding given file size in accumulation mode"}});
   options.push_back(ConfigParamSpec{"output-type", VariantType::String, "ctf", {"output types: ctf (per TF) or dict (create dictionaries) or both or none"}});
   options.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}});
   std::swap(workflowOptions, options);
@@ -90,9 +88,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     } else {
       throw std::invalid_argument("Invalid output-type");
     }
-    szMin = configcontext.options().get<int64_t>("min-file-size");
-    szMax = configcontext.options().get<int64_t>("max-file-size");
   }
-  WorkflowSpec specs{o2::ctf::getCTFWriterSpec(dets, run, doCTF, doDict, dictPerDet, szMin, szMax)};
+  WorkflowSpec specs{o2::ctf::getCTFWriterSpec(dets, run, doCTF, doDict, dictPerDet)};
   return std::move(specs);
 }


### PR DESCRIPTION
Since in on the EPNs we may store the CTFs on the RAM disk of limited capacity, one can
indicate the fall-back storage via `--output-dir-alt <dir>` option. The writer will switch to it if
(i) `szCheck = max(min-file-size*1.1, max-file-size)` is positive and
(ii) estimated (accounting for eventual other CTFs files written concurrently) available space on
the primary storage is below the `szCheck`. The  available space is estimated as 
````
current physically available space
-
number still open CTF files from concurrent writers * szCheck
+
the current size of these files
````
The fall-back storage is not checked for the available space.