### PR TITLE
Provide MC generator status code as part of MCTrack

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/MCTrack.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCTrack.h
@@ -187,6 +187,9 @@ class MCTrackT
   /// get the production process (id) of this track
   int getProcess() const { return ((PropEncoding)mProp).process; }
 
+  /// get generator status code
+  int getStatusCode() const { return mStatusCode; }
+
   void setToBeDone(bool f)
   {
     auto prop = ((PropEncoding)mProp);
@@ -244,6 +247,11 @@ class MCTrackT
       int toBeDone : 1; // whether this (still) needs tracking --> we might more complete information to cover full ParticleStatus space
     };
   };
+
+  // Additional status codes for MC generator information.
+  // NOTE: This additional memory cost might be reduced by using bits elsewhere
+  // such as part of mProp (process) or mPDG
+  Int_t mStatusCode = 0;
 
   ClassDefNV(MCTrackT, 4);
 };
@@ -326,7 +334,8 @@ inline MCTrackT<T>::MCTrackT(const TParticle& part)
     mStartVertexCoordinatesY(part.Vy()),
     mStartVertexCoordinatesZ(part.Vz()),
     mStartVertexCoordinatesT(part.T() * 1e09),
-    mProp(0)
+    mProp(0),
+    mStatusCode(0)
 {
   // our convention is to communicate the process as (part) of the unique ID
   setProcess(part.GetUniqueID());
@@ -339,6 +348,8 @@ inline MCTrackT<T>::MCTrackT(const TParticle& part)
     setToBeDone(true); // if inhibited, it had to be done: restore flag
     setInhibited(true);
   }
+  // set MC generator status code only for primaries
+  mStatusCode = part.TestBit(ParticleStatus::kPrimary) ? part.GetStatusCode() : -1;
 }
 
 template <typename T>

--- a/Generators/include/Generators/PrimaryGenerator.h
+++ b/Generators/include/Generators/PrimaryGenerator.h
@@ -63,7 +63,7 @@ class PrimaryGenerator : public FairPrimaryGenerator
                 Int_t daughter1 = -1, Int_t daughter2 = -1,
                 Bool_t wanttracking = true,
                 Double_t e = -9e9, Double_t tof = 0.,
-                Double_t weight = 0., TMCProcess proc = kPPrimary);
+                Double_t weight = 0., TMCProcess proc = kPPrimary, Int_t generatorStatus = 0);
 
   /** initialize the generator **/
   Bool_t Init() override;

--- a/Generators/src/Generator.cxx
+++ b/Generators/src/Generator.cxx
@@ -135,7 +135,8 @@ Bool_t
                         particle.Energy() * mEnergyUnit,
                         particle.T() * mTimeUnit,
                         particle.GetWeight(),
-                        (TMCProcess)particle.GetUniqueID());
+                        (TMCProcess)particle.GetUniqueID(),
+                        particle.GetStatusCode()); // generator status information passed as status code field
   }
 
   /** success **/

--- a/Generators/src/PrimaryGenerator.cxx
+++ b/Generators/src/PrimaryGenerator.cxx
@@ -126,7 +126,7 @@ void PrimaryGenerator::AddTrack(Int_t pdgid, Double_t px, Double_t py, Double_t 
                                 Int_t daughter1, Int_t daughter2,
                                 Bool_t wanttracking,
                                 Double_t e, Double_t tof,
-                                Double_t weight, TMCProcess proc)
+                                Double_t weight, TMCProcess proc, Int_t generatorStatus)
 {
   /** add track **/
 
@@ -152,7 +152,7 @@ void PrimaryGenerator::AddTrack(Int_t pdgid, Double_t px, Double_t py, Double_t 
   Double_t poly = 0.;
   Double_t polz = 0.;
   Int_t ntr = 0;    // Track number; to be filled by the stack
-  Int_t status = 0; // Generation status
+  Int_t status = generatorStatus; // Generation status
 
   // correct for tracks which are in list before generator is called
   if (mother1 != -1) {


### PR DESCRIPTION
Status codes provided from MC generators (as part
of TParticle) are now propagated and stored in MCTrack
(for primary particles).

This should allow to fill the necessary information
in AOD tables.

Some future memory optimization can be done and is targeted
(avoiding extra data member for this).