### PR TITLE
Fix: CTF reader must set DataHeader::runNumber

### DIFF
--- a/Detectors/CTF/workflow/src/CTFReaderSpec.cxx
+++ b/Detectors/CTF/workflow/src/CTFReaderSpec.cxx
@@ -224,6 +224,7 @@ void CTFReaderSpec::processTF(ProcessingContext& pc)
     }
     hd->firstTForbit = ctfHeader.firstTForbit;
     hd->tfCounter = this->mCTFCounter;
+    hd->runNumber = uint32_t(ctfHeader.run);
   };
 
   // send CTF Header


### PR DESCRIPTION
trivial fix, tested locally, merging