### PR TITLE
[EMCAL-630] Handling of overlap region of HG/LG digits

### DIFF
--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Constants.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Constants.h
@@ -31,8 +31,8 @@ enum {
 /// \enum ChannelType_t
 /// \brief Type of a raw data channel
 enum ChannelType_t {
-  HIGH_GAIN, ///< High gain channel
   LOW_GAIN,  ///< Low gain channel
+  HIGH_GAIN, ///< High gain channel
   TRU,       ///< TRU channel
   LEDMON     ///< LED monitor channel
 };

--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/ErrorTypeFEE.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/ErrorTypeFEE.h
@@ -56,6 +56,7 @@ class ErrorTypeFEE
     MINOR_ALTRO_ERROR, ///< Non-fatal error in decoding of the ALTRO payload
     FIT_ERROR,         ///< Raw fit failed
     GEOMETRY_ERROR,    ///< Decoded position outside EMCAL
+    GAIN_ERROR,        ///< Error due to gain type
     UNDEFINED          ///< Error source undefined
   };
   /// \brief Constructor
@@ -89,6 +90,10 @@ class ErrorTypeFEE
   /// \brief Set the error as page parser error and store the error code
   /// \param pageError Error code of the page parser error
   void setPageErrorType(int pageError) { setError(ErrorSource_t::PAGE_ERROR, pageError); }
+
+  /// \brief Set the error as gain type error and store the error code
+  /// \param gainError Error code of the gain type error
+  void setGainErrorType(int gainError) { setError(ErrorSource_t::GAIN_ERROR, gainError); }
 
   /// \brief Set the error type of the object
   /// \param errorsource Error type of the object
@@ -134,6 +139,10 @@ class ErrorTypeFEE
   /// \brief Get the error code of the obect in case the object is a page parsing error
   /// \return Error code (-1 in case the object is not a page parsing error)
   int getRawPageErrorType() const { return getRawErrorForType(ErrorSource_t::PAGE_ERROR); }
+
+  /// \brief Get the error code of the obect in case the object is a gain type error
+  /// \return Error code (-1 in case the object is not a gain type error)
+  int getGainTypeErrorType() const { return getRawErrorForType(ErrorSource_t::GAIN_ERROR); }
 
   /// \brief Printing information of the error type
   /// \param stream Output stream where to print the error

--- a/DataFormats/Detectors/EMCAL/src/ErrorTypeFEE.cxx
+++ b/DataFormats/Detectors/EMCAL/src/ErrorTypeFEE.cxx
@@ -33,6 +33,9 @@ void ErrorTypeFEE::PrintStream(std::ostream& stream) const
     case ErrorSource_t::GEOMETRY_ERROR:
       typestring = "geometry error";
       break;
+    case ErrorTypeFEE::GAIN_ERROR:
+      typestring = "gain type error";
+      break;
     case ErrorSource_t::UNDEFINED:
       typestring = "unknown error";
       break;

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/RawToCellConverterSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/RawToCellConverterSpec.h
@@ -81,6 +81,25 @@ class RawToCellConverterSpec : public framework::Task
   header::DataHeader::SubSpecificationType getSubspecification() const { return mSubspecification; }
 
  private:
+  /// \struct RecCellInfo
+  /// \brief Internal bookkeeping for cell double counting
+  ///
+  /// In case the energy is in the overlap region between the
+  /// two digitizers 2 channels exist for the same cell. In this
+  /// case the low gain cells are used above a certain threshold.
+  /// In certain error cases the information from the other digitizer
+  /// might be missing. Such cases must be fitered out, however this
+  /// can be done only after all cells are processed. The overlap information
+  /// needs to be propagated for the filtering but is not part of the
+  /// final cell object
+  struct RecCellInfo {
+    o2::emcal::Cell mCellData; ///< Cell information
+    bool mIsLGnoHG;            ///< Cell has only LG digits
+    bool mHGOutOfRange;        ///< Cell has only HG digits which are out of range
+    int mFecID;                ///< FEC ID of the channel (for monitoring)
+    int mHWAddressLG;          ///< HW address of LG (for monitoring)
+    int mHWAddressHG;          ///< HW address of HG (for monitoring)
+  };
   bool isLostTimeframe(framework::ProcessingContext& ctx) const;
   void sendData(framework::ProcessingContext& ctx, const std::vector<o2::emcal::Cell>& cells, const std::vector<o2::emcal::TriggerRecord>& triggers, const std::vector<ErrorTypeFEE>& decodingErrors) const;
 
@@ -89,7 +108,7 @@ class RawToCellConverterSpec : public framework::Task
   int mNumErrorMessages = 0;                                      ///< Current number of error messages
   int mErrorMessagesSuppressed = 0;                               ///< Counter of suppressed error messages
   int mMaxErrorMessages = 100;                                    ///< Max. number of error messages
-  bool mPrintTrailer = false;
+  bool mPrintTrailer = false;                                     ///< Print RCU trailer
   Geometry* mGeometry = nullptr;                                  ///!<! Geometry pointer
   std::unique_ptr<MappingHandler> mMapper = nullptr;              ///!<! Mapper
   std::unique_ptr<CaloRawFitter> mRawFitter;                      ///!<! Raw fitter


### PR DESCRIPTION
- In case both HG and LG are present we keep
  the HG if the amp is < 950 ADC counts, otherwise
  the low gain
- In case only HG is present we keep the cell if the
  amp is < 950 ADC counts, otherwise we flag it as
  HG-out-of-range
- In case only LG is present we flag the cell as
  LGnoHG.
All flagged cells are filtered out (discarded). In this
case a error is logged on the infoBrowser and an
error object is added to the raw data errors for QC.