### PR TITLE
ITS/MFT decoding: new error type Wrong Cable ID and protection against it

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/DecodingStat.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/DecodingStat.h
@@ -133,6 +133,7 @@ struct GBTLinkDecodingStat {
     ErrPacketDoneMissing,        // packet done is missing in the trailer while CRU page is not over
     ErrMissingDiagnosticWord,    // missing diagnostic word after RDH with stop
     ErrGBTWordNotRecognized,     // GBT word not recognized
+    ErrWrongeCableID,            // Invalid cable ID
     NErrorsDefined
   };
   static constexpr std::array<std::string_view, NErrorsDefined> ErrNames = {
@@ -154,7 +155,8 @@ struct GBTLinkDecodingStat {
     "Jump in RDH_packetCounter",                                         // ErrPacketCounterJump
     "Packet done is missing in the trailer while CRU page is not over",  // ErrPacketDoneMissing
     "Missing diagnostic GBT word after RDH with stop",                   // ErrMissingDiagnosticWord
-    "GBT word not recognized"                                            // ErrGBTWordNotRecognized
+    "GBT word not recognized",                                           // ErrGBTWordNotRecognized
+    "Wrong cable ID"                                                     // ErrWrongeCableID
   };
 
   uint32_t ruLinkID = 0; // Link ID within RU

--- a/Detectors/ITSMFT/common/reconstruction/src/DecodingStat.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/DecodingStat.cxx
@@ -107,7 +107,7 @@ void GBTLinkDecodingStat::print(bool skipNoErr) const
     rep += fmt::format(" | Decoding errors: {}", nErr);
     for (int i = 0; i < NErrorsDefined; i++) {
       if (!skipNoErr || errorCounts[i]) {
-        rep += fmt::format("{<}: {}", ErrNames[i].data(), errorCounts[i]);
+        rep += fmt::format(" [{}: {}]", ErrNames[i].data(), errorCounts[i]);
       }
     }
     LOG(important) << rep;

--- a/Detectors/ITSMFT/common/reconstruction/src/GBTLink.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/GBTLink.cxx
@@ -419,4 +419,20 @@ GBTLink::ErrorType GBTLink::checkErrorsDiagnosticWord(const GBTDiagnostic* gbtD)
   return NoError;
 }
 
+///_________________________________________________________________
+/// Check cable ID validity
+GBTLink::ErrorType GBTLink::checkErrorsCableID(const GBTData* gbtD, uint8_t cableSW)
+{
+  if (cableSW == 0xff) {
+    statistics.errorCounts[GBTLinkDecodingStat::ErrWrongeCableID]++;
+    if (needToPrintError(statistics.errorCounts[GBTLinkDecodingStat::ErrWrongeCableID])) {
+      gbtD->printX();
+      LOG(ERROR) << describe() << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrWrongeCableID] << ' ' << gbtD->getCableID();
+    }
+    errorBits |= 0x1 << int(GBTLinkDecodingStat::ErrWrongeCableID);
+    return Skip;
+  }
+  return NoError;
+}
+
 #endif


### PR DESCRIPTION
Sometimes the link sends wrong cable HW ID, not it will be reported and its data will be skipped