### PR TITLE
Only run datamodel doc update in upstream repo

### DIFF
--- a/.github/workflows/datamodel-doc.yml
+++ b/.github/workflows/datamodel-doc.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   datamodel-doc:
     runs-on: ubuntu-latest
+    if: github.repository == 'AliceO2Group/AliceO2'
     steps:
 
       - name: Checkout O2


### PR DESCRIPTION
Only the action in AliceO2Group/AliceO2 has the required secret for pushing to the documentation repository, so owners of forks get spurious notifications that this workflow fails in their repo.