### PR TITLE
Switch from options to ClustererParam for ITS/MFT clust.dict. and noise

### DIFF
--- a/Detectors/CTF/README.md
+++ b/Detectors/CTF/README.md
@@ -115,14 +115,14 @@ For the ITS and MFT entropy decoding one can request either to decompose cluster
 or to apply the noise mask to decoded clusters (or decoded digits). If the masking (e.g. via option `--its-entropy-decoder " --mask-noise "`) is requested, user should provide to the entropy decoder the noise mask file (eventually will be loaded from CCDB) and cluster patterns decoding dictionary (if the clusters were encoded with patterns IDs).
 For example,
 ```
-o2-ctf-reader-workflow --ctf-input <ctfFiles> --onlyDet ITS,MFT --its-entropy-decoder ' --mask-noise --noise-file its_noise.root --cluster-dict-file ./ ' | ...
+o2-ctf-reader-workflow --ctf-input <ctfFiles> --onlyDet ITS,MFT --its-entropy-decoder ' --mask-noise' | ...
 ```
 will decode ITS and MFT data, decompose on the fly ITS clusters to digits, mask the noisy pixels with the provided masks, recluster remaining ITS digits and send the new clusters out, together with unchanged MFT clusters.
 ```
-o2-ctf-reader-workflow --ctf-input <ctfFiles> --onlyDet ITS,MFT --mft-digits --mft-entropy-decoder ' --mask-noise --noise-file mft_noise.root --cluster-dict-file ./ ' | ...
+o2-ctf-reader-workflow --ctf-input <ctfFiles> --onlyDet ITS,MFT --mft-digits --mft-entropy-decoder ' --mask-noise' | ...
 ```
 will send decompose clusters to digits and send ben out after masking the noise for the MFT, while ITS clusters will be sent as decoded.
-
+Note that the necessary cluster topology dictionary and noise mask file paths need to be provided via corresponding `o2::itsmft::ClustererParam<o2::detectors::DetID::ITS>.dictFilePath` and `o2::itsmft::ClustererParam<o2::detectors::DetID::ITS>.noiseFilePath` configurables (same for the MFT).
 
 ## Support for externally provided encoding dictionaries
 

--- a/Detectors/GlobalTrackingWorkflow/src/GlobalFwdMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/GlobalFwdMatchingSpec.cxx
@@ -30,6 +30,7 @@
 #include "DataFormatsParameters/GRPObject.h"
 #include "GlobalTracking/MatchGlobalFwd.h"
 #include "GlobalTrackingWorkflow/GlobalFwdMatchingSpec.h"
+#include "ITSMFTReconstruction/ClustererParam.h"
 
 using namespace o2::framework;
 using MCLabelsTr = gsl::span<const o2::MCCompLabel>;
@@ -78,7 +79,7 @@ void GlobalFwdMatchingDPL::init(InitContext& ic)
   const auto& bcfill = digctx->getBunchFilling();
   mMatching.setBunchFilling(bcfill);
 
-  std::string dictPath = ic.options().get<std::string>("mft-dictionary-path");
+  std::string dictPath = o2::itsmft::ClustererParam<o2::detectors::DetID::MFT>::Instance().dictFilePath;
   std::string dictFile = o2::base::NameConf::getAlpideClusterDictionaryFileName(o2::detectors::DetID::MFT, dictPath, "bin");
   if (o2::utils::Str::pathExists(dictFile)) {
     mMFTDict.readBinaryFile(dictFile);
@@ -143,8 +144,7 @@ DataProcessorSpec getGlobalFwdMatchingSpec(bool useMC)
     Options{
       {"matchFcn", VariantType::String, "matchALL", {"Matching function (matchALL, ...)"}},
       {"cutFcn", VariantType::String, "cutDisabled", {"matching candicate cut"}},
-      {"matchPlaneZ", o2::framework::VariantType::Float, -77.5f, {"Matching plane z position [-77.5]"}},
-      {"mft-dictionary-path", VariantType::String, "", {"Path of the cluster-topology dictionary file"}}}};
+      {"matchPlaneZ", o2::framework::VariantType::Float, -77.5f, {"Matching plane z position [-77.5]"}}}};
 }
 
 } // namespace globaltracking

