### PR TITLE
Speedup in TOF matching

### DIFF
--- a/Detectors/GlobalTracking/src/MatchTOF.cxx
+++ b/Detectors/GlobalTracking/src/MatchTOF.cxx
@@ -492,7 +492,7 @@ void MatchTOF::doMatching(int sec)
         detIdTemp[idet] = -1;
       }
 
-      Geo::getPadDxDyDz(posFloat, detIdTemp, deltaPosTemp);
+      Geo::getPadDxDyDz(posFloat, detIdTemp, deltaPosTemp, sec);
 
       reachedPoint += step;
 
@@ -814,7 +814,7 @@ void MatchTOF::doMatchingForTPC(int sec)
           posFloat[2] = pos[2];
         }
 
-        Geo::getPadDxDyDz(posFloat, detIdTemp, deltaPosTemp);
+        Geo::getPadDxDyDz(posFloat, detIdTemp, deltaPosTemp, sec);
 
         if (detIdTemp[2] == -1) {
           continue;

--- a/Detectors/GlobalTracking/src/MatchTOF.cxx
+++ b/Detectors/GlobalTracking/src/MatchTOF.cxx
@@ -62,11 +62,7 @@ void MatchTOF::run(const o2::globaltracking::RecoContainer& inp)
 
   mTimerMatchTPC.Reset();
   mTimerMatchITSTPC.Reset();
-  mTimerTot.Start();
-
-  mTimerTot.Stop();
-  LOGF(INFO, "Timing prepareTOFCluster: Cpu: %.3e s Real: %.3e s in %d slots", mTimerTot.CpuTime(), mTimerTot.RealTime(), mTimerTot.Counter() - 1);
-  mTimerTot.Start();
+  mTimerTot.Reset();
 
   for (int i = 0; i < trkType::SIZE; i++) {
     mMatchedTracks[i].clear();
@@ -88,18 +84,30 @@ void MatchTOF::run(const o2::globaltracking::RecoContainer& inp)
   mSideTPC.clear();
   mExtraTPCFwdTime.clear();
 
-  if (!prepareTOFClusters()) { // check cluster before of tracks to see also if MC is required
-    return;
-  }
-
-  if (!prepareTPCData() || !prepareFITData()) {
-    return;
-  }
-
-  mTimerTot.Stop();
-  LOGF(INFO, "Timing prepare tracks: Cpu: %.3e s Real: %.3e s in %d slots", mTimerTot.CpuTime(), mTimerTot.RealTime(), mTimerTot.Counter() - 1);
   mTimerTot.Start();
+  bool isPrepareTOFClusters = prepareTOFClusters();
+  mTimerTot.Stop();
+  LOGF(INFO, "Timing prepareTOFCluster: Cpu: %.3e s Real: %.3e s in %d slots", mTimerTot.CpuTime(), mTimerTot.RealTime(), mTimerTot.Counter() - 1);
 
+  if (!isPrepareTOFClusters) { // check cluster before of tracks to see also if MC is required
+    return;
+  }
+
+  mTimerTot.Start();
+  if (!prepareTPCData()) {
+    return;
+  }
+  mTimerTot.Stop();
+  LOGF(INFO, "Timing prepare TPC tracks: Cpu: %.3e s Real: %.3e s in %d slots", mTimerTot.CpuTime(), mTimerTot.RealTime(), mTimerTot.Counter() - 1);
+
+  mTimerTot.Start();
+  if (!prepareFITData()) {
+    return;
+  }
+  mTimerTot.Stop();
+  LOGF(INFO, "Timing prepare FIT data: Cpu: %.3e s Real: %.3e s in %d slots", mTimerTot.CpuTime(), mTimerTot.RealTime(), mTimerTot.Counter() - 1);
+
+  mTimerTot.Start();
   for (int sec = o2::constants::math::NSectors; sec--;) {
     mMatchedTracksPairs.clear(); // new sector
     LOG(INFO) << "Doing matching for sector " << sec << "...";
@@ -126,7 +134,7 @@ void MatchTOF::run(const o2::globaltracking::RecoContainer& inp)
   mIsITSTPCTRDused = false;
 
   mTimerTot.Stop();
-  LOGF(INFO, "Timing Do Matching: Cpu: %.3e s Real: %.3e s in %d slots", mTimerTot.CpuTime(), mTimerTot.RealTime(), mTimerTot.Counter() - 1);
+  LOGF(INFO, "Timing Do Matching:        Cpu: %.3e s Real: %.3e s in %d slots", mTimerTot.CpuTime(), mTimerTot.RealTime(), mTimerTot.Counter() - 1);
   LOGF(INFO, "Timing Do Matching ITSTPC: Cpu: %.3e s Real: %.3e s in %d slots", mTimerMatchITSTPC.CpuTime(), mTimerMatchITSTPC.RealTime(), mTimerMatchITSTPC.Counter() - 1);
   LOGF(INFO, "Timing Do Matching TPC   : Cpu: %.3e s Real: %.3e s in %d slots", mTimerMatchTPC.CpuTime(), mTimerMatchTPC.RealTime(), mTimerMatchTPC.Counter() - 1);
 }
@@ -371,6 +379,7 @@ bool MatchTOF::prepareTOFClusters()
   int nClusterInCurrentChunk = mTOFClustersArrayInp.size();
   LOG(DEBUG) << "nClusterInCurrentChunk = " << nClusterInCurrentChunk;
   mNumOfClusters += nClusterInCurrentChunk;
+  mTOFClusWork.reserve(mTOFClusWork.size() + mNumOfClusters);
   for (int it = 0; it < nClusterInCurrentChunk; it++) {
     const Cluster& clOrig = mTOFClustersArrayInp[it];
     // create working copy of track param
@@ -1157,7 +1166,7 @@ bool MatchTOF::propagateToRefX(o2::track::TrackParCov& trc, float xRef, float st
 {
   // propagate track to matching reference X
   o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrLUT; // material correction method
-  const float tanHalfSector = tan(o2::constants::math::SectorSpanRad / 2);
+  static const float tanHalfSector = tan(o2::constants::math::SectorSpanRad / 2);
   bool refReached = false;
   float xStart = trc.getX();
   // the first propagation will be from 2m, if the track is not at least at 2m

--- a/Detectors/TOF/base/include/TOFBase/Geo.h
+++ b/Detectors/TOF/base/include/TOFBase/Geo.h
@@ -288,6 +288,7 @@ class Geo
   static Int_t getCHFromECH(int echan) { return ELCHAN_TO_CHAN[echan]; }
 
   static void Init();
+  static void InitIndices();
 
  private:
   static Int_t getSector(const Float_t* pos);

--- a/Detectors/TOF/base/include/TOFBase/Geo.h
+++ b/Detectors/TOF/base/include/TOFBase/Geo.h
@@ -13,6 +13,8 @@
 #define ALICEO2_TOF_GEO_H
 
 #include "Rtypes.h"
+#include <array>
+#include <vector>
 #include "CommonConstants/LHCConstants.h"
 //#include "DetectorsRaw/HBFUtils.h"
 
@@ -30,6 +32,7 @@ class Geo
 
   // From AliTOFGeometry
   static void translate(Float_t* xyz, Float_t translationVector[3]);
+  static void translate(Float_t& x, Float_t& y, Float_t& z, Float_t translationVector[3]);
   static void rotate(Float_t* xyz, Double_t rotationAngles[6]);
 
   static void rotateToSector(Float_t* xyz, Int_t isector);
@@ -71,13 +74,16 @@ class Geo
   static constexpr int BC_IN_ORBIT = o2::constants::lhc::LHCMaxBunches;     // N. bunch crossing in 1 orbit
 
   static constexpr Int_t NPADX = 48;
+  static constexpr Float_t NPADX_INV_INT = 1. / NPADX;
   static constexpr Int_t NPADZ = 2;
   static constexpr Int_t NPADS = NPADX * NPADZ;
+  static constexpr Float_t NPADS_INV_INT = 1. / NPADS;
   static constexpr Int_t NSTRIPA = 15;
   static constexpr Int_t NSTRIPB = 19;
   static constexpr Int_t NSTRIPC = 19;
   static constexpr Int_t NMAXNSTRIP = 20;
   static constexpr Int_t NSTRIPXSECTOR = NSTRIPA + 2 * NSTRIPB + 2 * NSTRIPC;
+  static constexpr Float_t NSTRIPXSECTOR_INV_INT = 1. / NSTRIPXSECTOR;
   static constexpr Int_t NPADSXSECTOR = NSTRIPXSECTOR * NPADS;
 
   static constexpr Int_t NSECTORS = 18;
@@ -107,6 +113,7 @@ class Geo
   static constexpr Float_t SIGMAFORTAIL12 = 0.5; // Sig2 for simulation of TDC tails
 
   static constexpr Float_t PHISEC = 20; // sector Phi width (deg)
+  static constexpr Float_t PHISECINV = 1. / PHISEC; // sector Phi width (deg)
 
   static constexpr Float_t TDCBIN = o2::constants::lhc::LHCBunchSpacingNS * 1E3 / 1024; ///< TDC bin width [ps]
   static constexpr Float_t NTDCBIN_PER_PS = 1. / TDCBIN;     ///< number of TDC bins in 1 ns
@@ -295,6 +302,9 @@ class Geo
   static Float_t mRotationMatrixSector[NSECTORS + 1][3][3]; // rotation matrixes
   static Float_t mRotationMatrixPlateStrip[NPLATES][NMAXNSTRIP][3][3];
   static Float_t mPadPosition[NSECTORS][NPLATES][NMAXNSTRIP][NPADZ][NPADX][3];
+  static Int_t mPlate[NSTRIPXSECTOR];
+  static Int_t mStripInPlate[NSTRIPXSECTOR];
+  static std::array<std::vector<float>, 5> mDistances;
 
   // cable length map
   static constexpr Float_t CABLEPROPAGATIONDELAY = 0.0513;           // Propagation delay [ns/cm]
@@ -302,7 +312,7 @@ class Geo
   static const Int_t CHAN_TO_ELCHAN[NCHANNELS];
   static const Int_t ELCHAN_TO_CHAN[N_ELECTRONIC_CHANNELS];
 
-  ClassDefNV(Geo, 1);
+  ClassDefNV(Geo, 2);
 };
 } // namespace tof
 } // namespace o2

--- a/Detectors/TOF/base/include/TOFBase/Geo.h
+++ b/Detectors/TOF/base/include/TOFBase/Geo.h
@@ -52,7 +52,7 @@ class Geo
   static Float_t getAngles(Int_t iplate, Int_t istrip) { return ANGLES[iplate][istrip]; }
   static Float_t getHeights(Int_t iplate, Int_t istrip) { return HEIGHTS[iplate][istrip]; }
   static Float_t getDistances(Int_t iplate, Int_t istrip) { return DISTANCES[iplate][istrip]; }
-  static void getPadDxDyDz(const Float_t* pos, Int_t* det, Float_t* DeltaPos);
+  static void getPadDxDyDz(const Float_t* pos, Int_t* det, Float_t* DeltaPos, int sector = -1);
   enum {
     // DAQ characteristics
     // cfr. TOF-TDR pag. 105 for Glossary

--- a/Detectors/TOF/base/src/Geo.cxx
+++ b/Detectors/TOF/base/src/Geo.cxx
@@ -146,7 +146,14 @@ void Geo::Init()
       }
     }
   }
