### PR TITLE
Write CTF metainfo file together with CTF

### DIFF
--- a/DataFormats/Detectors/Common/CMakeLists.txt
+++ b/DataFormats/Detectors/Common/CMakeLists.txt
@@ -15,6 +15,7 @@ o2_add_library(DetectorsCommonDataFormats
                        src/EncodedBlocks.cxx
                        src/CTFHeader.cxx
                        src/CTFDictHeader.cxx
+         src/FileMetaData.cxx
                PUBLIC_LINK_LIBRARIES
                ROOT::Core
                ROOT::Geom

--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/FileMetaData.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/FileMetaData.h
@@ -1,0 +1,49 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @brief meta data of the file produced by O2
+
+#ifndef _ALICEO2_FILE_METADATA_H
+#define _ALICEO2_FILE_METADATA_H
+
+#include <string>
+
+namespace o2
+{
+namespace dataformats
+{
+
+struct FileMetaData {
+  std::string LHCPeriod{};   // 1, LHC data taking period + detector name, in case of individual detector data stream, required
+  std::string lurl{};        // 3, the local EPN path to the CTF or calibration file, required
+  std::string type{};        // 4, CTF or calibration; default is CTF, optional
+  std::string guid{};        // 7, default is auto-generated, optional
+  std::string surl{};        // 8, the remote storage path where we store the data file, optional
+  std::string curl{};        // 9, the Grid catalogue path, optional
+  std::string md5{};         //10, default the checksum of the lurl file; only filled after a successful transfer, if needed, optional
+  std::string xxhash{};      //11, default calculated from the lurl file, only filled after a successful transfer, if needed, optional
+  std::string seName{};      //12, default is taken from the configuration file
+  std::string seioDaemons{}; //13, default is taken from the configuration file
+  std::string priority{};    //14, low or high; default is low
+  long run{};                // 2, run number, required
+  long ctime{};              // 5, default the timestamp of the lurl file, optional
+  size_t size{};             // 6, default the size of the lurl file, optional
+
+  bool fillFileData(const std::string& fname);
+  std::string asString() const;
+};
+
+std::ostream& operator<<(std::ostream& stream, const FileMetaData& m);
+
+} // namespace dataformats
+} // namespace o2
+
+#endif

--- a/DataFormats/Detectors/Common/src/FileMetaData.cxx
+++ b/DataFormats/Detectors/Common/src/FileMetaData.cxx
@@ -1,0 +1,87 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @brief meta data of the file produced by O2
+
+#include "DetectorsCommonDataFormats/FileMetaData.h"
+#include <Framework/Logger.h>
+#include <TMD5.h>
+#include <filesystem>
+#include <chrono>
+
+using namespace o2::dataformats;
+
+bool FileMetaData::fillFileData(const std::string& fname)
+{
+  try {
+    lurl = std::filesystem::canonical(fname).string();
+    size = std::filesystem::file_size(lurl);
+    std::unique_ptr<TMD5> md5ptr{TMD5::FileChecksum(fname.c_str())};
+    md5 = md5ptr->AsString();
+    ctime = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::system_clock::now()).time_since_epoch().count();
+  } catch (std::exception const& e) {
+    LOG(ERROR) << "Failed to fill metadata for file " << fname << ", reason: " << e.what();
+    return false;
+  }
+  return true;
+}
+
+std::string FileMetaData::asString() const
+{
+  std::string ms;
+
+  // obligatory part
+  ms += fmt::format("LHCPeriod: {}\n", LHCPeriod);
+  ms += fmt::format("run: {}\n", run);
+  ms += fmt::format("lurl: {}\n", lurl);
+
+  // optional part
+  if (!type.empty()) {
+    ms += fmt::format("type: {}\n", type);
+  }
+  if (ctime) {
+    ms += fmt::format("ctime: {}\n", ctime);
+  }
+  if (size) {
+    ms += fmt::format("size: {}\n", size);
+  }
+  if (!guid.empty()) {
+    ms += fmt::format("guid: {}\n", guid);
+  }
+  if (!surl.empty()) {
+    ms += fmt::format("surl: {}\n", surl);
+  }
+  if (!curl.empty()) {
+    ms += fmt::format("curl: {}\n", curl);
+  }
+  if (!md5.empty()) {
+    ms += fmt::format("md5: {}\n", md5);
+  }
+  if (!xxhash.empty()) {
+    ms += fmt::format("xxhash: {}\n", xxhash);
+  }
+  if (!seName.empty()) {
+    ms += fmt::format("seName: {}\n", seName);
+  }
+  if (!seioDaemons.empty()) {
+    ms += fmt::format("seioDaemons: {}\n", seioDaemons);
+  }
+  if (!priority.empty()) {
+    ms += fmt::format("priority: {}\n", priority);
+  }
+  return ms;
+}
+
+std::ostream& o2::dataformats::operator<<(std::ostream& stream, const FileMetaData& h)
+{
+  stream << h.asString();
+  return stream;
+}

