### PR TITLE
[MRRTF-142] MCH: add time resolution to simulated digits and noise on all ROFs

### DIFF
--- a/Detectors/MUON/MCH/Simulation/README.md
+++ b/Detectors/MUON/MCH/Simulation/README.md
@@ -1,0 +1,46 @@
+# How to make a simulation including MCH
+
+## Only MCH
+
+Like all [O2 simulations](../../../../doc/DetectorSimulation.md), it's a two stage process : first create the hits and then digitize them.
+
+### Hit creation
+
+    o2-sim -n 10 -g fwmugen -e TGeant3 -m MCH
+
+will generate 10 events using the `fwmugen` generator (1 forward muon per event), using Geant3 as transport, and with only MCH geometry.
+
+    CAUTION: by specifying -m MCH you only get MCH geometry, no absorber,
+    no dipole, no beam shield, etc... So that's only a relevant option
+    for quick debug, not for any kind of physics analysis.
+
+This steps creates (among others) an `o2sim_HitsMCH.root` file with the MCH hits, as well as `o2sim_geometry.root` and `o2sim_grp.root` which are used later on by the digitizer.
+
+### Digitization
+
+In the same directory where the hits were created, use :
+
+    o2-sim-digitizer-workflow
+
+This will creates `mchdigits.root`, updates `o2sim_grp.root` and generates a `collisioncontext.root`.
+This last file can be used to redo the digitization for the very _same_ collisions, but with e.g. different digitization parameters.
+
+Various options can be specified using the `--configKeyValues`.
+For example for the MCH digitizer :
+
+    o2-sim-digitizer-workflow --configKeyValues \
+    "MCHDigitizerParam.noiseProba=1E-6;MCHDigitizerParam.timeSpread=150"
+
+For the list of possible parameters see the [MCHDigitizerParam](./include/MCHSimulation/DigitizerParam.h) struct.
+
+## More realistic simulations
+
+For anything but debug, you should include more modules at the hit creation
+stage :
+
+    o2-sim -m HALL MAG DIPO COMP PIPE ABSO SHIL MCH
+
+Of course, add other detectors (MID,MFT,ITS,...) if need be.
+
+Note that for the moment there's is no way to simply include the geometry of a detector, just to have its material budget in the picture, without also having it participating to the hit creation (see [JIRA
+O2-2378](https://alice.its.cern.ch/jira/browse/O2-2378)).

--- a/Detectors/MUON/MCH/Simulation/include/MCHSimulation/DEDigitizer.h
+++ b/Detectors/MUON/MCH/Simulation/include/MCHSimulation/DEDigitizer.h
@@ -17,11 +17,14 @@
 #include "MCHSimulation/Hit.h"
 #include "MCHSimulation/Response.h"
 #include "MathUtils/Cartesian.h"
+#include <set>
 #include <vector>
+#include <map>
 #include "SimulationDataFormat/MCTruthContainer.h"
 #include "CommonDataFormat/InteractionRecord.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
+#include <random>
 
 namespace o2::mch
 {
@@ -31,17 +34,41 @@ namespace o2::mch
 class DEDigitizer
 {
  public:
-  DEDigitizer(int deId, o2::math_utils::Transform3D transformation);
-
-  /** startCollision sets the current IR under consideration.
+  /** Constructor.
    *
-   * All the digits created between a call to this one and clear()
-   * will be associated to a MCH ROFRecord == collisionTime
-  */
-  void startCollision(o2::InteractionRecord collisionTime);
+   * @param deId detection element
+   * @param transformation a geo transformation to convert global coordinates
+   *        (of this hits) into local (to the detection element) ones
+   * @param timeSpread the sigma of the time resolution to apply to digit
+   *        times (in nanoseconds, typically O(100ns))
+   * @param noiseChargeMean the mean of the charge to assign to noise digits
+   *        (in ADC counts, typically O(10))
+   * @param noiseChargeSigma the sigma of the charge to assign to noise digits
+   *        (in ADC counts, typically O(1))
+   * @param seed for random number generation
+   */
+  DEDigitizer(int deId,
+              o2::math_utils::Transform3D transformation,
+              float timeSpread,
+              float noiseChargeMean,
+              float noiseChargeSigma,
+              int seed);
 
-  /** Add some noise to the current collision */
-  void addNoise(float noiseProba);
+  /** Add some noise-only digits.
+   *
+   * @param noiseProba the probability that a given pad is above threshold
+   * (upon a given duration = one ADC sample = 100ns)
+   *
+   * Noise digits will be generated for all IR between `firstIR`
+   * and `lastIR`. Note that depending on the actual value of noiseProba
+   * some IR might not get any noisy digit, and that's fine.
+   *
+   * The noise digits will be added to any pre-existing digits (signal
+   * digits).
+   */
+  void addNoise(float noiseProba,
+                const o2::InteractionRecord& firstIR,
+                const o2::InteractionRecord& lastIR);
 
   /** process one MCH Hit.
    *
@@ -49,34 +76,59 @@ class DEDigitizer
    * to a Mathieson 2D distribution) that charge among several pads,
    * that will become digits eventually
    *
+   * @param collisionTime the IR this hit is associated to
    * @param hit the input hit to be digitized
    * @param evID the event identifier of the hit in the sim chain within srcID
    * @param srcID the origin (signal, background) of the hit
    * @see o2::steer::EventPart
    */
-  void process(const Hit& hit, int evID, int srcID);
+  void process(const o2::InteractionRecord& collisionTime, const Hit& hit, int evID, int srcID);
 
-  /** extractDigitsAndLabels appends digits and labels to given containers.
+  /** extractDigitsAndLabels appends digits and labels corresponding
+   * to a given ROF to the given containers.
    *
    * This function copies our internal information into the parameter vectors
    *
+   * @param rofs the ROF for which we want the digits and labels.
    * @param digits vector of digits where we append our internal digits.
    * @param labels MCTruthContainer where we append our internal labels.
    */
-  void extractDigitsAndLabels(std::vector<Digit>& digits,
+  void extractDigitsAndLabels(const o2::InteractionRecord& rof,
+                              std::vector<Digit>& digits,
                               o2::dataformats::MCTruthContainer<o2::MCCompLabel>& labels);
 
-  /** Clear resets our internal lists of digits and labels. */
+  void extractRofs(std::set<o2::InteractionRecord>& rofs);
+
+  void appendDigit(o2::InteractionRecord ir,
+                   int padid, float charge, const o2::MCCompLabel& label);
+
+  /** Clear our internal storage (pad charges and so on). */
   void clear();
 
  private:
-  int mDeId;                                         // detection element id
-  Response mResponse;                                // response function (Mathieson parameters, ...)
-  o2::math_utils::Transform3D mTransformation;       // from local to global and reverse
-  mapping::Segmentation mSegmentation;               // mapping of this detection element
-  o2::InteractionRecord mIR;                         // interaction record to associate charges and labels to
-  std::vector<float> mCharges;                       // pad charges (fixed size = number of pads in this DE)
-  std::vector<std::vector<o2::MCCompLabel>> mLabels; // mLabels.size()==mCharges.size()
+  /** get a random time shift (wrt to collision time), in bc unit.
+   */
+  int64_t drawRandomTimeShift();
+
+  /** shift ir0 by some random number of BCs, thus
+   * simulating the detector time resolution
+   */
+  o2::InteractionRecord shiftTime(o2::InteractionRecord ir);
+
+  struct Pad {
+    int padid;
+    float charge;
+    std::vector<o2::MCCompLabel> labels;
+    Pad(int padid_, float charge_, const o2::MCCompLabel& label) : padid{padid_}, charge{charge_}, labels{label} {}
+  };
+  int mDeId;                                   // detection element id
+  Response mResponse;                          // response function (Mathieson parameters, ...)
+  o2::math_utils::Transform3D mTransformation; // from local to global and reverse
+  mapping::Segmentation mSegmentation;         // mapping of this detection element
+  std::map<o2::InteractionRecord, std::vector<Pad>> mPadMap;
+  std::normal_distribution<float> mTimeDist;
+  std::normal_distribution<float> mChargeDist;
+  std::mt19937 mGene;
 };
 
 } // namespace o2::mch

--- a/Detectors/MUON/MCH/Simulation/include/MCHSimulation/DigitizerParam.h
+++ b/Detectors/MUON/MCH/Simulation/include/MCHSimulation/DigitizerParam.h
@@ -20,8 +20,13 @@ namespace o2::mch
 
 struct DigitizerParam : public o2::conf::ConfigurableParamHelper<DigitizerParam> {
 
-  bool continuous = true;           // whether we assume continuous mode or not
-  float noiseProba = 3.1671242e-05; // by default = proba to be above 4*sigma of a gaussian noise
+  bool continuous = true;   // whether we assume continuous mode or not
+  float noiseProba = 1E-6;  // noise proba (per pad per ROF=100ns)
+  float noiseMean = 42;     // mean noise (in ADC counts). default value assumes 3 ADC count per sample, 14 samples for a signal.
+  float noiseSigma = 11.22; // noise sigma (in ADC counts) = sqrt(14)*sigma_for_one_sample
+  float timeSpread = 150;   // time spread added to digit times (in nanoseconds)
+  int seed = 0;             // seed for random number generator(s) used for time and noise (0 means no seed given)
+  bool onlyNoise = false;   // for debug only : disable treatment of signal (i.e. keep only noise)
 
   O2ParamDef(DigitizerParam, "MCHDigitizerParam")
 };

--- a/Detectors/MUON/MCH/Simulation/include/MCHSimulation/Response.h
+++ b/Detectors/MUON/MCH/Simulation/include/MCHSimulation/Response.h
@@ -25,6 +25,7 @@ enum class Station {
   Type1,
   Type2345
 };
+
 class Response
 {
  public:
@@ -33,23 +34,31 @@ class Response
 
   float getQspreadX() const { return mQspreadX; };
   float getQspreadY() const { return mQspreadY; };
-  float getFCtoADC() const { return mFCtoADC; };
   float getChargeThreshold() const { return mChargeThreshold; };
-  float getInverseChargeThreshold() const { return mInverseChargeThreshold; };
-  float etocharge(float edepos);
-  double chargePadfraction(float xmin, float xmax, float ymin, float ymax);
-  double chargefrac1d(float min, float max, double k2, double sqrtk3, double k4);
-  uint32_t response(uint32_t adc);
-  float getAnod(float x);
-  float chargeCorr();
-  bool aboveThreshold(float charge) { return charge > mChargeThreshold; };
+
+  /** Converts energy deposition into a charge.
+   *
+   * @param edepos deposited energy from Geant (in GeV)
+   * @returns an equivalent charge (roughyl in ADC units)
+   *
+   */
+  float etocharge(float edepos) const;
+
+  /** Compute the charge fraction in a rectangle area for a unit charge
+   * occuring at position (0,0)
+   *
+   * @param xmin, xmax, ymin, ymax coordinates (in cm) defining the area
+   */
+  double chargePadfraction(float xmin, float xmax, float ymin, float ymax) const;
+
+  float getAnod(float x) const;
+  float chargeCorr() const;
+
+  bool isAboveThreshold(float charge) const { return charge > mChargeThreshold; };
   float getSigmaIntegration() const { return mSigmaIntegration; };
-  bool getIsSampa() { return mSampa; };
-  void setIsSampa(bool isSampa = true) { mSampa = isSampa; };
 
  private:
-  //setter to get Aliroot-readout-chain or Run 3 (Sampa) one
-  bool mSampa = true;
+  double chargefrac1d(float min, float max, double k2, double sqrtk3, double k4) const;
 
   //parameter for station number
   Station mStation;
@@ -64,24 +73,6 @@ class Response
   //AliMUONResponseV0.h: amplitude of charge correlation on 2 cathods, is RMS of ln(q1/q2)
 
   float mChargeThreshold = 1e-4;
-  float mInverseChargeThreshold = 10000.;
-  //AliMUONResponseV0.cxx constr.
-  //"charges below this threshold are 0"
-  float mFCtoADC = 1 / (0.61 * 1.25 * 0.2);
-  float mADCtoFC = 0.61 * 1.25 * 0.2;
-  //transitions between fc and ADD
-  //from AliMUONResponseV0.cxx
-  //equals (for Aliroo) AliMUONConstants::DefaultADC2MV()*AliMUONConstants::DefaultA0()*AliMUONConstants::DefaultCapa()
-  //for the moment not used since directly transition into ADC
-
-  //Mathieson parameter: NIM A270 (1988) 602-603
-  //should be a common place for MCH
-  // Mathieson parameters from L.Kharmandarian's thesis, page 190
-  //  fKy2 = TMath::Pi() / 2. * (1. - 0.5 * fSqrtKy3);//AliMUONMathieson::SetSqrtKx3AndDeriveKx2Kx4(Float_t SqrtKx3)
-  //  Float_t cy1 = fKy2 * fSqrtKy3 / 4. / TMath::ATan(Double_t(fSqrtKy3));
-  //  fKy4 = cy1 / fKy2 / fSqrtKy3; //this line from AliMUONMathieson::SetSqrtKy3AndDeriveKy2Ky4
-  //why this multiplicitation before again division? any number small compared to Float precision?
-
   float mSigmaIntegration;
 
   double mK2x;
@@ -91,11 +82,8 @@ class Response
   double mSqrtK3y;
   double mK4y;
 
-  //anode-cathode Pitch in 1/cm
-  float mInversePitch;
+  float mInversePitch; // anode-cathode Pitch in 1/cm
   float mPitch;
-  //maximal bit number
-  int mMaxADC = (1 << 12) - 1;
 };
 } // namespace mch
 } // namespace o2