--- a/Detectors/GlobalTrackingWorkflow/src/PrimaryVertexingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/PrimaryVertexingSpec.cxx
@@ -68,7 +68,7 @@ void PrimaryVertexingSpec::init(InitContext& ic)
   o2::base::Propagator::initFieldFromGRP();
 
   std::unique_ptr<o2::parameters::GRPObject> grp{o2::parameters::GRPObject::loadFrom()};
-  const auto& alpParams = o2::itsmft::DPLAlpideParam<DetID::ITS>::Instance();
+  const auto& alpParams = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance();
   if (!grp->isDetContinuousReadOut(DetID::ITS)) {
     mITSROFrameLengthMUS = alpParams.roFrameLengthTrig / 1.e3; // ITS ROFrame duration in \mus
   } else {

--- a/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
@@ -44,6 +44,7 @@
 #include "CommonDataFormat/BunchFilling.h"
 #include "CommonDataFormat/FlatHisto2D.h"
 #include "DataFormatsGlobalTracking/RecoContainer.h"
+#include "ITSMFTReconstruction/ClustererParam.h"
 
 using namespace o2::framework;
 using MCLabelsCl = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
@@ -97,7 +98,7 @@ void TPCITSMatchingDPL::init(InitContext& ic)
   mMatching.setVDriftCalib(mCalibMode);
   mMatching.setNThreads(std::max(1, ic.options().get<int>("nthreads")));
   //
-  std::string dictPath = ic.options().get<std::string>("its-dictionary-path");
+  std::string dictPath = o2::itsmft::ClustererParam<o2::detectors::DetID::ITS>::Instance().dictFilePath;
   std::string dictFile = o2::base::NameConf::getAlpideClusterDictionaryFileName(o2::detectors::DetID::ITS, dictPath, "bin");
   if (o2::utils::Str::pathExists(dictFile)) {
     mITSDict.readBinaryFile(dictFile);
@@ -196,7 +197,6 @@ DataProcessorSpec getTPCITSMatchingSpec(GTrackID::mask_t src, bool useFT0, bool 
     outputs,
     AlgorithmSpec{adaptFromTask<TPCITSMatchingDPL>(dataRequest, useFT0, calib, skipTPCOnly, useMC)},
     Options{
-      {"its-dictionary-path", VariantType::String, "", {"Path of the cluster-topology dictionary file"}},
       {"nthreads", VariantType::Int, 1, {"Number of afterburner threads"}},
       {"material-lut-path", VariantType::String, "", {"Path of the material LUT file"}},
       {"debug-tree-flags", VariantType::Int, 0, {"DebugFlagTypes bit-pattern for debug tree"}}}};

--- a/Detectors/ITSMFT/ITS/calibration/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/calibration/CMakeLists.txt
@@ -15,7 +15,9 @@ o2_add_library(ITSCalibration
                SOURCES src/NoiseCalibrator.cxx
                SOURCES src/NoiseSlotCalibrator.cxx
                SOURCES src/NoiseCalibratorSpec.cxx
-               PUBLIC_LINK_LIBRARIES O2::DataFormatsITS O2::ITSBase
+               PUBLIC_LINK_LIBRARIES O2::DataFormatsITS
+                                     O2::ITSBase
+                                     O2::ITSMFTReconstruction
                                      O2::DetectorsCalibration
                                      O2::CCDB)
 

--- a/Detectors/ITSMFT/ITS/calibration/src/NoiseCalibratorSpec.cxx
+++ b/Detectors/ITSMFT/ITS/calibration/src/NoiseCalibratorSpec.cxx
@@ -14,6 +14,8 @@
 #include "CCDB/CcdbApi.h"
 #include "DetectorsCalibration/Utils.h"
 #include "ITSCalibration/NoiseCalibratorSpec.h"
+#include "ITSMFTBase/DPLAlpideParam.h"
+#include "ITSMFTReconstruction/ClustererParam.h"
 #include "DataFormatsITSMFT/CompCluster.h"
 #include "DataFormatsITSMFT/ROFRecord.h"
 
@@ -31,7 +33,7 @@ namespace its
 
 void NoiseCalibratorSpec::init(InitContext& ic)
 {
-  std::string dictPath = ic.options().get<std::string>("its-dictionary-path");
+  std::string dictPath = o2::itsmft::ClustererParam<o2::detectors::DetID::ITS>::Instance().dictFilePath;
   std::string dictFile = o2::base::NameConf::getAlpideClusterDictionaryFileName(
     o2::detectors::DetID::ITS, dictPath, "bin");
   if (o2::utils::Str::pathExists(dictFile)) {
@@ -110,7 +112,6 @@ DataProcessorSpec getNoiseCalibratorSpec()
     outputs,
     AlgorithmSpec{adaptFromTask<NoiseCalibratorSpec>()},
     Options{
-      {"its-dictionary-path", VariantType::String, "", {"Path of the cluster-topology dictionary file"}},
       {"1pix-only", VariantType::Bool, false, {"Fast 1-pixel calibration only"}},
       {"prob-threshold", VariantType::Float, 3.e-6f, {"Probability threshold for noisy pixels"}}}};
 }

--- a/Detectors/ITSMFT/ITS/workflow/src/ClustererSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ClustererSpec.cxx
@@ -63,7 +63,7 @@ void ClustererDPL::init(InitContext& ic)
   mClusterer->setMaxBCSeparationToMask(nbc);
   mClusterer->setMaxRowColDiffToMask(clParams.maxRowColDiffToMask);
 
-  std::string dictPath = ic.options().get<std::string>("its-dictionary-path");
+  std::string dictPath = o2::itsmft::ClustererParam<o2::detectors::DetID::ITS>::Instance().dictFilePath;
   std::string dictFile = o2::base::NameConf::getAlpideClusterDictionaryFileName(o2::detectors::DetID::ITS, dictPath, "bin");
   if (o2::utils::Str::pathExists(dictFile)) {
     mClusterer->loadDictionary(dictFile);
@@ -152,7 +152,6 @@ DataProcessorSpec getClustererSpec(bool useMC)
     outputs,
     AlgorithmSpec{adaptFromTask<ClustererDPL>(useMC)},
     Options{
-      {"its-dictionary-path", VariantType::String, "", {"Path of the cluster-topology dictionary file"}},
       {"grp-file", VariantType::String, "o2sim_grp.root", {"Name of the grp file"}},
       {"no-patterns", o2::framework::VariantType::Bool, false, {"Do not save rare cluster patterns"}},
       {"nthreads", VariantType::Int, 1, {"Number of clustering threads"}}}};

--- a/Detectors/ITSMFT/ITS/workflow/src/CookedTrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/CookedTrackerSpec.cxx
@@ -40,6 +40,7 @@
 
 #include "ITSReconstruction/FastMultEstConfig.h"
 #include "ITSReconstruction/FastMultEst.h"
+#include "ITSMFTReconstruction/ClustererParam.h"
 
 using namespace o2::framework;
 
@@ -79,7 +80,7 @@ void CookedTrackerDPL::init(InitContext& ic)
     throw std::runtime_error(o2::utils::Str::concat_string("Cannot retrieve GRP from the ", filename));
   }
 
-  std::string dictPath = ic.options().get<std::string>("its-dictionary-path");
+  std::string dictPath = o2::itsmft::ClustererParam<o2::detectors::DetID::ITS>::Instance().dictFilePath;
   std::string dictFile = o2::base::NameConf::getAlpideClusterDictionaryFileName(o2::detectors::DetID::ITS, dictPath, "bin");
   if (o2::utils::Str::pathExists(dictFile)) {
     mDict.readBinaryFile(dictFile);
@@ -233,7 +234,6 @@ DataProcessorSpec getCookedTrackerSpec(bool useMC)
     AlgorithmSpec{adaptFromTask<CookedTrackerDPL>(useMC)},
     Options{
       {"grp-file", VariantType::String, "o2sim_grp.root", {"Name of the grp file"}},
-      {"its-dictionary-path", VariantType::String, "", {"Path of the cluster-topology dictionary file"}},
       {"nthreads", VariantType::Int, 1, {"Number of threads"}}}};
 }
 

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -28,6 +28,7 @@
 #include "ITStracking/IOUtils.h"
 #include "ITStracking/TrackingConfigParam.h"
 #include "ITSMFTBase/DPLAlpideParam.h"
