### PR TITLE
[MCH] fix tracking without station 1

### DIFF
--- a/Detectors/MUON/MCH/Tracking/src/TrackFinder.cxx
+++ b/Detectors/MUON/MCH/Tracking/src/TrackFinder.cxx
@@ -826,7 +826,10 @@ std::list<Track>::iterator TrackFinder::followTrackInChamber(std::list<Track>::i
     // or if one reaches station 1 and it is not requested, whether a cluster has been found on it or not
     if ((!isFirstOnStation && canSkip && excludedClusters.empty()) ||
         (chamber / 2 == 0 && !TrackerParam::Instance().requestStation[0] && (isFirstOnStation || !canSkip))) {
-      itFirstNewTrack = mTracks.emplace(itTrack, *itTrack);
+      auto itNewTrack = mTracks.emplace(itTrack, *itTrack);
+      if (itFirstNewTrack == mTracks.end()) {
+        itFirstNewTrack = itNewTrack;
+      }
       print("followTrackInChamber: duplicating candidate at position #", getTrackIndex(itFirstNewTrack));
     }
   }


### PR DESCRIPTION
This fixes a small bug in case the tracking was performed without requesting a cluster on station 1:
New tracks are added between itFirstNewTrack and itTrack. As its name says, itFirstNewTrack must point to the first new track added, and not be changed afterward.