### PR TITLE
SpaceCharge: Adding distortions and time bin information to debug tree

### DIFF
--- a/Detectors/TPC/spacecharge/macro/createSCHistosFromHits.C
+++ b/Detectors/TPC/spacecharge/macro/createSCHistosFromHits.C
@@ -328,8 +328,8 @@ void createSCHistosFromHits(const int ionDriftTime = 200, const int nEvIon = 1, 
           }
 
           // Primary ionization
+          const Side side = getSide(posHit.Z());
           if (std::signbit(zIonsPI) == std::signbit(posHit.Z())) {
-            const Side side = getSide(posHit.Z());
             const auto binPhi = hisSCRandom[side].GetXaxis()->FindBin(phiHit);
             const auto binR = hisSCRandom[side].GetYaxis()->FindBin(rHit);
             const auto binZ = hisSCRandom[side].GetZaxis()->FindBin(zIonsPI);
@@ -341,6 +341,9 @@ void createSCHistosFromHits(const int ionDriftTime = 200, const int nEvIon = 1, 
           // apply distortion of electron if specified
           if (distortionType == 1) {
             spacecharge.distortElectron(posHit);
+            if (side != getSide(posHit.Z())) {
+              posHit.SetZ(side == Side::A ? 0.1f : -0.1f);
+            }
           }
 
           // IBF: Place r-phi projection of hits randomly in z


### PR DESCRIPTION
- adding check to abort calculation of global distortions in case
something goes wrong
- fixing bug in createSCHistosFromHits macro where hits could change sides
after they were distorted