### PR TITLE
Adding WF for calibration based on diagnostic words

### DIFF
--- a/DataFormats/Detectors/TOF/include/DataFormatsTOF/Diagnostic.h
+++ b/DataFormats/Detectors/TOF/include/DataFormatsTOF/Diagnostic.h
@@ -17,6 +17,7 @@
 
 #include <map>
 #include <TObject.h>
+#include <gsl/gsl>
 
 namespace o2
 {
@@ -38,8 +39,11 @@ class Diagnostic
   int fillROW() { return fill(0); }
   int fillEmptyCrate(int crate, int frequency = 1) { return fill(getEmptyCrateKey(crate), frequency); }
   ULong64_t getEmptyCrateKey(int crate);
-  void print();
+  void print() const;
   void clear() { mVector.clear(); }
+  void fill(const Diagnostic& diag);                       // for calibration
+  void fill(const gsl::span<const o2::tof::Diagnostic>){}; // for calibration
+  void merge(const Diagnostic* prev);
 
  private:
   std::map<ULong64_t, uint32_t> mVector; // diagnostic frequency vector (key/pattern , frequency)

--- a/DataFormats/Detectors/TOF/src/Diagnostic.cxx
+++ b/DataFormats/Detectors/TOF/src/Diagnostic.cxx
@@ -14,6 +14,7 @@
 
 #include "DataFormatsTOF/Diagnostic.h"
 #include <iostream>
+#include "Framework/Logger.h"
 
 using namespace o2::tof;
 
@@ -58,9 +59,9 @@ int Diagnostic::getFrequency(ULong64_t pattern)
   return 0;
 }
 
