### PR TITLE
[WIP][EMCAL-534] Move error handling to CaloFitResults

### DIFF
--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CaloFitResults.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CaloFitResults.h
@@ -37,8 +37,34 @@ namespace emcal
 /// procedures than A different meaning Fitting is applied
 class CaloFitResults
 {
-
  public:
+  /**
+   * \enum RawFitterError_t
+   * \brief Error codes for failures in raw fitter procedure
+   */
+  enum class RawFitterError_t {
+    SAMPLE_UNINITIALIZED, ///< Samples not initialized or length is 0
+    FIT_ERROR,            ///< Fit procedure failed
+    CHI2_ERROR,           ///< Chi2 cannot be determined (usually due to insufficient amount of samples)
+    BUNCH_NOT_OK,         ///< Bunch selection failed
+    LOW_SIGNAL,           ///< No ADC value above threshold found
+    NO_ERROR              ///< No raw fitter error
+  };
+
+  /// \brief Create error message for a given error type
+  /// \param fiterror Fit error type
+  /// \return Error message connected to the error type
+  static std::string createErrorMessage(RawFitterError_t fiterror);
+
+  /// \brief Convert error type to numeric representation
+  /// \param fiterror Fit error type
+  /// \return Numeric representation of the raw fitter error
+  static int getErrorNumber(RawFitterError_t fiterror);
+
+  /// \brief Get the number of raw fit error types supported
+  /// \return Number of error types (4)
+  static constexpr int getNumberOfErrorTypes() noexcept { return 4; }
+
   /// \brief Default constructor
   CaloFitResults() = default;
 
@@ -66,11 +92,12 @@ class CaloFitResults
                           float amp,
                           int maxTimebin);
 
+  /// \brief Fit results object in case the raw fit went into error
+  /// \param fitError Error type of the raw fit
+  explicit CaloFitResults(RawFitterError_t fitError);
+
   /// \brief minimum interface
   explicit CaloFitResults(int maxSig, int minSig);
-
-  /// \brief Comparison of two fit results
-  bool operator==(const CaloFitResults& other) const;
 
   ~CaloFitResults() = default;
 
@@ -84,26 +111,73 @@ class CaloFitResults
   void setChi2(float chi2) { mChi2Sig = chi2; }
   void setNdf(unsigned short ndf) { mNdfSig = ndf; }
 
-  unsigned short getMaxSig() const { return mMaxSig; }
-  float getPed() const { return mPed; }
-  unsigned short getMinSig() const { return mMinSig; }
-  int getStatus() const { return mStatus; }
-  float getAmp() const { return mAmpSig; }
-  double getTime() const { return mTime; }
-  int getMaxTimeBin() const { return mMaxTimebin; }
-  float getChi2() const { return mChi2Sig; }
-  unsigned short getNdf() const { return mNdfSig; }
+  bool isFitOK() const { return mFitError == RawFitterError_t::NO_ERROR; }
+  RawFitterError_t getFitError() const { return mFitError; }
+  unsigned short getMaxSig() const
+  {
+    checkFitError();
+    return mMaxSig;
+  }
+  float getPed() const
+  {
+    checkFitError();
+    return mPed;
+  }
+  unsigned short getMinSig() const
+  {
+    checkFitError();
+    return mMinSig;
+  }
+  int getStatus() const
+  {
+    checkFitError();
+    return mStatus;
+  }
+  float getAmp() const
+  {
+    checkFitError();
+    return mAmpSig;
+  }
+  double getTime() const
+  {
+    checkFitError();
+    return mTime;
+  }
+  int getMaxTimeBin() const
+  {
+    checkFitError();
+    return mMaxTimebin;
+  }
+  float getChi2() const
+  {
+    checkFitError();
+    return mChi2Sig;
+  }
+  unsigned short getNdf() const
+  {
+    checkFitError();
+    return mNdfSig;
+  }
 
  private:
