### PR TITLE
Changes to inject TF creation time + set default remote access to alien

### DIFF
--- a/DataFormats/Detectors/Common/src/CTFHeader.cxx
+++ b/DataFormats/Detectors/Common/src/CTFHeader.cxx
@@ -18,7 +18,7 @@ using DetID = o2::detectors::DetID;
 /// describe itsel as a string
 std::string CTFHeader::describe() const
 {
-  return fmt::format("Run:{:07d} TF@orbit:{:08d} Detectors: {:s}", run, firstTForbit, DetID::getNames(detectors));
+  return fmt::format("Run:{:07d} TF@orbit:{:08d} CteationTime:{} Detectors: {}", run, firstTForbit, creationTime, DetID::getNames(detectors));
 }
 
 std::ostream& o2::ctf::operator<<(std::ostream& stream, const CTFHeader& h)

--- a/Detectors/CTF/workflow/src/CTFReaderSpec.cxx
+++ b/Detectors/CTF/workflow/src/CTFReaderSpec.cxx
@@ -83,6 +83,7 @@ class CTFReaderSpec : public o2::framework::Task
   template <typename C>
   void processDetector(DetID det, const CTFHeader& ctfHeader, ProcessingContext& pc) const;
   void setMessageHeader(const CTFHeader& ctfHeader, const std::string& lbl, ProcessingContext& pc) const;
+  void tryToFixCTFHeader(CTFHeader& ctfHeader) const;
   CTFReaderInp mInput{};
   std::unique_ptr<o2::utils::FileFetcher> mFileFetcher;
   std::unique_ptr<TFile> mCTFFile;
@@ -219,6 +220,10 @@ void CTFReaderSpec::processTF(ProcessingContext& pc)
   if (!readFromTree(*(mCTFTree.get()), "CTFHeader", ctfHeader, mCurrTreeEntry)) {
     throw std::runtime_error("did not find CTFHeader");
   }
+  if (ctfHeader.creationTime == 0) { // try to repair header with ad hoc data
+    tryToFixCTFHeader(ctfHeader);
+  }
+
   LOG(INFO) << ctfHeader;
 
   // send CTF Header
@@ -312,6 +317,53 @@ void CTFReaderSpec::processDetector(DetID det, const CTFHeader& ctfHeader, Proce
       throw std::runtime_error(fmt::format("Requested detector {} is missing in the CTF", lbl));
     }
     setMessageHeader(ctfHeader, lbl, pc);
+  }
+}
+
+///_______________________________________
+void CTFReaderSpec::tryToFixCTFHeader(CTFHeader& ctfHeader) const
+{
+  // HACK: fix CTFHeader for the pilot beam runs, where the TF creation time was not recorded
+  struct RunStartData {
+    uint32_t run = 0;
+    uint32_t firstTForbit = 0;
+    uint64_t tstampMS0 = 0;
+  };
+  const std::vector<RunStartData> tf0Data{
+    {505207, 133875, 1635322620830},
+    {505217, 14225007, 1635328375618},
+    {505278, 1349340, 1635376882079},
+    {505285, 1488862, 1635378517248},
+    {505303, 2615411, 1635392586314},
+    {505397, 5093945, 1635454778123},
+    {505404, 19196217, 1635456032855},
+    {505405, 28537913, 1635456862913},
+    {505406, 41107641, 1635457980628},
+    {505413, 452530, 1635460562613},
+    {505440, 13320708, 1635472436927},
+    {505443, 26546564, 1635473613239},
+    {505446, 177711, 1635477270241},
+    {505548, 88037114, 1635544414050},
+    {505582, 295044346, 1635562822389},
+    {505600, 417241082, 1635573688564},
+    {505623, 10445984, 1635621310460},
+    {505629, 126979, 1635623289756},
+    {505637, 338969, 1635630909893},
+    {505645, 188222, 1635634560881},
+    {505658, 81044, 1635645404694},
+    {505669, 328291, 1635657807147},
+    {505673, 30988, 1635659148972},
+    {505713, 620506, 1635725054798},
+    {505720, 5359903, 1635730673978}};
+  if (ctfHeader.run >= tf0Data.front().run && ctfHeader.run <= tf0Data.back().run) {
+    for (const auto& tf0 : tf0Data) {
+      if (ctfHeader.run == tf0.run) {
+        ctfHeader.creationTime = tf0.tstampMS0;
+        int64_t offset = std::ceil((ctfHeader.firstTForbit - tf0.firstTForbit) * o2::constants::lhc::LHCOrbitMUS * 1e-3);
+        ctfHeader.creationTime += offset > 0 ? offset : 0;
+        break;
+      }
+    }
   }
 }
 

