### PR TITLE
Update Compressor.cxx

### DIFF
--- a/Detectors/TOF/compression/src/Compressor.cxx
+++ b/Detectors/TOF/compression/src/Compressor.cxx
@@ -198,16 +198,16 @@ bool Compressor<RDH, verbose, paranoid>::processHBF()
   }
   mDecoderSaveBufferDataSize = 0;
 
-  /** updated encoder RDH open **/
-  mEncoderRDH->memorySize = reinterpret_cast<char*>(mEncoderPointer) - reinterpret_cast<char*>(mEncoderRDH);
-  mEncoderRDH->offsetToNext = mEncoderRDH->memorySize;
-
   /** bring encoder pointer back if fatal error and flag it **/
   if (mDecoderFatal) {
     mFatalCounter++;
     mEncoderPointer = mEncoderPointerStart;
     mEncoderRDH->detectorField |= 0x00001000;
   }
+
+  /** updated encoder RDH open **/
+  mEncoderRDH->memorySize = reinterpret_cast<char*>(mEncoderPointer) - reinterpret_cast<char*>(mEncoderRDH);
+  mEncoderRDH->offsetToNext = mEncoderRDH->memorySize;
 
   if (mDecoderError) {
     mErrorCounter++;


### PR DESCRIPTION
ciao @noferini 
I think this should fix the issues observed in the TOF decoder with bad RDH.
it is a problem generated by the compressor, which in case of fatal errors was not properly storing the size of the data in the RDH payload.