+  InitIndices();
+  mToBeIntit = kFALSE;
+}
 
+void Geo::InitIndices() {
+
+  // initialization of some indices arrays
+  
   for (Int_t istrip = 0; istrip < NSTRIPXSECTOR; ++istrip) {
     if (istrip < NSTRIPC) {
       mPlate[istrip] = 0;
@@ -178,8 +185,6 @@ void Geo::Init()
       mDistances[iplate].push_back(DISTANCES[iplate][nstrips - i - 1]);
     }
   }
-
-  mToBeIntit = kFALSE;
 }
 
 std::string Geo::getVolumePath(const Int_t* ind)
@@ -286,6 +291,10 @@ void Geo::getVolumeIndices(Int_t index, Int_t* detId)
   //
   // Retrieve volume indices from the calibration channel index
   //
+
+  if (mToBeIntit) {
+    InitIndices();
+  }
   detId[0] = index * NPADS_INV_INT * NSTRIPXSECTOR_INV_INT;
 
   Int_t dummyStripPerModule = index / NPADS - NSTRIPXSECTOR * detId[0];

--- a/Detectors/TOF/base/src/Geo.cxx
+++ b/Detectors/TOF/base/src/Geo.cxx
@@ -518,7 +518,7 @@ Int_t Geo::getSector(const Float_t* pos)
   return iSect;
 }
 
