### PR TITLE
Fixes for TRD matched

### DIFF
--- a/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
@@ -46,6 +46,7 @@
 #include "GPUTRDInterfaces.h"
 #include "GPUTRDGeometry.h"
 
+#include <regex>
 #include <algorithm>
 
 using namespace o2::framework;
@@ -230,12 +231,9 @@ void TRDGlobalTracking::run(ProcessingContext& pc)
     mITSABRefsArray = inputTracks.getITSABRefs();
     mITSABTrackClusIdx = inputTracks.getITSABClusterRefs();
     const auto clusITS = inputTracks.getITSClusters();
-    if (clusITS.empty()) {
-      LOG(FATAL) << "No ITS clusters";
-      return;
-    }
     const auto patterns = inputTracks.getITSClustersPatterns();
     auto pattIt = patterns.begin();
+    mITSClustersArray.clear();
     mITSClustersArray.reserve(clusITS.size());
     o2::its::ioutils::convertCompactClusters(clusITS, pattIt, mITSClustersArray, mITSDict);
   }
@@ -662,7 +660,8 @@ DataProcessorSpec getTRDGlobalTrackingSpec(bool useMC, GTrackID::mask_t src, boo
   }
 
   std::string processorName = o2::utils::Str::concat_string("trd-globaltracking", GTrackID::getSourcesNames(src));
-  std::replace(processorName.begin(), processorName.end(), ',', '_');
+  std::regex reg("[,\\[\\]]+");
+  processorName = regex_replace(processorName, reg, "_");
 
   return DataProcessorSpec{
     processorName,


### PR DESCRIPTION
* No need to fatal if there are no ITS clusters, clean converted cluster container before doing the conversion.
* Avoid `[]` in the device name

Trivial changes, tested locally, merging