+#include "ITSMFTReconstruction/ClustererParam.h"
 
 #include "Field/MagneticField.h"
 #include "DetectorsBase/GeometryManager.h"
@@ -140,7 +141,7 @@ void TrackerDPL::init(InitContext& ic)
     throw std::runtime_error(o2::utils::Str::concat_string("Cannot retrieve GRP from the ", filename));
   }
 
-  std::string dictPath = ic.options().get<std::string>("its-dictionary-path");
+  std::string dictPath = o2::itsmft::ClustererParam<o2::detectors::DetID::ITS>::Instance().dictFilePath;
   std::string dictFile = o2::base::NameConf::getAlpideClusterDictionaryFileName(o2::detectors::DetID::ITS, dictPath, "bin");
   if (o2::utils::Str::pathExists(dictFile)) {
     mDict.readBinaryFile(dictFile);
@@ -314,7 +315,6 @@ DataProcessorSpec getTrackerSpec(bool useMC, const std::string& trModeS, o2::gpu
     AlgorithmSpec{adaptFromTask<TrackerDPL>(useMC, trModeS, dType)},
     Options{
       {"grp-file", VariantType::String, "o2sim_grp.root", {"Name of the grp file"}},
-      {"its-dictionary-path", VariantType::String, "", {"Path of the cluster-topology dictionary file"}},
       {"material-lut-path", VariantType::String, "", {"Path of the material LUT file"}}}};
 }
 

