### PR TITLE
[TRD] Adapt to 3-level CCDB naming scheme

### DIFF
--- a/Detectors/TRD/base/include/TRDBase/Calibrations.h
+++ b/Detectors/TRD/base/include/TRDBase/Calibrations.h
@@ -47,7 +47,6 @@
 #include "TRDBase/PadStatus.h"
 #include "TRDBase/CalOnlineGainTables.h"
 
-class Geometry;
 namespace o2
 {
 namespace trd
@@ -55,22 +54,13 @@ namespace trd
 
 class Calibrations
 {
-  enum {
-    kSimulation = 1,
-    kReconstruction = 2,
-    kCalibration = 3
-  };
 
  public:
   Calibrations() = default;
   ~Calibrations() = default;
   //
-  int const getTimeStamp() { return mTimeStamp; }
-  void setTimeStamp(long timestamp) { mTimeStamp = timestamp; }
-  void setCCDB(int calibrationobjecttype, long timestamp);
-  void setCCDBForSimulation(long timestamp) { setCCDB(kSimulation, timestamp); };
-  void setCCDBForReconstruction(long timestamp) { setCCDB(kReconstruction, timestamp); };
-  void setCCDBForCalibration(long timestamp) { setCCDB(kCalibration, timestamp); };
+  int getTimeStamp() const { return mTimeStamp; }
+  void getCCDBObjects(long timestamp);
   void setOnlineGainTables(std::string& tablename);
   //
   double getVDrift(int roc, int col, int row) const;

--- a/Detectors/TRD/base/macros/OCDB2CCDB.C
+++ b/Detectors/TRD/base/macros/OCDB2CCDB.C
@@ -213,8 +213,9 @@ void UnpackGainTable(std::string& gainkey, CalOnlineGainTables* gtbl)
   }
 }
 
+// choose ccdbPath = "http://ccdb-test.cern.ch:8080" to write to the test CCDB at CERN
 //__________________________________________________________________________________________
-void OCDB2CCDB(Int_t run, const Char_t* storageURI = "alien://folder=/alice/data/2010/OCDB/")
+void OCDB2CCDB(TString ccdbPath = "http://localhost:8080", Int_t run = 297595, const Char_t* storageURI = "local:///cvmfs/alice-ocdb.cern.ch/calibration/data/2018/OCDB")
 {
   //
   // Main function to steer the extraction of TRD OCDB information
@@ -236,7 +237,7 @@ void OCDB2CCDB(Int_t run, const Char_t* storageURI = "alien://folder=/alice/data
   AliCDBEntry* entry = NULL;
   Run = run;
 
-  std::string TRDCalBase = "TRD_test";
+  std::string TRDCalBase = "TRD";
 
   manager->SetRun(Run);
 
@@ -250,7 +251,7 @@ void OCDB2CCDB(Int_t run, const Char_t* storageURI = "alien://folder=/alice/data
   //
   o2::ccdb::CcdbApi ccdb;
   map<string, string> metadata;               // do we want to store any meta data?
-  ccdb.init("http://ccdb-test.cern.ch:8080"); // or http://localhost:8080 for a local installation
+  ccdb.init(ccdbPath.Data());
 
   AliTRDCalChamberStatus* chamberStatus = 0;
   AliTRDCalDet *chamberExB = 0, *chamberVDrift = 0, *chamberGainFactor = 0, *chamberT0 = 0;
@@ -265,9 +266,9 @@ void OCDB2CCDB(Int_t run, const Char_t* storageURI = "alien://folder=/alice/data
         o2chamberstatus->setRawStatus(i, a);
       }
       // store abitrary user object in strongly typed manner
-      ccdb.storeAsTFileAny(o2chamberstatus, "TRD_test/ChamberStatus", metadata, Run, Run + 1);
+      ccdb.storeAsTFileAny(o2chamberstatus, "TRD/Calib/ChamberStatus", metadata, Run, Run + 1);
       // // read like this (you have to specify the type)
-      //auto o2chamberstatusback = ccdb.retrieveFromTFileAny<o2::trd::ChamberStatus>("TRD_test/ChamberStatus", metadata);
+      //auto o2chamberstatusback = ccdb.retrieveFromTFileAny<o2::trd::ChamberStatus>("TRD/Calib/ChamberStatus", metadata);
     } else
       cout << "attempt to get object chamber status from ocdb entry. Ergo not writing one to ccdb." << endl;
   } else
@@ -314,7 +315,7 @@ void OCDB2CCDB(Int_t run, const Char_t* storageURI = "alien://folder=/alice/data
 
   if (chamberGainFactor && chamberExB && chamberT0 && chamberVDrift) {
     //if all 4 mmebers of calibrations is here then write to ccdb.
-    ccdb.storeAsTFileAny(o2chambercalibrations, "TRD_test/ChamberCalibrations", metadata, Run, Run + 1);
+    ccdb.storeAsTFileAny(o2chambercalibrations, "TRD/Calib/ChamberCalibrations", metadata, Run, Run + 1);
   } else
     cout << "something wrong with one of the members of ChamberCalibrations and not writing to ccdb, fix :: " << chamberGainFactor << "&&" << chamberExB << "&&" << chamberT0 << "&&" << chamberVDrift << endl;
 
@@ -334,7 +335,7 @@ void OCDB2CCDB(Int_t run, const Char_t* storageURI = "alien://folder=/alice/data
         } else
           cout << "calroc is undefiend" << endl;
       }
-      ccdb.storeAsTFileAny(o2localvdrift, "TRD_test/LocalVDrift", metadata, Run, Run + 1);
+      ccdb.storeAsTFileAny(o2localvdrift, "TRD/Calib/LocalVDrift", metadata, Run, Run + 1);
     } else
       cout << "attempt to get object LocalVdrift from ocdb entry. Will not be writing LocalVDritf" << endl;
   } else
