### PR TITLE
CCDBApi: protection against missing X509_CERT_DIR env var

### DIFF
--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -354,8 +354,10 @@ void CcdbApi::curlSetSSLOptions(CURL* curl_handle)
 
   TJAlienCredentialsObject cmo = mJAlienCredentials->get(cmk);
 
-  string CAPath = getenv("X509_CERT_DIR");
-  curl_easy_setopt(curl_handle, CURLOPT_CAPATH, CAPath.c_str());
+  char* CAPath = getenv("X509_CERT_DIR");
+  if (CAPath) {
+    curl_easy_setopt(curl_handle, CURLOPT_CAPATH, CAPath);
+  }
   curl_easy_setopt(curl_handle, CURLOPT_CAINFO, nullptr);
   curl_easy_setopt(curl_handle, CURLOPT_SSLCERT, cmo.certpath.c_str());
   curl_easy_setopt(curl_handle, CURLOPT_SSLKEY, cmo.keypath.c_str());


### PR DESCRIPTION
@Atlantic777 @costing @sawenzel 

Here's a small change for your consideration.

Assuming I understand correctly that the CCDB is not 100% tied to AliEn, I would expect it to work as it was before https://github.com/AliceO2Group/AliceO2/pull/5826 even if some env variables are not set. 

As far as I can tell with this minimal change the ccdb related tests of O2 (`ctest -L ccdb`) work even without the env var set, otherwise they crash (and any attempt to use the CcdbApi crash as well).

(tested on macOS, with AliceO2 built with Spack, but I'd say that's not relevant as much as added requirement on some variables to be present if they are not really, or not always).