--- a/Detectors/MUON/MCH/Workflow/src/rofs-histogrammer.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/rofs-histogrammer.cxx
@@ -80,10 +80,13 @@ struct Histogrammer {
     THnSparseL h("rof_times", "rof times", 1, bins, xmin, xmax);
     for (const auto& p : mRofs) {
       const auto& rof = p.first;
-      Double_t x[1] = {1.0 * rof.getBCData().differenceInBC(firstRof)};
       Double_t w = rof.getNEntries();
-      h.Fill(x, w);
-      h.SetBinError(h.GetBin(x), sqrt(w));
+      Double_t x[1] = {1.0 * rof.getBCData().differenceInBC(firstRof)};
+      for (auto i = 0; i < rof.getBCWidth(); i++) {
+        x[0] += 1.0;
+        h.Fill(x, w);
+        h.SetBinError(h.GetBin(x), sqrt(w));
+      }
     }
     h.Write("", TObject::kWriteDelete);
   }

--- a/Steer/DigitizerWorkflow/src/MCHDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/MCHDigitizerSpec.cxx
@@ -48,7 +48,12 @@ class MCHDPLDigitizerTask : public o2::base::BaseDPLDigitizer
   void initDigitizerTask(framework::InitContext& ic) override
   {
     auto transformation = o2::mch::geo::transformationFromTGeoManager(*gGeoManager);
-    mDigitizer = std::make_unique<Digitizer>(transformation);
+    auto& params = DigitizerParam::Instance();
+    mDigitizer = std::make_unique<Digitizer>(transformation,
+                                             params.timeSpread,
+                                             params.noiseMean,
+                                             params.noiseSigma,
+                                             params.seed);
   }
 
   void logStatus(gsl::span<Digit> digits, gsl::span<ROFRecord> rofs,
@@ -74,33 +79,32 @@ class MCHDPLDigitizerTask : public o2::base::BaseDPLDigitizer
       return;
     }
     float noiseProba = DigitizerParam::Instance().noiseProba;
