### PR TITLE
[CPV] Fix mc labels handling in clusterizer

### DIFF
--- a/Detectors/CPV/calib/macros/readPedestalsFromCCDB.C
+++ b/Detectors/CPV/calib/macros/readPedestalsFromCCDB.C
@@ -6,7 +6,9 @@
 #include "CCDB/CCDBTimeStampUtils.h"
 #include "DataFormatsCPV/Pedestals.h"
 #include "CPVBase/Geometry.h"
+#include "CPVBase/CPVSimParams.h"
 #include <iostream>
+#include <fstream>
 #endif
 
 o2::cpv::Pedestals* readPedestalsFromCCDB(long timeStamp = 0, const char* ccdbURI = "http://ccdb-test.cern.ch:8080")
@@ -63,5 +65,22 @@ o2::cpv::Pedestals* readPedestalsFromCCDB(long timeStamp = 0, const char* ccdbUR
     can->cd(4);
     hPedSigmas1D[iMod]->Draw();
   }
+
+  // write pedestal thresholds to text file for electronics
+  std::ofstream pededstalsTxt;
+  float nSigmas = o2::cpv::CPVSimParams::Instance().mZSnSigmas;
+  pededstalsTxt.open("pedestals.txt");
+  for (unsigned short iCh = 0; iCh < 23040; iCh++) {
+    short threshold = peds->getPedestal(iCh) + std::floor(peds->getPedSigma(iCh) * nSigmas) + 1;
+    if ((threshold <= 0) || (threshold > 511)) {
+      threshold = 511; // set maximum threshold for suspisious channels
+    }
+    short ccId, dil, gas, pad;
+    geo.absIdToHWaddress(iCh, ccId, dil, gas, pad);
+    unsigned short addr = ccId * 4 * 5 * 48 + dil * 5 * 48 + gas * 48 + pad;
+    pededstalsTxt << addr << " " << threshold << std::endl;
+  }
+  pededstalsTxt.close();
+
   return peds;
 }

--- a/Detectors/CPV/simulation/include/CPVSimulation/Digitizer.h
+++ b/Detectors/CPV/simulation/include/CPVSimulation/Digitizer.h
@@ -45,12 +45,12 @@ class Digitizer : public TObject
   float simulatePedestalNoise(int absId);
 
  private:
-  static constexpr short NCHANNELS = 23040; //128*60*3:  toatl number of CPV channels
-  CalibParams* mCalibParams;                /// Calibration coefficients
-  Pedestals* mPedestals;                    /// Pedestals
-  BadChannelMap* mBadMap;                   /// Bad channel map
-  std::array<Digit, NCHANNELS> mArrayD;     ///array of digits (for inner use)
-  std::array<float, NCHANNELS> mDigitThresholds;
+  static constexpr short NCHANNELS = 23040;      //128*60*3:  toatl number of CPV channels
+  CalibParams* mCalibParams;                     /// Calibration coefficients
+  Pedestals* mPedestals;                         /// Pedestals
+  BadChannelMap* mBadMap;                        /// Bad channel map
+  std::array<Digit, NCHANNELS> mArrayD;          /// array of digits (for inner use)
+  std::array<float, NCHANNELS> mDigitThresholds; /// array of readout thresholds (for inner use)
   ClassDefOverride(Digitizer, 3);
 };
 } // namespace cpv

--- a/Detectors/CPV/workflow/src/ClusterizerSpec.cxx
+++ b/Detectors/CPV/workflow/src/ClusterizerSpec.cxx
@@ -15,7 +15,6 @@
 #include "DataFormatsCPV/CPVBlockHeader.h"
 #include "CPVWorkflow/ClusterizerSpec.h"
 #include "Framework/ControlService.h"
-#include <iostream>
 
 using namespace o2::cpv::reco_workflow;
 


### PR DESCRIPTION
Hello! There is a fix of failure of CPV clusterizer to process MC. Proper handling of MCLabels were needed in order to get rid of errors during clusterization. Also readPedestalsFromCCDB.C is modified to download o2::cpv::Pedestals from CCDB and prepare txt file which can be used for direct configure of FEE.