### PR TITLE
Improve checker for MID raw data consistency

### DIFF
--- a/Detectors/MUON/MID/QC/include/MIDQC/RawDataChecker.h
+++ b/Detectors/MUON/MID/QC/include/MIDQC/RawDataChecker.h
@@ -42,7 +42,7 @@ class RawDataChecker
   unsigned int getNBusyRaised() const;
   /// Gets the debug message
   std::string getDebugMessage() const { return mDebugMsg; }
-  void clear();
+  void clear(bool all = false);
 
   /// Sets the delay in the electronics
   void setElectronicsDelay(const ElectronicsDelay& electronicsDelay) { mElectronicsDelay = electronicsDelay; }

--- a/Detectors/MUON/MID/QC/src/GBTRawDataChecker.cxx
+++ b/Detectors/MUON/MID/QC/src/GBTRawDataChecker.cxx
@@ -72,18 +72,23 @@ bool GBTRawDataChecker::checkConsistency(const ROBoard& board)
   bool isCalib = raw::isCalibration(board.triggerWord);
   bool isPhys = board.triggerWord & raw::sPHY;
 
-  if (isPhys) {
-    if (isCalib) {
-      mEventDebugMsg += "inconsistent trigger: calibration and physics trigger cannot be fired together\n";
-      return false;
-    }
-    if (raw::isLoc(board.statusWord)) {
-      if (board.firedChambers) {
-        mEventDebugMsg += "inconsistent trigger: fired chambers should be 0\n";
-        return false;
-      }
-    }
-  }
+  // FIXME: During data acquisition we do not expect a calibration trigger
+  // in coincidence with a physics trigger.
+  // However, this situation can happen in the tests with the LTU.
+  // So, let us remove these tests for the time being
+
+  // if (isPhys) {
+  //   if (isCalib) {
+  //     mEventDebugMsg += "inconsistent trigger: calibration and physics trigger cannot be fired together\n";
+  //     return false;
+  //   }
+  //   if (raw::isLoc(board.statusWord)) {
+  //     if (board.firedChambers) {
+  //       mEventDebugMsg += "inconsistent trigger: fired chambers should be 0\n";
+  //       return false;
+  //     }
+  //   }
+  // }
   if (isSoxOrReset && (isCalib || isPhys)) {
     mEventDebugMsg += "inconsistent trigger: cannot be SOX and calibration\n";
     return false;

--- a/Detectors/MUON/MID/QC/src/RawDataChecker.cxx
+++ b/Detectors/MUON/MID/QC/src/RawDataChecker.cxx
@@ -94,11 +94,11 @@ unsigned int RawDataChecker::getNBusyRaised() const
   return sum;
 }
 
-void RawDataChecker::clear()
+void RawDataChecker::clear(bool all)
 {
   /// Clears the statistics
   for (auto& checker : mCheckers) {
-    checker.clear();
+    checker.clear(all);
   }
 }
 


### PR DESCRIPTION
This PR consists pf three commits:
- the first one temorarily remove some checks. In real life we do not expect calibration triggers and physics triggers happening at the same time. But in the tests we do, so we temporairly remove this check.
- the second one improves the treatment of busy local board
- the third one decouples the clear of the statistics information and of the inner object. This is needed for the Raw data QC since the statistics information needs to be cleared at every cycle.
The commits are meant to be atomic. Please do not squash.