### PR TITLE
Optionally read remote CTFs w/o copy (as root network file)

### DIFF
--- a/Common/Utils/include/CommonUtils/FileFetcher.h
+++ b/Common/Utils/include/CommonUtils/FileFetcher.h
@@ -99,6 +99,7 @@ class FileFetcher
   size_t mNRemote{0};
   size_t mMaxInQueue{5};
   bool mRunning = false;
+  bool mNoRemoteCopy = false;
   size_t mMaxLoops = 0;
   size_t mNLoops = 0;
   size_t mNFilesProc = 0;

--- a/Common/Utils/src/FileFetcher.cxx
+++ b/Common/Utils/src/FileFetcher.cxx
@@ -38,22 +38,27 @@ FileFetcher::FileFetcher(const std::string& input, const std::string& selRegex, 
   if (!remRegex.empty()) {
     mRemRegex = std::make_unique<std::regex>(remRegex);
   }
+  mNoRemoteCopy = mCopyCmd == "no-copy";
+
   // parse input list
   mCopyDirName = o2::utils::Str::create_unique_path(mCopyDirName, 8);
   processInput(input);
   LOGP(INFO, "Input contains {} files, {} remote", getNFiles(), mNRemote);
   if (mNRemote) {
-    // make sure the copy command is provided
-    if (mCopyCmd.find("?src") == std::string::npos || mCopyCmd.find("?dst") == std::string::npos) {
-      throw std::runtime_error(fmt::format("remote files asked but copy cmd \"{}\" is not valid", mCopyCmd));
+    if (mNoRemoteCopy) { // make sure the copy command is provided, unless copy was explicitly forbidden
+      LOGP(INFO, "... but their local copying is explicitly forbidden");
+    } else {
+      if (mCopyCmd.find("?src") == std::string::npos || mCopyCmd.find("?dst") == std::string::npos) {
+        throw std::runtime_error(fmt::format("remote files asked but copy cmd \"{}\" is not valid", mCopyCmd));
+      }
+      try {
+        fs::create_directories(mCopyDirName);
+      } catch (...) {
+        throw std::runtime_error(fmt::format("failed to create scratch directory {}", mCopyDirName));
+      }
+      mCopyCmdLogFile = fmt::format("{}/{}", mCopyDirName, "copy-cmd.log");
+      LOGP(INFO, "FileFetcher tmp scratch directory is set to {}", mCopyDirName);
     }
-    try {
-      fs::create_directories(mCopyDirName);
-    } catch (...) {
-      throw std::runtime_error(fmt::format("failed to create scratch directory {}", mCopyDirName));
-    }
-    mCopyCmdLogFile = fmt::format("{}/{}", mCopyDirName, "copy-cmd.log");
-    LOGP(INFO, "FileFetcher tmp scratch directory is set to {}", mCopyDirName);
   }
 }
 
@@ -121,7 +126,7 @@ void FileFetcher::processDirectory(const std::string& name)
 bool FileFetcher::addInputFile(const std::string& fname)
 {
   if (mRemRegex && std::regex_match(fname, *mRemRegex.get())) {
-    mInputFiles.emplace_back(FileRef{fname, createCopyName(fname), true, false});
+    mInputFiles.emplace_back(FileRef{fname, mNoRemoteCopy ? fname : createCopyName(fname), true, false});
     mNRemote++;
   } else if (fs::exists(fname)) { // local file
     mInputFiles.emplace_back(FileRef{fname, "", false, false});
@@ -223,6 +228,11 @@ void FileFetcher::fetcher()
   // data fetching/copying thread
   size_t fileEntry = -1ul;
 
+  if (!getNFiles()) {
+    mRunning = false;
+    return;
+  }
+
   while (mRunning) {
     mNLoops = mNFilesProc / getNFiles();
     if (mNLoops > mMaxLoops) {
@@ -241,7 +251,7 @@ void FileFetcher::fetcher()
     }
     mNFilesProc++;
     auto& fileRef = mInputFiles[fileEntry];
-    if (fileRef.copied || !fileRef.remote) {
+    if (fileRef.copied || !fileRef.remote || mNoRemoteCopy) {
       mQueue.push(fileEntry);
       mNFilesProcOK++;
     } else { // need to copy

--- a/Detectors/CTF/README.md
+++ b/Detectors/CTF/README.md
@@ -81,7 +81,7 @@ delay in seconds between consecutive CTFs sending (depends also on file fetching
 ```
 --copy-cmd arg (=XrdSecPROTOCOL=sss,unix xrdcp -N root://eosaliceo2.cern.ch/?src ?dst)
 ```
-copy command for remote files
+copy command for remote files or `no-copy` to avoid copying
 
 ```
 --ctf-file-regex arg (=.+o2_ctf_run.+\.root$)
@@ -97,6 +97,12 @@ regex string to identify remote files
 --max-cached-files arg (=3)
 ```
 max CTF files queued (copied for remote source).
+
+There is a possibility to read remote root files directly, w/o caching them locally. For that one should:
+1) provide the full URL the remote files, e.g. if the files are supposed to be accessed by `xrootd` (the `XrdSecPROTOCOL` and `XrdSecSSSKT` env. variables should be set up in advance), use
+`root://eosaliceo2.cern.ch//eos/aliceo2/ls2data/...root` (use `xrdfs root://eosaliceo2.cern.ch ls -u <path>` to list full URL).
+2) provide proper regex to define remote files, e.g. for the example above: `--remote-regex "^root://.+/eos/aliceo2/.+"`.
+3) pass an option `--copy-cmd no-copy`.
 
 For the ITS and MFT entropy decoding one can request either to decompose clusters to digits and send them instead of clusters (via `o2-ctf-reader-workflow` global options `--its-digits` and `--mft-digits` respectively)
 or to apply the noise mask to decoded clusters (or decoded digits). If the masking (e.g. via option `--its-entropy-decoder " --mask-noise "`) is requested, user should provide to the entropy decoder the noise mask file (eventually will be loaded from CCDB) and cluster patterns decoding dictionary (if the clusters were encoded with patterns IDs).

--- a/Detectors/CTF/workflow/src/ctf-reader-workflow.cxx
+++ b/Detectors/CTF/workflow/src/ctf-reader-workflow.cxx
@@ -51,7 +51,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   options.push_back(ConfigParamSpec{"max-tf", VariantType::Int, -1, {"max CTFs to process (<= 0 : infinite)"}});
   options.push_back(ConfigParamSpec{"loop", VariantType::Int, 0, {"loop N times (infinite for N<0)"}});
   options.push_back(ConfigParamSpec{"delay", VariantType::Float, 0.f, {"delay in seconds between consecutive TFs sending"}});
-  options.push_back(ConfigParamSpec{"copy-cmd", VariantType::String, "XrdSecPROTOCOL=sss,unix xrdcp -N root://eosaliceo2.cern.ch/?src ?dst", {"copy command for remote files"}});
+  options.push_back(ConfigParamSpec{"copy-cmd", VariantType::String, "XrdSecPROTOCOL=sss,unix xrdcp -N root://eosaliceo2.cern.ch/?src ?dst", {"copy command for remote files or no-copy to avoid copying"}});
   options.push_back(ConfigParamSpec{"ctf-file-regex", VariantType::String, ".*o2_ctf_run.+\\.root$", {"regex string to identify CTF files"}});
   options.push_back(ConfigParamSpec{"remote-regex", VariantType::String, "^/eos/aliceo2/.+", {"regex string to identify remote files"}});
   options.push_back(ConfigParamSpec{"max-cached-files", VariantType::Int, 3, {"max CTF files queued (copied for remote source)"}});


### PR DESCRIPTION
There is a possibility to read remote root files directly, w/o caching it locally. For that one should:
1) provide the full URL the remote files, e.g. if the files are supposed to be accessed by `xrootd` (the `XrdSecPROTOCOL` and `XrdSecSSSKT` env. variables should be set up in advance): `root://eosaliceo2.cern.ch//eos/aliceo2/ls2data/...root` 
(use `xrdfs root://eosaliceo2.cern.ch ls -u <path>` to list full URL).
2) provide proper regex to define remote files, e.g. for the example above: `--remote-regex "^root://.+/eos/aliceo2/.+"`.
3) pass an option `--copy-cmd no-copy`.