--- a/Detectors/CTF/workflow/src/ctf-reader-workflow.cxx
+++ b/Detectors/CTF/workflow/src/ctf-reader-workflow.cxx
@@ -53,9 +53,9 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   options.push_back(ConfigParamSpec{"max-tf", VariantType::Int, -1, {"max CTFs to process (<= 0 : infinite)"}});
   options.push_back(ConfigParamSpec{"loop", VariantType::Int, 0, {"loop N times (infinite for N<0)"}});
   options.push_back(ConfigParamSpec{"delay", VariantType::Float, 0.f, {"delay in seconds between consecutive TFs sending"}});
-  options.push_back(ConfigParamSpec{"copy-cmd", VariantType::String, "XrdSecPROTOCOL=sss,unix xrdcp -N root://eosaliceo2.cern.ch/?src ?dst", {"copy command for remote files or no-copy to avoid copying"}});
+  options.push_back(ConfigParamSpec{"copy-cmd", VariantType::String, "alien_cp ?src file://?dst", {"copy command for remote files or no-copy to avoid copying"}}); // Use "XrdSecPROTOCOL=sss,unix xrdcp -N root://eosaliceo2.cern.ch/?src ?dst" for direct EOS access
   options.push_back(ConfigParamSpec{"ctf-file-regex", VariantType::String, ".*o2_ctf_run.+\\.root$", {"regex string to identify CTF files"}});
-  options.push_back(ConfigParamSpec{"remote-regex", VariantType::String, "^/eos/aliceo2/.+", {"regex string to identify remote files"}});
+  options.push_back(ConfigParamSpec{"remote-regex", VariantType::String, "^(alien://|)/alice/data/.+", {"regex string to identify remote files"}}); // Use "^/eos/aliceo2/.+" for direct EOS access
   options.push_back(ConfigParamSpec{"max-cached-files", VariantType::Int, 3, {"max CTF files queued (copied for remote source)"}});
   options.push_back(ConfigParamSpec{"allow-missing-detectors", VariantType::Bool, false, {"send empty message if detector is missing in the CTF (otherwise throw)"}});
   options.push_back(ConfigParamSpec{"ctf-reader-verbosity", VariantType::Int, 0, {"verbosity level (0: summary per detector, 1: summary per block"}});

--- a/Detectors/Raw/README.md
+++ b/Detectors/Raw/README.md
@@ -336,7 +336,8 @@ o2-raw-file-reader-workflow
   --cache-data                          cache data at 1st reading, may require excessive memory!!!
   --detect-tf0                          autodetect HBFUtils start Orbit/BC from 1st TF seen (at SOX)
   --calculate-tf-start                  calculate TF start from orbit instead of using TType
-  --drop-tf arg (=none)                Drop each TFid%(1)==(2) of detector, e.g. ITS,2,4;TPC,4[,0];...
+  --drop-tf arg (=none)                 drop each TFid%(1)==(2) of detector, e.g. ITS,2,4;TPC,4[,0];...
+  --start-time arg (=0)                 define TF creation time as start-time + firstTForbit*orbit_duration, ms, otherwise: current time
   --configKeyValues arg                 semicolon separated key=value strings
 
   # to suppress various error checks / reporting
@@ -363,6 +364,8 @@ Using `--cache-data` option one can force caching the data to memory during the 
 
 At every invocation of the device `processing` callback a full TimeFrame for every link will be added as a multi-part `FairMQ` message and relayed by the relevant channel.
 By default each HBF will start a new part in the multipart message. This behaviour can be changed by providing `part-per-sp` option, in which case there will be one part per superpage (Note that this is incompatible to the DPLRawSequencer).
