### PR TITLE
Rewrite of TreeToTable and TableToTree

### DIFF
--- a/Detectors/AOD/src/StandaloneAODProducer.cxx
+++ b/Detectors/AOD/src/StandaloneAODProducer.cxx
@@ -94,9 +94,9 @@ void fillMCollisionTable(o2::steer::MCKinematicsReader const& mcreader)
 
   TFile outfile("aod.root", "UPDATE");
   {
-    TableToTree t2t(mccoltable, &outfile, aod::MetadataTrait<o2::aod::McCollisions>::metadata::tableLabel());
-    t2t.addAllBranches();
-    t2t.process();
+    TableToTree t2t(&outfile, aod::MetadataTrait<o2::aod::McCollisions>::metadata::tableLabel());
+    t2t.addBranches(mccoltable.get());
+    t2t.write();
   }
 }
 
@@ -200,14 +200,14 @@ void fillCollisionAndTrackTable()
       f.Close();
       TFile outfile("aod.root", "RECREATE");
       {
-        TableToTree t2t(colltable, &outfile, aod::MetadataTrait<o2::aod::Collisions>::metadata::tableLabel());
-        t2t.addAllBranches();
-        t2t.process();
+        TableToTree t2t(&outfile, aod::MetadataTrait<o2::aod::Collisions>::metadata::tableLabel());
+        t2t.addBranches(colltable.get());
+        t2t.write();
       }
       {
-        TableToTree t2t(tracktable, &outfile, "Tracks" /* aod::MetadataTrait<o2::aod::Tracks>::metadata::tableLabel() */);
-        t2t.addAllBranches();
-        t2t.process();
+        TableToTree t2t(&outfile, "Tracks" /* aod::MetadataTrait<o2::aod::Tracks>::metadata::tableLabel() */);
+        t2t.addBranches(tracktable.get());
+        t2t.write();
       }
     }
   }

--- a/Framework/AnalysisSupport/src/AODJAlienReaderHelpers.cxx
+++ b/Framework/AnalysisSupport/src/AODJAlienReaderHelpers.cxx
@@ -186,7 +186,7 @@ AlgorithmSpec AODJAlienReaderHelpers::rootFileReaderCallback()
     header::DataHeader TFNumberHeader;
     std::vector<OutputRoute> requestedTables;
     std::vector<OutputRoute> routes(spec.outputs);
