### PR TITLE
Write MID masks to file in the format expected from DCS

### DIFF
--- a/Detectors/MUON/MID/Filtering/CMakeLists.txt
+++ b/Detectors/MUON/MID/Filtering/CMakeLists.txt
@@ -10,8 +10,8 @@
 
 o2_add_library(
   MIDFiltering
-  SOURCES src/ChannelMasksHandler.cxx src/ChannelScalers.cxx src/FetToDead.cxx
-          src/MaskMaker.cxx
+  SOURCES src/ChannelMasksHandler.cxx src/ChannelScalers.cxx
+          src/ColumnDataMaskToROMask.cxx src/FetToDead.cxx src/MaskMaker.cxx
   PUBLIC_LINK_LIBRARIES O2::DataFormatsMID O2::MIDBase O2::MIDRaw
                         Microsoft.GSL::GSL)
 

--- a/Detectors/MUON/MID/Filtering/include/MIDFiltering/ChannelMasksHandler.h
+++ b/Detectors/MUON/MID/Filtering/include/MIDFiltering/ChannelMasksHandler.h
@@ -33,11 +33,10 @@ class ChannelMasksHandler
   void switchOffChannels(const ColumnData& dead);
   bool setFromChannelMask(const ColumnData& mask);
   bool setFromChannelMasks(const std::vector<ColumnData>& masks);
-  // void setReferenceMasks(const std::vector<ColumnData>& masks);
   bool applyMask(ColumnData& data) const;
 
   std::vector<ColumnData> getMasks() const;
-  std::vector<ColumnData> getReferenceMasks() const;
+  std::vector<ColumnData> getMasksFull(std::vector<ColumnData> referenceMask) const;
 
   /// Comparison operator
   bool operator==(const ChannelMasksHandler& right) const { return mMasks == right.mMasks; }
@@ -45,7 +44,6 @@ class ChannelMasksHandler
  private:
   ColumnData& getMask(uint8_t deId, uint8_t columnId);
   std::unordered_map<uint16_t, ColumnData> mMasks{}; // Channel masks
-  // std::unordered_map<uint16_t, ColumnData> mReferenceMasks{}; // Channel masks reference
 };
 
 } // namespace mid

--- a/Detectors/MUON/MID/Filtering/include/MIDFiltering/ColumnDataMaskToROMask.h
+++ b/Detectors/MUON/MID/Filtering/include/MIDFiltering/ColumnDataMaskToROMask.h
@@ -1,0 +1,54 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDFiltering/ColumnDataMaskToROMask.h
+/// \brief  Converts ColumnData masks into local board masks
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   12 October 2021
+#ifndef O2_MID_COLUMNDATAMASKTOROMASK_H
+#define O2_MID_COLUMNDATAMASKTOROMASK_H
+
+#include <vector>
+#include <gsl/span>
+#include "DataFormatsMID/ColumnData.h"
+#include "MIDRaw/ColumnDataToLocalBoard.h"
+#include "MIDRaw/CrateMapper.h"
+
+namespace o2
+{
+namespace mid
+{
+
+class ColumnDataMaskToROMask
+{
+ public:
+  ColumnDataMaskToROMask();
+  ~ColumnDataMaskToROMask() = default;
+
+  std::vector<ROBoard> convert(gsl::span<const ColumnData> colDataMasks);
+  void write(gsl::span<const ColumnData> colDataMasks, const char* outFilename);
+  uint32_t makeConfigWord(const ROBoard& mask) const;
+
+ private:
+  bool needsMask(const ROBoard& mask, bool hasDirectInputY) const;
+  ColumnDataToLocalBoard mColToBoard;    /// ColumnData to local board
+  CrateMapper mCrateMapper;              /// Crate mapper
+  std::vector<ColumnData> mDefaultMasks; /// Default masks
+
+  static constexpr uint32_t sTxDataMask = 0x10000;
+  static constexpr uint32_t sMonmoff = 0x2;
+  static constexpr uint32_t sXorY = 0x400;
+};
+
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_COLUMNDATAMASKTOROMASK_H */

--- a/Detectors/MUON/MID/Filtering/src/ChannelMasksHandler.cxx
+++ b/Detectors/MUON/MID/Filtering/src/ChannelMasksHandler.cxx
@@ -32,9 +32,6 @@ ColumnData& ChannelMasksHandler::getMask(uint8_t deId, uint8_t columnId)
     newMask.columnId = columnId;
     newMask.patterns.fill(0xFFFF);
     return newMask;
-
-    // newMask = mReferenceMasks[uniqueId];
-    // return newMask;
   }
   return maskIt->second;
 }
@@ -90,24 +87,20 @@ std::vector<ColumnData> ChannelMasksHandler::getMasks() const
   return masks;
 }
 
