### PR TITLE
FV0: fixes for pilot beams

### DIFF
--- a/Detectors/FIT/FV0/calibration/src/FV0ChannelTimeTimeSlotContainer.cxx
+++ b/Detectors/FIT/FV0/calibration/src/FV0ChannelTimeTimeSlotContainer.cxx
@@ -41,9 +41,10 @@ void FV0ChannelTimeTimeSlotContainer::fill(const gsl::span<const FV0CalibrationI
     if (chID < Constants::nFv0Channels) {
       mHistogram(chTime, chID);
       ++mEntriesPerChannel[chID];
-    } else {
-      LOG(FATAL) << "Invalid channel data";
     }
+    //else {
+    //  LOG(FATAL) << "Invalid channel data";
+    //}
   }
 }
 

--- a/Detectors/FIT/FV0/calibration/workflow/FV0ChannelTimeCalibrationSpec.h
+++ b/Detectors/FIT/FV0/calibration/workflow/FV0ChannelTimeCalibrationSpec.h
@@ -26,8 +26,8 @@ o2::framework::DataProcessorSpec getFV0ChannelTimeCalibrationSpec()
                                                               o2::fv0::FV0ChannelTimeTimeSlotContainer, o2::fv0::FV0ChannelTimeCalibrationObject>;
 
   std::vector<o2::framework::OutputSpec> outputs;
-  outputs.emplace_back(o2::framework::ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "FVO_CTO_CALIB"});
-  outputs.emplace_back(o2::framework::ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "FV0_CTO_CALIB"});
+  outputs.emplace_back(o2::framework::ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "FIT_CALIB"});
+  outputs.emplace_back(o2::framework::ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "FIT_CALIB"});
 
   constexpr const char* DEFAULT_INPUT_LABEL = "calib";
 


### PR DESCRIPTION
- fix in digit reader which reads only 1st entry from the tree
- remove silly fatal logging
- fix name