### PR TITLE
GPU: Split of ROOT dictionary for GPU ConfigKeyValues into GPUDataTypes

### DIFF
--- a/GPU/GPUTracking/Base/GPUReconstruction.cxx
+++ b/GPU/GPUTracking/Base/GPUReconstruction.cxx
@@ -76,7 +76,6 @@ struct GPUReconstructionPipelineContext {
 
 using namespace GPUCA_NAMESPACE::gpu;
 
-constexpr const char* const GPUReconstruction::DEVICE_TYPE_NAMES[];
 constexpr const char* const GPUReconstruction::GEOMETRY_TYPE_NAMES[];
 constexpr const char* const GPUReconstruction::IOTYPENAMES[];
 constexpr GPUReconstruction::GeometryType GPUReconstruction::geometryType;
@@ -1121,15 +1120,15 @@ GPUReconstruction* GPUReconstruction::CreateInstance(const GPUSettingsDeviceBack
 
   if (retVal == nullptr) {
     if (cfg.forceDeviceType) {
-      GPUError("Error: Could not load GPUReconstruction for specified device: %s (%u)", DEVICE_TYPE_NAMES[type], type);
+      GPUError("Error: Could not load GPUReconstruction for specified device: %s (%u)", GPUDataTypes::DEVICE_TYPE_NAMES[type], type);
     } else {
-      GPUError("Could not load GPUReconstruction for device type %s (%u), falling back to CPU version", DEVICE_TYPE_NAMES[type], type);
+      GPUError("Could not load GPUReconstruction for device type %s (%u), falling back to CPU version", GPUDataTypes::DEVICE_TYPE_NAMES[type], type);
       GPUSettingsDeviceBackend cfg2 = cfg;
       cfg2.deviceType = DeviceType::CPU;
       retVal = CreateInstance(cfg2);
     }
   } else {
-    GPUInfo("Created GPUReconstruction instance for device type %s (%u) %s", DEVICE_TYPE_NAMES[type], type, cfg.master ? " (slave)" : "");
+    GPUInfo("Created GPUReconstruction instance for device type %s (%u) %s", GPUDataTypes::DEVICE_TYPE_NAMES[type], type, cfg.master ? " (slave)" : "");
   }
 
   return retVal;
@@ -1137,22 +1136,12 @@ GPUReconstruction* GPUReconstruction::CreateInstance(const GPUSettingsDeviceBack
 
 GPUReconstruction* GPUReconstruction::CreateInstance(const char* type, bool forceType, GPUReconstruction* master)
 {
-  DeviceType t = GetDeviceType(type);
+  DeviceType t = GPUDataTypes::GetDeviceType(type);
   if (t == DeviceType::INVALID_DEVICE) {
     GPUError("Invalid device type: %s", type);
     return nullptr;
   }
   return CreateInstance(t, forceType, master);
-}
-
-GPUReconstruction::DeviceType GPUReconstruction::GetDeviceType(const char* type)
-{
-  for (unsigned int i = 1; i < sizeof(DEVICE_TYPE_NAMES) / sizeof(DEVICE_TYPE_NAMES[0]); i++) {
-    if (strcmp(DEVICE_TYPE_NAMES[i], type) == 0) {
-      return (DeviceType)i;
-    }
-  }
-  return DeviceType::INVALID_DEVICE;
 }
 
 #ifdef _WIN32

--- a/GPU/GPUTracking/Base/GPUReconstruction.h
+++ b/GPU/GPUTracking/Base/GPUReconstruction.h
@@ -84,7 +84,6 @@ class GPUReconstruction
   static constexpr GeometryType geometryType = GeometryType::ALIROOT;
 #endif
 
-  static constexpr const char* const DEVICE_TYPE_NAMES[] = {"INVALID", "CPU", "CUDA", "HIP", "OCL", "OCL2"};
   static DeviceType GetDeviceType(const char* type);
   enum InOutPointerType : unsigned int { CLUSTER_DATA = 0,
                                          SLICE_OUT_TRACK = 1,

--- a/GPU/GPUTracking/Benchmark/standalone.cxx
+++ b/GPU/GPUTracking/Benchmark/standalone.cxx
@@ -723,14 +723,14 @@ int main(int argc, char** argv)
     return 1;
   }
 
-  recUnique.reset(GPUReconstruction::CreateInstance(configStandalone.runGPU ? configStandalone.gpuType.c_str() : GPUReconstruction::DEVICE_TYPE_NAMES[GPUReconstruction::DeviceType::CPU], configStandalone.runGPUforce));
+  recUnique.reset(GPUReconstruction::CreateInstance(configStandalone.runGPU ? configStandalone.gpuType.c_str() : GPUDataTypes::DEVICE_TYPE_NAMES[GPUDataTypes::DeviceType::CPU], configStandalone.runGPUforce));
   rec = recUnique.get();
   if (configStandalone.testSyncAsync) {
-    recUniqueAsync.reset(GPUReconstruction::CreateInstance(configStandalone.runGPU ? configStandalone.gpuType.c_str() : GPUReconstruction::DEVICE_TYPE_NAMES[GPUReconstruction::DeviceType::CPU], configStandalone.runGPUforce, rec));
+    recUniqueAsync.reset(GPUReconstruction::CreateInstance(configStandalone.runGPU ? configStandalone.gpuType.c_str() : GPUDataTypes::DEVICE_TYPE_NAMES[GPUDataTypes::DeviceType::CPU], configStandalone.runGPUforce, rec));
     recAsync = recUniqueAsync.get();
   }
   if (configStandalone.proc.doublePipeline) {
-    recUniquePipeline.reset(GPUReconstruction::CreateInstance(configStandalone.runGPU ? configStandalone.gpuType.c_str() : GPUReconstruction::DEVICE_TYPE_NAMES[GPUReconstruction::DeviceType::CPU], configStandalone.runGPUforce, rec));
+    recUniquePipeline.reset(GPUReconstruction::CreateInstance(configStandalone.runGPU ? configStandalone.gpuType.c_str() : GPUDataTypes::DEVICE_TYPE_NAMES[GPUDataTypes::DeviceType::CPU], configStandalone.runGPUforce, rec));
     recPipeline = recUniquePipeline.get();
   }
   if (rec == nullptr || (configStandalone.testSyncAsync && recAsync == nullptr)) {

--- a/GPU/GPUTracking/CMakeLists.txt
+++ b/GPU/GPUTracking/CMakeLists.txt
@@ -62,11 +62,16 @@ set(SRCS
     TRDTracking/GPUTRDTrackerKernels.cxx
     Base/GPUParam.cxx)
 
-set(SRCS_O2_DATATYPES
+set(SRCS_O2_DATATYPE_HEADERS
     DataTypes/GPUTRDTrackO2.cxx)
+set(SRCS_O2_DATATYPES
+    DataTypes/GPUDataTypes.cxx
+    Interface/GPUO2InterfaceConfigurableParam.cxx)
+set(HDRS_CINT_O2 DataTypes/TPCdEdxCalibrationSplines.h Merger/GPUTPCGMMergedTrack.h)
+set(HDRS_CINT_O2_DATATYPES DataTypes/GPUDataTypes.h Interface/GPUO2InterfaceConfigurableParam.h)
+set(HDRS_CINT_O2_ADDITIONAL DataTypes/GPUSettings.h Definitions/GPUSettingsList.h DataTypes/GPUDataTypes.h DataTypes/GPUTRDTrack.h) # Manual dependencies for ROOT dictionary generation
 
 set(SRCS_NO_CINT
-    DataTypes/GPUDataTypes.cxx
     DataTypes/GPUMemorySizeScalers.cxx
     Base/GPUReconstruction.cxx
     Base/GPUReconstructionCPU.cxx
@@ -152,13 +157,6 @@ set(HDRS_INSTALL
     Definitions/GPUDefMacros.h
     Debug/GPUROOTDump.h
 )
-
-# Sources only for O2
-if(ALIGPU_BUILD_TYPE STREQUAL "O2")
-  set(SRCS ${SRCS} Interface/GPUO2InterfaceConfigurableParam.cxx)
-  set(HDRS_CINT_O2 ${HDRS_CINT_O2} DataTypes/TPCdEdxCalibrationSplines.h Interface/GPUO2InterfaceConfigurableParam.h)
-  set(HDRS_CINT_O2_ADDITIONAL DataTypes/GPUSettings.h Definitions/GPUSettingsList.h DataTypes/GPUDataTypes.h DataTypes/GPUTRDTrack.h Merger/GPUTPCGMMergedTrack.h) # Manual dependencies for ROOT dictionary generation
-endif()
 
 # Sources for O2 and for Standalone if requested in config file
 if(ALIGPU_BUILD_TYPE STREQUAL "O2" OR ALIGPU_BUILD_TYPE STREQUAL "Standalone")
@@ -283,16 +281,24 @@ if(ALIGPU_BUILD_TYPE STREQUAL "O2")
                  PUBLIC_LINK_LIBRARIES O2::GPUCommon
                                        O2::ReconstructionDataFormats
                  PRIVATE_LINK_LIBRARIES O2::DataFormatsTPC
-                 SOURCES ${SRCS_O2_DATATYPES})
-target_compile_definitions(${targetName} PRIVATE GPUCA_O2_LIB
-                           GPUCA_TPC_GEOMETRY_O2 GPUCA_HAVE_O2HEADERS)
+                 SOURCES ${SRCS_O2_DATATYPE_HEADERS})
+  target_compile_definitions(${targetName} PRIVATE GPUCA_O2_LIB GPUCA_TPC_GEOMETRY_O2 GPUCA_HAVE_O2HEADERS)
 
+  o2_add_library(GPUDataTypes
+                 TARGETVARNAME targetName
+                 PUBLIC_LINK_LIBRARIES O2::GPUDataTypeHeaders O2::GPUUtils
+                 PRIVATE_LINK_LIBRARIES O2::DataFormatsTPC
+                 SOURCES ${SRCS_O2_DATATYPES})
+  target_compile_definitions(${targetName} PRIVATE GPUCA_O2_LIB GPUCA_TPC_GEOMETRY_O2 GPUCA_HAVE_O2HEADERS)
+  o2_target_root_dictionary(GPUDataTypes
+                            HEADERS ${HDRS_CINT_O2_DATATYPES} ${HDRS_CINT_O2_ADDITIONAL}
+                            LINKDEF GPUTrackingLinkDef_O2_DataTypes.h)
 
   o2_add_library(${MODULE}
                  TARGETVARNAME targetName
                  PUBLIC_LINK_LIBRARIES O2::GPUCommon
                                        O2::GPUUtils
-                                       O2::GPUDataTypeHeaders
+                                       O2::GPUDataTypes
                                        O2::DataFormatsTPC
                                        O2::DataFormatsTOF
                                        O2::TPCBase
@@ -330,14 +336,14 @@ target_compile_definitions(${targetName} PRIVATE GPUCA_O2_LIB
     ${targetName}
     PRIVATE $<TARGET_PROPERTY:O2::Framework,INTERFACE_INCLUDE_DIRECTORIES>)
 
+  target_compile_definitions(${targetName} PRIVATE GPUCA_O2_LIB
+                             GPUCA_TPC_GEOMETRY_O2 GPUCA_HAVE_O2HEADERS)
+
   o2_target_root_dictionary(${MODULE}
                             HEADERS ${HDRS_CINT_O2} ${HDRS_CINT_O2_ADDITIONAL}
                             LINKDEF GPUTrackingLinkDef_O2.h)
 
-  target_compile_definitions(${targetName} PRIVATE GPUCA_O2_LIB
-                             GPUCA_TPC_GEOMETRY_O2 GPUCA_HAVE_O2HEADERS)
-
-  install(FILES ${HDRS_CINT_ALIROOT} ${HDRS_CINT_O2} ${HDRS_INSTALL}
+  install(FILES ${HDRS_CINT_ALIROOT} ${HDRS_CINT_O2} ${HDRS_CINT_O2_DATATYPES} ${HDRS_INSTALL}
           DESTINATION include/GPU)
   install(DIRECTORY utils
           DESTINATION include/GPU

--- a/GPU/GPUTracking/DataTypes/GPUDataTypes.cxx
+++ b/GPU/GPUTracking/DataTypes/GPUDataTypes.cxx
@@ -13,11 +13,20 @@
 /// \author David Rohr
 
 #include "GPUDataTypes.h"
-#include "GPUReconstruction.h"
+#include <cstring>
 
 using namespace GPUCA_NAMESPACE::gpu;
 
+constexpr const char* const GPUDataTypes::DEVICE_TYPE_NAMES[];
 constexpr const char* const GPUDataTypes::RECO_STEP_NAMES[];
 constexpr const char* const GPUDataTypes::GENERAL_STEP_NAMES[];
 
-GPUDataTypes::DeviceType GPUDataTypes::GetDeviceType(const char* type) { return GPUReconstruction::GetDeviceType(type); }
+GPUDataTypes::DeviceType GPUDataTypes::GetDeviceType(const char* type)
+{
+  for (unsigned int i = 1; i < sizeof(DEVICE_TYPE_NAMES) / sizeof(DEVICE_TYPE_NAMES[0]); i++) {
+    if (strcmp(DEVICE_TYPE_NAMES[i], type) == 0) {
+      return (DeviceType)i;
+    }
+  }
+  return DeviceType::INVALID_DEVICE;
+}

--- a/GPU/GPUTracking/DataTypes/GPUDataTypes.h
+++ b/GPU/GPUTracking/DataTypes/GPUDataTypes.h
@@ -171,6 +171,7 @@ class GPUDataTypes
                               TPCRaw = 64 };
 
 #ifdef GPUCA_NOCOMPAT_ALLOPENCL
+  static constexpr const char* const DEVICE_TYPE_NAMES[] = {"INVALID", "CPU", "CUDA", "HIP", "OCL", "OCL2"};
   static constexpr const char* const RECO_STEP_NAMES[] = {"TPC Transformation", "TPC Sector Tracking", "TPC Track Merging and Fit", "TPC Compression", "TRD Tracking", "ITS Tracking", "TPC dEdx Computation", "TPC Cluster Finding", "TPC Decompression", "Global Refit"};
   static constexpr const char* const GENERAL_STEP_NAMES[] = {"Prepare", "QA"};
   typedef bitfield<RecoStep, unsigned int> RecoStepField;

--- a/GPU/GPUTracking/Definitions/GPUSettingsList.h
+++ b/GPU/GPUTracking/Definitions/GPUSettingsList.h
@@ -95,7 +95,7 @@ BeginSubConfig(GPUSettingsRec, rec, configStandalone, "REC", 0, "Reconstruction 
 AddOptionRTC(maxTrackQPt, float, 1.f / GPUCA_MIN_TRACK_PTB5_DEFAULT, "", 0, "required max Q/Pt (==min Pt) of tracks")
 AddOptionRTC(nonConsecutiveIDs, char, false, "", 0, "Non-consecutive cluster IDs as in HLT, disables features that need access to slice data in TPC merger")
 AddOptionRTC(fwdTPCDigitsAsClusters, unsigned char, 0, "", 0, "Forward TPC digits as clusters (if they pass the ZS threshold)")
-AddOptionRTC(bz0Pt, unsigned char, 60, "", 0, "Nominal Pt to set when bz = 0 (in 10 MeV)")
+AddOptionRTC(bz0Pt10MeV, unsigned char, 60, "", 0, "Nominal Pt to set when bz = 0 (in 10 MeV)")
 AddOptionRTC(fitInProjections, char, -1, "", 0, "Fit in projection, -1 to enable for all but passes but the first one")
 AddOptionRTC(fitPropagateBzOnly, char, -1, "", 0, "Propagate using Bz only for n passes")
 AddOptionRTC(useMatLUT, char, 0, "", 0, "Use material lookup table for TPC refit")

--- a/GPU/GPUTracking/GPUTrackingLinkDef_O2.h
+++ b/GPU/GPUTracking/GPUTrackingLinkDef_O2.h
@@ -20,19 +20,5 @@
 
 #pragma link C++ class o2::gpu::TPCdEdxCalibrationSplines + ;
 #pragma link C++ class o2::gpu::GPUTPCGMMergedTrack + ;
-#pragma link C++ class o2::gpu::trackInterface < o2::track::TrackParCov> + ;
-#pragma link C++ class o2::gpu::GPUTRDTrack_t < o2::gpu::trackInterface < o2::track::TrackParCov>> + ;
-#pragma link C++ class std::vector < o2::gpu::GPUTRDTrack_t < o2::gpu::trackInterface < o2::track::TrackParCov>>> + ;
-#pragma link C++ class o2::gpu::GPUConfigurableParamGPUSettingsO2 + ;
-#pragma link C++ class o2::gpu::GPUConfigurableParamGPUSettingsRec + ;
-#pragma link C++ class o2::gpu::GPUConfigurableParamGPUSettingsRecTPC + ;
-#pragma link C++ class o2::gpu::GPUConfigurableParamGPUSettingsRecTRD + ;
-#pragma link C++ class o2::gpu::GPUConfigurableParamGPUSettingsProcessing + ;
-#pragma link C++ class o2::gpu::GPUConfigurableParamGPUSettingsProcessingRTC + ;
-#pragma link C++ class o2::gpu::GPUConfigurableParamGPUSettingsDisplay + ;
-#pragma link C++ class o2::gpu::GPUConfigurableParamGPUSettingsDisplayLight + ;
-#pragma link C++ class o2::gpu::GPUConfigurableParamGPUSettingsDisplayHeavy + ;
-#pragma link C++ class o2::gpu::GPUConfigurableParamGPUSettingsDisplayRenderer + ;
-#pragma link C++ class o2::gpu::GPUConfigurableParamGPUSettingsQA + ;
 
 #endif

--- a/GPU/GPUTracking/GPUTrackingLinkDef_O2_DataTypes.h
+++ b/GPU/GPUTracking/GPUTrackingLinkDef_O2_DataTypes.h
@@ -1,0 +1,36 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file GPUTrackingLinkDef_O2_DataTypes.h
+/// \author David Rohr
+
+#ifdef __CLING__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class o2::gpu::trackInterface < o2::track::TrackParCov> + ;
+#pragma link C++ class o2::gpu::GPUTRDTrack_t < o2::gpu::trackInterface < o2::track::TrackParCov>> + ;
+#pragma link C++ class std::vector < o2::gpu::GPUTRDTrack_t < o2::gpu::trackInterface < o2::track::TrackParCov>>> + ;
+#pragma link C++ class o2::gpu::GPUConfigurableParamGPUSettingsO2 + ;
+#pragma link C++ class o2::gpu::GPUConfigurableParamGPUSettingsRec + ;
+#pragma link C++ class o2::gpu::GPUConfigurableParamGPUSettingsRecTPC + ;
+#pragma link C++ class o2::gpu::GPUConfigurableParamGPUSettingsRecTRD + ;
+#pragma link C++ class o2::gpu::GPUConfigurableParamGPUSettingsProcessing + ;
+#pragma link C++ class o2::gpu::GPUConfigurableParamGPUSettingsProcessingRTC + ;
+#pragma link C++ class o2::gpu::GPUConfigurableParamGPUSettingsDisplay + ;
+#pragma link C++ class o2::gpu::GPUConfigurableParamGPUSettingsDisplayLight + ;
+#pragma link C++ class o2::gpu::GPUConfigurableParamGPUSettingsDisplayHeavy + ;
+#pragma link C++ class o2::gpu::GPUConfigurableParamGPUSettingsDisplayRenderer + ;
+#pragma link C++ class o2::gpu::GPUConfigurableParamGPUSettingsQA + ;
+
+#endif

--- a/GPU/GPUTracking/Merger/GPUTPCGMMerger.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMMerger.cxx
@@ -1798,7 +1798,7 @@ GPUd() void GPUTPCGMMerger::CollectMergedTracks(int nBlocks, int nThreads, int i
     mergedTrack.SetAlpha(p2.Alpha());
     const double kCLight = 0.000299792458;
     if (CAMath::Abs(Param().polynomialField.GetNominalBz()) < (0.01 * kCLight)) {
-      p1.QPt() = 0.01f * Param().rec.bz0Pt;
+      p1.QPt() = 100.f / Param().rec.bz0Pt10MeV;
     }
 
     // if (nParts > 1) printf("Merged %d: QPt %f %d parts %d hits\n", mMemory->nOutputTracks, p1.QPt(), nParts, nHits);


### PR DESCRIPTION
@shahor02 @mpuccio @martenole : Some days ago Ruben asked about the setting for the nominal Pt in case of Bz = 0.
This PR splits of the GPU data types configKeyValues in a separate library GPUDataTypes, so one does not need to link against the whole GPU stuff to access it. It is settable via `--configKeyValues GPU_rec.bz0Pt10MeV=x` with x in 10 MeV units.
- TRD tracking can already access it directly as `param().rec.bz0Pt10MeV`.
- For ITS, if you don't want to go the way through GPUReconstruction, you can get it from `o2::gpu::GPUConfigurableParamGPUSettingsRec::Instance()`.
