### PR TITLE
MCH-MID matching algorithm + data format + workflows

### DIFF
--- a/DataFormats/Reconstruction/CMakeLists.txt
+++ b/DataFormats/Reconstruction/CMakeLists.txt
@@ -29,6 +29,7 @@ o2_add_library(ReconstructionDataFormats
                        src/VtxTrackRef.cxx
                        src/TrackTPCTOF.cxx
                        src/TrackCosmics.cxx
+                       src/TrackMCHMID.cxx
                PUBLIC_LINK_LIBRARIES O2::GPUCommon
                                      O2::GPUUtils
                                      O2::FrameworkLogger
@@ -55,6 +56,7 @@ o2_target_root_dictionary(
           include/ReconstructionDataFormats/VtxTrackRef.h
           include/ReconstructionDataFormats/TrackTPCTOF.h
           include/ReconstructionDataFormats/TrackCosmics.h
+          include/ReconstructionDataFormats/TrackMCHMID.h
   )
 
 o2_add_test(Vertex

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackMCHMID.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackMCHMID.h
@@ -1,0 +1,84 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TrackMCHMID.h
+/// \brief Definition of the MUON track
+///
+/// \author Philippe Pillot, Subatech
+
+#ifndef ALICEO2_TRACKMCHMID_H
+#define ALICEO2_TRACKMCHMID_H
+
+#include "CommonDataFormat/InteractionRecord.h"
+#include "ReconstructionDataFormats/GlobalTrackID.h"
+
+namespace o2
+{
+namespace dataformats
+{
+
+/// MUON track external format
+class TrackMCHMID
+{
+ public:
+  TrackMCHMID() = default;
+  TrackMCHMID(const GlobalTrackID& mchID, const GlobalTrackID& midID, const InteractionRecord& midIR, double chi2)
+    : mMCHRef(mchID), mMIDRef(midID), mIR(midIR), mMatchNChi2(chi2) {}
+  TrackMCHMID(uint32_t mchIdx, uint32_t midIdx, const InteractionRecord& midIR, double chi2)
+    : mMCHRef(mchIdx, GlobalTrackID::MCH), mMIDRef(midIdx, GlobalTrackID::MID), mIR(midIR), mMatchNChi2(chi2) {}
+  ~TrackMCHMID() = default;
+
+  TrackMCHMID(const TrackMCHMID& track) = default;
+  TrackMCHMID& operator=(const TrackMCHMID& track) = default;
+  TrackMCHMID(TrackMCHMID&&) = default;
+  TrackMCHMID& operator=(TrackMCHMID&&) = default;
+
+  /// get the reference to the MCH track entry in its original container
+  GlobalTrackID getMCHRef() const { return mMCHRef; }
+  /// set the reference to the MCH track entry in its original container
+  void setMCHRef(const GlobalTrackID& id) { mMCHRef = id; }
+  /// set the reference to the MCH track entry in its original container
+  void setMCHRef(uint32_t idx) { mMCHRef.set(idx, GlobalTrackID::MCH); }
+
+  /// get the reference to the MID track entry in its original container
+  GlobalTrackID getMIDRef() const { return mMIDRef; }
+  /// set the reference to the MID track entry in its original container
+  void setMIDRef(const GlobalTrackID& id) { mMIDRef = id; }
+  /// set the reference to the MID track entry in its original container
+  void setMIDRef(uint32_t idx) { mMIDRef.set(idx, GlobalTrackID::MID); }
+
+  /// get the interaction record associated to this track
+  InteractionRecord getIR() const { return mIR; }
+  /// set the interaction record associated to this track
+  void setIR(const InteractionRecord& ir) { mIR = ir; }
+
+  /// get the MCH-MID matching chi2/ndf
+  double getMatchChi2OverNDF() const { return mMatchNChi2; }
+  /// set the MCH-MID matching chi2/ndf
+  void setMatchChi2OverNDF(double chi2) { mMatchNChi2 = chi2; }
+
+  void print() const;
+
+ private:
+  GlobalTrackID mMCHRef{}; ///< reference to MCH track entry in its original container
+  GlobalTrackID mMIDRef{}; ///< reference to MID track entry in its original container
+  InteractionRecord mIR{}; ///< associated interaction record
+  double mMatchNChi2 = 0.; ///< MCH-MID matching chi2/ndf
+
+  ClassDefNV(TrackMCHMID, 1);
+};
+
+std::ostream& operator<<(std::ostream& os, const TrackMCHMID& track);
+
+} // namespace dataformats
+} // namespace o2
+
+#endif // ALICEO2_TRACKMCHMID_H

--- a/DataFormats/Reconstruction/src/ReconstructionDataFormatsLinkDef.h
+++ b/DataFormats/Reconstruction/src/ReconstructionDataFormatsLinkDef.h
@@ -45,6 +45,9 @@
 #pragma link C++ class o2::dataformats::TrackCosmics + ;
 #pragma link C++ class std::vector < o2::dataformats::TrackCosmics> + ;
 
+#pragma link C++ class o2::dataformats::TrackMCHMID + ;
+#pragma link C++ class std::vector < o2::dataformats::TrackMCHMID> + ;
+
 #pragma link C++ class std::vector < std::pair < float, float>> + ;
 #pragma link C++ class std::vector < std::pair < int, float>> + ;
 #pragma link C++ class std::vector < int> + ;

--- a/DataFormats/Reconstruction/src/TrackMCHMID.cxx
+++ b/DataFormats/Reconstruction/src/TrackMCHMID.cxx
@@ -1,0 +1,43 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TrackMCHMID.h
+/// \brief Implementation of the MUON track
+///
+/// \author Philippe Pillot, Subatech
+
+#include "ReconstructionDataFormats/TrackMCHMID.h"
+
+#include <iostream>
+
+namespace o2
+{
+namespace dataformats
+{
+
+//__________________________________________________________________________
+/// write the content of the track to the output stream
+std::ostream& operator<<(std::ostream& os, const o2::dataformats::TrackMCHMID& track)
+{
+  os << track.getMCHRef() << " + " << track.getMIDRef() << " = "
+     << track.getIR() << " matching chi2/NDF: " << track.getMatchChi2OverNDF();
+  return os;
+}
+
+//__________________________________________________________________________
+/// write the content of the track to the standard output
+void TrackMCHMID::print() const
+{
+  std::cout << *this << std::endl;
+}
+
+} // namespace dataformats
+} // namespace o2

--- a/Detectors/MUON/Matching/CMakeLists.txt
+++ b/Detectors/MUON/Matching/CMakeLists.txt
@@ -9,8 +9,11 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-add_subdirectory(Common)
-add_subdirectory(Matching)
-add_subdirectory(MCH)
-add_subdirectory(MID)
-add_subdirectory(Workflow)
+o2_add_library(MUONMatching
+        SOURCES
+        src/TrackMatcher.cxx
+        src/TrackMatcherParam.cxx
+        PUBLIC_LINK_LIBRARIES O2::CommonUtils O2::DataFormatsMCH O2::DataFormatsMID O2::ReconstructionDataFormats)
+
+o2_target_root_dictionary(MUONMatching
+                          HEADERS include/MUONMatching/TrackMatcherParam.h)

--- a/Detectors/MUON/Matching/README.md
+++ b/Detectors/MUON/Matching/README.md
@@ -1,0 +1,31 @@
+<!-- doxy
+\page refDetectorsMUONMatching Matching
+/doxy -->
+
+# TrackMatcher.h(cxx)
+
+Implementation of the MCH-MID matching algorithm.
+
+## Input / Output
+
+It takes as input the lists or MCH ROFs, MCH tracks, MID ROFs and MID tracks. It returns the list of matched tracks with the data format [TrackMCHMID](../../../DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackMCHMID.h).
+
+## Short description of the algorithm
+
+The matching of each MCH track in each MCH ROF is done in 2 steps:
+1) by time: finding all the MID ROFs (resolution = 1 BC) compatible with the MCH ROF (BC range)
+2) by position: finding the MID track in those MID ROFs that is the most compatible (best matching chi2) with the MCH track. The chi2 must be lower than a threshold, defined via TrackMatcherParam (see below), to validate the matching.
+
+# TrackMatcherParam.h(cxx)
+
+Definition of the sigma cut used to set the maximum matching chi2 = 4 * (sigma cut)^2. The factor 4 is because the matching is done on 4 track parameters (x, slopex, y, slopey).
+
+The sigma cut is configurable via the command line or an INI or JSON configuration file (cf. [workflow documentation](../Workflow/README.md)).
+
+## Example of workflow
+
+`o2-mch-tracks-reader-workflow | o2-mid-tracks-reader-workflow | o2-muon-tracks-matcher-workflow | o2-muon-tracks-writer-workflow`
+
+This takes as input the root files with MCH and MID tracks and ROFs and gives as ouput a root file with the matched tracks.
+
+See the [workflow documentation](../Workflow/README.md) for more details about the track matcher workflow.

