### PR TITLE
DPL: introduce sending policy

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -36,6 +36,7 @@ o2_add_library(Framework
                        src/ControlService.cxx
                        src/ControlServiceHelpers.cxx
                        src/DispatchPolicy.cxx
+                       src/DataSender.cxx
                        src/ProcessingPoliciesHelpers.cxx
                        src/ConfigParamStore.cxx
                        src/ConfigParamsHelper.cxx
@@ -97,6 +98,7 @@ o2_add_library(Framework
                        src/ResourcesMonitoringHelper.cxx
                        src/ResourcePolicy.cxx
                        src/ResourcePolicyHelpers.cxx
+                       src/SendingPolicy.cxx
                        src/ServiceRegistry.cxx
                        src/SimpleResourceManager.cxx
                        src/SimpleRawDeviceService.cxx

--- a/Framework/Core/include/Framework/CommonServices.h
+++ b/Framework/Core/include/Framework/CommonServices.h
@@ -63,6 +63,7 @@ struct CommonServices {
   static ServiceSpec callbacksSpec();
   static ServiceSpec timesliceIndex();
   static ServiceSpec dataRelayer();
+  static ServiceSpec dataSender();
   static ServiceSpec tracingSpec();
   static ServiceSpec threadPool(int numWorkers);
   static ServiceSpec dataProcessingStats();

--- a/Framework/Core/include/Framework/DataProcessor.h
+++ b/Framework/Core/include/Framework/DataProcessor.h
@@ -22,14 +22,15 @@ class ArrowContext;
 class RawBufferContext;
 class ServiceRegistry;
 class DeviceState;
+class DataSender;
 
 /// Helper class to send messages from a contex at the end
 /// of a computation.
 struct DataProcessor {
-  static void doSend(FairMQDevice&, MessageContext&, ServiceRegistry&);
-  static void doSend(FairMQDevice&, StringContext&, ServiceRegistry&);
-  static void doSend(FairMQDevice&, ArrowContext&, ServiceRegistry&);
-  static void doSend(FairMQDevice&, RawBufferContext&, ServiceRegistry&);
+  static void doSend(DataSender&, MessageContext&, ServiceRegistry&);
+  static void doSend(DataSender&, StringContext&, ServiceRegistry&);
+  static void doSend(DataSender&, ArrowContext&, ServiceRegistry&);
+  static void doSend(DataSender&, RawBufferContext&, ServiceRegistry&);
 };
 
 } // namespace o2::framework

--- a/Framework/Core/include/Framework/DataSender.h
+++ b/Framework/Core/include/Framework/DataSender.h
@@ -1,0 +1,40 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef O2_FRAMEWORK_DATASENDER_H_
+#define O2_FRAMEWORK_DATASENDER_H_
+
+#include "Framework/SendingPolicy.h"
+#include <fairmq/FairMQParts.h>
+#include <string>
+
+namespace o2::framework
+{
+
+struct ServiceRegistry;
+
+/// Allow injecting policies on send
+class DataSender
+{
+ public:
+  DataSender(ServiceRegistry& registry,
+             SendingPolicy const& policy);
+  void send(FairMQParts&, std::string const& s);
+  std::unique_ptr<FairMQMessage> create();
+
+ private:
+  void* mContext;
+  ServiceRegistry& mRegistry;
+  SendingPolicy mPolicy;
+};
+
+} // namespace o2::framework
+
+#endif // O2_FRAMEWORK_DATASENDER_H_

--- a/Framework/Core/include/Framework/DeviceSpec.h
+++ b/Framework/Core/include/Framework/DeviceSpec.h
@@ -27,6 +27,7 @@
 #include "Framework/CompletionPolicy.h"
 #include "Framework/DispatchPolicy.h"
 #include "Framework/ResourcePolicy.h"
+#include "Framework/SendingPolicy.h"
 #include "Framework/ServiceSpec.h"
 
 #include <vector>
@@ -66,6 +67,7 @@ struct DeviceSpec {
   CompletionPolicy completionPolicy;
   DispatchPolicy dispatchPolicy;
   CallbacksPolicy callbacksPolicy;
+  SendingPolicy sendingPolicy;
   /// Policy on when the available resources are enough to run
   /// a computation.
   ResourcePolicy resourcePolicy;

--- a/Framework/Core/include/Framework/DriverInfo.h
+++ b/Framework/Core/include/Framework/DriverInfo.h
@@ -26,6 +26,7 @@
 #include "Framework/DispatchPolicy.h"
 #include "Framework/DeviceMetricsInfo.h"
 #include "Framework/LogParsingHelpers.h"
+#include "Framework/SendingPolicy.h"
 #include "DataProcessorInfo.h"
 #include "ResourcePolicy.h"
 
@@ -103,6 +104,10 @@ struct DriverInfo {
   /// These are the policies which can be applied to decide when there
   /// is enough resources to process data.
   std::vector<ResourcePolicy> resourcePolicies;
+
+  /// These are the policies which can be applied to decide how
+  /// we send data.
+  std::vector<SendingPolicy> sendingPolicies;
   /// The argc with which the driver was started.
   int argc;
   /// The argv with which the driver was started.

--- a/Framework/Core/include/Framework/SendingPolicy.h
+++ b/Framework/Core/include/Framework/SendingPolicy.h
@@ -1,0 +1,33 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef O2_FRAMEWORK_SENDINGPOLICY_H_
+#define O2_FRAMEWORK_SENDINGPOLICY_H_
+
+#include "Framework/DataProcessorMatchers.h"
+#include <fairmq/FwdDecls.h>
+#include <vector>
+#include <functional>
+#include <string>
+
+namespace o2::framework
+{
+
+struct SendingPolicy {
+  using SendingCallback = std::function<void(FairMQDevice&, FairMQParts&, std::string const& channel)>;
+  std::string name = "invalid";
+  DeviceMatcher matcher = nullptr;
+  SendingCallback send = nullptr;
+  static std::vector<SendingPolicy> createDefaultPolicies();
+};
+
+} // namespace o2::framework
+
+#endif // O2_FRAMEWORK_SENDINGPOLICY_H_

--- a/Framework/Core/include/Framework/runDataProcessing.h
+++ b/Framework/Core/include/Framework/runDataProcessing.h
@@ -18,6 +18,7 @@
 #include "Framework/DispatchPolicy.h"
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/DataAllocator.h"
+#include "Framework/SendingPolicy.h"
 #include "Framework/WorkflowSpec.h"
 #include "Framework/ConfigContext.h"
 #include "Framework/BoostOptionsRetriever.h"
@@ -97,6 +98,7 @@ void defaultConfiguration(std::vector<o2::framework::ServiceSpec>& services)
 }
 
 void defaultConfiguration(std::vector<o2::framework::CallbacksPolicy>& callbacksPolicies) {}
+void defaultConfiguration(std::vector<o2::framework::SendingPolicy>& callbacksPolicies) {}
 
 /// Workflow options which are required by DPL in order to work.
 std::vector<o2::framework::ConfigParamSpec> requiredWorkflowOptions();
@@ -141,6 +143,7 @@ int doMain(int argc, char** argv, o2::framework::WorkflowSpec const& specs,
            std::vector<o2::framework::DispatchPolicy> const& dispatchPolicies,
            std::vector<o2::framework::ResourcePolicy> const& resourcePolicies,
            std::vector<o2::framework::CallbacksPolicy> const& callbacksPolicies,
+           std::vector<o2::framework::SendingPolicy> const& sendingPolicies,
            std::vector<o2::framework::ConfigParamSpec> const& workflowOptions,
            o2::framework::ConfigContext& configContext);
 
@@ -188,6 +191,11 @@ int mainNoCatch(int argc, char** argv)
   auto defaultCallbacksPolicies = CallbacksPolicy::createDefaultPolicies();
   callbacksPolicies.insert(std::end(callbacksPolicies), std::begin(defaultCallbacksPolicies), std::end(defaultCallbacksPolicies));
 
+  std::vector<SendingPolicy> sendingPolicies;
+  UserCustomizationsHelper::userDefinedCustomization(sendingPolicies, 0);
+  auto defaultSendingPolicies = SendingPolicy::createDefaultPolicies();
+  sendingPolicies.insert(std::end(sendingPolicies), std::begin(defaultSendingPolicies), std::end(defaultSendingPolicies));
+
   std::vector<std::unique_ptr<ParamRetriever>> retrievers;
   std::unique_ptr<ParamRetriever> retriever{new BoostOptionsRetriever(true, argc, argv)};
   retrievers.emplace_back(std::move(retriever));
@@ -209,7 +217,7 @@ int mainNoCatch(int argc, char** argv)
   channelPolicies.insert(std::end(channelPolicies), std::begin(defaultChannelPolicies), std::end(defaultChannelPolicies));
   return doMain(argc, argv, specs,
                 channelPolicies, completionPolicies, dispatchPolicies,
-                resourcePolicies, callbacksPolicies, workflowOptions, configContext);
+                resourcePolicies, callbacksPolicies, sendingPolicies, workflowOptions, configContext);
 }
 
 int main(int argc, char** argv)

--- a/Framework/Core/src/CommonMessageBackendsHelpers.h
+++ b/Framework/Core/src/CommonMessageBackendsHelpers.h
@@ -13,6 +13,10 @@
 
 #include "Framework/RawDeviceService.h"
 #include "Framework/DataProcessor.h"
+#include "Framework/DataSender.h"
+#include "Framework/ProcessingContext.h"
+#include "Framework/EndOfStreamContext.h"
+#include "Framework/FairMQDeviceProxy.h"
 #include "Framework/ServiceRegistry.h"
 #include "Framework/Tracing.h"
 
@@ -36,8 +40,7 @@ struct CommonMessageBackendsHelpers {
     return [](ProcessingContext& ctx, void* service) {
       ZoneScopedN("send message callback");
       T* context = reinterpret_cast<T*>(service);
-      auto& device = ctx.services().get<RawDeviceService>();
-      DataProcessor::doSend(*device.device(), *context, ctx.services());
+      DataProcessor::doSend(ctx.services().get<DataSender>(), *context, ctx.services());
     };
   }
 
@@ -61,8 +64,7 @@ struct CommonMessageBackendsHelpers {
   {
     return [](EndOfStreamContext& ctx, void* service) {
       T* context = reinterpret_cast<T*>(service);
-      auto& device = ctx.services().get<RawDeviceService>();
-      DataProcessor::doSend(*device.device(), *context, ctx.services());
+      DataProcessor::doSend(ctx.services().get<DataSender>(), *context, ctx.services());
     };
   }
 };

--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -16,6 +16,7 @@
 #include "Framework/ServiceSpec.h"
 #include "Framework/TimesliceIndex.h"
 #include "Framework/DataTakingContext.h"
+#include "Framework/DataSender.h"
 #include "Framework/ServiceRegistry.h"
 #include "Framework/DeviceSpec.h"
 #include "Framework/LocalRootFileService.h"
@@ -399,6 +400,19 @@ o2::framework::ServiceSpec CommonServices::dataRelayer()
     .kind = ServiceKind::Serial};
 }
 
