### PR TITLE
parsing fixes, used for kr run

### DIFF
--- a/DataFormats/Detectors/TRD/CMakeLists.txt
+++ b/DataFormats/Detectors/TRD/CMakeLists.txt
@@ -15,6 +15,7 @@ o2_add_library(DataFormatsTRD
                        src/AngularResidHistos.cxx
                        src/Tracklet64.cxx
                        src/RawData.cxx
+                       src/RawDataStats.cxx
                        src/CompressedDigit.cxx
                        src/CTF.cxx
                        src/Digit.cxx

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
@@ -74,6 +74,8 @@ constexpr int MAXDATAPERLINK32 = 13824;       // max number of 32 bit words per 
 constexpr int MAXDATAPERLINK256 = 1728;       // max number of linkwords per cru link. (256bit words)
 constexpr int MAXEVENTCOUNTERSEPERATION = 200; // how far appart can subsequent mcmheader event counters be before we flag for concern, used as a sanity check in rawreader.
 constexpr int MAXMCMCOUNT = 69120;             // at most mcm count maxchamber x nrobc1 nmcmrob
+constexpr int MAXLINKERRORHISTOGRAMS = 10;     // size of the array holding the link error plots from the raw reader
+constexpr int MAXPARSEERRORHISTOGRAMS = 60;    // size of the array holding the parsing error plots from the raw reader
 } //namespace constants
 } // namespace trd
 } // namespace o2

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawDataStats.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawDataStats.h
@@ -45,9 +45,9 @@ enum ParsingErrors { TRDParsingNoError,
                      TRDParsingDigitSanityCheck,                        // adc failed sanity check see RawData.cxx for faiulre reasons
                      TRDParsingDigitExcessTimeBins,                     // ADC has more than 30 timebins (10 adc words)
                      TRDParsingDigitParsingExitInWrongState,            // exiting parsing in the wrong state ... got to the end of the buffer in wrong state.
-                     TRDParsingDigitStackMisMatch,                      // mismatch between rdh and hcheader stack calculation/value
-                     TRDParsingDigitLayerMisMatch,                      // mismatch between rdh and hcheader stack calculation/value
-                     TRDParsingDigitSectorMisMatch,                     // mismatch between rdh and hcheader stack calculation/value
+                     TRDParsingDigitStackMismatch,                      // mismatch between rdh and hcheader stack calculation/value
+                     TRDParsingDigitLayerMismatch,                      // mismatch between rdh and hcheader stack calculation/value
+                     TRDParsingDigitSectorMismatch,                     // mismatch between rdh and hcheader stack calculation/value
                      TRDParsingTrackletCRUPaddingWhileParsingTracklets, // reading a padding word while expecting tracklet data
                      TRDParsingTrackletBit11NotSetInTrackletHCHeader,   // bit 11 not set in hc header for tracklets.
                      TRDParsingTrackletHCHeaderSanityCheckFailure,      // HCHeader sanity check failure, see RawData.cxx for reasons.
@@ -59,8 +59,17 @@ enum ParsingErrors { TRDParsingNoError,
                      TRDParsingTrackletPadRowIncreaseError,                    // subsequent padrow can not be less than previous one.
                      TRDParsingTrackletColIncreaseError,                       // subsequent col can not be less than previous one
                      TRDParsingTrackletNoTrackletEndMarker,                    // got to the end of the buffer with out finding a tracklet end marker.
-                     TRDParsingTrackletExitingNoTrackletEndMarker              // got to the end of the buffer exiting tracklet parsing with no tracklet end marker
+                     TRDParsingTrackletExitingNoTrackletEndMarker,             // got to the end of the buffer exiting tracklet parsing with no tracklet end marker
+                     TRDParsingDigitHeaderCountGT3,                            // digital half chamber header had more than 3 additional words expected by header. most likely corruption above somewhere.
+                     TRDParsingDigitHeaderWrong1,                              // expected header word1 but wrong ending marker
+                     TRDParsingDigitHeaderWrong2,                              // expected header word2 but wrong ending marker
+                     TRDParsingDigitHeaderWrong3,                              // expected header word3 but wrong ending marker
+                     TRDParsingDigitHeaderWrong4,                              // expected header word but have no idea what we are looking at default of switch statement
+                     TRDParsingDigitDataStillOnLink,                           // got to the end of digit parsing and there is still data on link, normally not advancing far enough when dumping data.
+                     TRDParsingTrackletIgnoringDataTillEndMarker               // for some reason we are bouncing to the end word by word, this counts those words
 };
+
+extern std::vector<std::string> ParsingErrorsString;
 
 //enumerations for the options, saves on having a long parameter list.
 enum OptionBits {

--- a/DataFormats/Detectors/TRD/src/RawDataStats.cxx
+++ b/DataFormats/Detectors/TRD/src/RawDataStats.cxx
@@ -1,0 +1,56 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+// Cru raw data reader, this is the part that parses the raw data
+// it runs on the flp(pre compression) or on the epn(pre tracklet64 array generation)
+// it hands off blocks of cru pay load to the parsers.
+
+#include <string>
+#include <vector>
+#include "DataFormatsTRD/RawDataStats.h"
+
+// Diagnostics data to pass around.
+// Primarily to QC and debug graphs built into the readers.
+// This file is primarily for the  strings that appear at titles in the graphs.
+
+std::vector<std::string> ParsingErrorsString{"TRDParsingNoError",
+                                             "TRDParsingUnrecognisedVersion",
+                                             "TRDParsingBadDigt",
+                                             "TRDParsingBadTracklet",
+                                             "TRDParsingDigitEndMarkerWrongState",
+                                             "TRDParsingDigitMCMHeaderSanityCheckFailure",
+                                             "TRDParsingDigitROBDecreasing",
+                                             "TRDParsingDigitMCMNotIncreasing",
+                                             "TRDParsingDigitADCMaskMismatch",
+                                             "TRDParsingDigitADCMaskAdvanceToEnd",
+                                             "TRDParsingDigitMCMHeaderBypassButStateMCMHeader",
+                                             "TRDParsingDigitEndMarkerStateButReadingMCMADCData",
+                                             "TRDParsingDigitADCChannel21",
+                                             "TRDParsingDigitADCChannelGT22",
+                                             "TRDParsingDigitGT10ADCs",
+                                             "TRDParsingDigitSanityCheck",
+                                             "TRDParsingDigitExcessTimeBins",
+                                             "TRDParsingDigitParsingExitInWrongState",
+                                             "TRDParsingDigitStackMisMatch",
+                                             "TRDParsingDigitLayerMisMatch",
+                                             "TRDParsingDigitSectorMisMatch",
+                                             "TRDParsingTrackletCRUPaddingWhileParsingTracklets",
+                                             "TRDParsingTrackletBit11NotSetInTrackletHCHeader",
+                                             "TRDParsingTrackletHCHeaderSanityCheckFailure",
+                                             "TRDParsingTrackletMCMHeaderSanityCheckFailure",
+                                             "TRDParsingTrackletMCMHeaderButParsingMCMData",
+                                             "TRDParsingTrackletStateMCMHeaderButParsingMCMData",
+                                             "TRDParsingTrackletTrackletCountGTThatDeclaredInMCMHeader",
+                                             "TRDParsingTrackletInvalidTrackletCount",
+                                             "TRDParsingTrackletPadRowIncreaseError",
+                                             "TRDParsingTrackletColIncreaseError",
+                                             "TRDParsingTrackletNoTrackletEndMarker",
+                                             "TRDParsingTrackletExitingNoTrackletEndMarker"};

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CompressedRawReader.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CompressedRawReader.h
@@ -70,9 +70,9 @@ class CompressedRawReader
 
   inline uint32_t getDecoderByteCounter() const { return reinterpret_cast<const char*>(mDataPointer) - mDataBuffer; };
 
-  void setVerbosity(bool v) { mVerbose = v; };
-  void setDataVerbosity(bool v) { mDataVerbose = v; };
-  void setHeaderVerbosity(bool v) { mHeaderVerbose = v; };
+  void setVerbose(bool v) { mVerbose = v; };
+  void setDataVerbose(bool v) { mDataVerbose = v; };
+  void setHeaderVerbose(bool v) { mHeaderVerbose = v; };
   void configure(std::bitset<16> options)
   {
     mByteSwap = options[TRDByteSwapBit];

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
@@ -61,7 +61,7 @@ class CruRawReader
 
   void checkSummary();
   void resetCounters();
-  void configure(int tracklethcheader, std::bitset<16> options)
+  void configure(int tracklethcheader, int halfchamberwords, int halfchambermajor, std::bitset<16> options)
   {
     mByteSwap = options[TRDByteSwapBit];
     mVerbose = options[TRDVerboseBit];
@@ -69,6 +69,8 @@ class CruRawReader
     mDataVerbose = options[TRDDataVerboseBit];
     mFixDigitEndCorruption = options[TRDFixDigitCorruptionBit];
     mTrackletHCHeaderState = tracklethcheader;
+    mHalfChamberWords = halfchamberwords;
+    mHalfChamberMajor = halfchambermajor;
     mRootOutput = options[TRDEnableRootOutputBit];
     mEnableTimeInfo = options[TRDEnableTimeInfoBit];
     mEnableStats = options[TRDEnableStatsBit];
@@ -121,23 +123,13 @@ class CruRawReader
   }
   void OutputHalfCruRawData();
   // void setStats(o2::trd::TRDDataCountersPerTimeFrame* trdstats){mTimeFrameStats=trdstats;}
-  void setHistos(TH2F* h1, TH2F* h2, TH2F* h3)
+  //void setHistos(std::array<TH2F*, 10> hist, std::array<TH2F*, constants::MAXPARSEERRORHISTOGRAMS> parsingerrors2d)
+  void setHistos(TList* hist, TList* parsingerrors2d)
   {
-    hist1 = h1;
-    hist2 = h2;
-    hist3 = h3;
-  }; // a hack!
-  void setHistos1(TH2F* h1, TH2F* h2, TH2F* h3)
-  {
-    hist4 = h1;
-    hist5 = h2;
-    hist6 = h3;
-  }; // a hack!
-  void setHistos2(TH2F* h1, TH2F* h2)
-  {
-    hist7 = h1;
-    hist8 = h2;
-  }; // a hack!
+    mLinkErrors = hist;
+    mParsingErrors2d = parsingerrors2d;
+  };
+
   void setTimeHistos(TH1F* timeframetime, TH1F* trackletparsingtime, TH1F* digitparsingtime,
                      TH1F* crutime, TH1F* packagingtime, TH1F* versions, TH1F* versionsmajor,
                      TH1F* parsingerrors)
@@ -150,7 +142,7 @@ class CruRawReader
     mDataVersions = versions;
     mDataVersionsMajor = versionsmajor;
     mParsingErrors = parsingerrors;
-    mTrackletsParser.setErrorHistos(parsingerrors);
+    mTrackletsParser.setErrorHistos(parsingerrors, mParsingErrors2d);
   };
 
  protected:
@@ -179,6 +171,8 @@ class CruRawReader
   bool mByteSwap{false};
   bool mFixDigitEndCorruption{false};
   int mTrackletHCHeaderState{0};
+  int mHalfChamberWords{0};
+  int mHalfChamberMajor{0};
   bool mRootOutput{0};
   bool mEnableTimeInfo{0};
   bool mEnableStats{0};
@@ -275,13 +269,14 @@ class CruRawReader
 
   bool mReturnBlob{0};        // whether to return blobs or vectors;
   o2::trd::TRDDataCountersRunning mStatCountersRunning;
-
-  TH2F *hist1, *hist2, *hist3;                                      // a hack !
-  TH2F *hist4, *hist5, *hist6;                                      // a hack !
+  TList* mLinkErrors;
+  //std::array<TH2F*, constants::MAXLINKERRORHISTOGRAMS> mLinkErrors;
   TH2F *hist7, *hist8;                                              // a hack !
   TH1F *mTimeFrameTime, *mTrackletTiming, *mDigitTiming, *mCruTime; // a hack !
   TH1F *mDataVersions, *mDataVersionsMajor;                         // a hack !
   TH1F* mParsingErrors;                                             // a hack !
+  TList* mParsingErrors2d;
+  //std::array<TH2F*, constants::MAXPARSEERRORHISTOGRAMS> mParsingErrors2d;
 };
 
 } // namespace o2::trd

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/DataReaderTask.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/DataReaderTask.h
@@ -38,7 +38,7 @@ namespace o2::trd
 class DataReaderTask : public Task
 {
  public:
-  DataReaderTask(int tracklethcheader, std::bitset<16> option) : mCompressedData(option[TRDCompressedDataBit]), mByteSwap(option[TRDByteSwapBit]), mFixDigitEndCorruption(option[TRDFixDigitCorruptionBit]), mTrackletHCHeaderState(tracklethcheader), mVerbose(option[TRDVerboseBit]), mHeaderVerbose(option[TRDHeaderVerboseBit]), mDataVerbose(option[TRDDataVerboseBit]), mEnableTimeInfo(option[TRDEnableTimeInfoBit]), mEnableStats(option[TRDEnableStatsBit]), mRootOutput(option[TRDEnableRootOutputBit]), mIgnoreTrackletHCHeader(option[TRDIgnoreTrackletHCHeaderBit]), mIgnoreDigitHCHeader(option[TRDIgnoreDigitHCHeaderBit]), mOptions(option) {}
+  DataReaderTask(int tracklethcheader, int halfchamberwords, int halfchambermajor, std::string histofilename, std::bitset<16> option) : mCompressedData(option[TRDCompressedDataBit]), mByteSwap(option[TRDByteSwapBit]), mFixDigitEndCorruption(option[TRDFixDigitCorruptionBit]), mTrackletHCHeaderState(tracklethcheader), mHalfChamberWords(halfchamberwords), mHalfChamberMajor(halfchambermajor), mHistogramsFilename(histofilename), mVerbose(option[TRDVerboseBit]), mHeaderVerbose(option[TRDHeaderVerboseBit]), mDataVerbose(option[TRDDataVerboseBit]), mEnableTimeInfo(option[TRDEnableTimeInfoBit]), mEnableStats(option[TRDEnableStatsBit]), mRootOutput(option[TRDEnableRootOutputBit]), mIgnoreTrackletHCHeader(option[TRDIgnoreTrackletHCHeaderBit]), mIgnoreDigitHCHeader(option[TRDIgnoreDigitHCHeaderBit]), mOptions(option) {}
   ~DataReaderTask() override = default;
   void init(InitContext& ic) final;
   void sendData(ProcessingContext& pc, bool blankframe = false);
@@ -47,6 +47,7 @@ class DataReaderTask : public Task
   void endOfStream(o2::framework::EndOfStreamContext& ec) override;
 
   void setParsingErrorLabels();
+  void buildHistograms();
 
  private:
   CruRawReader mReader;                  // this will do the parsing, of raw data passed directly through the flp(no compression)
@@ -72,7 +73,9 @@ class DataReaderTask : public Task
   uint64_t mWordsRead = 0;
   uint64_t mWordsRejected = 0;
   int mTrackletHCHeaderState{0}; // what to do about tracklethcheader, 0 never there, 2 always there, 1 there iff tracklet data, i.e. only there if next word is *not* endmarker 10001000.
-
+  int mHalfChamberWords{0};      // if the halfchamber header is effectively blanked major.minor = 0.0 and halfchamberwords=0 then this value is used as the number of additional words to try recover the data
+  int mHalfChamberMajor{0};      // if the halfchamber header is effectively blanked major.minor = 0.0 and halfchamberwords=0 then this value is used as the major version to try recover the data
+  std::string mHistogramsFilename; // filename to use for histograms.
   std::string mDataDesc;
   o2::header::DataDescription mUserDataDescription = o2::header::gDataDescriptionInvalid; // alternative user-provided description to pick
   bool mFixDigitEndCorruption{false};                                                     // fix the parsing of corrupt end of digit data. bounce over it.
@@ -87,6 +90,10 @@ class DataReaderTask : public Task
   TH2F* LinkError5;
   TH2F* LinkError6;
   TH2F* LinkError7;
+  //std::array<TH2F*, constants::MAXLINKERRORHISTOGRAMS> mLinkErrors;
+  //std::array<TH2F*, constants::MAXPARSEERRORHISTOGRAMS> mParseErrors;
+  TList* mLinkErrors;
+  TList* mParseErrors;
   TH1F* mTimeFrameTime;
   TH1F* mTrackletParsingTime;
   TH1F* mDigitParsingTime;

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/DigitsParser.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/DigitsParser.h
@@ -25,6 +25,9 @@
 #include <fstream>
 #include <bitset>
 #include "TH1F.h"
+#include "TH2F.h"
+#include "TList.h"
+
 //using namespace o2::framework;
 
 namespace o2::trd
@@ -69,8 +72,17 @@ class DigitsParser
   uint64_t getDumpedDataCount() { return mWordsDumped; }
   uint64_t getDataWordsParsed() { return mDataWordsParsed; }
   void tryFindMCMHeaderAndDisplay(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator mStartParse);
+  //void tryFindMCMHeaderAndDisplay(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator mStartParse);
   void OutputIncomingData();
-  void setParsingHisto(TH1F* parsingerrors) { mParsingErrors = parsingerrors; }
+  void setParsingHisto(TH1F* parsingerrors, TList* parsingerrors2d)
+  {
+    mParsingErrors = parsingerrors;
+    mParsingErrors2d = parsingerrors2d;
+  }
+  void increment2dHist(int hist)
+  {
+    ((TH2F*)mParsingErrors2d->At(hist))->Fill(mFEEID.supermodule * 2 + mFEEID.side, mStack * constants::NLAYER + mLayer);
+  }
 
  private:
   int mState;
@@ -121,6 +133,7 @@ class DigitsParser
   std::array<uint16_t, constants::TIMEBINS> mADCValues{};
   std::array<uint16_t, constants::MAXMCMCOUNT> mMCMstats; // bit pattern for errors current event for a given mcm;
   TH1F* mParsingErrors;
+  TList* mParsingErrors2d;
 };
 
 } // namespace o2::trd

