### PR TITLE
AODProducer fixes: runNumber and ITSAB tracklets

### DIFF
--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -299,12 +299,10 @@ void AODProducerWorkflowDPL::fillTrackTablesPerCollision(int collisionID,
         } else {
           auto contributorsGID = data.getSingleDetectorRefs(trackIndex);
           const auto& trackPar = data.getTrackParam(trackIndex);
-          if (contributorsGID[GIndex::Source::ITS].isIndexSet() || contributorsGID[GIndex::Source::ITSAB].isIndexSet()) {
+          if (contributorsGID[GIndex::Source::ITS].isIndexSet()) {
             int nClusters = itsTracks[contributorsGID[GIndex::ITS].getIndex()].getNClusters();
             float chi2 = itsTracks[contributorsGID[GIndex::ITS].getIndex()].getChi2();
             extraInfoHolder.itsChi2NCl = nClusters != 0 ? chi2 / (float)nClusters : 0;
-          }
-          if (contributorsGID[GIndex::Source::ITS].isIndexSet()) {
             extraInfoHolder.itsClusterMap = itsTracks[contributorsGID[GIndex::ITS].getIndex()].getPattern();
           } else if (contributorsGID[GIndex::Source::ITSAB].isIndexSet()) { // this is an ITS-TPC afterburner contributor
             extraInfoHolder.itsClusterMap = itsABRefs[contributorsGID[GIndex::Source::ITSAB].getIndex()].pattern;

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -990,10 +990,9 @@ void AODProducerWorkflowDPL::run(ProcessingContext& pc)
   o2::InteractionRecord startIR = {0, dh->firstTForbit};
 
   uint64_t tfNumber;
-  // default dummy run number
-  int runNumber = 244918; // TODO: get real run number
+  int runNumber = int(dh->runNumber);
   if (mTFNumber == -1L) {
-    tfNumber = getTFNumber(startIR, runNumber);
+    tfNumber = dh->tfCounter; //getTFNumber(startIR, runNumber);
   } else {
     tfNumber = mTFNumber;
   }

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -992,6 +992,7 @@ void AODProducerWorkflowDPL::run(ProcessingContext& pc)
   uint64_t tfNumber;
   int runNumber = int(dh->runNumber);
   if (mTFNumber == -1L) {
+    // TODO has to be made globally unique (by using absolute time of TF). For now is unique within the run
     tfNumber = dh->tfCounter; //getTFNumber(startIR, runNumber);
   } else {
     tfNumber = mTFNumber;


### PR DESCRIPTION
@jgrosseo @nburmaso I've added fetching the runNumber from the DPL, as for the TF number: I assume you refer on the timestamp in `ms` calculated in https://github.com/shahor02/AliceO2/blob/e74a284012f34235db3b12e9242917612f4f5405/Detectors/AOD/src/AODProducerWorkflowSpec.cxx#L132 ?

The way it is done now will hardly work, it is very difficult to have `ms`-precise start of run, moreover, to record its orbit.

The exact time-stamp should be extracted from the http://ccdb-test.cern.ch:8080/browse/CTP/Calib/OrbitReset?report=true and DataHeader::firstTForbit, but this should be done using DPL methods to find the rough time (to query this CTP object). 
Is the timestamp necessary now?