-void Diagnostic::print()
+void Diagnostic::print() const
 {
-  std::cout << "Diagnosti patterns" << std::endl;
+  LOG(INFO) << "Diagnostic patterns";
   for (const auto& [key, value] : mVector) {
     std::cout << key << " = " << value << "; ";
   }
@@ -71,4 +72,21 @@ ULong64_t Diagnostic::getEmptyCrateKey(int crate)
 {
   ULong64_t key = (ULong64_t(11) << 32) + (ULong64_t(crate) << 36); // slot=11 means empty crate
   return key;
+}
+
+void Diagnostic::fill(const Diagnostic& diag)
+{
+  LOG(DEBUG) << "Filling diagnostic word";
+  for (auto const& el : diag.mVector) {
+    LOG(DEBUG) << "Filling diagnostic pattern " << el.first << " adding " << el.second << " to " << getFrequency(el.first) << " --> " << el.second + getFrequency(el.first);
+    fill(el.first, el.second);
+  }
+}
+
+void Diagnostic::merge(const Diagnostic* prev)
+{
+  LOG(DEBUG) << "Merging diagnostic words";
+  for (auto const& el : prev->mVector) {
+    fill(el.first, el.second + getFrequency(el.first));
+  }
 }

--- a/Detectors/TOF/calibration/CMakeLists.txt
+++ b/Detectors/TOF/calibration/CMakeLists.txt
@@ -20,6 +20,7 @@ o2_add_library(TOFCalibration
                        src/TOFDCSProcessor.cxx
                        src/TOFFEElightReader.cxx
                        src/TOFFEElightConfig.cxx
+           src/TOFDiagnosticCalibrator.cxx
                PUBLIC_LINK_LIBRARIES O2::DataFormatsTOF O2::TOFBase
                                      O2::CCDB
                                      O2::DetectorsCalibration
@@ -37,7 +38,8 @@ o2_target_root_dictionary(TOFCalibration
                                   include/TOFCalibration/CollectCalibInfoTOF.h
                                   include/TOFCalibration/TOFDCSProcessor.h
                                   include/TOFCalibration/TOFFEElightReader.h
-                                  include/TOFCalibration/TOFFEElightConfig.h)
+                                  include/TOFCalibration/TOFFEElightConfig.h
+          include/TOFCalibration/TOFDiagnosticCalibrator.h)
 
 if (OpenMP_CXX_FOUND)
     target_compile_definitions(${targetName} PRIVATE WITH_OPENMP)
@@ -47,6 +49,13 @@ endif()
 o2_add_executable(data-generator-workflow
                   COMPONENT_NAME calibration
                   SOURCES testWorkflow/data-generator-workflow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::Framework
+                                    O2::DataFormatsTOF
+                    O2::TOFBase)
+
+o2_add_executable(data-generator-diagnostic-workflow
+                  COMPONENT_NAME calibration
+                  SOURCES testWorkflow/data-generator-diagnostic-workflow.cxx
                   PUBLIC_LINK_LIBRARIES O2::Framework
                                     O2::DataFormatsTOF
                     O2::TOFBase)
@@ -106,3 +115,9 @@ o2_add_executable(tof-dcs-config-processor-workflow
                                         O2::TOFCalibration
                                         O2::DetectorsCalibration)
 
+o2_add_executable(tof-diagnostic-workflow
+                  COMPONENT_NAME calibration
+                  SOURCES testWorkflow/tof-diagnostic-workflow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::Framework
+                  O2::TOFCalibration
+                  O2::DetectorsCalibration)

--- a/Detectors/TOF/calibration/include/TOFCalibration/TOFDiagnosticCalibrator.h
+++ b/Detectors/TOF/calibration/include/TOFCalibration/TOFDiagnosticCalibrator.h
@@ -1,0 +1,54 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef TOF_DIAGNOSTIC_CALIBRATION_H_
+#define TOF_DIAGNOSTIC_CALIBRATION_H_
+
+#include "DetectorsCalibration/TimeSlotCalibration.h"
+#include "DetectorsCalibration/TimeSlot.h"
+#include "DataFormatsTOF/Diagnostic.h"
+#include "CCDB/CcdbObjectInfo.h"
+
+namespace o2
+{
+namespace tof
+{
+
+class TOFDiagnosticCalibrator final : public o2::calibration::TimeSlotCalibration<o2::tof::Diagnostic, o2::tof::Diagnostic>
+{
+  using TFType = uint64_t;
+  using Slot = o2::calibration::TimeSlot<o2::tof::Diagnostic>;
+  using CcdbObjectInfo = o2::ccdb::CcdbObjectInfo;
+  using CcdbObjectInfoVector = std::vector<CcdbObjectInfo>;
+
+ public:
+  TOFDiagnosticCalibrator(){};
+  ~TOFDiagnosticCalibrator() final = default;
+  bool hasEnoughData(const Slot& slot) const final { return true; }
+  void initOutput() final;
+  void finalizeSlot(Slot& slot) final;
+  Slot& emplaceNewSlot(bool front, TFType tstart, TFType tend) final;
+
+  const std::vector<Diagnostic>& getDiagnosticVector() const { return mDiagnosticVector; }
+  const CcdbObjectInfoVector& getDiagnosticInfoVector() const { return mccdbInfoVector; }
+  CcdbObjectInfoVector& getDiagnosticInfoVector() { return mccdbInfoVector; }
+
+ private:
+  CcdbObjectInfoVector mccdbInfoVector;
+  std::vector<Diagnostic> mDiagnosticVector;
+
+  ClassDefOverride(TOFDiagnosticCalibrator, 1);
+};
+
+} // end namespace tof
+} // end namespace o2
+
+#endif /* TOF_DIAGNOSTIC_CALIBRATION_H_ */

--- a/Detectors/TOF/calibration/src/TOFCalibrationLinkDef.h
+++ b/Detectors/TOF/calibration/src/TOFCalibrationLinkDef.h
@@ -48,4 +48,8 @@
 #pragma link C++ struct TOFFEElightConfig + ;
 #pragma link C++ struct TOFFEElightReader + ;
 
+#pragma link C++ class o2::calibration::TimeSlot < o2::tof::Diagnostic> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tof::Diagnostic, o2::tof::Diagnostic> + ;
+#pragma link C++ class o2::tof::TOFDiagnosticCalibrator + ;
+
 #endif

--- a/Detectors/TOF/calibration/src/TOFDiagnosticCalibrator.cxx
+++ b/Detectors/TOF/calibration/src/TOFDiagnosticCalibrator.cxx
@@ -1,0 +1,56 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "TOFCalibration/TOFDiagnosticCalibrator.h"
+#include "Framework/Logger.h"
+#include "DetectorsCalibration/Utils.h"
+#include "CommonUtils/MemFileHelper.h"
+#include "CCDB/CcdbApi.h"
+
+namespace o2
+{
+namespace tof
+{
+
+using Slot = o2::calibration::TimeSlot<o2::tof::Diagnostic>;
+
+//----------------------------------------------------------
+void TOFDiagnosticCalibrator::initOutput()
+{
+  mccdbInfoVector.clear();
+  mDiagnosticVector.clear();
+}
+
+//----------------------------------------------------------
+void TOFDiagnosticCalibrator::finalizeSlot(Slot& slot)
+{
+
+  Diagnostic* diag = slot.getContainer();
+  LOG(INFO) << "Finalizing slot";
+  diag->print();
+  std::map<std::string, std::string> md;
+  auto clName = o2::utils::MemFileHelper::getClassName(*diag);
+  auto flName = o2::ccdb::CcdbApi::generateFileName(clName);
+  mccdbInfoVector.emplace_back("TOF/Calib/Diagnostic", clName, flName, md, slot.getTFStart(), 99999999999999);
+  mDiagnosticVector.emplace_back(*diag);
+}
+
+//----------------------------------------------------------
+Slot& TOFDiagnosticCalibrator::emplaceNewSlot(bool front, TFType tstart, TFType tend)
+{
+  auto& cont = getSlots();
+  auto& slot = front ? cont.emplace_front(tstart, tend) : cont.emplace_back(tstart, tend);
+  slot.setContainer(std::make_unique<Diagnostic>());
+  return slot;
+}
+
+} // end namespace tof
+} // end namespace o2

--- a/Detectors/TOF/calibration/testWorkflow/TOFDiagnosticCalibratorSpec.h
+++ b/Detectors/TOF/calibration/testWorkflow/TOFDiagnosticCalibratorSpec.h
@@ -1,0 +1,116 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TOF_DIAGNOSTIC_CALIBRATOR_H
+#define O2_TOF_DIAGNOSTIC_CALIBRATOR_H
+
+/// @file   TOFDiagnosticCalibratorSpec.h
+/// @brief  Device to stor in CCDB the diagnostic words from TOF
+
+#include "TOFCalibration/TOFDiagnosticCalibrator.h"
+#include "DetectorsCalibration/Utils.h"
+#include "CommonUtils/MemFileHelper.h"
+#include "Framework/Task.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "Framework/WorkflowSpec.h"
+#include "CCDB/CcdbApi.h"
+#include "CCDB/CcdbObjectInfo.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace calibration
+{
+
+class TOFDiagnosticCalibDevice : public o2::framework::Task
+{
+ public:
+  void init(o2::framework::InitContext& ic) final
+  {
+    int slotL = ic.options().get<int>("tf-per-slot");
+    int delay = ic.options().get<int>("max-delay");
+    mCalibrator = std::make_unique<o2::tof::TOFDiagnosticCalibrator>();
+    mCalibrator->setSlotLength(slotL);
+    mCalibrator->setMaxSlotsDelay(delay);
+  }
+
+  void run(o2::framework::ProcessingContext& pc) final
+  {
+    auto tfcounter = o2::header::get<o2::framework::DataProcessingHeader*>(pc.inputs().get("input").header)->startTime;
+    auto const data = pc.inputs().get<o2::tof::Diagnostic*>("input");
+    LOG(INFO) << "Processing TF " << tfcounter;
+    mCalibrator->process<o2::tof::Diagnostic>(tfcounter, *data);
+    sendOutput(pc.outputs());
+  }
+
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final
+  {
+    LOG(INFO) << "Finalizing calibration";
+    constexpr uint64_t INFINITE_TF = 0xffffffffffffffff;
+    mCalibrator->checkSlotsToFinalize(INFINITE_TF);
+    sendOutput(ec.outputs());
+  }
+
+ private:
+  std::unique_ptr<o2::tof::TOFDiagnosticCalibrator> mCalibrator;
+
+  //________________________________________________________________
+  void sendOutput(DataAllocator& output)
+  {
+    // extract CCDB infos and calibration objects, convert it to TMemFile and send them to the output
+    // TODO in principle, this routine is generic, can be moved to Utils.h
+    using clbUtils = o2::calibration::Utils;
+    const auto& payloadVec = mCalibrator->getDiagnosticVector();
+    auto& infoVec = mCalibrator->getDiagnosticInfoVector(); // use non-const version as we update it
+    assert(payloadVec.size() == infoVec.size());
+    for (uint32_t i = 0; i < payloadVec.size(); i++) {
+      auto& w = infoVec[i];
+      auto image = o2::ccdb::CcdbApi::createObjectImage(&payloadVec[i], &w);
+      LOG(INFO) << "Sending object " << w.getPath() << "/" << w.getFileName() << " of size " << image->size()
+                << " bytes, valid for " << w.getStartValidityTimestamp() << " : " << w.getEndValidityTimestamp();
+      output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "TOF_Diagnostic", i}, *image.get()); // vector<char>
+      output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "TOF_Diagnostic", i}, w);            // root-serialized
+    }
+    if (payloadVec.size()) {
+      mCalibrator->initOutput(); // reset the outputs once they are already sent
+    }
+  }
+};
+
+} // namespace calibration
+
+namespace framework
+{
+
+DataProcessorSpec getTOFDiagnosticCalibDeviceSpec()
+{
+  using device = o2::calibration::TOFDiagnosticCalibDevice;
+  using clbUtils = o2::calibration::Utils;
+
+  std::vector<OutputSpec> outputs;
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "TOF_Diagnostic"});
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "TOF_Diagnostic"});
+  return DataProcessorSpec{
+    "tof-diagnostic-calibration",
+    Inputs{{"input", "TOF", "DIAGNOSTIC"}},
+    outputs,
+    AlgorithmSpec{adaptFromTask<device>()},
+    Options{
+      {"tf-per-slot", VariantType::Int, 5, {"number of TFs per calibration time slot"}},
+      {"max-delay", VariantType::Int, 3, {"number of slots in past to consider"}}}};
+}
+
+} // namespace framework
+} // namespace o2
+
+#endif

