### PR TITLE
DPL Analysis: drop support for old RN2 origin

### DIFF
--- a/Framework/Core/src/AnalysisDataModelHelpers.cxx
+++ b/Framework/Core/src/AnalysisDataModelHelpers.cxx
@@ -36,8 +36,6 @@ std::string getTreeName(header::DataHeader dh)
   // add prefix according to origin
   if (origin == "AOD") {
     treeName = "O2" + treeName;
-  } else if (origin == "RN2") {
-    treeName = "Run2" + treeName;
   }
 
   // exceptions from this

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -352,9 +352,6 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
       if (DataSpecUtils::partialMatch(input, header::DataOrigin{"AOD"})) {
         requestedAODs.emplace_back(input);
       }
-      if (DataSpecUtils::partialMatch(input, header::DataOrigin{"RN2"})) {
-        requestedAODs.emplace_back(input);
-      }
       if (DataSpecUtils::partialMatch(input, header::DataOrigin{"DYN"})) {
         if (std::find_if(requestedDYNs.begin(), requestedDYNs.end(), [&](InputSpec const& spec) { return input.binding == spec.binding; }) == requestedDYNs.end()) {
           requestedDYNs.emplace_back(input);
@@ -372,8 +369,6 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
     for (size_t oi = 0; oi < processor.outputs.size(); ++oi) {
       auto& output = processor.outputs[oi];
       if (DataSpecUtils::partialMatch(output, header::DataOrigin{"AOD"})) {
-        providedAODs.emplace_back(output);
-      } else if (DataSpecUtils::partialMatch(output, header::DataOrigin{"RN2"})) {
         providedAODs.emplace_back(output);
       } else if (DataSpecUtils::partialMatch(output, header::DataOrigin{"ATSK"})) {
         providedOutputObjHist.emplace_back(output);
@@ -1087,10 +1082,6 @@ std::tuple<std::vector<InputSpec>, std::vector<unsigned char>> WorkflowHelpers::
 
     // is AOD?
     if (DataSpecUtils::partialMatch(outputSpec, header::DataOrigin("AOD"))) {
-      outputType |= ANALYSIS;
-    }
-    // is RN2?
-    if (DataSpecUtils::partialMatch(outputSpec, header::DataOrigin("RN2"))) {
       outputType |= ANALYSIS;
     }
 


### PR DESCRIPTION
This was used by the old incarnation of the Run 2 data converter
which was reading ESD directly.