### PR TITLE
MCH: fix send empty output in case of dropped TF

### DIFF
--- a/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
@@ -155,9 +155,9 @@ class DataDecoderTask
 
   void sendEmptyOutput(framework::DataAllocator& output)
   {
-    decltype(mDecoder->getOrbits()) orbits{};
-    decltype(mDecoder->getDigits()) digits{};
+    std::vector<Digit> digits;
     std::vector<ROFRecord> rofs;
+    std::vector<OrbitInfo> orbits;
     output.snapshot(Output{header::gDataOriginMCH, "DIGITS", 0}, digits);
     output.snapshot(Output{header::gDataOriginMCH, "DIGITROFS", 0}, rofs);
     output.snapshot(Output{header::gDataOriginMCH, "ORBITS", 0}, orbits);


### PR DESCRIPTION
The orbits message is not of the same type as the internal orbits
member, so the internal type is not what should be used for sending...