### PR TITLE
DPL: Storing actual message size in the DataRef

### DIFF
--- a/Framework/Core/include/Framework/DataRef.h
+++ b/Framework/Core/include/Framework/DataRef.h
@@ -11,6 +11,8 @@
 #ifndef FRAMEWORK_DATAREF_H
 #define FRAMEWORK_DATAREF_H
 
+#include <cstddef> // for size_t
+
 namespace o2
 {
 namespace framework
@@ -24,6 +26,7 @@ struct DataRef {
   const InputSpec* spec = nullptr;
   const char* header = nullptr;
   const char* payload = nullptr;
+  size_t payloadSize = 0;
 };
 
 } // namespace framework

--- a/Framework/Core/include/Framework/DataRefUtils.h
+++ b/Framework/Core/include/Framework/DataRefUtils.h
@@ -168,7 +168,14 @@ struct DataRefUtils {
     if (!header) {
       return 0;
     }
-    return header->payloadSize;
+    // in case of an O2 message with multiple payloads, the size of the message stored
+    // in DataRef is returned,
+    // as a prototype solution we are using splitPayloadIndex == splitPayloadParts to
+    // indicate that there are splitPayloadParts payloads following the header
+    if (header->splitPayloadParts > 1 && header->splitPayloadIndex == header->splitPayloadParts) {
+      return ref.payloadSize;
+    }
+    return header->payloadSize < ref.payloadSize || ref.payloadSize == 0 ? header->payloadSize : ref.payloadSize;
   }
 
   template <typename T>

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -1168,9 +1168,10 @@ bool DataProcessingDevice::tryDispatchComputation(DataProcessorContext& context,
         auto payload = currentSetOfInputs[i].payload(partindex).get();
         return DataRef{nullptr,
                        static_cast<char const*>(header->GetData()),
-                       static_cast<char const*>(payload ? payload->GetData() : nullptr)};
+                       static_cast<char const*>(payload ? payload->GetData() : nullptr),
+                       payload ? payload->GetSize() : 0};
       }
-      return DataRef{nullptr, nullptr, nullptr};
+      return DataRef{};
     };
     auto nofPartsGetter = [&currentSetOfInputs](size_t i) -> size_t {
       return currentSetOfInputs[i].size();

--- a/Framework/Core/src/DataRelayer.cxx
+++ b/Framework/Core/src/DataRelayer.cxx
@@ -512,9 +512,10 @@ void DataRelayer::getReadyToProcess(std::vector<DataRelayer::RecordAction>& comp
         auto payload = partial[idx].payload(part).get();
         return DataRef{nullptr,
                        reinterpret_cast<const char*>(header->GetData()),
-                       reinterpret_cast<const char*>(payload ? payload->GetData() : nullptr)};
+                       reinterpret_cast<char const*>(payload ? payload->GetData() : nullptr),
+                       payload ? payload->GetSize() : 0};
       }
-      return DataRef{nullptr, nullptr, nullptr};
+      return DataRef{};
     };
     auto nPartsGetter = [&partial](size_t idx) {
       return partial[idx].size();


### PR DESCRIPTION
When multiple payloads per header will be supported, the payload
size in the DataHeader can only store one value and we need the
actual payload message size. DataRefUtils::getPayloadSize should
always be used.

Most of the user code has already been updated in #7034.

Part of #7110 