### PR TITLE
HistogramRegistry: provide add() function that directly returns hist pointer

### DIFF
--- a/Framework/Core/include/Framework/HistogramRegistry.h
+++ b/Framework/Core/include/Framework/HistogramRegistry.h
@@ -92,12 +92,12 @@ class HistogramRegistry
   // functions to add histograms to the registry
   HistPtr add(const HistogramSpec& histSpec);
   HistPtr add(char const* const name, char const* const title, const HistogramConfigSpec& histConfigSpec, bool callSumw2 = false);
-  HistPtr add(char const* const name, char const* const title, HistType histType, std::vector<AxisSpec> axes, bool callSumw2 = false);
+  HistPtr add(char const* const name, char const* const title, HistType histType, const std::vector<AxisSpec>& axes, bool callSumw2 = false);
 
   template <typename T>
   std::shared_ptr<T> add(char const* const name, char const* const title, const HistogramConfigSpec& histConfigSpec, bool callSumw2 = false);
   template <typename T>
-  std::shared_ptr<T> add(char const* const name, char const* const title, HistType histType, std::vector<AxisSpec> axes, bool callSumw2 = false);
+  std::shared_ptr<T> add(char const* const name, char const* const title, HistType histType, const std::vector<AxisSpec>& axes, bool callSumw2 = false);
 
   void addClone(const std::string& source, const std::string& target);
 
