### PR TITLE
TRD Fix trigger event types

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
@@ -76,6 +76,9 @@ constexpr int MAXEVENTCOUNTERSEPERATION = 200; // how far appart can subsequent 
 constexpr int MAXMCMCOUNT = 69120;             // at most mcm count maxchamber x nrobc1 nmcmrob
 constexpr int MAXLINKERRORHISTOGRAMS = 10;     // size of the array holding the link error plots from the raw reader
 constexpr int MAXPARSEERRORHISTOGRAMS = 60;    // size of the array holding the parsing error plots from the raw reader
+constexpr int ETYPEPHYSICSTRIGGER = 0x2;       // CRU Half Chamber header eventtype definition
+constexpr int ETYPECALIBRATIONTRIGGER = 0x3;   // CRU Half Chamber header eventtype definition
+
 } //namespace constants
 } // namespace trd
 } // namespace o2

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
@@ -164,6 +164,14 @@ class CruRawReader
   int checkDigitHCHeader();
   int checkTrackletHCHeader();
   bool skipRDH();
+  void updateLinkErrorGraphs(int currentlinkindex, int supermodule_half, int stack_layer);
+  void increment2dHist(int hist, int sectorside, int stack, int layer)
+  {
+    if (mRootOutput) {
+      mParsingErrors->Fill(hist);
+      ((TH2F*)mParsingErrors2d->At(hist))->Fill(sectorside, stack * constants::NLAYER + layer);
+    }
+  }
 
   inline void rewind()
   {

--- a/Detectors/TRD/reconstruction/src/CruRawReader.cxx
+++ b/Detectors/TRD/reconstruction/src/CruRawReader.cxx
@@ -189,8 +189,7 @@ bool CruRawReader::processHBFs(int datasizealreadyread, bool verbose)
           LOG(info) << "ignored rdh event ";
           break;
         case 0:
-          LOG(error) << "figure out what now"; // RS: don't use fatal
-                                               //          LOG(fatal) << "figure out what now";
+          LOG(error) << "figure out what now";
           break;
         case 1:
           LOG(info) << "all good parsing half cru";
@@ -241,28 +240,19 @@ int CruRawReader::checkDigitHCHeader()
       //stack mismatch
       //count these
       //mEventRecord.ErrorStats[TRDParsingDigitStackMismatch]++;
-      if (mRootOutput) {
-        mParsingErrors->Fill(TRDParsingDigitStackMismatch);
-        ((TH2F*)mParsingErrors2d->At(TRDParsingDigitStackMismatch))->Fill(mFEEID.supermodule * 2 + mFEEID.side, mStack[0] * constants::NLAYER + mLayer[0]);
-      }
+      increment2dHist(TRDParsingDigitStackMismatch, mFEEID.supermodule * 2 + mFEEID.side, mStack[0], mLayer[0]);
     }
     if (currentlayer != mLayer[0] || currentlayer != mLayer[1]) {
       //layer mismatch
       //count these
       //mEventRecord.ErrorStats[TRDParsingDigitLayerMisMatch]++;
-      if (mRootOutput) {
-        mParsingErrors->Fill(TRDParsingDigitLayerMismatch);
-        ((TH2F*)mParsingErrors2d->At(TRDParsingDigitLayerMismatch))->Fill(mFEEID.supermodule * 2 + mFEEID.side, mStack[0] * constants::NLAYER + mLayer[0]);
-      }
+      increment2dHist(TRDParsingDigitLayerMismatch, mFEEID.supermodule * 2 + mFEEID.side, mStack[0], mLayer[0]);
     }
     if (currentsector != mSector[0] || currentsector != mSector[1]) {
       //sector mismatch, mDetector comes in from a construction via the feeid and ori.
       //count these
       //mEventRecord.ErrorStats[TRDParsingDigitSectorMisMatch]++;
-      if (mRootOutput) {
-        mParsingErrors->Fill(TRDParsingDigitSectorMismatch);
-        ((TH2F*)mParsingErrors2d->At(TRDParsingDigitSectorMismatch))->Fill(mFEEID.supermodule * 2 + mFEEID.side, mStack[0] * constants::NLAYER + mLayer[0]);
-      }
+      increment2dHist(TRDParsingDigitSectorMismatch, mFEEID.supermodule * 2 + mFEEID.side, mStack[0], mLayer[0]);
     }
     mSector[2] = currentsector; //from hc header treating it as authoritative
     mDetector[2] = mSector[2] * 2 + mDigitHCHeader.side;
