### PR TITLE
[MCH] add cluster root I/O workflows

### DIFF
--- a/Detectors/MUON/MCH/Workflow/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Workflow/CMakeLists.txt
@@ -13,6 +13,8 @@
 o2_add_library(MCHWorkflow
                SOURCES
                    src/ClusterFinderOriginalSpec.cxx
+                   src/ClusterReaderSpec.cxx
+                   src/ClusterWriterSpec.cxx
                    src/DataDecoderSpec.cxx
                    src/EntropyDecoderSpec.cxx
                    src/TimeClusterFinderSpec.cxx
@@ -112,6 +114,18 @@ o2_add_executable(
         SOURCES src/clusters-sampler-workflow.cxx
         COMPONENT_NAME mch
         PUBLIC_LINK_LIBRARIES O2::Framework O2::DataFormatsMCH O2::MCHBase)
+
+o2_add_executable(
+        clusters-writer-workflow
+        SOURCES src/clusters-writer-workflow.cxx
+        COMPONENT_NAME mch
+        PUBLIC_LINK_LIBRARIES O2::MCHWorkflow)
+
+o2_add_executable(
+        clusters-reader-workflow
+        SOURCES src/clusters-reader-workflow.cxx
+        COMPONENT_NAME mch
+        PUBLIC_LINK_LIBRARIES O2::MCHWorkflow)
 
 o2_add_executable(
         clusters-to-tracks-original-workflow

--- a/Detectors/MUON/MCH/Workflow/README.md
+++ b/Detectors/MUON/MCH/Workflow/README.md
@@ -21,12 +21,14 @@
 * [Samplers](#samplers)
   * [Digit sampler](#digit-sampler)
   * [Cluster sampler](#cluster-sampler)
+  * [Cluster reader](#cluster-reader)
   * [Track sampler](#track-sampler)
   * [Track reader](#track-reader)
   * [Vertex sampler](#vertex-sampler)
 * [Sinks](#sinks)
   * [Precluster sink](#precluster-sink)
   * [Cluster sink](#cluster-sink)
+  * [Cluster writer](#cluster-writer)
   * [Track sink](#track-sink)
   * [Track writer](#track-writer)
 
@@ -106,7 +108,7 @@ Option `--check-no-leftover-digits xxx` allows to drop an error message (`xxx = 
 o2-mch-preclusters-to-clusters-original-workflow
 ```
 
-Take as input the list of all preclusters ([PreCluster](../Base/include/MCHBase/PreCluster.h)) in the current time frame, the list of all associated digits ([Digit](/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the preclusters associated to each interaction, with the data description "PRECLUSTERS", "PRECLUSTERDIGITS" and "PRECLUSTERROFS", respectively. Send the list of all clusters ([ClusterStruct](../include/DataFormatsMCH/ClusterBlock.h)) in the time frame, the list of all associated digits ([Digit](/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the clusters associated to each interaction in three separate messages with the data description "CLUSTERS", "CLUSTERDIGITS" and "CLUSTERROFS", respectively.
+Take as input the list of all preclusters ([PreCluster](../Base/include/MCHBase/PreCluster.h)) in the current time frame, the list of all associated digits ([Digit](/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the preclusters associated to each interaction, with the data description "PRECLUSTERS", "PRECLUSTERDIGITS" and "PRECLUSTERROFS", respectively. Send the list of all clusters ([ClusterStruct](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ClusterBlock.h)) in the time frame, the list of all associated digits ([Digit](/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the clusters associated to each interaction in three separate messages with the data description "CLUSTERS", "CLUSTERDIGITS" and "CLUSTERROFS", respectively.
 
 Option `--run2-config` allows to configure the clustering to process run2 data.
 
@@ -147,7 +149,7 @@ The decoding is done automatically by the `o2-ctf-reader-workflow`.
 
 ## Local to global cluster transformation
 
-The `o2-mch-clusters-transformer-workflow` takes as input the list of all clusters ([ClusterStruct](../include/DataFormatsMCH/ClusterBlock.h)), in local reference frame, in the current time frame, with the data description "CLUSTERS".
+The `o2-mch-clusters-transformer-workflow` takes as input the list of all clusters ([ClusterStruct](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ClusterBlock.h)), in local reference frame, in the current time frame, with the data description "CLUSTERS".
 
 It sends the list of the same clusters, but converted in global reference frame, with the data description "GLOBALCLUSTERS".
 
@@ -170,7 +172,7 @@ o2-mch-clusters-sink-workflow
 o2-mch-clusters-to-tracks-original-workflow
 ```
 
-Take as input the list of all clusters ([ClusterStruct](../include/DataFormatsMCH/ClusterBlock.h)) in the current time frame, with the data description "CLUSTERS", and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the clusters associated to each interaction, with the data description "CLUSTERROFS". Send the list of all MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)) in the time frame, the list of all associated clusters ([ClusterStruct](../include/DataFormatsMCH/ClusterBlock.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the tracks associated to each interaction in three separate messages with the data description "TRACKS", "TRACKCLUSTERS" and "TRACKROFS", respectively.
+Take as input the list of all clusters ([ClusterStruct](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ClusterBlock.h)) in the current time frame, with the data description "CLUSTERS", and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the clusters associated to each interaction, with the data description "CLUSTERROFS". Send the list of all MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)) in the time frame, the list of all associated clusters ([ClusterStruct](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ClusterBlock.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the tracks associated to each interaction in three separate messages with the data description "TRACKS", "TRACKCLUSTERS" and "TRACKROFS", respectively.
 
 Options `--l3Current xxx` and `--dipoleCurrent yyy` allow to specify the current in L3 and in the dipole to be used to set the magnetic field.
 
@@ -236,7 +238,7 @@ Options `--l3Current xxx` and `--dipoleCurrent yyy` allow to specify the current
 o2-mch-tracks-to-tracks-workflow
 ```
 
-Take as input the list of all MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)) in the current time frame, the list of all associated clusters ([ClusterStruct](../include/DataFormatsMCH/ClusterBlock.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the tracks associated to each interaction, with the data description "TRACKSIN", "TRACKCLUSTERSIN" and "TRACKROFSIN", respectively. Send the list of all refitted MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)) in the time frame, the list of all associated clusters ([ClusterStruct](../include/DataFormatsMCH/ClusterBlock.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the tracks associated to each interaction in three separate messages with the data description "TRACKS", "TRACKCLUSTERS" and "TRACKROFS", respectively.
+Take as input the list of all MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)) in the current time frame, the list of all associated clusters ([ClusterStruct](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ClusterBlock.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the tracks associated to each interaction, with the data description "TRACKSIN", "TRACKCLUSTERSIN" and "TRACKROFSIN", respectively. Send the list of all refitted MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)) in the time frame, the list of all associated clusters ([ClusterStruct](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ClusterBlock.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the tracks associated to each interaction in three separate messages with the data description "TRACKS", "TRACKCLUSTERS" and "TRACKROFS", respectively.
 
 Options `--l3Current xxx` and `--dipoleCurrent yyy` allow to specify the current in L3 and in the dipole to be used to set the magnetic field.
 
@@ -275,12 +277,25 @@ where `clusters.in` is a binary file containing for each event:
 
 * number of clusters (int)
 * number of associated digits (int)
-* list of clusters ([ClusterStruct](../include/DataFormatsMCH/ClusterBlock.h))
+* list of clusters ([ClusterStruct](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ClusterBlock.h))
 * list of associated digits ([Digit](/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h))
 
-Send the list of all clusters ([ClusterStruct](../include/DataFormatsMCH/ClusterBlock.h)) in the current time frame, with the data description "CLUSTERS" (or "GLOBALCLUSTERS" if `--global` option is used), and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the clusters associated to each interaction, with the data description "CLUSTERROFS".
+Send the list of all clusters ([ClusterStruct](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ClusterBlock.h)) in the current time frame, with the data description "CLUSTERS" (or "GLOBALCLUSTERS" if `--global` option is used), and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the clusters associated to each interaction, with the data description "CLUSTERROFS".
 
 Option `--nEventsPerTF xxx` allows to set the number of events (i.e. ROF records) to send per time frame (default = 1).
+
+### Cluster reader
+
+```
+o2-mch-clusters-reader-workflow --infile mchclusters.root [--enable-mc] [--local] [--digits]
+```
+Send the list of all clusters ([ClusterStruct](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ClusterBlock.h)) in the current time frame, with the data description "GLOBALCLUSTERS", and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the clusters associated to each interaction, with the data description "CLUSTERROFS".
+
+Option `--local` assumes that clusters are in the local coordinate system and send them with the description "CLUSTERS".
+
+Option `--digits` allows to also send the associated digits ([Digit](/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h)) with the data description "CLUSTERDIGITS".
+
+Option `--enable-mc` allows to also send the cluster MC labels with the data description "CLUSTERLABELS".
 
 ### Track sampler
 
@@ -290,7 +305,7 @@ o2-mch-tracks-sampler-workflow --infile "tracks.in"
 
 where `tracks.in` is a binary file with the same format as the one written by the workflow [o2-mch-tracks-sink-workflow](#track-sink)
 
-Send the list of all MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)) in the current time frame, the list of all associated clusters ([ClusterStruct](../include/DataFormatsMCH/ClusterBlock.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the tracks associated to each interaction in three separate messages with the data description "TRACKS", "TRACKCLUSTERS" and "TRACKROFS", respectively.
+Send the list of all MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)) in the current time frame, the list of all associated clusters ([ClusterStruct](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ClusterBlock.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the tracks associated to each interaction in three separate messages with the data description "TRACKS", "TRACKCLUSTERS" and "TRACKROFS", respectively.
 
 Option `--forTrackFitter` allows to send the messages with the data description "TRACKSIN", "TRACKCLUSTERSIN" and TRACKROFSIN, respectively, as expected by the workflow [o2-mch-tracks-to-tracks-workflow](#track-fitter).
 
@@ -347,16 +362,29 @@ Option `--useRun2DigitUID` allows to convert the run3 pad ID stored in the digit
 o2-mch-clusters-sink-workflow --outfile "clusters.out" [--txt] [--no-digits] [--global]
 ```
 
-Take as input the list of all clusters ([ClusterStruct](../include/DataFormatsMCH/ClusterBlock.h)) in the current time frame, and, optionnally, the list of all associated digits ([Digit](/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the clusters associated to each interaction, with the data description "CLUSTERS" (or "GLOBALCLUSTERS" if `--global` option is used), "CLUSTERDIGITS" (unless `--no-digits` option is used) and "CLUSTERROFS", respectively, and write them event-by-event in the binary file `clusters.out` with the following format for each event:
+Take as input the list of all clusters ([ClusterStruct](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ClusterBlock.h)) in the current time frame, and, optionnally, the list of all associated digits ([Digit](/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the clusters associated to each interaction, with the data description "CLUSTERS" (or "GLOBALCLUSTERS" if `--global` option is used), "CLUSTERDIGITS" (unless `--no-digits` option is used) and "CLUSTERROFS", respectively, and write them event-by-event in the binary file `clusters.out` with the following format for each event:
 
 * number of clusters (int)
 * number of associated digits (int) (= 0 if `--no-digits` is used)
-* list of clusters ([ClusterStruct](../include/DataFormatsMCH/ClusterBlock.h))
+* list of clusters ([ClusterStruct](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ClusterBlock.h))
 * list of associated digits ([Digit](/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h))(unless option `--no-digits` is used)
 
 Option `--txt` allows to write the clusters in the output file in text format.
 
 Option `--useRun2DigitUID` allows to convert the run3 pad ID stored in the digit data member mPadID into a digit UID in run2 format.
+
+### Cluster writer
+
+```
+o2-mch-clusters-writer-workflow [--enable-mc] [--local] [--no-digits]
+```
+Take as input the list of all clusters ([ClusterStruct](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ClusterBlock.h)) in the current time frame, with the data description "GLOBALCLUSTERS", the list of associated digits ([Digit](/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h)), with the data description "CLUSTERDIGITS", and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the clusters associated to each interaction, with the data description "CLUSTERROFS", and write them in the root file "mchclusters.root".
+
+Option `--local` allows to write the list of clusters in the local coordinate system, with the data description "CLUSTERS".
+
+Option `--no-digits` allows to do not write the associated digits.
+
+Option `--enable-mc` allows to also write the cluster MC labels, with the data description "CLUSTERLABELS".
 
 ### Track sink
 
@@ -364,14 +392,14 @@ Option `--useRun2DigitUID` allows to convert the run3 pad ID stored in the digit
 o2-mch-tracks-sink-workflow --outfile "tracks.out"
 ```
 
-Take as input the list of all tracks at vertex ([TrackAtVtxStruct](#track-extrapolation-to-vertex)) in the current time frame, the list of all MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)), the list of all associated clusters ([ClusterStruct](../include/DataFormatsMCH/ClusterBlock.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the MCH tracks associated to each interaction, with the data description "TRACKSATVERTEX", "TRACKS", "TRACKCLUSTERS" and "TRACKROFS", respectively, and write them event-by-event in the binary file `tracks.out` with the following format for each event:
+Take as input the list of all tracks at vertex ([TrackAtVtxStruct](#track-extrapolation-to-vertex)) in the current time frame, the list of all MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)), the list of all associated clusters ([ClusterStruct](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ClusterBlock.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the MCH tracks associated to each interaction, with the data description "TRACKSATVERTEX", "TRACKS", "TRACKCLUSTERS" and "TRACKROFS", respectively, and write them event-by-event in the binary file `tracks.out` with the following format for each event:
 
 * number of tracks at vertex (int)
 * number of MCH tracks (int)
 * number of associated clusters (int)
 * list of tracks at vertex ([TrackAtVtxStruct](#track-extrapolation-to-vertex))
 * list of MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h))
-* list of associated clusters ([ClusterStruct](../include/DataFormatsMCH/ClusterBlock.h))
+* list of associated clusters ([ClusterStruct](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ClusterBlock.h))
 
 Option `--tracksAtVertexOnly` allows to take as input and write only the tracks at vertex (number of MCH tracks and number of associated clusters = 0).
 

--- a/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/ClusterReaderSpec.h
+++ b/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/ClusterReaderSpec.h
@@ -1,0 +1,23 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_MCH_WORKFLOW_CLUSTER_READER_SPEC_H
+#define O2_MCH_WORKFLOW_CLUSTER_READER_SPEC_H
+
+#include "Framework/DataProcessorSpec.h"
+
+namespace o2::mch
+{
+o2::framework::DataProcessorSpec getClusterReaderSpec(bool useMC, const char* specName = "mch-cluster-reader",
+                                                      bool global = true, bool digits = false);
+} // namespace o2::mch
+
+#endif

--- a/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/ClusterWriterSpec.h
+++ b/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/ClusterWriterSpec.h
@@ -1,0 +1,23 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_MCH_WORKFLOW_CLUSTER_WRITER_SPEC_H
+#define O2_MCH_WORKFLOW_CLUSTER_WRITER_SPEC_H
+
+#include "Framework/DataProcessorSpec.h"
+
+namespace o2::mch
+{
+o2::framework::DataProcessorSpec getClusterWriterSpec(bool useMC, const char* specName = "mch-cluster-writer",
+                                                      bool global = true, bool digits = true);
+}
+
+#endif

--- a/Detectors/MUON/MCH/Workflow/src/ClusterReaderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/ClusterReaderSpec.cxx
@@ -1,0 +1,125 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "MCHWorkflow/ClusterReaderSpec.h"
+
+#include <iostream>
+#include <vector>
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "Framework/Lifetime.h"
+#include "Framework/Logger.h"
+#include "Framework/Task.h"
+#include "DPLUtils/RootTreeReader.h"
+#include "SimulationDataFormat/MCTruthContainer.h"
+#include "SimulationDataFormat/MCCompLabel.h"
+#include "DataFormatsMCH/ROFRecord.h"
+#include "DataFormatsMCH/ClusterBlock.h"
+#include "DataFormatsMCH/Digit.h"
+
+using namespace o2::framework;
+
+namespace o2::mch
+{
+
+struct ClusterReader {
+  std::unique_ptr<RootTreeReader> mTreeReader;
+  bool mUseMC = false;
+  bool mGlobal = false;
+  bool mDigits = false;
+
+  ClusterReader(bool useMC, bool global, bool digits) : mUseMC(useMC), mGlobal(global), mDigits(digits) {}
+
+  void init(InitContext& ic)
+  {
+    auto treeName = "o2sim";
+    auto fileName = ic.options().get<std::string>("infile");
+    auto nofEntries{-1};
+    auto clusterDescription = mGlobal ? header::DataDescription{"GLOBALCLUSTERS"} : header::DataDescription{"CLUSTERS"};
+
+    if (mUseMC) {
+      if (mDigits) {
+        mTreeReader = std::make_unique<RootTreeReader>(
+          treeName,
+          fileName.c_str(),
+          nofEntries,
+          RootTreeReader::PublishingMode::Single,
+          RootTreeReader::BranchDefinition<std::vector<ClusterStruct>>{Output{"MCH", clusterDescription, 0}, "clusters"},
+          RootTreeReader::BranchDefinition<std::vector<ROFRecord>>{Output{"MCH", "CLUSTERROFS", 0}, "clusterrofs"},
+          RootTreeReader::BranchDefinition<std::vector<Digit>>{Output{"MCH", "CLUSTERDIGITS", 0}, "clusterdigits"},
+          RootTreeReader::BranchDefinition<dataformats::MCTruthContainer<MCCompLabel>>{Output{"MCH", "CLUSTERLABELS", 0}, "clusterlabels"});
+      } else {
+        mTreeReader = std::make_unique<RootTreeReader>(
+          treeName,
+          fileName.c_str(),
+          nofEntries,
+          RootTreeReader::PublishingMode::Single,
+          RootTreeReader::BranchDefinition<std::vector<ClusterStruct>>{Output{"MCH", clusterDescription, 0}, "clusters"},
+          RootTreeReader::BranchDefinition<std::vector<ROFRecord>>{Output{"MCH", "CLUSTERROFS", 0}, "clusterrofs"},
+          RootTreeReader::BranchDefinition<dataformats::MCTruthContainer<MCCompLabel>>{Output{"MCH", "CLUSTERLABELS", 0}, "clusterlabels"});
+      }
+    } else {
+      if (mDigits) {
+        mTreeReader = std::make_unique<RootTreeReader>(
+          treeName,
+          fileName.c_str(),
+          nofEntries,
+          RootTreeReader::PublishingMode::Single,
+          RootTreeReader::BranchDefinition<std::vector<ClusterStruct>>{Output{"MCH", clusterDescription, 0}, "clusters"},
+          RootTreeReader::BranchDefinition<std::vector<ROFRecord>>{Output{"MCH", "CLUSTERROFS", 0}, "clusterrofs"},
+          RootTreeReader::BranchDefinition<std::vector<Digit>>{Output{"MCH", "CLUSTERDIGITS", 0}, "clusterdigits"});
+      } else {
+        mTreeReader = std::make_unique<RootTreeReader>(
+          treeName,
+          fileName.c_str(),
+          nofEntries,
+          RootTreeReader::PublishingMode::Single,
+          RootTreeReader::BranchDefinition<std::vector<ClusterStruct>>{Output{"MCH", clusterDescription, 0}, "clusters"},
+          RootTreeReader::BranchDefinition<std::vector<ROFRecord>>{Output{"MCH", "CLUSTERROFS", 0}, "clusterrofs"});
+      }
+    }
+  }
+
+  void run(ProcessingContext& pc)
+  {
+    if (mTreeReader->next()) {
+      (*mTreeReader)(pc);
+    } else {
+      pc.services().get<ControlService>().endOfStream();
+    }
+  }
+};
+
+DataProcessorSpec getClusterReaderSpec(bool useMC, const char* specName, bool global, bool digits)
+{
+  auto clusterDescription = global ? header::DataDescription{"GLOBALCLUSTERS"} : header::DataDescription{"CLUSTERS"};
+  std::vector<OutputSpec> outputSpecs;
+  outputSpecs.emplace_back(OutputSpec{{"clusters"}, "MCH", clusterDescription, 0, Lifetime::Timeframe});
+  outputSpecs.emplace_back(OutputSpec{{"clusterrofs"}, "MCH", "CLUSTERROFS", 0, Lifetime::Timeframe});
+  if (digits) {
+    outputSpecs.emplace_back(OutputSpec{{"clusterdigits"}, "MCH", "CLUSTERDIGITS", 0, Lifetime::Timeframe});
+  }
+  if (useMC) {
+    outputSpecs.emplace_back(OutputSpec{{"clusterlabels"}, "MCH", "CLUSTERLABELS", 0, Lifetime::Timeframe});
+  }
+
+  auto options = Options{
+    {"infile", VariantType::String, "mchclusters.root", {"name of the input cluster file"}},
+  };
+
+  return DataProcessorSpec{
+    specName,
+    Inputs{},
+    outputSpecs,
+    adaptFromTask<ClusterReader>(useMC, global, digits),
+    options};
+}
+} // namespace o2::mch

--- a/Detectors/MUON/MCH/Workflow/src/ClusterWriterSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/ClusterWriterSpec.cxx
@@ -1,0 +1,43 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "MCHWorkflow/ClusterWriterSpec.h"
+
+#include <vector>
+#include "Framework/Logger.h"
+#include "DPLUtils/MakeRootTreeWriterSpec.h"
+#include "SimulationDataFormat/MCTruthContainer.h"
+#include "SimulationDataFormat/MCCompLabel.h"
+#include "DataFormatsMCH/ROFRecord.h"
+#include "DataFormatsMCH/ClusterBlock.h"
+#include "DataFormatsMCH/Digit.h"
+
+using namespace o2::framework;
+
+namespace o2::mch
+{
+
+template <typename T>
+using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
+
+DataProcessorSpec getClusterWriterSpec(bool useMC, const char* specName, bool global, bool digits)
+{
+  auto clusterDescription = global ? header::DataDescription{"GLOBALCLUSTERS"} : header::DataDescription{"CLUSTERS"};
+  return MakeRootTreeWriterSpec(specName,
+                                "mchclusters.root",
+                                MakeRootTreeWriterSpec::TreeAttributes{"o2sim", "Tree MCH Clusters"},
+                                BranchDefinition<std::vector<ClusterStruct>>{InputSpec{"clusters", "MCH", clusterDescription}, "clusters"},
+                                BranchDefinition<std::vector<ROFRecord>>{InputSpec{"clusterrofs", "MCH", "CLUSTERROFS"}, "clusterrofs"},
+                                BranchDefinition<std::vector<Digit>>{InputSpec{"clusterdigits", "MCH", "CLUSTERDIGITS"}, "clusterdigits", digits ? 1 : 0},
+                                BranchDefinition<dataformats::MCTruthContainer<MCCompLabel>>{InputSpec{"clusterlabels", "MCH", "CLUSTERLABELS"}, "clusterlabels", useMC ? 1 : 0})();
+}
+
+} // namespace o2::mch

--- a/Detectors/MUON/MCH/Workflow/src/clusters-reader-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/clusters-reader-workflow.cxx
@@ -1,0 +1,34 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <vector>
+#include "Framework/ConfigParamSpec.h"
+#include "MCHWorkflow/ClusterReaderSpec.h"
+
+using namespace o2::framework;
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  workflowOptions.emplace_back("enable-mc", VariantType::Bool, false, ConfigParamSpec::HelpString{"Propagate MC info"});
+  workflowOptions.emplace_back("local", VariantType::Bool, false, ConfigParamSpec::HelpString{"Read clusters in local reference frame"});
+  workflowOptions.emplace_back("digits", VariantType::Bool, false, ConfigParamSpec::HelpString{"Read the associated digits"});
+}
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(const ConfigContext& config)
+{
+  bool useMC = config.options().get<bool>("enable-mc");
+  bool global = !config.options().get<bool>("local");
+  bool digits = config.options().get<bool>("digits");
+  return WorkflowSpec{o2::mch::getClusterReaderSpec(useMC, "mch-cluster-reader", global, digits)};
+}

--- a/Detectors/MUON/MCH/Workflow/src/clusters-writer-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/clusters-writer-workflow.cxx
@@ -1,0 +1,34 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <vector>
+#include "Framework/ConfigParamSpec.h"
+#include "MCHWorkflow/ClusterWriterSpec.h"
+
+using namespace o2::framework;
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  workflowOptions.emplace_back("enable-mc", VariantType::Bool, false, ConfigParamSpec::HelpString{"Propagate MC info"});
+  workflowOptions.emplace_back("local", VariantType::Bool, false, ConfigParamSpec::HelpString{"Write clusters in local reference frame"});
+  workflowOptions.emplace_back("no-digits", VariantType::Bool, false, ConfigParamSpec::HelpString{"Do not write associated digits"});
+}
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(const ConfigContext& config)
+{
+  bool useMC = config.options().get<bool>("enable-mc");
+  bool global = !config.options().get<bool>("local");
+  bool digits = !config.options().get<bool>("no-digits");
+  return WorkflowSpec{o2::mch::getClusterWriterSpec(useMC, "mch-cluster-writer", global, digits)};
+}


### PR DESCRIPTION
Add 2 workflows to read and write the clusters and the ROF they belong to in root format and update the documentation.

By default, clusters are supposed to be in the global coordinate system (with data description GLOBALCLUSTERS). An option (--local) allows to read/write clusters in the local coordinate system (with data description CLUSTERS).

Writing/reading of the digits associated to each clusters can optionally be deactivated/activated.

Writing/reading of the cluster MC labels can also be optionally activated (in prevision for when the labels will actually exist)