--- a/Detectors/MUON/Matching/include/MUONMatching/TrackMatcher.h
+++ b/Detectors/MUON/Matching/include/MUONMatching/TrackMatcher.h
@@ -1,0 +1,67 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TrackMatcher.h
+/// \brief Definition of a class to match MCH and MID tracks
+///
+/// \author Philippe Pillot, Subatech
+
+#ifndef ALICEO2_MUON_TRACKMATCHER_H_
+#define ALICEO2_MUON_TRACKMATCHER_H_
+
+#include <vector>
+
+#include <gsl/span>
+
+#include "CommonDataFormat/InteractionRecord.h"
+#include "DataFormatsMCH/ROFRecord.h"
+#include "DataFormatsMCH/TrackMCH.h"
+#include "DataFormatsMID/ROFRecord.h"
+#include "DataFormatsMID/Track.h"
+#include "ReconstructionDataFormats/TrackMCHMID.h"
+
+namespace o2
+{
+namespace muon
+{
+
+/// Class to match MCH and MID tracks
+class TrackMatcher
+{
+  using TrackMCHMID = o2::dataformats::TrackMCHMID;
+
+ public:
+  TrackMatcher() = default;
+  ~TrackMatcher() = default;
+
+  TrackMatcher(const TrackMatcher&) = delete;
+  TrackMatcher& operator=(const TrackMatcher&) = delete;
+  TrackMatcher(TrackMatcher&&) = delete;
+  TrackMatcher& operator=(TrackMatcher&&) = delete;
+
+  void init();
+  void match(gsl::span<const mch::ROFRecord>& mchROFs, gsl::span<const mch::TrackMCH>& mchTracks,
+             gsl::span<const mid::ROFRecord>& midROFs, gsl::span<const mid::Track>& midTracks);
+
+  /// get the MCH-MID matched tracks
+  const std::vector<TrackMCHMID>& getMuons() const { return mMuons; }
+
+ private:
+  double match(const mch::TrackMCH& mchTrack, const mid::Track& midTrack);
+
+  double mMaxChi2 = 0.;              ///< maximum chi2 to validate a MCH-MID track matching
+  std::vector<TrackMCHMID> mMuons{}; ///< list of MCH-MID matched tracks
+};
+
+} // namespace muon
+} // namespace o2
+
+#endif // ALICEO2_MUON_TRACKMATCHER_H_

