### PR TITLE
TRD fix non zerosuppressed data and sending qc messages

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawDataStats.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawDataStats.h
@@ -16,17 +16,21 @@
 #ifndef O2_TRD_RAWDATASTATS
 #define O2_TRD_RAWDATASTATS
 
+#include "TObject.h"
 #include <iostream>
 #include <string>
 #include <cstdint>
 #include <array>
 #include <vector>
 #include <bitset>
+#include <chrono>
+#include <map>
 #include <gsl/span>
 #include "DataFormatsTRD/Constants.h"
 
 namespace o2::trd
 {
+
 enum ParsingErrors { TRDParsingNoError,
                      TRDParsingUnrecognisedVersion,
                      TRDParsingBadDigt,
@@ -66,7 +70,8 @@ enum ParsingErrors { TRDParsingNoError,
                      TRDParsingDigitHeaderWrong3,                              // expected header word3 but wrong ending marker
                      TRDParsingDigitHeaderWrong4,                              // expected header word but have no idea what we are looking at default of switch statement
                      TRDParsingDigitDataStillOnLink,                           // got to the end of digit parsing and there is still data on link, normally not advancing far enough when dumping data.
-                     TRDParsingTrackletIgnoringDataTillEndMarker               // for some reason we are bouncing to the end word by word, this counts those words
+                     TRDParsingTrackletIgnoringDataTillEndMarker,              // for some reason we are bouncing to the end word by word, this counts those words
+                     TRDLastParsingError                                       // here as place holder for trivial sizing of structures.
 };
 
 extern std::vector<std::string> ParsingErrorsString;
@@ -83,47 +88,65 @@ enum OptionBits {
   TRDEnableStatsBit,
   TRDIgnoreDigitHCHeaderBit,
   TRDIgnoreTrackletHCHeaderBit,
-  TRDEnableRootOutputBit
+  TRDEnableRootOutputBit,
+  TRDGenerateStats
 };
 
 class TRDDataCountersPerEvent
 { //thisis on a per event basis
  public:
   //TODO this should go into a dpl message for catching by qc ?? I think.
-  uint64_t mTimeTaken;                        // time take to process an event (summed trackletparsing and digitparsing) parts not accounted for.
-  uint64_t mTimeTakenForDigits;               // time take to process tracklet data blocks [us].
-  uint64_t mTimeTakenForTracklets;            // time take to process digit data blocks [us].
-  uint64_t mDigitWordsRead;                   // digit words read in
-  uint64_t mDigitWordsSkipped;                // digit words skipped for various reasons.
-  uint64_t mTrackletWordsRead;                // tracklet words read in
-  uint64_t mTrackletWordsSkipped;             // tracklet words skipped for various reasons.
-  std::array<uint8_t, 1080> mLinkErrorFlag{}; //status of the error flags for this event, 8bit values from cru halfchamber header.
+  double mTimeTaken;             // time take to process an event (summed trackletparsing and digitparsing) parts not accounted for.
+  double mTimeTakenForDigits;    // time take to process tracklet data blocks [us].
+  double mTimeTakenForTracklets; // time take to process digit data blocks [us].
+  uint64_t mWordsRead;           // words read in
+  uint64_t mWordsRejected;       // words skipped for various reasons.
+  uint16_t mTrackletsFound;      // tracklets found in the event
+  uint16_t mDigitsFound;         // digits found in the event
+  //  std::array<uint16_t, o2::trd::constants::NSECTOR*60> mLinkLengths;
 };
 
 class TRDDataCountersPerTimeFrame
 { //thisis on a per event basis
  public:
-  std::array<uint32_t, 1080> mLinkNoData;                                   // Link had no data or was not present.
-  std::array<uint32_t, 1080> mLinkWords{};                                  //units of 256bits, read from the cru half chamber header
-  std::array<uint32_t, 1080> mLinkWordsRead{};                              // units of 32 bits the data words read before dumping or finishing
-  std::array<uint32_t, 1080> mLinkWordsDumped{};                            // units of 32 bits the data dumped due to some or other error
-  std::array<int64_t, o2::trd::constants::MAXMCMCOUNT> mLinkMCMsWithData{}; // and its corresponding volume of data.
-  std::array<uint32_t, constants::MAXMCMCOUNT> mMCMDigitCount{};
-  std::array<uint32_t, constants::MAXMCMCOUNT> mMCMTrackletCount{};
-  std::array<uint32_t, 30> mParsingErrors{};              // errors in parsing, indexed by enum above of ParsingErrors
-  std::array<uint32_t, 1080 * 30> mParsingErrorsByLink{}; // errors in parsing, indexed by enum above of ParsingErrors
-  uint64_t mTimeTaken;                                    // time taken to process the entire timeframe [ms].
-  uint64_t mTimeTakenForDigits;                           // time take to process tracklet data blocks [us].
-  uint64_t mTimeTakenForTracklets;                        // time take to process digit data blocks [us].
-  uint64_t mDigitsFound;                                  // digit found in the time frame.
-  uint64_t mTrackletsFound;                               // tracklets found in the time frame.
-  uint64_t mDigitWordsRead;                               // digit words read in.
-  uint64_t mDigitWordsSkipped;                            // digit words skipped for various reasons.
-  uint64_t mTrackletWordsRead;                            // tracklet words read in.
-  uint64_t mTrackletWordsSkipped;                         // tracklet words skipped for various reasons.
-  uint64_t mDataWordsRead;
-  uint64_t mDataWordsRejected;
-  //TRDDataCountersPerTimeFrame* operator=(TRDDataCountersPerTimeFrame *old){this=old;return *this;}
+  std::array<uint8_t, o2::trd::constants::NSECTOR * 60> mLinkErrorFlag{};                              //status of the error flags for this event, 8bit values from cru halfchamber header.
+  std::array<uint16_t, o2::trd::constants::NSECTOR * 60> mLinkNoData;                                  // Link had no data or was not present.
+  std::array<uint16_t, o2::trd::constants::NSECTOR * 60> mLinkWords{};                                 //units of 256bits, read from the cru half chamber header
+  std::array<uint16_t, o2::trd::constants::NSECTOR * 60> mLinkWordsRead{};                             // units of 32 bits the data words read before dumping or finishing
+  std::array<uint16_t, o2::trd::constants::NSECTOR * 60> mLinkWordsRejected{};                         // units of 32 bits the data dumped due to some or other error
+                                                                                                       //  std::array<uint16_t, o2::trd::constants::MAXMCMCOUNT> mLinkMCMsWithData{};                            // and its corresponding volume of data.
+  std::array<uint16_t, TRDLastParsingError> mParsingErrors{};                                          // errors in parsing, indexed by enum above of ParsingErrors
+  std::array<uint32_t, o2::trd::constants::NSECTOR * 60 * TRDLastParsingError> mParsingErrorsByLink{}; // errors in parsing, indexed by enum above of ParsingErrors
+                                                                                                       //  std::array<uint16_t, constants::MAXMCMCOUNT> mMCMDigitsFound{}; can be reprocessed in qc rather, save work and space,
+                                                                                                       //  std::array<uint16_t, constants::MAXMCMCOUNT> mMCMTrackletsFound{}; sim as above
+  uint16_t mDigitsPerEvent;                                                                            // average digits found per event
+  uint16_t mTrackletsPerEvent;                                                                         // average tracklets found per event
+                                                                                                       //  std::map<uint16_t, uint16_t> mRdhSize;               // sizes of rdhs read   i think tf sizes are plotted some where so not needed anymore i think.
+  double mTimeTaken;                                                                                   // time taken to process the entire timeframe [ms].
+  double mTimeTakenForDigits;                                                                          // time take to process tracklet data blocks [ms].
+  double mTimeTakenForTracklets;                                                                       // time take to process digit data blocks [ms].
+  uint32_t mDigitsFound;                                                                               // digit found in the time frame.
+  uint32_t mTrackletsFound;                                                                            // tracklets found in the time frame.
+  std::array<uint64_t, 256> mDataFormatRead{};                                                         // We just keep the major version number
+  void clear()
+  {
+    mLinkNoData.fill(0);
+    mLinkWords.fill(0);
+    mLinkWordsRead.fill(0);
+    mLinkWordsRejected.fill(0);
+    //    mLinkMCMsWithData.fill(0);
+    mParsingErrors.fill(0);
+    mParsingErrorsByLink.fill(0);
+    mDigitsPerEvent = 0;
+    mTrackletsPerEvent = 0;
+    mTimeTaken = 0;
+    mTimeTakenForDigits = 0;
+    mTimeTakenForTracklets = 0;
+    mDigitsFound = 0;
+    mTrackletsFound = 0; //tracklets found in timeframe.
+    mDataFormatRead.fill(0);
+  };
+  ClassDefNV(TRDDataCountersPerTimeFrame, 1); // primarily for serialisation so we can send this as a message in o2
 };
 
 //TODO not sure this class is needed

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
@@ -22,6 +22,7 @@
 #include <cstdint>
 #include <array>
 #include <vector>
+#include <chrono>
 #include "Headers/RAWDataHeader.h"
 #include "Headers/RDHAny.h"
 #include "DetectorsRaw/RDHUtils.h"
@@ -111,13 +112,13 @@ class CruRawReader
   //  std::vector<o2::trd::TriggerRecord> getIR() { return mEventTriggers; }
   void getParsedObjects(std::vector<Tracklet64>& tracklets, std::vector<Digit>& cdigits, std::vector<TriggerRecord>& triggers);
   void getParsedObjectsandClear(std::vector<Tracklet64>& tracklets, std::vector<Digit>& digits, std::vector<TriggerRecord>& triggers);
-  void buildDPLOutputs(o2::framework::ProcessingContext& outputs, bool displaytracklets = false);
+  void buildDPLOutputs(o2::framework::ProcessingContext& outputs);
   int getDigitsFound() { return mTotalDigitsFound; }
   int getTrackletsFound() { return mTotalTrackletsFound; }
   int sumTrackletsFound() { return mEventRecords.sumTracklets(); }
   int sumDigitsFound() { return mEventRecords.sumDigits(); }
-  int getWordsRead() { return mTotalDigitWordsRead; }
-  int getWordsRejected() { return mTotalDigitWordsRejected; }
+  int getWordsRead() { return mTotalDigitWordsRead + mTotalTrackletWordsRead; }
+  int getWordsRejected() { return mTotalDigitWordsRejected + mTotalTrackletWordsRejected; }
 
   std::shared_ptr<EventStorage*> getEventStorage() { return std::make_shared<EventStorage*>(&mEventRecords); }
   void clearall()

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/DigitsParser.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/DigitsParser.h
@@ -19,9 +19,10 @@
 #include "Framework/Task.h"
 #include "Framework/DataProcessorSpec.h"
 #include "DataFormatsTRD/RawData.h"
+#include "DataFormatsTRD/RawDataStats.h"
 #include "DataFormatsTRD/TriggerRecord.h"
 #include "DataFormatsTRD/Constants.h"
-
+#include "TRDReconstruction/EventRecord.h"
 #include <fstream>
 #include <bitset>
 #include "TH1F.h"
@@ -33,7 +34,6 @@
 namespace o2::trd
 {
 class Digit;
-class EventRecord;
 // class to Parse a single link of digits data.
 // calling class splits data by link and this gets called per link.
 
@@ -47,7 +47,7 @@ class DigitsParser
   int Parse(bool verbose = false); // presupposes you have set everything up already.
   int Parse(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>* data, std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator start,
             std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator end, int detector, int stack, int layer, int side, DigitHCHeader& hcheader,
-            TRDFeeID& feeid, unsigned int linkindex, EventRecord* eventrecord, std::bitset<16> options, bool cleardigits = false);
+            TRDFeeID& feeid, unsigned int linkindex, EventRecord* eventrecord, EventStorage* eventrecords, std::bitset<16> options, bool cleardigits = false);
 
   enum DigitParserState { StateDigitHCHeader, // always the start of a half chamber.
                           StateDigitMCMHeader,
@@ -79,9 +79,17 @@ class DigitsParser
     mParsingErrors = parsingerrors;
     mParsingErrors2d = parsingerrors2d;
   }
-  void increment2dHist(int hist)
+
+  void incParsingError(int error)
   {
-    ((TH2F*)mParsingErrors2d->At(hist))->Fill(mFEEID.supermodule * 2 + mFEEID.side, mStack * constants::NLAYER + mLayer);
+
+    if (mOptions[TRDGenerateStats]) {
+      mEventRecords->incParsingError(error, mFEEID.supermodule, mFEEID.side, mStackLayer);
+    }
+    if (mOptions[TRDEnableRootOutputBit]) {
+      mParsingErrors->Fill(error);
+      ((TH2F*)mParsingErrors2d->At(error))->Fill(mFEEID.supermodule * 2 + mFEEID.side, mStack * constants::NLAYER + mLayer);
+    }
   }
 
  private:
@@ -110,6 +118,7 @@ class DigitsParser
   uint32_t mADCMask;
   DigitMCMData* mDigitMCMData;
   EventRecord* mEventRecord;
+  EventStorage* mEventRecords;
   bool mVerbose{false};
   bool mHeaderVerbose{false};
   bool mDataVerbose{false};
@@ -126,12 +135,13 @@ class DigitsParser
   uint16_t mLayer;
   uint16_t mSector;
   uint16_t mSide;
+  uint16_t mHalfSM;     //store these values to prevent numerous recalculation;
+  uint16_t mStackLayer; //store these values to prevent numerous recalculation;
 
   uint16_t mEventCounter;
   TRDFeeID mFEEID;
   std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator mStartParse, mEndParse; // limits of parsing, effectively the link limits to parse on.
   std::array<uint16_t, constants::TIMEBINS> mADCValues{};
-  std::array<uint16_t, constants::MAXMCMCOUNT> mMCMstats; // bit pattern for errors current event for a given mcm;
   TH1F* mParsingErrors;
   TList* mParsingErrors2d;
 };

--- a/Detectors/TRD/reconstruction/src/DataReader.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReader.cxx
@@ -46,8 +46,9 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"halfchamberwords", VariantType::Int, 0, {"Fix half chamber for when it is version is 0.0 integer value of additional header words, ignored if version is not 0.0"}},
     {"halfchambermajor", VariantType::Int, 0, {"Fix half chamber for when it is version is 0.0 integer value of major version, ignored if version is not 0.0"}},
     {"ignore-digithcheader", VariantType::Bool, false, {"Ignore the digithalf chamber header for cross referencing, take rdh/cru as authorative."}},
