### PR TITLE
[MFT] Improved handling of MFT tracking for B=0

### DIFF
--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/IOUtils.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/IOUtils.h
@@ -56,9 +56,10 @@ constexpr float DefClusErrorCol = o2::itsmft::SegmentationAlpide::PitchCol * 0.5
 constexpr float DefClusError2Row = DefClusErrorRow * DefClusErrorRow;
 constexpr float DefClusError2Col = DefClusErrorCol * DefClusErrorCol;
 
-int loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& events, gsl::span<const itsmft::CompClusterExt> clusters,
+template <typename T>
+int loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe<T>& events, gsl::span<const itsmft::CompClusterExt> clusters,
                     gsl::span<const unsigned char>::iterator& pattIt, const itsmft::TopologyDictionary& dict,
-                    const dataformats::MCTruthContainer<MCCompLabel>* mClsLabels = nullptr, const o2::mft::Tracker* tracker = nullptr);
+                    const dataformats::MCTruthContainer<MCCompLabel>* mClsLabels = nullptr, const o2::mft::Tracker<T>* tracker = nullptr);
 
 void convertCompactClusters(gsl::span<const itsmft::CompClusterExt> clusters,
                             gsl::span<const unsigned char>::iterator& pattIt,

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/TrackCA.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/TrackCA.h
@@ -63,15 +63,30 @@ class TrackLTF : public TrackMFTExt
 };
 
 //_________________________________________________________________________________________________
-class TrackLTFL : public TrackLTF // A track for B=0
+class TrackLTFL : public TrackLTF // A track model for B=0
 {
+  using SMatrix44Sym = ROOT::Math::SMatrix<double, 4, 4, ROOT::Math::MatRepSym<double, 4>>;
+
  public:
   TrackLTFL() = default;
   TrackLTFL(const bool isCA) { setCA(isCA); }
   TrackLTFL(const TrackLTFL& t) = default;
   ~TrackLTFL() = default;
 
+  // Kalman filter/fitting update for linear tracks
+  bool update(const std::array<float, 2>& p, const std::array<float, 2>& cov)
+  {
+    // TODO
+    return true;
+  }
+
  private:
+  /// Covariance matrix of track parameters, ordered as follows:    <pre>
+  ///  <X,X>          <Y,X>           <SlopeX,X>          <SlopeY,X>
+  ///  <X,Y>          <Y,Y>           <SlopeX,Y>          <SlopeY,Y>
+  ///  <X,SlopeX>     <Y,SlopeX>      <SlopeX,SlopeX>     <SlopeY,SlopeX>
+  ///  <X,SlopeY>     <Y,SlopeY>      <SlopeX,SlopeY>     <SlopeY,SlopeY>
+  SMatrix44Sym mCovariances{}; ///< \brief Covariance matrix of track parameters
   ClassDefNV(TrackLTFL, 0);
 };
 

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/TrackCA.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/TrackCA.h
@@ -59,7 +59,7 @@ class TrackLTF : public TrackMFTExt
   std::array<Int_t, constants::mft::LayersNumber> mClusterId;
   std::array<MCCompLabel, constants::mft::LayersNumber> mMCCompLabels;
 
-  ClassDefNV(TrackLTF, 10);
+  ClassDefNV(TrackLTF, 11);
 };
 
 //_________________________________________________________________________________________________

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/TrackCA.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/TrackCA.h
@@ -32,8 +32,11 @@ class TrackLTF : public TrackMFTExt
 {
  public:
   TrackLTF() = default;
+  TrackLTF(const bool isCA) { setCA(isCA); }
+
   TrackLTF(const TrackLTF& t) = default;
   ~TrackLTF() = default;
+
   const std::array<Float_t, constants::mft::LayersNumber>& getXCoordinates() const { return mX; }
   const std::array<Float_t, constants::mft::LayersNumber>& getYCoordinates() const { return mY; }
   const std::array<Float_t, constants::mft::LayersNumber>& getZCoordinates() const { return mZ; }
@@ -60,19 +63,16 @@ class TrackLTF : public TrackMFTExt
 };
 
 //_________________________________________________________________________________________________
-class TrackCA : public TrackLTF
+class TrackLTFL : public TrackLTF // A track for B=0
 {
  public:
-  TrackCA()
-  {
-    TrackLTF();
-    this->setCA(true);
-  }
-  TrackCA(const TrackCA& t) = default;
-  ~TrackCA() = default;
+  TrackLTFL() = default;
+  TrackLTFL(const bool isCA) { setCA(isCA); }
+  TrackLTFL(const TrackLTFL& t) = default;
+  ~TrackLTFL() = default;
 
  private:
-  ClassDefNV(TrackCA, 10);
+  ClassDefNV(TrackLTFL, 0);
 };
 
 //_________________________________________________________________________________________________