--- a/Detectors/MUON/Matching/include/MUONMatching/TrackMatcherParam.h
+++ b/Detectors/MUON/Matching/include/MUONMatching/TrackMatcherParam.h
@@ -1,0 +1,38 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TrackMatcherParam.h
+/// \brief Configurable parameters for MCH-MID track matching
+/// \author Philippe Pillot, Subatech
+
+#ifndef ALICEO2_MUON_TRACKMATCHERPARAM_H_
+#define ALICEO2_MUON_TRACKMATCHERPARAM_H_
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "CommonUtils/ConfigurableParamHelper.h"
+
+namespace o2
+{
+namespace muon
+{
+
+/// Configurable parameters for MCH-MID track matching
+struct TrackMatcherParam : public o2::conf::ConfigurableParamHelper<TrackMatcherParam> {
+
+  double sigmaCut = 4.; ///< to select compatible MCH and MID tracks according to their matching chi2
+
+  O2ParamDef(TrackMatcherParam, "MUONMatching");
+};
+
+} // namespace muon
+} // namespace o2
+
+#endif // ALICEO2_MUON_TRACKMATCHERPARAM_H_

--- a/Detectors/MUON/Matching/src/MUONMatchingLinkDef.h
+++ b/Detectors/MUON/Matching/src/MUONMatchingLinkDef.h
@@ -1,0 +1,21 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifdef __CLING__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class o2::muon::TrackMatcherParam + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::muon::TrackMatcherParam> + ;
+
+#endif

