### PR TITLE
DPL: introduce CallbacksPolicy

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -17,6 +17,7 @@ o2_add_library(Framework
                        src/AnalysisHelpers.cxx
                        src/AnalysisDataModelHelpers.cxx
                        src/BoostOptionsRetriever.cxx
+                       src/CallbacksPolicy.cxx
                        src/ChannelConfigurationPolicy.cxx
                        src/ChannelMatching.cxx
                        src/ChannelConfigurationPolicyHelpers.cxx
@@ -45,6 +46,7 @@ o2_add_library(Framework
                        src/DataProcessingDevice.cxx
                        src/DataProcessingHeader.cxx
                        src/DataProcessingHelpers.cxx
+                       src/DataProcessorMatchers.cxx
                        src/DataRefUtils.cxx
                        src/SourceInfoHeader.cxx
                        src/DataProcessor.cxx

--- a/Framework/Core/include/Framework/CallbacksPolicy.h
+++ b/Framework/Core/include/Framework/CallbacksPolicy.h
@@ -1,0 +1,31 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_FRAMEWORK_CALLBACKSPOLICY_H_
+#define O2_FRAMEWORK_CALLBACKSPOLICY_H_
+
+#include "Framework/DataProcessorMatchers.h"
+#include <functional>
+#include <vector>
+
+namespace o2::framework
+{
+
+struct CallbackService;
+
+struct CallbacksPolicy {
+  using CallbacksCustomization = std::function<void(CallbackService&)>;
+  DeviceMatcher matcher = nullptr;
+  CallbacksCustomization policy = nullptr;
+  static std::vector<CallbacksPolicy> createDefaultPolicies();
+};
+} // namespace o2::framework
+#endif // O2_FRAMEWORK_CALLBACKSPOLICY_H_

--- a/Framework/Core/include/Framework/DataProcessorMatchers.h
+++ b/Framework/Core/include/Framework/DataProcessorMatchers.h
@@ -1,0 +1,37 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef O2_FRAMEWORK_DATAPROCESSORMATCHER_H_
+#define O2_FRAMEWORK_DATAPROCESSORMATCHER_H_
+#include <functional>
+
+namespace o2::framework
+{
+
+struct DataProcessorSpec;
+struct DeviceSpec;
+
+using DataProcessorMatcher = std::function<bool(DataProcessorSpec const& spec)>;
+using DeviceMatcher = std::function<bool(DeviceSpec const& spec)>;
+
+/// A set of helper to build policies that need to
+/// be applied based on some DataProcessorSpec property
+struct DataProcessorMatchers {
+  /// @return a matcher which will return true if the name
+  /// of the DataProcessorSpec it is passed matches a given name.
+  static DataProcessorMatcher matchByName(const char* name);
+};
+
+struct DeviceMatchers {
+  static DeviceMatcher matchByName(const char* name);
+};
+
+} // namespace o2::framework
+#endif // O2_FRAMEWORK_DATAPROCESSORMATCHER_H_

--- a/Framework/Core/include/Framework/DeviceSpec.h
+++ b/Framework/Core/include/Framework/DeviceSpec.h
@@ -11,6 +11,7 @@
 #ifndef O2_FRAMEWORK_DEVICESPEC_H_
 #define O2_FRAMEWORK_DEVICESPEC_H_
 
+#include "CallbacksPolicy.h"
 #include "Framework/WorkflowSpec.h"
 #include "Framework/ComputingResource.h"
 #include "Framework/DataProcessorSpec.h"
@@ -64,6 +65,7 @@ struct DeviceSpec {
   /// The completion policy to use for this device.
   CompletionPolicy completionPolicy;
   DispatchPolicy dispatchPolicy;
+  CallbacksPolicy callbacksPolicy;
   /// Policy on when the available resources are enough to run
   /// a computation.
   ResourcePolicy resourcePolicy;

--- a/Framework/Core/include/Framework/DriverInfo.h
+++ b/Framework/Core/include/Framework/DriverInfo.h
@@ -21,6 +21,7 @@
 #include "Framework/ChannelConfigurationPolicy.h"
 #include "Framework/ConfigParamSpec.h"
 #include "Framework/ProcessingPolicies.h"
+#include "Framework/CallbacksPolicy.h"
 #include "Framework/CompletionPolicy.h"
 #include "Framework/DispatchPolicy.h"
 #include "Framework/DeviceMetricsInfo.h"
@@ -110,6 +111,8 @@ struct DriverInfo {
   bool batch;
   /// User specified policies for handling errors, completion and early forwarding
   ProcessingPolicies processingPolicies;
+  /// User specified policies for handling callbacks.
+  std::vector<CallbacksPolicy> callbacksPolicies;
   /// The offset at which the process was started.
   uint64_t startTime;
   /// The optional timeout after which the driver will request

--- a/Framework/Core/include/Framework/runDataProcessing.h
+++ b/Framework/Core/include/Framework/runDataProcessing.h
@@ -12,6 +12,7 @@
 #define FRAMEWORK_RUN_DATA_PROCESSING_H
 
 #include "Framework/ChannelConfigurationPolicy.h"
+#include "Framework/CallbacksPolicy.h"
 #include "Framework/CompletionPolicy.h"
 #include "Framework/ConfigurableHelpers.h"
 #include "Framework/DispatchPolicy.h"
@@ -95,6 +96,8 @@ void defaultConfiguration(std::vector<o2::framework::ServiceSpec>& services)
   }
 }
 
+void defaultConfiguration(std::vector<o2::framework::CallbacksPolicy>& callbacksPolicies) {}
+
 /// Workflow options which are required by DPL in order to work.
 std::vector<o2::framework::ConfigParamSpec> requiredWorkflowOptions();
 
@@ -137,6 +140,7 @@ int doMain(int argc, char** argv, o2::framework::WorkflowSpec const& specs,
            std::vector<o2::framework::CompletionPolicy> const& completionPolicies,
            std::vector<o2::framework::DispatchPolicy> const& dispatchPolicies,
            std::vector<o2::framework::ResourcePolicy> const& resourcePolicies,
+           std::vector<o2::framework::CallbacksPolicy> const& callbacksPolicies,
            std::vector<o2::framework::ConfigParamSpec> const& workflowOptions,
            o2::framework::ConfigContext& configContext);
 
@@ -179,6 +183,11 @@ int mainNoCatch(int argc, char** argv)
   auto defaultResourcePolicies = ResourcePolicy::createDefaultPolicies();
   resourcePolicies.insert(std::end(resourcePolicies), std::begin(defaultResourcePolicies), std::end(defaultResourcePolicies));
 
+  std::vector<CallbacksPolicy> callbacksPolicies;
+  UserCustomizationsHelper::userDefinedCustomization(callbacksPolicies, 0);
+  auto defaultCallbacksPolicies = CallbacksPolicy::createDefaultPolicies();
+  defaultCallbacksPolicies.insert(std::end(callbacksPolicies), std::begin(defaultCallbacksPolicies), std::end(defaultCallbacksPolicies));
+
   std::vector<std::unique_ptr<ParamRetriever>> retrievers;
   std::unique_ptr<ParamRetriever> retriever{new BoostOptionsRetriever(true, argc, argv)};
   retrievers.emplace_back(std::move(retriever));
@@ -198,7 +207,9 @@ int mainNoCatch(int argc, char** argv)
   UserCustomizationsHelper::userDefinedCustomization(channelPolicies, 0);
   auto defaultChannelPolicies = ChannelConfigurationPolicy::createDefaultPolicies(configContext);
   channelPolicies.insert(std::end(channelPolicies), std::begin(defaultChannelPolicies), std::end(defaultChannelPolicies));
-  return doMain(argc, argv, specs, channelPolicies, completionPolicies, dispatchPolicies, resourcePolicies, workflowOptions, configContext);
+  return doMain(argc, argv, specs,
+                channelPolicies, completionPolicies, dispatchPolicies,
+                resourcePolicies, callbacksPolicies, workflowOptions, configContext);
 }
 
 int main(int argc, char** argv)

--- a/Framework/Core/src/CallbacksPolicy.cxx
+++ b/Framework/Core/src/CallbacksPolicy.cxx
@@ -1,0 +1,21 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/CallbacksPolicy.h"
+
+namespace o2::framework
+{
+
+std::vector<CallbacksPolicy> CallbacksPolicy::createDefaultPolicies()
+{
+  return {};
+}
+
+} // namespace o2::framework

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -245,7 +245,6 @@ void on_socket_polled(uv_poll_t* poller, int status, int events)
   // We do nothing, all the logic for now stays in DataProcessingDevice::doRun()
 }
 
