### PR TITLE
PV fit account ITS tracks time with 1/ITS downscaling

### DIFF
--- a/Detectors/Vertexing/include/DetectorsVertexing/PVertexerHelpers.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/PVertexerHelpers.h
@@ -46,13 +46,17 @@ struct VertexingInput {
 struct VertexSeed : public PVertex {
   double wghSum = 0.;                                                                              // sum of tracks weights
   double wghChi2 = 0.;                                                                             // sum of tracks weighted chi2's
-  double tMeanAcc = 0.;                                                                            // sum of track times * inv.err^2
-  double tMeanAccErr = 0.;                                                                         // some of tracks times inv.err^2
+  double tMeanAcc = 0.;                                                                            // sum of track times * inv.err^2 wotj real time error
+  double tMeanAccErr = 0.;                                                                         // some of tracks times inv.err^2 with real time error
+  double tMeanAccTB = 0.;                                                                          // sum of track times * inv.err^2 with time error from time bracket, i.e. ITS
+  double tMeanAccErrTB = 0.;                                                                       // sum of tracks times inv.err^2 with time error from time bracket, i.e. ITS
+  double wghSumTB = 0.;                                                                            // sum of weights for tracks with time error from time bracket, i.e. ITS
   double cxx = 0., cyy = 0., czz = 0., cxy = 0., cxz = 0., cyz = 0., cx0 = 0., cy0 = 0., cz0 = 0.; // elements of lin.equation matrix
   float scaleSigma2 = 1.;                                                                          // scaling parameter on top of Tukey param
   float scaleSigma2Prev = 1.;
   float maxScaleSigma2Tested = 0.;
   float scaleSig2ITuk2I = 0; // inverse squared Tukey parameter scaled by scaleSigma2
+  int nContributorsTB = 0;   // number of contributors with time error coming from Time Bracker
   int nScaleSlowConvergence = 0;
   int nScaleIncrease = 0;
   int nIterations = 0;
@@ -67,11 +71,15 @@ struct VertexSeed : public PVertex {
   void resetForNewIteration()
   {
     setNContributors(0);
+    nContributorsTB = 0;
     //setTimeStamp({0., 0.});
-    wghSum = 0;
-    wghChi2 = 0;
-    tMeanAcc = 0;
-    tMeanAccErr = 0;
+    wghSum = 0.;
+    wghChi2 = 0.;
+    wghSumTB = 0.;
+    tMeanAcc = 0.;
+    tMeanAccErr = 0.;
+    tMeanAccTB = 0.;
+    tMeanAccErrTB = 0.;
     cxx = cyy = czz = cxy = cxz = cyz = cx0 = cy0 = cz0 = 0.;
   }
 

--- a/Detectors/Vertexing/src/PVertexer.cxx
+++ b/Detectors/Vertexing/src/PVertexer.cxx
@@ -271,6 +271,11 @@ void PVertexer::accountTrack(TrackVF& trc, VertexSeed& vtxSeed) const
   }
   float syyI(trc.sig2YI), szzI(trc.sig2ZI), syzI(trc.sigYZI);
 
+  auto timeErrorFromTB = [&trc]() {
+    // decide if the time error is from the time bracket rather than gaussian error
+    return trc.gid.getSource() == GTrackID::ITS;
+  };
+
   //
   vtxSeed.wghSum += wghT;
   vtxSeed.wghChi2 += wghT * chi2T;
@@ -304,8 +309,15 @@ void PVertexer::accountTrack(TrackVF& trc, VertexSeed& vtxSeed) const
   //
   if (useTime) {
     float trErr2I = wghT / (trc.timeEst.getTimeStampError() * trc.timeEst.getTimeStampError());
-    vtxSeed.tMeanAcc += trc.timeEst.getTimeStamp() * trErr2I;
-    vtxSeed.tMeanAccErr += trErr2I;
+    if (timeErrorFromTB()) {
+      vtxSeed.tMeanAccTB += trc.timeEst.getTimeStamp() * trErr2I;
+      vtxSeed.tMeanAccErrTB += trErr2I;
+      vtxSeed.nContributorsTB++;
+      vtxSeed.wghSumTB += wghT;
+    } else {
+      vtxSeed.tMeanAcc += trc.timeEst.getTimeStamp() * trErr2I;
+      vtxSeed.tMeanAccErr += trErr2I;
+    }
   }
   vtxSeed.addContributor();
 }
@@ -328,9 +340,16 @@ bool PVertexer::solveVertex(VertexSeed& vtxSeed) const
   auto sol = mat * rhs;
   vtxSeed.setXYZ(sol(0), sol(1), sol(2));
   vtxSeed.setCov(mat(0, 0), mat(1, 0), mat(1, 1), mat(2, 0), mat(2, 1), mat(2, 2));
-  if (vtxSeed.tMeanAccErr > 0.) {
-    auto err2 = 1. / vtxSeed.tMeanAccErr;
-    vtxSeed.setTimeStamp({float(vtxSeed.tMeanAcc * err2), float(std::sqrt(err2))});
+  if (vtxSeed.tMeanAccErr + vtxSeed.tMeanAccErrTB > 0.) {
+    // since the time error from the ITS measurements does not improve with statistics, we downscale it with number of such tracks
+    auto t = vtxSeed.tMeanAcc;
+    auto e2i = vtxSeed.tMeanAccErr;
+    if (vtxSeed.wghSumTB > 0.) {
+      t += vtxSeed.tMeanAccTB / vtxSeed.wghSumTB;
+      e2i += vtxSeed.tMeanAccErrTB / vtxSeed.wghSumTB;
+    }
+    auto err2 = 1. / e2i;
+    vtxSeed.setTimeStamp({float(t * err2), float(std::sqrt(err2))});
   }
 
   vtxSeed.setChi2((vtxSeed.getNContributors() - vtxSeed.wghSum) / vtxSeed.scaleSig2ITuk2I); // calculate chi^2


### PR DESCRIPTION
Since ITS tracks time error comes from time bracket rather than measurement with normal error, it cannot be weight-averaged.
Therefore the ITS tracks time error accumulation is done separately and then downscaled by N_ITS_contributors.