### PR TITLE
TRD remove unused placeholder

### DIFF
--- a/Detectors/TRD/base/include/TRDBase/TrackletTransformer.h
+++ b/Detectors/TRD/base/include/TRDBase/TrackletTransformer.h
@@ -70,7 +70,6 @@ class TrackletTransformer
   float mXtb0;
 
   o2::trd::CalVdriftExB* mCalibration;
-  std::vector<float>* mT0;
 };
 
 } // namespace trd

--- a/Detectors/TRD/base/src/TrackletTransformer.cxx
+++ b/Detectors/TRD/base/src/TrackletTransformer.cxx
@@ -48,14 +48,8 @@ void TrackletTransformer::loadCalibrationParameters(int timestamp)
 
   mCalibration = ccdbmgr.get<o2::trd::CalVdriftExB>("TRD/Calib/CalVdriftExB");
 
-  // placeholder for when t0 is available
-  mT0 = ccdbmgr.get<std::vector<float>>("TRD/Calib/ChamberT0");
-
   if (mCalibration == nullptr) {
     LOG(error) << " failed to get vDrift and ExB parameters from ccdb";
-  }
-  if (mT0 == nullptr) {
-    LOG(warn) << " failed to get mT0 parameters from ccdb";
   }
 }
 


### PR DESCRIPTION
@jbarrella I would remove this for now, as it is not used anyway and otherwise we get errors from the CCDB when it tries to access the object. As a short term solution I have uploaded a dummy object with the lifetime of a couple days