### PR TITLE
MCH mapping optimizations

### DIFF
--- a/Detectors/MUON/MCH/Mapping/Impl4/src/CathodeSegmentationCImpl4.cxx
+++ b/Detectors/MUON/MCH/Mapping/Impl4/src/CathodeSegmentationCImpl4.cxx
@@ -115,7 +115,7 @@ O2MCHMAPPINGIMPL4_EXPORT void mchCathodeSegmentationForEachPadInDualSampa(
   MchCathodeSegmentationHandle segHandle, int dualSampaId,
   MchPadHandler handler, void* clientData)
 {
-  for (auto p : segHandle->impl->getCatPadIndexs(dualSampaId)) {
+  for (auto p : segHandle->impl->getCatPadIndices(dualSampaId)) {
     handler(clientData, p);
   }
 }
@@ -160,7 +160,7 @@ O2MCHMAPPINGIMPL4_EXPORT void mchCathodeSegmentationForEachPadInArea(
   MchCathodeSegmentationHandle segHandle, double xmin, double ymin, double xmax,
   double ymax, MchPadHandler handler, void* clientData)
 {
-  for (auto p : segHandle->impl->getCatPadIndexs(xmin, ymin, xmax, ymax)) {
+  for (auto p : segHandle->impl->getCatPadIndices(xmin, ymin, xmax, ymax)) {
     handler(clientData, p);
   }
 }
@@ -169,7 +169,7 @@ O2MCHMAPPINGIMPL4_EXPORT void mchCathodeSegmentationForEachNeighbouringPad(
   MchCathodeSegmentationHandle segHandle, int catPadIndex,
   MchPadHandler handler, void* userData)
 {
-  for (auto p : segHandle->impl->getNeighbouringCatPadIndexs(catPadIndex)) {
+  for (auto p : segHandle->impl->getNeighbouringCatPadIndices(catPadIndex)) {
     handler(userData, p);
   }
 }

--- a/Detectors/MUON/MCH/Mapping/Impl4/src/CathodeSegmentationImpl4.h
+++ b/Detectors/MUON/MCH/Mapping/Impl4/src/CathodeSegmentationImpl4.h
@@ -21,6 +21,7 @@
 #include <set>
 #include <ostream>
 #include <boost/geometry/index/rtree.hpp>
+#include <map>
 
 namespace o2
 {
@@ -46,17 +47,17 @@ class CathodeSegmentation
                       std::vector<PadGroupType> padGroupTypes,
                       std::vector<std::pair<float, float>> padSizes);
 
-  /// Return the list of catPadIndexs for the pads of the given dual sampa.
-  std::vector<int> getCatPadIndexs(int dualSampaIds) const;
+  /// Return the list of catPadIndices for the pads of the given dual sampa.
+  std::vector<int> getCatPadIndices(int dualSampaIds) const;
 
-  /// Return the list of catPadIndexs for the pads contained in the box
+  /// Return the list of catPadIndices for the pads contained in the box
   /// {xmin,ymin,xmax,ymax}.
-  std::vector<int> getCatPadIndexs(double xmin, double ymin, double xmax,
-                                   double ymax) const;
+  std::vector<int> getCatPadIndices(double xmin, double ymin, double xmax,
+                                    double ymax) const;
 
-  /// Return the list of catPadIndexs of the pads which are neighbours to
+  /// Return the list of catPadIndices of the pads which are neighbours to
   /// catPadIndex
-  std::vector<int> getNeighbouringCatPadIndexs(int catPadIndex) const;
+  std::vector<int> getNeighbouringCatPadIndices(int catPadIndex) const;
 
   std::set<int> dualSampaIds() const { return mDualSampaIds; }
 
@@ -116,6 +117,7 @@ class CathodeSegmentation
   std::vector<int> mCatPadIndex2PadGroupIndex;
   std::vector<int> mCatPadIndex2PadGroupTypeFastIndex;
   std::vector<int> mPadGroupIndex2CatPadIndexIndex;
+  std::map<int, std::vector<int>> mDualSampaId2CatPadIndices;
 };
 
 CathodeSegmentation* createCathodeSegmentation(int detElemId,

--- a/Detectors/MUON/MCH/Mapping/test/src/BenchCathodeSegmentation.cxx
+++ b/Detectors/MUON/MCH/Mapping/test/src/BenchCathodeSegmentation.cxx
@@ -84,6 +84,28 @@ static void benchCathodeSegmentationConstructionAll(benchmark::State& state)
   }
 }
 
+BENCHMARK_DEFINE_F(BenchO2, findPadByFEE)
+(benchmark::State& state)
+{
+  int detElemId = state.range(0);
+  bool isBendingPlane = state.range(1);
+  o2::mch::mapping::CathodeSegmentation seg{detElemId, isBendingPlane};
+
+  int ntp{0};
+  for (auto _ : state) {
+    ntp = 0;
+    int nds = seg.nofDualSampas();
+    for (int ds = 0; ds < nds; ++ds) {
+      auto dualSampaId = seg.dualSampaId(ds);
+      for (int ch = 0; ch < 64; ch++) {
+        seg.findPadByFEE(dualSampaId, ch);
+      }
+      ++ntp;
+    }
+  }
+  state.counters["ntp"] = ntp;
+}
+
 // note: a bench is not a test, so here we assume findPadByPosition is correct,
 // we just time it.
 // so you must have a test of it somewhere else.
@@ -112,6 +134,7 @@ BENCHMARK_DEFINE_F(BenchO2, findPadByPosition)
 BENCHMARK(benchCathodeSegmentationConstructionAll)->Unit(benchmark::kMillisecond);
 
 BENCHMARK_REGISTER_F(BenchO2, findPadByPosition)->Apply(segmentationList)->Unit(benchmark::kMillisecond);
+BENCHMARK_REGISTER_F(BenchO2, findPadByFEE)->Apply(segmentationList)->Unit(benchmark::kMillisecond);
 
 BENCHMARK_REGISTER_F(BenchO2, ctor)->Apply(segmentationList)->Unit(benchmark::kMicrosecond);
 


### PR DESCRIPTION
@aferrero2707 with those changes (cache of vector of pad indices per dual sampa, the rest is fixing wrong naming) the
`findByPadFEE` method is about 10 times faster. As a result the mch-data-decoder was measured (on a Mac so far) to be 3 times faster on the (noise) data taken with FLP158 (CH10R).