### PR TITLE
DPL: adjusting DataRelayer interface

### DIFF
--- a/Framework/Core/include/Framework/DataRelayer.h
+++ b/Framework/Core/include/Framework/DataRelayer.h
@@ -88,20 +88,18 @@ class DataRelayer
 
   /// This is to relay a whole set of FairMQMessages, all which are part
   /// of the same set of split parts.
-  /// @a firstHeader is the first message of such set
-  /// @a restOfParts is a pointer to the rest of the messages
-  /// @a restSize is how many messages are there in restOfParts
-  /// is the header which is common across all subsequent elements.
+  /// @a rawHeader raw header pointer
+  /// @a messages pointer to array of messages
+  /// @a nMessages size of the array
+  /// @a nPayloads number of payploads in the message sequence, default is 1
+  ///              which is the standard header-payload message pair, in this
+  ///              case nMessages / 2 pairs will be inserted and considered
+  ///              separate parts
   /// Notice that we expect that the header is an O2 Header Stack
-  RelayChoice relay(std::unique_ptr<FairMQMessage>& firstHeader,
-                    std::unique_ptr<FairMQMessage>* restOfParts,
-                    size_t restSize);
-
-  /// This is used to ask for relaying a given (header,payload) pair.
-  /// Notice that we expect that the header is an O2 Header Stack
-  /// with a DataProcessingHeader inside so that we can assess time.
-  RelayChoice relay(std::unique_ptr<FairMQMessage>& header,
-                    std::unique_ptr<FairMQMessage>& payload);
+  RelayChoice relay(void const* rawHeader,
+                    std::unique_ptr<FairMQMessage>* messages,
+                    size_t nMessages,
+                    size_t nPayloads = 1);
 
   /// @returns the actions ready to be performed.
   void getReadyToProcess(std::vector<RecordAction>& completed);

