### PR TITLE
Defining as inline sameCategory and diffCategory

### DIFF
--- a/Framework/Core/include/Framework/ASoAHelpers.h
+++ b/Framework/Core/include/Framework/ASoAHelpers.h
@@ -54,11 +54,11 @@ struct NTupleType<T, 0, REST...> {
 };
 
 // Group table (C++ vector of indices)
-bool sameCategory(std::pair<uint64_t, uint64_t> const& a, std::pair<uint64_t, uint64_t> const& b)
+inline bool sameCategory(std::pair<uint64_t, uint64_t> const& a, std::pair<uint64_t, uint64_t> const& b)
 {
   return a.first < b.first;
 }
-bool diffCategory(std::pair<uint64_t, uint64_t> const& a, std::pair<uint64_t, uint64_t> const& b)
+inline bool diffCategory(std::pair<uint64_t, uint64_t> const& a, std::pair<uint64_t, uint64_t> const& b)
 {
   return a.first >= b.first;
 }


### PR DESCRIPTION
Functions in a common header should be defined inline

If not, if multiple compiled units which have to be linked
to the same library include the common header, the function
is defined on each compiled units, which makes the linker to
reject the library production due to multiple defined function