### PR TITLE
o2-sim: hit merge optimizations

### DIFF
--- a/Detectors/Base/include/DetectorsBase/Detector.h
+++ b/Detectors/Base/include/DetectorsBase/Detector.h
@@ -35,6 +35,7 @@
 #include <type_traits>
 #include <unistd.h>
 #include <cassert>
+#include <list>
 
 #include <fairmq/FwdDecls.h>
 
@@ -163,6 +164,12 @@ class Detector : public FairDetector
   // and to decode it
   virtual void attachHits(FairMQChannel&, FairMQParts&) = 0;
   virtual void fillHitBranch(TTree& tr, FairMQParts& parts, int& index) = 0;
+  virtual void collectHits(int eventID, FairMQParts& parts, int& index) = 0;
+  virtual void mergeHitEntriesAndFlush(int eventID,
+                                       TTree& target,
+                                       std::vector<int> const& trackoffsets,
+                                       std::vector<int> const& nprimaries,
+                                       std::vector<int> const& subevtsOrdered) = 0;
 
   // interface needed to merge together hit entries in TBranches (as used by hit merger process)
   // trackoffsets: a map giving the corresponding trackoffset to be applied to the trackID property when
@@ -388,7 +395,6 @@ class DetImpl : public o2::base::Detector
             }
             // this could be further generalized by using a policy for T
             std::copy(incomingdata->begin(), incomingdata->end(), std::back_inserter(*targetdata));
-            // adjust offset
             delete incomingdata;
             incomingdata = nullptr;
           }
@@ -411,6 +417,67 @@ class DetImpl : public o2::base::Detector
     }
   }
 
+  // this merges several entries from temporary hit buffer into
+  // into a single entry in a target TTree / same branch
+  // (assuming T is typically a vector; merging is simply done by appending)
+  template <typename T, typename L>
+  void mergeAndAdjustHits(std::string const& brname, L& hitbufferlist, TTree& target,
+                          std::vector<int> const& trackoffsets, std::vector<int> const& nprimaries,
+                          std::vector<int> const& subevtsOrdered)
+  {
+    auto entries = hitbufferlist.size();
+
+    auto targetdata = new T;  // used to collect data inside a single container
+    T* filladdress = nullptr; // pointer used for final ROOT IO
+    if (entries == 1) {
+      filladdress = &hitbufferlist.front();
+      // nothing to do; we can directly do IO from the existing buffer
+    } else {
+      // here we need to do merging and index adjustment
+      int nprimTot = 0;
+      for (auto entry = 0; entry < entries; entry++) {
+        nprimTot += nprimaries[entry];
+      }
+      // offset for pimary track index
+      int idelta0 = 0;
+      // offset for secondary track index
+      int idelta1 = nprimTot;
+      filladdress = targetdata;
+      for (int entry = entries - 1; entry >= 0; --entry) {
+        // proceed in the order of subevent Ids
+        int index = subevtsOrdered[entry];
+        // number of primaries for this event
+        int nprim = nprimaries[index];
+        idelta1 -= nprim;
+        auto incomingdata = &hitbufferlist.back();
+        if (incomingdata) {
+          // fix the trackIDs for this data
+          for (auto& hit : *incomingdata) {
+            const auto oldID = hit.GetTrackID();
+            // offset depends on whether the trackis a primary or secondary
+            int offset = (oldID < nprim) ? idelta0 : idelta1;
+            hit.SetTrackID(oldID + offset);
+          }
+          // this could be further generalized by using a policy for T
+          std::copy(incomingdata->begin(), incomingdata->end(), std::back_inserter(*targetdata));
+          // adjust offset
+          hitbufferlist.pop_back();
+        }
+        // adjust offsets for next subevent
+        idelta0 += nprim;
+        idelta1 += trackoffsets[index];
+      } // subevent loop
+    }
+    // fill target for this event
+    auto targetbr = o2::base::getOrMakeBranch(target, brname.c_str(), &filladdress);
+    targetbr->SetAddress(&filladdress);
+    targetbr->Fill();
+    targetbr->ResetAddress();
+    targetdata->clear();
+    hitbufferlist.clear();
+    delete targetdata;
+  }
+
   void mergeHitEntries(TTree& origin, TTree& target, std::vector<int> const& trackoffsets, std::vector<int> const& nprimaries, std::vector<int> const& subevtsOrdered) final
   {
     // loop over hit containers / different branches
@@ -425,7 +492,92 @@ class DetImpl : public o2::base::Detector
     }
   }
 
