### PR TITLE
DPL: prevent OutputProxy from using 100% CPU usage when idle

### DIFF
--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -457,6 +457,12 @@ void DataProcessingDevice::initPollers()
         LOGP(debug, "{} is to send data. Not polling.", channelName);
         continue;
       }
+
+      if (channelName.rfind("from_") != 0) {
+        LOGP(info, "{} is not a DPL socket. Not polling.", channelName);
+        continue;
+      }
+
       // We assume there is always a ZeroMQ socket behind.
       int zmq_fd = 0;
       size_t zmq_fd_len = sizeof(zmq_fd);


### PR DESCRIPTION
This is because the output proxy channel polled as readable and
therefore it kept awakening the event loop.