### PR TITLE
GPU: Minor improvements to GPU benchmark

### DIFF
--- a/GPU/GPUbenchmark/Shared/Utils.h
+++ b/GPU/GPUbenchmark/Shared/Utils.h
@@ -214,6 +214,7 @@ struct benchmarkOpts {
   int nTests = 1;
   int streams = 8;
   std::string outFileName = "benchmark_result";
+  bool dumpChunks = false;
 };
 
 template <class chunk_t>

--- a/GPU/GPUbenchmark/Shared/Utils.h
+++ b/GPU/GPUbenchmark/Shared/Utils.h
@@ -95,7 +95,8 @@ inline std::ostream& operator<<(std::ostream& os, Mode mode)
 enum class KernelConfig {
   Single,
   Multi,
-  All
+  All,
+  Manual
 };
 
 inline std::ostream& operator<<(std::ostream& os, KernelConfig config)
@@ -109,6 +110,9 @@ inline std::ostream& operator<<(std::ostream& os, KernelConfig config)
       break;
     case KernelConfig::All:
       os << "all";
+      break;
+    case KernelConfig::Manual:
+      os << "manual";
       break;
   }
   return os;
@@ -204,6 +208,8 @@ struct benchmarkOpts {
   float chunkReservedGB = 1.f;
   float threadPoolFraction = 1.f;
   float freeMemoryFractionToAllocate = 0.95f;
+  int numThreads = -1;
+  int numBlocks = -1;
   int kernelLaunches = 1;
   int nTests = 1;
   int streams = 8;

--- a/GPU/GPUbenchmark/cuda/Kernels.cu
+++ b/GPU/GPUbenchmark/cuda/Kernels.cu
@@ -460,6 +460,12 @@ float GPUbenchmark<chunk_t>::runDistributed(void (*kernel)(chunk_t**, size_t*, T
               << std::endl;
   }
 
+  if (mOptions.dumpChunks) {
+    for (size_t iChunk{0}; iChunk < totComputedBlocks; ++iChunk) {
+      std::cout << "   │   - block " << iChunk << " address: " << ptrPerBlocks[iChunk] << ", size: " << perBlockCapacity[iChunk] << std::endl;
+    }
+  }
+
   // Setup
   chunk_t** block_ptr;
   size_t* block_size;
@@ -559,7 +565,8 @@ void GPUbenchmark<chunk_t>::runTest(Test test, Mode mode, KernelConfig config)
   mResultWriter.get()->addBenchmarkEntry(getTestName(mode, test, config), getType<chunk_t>(), mState.getMaxChunks());
   auto dimGrid{mState.nMultiprocessors};
   auto nBlocks{(config == KernelConfig::Single) ? 1 : (config == KernelConfig::Multi) ? dimGrid / mState.testChunks.size()
-                                                                                      : (config == KernelConfig::All) ? dimGrid : mOptions.numBlocks};
+                                                    : (config == KernelConfig::All)   ? dimGrid
+                                                                                      : mOptions.numBlocks};
   size_t nThreads;
   if (mOptions.numThreads < 0) {
     nThreads = std::min(mState.nMaxThreadsPerDimension, mState.nMaxThreadsPerBlock);

--- a/GPU/GPUbenchmark/cuda/benchmark.cu
+++ b/GPU/GPUbenchmark/cuda/benchmark.cu
@@ -21,22 +21,25 @@ bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
   bpo::variables_map vm;
   bpo::options_description options("Benchmark options");
   options.add_options()(
-    "help,h", "Print help message.")(
-    "version,v", "Print version.")(
-    "extra,x", "Print extra info for each available device.")(
     "arbitrary,a", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{""}, ""), "Custom selected chunks syntax <p>:<s>. P is starting GB, S is the size in GB.")(
-    "device,d", bpo::value<int>()->default_value(0), "Id of the device to run test on, EPN targeted.")(
-    "test,t", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"read", "write", "copy"}, "read write copy"), "Tests to be performed.")(
-    "kind,k", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"char", "int", "ulong", "int4"}, "char int ulong int4"), "Test data type to be used.")(
-    "mode,m", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"seq", "con", "dis"}, "seq con dis"), "Mode: sequential, concurrent or distributed.")(
-    "blockPool,b", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"sb", "mb", "ab"}, "sb mb ab"), "Pool strategy: single, multi or all blocks.")(
-    "threadPool,e", bpo::value<float>()->default_value(1.f), "Fraction of blockDim.x to use (aka: rounded fraction of thread pool).")(
+    "blockPool,b", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"sb", "mb", "ab"}, "sb mb ab cb"), "Block pool strategy: single, multi, all or manual blocks.")(
     "chunkSize,c", bpo::value<float>()->default_value(1.f), "Size of scratch partitions (GB).")(
+    "device,d", bpo::value<int>()->default_value(0), "Id of the device to run test on, EPN targeted.")(
+    "threadPool,e", bpo::value<float>()->default_value(1.f), "Fraction of blockDim.x to use (aka: rounded fraction of thread pool).")(
     "freeMemFraction,f", bpo::value<float>()->default_value(0.95f), "Fraction of free memory to be allocated (min: 0.f, max: 1.f).")(
+    "blocks,g", bpo::value<int>()->default_value(-1), "Number of blocks, manual mode. (g=-1: gridDim.x).")(
+    "help,h", "Print help message.")(
+    "inspect,i", "Inspect and dump chunk addresses")(
+    "threads,j", bpo::value<int>()->default_value(-1), "Number of threads per block, manual mode. (j=-1: blockDim.x).")(
+    "kind,k", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"char", "int", "ulong", "int4"}, "char int ulong int4"), "Test data type to be used.")(
     "launches,l", bpo::value<int>()->default_value(10), "Number of iterations in reading kernels.")(
+    "mode,m", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"seq", "con", "dis"}, "seq con dis"), "Mode: sequential, concurrent or distributed.")(
     "nruns,n", bpo::value<int>()->default_value(1), "Number of times each test is run.")(
+    "outfile,o", bpo::value<std::string>()->default_value("benchmark_result"), "Output file name to store results.")(
     "streams,s", bpo::value<int>()->default_value(8), "Size of the pool of streams available for concurrent tests.")(
-    "outfile,o", bpo::value<std::string>()->default_value("benchmark_result"), "Output file name to store results.");
+    "test,t", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"read", "write", "copy"}, "read write copy"), "Tests to be performed.")(
+    "version,v", "Print version.")(
+    "extra,x", "Print extra info for each available device.");
   try {
     bpo::store(parse_command_line(argc, argv, options), vm);
     if (vm.count("help")) {
@@ -68,6 +71,8 @@ bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
   conf.deviceId = vm["device"].as<int>();
   conf.freeMemoryFractionToAllocate = vm["freeMemFraction"].as<float>();
   conf.threadPoolFraction = vm["threadPool"].as<float>();
+  conf.numThreads = vm["threads"].as<int>();
+  conf.numBlocks = vm["blocks"].as<int>();
   conf.chunkReservedGB = vm["chunkSize"].as<float>();
   conf.kernelLaunches = vm["launches"].as<int>();
   conf.nTests = vm["nruns"].as<int>();
@@ -109,6 +114,12 @@ bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
       conf.pools.push_back(KernelConfig::Multi);
     } else if (pool == "ab") {
       conf.pools.push_back(KernelConfig::All);
+    } else if (pool == "cb") {
+      if (vm["blocks"].as<int>() < 0) {
+        std::cerr << "Manual pool setting requires --blocks or -g to be passed." << std::endl;
+        exit(1);
+      }
+      conf.pools.push_back(KernelConfig::Manual);
     } else {
       std::cerr << "Unkonwn pool: " << pool << std::endl;
       exit(1);

--- a/GPU/GPUbenchmark/cuda/benchmark.cu
+++ b/GPU/GPUbenchmark/cuda/benchmark.cu
@@ -29,7 +29,7 @@ bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
     "freeMemFraction,f", bpo::value<float>()->default_value(0.95f), "Fraction of free memory to be allocated (min: 0.f, max: 1.f).")(
     "blocks,g", bpo::value<int>()->default_value(-1), "Number of blocks, manual mode. (g=-1: gridDim.x).")(
     "help,h", "Print help message.")(
-    "inspect,i", "Inspect and dump chunk addresses")(
+    "inspect,i", "Inspect and dump chunk addresses.")(
     "threads,j", bpo::value<int>()->default_value(-1), "Number of threads per block, manual mode. (j=-1: blockDim.x).")(
     "kind,k", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"char", "int", "ulong", "int4"}, "char int ulong int4"), "Test data type to be used.")(
     "launches,l", bpo::value<int>()->default_value(10), "Number of iterations in reading kernels.")(
@@ -57,6 +57,10 @@ bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
       o2::benchmark::GPUbenchmark<char> bm_dummy{opts, nullptr};
       bm_dummy.printDevices();
       return false;
+    }
+
+    if (vm.count("inspect")) {
+      conf.dumpChunks = true;
     }
 
     bpo::notify(vm);


