### PR TITLE
Add missing information in MC tracks and TracksExtra tables

### DIFF
--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -299,6 +299,11 @@ void AODProducerWorkflowDPL::fillTrackTablesPerCollision(int collisionID,
         } else {
           auto contributorsGID = data.getSingleDetectorRefs(trackIndex);
           const auto& trackPar = data.getTrackParam(trackIndex);
+          if (contributorsGID[GIndex::Source::ITS].isIndexSet() || contributorsGID[GIndex::Source::ITSAB].isIndexSet()) {
+            int nClusters = itsTracks[contributorsGID[GIndex::ITS].getIndex()].getNClusters();
+            float chi2 = itsTracks[contributorsGID[GIndex::ITS].getIndex()].getChi2();
+            extraInfoHolder.itsChi2NCl = nClusters != 0 ? chi2 / (float)nClusters : 0;
+          }
           if (contributorsGID[GIndex::Source::ITS].isIndexSet()) {
             extraInfoHolder.itsClusterMap = itsTracks[contributorsGID[GIndex::ITS].getIndex()].getPattern();
           } else if (contributorsGID[GIndex::Source::ITSAB].isIndexSet()) { // this is an ITS-TPC afterburner contributor
@@ -653,6 +658,9 @@ void AODProducerWorkflowDPL::fillMCParticlesTable(o2::steer::MCKinematicsReader&
       }
       int statusCode = 0;
       uint8_t flags = 0;
+      if (!mcParticles[particle].isTransported()) {
+        flags |= 1 << 0; // mark as transported
+      }
       if (source == 0) {
         flags |= 1 << 1; // mark as particle from background event
       }


### PR DESCRIPTION
@sawenzel: Could you please check if `MCTrack::isTransported()` is used correctly for determining whether a MC particle came from generator or from transport code

@mario-krueger: this should fix the issue with ITS chi2 from [O2-2654](https://alice.its.cern.ch/jira/browse/O2-2654). As for `fLength`, this information should be already put in AOD:
https://github.com/AliceO2Group/AliceO2/blob/0835e14f5bd04969b30fa782efbae4f126031c25/Detectors/AOD/src/AODProducerWorkflowSpec.cxx#L322-L324
`fLength` is filled for tracks that have TOF information. Do you use `hasTOF` (https://github.com/AliceO2Group/AliceO2/blob/0835e14f5bd04969b30fa782efbae4f126031c25/Framework/Core/include/Framework/AnalysisDataModel.h#L226-L227)?