### PR TITLE
ConfigParam - Ccdb-Api integration

### DIFF
--- a/CCDB/CMakeLists.txt
+++ b/CCDB/CMakeLists.txt
@@ -53,6 +53,13 @@ o2_add_test(CcdbApi
             PUBLIC_LINK_LIBRARIES O2::CCDB
             LABELS ccdb)
 
+o2_add_test(CcdbApiConfigParam
+		SOURCES test/testCcdbApi_ConfigParam.cxx
+		COMPONENT_NAME ccdb
+		PUBLIC_LINK_LIBRARIES O2::CCDB O2::DetectorsVertexing
+		LABELS ccdb)
+
+
 o2_add_test(CcdbApi-Alien
 		SOURCES test/testCcdbApi_alien.cxx
 		COMPONENT_NAME ccdb

--- a/CCDB/test/testCcdbApi_ConfigParam.cxx
+++ b/CCDB/test/testCcdbApi_ConfigParam.cxx
@@ -1,0 +1,136 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file   testCcdbApi_ConfigParam.cxx
+/// \author Sandro Wenzel
+///
+
+#define BOOST_TEST_MODULE CCDB
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include "CCDB/CcdbApi.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "DetectorsVertexing/PVertexerParams.h"
+#include "CCDB/CCDBTimeStampUtils.h"
+#include <boost/test/unit_test.hpp>
+#include <filesystem>
+#include <cstdio>
+#include <cassert>
+#include <iostream>
+#include <cstdio>
+#include <curl/curl.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <chrono>
+#include <CommonUtils/StringUtils.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/foreach.hpp>
+#include <boost/optional/optional.hpp>
+
+using namespace std;
+using namespace o2::ccdb;
+namespace utf = boost::unit_test;
+namespace tt = boost::test_tools;
+
+static string ccdbUrl;
+static string basePath;
+bool hostReachable = false;
+
+/**
+ * Global fixture, ie general setup and teardown
+ */
+struct Fixture {
+  Fixture()
+  {
+    CcdbApi api;
+    ccdbUrl = "http://ccdb-test.cern.ch:8080";
+    api.init(ccdbUrl);
+    cout << "ccdb url: " << ccdbUrl << endl;
+    hostReachable = api.isHostReachable();
+    cout << "Is host reachable ? --> " << hostReachable << endl;
+    basePath = string("Test/pid") + getpid() + "/";
+    cout << "Path we will use in this test suite : " + basePath << endl;
+  }
+  ~Fixture()
+  {
+    if (hostReachable) {
+      CcdbApi api;
+      map<string, string> metadata;
+      api.init(ccdbUrl);
+      api.truncate(basePath + "*");
+      cout << "Test data truncated (" << basePath << ")" << endl;
+    }
+  }
+};
+BOOST_GLOBAL_FIXTURE(Fixture);
+
+/**
+ * Just an accessor to the hostReachable variable to be used to determine whether tests can be ran or not.
+ */
+struct if_reachable {
+  tt::assertion_result operator()(utf::test_unit_id)
+  {
+    return hostReachable;
+  }
+};
+
+/**
+ * Fixture for the tests, i.e. code is ran in every test that uses it, i.e. it is like a setup and teardown for tests.
+ */
+struct test_fixture {
+  test_fixture()
+  {
+    api.init(ccdbUrl);
+    metadata["Hello"] = "World";
+    std::cout << "*** " << boost::unit_test::framework::current_test_case().p_name << " ***" << std::endl;
+  }
+  ~test_fixture() = default;
+
+  CcdbApi api;
+  map<string, string> metadata;
+};
+
+BOOST_AUTO_TEST_CASE(testConfigParamRetrieval, *utf::precondition(if_reachable()))
+{
+  test_fixture f;
+
+  // We'd like to demonstrate the following:
+  // GIVEN:
+  // - user modifies field in a config param from command line (RT)
+  // - user fetches config param from CCDB
+  //
+  // WE'D LIKE TO ARRIVE AT A STATE with
+  // - the returned object from CCDB gets syncs with the config param registry
+  // - everything is consistent
+
+  // fetch the default instance
+  auto& p1 = o2::vertexing::PVertexerParams::Instance();
+
+  // update the config system with some runtime keys
+  o2::conf::ConfigurableParam::updateFromString("pvertexer.dbscanDeltaT=-3.");
+
+  std::map<std::string, std::string> headers;
+  std::map<std::string, std::string> meta;
+  long from = o2::ccdb::getCurrentTimestamp();
+  auto* object = f.api.retrieveFromTFileAny<o2::vertexing::PVertexerParams>("GLO/Config/PVertexer", meta, from + 1, &headers);
+  BOOST_CHECK(object != nullptr);
+  BOOST_CHECK(object->getMemberProvenance("dbscanDeltaT") == o2::conf::ConfigurableParam::EParamProvenance::kRT);
+  BOOST_CHECK(object->getMemberProvenance("useMeanVertexConstraint") == o2::conf::ConfigurableParam::EParamProvenance::kCCDB);
+  BOOST_CHECK(p1.getMemberProvenance("dbscanDeltaT") == o2::conf::ConfigurableParam::EParamProvenance::kRT);
+  BOOST_CHECK(p1.getMemberProvenance("useMeanVertexConstraint") == o2::conf::ConfigurableParam::EParamProvenance::kCCDB);
+  BOOST_CHECK(object == &p1);
+}

--- a/Common/Utils/include/CommonUtils/ConfigurableParam.h
+++ b/Common/Utils/include/CommonUtils/ConfigurableParam.h
@@ -262,6 +262,10 @@ class ConfigurableParam
   // be updated, absence of data for any of requested params will lead to fatal
   static void updateFromFile(std::string const&, std::string const& paramsList = "", bool unchangedOnly = false);
 
+  // interface for use from the CCDB API; allows to sync objects read from CCDB with the information
+  // stored in the registry; modifies given object as well as registry
+  virtual void syncCCDBandRegistry(void* obj) = 0;
+
  protected:
   // constructor is doing nothing else but
   // registering the concrete parameters
@@ -299,6 +303,7 @@ class ConfigurableParam
   void setRegisterMode(bool b) { sRegisterMode = b; }
   bool isInitialized() const { return sIsFullyInitialized; }
 
+  // friend class o2::ccdb::CcdbApi;
  private:
   // static registry for implementations of this type
   static std::vector<ConfigurableParam*>* sRegisteredParamClasses; //!

--- a/Common/Utils/include/CommonUtils/ConfigurableParamHelper.h
+++ b/Common/Utils/include/CommonUtils/ConfigurableParamHelper.h
@@ -55,6 +55,8 @@ class _ParamHelper
 
   static void assignmentImpl(std::string const& mainkey, TClass* cl, void* to, void* from,
                              std::map<std::string, ConfigurableParam::EParamProvenance>* provmap);
+  static void syncCCDBandRegistry(std::string const& mainkey, TClass* cl, void* to, void* from,
+                                  std::map<std::string, ConfigurableParam::EParamProvenance>* provmap);
 
   static void outputMembersImpl(std::ostream& out, std::string const& mainkey, std::vector<ParamDataMember> const* members, bool showProv);
   static void printMembersImpl(std::string const& mainkey, std::vector<ParamDataMember> const* members, bool showProv);
@@ -160,6 +162,22 @@ class ConfigurableParamHelper : virtual public ConfigurableParam
                                    sValueProvenanceMap);
       delete readback;
     }
+    setRegisterMode(true);
+  }
+
+  // ----------------------------------------------------------------
+
+  void syncCCDBandRegistry(void* externalobj) final
+  {
+    // We may be getting an external copy from CCDB which is passed as externalobj.
+    // The task of this function is to
+    // a) update the internal registry with fields coming from CCDB
+    //    but only if keys have not been modified via RT == command line / ini file
+    // b) update the external object with with fields having RT provenance
+    //
+    setRegisterMode(false);
+    _ParamHelper::syncCCDBandRegistry(getName(), TClass::GetClass(typeid(P)), (void*)this, (void*)externalobj,
+                                      sValueProvenanceMap);
     setRegisterMode(true);
   }
 


### PR DESCRIPTION
Update ConfigurableParams when they are fetched from
CCDB via CcdbApi. This guarantees the following:

a) ConfigParams are updated with the CCDB instance

b) However, members overriden by the user (kRT provenance) are not overriden
   by CCDB values (kRT takes higher priority)