### PR TITLE
[MCH MID] treat each entry of the input tree as a separate TF

### DIFF
--- a/Detectors/MUON/MCH/Workflow/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Workflow/CMakeLists.txt
@@ -87,7 +87,7 @@ o2_add_executable(
         sim-digits-reader-workflow
         SOURCES src/DigitReaderSpec.cxx src/sim-digits-reader-workflow.cxx
         COMPONENT_NAME mch
-        PUBLIC_LINK_LIBRARIES O2::Framework O2::DataFormatsMCH O2::MCHBase O2::MCHMappingImpl3 O2::SimulationDataFormat)
+        PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::DataFormatsMCH O2::MCHBase O2::MCHMappingImpl3 O2::SimulationDataFormat)
 
 o2_add_executable(
         preclusters-sink-workflow

--- a/Detectors/MUON/MID/Workflow/src/DigitReaderSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/DigitReaderSpec.cxx
@@ -16,11 +16,10 @@
 
 #include "MIDWorkflow/DigitReaderSpec.h"
 
+#include <memory>
 #include <sstream>
 #include <string>
-#include "fmt/format.h"
-#include "TFile.h"
-#include "TTree.h"
+#include "DPLUtils/RootTreeReader.h"
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/ControlService.h"
 #include "Framework/DataSpecUtils.h"
@@ -36,7 +35,7 @@
 #include "DetectorsCommonDataFormats/NameConf.h"
 #include "CommonUtils/StringUtils.h"
 
-namespace of = o2::framework;
+using namespace o2::framework;
 
 namespace o2
 {
@@ -46,75 +45,64 @@ namespace mid
 class DigitsReaderDeviceDPL
 {
  public:
-  DigitsReaderDeviceDPL(bool useMC, const std::vector<header::DataDescription>& descriptions) : mUseMC(useMC), mDescriptions(descriptions) {}
-  void init(o2::framework::InitContext& ic)
+  DigitsReaderDeviceDPL(bool useMC, const std::vector<header::DataDescription>& descriptions)
+    : mUseMC(useMC), mDescriptions(descriptions) {}
+
+  void init(InitContext& ic)
   {
-    auto filename = o2::utils::Str::concat_string(o2::utils::Str::rectifyDirectory(ic.options().get<std::string>("input-dir")),
-                                                  ic.options().get<std::string>("mid-digit-infile"));
-    mFile = std::make_unique<TFile>(filename.c_str());
-    if (!mFile->IsOpen()) {
-      LOG(ERROR) << "Cannot open the " << filename << " file !";
-      mState = 1;
-      return;
-    }
-    mTree = static_cast<TTree*>(mFile->Get("o2sim"));
-    if (!mTree) {
-      LOG(ERROR) << "Cannot find tree in " << filename;
-      mState = 1;
-      return;
-    }
-    mTree->SetBranchAddress("MIDDigit", &mDigits);
+    auto filename = utils::Str::concat_string(utils::Str::rectifyDirectory(ic.options().get<std::string>("input-dir")),
+                                              ic.options().get<std::string>("mid-digit-infile"));
     if (mUseMC) {
-      mTree->SetBranchAddress("MIDDigitMCLabels", &mMCContainer);
+      mReader = std::make_unique<RootTreeReader>("o2sim", filename.c_str(), -1,
+                                                 RootTreeReader::PublishingMode::Single,
+                                                 RootTreeReader::BranchDefinition<std::vector<ColumnDataMC>>{
+                                                   Output{header::gDataOriginMID, mDescriptions[0], 0, Lifetime::Timeframe}, "MIDDigit"},
+                                                 RootTreeReader::BranchDefinition<std::vector<ROFRecord>>{
+                                                   Output{header::gDataOriginMID, mDescriptions[1], 0, Lifetime::Timeframe}, "MIDROFRecords"},
+                                                 RootTreeReader::BranchDefinition<dataformats::MCTruthContainer<MCLabel>>{
+                                                   Output{header::gDataOriginMID, mDescriptions[2], 0, Lifetime::Timeframe}, "MIDDigitMCLabels"},
+                                                 &mPublishDigits);
+    } else {
+      mReader = std::make_unique<RootTreeReader>("o2sim", filename.c_str(), -1,
+                                                 RootTreeReader::PublishingMode::Single,
+                                                 RootTreeReader::BranchDefinition<std::vector<ColumnDataMC>>{
+                                                   Output{header::gDataOriginMID, mDescriptions[0], 0, Lifetime::Timeframe}, "MIDDigit"},
+                                                 RootTreeReader::BranchDefinition<std::vector<ROFRecord>>{
+                                                   Output{header::gDataOriginMID, mDescriptions[1], 0, Lifetime::Timeframe}, "MIDROFRecords"},
+                                                 &mPublishDigits);
     }
-    mTree->SetBranchAddress("MIDROFRecords", &mROFRecords);
-    mState = 0;
   }
 
-  void run(o2::framework::ProcessingContext& pc)
+  void run(ProcessingContext& pc)
   {
-    if (mState != 0) {
-      return;
+    if ((++(*mReader))(pc) == false) {
+      pc.services().get<ControlService>().endOfStream();
     }
-
-    std::vector<ColumnData> digits;
-    o2::dataformats::MCTruthContainer<MCLabel> mcContainer;
-    std::vector<ROFRecord> rofRecords;
-
-    for (auto ientry = 0; ientry < mTree->GetEntries(); ++ientry) {
-      mTree->GetEntry(ientry);
-      digits.insert(digits.end(), mDigits->begin(), mDigits->end());
-      rofRecords.insert(rofRecords.end(), mROFRecords->begin(), mROFRecords->end());
-      if (mUseMC) {
-        mcContainer.mergeAtBack(*mMCContainer);
-      }
-    }
-
-    LOG(DEBUG) << "MIDDigitsReader pushed " << digits.size() << " merged digits";
-    pc.outputs().snapshot(of::Output{header::gDataOriginMID, mDescriptions[0], 0, of::Lifetime::Timeframe}, digits);
-    pc.outputs().snapshot(of::Output{header::gDataOriginMID, mDescriptions[1], 0, of::Lifetime::Timeframe}, rofRecords);
-    LOG(DEBUG) << "MIDDigitsReader pushed " << digits.size() << " indexed digits";
-    if (mUseMC) {
-      pc.outputs().snapshot(of::Output{header::gDataOriginMID, mDescriptions[2], 0, of::Lifetime::Timeframe}, mcContainer);
-    }
-    mState = 2;
-    pc.services().get<of::ControlService>().endOfStream();
   }
 
  private:
-  std::unique_ptr<TFile> mFile{nullptr};
-  TTree* mTree{nullptr};                                             // not owner
-  std::vector<o2::mid::ColumnDataMC>* mDigits{nullptr};              // not owner
-  o2::dataformats::MCTruthContainer<MCLabel>* mMCContainer{nullptr}; // not owner
-  std::vector<o2::mid::ROFRecord>* mROFRecords{nullptr};             // not owner
+  std::unique_ptr<RootTreeReader> mReader{};
   std::vector<header::DataDescription> mDescriptions{};
-  int mState = 0;
   bool mUseMC = true;
+
+  /// structure holding the function to convert and publish the digits
+  RootTreeReader::SpecialPublishHook mPublishDigits{
+    [](std::string_view name, ProcessingContext& pc, Output const& output, char* data) -> bool {
+      if (name == "MIDDigit") {
+        auto inputDigits = reinterpret_cast<std::vector<ColumnDataMC>*>(data);
+        std::vector<ColumnData> digits{};
+        digits.insert(digits.end(), inputDigits->begin(), inputDigits->end());
+        pc.outputs().snapshot(output, digits);
+        LOG(DEBUG) << "MIDDigitsReader pushed " << digits.size() << " digits";
+        return true;
+      }
+      return false;
+    }};
 };
 
-framework::DataProcessorSpec getDigitReaderSpec(bool useMC, const char* baseDescription)
+DataProcessorSpec getDigitReaderSpec(bool useMC, const char* baseDescription)
 {
-  std::vector<of::OutputSpec> outputs;
+  std::vector<OutputSpec> outputs;
   std::vector<header::DataDescription> descriptions;
   std::stringstream ss;
   ss << "A:" << header::gDataOriginMID.as<std::string>() << "/" << baseDescription << "/0";
@@ -122,19 +110,19 @@ framework::DataProcessorSpec getDigitReaderSpec(bool useMC, const char* baseDesc
   if (useMC) {
     ss << ";C:" << header::gDataOriginMID.as<std::string>() << "/" << baseDescription << "LABELS/0";
   }
-  auto matchers = of::select(ss.str().c_str());
+  auto matchers = select(ss.str().c_str());
   for (auto& matcher : matchers) {
-    outputs.emplace_back(of::DataSpecUtils::asOutputSpec(matcher));
-    descriptions.emplace_back(of::DataSpecUtils::asConcreteDataDescription(matcher));
+    outputs.emplace_back(DataSpecUtils::asOutputSpec(matcher));
+    descriptions.emplace_back(DataSpecUtils::asConcreteDataDescription(matcher));
   }
 
-  return of::DataProcessorSpec{
+  return DataProcessorSpec{
     "MIDDigitsReader",
-    of::Inputs{},
+    Inputs{},
     outputs,
-    of::AlgorithmSpec{of::adaptFromTask<o2::mid::DigitsReaderDeviceDPL>(useMC, descriptions)},
-    of::Options{{"mid-digit-infile", of::VariantType::String, "middigits.root", {"Name of the input file"}},
-                {"input-dir", of::VariantType::String, "none", {"Input directory"}}}};
+    AlgorithmSpec{adaptFromTask<DigitsReaderDeviceDPL>(useMC, descriptions)},
+    Options{{"mid-digit-infile", VariantType::String, "middigits.root", {"Name of the input file"}},
+            {"input-dir", VariantType::String, "none", {"Input directory"}}}};
 }
 } // namespace mid
 } // namespace o2


### PR DESCRIPTION
- use RootTreeReader to read the data from the input root file and send the messages, instead of doing it "by hand".

- In case the tree has several entries, send one set of messages per entry, thus treating each of them as a separate TF. Previously the entries where concatenated in the same messages, but without changing the references to the digits in the ROFs. Concatenation of several entries in the same messages is an option that could be introduced later if needed, with an appropriate reindexing.
