### PR TITLE
[MCH] propagate ROF width

### DIFF
--- a/Detectors/MUON/MCH/Workflow/src/ClusterFinderOriginalSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/ClusterFinderOriginalSpec.cxx
@@ -104,7 +104,8 @@ class ClusterFinderOriginalTask
       mTimeClusterFinder += tEnd - tStart;
 
       // fill the ouput messages
-      clusterROFs.emplace_back(preClusterROF.getBCData(), clusters.size(), mClusterFinder.getClusters().size());
+      clusterROFs.emplace_back(preClusterROF.getBCData(), clusters.size(), mClusterFinder.getClusters().size(),
+                               preClusterROF.getBCWidth());
       writeClusters(clusters, usedDigits);
     }
 

--- a/Detectors/MUON/MCH/Workflow/src/PreClusterFinderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/PreClusterFinderSpec.cxx
@@ -142,7 +142,7 @@ class PreClusterFinderTask
 
       // get the preclusters and associated digits
       tStart = std::chrono::high_resolution_clock::now();
-      preClusterROFs.emplace_back(digitROF.getBCData(), mPreClusters.size(), nPreClusters);
+      preClusterROFs.emplace_back(digitROF.getBCData(), mPreClusters.size(), nPreClusters, digitROF.getBCWidth());
       mPreClusterFinder.getPreClusters(mPreClusters, mUsedDigits);
       tEnd = std::chrono::high_resolution_clock::now();
       mTimeStorePreClusters += tEnd - tStart;

--- a/Detectors/MUON/MCH/Workflow/src/TrackFinderOriginalSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackFinderOriginalSpec.cxx
@@ -116,7 +116,8 @@ class TrackFinderTask
       // fill the ouput messages
       int trackOffset(mchTracks.size());
       writeTracks(tracks, mchTracks, usedClusters);
-      trackROFs.emplace_back(clusterROF.getBCData(), trackOffset, mchTracks.size() - trackOffset);
+      trackROFs.emplace_back(clusterROF.getBCData(), trackOffset, mchTracks.size() - trackOffset,
+                             clusterROF.getBCWidth());
     }
   }
 

--- a/Detectors/MUON/MCH/Workflow/src/TrackFinderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackFinderSpec.cxx
@@ -133,7 +133,8 @@ class TrackFinderTask
       // fill the ouput messages
       int trackOffset(mchTracks.size());
       writeTracks(tracks, mchTracks, usedClusters);
-      trackROFs.emplace_back(clusterROF.getBCData(), trackOffset, mchTracks.size() - trackOffset);
+      trackROFs.emplace_back(clusterROF.getBCData(), trackOffset, mchTracks.size() - trackOffset,
+                             clusterROF.getBCWidth());
     }
 
     LOGP(info, "Found {:3d} MCH tracks from {:4d} clusters in {:2d} ROFs",

--- a/Detectors/MUON/MCH/Workflow/src/TrackFitterSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackFitterSpec.cxx
@@ -119,7 +119,7 @@ class TrackFitterTask
       }
 
       // write the current ROF with references to the associated tracks
-      rofsOut.emplace_back(rof.getBCData(), trackOffset, tracksOut.size() - trackOffset);
+      rofsOut.emplace_back(rof.getBCData(), trackOffset, tracksOut.size() - trackOffset, rof.getBCWidth());
     }
   }
 


### PR DESCRIPTION
The width of the ROF record determined by the time clustering must be propagated along the reconstruction chain, so that the matching with the MID is done within the correct MCH time window.