-
 /// This  takes care  of initialising  the device  from its  specification. In
 /// particular it needs to:
 ///
@@ -289,7 +288,6 @@ void DataProcessingDevice::Init()
 
   mExpirationHandlers.clear();
 
-
   if (mInit) {
     InitContext initContext{*mConfigRegistry, mServiceRegistry};
     mStatefulProcess = mInit(initContext);
@@ -305,6 +303,11 @@ void DataProcessingDevice::Init()
     } else if (name.find(mSpec.channelPrefix + "from_internal-dpl-ccdb-backend") == 0) {
       mState.inputChannelInfos[ci].state = InputChannelState::Pull;
     }
+  }
+
+  // Invoke the callback policy for this device.
+  if (mSpec.callbacksPolicy.policy != nullptr) {
+    mSpec.callbacksPolicy.policy(mServiceRegistry.get<CallbackService>());
   }
 }
 

--- a/Framework/Core/src/DataProcessorMatchers.cxx
+++ b/Framework/Core/src/DataProcessorMatchers.cxx
@@ -1,0 +1,31 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/DataProcessorMatchers.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/DeviceSpec.h"
+
+namespace o2::framework
+{
+DataProcessorMatcher DataProcessorMatchers::matchByName(char const* name_)
+{
+  return [name = std::string(name_)](DataProcessorSpec const& spec) {
+    return spec.name == name;
+  };
+}
+
+DeviceMatcher DeviceMatchers::matchByName(char const* name_)
+{
+  return [name = std::string(name_)](DeviceSpec const& spec) {
+    return spec.name == name;
+  };
+}
+} // namespace o2::framework