--- a/Detectors/TRD/reconstruction/src/DataReader.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReader.cxx
@@ -43,8 +43,11 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"enable-stats", VariantType::Bool, false, {"enable the reader stats"}},
     {"enable-root-output", VariantType::Bool, false, {"Write the data to file"}},
     {"ignore-tracklethcheader", VariantType::Bool, false, {"Ignore the tracklethalf chamber header for cross referencing"}},
+    {"halfchamberwords", VariantType::Int, 0, {"Fix half chamber for when it is version is 0.0 integer value of additional header words, ignored if version is not 0.0"}},
+    {"halfchambermajor", VariantType::Int, 0, {"Fix half chamber for when it is version is 0.0 integer value of major version, ignored if version is not 0.0"}},
     {"ignore-digithcheader", VariantType::Bool, false, {"Ignore the digithalf chamber header for cross referencing, take rdh/cru as authorative."}},
     {"tracklethcheader", VariantType::Int, 0, {"Status of TrackletHalfChamberHeader 0 off always, 1 iff tracklet data, 2 on always"}},
+    {"histogramsfile", VariantType::String, "histos.root", {"Name of the histogram file, so one can run multiple per node"}},
     {"trd-datareader-enablebyteswapdata", VariantType::Bool, false, {"byteswap the incoming data, raw data needs it and simulation does not."}}};
 
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
@@ -72,6 +75,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   auto tracklethcheader = cfgc.options().get<int>("tracklethcheader");
   auto enabletimeinfo = cfgc.options().get<bool>("enable-timing");
   auto enablestats = cfgc.options().get<bool>("enable-stats");