@@ -352,7 +353,7 @@ void OCDB2CCDB(Int_t run, const Char_t* storageURI = "alien://folder=/alice/data
           o2localt0->setPadValue(i, j, calroc->GetValue(j));
         }
       }
-      ccdb.storeAsTFileAny(o2localt0, "TRD_test/LocalT0", metadata, Run, Run + 1);
+      ccdb.storeAsTFileAny(o2localt0, "TRD/Calib/LocalT0", metadata, Run, Run + 1);
     } else
       cout << "attempt to get object chamber LocalT0 from ocdb entry. Will not be writing LocalT0" << endl;
   } else
@@ -371,7 +372,7 @@ void OCDB2CCDB(Int_t run, const Char_t* storageURI = "alien://folder=/alice/data
           o2padnoise->setPadValue(i, j, calroc->GetValue(j));
         }
       }
-      ccdb.storeAsTFileAny(o2padnoise, "TRD_test/PadNoise", metadata, Run, Run + 1);
+      ccdb.storeAsTFileAny(o2padnoise, "TRD/Calib/PadNoise", metadata, Run, Run + 1);
     } else
       cout << "attempt to get object PadNoise from ocdb entry. Will not be writing PadNoise" << endl;
   }
@@ -388,7 +389,7 @@ void OCDB2CCDB(Int_t run, const Char_t* storageURI = "alien://folder=/alice/data
           o2localgainfactor->setPadValue(i, j, calroc->GetValue(j));
         }
       }
-      ccdb.storeAsTFileAny(o2localgainfactor, "TRD_test/LocalGainFactor", metadata, Run, Run + 1);
+      ccdb.storeAsTFileAny(o2localgainfactor, "TRD/Calib/LocalGainFactor", metadata, Run, Run + 1);
     } else
       cout << "attempt to get object LocalGainFactor from ocdb entry. Will not be writing LocalGainFactor" << endl;
   } else
@@ -406,7 +407,7 @@ void OCDB2CCDB(Int_t run, const Char_t* storageURI = "alien://folder=/alice/data
           o2padstatus->setStatus(i, j, rocstatus->GetStatus(j));
         }
       }
-      ccdb.storeAsTFileAny(o2padstatus, "TRD_test/PadStatus", metadata, Run, Run + 1);
+      ccdb.storeAsTFileAny(o2padstatus, "TRD/Calib/PadStatus", metadata, Run, Run + 1);
     }
   }
 
