### PR TITLE
DPL: if all the inputs are sporadic, then also the outputs will be

### DIFF
--- a/Framework/Core/src/WorkflowHelpers.h
+++ b/Framework/Core/src/WorkflowHelpers.h
@@ -197,9 +197,8 @@ struct WorkflowHelpers {
                                          std::vector<InputSpec>& requestedAODs,
                                          DataProcessorSpec& publisher);
 
-  // Re-adjust service devices if the inputs of other devices were modified
-  // @a workflow to analyze
-  static void adjustServiceDevices(WorkflowSpec& workflow, ConfigContext const& ctx);
+  // Final adjustments to @a workflow after service devices have been injected.
+  static void adjustTopology(WorkflowSpec& workflow, ConfigContext const& ctx);
 
   static void constructGraph(const WorkflowSpec& workflow,
                              std::vector<DeviceConnectionEdge>& logicalEdges,

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -1468,6 +1468,7 @@ int runStateMachine(DataProcessorSpecs const& workflow,
             }
             altered = true;
           }
+          WorkflowHelpers::adjustTopology(altered_workflow, *driverInfo.configContext);
           if (altered) {
             WorkflowSpecNode node{altered_workflow};
             for (auto& service : driverServices) {


### PR DESCRIPTION
This is done to avoid having to change the lifetime of
all the devices which run on sampled and unsampled data alike.