### PR TITLE
[MFT] Workaround for MFT tracking with misaligned detector

### DIFF
--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/MFTTrackingParam.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/MFTTrackingParam.h
@@ -36,6 +36,7 @@ struct MFTTrackingParam : public o2::conf::ConfigurableParamHelper<MFTTrackingPa
   Int_t trackmodel = MFTTrackModel::Optimized;
   double MFTRadLength = 0.042; // MFT average material budget within acceptance
   bool verbose = false;
+  bool forceZeroField = true; // Force MFT tracking with B=0 (default = true until alignment is applied)
 
   /// tracking algorithm (LTF and CA) parameters
   /// minimum number of points for a LTF track
@@ -47,7 +48,7 @@ struct MFTTrackingParam : public o2::conf::ConfigurableParamHelper<MFTTrackingPa
   /// minimum number of detector stations for a CA track
   Int_t MinTrackStationsCA = 4;
   /// maximum distance for a cluster to be attached to a seed line (LTF)
-  Float_t LTFclsRCut = 0.0100;
+  Float_t LTFclsRCut = 0.100; // Temporary for misaligned detector. Default 0.0100
   /// maximum distance for a cluster to be attached to a seed line (CA road)
   Float_t ROADclsRCut = 0.0400;
   /// number of bins in r-direction

--- a/Detectors/ITSMFT/MFT/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/Tracker.cxx
@@ -90,6 +90,8 @@ void Tracker<T>::initConfig(const MFTTrackingParam& trkParam, bool printConfig)
     LOG(INFO) << "PhiBins             = " << mPhiBins;
     LOG(INFO) << "LTFseed2BinWin      = " << mLTFseed2BinWin;
     LOG(INFO) << "LTFinterBinWin      = " << mLTFinterBinWin;
+    LOG(INFO) << "FullClusterScan     = " << (trkParam.FullClusterScan ? "true" : "false");
+    LOG(INFO) << "forceZeroField      = " << (trkParam.forceZeroField ? "true" : "false");
   }
 }
 

--- a/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
@@ -68,21 +68,20 @@ void TrackerDPL::init(InitContext& ic)
 
     double centerMFT[3] = {0, 0, -61.4}; // Field at center of MFT
     auto Bz = field->getBz(centerMFT);
-    if (Bz != 0) {
+    if (Bz == 0 || trackingParam.forceZeroField) {
+      LOG(INFO) << "Starting MFT Linear tracker: Field is off!";
+      mFieldOn = false;
+      mTrackerL = std::make_unique<o2::mft::Tracker<TrackLTFL>>(mUseMC);
+      mTrackerL->initConfig(trackingParam, true);
+      mTrackerL->initialize(trackingParam.FullClusterScan);
+    } else {
       LOG(INFO) << "Starting MFT tracker: Field is on!";
       mFieldOn = true;
       mTracker = std::make_unique<o2::mft::Tracker<TrackLTF>>(mUseMC);
       mTracker->setBz(Bz);
       mTracker->initConfig(trackingParam, true);
       mTracker->initialize(trackingParam.FullClusterScan);
-    } else {
-      LOG(INFO) << "Starting MFT Linear tracker: Field is off!";
-      mFieldOn = false;
-      mTrackerL = std::make_unique<o2::mft::Tracker<TrackLTFL>>(mUseMC);
-      mTrackerL->initConfig(trackingParam, true);
-      mTrackerL->initialize(trackingParam.FullClusterScan);
     }
-
   } else {
     throw std::runtime_error(o2::utils::Str::concat_string("Cannot retrieve GRP from the ", filename));
   }


### PR DESCRIPTION
This PR adds option to force zero B field tracking for the MFT and set this as default for convenience in pilot beam assessment and event display. At the moment, B=0 case uses a dummy MFT tracker: Kalman filter is disabled, track position and direction from first and last track-clusters. This is considered a valid approach while alignment corrections are not applied to the detector geometry.
To restore normal tracking configuration use the following configKeyValues:

`o2-mft-reco-workflow --configKeyValues "MFTTracking.forceZeroField=false;MFTTracking.LTFclsRCut=0.0100;"`