-void Geo::getPadDxDyDz(const Float_t* pos, Int_t* det, Float_t* DeltaPos)
+void Geo::getPadDxDyDz(const Float_t* pos, Int_t* det, Float_t* DeltaPos, int sector)
 {
   //
   // Returns the x coordinate in the Pad reference frame
@@ -531,9 +531,13 @@ void Geo::getPadDxDyDz(const Float_t* pos, Int_t* det, Float_t* DeltaPos)
     DeltaPos[ii] = pos[ii];
   }
 
-  det[0] = getSector(DeltaPos);
+  det[0] = sector;
   if (det[0] == -1) {
-    return;
+    det[0] = getSector(DeltaPos);
+
+    if (det[0] == -1) {
+      return;
+    }
   }
 
   fromGlobalToSector(DeltaPos, det[0]);

--- a/Detectors/TOF/base/src/Geo.cxx
+++ b/Detectors/TOF/base/src/Geo.cxx
@@ -150,10 +150,11 @@ void Geo::Init()
   mToBeIntit = kFALSE;
 }
 
-void Geo::InitIndices() {
+void Geo::InitIndices()
+{
 
   // initialization of some indices arrays
-  
+
   for (Int_t istrip = 0; istrip < NSTRIPXSECTOR; ++istrip) {
     if (istrip < NSTRIPC) {
       mPlate[istrip] = 0;

--- a/Detectors/TOF/base/test/testTOFIndex.cxx
+++ b/Detectors/TOF/base/test/testTOFIndex.cxx
@@ -32,6 +32,8 @@ BOOST_AUTO_TEST_CASE(testTOFIndex)
   Bool_t ErrorPx = 0;
   Bool_t ErrorPz = 0;
 
+  o2::tof::Geo::Init();
+
   for (Int_t i = 0; i < Geo::NSECTORS; i++) { // Loop on all Sectors
     indextof[0] = i;
     for (Int_t j = 0; j < Geo::NPLATES; j++) { // Loop on all Plates

--- a/Detectors/TOF/base/test/testTOFIndex.cxx
+++ b/Detectors/TOF/base/test/testTOFIndex.cxx
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_CASE(testTOFIndex)
   Bool_t ErrorPx = 0;
   Bool_t ErrorPz = 0;
 
-  o2::tof::Geo::Init();
+  o2::tof::Geo::InitIndices();
 
   for (Int_t i = 0; i < Geo::NSECTORS; i++) { // Loop on all Sectors
     indextof[0] = i;


### PR DESCRIPTION
Speed-up on 600 PbPb events generated by @davidrohr :+1: 
dev:
[19467:tof-matcher]: [16:51:08][INFO] Timing Do Matching: Cpu: 3.776e+01 s Real: 3.772e+01 s in 0 slots
[19467:tof-matcher]: [16:51:08][INFO] Timing Do Matching ITSTPC: Cpu: 0.000e+00 s Real: 0.000e+00 s in 0 slots
[19467:tof-matcher]: [16:51:08][INFO] Timing Do Matching TPC   : Cpu: 3.755e+01 s Real: 3.751e+01 s in 17 slots
[19467:tof-matcher]: [16:51:08][INFO] Shifting Z for 334358 matched TPC tracks according to TOF time info
[19468:TOFCalibWriter]: [16:51:09][INFO] RECEIVED MATCHED SIZE 334358
[19467:tof-matcher]: [16:51:09][INFO] TOF matching total timing: Cpu: 5.215e+01 Real: 5.211e+01 s in 1 slots
[19469:TOFMatchedWriter_TPC]: [16:51:09][INFO] RECEIVED MATCHED SIZE 334358

this branch:
[5487:tof-matcher]: [16:42:51][INFO] Timing Do Matching: Cpu: 2.891e+01 s Real: 2.888e+01 s in 0 slots
[5487:tof-matcher]: [16:42:51][INFO] Timing Do Matching ITSTPC: Cpu: 0.000e+00 s Real: 0.000e+00 s in 0 slots
[5487:tof-matcher]: [16:42:51][INFO] Timing Do Matching TPC   : Cpu: 2.870e+01 s Real: 2.866e+01 s in 17 slots
[5487:tof-matcher]: [16:42:51][INFO] Shifting Z for 334358 matched TPC tracks according to TOF time info
[5488:TOFCalibWriter]: [16:42:51][INFO] RECEIVED MATCHED SIZE 334358
[5487:tof-matcher]: [16:42:51][INFO] TOF matching total timing: Cpu: 4.460e+01 Real: 4.456e+01 s in 1 slots

==> ~25%

Compared to the initial measurements (~536s for "Timing Do Matching TPC") ==> we get to a factor 18 improvement. 
@noferini , please check that you "like" the changes, of course. 