@@ -299,9 +289,7 @@ int CruRawReader::parseDigitHCHeader()
 
   int additionalHeaderWords = mDigitHCHeader.numberHCW;
   if (additionalHeaderWords >= 3) {
-    if (mRootOutput) {
-      ((TH2F*)mParsingErrors2d->At(TRDParsingDigitHeaderCountGT3))->Fill(mFEEID.supermodule * 2 + mFEEID.side, mStack[0] * constants::NLAYER + mLayer[0]);
-    }
+    increment2dHist(TRDParsingDigitHeaderCountGT3, mFEEID.supermodule * 2 + mFEEID.side, mStack[0], mLayer[0]);
     //TODO graph this and stats it
     if (mMaxErrsPrinted > 0) {
       LOG(error) << "Error parsing DigitHCHeader, too many additional words count=" << additionalHeaderWords;
@@ -321,40 +309,56 @@ int CruRawReader::parseDigitHCHeader()
         mDigitHCHeader1.word = headers[headerwordcount];
         if (mDigitHCHeader1.res != 0x1) {
           //LOG(error) << "Digit HC Header 1 reserved : " << std::hex << mDigitHCHeader1.res << " raw: 0x" << mDigitHCHeader1.word;
-          if (mRootOutput) {
-            ((TH2F*)mParsingErrors2d->At(TRDParsingDigitHeaderWrong1))->Fill(mFEEID.supermodule * 2 + mFEEID.side, mStack[0] * constants::NLAYER + mLayer[0]);
-          }
+          increment2dHist(TRDParsingDigitHeaderWrong1, mFEEID.supermodule * 2 + mFEEID.side, mStack[0], mLayer[0]);
         }
         break;
       case 2: // header header2;
         mDigitHCHeader2.word = headers[headerwordcount];
         if (mDigitHCHeader2.res != 0b110001) {
           // LOG(error) << "Digit HC Header 2 reserved : " << std::hex << mDigitHCHeader2.res << " raw: 0x" << mDigitHCHeader2.word;
-          if (mRootOutput) {
-            ((TH2F*)mParsingErrors2d->At(TRDParsingDigitHeaderWrong2))->Fill(mFEEID.supermodule * 2 + mFEEID.side, mStack[0] * constants::NLAYER + mLayer[0]);
-          }
+          increment2dHist(TRDParsingDigitHeaderWrong2, mFEEID.supermodule * 2 + mFEEID.side, mStack[0], mLayer[0]);
         }
         break;
       case 3: // header header3;
         mDigitHCHeader3.word = headers[headerwordcount];
         if (mDigitHCHeader3.res != 0b110101) {
           // LOG(error) << "Digit HC Header 3 reserved : " << std::hex << mDigitHCHeader3.res << " raw: 0x" << mDigitHCHeader3.word;
-          if (mRootOutput) {
-            ((TH2F*)mParsingErrors2d->At(TRDParsingDigitHeaderWrong3))->Fill(mFEEID.supermodule * 2 + mFEEID.side, mStack[0] * constants::NLAYER + mLayer[0]);
-          }
+          increment2dHist(TRDParsingDigitHeaderWrong3, mFEEID.supermodule * 2 + mFEEID.side, mStack[0], mLayer[0]);
         }
         break;
       default:
         //LOG(error) << "Error parsing DigitHCHeader at word:" << headerwordcount << " looking at 0x:" << std::hex << mHBFPayload[mHBFoffset32 - 1];
-        if (mRootOutput) {
-          ((TH2F*)mParsingErrors2d->At(TRDParsingDigitHeaderWrong4))->Fill(mFEEID.supermodule * 2 + mFEEID.side, mStack[0] * constants::NLAYER + mLayer[0]);
-        }
+        increment2dHist(TRDParsingDigitHeaderWrong4, mFEEID.supermodule * 2 + mFEEID.side, mStack[0], mLayer[0]);
     }
   }
   if (mHeaderVerbose) {
     printDigitHCHeader(mDigitHCHeader, &headers[0]);
   }
   return 1;
