### PR TITLE
Prepend MCH local config and debug options by mch- to avoid conflict

### DIFF
--- a/Detectors/MUON/MCH/Calibration/src/pedestal-decoding-workflow.cxx
+++ b/Detectors/MUON/MCH/Calibration/src/pedestal-decoding-workflow.cxx
@@ -144,7 +144,7 @@ class PedestalsTask
   //_________________________________________________________________________________________________
   void init(framework::InitContext& ic)
   {
-    mDebug = ic.options().get<bool>("debug");
+    mDebug = ic.options().get<bool>("mch-debug");
     mLoggingInterval = ic.options().get<int>("logging-interval") * 1000;
 
     auto mapCRUfile = ic.options().get<std::string>("cru-map");
@@ -419,7 +419,7 @@ o2::framework::DataProcessorSpec getMCHPedestalDecodingSpec(const char* specName
     Outputs{OutputSpec{header::gDataOriginMCH, "PDIGITS", 0, Lifetime::Timeframe},
             OutputSpec{header::gDataOriginMCH, "ERRORS", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<o2::mch::raw::PedestalsTask>(inputSpec)},
-    Options{{"debug", VariantType::Bool, false, {"enable verbose output"}},
+    Options{{"mch-debug", VariantType::Bool, false, {"enable verbose output"}},
             {"logging-interval", VariantType::Int, 0, {"time interval in seconds between logging messages (set to zero to disable)"}},
             {"noise-threshold", VariantType::Float, (float)2.0, {"maximum acceptable noise value"}},
             {"pedestal-threshold", VariantType::Float, (float)150, {"maximum acceptable pedestal value"}},

--- a/Detectors/MUON/MCH/Workflow/src/ClusterFinderOriginalSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/ClusterFinderOriginalSpec.cxx
@@ -58,7 +58,7 @@ class ClusterFinderOriginalTask
     /// Prepare the clusterizer
     LOG(INFO) << "initializing cluster finder";
 
-    auto config = ic.options().get<std::string>("config");
+    auto config = ic.options().get<std::string>("mch-config");
     if (!config.empty()) {
       o2::conf::ConfigurableParam::updateFromFile(config, "MCHClustering", true);
     }
@@ -148,7 +148,7 @@ o2::framework::DataProcessorSpec getClusterFinderOriginalSpec(const char* specNa
             OutputSpec{{"clusters"}, "MCH", "CLUSTERS", 0, Lifetime::Timeframe},
             OutputSpec{{"clusterdigits"}, "MCH", "CLUSTERDIGITS", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<ClusterFinderOriginalTask>()},
-    Options{{"config", VariantType::String, "", {"JSON or INI file with clustering parameters"}},
+    Options{{"mch-config", VariantType::String, "", {"JSON or INI file with clustering parameters"}},
             {"run2-config", VariantType::Bool, false, {"setup for run2 data"}}}};
 }
 

--- a/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
@@ -80,7 +80,7 @@ class DataDecoderTask
 
     auto ds2manu = ic.options().get<bool>("ds2manu");
     auto sampaBcOffset = CoDecParam::Instance().sampaBcOffset;
-    mDebug = ic.options().get<bool>("debug");
+    mDebug = ic.options().get<bool>("mch-debug");
     mCheckROFs = ic.options().get<bool>("check-rofs");
     mDummyROFs = ic.options().get<bool>("dummy-rofs");
     auto mapCRUfile = ic.options().get<std::string>("cru-map");
@@ -331,7 +331,7 @@ o2::framework::DataProcessorSpec getDecodingSpec(const char* specName, std::stri
             OutputSpec{header::gDataOriginMCH, "DIGITROFS", 0, Lifetime::Timeframe},
             OutputSpec{header::gDataOriginMCH, "ORBITS", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<DataDecoderTask>(std::move(task))},
-    Options{{"debug", VariantType::Bool, false, {"enable verbose output"}},
+    Options{{"mch-debug", VariantType::Bool, false, {"enable verbose output"}},
             {"cru-map", VariantType::String, "", {"custom CRU mapping"}},
             {"fec-map", VariantType::String, "", {"custom FEC mapping"}},
             {"dummy-elecmap", VariantType::Bool, false, {"use dummy electronic mapping (for debug, temporary)"}},

--- a/Detectors/MUON/MCH/Workflow/src/TimeClusterFinderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TimeClusterFinderSpec.cxx
@@ -54,7 +54,7 @@ class TimeClusterFinderTask
     mTimeClusterWidth = ic.options().get<int>("max-cluster-width");
     mNbinsInOneWindow = ic.options().get<int>("peak-search-nbins");
     mMinDigitPerROF = ic.options().get<int>("min-digits-per-rof");
-    mDebug = ic.options().get<bool>("debug");
+    mDebug = ic.options().get<bool>("mch-debug");
 
     if (mDebug) {
       fair::Logger::SetConsoleColor(true);
@@ -126,7 +126,7 @@ o2::framework::DataProcessorSpec getTimeClusterFinderSpec(const char* specName)
     Inputs{InputSpec{"rofs", header::gDataOriginMCH, "DIGITROFS", 0, Lifetime::Timeframe}},
     Outputs{OutputSpec{{"rofs"}, header::gDataOriginMCH, "TIMECLUSTERROFS", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<TimeClusterFinderTask>()},
-    Options{{"debug", VariantType::Bool, false, {"enable verbose output"}},
+    Options{{"mch-debug", VariantType::Bool, false, {"enable verbose output"}},
             {"max-cluster-width", VariantType::Int, 1000 / 25, {"maximum time width of time clusters, in BC units"}},
             {"peak-search-nbins", VariantType::Int, 5, {"number of time bins for the peak search algorithm (must be an odd number >= 3)"}},
             {"min-digits-per-rof", VariantType::Int, 0, {"minimum number of digits per ROF (below that threshold ROF is discarded)"}}}};

--- a/Detectors/MUON/MCH/Workflow/src/TrackFinderOriginalSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackFinderOriginalSpec.cxx
@@ -63,13 +63,13 @@ class TrackFinderTask
 
     auto l3Current = ic.options().get<float>("l3Current");
     auto dipoleCurrent = ic.options().get<float>("dipoleCurrent");
-    auto config = ic.options().get<std::string>("config");
+    auto config = ic.options().get<std::string>("mch-config");
     if (!config.empty()) {
       o2::conf::ConfigurableParam::updateFromFile(config, "MCHTracking", true);
     }
     mTrackFinder.init(l3Current, dipoleCurrent);
 
-    auto debugLevel = ic.options().get<int>("debug");
+    auto debugLevel = ic.options().get<int>("mch-debug");
     mTrackFinder.debug(debugLevel);
 
     auto stop = [this]() {
@@ -165,8 +165,8 @@ o2::framework::DataProcessorSpec getTrackFinderOriginalSpec(const char* specName
     AlgorithmSpec{adaptFromTask<TrackFinderTask>()},
     Options{{"l3Current", VariantType::Float, -30000.0f, {"L3 current"}},
             {"dipoleCurrent", VariantType::Float, -6000.0f, {"Dipole current"}},
-            {"config", VariantType::String, "", {"JSON or INI file with tracking parameters"}},
-            {"debug", VariantType::Int, 0, {"debug level"}}}};
+            {"mch-config", VariantType::String, "", {"JSON or INI file with tracking parameters"}},
+            {"mch-debug", VariantType::Int, 0, {"debug level"}}}};
 }
 
 } // namespace mch

--- a/Detectors/MUON/MCH/Workflow/src/TrackFinderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackFinderSpec.cxx
@@ -80,13 +80,13 @@ class TrackFinderTask
       dipoleCurrent = ic.options().get<float>("dipoleCurrent");
     }
 
-    auto config = ic.options().get<std::string>("config");
+    auto config = ic.options().get<std::string>("mch-config");
     if (!config.empty()) {
       o2::conf::ConfigurableParam::updateFromFile(config, "MCHTracking", true);
     }
     mTrackFinder.init(l3Current, dipoleCurrent);
 
-    auto debugLevel = ic.options().get<int>("debug");
+    auto debugLevel = ic.options().get<int>("mch-debug");
     mTrackFinder.debug(debugLevel);
 
     auto stop = [this]() {
@@ -186,8 +186,8 @@ o2::framework::DataProcessorSpec getTrackFinderSpec(const char* specName)
     Options{{"l3Current", VariantType::Float, -30000.0f, {"L3 current"}},
             {"dipoleCurrent", VariantType::Float, -6000.0f, {"Dipole current"}},
             {"grp-file", VariantType::String, o2::base::NameConf::getGRPFileName(), {"Name of the grp file"}},
-            {"config", VariantType::String, "", {"JSON or INI file with tracking parameters"}},
-            {"debug", VariantType::Int, 0, {"debug level"}}}};
+            {"mch-config", VariantType::String, "", {"JSON or INI file with tracking parameters"}},
+            {"mch-debug", VariantType::Int, 0, {"debug level"}}}};
 }
 
 } // namespace mch

--- a/Detectors/MUON/Workflow/src/TrackMatcherSpec.cxx
+++ b/Detectors/MUON/Workflow/src/TrackMatcherSpec.cxx
@@ -50,7 +50,7 @@ class TrackMatcherTask
   {
     LOG(INFO) << "initializing track matching";
 
-    auto config = ic.options().get<std::string>("config");
+    auto config = ic.options().get<std::string>("mch-config");
     if (!config.empty()) {
       conf::ConfigurableParam::updateFromFile(config, "MUONMatching", true);
     }
@@ -95,7 +95,7 @@ DataProcessorSpec getTrackMatcherSpec(const char* name)
            InputSpec{"midtracks", "MID", "TRACKS", 0, Lifetime::Timeframe}},
     Outputs{OutputSpec{{"muontracks"}, "GLO", "MCHMID", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<TrackMatcherTask>()},
-    Options{{"config", VariantType::String, "", {"JSON or INI file with matching parameters"}}}};
+    Options{{"mch-config", VariantType::String, "", {"JSON or INI file with matching parameters"}}}};
 }
 
 } // namespace muon


### PR DESCRIPTION
DPL workflow building fails if the local device option has the same name as the global option of (any) workflow.
This is a quick fix until this unnecessary conflict will be resolved

@aphecetche merging this since otherwise it is impossible to have a workflow including MCH reconstruction and any QC at the same time (needed for Sunday's TED shots)