### PR TITLE
Fix ITS chip mapping: swap module high/low cables

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RUInfo.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RUInfo.h
@@ -17,6 +17,7 @@
 
 #include <Rtypes.h>
 #include <cstdint>
+#include <string>
 
 namespace o2
 {
@@ -48,6 +49,7 @@ struct ChipOnRUInfo {
   std::uint8_t cableHWPos = DUMMY8;     // position of the bit of this cable in the activeLanes
   std::uint8_t chipOnCable = DUMMY8;    // chip within the cable (0 = master)
 
+  std::string asString() const;
   void print() const;
 };
 
@@ -61,6 +63,7 @@ struct ChipInfo {
   std::uint16_t ru = DUMMY16;     // RU sequential id
   std::uint16_t ruType = DUMMY16; // RU (or subBarrel) type
 
+  std::string asString() const;
   void print() const;
 };
 } // namespace itsmft

--- a/Detectors/ITSMFT/common/reconstruction/src/RUInfo.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/RUInfo.cxx
@@ -13,24 +13,27 @@
 // \brief Transient structures for ITS and MFT HW -> SW mapping
 
 #include "ITSMFTReconstruction/RUInfo.h"
-#include <bitset>
+#include "Framework/Logger.h"
 
 using namespace o2::itsmft;
 
+std::string ChipOnRUInfo::asString() const
+{
+  return fmt::format("ChonRu:{:3d} ModSW:{:2d} ChOnModSW:{:2d} CabSW:{:3d}| ChOnCab:{:1d} | CabHW:{:2d} | CabPos:{:2d} | ModHW:{:2d} | ChOnModHW:{:2d}",
+                     int(id), int(moduleSW), int(chipOnModuleSW), int(cableSW), int(chipOnCable), int(cableHW), int(cableHWPos), int(moduleHW), int(chipOnModuleHW));
+}
+
 void ChipOnRUInfo::print() const
 {
-  std::bitset<8> chw(cableHW), mhw(moduleHW);
-  printf("ChonRu:%3d ModSW:%2d ChOnModSW:%2d CabSW:%3d| ChOnCab:%d | CabHW: %8s (%2d) | ModHW: %8s | ChOnModHW: %2d\n",
-         id, moduleSW, chipOnModuleSW, cableSW, chipOnCable, chw.to_string().c_str(), cableHWPos,
-         mhw.to_string().c_str(), chipOnModuleHW);
+  LOG(INFO) << asString();
+}
+
+std::string ChipInfo::asString() const
+{
+  return fmt::format("CH{:5d} RUTyp:{:d} RU:{:3d} | {}", int(id), int(ruType), int(ru), chOnRU ? chOnRU->asString() : std::string{});
 }
 
 void ChipInfo::print() const
 {
-  printf("CH%5d RUTyp:%d RU:%3d | ", id, ruType, ru);
-  if (chOnRU) {
-    chOnRU->print();
-  } else {
-    printf("\n");
-  }
+  LOGP(INFO, asString());
 }


### PR DESCRIPTION
@davidrohr @mpuccio this will make already emulated ITS raw data tracking inefficient (will be ok if regenerated from existing digits): I had to swap some pairs of cables to match the decoder/encoder mapping to real detector.