--- a/Detectors/ITSMFT/MFT/workflow/src/ClustererSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/ClustererSpec.cxx
@@ -69,7 +69,7 @@ void ClustererDPL::init(InitContext& ic)
   mClusterer->setMaxBCSeparationToMask(nbc);
   mClusterer->setMaxRowColDiffToMask(clParams.maxRowColDiffToMask);
 
-  std::string dictPath = ic.options().get<std::string>("mft-dictionary-path");
+  std::string dictPath = o2::itsmft::ClustererParam<o2::detectors::DetID::MFT>::Instance().dictFilePath;
   std::string dictFile = o2::base::NameConf::getAlpideClusterDictionaryFileName(o2::detectors::DetID::MFT, dictPath, "bin");
   if (o2::utils::Str::pathExists(dictFile)) {
     mClusterer->loadDictionary(dictFile);
@@ -157,7 +157,6 @@ DataProcessorSpec getClustererSpec(bool useMC)
     outputs,
     AlgorithmSpec{adaptFromTask<ClustererDPL>(useMC)},
     Options{
-      {"mft-dictionary-path", VariantType::String, "", {"Path of the cluster-topology dictionary file"}},
       {"grp-file", VariantType::String, "o2sim_grp.root", {"Name of the grp file"}},
       {"no-patterns", o2::framework::VariantType::Bool, false, {"Do not save rare cluster patterns"}},
       {"nthreads", VariantType::Int, 1, {"Number of clustering threads"}}}};

--- a/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
@@ -34,6 +34,7 @@
 #include "DetectorsBase/GeometryManager.h"
 #include "DetectorsBase/Propagator.h"
 #include "DetectorsCommonDataFormats/NameConf.h"
+#include "ITSMFTReconstruction/ClustererParam.h"
 
 using namespace o2::framework;
 
@@ -75,7 +76,7 @@ void TrackerDPL::init(InitContext& ic)
     throw std::runtime_error(o2::utils::Str::concat_string("Cannot retrieve GRP from the ", filename));
   }
 
