### PR TITLE
DPL Analysis: prevent adding extra empty slices when the last index is -1

### DIFF
--- a/Framework/Core/include/Framework/Kernels.h
+++ b/Framework/Core/include/Framework/Kernels.h
@@ -96,9 +96,12 @@ auto sliceByColumn(
     makeSlice(offset, count);
     offset += count;
   }
-
-  if (values.Value(size - 1) < fullSize - 1) {
-    for (auto v = values.Value(size - 1) + 1; v < fullSize; ++v) {
+  v = values.Value(size - 1);
+  if (v >= 0) {
+    vprev = v;
+  }
+  if (vprev < fullSize - 1) {
+    for (auto v = vprev + 1; v < fullSize; ++v) {
       makeSlice(offset, 0);
     }
   }

--- a/Framework/Core/test/test_GroupSlicer.cxx
+++ b/Framework/Core/test/test_GroupSlicer.cxx
@@ -242,6 +242,56 @@ BOOST_AUTO_TEST_CASE(GroupSlicerMismatchedGroups)
   }
 }
 
+BOOST_AUTO_TEST_CASE(GroupSlicerMismatchedUnassignedGroups)
+{
+  TableBuilder builderE;
+  auto evtsWriter = builderE.cursor<aod::Events>();
+  for (auto i = 0; i < 20; ++i) {
+    evtsWriter(0, i, 0.5f * i, 2.f * i, 3.f * i);
+  }
+  auto evtTable = builderE.finalize();
+
+  TableBuilder builderT;
+  auto trksWriter = builderT.cursor<aod::TrksX>();
+  for (auto i = 0; i < 20; ++i) {
+    if (i == 3 || i == 10 || i == 12 || i == 16 || i == 19) {
+      continue;
+    }
+    for (auto j = 0.f; j < 5; j += 0.5f) {
+      trksWriter(0, i, 0.5f * j);
+    }
+  }
+  for (auto i = 0; i < 5; ++i) {
+    trksWriter(0, -1, 0.123f * i + 1.654f);
+  }
+  auto trkTable = builderT.finalize();
+
+  aod::Events e{evtTable};
+  aod::TrksX t{trkTable};
+  BOOST_CHECK_EQUAL(e.size(), 20);
+  BOOST_CHECK_EQUAL(t.size(), (5 + 10 * (20 - 5)));
+
+  auto tt = std::make_tuple(t);
+  o2::framework::AnalysisDataProcessorBuilder::GroupSlicer g(e, tt);
+
+  unsigned int count = 0;
+  for (auto& slice : g) {
+    auto as = slice.associatedTables();
+    auto gg = slice.groupingElement();
+    BOOST_CHECK_EQUAL(gg.globalIndex(), count);
+    auto trks = std::get<aod::TrksX>(as);
+    if (count == 3 || count == 10 || count == 12 || count == 16 || count == 19) {
+      BOOST_CHECK_EQUAL(trks.size(), 0);
+    } else {
+      BOOST_CHECK_EQUAL(trks.size(), 10);
+    }
+    for (auto& trk : trks) {
+      BOOST_CHECK_EQUAL(trk.eventId(), count);
+    }
+    ++count;
+  }
+}
+
 BOOST_AUTO_TEST_CASE(GroupSlicerMismatchedFilteredGroups)
 {
   TableBuilder builderE;


### PR DESCRIPTION
* Check for the last non-negative value before padding the slices to full size
* Add a test case