### PR TITLE
TRD possibility to flag noisy MCMs

### DIFF
--- a/DataFormats/Detectors/TRD/CMakeLists.txt
+++ b/DataFormats/Detectors/TRD/CMakeLists.txt
@@ -20,6 +20,7 @@ o2_add_library(DataFormatsTRD
                        src/CTF.cxx
                        src/Digit.cxx
                        src/KrCluster.cxx
+                       src/NoiseCalibration.cxx
                PUBLIC_LINK_LIBRARIES O2::CommonDataFormat O2::SimulationDataFormat)
 
 o2_target_root_dictionary(DataFormatsTRD
@@ -36,6 +37,7 @@ o2_target_root_dictionary(DataFormatsTRD
                        include/DataFormatsTRD/Digit.h
                        include/DataFormatsTRD/KrCluster.h
                        include/DataFormatsTRD/KrClusterTriggerRecord.h
+                       include/DataFormatsTRD/NoiseCalibration.h
                        include/DataFormatsTRD/CTF.h
                        include/DataFormatsTRD/CalVdriftExB.h
                        include/DataFormatsTRD/SignalArray.h

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
@@ -27,6 +27,7 @@ constexpr int NSTACK = 5;          // the number of stacks per sector
 constexpr int NLAYER = 6;          // the number of layers
 constexpr int NCHAMBERPERSEC = 30; // the number of chambers per sector
 constexpr int MAXCHAMBER = 540;    // the maximum number of installed chambers
+constexpr int MAXHALFCHAMBER = 1080; // the maximum number of installed half-chambers
 constexpr int NCHAMBER = 521;      // the number of chambers actually installed
 constexpr int NHALFCRU = 72;       // the number of half cru (link bundles)
 constexpr int NLINKSPERHALFCRU = 15; // the number of links per half cru or cru end point.

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/NoiseCalibration.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/NoiseCalibration.h
@@ -1,0 +1,65 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_TRD_NOISECALIBRATION_H
+#define ALICEO2_TRD_NOISECALIBRATION_H
+
+#include "Rtypes.h"
+#include <bitset>
+#include "DataFormatsTRD/Constants.h"
+#include "DataFormatsTRD/Tracklet64.h"
+
+namespace o2
+{
+namespace trd
+{
+
+/// \class NoiseStatusMCM
+/// \brief Simple noise status bit for each MCM of the TRD
+/// \author Ole Schmidt
+
+class NoiseStatusMCM
+{
+
+ public:
+  NoiseStatusMCM() = default;
+
+  // convert global MCM index into HC, ROB and MCM number
+  static constexpr void convertMcmIdxGlb(int mcmGlb, int& hcid, int& rob, int& mcm)
+  {
+    hcid = mcmGlb / constants::NMCMHCMAX;
+    int side = (hcid % 2) ? 1 : 0;
+    rob = ((mcmGlb % constants::NMCMHCMAX) / constants::NMCMROB) * 2 + side;
+    mcm = (mcmGlb % constants::NMCMHCMAX) % constants::NMCMROB;
+  }
+  // convert HC, ROB and MCM number into a global MCM index
+  static constexpr int getMcmIdxGlb(int hcid, int rob, int mcm) { return hcid * constants::NMCMHCMAX + (rob / 2) * constants::NMCMROB + mcm; }
+
+  // setters
+  void setIsNoisy(int hcid, int rob, int mcm) { mNoiseFlag.set(hcid * constants::NMCMHCMAX + rob * constants::NMCMROB + mcm); }
+  void setIsNoisy(int mcmIdxGlb) { mNoiseFlag.set(mcmIdxGlb); }
+
+  // getters
+  bool getIsNoisy(int hcid, int rob, int mcm) const { return mNoiseFlag.test(hcid * constants::NMCMHCMAX + (rob / 2) * constants::NMCMROB + mcm); }
+  bool getIsNoisy(int mcmIdxGlb) const { return mNoiseFlag.test(mcmIdxGlb); }
+  auto getNumberOfNoisyMCMs() const { return mNoiseFlag.count(); }
+  bool isTrackletFromNoisyMCM(const Tracklet64& trklt) const { return getIsNoisy(trklt.getHCID(), trklt.getROB(), trklt.getMCM()); }
+
+ private:
+  std::bitset<constants::MAXHALFCHAMBER * constants::NMCMHCMAX> mNoiseFlag{};
+
+  ClassDefNV(NoiseStatusMCM, 1);
+};
+
+} // namespace trd
+} // namespace o2
+
+#endif // ALICEO2_TRD_NOISECALIBRATION_H

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Tracklet64.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Tracklet64.h
@@ -97,6 +97,7 @@ class Tracklet64
   // ----- Getters for tracklet information -----
   GPUd() int getMCM() const { return 4 * (getPadRow() % 4) + getColumn(); }                                 // returns MCM position on ROB [0..15]
   GPUd() int getROB() const { return (getHCID() % 2) ? (getPadRow() / 4) * 2 + 1 : (getPadRow() / 4) * 2; } // returns ROB number [0..5] for C0 chamber and [0..7] for C1 chamber
+  GPUd() int getPositionBinSigned() const;
   GPUd() float getUncalibratedY() const;                                                                    // translate local position into global y (in cm) not taking into account calibrations (ExB, vDrift, t0)
   GPUd() float getUncalibratedDy(float nTbDrift = 19.4f) const;                                             // translate local slope into dy/dx with dx=3m (drift length) and default drift time in time bins (19.4 timebins / 3cm)
 
@@ -172,7 +173,7 @@ class Tracklet64
   ClassDefNV(Tracklet64, 1);
 };
 
-GPUdi() float Tracklet64::getUncalibratedY() const
+GPUdi() int Tracklet64::getPositionBinSigned() const
 {
   int padLocalBin = getPosition();
   int padLocal = 0;
@@ -181,6 +182,12 @@ GPUdi() float Tracklet64::getUncalibratedY() const
   } else {
     padLocal = padLocalBin & ((1 << constants::NBITSTRKLPOS) - 1);
   }
+  return padLocal;
+}
+
+GPUdi() float Tracklet64::getUncalibratedY() const
+{
+  int padLocal = getPositionBinSigned();
   int mcmCol = (getMCM() % constants::NMCMROBINCOL) + constants::NMCMROBINCOL * (getROB() % 2);
   float offset = -63.f + ((float)constants::NCOLMCM) * mcmCol;
   float padWidth = 0.635f + 0.03f * (getDetector() % constants::NLAYER);

--- a/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
+++ b/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
@@ -28,6 +28,7 @@
 #pragma link C++ class o2::trd::Digit + ;
 #pragma link C++ class o2::trd::KrCluster + ;
 #pragma link C++ class o2::trd::KrClusterTriggerRecord + ;
+#pragma link C++ class o2::trd::NoiseStatusMCM + ;
 #pragma link C++ class o2::trd::AngularResidHistos + ;
 #pragma link C++ class o2::trd::CalVdriftExB + ;
 #pragma link C++ class o2::trd::CompressedDigit + ;

--- a/DataFormats/Detectors/TRD/src/NoiseCalibration.cxx
+++ b/DataFormats/Detectors/TRD/src/NoiseCalibration.cxx
@@ -1,0 +1,15 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file NoiseCalibration.cxx
+/// \brief For CCDB objects related to noise calibration of the TRD
+
+#include "DataFormatsTRD/NoiseCalibration.h"

--- a/Detectors/TRD/calibration/CMakeLists.txt
+++ b/Detectors/TRD/calibration/CMakeLists.txt
@@ -9,6 +9,8 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
+add_subdirectory(macros)
+
 o2_add_library(TRDCalibration
                SOURCES src/TrackBasedCalib.cxx
                        src/CalibratorVdExB.cxx

--- a/Detectors/TRD/calibration/macros/CMakeLists.txt
+++ b/Detectors/TRD/calibration/macros/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# All rights not expressly granted are reserved.
+#
+# This software is distributed under the terms of the GNU General Public
+# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+o2_add_test_root_macro(checkNoisyMCMs.C
+                       PUBLIC_LINK_LIBRARIES O2::DataFormatsTRD
+                                             O2::CCDB
+                       LABELS trd)

--- a/Detectors/TRD/calibration/macros/checkNoisyMCMs.C
+++ b/Detectors/TRD/calibration/macros/checkNoisyMCMs.C
@@ -1,0 +1,104 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file checkNoisyMCMs.C
+/// \brief macro identify noisy MCMs based on the number of found tracklets
+
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include "CCDB/CcdbApi.h"
+#include "DataFormatsTRD/NoiseCalibration.h"
+#include "DataFormatsTRD/Tracklet64.h"
+#include "DataFormatsTRD/TriggerRecord.h"
+
+#include <TFile.h>
+#include <TTree.h>
+
+#include <string>
+#include <vector>
+#include <utility>
+#include <map>
+#include <algorithm>
+
+#endif
+
+void checkNoisyMCMs(std::string inpFile = "trdtracklets.root", bool enableWriteCCDB = false)
+{
+  using namespace o2::trd;
+
+  NoiseStatusMCM noiseMap;
+
+  auto fIn = TFile::Open(inpFile.c_str(), "open");
+  if (!fIn) {
+    printf("ERROR: could not open file %s\n", inpFile.c_str());
+    return;
+  }
+  auto tree = (TTree*)fIn->Get("o2sim");
+  if (!tree) {
+    printf("ERROR: did not find tree with tracklets in file %s\n", inpFile.c_str());
+    return;
+  }
+
+  std::vector<o2::trd::TriggerRecord> trigIn, *trigInPtr{&trigIn};
+  std::vector<o2::trd::Tracklet64> tracklets, *trackletsInPtr{&tracklets};
+  tree->SetBranchAddress("TrackTrg", &trigInPtr);
+  tree->SetBranchAddress("Tracklet", &trackletsInPtr);
+
+  std::array<std::pair<unsigned int, unsigned short>, constants::MAXHALFCHAMBER * constants::NMCMHCMAX> trackletCounter{};
+  std::for_each(trackletCounter.begin(), trackletCounter.end(), [](auto& counter) { static int idx = 0; counter.second = idx++; });
+
+  // count number of tracklets per MCM
+  size_t totalTrackletCounter = 0;
+  for (int iEntry = 0; iEntry < tree->GetEntries(); ++iEntry) {
+    tree->GetEntry(iEntry);
+    for (const auto& tracklet : tracklets) {
+      totalTrackletCounter++;
+      int mcmGlb = NoiseStatusMCM::getMcmIdxGlb(tracklet.getHCID(), tracklet.getROB(), tracklet.getMCM());
+      trackletCounter[mcmGlb].first++;
+    }
+  }
+
+  // estimate noise threshold
+  std::sort(trackletCounter.begin(), trackletCounter.end(), [](const auto& a, const auto& b) { return a.first < b.first; }); // sort by number of tracklets per MCM
+  float mean = 0;
+  int nActiveMcms = 0;
+  for (int idx = 0; idx < static_cast<int>(0.9 * (constants::MAXHALFCHAMBER * constants::NMCMHCMAX)); ++idx) {
+    // get average number of tracklets discarding the 10% of MCMs with most entries
+    if (trackletCounter[idx].first > 0) {
+      nActiveMcms++;
+      mean += trackletCounter[idx].first;
+    }
+  }
+  if (!nActiveMcms) {
+    printf("ERROR: did not find any MCMs which sent tracklets. Aborting\n");
+    return;
+  }
+  mean /= nActiveMcms;
+  float noiseThreshold = 10 * mean;
+
+  for (const auto& counter : trackletCounter) {
+    if (counter.first > noiseThreshold) {
+      noiseMap.setIsNoisy(counter.second);
+    }
+  }
+
+  if (enableWriteCCDB) {
+    o2::ccdb::CcdbApi ccdb;
+    ccdb.init("http://ccdb-test.cern.ch:8080");
+    std::map<std::string, std::string> metadata;
+    metadata.emplace(std::make_pair("UploadedBy", "marten"));
+    auto timeStampStart = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+    auto timeStampEnd = timeStampStart;
+    timeStampEnd += 1e3 * 60 * 60 * 24 * 60; // 60 days
+    ccdb.storeAsTFileAny(&noiseMap, "TRD/Calib/NoiseMapMCM", metadata, timeStampStart, timeStampEnd);
+  }
+
+  printf("Found in total %lu noisy MCMs for %lu tracklets from %lu trigger records\n", noiseMap.getNumberOfNoisyMCMs(), totalTrackletCounter, trigIn.size());
+}


### PR DESCRIPTION
Hi @tdietel 
this would add a simple CCDB object with a flag for each MCM whether it is noisy or not. A MCM is considered noisy if it sends 10 times more data then the average MCM does. For calculating the average 10% of MCMs with the largest amount of tracklets are excluded.
For the pilot beam I see 77 MCMs in total are flagged which corresponds to 0.12 % of all MCMs.
Do you think it would make sense to ignore data from noisy MCMs in reconstruction? I had posted the tracklet spectra with and without noise suppression on mattermost.