+  auto halfchamberwords = cfgc.options().get<int>("halfchamberwords");
+  auto halfchambermajor = cfgc.options().get<int>("halfchambermajor");
 
   std::vector<OutputSpec> outputs;
   outputs.emplace_back("TRD", "TRACKLETS", 0, Lifetime::Timeframe);
@@ -93,7 +98,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   binaryoptions[o2::trd::TRDByteSwapBit] = cfgc.options().get<bool>("trd-datareader-enablebyteswapdata");
 
   AlgorithmSpec algoSpec;
-  algoSpec = AlgorithmSpec{adaptFromTask<o2::trd::DataReaderTask>(tracklethcheader, binaryoptions)};
+  algoSpec = AlgorithmSpec{adaptFromTask<o2::trd::DataReaderTask>(tracklethcheader, halfchamberwords, halfchambermajor, cfgc.options().get<std::string>("histogramsfile"), binaryoptions)};
 
   WorkflowSpec workflow;
 

--- a/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
+++ b/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
@@ -108,6 +108,7 @@ int TrackletsParser::Parse()
   //we are handed the buffer payload of an rdh and need to parse its contents.
   //producing a vector of digits.
 
+  mTrackletParsingBad = false;
   if (mHeaderVerbose) {
     OutputIncomingData();
   }