### PR DESCRIPTION
@davidrohr : can this work?

```bash
[O2/latest-gpu-benchmark-o2] /tmp $> o2-gpu-memory-benchmark-hip -a 1:5 6.5:4 -m dis -kint4 -b cb -j1021 -g9 -t write -i
 ◈ Running on: Vega 20
   ├ Buffer type: int4
   ├ Allocated: 30/32(GB) [95%]
   └ Available streams: 8

 ◈ int4 write benchmark with 1 runs and 10 kernel launches
   ├ distributed write manual block(s) (1/1): 
   │   - blocks per kernel: 9/60
   │   - threads per block: 1021
   │   - chunk 0 address : 0x7fe100000000, size: 67108864
   │   - chunk 1 address : 0x7fe140000000, size: 67108864
   │   - chunk 2 address : 0x7fe180000000, size: 67108864
   │   - chunk 3 address : 0x7fe1c0000000, size: 67108864
   │   - chunk 4 address : 0x7fe200000000, size: 67108864
   │   - chunk 5 address : 0x7fe260000000, size: 67108864
   │   - chunk 6 address : 0x7fe2a0000000, size: 67108864
   │   - chunk 7 address : 0x7fe2e0000000, size: 67108864
   │   - chunk 8 address : 0x7fe320000000, size: 67108864
   │     └ throughput: 468 GB/s (0.192 s)
   └ done
```