### PR TITLE
Fixes for TRD decoder

### DIFF
--- a/DataFormats/Detectors/TRD/src/RawData.cxx
+++ b/DataFormats/Detectors/TRD/src/RawData.cxx
@@ -427,7 +427,7 @@ int getDigitHCHeaderWordType(uint32_t word)
 }
 void printDigitHCHeader(o2::trd::DigitHCHeader& header, uint32_t headers[3])
 {
-  LOGF(INFO, "Digit HalfChamber Header\n Raw:0x%08x reserve:0x%01x side:0x%01x stack:0x%02x layer:0x%02x supermod:0x%02x numberHCW:0x%02x minor:0x%03x major:0x%03x version(>2007):0x%01x \n",
+  LOGF(INFO, "Digit HalfChamber Header: Raw:0x%08x reserve:0x%01x side:0x%01x stack:0x%02x layer:0x%02x supermod:0x%02x numberHCW:0x%02x minor:0x%03x major:0x%03x version(>2007):0x%01x",
        header.word, header.res, header.side, header.stack, header.layer, header.supermodule,
        header.numberHCW, header.minor, header.major, header.version);
   int countheaderwords = header.numberHCW;
@@ -438,9 +438,9 @@ void printDigitHCHeader(o2::trd::DigitHCHeader& header, uint32_t headers[3])
         DigitHCHeader1 header1;
         header1.word = headers[countheaderwords];
         if (header1.res != 0x1) {
-          LOGF(INFO, "*Corrupt* Digit HalfChamber Header1 Raw:0x%08x reserve:0x%02x pretriggercount=0x%02x pretriggerphase=0x%02x bunchxing:0x%05x number of timebins : 0x%03x\n", header1.word, header1.res, header1.ptrigcount, header1.ptrigphase, header1.bunchcrossing, header1.numtimebins);
+          LOGF(INFO, "*Corrupt* Digit HalfChamber Header1 Raw:0x%08x reserve:0x%02x pretriggercount=0x%02x pretriggerphase=0x%02x bunchxing:0x%05x number of timebins : 0x%03x", header1.word, header1.res, header1.ptrigcount, header1.ptrigphase, header1.bunchcrossing, header1.numtimebins);
         } else {
-          LOGF(INFO, "Digit HalfChamber Header1 Raw:0x%08x reserve:0x%02x pretriggercount=0x%02x pretriggerphase=0x%02x bunchxing:0x%05x number of timebins : 0x%03x\n", header1.word, header1.res, header1.ptrigcount, header1.ptrigphase, header1.bunchcrossing, header1.numtimebins);
+          LOGF(INFO, "Digit HalfChamber Header1 Raw:0x%08x reserve:0x%02x pretriggercount=0x%02x pretriggerphase=0x%02x bunchxing:0x%05x number of timebins : 0x%03x", header1.word, header1.res, header1.ptrigcount, header1.ptrigphase, header1.bunchcrossing, header1.numtimebins);
         }
         break;
       case 2:
@@ -456,9 +456,9 @@ void printDigitHCHeader(o2::trd::DigitHCHeader& header, uint32_t headers[3])
         DigitHCHeader3 header3;
         header3.word = headers[countheaderwords];
         if (header3.res != 0b110101) {
-          LOGF(INFO, "*Corrupt*Digit HalfChamber Header3\n Raw:0x%08x reserve:0x%08x readout program revision:0x%08x assembler program version:0x%01x \n", header3.word, header3.res, header3.svnrver, header3.svnver);
+          LOGF(INFO, "*Corrupt*Digit HalfChamber Header3: Raw:0x%08x reserve:0x%08x readout program revision:0x%08x assembler program version:0x%01x", header3.word, header3.res, header3.svnrver, header3.svnver);
         } else {
-          LOGF(INFO, "Digit HalfChamber Header3\n Raw:0x%08x reserve:0x%08x readout program revision:0x%08x assembler program version:0x%01x \n", header3.word, header3.res, header3.svnrver, header3.svnver);
+          LOGF(INFO, "Digit HalfChamber Header3: Raw:0x%08x reserve:0x%08x readout program revision:0x%08x assembler program version:0x%01x", header3.word, header3.res, header3.svnrver, header3.svnver);
         }
         break;
     }

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
@@ -76,6 +76,15 @@ class CruRawReader
     mEnableStats = options[TRDEnableStatsBit];
     mOptions = options;
   }