+}
+
+void CruRawReader::updateLinkErrorGraphs(int currentlinkindex, int supermodule_half, int stack_layer)
+{
+  if (mRootOutput) {
+    if (mCurrentHalfCRULinkErrorFlags[currentlinkindex] == 0) {
+      ((TH2F*)mLinkErrors->At(0))->Fill(supermodule_half, stack_layer);
+    }
+    if (mCurrentHalfCRULinkErrorFlags[currentlinkindex] == 1) {
+      ((TH2F*)mLinkErrors->At(1))->Fill(supermodule_half, stack_layer);
+    }
+    if (mCurrentHalfCRULinkErrorFlags[currentlinkindex] == 2) {
+      ((TH2F*)mLinkErrors->At(2))->Fill(supermodule_half, stack_layer);
+    }
+    if (mCurrentHalfCRULinkErrorFlags[currentlinkindex] > 0) {
+      ((TH2F*)mLinkErrors->At(3))->Fill(supermodule_half, stack_layer);
+    }
+    if (mCurrentHalfCRULinkLengths[currentlinkindex] > 0) {
+      ((TH2F*)mLinkErrors->At(4))->Fill(supermodule_half, stack_layer);
+    }
+    if (mCurrentHalfCRULinkLengths[currentlinkindex] == 0) {
+      ((TH2F*)mLinkErrors->At(5))->Fill(supermodule_half, stack_layer);
+    }
+  }
 }
 
 int CruRawReader::processHalfCRU(int cruhbfstartoffset)
@@ -411,6 +415,7 @@ int CruRawReader::processHalfCRU(int cruhbfstartoffset)
 
   std::array<uint32_t, 1024>::iterator currentlinkstart = mHBFPayload.begin() + cruhbfstartoffset;
   if (mHeaderVerbose) {
+    printHalfCRUHeader(mCurrentHalfCRUHeader);
     OutputHalfCruRawData();
   }
   std::array<uint32_t, 1024>::iterator linkstart, linkend;
@@ -461,27 +466,7 @@ int CruRawReader::processHalfCRU(int cruhbfstartoffset)
     int supermodule_half = mSector[0] * 2 + mHalfChamberSide[0]; // will just go with the rdh one here its only for the hack graphing purposes.
     float stack_layer;
     stack_layer = mStack[0] * constants::NLAYER + mLayer[0]; // similarly this is also only for graphing so just use the rdh ones for now.
-    if (mRootOutput) {
-      if (mCurrentHalfCRULinkErrorFlags[currentlinkindex] == 0) {
-        ((TH2F*)mLinkErrors->At(0))->Fill(supermodule_half, stack_layer);
-      }
-      if (mCurrentHalfCRULinkErrorFlags[currentlinkindex] == 1) {
-        ((TH2F*)mLinkErrors->At(1))->Fill(supermodule_half, stack_layer);
-      }
-      if (mCurrentHalfCRULinkErrorFlags[currentlinkindex] == 2) {
-        ((TH2F*)mLinkErrors->At(2))->Fill(supermodule_half, stack_layer);
-      }
-      if (mCurrentHalfCRULinkErrorFlags[currentlinkindex] > 0) {
-        ((TH2F*)mLinkErrors->At(3))->Fill(supermodule_half, stack_layer);
-      }
-      if (mCurrentHalfCRULinkLengths[currentlinkindex] > 0) {
-        ((TH2F*)mLinkErrors->At(4))->Fill(supermodule_half, stack_layer);
-      }
-      if (mCurrentHalfCRULinkLengths[currentlinkindex] == 0) {
-        ((TH2F*)mLinkErrors->At(5))->Fill(supermodule_half, stack_layer);
-      }
-    }
-    //mStatCountersPerEvent.mLinkErrorFlag[currentdetector] = mCurrentHalfCRULinkErrorFlags[currentlinkindex];
+    updateLinkErrorGraphs(currentlinkindex, supermodule_half, stack_layer);
 
     currentlinksize = mCurrentHalfCRULinkLengths[currentlinkindex];
     currentlinksize32 = currentlinksize * 8; //x8 to go from 256 bits to 32 bit;
