### PR TITLE
[EMCAL-630] Add DDL ID in case of hardware address error to infologger

### DIFF
--- a/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
@@ -155,7 +155,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
         currentCellContainer = found->second;
       }
 
-      if (feeID > 40) {
+      if (feeID >= 40) {
         continue; //skip STU ddl
       }
 
@@ -240,7 +240,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
           iCol = map.getColumn(chan.getHardwareAddress());
           chantype = map.getChannelType(chan.getHardwareAddress());
         } catch (Mapper::AddressNotFoundException& ex) {
-          LOG(ERROR) << ex.what();
+          LOG(ERROR) << "Hardware correction DDL " << feeID << ex.what();
           continue;
         };
 


### PR DESCRIPTION
This is necessary to figure out which SM is raising
the address error (most likely due to faulty configuration)
In addition excluding DDL ID 40 though it should
normally be empty