-// std::vector<ColumnData> ChannelMasksHandler::getReferenceMasks() const
-// {
-//   /// Gets the masks
-//   std::vector<ColumnData> masks;
-//   for (auto& maskIt : mReferenceMasks) {
-//     masks.emplace_back(maskIt.second);
-//   }
-//   return masks;
-// }
+std::vector<ColumnData> ChannelMasksHandler::getMasksFull(std::vector<ColumnData> referenceMask) const
+{
+  /// Returns the computed masks merged with the reference masks,
+  /// which are the masks for non-existent channels
+  for (auto& mask : referenceMask) {
+    applyMask(mask);
+  }
+  return referenceMask;
+}
 
 bool ChannelMasksHandler::setFromChannelMask(const ColumnData& mask)
 {
   /// Sets the mask from a channel mask
   auto uniqueColumnId = getColumnDataUniqueId(mask.deId, mask.columnId);
-  // auto ref = mReferenceMasks.find(uniqueColumnId);
-  // if (mask == ref->second) {
-  //   return false;
-  // }
   mMasks[uniqueColumnId] = mask;
   return true;
 }
@@ -121,35 +114,5 @@ bool ChannelMasksHandler::setFromChannelMasks(const std::vector<ColumnData>& mas
   }
   return isDone;
 }
-
-// void ChannelMasksHandler::setReferenceMasks(const std::vector<ColumnData>& masks)
-// {
-//   /// Sets the reference mask
-//   for (auto& mask : masks) {
-//     mReferenceMasks[getColumnDataUniqueId(mask.deId, mask.columnId)] = mask;
-//   }
-// }
-
-// ChannelMasksHandler buildDefaultChannelMasksHandler()
-// {
-//   /// Builds the default channel mask
-//   Mapping mapping;
-//   ChannelMasksHandler ChannelMasksHandler;
-//   for (int ide = 0; ide < detparams::NDetectionElements; ++ide) {
-//     for (int icol = mapping.getFirstColumn(ide); icol < 7; ++icol) {
-//       ColumnData mask;
-//       mask.deId = ide;
-//       mask.columnId = icol;
-//       for (int iline = mapping.getFirstBoardBP(icol, ide); iline <= mapping.getLastBoardBP(icol, ide); ++iline) {
-//         mask.setBendPattern(0xFFFF, iline);
-//       }
-//       for (int istrip = 0; istrip < mapping.getNStripsNBP(icol, ide); ++istrip) {
-//         mask.addStrip(istrip, 1, 0);
-//       }
-//       ChannelMasksHandler.setFromChannelMasksHandler(mask);
-//     }
-//   }
-//   return ChannelMasksHandler;
-// }
 } // namespace mid
 } // namespace o2