-  std::string dictPath = ic.options().get<std::string>("mft-dictionary-path");
+  std::string dictPath = o2::itsmft::ClustererParam<o2::detectors::DetID::MFT>::Instance().dictFilePath;
   std::string dictFile = o2::base::NameConf::getAlpideClusterDictionaryFileName(o2::detectors::DetID::MFT, dictPath, "bin");
   if (o2::utils::Str::pathExists(dictFile)) {
     mDict.readBinaryFile(dictFile);
@@ -218,8 +219,7 @@ DataProcessorSpec getTrackerSpec(bool useMC)
     outputs,
     AlgorithmSpec{adaptFromTask<TrackerDPL>(useMC)},
     Options{
-      {"grp-file", VariantType::String, "o2sim_grp.root", {"Name of the output file"}},
-      {"mft-dictionary-path", VariantType::String, "", {"Path of the cluster-topology dictionary file"}}}};
+      {"grp-file", VariantType::String, "o2sim_grp.root", {"Name of the output file"}}}};
 }
 
 } // namespace mft

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ClustererParam.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ClustererParam.h
@@ -19,6 +19,7 @@
 #include "CommonUtils/ConfigurableParam.h"
 #include "CommonUtils/ConfigurableParamHelper.h"
 #include <string_view>
+#include <string>
 
 namespace o2
 {
@@ -35,6 +36,9 @@ struct ClustererParam : public o2::conf::ConfigurableParamHelper<ClustererParam<
 
   int maxRowColDiffToMask = 0;  ///< pixel may be masked as overflow if such a neighbour in prev frame was fired
   int maxBCDiffToMaskBias = 10; ///< mask if 2 ROFs differ by <= StrobeLength + Bias BCs, use value <0 to disable masking
+
+  std::string dictFilePath{};  ///< optional cluster toplogy dictionary path
+  std::string noiseFilePath{}; ///< optional noise masks file path
 
   O2ParamDef(ClustererParam, getParamName().data());
 

--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/STFDecoderSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/STFDecoderSpec.h
@@ -42,8 +42,6 @@ struct STFDecoderInp {
   bool askSTFDist = true;
   o2::header::DataOrigin origin{"NIL"};
   std::string deviceName{};
-  std::string dict{};
-  std::string noise{};
   std::string inputSpec{};
 };
 

--- a/Detectors/ITSMFT/common/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/EntropyDecoderSpec.cxx
@@ -17,6 +17,7 @@
 #include "Framework/ConfigParamRegistry.h"
 #include "DataFormatsITSMFT/CompCluster.h"
 #include "ITSMFTWorkflow/EntropyDecoderSpec.h"
+#include "ITSMFTReconstruction/ClustererParam.h"
 
 using namespace o2::framework;
 
@@ -37,9 +38,11 @@ void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
 {
   auto detID = mOrigin == o2::header::gDataOriginITS ? o2::detectors::DetID::ITS : o2::detectors::DetID::MFT;
   mCTFDictPath = ic.options().get<std::string>("ctf-dict");
-  mClusDictPath = o2::base::NameConf::getAlpideClusterDictionaryFileName(detID, ic.options().get<std::string>("cluster-dict-file"), "bin");
+  mClusDictPath = o2::header::gDataOriginITS ? o2::itsmft::ClustererParam<o2::detectors::DetID::ITS>::Instance().dictFilePath : o2::itsmft::ClustererParam<o2::detectors::DetID::MFT>::Instance().dictFilePath;
+  mClusDictPath = o2::base::NameConf::getAlpideClusterDictionaryFileName(detID, mClusDictPath, "bin");
   mMaskNoise = ic.options().get<bool>("mask-noise");
-  mNoiseFilePath = o2::base::NameConf::getNoiseFileName(detID, ic.options().get<std::string>("noise-file"), "root");
+  mNoiseFilePath = o2::header::gDataOriginITS ? o2::itsmft::ClustererParam<o2::detectors::DetID::ITS>::Instance().noiseFilePath : o2::itsmft::ClustererParam<o2::detectors::DetID::MFT>::Instance().noiseFilePath;
+  mNoiseFilePath = o2::base::NameConf::getNoiseFileName(detID, mNoiseFilePath, "root");
 }
 
 void EntropyDecoderSpec::run(ProcessingContext& pc)
@@ -122,9 +125,7 @@ DataProcessorSpec getEntropyDecoderSpec(o2::header::DataOrigin orig, bool getDig
     AlgorithmSpec{adaptFromTask<EntropyDecoderSpec>(orig, getDigits)},
     Options{
       {"ctf-dict", VariantType::String, o2::base::NameConf::getCTFDictFileName(), {"File of CTF decoding dictionary"}},
-      {"mask-noise", VariantType::Bool, false, {"apply noise mask to digits or clusters (involves reclusterization)"}},
-      {"noise-file", VariantType::String, "", {"name of the noise map file"}},
-      {"cluster-dict-file", VariantType::String, "", {"name of the cluster-topology dictionary file"}}}};
+      {"mask-noise", VariantType::Bool, false, {"apply noise mask to digits or clusters (involves reclusterization)"}}}};
 }
 
 } // namespace itsmft

