### PR TITLE
DPL Analysis: allow std::vector column types backed by variable size list

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -29,6 +29,7 @@
 #include <cassert>
 #include <fmt/format.h>
 #include <typeinfo>
+#include <gsl/span>
 
 namespace o2::soa
 {
@@ -253,7 +254,7 @@ class ColumnIterator : ChunkingPolicy
       auto list = std::static_pointer_cast<arrow::ListArray>(mColumn->chunk(mCurrentChunk));
       auto offset = list->value_offset(*mCurrentPos - mFirstIndex);
       auto length = list->value_length(*mCurrentPos - mFirstIndex);
-      return T{mCurrent + offset, mCurrent + offset + length};
+      return gsl::span{mCurrent + offset, mCurrent + offset + length};
     } else {
       return *(mCurrent + (*mCurrentPos >> SCALE_FACTOR));
     }

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -145,6 +145,20 @@ struct Flat {
   constexpr static bool chunked = false;
 };
 
+/// unwrapper
+template <typename T>
+struct unwrap {
+  using type = T;
+};
+
+template <typename T>
+struct unwrap<std::vector<T>> {
+  using type = T;
+};
+
+template <typename T>
+using unwrap_t = typename unwrap<T>::type;
+
 /// Iterator on a single column.
 /// FIXME: the ChunkingPolicy for now is fixed to Flat and is a mere boolean
 /// which is used to switch off slow "chunking aware" parts. This is ok for
@@ -166,7 +180,7 @@ class ColumnIterator : ChunkingPolicy
       mCurrentChunk{0}
   {
     auto array = getCurrentArray();
-    mCurrent = reinterpret_cast<T const*>(array->values()->data()) + array->offset();
+    mCurrent = reinterpret_cast<unwrap_t<T> const*>(array->values()->data()) + array->offset();
     mLast = mCurrent + array->length();
   }
 
@@ -185,7 +199,7 @@ class ColumnIterator : ChunkingPolicy
 
     mCurrentChunk++;
     auto array = getCurrentArray();
-    mCurrent = reinterpret_cast<T const*>(array->values()->data()) + array->offset() - (mFirstIndex >> SCALE_FACTOR);
+    mCurrent = reinterpret_cast<unwrap_t<T> const*>(array->values()->data()) + array->offset() - (mFirstIndex >> SCALE_FACTOR);
     mLast = mCurrent + array->length() + (mFirstIndex >> SCALE_FACTOR);
   }
 
@@ -196,7 +210,7 @@ class ColumnIterator : ChunkingPolicy
 
     mCurrentChunk--;
     auto array = getCurrentArray();
-    mCurrent = reinterpret_cast<T const*>(array->values()->data()) + array->offset() - (mFirstIndex >> SCALE_FACTOR);
+    mCurrent = reinterpret_cast<unwrap_t<T> const*>(array->values()->data()) + array->offset() - (mFirstIndex >> SCALE_FACTOR);
     mLast = mCurrent + array->length() + (mFirstIndex >> SCALE_FACTOR);
   }
 
@@ -219,7 +233,7 @@ class ColumnIterator : ChunkingPolicy
     mCurrentChunk = mColumn->num_chunks() - 1;
     auto array = getCurrentArray();
     mFirstIndex = mColumn->length() - array->length();
-    mCurrent = reinterpret_cast<T const*>(array->values()->data()) + array->offset() - (mFirstIndex >> SCALE_FACTOR);
+    mCurrent = reinterpret_cast<unwrap_t<T> const*>(array->values()->data()) + array->offset() - (mFirstIndex >> SCALE_FACTOR);
     mLast = mCurrent + array->length() + (mFirstIndex >> SCALE_FACTOR);
   }
 
@@ -235,6 +249,11 @@ class ColumnIterator : ChunkingPolicy
       //        masked char to a bool, because it's undefined behavior.
       // FIXME: check if shifting the masked bit to the first position is better than != 0
       return (*((char*)mCurrent + (*mCurrentPos >> SCALE_FACTOR)) & (1 << (*mCurrentPos & 0x7))) != 0;
