### PR TITLE
[EMCAL-728] Reduce verbosity of the error logging

### DIFF
--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/Channel.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/Channel.h
@@ -146,6 +146,30 @@ class Channel
   /// \param starttime Start time of the bunch
   Bunch& createBunch(uint8_t bunchlength, uint8_t starttime);
 
+  /// \brief Extrcting hardware address from the channel header word
+  /// \param channelheader Channel header word
+  static int getHardwareAddressFromChannelHeader(int channelheader) { return channelheader & 0xFFF; };
+
+  /// \brief Extrcting payload size from the channel header word
+  /// \param channelheader Channel header word
+  static int getPayloadSizeFromChannelHeader(int channelheader) { return (channelheader >> 16) & 0x3FF; }
+
+  /// \brief Extracting branch index from the hardware address
+  /// \param hwaddress Hardware address of the channel
+  static int getBranchIndexFromHwAddress(int hwaddress) { return ((hwaddress >> 11) & 0x1); }
+
+  /// \brief Extracting FEC index in branch from the hardware address
+  /// \param hwaddress Hardware address of the channel
+  static int getFecIndexFromHwAddress(int hwaddress) { return ((hwaddress >> 7) & 0xF); }
+
+  /// \brief Extracting ALTRO index from the hardware address
+  /// \param hwaddress Hardware address of the channel
+  static int getAltroIndexFromHwAddress(int hwaddress) { return ((hwaddress >> 4) & 0x7); }
+
+  /// \brief Extracting Channel index in FEC from the hardware address
+  /// \param hwaddress Hardware address of the channel
+  static int getChannelIndexFromHwAddress(int hwaddress) { return (hwaddress & 0xF); }
+
  private:
   int32_t mHardwareAddress = -1; ///< Hardware address
   uint8_t mPayloadSize = 0;      ///< Payload size

--- a/Detectors/EMCAL/reconstruction/src/AltroDecoder.cxx
+++ b/Detectors/EMCAL/reconstruction/src/AltroDecoder.cxx
@@ -70,7 +70,7 @@ void AltroDecoder::readChannels()
     }
     // starting a new channel
     auto channelheader = currentword;
-    mChannels.emplace_back(currentword & 0xFFF, (currentword >> 16) & 0x3FF);
+    mChannels.emplace_back(Channel::getHardwareAddressFromChannelHeader(currentword), Channel::getPayloadSizeFromChannelHeader(currentword));
     auto& currentchannel = mChannels.back();
     currentchannel.setBadChannel((currentword >> 29) & 0x1);
 

--- a/Detectors/EMCAL/reconstruction/src/Channel.cxx
+++ b/Detectors/EMCAL/reconstruction/src/Channel.cxx
@@ -17,7 +17,7 @@ int Channel::getBranchIndex() const
   if (mHardwareAddress == -1) {
     throw HardwareAddressError();
   }
-  return ((mHardwareAddress >> 11) & 0x1);
+  return getBranchIndexFromHwAddress(mHardwareAddress);
 }
 
 int Channel::getFECIndex() const
@@ -25,7 +25,7 @@ int Channel::getFECIndex() const
   if (mHardwareAddress == -1) {
     throw HardwareAddressError();
   }
-  return ((mHardwareAddress >> 7) & 0xF);
+  return getFecIndexFromHwAddress(mHardwareAddress);
 }
 
 Int_t Channel::getAltroIndex() const
@@ -33,7 +33,7 @@ Int_t Channel::getAltroIndex() const
   if (mHardwareAddress == -1) {
     throw HardwareAddressError();
   }
-  return ((mHardwareAddress >> 4) & 0x7);
+  return getAltroIndexFromHwAddress(mHardwareAddress);
 }
 
 Int_t Channel::getChannelIndex() const
@@ -41,7 +41,7 @@ Int_t Channel::getChannelIndex() const
   if (mHardwareAddress == -1) {
     throw HardwareAddressError();
   }
-  return (mHardwareAddress & 0xF);
+  return getChannelIndexFromHwAddress(mHardwareAddress);
 }
 
 Bunch& Channel::createBunch(uint8_t bunchlength, uint8_t starttime)

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/RawToCellConverterSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/RawToCellConverterSpec.h
@@ -9,11 +9,16 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#include <climits>
+#include <string_view>
+#include <unordered_map>
 #include <vector>
+#include <boost/container_hash/hash.hpp>
 
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
 #include "DataFormatsEMCAL/Cell.h"
