### PR TITLE
Ctpdev:digi2raw and ctp-raw-recoder fixes

### DIFF
--- a/Detectors/CTP/simulation/src/Digits2Raw.cxx
+++ b/Detectors/CTP/simulation/src/Digits2Raw.cxx
@@ -39,12 +39,12 @@ void Digits2Raw::init()
   // Interaction Record
   int ilink = 0;
   uint64_t feeID = getFEEIDIR();
-  std::string outFileLink0 = mOutputPerLink ? fmt::format("{}{}_feeid{}.raw", outd, mCTPRawDataFileName, feeID) : fmt::format("{}{}.raw", outd, mCTPRawDataFileName, feeID);
+  std::string outFileLink0 = mOutputPerLink ? fmt::format("{}{}_feeid{}.raw", outd, mCTPRawDataFileName, feeID) : fmt::format("{}{}.raw", outd, mCTPRawDataFileName);
   mWriter.registerLink(feeID, mCruID, ilink, mEndPointID, outFileLink0);
   // Trigger Class record
   ilink = 1;
   feeID = getFEEIDTC();
-  std::string outFileLink1 = mOutputPerLink ? fmt::format("{}{}_feeid{}.raw", outd, mCTPRawDataFileName, feeID) : fmt::format("{}{}.raw", outd, mCTPRawDataFileName, feeID);
+  std::string outFileLink1 = mOutputPerLink ? fmt::format("{}{}_feeid{}.raw", outd, mCTPRawDataFileName, feeID) : fmt::format("{}{}.raw", outd, mCTPRawDataFileName);
   mWriter.registerLink(feeID, mCruID, ilink, mEndPointID, outFileLink1);
   // ilink = 2: HBMap, Counters - tbd
   mWriter.setEmptyPageCallBack(this);

--- a/Detectors/CTP/simulation/src/digi2raw.cxx
+++ b/Detectors/CTP/simulation/src/digi2raw.cxx
@@ -26,7 +26,7 @@
 #include "DataFormatsParameters/GRPObject.h"
 namespace bpo = boost::program_options;
 
-void digi2raw(const std::string& inpName, const std::string& outDir, int verbosity, bool filePerLink, uint32_t rdhV = 4, bool noEmptyHBF = false,
+void digi2raw(const std::string& inpName, const std::string& outDir, int verbosity, const std::string& fileForLink, uint32_t rdhV = 4, bool noEmptyHBF = false,
               int superPageSizeInB = 1024 * 1024);
 
 int main(int argc, char** argv)
@@ -44,7 +44,7 @@ int main(int argc, char** argv)
     add_option("verbosity,v", bpo::value<int>()->default_value(0), "verbosity level");
     //    add_option("input-file,i", bpo::value<std::string>()->default_value(o2::base::NameConf::getDigitsFileName(o2::detectors::DetID::CTP)),"input CTP digits file"); // why not used?
     add_option("input-file,i", bpo::value<std::string>()->default_value("ctpdigits.root"), "input CTP digits file");
-    add_option("file-per-link,l", bpo::value<bool>()->default_value(false)->implicit_value(true), "create output file per CRU (default: per layer)");
+    add_option("file-for,f", bpo::value<std::string>()->default_value("all"), "single file per: all,link,cru");
     add_option("output-dir,o", bpo::value<std::string>()->default_value("./"), "output directory for raw data");
     uint32_t defRDH = o2::raw::RDHUtils::getVersion<o2::header::RAWDataHeader>();
     add_option("rdh-version,r", bpo::value<uint32_t>()->default_value(defRDH), "RDH version to use");
@@ -79,7 +79,7 @@ int main(int argc, char** argv)
   digi2raw(vm["input-file"].as<std::string>(),
            vm["output-dir"].as<std::string>(),
            vm["verbosity"].as<int>(),
-           vm["file-per-link"].as<bool>(),
+           vm["file-for"].as<std::string>(),
            vm["rdh-version"].as<uint32_t>(),
            vm["no-empty-hbf"].as<bool>());
 
@@ -88,12 +88,12 @@ int main(int argc, char** argv)
   return 0;
 }
 
