### PR TITLE
[WIP][EMCAL-681] Implement pileup simulation for pre-trigger bunches

### DIFF
--- a/Detectors/EMCAL/simulation/src/DigitsWriteoutBuffer.cxx
+++ b/Detectors/EMCAL/simulation/src/DigitsWriteoutBuffer.cxx
@@ -13,6 +13,7 @@
 #include <vector>
 #include <list>
 #include <deque>
+#include <iostream>
 #include <gsl/span>
 #include "EMCALSimulation/LabeledDigit.h"
 #include "EMCALSimulation/DigitsWriteoutBuffer.h"
@@ -22,13 +23,15 @@ using namespace o2::emcal;
 DigitsWriteoutBuffer::DigitsWriteoutBuffer(unsigned int nTimeBins, unsigned int binWidth) : mBufferSize(nTimeBins),
                                                                                             mTimeBinWidth(binWidth)
 {
-  mTimedDigits.resize(nTimeBins);
+  //mTimedDigits.resize(nTimeBins);
+  for(int itime = 0; itime < nTimeBins;itime++) mTimedDigits.push_back(std::unordered_map<int, std::list<LabeledDigit>>());
   mMarker.mReferenceTime = 0.;
   mMarker.mPositionInBuffer = mTimedDigits.begin();
 }
 
 void DigitsWriteoutBuffer::clear()
 {
+  std::cout << "Clearing ..." << std::endl; 
   mTimedDigits.clear();
   mMarker.mReferenceTime = 0.;
   mMarker.mPositionInBuffer = mTimedDigits.begin();
@@ -36,10 +39,15 @@ void DigitsWriteoutBuffer::clear()
 
 void DigitsWriteoutBuffer::addDigit(unsigned int towerID, LabeledDigit dig, double eventTime)
 {
-
+  auto positionMarker = mMarker.mPositionInBuffer - mTimedDigits.begin();
   int nsamples = int((eventTime - mMarker.mReferenceTime) / mTimeBinWidth);
-  auto timeEntry = mMarker.mPositionInBuffer;
-  timeEntry[nsamples][towerID].push_back(dig);
+  auto &timeEntry = *(mMarker.mPositionInBuffer + nsamples);
+  auto towerEntry = timeEntry.find(towerID);
+  if(towerEntry == timeEntry.end()) {
+    towerEntry = timeEntry.insert(std::pair<int, std::list<o2::emcal::LabeledDigit>>(towerID, std::list<o2::emcal::LabeledDigit>())).first;
+  }
+  towerEntry->second.push_back(dig);
+  //timeEntry->insert(std::make_pair(towerID, dig));
 }
 
 void DigitsWriteoutBuffer::forwardMarker(double eventTime)
@@ -55,6 +63,7 @@ void DigitsWriteoutBuffer::forwardMarker(double eventTime)
   if (mMarker.mPositionInBuffer - mTimedDigits.begin() > mNumberReadoutSamples) {
     mTimedDigits.pop_front();
   }
+
 }
 
 gsl::span<std::unordered_map<int, std::list<LabeledDigit>>> DigitsWriteoutBuffer::getLastNSamples(int nsamples)

--- a/Detectors/EMCAL/workflow/src/EMCALDigitizerSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/EMCALDigitizerSpec.cxx
@@ -80,13 +80,15 @@ void DigitizerSpec::run(framework::ProcessingContext& ctx)
   mAccumulatedDigits.clear();
   int trigID = 0;
   int indexStart = mAccumulatedDigits.size();
+
+  bool preTriggerColl = false;
   // loop over all composite collisions given from context
   // (aka loop over all the interaction records)
   for (int collID = 0; collID < timesview.size(); ++collID) {
 
     mDigitizer.setEventTime(timesview[collID].getTimeNS());
 
-    if (!mDigitizer.isEmpty() && (o2::emcal::SimParam::Instance().isDisablePileup() || !mDigitizer.isLive())) {
+    if (!mDigitizer.isEmpty() && (o2::emcal::SimParam::Instance().isDisablePileup() || !mDigitizer.isLive()) && !preTriggerColl) {
       // copy digits into accumulator
       mDigits.clear();
       mLabels.clear();
@@ -101,7 +103,33 @@ void DigitizerSpec::run(framework::ProcessingContext& ctx)
     }
 
     if (!mDigitizer.isLive()) {
+      // Take collisions that occurs 600 ns before the readout window is open
+      if (mDigitizer.preTriggerCollision()) {
+        for (auto& part : eventParts[collID]) {
+          mSumDigitizer.setCurrEvID(part.entryID);
+          mSumDigitizer.setCurrSrcID(part.sourceID);
+
+          // get the hits for this event and this source
+          mHits.clear();
+          context->retrieveHits(mSimChains, "EMCHit", part.sourceID, part.entryID, &mHits);
+
+          LOG(INFO) << "For collision " << collID << " eventID " << part.entryID << " found " << mHits.size() << " hits ";
+
+          std::vector<o2::emcal::LabeledDigit> summedDigits = mSumDigitizer.process(mHits);
+
+          // call actual digitization procedure
+          mDigitizer.process(summedDigits);
+
+          preTriggerColl = true;
+        }
+      }
       continue;
+    } else {
+      preTriggerColl = false;
+      // Discard collisions that occurs 900 ns after the readout window is open
+      if (mDigitizer.afterTriggerCollision()) {
+        continue;
+      }
     }
 
     if (mDigitizer.isEmpty()) {


### PR DESCRIPTION
The current pileup simulation only includes collisions that happen up to 1.5 mus after the trigger, contributions from collisions before the trigger are not included. Still they can leave a signal in the readout window. The logic needs to be changed in the following way:

 -Digitization needs to be started again 600 mus before the end of the busy time.
 -Trigger time still needs to be set to the event that actually triggered the collision.
 -Collisions with a time > trigger time + 900 mus will not leave a signal in the readout window and can therefore be discarded.

In addition to some changes in the DigitsWriteoutBuffer.