### PR TITLE
DPL: minor fixes in AOD table writer

### DIFF
--- a/Framework/Core/src/CommonDataProcessors.cxx
+++ b/Framework/Core/src/CommonDataProcessors.cxx
@@ -351,7 +351,7 @@ DataProcessorSpec
           LOGP(WARNING, "The table \"{}\" is not valid and will not be saved!", tableName);
           continue;
         }
-        if (table->schema()->fields().empty() == true) {
+        if (table->schema()->fields().empty()) {
           LOGP(DEBUG, "The table \"{}\" is empty but will be saved anyway!", tableName);
         }
 


### PR DESCRIPTION
* Remove std::move that prevented copy elisions
* Fix potential null pointer dereference
* Use .empty()
* Fix incorrect description string handling
* Do not copy strings in a loop
* Do not use else after `continue;`