### PR TITLE
macro to upload CTP orbit reset time object

### DIFF
--- a/macro/CMakeLists.txt
+++ b/macro/CMakeLists.txt
@@ -55,6 +55,7 @@ install(FILES CheckDigits_mft.C
               run_trac_alice3.C
               CreateBCPattern.C
               UploadDummyAlignment.C
+       CreateCTPOrbitResetObject.C
         DESTINATION share/macro/)
 
 # FIXME: a lot of macros that are here should really be elsewhere. Those which
@@ -327,6 +328,9 @@ o2_add_test_root_macro(UploadDummyAlignment.C
                       PUBLIC_LINK_LIBRARIES O2::CCDB
                                             O2::DetectorsCommonDataFormats
                                             O2::CommonDataFormat)
+
+o2_add_test_root_macro(CreateCTPOrbitResetObject.C
+                      PUBLIC_LINK_LIBRARIES O2::CCDB)
 
 # FIXME: move to subsystem dir + check compilation o2_add_test_root_macro(
 # run_rec_ca.C PUBLIC_LINK_LIBRARIES O2::DetectorsCommonDataFormats

--- a/macro/CreateCTPOrbitResetObject.C
+++ b/macro/CreateCTPOrbitResetObject.C
@@ -1,0 +1,24 @@
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include "CCDB/CcdbApi.h"
+#include "Framework/Logger.h"
+#include <array>
+#endif
+
+// create and upload orbit reset object to CCDB
+constexpr long DummyTime = -1;
+
+void CreateCTPOrbitResetObject(const std::string& ccdbHost = "http://ccdb-test.cern.ch:8080", long t = DummyTime, long tmin = 0, long tmax = -1)
+{
+
+  if (t == DummyTime) {
+    t = std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::system_clock::now()).time_since_epoch().count();
+  }
+  std::array<long, 1> rt{t};
+  const std::string objName{"CTP/OrbitReset"};
+  o2::ccdb::CcdbApi api;
+  api.init(ccdbHost.c_str());   // or http://localhost:8080 for a local installation
+  map<string, string> metadata; // can be empty
+  metadata["comment"] = "CTP Orbit reset";
+  api.storeAsTFileAny(&rt, objName, metadata, tmin, tmax);
+  LOGP(INFO, "Uploaded CTP Oribt reset time {} to {}", t, objName);
+}


### PR DESCRIPTION
@lietava this is the format for the CTP reset object: just plain `array<long,1>` so there is no need of O2 to create it on your side.