### PR TITLE
MID words and muon clusters removal

### DIFF
--- a/Detectors/Upgrades/ALICE3/AOD/include/UpgradesAODUtils/Run2LikeAO2D.h
+++ b/Detectors/Upgrades/ALICE3/AOD/include/UpgradesAODUtils/Run2LikeAO2D.h
@@ -35,7 +35,6 @@ enum TreeIndex {     // Index of the output trees
   kCalo,             //N/A
   kCaloTrigger,      //N/A
   kMuon,             //N/A
-  kMuonCls,          //N/A
   kZdc,              //N/A
   kFV0A,             //N/A
   kFV0C,             //N/A
@@ -57,10 +56,10 @@ enum MCParticleFlags : uint8_t {
   ProducedInTransport = 1 // Bit 0: 0 = from generator; 1 = from transport
 };
 
-const TString gTreeName[kTrees] = {"O2collision", "DbgEventExtra", "O2track", "O2calo", "O2calotrigger", "O2muon", "O2muoncluster", "O2zdc", "O2fv0a", "O2fv0c", "O2ft0", "O2fdd", "O2v0", "O2cascade", "O2tof", "O2mcparticle", "O2mccollision", "O2mctracklabel", "O2mccalolabel", "O2mccollisionlabel", "O2bc"};
-const TString gTreeTitle[kTrees] = {"Collision tree", "Collision extra", "Barrel tracks", "Calorimeter cells", "Calorimeter triggers", "MUON tracks", "MUON clusters", "ZDC", "FV0A", "FV0C", "FT0", "FDD", "V0s", "Cascades", "TOF hits", "Kinematics", "MC collisions", "MC track labels", "MC calo labels", "MC collision labels", "BC info"};
+const TString gTreeName[kTrees] = {"O2collision", "DbgEventExtra", "O2track", "O2calo", "O2calotrigger", "O2muon", "O2zdc", "O2fv0a", "O2fv0c", "O2ft0", "O2fdd", "O2v0", "O2cascade", "O2tof", "O2mcparticle", "O2mccollision", "O2mctracklabel", "O2mccalolabel", "O2mccollisionlabel", "O2bc"};
+const TString gTreeTitle[kTrees] = {"Collision tree", "Collision extra", "Barrel tracks", "Calorimeter cells", "Calorimeter triggers", "MUON tracks", "ZDC", "FV0A", "FV0C", "FT0", "FDD", "V0s", "Cascades", "TOF hits", "Kinematics", "MC collisions", "MC track labels", "MC calo labels", "MC collision labels", "BC info"};
 
-const Bool_t gSaveTree[kTrees] = {kTRUE, kFALSE, kTRUE, kFALSE, kFALSE, kFALSE, kFALSE, kTRUE, kTRUE, kTRUE, kTRUE, kTRUE,
+const Bool_t gSaveTree[kTrees] = {kTRUE, kFALSE, kTRUE, kFALSE, kFALSE, kFALSE, kTRUE, kTRUE, kTRUE, kTRUE, kTRUE,
                                   //V0 and cascade (not done for now)
                                   kFALSE, kFALSE,
                                   //TOF

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -372,6 +372,22 @@ DECLARE_SOA_DYNAMIC_COLUMN(Pz, pz, //!
                            [](float pt, float tgl) -> float {
                              return pt * tgl;
                            });
+DECLARE_SOA_DYNAMIC_COLUMN(MIDBoardCh1, midBoardCh1, //!
+                           [](uint32_t midBoards) -> int {
+                             return static_cast<int>(midBoards & 0xFF);
+                           });
+DECLARE_SOA_DYNAMIC_COLUMN(MIDBoardCh2, midBoardCh2, //!
+                           [](uint32_t midBoards) -> int {
+                             return static_cast<int>((midBoards >> 8) & 0xFF);
+                           });
+DECLARE_SOA_DYNAMIC_COLUMN(MIDBoardCh3, midBoardCh3, //!
+                           [](uint32_t midBoards) -> int {
+                             return static_cast<int>((midBoards >> 16) & 0xFF);
+                           });
+DECLARE_SOA_DYNAMIC_COLUMN(MIDBoardCh4, midBoardCh4, //!
+                           [](uint32_t midBoards) -> int {
+                             return static_cast<int>((midBoards >> 24) & 0xFF);
+                           });
 
 // FwdTracksCov columns definitions
 DECLARE_SOA_COLUMN(SigmaX, sigmaX, float);        //!

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -351,7 +351,7 @@ DECLARE_SOA_COLUMN(MatchMFTTrackID, matchMFTTrackID, int);     //! ID of matchin
 DECLARE_SOA_COLUMN(MatchMCHTrackID, matchMCHTrackID, int);     //! ID of matching MCH track for GlobalMuonTracks  (ints while self indexing not available)
 DECLARE_SOA_COLUMN(MCHBitMap, MchBitMap, uint16_t);            //! Fired muon trackig chambers bitmap
 DECLARE_SOA_COLUMN(MIDBitMap, midBitMap, uint8_t);             //! MID bitmap: non-bending plane (4bit), bending plane (4bit)
-DECLARE_SOA_COLUMN(MIDBoards, midBoards, uint32_t);            //! Local boards on each MID plane (8 bits plane)
+DECLARE_SOA_COLUMN(MIDBoards, midBoards, uint32_t);            //! Local boards on each MID plane (8 bits per plane)
 DECLARE_SOA_DYNAMIC_COLUMN(Sign, sign,                         //!
                            [](float signed1Pt) -> short { return (signed1Pt > 0) ? 1 : -1; });
 DECLARE_SOA_EXPRESSION_COLUMN(Eta, eta, float, //!
@@ -481,26 +481,6 @@ DECLARE_SOA_EXTENDED_TABLE(FwdTracksCov, StoredFwdTracksCov, "FWDTRACKCOV", //!
 
 using FwdTrack = FwdTracks::iterator;
 using FwdTrackCovFwd = FwdTracksCov::iterator;
-
-namespace muoncluster
-{
-DECLARE_SOA_INDEX_COLUMN(FwdTrack, fwdtrack); //! points to a fwdtrack in the fwdtrack table
-DECLARE_SOA_COLUMN(X, x, float);              //!
-DECLARE_SOA_COLUMN(Y, y, float);              //!
-DECLARE_SOA_COLUMN(Z, z, float);              //!
-DECLARE_SOA_COLUMN(ErrX, errX, float);        //!
-DECLARE_SOA_COLUMN(ErrY, errY, float);        //!
-DECLARE_SOA_COLUMN(Charge, charge, float);    //!
-DECLARE_SOA_COLUMN(Chi2, chi2, float);        //!
-} // namespace muoncluster
-
-DECLARE_SOA_TABLE(MuonClusters, "AOD", "MUONCLUSTER", //!
-                  muoncluster::FwdTrackId,
-                  muoncluster::X, muoncluster::Y, muoncluster::Z,
-                  muoncluster::ErrX, muoncluster::ErrY,
-                  muoncluster::Charge, muoncluster::Chi2);
-
-using MuonCluster = MuonClusters::iterator;
 
 } // namespace aod
 namespace soa

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -350,6 +350,8 @@ DECLARE_SOA_COLUMN(MatchScoreMCHMFT, matchScoreMCHMFT, float); //! MCH-MFT Machi
 DECLARE_SOA_COLUMN(MatchMFTTrackID, matchMFTTrackID, int);     //! ID of matching MFT track for GlobalMuonTrack (ints while self indexing not available)
 DECLARE_SOA_COLUMN(MatchMCHTrackID, matchMCHTrackID, int);     //! ID of matching MCH track for GlobalMuonTracks  (ints while self indexing not available)
 DECLARE_SOA_COLUMN(MCHBitMap, MchBitMap, uint16_t);            //! Fired muon trackig chambers bitmap
+DECLARE_SOA_COLUMN(MIDBitMap, midBitMap, uint8_t);             //! MID bitmap: non-bending plane (4bit), bending plane (4bit)
+DECLARE_SOA_COLUMN(MIDBoards, midBoards, uint32_t);            //! Local boards on each MID plane (8 bits plane)
 DECLARE_SOA_DYNAMIC_COLUMN(Sign, sign,                         //!
                            [](float signed1Pt) -> short { return (signed1Pt > 0) ? 1 : -1; });
 DECLARE_SOA_EXPRESSION_COLUMN(Eta, eta, float, //!
@@ -448,7 +450,7 @@ DECLARE_SOA_TABLE_FULL(StoredFwdTracks, "FwdTracks", "AOD", "FWDTRACK",
                        fwdtrack::Sign<fwdtrack::Signed1Pt>,
                        fwdtrack::Chi2, fwdtrack::Chi2MatchMCHMID, fwdtrack::Chi2MatchMCHMFT,
                        fwdtrack::MatchScoreMCHMFT, fwdtrack::MatchMFTTrackID, fwdtrack::MatchMCHTrackID,
-                       fwdtrack::MCHBitMap);
+                       fwdtrack::MCHBitMap, fwdtrack::MIDBitMap, fwdtrack::MIDBoards);
 
 DECLARE_SOA_EXTENDED_TABLE(FwdTracks, StoredFwdTracks, "FWDTRACK", //!
                            aod::fwdtrack::Eta,                     // NOTE the order is different here than in MFTTracks as table extension has to be unique


### PR DESCRIPTION
Bitmap for MID chambers added in fwd tracks table. Word containing MID local boards on each chamber also added.
Muon clusters removed from the datamodel.

PR on AliPhysics to produce compatible data: alisw/AliPhysics#18469