+
+  void setMaxErrWarnPrinted(int nerr, int nwar)
+  {
+    mMaxErrsPrinted = nerr < 0 ? std::numeric_limits<int>::max() : nerr;
+    mMaxWarnPrinted = nwar < 0 ? std::numeric_limits<int>::max() : nwar;
+  }
+  void checkNoWarn();
+  void checkNoErr();
+
   void setBlob(bool returnblob) { mReturnBlob = returnblob; }; //set class to produce blobs and not vectors. (compress vs pass through)`
   void setDataBuffer(const char* val)
   {
@@ -194,6 +203,9 @@ class CruRawReader
 
   uint32_t mTotalTrackletsFound{0};
   uint32_t mTotalDigitsFound{0};
+
+  int mMaxErrsPrinted = 20;
+  int mMaxWarnPrinted = 20;
 
   long mDataBufferSize;
   uint64_t mDataReadIn = 0;

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/DataReaderTask.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/DataReaderTask.h
@@ -61,7 +61,6 @@ class DataReaderTask : public Task
   bool mHeaderVerbose{false};    // verbose output of headers
   bool mCompressedData{false};   // are we dealing with the compressed data from the flp (send via option)
   bool mByteSwap{true};          // whether we are to byteswap the incoming data, mc is not byteswapped, raw data is (too be changed in cru at some point)
-                                 //  o2::header::DataDescription mDataDesc; // Data description of the incoming data
   bool mEnableTimeInfo{false};   // enable the timing of timeframe,cru,digit,tracklet processing.
   bool mEnableStats{false};      // enable the taking of stats in the rawdatastats class
   bool mRootOutput{false};       // enable the writing of histos.root, a poor mans qc, mostly for debugging.
@@ -76,7 +75,6 @@ class DataReaderTask : public Task
   int mHalfChamberWords{0};      // if the halfchamber header is effectively blanked major.minor = 0.0 and halfchamberwords=0 then this value is used as the number of additional words to try recover the data
   int mHalfChamberMajor{0};      // if the halfchamber header is effectively blanked major.minor = 0.0 and halfchamberwords=0 then this value is used as the major version to try recover the data
   std::string mHistogramsFilename; // filename to use for histograms.
-  std::string mDataDesc;
   o2::header::DataDescription mUserDataDescription = o2::header::gDataDescriptionInvalid; // alternative user-provided description to pick
   bool mFixDigitEndCorruption{false};                                                     // fix the parsing of corrupt end of digit data. bounce over it.
   o2::trd::TRDDataCountersPerTimeFrame mTimeFrameStats;                                   // TODO for compressed data this is going to come in for each subtimeframe

--- a/Detectors/TRD/reconstruction/src/DataReader.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReader.cxx
@@ -116,10 +116,11 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   }
   workflow.emplace_back(DataProcessorSpec{
     std::string("trd-datareader"), // left as a string cast incase we append stuff to the string
-    inputs,                        //select(std::string("x:TRD/" + inputspec).c_str()),
+    inputs,
     outputs,
     algoSpec,
-    Options{}});
+    Options{{"log-max-errors", VariantType::Int, 20, {"maximum number of errors to log"}},
+            {"log-max-warnings", VariantType::Int, 20, {"maximum number of warnings to log"}}}});
 
   if (cfgc.options().get<bool>("enable-root-output")) {
     workflow.emplace_back(o2::trd::getTRDDigitWriterSpec(false, false));

--- a/Detectors/TRD/reconstruction/src/DataReaderTask.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReaderTask.cxx
@@ -18,14 +18,11 @@
 
 #include "Framework/ControlService.h"
 #include "Framework/ConfigParamRegistry.h"
-#include "Framework/RawDeviceService.h"
 #include "Framework/DeviceSpec.h"
 #include "Framework/DataSpecUtils.h"
 #include "Framework/InputRecordWalker.h"
 
 #include "DataFormatsTRD/Constants.h"
-
-#include <fairmq/FairMQDevice.h>
 #include <TH3F.h>
 #include "TH2F.h"
 #include "TFile.h"
@@ -162,9 +159,9 @@ void DataReaderTask::init(InitContext& ic)
   auto finishFunction = [this]() {
     mReader.checkSummary();
   };
+  mReader.setMaxErrWarnPrinted(ic.options().get<int>("log-max-errors"), ic.options().get<int>("log-max-warnings"));
   buildHistograms(); // if requested create all the histograms
   ic.services().get<CallbackService>().set(CallbackService::Id::Stop, finishFunction);
-  mDataDesc = "RAWDATA";
 }
 
 void DataReaderTask::endOfStream(o2::framework::EndOfStreamContext& ec)