@@ -336,7 +336,8 @@ constexpr HistogramRegistry::HistName::HistName(const ConstStr<chars...>& hashed
 template <typename T>
 std::shared_ptr<T> HistogramRegistry::add(char const* const name, char const* const title, const HistogramConfigSpec& histConfigSpec, bool callSumw2)
 {
-  if (auto histPtr = std::get_if<std::shared_ptr<T>>(add(name, title, histConfigSpec, callSumw2))) {
+  auto histVariant = add(name, title, histConfigSpec, callSumw2);
+  if (auto histPtr = std::get_if<std::shared_ptr<T>>(&histVariant)) {
     return *histPtr;
   } else {
     throw runtime_error_f(R"(Histogram type specified in add<>("%s") does not match the actual type of the histogram!)", name);
@@ -344,9 +345,10 @@ std::shared_ptr<T> HistogramRegistry::add(char const* const name, char const* co
 }
 
 template <typename T>
-std::shared_ptr<T> HistogramRegistry::add(char const* const name, char const* const title, HistType histType, std::vector<AxisSpec> axes, bool callSumw2)
+std::shared_ptr<T> HistogramRegistry::add(char const* const name, char const* const title, HistType histType, const std::vector<AxisSpec>& axes, bool callSumw2)
 {
-  if (auto histPtr = std::get_if<std::shared_ptr<T>>(add(name, title, histType, axes, callSumw2))) {
+  auto histVariant = add(name, title, histType, axes, callSumw2);
+  if (auto histPtr = std::get_if<std::shared_ptr<T>>(&histVariant)) {
     return *histPtr;
   } else {
     throw runtime_error_f(R"(Histogram type specified in add<>("%s") does not match the actual type of the histogram!)", name);

--- a/Framework/Core/include/Framework/HistogramRegistry.h
+++ b/Framework/Core/include/Framework/HistogramRegistry.h
@@ -93,6 +93,12 @@ class HistogramRegistry
   HistPtr add(const HistogramSpec& histSpec);
   HistPtr add(char const* const name, char const* const title, const HistogramConfigSpec& histConfigSpec, bool callSumw2 = false);
   HistPtr add(char const* const name, char const* const title, HistType histType, std::vector<AxisSpec> axes, bool callSumw2 = false);
+
+  template <typename T>
+  std::shared_ptr<T> add(char const* const name, char const* const title, const HistogramConfigSpec& histConfigSpec, bool callSumw2 = false);
+  template <typename T>
+  std::shared_ptr<T> add(char const* const name, char const* const title, HistType histType, std::vector<AxisSpec> axes, bool callSumw2 = false);
+
   void addClone(const std::string& source, const std::string& target);
 
   // function to query if name is already in use
@@ -326,6 +332,26 @@ constexpr HistogramRegistry::HistName::HistName(const ConstStr<chars...>& hashed
     hash(hashedHistName.hash),
     idx(hash & REGISTRY_BITMASK)
 {
+}
+
+template <typename T>
+std::shared_ptr<T> HistogramRegistry::add(char const* const name, char const* const title, const HistogramConfigSpec& histConfigSpec, bool callSumw2)
+{
+  if (auto histPtr = std::get_if<std::shared_ptr<T>>(add(name, title, histConfigSpec, callSumw2))) {
+    return *histPtr;
+  } else {
+    throw runtime_error_f(R"(Histogram type specified in add<>("%s") does not match the actual type of the histogram!)", name);
+  }
+}
+
+template <typename T>
+std::shared_ptr<T> HistogramRegistry::add(char const* const name, char const* const title, HistType histType, std::vector<AxisSpec> axes, bool callSumw2)
+{
+  if (auto histPtr = std::get_if<std::shared_ptr<T>>(add(name, title, histType, axes, callSumw2))) {
+    return *histPtr;
+  } else {
+    throw runtime_error_f(R"(Histogram type specified in add<>("%s") does not match the actual type of the histogram!)", name);
+  }
 }
 
 template <typename T>

--- a/Framework/Core/include/Framework/HistogramRegistry.h
+++ b/Framework/Core/include/Framework/HistogramRegistry.h
@@ -42,15 +42,15 @@ namespace o2::framework
 struct HistFiller {
   // fill any type of histogram (if weight was requested it must be the last argument)
   template <typename T, typename... Ts>
-  static void fillHistAny(std::shared_ptr<T>& hist, const Ts&... positionAndWeight);
+  static void fillHistAny(std::shared_ptr<T> hist, const Ts&... positionAndWeight);
 
   // fill any type of histogram with columns (Cs) of a filtered table (if weight is requested it must reside the last specified column)
   template <typename... Cs, typename R, typename T>
-  static void fillHistAny(std::shared_ptr<R>& hist, const T& table, const o2::framework::expressions::Filter& filter);
+  static void fillHistAny(std::shared_ptr<R> hist, const T& table, const o2::framework::expressions::Filter& filter);
 
   // function that returns rough estimate for the size of a histogram in MB
   template <typename T>
-  static double getSize(std::shared_ptr<T>& hist, double fillFraction = 1.);
+  static double getSize(std::shared_ptr<T> hist, double fillFraction = 1.);
 
  private:
   // helper function to determine base element size of histograms (in bytes)
@@ -106,11 +106,10 @@ class HistogramRegistry
 
   // get the underlying histogram pointer
   template <typename T>
-  std::shared_ptr<T>& get(const HistName& histName);
+  std::shared_ptr<T> get(const HistName& histName);
 
-  // get the underlying histogram pointer
   template <typename T>
-  auto& operator()(const HistName& histName);
+  std::shared_ptr<T> operator()(const HistName& histName);
 
   // return the OutputSpec associated to the HistogramRegistry
   OutputSpec const spec();
@@ -147,7 +146,7 @@ class HistogramRegistry
 
   // clone an existing histogram and insert it into the registry
   template <typename T>
-  HistPtr insertClone(const HistName& histName, const std::shared_ptr<T>& originalHist);
+  HistPtr insertClone(const HistName& histName, const std::shared_ptr<T> originalHist);
 
   // helper function that checks if histogram name can be used in registry
   void validateHistName(const char* name, const uint32_t hash);
@@ -192,7 +191,7 @@ class HistogramRegistry
 //--------------------------------------------------------------------------------------------------
 
 template <typename T, typename... Ts>
-void HistFiller::fillHistAny(std::shared_ptr<T>& hist, const Ts&... positionAndWeight)
+void HistFiller::fillHistAny(std::shared_ptr<T> hist, const Ts&... positionAndWeight)
 {
   constexpr int nArgs = sizeof...(Ts);
 
@@ -228,7 +227,7 @@ void HistFiller::fillHistAny(std::shared_ptr<T>& hist, const Ts&... positionAndW
 }
 
 template <typename... Cs, typename R, typename T>
-void HistFiller::fillHistAny(std::shared_ptr<R>& hist, const T& table, const o2::framework::expressions::Filter& filter)
+void HistFiller::fillHistAny(std::shared_ptr<R> hist, const T& table, const o2::framework::expressions::Filter& filter)
 {
   if constexpr (std::is_base_of_v<StepTHn, T>) {
     LOGF(FATAL, "Table filling is not (yet?) supported for StepTHn.");
@@ -241,7 +240,7 @@ void HistFiller::fillHistAny(std::shared_ptr<R>& hist, const T& table, const o2:
 }
 
 template <typename T>
-double HistFiller::getSize(std::shared_ptr<T>& hist, double fillFraction)
+double HistFiller::getSize(std::shared_ptr<T> hist, double fillFraction)
 {
   double size{0.};
   if constexpr (std::is_base_of_v<TH1, T>) {
@@ -355,7 +354,7 @@ std::shared_ptr<T> HistogramRegistry::add(char const* const name, char const* co
 }
 
 template <typename T>
-std::shared_ptr<T>& HistogramRegistry::get(const HistName& histName)
+std::shared_ptr<T> HistogramRegistry::get(const HistName& histName)
 {
   if (auto histPtr = std::get_if<std::shared_ptr<T>>(&mRegistryValue[getHistIndex(histName)])) {
     return *histPtr;
@@ -365,13 +364,13 @@ std::shared_ptr<T>& HistogramRegistry::get(const HistName& histName)
 }
 
 template <typename T>
-auto& HistogramRegistry::operator()(const HistName& histName)
+std::shared_ptr<T> HistogramRegistry::operator()(const HistName& histName)
 {
   return get<T>(histName);
 }
 
 template <typename T>
-HistPtr HistogramRegistry::insertClone(const HistName& histName, const std::shared_ptr<T>& originalHist)
+HistPtr HistogramRegistry::insertClone(const HistName& histName, const std::shared_ptr<T> originalHist)
 {
   validateHistName(histName.str, histName.hash);
   for (auto i = 0u; i < MAX_REGISTRY_SIZE; ++i) {

--- a/Framework/Core/src/HistogramRegistry.cxx
+++ b/Framework/Core/src/HistogramRegistry.cxx
@@ -106,7 +106,7 @@ HistPtr HistogramRegistry::add(char const* const name, char const* const title, 
   return insert({name, title, histConfigSpec, callSumw2});
 }
 
-HistPtr HistogramRegistry::add(char const* const name, char const* const title, HistType histType, std::vector<AxisSpec> axes, bool callSumw2)
+HistPtr HistogramRegistry::add(char const* const name, char const* const title, HistType histType, const std::vector<AxisSpec>& axes, bool callSumw2)
 {
   return insert({name, title, {histType, axes}, callSumw2});
 }

--- a/Framework/Core/test/benchmark_HistogramRegistry.cxx
+++ b/Framework/Core/test/benchmark_HistogramRegistry.cxx
@@ -37,7 +37,7 @@ static void BM_HashedNameLookup(benchmark::State& state)
     state.ResumeTiming();
 
     for (auto i = 0; i < nLookups; ++i) {
-      auto& x = registry.get<TH1>(HIST("histo4"));
+      auto x = registry.get<TH1>(HIST("histo4"));
       benchmark::DoNotOptimize(x);
     }
     state.counters["Average lookup distance"] = ((double)registry.lookup / (double)(state.range(0)));

--- a/Framework/Core/test/test_HistogramRegistry.cxx
+++ b/Framework/Core/test/test_HistogramRegistry.cxx
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(HistogramRegistryStepTHn)
   registry.add("stepTHnD", "b", {kStepTHnD, {{100, -10.0f, 10.01f}, {100, -10.0f, 10.01f}}, 3});
   registry.addClone("stepTHnD", "stepTHnD2");
 
-  auto& histo = registry.get<StepTHn>(HIST("stepTHnD"));
+  auto histo = registry.get<StepTHn>(HIST("stepTHnD"));
   BOOST_REQUIRE_EQUAL(histo->getNSteps(), 3);
 
   // fill first step at position (0,3)


### PR DESCRIPTION
fyi @njacazio 
with this we could do things like
```
auto myHist = histos.add<TH1>("myHist", "", kTH1F, {{10, 0.5, 10.5}}));
myHist->GetXaxis()->SetBinLabel(1, "abc"); 
```