### PR TITLE
[EMCAL-606] Test all mappings in the test for the mapper

### DIFF
--- a/Detectors/EMCAL/base/include/EMCALBase/Mapper.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/Mapper.h
@@ -19,6 +19,7 @@
 #include <unordered_map>
 #include <sstream>
 #include <string>
+#include <boost/container_hash/hash.hpp>
 
 #include "fmt/format.h"
 #include "RStringView.h"
@@ -64,10 +65,17 @@ class Mapper
     /// \return hash value for channel ID
     size_t operator()(const ChannelID& s) const
     {
+      std::size_t seed = 0;
+      boost::hash_combine(seed, s.mRow);
+      boost::hash_combine(seed, s.mColumn);
+      boost::hash_combine(seed, o2::emcal::channelTypeToInt(s.mChannelType));
+      return seed;
+      /*
       size_t h1 = std::hash<int>()(s.mRow);
       size_t h2 = std::hash<int>()(s.mColumn);
       size_t h3 = std::hash<int>()(o2::emcal::channelTypeToInt(s.mChannelType));
       return ((h1 ^ (h2 << 1)) >> 1) ^ (h3 << 1);
+      */
     }
   };
 

--- a/Detectors/EMCAL/base/test/testMapper.cxx
+++ b/Detectors/EMCAL/base/test/testMapper.cxx
@@ -12,6 +12,7 @@
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
+#include <fmt/format.h>
 #include <DataFormatsEMCAL/Constants.h>
 #include "EMCALBase/Mapper.h"
 #include <array>
@@ -20,7 +21,15 @@
 #include <vector>
 #include "RStringView.h"
 
-std::vector<std::array<int, 4>> loadReferenceMapping(const std::string_view filename);
+struct refchannel {
+  int mAddress;
+  int mRow;
+  int mCol;
+  int mCellType;
+  int mAmbiguous;
+};
+
+std::vector<refchannel> loadReferenceMapping(const std::string_view filename);
 
 /// \macro Test implementation of the EMCAL mapper
 ///
@@ -39,43 +48,69 @@ BOOST_AUTO_TEST_CASE(Mapper_test)
   }
   inputDir += "/share/Detectors/EMC/files/";
 
