### PR TITLE
DPL Analysis: generalized grouping

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1574,7 +1574,7 @@ constexpr auto is_binding_compatible_v()
 #define DECLARE_SOA_ARRAY_INDEX_COLUMN(_Name_, _Getter_, _Size_) DECLARE_SOA_ARRAY_INDEX_COLUMN_FULL(_Name_, _Getter_, int32_t, _Size_, _Name_##s, "")
 
 ///NORMAL
-#define DECLARE_SOA_INDEX_COLUMN_FULL(_Name_, _Getter_, _Type_, _Table_, _Suffix_)                                                \
+#define DECLARE_SOA_INDEX_COLUMN_FULL_BASE(_Name_, _Getter_, _Type_, _Table_, _Suffix_, _Sorted_)                                 \
   struct _Name_##Id : o2::soa::Column<_Type_, _Name_##Id> {                                                                       \
     static_assert(std::is_integral_v<_Type_>, "Index type must be integral");                                                     \
     static_assert((*_Suffix_ == '\0') || (*_Suffix_ == '_'), "Suffix has to begin with _");                                       \
@@ -1583,6 +1583,7 @@ constexpr auto is_binding_compatible_v()
     using type = _Type_;                                                                                                          \
     using column_t = _Name_##Id;                                                                                                  \
     using binding_t = _Table_;                                                                                                    \
+    static constexpr bool sorted = _Sorted_;                                                                                      \
     _Name_##Id(arrow::ChunkedArray const* column)                                                                                 \
       : o2::soa::Column<_Type_, _Name_##Id>(o2::soa::ColumnIterator<type>(column))                                                \
     {                                                                                                                             \
@@ -1641,7 +1642,9 @@ constexpr auto is_binding_compatible_v()
   static const o2::framework::expressions::BindingNode _Getter_##Id { "fIndex" #_Table_ _Suffix_, typeid(_Name_##Id).hash_code(), \
                                                                       o2::framework::expressions::selectArrowType<_Type_>() }
 