+o2::framework::ServiceSpec CommonServices::dataSender()
+{
+  return ServiceSpec{
+    .name = "datasender",
+    .init = [](ServiceRegistry& services, DeviceState&, fair::mq::ProgOptions& options) -> ServiceHandle {
+      auto& spec = services.get<DeviceSpec const>();
+      return ServiceHandle{TypeIdHelpers::uniqueId<DataSender>(),
+                           new DataSender(services, spec.sendingPolicy)};
+    },
+    .configure = noConfiguration(),
+    .kind = ServiceKind::Serial};
+}
+
 struct TracingInfrastructure {
   int processingCount;
 };
@@ -615,6 +629,7 @@ std::vector<ServiceSpec> CommonServices::defaultServices(int numThreads)
     parallelSpec(),
     callbacksSpec(),
     dataRelayer(),
+    dataSender(),
     dataProcessingStats(),
     CommonMessageBackends::fairMQBackendSpec(),
     ArrowSupport::arrowBackendSpec(),

--- a/Framework/Core/src/DataSender.cxx
+++ b/Framework/Core/src/DataSender.cxx
@@ -1,0 +1,41 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/DataSender.h"
+#include "Framework/ServiceRegistry.h"
+#include "Framework/RawDeviceService.h"
+
+#include <fairmq/Device.h>
+
+namespace o2::framework
+{
+
+DataSender::DataSender(ServiceRegistry& registry,
+                       SendingPolicy const& policy)
+  : mContext{registry.get<RawDeviceService>().device()},
+    mRegistry{registry},
+    mPolicy{policy}
+{
+}
+
+std::unique_ptr<FairMQMessage> DataSender::create()
+{
+  FairMQDevice* device = (FairMQDevice*)mContext;
+  return device->NewMessage();
+}
+
+void DataSender::send(FairMQParts& parts, std::string const& channel)
+{
+  FairMQDevice* device = (FairMQDevice*)mContext;
+  mPolicy.send(*device, parts, channel);
+}
+
+} // namespace o2::framework

