### PR TITLE
[MID] improve MID tracking

### DIFF
--- a/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/Track.h
+++ b/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/Track.h
@@ -57,7 +57,7 @@ class Track
   };
 
   /// Gets the covariance parameters
-  const std::array<float, 6> getCovarianceParameters() const { return mCovarianceParameters; }
+  const std::array<float, 6>& getCovarianceParameters() const { return mCovarianceParameters; }
   /// returns the covariance parameter covParam
   float getCovarianceParameter(CovarianceParamIndex covParam) const
   {
@@ -74,7 +74,11 @@ class Track
 
   bool propagateToZ(float zPosition);
 
+  /// Gets the matched clusters without bound checking
+  int getClusterMatchedUnchecked(int chamber) const { return mClusterMatched[chamber]; }
   int getClusterMatched(int chamber) const;
+  /// Sets the matched clusters without bound checking
+  void setClusterMatchedUnchecked(int chamber, int id) { mClusterMatched[chamber] = id; }
   void setClusterMatched(int chamber, int id);
 
   /// Returns the chi2 of the track

--- a/Detectors/MUON/MID/Workflow/src/TrackerMCSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/TrackerMCSpec.cxx
@@ -48,7 +48,7 @@ class TrackerMCDeviceDPL
 
     mTracker = std::make_unique<Tracker>(createTransformationFromManager(gGeoManager));
 
-    if (!mTracker->init()) {
+    if (!mTracker->init(true)) {
       LOG(ERROR) << "Initialization of MID tracker device failed";
     }
   }

--- a/Detectors/MUON/MID/Workflow/src/TrackerSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/TrackerSpec.cxx
@@ -47,7 +47,7 @@ class TrackerDeviceDPL
 
     mTracker = std::make_unique<Tracker>(createTransformationFromManager(gGeoManager));
 
-    if (!mTracker->init()) {
+    if (!mTracker->init(true)) {
       LOG(ERROR) << "Initialization of MID tracker device failed";
     }
 


### PR DESCRIPTION
- fix chi2 and NDF calculation and chi2 cut
- fix track selection in the algorithm keeping only the best track candidates (keep track with more cluster, then best chi2 in case of equality)
- really consider all combinations (attaching a maximum of clusters) in the algorithm keeping all track candidates
- remove unnecessary calculations + other improvements to speed up the code
- change the devices to use the tracking algorithm keeping all track candidates

