### PR TITLE
TPC: track and cluster filter, Kr file writer sync. reco

### DIFF
--- a/Detectors/TPC/calibration/CMakeLists.txt
+++ b/Detectors/TPC/calibration/CMakeLists.txt
@@ -35,10 +35,12 @@ o2_add_library(TPCCalibration
                        src/IDCCCDBHelper.cxx
                        src/CalibdEdx.cxx
                        src/CalibratordEdx.cxx
+                       src/TrackDump.cxx
                PUBLIC_LINK_LIBRARIES O2::DataFormatsTPC O2::TPCBase
                                      O2::TPCReconstruction ROOT::Minuit
                                      Microsoft.GSL::GSL
                                      O2::DetectorsCalibration
+                                     O2::GPUO2Interface
                                      O2::CCDB)
 
 o2_target_root_dictionary(TPCCalibration
@@ -66,7 +68,8 @@ o2_target_root_dictionary(TPCCalibration
                                   include/TPCCalibration/IDCFourierTransform.h
                                   include/TPCCalibration/IDCCCDBHelper.h
                                   include/TPCCalibration/CalibdEdx.h
-                                  include/TPCCalibration/CalibratordEdx.h)
+                                  include/TPCCalibration/CalibratordEdx.h
+                                  include/TPCCalibration/TrackDump.h)
 
 o2_add_executable(dcs-sim-workflow
                   COMPONENT_NAME tpc

--- a/Detectors/TPC/calibration/include/TPCCalibration/TrackDump.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/TrackDump.h
@@ -1,0 +1,89 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TPC_TrackDump_H_
+#define O2_TPC_TrackDump_H_
+
+#include <Rtypes.h>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <gsl/span>
+#include <vector>
+
+#include "DataFormatsTPC/TrackTPC.h"
+#include "CommonUtils/TreeStreamRedirector.h"
+
+/// \file TrackDump.h
+/// \author Jens Wiechula (Jens.Wiechula@ikf.uni-frankfurt.de)
+
+namespace o2::tpc
+{
+
+class ClusterNativeAccess;
+
+/// The class can be used to dump track and associated clusters to a tree to easily iterate over them and draw them
+class TrackDump
+{
+ public:
+  struct ClusterGlobal {
+    float gx{};
+    float gy{};
+    uint16_t qMax; //< QMax of the cluster
+    uint16_t qTot; //< Total charge of the cluster
+    uint8_t sector = 0;
+    uint8_t padrow = 0;
+
+    ClassDefNV(ClusterGlobal, 1);
+  };
+
+  struct ClusterNativeAdd : public ClusterNative {
+    ClusterNativeAdd() = default;
+    ClusterNativeAdd(const ClusterNative& cl) : ClusterNative(cl){};
+    ~ClusterNativeAdd() = default;
+
+    // float z = 0.f;
+
+    float tgl = 0.f;
+    float snp = 0.f;
+    uint8_t sector = 0;
+    uint8_t padrow = 0;
+
+    float getLx() const;
+    float getLy() const;
+    float getGx() const;
+    float getGy() const;
+
+    ClassDefNV(ClusterNativeAdd, 1);
+  };
+
+  struct TrackInfo : public TrackTPC {
+    TrackInfo() = default;
+    TrackInfo(const TrackTPC& track) : TrackTPC(track){};
+    TrackInfo(const TrackInfo&) = default;
+    ~TrackInfo() = default;
+
+    std::vector<ClusterNativeAdd> clusters{};
+
+    ClassDefNV(TrackInfo, 1);
+  };
+
+  void filter(const gsl::span<const TrackTPC> tracks, ClusterNativeAccess const& clusterIndex, const gsl::span<const o2::tpc::TPCClRefElem> clRefs);
+  void finalize();
+
+  std::string outputFileName{"filtered-tracks-and-clusters.root"}; ///< Name of the output file with the tree
+  bool writeTracks{true};                                          ///< write global cluster information for quick drawing
+  bool writeGlobal{false};                                         ///< write global cluster information for quick drawing
+ private:
+  std::unique_ptr<o2::utils::TreeStreamRedirector> mTreeDump; ///< Tree writer
+};
+} // namespace o2::tpc
+#endif

--- a/Detectors/TPC/calibration/src/TPCCalibrationLinkDef.h
+++ b/Detectors/TPC/calibration/src/TPCCalibrationLinkDef.h
@@ -70,5 +70,14 @@
 #pragma link C++ class o2::tpc::CalibratordEdx + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::tpc::CalibdEdx> + ;
 #pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tpc::TrackTPC, o2::tpc::CalibdEdx> + ;
+#pragma link C++ class o2::tpc::TrackDump + ;
+#pragma link C++ class o2::tpc::TrackDump::ClusterNativeAdd + ;
+#pragma link C++ class o2::tpc::TrackDump::ClusterGlobal + ;
+#pragma link C++ class std::vector < o2::tpc::TrackDump::ClusterNativeAdd> + ;
+#pragma link C++ class std::vector < std::vector < o2::tpc::TrackDump::ClusterNativeAdd>> + ;
+#pragma link C++ class std::vector < o2::tpc::TrackDump::ClusterGlobal> + ;
+#pragma link C++ class std::vector < std::vector < o2::tpc::TrackDump::ClusterGlobal>> + ;
+#pragma link C++ class o2::tpc::TrackDump::TrackInfo + ;
+#pragma link C++ class std::vector < o2::tpc::TrackDump::TrackInfo> + ;
 
 #endif

--- a/Detectors/TPC/calibration/src/TrackDump.cxx
+++ b/Detectors/TPC/calibration/src/TrackDump.cxx
@@ -1,0 +1,108 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <vector>
+#include "GPUO2Interface.h"
+#include "GPUDefOpenCL12Templates.h"
+#include "GPUDefConstantsAndSettings.h"
+#include "SliceTracker/GPUTPCGeometry.h"
+
+#include "DataFormatsTPC/Defs.h"
+#include "DataFormatsTPC/ClusterNative.h"
+#include "TPCBase/Mapper.h"
+#include "TPCCalibration/TrackDump.h"
+
+using namespace o2::tpc;
+using namespace o2::tpc::constants;
+
+void TrackDump::filter(const gsl::span<const TrackTPC> tracks, ClusterNativeAccess const& clusterIndex, const gsl::span<const o2::tpc::TPCClRefElem> clRefs)
+{
+  if (!mTreeDump && outputFileName.size()) {
+    mTreeDump = std::make_unique<utils::TreeStreamRedirector>(outputFileName.data(), "recreate");
+  }
+
+  std::vector<TrackInfo> tpcTracks;
+  std::vector<std::vector<ClusterGlobal>> clustersGlobalEvent;
+  std::vector<ClusterGlobal>* clustersGlobal{};
+
+  GPUCA_NAMESPACE::gpu::GPUTPCGeometry gpuGeom;
+
+  for (const auto& track : tracks) {
+    const int nCl = track.getNClusterReferences();
+    auto& trackInfo = tpcTracks.emplace_back(track);
+    auto& clInfos = trackInfo.clusters;
+    if (writeGlobal) {
+      clustersGlobal = &clustersGlobalEvent.emplace_back();
+    }
+
+    for (int j = nCl - 1; j >= 0; j--) {
+      uint8_t sector, padrow;
+      uint32_t clusterIndexInRow;
+      track.getClusterReference(clRefs, j, sector, padrow, clusterIndexInRow);
+      const auto& cl = clusterIndex.clusters[sector][padrow][clusterIndexInRow];
+      auto& clInfo = clInfos.emplace_back(cl);
+      clInfo.sector = sector;
+      clInfo.padrow = padrow;
+
+      if (clustersGlobal) {
+        auto& clGlobal = clustersGlobal->emplace_back(ClusterGlobal{clInfo.getGx(), clInfo.getGy(), cl.qMax, cl.qTot, sector, padrow});
+      }
+    }
+  }
+
+  if (mTreeDump) {
+    auto& tree = (*mTreeDump) << "tpcrec";
+    if (writeTracks) {
+      //  << "info=" << trackInfos
+      tree << "TPCTracks=" << tpcTracks;
+    }
+    if (writeGlobal) {
+      tree << "cls" << clustersGlobalEvent;
+    }
+    tree << "\n";
+    //  << "clusters=" << clInfoVec
+  }
+}
+
+void TrackDump::finalize()
+{
+  if (mTreeDump) {
+    mTreeDump->Close();
+  }
+
+  mTreeDump.reset();
+}
+
+float TrackDump::ClusterNativeAdd::getLx() const
+{
+  static GPUCA_NAMESPACE::gpu::GPUTPCGeometry gpuGeom;
+  return gpuGeom.Row2X(padrow);
+}
+
+float TrackDump::ClusterNativeAdd::getLy() const
+{
+  static GPUCA_NAMESPACE::gpu::GPUTPCGeometry gpuGeom;
+  return gpuGeom.LinearPad2Y(sector, padrow, getPad());
+}
+
+float TrackDump::ClusterNativeAdd::getGx() const
+{
+  const LocalPosition2D l2D{getLx(), getLy()};
+  const auto g2D = Mapper::LocalToGlobal(l2D, Sector(sector));
+  return g2D.x();
+}
+
+float TrackDump::ClusterNativeAdd::getGy() const
+{
+  const LocalPosition2D l2D{getLx(), getLy()};
+  const auto g2D = Mapper::LocalToGlobal(l2D, Sector(sector));
+  return g2D.y();
+}

--- a/Detectors/TPC/workflow/CMakeLists.txt
+++ b/Detectors/TPC/workflow/CMakeLists.txt
@@ -31,6 +31,7 @@ o2_add_library(TPCWorkflow
                        src/MonitorWorkflowSpec.cxx
                        src/ProcessingHelpers.cxx
                        src/TrackAndClusterFilterSpec.cxx
+                       src/FileWriterSpec.cxx
                TARGETVARNAME targetName
                PUBLIC_LINK_LIBRARIES O2::Framework O2::DataFormatsTPC
                                      O2::DPLUtils O2::TPCReconstruction

--- a/Detectors/TPC/workflow/CMakeLists.txt
+++ b/Detectors/TPC/workflow/CMakeLists.txt
@@ -30,6 +30,7 @@ o2_add_library(TPCWorkflow
                        src/ApplyCCDBCalibSpec.cxx
                        src/MonitorWorkflowSpec.cxx
                        src/ProcessingHelpers.cxx
+                       src/TrackAndClusterFilterSpec.cxx
                TARGETVARNAME targetName
                PUBLIC_LINK_LIBRARIES O2::Framework O2::DataFormatsTPC
                                      O2::DPLUtils O2::TPCReconstruction
@@ -158,6 +159,11 @@ o2_add_executable(idc-test-ft
 o2_add_executable(miptrack-filter
                   COMPONENT_NAME tpc
                   SOURCES src/tpc-miptrack-filter.cxx
+                  PUBLIC_LINK_LIBRARIES O2::TPCWorkflow)
+
+o2_add_executable(track-and-cluster-filter
+                  COMPONENT_NAME tpc
+                  SOURCES src/track-and-cluster-filter.cxx
                   PUBLIC_LINK_LIBRARIES O2::TPCWorkflow)
 
 o2_add_test(workflow

--- a/Detectors/TPC/workflow/include/TPCWorkflow/FileWriterSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/FileWriterSpec.h
@@ -1,0 +1,34 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   FileWriterSpec.h
+/// \brief  Writer for calibration data
+/// \author Jens Wiechula
+
+#ifndef TPC_FileWriterSpec_H_
+#define TPC_FileWriterSpec_H_
+
+#include "Framework/DataProcessorSpec.h"
+#include <string>
+
+namespace o2
+{
+namespace tpc
+{
+
+/// create a processor spec
+/// read simulated TPC clusters from file and publish
+o2::framework::DataProcessorSpec getFileWriterSpec(const std::string inputSpec);
+
+} // end namespace tpc
+} // end namespace o2
+
+#endif // TPC_RAWTODIGITSSPEC_H_

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TrackAndClusterFilterSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TrackAndClusterFilterSpec.h
@@ -1,0 +1,31 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   MonitorWorkflowSpec.h
+/// @author Jens Wiechula
+/// @since  2020-01-17
+/// @brief  Raw data monitor workflow
+
+#ifndef TPC_MonitorWorkflowSpec_H_
+#define TPC_MonitorWorkflowSpec_H_
+
+#include "Framework/DataProcessorSpec.h"
+
+namespace o2::tpc
+{
+
+/// create a processor spec
+/// read simulated TPC clusters from file and publish
+o2::framework::DataProcessorSpec getTrackAndClusterFilterSpec();
+
+} // namespace o2::tpc
+
+#endif // TPC_MonitorWorkflowSpec_H_

--- a/Detectors/TPC/workflow/src/FileWriterSpec.cxx
+++ b/Detectors/TPC/workflow/src/FileWriterSpec.cxx
@@ -1,0 +1,320 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file FileWriterSpec.cxx
+/// \brief  Writer for calibration data
+/// \author Jens Wiechula, Jens.Wiechula@ikf.uni-frankfurt.de
+//
+#include <filesystem>
+#include <memory>
+#include <vector>
+#include <string>
+#include "fmt/format.h"
+
+#include "TTree.h"
+
+#include <FairMQDevice.h>
+#include "Framework/Task.h"
+#include "Framework/RawDeviceService.h"
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/Logger.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/WorkflowSpec.h"
+#include "Framework/InputRecordWalker.h"
+
+#include "Headers/DataHeader.h"
+#include "DetectorsCommonDataFormats/NameConf.h"
+#include "DetectorsCommonDataFormats/FileMetaData.h"
+#include "DetectorsCommonDataFormats/DetID.h"
+
+#include "TPCWorkflow/ProcessingHelpers.h"
+#include "DataFormatsTPC/Digit.h"
+#include "DataFormatsTPC/KrCluster.h"
+#include "DataFormatsTPC/TPCSectorHeader.h"
+#include "TPCBase/Sector.h"
+
+using namespace o2::framework;
+using o2::dataformats::FileMetaData;
+using SubSpecificationType = DataAllocator::SubSpecificationType;
+using DetID = o2::detectors::DetID;
+
+namespace o2::tpc
+{
+
+class FileWriterDevice : public Task
+{
+ public:
+  FileWriterDevice() = default;
+
+  void init(InitContext& ic) final
+  {
+    mOutDir = o2::utils::Str::rectifyDirectory(ic.options().get<std::string>("output-dir"));
+
+    mCreateRunEnvDir = !ic.options().get<bool>("ignore-partition-run-dir");
+    mMaxTFPerFile = ic.options().get<int>("max-tf-per-file");
+    mMetaFileDir = ic.options().get<std::string>("meta-output-dir");
+    if (mMetaFileDir != "/dev/null") {
+      mMetaFileDir = o2::utils::Str::rectifyDirectory(mMetaFileDir);
+      mStoreMetaFile = true;
+    }
+  }
+
+  void run(ProcessingContext& pc) final
+  {
+    const std::string NAStr = "NA";
+
+    const auto dh = DataRefUtils::getHeader<o2::header::DataHeader*>(pc.inputs().getFirstValid(true));
+    auto oldRun = mRun;
+    auto oldOrbit = mFirstTForbit;
+    mRun = processing_helpers::getRunNumber(pc);
+    mPresentTF = dh->tfCounter;
+    mFirstTForbit = dh->firstTForbit;
+
+    LOGP(info, "run: {}, TF: {}, Orbit: {} ({}), info branches: {}", mRun, mPresentTF, mFirstTForbit, oldOrbit, mInfoBranches.size());
+
+    auto oldEnv = mEnvironmentID;
+    {
+      auto envN = pc.services().get<RawDeviceService>().device()->fConfig->GetProperty<std::string>("environment_id", NAStr);
+      if (envN != NAStr) {
+        mEnvironmentID = envN;
+      }
+    }
+    if ((oldRun != 0 && oldRun != mRun) || (!oldEnv.empty() && oldEnv != mEnvironmentID)) {
+      LOGP(WARNING, "RunNumber/Environment changed from {}/{} to {}/{}", oldRun, oldEnv, mRun, mEnvironmentID);
+      closeTreeAndFile();
+    }
+    // check for the LHCPeriod
+    if (mLHCPeriod.empty()) {
+      auto LHCPeriodStr = pc.services().get<RawDeviceService>().device()->fConfig->GetProperty<std::string>("LHCPeriod", NAStr);
+      if (LHCPeriodStr != NAStr) {
+        mLHCPeriod = LHCPeriodStr;
+      } else {
+        const char* months[12] = {"JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"};
+        time_t now = time(nullptr);
+        auto ltm = gmtime(&now);
+        mLHCPeriod = months[ltm->tm_mon];
+        LOG(WARNING) << "LHCPeriod is not available, using current month " << mLHCPeriod;
+      }
+      mLHCPeriod += fmt::format("_{}", DetID::getName(DetID::TPC));
+    }
+
+    if (mWrite && (mFirstTForbit != oldOrbit)) {
+      prepareTreeAndFile(dh);
+
+      for (auto br : mInfoBranches) {
+        br->Fill();
+        LOGP(info, "Filling branch {}", br->GetName());
+      }
+      mTFOrbits.push_back(mFirstTForbit);
+      ++mNTFs;
+    }
+
+    bool hasData = false;
+    for (auto const& inputRef : InputRecordWalker(pc.inputs())) {
+      auto const* sectorHeader = DataRefUtils::getHeader<TPCSectorHeader*>(inputRef);
+      if (sectorHeader == nullptr) {
+        LOGP(error, "sector header missing on header stack for input on ", inputRef.spec->binding);
+        continue;
+      }
+
+      const int sector = sectorHeader->sector();
+      auto inData = pc.inputs().get<std::vector<o2::tpc::KrCluster>>(inputRef);
+      auto dataPtr = &inData;
+
+      if (!mDataBranches[sector]) {
+        mDataBranches[sector] = mTreeOut->Branch(fmt::format("TPCBoxCluster_{}", sector).data(), &inData);
+      } else {
+        mDataBranches[sector]->SetAddress(&dataPtr);
+      }
+      mDataBranches[sector]->Fill();
+      mDataBranches[sector]->ResetAddress();
+
+      LOGP(info, "getting data for sector {}", sector);
+      hasData = true;
+    }
+
+    //if (hasData && mTreeOut) {
+    //LOGP(info, "fill tree");
+    //mTreeOut->Fill();
+    //}
+    //for (auto br : mDataBranches) {
+    //if (br) {
+    //br->ResetAddress();
+    //}
+    //}
+  }
+
+  void endOfStream(EndOfStreamContext& ec) final
+  {
+    closeTreeAndFile();
+  }
+
+  void stop() final
+  {
+    closeTreeAndFile();
+  }
+
+ private:
+  std::array<TBranch*, Sector::MAXSECTOR> mDataBranches{}; ///< data branch pointers
+  std::vector<TBranch*> mInfoBranches;                     ///< common information
+  std::vector<uint32_t> mTFOrbits{};                       ///< 1st orbits of TF accumulated in current file
+  std::unique_ptr<TFile> mFileOut;                         ///< output file containin the tree
+  std::unique_ptr<TTree> mTreeOut;                         ///< output tree
+  std::unique_ptr<FileMetaData> mFileMetaData;             ///< meta data file for eos and alien file creation
+  std::string mOutDir{};                                   ///< file output direcotry
+  std::string mLHCPeriod{};                                ///< LHC period under which to register the data on eos and alien
+  std::string mMetaFileDir{"/dev/null"};                   ///< output directory for meta data file
+  std::string mCurrentFileName{};                          ///< current file name
+  std::string mCurrentFileNameFull{};                      ///< current file name with full directory
+  std::string mEnvironmentID{};                            ///< partition env. id
+  uint64_t mRun = 0;                                       ///< present run number
+  uint32_t mPresentTF = 0;                                 ///< present TF number
+  uint32_t mFirstTForbit = 0;                              ///< first orbit of present tf
+  size_t mNTFs = 0;                                        ///< total number of TFs accumulated in the current file
+  size_t mNFiles = 0;                                      ///< total number of calibration files written
+  int mMaxTFPerFile = 0;                                   ///< maximum number of TFs per file
+  bool mStoreMetaFile = false;                             ///< store the meata data file?
+  bool mWrite = true;                                      ///< write data
+  bool mCreateRunEnvDir = true;                            ///< create the output directory structure?
+
+  static constexpr std::string_view TMPFileEnding{".part"};
+
+  void prepareTreeAndFile(const o2::header::DataHeader* dh);
+  void closeTreeAndFile();
+};
+//___________________________________________________________________
+void FileWriterDevice::prepareTreeAndFile(const o2::header::DataHeader* dh)
+{
+  if (!mWrite) {
+    return;
+  }
+  bool needToOpen = false;
+  if (!mTreeOut) {
+    needToOpen = true;
+  } else {
+    if ((mMaxTFPerFile > 0) && (mNTFs >= mMaxTFPerFile)) {
+      needToOpen = true;
+    }
+  }
+  if (needToOpen) {
+    LOGP(info, "opening new file");
+    closeTreeAndFile();
+    //auto fname = o2::base::NameConf::getCTFFileName(mRun, dh->firstTForbit, dh->tfCounter, "tpc_krypton");
+    auto ctfDir = mOutDir.empty() ? o2::utils::Str::rectifyDirectory("./") : mOutDir;
+    //if (mChkSize > 0 && (mDirFallBack != "/dev/null")) {
+    //createLockFile(dh, 0);
+    //auto sz = getAvailableDiskSpace(ctfDir, 0); // check main storage
+    //if (sz < mChkSize) {
+    //removeLockFile();
+    //LOG(WARNING) << "Primary  output device has available size " << sz << " while " << mChkSize << " is requested: will write on secondary one";
+    //ctfDir = mDirFallBack;
+    //}
+    //}
+    if (mCreateRunEnvDir && !mEnvironmentID.empty()) {
+      ctfDir += fmt::format("{}_{}/", mEnvironmentID, mRun);
+      if (!std::filesystem::exists(ctfDir)) {
+        if (!std::filesystem::create_directories(ctfDir)) {
+          throw std::runtime_error(fmt::format("Failed to create {} directory", ctfDir));
+        } else {
+          LOG(INFO) << "Created {} directory for s output" << ctfDir;
+        }
+      }
+    }
+    mCurrentFileName = o2::base::NameConf::getCTFFileName(mRun, dh->firstTForbit, dh->tfCounter, "tpc_krypton");
+    mCurrentFileNameFull = fmt::format("{}{}", ctfDir, mCurrentFileName);
+    mFileOut.reset(TFile::Open(fmt::format("{}{}", mCurrentFileNameFull, TMPFileEnding).c_str(), "recreate")); // to prevent premature external usage, use temporary name
+    mTreeOut = std::make_unique<TTree>("Clusters", "O2 tree");
+    mInfoBranches.emplace_back(mTreeOut->Branch("run", &mRun));
+    mInfoBranches.emplace_back(mTreeOut->Branch("tfCounter", &mPresentTF));
+    mInfoBranches.emplace_back(mTreeOut->Branch("firstOrbit", &mFirstTForbit));
+    LOGP(info, "created {} info branches", mInfoBranches.size());
+    //for (int iSec = 0; iSec < Sector::MAXSECTOR; ++iSec) {
+    //std::vector<KrCluster> clusters;
+    //LOGP(info, "creating branch for sector {} on tree {} with name {}", iSec, (void*)mTreeOut.get(), fmt::format("TPCBoxCluster_{}", iSec).data());
+    //mDataBranches[iSec] = mTreeOut->Branch(fmt::format("TPCBoxCluster_{}", iSec).data(), &clusters);
+    //mDataBranches[iSec]->ResetAddress();
+    //}
+    if (mStoreMetaFile) {
+      mFileMetaData = std::make_unique<o2::dataformats::FileMetaData>();
+    }
+
+    mNFiles++;
+  }
+}
+//___________________________________________________________________
+void FileWriterDevice::closeTreeAndFile()
+{
+  if (!mTreeOut) {
+    return;
+  }
+
+  LOGP(info, "closing file {}", mCurrentFileName);
+  try {
+    mFileOut->cd();
+    mTreeOut->SetEntries();
+    mTreeOut->Write();
+    mTreeOut.reset();
+    mFileOut->Close();
+    mFileOut.reset();
+    if (!TMPFileEnding.empty()) {
+      std::filesystem::rename(o2::utils::Str::concat_string(mCurrentFileNameFull, TMPFileEnding), mCurrentFileNameFull);
+    }
+    // write  file metaFile data
+    if (mStoreMetaFile) {
+      mFileMetaData->fillFileData(mCurrentFileNameFull);
+      mFileMetaData->run = mRun;
+      mFileMetaData->LHCPeriod = mLHCPeriod;
+      mFileMetaData->type = "raw";
+      auto metaFileNameTmp = fmt::format("{}{}.tmp", mMetaFileDir, mCurrentFileName);
+      auto metaFileName = fmt::format("{}{}.done", mMetaFileDir, mCurrentFileName);
+      try {
+        std::ofstream metaFileOut(metaFileNameTmp);
+        metaFileOut << *mFileMetaData.get();
+        metaFileOut << "TFOrbits: ";
+        for (size_t i = 0; i < mTFOrbits.size(); i++) {
+          metaFileOut << fmt::format("{}{}", i ? ", " : "", mTFOrbits[i]);
+        }
+        metaFileOut << '\n';
+        metaFileOut.close();
+        std::filesystem::rename(metaFileNameTmp, metaFileName);
+      } catch (std::exception const& e) {
+        LOG(ERROR) << "Failed to store  meta data file " << metaFileName << ", reason: " << e.what();
+      }
+      mFileMetaData.reset();
+    }
+  } catch (std::exception const& e) {
+    LOG(ERROR) << "Failed to finalize  file " << mCurrentFileNameFull << ", reason: " << e.what();
+  }
+  mTFOrbits.clear();
+  mInfoBranches.clear();
+  std::fill(mDataBranches.begin(), mDataBranches.end(), nullptr);
+  mNTFs = 0;
+  //mAccSize = 0;
+  //removeLockFile();
+}
+
+DataProcessorSpec getFileWriterSpec(const std::string inputSpec)
+{
+  return DataProcessorSpec{
+    "file-writer",
+    select(inputSpec.data()),
+    Outputs{},
+    AlgorithmSpec{adaptFromTask<FileWriterDevice>()},
+    Options{
+      {"output-dir", VariantType::String, "none", {" output directory, must exist"}},
+      {"meta-output-dir", VariantType::String, "/dev/null", {" metadata output directory, must exist (if not /dev/null)"}},
+      {"max-tf-per-file", VariantType::Int, 0, {"if > 0, avoid storing more than requested TFs per file"}},
+      {"ignore-partition-run-dir", VariantType::Bool, false, {"Do not creare partition-run directory in output-dir"}},
+    }};
+}; // end DataProcessorSpec
+
+} // namespace o2::tpc

--- a/Detectors/TPC/workflow/src/TrackAndClusterFilterSpec.cxx
+++ b/Detectors/TPC/workflow/src/TrackAndClusterFilterSpec.cxx
@@ -1,0 +1,118 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <vector>
+#include <string>
+#include "fmt/format.h"
+
+#include "Framework/Task.h"
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/Logger.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/WorkflowSpec.h"
+
+#include "DataFormatsTPC/WorkflowHelper.h"
+#include "DataFormatsTPC/TPCSectorHeader.h"
+#include "Headers/DataHeader.h"
+#include "Headers/DataHeaderHelpers.h"
+#include "DetectorsCalibration/Utils.h"
+#include "TPCCalibration/TrackDump.h"
+
+using namespace o2::framework;
+using SubSpecificationType = o2::framework::DataAllocator::SubSpecificationType;
+
+namespace o2::tpc
+{
+
+class TrackAndClusterFilterDevice : public o2::framework::Task
+{
+ public:
+  TrackAndClusterFilterDevice() = default;
+
+  void init(o2::framework::InitContext& ic) final
+  {
+    mTrackDump.outputFileName = ic.options().get<std::string>("output-file");
+    mTrackDump.writeTracks = ic.options().get<bool>("write-tracks");
+    mTrackDump.writeGlobal = ic.options().get<bool>("write-global-cluster-info");
+  }
+
+  void run(o2::framework::ProcessingContext& pc) final
+  {
+    // for (auto const& ref : pc.inputs()) {
+    //   const auto* dh = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
+    //   LOGP(info, "Specifier: {}/{}/{} Part {} of {}", dh->dataOrigin, dh->dataDescription, dh->subSpecification, dh->splitPayloadIndex, dh->splitPayloadParts);
+    // }
+    const auto tracks = pc.inputs().get<gsl::span<o2::tpc::TrackTPC>>("trackTPC");
+    const auto clRefs = pc.inputs().get<gsl::span<o2::tpc::TPCClRefElem>>("trackTPCClRefs");
+    const auto& clustersInputs = getWorkflowTPCInput(pc);
+
+    std::vector<TrackTPC> filteredTracks;
+    std::copy_if(tracks.begin(), tracks.end(), std::back_inserter(filteredTracks),
+                 [this](const auto& track) { return isGood(track); });
+
+    LOGP(info, "Filtered {} good tracks out of {} total tpc tracks", filteredTracks.size(), tracks.size());
+
+    mTrackDump.filter(tracks, clustersInputs->clusterIndex, clRefs);
+  }
+
+  void endOfStream(o2::framework::EndOfStreamContext& /*ec*/) final
+  {
+    stop();
+  }
+
+  void stop() final
+  {
+    mTrackDump.finalize();
+  }
+
+ private:
+  TrackDump mTrackDump;
+
+  bool isGood(const TrackTPC& track)
+  {
+    if (track.getP() < 0.02) {
+      return false;
+    }
+
+    if (track.getNClusters() < 60) {
+      return false;
+    }
+
+    if (track.getdEdx().dEdxTotTPC < 20) {
+      return false;
+    }
+
+    return true;
+  }
+};
+
+DataProcessorSpec getTrackAndClusterFilterSpec()
+{
+  std::vector<InputSpec> inputs;
+  std::vector<OutputSpec> outputs;
+  inputs.emplace_back("trackTPC", "TPC", "TRACKS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("trackTPCClRefs", "TPC", "CLUSREFS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("clusTPC", ConcreteDataTypeMatcher{"TPC", "CLUSTERNATIVE"}, Lifetime::Timeframe);
+
+  return DataProcessorSpec{
+    "tpc-track-and-cluster-filter",
+    inputs,
+    outputs,
+    AlgorithmSpec{adaptFromTask<TrackAndClusterFilterDevice>()},
+    Options{
+      {"output-file", VariantType::String, "filtered-track-and-clusters.root", {"output file name"}},
+      {"write-tracks", VariantType::Bool, true, {"dump filtered tracks and clusters"}},
+      {"write-global-cluster-info", VariantType::Bool, false, {"write simple clusters tree"}},
+    } // end Options
+  };  // end DataProcessorSpec
+}
+} // namespace o2::tpc

--- a/Detectors/TPC/workflow/src/track-and-cluster-filter.cxx
+++ b/Detectors/TPC/workflow/src/track-and-cluster-filter.cxx
@@ -1,0 +1,63 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <vector>
+
+#include "Framework/WorkflowSpec.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicy.h"
+#include "Framework/CompletionPolicyHelpers.h"
+#include "TPCCalibration/TrackDump.h"
+#include "TPCReaderWorkflow/TPCSectorCompletionPolicy.h"
+#include "TPCWorkflow/TrackAndClusterFilterSpec.h"
+
+using namespace o2::framework;
+
+// customize the completion policy
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  using o2::framework::CompletionPolicy;
+  policies.push_back(CompletionPolicyHelpers::defineByName("tpc-track-and-cluster-filter", CompletionPolicy::CompletionOp::Consume));
+
+  // the TPC sector completion policy checks when the set of TPC/CLUSTERNATIVE data is complete
+  // in addition we require to have input from all other routes
+  policies.push_back(o2::tpc::TPCSectorCompletionPolicy("tpc-track-and-cluster-filter",
+                                                        o2::tpc::TPCSectorCompletionPolicy::Config::RequireAll,
+                                                        InputSpec{"cluster", ConcreteDataTypeMatcher{"TPC", "CLUSTERNATIVE"}})());
+}
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+
+  std::vector<ConfigParamSpec> options{
+    // {"use-digit-input", VariantType::Bool, false, {"use TPC digits as input, instead of raw data"}},
+    // {"input-spec", VariantType::String, "tpcraw:TPC/RAWDATA", {"selection string input specs"}},
+  };
+
+  std::swap(workflowOptions, options);
+}
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfg)
+{
+  // const bool useDigitsAsInput = cfg.options().get<bool>("use-digit-input");
+  // const auto inputSpec = cfg.options().get<std::string>("input-spec");
+
+  WorkflowSpec specs;
+
+  specs.emplace_back(o2::tpc::getTrackAndClusterFilterSpec());
+
+  return specs;
+}


### PR DESCRIPTION
* Add a track and cluster filter for quick visualization and development purposes. The custers are stored together with track
* For synchronous data taking with the Kr-cluster finder a dedicated writer is implemented which stores also the required meta data file for automatic eos export and alien registration. This is based on the CTFWriter.