### PR TITLE
DPL: drop noexcept from homogeneous_apply_refs

### DIFF
--- a/Framework/Foundation/include/Framework/StructToTuple.h
+++ b/Framework/Foundation/include/Framework/StructToTuple.h
@@ -142,7 +142,7 @@ constexpr long brace_constructible_size()
 #endif
 
 template <typename L, class T>
-auto constexpr homogeneous_apply_refs(L l, T&& object) noexcept
+auto constexpr homogeneous_apply_refs(L l, T&& object)
 {
   using type = std::decay_t<T>;
   constexpr unsigned long numElements = brace_constructible_size<T>();


### PR DESCRIPTION
Simply not true anymore