### PR TITLE
[EMCAL-551] Align indices for HG/LG cells

### DIFF
--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Constants.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Constants.h
@@ -31,8 +31,8 @@ enum {
 /// \enum ChannelType_t
 /// \brief Type of a raw data channel
 enum ChannelType_t {
-  HIGH_GAIN, ///< High gain channel
   LOW_GAIN,  ///< Low gain channel
+  HIGH_GAIN, ///< High gain channel
   TRU,       ///< TRU channel
   LEDMON     ///< LED monitor channel
 };


### PR DESCRIPTION
Adapt order of HG/LG cells to comply with
the indices used in the mapping (0 - low
gain, 1 - high gain)