### PR TITLE
Bug fixes for MID decoder

### DIFF
--- a/Detectors/MUON/MID/Raw/include/MIDRaw/ELinkDataShaper.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/ELinkDataShaper.h
@@ -31,20 +31,17 @@ namespace mid
 class ELinkDataShaper
 {
  public:
-  ELinkDataShaper(bool isDebugMode, bool isLoc, uint8_t uniqueId);
+  ELinkDataShaper(bool isDebugMode, bool isLoc, uint8_t uniqueId, const ElectronicsDelay& electronicsDelay);
   /// Main function to be executed when decoding is done
   inline void onDone(const ELinkDecoder& decoder, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs) { std::invoke(mOnDone, this, decoder, data, rofs); }
 
   void set(uint32_t orbit);
 
-  /// Sets the delay in the electronics
-  void setElectronicsDelay(const ElectronicsDelay& electronicsDelay) { mElectronicsDelay = electronicsDelay; }
-
  private:
   uint8_t mUniqueId{0};                 /// UniqueId
+  ElectronicsDelay mElectronicsDelay{}; /// Delays in the electronics
   uint32_t mRDHOrbit{0};                /// RDH orbit
   bool mReceivedCalibration{false};     /// Flag to indicate if the  calibration trigger was received
-  ElectronicsDelay mElectronicsDelay{}; /// Delays in the electronics
 
   InteractionRecord mIR{};      /// Interaction record
   uint16_t mExpectedFETClock{}; /// Expected FET clock
@@ -58,12 +55,12 @@ class ELinkDataShaper
   void onDoneReg(const ELinkDecoder&, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs){}; /// Dummy function
   void onDoneRegDebug(const ELinkDecoder& decoder, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs);
 
-  void addLoc(const ELinkDecoder& decoder, EventType eventType, uint16_t correctedClock, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs);
+  void addLoc(const ELinkDecoder& decoder, EventType eventType, InteractionRecord ir, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs);
   bool checkLoc(const ELinkDecoder& decoder);
   EventType processCalibrationTrigger(uint16_t localClock);
   void processOrbitTrigger(uint16_t localClock, uint8_t triggerWord);
-  EventType processSelfTriggered(uint16_t localClock, uint16_t& correctedClock);
-  bool processTrigger(const ELinkDecoder& decoder, EventType& eventType, uint16_t& correctedClock);
+  EventType processSelfTriggered(uint16_t localClock, InteractionRecord& ir);
+  bool processTrigger(const ELinkDecoder& decoder, EventType& eventType, InteractionRecord& ir);
 };
 } // namespace mid
 } // namespace o2

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/GBTUserLogicEncoder.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/GBTUserLogicEncoder.h
@@ -31,7 +31,7 @@ namespace mid
 class GBTUserLogicEncoder
 {
  public:
-  void process(gsl::span<const ROBoard> data, const InteractionRecord& ir);
+  void process(gsl::span<const ROBoard> data, InteractionRecord ir);
   void processTrigger(const InteractionRecord& ir, uint8_t triggerWord);
 
   void flush(std::vector<char>& buffer, const InteractionRecord& ir);

--- a/Detectors/MUON/MID/Raw/src/ELinkDataShaper.cxx
+++ b/Detectors/MUON/MID/Raw/src/ELinkDataShaper.cxx
@@ -122,6 +122,7 @@ bool ELinkDataShaper::processTrigger(const ELinkDecoder& decoder, EventType& eve
   // From here we treat triggered events
   bool goOn = false;
   correctedClock = localClock;
+  eventType = EventType::Standard;
   if (decoder.getTriggerWord() & raw::sCALIBRATE) {
     // This is an answer to a calibration trigger
     eventType = processCalibrationTrigger(localClock);
@@ -131,7 +132,6 @@ bool ELinkDataShaper::processTrigger(const ELinkDecoder& decoder, EventType& eve
   if (decoder.getTriggerWord() & raw::sORB) {
     // This is the answer to an orbit trigger
     processOrbitTrigger(localClock, decoder.getTriggerWord());
-    eventType = EventType::Standard;
   }
 
   return goOn;

--- a/Detectors/MUON/MID/Raw/src/ELinkDataShaper.cxx
+++ b/Detectors/MUON/MID/Raw/src/ELinkDataShaper.cxx
@@ -23,7 +23,7 @@ namespace o2
 namespace mid
 {
 
-ELinkDataShaper::ELinkDataShaper(bool isDebugMode, bool isLoc, uint8_t uniqueId) : mUniqueId(uniqueId)
+ELinkDataShaper::ELinkDataShaper(bool isDebugMode, bool isLoc, uint8_t uniqueId, const ElectronicsDelay& electronicsDelay) : mUniqueId(uniqueId), mElectronicsDelay(electronicsDelay)
 {
   /// Ctr
   if (isDebugMode) {
@@ -38,6 +38,10 @@ ELinkDataShaper::ELinkDataShaper(bool isDebugMode, bool isLoc, uint8_t uniqueId)
     } else {
       mOnDone = &ELinkDataShaper::onDoneReg;
     }
+  }
+  if (!isLoc) {
+    mElectronicsDelay.BCToLocal += electronicsDelay.regToLocal;
+    mElectronicsDelay.calibToFET += electronicsDelay.regToLocal;
   }
 }
 
@@ -63,10 +67,29 @@ bool ELinkDataShaper::checkLoc(const ELinkDecoder& decoder)
   return (decoder.getId() == (mUniqueId & 0xF));
 }
 
-EventType ELinkDataShaper::processSelfTriggered(uint16_t localClock, uint16_t& correctedClock)
+EventType ELinkDataShaper::processSelfTriggered(uint16_t localClock, InteractionRecord& ir)
 {
   /// Processes the self-triggered event
-  correctedClock = localClock - mElectronicsDelay.BCToLocal;
+
+  // This is a self-triggered events.
+  // The physics data arrives with a delay compared to the BC,
+  // which is due to the travel time of muons up to the MID chambers
+  // plus the travel time of the signal to the readout electronics.
+  // In the case of regional cards, a further delay is expected
+  // since this card needs to wait for the tracklet decision of each local card.
+  // For simplicity, this delay is added to the BCToLocal in the constructor.
+  // In both cases, we need to correct for the delay in order to go back to the real BC.
+  if (ir.bc < mElectronicsDelay.BCToLocal) {
+    // If the bc is smaller than the delay, it means that the local clock was reset
+    // This events therefore belongs to the previous orbit.
+    // We therefore add the value of the last BC (+1 to account for the reset)
+    // and we decrease the orbit by 1.
+    ir.bc += mLastClock + 1;
+    --ir.orbit;
+  }
+  // We can now safely subtract the delay, which, thanks to the above protection,
+  // will not result in a negative number
+  ir.bc -= mElectronicsDelay.BCToLocal;
   if (mReceivedCalibration && (localClock == mExpectedFETClock)) {
     // Reset the calibration flag for this e-link
     mReceivedCalibration = false;
@@ -106,22 +129,30 @@ void ELinkDataShaper::processOrbitTrigger(uint16_t localClock, uint8_t triggerWo
   }
 }
 
-bool ELinkDataShaper::processTrigger(const ELinkDecoder& decoder, EventType& eventType, uint16_t& correctedClock)
+bool ELinkDataShaper::processTrigger(const ELinkDecoder& decoder, EventType& eventType, InteractionRecord& ir)
 {
   /// Processes the trigger information
   /// Returns true if the event should be further processed,
   /// returns false otherwise.
   auto localClock = decoder.getCounter();
 
+  // FIXME: So far the bc information is not used
+  // since it seems that it is always equal to 0
+  // (at least in the RDH of the first page, which is what we need).
+  // In this case the local clock and the BC coincide.
+  // If this is not the case, the bc of the orbit trigger should be correctly taken into account
+  ir.bc = localClock;
+  // ir.bc = mIR.bc + localClock;
+  ir.orbit = mIR.orbit;
+
   if (decoder.getTriggerWord() == 0) {
     // This is a self-triggered event
-    eventType = processSelfTriggered(localClock, correctedClock);
+    eventType = processSelfTriggered(localClock, ir);
     return true;
   }
 
   // From here we treat triggered events
   bool goOn = false;
-  correctedClock = localClock;
   eventType = EventType::Standard;
   if (decoder.getTriggerWord() & raw::sCALIBRATE) {
     // This is an answer to a calibration trigger
@@ -137,13 +168,12 @@ bool ELinkDataShaper::processTrigger(const ELinkDecoder& decoder, EventType& eve
   return goOn;
 }
 
-void ELinkDataShaper::addLoc(const ELinkDecoder& decoder, EventType eventType, uint16_t correctedClock, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)
+void ELinkDataShaper::addLoc(const ELinkDecoder& decoder, EventType eventType, InteractionRecord ir, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)
 {
   /// Adds the local board to the output data vector
   auto firstEntry = data.size();
   data.push_back({decoder.getStatusWord(), decoder.getTriggerWord(), mUniqueId, decoder.getInputs()});
-  InteractionRecord intRec(mIR.bc + correctedClock, mIR.orbit);
-  rofs.emplace_back(intRec, eventType, firstEntry, 1);
+  rofs.emplace_back(ir, eventType, firstEntry, 1);
   for (int ich = 0; ich < 4; ++ich) {
     if ((data.back().firedChambers & (1 << ich))) {
       data.back().patternsBP[ich] = decoder.getPattern(0, ich);
@@ -156,9 +186,9 @@ void ELinkDataShaper::onDoneLoc(const ELinkDecoder& decoder, std::vector<ROBoard
 {
   /// Performs action on decoded local board
   EventType eventType;
-  uint16_t correctedClock;
-  if (processTrigger(decoder, eventType, correctedClock) && checkLoc(decoder)) {
-    addLoc(decoder, eventType, correctedClock, data, rofs);
+  InteractionRecord ir;
+  if (processTrigger(decoder, eventType, ir) && checkLoc(decoder)) {
+    addLoc(decoder, eventType, ir, data, rofs);
   }
 }
 
@@ -166,45 +196,21 @@ void ELinkDataShaper::onDoneLocDebug(const ELinkDecoder& decoder, std::vector<RO
 {
   /// This always adds the local board to the output, without performing tests
   EventType eventType;
-  uint16_t correctedClock;
-  processTrigger(decoder, eventType, correctedClock);
-  addLoc(decoder, eventType, correctedClock, data, rofs);
-  if (decoder.getTriggerWord() & raw::sORB) {
-    // The local clock is increased when receiving an orbit trigger,
-    // but the local counter returned in answering the trigger
-    // belongs to the previous orbit
-    --rofs.back().interactionRecord.orbit;
-  }
+  InteractionRecord ir;
+  processTrigger(decoder, eventType, ir);
+  addLoc(decoder, eventType, ir, data, rofs);
 }
 
 void ELinkDataShaper::onDoneRegDebug(const ELinkDecoder& decoder, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)
 {
   /// Performs action on decoded regional board in debug mode.
   EventType eventType;
-  uint16_t correctedClock;
-  processTrigger(decoder, eventType, correctedClock);
+  InteractionRecord ir;
+  processTrigger(decoder, eventType, ir);
   // If we want to distinguish the two regional e-links, we can use the link ID instead
   auto firstEntry = data.size();
   data.push_back({decoder.getStatusWord(), decoder.getTriggerWord(), mUniqueId, decoder.getInputs()});
-
-  auto orbit = (decoder.getTriggerWord() & raw::sORB) ? mIR.orbit - 1 : mIR.orbit;
-
-  InteractionRecord intRec(mIR.bc + correctedClock, orbit);
-  if (decoder.getTriggerWord() == 0) {
-    if (intRec.bc < mElectronicsDelay.regToLocal) {
-      // In the tests, the HB does not really correspond to a change of orbit
-      // So we need to keep track of the last clock at which the HB was received
-      // and come back to that value
-      // FIXME: Remove this part as well as mLastClock when tests are no more needed
-      intRec -= (constants::lhc::LHCMaxBunches - mLastClock - 1);
-    }
-    // This is a self-triggered event.
-    // In this case the regional card needs to wait to receive the tracklet decision of each local
-    // which result in a delay that needs to be subtracted if we want to be able to synchronize
-    // local and regional cards for the checks
-    intRec -= mElectronicsDelay.regToLocal;
-  }
-  rofs.emplace_back(intRec, eventType, firstEntry, 1);
+  rofs.emplace_back(ir, eventType, firstEntry, 1);
 }
 
 } // namespace mid

--- a/Detectors/MUON/MID/Raw/src/ELinkManager.cxx
+++ b/Detectors/MUON/MID/Raw/src/ELinkManager.cxx
@@ -32,8 +32,7 @@ void ELinkManager::init(uint16_t feeId, bool isDebugMode, bool isBare, const Ele
     for (int ilink = 0; ilink < 10; ++ilink) {
       bool isLoc = ilink < 8;
       auto uniqueId = raw::makeUniqueLocID(crateId, ilink % 8 + offset);
-      ELinkDataShaper shaper(isDebugMode, isLoc, uniqueId);
-      shaper.setElectronicsDelay(electronicsDelay);
+      ELinkDataShaper shaper(isDebugMode, isLoc, uniqueId, electronicsDelay);
 #if defined(MID_RAW_VECTORS)
       mDataShapers.emplace_back(shaper);
 #else

--- a/Detectors/MUON/MID/Raw/src/GBTUserLogicEncoder.cxx
+++ b/Detectors/MUON/MID/Raw/src/GBTUserLogicEncoder.cxx
@@ -62,7 +62,7 @@ void GBTUserLogicEncoder::processTrigger(const InteractionRecord& ir, uint8_t tr
 void GBTUserLogicEncoder::addRegionalBoards(uint8_t activeBoards, InteractionRecord ir)
 {
   /// Adds the regional board information
-  ir += mElectronicsDelay.BCToLocal + mElectronicsDelay.regToLocal;
+  ir += mElectronicsDelay.regToLocal;
   auto& vec = mBoards[ir];
   for (uint8_t ireg = 0; ireg < 2; ++ireg) {
     uint8_t firedLoc = (activeBoards >> (4 * ireg)) & 0xF;
@@ -72,9 +72,10 @@ void GBTUserLogicEncoder::addRegionalBoards(uint8_t activeBoards, InteractionRec
   }
 }
 
-void GBTUserLogicEncoder::process(gsl::span<const ROBoard> data, const InteractionRecord& ir)
+void GBTUserLogicEncoder::process(gsl::span<const ROBoard> data, InteractionRecord ir)
 {
   /// Encode data
+  ir += mElectronicsDelay.BCToLocal;
   auto& vec = mBoards[ir];
   uint8_t activeBoards = 0;
   for (auto& loc : data) {


### PR DESCRIPTION
The MID decoder was not correctly accounting for the possible delay between the BC and the MID local clock.
This delay is currently set to 0, but it will need to be tuned on real data.
Also, the event type was not correctly assigned if the calibration trigger occurred in coincidence with an orbit trigger.
The commits are meant to be atomic. Please do not squash.