### PR TITLE
o2-eve: adding maximum allowed memory option

### DIFF
--- a/EventVisualisation/View/include/EventVisualisationView/EventManagerFrame.h
+++ b/EventVisualisation/View/include/EventVisualisationView/EventManagerFrame.h
@@ -39,6 +39,7 @@ class EventManagerFrame : public TGMainFrame
   bool inTick = false;
   bool setInTick();   // try set inTick, return true if set, false if already set
   void clearInTick(); // safely clears inTick
+  void checkMemory(); // check memory used end exit(-1) if it is too much
   static TGTextButton* makeButton(TGCompositeFrame* p, const char* txt, Int_t width = 0,
                                   Int_t lo = 0, Int_t ro = 0, Int_t to = 0, Int_t bo = 0);
 

--- a/EventVisualisation/View/include/EventVisualisationView/Options.h
+++ b/EventVisualisation/View/include/EventVisualisationView/Options.h
@@ -33,6 +33,7 @@ class Options
   std::string mFileName;   // -f 'data.root'
   std::string mDataFolder; // -d './'
   std::string mSavedDataFolder; // -s './'
+  long mMemoryLimit;            // -m 1500 (MB) = 1.5GB
 
   // helper methods
   static Options instance;
@@ -43,6 +44,7 @@ class Options
     mFileName = "data.root";
     mDataFolder = "./";    // current working directory
     mSavedDataFolder = ""; // not use
+    mMemoryLimit = -1;     // not use
   }
 
  public:
@@ -58,6 +60,7 @@ class Options
   std::string savedDataFolder() { return this->mSavedDataFolder; }
   std::string fileName() { return this->mFileName; }
   bool randomTracks() { return this->mRandomTracks; }
+  long memoryLimit() { return this->mMemoryLimit; }
 };
 
 } // namespace event_visualisation

--- a/EventVisualisation/View/src/EventManagerFrame.cxx
+++ b/EventVisualisation/View/src/EventManagerFrame.cxx
@@ -183,11 +183,35 @@ namespace o2
     clearInTick();
   }
 
+  void EventManagerFrame::checkMemory()
+  {
+    const long memoryLimit = Options::Instance()->memoryLimit();
+    if (memoryLimit != -1) {
+      const char* statmPath = "/proc/self/statm";
+      long size = -1;
+      FILE* f = fopen(statmPath, "r");
+      if (f != nullptr) { // could not read file => no check
+        int success = fscanf(f, "%ld", &size);
+        fclose(f);
+        if (success == 1) {       // properly readed
+          size = 4 * size / 1024; // in MB
+          LOG(INFO) << "Memory used: " << size << " memory allowed: " << memoryLimit;
+          if (size > memoryLimit) {
+            LOG(ERROR) << "Memory used: " << size << " exceeds memory allowed: "
+                       << memoryLimit;
+            exit(-1);
+          }
+        }
+      }
+    }
+  }
+
   void EventManagerFrame::DoTimeTick()
   {
     if (not setInTick()) {
       return;
     }
+    checkMemory(); // exits if memory usage too high = prevents freezing long-running machine
     if (mEventManager->getDataSource()->refresh()) {
       mEventManager->displayCurrentEvent();
     }

--- a/EventVisualisation/View/src/Options.cxx
+++ b/EventVisualisation/View/src/Options.cxx
@@ -59,6 +59,8 @@ std::string Options::usage()
   ss << "\t\t"
      << "-j             use json files as a source" << std::endl;
   ss << "\t\t"
+     << "-m limit       maximum size of the memory which do not cause exiting" << std::endl;
+  ss << "\t\t"
      << "-o             use online json files as a source" << std::endl;
   ss << "\t\t"
      << "-p name        name of the options file" << std::endl;
@@ -79,7 +81,7 @@ bool Options::processCommandLine(int argc, char* argv[])
   // put ':' in the starting of the
   // string so that program can
   //distinguish between '?' and ':'
-  while ((opt = getopt(argc, argv, ":d:f:hijop:rs:vt")) != -1) {
+  while ((opt = getopt(argc, argv, ":d:f:hijm:op:rs:vt")) != -1) {
     switch (opt) {
       case 'd':
         this->mDataFolder = optarg;
@@ -92,6 +94,9 @@ bool Options::processCommandLine(int argc, char* argv[])
         return false;
       case 'j':
         this->mJSON = true;
+        break;
+      case 'm':
+        this->mMemoryLimit = std::stol(std::string(optarg));
         break;
       case 'o':
         this->mOnline = true;


### PR DESCRIPTION
in case of any potential memory leaks, o2-eve will exit after exceeding memory limit option
(so it can be run again)
not setting a limit (-m limit) causes not checking
