### PR TITLE
[WIP][EMCAL-728] Error handler for cached error logging

### DIFF
--- a/Detectors/EMCAL/reconstruction/CMakeLists.txt
+++ b/Detectors/EMCAL/reconstruction/CMakeLists.txt
@@ -13,6 +13,7 @@ o2_add_library(EMCALReconstruction
                SOURCES src/RawReaderMemory.cxx
                        src/RawBuffer.cxx
                        src/RawHeaderStream.cxx
+                       src/RawErrorHandler.cxx
                        src/RawPayload.cxx
                        src/AltroDecoder.cxx
                        src/Bunch.cxx

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RawErrorHandler.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RawErrorHandler.h
@@ -1,0 +1,103 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef ALICEO2_RAWERRORHANDLER_H
+#define ALICEO2_RAWERRORHANDLER_H
+
+#include <array>
+#include <string>
+#include <EMCALReconstruction/AltroDecoder.h>
+
+namespace o2
+{
+
+namespace emcal
+{
+
+class MappingHandler;
+
+class RawErrorCodeHandler
+{
+ public:
+  RawErrorCodeHandler();
+  ~RawErrorCodeHandler() = default;
+  int getGlobalCodeForAltroError(const AltroDecoderError::ErrorType_t& err) const;
+  int getGlobalCodeForMinorAltroError(const MinorAltroDecodingError::ErrorType_t& err) const;
+  int getGlobalCodeForGainError(int errorcode) const;
+  constexpr int getNumberOfErrorCodes() { return mAltroIndices.size() + mMinorAltroIndices.size() + mGainErrorIndices.size(); }
+
+ private:
+  std::array<int, AltroDecoderError::getNumberOfErrorTypes()> mAltroIndices;
+  std::array<int, MinorAltroDecodingError::getNumberOfErrorTypes()> mMinorAltroIndices;
+  std::array<int, 2> mGainErrorIndices;
+};
+
+class RawErrorHandler
+{
+ public:
+  RawErrorHandler() = default;
+  RawErrorHandler(int nclasses);
+  ~RawErrorHandler() = default;
+
+  void setNumberOfErrorClasses(int nclasses);
+  void setMapper(MappingHandler* mapper);
+  void define(int errorcode, const char* messasge);
+  bool book(int errorcode, int ddl, int hwaddress);
+  void clear();
+  void stat();
+  void reset();
+
+ private:
+  class DDLErrorContainer
+  {
+   public:
+    DDLErrorContainer();
+    ~DDLErrorContainer() = default;
+    void reset();
+    bool book(int hwaddress)
+    {
+      bool hasBefore = mHwAddress[hwaddress] == 0;
+      mHwAddress[hwaddress]++;
+      return hasBefore;
+    }
+    const std::array<int, 3279>& getErrorCounters() const { return mHwAddress; }
+
+   private:
+    std::array<int, 3279> mHwAddress;
+  };
+
+  class RawErrorClass
+  {
+   public:
+    RawErrorClass() = default;
+    RawErrorClass(const char* basemessage);
+    ~RawErrorClass() = default;
+    void setMapper(MappingHandler* mapper) { mMapper = mapper; }
+    void setMessage(const char* message) { mDescription = message; }
+    bool book(unsigned int ddl, int hwaddress);
+    void reset();
+    void stats();
+
+   private:
+    MappingHandler* mMapper = nullptr;
+    std::array<DDLErrorContainer, 40> mDDLHandlers;
+    std::string mDescription;
+  };
+
+  MappingHandler* mMapper = nullptr;
+  std::vector<RawErrorClass> mErrorClasses;
+  std::vector<bool> mInitialized;
+};
+
+} // namespace emcal
+
+} // namespace o2
+
+#endif

--- a/Detectors/EMCAL/reconstruction/src/RawErrorHandler.cxx
+++ b/Detectors/EMCAL/reconstruction/src/RawErrorHandler.cxx
@@ -1,0 +1,193 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include <algorithm>
+#include <iomanip>
+#include <sstream>
+#include <EMCALBase/Mapper.h>
+#include <EMCALReconstruction/Channel.h>
+#include <EMCALReconstruction/RawErrorHandler.h>
+#include <FairLogger.h>
+
+using namespace o2::emcal;
+
+RawErrorHandler::DDLErrorContainer::DDLErrorContainer() : mHwAddress()
+{
+  std::fill(mHwAddress.begin(), mHwAddress.end(), 0);
+}
+
+void RawErrorHandler::DDLErrorContainer::reset()
+{
+  std::fill(mHwAddress.begin(), mHwAddress.end(), 0);
+}
+
+RawErrorHandler::RawErrorClass::RawErrorClass(const char* message) : mMapper(nullptr), mDDLHandlers(), mDescription(message) {}
+
+bool RawErrorHandler::RawErrorClass::book(unsigned int ddl, int hwaddress)
+{
+  if (ddl > mDDLHandlers.size()) {
+    LOG(ERROR) << "DDL index out of range: " << ddl;
+    return false;
+  }
+  auto bookStatus = mDDLHandlers[ddl].book(hwaddress);
+  if (!bookStatus) {
+    // Create error message (for the first time)
+    if (!mMapper) {
+      LOG(ERROR) << "New error channel, but no mapper. Cannot provide more information about channel";
+    } else {
+      auto fec = mMapper->getFEEForChannelInDDL(ddl, Channel::getFecIndexFromHwAddress(hwaddress), Channel::getBranchIndexFromHwAddress(hwaddress));
+      LOG(ERROR) << "DDL " << ddl << ", FEC " << fec << ", address 0x" << std::hex << hwaddress << std::dec << ": " << mDescription;
+    }
+  }
+  return bookStatus;
+}
+
+void RawErrorHandler::RawErrorClass::reset()
+{
+  for (auto& cont : mDDLHandlers)
+    cont.reset();
+}
+void RawErrorHandler::RawErrorClass::stats()
+{
+  if (!mMapper) {
+    LOG(ERROR) << "Mapper not available, cannot print stats";
+    return;
+  }
+  bool initialzied = false;
+  auto& description = mDescription;
+  auto header = [description, &initialzied]() { if(!initialzied) { LOG(ERROR) << "Summary of raw errors: " << description; initialzied = true; } };
+  for (int iddl = 0; iddl < mDDLHandlers.size(); iddl++) {
+    auto ddlerrors = mDDLHandlers[iddl].getErrorCounters();
+    for (int ihwadd = 0; ihwadd < ddlerrors.size(); ihwadd++) {
+      if (ddlerrors[ihwadd]) {
+        header();
+        auto fec = mMapper->getFEEForChannelInDDL(iddl, Channel::getFecIndexFromHwAddress(ihwadd), Channel::getBranchIndexFromHwAddress(ihwadd));
+        LOG(ERROR) << "DDL " << iddl << ", FEC " << fec << ", address 0x" << std::hex << ihwadd << std::dec << ": " << mDescription << ": " << ddlerrors[ihwadd] << " errors";
+      }
+    }
+  }
+}
+
+RawErrorHandler::RawErrorHandler(int nclasses) : mMapper(nullptr), mErrorClasses(), mInitialized() { setNumberOfErrorClasses(nclasses); }
+
+void RawErrorHandler::setNumberOfErrorClasses(int nclasses)
+{
+  std::vector<RawErrorClass> oldclasses;
+  std::vector<bool> oldInitStatus;
+  if (mErrorClasses.size() > 0 && nclasses > mErrorClasses.size()) {
+    oldclasses = mErrorClasses;
+    oldInitStatus = mInitialized;
+  }
+  mErrorClasses.resize(nclasses);
+  mInitialized.resize(nclasses);
+  int currentclass = 0;
+  if (oldclasses.size()) {
+    for (currentclass = 0; currentclass < oldclasses.size(); currentclass++) {
+      mErrorClasses[currentclass] = oldclasses[currentclass];
+      mInitialized[currentclass] = oldInitStatus[currentclass];
+    }
+  }
+  while (currentclass < mErrorClasses.size()) {
+    mInitialized[currentclass] = false;
+    currentclass++;
+  }
+}
+
+void RawErrorHandler::setMapper(MappingHandler* mapper)
+{
+  mMapper = mapper;
+  for (int icls = 0; icls < mErrorClasses.size(); icls++) {
+    if (mInitialized[icls]) {
+      mErrorClasses[icls].setMapper(mMapper);
+    }
+  }
+}
+
+void RawErrorHandler::define(int errorcode, const char* message)
+{
+  if (errorcode > mErrorClasses.size()) {
+    setNumberOfErrorClasses(errorcode);
+  }
+  if (mInitialized[errorcode]) {
+    mErrorClasses[errorcode].setMessage(message);
+  } else {
+    mErrorClasses[errorcode] = RawErrorClass(message);
+  }
+  if (mMapper)
+    mErrorClasses[errorcode].setMapper(mMapper);
+}
+
+bool RawErrorHandler::book(int errorcode, int ddl, int hwaddress)
+{
+  if (errorcode > mErrorClasses.size()) {
+    LOG(ERROR) << "Error code " << errorcode << " out-of-range, max " << mErrorClasses.size();
+    return false;
+  }
+  if (!mInitialized[errorcode]) {
+    LOG(ERROR) << "Error code " << errorcode << " not initialized";
+    return false;
+  }
+  return mErrorClasses[errorcode].book(ddl, hwaddress);
+}
+
+void RawErrorHandler::stat()
+{
+  for (int icls = 0; icls < mErrorClasses.size(); icls++) {
+    if (mInitialized[icls]) {
+      mErrorClasses[icls].stats();
+    }
+  }
+}
+
+void RawErrorHandler::clear()
+{
+  mErrorClasses.clear();
+}
+
+void RawErrorHandler::reset()
+{
+  for (int icls = 0; icls < mErrorClasses.size(); icls++) {
+    if (mInitialized[icls]) {
+      mErrorClasses[icls].reset();
+    }
+  }
+}
+
+RawErrorCodeHandler::RawErrorCodeHandler()
+{
+  int currentcode = 0;
+  for (int ierror = 0; ierror < AltroDecoderError::getNumberOfErrorTypes(); ierror++) {
+    mAltroIndices[ierror] = currentcode;
+    currentcode++;
+  }
+  for (int ierror = 0; ierror < MinorAltroDecodingError::getNumberOfErrorTypes(); ierror++) {
+    mMinorAltroIndices[ierror] = currentcode;
+    currentcode++;
+  }
+  for (int ierror = 0; ierror < 2; ierror++) {
+    mGainErrorIndices[ierror] = currentcode;
+    currentcode++;
+  }
+}
+
+int RawErrorCodeHandler::getGlobalCodeForAltroError(const AltroDecoderError::ErrorType_t& err) const
+{
+  return mAltroIndices[AltroDecoderError::errorTypeToInt(err)];
+}
+
+int RawErrorCodeHandler::getGlobalCodeForMinorAltroError(const MinorAltroDecodingError::ErrorType_t& err) const
+{
+  return mMinorAltroIndices[MinorAltroDecodingError::errorTypeToInt(err)];
+}
+
+int RawErrorCodeHandler::getGlobalCodeForGainError(int errorcode) const
+{
+  return mGainErrorIndices[errorcode];
+}

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/RawToCellConverterSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/RawToCellConverterSpec.h
@@ -11,12 +11,13 @@
 
 #include <climits>
 #include <string_view>
-#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 #include <boost/container_hash/hash.hpp>
 
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
+#include "DataFormatsEMCAL/Constants.h"
 #include "DataFormatsEMCAL/Cell.h"
 #include "DataFormatsEMCAL/ErrorTypeFEE.h"
 #include "DataFormatsEMCAL/TriggerRecord.h"
@@ -24,6 +25,7 @@
 #include "EMCALBase/Geometry.h"
 #include "EMCALBase/Mapper.h"
 #include "EMCALReconstruction/CaloRawFitter.h"
+#include "EMCALReconstruction/RawErrorHandler.h"
 
 namespace o2
 {
@@ -86,158 +88,6 @@ class RawToCellConverterSpec : public framework::Task
   header::DataHeader::SubSpecificationType getSubspecification() const { return mSubspecification; }
 
  private:
-  /// \struct MessageChannel
-  /// \brief Handling of messages per HW channel
-  struct MessageChannel {
-    int mDDL;             ///< DDK ID
-    int mFEC;             ///< FEC in DDL
-    int mHWAddress;       ///< Full hardware address
-    std::string mMessage; ///< Error message
-
-    /// \brief Check whehter message is equal to other message
-    /// \param other Message to compare to
-    /// \return True if the messages (including channel information) are the same, false otherwise
-    bool operator==(const MessageChannel& other) const
-    {
-      return mDDL == other.mDDL && mFEC == other.mFEC && mHWAddress == other.mHWAddress && mMessage == other.mMessage;
-    }
-
-    /// \brief Create combined error message with channel information
-    /// \return Error message to be logged
-    std::string print();
-  };
-
-  /// \struct MessageChannelHasher
-  /// \brief Hash functor for channel-based error messages
-  struct MessageChannelHasher {
-
-    /// \brief Hash functor
-    /// \param s MessageChannel object to be hashed
-    /// \return Hash value
-    size_t operator()(const MessageChannel& s) const
-    {
-      std::size_t seed = 0;
-      boost::hash_combine(seed, s.mDDL);
-      boost::hash_combine(seed, s.mFEC);
-      boost::hash_combine(seed, s.mHWAddress);
-      boost::hash_combine(seed, std::hash<std::string>{}(s.mMessage));
-      return seed;
-    }
-  };
-
-  /// \struct MessageDDL
-  /// \brief Handling messages per DDL
-  struct MessageDDL {
-    int mDDL;             ///< DDL ID
-    std::string mMessage; ///< Error message
-
-    /// \brief Check whehter message is equal to other message
-    /// \param other Message to compare to
-    /// \return True if the messages (including DDL information) are the same, false otherwise
-    bool operator==(const MessageDDL& other) const
-    {
-      return mDDL == other.mDDL && mMessage == other.mMessage;
-    }
-
-    /// \brief Create combined error message with DDL information
-    /// \return Error message to be logged
-    std::string print();
-  };
-
-  /// \struct MessageDDLHasher
-  /// \brief Hash functor for DDL-based error messages
-  struct MessageDDLHasher {
-
-    /// \brief Hash functor
-    /// \param s MessageDDL object to be hashed
-    /// \return Hash value
-    size_t operator()(const MessageDDL& s) const
-    {
-      std::size_t seed = 0;
-      boost::hash_combine(seed, s.mDDL);
-      boost::hash_combine(seed, std::hash<std::string>{}(s.mMessage));
-      return seed;
-    }
-  };
-
-  /// \struct MessageCell
-  /// \brief Handling messages per Cell
-  struct MessageCell {
-    int mSMID;            ///< Supermodule ID
-    int mCellID;          ///< Cell ID
-    std::string mMessage; ///< Error message
-
-    /// \brief Check whehter message is equal to other message
-    /// \param other Message to compare to
-    /// \return True if the messages (including cell information) are the same, false otherwise
-    bool operator==(const MessageCell& other) const
-    {
-      return mSMID == other.mSMID && mCellID == other.mCellID && mMessage == other.mMessage;
-    }
-
-    /// \brief Create combined error message with cell information
-    /// \return Error message to be logged
-    std::string print();
-  };
-
-  /// \struct MessageCellHasher
-  /// \brief Hash functor for Cell-based error messages
-  struct MessageCellHasher {
-
-    /// \brief Hash functor
-    /// \param s MessageDDL object to be hashed
-    /// \return Hash value
-    size_t operator()(const MessageCell& s) const
-    {
-      std::size_t seed = 0;
-      boost::hash_combine(seed, s.mCellID);
-      boost::hash_combine(seed, s.mSMID);
-      boost::hash_combine(seed, std::hash<std::string>{}(s.mMessage));
-      return seed;
-    }
-  };
-
-  /// \class MessageHandler
-  /// \brief Logging of error message suppressing multiple occurrences
-  ///
-  /// In order to prevent multiple occurrences of the same error message
-  /// which can end up in a message flood on the infoBrowser an internal
-  /// map keeps track of messages already printed before. In case the
-  /// message is fouund in the map it is suppressed until the end of the run.
-  template <typename MessageType, typename Hasher>
-  class MessageHandler
-  {
-   public:
-    /// \enum Severity
-    /// \brief Logging severity
-    enum class Severity {
-      WARNING, ///< Waring level
-      ERROR,   ///< Error level
-      FATAL    ///< Fatal level
-    };
-
-    /// \brief Constructor
-    MessageHandler() = default;
-
-    /// \brief Destructor
-    ~MessageHandler() = default;
-
-    /// \brief Logging error message
-    /// \brief msg Message object (channel and message)
-    /// \brief level Log severity
-    ///
-    /// Printing message in case the message has not been printed
-    /// before for the same channel
-    void log(MessageType msg, Severity level);
-
-   private:
-    std::unordered_map<MessageType, unsigned long, Hasher> mErrorsPerEntry; ///< Counter of the number of suppressed error messages
-  };
-
-  using ChannelMessageHandler = MessageHandler<MessageChannel, MessageChannelHasher>;
-  using CellMessageHandler = MessageHandler<MessageCell, MessageCellHasher>;
-  using DDLMessageHandler = MessageHandler<MessageDDL, MessageDDLHasher>;
-
   /// \struct RecCellInfo
   /// \brief Internal bookkeeping for cell double counting
   ///
@@ -259,9 +109,22 @@ class RawToCellConverterSpec : public framework::Task
     int mHWAddressHG;          ///< HW address of HG (for monitoring)
   };
 
+  class CellIDErrorHandler
+  {
+   public:
+    CellIDErrorHandler() = default;
+    ~CellIDErrorHandler() = default;
+
+    void book(int ddl, int cellID, ChannelType_t chantype);
+
+   private:
+    std::unordered_set<int> mCellIDs;
+  };
+
   /// \brief Check if the timeframe is an empty timeframe (contains DEADBEEF message)
   /// \return True if the timeframe is a lost timeframe, false if it is OK
-  bool isLostTimeframe(framework::ProcessingContext& ctx) const;
+  bool
+    isLostTimeframe(framework::ProcessingContext& ctx) const;
 
   /// \brief Send data to output channels
   /// \param cells Container with cells from all events in the timeframe
@@ -282,9 +145,9 @@ class RawToCellConverterSpec : public framework::Task
   std::vector<Cell> mOutputCells;                                 ///< Container with output cells
   std::vector<TriggerRecord> mOutputTriggerRecords;               ///< Container with output cells
   std::vector<ErrorTypeFEE> mOutputDecoderErrors;                 ///< Container with decoder errors
-  ChannelMessageHandler mChannelMessages;                         ///< Handling of error message per Channel
-  CellMessageHandler mCellMessages;                               ///< Handling of error message per Cell
-  DDLMessageHandler mDDLMessages;                                 ///< Handling of error messages per DDL
+  RawErrorHandler mErrorHandler;                                  ///< Error handling of per-channel RawError
+  RawErrorCodeHandler mErrorCodeHandler;                          ///< Error code mapping
+  CellIDErrorHandler mCellErrorHandler;                           ///< Error handling for Cell IDs
 };
 
 /// \brief Creating DataProcessorSpec for the EMCAL Cell Converter Spec


### PR DESCRIPTION
Log only the first occurrence of an error type,
and count number of subsequent errors of the
same type per channel. Using linear containers
in dimension DDL and hwaddress for direct access
to channel ID. Providing error stats at the end
of the run.

The raw error handler is included also in the
RawToCellConverter and used for all Channel / DDL
based errors. Only the rare errors corresponding
to an invalid cell ID are suppressed after their
first occurrence by a dedicated handler using
std::unordered_set.