### PR TITLE
Data Sampling: allow to select header value treated as TimesliceId

### DIFF
--- a/Utilities/DataSampling/README.md
+++ b/Utilities/DataSampling/README.md
@@ -73,11 +73,13 @@ The [o2-datasampling-pod-and-root](https://github.com/AliceO2Group/AliceO2/blob/
 
 The following sampling conditions are available. When more than one is used, a positive decision is taken when all the conditions are fulfilled.
 - **DataSamplingConditionRandom** - pseudo-randomly accepts specified fraction of incoming messages. Use seed "0" to have it randomly selected.
+  The "timesliceId" parameter selects the header value that is used to select the message, the available options are "startTime" (default), "tfCounter" and "firstTForbit".
 ```json
 {
   "condition": "random",
   "fraction": "0.1",
-  "seed": "22222"
+  "seed": "22222",
+  "timesliceId": "startTime"
 }
 ```
 - **DataSamplingConditionNConsecutive** - approves n consecutive samples in defined cycle. It assumes that timesliceID always increments by one.


### PR DESCRIPTION
This allows to select the header value that is used to decide on selecting random samples.
Despite the plans from few years ago, startTime still uses only a simple counter.
In case of EPNs running in parallel, it means that messages will be sampled at the same time and the first (0) will always cause positive sampling decision.
First we will test different header values as inputs and then we will decide which should be kept as default.