+  void mergeHitEntriesAndFlush(int eventID, TTree& target, std::vector<int> const& trackoffsets, std::vector<int> const& nprimaries, std::vector<int> const& subevtsOrdered) final
+  {
+    // loop over hit containers / different branches
+    // adjust trackID in hits on the go
+    int probe = 0;
+    using Hit_t = typename std::remove_pointer<decltype(static_cast<Det*>(this)->Det::getHits(0))>::type;
+    // remove buffered event from the hit store
+    using Collector_t = std::map<int, std::vector<std::list<Hit_t>>>;
+    auto hitbufferPtr = reinterpret_cast<Collector_t*>(mHitCollectorBufferPtr);
+    auto iter = hitbufferPtr->find(eventID);
+    if (iter == hitbufferPtr->end()) {
+      LOG(ERROR) << "No buffered hits available for event " << eventID;
+      return;
+    }
+
+    std::string name = static_cast<Det*>(this)->getHitBranchNames(probe);
+    while (name.size() > 0) {
+      auto& listofHitBuffers = (*iter).second[probe];
+      // flushing and buffer removal is done inside here:
+      mergeAndAdjustHits<Hit_t>(name, listofHitBuffers, target, trackoffsets, nprimaries, subevtsOrdered);
+      // next name
+      probe++;
+      name = static_cast<Det*>(this)->getHitBranchNames(probe);
+    }
+    hitbufferPtr->erase(eventID);
+  }
+
  public:
+  /// Collect Hits available as incoming message (shared mem or not)
+  /// inside this process for later streaming to output. A function needed
+  /// by the hit-merger process (not for direct use by users)
+  void collectHits(int eventID, FairMQParts& parts, int& index) override
+  {
+    using Hit_t = typename std::remove_pointer<decltype(static_cast<Det*>(this)->Det::getHits(0))>::type;
+    using Collector_t = std::map<int, std::vector<std::list<Hit_t>>>;
+    static Collector_t hitcollector; // note: we can't put this as member because
+    // decltype type deduction doesn't seem to work for class members; so we use a static member
+    // and will use some pointer member to communicate this data to other functions
+    mHitCollectorBufferPtr = (char*)&hitcollector;
+
+    int probe = 0;
+    bool* busy = nullptr;
+    using HitPtr_t = decltype(static_cast<Det*>(this)->Det::getHits(probe));
+    std::string name = static_cast<Det*>(this)->getHitBranchNames(probe++);
+
+    auto copyToBuffer = [eventID](HitPtr_t hitdata, Collector_t& collectbuffer, int probe) {
+      auto eventIter = collectbuffer.find(eventID);
+      if (eventIter == collectbuffer.end()) {
+        collectbuffer[eventID] = std::vector<std::list<Hit_t>>();
+      }
+      auto& hitvector = collectbuffer[eventID];
+
+      if (probe >= hitvector.size()) {
+        hitvector.resize(probe + 1);
+      }
+      // add empty hit bucket to list for this event and probe
+      hitvector[probe].push_back(Hit_t());
+      // copy the data into this bucket
+      hitvector[probe].back() = *hitdata;
+    };
+
+    while (name.size() > 0) {
+      if (!UseShm<Det>::value || !o2::utils::ShmManager::Instance().isOperational()) {
+        // for each branch name we extract/decode hits from the message parts ...
+        auto hitsptr = decodeTMessage<HitPtr_t>(parts, index++);
+        if (hitsptr) {
+          // ... and copy them to the buffer
+          copyToBuffer(hitsptr, hitcollector, probe);
+          delete hitsptr;
+        }
+      } else {
+        // for each branch name we extract/decode hits from the message parts ...
+        auto hitsptr = decodeShmMessage<HitPtr_t>(parts, index++, busy);
+        // ... and copy them to the buffer
+        copyToBuffer(hitsptr, hitcollector, probe);
+      }
+      // next name
+      name = static_cast<Det*>(this)->getHitBranchNames(probe++);
+    }
+    // there is only one busy flag per detector so we need to clear it only
+    // at the end (after all branches have been treated)
+    if (busy) {
+      *busy = false;
+    }
+  }
+
   void fillHitBranch(TTree& tr, FairMQParts& parts, int& index) override
   {
     int probe = 0;
@@ -576,6 +728,8 @@ class DetImpl : public o2::base::Detector
   std::vector<void*> mCachedPtr[NHITBUFFERS];
   int mCurrentBuffer = 0; // holding the current buffer information
   int mInitialized = false;
+
+  char* mHitCollectorBufferPtr = nullptr; //! pointer to hit (collector) buffer location (strictly internal)
   ClassDefOverride(DetImpl, 0);
 };
 } // namespace base