--- a/Detectors/MUON/MID/Filtering/src/ColumnDataMaskToROMask.cxx
+++ b/Detectors/MUON/MID/Filtering/src/ColumnDataMaskToROMask.cxx
@@ -1,0 +1,107 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Filtering/src/ColumnDataMaskToROMask.cxx
+/// \brief  Converts ColumnData masks into local board masks
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   12 October 2021
+
+#include "MIDFiltering/ColumnDataMaskToROMask.h"
+
+#include <fstream>
+#include "fmt/format.h"
+#include "MIDFiltering/MaskMaker.h"
+#include "MIDFiltering/ChannelMasksHandler.h"
+
+namespace o2
+{
+namespace mid
+{
+ColumnDataMaskToROMask::ColumnDataMaskToROMask()
+{
+  // Default ctr
+  mDefaultMasks = makeDefaultMasks();
+  mColToBoard.setDebugMode(true);
+}
+
+bool ColumnDataMaskToROMask::needsMask(const ROBoard& mask, bool hasDirectInputY) const
+{
+  /// Returns true if the local board is masked
+  if (!hasDirectInputY) {
+    return true;
+  }
+
+  for (int ich = 0; ich < 4; ++ich) {
+    if (mask.patternsBP[ich] != 0xFFFF || mask.patternsNBP[ich] != 0xFFFF) {
+      return true;
+    }
+  }
+  return false;
+}
+
+uint32_t ColumnDataMaskToROMask::makeConfigWord(const ROBoard& mask) const
+{
+  /// Computes the configuration word for the local board
+  auto cfgWord = sTxDataMask;
+  bool hasDirectInputY = mCrateMapper.hasDirectInputY(mask.boardId);
+  bool isMasked = needsMask(mask, hasDirectInputY);
+  if (isMasked) {
+    cfgWord |= sMonmoff;
+  }
+  if (!hasDirectInputY) {
+    cfgWord |= sXorY;
+  }
+  return cfgWord;
+}
+
+std::vector<ROBoard> ColumnDataMaskToROMask::convert(gsl::span<const ColumnData> colDataMasks)
+{
+  /// Converts ColumnData masks into local board masks
+  mColToBoard.process(colDataMasks);
+
+  std::vector<ROBoard> roMasks;
+  for (auto& mapIt : mColToBoard.getData()) {
+    for (auto& board : mapIt.second) {
+      roMasks.emplace_back(board);
+    }
+  }
+  return roMasks;
+}
+
+void ColumnDataMaskToROMask::write(gsl::span<const ColumnData> colDataMasks, const char* outFilename)
+{
+  /// Writes the mask to file
+
+  // FIXME: currently, the masks are written to a file that is then read by WinCC
+  // In the future, this should be moved to ccdb
+
+  auto roMasks = convert(colDataMasks);
+
+  // We order the masks for easier reading from humans
+  std::sort(roMasks.begin(), roMasks.end(), [](const ROBoard& loc1, const ROBoard& loc2) { return loc1.boardId < loc2.boardId; });
+
+  std::ofstream outFile(outFilename);
+  for (auto& mask : roMasks) {
+    auto cfgWord = makeConfigWord(mask);
+    outFile << fmt::format("{:02x} {:08x}", mask.boardId, cfgWord);
+
+    bool isMasked = cfgWord & sMonmoff;
+
+    for (int ich = 0; ich < 4; ++ich) {
+      uint16_t valBP = isMasked ? mask.patternsBP[ich] : 0;
+      uint16_t valNBP = (isMasked && (cfgWord & sXorY) == 0) ? mask.patternsNBP[ich] : 0;
+      outFile << fmt::format(" {:04x}{:04x}", valBP, valNBP);
+    }
+    outFile << std::endl;
+  }
+}
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/CrateMapper.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/CrateMapper.h
@@ -39,12 +39,17 @@ class CrateMapper
   static uint8_t getLineId(uint16_t deBoardId) { return (deBoardId >> 7) & 0x3; }
   uint8_t deLocalBoardToRO(uint8_t deId, uint8_t columnId, uint8_t lineId) const;
 
-  uint16_t roLocalBoardToDE(uint8_t crateId, uint8_t boardId) const;
+  uint16_t roLocalBoardToDE(uint8_t uniqueLocId) const;
+
+  bool hasDirectInputY(uint8_t uniqueLocId) const;
 
  private:
   void init();
-  std::unordered_map<uint8_t, uint16_t> mROToDEMap; /// Correspondence between RO and DE board
-  std::unordered_map<uint16_t, uint8_t> mDEToROMap; /// Correspondence between DE and RO board
+  /// Returns the unique Loc ID in the right side
+  uint8_t getUniqueLocIdRight(uint8_t uniqueLocId) const { return uniqueLocId % 0x80; }
+  std::unordered_map<uint8_t, uint16_t> mROToDEMap;   /// Correspondence between RO and DE board
+  std::unordered_map<uint16_t, uint8_t> mDEToROMap;   /// Correspondence between DE and RO board
+  std::unordered_map<uint8_t, bool> mHasDirectInputY; /// Flag to state if the local board has direct input from FEE
 };
 } // namespace mid
 } // namespace o2

