### PR TITLE
DPL Analysis: add exception when grouping with improperly sorted index

### DIFF
--- a/Framework/Core/include/Framework/Kernels.h
+++ b/Framework/Core/include/Framework/Kernels.h
@@ -33,6 +33,7 @@ namespace o2::framework
 template <typename T>
 auto sliceByColumn(
   char const* key,
+  char const* target,
   std::shared_ptr<arrow::Table> const& input,
   T fullSize,
   std::vector<arrow::Datum>* slices,
@@ -81,6 +82,9 @@ auto sliceByColumn(
   for (auto i = 0; i < size; ++i) {
     count = counts.Value(i);
     if (v >= 0) {
+      if (v < vprev) {
+        throw runtime_error_f("Table %s index %s is not sorted: next value %d < previous value %d!", target, key, v, vprev);
+      }
       vprev = v;
     }
     v = values.Value(i);

--- a/Framework/Core/include/Framework/Kernels.h
+++ b/Framework/Core/include/Framework/Kernels.h
@@ -45,11 +45,15 @@ auto sliceByColumn(
   arrow::Datum value_counts;
   auto column = input->GetColumnByName(key);
   for (auto i = 0; i < column->num_chunks(); ++i) {
+    T prev = 0;
+    T cur = 0;
     auto array = static_cast<arrow::NumericArray<typename detail::ConversionTraits<T>::ArrowType>>(column->chunk(i)->data());
-    for (auto e = 1; e < array.length(); ++e) {
-      T prev = array.Value(e - 1);
-      T cur = array.Value(e);
-      if (prev > cur) {
+    for (auto e = 0; e < array.length(); ++e) {
+      if (cur >= 0) {
+        prev = cur;
+      }
+      cur = array.Value(e);
+      if (cur >= 0 && prev > cur) {
         throw runtime_error_f("Table %s index %s is not sorted: next value %d < previous value %d!", target, key, cur, prev);
       }
     }

--- a/Framework/Core/test/test_GroupSlicer.cxx
+++ b/Framework/Core/test/test_GroupSlicer.cxx
@@ -417,7 +417,7 @@ BOOST_AUTO_TEST_CASE(ArrowDirectSlicing)
 
   std::vector<arrow::Datum> slices;
   std::vector<uint64_t> offsts;
-  auto status = sliceByColumn("fID", b_e.asArrowTable(), 20, &slices, &offsts);
+  auto status = sliceByColumn("fID", "BigE", b_e.asArrowTable(), 20, &slices, &offsts);
   for (auto i = 0u; i < 5; ++i) {
     auto tbl = arrow::util::get<std::shared_ptr<arrow::Table>>(slices[i].value);
     auto ca = tbl->GetColumnByName("fArr");

--- a/Framework/Core/test/test_Kernels.cxx
+++ b/Framework/Core/test/test_Kernels.cxx
@@ -71,7 +71,7 @@ BOOST_AUTO_TEST_CASE(TestSlicingFramework)
 
   std::vector<uint64_t> offsets;
   std::vector<arrow::Datum> slices;
-  auto status = sliceByColumn<int32_t>("x", table, 12, &slices, &offsets);
+  auto status = sliceByColumn<int32_t>("x", "xy", table, 12, &slices, &offsets);
   BOOST_REQUIRE(status.ok());
   BOOST_REQUIRE_EQUAL(slices.size(), 12);
   std::array<int, 12> sizes{0, 4, 1, 0, 1, 2, 0, 0, 0, 0, 0, 0};

--- a/Framework/Core/test/test_Kernels.cxx
+++ b/Framework/Core/test/test_Kernels.cxx
@@ -79,3 +79,30 @@ BOOST_AUTO_TEST_CASE(TestSlicingFramework)
     BOOST_REQUIRE_EQUAL(slices[i].table()->num_rows(), sizes[i]);
   }
 }
+
+BOOST_AUTO_TEST_CASE(TestSlicingException)
+{
+  TableBuilder builder;
+  auto rowWriter = builder.persist<int32_t, int32_t>({"x", "y"});
+
+  rowWriter(0, 1, 4);
+  rowWriter(0, 1, 5);
+  rowWriter(0, 1, 6);
+  rowWriter(0, 1, 7);
+  rowWriter(0, 2, 7);
+  rowWriter(0, 5, 8);
+  rowWriter(0, 4, 9);
+  rowWriter(0, 6, 10);
+  auto table = builder.finalize();
+
+  std::vector<uint64_t> offsets;
+  std::vector<arrow::Datum> slices;
+  try {
+    auto status = sliceByColumn<int32_t>("x", "xy", table, 12, &slices, &offsets);
+  } catch (RuntimeErrorRef re) {
+    BOOST_REQUIRE_EQUAL(std::string{error_from_ref(re).what}, "Table xy index x is not sorted: next value 4 < previous value 5!");
+    return;
+  } catch (...) {
+    BOOST_FAIL("Slicing should have failed due to unsorted index");
+  }
+}


### PR DESCRIPTION
If non-monotonous order detected when grouping, an exception is thrown, stating the name of the table being grouped, name of the index and offending values.