+    bool onlyNoise = DigitizerParam::Instance().onlyNoise;
     auto tStart = std::chrono::high_resolution_clock::now();
     auto context = pc.inputs().get<o2::steer::DigitizationContext*>("collisioncontext");
     context->initSimChains(o2::detectors::DetID::MCH, mSimChains);
     const auto& eventRecords = context->getEventRecords();
     const auto& eventParts = context->getEventParts();
+    if (!onlyNoise) {
+      for (auto i = 0; i < eventRecords.size(); i++) {
+        auto ir = eventRecords[i];
+        for (const auto& part : eventParts[i]) {
+          std::vector<o2::mch::Hit> hits;
+          context->retrieveHits(mSimChains, "MCHHit", part.sourceID, part.entryID, &hits);
+          mDigitizer->processHits(ir, hits, part.entryID, part.sourceID);
+        }
+      }
+    }
+
+    // we generate noise only (for the moment ?) between first and last collision
+    auto firstIR = eventRecords.front();
+    auto lastIR = eventRecords.back();
+    mDigitizer->addNoise(noiseProba, firstIR, lastIR);
+
     std::vector<o2::mch::Digit> digits;
     std::vector<o2::mch::ROFRecord> rofs;
     o2::dataformats::MCTruthContainer<o2::MCCompLabel> labels;
