### PR TITLE
[EMCAL-534] Add option to switch off pedestal subtraction for non-ZS …

### DIFF
--- a/Detectors/EMCAL/reconstruction/src/CaloRawFitter.cxx
+++ b/Detectors/EMCAL/reconstruction/src/CaloRawFitter.cxx
@@ -63,7 +63,7 @@ int CaloRawFitter::getErrorNumber(CaloRawFitter::RawFitterError_t fiterror)
   return -1;
 }
 
-//Default constructor
+// Default constructor
 CaloRawFitter::CaloRawFitter(const char* name, const char* nameshort) : mMinTimeIndex(-1),
                                                                         mMaxTimeIndex(-1),
                                                                         mAmpCut(4),
@@ -160,6 +160,9 @@ double CaloRawFitter::evaluatePedestal(const gsl::span<const uint16_t> data, std
 {
   if (!mNsamplePed) {
     throw RawFitterError_t::SAMPLE_UNINITIALIZED;
+  }
+  if (data.size() < mNsamplePed) {
+    return 0.;
   }
   return static_cast<double>(std::accumulate(data.begin(), data.begin() + mNsamplePed, 0)) / mNsamplePed;
 }
@@ -284,9 +287,6 @@ std::tuple<int, int, float, short, short, float, int, int> CaloRawFitter::preFit
   if (bunchindex >= 0) {
     if (adcMAX >= adcThreshold) {
       // use more convenient numbering and possibly subtract pedestal
-
-      //std::tie(ped, mReversed) = reverseAndSubtractPed((bunchvector.at(index)), altrocfg1, altrocfg2);
-      //maxf = (float)*std::max_element(mReversed.begin(), mReversed.end());
 
       int bunchlength = bunchvector[bunchindex].getBunchLength();
       const std::vector<uint16_t>& sig = bunchvector[bunchindex].getADC();

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/RawToCellConverterSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/RawToCellConverterSpec.h
@@ -112,6 +112,7 @@ class RawToCellConverterSpec : public framework::Task
   int mMaxErrorMessages = 100;                                       ///< Max. number of error messages
   bool mMergeLGHG = true;                                            ///< Merge low and high gain cells
   bool mPrintTrailer = false;                                        ///< Print RCU trailer
+  bool mDisablePedestalEvaluation = false;                           ///< Disable pedestal evaluation independent of settings in the RCU trailer
   std::chrono::time_point<std::chrono::system_clock> mReferenceTime; ///< Reference time for muting messages
   Geometry* mGeometry = nullptr;                                     ///!<! Geometry pointer
   std::unique_ptr<MappingHandler> mMapper = nullptr;                 ///!<! Mapper


### PR DESCRIPTION
…events

Pedestal subtraction steered via the ZS status in the RCU
trailer. In case the data is taken in no-ZS mode the
pedestal subtraction is enabled. A dedicated setter is
added to bypass the determination via the RCU trailer
in case the pedestals should not be evaluated on
request.

In case of ZS Data the pedestal subtraction is always
disabled as it is performed online.