### PR TITLE
Improve GPU memory benchmark

### DIFF
--- a/GPU/GPUbenchmark/Shared/Kernels.h
+++ b/GPU/GPUbenchmark/Shared/Kernels.h
@@ -39,7 +39,7 @@ class GPUbenchmark final
   template <typename... T>
   float measure(void (GPUbenchmark::*)(T...), const char*, T&&... args);
 
-  // Single stream synchronous (sequential kernels) execution
+  // Single stream (sequential kernels) execution
   template <typename... T>
   float runSequential(void (*kernel)(chunk_t*, size_t, T...),
                       std::pair<float, float>& chunkRanges,
@@ -48,7 +48,7 @@ class GPUbenchmark final
                       int dimBlock,
                       T&... args);
 
-  // Multi-streams asynchronous executions on whole memory
+  // Multi-streams asynchronous executions
   template <typename... T>
   std::vector<float> runConcurrent(void (*kernel)(chunk_t*, size_t, T...),
                                    std::vector<std::pair<float, float>>& chunkRanges,
@@ -57,6 +57,15 @@ class GPUbenchmark final
                                    int nBlocks,
                                    int nThreads,
                                    T&... args);
+
+  // Single stream executions on all chunks at a time by same kernel
+  template <typename... T>
+  float runDistributed(void (*kernel)(chunk_t**, size_t*, T...),
+                       std::vector<std::pair<float, float>>& chunkRanges,
+                       int nLaunches,
+                       int nBlocks,
+                       int nThreads,
+                       T&... args);
 
   // Main interface
   void globalInit();     // Allocate scratch buffers and compute runtime parameters

--- a/GPU/GPUbenchmark/Shared/Kernels.h
+++ b/GPU/GPUbenchmark/Shared/Kernels.h
@@ -42,7 +42,7 @@ class GPUbenchmark final
   // Single stream synchronous (sequential kernels) execution
   template <typename... T>
   float runSequential(void (*kernel)(chunk_t*, size_t, T...),
-                      std::pair<int, int>& chunkRanges,
+                      std::pair<float, float>& chunkRanges,
                       int nLaunches,
                       int dimGrid,
                       int dimBlock,
@@ -51,7 +51,7 @@ class GPUbenchmark final
   // Multi-streams asynchronous executions on whole memory
   template <typename... T>
   std::vector<float> runConcurrent(void (*kernel)(chunk_t*, size_t, T...),
-                                   std::vector<std::pair<int, int>>& chunkRanges,
+                                   std::vector<std::pair<float, float>>& chunkRanges,
                                    int nLaunches,
                                    int dimStreams,
                                    int nBlocks,

--- a/GPU/GPUbenchmark/Shared/Utils.h
+++ b/GPU/GPUbenchmark/Shared/Utils.h
@@ -72,7 +72,8 @@ inline std::ostream& operator<<(std::ostream& os, Test test)
 
 enum class Mode {
   Sequential,
-  Concurrent
+  Concurrent,
+  Distributed
 };
 
 inline std::ostream& operator<<(std::ostream& os, Mode mode)
@@ -83,6 +84,9 @@ inline std::ostream& operator<<(std::ostream& os, Mode mode)
       break;
     case Mode::Concurrent:
       os << "concurrent";
+      break;
+    case Mode::Distributed:
+      os << "distributed";
       break;
   }
   return os;

--- a/GPU/GPUbenchmark/Shared/Utils.h
+++ b/GPU/GPUbenchmark/Shared/Utils.h
@@ -138,17 +138,11 @@ inline std::string getTestName(Mode mode, Test test, KernelConfig blocks)
   return tname;
 }
 
-template <class chunk_t>
-inline chunk_t* getPartPtr(chunk_t* scratchPtr, float chunkReservedGB, int partNumber)
-{
-  return reinterpret_cast<chunk_t*>(reinterpret_cast<char*>(scratchPtr) + static_cast<size_t>(GB * chunkReservedGB) * partNumber);
-}
-
 // Return pointer to custom offset (GB)
 template <class chunk_t>
-inline chunk_t* getCustomPtr(chunk_t* scratchPtr, int partNumber)
+inline chunk_t* getCustomPtr(chunk_t* scratchPtr, float startGB)
 {
-  return reinterpret_cast<chunk_t*>(reinterpret_cast<char*>(scratchPtr) + static_cast<size_t>(GB * partNumber));
+  return reinterpret_cast<chunk_t*>(reinterpret_cast<char*>(scratchPtr) + static_cast<size_t>(GB * startGB));
 }
 
 inline float computeThroughput(Test test, float result, float chunkSizeGB, int ntests)
@@ -160,9 +154,9 @@ inline float computeThroughput(Test test, float result, float chunkSizeGB, int n
 }
 
 template <class chunk_t>
-inline size_t getBufferCapacity(int chunkReservedGB)
+inline size_t getBufferCapacity(float chunkReservedGB)
 {
-  return static_cast<size_t>(GB * chunkReservedGB / sizeof(chunk_t));
+  return static_cast<size_t>((GB * chunkReservedGB) / sizeof(chunk_t));
 }
 
 // LCG: https://rosettacode.org/wiki/Linear_congruential_generator