-  std::string mappingfile = inputDir + "RCU0A.data";
-  o2::emcal::Mapper testmapper(mappingfile);
+  std::vector<char> sides = {'A', 'C'};
+  for (auto side : sides) {
+    for (int iddl = 0; iddl < 2; iddl++) {
+      std::string mappingbase = fmt::format("RCU{}{}.data", iddl, side);
+      std::cout << "Test mapping " << mappingbase << std::endl;
+      std::string mappingfile = inputDir + mappingbase;
+      o2::emcal::Mapper testmapper(mappingfile);
 
-  // Load reference mapping (same file)
-  auto refmapping = loadReferenceMapping(mappingfile);
+      // Load reference mapping (same file)
+      auto refmapping = loadReferenceMapping(mappingfile);
 
-  // test mapping of channel
-  for (const auto& chan : refmapping) {
-    BOOST_CHECK_EQUAL(chan[1], testmapper.getRow(chan[0]));
-    BOOST_CHECK_EQUAL(chan[2], testmapper.getColumn(chan[0]));
-    BOOST_CHECK_EQUAL(o2::emcal::intToChannelType(chan[3]), testmapper.getChannelType(chan[0]));
-    BOOST_CHECK_EQUAL(chan[0], testmapper.getHardwareAddress(chan[1], chan[2], o2::emcal::intToChannelType(chan[3]))); // test of inverse mapping
+      // test mapping of channel
+      for (const auto& chan : refmapping) {
+        BOOST_CHECK_EQUAL(chan.mRow, testmapper.getRow(chan.mAddress));
+        BOOST_CHECK_EQUAL(chan.mCol, testmapper.getColumn(chan.mAddress));
+        BOOST_CHECK_EQUAL(o2::emcal::intToChannelType(chan.mCellType), testmapper.getChannelType(chan.mAddress));
+        if (!chan.mAmbiguous) {
+          // Skip channels in inverse mapping for which two hardware adresses are registered
+          // (feature of the odd DDL mappings)
+          BOOST_CHECK_EQUAL(chan.mAddress, testmapper.getHardwareAddress(chan.mRow, chan.mCol, o2::emcal::intToChannelType(chan.mCellType))); // test of inverse mapping
+        }
+      }
+      if (mappingbase == "RCU0A.data") {
+        // test of the error handling:
+        // Hardware address outside range
+        BOOST_CHECK_EXCEPTION(testmapper.getRow(4000), o2::emcal::Mapper::AddressNotFoundException, [](o2::emcal::Mapper::AddressNotFoundException const& e) { return e.getAddress() == 4000; });
+        // Row, and column out of range
+        BOOST_CHECK_EXCEPTION(testmapper.getHardwareAddress(16, 0, o2::emcal::ChannelType_t::HIGH_GAIN), o2::emcal::Mapper::ChannelNotFoundException, [](o2::emcal::Mapper::ChannelNotFoundException const& e) { return e.getChannel().mRow == 16; });
+        BOOST_CHECK_EXCEPTION(testmapper.getHardwareAddress(0, 128, o2::emcal::ChannelType_t::TRU), o2::emcal::Mapper::ChannelNotFoundException, [](o2::emcal::Mapper::ChannelNotFoundException const& e) { return e.getChannel().mColumn == 128; });
+      }
+    }
   }
-
-  // test of the error handling:
-  // Hardware address outside range
-  BOOST_CHECK_EXCEPTION(testmapper.getRow(4000), o2::emcal::Mapper::AddressNotFoundException, [](o2::emcal::Mapper::AddressNotFoundException const& e) { return e.getAddress() == 4000; });
-  // Row, and column out of range
-  BOOST_CHECK_EXCEPTION(testmapper.getHardwareAddress(16, 0, o2::emcal::ChannelType_t::HIGH_GAIN), o2::emcal::Mapper::ChannelNotFoundException, [](o2::emcal::Mapper::ChannelNotFoundException const& e) { return e.getChannel().mRow == 16; });
-  BOOST_CHECK_EXCEPTION(testmapper.getHardwareAddress(0, 128, o2::emcal::ChannelType_t::TRU), o2::emcal::Mapper::ChannelNotFoundException, [](o2::emcal::Mapper::ChannelNotFoundException const& e) { return e.getChannel().mColumn == 128; });
 }
 
 /// \brief Load reference mapping from mapping file
 /// \param mappingfile Full path to the file with the mapping
 /// \return Vector with channel information (as integers)
-std::vector<std::array<int, 4>> loadReferenceMapping(const std::string_view mappingfile)
+std::vector<refchannel> loadReferenceMapping(const std::string_view mappingfile)
 {
+  std::vector<refchannel> mapping;
   std::ifstream in(mappingfile.data());
   std::string tmpstr;
+  // skip first two lines (header)
   std::getline(in, tmpstr);
-  std::vector<std::array<int, 4>> mapping;
   std::getline(in, tmpstr);
   int address, row, col, caloflag;
+  int nline = 0;
   while (std::getline(in, tmpstr)) {
     std::stringstream addressdecoder(tmpstr);
     addressdecoder >> address >> row >> col >> caloflag;
-    mapping.push_back({{address, row, col, caloflag}});
+    // check whether the col/row is already registered with a different hardware address
+    // Odd-DDLs have several TRU channels listed with different hardware addresses
+    // In such cases the inverse mapping cannot be tested reliably due to ambiguity and
+    // must be skipped.
+    auto channelPresent = std::find_if(mapping.begin(), mapping.end(), [row, col, caloflag](const refchannel& test) {
+      return row == test.mRow && col == test.mCol && caloflag == test.mCellType;
+    });
+    bool ambiguous = false;
+    if (channelPresent != mapping.end()) {
+      ambiguous = true;
+      channelPresent->mAmbiguous = ambiguous;
+    }
+    mapping.push_back({address, row, col, caloflag, ambiguous});
   }
 
   return mapping;


### PR DESCRIPTION
- Add missing DDL mappings to the test
- Exclude ambiguous channels from the test of the
  inverse mapping
- Use boost::hash_combine to calculate hash value
  for inverse mapping