### PR TITLE
fix in tof cosmic calibrator (TLinearFitter)

### DIFF
--- a/DataFormats/Detectors/TOF/include/DataFormatsTOF/CalibTimeSlewingParamTOF.h
+++ b/DataFormats/Detectors/TOF/include/DataFormatsTOF/CalibTimeSlewingParamTOF.h
@@ -67,7 +67,12 @@ class CalibTimeSlewingParamTOF
     int channelInSector = channel % NCHANNELXSECTOR;
     return getFractionUnderPeak(sector, channelInSector);
   }
-
+  float getSigmaPeak(int channel) const
+  {
+    int sector = channel / NCHANNELXSECTOR;
+    int channelInSector = channel % NCHANNELXSECTOR;
+    return getSigmaPeak(sector, channelInSector);
+  }
   void setFractionUnderPeak(int sector, int channel, float value) { mFractionUnderPeak[sector][channel] = value; }
   void setSigmaPeak(int sector, int channel, float value) { mSigmaPeak[sector][channel] = value; }
 

--- a/DataFormats/Detectors/TOF/src/CalibTimeSlewingParamTOF.cxx
+++ b/DataFormats/Detectors/TOF/src/CalibTimeSlewingParamTOF.cxx
@@ -133,6 +133,10 @@ bool CalibTimeSlewingParamTOF::updateOffsetInfo(int channel, float residualOffse
   channel = channel % NCHANNELXSECTOR;
   //  printf("sector = %d, channel = %d\n", sector, channel);
 
+  mGlobalOffset[sector][channel] += residualOffset;
+  return true;
+
+  /*
   // printf("DBG: addTimeSlewinginfo sec=%i\n",sector);
 
   int n = mChannelStart[sector][channel]; // first time slewing entry for the current channel. this corresponds to tot = 0
@@ -149,6 +153,7 @@ bool CalibTimeSlewingParamTOF::updateOffsetInfo(int channel, float residualOffse
   }
   (mTimeSlewing[sector])[n].second += (short)residualOffset;
   return true;
+*/
 }
 //______________________________________________
 CalibTimeSlewingParamTOF& CalibTimeSlewingParamTOF::operator+=(const CalibTimeSlewingParamTOF& other)

--- a/Detectors/TOF/calibration/include/TOFCalibration/TOFChannelCalibrator.h
+++ b/Detectors/TOF/calibration/include/TOFCalibration/TOFChannelCalibrator.h
@@ -275,7 +275,7 @@ class TOFChannelCalibrator final : public o2::calibration::TimeSlotCalibration<T
 
   bool mCalibWithCosmics = false; // flag to indicate whether we are calibrating with cosmics
 
-  int mNThreads = 0; // number of threads from OpenMP
+  int mNThreads = 1; // number of threads from OpenMP
 
   std::string mStripOffsetFunction; // TLinear functon for fitting channel offset within the strip in cosmic data
 

--- a/Detectors/TOF/calibration/testWorkflow/TOFChannelCalibratorSpec.h
+++ b/Detectors/TOF/calibration/testWorkflow/TOFChannelCalibratorSpec.h
@@ -27,6 +27,7 @@
 #include "CCDB/CcdbApi.h"
 #include "CCDB/CcdbObjectInfo.h"
 #include <limits>
+#include "TFile.h"
 
 using namespace o2::framework;
 
@@ -79,6 +80,13 @@ class TOFChannelCalibDevice : public o2::framework::Task
     // calibration objects set to zero
     mPhase.addLHCphase(0, 0);
     mPhase.addLHCphase(2000000000, 0);
+
+    TFile* fsleewing = TFile::Open("localTimeSlewing.root");
+    if (fsleewing) {
+      TimeSlewing* ob = (TimeSlewing*)fsleewing->Get("TimeSlewing");
+      mTimeSlewing = *ob;
+      return;
+    }
 
     for (int ich = 0; ich < TimeSlewing::NCHANNELS; ich++) {
       mTimeSlewing.addTimeSlewingInfo(ich, 0, 0);


### PR DESCRIPTION
Default = 1 thread used
fix in TLinearFitter fit to protect from non positive matrix definition (completed addpoint with missing points)