### PR TITLE
Class to handle the MID readout card configuration and response

### DIFF
--- a/Detectors/MUON/MID/Raw/CMakeLists.txt
+++ b/Detectors/MUON/MID/Raw/CMakeLists.txt
@@ -1,13 +1,13 @@
-# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
-# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# Copyright 2019-2020 CERN and copyright holders of ALICE O2. See
+# https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 # All rights not expressly granted are reserved.
 #
-# This software is distributed under the terms of the GNU General Public
-# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+# This software is distributed under the terms of the GNU General Public License
+# v3 (GPL Version 3), copied verbatim in the file "COPYING".
 #
 # In applying this license CERN does not waive the privileges and immunities
-# granted to it by virtue of its status as an Intergovernmental Organization
-# or submit itself to any jurisdiction.
+# granted to it by virtue of its status as an Intergovernmental Organization or
+# submit itself to any jurisdiction.
 
 o2_add_library(
   MIDRaw
@@ -26,6 +26,9 @@ o2_add_library(
           src/GBTUserLogicEncoder.cxx
           src/LinkDecoder.cxx
           src/RawFileReader.cxx
+          src/ROBoardConfig.cxx
+          src/ROBoardConfigHandler.cxx
+          src/ROBoardResponse.cxx
   PUBLIC_LINK_LIBRARIES
     Microsoft.GSL::GSL
     O2::DataFormatsMID

--- a/Detectors/MUON/MID/Raw/README.md
+++ b/Detectors/MUON/MID/Raw/README.md
@@ -3,10 +3,12 @@
 /doxy -->
 
 # MID Raw
+
 This directory contains the classes to handle the MID RAW data
 This is particularly important for testing and debugging the MID Read-out.
 
 ## MID FEEId config
+
 The MID readout consists of 16 crates, divided in two sides.
 Each side is read out by one CRU, which contains 24 links divided in two end points.
 The readout of one crate requires 2 links, so a total of 16 active GBT links per side is required.
@@ -16,7 +18,30 @@ However, each GBT link has its own physical ID, which is given by its cruId, end
 
 The class FEEIdConfig, provides an easy way to associate the physical GBT link, with the corresponding feeId.
 The configuration can be loaded from a file, which should be in the form:
-```
+
+```less
 feeId linkId endPointId cruId
 ```
+
 and should contain 1 line per configured link.
+
+## MID ROBoard configuration
+
+The local and regional board have configuration registers that can be modified to change parameters such as the delays, the masks, and the way the zero suppression is performed.
+
+The delays are not supposed to change, but the masks and the zero suppression can be configurable.
+The configuration file is a txt file that is read by WinCC and applied to the electronics via GBT, using the ALF+FRED software.
+
+The list of noisy channels and the corresponding masks are obtained running a dedicate workflow (see [here](../Workflow/README.md) for details).
+It is therefore natural for such a workflow to generate a configuration file that can then be passed to DCS.
+
+This file is in the form:
+
+```less
+localBoardId MID_LOC_config MID_LOC_maskX1Y1 MID_LOC_maskX2Y2 MID_LOC_maskX3Y3 MID_LOC_maskX4Y4
+```
+
+where the MID_LOC* variables are the ones described in the `Detector Control` link [here](http://www-subatech.in2p3.fr/~electro/projets/alice/dimuon/trigger/upgrade/index.html).
+
+These values are coded into the class [ROBoardConfig](include/MIDRaw/ROBoardConfig.h).
+The class [ROBoardConfigHandler](include/MIDRaw/ROBoardConfigHandler.h) was created to handle the loading/writing of the parameters from/to the txt file.

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/CrateMapper.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/CrateMapper.h
@@ -17,7 +17,9 @@
 #define O2_MID_CRATEMAPPER_H
 
 #include <cstdint>
+#include <vector>
 #include <unordered_map>
+#include <unordered_set>
 
 namespace o2
 {
@@ -41,15 +43,25 @@ class CrateMapper
 
   uint16_t roLocalBoardToDE(uint8_t uniqueLocId) const;
 
-  bool hasDirectInputY(uint8_t uniqueLocId) const;
+  /// Checks if local board ID has direct input from FEE y strips
+  bool hasDirectInputY(uint8_t uniqueLocId) const { return mLocIdsWithDirectInputY.find(getROBoardIdRight(uniqueLocId)) != mLocIdsWithDirectInputY.end(); }
+
+  /// Gets the local boards with a direct input from FEE y strips
+  std::unordered_set<uint8_t> getLocalBoardsWithDirectInputY() const { return mLocIdsWithDirectInputY; }
+
+  /// Returns the list of readout local board IDs
+  /// \param gbtUniqueId Limit the query to the links belonging to the specified gbtUniqueId. If gbtUniqueId is 0xFFFF, return all
+  /// \return Sorted vector of local board unique IDs
+  std::vector<uint8_t> getROBoardIds(uint16_t gbtUniqueId = 0xFFFF) const;
 
  private:
+  /// Initializes the crate mapping
   void init();
   /// Returns the unique Loc ID in the right side
-  uint8_t getUniqueLocIdRight(uint8_t uniqueLocId) const { return uniqueLocId % 0x80; }
-  std::unordered_map<uint8_t, uint16_t> mROToDEMap;   /// Correspondence between RO and DE board
-  std::unordered_map<uint16_t, uint8_t> mDEToROMap;   /// Correspondence between DE and RO board
-  std::unordered_map<uint8_t, bool> mHasDirectInputY; /// Flag to state if the local board has direct input from FEE
+  uint8_t getROBoardIdRight(uint8_t uniqueLocId) const { return uniqueLocId % 0x80; }
+  std::unordered_map<uint8_t, uint16_t> mROToDEMap;    /// Correspondence between RO and DE board
+  std::unordered_map<uint16_t, uint8_t> mDEToROMap;    /// Correspondence between DE and RO board
+  std::unordered_set<uint8_t> mLocIdsWithDirectInputY; /// IDs of the local board with direct input from FEE y strips
 };
 } // namespace mid
 } // namespace o2

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/CrateParameters.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/CrateParameters.h
@@ -41,7 +41,7 @@ inline uint8_t getCrateIdFromGBTUniqueId(uint16_t gbtUniqueId) { return gbtUniqu
 /// Gets the link ID in crate from the RO ID
 inline uint8_t getGBTIdInCrate(uint16_t gbtUniqueId) { return gbtUniqueId % sNGBTsPerCrate; }
 /// Gets the link ID in crate from the board ID
-inline uint8_t getGBTIdFromBoardInCrate(uint16_t locId) { return locId / sMaxNBoardsInLink; }
+inline uint8_t getGBTIdFromBoardInCrate(uint8_t locId) { return locId / sMaxNBoardsInLink; }
 /// Gets the absolute crate ID
 inline uint8_t getCrateId(bool isRightSide, uint8_t crateIdOneSide) { return isRightSide ? crateIdOneSide : crateIdOneSide + sNCratesPerSide; }
 // Gets the locId in crate from the loc position in the GBT

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/GBTMapper.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/GBTMapper.h
@@ -1,0 +1,42 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDRaw/GBTMapper.h
+/// \brief  MID GBT mapping
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   16 November 2021
+#ifndef O2_MID_GBTMAPPER_H
+#define O2_MID_GBTMAPPER_H
+
+#include "DataFormatsMID/ROBoard.h"
+#include "MIDRaw/CrateParameters.h"
+
+namespace o2
+{
+namespace mid
+{
+/// Functions to relate the unique local board ID with the corresponding GBT ID
+namespace gbtmapper
+{
+/// Gets the GBT ID from the unique loc ID
+/// \param uniqueLocId Unique local board ID
+/// \return GBT ID
+inline uint16_t getGBTIdFromUniqueLocId(uint8_t uniqueLocId) { return crateparams::makeGBTUniqueId(raw::getCrateId(uniqueLocId), crateparams::getGBTIdFromBoardInCrate(raw::getLocId(uniqueLocId))); }
+/// Check if the board is in the GBT
+/// \param uniqueLocId Unique local board ID
+/// \param gbtUniqueId Unique GBT ID
+/// \return True if the local board is in the GBT
+inline bool isBoardInGBT(uint8_t uniqueLocId, uint16_t gbtUniqueId) { return (raw::getCrateId(uniqueLocId) == crateparams::getCrateIdFromGBTUniqueId(gbtUniqueId) && crateparams::getGBTIdFromBoardInCrate(raw::getLocId(uniqueLocId)) == crateparams::getGBTIdInCrate(gbtUniqueId)); }
+} // namespace gbtmapper
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_GBTMAPPER_H */

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/ROBoardConfig.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/ROBoardConfig.h
@@ -1,0 +1,45 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDRaw/ROBoardConfig.h
+/// \brief  Configuration for the readout local board
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   12 November 2021
+#ifndef O2_MID_ROBOARDCONFIG_H
+#define O2_MID_ROBOARDCONFIG_H
+
+#include <cstdint>
+#include "DataFormatsMID/ROBoard.h"
+
+namespace o2
+{
+namespace mid
+{
+struct ROBoardConfig {
+  uint32_t configWord = 0;            // Readout board config word
+  uint8_t boardId{0};                 // Board ID
+  std::array<uint16_t, 4> masksBP{};  // Bending plane mask
+  std::array<uint16_t, 4> masksNBP{}; // Non-bending plane mask
+};
+
+std::ostream& operator<<(std::ostream& os, const ROBoardConfig& cfg);
+
+namespace crateconfig
+{
+static constexpr uint32_t sTxDataMask = 0x10000;
+static constexpr uint32_t sMonmoff = 0x2;
+static constexpr uint32_t sXorY = 0x400;
+} // namespace crateconfig
+
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_ROBOARDCONFIG_H */

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/ROBoardConfigHandler.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/ROBoardConfigHandler.h
@@ -1,0 +1,71 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDRaw/ROBoardConfig.h
+/// \brief  Handler for readout local board configuration
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   12 November 2021
+#ifndef O2_MID_ROBOARDCONFIGHANDLER_H
+#define O2_MID_ROBOARDCONFIGHANDLER_H
+
+#include <vector>
+#include <unordered_map>
+#include "MIDRaw/ROBoardConfig.h"
+
+namespace o2
+{
+namespace mid
+{
+class ROBoardConfigHandler
+{
+ public:
+  /// Default constructor
+  ROBoardConfigHandler();
+  /// Constructor from file
+  ROBoardConfigHandler(const char* filename);
+  /// Constructor from list of local board configuration
+  ROBoardConfigHandler(const std::vector<ROBoardConfig>& configurations);
+  /// Default destructor
+  ~ROBoardConfigHandler() = default;
+
+  /// Returns the configuration for the local board
+  const ROBoardConfig getConfig(uint8_t uniqueLocId) const;
+
+  /// Returns the configuration map
+  const std::unordered_map<uint8_t, ROBoardConfig> getConfigMap() const { return mROBoardConfigs; }
+
+  /// Sets the local board configurations from a vector
+  void set(const std::vector<ROBoardConfig>& configurations);
+
+  /// Updates the mask values
+  void updateMasks(const std::vector<ROBoard>& masks);
+
+  /// Writes the configuration to file
+  void write(const char* filename) const;
+
+ private:
+  /// Loads the board  from a configuration file
+  /// The file is in the form:
+  /// locId status maskX1Y1 maskX2Y2 maskX3Y3 maskX4Y4
+  /// with one line per local board
+  bool load(const char* filename);
+  std::unordered_map<uint8_t, ROBoardConfig> mROBoardConfigs; /// Vector of local board configuration
+};
+
+/// Creates the default local board configurations
+std::vector<ROBoardConfig> makeDefaultROBoardConfig(uint16_t gbtUniqueId = 0xFFFF);
+/// Creates a local board configuration where no zero suppression is required
+std::vector<ROBoardConfig> makeNoZSROBoardConfig(uint16_t gbtUniqueId = 0xFFFF);
+
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_ROBOARDCONFIGHANDLER_H */

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/ROBoardResponse.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/ROBoardResponse.h
@@ -1,0 +1,66 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDRaw/ROBoardResponse.h
+/// \brief  Local board response
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   12 November 2021
+#ifndef O2_MID_ROBOARDRESPONSE_H
+#define O2_MID_ROBOARDRESPONSE_H
+
+#include <vector>
+#include "DataFormatsMID/ROBoard.h"
+#include "MIDRaw/ROBoardConfigHandler.h"
+
+namespace o2
+{
+namespace mid
+{
+class ROBoardResponse
+{
+ public:
+  /// Default constructor
+  ROBoardResponse() = default;
+  /// Constructor from list of local board configuration
+  ROBoardResponse(const std::vector<ROBoardConfig>& configurations);
+  /// Default destructor
+  ~ROBoardResponse() = default;
+
+  /// Sets from configuration
+  /// \param configurations Vector of local board configurations
+  void set(const std::vector<ROBoardConfig>& configurations) { mConfigHandler.set(configurations); }
+
+  /// Returns true if the local board has no fired digits after zero suppression
+  bool isZeroSuppressed(const ROBoard& loc) const;
+
+  /// Applies zero suppression
+  /// \param locs Vector of local boards to be checked: zero suppressed boards are removed
+  /// \return True if some board was removed
+  bool applyZeroSuppression(std::vector<ROBoard>& locs) const;
+
+  /// Returns the regional response
+  /// \param locs Local board of one GBT link
+  /// \return Vector with regional response
+  std::vector<ROBoard> getRegionalResponse(const std::vector<ROBoard>& locs) const;
+
+  /// Returns the trigger response
+  /// \param triggerWord Trigger word
+  /// \return List of trigger boards
+  std::vector<ROBoard> getTriggerResponse(uint8_t triggerWord) const;
+
+ private:
+  ROBoardConfigHandler mConfigHandler; /// Local board configuration handler
+};
+
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_ROBOARDRESPONSE_H */

--- a/Detectors/MUON/MID/Raw/src/ROBoardConfig.cxx
+++ b/Detectors/MUON/MID/Raw/src/ROBoardConfig.cxx
@@ -1,0 +1,37 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Raw/src/ROBoardConfig.cxx
+/// \brief  Configuration for the readout local board
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   12 November 2021
+
+#include "MIDRaw/ROBoardConfig.h"
+
+#include <iostream>
+#include "fmt/format.h"
+
+namespace o2
+{
+namespace mid
+{
+std::ostream& operator<<(std::ostream& os, const ROBoardConfig& cfg)
+{
+  /// Stream operator for ROBoardConfig
+  os << fmt::format("{:02x} {:08x}", cfg.boardId, cfg.configWord);
+  for (int ich = 0; ich < 4; ++ich) {
+    os << fmt::format(" {:04x}{:04x}", cfg.masksBP[ich], cfg.masksNBP[ich]);
+  }
+  return os;
+}
+
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/Raw/src/ROBoardConfigHandler.cxx
+++ b/Detectors/MUON/MID/Raw/src/ROBoardConfigHandler.cxx
@@ -1,0 +1,181 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Raw/src/ROBoardConfigHandler.cxx
+/// \brief  Handler for readout local board configuration
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   12 November 2021
+
+#include "MIDRaw/ROBoardConfigHandler.h"
+
+#include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include "fmt/format.h"
+#include "MIDRaw/CrateMapper.h"
+
+namespace o2
+{
+namespace mid
+{
+
+ROBoardConfigHandler::ROBoardConfigHandler()
+{
+  /// Default constructor
+  set(makeDefaultROBoardConfig());
+}
+
+ROBoardConfigHandler::ROBoardConfigHandler(const char* filename)
+{
+  /// Construct from file
+  load(filename);
+}
+
+ROBoardConfigHandler::ROBoardConfigHandler(const std::vector<ROBoardConfig>& configurations)
+{
+  set(configurations);
+}
+
+const ROBoardConfig ROBoardConfigHandler::getConfig(uint8_t uniqueLocId) const
+{
+  auto cfgIt = mROBoardConfigs.find(uniqueLocId);
+  if (cfgIt == mROBoardConfigs.end()) {
+    throw std::runtime_error(fmt::format("Cannot find local board {:02x}", uniqueLocId));
+  }
+  return cfgIt->second;
+}
+
+bool ROBoardConfigHandler::load(const char* filename)
+{
+  std::ifstream inFile(filename);
+  if (!inFile.is_open()) {
+    return false;
+  }
+  std::vector<ROBoardConfig> configurations;
+  std::string line, token;
+  while (std::getline(inFile, line)) {
+    if (std::count(line.begin(), line.end(), ' ') < 5) {
+      continue;
+    }
+    if (line.find('#') < line.find(' ')) {
+      continue;
+    }
+    ROBoardConfig cfg;
+    std::stringstream ss;
+    ss << line;
+    std::getline(ss, token, ' ');
+    cfg.boardId = static_cast<uint8_t>(std::strtol(token.c_str(), nullptr, 16));
+    std::getline(ss, token, ' ');
+    cfg.configWord = static_cast<uint32_t>(std::strtol(token.c_str(), nullptr, 16));
+    for (int ich = 0; ich < 4; ++ich) {
+      std::getline(ss, token, ' ');
+      auto mask = static_cast<uint32_t>(std::strtol(token.c_str(), nullptr, 16));
+      cfg.masksBP[ich] = (mask >> 16) & 0xFFFF;
+      cfg.masksNBP[ich] = (mask & 0xFFFF);
+    }
+    configurations.emplace_back(cfg);
+    inFile.close();
+  }
+  set(configurations);
+  return true;
+}
+
+void ROBoardConfigHandler::write(const char* filename) const
+{
+  /// Writes the masks to a configuration file
+  std::vector<ROBoardConfig> configs;
+  for (auto& cfgIt : mROBoardConfigs) {
+    configs.emplace_back(cfgIt.second);
+  }
+
+  std::sort(configs.begin(), configs.end(), [](const ROBoardConfig& cfg1, const ROBoardConfig& cfg2) { return cfg1.boardId < cfg2.boardId; });
+
+  std::ofstream outFile(filename);
+  for (auto& cfg : configs) {
+    outFile << cfg << std::endl;
+  }
+  outFile.close();
+}
+
+void ROBoardConfigHandler::set(const std::vector<ROBoardConfig>& configurations)
+{
+  mROBoardConfigs.clear();
+  for (auto& cfg : configurations) {
+    mROBoardConfigs.emplace(cfg.boardId, cfg);
+  }
+}
+
+void ROBoardConfigHandler::updateMasks(const std::vector<ROBoard>& masks)
+{
+  for (auto& mask : masks) {
+    auto cfgIt = mROBoardConfigs.find(mask.boardId);
+
+    // First we check if some patterns has zeros.
+    // When set xORy for boards with no Y input.
+    // So in this case we explicitly mask Y.
+    bool isMasked = ((cfgIt->second.configWord & crateconfig::sXorY) != 0);
+    for (int ich = 0; ich < 4; ++ich) {
+      if (mask.patternsBP[ich] != 0xFFFF || mask.patternsNBP[ich] != 0xFFFF) {
+        isMasked = true;
+      }
+    }
+
+    if (isMasked) {
+      cfgIt->second.configWord |= crateconfig::sMonmoff;
+      cfgIt->second.masksBP = mask.patternsBP;
+      if ((cfgIt->second.configWord & crateconfig::sXorY) == 0) {
+        cfgIt->second.masksNBP = mask.patternsNBP;
+      }
+    }
+  }
+}
+
+std::vector<ROBoardConfig> makeDefaultROBoardConfig(uint16_t gbtUniqueId)
+{
+  // FIXME: in the current configuration, when an Y strip covers several local boards
+  // the signal is sent to the first board only and no copy of the signal is sent to the others
+  // In this case we cannot implement zero suppression to boards that only receive the X signal.
+  // Originally we applied zero suppression to the board receiving both X and Y signals,
+  // but this leads to a bias.
+  // When the neighbour board is fired, indeed we have that:
+  // - the board with no Y signal transmits its X signal
+  // - the board with Y signal has no X signal. If we require X AND Y we lose the Y signal.
+  // For the moment we decide to require X OR Y by default to all board.
+  // This is equivalent to no zero suppression applied.
+  // In the future, we might apply X AND Y to cases were the Y strip belong to 1 local board only.
+  std::vector<ROBoardConfig> configurations;
+  CrateMapper crateMapper;
+  auto locIds = crateMapper.getROBoardIds(gbtUniqueId);
+  for (auto& locId : locIds) {
+    ROBoardConfig cfg;
+    cfg.configWord = crateconfig::sTxDataMask | crateconfig::sXorY;
+    cfg.boardId = locId;
+    configurations.emplace_back(cfg);
+  }
+  return configurations;
+}
+
+std::vector<ROBoardConfig> makeNoZSROBoardConfig(uint16_t gbtUniqueId)
+{
+  // FIXME: notice that the current default implies no zero suppression
+  // so this is equivalent to the default
+  // We still keep this in case we change the default behaviour in the future
+  auto configurations = makeDefaultROBoardConfig(gbtUniqueId);
+  for (auto& cfg : configurations) {
+    cfg.configWord |= crateconfig::sXorY;
+  }
+  return configurations;
+}
+
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/Raw/src/ROBoardResponse.cxx
+++ b/Detectors/MUON/MID/Raw/src/ROBoardResponse.cxx
@@ -1,0 +1,104 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Raw/src/ROBoardResponse.cxx
+/// \brief  Local board response
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   12 November 2021
+
+#include "MIDRaw/ROBoardResponse.h"
+
+#include <unordered_map>
+#include "MIDRaw/CrateParameters.h"
+
+namespace o2
+{
+namespace mid
+{
+
+ROBoardResponse::ROBoardResponse(const std::vector<ROBoardConfig>& configurations) : mConfigHandler(configurations)
+{
+}
+
+bool ROBoardResponse::isZeroSuppressed(const ROBoard& loc) const
+{
+  auto cfg = mConfigHandler.getConfig(loc.boardId);
+  if (cfg.configWord & crateconfig::sXorY) {
+    return false;
+  }
+  for (int ich = 0; ich < 4; ++ich) {
+    if (loc.patternsBP[ich] && loc.patternsNBP[ich]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool ROBoardResponse::applyZeroSuppression(std::vector<ROBoard>& locs) const
+{
+  std::vector<ROBoard> zsLocs;
+  bool isSuppressed = false;
+  for (auto& loc : locs) {
+    if (!isZeroSuppressed(loc)) {
+      zsLocs.emplace_back(loc);
+      isSuppressed = true;
+    }
+  }
+  locs.swap(zsLocs);
+  return isSuppressed;
+}
+
+std::vector<ROBoard> ROBoardResponse::getTriggerResponse(uint8_t triggerWord) const
+{
+  std::vector<ROBoard> locBoards;
+  auto& cfgMap = mConfigHandler.getConfigMap();
+  for (auto& item : cfgMap) {
+    locBoards.push_back({raw::sSTARTBIT | raw::sCARDTYPE, triggerWord, item.first, 0});
+    if (triggerWord & (raw::sSOX | raw::sEOX)) {
+      /// Write masks
+      if (item.second.configWord & crateconfig::sMonmoff) {
+        locBoards.back().statusWord |= raw::sMASKED;
+        for (int ich = 0; ich < 4; ++ich) {
+          locBoards.back().patternsBP[ich] = item.second.masksBP[ich];
+          locBoards.back().patternsNBP[ich] = item.second.masksNBP[ich];
+        }
+      }
+    }
+  }
+  auto regBoards = getRegionalResponse(locBoards);
+  locBoards.insert(locBoards.begin(), regBoards.begin(), regBoards.end());
+  return locBoards;
+}
+
+std::vector<ROBoard> ROBoardResponse::getRegionalResponse(const std::vector<ROBoard>& locs) const
+{
+  std::unordered_map<uint8_t, uint8_t> firedLocs;
+
+  uint8_t triggerWord = 0;
+  for (auto& loc : locs) {
+    auto locId = raw::getLocId(loc.boardId);
+    auto regId = 8 * crateparams::getGBTIdFromBoardInCrate(locId) + (locId % 8) / 4;
+    auto uniqueRegId = raw::makeUniqueLocID(raw::getCrateId(loc.boardId), regId);
+    int locPos = locId % 4;
+    firedLocs[uniqueRegId] |= (1 << locPos);
+    triggerWord = loc.triggerWord;
+  }
+
+  std::vector<ROBoard> regBoards;
+  for (auto& item : firedLocs) {
+    regBoards.push_back({raw::sSTARTBIT, triggerWord, item.first, item.second});
+  }
+
+  return regBoards;
+}
+
+} // namespace mid
+} // namespace o2


### PR DESCRIPTION
This PR introduces new classes for better handling of the MID card cnfiguration.
The electronics can be configured with masks and with parameters stating if the card should send the output when the X AND Y strips are fired or the X OR Y are fired.
The aim of this PR is to be able to load and write such configurations, as well as to better mimic the electronic behaviour in the simulation/reconstruction code.
The commits are meant to be atomic: please do not squash.