### PR TITLE
MCUtils: restructuring, testing, additional features

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/MCUtils.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCUtils.h
@@ -23,10 +23,18 @@ namespace o2
 {
 namespace mcutils
 {
-/// Function to determine if a MC track/particle p is a primary according to physics criteria.
-/// Needs the particle as input, as well as the whole navigable container of particles
-/// (of which p needs to be a part itself). The container can be fetched via MCKinematicsReader.
-bool isPhysicalPrimary(o2::MCTrack const& p, std::vector<o2::MCTrack> const& pcontainer);
+/// A couple of functions to query on MC tracks ( that needs navigation within the global container
+/// of available tracks. It is a class so as to make it available for interactive ROOT more easily
+class MCTrackNavigator
+{
+ public:
+  /// Function to determine if a MC track/particle p is a primary according to physics criteria.
+  /// Needs the particle as input, as well as the whole navigable container of particles
+  /// (of which p needs to be a part itself). The container can be fetched via MCKinematicsReader.
+  static bool isPhysicalPrimary(o2::MCTrack const& p, std::vector<o2::MCTrack> const& pcontainer);
+
+  ClassDefNV(MCTrackNavigator, 1);
+};
 
 /// Determine if a particle (identified by pdg) is stable
 inline bool isStable(int pdg)

--- a/DataFormats/simulation/include/SimulationDataFormat/MCUtils.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCUtils.h
@@ -24,7 +24,7 @@ namespace o2
 namespace mcutils
 {
 /// A couple of functions to query on MC tracks ( that needs navigation within the global container
-/// of available tracks. It is a class so as to make it available for interactive ROOT more easily
+/// of available tracks. It is a class so as to make it available for interactive ROOT more easily.
 class MCTrackNavigator
 {
  public:
@@ -32,6 +32,29 @@ class MCTrackNavigator
   /// Needs the particle as input, as well as the whole navigable container of particles
   /// (of which p needs to be a part itself). The container can be fetched via MCKinematicsReader.
   static bool isPhysicalPrimary(o2::MCTrack const& p, std::vector<o2::MCTrack> const& pcontainer);
+
+  // some convenience functions for navigation
+
+  /// Given an MCTrack p; Return the first primary mother particle in the upward parent chain (follow
+  /// only first mothers). The first primary mother may have further parent (put by the generator).
+  /// Return p itself if p is a primary.
+  static o2::MCTrack const& getFirstPrimary(o2::MCTrack const& p, std::vector<o2::MCTrack> const& pcontainer);
+
+  /// Given an MCTrack p; Return it's direct mother or nullptr. (we follow only first mother)
+  static o2::MCTrack const* getMother(o2::MCTrack const& p, std::vector<o2::MCTrack> const& pcontainer);
+
+  /// Given an MCTrack p; Return it's direct daughter or nullptr. (we follow only first daughter)
+  static o2::MCTrack const* getDaughter(o2::MCTrack const& p, std::vector<o2::MCTrack> const& pcontainer);
+
+  /// Given an MCTrack p; Fill the complete parent chain (ancestorchain) up to the most fundamental particle (follow only
+  /// first mothers).
+  // static void getParentChain(o2::MCTrack const& p, std::vector<o2::MCTrack> const& pcontainer, std::vector<o2::MCTrack> &ancestorchain);
+
+  /// query if a track is a direct **or** indirect daughter of a parentID
+  /// if trackid is same as parentid it returns true
+  /// bool isTrackDaughterOf(int /*trackid*/, int /*parentid*/) const;
+  /// we can think about offering some visitor like patterns executing a
+  /// user hook on nodes
 
   ClassDefNV(MCTrackNavigator, 1);
 };

--- a/DataFormats/simulation/src/MCUtils.cxx
+++ b/DataFormats/simulation/src/MCUtils.cxx
@@ -15,10 +15,11 @@
 
 #include <SimulationDataFormat/MCUtils.h>
 
-using namespace o2::mcutils;
+namespace o2::mcutils
+{
 
 // taken from AliRoot and adapted to use of o2::MCTrack class
-bool isPhysicalPrimary(o2::MCTrack const& p, std::vector<o2::MCTrack> const& pcontainer)
+bool MCTrackNavigator::isPhysicalPrimary(o2::MCTrack const& p, std::vector<o2::MCTrack> const& pcontainer)
 {
   // Test if a particle is a physical primary according to the following definition:
   // Particles produced in the collision including products of strong and
@@ -119,3 +120,5 @@ bool isPhysicalPrimary(o2::MCTrack const& p, std::vector<o2::MCTrack> const& pco
     }
   } // end else branch produced by generator
 }
+
+} // namespace o2::mcutils

--- a/DataFormats/simulation/src/MCUtils.cxx
+++ b/DataFormats/simulation/src/MCUtils.cxx
@@ -18,6 +18,38 @@
 namespace o2::mcutils
 {
 
+o2::MCTrack const* MCTrackNavigator::getMother(const o2::MCTrack& p, const std::vector<o2::MCTrack>& pcontainer)
+{
+  const auto mid = p.getMotherTrackId();
+  if (mid < 0 or mid > pcontainer.size()) {
+    return nullptr;
+  }
+  return &(pcontainer[mid]);
+}
+
+o2::MCTrack const* MCTrackNavigator::getDaughter(const o2::MCTrack& p, const std::vector<o2::MCTrack>& pcontainer)
+{
+  const auto did = p.getFirstDaughterTrackId();
+  if (did < 0 or did > pcontainer.size()) {
+    return nullptr;
+  }
+  return &(pcontainer[did]);
+}
+
+o2::MCTrack const& MCTrackNavigator::getFirstPrimary(const o2::MCTrack& p, const std::vector<o2::MCTrack>& pcontainer)
+{
+  if (p.isPrimary()) {
+    return p;
+  }
+  o2::MCTrack const* ptr = &p;
+  while (true) {
+    ptr = getMother(*ptr, pcontainer);
+    if (ptr->isPrimary()) {
+      return *ptr;
+    }
+  }
+}
+
 // taken from AliRoot and adapted to use of o2::MCTrack class
 bool MCTrackNavigator::isPhysicalPrimary(o2::MCTrack const& p, std::vector<o2::MCTrack> const& pcontainer)
 {
@@ -51,20 +83,18 @@ bool MCTrackNavigator::isPhysicalPrimary(o2::MCTrack const& p, std::vector<o2::M
     // Particle produced by generator
     // Solution for K0L decayed by Pythia6
     // ->
-    const int ipm = p.getMotherTrackId();
-    if (ipm > -1) {
-      const auto& ppm = pcontainer[ipm];
-      if (std::abs(ppm.GetPdgCode()) == 130) {
+    const auto ipm = getMother(p, pcontainer);
+    if (ipm != nullptr) {
+      if (std::abs(ipm->GetPdgCode()) == 130) {
         return false;
       }
     }
     // <-
     // check for direct photon in parton shower
     // ->
-    const int ipd = p.getFirstDaughterTrackId();
-    if (pdg == 22 && ipd > -1) {
-      const auto& ppd = pcontainer[ipd];
-      if (ppd.GetPdgCode() == 22) {
+    if (pdg == 22) {
+      const auto ipd = getDaughter(p, pcontainer);
+      if (ipd && ipd->GetPdgCode() == 22) {
         return false;
       }
     }
@@ -75,8 +105,7 @@ bool MCTrackNavigator::isPhysicalPrimary(o2::MCTrack const& p, std::vector<o2::M
     // Particle produced during transport
     //
 
-    int imo = p.getMotherTrackId();
-    auto pm = &(pcontainer[imo]);
+    auto pm = getMother(p, pcontainer);
     int mpdg = std::abs(pm->GetPdgCode());
     // Check for Sigma0
     if ((mpdg == 3212) && pm->isPrimary()) {
@@ -107,8 +136,7 @@ bool MCTrackNavigator::isPhysicalPrimary(o2::MCTrack const& p, std::vector<o2::M
     // To be sure that heavy flavor has not been produced in a secondary interaction
     // Loop back to the generated mother
     while (!pm->isPrimary()) {
-      imo = pm->getMotherTrackId();
-      pm = &(pcontainer[imo]);
+      pm = getMother(*pm, pcontainer);
     }
     mpdg = std::abs(pm->GetPdgCode());
     mfl = int(mpdg / std::pow(10, int(std::log10(mpdg))));

--- a/DataFormats/simulation/src/SimulationDataLinkDef.h
+++ b/DataFormats/simulation/src/SimulationDataLinkDef.h
@@ -71,4 +71,6 @@
 
 #pragma link C++ class o2::dataformats::IOMCTruthContainerView + ;
 
+#pragma link C++ class o2::mcutils::MCTrackNavigator + ;
+
 #endif

--- a/run/SimExamples/Jet_Embedding_Pythia8/exampleMCTrackAnalysis.macro
+++ b/run/SimExamples/Jet_Embedding_Pythia8/exampleMCTrackAnalysis.macro
@@ -44,6 +44,7 @@ void exampleMCTrackAnalysis(const char* itsdigitfilename) {
   int purenoisedigits = 0;
   int secondarydigits = 0;
   int primarydigits = 0;
+
   for (int pos = 0; pos < digits->size(); ++pos) {
     auto& digit = (*digits)[pos];
     bool noisecontrib = false;


### PR DESCRIPTION
Slightly restructuring the code for mcutils::isPhysicalPrimary. It now sits in a class rather than namespace
since this makes ROOT dictionary generation easier (with future extensions).

Also adding a few more functions to navigate in MCTrack vectors.

Testing/using the isPhysicalPrimary code in a simulation test.
