### PR TITLE
MCH: prevent decoder crashes due to unknown link id error

### DIFF
--- a/Detectors/MUON/MCH/Raw/Decoder/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Raw/Decoder/CMakeLists.txt
@@ -12,6 +12,7 @@
 o2_add_library(MCHRawDecoder
         SOURCES src/BareELinkDecoder.cxx
                 src/DataDecoder.cxx
+                src/ErrorCodes.cxx
                 src/OrbitInfo.cxx
                 src/PageDecoder.cxx
                 src/ROFFinder.cxx

--- a/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DataDecoder.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DataDecoder.h
@@ -176,6 +176,9 @@ class DataDecoder
   /// Initialize the digits from an external vector. To be only used for unit tests.
   void setDigits(const RawDigitVector& digits) { mDigits = digits; }
 
+  /// send all messages from our error map to the infologger
+  void logErrorMap(int tfcount) const;
+
  private:
   void initElec2DetMapper(std::string filename);
   void initFee2SolarMapper(std::string filename);
@@ -230,6 +233,7 @@ class DataDecoder
   bool mDs2manu{false};
   uint32_t mOrbit{0};
   bool mUseDummyElecMap{false};
+  std::map<std::string, uint64_t> mErrorMap; // counts for error messages
 };
 
 bool operator<(const DataDecoder::RawDigit& d1, const DataDecoder::RawDigit& d2);

--- a/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/ErrorCodes.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/ErrorCodes.h
@@ -12,6 +12,8 @@
 #ifndef O2_MCH_RAW_ERROR_CODES_H
 #define O2_MCH_RAW_ERROR_CODES_H
 
+#include <string>
+
 namespace o2
 {
 namespace mch
@@ -32,6 +34,8 @@ enum ErrorCodes {
   ErrorBadLinkID = 1 << 9,            // 512
   ErrorUnknownLinkID = 1 << 10        // 1024
 };
+
+std::string errorCodeAsString(uint32_t code);
 
 } // namespace raw
 } // namespace mch

--- a/Detectors/MUON/MCH/Raw/Decoder/src/ErrorCodes.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/ErrorCodes.cxx
@@ -1,0 +1,73 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "MCHRawDecoder/ErrorCodes.h"
+
+namespace o2
+{
+namespace mch
+{
+namespace raw
+{
+
+void append(const char* msg, std::string& to)
+{
+  std::string s = to.size() ? "& " + to : "";
+  s += msg;
+  if (to.size()) {
+    to += "& ";
+  }
+  to += msg;
+}
+
+std::string errorCodeAsString(uint32_t ec)
+{
+  std::string msg;
+
+  if (ec & ErrorParity) {
+    append("Parity", msg);
+  }
+  if (ec & ErrorHammingCorrectable) {
+    append("Hamming Correctable", msg);
+  }
+  if (ec & ErrorHammingUncorrectable) {
+    append("Hamming Uncorrectable", msg);
+  }
+  if (ec & ErrorBadClusterSize) {
+    append("Cluster Size", msg);
+  }
+  if (ec & ErrorBadPacketType) {
+    append("Bad Packet Type", msg);
+  }
+  if (ec & ErrorBadHeartBeatPacket) {
+    append("Bad HeartBeat Packet", msg);
+  }
+  if (ec & ErrorBadIncompleteWord) {
+    append("Bad Incomplete Word", msg);
+  }
+  if (ec & ErrorTruncatedData) {
+    append("Truncated Data", msg);
+  }
+  if (ec & ErrorBadELinkID) {
+    append("Bad E-Link ID", msg);
+  }
+  if (ec & ErrorBadLinkID) {
+    append("Bad Link ID", msg);
+  }
+  if (ec & ErrorUnknownLinkID) {
+    append("Unknown Link ID", msg);
+  }
+  return msg;
+}
+
+} // namespace raw
+} // namespace mch
+} // namespace o2

--- a/Detectors/MUON/MCH/Raw/Decoder/src/UserLogicEndpointDecoder.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/UserLogicEndpointDecoder.h
@@ -133,6 +133,7 @@ size_t UserLogicEndpointDecoder<CHARGESUM, VERSION>::append(Payload buffer)
         if (handler) {
           DsElecId dsId{static_cast<uint16_t>(0), static_cast<uint8_t>(0), static_cast<uint8_t>(0)};
           handler(dsId, -1, ErrorBadLinkID);
+          continue;
         } else {
           throw fmt::format("warning : out-of-range gbt {} word={:08X}\n", gbt, word);
         }
@@ -153,6 +154,7 @@ size_t UserLogicEndpointDecoder<CHARGESUM, VERSION>::append(Payload buffer)
         if (handler) {
           DsElecId dsId{static_cast<uint16_t>(0), static_cast<uint8_t>(0), static_cast<uint8_t>(0)};
           handler(dsId, -1, ErrorUnknownLinkID);
+          continue;
         } else {
           throw std::logic_error(fmt::format("{} Could not get solarId from feeLinkId={}\n", __PRETTY_FUNCTION__, asString(feeLinkId)));
         }
@@ -172,6 +174,7 @@ size_t UserLogicEndpointDecoder<CHARGESUM, VERSION>::append(Payload buffer)
       if (handler) {
         DsElecId dsId{static_cast<uint16_t>(0), static_cast<uint8_t>(0), static_cast<uint8_t>(0)};
         handler(dsId, -1, ErrorBadELinkID);
+        continue;
       } else {
         throw fmt::format("warning : out-of-range DS ID {} word={:08X}\n", dsid, word);
       }


### PR DESCRIPTION
@aferrero2707 here's a proposal to make the decoder a bit more robust and avoid crashing on some common errors. 

In addition I've put a basic message map in place to avoid having too many messages. To be refined later on (e.g. we should also define what kind of detail we need in the messages for the info logger, i.e. on production, versus what is more debug and oriented towards developers only)