### PR TITLE
Use Lifetime::QA for sampled quantities

### DIFF
--- a/Utilities/DataSampling/src/DataSamplingPolicy.cxx
+++ b/Utilities/DataSampling/src/DataSamplingPolicy.cxx
@@ -69,6 +69,7 @@ DataSamplingPolicy DataSamplingPolicy::fromConfiguration(const ptree& config)
     }
     for (const auto& outputAsInputSpec : outputsAsInputSpecs) {
       outputSpecs.emplace_back(DataSpecUtils::asOutputSpec(outputAsInputSpec));
+      outputSpecs.back().lifetime = Lifetime::QA;
     }
   } else { // otherwise default format will be used
     for (const auto& inputSpec : inputSpecs) {
@@ -78,12 +79,12 @@ DataSamplingPolicy DataSamplingPolicy::fromConfiguration(const ptree& config)
           createPolicyDataOrigin(),
           createPolicyDataDescription(name, outputId++),
           DataSpecUtils::getOptionalSubSpec(inputSpec).value(),
-          inputSpec.lifetime});
+          Lifetime::QA});
       } else {
         outputSpecs.emplace_back(OutputSpec{
           {inputSpec.binding},
           {createPolicyDataOrigin(), createPolicyDataDescription(name, outputId++)},
-          inputSpec.lifetime});
+          Lifetime::QA});
       }
     }
   }

--- a/Utilities/DataSampling/test/test_DataSampling.cxx
+++ b/Utilities/DataSampling/test/test_DataSampling.cxx
@@ -66,13 +66,13 @@ BOOST_AUTO_TEST_CASE(DataSamplingSimpleFlow)
 
   auto output = std::find_if(disp->outputs.begin(), disp->outputs.end(),
                              [](const OutputSpec& out) {
-                               return DataSpecUtils::match(out, ConcreteDataMatcher{"DS", "tpcclusters0", 0}) && out.lifetime == Lifetime::Timeframe;
+                               return DataSpecUtils::match(out, ConcreteDataMatcher{"DS", "tpcclusters0", 0}) && out.lifetime == Lifetime::QA;
                              });
   BOOST_CHECK(output != disp->outputs.end());
 
   output = std::find_if(disp->outputs.begin(), disp->outputs.end(),
                         [](const OutputSpec& out) {
-                          return DataSpecUtils::match(out, ConcreteDataMatcher{"DS", "tpcclusters1", 0}) && out.lifetime == Lifetime::Timeframe;
+                          return DataSpecUtils::match(out, ConcreteDataMatcher{"DS", "tpcclusters1", 0}) && out.lifetime == Lifetime::QA;
                         });
   BOOST_CHECK(output != disp->outputs.end());
 
@@ -125,13 +125,13 @@ BOOST_AUTO_TEST_CASE(DataSamplingParallelFlow)
 
     auto output = std::find_if(disp->outputs.begin(), disp->outputs.end(),
                                [](const OutputSpec& out) {
-                                 return DataSpecUtils::match(out, ConcreteDataMatcher{"DS", "tpcclusters0", 0}) && out.lifetime == Lifetime::Timeframe;
+                                 return DataSpecUtils::match(out, ConcreteDataMatcher{"DS", "tpcclusters0", 0}) && out.lifetime == Lifetime::QA;
                                });
     BOOST_CHECK(output != disp->outputs.end());
 
     output = std::find_if(disp->outputs.begin(), disp->outputs.end(),
                           [](const OutputSpec& out) {
-                            return DataSpecUtils::match(out, ConcreteDataMatcher{"DS", "tpcclusters1", 0}) && out.lifetime == Lifetime::Timeframe;
+                            return DataSpecUtils::match(out, ConcreteDataMatcher{"DS", "tpcclusters1", 0}) && out.lifetime == Lifetime::QA;
                           });
     BOOST_CHECK(output != disp->outputs.end());
 

--- a/Utilities/DataSampling/test/test_DataSamplingPolicy.cxx
+++ b/Utilities/DataSampling/test/test_DataSamplingPolicy.cxx
@@ -68,8 +68,8 @@ BOOST_AUTO_TEST_CASE(DataSamplingPolicyFromConfiguration)
     BOOST_CHECK((policy.prepareOutput(ConcreteDataMatcher{"TST", "CHLEB", 33})) == (Output{"DS", "my_policy0", 33}));
     BOOST_CHECK((policy.prepareOutput(ConcreteDataMatcher{"TST", "MLEKO", 33})) == (Output{"DS", "my_policy1", 33}));
     const auto& map = policy.getPathMap();
