### PR TITLE
DPL Analysis: fix Build<> to respect index table declaration

### DIFF
--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -348,7 +348,7 @@ struct IndexSparse {
 };
 
 /// This helper struct allows you to declare index tables to be created in a task
-template <typename T, typename IP = IndexSparse>
+template <typename T, typename IP = std::conditional_t<aod::MetadataTrait<T>::metadata::exclusive, IndexExclusive, IndexSparse>>
 struct Builds : TableTransform<typename aod::MetadataTrait<T>::metadata> {
   using Key = typename T::indexing_t;
   using H = typename T::first_t;
@@ -382,9 +382,6 @@ struct Builds : TableTransform<typename aod::MetadataTrait<T>::metadata> {
     return (this->table != nullptr);
   }
 };
-
-template <typename T>
-using BuildsExclusive = Builds<T, IndexExclusive>;
 
 /// This helper class allows you to declare things which will be created by a
 /// given analysis task. Currently wrapped objects are limited to be TNamed

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -348,8 +348,9 @@ struct IndexSparse {
 };
 
 /// This helper struct allows you to declare index tables to be created in a task
-template <typename T, typename IP = std::conditional_t<aod::MetadataTrait<T>::metadata::exclusive, IndexExclusive, IndexSparse>>
+template <typename T>
 struct Builds : TableTransform<typename aod::MetadataTrait<T>::metadata> {
+  using IP = std::conditional_t<aod::MetadataTrait<T>::metadata::exclusive, IndexExclusive, IndexSparse>;
   using Key = typename T::indexing_t;
   using H = typename T::first_t;
   using Ts = typename T::rest_t;

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -299,28 +299,28 @@ static inline auto extractOriginalsTuple(framework::pack<Os...>, ProcessingConte
   return std::make_tuple(extractTypedOriginal<Os>(pc)...);
 }
 
-template <typename T, typename P>
-struct OutputManager<Builds<T, P>> {
-  static bool appendOutput(std::vector<OutputSpec>& outputs, Builds<T, P>& what, uint32_t)
+template <typename T>
+struct OutputManager<Builds<T>> {
+  static bool appendOutput(std::vector<OutputSpec>& outputs, Builds<T>& what, uint32_t)
   {
     outputs.emplace_back(what.spec());
     return true;
   }
 
-  static bool prepare(ProcessingContext& pc, Builds<T, P>& what)
+  static bool prepare(ProcessingContext& pc, Builds<T>& what)
   {
     return what.build(what.pack(),
-                      extractTypedOriginal<typename Builds<T, P>::Key>(pc),
+                      extractTypedOriginal<typename Builds<T>::Key>(pc),
                       extractOriginalsTuple(what.originals_pack(), pc));
   }
 
-  static bool finalize(ProcessingContext& pc, Builds<T, P>& what)
+  static bool finalize(ProcessingContext& pc, Builds<T>& what)
   {
     pc.outputs().adopt(what.output(), what.asArrowTable());
     return true;
   }
 
-  static bool postRun(EndOfStreamContext&, Builds<T, P>&)
+  static bool postRun(EndOfStreamContext&, Builds<T>&)
   {
     return true;
   }
@@ -492,9 +492,9 @@ struct IndexManager {
   static bool requestInputs(std::vector<InputSpec>&, T const&) { return false; };
 };
 
-template <typename IDX, typename P>
-struct IndexManager<Builds<IDX, P>> {
-  static bool requestInputs(std::vector<InputSpec>& inputs, Builds<IDX, P>& builds)
+template <typename IDX>
+struct IndexManager<Builds<IDX>> {
+  static bool requestInputs(std::vector<InputSpec>& inputs, Builds<IDX>& builds)
   {
     auto base_specs = builds.base_specs();
     for (auto& base_spec : base_specs) {


### PR DESCRIPTION
`Builds<T>` template will now use index table metadata to chose building algorithm, previously building exclusive table would choose sparse index builder path unless `BuildsExclusive<T>` was used, regardless if index table `T` was declared as exclusive or not.