-    {"tracklethcheader", VariantType::Int, 0, {"Status of TrackletHalfChamberHeader 0 off always, 1 iff tracklet data, 2 on always"}},
+    {"tracklethcheader", VariantType::Int, 2, {"Status of TrackletHalfChamberHeader 0 off always, 1 iff tracklet data, 2 on always"}},
     {"histogramsfile", VariantType::String, "histos.root", {"Name of the histogram file, so one can run multiple per node"}},
+    //{"generate-stats", VariantType::Bool, true, {"Generate the state message sent to qc"}},
     {"trd-datareader-enablebyteswapdata", VariantType::Bool, false, {"byteswap the incoming data, raw data needs it and simulation does not."}}};
 
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
@@ -82,6 +83,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   outputs.emplace_back("TRD", "TRACKLETS", 0, Lifetime::Timeframe);
   outputs.emplace_back("TRD", "DIGITS", 0, Lifetime::Timeframe);
   outputs.emplace_back("TRD", "TRKTRGRD", 0, Lifetime::Timeframe);
+  outputs.emplace_back("TRD", "RAWSTATS", 0, Lifetime::Timeframe);
   //outputs.emplace_back("TRD", "FLPSTAT", 0, Lifetime::Timeframe);
   //
   std::bitset<16> binaryoptions;
