### PR TITLE
Optionally ignore BC check in TPC-ITS macthing

### DIFF
--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
@@ -325,6 +325,9 @@ class MatchTPCITS
   void setUseFT0(bool v) { mUseFT0 = v; }
   bool getUseFT0() const { return mUseFT0; }
 
+  void setUseBCFilling(bool v) { mUseBCFilling = v; }
+  bool getUseBCFilling() const { return mUseBCFilling; }
+
   ///< set ITS ROFrame duration in microseconds
   void setITSROFrameLengthMUS(float fums);
   ///< set ITS ROFrame duration in BC (continuous mode only)
@@ -517,7 +520,7 @@ class MatchTPCITS
   const o2::ft0::InteractionTag* mFT0Params = nullptr;
 
   MatCorrType mUseMatCorrFlag = MatCorrType::USEMatCorrTGeo;
-
+  bool mUseBCFilling = true;  ///< use BC filling for candidates validation
   bool mSkipTPCOnly = false;  ///< for test only: don't use TPC only tracks, use only external ones
   bool mITSTriggered = false; ///< ITS readout is triggered
   bool mUseFT0 = false;       ///< FT0 information is available

--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -775,11 +775,12 @@ void MatchTPCITS::doMatching(int sec)
       int matchedIC = MinusOne;
       if (!isCosmics()) {
         // validate by bunch filling scheme
-        auto irBracket = tBracket2IRBracket(trange);
-        if (irBracket.isInvalid()) {
-          continue;
+        if (mUseBCFilling) {
+          auto irBracket = tBracket2IRBracket(trange);
+          if (irBracket.isInvalid()) {
+            continue;
+          }
         }
-
         if (checkInteractionCandidates) {
           // check if corrected TPC track time is compatible with any of interaction times
           auto interactionRefs = mITSROFIntCandEntries[trefITS.roFrame]; // reference on interaction candidates compatible with this track

--- a/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
@@ -97,6 +97,7 @@ void TPCITSMatchingDPL::init(InitContext& ic)
   mMatching.setUseFT0(mUseFT0);
   mMatching.setVDriftCalib(mCalibMode);
   mMatching.setNThreads(std::max(1, ic.options().get<int>("nthreads")));
+  mMatching.setUseBCFilling(!ic.options().get<bool>("ignore-bc-check"));
   //
   std::string dictPath = o2::itsmft::ClustererParam<o2::detectors::DetID::ITS>::Instance().dictFilePath;
   std::string dictFile = o2::base::NameConf::getAlpideClusterDictionaryFileName(o2::detectors::DetID::ITS, dictPath, "bin");
@@ -123,10 +124,11 @@ void TPCITSMatchingDPL::init(InitContext& ic)
   mMatching.setDebugFlag(dbgFlags);
 
   // set bunch filling. Eventually, this should come from CCDB
-  const auto* digctx = o2::steer::DigitizationContext::loadFromFile();
-  const auto& bcfill = digctx->getBunchFilling();
-  mMatching.setBunchFilling(bcfill);
-
+  if (mMatching.getUseBCFilling()) {
+    const auto* digctx = o2::steer::DigitizationContext::loadFromFile();
+    const auto& bcfill = digctx->getBunchFilling();
+    mMatching.setBunchFilling(bcfill);
+  }
   mMatching.init();
   //
 }
@@ -199,6 +201,7 @@ DataProcessorSpec getTPCITSMatchingSpec(GTrackID::mask_t src, bool useFT0, bool 
     Options{
       {"nthreads", VariantType::Int, 1, {"Number of afterburner threads"}},
       {"material-lut-path", VariantType::String, "", {"Path of the material LUT file"}},
+      {"ignore-bc-check", VariantType::Bool, false, {"Do not check match candidate against BC filling"}},
       {"debug-tree-flags", VariantType::Int, 0, {"DebugFlagTypes bit-pattern for debug tree"}}}};
 }
 


### PR DESCRIPTION
In which case no collisision-context will be loaded