--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -823,6 +823,7 @@ void DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(const WorkflowSpec& workf
                                                        std::vector<DispatchPolicy> const& dispatchPolicies,
                                                        std::vector<ResourcePolicy> const& resourcePolicies,
                                                        std::vector<CallbacksPolicy> const& callbacksPolicies,
+                                                       std::vector<SendingPolicy> const& sendingPolicies,
                                                        std::vector<DeviceSpec>& devices,
                                                        ResourceManager& resourceManager,
                                                        std::string const& uniqueWorkflowId,
@@ -905,6 +906,12 @@ void DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs(const WorkflowSpec& workf
     for (auto& policy : callbacksPolicies) {
       if (policy.matcher(device, configContext) == true) {
         device.callbacksPolicy = policy;
+        break;
+      }
+    }
+    for (auto& policy : sendingPolicies) {
+      if (policy.matcher(device, configContext) == true) {
+        device.sendingPolicy = policy;
         break;
       }
     }

--- a/Framework/Core/src/DeviceSpecHelpers.h
+++ b/Framework/Core/src/DeviceSpecHelpers.h
@@ -52,6 +52,7 @@ struct DeviceSpecHelpers {
     std::vector<DispatchPolicy> const& dispatchPolicies,
     std::vector<ResourcePolicy> const& resourcePolicies,
     std::vector<CallbacksPolicy> const& callbacksPolicies,
+    std::vector<SendingPolicy> const& sendingPolicy,
     std::vector<DeviceSpec>& devices,
     ResourceManager& resourceManager,
     std::string const& uniqueWorkflowId,
@@ -75,8 +76,10 @@ struct DeviceSpecHelpers {
   {
     std::vector<DispatchPolicy> dispatchPolicies = DispatchPolicy::createDefaultPolicies();
     std::vector<ResourcePolicy> resourcePolicies = ResourcePolicy::createDefaultPolicies();
+    std::vector<SendingPolicy> sendingPolicies = SendingPolicy::createDefaultPolicies();
     dataProcessorSpecs2DeviceSpecs(workflow, channelPolicies, completionPolicies,
-                                   dispatchPolicies, resourcePolicies, callbacksPolicies, devices,
+                                   dispatchPolicies, resourcePolicies, callbacksPolicies,
+                                   sendingPolicies, devices,
                                    resourceManager, uniqueWorkflowId, configContext, optimizeTopology,
                                    resourcesMonitoringInterval, channelPrefix);
   }

--- a/Framework/Core/src/SendingPolicy.cxx
+++ b/Framework/Core/src/SendingPolicy.cxx
@@ -1,0 +1,27 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/SendingPolicy.h"
+#include <fairmq/Device.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+namespace o2::framework
+{
+
+std::vector<SendingPolicy> SendingPolicy::createDefaultPolicies()
+{
+  return {SendingPolicy{
+    .name = "default",
+    .matcher = [](DeviceSpec const& spec, ConfigContext const& ctx) { return true; },
+    .send = [](FairMQDevice& device, FairMQParts& parts, std::string const& channel) { device.Send(parts, channel, 0); }}};
+}
+} // namespace o2::framework

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -1480,6 +1480,7 @@ int runStateMachine(DataProcessorSpecs const& workflow,
                                                             driverInfo.dispatchPolicies,
                                                             driverInfo.resourcePolicies,
                                                             driverInfo.callbacksPolicies,
+                                                            driverInfo.sendingPolicies,
                                                             runningWorkflow.devices,
                                                             *resourceManager,
                                                             driverInfo.uniqueWorkflowId,
@@ -2243,6 +2244,7 @@ int doMain(int argc, char** argv, o2::framework::WorkflowSpec const& workflow,
            std::vector<DispatchPolicy> const& dispatchPolicies,
            std::vector<ResourcePolicy> const& resourcePolicies,
            std::vector<CallbacksPolicy> const& callbacksPolicies,
+           std::vector<SendingPolicy> const& sendingPolicies,
            std::vector<ConfigParamSpec> const& currentWorkflowOptions,
            o2::framework::ConfigContext& configContext)
 {
@@ -2510,7 +2512,9 @@ int doMain(int argc, char** argv, o2::framework::WorkflowSpec const& workflow,
   DriverControl driverControl;
   initialiseDriverControl(varmap, driverControl);
 
-  DriverInfo driverInfo;
+  DriverInfo driverInfo{
+    .sendingPolicies = sendingPolicies,
+    .callbacksPolicies = callbacksPolicies};
   driverInfo.states.reserve(10);
   driverInfo.sigintRequested = false;
   driverInfo.sigchldRequested = false;
@@ -2518,7 +2522,6 @@ int doMain(int argc, char** argv, o2::framework::WorkflowSpec const& workflow,
   driverInfo.completionPolicies = completionPolicies;
   driverInfo.dispatchPolicies = dispatchPolicies;
   driverInfo.resourcePolicies = resourcePolicies;
-  driverInfo.callbacksPolicies = callbacksPolicies;
   driverInfo.argc = argc;
   driverInfo.argv = argv;
   driverInfo.batch = varmap["no-batch"].defaulted() ? varmap["batch"].as<bool>() : false;

--- a/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
@@ -48,9 +48,9 @@ void customize(std::vector<SendingPolicy>& policies)
 {
   policies.push_back(SendingPolicy{
     .matcher = DeviceMatchers::matchByName("A"),
-    .send = [](FairMQDevice& device, FairMQParts& parts, std::string const& channel) { 
+    .send = [](FairMQDevice& device, FairMQParts& parts, std::string const& channel) {
       LOG(INFO) << "A custom policy for sending invoked!";
-      device.Send(parts, channel, 0); 
+      device.Send(parts, channel, 0);
     }});
 }
 

--- a/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
@@ -44,6 +44,16 @@ void customize(std::vector<CallbacksPolicy>& policies)
     }});
 }
 
+void customize(std::vector<SendingPolicy>& policies)
+{
+  policies.push_back(SendingPolicy{
+    .matcher = DeviceMatchers::matchByName("A"),
+    .send = [](FairMQDevice& device, FairMQParts& parts, std::string const& channel) { 
+      LOG(INFO) << "A custom policy for sending invoked!";
+      device.Send(parts, channel, 0); 
+    }});
+}
+
 #include "Framework/runDataProcessing.h"
 
 AlgorithmSpec simplePipe(std::string const& what, int minDelay)


### PR DESCRIPTION
Useful to customise behavior based on certain output types,
e.g. to make sure QC sampled data can be dropped in case of
backpressure.