### PR TITLE
Fix needed for TOF calibration to avoid truncation double->float

### DIFF
--- a/Detectors/GlobalTracking/src/MatchTOF.cxx
+++ b/Detectors/GlobalTracking/src/MatchTOF.cxx
@@ -1077,6 +1077,8 @@ void MatchTOF::selectBestMatches()
     // get fit info
     double t0info = 0;
 
+    const o2::track::TrackLTIntegral& intLT = matchingPair.getLTIntegralOut();
+
     if (mFITRecPoints.size() > 0) {
       int index = findFITIndex(mTOFClusWork[matchingPair.getTOFClIndex()].getBC());
 
@@ -1084,9 +1086,11 @@ void MatchTOF::selectBestMatches()
         o2::InteractionRecord ir = mFITRecPoints[index].getInteractionRecord();
         t0info = ir.bc2ns() * 1E3;
       }
+    } else { // move time to time in orbit to avoid loss of precision when truncating from double to float
+      int bcStarOrbit = int((mTOFClusWork[matchingPair.getTOFClIndex()].getTimeRaw() - intLT.getTOF(o2::track::PID::Pion)) * o2::tof::Geo::BC_TIME_INPS_INV);
+      bcStarOrbit = (bcStarOrbit / o2::constants::lhc::LHCMaxBunches) * o2::constants::lhc::LHCMaxBunches; // truncation
+      t0info = bcStarOrbit * o2::tof::Geo::BC_TIME_INPS;
     }
-
-    const o2::track::TrackLTIntegral& intLT = matchingPair.getLTIntegralOut();
 
     // add also calibration infos
     mCalibInfoTOF.emplace_back(mTOFClusWork[matchingPair.getTOFClIndex()].getMainContributingChannel(),

--- a/Detectors/GlobalTrackingWorkflow/src/TOFEventTimeChecker.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TOFEventTimeChecker.cxx
@@ -154,6 +154,7 @@ void TOFEventTimeChecker::processEvent(std::vector<MyTrack>& tracks)
     mPBetavsPExpPi->Fill(track.mP, betaexpPi);
     mPBetavsPExpKa->Fill(track.mP, betaexpKa);
     mPBetavsPExpPr->Fill(track.mP, betaexpPr);
+
     mHTimePivsP->Fill(track.mP, track.tofSignal() - et - track.tofExpTimePi());
     mHTimeKvsP->Fill(track.mP, track.tofSignal() - et - track.tofExpTimeKa());
     mHTimePrvsP->Fill(track.mP, track.tofSignal() - et - track.tofExpTimePr());

--- a/Detectors/GlobalTrackingWorkflow/src/TOFEventTimeChecker.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TOFEventTimeChecker.cxx
@@ -154,7 +154,6 @@ void TOFEventTimeChecker::processEvent(std::vector<MyTrack>& tracks)
     mPBetavsPExpPi->Fill(track.mP, betaexpPi);
     mPBetavsPExpKa->Fill(track.mP, betaexpKa);
     mPBetavsPExpPr->Fill(track.mP, betaexpPr);
-
     mHTimePivsP->Fill(track.mP, track.tofSignal() - et - track.tofExpTimePi());
     mHTimeKvsP->Fill(track.mP, track.tofSignal() - et - track.tofExpTimeKa());
     mHTimePrvsP->Fill(track.mP, track.tofSignal() - et - track.tofExpTimePr());

--- a/Detectors/TOF/base/include/TOFBase/Utils.h
+++ b/Detectors/TOF/base/include/TOFBase/Utils.h
@@ -41,7 +41,7 @@ class Utils
 
  private:
   static std::vector<int> mFillScheme;
-  static int mBCmult[o2::constants::lhc::LHCMaxBunches + 1];
+  static int mBCmult[o2::constants::lhc::LHCMaxBunches];
   static int mNautodet;
   static int mMaxBC;
   static bool mIsInit;

--- a/Detectors/TOF/calibration/src/TOFChannelCalibrator.cxx
+++ b/Detectors/TOF/calibration/src/TOFChannelCalibrator.cxx
@@ -70,14 +70,15 @@ void TOFChannelData::fill(const gsl::span<const o2::dataformats::CalibInfoTOF> d
     } else {
       int istrip = ch / 96;
       int istripInSector = chInSect / 96;
-      //      int fea =  (chInSect % 96) / 24;
+      int fea = (chInSect % 48) / 12;
       int choffset = (istrip - istripInSector) * 96;
-      int minch = istripInSector * 96;
-      int maxch = minch + 96;
-      //      int minch = istripInSector * 96 + fea*24;
-      //      int maxch = minch + 24;
+      //int minch = istripInSector * 96;
+      //int maxch = minch + 96;
+      int minch = istripInSector * 96 + fea * 12;
+      int maxch = minch + 12;
       for (int ich = minch; ich < maxch; ich++) {
-        mHisto[sector](dtcorr, ich); // we pass the calibrated time
+        mHisto[sector](dtcorr, ich);      // we pass the calibrated time
+        mHisto[sector](dtcorr, ich + 48); // we pass the calibrated time
         mEntries[ich + choffset] += 1;
       }
     }


### PR DESCRIPTION
@chiarazampolli 
This is needed to avoid do manage info calib (t - txp) with large values (t up to 11000000000 ps in timeframe) which are then truncated to float.

This happens if FT0 is not available.

Now (t - texp) convert to time in orbit instead of timeframe before to be converted to calibration info.

Other optimization in...