@@ -180,10 +181,11 @@ int TrackletsParser::Parse()
     if (*word == o2::trd::constants::CRUPADDING32) {
       //padding word first as it clashes with the hcheader.
       mState = StatePadding;
-      LOG(warn) << "CRU Padding word while parsing tracklets. Corrupt data dumping the rest of this link";
+      //LOG(warn) << "CRU Padding word while parsing tracklets. Corrupt data dumping the rest of this link";
       //mEventRecord.ErrorStats[TRDParsingTrackletCRUPaddingWhileParsingTracklets]++;
       if (mOptions[TRDEnableRootOutputBit]) {
         mParsingErrors->Fill(TRDParsingTrackletCRUPaddingWhileParsingTracklets);
+        increment2dHist(TRDParsingTrackletCRUPaddingWhileParsingTracklets);
       }
       //TOOD replace warning with stats increment
       mWordsDumped = std::distance(word, mEndParse);
@@ -199,17 +201,22 @@ int TrackletsParser::Parse()
         mWordsDumped++;
         //LOG(info) << "ignoring till end marker ..... word read:0x"<<std::hex << *word << " at offset 0x"<< std::distance(mStartParse,word);
         //TODO increment counter instead of above log message
+        if (mOptions[TRDEnableRootOutputBit]) {
+          mParsingErrors->Fill(TRDParsingTrackletBit11NotSetInTrackletHCHeader);
+          increment2dHist(TRDParsingTrackletBit11NotSetInTrackletHCHeader);
+        }
         continue; //go back to the start of loop, walk the data till the above code of the tracklet end marker is hit, padding is hit or we get to the end of the data.
         //TODO might be good to check for end of digit marker as well?
       }
       //now for Tracklet hc header
       if ((((*word) & (0x1 << 11)) != 0) && !mIgnoreTrackletHCHeader && mState == StateTrackletHCHeader) { //TrackletHCHeader has bit 11 set to 1 always. Check for state because raw data can have bit 11 set!
         if (mState != StateTrackletHCHeader) {
-          LOG(warn) << "Something wrong with TrackletHCHeader bit 11 is set but state is not " << StateTrackletMCMHeader << " its :" << mState;
+          //   LOG(warn) << "Something wrong with TrackletHCHeader bit 11 is set but state is not " << StateTrackletMCMHeader << " its :" << mState;
           //TODO count remove warning
           //mEventRecord.ErrorStats[TRDParsingTrackletBit11NotSetInTrackletHCHeader]++;
           if (mOptions[TRDEnableRootOutputBit]) {
             mParsingErrors->Fill(TRDParsingTrackletBit11NotSetInTrackletHCHeader);
+            increment2dHist(TRDParsingTrackletBit11NotSetInTrackletHCHeader);
           }
         }
         //read the header
@@ -220,11 +227,12 @@ int TrackletsParser::Parse()
         mTrackletHCHeader = (TrackletHCHeader*)&word;
         //sanity check of trackletheader ??
         if (!trackletHCHeaderSanityCheck(*mTrackletHCHeader)) {
-          LOG(warn) << "Sanity check Failure HCHeader : " << std::hex << *word << " at offset :0x" << std::distance(mStartParse, word);
+          //  LOG(warn) << "Sanity check Failure HCHeader : " << std::hex << *word << " at offset :0x" << std::distance(mStartParse, word);
           //TODO count remove warning
           //mEventRecord.ErrorStats[TRDParsingTrackletHCHeaderSanityCheckFailure]++;
           if (mOptions[TRDEnableRootOutputBit]) {
             mParsingErrors->Fill(TRDParsingTrackletHCHeaderSanityCheckFailure);
+            increment2dHist(TRDParsingTrackletHCHeaderSanityCheckFailure);
           }
         }
         mWordsRead++;
@@ -240,10 +248,11 @@ int TrackletsParser::Parse()
             printTrackletMCMHeader(a);
           }
           if (!trackletMCMHeaderSanityCheck(*mTrackletMCMHeader)) {
-            LOG(warn) << "***TrackletMCMHeader SanityCheckFailure: 0x" << std::hex << *word << " at offset: 0x" << std::distance(mStartParse, word);
+            //   LOG(warn) << "***TrackletMCMHeader SanityCheckFailure: 0x" << std::hex << *word << " at offset: 0x" << std::distance(mStartParse, word);
             //mEventRecord.ErrorStats[TRDParsingTrackletMCMHeaderSanityCheckFailure]++;
             if (mOptions[TRDEnableRootOutputBit]) {
               mParsingErrors->Fill(TRDParsingTrackletMCMHeaderSanityCheckFailure);
+              increment2dHist(TRDParsingTrackletMCMHeaderSanityCheckFailure);
             }
           }
           headertrackletcount = getNumberofTracklets(*mTrackletMCMHeader);