--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -822,6 +822,7 @@ void DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(const WorkflowSpec& workf
                                                        std::vector<CompletionPolicy> const& completionPolicies,
                                                        std::vector<DispatchPolicy> const& dispatchPolicies,
                                                        std::vector<ResourcePolicy> const& resourcePolicies,
+                                                       std::vector<CallbacksPolicy> const& callbacksPolicies,
                                                        std::vector<DeviceSpec>& devices,
                                                        ResourceManager& resourceManager,
                                                        std::string const& uniqueWorkflowId,
@@ -897,6 +898,12 @@ void DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(const WorkflowSpec& workf
     for (auto& policy : dispatchPolicies) {
       if (policy.deviceMatcher(device) == true) {
         device.dispatchPolicy = policy;
+        break;
+      }
+    }
+    for (auto& policy : callbacksPolicies) {
+      if (policy.matcher(device) == true) {
+        device.callbacksPolicy = policy;
         break;
       }
     }

--- a/Framework/Core/src/DeviceSpecHelpers.h
+++ b/Framework/Core/src/DeviceSpecHelpers.h
@@ -50,6 +50,7 @@ struct DeviceSpecHelpers {
     std::vector<CompletionPolicy> const& completionPolicies,
     std::vector<DispatchPolicy> const& dispatchPolicies,
     std::vector<ResourcePolicy> const& resourcePolicies,
+    std::vector<CallbacksPolicy> const& callbacksPolicies,
     std::vector<DeviceSpec>& devices,
     ResourceManager& resourceManager,
     std::string const& uniqueWorkflowId,
@@ -61,6 +62,7 @@ struct DeviceSpecHelpers {
     const WorkflowSpec& workflow,
     std::vector<ChannelConfigurationPolicy> const& channelPolicies,
     std::vector<CompletionPolicy> const& completionPolicies,
+    std::vector<CallbacksPolicy> const& callbacksPolicies,
     std::vector<DeviceSpec>& devices,
     ResourceManager& resourceManager,
     std::string const& uniqueWorkflowId,
@@ -71,7 +73,7 @@ struct DeviceSpecHelpers {
     std::vector<DispatchPolicy> dispatchPolicies = DispatchPolicy::createDefaultPolicies();
     std::vector<ResourcePolicy> resourcePolicies = ResourcePolicy::createDefaultPolicies();
     dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies,
-                                   dispatchPolicies, resourcePolicies, devices,
+                                   dispatchPolicies, resourcePolicies, callbacksPolicies, devices,
                                    resourceManager, uniqueWorkflowId, optimizeTopology,
                                    resourcesMonitoringInterval, channelPrefix);
   }

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -10,6 +10,7 @@
 // or submit itself to any jurisdiction.
 #include <stdexcept>
 #include "Framework/BoostOptionsRetriever.h"
+#include "Framework/CallbacksPolicy.h"
 #include "Framework/ChannelConfigurationPolicy.h"
 #include "Framework/ChannelMatching.h"
 #include "Framework/ConfigParamsHelper.h"
@@ -1491,6 +1492,7 @@ int runStateMachine(DataProcessorSpecs const& workflow,
                                                             driverInfo.completionPolicies,
                                                             driverInfo.dispatchPolicies,
                                                             driverInfo.resourcePolicies,
+                                                            driverInfo.callbacksPolicies,
                                                             runningWorkflow.devices,
                                                             *resourceManager,
                                                             driverInfo.uniqueWorkflowId,
@@ -2252,6 +2254,7 @@ int doMain(int argc, char** argv, o2::framework::WorkflowSpec const& workflow,
            std::vector<CompletionPolicy> const& completionPolicies,
            std::vector<DispatchPolicy> const& dispatchPolicies,
            std::vector<ResourcePolicy> const& resourcePolicies,
+           std::vector<CallbacksPolicy> const& callbacksPolicies,
            std::vector<ConfigParamSpec> const& currentWorkflowOptions,
            o2::framework::ConfigContext& configContext)
 {
@@ -2527,6 +2530,7 @@ int doMain(int argc, char** argv, o2::framework::WorkflowSpec const& workflow,
   driverInfo.completionPolicies = completionPolicies;
   driverInfo.dispatchPolicies = dispatchPolicies;
   driverInfo.resourcePolicies = resourcePolicies;
+  driverInfo.callbacksPolicies = callbacksPolicies;
   driverInfo.argc = argc;
   driverInfo.argv = argv;
   driverInfo.batch = varmap["no-batch"].defaulted() ? varmap["batch"].as<bool>() : false;

--- a/Framework/Core/test/test_DeviceSpec.cxx
+++ b/Framework/Core/test/test_DeviceSpec.cxx
@@ -45,6 +45,7 @@ BOOST_AUTO_TEST_CASE(TestDeviceSpec1)
   auto configContext = makeEmptyConfigContext();
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies(*configContext);
   auto completionPolicies = CompletionPolicy::createDefaultPolicies();
+  auto callbacksPolicies = CallbacksPolicy::createDefaultPolicies();
   BOOST_REQUIRE_EQUAL(channelPolicies.empty(), false);
   BOOST_REQUIRE_EQUAL(completionPolicies.empty(), false);
   std::vector<DeviceSpec> devices;
@@ -58,7 +59,7 @@ BOOST_AUTO_TEST_CASE(TestDeviceSpec1)
   BOOST_CHECK_EQUAL(offers[0].startPort, 22000);
   BOOST_CHECK_EQUAL(offers[0].rangeSize, 1000);
 
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, rm, "workflow-id");
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, callbacksPolicies, devices, rm, "workflow-id");
   BOOST_REQUIRE_EQUAL(devices.size(), 2);
   BOOST_CHECK_EQUAL(devices[0].outputChannels.size(), 1);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, ChannelMethod::Bind);
@@ -89,12 +90,13 @@ BOOST_AUTO_TEST_CASE(TestDeviceSpec1PushPull)
   std::vector<ChannelConfigurationPolicy> channelPolicies = {pushPullPolicy};
   auto configContext = makeEmptyConfigContext();
   auto completionPolicies = CompletionPolicy::createDefaultPolicies();
+  auto callbacksPolicies = CallbacksPolicy::createDefaultPolicies();
 
   BOOST_REQUIRE_EQUAL(channelPolicies.empty(), false);
   std::vector<DeviceSpec> devices;
   std::vector<ComputingResource> resources{ComputingResourceHelpers::getLocalhostResource()};
   SimpleResourceManager rm(resources);
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, rm, "workflow-id");
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, callbacksPolicies, devices, rm, "workflow-id");
   BOOST_CHECK_EQUAL(devices.size(), 2);
   BOOST_CHECK_EQUAL(devices[0].outputChannels.size(), 1);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, ChannelMethod::Bind);