+#include "DataFormatsEMCAL/ErrorTypeFEE.h"
 #include "DataFormatsEMCAL/TriggerRecord.h"
 #include "Headers/DataHeader.h"
 #include "EMCALBase/Geometry.h"
@@ -81,6 +86,158 @@ class RawToCellConverterSpec : public framework::Task
   header::DataHeader::SubSpecificationType getSubspecification() const { return mSubspecification; }
 
  private:
+  /// \struct MessageChannel
+  /// \brief Handling of messages per HW channel
+  struct MessageChannel {
+    int mDDL;             ///< DDK ID
+    int mFEC;             ///< FEC in DDL
+    int mHWAddress;       ///< Full hardware address
+    std::string mMessage; ///< Error message
+
+    /// \brief Check whehter message is equal to other message
+    /// \param other Message to compare to
+    /// \return True if the messages (including channel information) are the same, false otherwise
+    bool operator==(const MessageChannel& other) const
+    {
+      return mDDL == other.mDDL && mFEC == other.mFEC && mHWAddress == other.mHWAddress && mMessage == other.mMessage;
+    }
+
+    /// \brief Create combined error message with channel information
+    /// \return Error message to be logged
+    std::string print();
+  };
+
+  /// \struct MessageChannelHasher
+  /// \brief Hash functor for channel-based error messages
+  struct MessageChannelHasher {
+
+    /// \brief Hash functor
+    /// \param s MessageChannel object to be hashed
+    /// \return Hash value
+    size_t operator()(const MessageChannel& s) const
+    {
+      std::size_t seed = 0;
+      boost::hash_combine(seed, s.mDDL);
+      boost::hash_combine(seed, s.mFEC);
+      boost::hash_combine(seed, s.mHWAddress);
+      boost::hash_combine(seed, std::hash<std::string>{}(s.mMessage));
+      return seed;
+    }
+  };
+
+  /// \struct MessageDDL
+  /// \brief Handling messages per DDL
+  struct MessageDDL {
+    int mDDL;             ///< DDL ID
+    std::string mMessage; ///< Error message
+
+    /// \brief Check whehter message is equal to other message
+    /// \param other Message to compare to
+    /// \return True if the messages (including DDL information) are the same, false otherwise
+    bool operator==(const MessageDDL& other) const
+    {
+      return mDDL == other.mDDL && mMessage == other.mMessage;
+    }
+
+    /// \brief Create combined error message with DDL information
+    /// \return Error message to be logged
+    std::string print();
+  };
+
+  /// \struct MessageDDLHasher
+  /// \brief Hash functor for DDL-based error messages
+  struct MessageDDLHasher {
+
+    /// \brief Hash functor
+    /// \param s MessageDDL object to be hashed
+    /// \return Hash value
+    size_t operator()(const MessageDDL& s) const
+    {
+      std::size_t seed = 0;
+      boost::hash_combine(seed, s.mDDL);
+      boost::hash_combine(seed, std::hash<std::string>{}(s.mMessage));
+      return seed;
+    }
+  };
+
+  /// \struct MessageCell
+  /// \brief Handling messages per Cell
+  struct MessageCell {
+    int mSMID;            ///< Supermodule ID
+    int mCellID;          ///< Cell ID
+    std::string mMessage; ///< Error message
+
+    /// \brief Check whehter message is equal to other message
+    /// \param other Message to compare to
+    /// \return True if the messages (including cell information) are the same, false otherwise
+    bool operator==(const MessageCell& other) const
+    {
+      return mSMID == other.mSMID && mCellID == other.mCellID && mMessage == other.mMessage;
+    }
+
+    /// \brief Create combined error message with cell information
+    /// \return Error message to be logged
+    std::string print();
+  };
+
+  /// \struct MessageCellHasher
+  /// \brief Hash functor for Cell-based error messages
+  struct MessageCellHasher {
+
+    /// \brief Hash functor
+    /// \param s MessageDDL object to be hashed
+    /// \return Hash value
+    size_t operator()(const MessageCell& s) const
+    {
+      std::size_t seed = 0;
+      boost::hash_combine(seed, s.mCellID);
+      boost::hash_combine(seed, s.mSMID);
+      boost::hash_combine(seed, std::hash<std::string>{}(s.mMessage));
+      return seed;
+    }
+  };
+
+  /// \class MessageHandler
+  /// \brief Logging of error message suppressing multiple occurrences
+  ///
+  /// In order to prevent multiple occurrences of the same error message
+  /// which can end up in a message flood on the infoBrowser an internal
+  /// map keeps track of messages already printed before. In case the
+  /// message is fouund in the map it is suppressed until the end of the run.
+  template <typename MessageType, typename Hasher>
+  class MessageHandler
+  {
+   public:
+    /// \enum Severity
+    /// \brief Logging severity
+    enum class Severity {
+      WARNING, ///< Waring level
+      ERROR,   ///< Error level
+      FATAL    ///< Fatal level
+    };
+
+    /// \brief Constructor
+    MessageHandler() = default;
+
+    /// \brief Destructor
+    ~MessageHandler() = default;
+
+    /// \brief Logging error message
+    /// \brief msg Message object (channel and message)
+    /// \brief level Log severity
+    ///
+    /// Printing message in case the message has not been printed
+    /// before for the same channel
+    void log(MessageType msg, Severity level);
+
+   private:
+    std::unordered_map<MessageType, unsigned long, Hasher> mErrorsPerEntry; ///< Counter of the number of suppressed error messages
+  };
+
+  using ChannelMessageHandler = MessageHandler<MessageChannel, MessageChannelHasher>;
+  using CellMessageHandler = MessageHandler<MessageCell, MessageCellHasher>;
+  using DDLMessageHandler = MessageHandler<MessageDDL, MessageDDLHasher>;
+
   /// \struct RecCellInfo
   /// \brief Internal bookkeeping for cell double counting
   ///
