### PR TITLE
MCH: add time clustering of MCH digits

### DIFF
--- a/Detectors/MUON/MCH/PreClustering/CMakeLists.txt
+++ b/Detectors/MUON/MCH/PreClustering/CMakeLists.txt
@@ -12,4 +12,4 @@
 o2_add_library(MCHPreClustering
         SOURCES src/PreClusterFinder.cxx
         src/PreClusterFinderMapping.cxx
-        PUBLIC_LINK_LIBRARIES O2::MCHMappingImpl3 O2::MCHBase O2::Framework)
+        PUBLIC_LINK_LIBRARIES O2::MCHMappingImpl4 O2::MCHBase O2::Framework)

--- a/Detectors/MUON/MCH/TimeClustering/CMakeLists.txt
+++ b/Detectors/MUON/MCH/TimeClustering/CMakeLists.txt
@@ -9,18 +9,16 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-add_subdirectory(Base)
-add_subdirectory(Contour)
-add_subdirectory(Mapping)
-add_subdirectory(TimeClustering)
-add_subdirectory(PreClustering)
-add_subdirectory(Geometry)
-add_subdirectory(Clustering)
-add_subdirectory(Simulation)
-add_subdirectory(Tracking)
-add_subdirectory(Raw)
-add_subdirectory(CTF)
-add_subdirectory(Workflow)
-add_subdirectory(Conditions)
-add_subdirectory(Calibration)
-add_subdirectory(DevIO)
+o2_add_library(MCHTimeClustering
+        SOURCES src/ROFTimeClusterFinder.cxx
+        PUBLIC_LINK_LIBRARIES O2::MCHBase O2::Framework)
+
+if(BUILD_TESTING)
+
+        o2_add_test(time-cluster-finder
+                SOURCES src/testROFTimeClusterFinder.cxx
+                COMPONENT_NAME mchtimeclustering
+                LABELS "muon;mch;timeclustering"
+                PUBLIC_LINK_LIBRARIES O2::MCHRawDecoder O2::MCHTimeClustering Boost::boost)
+
+endif()

--- a/Detectors/MUON/MCH/TimeClustering/include/MCHTimeClustering/ROFTimeClusterFinder.h
+++ b/Detectors/MUON/MCH/TimeClustering/include/MCHTimeClustering/ROFTimeClusterFinder.h
@@ -42,7 +42,7 @@ class ROFTimeClusterFinder
   void process();
 
   /// return the vector of time-cluster ROFs
-  ROFVector getROFRecords() { return mOutputROFs; }
+  const ROFVector& getROFRecords() const { return mOutputROFs; }
 
   /// stores the output ROFs into a flat memory buffer
   char* saveROFRsToBuffer(size_t& bufSize);

--- a/Detectors/MUON/MCH/TimeClustering/include/MCHTimeClustering/ROFTimeClusterFinder.h
+++ b/Detectors/MUON/MCH/TimeClustering/include/MCHTimeClustering/ROFTimeClusterFinder.h
@@ -1,0 +1,101 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file ROFTimeClusterFinder.h
+/// \brief Class to group the fired pads according to their time stamp
+///
+/// \author Andrea Ferrero, CEA
+
+#ifndef ALICEO2_MCH_ROFTIMECLUSTERFINDER_H_
+#define ALICEO2_MCH_ROFTIMECLUSTERFINDER_H_
+
+#include <cassert>
+#include <cstdint>
+#include <vector>
+#include <gsl/span>
+
+#include "DataFormatsMCH/Digit.h"
+#include "DataFormatsMCH/ROFRecord.h"
+
+namespace o2
+{
+namespace mch
+{
+
+class ROFTimeClusterFinder
+{
+ public:
+  using ROFVector = std::vector<o2::mch::ROFRecord>;
+
+  ROFTimeClusterFinder(gsl::span<const o2::mch::ROFRecord> rof, uint32_t timeClusterSize, uint32_t nBins, int debug);
+  ~ROFTimeClusterFinder() = default;
+
+  /// process the digit ROFs and create the time clusters
+  void process();
+
+  /// return the vector of time-cluster ROFs
+  ROFVector getROFRecords() { return mOutputROFs; }
+
+  /// stores the output ROFs into a flat memory buffer
+  char* saveROFRsToBuffer(size_t& bufSize);
+
+  /// debugging output
+  void dumpInputROFs();
+  void dumpOutputROFs();
+
+ private:
+  /// structure representing one bin in the time histogram used for the peak search algorithm
+  struct TimeBin {
+    int32_t mFirstIdx{-1}; ///< index of the first digit ROF in the bin
+    int32_t mLastIdx{-1};  ///< index of the last digit ROF in the bin
+    uint32_t mSize{0};     ///< number of digit ROFs in the bin
+    uint32_t mNDigits{0};  ///< number of digits in the bin
+
+    TimeBin() = default;
+
+    bool empty() { return mNDigits == 0; }
+
+    bool operator<(const TimeBin& other) { return (mNDigits < other.mNDigits); }
+    bool operator>(const TimeBin& other) { return (mNDigits > other.mNDigits); }
+    bool operator<=(const TimeBin& other) { return (mNDigits <= other.mNDigits); }
+    bool operator>=(const TimeBin& other) { return (mNDigits >= other.mNDigits); }
+  };
+
+  // peak search parameters
+  static constexpr uint32_t sMaxOrbitsInTF = 256;                              ///< upper limit of the time frame size
+  static constexpr uint32_t sBcInOneOrbit = o2::constants::lhc::LHCMaxBunches; ///< number of bunch-crossings in one orbit
+  static constexpr uint32_t sBcInOneTF = sBcInOneOrbit * sMaxOrbitsInTF;       ///< maximum number of bunch-crossings in one time frame
+
+  uint32_t mTimeClusterSize;  ///< maximum size of one time cluster, in bunch crossings
+  uint32_t mNbinsInOneWindow; ///< number of time bins considered for the peak search
+  double mBinWidth;           ///< width of one time bin in the peak search algorithm, in bunch crossings
+  uint32_t mNbinsInOneTF;     ///< maximum number of peak search bins in one time frame
+
+  /// fill the time histogram for the peak search algorithm
+  void initTimeBins();
+  /// search for the next peak in the time histogram
+  int32_t getNextPeak();
+  /// create an output ROF containing all the digits in the [firstBin,lastBin] range of the time histogram
+  void storeROF(int32_t firstBin, int32_t lastBin);
+
+  std::vector<TimeBin> mTimeBins; ///< time histogram for the peak search algorithm
+  int32_t mLastSavedTimeBin;      ///< index of the last bin that has been stored in the output ROFs
+
+  gsl::span<const o2::mch::ROFRecord> mInputROFs; ///< input digit ROFs
+  ROFVector mOutputROFs{};                        ///< output time cluster ROFs
+  //o2::InteractionRecord mTFstart;                 ///< beginning of the time frame being processed
+  int mDebug{true};
+};
+
+} // namespace mch
+} // namespace o2
+
+#endif // ALICEO2_MCH_ROFTIMECLUSTERFINDER_H_

