### PR TITLE
Implement --onlyDet option in o2-raw-tf-reader and enable non-raw data

### DIFF
--- a/Detectors/Raw/README.md
+++ b/Detectors/Raw/README.md
@@ -460,11 +460,6 @@ The relevant command line options are:
 input data (obligatory): comma-separated list of input data files and/or files with list of data files and/or directories containing files
 
 ```
---onlyDet arg (=all)
-```
-list of dectors to select from available in the data. AT THE MOMENT NOT FUNCTIONAL
-
-```
 --max-tf arg (=-1)
 ```
 max TF ID to process (<= 0 : infinite)
@@ -513,6 +508,22 @@ verbosity level (1 or 2: check RDH, print DH/DPH for 1st or all slices, >2 print
 --raw-channel-config arg
 ```
 optional raw FMQ channel for non-DPL output, similar to `o2-raw-file-reader-workflow`.
+
+Since a priory it is not known what kind of data is in the raw TF file provided on the input, by default the reader will define outputs for the raw data of all known detectors (as subspecification-wildcarded `<DET>/RAWDATA`). Additionally, since some detectors might have done processing on the FLP (in which case the DD TF will contain derived data, e.g. cells), the reader will open extra outputs for all kinds of messages for which we know they can be produced on the FLP. Following 3 partially redundant options allow to decrease the number of defined outputs:
+```
+--onlyDet arg (=all)
+```
+list of detectors to select from available in the data, outputs for others will not be created, their data will be skipped.
+```
+--raw-only-det arg (=none)
+```
+list of detectors for which non-raw outputs (if any) are discarded.
+```
+--non-raw-only-det arg (=none)
+```
+list of detectors for which raw outputs are discarded.
+
+The raw data will be propagated (if present) only if the detector is selected in `--onlyDet` and `NOT` selected in `--non-raw-only-det`. The non-raw data will be propagated (if defined for the given detector and present in the file) only if the detector is selected in `--onlyDet` and `NOT` selected in `--raw-only-det`.
 
 ## Miscellaneous macros
 

--- a/Detectors/Raw/TFReaderDD/include/TFReaderDD/SubTimeFrameFileReader.h
+++ b/Detectors/Raw/TFReaderDD/include/TFReaderDD/SubTimeFrameFileReader.h
@@ -15,6 +15,7 @@
 #define ALICEO2_SUBTIMEFRAME_FILE_READER_RAWDD_H_
 
 #include <Headers/DataHeader.h>
+#include "DetectorsCommonDataFormats/DetID.h"
 #include <Headers/Stack.h>
 #include <fairmq/FairMQParts.h>
 #include <fairmq/FairMQDevice.h>
@@ -23,6 +24,7 @@
 #include <boost/iostreams/device/mapped_file.hpp>
 #include <fstream>
 #include <vector>
+#include <unordered_map>
 
 namespace o2f = o2::framework;
 
@@ -48,7 +50,7 @@ class SubTimeFrameFileReader
   };
 
   SubTimeFrameFileReader() = delete;
-  SubTimeFrameFileReader(const std::string& pFileName);
+  SubTimeFrameFileReader(const std::string& pFileName, o2::detectors::DetID::mask_t detMask);
   ~SubTimeFrameFileReader();
 
   /// Read a single TF from the file
@@ -73,6 +75,7 @@ class SubTimeFrameFileReader
 
  private:
   std::string mFileName;
+  std::unordered_map<o2::header::DataOrigin, bool> mDetOrigMap;
   boost::iostreams::mapped_file_source mFileMap;
   std::uint64_t mFileMapOffset = 0;
   std::uint64_t mFileSize = 0;

--- a/Detectors/Raw/TFReaderDD/src/TFReaderSpec.h
+++ b/Detectors/Raw/TFReaderDD/src/TFReaderSpec.h
@@ -15,6 +15,7 @@
 /// @file   TFReaderWorkflow.h
 
 #include "Framework/WorkflowSpec.h"
+#include "DetectorsCommonDataFormats/DetID.h"
 
 namespace o2
 {
@@ -23,10 +24,15 @@ namespace rawdd
 struct TFReaderInp {
   std::string inpdata{};
   std::string detList{};
+  std::string detListRawOnly{};
+  std::string detListNonRawOnly{};
   std::string rawChannelConfig{};
   std::string copyCmd{};
   std::string tffileRegex{};
   std::string remoteRegex{};
+  o2::detectors::DetID::mask_t detMask{};
+  o2::detectors::DetID::mask_t detMaskRawOnly{};
+  o2::detectors::DetID::mask_t detMaskNonRawOnly{};
   int maxTFCache = 1;
   int maxFileCache = 1;
   int verbosity = 0;

--- a/Detectors/Raw/TFReaderDD/src/tf-reader-workflow.cxx
+++ b/Detectors/Raw/TFReaderDD/src/tf-reader-workflow.cxx
@@ -25,6 +25,8 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
   std::vector<ConfigParamSpec> options;
   options.push_back(ConfigParamSpec{"input-data", VariantType::String, "", {"input data (obligatory)"}});
   options.push_back(ConfigParamSpec{"onlyDet", VariantType::String, "all", {"list of dectors"}});
+  options.push_back(ConfigParamSpec{"raw-only-det", VariantType::String, "none", {"do not open non-raw channel for these detectors"}});
+  options.push_back(ConfigParamSpec{"non-raw-only-det", VariantType::String, "none", {"do not open raw channel for these detectors"}});
   options.push_back(ConfigParamSpec{"max-tf", VariantType::Int, -1, {"max TF ID to process (<= 0 : infinite)"}});
   options.push_back(ConfigParamSpec{"loop", VariantType::Int, 0, {"loop N times (-1 = infinite)"}});
   options.push_back(ConfigParamSpec{"delay", VariantType::Float, 0.f, {"delay in seconds between consecutive TFs sending"}});
@@ -53,6 +55,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   int n = configcontext.options().get<int>("max-tf");
   rinp.maxTFs = n > 0 ? n : 0x7fffffff;
   rinp.detList = configcontext.options().get<std::string>("onlyDet");
+  rinp.detListRawOnly = configcontext.options().get<std::string>("raw-only-det");
+  rinp.detListNonRawOnly = configcontext.options().get<std::string>("non-raw-only-det");
   rinp.rawChannelConfig = configcontext.options().get<std::string>("raw-channel-config");
   rinp.delay_us = uint64_t(1e6 * configcontext.options().get<float>("delay")); // delay in microseconds
   rinp.verbosity = configcontext.options().get<int>("tf-reader-verbosity");


### PR DESCRIPTION
If the detector runs processing on the FLP, then the DD raw TF will contain derived data
(e.g. digits, triggers etc) instead of the raw.
For the detectors which might run some processing corresponding output channels are
defined (on top of the raw data channels).
These are TOF, FIT detectors, EMC, PHS and CPV. For the EMC and PHS is it not yet
clear which subsecs will be sent from the FLP.

Since a priory it is not known what kind of data is in the raw TF file provided on the input, by default the reader will define outputs for the raw data of all known detectors (as subspecification-wildcarded `<DET>/RAWDATA`). Additionally, since some detectors might have done processing on the FLP (in which case the DD TF will contain derived data, e.g. cells), the reader will open extra outputs for all kinds of messages for which we know they can be produced on the FLP. Following 3 partially redundant options allow to decrease the number of defined outputs:
```
--onlyDet arg (=all)
```
list of detectors to select from available in the data, outputs for others will not be created, their data will be skipped.
```
--raw-only-det arg (=none)
```
list of detectors for which non-raw outputs (if any) are discarded.
```
--non-raw-only-det arg (=none)
```
list of detectors for which raw outputs are discarded.

The raw data will be propagated (if present) only if the detector is selected in `--onlyDet` and `NOT` selected in `--non-raw-only-det`. The non-raw data will be propagated (if defined for the given detector and present in the file) only if the detector is selected in `--onlyDet` and `NOT` selected in `--raw-only-det`.