@@ -544,8 +529,14 @@ int CruRawReader::processHalfCRU(int cruhbfstartoffset)
         LOG(info) << "*** Tracklet Parser : trackletwordsread:" << mTrackletWordsRead << " ending " << std::hex << linkstart << " at hbfoffset: " << std::dec << mHBFoffset32;
       }
 
-      // check if we are now at the end of the data due to bugs, i.e. if trackletparsing read padding words.
-      if (linkstart != linkend) {
+      /****************
+      ** DIGITS NOW ***
+      *****************/
+      // Check if we have a calibration trigger ergo we do actually have digits data. check if we are now at the end of the data due to bugs, i.e. if trackletparsing read padding words.
+      if (linkstart != linkend && mCurrentHalfCRUHeader.EventType == o2::trd::constants::ETYPECALIBRATIONTRIGGER) { // calibration trigger
+        if (mHeaderVerbose) {
+          LOG(info) << "*** Digit Parsing : starting at " << std::hex << linkstart << " at hbfoffset: " << std::dec << mHBFoffset32 << " linkhbf start pos:" << hbfoffsetatstartoflink;
+        }
         // linkstart advanced all the way to the end due to trackletparser parsing crupadding words (known bug or feature )
         auto hfboffsetbeforehcparse = mHBFoffset32;
         //now read the digit half chamber header
@@ -567,66 +558,63 @@ int CruRawReader::processHalfCRU(int cruhbfstartoffset)
           linkstart += 1 + mDigitHCHeader.numberHCW;
         }
 
-      if (mDigitHCHeader.major == 0x47) {
-        // config event so ignore for now and bail out of parsing.
-        if (mMaxWarnPrinted > 0) {
-          LOG(warn) << " HCHeader major version is 0x47 bailing out of parsing this as its a config event";
-          checkNoWarn();
-        }
-        //advance data pointers to the end;
-        //mHBFoffset32 = std::distance(mHBFPayload.begin(),linkend);//dataoffsetstart32 + currentlinksize; // go to the end of the link
-        mHBFoffset32 = std::distance(mHBFPayload.begin(), linkend); //currentlinksize-mTrackletWordsRead-sizeof(digitHCHeader)/4; // advance to the end of the link
-        mTotalDigitWordsRejected += std::distance(linkstart + mTrackletWordsRead + sizeof(DigitHCHeader) / 4, linkend);
-        linkstart = linkend;
-      } else {
-        if (((mDigitHCHeader.major & 0x27) == mDigitHCHeader.major) || ((mDigitHCHeader.major & 0x37) == mDigitHCHeader.major) || ((mDigitHCHeader.major & 0x17) == mDigitHCHeader.major)) {
-          //                ZS                                                          DisableTracklets
-          mDigitWordsRead = 0;
-          auto digitsparsingstart = std::chrono::high_resolution_clock::now();
-          //linkstart and linkend already have the multiple cruheaderoffsets built in
-          mDigitWordsRead = mDigitsParser.Parse(&mHBFPayload, linkstart, linkend, mDetector[mWhichData], mStack[mWhichData], mLayer[mWhichData], mSide[mWhichData], mDigitHCHeader, mFEEID, currentlinkindex, mCurrentEvent, mOptions, cleardigits);
-          std::chrono::duration<double, std::micro> digitsparsingtime = std::chrono::high_resolution_clock::now() - trackletparsingstart;
-          if (mRootOutput) {
-            mDigitTiming->Fill((int)std::chrono::duration_cast<std::chrono::microseconds>(digitsparsingtime).count());
-          }
-          mDigitWordsRejected = mDigitsParser.getDumpedDataCount();
-          if (mHeaderVerbose) {
-            if (mDigitsParser.getDumpedDataCount() != 0) {
-              LOG(info) << "FEEID: " << mFEEID.word << " LINK #" << oriindex << " bad datacount:" << mDigitsParser.getDataWordsParsed() << "::" << mDigitsParser.getDumpedDataCount();
-            } else {
-              LOG(info) << "FEEID: " << mFEEID.word << " LINK #" << oriindex << " good datacount:" << mDigitsParser.getDataWordsParsed() << "::" << mDigitsParser.getDumpedDataCount();
-            }
-          }
-          if (mDigitWordsRead + mDigitWordsRejected != std::distance(linkstart, linkend)) {
-            //we have the data corruption problem of a pile of stuff at the end of a link, jump over it.
-            if (mFixDigitEndCorruption) {
-              mDigitWordsRead = std::distance(linkstart, linkend);
-            } else {
-              if (mRootOutput) {
-                mParsingErrors->Fill(TRDParsingDigitStackMismatch);
-                ((TH2F*)mParsingErrors2d->At(TRDParsingDigitDataStillOnLink))->Fill(mFEEID.supermodule * 2 + mFEEID.side, mStack[0] * constants::NLAYER + mLayer[0]);
-              }
-            }
-          }
-          mTotalDigitsFound += mDigitsParser.getDigitsFound();
-          if (mVerbose) {
-            LOG(info) << "mDigitWordsRead : " << mDigitWordsRead << " mem copy with offset of : " << cruhbfstartoffset << " parsing digits with linkstart: " << linkstart << " ending at : " << linkend << " linkhbf start pos:" << hbfoffsetatstartoflink;
-          }
-          mHBFoffset32 += mDigitWordsRead + mDigitWordsRejected; // all 3 in 32bit units
-          mTotalDigitWordsRead += mDigitWordsRead;
-          mTotalDigitWordsRejected += mDigitWordsRejected;
-        } else {
+        if (mDigitHCHeader.major == 0x47) {
+          // config event so ignore for now and bail out of parsing.
           if (mMaxWarnPrinted > 0) {
-            LOG(warn) << "Digit format not configured ! major.minor in : 0x" << std::hex << mDigitHCHeader.major << ".0x" << mDigitHCHeader.minor;
+            LOG(warn) << " HCHeader major version is 0x47 bailing out of parsing this as its a config event";
             checkNoWarn();
           }
+          //advance data pointers to the end;
+          //mHBFoffset32 = std::distance(mHBFPayload.begin(),linkend);//dataoffsetstart32 + currentlinksize; // go to the end of the link
           mHBFoffset32 = std::distance(mHBFPayload.begin(), linkend); //currentlinksize-mTrackletWordsRead-sizeof(digitHCHeader)/4; // advance to the end of the link
           mTotalDigitWordsRejected += std::distance(linkstart + mTrackletWordsRead + sizeof(DigitHCHeader) / 4, linkend);
           linkstart = linkend;
+        } else {
+          if (((mDigitHCHeader.major & 0x27) == mDigitHCHeader.major) || ((mDigitHCHeader.major & 0x37) == mDigitHCHeader.major) || ((mDigitHCHeader.major & 0x17) == mDigitHCHeader.major)) {
+            //                ZS                                                          DisableTracklets
+            mDigitWordsRead = 0;
+            auto digitsparsingstart = std::chrono::high_resolution_clock::now();
+            //linkstart and linkend already have the multiple cruheaderoffsets built in
+            mDigitWordsRead = mDigitsParser.Parse(&mHBFPayload, linkstart, linkend, mDetector[mWhichData], mStack[mWhichData], mLayer[mWhichData], mSide[mWhichData], mDigitHCHeader, mFEEID, currentlinkindex, mCurrentEvent, mOptions, cleardigits);
+            std::chrono::duration<double, std::micro> digitsparsingtime = std::chrono::high_resolution_clock::now() - trackletparsingstart;
+            if (mRootOutput) {
+              mDigitTiming->Fill((int)std::chrono::duration_cast<std::chrono::microseconds>(digitsparsingtime).count());
+            }
+            mDigitWordsRejected = mDigitsParser.getDumpedDataCount();
+            if (mHeaderVerbose) {
+              if (mDigitsParser.getDumpedDataCount() != 0) {
+                LOG(info) << "FEEID: " << mFEEID.word << " LINK #" << oriindex << " bad datacount:" << mDigitsParser.getDataWordsParsed() << "::" << mDigitsParser.getDumpedDataCount();
+              } else {
+                LOG(info) << "FEEID: " << mFEEID.word << " LINK #" << oriindex << " good datacount:" << mDigitsParser.getDataWordsParsed() << "::" << mDigitsParser.getDumpedDataCount();
+              }
+            }
+            if (mDigitWordsRead + mDigitWordsRejected != std::distance(linkstart, linkend)) {
+              //we have the data corruption problem of a pile of stuff at the end of a link, jump over it.
+              if (mFixDigitEndCorruption) {
+                mDigitWordsRead = std::distance(linkstart, linkend);
+              } else {
+                increment2dHist(TRDParsingDigitDataStillOnLink, mFEEID.supermodule * 2 + mFEEID.side, mStack[0], mLayer[0]);
+              }
+            }
+            mTotalDigitsFound += mDigitsParser.getDigitsFound();
+            if (mVerbose) {
+              LOG(info) << "mDigitWordsRead : " << mDigitWordsRead << " mem copy with offset of : " << cruhbfstartoffset << " parsing digits with linkstart: " << linkstart << " ending at : " << linkend << " linkhbf start pos:" << hbfoffsetatstartoflink;
+            }
+            mHBFoffset32 += mDigitWordsRead + mDigitWordsRejected; // all 3 in 32bit units
+            mTotalDigitWordsRead += mDigitWordsRead;
+            mTotalDigitWordsRejected += mDigitWordsRejected;
+          } else {
+            if (mMaxWarnPrinted > 0) {
+              LOG(warn) << "Digit format not configured ! major.minor in : 0x" << std::hex << mDigitHCHeader.major << ".0x" << mDigitHCHeader.minor;
+              checkNoWarn();
+            }
+            mHBFoffset32 = std::distance(mHBFPayload.begin(), linkend); //currentlinksize-mTrackletWordsRead-sizeof(digitHCHeader)/4; // advance to the end of the link
+            mTotalDigitWordsRejected += std::distance(linkstart + mTrackletWordsRead + sizeof(DigitHCHeader) / 4, linkend);
+            linkstart = linkend;
+          }
         }
-      }
       } else {
-        if (mRootOutput) {
+        if (mRootOutput && mCurrentHalfCRUHeader.EventType == o2::trd::constants::ETYPECALIBRATIONTRIGGER) {
           mDataVersions->Fill(0);
           mDataVersionsMajor->Fill(0);
         }
@@ -670,8 +658,6 @@ bool CruRawReader::buildCRUPayLoad()
   int cruid = 0;
   int additionalBytes = -1;
   int crudatasize = -1;
-  LOG(info) << "--- Build CRU Payload, added " << additionalBytes << " bytes to CRU "
-            << cruid << " with new size " << crudatasize;
   return true;
 }
 

--- a/Detectors/TRD/reconstruction/src/DigitsParser.cxx
+++ b/Detectors/TRD/reconstruction/src/DigitsParser.cxx
@@ -135,7 +135,6 @@ int DigitsParser::Parse(bool verbose)
       //state *should* be StateDigitMCMData check that it is
       if (mState == StateDigitMCMData || mState == StateDigitEndMarker || mState == StateDigitHCHeader || mState == StateDigitMCMHeader) {
       } else {
-        //LOG(warn) << "Digit end marker found but state is not StateDigitMCMData(" << StateDigitMCMData << ") or StateDigit but rather " << mState;
         // mEventRecord.ErrorStats[TRDParsingDigitEndMarkerWrongState]++;
         if (mOptions[TRDEnableRootOutputBit]) {
           mParsingErrors->Fill(TRDParsingDigitEndMarkerWrongState);
@@ -164,7 +163,6 @@ int DigitsParser::Parse(bool verbose)
         }
         //checkDigitMCMHeader(mDigitMCMHeader,lastmcmreader,lastrobread,lastevencounterread):
         if (!digitMCMHeaderSanityCheck(mDigitMCMHeader)) {
-          //LOG(warn) << "***DigitMCMHeader Sanity Check Failure 0x" << std::hex << *word << " at offset " << std::distance(mStartParse, word);
           // mEventRecord.ErrorStats[TRDParsingDigitMCMHeaderSanityCheckFailure]++;
           if (mOptions[TRDEnableRootOutputBit]) {
             mParsingErrors->Fill(TRDParsingDigitMCMHeaderSanityCheckFailure);
@@ -183,7 +181,6 @@ int DigitsParser::Parse(bool verbose)
           lastmcmread = 0;
         } else {
           if (mDigitMCMHeader->rob < lastrobread) {
-            //LOG(warn) << "**DigitMCMHeader ROB number is not increasing was:" << lastrobread << " now:" << mDigitMCMHeader->rob << " 0x" << std::hex << *word << " at offset " << std::distance(mStartParse, word);
             // mEventRecord.ErrorStats[TRDParsingDigitROBDecreasing]++;
             if (mOptions[TRDEnableRootOutputBit]) {
               mParsingErrors->Fill(TRDParsingDigitROBDecreasing);
@@ -197,7 +194,6 @@ int DigitsParser::Parse(bool verbose)
           //the case of rob not changing we ignore, error condition handled by mcm # increasing.
         }
         if (mDigitMCMHeader->mcm < lastmcmread && mDigitMCMHeader->rob == lastrobread) {
-          //LOG(warn) << "**DigitMCMHeader MCM number is not increasing 0x" << std::hex << *word << " at offset " << std::distance(mStartParse, word);
           // mEventRecord.ErrorStats[TRDParsingDigitMCMNotIncreasing]++;
           if (mOptions[TRDEnableRootOutputBit]) {
             mParsingErrors->Fill(TRDParsingDigitMCMNotIncreasing);
@@ -222,7 +218,6 @@ int DigitsParser::Parse(bool verbose)
             LOG(info) << "**DigitADCMask is " << std::hex << mDigitMCMADCMask->adcmask << " raw form : 0x" << std::hex << mDigitMCMADCMask->word << " at offset " << std::distance(mStartParse, word);
           }
           if (word == mEndParse) {
-            //LOG(warn) << "we have a problem we have advanced from MCMHeader to the adcmask but are now at the end of the loop";
             // mEventRecord.ErrorStats[TRDParsingDigitADCMaskAdvanceToEnd]++;
             if (mOptions[TRDEnableRootOutputBit]) {
               mParsingErrors->Fill(TRDParsingDigitADCMaskAdvanceToEnd);
@@ -233,7 +228,6 @@ int DigitsParser::Parse(bool verbose)
           bitsinmask = adcmask.count();
           //check ADCMask:
           if (!digitMCMADCMaskSanityCheck(*mDigitMCMADCMask, bitsinmask)) {
-            //LOG(info) << "**DigitADCMask SANITY CHECK FAILURE " << std::hex << mDigitMCMADCMask->adcmask << " raw form : 0x" << std::hex << mDigitMCMADCMask->word << " at offset " << std::distance(mStartParse, word);
             // mEventRecord.ErrorStats[TRDParsingDigitADCMaskMismatch]++;
             if (mOptions[TRDEnableRootOutputBit]) {
               mParsingErrors->Fill(TRDParsingDigitADCMaskMismatch);
@@ -308,7 +302,6 @@ int DigitsParser::Parse(bool verbose)
               //we are at the end
               // do nothing.
             }
-            //mEventRecord.ErrorStats[TRDParsingDigitEndMarkerStateButReadingMCMADCData]++;
             if (mOptions[TRDEnableRootOutputBit]) {
               mParsingErrors->Fill(TRDParsingDigitEndMarkerStateButReadingMCMADCData);
               increment2dHist(TRDParsingDigitEndMarkerStateButReadingMCMADCData);
@@ -361,7 +354,6 @@ int DigitsParser::Parse(bool verbose)
               }
             }
             if (mDigitWordCount > constants::TIMEBINS / 3) {
-              // LOG(error) << "***DigitMCMData with more than 10 adc's! currently on 0x" << std::hex << *word << " at offset " << std::distance(mStartParse, word);
               //mEventRecord.ErrorStats[TRDParsingDigitGT10ADCs]++;
               if (mOptions[TRDEnableRootOutputBit]) {
                 mParsingErrors->Fill(TRDParsingDigitGT10ADCs);
@@ -389,7 +381,6 @@ int DigitsParser::Parse(bool verbose)
               mADCValues[digittimebinoffset++] = mDigitMCMData->x;
 
               if (digittimebinoffset > constants::TIMEBINS) {
-                //LOG(error) << "too many timebins to insert into mADCValues digittimebinoffset:" << digittimebinoffset;
                 //mEventRecord.ErrorStats[TRDParsingDigitExcessTimeBins]++;
                 if (mOptions[TRDEnableRootOutputBit]) {
                   mParsingErrors->Fill(TRDParsingDigitExcessTimeBins);
@@ -397,7 +388,6 @@ int DigitsParser::Parse(bool verbose)
                 }
                 //bale out TODO
                 mWordsDumped += std::distance(word, mEndParse) - 1;
-                //LOG(error) << " dumping the rest of this digitparsing buffer of " << mWordsDumped;
                 word = mEndParse;
               }
               if (mVerbose || mDataVerbose) {
@@ -430,7 +420,6 @@ int DigitsParser::Parse(bool verbose)
     //end of data so
   } // for loop over word
   if (!(mState == StateDigitMCMHeader || mState == StatePadding || mState == StateDigitEndMarker)) {
-    // LOG(warn) << "Exiting parsing but the state is wrong ... mState= " << mState;
     //mEventRecord.ErrorStats[TRDParsingDigitParsingExitInWrongState]++;
     if (mOptions[TRDEnableRootOutputBit]) {
       mParsingErrors->Fill(TRDParsingDigitParsingExitInWrongState);

--- a/Detectors/TRD/simulation/src/Trap2CRU.cxx
+++ b/Detectors/TRD/simulation/src/Trap2CRU.cxx
@@ -314,7 +314,7 @@ uint32_t Trap2CRU::buildHalfCRUHeader(HalfCRUHeader& header, const uint32_t bc, 
 {
   int bunchcrossing = bc;
   int stopbits = 0x01; // do we care about this and eventtype in simulations?
-  int eventtype = 0x01;
+  int eventtype = o2::trd::constants::ETYPECALIBRATIONTRIGGER;
   int crurdhversion = 6;
   int feeid = 0;
   int cruid = 0;


### PR DESCRIPTION
Change over from using half chamber headers to event type field of cru half chamber header.
It started being filled correctly on thursday(?)

Implemented this as 
PhysicsTrigger = 0x2 (no digits, no half chamber header)
Calibration Trigger=0x1 (possibly digits, definitely half chamber header)
Which is the reverse of what I was told, but seems to reflect what is in the data.
By the time this gets through CI, I will have confirmation.
Fix the mc2raw to use the constants.

This removes the logging that was seen over the weekend.
Tested in FST and with the trap2raw.

Some other clean ups.