-void digi2raw(const std::string& inpName, const std::string& outDir, int verbosity, bool filePerLink, uint32_t rdhV, bool noEmptyHBF, int superPageSizeInB)
+void digi2raw(const std::string& inpName, const std::string& outDir, int verbosity, const std::string& fileForLink, uint32_t rdhV, bool noEmptyHBF, int superPageSizeInB)
 {
   TStopwatch swTot;
   swTot.Start();
   o2::ctp::Digits2Raw m2r;
-  m2r.setFilePerLink(filePerLink);
+  m2r.setFilePerLink(fileForLink == "link");
   m2r.setVerbosity(verbosity);
   auto& wr = m2r.getWriter();
   std::string inputGRP = o2::base::NameConf::getGRPFileName();

--- a/Detectors/CTP/workflow/CMakeLists.txt
+++ b/Detectors/CTP/workflow/CMakeLists.txt
@@ -23,7 +23,7 @@ o2_add_library(CTPWorkflow
                                      O2::CTPWorkflowIO)
 o2_add_executable(reco-workflow
                   COMPONENT_NAME ctp
-                  SOURCES src/ctp-reco-workflow.cxx
+                  SOURCES src/ctp-raw-decoder.cxx
                   PUBLIC_LINK_LIBRARIES O2::Algorithm
                                         O2::CTPWorkflow)
 

--- a/Detectors/CTP/workflow/include/CTPWorkflow/RecoWorkflow.h
+++ b/Detectors/CTP/workflow/include/CTPWorkflow/RecoWorkflow.h
@@ -34,12 +34,9 @@ enum struct OutputType { Digits,
 };
 
 /// create the workflow for CTP reconstruction
-framework::WorkflowSpec getWorkflow(bool disableRootInp,
-                                    bool disableRootOut,
-                                    bool propagateMC = true,
-                                    bool noLostTF = false,
-                                    std::string const& cfgInput = "raw",    //
-                                    std::string const& cfgOutput = "digits" //
+framework::WorkflowSpec getWorkflow(
+                                    std::string const& cfgInput = "raw",   
+                                    std::string const& cfgOutput = "digits" 
 );
 } // namespace reco_workflow
 

--- a/Detectors/CTP/workflow/include/CTPWorkflow/RecoWorkflow.h
+++ b/Detectors/CTP/workflow/include/CTPWorkflow/RecoWorkflow.h
@@ -25,18 +25,9 @@ namespace ctp
 namespace reco_workflow
 {
 
-/// define input and output types of the workflow
-enum struct InputType { Digits, // read digits from file
-                        Raw     // read data in raw page format from file
-};
-enum struct OutputType { Digits,
-                         Raw
-};
-
 /// create the workflow for CTP reconstruction
-framework::WorkflowSpec getWorkflow(
-  std::string const& cfgInput = "raw",
-  std::string const& cfgOutput = "digits");
+framework::WorkflowSpec getWorkflow(bool noLostTF);
+
 } // namespace reco_workflow
 
 } // namespace ctp

--- a/Detectors/CTP/workflow/include/CTPWorkflow/RecoWorkflow.h
+++ b/Detectors/CTP/workflow/include/CTPWorkflow/RecoWorkflow.h
@@ -35,9 +35,8 @@ enum struct OutputType { Digits,
 
 /// create the workflow for CTP reconstruction
 framework::WorkflowSpec getWorkflow(
-                                    std::string const& cfgInput = "raw",   
-                                    std::string const& cfgOutput = "digits" 
-);
+  std::string const& cfgInput = "raw",
+  std::string const& cfgOutput = "digits");
 } // namespace reco_workflow
 
 } // namespace ctp

