### PR TITLE
o2-eve should not recreate the tpc transformation map every time

### DIFF
--- a/EventVisualisation/Workflow/src/EveWorkflowHelper.cxx
+++ b/EventVisualisation/Workflow/src/EveWorkflowHelper.cxx
@@ -211,7 +211,10 @@ void EveWorkflowHelper::drawTPCClusters(GID gid, float trackTime)
   const auto& elParam = o2::tpc::ParameterElectronics::Instance();
 
   float clusterTimeBinOffset = trc.getTime0(); // in in time beans time assigned to track - primary vertex
-  std::unique_ptr<gpu::TPCFastTransform> fastTransform = (o2::tpc::TPCFastTransformHelperO2::instance()->create(0));
+
+  // FIXME: THIS MUST NOT BE CREATED EVERY TIME
+  // IT SHOULD BE CREATED IN THE INITIALIZATION, AND LATER WE NEED TO UPDATE IT REGULARLY
+  static std::unique_ptr<gpu::TPCFastTransform> fastTransform = (o2::tpc::TPCFastTransformHelperO2::instance()->create(0));
 
   // store the TPC cluster positions
   for (int iCl = trc.getNClusterReferences(); iCl--;) {


### PR DESCRIPTION
trivial, tested locally, and needed for tomorrows nightly, merging

@jmyrcha : You have been creating the TPCFastTransform object every time. This function took 99% of the runtime of the ED. What I do here is only a quick hack for the next nightly, making it static.
Could you fix it properly, and move the creation of this object into the initialization phase, and then just reuse it every time?