### PR TITLE
[EMCAL-630] Force usage of references in range-based iteration over e…

### DIFF
--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/RawToCellConverterSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/RawToCellConverterSpec.h
@@ -97,6 +97,7 @@ class RawToCellConverterSpec : public framework::Task
     bool mIsLGnoHG;            ///< Cell has only LG digits
     bool mHGOutOfRange;        ///< Cell has only HG digits which are out of range
     int mFecID;                ///< FEC ID of the channel (for monitoring)
+    int mDDLID;                ///< DDL of the channel (for monitoring)
     int mHWAddressLG;          ///< HW address of LG (for monitoring)
     int mHWAddressHG;          ///< HW address of HG (for monitoring)
   };

--- a/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
@@ -348,6 +348,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
                 if (ampOld > o2::emcal::constants::OVERFLOWCUT) {
                   // High gain digit has energy above overflow cut, use low gain instead
                   res->mCellData.setEnergy(amp * o2::emcal::constants::EMCAL_HGLGFACTOR);
+                  res->mCellData.setTimeStamp(fitResults.getTime() - timeshift);
                   res->mCellData.setLowGain();
                 }
                 res->mIsLGnoHG = false;
@@ -361,6 +362,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
               res->mHWAddressHG = chan.getHardwareAddress();
               if (amp / CONVADCGEV <= o2::emcal::constants::OVERFLOWCUT) {
                 res->mCellData.setEnergy(amp);
+                res->mCellData.setTimeStamp(fitResults.getTime() - timeshift);
                 res->mCellData.setHighGain();
               }
             }
@@ -378,16 +380,16 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
             } else {
               // High gain cell: Flag as low gain if above threshold
               if (amp / CONVADCGEV > o2::emcal::constants::OVERFLOWCUT) {
-                flagChanType = chantype;
+                flagChanType = ChannelType_t::LOW_GAIN;
                 hgOutOfRange = true;
               }
               hwAddressHG = chan.getHardwareAddress();
             }
-            int fecID = mMapper->getFEEForChannelInDDL(iSM / 2, chan.getFECIndex(), chan.getBranchIndex());
+            int fecID = mMapper->getFEEForChannelInDDL(feeID, chan.getFECIndex(), chan.getBranchIndex());
             currentCellContainer->push_back({o2::emcal::Cell(CellID, amp, fitResults.getTime() - timeshift, chantype),
                                              lgNoHG,
                                              hgOutOfRange,
-                                             fecID, hwAddressLG, hwAddressHG});
+                                             fecID, feeID, hwAddressLG, hwAddressHG});
           }
         } catch (CaloRawFitter::RawFitterError_t& fiterror) {
           if (fiterror != CaloRawFitter::RawFitterError_t::BUNCH_NOT_OK) {
@@ -424,15 +426,13 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
       std::sort(cells->begin(), cells->end(), [](const RecCellInfo& lhs, const RecCellInfo& rhs) { return lhs.mCellData.getTower() < rhs.mCellData.getTower(); });
       for (const auto& cell : *cells) {
         if (cell.mIsLGnoHG) {
-          auto [smID, modID, iphiMod, ietaMod] = mGeometry->GetCellIndex(cell.mCellData.getTower());
-          LOG(ERROR) << "FEC " << cell.mFecID << ": 0x" << std::hex << cell.mHWAddressLG << std::dec << " (SM " << smID << ") has low gain but no high-gain";
-          mOutputDecoderErrors.emplace_back(smID * 2, ErrorTypeFEE::GAIN_ERROR, 0);
+          LOG(ERROR) << "FEC " << cell.mFecID << ": 0x" << std::hex << cell.mHWAddressLG << std::dec << " (DDL " << cell.mDDLID << ") has low gain but no high-gain";
+          mOutputDecoderErrors.emplace_back(cell.mFecID, ErrorTypeFEE::GAIN_ERROR, 0);
           continue;
         }
         if (cell.mHGOutOfRange) {
-          auto [smID, modID, iphiMod, ietaMod] = mGeometry->GetCellIndex(cell.mCellData.getTower());
-          LOG(ERROR) << "FEC " << cell.mFecID << ": 0x" << std::hex << cell.mHWAddressHG << std::dec << " (SM " << smID << ") has only high-gain out-of-range";
-          mOutputDecoderErrors.emplace_back(smID * 2, ErrorTypeFEE::GAIN_ERROR, 1);
+          LOG(ERROR) << "FEC " << cell.mFecID << ": 0x" << std::hex << cell.mHWAddressHG << std::dec << " (DDL " << cell.mDDLID << ") has only high-gain out-of-range";
+          mOutputDecoderErrors.emplace_back(cell.mFecID, ErrorTypeFEE::GAIN_ERROR, 1);
           continue;
         }
         ncellsEvent++;


### PR DESCRIPTION
…vents / cells

Explicitly force references preventing implicit use
of
- move semanticsc
- copy
in range-based loop over events and cells.