### PR TITLE
remove unnecessary --geometry option of MID tracker

### DIFF
--- a/Detectors/MUON/MID/Workflow/src/TrackerMCSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/TrackerMCSpec.cxx
@@ -29,6 +29,7 @@
 #include "DetectorsBase/GeometryManager.h"
 #include "DataFormatsMID/MCClusterLabel.h"
 #include "MIDSimulation/TrackLabeler.h"
+#include "DetectorsCommonDataFormats/NameConf.h"
 
 namespace of = o2::framework;
 
@@ -41,9 +42,8 @@ class TrackerMCDeviceDPL
  public:
   void init(o2::framework::InitContext& ic)
   {
-    auto geoFilename = ic.options().get<std::string>("geometry-filename");
     if (!gGeoManager) {
-      o2::base::GeometryManager::loadGeometry(geoFilename);
+      o2::base::GeometryManager::loadGeometry();
     }
 
     mTracker = std::make_unique<Tracker>(createTransformationFromManager(gGeoManager));
@@ -105,8 +105,7 @@ framework::DataProcessorSpec getTrackerMCSpec()
     {inputSpecs},
     {outputSpecs},
     of::adaptFromTask<o2::mid::TrackerMCDeviceDPL>(),
-    of::Options{
-      {"geometry-filename", of::VariantType::String, "", {"Name of the geometry file"}}}};
+    of::Options{}};
 }
 } // namespace mid
 } // namespace o2

--- a/Detectors/MUON/MID/Workflow/src/TrackerSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/TrackerSpec.cxx
@@ -27,6 +27,7 @@
 #include "DataFormatsMID/Track.h"
 #include "MIDTracking/Tracker.h"
 #include "DetectorsBase/GeometryManager.h"
+#include "DetectorsCommonDataFormats/NameConf.h"
 
 namespace of = o2::framework;
 
@@ -40,9 +41,8 @@ class TrackerDeviceDPL
   void init(o2::framework::InitContext& ic)
   {
 
-    auto geoFilename = ic.options().get<std::string>("geometry-filename");
     if (!gGeoManager) {
-      o2::base::GeometryManager::loadGeometry(geoFilename);
+      o2::base::GeometryManager::loadGeometry();
     }
 
     mTracker = std::make_unique<Tracker>(createTransformationFromManager(gGeoManager));
@@ -109,8 +109,7 @@ framework::DataProcessorSpec getTrackerSpec()
     {inputSpecs},
     {outputSpecs},
     of::adaptFromTask<o2::mid::TrackerDeviceDPL>(),
-    of::Options{
-      {"geometry-filename", of::VariantType::String, "", {"Name of the geometry file"}}}};
+    of::Options{}};
 }
 } // namespace mid
 } // namespace o2


### PR DESCRIPTION
The geometry directory or file is set centrally via NameConf.mDirGeom configurable