### PR TITLE
Making const what should be const in the DPL RawDeviceService API

### DIFF
--- a/Framework/Core/include/Framework/RawDeviceService.h
+++ b/Framework/Core/include/Framework/RawDeviceService.h
@@ -31,7 +31,7 @@ class RawDeviceService
 
   virtual FairMQDevice* device() = 0;
   virtual void setDevice(FairMQDevice* device) = 0;
-  virtual DeviceSpec const& spec() = 0;
+  virtual DeviceSpec const& spec() const = 0;
   /// Expose FairMQDevice::WaitFor method to avoid having to include
   /// FairMQDevice.h.
   ///

--- a/Framework/Core/include/Framework/SimpleRawDeviceService.h
+++ b/Framework/Core/include/Framework/SimpleRawDeviceService.h
@@ -37,7 +37,7 @@ class SimpleRawDeviceService : public RawDeviceService
     mDevice = device;
   }
 
-  DeviceSpec const& spec() final
+  DeviceSpec const& spec() const final
   {
     return mSpec;
   }


### PR DESCRIPTION
This allows to use const reference in places where we want to have only read access