### PR TITLE
DPL: drop "DPL:" prefix in infologger

### DIFF
--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -256,7 +256,7 @@ auto createInfoLoggerSinkHelper(InfoLogger* logger, InfoLoggerContext* ctx)
       atoi(metadata.line.c_str())};
 
     if (logger) {
-      logger->log(opt, *ctx, "DPL: %s", content.c_str());
+      logger->log(opt, *ctx, "%s", content.c_str());
     }
   };
 };


### PR DESCRIPTION
Prefix is misleading given it is added to user error messages as
well by now.