### PR TITLE
TRD fix halfchamberside and reduce err,warn messages

### DIFF
--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/DigitsParser.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/DigitsParser.h
@@ -84,11 +84,11 @@ class DigitsParser
   {
 
     if (mOptions[TRDGenerateStats]) {
-      mEventRecords->incParsingError(error, mFEEID.supermodule, mFEEID.side, mStackLayer);
+      mEventRecords->incParsingError(error, mFEEID.supermodule, mHalfChamberSide, mStackLayer);
     }
     if (mOptions[TRDEnableRootOutputBit]) {
       mParsingErrors->Fill(error);
-      ((TH2F*)mParsingErrors2d->At(error))->Fill(mFEEID.supermodule * 2 + mFEEID.side, mStack * constants::NLAYER + mLayer);
+      ((TH2F*)mParsingErrors2d->At(error))->Fill(mFEEID.supermodule * 2 + mHalfChamberSide, mStack * constants::NLAYER + mLayer);
     }
   }
 
@@ -134,8 +134,7 @@ class DigitsParser
   uint16_t mStack;
   uint16_t mLayer;
   uint16_t mSector;
-  uint16_t mSide;
-  uint16_t mHalfSM;     //store these values to prevent numerous recalculation;
+  uint16_t mHalfChamberSide;
   uint16_t mStackLayer; //store these values to prevent numerous recalculation;
 
   uint16_t mEventCounter;

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/TrackletsParser.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/TrackletsParser.h
@@ -41,8 +41,7 @@ class TrackletsParser
   void setData(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>* data) { mData = data; }
   int Parse(); // presupposes you have set everything up already.
   int Parse(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>* data, std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator start, std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator end, TRDFeeID feeid, int robside,
-            int detector, int stack, int layer, EventRecord* eventrecord, EventStorage* eventrecords, std::bitset<16> option, bool cleardigits = false,
-            int usetracklethcheader = 0);
+            int detector, int stack, int layer, EventRecord* eventrecord, EventStorage* eventrecords, std::bitset<16> option, bool cleardigits = false, int usetracklethcheader = 0);
   void setVerbose(bool verbose, bool header = false, bool data = false)
   {
     mVerbose = verbose;
@@ -78,11 +77,11 @@ class TrackletsParser
   void incParsingError(int error)
   {
     if (mOptions[TRDGenerateStats]) {
-      mEventRecords->incParsingError(error, mFEEID.supermodule, mFEEID.side, mStack * constants::NLAYER + mLayer);
+      mEventRecords->incParsingError(error, mFEEID.supermodule, mHalfChamberSide, mStack * constants::NLAYER + mLayer);
     }
     if (mOptions[TRDEnableRootOutputBit]) {
       mParsingErrors->Fill(error);
-      ((TH2F*)mParsingErrors2d->At(error))->Fill(mFEEID.supermodule * 2 + mFEEID.side, mStack * constants::NLAYER + mLayer);
+      ((TH2F*)mParsingErrors2d->At(error))->Fill(mFEEID.supermodule * 2 + mHalfChamberSide, mStack * constants::NLAYER + mLayer);
     }
   }
 
@@ -120,7 +119,7 @@ class TrackletsParser
   uint16_t mCRUID;
   uint16_t mHCID;
   uint16_t mDetector;
-  uint16_t mRobSide;
+  uint16_t mHalfChamberSide;
   uint16_t mStack;
   uint16_t mLayer;
   TRDFeeID mFEEID; // current Fee ID working on

--- a/Detectors/TRD/reconstruction/src/CruRawReader.cxx
+++ b/Detectors/TRD/reconstruction/src/CruRawReader.cxx
@@ -570,20 +570,15 @@ int CruRawReader::processHalfCRU(int cruhbfstartoffset)
 
         if (mDigitHCHeader.major == 0x47) {
           // config event so ignore for now and bail out of parsing.
-          LOG(warn) << " HCHeader major version is 0x47 bailing out of parsing this as its a config event";
           //advance data pointers to the end;
           linkstart = linkend;
-          //mHBFoffset32 = std::distance(mHBFPayload.begin(),linkend);//dataoffsetstart32 + currentlinksize; // go to the end of the link
           mHBFoffset32 = std::distance(mHBFPayload.begin(), linkend); //currentlinksize-mTrackletWordsRead-sizeof(digitHCHeader)/4; // advance to the end of the link
           mTotalDigitWordsRejected += std::distance(linkstart + mTrackletWordsRead + sizeof(DigitHCHeader) / 4, linkend);
         } else {
-          //if (((mDigitHCHeader.major & 0x27) == mDigitHCHeader.major) || ((mDigitHCHeader.major & 0x37) == mDigitHCHeader.major) || ((mDigitHCHeader.major & 0x17) == mDigitHCHeader.major))
-          {
-            //                ZS                                                          DisableTracklets
             mDigitWordsRead = 0;
             auto digitsparsingstart = std::chrono::high_resolution_clock::now();
             //linkstart and linkend already have the multiple cruheaderoffsets built in
-            mDigitWordsRead = mDigitsParser.Parse(&mHBFPayload, linkstart, linkend, mDetector[mWhichData], mStack[mWhichData], mLayer[mWhichData], mSide[mWhichData], mDigitHCHeader, mFEEID, currentlinkindex, mCurrentEvent, &mEventRecords, mOptions, cleardigits);
+            mDigitWordsRead = mDigitsParser.Parse(&mHBFPayload, linkstart, linkend, mDetector[mWhichData], mStack[mWhichData], mLayer[mWhichData], mHalfChamberSide[mWhichData], mDigitHCHeader, mFEEID, currentlinkindex, mCurrentEvent, &mEventRecords, mOptions, cleardigits);
             std::chrono::duration<double, std::micro> digitsparsingtime = std::chrono::high_resolution_clock::now() - digitsparsingstart;
             if (mRootOutput) {
               mDigitTiming->Fill((int)std::chrono::duration_cast<std::chrono::microseconds>(digitsparsingtime).count());
@@ -626,7 +621,6 @@ int CruRawReader::processHalfCRU(int cruhbfstartoffset)
             mHBFoffset32 += mDigitWordsRead + mDigitWordsRejected; // all 3 in 32bit units
             mTotalDigitWordsRead += mDigitWordsRead;
             mTotalDigitWordsRejected += mDigitWordsRejected;
-          }
           sumlinklengths += mCurrentHalfCRULinkLengths[currentlinkindex];
           sumtrackletwords += mTrackletWordsRead;
           sumdigitwords += mDigitWordsRead;

--- a/Detectors/TRD/reconstruction/src/DigitsParser.cxx
+++ b/Detectors/TRD/reconstruction/src/DigitsParser.cxx
@@ -51,8 +51,7 @@ int DigitsParser::Parse(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>* 
   mDetector = detector;
   mStack = stack;
   mLayer = layer;
-  mSide = side;
-  mHalfSM = detector * 2 + mSide;
+  mHalfChamberSide = side;
   mStackLayer = mStack * constants::NLAYER + mLayer;
   mDigitHCHeader = hcheader;
   mFEEID = feeid;

--- a/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
+++ b/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
@@ -44,14 +44,14 @@ inline void TrackletsParser::swapByteOrder(unsigned int& ui)
 int TrackletsParser::Parse(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>* data,
                            std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator start,
                            std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator end,
-                           TRDFeeID feeid, int robside, int detector, int stack, int layer,
+                           TRDFeeID feeid, int halfchamberside, int detector, int stack, int layer,
                            EventRecord* eventrecord, EventStorage* eventrecords, std::bitset<16> options, bool cleardigits, int usetracklethcheader)
 {
   mStartParse = start;
   mEndParse = end;
   mDetector = detector;
   mFEEID = feeid;
-  mRobSide = robside;
+  mHalfChamberSide = halfchamberside;
   mStack = stack;
   mLayer = layer;
   mOptions = options;
@@ -278,12 +278,12 @@ int TrackletsParser::Parse()
             int col = mTrackletMCMHeader->col;
             int pos = mTrackletMCMData->pos;
             int slope = mTrackletMCMData->slope;
-            int hcid = mDetector * 2 + mRobSide;
-            if (mDataVerbose) {
+            int hcid = mDetector * 2 + mHalfChamberSide;
+            if (mHeaderVerbose) {
               if (mTrackletHCHeaderState) {
-                LOG(info) << "Tracklet HCID : " << hcid << " mDetector:" << mDetector << " robside:" << mRobSide << " " << mTrackletMCMHeader->padrow << ":" << mTrackletMCMHeader->col << " ---- " << mTrackletHCHeader->supermodule << ":" << mTrackletHCHeader->stack << ":" << mTrackletHCHeader->layer << ":" << mTrackletHCHeader->side << " rawhcheader : 0x" << std::hex << std::hex << mTrackletHCHeader->word;
+                LOG(info) << "Tracklet HCID : " << hcid << " mDetector:" << mDetector << " robside:" << mHalfChamberSide << " " << mTrackletMCMHeader->padrow << ":" << mTrackletMCMHeader->col << " ---- " << mTrackletHCHeader->supermodule << ":" << mTrackletHCHeader->stack << ":" << mTrackletHCHeader->layer << ":" << mTrackletHCHeader->side << " rawhcheader : 0x" << std::hex << std::hex << mTrackletHCHeader->word;
               } else {
-                LOG(info) << "Tracklet HCID : " << hcid << " mDetector:" << mDetector << " robside:" << mRobSide << " " << mTrackletMCMHeader->padrow << ":" << mTrackletMCMHeader->col;
+                LOG(info) << "Tracklet HCID : " << hcid << " mDetector:" << mDetector << " robside:" << mHalfChamberSide << " " << mTrackletMCMHeader->padrow << ":" << mTrackletMCMHeader->col;
               }
             }
             //TODO cross reference hcid to somewhere for a check. mDetector is assigned at the time of parser init.


### PR DESCRIPTION
- fix halfchamberside and a/c side mix up for stats.
- reduce messages for config events, was 20 but then 20 per epn... now zero.
- add tracklet detail printout to headerverbose.