### PR TITLE
[MFT] Use unique volume names

### DIFF
--- a/Detectors/ITSMFT/MFT/base/src/HalfCone.cxx
+++ b/Detectors/ITSMFT/MFT/base/src/HalfCone.cxx
@@ -54,7 +54,7 @@ HalfCone::~HalfCone() = default;
 TGeoVolumeAssembly* HalfCone::createHalfCone(Int_t half)
 {
 
-  auto* HalfConeVolume = new TGeoVolumeAssembly("HalfConeVolume");
+  auto* HalfConeVolume = new TGeoVolumeAssembly(Form("HalfConeVolume%d", half));
 
   TGeoMedium* malu5083 = gGeoManager->GetMedium("MFT_Alu5083$");
 


### PR DESCRIPTION
* MFT half cones seem to be only volumes in geo tree with non-unique
  names

* fixes potential issues related to finding correct volume by name or
  geo path