--- a/Detectors/MUON/MCH/TimeClustering/src/ROFTimeClusterFinder.cxx
+++ b/Detectors/MUON/MCH/TimeClustering/src/ROFTimeClusterFinder.cxx
@@ -1,0 +1,278 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "MCHTimeClustering/ROFTimeClusterFinder.h"
+
+#include <iostream>
+#include <fmt/format.h>
+
+namespace o2
+{
+namespace mch
+{
+
+using namespace std;
+
+//_________________________________________________________________________________________________
+
+ROFTimeClusterFinder::ROFTimeClusterFinder(gsl::span<const o2::mch::ROFRecord> rofs, uint32_t timeClusterSize, uint32_t nBins, int debug) : mInputROFs(rofs), mTimeClusterSize(timeClusterSize), mNbinsInOneWindow(nBins), mDebug(debug)
+{
+  // bin width in bunch crossing units
+  mBinWidth = mTimeClusterSize / mNbinsInOneWindow;
+  mNbinsInOneTF = sBcInOneTF / mBinWidth + 1;
+
+  mTimeBins.resize(mNbinsInOneTF);
+}
+
+//_________________________________________________________________________________________________
+
+void ROFTimeClusterFinder::initTimeBins()
+{
+  // initialize the time bins vector
+  std::fill(mTimeBins.begin(), mTimeBins.end(), TimeBin());
+
+  if (mInputROFs.empty()) {
+    return;
+  }
+
+  o2::InteractionRecord mFirstIR = mInputROFs.front().getBCData();
+
+  // store the number of digits in each bin
+  for (size_t iRof = 0; iRof < mInputROFs.size(); iRof++) {
+    const auto& rof = mInputROFs[iRof];
+    const auto& ir = rof.getBCData();
+    auto rofBc = ir.differenceInBC(mFirstIR);
+    auto binIdx = rofBc / mBinWidth;
+
+    if (binIdx < 0) {
+      continue;
+    } else if (binIdx >= mNbinsInOneTF) {
+      break;
+    }
+
+    auto& timeBin = mTimeBins[binIdx];
+
+    if (timeBin.mFirstIdx < 0) {
+      timeBin.mFirstIdx = iRof;
+    }
+    timeBin.mLastIdx = iRof;
+    timeBin.mSize += 1;
+    timeBin.mNDigits += rof.getNEntries();
+  }
+
+  if (mDebug) {
+    std::cout << "Peak search histogram:" << std::endl;
+    for (int32_t i = 0; i < mNbinsInOneTF; i++) {
+      if (mTimeBins[i].mNDigits > 0) {
+        std::cout << fmt::format("bin {}: {}", i, mTimeBins[i].mNDigits) << std::endl;
+      }
+    }
+  }
+}
+
+//_________________________________________________________________________________________________
+
+int32_t ROFTimeClusterFinder::getNextPeak()
+{
+  int32_t sPadding = mNbinsInOneWindow / 2;
+
+  if (mDebug) {
+    std::cout << "Searching peak from " << mLastSavedTimeBin + 1 << std::endl;
+  }
+
+  // loop over the bins and search for local maxima
+  // a local maxima is defined as a bin tht is higher than all the surrounding 4 bins (2 below and 2 above)
+  for (int32_t i = mLastSavedTimeBin + sPadding + 1; i < mNbinsInOneTF; i++) {
+    auto& peak = mTimeBins[i];
+    if (peak.empty()) {
+      continue;
+    }
+
+    bool found{true};
+    // the peak must be strictly higher than previous bins
+    for (int j = i - sPadding; j < i; j++) {
+      if (j >= 0 && peak <= mTimeBins[j]) {
+        found = false;
+        break;
+      }
+    }
+    // the peak must be higher than or equal to next bins
+    for (int j = i + 1; j <= i + sPadding; j++) {
+      if (j < mNbinsInOneTF && peak < mTimeBins[j]) {
+        found = false;
+        break;
+      }
+    }
+
+    if (!found) {
+      continue;
+    }
+
+    if (mDebug) {
+      std::cout << fmt::format("new peak found at bin {}, entries = {}", i, mTimeBins[i].mNDigits) << std::endl;
+    }
+
+    return i;
+  }
+  return -1;
+}
+
+//_________________________________________________________________________________________________
+
+void ROFTimeClusterFinder::storeROF(int32_t firstBin, int32_t lastBin)
+{
+  if (mDebug) {
+    std::cout << fmt::format("Storing ROF from bin range [{},{}]", firstBin, lastBin) << std::endl;
+  }
+
+  if (firstBin < 0) {
+    firstBin = 0;
+  }
+  if (lastBin >= mNbinsInOneTF) {
+    lastBin = mNbinsInOneTF - 1;
+  }
+
+  int32_t rofFirstIdx{-1};
+  int32_t rofLastIdx{-1};
+  uint32_t nDigits{0};
+  uint32_t nROFs{0};
+  for (int32_t j = firstBin; j <= lastBin; j++) {
+    auto& timeBin = mTimeBins[j];
+    if (timeBin.mFirstIdx < 0) {
+      continue;
+    }
+
+    if (rofFirstIdx < 0) {
+      rofFirstIdx = timeBin.mFirstIdx;
+    };
+    rofLastIdx = timeBin.mLastIdx;
+
+    nROFs += timeBin.mSize;
+    nDigits += timeBin.mNDigits;
+
+    if (mDebug) {
+      std::cout << fmt::format("  bin {}: firstIdx={}  size={}  ndigits={}", j, timeBin.mFirstIdx, timeBin.mSize, timeBin.mNDigits) << std::endl;
+    }
+  }
+
+  // a new time ROF is stored only if there are some digit ROFs in the interval
+  if (rofFirstIdx >= 0) {
+    // get the indexes of the first and last ROFs in this time cluster, and the corresponding interaction records
+    auto& firstRofInCluster = mInputROFs[rofFirstIdx];
+    auto& irFirst = firstRofInCluster.getBCData();
+    auto& lastRofInCluster = mInputROFs[rofLastIdx];
+    auto& irLast = lastRofInCluster.getBCData();
+
+    // get the index of the first digit in this time cluster
+    auto firstDigitIdx = firstRofInCluster.getFirstIdx();
+
+    // compute the width in BC units of the time-cluster ROF
+    auto bcDiff = irLast.differenceInBC(irFirst);
+    auto bcWidth = bcDiff + lastRofInCluster.getBCWidth();
+
+    // create a ROF that includes all the digits in this time cluster
+    mOutputROFs.emplace_back(irFirst, firstDigitIdx, nDigits, bcWidth);
+
+    if (mDebug) {
+      std::cout << fmt::format("new ROF stored: firstDigitIdx={}  size={}  bcWidth={}", firstDigitIdx, nDigits, bcWidth) << std::endl;
+    }
+  }
+
+  mLastSavedTimeBin = lastBin;
+}
+
+//_________________________________________________________________________________________________
+
+void ROFTimeClusterFinder::process()
+{
+  if (mDebug) {
+    std::cout << "\n\n==================\n[ROFTimeClusterFinder] processing new TF\n"
+              << std::endl;
+  }
+
+  initTimeBins();
+
+  mLastSavedTimeBin = -1;
+  int32_t peak{-1};
+  while ((peak = getNextPeak()) >= 0) {
+    int32_t peakStart = peak - mNbinsInOneWindow / 2;
+    int32_t peakEnd = peakStart + mNbinsInOneWindow - 1;
+
+    // peak found, we add the corresponding rof(s)
+    // first we fill the gap between the last peak and the current one, if needed
+    if (mDebug) {
+      std::cout << fmt::format("peakStart={}  mLastSavedTimeBin={}", peakStart, mLastSavedTimeBin) << std::endl;
+    }
+    while ((peakStart - mLastSavedTimeBin) > 1) {
+      int32_t firstBin = mLastSavedTimeBin + 1;
+      int32_t lastBin = firstBin + mNbinsInOneWindow - 1;
+      if (lastBin >= peakStart) {
+        lastBin = peakStart - 1;
+      }
+
+      storeROF(firstBin, lastBin);
+    }
+    storeROF(peakStart, peakEnd);
+  }
+}
+
+//_________________________________________________________________________________________________
+
+char* ROFTimeClusterFinder::saveROFRsToBuffer(size_t& bufSize)
+{
+  static constexpr size_t sizeOfROFRecord = sizeof(o2::mch::ROFRecord);
+
+  if (mDebug) {
+    dumpOutputROFs();
+  }
+
+  bufSize = mOutputROFs.size() * sizeOfROFRecord;
+  o2::mch::ROFRecord* buf = reinterpret_cast<o2::mch::ROFRecord*>(malloc(bufSize));
+  if (!buf) {
+    bufSize = 0;
+    return nullptr;
+  }
+
+  o2::mch::ROFRecord* p = buf;
+  for (size_t i = 0; i < mOutputROFs.size(); i++) {
+    auto& rof = mOutputROFs[i];
+    memcpy(p, &(rof), sizeOfROFRecord);
+    p += 1;
+  }
+
+  return reinterpret_cast<char*>(buf);
+}
+
+//_________________________________________________________________________________________________
+
+void ROFTimeClusterFinder::dumpInputROFs()
+{
+  for (size_t i = 0; i < mInputROFs.size(); i++) {
+    auto& rof = mInputROFs[i];
+    const auto ir = rof.getBCData();
+    std::cout << fmt::format("    ROF {}  RANGE {}-{}  SIZE {}  IR {}-{},{}\n", i, rof.getFirstIdx(), rof.getLastIdx(),
+                             rof.getNEntries(), ir.orbit, ir.bc, ir.toLong());
+  }
+}
+
+//_________________________________________________________________________________________________
+
+void ROFTimeClusterFinder::dumpOutputROFs()
+{
+  for (size_t i = 0; i < mOutputROFs.size(); i++) {
+    auto& rof = mOutputROFs[i];
+    std::cout << fmt::format("    ROF {}  RANGE {}-{}  SIZE {}  IR {}-{},{}\n", i, rof.getFirstIdx(), rof.getLastIdx(),
+                             rof.getNEntries(), rof.getBCData().orbit, rof.getBCData().bc, rof.getBCData().toLong());
+  }
+}
+
+} // namespace mch
+} // namespace o2

