### PR TITLE
GPU: Increase TPC seeding access grid buffer size

### DIFF
--- a/GPU/GPUTracking/SliceTracker/GPUTPCSliceData.cxx
+++ b/GPU/GPUTracking/SliceTracker/GPUTPCSliceData.cxx
@@ -118,7 +118,7 @@ GPUd() void GPUTPCSliceData::GetMaxNBins(GPUconstantref() const MEM_CONSTANT(GPU
 
 GPUd() unsigned int GPUTPCSliceData::GetGridSize(unsigned int nHits, unsigned int nRows)
 {
-  return 26 * nRows + 4 * nHits;
+  return 30 * nRows + 4 * nHits;
 }
 
 GPUdi() void GPUTPCSliceData::CreateGrid(GPUconstantref() const MEM_CONSTANT(GPUConstantMem) * mem, GPUTPCRow* GPUrestrict() row, float yMin, float yMax, float zMin, float zMax)


### PR DESCRIPTION
trivial, merging.
Note this is not the cause of the GPU crash, the buffer is checked and the event is skipped if exceeded.