-#define DECLARE_SOA_INDEX_COLUMN(_Name_, _Getter_) DECLARE_SOA_INDEX_COLUMN_FULL(_Name_, _Getter_, int32_t, _Name_##s, "")
+#define DECLARE_SOA_INDEX_COLUMN_FULL(_Name_, _Getter_, _Type_, _Table_, _Suffix_) DECLARE_SOA_INDEX_COLUMN_FULL_BASE(_Name_, _Getter_, _Type_, _Table_, _Suffix_, false)
+#define DECLARE_SOA_INDEX_COLUMN(_Name_, _Getter_) DECLARE_SOA_INDEX_COLUMN_FULL_BASE(_Name_, _Getter_, int32_t, _Name_##s, "", false)
+#define DECLARE_SOA_SORTED_INDEX_COLUMN(_Name_, _Getter_) DECLARE_SOA_INDEX_COLUMN_FULL_BASE(_Name_, _Getter_, int32_t, _Name_##s, "", true)
 
 ///SELF
 #define DECLARE_SOA_SELF_INDEX_COLUMN_FULL(_Name_, _Getter_, _Type_, _Label_)                                           \

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -54,7 +54,7 @@ using BCsWithTimestamps = soa::Join<aod::BCs, aod::Timestamps>;
 
 namespace collision
 {
-DECLARE_SOA_INDEX_COLUMN(BC, bc);                              //! Most probably BC to where this collision has occured
+DECLARE_SOA_SORTED_INDEX_COLUMN(BC, bc);                       //! Most probably BC to where this collision has occured
 DECLARE_SOA_COLUMN(PosX, posX, float);                         //! X Vertex position in cm
 DECLARE_SOA_COLUMN(PosY, posY, float);                         //! Y Vertex position in cm
 DECLARE_SOA_COLUMN(PosZ, posZ, float);                         //! Z Vertex position in cm
@@ -88,7 +88,7 @@ using Collision = Collisions::iterator;
 namespace track
 {
 // TRACKPAR TABLE definition
-DECLARE_SOA_INDEX_COLUMN(Collision, collision); //! Collision to which this track belongs
+DECLARE_SOA_SORTED_INDEX_COLUMN(Collision, collision); //! Collision to which this track belongs
 // TODO change to TrackTypeEnum when enums are supported
 DECLARE_SOA_COLUMN(TrackType, trackType, uint8_t);   //! Type of track. See enum TrackTypeEnum
 DECLARE_SOA_COLUMN(X, x, float);                     //!
@@ -347,7 +347,7 @@ using FullTrack = FullTracks::iterator;
 namespace fwdtrack
 {
 // FwdTracks and MFTTracks Columns definitions
-DECLARE_SOA_INDEX_COLUMN(Collision, collision);                                              //!
+DECLARE_SOA_SORTED_INDEX_COLUMN(Collision, collision);                                       //!
 DECLARE_SOA_COLUMN(TrackType, trackType, uint8_t);                                           //! Type of track. See enum ForwardTrackTypeEnum
 DECLARE_SOA_COLUMN(X, x, float);                                                             //! TrackParFwd parameter x
 DECLARE_SOA_COLUMN(Y, y, float);                                                             //! TrackParFwd parameter y
@@ -579,7 +579,7 @@ using HMPID = HMPIDs::iterator;
 
 namespace calo
 {
-DECLARE_SOA_INDEX_COLUMN(BC, bc);                    //! BC index
+DECLARE_SOA_SORTED_INDEX_COLUMN(BC, bc);             //! BC index
 DECLARE_SOA_COLUMN(CellNumber, cellNumber, int16_t); //!
 DECLARE_SOA_COLUMN(Amplitude, amplitude, float);     //!
 DECLARE_SOA_COLUMN(Time, time, float);               //!
@@ -594,7 +594,7 @@ using Calo = Calos::iterator;
 
 namespace calotrigger
 {
-DECLARE_SOA_INDEX_COLUMN(BC, bc);                      //! BC index
+DECLARE_SOA_SORTED_INDEX_COLUMN(BC, bc);               //! BC index
 DECLARE_SOA_COLUMN(FastOrAbsID, fastOrAbsID, int16_t); //! FastOR absolute ID
 DECLARE_SOA_COLUMN(LnAmplitude, lnAmplitude, int16_t); //! L0 amplitude (ADC) := Peak Amplitude
 DECLARE_SOA_COLUMN(TriggerBits, triggerBits, int32_t); //! Online trigger bits
@@ -608,7 +608,7 @@ using CaloTrigger = CaloTriggers::iterator;
 
 namespace zdc
 {
-DECLARE_SOA_INDEX_COLUMN(BC, bc);                               //! BC index
+DECLARE_SOA_SORTED_INDEX_COLUMN(BC, bc);                        //! BC index
 DECLARE_SOA_COLUMN(EnergyZEM1, energyZEM1, float);              //!
 DECLARE_SOA_COLUMN(EnergyZEM2, energyZEM2, float);              //!
 DECLARE_SOA_COLUMN(EnergyCommonZNA, energyCommonZNA, float);    //!
@@ -636,7 +636,7 @@ using Zdc = Zdcs::iterator;
 
 namespace fv0a
 {
-DECLARE_SOA_INDEX_COLUMN(BC, bc);                      //! BC index
+DECLARE_SOA_SORTED_INDEX_COLUMN(BC, bc);               //! BC index
 DECLARE_SOA_COLUMN(Amplitude, amplitude, float[48]);   //! Amplitudes per cell
 DECLARE_SOA_COLUMN(Time, time, float);                 //! Time in ns
 DECLARE_SOA_COLUMN(TriggerMask, triggerMask, uint8_t); //!
@@ -649,7 +649,7 @@ using FV0A = FV0As::iterator;
 // V0C table for Run2 only
 namespace fv0c
 {
-DECLARE_SOA_INDEX_COLUMN(BC, bc);                    //! BC index
+DECLARE_SOA_SORTED_INDEX_COLUMN(BC, bc);             //! BC index
 DECLARE_SOA_COLUMN(Amplitude, amplitude, float[32]); //! Amplitudes per cell
 DECLARE_SOA_COLUMN(Time, time, float);               //! Time in ns
 } // namespace fv0c
@@ -660,7 +660,7 @@ using FV0C = FV0Cs::iterator;
 
 namespace ft0
 {
-DECLARE_SOA_INDEX_COLUMN(BC, bc);                       //! BC index
+DECLARE_SOA_SORTED_INDEX_COLUMN(BC, bc);                //! BC index
 DECLARE_SOA_COLUMN(AmplitudeA, amplitudeA, float[96]);  //!
 DECLARE_SOA_COLUMN(AmplitudeC, amplitudeC, float[112]); //!
 DECLARE_SOA_COLUMN(TimeA, timeA, float);                //!
@@ -676,7 +676,7 @@ using FT0 = FT0s::iterator;
 
 namespace fdd
 {
-DECLARE_SOA_INDEX_COLUMN(BC, bc);                      //! BC index
+DECLARE_SOA_SORTED_INDEX_COLUMN(BC, bc);               //! BC index
 DECLARE_SOA_COLUMN(AmplitudeA, amplitudeA, float[4]);  //!
 DECLARE_SOA_COLUMN(AmplitudeC, amplitudeC, float[4]);  //!
 DECLARE_SOA_COLUMN(TimeA, timeA, float);               //!
@@ -695,7 +695,7 @@ namespace v0
 {
 DECLARE_SOA_INDEX_COLUMN_FULL(PosTrack, posTrack, int, Tracks, "_Pos"); //! Positive track
 DECLARE_SOA_INDEX_COLUMN_FULL(NegTrack, negTrack, int, Tracks, "_Neg"); //! Negative track
-DECLARE_SOA_INDEX_COLUMN(Collision, collision);                         //! Collision index
+DECLARE_SOA_SORTED_INDEX_COLUMN(Collision, collision);                  //! Collision index
 } // namespace v0
 
 DECLARE_SOA_TABLE(StoredV0s, "AOD", "V0", //! On disk V0 table
@@ -716,7 +716,7 @@ using V0 = V0s::iterator;
 
 namespace cascade
 {
-DECLARE_SOA_INDEX_COLUMN(V0, v0);                                   //! V0 index
+DECLARE_SOA_SORTED_INDEX_COLUMN(V0, v0);                            //! V0 index
 DECLARE_SOA_INDEX_COLUMN_FULL(Bachelor, bachelor, int, Tracks, ""); //! Bachelor track index
 DECLARE_SOA_INDEX_COLUMN(Collision, collision);                     //! Collision index
 } // namespace cascade
@@ -763,7 +763,7 @@ using Run2BCInfo = Run2BCInfos::iterator;
 // ---- MC tables ----
 namespace mccollision
 {
-DECLARE_SOA_INDEX_COLUMN(BC, bc); //! BC index
+DECLARE_SOA_SORTED_INDEX_COLUMN(BC, bc); //! BC index
 // TODO enum to be added to O2
 DECLARE_SOA_COLUMN(GeneratorsID, generatorsID, short);       //!
 DECLARE_SOA_COLUMN(PosX, posX, float);                       //! X vertex position in cm
@@ -784,7 +784,7 @@ using McCollision = McCollisions::iterator;
 
 namespace mcparticle
 {
-DECLARE_SOA_INDEX_COLUMN(McCollision, mcCollision);                                     //! MC collision of this particle
+DECLARE_SOA_SORTED_INDEX_COLUMN(McCollision, mcCollision);                              //! MC collision of this particle
 DECLARE_SOA_COLUMN(PdgCode, pdgCode, int);                                              //! PDG code
 DECLARE_SOA_COLUMN(StatusCode, statusCode, int);                                        //! Status code directly from the generator
 DECLARE_SOA_COLUMN(Flags, flags, uint8_t);                                              //! ALICE specific flags. Do not use directly. Use the dynamic columns, e.g. producedByGenerator()
@@ -910,13 +910,13 @@ using McCollisionLabel = McCollisionLabels::iterator;
 
 namespace indices
 {
-DECLARE_SOA_INDEX_COLUMN(Collision, collision); //!
-DECLARE_SOA_INDEX_COLUMN(BC, bc);               //!
-DECLARE_SOA_INDEX_COLUMN(Zdc, zdc);             //!
-DECLARE_SOA_INDEX_COLUMN(FV0A, fv0a);           //!
-DECLARE_SOA_INDEX_COLUMN(FV0C, fv0c);           //!
-DECLARE_SOA_INDEX_COLUMN(FT0, ft0);             //!
-DECLARE_SOA_INDEX_COLUMN(FDD, fdd);             //!
+DECLARE_SOA_SORTED_INDEX_COLUMN(Collision, collision); //!
+DECLARE_SOA_SORTED_INDEX_COLUMN(BC, bc);               //!
+DECLARE_SOA_SORTED_INDEX_COLUMN(Zdc, zdc);             //!
+DECLARE_SOA_SORTED_INDEX_COLUMN(FV0A, fv0a);           //!
+DECLARE_SOA_SORTED_INDEX_COLUMN(FV0C, fv0c);           //!
+DECLARE_SOA_SORTED_INDEX_COLUMN(FT0, ft0);             //!
+DECLARE_SOA_SORTED_INDEX_COLUMN(FDD, fdd);             //!
 } // namespace indices
 
 // First entry: Collision

--- a/Framework/Core/include/Framework/Kernels.h
+++ b/Framework/Core/include/Framework/Kernels.h
@@ -45,10 +45,10 @@ auto sliceByColumnGeneric(
         groups[v].push_back(offset);
       } else if (unassigned != nullptr) {
         auto av = std::abs(v);
-        if (unassigned->size() < av) {
+        if (unassigned->size() < av + 1) {
           unassigned->resize(av + 1);
         }
-        unassigned[std::abs(v)].push_back(offset);
+        unassigned[av].push_back(offset);
       }
       ++offset;
     }

--- a/Framework/Core/include/Framework/Kernels.h
+++ b/Framework/Core/include/Framework/Kernels.h
@@ -29,28 +29,32 @@ using ListVector = std::vector<std::vector<int64_t>>;
 template <typename T>
 auto sliceByColumnGeneric(
   char const* key,
+  char const* target,
   std::shared_ptr<arrow::Table> const& input,
   T fullSize,
   ListVector* groups,
   ListVector* unassigned = nullptr)
 {
-  groups->reserve(fullSize);
+  groups->resize(fullSize);
   auto column = input->GetColumnByName(key);
-  int64_t offset = 0;
+  int64_t row = 0;
   for (auto iChunk = 0; iChunk < column->num_chunks(); ++iChunk) {
-    auto chunk = static_cast<arrow::NumericArray<typename detail::ConversionTraits<T>>>(column->chunk(iChunk)->data());
+    auto chunk = static_cast<arrow::NumericArray<typename detail::ConversionTraits<T>::ArrowType>>(column->chunk(iChunk)->data());
     for (auto iElement = 0; iElement < chunk.length(); ++iElement) {
       auto v = chunk.Value(iElement);
       if (v >= 0) {
-        groups[v].push_back(offset);
+        if (v >= groups->size()) {
+          throw runtime_error_f("Table %s has an entry with index (%d) that is larger than the grouping table size (%d)", target, v, fullSize);
+        }
+        (*groups)[v].push_back(row);
       } else if (unassigned != nullptr) {
         auto av = std::abs(v);
         if (unassigned->size() < av + 1) {
           unassigned->resize(av + 1);
         }
-        unassigned[av].push_back(offset);
+        (*unassigned)[av].push_back(row);
       }
-      ++offset;
+      ++row;
     }
   }
 }

--- a/Framework/Core/test/test_AnalysisTask.cxx
+++ b/Framework/Core/test/test_AnalysisTask.cxx
@@ -47,8 +47,6 @@ DECLARE_SOA_TABLE(Events, "AOD", "EVENTS",
                   test::EventProperty);
 } // namespace o2::aod
 
-// FIXME: for the moment we do not derive from AnalysisTask as
-// we need GCC 7.4+ to fix a bug.
 struct ATask {
   Produces<aod::FooBars> foobars;
 
@@ -58,32 +56,24 @@ struct ATask {
   }
 };
 
-// FIXME: for the moment we do not derive from AnalysisTask as
-// we need GCC 7.4+ to fix a bug.
 struct BTask {
   void process(o2::aod::Collision const&, o2::soa::Join<o2::aod::Tracks, o2::aod::TracksExtra, o2::aod::TracksCov> const&, o2::aod::AmbiguousTracks const&, o2::soa::Join<o2::aod::Calos, o2::aod::CaloTriggers> const&)
   {
   }
 };
 
-// FIXME: for the moment we do not derive from AnalysisTask as
-// we need GCC 7.4+ to fix a bug.
 struct CTask {
   void process(o2::aod::Collision const&, o2::aod::Tracks const&)
   {
   }
 };
 
-// FIXME: for the moment we do not derive from AnalysisTask as
-// we need GCC 7.4+ to fix a bug.
 struct DTask {
   void process(o2::aod::Tracks const&)
   {
   }
 };
 
-// FIXME: for the moment we do not derive from AnalysisTask as
-// we need GCC 7.4+ to fix a bug.
 struct ETask {
   void process(o2::aod::FooBars::iterator const& foobar)
   {
@@ -91,8 +81,6 @@ struct ETask {
   }
 };
 
-// FIXME: for the moment we do not derive from AnalysisTask as
-// we need GCC 7.4+ to fix a bug.
 struct FTask {
   expressions::Filter fooFilter = aod::test::foo > 1.;
   void process(soa::Filtered<o2::aod::FooBars>::iterator const& foobar)
@@ -101,8 +89,6 @@ struct FTask {
   }
 };
 
-// FIXME: for the moment we do not derive from AnalysisTask as
-// we need GCC 7.4+ to fix a bug.
 struct GTask {
   void process(o2::soa::Join<o2::aod::Foos, o2::aod::Bars, o2::aod::XYZ> const& foobars)
   {
@@ -114,8 +100,6 @@ struct GTask {
   }
 };
 
-// FIXME: for the moment we do not derive from AnalysisTask as
-// we need GCC 7.4+ to fix a bug.
 struct HTask {
   void process(o2::soa::Join<o2::aod::Foos, o2::aod::Bars, o2::aod::XYZ>::iterator const& foobar)
   {

--- a/Framework/Core/test/test_GroupSlicer.cxx
+++ b/Framework/Core/test/test_GroupSlicer.cxx
@@ -40,11 +40,16 @@ using Event = Events::iterator;
 
 namespace test
 {
-DECLARE_SOA_INDEX_COLUMN(Event, event);
+DECLARE_SOA_SORTED_INDEX_COLUMN(Event, event);
 DECLARE_SOA_COLUMN(X, x, float);
 DECLARE_SOA_COLUMN(Y, y, float);
 DECLARE_SOA_COLUMN(Z, z, float);
 } // namespace test
+
+namespace unsorted
+{
+DECLARE_SOA_INDEX_COLUMN(Event, event);
+}
 
 DECLARE_SOA_TABLE(TrksX, "AOD", "TRKSX",
                   test::EventId,
@@ -58,6 +63,16 @@ DECLARE_SOA_TABLE(TrksZ, "AOD", "TRKSZ",
 DECLARE_SOA_TABLE(TrksU, "AOD", "TRKSU",
                   test::X,
                   test::Y,
+                  test::Z);
+
+DECLARE_SOA_TABLE(TrksXU, "AOD", "TRKSX",
+                  unsorted::EventId,
+                  test::X);
+DECLARE_SOA_TABLE(TrksYU, "AOD", "TRKSY",
+                  unsorted::EventId,
+                  test::Y);
+DECLARE_SOA_TABLE(TrksZU, "AOD", "TRKSZ",
+                  unsorted::EventId,
                   test::Z);
 
 namespace test
@@ -336,6 +351,59 @@ BOOST_AUTO_TEST_CASE(GroupSlicerMismatchedFilteredGroups)
     auto gg = slice.groupingElement();
     BOOST_CHECK_EQUAL(gg.globalIndex(), rows[count]);
     auto trks = std::get<aod::TrksX>(as);
+    if (rows[count] == 3 || rows[count] == 10 || rows[count] == 12 || rows[count] == 16) {
+      BOOST_CHECK_EQUAL(trks.size(), 0);
+    } else {
+      BOOST_CHECK_EQUAL(trks.size(), 10);
+    }
+    for (auto& trk : trks) {
+      BOOST_CHECK_EQUAL(trk.eventId(), rows[count]);
+    }
+    ++count;
+  }
+}
+
+BOOST_AUTO_TEST_CASE(GroupSlicerMismatchedUnsortedFilteredGroups)
+{
+  TableBuilder builderE;
+  auto evtsWriter = builderE.cursor<aod::Events>();
+  for (auto i = 0; i < 20; ++i) {
+    evtsWriter(0, i, 0.5f * i, 2.f * i, 3.f * i);
+  }
+  auto evtTable = builderE.finalize();
+
+  TableBuilder builderT;
+  auto trksWriter = builderT.cursor<aod::TrksXU>();
+  std::vector<int> randomized{10, 2, 1, 0, 15, 3, 6, 4, 14, 5, 7, 9, 8, 19, 11, 13, 17, 12, 18, 19};
+  std::vector<int64_t> sel;
+  sel.resize(10 * (20 - 4));
+  std::iota(sel.begin(), sel.end(), 0);
+  for (auto i : randomized) {
+    if (i == 3 || i == 10 || i == 12 || i == 16) {
+      continue;
+    }
+    for (auto j = 0.f; j < 5; j += 0.5f) {
+      trksWriter(0, i, 0.5f * j);
+    }
+  }
+  auto trkTable = builderT.finalize();
+  using FilteredEvents = soa::Filtered<aod::Events>;
+  soa::SelectionVector rows{2, 4, 10, 9, 15};
+  FilteredEvents e{{evtTable}, {2, 4, 10, 9, 15}};
+  soa::Filtered<aod::TrksXU> t{{trkTable}, std::move(sel)};
+  BOOST_CHECK_EQUAL(e.size(), 5);
+  BOOST_CHECK_EQUAL(t.size(), 10 * (20 - 4));
+
+  auto tt = std::make_tuple(t);
+  o2::framework::AnalysisDataProcessorBuilder::GroupSlicer g(e, tt);
+
+  unsigned int count = 0;
+
+  for (auto& slice : g) {
+    auto as = slice.associatedTables();
+    auto gg = slice.groupingElement();
+    BOOST_CHECK_EQUAL(gg.globalIndex(), rows[count]);
+    auto trks = std::get<soa::Filtered<aod::TrksXU>>(as);
     if (rows[count] == 3 || rows[count] == 10 || rows[count] == 12 || rows[count] == 16) {
       BOOST_CHECK_EQUAL(trks.size(), 0);
     } else {


### PR DESCRIPTION
* Adds "sorted" property to index columns
* Adds generic slicing using Filtered mechanism to define groups
* Adds a test

Note: analysis data model in O2Physics will also need to be updated to mark the index columns in Produced tables that are sorted by construction.

@jgrosseo @ktf 
The issue is that this will work for unsorted grouping only when grouped arguments are already `Filtered` in process method signature, otherwise we cannot call it. Any suggestions?