### PR TITLE
Extending DPL input handling and message caching related to [O2 1325] 

### DIFF
--- a/Framework/Core/src/DataRelayer.cxx
+++ b/Framework/Core/src/DataRelayer.cxx
@@ -292,8 +292,7 @@ DataRelayer::RelayChoice
     cachedStateMetrics[cacheIdx] = CacheEntryStatus::PENDING;
     // TODO: make sure that multiple parts can only be added within the same call of
     // DataRelayer::relay
-    assert(nPayloads == 1);
-    assert(nMessages % 2 == 0);
+    assert(nPayloads > 0);
     for (size_t mi = 0; mi < nMessages; ++mi) {
       assert(mi + nPayloads < nMessages);
       target.add([&messages, &mi](size_t i) -> FairMQMessagePtr& { return messages[mi + i]; }, nPayloads + 1);

--- a/Framework/Core/test/test_DataRelayer.cxx
+++ b/Framework/Core/test/test_DataRelayer.cxx
@@ -611,3 +611,123 @@ BOOST_AUTO_TEST_CASE(SplitParts)
   BOOST_CHECK_NE(header2.get(), nullptr);
   BOOST_CHECK_NE(payload2.get(), nullptr);
 }
+
+BOOST_AUTO_TEST_CASE(SplitPayloadPairs)
+{
+  Monitoring metrics;
+  InputSpec spec1{"clusters", "TPC", "CLUSTERS"};
+
+  std::vector<InputRoute> inputs = {
+    InputRoute{spec1, 0, "Fake1", 0},
+  };
+
+  std::vector<ForwardRoute> forwards;
+  TimesliceIndex index{1};
+
+  auto policy = CompletionPolicyHelpers::consumeWhenAny();
+  DataRelayer relayer(policy, inputs, metrics, index);
+  relayer.setPipelineLength(4);
+
+  DataHeader dh{"CLUSTERS", "TPC", 0};
+
+  auto transport = FairMQTransportFactory::CreateTransportFactory("zeromq");
+  auto channelAlloc = o2::pmr::getTransportAllocator(transport.get());
+  size_t timeslice = 0;
+
+  const int nSplitParts = 100;
+  std::vector<std::unique_ptr<FairMQMessage>> splitParts;
+  splitParts.reserve(2 * nSplitParts);
+
+  for (size_t i = 0; i < nSplitParts; ++i) {
+    dh.splitPayloadIndex = i;
+    dh.splitPayloadParts = nSplitParts;
+
+    FairMQMessagePtr header = o2::pmr::getMessage(Stack{channelAlloc, dh, DataProcessingHeader{timeslice, 1}});
+    FairMQMessagePtr payload = transport->CreateMessage(100);
+
+    splitParts.emplace_back(std::move(header));
+    splitParts.emplace_back(std::move(payload));
+  }
+  BOOST_REQUIRE_EQUAL(splitParts.size(), 2 * nSplitParts);
+
+  relayer.relay(splitParts[0]->GetData(), splitParts.data(), splitParts.size());
+  std::vector<RecordAction> ready;
+  relayer.getReadyToProcess(ready);
+  BOOST_REQUIRE_EQUAL(ready.size(), 1);
+  BOOST_REQUIRE_EQUAL(ready[0].op, CompletionPolicy::CompletionOp::Consume);
+  auto messageSet = relayer.consumeAllInputsForTimeslice(ready[0].slot);
+  // we have one input route and thus one message set containing pairs for all
+  // payloads
+  BOOST_REQUIRE_EQUAL(messageSet.size(), 1);
+  BOOST_CHECK_EQUAL(messageSet[0].size(), nSplitParts);
+  BOOST_CHECK_EQUAL(messageSet[0].getNumberOfPayloads(0), 1);
+}
+
+BOOST_AUTO_TEST_CASE(SplitPayloadSequence)
+{
+  Monitoring metrics;
+  InputSpec spec1{"clusters", "TST", "COUNTER"};
+
+  std::vector<InputRoute> inputs = {
+    InputRoute{spec1, 0, "Fake1", 0},
+  };
+
+  std::vector<ForwardRoute> forwards;
+  TimesliceIndex index{1};
+
+  auto policy = CompletionPolicyHelpers::consumeWhenAny();
+  DataRelayer relayer(policy, inputs, metrics, index);
+  relayer.setPipelineLength(4);
+
+  auto transport = FairMQTransportFactory::CreateTransportFactory("zeromq");
+  size_t timeslice = 0;
+
+  std::vector<size_t> sequenceSize;
+  size_t nTotalPayloads = 0;
+
+  auto createSequence = [&nTotalPayloads, &timeslice, &sequenceSize, &transport, &relayer](size_t nPayloads) -> void {
+    auto channelAlloc = o2::pmr::getTransportAllocator(transport.get());
+    std::vector<std::unique_ptr<FairMQMessage>> messages;
+    messages.reserve(nPayloads + 1);
+    DataHeader dh{"COUNTER", "TST", 0};
+
+    // one header with index set to the number of split parts indicates sequence
+    // of payloads without additional headers
+    dh.splitPayloadIndex = nPayloads;
+    dh.splitPayloadParts = nPayloads;
+    FairMQMessagePtr header = o2::pmr::getMessage(Stack{channelAlloc, dh, DataProcessingHeader{timeslice, 1}});
+    messages.emplace_back(std::move(header));
+
+    for (size_t i = 0; i < nPayloads; ++i) {
+      messages.emplace_back(transport->CreateMessage(100));
+      *(reinterpret_cast<size_t*>(messages.back()->GetData())) = nTotalPayloads;
+      ++nTotalPayloads;
+    }
+    BOOST_CHECK_EQUAL(messages.size(), nPayloads + 1);
+    relayer.relay(messages[0]->GetData(), messages.data(), messages.size(), nPayloads);
+    sequenceSize.emplace_back(nPayloads);
+  };
+  createSequence(100);
+  createSequence(1);
+  createSequence(42);
+
+  std::vector<RecordAction> ready;
+  relayer.getReadyToProcess(ready);
+  BOOST_REQUIRE_EQUAL(ready.size(), 1);
+  BOOST_REQUIRE_EQUAL(ready[0].op, CompletionPolicy::CompletionOp::Consume);
+  auto messageSet = relayer.consumeAllInputsForTimeslice(ready[0].slot);
+  // we have one input route
+  BOOST_REQUIRE_EQUAL(messageSet.size(), 1);
+  // one message set containing number of added sequences of messages
+  BOOST_REQUIRE_EQUAL(messageSet[0].size(), sequenceSize.size());
+  size_t counter = 0;
+  for (auto seqid = 0; seqid < sequenceSize.size(); ++seqid) {
+    BOOST_CHECK_EQUAL(messageSet[0].getNumberOfPayloads(seqid), sequenceSize[seqid]);
+    for (auto pi = 0; pi < messageSet[0].getNumberOfPayloads(seqid); ++pi) {
+      BOOST_REQUIRE(messageSet[0].payload(seqid, pi));
+      auto const* data = messageSet[0].payload(seqid, pi)->GetData();
+      BOOST_CHECK_EQUAL(*(reinterpret_cast<size_t const*>(data)), counter);
+      ++counter;
+    }
+  }
+}

