### PR TITLE
Default MID FEEId config reflects current CERN config

### DIFF
--- a/Detectors/MUON/MID/Raw/include/MIDRaw/FEEIdConfig.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/FEEIdConfig.h
@@ -58,6 +58,8 @@ class FEEIdConfig
 
  private:
   bool load(const char* filename);
+  void add(uint16_t gbtUniqueId, uint8_t linkId, uint8_t epId, uint16_t cruId, uint16_t feeId);
+  void add(uint16_t gbtUniqueId, uint8_t linkId, uint8_t epId, uint16_t cruId);
 
   std::unordered_map<uint32_t, uint16_t> mLinkUniqueIdToGBTUniqueId{};       /// Correspondence between link unique ID and GBT unique Id
   std::unordered_map<uint16_t, uint16_t> mGBTUniqueIdToFeeId{};              /// Correspondence between GBT unique ID and FEE ID


### PR DESCRIPTION
The default FEEId config was an ideal one, but did not reflected the configuration at CERN.
With this commit the default can be used at is to correctly decode data