--- a/Detectors/CTF/workflow/src/CTFWriterSpec.cxx
+++ b/Detectors/CTF/workflow/src/CTFWriterSpec.cxx
@@ -23,6 +23,7 @@
 #include "DetectorsCommonDataFormats/CTFHeader.h"
 #include "DetectorsCommonDataFormats/NameConf.h"
 #include "DetectorsCommonDataFormats/EncodedBlocks.h"
+#include "DetectorsCommonDataFormats/FileMetaData.h"
 #include "CommonUtils/StringUtils.h"
 #include "DataFormatsITSMFT/CTF.h"
 #include "DataFormatsTPC/CTF.h"
@@ -124,17 +125,20 @@ class CTFWriterSpec : public o2::framework::Task
   size_t mNCTF = 0;        // total number of CTFs written
   size_t mNAccCTF = 0;     // total number of CTFs accumulated in the current file
   size_t mNCTFFiles = 0;   // total number of CTF files written
+  std::vector<uint32_t> mTFOrbits{}; // 1st orbits of TF accumulated in current file
 
-  std::string mEnvironmentID = ""; // partition env. id
-  std::string mDictDir = "";
-  std::string mCTFDir = "";
+  std::string mLHCPeriod{};
+  std::string mEnvironmentID{}; // partition env. id
+  std::string mDictDir{};
+  std::string mCTFDir{};
   std::string mCTFDirFallBack = "/dev/null";
-  std::string mCurrentCTFFileName = "";
+  std::string mCurrentCTFFileName{};
   const std::string LOCKFileDir = "/tmp/ctf-writer-locks";
-  std::string mLockFileName = "";
+  std::string mLockFileName{};
   int mLockFD = -1;
   std::unique_ptr<TFile> mCTFFileOut;
   std::unique_ptr<TTree> mCTFTreeOut;
+  std::unique_ptr<o2::dataformats::FileMetaData> mCTFFileMetaData;
 
   std::unique_ptr<TFile> mDictFileOut; // file to store dictionary
   std::unique_ptr<TTree> mDictTreeOut; // tree to store dictionary
@@ -327,6 +331,19 @@ void CTFWriterSpec::run(ProcessingContext& pc)
     LOGP(WARNING, "RunNumber/Environment changed from {}/{} to {}/{}", oldRun, oldEnv, mRun, mEnvironmentID);
     closeTFTreeAndFile();
   }