+
+By the default the DataProcessingHeader of each message will have its creation time set to `now()`. This can be changed by passing an option `--start-time <t>`: in this case the creation time will be defined as `t + firstTForbir*orbit_duration` in milliseconds.
 
 The standard use case of this workflow is to provide the input for other worfklows using the piping, e.g.
 ```cpp

--- a/Detectors/Raw/TFReaderDD/src/SubTimeFrameFileReader.cxx
+++ b/Detectors/Raw/TFReaderDD/src/SubTimeFrameFileReader.cxx
@@ -402,7 +402,7 @@ std::unique_ptr<MessagesPerRoute> SubTimeFrameFileReader::read(FairMQDevice* dev
   const auto fmqChannel = findOutputChannel(&stfDistDataHeader);
   if (!fmqChannel.empty()) { // no output channel
     auto fmqFactory = device->GetChannel(fmqChannel, 0).Transport();
-    o2::header::Stack headerStackSTF{stfDistDataHeader, o2f::DataProcessingHeader{tfID}};
+    o2::header::Stack headerStackSTF{stfDistDataHeader, o2f::DataProcessingHeader{tfID, 1, lStfFileMeta.mWriteTimeMs}};
     if (verbosity > 0) {
       printStack(headerStackSTF);
     }

--- a/Detectors/Raw/TFReaderDD/src/tf-reader-workflow.cxx
+++ b/Detectors/Raw/TFReaderDD/src/tf-reader-workflow.cxx
@@ -30,9 +30,9 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
   options.push_back(ConfigParamSpec{"max-tf", VariantType::Int, -1, {"max TF ID to process (<= 0 : infinite)"}});
   options.push_back(ConfigParamSpec{"loop", VariantType::Int, 0, {"loop N times (-1 = infinite)"}});
   options.push_back(ConfigParamSpec{"delay", VariantType::Float, 0.f, {"delay in seconds between consecutive TFs sending"}});
-  options.push_back(ConfigParamSpec{"copy-cmd", VariantType::String, "XrdSecPROTOCOL=sss,unix xrdcp -N root://eosaliceo2.cern.ch/?src ?dst", {"copy command for remote files"}});
+  options.push_back(ConfigParamSpec{"copy-cmd", VariantType::String, "alien_cp ?src file://?dst", {"copy command for remote files"}}); // Use "XrdSecPROTOCOL=sss,unix xrdcp -N root://eosaliceo2.cern.ch/?src ?dst" for direct EOS access
   options.push_back(ConfigParamSpec{"tf-file-regex", VariantType::String, ".+\\.tf$", {"regex string to identify TF files"}});
-  options.push_back(ConfigParamSpec{"remote-regex", VariantType::String, "^/eos/aliceo2/.+", {"regex string to identify remote files"}});
+  options.push_back(ConfigParamSpec{"remote-regex", VariantType::String, "^(alien://|)/alice/data/.+", {"regex string to identify remote files"}}); // Use "^/eos/aliceo2/.+" for direct EOS access
   options.push_back(ConfigParamSpec{"max-cached-tf", VariantType::Int, 3, {"max TFs to cache in memory"}});
   options.push_back(ConfigParamSpec{"max-cached-files", VariantType::Int, 3, {"max TF files queued (copied for remote source)"}});
   options.push_back(ConfigParamSpec{"tf-reader-verbosity", VariantType::Int, 0, {"verbosity level (1 or 2: check RDH, print DH/DPH for 1st or all slices, >2 print RDH)"}});

--- a/Detectors/Raw/include/DetectorsRaw/RawFileReader.h
+++ b/Detectors/Raw/include/DetectorsRaw/RawFileReader.h
@@ -46,6 +46,7 @@ struct ReaderInp {
   uint32_t errMap = 0xffffffff;
   uint32_t minTF = 0;
   uint32_t maxTF = 0xffffffff;
+  uint32_t startTime = 0;
   bool partPerSP = true;
   bool cache = false;
   bool autodetectTF0 = false;

--- a/Detectors/Raw/src/RawFileReaderWorkflow.cxx
+++ b/Detectors/Raw/src/RawFileReaderWorkflow.cxx
@@ -68,6 +68,7 @@ class RawReaderSpecs : public o2f::Task
   uint32_t mDelayUSec = 0;        // Delay in microseconds between TFs
   uint32_t mMinTFID = 0;          // 1st TF to extract
   uint32_t mMaxTFID = 0xffffffff; // last TF to extrct
+  uint64_t mStartTimeMS = 0;      // start time to inject to DPH
   size_t mLoopsDone = 0;
   size_t mSentSize = 0;
   size_t mSentMessages = 0;
@@ -207,6 +208,7 @@ void RawReaderSpecs::run(o2f::ProcessingContext& ctx)
       return;
     }
   }
+  uint64_t creationTime = mStartTimeMS ? 0UL : std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
 
   if (tfID < mMinTFID) {
     tfID = mMinTFID;
@@ -263,8 +265,11 @@ void RawReaderSpecs::run(o2f::ProcessingContext& ctx)
         auto ir = o2::raw::RDHUtils::getHeartBeatIR(plMessage->GetData());
         auto tfid = hbfU.getTF(ir);
         firstOrbit = hdrTmpl.firstTForbit = hbfU.getIRTF(tfid).orbit; // will be picked for the following parts
+        if (!creationTime) {
+          creationTime = mStartTimeMS + std::ceil(firstOrbit * o2::constants::lhc::LHCOrbitMUS * 1e-3);
+        }
       }
-      o2::header::Stack headerStack{hdrTmpl, o2::framework::DataProcessingHeader{mTFCounter}};
+      o2::header::Stack headerStack{hdrTmpl, o2::framework::DataProcessingHeader{mTFCounter, 1, creationTime}};
       memcpy(hdMessage->GetData(), headerStack.data(), headerStack.size());
       hdrTmpl.splitPayloadIndex++; // prepare for next
 
@@ -284,7 +289,7 @@ void RawReaderSpecs::run(o2f::ProcessingContext& ctx)
     const auto fmqChannel = findOutputChannel(stfDistDataHeader);
     if (!fmqChannel.empty()) { // no output channel
       auto fmqFactory = device->GetChannel(fmqChannel, 0).Transport();
-      o2::header::Stack headerStackSTF{stfDistDataHeader, o2::framework::DataProcessingHeader{mTFCounter}};
+      o2::header::Stack headerStackSTF{stfDistDataHeader, o2::framework::DataProcessingHeader{mTFCounter, 1, creationTime}};
       auto hdMessageSTF = fmqFactory->CreateMessage(hstackSize, fair::mq::Alignment{64});
       auto plMessageSTF = fmqFactory->CreateMessage(stfDistDataHeader.payloadSize, fair::mq::Alignment{64});
       memcpy(hdMessageSTF->GetData(), headerStackSTF.data(), headerStackSTF.size());

--- a/Detectors/Raw/src/rawfile-reader-workflow.cxx
+++ b/Detectors/Raw/src/rawfile-reader-workflow.cxx
@@ -37,6 +37,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   options.push_back(ConfigParamSpec{"detect-tf0", VariantType::Bool, false, {"autodetect HBFUtils start Orbit/BC from 1st TF seen"}});
   options.push_back(ConfigParamSpec{"calculate-tf-start", VariantType::Bool, false, {"calculate TF start instead of using TType"}});
   options.push_back(ConfigParamSpec{"drop-tf", VariantType::String, "none", {"Drop each TFid%(1)==(2) of detector, e.g. ITS,2,4;TPC,4[,0];..."}});
+  options.push_back(ConfigParamSpec{"start-time", VariantType::Int64, 0L, {"define TF creation time as start-time + firstTForbit*orbit_duration, ms, otherwise: current time"}});
   options.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {"semicolon separated key=value strings"}});
   // options for error-check suppression
 
@@ -67,6 +68,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   rinp.rawChannelConfig = configcontext.options().get<std::string>("raw-channel-config");
   rinp.delay_us = uint32_t(1e6 * configcontext.options().get<float>("delay")); // delay in microseconds
   rinp.dropTF = configcontext.options().get<std::string>("drop-tf");
+  rinp.startTime = configcontext.options().get<int64_t>("start-time");
   rinp.errMap = 0;
   for (int i = RawFileReader::NErrorsDefined; i--;) {
     auto ei = RawFileReader::ErrTypes(i);


### PR DESCRIPTION
* CTF/TF readers: set default remote file access to alien instead of EOS
since by default the access to CTF or rawTF data will be done via alien, the defaults of `--remote-regex` and `--copy-cmd` of `o2-ctf-reader-workflow` and `o2-raw-tf-reader-workflow` are adapted to alien.

* Ad hoc correction of pilot beam run CTF times
CTFs created during the pilot beam test have no TFs creation time stored. This implements an ad-hoc correction for the global runs of the pilot beam.

* Possibility to set TF creation time in raw-file-reader workflow
By the default the DataProcessingHeader of each message will have its creation time set to `now()`. This can be changed by passing an option `--start-time <t>`: in this case the creation time will be defined as `t + firstTForbir*orbit_duration` in milliseconds.