### PR TITLE
GPU: Add random tests + fixes to benchmark

### DIFF
--- a/GPU/GPUbenchmark/Shared/Utils.h
+++ b/GPU/GPUbenchmark/Shared/Utils.h
@@ -26,6 +26,7 @@
 #include <boost/program_options.hpp>
 #include <vector>
 #include <string>
+#include <cmath>
 #include <TTree.h>
 #include <TFile.h>
 
@@ -51,7 +52,10 @@
 enum class Test {
   Read,
   Write,
-  Copy
+  Copy,
+  RandomRead,
+  RandomWrite,
+  RandomCopy
 };
 
 inline std::ostream& operator<<(std::ostream& os, Test test)
@@ -65,6 +69,15 @@ inline std::ostream& operator<<(std::ostream& os, Test test)
       break;
     case Test::Copy:
       os << "copy";
+      break;
+    case Test::RandomRead:
+      os << "random read";
+      break;
+    case Test::RandomWrite:
+      os << "random write";
+      break;
+    case Test::RandomCopy:
+      os << "random copy";
       break;
   }
   return os;
@@ -162,35 +175,32 @@ inline float computeThroughput(Test test, float result, float chunkSizeGB, int n
 }
 
 template <class chunk_t>
-inline size_t getBufferCapacity(float chunkReservedGB)
+inline size_t getBufferCapacity(float chunkSizeGB, int prime)
 {
-  return (static_cast<size_t>(GB * chunkReservedGB) & 0xFFFFFFFFFFFFF000) / sizeof(chunk_t);
+  auto chunkCapacity = (static_cast<size_t>(GB * chunkSizeGB) & 0xFFFFFFFFFFFFF000) / sizeof(chunk_t);
+  if (!prime) {
+    return chunkCapacity;
+  } else {
+    return (chunkCapacity % prime == 0) ? (chunkCapacity - 0x1000) : chunkCapacity;
+  }
 }
 