--- a/Detectors/MUON/MCH/TimeClustering/src/testROFTimeClusterFinder.cxx
+++ b/Detectors/MUON/MCH/TimeClustering/src/testROFTimeClusterFinder.cxx
@@ -14,7 +14,6 @@
 #define BOOST_TEST_DYN_LINK
 
 #include <vector>
-
 #include <boost/test/unit_test.hpp>
 #include <fmt/format.h>
 #include "MCHTimeClustering/ROFTimeClusterFinder.h"

--- a/Detectors/MUON/MCH/TimeClustering/src/testROFTimeClusterFinder.cxx
+++ b/Detectors/MUON/MCH/TimeClustering/src/testROFTimeClusterFinder.cxx
@@ -1,0 +1,248 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test MCHRaw ROFFinder
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+#include <fmt/format.h>
+#include "MCHTimeClustering/ROFTimeClusterFinder.h"
+
+BOOST_AUTO_TEST_SUITE(o2_mch_raw)
+
+BOOST_AUTO_TEST_SUITE(timeclustering)
+
+using ROFRecord = o2::mch::ROFRecord;
+using ROFVector = std::vector<ROFRecord>;
+
+//static constexpr uint32_t sWinSize = 1000 / 25;    // number of BC in 1 us
+//static constexpr uint32_t sBinsInOneWindow = 5;     // number of bins in wich the 1 us window is divided for the peak search
+//static constexpr uint32_t sBinWidth = sWinSize / sBinsInOneWindow; // 5 bins in one 1 us window
+
+static ROFVector makeROFs(std::vector<int> binEntries, uint32_t winSize, uint32_t nBinsInOneWindow)
+{
+  uint32_t binWidth = winSize / nBinsInOneWindow;
+  uint32_t orbit = 1;
+  uint32_t tfTime = 0;
+  size_t nBins = binEntries.size();
+  ROFVector rofRecords;
+
+  int firstDigitIdx = 0;
+  for (int bin = 0; bin < nBins; bin++) {
+    // one ROF in each peak search bin, for simplicity
+    // skip empty bins
+    if (binEntries[bin] == 0) {
+      continue;
+    }
+    o2::InteractionRecord ir(tfTime + bin * binWidth, orbit);
+    rofRecords.emplace_back(ir, firstDigitIdx, binEntries[bin], 4);
+    firstDigitIdx += binEntries[bin];
+  }
+  return rofRecords;
+}
+
+//----------------------------------------------------------------------------
+static ROFVector makeTimeROFs(std::vector<int> binEntries, uint32_t winSize, uint32_t nBinsInOneWindow)
+{
+  const auto& rofRecords = makeROFs(binEntries, winSize, nBinsInOneWindow);
+
+  o2::mch::ROFTimeClusterFinder rofProcessor(rofRecords, winSize, nBinsInOneWindow, 1);
+  rofProcessor.process();
+
+  const auto& rofTimeRecords = rofProcessor.getROFRecords();
+
+  return rofTimeRecords;
+}
+
+//----------------------------------------------------------------------------
+static std::vector<int> getBinIntegral(std::vector<int> binEntries)
+{
+  std::vector<int> integral = binEntries;
+  for (size_t i = 1; i < integral.size(); i++) {
+    integral[i] += integral[i - 1];
+    std::cout << fmt::format("bin[{}]={}  integral[{}]={}", i, binEntries[i], i, integral[i]) << std::endl;
+  }
+  return integral;
+}
+
+//----------------------------------------------------------------------------
+static void checkROF(const ROFRecord rof, std::vector<int> binEntries, uint32_t winSize, uint32_t nBinsInOneWindow, int start, int width)
+{
+  uint32_t binWidth = winSize / nBinsInOneWindow;
+  uint32_t orbit = 1;
+  uint32_t tfTime = 0;
+  std::vector<int> binIntegral = getBinIntegral(binEntries);
+
+  // checks of indexes and sizes
+  int firstIdx = binIntegral[start] - binEntries[start];
+  int size = binIntegral[start + width - 1] - firstIdx;
+  BOOST_CHECK_EQUAL(rof.getFirstIdx(), firstIdx);
+  BOOST_CHECK_EQUAL(rof.getNEntries(), size);
+
+  // checks of interaction records and BC widths
+  o2::InteractionRecord irStart(tfTime + start * binWidth, orbit);
+  BOOST_CHECK_EQUAL(rof.getBCData(), irStart);
+  int bcWidth = (width - 1) * binWidth + 4;
+  BOOST_CHECK_EQUAL(rof.getBCWidth(), bcWidth);
+}
+
+//----------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(OneTimeCluster)
+{
+  uint32_t orbit = 1;
+  uint32_t tfTime = 0;
+  uint32_t winSize = 1000 / 25;
+  uint32_t nBins = 5;
+  std::vector<int> binEntries = {1, 2, 5, 1, 2};
+  std::vector<int> binIntegral = getBinIntegral(binEntries);
+
+  const auto& rofTimeRecords = makeTimeROFs(binEntries, winSize, nBins);
+  BOOST_CHECK_EQUAL(rofTimeRecords.size(), 1);
+
+  checkROF(rofTimeRecords[0], binEntries, winSize, nBins, 0, 5);
+}
+
+//----------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(OneTimeClusterLargeWin)
+{
+  uint32_t orbit = 1;
+  uint32_t tfTime = 0;
+  uint32_t winSize = 1500 / 25;
+  uint32_t nBins = 5;
+  std::vector<int> binEntries = {1, 2, 5, 1, 2};
+  std::vector<int> binIntegral = getBinIntegral(binEntries);
+
+  const auto& rofTimeRecords = makeTimeROFs(binEntries, winSize, nBins);
+  BOOST_CHECK_EQUAL(rofTimeRecords.size(), 1);
+
+  checkROF(rofTimeRecords[0], binEntries, winSize, nBins, 0, 5);
+}
+
+//----------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(OneTimeCluster7bins)
+{
+  uint32_t orbit = 1;
+  uint32_t tfTime = 0;
+  uint32_t winSize = 1200 / 25;
+  uint32_t nBins = 7;
+  std::vector<int> binEntries = {1, 2, 1, 5, 1, 3, 2};
+  std::vector<int> binIntegral = getBinIntegral(binEntries);
+
+  const auto& rofTimeRecords = makeTimeROFs(binEntries, winSize, nBins);
+  BOOST_CHECK_EQUAL(rofTimeRecords.size(), 1);
+
+  checkROF(rofTimeRecords[0], binEntries, winSize, nBins, 0, 7);
+}
+
+//----------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(OneTimeClusterEmptyStart)
+{
+  uint32_t orbit = 1;
+  uint32_t tfTime = 0;
+  uint32_t winSize = 1000 / 25;
+  uint32_t nBins = 5;
+  std::vector<int> binEntries = {0, 1, 2, 5, 1};
+  std::vector<int> binIntegral = getBinIntegral(binEntries);
+
+  const auto& rofTimeRecords = makeTimeROFs(binEntries, winSize, nBins);
+  BOOST_CHECK_EQUAL(rofTimeRecords.size(), 1);
+
+  checkROF(rofTimeRecords[0], binEntries, winSize, nBins, 1, 4);
+}
+
+//----------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(OneTimeClusterEmptyEnd)
+{
+  uint32_t orbit = 1;
+  uint32_t tfTime = 0;
+  uint32_t winSize = 1000 / 25;
+  uint32_t nBins = 5;
+  std::vector<int> binEntries = {1, 2, 5, 1, 0};
+  std::vector<int> binIntegral = getBinIntegral(binEntries);
+
+  const auto& rofTimeRecords = makeTimeROFs(binEntries, winSize, nBins);
+  BOOST_CHECK_EQUAL(rofTimeRecords.size(), 1);
+
+  checkROF(rofTimeRecords[0], binEntries, winSize, nBins, 0, 4);
+}
+
+//----------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(TwoTimeClusters)
+{
+  uint32_t orbit = 1;
+  uint32_t tfTime = 0;
+  uint32_t winSize = 1000 / 25;
+  uint32_t nBins = 5;
+  std::vector<int> binEntries = {1, 2, 5, 1, 2, 2, 1, 6, 3, 1};
+  std::vector<int> binIntegral = getBinIntegral(binEntries);
+
+  const auto& rofTimeRecords = makeTimeROFs(binEntries, winSize, nBins);
+  BOOST_CHECK_EQUAL(rofTimeRecords.size(), 2);
+
+  checkROF(rofTimeRecords[0], binEntries, winSize, nBins, 0, 5);
+  checkROF(rofTimeRecords[1], binEntries, winSize, nBins, 5, 5);
+}
+
+//----------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(TwoTimeClustersWithEmptyGap)
+{
+  uint32_t orbit = 1;
+  uint32_t tfTime = 0;
+  uint32_t winSize = 1000 / 25;
+  uint32_t nBins = 5;
+  std::vector<int> binEntries = {1, 2, 5, 1, 2, 0, 2, 1, 6, 3, 1};
+  std::vector<int> binIntegral = getBinIntegral(binEntries);
+
+  const auto& rofTimeRecords = makeTimeROFs(binEntries, winSize, nBins);
+  BOOST_CHECK_EQUAL(rofTimeRecords.size(), 2);
+
+  checkROF(rofTimeRecords[0], binEntries, winSize, nBins, 0, 5);
+  checkROF(rofTimeRecords[1], binEntries, winSize, nBins, 6, 5);
+}
+
+//----------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(TwoTimeClustersWithNonEmptyGap)
+{
+  uint32_t orbit = 1;
+  uint32_t winSize = 1000 / 25;
+  uint32_t nBins = 5;
+  std::vector<int> binEntries = {1, 2, 5, 1, 2, 4, 5, 2, 1, 6, 3, 1};
+  std::vector<int> binIntegral = getBinIntegral(binEntries);
+
+  const auto& rofTimeRecords = makeTimeROFs(binEntries, winSize, nBins);
+  BOOST_CHECK_EQUAL(rofTimeRecords.size(), 3);
+
+  checkROF(rofTimeRecords[0], binEntries, winSize, nBins, 0, 5);
+  checkROF(rofTimeRecords[1], binEntries, winSize, nBins, 5, 2);
+  checkROF(rofTimeRecords[2], binEntries, winSize, nBins, 7, 5);
+}
+
+//----------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(OneTimeClusterWithGapAtBeginning)
+{
+  uint32_t orbit = 1;
+  uint32_t winSize = 1000 / 25;
+  uint32_t nBins = 5;
+  std::vector<int> binEntries = {1, 2, 5, 1, 6, 4, 5};
+  std::vector<int> binIntegral = getBinIntegral(binEntries);
+
+  const auto& rofTimeRecords = makeTimeROFs(binEntries, winSize, nBins);
+  BOOST_CHECK_EQUAL(rofTimeRecords.size(), 2);
+
+  checkROF(rofTimeRecords[0], binEntries, winSize, nBins, 0, 2);
+  checkROF(rofTimeRecords[1], binEntries, winSize, nBins, 2, 5);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END()

--- a/Detectors/MUON/MCH/Workflow/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Workflow/CMakeLists.txt
@@ -15,6 +15,7 @@ o2_add_library(MCHWorkflow
                    src/ClusterFinderOriginalSpec.cxx
                    src/DataDecoderSpec.cxx
                    src/EntropyDecoderSpec.cxx
+                   src/TimeClusterFinderSpec.cxx
                    src/PreClusterFinderSpec.cxx
                    src/TrackReaderSpec.cxx
                    src/TrackTreeReader.cxx
@@ -28,6 +29,7 @@ o2_add_library(MCHWorkflow
                    O2::MCHCTF
                    O2::MCHClustering
                    O2::MCHPreClustering
+                   O2::MCHTimeClustering
                    O2::MCHRawCommon
                    O2::MCHRawDecoder
                )
@@ -60,6 +62,12 @@ o2_add_executable(
 o2_add_executable(
         cru-page-to-digits-workflow
         SOURCES src/cru-page-to-digits-workflow.cxx
+        COMPONENT_NAME mch
+        PUBLIC_LINK_LIBRARIES O2::MCHWorkflow)
+
+o2_add_executable(
+        digits-to-timeclusters-workflow
+        SOURCES src/digits-to-timeclusters-workflow.cxx
         COMPONENT_NAME mch
         PUBLIC_LINK_LIBRARIES O2::MCHWorkflow)
 

--- a/Detectors/MUON/MCH/Workflow/README.md
+++ b/Detectors/MUON/MCH/Workflow/README.md
@@ -7,6 +7,7 @@
 <!-- vim-markdown-toc GFM -->
 
 * [Raw to digits](#raw-to-digits)
+* [Time clustering](#time-clustering)
 * [Preclustering](#preclustering)
 * [Clustering](#clustering)
 * [CTF encoding/decoding](#ctf-encodingdecoding)
@@ -62,13 +63,28 @@ dataDescription = RAWDATA
 filePath = /home/data/data-de819-ped-raw.raw
 ```
 
+## Time clustering
+
+```shell
+o2-mch-digits-to-timeclusters-workflow
+```
+
+Take as input the list of all digits ([Digit](/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h)) in the current time frame, with the data description "DIGITS", and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the digits associated to each interaction, with the data description "DIGITROFS". Send a new list of ROF records that combine all the digits correlated in time within a user-defined time window, with the data description "TIMECLUSTERROFS".
+
+The option `--time-cluster-width xxx` allows to set the width of the time correlation window.
+
+The time clustering is based on a brute-force peak search algorithm, which arranges the input digits into coarse time bins. The number of bins in one time cluster window can be set via the `--peak-search-nbins` option.
+
 ## Preclustering
 
 ```shell
 o2-mch-digits-to-preclusters-workflow
 ```
 
-Take as input the list of all digits ([Digit](/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h)) in the current time frame, with the data description "DIGITS", and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the digits associated to each interaction, with the data description "DIGITROFS". Send the list of all preclusters ([PreCluster](../Base/include/MCHBase/PreCluster.h)) in the time frame, the list of all associated digits ([Digit](/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the preclusters associated to each interaction in three separate messages with the data description "PRECLUSTERS", "PRECLUSTERDIGITS" and "PRECLUSTERROFS", respectively.
+Take as input the list of all digits ([Digit](/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h)) in the current time frame, with the data description "DIGITS", and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the digits associated to each interaction.
+The ROF records input can have the data description "inputrofs:MCH/DIGITROFS" if the direct output of the raw decoder is used, or "inputrofs:MCH/TIMECLUSTERROFS" if the time clustering output is used (default option). The ROF input description can be set on the command line via the `rof-spec` option.
+
+Send the list of all preclusters ([PreCluster](../Base/include/MCHBase/PreCluster.h)) in the time frame, the list of all associated digits ([Digit](/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the preclusters associated to each interaction in three separate messages with the data description "PRECLUSTERS", "PRECLUSTERDIGITS" and "PRECLUSTERROFS", respectively.
 
 Option `--check-no-leftover-digits xxx` allows to drop an error message (`xxx = "error"` (default)) or an exception (`xxx = "fatal"`) in case not all the input digits end up in a precluster, or to disable this check (`xxx = "off"`).
 

--- a/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/PreClusterFinderSpec.h
+++ b/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/PreClusterFinderSpec.h
@@ -24,7 +24,9 @@ namespace o2
 namespace mch
 {
 
-o2::framework::DataProcessorSpec getPreClusterFinderSpec(const char* rofDesc, const char* name = "PreClusterFinder");
+o2::framework::DataProcessorSpec
+  getPreClusterFinderSpec(const char* specName = "PreClusterFinder",
+                          const char* digitRofDataDescription = "DIGITROFS");
 
 } // end namespace mch
 } // end namespace o2

--- a/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/TimeClusterFinderSpec.h
+++ b/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/TimeClusterFinderSpec.h
@@ -9,13 +9,13 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file PreClusterFinderSpec.h
-/// \brief Definition of a data processor to run the preclusterizer
+/// \file TimeClusterFinderSpec.h
+/// \brief Definition of a data processor to run the time clusterizer
 ///
-/// \author Philippe Pillot, Subatech
+/// \author Andrea Ferrero, CEA
 
-#ifndef O2_MCH_PRECLUSTERFINDERSPEC_H_
-#define O2_MCH_PRECLUSTERFINDERSPEC_H_
+#ifndef O2_MCH_TIMECLUSTERFINDERSPEC_H_
+#define O2_MCH_TIMECLUSTERFINDERSPEC_H_
 
 #include "Framework/DataProcessorSpec.h"
 
@@ -24,9 +24,9 @@ namespace o2
 namespace mch
 {
 
-o2::framework::DataProcessorSpec getPreClusterFinderSpec(const char* rofDesc, const char* name = "PreClusterFinder");
+o2::framework::DataProcessorSpec getTimeClusterFinderSpec(const char* specName = "mch-time-cluster-finder");
 
 } // end namespace mch
 } // end namespace o2
 
-#endif // O2_MCH_PRECLUSTERFINDERSPEC_H_
+#endif // O2_MCH_TIMECLUSTERFINDERSPEC_H_

--- a/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/TimeClusterFinderSpec.h
+++ b/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/TimeClusterFinderSpec.h
@@ -24,7 +24,7 @@ namespace o2
 namespace mch
 {
 
-o2::framework::DataProcessorSpec getTimeClusterFinderSpec(const char* specName = "mch-time-cluster-finder");
+o2::framework::DataProcessorSpec getTimeClusterFinderSpec(const char* specName = "TimeClusterFinder");
 
 } // end namespace mch
 } // end namespace o2

--- a/Detectors/MUON/MCH/Workflow/src/PreClusterFinderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/PreClusterFinderSpec.cxx
@@ -32,6 +32,7 @@
 #include "Framework/Output.h"
 #include "Framework/Task.h"
 #include "Framework/Logger.h"
+#include "Framework/WorkflowSpec.h"
 
 #include "DataFormatsMCH/ROFRecord.h"
 #include "DataFormatsMCH/Digit.h"
@@ -186,13 +187,18 @@ class PreClusterFinderTask
 };
 
 //_________________________________________________________________________________________________
-o2::framework::DataProcessorSpec getPreClusterFinderSpec(const char* name)
+o2::framework::DataProcessorSpec getPreClusterFinderSpec(const char* rofDesc, const char* name)
 {
+  std::string rofSpec = std::string("digitrofs:MCH/") + rofDesc;
+  auto inputs = o2::framework::select(rofSpec.c_str());
+  for (auto& inp : inputs) {
+    inp.lifetime = Lifetime::Timeframe;
+  }
+  inputs.emplace_back("digits", "MCH", "DIGITS", 0, Lifetime::Timeframe);
+
   std::string helpstr = "[off/error/fatal] check that all digits are included in pre-clusters";
   return DataProcessorSpec{
-    name,
-    Inputs{InputSpec{"digitrofs", "MCH", "DIGITROFS", 0, Lifetime::Timeframe},
-           InputSpec{"digits", "MCH", "DIGITS", 0, Lifetime::Timeframe}},
+    name, inputs,
     Outputs{OutputSpec{{"preclusterrofs"}, "MCH", "PRECLUSTERROFS", 0, Lifetime::Timeframe},
             OutputSpec{{"preclusters"}, "MCH", "PRECLUSTERS", 0, Lifetime::Timeframe},
             OutputSpec{{"preclusterdigits"}, "MCH", "PRECLUSTERDIGITS", 0, Lifetime::Timeframe}},

--- a/Detectors/MUON/MCH/Workflow/src/PreClusterFinderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/PreClusterFinderSpec.cxx
@@ -187,18 +187,16 @@ class PreClusterFinderTask
 };
 
 //_________________________________________________________________________________________________
-o2::framework::DataProcessorSpec getPreClusterFinderSpec(const char* rofDesc, const char* name)
+o2::framework::DataProcessorSpec getPreClusterFinderSpec(const char* specName,
+                                                         const char* digitRofDataDescription)
 {
-  std::string rofSpec = std::string("digitrofs:MCH/") + rofDesc;
-  auto inputs = o2::framework::select(rofSpec.c_str());
-  for (auto& inp : inputs) {
-    inp.lifetime = Lifetime::Timeframe;
-  }
-  inputs.emplace_back("digits", "MCH", "DIGITS", 0, Lifetime::Timeframe);
+  std::string input = "digits:MCH/DIGITS/0;";
+  input += fmt::format("digitrofs:MCH/{}/0", digitRofDataDescription);
 
   std::string helpstr = "[off/error/fatal] check that all digits are included in pre-clusters";
   return DataProcessorSpec{
-    name, inputs,
+    specName,
+    o2::framework::select(input.c_str()),
     Outputs{OutputSpec{{"preclusterrofs"}, "MCH", "PRECLUSTERROFS", 0, Lifetime::Timeframe},
             OutputSpec{{"preclusters"}, "MCH", "PRECLUSTERS", 0, Lifetime::Timeframe},
             OutputSpec{{"preclusterdigits"}, "MCH", "PRECLUSTERDIGITS", 0, Lifetime::Timeframe}},

--- a/Detectors/MUON/MCH/Workflow/src/TimeClusterFinderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TimeClusterFinderSpec.cxx
@@ -1,0 +1,142 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TimeClusterFinderSpec.cxx
+/// \brief Implementation of a data processor to run the time clusterizer
+///
+/// \author Andrea Ferrero, CEA
+
+#include "MCHWorkflow/TimeClusterFinderSpec.h"
+
+#include <iostream>
+#include <fstream>
+#include <chrono>
+#include <vector>
+
+#include <stdexcept>
+
+#include <fmt/core.h>
+
+#include "Framework/CallbackService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Lifetime.h"
+#include "Framework/Output.h"
+#include "Framework/Task.h"
+#include "Framework/Logger.h"
+
+#include "MCHRawDecoder/OrbitInfo.h"
+#include "MCHTimeClustering/ROFTimeClusterFinder.h"
+
+namespace o2
+{
+namespace mch
+{
+
+using namespace std;
+using namespace o2::framework;
+
+class TimeClusterFinderTask
+{
+ public:
+  //_________________________________________________________________________________________________
+  void init(framework::InitContext& ic)
+  {
+    mTimeClusterWidth = ic.options().get<int>("max-cluster-width");
+    mNbinsInOneWindow = ic.options().get<int>("peak-search-nbins");
+    // number of bins must be >= 3
+    if (mNbinsInOneWindow < 3) {
+      mNbinsInOneWindow = 3;
+    }
+    // number of bins must be odd
+    if ((mNbinsInOneWindow % 2) == 0) {
+      mNbinsInOneWindow += 1;
+    }
+
+    auto stop = [this]() {
+      LOGP(info, "\nfinder duration = {} us / TF\n", mTimeProcess.count() * 1000 / mTFcount);
+    };
+    ic.services().get<CallbackService>().set(CallbackService::Id::Stop, stop);
+  }
+
+  //_________________________________________________________________________________________________
+  void run(framework::ProcessingContext& pc)
+  {
+    const auto* dh = o2::header::get<o2::header::DataHeader*>(pc.inputs().getByPos(0).header);
+    auto firstTForbit = dh->firstTForbit;
+    // get the input rofs
+    auto rofs = pc.inputs().get<gsl::span<o2::mch::ROFRecord>>("rofs");
+
+    /*auto orbits = pc.inputs().get<gsl::span<uint64_t>>("orbits");
+    std::set<uint32_t> ordered_orbits;
+    for (auto orbitInfo : orbits) {
+      ordered_orbits.insert(orbitInfo & 0xFFFFFFFF);
+    }
+
+    firstTForbit = *(ordered_orbits.begin());
+    if (mDebug) {
+      std::cout << "First TF orbit: " << firstTForbit << std::endl;
+    }*/
+
+    o2::mch::ROFTimeClusterFinder rofProcessor(rofs, mTimeClusterWidth, mNbinsInOneWindow, 0);
+
+    if (mDebug) {
+      std::cout << "\n\n=====================\nInput ROFs:\n";
+      rofProcessor.dumpInputROFs();
+    }
+
+    auto tStart = std::chrono::high_resolution_clock::now();
+    rofProcessor.process();
+    auto tEnd = std::chrono::high_resolution_clock::now();
+    mTimeProcess += tEnd - tStart;
+
+    if (mDebug) {
+      std::cout << "\n=====================\nOutput ROFs:\n";
+      rofProcessor.dumpOutputROFs();
+    }
+
+    // send the output buffer via DPL
+    size_t rofsSize;
+    char* rofsBuffer = rofProcessor.saveROFRsToBuffer(rofsSize);
+
+    // create the output message
+    auto freefct = [](void* data, void*) { free(data); };
+    pc.outputs().adoptChunk(Output{header::gDataOriginMCH, "TIMECLUSTERROFS", 0}, rofsBuffer, rofsSize, freefct, nullptr);
+
+    mTFcount += 1;
+  }
+
+ private:
+  std::chrono::duration<double, std::milli> mTimeProcess{}; ///< timer
+
+  uint32_t mTimeClusterWidth; ///< maximum size of one time cluster, in bunch crossings
+  uint32_t mNbinsInOneWindow; ///< number of time bins considered for the peak search
+  int mTFcount{0};            ///< number of processed time frames
+  int mDebug{0};              ///< verbosity flag
+};
+
+//_________________________________________________________________________________________________
+o2::framework::DataProcessorSpec getTimeClusterFinderSpec(const char* specName)
+{
+  return DataProcessorSpec{
+    specName,
+    Inputs{InputSpec{"rofs", header::gDataOriginMCH, "DIGITROFS", 0, Lifetime::Timeframe},
+           InputSpec{"orbits", header::gDataOriginMCH, "ORBITS", 0, Lifetime::Timeframe}},
+    Outputs{OutputSpec{header::gDataOriginMCH, "TIMECLUSTERROFS", 0, Lifetime::Timeframe}},
+    AlgorithmSpec{adaptFromTask<TimeClusterFinderTask>()},
+    Options{{"debug", VariantType::Bool, false, {"enable verbose output"}},
+            {"max-cluster-width", VariantType::Int, 1000 / 25, {"maximum time width of time clusters, in BC units"}},
+            {"peak-search-nbins", VariantType::Int, 5, {"number of time bins for the peak search algorithm (must be an odd number >= 3)"}}}};
+}
+
+} // end namespace mch
+} // end namespace o2

--- a/Detectors/MUON/MCH/Workflow/src/TrackMCLabelFinderSpec.h
+++ b/Detectors/MUON/MCH/Workflow/src/TrackMCLabelFinderSpec.h
@@ -24,7 +24,9 @@ namespace o2
 namespace mch
 {
 
-o2::framework::DataProcessorSpec getTrackMCLabelFinderSpec(const char* name = "TrackMCLabelFinder");
+o2::framework::DataProcessorSpec
+  getTrackMCLabelFinderSpec(const char* specName = "TrackMCLabelFinder",
+                            const char* digitRofDataDescription = "DIGITROFS");
 
 } // end namespace mch
 } // end namespace o2

--- a/Detectors/MUON/MCH/Workflow/src/digits-to-preclusters-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/digits-to-preclusters-workflow.cxx
@@ -20,17 +20,25 @@
 #include "Framework/CallbackService.h"
 #include "Framework/ControlService.h"
 #include "Framework/Task.h"
-#include "Framework/runDataProcessing.h"
 #include "MCHWorkflow/PreClusterFinderSpec.h"
 
 using namespace o2;
 using namespace o2::framework;
 
-WorkflowSpec defineDataProcessing(const ConfigContext&)
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  workflowOptions.push_back(ConfigParamSpec{"rof-desc", VariantType::String, "TIMECLUSTERROFS", {"description string for the input ROF data"}});
+}
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(const ConfigContext& configcontext)
 {
   WorkflowSpec specs;
 
-  DataProcessorSpec producer = o2::mch::getPreClusterFinderSpec();
+  auto rofDesc = configcontext.options().get<std::string>("rof-desc");
+
+  DataProcessorSpec producer = o2::mch::getPreClusterFinderSpec(rofDesc.c_str());
   specs.push_back(producer);
 
   return specs;

--- a/Detectors/MUON/MCH/Workflow/src/digits-to-preclusters-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/digits-to-preclusters-workflow.cxx
@@ -27,19 +27,13 @@ using namespace o2::framework;
 
 void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
-  workflowOptions.push_back(ConfigParamSpec{"rof-desc", VariantType::String, "TIMECLUSTERROFS", {"description string for the input ROF data"}});
+  workflowOptions.push_back(ConfigParamSpec{"input-digitrofs-data-description", VariantType::String, "TIMECLUSTERROFS", {"description string for the input ROF data"}});
 }
 
 #include "Framework/runDataProcessing.h"
 
 WorkflowSpec defineDataProcessing(const ConfigContext& configcontext)
 {
-  WorkflowSpec specs;
-
-  auto rofDesc = configcontext.options().get<std::string>("rof-desc");
-
-  DataProcessorSpec producer = o2::mch::getPreClusterFinderSpec(rofDesc.c_str());
-  specs.push_back(producer);
-
-  return specs;
+  auto rofDesc = configcontext.options().get<std::string>("input-digitrofs-data-description");
+  return {o2::mch::getPreClusterFinderSpec(rofDesc.c_str())};
 }

--- a/Detectors/MUON/MCH/Workflow/src/digits-to-timeclusters-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/digits-to-timeclusters-workflow.cxx
@@ -1,0 +1,36 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file digits-to-timeclusters-workflow.cxx
+/// \brief This is an executable that runs the time clusterization via DPL.
+///
+/// This is an executable that takes digits from the Data Processing Layer, runs the time clusterization and sends the time clusters via the Data Processing Layer.
+///
+/// \author Andrea Ferrero, CEA
+
+#include "Framework/CallbackService.h"
+#include "Framework/ControlService.h"
+#include "Framework/Task.h"
+#include "Framework/runDataProcessing.h"
+#include "MCHWorkflow/TimeClusterFinderSpec.h"
+
+using namespace o2;
+using namespace o2::framework;
+
+WorkflowSpec defineDataProcessing(const ConfigContext&)
+{
+  WorkflowSpec specs;
+
+  DataProcessorSpec producer = o2::mch::getTimeClusterFinderSpec();
+  specs.push_back(producer);
+
+  return specs;
+}

--- a/Detectors/MUON/MCH/Workflow/src/digits-to-timeclusters-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/digits-to-timeclusters-workflow.cxx
@@ -27,10 +27,5 @@ using namespace o2::framework;
 
 WorkflowSpec defineDataProcessing(const ConfigContext&)
 {
-  WorkflowSpec specs;
-
-  DataProcessorSpec producer = o2::mch::getTimeClusterFinderSpec();
-  specs.push_back(producer);
-
-  return specs;
+  return {o2::mch::getTimeClusterFinderSpec()};
 }

--- a/Detectors/MUON/MCH/Workflow/src/reco-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/reco-workflow.cxx
@@ -19,6 +19,7 @@
 #include "Framework/WorkflowSpec.h"
 #include "MCHWorkflow/ClusterFinderOriginalSpec.h"
 #include "MCHWorkflow/PreClusterFinderSpec.h"
+#include "MCHWorkflow/TimeClusterFinderSpec.h"
 #include "MCHWorkflow/TrackWriterSpec.h"
 #include "TrackFinderSpec.h"
 #include "TrackFitterSpec.h"
@@ -35,6 +36,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input reader"}},
     {"disable-root-output", o2::framework::VariantType::Bool, false, {"do not write output root files"}},
     {"disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation even if available"}},
+    {"disable-time-clustering", o2::framework::VariantType::Bool, false, {"disable time clustering step (for debug only)"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
 
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
@@ -51,13 +53,21 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   auto disableRootOutput = configcontext.options().get<bool>("disable-root-output");
   auto disableRootInput = configcontext.options().get<bool>("disable-root-input");
   auto useMC = !configcontext.options().get<bool>("disable-mc");
+  auto disableTimeClustering = configcontext.options().get<bool>("disable-time-clustering");
 
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
 
   if (!disableRootInput) {
     specs.emplace_back(o2::mch::getDigitReaderSpec(useMC, "mch-sim-digit-reader"));
   }
-  specs.emplace_back(o2::mch::getPreClusterFinderSpec("mch-precluster-finder"));
+
+  std::string rofDesc = "DIGITROFS";
+  if (!disableTimeClustering) {
+    specs.emplace_back(o2::mch::getTimeClusterFinderSpec("mch-time-clustering"));
+    rofDesc = "TIMECLUSTERROFS";
+  }
+
+  specs.emplace_back(o2::mch::getPreClusterFinderSpec(rofDesc.c_str(), "mch-precluster-finder"));
   specs.emplace_back(o2::mch::getClusterFinderOriginalSpec("mch-cluster-finder"));
   specs.emplace_back(o2::mch::getClusterTransformerSpec());
   specs.emplace_back(o2::mch::getTrackFinderSpec("mch-track-finder"));

--- a/Detectors/MUON/MCH/Workflow/src/reco-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/reco-workflow.cxx
@@ -53,28 +53,29 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   auto disableRootOutput = configcontext.options().get<bool>("disable-root-output");
   auto disableRootInput = configcontext.options().get<bool>("disable-root-input");
   auto useMC = !configcontext.options().get<bool>("disable-mc");
-  auto disableTimeClustering = configcontext.options().get<bool>("disable-time-clustering");
+  auto enableTimeClustering = !configcontext.options().get<bool>("disable-time-clustering");
+
+  const char* digitRofDataDescription =
+    enableTimeClustering ? "TIMECLUSTERROFS" : "DIGITROFS";
 
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
 
   if (!disableRootInput) {
     specs.emplace_back(o2::mch::getDigitReaderSpec(useMC, "mch-sim-digit-reader"));
   }
-
-  std::string rofDesc = "DIGITROFS";
-  if (!disableTimeClustering) {
+  if (enableTimeClustering) {
     specs.emplace_back(o2::mch::getTimeClusterFinderSpec("mch-time-clustering"));
-    rofDesc = "TIMECLUSTERROFS";
   }
 
-  specs.emplace_back(o2::mch::getPreClusterFinderSpec(rofDesc.c_str(), "mch-precluster-finder"));
+  specs.emplace_back(o2::mch::getPreClusterFinderSpec("mch-precluster-finder",
+                                                      digitRofDataDescription));
   specs.emplace_back(o2::mch::getClusterFinderOriginalSpec("mch-cluster-finder"));
   specs.emplace_back(o2::mch::getClusterTransformerSpec());
   specs.emplace_back(o2::mch::getTrackFinderSpec("mch-track-finder"));
 
   if (!disableRootOutput) {
     if (useMC) {
-      specs.emplace_back(o2::mch::getTrackMCLabelFinderSpec("mch-track-mc-label-finder"));
+      specs.emplace_back(o2::mch::getTrackMCLabelFinderSpec("mch-track-mc-label-finder", digitRofDataDescription));
     }
     specs.emplace_back(o2::mch::getTrackWriterSpec(useMC, "mch-track-writer", "mchtracks.root"));
   }


### PR DESCRIPTION
The time clustering algorithm uses a brute-force peak search algorithm to find the time regions where the digits clusterize around a given point in time.