### PR TITLE
Fix memory leak in FST

### DIFF
--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -188,12 +188,12 @@ fi
 TRD_SOURCES=
 TOF_SOURCES=
 TRACK_SOURCES=
-has_detector_matching ITSTPC && add_comma_separated TRACK_SOURCES "ITS-TPC"
-has_detector_matching TPCTRD && { add_comma_separated TRD_SOURCES TPC; add_comma_separated TRACK_SOURCES "TPC-TRD"; }
-has_detector_matching ITSTPCTRD && { add_comma_separated TRD_SOURCES ITS-TPC; add_comma_separated TRACK_SOURCES "ITS-TPC-TRD"; }
-has_detector_matching TPCTOF && { add_comma_separated TOF_SOURCES TPC; add_comma_separated TRACK_SOURCES "TPC-TOF"; }
-has_detector_matching ITSTPCTOF && { add_comma_separated TOF_SOURCES ITS-TPC; add_comma_separated TRACK_SOURCES "ITS-TPC-TOF"; }
-has_detector_matching MFTMCH && add_comma_separated TRACK_SOURCES "MFT-MCH"
+has_detectors_reco ITS TPC && has_detector_matching ITSTPC && add_comma_separated TRACK_SOURCES "ITS-TPC"
+has_detectors_reco TPC TRD && has_detector_matching TPCTRD && { add_comma_separated TRD_SOURCES TPC; add_comma_separated TRACK_SOURCES "TPC-TRD"; }
+has_detectors_reco ITS TPC TRD && has_detector_matching ITSTPCTRD && { add_comma_separated TRD_SOURCES ITS-TPC; add_comma_separated TRACK_SOURCES "ITS-TPC-TRD"; }
+has_detectors_reco TPC TOF && has_detector_matching TPCTOF && { add_comma_separated TOF_SOURCES TPC; add_comma_separated TRACK_SOURCES "TPC-TOF"; }
+has_detectors_reco ITS TPC TOF && has_detector_matching ITSTPCTOF && { add_comma_separated TOF_SOURCES ITS-TPC; add_comma_separated TRACK_SOURCES "ITS-TPC-TOF"; }
+has_detectors_reco MFT MCH && has_detector_matching MFTMCH && add_comma_separated TRACK_SOURCES "MFT-MCH"
 for det in `echo $LIST_OF_DETECTORS | sed "s/,/ /g"`; do
   if [[ $LIST_OF_ASYNC_RECO_STEPS =~ (^| )${det}( |$) ]]; then
     has_processing_step ${det}_RECO && add_comma_separated TRACK_SOURCES "$det"

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -65,7 +65,7 @@ ARGS_ALL="--session default --severity $SEVERITY --shm-segment-id $NUMAID --shm-
 if [ $EPNMODE == 1 ]; then
   ARGS_ALL+=" --infologger-severity $INFOLOGGER_SEVERITY"
   ARGS_ALL+=" --monitoring-backend influxdb-unix:///tmp/telegraf.sock --resources-monitoring 60"
-else
+elif [ "0$ENABLE_METRICS" != "01" ]; then
   ARGS_ALL+=" --monitoring-backend no-op://"
 fi
 if [ $EXTINPUT == 1 ] || [ $NUMAGPUIDS == 1 ]; then


### PR DESCRIPTION
@shahor02 : This passes the `--ignore-dist-stf` option to the `tof-compressed-decoder` in case there is no flp processing.
I assume we have to do the same for the other detectors with optional FLP processing, or don't they have DEADBEEF treatment yet in their second processing steps?