### PR TITLE
DPL: actually set verbosity for metric.

### DIFF
--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -489,7 +489,7 @@ auto flushMetrics(ServiceRegistry& registry, DataProcessingStats& stats) -> void
   for (size_t si = 0; si < stats.statesSize.load(); ++si) {
     auto value = std::atomic_load_explicit(&stats.relayerState[si], std::memory_order_relaxed);
     std::atomic_thread_fence(std::memory_order_acquire);
-    monitoring.send({value, fmt::format("data_relayer/{}", si, o2::monitoring::Verbosity::Debug)});
+    monitoring.send({value, fmt::format("data_relayer/{}", si), o2::monitoring::Verbosity::Debug});
   }
   relayer.sendContextState();
   monitoring.flushBuffer();


### PR DESCRIPTION
fmt::format was eating the verbosity level due to misplaced bracket.