@@ -135,11 +137,12 @@ BOOST_AUTO_TEST_CASE(TestDeviceSpec2)
   auto configContext = makeEmptyConfigContext();
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies(*configContext);
   auto completionPolicies = CompletionPolicy::createDefaultPolicies();
+  auto callbacksPolicies = CallbacksPolicy::createDefaultPolicies();
   std::vector<DeviceSpec> devices;
 
   std::vector<ComputingResource> resources{ComputingResourceHelpers::getLocalhostResource()};
   SimpleResourceManager rm(resources);
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, rm, "workflow-id");
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, callbacksPolicies, devices, rm, "workflow-id");
   BOOST_CHECK_EQUAL(devices.size(), 2);
   BOOST_CHECK_EQUAL(devices[0].outputChannels.size(), 1);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, ChannelMethod::Bind);
@@ -178,11 +181,12 @@ BOOST_AUTO_TEST_CASE(TestDeviceSpec3)
   auto configContext = makeEmptyConfigContext();
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies(*configContext);
   auto completionPolicies = CompletionPolicy::createDefaultPolicies();
+  auto callbacksPolicies = CallbacksPolicy::createDefaultPolicies();
   std::vector<DeviceSpec> devices;
 
   std::vector<ComputingResource> resources{ComputingResourceHelpers::getLocalhostResource()};
   SimpleResourceManager rm(resources);
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, rm, "workflow-id");
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, callbacksPolicies, devices, rm, "workflow-id");
   BOOST_CHECK_EQUAL(devices.size(), 3);
   BOOST_CHECK_EQUAL(devices[0].outputChannels.size(), 2);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, ChannelMethod::Bind);
