### PR TITLE
macro to upload and fetch Mat LUT to/from CCDB

### DIFF
--- a/Detectors/Base/include/DetectorsBase/MatLayerCylSet.h
+++ b/Detectors/Base/include/DetectorsBase/MatLayerCylSet.h
@@ -69,7 +69,6 @@ class MatLayerCylSet : public o2::gpu::FlatObject
   GPUd() float getRMax2() const { return get()->mRMax2; }
 
 #ifndef GPUCA_ALIGPUCODE // this part is unvisible on GPU version
-
   void print(bool data = false) const;
   void addLayer(float rmin, float rmax, float zmax, float dz, float drphi);
   void populateFromTGeo(int ntrPerCel = 10);
@@ -78,6 +77,8 @@ class MatLayerCylSet : public o2::gpu::FlatObject
   void dumpToTree(const std::string outName = "matbudTree.root") const;
   void writeToFile(std::string outFName = "matbud.root", std::string name = "MatBud");
   static MatLayerCylSet* loadFromFile(std::string inpFName = "matbud.root", std::string name = "MatBud");
+  static MatLayerCylSet* rectifyPtrFromFile(MatLayerCylSet* ptr);
+
   void flatten();
 
 #endif // !GPUCA_ALIGPUCODE

--- a/Detectors/Base/src/MatLayerCylSet.cxx
+++ b/Detectors/Base/src/MatLayerCylSet.cxx
@@ -183,12 +183,21 @@ MatLayerCylSet* MatLayerCylSet::loadFromFile(std::string inpFName, std::string n
     LOG(ERROR) << "Failed to open input file " << inpFName;
     return nullptr;
   }
-  MatLayerCylSet* mb = reinterpret_cast<MatLayerCylSet*>(inpf.GetObjectChecked(name.data(), Class()));
+  MatLayerCylSet* mb = rectifyPtrFromFile(reinterpret_cast<MatLayerCylSet*>(inpf.GetObjectChecked(name.data(), Class())));
   if (!mb) {
     LOG(ERROR) << "Failed to load " << name << " from " << inpFName;
   }
-  mb->fixPointers();
   return mb;
+}
+
+//________________________________________________________________________________
+MatLayerCylSet* MatLayerCylSet::rectifyPtrFromFile(MatLayerCylSet* ptr)
+{
+  // rectify object loaded from file
+  if (ptr && !ptr->get()) {
+    ptr->fixPointers();
+  }
+  return ptr;
 }
 
 //________________________________________________________________________________

--- a/macro/CMakeLists.txt
+++ b/macro/CMakeLists.txt
@@ -53,6 +53,7 @@ install(FILES CheckDigits_mft.C
               run_trac_its.C
               CreateBCPattern.C
               UploadDummyAlignment.C
+       UploadMatBudLUT.C
        CreateCTPOrbitResetObject.C
         DESTINATION share/macro/)
 
@@ -345,6 +346,12 @@ o2_add_test_root_macro(run_trac_its.C
                                              O2::SimulationDataFormat
                         LABELS its)
 
+o2_add_test_root_macro(UploadMatBudLUT.C
+                       PUBLIC_LINK_LIBRARIES O2::DetectorsCommonDataFormats
+                                             O2::CCDB
+                                             O2::DataFormatsParameters
+                                             O2::DetectorsBase
+          O2::CommonUtils)
 #
 # NOTE: commented out until unit testing reenabled FIXME : re-enable or delete ?
 #

--- a/macro/UploadMatBudLUT.C
+++ b/macro/UploadMatBudLUT.C
@@ -1,0 +1,39 @@
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include "DetectorsCommonDataFormats/NameConf.h"
+#include "CCDB/CcdbApi.h"
+#include "CCDB/BasicCCDBManager.h"
+#include "Framework/Logger.h"
+#include <fmt/format.h>
+#include "DetectorsBase/MatLayerCylSet.h"
+#include "CommonUtils/StringUtils.h"
+#endif
+
+// upload material LUT to CCDB
+bool UploadMatBudLUT(const std::string& matLUTFile, long tmin = 0, long tmax = -1, const std::string& url = "GLO/Param/MatLUT", const std::string& ccdbHost = "http://ccdb-test.cern.ch:8080")
+{
+  o2::base::MatLayerCylSet* lut = nullptr;
+  if (o2::utils::Str::pathExists(matLUTFile)) {
+    lut = o2::base::MatLayerCylSet::loadFromFile(matLUTFile);
+  } else {
+    LOG(ERROR) << "Material LUT " << matLUTFile << " file is absent";
+    return false;
+  }
+
+  o2::ccdb::CcdbApi api;
+  api.init(ccdbHost.c_str());   // or http://localhost:8080 for a local installation
+  map<string, string> metadata; // can be empty
+  metadata["comment"] = "Material lookup table";
+  api.storeAsTFileAny(lut, url, metadata, tmin, tmax);
+  return true;
+}
+
+auto fetchMatBudLUT(const std::string& url = "GLO/Param/MatLUT", const std::string& ccdbHost = "http://ccdb-test.cern.ch:8080")
+{
+  auto& mgr = o2::ccdb::BasicCCDBManager::instance();
+  mgr.setURL(ccdbHost);
+  auto lut = o2::base::MatLayerCylSet::rectifyPtrFromFile(mgr.get<o2::base::MatLayerCylSet>(url));
+  if (!lut) {
+    LOG(ERROR) << "Failed to fetch material LUT from " << ccdbHost << "/" << url;
+  }
+  return lut;
+}


### PR DESCRIPTION
@victor-gonzalez @jgrosseo I've uploaded the mat.LUT to both [test](http://ccdb-test.cern.ch:8080/browse/GLO/Param/MatLUT?report=true) and [production](http://alice-ccdb.cern.ch:8080/browse/GLO/Param/MatLUT) servers. 

This [snippet](https://github.com/shahor02/AliceO2/blob/76375ca96cf51b9345c5bd64ed1129d9f793270e/macro/UploadMatBudLUT.C#L32-L34) shows how it should be loaded (it is a special, copiable object, so it requires a small initialization from the retrieved pointer).
