### PR TITLE
consumeWhenAllOrdered completion policy to ensure writers write TFs to tree in order

### DIFF
--- a/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
+++ b/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
@@ -96,6 +96,13 @@ void customize(std::vector<o2::framework::CompletionPolicy>& policies)
   using CompletionPolicyHelpers = o2::framework::CompletionPolicyHelpers;
   policies.push_back(CompletionPolicyHelpers::defineByName("tpc-cluster-decoder.*", CompletionPolicy::CompletionOp::Consume));
   policies.push_back(CompletionPolicyHelpers::defineByName("tpc-clusterer.*", CompletionPolicy::CompletionOp::Consume));
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered("tpc-digits-writer.*"));
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered("tpc-clusterhardware-writer.*"));
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered("tpc-native-cluster-writer.*"));
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered("tpc-track-writer.*"));
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered("tpc-compcluster-writer.*"));
+
   // the custom completion policy for the tracker
   policies.push_back(o2::tpc::TPCSectorCompletionPolicy("tpc-tracker.*", o2::tpc::TPCSectorCompletionPolicy::Config::RequireAll, &gPolicyData, &gTpcSectorMask)());
 }

--- a/Framework/Core/include/Framework/CompletionPolicyHelpers.h
+++ b/Framework/Core/include/Framework/CompletionPolicyHelpers.h
@@ -32,6 +32,16 @@ struct CompletionPolicyHelpers {
   {
     return consumeWhenAll("consume-all", matcher);
   }
+
+  /// as consumeWhenAll, but ensures that records are processed with incremental DataHeader::tfCounter
+  static CompletionPolicy consumeWhenAllOrdered(const char* name, CompletionPolicy::Matcher matcher);
+  /// Default matcher applies for all devices
+  static CompletionPolicy consumeWhenAllOrdered(CompletionPolicy::Matcher matcher = [](auto const&) -> bool { return true; })
+  {
+    return consumeWhenAllOrdered("consume-all-ordered", matcher);
+  }
+  static CompletionPolicy consumeWhenAllOrdered(std::string matchName);
+
   /// When any of the parts of the record have been received, consume them.
   static CompletionPolicy consumeWhenAny(const char* name, CompletionPolicy::Matcher matcher);
   /// Default matcher applies for all devices

--- a/Framework/Core/src/CompletionPolicyHelpers.cxx
+++ b/Framework/Core/src/CompletionPolicyHelpers.cxx
@@ -127,7 +127,7 @@ CompletionPolicy CompletionPolicyHelpers::consumeWhenAllOrdered(const char* name
       }
     }
     (*nextTfCounter)++;
-    return CompletionPolicy::CompletionOp::Consume;
+    return CompletionPolicy::CompletionOp::ConsumeAndRescan;
   };
   return CompletionPolicy{name, matcher, callback};
 }

--- a/Framework/Core/src/CompletionPolicyHelpers.cxx
+++ b/Framework/Core/src/CompletionPolicyHelpers.cxx
@@ -114,6 +114,32 @@ CompletionPolicy CompletionPolicyHelpers::consumeWhenAll(const char* name, Compl
   return CompletionPolicy{name, matcher, callback};
 }
 
+CompletionPolicy CompletionPolicyHelpers::consumeWhenAllOrdered(const char* name, CompletionPolicy::Matcher matcher)
+{
+  auto nextTfCounter = std::make_shared<long int>(0);
+  auto callback = [nextTfCounter](InputSpan const& inputs) -> CompletionPolicy::CompletionOp {
+    for (auto& input : inputs) {
+      if (input.header == nullptr) {
+        return CompletionPolicy::CompletionOp::Wait;
+      }
+      if (framework::DataRefUtils::isValid(input) && framework::DataRefUtils::getHeader<o2::header::DataHeader*>(input)->tfCounter != *nextTfCounter) {
+        return CompletionPolicy::CompletionOp::Wait;
+      }
+    }
+    (*nextTfCounter)++;
+    return CompletionPolicy::CompletionOp::Consume;
+  };
+  return CompletionPolicy{name, matcher, callback};
+}
+
+CompletionPolicy CompletionPolicyHelpers::consumeWhenAllOrdered(std::string matchName)
+{
+  auto matcher = [matchName](DeviceSpec const& device) -> bool {
+    return std::regex_match(device.name.begin(), device.name.end(), std::regex(matchName));
+  };
+  return consumeWhenAllOrdered(matcher);
+}
+
 CompletionPolicy CompletionPolicyHelpers::consumeExistingWhenAny(const char* name, CompletionPolicy::Matcher matcher)
 {
   return CompletionPolicy{


### PR DESCRIPTION
@ktf : This implements the completion policy, and it works in the fact that it waits for TF 0 before writing other TFs.
However, there is a problem: when TF 1 is completely received before TF 0, the completion policy issues a `return CompletionPolicy::CompletionOp::Wait` when the last message for TF 1 arrives.
Afterwards, the completion policy is never called again for TF 1, even after TF 0 has been processed.
Thus the workflow gets stuck.

Is there any way I can mark other timeslices as "updated" such that the completion policy will check them again?