@@ -153,16 +153,17 @@ inline void TrackLTF::sort()
 
 namespace framework
 {
-template <typename T>
-struct is_messageable;
-template <>
-struct is_messageable<o2::mft::TrackCA> : std::true_type {
-};
 
 template <typename T>
 struct is_messageable;
 template <>
 struct is_messageable<o2::mft::TrackLTF> : std::true_type {
+};
+
+template <typename T>
+struct is_messageable;
+template <>
+struct is_messageable<o2::mft::TrackLTFL> : std::true_type {
 };
 
 } // namespace framework

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/TrackFitter.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/TrackFitter.h
@@ -29,7 +29,8 @@ namespace o2
 namespace mft
 {
 
-/// Class to fit a track to a set of clusters
+/// Class to fit a forward track to a set of clusters
+template <typename T>
 class TrackFitter
 {
 
@@ -50,16 +51,16 @@ class TrackFitter
   void setVerbosity(float v) { mVerbose = v; }
   void setTrackModel(float m) { mTrackModel = m; }
 
-  bool initTrack(TrackLTF& track, bool outward = false);
-  bool fit(TrackLTF& track, bool outward = false);
+  bool initTrack(T& track, bool outward = false);
+  bool fit(T& track, bool outward = false);
 
   /// Return the maximum chi2 above which the track can be considered as abnormal
   static constexpr double getMaxChi2() { return SMaxChi2; }
 
  private:
-  bool propagateToZ(TrackLTF& track, double z);
-  bool propagateToNextClusterWithMCS(TrackLTF& track, double z, int& startingLayerID, const int& newLayerID);
-  bool computeCluster(TrackLTF& track, int cluster, int& startingLayerID);
+  bool propagateToZ(T& track, double z);
+  bool propagateToNextClusterWithMCS(T& track, double z, int& startingLayerID, const int& newLayerID);
+  bool computeCluster(T& track, int cluster, int& startingLayerID);
 
   bool mFieldON = true;
   Float_t mBZField; // kiloGauss.
@@ -71,7 +72,8 @@ class TrackFitter
 };
 
 // Functions to estimate momentum and charge from track curvature
-Double_t invQPtFromFCF(const TrackLTF& track, Double_t bFieldZ, Double_t& chi2);
+template <typename T>
+Double_t invQPtFromFCF(const T& track, Double_t bFieldZ, Double_t& chi2);
 Bool_t LinearRegression(Int_t nVal, std::vector<double>& xVal, std::vector<double>& yVal, std::vector<double>& yErr, Double_t& a, Double_t& ae, Double_t& b, Double_t& be);
 
 } // namespace mft

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/Tracker.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/Tracker.h
@@ -33,8 +33,9 @@ namespace o2
 namespace mft
 {
 
-class TrackLTF;
+class T;
 
+template <typename T>
 class Tracker : public TrackerConfig
 {
 
@@ -52,10 +53,9 @@ class Tracker : public TrackerConfig
   auto& getTracksLTF() { return mTracksLTF; }
   auto& getTrackLabels() { return mTrackLabels; }
 
-  void clustersToTracks(ROframe&, std::ostream& = std::cout);
+  void clustersToTracks(ROframe<T>&, std::ostream& = std::cout);
 
-  template <class T>
-  void computeTracksMClabels(const T&);
+  void computeTracksMClabels(const std::vector<T>&);
 
   void setROFrame(std::uint32_t f) { mROFrame = f; }
   std::uint32_t getROFrame() const { return mROFrame; }
@@ -64,33 +64,33 @@ class Tracker : public TrackerConfig
   void initConfig(const MFTTrackingParam& trkParam, bool printConfig = false);
 
  private:
-  void findTracks(ROframe&);
-  void findTracksLTF(ROframe&);
-  void findTracksCA(ROframe&);
-  void findTracksLTFfcs(ROframe&);
-  void findTracksCAfcs(ROframe&);
-  void computeCellsInRoad(ROframe&);
+  void findTracks(ROframe<T>&);
+  void findTracksLTF(ROframe<T>&);
+  void findTracksCA(ROframe<T>&);
+  void findTracksLTFfcs(ROframe<T>&);
+  void findTracksCAfcs(ROframe<T>&);
+  void computeCellsInRoad(ROframe<T>&);
   void runForwardInRoad();
-  void runBackwardInRoad(ROframe&);
+  void runBackwardInRoad(ROframe<T>&);
   void updateCellStatusInRoad();
 
-  bool fitTracks(ROframe&);
+  bool fitTracks(ROframe<T>&);
 
   const Int_t isDiskFace(Int_t layer) const { return (layer % 2); }
   const Float_t getDistanceToSeed(const Cluster&, const Cluster&, const Cluster&) const;
-  void getBinClusterRange(const ROframe&, const Int_t, const Int_t, Int_t&, Int_t&) const;
+  void getBinClusterRange(const ROframe<T>&, const Int_t, const Int_t, Int_t&, Int_t&) const;
   const Float_t getCellDeviation(const Cell&, const Cell&) const;
   const Bool_t getCellsConnect(const Cell&, const Cell&) const;
-  void addCellToCurrentTrackCA(const Int_t, const Int_t, ROframe&);
-  void addCellToCurrentRoad(ROframe&, const Int_t, const Int_t, const Int_t, const Int_t, Int_t&);
+  void addCellToCurrentTrackCA(const Int_t, const Int_t, ROframe<T>&);
+  void addCellToCurrentRoad(ROframe<T>&, const Int_t, const Int_t, const Int_t, const Int_t, Int_t&);
 
   Float_t mBz = 5.f;
   std::uint32_t mROFrame = 0;
   std::vector<TrackMFTExt> mTracks;
-  std::vector<TrackLTF> mTracksLTF;
+  std::vector<T> mTracksLTF;
   std::vector<Cluster> mClusters;
   std::vector<MCCompLabel> mTrackLabels;
-  std::unique_ptr<o2::mft::TrackFitter> mTrackFitter = nullptr;
+  std::unique_ptr<o2::mft::TrackFitter<T>> mTrackFitter = nullptr;
 
   Int_t mMaxCellLevel = 0;
 
@@ -119,7 +119,8 @@ class Tracker : public TrackerConfig
 };
 
 //_________________________________________________________________________________________________
-inline const Float_t Tracker::getDistanceToSeed(const Cluster& cluster1, const Cluster& cluster2, const Cluster& cluster) const
+template <typename T>
+inline const Float_t Tracker<T>::getDistanceToSeed(const Cluster& cluster1, const Cluster& cluster2, const Cluster& cluster) const
 {
   // the seed is between "cluster1" and "cluster2" and cuts the plane
   // of the "cluster" at a distance dR from it
@@ -136,7 +137,8 @@ inline const Float_t Tracker::getDistanceToSeed(const Cluster& cluster1, const C
 }
 
 //_________________________________________________________________________________________________
-inline void Tracker::getBinClusterRange(const ROframe& event, const Int_t layer, const Int_t bin, Int_t& clsMinIndex, Int_t& clsMaxIndex) const
+template <typename T>
+inline void Tracker<T>::getBinClusterRange(const ROframe<T>& event, const Int_t layer, const Int_t bin, Int_t& clsMinIndex, Int_t& clsMaxIndex) const
 {
   const auto& pair = event.getClusterBinIndexRange(layer)[bin];
   clsMinIndex = pair.first;
@@ -144,7 +146,8 @@ inline void Tracker::getBinClusterRange(const ROframe& event, const Int_t layer,
 }
 
 //_________________________________________________________________________________________________
-inline const Float_t Tracker::getCellDeviation(const Cell& cell1, const Cell& cell2) const
+template <typename T>
+inline const Float_t Tracker<T>::getCellDeviation(const Cell& cell1, const Cell& cell2) const
 {
   Float_t cell1dx = cell1.getX2() - cell1.getX1();
   Float_t cell1dy = cell1.getY2() - cell1.getY1();
@@ -163,7 +166,8 @@ inline const Float_t Tracker::getCellDeviation(const Cell& cell1, const Cell& ce
 }
 
 //_________________________________________________________________________________________________
-inline const Bool_t Tracker::getCellsConnect(const Cell& cell1, const Cell& cell2) const
+template <typename T>
+inline const Bool_t Tracker<T>::getCellsConnect(const Cell& cell1, const Cell& cell2) const
 {
   Float_t cell1x2 = cell1.getX2();
   Float_t cell1y2 = cell1.getY2();
@@ -180,8 +184,8 @@ inline const Bool_t Tracker::getCellsConnect(const Cell& cell1, const Cell& cell
 }
 
 //_________________________________________________________________________________________________
-template <class T>
-inline void Tracker::computeTracksMClabels(const T& tracks)
+template <typename T>
+inline void Tracker<T>::computeTracksMClabels(const std::vector<T>& tracks)
 {
   /// Moore's Voting Algorithm
   for (auto& track : tracks) {

--- a/Detectors/ITSMFT/MFT/tracking/src/IOUtils.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/IOUtils.cxx
@@ -36,7 +36,8 @@ namespace mft
 {
 
 //_________________________________________________________
-int ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& event, gsl::span<const itsmft::CompClusterExt> clusters, gsl::span<const unsigned char>::iterator& pattIt, const itsmft::TopologyDictionary& dict, const dataformats::MCTruthContainer<MCCompLabel>* mcLabels, const o2::mft::Tracker* tracker)
+template <typename T>
+int ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe<T>& event, gsl::span<const itsmft::CompClusterExt> clusters, gsl::span<const unsigned char>::iterator& pattIt, const itsmft::TopologyDictionary& dict, const dataformats::MCTruthContainer<MCCompLabel>* mcLabels, const o2::mft::Tracker<T>* tracker)
 {
   event.clear();
   GeometryTGeo* geom = GeometryTGeo::Instance();
@@ -119,6 +120,13 @@ void ioutils::convertCompactClusters(gsl::span<const itsmft::CompClusterExt> clu
     cl3d.setErrors(sigmaX2, sigmaY2, 0);
   }
 }
+template int o2::mft::ioutils::loadROFrameData<o2::mft::TrackLTF>(const o2::itsmft::ROFRecord&, ROframe<o2::mft::TrackLTF>&, gsl::span<const itsmft::CompClusterExt>,
+                                                                  gsl::span<const unsigned char>::iterator&, const itsmft::TopologyDictionary&,
+                                                                  const dataformats::MCTruthContainer<MCCompLabel>*, const o2::mft::Tracker<o2::mft::TrackLTF>*);
+
+template int o2::mft::ioutils::loadROFrameData<o2::mft::TrackLTFL>(const o2::itsmft::ROFRecord&, ROframe<o2::mft::TrackLTFL>&, gsl::span<const itsmft::CompClusterExt>,
+                                                                   gsl::span<const unsigned char>::iterator&, const itsmft::TopologyDictionary&,
+                                                                   const dataformats::MCTruthContainer<MCCompLabel>*, const o2::mft::Tracker<o2::mft::TrackLTFL>*);
 
 } // namespace mft
 } // namespace o2

--- a/Detectors/ITSMFT/MFT/tracking/src/MFTTrackingLinkDef.h
+++ b/Detectors/ITSMFT/MFT/tracking/src/MFTTrackingLinkDef.h
@@ -15,9 +15,9 @@
 #pragma link off all classes;
 #pragma link off all functions;
 #pragma link C++ class o2::mft::TrackLTF + ;
-#pragma link C++ class o2::mft::TrackCA + ;
+#pragma link C++ class o2::mft::TrackLTFL + ;
 #pragma link C++ class std::vector < o2::mft::TrackLTF> + ;
-#pragma link C++ class std::vector < o2::mft::TrackCA> + ;
+#pragma link C++ class std::vector < o2::mft::TrackLTFL> + ;
 #pragma link C++ class o2::mft::TrackerConfig + ;
 #pragma link C++ class o2::mft::MFTTrackingParam + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::mft::MFTTrackingParam> + ;

--- a/Detectors/ITSMFT/MFT/tracking/src/ROframe.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/ROframe.cxx
@@ -21,11 +21,8 @@ namespace o2
 namespace mft
 {
 
-ROframe::ROframe(const Int_t ROframeId) : mROframeId{ROframeId}
-{
-}
-
-Int_t ROframe::getTotalClusters() const
+template <typename T>
+Int_t ROframe<T>::getTotalClusters() const
 {
   size_t totalClusters{0};
   for (auto& clusters : mClusters) {
@@ -34,14 +31,16 @@ Int_t ROframe::getTotalClusters() const
   return Int_t(totalClusters);
 }
 
-void ROframe::initialize(bool fullClusterScan)
+template <typename T>
+void ROframe<T>::initialize(bool fullClusterScan)
 {
   if (!fullClusterScan) {
     sortClusters();
   }
 }
 
-void ROframe::sortClusters()
+template <typename T>
+void ROframe<T>::sortClusters()
 {
   Int_t nClsInLayer, binPrevIndex, clsMinIndex, clsMaxIndex, jClsLayer;
   // sort the clusters in R-Phi
@@ -76,6 +75,9 @@ void ROframe::sortClusters()
     mClusterBinIndexRange[iLayer][binPrevIndex] = std::pair<Int_t, Int_t>(clsMinIndex, clsMaxIndex);
   } // layers
 }
+
+template class ROframe<o2::mft::TrackLTF>;
+template class ROframe<o2::mft::TrackLTFL>;
 
 } // namespace mft
 } // namespace o2

--- a/Detectors/ITSMFT/MFT/tracking/src/TrackFitter.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/TrackFitter.cxx
@@ -38,7 +38,8 @@ namespace mft
 {
 
 //_________________________________________________________________________________________________
-bool TrackFitter::fit(TrackLTF& track, bool outward)
+template <typename T>
+bool TrackFitter<T>::fit(T& track, bool outward)
 {
   /// Fit a track using its attached clusters
   /// Returns false in case of failure
@@ -77,7 +78,8 @@ bool TrackFitter::fit(TrackLTF& track, bool outward)
 }
 
 //_________________________________________________________________________________________________
-bool TrackFitter::initTrack(TrackLTF& track, bool outward)
+template <typename T>
+bool TrackFitter<T>::initTrack(T& track, bool outward)
 {
 
   // initialize the starting track parameters and cluster
@@ -167,7 +169,8 @@ bool TrackFitter::initTrack(TrackLTF& track, bool outward)
 }
 
 //_________________________________________________________________________________________________
-bool TrackFitter::propagateToZ(TrackLTF& track, double z)
+template <typename T>
+bool TrackFitter<T>::propagateToZ(T& track, double z)
 {
   // Propagate track to the z position of the new cluster
   switch (mTrackModel) {
@@ -192,7 +195,8 @@ bool TrackFitter::propagateToZ(TrackLTF& track, double z)
 }
 
 //_________________________________________________________________________________________________
-bool TrackFitter::propagateToNextClusterWithMCS(TrackLTF& track, double z, int& startingLayerID, const int& newLayerID)
+template <typename T>
+bool TrackFitter<T>::propagateToNextClusterWithMCS(T& track, double z, int& startingLayerID, const int& newLayerID)
 {
 
   // Propagate track to the next cluster z position, adding angular MCS effects at the center of
@@ -274,7 +278,8 @@ bool TrackFitter::propagateToNextClusterWithMCS(TrackLTF& track, double z, int& 
 }
 
 //_________________________________________________________________________________________________
-bool TrackFitter::computeCluster(TrackLTF& track, int cluster, int& startingLayerID)
+template <typename T>
+bool TrackFitter<T>::computeCluster(T& track, int cluster, int& startingLayerID)
 {
   /// Propagate track to the z position of the new cluster
   /// accounting for MCS dispersion in the current layer and the other(s) crossed
@@ -322,7 +327,8 @@ bool TrackFitter::computeCluster(TrackLTF& track, int cluster, int& startingLaye
 }
 
 //_________________________________________________________________________________________________
-Double_t invQPtFromFCF(const TrackLTF& track, Double_t bFieldZ, Double_t& sigmainvqptsq)
+template <typename T>
+Double_t invQPtFromFCF(const T& track, Double_t bFieldZ, Double_t& sigmainvqptsq)
 {
 
   const std::array<Float_t, constants::mft::LayersNumber>& xPositions = track.getXCoordinates();
@@ -511,6 +517,9 @@ Bool_t LinearRegression(Int_t nVal, std::vector<double>& xVal, std::vector<doubl
   }
   return kTRUE;
 }
+
+template class TrackFitter<o2::mft::TrackLTF>;
+template class TrackFitter<o2::mft::TrackLTFL>;
 
 } // namespace mft
 } // namespace o2

--- a/Detectors/ITSMFT/MFT/tracking/src/TrackFitter.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/TrackFitter.cxx
@@ -41,37 +41,41 @@ namespace mft
 template <typename T>
 bool TrackFitter<T>::fit(T& track, bool outward)
 {
-  /// Fit a track using its attached clusters
-  /// Returns false in case of failure
+  if constexpr (std::is_same<T, o2::mft::TrackLTF>::value) {
+    /// Fit a track using its attached clusters
+    /// Returns false in case of failure
 
-  auto nClusters = track.getNumberOfPoints();
-  auto lastLayer = track.getLayers()[(outward ? 0 : nClusters - 1)];
+    auto nClusters = track.getNumberOfPoints();
+    auto lastLayer = track.getLayers()[(outward ? 0 : nClusters - 1)];
 
-  if (mVerbose) {
-    std::cout << "Seed covariances: \n"
-              << track.getCovariances() << std::endl
-              << std::endl;
-  }
+    if (mVerbose) {
+      std::cout << "Seed covariances: \n"
+                << track.getCovariances() << std::endl
+                << std::endl;
+    }
 
-  // recursively compute clusters, updating the track parameters
-  if (!outward) { // Inward for vertexing
-    while (nClusters-- > 0) {
-      if (!computeCluster(track, nClusters, lastLayer)) {
-        return false;
+    // recursively compute clusters, updating the track parameters
+    if (!outward) { // Inward for vertexing
+      while (nClusters-- > 0) {
+        if (!computeCluster(track, nClusters, lastLayer)) {
+          return false;
+        }
+      }
+    } else { // Outward for MCH matching
+      int ncl = 0;
+      while (ncl < nClusters) {
+        if (!computeCluster(track, ncl, lastLayer)) {
+          return false;
+        }
+        ncl++;
       }
     }
-  } else { // Outward for MCH matching
-    int ncl = 0;
-    while (ncl < nClusters) {
-      if (!computeCluster(track, ncl, lastLayer)) {
-        return false;
-      }
-      ncl++;
+    if (mVerbose) {
+      std::cout << "Track Chi2 = " << track.getTrackChi2() << std::endl;
+      std::cout << " ***************************** Done fitting *****************************\n";
     }
-  }
-  if (mVerbose) {
-    std::cout << "Track Chi2 = " << track.getTrackChi2() << std::endl;
-    std::cout << " ***************************** Done fitting *****************************\n";
+  } else { // Magnet off: linear tracks
+    // Do nothing while there is no alignment
   }
 
   return true;
@@ -82,88 +86,145 @@ template <typename T>
 bool TrackFitter<T>::initTrack(T& track, bool outward)
 {
 
-  // initialize the starting track parameters and cluster
-  double sigmainvQPtsq;
-  double chi2invqptquad;
-  auto invQPt0 = invQPtFromFCF(track, mBZField, sigmainvQPtsq);
-  if (std::abs(mBZField) < 0.5) { // Temporary workaround for MFT tracking with magnet off;
-    invQPt0 = 1e-5;
+  if constexpr (std::is_same<T, o2::mft::TrackLTF>::value) { // Magnet on
+    // initialize the starting track parameters
+    double sigmainvQPtsq;
+    double chi2invqptquad;
+    auto invQPt0 = invQPtFromFCF(track, mBZField, sigmainvQPtsq);
+    auto nPoints = track.getNumberOfPoints();
+    auto k = TMath::Abs(o2::constants::math::B2C * mBZField);
+    auto Hz = std::copysign(1, mBZField);
+
+    if (mVerbose) {
+      std::cout << "\n ***************************** Start Fitting new track ***************************** \n";
+      std::cout << "N Clusters = " << nPoints << std::endl;
+    }
+
+    track.setInvQPtSeed(invQPt0);
+    track.setChi2QPtSeed(chi2invqptquad);
+    track.setInvQPt(invQPt0);
+
+    /// Compute the initial track parameters to seed the Kalman filter
+    int first_cls, last_cls;
+    if (outward) { // MCH matching
+      first_cls = 1;
+      last_cls = 0;
+    } else { // Vertexing
+      first_cls = nPoints - 1;
+      last_cls = nPoints - 2;
+    }
+
+    auto x0 = track.getXCoordinates()[first_cls];
+    auto y0 = track.getYCoordinates()[first_cls];
+    auto z0 = track.getZCoordinates()[first_cls];
+
+    //Compute tanl using first two clusters
+    auto deltaX = track.getXCoordinates()[1] - track.getXCoordinates()[0];
+    auto deltaY = track.getYCoordinates()[1] - track.getYCoordinates()[0];
+    auto deltaZ = track.getZCoordinates()[1] - track.getZCoordinates()[0];
+    auto deltaR = TMath::Sqrt(deltaX * deltaX + deltaY * deltaY);
+    auto tanl0 = 0.5 * TMath::Sqrt2() * (deltaZ / deltaR) *
+                 TMath::Sqrt(TMath::Sqrt((invQPt0 * deltaR * k) * (invQPt0 * deltaR * k) + 1) + 1);
+
+    // Compute phi at the last cluster using two last clusters
+    deltaX = track.getXCoordinates()[first_cls] - track.getXCoordinates()[last_cls];
+    deltaY = track.getYCoordinates()[first_cls] - track.getYCoordinates()[last_cls];
+    deltaZ = track.getZCoordinates()[first_cls] - track.getZCoordinates()[last_cls];
+    deltaR = TMath::Sqrt(deltaX * deltaX + deltaY * deltaY);
+    auto phi0 = TMath::ATan2(deltaY, deltaX) - 0.5 * Hz * invQPt0 * deltaZ * k / tanl0;
+
+    track.setX(x0);
+    track.setY(y0);
+    track.setZ(z0);
+    track.setPhi(phi0);
+    track.setTanl(tanl0);
+
+    if (mVerbose) {
+      std::cout << " Init " << (track.isCA() ? "CA Track " : "LTF Track") << std::endl;
+      auto model = (mTrackModel == Helix) ? "Helix" : (mTrackModel == Quadratic) ? "Quadratic"
+                                                    : (mTrackModel == Optimized) ? "Optimized"
+                                                                                 : "Linear";
+      std::cout << "Track Model: " << model << std::endl;
+      std::cout << "  initTrack: X = " << x0 << " Y = " << y0 << " Z = " << z0 << " Tgl = " << tanl0 << "  Phi = " << phi0 << " pz = " << track.getPz() << " q/pt = " << track.getInvQPt() << std::endl;
+    }
+
+    SMatrix55Sym lastParamCov;
+    float qptsigma = TMath::Max(std::abs(track.getInvQPt()), .5);
+    float tanlsigma = TMath::Max(std::abs(track.getTanl()), .5);
+
+    lastParamCov(0, 0) = 1;                              // <X,X>
+    lastParamCov(1, 1) = 1;                              // <Y,X>
+    lastParamCov(2, 2) = TMath::Pi() * TMath::Pi() / 16; // <PHI,X>
+    lastParamCov(3, 3) = 10 * tanlsigma * tanlsigma;     // <TANL,X>
+    lastParamCov(4, 4) = 10 * qptsigma * qptsigma;       // <INVQPT,X>
+
+    track.setCovariances(lastParamCov);
+    track.setTrackChi2(0.);
+
+  } else { // Magnet off: linear tracks
+
+    // initialize the starting track parameters
+    double chi2invqptquad;
+    auto invQPt0 = 0;
+
+    auto nPoints = track.getNumberOfPoints();
+
+    if (mVerbose) {
+      std::cout << "\n ***************************** Start Fitting new track ***************************** \n";
+      std::cout << "N Clusters = " << nPoints << std::endl;
+    }
+
+    track.setInvQPtSeed(0);
+    track.setChi2QPtSeed(0);
+    track.setInvQPt(invQPt0);
+
+    /// Compute the initial track parameters to seed the Kalman filter
+    int first_cls, last_cls;
+    if (outward) { // MCH matching
+      first_cls = nPoints - 1;
+      last_cls = 0;
+    } else { // Vertexing
+      first_cls = nPoints - 1;
+      last_cls = 0;
+    }
+
+    auto x0 = track.getXCoordinates()[first_cls];
+    auto y0 = track.getYCoordinates()[first_cls];
+    auto z0 = track.getZCoordinates()[first_cls];
+
+    auto deltaX = track.getXCoordinates()[first_cls] - track.getXCoordinates()[last_cls];
+    auto deltaY = track.getYCoordinates()[first_cls] - track.getYCoordinates()[last_cls];
+    auto deltaZ = track.getZCoordinates()[first_cls] - track.getZCoordinates()[last_cls];
+    auto deltaR = TMath::Sqrt(deltaX * deltaX + deltaY * deltaY);
+    auto tanl0 = deltaZ / deltaR;
+    auto phi0 = TMath::ATan2(deltaY, deltaX);
+
+    track.setX(x0);
+    track.setY(y0);
+    track.setZ(z0);
+    track.setPhi(phi0);
+    track.setTanl(tanl0);
+
+    if (mVerbose) {
+      std::cout << " Init " << (track.isCA() ? "CA Track " : "LTF Track") << std::endl;
+      auto model = "Linear";
+      std::cout << "Track Model: " << model << std::endl;
+      std::cout << "  initTrack: X = " << x0 << " Y = " << y0 << " Z = " << z0 << " Tgl = " << tanl0 << "  Phi = " << phi0 << " pz = " << track.getPz() << " q/pt = " << track.getInvQPt() << std::endl;
+    }
+
+    SMatrix55Sym lastParamCov;
+    float qptsigma = TMath::Max(std::abs(track.getInvQPt()), .5);
+    float tanlsigma = TMath::Max(std::abs(track.getTanl()), .5);
+
+    lastParamCov(0, 0) = 1;                              // <X,X>
+    lastParamCov(1, 1) = 1;                              // <Y,X>
+    lastParamCov(2, 2) = TMath::Pi() * TMath::Pi() / 16; // <PHI,X>
+    lastParamCov(3, 3) = 10 * tanlsigma * tanlsigma;     // <TANL,X>
+    lastParamCov(4, 4) = 10 * qptsigma * qptsigma;       // <INVQPT,X>
+
+    track.setCovariances(lastParamCov);
+    track.setTrackChi2(0.);
   }
-  auto nPoints = track.getNumberOfPoints();
-  auto k = TMath::Abs(o2::constants::math::B2C * mBZField);
-  auto Hz = std::copysign(1, mBZField);
-
-  if (mVerbose) {
-    std::cout << "\n ***************************** Start Fitting new track ***************************** \n";
-    std::cout << "N Clusters = " << nPoints << std::endl;
-  }
-
-  track.setInvQPtSeed(invQPt0);
-  track.setChi2QPtSeed(chi2invqptquad);
-  track.setInvQPt(invQPt0);
-
-  /// Compute the initial track parameters to seed the Kalman filter
-  int first_cls, last_cls;
-  if (outward) { // MCH matching
-    first_cls = 1;
-    last_cls = 0;
-  } else { // Vertexing
-    first_cls = nPoints - 1;
-    last_cls = nPoints - 2;
-  }
-
-  auto x0 = track.getXCoordinates()[first_cls];
-  auto y0 = track.getYCoordinates()[first_cls];
-  auto z0 = track.getZCoordinates()[first_cls];
-
-  //Compute tanl using first two clusters
-  auto deltaX = track.getXCoordinates()[1] - track.getXCoordinates()[0];
-  auto deltaY = track.getYCoordinates()[1] - track.getYCoordinates()[0];
-  auto deltaZ = track.getZCoordinates()[1] - track.getZCoordinates()[0];
-  auto deltaR = TMath::Sqrt(deltaX * deltaX + deltaY * deltaY);
-  auto tanl0 = 0.5 * TMath::Sqrt2() * (deltaZ / deltaR) *
-               TMath::Sqrt(TMath::Sqrt((invQPt0 * deltaR * k) * (invQPt0 * deltaR * k) + 1) + 1);
-
-  // Compute phi at the last cluster using two last clusters
-  deltaX = track.getXCoordinates()[first_cls] - track.getXCoordinates()[last_cls];
-  deltaY = track.getYCoordinates()[first_cls] - track.getYCoordinates()[last_cls];
-  deltaZ = track.getZCoordinates()[first_cls] - track.getZCoordinates()[last_cls];
-  deltaR = TMath::Sqrt(deltaX * deltaX + deltaY * deltaY);
-  auto phi0 = TMath::ATan2(deltaY, deltaX) - 0.5 * Hz * invQPt0 * deltaZ * k / tanl0;
-  auto sigmax0sq = track.getSigmasX2()[first_cls];
-  auto sigmay0sq = track.getSigmasY2()[first_cls];
-  auto sigmax1sq = track.getSigmasX2()[last_cls];
-  auto sigmay1sq = track.getSigmasY2()[last_cls];
-  auto sigmaDeltaXsq = sigmax0sq + sigmax1sq;
-  auto sigmaDeltaYsq = sigmay0sq + sigmay1sq;
-
-  track.setX(x0);
-  track.setY(y0);
-  track.setZ(z0);
-  track.setPhi(phi0);
-  track.setTanl(tanl0);
-
-  if (mVerbose) {
-    std::cout << " Init " << (track.isCA() ? "CA Track " : "LTF Track") << std::endl;
-    auto model = (mTrackModel == Helix) ? "Helix" : (mTrackModel == Quadratic) ? "Quadratic"
-                                                  : (mTrackModel == Optimized) ? "Optimized"
-                                                                               : "Linear";
-    std::cout << "Track Model: " << model << std::endl;
-    std::cout << "  initTrack: X = " << x0 << " Y = " << y0 << " Z = " << z0 << " Tgl = " << tanl0 << "  Phi = " << phi0 << " pz = " << track.getPz() << " q/pt = " << track.getInvQPt() << std::endl;
-  }
-
-  SMatrix55Sym lastParamCov;
-  float qptsigma = TMath::Max(std::abs(track.getInvQPt()), .5);
-  float tanlsigma = TMath::Max(std::abs(track.getTanl()), .5);
-
-  lastParamCov(0, 0) = 1;                              // <X,X>
-  lastParamCov(1, 1) = 1;                              // <Y,X>
-  lastParamCov(2, 2) = TMath::Pi() * TMath::Pi() / 16; // <PHI,X>
-  lastParamCov(3, 3) = 10 * tanlsigma * tanlsigma;     // <TANL,X>
-  lastParamCov(4, 4) = 10 * qptsigma * qptsigma;       // <INVQPT,X>
-
-  track.setCovariances(lastParamCov);
-  track.setTrackChi2(0.);
 
   return true;
 }
@@ -173,23 +234,28 @@ template <typename T>
 bool TrackFitter<T>::propagateToZ(T& track, double z)
 {
   // Propagate track to the z position of the new cluster
-  switch (mTrackModel) {
-    case Linear:
-      track.propagateToZlinear(z);
-      break;
-    case Quadratic:
-      track.propagateToZquadratic(z, mBZField);
-      break;
-    case Helix:
-      track.propagateToZhelix(z, mBZField);
-      break;
-    case Optimized:
-      track.propagateToZ(z, mBZField);
-      break;
-    default:
-      std::cout << " Invalid track model.\n";
-      return false;
-      break;
+  if constexpr (std::is_same<T, o2::mft::TrackLTF>::value) { // Magnet on
+
+    switch (mTrackModel) {
+      case Linear:
+        track.propagateToZlinear(z);
+        break;
+      case Quadratic:
+        track.propagateToZquadratic(z, mBZField);
+        break;
+      case Helix:
+        track.propagateToZhelix(z, mBZField);
+        break;
+      case Optimized:
+        track.propagateToZ(z, mBZField);
+        break;
+      default:
+        std::cout << " Invalid track model.\n";
+        return false;
+        break;
+    }
+  } else {
+    // Do nothing while there is no alignment
   }
   return true;
 }

--- a/Detectors/ITSMFT/MFT/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/Tracker.cxx
@@ -27,13 +27,15 @@ namespace mft
 {
 
 //_________________________________________________________________________________________________
-Tracker::Tracker(bool useMC) : mUseMC{useMC}
+template <typename T>
+Tracker<T>::Tracker(bool useMC) : mUseMC{useMC}
 {
-  mTrackFitter = std::make_unique<o2::mft::TrackFitter>();
+  mTrackFitter = std::make_unique<o2::mft::TrackFitter<T>>();
 }
 
 //_________________________________________________________________________________________________
-void Tracker::setBz(Float_t bz)
+template <typename T>
+void Tracker<T>::setBz(Float_t bz)
 {
   /// Configure track propagation
   mBz = bz;
@@ -41,7 +43,8 @@ void Tracker::setBz(Float_t bz)
 }
 
 //_________________________________________________________________________________________________
-void Tracker::initConfig(const MFTTrackingParam& trkParam, bool printConfig)
+template <typename T>
+void Tracker<T>::initConfig(const MFTTrackingParam& trkParam, bool printConfig)
 {
   /// initialize from MFTTrackingParam (command line configuration parameters)
 
@@ -91,7 +94,8 @@ void Tracker::initConfig(const MFTTrackingParam& trkParam, bool printConfig)
 }
 
 //_________________________________________________________________________________________________
-void Tracker::initialize(bool fullClusterScan)
+template <typename T>
+void Tracker<T>::initialize(bool fullClusterScan)
 {
   mRoad.initialize();
 
@@ -191,7 +195,8 @@ void Tracker::initialize(bool fullClusterScan)
 }
 
 //_________________________________________________________________________________________________
-void Tracker::clustersToTracks(ROframe& event, std::ostream& timeBenchmarkOutputStream)
+template <typename T>
+void Tracker<T>::clustersToTracks(ROframe<T>& event, std::ostream& timeBenchmarkOutputStream)
 {
   mTracks.clear();
   mTrackLabels.clear();
@@ -200,7 +205,8 @@ void Tracker::clustersToTracks(ROframe& event, std::ostream& timeBenchmarkOutput
 }
 
 //_________________________________________________________________________________________________
-void Tracker::findTracks(ROframe& event)
+template <typename T>
+void Tracker<T>::findTracks(ROframe<T>& event)
 {
   if (!mFullClusterScan) {
     findTracksLTF(event);
@@ -212,7 +218,8 @@ void Tracker::findTracks(ROframe& event)
 }
 
 //_________________________________________________________________________________________________
-void Tracker::findTracksLTF(ROframe& event)
+template <typename T>
+void Tracker<T>::findTracksLTF(ROframe<T>& event)
 {
   // find (high momentum) tracks by the Linear Track Finder (LTF) method
 
@@ -266,7 +273,7 @@ void Tracker::findTracksLTF(ROframe& event)
           }
           clsInLayer2 = it2 - event.getClustersInLayer(layer2).begin();
 
-          // start a TrackLTF
+          // start a Track type T
           nPoints = 0;
 
           // add the first seed point
@@ -340,15 +347,15 @@ void Tracker::findTracksLTF(ROframe& event)
             continue;
           }
 
-          // add a new TrackLTF
-          event.addTrackLTF();
+          // add a new Track
+          event.addTrack();
           for (Int_t point = 0; point < nPoints; ++point) {
             auto layer = trackPoints[point].layer;
             auto clsInLayer = trackPoints[point].idInLayer;
             Cluster& cluster = event.getClustersInLayer(layer)[clsInLayer];
             mcCompLabel = mUseMC ? event.getClusterLabels(layer, cluster.clusterId) : MCCompLabel();
             extClsIndex = event.getClusterExternalIndex(layer, cluster.clusterId);
-            event.getCurrentTrackLTF().setPoint(cluster, layer, clsInLayer, mcCompLabel, extClsIndex);
+            event.getCurrentTrack().setPoint(cluster, layer, clsInLayer, mcCompLabel, extClsIndex);
             // mark the used clusters
             cluster.setUsed(true);
           }
@@ -360,7 +367,8 @@ void Tracker::findTracksLTF(ROframe& event)
 }
 
 //_________________________________________________________________________________________________
-void Tracker::findTracksLTFfcs(ROframe& event)
+template <typename T>
+void Tracker<T>::findTracksLTFfcs(ROframe<T>& event)
 {
   // find (high momentum) tracks by the Linear Track Finder (LTF) method
   // with full scan of the clusters in the target plane
@@ -409,7 +417,7 @@ void Tracker::findTracksLTFfcs(ROframe& event)
         }
         clsInLayer2 = it2 - event.getClustersInLayer(layer2).begin();
 
-        // start a TrackLTF
+        // start a track type T
         nPoints = 0;
 
         // add the first seed point
@@ -474,15 +482,15 @@ void Tracker::findTracksLTFfcs(ROframe& event)
           continue;
         }
 
-        // add a new TrackLTF
-        event.addTrackLTF();
+        // add a new Track type T
+        event.addTrack();
         for (Int_t point = 0; point < nPoints; ++point) {
           auto layer = trackPoints[point].layer;
           auto clsInLayer = trackPoints[point].idInLayer;
           Cluster& cluster = event.getClustersInLayer(layer)[clsInLayer];
           mcCompLabel = mUseMC ? event.getClusterLabels(layer, cluster.clusterId) : MCCompLabel();
           extClsIndex = event.getClusterExternalIndex(layer, cluster.clusterId);
-          event.getCurrentTrackLTF().setPoint(cluster, layer, clsInLayer, mcCompLabel, extClsIndex);
+          event.getCurrentTrack().setPoint(cluster, layer, clsInLayer, mcCompLabel, extClsIndex);
           // mark the used clusters
           cluster.setUsed(true);
         }
@@ -493,7 +501,8 @@ void Tracker::findTracksLTFfcs(ROframe& event)
 }
 
 //_________________________________________________________________________________________________
-void Tracker::findTracksCA(ROframe& event)
+template <typename T>
+void Tracker<T>::findTracksCA(ROframe<T>& event)
 {
   // layers: 0, 1, 2, ..., 9
   // rules for combining first/last plane in a road:
@@ -627,7 +636,8 @@ void Tracker::findTracksCA(ROframe& event)
 }
 
 //_________________________________________________________________________________________________
-void Tracker::findTracksCAfcs(ROframe& event)
+template <typename T>
+void Tracker<T>::findTracksCAfcs(ROframe<T>& event)
 {
   // layers: 0, 1, 2, ..., 9
   // rules for combining first/last plane in a road:
@@ -742,7 +752,8 @@ void Tracker::findTracksCAfcs(ROframe& event)
 }
 
 //_________________________________________________________________________________________________
-void Tracker::computeCellsInRoad(ROframe& event)
+template <typename T>
+void Tracker<T>::computeCellsInRoad(ROframe<T>& event)
 {
   Int_t layer1, layer1min, layer1max, layer2, layer2min, layer2max;
   Int_t nPtsInLayer1, nPtsInLayer2;
@@ -793,7 +804,8 @@ void Tracker::computeCellsInRoad(ROframe& event)
 }
 
 //_________________________________________________________________________________________________
-void Tracker::runForwardInRoad()
+template <typename T>
+void Tracker<T>::runForwardInRoad()
 {
   Int_t layerR, layerL, icellR, icellL;
   Int_t iter = 0;
@@ -840,7 +852,8 @@ void Tracker::runForwardInRoad()
 }
 
 //_________________________________________________________________________________________________
-void Tracker::runBackwardInRoad(ROframe& event)
+template <typename T>
+void Tracker<T>::runBackwardInRoad(ROframe<T>& event)
 {
   if (mMaxCellLevel == 1) {
     return; // we have only isolated cells
@@ -947,8 +960,8 @@ void Tracker::runBackwardInRoad(ROframe& event)
         continue;
       }
 
-      // add a new TrackCA
-      event.addTrackCA(mRoad.getRoadId());
+      // add a new Track setting isCA = true
+      event.addTrack(true);
       for (icell = 0; icell < nCells; ++icell) {
         layerC = trackCells[icell].layer;
         cellIdC = trackCells[icell].idInLayer;
@@ -964,7 +977,8 @@ void Tracker::runBackwardInRoad(ROframe& event)
 }
 
 //_________________________________________________________________________________________________
-void Tracker::updateCellStatusInRoad()
+template <typename T>
+void Tracker<T>::updateCellStatusInRoad()
 {
   Int_t layerMin, layerMax;
   mRoad.getLength(layerMin, layerMax);
@@ -977,7 +991,8 @@ void Tracker::updateCellStatusInRoad()
 }
 
 //_________________________________________________________________________________________________
-void Tracker::addCellToCurrentRoad(ROframe& event, const Int_t layer1, const Int_t layer2, const Int_t clsInLayer1, const Int_t clsInLayer2, Int_t& cellId)
+template <typename T>
+void Tracker<T>::addCellToCurrentRoad(ROframe<T>& event, const Int_t layer1, const Int_t layer2, const Int_t clsInLayer1, const Int_t clsInLayer2, Int_t& cellId)
 {
   Cell& cell = mRoad.addCellInLayer(layer1, layer2, clsInLayer1, clsInLayer2, cellId);
 
@@ -997,9 +1012,10 @@ void Tracker::addCellToCurrentRoad(ROframe& event, const Int_t layer1, const Int
 }
 
 //_________________________________________________________________________________________________
-void Tracker::addCellToCurrentTrackCA(const Int_t layer1, const Int_t cellId, ROframe& event)
+template <typename T>
+void Tracker<T>::addCellToCurrentTrackCA(const Int_t layer1, const Int_t cellId, ROframe<T>& event)
 {
-  TrackCA& trackCA = event.getCurrentTrackCA();
+  auto& trackCA = event.getCurrentTrack();
   const Cell& cell = mRoad.getCellsInLayer(layer1)[cellId];
   const Int_t layer2 = cell.getSecondLayerId();
   const Int_t clsInLayer1 = cell.getFirstClusterIndex();
@@ -1023,28 +1039,22 @@ void Tracker::addCellToCurrentTrackCA(const Int_t layer1, const Int_t cellId, RO
 }
 
 //_________________________________________________________________________________________________
-bool Tracker::fitTracks(ROframe& event)
+template <typename T>
+bool Tracker<T>::fitTracks(ROframe<T>& event)
 {
-  for (auto& track : event.getTracksLTF()) {
-    TrackLTF outParam = track;
+  for (auto& track : event.getTracks()) {
+    T outParam = track;
     mTrackFitter->initTrack(track);
     mTrackFitter->fit(track);
     mTrackFitter->initTrack(outParam, true);
     mTrackFitter->fit(outParam, true);
     track.setOutParam(outParam);
   }
-  for (auto& track : event.getTracksCA()) {
-    track.sort();
-    TrackCA outParam = track;
-    mTrackFitter->initTrack(track);
-    mTrackFitter->fit(track);
-    mTrackFitter->initTrack(outParam, true);
-    mTrackFitter->fit(outParam, true);
-    track.setOutParam(outParam);
-  }
-
   return true;
 }
+
+template class Tracker<o2::mft::TrackLTF>;
+template class Tracker<o2::mft::TrackLTFL>;
 
 } // namespace mft
 } // namespace o2

--- a/Detectors/ITSMFT/MFT/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/Tracker.cxx
@@ -482,7 +482,7 @@ void Tracker<T>::findTracksLTFfcs(ROframe<T>& event)
           continue;
         }
 
-        // add a new Track type T
+        // add a new Track
         event.addTrack();
         for (Int_t point = 0; point < nPoints; ++point) {
           auto layer = trackPoints[point].layer;
@@ -972,6 +972,7 @@ void Tracker<T>::runBackwardInRoad(ROframe<T>& event)
         event.getClustersInLayer(cellC.getFirstLayerId())[cellC.getFirstClusterIndex()].setUsed(true);
         event.getClustersInLayer(cellC.getSecondLayerId())[cellC.getSecondClusterIndex()].setUsed(true);
       }
+      event.getCurrentTrack().sort();
     } // end loop cells
   }   // end loop start layer
 }
@@ -1044,7 +1045,6 @@ bool Tracker<T>::fitTracks(ROframe<T>& event)
 {
   for (auto& track : event.getTracks()) {
     T outParam = track;
-    track.sort();
     mTrackFitter->initTrack(track);
     mTrackFitter->fit(track);
     mTrackFitter->initTrack(outParam, true);

--- a/Detectors/ITSMFT/MFT/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/Tracker.cxx
@@ -1044,6 +1044,7 @@ bool Tracker<T>::fitTracks(ROframe<T>& event)
 {
   for (auto& track : event.getTracks()) {
     T outParam = track;
+    track.sort();
     mTrackFitter->initTrack(track);
     mTrackFitter->fit(track);
     mTrackFitter->initTrack(outParam, true);

--- a/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/TrackerSpec.h
+++ b/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/TrackerSpec.h
@@ -17,6 +17,7 @@
 #include "MFTTracking/Tracker.h"
 
 #include "Framework/DataProcessorSpec.h"
+#include "MFTTracking/TrackCA.h"
 #include "Framework/Task.h"
 #include "DataFormatsParameters/GRPObject.h"
 #include "DataFormatsITSMFT/TopologyDictionary.h"
@@ -26,9 +27,11 @@ namespace o2
 {
 namespace mft
 {
+using o2::mft::TrackLTF;
 
 class TrackerDPL : public o2::framework::Task
 {
+
  public:
   TrackerDPL(bool useMC) : mUseMC(useMC) {}
   ~TrackerDPL() override = default;
@@ -38,9 +41,11 @@ class TrackerDPL : public o2::framework::Task
 
  private:
   bool mUseMC = false;
+  bool mFieldOn = true;
   o2::itsmft::TopologyDictionary mDict;
   std::unique_ptr<o2::parameters::GRPObject> mGRP = nullptr;
-  std::unique_ptr<o2::mft::Tracker> mTracker = nullptr;
+  std::unique_ptr<o2::mft::Tracker<TrackLTF>> mTracker = nullptr;
+  std::unique_ptr<o2::mft::Tracker<TrackLTFL>> mTrackerL = nullptr;
   TStopwatch mTimer;
 };
 

--- a/Detectors/ITSMFT/MFT/workflow/src/ClustererSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/ClustererSpec.cxx
@@ -94,8 +94,8 @@ void ClustererDPL::run(ProcessingContext& pc)
   }
   const o2::dataformats::ConstMCTruthContainerView<o2::MCCompLabel> labels(labelbuffer);
 
-  LOG(INFO) << "MFTClusterer pulled " << digits.size() << " digits, in "
-            << rofs.size() << " RO frames";
+  LOG(DEBUG) << "MFTClusterer pulled " << digits.size() << " digits, in "
+             << rofs.size() << " RO frames";
 
   o2::itsmft::DigitPixelReader reader;
   reader.setDigits(digits);
@@ -130,7 +130,7 @@ void ClustererDPL::run(ProcessingContext& pc)
 
   // TODO: in principle, after masking "overflow" pixels the MC2ROFRecord maxROF supposed to change, nominally to minROF
   // -> consider recalculationg maxROF
-  LOG(INFO) << "MFTClusterer pushed " << clusCompVec.size() << " compressed clusters, in " << clusROFVec.size() << " RO frames";
+  LOG(DEBUG) << "MFTClusterer pushed " << clusCompVec.size() << " compressed clusters, in " << clusROFVec.size() << " RO frames";
 }
 
 DataProcessorSpec getClustererSpec(bool useMC)

--- a/Detectors/ITSMFT/MFT/workflow/src/TrackWriterSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/TrackWriterSpec.cxx
@@ -44,7 +44,7 @@ DataProcessorSpec getTrackWriterSpec(bool useMC)
     *tracksSize = tracks.size();
   };
   auto logger = [tracksSize](std::vector<o2::itsmft::ROFRecord> const& rofs) {
-    LOG(INFO) << "MFTTrackWriter pulled " << *tracksSize << " tracks, in " << rofs.size() << " RO frames";
+    LOG(DEBUG) << "MFTTrackWriter pulled " << *tracksSize << " tracks, in " << rofs.size() << " RO frames";
   };
   return MakeRootTreeWriterSpec("mft-track-writer",
                                 "mfttracks.root",

--- a/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
@@ -61,16 +61,24 @@ void TrackerDPL::init(InitContext& ic)
     // tracking configuration parameters
     auto& trackingParam = MFTTrackingParam::Instance();
     // create the tracker: set the B-field, the configuration and initialize
-    mTracker = std::make_unique<o2::mft::Tracker>(mUseMC);
+
     double centerMFT[3] = {0, 0, -61.4}; // Field at center of MFT
     auto Bz = field->getBz(centerMFT);
-    if (Bz == 0) {
-      Bz = 0.1; // Temporary workaround for MFT tracking with magnet off;
-      LOG(INFO) << " Temporary workaround for MFT tracking with magnet off. Bz = " << Bz;
+    if (Bz != 0) {
+      LOG(INFO) << "Starting MFT tracker: Field is on!";
+      mFieldOn = true;
+      mTracker = std::make_unique<o2::mft::Tracker<TrackLTF>>(mUseMC);
+      mTracker->setBz(Bz);
+      mTracker->initConfig(trackingParam, true);
+      mTracker->initialize(trackingParam.FullClusterScan);
+    } else {
+      LOG(INFO) << "Starting MFT Linear tracker: Field is off!";
+      mFieldOn = false;
+      mTrackerL = std::make_unique<o2::mft::Tracker<TrackLTFL>>(mUseMC);
+      mTrackerL->initConfig(trackingParam, true);
+      mTrackerL->initialize(trackingParam.FullClusterScan);
     }
-    mTracker->setBz(Bz);
-    mTracker->initConfig(trackingParam, true);
-    mTracker->initialize(trackingParam.FullClusterScan);
+
   } else {
     throw std::runtime_error(o2::utils::Str::concat_string("Cannot retrieve GRP from the ", filename));
   }
@@ -90,8 +98,7 @@ void TrackerDPL::run(ProcessingContext& pc)
   mTimer.Start(false);
   gsl::span<const unsigned char> patterns = pc.inputs().get<gsl::span<unsigned char>>("patterns");
   auto compClusters = pc.inputs().get<const std::vector<o2::itsmft::CompClusterExt>>("compClusters");
-  auto nTracksLTF = 0;
-  auto nTracksCA = 0;
+  auto ntracks = 0;
 
   // code further down does assignment to the rofs and the altered object is used for output
   // we therefore need a copy of the vector rather than an object created directly on the input data,
@@ -112,56 +119,62 @@ void TrackerDPL::run(ProcessingContext& pc)
               << mc2rofs.size() << " MC events";
   }
 
-  //std::vector<o2::mft::TrackMFTExt> tracks;
   auto& allClusIdx = pc.outputs().make<std::vector<int>>(Output{"MFT", "TRACKCLSID", 0, Lifetime::Timeframe});
   std::vector<o2::MCCompLabel> trackLabels;
   std::vector<o2::MCCompLabel> allTrackLabels;
-  std::vector<o2::mft::TrackLTF> tracksLTF;
-  std::vector<o2::mft::TrackCA> tracksCA;
+  std::vector<o2::mft::TrackLTF> tracks;
+  std::vector<o2::mft::TrackLTFL> tracksL;
   auto& allTracksMFT = pc.outputs().make<std::vector<o2::mft::TrackMFT>>(Output{"MFT", "TRACKS", 0, Lifetime::Timeframe});
 
   std::uint32_t roFrame = 0;
-  o2::mft::ROframe event(0);
 
-  Bool_t continuous = mGRP->isDetContinuousReadOut("MFT");
-  LOG(INFO) << "MFTTracker RO: continuous=" << continuous;
+  if (mFieldOn) {
+    o2::mft::ROframe<TrackLTF> event(0);
 
-  // tracking configuration parameters
-  auto& trackingParam = MFTTrackingParam::Instance();
+    Bool_t continuous = mGRP->isDetContinuousReadOut("MFT");
+    LOG(INFO) << "MFTTracker RO: continuous=" << continuous;
 
-  // snippet to convert found tracks to final output tracks with separate cluster indices
-  auto copyTracks = [&event](auto& tracks, auto& allTracks, auto& allClusIdx) {
-    for (auto& trc : tracks) {
-      trc.setExternalClusterIndexOffset(allClusIdx.size());
-      int ncl = trc.getNumberOfPoints();
-      for (int ic = 0; ic < ncl; ic++) {
-        auto externalClusterID = trc.getExternalClusterIndex(ic);
-        allClusIdx.push_back(externalClusterID);
+    // tracking configuration parameters
+    auto& trackingParam = MFTTrackingParam::Instance();
+
+    // snippet to convert found tracks to final output tracks with separate cluster indices
+    auto copyTracks = [&event](auto& tracks, auto& allTracks, auto& allClusIdx) {
+      for (auto& trc : tracks) {
+        trc.setExternalClusterIndexOffset(allClusIdx.size());
+        int ncl = trc.getNumberOfPoints();
+        for (int ic = 0; ic < ncl; ic++) {
+          auto externalClusterID = trc.getExternalClusterIndex(ic);
+          allClusIdx.push_back(externalClusterID);
+        }
+        allTracks.emplace_back(trc);
       }
-      allTracks.emplace_back(trc);
-    }
-  };
+    };
 
-  gsl::span<const unsigned char>::iterator pattIt = patterns.begin();
-  for (auto& rof : rofs) {
-    int nclUsed = ioutils::loadROFrameData(rof, event, compClusters, pattIt, mDict, labels, mTracker.get());
-    if (nclUsed) {
-      event.setROFrameId(roFrame);
-      event.initialize(trackingParam.FullClusterScan);
-      LOG(INFO) << "ROframe: " << roFrame << ", clusters loaded : " << nclUsed;
-      mTracker->setROFrame(roFrame);
-      mTracker->clustersToTracks(event);
-      tracksLTF.swap(event.getTracksLTF());
-      tracksCA.swap(event.getTracksCA());
-      nTracksLTF += tracksLTF.size();
-      nTracksCA += tracksCA.size();
+    gsl::span<const unsigned char>::iterator pattIt = patterns.begin();
+    for (auto& rof : rofs) {
+      int nclUsed = ioutils::loadROFrameData(rof, event, compClusters, pattIt, mDict, labels, mTracker.get());
+      if (nclUsed) {
+        event.setROFrameId(roFrame);
+        event.initialize(trackingParam.FullClusterScan);
+        LOG(INFO) << "ROframe: " << roFrame << ", clusters loaded : " << nclUsed;
+        mTracker->setROFrame(roFrame);
+        mTracker->clustersToTracks(event);
+        tracks.swap(event.getTracks());
+        ntracks += tracks.size();
 
-      if (mUseMC) {
-        mTracker->computeTracksMClabels(tracksLTF);
-        mTracker->computeTracksMClabels(tracksCA);
-        trackLabels.swap(mTracker->getTrackLabels());
-        std::copy(trackLabels.begin(), trackLabels.end(), std::back_inserter(allTrackLabels));
-        trackLabels.clear();
+        if (mUseMC) {
+          mTracker->computeTracksMClabels(tracks);
+          trackLabels.swap(mTracker->getTrackLabels());
+          std::copy(trackLabels.begin(), trackLabels.end(), std::back_inserter(allTrackLabels));
+          trackLabels.clear();
+        }
+
+        LOG(INFO) << "Found MFT tracks: " << tracks.size();
+        int first = allTracksMFT.size();
+        int number = tracks.size();
+        rof.setFirstEntry(first);
+        rof.setNEntries(number);
+        copyTracks(tracks, allTracksMFT, allClusIdx);
       }
 
       LOG(INFO) << "Found tracks LTF: " << tracksLTF.size();
@@ -173,11 +186,58 @@ void TrackerDPL::run(ProcessingContext& pc)
       copyTracks(tracksLTF, allTracksMFT, allClusIdx);
       copyTracks(tracksCA, allTracksMFT, allClusIdx);
     }
-    roFrame++;
-  }
+  } else { // Use Linear Tracker for Field off
+    o2::mft::ROframe<TrackLTFL> event(0);
 
-  LOG(INFO) << "MFTTracker found " << nTracksLTF << " tracks LTF";
-  LOG(INFO) << "MFTTracker found " << nTracksCA << " tracks CA";
+    Bool_t continuous = mGRP->isDetContinuousReadOut("MFT");
+    LOG(INFO) << "MFTTracker RO: continuous=" << continuous;
+
+    // tracking configuration parameters
+    auto& trackingParam = MFTTrackingParam::Instance();
+
+    // snippet to convert found tracks to final output tracks with separate cluster indices
+    auto copyTracks = [&event](auto& tracks, auto& allTracks, auto& allClusIdx) {
+      for (auto& trc : tracks) {
+        trc.setExternalClusterIndexOffset(allClusIdx.size());
+        int ncl = trc.getNumberOfPoints();
+        for (int ic = 0; ic < ncl; ic++) {
+          auto externalClusterID = trc.getExternalClusterIndex(ic);
+          allClusIdx.push_back(externalClusterID);
+        }
+        allTracks.emplace_back(trc);
+      }
+    };
+
+    gsl::span<const unsigned char>::iterator pattIt = patterns.begin();
+    for (auto& rof : rofs) {
+      int nclUsed = ioutils::loadROFrameData(rof, event, compClusters, pattIt, mDict, labels, mTrackerL.get());
+      if (nclUsed) {
+        event.setROFrameId(roFrame);
+        event.initialize(trackingParam.FullClusterScan);
+        LOG(INFO) << "ROframe: " << roFrame << ", clusters loaded : " << nclUsed;
+        mTrackerL->setROFrame(roFrame);
+        mTrackerL->clustersToTracks(event);
+        tracksL.swap(event.getTracks());
+        ntracks += tracksL.size();
+
+        if (mUseMC) {
+          mTrackerL->computeTracksMClabels(tracksL);
+          trackLabels.swap(mTrackerL->getTrackLabels());
+          std::copy(trackLabels.begin(), trackLabels.end(), std::back_inserter(allTrackLabels));
+          trackLabels.clear();
+        }
+
+        LOG(INFO) << "Found MFT tracks: " << tracks.size();
+        int first = allTracksMFT.size();
+        int number = tracksL.size();
+        rof.setFirstEntry(first);
+        rof.setNEntries(number);
+        copyTracks(tracksL, allTracksMFT, allClusIdx);
+      }
+      roFrame++;
+    }
+  }
+  LOG(INFO) << "MFTTracker found " << ntracks << " tracks";
   LOG(INFO) << "MFTTracker pushed " << allTracksMFT.size() << " tracks";
 
   if (mUseMC) {

--- a/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
@@ -176,15 +176,7 @@ void TrackerDPL::run(ProcessingContext& pc)
         rof.setNEntries(number);
         copyTracks(tracks, allTracksMFT, allClusIdx);
       }
-
-      LOG(INFO) << "Found tracks LTF: " << tracksLTF.size();
-      LOG(INFO) << "Found tracks CA: " << tracksCA.size();
-      int first = allTracksMFT.size();
-      int number = tracksLTF.size() + tracksCA.size();
-      rof.setFirstEntry(first);
-      rof.setNEntries(number);
-      copyTracks(tracksLTF, allTracksMFT, allClusIdx);
-      copyTracks(tracksCA, allTracksMFT, allClusIdx);
+      roFrame++;
     }
   } else { // Use Linear Tracker for Field off
     o2::mft::ROframe<TrackLTFL> event(0);

--- a/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
@@ -53,6 +53,9 @@ void TrackerDPL::init(InitContext& ic)
     o2::base::Propagator::initFieldFromGRP(grp);
     auto field = static_cast<o2::field::MagneticField*>(TGeoGlobalMagField::Instance()->GetField());
 
+    Bool_t continuous = mGRP->isDetContinuousReadOut("MFT");
+    LOG(INFO) << "MFTTracker RO: continuous=" << continuous;
+
     o2::base::GeometryManager::loadGeometry();
     o2::mft::GeometryTGeo* geom = o2::mft::GeometryTGeo::Instance();
     geom->fillMatrixCache(o2::math_utils::bit2Mask(o2::math_utils::TransformType::T2L, o2::math_utils::TransformType::T2GRot,
@@ -131,9 +134,6 @@ void TrackerDPL::run(ProcessingContext& pc)
   if (mFieldOn) {
     o2::mft::ROframe<TrackLTF> event(0);
 
-    Bool_t continuous = mGRP->isDetContinuousReadOut("MFT");
-    LOG(INFO) << "MFTTracker RO: continuous=" << continuous;
-
     // tracking configuration parameters
     auto& trackingParam = MFTTrackingParam::Instance();
 
@@ -156,7 +156,7 @@ void TrackerDPL::run(ProcessingContext& pc)
       if (nclUsed) {
         event.setROFrameId(roFrame);
         event.initialize(trackingParam.FullClusterScan);
-        LOG(INFO) << "ROframe: " << roFrame << ", clusters loaded : " << nclUsed;
+        LOG(DEBUG) << "ROframe: " << roFrame << ", clusters loaded : " << nclUsed;
         mTracker->setROFrame(roFrame);
         mTracker->clustersToTracks(event);
         tracks.swap(event.getTracks());
@@ -169,7 +169,7 @@ void TrackerDPL::run(ProcessingContext& pc)
           trackLabels.clear();
         }
 
-        LOG(INFO) << "Found MFT tracks: " << tracks.size();
+        LOG(DEBUG) << "Found MFT tracks: " << tracks.size();
         int first = allTracksMFT.size();
         int number = tracks.size();
         rof.setFirstEntry(first);
@@ -180,9 +180,6 @@ void TrackerDPL::run(ProcessingContext& pc)
     }
   } else { // Use Linear Tracker for Field off
     o2::mft::ROframe<TrackLTFL> event(0);
-
-    Bool_t continuous = mGRP->isDetContinuousReadOut("MFT");
-    LOG(INFO) << "MFTTracker RO: continuous=" << continuous;
 
     // tracking configuration parameters
     auto& trackingParam = MFTTrackingParam::Instance();
@@ -219,7 +216,7 @@ void TrackerDPL::run(ProcessingContext& pc)
           trackLabels.clear();
         }
 
-        LOG(INFO) << "Found MFT tracks: " << tracks.size();
+        LOG(DEBUG) << "Found MFT tracks: " << tracks.size();
         int first = allTracksMFT.size();
         int number = tracksL.size();
         rof.setFirstEntry(first);
@@ -229,7 +226,6 @@ void TrackerDPL::run(ProcessingContext& pc)
       roFrame++;
     }
   }
-  LOG(INFO) << "MFTTracker found " << ntracks << " tracks";
   LOG(INFO) << "MFTTracker pushed " << allTracksMFT.size() << " tracks";
 
   if (mUseMC) {


### PR DESCRIPTION
The B=0 case is isolated to reduce overhead.
At the moment track fitting for B=0 resumes to a simple parameter determination using the first and last track-clusters. Proper fitting to be used once the detector is aligned.