### PR TITLE
Making MCReplayEngine available

### DIFF
--- a/Detectors/gconfig/CMakeLists.txt
+++ b/Detectors/gconfig/CMakeLists.txt
@@ -23,16 +23,20 @@ o2_add_library(FLUKASetup
                SOURCES src/FlukaConfig.cxx
                PUBLIC_LINK_LIBRARIES FairRoot::Base O2::SimulationDataFormat O2::Generators ROOT::EGPythia6 O2::SimSetup
 	      )
-
+o2_add_library(MCReplaySetup
+               SOURCES src/MCReplayConfig.cxx
+               PUBLIC_LINK_LIBRARIES MC::MCReplay FairRoot::Base O2::SimulationDataFormat O2::Generators O2::SimSetup
+)
 o2_add_library(SimSetup
-               SOURCES  src/GlobalProcessCutSimParam.cxx src/SimSetup.cxx src/SetCuts.cxx src/FlukaParam.cxx
+               SOURCES  src/GlobalProcessCutSimParam.cxx src/SimSetup.cxx src/SetCuts.cxx src/FlukaParam.cxx src/MCReplayParam.cxx
 	       PUBLIC_LINK_LIBRARIES O2::CommonUtils O2::DetectorsBase
               )
 
 o2_target_root_dictionary(SimSetup
                           HEADERS include/SimSetup/SimSetup.h
                                   include/SimSetup/GlobalProcessCutSimParam.h
-				  include/SimSetup/FlukaParam.h
+                                  include/SimSetup/FlukaParam.h
+                                  include/SimSetup/MCReplayParam.h
                           LINKDEF src/GConfLinkDef.h)
 o2_add_test_root_macro(DecayConfig.C
                        PUBLIC_LINK_LIBRARIES O2::SimSetup
@@ -53,6 +57,10 @@ o2_add_test_root_macro(g3Config.C
                        LABELS simsetup)
 
 o2_add_test_root_macro(g4Config.C
+                       PUBLIC_LINK_LIBRARIES O2::SimSetup
+                       LABELS simsetup)
+
+o2_add_test_root_macro(mcreplayConfig.C
                        PUBLIC_LINK_LIBRARIES O2::SimSetup
                        LABELS simsetup)
 

--- a/Detectors/gconfig/include/SimSetup/MCReplayParam.h
+++ b/Detectors/gconfig/include/SimSetup/MCReplayParam.h
@@ -1,0 +1,35 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author A+Morsch
+
+#ifndef ALICEO2_EVENTGEN_MCREPLAYPARAM_H_
+#define ALICEO2_EVENTGEN_MCREPLAYPARAM_H_
+
+#include <string>
+#include "CommonUtils/ConfigurableParam.h"
+#include "CommonUtils/ConfigurableParamHelper.h"
+
+namespace o2
+{
+/**
+ ** A parameter class/struct holding values for
+ ** MCReplay Transport Code
+ **/
+struct MCReplayParam : public o2::conf::ConfigurableParamHelper<MCReplayParam> {
+  std::string stepTreename = "StepLoggerTree";          // name of the TTree containing the actual steps
+  std::string stepFilename = "MCStepLoggerOutput.root"; // filename where to find the stepTreename
+  float energyCut = -1.;                                // minimum energy required for a step to continue tracking
+  O2ParamDef(MCReplayParam, "MCReplayParam");
+};
+} // end namespace o2
+
+#endif // ALICEO2_EVENTGEN_MCREPLAYPARAM_H_

--- a/Detectors/gconfig/mcreplayConfig.C
+++ b/Detectors/gconfig/mcreplayConfig.C
@@ -1,0 +1,20 @@
+// Configuration macro for MCReplay VirtualMC
+
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include "MCReplay/MCReplayEngine.h"
+#include "SimSetup/MCReplayParam.h"
+#include "FairRunSim.h"
+#endif
+#include "commonConfig.C"
+
+void Config()
+{
+  // TString* gModel = run->GetGeoModel();
+  FairRunSim* run = FairRunSim::Instance();
+  auto* replay = new mcreplay::MCReplayEngine();
+  stackSetup(replay, run);
+  auto& params = o2::MCReplayParam::Instance();
+  replay->setStepFilename(params.stepFilename);
+  replay->setStepTreename(params.stepTreename);
+  replay->SetCut("CUTALLE", params.energyCut);
+}

--- a/Detectors/gconfig/src/GConfLinkDef.h
+++ b/Detectors/gconfig/src/GConfLinkDef.h
@@ -21,5 +21,7 @@
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::GlobalProcessCutSimParam> + ;
 #pragma link C++ class o2::FlukaParam+ ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::FlukaParam> + ;
+#pragma link C++ class o2::MCReplayParam + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::MCReplayParam> + ;
 
 #endif

--- a/Detectors/gconfig/src/MCReplayConfig.cxx
+++ b/Detectors/gconfig/src/MCReplayConfig.cxx
@@ -1,0 +1,36 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "FairRunSim.h"
+#include "MCReplay/MCReplayEngine.h"
+#include "SimSetup/MCReplayParam.h"
+#include "SimulationDataFormat/Stack.h"
+#include "SimulationDataFormat/StackParam.h"
+#include "FairLogger.h"
+#include "FairModule.h"
+#include "Generators/DecayerPythia8.h"
+
+// these are used in commonConfig.C
+using o2::eventgen::DecayerPythia8;
+
+namespace o2
+{
+namespace mcreplayconfig
+{
+#include "../mcreplayConfig.C"
+
+void MCReplayConfig()
+{
+  LOG(INFO) << "Setting up MCReplay sim from library code";
+  Config();
+}
+} // namespace mcreplayconfig
+} // namespace o2

--- a/Detectors/gconfig/src/MCReplayParam.cxx
+++ b/Detectors/gconfig/src/MCReplayParam.cxx
@@ -1,0 +1,13 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "SimSetup/MCReplayParam.h"
+O2ParamImpl(o2::MCReplayParam);

--- a/Detectors/gconfig/src/SimSetup.cxx
+++ b/Detectors/gconfig/src/SimSetup.cxx
@@ -56,6 +56,8 @@ void SimSetup::setup(const char* engine)
     setupFromPlugin("libO2G4Setup", "_ZN2o28g4config8G4ConfigEv");
   } else if (strcmp(engine, "TFluka") == 0) {
     setupFromPlugin("libO2FLUKASetup", "_ZN2o211flukaconfig11FlukaConfigEv");
+  } else if (strcmp(engine, "MCReplay") == 0) {
+    setupFromPlugin("libO2MCReplaySetup", "_ZN2o214mcreplayconfig14MCReplayConfigEv");
   } else {
     LOG(FATAL) << "Unsupported engine " << engine;
   }