@@ -417,7 +418,7 @@ void OCDB2CCDB(Int_t run, const Char_t* storageURI = "alien://folder=/alice/data
       for (int i = 0; i < AliTRDCalDet::kNdet; i++) {
         o2chambernoise->setNoise(i, chambernoise->GetValue(i));
       }
-      ccdb.storeAsTFileAny(o2chambernoise, "TRD_test/ChamberNoise", metadata, Run, Run + 1);
+      ccdb.storeAsTFileAny(o2chambernoise, "TRD/Calib/ChamberNoise", metadata, Run, Run + 1);
     } else
       cout << "attempt to get object ChamberNoise from ocdb entry. Will not be writing ChamberNoise" << endl;
   }

--- a/Detectors/TRD/base/macros/OCDB2CCDBTrapConfig.C
+++ b/Detectors/TRD/base/macros/OCDB2CCDBTrapConfig.C
@@ -160,8 +160,9 @@ void ParseTrapConfigs(TrapConfig* trapconfig, AliTRDtrapConfig* run2config)
                                                                                                  // the same way as it was done in run2 and nothing in the code allows you to change it.
     }*/
 }
+// choose ccdbPath = "http://ccdb-test.cern.ch:8080" to write to the test CCDB at CERN
 //__________________________________________________________________________________________