@@ -101,7 +258,15 @@ class RawToCellConverterSpec : public framework::Task
     int mHWAddressLG;          ///< HW address of LG (for monitoring)
     int mHWAddressHG;          ///< HW address of HG (for monitoring)
   };
+
+  /// \brief Check if the timeframe is an empty timeframe (contains DEADBEEF message)
+  /// \return True if the timeframe is a lost timeframe, false if it is OK
   bool isLostTimeframe(framework::ProcessingContext& ctx) const;
+
+  /// \brief Send data to output channels
+  /// \param cells Container with cells from all events in the timeframe
+  /// \param triggers Trigger records with ranges in cell container
+  /// \param decodingErrors Container with raw decoding errors (not separated per event)
   void sendData(framework::ProcessingContext& ctx, const std::vector<o2::emcal::Cell>& cells, const std::vector<o2::emcal::TriggerRecord>& triggers, const std::vector<ErrorTypeFEE>& decodingErrors) const;
 
   header::DataHeader::SubSpecificationType mSubspecification = 0; ///< Subspecification for output channels
@@ -109,6 +274,7 @@ class RawToCellConverterSpec : public framework::Task
   int mNumErrorMessages = 0;                                      ///< Current number of error messages
   int mErrorMessagesSuppressed = 0;                               ///< Counter of suppressed error messages
   int mMaxErrorMessages = 100;                                    ///< Max. number of error messages
+  bool mMergeLGHG = true;                                         ///< Merge low and high gain cells
   bool mPrintTrailer = false;                                     ///< Print RCU trailer
   Geometry* mGeometry = nullptr;                                  ///!<! Geometry pointer
   std::unique_ptr<MappingHandler> mMapper = nullptr;              ///!<! Mapper
@@ -116,6 +282,9 @@ class RawToCellConverterSpec : public framework::Task
   std::vector<Cell> mOutputCells;                                 ///< Container with output cells
   std::vector<TriggerRecord> mOutputTriggerRecords;               ///< Container with output cells
   std::vector<ErrorTypeFEE> mOutputDecoderErrors;                 ///< Container with decoder errors
+  ChannelMessageHandler mChannelMessages;                         ///< Handling of error message per Channel
+  CellMessageHandler mCellMessages;                               ///< Handling of error message per Cell
+  DDLMessageHandler mDDLMessages;                                 ///< Handling of error messages per DDL
 };
 
 /// \brief Creating DataProcessorSpec for the EMCAL Cell Converter Spec


### PR DESCRIPTION
Errors related to raw channels (HW channels, DDL,
cell ID are cached in a std::unordered_map. In case
the same message has already been printed before
the message is suppressed in all further occurrences
and instead the number of occurrences is counted.

In addition option to switch off merging of high gain/
low gain cells, this is particular of relevance for MC
where only either of the two channel types are stored,
resulting in a large amount of raw data errors.