@@ -227,11 +231,12 @@ BOOST_AUTO_TEST_CASE(TestDeviceSpec4)
   auto configContext = makeEmptyConfigContext();
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies(*configContext);
   auto completionPolicies = CompletionPolicy::createDefaultPolicies();
+  auto callbacksPolicies = CallbacksPolicy::createDefaultPolicies();
   std::vector<DeviceSpec> devices;
   std::vector<ComputingResource> resources{ComputingResourceHelpers::getLocalhostResource()};
   SimpleResourceManager rm(resources);
 
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, rm, "workflow-id");
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, callbacksPolicies, devices, rm, "workflow-id");
   BOOST_CHECK_EQUAL(devices.size(), 4);
   BOOST_CHECK_EQUAL(devices[0].outputChannels.size(), 2);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, ChannelMethod::Bind);
@@ -297,11 +302,12 @@ BOOST_AUTO_TEST_CASE(TestTopologyForwarding)
   auto configContext = makeEmptyConfigContext();
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies(*configContext);
   auto completionPolicies = CompletionPolicy::createDefaultPolicies();
+  auto callbacksPolicies = CallbacksPolicy::createDefaultPolicies();
   std::vector<DeviceSpec> devices;
 
   std::vector<ComputingResource> resources{ComputingResourceHelpers::getLocalhostResource()};
   SimpleResourceManager rm(resources);
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, rm, "workflow-id");
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, callbacksPolicies, devices, rm, "workflow-id");
   BOOST_CHECK_EQUAL(devices.size(), 3);
   BOOST_CHECK_EQUAL(devices[0].outputChannels.size(), 1);
   BOOST_CHECK_EQUAL(devices[0].outputChannels[0].method, ChannelMethod::Bind);
