### PR TITLE
Automatically push workflow changes to alibuild/AliceO2

### DIFF
--- a/.github/workflows/push-workflow-updates.yml
+++ b/.github/workflows/push-workflow-updates.yml
@@ -1,0 +1,26 @@
+# The GitHub access token for the clang-format check doesn't have the "workflow"
+# permission, so it can't push to alibuild/AliceO2 if workflow files have
+# changed. This action keeps workflow files up to date between the repos.
+
+name: Push workflow updates
+
+on:
+  push:
+    paths:
+      - '.github/workflows/**'
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Push to alibuild's repo
+        env:
+          GITHUB_TOKEN: ${{ secrets.ALIBUILD_WORKFLOW_PUSH_TOKEN }}
+        run: |
+          git push -f "https://alibuild:${GITHUB_TOKEN}@github.com/alibuild/AliceO2.git" \
+                      '${{ !github.event.deleted && github.event.ref || "" }}:${{ github.event.ref }}'


### PR DESCRIPTION
This would solve the occasional breakage of the clang-format check, which can't push branches to its fork when GitHub workflows differ between its old dev and PRs based on the current dev.

It would probably be better to just give the clang-format check the workflow permission, if possible.