--- a/Detectors/MUON/Matching/src/TrackMatcher.cxx
+++ b/Detectors/MUON/Matching/src/TrackMatcher.cxx
@@ -1,0 +1,139 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TrackMatcher.cxx
+/// \brief Implementation of a class to match MCH and MID tracks
+///
+/// \author Philippe Pillot, Subatech
+
+#include <algorithm>
+#include <map>
+
+#include <Math/SMatrix.h>
+#include <Math/SVector.h>
+
+#include "Framework/Logger.h"
+#include "MUONMatching/TrackMatcher.h"
+#include "MUONMatching/TrackMatcherParam.h"
+
+namespace o2
+{
+namespace muon
+{
+
+using SMatrixSym4 = ROOT::Math::SMatrix<double, 4, 4, ROOT::Math::MatRepSym<double, 4>>;
+using SMatrix4 = ROOT::Math::SMatrix<double, 4, 4, ROOT::Math::MatRepStd<double, 4>>;
+using SVector4 = ROOT::Math::SVector<double, 4>;
+
+//_________________________________________________________________________________________________
+/// prepare to run the matching algorithm
+void TrackMatcher::init()
+{
+  // set the maximum chi2 used for matching (4 parameters matched)
+  const auto& trackMatcherParam = TrackMatcherParam::Instance();
+  mMaxChi2 = 4. * trackMatcherParam.sigmaCut * trackMatcherParam.sigmaCut;
+}
+
+//_________________________________________________________________________________________________
+/// run the matching algorithm
+void TrackMatcher::match(gsl::span<const mch::ROFRecord>& mchROFs, gsl::span<const mch::TrackMCH>& mchTracks,
+                         gsl::span<const mid::ROFRecord>& midROFs, gsl::span<const mid::Track>& midTracks)
+{
+  mMuons.clear();
+
+  if (mchROFs.empty() || midROFs.empty()) {
+    return;
+  }
+
+  // sort the MID ROFs in increasing time
+  std::map<InteractionRecord, int> midSortedROFs{};
+  for (int i = 0; i < midROFs.size(); ++i) {
+    midSortedROFs[midROFs[i].interactionRecord] = i;
+  }
+
+  for (const auto& mchROF : mchROFs) {
+
+    // find the MID ROFs in time with the MCH ROF
+    auto itStartMIDROF = midSortedROFs.lower_bound(mchROF.getBCData());
+    auto itEndMIDROF = midSortedROFs.upper_bound(mchROF.getBCData() + (mchROF.getBCWidth() - 1));
+
+    for (auto iMCHTrack = mchROF.getFirstIdx(); iMCHTrack <= mchROF.getLastIdx(); ++iMCHTrack) {
+
+      double bestMatchChi2(mMaxChi2);
+      int iBestMIDROF(-1);
+      uint32_t iBestMIDTrack(0);
+
+      for (auto itMIDROF = itStartMIDROF; itMIDROF != itEndMIDROF; ++itMIDROF) {
+
+        const auto& midROF = midROFs[itMIDROF->second];
+        for (auto iMIDTrack = midROF.firstEntry; iMIDTrack < midROF.firstEntry + midROF.nEntries; ++iMIDTrack) {
+
+          // try to match the current MCH track with the current MID track and keep the best matching
+          double matchChi2 = match(mchTracks[iMCHTrack], midTracks[iMIDTrack]);
+          if (matchChi2 < bestMatchChi2) {
+            bestMatchChi2 = matchChi2;
+            iBestMIDROF = itMIDROF->second;
+            iBestMIDTrack = uint32_t(iMIDTrack);
+          }
+        }
+      }
+
+      // store the muon track if the matching succeeded
+      if (iBestMIDROF >= 0) {
+        mMuons.emplace_back(uint32_t(iMCHTrack), iBestMIDTrack, midROFs[iBestMIDROF].interactionRecord,
+                            bestMatchChi2 / 4.);
+      }
+    }
+  }
+
+  // sort the MUON tracks in increasing BC time
+  std::stable_sort(mMuons.begin(), mMuons.end(), [](const TrackMCHMID& mu1, const TrackMCHMID& mu2) {
+    return mu1.getIR() < mu2.getIR();
+  });
+}
+
+//_________________________________________________________________________________________________
+/// compute the matching chi2/ndf between these MCH and MID tracks
+double TrackMatcher::match(const mch::TrackMCH& mchTrack, const mid::Track& midTrack)
+{
+  // compute the (X, slopeX, Y, slopeY) parameters difference between the 2 tracks at the z-position of the MID track
+  const double* mchParam = mchTrack.getParametersAtMID();
+  double dZ = midTrack.getPositionZ() - mchTrack.getZAtMID();
+  SVector4 paramDiff(mchParam[0] + mchParam[1] * dZ - midTrack.getPositionX(),
+                     mchParam[1] - midTrack.getDirectionX(),
+                     mchParam[2] + mchParam[3] * dZ - midTrack.getPositionY(),
+                     mchParam[3] - midTrack.getDirectionY());
+
+  // propagate the MCH track covariances to the z-position of the MID track
+  SMatrixSym4 mchCov(mchTrack.getCovariancesAtMID(), 10);
+  SMatrix4 jacobian(ROOT::Math::SMatrixIdentity{});
+  jacobian(0, 1) = dZ;
+  jacobian(2, 3) = dZ;
+  auto sumCov = ROOT::Math::Similarity(jacobian, mchCov);
+
+  // add the MID track covariances
+  sumCov(0, 0) += midTrack.getCovarianceParameter(mid::Track::CovarianceParamIndex::VarX);
+  sumCov(1, 0) += midTrack.getCovarianceParameter(mid::Track::CovarianceParamIndex::CovXSlopeX);
+  sumCov(1, 1) += midTrack.getCovarianceParameter(mid::Track::CovarianceParamIndex::VarSlopeX);
+  sumCov(2, 2) += midTrack.getCovarianceParameter(mid::Track::CovarianceParamIndex::VarY);
+  sumCov(3, 2) += midTrack.getCovarianceParameter(mid::Track::CovarianceParamIndex::CovYSlopeY);
+  sumCov(3, 3) += midTrack.getCovarianceParameter(mid::Track::CovarianceParamIndex::VarSlopeY);
+
+  // compute the chi2
+  if (!sumCov.Invert()) {
+    LOG(ERROR) << "Covariance matrix inversion failed: " << sumCov;
+    return mMaxChi2;
+  }
+  return ROOT::Math::Similarity(paramDiff, sumCov);
+}
+
+} // namespace muon
+} // namespace o2