--- a/Detectors/CTP/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/CTP/workflow/src/RecoWorkflow.cxx
@@ -45,10 +45,7 @@ const std::unordered_map<std::string, InputType> InputMap{
 const std::unordered_map<std::string, OutputType> OutputMap{
   {"digits", OutputType::Digits}};
 
-o2::framework::WorkflowSpec getWorkflow(bool disableRootInp,
-                                        bool disableRootOut,
-                                        bool propagateMC,
-                                        bool noLostTF,
+o2::framework::WorkflowSpec getWorkflow(
                                         std::string const& cfgInput,
                                         std::string const& cfgOutput)
 {
@@ -71,24 +68,6 @@ o2::framework::WorkflowSpec getWorkflow(bool disableRootInp,
 
   o2::framework::WorkflowSpec specs;
 
-  // //Raw to ....
-  if (inputType == InputType::Raw) {
-    //no explicit raw reader
-
-    if (isEnabled(OutputType::Digits)) {
-      specs.emplace_back(o2::ctp::reco_workflow::getRawToDigitConverterSpec(noLostTF));
-      if (!disableRootOut) {
-        specs.emplace_back(o2::ctp::getDigitWriterSpec(true));
-      }
-    }
-  }
-
-  // Digits to ....
-  if (inputType == InputType::Digits) {
-    if (!disableRootInp) {
-      specs.emplace_back(o2::ctp::getDigitsReaderSpec(propagateMC));
-    }
-  }
   return std::move(specs);
 }
 

--- a/Detectors/CTP/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/CTP/workflow/src/RecoWorkflow.cxx
@@ -38,36 +38,10 @@ namespace ctp
 namespace reco_workflow
 {
 
-const std::unordered_map<std::string, InputType> InputMap{
-  {"raw", InputType::Raw},
-  {"digits", InputType::Digits}};
-
-const std::unordered_map<std::string, OutputType> OutputMap{
-  {"digits", OutputType::Digits}};
-
-o2::framework::WorkflowSpec getWorkflow(
-  std::string const& cfgInput,
-  std::string const& cfgOutput)
+o2::framework::WorkflowSpec getWorkflow(bool noLostTF)
 {
-  InputType inputType;
-
-  try {
-    inputType = InputMap.at(cfgInput);
-  } catch (std::out_of_range&) {
-    throw std::invalid_argument(std::string("invalid input type: ") + cfgInput);
-  }
-  std::vector<OutputType> outputTypes;
-  try {
-    outputTypes = RangeTokenizer::tokenize<OutputType>(cfgOutput, [](std::string const& token) { return OutputMap.at(token); });
-  } catch (std::out_of_range&) {
-    throw std::invalid_argument(std::string("invalid output type: ") + cfgOutput);
-  }
-  auto isEnabled = [&outputTypes](OutputType type) {
-    return std::find(outputTypes.begin(), outputTypes.end(), type) != outputTypes.end();
-  };
-
   o2::framework::WorkflowSpec specs;
-
+  specs.emplace_back(o2::ctp::reco_workflow::getRawToDigitConverterSpec(noLostTF));
   return std::move(specs);
 }
 

--- a/Detectors/CTP/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/CTP/workflow/src/RecoWorkflow.cxx
@@ -46,8 +46,8 @@ const std::unordered_map<std::string, OutputType> OutputMap{
   {"digits", OutputType::Digits}};
 
 o2::framework::WorkflowSpec getWorkflow(
-                                        std::string const& cfgInput,
-                                        std::string const& cfgOutput)
+  std::string const& cfgInput,
+  std::string const& cfgOutput)
 {
   InputType inputType;
 

--- a/Detectors/CTP/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/CTP/workflow/src/RecoWorkflow.cxx
@@ -15,17 +15,10 @@
 
 #include "FairLogger.h"
 
-#include "Framework/RootSerializationSupport.h"
-#include "Algorithm/RangeTokenizer.h"
-#include "DPLUtils/MakeRootTreeWriterSpec.h"
 #include "DataFormatsCTP/Digits.h"
-#include "SimulationDataFormat/MCCompLabel.h"
 #include "CTPWorkflow/RecoWorkflow.h"
-#include "CTPWorkflowIO/DigitReaderSpec.h"
-#include "CTPWorkflowIO/DigitWriterSpec.h"
 #include "CTPWorkflow/RawToDigitConverterSpec.h"
 #include "Framework/DataSpecUtils.h"
-#include "SimulationDataFormat/MCTruthContainer.h"
 
 using namespace o2::dataformats;
 

--- a/Detectors/CTP/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/CTP/workflow/src/RecoWorkflow.cxx
@@ -20,8 +20,6 @@
 #include "CTPWorkflow/RawToDigitConverterSpec.h"
 #include "Framework/DataSpecUtils.h"
 
-using namespace o2::dataformats;
-
 namespace o2
 {
 

--- a/Detectors/CTP/workflow/src/ctp-raw-decoder.cxx
+++ b/Detectors/CTP/workflow/src/ctp-raw-decoder.cxx
@@ -29,12 +29,8 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   std::vector<o2::framework::ConfigParamSpec> options{
     {"input-type", o2::framework::VariantType::String, "raw", {"digits, raw"}},
-    {"output-type", o2::framework::VariantType::String, "digits", {"digits, raw"}},
-    {"disable-mc", o2::framework::VariantType::Bool, false, {"disable sending of MC information"}},
-    {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input reader"}},
-    {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writer"}},
-    {"configKeyValues", o2::framework::VariantType::String, "", {"Semicolon separated key=value strings ..."}},
-    {"ignore-dist-stf", o2::framework::VariantType::Bool, false, {"do not subscribe to FLP/DISTSUBTIMEFRAME/0 message (no lost TF recovery)"}}};
+    {"output-type", o2::framework::VariantType::String, "digits", {"digits, raw"}}
+    };
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
   std::swap(workflowOptions, options);
 }
@@ -58,13 +54,8 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
   // Update the (declared) parameters if changed from the command line
   o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
 
-  auto wf = o2::ctp::reco_workflow::getWorkflow(cfgc.options().get<bool>("disable-root-input"),
-                                                cfgc.options().get<bool>("disable-root-output"),
-                                                !cfgc.options().get<bool>("disable-mc"),
-                                                !cfgc.options().get<bool>("ignore-dist-stf"),  //
-                                                cfgc.options().get<std::string>("input-type"), //
-                                                cfgc.options().get<std::string>("output-type") //
-  );
+  auto wf = o2::ctp::reco_workflow::getWorkflow( cfgc.options().get<std::string>("input-type"), 
+                                                cfgc.options().get<std::string>("output-type") );
   // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
   o2::raw::HBFUtilsInitializer hbfIni(cfgc, wf);
   return std::move(wf);

--- a/Detectors/CTP/workflow/src/ctp-raw-decoder.cxx
+++ b/Detectors/CTP/workflow/src/ctp-raw-decoder.cxx
@@ -29,8 +29,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   std::vector<o2::framework::ConfigParamSpec> options{
     {"input-type", o2::framework::VariantType::String, "raw", {"digits, raw"}},
-    {"output-type", o2::framework::VariantType::String, "digits", {"digits, raw"}}
-    };
+    {"output-type", o2::framework::VariantType::String, "digits", {"digits, raw"}}};
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
   std::swap(workflowOptions, options);
 }
@@ -54,8 +53,8 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
   // Update the (declared) parameters if changed from the command line
   o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
 
-  auto wf = o2::ctp::reco_workflow::getWorkflow( cfgc.options().get<std::string>("input-type"), 
-                                                cfgc.options().get<std::string>("output-type") );
+  auto wf = o2::ctp::reco_workflow::getWorkflow(cfgc.options().get<std::string>("input-type"),
+                                                cfgc.options().get<std::string>("output-type"));
   // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
   o2::raw::HBFUtilsInitializer hbfIni(cfgc, wf);
   return std::move(wf);

--- a/Detectors/CTP/workflow/src/ctp-raw-decoder.cxx
+++ b/Detectors/CTP/workflow/src/ctp-raw-decoder.cxx
@@ -30,8 +30,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   std::vector<o2::framework::ConfigParamSpec> options{
     {"input-type", o2::framework::VariantType::String, "raw", {"digits, raw"}},
     {"output-type", o2::framework::VariantType::String, "digits", {"digits, raw"}},
-    {"configKeyValues", o2::framework::VariantType::String, "", {"Semicolon separated key=value strings ..."}}
-    };
+    {"configKeyValues", o2::framework::VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
   std::swap(workflowOptions, options);
 }

--- a/Detectors/CTP/workflow/src/ctp-raw-decoder.cxx
+++ b/Detectors/CTP/workflow/src/ctp-raw-decoder.cxx
@@ -28,8 +28,6 @@
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   std::vector<o2::framework::ConfigParamSpec> options{
-    {"input-type", o2::framework::VariantType::String, "raw", {"digits, raw"}},
-    {"output-type", o2::framework::VariantType::String, "digits", {"digits, raw"}},
     {"configKeyValues", o2::framework::VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
   std::swap(workflowOptions, options);
@@ -54,8 +52,7 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
   // Update the (declared) parameters if changed from the command line
   o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
 
-  auto wf = o2::ctp::reco_workflow::getWorkflow(cfgc.options().get<std::string>("input-type"),
-                                                cfgc.options().get<std::string>("output-type"));
+  auto wf = o2::ctp::reco_workflow::getWorkflow();
   // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
   o2::raw::HBFUtilsInitializer hbfIni(cfgc, wf);
   return std::move(wf);

--- a/Detectors/CTP/workflow/src/ctp-raw-decoder.cxx
+++ b/Detectors/CTP/workflow/src/ctp-raw-decoder.cxx
@@ -28,6 +28,7 @@
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   std::vector<o2::framework::ConfigParamSpec> options{
+    {"ignore-dist-stf", o2::framework::VariantType::Bool, false, {"do not subscribe to FLP/DISTSUBTIMEFRAME/0 message (no lost TF recovery)"}},
     {"configKeyValues", o2::framework::VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
   std::swap(workflowOptions, options);
@@ -52,7 +53,7 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
   // Update the (declared) parameters if changed from the command line
   o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
 
-  auto wf = o2::ctp::reco_workflow::getWorkflow();
+  auto wf = o2::ctp::reco_workflow::getWorkflow(!cfgc.options().get<bool>("ignore-dist-stf"));
   // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
   o2::raw::HBFUtilsInitializer hbfIni(cfgc, wf);
   return std::move(wf);

--- a/Detectors/CTP/workflow/src/ctp-raw-decoder.cxx
+++ b/Detectors/CTP/workflow/src/ctp-raw-decoder.cxx
@@ -29,7 +29,9 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   std::vector<o2::framework::ConfigParamSpec> options{
     {"input-type", o2::framework::VariantType::String, "raw", {"digits, raw"}},
-    {"output-type", o2::framework::VariantType::String, "digits", {"digits, raw"}}};
+    {"output-type", o2::framework::VariantType::String, "digits", {"digits, raw"}},
+    {"configKeyValues", o2::framework::VariantType::String, "", {"Semicolon separated key=value strings ..."}}
+    };
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
   std::swap(workflowOptions, options);
 }

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -366,7 +366,7 @@ if [ $CTFINPUT == 0 ]; then
   has_detector TRD && add_W o2-trd-datareader "$TRD_DECODER_OPTIONS --pipeline $(get_N trd-datareader TRD RAW TRDRAWDEC)" "" 0
   has_detector ZDC && add_W o2-zdc-raw2digits "$DISABLE_ROOT_OUTPUT --pipeline $(get_N zdc-datareader-dpl ZDC RAW)"
   has_detector HMP && add_W o2-hmpid-raw-to-digits-stream-workflow "--pipeline $(get_N HMP-RawStreamDecoder HMP RAW)"
-  has_detector CTP && add_W o2-ctp-reco-workflow --pipeline $(get_N CTP-RawStreamDecoder CTP RAW)"
+  has_detector CTP && add_W o2-ctp-reco-workflow "--pipeline $(get_N CTP-RawStreamDecoder CTP RAW)"
   has_detector PHS && ! has_detector_flp_processing PHS && add_W o2-phos-reco-workflow "--input-type raw --output-type cells --disable-root-input $DISABLE_ROOT_OUTPUT --pipeline $(get_N PHOSRawToCellConverterSpec PHS REST) $DISABLE_MC"
   has_detector CPV && add_W o2-cpv-reco-workflow "--input-type $CPV_INPUT --output-type clusters --disable-root-input $DISABLE_ROOT_OUTPUT --pipeline $(get_N CPVRawToDigitConverterSpec CPV REST),$(get_N CPVClusterizerSpec CPV REST) $DISABLE_MC"
   has_detector EMC && ! has_detector_flp_processing EMC && add_W o2-emcal-reco-workflow "--input-type raw --output-type cells $EMCRAW2C_CONFIG $DISABLE_ROOT_OUTPUT $DISABLE_MC --pipeline $(get_N EMCALRawToCellConverterSpec EMC REST EMCREC)"

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -366,7 +366,7 @@ if [ $CTFINPUT == 0 ]; then
   has_detector TRD && add_W o2-trd-datareader "$TRD_DECODER_OPTIONS --pipeline $(get_N trd-datareader TRD RAW TRDRAWDEC)" "" 0
   has_detector ZDC && add_W o2-zdc-raw2digits "$DISABLE_ROOT_OUTPUT --pipeline $(get_N zdc-datareader-dpl ZDC RAW)"
   has_detector HMP && add_W o2-hmpid-raw-to-digits-stream-workflow "--pipeline $(get_N HMP-RawStreamDecoder HMP RAW)"
-  has_detector CTP && add_W o2-ctp-reco-workflow "$DISABLE_ROOT_OUTPUT --pipeline $(get_N CTP-RawStreamDecoder CTP RAW)"
+  has_detector CTP && add_W o2-ctp-reco-workflow --pipeline $(get_N CTP-RawStreamDecoder CTP RAW)"
   has_detector PHS && ! has_detector_flp_processing PHS && add_W o2-phos-reco-workflow "--input-type raw --output-type cells --disable-root-input $DISABLE_ROOT_OUTPUT --pipeline $(get_N PHOSRawToCellConverterSpec PHS REST) $DISABLE_MC"
   has_detector CPV && add_W o2-cpv-reco-workflow "--input-type $CPV_INPUT --output-type clusters --disable-root-input $DISABLE_ROOT_OUTPUT --pipeline $(get_N CPVRawToDigitConverterSpec CPV REST),$(get_N CPVClusterizerSpec CPV REST) $DISABLE_MC"
   has_detector EMC && ! has_detector_flp_processing EMC && add_W o2-emcal-reco-workflow "--input-type raw --output-type cells $EMCRAW2C_CONFIG $DISABLE_ROOT_OUTPUT $DISABLE_MC --pipeline $(get_N EMCALRawToCellConverterSpec EMC REST EMCREC)"

--- a/prodtests/full_system_test.sh
+++ b/prodtests/full_system_test.sh
@@ -130,7 +130,7 @@ taskwrapper cpvraw.log o2-cpv-digi2raw --file-for cru -o raw/CPV
 taskwrapper zdcraw.log o2-zdc-digi2raw --file-for cru -o raw/ZDC
 taskwrapper hmpraw.log o2-hmpid-digits-to-raw-workflow --file-for cru --outdir raw/HMP
 taskwrapper trdraw.log o2-trd-trap2raw -o raw/TRD --fileper halfcru
-taskwrapper ctpraw.log o2-ctp-digi2raw -o raw/CTP --file-per-link
+taskwrapper ctpraw.log o2-ctp-digi2raw -o raw/CTP --file-for cru
 
 cat raw/*/*.cfg > rawAll.cfg
 


### PR DESCRIPTION
Fixes described here:
https://github.com/AliceO2Group/AliceO2/pull/7121#issue-1006855566
:
CTP decoding was producing more logs than all other detectors together, so I've changed a lot of INFOs to DEBUG in your code.
Also, had to touch your digits class.

The CTP digit2row still has this custom option --file-per-link instead of --file-for [all,link,cru], could you please fix this? The output naming is ok.

Then, your raw->digits decoder is for some reason named o2-ctp-reco-workflow, Could you please rename it to something more appropriate, e.g. o2-ctp-raw-decoder. More serious is that it declares a lot of options which it is not supposed to support, I guess it comes from some copy/paste.

  --input-type arg (=raw)               digits, raw
  --output-type arg (=digits)           digits, raw
  --disable-mc                          disable sending of MC information
  --disable-root-input                  disable root-files input reader
  --disable-root-output                 disable root-files output writer
Can you have input other than raw and output other than digits?
Raw decoders are not supposed to support MC, so you don't need this option at all.
And for the raw decoders there is no root input anyway.