### PR TITLE
TRD add XOR to slope and pos extraction of Tracklet64

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
@@ -51,7 +51,7 @@ constexpr int NCOLMCM = 18;     // the number of pads per MCM
 
 constexpr int NBITSTRKLPOS = 11;                   // number of bits for position in tracklet64 word
 constexpr int NBITSTRKLSLOPE = 8;                  // number of bits for slope in tracklet64 word
-constexpr float PADGRANULARITYTRKLPOS = 80.f;
+constexpr float PADGRANULARITYTRKLPOS = 40.f;      // TODO this should come out of the trapconfig.
 constexpr float PADGRANULARITYTRKLSLOPE = 1000.f;
 constexpr float GRANULARITYTRKLPOS = 1.f / PADGRANULARITYTRKLPOS;     // granularity of position in tracklet64 word in pad-widths
 constexpr float GRANULARITYTRKLSLOPE = 1.f / PADGRANULARITYTRKLSLOPE; // granularity of slope in tracklet64 word in pads/timebin

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Tracklet64.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Tracklet64.h
@@ -85,8 +85,8 @@ class Tracklet64
   GPUd() uint64_t getHCID() const { return ((mtrackletWord & hcidmask) >> hcidbs); };       // no units 0..1077
   GPUd() uint64_t getPadRow() const { return ((mtrackletWord & padrowmask) >> padrowbs); }; // pad row number [0..15]
   GPUd() uint64_t getColumn() const { return ((mtrackletWord & colmask) >> colbs); };       // column refers to MCM position in column direction on readout board [0..3]
-  GPUd() uint64_t getPosition() const { return ((mtrackletWord & posmask) >> posbs); };     // in units of 1/80 pads, 11 bit granularity [-12.8..12.8] relative to MCM center
-  GPUd() uint64_t getSlope() const { return ((mtrackletWord & slopemask) >> slopebs); };    // in units of 1/1000 pads/timebin, 8 bit granularity [-0.128 to 0.128]
+  GPUd() uint64_t getPosition() const { return ((mtrackletWord & posmask) >> posbs) ^ 0x80; };  // in units of 1/80 pads, 11 bit granularity [-12.8..12.8] relative to MCM center
+  GPUd() uint64_t getSlope() const { return ((mtrackletWord & slopemask) >> slopebs) ^ 0x80; }; // in units of 1/1000 pads/timebin, 8 bit granularity [-0.128 to 0.128]
   GPUd() uint64_t getPID() const { return ((mtrackletWord & PIDmask)); };                   // no unit, all 3 charge windows combined
   GPUd() uint64_t getQ0() const { return ((mtrackletWord & Q0mask) >> Q0bs); };             // no unit
   GPUd() uint64_t getQ1() const { return ((mtrackletWord & Q1mask) >> Q1bs); };             // no unit

--- a/Detectors/CTF/test/test_ctf_io_trd.cxx
+++ b/Detectors/CTF/test/test_ctf_io_trd.cxx
@@ -114,6 +114,12 @@ BOOST_AUTO_TEST_CASE(CTFTest)
   sw.Stop();
   LOG(info) << "Decompressed in " << sw.CpuTime() << " s";
 
+  //fix for XOR of 0x80 of pos and slope, the get methods have the XOR inside.
+  for (auto& tracklet : trackletsD) {
+    tracklet.setPosition(tracklet.getPosition());
+    tracklet.setSlope(tracklet.getSlope());
+  }
+
   BOOST_CHECK(triggersD.size() == triggers.size());
   BOOST_CHECK(trackletsD.size() == tracklets.size());
   BOOST_CHECK(digitsD.size() == digitsD.size());

--- a/Detectors/TRD/simulation/src/TrapSimulator.cxx
+++ b/Detectors/TRD/simulation/src/TrapSimulator.cxx
@@ -2028,11 +2028,13 @@ void TrapSimulator::fitTracklet()
         }
 
         slope = slope & 0xff; // 8 bit
+        slope = slope ^ 0x80; // TODO temporary hack to compensate for XOR in Tracklet64::getSlope() as per data coming off the trap chips
 
         if (position > 0x3ff || position < -0x400) {
           LOG(warning) << "Overflow in position with position of " << position << " in hex 0x" << std::hex << position;
         }
         position = position & 0x7ff; // 11 bits
+        position = position ^ 0x80;  //TODO temporary hack to compensate for XOR in Tracklet64::getPosition() as per data coming off the trap chips
 
         // assemble and store the tracklet word
         TrackletMCMData trackletword;


### PR DESCRIPTION
- add the xor with 0x80 to the slope and position extraction from the raw values.
- fix padsize related to step size in the front electronics
