### PR TITLE
DPL: speed up bulk reading

### DIFF
--- a/Framework/Core/src/TableTreeHelpers.cxx
+++ b/Framework/Core/src/TableTreeHelpers.cxx
@@ -616,7 +616,7 @@ size_t ColumnIterator::push()
 {
   arrow::Status stat;
 
-  static TBufferFile buffer{TBuffer::EMode::kWrite, 64 * 1024};
+  static TBufferFile buffer{TBuffer::EMode::kWrite, 4 * 1024 * 1024};
   buffer.Reset();
   auto size = mBranch->GetBulkRead().GetBulkEntries(mPos, buffer);
   if (size < 0) {

--- a/Framework/Core/src/TableTreeHelpers.cxx
+++ b/Framework/Core/src/TableTreeHelpers.cxx
@@ -616,7 +616,8 @@ size_t ColumnIterator::push()
 {
   arrow::Status stat;
 
-  TBufferFile buffer{TBuffer::EMode::kWrite, 64 * 1024};
+  static TBufferFile buffer{TBuffer::EMode::kWrite, 64 * 1024};
+  buffer.Reset();
   auto size = mBranch->GetBulkRead().GetBulkEntries(mPos, buffer);
   if (size < 0) {
     return 0;


### PR DESCRIPTION
Allocating and deallocating the buffer was actually a significant (10%)
fraction of the reading. This should fix it until we actually write
directly to the target message.