-    for (auto route : routes) {
+    for (auto& route : routes) {
       if (DataSpecUtils::partialMatch(route.matcher, header::DataOrigin("TFN"))) {
         auto concrete = DataSpecUtils::asConcreteDataMatcher(route.matcher);
         TFNumberHeader = header::DataHeader(concrete.description, concrete.origin, concrete.subSpec);
@@ -294,19 +294,19 @@ AlgorithmSpec AODJAlienReaderHelpers::rootFileReaderCallback()
         // fill the table
         auto colnames = getColumnNames(dh);
         t2t.setLabel(tr->GetName());
-        if (colnames.size() == 0) {
+        if (colnames.empty()) {
           totalSizeCompressed += tr->GetZipBytes();
           totalSizeUncompressed += tr->GetTotBytes();
-          t2t.addAllColumns(tr);
+          t2t.addColumns(tr);
         } else {
           for (auto& colname : colnames) {
             TBranch* branch = tr->GetBranch(colname.c_str());
             totalSizeCompressed += branch->GetZipBytes("*");
             totalSizeUncompressed += branch->GetTotBytes("*");
-            t2t.addColumn(colname.c_str());
           }
+          t2t.addColumns(tr, std::move(colnames));
         }
-        t2t.fill(tr);
+        t2t.read();
         delete tr;
 
         // needed for metrics dumping (upon next file read, or terminate due to watchdog)

--- a/Framework/Core/include/Framework/TableTreeHelpers.h
+++ b/Framework/Core/include/Framework/TableTreeHelpers.h
@@ -374,7 +374,7 @@ class TreeToTable
   {
   }
   void setLabel(const char* label);
-  void addColumns(TTree* tree, std::vector<const char*>&& names = {});
+  void addColumns(TTree* tree, std::vector<std::string>&& names = {});
   void read();
   auto finalize()
   {

--- a/Framework/Core/include/Framework/TableTreeHelpers.h
+++ b/Framework/Core/include/Framework/TableTreeHelpers.h
@@ -37,7 +37,7 @@ class ColumnToBranchBase
 {
  public:
   ColumnToBranchBase(arrow::ChunkedArray* column, arrow::Field* field, int size = 1);
-  virtual ~ColumnToBranchBase(){};
+  virtual ~ColumnToBranchBase() = default;
   void at(int64_t* pos)
   {
     mCurrentPos = pos;
@@ -242,7 +242,7 @@ class BranchToColumnBase
 {
  public:
   BranchToColumnBase(TBranch* branch, const char* name, EDataType type, int listSize);
-  virtual ~BranchToColumnBase(){};
+  virtual ~BranchToColumnBase() = default;
 
   TBranch* branch()
   {

--- a/Framework/Core/include/Framework/TableTreeHelpers.h
+++ b/Framework/Core/include/Framework/TableTreeHelpers.h
@@ -313,7 +313,7 @@ class BranchToColumn : public BranchToColumnBase
     }
     auto chunk = std::make_shared<arrow::ChunkedArray>(array);
     auto field = std::make_shared<arrow::Field>(mBranch->GetName(), arrowType);
-    return std::tie(chunk, field);
+    return std::make_pair(chunk, field);
   }
 
  private:

--- a/Framework/Core/include/Framework/TableTreeHelpers.h
+++ b/Framework/Core/include/Framework/TableTreeHelpers.h
@@ -22,97 +22,204 @@ namespace o2::framework
 {
 
 // -----------------------------------------------------------------------------
-// TableToTree allows to save the contents of a given arrow::Table to a TTree
-//  BranchIterator is used by TableToTree
+// GenericTableToTree allows to save the contents of a given arrow::Table into
+// a TTree
+// BranchFiller is used by GenericTableToTree
 //
 // To write the contents of a table ta to a tree tr on file f do:
-//  . TableToTree t2t(ta,f,treename);
-//  . t2t.addBranch(coumn1); t2t.addBranch(coumn1); ...
-//    OR
-//    t2t.addAllBranches();
-//  . t2t.process();
+//  . GenericTableToTree t2t(f,treename);
+//  . t2t.addBranches(ta);
+//    OR t2t.addBranch(column.get(), field.get()), ...;
+//  . t2t.write();
 //
 // .............................................................................
-class BranchIterator
+class ColumnToBranchBase
 {
+ public:
+  ColumnToBranchBase(arrow::ChunkedArray* column, arrow::Field* field, int size = 1);
+  virtual ~ColumnToBranchBase(){};
+  void at(int64_t* pos)
+  {
+    mCurrentPos = pos;
+    resetBuffer();
+  }
+
+ protected:
+  std::string mBranchName;
+
+  virtual void resetBuffer() = 0;
+  virtual void nextChunk() = 0;
+
+  arrow::ChunkedArray* mColumn = nullptr;
+
+  int64_t const* mCurrentPos = nullptr;
+  mutable int mFirstIndex = 0;
+  mutable int mCurrentChunk = 0;
+
+  int listSize = 1;
+};
+
+template <typename T>
+struct ROOTTypeString {
+  static constexpr char const* str = "/E";
+};
+
+template <>
+struct ROOTTypeString<bool> {
+  static constexpr char const* str = "/O";
+};
+
+template <>
+struct ROOTTypeString<uint8_t> {
+  static constexpr char const* str = "/b";
+};
+
+template <>
+struct ROOTTypeString<uint16_t> {
+  static constexpr char const* str = "/s";
+};
+
+template <>
+struct ROOTTypeString<uint32_t> {
+  static constexpr char const* str = "/i";
+};
+
+template <>
+struct ROOTTypeString<uint64_t> {
+  static constexpr char const* str = "/l";
+};
+
+template <>
+struct ROOTTypeString<int8_t> {
+  static constexpr char const* str = "/B";
+};
+
+template <>
+struct ROOTTypeString<int16_t> {
+  static constexpr char const* str = "/S";
+};
+
+template <>
+struct ROOTTypeString<int32_t> {
+  static constexpr char const* str = "/I";
+};
+
+template <>
+struct ROOTTypeString<int64_t> {
+  static constexpr char const* str = "/L";
+};
+
+template <>
+struct ROOTTypeString<float> {
+  static constexpr char const* str = "/F";
+};
+
+template <>
+struct ROOTTypeString<double> {
+  static constexpr char const* str = "/D";
+};
+
+template <typename T>
+constexpr auto ROOTTypeString_t = ROOTTypeString<T>::str;
+
+template <typename T>
+class ColumnToBranch : public ColumnToBranchBase
+{
+ public:
+  ColumnToBranch(TTree* tree, arrow::ChunkedArray* column, arrow::Field* field, int size = 1)
+    : ColumnToBranchBase(column, field, size)
+  {
+    if constexpr (std::is_pointer_v<T>) {
+      mLeaflist = mBranchName + "[" + std::to_string(listSize) + "]" + ROOTTypeString_t<std::remove_pointer_t<T>>;
+    } else {
+      mLeaflist = mBranchName + ROOTTypeString_t<T>;
+    }
+    mBranch = tree->GetBranch(mBranchName.c_str());
+    if (mBranch == nullptr) {
+      mBranch = tree->Branch(mBranchName.c_str(), (char*)nullptr, mLeaflist.c_str());
+    }
+    if constexpr (std::is_same_v<bool, std::remove_pointer_t<T>>) {
+      mCurrent = new bool[listSize];
+      mLast = mCurrent + listSize;
+      accessChunk(0);
+    } else {
+      accessChunk(0);
+    }
+  }
 
  private:
-  std::string mBranchName;    // branch name
-  arrow::ArrayVector mChunks; // chunks
-  Int_t mNumberChuncs;        // number of chunks
-  Int_t mCounterChunk;        // chunk counter
-  Int_t mNumberRows;          // number of rows
-  Int_t mCounterRow;          // row counter
+  std::string mLeaflist;
 
-  // data buffers for each data type
-  bool mStatus = false;
-  arrow::Field* mField;
-  arrow::Type::type mFieldType;
-  arrow::Type::type mElementType;
-  int32_t mNumberElements;
-  std::string mLeaflistString;
+  void resetBuffer() override
+  {
+    if constexpr (std::is_same_v<bool, std::remove_pointer_t<T>>) {
+      if (O2_BUILTIN_UNLIKELY((*mCurrentPos - mFirstIndex) * listSize >= getCurrentArray()->length())) {
+        nextChunk();
+      }
+    } else {
+      if (O2_BUILTIN_UNLIKELY((mCurrent + (*mCurrentPos - mFirstIndex) * listSize) >= mLast)) {
+        nextChunk();
+      }
+    }
+    accessChunk(*mCurrentPos);
+    mBranch->SetAddress((void*)(mCurrent + (*mCurrentPos - mFirstIndex) * listSize));
+  }
 
-  TBranch* mBranchPtr = nullptr;
+  auto getCurrentArray() const
+  {
+    if (listSize > 1) {
+      return std::static_pointer_cast<o2::soa::arrow_array_for_t<std::remove_pointer_t<T>>>(std::static_pointer_cast<arrow::FixedSizeListArray>(mColumn->chunk(mCurrentChunk))->values());
+    } else {
+      return std::static_pointer_cast<o2::soa::arrow_array_for_t<std::remove_pointer_t<T>>>(mColumn->chunk(mCurrentChunk));
+    }
+  }
 
-  char* mBranchBuffer = nullptr;
-  void* mValueBuffer = nullptr;
+  void nextChunk() override
+  {
+    mFirstIndex += getCurrentArray()->length();
+    ++mCurrentChunk;
+  }
 
-  std::shared_ptr<arrow::BooleanArray> mArray_o = nullptr;
-  //bool mBoolValueHolder;
-  bool* mVariable_o = nullptr;
+  void accessChunk(int at)
+  {
+    auto array = getCurrentArray();
+    if constexpr (std::is_same_v<bool, std::remove_pointer_t<T>>) {
+      for (auto i = 0; i < listSize; ++i) {
+        mCurrent[i] = (bool)array->Value((at - mFirstIndex) * listSize + i);
+      }
+    } else {
+      mCurrent = (std::remove_pointer_t<T>*)array->raw_values();
+      mLast = mCurrent + array->length() * listSize;
+    }
+  }
 
-  uint8_t* mVariable_ub = nullptr;
-  uint16_t* mVariable_us = nullptr;
-  uint32_t* mVariable_ui = nullptr;
-  uint64_t* mVariable_ul = nullptr;
-  int8_t* mVariable_b = nullptr;
-  int16_t* mVariable_s = nullptr;
-  int32_t* mVariable_i = nullptr;
-  int64_t* mVariable_l = nullptr;
-  float* mVariable_f = nullptr;
-  double* mVariable_d = nullptr;
-
-  // initialize a branch
-  bool initBranch(TTree* tree);
-
-  // initialize chunk ib
-  bool initDataBuffer(Int_t ib);
-
- public:
-  BranchIterator(TTree* tree, std::shared_ptr<arrow::ChunkedArray> col, std::shared_ptr<arrow::Field> field);
-  ~BranchIterator();
-
-  // has the iterator been properly initialized
-  bool getStatus();
-
-  // fills buffer with next value
-  // returns false if end of buffer reached
-  bool push();
+  mutable std::remove_pointer_t<T>* mCurrent = nullptr;
+  mutable std::remove_pointer_t<T>* mLast = nullptr;
+  TBranch* mBranch = nullptr;
 };
 
 class TableToTree
 {
+ public:
+  TableToTree(TFile* file, const char* treename);
+
+  TTree* write();
+  void addBranch(arrow::ChunkedArray* column, arrow::Field* field);
+  void addBranches(arrow::Table* table);
 
  private:
-  TTree* mTreePtr;
+  int64_t mRows = 0;
+  TTree* mTree = nullptr;
+  std::vector<std::unique_ptr<ColumnToBranchBase>> ColumnExtractors;
+};
 
-  // a list of BranchIterator
-  std::vector<std::unique_ptr<BranchIterator>> mBranchIterators;
-
-  // table to convert
-  std::shared_ptr<arrow::Table> mTable;
-
+class GenericTreeToTable
+{
  public:
-  TableToTree(std::shared_ptr<arrow::Table> table,
-              TFile* file,
-              const char* treename);
-
-  // add branches
-  bool addBranch(std::shared_ptr<arrow::ChunkedArray> col, std::shared_ptr<arrow::Field> field);
-  bool addAllBranches();
-
-  // write table to tree
-  TTree* process();
+ private:
+  std::shared_ptr<arrow::Table> mTable;
+  std::vector<std::shared_ptr<arrow::Field>> mFields;
+  std::string mTableLabel;
 };
 
 class TreeToTable

--- a/Framework/Core/src/CommonDataProcessors.cxx
+++ b/Framework/Core/src/CommonDataProcessors.cxx
@@ -289,7 +289,7 @@ DataProcessorSpec
     std::map<uint64_t, uint64_t> tfNumbers;
 
     // this functor is called once per time frame
-    return std::move([dod, tfNumbers](ProcessingContext& pc) mutable -> void {
+    return [dod, tfNumbers](ProcessingContext& pc) mutable -> void {
       LOGP(DEBUG, "======== getGlobalAODSink::processing ==========");
       LOGP(DEBUG, " processing data set with {} entries", pc.inputs().size());
 
@@ -360,8 +360,7 @@ DataProcessorSpec
         for (auto d : ds) {
           auto fileAndFolder = dod->getFileFolder(d, tfNumber);
           auto treename = fileAndFolder.folderName + d->treename;
-          TableToTree ta2tr(table,
-                            fileAndFolder.file,
+          TableToTree ta2tr(fileAndFolder.file,
                             treename.c_str());
 
           if (d->colnames.size() > 0) {
@@ -370,16 +369,16 @@ DataProcessorSpec
               auto col = table->column(idx);
               auto field = table->schema()->field(idx);
               if (idx != -1) {
-                ta2tr.addBranch(col, field);
+                ta2tr.addBranch(col.get(), field.get());
               }
             }
           } else {
-            ta2tr.addAllBranches();
+            ta2tr.addBranches(table.get());
           }
-          ta2tr.process();
+          ta2tr.write();
         }
       }
-    });
+    };
   }; // end of writerFunction
 
   // the command line options relevant for the writer are global

--- a/Framework/Core/src/TableTreeHelpers.cxx
+++ b/Framework/Core/src/TableTreeHelpers.cxx
@@ -9,86 +9,38 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 #include "Framework/TableTreeHelpers.h"
-#include <stdexcept>
 #include "Framework/Logger.h"
+#include "Framework/RuntimeError.h"
 
-#include "arrow/type_traits.h"
+#include <arrow/type_traits.h>
 #include <arrow/util/key_value_metadata.h>
 #include <TBufferFile.h>
 
 namespace o2::framework
 {
 
-namespace
-{
 // -----------------------------------------------------------------------------
 // TreeToTable allows to fill the contents of a given TTree to an arrow::Table
 //  ColumnIterator is used by TreeToTable
 //
 // To copy the contents of a tree tr to a table ta do:
-//  . TreeToTable t2t(tr);
-//  . t2t.addColumn(columnname1); t2t.addColumn(columnname2); ...
-//    OR
-//    t2t.addAllColumns();
-//  . auto ta = t2t.process();
+//  . TreeToTable t2t();
+//  . t2t.addColumns(tr, vector{name1, name2, ..}); // optional 2nd arg
+//  . auto ta = t2t.read();
 //
 // .............................................................................
-class ColumnIterator
-{
-
- private:
-  // all the possible arrow::TBuilder types
-  arrow::FixedSizeListBuilder* mTableBuilder_list = nullptr;
-
-  arrow::BooleanBuilder* mTableBuilder_o = nullptr;
-  arrow::UInt8Builder* mTableBuilder_ub = nullptr;
-  arrow::UInt16Builder* mTableBuilder_us = nullptr;
-  arrow::UInt32Builder* mTableBuilder_ui = nullptr;
-  arrow::UInt64Builder* mTableBuilder_ul = nullptr;
-  arrow::Int8Builder* mTableBuilder_b = nullptr;
-  arrow::Int16Builder* mTableBuilder_s = nullptr;
-  arrow::Int32Builder* mTableBuilder_i = nullptr;
-  arrow::Int64Builder* mTableBuilder_l = nullptr;
-  arrow::FloatBuilder* mTableBuilder_f = nullptr;
-  arrow::DoubleBuilder* mTableBuilder_d = nullptr;
-
-  bool mStatus = false;
-  EDataType mElementType;
-  int64_t mNumberElements;
-  const char* mColumnName;
-  int mPos = 0;
-  int mNumEntries = 0;
-  TBranch* mBranch = nullptr;
-
-  std::shared_ptr<arrow::Field> mField;
-  std::shared_ptr<arrow::Array> mArray;
-
- public:
-  ColumnIterator(TTree* reader, const char* colname);
-  ~ColumnIterator();
-
-  // has the iterator been properly initialized
-  bool getStatus();
-
-  // copy the contents of the associated branch to the arrow::TBuilder
-  size_t push();
-
-  // reserve enough space to push s elements without reallocating
-  void reserve(size_t s);
-
-  std::shared_ptr<arrow::Array> getArray() { return mArray; }
-  std::shared_ptr<arrow::Field> getSchema() { return mField; }
-
-  // finish the arrow::TBuilder
-  // with this mArray is prepared to be used in arrow::Table::Make
-  void finish();
-};
-} // namespace
-
 ColumnToBranchBase::ColumnToBranchBase(arrow::ChunkedArray* column, arrow::Field* field, int size)
   : mBranchName{field->name()},
     mColumn{column},
     listSize{size}
+{
+}
+
+BranchToColumnBase::BranchToColumnBase(TBranch* branch, const char* name, EDataType type, int listSize)
+  : mBranch{branch},
+    mColumnName{name},
+    mType{type},
+    mListSize{listSize}
 {
 }
 
@@ -204,335 +156,42 @@ TTree* TableToTree::write()
   return mTree;
 }
 
-// -----------------------------------------------------------------------------
-#define MAKE_LIST_BUILDER(ElementType, NumElements)                \
-  std::unique_ptr<arrow::ArrayBuilder> ValueBuilder;               \
-  arrow::MemoryPool* MemoryPool = arrow::default_memory_pool();    \
-  auto stat = MakeBuilder(MemoryPool, ElementType, &ValueBuilder); \
-  mTableBuilder_list = new arrow::FixedSizeListBuilder(            \
-    MemoryPool,                                                    \
-    std::move(ValueBuilder),                                       \
-    NumElements);
-
-#define MAKE_FIELD(ElementType, NumElements)                                                         \
-  if (NumElements == 1) {                                                                            \
-    mField =                                                                                         \
-      std::make_shared<arrow::Field>(mColumnName, ElementType);                                      \
-  } else {                                                                                           \
-    mField =                                                                                         \
-      std::make_shared<arrow::Field>(mColumnName, arrow::fixed_size_list(ElementType, NumElements)); \
-  }
-
-#define MAKE_FIELD_AND_BUILDER(ElementCType, NumElements, Builder)                                                                            \
-  MAKE_FIELD(arrow::TypeTraits<arrow::CTypeTraits<ElementCType>::ArrowType>::type_singleton(), NumElements);                                  \
-  if (NumElements == 1) {                                                                                                                     \
-    arrow::MemoryPool* MemoryPool = arrow::default_memory_pool();                                                                             \
-    Builder = new arrow::TypeTraits<arrow::CTypeTraits<ElementCType>::ArrowType>::BuilderType(MemoryPool);                                    \
-  } else {                                                                                                                                    \
-    MAKE_LIST_BUILDER(arrow::TypeTraits<arrow::CTypeTraits<ElementCType>::ArrowType>::type_singleton(), NumElements);                         \
-    Builder = static_cast<arrow::TypeTraits<arrow::CTypeTraits<ElementCType>::ArrowType>::BuilderType*>(mTableBuilder_list->value_builder()); \
-  }
-
-// is used in TreeToTable
-ColumnIterator::ColumnIterator(TTree* tree, const char* colname)
+void TreeToTable::addColumns(TTree* tree, std::vector<const char*>&& names)
 {
-  mBranch = tree->GetBranch(colname);
-  mNumEntries = mBranch->GetEntries();
-
-  if (!mBranch) {
-    LOGP(WARNING, "Can not locate branch {}", colname);
-    return;
+  auto branches = tree->GetListOfBranches();
+  auto n = branches->GetEntries();
+  if (n == 0) {
+    throw runtime_error("Tree has no branches");
   }
-  mColumnName = colname;
+  if (names.empty()) {
 
-  // type of the branch elements
-  TClass* cl;
-  mBranch->GetExpectedType(cl, mElementType);
-
-  // currently only single-value or single-array branches are accepted
-  // thus of the form e.g. alpha/D or alpha[5]/D
-  // check if this is a single-value or single-array branch
-  mNumberElements = 1;
-  std::string branchTitle = mBranch->GetTitle();
-  Int_t pos0 = branchTitle.find("[");
-  Int_t pos1 = branchTitle.find("]");
-  if (pos0 > 0 && pos1 > 0) {
-    mNumberElements = atoi(branchTitle.substr(pos0 + 1, pos1 - pos0 - 1).c_str());
-  }
-
-  // initialize the TTreeReaderValue<T> / TTreeReaderArray<T>
-  //            the corresponding arrow::TBuilder
-  //            the column field
-  // the TTreeReaderValue is incremented by reader->Next()
-  // switch according to mElementType
-  mStatus = true;
-
-  if (mNumberElements == 1) {
-    switch (mElementType) {
-      case EDataType::kBool_t:
-        MAKE_FIELD_AND_BUILDER(bool, 1, mTableBuilder_o);
-        break;
-      case EDataType::kUChar_t:
-        MAKE_FIELD_AND_BUILDER(uint8_t, 1, mTableBuilder_ub);
-        break;
-      case EDataType::kUShort_t:
-        MAKE_FIELD_AND_BUILDER(uint16_t, 1, mTableBuilder_us);
-        break;
-      case EDataType::kUInt_t:
-        MAKE_FIELD_AND_BUILDER(uint32_t, 1, mTableBuilder_ui);
-        break;
-      case EDataType::kULong64_t:
-        MAKE_FIELD_AND_BUILDER(uint64_t, 1, mTableBuilder_ul);
-        break;
-      case EDataType::kChar_t:
-        MAKE_FIELD_AND_BUILDER(int8_t, 1, mTableBuilder_b);
-        break;
-      case EDataType::kShort_t:
-        MAKE_FIELD_AND_BUILDER(int16_t, 1, mTableBuilder_s);
-        break;
-      case EDataType::kInt_t:
-        MAKE_FIELD_AND_BUILDER(int32_t, 1, mTableBuilder_i);
-        break;
-      case EDataType::kLong64_t:
-        MAKE_FIELD_AND_BUILDER(int64_t, 1, mTableBuilder_l);
-        break;
-      case EDataType::kFloat_t:
-        MAKE_FIELD_AND_BUILDER(float, 1, mTableBuilder_f);
-        break;
-      case EDataType::kDouble_t:
-        MAKE_FIELD_AND_BUILDER(double, 1, mTableBuilder_d);
-        break;
-      default:
-        LOGP(FATAL, "Type {} not handled!", mElementType);
-        break;
+    for (auto i = 0; i < n; ++i) {
+      auto branch = static_cast<TBranch*>(branches->At(i));
+      AddReader(branch, branch->GetName());
     }
   } else {
-    switch (mElementType) {
-      case EDataType::kBool_t:
-        MAKE_FIELD_AND_BUILDER(bool, mNumberElements, mTableBuilder_o);
-        break;
-      case EDataType::kUChar_t:
-        MAKE_FIELD_AND_BUILDER(uint8_t, mNumberElements, mTableBuilder_ub);
-        break;
-      case EDataType::kUShort_t:
-        MAKE_FIELD_AND_BUILDER(uint16_t, mNumberElements, mTableBuilder_us);
-        break;
-      case EDataType::kUInt_t:
-        MAKE_FIELD_AND_BUILDER(uint32_t, mNumberElements, mTableBuilder_ui);
-        break;
-      case EDataType::kULong64_t:
-        MAKE_FIELD_AND_BUILDER(uint64_t, mNumberElements, mTableBuilder_ul);
-        break;
-      case EDataType::kChar_t:
-        MAKE_FIELD_AND_BUILDER(int8_t, mNumberElements, mTableBuilder_b);
-        break;
-      case EDataType::kShort_t:
-        MAKE_FIELD_AND_BUILDER(int16_t, mNumberElements, mTableBuilder_s);
-        break;
-      case EDataType::kInt_t:
-        MAKE_FIELD_AND_BUILDER(int32_t, mNumberElements, mTableBuilder_i);
-        break;
-      case EDataType::kLong64_t:
-        MAKE_FIELD_AND_BUILDER(int64_t, mNumberElements, mTableBuilder_l);
-        break;
-      case EDataType::kFloat_t:
-        MAKE_FIELD_AND_BUILDER(float, mNumberElements, mTableBuilder_f);
-        break;
-      case EDataType::kDouble_t:
-        MAKE_FIELD_AND_BUILDER(double, mNumberElements, mTableBuilder_d);
-        break;
-      default:
-        LOGP(FATAL, "Type {} not handled!", mElementType);
-        break;
+    for (auto i = 0; i < n; ++i) {
+      auto branch = static_cast<TBranch*>(branches->At(i));
+      auto lookup = std::find_if(names.begin(), names.end(), [&](auto name) { return name == branch->GetName(); });
+      if (lookup != names.end()) {
+        AddReader(branch, branch->GetName());
+      }
+      if (mBranchReaders.size() != names.size()) {
+        LOGF(warn, "Not all requested columns were found in the tree");
+      }
     }
   }
-}
-
-ColumnIterator::~ColumnIterator()
-{
-  if (mTableBuilder_list) {
-    delete mTableBuilder_list;
-  } else {
-    delete mTableBuilder_o;
-    delete mTableBuilder_ub;
-    delete mTableBuilder_us;
-    delete mTableBuilder_ui;
-    delete mTableBuilder_ul;
-    delete mTableBuilder_b;
-    delete mTableBuilder_s;
-    delete mTableBuilder_i;
-    delete mTableBuilder_l;
-    delete mTableBuilder_f;
-    delete mTableBuilder_d;
+  if (mBranchReaders.empty()) {
+    throw runtime_error("No columns will be read");
   }
-};
-
-bool ColumnIterator::getStatus()
-{
-  return mStatus;
-}
-
-void ColumnIterator::reserve(size_t s)
-{
-  arrow::Status stat;
-  if (mNumberElements != 1) {
-    stat = mTableBuilder_list->Reserve(s);
+  tree->SetCacheSize(50000000);
+  // FIXME: see https://github.com/root-project/root/issues/8962 and enable
+  // again once fixed.
+  //tree->SetClusterPrefetch(true);
+  for (auto& reader : mBranchReaders) {
+    tree->AddBranchToCache(reader->branch());
   }
-
-  switch (mElementType) {
-    case EDataType::kBool_t:
-      stat = mTableBuilder_o->Reserve(s * mNumberElements);
-      break;
-    case EDataType::kUChar_t:
-      stat = mTableBuilder_ub->Reserve(s * mNumberElements);
-      break;
-    case EDataType::kUShort_t:
-      stat = mTableBuilder_us->Reserve(s * mNumberElements);
-      break;
-    case EDataType::kUInt_t:
-      stat = mTableBuilder_ui->Reserve(s * mNumberElements);
-      break;
-    case EDataType::kULong64_t:
-      stat = mTableBuilder_ul->Reserve(s * mNumberElements);
-      break;
-    case EDataType::kChar_t:
-      stat = mTableBuilder_b->Reserve(s * mNumberElements);
-      break;
-    case EDataType::kShort_t:
-      stat = mTableBuilder_s->Reserve(s * mNumberElements);
-      break;
-    case EDataType::kInt_t:
-      stat = mTableBuilder_i->Reserve(s * mNumberElements);
-      break;
-    case EDataType::kLong64_t:
-      stat = mTableBuilder_l->Reserve(s * mNumberElements);
-      break;
-    case EDataType::kFloat_t:
-      stat = mTableBuilder_f->Reserve(s * mNumberElements);
-      break;
-    case EDataType::kDouble_t:
-      stat = mTableBuilder_d->Reserve(s * mNumberElements);
-      break;
-    default:
-      LOGP(FATAL, "Type {} not handled!", mElementType);
-      break;
-  }
-}
-
-template <typename T, typename Builder>
-arrow::Status appendValues(Builder builder, TBuffer& buffer, int64_t size)
-{
-  return builder->AppendValues(reinterpret_cast<T const*>(buffer.GetCurrent()), size, nullptr);
-}
-
-size_t ColumnIterator::push()
-{
-  arrow::Status stat;
-
-  static TBufferFile buffer{TBuffer::EMode::kWrite, 4 * 1024 * 1024};
-  buffer.Reset();
-  auto size = mBranch->GetBulkRead().GetBulkEntries(mPos, buffer);
-  if (size < 0) {
-    return 0;
-  }
-  if ((mPos + size) > mNumEntries) {
-    size = mNumEntries - mPos;
-  }
-  mPos += size;
-
-  // switch according to mElementType
-  switch (mElementType) {
-    case EDataType::kBool_t:
-      stat = appendValues<unsigned char>(mTableBuilder_o, buffer, size * mNumberElements);
-      break;
-    case EDataType::kUChar_t:
-      stat = appendValues<unsigned char>(mTableBuilder_ub, buffer, size * mNumberElements);
-      break;
-    case EDataType::kUShort_t:
-      stat = appendValues<unsigned short>(mTableBuilder_us, buffer, size * mNumberElements);
-      break;
-    case EDataType::kUInt_t:
-      stat = appendValues<unsigned int>(mTableBuilder_ui, buffer, size * mNumberElements);
-      break;
-    case EDataType::kULong64_t:
-      stat = appendValues<uint64_t>(mTableBuilder_ul, buffer, size * mNumberElements);
-      break;
-    case EDataType::kChar_t:
-      stat = appendValues<signed char>(mTableBuilder_b, buffer, size * mNumberElements);
-      break;
-    case EDataType::kShort_t:
-      stat = appendValues<short>(mTableBuilder_s, buffer, size * mNumberElements);
-      break;
-    case EDataType::kInt_t:
-      stat = appendValues<int>(mTableBuilder_i, buffer, size * mNumberElements);
-      break;
-    case EDataType::kLong64_t:
-      stat = appendValues<int64_t>(mTableBuilder_l, buffer, size * mNumberElements);
-      break;
-    case EDataType::kFloat_t:
-      stat = appendValues<float>(mTableBuilder_f, buffer, size * mNumberElements);
-      break;
-    case EDataType::kDouble_t:
-      stat = appendValues<double>(mTableBuilder_d, buffer, size * mNumberElements);
-      break;
-    default:
-      LOGP(FATAL, "Type {} not handled!", mElementType);
-      break;
-  }
-  if (mNumberElements != 1) {
-    stat = mTableBuilder_list->AppendValues(size);
-  }
-  return size;
-}
-
-void ColumnIterator::finish()
-{
-  arrow::Status stat;
-
-  if (mNumberElements != 1) {
-    stat = mTableBuilder_list->Finish(&mArray);
-    return;
-  }
-
-  // switch according to mElementType
-    switch (mElementType) {
-      case EDataType::kBool_t:
-        stat = mTableBuilder_o->Finish(&mArray);
-        break;
-      case EDataType::kUChar_t:
-        stat = mTableBuilder_ub->Finish(&mArray);
-        break;
-      case EDataType::kUShort_t:
-        stat = mTableBuilder_us->Finish(&mArray);
-        break;
-      case EDataType::kUInt_t:
-        stat = mTableBuilder_ui->Finish(&mArray);
-        break;
-      case EDataType::kULong64_t:
-        stat = mTableBuilder_ul->Finish(&mArray);
-        break;
-      case EDataType::kChar_t:
-        stat = mTableBuilder_b->Finish(&mArray);
-        break;
-      case EDataType::kShort_t:
-        stat = mTableBuilder_s->Finish(&mArray);
-        break;
-      case EDataType::kInt_t:
-        stat = mTableBuilder_i->Finish(&mArray);
-        break;
-      case EDataType::kLong64_t:
-        stat = mTableBuilder_l->Finish(&mArray);
-        break;
-      case EDataType::kFloat_t:
-        stat = mTableBuilder_f->Finish(&mArray);
-        break;
-      case EDataType::kDouble_t:
-        stat = mTableBuilder_d->Finish(&mArray);
-        break;
-      default:
-        LOGP(FATAL, "Type {} not handled!", mElementType);
-        break;
-    }
+  tree->StopCacheLearningPhase();
 }
 
 void TreeToTable::setLabel(const char* label)
@@ -540,76 +199,64 @@ void TreeToTable::setLabel(const char* label)
   mTableLabel = label;
 }
 
-void TreeToTable::addColumn(const char* colname)
+void TreeToTable::read()
 {
-  mColumnNames.push_back(colname);
+  std::vector<std::shared_ptr<arrow::ChunkedArray>> columns;
+  std::vector<std::shared_ptr<arrow::Field>> fields;
+  for (auto& reader : mBranchReaders) {
+    static TBufferFile buffer{TBuffer::EMode::kWrite, 4 * 1024 * 1024};
+    buffer.Reset();
+    auto chunkAndField = reader->read(&buffer);
+    columns.push_back(chunkAndField.first);
+    fields.push_back(chunkAndField.second);
+  }
+  auto schema = std::make_shared<arrow::Schema>(fields, std::make_shared<arrow::KeyValueMetadata>(std::vector{std::string{"label"}}, std::vector{mTableLabel}));
+  mTable = arrow::Table::Make(schema, columns);
 }
 
-bool TreeToTable::addAllColumns(TTree* tree)
+void TreeToTable::AddReader(TBranch* branch, const char* name)
 {
-  auto branchList = tree->GetListOfBranches();
-
-  // loop over branches
-  if (branchList->IsEmpty()) {
-    return false;
+  static TClass* cls;
+  EDataType type;
+  branch->GetExpectedType(cls, type);
+  auto listSize = static_cast<TLeaf*>(branch->GetListOfLeaves()->At(0))->GetLenStatic();
+  switch (type) {
+    case EDataType::kBool_t:
+      mBranchReaders.emplace_back(std::make_unique<BranchToColumn<bool>>(branch, name, type, listSize));
+      break;
+    case EDataType::kUChar_t:
+      mBranchReaders.emplace_back(std::make_unique<BranchToColumn<uint8_t>>(branch, name, type, listSize));
+      break;
+    case EDataType::kUShort_t:
+      mBranchReaders.emplace_back(std::make_unique<BranchToColumn<uint16_t>>(branch, name, type, listSize));
+      break;
+    case EDataType::kUInt_t:
+      mBranchReaders.emplace_back(std::make_unique<BranchToColumn<uint32_t>>(branch, name, type, listSize));
+      break;
+    case EDataType::kULong64_t:
+      mBranchReaders.emplace_back(std::make_unique<BranchToColumn<uint64_t>>(branch, name, type, listSize));
+      break;
+    case EDataType::kChar_t:
+      mBranchReaders.emplace_back(std::make_unique<BranchToColumn<int8_t>>(branch, name, type, listSize));
+      break;
+    case EDataType::kShort_t:
+      mBranchReaders.emplace_back(std::make_unique<BranchToColumn<int16_t>>(branch, name, type, listSize));
+      break;
+    case EDataType::kInt_t:
+      mBranchReaders.emplace_back(std::make_unique<BranchToColumn<int32_t>>(branch, name, type, listSize));
+      break;
+    case EDataType::kLong64_t:
+      mBranchReaders.emplace_back(std::make_unique<BranchToColumn<int64_t>>(branch, name, type, listSize));
+      break;
+    case EDataType::kFloat_t:
+      mBranchReaders.emplace_back(std::make_unique<BranchToColumn<float>>(branch, name, type, listSize));
+      break;
+    case EDataType::kDouble_t:
+      mBranchReaders.emplace_back(std::make_unique<BranchToColumn<double>>(branch, name, type, listSize));
+      break;
+    default:
+      throw runtime_error("Unsupported branch type");
   }
-  for (Int_t ii = 0; ii < branchList->GetEntries(); ii++) {
-    auto br = (TBranch*)branchList->At(ii);
-
-    // IMPROVE: make sure that a column is not added more than one time
-    mColumnNames.push_back(br->GetName());
-  }
-  return true;
-}
-
-void TreeToTable::fill(TTree* tree)
-{
-  std::vector<std::unique_ptr<ColumnIterator>> columnIterators;
-
-  tree->SetCacheSize(50000000);
-  // FIXME: see https://github.com/root-project/root/issues/8962 and enable
-  // again once fixed.
-  //tree->SetClusterPrefetch(true);
-  for (auto&& columnName : mColumnNames) {
-    tree->AddBranchToCache(columnName.c_str(), true);
-    auto colit = std::make_unique<ColumnIterator>(tree, columnName.c_str());
-    auto stat = colit->getStatus();
-    if (!stat) {
-      throw std::runtime_error("Unable to convert column " + columnName);
-    }
-    columnIterators.push_back(std::move(colit));
-  }
-  tree->StopCacheLearningPhase();
-  auto numEntries = tree->GetEntries();
-  if (numEntries > 0) {
-
-    for (size_t ci = 0; ci < columnIterators.size(); ++ci) {
-      auto& column = columnIterators[ci];
-      auto& columnName = mColumnNames[ci];
-      column->reserve(numEntries);
-      while (column->push() != 0) {
-      }
-    }
-  }
-
-  // prepare the elements needed to create the final table
-  std::vector<std::shared_ptr<arrow::Array>> array_vector;
-  std::vector<std::shared_ptr<arrow::Field>> schema_vector;
-  for (auto&& colit : columnIterators) {
-    colit->finish();
-    array_vector.push_back(colit->getArray());
-    schema_vector.push_back(colit->getSchema());
-  }
-  auto fields = std::make_shared<arrow::Schema>(schema_vector, std::make_shared<arrow::KeyValueMetadata>(std::vector{std::string{"label"}}, std::vector{mTableLabel}));
-
-  // create the final table
-  // ta is of type std::shared_ptr<arrow::Table>
-  mTable = (arrow::Table::Make(fields, array_vector));
-}
-
-std::shared_ptr<arrow::Table> TreeToTable::finalize()
-{
-  return mTable;
 }
 
 } // namespace o2::framework

--- a/Framework/Core/src/TableTreeHelpers.cxx
+++ b/Framework/Core/src/TableTreeHelpers.cxx
@@ -156,7 +156,7 @@ TTree* TableToTree::write()
   return mTree;
 }
 
-void TreeToTable::addColumns(TTree* tree, std::vector<const char*>&& names)
+void TreeToTable::addColumns(TTree* tree, std::vector<std::string>&& names)
 {
   auto branches = tree->GetListOfBranches();
   auto n = branches->GetEntries();

--- a/Framework/Core/test/benchmark_TableToTree.cxx
+++ b/Framework/Core/test/benchmark_TableToTree.cxx
@@ -61,10 +61,9 @@ static void BM_TableToTree(benchmark::State& state)
     TFile fout("table2tree.root", "RECREATE");
 
     // benchmark TableToTree
-    TableToTree ta2tr(table, &fout, "table2tree");
-    if (ta2tr.addAllBranches()) {
-      ta2tr.process();
-    }
+    TableToTree ta2tr(&fout, "table2tree");
+    ta2tr.addBranches(table.get());
+    ta2tr.write();
 
     // clean up
     fout.Close();

--- a/Framework/Core/test/benchmark_TreeToTable.cxx
+++ b/Framework/Core/test/benchmark_TreeToTable.cxx
@@ -74,10 +74,9 @@ static void BM_TreeToTable(benchmark::State& state)
     // benchmark TreeToTable
     if (tr) {
       tr2ta = new TreeToTable;
-      if (tr2ta->addAllColumns(tr)) {
-        tr2ta->fill(tr);
-        auto ta = tr2ta->finalize();
-      }
+      tr2ta->addColumns(tr);
+      tr2ta->read();
+      auto ta = tr2ta->finalize();
 
     } else {
       LOG(INFO) << "tree is empty!";

--- a/Framework/Core/test/benchmark_TreeToTable.cxx
+++ b/Framework/Core/test/benchmark_TreeToTable.cxx
@@ -57,9 +57,9 @@ static void BM_TreeToTable(benchmark::State& state)
 
   // now convert the table to a tree
   TFile fout("tree2table.root", "RECREATE");
-  TableToTree ta2tr(table, &fout, "tree2table");
-  ta2tr.addAllBranches();
-  ta2tr.process();
+  TableToTree ta2tr(&fout, "tree2table");
+  ta2tr.addBranches(table.get());
+  ta2tr.write();
   fout.Close();
 
   // read tree and convert to table again

--- a/Framework/Core/test/test_TreeToTable.cxx
+++ b/Framework/Core/test/test_TreeToTable.cxx
@@ -96,15 +96,17 @@ BOOST_AUTO_TEST_CASE(TreeToTableConversion)
   BOOST_REQUIRE_EQUAL(table->Validate().ok(), true);
   BOOST_REQUIRE_EQUAL(table->num_rows(), ndp);
   BOOST_REQUIRE_EQUAL(table->num_columns(), ncols);
-  BOOST_REQUIRE_EQUAL(table->column(0)->type()->id(), arrow::boolean()->id());
-  BOOST_REQUIRE_EQUAL(table->column(1)->type()->id(), arrow::float32()->id());
-  BOOST_REQUIRE_EQUAL(table->column(2)->type()->id(), arrow::float32()->id());
-  BOOST_REQUIRE_EQUAL(table->column(3)->type()->id(), arrow::float32()->id());
-  BOOST_REQUIRE_EQUAL(table->column(4)->type()->id(), arrow::float64()->id());
-  BOOST_REQUIRE_EQUAL(table->column(5)->type()->id(), arrow::int32()->id());
-  BOOST_REQUIRE_EQUAL(table->column(6)->type()->id(), arrow::fixed_size_list(arrow::float64(), nelem)->id());
-  BOOST_REQUIRE_EQUAL(table->column(7)->type()->id(), arrow::fixed_size_list(arrow::float32(), 96)->id());
-  BOOST_REQUIRE_EQUAL(table->column(8)->type()->id(), arrow::fixed_size_list(arrow::boolean(), 5)->id());
+
+  BOOST_REQUIRE_EQUAL(table->column(0)->type()->id(), arrow::Type::type::BOOL);
+  BOOST_REQUIRE_EQUAL(table->column(1)->type()->id(), arrow::Type::type::FLOAT);
+  BOOST_REQUIRE_EQUAL(table->column(2)->type()->id(), arrow::Type::type::FLOAT);
+  BOOST_REQUIRE_EQUAL(table->column(3)->type()->id(), arrow::Type::type::FLOAT);
+  BOOST_REQUIRE_EQUAL(table->column(4)->type()->id(), arrow::Type::type::DOUBLE);
+  BOOST_REQUIRE_EQUAL(table->column(5)->type()->id(), arrow::Type::type::INT32);
+  BOOST_REQUIRE_EQUAL(table->column(6)->type()->id(), arrow::Type::type::FIXED_SIZE_LIST);
+  BOOST_REQUIRE_EQUAL(table->column(7)->type()->id(), arrow::Type::type::FIXED_SIZE_LIST);
+  BOOST_REQUIRE_EQUAL(table->column(8)->type()->id(), arrow::Type::type::FIXED_SIZE_LIST);
+  BOOST_REQUIRE_EQUAL(table->column(9)->type()->id(), arrow::Type::UINT8);
 
   // count number of rows with ok==true
   int ntrueout = 0;
@@ -134,11 +136,11 @@ BOOST_AUTO_TEST_CASE(TreeToTableConversion)
   BOOST_REQUIRE_EQUAL(ntruein[1], ntrueout);
 
   // save table as tree
-  TFile* f2 = new TFile("table2tree.root", "RECREATE");
-  TableToTree ta2tr(table, f2, "mytree");
-  stat = ta2tr.addAllBranches();
+  auto* f2 = TFile::Open("table2tree.root", "RECREATE");
+  TableToTree ta2tr(f2, "mytree");
+  ta2tr.addBranches(table.get());
 
-  auto t2 = ta2tr.process();
+  auto t2 = ta2tr.write();
   auto br = (TBranch*)t2->GetBranch("ok");
   BOOST_REQUIRE_EQUAL(t2->GetEntries(), ndp);
   BOOST_REQUIRE_EQUAL(br->GetEntries(), ndp);

--- a/Framework/Core/test/test_TreeToTable.cxx
+++ b/Framework/Core/test/test_TreeToTable.cxx
@@ -80,16 +80,10 @@ BOOST_AUTO_TEST_CASE(TreeToTableConversion)
   }
   t1.Write();
 
-  // Create an arrow table from this.
-  TreeToTable tr2ta;
-  auto stat = tr2ta.addAllColumns(&t1);
-  if (!stat) {
-    LOG(ERROR) << "Table was not created!";
-    return;
-  }
-
-  tr2ta.fill(&t1);
-  auto table = tr2ta.finalize();
+  TreeToTable t2t{};
+  t2t.addColumns(&t1);
+  t2t.read();
+  auto table = t2t.finalize();
   f1.Close();
 
   // test result


### PR DESCRIPTION
Classes are rewritten to be more generic and to allow later extension of supported column/branch types. Table reader, TreeToTable, gets initial support for specifying memory pool for table allocation from outside. 

Relevant benchmarks and tests are updated.