### PR TITLE
Stop reporting 0xdeadbeef TFs after such N(D=5) consecutive TFs seen

### DIFF
--- a/Common/Utils/CMakeLists.txt
+++ b/Common/Utils/CMakeLists.txt
@@ -19,6 +19,7 @@ o2_add_library(CommonUtils
                        src/FileSystemUtils.cxx
                        src/FIFO.cxx
                        src/FileFetcher.cxx
+                       src/VerbosityConfig.cxx
                PUBLIC_LINK_LIBRARIES ROOT::Hist ROOT::Tree Boost::iostreams O2::CommonDataFormat O2::Headers
                                      FairLogger::FairLogger)
 
@@ -37,8 +38,8 @@ o2_target_root_dictionary(CommonUtils
                                   include/CommonUtils/ConfigurationMacroHelper.h
                                   include/CommonUtils/RootSerializableKeyValueStore.h
                                   include/CommonUtils/KeyValParam.h
-                                  include/CommonUtils/FileFetcher.h
-        )
+                                  include/CommonUtils/VerbosityConfig.h
+                                  include/CommonUtils/FileFetcher.h)
 
 o2_add_test(TreeStream
             COMPONENT_NAME CommonUtils

--- a/Common/Utils/include/CommonUtils/VerbosityConfig.h
+++ b/Common/Utils/include/CommonUtils/VerbosityConfig.h
@@ -1,0 +1,33 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author ruben.shahoyan@cern.ch
+/// \brief params to steer common verbosity behaviour
+
+#ifndef COMMON_VERBOSITY_CONFIG_H_
+#define COMMON_VERBOSITY_CONFIG_H_
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "CommonUtils/ConfigurableParamHelper.h"
+
+namespace o2
+{
+namespace conf
+{
+struct VerbosityConfig : public o2::conf::ConfigurableParamHelper<VerbosityConfig> {
+  size_t maxWarnDeadBeef = 5; // max amount of consecutive DeadBeef TF messages to report
+
+  O2ParamDef(VerbosityConfig, "VerbosityConfig");
+};
+} // namespace conf
+} // namespace o2
+
+#endif

--- a/Common/Utils/src/CommonUtilsLinkDef.h
+++ b/Common/Utils/src/CommonUtilsLinkDef.h
@@ -31,4 +31,7 @@
 #pragma link C++ class o2::conf::KeyValParam + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::conf::KeyValParam> + ;
 
+#pragma link C++ class o2::conf::VerbosityConfig + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::conf::VerbosityConfig> + ;
+
 #endif

--- a/Common/Utils/src/VerbosityConfig.cxx
+++ b/Common/Utils/src/VerbosityConfig.cxx
@@ -1,0 +1,16 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author ruben.shahoyan@cern.ch
+/// \brief params to steer common verbosity behaviour
+
+#include "CommonUtils/VerbosityConfig.h"
+O2ParamImpl(o2::conf::VerbosityConfig);

--- a/Detectors/CTP/workflow/src/RawToDigitConverterSpec.cxx
+++ b/Detectors/CTP/workflow/src/RawToDigitConverterSpec.cxx
@@ -17,6 +17,7 @@
 #include "DetectorsRaw/RDHUtils.h"
 #include "DPLUtils/DPLRawParser.h"
 #include "CTPWorkflow/RawToDigitConverterSpec.h"
+#include "CommonUtils/VerbosityConfig.h"
 
 using namespace o2::ctp::reco_workflow;
 
@@ -41,16 +42,22 @@ void RawToDigitConverterSpec::run(framework::ProcessingContext& ctx)
   // if we see requested data type input with 0xDEADBEEF subspec and 0 payload this means that the "delayed message"
   // mechanism created it in absence of real data from upstream. Processor should send empty output to not block the workflow
   {
+    static size_t contDeadBeef = 0; // number of times 0xDEADBEEF was seen continuously
     std::vector<InputSpec> dummy{InputSpec{"dummy", o2::framework::ConcreteDataMatcher{"CTP", "RAWDATA", 0xDEADBEEF}}};
     for (const auto& ref : o2::framework::InputRecordWalker(inputs, dummy)) {
       const auto dh = o2::framework::DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
       if (dh->payloadSize == 0) {
-        LOGP(WARNING, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF",
-             dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize);
+        auto maxWarn = o2::conf::VerbosityConfig::Instance().maxWarnDeadBeef;
+        if (++contDeadBeef <= maxWarn) {
+          LOGP(WARNING, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
+               dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize,
+               contDeadBeef == maxWarn ? fmt::format(". {} such inputs in row received, stopping reporting", contDeadBeef) : "");
+        }
         ctx.outputs().snapshot(o2::framework::Output{"CTP", "DIGITS", 0, o2::framework::Lifetime::Timeframe}, mOutputDigits);
         return;
       }
     }
+    contDeadBeef = 0; // if good data, reset the counter
   }
   //
   uint32_t payloadCTP;

--- a/Detectors/FIT/FT0/workflow/include/FT0Workflow/FT0DataReaderDPLSpec.h
+++ b/Detectors/FIT/FT0/workflow/include/FT0Workflow/FT0DataReaderDPLSpec.h
@@ -28,6 +28,8 @@
 #include <iostream>
 #include <vector>
 #include <gsl/span>
+#include "CommonUtils/VerbosityConfig.h"
+
 using namespace o2::framework;
 
 namespace o2
@@ -48,16 +50,22 @@ class FT0DataReaderDPLSpec : public Task
     // if we see requested data type input with 0xDEADBEEF subspec and 0 payload this means that the "delayed message"
     // mechanism created it in absence of real data from upstream. Processor should send empty output to not block the workflow
     {
+      static size_t contDeadBeef = 0; // number of times 0xDEADBEEF was seen continuously
       std::vector<InputSpec> dummy{InputSpec{"dummy", ConcreteDataMatcher{o2::header::gDataOriginFT0, o2::header::gDataDescriptionRawData, 0xDEADBEEF}}};
       for (const auto& ref : InputRecordWalker(pc.inputs(), dummy)) {
         const auto dh = o2::framework::DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
         if (dh->payloadSize == 0) {
-          LOGP(WARNING, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF",
-               dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize);
+          auto maxWarn = o2::conf::VerbosityConfig::Instance().maxWarnDeadBeef;
+          if (++contDeadBeef <= maxWarn) {
+            LOGP(WARNING, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
+                 dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize,
+                 contDeadBeef == maxWarn ? fmt::format(". {} such inputs in row received, stopping reporting", contDeadBeef) : "");
+          }
           mRawReader.makeSnapshot(pc); // send empty output
           return;
         }
       }
+      contDeadBeef = 0; // if good data, reset the counter
     }
     std::vector<InputSpec> filter{InputSpec{"filter", ConcreteDataTypeMatcher{o2::header::gDataOriginFT0, o2::header::gDataDescriptionRawData}, Lifetime::Timeframe}};
     DPLRawParser parser(pc.inputs(), filter);

--- a/Detectors/HMPID/workflow/src/DataDecoderSpec.cxx
+++ b/Detectors/HMPID/workflow/src/DataDecoderSpec.cxx
@@ -49,6 +49,7 @@
 #include "HMPIDBase/Geo.h"
 #include "HMPIDReconstruction/HmpidDecoder2.h"
 #include "HMPIDWorkflow/DataDecoderSpec.h"
+#include "CommonUtils/VerbosityConfig.h"
 
 namespace o2
 {
@@ -168,15 +169,21 @@ void DataDecoderTask::decodeTF(framework::ProcessingContext& pc)
   // if we see requested data type input with 0xDEADBEEF subspec and 0 payload this means that the "delayed message"
   // mechanism created it in absence of real data from upstream. Processor should send empty output to not block the workflow
   {
+    static size_t contDeadBeef = 0; // number of times 0xDEADBEEF was seen continuously
     std::vector<InputSpec> dummy{InputSpec{"dummy", ConcreteDataMatcher{"HMP", "RAWDATA", 0xDEADBEEF}}};
     for (const auto& ref : InputRecordWalker(inputs, dummy)) {
       const auto dh = o2::framework::DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
       if (dh->payloadSize == 0) {
-        LOGP(WARNING, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF",
-             dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize);
+        auto maxWarn = o2::conf::VerbosityConfig::Instance().maxWarnDeadBeef;
+        if (++contDeadBeef <= maxWarn) {
+          LOGP(WARNING, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
+               dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize,
+               contDeadBeef == maxWarn ? fmt::format(". {} such inputs in row received, stopping reporting", contDeadBeef) : "");
+        }
         return;
       }
     }
+    contDeadBeef = 0; // if good data, reset the counter
   }
 
   DPLRawParser parser(inputs, o2::framework::select("TF:HMP/RAWDATA"));

--- a/Detectors/PHOS/workflow/src/RawToCellConverterSpec.cxx
+++ b/Detectors/PHOS/workflow/src/RawToCellConverterSpec.cxx
@@ -25,6 +25,7 @@
 #include "PHOSReconstruction/CaloRawFitterGS.h"
 #include "PHOSReconstruction/RawDecodingError.h"
 #include "PHOSWorkflow/RawToCellConverterSpec.h"
+#include "CommonUtils/VerbosityConfig.h"
 
 using namespace o2::phos::reco_workflow;
 
@@ -103,10 +104,17 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
 
   // if we see requested data type input with 0xDEADBEEF subspec and 0 payload this means that the "delayed message"
   // mechanism created it in absence of real data from upstream. Processor should send empty output to not block the workflow
+  static size_t contDeadBeef = 0; // number of times 0xDEADBEEF was seen continuously
   std::vector<o2::framework::InputSpec> dummy{o2::framework::InputSpec{"dummy", o2::framework::ConcreteDataMatcher{"PHS", o2::header::gDataDescriptionRawData, 0xDEADBEEF}}};
   for (const auto& ref : framework::InputRecordWalker(ctx.inputs(), dummy)) {
     const auto dh = o2::framework::DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
     if (dh->payloadSize == 0) { // send empty output
+      auto maxWarn = o2::conf::VerbosityConfig::Instance().maxWarnDeadBeef;
+      if (++contDeadBeef <= maxWarn) {
+        LOGP(WARNING, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
+             dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize,
+             contDeadBeef == maxWarn ? fmt::format(". {} such inputs in row received, stopping reporting", contDeadBeef) : "");
+      }
       mOutputCells.clear();
       ctx.outputs().snapshot(o2::framework::Output{"PHS", "CELLS", 0, o2::framework::Lifetime::Timeframe}, mOutputCells);
       mOutputTriggerRecords.clear();
@@ -120,6 +128,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
       return; //empty TF, nothing to process
     }
   }
+  contDeadBeef = 0; // if good data, reset the counter
 
   std::vector<o2::framework::InputSpec> inputFilter{o2::framework::InputSpec{"filter", o2::framework::ConcreteDataTypeMatcher{"PHS", "RAWDATA"}, o2::framework::Lifetime::Timeframe}};
   for (const auto& rawData : framework::InputRecordWalker(ctx.inputs(), inputFilter)) {

--- a/Detectors/TOF/workflow/src/CompressedDecodingTask.cxx
+++ b/Detectors/TOF/workflow/src/CompressedDecodingTask.cxx
@@ -28,6 +28,7 @@
 #include "DetectorsRaw/RDHUtils.h"
 #include "Framework/InputRecordWalker.h"
 #include "Framework/DataRefUtils.h"
+#include "CommonUtils/VerbosityConfig.h"
 
 using namespace o2::framework;
 
@@ -164,15 +165,21 @@ void CompressedDecodingTask::decodeTF(ProcessingContext& pc)
   // if we see requested data type input with 0xDEADBEEF subspec and 0 payload this means that the "delayed message"
   // mechanism created it in absence of real data from upstream. Processor should send empty output to not block the workflow
   {
+    static size_t contDeadBeef = 0; // number of times 0xDEADBEEF was seen continuously
     std::vector<InputSpec> dummy{InputSpec{"dummy", ConcreteDataMatcher{"TOF", mDataDesc, 0xDEADBEEF}}};
     for (const auto& ref : InputRecordWalker(inputs, dummy)) {
       const auto dh = o2::framework::DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
       if (dh->payloadSize == 0) {
-        LOGP(WARNING, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF",
-             dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize);
+        auto maxWarn = o2::conf::VerbosityConfig::Instance().maxWarnDeadBeef;
+        if (++contDeadBeef <= maxWarn) {
+          LOGP(WARNING, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
+               dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize,
+               contDeadBeef == maxWarn ? fmt::format(". {} such inputs in row received, stopping reporting", contDeadBeef) : "");
+        }
         return;
       }
     }
+    contDeadBeef = 0; // if good data, reset the counter
   }
 
   /** loop over inputs routes **/

--- a/Detectors/TPC/reconstruction/src/RawReaderCRU.cxx
+++ b/Detectors/TPC/reconstruction/src/RawReaderCRU.cxx
@@ -23,6 +23,7 @@
 #include "TPCBase/Mapper.h"
 #include "Framework/Logger.h"
 #include "DetectorsRaw/RDHUtils.h"
+#include "CommonUtils/VerbosityConfig.h"
 
 #define CHECK_BIT(var, pos) ((var) & (1 << (pos)))
 

--- a/Detectors/ZDC/workflow/src/ZDCDataReaderDPLSpec.cxx
+++ b/Detectors/ZDC/workflow/src/ZDCDataReaderDPLSpec.cxx
@@ -12,6 +12,7 @@
 /// @file   ZDCDataReaderDPLSpec.cxx
 
 #include "ZDCWorkflow/ZDCDataReaderDPLSpec.h"
+#include "CommonUtils/VerbosityConfig.h"
 
 using namespace o2::framework;
 
@@ -38,16 +39,22 @@ void ZDCDataReaderDPLSpec::run(ProcessingContext& pc)
   // if we see requested data type input with 0xDEADBEEF subspec and 0 payload this means that the "delayed message"
   // mechanism created it in absence of real data from upstream. Processor should send empty output to not block the workflow
   {
+    static size_t contDeadBeef = 0; // number of times 0xDEADBEEF was seen continuously
     std::vector<InputSpec> dummy{InputSpec{"dummy", ConcreteDataMatcher{o2::header::gDataOriginZDC, o2::header::gDataDescriptionRawData, 0xDEADBEEF}}};
     for (const auto& ref : InputRecordWalker(pc.inputs(), dummy)) {
       const auto dh = o2::framework::DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
       if (dh->payloadSize == 0) {
-        LOGP(WARNING, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF",
-             dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize);
+        auto maxWarn = o2::conf::VerbosityConfig::Instance().maxWarnDeadBeef;
+        if (++contDeadBeef <= maxWarn) {
+          LOGP(WARNING, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
+               dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize,
+               contDeadBeef == maxWarn ? fmt::format(". {} such inputs in row received, stopping reporting", contDeadBeef) : "");
+        }
         mRawReader.makeSnapshot(pc); // send empty output
         return;
       }
     }
+    contDeadBeef = 0; // if good data, reset the counter
   }
 
   DPLRawParser parser(pc.inputs(), o2::framework::select("zdc:ZDC/RAWDATA"));


### PR DESCRIPTION
The threshould can be changed via e.g. `--configKeyValues "VerbosityConfig.maxWarnDeadBeef=10"`
Healthy TF will reset the counter, so the deadbeef TF will be reported again if reappear