### PR TITLE
Few improvements for the ITS CA async processing

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
@@ -67,6 +67,8 @@ struct TrackingParameters {
   std::vector<float> LayerMisalignment = {0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
   int ZBins{256};
   int PhiBins{128};
+  bool UseDiamond = false;
+  float Diamond[3] = {0.f, 0.f, 0.f};
 
   /// General parameters
   int ClusterSharing = 0;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -166,7 +166,7 @@ class TimeFrame final
   std::vector<Road> mRoads;
   std::vector<std::vector<MCCompLabel>> mTracksLabel;
   std::vector<std::vector<TrackITSExt>> mTracks;
-  std::vector<int> mBogusClusters;  /// keep track of clusters with wild coordinates
+  std::vector<int> mBogusClusters; /// keep track of clusters with wild coordinates
 
   std::vector<index_table_t> mIndexTables;
   std::vector<std::vector<Tracklet>> mTracklets;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -121,6 +121,8 @@ class TimeFrame final
 
   void setMultiplicityCutMask(std::vector<bool> cutMask) { mMultiplicityCutMask.swap(cutMask); }
 
+  int hasBogusClusters() const { return std::accumulate(mBogusClusters.begin(), mBogusClusters.end(), 0); }
+
   /// Debug and printing
   void checkTrackletLUTs();
   void printROFoffsets();
@@ -164,6 +166,7 @@ class TimeFrame final
   std::vector<Road> mRoads;
   std::vector<std::vector<MCCompLabel>> mTracksLabel;
   std::vector<std::vector<TrackITSExt>> mTracks;
+  std::vector<int> mBogusClusters;  /// keep track of clusters with wild coordinates
 
   std::vector<index_table_t> mIndexTables;
   std::vector<std::vector<Tracklet>> mTracklets;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
@@ -47,6 +47,8 @@ struct TrackerParamConfig : public o2::conf::ConfigurableParamHelper<TrackerPara
   float pvRes = -1.f;
   int LUTbinsPhi = -1;
   int LUTbinsZ = -1;
+  float diamondPos[3] = {0.f, 0.f, 0.f};
+  bool useDiamond = false;
 
   O2ParamDef(TrackerParamConfig, "ITSCATrackerParam");
 };

--- a/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
@@ -190,6 +190,7 @@ void TimeFrame::initialise(const int iteration, const MemoryParameters& memParam
     mIndexTableUtils.setTrackingParameters(trkParam);
     mMSangles.resize(trkParam.NLayers);
     mPositionResolution.resize(trkParam.NLayers);
+    mBogusClusters.resize(trkParam.NLayers, 0);
 
     for (unsigned int iLayer{0}; iLayer < mClusters.size(); ++iLayer) {
       if (mClusters[iLayer].size()) {
@@ -224,8 +225,16 @@ void TimeFrame::initialise(const int iteration, const MemoryParameters& memParam
           ClusterHelper& h = cHelper[iCluster];
           float x = c.xCoordinate - mBeamPos[0];
           float y = c.yCoordinate - mBeamPos[1];
+          const float& z = c.zCoordinate;
           float phi = math_utils::computePhi(x, y);
-          const int zBin{mIndexTableUtils.getZBinIndex(iLayer, c.zCoordinate)};
+          int zBin{mIndexTableUtils.getZBinIndex(iLayer, z)};
+          if (zBin < 0) {
+            zBin = 0;
+            mBogusClusters[iLayer]++;
+          } else if (zBin >= trkParam.ZBins) {
+            zBin = trkParam.ZBins - 1;
+            mBogusClusters[iLayer]++;
+          }
           int bin = mIndexTableUtils.getBinIndex(zBin, mIndexTableUtils.getPhiBinIndex(phi));
           h.phi = phi;
           h.r = math_utils::hypot(x, y);

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -656,6 +656,10 @@ void Tracker::getGlobalConfiguration()
     params.NSigmaCut *= tc.nSigmaCut > 0 ? tc.nSigmaCut : 1.f;
     params.CellDeltaTanLambdaSigma *= tc.deltaTanLres > 0 ? tc.deltaTanLres : 1.f;
     params.TrackletMaxDeltaPhi *= tc.phiCut > 0 ? tc.phiCut : 1.f;
+    for (int iD{0}; iD < 3; ++iD) {
+      params.Diamond[iD] = tc.diamondPos[iD];
+    }
+    params.UseDiamond = tc.useDiamond;
   }
 }
 

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -625,9 +625,12 @@ track::TrackParCov Tracker::buildTrackSeed(const Cluster& cluster1, const Cluste
 
   const float fy = 1. / (cluster2.radius - cluster3.radius);
   const float& tz = fy;
-  const float cy = (math_utils::computeCurvature(x1, y1, x2, y2 + resolution, x3, y3) - crv) /
-                   (resolution * getBz() * o2::constants::math::B2C) *
-                   20.f; // FIXME: MS contribution to the cov[14] (*20 added)
+  float cy = 1.e15f;
+  if (std::abs(getBz()) > o2::constants::math::Almost0) {
+    cy = (math_utils::computeCurvature(x1, y1, x2, y2 + resolution, x3, y3) - crv) /
+         (resolution * getBz() * o2::constants::math::B2C) *
+         20.f; // FIXME: MS contribution to the cov[14] (*20 added)
+  }
   const float s2 = resolution;
 
   return track::TrackParCov(tf3.xTrackingFrame, tf3.alphaTrackingFrame,

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -635,7 +635,7 @@ track::TrackParCov Tracker::buildTrackSeed(const Cluster& cluster1, const Cluste
 
   return track::TrackParCov(tf3.xTrackingFrame, tf3.alphaTrackingFrame,
                             {y3, z3, crv * (x3 - x0), 0.5f * (tgl12 + tgl23),
-                             std::abs(getBz()) < o2::constants::math::Almost0 ? o2::constants::math::Almost0
+                             std::abs(getBz()) < o2::constants::math::Almost0 ? 1.f / o2::track::kMostProbablePt
                                                                               : crv / (getBz() * o2::constants::math::B2C)},
                             {s2, 0.f, s2, s2 * fy, 0.f, s2 * fy * fy, 0.f, s2 * tz, 0.f, s2 * tz * tz, s2 * cy, 0.f,
                              s2 * fy * cy, 0.f, s2 * cy * cy});

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackerTraitsCPU.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackerTraitsCPU.cxx
@@ -51,8 +51,10 @@ void TrackerTraitsCPU::computeLayerTracklets()
 
   TimeFrame* tf = mTimeFrame;
 
+  const Vertex diamondVert({mTrkParams.Diamond[0], mTrkParams.Diamond[1], mTrkParams.Diamond[2]}, {25.e-6f, 0.f, 0.f, 25.e-6f, 0.f, 36.f}, 1, 1.f);
+  gsl::span<const Vertex> diamondSpan(&diamondVert, 1);
   for (int rof0{0}; rof0 < tf->getNrof(); ++rof0) {
-    gsl::span<const Vertex> primaryVertices = tf->getPrimaryVertices(rof0);
+    gsl::span<const Vertex> primaryVertices = mTrkParams.UseDiamond ? diamondSpan : tf->getPrimaryVertices(rof0);
     int minRof = (rof0 >= mTrkParams.DeltaROF) ? rof0 - mTrkParams.DeltaROF : 0;
     int maxRof = (rof0 == tf->getNrof() - mTrkParams.DeltaROF) ? rof0 : rof0 + mTrkParams.DeltaROF;
     for (int iLayer{0}; iLayer < mTrkParams.TrackletsPerRoad(); ++iLayer) {

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackerTraitsCPU.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackerTraitsCPU.cxx
@@ -82,8 +82,8 @@ void TrackerTraitsCPU::computeLayerTracklets()
           const float zAtRmin{tanLambda * (tf->getMinR(iLayer + 1) - currentCluster.radius) + currentCluster.zCoordinate};
           const float zAtRmax{tanLambda * (tf->getMaxR(iLayer + 1) - currentCluster.radius) + currentCluster.zCoordinate};
 
-          const float inverseDeltaZ0{1.f / (currentCluster.zCoordinate - primaryVertex.getZ())};
-          const float sigmaZ{std::sqrt(Sq(resolution) * Sq(tanLambda) * ((Sq(inverseR0) + Sq(inverseDeltaZ0)) * Sq(meanDeltaR) + 1.f) + Sq(meanDeltaR * tf->getMSangle(iLayer)))};
+          const float sqInverseDeltaZ0{1.f / (Sq(currentCluster.zCoordinate - primaryVertex.getZ()) + 2.e-8f)}; ///protecting from overflows adding the detector resolution
+          const float sigmaZ{std::sqrt(Sq(resolution) * Sq(tanLambda) * ((Sq(inverseR0) + sqInverseDeltaZ0) * Sq(meanDeltaR) + 1.f) + Sq(meanDeltaR * tf->getMSangle(iLayer)))};
 
           const int4 selectedBinsRect{getBinsRect(currentCluster, iLayer, zAtRmin, zAtRmax,
                                                   sigmaZ * mTrkParams.NSigmaCut, mTrkParams.TrackletMaxDeltaPhi)};

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -286,6 +286,9 @@ void TrackerDPL::run(ProcessingContext& pc)
 
   mTimeFrame.setMultiplicityCutMask(processingMask);
   mTracker->clustersToTracks(logger);
+  if (mTimeFrame.hasBogusClusters()) {
+    LOG(warning) << fmt::format(" - The processed timeframe had {} clusters with wild z coordinates, check the dictionaries", mTimeFrame.hasBogusClusters());
+  }
 
   for (unsigned int iROF{0}; iROF < rofs.size(); ++iROF) {
 

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -134,6 +134,13 @@ void TrackerDPL::init(InitContext& ic)
       trackParams[0].PhiBins = 4;
       trackParams[0].ZBins = 16;
       trackParams[0].PVres = 1.e5f;
+      trackParams[0].LayerMisalignment[0] = 3.e-2;
+      trackParams[0].LayerMisalignment[1] = 3.e-2;
+      trackParams[0].LayerMisalignment[2] = 3.e-2;
+      trackParams[0].LayerMisalignment[3] = 1.e-1;
+      trackParams[0].LayerMisalignment[4] = 1.e-1;
+      trackParams[0].LayerMisalignment[5] = 1.e-1;
+      trackParams[0].LayerMisalignment[6] = 1.e-1;
       trackParams[0].FitIterationMaxChi2[0] = 1.e28;
       trackParams[0].FitIterationMaxChi2[1] = 1.e28;
       LOG(info) << "Initializing tracker in reconstruction for cosmics with " << trackParams.size() << " passes";


### PR DESCRIPTION
- Protect from spurious clusters while reading CTFs
Fixes some occasional crashes and reports in case of "strange" clusters are detected

- Optionally use a diamond instead of PV from finder
Helps greatly to process the runs from yesterday

- Add misalignment to cosmic processing
Makes cosmics reconstruction up to 100% more efficient than before (even some interactions with the detector material are reconstructed)