--- a/run/O2HitMerger.h
+++ b/run/O2HitMerger.h
@@ -325,7 +325,10 @@ class O2HitMerger : public FairMQDevice
       LOG(ERROR) << "Some error occurred on socket during receive on sim data";
       return true; // keep going
     }
+    TStopwatch timer;
+    timer.Start();
     auto more = handleSimData(request, 0);
+    LOG(INFO) << "HitMerger processing took " << timer.RealTime();
     if (!more && mAsService) {
       LOG(INFO) << " CONTROL ";
       // if we are done treating data we may go back to init phase

--- a/run/O2HitMerger.h
+++ b/run/O2HitMerger.h
@@ -61,6 +61,7 @@
 #include "CommonUtils/ShmManager.h"
 #include <map>
 #include <vector>
+#include <list>
 #include <csignal>
 #include <mutex>
 #include <filesystem>
@@ -220,9 +221,6 @@ class O2HitMerger : public FairMQDevice
 
     // clear "counter" datastructures
     mPartsCheckSum.clear();
-    mEventToTTreeMap.clear();
-    mEventToTMemFileMap.clear();
-    mEntries = 0;
     mEventChecksum = 0;
     return true;
   }
@@ -258,49 +256,23 @@ class O2HitMerger : public FairMQDevice
       LOG(DEBUG2) << "I1 " << ptr[0] << " NAME " << id.getName() << " MB "
                   << data.At(index)->GetSize() / 1024. / 1024.;
 
-      TTree* tree = mEventToTTreeMap[eventID];
-
       // get the detector that can interpret it
       auto detector = mDetectorInstances[id].get();
       if (detector) {
-        detector->fillHitBranch(*tree, data, index);
+        detector->collectHits(eventID, data, index);
       }
     }
   }
 
-  template <typename T>
-  void fillBranch(int eventID, std::string const& name, T* ptr)
-  {
-    // fetch tree into which to fill
-    const std::lock_guard<std::mutex> lock(mMapsMtx);
-    auto iter = mEventToTTreeMap.find(eventID);
-    if (iter == mEventToTTreeMap.end()) {
-      {
-        std::stringstream str;
-        str << "memfile" << eventID;
-        mEventToTMemFileMap[eventID] = new TMemFile(str.str().c_str(), "RECREATE");
-      }
-      {
-        std::stringstream str;
-        str << "o2sim" << eventID;
-        mEventToTTreeMap[eventID] = new TTree(str.str().c_str(), str.str().c_str());
-        mEventToTTreeMap[eventID]->SetDirectory(mEventToTMemFileMap[eventID]);
-      }
-    }
-    TTree* tree = mEventToTTreeMap[eventID];
-
-    auto br = o2::base::getOrMakeBranch(*tree, name.c_str(), &ptr);
-    br->SetAddress(&ptr);
-    br->Fill();
-    br->ResetAddress();
-  }
-
-  template <typename T>
-  void consumeData(int eventID, std::string name, FairMQParts& data, int& index)
+  template <typename T, typename BT>
+  void consumeData(int eventID, FairMQParts& data, int& index, BT& buffer)
   {
     auto decodeddata = o2::base::decodeTMessage<T*>(data, index);
-    fillBranch(eventID, name, decodeddata);
-    delete decodeddata;
+    if (buffer.find(eventID) == buffer.end()) {
+      buffer[eventID] = typename BT::mapped_type();
+    }
+    buffer[eventID].push_back(decodeddata);
+    // delete decodeddata; --> we store the pointers
     index++;
   }
 