@@ -256,14 +265,18 @@ int TrackletsParser::Parse()
           mcmtrackletcount = 0;
           mWordsRead++;
         } else {
-          if (mState == StateTrackletMCMHeader) {
+          if (mState == StateTrackletMCMHeader || (mState == StateTrackletHCHeader && !mOptions[mIgnoreTrackletHCHeader])) {
             // if we are here something is wrong, dump the data. The else of line 227 should imply we are in StateTrackletMCMData;
             ignoreDataTillTrackletEndMarker = true;
             //mEventRecord.ErrorStats[
             if (mOptions[TRDEnableRootOutputBit]) {
               mParsingErrors->Fill(TRDParsingTrackletStateMCMHeaderButParsingMCMData);
+              increment2dHist(TRDParsingTrackletStateMCMHeaderButParsingMCMData);
             }
-            mWordsRead++;
+            //mWordsRead++;
+            mWordsDumped = std::distance(word, mEndParse);
+            ignoreDataTillTrackletEndMarker = true;
+            word = mEndParse;
             continue;
           }
           mState = StateTrackletMCMData;
@@ -283,6 +296,7 @@ int TrackletsParser::Parse()
             //mEventRecord.ErrorStats[TRDParsingTrackletTrackletCountGTThatDeclaredInMCMHeader]++;
             if (mOptions[TRDEnableRootOutputBit]) {
               mParsingErrors->Fill(TRDParsingTrackletTrackletCountGTThatDeclaredInMCMHeader);
+              increment2dHist(TRDParsingTrackletTrackletCountGTThatDeclaredInMCMHeader);
             }
             mEventRecord->popTracklets(mcmtrackletcount); // our format is always 4
             //TODO count remove warning
@@ -305,6 +319,7 @@ int TrackletsParser::Parse()
               //mEventRecord.ErrorStats[TRDParsingTrackletInvalidTrackletCount]++;
               if (mOptions[TRDEnableRootOutputBit]) {
                 mParsingErrors->Fill(TRDParsingTrackletInvalidTrackletCount);
+                increment2dHist(TRDParsingTrackletInvalidTrackletCount);
               }
               //this should have been caught above by the headertrackletcount to mcmtrackletcount
               ignoreDataTillTrackletEndMarker = true;
@@ -327,7 +342,6 @@ int TrackletsParser::Parse()
               }
             }
             //TODO cross reference hcid to somewhere for a check. mDetector is assigned at the time of parser init.
