### PR TITLE
[EMCAL-548] Using raw fitter to convert digits to cells

### DIFF
--- a/Detectors/EMCAL/reconstruction/CMakeLists.txt
+++ b/Detectors/EMCAL/reconstruction/CMakeLists.txt
@@ -40,6 +40,7 @@ o2_target_root_dictionary(
                           EMCALReconstruction
                           HEADERS include/EMCALReconstruction/RawReaderMemory.h
                                   include/EMCALReconstruction/AltroDecoder.h
+                                  include/EMCALReconstruction/AltroHelper.h
                                   include/EMCALReconstruction/RawPayload.h
                                   include/EMCALReconstruction/Bunch.h
                                   include/EMCALReconstruction/Channel.h

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/AltroHelper.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/AltroHelper.h
@@ -1,0 +1,78 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef ALICEO2_EMCAL_ALTROHELPER_H_
+#define ALICEO2_EMCAL_ALTROHELPER_H_
+
+#include <Rtypes.h>
+#include <iosfwd>
+#include <exception>
+#include <cstdint>
+#include <vector>
+#include <map>
+#include "DataFormatsEMCAL/Digit.h"
+#include "EMCALReconstruction/Bunch.h"
+
+namespace o2
+{
+namespace emcal
+{
+
+/// \struct AltroBunch
+/// \brief ALTRO bunch information obtained from digits
+struct AltroBunch {
+  int mStarttime;         ///< Start time of the bunch
+  std::vector<int> mADCs; ///< ADCs belonging to the bunch
+};
+
+/// \struct ChannelData
+/// \brief Structure for mapping digits to Channels within a SRU
+struct ChannelData {
+  int mRow;                               ///< Row of the channel
+  int mCol;                               ///< Column of the channel
+  std::vector<o2::emcal::Digit*> mDigits; ///< Digits for the channel  within the current event
+};
+
+/// \struct SRUDigitContainer
+/// \brief Structure for organizing digits within the SRU
+struct SRUDigitContainer {
+  int mSRUid;                           ///< DDL of the SRU
+  std::map<int, ChannelData> mChannels; ///< Containers for channels within the SRU
+};
+
+/// \struct ChannelDigits
+/// \brief Structure for mapping digits to Channels within a SRU
+struct ChannelDigits {
+  o2::emcal::ChannelType_t mChanType;
+  std::vector<const o2::emcal::Digit*> mChannelDigits;
+};
+
+/// \struct DigitContainerPerSRU
+/// \brief Structure for organizing digits within the SRU and preserves the digit type
+struct DigitContainerPerSRU {
+  int mSRUid;                                   ///< DDL of the SRU
+  std::map<int, ChannelDigits> mChannelsDigits; ///< Containers for channels within the SRU
+};
+
+struct ChannelBunchData {
+  o2::emcal::ChannelType_t mChanType;
+  std::vector<o2::emcal::Bunch> mChannelsBunches;
+};
+
+/// \struct SRUBunchContainer
+/// \brief Structure for organizing Bunches within the SRU
+struct SRUBunchContainer {
+  int mSRUid;                                    ///< DDL of the SRU
+  std::map<int, ChannelBunchData> mChannelsData; ///< Containers for channels' bunches within the SRU
+};
+
+} // namespace emcal
+} // namespace o2
+#endif

--- a/Detectors/EMCAL/simulation/CMakeLists.txt
+++ b/Detectors/EMCAL/simulation/CMakeLists.txt
@@ -13,7 +13,7 @@ o2_add_library(EMCALSimulation
                SOURCES src/Detector.cxx src/Digitizer.cxx src/SDigitizer.cxx
                        src/DigitsWriteoutBuffer.cxx src/SpaceFrame.cxx src/SimParam.cxx
                        src/LabeledDigit.cxx src/RawWriter.cxx
-               PUBLIC_LINK_LIBRARIES O2::EMCALBase O2::DetectorsBase O2::SimConfig O2::SimulationDataFormat O2::Headers O2::DetectorsRaw)
+               PUBLIC_LINK_LIBRARIES O2::EMCALBase O2::DetectorsBase O2::SimConfig O2::SimulationDataFormat O2::Headers O2::DetectorsRaw O2::EMCALReconstruction)
 
 o2_target_root_dictionary(EMCALSimulation
                           HEADERS include/EMCALSimulation/Detector.h

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/RawWriter.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/RawWriter.h
@@ -28,6 +28,7 @@
 #include "EMCALBase/Mapper.h"
 #include "DataFormatsEMCAL/Digit.h"
 #include "DataFormatsEMCAL/TriggerRecord.h"
+#include "EMCALReconstruction/AltroHelper.h"
 
 namespace o2
 {
@@ -36,28 +37,6 @@ namespace emcal
 {
 
 class Geometry;
-
-/// \struct AltroBunch
-/// \brief ALTRO bunch information obtained from digits
-struct AltroBunch {
-  int mStarttime;         ///< Start time of the bunch
-  std::vector<int> mADCs; ///< ADCs belonging to the bunch
-};
-
-/// \struct ChannelData
-/// \brief Structure for mapping digits to Channels within a SRU
-struct ChannelData {
-  int mRow;                               ///< Row of the channel
-  int mCol;                               ///< Column of the channel
-  std::vector<o2::emcal::Digit*> mDigits; ///< Digits for the channel  within the current event
-};
-
-/// \struct SRUDigitContainer
-/// \brief Structure for organizing digits within the SRU
-struct SRUDigitContainer {
-  int mSRUid;                           ///< DDL of the SRU
-  std::map<int, ChannelData> mChannels; ///< Containers for channels within the SRU
-};
 
 /// \union ChannelHeader
 /// \brief Bitfield encoding channel headers

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/CellConverterSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/CellConverterSpec.h
@@ -17,6 +17,7 @@
 #include "Framework/Task.h"
 #include "EMCALBase/Geometry.h"
 #include "EMCALReconstruction/CaloRawFitter.h"
+#include "EMCALReconstruction/AltroHelper.h"
 
 namespace o2
 {
@@ -24,30 +25,6 @@ namespace o2
 namespace emcal
 {
 
-struct AltroBunch {
-  int mStarttime;
-  std::vector<int> mADCs;
-};
-
-struct ChannelDigits {
-  o2::emcal::ChannelType_t mChanType;
-  std::vector<const o2::emcal::Digit*> mChannelDigits;
-};
-
-struct SRUDigitContainer {
-  int mSRUid;
-  std::map<int, ChannelDigits> mChannelsDigits;
-};
-
-struct ChannelData {
-  o2::emcal::ChannelType_t mChanType;
-  std::vector<o2::emcal::Bunch> mChannelsBunches;
-};
-
-struct SRUBunchContainer {
-  int mSRUid;
-  std::map<int, ChannelData> mChannelsData;
-};
 namespace reco_workflow
 {
 

--- a/Detectors/EMCAL/workflow/src/CellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/CellConverterSpec.cxx
@@ -15,19 +15,43 @@
 #include "DataFormatsEMCAL/EMCALBlockHeader.h"
 #include "EMCALWorkflow/CellConverterSpec.h"
 #include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
 #include "DataFormatsEMCAL/MCLabel.h"
+#include "EMCALBase/Geometry.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
+#include "EMCALReconstruction/CaloRawFitterStandard.h"
+#include "EMCALReconstruction/CaloRawFitterGamma2.h"
 
 using namespace o2::emcal::reco_workflow;
 
 void CellConverterSpec::init(framework::InitContext& ctx)
 {
   LOG(DEBUG) << "[EMCALCellConverter - init] Initialize converter " << (mPropagateMC ? "with" : "without") << " MC truth container";
+
+  if (!mGeometry) {
+    mGeometry = o2::emcal::Geometry::GetInstanceFromRunNumber(223409);
+  }
+  if (!mGeometry) {
+    LOG(ERROR) << "Failure accessing geometry";
+  }
+
+  auto fitmethod = ctx.options().get<std::string>("fitmethod");
+  if (fitmethod == "standard") {
+    LOG(INFO) << "Using standard raw fitter";
+    mRawFitter = std::unique_ptr<o2::emcal::CaloRawFitter>(new o2::emcal::CaloRawFitterStandard);
+  } else if (fitmethod == "gamma2") {
+    LOG(INFO) << "Using gamma2 raw fitter";
+    mRawFitter = std::unique_ptr<o2::emcal::CaloRawFitter>(new o2::emcal::CaloRawFitterGamma2);
+  }
+  mRawFitter->setAmpCut(0.);
+  mRawFitter->setL1Phase(0.);
 }
 
 void CellConverterSpec::run(framework::ProcessingContext& ctx)
 {
   LOG(DEBUG) << "[EMCALCellConverter - run] called";
+  const double CONVADCGEV = 0.016; // Conversion from ADC counts to energy: E = 16 MeV / ADC
+
   mOutputCells.clear();
   mOutputTriggers.clear();
   auto digitsAll = ctx.inputs().get<gsl::span<o2::emcal::Digit>>("digits");
@@ -40,19 +64,33 @@ void CellConverterSpec::run(framework::ProcessingContext& ctx)
       continue;
     }
     gsl::span<const o2::emcal::Digit> digits(digitsAll.data() + trg.getFirstEntry(), trg.getNumberOfObjects());
-    for (const auto& dig : digits) {
-      ChannelType_t chantype;
-      if (dig.getHighGain()) {
-        chantype = ChannelType_t::HIGH_GAIN;
-      } else if (dig.getLowGain()) {
-        chantype = ChannelType_t::LOW_GAIN;
-      } else if (dig.getTRU()) {
-        chantype = ChannelType_t::TRU;
-      } else if (dig.getLEDMon()) {
-        chantype = ChannelType_t::LEDMON;
+
+    for (const auto& srucont : digitsToBunches(digits)) {
+
+      if (srucont.mSRUid == 21 || srucont.mSRUid == 22 || srucont.mSRUid == 36 || srucont.mSRUid == 39) {
+        continue;
       }
-      mOutputCells.emplace_back(dig.getTower(), dig.getEnergy(), dig.getTimeStamp(), chantype);
-      ncellsTrigger++;
+
+      for (const auto& [tower, channelData] : srucont.mChannelsData) {
+
+        // define the conatiner for the fit results, and perform the raw fitting using the stadnard raw fitter
+        CaloFitResults fitResults;
+        try {
+          fitResults = mRawFitter->evaluate(channelData.mChannelsBunches);
+
+          if (fitResults.getAmp() < 0) {
+            fitResults.setAmp(0.);
+          }
+          if (fitResults.getTime() < 0) {
+            fitResults.setTime(0.);
+          }
+        } catch (CaloRawFitter::RawFitterError_t& fiterror) {
+          LOG(ERROR) << "Failure in raw fitting: " << CaloRawFitter::createErrorMessage(fiterror);
+        }
+
+        mOutputCells.emplace_back(tower, fitResults.getAmp() * CONVADCGEV, fitResults.getTime(), channelData.mChanType);
+        ncellsTrigger++;
+      }
     }
     mOutputTriggers.emplace_back(trg.getBCData(), currentstart, ncellsTrigger);
     currentstart = mOutputCells.size();
@@ -67,6 +105,134 @@ void CellConverterSpec::run(framework::ProcessingContext& ctx)
     auto truthcont = ctx.inputs().get<o2::dataformats::MCTruthContainer<o2::emcal::MCLabel>*>("digitsmctr");
     ctx.outputs().snapshot(o2::framework::Output{"EMC", "CELLSMCTR", 0, o2::framework::Lifetime::Timeframe}, *truthcont);
   }
+}
+
+std::vector<o2::emcal::SRUBunchContainer> CellConverterSpec::digitsToBunches(gsl::span<const o2::emcal::Digit> digits)
+{
+
+  std::vector<o2::emcal::SRUBunchContainer> sruBunchContainer;
+  std::vector<o2::emcal::SRUDigitContainer> sruDigitContainer;
+
+  for (auto iddl = 0; iddl < 40; iddl++) {
+    o2::emcal::SRUBunchContainer srucontBunch;
+    srucontBunch.mSRUid = iddl;
+    sruBunchContainer.push_back(srucontBunch);
+
+    o2::emcal::SRUDigitContainer srucontDigits;
+    srucontDigits.mSRUid = iddl;
+    sruDigitContainer.push_back(srucontDigits);
+  }
+
+  std::vector<const o2::emcal::Digit*>* bunchDigits;
+  int lasttower = -1;
+  for (auto& dig : digits) {
+    auto tower = dig.getTower();
+    if (tower != lasttower) {
+      lasttower = tower;
+      if (tower > 20000) {
+        std::cout << "Wrong cell ID " << tower << std::endl;
+      }
+
+      auto onlineindices = mGeometry->getOnlineID(tower);
+      int sruID = std::get<0>(onlineindices);
+
+      auto towerdata = sruDigitContainer[sruID].mChannelsDigits.find(tower);
+      if (towerdata == sruDigitContainer[sruID].mChannelsDigits.end()) {
+        sruDigitContainer[sruID].mChannelsDigits[tower] = {dig.getType(), std::vector<const o2::emcal::Digit*>(o2::emcal::constants::EMCAL_MAXTIMEBINS)};
+        bunchDigits = &(sruDigitContainer[sruID].mChannelsDigits[tower].mChannelDigits);
+        memset(bunchDigits->data(), 0, sizeof(o2::emcal::Digit*) * o2::emcal::constants::EMCAL_MAXTIMEBINS);
+      } else {
+        bunchDigits = &(towerdata->second.mChannelDigits);
+      }
+    }
+
+    // Get time sample of the digit:
+    // Digitizer stores the time sample in ns, needs to be converted to time sample dividing
+    // by the length of the time sample
+    auto timesample = int(dig.getTimeStamp() / emcal::constants::EMCAL_TIMESAMPLE);
+    if (timesample >= o2::emcal::constants::EMCAL_MAXTIMEBINS) {
+      LOG(ERROR) << "Digit time sample " << timesample << " outside range [0," << o2::emcal::constants::EMCAL_MAXTIMEBINS << "]";
+      continue;
+    }
+    (*bunchDigits)[timesample] = &dig;
+  }
+
+  for (auto srucont : sruDigitContainer) {
+
+    if (srucont.mSRUid == 21 || srucont.mSRUid == 22 || srucont.mSRUid == 36 || srucont.mSRUid == 39) {
+      continue;
+    }
+
+    for (const auto& [tower, channelDigits] : srucont.mChannelsDigits) {
+
+      std::vector<o2::emcal::Bunch> rawbunches;
+      for (auto& bunch : findBunches(channelDigits.mChannelDigits)) {
+        rawbunches.emplace_back(bunch.mADCs.size(), bunch.mStarttime);
+        for (auto adc : bunch.mADCs) {
+          rawbunches.back().addADC(adc);
+        }
+      }
+
+      sruBunchContainer[srucont.mSRUid].mChannelsData[tower] = {channelDigits.mChanType, rawbunches};
+    }
+  }
+
+  return sruBunchContainer;
+}
+
+std::vector<o2::emcal::AltroBunch> CellConverterSpec::findBunches(const std::vector<const o2::emcal::Digit*>& channelDigits)
+{
+  std::vector<AltroBunch> result;
+  AltroBunch currentBunch;
+  bool bunchStarted = false;
+  // Digits in ALTRO bunch in time-reversed order
+  int itime;
+  for (itime = channelDigits.size() - 1; itime >= 0; itime--) {
+    auto dig = channelDigits[itime];
+    if (!dig) {
+      if (bunchStarted) {
+        // we have a bunch which is started and needs to be closed
+        // check if the ALTRO bunch has a minimum amount of 3 ADCs
+        if (currentBunch.mADCs.size() >= 3) {
+          // Bunch selected, set start time and push to bunches
+          currentBunch.mStarttime = itime + 1;
+          result.push_back(currentBunch);
+          currentBunch = AltroBunch();
+          bunchStarted = false;
+        }
+      }
+      continue;
+    }
+    int adc = dig->getAmplitudeADC();
+    if (adc < 3) {
+      // ADC value below threshold
+      // in case we have an open bunch it needs to be stopped bunch
+      // Set the start time to the time sample of previous (passing) digit
+      if (bunchStarted) {
+        // check if the ALTRO bunch has a minimum amount of ADCs
+        if (currentBunch.mADCs.size() >= 3) {
+          // Bunch selected, set start time and push to bunches
+          currentBunch.mStarttime = itime + 1;
+          result.push_back(currentBunch);
+          currentBunch = AltroBunch();
+          bunchStarted = false;
+        }
+      }
+    }
+    // Valid ADC value, if the bunch is closed we start a new bunch
+    if (!bunchStarted) {
+      bunchStarted = true;
+    }
+    currentBunch.mADCs.emplace_back(adc);
+  }
+  // if we have a last bunch set time start time to the time bin of teh previous digit
+  if (bunchStarted) {
+    if (currentBunch.mADCs.size() >= 3) {
+      currentBunch.mStarttime = itime + 1;
+      result.push_back(currentBunch);
+    }
+  }
+  return result;
 }
 
 o2::framework::DataProcessorSpec o2::emcal::reco_workflow::getCellConverterSpec(bool propagateMC)
@@ -84,5 +250,7 @@ o2::framework::DataProcessorSpec o2::emcal::reco_workflow::getCellConverterSpec(
   return o2::framework::DataProcessorSpec{"EMCALCellConverterSpec",
                                           inputs,
                                           outputs,
-                                          o2::framework::adaptFromTask<o2::emcal::reco_workflow::CellConverterSpec>(propagateMC)};
+                                          o2::framework::adaptFromTask<o2::emcal::reco_workflow::CellConverterSpec>(propagateMC),
+                                          o2::framework::Options{
+                                            {"fitmethod", o2::framework::VariantType::String, "gamma2", {"Fit method (standard or gamma2)"}}}};
 }

--- a/Detectors/EMCAL/workflow/src/CellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/CellConverterSpec.cxx
@@ -111,14 +111,14 @@ std::vector<o2::emcal::SRUBunchContainer> CellConverterSpec::digitsToBunches(gsl
 {
 
   std::vector<o2::emcal::SRUBunchContainer> sruBunchContainer;
-  std::vector<o2::emcal::SRUDigitContainer> sruDigitContainer;
+  std::vector<o2::emcal::DigitContainerPerSRU> sruDigitContainer;
 
   for (auto iddl = 0; iddl < 40; iddl++) {
     o2::emcal::SRUBunchContainer srucontBunch;
     srucontBunch.mSRUid = iddl;
     sruBunchContainer.push_back(srucontBunch);
 
-    o2::emcal::SRUDigitContainer srucontDigits;
+    o2::emcal::DigitContainerPerSRU srucontDigits;
     srucontDigits.mSRUid = iddl;
     sruDigitContainer.push_back(srucontDigits);
   }


### PR DESCRIPTION
As the digitiser now digitises hits with time information the digits->cell converter must also do the raw fitting in the same way as the raw->cell converter. The steps include:
    Separation of ALTRO bunches and adding the time stamps
    filtering of all labels belonging to digits in the same ALTRO bunch
    Performing the raw fit on the ALTRO bunch in the same way as in data

The Handling of MC labels is not done yet.