### PR TITLE
TRD digit and tracklet writer workflow

### DIFF
--- a/Detectors/TRD/workflow/io/CMakeLists.txt
+++ b/Detectors/TRD/workflow/io/CMakeLists.txt
@@ -28,3 +28,7 @@ o2_add_executable(track-reader
                  COMPONENT_NAME trd
                  SOURCES src/trd-track-reader-workflow.cxx
                  PUBLIC_LINK_LIBRARIES O2::TRDWorkflowIO)
+o2_add_executable(digittracklet-writer
+                 COMPONENT_NAME trd
+                 SOURCES src/trd-digittracklet-writer-workflow.cxx
+                 PUBLIC_LINK_LIBRARIES O2::TRDWorkflowIO)

--- a/Detectors/TRD/workflow/io/src/trd-digittracklet-writer-workflow.cxx
+++ b/Detectors/TRD/workflow/io/src/trd-digittracklet-writer-workflow.cxx
@@ -1,0 +1,48 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "Framework/CompletionPolicy.h"
+#include "Framework/ConfigParamSpec.h"
+#include "TRDWorkflowIO/TRDDigitReaderSpec.h"
+#include "TRDWorkflowIO/TRDTrackletWriterSpec.h"
+#include "TRDWorkflowIO/TRDDigitWriterSpec.h"
+
+using namespace o2::framework;
+
+// ------------------------------------------------------------------
+// this is simply to enable one to write out the tracklet and digits and triggers after reading in the ctf
+// to do a comparison pre and post ctf. Use case is probably only unit tests.
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  std::vector<o2::framework::ConfigParamSpec> options{
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
+
+  std::swap(workflowOptions, options);
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  // Update the (declared) parameters if changed from the command line
+  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
+
+  WorkflowSpec specs;
+  specs.emplace_back(o2::trd::getTRDTrackletWriterSpec(false));
+  specs.emplace_back(o2::trd::getTRDDigitWriterSpec(false, false));
+  return specs;
+}


### PR DESCRIPTION
Primarily for cross checking the ctf decoding and encoding and for unit tests.
Can now insert a workflow to dump out the tracklets and digits.
Just to be clear this is needed to be able to do the following : 

`o2-ctf-reader-workflow $ARGS_ALL --onlyDet TRD --ctf-input $PWD/ctf |  o2-trd-digittracklet-write $ARGS_ALL --TRDTrkltWrt \"--outfile trdtracklets_$1.root\" --TRDDigitWriter \"--outfile trddigits_$1.root\" `
This dumps the digits, tracklets, triggerrecords after the ctf decoding done inside o2-ctf-reader-workflow