-            //
             //mEventRecord.TrackletCounts[mcm][mcmtrackletcount]++;
             mEventRecord->getTracklets().emplace_back(4, hcid, padrow, col, pos, slope, q0, q1, q2); // our format is always 4
             if (mDataVerbose) {
@@ -357,12 +371,14 @@ int TrackletsParser::Parse()
     trackletloopcount++;
   } //end of for loop
   //sanity check
-  LOG(warn) << " end of Trackelt parsing but we are exiting with out a tracklet end marker with " << mWordsRead << " 32bit words read";
+  //LOG(warn) << " end of Trackelt parsing but we are exiting with out a tracklet end marker with " << mWordsRead << " 32bit words read";
   //mEventRecord.ErrorStats[TRDParsingTrackletExitingNoTrackletEndMarker]++;
   if (mOptions[TRDEnableRootOutputBit]) {
     mParsingErrors->Fill(TRDParsingTrackletExitingNoTrackletEndMarker);
+    increment2dHist(TRDParsingTrackletExitingNoTrackletEndMarker);
   }
   mTrackletparsetime += std::chrono::high_resolution_clock::now() - parsetimestart;
+  mTrackletParsingBad = true;
   return mWordsRead;
 }
 

--- a/Detectors/TRD/simulation/src/Trap2CRU.cxx
+++ b/Detectors/TRD/simulation/src/Trap2CRU.cxx
@@ -582,7 +582,7 @@ int Trap2CRU::writeDigitHCHeader(const int eventcount, const uint32_t linkid)
   digitheader1.numtimebins = 30;
   memcpy(mRawDataPtr, (char*)&digitheader, sizeof(DigitHCHeader)); // 8 because we are only using the first 2 32bit words of the header, the rest are optional.
   mRawDataPtr += sizeof(DigitHCHeader);