@@ -309,11 +281,10 @@ class O2HitMerger : public FairMQDevice
   // also creates the MCEventHeader branch expected for physics analysis
   void fillSubEventInfoEntry(o2::data::SubEventInfo& info)
   {
-    auto infoptr = &info;
-    fillBranch(info.eventID, "SubEventInfo", infoptr);
-    // a separate branch for MCEventHeader to be backward compatible
-    auto headerptr = &info.mMCEventHeader;
-    fillBranch(info.eventID, "MCEventHeader.", headerptr);
+    if (mSubEventInfoBuffer.find(info.eventID) == mSubEventInfoBuffer.end()) {
+      mSubEventInfoBuffer[info.eventID] = std::list<o2::data::SubEventInfo*>();
+    }
+    mSubEventInfoBuffer[info.eventID].push_back(&info);
   }
 
   bool waitForControlInput()
@@ -375,18 +346,11 @@ class O2HitMerger : public FairMQDevice
     LOG(INFO) << "SIMDATA channel got " << data.Size() << " parts for event " << info.eventID << " part " << info.part << " out of " << info.nparts;
 
     fillSubEventInfoEntry(info);
-    consumeData<std::vector<o2::MCTrack>>(info.eventID, "MCTrack", data, index);
-    consumeData<std::vector<o2::TrackReference>>(info.eventID, "TrackRefs", data, index);
+    consumeData<std::vector<o2::MCTrack>>(info.eventID, data, index, mMCTrackBuffer);
+    consumeData<std::vector<o2::TrackReference>>(info.eventID, data, index, mTrackRefBuffer);
     while (index < data.Size()) {
       consumeHits(info.eventID, data, index);
     }
-    // set the number of entries in the tree
-    auto tree = mEventToTTreeMap[info.eventID];
-    auto memfile = mEventToTMemFileMap[info.eventID];
-    tree->SetEntries(tree->GetEntries() + 1);
-    LOG(INFO) << "tree has file " << tree->GetDirectory()->GetFile()->GetName();
-    // memfile->Write("", TObject::kOverwrite);
-    mEntries++;
 
     if (isDataComplete<uint32_t>(accum, info.nparts)) {
       LOG(INFO) << "EVERYTHING IS HERE FOR EVENT " << info.eventID << "\n";
@@ -427,13 +391,7 @@ class O2HitMerger : public FairMQDevice
 
   void cleanEvent(int eventID)
   {
-    // remove tree for that eventID
-    const std::lock_guard<std::mutex> lock(mMapsMtx);
-    // mEventToTMemFileMap[eventID]->Close();
-    delete mEventToTTreeMap[eventID];
-    delete mEventToTMemFileMap[eventID];
-    mEventToTTreeMap.erase(eventID);
-    mEventToTMemFileMap.erase(eventID); // remove memfile
+    // cleanup intermediate per-Event buffers
   }
 
   template <typename T>
@@ -442,87 +400,90 @@ class O2HitMerger : public FairMQDevice
     std::copy(from.begin(), from.end(), std::back_inserter(to));
   }
 
