### PR TITLE
Changing CCDB path for configuration of DCS DPs

### DIFF
--- a/Detectors/DCS/testWorkflow/macros/makeCCDBEntryForDCS.C
+++ b/Detectors/DCS/testWorkflow/macros/makeCCDBEntryForDCS.C
@@ -51,8 +51,8 @@ int makeCCDBEntryForDCS(const std::string url = "http://localhost:8080")
   api.init(url); // or http://localhost:8080 for a local installation
   std::map<std::string, std::string> md;
   long ts = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-  api.storeAsTFileAny(&dpid2DataDesc_Common, "COMMON/DCSconfig", md, ts);
-  api.storeAsTFileAny(&dpid2DataDesc_Common_1, "COMMON1/DCSconfig", md, ts);
+  api.storeAsTFileAny(&dpid2DataDesc_Common, "COMMON/Config/DCSDPconfig", md, ts);
+  api.storeAsTFileAny(&dpid2DataDesc_Common_1, "COMMON1/Config/DCSDPconfig", md, ts);
 
   return 0;
 }

--- a/Detectors/DCS/testWorkflow/src/dcs-proxy.cxx
+++ b/Detectors/DCS/testWorkflow/src/dcs-proxy.cxx
@@ -81,7 +81,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
     std::sregex_token_iterator reg_end;
     for (; it != reg_end; ++it) {
       LOG(INFO) << "DCS DPs configured for detector " << it->str();
-      std::unordered_map<DPID, std::string>* dpid2Det = mgr.getForTimeStamp<std::unordered_map<DPID, std::string>>(it->str() + "/DCSconfig", ts);
+      std::unordered_map<DPID, std::string>* dpid2Det = mgr.getForTimeStamp<std::unordered_map<DPID, std::string>>(it->str() + "/Config/DCSDPconfig", ts);
       for (auto& el : *dpid2Det) {
         o2::header::DataDescription tmpd;
         tmpd.runtimeInit(el.second.c_str(), el.second.size());

--- a/Detectors/EMCAL/calib/macros/makeEMCALCCDBEntryForDCS.C
+++ b/Detectors/EMCAL/calib/macros/makeEMCALCCDBEntryForDCS.C
@@ -62,7 +62,7 @@ int makeEMCALCCDBEntryForDCS(const std::string url = "http://ccdb-test.cern.ch:8
   api.init(url); // or http://localhost:8080 for a local installation
   std::map<std::string, std::string> md;
   long ts = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-  api.storeAsTFileAny(&dpid2DataDesc, "EMC/DCSconfig", md, ts);
+  api.storeAsTFileAny(&dpid2DataDesc, "EMC/Config/DCSDPconfig", md, ts);
 
   return 0;
 }

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/EMCALDCSDataProcessorSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/EMCALDCSDataProcessorSpec.h
@@ -71,7 +71,7 @@ class EMCALDCSDataProcessor : public o2::framework::Task
       CcdbApi api;
       api.init(mgr.getURL());
       long ts = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-      std::unordered_map<DPID, std::string>* dpid2DataDesc = mgr.getForTimeStamp<std::unordered_map<DPID, std::string>>("EMC/DCSconfig", ts);
+      std::unordered_map<DPID, std::string>* dpid2DataDesc = mgr.getForTimeStamp<std::unordered_map<DPID, std::string>>("EMC/Config/DCSDPconfig", ts);
       for (auto& i : *dpid2DataDesc) {
         vect.push_back(i.first);
       }

--- a/Detectors/ITSMFT/MFT/condition/macros/makeMFTCCDBEntryForDCS.C
+++ b/Detectors/ITSMFT/MFT/condition/macros/makeMFTCCDBEntryForDCS.C
@@ -45,7 +45,7 @@ int makeMFTCCDBEntryForDCS(const std::string url = "http://ccdb-test.cern.ch:808
   api.init(url); // or http://localhost:8080 for a local installation
   std::map<std::string, std::string> md;
   long ts = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-  api.storeAsTFileAny(&dpid2DataDesc, "MFT/DCSconfig", md, ts);
+  api.storeAsTFileAny(&dpid2DataDesc, "MFT/Config/DCSDPconfig", md, ts);
 
   return 0;
 }

--- a/Detectors/ITSMFT/MFT/condition/testWorkflow/MFTDCSDataProcessorSpec.h
+++ b/Detectors/ITSMFT/MFT/condition/testWorkflow/MFTDCSDataProcessorSpec.h
@@ -75,7 +75,7 @@ class MFTDCSDataProcessor : public o2::framework::Task
       CcdbApi api;
       api.init(mgr.getURL());
       long ts = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-      std::unordered_map<DPID, std::string>* dpid2DataDesc = mgr.getForTimeStamp<std::unordered_map<DPID, std::string>>("MFT/DCSconfig", ts);
+      std::unordered_map<DPID, std::string>* dpid2DataDesc = mgr.getForTimeStamp<std::unordered_map<DPID, std::string>>("MFT/Config/DCSDPconfig", ts);
       for (auto& i : *dpid2DataDesc) {
         vect.push_back(i.first);
       }

--- a/Detectors/MUON/Common/src/dcs-ccdb.cxx
+++ b/Detectors/MUON/Common/src/dcs-ccdb.cxx
@@ -35,7 +35,7 @@ using DPMAP = std::unordered_map<DPID, std::vector<DPVAL>>;
 
 std::string CcdbDpConfName()
 {
-  return fmt::format("{}/DCSconfig", o2::muon::subsysname());
+  return fmt::format("{}/Config/DCSDPconfig", o2::muon::subsysname());
 }
 
 bool verbose;

--- a/Detectors/TOF/calibration/macros/makeTOFCCDBEntryForDCS.C
+++ b/Detectors/TOF/calibration/macros/makeTOFCCDBEntryForDCS.C
@@ -47,7 +47,7 @@ int makeTOFCCDBEntryForDCS(const std::string url = "http://localhost:8080")
   api.init(url); // or http://localhost:8080 for a local installation
   std::map<std::string, std::string> md;
   long ts = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-  api.storeAsTFileAny(&dpid2DataDesc, "TOF/DCSconfig", md, ts);
+  api.storeAsTFileAny(&dpid2DataDesc, "TOF/Config/DCSDPconfig", md, ts);
 
   return 0;
 }

--- a/Detectors/TOF/calibration/testWorkflow/TOFDCSDataProcessorSpec.h
+++ b/Detectors/TOF/calibration/testWorkflow/TOFDCSDataProcessorSpec.h
@@ -71,7 +71,7 @@ class TOFDCSDataProcessor : public o2::framework::Task
       CcdbApi api;
       api.init(mgr.getURL());
       long ts = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-      std::unordered_map<DPID, std::string>* dpid2DataDesc = mgr.getForTimeStamp<std::unordered_map<DPID, std::string>>("TOF/DCSconfig", ts);
+      std::unordered_map<DPID, std::string>* dpid2DataDesc = mgr.getForTimeStamp<std::unordered_map<DPID, std::string>>("TOF/Config/DCSDPconfig", ts);
       for (auto& i : *dpid2DataDesc) {
         vect.push_back(i.first);
       }

--- a/Detectors/TPC/calibration/macro/makeTPCCCDBEntryForDCS.C
+++ b/Detectors/TPC/calibration/macro/makeTPCCCDBEntryForDCS.C
@@ -86,7 +86,7 @@ int makeTPCCCDBEntryForDCS(const std::string url = "http://localhost:8080")
   api.init(url); // or http://localhost:8080 for a local installation
   std::map<std::string, std::string> md;
   long ts = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-  api.storeAsTFileAny(&dpid2DataDesc, "TPC/DCSconfig", md, ts);
+  api.storeAsTFileAny(&dpid2DataDesc, "TPC/Config/DCSDPconfig", md, ts);
 
   return 0;
 }


### PR DESCRIPTION
@aphecetche , @wiechula , @mpoghos , @shahor02 , @syano0822 : this is following the convention of 3 level path for CCDB entries, plus change in DCSconfig --> DCSDPconfig, for clarity. 

Please, regenerate your entries in the CCDB to process Data Points. 