-  unsigned short mMaxSig = 0; ///< Maximum sample value ( 0 - 1023 )
-  float mPed = -1;            ///< Pedestal
-  int mStatus = -1;           ///< Sucess or failure of fitting pocedure
-  float mAmpSig = -1;         ///< Amplitude in entities of ADC counts
-  double mTime = -1;          ///< Peak/max time of signal in entities of sample intervals
-  int mMaxTimebin = -1;       ///< Timebin with maximum ADC value
-  float mChi2Sig = -1;        ///< Chi Square of fit
-  unsigned short mNdfSig = 0; ///< Number of degrees of freedom of fit
-  unsigned short mMinSig = 0; ///< Pedestal
+  /// \brief Throw fit error in case the fit went into an eror status
+  /// \throw RawFitterError_t in case the fit went into error and users try to access fit results nevertheless
+  void checkFitError() const
+  {
+    if (mFitError != RawFitterError_t::NO_ERROR)
+      throw mFitError;
+  }
+
+  RawFitterError_t mFitError = RawFitterError_t::NO_ERROR; ///< Error of the raw fitter process
+  unsigned short mMaxSig = 0;                              ///< Maximum sample value ( 0 - 1023 )
+  float mPed = -1;                                         ///< Pedestal
+  int mStatus = -1;                                        ///< Sucess or failure of fitting pocedure
+  float mAmpSig = -1;                                      ///< Amplitude in entities of ADC counts
+  double mTime = -1;                                       ///< Peak/max time of signal in entities of sample intervals
+  int mMaxTimebin = -1;                                    ///< Timebin with maximum ADC value
+  float mChi2Sig = -1;                                     ///< Chi Square of fit
+  unsigned short mNdfSig = 0;                              ///< Number of degrees of freedom of fit
+  unsigned short mMinSig = 0;                              ///< Pedestal
 };
 
 } // namespace emcal

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CaloRawFitterGamma2.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CaloRawFitterGamma2.h
@@ -56,7 +56,6 @@ class CaloRawFitterGamma2 final : public CaloRawFitter
   /// \param bunchvector ALTRO bunches for the current channel
   /// \param altrocfg1 ALTRO config register 1 from RCU trailer
   /// \param altrocfg2 ALTRO config register 2 from RCU trailer
-  /// \throw RawFitterError_t::FIT_ERROR in case the peak fit failed
   /// \return Container with the fit results (amp, time, chi2, ...)
   CaloFitResults evaluate(const gsl::span<const Bunch> bunchvector) final;
 
@@ -72,8 +71,7 @@ class CaloRawFitterGamma2 final : public CaloRawFitter
   /// \param[in] time Initial guess of the time for the fit
   /// \param[out] time Time result of the peak fit
   /// \return chi2 of the fit
-  /// \throw RawFitterError_t::FIT_ERROR in case of fit errors (insufficient number of time samples, matrix diagonalization error, ...)
-  float doFit_1peak(int firstTimeBin, int nSamples, float& ampl, float& time);
+  std::optional<float> doFit_1peak(int firstTimeBin, int nSamples, float& ampl, float& time);
 
   /// \brief Fits the raw signal time distribution
   /// \param maxTimeBin Time bin of the max. amplitude

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CaloRawFitterStandard.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CaloRawFitterStandard.h
@@ -59,15 +59,13 @@ class CaloRawFitterStandard final : public CaloRawFitter
   /// \brief Evaluation Amplitude and TOF
   /// \param bunchvector Calo bunches for the tower and event
   /// \return Container with the fit results (amp, time, chi2, ...)
-  /// \throw RawFitterError_t in case the fit failed (including all possible errors from upstream)
   CaloFitResults evaluate(const gsl::span<const Bunch> bunchvector) final;
 
   /// \brief Fits the raw signal time distribution using TMinuit
   /// \param firstTimeBin First timebin of the ALTRO bunch
   /// \param lastTimeBin Last timebin of the ALTRO bunch
   /// \return the fit parameters: amplitude, time, chi2
-  /// \throw RawFitter_t::FIT_ERROR in case the fit failed (insufficient number of samples or fit error from MINUIT)
-  std::tuple<float, float, float> fitRaw(int firstTimeBin, int lastTimeBin) const;
+  std::optional<std::tuple<float, float, float>> fitRaw(int firstTimeBin, int lastTimeBin) const;
 
  private:
   ClassDefNV(CaloRawFitterStandard, 1);

--- a/Detectors/EMCAL/reconstruction/src/CaloFitResults.cxx
+++ b/Detectors/EMCAL/reconstruction/src/CaloFitResults.cxx
@@ -20,6 +20,44 @@
 
 using namespace o2::emcal;
 
