### PR TITLE
use default d-tor for FairMQOutputStream

### DIFF
--- a/Framework/Core/src/FairMQResizableBuffer.cxx
+++ b/Framework/Core/src/FairMQResizableBuffer.cxx
@@ -53,13 +53,6 @@ Status FairMQOutputStream::Reset(int64_t initial_capacity, MemoryPool* pool)
   return Status::OK();
 }
 
-FairMQOutputStream::~FairMQOutputStream()
-{
-  // By the time we call the destructor, the contents
-  // of the buffer are already moved to fairmq
-  // for being sent.
-}
-
 Status FairMQOutputStream::Close()
 {
   if (is_open_) {

--- a/Framework/Core/src/FairMQResizableBuffer.h
+++ b/Framework/Core/src/FairMQResizableBuffer.h
@@ -41,7 +41,10 @@ class FairMQOutputStream : public OutputStream
   static Result<std::shared_ptr<FairMQOutputStream>> Create(
     int64_t initial_capacity = 4096, MemoryPool* pool = default_memory_pool());
 
-  ~FairMQOutputStream() override;
+  // By the time we call the destructor, the contents
+  // of the buffer are already moved to fairmq
+  // for being sent.
+  ~FairMQOutputStream() override = default;
 
   // Implement the OutputStream interface
 


### PR DESCRIPTION
@ktf the FullCI was failing due to the 
```
/sw/SOURCES/O2/7140-slc8_x86-64/0/Framework/Core/src/FairMQResizableBuffer.cxx:56:21: error: use '= default' to define a trivial destructor [modernize-use-equals-default]
```