+    } else if constexpr (o2::framework::is_base_of_template<std::vector, T>::value) {
+      auto list = std::static_pointer_cast<arrow::ListArray>(mColumn->chunk(mCurrentChunk));
+      auto offset = list->value_offset(*mCurrentPos - mFirstIndex);
+      auto length = list->value_length(*mCurrentPos - mFirstIndex);
+      return T{mCurrent + offset, mCurrent + offset + length};
     } else {
       return *(mCurrent + (*mCurrentPos >> SCALE_FACTOR));
     }
@@ -264,9 +283,9 @@ class ColumnIterator : ChunkingPolicy
     return *this;
   }
 
-  mutable T const* mCurrent;
+  mutable unwrap_t<T> const* mCurrent;
   int64_t const* mCurrentPos;
-  mutable T const* mLast;
+  mutable unwrap_t<T> const* mLast;
   arrow::ChunkedArray const* mColumn;
   mutable int mFirstIndex;
   mutable int mCurrentChunk;
@@ -278,6 +297,9 @@ class ColumnIterator : ChunkingPolicy
     std::shared_ptr<arrow::Array> chunkToUse = mColumn->chunk(mCurrentChunk);
     if constexpr (std::is_same_v<arrow_array_for_t<T>, arrow::FixedSizeListArray>) {
       chunkToUse = std::dynamic_pointer_cast<arrow::FixedSizeListArray>(chunkToUse)->values();
+      return std::static_pointer_cast<arrow_array_for_t<value_for_t<T>>>(chunkToUse);
+    } else if constexpr (std::is_same_v<arrow_array_for_t<T>, arrow::ListArray>) {
+      chunkToUse = std::dynamic_pointer_cast<arrow::ListArray>(chunkToUse)->values();
       return std::static_pointer_cast<arrow_array_for_t<value_for_t<T>>>(chunkToUse);
     } else {
       return std::static_pointer_cast<arrow_array_for_t<T>>(chunkToUse);

--- a/Framework/Core/include/Framework/ArrowTypes.h
+++ b/Framework/Core/include/Framework/ArrowTypes.h
@@ -77,6 +77,21 @@ struct arrow_array_for<double[N]> {
   using type = arrow::FixedSizeListArray;
   using value_type = double;
 };
+template <>
+struct arrow_array_for<std::vector<int>> {
+  using type = arrow::ListArray;
+  using value_type = int;
+};
+template <>
+struct arrow_array_for<std::vector<float>> {
+  using type = arrow::ListArray;
+  using value_type = float;
+};
+template <>
+struct arrow_array_for<std::vector<double>> {
+  using type = arrow::ListArray;
+  using value_type = double;
+};
 
 template <typename T>
 using arrow_array_for_t = typename arrow_array_for<T>::type;

--- a/Framework/Core/test/test_ASoA.cxx
+++ b/Framework/Core/test/test_ASoA.cxx
@@ -61,6 +61,14 @@ DECLARE_SOA_COLUMN_FULL(Thickness, thickness, int, "thickness");
 DECLARE_SOA_TABLE(Segments, "TST", "SEGMENTS", test::N, test::PointAId, test::PointBId, test::InfoId);
 DECLARE_SOA_TABLE(SegmentsExtras, "TST", "SEGMENTSEX", test::Thickness);
 
+namespace test
+{
+DECLARE_SOA_COLUMN(L1, l1, std::vector<float>);
+DECLARE_SOA_COLUMN(L2, l2, std::vector<int>);
+} // namespace test
+
+DECLARE_SOA_TABLE(Lists, "TST", "LISTS", o2::soa::Index<>, test::L1, test::L2);
+
 BOOST_AUTO_TEST_CASE(TestTableIteration)
 {
   TableBuilder builder;
@@ -779,5 +787,42 @@ BOOST_AUTO_TEST_CASE(TestAdvancedIndices)
     BOOST_CHECK(bbb);
     BOOST_CHECK_EQUAL(op.globalIndex(), references[i]);
     ++i;
+  }
+}
+
+BOOST_AUTO_TEST_CASE(TestListColumns)
+{
+  TableBuilder b;
+  auto writer = b.cursor<Lists>();
+  std::vector<float> floats;
+  std::vector<int> ints;
+  for (auto i = 1; i < 11; ++i) {
+    floats.clear();
+    ints.clear();
+    for (auto j = 0; j < i; ++j) {
+      floats.push_back(0.1231233 * (float)j + 0.1982798);
+      ints.push_back(j + 10);
+    }
+
+    writer(0, floats, ints);
+  }
+  auto lt = b.finalize();
+  Lists tbl{lt};
+  int s = 1;
+  for (auto& row : tbl) {
+    auto f = row.l1();
+    auto i = row.l2();
+    auto constexpr bf = std::is_same_v<decltype(f), std::vector<float>>;
+    auto constexpr bi = std::is_same_v<decltype(i), std::vector<int>>;
+    BOOST_CHECK(bf);
+    BOOST_CHECK(bi);
+    BOOST_CHECK_EQUAL(f.size(), s);
+    BOOST_CHECK_EQUAL(i.size(), s);
+
+    for (auto j = 0; j < f.size(); ++j) {
+      BOOST_CHECK_CLOSE(f[j], 0.1231233 * (float)j + 0.1982798, 0.0001);
+      BOOST_CHECK_EQUAL(i[j], j + 10);
+    }
+    ++s;
   }
 }

