### PR TITLE
TRD Tracklet Transformer CCDB interface

### DIFF
--- a/Detectors/TRD/base/include/TRDBase/TrackletTransformer.h
+++ b/Detectors/TRD/base/include/TRDBase/TrackletTransformer.h
@@ -15,6 +15,8 @@
 #include "TRDBase/Geometry.h"
 #include "DataFormatsTRD/Tracklet64.h"
 #include "DataFormatsTRD/CalibratedTracklet.h"
+#include "DataFormatsTRD/CalVdriftExB.h"
+#include "CCDB/BasicCCDBManager.h"
 
 namespace o2
 {
@@ -37,21 +39,26 @@ class TrackletTransformer
   void setXDrift(float x) { mXDrift = x; }
   void setXtb0(float x) { mXtb0 = x; }
 
+  bool hasCalibration() { return mCalibration != nullptr; }
+
   void loadPadPlane(int hcid);
+
+  // use 555555 for default calibration values
+  void loadCalibrationParameters(int timestamp);
 
   float calculateY(int hcid, int column, int position);
 
   float calculateZ(int padrow);
 
-  float calculateDy(int slope, double lorentzAngle, double driftVRatio);
+  float calculateDy(int hcid, int slope);
 
-  float calibrateX(double x, double t0Correction);
+  float calibrateX(double x);
 
   std::array<float, 3> transformL2T(int hcid, std::array<double, 3> spacePoint);
 
   CalibratedTracklet transformTracklet(Tracklet64 tracklet);
 
-  double getTimebin(double x);
+  double getTimebin(int detector, double x);
 
  private:
   o2::trd::Geometry* mGeo;
@@ -62,9 +69,8 @@ class TrackletTransformer
   float mXDrift;
   float mXtb0;
 
-  float mt0Correction;
-  float mLorentzAngle;
-  float mDriftVRatio;
+  o2::trd::CalVdriftExB* mCalibration;
+  std::vector<float>* mT0;
 };
 
 } // namespace trd

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrackletTransformerSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrackletTransformerSpec.h
@@ -23,18 +23,19 @@ namespace trd
 class TRDTrackletTransformerSpec : public o2::framework::Task
 {
  public:
-  TRDTrackletTransformerSpec(std::shared_ptr<o2::globaltracking::DataRequest> dataRequest, bool trigRecFilterActive) : mDataRequest(dataRequest), mTrigRecFilterActive(trigRecFilterActive){};
+  TRDTrackletTransformerSpec(std::shared_ptr<o2::globaltracking::DataRequest> dataRequest, bool trigRecFilterActive, int timestamp) : mDataRequest(dataRequest), mTrigRecFilterActive(trigRecFilterActive), mTimestamp(timestamp){};
   ~TRDTrackletTransformerSpec() override = default;
   void init(o2::framework::InitContext& ic) override;
   void run(o2::framework::ProcessingContext& pc) override;
 
  private:
-  TrackletTransformer mTransformer;
   bool mTrigRecFilterActive; ///< if true, transform only TRD tracklets for which ITS data is available
   std::shared_ptr<o2::globaltracking::DataRequest> mDataRequest;
+  int mTimestamp;
+  TrackletTransformer mTransformer;
 };
 
-o2::framework::DataProcessorSpec getTRDTrackletTransformerSpec(bool trigRecFilterActive);
+o2::framework::DataProcessorSpec getTRDTrackletTransformerSpec(bool trigRecFilterActive, int timestamp);
 
 } // end namespace trd
 } // end namespace o2

--- a/Detectors/TRD/workflow/src/TRDTrackletTransformerSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrackletTransformerSpec.cxx
@@ -29,11 +29,16 @@ namespace trd
 void TRDTrackletTransformerSpec::init(o2::framework::InitContext& ic)
 {
   LOG(INFO) << "Initializing tracklet transformer";
+  mTransformer.loadCalibrationParameters(mTimestamp);
 }
 
 void TRDTrackletTransformerSpec::run(o2::framework::ProcessingContext& pc)
 {
   LOG(INFO) << "Running tracklet transformer";
+  if (!mTransformer.hasCalibration()) {
+    // ccdb object was not found for specified timestamp
+    return;
+  }
 
   o2::globaltracking::RecoContainer inputData;
   inputData.collectData(pc, *mDataRequest);
@@ -111,7 +116,7 @@ void TRDTrackletTransformerSpec::run(o2::framework::ProcessingContext& pc)
   pc.outputs().snapshot(Output{"TRD", "TRIGRECMASK", 0, Lifetime::Timeframe}, trigRecBitfield);
 }
 
-o2::framework::DataProcessorSpec getTRDTrackletTransformerSpec(bool trigRecFilterActive)
+o2::framework::DataProcessorSpec getTRDTrackletTransformerSpec(bool trigRecFilterActive, int timestamp)
 {
   std::shared_ptr<DataRequest> dataRequest = std::make_shared<DataRequest>();
   if (trigRecFilterActive) {
@@ -129,7 +134,7 @@ o2::framework::DataProcessorSpec getTRDTrackletTransformerSpec(bool trigRecFilte
     "TRDTRACKLETTRANSFORMER",
     inputs,
     outputs,
-    AlgorithmSpec{adaptFromTask<TRDTrackletTransformerSpec>(dataRequest, trigRecFilterActive)},
+    AlgorithmSpec{adaptFromTask<TRDTrackletTransformerSpec>(dataRequest, trigRecFilterActive, timestamp)},
     Options{}};
 }
 

--- a/Detectors/TRD/workflow/src/TRDTrackletTransformerWorkflow.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrackletTransformerWorkflow.cxx
@@ -25,6 +25,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"disable-mc", o2::framework::VariantType::Bool, false, {"Disable MC labels"}},
     {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input reader"}},
     {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writer"}},
+    {"timestamp", o2::framework::VariantType::Int, 555555, {"timestamp for CCDB calibration objects"}},
     {"filter-trigrec", o2::framework::VariantType::Bool, false, {"ignore interaction records without ITS data"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
 
@@ -41,6 +42,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   // MC labels are passed through for the global tracking downstream
   // in case ROOT output is requested the tracklet labels are duplicated
   bool useMC = !configcontext.options().get<bool>("disable-mc");
+  int timestamp = configcontext.options().get<int>("timestamp");
 
   WorkflowSpec spec;
 
@@ -53,7 +55,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     o2::globaltracking::InputHelper::addInputSpecsIRFramesITS(configcontext, spec);
   }
 
-  spec.emplace_back(o2::trd::getTRDTrackletTransformerSpec(trigRecFilterActive));
+  spec.emplace_back(o2::trd::getTRDTrackletTransformerSpec(trigRecFilterActive, timestamp));
 
   if (!configcontext.options().get<bool>("disable-root-output")) {
     spec.emplace_back(o2::trd::getTRDCalibratedTrackletWriterSpec(useMC));


### PR DESCRIPTION
This commit includes a change that makes the `TrackletTransformer` fetch the `CalVdriftExB` object from CCDB and use these values for calibration.

One question: line 50, I set the timestamp of the CCDB manager. I assume this value needs to correspond with whatever the latest timestamp is. If I do not set the timestamp, then it does not find anything. I am not sure how to get that information to keep the timestamp up to date automatically? 