@@ -96,6 +98,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   binaryoptions[o2::trd::TRDIgnoreTrackletHCHeaderBit] = cfgc.options().get<bool>("ignore-tracklethcheader");
   binaryoptions[o2::trd::TRDEnableRootOutputBit] = cfgc.options().get<bool>("enable-root-output");
   binaryoptions[o2::trd::TRDByteSwapBit] = cfgc.options().get<bool>("trd-datareader-enablebyteswapdata");
+  //binaryoptions[o2::trd::TRDGenerateStats] = cfgc.options().get<bool>("generate-stats");
+  binaryoptions[o2::trd::TRDGenerateStats] = true; //cfgc.options().get<bool>("generate-stats");
 
   AlgorithmSpec algoSpec;
   algoSpec = AlgorithmSpec{adaptFromTask<o2::trd::DataReaderTask>(tracklethcheader, halfchamberwords, halfchambermajor, cfgc.options().get<std::string>("histogramsfile"), binaryoptions)};

--- a/Detectors/TRD/reconstruction/src/DataReaderTask.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReaderTask.cxx
@@ -208,7 +208,7 @@ void DataReaderTask::endOfStream(o2::framework::EndOfStreamContext& ec)
 void DataReaderTask::sendData(ProcessingContext& pc, bool blankframe)
 {
   if (!blankframe) {
-    mReader.buildDPLOutputs(pc, mDataVerbose);
+    mReader.buildDPLOutputs(pc);
   } else {
     //ensure the objects we are sending back are indeed blank.
     //TODO maybe put this in buildDPLOutputs so sending all done in 1 place, not now though.
@@ -301,8 +301,8 @@ void DataReaderTask::run(ProcessingContext& pc)
   if (mRootOutput) {
     mTimeFrameTime->Fill((int)std::chrono::duration_cast<std::chrono::milliseconds>(dataReadTime).count());
   }
-  LOGP(info, "Digits: {}, Tracklets: {}, DataRead in: {}, Rejected: {} bytes for TF {} in {} ms",
-       mReader.getDigitsFound(), mReader.getTrackletsFound(), mWordsRead * 4, mWordsRejected * 4, tfCount,
+  LOGP(info, "Digits: {}, Tracklets: {}, DataRead in: {:.3f} MB, Rejected: {:.3f} MB for TF {} in {} ms",
+       mReader.getDigitsFound(), mReader.getTrackletsFound(), (float)mWordsRead * 4 / 1024.0 / 1024.0, (float)mWordsRejected * 4 / 1024.0 / 1024.0, tfCount,
        std::chrono::duration_cast<std::chrono::milliseconds>(dataReadTime).count());
 }
 


### PR DESCRIPTION
- fixes detector number, and channel in non zero suppressed digit data.
- expands accepted formats to all but config events.
- qc stats, and its subsequent message.
- defaults tracklethalfchambers header to 2, it was 0 at @shahor02 request.
- histogram option is left in until the qc version of the histograms is properly qualified.
- white bars traced to 2 uses of the word "side", detector side and halfchamber side, now fixed.
