### PR TITLE
GPU: Setting a specific Bz should always set it, not only when uninitialized

### DIFF
--- a/GPU/GPUTracking/Base/GPUReconstruction.cxx
+++ b/GPU/GPUTracking/Base/GPUReconstruction.cxx
@@ -1037,9 +1037,7 @@ void GPUReconstruction::SetSettings(float solenoidBz, const GPURecoStepConfigura
 #ifdef GPUCA_O2_LIB
   GPUO2InterfaceConfiguration config;
   config.ReadConfigurableParam_internal();
-  if (config.configGRP.solenoidBz <= -1e6f) {
-    config.configGRP.solenoidBz = solenoidBz;
-  }
+  config.configGRP.solenoidBz = solenoidBz;
   SetSettings(&config.configGRP, &config.configReconstruction, &config.configProcessing, workflow);
 #else
   GPUSettingsGRP grp;


### PR DESCRIPTION
@martenole @shahor02 @chiarazampolli : This fixes the Bz for TRD tracking. Worry, was quite a stupid bug...

trivial, merging