-    size_t firstIdx = 0;
-    auto mchRecords = groupIR(eventRecords);
-    for (auto mrec : mchRecords) {
-      auto collisionIndices = mrec.second;
-      const auto& mchIR = mrec.first;
-      mDigitizer->startCollision(mchIR);
-      for (auto collisionIndex : collisionIndices) {
-        for (const auto& part : eventParts[collisionIndex]) {
-          std::vector<o2::mch::Hit> hits;
-          context->retrieveHits(mSimChains, "MCHHit", part.sourceID, part.entryID, &hits);
-          mDigitizer->processHits(hits, part.entryID, part.sourceID);
-        }
-      }
-      mDigitizer->addNoise(noiseProba);
-      mDigitizer->extractDigitsAndLabels(digits, labels);
-      auto nEntries = digits.size() - firstIdx;
-      rofs.emplace_back(ROFRecord(mchIR, firstIdx, nEntries));
-      firstIdx = digits.size();
-    }
+    mDigitizer->extract(rofs, digits, labels);
     pc.outputs().snapshot(Output{"MCH", "DIGITS", 0, Lifetime::Timeframe}, digits);
     pc.outputs().snapshot(Output{"MCH", "DIGITROFS", 0, Lifetime::Timeframe}, rofs);
     if (pc.outputs().isAllowed({"MCH", "DIGITSLABELS", 0})) {
@@ -117,7 +121,8 @@ class MCHDPLDigitizerTask : public o2::base::BaseDPLDigitizer
   }
 
  private:
-  std::unique_ptr<Digitizer> mDigitizer;
+  std::unique_ptr<Digitizer>
+    mDigitizer;
   std::vector<TChain*> mSimChains;
 };
 


### PR DESCRIPTION
The noise is added to potentially all ROFs (but within the limited range of first and
last hadronic interaction in the eventRecords) not only those with collisions.