--- a/Detectors/TOF/calibration/testWorkflow/data-generator-diagnostic-workflow.cxx
+++ b/Detectors/TOF/calibration/testWorkflow/data-generator-diagnostic-workflow.cxx
@@ -44,6 +44,6 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     ngen = 1;
   }
   specs.emplace_back(getTFDispatcherSpec(slot, ngen, nlanes, std::max(1, int(float(latency) / nlanes / pressure))));
-  specs.emplace_back(timePipeline(getTFProcessorCalibInfoTOFSpec(latency, latencyRMS), nlanes));
+  specs.emplace_back(timePipeline(getTFProcessorDiagnosticSpec(latency, latencyRMS), nlanes));
   return specs;
 }

--- a/Detectors/TOF/calibration/testWorkflow/tof-diagnostic-workflow.cxx
+++ b/Detectors/TOF/calibration/testWorkflow/tof-diagnostic-workflow.cxx
@@ -1,0 +1,32 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/DataProcessorSpec.h"
+#include "TOFDiagnosticCalibratorSpec.h"
+
+using namespace o2::framework;
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  WorkflowSpec specs;
+  specs.emplace_back(getTOFDiagnosticCalibDeviceSpec());
+  return specs;
+}


### PR DESCRIPTION
This is the workflow to propagate to the CCDB the diagnostic words from decoding. 

Example usage:

`o2-calibration-data-generator-diagnostic-workflow --max-timeframes 10 | o2-calibration-tof-diagnostic-workflow  | o2-calibration-ccdb-populator-workflow --ccdb-path="http://localhost:8080"`
