### PR TITLE
Data model docs update: don't fail when PR already exists

### DIFF
--- a/.github/workflows/datamodel-doc.yml
+++ b/.github/workflows/datamodel-doc.yml
@@ -72,4 +72,5 @@ jobs:
           # confused when multiple repos are checked out.
           hub pull-request -b AliceO2Group:master -h alibuild:auto-datamodel-doc \
               --no-edit --no-maintainer-edits -m 'Automatic data model update'   \
-              -m "This update to the data model documentation was automatically created from tonight's O2 dev branch."
+              -m "This update to the data model documentation was automatically created from tonight's O2 dev branch." ||
+            :  # If the PR already exists, hub fails, but we've just force-pushed, so we don't need a new PR.


### PR DESCRIPTION
In that case, it's fine that `hub` fails, as we update the existing PR instead by force-pushing to the `auto-datamodel-doc` branch.