@@ -578,9 +584,10 @@ BOOST_AUTO_TEST_CASE(TestTopologyLayeredTimePipeline)
   auto configContext = makeEmptyConfigContext();
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies(*configContext);
   auto completionPolicies = CompletionPolicy::createDefaultPolicies();
+  auto callbacksPolicies = CallbacksPolicy::createDefaultPolicies();
   std::vector<ComputingResource> resources{ComputingResourceHelpers::getLocalhostResource()};
   SimpleResourceManager rm(resources);
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, rm, "workflow-id");
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, callbacksPolicies, devices, rm, "workflow-id");
   BOOST_CHECK_EQUAL(devices.size(), 6);
   BOOST_CHECK_EQUAL(devices[0].id, "A");
   BOOST_CHECK_EQUAL(devices[1].id, "B_t0");

--- a/Framework/Core/test/test_DeviceSpecHelpers.cxx
+++ b/Framework/Core/test/test_DeviceSpecHelpers.cxx
@@ -134,9 +134,12 @@ BOOST_AUTO_TEST_CASE(test_prepareArguments)
 
   auto configContext = makeEmptyConfigContext();
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies(*configContext);
+  auto callbacksPolicies = CallbacksPolicy::createDefaultPolicies();
+
   DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow,
                                                     channelPolicies,
                                                     CompletionPolicy::createDefaultPolicies(),
+                                                    callbacksPolicies,
                                                     deviceSpecs,
                                                     *rm, "workflow-id");
 

--- a/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
+++ b/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
@@ -91,7 +91,8 @@ BOOST_AUTO_TEST_CASE(TestDDS)
   std::vector<ComputingResource> resources{ComputingResourceHelpers::getLocalhostResource()};
   SimpleResourceManager rm(resources);
   auto completionPolicies = CompletionPolicy::createDefaultPolicies();
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, rm, "workflow-id", true);
+  auto callbacksPolicies = CallbacksPolicy::createDefaultPolicies();
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, callbacksPolicies, devices, rm, "workflow-id", true);
   std::vector<DeviceControl> controls;
   std::vector<DeviceExecution> executions;
   controls.resize(devices.size());

--- a/Framework/Core/test/test_FrameworkDataFlowToO2Control.cxx
+++ b/Framework/Core/test/test_FrameworkDataFlowToO2Control.cxx
@@ -418,7 +418,8 @@ BOOST_AUTO_TEST_CASE(TestO2ControlDump)
   std::vector<ComputingResource> resources{ComputingResourceHelpers::getLocalhostResource()};
   SimpleResourceManager rm(resources);
   auto completionPolicies = CompletionPolicy::createDefaultPolicies();
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, rm, "workflow-id", true);
+  auto callbacksPolicies = CallbacksPolicy::createDefaultPolicies();
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, callbacksPolicies, devices, rm, "workflow-id", true);
   std::vector<DeviceControl> controls;
   std::vector<DeviceExecution> executions;
   controls.resize(devices.size());

--- a/Framework/Core/test/test_Graphviz.cxx
+++ b/Framework/Core/test/test_Graphviz.cxx
@@ -100,9 +100,10 @@ BOOST_AUTO_TEST_CASE(TestGraphviz)
   auto configContext = makeEmptyConfigContext();
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies(*configContext);
   auto completionPolicies = CompletionPolicy::createDefaultPolicies();
