### PR TITLE
Make geometry loadable from the CCDB

### DIFF
--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -700,16 +700,21 @@ void* CcdbApi::extractFromTFile(TFile& file, TClass const* cl)
   auto result = object;
   // We need to handle some specific cases as ROOT ties them deeply
   // to the file they are contained in
-  if (cl->InheritsFrom("TObject")) {
+  if (cl->InheritsFrom("TObject")) { // RS not sure why cloning is needed, certainly for the histos it it enough to SetDirectory(nullptr)
     // make a clone
-    auto obj = ((TObject*)object)->Clone();
     // detach from the file
-    if (auto tree = dynamic_cast<TTree*>(obj)) {
+    auto tree = dynamic_cast<TTree*>((TObject*)object);
+    if (tree) { // RS At the moment leaving the cloning for TTree
+      tree = (TTree*)tree->Clone();
       tree->SetDirectory(nullptr);
-    } else if (auto h = dynamic_cast<TH1*>(obj)) {
-      h->SetDirectory(nullptr);
+      result = tree;
+    } else {
+      auto h = dynamic_cast<TH1*>((TObject*)object);
+      if (h) {
+        h->SetDirectory(nullptr);
+        result = h;
+      }
     }
-    result = obj;
   }
   return result;
 }

--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/NameConf.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/NameConf.h
@@ -67,6 +67,10 @@ class NameConf : public o2::conf::ConfigurableParamHelper<NameConf>
     return o2::utils::Str::concat_string(prefix, "_", CONFIG_STRING, ".ini");
   }
 
+  static constexpr std::string_view CCDBOBJECT = "ccdb_object"; // hardcoded
+  static constexpr std::string_view CCDBMETA = "ccdb_meta";     // hardcoded
+  static constexpr std::string_view CCDBQUERY = "ccdb_query";   // hardcoded
+
   // Filename to store geometry file
   static std::string getGeomFileName(const std::string_view prefix = "");
 
@@ -83,7 +87,7 @@ class NameConf : public o2::conf::ConfigurableParamHelper<NameConf>
   static std::string getCutProcFileName(const std::string_view prefix = "");
 
   // TGeometry object name
-  static constexpr std::string_view GEOMOBJECTNAME = "FAIRGeom"; // hardcoded
+  static constexpr std::string_view GEOMOBJECTNAME_FAIR = "FAIRGeom"; // hardcoded
 
   // public standard TTree key (for MC ) -- not a function
   static constexpr std::string_view MCTTREENAME = "o2sim"; // hardcoded

--- a/Detectors/Base/include/DetectorsBase/GeometryManager.h
+++ b/Detectors/Base/include/DetectorsBase/GeometryManager.h
@@ -51,6 +51,7 @@ class GeometryManager : public TObject
   ///< load geometry from file
   static void loadGeometry(std::string_view geomFilePath = "", bool applyMisalignment = true);
   static bool isGeometryLoaded() { return gGeoManager != nullptr; }
+  static void applyMisalignent(bool applyMisalignment = true);
 
   ///< Get the global transformation matrix (ideal geometry) for a given alignable volume
   ///< The alignable volume is identified by 'symname' which has to be either a valid symbolic

--- a/Detectors/Base/src/GeometryManager.cxx
+++ b/Detectors/Base/src/GeometryManager.cxx
@@ -484,20 +484,32 @@ o2::base::MatBudget GeometryManager::meanMaterialBudget(float x0, float y0, floa
 }
 
 //_________________________________
-void GeometryManager::loadGeometry(std::string_view geomFileName, bool applyMisalignment)
+void GeometryManager::applyMisalignent(bool applyMisalignment)
 {
   ///< load geometry from file
-  std::string fname = o2::base::NameConf::getGeomFileName(geomFileName);
-  LOG(INFO) << "Loading geometry " << o2::base::NameConf::GEOMOBJECTNAME << " from " << fname;
-  TFile flGeom(fname.data());
-  if (flGeom.IsZombie()) {
-    LOG(FATAL) << "Failed to open file " << fname;
-  }
-  if (!flGeom.Get(std::string(o2::base::NameConf::GEOMOBJECTNAME).c_str())) {
-    LOG(FATAL) << "Did not find geometry named " << o2::base::NameConf::GEOMOBJECTNAME;
+  if (!isGeometryLoaded()) {
+    LOG(FATAL) << "geometry is not loaded";
   }
   if (applyMisalignment) {
     auto& aligner = Aligner::Instance();
     aligner.applyAlignment();
   }
+}
+
+//_________________________________
+void GeometryManager::loadGeometry(std::string_view geomFileName, bool applyMisalignment)
+{
+  ///< load geometry from file
+  std::string fname = o2::base::NameConf::getGeomFileName(geomFileName);
+  LOG(INFO) << "Loading geometry from " << fname;
+  TFile flGeom(fname.data());
+  if (flGeom.IsZombie()) {
+    LOG(FATAL) << "Failed to open file " << fname;
+  }
+  // try under the standard CCDB name
+  if (!flGeom.Get(std::string(o2::base::NameConf::CCDBOBJECT).c_str()) &&
+      !flGeom.Get(std::string(o2::base::NameConf::GEOMOBJECTNAME_FAIR).c_str())) {
+    LOG(FATAL) << "Did not find geometry named " << o2::base::NameConf::CCDBOBJECT << " or " << o2::base::NameConf::GEOMOBJECTNAME_FAIR;
+  }
+  applyMisalignent(applyMisalignment);
 }

--- a/Detectors/MUON/MCH/Geometry/Transformer/src/convert-geometry.cxx
+++ b/Detectors/MUON/MCH/Geometry/Transformer/src/convert-geometry.cxx
@@ -52,7 +52,7 @@ TGeoManager* readFromFile(std::string filename)
     throw std::runtime_error("can not open " + filename);
   }
 