--- a/Framework/Core/test/test_ASoA.cxx
+++ b/Framework/Core/test/test_ASoA.cxx
@@ -824,5 +824,5 @@ BOOST_AUTO_TEST_CASE(TestListColumns)
       BOOST_CHECK_EQUAL(i[j], j + 10);
     }
     ++s;
-  } 
+  }
 }

--- a/Framework/Core/test/test_ASoA.cxx
+++ b/Framework/Core/test/test_ASoA.cxx
@@ -800,7 +800,7 @@ BOOST_AUTO_TEST_CASE(TestListColumns)
     floats.clear();
     ints.clear();
     for (auto j = 0; j < i; ++j) {
-      floats.push_back(0.1231233 * (float)j + 0.1982798);
+      floats.push_back(0.1231233f * (float)j + 0.1982798f);
       ints.push_back(j + 10);
     }
 
@@ -812,17 +812,17 @@ BOOST_AUTO_TEST_CASE(TestListColumns)
   for (auto& row : tbl) {
     auto f = row.l1();
     auto i = row.l2();
-    auto constexpr bf = std::is_same_v<decltype(f), std::vector<float>>;
-    auto constexpr bi = std::is_same_v<decltype(i), std::vector<int>>;
+    auto constexpr bf = std::is_same_v<decltype(f), gsl::span<const float, (size_t)-1>>;
+    auto constexpr bi = std::is_same_v<decltype(i), gsl::span<const int, (size_t)-1>>;
     BOOST_CHECK(bf);
     BOOST_CHECK(bi);
     BOOST_CHECK_EQUAL(f.size(), s);
     BOOST_CHECK_EQUAL(i.size(), s);
 
-    for (auto j = 0; j < f.size(); ++j) {
-      BOOST_CHECK_CLOSE(f[j], 0.1231233 * (float)j + 0.1982798, 0.0001);
+    for (auto j = 0u; j < f.size(); ++j) {
+      BOOST_CHECK_EQUAL(f[j], 0.1231233f * (float)j + 0.1982798f);
       BOOST_CHECK_EQUAL(i[j], j + 10);
     }
     ++s;
-  }
+  } 
 }


### PR DESCRIPTION
* Update TableBuilder to handle writing vectors
* Update ColumnIterator to handle extracting vectors
* Add a test case to test_ASoA

@ktf this works, but I have doubts about using std::vector here (although very convenient)