@@ -253,79 +250,53 @@ void DataReaderTask::run(ProcessingContext& pc)
     return;
   }
   uint64_t total1 = 0, total2 = 0;
-  /* set encoder output buffer */
-  char bufferOut[o2::trd::constants::HBFBUFFERMAX];
-  int loopcounter = 0;
-  uint64_t tfcounter = 0;
-  uint64_t inputcounter = 0;
-  auto device = pc.services().get<o2::framework::RawDeviceService>().device();
-  auto outputRoutes = pc.services().get<o2::framework::RawDeviceService>().spec().outputs;
-  auto fairMQChannel = outputRoutes.at(0).channel;
-  /* loop over inputs routes */
-  for (auto iit = pc.inputs().begin(), iend = pc.inputs().end(); iit != iend; ++iit) {
-    if (!iit.isValid()) {
-      continue;
-    }
-    /* loop over input parts */
-    int inputpartscount = 0;
-    int emptyframe = 0;
-    tfcounter++;
-    for (auto const& ref : iit) {
-      auto inputprocessingstart = std::chrono::high_resolution_clock::now(); // measure total processing time
-      if (mVerbose) {
-        const auto dh = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
-        LOGP(info, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : ",
-             dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize);
-      }
-      const auto* headerIn = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
-      auto payloadIn = ref.payload;
-      auto payloadInSize = headerIn->payloadSize;
-      //    const auto dh = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
-      if (std::string(headerIn->dataDescription.str) != std::string("DISTSUBTIMEFRAMEFLP")) {
-        if (!mCompressedData) { //we have raw data coming in from flp
-          if (mVerbose) {
-            LOG(info) << " parsing non compressed data in the data reader task with a payload of " << payloadInSize << " payload size";
-          }
-          //          LOG(info) << "start of data is at ref.payload=0x"<< std::hex << " headerIn->payloadSize:0x" << headerIn->payloadSize <<" headerIn->headerSize:0x" <<headerIn->headerSize;
-          total1 += headerIn->payloadSize;
-          total2 += headerIn->headerSize;
-          //          LOG(info) << "start of data is at ref.payload=0x"<< std::hex << " total1:0x" << total1 <<" total2:0x" <<total2;
-          mReader.setDataBuffer(payloadIn);
-          mReader.setDataBufferSize(payloadInSize);
-          mReader.configure(mTrackletHCHeaderState, mHalfChamberWords, mHalfChamberMajor, mOptions);
-          //mReader.setStats(&mTimeFrameStats);
-          mReader.run();
-          mWordsRead += mReader.getWordsRead();
-          mWordsRejected += mReader.getWordsRejected();
-          if (mVerbose) {
-            LOG(info) << "relevant vectors to read : " << mReader.sumTrackletsFound() << " tracklets and " << mReader.sumDigitsFound() << " compressed digits";
-          }
-        } else { // we have compressed data coming in from flp.
-          mCompressedReader.setDataBuffer(payloadIn);
-          mCompressedReader.setDataBufferSize(payloadInSize);
-          mCompressedReader.configure(mOptions);
-          mCompressedReader.run();
-        }
-      } // ignore the input of DISTSUBTIMEFRAMEFLP
-    }
 
-    std::chrono::duration<double, std::milli> dataReadTime = std::chrono::high_resolution_clock::now() - dataReadStart;
-    LOG(info) << "Processing time for Data reading  " << std::chrono::duration_cast<std::chrono::milliseconds>(dataReadTime).count() << "ms";
-    if (mRootOutput) {
-      mTimeFrameTime->Fill((int)std::chrono::duration_cast<std::chrono::milliseconds>(dataReadTime).count());
+  std::vector<InputSpec> sel{InputSpec{"filter", ConcreteDataTypeMatcher{"TRD", "RAWDATA"}}};
+  uint64_t tfCount = 0;
+  for (const auto& ref : InputRecordWalker(pc.inputs(), sel)) {
+    auto inputprocessingstart = std::chrono::high_resolution_clock::now(); // measure total processing time
+    const auto* dh = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
+    tfCount = dh->tfCounter;
+    if (mVerbose) {
+      LOGP(info, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : ",
+           dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize);
     }
-    LOG(info) << "[" << tfcounter << "] D:" << mReader.getDigitsFound() << " T:" << mReader.getTrackletsFound();
-    /* output */
-    sendData(pc, false);
+    auto payloadIn = ref.payload;
+    auto payloadInSize = dh->payloadSize;
+    if (!mCompressedData) { //we have raw data coming in from flp
+      if (mVerbose) {
+        LOG(info) << " parsing non compressed data in the data reader task with a payload of " << payloadInSize << " payload size";
+      }
+      //          LOG(info) << "start of data is at ref.payload=0x"<< std::hex << " dh->payloadSize:0x" << dh->payloadSize <<" dh->headerSize:0x" <<dh->headerSize;
+      total1 += dh->payloadSize;
+      total2 += dh->headerSize;
+      //          LOG(info) << "start of data is at ref.payload=0x"<< std::hex << " total1:0x" << total1 <<" total2:0x" <<total2;
+      mReader.setDataBuffer(payloadIn);
+      mReader.setDataBufferSize(payloadInSize);
+      mReader.configure(mTrackletHCHeaderState, mHalfChamberWords, mHalfChamberMajor, mOptions);
+      //mReader.setStats(&mTimeFrameStats);
+      mReader.run();
+      mWordsRead += mReader.getWordsRead();
+      mWordsRejected += mReader.getWordsRejected();
+      if (mVerbose) {
+        LOG(info) << "relevant vectors to read : " << mReader.sumTrackletsFound() << " tracklets and " << mReader.sumDigitsFound() << " compressed digits";
+      }
+    } else { // we have compressed data coming in from flp.
+      mCompressedReader.setDataBuffer(payloadIn);
+      mCompressedReader.setDataBufferSize(payloadInSize);
+      mCompressedReader.configure(mOptions);
+      mCompressedReader.run();
+    }
   }
-    if (!mCompressedData) {
-      LOG(info) << "Digits found : " << mReader.getDigitsFound();
-      LOG(info) << "Tracklets found : " << mReader.getTrackletsFound();
-      LOG(info) << "DataRead in :" << mWordsRead * 4 << " bytes";
-      LOG(info) << "DataRejected in :" << mWordsRejected * 4 << " bytes";
-      LOG(info) << "DataRetention :bad/good" << (double)mWordsRejected / (double)mWordsRead << "";
-      LOG(info) << "Total % good data bad/(good+bad)" << (double)mWordsRejected / ((double)mWordsRead + (double)mWordsRejected) * 100.0 << " %";
-    }
+
+  sendData(pc, false);
+  std::chrono::duration<double, std::milli> dataReadTime = std::chrono::high_resolution_clock::now() - dataReadStart;
+  if (mRootOutput) {
+    mTimeFrameTime->Fill((int)std::chrono::duration_cast<std::chrono::milliseconds>(dataReadTime).count());
+  }
+  LOGP(info, "Digits: {}, Tracklets: {}, DataRead in: {}, Rejected: {} bytes for TF {} in {} ms",
+       mReader.getDigitsFound(), mReader.getTrackletsFound(), mWordsRead * 4, mWordsRejected * 4, tfCount,
+       std::chrono::duration_cast<std::chrono::milliseconds>(dataReadTime).count());
 }
 
 } // namespace o2::trd