-  auto possibleGeoNames = {"ALICE", "FAIRGeom", "MCH-ONLY", "MCH-BASICS"};
+  auto possibleGeoNames = {"ccdb_object", "ALICE", "FAIRGeom", "MCH-ONLY", "MCH-BASICS"};
 
   TGeoManager* geo{nullptr};
 
@@ -64,7 +64,7 @@ TGeoManager* readFromFile(std::string filename)
   }
   if (!geo) {
     f->ls();
-    throw std::runtime_error("could not find ALICE geometry (using ALICE or FAIRGeom names)");
+    throw std::runtime_error("could not find ALICE geometry (using ccdb_object, ALICE or FAIRGeom names)");
   }
   return geo;
 }

--- a/Detectors/TOF/prototyping/CMakeLists.txt
+++ b/Detectors/TOF/prototyping/CMakeLists.txt
@@ -10,7 +10,7 @@
 # or submit itself to any jurisdiction.
 
 o2_add_test_root_macro(checkRotation.C
-                       PUBLIC_LINK_LIBRARIES O2::TOFBase
+                       PUBLIC_LINK_LIBRARIES O2::TOFBase O2::DetectorsBase
                        LABELS tof)
 
 o2_add_test_root_macro(convertTreeTo02object.C

--- a/Detectors/TOF/prototyping/checkRotation.C
+++ b/Detectors/TOF/prototyping/checkRotation.C
@@ -1,6 +1,7 @@
 #if !defined(__CLING__) || defined(__ROOTCLING__)
 #include "TFile.h"
 #include "TOFBase/Geo.h"
+#include "DetectorsBase/GeometryManager.h"
 #endif
 
 void checkRotation(const char* nameinput = "../../../macro/geometry.root")
@@ -16,8 +17,7 @@ void checkRotation(const char* nameinput = "../../../macro/geometry.root")
 
   Int_t n = 1;
 
-  TFile* fin = new TFile(nameinput);
-  fin->Get("FAIRGeom");
+  o2::base::GeometryManager::loadGeometry(nameinput, false);
 
   Int_t isector;
 

--- a/Steer/src/O2MCApplication.cxx
+++ b/Steer/src/O2MCApplication.cxx
@@ -151,6 +151,8 @@ bool O2MCApplicationBase::MisalignGeometry()
 
   auto& confref = o2::conf::SimConfig::Instance();
   auto geomfile = o2::base::NameConf::getGeomFileName(confref.getOutPrefix());
+  // since in general the geometry is a CCDB object, it must be exported under the standard name
+  gGeoManager->SetName(std::string(o2::base::NameConf::CCDBOBJECT).c_str());
   gGeoManager->Export(geomfile.c_str());
 
   // apply alignment for included detectors AFTER exporting ideal geometry


### PR DESCRIPTION
@jgrosseo @victor-gonzalez I've uploaded the geometry both to `http://alice-ccdb.cern.ch` and `http://ccdb-test.cern.ch:8080`,
can be loaded via
```
auto& ccdbmgr = o2::ccdb::BasicCCDBManager::instance();
auto* gm = ccdbmgr.get<TGeoManager>("GLO/Config/Geometry");
```
No need to call `o2::base::GeometryManager::loadGeometry()`.
For the record: to apply misalignment to loaded geometry on can call `o2::base::GeometryManager::applyMisalignent()`.

Note that the name of the geometry object in the `o2sim_geometry.root` was changed to `ccdb_object`, as the CcdbAPI is requiring. The code reading `o2sim_geometry.root` was made backward compatible (checks for `ccdb_object`, falls back to `FAIRGeom`)