### PR TITLE
DPL Analysis: Generic grouping

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -2279,6 +2279,19 @@ struct IndexTable : Table<soa::Index<>, H, Ts...> {
 
 template <typename T>
 using is_soa_index_table_t = typename framework::is_base_of_template<soa::IndexTable, T>;
+
+template <typename T>
+struct SmallGroups : Filtered<T> {
+  SmallGroups(std::vector<std::shared_ptr<arrow::Table>>&& tables, SelectionVector&& selection, uint64_t offset = 0)
+    : Filtered<T>(std::move(tables), std::forward<SelectionVector>(selection), offset) {}
+
+  SmallGroups(std::vector<std::shared_ptr<arrow::Table>>&& tables, framework::expressions::Selection selection, uint64_t offset = 0)
+    : Filtered<T>(std::move(tables), selection, offset) {}
+
+  SmallGroups(std::vector<std::shared_ptr<arrow::Table>>&& tables, gandiva::NodePtr const& tree, uint64_t offset = 0)
+    : Filtered<T>(std::move(tables), tree, offset) {}
+};
+
 } // namespace o2::soa
 
 #endif // O2_FRAMEWORK_ASOA_H_

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -52,6 +52,85 @@ namespace o2::framework
 struct AnalysisTask {
 };
 
+namespace
+{
+template <typename B, typename C>
+constexpr static bool isIndexTo()
+{
+  if constexpr (soa::is_type_with_binding_v<C>) {
+    if constexpr (soa::is_soa_index_table_t<std::decay_t<B>>::value) {
+      using T = typename std::decay_t<B>::first_t;
+      if constexpr (soa::is_type_with_originals_v<std::decay_t<T>>) {
+        using TT = typename framework::pack_element_t<0, typename std::decay_t<T>::originals>;
+        return std::is_same_v<typename C::binding_t, TT>;
+      } else {
+        using TT = std::decay_t<T>;
+        return std::is_same_v<typename C::binding_t, TT>;
+      }
+    } else {
+      if constexpr (soa::is_type_with_originals_v<std::decay_t<B>>) {
+        using TT = typename framework::pack_element_t<0, typename std::decay_t<B>::originals>;
+        return std::is_same_v<typename C::binding_t, TT>;
+      } else {
+        using TT = std::decay_t<B>;
+        return std::is_same_v<typename C::binding_t, TT>;
+      }
+    }
+  }
+  return false;
+}
+
+template <typename B, typename C>
+constexpr static bool isSortedIndexTo()
+{
+  if constexpr (soa::is_type_with_binding_v<C>) {
+    if constexpr (soa::is_soa_index_table_t<std::decay_t<B>>::value) {
+      using T = typename std::decay_t<B>::first_t;
+      if constexpr (soa::is_type_with_originals_v<std::decay_t<T>>) {
+        using TT = typename framework::pack_element_t<0, typename std::decay_t<T>::originals>;
+        return std::is_same_v<typename C::binding_t, TT> && C::sorted;
+      } else {
+        using TT = std::decay_t<T>;
+        return std::is_same_v<typename C::binding_t, TT> && C::sorted;
+      }
+    } else {
+      if constexpr (soa::is_type_with_originals_v<std::decay_t<B>>) {
+        using TT = typename framework::pack_element_t<0, typename std::decay_t<B>::originals>;
+        return std::is_same_v<typename C::binding_t, TT> && C::sorted;
+      } else {
+        using TT = std::decay_t<B>;
+        return std::is_same_v<typename C::binding_t, TT> && C::sorted;
+      }
+    }
+  }
+  return false;
+}
+
+template <typename B, typename... C>
+constexpr static bool hasIndexTo(framework::pack<C...>&&)
+{
+  return (isIndexTo<B, C>() || ...);
+}
+
+template <typename B, typename... C>
+constexpr static bool hasSortedIndexTo(framework::pack<C...>&&)
+{
+  return (isSortedIndexTo<B, C>() || ...);
+}
+
+template <typename B, typename Z>
+constexpr static bool relatedByIndex()
+{
+  return hasIndexTo<B>(typename Z::persistent_columns_t{});
+}
+
+template <typename B, typename Z>
+constexpr static bool relatedBySortedIndex()
+{
+  return hasSortedIndexTo<B>(typename Z::persistent_columns_t{});
+}
+} // namespace
+
 // Helper struct which builds a DataProcessorSpec from
 // the contents of an AnalysisTask...
 
