### PR TITLE
MCH: consistent specnames for DataProcessorSpec getters

### DIFF
--- a/Detectors/MUON/MCH/Calibration/src/PedestalCalibSpec.h
+++ b/Detectors/MUON/MCH/Calibration/src/PedestalCalibSpec.h
@@ -158,12 +158,7 @@ class PedestalCalibDevice : public o2::framework::Task
 namespace framework
 {
 
-std::string getMCHPedestalCalibDeviceName()
-{
-  return "calib-mch-pedestal";
-}
-
-DataProcessorSpec getMCHPedestalCalibSpec(const std::string inputSpec)
+DataProcessorSpec getMCHPedestalCalibSpec(const char* specName, const std::string inputSpec)
 {
   constexpr int64_t INFINITE_TF = 0xffffffffffffffff;
   using device = o2::mch::calibration::PedestalCalibDevice;
@@ -175,7 +170,7 @@ DataProcessorSpec getMCHPedestalCalibSpec(const std::string inputSpec)
   outputs.emplace_back(OutputSpec{"MCH", "PEDESTALS", 0, Lifetime::Timeframe});
 
   return DataProcessorSpec{
-    getMCHPedestalCalibDeviceName(),
+    specName,
     select(inputSpec.data()),
     outputs,
     AlgorithmSpec{adaptFromTask<device>()},

--- a/Detectors/MUON/MCH/Calibration/src/pedestal-calib-workflow.cxx
+++ b/Detectors/MUON/MCH/Calibration/src/pedestal-calib-workflow.cxx
@@ -17,11 +17,13 @@
 
 using namespace o2::framework;
 
+const char* specName = "mch-calib-pedestals";
+
 // customize the completion policy
 void customize(std::vector<o2::framework::CompletionPolicy>& policies)
 {
   using o2::framework::CompletionPolicy;
-  policies.push_back(CompletionPolicyHelpers::defineByName(getMCHPedestalCalibDeviceName(), CompletionPolicy::CompletionOp::Consume));
+  policies.push_back(CompletionPolicyHelpers::defineByName(specName, CompletionPolicy::CompletionOp::Consume));
 }
 
 // we need to add workflow options before including Framework/runDataProcessing
@@ -41,6 +43,6 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
   const std::string inputSpec = configcontext.options().get<std::string>("input-spec");
   WorkflowSpec specs;
-  specs.emplace_back(getMCHPedestalCalibSpec(inputSpec));
+  specs.emplace_back(getMCHPedestalCalibSpec(specName, inputSpec));
   return specs;
 }

--- a/Detectors/MUON/MCH/Calibration/src/pedestal-decoding-workflow.cxx
+++ b/Detectors/MUON/MCH/Calibration/src/pedestal-decoding-workflow.cxx
@@ -389,16 +389,13 @@ class PedestalsTask
 
 using namespace o2::framework;
 
-std::string getMCHPedestalDecodingDeviceName()
-{
-  return "mch-pedestal-decoder";
-}
+const char* specName = "mch-pedestal-decoder";
 
 // customize the completion policy
 void customize(std::vector<o2::framework::CompletionPolicy>& policies)
 {
   using o2::framework::CompletionPolicy;
-  policies.push_back(CompletionPolicyHelpers::defineByName(getMCHPedestalDecodingDeviceName(), CompletionPolicy::CompletionOp::Consume));
+  policies.push_back(CompletionPolicyHelpers::defineByName(specName, CompletionPolicy::CompletionOp::Consume));
 }
 
 void customize(std::vector<ConfigParamSpec>& workflowOptions)
@@ -413,11 +410,11 @@ using namespace o2;
 using namespace o2::framework;
 
 //_________________________________________________________________________________________________
-o2::framework::DataProcessorSpec getMCHPedestalDecodingSpec(std::string inputSpec)
+o2::framework::DataProcessorSpec getMCHPedestalDecodingSpec(const char* specName, std::string inputSpec)
 {
   //o2::mch::raw::PedestalsTask task();
   return DataProcessorSpec{
-    getMCHPedestalDecodingDeviceName(),
+    specName,
     o2::framework::select(inputSpec.c_str()),
     Outputs{OutputSpec{header::gDataOriginMCH, "PDIGITS", 0, Lifetime::Timeframe},
             OutputSpec{header::gDataOriginMCH, "ERRORS", 0, Lifetime::Timeframe}},
@@ -437,7 +434,7 @@ WorkflowSpec defineDataProcessing(const ConfigContext& config)
 
   WorkflowSpec specs;
 
-  DataProcessorSpec producer = getMCHPedestalDecodingSpec(inputSpec);
+  DataProcessorSpec producer = getMCHPedestalDecodingSpec(specName, inputSpec);
   specs.push_back(producer);
 
   return specs;

--- a/Detectors/MUON/MCH/DevIO/Digits/digits-file-reader-workflow.cxx
+++ b/Detectors/MUON/MCH/DevIO/Digits/digits-file-reader-workflow.cxx
@@ -121,7 +121,7 @@ class DigitSamplerTask : public io::DigitIOBaseTask
   }
 };
 
-o2::framework::DataProcessorSpec getDataProcessorSpec(bool run2)
+o2::framework::DataProcessorSpec getDigitsFileReaderSpec(const char* specName, bool run2)
 {
   std::string spec = fmt::format("digits:MCH/DIGITS{}/0", run2 ? "R2" : "");
   InputSpec itmp = o2::framework::select(spec.c_str())[0];
@@ -134,7 +134,7 @@ o2::framework::DataProcessorSpec getDataProcessorSpec(bool run2)
   options.insert(options.end(), commonOptions.begin(), commonOptions.end());
 
   return DataProcessorSpec{
-    "mch-digits-file-reader",
+    specName,
     Inputs{},
     Outputs{{DataSpecUtils::asOutputSpec(itmp)},
             OutputSpec{{"rofs"}, "MCH", "DIGITROFS", 0, Lifetime::Timeframe}},
@@ -142,7 +142,7 @@ o2::framework::DataProcessorSpec getDataProcessorSpec(bool run2)
     options};
 }
 
-/** add workflow options. Note that customization needs to be declared 
+/** add workflow options. Note that customization needs to be declared
 * before including Framework/runDataProcessing
 */
 void customize(std::vector<ConfigParamSpec>& workflowOptions)
@@ -156,5 +156,5 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 //_________________________________________________________________________________________________
 WorkflowSpec defineDataProcessing(const ConfigContext& cc)
 {
-  return WorkflowSpec{getDataProcessorSpec(cc.options().get<bool>(OPTNAME_RUN2))};
+  return WorkflowSpec{getDigitsFileReaderSpec("mch-digits-file-reader", cc.options().get<bool>(OPTNAME_RUN2))};
 }

--- a/Detectors/MUON/MCH/Workflow/README.md
+++ b/Detectors/MUON/MCH/Workflow/README.md
@@ -6,6 +6,7 @@
 
 <!-- vim-markdown-toc GFM -->
 
+* [A note for developers](#a-note-for-developers)
 * [Raw to digits](#raw-to-digits)
 * [Time clustering](#time-clustering)
 * [Preclustering](#preclustering)
@@ -30,6 +31,17 @@
   * [Track writer](#track-writer)
 
 <!-- vim-markdown-toc -->
+
+
+## A note for developers
+
+When defining a function that returns a `DataProcessorSpec`, please stick to the following pattern for its parameters :
+
+    DataProcessorSpec getXXX([bool useMC], const char* specName="mch-xxx", other parameters);
+
+* first parameter, if relevant, should be a boolean indicating whether the processor has to deal with Monte Carlo data or not. For a processor that never has to deal with MC, leave that parameter out
+* second parameter is the name by which that device will be referenced in all log files, so, in order to be easily recognizable, it *must* start with the prefix `mch-`
+* the rest of the parameters (if any) is specific to each device
 
 ## Raw to digits
 

--- a/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/ClusterFinderOriginalSpec.h
+++ b/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/ClusterFinderOriginalSpec.h
@@ -24,7 +24,7 @@ namespace o2
 namespace mch
 {
 
-o2::framework::DataProcessorSpec getClusterFinderOriginalSpec(const char* name = "ClusterFinderOriginal");
+o2::framework::DataProcessorSpec getClusterFinderOriginalSpec(const char* specName = "mch-cluster-finder-original");
 
 } // end namespace mch
 } // end namespace o2

--- a/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/DataDecoderSpec.h
+++ b/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/DataDecoderSpec.h
@@ -28,7 +28,7 @@ namespace mch
 namespace raw
 {
 
-o2::framework::DataProcessorSpec getDecodingSpec(std::string inputSpec = "TF:MCH/RAWDATA",
+o2::framework::DataProcessorSpec getDecodingSpec(const char* specName = "mch-data-decoder", std::string inputSpec = "TF:MCH/RAWDATA",
                                                  bool askDISTSTF = false);
 
 } // end namespace raw

--- a/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/EntropyDecoderSpec.h
+++ b/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/EntropyDecoderSpec.h
@@ -22,7 +22,7 @@ namespace o2
 namespace mch
 {
 /// create a processor spec
-framework::DataProcessorSpec getEntropyDecoderSpec();
+framework::DataProcessorSpec getEntropyDecoderSpec(const char* specName = "mch-entropy-decoder");
 
 } // namespace mch
 } // namespace o2

--- a/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/TimeClusterFinderSpec.h
+++ b/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/TimeClusterFinderSpec.h
@@ -24,7 +24,7 @@ namespace o2
 namespace mch
 {
 
-o2::framework::DataProcessorSpec getTimeClusterFinderSpec(const char* specName = "TimeClusterFinder");
+o2::framework::DataProcessorSpec getTimeClusterFinderSpec(const char* specName = "mch-time-cluster-finder");
 
 } // end namespace mch
 } // end namespace o2

--- a/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/TrackReaderSpec.h
+++ b/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/TrackReaderSpec.h
@@ -16,7 +16,7 @@
 
 namespace o2::mch
 {
-o2::framework::DataProcessorSpec getTrackReaderSpec(bool useMC, const char* name = "mch-tracks-reader");
+o2::framework::DataProcessorSpec getTrackReaderSpec(bool useMC, const char* specName = "mch-tracks-reader");
 }
 
 #endif

--- a/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/TrackWriterSpec.h
+++ b/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/TrackWriterSpec.h
@@ -16,9 +16,7 @@
 
 namespace o2::mch
 {
-o2::framework::DataProcessorSpec getTrackWriterSpec(bool useMC,
-                                                    const char* specName = "mch-track-writer",
-                                                    const char* fileName = "mchtracks.root");
+o2::framework::DataProcessorSpec getTrackWriterSpec(bool useMC, const char* specName = "mch-track-writer", const char* fileName = "mchtracks.root");
 }
 
 #endif

--- a/Detectors/MUON/MCH/Workflow/src/ClusterFinderOriginalSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/ClusterFinderOriginalSpec.cxx
@@ -136,10 +136,10 @@ class ClusterFinderOriginalTask
 };
 
 //_________________________________________________________________________________________________
-o2::framework::DataProcessorSpec getClusterFinderOriginalSpec(const char* name)
+o2::framework::DataProcessorSpec getClusterFinderOriginalSpec(const char* specName)
 {
   return DataProcessorSpec{
-    name,
+    specName,
     Inputs{InputSpec{"preclusterrofs", "MCH", "PRECLUSTERROFS", 0, Lifetime::Timeframe},
            InputSpec{"preclusters", "MCH", "PRECLUSTERS", 0, Lifetime::Timeframe},
            InputSpec{"digits", "MCH", "PRECLUSTERDIGITS", 0, Lifetime::Timeframe}},

--- a/Detectors/MUON/MCH/Workflow/src/ClusterTransformerSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/ClusterTransformerSpec.cxx
@@ -98,11 +98,11 @@ class ClusterTransformerTask
   o2::mch::geo::TransformationCreator transformation;
 };
 
-DataProcessorSpec getClusterTransformerSpec(const char* name)
+DataProcessorSpec getClusterTransformerSpec(const char* specName)
 {
   std::string inputConfig = fmt::format("rofs:MCH/CLUSTERROFS;clusters:MCH/CLUSTERS");
   return DataProcessorSpec{
-    name,
+    specName,
     Inputs{o2::framework::select(inputConfig.c_str())},
     Outputs{OutputSpec{{"globalclusters"}, "MCH", "GLOBALCLUSTERS", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<ClusterTransformerTask>()},

--- a/Detectors/MUON/MCH/Workflow/src/ClusterTransformerSpec.h
+++ b/Detectors/MUON/MCH/Workflow/src/ClusterTransformerSpec.h
@@ -15,7 +15,7 @@
 
 namespace o2::mch
 {
-o2::framework::DataProcessorSpec getClusterTransformerSpec(const char* name = "mch-cluster-transformer");
+o2::framework::DataProcessorSpec getClusterTransformerSpec(const char* specName = "mch-cluster-transformer");
 };
 
 #endif

--- a/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
@@ -89,8 +89,8 @@ class DataDecoderTask
                                useDummyElecMap);
 
     auto stop = [this]() {
-      LOG(INFO) << "decoding duration = " << mTimeDecoding.count() * 1000 / mTFcount << " us / TF";
-      LOG(INFO) << "ROF finder duration = " << mTimeROFFinder.count() * 1000 / mTFcount << " us / TF";
+      LOG(error) << "mch-data-decoder: decoding duration = " << mTimeDecoding.count() * 1000 / mTFcount << " us / TF";
+      LOG(error) << "mch-data-decoder: ROF finder duration = " << mTimeROFFinder.count() * 1000 / mTFcount << " us / TF";
     };
     ic.services().get<CallbackService>().set(CallbackService::Id::Stop, stop);
   }
@@ -301,7 +301,7 @@ class DataDecoderTask
 };
 
 //_________________________________________________________________________________________________
-o2::framework::DataProcessorSpec getDecodingSpec(std::string inputSpec,
+o2::framework::DataProcessorSpec getDecodingSpec(const char* specName, std::string inputSpec,
                                                  bool askSTFDist)
 {
   auto inputs = o2::framework::select(inputSpec.c_str());
@@ -317,7 +317,7 @@ o2::framework::DataProcessorSpec getDecodingSpec(std::string inputSpec,
   }
   o2::mch::raw::DataDecoderTask task(inputSpec);
   return DataProcessorSpec{
-    "DataDecoder",
+    specName,
     inputs,
     Outputs{OutputSpec{header::gDataOriginMCH, "DIGITS", 0, Lifetime::Timeframe},
             OutputSpec{header::gDataOriginMCH, "DIGITROFS", 0, Lifetime::Timeframe},

--- a/Detectors/MUON/MCH/Workflow/src/DigitReaderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/DigitReaderSpec.cxx
@@ -108,7 +108,7 @@ class DigitsReaderDeviceDPL
   bool mUseMC = true;
 };
 
-framework::DataProcessorSpec getDigitReaderSpec(bool useMC, const char* name)
+framework::DataProcessorSpec getDigitReaderSpec(bool useMC, const char* specName)
 {
   std::vector<of::OutputSpec> outputs;
   std::vector<header::DataDescription> descriptions;
@@ -125,7 +125,7 @@ framework::DataProcessorSpec getDigitReaderSpec(bool useMC, const char* name)
   }
 
   return of::DataProcessorSpec{
-    name,
+    specName,
     of::Inputs{},
     outputs,
     of::AlgorithmSpec{of::adaptFromTask<o2::mch::DigitsReaderDeviceDPL>(useMC, descriptions)},

--- a/Detectors/MUON/MCH/Workflow/src/DigitReaderSpec.h
+++ b/Detectors/MUON/MCH/Workflow/src/DigitReaderSpec.h
@@ -23,7 +23,7 @@ namespace o2
 {
 namespace mch
 {
-framework::DataProcessorSpec getDigitReaderSpec(bool useMC, const char* name = "mch-sim-digit-reader");
+framework::DataProcessorSpec getDigitReaderSpec(bool useMC, const char* specName = "mch-sim-digit-reader");
 }
 } // namespace o2
 

--- a/Detectors/MUON/MCH/Workflow/src/DigitSamplerSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/DigitSamplerSpec.cxx
@@ -214,10 +214,10 @@ class DigitSamplerTask
 };
 
 //_________________________________________________________________________________________________
-o2::framework::DataProcessorSpec getDigitSamplerSpec()
+o2::framework::DataProcessorSpec getDigitSamplerSpec(const char* specName)
 {
   return DataProcessorSpec{
-    "DigitSampler",
+    specName,
     Inputs{},
     Outputs{OutputSpec{{"rofs"}, "MCH", "DIGITROFS", 0, Lifetime::Timeframe},
             OutputSpec{{"digits"}, "MCH", "DIGITS", 0, Lifetime::Timeframe}},

--- a/Detectors/MUON/MCH/Workflow/src/DigitSamplerSpec.h
+++ b/Detectors/MUON/MCH/Workflow/src/DigitSamplerSpec.h
@@ -24,7 +24,7 @@ namespace o2
 namespace mch
 {
 
-o2::framework::DataProcessorSpec getDigitSamplerSpec();
+o2::framework::DataProcessorSpec getDigitSamplerSpec(const char* specName = "mch-digit-sampler");
 
 } // end namespace mch
 } // end namespace o2

--- a/Detectors/MUON/MCH/Workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/EntropyDecoderSpec.cxx
@@ -79,14 +79,14 @@ void EntropyDecoderSpec::endOfStream(EndOfStreamContext& ec)
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 
-DataProcessorSpec getEntropyDecoderSpec()
+DataProcessorSpec getEntropyDecoderSpec(const char* specName)
 {
   std::vector<OutputSpec> outputs{
     OutputSpec{{"rofs"}, "MCH", "DIGITROFS", 0, Lifetime::Timeframe},
     OutputSpec{{"digits"}, "MCH", "DIGITS", 0, Lifetime::Timeframe}};
 
   return DataProcessorSpec{
-    "mch-entropy-decoder",
+    specName,
     Inputs{InputSpec{"ctf", "MCH", "CTFDATA", 0, Lifetime::Timeframe}},
     outputs,
     AlgorithmSpec{adaptFromTask<EntropyDecoderSpec>()},

--- a/Detectors/MUON/MCH/Workflow/src/PreClusterSinkSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/PreClusterSinkSpec.cxx
@@ -196,10 +196,10 @@ class PreClusterSinkTask
 };
 
 //_________________________________________________________________________________________________
-o2::framework::DataProcessorSpec getPreClusterSinkSpec()
+o2::framework::DataProcessorSpec getPreClusterSinkSpec(const char* specName)
 {
   return DataProcessorSpec{
-    "PreClusterSink",
+    specName,
     Inputs{InputSpec{"rofs", "MCH", "PRECLUSTERROFS", 0, Lifetime::Timeframe},
            InputSpec{"preclusters", "MCH", "PRECLUSTERS", 0, Lifetime::Timeframe},
            InputSpec{"digits", "MCH", "PRECLUSTERDIGITS", 0, Lifetime::Timeframe}},

--- a/Detectors/MUON/MCH/Workflow/src/PreClusterSinkSpec.h
+++ b/Detectors/MUON/MCH/Workflow/src/PreClusterSinkSpec.h
@@ -24,7 +24,7 @@ namespace o2
 namespace mch
 {
 
-o2::framework::DataProcessorSpec getPreClusterSinkSpec();
+o2::framework::DataProcessorSpec getPreClusterSinkSpec(const char* specName = "mch-precluster-sink");
 
 } // end namespace mch
 } // end namespace o2

--- a/Detectors/MUON/MCH/Workflow/src/TrackAtVertexSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackAtVertexSpec.cxx
@@ -219,10 +219,10 @@ class TrackAtVertexTask
 };
 
 //_________________________________________________________________________________________________
-o2::framework::DataProcessorSpec getTrackAtVertexSpec(const char* name)
+o2::framework::DataProcessorSpec getTrackAtVertexSpec(const char* specName)
 {
   return DataProcessorSpec{
-    name,
+    specName,
     Inputs{InputSpec{"vertices", "MCH", "VERTICES", 0, Lifetime::Timeframe},
            InputSpec{"rofs", "MCH", "TRACKROFS", 0, Lifetime::Timeframe},
            InputSpec{"tracks", "MCH", "TRACKS", 0, Lifetime::Timeframe},

--- a/Detectors/MUON/MCH/Workflow/src/TrackAtVertexSpec.h
+++ b/Detectors/MUON/MCH/Workflow/src/TrackAtVertexSpec.h
@@ -24,7 +24,7 @@ namespace o2
 namespace mch
 {
 
-o2::framework::DataProcessorSpec getTrackAtVertexSpec(const char* name = "TrackAtVertex");
+o2::framework::DataProcessorSpec getTrackAtVertexSpec(const char* specName = "mch-track-at-vertex");
 
 } // end namespace mch
 } // end namespace o2

--- a/Detectors/MUON/MCH/Workflow/src/TrackFinderOriginalSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackFinderOriginalSpec.cxx
@@ -152,10 +152,10 @@ class TrackFinderTask
 };
 
 //_________________________________________________________________________________________________
-o2::framework::DataProcessorSpec getTrackFinderOriginalSpec()
+o2::framework::DataProcessorSpec getTrackFinderOriginalSpec(const char* specName)
 {
   return DataProcessorSpec{
-    "TrackFinderOriginal",
+    specName,
     Inputs{InputSpec{"clusterrofs", "MCH", "CLUSTERROFS", 0, Lifetime::Timeframe},
            InputSpec{"clusters", "MCH", "GLOBALCLUSTERS", 0, Lifetime::Timeframe}},
     Outputs{OutputSpec{{"trackrofs"}, "MCH", "TRACKROFS", 0, Lifetime::Timeframe},

--- a/Detectors/MUON/MCH/Workflow/src/TrackFinderOriginalSpec.h
+++ b/Detectors/MUON/MCH/Workflow/src/TrackFinderOriginalSpec.h
@@ -24,7 +24,7 @@ namespace o2
 namespace mch
 {
 
-o2::framework::DataProcessorSpec getTrackFinderOriginalSpec();
+o2::framework::DataProcessorSpec getTrackFinderOriginalSpec(const char* specName = "mch-track-finder-original");
 
 } // end namespace mch
 } // end namespace o2

--- a/Detectors/MUON/MCH/Workflow/src/TrackFinderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackFinderSpec.cxx
@@ -172,10 +172,10 @@ class TrackFinderTask
 };
 
 //_________________________________________________________________________________________________
-o2::framework::DataProcessorSpec getTrackFinderSpec(const char* name)
+o2::framework::DataProcessorSpec getTrackFinderSpec(const char* specName)
 {
   return DataProcessorSpec{
-    name,
+    specName,
     Inputs{InputSpec{"clusterrofs", "MCH", "CLUSTERROFS", 0, Lifetime::Timeframe},
            InputSpec{"clusters", "MCH", "GLOBALCLUSTERS", 0, Lifetime::Timeframe}},
     Outputs{OutputSpec{{"trackrofs"}, "MCH", "TRACKROFS", 0, Lifetime::Timeframe},

--- a/Detectors/MUON/MCH/Workflow/src/TrackFinderSpec.h
+++ b/Detectors/MUON/MCH/Workflow/src/TrackFinderSpec.h
@@ -24,7 +24,7 @@ namespace o2
 namespace mch
 {
 
-o2::framework::DataProcessorSpec getTrackFinderSpec(const char* name = "TrackFinder");
+o2::framework::DataProcessorSpec getTrackFinderSpec(const char* specName = "mch-track-finder");
 
 } // end namespace mch
 } // end namespace o2

--- a/Detectors/MUON/MCH/Workflow/src/TrackFitterSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackFitterSpec.cxx
@@ -128,10 +128,10 @@ class TrackFitterTask
 };
 
 //_________________________________________________________________________________________________
-o2::framework::DataProcessorSpec getTrackFitterSpec()
+o2::framework::DataProcessorSpec getTrackFitterSpec(const char* specName)
 {
   return DataProcessorSpec{
-    "TrackFitter",
+    specName,
     Inputs{InputSpec{"rofsin", "MCH", "TRACKROFSIN", 0, Lifetime::Timeframe},
            InputSpec{"tracksin", "MCH", "TRACKSIN", 0, Lifetime::Timeframe},
            InputSpec{"clustersin", "MCH", "TRACKCLUSTERSIN", 0, Lifetime::Timeframe}},

--- a/Detectors/MUON/MCH/Workflow/src/TrackFitterSpec.h
+++ b/Detectors/MUON/MCH/Workflow/src/TrackFitterSpec.h
@@ -24,7 +24,7 @@ namespace o2
 namespace mch
 {
 
-o2::framework::DataProcessorSpec getTrackFitterSpec();
+o2::framework::DataProcessorSpec getTrackFitterSpec(const char* specName = "mch-track-fitter");
 
 } // end namespace mch
 } // end namespace o2

--- a/Detectors/MUON/MCH/Workflow/src/TrackReaderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackReaderSpec.cxx
@@ -102,7 +102,7 @@ struct TrackReader {
   }
 };
 
-DataProcessorSpec getTrackReaderSpec(bool useMC, const char* name)
+DataProcessorSpec getTrackReaderSpec(bool useMC, const char* specName)
 {
   std::vector<OutputSpec> outputSpecs;
   outputSpecs.emplace_back(OutputSpec{{"tracks"}, "MCH", "TRACKS", 0, Lifetime::Timeframe});
@@ -117,7 +117,7 @@ DataProcessorSpec getTrackReaderSpec(bool useMC, const char* name)
   };
 
   return DataProcessorSpec{
-    name,
+    specName,
     Inputs{},
     outputSpecs,
     adaptFromTask<TrackReader>(useMC),

--- a/Detectors/MUON/MCH/Workflow/src/TrackSamplerSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackSamplerSpec.cxx
@@ -176,7 +176,7 @@ class TrackSamplerTask
 };
 
 //_________________________________________________________________________________________________
-o2::framework::DataProcessorSpec getTrackSamplerSpec(bool forTrackFitter)
+o2::framework::DataProcessorSpec getTrackSamplerSpec(const char* specName, bool forTrackFitter)
 {
   Outputs outputs{};
   if (forTrackFitter) {
@@ -190,7 +190,7 @@ o2::framework::DataProcessorSpec getTrackSamplerSpec(bool forTrackFitter)
   }
 
   return DataProcessorSpec{
-    "TrackSampler",
+    specName,
     Inputs{},
     outputs,
     AlgorithmSpec{adaptFromTask<TrackSamplerTask>()},

--- a/Detectors/MUON/MCH/Workflow/src/TrackSamplerSpec.h
+++ b/Detectors/MUON/MCH/Workflow/src/TrackSamplerSpec.h
@@ -24,7 +24,7 @@ namespace o2
 namespace mch
 {
 
-o2::framework::DataProcessorSpec getTrackSamplerSpec(bool forTrackFitter);
+o2::framework::DataProcessorSpec getTrackSamplerSpec(const char* specName, bool forTrackFitter);
 
 } // end namespace mch
 } // end namespace o2

--- a/Detectors/MUON/MCH/Workflow/src/TrackSinkSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackSinkSpec.cxx
@@ -204,7 +204,7 @@ class TrackSinkTask
 };
 
 //_________________________________________________________________________________________________
-o2::framework::DataProcessorSpec getTrackSinkSpec(bool mchTracks, bool tracksAtVtx)
+o2::framework::DataProcessorSpec getTrackSinkSpec(const char* specName, bool mchTracks, bool tracksAtVtx)
 {
   Inputs inputs{};
   if (mchTracks) {
@@ -220,7 +220,7 @@ o2::framework::DataProcessorSpec getTrackSinkSpec(bool mchTracks, bool tracksAtV
   }
 
   return DataProcessorSpec{
-    "TrackSink",
+    specName,
     inputs,
     Outputs{},
     AlgorithmSpec{adaptFromTask<TrackSinkTask>()},

--- a/Detectors/MUON/MCH/Workflow/src/TrackSinkSpec.h
+++ b/Detectors/MUON/MCH/Workflow/src/TrackSinkSpec.h
@@ -24,7 +24,7 @@ namespace o2
 namespace mch
 {
 
-o2::framework::DataProcessorSpec getTrackSinkSpec(bool mchTracks, bool tracksAtVtx);
+o2::framework::DataProcessorSpec getTrackSinkSpec(const char* specName, bool mchTracks, bool tracksAtVtx);
 
 } // end namespace mch
 } // end namespace o2

--- a/Detectors/MUON/MCH/Workflow/src/VertexSamplerSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/VertexSamplerSpec.cxx
@@ -110,10 +110,10 @@ class VertexSamplerSpec
 };
 
 //_________________________________________________________________________________________________
-o2::framework::DataProcessorSpec getVertexSamplerSpec(const char* name)
+o2::framework::DataProcessorSpec getVertexSamplerSpec(const char* specName)
 {
   return DataProcessorSpec{
-    name,
+    specName,
     Inputs{InputSpec{"rofs", "MCH", "TRACKROFS", 0, Lifetime::Timeframe},
            // track and cluster messages are there just to keep things synchronized
            InputSpec{"tracks", "MCH", "TRACKS", 0, Lifetime::Timeframe},

--- a/Detectors/MUON/MCH/Workflow/src/VertexSamplerSpec.h
+++ b/Detectors/MUON/MCH/Workflow/src/VertexSamplerSpec.h
@@ -24,7 +24,7 @@ namespace o2
 namespace mch
 {
 
-o2::framework::DataProcessorSpec getVertexSamplerSpec(const char* name = "VertexSampler");
+o2::framework::DataProcessorSpec getVertexSamplerSpec(const char* specName = "mch-vertex-sampler");
 } // end namespace mch
 } // end namespace o2
 

--- a/Detectors/MUON/MCH/Workflow/src/clusters-sampler-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/clusters-sampler-workflow.cxx
@@ -157,14 +157,14 @@ class ClusterSamplerTask
 };
 
 //_________________________________________________________________________________________________
-o2::framework::DataProcessorSpec getClusterSamplerSpec(bool globalReferenceSystem)
+o2::framework::DataProcessorSpec getClusterSamplerSpec(const char* specName, bool globalReferenceSystem)
 {
 
   std::string spec = fmt::format("clusters:MCH/{}CLUSTERS/0", globalReferenceSystem ? "GLOBAL" : "");
   InputSpec itmp = o2::framework::select(spec.c_str())[0];
 
   return DataProcessorSpec{
-    "ClusterSampler",
+    specName,
     Inputs{},
     Outputs{OutputSpec{{"rofs"}, "MCH", "CLUSTERROFS", 0, Lifetime::Timeframe},
             DataSpecUtils::asOutputSpec(itmp)},
@@ -176,5 +176,5 @@ o2::framework::DataProcessorSpec getClusterSamplerSpec(bool globalReferenceSyste
 //_________________________________________________________________________________________________
 WorkflowSpec defineDataProcessing(const ConfigContext& cc)
 {
-  return WorkflowSpec{getClusterSamplerSpec(cc.options().get<bool>("global"))};
+  return WorkflowSpec{getClusterSamplerSpec("mch-cluster-sampler", cc.options().get<bool>("global"))};
 }

--- a/Detectors/MUON/MCH/Workflow/src/cru-page-reader-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/cru-page-reader-workflow.cxx
@@ -584,10 +584,10 @@ class FileReaderTask
 
 //_________________________________________________________________________________________________
 // clang-format off
-o2::framework::DataProcessorSpec getFileReaderSpec()
+o2::framework::DataProcessorSpec getFileReaderSpec(const char* specName)
 {
   return DataProcessorSpec{
-    "FileReader",
+    specName,
     Inputs{},
     Outputs{OutputSpec{"RDT", "RAWDATA", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<FileReaderTask>()},
@@ -614,7 +614,7 @@ WorkflowSpec defineDataProcessing(const ConfigContext&)
   WorkflowSpec specs;
 
   // The producer to generate some data in the workflow
-  DataProcessorSpec producer = mch::raw::getFileReaderSpec();
+  DataProcessorSpec producer = mch::raw::getFileReaderSpec("mch-cru-page-reader");
   specs.push_back(producer);
 
   return specs;

--- a/Detectors/MUON/MCH/Workflow/src/cru-page-to-digits-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/cru-page-to-digits-workflow.cxx
@@ -34,7 +34,7 @@ WorkflowSpec defineDataProcessing(const ConfigContext&)
 {
   WorkflowSpec specs;
 
-  DataProcessorSpec producer = o2::mch::raw::getDecodingSpec("readout:RDT/RAWDATA");
+  DataProcessorSpec producer = o2::mch::raw::getDecodingSpec("mch-data-decoder", "readout:RDT/RAWDATA");
   specs.push_back(producer);
 
   return specs;

--- a/Detectors/MUON/MCH/Workflow/src/entropy-encoder-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/entropy-encoder-workflow.cxx
@@ -79,14 +79,14 @@ void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 
-DataProcessorSpec getEntropyEncoderSpec()
+DataProcessorSpec getEntropyEncoderSpec(const char* specName)
 {
   std::vector<InputSpec> inputs;
   inputs.emplace_back("rofs", "MCH", "DIGITROFS", 0, Lifetime::Timeframe);
   inputs.emplace_back("digits", "MCH", "DIGITS", 0, Lifetime::Timeframe);
 
   return DataProcessorSpec{
-    "mch-entropy-encoder",
+    specName,
     inputs,
     Outputs{{"MCH", "CTFDATA", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<EntropyEncoderSpec>()},
@@ -116,6 +116,6 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   WorkflowSpec wf;
   // Update the (declared) parameters if changed from the command line
   o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
-  wf.emplace_back(o2::mch::getEntropyEncoderSpec());
+  wf.emplace_back(o2::mch::getEntropyEncoderSpec("mch-entropy-encoder"));
   return wf;
 }

--- a/Detectors/MUON/MCH/Workflow/src/raw-to-digits-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/raw-to-digits-workflow.cxx
@@ -58,7 +58,7 @@ WorkflowSpec defineDataProcessing(const ConfigContext& configcontext)
 
   auto askSTFDist = !configcontext.options().get<bool>("ignore-dist-stf");
 
-  WorkflowSpec wf{o2::mch::raw::getDecodingSpec(inputSpec, askSTFDist)};
+  WorkflowSpec wf{o2::mch::raw::getDecodingSpec("mch-data-decoder", inputSpec, askSTFDist)};
 
   // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
   o2::raw::HBFUtilsInitializer hbfIni(configcontext, wf);

--- a/Detectors/MUON/MCH/Workflow/src/reco-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/reco-workflow.cxx
@@ -64,7 +64,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     specs.emplace_back(o2::mch::getDigitReaderSpec(useMC, "mch-sim-digit-reader"));
   }
   if (enableTimeClustering) {
-    specs.emplace_back(o2::mch::getTimeClusterFinderSpec("mch-time-clustering"));
+    specs.emplace_back(o2::mch::getTimeClusterFinderSpec("mch-time-cluster-finder"));
   }
 
   specs.emplace_back(o2::mch::getPreClusterFinderSpec("mch-precluster-finder",

--- a/Detectors/MUON/MCH/Workflow/src/tracks-sampler-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/tracks-sampler-workflow.cxx
@@ -34,5 +34,5 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 WorkflowSpec defineDataProcessing(const ConfigContext& config)
 {
   bool forTrackFitter = config.options().get<bool>("forTrackFitter");
-  return WorkflowSpec{o2::mch::getTrackSamplerSpec(forTrackFitter)};
+  return WorkflowSpec{o2::mch::getTrackSamplerSpec("mch-track-sampler", forTrackFitter)};
 }

--- a/Detectors/MUON/MCH/Workflow/src/tracks-sink-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/tracks-sink-workflow.cxx
@@ -37,5 +37,5 @@ WorkflowSpec defineDataProcessing(const ConfigContext& config)
 {
   bool mchTracks = !config.options().get<bool>("tracksAtVertexOnly");
   bool tracksAtVtx = !config.options().get<bool>("mchTracksOnly");
-  return WorkflowSpec{o2::mch::getTrackSinkSpec(mchTracks, tracksAtVtx)};
+  return WorkflowSpec{o2::mch::getTrackSinkSpec("mch-track-sink", mchTracks, tracksAtVtx)};
 }

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -244,7 +244,7 @@ if [ $CTFINPUT == 0 ]; then
   has_detector FT0 && WORKFLOW+="o2-ft0-flp-dpl-workflow $ARGS_ALL --configKeyValues \"$ARGS_ALL_CONFIG\" --disable-root-output --pipeline ft0-datareader-dpl:$N_F_RAW | "
   has_detector FV0 && WORKFLOW+="o2-fv0-flp-dpl-workflow $ARGS_ALL --configKeyValues \"$ARGS_ALL_CONFIG\" --disable-root-output --pipeline fv0-datareader-dpl:$N_F_RAW | "
   has_detector MID && WORKFLOW+="o2-mid-raw-to-digits-workflow $ARGS_ALL --configKeyValues \"$ARGS_ALL_CONFIG\" $MIDDEC_CONFIG --pipeline MIDRawDecoder:$N_F_RAW,MIDDecodedDataAggregator:$N_F_RAW | "
-  has_detector MCH && WORKFLOW+="o2-mch-raw-to-digits-workflow $ARGS_ALL --configKeyValues \"$ARGS_ALL_CONFIG\" --pipeline DataDecoder:$N_F_RAW | "
+  has_detector MCH && WORKFLOW+="o2-mch-raw-to-digits-workflow $ARGS_ALL --configKeyValues \"$ARGS_ALL_CONFIG\" --pipeline mch-data-decoder:$N_F_RAW | "
   has_detector TOF && [ $EPNMODE == 0 ] && WORKFLOW+="o2-tof-compressor $ARGS_ALL --configKeyValues \"$ARGS_ALL_CONFIG\" | "
   has_detector FDD && WORKFLOW+="o2-fdd-flp-dpl-workflow $ARGS_ALL --configKeyValues \"$ARGS_ALL_CONFIG\" --disable-root-output --pipeline fdd-datareader-dpl:$N_F_RAW | "
   has_detector TRD && WORKFLOW+="o2-trd-datareader $ARGS_ALL --pipeline trd-datareader:$N_F_RAW | "


### PR DESCRIPTION
@pillot @aferrero2707 The idea of this PR is to be a bit more consistent in our parameter list for the `getXXX` functions that return `DataProcessSpec` objects. So the proposal is, when defining a function that returns a `DataProcessorSpec`, to stick to the following pattern for its parameters :

```
DataProcessorSpec getXXX([bool useMC], const char* specName="mch-xxx", other parameters);
```

- first parameter, if relevant, should be a boolean indicating whether the processor has to deal with Monte Carlo data or not. For a processor that never has to deal with MC, leave that parameter out
- second parameter is the name by which that device will be referenced in all log files, so, in order to be easily recognizable, it *must* start with the prefix `mch-`
- the rest of the parameters (if any) is specific to each device

As an aside, @davidrohr, this should fix the "anonymous DataDecoder issue" in workflow logs you reported some time ago. 