--- a/Detectors/MUON/MID/Raw/src/DecodedDataAggregator.cxx
+++ b/Detectors/MUON/MID/Raw/src/DecodedDataAggregator.cxx
@@ -44,7 +44,7 @@ void DecodedDataAggregator::addData(const ROBoard& loc, size_t firstEntry, size_
   uint8_t crateId = raw::getCrateId(uniqueLocId);
   bool isRightSide = crateparams::isRightSide(crateId);
   try {
-    uint16_t deBoardId = mCrateMapper.roLocalBoardToDE(crateId, raw::getLocId(loc.boardId));
+    uint16_t deBoardId = mCrateMapper.roLocalBoardToDE(uniqueLocId);
     auto rpcLineId = mCrateMapper.getRPCLine(deBoardId);
     auto columnId = mCrateMapper.getColumnId(deBoardId);
     auto lineId = mCrateMapper.getLineId(deBoardId);

--- a/Detectors/MUON/MID/Raw/test/testCrateMapper.cxx
+++ b/Detectors/MUON/MID/Raw/test/testCrateMapper.cxx
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE(FEEBoardToDE)
       }
       bool exceptionReceived = false;
       try {
-        crateMapper.roLocalBoardToDE(icrate, iboard);
+        crateMapper.roLocalBoardToDE(o2::mid::raw::makeUniqueLocID(icrate, iboard));
       } catch (std::runtime_error except) {
         exceptionReceived = true;
       }
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_CASE(Consistency)
       for (int iline = mapping.getFirstBoardBP(icol, ide); iline <= mapping.getLastBoardBP(icol, ide); ++iline) {
         auto uniqueLocId = crateMapper.deLocalBoardToRO(ide, icol, iline);
         auto crateId = o2::mid::raw::getCrateId(uniqueLocId);
-        auto deBoardId = crateMapper.roLocalBoardToDE(crateId, o2::mid::raw::getLocId(uniqueLocId));
+        auto deBoardId = crateMapper.roLocalBoardToDE(uniqueLocId);
         BOOST_TEST(static_cast<int>(crateMapper.getColumnId(deBoardId)) == icol);
         BOOST_TEST(static_cast<int>(crateMapper.getLineId(deBoardId)) == iline);
         int rpcLineId = crateMapper.getRPCLine(deBoardId);

--- a/Detectors/MUON/MID/Workflow/src/MaskHandlerSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/MaskHandlerSpec.cxx
@@ -18,6 +18,7 @@
 
 #include <array>
 #include <vector>
+#include <map>
 #include <chrono>
 #include <gsl/gsl>
 #include "Framework/ConfigParamRegistry.h"
@@ -27,8 +28,9 @@
 #include "Framework/Task.h"
 #include "DataFormatsMID/ColumnData.h"
 #include "DataFormatsMID/ROFRecord.h"
-#include "MIDRaw/ColumnDataToLocalBoard.h"
 #include "MIDFiltering/ChannelMasksHandler.h"
+#include "MIDFiltering/ColumnDataMaskToROMask.h"
+#include "MIDFiltering/MaskMaker.h"
 
 namespace of = o2::framework;
 
@@ -43,6 +45,8 @@ class MaskHandlerDeviceDPL
   void init(o2::framework::InitContext& ic)
   {
 
+    mOutFilename = ic.options().get<std::string>("mid-mask-outfile");
+
     auto stop = [this]() {
       printSummary();
     };
@@ -52,8 +56,7 @@ class MaskHandlerDeviceDPL
   void printSummary()
   {
     std::string name = "calib";
-    o2::mid::ColumnDataToLocalBoard colToBoard;
-    colToBoard.setDebugMode(true);
+    o2::mid::ColumnDataMaskToROMask colMasksToRO;
 
     for (auto& masks : mMasksHandlers) {
       auto maskVec = masks.getMasks();
@@ -65,18 +68,27 @@ class MaskHandlerDeviceDPL
           LOG(INFO) << mask;
         }
         std::cout << "\nCorresponding boards masks:" << std::endl;
-        colToBoard.process(maskVec);
-        for (auto& mapIt : colToBoard.getData()) {
-          for (auto& board : mapIt.second) {
-            std::cout << board << std::endl;
-          }
+        auto roMasks = colMasksToRO.convert(maskVec);
+        for (auto& board : roMasks) {
+          std::cout << board << std::endl;
         }
       }
+
+      if (!mOutFilename.empty()) {
+        auto idx = mOutFilename.find_last_of("/");
+        auto insertIdx = (idx == std::string::npos) ? 0 : idx + 1;
+        std::string outFilename = mOutFilename;
+        outFilename.insert(insertIdx, "_");
+        outFilename.insert(insertIdx, name.c_str());
+        colMasksToRO.write(masks.getMasksFull(o2::mid::makeDefaultMasks()), outFilename.c_str());
+      }
+
       name = "FET";
     }
   }
 
-  void run(o2::framework::ProcessingContext& pc)
+  void
+    run(o2::framework::ProcessingContext& pc)
   {
     auto tStart = std::chrono::high_resolution_clock::now();
 
@@ -112,6 +124,7 @@ class MaskHandlerDeviceDPL
   std::array<ChannelMasksHandler, 2> mMasksHandlers{}; ///< Output masks
   std::chrono::duration<double> mTimer{0};             ///< full timer
   std::chrono::duration<double> mTimerMaskHandler{0};  ///< mask handler timer
+  std::string mOutFilename{};                          ///< output filename
 };
 
 framework::DataProcessorSpec getMaskHandlerSpec()
@@ -124,7 +137,9 @@ framework::DataProcessorSpec getMaskHandlerSpec()
     "MIDMaskHandler",
     {inputSpecs},
     {},
-    of::AlgorithmSpec{of::adaptFromTask<o2::mid::MaskHandlerDeviceDPL>()}};
+    of::AlgorithmSpec{of::adaptFromTask<o2::mid::MaskHandlerDeviceDPL>()},
+    of::Options{
+      {"mid-mask-outfile", of::VariantType::String, "", {"Output filename"}}}};
 }
 } // namespace mid
 } // namespace o2


### PR DESCRIPTION
This PR consists of three commits:
- the first one add to the mapping the information on which local board has a direct input from the Front-End electronics
- the second one introduces a class to convert the MID digits into a mask suitable for the reaodut electronics
- the third commit uses the first two to write a file that can be used by WinCC to setup the mask
Notice that such a mask should go to the ccdb at some point, but this will be done when the MID DCS can handle the communication with ccdb.
Text files are used for the time being.

The commits are meant to be atomic: please do not squash