### PR TITLE
Readd event display printout, was removed

### DIFF
--- a/EventVisualisation/Workflow/src/O2DPLDisplay.cxx
+++ b/EventVisualisation/Workflow/src/O2DPLDisplay.cxx
@@ -128,8 +128,16 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   bool eveHostNameMatch = eveHostName.empty() || eveHostName == hostname;
 
   int eveDDSColIdx = cfgc.options().get<int>("eve-dds-collection-index");
-  char* colIdx = getenv("DDS_COLLECTION_INDEX");
-  eveHostNameMatch &= eveDDSColIdx == -1 || (colIdx && atoi(colIdx) == eveDDSColIdx);
+  if (eveDDSColIdx != -1) {
+    char* colIdx = getenv("DDS_COLLECTION_INDEX");
+    int myIdx = colIdx ? atoi(colIdx) : -1;
+    if (myIdx == eveDDSColIdx) {
+      LOG(important) << "Restricting DPL Display to collection index, my index " << myIdx << ", enabled " << int(myIdx == eveDDSColIdx);
+    } else {
+      LOG(info) << "Restricting DPL Display to collection index, my index " << myIdx << ", enabled " << int(myIdx == eveDDSColIdx);
+    }
+    eveHostNameMatch &= myIdx == eveDDSColIdx;
+  }
 
   std::chrono::milliseconds timeInterval(cfgc.options().get<int>("time-interval"));
   int numberOfFiles = cfgc.options().get<int>("number-of_files");


### PR DESCRIPTION
@jmyrcha : I had added this printout before, and it was removed by one of your PRs in the meantime.
Please make sure it stays in, it gives us a simple log message to the infologger that the ED is active and which node is writing the JSONs.