### PR TITLE
TPC: handle exceptions in calib_processing_helper::processRawData

### DIFF
--- a/Detectors/TPC/workflow/include/TPCWorkflow/CalibProcessingHelper.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/CalibProcessingHelper.h
@@ -29,7 +29,7 @@ class RawReaderCRU;
 namespace calib_processing_helper
 {
 
-uint64_t processRawData(o2::framework::InputRecord& inputs, std::unique_ptr<RawReaderCRU>& reader, bool useOldSubspec = false, const std::vector<int>& sectors = {});
+uint64_t processRawData(o2::framework::InputRecord& inputs, std::unique_ptr<RawReaderCRU>& reader, bool useOldSubspec = false, const std::vector<int>& sectors = {}, size_t* nerrors = nullptr);
 } // namespace calib_processing_helper
 } // namespace tpc
 } // namespace o2


### PR DESCRIPTION
RawParser used by processRawData throws on corrupted TPC raw data, eventually killing workflows
on all EPNs. This PR catches those exceptions, logs an error and skips the FMQ part, i.e.
1 HBF for single link with current packaging.
If an optional pointer on the counter is provided, it will be incremented for each throw.