--- a/dependencies/FindMCStepLogger.cmake
+++ b/dependencies/FindMCStepLogger.cmake
@@ -1,0 +1,24 @@
+# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# All rights not expressly granted are reserved.
+#
+# This software is distributed under the terms of the GNU General Public
+# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+# use the the config provided by the Geant3 installation but amend the target
+# geant321 with the include directories
+
+find_package(MCStepLogger NO_MODULE COMPONENTS MCReplayCore)
+if(NOT MCStepLogger_FOUND)
+  return()
+endif()
+
+# Promote the imported target to global visibility
+# (so we can alias it)
+set_target_properties(MCReplayCore PROPERTIES IMPORTED_GLOBAL TRUE)
+
+add_library(MC::MCReplay ALIAS MCReplayCore)

--- a/dependencies/O2SimulationDependencies.cmake
+++ b/dependencies/O2SimulationDependencies.cmake
@@ -76,6 +76,9 @@ set_package_properties(HepMC3
 		       TYPE OPTIONAL DESCRIPTION
 		       "the HepMC3 event record package")
 
+find_package(MCStepLogger MODULE)
+set_package_properties(MCStepLogger PROPERTIES TYPE ${mcPackageRequirement})
+
 set(doBuildSimulation OFF)
 
 if(pythia_FOUND

--- a/doc/DetectorSimulation.md
+++ b/doc/DetectorSimulation.md
@@ -169,7 +169,7 @@ o2-sim --embedIntoFile o2sim.background.root
 
 Background events are sampled one-by-one until all events have been used. At that point the events start to be reused.
 
-#### 5. **How can I obtain detailed stepping information?**
+#### 5. **How can I obtain detailed stepping information?** <a name="MCStepLoggerSection"></a>
 Run the simulation (currently only supported in combination with `o2-sim-serial`) with a preloaded library:
 ```
 MCSTEPLOG_TTREE=1 LD_PRELOAD=$O2_ROOT/lib/libMCStepLogger.so o2-sim-serial -j 1 -n 10
@@ -219,7 +219,19 @@ Notice that in this case the user is presented with a pointer to the event-gener
 For the sake of generality, a `void*` has to be used in order to pass any possible types of event-generators, that are
 normally othogonal one to another. The name encodes a string to identify what generator has been passed and perform the correct cast to use it.
 
+### Replaying steps and optimising full sim parameters
 
+The `MCReplay` engine can be used to replay a simulation based on steps logged by the `MCStepLogger` (see also a more [in-depth documentation](https://github.com/AliceO2Group/VMCStepLogger/tree/v0.2.0/MCReplay)).
+
+To run it with O2, first follow the steps as explained in [MCStepLoggerSection](#MCStepLoggerSection) to produce a file containing logged steps. To replay, do
+```bash
+o2-sim-serial -n <ref_nevents> -e MCReplay -g extkinO2 --extKinFile o2sim_Kine.root -o replay
+```
+It is advisory to use another output prefix as done in this case since otherwise the hit files would be overwritten which might contain exactly the information one is interested in. Make sure to use/exclude the same modules as used in the reference run (`-m` and `--skipModules` flags). In case the reference run was done with another prefix, the kinematics file name is different, namely `<prefix>_Kine.root`.
+
+If the name of the step log file is different, it can be passed with `--configKeyValues="MCReplayParam.stepFilename=<path/step/file/name>"`. It is also possible to set a minimum energy (in units of GeV) cut particles have to have when produced. For that, use `--configKeyValues="MCReplayParam.energyCut=0.1"` if everything produced below `0.1 GeV` should be dropped.
+
+Comparing the produced hits with those from the reference run it is possible to omit steps/particle production which have a negligible impact on the hits and hence on digits. As a result, the detector simulation can be tuned to be faster and more efficient.
 
 ### Deep triggers
 Deep triggers is just a name to a new functionality that allows the user to define custom functions that will have a direct handle on the event generator interface. The functionality follows the schema of the previous point, with the user providing a custom lambda function that will receive from the framework a pointer to the internal event-generator interface object (i.e. for Pythia8, a pointer to the Pythia object) and a tagname to identify the interface. This functionality might be useful to users who want to provide triggers based on information beyond the stack of the generated particles, based on more internal counters/information in the event generator machinery.

--- a/run/SimExamples/StepMonitoring/Simple1/run.sh
+++ b/run/SimExamples/StepMonitoring/Simple1/run.sh
@@ -4,4 +4,4 @@
 # alienv enter O2/latest MCStepLogger/latest
 
 # This demonstrates the most basic usage of the steplogger
-LD_PRELOAD=$MCSTEPLOGGER_ROOT/lib/libMCStepLoggerIntercept.so o2-sim-serial -n 1 -g pythia8pp -m PIPE ITS TPC
+LD_PRELOAD=$MCSTEPLOGGER_ROOT/lib/libMCStepLoggerInterceptSteps.so o2-sim-serial -n 1 -g pythia8pp -m PIPE ITS TPC


### PR DESCRIPTION
* using this engine, a reference run (e.g. GEANT3 or GEANT4) can be
  exactly repeated in terms of their stepping
  -> steps and their properties are exactly reproduced compared to the
  reference run
  -> steps are required to be recorded using the MCStepLogger

* hits of detectors using RNGs throughout the hit creation are not
  exactly reproduced when the same RNGs are also employed during
  stepping (because step simulation is omitted during replay)

  In that case, one replay based on the logged steps can be done whose
  hits can then be used as reference.

* based on the above, the replay engine can be used to optimise full
  simulation parameters such as those implemented in the GEANT VMCs.
  At the moment, a global energy cut can already be applied
  Its impact on hit creation can be investigated and an optimisation wrt
  it is already possible.
  The implementation of the full list of cut parameters supported by the
  current VMC engines is underway.

* adjust lib path in run/SimExamples/StepMonitoring/Simple1/run.sh