### PR TITLE
DPL Analysis: protect writer against empty messages

### DIFF
--- a/Framework/Core/src/CommonDataProcessors.cxx
+++ b/Framework/Core/src/CommonDataProcessors.cxx
@@ -340,6 +340,11 @@ DataProcessorSpec
         }
 
         // get the TableConsumer and corresponding arrow table
+        auto msg = pc.inputs().get(ref.spec->binding);
+        if (msg.header == nullptr) {
+          LOGP(ERROR, "No header for message {}:{}", ref.spec->binding, *ref.spec);
+          continue;
+        }
         auto s = pc.inputs().get<TableConsumer>(ref.spec->binding);
         auto table = s->asArrowTable();
         if (!table->Validate().ok()) {


### PR DESCRIPTION
Whether it is correct for the message to be empty still to be checked.