-  memcpy(mRawDataPtr, (char*)&digitheader, sizeof(DigitHCHeader1)); // 8 because we are only using the first 2 32bit words of the header, the rest are optional.
+  memcpy(mRawDataPtr, (char*)&digitheader1, sizeof(DigitHCHeader1)); // 8 because we are only using the first 2 32bit words of the header, the rest are optional.
   mRawDataPtr += sizeof(DigitHCHeader1);
   wordswritten += 2;
   return wordswritten;


### PR DESCRIPTION
- fix 1 remaining parsing warning for mc2raw
- handles multiple end of digit markers correctly
- remove error and warning messages, see histograms and eventually qc for those messages.
- 2d histograms for parsing errors, rather illuminating
- fix corrupted halfchamber header where additional header words and data version are zero now.
- command line option to set DigitHCHeader.numberHCW --hcheaderwords
- command line option to set data version --hcheadermajor  only major version is used.
- command line option to expressly ignore halfchamber header (location, major version and addtional words blank or identical)
- histograms neatened up
- tracklets at the position of the stuck half chamber header are still there, bit corruption, so tracklets at hcid 512, row 8 are to be ignored, remove the spike
- if a digit mcmheader is corrupt digit data is dumped, there is however a possibilty to recover digits later on in the buffer of that rob, needs more investigation for producing corrupt digits.
- stats messages to qc are stripped out of this PR

This is the hash used for Kr runs.

I have not been through all the permutations of combinations there are too many now, the ones to process previous data work though.