-    BOOST_CHECK((*map.find(ConcreteDataMatcher{"TST", "CHLEB", 33})).second == (OutputSpec{"DS", "my_policy0", 33}));
-    BOOST_CHECK((*map.find(ConcreteDataMatcher{"TST", "MLEKO", 33})).second == (OutputSpec{"DS", "my_policy1", 33}));
+    BOOST_CHECK_EQUAL((*map.find(ConcreteDataMatcher{"TST", "CHLEB", 33})).second, (OutputSpec{"DS", "my_policy0", 33, Lifetime::QA}));
+    BOOST_CHECK_EQUAL((*map.find(ConcreteDataMatcher{"TST", "MLEKO", 33})).second, (OutputSpec{"DS", "my_policy1", 33, Lifetime::QA}));
     BOOST_CHECK_EQUAL(map.size(), 2);
 
     BOOST_CHECK(policy.match(ConcreteDataMatcher{"TST", "CHLEB", 33}));
@@ -97,8 +97,8 @@ BOOST_AUTO_TEST_CASE(DataSamplingPolicyFromConfiguration)
     BOOST_CHECK((policy.prepareOutput(ConcreteDataMatcher{"TST", "CHLEB", 33})) == (Output{"TST", "CHLEB_S", 33}));
     BOOST_CHECK((policy.prepareOutput(ConcreteDataMatcher{"TST", "MLEKO", 33})) == (Output{"TST", "MLEKO_S", 33}));
     const auto& map = policy.getPathMap();
-    BOOST_CHECK((*map.find(ConcreteDataMatcher{"TST", "CHLEB", 33})).second == (OutputSpec{"TST", "CHLEB_S", 33}));
-    BOOST_CHECK((*map.find(ConcreteDataMatcher{"TST", "MLEKO", 33})).second == (OutputSpec{"TST", "MLEKO_S", 33}));
+    BOOST_CHECK_EQUAL((*map.find(ConcreteDataMatcher{"TST", "CHLEB", 33})).second, (OutputSpec{"TST", "CHLEB_S", 33, Lifetime::QA}));
+    BOOST_CHECK_EQUAL((*map.find(ConcreteDataMatcher{"TST", "MLEKO", 33})).second, (OutputSpec{"TST", "MLEKO_S", 33, Lifetime::QA}));
     BOOST_CHECK_EQUAL(map.size(), 2);
   }
   // with custom outputs which are wildcards
@@ -109,8 +109,8 @@ BOOST_AUTO_TEST_CASE(DataSamplingPolicyFromConfiguration)
     BOOST_CHECK((policy.prepareOutput(ConcreteDataMatcher{"TST", "CHLEB", 33})) == (Output{"TST", "CHLEB_S", 33}));
     BOOST_CHECK((policy.prepareOutput(ConcreteDataMatcher{"TST", "MLEKO", 33})) == (Output{"TST", "MLEKO_S", 33}));
     const auto& map = policy.getPathMap();
-    BOOST_CHECK((*map.find(ConcreteDataMatcher{"TST", "CHLEB", 33})).second == (OutputSpec{{"TST", "CHLEB_S"}}));
-    BOOST_CHECK((*map.find(ConcreteDataMatcher{"TST", "MLEKO", 33})).second == (OutputSpec{{"TST", "MLEKO_S"}}));
+    BOOST_CHECK_EQUAL((*map.find(ConcreteDataMatcher{"TST", "CHLEB", 33})).second, (OutputSpec{{"TST", "CHLEB_S"}, Lifetime::QA}));
+    BOOST_CHECK_EQUAL((*map.find(ConcreteDataMatcher{"TST", "MLEKO", 33})).second, (OutputSpec{{"TST", "MLEKO_S"}, Lifetime::QA}));
     BOOST_CHECK_EQUAL(map.size(), 2);
   }
 }


### PR DESCRIPTION
This will make sure that sampled data will not be used to do counting
of in-fly timeframes.