+  // check for the LHCPeriod
+  if (mLHCPeriod.empty()) {
+    auto LHCPeriodStr = pc.services().get<RawDeviceService>().device()->fConfig->GetProperty<std::string>("LHCPeriod", NAStr);
+    if (LHCPeriodStr != NAStr) {
+      mLHCPeriod = LHCPeriodStr;
+    } else {
+      const char* months[12] = {"JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"};
+      time_t now = time(0);
+      auto ltm = gmtime(&now);
+      mLHCPeriod = months[ltm->tm_mon];
+      LOG(WARNING) << "LHCPeriod is not available, using current month " << mLHCPeriod;
+    }
+  }
 
   mCurrCTFSize = estimateCTFSize(pc);
   if (mWriteCTF) {
@@ -358,6 +375,7 @@ void CTFWriterSpec::run(ProcessingContext& pc)
     szCTF += appendToTree(*mCTFTreeOut.get(), "CTFHeader", header);
     mAccCTFSize += szCTF;
     mCTFTreeOut->SetEntries(++mNAccCTF);
+    mTFOrbits.push_back(dh->firstTForbit);
     LOG(INFO) << "TF#" << mNCTF << ": wrote CTF{" << header << "} of size " << szCTF << " to " << mCurrentCTFFileName << " in " << mTimer.CpuTime() - cput << " s";
     if (mNAccCTF > 1) {
       LOG(INFO) << "Current CTF tree has " << mNAccCTF << " entries with total size of " << mAccCTFSize << " bytes";
@@ -437,6 +455,8 @@ void CTFWriterSpec::prepareTFTreeAndFile(const o2::header::DataHeader* dh)
     mCurrentCTFFileName = o2::utils::Str::concat_string(ctfDir, o2::base::NameConf::getCTFFileName(mRun, dh->firstTForbit, dh->tfCounter));
     mCTFFileOut.reset(TFile::Open(o2::utils::Str::concat_string(mCurrentCTFFileName, TMPFileEnding).c_str(), "recreate")); // to prevent premature external usage, use temporary name
     mCTFTreeOut = std::make_unique<TTree>(std::string(o2::base::NameConf::CTFTREENAME).c_str(), "O2 CTF tree");
+    mCTFFileMetaData = std::make_unique<o2::dataformats::FileMetaData>();
+
     mNCTFFiles++;
   }
 }
@@ -452,6 +472,27 @@ void CTFWriterSpec::closeTFTreeAndFile()
     if (!TMPFileEnding.empty()) {
       std::filesystem::rename(o2::utils::Str::concat_string(mCurrentCTFFileName, TMPFileEnding), mCurrentCTFFileName);
     }
+    // write CTF file meta data
+    mCTFFileMetaData->fillFileData(mCurrentCTFFileName);
+    mCTFFileMetaData->run = mRun;
+    mCTFFileMetaData->LHCPeriod = mLHCPeriod;
+    mCTFFileMetaData->type = "CTF";
+    mCTFFileMetaData->priority = "high";
+    auto metaName = o2::utils::Str::concat_string(mCurrentCTFFileName, ".done");
+    try {
+      std::ofstream metaOut(metaName);
+      metaOut << *mCTFFileMetaData.get();
+      metaOut << "TFOrbits: ";
+      for (size_t i = 0; i < mTFOrbits.size(); i++) {
+        metaOut << fmt::format("{}{}", i ? ", " : "", mTFOrbits[i]);
+      }
+      metaOut << '\n';
+      metaOut.close();
+    } catch (std::exception const& e) {
+      LOG(ERROR) << "Failed to store CTF metadata file " << metaName << ", reason: " << e.what();
+    }
+    mCTFFileMetaData.reset();
+    mTFOrbits.clear();
     mNAccCTF = 0;
     mAccCTFSize = 0;
     removeLockFile();


### PR DESCRIPTION
@ironMann please check if this is enough, for every file like 
`o2_ctf_run00500463_orbit0019553057_tf0000000001.root`
it will write a text file `o2_ctf_run00500463_orbit0019553057_tf0000000001.done` with content:

```
LHCPeriod: N/A
run: 500463
lurl: /home/shahoian/tmp/ct/o2_ctf_run00500463_orbit0019553057_tf0000000001.root
type: CTF
ctime: 1632354704597
size: 1348358
md5: 9745b36b4a70f138a72b6e4d6057cbf4
TFOrbits: 19553057, 19601185, 19601441
```

The last entry is the extension we discussed with Latchezar.
Shall I also write the names of optional fields which are not filled?