--- a/Framework/Core/test/test_VariablePayloadSequenceWorkflow.cxx
+++ b/Framework/Core/test/test_VariablePayloadSequenceWorkflow.cxx
@@ -224,7 +224,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const& config)
     }
   };
 
-  auto createCounters = [](RawDeviceService const& rds) -> std::shared_ptr<ConsumerCounters> {
+  auto createCounters = [](RawDeviceService& rds) -> std::shared_ptr<ConsumerCounters> {
     auto counters = std::make_shared<ConsumerCounters>();
     ConsumerCounters& c = *counters;
     for (auto const& channelSpec : rds.spec().inputChannels) {
@@ -249,7 +249,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const& config)
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // the consumer process connects to the producer
   //
-  auto consumerInit = [createCounters, checkCounters, inputChecker](RawDeviceService const& rds, CallbackService& callbacks) {
+  auto consumerInit = [createCounters, checkCounters, inputChecker](RawDeviceService& rds, CallbackService& callbacks) {
     auto counters = createCounters(rds);
     callbacks.set(CallbackService::Id::Stop, [counters, checkCounters]() {
       ASSERT_ERROR(checkCounters(counters));


### PR DESCRIPTION
This is a prototype which also will allow with a few more changes to activate support for an updated O2 message model where split payloads can be transferred in a sequence with one preceding data header.

Has to be finally activated in `DataProcessingDevice` together with a workflow test.

For using this in the workflows together with Data Distribution, also the raw proxy needs to be extended, and for that a better encapsulation of the message model is in development based on the outcome of the prototype test.