### PR TITLE
Fix typo in option "vetex-track-matching-sources"

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/README.md
+++ b/Detectors/GlobalTrackingWorkflow/README.md
@@ -6,7 +6,7 @@
 
 ## Primary vertexer and vertex-track matcher
 
-Builds primary vertices from all allowed sources (currently by default: ITS, ITS-TPC, ITS-TPC-TOF, can be reduced with `--vertexing-sources <source0,source1...>`) and if builds a vector of indices (`VtxTrackIndex`) of tracks from every source (currently by default: ITS, TPC, ITS-TPC, TPC-TOF, ITS-TPC-TOF, can be reduced with `--vetex-track-matching-sources`) which either contributes to vertex (flagged) or matches to it time-wise (ambiguous matches are flagged). To disable vertex tracks matching used `--vetex-track-matching-sources none`.
+Builds primary vertices from all allowed sources (currently by default: ITS, ITS-TPC, ITS-TPC-TOF, can be reduced with `--vertexing-sources <source0,source1...>`) and if builds a vector of indices (`VtxTrackIndex`) of tracks from every source (currently by default: ITS, TPC, ITS-TPC, TPC-TOF, ITS-TPC-TOF, can be reduced with `--vertex-track-matching-sources`) which either contributes to vertex (flagged) or matches to it time-wise (ambiguous matches are flagged). To disable vertex tracks matching used `--vertex-track-matching-sources none`.
 ```cpp
 o2-primary-vertexing-workflow
 ```

--- a/Detectors/GlobalTrackingWorkflow/src/primary-vertexing-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/primary-vertexing-workflow.cxx
@@ -42,7 +42,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writer"}},
     {"vertexing-sources", VariantType::String, std::string{GID::ALL}, {"comma-separated list of sources to use in vertexing"}},
     {"validate-with-ft0", o2::framework::VariantType::Bool, false, {"use FT0 time for vertex validation"}},
-    {"vetex-track-matching-sources", VariantType::String, std::string{GID::ALL}, {"comma-separated list of sources to use in vertex-track associations or \"none\" to disable matching"}},
+    {"vertex-track-matching-sources", VariantType::String, std::string{GID::ALL}, {"comma-separated list of sources to use in vertex-track associations or \"none\" to disable matching"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
 
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
@@ -71,7 +71,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   auto validateWithFT0 = configcontext.options().get<bool>("validate-with-ft0");
 
   GID::mask_t srcPV = allowedSourcesPV & GID::getSourcesMask(configcontext.options().get<std::string>("vertexing-sources"));
-  GID::mask_t srcVT = allowedSourcesVT & GID::getSourcesMask(configcontext.options().get<std::string>("vetex-track-matching-sources"));
+  GID::mask_t srcVT = allowedSourcesVT & GID::getSourcesMask(configcontext.options().get<std::string>("vertex-track-matching-sources"));
   if (validateWithFT0) {
     srcPV |= GID::getSourceMask(GID::FT0);
   }


### PR DESCRIPTION
trivial fix in option spelling, merging