--- a/Detectors/MUON/Matching/src/TrackMatcherParam.cxx
+++ b/Detectors/MUON/Matching/src/TrackMatcherParam.cxx
@@ -1,0 +1,18 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TrackMatcherParam.cxx
+/// \brief Configurable parameters for MCH-MID track matching
+/// \author Philippe Pillot, Subatech
+
+#include "MUONMatching/TrackMatcherParam.h"
+
+O2ParamImpl(o2::muon::TrackMatcherParam);

--- a/Detectors/MUON/README.md
+++ b/Detectors/MUON/README.md
@@ -11,4 +11,6 @@ The MUON subsystem is composed of three detectors : [MFT](../ITSMFT/MFT), [MCH](
 * \subpage refDetectorsMUONMID
 * \subpage refDetectorsMUONMCH
 * \subpage refDetectorsMUONCommon
+* \subpage refDetectorsMUONMatching
+* \subpage refDetectorsMUONWorkflow
 /doxy -->

--- a/Detectors/MUON/Workflow/CMakeLists.txt
+++ b/Detectors/MUON/Workflow/CMakeLists.txt
@@ -9,8 +9,14 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-add_subdirectory(Common)
-add_subdirectory(Matching)
-add_subdirectory(MCH)
-add_subdirectory(MID)
-add_subdirectory(Workflow)
+o2_add_executable(
+        tracks-matcher-workflow
+        SOURCES src/TrackMatcherSpec.cxx src/tracks-matcher-workflow.cxx
+        COMPONENT_NAME muon
+        PUBLIC_LINK_LIBRARIES O2::Framework O2::MUONMatching)
+
+o2_add_executable(
+        tracks-writer-workflow
+        SOURCES src/TrackWriterSpec.cxx src/tracks-writer-workflow.cxx
+        COMPONENT_NAME muon
+        PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::ReconstructionDataFormats)

--- a/Detectors/MUON/Workflow/README.md
+++ b/Detectors/MUON/Workflow/README.md
@@ -1,0 +1,51 @@
+<!-- doxy
+\page refDetectorsMUONWorkflow Workflows
+/doxy -->
+
+# MUON Workflows
+
+<!-- vim-markdown-toc GFM -->
+
+* [Matching](#matching)
+* [Track writer](#track-writer)
+
+<!-- vim-markdown-toc -->
+
+## Matching
+
+```shell
+o2-muon-tracks-matcher-workflow
+```
+
+Take as input the lists of MCH tracks ([TrackMCH](../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)), MCH ROF records ([ROFRecord](../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)), MID tracks ([Track](../../../DataFormats/Detectors/MUON/MID/include/DataFormatsMID/Track.h)) and MID ROF records ([ROFRecord](../../../DataFormats/Detectors/MUON/MID/include/DataFormatsMID/ROFRecord.h)) in the current time frame, with the data descriptions  "MCH/TRACKS", "MCH/TRACKROFS", "MID/TRACKS" and "MID/TRACKSROF", respectively. Send the list of matched tracks ([TrackMCHMID](../../../DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackMCHMID.h)) in the time frame, with the data description "GLO/MCHMID".
+
+Option `--config "file.json"` or `--config "file.ini"` allows to change the matching parameters from a configuration file. This file can be either in JSON or in INI format, as described below:
+
+* Example of configuration file in JSON format:
+```json
+{
+    "MUONMatching": {
+        "sigmaCut": "4."
+    }
+}
+```
+* Example of configuration file in INI format:
+```ini
+[MUONMatching]
+sigmaCut=4.
+```
+
+Option `--configKeyValues "key1=value1;key2=value2;..."` allows to change the matching parameters from the command line. The parameters changed from the command line will supersede the ones changed from a configuration file.
+
+* Example of parameters changed from the command line:
+```shell
+--configKeyValues "MUONMatching.sigmaCut=4."
+```
+
+## Track writer
+
+```shell
+o2-muon-tracks-writer-workflow --outfile "muontracks.root"
+```
+
+Take as input the list of matched tracks ([TrackMCHMID](../../../DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackMCHMID.h)) in the current time frame, with the data description "GLO/MCHMID", and write them in a root file. It is implemented using the generic [MakeRootTreeWriterSpec](../../../Framework/Utils/include/DPLUtils/MakeRootTreeWriterSpec.h) and thus offers the same options.

--- a/Detectors/MUON/Workflow/src/TrackMatcherSpec.cxx
+++ b/Detectors/MUON/Workflow/src/TrackMatcherSpec.cxx
@@ -1,0 +1,102 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TrackMatcherSpec.cxx
+/// \brief Implementation of a data processor to match MCH and MID tracks
+///
+/// \author Philippe Pillot, Subatech
+
+#include "TrackMatcherSpec.h"
+
+#include <chrono>
+#include <string>
+#include <vector>
+
+#include <gsl/span>
+
+#include "Framework/CallbackService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/Task.h"
+#include "Framework/Logger.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "DataFormatsMCH/ROFRecord.h"
+#include "DataFormatsMCH/TrackMCH.h"
+#include "DataFormatsMID/ROFRecord.h"
+#include "DataFormatsMID/Track.h"
+#include "ReconstructionDataFormats/TrackMCHMID.h"
+#include "MUONMatching/TrackMatcher.h"
+
+namespace o2
+{
+namespace muon
+{
+
+using namespace o2::framework;
+
+class TrackMatcherTask
+{
+ public:
+  //_________________________________________________________________________________________________
+  /// prepare the track matching
+  void init(InitContext& ic)
+  {
+    LOG(INFO) << "initializing track matching";
+
+    auto config = ic.options().get<std::string>("config");
+    if (!config.empty()) {
+      conf::ConfigurableParam::updateFromFile(config, "MUONMatching", true);
+    }
+    mTrackMatcher.init();
+
+    auto stop = [this]() {
+      LOG(INFO) << "track matching duration = " << mElapsedTime.count() << " s";
+    };
+    ic.services().get<CallbackService>().set(CallbackService::Id::Stop, stop);
+  }
+
+  //_________________________________________________________________________________________________
+  /// run the track matching
+  void run(ProcessingContext& pc)
+  {
+    auto mchROFs = pc.inputs().get<gsl::span<mch::ROFRecord>>("mchrofs");
+    auto mchTracks = pc.inputs().get<gsl::span<mch::TrackMCH>>("mchtracks");
+    auto midROFs = pc.inputs().get<gsl::span<mid::ROFRecord>>("midrofs");
+    auto midTracks = pc.inputs().get<gsl::span<mid::Track>>("midtracks");
+
+    auto tStart = std::chrono::high_resolution_clock::now();
+    mTrackMatcher.match(mchROFs, mchTracks, midROFs, midTracks);
+    auto tEnd = std::chrono::high_resolution_clock::now();
+    mElapsedTime += tEnd - tStart;
+
+    pc.outputs().snapshot(OutputRef{"muontracks"}, mTrackMatcher.getMuons());
+  }
+
+ private:
+  TrackMatcher mTrackMatcher{};                 ///< MCH-MID track matcher
+  std::chrono::duration<double> mElapsedTime{}; ///< timer
+};
+
+//_________________________________________________________________________________________________
+DataProcessorSpec getTrackMatcherSpec(const char* name)
+{
+  return DataProcessorSpec{
+    name,
+    Inputs{InputSpec{"mchrofs", "MCH", "TRACKROFS", 0, Lifetime::Timeframe},
+           InputSpec{"mchtracks", "MCH", "TRACKS", 0, Lifetime::Timeframe},
+           InputSpec{"midrofs", "MID", "TRACKSROF", 0, Lifetime::Timeframe},
+           InputSpec{"midtracks", "MID", "TRACKS", 0, Lifetime::Timeframe}},
+    Outputs{OutputSpec{{"muontracks"}, "GLO", "MCHMID", 0, Lifetime::Timeframe}},
+    AlgorithmSpec{adaptFromTask<TrackMatcherTask>()},
+    Options{{"config", VariantType::String, "", {"JSON or INI file with matching parameters"}}}};
+}
+
+} // namespace muon
+} // namespace o2

--- a/Detectors/MUON/Workflow/src/TrackMatcherSpec.h
+++ b/Detectors/MUON/Workflow/src/TrackMatcherSpec.h
@@ -1,0 +1,32 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TrackMatcherSpec.h
+/// \brief Definition of a data processor to match MCH and MID tracks
+///
+/// \author Philippe Pillot, Subatech
+
+#ifndef ALICEO2_MUON_TRACKMATCHERSPEC_H_
+#define ALICEO2_MUON_TRACKMATCHERSPEC_H_
+
+#include "Framework/DataProcessorSpec.h"
+
+namespace o2
+{
+namespace muon
+{
+
+framework::DataProcessorSpec getTrackMatcherSpec(const char* name = "TrackMatcher");
+
+} // namespace muon
+} // namespace o2
+
+#endif // ALICEO2_MUON_TRACKMATCHERSPEC_H_

--- a/Detectors/MUON/Workflow/src/TrackWriterSpec.cxx
+++ b/Detectors/MUON/Workflow/src/TrackWriterSpec.cxx
@@ -1,0 +1,43 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TrackWriterSpec.cxx
+/// \brief Implementation of a data processor to write matched MCH-MID tracks in a root file
+///
+/// \author Philippe Pillot, Subatech
+
+#include "TrackWriterSpec.h"
+
+#include <vector>
+
+#include "DPLUtils/MakeRootTreeWriterSpec.h"
+#include "ReconstructionDataFormats/TrackMCHMID.h"
+
+namespace o2
+{
+namespace muon
+{
+
+using namespace o2::framework;
+
+template <typename T>
+using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
+
+DataProcessorSpec getTrackWriterSpec(const char* specName, const char* fileName)
+{
+  return MakeRootTreeWriterSpec(specName,
+                                fileName,
+                                MakeRootTreeWriterSpec::TreeAttributes{"o2sim", "Tree Matched MCH-MID Tracks"},
+                                BranchDefinition<std::vector<dataformats::TrackMCHMID>>{InputSpec{"tracks", "GLO", "MCHMID"}, "tracks"})();
+}
+
+} // namespace muon
+} // namespace o2

--- a/Detectors/MUON/Workflow/src/TrackWriterSpec.h
+++ b/Detectors/MUON/Workflow/src/TrackWriterSpec.h
@@ -1,0 +1,33 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TrackWriterSpec.h
+/// \brief Definition of a data processor to write matched MCH-MID tracks in a root file
+///
+/// \author Philippe Pillot, Subatech
+
+#ifndef ALICEO2_MUON_TRACKWRITERSPEC_H_
+#define ALICEO2_MUON_TRACKWRITERSPEC_H_
+
+#include "Framework/DataProcessorSpec.h"
+
+namespace o2
+{
+namespace muon
+{
+
+framework::DataProcessorSpec getTrackWriterSpec(const char* specName = "TrackWriter",
+                                                const char* fileName = "muontracks.root");
+
+} // namespace muon
+} // namespace o2
+
+#endif // ALICEO2_MUON_TRACKWRITERSPEC_H_

--- a/Detectors/MUON/Workflow/src/tracks-matcher-workflow.cxx
+++ b/Detectors/MUON/Workflow/src/tracks-matcher-workflow.cxx
@@ -1,0 +1,41 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file tracks-matcher-workflow.cxx
+/// \brief Implementation of a DPL device to run the MCH-MID track matcher
+///
+/// \author Philippe Pillot, Subatech
+
+#include <string>
+#include <vector>
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/ConfigContext.h"
+#include "Framework/WorkflowSpec.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "TrackMatcherSpec.h"
+
+using namespace o2::framework;
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  workflowOptions.emplace_back("configKeyValues", VariantType::String, "",
+                               ConfigParamSpec::HelpString{"Semicolon separated key=value strings"});
+}
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(const ConfigContext& configcontext)
+{
+  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
+  return WorkflowSpec{o2::muon::getTrackMatcherSpec()};
+}

--- a/Detectors/MUON/Workflow/src/tracks-writer-workflow.cxx
+++ b/Detectors/MUON/Workflow/src/tracks-writer-workflow.cxx
@@ -1,0 +1,25 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file tracks-writer-workflow.cxx
+/// \brief Implementation of a DPL device to run the MCH-MID track writer
+///
+/// \author Philippe Pillot, Subatech
+
+#include "Framework/runDataProcessing.h"
+#include "TrackWriterSpec.h"
+
+using namespace o2::framework;
+
+WorkflowSpec defineDataProcessing(const ConfigContext&)
+{
+  return WorkflowSpec{o2::muon::getTrackWriterSpec()};
+}


### PR DESCRIPTION
This PR has 3 components:
- The new TrackMCHMID data format for the matched tracks. It contains the matching chi2/ndf, the IR (from MID) and the indices of the associated MCH and MID tracks in the input messages.
- The matching algorithm with the associated configurable parameters
- The workflows to run the matching and to write the matched tracks in a root file
