### PR TITLE
DPL: Message forwarding should be based on the headers of each individual part

### DIFF
--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -1241,7 +1241,7 @@ bool DataProcessingDevice::tryDispatchComputation(DataProcessorContext& context,
           cachedForwardingChoice = -1;
           for (size_t fi = 0; fi < spec->forwards.size(); fi++) {
             auto& forward = spec->forwards[fi];
-            if (DataSpecUtils::match(forward.matcher, dh->dataOrigin, dh->dataDescription, dh->subSpecification) == false || (dph->startTime % forward.maxTimeslices) != forward.timeslice) {
+            if (DataSpecUtils::match(forward.matcher, fdh->dataOrigin, fdh->dataDescription, fdh->subSpecification) == false || (fdph->startTime % forward.maxTimeslices) != forward.timeslice) {
               continue;
             }
             cachedForwardingChoice = fi;


### PR DESCRIPTION
It seems this has always been wrong, the message forwaring of multiparts was based on the header of the first part, not of each individual part. Let's see what the CI says. We should double-check this before merging, to avoid that someone made accidental use of this bug.