### PR TITLE
Add MID tracks/clusters to RecoContainer + fixes for AODProduces

### DIFF
--- a/DataFormats/Detectors/GlobalTracking/CMakeLists.txt
+++ b/DataFormats/Detectors/GlobalTracking/CMakeLists.txt
@@ -18,6 +18,7 @@ o2_add_library(
     O2::DataFormatsITS
     O2::DataFormatsMFT
     O2::DataFormatsMCH
+    O2::DataFormatsMID
     O2::DataFormatsFT0
     O2::DataFormatsFV0
     O2::DataFormatsFDD

--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
@@ -74,6 +74,15 @@ class ROFRecord;
 class ClusterStruct;
 } // namespace o2::mch
 
+namespace o2::mid
+{
+class Cluster2D;
+class Cluster3D;
+class ROFRecord;
+class Track;
+class MCClusterLabel;
+} // namespace o2::mid
+
 namespace o2::itsmft
 {
 class ROFRecord;
@@ -182,6 +191,7 @@ struct DataRequest {
   void requestITSTracks(bool mc);
   void requestMFTTracks(bool mc);
   void requestMCHTracks(bool mc);
+  void requestMIDTracks(bool mc);
   void requestTPCTracks(bool mc);
   void requestITSTPCTracks(bool mc);
   void requestGlobalFwdTracks(bool mc);
@@ -281,6 +291,7 @@ struct RecoContainer {
   std::unique_ptr<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>> mcCPVClusters;
   std::unique_ptr<const o2::dataformats::MCTruthContainer<o2::phos::MCLabel>> mcPHSCells;
   std::unique_ptr<const o2::dataformats::MCTruthContainer<o2::emcal::MCLabel>> mcEMCCells;
+  std::unique_ptr<const o2::dataformats::MCTruthContainer<o2::mid::MCClusterLabel>> mcMIDTrackClusters;
 
   gsl::span<const unsigned char> clusterShMapTPC; ///< externally set TPC clusters sharing map
 
@@ -296,6 +307,7 @@ struct RecoContainer {
   void addITSTracks(o2::framework::ProcessingContext& pc, bool mc);
   void addMFTTracks(o2::framework::ProcessingContext& pc, bool mc);
   void addMCHTracks(o2::framework::ProcessingContext& pc, bool mc);
+  void addMIDTracks(o2::framework::ProcessingContext& pc, bool mc);
   void addTPCTracks(o2::framework::ProcessingContext& pc, bool mc);
 
   void addITSTPCTRDTracks(o2::framework::ProcessingContext& pc, bool mc);
@@ -440,7 +452,15 @@ struct RecoContainer {
   auto getMCHTracksROFRecords() const { return getSpan<o2::mch::ROFRecord>(GTrackID::MCH, TRACKREFS); }
   auto getMCHTrackClusters() const { return getSpan<o2::mch::ClusterStruct>(GTrackID::MCH, CLUSREFS); }
   auto getMCHTracksMCLabels() const { return getSpan<o2::MCCompLabel>(GTrackID::MCH, MCLABELS); }
-  // FIXME: add clusters
+
+  // MID
+  const o2::mid::Track& getMIDTrack(GTrackID gid) const { return getTrack<o2::mid::Track>(gid); }
+  auto getMIDTracks() const { return getTracks<o2::mid::Track>(GTrackID::MID); }
+  auto getMIDTracksROFRecords() const { return getSpan<o2::mid::ROFRecord>(GTrackID::MID, TRACKREFS); }
+  auto getMIDTrackClusters() const { return getSpan<o2::mid::Cluster3D>(GTrackID::MID, CLUSREFS); }
+  auto getMIDTrackClustersROFRecords() const { return getSpan<o2::mid::ROFRecord>(GTrackID::MID, MATCHES); }
+  auto getMIDTracksMCLabels() const { return getSpan<o2::MCCompLabel>(GTrackID::MID, MCLABELS); }
+  const o2::dataformats::MCTruthContainer<o2::mid::MCClusterLabel>* getMIDTracksClusterMCLabels() const;
 
   // TPC
   const o2::tpc::TrackTPC& getTPCTrack(GTrackID id) const { return getTrack<o2::tpc::TrackTPC>(id); }

--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h
@@ -11,7 +11,7 @@
 
 /// \file RecoContainerCreateTracksVariadic.h
 /// \brief Wrapper container for different reconstructed object types
-/// \author ruben.shahoyan@cern.ch
+/// \author ruben.shahoyan@cern.chM
 
 #include "Framework/ProcessingContext.h"
 #include "Framework/InputSpec.h"
@@ -21,9 +21,16 @@
 #include "DataFormatsITSMFT/CompCluster.h"
 #include "DataFormatsITS/TrackITS.h"
 #include "DataFormatsMFT/TrackMFT.h"
+
 #include "DataFormatsMCH/TrackMCH.h"
 #include "DataFormatsMCH/ClusterBlock.h"
 #include "DataFormatsMCH/ROFRecord.h"
+
+#include "DataFormatsMID/ROFRecord.h"
+#include "DataFormatsMID/Cluster3D.h"
+#include "DataFormatsMID/Track.h"
+#include "DataFormatsMID/MCClusterLabel.h"
+
 #include "DataFormatsTPC/TrackTPC.h"
 #include "DataFormatsTOF/Cluster.h"
 #include "DataFormatsITSMFT/ROFRecord.h"

--- a/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
+++ b/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
@@ -379,6 +379,22 @@ void DataRequest::requestTracks(GTrackID::mask_t src, bool useMC)
   if (src[GTrackID::TPCTRD]) {
     requestTPCTRDTracks(useMC);
   }
+
+  if (src[GTrackID::FT0]) {
+    requestFT0RecPoints(false); // RS FIXME: at the moment does not support MC
+  }
+  if (src[GTrackID::FV0]) {
+    requestFV0RecPoints(false); // RS FIXME: at the moment does not support MC
+  }
+  if (src[GTrackID::FDD]) {
+    requestFDDRecPoints(false); // RS FIXME: at the moment does not support MC
+  }
+  if (src[GTrackID::ZDC]) {
+    requestZDCRecEvents(false); // RS FIXME: at the moment does not support MC
+  }
+  if (GTrackID::includesDet(DetID::CTP, src)) {
+    requestCTPDigits(false); // RS FIXME: at the moment does not support MC
+  }
 }
 
 void DataRequest::requestClusters(GTrackID::mask_t src, bool useMC)
@@ -402,7 +418,7 @@ void DataRequest::requestClusters(GTrackID::mask_t src, bool useMC)
     requestTRDTracklets(useMC);
   }
   if (GTrackID::includesDet(DetID::CTP, src)) {
-    requestCTPDigits(useMC);
+    requestCTPDigits(false); // RS FIXME: at the moment does not support MC
   }
   if (GTrackID::includesDet(DetID::CPV, src)) {
     requestCPVClusters(useMC);

--- a/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
+++ b/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
@@ -896,7 +896,7 @@ void RecoContainer::addFDDRecPoints(ProcessingContext& pc, bool mc)
 //__________________________________________________________
 void RecoContainer::addZDCRecEvents(ProcessingContext& pc, bool mc)
 {
-  commonPool[GTrackID::ZDC].registerContainer(pc.inputs().get<gsl::span<o2::zdc::BCRecData>>("zdcbcrecdata"), MATCHES);
+  commonPool[GTrackID::ZDC].registerContainer(pc.inputs().get<gsl::span<o2::zdc::BCRecData>>("zdcbcrec"), MATCHES);
   commonPool[GTrackID::ZDC].registerContainer(pc.inputs().get<gsl::span<o2::zdc::ZDCEnergy>>("zdcenergy"), TRACKS);
   commonPool[GTrackID::ZDC].registerContainer(pc.inputs().get<gsl::span<o2::zdc::ZDCTDCData>>("zdctdcdata"), CLUSTERS);
   commonPool[GTrackID::ZDC].registerContainer(pc.inputs().get<gsl::span<uint16_t>>("zdcinfo"), PATTERNS);

--- a/DataFormats/Detectors/MUON/MID/CMakeLists.txt
+++ b/DataFormats/Detectors/MUON/MID/CMakeLists.txt
@@ -12,8 +12,9 @@
 o2_add_library(
   DataFormatsMID
   SOURCES src/ColumnData.cxx src/CTF.cxx src/ROBoard.cxx src/Track.cxx
+          src/MCClusterLabel.cxx
   PUBLIC_LINK_LIBRARIES
-    Boost::serialization O2::MathUtils O2::CommonDataFormat
+    Boost::serialization O2::MathUtils O2::CommonDataFormat O2::SimulationDataFormat
     O2::DetectorsCommonDataFormats O2::ReconstructionDataFormats)
 
 o2_target_root_dictionary(
@@ -24,4 +25,5 @@ o2_target_root_dictionary(
           include/DataFormatsMID/ROBoard.h
           include/DataFormatsMID/ROFRecord.h
           include/DataFormatsMID/Track.h
-          include/DataFormatsMID/CTF.h)
+          include/DataFormatsMID/CTF.h
+          include/DataFormatsMID/MCClusterLabel.h)

--- a/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/MCClusterLabel.h
+++ b/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/MCClusterLabel.h
@@ -9,7 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file   MIDSimulation/MCClusterLabel.h
+/// \file   DataFormatsMID/MCClusterLabel.h
 /// \brief  Label for MID clusters
 /// \author Diego Stocco <Diego.Stocco at cern.ch>
 /// \date   23 April 2019
@@ -44,7 +44,7 @@ class MCClusterLabel : public o2::MCCompLabel
   bool isFiredNBP() const { return mFiredCathodes[1]; }
 
   ClassDefNV(MCClusterLabel, 1);
-}; // namespace mid
+};
 } // namespace mid
 } // namespace o2
 

--- a/DataFormats/Detectors/MUON/MID/src/DataFormatsMIDLinkDef.h
+++ b/DataFormats/Detectors/MUON/MID/src/DataFormatsMIDLinkDef.h
@@ -29,4 +29,9 @@
 #pragma link C++ struct o2::mid::CTFHeader + ;
 #pragma link C++ struct o2::mid::CTF + ;
 #pragma link C++ class o2::ctf::EncodedBlocks < o2::mid::CTFHeader, 7, uint32_t> + ;
+
+#include "SimulationDataFormat/MCTruthContainer.h"
+#pragma link C++ class o2::mid::MCClusterLabel + ;
+#pragma link C++ class o2::dataformats::MCTruthContainer < o2::mid::MCClusterLabel> + ;
+
 #endif

--- a/DataFormats/Detectors/MUON/MID/src/MCClusterLabel.cxx
+++ b/DataFormats/Detectors/MUON/MID/src/MCClusterLabel.cxx
@@ -9,14 +9,12 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file   MID/Simulation/src/MCClusterLabel.cxx
+/// \file   MCClusterLabel.cxx
 /// \brief  Implementation of MC label for MID clusters
 /// \author Diego Stocco <Diego.Stocco at cern.ch>
 /// \date   23 April 2019
 
-#include "MIDSimulation/MCClusterLabel.h"
-
-ClassImp(o2::mid::MCClusterLabel);
+#include "DataFormatsMID/MCClusterLabel.h"
 
 namespace o2
 {

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -1315,10 +1315,9 @@ DataProcessorSpec getAODProducerWorkflowSpec(GID::mask_t src, bool useMC)
   dataRequest->requestTracks(src, useMC);
   dataRequest->requestPrimaryVertertices(useMC);
   dataRequest->requestSecondaryVertertices(useMC);
-  dataRequest->requestFT0RecPoints(false);
-  dataRequest->requestFV0RecPoints(false);
-  dataRequest->requestFDDRecPoints(false);
-  dataRequest->requestClusters(GIndex::getSourcesMask("TPC,TOF"), false);
+  if (src[GID::TPC]) {
+    dataRequest->requestClusters(GIndex::getSourcesMask("TPC"), false); // TOF clusters are requested with TOF tracks
+  }
 
   outputs.emplace_back(OutputLabel{"O2bc"}, "AOD", "BC", 0, Lifetime::Timeframe);
   outputs.emplace_back(OutputLabel{"O2cascade"}, "AOD", "CASCADE", 0, Lifetime::Timeframe);

--- a/Detectors/AOD/src/aod-producer-workflow.cxx
+++ b/Detectors/AOD/src/aod-producer-workflow.cxx
@@ -43,7 +43,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
   auto useMC = !configcontext.options().get<bool>("disable-mc");
 
-  GID::mask_t allowedSrc = GID::getSourcesMask("ITS,MFT,MCH,TPC,ITS-TPC,ITS-TPC-TOF,TPC-TOF,MFT-MCH,FT0,FV0,FDD,TPC-TRD,ITS-TPC-TRD");
+  GID::mask_t allowedSrc = GID::getSourcesMask("ITS,MFT,MCH,TPC,ITS-TPC,ITS-TPC-TOF,TPC-TOF,MFT-MCH,FT0,FV0,FDD,TPC-TRD,ITS-TPC-TRD,FT0,FV0,FDD,ZDC");
   GID::mask_t src = allowedSrc & GID::getSourcesMask(configcontext.options().get<std::string>("info-sources"));
 
   WorkflowSpec specs;

--- a/Detectors/GlobalTrackingWorkflow/helpers/CMakeLists.txt
+++ b/Detectors/GlobalTrackingWorkflow/helpers/CMakeLists.txt
@@ -17,6 +17,7 @@ o2_add_library(GlobalTrackingWorkflowHelpers
                                       O2::ITSWorkflow
                                       O2::ITSMFTWorkflow
                                       O2::MCHWorkflow
+                                      O2::MIDWorkflow
                                       O2::MFTWorkflow
                                       O2::TPCWorkflow
                                       O2::GlobalTrackingWorkflowReaders

--- a/Detectors/GlobalTrackingWorkflow/helpers/src/InputHelper.cxx
+++ b/Detectors/GlobalTrackingWorkflow/helpers/src/InputHelper.cxx
@@ -35,6 +35,7 @@
 #include "TRDWorkflowIO/TRDTrackReaderSpec.h"
 #include "CTPWorkflowIO/DigitReaderSpec.h"
 #include "MCHWorkflow/TrackReaderSpec.h"
+#include "MIDWorkflow/TrackReaderSpec.h"
 #include "PHOSWorkflow/ReaderSpec.h"
 #include "CPVWorkflow/ReaderSpec.h"
 #include "EMCALWorkflow/PublisherSpec.h"
@@ -74,6 +75,9 @@ int InputHelper::addInputSpecs(const ConfigContext& configcontext, WorkflowSpec&
   }
   if (maskTracks[GID::MCH]) {
     specs.emplace_back(o2::mch::getTrackReaderSpec(maskTracksMC[GID::MCH]));
+  }
+  if (maskTracks[GID::MID]) {
+    specs.emplace_back(o2::mid::getTrackReaderSpec(maskTracksMC[GID::MID]));
   }
   if (maskTracks[GID::TPC]) {
     specs.emplace_back(o2::tpc::getTPCTrackReaderSpec(maskTracksMC[GID::TPC]));

--- a/Detectors/MUON/MID/Simulation/CMakeLists.txt
+++ b/Detectors/MUON/MID/Simulation/CMakeLists.txt
@@ -22,7 +22,6 @@ o2_add_library(
           src/Geometry.cxx
           src/Hit.cxx
           src/Materials.cxx
-          src/MCClusterLabel.cxx
           src/MCLabel.cxx
           src/PreClusterLabeler.cxx
           src/Stepper.cxx
@@ -42,7 +41,6 @@ o2_target_root_dictionary(
           include/MIDSimulation/Digitizer.h
           include/MIDSimulation/DigitsMerger.h
           include/MIDSimulation/Hit.h
-          include/MIDSimulation/MCClusterLabel.h
           include/MIDSimulation/MCLabel.h
           include/MIDSimulation/Stepper.h)
 

--- a/Detectors/MUON/MID/Simulation/include/MIDSimulation/ClusterLabeler.h
+++ b/Detectors/MUON/MID/Simulation/include/MIDSimulation/ClusterLabeler.h
@@ -22,7 +22,7 @@
 #include "SimulationDataFormat/MCTruthContainer.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "MIDClustering/PreCluster.h"
-#include "MIDSimulation/MCClusterLabel.h"
+#include "DataFormatsMID/MCClusterLabel.h"
 
 namespace o2
 {

--- a/Detectors/MUON/MID/Simulation/include/MIDSimulation/TrackLabeler.h
+++ b/Detectors/MUON/MID/Simulation/include/MIDSimulation/TrackLabeler.h
@@ -22,7 +22,7 @@
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "DataFormatsMID/Track.h"
 #include "DataFormatsMID/Cluster3D.h"
-#include "MIDSimulation/MCClusterLabel.h"
+#include "DataFormatsMID/MCClusterLabel.h"
 
 namespace o2
 {

--- a/Detectors/MUON/MID/Simulation/src/MIDSimulationLinkDef.h
+++ b/Detectors/MUON/MID/Simulation/src/MIDSimulationLinkDef.h
@@ -24,8 +24,6 @@
 #pragma link C++ class std::vector < o2::mid::Hit> + ;
 #pragma link C++ class o2::mid::ColumnDataMC + ;
 #pragma link C++ class std::vector < o2::mid::ColumnDataMC> + ;
-#pragma link C++ class o2::mid::MCClusterLabel + ;
-#pragma link C++ class o2::dataformats::MCTruthContainer < o2::mid::MCClusterLabel> + ;
 #pragma link C++ class o2::mid::MCLabel + ;
 #pragma link C++ class o2::dataformats::MCTruthContainer < o2::mid::MCLabel> + ;
 

--- a/Detectors/MUON/MID/Workflow/CMakeLists.txt
+++ b/Detectors/MUON/MID/Workflow/CMakeLists.txt
@@ -27,6 +27,7 @@ o2_add_library(
           src/RawWriterSpec.cxx
           src/TrackerMCSpec.cxx
           src/TrackerSpec.cxx
+          src/TrackReaderSpec.cxx
           src/ZeroSuppressionSpec.cxx
   PUBLIC_LINK_LIBRARIES
     O2::Framework

--- a/Detectors/MUON/MID/Workflow/include/MIDWorkflow/TrackReaderSpec.h
+++ b/Detectors/MUON/MID/Workflow/include/MIDWorkflow/TrackReaderSpec.h
@@ -1,0 +1,22 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_MID_WORKFLOW_TRACK_READER_SPEC_H
+#define O2_MID_WORKFLOW_TRACK_READER_SPEC_H
+
+#include "Framework/DataProcessorSpec.h"
+
+namespace o2::mid
+{
+o2::framework::DataProcessorSpec getTrackReaderSpec(bool useMC, const char* specName = "mid-tracks-reader");
+}
+
+#endif

--- a/Detectors/MUON/MID/Workflow/src/TrackReaderSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/TrackReaderSpec.cxx
@@ -1,0 +1,138 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "MIDWorkflow/TrackReaderSpec.h"
+
+#include "DPLUtils/RootTreeReader.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "Framework/Lifetime.h"
+#include "Framework/Logger.h"
+#include "Framework/Task.h"
+#include "SimulationDataFormat/MCCompLabel.h"
+#include "SimulationDataFormat/MCTruthContainer.h"
+#include "DataFormatsMID/Cluster3D.h"
+#include "DataFormatsMID/ROFRecord.h"
+#include "DataFormatsMID/Track.h"
+#include "DataFormatsMID/MCClusterLabel.h"
+#include <iostream>
+#include <vector>
+
+using namespace o2::framework;
+
+namespace o2::mid
+{
+
+template <typename T>
+void printBranch(char* data, const char* what)
+{
+  auto tdata = reinterpret_cast<std::vector<T>*>(data);
+  LOGP(info, "MID {:d} {:s}", tdata->size(), what);
+}
+
+RootTreeReader::SpecialPublishHook logging{
+  [](std::string_view name, ProcessingContext&, Output const&, char* data) -> bool {
+    if (name == "MIDTrackROF") {
+      printBranch<ROFRecord>(data, "TRACKSROF");
+    }
+    if (name == "MIDTrackClusterROF") {
+      printBranch<ROFRecord>(data, "TRCLUSROFS");
+    }
+    if (name == "MIDTrack") {
+      printBranch<Track>(data, "TRACKS");
+    }
+    if (name == "MIDTrackCluster") {
+      printBranch<Cluster3D>(data, "TRACKCLUSTERS");
+    }
+    if (name == "MIDTrackLabels") {
+      auto tdata = reinterpret_cast<o2::dataformats::MCTruthContainer<MCCompLabel>*>(data);
+      LOGP(info, "MID {:d} {:s}", tdata->getNElements(), "TRACKLABELS");
+    }
+    if (name == "MIDTrackClusterLabels") {
+      auto tdata = reinterpret_cast<o2::dataformats::MCTruthContainer<MCClusterLabel>*>(data);
+      LOGP(info, "MID {:d} {:s}", tdata->getNElements(), "TRCLUSLABELS");
+    }
+    return false;
+  }};
+
+struct TrackReader {
+  std::unique_ptr<RootTreeReader> mTreeReader;
+  bool mUseMC = false;
+  TrackReader(bool useMC = false) : mUseMC(useMC) {}
+  void init(InitContext& ic)
+  {
+    if (!mUseMC) {
+      LOGP(warning, "Not reading MID Track Labels");
+    }
+    auto treeName = "midreco";
+    auto fileName = ic.options().get<std::string>("infile");
+    auto nofEntries{-1};
+    if (mUseMC) {
+      mTreeReader = std::make_unique<RootTreeReader>(
+        treeName,
+        fileName.c_str(),
+        nofEntries,
+        RootTreeReader::PublishingMode::Single,
+        RootTreeReader::BranchDefinition<std::vector<Track>>{Output{"MID", "TRACKS", 0}, "MIDTrack"},
+        RootTreeReader::BranchDefinition<std::vector<ROFRecord>>{Output{"MID", "TRACKSROF", 0}, "MIDTrackROF"},
+        RootTreeReader::BranchDefinition<std::vector<Cluster3D>>{Output{"MID", "TRACKCLUSTERS", 0}, "MIDTrackCluster"},
+        RootTreeReader::BranchDefinition<std::vector<ROFRecord>>{Output{"MID", "TRCLUSROF", 0}, "MIDTrackClusterROF"},
+        RootTreeReader::BranchDefinition<o2::dataformats::MCTruthContainer<MCCompLabel>>{Output{"MID", "TRACKSLABELS", 0}, "MIDTrackLabels"},
+        RootTreeReader::BranchDefinition<o2::dataformats::MCTruthContainer<MCClusterLabel>>{Output{"MID", "TRCLUSLABELS", 0}, "MIDTrackClusterLabels"},
+        &logging);
+    } else {
+      mTreeReader = std::make_unique<RootTreeReader>(
+        treeName,
+        fileName.c_str(),
+        nofEntries,
+        RootTreeReader::PublishingMode::Single,
+        RootTreeReader::BranchDefinition<std::vector<Track>>{Output{"MID", "TRACKS", 0}, "MIDTrack"},
+        RootTreeReader::BranchDefinition<std::vector<ROFRecord>>{Output{"MID", "TRACKSROF", 0}, "MIDTrackROF"},
+        RootTreeReader::BranchDefinition<std::vector<Cluster3D>>{Output{"MID", "TRACKCLUSTERS", 0}, "MIDTrackCluster"},
+        RootTreeReader::BranchDefinition<std::vector<ROFRecord>>{Output{"MID", "TRCLUSROF", 0}, "MIDTrackClusterROF"},
+        &logging);
+    }
+  }
+
+  void run(ProcessingContext& pc)
+  {
+    if (mTreeReader->next()) {
+      (*mTreeReader)(pc);
+    } else {
+      pc.services().get<ControlService>().endOfStream();
+    }
+  }
+};
+
+DataProcessorSpec getTrackReaderSpec(bool useMC, const char* specName)
+{
+  std::vector<OutputSpec> outputSpecs;
+  outputSpecs.emplace_back(OutputSpec{{"tracks"}, "MID", "TRACKS", 0, Lifetime::Timeframe});
+  outputSpecs.emplace_back(OutputSpec{{"tracksrof"}, "MID", "TRACKSROF", 0, Lifetime::Timeframe});
+  outputSpecs.emplace_back(OutputSpec{{"trackclusters"}, "MID", "TRACKCLUSTERS", 0, Lifetime::Timeframe});
+  outputSpecs.emplace_back(OutputSpec{{"trclusrof"}, "MID", "TRCLUSROF", 0, Lifetime::Timeframe});
+  if (useMC) {
+    outputSpecs.emplace_back(OutputSpec{{"tracklabels"}, "MID", "TRACKLABELS", 0, Lifetime::Timeframe});
+    outputSpecs.emplace_back(OutputSpec{{"trcluslabels"}, "MID", "TRCLUSLABELS", 0, Lifetime::Timeframe});
+  }
+
+  auto options = Options{
+    {"infile", VariantType::String, "mid-reco.root", {"name of the input track file"}},
+  };
+
+  return DataProcessorSpec{
+    specName,
+    Inputs{},
+    outputSpecs,
+    adaptFromTask<TrackReader>(useMC),
+    options};
+}
+} // namespace o2::mid

--- a/Detectors/MUON/MID/Workflow/src/TrackReaderSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/TrackReaderSpec.cxx
@@ -85,7 +85,7 @@ struct TrackReader {
         RootTreeReader::BranchDefinition<std::vector<ROFRecord>>{Output{"MID", "TRACKSROF", 0}, "MIDTrackROF"},
         RootTreeReader::BranchDefinition<std::vector<Cluster3D>>{Output{"MID", "TRACKCLUSTERS", 0}, "MIDTrackCluster"},
         RootTreeReader::BranchDefinition<std::vector<ROFRecord>>{Output{"MID", "TRCLUSROF", 0}, "MIDTrackClusterROF"},
-        RootTreeReader::BranchDefinition<o2::dataformats::MCTruthContainer<MCCompLabel>>{Output{"MID", "TRACKSLABELS", 0}, "MIDTrackLabels"},
+        RootTreeReader::BranchDefinition<o2::dataformats::MCTruthContainer<MCCompLabel>>{Output{"MID", "TRACKLABELS", 0}, "MIDTrackLabels"},
         RootTreeReader::BranchDefinition<o2::dataformats::MCTruthContainer<MCClusterLabel>>{Output{"MID", "TRCLUSLABELS", 0}, "MIDTrackClusterLabels"},
         &logging);
     } else {

--- a/Detectors/MUON/MID/Workflow/src/TrackerMCSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/TrackerMCSpec.cxx
@@ -76,7 +76,7 @@ class TrackerMCDeviceDPL
     pc.outputs().snapshot(of::Output{"MID", "TRCLUSROF", 0, of::Lifetime::Timeframe}, mTracker->getClusterROFRecords());
     LOG(DEBUG) << "Sent " << mTracker->getClusterROFRecords().size() << " ROFs.";
 
-    pc.outputs().snapshot(of::Output{"MID", "TRACKSLABELS", 0, of::Lifetime::Timeframe}, mTrackLabeler.getTracksLabels());
+    pc.outputs().snapshot(of::Output{"MID", "TRACKLABELS", 0, of::Lifetime::Timeframe}, mTrackLabeler.getTracksLabels());
     LOG(DEBUG) << "Sent " << mTrackLabeler.getTracksLabels().getIndexedSize() << " indexed tracks.";
     pc.outputs().snapshot(of::Output{"MID", "TRCLUSLABELS", 0, of::Lifetime::Timeframe}, mTrackLabeler.getTrackClustersLabels());
     LOG(DEBUG) << "Sent " << mTrackLabeler.getTrackClustersLabels().getIndexedSize() << " indexed track clusters.";
@@ -97,7 +97,7 @@ framework::DataProcessorSpec getTrackerMCSpec()
     of::OutputSpec{"MID", "TRACKCLUSTERS"},
     of::OutputSpec{"MID", "TRACKSROF"},
     of::OutputSpec{"MID", "TRCLUSROF"},
-    of::OutputSpec{"MID", "TRACKSLABELS"},
+    of::OutputSpec{"MID", "TRACKLABELS"},
     of::OutputSpec{"MID", "TRCLUSLABELS"}};
 
   return of::DataProcessorSpec{

--- a/Detectors/MUON/MID/Workflow/src/TrackerMCSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/TrackerMCSpec.cxx
@@ -27,7 +27,7 @@
 #include "MIDSimulation/Geometry.h"
 #include "MIDTracking/Tracker.h"
 #include "DetectorsBase/GeometryManager.h"
-#include "MIDSimulation/MCClusterLabel.h"
+#include "DataFormatsMID/MCClusterLabel.h"
 #include "MIDSimulation/TrackLabeler.h"
 
 namespace of = o2::framework;

--- a/Detectors/MUON/MID/Workflow/src/reco-workflow.cxx
+++ b/Detectors/MUON/MID/Workflow/src/reco-workflow.cxx
@@ -79,7 +79,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
                                                 MakeRootTreeWriterSpec::BranchDefinition<std::vector<o2::mid::Cluster3D>>{InputSpec{"mid_trclus", o2::header::gDataOriginMID, "TRACKCLUSTERS"}, "MIDTrackCluster"},
                                                 MakeRootTreeWriterSpec::BranchDefinition<std::vector<o2::mid::ROFRecord>>{InputSpec{"mid_tracks_rof", o2::header::gDataOriginMID, "TRACKSROF"}, "MIDTrackROF"},
                                                 MakeRootTreeWriterSpec::BranchDefinition<std::vector<o2::mid::ROFRecord>>{InputSpec{"mid_trclus_rof", o2::header::gDataOriginMID, "TRCLUSROF"}, "MIDTrackClusterROF"},
-                                                MakeRootTreeWriterSpec::BranchDefinition<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>{InputSpec{"mid_track_labels", o2::header::gDataOriginMID, "TRACKSLABELS"}, "MIDTrackLabels", disableMC ? 0 : 1},
+                                                MakeRootTreeWriterSpec::BranchDefinition<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>{InputSpec{"mid_track_labels", o2::header::gDataOriginMID, "TRACKLABELS"}, "MIDTrackLabels", disableMC ? 0 : 1},
                                                 MakeRootTreeWriterSpec::BranchDefinition<o2::dataformats::MCTruthContainer<o2::mid::MCClusterLabel>>{InputSpec{"mid_trclus_labels", o2::header::gDataOriginMID, "TRCLUSLABELS"}, "MIDTrackClusterLabels", disableMC ? 0 : 1})());
     }
   }

--- a/Detectors/MUON/MID/Workflow/src/reco-workflow.cxx
+++ b/Detectors/MUON/MID/Workflow/src/reco-workflow.cxx
@@ -26,7 +26,7 @@
 #include "DataFormatsMID/Cluster3D.h"
 #include "DataFormatsMID/Track.h"
 #include "DataFormatsMID/ROFRecord.h"
-#include "MIDSimulation/MCClusterLabel.h"
+#include "DataFormatsMID/MCClusterLabel.h"
 #include "MIDWorkflow/ClusterizerMCSpec.h"
 #include "MIDWorkflow/ClusterizerSpec.h"
 #include "MIDWorkflow/TrackerMCSpec.h"

--- a/Detectors/MUON/MID/Workflow/src/tracks-reader-workflow.cxx
+++ b/Detectors/MUON/MID/Workflow/src/tracks-reader-workflow.cxx
@@ -22,7 +22,7 @@ using namespace o2::framework;
 // we need to add workflow options before including Framework/runDataProcessing
 void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
-  workflowOptions.emplace_back("disable-mc", VariantType::Bool, true, ConfigParamSpec::HelpString{"Disable MC info"});
+  workflowOptions.emplace_back("disable-mc", VariantType::Bool, false, ConfigParamSpec::HelpString{"Disable MC info"});
 }
 
 #include "Framework/runDataProcessing.h"

--- a/Detectors/MUON/MID/Workflow/src/tracks-reader-workflow.cxx
+++ b/Detectors/MUON/MID/Workflow/src/tracks-reader-workflow.cxx
@@ -16,6 +16,7 @@
 #include <vector>
 #include "Framework/ConfigParamSpec.h"
 #include "MIDWorkflow/TrackReaderSpec.h"
+#include "CommonUtils/ConfigurableParam.h"
 
 using namespace o2::framework;
 
@@ -23,6 +24,7 @@ using namespace o2::framework;
 void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
   workflowOptions.emplace_back("disable-mc", VariantType::Bool, false, ConfigParamSpec::HelpString{"Disable MC info"});
+  workflowOptions.emplace_back("configKeyValues", VariantType::String, "", ConfigParamSpec::HelpString{"Semicolon separated key=value strings ..."});
 }
 
 #include "Framework/runDataProcessing.h"

--- a/Detectors/MUON/MID/Workflow/src/tracks-reader-workflow.cxx
+++ b/Detectors/MUON/MID/Workflow/src/tracks-reader-workflow.cxx
@@ -13,114 +13,22 @@
 /// \brief  DPL workflow to send MID tracks read from a root file
 /// \author Philippe Pillot, Subatech
 
-#include <algorithm>
-#include <functional>
-#include <iterator>
-#include <memory>
-#include <stdexcept>
-
-#include "Framework/runDataProcessing.h"
-#include "Framework/ControlService.h"
-#include "Framework/Task.h"
-
-#include "DPLUtils/RootTreeReader.h"
-
-#include "DataFormatsMID/ROFRecord.h"
-#include "DataFormatsMID/Track.h"
+#include <vector>
+#include "Framework/ConfigParamSpec.h"
+#include "MIDWorkflow/TrackReaderSpec.h"
 
 using namespace o2::framework;
-using namespace o2::mid;
 
-class TrackSamplerTask
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
- public:
-  /// prepare the reader
-  void init(InitContext& ic)
-  {
-    auto inputFileName = ic.options().get<std::string>("infile");
-    mMinNumberOfROFsPerTF = ic.options().get<int>("repack-rofs");
+  workflowOptions.emplace_back("disable-mc", VariantType::Bool, true, ConfigParamSpec::HelpString{"Disable MC info"});
+}
 
-    mReader = std::make_unique<RootTreeReader>("midreco", inputFileName.c_str(), -1,
-                                               RootTreeReader::PublishingMode::Single,
-                                               RootTreeReader::BranchDefinition<std::vector<Track>>{
-                                                 Output{"MID", "TRACKS", 0, Lifetime::Timeframe}, "MIDTrack"},
-                                               RootTreeReader::BranchDefinition<std::vector<ROFRecord>>{
-                                                 Output{"MID", "TRACKSROF", 0, Lifetime::Timeframe}, "MIDTrackROF"},
-                                               &mAccumulator);
-  }
+#include "Framework/runDataProcessing.h"
 
-  /// process the next entry
-  void run(ProcessingContext& pc)
-  {
-    if (mReader->next()) {
-      (*mReader)(pc);
-      if (mROFs.size() >= mMinNumberOfROFsPerTF) {
-        publish(pc.outputs());
-      }
-    } else {
-      if (mROFs.size() > 0) {
-        publish(pc.outputs());
-      }
-      pc.services().get<ControlService>().endOfStream();
-    }
-  }
-
- private:
-  /// accumulate the data
-  bool accumulate(std::string_view name, char* data)
-  {
-    if (name == "MIDTrackROF") {
-
-      auto rofs = reinterpret_cast<std::vector<ROFRecord>*>(data);
-
-      // accumulate the ROFs, shifting the track indexing accordingly
-      size_t offset = (mROFs.size() > 0) ? mROFs.back().firstEntry + mROFs.back().nEntries : 0;
-      std::transform(rofs->begin(), rofs->end(), std::back_inserter(mROFs), [offset](const ROFRecord& rof) {
-        return ROFRecord{rof, rof.firstEntry + offset, rof.nEntries};
-      });
-
-    } else if (name == "MIDTrack") {
-
-      auto tracks = reinterpret_cast<std::vector<Track>*>(data);
-
-      // accumulate the tracks
-      mTracks.insert(mTracks.end(), tracks->begin(), tracks->end());
-
-    } else {
-      throw std::invalid_argument("invalid branch");
-    }
-
-    return true;
-  }
-
-  /// publish the data and clear the internal vector
-  void publish(DataAllocator& out)
-  {
-    out.snapshot(OutputRef{"rofs"}, mROFs);
-    out.snapshot(OutputRef{"tracks"}, mTracks);
-    mROFs.clear();
-    mTracks.clear();
-  }
-
-  size_t mMinNumberOfROFsPerTF = 1;          ///< minimum number of ROF to send per TF
-  std::vector<ROFRecord> mROFs{};            ///< internal vector of ROFs
-  std::vector<Track> mTracks{};              ///< internal vector of tracks
-  std::unique_ptr<RootTreeReader> mReader{}; ///< root file reader
-  /// structure holding the function to accumulate the data
-  RootTreeReader::SpecialPublishHook mAccumulator{
-    [this](std::string_view name, ProcessingContext&, Output const&, char* data) -> bool {
-      return this->accumulate(name, data);
-    }};
-};
-
-WorkflowSpec defineDataProcessing(const ConfigContext&)
+WorkflowSpec defineDataProcessing(const ConfigContext& config)
 {
-  return WorkflowSpec{DataProcessorSpec{
-    "TrackSampler",
-    Inputs{},
-    Outputs{OutputSpec{{"rofs"}, "MID", "TRACKSROF", 0, Lifetime::Timeframe},
-            OutputSpec{{"tracks"}, "MID", "TRACKS", 0, Lifetime::Timeframe}},
-    AlgorithmSpec{adaptFromTask<TrackSamplerTask>()},
-    Options{{"infile", VariantType::String, "mid-reco.root", {"input filename"}},
-            {"repack-rofs", VariantType::Int, 1, {"min number of rofs per timeframe"}}}}};
+  bool useMC = !config.options().get<bool>("disable-mc");
+  return WorkflowSpec{o2::mid::getTrackReaderSpec(useMC)};
 }


### PR DESCRIPTION
At the moment MID data can enter to RecoContainer from upstream reconstruction only, InputHelper/GlobalReader will be updated once MID readers are provided.