-// LCG: https://rosettacode.org/wiki/Linear_congruential_generator
-class LCGRnd
+inline bool is_prime(const int n)
 {
- public:
-  __host__ __device__ void seed(unsigned int s) { mSeed = s; }
-
- protected:
-  __host__ __device__ LCGRnd() : mSeed{0}, mA{0}, mC{0}, mM(2147483648) {}
-  __host__ __device__ int rnd() { return (mSeed = (mA * mSeed + mC) % mM); }
-
-  int mA, mC;
-  unsigned int mM, mSeed;
-};
-
-class BSDRnd : public LCGRnd
-{
- public:
-  __host__ __device__ BSDRnd()
-  {
-    mA = 1103515245;
-    mC = 12345;
+  bool isPrime = true;
+  if (n == 0 || n == 1) {
+    isPrime = false;
+  } else {
+    for (int i = 2; i <= sqrt(n); ++i) {
+      if (n % i == 0) {
+        isPrime = false;
+        break;
+      }
+    }
   }
-  __host__ __device__ int rnd() { return LCGRnd::rnd(); }
-};
+
+  return isPrime;
+}
 
 namespace o2
 {
@@ -213,6 +223,7 @@ struct benchmarkOpts {
   int kernelLaunches = 1;
   int nTests = 1;
   int streams = 8;
+  int prime = 0;
   std::string outFileName = "benchmark_result";
   bool dumpChunks = false;
 };
@@ -222,11 +233,6 @@ struct gpuState {
   int getMaxChunks()
   {
     return (double)scratchSize / (chunkReservedGB * GB);
-  }
-
-  size_t getChunkCapacity()
-  {
-    return getBufferCapacity<chunk_t>(chunkReservedGB);
   }
 
   int getNKernelLaunches() { return iterations; }

--- a/GPU/GPUbenchmark/cuda/Kernels.cu
+++ b/GPU/GPUbenchmark/cuda/Kernels.cu
@@ -284,7 +284,7 @@ __global__ void rand_copy_dist_k(
   size_t n = block_size[blockIdx.x];
   size_t offset = n / 2;
   for (size_t i = threadIdx.x; i < offset; i += blockDim.x) {
-    ptr[(i * prime) % offset] = chunkPtr[offset + (i * prime) % offset];
+    ptr[(i * prime) % offset] = ptr[offset + (i * prime) % offset];
   }
 }
 } // namespace gpu

--- a/GPU/GPUbenchmark/cuda/Kernels.cu
+++ b/GPU/GPUbenchmark/cuda/Kernels.cu
@@ -130,14 +130,50 @@ __global__ void copy_k(
 template <class chunk_t>
 __global__ void rand_read_k(
   chunk_t* chunkPtr,
-  size_t chunkSize)
+  size_t chunkSize,
+  int prime)
 {
   chunk_t sink{0};
-  BSDRnd r{};
-  for (size_t i = threadIdx.x; i < chunkSize; i += blockDim.x) {
-    sink = chunkPtr[i];
+  for (size_t i = blockIdx.x * blockDim.x + threadIdx.x; i < chunkSize; i += blockDim.x * gridDim.x) {
+    sink += chunkPtr[(i * prime) % chunkSize];
   }
-  chunkPtr[threadIdx.x] = sink; // writing done once
+  chunkPtr[threadIdx.x] = sink;
+}
+
+// Random write
+template <class chunk_t>
+__global__ void rand_write_k(
+  chunk_t* chunkPtr,
+  size_t chunkSize,
+  int prime)
+{
+  for (size_t i = blockIdx.x * blockDim.x + threadIdx.x; i < chunkSize; i += blockDim.x * gridDim.x) {
+    chunkPtr[(i * prime) % chunkSize] = 0;
+  }
+}
+
+template <>
+__global__ void rand_write_k(
+  int4* chunkPtr,
+  size_t chunkSize,
+  int prime)
+{
+  for (size_t i = blockIdx.x * blockDim.x + threadIdx.x; i < chunkSize; i += blockDim.x * gridDim.x) {
+    chunkPtr[(i * prime) % chunkSize] = {0, 1, 0, 0};
+  };
+}
+
+// Random copy
+template <class chunk_t>
+__global__ void rand_copy_k(
+  chunk_t* chunkPtr,
+  size_t chunkSize,
+  int prime)
+{
+  size_t offset = chunkSize / 2;
+  for (size_t i = blockIdx.x * blockDim.x + threadIdx.x; i < offset; i += blockDim.x * gridDim.x) {
+    chunkPtr[(i * prime) % offset] = chunkPtr[offset + (i * prime) % offset]; // might be % = 0...
+  }
 }
 
 // Distributed read
@@ -198,10 +234,59 @@ __global__ void copy_dist_k(
 template <class chunk_t>
 __global__ void rand_read_dist_k(
   chunk_t** block_ptr,
-  size_t* block_size)
+  size_t* block_size,
+  int prime)
 {
+  chunk_t sink{0};
+  chunk_t* ptr = block_ptr[blockIdx.x];
+  size_t n = block_size[blockIdx.x];
+  for (size_t i = threadIdx.x; i < n; i += blockDim.x) {
+    sink += ptr[(i * prime) % n];
+  }
+  ptr[threadIdx.x] = sink;
 }
 
+// Distributed Random write
+template <class chunk_t>
+__global__ void rand_write_dist_k(
+  chunk_t** block_ptr,
+  size_t* block_size,
+  int prime)
+{
+  chunk_t* ptr = block_ptr[blockIdx.x];
+  size_t n = block_size[blockIdx.x];
+  for (size_t i = threadIdx.x; i < n; i += blockDim.x) {
+    ptr[(i * prime) % n] = 0;
+  }
+}
+
+template <>
+__global__ void rand_write_dist_k(
+  int4** block_ptr,
+  size_t* block_size,
+  int prime)
+{
+  int4* ptr = block_ptr[blockIdx.x];
+  size_t n = block_size[blockIdx.x];
+  for (size_t i = threadIdx.x; i < n; i += blockDim.x) {
+    ptr[(i * prime) % n] = {0, 1, 0, 0};
+  }
+}
+
+// Distributed Random copy
+template <class chunk_t>
+__global__ void rand_copy_dist_k(
+  chunk_t** block_ptr,
+  size_t* block_size,
+  int prime)
+{
+  chunk_t* ptr = block_ptr[blockIdx.x];
+  size_t n = block_size[blockIdx.x];
+  size_t offset = n / 2;
+  for (size_t i = threadIdx.x; i < offset; i += blockDim.x) {
+    ptr[(i * prime) % offset] = chunkPtr[offset + (i * prime) % offset];
+  }
+}
 } // namespace gpu
 
 void printDeviceProp(int deviceId)
@@ -342,14 +427,14 @@ float GPUbenchmark<chunk_t>::runSequential(void (*kernel)(chunk_t*, size_t, T...
   chunk_t* chunkPtr = getCustomPtr<chunk_t>(mState.scratchPtr, chunk.first);
 
   // Warm up
-  (*kernel)<<<nBlocks, nThreads, 0, stream>>>(chunkPtr, getBufferCapacity<chunk_t>(chunk.second), args...);
+  (*kernel)<<<nBlocks, nThreads, 0, stream>>>(chunkPtr, getBufferCapacity<chunk_t>(chunk.second, mOptions.prime), args...);
 
   GPUCHECK(cudaEventCreate(&start));
   GPUCHECK(cudaEventCreate(&stop));
 
   GPUCHECK(cudaEventRecord(start));
-  for (auto iLaunch{0}; iLaunch < nLaunches; ++iLaunch) {                                                     // Schedule all the requested kernel launches
-    (*kernel)<<<nBlocks, nThreads, 0, stream>>>(chunkPtr, getBufferCapacity<chunk_t>(chunk.second), args...); // NOLINT: clang-tidy false-positive
+  for (auto iLaunch{0}; iLaunch < nLaunches; ++iLaunch) {                                                                     // Schedule all the requested kernel launches
+    (*kernel)<<<nBlocks, nThreads, 0, stream>>>(chunkPtr, getBufferCapacity<chunk_t>(chunk.second, mOptions.prime), args...); // NOLINT: clang-tidy false-positive
   }
   GPUCHECK(cudaEventRecord(stop));      // record checkpoint
   GPUCHECK(cudaEventSynchronize(stop)); // synchronize executions
@@ -389,7 +474,7 @@ std::vector<float> GPUbenchmark<chunk_t>::runConcurrent(void (*kernel)(chunk_t*,
   for (auto iChunk{0}; iChunk < nChunks; ++iChunk) {
     auto& chunk = chunkRanges[iChunk];
     chunk_t* chunkPtr = getCustomPtr<chunk_t>(mState.scratchPtr, chunk.first);
-    (*kernel)<<<nBlocks, nThreads, 0, streams[iChunk % dimStreams]>>>(chunkPtr, getBufferCapacity<chunk_t>(chunk.second), args...);
+    (*kernel)<<<nBlocks, nThreads, 0, streams[iChunk % dimStreams]>>>(chunkPtr, getBufferCapacity<chunk_t>(chunk.second, mOptions.prime), args...);
   }
   auto start = std::chrono::high_resolution_clock::now();
 
@@ -398,7 +483,7 @@ std::vector<float> GPUbenchmark<chunk_t>::runConcurrent(void (*kernel)(chunk_t*,
     chunk_t* chunkPtr = getCustomPtr<chunk_t>(mState.scratchPtr, chunk.first);
     GPUCHECK(cudaEventRecord(starts[iChunk], streams[iChunk % dimStreams]));
     for (auto iLaunch{0}; iLaunch < nLaunches; ++iLaunch) {
-      (*kernel)<<<nBlocks, nThreads, 0, streams[iChunk % dimStreams]>>>(chunkPtr, getBufferCapacity<chunk_t>(chunk.second), args...);
+      (*kernel)<<<nBlocks, nThreads, 0, streams[iChunk % dimStreams]>>>(chunkPtr, getBufferCapacity<chunk_t>(chunk.second, mOptions.prime), args...);
     }
     GPUCHECK(cudaEventRecord(stops[iChunk], streams[iChunk % dimStreams]));
   }
@@ -450,7 +535,7 @@ float GPUbenchmark<chunk_t>::runDistributed(void (*kernel)(chunk_t**, size_t*, T
     for (int iBlock{0}; iBlock < blocksPerChunk; ++iBlock, ++index) {
       float memPerBlock = chunkRanges[iChunk].second / blocksPerChunk;
       ptrPerBlocks[index] = getCustomPtr<chunk_t>(chunkPtrs[iChunk], iBlock * memPerBlock);
-      perBlockCapacity[index] = getBufferCapacity<chunk_t>(memPerBlock);
+      perBlockCapacity[index] = getBufferCapacity<chunk_t>(memPerBlock, mOptions.prime);
     }
   }
 
@@ -575,10 +660,11 @@ void GPUbenchmark<chunk_t>::runTest(Test test, Mode mode, KernelConfig config)
   }
   nThreads *= mOptions.threadPoolFraction;
 
-  auto capacity{mState.getChunkCapacity()};
-
   void (*kernel)(chunk_t*, size_t);
   void (*kernel_distributed)(chunk_t**, size_t*);
+  void (*kernel_rand)(chunk_t*, size_t, int);
+  void (*kernel_rand_distributed)(chunk_t**, size_t*, int);
+  bool is_random{false};
 
   if (mode != Mode::Distributed) {
     switch (test) {
@@ -592,6 +678,21 @@ void GPUbenchmark<chunk_t>::runTest(Test test, Mode mode, KernelConfig config)
       }
       case Test::Copy: {
         kernel = &gpu::copy_k<chunk_t>;
+        break;
+      }
+      case Test::RandomRead: {
+        kernel_rand = &gpu::rand_read_k<chunk_t>;
+        is_random = true;
+        break;
+      }
+      case Test::RandomWrite: {
+        kernel_rand = &gpu::rand_write_k<chunk_t>;
+        is_random = true;
+        break;
+      }
+      case Test::RandomCopy: {
+        kernel_rand = &gpu::rand_copy_k<chunk_t>;
+        is_random = true;
         break;
       }
     }
@@ -609,6 +710,21 @@ void GPUbenchmark<chunk_t>::runTest(Test test, Mode mode, KernelConfig config)
         kernel_distributed = &gpu::copy_dist_k<chunk_t>;
         break;
       }
+      case Test::RandomRead: {
+        kernel_rand_distributed = &gpu::rand_read_dist_k<chunk_t>;
+        is_random = true;
+        break;
+      }
+      case Test::RandomWrite: {
+        kernel_rand_distributed = &gpu::rand_write_dist_k<chunk_t>;
+        is_random = true;
+        break;
+      }
+      case Test::RandomCopy: {
+        kernel_rand_distributed = &gpu::rand_copy_dist_k<chunk_t>;
+        is_random = true;
+        break;
+      }
     }
   }
 
@@ -620,28 +736,51 @@ void GPUbenchmark<chunk_t>::runTest(Test test, Mode mode, KernelConfig config)
       std::cout << "   │   - per chunk throughput:\n";
       for (auto iChunk{0}; iChunk < mState.testChunks.size(); ++iChunk) { // loop over single chunks separately
         auto& chunk = mState.testChunks[iChunk];
-        auto result = runSequential(kernel,
-                                    chunk,
-                                    mState.getNKernelLaunches(),
-                                    nBlocks,
-                                    nThreads);
-        auto throughput = computeThroughput(test, result, chunk.second, mState.getNKernelLaunches());
+        float result{0.f};
+        if (!is_random) {
+          result = runSequential(kernel,
+                                 chunk,
+                                 mState.getNKernelLaunches(),
+                                 nBlocks,
+                                 nThreads);
+        } else {
+          result = runSequential(kernel_rand,
+                                 chunk,
+                                 mState.getNKernelLaunches(),
+                                 nBlocks,
+                                 nThreads,
+                                 mOptions.prime);
+        }
+        float chunkSize = getBufferCapacity<chunk_t>(chunk.second, mOptions.prime) * sizeof(chunk_t) / GB;
+        auto throughput = computeThroughput(test, result, chunkSize, mState.getNKernelLaunches());
         std::cout << "   │     " << ((mState.testChunks.size() - iChunk != 1) ? "├ " : "└ ") << iChunk + 1 << "/" << mState.testChunks.size()
                   << ": [" << chunk.first << "-" << chunk.first + chunk.second << ") \e[1m" << throughput << " GB/s \e[0m(" << result * 1e-3 << " s)\n";
         mResultWriter.get()->storeBenchmarkEntry(test, iChunk, result, chunk.second, mState.getNKernelLaunches());
       }
     } else if (mode == Mode::Concurrent) {
       std::cout << "   │   - per chunk throughput:\n";
-      auto results = runConcurrent(kernel,
-                                   mState.testChunks,
-                                   mState.getNKernelLaunches(),
-                                   mState.getStreamsPoolSize(),
-                                   nBlocks,
-                                   nThreads);
+      std::vector<float> results;
+      if (!is_random) {
+        results = runConcurrent(kernel,
+                                mState.testChunks,
+                                mState.getNKernelLaunches(),
+                                mState.getStreamsPoolSize(),
+                                nBlocks,
+                                nThreads);
+      } else {
+        results = runConcurrent(kernel_rand,
+                                mState.testChunks,
+                                mState.getNKernelLaunches(),
+                                mState.getStreamsPoolSize(),
+                                nBlocks,
+                                nThreads,
+                                mOptions.prime);
+      }
       float sum{0};
       for (auto iChunk{0}; iChunk < mState.testChunks.size(); ++iChunk) {
         auto& chunk = mState.testChunks[iChunk];
-        auto throughput = computeThroughput(test, results[iChunk], chunk.second, mState.getNKernelLaunches());
+        float chunkSize = getBufferCapacity<chunk_t>(chunk.second, mOptions.prime) * sizeof(chunk_t) / GB;
+        auto throughput = computeThroughput(test, results[iChunk], chunkSize, mState.getNKernelLaunches());
         sum += throughput;
         std::cout << "   │     " << ((mState.testChunks.size() - iChunk != 1) ? "├ " : "└ ") << iChunk + 1 << "/" << mState.testChunks.size()
                   << ": [" << chunk.first << "-" << chunk.first + chunk.second << ") \e[1m" << throughput << " GB/s \e[0m(" << results[iChunk] * 1e-3 << " s)\n";
@@ -660,14 +799,25 @@ void GPUbenchmark<chunk_t>::runTest(Test test, Mode mode, KernelConfig config)
       std::cout << "   │   - total throughput with host time: \e[1m" << computeThroughput(test, results[mState.testChunks.size()], tot, mState.getNKernelLaunches())
                 << " GB/s \e[0m (" << std::setw(2) << results[mState.testChunks.size()] / 1000 << " s)" << std::endl;
     } else if (mode == Mode::Distributed) {
-      auto result = runDistributed(kernel_distributed,
-                                   mState.testChunks,
-                                   mState.getNKernelLaunches(),
-                                   nBlocks,
-                                   nThreads);
+      float result{0.f};
+      if (!is_random) {
+        result = runDistributed(kernel_distributed,
+                                mState.testChunks,
+                                mState.getNKernelLaunches(),
+                                nBlocks,
+                                nThreads);
+      } else {
+        result = runDistributed(kernel_rand_distributed,
+                                mState.testChunks,
+                                mState.getNKernelLaunches(),
+                                nBlocks,
+                                nThreads,
+                                mOptions.prime);
+      }
       float tot{0};
       for (auto& chunk : mState.testChunks) {
-        tot += chunk.second;
+        float chunkSize = getBufferCapacity<chunk_t>(chunk.second, mOptions.prime) * sizeof(chunk_t) / GB;
+        tot += chunkSize;
       }
       auto throughput = computeThroughput(test, result, tot, mState.getNKernelLaunches());
       std::cout << "   │     └ throughput: \e[1m" << throughput << " GB/s \e[0m(" << result * 1e-3 << " s)\n";

--- a/GPU/GPUbenchmark/cuda/benchmark.cu
+++ b/GPU/GPUbenchmark/cuda/benchmark.cu
@@ -13,7 +13,7 @@
 ///
 
 #include "../Shared/Kernels.h"
-#define VERSION "version 0.2"
+#define VERSION "version 0.3"
 
 bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
 {
@@ -36,8 +36,9 @@ bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
     "mode,m", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"seq", "con", "dis"}, "seq con dis"), "Mode: sequential, concurrent or distributed.")(
     "nruns,n", bpo::value<int>()->default_value(1), "Number of times each test is run.")(
     "outfile,o", bpo::value<std::string>()->default_value("benchmark_result"), "Output file name to store results.")(
+    "prime,p", bpo::value<int>()->default_value(0), "Prime number to be used for the test.")(
     "streams,s", bpo::value<int>()->default_value(8), "Size of the pool of streams available for concurrent tests.")(
-    "test,t", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"read", "write", "copy"}, "read write copy"), "Tests to be performed.")(
+    "test,t", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"read", "write", "copy", "rread", "rwrite", "rcopy"}, "read write copy rread rwrite rcopy"), "Tests to be performed.")(
     "version,v", "Print version.")(
     "extra,x", "Print extra info for each available device.");
   try {
@@ -81,6 +82,11 @@ bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
   conf.kernelLaunches = vm["launches"].as<int>();
   conf.nTests = vm["nruns"].as<int>();
   conf.streams = vm["streams"].as<int>();
+  conf.prime = vm["prime"].as<int>();
+  if ((conf.prime > 0 && !is_prime(conf.prime))) {
+    std::cerr << "Invalid prime number: " << conf.prime << std::endl;
+    exit(1);
+  }
 
   conf.tests.clear();
   for (auto& test : vm["test"].as<std::vector<std::string>>()) {
@@ -90,6 +96,24 @@ bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
       conf.tests.push_back(Test::Write);
     } else if (test == "copy") {
       conf.tests.push_back(Test::Copy);
+    } else if (test == "rread") {
+      if (!vm["prime"].as<int>()) {
+        std::cerr << "Prime number must be specified for rread test." << std::endl;
+        exit(1);
+      }
+      conf.tests.push_back(Test::RandomRead);
+    } else if (test == "rwrite") {
+      if (!vm["prime"].as<int>()) {
+        std::cerr << "Prime number must be specified for rwrite test." << std::endl;
+        exit(1);
+      }
+      conf.tests.push_back(Test::RandomWrite);
+    } else if (test == "rcopy") {
+      if (!vm["prime"].as<int>()) {
+        std::cerr << "Prime number must be specified for rcopy test." << std::endl;
+        exit(1);
+      }
+      conf.tests.push_back(Test::RandomCopy);
     } else {
       std::cerr << "Unkonwn test: " << test << std::endl;
       exit(1);


### PR DESCRIPTION
@davidrohr : will double check later, but in case you want to have a look.

E.G.
```bash
[O2/latest-dev-o2] /tmp $> o2-gpu-memory-benchmark-hip -a 0.5:15 -b cb -k int4 -l 100 -m dis -g 60 -p137
 ◈ Running on: Vega 20
   ├ Buffer type: int4
   ├ Allocated: 30/32(GB) [95%]
   └ Available streams: 8

 ◈ int4 read benchmark with 1 runs and 100 kernel launches
   ├ distributed read manual block(s) (1/1): 
   │   - blocks per kernel: 60/60
   │   - threads per block: 1024
   │     └ throughput: **708 GB/s** (2.12 s)
   └ done
 ◈ int4 write benchmark with 1 runs and 100 kernel launches
   ├ distributed write manual block(s) (1/1): 
   │   - blocks per kernel: 60/60
   │   - threads per block: 1024
   │     └ throughput: **277 GB/s** (5.41 s)
   └ done
 ◈ int4 copy benchmark with 1 runs and 100 kernel launches
   ├ distributed copy manual block(s) (1/1): 
   │   - blocks per kernel: 60/60
   │   - threads per block: 1024
   │     └ throughput: **675 GB/s** (2.22 s)
   └ done
 ◈ int4 random read benchmark with 1 runs and 100 kernel launches
   ├ distributed random read manual block(s) (1/1): 
   │   - blocks per kernel: 60/60
   │   - threads per block: 1024
   │     └ throughput: **106 GB/s** (14.1 s)
   └ done
 ◈ int4 random write benchmark with 1 runs and 100 kernel launches
   ├ distributed random write manual block(s) (1/1): 
   │   - blocks per kernel: 60/60
   │   - threads per block: 1024
   │     └ throughput: **44.4 GB/s** (33.8 s)
   └ done
 ◈ int4 random copy benchmark with 1 runs and 100 kernel launches
   ├ distributed random copy manual block(s) (1/1): 
   │   - blocks per kernel: 60/60
   │   - threads per block: 1024
   │     └ throughput: **59.5 GB/s** (25.2 s)
   └ done
```
I am a bit unsure on the copy kernel.


   
   