### PR TITLE
Fix in MatchGlobalFwd: check ROF validity

### DIFF
--- a/Detectors/GlobalTracking/src/MatchGlobalFwd.cxx
+++ b/Detectors/GlobalTracking/src/MatchGlobalFwd.cxx
@@ -212,6 +212,9 @@ void MatchGlobalFwd::doMatching()
     while (mchROF < nMCHROFs && (thisMFTBracket.isOutside(mMCHROFTimes[mchROF]))) {
       mchROF++;
     }
+    if (mchROF >= nMCHROFs) {
+      continue;
+    }
     int mchROFMatchFirst = -1;
     int mchROFMatchLast = -1;
 
@@ -220,6 +223,9 @@ void MatchGlobalFwd::doMatching()
 
       while (mchROF < nMCHROFs && !(thisMFTBracket < mMCHROFTimes[mchROF])) {
         mchROF++;
+      }
+      if (mchROF >= nMCHROFs) {
+        continue;
       }
       mchROFMatchLast = mchROF - 1;
     } else {


### PR DESCRIPTION
@rpezzi I've got an exception in the FST due to the span out-of-bound access in:
```
#7  0x00007fa40ce73067 in o2::globaltracking::MatchGlobalFwd::ROFMatch (
    this=0x3994658, MFTROFId=0, firstMCHROFId=10, lastMCHROFId=9)
    at /home/shahoian/alice/sw/SOURCES/O2/dev/0/Detectors/GlobalTracking/src/MatchGlobalFwd.cxx:239
239       const auto& firstMCHROF = mMCHTrackROFRec[firstMCHROFId];
```
The gdb shows:
```
(gdb) up
#8  0x00007fa40ce72dca in o2::globaltracking::MatchGlobalFwd::doMatching (this=0x3994658)
    at /home/shahoian/alice/sw/SOURCES/O2/dev/0/Detectors/GlobalTracking/src/MatchGlobalFwd.cxx:229
229           ROFMatch(MFTROFId, mchROFMatchFirst, mchROFMatchLast);
(gdb) p mMCHTrackROFRec.size()
$3 = 10
(gdb) p mchROFMatchFirst
$4 = 10
(gdb) p mchROFMatchLast
$5 = 9
(gdb) p mchROF
$6 = 10
(gdb) p nMCHROFs
$7 = 10
```
I am applying a trivial fix and merging to recover the FST, please check if further refinements needed. I see you always use `continue` when the time is not in the bracket: `thisMFTBracket.isOutside(mMCHROFTimes[mchROF])`. If the times are ordered, usually you can `break` when further checks are useless (isOutside returns +1/-1 depending on which side of the bracket the point is).