--- a/Detectors/ITSMFT/common/workflow/src/stf-decoder-workflow.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/stf-decoder-workflow.cxx
@@ -27,8 +27,6 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     ConfigParamSpec{"no-cluster-patterns", VariantType::Bool, false, {"do not produce clusters patterns (def: produce)"}},
     ConfigParamSpec{"digits", VariantType::Bool, false, {"produce digits (def: skip)"}},
     ConfigParamSpec{"enable-calib-data", VariantType::Bool, false, {"produce GBT calibration stream (def: skip)"}},
-    ConfigParamSpec{"dict-file", VariantType::String, "", {"name of the cluster-topology dictionary file"}},
-    ConfigParamSpec{"noise-file", VariantType::String, "", {"name of the noise map file"}},
     ConfigParamSpec{"ignore-dist-stf", VariantType::Bool, false, {"do not subscribe to FLP/DISTSUBTIMEFRAME/0 message (no lost TF recovery)"}},
     ConfigParamSpec{"dataspec", VariantType::String, "", {"selection string for the input data, if not provided <DET>Raw:<DET>/RAWDATA with DET=ITS or MFT will be used"}},
     ConfigParamSpec{"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
@@ -48,8 +46,6 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   inp.doPatterns = inp.doClusters && !cfgc.options().get<bool>("no-cluster-patterns");
   inp.doDigits = cfgc.options().get<bool>("digits");
   inp.doCalib = cfgc.options().get<bool>("enable-calib-data");
-  inp.dict = cfgc.options().get<std::string>("dict-file");
-  inp.noise = cfgc.options().get<std::string>("noise-file");
   inp.askSTFDist = !cfgc.options().get<bool>("ignore-dist-stf");
   inp.inputSpec = cfgc.options().get<std::string>("dataspec");
   // Update the (declared) parameters if changed from the command line

--- a/EventVisualisation/Workflow/include/EveWorkflow/EveConfiguration.h
+++ b/EventVisualisation/Workflow/include/EveWorkflow/EveConfiguration.h
@@ -44,6 +44,7 @@ template <template <typename T> class S>
 struct CalibObjectsTemplate {
   typename S<o2::trd::GeometryFlat>::type* trdGeometry = nullptr;
   typename S<o2::itsmft::TopologyDictionary>::type* itsPatternDict = nullptr;
+  typename S<o2::itsmft::TopologyDictionary>::type* mftPatternDict = nullptr;
 };
 
 typedef CalibObjectsTemplate<DefaultPtr> CalibObjects; // NOTE: These 2 must have identical layout since they are memcopied

--- a/EventVisualisation/Workflow/include/EveWorkflow/EveWorkflowHelper.h
+++ b/EventVisualisation/Workflow/include/EveWorkflow/EveWorkflowHelper.h
@@ -21,6 +21,11 @@
 #include "EveWorkflow/EveConfiguration.h"
 #include "EventVisualisationDataConverter/VisualisationEvent.h"
 
+namespace o2::itsmft
+{
+class TopologyDictionary;
+}
+
 namespace o2::event_visualisation
 {
 using GID = o2::dataformats::GlobalTrackID;
@@ -73,7 +78,7 @@ class EveWorkflowHelper
   void drawITSClusters(GID gid, float trackTime);
   void drawTPCClusters(GID gid, float trackTime);
   void drawPoint(o2::BaseCluster<float> pnt);
-  void prepareITSClusters(std::string dictfile = "");
+  void prepareITSClusters(const o2::itsmft::TopologyDictionary& dict);
   o2::globaltracking::RecoContainer mRecoCont;
   o2::globaltracking::RecoContainer& getRecoContainer() { return mRecoCont; }
   TracksSet mTrackSet;

--- a/EventVisualisation/Workflow/include/EveWorkflow/O2DPLDisplay.h
+++ b/EventVisualisation/Workflow/include/EveWorkflow/O2DPLDisplay.h
@@ -70,9 +70,10 @@ class O2DPLDisplaySpec : public o2::framework::Task
 
   o2::dataformats::GlobalTrackID::mask_t mTrkMask;
   o2::dataformats::GlobalTrackID::mask_t mClMask;
+  o2::itsmft::TopologyDictionary mITSDict;
+  o2::itsmft::TopologyDictionary mMFTDict;
   std::unique_ptr<EveConfiguration> mConfig;
   std::unique_ptr<o2::trd::GeometryFlat> mTrdGeo;
-  std::unique_ptr<o2::itsmft::TopologyDictionary> mITSDict;
   std::shared_ptr<o2::globaltracking::DataRequest> mDataRequest;
 };
 

--- a/EventVisualisation/Workflow/src/EveWorkflowHelper.cxx
+++ b/EventVisualisation/Workflow/src/EveWorkflowHelper.cxx
@@ -21,6 +21,7 @@
 #include "DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h"
 #include "DetectorsCommonDataFormats/NameConf.h"
 #include "DetectorsBase/Propagator.h"
+#include "ITSMFTReconstruction/ClustererParam.h"
 #include <type_traits>
 
 using namespace o2::event_visualisation;
@@ -41,8 +42,6 @@ void EveWorkflowHelper::selectTracks(const CalibObjectsConst* calib,
 
 void EveWorkflowHelper::draw(std::string jsonPath, int numberOfFiles, int numberOfTracks)
 {
-  EveWorkflowHelper::prepareITSClusters();
-
   size_t nTracks = mTrackSet.trackGID.size();
   if (numberOfTracks != -1 && numberOfTracks < nTracks) {
     nTracks = numberOfTracks; // less than available
@@ -133,13 +132,8 @@ void EveWorkflowHelper::drawPoint(o2::BaseCluster<float> pnt)
   mEvent.addCluster(pnt.getX(), pnt.getY(), pnt.getZ());
 }
 
-void EveWorkflowHelper::prepareITSClusters(std::string dictfile)
+void EveWorkflowHelper::prepareITSClusters(const o2::itsmft::TopologyDictionary& dict)
 {
-  o2::itsmft::TopologyDictionary dict;
-  if (dictfile.empty()) {
-    dictfile = o2::base::NameConf::getAlpideClusterDictionaryFileName(o2::detectors::DetID::ITS, "", "bin");
-    dict.readBinaryFile(dictfile);
-  }
   const auto& ITSClusterROFRec = mRecoCont.getITSClustersROFRecords();
   const auto& clusITS = mRecoCont.getITSClusters();
   if (clusITS.size() && ITSClusterROFRec.size()) {


### PR DESCRIPTION
ITS and MFT DPL-device options cluster-dict-file, dict-file, noise-file ets were eliminated in favour of
configurable param ITSClustererParam.dictFilePath and ITSClustererParam.noiseFilePath (idem for MFT), i.e.
the option should be provided as
`--configKeyValues "ITSClustererParam.dictFilePath=XXX"` with XXX is either the directory where the default filename
is checked or explicit full path.

@jmyrcha I did some fixes in the dictionaries initialization and usage in the EveWorkflowHelper and O2DPLDisplay, including the setting of `mConfig->configCalib.itsPatternDict` (and same for MFT) in  https://github.com/shahor02/AliceO2/blob/7fa33850b62dbedd4f4e80f76c7553db757f6b5b/EventVisualisation/Workflow/src/O2DPLDisplay.cxx#L81-L99, but I guess this is an obsolete code, you can probably remove it later.

@davidrohr this will invalidate O2DataProcessing `dpl-workflow.sh`, once the test are passed I'll prepare a sync. PR for O2DataProcessing so that both can be merged simultaneously. But then the updated O2DataProcessing should not be used on epns, until the O2 with this PR propagates there (and at that moment all workflows involving ITS/MFT will need to be regenerated).