-void OCDB2CCDBTrapConfig(Int_t run, const Char_t* storageURI = "alien://folder=/alice/data/2018/OCDB/")
+void OCDB2CCDBTrapConfig(TString ccdbPath = "http://localhost:8080", Int_t run = 297595, const Char_t* storageURI = "local:///cvmfs/alice-ocdb.cern.ch/calibration/data/2018/OCDB")
 {
   //
   // Main function to steer the extraction of TRD OCDB information
@@ -171,7 +172,7 @@ void OCDB2CCDBTrapConfig(Int_t run, const Char_t* storageURI = "alien://folder=/
   TTimeStamp jobStartTime;
   // if the storage is on alien than we need to do some extra stuff
   TString storageString(storageURI);
-  if (storageString.Contains("alien://")) {
+  if (storageString.Contains("raw://")) {
     TGrid::Connect("alien://");
   }
 
@@ -182,8 +183,6 @@ void OCDB2CCDBTrapConfig(Int_t run, const Char_t* storageURI = "alien://folder=/
   storage = manager->GetDefaultStorage();
   AliCDBEntry* entry = NULL;
   Run = run;
-
-  std::string TRDCalBase = "TRD_test";
 
   manager->SetRun(Run);
 
@@ -197,7 +196,7 @@ void OCDB2CCDBTrapConfig(Int_t run, const Char_t* storageURI = "alien://folder=/
   //
   o2::ccdb::CcdbApi ccdb;
   map<string, string> metadata;               // do we want to store any meta data?
-  ccdb.init("http://ccdb-test.cern.ch:8080"); // or http://localhost:8080 for a local installation
+  ccdb.init(ccdbPath.Data());
 
   /*
 AliTRDCalTrapConfig has a print command that outputs the list of trapconfigs stored.
@@ -249,7 +248,6 @@ its all going here unfortunately ....
     "cf_pg-fpnp32_zs-s16-deh_tb24_trkl-b5n-fs1e24-ht200-qs0e23s23e22-pidlhc11dv3en-pt100_ptrg.r5765",
     "cf_pg-fpnp32_zs-s16-deh_tb24_trkl-b5p-fs1e24-ht200-qs0e24s24e23-pidlinear-pt100_ptrg.r5570",
     "cf_pg-fpnp32_zs-s16-deh_tb30_trkl-b0-fs1e30-ht200-qs0e29s29e28-nb233-pidlhc11dv4en_ptrg.r5773",
-    "cf_pg-fpnp32_zs-s16-deh_tb30_trkl-b5n-fs1e24-ht200-qs0e24s24e23-pidlinear-pt100_ptrg.r5549",
     "cf_pg-fpnp32_zs-s16-deh_tb26_trkl-b5n-fs1e24-ht200-qs0e23s23e22-pidlhc11dv3en-pt100_ptrg.r5771",
     "cf_pg-fpnp32_zs-s16-deh_tb30_trkl-b5n-fs1e30-ht200-qs0e29s29e28-nb233-pidlhc11dv4en-pt100_ptrg.r5773",
     "cf_pg-fpnp32_zs-s16-deh_tb24_trkl-b0-fs1e24-ht200-qs0e24s24e23-pidlinear_ptrg.r5570",
@@ -273,9 +271,8 @@ its all going here unfortunately ....
         auto o2trapconfig = new TrapConfig();
         run2trapconfig = run2caltrapconfig->Get(run2trapconfigname.c_str());
         ParseTrapConfigs(o2trapconfig, run2trapconfig);
-        ccdb.storeAsTFileAny(o2trapconfig, "TRD_test/TrapConfig", metadata, 1, 1670700184549); //upper time chosen into the future else the server simply adds a year
-        //    cout << "ccdb.storeAsTFileAny(o2trapconfig, Form(\"" << TRDCalBase.c_str() << "/TrapConfig/" << run2trapconfigname.c_str()<< endl; //upper time chosen into the future else the server simply adds a year
-        //AliTRDcalibDB *calibdb=AliTRDcalibDB::Instance();
+        std::string objectPath = "TRD/TrapConfig/" + run2trapconfigname;
+        ccdb.storeAsTFileAny(o2trapconfig, objectPath, metadata, 1, 1670700184549); //upper time chosen into the future else the server simply adds a year
       }
     }
   }

--- a/Detectors/TRD/base/macros/PrintTrapConfig.C
+++ b/Detectors/TRD/base/macros/PrintTrapConfig.C
@@ -217,7 +217,7 @@ void PrintTrapConfig(Int_t run, const Char_t* storageURI = "alien://folder=/alic
   AliCDBEntry* entry = NULL;
   Run = run;
 
-  std::string TRDCalBase = "TRD_test";
+  std::string TRDCalBase = "TRD";
 
   manager->SetRun(Run);
 
@@ -309,8 +309,8 @@ its all going here unfortunately ....
         PrintTrapConfigsAsStored(run2trapconfig);
         auto& ccdbmgr = o2::ccdb::BasicCCDBManager::instance();
         ccdbmgr.setTimestamp(297595);
-        // auto run3trapconfig = ccdbmgr.get<o2::trd::TrapConfig>("TRD_test/TrapConfig2020/cf_pg-fpnp32_zs-s16-deh_tb30_trkl-b5n-fs1e24-ht200-qs0e24s24e23-pidlinear-pt100_ptrg.r5549");
-        auto run3trapconfig = ccdbmgr.get<o2::trd::TrapConfig>("TRD_test/TrapConfig2020/c");
+        auto run3trapconfig = ccdbmgr.get<o2::trd::TrapConfig>("TRD/TrapConfig/cf_pg-fpnp32_zs-s16-deh_tb30_trkl-b5n-fs1e24-ht200-qs0e24s24e23-pidlinear-pt100_ptrg.r5549");
+        //auto run3trapconfig = ccdbmgr.get<o2::trd::TrapConfig>("TRD/Config/TrapConfig2020");
         if (run3trapconfig)
           PrintTrapConfigsAsStored3(run3trapconfig);
         //     ccdb.storeAsTFileAny(o2trapconfig, Form("%s/TrapConfig2020/%s", TRDCalBase.c_str(), run2trapconfigname.c_str()), metadata, 1, 1670700184549); //upper time chosen into the future else the server simply adds a year

--- a/Detectors/TRD/base/macros/Readocdb.C
+++ b/Detectors/TRD/base/macros/Readocdb.C
@@ -234,8 +234,6 @@ void Readocdb(Int_t run, const Char_t* storageURI = "alien://folder=/alice/data/
   AliCDBEntry* entry = NULL;
   Run = run;
 
-  std::string TRDCalBase = "TRD_test";
-
   manager->SetRun(Run);
 
   time_t startTime = 0;

--- a/Detectors/TRD/base/src/Calibrations.cxx
+++ b/Detectors/TRD/base/src/Calibrations.cxx
@@ -42,58 +42,45 @@ using namespace o2::trd;
 // in some FOO detector code (detector initialization)
 // just give the correct path and you will be served the object
 
-void Calibrations::setCCDB(int calibrationobjecttype, long timestamp)
+void Calibrations::getCCDBObjects(long timestamp)
 {
   auto& ccdbmgr = o2::ccdb::BasicCCDBManager::instance();
+  //ccdbmgr.clearCache();
+  //ccdbmgr.setURL("http://localhost:8080");
+  mTimeStamp = timestamp;
   ccdbmgr.setTimestamp(timestamp); // set which time stamp of data we want this is called per timeframe, and removes the need to call it when querying a value.
-  switch (calibrationobjecttype) {
-    case 1: //simulation
-      mChamberCalibrations = ccdbmgr.get<o2::trd::ChamberCalibrations>("TRD_test/ChamberCalibrations");
-      if (!mChamberCalibrations) {
-        LOG(fatal) << "No chamber calibrations returned from CCDB for TRD calibrations,  or TRD from what ever you are running.";
-      }
-      mLocalVDrift = ccdbmgr.get<o2::trd::LocalVDrift>("TRD_test/LocalVDrift");
-      if (!mLocalVDrift) {
-        LOG(fatal) << "No Local V Drift calibrations returned from CCDB for TRD calibrations,  or TRD from what ever you are running.";
-      }
-      mLocalT0 = ccdbmgr.get<o2::trd::LocalT0>("TRD_test/LocalT0");
-      if (!mLocalT0) {
-        LOG(fatal) << "No Local T0 calibrations returned from CCDB for TRD calibrations,  or TRD from what ever you are running.";
-      }
-      mLocalGainFactor = ccdbmgr.get<o2::trd::LocalGainFactor>("TRD_test/LocalGainFactor");
-      if (!mLocalT0) {
-        LOG(fatal) << "No Local T0 calibrations returned from CCDB for TRD calibrations,  or TRD from what ever you are running.";
-      }
-      mPadNoise = ccdbmgr.get<o2::trd::PadNoise>("TRD_test/PadNoise");
-      if (!mPadNoise) {
-        LOG(fatal) << "No Padnoise calibrations returned from CCDB for TRD calibrations,  or TRD from what ever you are running.";
-      }
-      mChamberStatus = ccdbmgr.get<o2::trd::ChamberStatus>("TRD_test/ChamberStatus");
-      if (!mChamberStatus) {
-        LOG(fatal) << "No ChamberStatus calibrations returned from CCDB for TRD calibrations,  or TRD from what ever you are running.";
-      }
-      mPadStatus = ccdbmgr.get<o2::trd::PadStatus>("TRD_test/PadStatus");
-      if (!mPadStatus) {
-        LOG(fatal) << "No Pad Status calibrations returned from CCDB for TRD calibrations,  or TRD from what ever you are running.";
-      }
-      mChamberNoise = ccdbmgr.get<o2::trd::ChamberNoise>("TRD_test/ChamberNoise");
-      if (!mChamberNoise) {
-        LOG(fatal) << "No ChamberNoise calibrations returned from CCDB for TRD calibrations,  or TRD from what ever you are running.";
-      }
-      //mCalOnlineGainTables= ccdbmgr.get<o2::trd::CalOnlineGainTables>("TRD_test/OnlineGainTables");
-      //std::shared_ptr<TrapConfig> mTrapConfig;
-      //std::shared_ptr<PRFWidth> mPRDWidth
-      //std::shared_ptr<CalOnlineGainTables> mCalOnlineGainTables;
 
-      break;
-    case 2: //reconstruction
-      LOG(fatal) << "Reconstruction calibration not implemented yet ";
-      break;
-    case 3: // calibration
-      LOG(fatal) << "Calibrating calibration not implemented yet ";
-      break;
-    default:
-      LOG(fatal) << "unknown calibration type coming into setCCDB for TRD Calibrations";
+  mChamberCalibrations = ccdbmgr.get<o2::trd::ChamberCalibrations>("TRD/Calib/ChamberCalibrations");
+  if (!mChamberCalibrations) {
+    LOG(fatal) << "No chamber calibrations returned from CCDB for TRD calibrations,  or TRD from what ever you are running.";
+  }
+  mLocalVDrift = ccdbmgr.get<o2::trd::LocalVDrift>("TRD/Calib/LocalVDrift");
+  if (!mLocalVDrift) {
+    LOG(fatal) << "No Local V Drift calibrations returned from CCDB for TRD calibrations,  or TRD from what ever you are running.";
+  }
+  mLocalT0 = ccdbmgr.get<o2::trd::LocalT0>("TRD/Calib/LocalT0");
+  if (!mLocalT0) {
+    LOG(fatal) << "No Local T0 calibrations returned from CCDB for TRD calibrations,  or TRD from what ever you are running.";
+  }
+  mLocalGainFactor = ccdbmgr.get<o2::trd::LocalGainFactor>("TRD/Calib/LocalGainFactor");
+  if (!mLocalT0) {
+    LOG(fatal) << "No Local T0 calibrations returned from CCDB for TRD calibrations,  or TRD from what ever you are running.";
+  }
+  mPadNoise = ccdbmgr.get<o2::trd::PadNoise>("TRD/Calib/PadNoise");
+  if (!mPadNoise) {
+    LOG(fatal) << "No Padnoise calibrations returned from CCDB for TRD calibrations,  or TRD from what ever you are running.";
+  }
+  mChamberStatus = ccdbmgr.get<o2::trd::ChamberStatus>("TRD/Calib/ChamberStatus");
+  if (!mChamberStatus) {
+    LOG(fatal) << "No ChamberStatus calibrations returned from CCDB for TRD calibrations,  or TRD from what ever you are running.";
+  }
+  mPadStatus = ccdbmgr.get<o2::trd::PadStatus>("TRD/Calib/PadStatus");
+  if (!mPadStatus) {
+    LOG(fatal) << "No Pad Status calibrations returned from CCDB for TRD calibrations,  or TRD from what ever you are running.";
+  }
+  mChamberNoise = ccdbmgr.get<o2::trd::ChamberNoise>("TRD/Calib/ChamberNoise");
+  if (!mChamberNoise) {
+    LOG(fatal) << "No ChamberNoise calibrations returned from CCDB for TRD calibrations,  or TRD from what ever you are running.";
   }
 }
 
@@ -104,7 +91,7 @@ void Calibrations::setOnlineGainTables(std::string& tablename)
   }
 
   auto& ccdbmgr = o2::ccdb::BasicCCDBManager::instance();
-  std::string fulltablename = "TRD_test/OnlineGainTables/" + tablename;
+  std::string fulltablename = "TRD/OnlineGainTables/" + tablename;
   mCalOnlineGainTables = ccdbmgr.get<o2::trd::CalOnlineGainTables>(fulltablename);
 }
 

--- a/Detectors/TRD/calibration/README.md
+++ b/Detectors/TRD/calibration/README.md
@@ -1,0 +1,18 @@
+<!-- doxy
+\page refTRDcalibration TRD calibration
+/doxy -->
+
+# TRD calibration in O2
+
+## vDrift and ExB calibration
+
+The drift velocity and ExB angle are calibrated using input from the global tracking, namely ITS-TPC-TRD and TPC-TRD tracks. The latter is currently disabled, but can be enabled to have more statistics easily. From the global tracks we obtain the association of TRD tracklets to tracks. In the calibration procedure  a refit is performed to get TRD only tracks and the angular deviations between those TRD tracks and the associated tracklets are stored in histograms (see class TrackBasedCalib). This is done on the EPNs during the reconstruction. The histograms are send to aggregator nodes which calculate for each TRD chamber the drift velocity and ExB angle based on those histograms (see class CalibratorVdExB).
+
+To run the calibration one can start the following workflow:
+    o2-trd-global-tracking -b --disable-root-output | o2-calibration-trd-vdrift-exb -b --calib-vdexb-calibration '--tf-per-slot 5 --min-entries 50000 --max-delay 90000'
+You can get information on the meaning of the parameters by running `o2-calibration-trd-vdrift-exb -b --help full`
+
+If you want to run the calibration from a local file with residuals, trdangreshistos.root, you can run:
+    o2-calibration-trd-vdrift-exb -b --enable-root-input --calib-vdexb-calibration '--tf-per-slot 1 --min-entries 50000'
+
+## DCS data points

--- a/Detectors/TRD/calibration/src/CalibratorVdExB.cxx
+++ b/Detectors/TRD/calibration/src/CalibratorVdExB.cxx
@@ -163,7 +163,8 @@ void CalibratorVdExB::finalizeSlot(Slot& slot)
     calObject.setVdrift(iDet, vdFitResults[iDet]);
     calObject.setExB(iDet, laFitResults[iDet]);
   }
-  ccdb.storeAsTFileAny(&calObject, "TRD_test/CalVdriftExB", metadata, 265503, 265503 + 1); // temporary only short validity of 1 run
+  auto timeStamp = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+  ccdb.storeAsTFileAny(&calObject, "TRD/Calib/CalVdriftExB", metadata, timeStamp);
 }
 
 Slot& CalibratorVdExB::emplaceNewSlot(bool front, uint64_t tStart, uint64_t tEnd)

--- a/Detectors/TRD/macros/CheckCCDBvalues.C
+++ b/Detectors/TRD/macros/CheckCCDBvalues.C
@@ -43,7 +43,7 @@ void CheckCCDBvalues(const long runNumber = 297595)
   TH1F* histPadGainFactor = new TH1F("histPadGainFactor", ";Pad Gain Factor;Counts", 100, 0, 2);
 
   o2::trd::Calibrations calib;
-  calib.setCCDBForSimulation(runNumber);
+  calib.getCCDBObjects(runNumber);
   for (det = 0; det < 540; ++det) {
     exb = calib.getExB(det);
     histExB->Fill(exb);

--- a/Detectors/TRD/macros/CheckHits.C
+++ b/Detectors/TRD/macros/CheckHits.C
@@ -37,7 +37,7 @@ void CheckHits(const int detector = 50, // 354, 14, 242, 50
                std::string paramfile = "o2sim_par.root")
 {
   // o2::trd::Calibrations calib;
-  // calib.setCCDBForSimulation(297595);
+  // calib.getCCDBObjects(297595);
 
   TFile* fin = TFile::Open(hitfile.data());
   TTree* hitTree = (TTree*)fin->Get("o2sim");

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
@@ -41,8 +41,8 @@ class TRDDPLTrapSimulatorTask : public o2::framework::Task
 
 
  private:
-  TrapConfig* mTrapConfig = nullptr;
-  unsigned long mRunNumber = 297595; //run number to anchor simulation to.
+  TrapConfig* mTrapConfig{nullptr};
+  unsigned long mRunNumber{297595}; //run number to anchor simulation to.
   bool mEnableOnlineGainCorrection{false};
   bool mUseMC{false}; // whether or not to use MC labels
   bool mEnableTrapConfigDump{false};
@@ -51,9 +51,7 @@ class TRDDPLTrapSimulatorTask : public o2::framework::Task
   std::string mOnlineGainTableName;
   std::unique_ptr<Calibrations> mCalib; // store the calibrations connection to CCDB. Used primarily for the gaintables in line above.
 
-  TrapConfig* getTrapConfig();
-  void loadTrapConfig();
-  void loadDefaultTrapConfig();
+  void initTrapConfig();
   void setOnlineGainTables();
   void processTRAPchips(int& nTracklets, std::vector<Tracklet64>& trackletsAccum, std::array<TrapSimulator, constants::NMCMHCMAX>& trapSimulators, std::vector<short>& digitCounts, std::vector<int>& digitIndices);
 };

--- a/Detectors/TRD/workflow/src/TRDDigitizerSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDDigitizerSpec.cxx
@@ -62,7 +62,7 @@ class TRDDPLDigitizerTask : public o2::base::BaseDPLDigitizer
     bool mctruth = pc.outputs().isAllowed({"TRD", "LABELS", 0});
 
     Calibrations simcal;
-    simcal.setCCDBForSimulation(297595);
+    simcal.getCCDBObjects(297595);
     mDigitizer.setCalibrations(&simcal);
 
     // read collision context from input


### PR DESCRIPTION
- TRD TRAP simulator can use different TRAP configs, was hardcoded before
- minor cleanup