### PR TITLE
Changes + fixes in CTF writer

### DIFF
--- a/Detectors/CTF/README.md
+++ b/Detectors/CTF/README.md
@@ -22,6 +22,7 @@ o2-ctf-writer --min-file-size <min> --max-file-size <max> ...
 ```
 will accumulate CTFs in entries of the same tree/file until its size fits exceeds `min` and does not exceed `max` (`max` check is disabled if `max<=min`) or EOS received.
 The `--max-file-size` limit will be ignored if the very first CTF already exceeds it.
+Additional option `--max-ctf-per-file <N>` will forbid writing more than `N` CTFs to single file (provided `N>0`) even if the `min-file-size` is not reached. User may request autosaving of CTFs accumulated in the file after every `N` TFs processed by passing an option `--save-ctf-after <N>`.
 
 The output directory (by default: `cwd`) for CTFs can be set via `--output-dir` option and must exist. Since in on the EPNs we may store the CTFs on the RAM disk of limited capacity, one can indicate the fall-back storage via `--output-dir-alt` option. The writer will switch to it if
 (i) `szCheck = max(min-file-size*1.1, max-file-size)` is positive and (ii) estimated (accounting for eventual other CTFs files written concurrently) available space on the primary storage is below the `szCheck`. The available space is estimated as:
@@ -33,7 +34,13 @@ number still open CTF files from concurrent writers * szCheck
 the current size of these files
 ````
 
-Option `--ctf-dict-dir <dir>` can be provided to indicate the (existing) directory for the dictionary IO.
+If the option `--meta-output-dir <dir>` is not `/dev/null`, the CTF `meta-info` files will be written to this directory (which must exist!).
+
+By default only CTFs will written. If the upstream entropy compression is performed w/o external dictionaries, then the for every CTF its own dictionary will be generated and stored in the CTF. In this mode one can request creation of dictionary file (or dictionary file per detector if option `--dict-per-det` is provided) by passing option `--output-type dict` (in which case only the dictionares will be stored but not the CTFs) or
+`--output-type both` (will store both dictionaries and CTF). This is the only valid mode for dictionaries creation (if one requests dictionary creation but the compression was done with external dictionaries, the newly created dictionaries will be empty).
+In the dictionaries creation mode their data are accumulated over all CTFs procssed. User may request periodic (and incremental) saving of dictionaries after every `N` TFs processed by passing `--save-dict-after <N>` option.
+
+Option `--ctf-dict-dir <dir>` can be provided to indicate the (existing) directory where the dictionary will be stored.
 
 ## CTF reader workflow
 

--- a/Detectors/CTF/workflow/include/CTFWorkflow/CTFWriterSpec.h
+++ b/Detectors/CTF/workflow/include/CTFWorkflow/CTFWriterSpec.h
@@ -24,8 +24,7 @@ namespace ctf
 {
 
 /// create a processor spec
-framework::DataProcessorSpec getCTFWriterSpec(o2::detectors::DetID::mask_t dets, uint64_t run, bool doCTF = true,
-                                              bool doDict = false, bool dictPerDet = false);
+framework::DataProcessorSpec getCTFWriterSpec(o2::detectors::DetID::mask_t dets, uint64_t run, const std::string& outType);
 
 } // namespace ctf
 } // namespace o2

--- a/Detectors/CTF/workflow/src/ctf-writer-workflow.cxx
+++ b/Detectors/CTF/workflow/src/ctf-writer-workflow.cxx
@@ -31,7 +31,6 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   std::vector<o2::framework::ConfigParamSpec> options;
   options.push_back(ConfigParamSpec{"onlyDet", VariantType::String, std::string{DetID::NONE}, {"comma separated list of detectors to accept. Overrides skipDet"}});
   options.push_back(ConfigParamSpec{"skipDet", VariantType::String, std::string{DetID::NONE}, {"comma separate list of detectors to skip"}});
-  options.push_back(ConfigParamSpec{"dict-per-det", VariantType::Bool, false, {"create dictionary file per detector"}});
   options.push_back(ConfigParamSpec{"grpfile", VariantType::String, o2::base::NameConf::getGRPFileName(), {"name of the grp file"}});
   options.push_back(ConfigParamSpec{"no-grp", VariantType::Bool, false, {"do not read GRP file"}});
   options.push_back(ConfigParamSpec{"output-type", VariantType::String, "ctf", {"output types: ctf (per TF) or dict (create dictionaries) or both or none"}});
@@ -49,7 +48,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   long run = 0;
   bool doCTF = true, doDict = false, dictPerDet = false;
   size_t szMin = 0, szMax = 0;
-
+  std::string outType{}; // RS FIXME once global/local options clash is solved, --output-type will become device option
   if (!configcontext.helpOnCommandLine()) {
     bool noGRP = configcontext.options().get<bool>("no-grp");
     auto onlyDet = configcontext.options().get<std::string>("onlyDet");
@@ -71,24 +70,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     if (dets.none()) {
       throw std::invalid_argument("Invalid workflow: no detectors found");
     }
-    auto outmode = configcontext.options().get<std::string>("output-type");
-    dictPerDet = configcontext.options().get<bool>("dict-per-det");
-    if (outmode == "ctf") {
-      doCTF = true;
-      doDict = false;
-    } else if (outmode == "dict") {
-      doCTF = false;
-      doDict = true;
-    } else if (outmode == "both") {
-      doCTF = true;
-      doDict = true;
-    } else if (outmode == "none") {
-      doCTF = false;
-      doDict = false;
-    } else {
-      throw std::invalid_argument("Invalid output-type");
-    }
+    outType = configcontext.options().get<std::string>("output-type");
   }
-  WorkflowSpec specs{o2::ctf::getCTFWriterSpec(dets, run, doCTF, doDict, dictPerDet)};
+  WorkflowSpec specs{o2::ctf::getCTFWriterSpec(dets, run, outType)};
   return std::move(specs);
 }


### PR DESCRIPTION
* Write the CTF meta-info file to the dedicated directory provided via `--meta-output-dir` option, skip writing it if `/dev/null` is supplied (default).
* if `--max-ctf-per-file <N>` provides values `>0`, close CTF file with multiple CTFs after writing N CTFs, even if the `--min-file-size` is not reached
* `--save-ctf-after <N>` allows to auto-save CTF file with multiple CTFs after every `N>0` CTFs.

* Reshuffle some options + fix in CTF tree saving 