### PR TITLE
OrbitReset obj. will used vector instead of array

### DIFF
--- a/macro/CreateCTPOrbitResetObject.C
+++ b/macro/CreateCTPOrbitResetObject.C
@@ -5,7 +5,7 @@
 #endif
 
 // create and upload orbit reset object to CCDB
-constexpr long DummyTime = -1;
+constexpr Long64_t DummyTime = -1;
 
 void CreateCTPOrbitResetObject(const std::string& ccdbHost = "http://ccdb-test.cern.ch:8080", long t = DummyTime, long tmin = 0, long tmax = -1)
 {
@@ -13,7 +13,7 @@ void CreateCTPOrbitResetObject(const std::string& ccdbHost = "http://ccdb-test.c
   if (t == DummyTime) {
     t = std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::system_clock::now()).time_since_epoch().count();
   }
-  std::array<long, 1> rt{t};
+  std::vector<Long64_t> rt{t};
   const std::string objName{"CTP/OrbitReset"};
   o2::ccdb::CcdbApi api;
   api.init(ccdbHost.c_str());   // or http://localhost:8080 for a local installation


### PR DESCRIPTION
To avoid root files portability problem.

@lietava We discovered that the std::array written to root file on Linux is not readable on Mac. Should be root bug to be fixed, but at the moment I've changed the format from `array<long>` to `vector<Long64_t>.

Trivial fix tested locally, merging.