+  auto callbacksPolicies = CallbacksPolicy::createDefaultPolicies();
   std::vector<ComputingResource> resources = {ComputingResourceHelpers::getLocalhostResource()};
   SimpleResourceManager rm(resources);
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, rm, "workflow-id");
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, callbacksPolicies, devices, rm, "workflow-id");
   str.str("");
   GraphvizHelpers::dumpDeviceSpec2Graphviz(str, devices);
   lineByLineComparision(str.str(), R"EXPECTED(digraph structs {
@@ -139,9 +140,10 @@ BOOST_AUTO_TEST_CASE(TestGraphvizWithPipeline)
   auto configContext = makeEmptyConfigContext();
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies(*configContext);
   auto completionPolicies = CompletionPolicy::createDefaultPolicies();
+  auto callbacksPolicies = CallbacksPolicy::createDefaultPolicies();
   std::vector<ComputingResource> resources = {ComputingResourceHelpers::getLocalhostResource()};
   SimpleResourceManager rm(resources);
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, rm, "workflow-id");
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, callbacksPolicies, devices, rm, "workflow-id");
   str.str("");
   GraphvizHelpers::dumpDeviceSpec2Graphviz(str, devices);
   lineByLineComparision(str.str(), R"EXPECTED(digraph structs {

--- a/Framework/Core/test/test_TimeParallelPipelining.cxx
+++ b/Framework/Core/test/test_TimeParallelPipelining.cxx
@@ -57,9 +57,10 @@ BOOST_AUTO_TEST_CASE(TimePipeliningSimple)
   auto configContext = makeEmptyConfigContext();
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies(*configContext);
   auto completionPolicies = CompletionPolicy::createDefaultPolicies();
+  auto callbacksPolicies = CallbacksPolicy::createDefaultPolicies();
   std::vector<ComputingResource> resources = {ComputingResourceHelpers::getLocalhostResource()};
   SimpleResourceManager rm(resources);
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, rm, "workflow-id");
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, callbacksPolicies, devices, rm, "workflow-id");
   BOOST_REQUIRE_EQUAL(devices.size(), 4);
   auto& producer = devices[0];
   auto& layer0Consumer0 = devices[1];
@@ -110,9 +111,10 @@ BOOST_AUTO_TEST_CASE(TimePipeliningFull)
   auto configContext = makeEmptyConfigContext();
   auto channelPolicies = ChannelConfigurationPolicy::createDefaultPolicies(*configContext);
   auto completionPolicies = CompletionPolicy::createDefaultPolicies();
+  auto callbacksPolicies = CallbacksPolicy::createDefaultPolicies();
   std::vector<ComputingResource> resources = {ComputingResourceHelpers::getLocalhostResource()};
   SimpleResourceManager rm(resources);
-  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, devices, rm, "workflow-id");
+  DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies, callbacksPolicies, devices, rm, "workflow-id");
   BOOST_REQUIRE_EQUAL(devices.size(), 7);
   auto& producer = devices[0];
   auto& layer0Consumer0 = devices[1];

--- a/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
@@ -16,6 +16,7 @@
 #include "Framework/ControlService.h"
 #include "Framework/Configurable.h"
 #include "Framework/RunningWorkflowInfo.h"
+#include "Framework/CallbackService.h"
 #include <FairMQDevice.h>
 #include <InfoLogger/InfoLogger.hxx>
 
@@ -33,6 +34,15 @@ struct WorkflowOptions {
   Configurable<std::string> aString{"aString", "foobar", {"a string option"}};
   Configurable<bool> aBool{"aBool", true, {"a boolean option"}};
 };
+
+void customize(std::vector<CallbacksPolicy>& policies)
+{
+  policies.push_back(CallbacksPolicy{
+    .matcher = DeviceMatchers::matchByName("A"),
+    .policy = [](CallbackService& service) {
+      service.set(CallbackService::Id::Start, []() { LOG(INFO) << "invoked at start"; });
+    }});
+}
 
 #include "Framework/runDataProcessing.h"
 


### PR DESCRIPTION
Useful to customise which callbacks are set up by default depending on the device type.