### PR TITLE
DPL: allow Lifetime::Enumeration to repeat values

### DIFF
--- a/Framework/Core/include/Framework/LifetimeHelpers.h
+++ b/Framework/Core/include/Framework/LifetimeHelpers.h
@@ -31,7 +31,9 @@ struct LifetimeHelpers {
   static ExpirationHandler::Creator dataDrivenCreation();
   /// Callback which creates a new timeslice as soon as one is available and
   /// uses an incremental number as timestamp.
-  static ExpirationHandler::Creator enumDrivenCreation(size_t first, size_t last, size_t step, size_t inputTimeslice, size_t maxTimeSliceId);
+  /// @a repetitions number of times we should repeat the same value of the
+  /// enumeration.
+  static ExpirationHandler::Creator enumDrivenCreation(size_t first, size_t last, size_t step, size_t inputTimeslice, size_t maxTimeSliceId, size_t repetitions);
 
   /// Callback which creates a new timeslice when timer
   /// expires and there is not a compatible datadriven callback

--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -113,7 +113,7 @@ struct ExpirationHandlerHelpers {
       uv_signal_start(sh, detail::signal_callback, SIGUSR1);
       state.activeSignals.push_back(sh);
 
-      return LifetimeHelpers::enumDrivenCreation(start, stop, step, inputTimeslice, maxInputTimeslices);
+      return LifetimeHelpers::enumDrivenCreation(start, stop, step, inputTimeslice, maxInputTimeslices, 1);
     };
   }
 
@@ -126,7 +126,14 @@ struct ExpirationHandlerHelpers {
       auto start = options.get<int64_t>(startName.c_str());
       auto stop = options.get<int64_t>(endName.c_str());
       auto step = options.get<int64_t>(stepName.c_str());
-      return LifetimeHelpers::enumDrivenCreation(start, stop, step, inputTimeslice, maxInputTimeslices);
+      auto repetitions = 1;
+      for (auto& meta : matcher.metadata) {
+        if (meta.name == "repetitions") {
+          repetitions = meta.defaultValue.get<int64_t>();
+          break;
+        }
+      }
+      return LifetimeHelpers::enumDrivenCreation(start, stop, step, inputTimeslice, maxInputTimeslices, repetitions);
     };
   }
 

--- a/Framework/Core/src/LifetimeHelpers.cxx
+++ b/Framework/Core/src/LifetimeHelpers.cxx
@@ -58,10 +58,12 @@ ExpirationHandler::Creator LifetimeHelpers::dataDrivenCreation()
   };
 }
 
-ExpirationHandler::Creator LifetimeHelpers::enumDrivenCreation(size_t start, size_t end, size_t step, size_t inputTimeslice, size_t maxInputTimeslices)
+ExpirationHandler::Creator LifetimeHelpers::enumDrivenCreation(size_t start, size_t end, size_t step, size_t inputTimeslice, size_t maxInputTimeslices, size_t maxRepetitions)
 {
   auto last = std::make_shared<size_t>(start + inputTimeslice * step);
-  return [start, end, step, last, inputTimeslice, maxInputTimeslices](TimesliceIndex& index) -> TimesliceSlot {
+  auto repetition = std::make_shared<size_t>(0);
+
+  return [start, end, step, last, inputTimeslice, maxInputTimeslices, maxRepetitions, repetition](TimesliceIndex& index) -> TimesliceSlot {
     for (size_t si = 0; si < index.size(); si++) {
       if (*last > end) {
         return TimesliceSlot{TimesliceSlot::INVALID};
@@ -69,11 +71,15 @@ ExpirationHandler::Creator LifetimeHelpers::enumDrivenCreation(size_t start, siz
       auto slot = TimesliceSlot{si};
       if (index.isValid(slot) == false) {
         TimesliceId timestamp{*last};
-        *last += step * maxInputTimeslices;
+        *repetition += 1;
+        if (*repetition % maxRepetitions == 0) {
+          *last += step * maxInputTimeslices;
+        }
         index.associate(timestamp, slot);
         return slot;
       }
     }
+
     return TimesliceSlot{TimesliceSlot::INVALID};
   };
 }


### PR DESCRIPTION
Is now possible to specify the "repetitions" metadata for an InputSpec which uses Lifetime::Enumeration.
When the associated input gets expired, it will create "repetitions" entries with the same startTime. 
This allows things like reading a file in "repetitions" steps, rather than at once.
