### PR TITLE
Methods to constrain track by vertex

### DIFF
--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrization.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrization.h
@@ -126,6 +126,11 @@ class TrackParametrization
   using dim3_t = gpu::gpustd::array<value_t, 3>;
   using params_t = gpu::gpustd::array<value_t, kNParams>;
 
+  struct yzerr_t { // 2 measurement with error
+    dim2_t yz;
+    dim3_t yzerr;
+  };
+
 #ifndef GPUCA_GPUCODE_DEVICE
   static_assert(std::is_floating_point_v<value_t>);
 #endif
@@ -224,6 +229,8 @@ class TrackParametrization
   GPUd() void updateParam(value_t delta, int i);
   GPUd() void updateParams(const params_t& delta);
   GPUd() void updateParams(const value_t* delta);
+
+  GPUd() yzerr_t getVertexInTrackFrame(const o2::dataformats::VertexBase& vtx) const;
 
  private:
   //

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrizationWithError.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrizationWithError.h
@@ -104,6 +104,7 @@ class TrackParametrizationWithError : public TrackParametrization<value_T>
 
   GPUd() bool update(const dim2_t& p, const dim3_t& cov);
   GPUd() bool update(const value_t* p, const value_t* cov);
+  GPUd() value_T update(const o2::dataformats::VertexBase& vtx, value_T maxChi2 = 1e15);
 
   template <typename T>
   GPUd() bool update(const BaseCluster<T>& p);

--- a/DataFormats/Reconstruction/src/TrackParametrization.cxx
+++ b/DataFormats/Reconstruction/src/TrackParametrization.cxx
@@ -748,6 +748,19 @@ GPUd() bool TrackParametrization<value_T>::correctForELoss(value_t xrho, bool an
   return true;
 }
 
+//______________________________________________
+template <typename value_T>
+GPUd() typename o2::track::TrackParametrization<value_T>::yzerr_t TrackParametrization<value_T>::getVertexInTrackFrame(const o2::dataformats::VertexBase& v) const
+{
+  // rotate vertex to track frame and return parameters used by getPredictedChi2 and update of TrackParametrizationWithError
+  value_t sn, cs;
+  math_utils::detail::sincos(-mAlpha, sn, cs); // use -alpha since we rotate from lab to tracking frame
+  value_t sn2 = sn * sn, cs2 = cs * cs, sncs = sn * cs;
+  value_t dsxysncs = 2. * v.getSigmaXY() * sncs;
+  return {{/*v.getX()*cs-v.getY()*sn,*/ v.getX() * sn + v.getY() * cs, v.getZ()},
+          {v.getSigmaX2() * sn2 + dsxysncs + v.getSigmaY2() * cs2, (sn + cs) * v.getSigmaYZ(), v.getSigmaZ2()}};
+}
+
 namespace o2::track
 {
 template class TrackParametrization<float>;

--- a/DataFormats/Reconstruction/src/TrackParametrizationWithError.cxx
+++ b/DataFormats/Reconstruction/src/TrackParametrizationWithError.cxx
@@ -937,6 +937,17 @@ GPUd() bool TrackParametrizationWithError<value_T>::update(const value_t* p, con
 
 //______________________________________________
 template <typename value_T>
+GPUd() value_T TrackParametrizationWithError<value_T>::update(const o2::dataformats::VertexBase& vtx, value_T maxChi2)
+{
+  // Update track with vertex if the track-vertex chi2 does not exceed maxChi2. Track must be already propagated to the DCA to vertex
+  // return update chi2 or -chi2 if chi2 if chi2 exceeds maxChi2
+  auto vtLoc = this->getVertexInTrackFrame(vtx);
+  value_T chi2 = getPredictedChi2(vtLoc.yz, vtLoc.yzerr);
+  return chi2 < maxChi2 && update(vtLoc.yz, vtLoc.yzerr) ? chi2 : -chi2;
+}
+
+//______________________________________________
+template <typename value_T>
 GPUd() bool TrackParametrizationWithError<value_T>::correctForMaterial(value_t x2x0, value_t xrho, bool anglecorr, value_t dedx)
 {
   //------------------------------------------------------------------


### PR DESCRIPTION
Allows to constrain the track by the vertex, e.g.:
```
o2::track::TrackParCov track; // init it ...
o2::dataformats::BaseVertex vtx; // init it ...

// 1) propagate track to DCA to the vertex
if (!track.propagateToDCA(vtx, bz)) { /*failed*/}
// or use more precise o2::base::Propagator::propagateToDCA... methods.

// 2) get vertex point in the track frame
auto vloc = track.getVertexInTrackFrame(vtx);

// 3) use standard method do the check chi2
auto chi2 = track.getPredictedChi2(vloc.first, vloc.second);

// 4) if chi2 is acceptable, update the track
if (!track.update(vloc.first, vloc.second)) { /*failed*/}

//========================
// alternatively, 2,3,4 can be done in a single step
auto chi2 = track.update(vtx, maxChi2);
if (chi2<0) {/*failure*/}
```