+std::string CaloFitResults::createErrorMessage(CaloFitResults::RawFitterError_t errorcode)
+{
+  switch (errorcode) {
+    case RawFitterError_t::SAMPLE_UNINITIALIZED:
+      return "Sample for fit not initialzied or bunch length is 0";
+    case RawFitterError_t::FIT_ERROR:
+      return "Fit of the raw bunch was not successful";
+    case RawFitterError_t::CHI2_ERROR:
+      return "Chi2 of the fit could not be determined";
+    case RawFitterError_t::BUNCH_NOT_OK:
+      return "Calo bunch could not be selected";
+    case RawFitterError_t::LOW_SIGNAL:
+      return "No ADC value above threshold found";
+  };
+  // Silence compiler warnings for false positives
+  // can never enter here due to usage of enum class
+  return "Unknown error code";
+}
+
+int CaloFitResults::getErrorNumber(CaloFitResults::RawFitterError_t fiterror)
+{
+  switch (fiterror) {
+    case RawFitterError_t::SAMPLE_UNINITIALIZED:
+      return 0;
+    case RawFitterError_t::FIT_ERROR:
+      return 1;
+    case RawFitterError_t::CHI2_ERROR:
+      return 2;
+    case RawFitterError_t::BUNCH_NOT_OK:
+      return 3;
+    case RawFitterError_t::LOW_SIGNAL:
+      return 4;
+  };
+  // Silence compiler warnings for false positives
+  // can never enter here due to usage of enum class
+  return -1;
+}
+
 CaloFitResults::CaloFitResults(unsigned short maxSig, float ped,
                                int fitstatus, float amp,
                                double time, int maxTimebin,
@@ -51,26 +89,6 @@ CaloFitResults::CaloFitResults(int maxSig, int minSig) : mMaxSig(maxSig),
 {
 }
 
-CaloFitResults& CaloFitResults::operator=(const CaloFitResults& source)
+CaloFitResults::CaloFitResults(RawFitterError_t fitError) : mFitError(fitError)
 {
-  if (this != &source) {
-    mMaxSig = source.mMaxSig;
-    mPed = source.mPed;
-    mStatus = source.mStatus;
-    mAmpSig = source.mAmpSig;
-    mTime = source.mTime;
-    mMaxTimebin = source.mMaxTimebin;
-    mChi2Sig = source.mChi2Sig;
-    mNdfSig = source.mNdfSig;
-    mMinSig = source.mMinSig;
-  }
-  return *this;
-}
-
-bool CaloFitResults::operator==(const CaloFitResults& other) const
-{
-  return (mMaxSig == other.mMaxSig) && (mPed == other.mPed) &&
-         (mStatus == other.mStatus) && (mAmpSig == other.mAmpSig) && (mTime == other.mTime) &&
-         (mMaxTimebin == other.mMaxTimebin) && (mChi2Sig == other.mChi2Sig) &&
-         (mNdfSig == other.mNdfSig) && (mMinSig == other.mMinSig);
 }

--- a/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
@@ -345,9 +345,8 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
         }
 
         // define the conatiner for the fit results, and perform the raw fitting using the stadnard raw fitter
-        CaloFitResults fitResults;
-        try {
-          fitResults = mRawFitter->evaluate(chan.getBunches());
+        CaloFitResults fitResults = mRawFitter->evaluate(chan.getBunches());
+        if (fitResults.isFitOK()) {
           // Prevent negative entries - we should no longer get here as the raw fit usually will end in an error state
           if (fitResults.getAmp() < 0) {
             fitResults.setAmp(0.);
@@ -355,6 +354,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
           if (fitResults.getTime() < 0) {
             fitResults.setTime(0.);
           }
+<<<<<<< HEAD
           double amp = fitResults.getAmp() * CONVADCGEV;
           if (mMergeLGHG) {
             // Handling of HG/LG for ceratin cells
@@ -431,9 +431,16 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
           }
         } catch (CaloRawFitter::RawFitterError_t& fiterror) {
           if (fiterror != CaloRawFitter::RawFitterError_t::BUNCH_NOT_OK) {
+=======
+
+          currentCellContainer->emplace_back(CellID, fitResults.getAmp() * CONVADCGEV, fitResults.getTime(), chantype);
+        } else {
+          auto fiterror = fitResults.getFitError();
+          if (fiterror != CaloFitResults::RawFitterError_t::BUNCH_NOT_OK) {
+>>>>>>> 43f65c6cc7 ([EMCAL-534] Move error handling to CaloFitResults)
             // Display
             if (mNumErrorMessages < mMaxErrorMessages) {
-              LOG(ERROR) << "Failure in raw fitting: " << CaloRawFitter::createErrorMessage(fiterror);
+              LOG(ERROR) << "Failure in raw fitting: " << CaloFitResults::createErrorMessage(fiterror);
               mNumErrorMessages++;
               if (mNumErrorMessages == mMaxErrorMessages) {
                 LOG(ERROR) << "Max. amount of error messages (" << mMaxErrorMessages << " reached, further messages will be suppressed";
@@ -442,10 +449,10 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
               mErrorMessagesSuppressed++;
             }
           } else {
-            LOG(DEBUG2) << "Failure in raw fitting: " << CaloRawFitter::createErrorMessage(fiterror);
+            LOG(DEBUG2) << "Failure in raw fitting: " << CaloFitResults::createErrorMessage(fiterror);
             nBunchesNotOK++;
           }
-          mOutputDecoderErrors.emplace_back(feeID, ErrorTypeFEE::ErrorSource_t::FIT_ERROR, CaloRawFitter::getErrorNumber(fiterror));
+          mOutputDecoderErrors.emplace_back(feeID, ErrorTypeFEE::ErrorSource_t::FIT_ERROR, CaloFitResults::getErrorNumber(fiterror));
         }
       }
       if (nBunchesNotOK) {


### PR DESCRIPTION
- Raw fitter classes do not throw exceptions any more
  but functions which might fail return std::optional
- CaloFitResults keeps track of the error status
- In case of a fit error the CaloFitResult is initialized
  only with the error status
- CaloFitResult throws a RawFitterError_t in case
  users try to access parameters of the fit, however
  this can be prevented if the user checks the fit
  status with isFitOK and ignores the fit results in case
  the fit results are not OK.