@@ -119,7 +198,7 @@ struct AnalysisDataProcessorBuilder {
   static void appendSomethingWithMetadata(const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eInfos, size_t hash)
   {
     using dT = std::decay_t<T>;
-    if constexpr (framework::is_specialization<dT, soa::Filtered>::value) {
+    if constexpr (soa::is_soa_filtered_t<dT>::value) {
       eInfos.push_back({AI, hash, dT::hashes(), o2::soa::createSchemaFromColumns(typename dT::table_t::persistent_columns_t{}), nullptr});
     } else if constexpr (soa::is_soa_iterator_t<dT>::value) {
       if constexpr (std::is_same_v<typename dT::policy_t, soa::FilteredIndexPolicy>) {
@@ -128,12 +207,6 @@ struct AnalysisDataProcessorBuilder {
     }
     doAppendInputWithMetadata(soa::make_originals_from_type<dT>(), name, value, inputs);
   }
-
-  //  template <typename... T>
-  //  static void inputsFromArgsTuple(std::tuple<T...>& processTuple, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eInfos)
-  //  {
-  //    (inputsFromArgs<o2::framework::has_type_at_v<T>(pack<T...>{})>(std::get<T>(processTuple), inputs, eInfos), ...);
-  //  }
 
   template <typename R, typename C, typename... Args>
   static void inputsFromArgs(R (C::*)(Args...), const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eInfos)
@@ -189,9 +262,15 @@ struct AnalysisDataProcessorBuilder {
   static auto extractFilteredFromRecord(InputRecord& record, ExpressionInfo const& info, pack<Os...> const&)
   {
     if constexpr (soa::is_soa_iterator_t<T>::value) {
-      return typename T::parent_t(std::vector<std::shared_ptr<arrow::Table>>{extractTableFromRecord<Os>(record)...}, info.tree);
+      if (info.tree != nullptr) {
+        return typename T::parent_t(std::vector<std::shared_ptr<arrow::Table>>{extractTableFromRecord<Os>(record)...}, info.tree);
+      }
+      return typename T::parent_t(std::vector<std::shared_ptr<arrow::Table>>{extractTableFromRecord<Os>(record)...}, soa::SelectionVector{});
     } else {
-      return T(std::vector<std::shared_ptr<arrow::Table>>{extractTableFromRecord<Os>(record)...}, info.tree);
+      if (info.tree != nullptr) {
+        return T(std::vector<std::shared_ptr<arrow::Table>>{extractTableFromRecord<Os>(record)...}, info.tree);
+      }
+      return T(std::vector<std::shared_ptr<arrow::Table>>{extractTableFromRecord<Os>(record)...}, soa::SelectionVector{});
     }
   }
 
@@ -275,93 +354,80 @@ struct AnalysisDataProcessorBuilder {
         }
       }
 
+      template <typename T>
+      auto splittingFunction(T&& table)
+      {
+        constexpr auto index = framework::has_type_at_v<std::decay_t<T>>(associated_pack_t{});
+        if constexpr (relatedByIndex<std::decay_t<G>, std::decay_t<T>>()) {
+          auto name = getLabelFromType<std::decay_t<T>>();
+          if constexpr (!framework::is_specialization<std::decay_t<T>, soa::SmallGroups>::value) {
+            if (table.size() == 0) {
+              return;
+            }
+            // use presorted splitting approach
+            auto result = o2::framework::sliceByColumn(mIndexColumnName.c_str(),
+                                                       name.c_str(),
+                                                       table.asArrowTable(),
+                                                       static_cast<int32_t>(mGt->tableSize()),
+                                                       &groups[index],
+                                                       &offsets[index],
+                                                       &sizes[index]);
+            if (result.ok() == false) {
+              throw runtime_error("Cannot split collection");
+            }
+            if (groups[index].size() > mGt->tableSize()) {
+              throw runtime_error_f("Splitting collection %s resulted in a larger group number (%d) than there is rows in the grouping table (%d).", name.c_str(), groups[index].size(), mGt->tableSize());
+            };
+          } else {
+            if (table.tableSize() == 0) {
+              return;
+            }
+            // use generic splitting approach
+            o2::framework::sliceByColumnGeneric(mIndexColumnName.c_str(),
+                                                name.c_str(),
+                                                table.asArrowTable(),
+                                                static_cast<int32_t>(mGt->tableSize()),
+                                                &filterGroups[index]);
+          }
+        }
+      }
+
+      template <typename T>
+      auto extractingFunction(T&& table)
+      {
+        if constexpr (soa::is_soa_filtered_t<std::decay_t<T>>::value) {
+          constexpr auto index = framework::has_type_at_v<std::decay_t<T>>(associated_pack_t{});
+          selections[index] = &table.getSelectedRows();
+          starts[index] = selections[index]->begin();
+          offsets[index].push_back(table.tableSize());
+        }
+      }
+
       GroupSlicerIterator(G& gt, std::tuple<A...>& at)
-        : mAt{&at},
+        : mIndexColumnName{std::string("fIndex") + getLabelFromType<G>()},
+          mGt{&gt},
+          mAt{&at},
           mGroupingElement{gt.begin()},
           position{0}
       {
         if constexpr (soa::is_soa_filtered_t<std::decay_t<G>>::value) {
-          groupSelection = &gt.getSelectedRows();
+          groupSelection = &mGt->getSelectedRows();
         }
-        auto indexColumnName = std::string("fIndex") + getLabelFromType<G>();
+
         /// prepare slices and offsets for all associated tables that have index
         /// to grouping table
         ///
-        auto splitter = [&](auto&& x) {
-          using xt = std::decay_t<decltype(x)>;
-          constexpr auto index = framework::has_type_at_v<std::decay_t<decltype(x)>>(associated_pack_t{});
-          if (hasIndexTo<std::decay_t<G>>(typename xt::persistent_columns_t{})) {
-            if (x.size() != 0) {
-              auto name = getLabelFromType<decltype(x)>();
-              auto result = o2::framework::sliceByColumn(indexColumnName.c_str(),
-                                                         name.c_str(),
-                                                         x.asArrowTable(),
-                                                         static_cast<int32_t>(gt.tableSize()),
-                                                         &groups[index],
-                                                         &offsets[index],
-                                                         &sizes[index]);
-              if (result.ok() == false) {
-                throw runtime_error("Cannot split collection");
-              }
-              if (groups[index].size() > gt.tableSize()) {
-                throw runtime_error_f("Splitting collection %s resulted in a larger group number (%d) than there is rows in the grouping table (%d).", name.c_str(), groups[index].size(), gt.tableSize());
-              };
-            }
-          }
-        };
-
         std::apply(
           [&](auto&&... x) -> void {
-            (splitter(x), ...);
+            (splittingFunction(x), ...);
           },
           at);
         /// extract selections from filtered associated tables
-        auto extractor = [&](auto&& x) {
-          using xt = std::decay_t<decltype(x)>;
-          if constexpr (soa::is_soa_filtered_t<xt>::value) {
-            constexpr auto index = framework::has_type_at_v<std::decay_t<decltype(x)>>(associated_pack_t{});
-            selections[index] = &x.getSelectedRows();
-            starts[index] = selections[index]->begin();
-            offsets[index].push_back(std::get<xt>(at).tableSize());
-          }
-        };
         std::apply(
           [&](auto&&... x) -> void {
-            (extractor(x), ...);
+            (extractingFunction(x), ...);
           },
           at);
-      }
-
-      template <typename B, typename... C>
-      constexpr static bool hasIndexTo(framework::pack<C...>&&)
-      {
-        return (isIndexTo<B, C>() || ...);
-      }
-
-      template <typename B, typename C>
-      constexpr static bool isIndexTo()
-      {
-        if constexpr (soa::is_type_with_binding_v<C>) {
-          if constexpr (soa::is_soa_index_table_t<std::decay_t<B>>::value) {
-            using T = typename std::decay_t<B>::first_t;
-            if constexpr (soa::is_type_with_originals_v<std::decay_t<T>>) {
-              using TT = typename framework::pack_element_t<0, typename std::decay_t<T>::originals>;
-              return std::is_same_v<typename C::binding_t, TT>;
-            } else {
-              using TT = std::decay_t<T>;
-              return std::is_same_v<typename C::binding_t, TT>;
-            }
-          } else {
-            if constexpr (soa::is_type_with_originals_v<std::decay_t<B>>) {
-              using TT = typename framework::pack_element_t<0, typename std::decay_t<B>::originals>;
-              return std::is_same_v<typename C::binding_t, TT>;
-            } else {
-              using TT = std::decay_t<B>;
-              return std::is_same_v<typename C::binding_t, TT>;
-            }
-          }
-        }
-        return false;
       }
 
       GroupSlicerIterator& operator++()
@@ -400,47 +466,75 @@ struct AnalysisDataProcessorBuilder {
       auto prepareArgument()
       {
         constexpr auto index = framework::has_type_at_v<A1>(associated_pack_t{});
-        if (std::get<A1>(*mAt).size() == 0) {
-          return std::get<A1>(*mAt);
-        }
-        if (hasIndexTo<std::decay_t<G>>(typename std::decay_t<A1>::persistent_columns_t{})) {
+        auto& originalTable = std::get<A1>(*mAt);
+
+        if constexpr (relatedByIndex<std::decay_t<G>, std::decay_t<A1>>()) {
           uint64_t pos;
           if constexpr (soa::is_soa_filtered_t<std::decay_t<G>>::value) {
             pos = (*groupSelection)[position];
           } else {
             pos = position;
           }
-          if constexpr (soa::is_soa_filtered_t<std::decay_t<A1>>::value) {
-            auto groupedElementsTable = arrow::util::get<std::shared_ptr<arrow::Table>>(((groups[index])[pos]).value);
+          if constexpr (!framework::is_specialization<std::decay_t<A1>, soa::SmallGroups>::value) {
+            if (originalTable.size() == 0) {
+              return originalTable;
+            }
+            // optimized split
+            if constexpr (soa::is_soa_filtered_t<std::decay_t<A1>>::value) {
+              auto groupedElementsTable = arrow::util::get<std::shared_ptr<arrow::Table>>(((groups[index])[pos]).value);
 
-            // for each grouping element we need to slice the selection vector
-            auto start_iterator = std::lower_bound(starts[index], selections[index]->end(), (offsets[index])[pos]);
-            auto stop_iterator = std::lower_bound(start_iterator, selections[index]->end(), (offsets[index])[pos] + (sizes[index])[pos]);
-            starts[index] = stop_iterator;
-            soa::SelectionVector slicedSelection{start_iterator, stop_iterator};
-            std::transform(slicedSelection.begin(), slicedSelection.end(), slicedSelection.begin(),
-                           [&](int64_t idx) {
-                             return idx - static_cast<int64_t>((offsets[index])[pos]);
-                           });
+              // for each grouping element we need to slice the selection vector
+              auto start_iterator = std::lower_bound(starts[index], selections[index]->end(), (offsets[index])[pos]);
+              auto stop_iterator = std::lower_bound(start_iterator, selections[index]->end(), (offsets[index])[pos] + (sizes[index])[pos]);
+              starts[index] = stop_iterator;
+              soa::SelectionVector slicedSelection{start_iterator, stop_iterator};
+              std::transform(slicedSelection.begin(), slicedSelection.end(), slicedSelection.begin(),
+                             [&](int64_t idx) {
+                               return idx - static_cast<int64_t>((offsets[index])[pos]);
+                             });
 
-            std::decay_t<A1> typedTable{{groupedElementsTable}, std::move(slicedSelection), (offsets[index])[pos]};
-            typedTable.bindInternalIndicesTo(&std::get<A1>(*mAt));
-            return typedTable;
+              std::decay_t<A1> typedTable{{groupedElementsTable}, std::move(slicedSelection), (offsets[index])[pos]};
+              typedTable.bindInternalIndicesTo(&originalTable);
+              return typedTable;
+            } else {
+              auto groupedElementsTable = arrow::util::get<std::shared_ptr<arrow::Table>>(((groups[index])[pos]).value);
+              std::decay_t<A1> typedTable{{groupedElementsTable}, (offsets[index])[pos]};
+              typedTable.bindInternalIndicesTo(&originalTable);
+              return typedTable;
+            }
           } else {
-            auto groupedElementsTable = arrow::util::get<std::shared_ptr<arrow::Table>>(((groups[index])[pos]).value);
-            std::decay_t<A1> typedTable{{groupedElementsTable}, (offsets[index])[pos]};
-            typedTable.bindInternalIndicesTo(&std::get<A1>(*mAt));
-            return typedTable;
+            //generic split
+            if constexpr (soa::is_soa_filtered_t<std::decay_t<A1>>::value) {
+              if (originalTable.tableSize() == 0) {
+                return originalTable;
+              }
+              // intersect selections
+              o2::soa::SelectionVector s;
+              if (selections[index]->empty()) {
+                std::copy((filterGroups[index])[pos].begin(), (filterGroups[index])[pos].end(), std::back_inserter(s));
+              } else {
+                std::set_intersection((filterGroups[index])[pos].begin(), (filterGroups[index])[pos].end(), selections[index]->begin(), selections[index]->end(), std::back_inserter(s));
+              }
+              std::decay_t<A1> typedTable{{originalTable.asArrowTable()}, std::move(s)};
+              typedTable.bindInternalIndicesTo(&originalTable);
+              return typedTable;
+            } else {
+              throw runtime_error("Unsorted grouped table needs to be used with soa::SmallGroups<>");
+            }
           }
+        } else {
+          return std::get<A1>(*mAt);
         }
-        return std::get<A1>(*mAt);
       }
 
+      std::string mIndexColumnName;
+      G const* mGt;
       std::tuple<A...>* mAt;
       typename grouping_t::iterator mGroupingElement;
       uint64_t position = 0;
       soa::SelectionVector const* groupSelection = nullptr;
       std::array<std::vector<arrow::Datum>, sizeof...(A)> groups;
+      std::array<ListVector, sizeof...(A)> filterGroups;
       std::array<std::vector<uint64_t>, sizeof...(A)> offsets;
       std::array<std::vector<int>, sizeof...(A)> sizes;
       std::array<soa::SelectionVector const*, sizeof...(A)> selections;

--- a/Framework/Core/test/test_AnalysisTask.cxx
+++ b/Framework/Core/test/test_AnalysisTask.cxx
@@ -47,8 +47,6 @@ DECLARE_SOA_TABLE(Events, "AOD", "EVENTS",
                   test::EventProperty);
 } // namespace o2::aod
 
-// FIXME: for the moment we do not derive from AnalysisTask as
-// we need GCC 7.4+ to fix a bug.
 struct ATask {
   Produces<aod::FooBars> foobars;
 
@@ -58,32 +56,24 @@ struct ATask {
   }
 };
 
-// FIXME: for the moment we do not derive from AnalysisTask as
-// we need GCC 7.4+ to fix a bug.
 struct BTask {
   void process(o2::aod::Collision const&, o2::soa::Join<o2::aod::Tracks, o2::aod::TracksExtra, o2::aod::TracksCov> const&, o2::aod::AmbiguousTracks const&, o2::soa::Join<o2::aod::Calos, o2::aod::CaloTriggers> const&)
   {
   }
 };
 
-// FIXME: for the moment we do not derive from AnalysisTask as
-// we need GCC 7.4+ to fix a bug.
 struct CTask {
   void process(o2::aod::Collision const&, o2::aod::Tracks const&)
   {
   }
 };
 
-// FIXME: for the moment we do not derive from AnalysisTask as
-// we need GCC 7.4+ to fix a bug.
 struct DTask {
   void process(o2::aod::Tracks const&)
   {
   }
 };
 
-// FIXME: for the moment we do not derive from AnalysisTask as
-// we need GCC 7.4+ to fix a bug.
 struct ETask {
   void process(o2::aod::FooBars::iterator const& foobar)
   {
@@ -91,8 +81,6 @@ struct ETask {
   }
 };
 
-// FIXME: for the moment we do not derive from AnalysisTask as
-// we need GCC 7.4+ to fix a bug.
 struct FTask {
   expressions::Filter fooFilter = aod::test::foo > 1.;
   void process(soa::Filtered<o2::aod::FooBars>::iterator const& foobar)
@@ -101,8 +89,6 @@ struct FTask {
   }
 };
 
-// FIXME: for the moment we do not derive from AnalysisTask as
-// we need GCC 7.4+ to fix a bug.
 struct GTask {
   void process(o2::soa::Join<o2::aod::Foos, o2::aod::Bars, o2::aod::XYZ> const& foobars)
   {
@@ -114,8 +100,6 @@ struct GTask {
   }
 };
 
-// FIXME: for the moment we do not derive from AnalysisTask as
-// we need GCC 7.4+ to fix a bug.
 struct HTask {
   void process(o2::soa::Join<o2::aod::Foos, o2::aod::Bars, o2::aod::XYZ>::iterator const& foobar)
   {


### PR DESCRIPTION
@jgrosseo 
Discussing this with @ktf, we've found a minimal workaround: `SmallGroups<>` is defined as a simple alias to `Filtered` and thus the arguments of process function are always compatible when generic grouping is used.

Now back to marking columns sorted and not sorted, what is the proposed scheme? Assume that default macro always declares sorted index, and require `UNSORTED` to be explicit?