@@ -202,7 +196,7 @@ struct benchmarkOpts {
   std::vector<Mode> modes = {Mode::Sequential, Mode::Concurrent};
   std::vector<KernelConfig> pools = {KernelConfig::Single, KernelConfig::Multi};
   std::vector<std::string> dtypes = {"char", "int", "ulong"};
-  std::vector<std::pair<int, int>> testChunks;
+  std::vector<std::pair<float, float>> testChunks;
   float chunkReservedGB = 1.f;
   float threadPoolFraction = 1.f;
   float freeMemoryFractionToAllocate = 0.95f;
@@ -235,10 +229,10 @@ struct gpuState {
   float chunkReservedGB; // Size of each partition (GB)
 
   // General containers and state
-  chunk_t* scratchPtr;                         // Pointer to scratch buffer
-  size_t scratchSize;                          // Size of scratch area (B)
-  std::vector<chunk_t*> partAddrOnHost;        // Pointers to scratch partitions on host vector
-  std::vector<std::pair<int, int>> testChunks; // Vector of definitions for arbitrary chunks
+  chunk_t* scratchPtr;                             // Pointer to scratch buffer
+  size_t scratchSize;                              // Size of scratch area (B)
+  std::vector<chunk_t*> partAddrOnHost;            // Pointers to scratch partitions on host vector
+  std::vector<std::pair<float, float>> testChunks; // Vector of definitions for arbitrary chunks
 
   // Static info
   size_t totalMemory;

--- a/GPU/GPUbenchmark/cuda/Kernels.cu
+++ b/GPU/GPUbenchmark/cuda/Kernels.cu
@@ -386,7 +386,7 @@ void GPUbenchmark<chunk_t>::globalInit()
   mState.iterations = mOptions.kernelLaunches;
   mState.streams = mOptions.streams;
   mState.testChunks = mOptions.testChunks;
-  if (!checkTestChunks(mOptions.testChunks, free / GB)) {
+  if (!checkTestChunks(mOptions.testChunks, mOptions.freeMemoryFractionToAllocate * free / GB)) {
     std::cerr << "Failed to configure memory chunks: check arbitrary chunks boundaries." << std::endl;
     exit(1);
   }

--- a/GPU/GPUbenchmark/cuda/benchmark.cu
+++ b/GPU/GPUbenchmark/cuda/benchmark.cu
@@ -95,7 +95,7 @@ bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
       conf.modes.push_back(Mode::Concurrent);
     } else if (mode == "dis") {
       conf.modes.push_back(Mode::Distributed);
-    }else {
+    } else {
       std::cerr << "Unkonwn mode: " << mode << std::endl;
       exit(1);
     }

--- a/GPU/GPUbenchmark/cuda/benchmark.cu
+++ b/GPU/GPUbenchmark/cuda/benchmark.cu
@@ -13,7 +13,7 @@
 ///
 
 #include "../Shared/Kernels.h"
-#define VERSION "version 0.1-pr#6773"
+#define VERSION "version 0.2"
 
 bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
 {
@@ -117,7 +117,7 @@ bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
   for (auto& aChunk : vm["arbitrary"].as<std::vector<std::string>>()) {
     const size_t sep = aChunk.find(':');
     if (sep != std::string::npos) {
-      conf.testChunks.emplace_back(std::stoi(aChunk.substr(0, sep)), std::stoi(aChunk.substr(sep + 1)));
+      conf.testChunks.emplace_back(std::stof(aChunk.substr(0, sep)), std::stof(aChunk.substr(sep + 1)));
     }
   }
 

--- a/GPU/GPUbenchmark/cuda/benchmark.cu
+++ b/GPU/GPUbenchmark/cuda/benchmark.cu
@@ -28,7 +28,7 @@ bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
     "device,d", bpo::value<int>()->default_value(0), "Id of the device to run test on, EPN targeted.")(
     "test,t", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"read", "write", "copy"}, "read write copy"), "Tests to be performed.")(
     "kind,k", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"char", "int", "ulong", "int4"}, "char int ulong int4"), "Test data type to be used.")(
-    "mode,m", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"seq", "con"}, "seq con"), "Mode: sequential or concurrent.")(
+    "mode,m", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"seq", "con", "dis"}, "seq con dis"), "Mode: sequential, concurrent or distributed.")(
     "blockPool,b", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"sb", "mb", "ab"}, "sb mb ab"), "Pool strategy: single, multi or all blocks.")(
     "threadPool,e", bpo::value<float>()->default_value(1.f), "Fraction of blockDim.x to use (aka: rounded fraction of thread pool).")(
     "chunkSize,c", bpo::value<float>()->default_value(1.f), "Size of scratch partitions (GB).")(
@@ -93,7 +93,9 @@ bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
       conf.modes.push_back(Mode::Sequential);
     } else if (mode == "con") {
       conf.modes.push_back(Mode::Concurrent);
-    } else {
+    } else if (mode == "dis") {
+      conf.modes.push_back(Mode::Distributed);
+    }else {
       std::cerr << "Unkonwn mode: " << mode << std::endl;
       exit(1);
     }


### PR DESCRIPTION
@davidrohr to keep track of the status:

- [x] sequential kernels should use that approach to split the access of the blocks among the chunks, concurrent kernels should stay as they are.
- [x] concurrent total throughput measurement should be based on a measurement of the host time.
- [x] benchmark should check that the chunk size does not go out of bounds of the allocated memory and do not intersect each others.
- [x] benchmarks to accept fractionary boundaries and sizes for chunks