### PR TITLE
 ITS/MFT CTF decoder can mask noise in clusters or send digits

### DIFF
--- a/Detectors/CTF/README.md
+++ b/Detectors/CTF/README.md
@@ -98,6 +98,18 @@ regex string to identify remote files
 ```
 max CTF files queued (copied for remote source).
 
+For the ITS and MFT entropy decoding one can request either to decompose clusters to digits and send them instead of clusters (via `o2-ctf-reader-workflow` global options `--its-digits` and `--mft-digits` respectively)
+or to apply the noise mask to decoded clusters (or decoded digits). If the masking (e.g. via option `--its-entropy-decoder " --mask-noise "`) is requested, user should provide to the entropy decoder the noise mask file (eventually will be loaded from CCDB) and cluster patterns decoding dictionary (if the clusters were encoded with patterns IDs).
+For example,
+```
+o2-ctf-reader-workflow --ctf-input <ctfFiles> --onlyDet ITS,MFT --its-entropy-decoder ' --mask-noise --noise-file its_noise.root --cluster-dict-file ./ ' | ...
+```
+will decode ITS and MFT data, decompose on the fly ITS clusters to digits, mask the noisy pixels with the provided masks, recluster remaining ITS digits and send the new clusters out, together with unchanged MFT clusters.
+```
+o2-ctf-reader-workflow --ctf-input <ctfFiles> --onlyDet ITS,MFT --mft-digits --mft-entropy-decoder ' --mask-noise --noise-file mft_noise.root --cluster-dict-file ./ ' | ...
+```
+will send decompose clusters to digits and send ben out after masking the noise for the MFT, while ITS clusters will be sent as decoded.
+
 
 ## Support for externally provided encoding dictionaries
 

--- a/Detectors/CTF/test/test_ctf_io_itsmft.cxx
+++ b/Detectors/CTF/test/test_ctf_io_itsmft.cxx
@@ -105,11 +105,12 @@ BOOST_AUTO_TEST_CASE(CompressedClustersTest)
   std::vector<ROFRecord> rofRecVecD;
   std::vector<CompClusterExt> cclusVecD;
   std::vector<unsigned char> pattVecD;
+  LookUp clPattLookup;
   sw.Start();
   const auto ctfImage = o2::itsmft::CTF::getImage(vec.data());
   {
     CTFCoder coder(o2::detectors::DetID::ITS);
-    coder.decode(ctfImage, rofRecVecD, cclusVecD, pattVecD); // decompress
+    coder.decode(ctfImage, rofRecVecD, cclusVecD, pattVecD, nullptr, clPattLookup); // decompress
   }
   sw.Stop();
   LOG(INFO) << "Decompressed in " << sw.CpuTime() << " s";

--- a/Detectors/CTF/workflow/src/ctf-reader-workflow.cxx
+++ b/Detectors/CTF/workflow/src/ctf-reader-workflow.cxx
@@ -56,6 +56,9 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   options.push_back(ConfigParamSpec{"remote-regex", VariantType::String, "^/eos/aliceo2/.+", {"regex string to identify remote files"}});
   options.push_back(ConfigParamSpec{"max-cached-files", VariantType::Int, 3, {"max CTF files queued (copied for remote source)"}});
   options.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}});
+  //
+  options.push_back(ConfigParamSpec{"its-digits", VariantType::Bool, false, {"convert ITS clusters to digits"}});
+  options.push_back(ConfigParamSpec{"mft-digits", VariantType::Bool, false, {"convert MFT clusters to digits"}});
 
   std::swap(workflowOptions, options);
 }
@@ -106,10 +109,10 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 
   // add decodors for all allowed detectors.
   if (ctfInput.detMask[DetID::ITS]) {
-    specs.push_back(o2::itsmft::getEntropyDecoderSpec(DetID::getDataOrigin(DetID::ITS)));
+    specs.push_back(o2::itsmft::getEntropyDecoderSpec(DetID::getDataOrigin(DetID::ITS), configcontext.options().get<bool>("its-digits")));
   }
   if (ctfInput.detMask[DetID::MFT]) {
-    specs.push_back(o2::itsmft::getEntropyDecoderSpec(DetID::getDataOrigin(DetID::MFT)));
+    specs.push_back(o2::itsmft::getEntropyDecoderSpec(DetID::getDataOrigin(DetID::MFT), configcontext.options().get<bool>("mft-digits")));
   }
   if (ctfInput.detMask[DetID::TPC]) {
     specs.push_back(o2::tpc::getEntropyDecoderSpec());

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/CTFCoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/CTFCoder.h
@@ -167,9 +167,15 @@ void CTFCoder::decompress(const CompressedClusters& compCl, VROF& rofRecVec, VCL
 
   // >> ====== Helper functions for reclusterization after masking some pixels in decoded clusters ======
   // clusterize the pmat matrix holding pixels of the single cluster after masking the noisy ones
+
   auto clusterize = [&](uint16_t chipID, int16_t row, int16_t col, int leftFired) {
+#ifdef _ALLOW_DIAGONAL_ALPIDE_CLUSTERS_
     const std::array<int16_t, 8> walkRow = {1, -1, 0, 0, 1, 1, -1, -1};
     const std::array<int16_t, 8> walkCol = {0, 0, -1, 1, 1, -1, 1, 1};
+#else
+    const std::array<int16_t, 4> walkRow = {1, -1, 0, 0};
+    const std::array<int16_t, 4> walkCol = {0, 0, -1, 1};
+#endif
     Clusterer::BBox bbox(chipID);
     // check and add to new cluster seed fired pixels around ir1, ic1, return true if there are still fired pixels left
     std::function<bool(int16_t, int16_t)> checkPixelAndNeighbours = [&](int16_t ir1, int16_t ic1) {

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/CTFCoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/CTFCoder.h
@@ -22,9 +22,16 @@
 #include "DataFormatsITSMFT/CTF.h"
 #include "DataFormatsITSMFT/ROFRecord.h"
 #include "DataFormatsITSMFT/CompCluster.h"
+#include "DataFormatsITSMFT/Digit.h"
+#include "DataFormatsITSMFT/NoiseMap.h"
+#include "ITSMFTReconstruction/LookUp.h"
+#include "ITSMFTReconstruction/PixelData.h"
+#include "ITSMFTReconstruction/Clusterer.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 #include "DetectorsBase/CTFCoderBase.h"
 #include "rANS/rans.h"
+
+//#define _CHECK_INCREMENTES_ // Uncoment this the check the incremements being non-negative
 
 class TTree;
 
@@ -36,6 +43,9 @@ namespace itsmft
 class CTFCoder : public o2::ctf::CTFCoderBase
 {
  public:
+  using PMatrix = std::array<std::array<bool, ClusterPattern::MaxRowSpan + 2>, ClusterPattern::MaxColSpan + 2>;
+  using RowColBuff = std::vector<PixelData>;
+
   CTFCoder(o2::detectors::DetID det) : o2::ctf::CTFCoderBase(CTF::getNBlocks(), det) {}
   ~CTFCoder() = default;
 
@@ -45,23 +55,32 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 
   /// entropy decode clusters from buffer with CTF
   template <typename VROF, typename VCLUS, typename VPAT>
-  void decode(const CTF::base& ec, VROF& rofRecVec, VCLUS& cclusVec, VPAT& pattVec);
+  void decode(const CTF::base& ec, VROF& rofRecVec, VCLUS& cclusVec, VPAT& pattVec, const NoiseMap* noiseMap, const LookUp& clPattLookup);
+
+  /// entropy decode digits from buffer with CTF
+  template <typename VROF, typename VDIG>
+  void decode(const CTF::base& ec, VROF& rofRecVec, VDIG& digVec, const NoiseMap* noiseMap, const LookUp& clPattLookup);
 
   void createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op);
 
  private:
+  CompressedClusters decodeCompressedClusters(const CTF::base& ec);
+
   /// compres compact clusters to CompressedClusters
-  void compress(CompressedClusters& cc, const gsl::span<const ROFRecord>& rofRecVec, const gsl::span<const CompClusterExt>& cclusVec, const gsl::span<const unsigned char>& pattVec);
-  size_t estimateCompressedSize(const CompressedClusters& cc);
+  void compress(CompressedClusters& compCl, const gsl::span<const ROFRecord>& rofRecVec, const gsl::span<const CompClusterExt>& cclusVec, const gsl::span<const unsigned char>& pattVec);
+  size_t estimateCompressedSize(const CompressedClusters& compCl);
 
   /// decompress CompressedClusters to compact clusters
   template <typename VROF, typename VCLUS, typename VPAT>
-  void decompress(const CompressedClusters& cc, VROF& rofRecVec, VCLUS& cclusVec, VPAT& pattVec);
+  void decompress(const CompressedClusters& compCl, VROF& rofRecVec, VCLUS& cclusVec, VPAT& pattVec, const NoiseMap* noiseMap, const LookUp& clPattLookup);
+
+  /// decompress CompressedClusters to digits
+  template <typename VROF, typename VDIG>
+  void decompress(const CompressedClusters& compCl, VROF& rofRecVec, VDIG& digVec, const NoiseMap* noiseMap, const LookUp& clPattLookup);
 
   void appendToTree(TTree& tree, CTF& ec);
-  void readFromTree(TTree& tree, int entry, std::vector<ROFRecord>& rofRecVec, std::vector<CompClusterExt>& cclusVec, std::vector<unsigned char>& pattVec);
+  void readFromTree(TTree& tree, int entry, std::vector<ROFRecord>& rofRecVec, std::vector<CompClusterExt>& cclusVec, std::vector<unsigned char>& pattVec, const NoiseMap* noiseMap, const LookUp& clPattLookup);
 
- protected:
   ClassDefNV(CTFCoder, 1);
 };
 
@@ -83,136 +102,319 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const ROFRecord>& rofRecVec, co
     MD::EENCODE, //BLCpattID
     MD::EENCODE  //BLCpattMap
   };
-  CompressedClusters cc;
-  compress(cc, rofRecVec, cclusVec, pattVec);
+  CompressedClusters compCl;
+  compress(compCl, rofRecVec, cclusVec, pattVec);
   // book output size with some margin
-  auto szIni = estimateCompressedSize(cc);
+  auto szIni = estimateCompressedSize(compCl);
   buff.resize(szIni);
 
   auto ec = CTF::create(buff);
   using ECB = CTF::base;
 
-  ec->setHeader(cc.header);
+  ec->setHeader(compCl.header);
   assignDictVersion(static_cast<o2::ctf::CTFDictHeader&>(ec->getHeader()));
   ec->getANSHeader().majorVersion = 0;
   ec->getANSHeader().minorVersion = 1;
   // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
 #define ENCODEITSMFT(part, slot, bits) CTF::get(buff.data())->encode(part, int(slot), bits, optField[int(slot)], &buff, mCoders[int(slot)].get());
   // clang-format off
-  ENCODEITSMFT(cc.firstChipROF, CTF::BLCfirstChipROF, 0);
-  ENCODEITSMFT(cc.bcIncROF, CTF::BLCbcIncROF, 0);
-  ENCODEITSMFT(cc.orbitIncROF, CTF::BLCorbitIncROF, 0);
-  ENCODEITSMFT(cc.nclusROF, CTF::BLCnclusROF, 0);
+  ENCODEITSMFT(compCl.firstChipROF, CTF::BLCfirstChipROF, 0);
+  ENCODEITSMFT(compCl.bcIncROF, CTF::BLCbcIncROF, 0);
+  ENCODEITSMFT(compCl.orbitIncROF, CTF::BLCorbitIncROF, 0);
+  ENCODEITSMFT(compCl.nclusROF, CTF::BLCnclusROF, 0);
   //
-  ENCODEITSMFT(cc.chipInc, CTF::BLCchipInc, 0);
-  ENCODEITSMFT(cc.chipMul, CTF::BLCchipMul, 0);
-  ENCODEITSMFT(cc.row, CTF::BLCrow, 0);
-  ENCODEITSMFT(cc.colInc, CTF::BLCcolInc, 0);
-  ENCODEITSMFT(cc.pattID, CTF::BLCpattID, 0);
-  ENCODEITSMFT(cc.pattMap, CTF::BLCpattMap, 0);
+  ENCODEITSMFT(compCl.chipInc, CTF::BLCchipInc, 0);
+  ENCODEITSMFT(compCl.chipMul, CTF::BLCchipMul, 0);
+  ENCODEITSMFT(compCl.row, CTF::BLCrow, 0);
+  ENCODEITSMFT(compCl.colInc, CTF::BLCcolInc, 0);
+  ENCODEITSMFT(compCl.pattID, CTF::BLCpattID, 0);
+  ENCODEITSMFT(compCl.pattMap, CTF::BLCpattMap, 0);
   // clang-format on
   CTF::get(buff.data())->print(getPrefix());
 }
 
 /// decode entropy-encoded clusters to standard compact clusters
 template <typename VROF, typename VCLUS, typename VPAT>
-void CTFCoder::decode(const CTF::base& ec, VROF& rofRecVec, VCLUS& cclusVec, VPAT& pattVec)
+void CTFCoder::decode(const CTF::base& ec, VROF& rofRecVec, VCLUS& cclusVec, VPAT& pattVec, const NoiseMap* noiseMap, const LookUp& clPattLookup)
 {
-  CompressedClusters cc;
-  cc.header = ec.getHeader();
-  checkDictVersion(static_cast<const o2::ctf::CTFDictHeader&>(cc.header));
-  ec.print(getPrefix());
-#define DECODEITSMFT(part, slot) ec.decode(part, int(slot), mCoders[int(slot)].get())
-  // clang-format off
-  DECODEITSMFT(cc.firstChipROF, CTF::BLCfirstChipROF);
-  DECODEITSMFT(cc.bcIncROF,     CTF::BLCbcIncROF);
-  DECODEITSMFT(cc.orbitIncROF,  CTF::BLCorbitIncROF);
-  DECODEITSMFT(cc.nclusROF,     CTF::BLCnclusROF);
-  //
-  DECODEITSMFT(cc.chipInc,      CTF::BLCchipInc);
-  DECODEITSMFT(cc.chipMul,      CTF::BLCchipMul);
-  DECODEITSMFT(cc.row,          CTF::BLCrow);
-  DECODEITSMFT(cc.colInc,       CTF::BLCcolInc);
-  DECODEITSMFT(cc.pattID,       CTF::BLCpattID);
-  DECODEITSMFT(cc.pattMap,      CTF::BLCpattMap);
-  // clang-format on
-  //
-  decompress(cc, rofRecVec, cclusVec, pattVec);
+  auto compCl = decodeCompressedClusters(ec);
+  decompress(compCl, rofRecVec, cclusVec, pattVec, noiseMap, clPattLookup);
+}
+
+/// decode entropy-encoded clusters to digits
+template <typename VROF, typename VDIG>
+void CTFCoder::decode(const CTF::base& ec, VROF& rofRecVec, VDIG& digVec, const NoiseMap* noiseMap, const LookUp& clPattLookup)
+{
+  auto compCl = decodeCompressedClusters(ec);
+  decompress(compCl, rofRecVec, digVec, noiseMap, clPattLookup);
 }
 
 /// decompress compressed clusters to standard compact clusters
 template <typename VROF, typename VCLUS, typename VPAT>
-void CTFCoder::decompress(const CompressedClusters& cc, VROF& rofRecVec, VCLUS& cclusVec, VPAT& pattVec)
+void CTFCoder::decompress(const CompressedClusters& compCl, VROF& rofRecVec, VCLUS& cclusVec, VPAT& pattVec, const NoiseMap* noiseMap, const LookUp& clPattLookup)
 {
-  rofRecVec.resize(cc.header.nROFs);
-  cclusVec.resize(cc.header.nClusters);
-  pattVec.resize(cc.header.nPatternBytes);
+  PMatrix pmat{};
+  RowColBuff firedPixBuff{}, maskedPixBuff{};
+  rofRecVec.resize(compCl.header.nROFs);
+  cclusVec.clear();
+  cclusVec.reserve(compCl.header.nClusters);
+  pattVec.clear();
+  pattVec.reserve(compCl.header.nPatternBytes);
+  o2::InteractionRecord prevIR(compCl.header.firstBC, compCl.header.firstOrbit);
+  uint32_t clCount = 0, chipCount = 0;
+  auto pattIt = compCl.pattMap.begin();
+  auto pattItStored = pattIt;
 
-  o2::InteractionRecord prevIR(cc.header.firstBC, cc.header.firstOrbit);
-  uint32_t firstEntry = 0, clCount = 0, chipCount = 0;
-  for (uint32_t irof = 0; irof < cc.header.nROFs; irof++) {
+  // >> ====== Helper functions for reclusterization after masking some pixels in decoded clusters ======
+  // clusterize the pmat matrix holding pixels of the single cluster after masking the noisy ones
+  auto clusterize = [&](uint16_t chipID, int16_t row, int16_t col, int leftFired) {
+    const std::array<int16_t, 8> walkRow = {1, -1, 0, 0, 1, 1, -1, -1};
+    const std::array<int16_t, 8> walkCol = {0, 0, -1, 1, 1, -1, 1, 1};
+    Clusterer::BBox bbox(chipID);
+    // check and add to new cluster seed fired pixels around ir1, ic1, return true if there are still fired pixels left
+    std::function<bool(int16_t, int16_t)> checkPixelAndNeighbours = [&](int16_t ir1, int16_t ic1) {
+      // if pixel in pmat is fired, add it to new cluster seed and adjust the BBox, decreasing the number of fired pixels left
+      auto checkPixel = [&](int16_t ir1, int16_t ic1) {
+        if (pmat[ir1][ic1]) {
+          pmat[ir1][ic1] = false;
+          uint16_t r = row + ir1 - 1, c = col + ic1 - 1;
+          firedPixBuff.emplace_back(r, c);
+          bbox.adjust(r, c);
+          leftFired--;
+          return true;
+        }
+        return false;
+      };
+      // check and add to new cluster seed fired pixels at and around ir1, ic1, return true if there are still fired pixels left
+      if (checkPixel(ir1, ic1) && leftFired) {
+        uint16_t iw = 0;
+        while (checkPixelAndNeighbours(ir1 + walkRow[iw], ic1 + walkCol[iw]) && ++iw < walkRow.size()) {
+        }
+      }
+      return leftFired;
+    };
+    // true will be returned if after incremental check of neighbours fired pixels are still left
+
+    firedPixBuff.clear();          // start new cluster seed
+    for (auto s : maskedPixBuff) { // we start checking from the holes remaining from the masked pixels
+      uint16_t iw = 0;
+      do {
+        checkPixelAndNeighbours(s.getRowDirect() + walkRow[iw], s.getCol() + walkCol[iw]);
+        if (!firedPixBuff.empty()) {
+          bbox.chipID = chipID;
+          Clusterer::streamCluster(firedPixBuff, nullptr, bbox, clPattLookup, &cclusVec, &pattVec, nullptr, 0);
+          firedPixBuff.clear();
+          bbox.clear();
+        }
+      } while (leftFired && ++iw < walkRow.size());
+      if (!leftFired) {
+        break;
+      }
+    }
+  };
+
+  auto reclusterize = [&]() {
+    auto clus = cclusVec.back(); // original newly added cluster
+    // acquire pattern
+    o2::itsmft::ClusterPattern patt;
+    auto pattItPrev = pattIt;
+    maskedPixBuff.clear();
+    if (clPattLookup.size() == 0 && clus.getPatternID() != o2::itsmft::CompCluster::InvalidPatternID) {
+      throw std::runtime_error("Clusters contain pattern IDs, but no dictionary is provided...");
+    }
+    if (clus.getPatternID() == o2::itsmft::CompCluster::InvalidPatternID || clPattLookup.isGroup(clus.getPatternID())) {
+      patt.acquirePattern(pattIt);
+    } else {
+      patt = clPattLookup.getPattern(clus.getPatternID());
+    }
+    int rowSpan = patt.getRowSpan(), colSpan = patt.getColumnSpan(), nMasked = 0;
+    if (rowSpan == 1 && colSpan == 1) {                                        // easy case: 1 pixel cluster
+      if (noiseMap->isNoisy(clus.getChipID(), clus.getRow(), clus.getCol())) { // just kill the cluster
+        std::copy(pattItStored, pattItPrev, back_inserter(pattVec));           // save patterns from after last saved to the one before killing this
+        pattItStored = pattIt;                                                 // advance to the head of the pattern iterator
+        cclusVec.pop_back();
+      }
+      // otherwise do nothing: cluster was already added, eventual patterns will be copied in large block at next modified cluster writing
+    } else {
+      int rowSpan = patt.getRowSpan(), colSpan = patt.getColumnSpan(), nMasked = 0, nPixels = 0; // apply noise and fill hits matrix
+      for (int ir = 0; ir < rowSpan; ir++) {
+        int row = clus.getRow() + ir;
+        for (int ic = 0; ic < colSpan; ic++) {
+          if (patt.isSet(ir, ic)) {
+            if (noiseMap->isNoisy(clus.getChipID(), row, ic + clus.getCol())) {
+              maskedPixBuff.emplace_back(ir + 1, ic + 1);
+              pmat[ir + 1][ic + 1] = false; // reset since might be left from prev cluster
+              nMasked++;
+            } else {
+              pmat[ir + 1][ic + 1] = true;
+              nPixels++;
+            }
+          } else {
+            pmat[ir + 1][ic + 1] = false; // reset since might be left from prev cluster
+          }
+        }
+      }
+
+      if (nMasked) {
+        cclusVec.pop_back();                                         // remove added cluster
+        std::copy(pattItStored, pattItPrev, back_inserter(pattVec)); // save patterns from after last saved to the one before killing this
+        pattItStored = pattIt;                                       // advance to the head of the pattern iterator
+        if (nPixels) {                                               // need to reclusterize remaining pixels
+          clusterize(clus.getChipID(), clus.getRow(), clus.getCol(), nPixels);
+        }
+      }
+    }
+  };
+  // << ====== Helper functions for reclusterization after masking some pixels in decoded clusters ======
+
+  for (uint32_t irof = 0; irof < compCl.header.nROFs; irof++) {
     // restore ROFRecord
     auto& rofRec = rofRecVec[irof];
-    if (cc.orbitIncROF[irof]) {      // new orbit
-      prevIR.bc = cc.bcIncROF[irof]; // bcInc has absolute meaning
-      prevIR.orbit += cc.orbitIncROF[irof];
+    if (compCl.orbitIncROF[irof]) {      // new orbit
+      prevIR.bc = compCl.bcIncROF[irof]; // bcInc has absolute meaning
+      prevIR.orbit += compCl.orbitIncROF[irof];
     } else {
-      prevIR.bc += cc.bcIncROF[irof];
+      prevIR.bc += compCl.bcIncROF[irof];
     }
     rofRec.setBCData(prevIR);
-    rofRec.setFirstEntry(firstEntry);
-    rofRec.setNEntries(cc.nclusROF[irof]);
-    firstEntry += cc.nclusROF[irof];
+    rofRec.setFirstEntry(cclusVec.size());
 
     // resrore chips data
-    auto prevChip = cc.firstChipROF[irof];
-    uint16_t prevCol = 0, prevRow = 0;
-
-    // >> this is the version with chipInc stored once per new chip
+    auto chipID = compCl.firstChipROF[irof];
+    uint16_t col = 0;
     int inChip = 0;
-    for (uint32_t icl = 0; icl < cc.nclusROF[irof]; icl++) {
-      auto& clus = cclusVec[clCount];
-      if (inChip++ < cc.chipMul[chipCount]) { // still the same chip
-        clus.setCol((prevCol += cc.colInc[clCount]));
+    for (uint32_t icl = 0; icl < compCl.nclusROF[irof]; icl++) {
+      auto& clus = cclusVec.emplace_back();
+      if (inChip++ < compCl.chipMul[chipCount]) { // still the same chip
+        clus.setCol((col += compCl.colInc[clCount]));
       } else { // new chip starts
-        prevChip += cc.chipInc[++chipCount];
+        chipID += compCl.chipInc[++chipCount];
         inChip = 1;
-        clus.setCol((prevCol = cc.colInc[clCount])); // colInc has abs. col meaning
+        clus.setCol((col = compCl.colInc[clCount])); // colInc has abs. col meaning
       }
-      clus.setChipID(prevChip);
-      clus.setRow(cc.row[clCount]);
-      clus.setPatternID(cc.pattID[clCount]);
+      clus.setRow(compCl.row[clCount]);
+      clus.setPatternID(compCl.pattID[clCount]);
+      clus.setChipID(chipID);
+      if (noiseMap) { // noise masking was requested
+        reclusterize();
+      }
       clCount++;
     }
-    if (cc.nclusROF[irof]) {
+    if (compCl.nclusROF[irof]) {
       chipCount++; // since next chip for sure will be new and inChip will be 0...
     }
-    // << this is the version with chipInc stored once per new chip
+    rofRec.setNEntries(cclusVec.size() - rofRec.getFirstEntry());
+  }
+  if (noiseMap) {                 // reclusterization was requested
+    if (pattItStored != pattIt) { // copy unsaved patterns
+      std::copy(pattItStored, pattIt, back_inserter(pattVec));
+    }
+  } else { // copy decoded patterns as they are
+    pattVec.resize(compCl.header.nPatternBytes);
+    memcpy(pattVec.data(), compCl.pattMap.data(), compCl.header.nPatternBytes);
+  }
+  assert(chipCount == compCl.header.nChips);
 
-    /*
-    // >> this is the version with chipInc stored for every pixel, requires entropy compression dealing with repeating symbols
-    for (uint32_t icl = 0; icl < cc.nclusROF[irof]; icl++) {
-    auto& clus = cclusVec[clCount];
-    if (cc.chipInc[clCount]) { // new chip
-    prevChip += cc.chipInc[clCount];
-    clus.setCol((prevCol = cc.colInc[clCount])); // colInc has abs. col meaning
+  if (clCount != compCl.header.nClusters) {
+    LOG(ERROR) << "expected " << compCl.header.nClusters << " but counted " << clCount << " in ROFRecords";
+    throw std::runtime_error("mismatch between expected and counter number of clusters");
+  }
+}
+
+/// decompress compressed clusters to digits
+template <typename VROF, typename VDIG>
+void CTFCoder::decompress(const CompressedClusters& compCl, VROF& rofRecVec, VDIG& digVec, const NoiseMap* noiseMap, const LookUp& clPattLookup)
+{
+  rofRecVec.resize(compCl.header.nROFs);
+  digVec.reserve(compCl.header.nClusters * 2);
+  o2::InteractionRecord prevIR(compCl.header.firstBC, compCl.header.firstOrbit);
+  uint32_t clCount = 0, chipCount = 0;
+  auto pattIt = compCl.pattMap.begin();
+  o2::itsmft::ClusterPattern patt;
+  for (uint32_t irof = 0; irof < compCl.header.nROFs; irof++) {
+    size_t chipStartNDig = digVec.size();
+    // restore ROFRecord
+    auto& rofRec = rofRecVec[irof];
+    if (compCl.orbitIncROF[irof]) {      // new orbit
+      prevIR.bc = compCl.bcIncROF[irof]; // bcInc has absolute meaning
+      prevIR.orbit += compCl.orbitIncROF[irof];
     } else {
-    clus.setCol((prevCol += cc.colInc[clCount]));
+      prevIR.bc += compCl.bcIncROF[irof];
     }
-    clus.setChipID(prevChip);
-    clus.setRow(cc.row[clCount]);
-    clus.setPatternID(cc.pattID[clCount]);
-    clCount++;
+    rofRec.setBCData(prevIR);
+    rofRec.setFirstEntry(digVec.size());
+
+    // resrore chips data
+    uint16_t chipID = compCl.firstChipROF[irof], col = 0;
+    int inChip = 0;
+    for (uint32_t icl = 0; icl < compCl.nclusROF[irof]; icl++) {
+      if (inChip++ < compCl.chipMul[chipCount]) { // still the same chip
+        col += compCl.colInc[clCount];
+#ifdef _CHECK_INCREMENTES_ // RS FIXME with current clusterization column increment can be slightly negative
+//        if (int16_t(compCl.colInc[clCount])<0) {
+//          LOG(WARNING) << "Negative column increment " << int16_t(compCl.colInc[clCount]) << " -> " << col << " in chip " << chipID;
+//        }
+#endif
+      } else { // new chip starts
+        // sort digits of previous chip in col/row
+        auto added = digVec.size() - chipStartNDig;
+        if (added > 1) { // we need to sort digits in colums and in rows within a column
+          std::sort(digVec.end() - added, digVec.end(),
+                    [](Digit& a, Digit& b) { return a.getColumn() < b.getColumn() || (a.getColumn() == b.getColumn() && a.getRow() < b.getRow()); });
+        }
+        chipStartNDig = digVec.size();
+        chipID += compCl.chipInc[++chipCount];
+#ifdef _CHECK_INCREMENTES_
+        if (int16_t(compCl.chipInc[chipCount]) < 0) {
+          LOG(WARNING) << "Negative chip increment " << int16_t(compCl.chipInc[chipCount]) << " -> " << chipID;
+        }
+#endif
+        inChip = 1;
+        col = compCl.colInc[clCount]; // colInc has abs. col meaning
+      }
+      uint16_t row = compCl.row[clCount];
+      auto pattID = compCl.pattID[clCount];
+      if (pattID == o2::itsmft::CompCluster::InvalidPatternID) {
+        patt.acquirePattern(pattIt);
+      } else {
+        if (clPattLookup.size() == 0) {
+          throw std::runtime_error("Clusters contain pattern IDs, but no dictionary is provided...");
+        }
+        if (pattID == o2::itsmft::CompCluster::InvalidPatternID || clPattLookup.isGroup(pattID)) {
+          patt.acquirePattern(pattIt);
+        } else {
+          patt = clPattLookup.getPattern(pattID);
+        }
+      }
+      clCount++;
+
+      auto fillRowCol = [&digVec, chipID, row, col, noiseMap](int r, int c) {
+        r += row;
+        c += col;
+        if (noiseMap && noiseMap->isNoisy(chipID, r, c)) {
+          return;
+        }
+        digVec.emplace_back(chipID, uint16_t(r), uint16_t(c));
+      };
+      patt.process(fillRowCol);
     }
-    // << this is the version with chipInc stored for every pixel, requires entropy compression dealing with repeating symbols
-    */
+    auto added = digVec.size() - chipStartNDig;
+    if (added > 1) { // Last chip of the ROF: we need to sort digits in colums and in rows within a column
+      std::sort(digVec.end() - added, digVec.end(),
+                [](Digit& a, Digit& b) { return a.getColumn() < b.getColumn() || (a.getColumn() == b.getColumn() && a.getRow() < b.getRow()); });
+    }
+
+    if (compCl.nclusROF[irof]) {
+      chipCount++; // since next chip for sure will be new and incChip will be 0...
+    }
+    rofRec.setNEntries(digVec.size() - rofRec.getFirstEntry());
   }
   // explicit patterns
-  memcpy(pattVec.data(), cc.pattMap.data(), cc.header.nPatternBytes); // RSTODO use swap?
-  assert(chipCount == cc.header.nChips);
+  assert(pattIt == compCl.pattMap.end());
+  assert(chipCount == compCl.header.nChips);
 
-  if (clCount != cc.header.nClusters) {
-    LOG(ERROR) << "expected " << cc.header.nClusters << " but counted " << clCount << " in ROFRecords";
+  if (clCount != compCl.header.nClusters) {
+    LOG(ERROR) << "expected " << compCl.header.nClusters << " but counted " << clCount << " in ROFRecords";
     throw std::runtime_error("mismatch between expected and counter number of clusters");
   }
 }

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
@@ -16,6 +16,10 @@
 
 #define _PERFORM_TIMING_
 
+// uncomment this to not allow diagonal clusters, e.g. like |* |
+//                                                          | *|
+#define _ALLOW_DIAGONAL_ALPIDE_CLUSTERS_
+
 #include <utility>
 #include <vector>
 #include <cstring>

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/LookUp.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/LookUp.h
@@ -36,11 +36,13 @@ class LookUp
   LookUp();
   LookUp(std::string fileName);
   static int groupFinder(int nRow, int nCol);
-  int findGroupID(int nRow, int nCol, const unsigned char patt[ClusterPattern::MaxPatternBytes]);
-  int getTopologiesOverThreshold() { return mTopologiesOverThreshold; }
+  int findGroupID(int nRow, int nCol, const unsigned char patt[ClusterPattern::MaxPatternBytes]) const;
+  int getTopologiesOverThreshold() const { return mTopologiesOverThreshold; }
   void loadDictionary(std::string fileName);
-  bool isGroup(int id) const;
+  bool isGroup(int id) const { return mDictionary.isGroup(id); }
   int size() const { return mDictionary.getSize(); }
+  auto getPattern(int id) const { return mDictionary.getPattern(id); }
+  auto getDictionaty() const { return mDictionary; }
 
  private:
   TopologyDictionary mDictionary;

--- a/Detectors/ITSMFT/common/reconstruction/src/Clusterer.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/Clusterer.cxx
@@ -358,7 +358,11 @@ void Clusterer::ClustererThread::updateChip(const ChipPixelData* curChipData, ui
       return;
     }
   } else {
+#ifdef _ALLOW_DIAGONAL_ALPIDE_CLUSTERS_
     int neighbours[]{curr[row - 1], prev[row], prev[row + 1], prev[row - 1]};
+#else
+    int neighbours[]{curr[row - 1], prev[row]};
+#endif
     for (auto pci : neighbours) {
       if (pci < 0) {
         continue;

--- a/Detectors/ITSMFT/common/reconstruction/src/LookUp.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/LookUp.cxx
@@ -57,7 +57,7 @@ int LookUp::groupFinder(int nRow, int nCol)
   return grNum;
 }
 
-int LookUp::findGroupID(int nRow, int nCol, const unsigned char patt[ClusterPattern::MaxPatternBytes])
+int LookUp::findGroupID(int nRow, int nCol, const unsigned char patt[ClusterPattern::MaxPatternBytes]) const
 {
   int nBits = nRow * nCol;
   // Small topology
@@ -67,7 +67,8 @@ int LookUp::findGroupID(int nRow, int nCol, const unsigned char patt[ClusterPatt
       return ID;
     } else { //small rare topology (inside groups)
       int index = groupFinder(nRow, nCol);
-      return mDictionary.mGroupMap[index];
+      auto res = mDictionary.mGroupMap.find(index);
+      return res == mDictionary.mGroupMap.end() ? -1 : res->second;
     }
   }
   // Big topology
@@ -77,13 +78,9 @@ int LookUp::findGroupID(int nRow, int nCol, const unsigned char patt[ClusterPatt
     return ret->second;
   } else { // Big rare topology (inside groups)
     int index = groupFinder(nRow, nCol);
-    return mDictionary.mGroupMap[index];
+    auto res = mDictionary.mGroupMap.find(index);
+    return res == mDictionary.mGroupMap.end() ? -1 : res->second;
   }
-}
-
-bool LookUp::isGroup(int id) const
-{
-  return mDictionary.isGroup(id);
 }
 
 } // namespace itsmft

--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/EntropyDecoderSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/EntropyDecoderSpec.h
@@ -19,7 +19,10 @@
 #include "Framework/Task.h"
 #include "Headers/DataHeader.h"
 #include "ITSMFTReconstruction/CTFCoder.h"
+#include "DataFormatsITSMFT/NoiseMap.h"
+#include "ITSMFTReconstruction/LookUp.h"
 #include <TStopwatch.h>
+#include <memory>
 
 namespace o2
 {
@@ -29,20 +32,33 @@ namespace itsmft
 class EntropyDecoderSpec : public o2::framework::Task
 {
  public:
-  EntropyDecoderSpec(o2::header::DataOrigin orig);
+  EntropyDecoderSpec(o2::header::DataOrigin orig, bool getDigits = false);
   ~EntropyDecoderSpec() override = default;
   void init(o2::framework::InitContext& ic) final;
   void run(o2::framework::ProcessingContext& pc) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
 
+  static auto getName(o2::header::DataOrigin orig) { return std::string{orig == o2::header::gDataOriginITS ? ITSDeviceName : MFTDeviceName}; }
+
  private:
+  void updateTimeDependentParams(o2::framework::ProcessingContext& pc);
+
+  static constexpr std::string_view ITSDeviceName = "its-entropy-decoder";
+  static constexpr std::string_view MFTDeviceName = "mft-entropy-decoder";
   o2::header::DataOrigin mOrigin = o2::header::gDataOriginInvalid;
   o2::itsmft::CTFCoder mCTFCoder;
+  std::unique_ptr<NoiseMap> mNoiseMap;
+  LookUp mPattIdConverter;
+  bool mGetDigits{false};
+  bool mMaskNoise{false};
+  std::string mCTFDictPath{};
+  std::string mClusDictPath{};
+  std::string mNoiseFilePath{};
   TStopwatch mTimer;
 };
 
 /// create a processor spec
-framework::DataProcessorSpec getEntropyDecoderSpec(o2::header::DataOrigin orig);
+framework::DataProcessorSpec getEntropyDecoderSpec(o2::header::DataOrigin orig, bool getDigits = false);
 
 } // namespace itsmft
 } // namespace o2


### PR DESCRIPTION
For the ITS and MFT entropy decoding one can request either to decompose clusters to digits and send them instead of clusters (via `o2-ctf-reader-workflow` global options `--its-digits` and `--mft-digits` respectively)
or to apply the noise mask to decoded clusters (or decoded digits). If the masking (e.g. via option `--its-entropy-decoder " --mask-noise "`) is requested, user should provide to the entropy decoder the noise mask file (eventually will be loaded from CCDB) and cluster patterns decoding dictionary (if the clusters were encoded with patterns IDs).
For example,
```
o2-ctf-reader-workflow --ctf-input <ctfFiles> --onlyDet ITS,MFT --its-entropy-decoder ' --mask-noise --noise-file its_noise.root --cluster-dict-file ./ ' | ...
```
will decode ITS and MFT data, decompose on the fly ITS clusters to digits, mask the noisy pixels with the provided masks, recluster remaining ITS digits and send the new clusters out, together with unchanged MFT clusters.
```
o2-ctf-reader-workflow --ctf-input <ctfFiles> --onlyDet ITS,MFT --mft-digits --mft-entropy-decoder ' --mask-noise --noise-file mft_noise.root --cluster-dict-file ./ ' | ...
```
will send decompose clusters to digits and send ben out after masking the noise for the MFT, while ITS clusters will be sent as decoded.