--- a/Detectors/TRD/reconstruction/src/EventRecord.cxx
+++ b/Detectors/TRD/reconstruction/src/EventRecord.cxx
@@ -207,7 +207,7 @@ void EventStorage::sendData(o2::framework::ProcessingContext& pc, bool displaytr
   pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginTRD, "TRACKLETS", 0, o2::framework::Lifetime::Timeframe}, tracklets);
   pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginTRD, "TRKTRGRD", 0, o2::framework::Lifetime::Timeframe}, triggers);
   std::chrono::duration<double, std::micro> dataReadTime = std::chrono::high_resolution_clock::now() - dataReadStart;
-  LOG(info) << "Preparing for sending and sending data took  " << std::chrono::duration_cast<std::chrono::milliseconds>(dataReadTime).count() << "ms";
+  LOG(debug) << "Preparing for sending and sending data took  " << std::chrono::duration_cast<std::chrono::milliseconds>(dataReadTime).count() << "ms";
   if (mPackagingTime != nullptr) {
     mPackagingTime->Fill((int)std::chrono::duration_cast<std::chrono::microseconds>(dataReadTime).count());
   }


### PR DESCRIPTION
* Loop only over TRD data, send output once per TF
* Option to limit number of errors and warnings logged (default 20, 20)
* Some cleanup (more needed)