-  void reorderAndMergeMCTRacks(TTree& origin, TTree& target, const std::vector<int>& nprimaries, const std::vector<int>& nsubevents)
+  void reorderAndMergeMCTracks(int eventID, TTree& target, const std::vector<int>& nprimaries, const std::vector<int>& nsubevents)
   {
-    std::vector<MCTrack>* incomingdata = nullptr;
+    // avoid doing this for trivial cases
+    std::vector<MCTrack>* mcTracksPerSubEvent = nullptr;
     auto targetdata = std::make_unique<std::vector<MCTrack>>();
-    auto originbr = origin.GetBranch("MCTrack");
-    originbr->SetAddress(&incomingdata);
-    const auto entries = origin.GetEntries();
-    //
-    // loop over subevents to store the primary events
-    //
-    Int_t nprimTot = 0;
-    for (auto entry = entries - 1; entry >= 0; --entry) {
-      int index = nsubevents[entry];
-      nprimTot += nprimaries[index];
-      printf("merge %lld %5d %5d %5d \n", entry, index, nsubevents[entry], nsubevents[index]);
-      originbr->GetEntry(index);
-      for (Int_t i = 0; i < nprimaries[index]; i++) {
-        auto& track = incomingdata->at(i);
-        if (track.isTransported()) { // reset daughters only if track was transported, it will be fixed below
+
+    auto& vectorOfSubEventMCTracks = mMCTrackBuffer[eventID];
+    const auto entries = vectorOfSubEventMCTracks.size();
+
+    if (entries > 1) {
+      //
+      // loop over subevents to store the primary events
+      //
+      int nprimTot = 0;
+      for (int entry = entries - 1; entry >= 0; --entry) {
+        int index = nsubevents[entry];
+        nprimTot += nprimaries[index];
+        printf("merge %lld %5d %5d %5d \n", entry, index, nsubevents[entry], nsubevents[index]);
+        for (int i = 0; i < nprimaries[index]; i++) {
+          auto& track = (*vectorOfSubEventMCTracks[index])[i];
+          if (track.isTransported()) { // reset daughters only if track was transported, it will be fixed below
+            track.SetFirstDaughterTrackId(-1);
+            track.SetLastDaughterTrackId(-1);
+          }
+          targetdata->push_back(track);
+        }
+      }
+      //
+      // loop a second time to store the secondaries and fix the mother track IDs
+      //
+      Int_t idelta1 = nprimTot;
+      Int_t idelta0 = 0;
+      for (int entry = entries - 1; entry >= 0; --entry) {
+        int index = nsubevents[entry];
+
+        auto& subEventTracks = *(vectorOfSubEventMCTracks[index]);
+        // we need to fetch the right mctracks here!!
+        Int_t npart = (int)(subEventTracks.size());
+        Int_t nprim = nprimaries[index];
+        idelta1 -= nprim;
+
+        for (Int_t i = nprim; i < npart; i++) {
+          auto& track = subEventTracks[i];
+          Int_t cId = track.getMotherTrackId();
+          if (cId >= nprim) {
+            cId += idelta1;
+          } else {
+            cId += idelta0;
+          }
+          track.SetMotherTrackId(cId);
           track.SetFirstDaughterTrackId(-1);
-          track.SetLastDaughterTrackId(-1);
+
+          Int_t hwm = (int)(targetdata->size());
+          auto& mother = (*targetdata)[cId];
+          if (mother.getFirstDaughterTrackId() == -1) {
+            mother.SetFirstDaughterTrackId(hwm);
+          }
+          mother.SetLastDaughterTrackId(hwm);
+
+          targetdata->push_back(track);
         }
-        targetdata->push_back(track);
+        idelta0 += nprim;
+        idelta1 += npart;
       }
-      incomingdata->clear();
-      delete incomingdata;
-      incomingdata = nullptr;
     }
-    //
-    // loop a second time to store the secondaries and fix the mother track IDs
-    //
-    Int_t idelta1 = nprimTot;
-    Int_t idelta0 = 0;
-    for (auto entry = entries - 1; entry >= 0; --entry) {
-      int index = nsubevents[entry];
-
-      originbr->GetEntry(index);
-
-      Int_t npart = (int)(incomingdata->size());
-      Int_t nprim = nprimaries[index];
-      idelta1 -= nprim;
-
-      for (Int_t i = nprim; i < npart; i++) {
-        auto& track = (*incomingdata)[i];
-        Int_t cId = track.getMotherTrackId();
-        if (cId >= nprim) {
-          cId += idelta1;
-        } else {
-          cId += idelta0;
-        }
-        track.SetMotherTrackId(cId);
-        track.SetFirstDaughterTrackId(-1);
-
-        Int_t hwm = (int)(targetdata->size());
-        auto& mother = (*targetdata)[cId];
-        if (mother.getFirstDaughterTrackId() == -1) {
-          mother.SetFirstDaughterTrackId(hwm);
-        }
-        mother.SetLastDaughterTrackId(hwm);
-
-        targetdata->push_back(track);
-      }
-      idelta0 += nprim;
-      idelta1 += npart;
-      incomingdata->clear();
-      delete incomingdata;
-      incomingdata = nullptr;
-    }
-
     //
     // write to output
-    auto filladdr = targetdata.get();
+    auto filladdr = (entries > 1) ? targetdata.get() : vectorOfSubEventMCTracks[0];
     auto targetbr = o2::base::getOrMakeBranch(target, "MCTrack", &filladdr);
     targetbr->SetAddress(&filladdr);
     targetbr->Fill();
     targetbr->ResetAddress();
+
+    // cleanup buffered data
+    for (auto ptr : vectorOfSubEventMCTracks) {
+      delete ptr; // avoid this by using unique ptr
+    }
+    // TODO: protect by lock (as multithreaded access to STL MAP)
+    mMCTrackBuffer.erase(eventID);
   }
 
-  template <typename T>
-  void remapTrackIdsAndMerge(std::string brname, TTree& origin, TTree& target,
-                             const std::vector<int>& trackoffsets, const std::vector<int>& nprimaries, const std::vector<int>& subevOrdered)
+  template <typename T, typename M>
+  void remapTrackIdsAndMerge(std::string brname, int eventID, TTree& target,
+                             const std::vector<int>& trackoffsets, const std::vector<int>& nprimaries, const std::vector<int>& subevOrdered, M& mapOfVectorOfTs)
   {
     //
     // Remap the mother track IDs by adding an offset.
@@ -531,36 +492,32 @@ class O2HitMerger : public FairMQDevice
     //
     T* incomingdata = nullptr;
     std::unique_ptr<T> targetdata(nullptr);
-    auto originbr = origin.GetBranch(brname.c_str());
-    originbr->SetAddress(&incomingdata);
-    const auto entries = origin.GetEntries();
+    auto& vectorOfT = mapOfVectorOfTs[eventID];
+    const auto entries = vectorOfT.size();
 
     if (entries == 1) {
       // nothing to do in case there is only one entry
-      originbr->GetEntry(0);
+      incomingdata = vectorOfT[0];
     } else {
       targetdata = std::make_unique<T>();
       // loop over subevents
       Int_t nprimTot = 0;
-      for (auto entry = 0; entry < entries; entry++) {
+      for (int entry = 0; entry < entries; entry++) {
         nprimTot += nprimaries[entry];
       }
       Int_t idelta0 = 0;
       Int_t idelta1 = nprimTot;
-      for (auto entry = entries - 1; entry >= 0; --entry) {
+      for (int entry = entries - 1; entry >= 0; --entry) {
         Int_t index = subevOrdered[entry];
         Int_t nprim = nprimaries[index];
-        originbr->GetEntry(index);
+        incomingdata = vectorOfT[index];
         idelta1 -= nprim;
         for (auto& data : *incomingdata) {
           updateTrackIdWithOffset(data, nprim, idelta0, idelta1);
           targetdata->push_back(data);
         }
-        incomingdata->clear();
         idelta0 += nprim;
         idelta1 += trackoffsets[index];
-        delete incomingdata;
-        incomingdata = nullptr;
       }
     }
     auto dataaddr = (entries == 1) ? incomingdata : targetdata.get();
@@ -568,6 +525,12 @@ class O2HitMerger : public FairMQDevice
     targetbr->SetAddress(&dataaddr);
     targetbr->Fill();
     targetbr->ResetAddress();
+
+    // cleanup mem
+    for (auto ptr : vectorOfT) {
+      delete ptr; // avoid this by using unique ptr
+    }
+    mapOfVectorOfTs.erase(eventID);
   }
 
   void updateTrackIdWithOffset(MCTrack& track, Int_t nprim, Int_t idelta0, Int_t idelta1)
@@ -586,45 +549,6 @@ class O2HitMerger : public FairMQDevice
     ref.setTrackID(cId + ioffset);
   }
 
-  // this merges all entries from the TBranch brname from the origin TTree (containing one event only)
-  // into a single entry in a target TTree / same branch
-  // (assuming T is typically a vector; merging is simply done by appending)
-  template <typename T>
-  void merge(std::string brname, TTree& origin, TTree& target)
-  {
-    auto originbr = origin.GetBranch(brname.c_str());
-    auto targetdata = std::make_unique<T>();
-    T* incomingdata = nullptr;
-    originbr->SetAddress(&incomingdata);
-
-    const auto entries = origin.GetEntries();
-
-    T* filladdress = nullptr;
-    if (entries == 1) {
-      // this avoids useless copy in case there was no sub-event splitting; we just use the original data
-      originbr->GetEntry(0);
-      filladdress = incomingdata;
-    } else {
-      filladdress = targetdata.get();
-      for (auto entry = 0; entry < entries; ++entry) {
-        originbr->GetEntry(entry);
-        backInsert(*incomingdata, *targetdata);
-        delete incomingdata;
-        incomingdata = nullptr;
-      }
-    }
-
-    // fill target for this event
-    auto targetbr = o2::base::getOrMakeBranch(target, brname.c_str(), &filladdress);
-    targetbr->SetAddress(&filladdress);
-    targetbr->Fill();
-    targetbr->ResetAddress();
-    if (incomingdata) {
-      delete incomingdata;
-      incomingdata = nullptr;
-    }
-  }
-
   void initHitTreeAndOutFile(std::string prefix, int detID)
   {
     using o2::detectors::DetID;
@@ -639,8 +563,8 @@ class O2HitMerger : public FairMQDevice
     mDetectorToTTreeMap[detID]->SetDirectory(mDetectorOutFiles[detID]);
   }
 
-  // This method goes over the tree containing data for a given event; potentially merges
-  // it and flushes it into the actual output file.
+  // This method goes over the buffers containing data for a given event; potentially merges
+  // them and flushes into the actual output file.
   // The method can be called asynchronously to data collection
   bool mergeAndFlushData(int eventID)
   {
@@ -656,16 +580,17 @@ class O2HitMerger : public FairMQDevice
     while (canflush == true) {
       auto flusheventID = mNextFlushID;
       LOG(INFO) << "Merge and flush event " << flusheventID;
-      auto tree = mEventToTTreeMap[flusheventID];
-      if (!tree) {
-        LOG(INFO) << "NO TTREE FOUND FOR EVENT " << flusheventID;
+      auto iter = mSubEventInfoBuffer.find(flusheventID);
+      if (iter == mSubEventInfoBuffer.end()) {
+        LOG(ERROR) << "No info/data found for event " << flusheventID;
         if (!checkIfNextFlushable()) {
           return false;
         }
       }
 
-      if (tree->GetEntries() == 0 || mNExpectedEvents == 0) {
-        LOG(INFO) << "NO ENTRY IN TTREE FOUND FOR EVENT " << flusheventID;
+      auto& subEventInfoList = (*iter).second;
+      if (subEventInfoList.size() == 0 || mNExpectedEvents == 0) {
+        LOG(ERROR) << "No data entries found for event " << flusheventID;
         if (!checkIfNextFlushable()) {
           return false;
         }
@@ -675,21 +600,19 @@ class O2HitMerger : public FairMQDevice
       timer.Start();
 
       // calculate trackoffsets
-      auto infobr = tree->GetBranch("SubEventInfo");
-
       auto& confref = o2::conf::SimConfig::Instance();
 
-      std::vector<int> trackoffsets; // collecting trackoffsets to be applied to correct
-      std::vector<int> nprimaries;   // collecting primary particles in each subevent
-      std::vector<int> nsubevents;   // collecting of subevent numbers
+      // collecting trackoffsets (per data arrival id) to be used for global track-ID correction pass
+      std::vector<int> trackoffsets;
+      // collecting primary particles in each subevent (data arrival id)
+      std::vector<int> nprimaries;
+      // mapping of id to actual sub-event id (or part)
+      std::vector<int> nsubevents;
 
       o2::dataformats::MCEventHeader* eventheader = nullptr; // The event header
 
       // the MC labels (trackID) for hits
-      o2::data::SubEventInfo* info = nullptr;
-      infobr->SetAddress(&info);
-      for (int i = 0; i < infobr->GetEntries(); ++i) {
-        infobr->GetEntry(i);
+      for (auto info : subEventInfoList) {
         assert(info->npersistenttracks >= 0);
         trackoffsets.emplace_back(info->npersistenttracks);
         nprimaries.emplace_back(info->nprimarytracks);
@@ -724,16 +647,15 @@ class O2HitMerger : public FairMQDevice
       // b) merge the general data
       //
       // for MCTrack remap the motherIds and merge at the same go
-      const auto entries = tree->GetEntries();
+      const auto entries = subEventInfoList.size();
       std::vector<int> subevOrdered((int)(nsubevents.size()));
-      for (auto entry = entries - 1; entry >= 0; --entry) {
+      for (int entry = entries - 1; entry >= 0; --entry) {
         subevOrdered[nsubevents[entry] - 1] = entry;
         printf("HitMerger entry: %lld nprimry: %5d trackoffset: %5d \n", entry, nprimaries[entry], trackoffsets[entry]);
       }
 
-      reorderAndMergeMCTRacks(*tree, *mOutTree, nprimaries, subevOrdered);
-      Int_t ioffset = 0;
-      remapTrackIdsAndMerge<std::vector<o2::TrackReference>>("TrackRefs", *tree, *mOutTree, trackoffsets, nprimaries, subevOrdered);
+      reorderAndMergeMCTracks(flusheventID, *mOutTree, nprimaries, subevOrdered);
+      remapTrackIdsAndMerge<std::vector<o2::TrackReference>>("TrackRefs", flusheventID, *mOutTree, trackoffsets, nprimaries, subevOrdered, mTrackRefBuffer);
 
       // c) do the merge procedure for all hits ... delegate this to detector specific functions
       // since they know about types; number of branches; etc.
@@ -742,7 +664,8 @@ class O2HitMerger : public FairMQDevice
         auto& det = mDetectorInstances[id];
         if (det) {
           auto hittree = mDetectorToTTreeMap[id];
-          det->mergeHitEntries(*tree, *hittree, trackoffsets, nprimaries, subevOrdered);
+          // det->mergeHitEntries(*tree, *hittree, trackoffsets, nprimaries, subevOrdered);
+          det->mergeHitEntriesAndFlush(flusheventID, *hittree, trackoffsets, nprimaries, subevOrdered);
           hittree->SetEntries(hittree->GetEntries() + 1);
           LOG(INFO) << "flushing tree to file " << hittree->GetDirectory()->GetFile()->GetName();
           mDetectorOutFiles[id]->Write("", TObject::kOverwrite);
@@ -773,11 +696,13 @@ class O2HitMerger : public FairMQDevice
   std::unordered_map<int, TTree*> mDetectorToTTreeMap; //! the trees
 
   // intermediate structures to collect data per event
-  std::unordered_map<int, TTree*> mEventToTTreeMap;       //! in memory trees to collect / presort incoming data per event
-  std::unordered_map<int, TMemFile*> mEventToTMemFileMap; //! files associated to the TTrees
   std::thread mMergerIOThread;                            //! a thread used to do hit merging and IO flushing asynchronously
   std::mutex mMapsMtx;                                    //!
-  int mEntries = 0;         //! counts the number of entries in the branches
+
+  std::unordered_map<int, std::vector<std::vector<o2::MCTrack>*>> mMCTrackBuffer;         //! vector of sub-event track vectors; one per event
+  std::unordered_map<int, std::vector<std::vector<o2::TrackReference>*>> mTrackRefBuffer; //!
+  std::unordered_map<int, std::list<o2::data::SubEventInfo*>> mSubEventInfoBuffer;
+
   int mEventChecksum = 0;   //! checksum for events
   int mNExpectedEvents = 0; //! number of events that we expect to receive
   std::unordered_map<int, bool> mFlushableEvents; //! collection of events which has completely arrived


### PR DESCRIPTION
The commit is speeding up the sim merging step by
not using TMemFiles as intermediate buffers,
in favour of dedicated plain merger pools keeping the
data in memory until streamed out.

In result, the processing time of the hit-merger
kernel is decreased by a factor 5.