--- a/Framework/Core/src/DataRelayer.cxx
+++ b/Framework/Core/src/DataRelayer.cxx
@@ -126,10 +126,10 @@ DataRelayer::ActivityStats DataRelayer::processDanglingInputs(std::vector<Expira
       // We check that no data is already there for the given cell
       // it is enough to check the first element
       auto& part = mCache[ti * mDistinctRoutesIndex.size() + expirator.routeIndex.value];
-      if (part.size() > 0 && part[0].header != nullptr) {
+      if (part.size() > 0 && part.header(0) != nullptr) {
         continue;
       }
-      if (part.size() > 0 && part[0].payload != nullptr) {
+      if (part.size() > 0 && part.payload(0) != nullptr) {
         continue;
       }
       // We check that the cell can actually be expired.
@@ -145,16 +145,14 @@ DataRelayer::ActivityStats DataRelayer::processDanglingInputs(std::vector<Expira
 
       assert(ti * mDistinctRoutesIndex.size() + expirator.routeIndex.value < mCache.size());
       assert(expirator.handler);
-      // expired, so we create one entry
-      if (part.size() == 0) {
-        part.parts.resize(1);
-      }
-      expirator.handler(services, part[0], variables);
+      PartRef newRef;
+      expirator.handler(services, newRef, variables);
+      part.reset(std::move(newRef));
       activity.expiredSlots++;
 
       mTimesliceIndex.markAsDirty(slot, true);
-      assert(part[0].header != nullptr);
-      assert(part[0].payload != nullptr);
+      assert(part.header(0) != nullptr);
+      assert(part.payload(0) != nullptr);
     }
   }
   return activity;
@@ -163,7 +161,7 @@ DataRelayer::ActivityStats DataRelayer::processDanglingInputs(std::vector<Expira
 /// This does the mapping between a route and a InputSpec. The
 /// reason why these might diffent is that when you have timepipelining
 /// you have one route per timeslice, even if the type is the same.
-size_t matchToContext(void* data,
+size_t matchToContext(void const* data,
                       std::vector<DataDescriptorMatcher> const& matchers,
                       std::vector<size_t> const& index,
                       VariableContext& context)
@@ -203,19 +201,13 @@ void sendVariableContextMetrics(VariableContext& context, TimesliceSlot slot,
 }
 
 DataRelayer::RelayChoice
-  DataRelayer::relay(std::unique_ptr<FairMQMessage>& header,
-                     std::unique_ptr<FairMQMessage>& payload)
-{
-  return relay(header, &payload, 1);
-}
-
-DataRelayer::RelayChoice
-  DataRelayer::relay(std::unique_ptr<FairMQMessage>& firstPart,
-                     std::unique_ptr<FairMQMessage>* restOfParts,
-                     size_t restOfPartsSize)
+  DataRelayer::relay(void const* rawHeader,
+                     std::unique_ptr<FairMQMessage>* messages,
+                     size_t nMessages,
+                     size_t nPayloads)
 {
   std::scoped_lock<LockableBase(std::recursive_mutex)> lock(mMutex);
-  DataProcessingHeader const* dph = o2::header::get<DataProcessingHeader*>(firstPart->GetData());
+  DataProcessingHeader const* dph = o2::header::get<DataProcessingHeader*>(rawHeader);
   // STATE HOLDING VARIABLES
   // This is the class level state of the relaying. If we start supporting
   // multithreading this will have to be made thread safe before we can invoke
@@ -238,12 +230,12 @@ DataRelayer::RelayChoice
   // become more complicated when we will start supporting ranges.
   auto getInputTimeslice = [&matchers = mInputMatchers,
                             &distinctRoutes = mDistinctRoutesIndex,
-                            &firstPart,
+                            &rawHeader,
                             &index](VariableContext& context)
     -> std::tuple<int, TimesliceId> {
     /// FIXME: for the moment we only use the first context and reset
     /// between one invokation and the other.
-    auto input = matchToContext(firstPart->GetData(), matchers, distinctRoutes, context);
+    auto input = matchToContext(rawHeader, matchers, distinctRoutes, context);
 
     if (input == INVALID_INPUT) {
       return {
@@ -285,24 +277,24 @@ DataRelayer::RelayChoice
   };
 
   // Actually save the header / payload in the slot
-  auto saveInSlot = [&firstPart,
-                     &cachedStateMetrics = mCachedStateMetrics,
-                     &restOfParts,
-                     &restOfPartsSize,
+  auto saveInSlot = [&cachedStateMetrics = mCachedStateMetrics,
+                     &messages,
+                     &nMessages,
+                     &nPayloads,
                      &cache,
                      &numInputTypes,
                      &metrics](TimesliceId timeslice, int input, TimesliceSlot slot) {
     auto cacheIdx = numInputTypes * slot.index + input;
-    std::vector<PartRef>& parts = cache[cacheIdx].parts;
+    MessageSet& target = cache[cacheIdx];
     cachedStateMetrics[cacheIdx] = CacheEntryStatus::PENDING;
     // TODO: make sure that multiple parts can only be added within the same call of
     // DataRelayer::relay
-    PartRef entry{std::move(firstPart), std::move(restOfParts[0])};
-    parts.emplace_back(std::move(entry));
-    auto rest = restOfParts + 1;
-    for (size_t pi = 0; pi < (restOfPartsSize - 1) / 2; ++pi) {
-      PartRef entry{std::move(rest[pi * 2]), std::move(rest[pi * 2 + 1])};
-      parts.emplace_back(std::move(entry));
+    assert(nPayloads == 1);
+    assert(nMessages % 2 == 0);
+    for (size_t mi = 0; mi < nMessages; ++mi) {
+      assert(mi + nPayloads < nMessages);
+      target.add([&messages, &mi](size_t i) -> FairMQMessagePtr& { return messages[mi + i]; }, nPayloads + 1);
+      mi += nPayloads;
     }
   };
 
@@ -390,9 +382,10 @@ DataRelayer::RelayChoice
   VariableContext pristineContext;
   std::tie(input, timeslice) = getInputTimeslice(pristineContext);
 
-  auto DataHeaderInfo = [&firstPart]() {
+  auto DataHeaderInfo = [&rawHeader]() {
     std::string error;
-    const auto* dh = o2::header::get<o2::header::DataHeader*>(firstPart->GetData());
+    // extract header from message model
+    const auto* dh = o2::header::get<o2::header::DataHeader*>(rawHeader);
     if (dh) {
       error += fmt::format("{}/{}/{}", dh->dataOrigin, dh->dataDescription, dh->subSpecification);
     } else {
@@ -405,10 +398,8 @@ DataRelayer::RelayChoice
     LOG(ERROR) << "Could not match incoming data to any input route: " << DataHeaderInfo();
     mStats.malformedInputs++;
     mStats.droppedIncomingMessages++;
-    firstPart.reset(nullptr);
-    for (size_t pi = 0; pi < restOfPartsSize; ++pi) {
-      auto& payload = restOfParts[pi];
-      payload.reset(nullptr);
+    for (size_t pi = 0; pi < nMessages; ++pi) {
+      messages[pi].reset(nullptr);
     }
     return Invalid;
   }
@@ -417,10 +408,8 @@ DataRelayer::RelayChoice
     LOG(ERROR) << "Could not determine the timeslice for input: " << DataHeaderInfo();
     mStats.malformedInputs++;
     mStats.droppedIncomingMessages++;
-    firstPart.reset(nullptr);
-    for (size_t pi = 0; pi < restOfPartsSize; ++pi) {
-      auto& payload = restOfParts[pi];
-      payload.reset(nullptr);
+    for (size_t pi = 0; pi < nMessages; ++pi) {
+      messages[pi].reset(nullptr);
     }
     return Invalid;
   }
@@ -447,10 +436,8 @@ DataRelayer::RelayChoice
       LOG(WARNING) << "Incoming data is invalid, not relaying.";
       mStats.malformedInputs++;
       mStats.droppedIncomingMessages++;
-      firstPart.reset(nullptr);
-      for (size_t pi = 0; pi < restOfPartsSize; ++pi) {
-        auto& payload = restOfParts[pi];
-        payload.reset(nullptr);
+      for (size_t pi = 0; pi < nMessages; ++pi) {
+        messages[pi].reset(nullptr);
       }
       return Invalid;
     case TimesliceIndex::ActionTaken::ReplaceUnused:
@@ -518,11 +505,12 @@ void DataRelayer::getReadyToProcess(std::vector<DataRelayer::RecordAction>& comp
       continue;
     }
     auto partial = getPartialRecord(li);
+    // TODO: get the data ref from message model
     auto getter = [&partial](size_t idx, size_t part) {
-      if (partial[idx].size() > 0 && partial[idx].at(part).header && partial[idx].at(part).payload) {
+      if (partial[idx].size() > 0 && partial[idx].header(part) && partial[idx].payload(part)) {
         return DataRef{nullptr,
-                       reinterpret_cast<const char*>(partial[idx].at(part).header->GetData()),
-                       reinterpret_cast<const char*>(partial[idx].at(part).payload->GetData())};
+                       reinterpret_cast<const char*>(partial[idx].header(part)->GetData()),
+                       reinterpret_cast<const char*>(partial[idx].payload(part)->GetData())};
       }
       return DataRef{};
     };
@@ -657,6 +645,9 @@ void DataRelayer::publishMetrics()
   std::scoped_lock<LockableBase(std::recursive_mutex)> lock(mMutex);
 
   auto numInputTypes = mDistinctRoutesIndex.size();
+  // FIXME: many of the DataRelayer function rely on allocated cache, so its
+  // maybe misleading to have the allocation in a function primarily for
+  // metrics publishing, do better in setPipelineLength?
   mCache.resize(numInputTypes * mTimesliceIndex.size());
   mMetrics.send({(int)numInputTypes, "data_relayer/h", Verbosity::Debug});
   mMetrics.send({(int)mTimesliceIndex.size(), "data_relayer/w", Verbosity::Debug});

--- a/Framework/Core/test/benchmark_DataRelayer.cxx
+++ b/Framework/Core/test/benchmark_DataRelayer.cxx
@@ -19,6 +19,8 @@
 #include <Monitoring/Monitoring.h>
 #include <fairmq/FairMQTransportFactory.h>
 #include <cstring>
+#include <array>
+#include <vector>
 
 using Monitoring = o2::monitoring::Monitoring;
 using namespace o2::framework;
@@ -98,12 +100,15 @@ static void BM_RelaySingleSlot(benchmark::State& state)
   for (auto _ : state) {
     // FIXME: Understand why pausing the timer makes it slower..
     //state.PauseTiming();
-    FairMQMessagePtr header = transport->CreateMessage(stack.size());
-    FairMQMessagePtr payload = transport->CreateMessage(1000);
+    std::array<FairMQMessagePtr, 2> messages;
+    messages[0] = transport->CreateMessage(stack.size());
+    messages[1] = transport->CreateMessage(1000);
+    FairMQMessagePtr& header = messages[0];
+    FairMQMessagePtr& payload = messages[1];
     memcpy(header->GetData(), stack.data(), stack.size());
     //state.ResumeTiming();
 
-    relayer.relay(header, payload);
+    relayer.relay(header->GetData(), messages.data(), messages.size());
     std::vector<RecordAction> ready;
     relayer.getReadyToProcess(ready);
     assert(ready.size() == 1);
@@ -150,13 +155,16 @@ static void BM_RelayMultipleSlots(benchmark::State& state)
 
     DataProcessingHeader dph{timeslice++, 1};
     Stack stack{dh, dph};
-    FairMQMessagePtr header = transport->CreateMessage(stack.size());
-    FairMQMessagePtr payload = transport->CreateMessage(1000);
+    std::array<FairMQMessagePtr, 2> messages;
+    messages[0] = transport->CreateMessage(stack.size());
+    messages[1] = transport->CreateMessage(1000);
+    FairMQMessagePtr& header = messages[0];
+    FairMQMessagePtr& payload = messages[1];
 
     memcpy(header->GetData(), stack.data(), stack.size());
     //state.ResumeTiming();
 
-    relayer.relay(header, payload);
+    relayer.relay(header->GetData(), messages.data(), messages.size());
     std::vector<RecordAction> ready;
     relayer.getReadyToProcess(ready);
     assert(ready.size() == 1);
@@ -210,27 +218,32 @@ static void BM_RelayMultipleRoutes(benchmark::State& state)
     DataProcessingHeader dph1{timeslice, 1};
     Stack stack1{dh1, dph1};
 
-    FairMQMessagePtr header1 = transport->CreateMessage(stack1.size());
-    FairMQMessagePtr payload1 = transport->CreateMessage(1000);
+    std::array<FairMQMessagePtr, 4> messages;
+    messages[0] = transport->CreateMessage(stack1.size());
+    messages[1] = transport->CreateMessage(1000);
+    FairMQMessagePtr& header1 = messages[0];
+    FairMQMessagePtr& payload1 = messages[1];
 
     memcpy(header1->GetData(), stack1.data(), stack1.size());
 
     DataProcessingHeader dph2{timeslice, 1};
     Stack stack2{dh2, dph2};
 
-    FairMQMessagePtr header2 = transport->CreateMessage(stack2.size());
-    FairMQMessagePtr payload2 = transport->CreateMessage(1000);
+    messages[2] = transport->CreateMessage(stack2.size());
+    messages[3] = transport->CreateMessage(1000);
+    FairMQMessagePtr& header2 = messages[2];
+    FairMQMessagePtr& payload2 = messages[3];
 
     memcpy(header2->GetData(), stack2.data(), stack2.size());
     //state.ResumeTiming();
 
-    relayer.relay(header1, payload1);
+    relayer.relay(header1->GetData(), &messages[0], 2);
     std::vector<RecordAction> ready;
     relayer.getReadyToProcess(ready);
     assert(ready.size() == 1);
     assert(ready[0].op == CompletionPolicy::CompletionOp::Consume);
 
-    relayer.relay(header2, payload2);
+    relayer.relay(header2->GetData(), &messages[2], 2);
     ready.clear();
     relayer.getReadyToProcess(ready);
     assert(ready.size() == 1);
@@ -275,12 +288,14 @@ static void BM_RelaySplitParts(benchmark::State& state)
   for (auto _ : state) {
     // FIXME: Understand why pausing the timer makes it slower..
     state.PauseTiming();
+    const int nSplitParts = 10;
     std::vector<std::unique_ptr<FairMQMessage>> splitParts;
+    splitParts.reserve(nSplitParts);
 
-    for (size_t i = 0; i < 100; ++i) {
+    for (size_t i = 0; i < nSplitParts; ++i) {
       DataProcessingHeader dph1{timeslice, 1};
       dh1.splitPayloadIndex = i;
-      dh1.splitPayloadParts = 10;
+      dh1.splitPayloadParts = nSplitParts;
       Stack stack1{dh1, dph1};
 
       FairMQMessagePtr header1 = transport->CreateMessage(stack1.size());
@@ -292,7 +307,7 @@ static void BM_RelaySplitParts(benchmark::State& state)
     }
     state.ResumeTiming();
 
-    relayer.relay(splitParts[0], &splitParts[1], splitParts.size() - 1);
+    relayer.relay(splitParts[0]->GetData(), splitParts.data(), splitParts.size());
     std::vector<RecordAction> ready;
     relayer.getReadyToProcess(ready);
     assert(ready.size() == 1);

--- a/Framework/Core/test/test_DataRelayer.cxx
+++ b/Framework/Core/test/test_DataRelayer.cxx
@@ -16,6 +16,7 @@
 #include <boost/test/unit_test.hpp>
 #include "Headers/DataHeader.h"
 #include "Headers/Stack.h"
+#include "MemoryResources/MemoryResources.h"
 #include "Framework/CompletionPolicyHelpers.h"
 #include "Framework/DataRelayer.h"
 #include "../src/DataRelayerHelpers.h"
@@ -23,7 +24,8 @@
 #include "Framework/WorkflowSpec.h"
 #include <Monitoring/Monitoring.h>
 #include <fairmq/FairMQTransportFactory.h>
-#include <cstring>
+#include <array>
+#include <vector>
 
 using Monitoring = o2::monitoring::Monitoring;
 using namespace o2::framework;
@@ -58,12 +60,14 @@ BOOST_AUTO_TEST_CASE(TestNoWait)
   dh.splitPayloadParts = 1;
 
   DataProcessingHeader dph{0, 1};
-  Stack stack{dh, dph};
   auto transport = FairMQTransportFactory::CreateTransportFactory("zeromq");
-  FairMQMessagePtr header = transport->CreateMessage(stack.size());
-  FairMQMessagePtr payload = transport->CreateMessage(1000);
-  memcpy(header->GetData(), stack.data(), stack.size());
-  relayer.relay(header, payload);
+  std::array<FairMQMessagePtr, 2> messages;
+  auto channelAlloc = o2::pmr::getTransportAllocator(transport.get());
+  messages[0] = o2::pmr::getMessage(Stack{channelAlloc, dh, dph});
+  messages[1] = transport->CreateMessage(1000);
+  FairMQMessagePtr& header = messages[0];
+  FairMQMessagePtr& payload = messages[1];
+  relayer.relay(header->GetData(), messages.data(), messages.size());
   std::vector<RecordAction> ready;
   relayer.getReadyToProcess(ready);
   BOOST_REQUIRE_EQUAL(ready.size(), 1);
@@ -103,12 +107,14 @@ BOOST_AUTO_TEST_CASE(TestNoWaitMatcher)
   dh.splitPayloadParts = 1;
 
   DataProcessingHeader dph{0, 1};
-  Stack stack{dh, dph};
   auto transport = FairMQTransportFactory::CreateTransportFactory("zeromq");
-  FairMQMessagePtr header = transport->CreateMessage(stack.size());
-  FairMQMessagePtr payload = transport->CreateMessage(1000);
-  memcpy(header->GetData(), stack.data(), stack.size());
-  relayer.relay(header, payload);
+  std::array<FairMQMessagePtr, 2> messages;
+  auto channelAlloc = o2::pmr::getTransportAllocator(transport.get());
+  messages[0] = o2::pmr::getMessage(Stack{channelAlloc, dh, dph});
+  messages[1] = transport->CreateMessage(1000);
+  FairMQMessagePtr& header = messages[0];
+  FairMQMessagePtr& payload = messages[1];
+  relayer.relay(header->GetData(), messages.data(), messages.size());
   std::vector<RecordAction> ready;
   relayer.getReadyToProcess(ready);
   BOOST_REQUIRE_EQUAL(ready.size(), 1);
@@ -151,14 +157,15 @@ BOOST_AUTO_TEST_CASE(TestRelay)
   relayer.setPipelineLength(4);
 
   auto transport = FairMQTransportFactory::CreateTransportFactory("zeromq");
+  auto channelAlloc = o2::pmr::getTransportAllocator(transport.get());
 
-  auto createMessage = [&transport, &relayer](DataHeader& dh, size_t time) {
-    DataProcessingHeader dph{time, 1};
-    Stack stack{dh, dph};
-    FairMQMessagePtr header = transport->CreateMessage(stack.size());
-    FairMQMessagePtr payload = transport->CreateMessage(1000);
-    memcpy(header->GetData(), stack.data(), stack.size());
-    relayer.relay(header, payload);
+  auto createMessage = [&transport, &channelAlloc, &relayer](DataHeader& dh, size_t time) {
+    std::array<FairMQMessagePtr, 2> messages;
+    messages[0] = o2::pmr::getMessage(Stack{channelAlloc, dh, DataProcessingHeader{time, 1}});
+    messages[1] = transport->CreateMessage(1000);
+    FairMQMessagePtr& header = messages[0];
+    FairMQMessagePtr& payload = messages[1];
+    relayer.relay(header->GetData(), messages.data(), messages.size());
     BOOST_CHECK_EQUAL(header.get(), nullptr);
     BOOST_CHECK_EQUAL(payload.get(), nullptr);
   };
@@ -228,14 +235,15 @@ BOOST_AUTO_TEST_CASE(TestRelayBug)
   relayer.setPipelineLength(3);
 
   auto transport = FairMQTransportFactory::CreateTransportFactory("zeromq");
+  auto channelAlloc = o2::pmr::getTransportAllocator(transport.get());
 
-  auto createMessage = [&transport, &relayer](DataHeader& dh, size_t time) {
-    DataProcessingHeader dph{time, 1};
-    Stack stack{dh, dph};
-    FairMQMessagePtr header = transport->CreateMessage(stack.size());
-    FairMQMessagePtr payload = transport->CreateMessage(1000);
-    memcpy(header->GetData(), stack.data(), stack.size());
-    relayer.relay(header, payload);
+  auto createMessage = [&transport, &channelAlloc, &relayer](DataHeader& dh, size_t time) {
+    std::array<FairMQMessagePtr, 2> messages;
+    messages[0] = o2::pmr::getMessage(Stack{channelAlloc, dh, DataProcessingHeader{time, 1}});
+    messages[1] = transport->CreateMessage(1000);
+    FairMQMessagePtr& header = messages[0];
+    FairMQMessagePtr& payload = messages[1];
+    relayer.relay(header->GetData(), messages.data(), messages.size());
     BOOST_CHECK_EQUAL(header.get(), nullptr);
     BOOST_CHECK_EQUAL(payload.get(), nullptr);
   };
@@ -318,12 +326,14 @@ BOOST_AUTO_TEST_CASE(TestCache)
 
   DataProcessingHeader dph{0, 1};
   auto transport = FairMQTransportFactory::CreateTransportFactory("zeromq");
-  auto createMessage = [&transport, &relayer, &dh](const DataProcessingHeader& h) {
-    Stack stack{dh, h};
-    FairMQMessagePtr header = transport->CreateMessage(stack.size());
-    FairMQMessagePtr payload = transport->CreateMessage(1000);
-    memcpy(header->GetData(), stack.data(), stack.size());
-    auto res = relayer.relay(header, payload);
+  auto channelAlloc = o2::pmr::getTransportAllocator(transport.get());
+  auto createMessage = [&transport, &channelAlloc, &relayer, &dh](auto const& h) {
+    std::array<FairMQMessagePtr, 2> messages;
+    messages[0] = o2::pmr::getMessage(Stack{channelAlloc, dh, h});
+    messages[1] = transport->CreateMessage(1000);
+    FairMQMessagePtr& header = messages[0];
+    FairMQMessagePtr& payload = messages[1];
+    auto res = relayer.relay(header->GetData(), messages.data(), messages.size());
     BOOST_REQUIRE(res != DataRelayer::RelayChoice::WillRelay || header.get() == nullptr);
     BOOST_REQUIRE(res != DataRelayer::RelayChoice::WillRelay || payload.get() == nullptr);
     BOOST_REQUIRE(res != DataRelayer::RelayChoice::Backpressured || header.get() != nullptr);
@@ -397,12 +407,14 @@ BOOST_AUTO_TEST_CASE(TestPolicies)
   dh2.splitPayloadParts = 1;
 
   auto transport = FairMQTransportFactory::CreateTransportFactory("zeromq");
-  auto createMessage = [&transport, &relayer](DataHeader const& dh, DataProcessingHeader const& h) {
-    Stack stack{dh, h};
-    FairMQMessagePtr header = transport->CreateMessage(stack.size());
-    FairMQMessagePtr payload = transport->CreateMessage(1000);
-    memcpy(header->GetData(), stack.data(), stack.size());
-    return relayer.relay(header, payload);
+  auto channelAlloc = o2::pmr::getTransportAllocator(transport.get());
+  auto createMessage = [&transport, &channelAlloc, &relayer](auto const& dh, auto const& h) {
+    std::array<FairMQMessagePtr, 2> messages;
+    messages[0] = o2::pmr::getMessage(Stack{channelAlloc, dh, h});
+    messages[1] = transport->CreateMessage(1000);
+    FairMQMessagePtr& header = messages[0];
+    FairMQMessagePtr& payload = messages[1];
+    return relayer.relay(header->GetData(), messages.data(), messages.size());
   };
 
   // This fills the cache, and then empties it.
@@ -465,12 +477,14 @@ BOOST_AUTO_TEST_CASE(TestClear)
   dh2.splitPayloadParts = 1;
 
   auto transport = FairMQTransportFactory::CreateTransportFactory("zeromq");
-  auto createMessage = [&transport, &relayer](DataHeader const& dh, DataProcessingHeader const& h) {
-    Stack stack{dh, h};
-    FairMQMessagePtr header = transport->CreateMessage(stack.size());
-    FairMQMessagePtr payload = transport->CreateMessage(1000);
-    memcpy(header->GetData(), stack.data(), stack.size());
-    return relayer.relay(header, payload);
+  auto channelAlloc = o2::pmr::getTransportAllocator(transport.get());
+  auto createMessage = [&transport, &channelAlloc, &relayer](auto const& dh, auto const& h) {
+    std::array<FairMQMessagePtr, 2> messages;
+    messages[0] = o2::pmr::getMessage(Stack{channelAlloc, dh, h});
+    messages[1] = transport->CreateMessage(1000);
+    FairMQMessagePtr& header = messages[0];
+    FairMQMessagePtr& payload = messages[1];
+    return relayer.relay(header->GetData(), messages.data(), messages.size());
   };
 
   // This fills the cache, and then empties it.
@@ -520,20 +534,22 @@ BOOST_AUTO_TEST_CASE(TestTooMany)
   dh2.splitPayloadParts = 1;
 
   auto transport = FairMQTransportFactory::CreateTransportFactory("zeromq");
+  auto channelAlloc = o2::pmr::getTransportAllocator(transport.get());
 
-  Stack s1{dh1, DataProcessingHeader{0, 1}};
-  FairMQMessagePtr header = transport->CreateMessage(s1.size());
-  FairMQMessagePtr payload = transport->CreateMessage(1000);
-  memcpy(header->GetData(), s1.data(), s1.size());
-  relayer.relay(header, payload);
+  std::array<FairMQMessagePtr, 4> messages;
+  messages[0] = o2::pmr::getMessage(Stack{channelAlloc, dh1, DataProcessingHeader{0, 1}});
+  messages[1] = transport->CreateMessage(1000);
+  FairMQMessagePtr& header = messages[0];
+  FairMQMessagePtr& payload = messages[1];
+  relayer.relay(header->GetData(), &messages[0], 2);
   BOOST_CHECK_EQUAL(header.get(), nullptr);
   BOOST_CHECK_EQUAL(payload.get(), nullptr);
   // This fills the cache, and then waits.
-  Stack s2{dh1, DataProcessingHeader{1, 1}};
-  FairMQMessagePtr header2 = transport->CreateMessage(s2.size());
-  FairMQMessagePtr payload2 = transport->CreateMessage(1000);
-  memcpy(header2->GetData(), s2.data(), s2.size());
-  auto action = relayer.relay(header2, payload2);
+  messages[2] = o2::pmr::getMessage(Stack{channelAlloc, dh1, DataProcessingHeader{1, 1}});
+  messages[3] = transport->CreateMessage(1000);
+  FairMQMessagePtr& header2 = messages[2];
+  FairMQMessagePtr& payload2 = messages[3];
+  auto action = relayer.relay(header2->GetData(), &messages[2], 2);
   BOOST_CHECK_EQUAL(action, DataRelayer::Backpressured);
   BOOST_CHECK_NE(header2.get(), nullptr);
   BOOST_CHECK_NE(payload2.get(), nullptr);
@@ -575,20 +591,22 @@ BOOST_AUTO_TEST_CASE(SplitParts)
   dh2.splitPayloadParts = 1;
 
   auto transport = FairMQTransportFactory::CreateTransportFactory("zeromq");
+  auto channelAlloc = o2::pmr::getTransportAllocator(transport.get());
 
-  Stack s1{dh1, DataProcessingHeader{0, 1}};
-  FairMQMessagePtr header = transport->CreateMessage(s1.size());
-  FairMQMessagePtr payload = transport->CreateMessage(1000);
-  memcpy(header->GetData(), s1.data(), s1.size());
-  relayer.relay(header, payload);
+  std::array<FairMQMessagePtr, 4> messages;
+  messages[0] = o2::pmr::getMessage(Stack{channelAlloc, dh1, DataProcessingHeader{0, 1}});
+  messages[1] = transport->CreateMessage(1000);
+  FairMQMessagePtr& header = messages[0];
+  FairMQMessagePtr& payload = messages[1];
+  relayer.relay(header->GetData(), &messages[0], 2);
   BOOST_CHECK_EQUAL(header.get(), nullptr);
   BOOST_CHECK_EQUAL(payload.get(), nullptr);
   // This fills the cache, and then waits.
-  Stack s2{dh1, DataProcessingHeader{1, 1}};
-  FairMQMessagePtr header2 = transport->CreateMessage(s2.size());
-  FairMQMessagePtr payload2 = transport->CreateMessage(1000);
-  memcpy(header2->GetData(), s2.data(), s2.size());
-  auto action = relayer.relay(header2, payload2);
+  messages[2] = o2::pmr::getMessage(Stack{channelAlloc, dh1, DataProcessingHeader{1, 1}});
+  messages[3] = transport->CreateMessage(1000);
+  FairMQMessagePtr& header2 = messages[2];
+  FairMQMessagePtr& payload2 = messages[3];
+  auto action = relayer.relay(header2->GetData(), &messages[2], 2);
   BOOST_CHECK_EQUAL(action, DataRelayer::Backpressured);
   BOOST_CHECK_NE(header2.get(), nullptr);
   BOOST_CHECK_NE(payload2.get(), nullptr);


### PR DESCRIPTION
DataRelayer is using new version of MessageSet API which will
allow to switch message store in MessageSet transparently

Continuation of #7110 

There is a speedup in the message handling in DataProcessingDevice for split parts

Before
```
Run on (8 X 3400 MHz CPU s)
---------------------------------------------------------------
Benchmark                        Time           CPU Iterations
---------------------------------------------------------------
BM_RelayMessageCreation        193 ns        193 ns    3580395
BM_RelaySingleSlot             987 ns        986 ns     705237
BM_RelayMultipleSlots         1012 ns       1012 ns     661466
BM_RelayMultipleRoutes        1880 ns       1880 ns     374791
BM_RelaySplitParts            3806 ns       3792 ns     190106
```

After
```
Run on (8 X 3400 MHz CPU s)
---------------------------------------------------------------
Benchmark                        Time           CPU Iterations
---------------------------------------------------------------
BM_RelayMessageCreation        199 ns        199 ns    3567992
BM_RelaySingleSlot            1000 ns        999 ns     700044
BM_RelayMultipleSlots         1012 ns       1012 ns     683663
BM_RelayMultipleRoutes        2012 ns       2012 ns     345065
BM_RelaySplitParts            1391 ns       1390 ns     521503

```

Part of #7110 