### PR TITLE
Few bug fixes for CI and cosmics

### DIFF
--- a/Detectors/ITSMFT/ITS/macros/test/CheckTracksCA.C
+++ b/Detectors/ITSMFT/ITS/macros/test/CheckTracksCA.C
@@ -46,7 +46,7 @@ struct ParticleInfo {
 
 #pragma link C++ class ParticleInfo + ;
 
-void CheckTracksCA(bool doFakeClStud = true, std::string tracfile = "o2trac_its.root", std::string clusfile = "o2clus_its.root", std::string kinefile = "o2sim_Kine.root")
+void CheckTracksCA(bool doFakeClStud = false, std::string tracfile = "o2trac_its.root", std::string clusfile = "o2clus_its.root", std::string kinefile = "o2sim_Kine.root")
 {
 
   using namespace o2::itsmft;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
@@ -48,11 +48,6 @@ class Configuration : public Param
 
 struct TrackingParameters {
   TrackingParameters& operator=(const TrackingParameters& t) = default;
-  void CopyCuts(TrackingParameters& other, float scale = 1.)
-  {
-    TrackletMaxDeltaPhi = other.TrackletMaxDeltaPhi * scale;
-    NSigmaCut = other.NSigmaCut * scale;
-  }
 
   int CellMinimumLevel();
   int CellsPerRoad() const { return NLayers - 2; }
@@ -74,14 +69,14 @@ struct TrackingParameters {
   int ClusterSharing = 0;
   int MinTrackLength = 7;
   float NSigmaCut = 5;
-  float PVres = 1.e-2f; /// FIXME: this has to be taken directly from the reconstructed vertices
+  float PVres = 1.e-2f;
   /// Trackleting cuts
-  float TrackletMaxDeltaPhi = 0.3f;
+  float TrackletMinPt = 0.3f;
   /// Cell finding cuts
   float CellDeltaTanLambdaSigma = 0.007f;
   /// Fitter parameters
   bool UseMatBudLUT = false;
-  std::array<float, 2> FitIterationMaxChi2 = {100, 50};
+  std::array<float, 2> FitIterationMaxChi2 = {50, 20};
 };
 
 struct MemoryParameters {

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -79,6 +79,7 @@ class TimeFrame final
   float getMinR(int layer) const { return mMinR[layer]; }
   float getMaxR(int layer) const { return mMaxR[layer]; }
   float getMSangle(int layer) const { return mMSangles[layer]; }
+  float getPhiCut(int layer) const { return mPhiCuts[layer]; }
   float getPositionResolution(int layer) const { return mPositionResolution[layer]; }
 
   gsl::span<Cluster> getClustersOnLayer(int rofId, int layerId);
@@ -123,6 +124,8 @@ class TimeFrame final
 
   int hasBogusClusters() const { return std::accumulate(mBogusClusters.begin(), mBogusClusters.end(), 0); }
 
+  void setBz(float bz) { mBz = bz; }
+
   /// Debug and printing
   void checkTrackletLUTs();
   void printROFoffsets();
@@ -141,12 +144,14 @@ class TimeFrame final
   void addTrackingFrameInfoToLayer(int layer, T&&... args);
   void addClusterExternalIndexToLayer(int layer, const int idx);
 
+  float mBz = 5.;
   int mNrof = 0;
   int mBeamPosWeight = 0;
   float mBeamPos[2] = {0.f, 0.f};
   std::vector<float> mMinR;
   std::vector<float> mMaxR;
   std::vector<float> mMSangles;
+  std::vector<float> mPhiCuts;
   std::vector<float> mPositionResolution;
   std::vector<bool> mMultiplicityCutMask;
   std::vector<int> mROframesPV = {0};

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracker.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracker.h
@@ -109,7 +109,7 @@ class Tracker
 
   bool mCUDA = false;
   bool mApplySmoothing = false;
-  o2::base::PropagatorImpl<float>::MatCorrType mCorrType = o2::base::PropagatorImpl<float>::MatCorrType::USEMatCorrLUT;
+  o2::base::PropagatorImpl<float>::MatCorrType mCorrType = o2::base::PropagatorImpl<float>::MatCorrType::USEMatCorrNONE;
   float mBz = 5.f;
   std::uint32_t mTimeFrameCounter = 0;
   o2::gpu::GPUChainITS* mRecoChain = nullptr;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracker.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Tracker.h
@@ -130,11 +130,6 @@ inline float Tracker::getBz() const
   return mBz;
 }
 
-inline void Tracker::setBz(float bz)
-{
-  mBz = bz;
-}
-
 template <typename... T>
 void Tracker::initialiseTimeFrame(T&&... args)
 {

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
@@ -44,7 +44,7 @@ struct TrackerParamConfig : public o2::conf::ConfigurableParamHelper<TrackerPara
   float sysErrZ2[7] = {0}; // systematic error^2 in Z per layer
   float nSigmaCut = -1.f;
   float deltaTanLres = -1.f;
-  float phiCut = -1.f;
+  float minPt = -1.f;
   float pvRes = -1.f;
   int LUTbinsPhi = -1;
   int LUTbinsZ = -1;

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -658,7 +658,7 @@ void Tracker::getGlobalConfiguration()
     params.PVres = tc.pvRes > 0 ? tc.pvRes : params.PVres;
     params.NSigmaCut *= tc.nSigmaCut > 0 ? tc.nSigmaCut : 1.f;
     params.CellDeltaTanLambdaSigma *= tc.deltaTanLres > 0 ? tc.deltaTanLres : 1.f;
-    params.TrackletMaxDeltaPhi *= tc.phiCut > 0 ? tc.phiCut : 1.f;
+    params.TrackletMinPt *= tc.minPt > 0 ? tc.minPt : 1.f;
     for (int iD{0}; iD < 3; ++iD) {
       params.Diamond[iD] = tc.diamondPos[iD];
     }
@@ -670,6 +670,12 @@ void Tracker::adoptTimeFrame(TimeFrame& tf)
 {
   mTimeFrame = &tf;
   mTraits->adoptTimeFrame(&tf);
+}
+
+void Tracker::setBz(float bz)
+{
+  mBz = bz;
+  mTimeFrame->setBz(bz);
 }
 
 } // namespace its

--- a/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Tracker.cxx
@@ -370,6 +370,14 @@ bool Tracker::fitTrack(TrackITSExt& track, int start, int end, int step, const f
       return false;
     }
 
+    if (mCorrType == o2::base::PropagatorF::MatCorrType::USEMatCorrNONE) {
+      float radl = 9.36f; // Radiation length of Si [cm]
+      float rho = 2.33f;  // Density of Si [g/cm^3]
+      if (!track.correctForMaterial(mTrkParams[0].LayerxX0[iLayer], mTrkParams[0].LayerxX0[iLayer] * radl * rho, true)) {
+        continue;
+      }
+    }
+
     GPUArray<float, 3> cov{trackingHit.covarianceTrackingFrame};
     cov[0] = std::hypot(cov[0], mTrkParams[0].LayerMisalignment[iLayer]);
     cov[2] = std::hypot(cov[2], mTrkParams[0].LayerMisalignment[iLayer]);

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/TrackerSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/TrackerSpec.h
@@ -49,6 +49,7 @@ class TrackerDPL : public framework::Task
  private:
   bool mIsMC = false;
   bool mRunVertexer = true;
+  float mBz = 0.f;
   std::string mMode = "sync";
   o2::itsmft::TopologyDictionary mDict;
   std::unique_ptr<o2::gpu::GPUReconstruction> mRecChain = nullptr;

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -79,9 +79,10 @@ void TrackerDPL::init(InitContext& ic)
     if (o2::utils::Str::pathExists(matLUTFile)) {
       auto* lut = o2::base::MatLayerCylSet::loadFromFile(matLUTFile);
       o2::base::Propagator::Instance()->setMatLUT(lut);
+      mTracker->setCorrType(o2::base::PropagatorImpl<float>::MatCorrType::USEMatCorrLUT);
       LOG(info) << "Loaded material LUT from " << matLUTFile;
     } else {
-      LOG(info) << "Material LUT " << matLUTFile << " file is absent, only TGeo can be used";
+      LOG(info) << "Material LUT " << matLUTFile << " file is absent, only heuristic material correction can be used";
     }
 
     std::vector<TrackingParameters> trackParams;

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -130,7 +130,7 @@ void TrackerDPL::init(InitContext& ic)
       memParams.resize(1);
       trackParams[0].MinTrackLength = 4;
       trackParams[0].TrackletMaxDeltaPhi = o2::its::constants::math::Pi * 0.5f;
-      trackParams[0].CellDeltaTanLambdaSigma *= 400;
+      trackParams[0].CellDeltaTanLambdaSigma *= 10;
       trackParams[0].PhiBins = 4;
       trackParams[0].ZBins = 16;
       trackParams[0].PVres = 1.e5f;

--- a/macro/run_trac_ca_its.C
+++ b/macro/run_trac_ca_its.C
@@ -193,7 +193,6 @@ void run_trac_ca_its(bool cosmics = false,
   std::vector<MemoryParameters> memParams(1);
   if (cosmics) {
     trackParams[0].MinTrackLength = 4;
-    trackParams[0].TrackletMaxDeltaPhi = o2::its::constants::math::Pi * 0.5f;
     trackParams[0].CellDeltaTanLambdaSigma *= 400;
     trackParams[0].PhiBins = 4;
     trackParams[0].ZBins = 16;
@@ -215,11 +214,8 @@ void run_trac_ca_its(bool cosmics = false,
     // ---
     // Uncomment for pp
     trackParams.resize(3);
-    trackParams[0].TrackletMaxDeltaPhi = 0.05f;
-    trackParams[0].DeltaROF = 0;
-    trackParams[1].CopyCuts(trackParams[0], 2.);
-    trackParams[1].DeltaROF = 0;
-    trackParams[2].CopyCuts(trackParams[1], 2.);
+    trackParams[1].TrackletMinPt = 0.2f;
+    trackParams[2].TrackletMinPt = 0.1f;
     trackParams[2].DeltaROF = 1;
     trackParams[2].MinTrackLength = 4;
     memParams.resize(3);


### PR DESCRIPTION
- SigmaTanL for cosmics set to sync_misaligned << This should mitigate the issue in the technical runs @davidrohr
- Change default for cluster studies << Minor
- Compute deltaPhi cut starting from minpt << This makes it easier to tune the cut
- Don't use TGeo as default for material correction << This change makes the tracker 4 times faster wrt LUT and it is the new default when matbut.root is not available
