### PR TITLE
Embedding: combine associated signal and background MC collisions

### DIFF
--- a/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
+++ b/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
@@ -330,7 +330,7 @@ class AODProducerWorkflowDPL : public Task
                             gsl::span<const o2::dataformats::VtxTrackRef>& primVer2TRefs,
                             gsl::span<const GIndex>& GIndices,
                             o2::globaltracking::RecoContainer& data,
-                            std::vector<std::pair<int, int>> const& mcColToEvSrc);
+                            std::map<std::pair<int, int>, int> const& mcColToEvSrc);
 
   template <typename MCTrackLabelCursorType, typename MCMFTTrackLabelCursorType, typename MCFwdTrackLabelCursorType>
   void fillMCTrackLabelsTable(const MCTrackLabelCursorType& mcTrackLabelCursor,


### PR DESCRIPTION
* Corresponding signal and background events are combined into "composite" collisions
* MC particles from a background event in these collisions have second bit = 1 in `flags` (see https://github.com/AliceO2Group/AliceO2/blob/dev/Framework/Core/include/Framework/DataTypes.h#L68)
* Note that there may be several signal events inside a collision (see e.g. comments here https://github.com/AliceO2Group/O2DPG/blob/055b8759c5f58822b5006602a69df76bfca88a1b/MC/bin/o2dpg_sim_workflow.py#L15-L17)
* A primary vertex is pointed to a "composite" MC collision that contains its corresponding MC event. That means that, in principle, several vertices may point to one MC collision.

@sawenzel, @iarsene: please take a look and see if this implementation is ok for you   