### PR TITLE
IDCs: Adding possibillity to perform grouping on an aggregator node

### DIFF
--- a/Detectors/TPC/base/include/TPCBase/Mapper.h
+++ b/Detectors/TPC/base/include/TPCBase/Mapper.h
@@ -363,6 +363,9 @@ class Mapper
     return 0;
   }
 
+  /// \return returns number of pads per side of the TPC
+  static constexpr int getNumberOfPadsPerSide() { return getPadsInSector() * SECTORSPERSIDE; }
+
   /// Convert sector, row, pad to global pad row in sector and pad number
   const PadPos getGlobalPadPos(const PadROCPos& padROC) const
   {
@@ -502,15 +505,15 @@ class Mapper
                            float(double(pos.X()) * sn + double(pos.Y() * cs)));
   }
 
-  static constexpr unsigned int NSECTORS{36};                                                                                                                      ///< total number of sectors in the TPC
-  static constexpr unsigned int NREGIONS{10};                                                                                                                      ///< total number of regions in one sector
-  static constexpr unsigned int PADROWS{152};                                                                                                                      ///< total number of pad rows
-  static constexpr unsigned int PADSPERREGION[NREGIONS]{1200, 1200, 1440, 1440, 1440, 1440, 1600, 1600, 1600, 1600};                                               ///< number of pads per CRU
-  static constexpr unsigned int GLOBALPADOFFSET[NREGIONS]{0, 1200, 2400, 3840, 5280, 6720, 8160, 9760, 11360, 12960};                                              ///< offset of number of pads for region
-  static constexpr unsigned int ROWSPERREGION[NREGIONS]{17, 15, 16, 15, 18, 16, 16, 14, 13, 12};                                                                   ///< number of pad rows for region
-  static constexpr unsigned int ROWOFFSET[NREGIONS]{0, 17, 32, 48, 63, 81, 97, 113, 127, 140};                                                                     ///< offset to calculate local row from global row
-  static constexpr float REGIONAREA[NREGIONS]{374.4f, 378.f, 453.6f, 470.88f, 864.f, 864.f, 1167.36f, 1128.96f, 1449.6f, 1456.8f};                                 ///< volume of each region in cm^2
-  static constexpr float PADAREA[NREGIONS]{1 / 0.312f, 1 / 0.315f, 1 / 0.315f, 1 / 0.327f, 1 / 0.6f, 1 / 0.6f, 1 / 0.7296f, 1 / 0.7056f, 1 / 0.906f, 1 / 0.9105f}; ///< inverse size of the pad area padwidth*padLength
+  static constexpr unsigned int NSECTORS{36};                                                                                                                         ///< total number of sectors in the TPC
+  static constexpr unsigned int NREGIONS{10};                                                                                                                         ///< total number of regions in one sector
+  static constexpr unsigned int PADROWS{152};                                                                                                                         ///< total number of pad rows
+  static constexpr unsigned int PADSPERREGION[NREGIONS]{1200, 1200, 1440, 1440, 1440, 1440, 1600, 1600, 1600, 1600};                                                  ///< number of pads per CRU
+  static constexpr unsigned int GLOBALPADOFFSET[NREGIONS]{0, 1200, 2400, 3840, 5280, 6720, 8160, 9760, 11360, 12960};                                                 ///< offset of number of pads for region
+  static constexpr unsigned int ROWSPERREGION[NREGIONS]{17, 15, 16, 15, 18, 16, 16, 14, 13, 12};                                                                      ///< number of pad rows for region
+  static constexpr unsigned int ROWOFFSET[NREGIONS]{0, 17, 32, 48, 63, 81, 97, 113, 127, 140};                                                                        ///< offset to calculate local row from global row
+  static constexpr float REGIONAREA[NREGIONS]{374.4f, 378.f, 453.6f, 470.88f, 864.f, 864.f, 1167.36f, 1128.96f, 1449.6f, 1456.8f};                                    ///< volume of each region in cm^2
+  static constexpr float INVPADAREA[NREGIONS]{1 / 0.312f, 1 / 0.315f, 1 / 0.315f, 1 / 0.327f, 1 / 0.6f, 1 / 0.6f, 1 / 0.7296f, 1 / 0.7056f, 1 / 0.906f, 1 / 0.9105f}; ///< inverse size of the pad area padwidth*padLength
   static constexpr unsigned REGION[PADROWS] = {
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
     1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,

--- a/Detectors/TPC/base/src/Painter.cxx
+++ b/Detectors/TPC/base/src/Painter.cxx
@@ -750,7 +750,7 @@ TH3F painter::convertCalDetToTH3(const std::vector<CalDet<DataT>>& calDet, const
                 continue;
               }
               const double area = boost::geometry::area(output.front());
-              const double fac = area * Mapper::PADAREA[region];
+              const double fac = area * Mapper::INVPADAREA[region];
 
               for (int iSide = 0; iSide < 2; ++iSide) {
                 const Side side = iSide == 0 ? Side::C : Side::A;

--- a/Detectors/TPC/calibration/CMakeLists.txt
+++ b/Detectors/TPC/calibration/CMakeLists.txt
@@ -25,12 +25,16 @@ o2_add_library(TPCCalibration
                        src/CalibLaserTracks.cxx
                        src/LaserTracksCalibrator.cxx
                        src/IDCAverageGroup.cxx
+                       src/IDCAverageGroupBase.cxx
+                       src/IDCAverageGroupHelper.cxx
                        src/IDCGroup.cxx
                        src/IDCGroupHelperRegion.cxx
+                       src/IDCGroupHelperSector.cxx
                        src/IDCGroupingParameter.cxx
                        src/IDCFactorization.cxx
                        src/IDCFourierTransformBase.cxx
                        src/IDCFourierTransform.cxx
+                       src/IDCDrawHelper.cxx
                        src/RobustAverage.cxx
                        src/IDCCCDBHelper.cxx
                        src/CalibdEdx.cxx
@@ -57,6 +61,8 @@ o2_target_root_dictionary(TPCCalibration
                                   include/TPCCalibration/CalibLaserTracks.h
                                   include/TPCCalibration/LaserTracksCalibrator.h
                                   include/TPCCalibration/IDCAverageGroup.h
+                                  include/TPCCalibration/IDCAverageGroupBase.h
+                                  include/TPCCalibration/IDCAverageGroupHelper.h
                                   include/TPCCalibration/IDCGroup.h
                                   include/TPCCalibration/IDCGroupHelperRegion.h
                                   include/TPCCalibration/IDCGroupHelperSector.h
@@ -69,7 +75,8 @@ o2_target_root_dictionary(TPCCalibration
                                   include/TPCCalibration/IDCCCDBHelper.h
                                   include/TPCCalibration/CalibdEdx.h
                                   include/TPCCalibration/CalibratordEdx.h
-                                  include/TPCCalibration/TrackDump.h)
+                                  include/TPCCalibration/TrackDump.h
+                                  include/TPCCalibration/IDCDrawHelper.h)
 
 o2_add_executable(dcs-sim-workflow
                   COMPONENT_NAME tpc

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCAverageGroup.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCAverageGroup.h
@@ -16,11 +16,12 @@
 #ifndef ALICEO2_IDCAVERAGEGROUP_H_
 #define ALICEO2_IDCAVERAGEGROUP_H_
 
-#include <vector>
-#include "TPCCalibration/IDCGroup.h"
-#include "Rtypes.h"
-#include "TPCBase/Sector.h"
 #include "TPCCalibration/RobustAverage.h"
+#include "TPCCalibration/IDCAverageGroupBase.h"
+#include "TPCBase/Sector.h"
+#include "TPCBase/CalDet.h"
+#include <vector>
+#include "Rtypes.h"
 
 namespace o2::utils
 {
@@ -30,11 +31,49 @@ class TreeStreamRedirector;
 namespace o2::tpc
 {
 
+// forward declaration of helper class
+template <class Type>
+class IDCAverageGroupHelper;
+
+template <typename T>
+struct Enable_enum_class_bitfield {
+  static constexpr bool value = false;
+};
+
+// operator overload for allowing bitfiedls with enum
+template <typename T>
+typename std::enable_if<std::is_enum<T>::value && Enable_enum_class_bitfield<T>::value, T>::type
+  operator&(T lhs, T rhs)
+{
+  typedef typename std::underlying_type<T>::type integer_type;
+  return static_cast<T>(static_cast<integer_type>(lhs) & static_cast<integer_type>(rhs));
+}
+
+template <typename T>
+typename std::enable_if<std::is_enum<T>::value && Enable_enum_class_bitfield<T>::value, T>::type
+  operator|(T lhs, T rhs)
+{
+  typedef typename std::underlying_type<T>::type integer_type;
+  return static_cast<T>(static_cast<integer_type>(lhs) | static_cast<integer_type>(rhs));
+}
+
+enum class PadFlags : unsigned short {
+  flagGoodPad = 1 << 0,     ///< flag for a good pad binary 0001
+  flagDeadPad = 1 << 1,     ///< flag for a dead pad binary 0010
+  flagUnknownPad = 1 << 2,  ///< flag for unknown status binary 0100
+  flagSaturatedPad = 1 << 3 ///< flag for unknown status binary 0100
+};
+
+template <>
+struct Enable_enum_class_bitfield<PadFlags> {
+  static constexpr bool value = true;
+};
+
 /// class for averaging and grouping IDCs
 /// usage:
 /// 1. Define grouping parameters
 /// const int region = 3;
-/// IDCAverageGroup idcaverage(6, 4, 3, 2, region);
+/// IDCAverageGroup<IDCAverageGroupCRU> idcaverage(6, 4, 3, 2, region);
 /// 2. set the ungrouped IDCs for one CRU
 /// const int nIntegrationIntervals = 3;
 /// std::vector<float> idcsungrouped(nIntegrationIntervals*Mapper::PADSPERREGION[region], 11.11); // vector containing IDCs for one region
@@ -44,8 +83,9 @@ namespace o2::tpc
 /// 4. draw IDCs
 /// idcaverage.drawUngroupedIDCs(0)
 /// idcaverage.drawGroupedIDCs(0)
-
-class IDCAverageGroup
+/// \tparam IDCAverageGroupCRU or IDCAverageGroupTPC
+template <class Type>
+class IDCAverageGroup : public IDCAverageGroupBase<Type>
 {
  public:
   /// constructor
@@ -54,97 +94,85 @@ class IDCAverageGroup
   /// \param groupLastRowsThreshold minimum number of pads in row direction for the last group in row direction
   /// \param groupLastPadsThreshold minimum number of pads in pad direction for the last group in pad direction
   /// \param region region of the TPC
-  /// \param sigma maximum accepted standard deviation for filtering outliers: sigma*stdev
-  IDCAverageGroup(const unsigned char groupPads = 4, const unsigned char groupRows = 4, const unsigned char groupLastRowsThreshold = 2, const unsigned char groupLastPadsThreshold = 2, const unsigned int region = 0, const Sector sector = Sector{0}, const float sigma = 3);
+  /// \param overlapRows define parameter for additional overlapping pads in row direction
+  /// \param overlapPads define parameter for additional overlapping pads in pad direction
+  template <bool IsEnabled = true, typename std::enable_if<(IsEnabled && (std::is_same<Type, IDCAverageGroupCRU>::value)), int>::type = 0>
+  IDCAverageGroup(const unsigned char groupPads = 4, const unsigned char groupRows = 4, const unsigned char groupLastRowsThreshold = 2, const unsigned char groupLastPadsThreshold = 2, const unsigned int region = 0, const Sector sector = Sector{0}, const unsigned char overlapRows = 0, const unsigned char overlapPads = 0)
+    : IDCAverageGroupBase<Type>{groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold, region, sector, sNThreads}, mOverlapRows{overlapRows}, mOverlapPads{overlapPads}
+  {
+    init();
+  }
 
-  /// set the IDCs which will be averaged and grouped
-  /// \param idcs vector containing the IDCs
-  void setIDCs(const std::vector<float>& idcs);
+  /// \param groupPads number of pads in pad direction which will be grouped
+  /// \param groupRows number of pads in row direction which will be grouped
+  /// \param groupLastRowsThreshold minimum number of pads in row direction for the last group in row direction
+  /// \param groupLastPadsThreshold minimum number of pads in pad direction for the last group in pad direction
+  /// \param overlapRows define parameter for additional overlapping pads in row direction
+  /// \param overlapPads define parameter for additional overlapping pads in pad direction
+  template <bool IsEnabled = true, typename std::enable_if<(IsEnabled && (std::is_same<Type, IDCAverageGroupTPC>::value)), int>::type = 0>
+  IDCAverageGroup(const std::array<unsigned char, Mapper::NREGIONS>& groupPads = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, const std::array<unsigned char, Mapper::NREGIONS>& groupRows = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, const std::array<unsigned char, Mapper::NREGIONS>& groupLastRowsThreshold = {}, const std::array<unsigned char, Mapper::NREGIONS>& groupLastPadsThreshold = {}, const unsigned char overlapRows = 0, const unsigned char overlapPads = 0)
+    : IDCAverageGroupBase<Type>{groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold, sNThreads}, mOverlapRows{overlapRows}, mOverlapPads{overlapPads}
+  {
+    init();
+  }
 
-  /// set the IDCs which will be averaged and grouped using move operator
-  /// \param IDCs vector containing the IDCs
-  void setIDCs(std::vector<float>&& idcs);
+  /// Update pad flag map from a local file
+  /// \param file file containing the caldet map  with the flags
+  // \param objName name of the object (TODO use a fixed name)
+  void updatePadStatusMapFromFile(const char* file, const char* objName);
 
-  /// \return returns number of integration intervalls stored in this object
-  unsigned int getNIntegrationIntervals() const;
+  /// TODO: Update pad flag map from the CCDB
+  // void updatePadStatusMapFromCCDB(const char* file, const char* objName);
 
   /// grouping and averaging of IDCs
   void processIDCs();
 
-  /// \return returns grouped IDC object
-  const auto& getIDCGroup() const { return mIDCsGrouped; }
-
-  /// \return returns grouped IDC object
-  auto getIDCGroupData() && { return std::move(mIDCsGrouped).getData(); }
+  /// draw plot with information about the performed grouping
+  /// \param filename name of the output file. If empty the name is chosen automatically
+  void drawGrouping(const std::string filename = "");
 
   /// dump object to disc
   /// \param outFileName name of the output file
   /// \param outName name of the object in the output file
   void dumpToFile(const char* outFileName = "IDCAverageGroup.root", const char* outName = "IDCAverageGroup") const;
 
-  /// load ungrouped and grouped IDCs from File
-  bool setFromFile(const char* fileName = "IDCAverageGroup.root", const char* name = "IDCAverageGroup");
-
-  /// draw ungrouped IDCs
-  /// \param integrationInterval integration interval for which the IDCs will be drawn
+  /// draw the status map for the flags (for debugging) for a sector
+  /// \param sector sector which will be drawn
   /// \param filename name of the output file. If empty the canvas is drawn.
-  void drawUngroupedIDCs(const unsigned int integrationInterval = 0, const std::string filename = "IDCsUngrouped.pdf") const;
+  void drawPadStatusMapSector(const unsigned int sector, const std::string filename = "PadStatusFlags_Sector.pdf") const { drawPadStatusMap(false, Sector(sector), filename); }
 
-  /// draw grouped IDCs
-  /// \param integrationInterval integration interval for which the IDCs will be drawn
+  /// draw the status map for the flags (for debugging) for a full side
+  /// \param side side which will be drawn
   /// \param filename name of the output file. If empty the canvas is drawn.
-  void drawGroupedIDCs(const unsigned int integrationInterval = 0, const std::string filename = "IDCsGrouped.pdf") const { mIDCsGrouped.draw(integrationInterval, filename); }
-
-  /// \return returns the stored ungrouped IDC value for local ungrouped pad row and ungrouped pad
-  /// \param ulrow ungrouped local row in region
-  /// \param upad ungrouped pad in pad direction
-  /// \param integrationInterval integration interval for which the IDCs will be returned
-  float getUngroupedIDCValLocal(const unsigned int ulrow, const unsigned int upad, const unsigned int integrationInterval) const { return mIDCsUngrouped[getUngroupedIndex(ulrow, upad, integrationInterval)]; }
-
-  /// \return returns the stored ungrouped IDC value for global ungrouped pad row and ungrouped pad
-  /// \param ugrow ungrouped global row
-  /// \param upad ungrouped pad in pad direction
-  /// \param integrationInterval integration interval for which the IDCs will be returned
-  float getUngroupedIDCValGlobal(const unsigned int ugrow, const unsigned int upad, const unsigned int integrationInterval) const { return mIDCsUngrouped[getUngroupedIndexGlobal(ugrow, upad, integrationInterval)]; }
-
-  /// \return returns the stored ungrouped IDC value for local pad number
-  /// \param localPadNumber local pad number for region
-  /// \param integrationInterval integration interval for which the IDCs will be returned
-  float getUngroupedIDCVal(const unsigned int localPadNumber, const unsigned int integrationInterval) const;
-
-  /// \return returns the stored grouped IDC value for local ungrouped pad row and ungrouped pad
-  /// \param ulrow local row in region of the ungrouped IDCs
-  /// \param upad pad number of the ungrouped IDCs
-  /// \param integrationInterval integration interval
-  float getGroupedIDCValLocal(unsigned int ulrow, unsigned int upad, unsigned int integrationInterval) const { return mIDCsGrouped.getValUngrouped(ulrow, upad, integrationInterval); }
-
-  /// \return returns the stored grouped IDC value for local ungrouped pad row and ungrouped pad
-  /// \param ugrow global ungrouped row
-  /// \param upad pad number of the ungrouped IDCs
-  /// \param integrationInterval integration interval
-  float getGroupedIDCValGlobal(unsigned int ugrow, unsigned int upad, unsigned int integrationInterval) const { return mIDCsGrouped.getValUngroupedGlobal(ugrow, upad, integrationInterval); }
+  void drawPadStatusMapSide(const o2::tpc::Side side, const std::string filename = "PadStatusFlags_Side.pdf") const { drawPadStatusMap(true, side == Side::A ? Sector(0) : Sector(Sector::MAXSECTOR - 1), filename); }
 
   /// get the number of threads used for some of the calculations
   static int getNThreads() { return sNThreads; }
 
-  /// \return returns sector of which the IDCs are averaged and grouped
-  Sector getSector() const { return mSector; }
+  /// \return returns grouped IDC object
+  const auto& getIDCGroup() const { return this->mIDCsGrouped; }
 
   /// \return returns ungrouped IDCs
-  const auto& getIDCsUngrouped() const { return mIDCsUngrouped; }
+  const auto& getIDCsUngrouped() const { return this->mIDCsUngrouped; }
 
-  /// \return returns region
-  unsigned int getRegion() const { return mIDCsGrouped.getRegion(); }
-
-  /// \return returns sigma used for filtering
-  float getSigma() const { return mSigma; }
+  /// \param sigma sigma which is used during outlier filtering
+  static void setSigma(const float sigma) { o2::conf::ConfigurableParam::setValue<float>("TPCIDCGroupParam", "Sigma", sigma); }
 
   /// set the number of threads used for some of the calculations
   static void setNThreads(const int nThreads) { sNThreads = nThreads; }
 
+  /// Set pad flag map directly
+  /// \param padStatus CalDet containing for each pad the status flag
+  void setPadStatusMap(const CalDet<PadFlags>& padStatus) { mPadStatus = std::make_unique<CalDet<PadFlags>>(padStatus); }
+
+  /// load ungrouped and grouped IDCs from File
+  /// \param fileName name of the input file
+  /// \param name name of the object in the output file
+  bool setFromFile(const char* fileName = "IDCAverageGroup.root", const char* name = "IDCAverageGroup");
+
   /// for debugging: creating debug tree
   /// \param nameFile name of the output file
-  void createDebugTree(const char* nameFile) const;
+  void createDebugTree(const char* nameFile);
 
   /// for debugging: creating debug tree for integrated IDCs for all objects which are in the same file
   /// \param nameFile name of the output file
@@ -152,25 +180,29 @@ class IDCAverageGroup
   static void createDebugTreeForAllCRUs(const char* nameFile, const char* filename);
 
  private:
-  inline static int sNThreads{1};            ///< number of threads which are used during the calculations
-  std::vector<float> mIDCsUngrouped{};       ///< integrated ungrouped IDC values per pad
-  IDCGroup mIDCsGrouped{};                   ///< grouped and averaged IDC values
-  const Sector mSector{};                    ///< sector of averaged and grouped IDCs (used for debugging)
-  const float mSigma{};                      ///< sigma cut for outlier filtering
-  std::vector<RobustAverage> mRobustAverage; ///<! object for averaging (each thread will get his one object)
+  inline static int sNThreads{1};                                                                                                 ///< number of threads which are used during the calculations
+  const unsigned char mOverlapRows{0};                                                                                            ///< additional/overlapping pads in row direction (TODO overlap per region)
+  const unsigned char mOverlapPads{0};                                                                                            ///< additional/overlapping pads in pad direction (TODO overlap per region)
+  std::unique_ptr<CalDet<PadFlags>> mPadStatus{std::make_unique<CalDet<PadFlags>>(CalDet<PadFlags>("flags", PadSubset::Region))}; ///< status flag for each pad (i.e. if the pad is dead)
 
-  /// \return returns index to data from ungrouped pad and row
-  /// \param ulrow ungrouped local row in region
-  /// \param upad ungrouped pad in pad direction
-  unsigned int getUngroupedIndex(const unsigned int ulrow, const unsigned int upad, const unsigned int integrationInterval) const;
-
-  /// \return returns index to data from ungrouped pad and row
-  /// \param ugrow ungrouped global row
-  /// \param upad ungrouped pad in pad direction
-  unsigned int getUngroupedIndexGlobal(const unsigned int ugrow, const unsigned int upad, const unsigned int integrationInterval) const;
+  /// init function
+  void init();
 
   /// called from createDebugTreeForAllCRUs()
-  static void createDebugTree(const IDCAverageGroup& idcavg, o2::utils::TreeStreamRedirector& pcstream);
+  static void createDebugTree(const IDCAverageGroupHelper<Type>& idcStruct, o2::utils::TreeStreamRedirector& pcstream);
+
+  /// normal distribution used for weighting overlapping pads
+  /// \param x distance to the center of the normal distribution
+  /// \param sigma sigma of the normal distribution
+  static float normal_dist(const float x, const float sigma);
+
+  /// perform the loop over the IDCs by either perform the grouping or the drawing
+  /// \param type containing necessary methods for either perform the grouping or the drawing
+  template <class LoopType>
+  void loopOverGroups(IDCAverageGroupHelper<LoopType>& idcStruct);
+
+  /// helper function for drawing
+  void drawPadStatusMap(const bool type, const Sector sector, const std::string filename) const;
 
   ClassDefNV(IDCAverageGroup, 1)
 };

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCAverageGroupBase.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCAverageGroupBase.h
@@ -1,0 +1,217 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file IDCAverageGroupBase.h
+/// \brief base class for averaging and grouping of IDCs
+/// \author Matthias Kleiner <mkleiner@ikf.uni-frankfurt.de>
+
+#ifndef ALICEO2_IDCAVERAGEGROUPBASE_H_
+#define ALICEO2_IDCAVERAGEGROUPBASE_H_
+
+#include <vector>
+#include "TPCCalibration/IDCGroup.h"
+#include "TPCCalibration/RobustAverage.h"
+#include "TPCCalibration/IDCGroupHelperSector.h"
+#include "TPCCalibration/IDCContainer.h"
+#include "TPCBase/Mapper.h"
+#include "TPCBase/Sector.h"
+
+namespace o2::tpc
+{
+
+/// Helper class for either perform the grouping or draw the grouping
+template <class Type>
+class IDCAverageGroupBase;
+
+/// dummy class for specializing the class
+class IDCAverageGroupCRU;
+class IDCAverageGroupTPC;
+class IDCAverageGroupDraw;
+
+/// class for averaging and grouping only one CRU
+template <>
+class IDCAverageGroupBase<IDCAverageGroupCRU>
+{
+ public:
+  /// constructor
+  /// \param groupPads number of pads in pad direction which will be grouped
+  /// \param groupRows number of pads in row direction which will be grouped
+  /// \param groupLastRowsThreshold minimum number of pads in row direction for the last group in row direction
+  /// \param groupLastPadsThreshold minimum number of pads in pad direction for the last group in pad direction
+  /// \param region region of the TPC
+  /// \param sector processed sector
+  /// \param nThreads number of CPU threads used
+  IDCAverageGroupBase(const unsigned char groupPads, const unsigned char groupRows, const unsigned char groupLastRowsThreshold, const unsigned char groupLastPadsThreshold, const unsigned int region, const Sector sector, const int nThreads)
+    : mIDCsGrouped{groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold, region}, mSector{sector}, mRobustAverage(nThreads){};
+
+  /// \return returns number of integration intervals for stored ungrouped IDCs
+  unsigned int getNIntegrationIntervals() const { return mIDCsUngrouped.size() / Mapper::PADSPERREGION[getRegion()]; }
+
+  /// \return returns the region of the IDCs
+  unsigned int getRegion() const { return mIDCsGrouped.getRegion(); }
+
+  /// \return returns the CRU number
+  unsigned int getCRU() const { return getRegion() + mSector * Mapper::NREGIONS; }
+
+  /// \return returns sector of which the IDCs are averaged and grouped
+  Sector getSector() const { return mSector; }
+
+  /// setting the ungrouped IDCs using copy constructor
+  /// \param idcs vector containing the ungrouped IDCs
+  void setIDCs(const std::vector<float>& idcs);
+
+  /// setting the ungrouped IDCs using move semantics
+  /// \param idcs vector containing the ungrouped IDCs
+  void setIDCs(std::vector<float>&& idcs);
+
+  /// \return returns grouped IDC object using move semantics
+  auto getIDCGroupData() && { return std::move(mIDCsGrouped).getData(); }
+
+  /// \return returns the stored ungrouped IDC value for global ungrouped pad row and ungrouped pad
+  /// \param ugrow ungrouped global row
+  /// \param upad ungrouped pad in pad direction
+  /// \param integrationInterval integration interval for which the IDCs will be returned
+  float getUngroupedIDCValGlobal(const unsigned int ugrow, const unsigned int upad, const unsigned int integrationInterval) const { return mIDCsUngrouped[getUngroupedIndexGlobal(ugrow, upad, integrationInterval)]; }
+
+  /// \return returns index to data from ungrouped pad and row
+  /// \param ulrow ungrouped local row in region
+  /// \param upad ungrouped pad in pad direction
+  unsigned int getUngroupedIndex(const unsigned int ulrow, const unsigned int upad, const unsigned int integrationInterval) const { return integrationInterval * Mapper::PADSPERREGION[getRegion()] + Mapper::OFFSETCRULOCAL[getRegion()][ulrow] + upad; }
+
+  /// \return returns index to data from ungrouped pad and row
+  /// \param ugrow ungrouped global row
+  /// \param upad ungrouped pad in pad direction
+  unsigned int getUngroupedIndexGlobal(const unsigned int ugrow, const unsigned int upad, const unsigned int integrationInterval) const { return integrationInterval * Mapper::PADSPERREGION[getRegion()] + Mapper::OFFSETCRUGLOBAL[ugrow] + upad; }
+
+  /// draw ungrouped IDCs
+  /// \param integrationInterval integration interval for which the IDCs will be drawn
+  /// \param filename name of the output file. If empty the canvas is drawn.
+  void drawUngroupedIDCs(const unsigned int integrationInterval = 0, const std::string filename = "IDCsUngrouped.pdf") const;
+
+  /// draw grouped IDCs
+  /// \param integrationInterval integration interval for which the IDCs will be drawn
+  /// \param filename name of the output file. If empty the canvas is drawn.
+  void drawGroupedIDCs(const unsigned int integrationInterval = 0, const std::string filename = "IDCsGrouped.pdf") const { mIDCsGrouped.draw(integrationInterval, filename); }
+
+ protected:
+  IDCGroup mIDCsGrouped{};                   ///< grouped and averaged IDC values
+  std::vector<RobustAverage> mRobustAverage; ///<! object for averaging (each thread will get his one object)
+  std::vector<float> mWeightsPad{};          ///< storage of the weights in pad direction used if mOverlapPads>0
+  std::vector<float> mWeightsRow{};          ///< storage of the weights in row direction used if mOverlapRows>0
+  std::vector<float> mIDCsUngrouped{};       ///< integrated ungrouped IDC values per pad
+  const Sector mSector{};                    ///< sector of averaged and grouped IDCs (used for debugging)
+};
+
+/// class for averaging and grouping the DeltaIDCs (grouping of A- and C-side)
+template <>
+class IDCAverageGroupBase<IDCAverageGroupTPC>
+{
+ public:
+  /// constructor
+  /// \param groupPads number of pads in pad direction which will be grouped
+  /// \param groupRows number of pads in row direction which will be grouped
+  /// \param groupLastRowsThreshold minimum number of pads in row direction for the last group in row direction
+  /// \param groupLastPadsThreshold minimum number of pads in pad direction for the last group in pad direction
+  /// \param nThreads number of CPU threads used
+  IDCAverageGroupBase(const std::array<unsigned char, Mapper::NREGIONS>& groupPads, const std::array<unsigned char, Mapper::NREGIONS>& groupRows, const std::array<unsigned char, Mapper::NREGIONS>& groupLastRowsThreshold, const std::array<unsigned char, Mapper::NREGIONS>& groupLastPadsThreshold, const int nThreads)
+    : mIDCGroupHelperSector(groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold), mRobustAverage(nThreads){};
+
+  /// \return returns number of integration intervalls stored in this object
+  /// \param side side of the TPC
+  unsigned int getNIntegrationIntervals(const o2::tpc::Side side) const { return mIDCsUngrouped.getIDCDelta(side).size() / Mapper::getNumberOfPadsPerSide(); }
+
+  /// \return returns grouped IDCDelta object
+  const auto& getIDCGroupData() & { return std::move(mIDCsGrouped); }
+
+  /// \return returns grouped IDCDelta object
+  auto getIDCGroupData() && { return std::move(mIDCsGrouped); }
+
+  /// \return returns helper object containing the grouping parameters and accessing of data indices
+  auto& getIDCGroupHelperSector() const { return mIDCGroupHelperSector; }
+
+  /// \return returns index to data from ungrouped pad and row
+  /// \param sector sector
+  /// \param region region
+  /// \param urow row of the ungrouped IDCs
+  /// \param upad pad number of the ungrouped IDCs
+  /// \param integrationInterval integration interval
+  unsigned int getUngroupedIndexGlobal(const unsigned int sector, const unsigned int region, unsigned int urow, unsigned int upad, unsigned int integrationInterval) const { return IDCGroupHelperSector::getUngroupedIndexGlobal(sector, region, urow, upad, integrationInterval); }
+
+  /// \return returns the stored DeltaIDC value for local ungrouped pad row and ungrouped pad
+  /// \param sector sector
+  /// \param region region
+  /// \param urow row of the ungrouped IDCs
+  /// \param upad pad number of the ungrouped IDCs
+  /// \param integrationInterval integration interval
+  float getGroupedIDCDeltaVal(const unsigned int sector, const unsigned int region, unsigned int urow, unsigned int upad, unsigned int integrationInterval) const { return mIDCsGrouped.getValue(Sector(sector).side(), mIDCGroupHelperSector.getIndexUngrouped(sector, region, urow, upad, integrationInterval)); }
+
+  /// \return returns the stored DeltaIDC value for local ungrouped pad row and ungrouped pad
+  /// \param sector sector
+  /// \param region region
+  /// \param urow row of the ungrouped IDCs
+  /// \param upad pad number of the ungrouped IDCs
+  /// \param integrationInterval integration interval
+  float getUngroupedIDCDeltaVal(const unsigned int sector, const unsigned int region, unsigned int urow, unsigned int upad, unsigned int integrationInterval) const { return mIDCsUngrouped.getValue(Sector(sector).side(), getUngroupedIndexGlobal(sector, region, urow, upad, integrationInterval)); }
+
+  /// draw IDCDelta for one sector for one integration interval
+  /// \param sector sector which will be drawn
+  /// \param integrationInterval which will be drawn
+  /// \param filename name of the output file. If empty the canvas is drawn.
+  void drawGroupedIDCsSector(const unsigned int sector, const unsigned int integrationInterval, const std::string filename = "IDCDeltaGroupedSector.pdf") const { drawIDCDeltaHelper(false, Sector(sector), integrationInterval, true, filename); }
+
+  /// draw IDCDelta for one sector for one integration interval
+  /// \param sector sector which will be drawn
+  /// \param integrationInterval which will be drawn
+  /// \param filename name of the output file. If empty the canvas is drawn.
+  void drawUngroupedIDCsSector(const unsigned int sector, const unsigned int integrationInterval, const std::string filename = "IDCDeltaUngroupedSector.pdf") const { drawIDCDeltaHelper(false, Sector(sector), integrationInterval, false, filename); }
+
+  /// draw IDCs for one side for one integration interval
+  /// \param side side which will be drawn
+  /// \param integrationInterval which will be drawn
+  /// \param filename name of the output file. If empty the canvas is drawn.
+  void drawGroupedIDCsSide(const o2::tpc::Side side, const unsigned int integrationInterval, const std::string filename = "IDCDeltaGroupedSide.pdf") const { drawIDCDeltaHelper(true, side == Side::A ? Sector(0) : Sector(Sector::MAXSECTOR - 1), integrationInterval, true, filename); }
+
+  /// draw IDCs for one side for one integration interval
+  /// \param side side which will be drawn
+  /// \param integrationInterval which will be drawn
+  /// \param filename name of the output file. If empty the canvas is drawn.
+  void drawUngroupedIDCsSide(const o2::tpc::Side side, const unsigned int integrationInterval, const std::string filename = "IDCDeltaUngroupedSide.pdf") const { drawIDCDeltaHelper(true, side == Side::A ? Sector(0) : Sector(Sector::MAXSECTOR - 1), integrationInterval, false, filename); }
+
+  /// setting the ungrouped IDCs using copy constructor
+  /// \param idcs vector containing the ungrouped IDCs
+  void setIDCs(const IDCDelta<float>& idcs);
+
+  /// setting the ungrouped IDCs using move semantics
+  /// \param idcs vector containing the ungrouped IDCs
+  void setIDCs(IDCDelta<float>&& idcs);
+
+ protected:
+  IDCDelta<float> mIDCsGrouped{};                                 ///< grouped and averaged IDC values
+  IDCGroupHelperSector mIDCGroupHelperSector;                     ///< helper object containing the grouping parameter and methods for accessing data indices
+  std::vector<RobustAverage> mRobustAverage;                      ///<! object for averaging (each thread will get his one object)
+  std::array<std::vector<float>, Mapper::NREGIONS> mWeightsPad{}; ///< storage of the weights in pad direction used if mOverlapPads>0
+  std::array<std::vector<float>, Mapper::NREGIONS> mWeightsRow{}; ///< storage of the weights in row direction used if mOverlapRows>0
+  IDCDelta<float> mIDCsUngrouped{};                               ///< integrated ungrouped IDC values per pad
+
+  /// set correct size for grouped IDCs
+  void resizeGroupedIDCs();
+
+  /// set correct size for grouped IDCs
+  /// \param side side of the TPC
+  void resizeGroupedIDCs(const Side side);
+
+  /// helper function for drawing IDCDelta
+  void drawIDCDeltaHelper(const bool type, const Sector sector, const unsigned int integrationInterval, const bool grouped, const std::string filename) const;
+};
+
+} // namespace o2::tpc
+
+#endif

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCAverageGroupHelper.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCAverageGroupHelper.h
@@ -1,0 +1,249 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file IDCAverageGroupHelper.h
+/// \brief helper class for averaging and grouping of IDCs
+/// \author Matthias Kleiner <mkleiner@ikf.uni-frankfurt.de>
+
+#ifndef ALICEO2_IDCAVERAGEGROUPHELPER_H_
+#define ALICEO2_IDCAVERAGEGROUPHELPER_H_
+
+#include <vector>
+#include "TPCBase/Mapper.h"
+#include "TPCCalibration/IDCGroupHelperRegion.h"
+#include "TPCCalibration/IDCGroupHelperSector.h"
+#include "TPCCalibration/IDCGroup.h"
+
+// forward declaration
+class TH2Poly;
+
+namespace o2::tpc
+{
+
+// forward declaration of some classes
+class RobustAverage;
+class IDCAverageGroupDraw;
+class IDCAverageGroupCRU;
+class IDCAverageGroupTPC;
+class PadRegionInfo;
+
+template <typename DataT>
+struct IDCDelta;
+
+template <class Type>
+class IDCAverageGroupHelper;
+
+/// Helper class for performing the grouping per CRU
+template <>
+class IDCAverageGroupHelper<IDCAverageGroupCRU>
+{
+ public:
+  /// constructor
+  IDCAverageGroupHelper(IDCGroup& idcsGrouped, const std::vector<float>& weightsPad, const std::vector<float>& weightsRow, const std::vector<float>& idcsUngrouped, std::vector<RobustAverage>& robustAverage, const unsigned int cru) : mIDCsGrouped{idcsGrouped}, mWeightsPad{weightsPad}, mWeightsRow{weightsRow}, mIDCsUngrouped{idcsUngrouped}, mRobustAverage{robustAverage}, mCRU{cru} {};
+
+  /// \return returns processed region
+  unsigned int getRegion() const { return mIDCsGrouped.getRegion(); }
+
+  /// \return returns processed CRU
+  auto getCRU() const { return mCRU; }
+
+  /// \return returns grouping parameter
+  int getGroupRows() const { return static_cast<int>(mIDCsGrouped.getGroupRows()); }
+
+  /// \return returns grouping parameter
+  int getGroupPads() const { return static_cast<int>(mIDCsGrouped.getGroupPads()); }
+
+  /// \return returns last ungrouped row
+  int getLastRow() const { return static_cast<int>(mIDCsGrouped.getLastRow()); }
+
+  /// \return returns number of grouped pads per row
+  /// \param glrow grouped local row
+  unsigned int getPadsPerRow(const unsigned int glrow) const { return mIDCsGrouped.getPadsPerRow(glrow); }
+
+  /// \return returns last ungrouped pad for given global row
+  /// \param ulrow ungrouped local row
+  unsigned int getLastPad(const unsigned int ulrow) const { return mIDCsGrouped.getLastPad(ulrow); }
+
+  /// \return returns weighting in pad direction for nth outer pad
+  /// \param relPosPad distance in pads to the group of IDCs
+  float getWeightPad(const unsigned int relPosPad) const { return mWeightsPad[relPosPad]; }
+
+  /// \return returns weighting in row direction for nth outer pad
+  /// \param relPosRow distance in pads to the group of IDCs
+  float getWeightRow(const unsigned int relPosRow) const { return mWeightsRow[relPosRow]; }
+
+  /// \return returns weighting in pad or row direction
+  /// \param relPosRow distance in pads to the group of IDCs in row direction
+  /// \param relPosPad distance in pads to the group of IDCs in pad direction
+  float getWeight(const unsigned int relPosRow, const unsigned int relPosPad) const { return (relPosRow > relPosPad) ? getWeightRow(relPosRow) : getWeightPad(relPosPad); }
+
+  /// \return returns ungrouped IDC value
+  /// \param padInRegion local pad number in processed region
+  float getUngroupedIDCVal(const unsigned int padInRegion) const { return mIDCsUngrouped[mOffsetUngrouped + padInRegion]; }
+
+  /// \return returns the stored grouped IDC value for local ungrouped pad row and ungrouped pad
+  /// \param ugrow global ungrouped row
+  /// \param upad pad number of the ungrouped IDCs
+  float getGroupedIDCValGlobal(unsigned int ugrow, unsigned int upad) const { return mIDCsGrouped.getValUngroupedGlobal(ugrow, upad, mIntegrationInterval); }
+
+  /// add a value to the averaging object
+  /// \param padInRegion pad index in the processed region to the value which will be added
+  /// \param weight weight of the value
+  void addValue(const unsigned int padInRegion, const float weight);
+
+  /// calculating and setting the grouped IDC value
+  /// \param rowGrouped grouped row index
+  /// \param padGrouped grouped pad index
+  void setGroupedIDC(const unsigned int rowGrouped, const unsigned int padGrouped);
+
+  /// setting the members for correct data access
+  /// \param threadNum thread index
+  /// \param integrationInterval integration interval
+  void set(const unsigned int threadNum, const unsigned int integrationInterval);
+
+  /// \return returns processed integration interval
+  unsigned int getIntegrationInterval() const { return mIntegrationInterval; }
+
+  /// clearing the object for averaging
+  void clearRobustAverage();
+
+ private:
+  IDCGroup& mIDCsGrouped;                     ///< grouped and averaged IDC values
+  const std::vector<float>& mWeightsPad{};    ///< storage of the weights in pad direction used if mOverlapPads>0
+  const std::vector<float>& mWeightsRow{};    ///< storage of the weights in row direction used if mOverlapRows>0
+  const std::vector<float>& mIDCsUngrouped{}; ///< integrated ungrouped IDC values per pad
+  std::vector<RobustAverage>& mRobustAverage; ///<! object for averaging (each thread will get his one object)
+  const unsigned int mCRU{};                  ///< cru of the processed region
+  unsigned int mThreadNum{};                  ///< thread number for robust averaging
+  unsigned int mIntegrationInterval{};        ///< current integration interval
+  unsigned int mOffsetUngrouped{};            ///< offset to calculate the index for the ungrouped IDCs
+};
+
+template <>
+class IDCAverageGroupHelper<IDCAverageGroupTPC>
+{
+ public:
+  IDCAverageGroupHelper(IDCDelta<float>& idcsGrouped, const std::array<std::vector<float>, Mapper::NREGIONS>& weightsPad, const std::array<std::vector<float>, Mapper::NREGIONS>& weightsRow, const IDCDelta<float>& idcsUngrouped, std::vector<RobustAverage>& robustAverage, const IDCGroupHelperSector& idcGroupHelperSector) : mIDCsGrouped{idcsGrouped}, mWeightsPad{weightsPad}, mWeightsRow{weightsRow}, mIDCsUngrouped{idcsUngrouped}, mRobustAverage{robustAverage}, mIDCGroupHelperSector{idcGroupHelperSector} {};
+
+  /// \return returns processed region
+  unsigned int getRegion() const { return mCRU.region(); }
+
+  /// \return returns processed CRU
+  auto getCRU() const { return mCRU; }
+
+  /// \return returns processed sector
+  Sector getSector() const { return mCRU.sector(); }
+
+  /// \return returns processed side of the TPC
+  Side getSide() const { return mCRU.side(); }
+
+  /// \return returns grouping parameter
+  int getGroupRows() const { return static_cast<int>(mIDCGroupHelperSector.getGroupingParameter().getGroupRows(getRegion())); }
+
+  /// \return returns grouping parameter
+  int getGroupPads() const { return static_cast<int>(mIDCGroupHelperSector.getGroupingParameter().getGroupPads(getRegion())); }
+
+  /// \return returns last ungrouped row
+  int getLastRow() const { return static_cast<int>(mIDCGroupHelperSector.getLastRow(getRegion())); }
+
+  /// \return returns number of grouped pads per row
+  /// \param glrow grouped local row
+  unsigned int getPadsPerRow(const unsigned int glrow) const { return mIDCGroupHelperSector.getPadsPerRow(getRegion(), glrow); }
+
+  /// \return returns last ungrouped pad for given global row
+  /// \param ulrow ungrouped local row
+  unsigned int getLastPad(const unsigned int ulrow) const { return mIDCGroupHelperSector.getLastPad(getRegion(), ulrow); }
+
+  /// \return returns weighting in pad direction for nth outer pad
+  /// \param relPosPad distance in pads to the group of IDCs
+  float getWeightPad(const unsigned int relPosPad) const { return mWeightsPad[getRegion()][relPosPad]; }
+
+  /// \return returns weighting in row direction for nth outer pad
+  /// \param relPosRow distance in pads to the group of IDCs
+  float getWeightRow(const unsigned int relPosRow) const { return mWeightsRow[getRegion()][relPosRow]; }
+
+  /// \return returns weighting in pad or row direction
+  /// \param relPosRow distance in pads to the group of IDCs in row direction
+  /// \param relPosPad distance in pads to the group of IDCs in pad direction
+  float getWeight(const unsigned int relPosRow, const unsigned int relPosPad) const { return (relPosRow > relPosPad) ? getWeightRow(relPosRow) : getWeightPad(relPosPad); }
+
+  /// \return returns the stored DeltaIDC value for local ungrouped pad row and ungrouped pad
+  /// \param urow row of the ungrouped IDCs
+  /// \param upad pad number of the ungrouped IDCs
+  float getGroupedIDCValGlobal(unsigned int urow, unsigned int upad) const;
+
+  /// \param padInRegion local pad number in processed region
+  float getUngroupedIDCVal(const unsigned int padInRegion) const;
+
+  /// \return returns processed integration interval
+  unsigned int getIntegrationInterval() const { return mIntegrationInterval; }
+
+  /// add a value to the averaging object
+  /// \param padInRegion pad index in the processed region to the value which will be added
+  /// \param weight weight of the value
+  void addValue(const unsigned int padInRegion, const float weight);
+
+  /// calculating and setting the grouped IDC value
+  /// \param glrow local row of the grouped IDCs
+  /// \param pad pad of the grouped IDCs
+  /// \param integrationInterval integration interval
+  void setGroupedIDC(const unsigned int glrow, const unsigned int padGrouped, const float val);
+
+  /// calculating and setting the grouped IDC value
+  /// \param rowGrouped grouped row index
+  /// \param padGrouped grouped pad index
+  void setGroupedIDC(const unsigned int rowGrouped, const unsigned int padGrouped);
+
+  /// \param threadNum thread index
+  void setThreadNum(const unsigned int threadNum) { mThreadNum = threadNum; }
+
+  /// set integration interval for current processed region
+  void setIntegrationInterval(const unsigned int integrationInterval);
+
+  /// set current processed CRU
+  void setCRU(const CRU cru) { mCRU = cru; }
+
+  /// clearing the object for averaging
+  void clearRobustAverage();
+
+ private:
+  IDCDelta<float>& mIDCsGrouped;                                         ///< grouped and averaged IDC values
+  const std::array<std::vector<float>, Mapper::NREGIONS>& mWeightsPad{}; ///< storage of the weights in pad direction used if mOverlapPads>0
+  const std::array<std::vector<float>, Mapper::NREGIONS>& mWeightsRow{}; ///< storage of the weights in row direction used if mOverlapRows>0
+  const IDCDelta<float>& mIDCsUngrouped;                                 ///< integrated ungrouped IDC values per pad
+  std::vector<RobustAverage>& mRobustAverage;                            ///<! object for averaging (each thread will get his one object)
+  const IDCGroupHelperSector& mIDCGroupHelperSector;                     ///< helper for acces the data
+  CRU mCRU{};                                                            ///< cru of the processed region
+  unsigned int mThreadNum{};                                             ///< thread number for robust averaging
+  unsigned int mIntegrationInterval{};                                   ///< current integration interval
+  unsigned int mOffsetUngrouped{};                                       ///< offset to calculate the index for the ungrouped IDCs
+  unsigned int mOffsetGrouped{};                                         ///< offset to calculate the index for the grouped IDCs
+};
+
+/// Helper class for drawing the IDCs
+template <>
+class IDCAverageGroupHelper<IDCAverageGroupDraw> : public IDCGroupHelperRegion
+{
+ public:
+  IDCAverageGroupHelper(const unsigned char groupPads, const unsigned char groupRows, const unsigned char groupLastRowsThreshold, const unsigned char groupLastPadsThreshold, const unsigned int region, const unsigned int nPads, const PadRegionInfo& padInf, TH2Poly& poly)
+    : IDCGroupHelperRegion{groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold, region}, mCountDraw(nPads), mPadInf{padInf}, mPoly{poly} {};
+
+  std::vector<int> mCountDraw;                  ///< counter to keep track of the already drawn pads
+  const PadRegionInfo& mPadInf;                 ///< object for storing pad region information
+  TH2Poly& mPoly;                               ///< TH2Poly which will be used/filled for drawing
+  int mGroupCounter = 0;                        ///< counter for drawing the group index
+  int mCol = 0;                                 ///< counter for drawing the color of each group
+  const std::array<int, 4> mColors{1, 2, 3, 4}; ///< colors (TH2Poly will be filled with these values)
+};
+
+} // namespace o2::tpc
+
+#endif

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCCCDBHelper.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCCCDBHelper.h
@@ -16,23 +16,33 @@
 #ifndef ALICEO2_TPC_IDCCCDBHELPER_H_
 #define ALICEO2_TPC_IDCCCDBHELPER_H_
 
-#include "TPCCalibration/IDCContainer.h"
-#include "TPCCalibration/IDCGroupHelperSector.h"
+#include "DataFormatsTPC/Defs.h"
+#include "TPCBase/Sector.h"
 #include "CCDB/BasicCCDBManager.h"
 #include "Rtypes.h"
 
 namespace o2::tpc
 {
 
-/// Usage
-/// o2::tpc::IDCCCDBHelper<short> helper;
-/// helper.setTimeStamp(0);
-/// helper.loadAll();
-/// helper.drawIDCZeroSide(o2::tpc::Side::A);
-/// const unsigned int sector 10;
-/// const unsigned int integrationInterval =3;
-/// helper.drawIDCDeltaSector(sector, 3);
-/// TODO add drawing of 1D-distributions
+class IDCGroupHelperSector;
+class IDCZero;
+class IDCOne;
+template <typename DataT>
+class IDCDelta;
+
+/*
+ Usage
+ o2::tpc::IDCCCDBHelper<short> helper("http://localhost:8080");
+ helper.setTimeStamp(0);
+ helper.loadAll();
+ const unsigned int sector = 10;
+ const unsigned int integrationInterval = 0;
+ helper.drawIDCZeroSide(o2::tpc::Side::A);
+ helper.drawIDCDeltaSector(sector, integrationInterval);
+ helper.drawIDCDeltaSide(o2::tpc::Side::A, integrationInterval);
+ helper.drawIDCSide(o2::tpc::Side::A, integrationInterval);
+ TODO add drawing of 1D-distributions
+*/
 
 /// \tparam DataT the data type for the IDCDelta which are stored in the CCDB (short, char, float)
 template <typename DataT = short>
@@ -50,20 +60,23 @@ class IDCCCDBHelper
   void loadAll();
 
   /// load/update IDCDelta
-  void loadIDCDelta() { mIDCDelta = mCCDBManager.get<o2::tpc::IDCDelta<DataT>>("TPC/Calib/IDC/IDCDELTA"); }
+  void loadIDCDelta();
 
   /// load/update 0D-IDCs
-  void loadIDCZero() { mIDCZero = mCCDBManager.get<o2::tpc::IDCZero>("TPC/Calib/IDC/IDC0"); }
+  void loadIDCZero();
+
+  /// load/update 0D-IDCs
+  void loadIDCOne();
 
   /// load/update grouping parameter
-  void loadGroupingParameter() { mHelperSector = std::make_unique<IDCGroupHelperSector>(IDCGroupHelperSector{*mCCDBManager.get<o2::tpc::ParameterIDCGroupCCDB>("TPC/Calib/IDC/GROUPINGPAR")}); }
+  void loadGroupingParameter();
 
   /// \return returns the stored IDC0 value for local ungrouped pad row and ungrouped pad
   /// \param sector sector
   /// \param region region
   /// \param urow row of the ungrouped IDCs
   /// \param upad pad number of the ungrouped IDCs
-  float getIDCZeroVal(const unsigned int sector, const unsigned int region, unsigned int urow, unsigned int upad) const { return mIDCZero->getValueIDCZero(Sector(sector).side(), mHelperSector->getIndexUngrouped(sector, region, urow, upad, 0)); }
+  float getIDCZeroVal(const unsigned int sector, const unsigned int region, unsigned int urow, unsigned int upad) const;
 
   /// \return returns the stored DeltaIDC value for local ungrouped pad row and ungrouped pad
   /// \param sector sector
@@ -72,50 +85,87 @@ class IDCCCDBHelper
   /// \param upad pad number of the ungrouped IDCs
   /// \param chunk chunk of the Delta IDC (can be obtained with getLocalIntegrationInterval())
   /// \param localintegrationInterval local integration interval for chunk (can be obtained with getLocalIntegrationInterval())
-  float getIDCDeltaVal(const unsigned int sector, const unsigned int region, unsigned int urow, unsigned int upad, unsigned int localintegrationInterval) const { return mIDCDelta->getValue(Sector(sector).side(), mHelperSector->getIndexUngrouped(sector, region, urow, upad, localintegrationInterval)); }
+  float getIDCDeltaVal(const unsigned int sector, const unsigned int region, unsigned int urow, unsigned int upad, unsigned int localintegrationInterval) const;
+
+  /// \return returns IDCOne value
+  /// \param side side of the TPC
+  /// \param localintegrationInterval local integration interval for chunk (can be obtained with getLocalIntegrationInterval())
+  float getIDCOneVal(const o2::tpc::Side side, const unsigned int localintegrationInterval) const;
+
+  /// \return returns the IDC value which is calculated with: (IDCDelta + 1) * IDCOne * IDCZero
+  /// \param sector sector
+  /// \param region region
+  /// \param urow row of the ungrouped IDCs
+  /// \param upad pad number of the ungrouped IDCs
+  /// \param chunk chunk of the Delta IDC (can be obtained with getLocalIntegrationInterval())
+  /// \param localintegrationInterval local integration interval for chunk (can be obtained with getLocalIntegrationInterval())
+  float getIDCVal(const unsigned int sector, const unsigned int region, unsigned int urow, unsigned int upad, unsigned int localintegrationInterval) const;
 
   /// draw IDC zero I_0(r,\phi) = <I(r,\phi,t)>_t
   /// \param side side which will be drawn
   /// \param filename name of the output file. If empty the canvas is drawn.
-  void drawIDCZeroSide(const o2::tpc::Side side, const std::string filename = "IDCZeroSide.pdf") const { drawSide(IDCType::IDCZero, side, 0, filename); }
+  void drawIDCZeroSide(const o2::tpc::Side side, const std::string filename = "IDCZeroSide.pdf") const { drawIDCZeroHelper(true, side == Side::A ? Sector(0) : Sector(Sector::MAXSECTOR - 1), filename); }
 
   /// draw IDCDelta for one side for one integration interval
   /// \param side side which will be drawn
   /// \param integrationInterval which will be drawn
   /// \param filename name of the output file. If empty the canvas is drawn.
-  void drawIDCDeltaSide(const o2::tpc::Side side, const unsigned int integrationInterval, const std::string filename = "IDCDeltaSide.pdf") const { drawSide(IDCType::IDCDelta, side, integrationInterval, filename); }
+  void drawIDCDeltaSide(const o2::tpc::Side side, const unsigned int integrationInterval, const std::string filename = "IDCDeltaSide.pdf") const { drawIDCDeltaHelper(true, side == Side::A ? Sector(0) : Sector(Sector::MAXSECTOR - 1), integrationInterval, filename); }
+
+  /// draw IDCs which is calculated with: (IDCDelta + 1) * IDCOne * IDCZero
+  /// \param side side which will be drawn
+  /// \param integrationInterval which will be drawn
+  /// \param filename name of the output file. If empty the canvas is drawn.
+  void drawIDCSide(const o2::tpc::Side side, const unsigned int integrationInterval, const std::string filename = "IDCSide.pdf") const { drawIDCHelper(true, side == Side::A ? Sector(0) : Sector(Sector::MAXSECTOR - 1), integrationInterval, filename); }
 
   /// draw IDC zero I_0(r,\phi) = <I(r,\phi,t)>_t
   /// \param sector sector which will be drawn
   /// \param filename name of the output file. If empty the canvas is drawn.
-  void drawIDCZeroSector(const unsigned int sector, const std::string filename = "IDCZeroSector.pdf") const { drawSector(IDCType::IDCZero, sector, 0, filename); }
+  void drawIDCZeroSector(const unsigned int sector, const std::string filename = "IDCZeroSector.pdf") const { drawIDCZeroHelper(false, Sector(sector), filename); }
 
   /// draw IDCDelta for one sector for one integration interval
   /// \param sector sector which will be drawn
   /// \param integrationInterval which will be drawn
   /// \param filename name of the output file. If empty the canvas is drawn.
-  void drawIDCDeltaSector(const unsigned int sector, const unsigned int integrationInterval, const std::string filename = "IDCDeltaSector.pdf") const { drawSector(IDCType::IDCDelta, sector, integrationInterval, filename); }
+  void drawIDCDeltaSector(const unsigned int sector, const unsigned int integrationInterval, const std::string filename = "IDCDeltaSector.pdf") const { drawIDCDeltaHelper(false, Sector(sector), integrationInterval, filename); }
+
+  /// draw IDC zero I_0(r,\phi) = <I(r,\phi,t)>_t
+  /// \param sector sector which will be drawn
+  /// \param integrationInterval which will be drawn
+  /// \param filename name of the output file. If empty the canvas is drawn.
+  void drawIDCSector(const unsigned int sector, const unsigned int integrationInterval, const std::string filename = "IDCSector.pdf") const { drawIDCHelper(false, Sector(sector), integrationInterval, filename); }
 
  private:
   IDCZero* mIDCZero = nullptr;                                                      ///< 0D-IDCs: ///< I_0(r,\phi) = <I(r,\phi,t)>_t
   IDCDelta<DataT>* mIDCDelta = nullptr;                                             ///< compressed or uncompressed Delta IDC: \Delta I(r,\phi,t) = I(r,\phi,t) / ( I_0(r,\phi) * I_1(t) )
+  IDCOne* mIDCOne = nullptr;                                                        ///< I_1(t) = <I(r,\phi,t) / I_0(r,\phi)>_{r,\phi}
   std::unique_ptr<IDCGroupHelperSector> mHelperSector{};                            ///< helper for accessing IDC0 and IDC-Delta
   o2::ccdb::BasicCCDBManager mCCDBManager = o2::ccdb::BasicCCDBManager::instance(); ///< CCDB manager for loading objects
 
-  /// draw IDCs for one side for one integration interval
-  /// \param Side side which will be drawn
-  /// \param integrationInterval which will be drawn
+  /// helper function for drawing IDCZero
+  /// \param sector sector which will be drawn
   /// \param filename name of the output file. If empty the canvas is drawn.
-  void drawSide(const IDCType type, const o2::tpc::Side side, const unsigned int integrationInterval, const std::string filename) const;
+  void drawIDCZeroHelper(const bool type, const Sector sector, const std::string filename) const;
 
-  /// draw IDCs for one sector for one integration interval
+  /// helper function for drawing IDCDelta
   /// \param sector sector which will be drawn
   /// \param integrationInterval which will be drawn
   /// \param filename name of the output file. If empty the canvas is drawn.
-  void drawSector(const IDCType type, const unsigned int sector, const unsigned int integrationInterval, const std::string filename) const;
+  void drawIDCDeltaHelper(const bool type, const Sector sector, const unsigned int integrationInterval, const std::string filename) const;
 
-  /// return returns title for z axis for given IDCType
-  std::string getZAxisTitle(const o2::tpc::IDCType type) const;
+  /// helper function for drawing IDC
+  /// \param sector sector which will be drawn
+  /// \param integrationInterval which will be drawn
+  /// \param filename name of the output file. If empty the canvas is drawn.
+  void drawIDCHelper(const bool type, const Sector sector, const unsigned int integrationInterval, const std::string filename) const;
+
+  /// \return returns index to data from ungrouped pad and row
+  /// \param sector sector
+  /// \param region region
+  /// \param urow row of the ungrouped IDCs
+  /// \param upad pad number of the ungrouped IDCs
+  /// \param integrationInterval integration interval
+  unsigned int getUngroupedIndexGlobal(const unsigned int sector, const unsigned int region, unsigned int urow, unsigned int upad, unsigned int integrationInterval) const;
 
   ClassDefNV(IDCCCDBHelper, 1)
 };

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCDrawHelper.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCDrawHelper.h
@@ -1,0 +1,64 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file IDCDrawHelper.h
+/// \brief helper class for drawing IDCs per region/side
+/// \author Matthias Kleiner <mkleiner@ikf.uni-frankfurt.de>
+
+#ifndef ALICEO2_TPC_IDCDRAWHELPER_H_
+#define ALICEO2_TPC_IDCDRAWHELPER_H_
+
+#include "DataFormatsTPC/Defs.h"
+#include "functional"
+#include "TPCCalibration/IDCContainer.h"
+
+namespace o2::tpc
+{
+
+class IDCDrawHelper
+{
+
+ public:
+  /// helper struct containing a function to give access to the IDCs which will be drawn
+  /// \param sector sector of the TPC
+  /// \param region region in the TPC
+  /// \row local row in the region
+  /// \param pad pad in the row
+  struct IDCDraw {
+    float getIDC(const unsigned int sector, const unsigned int region, const unsigned int row, const unsigned int pad) const { return mIDCFunc(sector, region, row, pad); }
+    std::function<float(const unsigned int, const unsigned int, const unsigned int, const unsigned int)> mIDCFunc; ///< function returning the value which will be drawn for sector, region, row, pad
+  };
+
+  /// draw sector
+  /// \param idc IDCDraw struct containing function to get the values which will be drawn
+  /// \param startRegion first region which will be drawn
+  /// \param endRegion last region which will be drawn
+  /// \param sector sector which will be drawn
+  /// \param zAxisTitle axis title of the z axis
+  /// \param fileName name of the output file (if empty the canvas is drawn instead of writte to a file)
+  static void drawSector(const IDCDraw& idc, const unsigned int startRegion, const unsigned int endRegion, const unsigned int sector, const std::string zAxisTitle, const std::string filename);
+
+  /// draw side
+  /// \param idc IDCDraw struct containing function to get the values which will be drawn
+  /// \param side side which will be drawn
+  /// \param zAxisTitle axis title of the z axis
+  /// \param fileName name of the output file (if empty the canvas is drawn instead of writte to a file)
+  static void drawSide(const IDCDraw& idc, const o2::tpc::Side side, const std::string zAxisTitle, const std::string filename);
+
+  /// \return returns z axis title
+  /// \param type IDC type
+  /// \param compression compression of the IDCs if used (only for IDCDelta)
+  static std::string getZAxisTitle(const IDCType type, const IDCDeltaCompression compression = IDCDeltaCompression::NO);
+};
+
+} // namespace o2::tpc
+
+#endif

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCGroup.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCGroup.h
@@ -78,6 +78,9 @@ class IDCGroup : public IDCGroupHelperRegion
   /// \return returns grouped and averaged IDC values using move semantics
   auto getData() && { return std::move(mIDCsGrouped); }
 
+  /// directly setting grouped IDC values
+  void setData(const std::vector<float>& idcs) { mIDCsGrouped = idcs; }
+
   /// \return returns number of stored integration intervals
   unsigned int getNIntegrationIntervals() const { return mIDCsGrouped.size() / getNIDCsPerIntegrationInterval(); }
 
@@ -98,8 +101,16 @@ class IDCGroup : public IDCGroupHelperRegion
   /// calculate and return 1D-IDCs for this CRU
   std::vector<float> get1DIDCs() const;
 
+  /// calculate and return 1D-IDCs for ungrouped IDCs
+  /// \param idc vector containing the ungrouped IDCs for one region
+  /// \param region TPC region to which the IDCs corresponds to
+  static std::vector<float> get1DIDCsUngrouped(const std::vector<float> idc, const unsigned int region);
+
  private:
   std::vector<float> mIDCsGrouped{}; ///< grouped and averaged IDC values for n integration intervals for one CRU
+
+  /// calculate and return 1D-IDCs for a vector of IDCs
+  static std::vector<float> get1DIDCs(const std::vector<float> idc, const unsigned int nIntervals, const unsigned int nIDCsPerIntegrationInterval, const unsigned int region, const bool normalize);
 
   ClassDefNV(IDCGroup, 1)
 };

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCGroupHelperRegion.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCGroupHelperRegion.h
@@ -33,11 +33,14 @@ class IDCGroupHelperRegion
   /// \param groupLastRowsThreshold minimum number of pads in row direction for the last group in row direction
   /// \param groupLastPadsThreshold minimum number of pads in pad direction for the last group in pad direction
   /// \param region region of the TPC
-  IDCGroupHelperRegion(const unsigned char groupPads = 4, const unsigned char groupRows = 4, const unsigned char groupLastRowsThreshold = 2, const unsigned char groupLastPadsThreshold = 2, const unsigned int region = 0)
+  IDCGroupHelperRegion(const unsigned char groupPads, const unsigned char groupRows, const unsigned char groupLastRowsThreshold, const unsigned char groupLastPadsThreshold, const unsigned int region)
     : mGroupPads{groupPads}, mGroupRows{groupRows}, mGroupLastRowsThreshold{groupLastRowsThreshold}, mGroupLastPadsThreshold{groupLastPadsThreshold}, mRegion{region}
   {
     initIDCGroupHelperRegion();
   }
+
+  /// default constructor for ROOT I/O
+  IDCGroupHelperRegion() = default;
 
   /// \return returns number of grouped rows
   unsigned int getNRows() const { return mRows; }
@@ -102,10 +105,16 @@ class IDCGroupHelperRegion
   unsigned int getIndex(const unsigned int glrow, const unsigned int pad, unsigned int integrationInterval) const { return mNIDCsPerCRU * integrationInterval + mOffsRow[glrow] + pad; }
 
   /// \return returns index to the data
-  /// \param urow local ungrouped row
+  /// \param ulrow local ungrouped row
   /// \param upad ungrouped pad
   /// \param integrationInterval integration interval
   unsigned int getIndexUngrouped(const unsigned int ulrow, const unsigned int upad, unsigned int integrationInterval) const { return getIndex(getGroupedRow(ulrow), getGroupedPad(upad, ulrow), integrationInterval); }
+
+  /// \return returns index to the data
+  /// \param ugrow global ungrouped row
+  /// \param upad ungrouped pad
+  /// \param integrationInterval integration interval
+  unsigned int getIndexUngroupedGlob(const unsigned int ugrow, const unsigned int upad, unsigned int integrationInterval) const;
 
   /// \return returns the global pad number for given local pad row and pad
   /// \param ulrow local ungrouped row in a region
@@ -115,7 +124,7 @@ class IDCGroupHelperRegion
   /// \return returns last ungrouped row
   unsigned int getLastRow() const;
 
-  /// \return returns last ungrouped pad for given global row
+  /// \return returns last ungrouped pad for given local row
   /// \param row local ungrouped row
   unsigned int getLastPad(const unsigned int ulrow) const;
 

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCGroupHelperSector.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCGroupHelperSector.h
@@ -17,17 +17,14 @@
 #define ALICEO2_TPC_IDCGROUPHELPERSECTOR_H_
 
 #include <vector>
-#include <numeric>
 #include "Rtypes.h"
 #include "TPCBase/Mapper.h"
-#include "TPCCalibration/IDCGroupHelperRegion.h"
 #include "TPCCalibration/IDCGroupingParameter.h"
 
 namespace o2::tpc
 {
 
 /// Helper class for accessing grouped pads for one sector
-
 class IDCGroupHelperSector
 {
  public:
@@ -47,34 +44,71 @@ class IDCGroupHelperSector
   IDCGroupHelperSector() = default;
 
   /// \return returns index to the data
+  /// \param sector sector
+  /// \param region TPC region
   /// \param glrow grouped local row
   /// \param pad pad of the grouped IDCs
-  unsigned int getIndexGrouped(const unsigned int sector, const unsigned int region, const unsigned int glrow, const unsigned int pad, unsigned int integrationInterval) const { return mNIDCsPerSector * (integrationInterval * SECTORSPERSIDE + sector) + mRegionOffs[region] + mOffsRow[region][glrow] + pad; }
+  /// \param integrationInterval integration interval
+  unsigned int getIndexGrouped(const unsigned int sector, const unsigned int region, const unsigned int glrow, const unsigned int pad, unsigned int integrationInterval) const { return mNIDCsPerSector * (integrationInterval * SECTORSPERSIDE + sector % o2::tpc::SECTORSPERSIDE) + mRegionOffs[region] + mOffsRow[region][glrow] + pad; }
 
   /// \return returns the index to the grouped data with ungrouped inputs
   /// \param sector sector
   /// \param region TPC region
-  /// \param ulrow row of the ungrouped IDCs
+  /// \param ulrow local row of the ungrouped IDCs
   /// \param upad pad number of the ungrouped IDCs
   /// \param integrationInterval integration interval
-  unsigned int getIndexUngrouped(const unsigned int sector, const unsigned int region, unsigned int ulrow, unsigned int upad, unsigned int integrationInterval) const { return getIndexGrouped(sector % o2::tpc::SECTORSPERSIDE, region, getGroupedRow(region, ulrow), getGroupedPad(region, ulrow, upad), integrationInterval); }
+  unsigned int getIndexUngrouped(const unsigned int sector, const unsigned int region, unsigned int ulrow, unsigned int upad, unsigned int integrationInterval) const { return getIndexGrouped(sector, region, getGroupedRow(region, ulrow), getGroupedPad(region, ulrow, upad), integrationInterval); }
+
+  /// \return returns the index to the grouped data with ungrouped inputs
+  /// \param sector sector
+  /// \param region TPC region
+  /// \param ugrow global row of the ungrouped IDCs
+  /// \param upad pad number of the ungrouped IDCs
+  /// \param integrationInterval integration interval
+  unsigned int getIndexUngroupedGlobal(const unsigned int sector, const unsigned int region, unsigned int ugrow, unsigned int upad, unsigned int integrationInterval) const { return getIndexUngrouped(sector, region, ugrow - Mapper::ROWOFFSET[region], upad, integrationInterval); }
 
   /// \return returns grouped pad for ungrouped row and pad
   /// \param region region
   /// \param ulrow local ungrouped row in a region
   /// \param upad ungrouped pad
-  unsigned int getGroupedPad(const unsigned int region, unsigned int ulrow, unsigned int upad) const { return IDCGroupHelperRegion::getGroupedPad(upad, ulrow, region, mGroupingPar.GroupPads[region], mGroupingPar.GroupRows[region], mRows[region], mPadsPerRow[region]); }
+  unsigned int getGroupedPad(const unsigned int region, unsigned int ulrow, unsigned int upad) const;
 
   /// \return returns the row of the group from the local ungrouped row in a region
   /// \param region region
   /// \param ulrow local ungrouped row in a region
-  unsigned int getGroupedRow(const unsigned int region, unsigned int ulrow) const { return IDCGroupHelperRegion::getGroupedRow(ulrow, mGroupingPar.GroupRows[region], mRows[region]); }
+  unsigned int getGroupedRow(const unsigned int region, unsigned int ulrow) const;
 
   /// \returns grouping parameter
   const auto& getGroupingParameter() const { return mGroupingPar; }
 
-  /// \return returns number if IDCs for given region
-  unsigned int getNIDCs(const unsigned int region) { return mNIDCsPerCRU[region]; }
+  /// \return returns number of IDCs for given region
+  unsigned int getNIDCs(const unsigned int region) const { return mNIDCsPerCRU[region]; }
+
+  /// \return returns number of IDCs for a whole sector
+  unsigned int getNIDCsPerSector() const { return mNIDCsPerSector; }
+
+  /// \return returns last ungrouped row
+  unsigned int getLastRow(const unsigned int region) const;
+
+  /// \return returns last ungrouped pad for given global row
+  /// \param ulrow ungrouped local row
+  unsigned int getLastPad(const unsigned int region, const unsigned int ulrow) const;
+
+  /// \return returns offsey to calculate the index
+  /// \param glrow grouped local row
+  unsigned int getOffsRow(const unsigned int region, const unsigned int glrow) const { return mOffsRow[region][glrow]; }
+
+  /// \return returns number of grouped pads per row
+  /// \param glrow grouped local row
+  unsigned getPadsPerRow(const unsigned int region, const unsigned int glrow) const { return mPadsPerRow[region][glrow]; }
+
+  /// \return returns index to ungrouped data from ungrouped pad and row
+  /// \param sector sector
+  /// \param region region
+  /// \param urow row of the ungrouped IDCs
+  /// \param upad pad number of the ungrouped IDCs
+  /// \param integrationInterval integration interval
+  static unsigned int getUngroupedIndexGlobal(const unsigned int sector, const unsigned int region, unsigned int urow, unsigned int upad, unsigned int integrationInterval) { return (integrationInterval * SECTORSPERSIDE + sector % SECTORSPERSIDE) * Mapper::getPadsInSector() + Mapper::GLOBALPADOFFSET[region] + Mapper::OFFSETCRULOCAL[region][urow] + upad; }
 
  protected:
   ParameterIDCGroupCCDB mGroupingPar{};                                  ///< struct containg the grouping parameter
@@ -85,21 +119,8 @@ class IDCGroupHelperSector
   std::array<std::vector<unsigned int>, Mapper::NREGIONS> mPadsPerRow{}; ///< number of pads per row per region
   std::array<std::vector<unsigned int>, Mapper::NREGIONS> mOffsRow{};    ///< offset to calculate the index in the data from row and pad per region
 
-  void initIDCGroupHelperSector()
-  {
-    for (unsigned int reg = 0; reg < Mapper::NREGIONS; ++reg) {
-      const IDCGroupHelperRegion groupTmp(mGroupingPar.GroupPads[reg], mGroupingPar.GroupRows[reg], mGroupingPar.GroupLastRowsThreshold[reg], mGroupingPar.GroupLastPadsThreshold[reg], reg);
-      mNIDCsPerCRU[reg] = groupTmp.getNIDCsPerIntegrationInterval();
-      mRows[reg] = groupTmp.getNRows();
-      mPadsPerRow[reg] = groupTmp.getPadsPerRow();
-      mOffsRow[reg] = groupTmp.getRowOffset();
-      if (reg > 0) {
-        const unsigned int lastInd = reg - 1;
-        mRegionOffs[reg] = mRegionOffs[lastInd] + mNIDCsPerCRU[lastInd];
-      }
-    }
-    mNIDCsPerSector = static_cast<unsigned int>(std::accumulate(mNIDCsPerCRU.begin(), mNIDCsPerCRU.end(), decltype(mNIDCsPerCRU)::value_type(0)));
-  }
+  /// init function for setting the members
+  void initIDCGroupHelperSector();
 
   ClassDefNV(IDCGroupHelperSector, 1)
 };

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCGroupingParameter.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCGroupingParameter.h
@@ -38,7 +38,7 @@ struct ParameterIDCGroup : public o2::conf::ConfigurableParamHelper<ParameterIDC
   unsigned char GroupLastRowsThreshold[Mapper::NREGIONS]{3, 3, 3, 3, 2, 2, 2, 2, 2, 2}; ///< if the last group (region edges) consists in row direction less then mGroupLastRowsThreshold pads then it will be grouped into the previous group
   unsigned char GroupLastPadsThreshold[Mapper::NREGIONS]{3, 3, 3, 3, 2, 2, 2, 2, 1, 1}; ///< if the last group (sector edges) consists in pad direction less then mGroupLastPadsThreshold pads then it will be grouped into the previous group
   AveragingMethod Method = AveragingMethod::SLOW;                                       ///< method which is used for averaging
-
+  float Sigma = 3.f;                                                                    ///< sigma cut which can be used during the grouping for outlier filtering
   O2ParamDef(ParameterIDCGroup, "TPCIDCGroupParam");
 };
 

--- a/Detectors/TPC/calibration/include/TPCCalibration/RobustAverage.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/RobustAverage.h
@@ -42,7 +42,11 @@ class RobustAverage
  public:
   /// constructor
   /// \param maxValues maximum number of values which will be averaged. Copy of values will be done.
-  RobustAverage(const unsigned int maxValues) { mValues.reserve(maxValues); }
+  RobustAverage(const unsigned int maxValues)
+  {
+    mValues.reserve(maxValues);
+    mWeights.reserve(maxValues);
+  }
 
   /// default constructor
   RobustAverage() = default;
@@ -56,10 +60,11 @@ class RobustAverage
   void reserve(const unsigned int maxValues) { mValues.reserve(maxValues); }
 
   /// clear the stored values
-  void clear() { mValues.clear(); }
+  void clear();
 
   /// \param value value which will be added to the list of stored values for averaging
-  void addValue(const float value) { mValues.emplace_back(value); }
+  /// \param weight weight of the value
+  void addValue(const float value, const float weight = 1.f);
 
   /// returns the filtered average value
   /// \param sigma maximum accepted standard deviation: sigma*stdev
@@ -68,16 +73,26 @@ class RobustAverage
   /// \return returns mean of stored values
   float getMean() const { return getMean(mValues.begin(), mValues.end()); }
 
+  /// \return returns weighted mean of stored values
+  float getWeightedMean() const { return getWeightedMean(mValues.begin(), mValues.end(), mWeights.begin(), mWeights.end()); }
+
+  /// \return returns standard deviation of stored values
+  float getStdDev() { return getStdDev(getMean()); }
+
   /// values which will be averaged and filtered
   void print() const;
 
  private:
   std::vector<float> mValues{};    ///< values which will be averaged and filtered
+  std::vector<float> mWeights{};   ///< weights of each value
   std::vector<float> mTmpValues{}; ///< tmp vector used for calculation of std dev
 
   float getMean(std::vector<float>::const_iterator begin, std::vector<float>::const_iterator end) const;
 
-  /// performing outlier filtering of the stored values
+  float getWeightedMean(std::vector<float>::const_iterator beginValues, std::vector<float>::const_iterator endValues, std::vector<float>::const_iterator beginWeight, std::vector<float>::const_iterator endWeight) const;
+
+  /// \return returns standard deviation of stored values
+  /// \param mean mean of stored values
   float getStdDev(const float mean);
 
   /// performing outlier filtering of the stored values by defining range of included values in terms of standard deviation

--- a/Detectors/TPC/calibration/src/IDCAverageGroup.cxx
+++ b/Detectors/TPC/calibration/src/IDCAverageGroup.cxx
@@ -10,18 +10,21 @@
 // or submit itself to any jurisdiction.
 
 #include "TPCCalibration/IDCAverageGroup.h"
-#include "TPCCalibration/IDCGroup.h"
+#include "TPCCalibration/IDCAverageGroupBase.h"
+#include "TPCCalibration/IDCAverageGroupHelper.h"
+#include "TPCCalibration/IDCDrawHelper.h"
 #include "CommonUtils/TreeStreamRedirector.h"
-#include "TPCCalibration/IDCGroupingParameter.h"
 #include "TPCBase/Mapper.h"
+#include "CommonConstants/MathConstants.h"
 
+// root includes
 #include "TFile.h"
 #include "TKey.h"
 #include "TPCBase/Painter.h"
 #include "TH2Poly.h"
 #include "TCanvas.h"
 #include "TLatex.h"
-#include "TKey.h"
+#include "TStyle.h"
 #include "Framework/Logger.h"
 
 #if (defined(WITH_OPENMP) || defined(_OPENMP)) && !defined(__CLING__)
@@ -30,151 +33,392 @@
 static inline int omp_get_thread_num() { return 0; }
 #endif
 
-o2::tpc::IDCAverageGroup::IDCAverageGroup(const unsigned char groupPads, const unsigned char groupRows, const unsigned char groupLastRowsThreshold, const unsigned char groupLastPadsThreshold, const unsigned int region, const Sector sector, const float sigma)
-  : mIDCsGrouped{groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold, region}, mSector{sector}, mSigma{sigma}, mRobustAverage(sNThreads)
+template <>
+void o2::tpc::IDCAverageGroup<o2::tpc::IDCAverageGroupCRU>::init()
 {
   unsigned int maxValues = 0;
   for (unsigned int i = 0; i < Mapper::NREGIONS; ++i) {
-    const unsigned int maxGroup = (mIDCsGrouped.getGroupRows() + mIDCsGrouped.getGroupLastRowsThreshold()) * (mIDCsGrouped.getGroupPads() + mIDCsGrouped.getGroupLastPadsThreshold() + Mapper::ADDITIONALPADSPERROW[i].back());
+    const unsigned int maxGroup = (this->mIDCsGrouped.getGroupRows() + this->mIDCsGrouped.getGroupLastRowsThreshold()) * (this->mIDCsGrouped.getGroupPads() + this->mIDCsGrouped.getGroupLastPadsThreshold() + Mapper::ADDITIONALPADSPERROW[i].back());
     if (maxGroup > maxValues) {
       maxValues = maxGroup;
     }
   }
 
-  for (auto& rob : mRobustAverage) {
+  for (auto& rob : this->mRobustAverage) {
     rob.reserve(maxValues);
+  }
+
+  // init weights
+  const float sigmaEdge = 1.f;
+  this->mWeightsPad.reserve(mOverlapPads);
+  for (int i = 0; i < mOverlapPads; ++i) {
+    const float groupPadsHalf = this->mIDCsGrouped.getGroupPads() / 2.f;
+    const float sigmaPad = groupPadsHalf / sigmaEdge; // assume 3-sigma at the edge of the last pad
+    this->mWeightsPad.emplace_back(normal_dist(groupPadsHalf + i, sigmaPad));
+  }
+
+  this->mWeightsRow.reserve(mOverlapRows);
+  for (int i = 0; i < mOverlapRows; ++i) {
+    const float groupRowsHalf = this->mIDCsGrouped.getGroupRows() / 2.f;
+    const float sigmaRow = groupRowsHalf / sigmaEdge; // assume 3-sigma at the edge of the last pad
+    this->mWeightsRow.emplace_back(normal_dist(groupRowsHalf + i, sigmaRow));
   }
 }
 
-void o2::tpc::IDCAverageGroup::processIDCs()
+template <>
+void o2::tpc::IDCAverageGroup<o2::tpc::IDCAverageGroupTPC>::init()
 {
-  const static auto& paramIDCGroup = ParameterIDCGroup::Instance();
+  unsigned int maxValues = 0;
+  for (unsigned int i = 0; i < Mapper::NREGIONS; ++i) {
+    const unsigned int maxGroup = (this->mIDCGroupHelperSector.getGroupingParameter().getGroupRows(i) + this->mIDCGroupHelperSector.getGroupingParameter().getGroupLastRowsThreshold(i)) * (this->mIDCGroupHelperSector.getGroupingParameter().getGroupPads(i) + this->mIDCGroupHelperSector.getGroupingParameter().getGroupLastPadsThreshold(i) + Mapper::ADDITIONALPADSPERROW[i].back());
+    if (maxGroup > maxValues) {
+      maxValues = maxGroup;
+    }
+  }
 
-#pragma omp parallel for num_threads(sNThreads)
-  for (unsigned int integrationInterval = 0; integrationInterval < getNIntegrationIntervals(); ++integrationInterval) {
-    const unsigned int threadNum = omp_get_thread_num();
-    const unsigned int lastRow = mIDCsGrouped.getLastRow();
-    unsigned int rowGrouped = 0;
-    for (unsigned int iRow = 0; iRow <= lastRow; iRow += mIDCsGrouped.getGroupRows()) {
-      // the sectors is divide in to two parts around ylocal=0 to get the same simmetric grouping around ylocal=0
-      for (int iYLocalSide = 0; iYLocalSide < 2; ++iYLocalSide) {
-        const unsigned int region = mIDCsGrouped.getRegion();
-        const unsigned int nPads = Mapper::PADSPERROW[region][iRow] / 2;
-        const unsigned int endPads = mIDCsGrouped.getLastPad(iRow) + nPads;
+  for (auto& rob : this->mRobustAverage) {
+    rob.reserve(maxValues);
+  }
 
-        const unsigned int halfPadsInRow = mIDCsGrouped.getPadsPerRow(rowGrouped) / 2;
-        unsigned int padGrouped = iYLocalSide ? halfPadsInRow : halfPadsInRow - 1;
-        for (unsigned int ipad = nPads; ipad <= endPads; ipad += mIDCsGrouped.getGroupPads()) {
-          const unsigned int endRows = (iRow == lastRow) ? (Mapper::ROWSPERREGION[region] - iRow) : mIDCsGrouped.getGroupRows();
-          mRobustAverage[threadNum].clear();
-          for (unsigned int iRowMerge = 0; iRowMerge < endRows; ++iRowMerge) {
-            const unsigned int iRowTmp = iRow + iRowMerge;
-            const auto offs = Mapper::ADDITIONALPADSPERROW[region][iRowTmp] - Mapper::ADDITIONALPADSPERROW[region][iRow];
-            const auto padStart = (ipad == 0) ? 0 : offs;
-            const unsigned int endPadsTmp = (ipad == endPads) ? (Mapper::PADSPERROW[region][iRowTmp] - ipad) : mIDCsGrouped.getGroupPads() + offs;
-            for (unsigned int ipadMerge = padStart; ipadMerge < endPadsTmp; ++ipadMerge) {
-              const unsigned int iPadTmp = ipad + ipadMerge;
-              const unsigned int iPadSide = iYLocalSide ? iPadTmp : Mapper::PADSPERROW[region][iRowTmp] - iPadTmp - 1;
-              const unsigned int indexIDC = integrationInterval * Mapper::PADSPERREGION[region] + Mapper::OFFSETCRULOCAL[region][iRowTmp] + iPadSide;
-              mRobustAverage[threadNum].addValue(mIDCsUngrouped[indexIDC] * Mapper::PADAREA[region]);
-            }
-          }
+  // init weights
+  for (unsigned int region = 0; region < Mapper::NREGIONS; ++region) {
+    const float sigmaEdge = 1.f; /// TODO make configurable
+    this->mWeightsPad[region].reserve(mOverlapPads);
+    for (unsigned int i = 0; i < mOverlapPads; ++i) {
+      const float groupPadsHalf = this->mIDCGroupHelperSector.getGroupingParameter().getGroupPads(i) / 2.f;
+      const float sigmaPad = groupPadsHalf / sigmaEdge; // assume 3-sigma at the edge of the last pad
+      this->mWeightsPad[i].emplace_back(normal_dist(groupPadsHalf + i, sigmaPad));
+    }
 
-          switch (paramIDCGroup.Method) {
-            case o2::tpc::AveragingMethod::SLOW:
-            default:
-              mIDCsGrouped(rowGrouped, padGrouped, integrationInterval) = mRobustAverage[threadNum].getFilteredAverage(mSigma);
-              break;
-            case o2::tpc::AveragingMethod::FAST:
-              mIDCsGrouped(rowGrouped, padGrouped, integrationInterval) = mRobustAverage[threadNum].getMean();
-              break;
-          }
-
-          iYLocalSide ? ++padGrouped : --padGrouped;
-        }
-      }
-      ++rowGrouped;
+    this->mWeightsRow[region].reserve(mOverlapRows);
+    for (unsigned int i = 0; i < mOverlapRows; ++i) {
+      const float groupRowsHalf = this->mIDCGroupHelperSector.getGroupingParameter().getGroupRows(i) / 2.f;
+      const float sigmaRow = groupRowsHalf / sigmaEdge; // assume 3-sigma at the edge of the last pad
+      this->mWeightsRow[i].emplace_back(normal_dist(groupRowsHalf + i, sigmaRow));
     }
   }
 }
 
-void o2::tpc::IDCAverageGroup::dumpToFile(const char* outFileName, const char* outName) const
+template <class Type>
+void o2::tpc::IDCAverageGroup<Type>::updatePadStatusMapFromFile(const char* file, const char* objName)
+{
+  TFile inpfile(file);
+  CalDet<PadFlags>* padStatus{nullptr};
+  inpfile.GetObject(objName, padStatus);
+  if (!padStatus) {
+    LOG(FATAL) << "No valid pad flag object was loaded";
+    return;
+  }
+
+  const auto type = padStatus->getPadSubset();
+  if (type != PadSubset::Region) {
+    LOG(FATAL) << "Wrong pad subset type! Type must be PadSubset::Region";
+    return;
+  }
+  mPadStatus.reset(padStatus);
+}
+
+template <class Type>
+float o2::tpc::IDCAverageGroup<Type>::normal_dist(const float x, const float sigma)
+{
+  const float fac = x / sigma;
+  return std::exp(-fac * fac / 2);
+}
+
+template <>
+void o2::tpc::IDCAverageGroup<o2::tpc::IDCAverageGroupCRU>::processIDCs()
+{
+  std::vector<IDCAverageGroupHelper<IDCAverageGroupCRU>> idcStruct(sNThreads, IDCAverageGroupHelper<IDCAverageGroupCRU>{this->mIDCsGrouped, this->mWeightsPad, this->mWeightsRow, this->mIDCsUngrouped, this->mRobustAverage, this->getCRU()});
+#pragma omp parallel for num_threads(sNThreads)
+  for (unsigned int integrationInterval = 0; integrationInterval < this->getNIntegrationIntervals(); ++integrationInterval) {
+    const unsigned int threadNum = omp_get_thread_num();
+    idcStruct[threadNum].set(threadNum, integrationInterval);
+    loopOverGroups(idcStruct[threadNum]);
+  }
+}
+
+template <>
+void o2::tpc::IDCAverageGroup<o2::tpc::IDCAverageGroupTPC>::processIDCs()
+{
+  std::vector<IDCAverageGroupHelper<IDCAverageGroupTPC>> idcStruct(sNThreads, IDCAverageGroupHelper<IDCAverageGroupTPC>{this->mIDCsGrouped, this->mWeightsPad, this->mWeightsRow, this->mIDCsUngrouped, this->mRobustAverage, this->mIDCGroupHelperSector});
+  for (int thread = 0; thread < sNThreads; ++thread) {
+    idcStruct[thread].setThreadNum(thread);
+  }
+
+#pragma omp parallel for num_threads(sNThreads)
+  for (unsigned int iCRU = 0; iCRU < CRU::MaxCRU; ++iCRU) {
+    const unsigned int threadNum = omp_get_thread_num();
+    const CRU cru(iCRU);
+    idcStruct[threadNum].setCRU(cru);
+    for (unsigned int integrationInterval = 0; integrationInterval < this->getNIntegrationIntervals(cru.side()); ++integrationInterval) {
+      idcStruct[threadNum].setIntegrationInterval(integrationInterval);
+      loopOverGroups(idcStruct[threadNum]);
+    }
+  }
+}
+
+template <class Type>
+void o2::tpc::IDCAverageGroup<Type>::drawGrouping(const std::string filename)
+{
+  const auto& mapper = Mapper::instance();
+  TH2Poly* poly = o2::tpc::painter::makeSectorHist("hSector", "Sector;#it{x} (cm);#it{y} (cm)");
+  poly->SetContour(255);
+  gStyle->SetNumberContours(255);
+
+  TCanvas can("can", "can", 2000, 1400);
+  can.SetRightMargin(0.01f);
+  can.SetLeftMargin(0.06f);
+  can.SetTopMargin(0.04f);
+  can.cd();
+  poly->SetTitle(0);
+  poly->GetYaxis()->SetTickSize(0.002f);
+  poly->GetYaxis()->SetTitleOffset(0.7f);
+  poly->SetStats(0);
+  poly->Draw("col");
+
+  for (unsigned int i = 0; i < Mapper::NREGIONS; ++i) {
+    if constexpr (std::is_same_v<Type, IDCAverageGroupCRU>) {
+      IDCAverageGroupHelper<IDCAverageGroupDraw> idcStruct(this->mIDCsGrouped.getGroupPads(), this->mIDCsGrouped.getGroupRows(), this->mIDCsGrouped.getGroupLastRowsThreshold(), this->mIDCsGrouped.getGroupLastPadsThreshold(), i, Mapper::PADSPERREGION[i], mapper.getPadRegionInfo(i), *poly);
+      loopOverGroups(idcStruct);
+    } else {
+      IDCAverageGroupHelper<IDCAverageGroupDraw> idcStruct(this->mIDCGroupHelperSector.getGroupingParameter().getGroupPads(i), this->mIDCGroupHelperSector.getGroupingParameter().getGroupRows(i), this->mIDCGroupHelperSector.getGroupingParameter().getGroupLastRowsThreshold(i), this->mIDCGroupHelperSector.getGroupingParameter().getGroupLastPadsThreshold(i), i, Mapper::PADSPERREGION[i], mapper.getPadRegionInfo(i), *poly);
+      loopOverGroups(idcStruct);
+    }
+  }
+
+  painter::drawSectorLocalPadNumberPoly(kBlack);
+  painter::drawSectorInformationPoly(kRed, kRed);
+
+  if constexpr (std::is_same_v<Type, IDCAverageGroupCRU>) {
+    const std::string outName = filename.empty() ? fmt::format("grouping_rows-{}_pads-{}_rowThr-{}_padThr-{}_ovRows-{}_ovPads-{}.pdf", this->mIDCsGrouped.getGroupPads(), this->mIDCsGrouped.getGroupRows(), this->mIDCsGrouped.getGroupLastRowsThreshold(), this->mIDCsGrouped.getGroupLastPadsThreshold(), mOverlapRows, mOverlapPads) : filename;
+    can.SaveAs(outName.data());
+  } else {
+    std::string sgrRows = {"_"};
+    std::string sgrPads = {"_"};
+    std::string sgrRowsTh = {"_"};
+    std::string sgrPadsTh = {"_"};
+    if (filename.empty()) {
+      for (unsigned int i = 0; i < Mapper::NREGIONS; ++i) {
+        const int grRows = this->mIDCGroupHelperSector.getGroupingParameter().getGroupRows(i);
+        sgrRows += fmt::format("{}_", grRows);
+        const int grPads = this->mIDCGroupHelperSector.getGroupingParameter().getGroupPads(i);
+        sgrPads += fmt::format("{}_", grPads);
+        const int grRowsTh = this->mIDCGroupHelperSector.getGroupingParameter().getGroupLastRowsThreshold(i);
+        sgrRowsTh += fmt::format("{}_", grRowsTh);
+        const int grPadsTh = this->mIDCGroupHelperSector.getGroupingParameter().getGroupLastPadsThreshold(i);
+        sgrPadsTh += fmt::format("{}_", grPadsTh);
+      }
+    }
+    const std::string outName = filename.empty() ? fmt::format("grouping_rows{}pads{}rowThr{}padThr{}ovRows-{}_ovPads-{}.pdf", sgrRows, sgrPads, sgrRowsTh, sgrPadsTh, mOverlapRows, mOverlapPads) : filename;
+    can.SaveAs(outName.data());
+  }
+  delete poly;
+}
+
+template <class Type>
+template <class LoopType>
+void o2::tpc::IDCAverageGroup<Type>::loopOverGroups(IDCAverageGroupHelper<LoopType>& idcStruct)
+{
+  const unsigned int region = idcStruct.getRegion();
+  const int groupRows = idcStruct.getGroupRows();
+  const int groupPads = idcStruct.getGroupPads();
+  const int lastRow = idcStruct.getLastRow();
+  unsigned int rowGrouped = 0;
+
+  // loop over ungrouped row
+  for (int iRow = 0; iRow <= lastRow; iRow += groupRows) {
+    const bool bNotLastrow = iRow != lastRow;
+
+    // the sectors is divide in to two parts around ylocal=0 to get the same simmetric grouping around ylocal=0
+    for (int iYLocalSide = 0; iYLocalSide < 2; ++iYLocalSide) {
+      if constexpr (std::is_same_v<LoopType, IDCAverageGroupDraw>) {
+        idcStruct.mCol = region + iRow / groupRows + iYLocalSide;
+      }
+      unsigned int padGrouped = iYLocalSide ? idcStruct.getPadsPerRow(rowGrouped) / 2 : idcStruct.getPadsPerRow(rowGrouped) / 2 - 1; // grouped pad in pad direction
+      const int nPadsStart = Mapper::PADSPERROW[region][iRow] / 2;                                                                   // first ungrouped pad in pad direction
+      const int nPadsEnd = idcStruct.getLastPad(iRow) + nPadsStart;                                                                  // last grouped pad in pad direction
+
+      // loop over ungrouped pads
+      for (int iPad = nPadsStart; iPad <= nPadsEnd; iPad += groupPads) {
+        if constexpr (std::is_same_v<LoopType, IDCAverageGroupCRU> || std::is_same_v<LoopType, IDCAverageGroupTPC>) {
+          idcStruct.clearRobustAverage();
+        }
+
+        const int startRow = ((iRow - mOverlapRows) < 0) ? 0 : -mOverlapRows;                                                                                                          // first row in this group
+        const int endRow = ((iRow + groupRows + mOverlapRows) >= Mapper::ROWSPERREGION[region] || !bNotLastrow) ? (Mapper::ROWSPERREGION[region] - iRow) : (mOverlapRows + groupRows); // last row in this group
+        for (int iRowMerge = startRow; iRowMerge < endRow; ++iRowMerge) {
+          const bool bOverlapRowRight = iRowMerge >= groupRows;
+          const unsigned int ungroupedRow = iRow + iRowMerge;
+          const int offsPad = static_cast<int>(Mapper::ADDITIONALPADSPERROW[region][ungroupedRow]) - static_cast<int>(Mapper::ADDITIONALPADSPERROW[region][iRow]); // offset due to additional pads in pad direction in the current row compared to the first row in the group
+
+          const bool lastPad = iPad == nPadsEnd;
+          const int padEnd = lastPad ? (static_cast<int>(Mapper::PADSPERROW[region][ungroupedRow]) - iPad) : (groupPads + offsPad + mOverlapPads); // last ungrouped pad in pad direction
+          const int padStart = offsPad - mOverlapPads;                                                                                             // first ungrouped pad in pad direction
+
+          for (int ipadMerge = padStart; ipadMerge < padEnd; ++ipadMerge) {
+            const unsigned int ungroupedPad = iYLocalSide ? (iPad + ipadMerge) : Mapper::PADSPERROW[region][ungroupedRow] - (iPad + ipadMerge) - 1;
+            const unsigned int padInRegion = Mapper::OFFSETCRULOCAL[region][ungroupedRow] + ungroupedPad;
+
+            // averaging and grouping
+            if constexpr (std::is_same_v<LoopType, IDCAverageGroupCRU> || std::is_same_v<LoopType, IDCAverageGroupTPC>) {
+              // check status flag
+              const auto flag = mPadStatus->getCalArray(idcStruct.getCRU()).getValue(padInRegion);
+
+              // TODO add more cases...
+              if (flag == PadFlags::flagDeadPad) {
+                // dead pad. just skip this
+                continue;
+              }
+
+              float weight = 1;
+              // set weight for outer pads which are not in the main group
+              if (mOverlapRows && mOverlapPads) {
+                if (iRowMerge < 0) {
+                  // everything on the left border
+                  const int relPosRow = std::abs(iRowMerge);
+                  if (ipadMerge < offsPad) {
+                    const int relPosPad = std::abs(ipadMerge - offsPad);
+                    weight = idcStruct.getWeight(relPosRow, relPosPad);
+                  } else if (!lastPad && ipadMerge >= (groupPads + offsPad)) {
+                    const int relPosPad = std::abs(1 + ipadMerge - (groupPads + offsPad));
+                    weight = idcStruct.getWeight(relPosRow, relPosPad);
+                  } else {
+                    weight = idcStruct.getWeightRow(relPosRow);
+                  }
+                } else if (bNotLastrow && bOverlapRowRight) {
+                  const int relPosRow = std::abs(1 + iRowMerge - (groupRows));
+                  if (ipadMerge < offsPad) {
+                    const int relPosPad = std::abs(ipadMerge - offsPad);
+                    weight = idcStruct.getWeight(relPosRow, relPosPad);
+                  } else if (!lastPad && ipadMerge >= (groupPads + offsPad)) {
+                    const int relPosPad = std::abs(1 + ipadMerge - (groupPads + offsPad));
+                    weight = idcStruct.getWeight(relPosRow, relPosPad);
+                  } else {
+                    weight = idcStruct.getWeightRow(relPosRow);
+                  }
+                } else if (ipadMerge < offsPad) {
+                  // bottom
+                  const int relPadPos = std::abs(ipadMerge - offsPad);
+                  weight = idcStruct.getWeightPad(relPadPos);
+                } else if (!lastPad && ipadMerge >= (groupPads + offsPad)) {
+                  const int relPadPos = std::abs(1 + ipadMerge - (groupPads + offsPad));
+                  weight = idcStruct.getWeightPad(relPadPos);
+                } else {
+                }
+              }
+              idcStruct.addValue(padInRegion, weight);
+            } else {
+              // drawing the grouping
+              const GlobalPadNumber padNum = o2::tpc::Mapper::getGlobalPadNumber(ungroupedRow, ungroupedPad, region);
+              static auto coords = o2::tpc::painter::getPadCoordinatesSector();
+              auto coordinate = coords[padNum];
+
+              const float yPos = (coordinate.yVals[0] + coordinate.yVals[2]) / 2;
+              const float xPos = (coordinate.xVals[0] + coordinate.xVals[2]) / 2;
+              const int nCountDraw = idcStruct.mCountDraw[padInRegion]++;
+              const float offsX = (nCountDraw % 2) * 0.6f * idcStruct.mPadInf.getPadHeight();
+              const float offsY = (nCountDraw / 2) * 0.2f * idcStruct.mPadInf.getPadWidth();
+              const float xPosDraw = xPos - 0.3f * idcStruct.mPadInf.getPadHeight() + offsX;
+              const float yPosDraw = yPos - 0.4f * idcStruct.mPadInf.getPadWidth() + offsY;
+
+              TLatex latex;
+              latex.SetTextFont(63);
+              latex.SetTextSize(1);
+              const char* groupText = Form("#bf{#color[%lu]{%i}}", (idcStruct.mCol % idcStruct.mColors.size()) + 1, idcStruct.mGroupCounter);
+              latex.DrawLatex(xPosDraw, yPosDraw, groupText);
+              if (iRowMerge < 0 || (bNotLastrow && bOverlapRowRight) || (ipadMerge < offsPad) || (!lastPad && ipadMerge >= (groupPads + offsPad))) {
+              } else {
+                idcStruct.mPoly.Fill(xPos, yPos, idcStruct.mColors[idcStruct.mCol % idcStruct.mColors.size()]);
+              }
+            }
+          }
+        }
+        if constexpr (std::is_same_v<LoopType, IDCAverageGroupCRU> || std::is_same_v<LoopType, IDCAverageGroupTPC>) {
+          idcStruct.setGroupedIDC(rowGrouped, padGrouped);
+        } else {
+          ++idcStruct.mGroupCounter;
+          ++idcStruct.mCol;
+        }
+        iYLocalSide ? ++padGrouped : --padGrouped;
+      }
+    }
+    ++rowGrouped;
+  }
+}
+
+template <class Type>
+void o2::tpc::IDCAverageGroup<Type>::dumpToFile(const char* outFileName, const char* outName) const
 {
   TFile fOut(outFileName, "RECREATE");
   fOut.WriteObject(this, outName);
   fOut.Close();
 }
 
-bool o2::tpc::IDCAverageGroup::setFromFile(const char* fileName, const char* name)
+template <class Type>
+bool o2::tpc::IDCAverageGroup<Type>::setFromFile(const char* fileName, const char* name)
 {
   TFile inpf(fileName, "READ");
-  IDCAverageGroup* idcAverageGroupTmp{nullptr};
-  idcAverageGroupTmp = reinterpret_cast<IDCAverageGroup*>(inpf.GetObjectChecked(name, IDCAverageGroup::Class()));
+  using Temp = IDCAverageGroup<Type>;
+  Temp* idcAverageGroupTmp{nullptr};
+  idcAverageGroupTmp = reinterpret_cast<Temp*>(inpf.GetObjectChecked(name, Temp::Class()));
 
   if (!idcAverageGroupTmp) {
     LOGP(ERROR, "Failed to load {} from {}", name, inpf.GetName());
     return false;
   }
-  setIDCs(idcAverageGroupTmp->getIDCsUngrouped());
+  this->setIDCs(idcAverageGroupTmp->getIDCsUngrouped());
 
   delete idcAverageGroupTmp;
   return true;
 }
 
-void o2::tpc::IDCAverageGroup::drawUngroupedIDCs(const unsigned int integrationInterval, const std::string filename) const
+template <class Type>
+void o2::tpc::IDCAverageGroup<Type>::drawPadStatusMap(const bool type, const Sector sector, const std::string filename) const
 {
-  const auto coords = o2::tpc::painter::getPadCoordinatesSector();
-  TH2Poly* poly = o2::tpc::painter::makeSectorHist("hSector", "Sector;local #it{x} (cm);local #it{y} (cm); #it{IDC}");
-  poly->SetContour(255);
-  poly->SetTitle(nullptr);
-  poly->GetYaxis()->SetTickSize(0.002f);
-  poly->GetYaxis()->SetTitleOffset(0.7f);
-  poly->GetZaxis()->SetTitleOffset(1.3f);
-  poly->SetStats(0);
+  std::function<float(const unsigned int, const unsigned int, const unsigned int, const unsigned int)> idcFunc = [this](const unsigned int sector, const unsigned int region, const unsigned int row, const unsigned int pad) {
+    const unsigned int padInRegion = Mapper::OFFSETCRULOCAL[region][row] + pad;
+    const auto flag = mPadStatus->getCalArray(region + sector * Mapper::NREGIONS).getValue(padInRegion);
+    return static_cast<float>(flag);
+  };
 
-  TCanvas* can = new TCanvas("can", "can", 2000, 1400);
-  can->SetRightMargin(0.14f);
-  can->SetLeftMargin(0.06f);
-  can->SetTopMargin(0.04f);
-
-  TLatex lat;
-  lat.SetTextFont(63);
-  lat.SetTextSize(2);
-
-  poly->Draw("colz");
-  const unsigned int region = mIDCsGrouped.getRegion();
-  for (unsigned int irow = 0; irow < Mapper::ROWSPERREGION[region]; ++irow) {
-    for (unsigned int ipad = 0; ipad < Mapper::PADSPERROW[region][irow]; ++ipad) {
-      const auto padNum = Mapper::getGlobalPadNumber(irow, ipad, region);
-      const auto coordinate = coords[padNum];
-      const float yPos = -0.5 * (coordinate.yVals[0] + coordinate.yVals[2]); // local coordinate system is mirrored
-      const float xPos = 0.5 * (coordinate.xVals[0] + coordinate.xVals[2]);
-      const unsigned int indexIDC = integrationInterval * Mapper::PADSPERREGION[region] + Mapper::OFFSETCRULOCAL[region][irow] + ipad;
-      const float idc = mIDCsUngrouped[indexIDC] * Mapper::PADAREA[region];
-      poly->Fill(xPos, yPos, idc);
-      lat.SetTextAlign(12);
-      lat.DrawLatex(xPos, yPos, Form("%i", ipad));
-    }
-  }
-
-  if (!filename.empty()) {
-    can->SaveAs(filename.data());
-    delete poly;
-    delete can;
-  }
+  IDCDrawHelper::IDCDraw drawFun;
+  drawFun.mIDCFunc = idcFunc;
+  const std::string zAxisTitle = "status flag";
+  type ? IDCDrawHelper::drawSide(drawFun, sector.side(), zAxisTitle, filename) : IDCDrawHelper::drawSector(drawFun, 0, Mapper::NREGIONS, sector, zAxisTitle, filename);
 }
 
-/// for debugging: creating debug tree for integrated IDCs
-/// \param nameFile name of the output file
-void o2::tpc::IDCAverageGroup::createDebugTree(const char* nameFile) const
+template <>
+void o2::tpc::IDCAverageGroup<o2::tpc::IDCAverageGroupCRU>::createDebugTree(const char* nameFile)
 {
   o2::utils::TreeStreamRedirector pcstream(nameFile, "RECREATE");
   pcstream.GetFile()->cd();
-  createDebugTree(*this, pcstream);
+  IDCAverageGroupHelper<IDCAverageGroupCRU> idcStruct(this->mIDCsGrouped, this->mWeightsPad, this->mWeightsRow, this->mIDCsUngrouped, this->mRobustAverage, this->getCRU());
+  for (unsigned int integrationInterval = 0; integrationInterval < this->getNIntegrationIntervals(); ++integrationInterval) {
+    idcStruct.set(0, integrationInterval);
+    createDebugTree(idcStruct, pcstream);
+  }
   pcstream.Close();
 }
 
-void o2::tpc::IDCAverageGroup::createDebugTreeForAllCRUs(const char* nameFile, const char* filename)
+template <>
+void o2::tpc::IDCAverageGroup<o2::tpc::IDCAverageGroupTPC>::createDebugTree(const char* nameFile)
+{
+  IDCAverageGroupHelper<IDCAverageGroupTPC> idcStruct(this->mIDCsGrouped, this->mWeightsPad, this->mWeightsRow, this->mIDCsUngrouped, this->mRobustAverage, this->mIDCGroupHelperSector);
+  o2::utils::TreeStreamRedirector pcstream(nameFile, "RECREATE");
+  pcstream.GetFile()->cd();
+  for (unsigned int iCRU = 0; iCRU < CRU::MaxCRU; ++iCRU) {
+    const CRU cru(iCRU);
+    idcStruct.setCRU(cru);
+    for (unsigned int integrationInterval = 0; integrationInterval < this->getNIntegrationIntervals(cru.side()); ++integrationInterval) {
+      idcStruct.setIntegrationInterval(integrationInterval);
+      createDebugTree(idcStruct, pcstream);
+    }
+  }
+  pcstream.Close();
+}
+
+template <>
+void o2::tpc::IDCAverageGroup<o2::tpc::IDCAverageGroupCRU>::createDebugTreeForAllCRUs(const char* nameFile, const char* filename)
 {
   o2::utils::TreeStreamRedirector pcstream(nameFile, "RECREATE");
   pcstream.GetFile()->cd();
@@ -184,99 +428,78 @@ void o2::tpc::IDCAverageGroup::createDebugTreeForAllCRUs(const char* nameFile, c
     const auto key = dynamic_cast<TKey*>(keyAsObj);
     LOGP(info, "Key name: {} Type: {}", key->GetName(), key->GetClassName());
 
-    if (std::strcmp(o2::tpc::IDCAverageGroup::Class()->GetName(), key->GetClassName()) != 0) {
+    if (std::strcmp(o2::tpc::IDCAverageGroup<IDCAverageGroupCRU>::Class()->GetName(), key->GetClassName()) != 0) {
       LOGP(info, "skipping object. wrong class.");
       continue;
     }
 
-    IDCAverageGroup* idcavg = (IDCAverageGroup*)fInp.Get(key->GetName());
-    createDebugTree(*idcavg, pcstream);
+    IDCAverageGroup<IDCAverageGroupCRU>* idcavg = (IDCAverageGroup<IDCAverageGroupCRU>*)fInp.Get(key->GetName());
+    IDCAverageGroupHelper<IDCAverageGroupCRU> idcStruct(idcavg->mIDCsGrouped, idcavg->mWeightsPad, idcavg->mWeightsRow, idcavg->mIDCsUngrouped, idcavg->mRobustAverage, idcavg->getCRU());
+    for (unsigned int integrationInterval = 0; integrationInterval < idcavg->getNIntegrationIntervals(); ++integrationInterval) {
+      idcStruct.set(0, integrationInterval);
+      createDebugTree(idcStruct, pcstream);
+    }
     delete idcavg;
   }
   pcstream.Close();
 }
 
-void o2::tpc::IDCAverageGroup::createDebugTree(const IDCAverageGroup& idcavg, o2::utils::TreeStreamRedirector& pcstream)
+template <class Type>
+void o2::tpc::IDCAverageGroup<Type>::createDebugTree(const IDCAverageGroupHelper<Type>& idcStruct, o2::utils::TreeStreamRedirector& pcstream)
 {
   const Mapper& mapper = Mapper::instance();
-  unsigned int sector = idcavg.getSector();
-  unsigned int cru = sector * Mapper::NREGIONS + idcavg.getRegion();
-  const o2::tpc::CRU cruTmp(cru);
-  unsigned int region = cruTmp.region();
+  unsigned int cru = idcStruct.getCRU();
+  const CRU cruTmp(cru);
+  unsigned int sector = cruTmp.sector();
+  unsigned int region = idcStruct.getRegion();
+  unsigned int integrationInterval = idcStruct.getIntegrationInterval();
 
-  for (unsigned int integrationInterval = 0; integrationInterval < idcavg.getNIntegrationIntervals(); ++integrationInterval) {
-    const unsigned long padsPerCRU = Mapper::PADSPERREGION[region];
-    std::vector<unsigned int> vRow(padsPerCRU);
-    std::vector<unsigned int> vPad(padsPerCRU);
-    std::vector<float> vXPos(padsPerCRU);
-    std::vector<float> vYPos(padsPerCRU);
-    std::vector<float> vGlobalXPos(padsPerCRU);
-    std::vector<float> vGlobalYPos(padsPerCRU);
-    std::vector<float> idcsPerIntegrationInterval(padsPerCRU);        // idcs for one time bin
-    std::vector<float> groupedidcsPerIntegrationInterval(padsPerCRU); // idcs for one time bin
-    std::vector<float> invPadArea(padsPerCRU);
+  const unsigned long padsPerCRU = Mapper::PADSPERREGION[region];
+  std::vector<unsigned int> vRow(padsPerCRU);
+  std::vector<unsigned int> vPad(padsPerCRU);
+  std::vector<float> vXPos(padsPerCRU);
+  std::vector<float> vYPos(padsPerCRU);
+  std::vector<float> vGlobalXPos(padsPerCRU);
+  std::vector<float> vGlobalYPos(padsPerCRU);
+  std::vector<float> idcsPerIntegrationInterval(padsPerCRU);        // idcs for one time bin
+  std::vector<float> groupedidcsPerIntegrationInterval(padsPerCRU); // idcs for one time bin
+  std::vector<float> invPadArea(padsPerCRU);
 
-    for (unsigned int iPad = 0; iPad < padsPerCRU; ++iPad) {
-      const GlobalPadNumber globalNum = Mapper::GLOBALPADOFFSET[region] + iPad;
-      const auto& padPosLocal = mapper.padPos(globalNum);
-      vRow[iPad] = padPosLocal.getRow();
-      vPad[iPad] = padPosLocal.getPad();
-      vXPos[iPad] = mapper.getPadCentre(padPosLocal).X();
-      vYPos[iPad] = mapper.getPadCentre(padPosLocal).Y();
-      invPadArea[iPad] = Mapper::PADAREA[region];
-      const GlobalPosition2D globalPos = mapper.LocalToGlobal(LocalPosition2D(vXPos[iPad], vYPos[iPad]), cruTmp.sector());
-      vGlobalXPos[iPad] = globalPos.X();
-      vGlobalYPos[iPad] = globalPos.Y();
-      idcsPerIntegrationInterval[iPad] = idcavg.getUngroupedIDCVal(iPad, integrationInterval);
-      groupedidcsPerIntegrationInterval[iPad] = idcavg.getGroupedIDCValGlobal(vRow[iPad], vPad[iPad], integrationInterval);
-    }
-
-    pcstream << "tree"
-             << "cru=" << cru
-             << "sector=" << sector
-             << "region=" << region
-             << "integrationInterval=" << integrationInterval
-             << "IDCUngrouped.=" << idcsPerIntegrationInterval
-             << "IDCGrouped.=" << groupedidcsPerIntegrationInterval
-             << "invPadArea.=" << invPadArea
-             << "pad.=" << vPad
-             << "row.=" << vRow
-             << "lx.=" << vXPos
-             << "ly.=" << vYPos
-             << "gx.=" << vGlobalXPos
-             << "gy.=" << vGlobalYPos
-             << "\n";
+  for (unsigned int iPad = 0; iPad < padsPerCRU; ++iPad) {
+    const GlobalPadNumber globalNum = Mapper::GLOBALPADOFFSET[region] + iPad;
+    const auto& padPosLocal = mapper.padPos(globalNum);
+    vRow[iPad] = padPosLocal.getRow();
+    vPad[iPad] = padPosLocal.getPad();
+    vXPos[iPad] = mapper.getPadCentre(padPosLocal).X();
+    vYPos[iPad] = mapper.getPadCentre(padPosLocal).Y();
+    invPadArea[iPad] = Mapper::INVPADAREA[region];
+    const GlobalPosition2D globalPos = mapper.LocalToGlobal(LocalPosition2D(vXPos[iPad], vYPos[iPad]), cruTmp.sector());
+    vGlobalXPos[iPad] = globalPos.X();
+    vGlobalYPos[iPad] = globalPos.Y();
+    idcsPerIntegrationInterval[iPad] = idcStruct.getUngroupedIDCVal(iPad);
+    groupedidcsPerIntegrationInterval[iPad] = idcStruct.getGroupedIDCValGlobal(vRow[iPad], vPad[iPad]);
   }
+
+  pcstream << "tree"
+           << "cru=" << cru
+           << "sector=" << sector
+           << "region=" << region
+           << "integrationInterval=" << integrationInterval
+           << "IDCUngrouped.=" << idcsPerIntegrationInterval
+           << "IDCGrouped.=" << groupedidcsPerIntegrationInterval
+           << "invPadArea.=" << invPadArea
+           << "pad.=" << vPad
+           << "row.=" << vRow
+           << "lx.=" << vXPos
+           << "ly.=" << vYPos
+           << "gx.=" << vGlobalXPos
+           << "gy.=" << vGlobalYPos
+           << "\n";
 }
 
-void o2::tpc::IDCAverageGroup::setIDCs(const std::vector<float>& idcs)
-{
-  mIDCsUngrouped = idcs;
-  mIDCsGrouped.resize(getNIntegrationIntervals());
-}
-
-void o2::tpc::IDCAverageGroup::setIDCs(std::vector<float>&& idcs)
-{
-  mIDCsUngrouped = std::move(idcs);
-  mIDCsGrouped.resize(getNIntegrationIntervals());
-}
-
-unsigned int o2::tpc::IDCAverageGroup::getNIntegrationIntervals() const
-{
-  return mIDCsUngrouped.size() / Mapper::PADSPERREGION[mIDCsGrouped.getRegion()];
-}
-
-float o2::tpc::IDCAverageGroup::getUngroupedIDCVal(const unsigned int localPadNumber, const unsigned int integrationInterval) const
-{
-  return mIDCsUngrouped[localPadNumber + integrationInterval * Mapper::PADSPERREGION[mIDCsGrouped.getRegion()]];
-}
-
-unsigned int o2::tpc::IDCAverageGroup::getUngroupedIndex(const unsigned int ulrow, const unsigned int upad, const unsigned int integrationInterval) const
-{
-  return integrationInterval * Mapper::PADSPERREGION[mIDCsGrouped.getRegion()] + Mapper::OFFSETCRULOCAL[mIDCsGrouped.getRegion()][ulrow] + upad;
-}
-
-unsigned int o2::tpc::IDCAverageGroup::getUngroupedIndexGlobal(const unsigned int ugrow, const unsigned int upad, const unsigned int integrationInterval) const
-{
-  return integrationInterval * Mapper::PADSPERREGION[mIDCsGrouped.getRegion()] + Mapper::OFFSETCRUGLOBAL[ugrow] + upad;
-}
+template class o2::tpc::IDCAverageGroup<o2::tpc::IDCAverageGroupCRU>;
+template class o2::tpc::IDCAverageGroup<o2::tpc::IDCAverageGroupTPC>;
+template void o2::tpc::IDCAverageGroup<o2::tpc::IDCAverageGroupCRU>::loopOverGroups(IDCAverageGroupHelper<o2::tpc::IDCAverageGroupCRU>&);
+template void o2::tpc::IDCAverageGroup<o2::tpc::IDCAverageGroupTPC>::loopOverGroups(IDCAverageGroupHelper<o2::tpc::IDCAverageGroupTPC>&);
+template void o2::tpc::IDCAverageGroup<o2::tpc::IDCAverageGroupCRU>::loopOverGroups(IDCAverageGroupHelper<o2::tpc::IDCAverageGroupDraw>&);
+template void o2::tpc::IDCAverageGroup<o2::tpc::IDCAverageGroupTPC>::loopOverGroups(IDCAverageGroupHelper<o2::tpc::IDCAverageGroupDraw>&);

--- a/Detectors/TPC/calibration/src/IDCAverageGroupBase.cxx
+++ b/Detectors/TPC/calibration/src/IDCAverageGroupBase.cxx
@@ -1,0 +1,74 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "TPCCalibration/IDCAverageGroupBase.h"
+#include "TPCBase/Mapper.h"
+#include "TPCCalibration/IDCDrawHelper.h"
+
+void o2::tpc::IDCAverageGroupBase<o2::tpc::IDCAverageGroupCRU>::drawUngroupedIDCs(const unsigned int integrationInterval, const std::string filename) const
+{
+  std::function<float(const unsigned int, const unsigned int, const unsigned int, const unsigned int)> idcFunc = [this, integrationInterval](const unsigned int, const unsigned int region, const unsigned int row, const unsigned int pad) {
+    const unsigned int indexIDC = integrationInterval * Mapper::PADSPERREGION[region] + Mapper::OFFSETCRULOCAL[region][row] + pad;
+    return this->mIDCsUngrouped[indexIDC] * Mapper::INVPADAREA[region];
+  };
+
+  IDCDrawHelper::IDCDraw drawFun;
+  drawFun.mIDCFunc = idcFunc;
+  const std::string zAxisTitle = IDCDrawHelper::getZAxisTitle(IDCType::IDC);
+  IDCDrawHelper::drawSector(drawFun, this->mIDCsGrouped.getRegion(), this->mIDCsGrouped.getRegion() + 1, 0, zAxisTitle, filename);
+}
+
+void o2::tpc::IDCAverageGroupBase<o2::tpc::IDCAverageGroupCRU>::setIDCs(const std::vector<float>& idcs)
+{
+  mIDCsUngrouped = idcs;
+  mIDCsGrouped.resize(getNIntegrationIntervals());
+}
+
+void o2::tpc::IDCAverageGroupBase<o2::tpc::IDCAverageGroupCRU>::setIDCs(std::vector<float>&& idcs)
+{
+  mIDCsUngrouped = std::move(idcs);
+  mIDCsGrouped.resize(getNIntegrationIntervals());
+}
+
+void o2::tpc::IDCAverageGroupBase<o2::tpc::IDCAverageGroupTPC>::drawIDCDeltaHelper(const bool type, const Sector sector, const unsigned int integrationInterval, const bool grouped, const std::string filename) const
+{
+  std::function<float(const unsigned int, const unsigned int, const unsigned int, const unsigned int)> idcFunc = [this, integrationInterval, grouped](const unsigned int sector, const unsigned int region, const unsigned int irow, const unsigned int pad) {
+    return grouped ? this->getGroupedIDCDeltaVal(sector, region, irow, pad, integrationInterval) : this->getUngroupedIDCDeltaVal(sector, region, irow, pad, integrationInterval);
+  };
+  IDCDrawHelper::IDCDraw drawFun;
+  drawFun.mIDCFunc = idcFunc;
+  const std::string zAxisTitle = IDCDrawHelper::getZAxisTitle(IDCType::IDCDelta, IDCDeltaCompression::NO);
+  type ? IDCDrawHelper::drawSide(drawFun, sector.side(), zAxisTitle, filename) : IDCDrawHelper::drawSector(drawFun, 0, Mapper::NREGIONS, sector, zAxisTitle, filename);
+}
+
+void o2::tpc::IDCAverageGroupBase<o2::tpc::IDCAverageGroupTPC>::resizeGroupedIDCs()
+{
+  resizeGroupedIDCs(Side::A);
+  resizeGroupedIDCs(Side::C);
+}
+
+void o2::tpc::IDCAverageGroupBase<o2::tpc::IDCAverageGroupTPC>::resizeGroupedIDCs(const Side side)
+{
+  const unsigned int nIDCs = mIDCGroupHelperSector.getNIDCsPerSector() * SECTORSPERSIDE * getNIntegrationIntervals(side);
+  mIDCsGrouped.resize(side, nIDCs);
+}
+
+void o2::tpc::IDCAverageGroupBase<o2::tpc::IDCAverageGroupTPC>::setIDCs(const IDCDelta<float>& idcs)
+{
+  mIDCsUngrouped = idcs;
+  resizeGroupedIDCs();
+}
+
+void o2::tpc::IDCAverageGroupBase<o2::tpc::IDCAverageGroupTPC>::setIDCs(IDCDelta<float>&& idcs)
+{
+  mIDCsUngrouped = std::move(idcs);
+  resizeGroupedIDCs();
+}

--- a/Detectors/TPC/calibration/src/IDCAverageGroupHelper.cxx
+++ b/Detectors/TPC/calibration/src/IDCAverageGroupHelper.cxx
@@ -1,0 +1,93 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "TPCCalibration/IDCAverageGroupHelper.h"
+#include "TPCCalibration/IDCAverageGroupBase.h"
+#include "TPCCalibration/IDCContainer.h"
+#include "TPCCalibration/RobustAverage.h"
+
+void o2::tpc::IDCAverageGroupHelper<o2::tpc::IDCAverageGroupCRU>::setGroupedIDC(const unsigned int rowGrouped, const unsigned int padGrouped)
+{
+  const static auto& paramIDCGroup = ParameterIDCGroup::Instance();
+  switch (paramIDCGroup.Method) {
+    case o2::tpc::AveragingMethod::SLOW:
+    default:
+      mIDCsGrouped(rowGrouped, padGrouped, mIntegrationInterval) = mRobustAverage[mThreadNum].getFilteredAverage(paramIDCGroup.Sigma);
+      break;
+    case o2::tpc::AveragingMethod::FAST:
+      mIDCsGrouped(rowGrouped, padGrouped, mIntegrationInterval) = mRobustAverage[mThreadNum].getMean();
+      break;
+  }
+}
+
+void o2::tpc::IDCAverageGroupHelper<o2::tpc::IDCAverageGroupCRU>::set(const unsigned int threadNum, const unsigned int integrationInterval)
+{
+  mThreadNum = threadNum;
+  mIntegrationInterval = integrationInterval;
+  mOffsetUngrouped = integrationInterval * Mapper::PADSPERREGION[getRegion()];
+}
+
+void o2::tpc::IDCAverageGroupHelper<o2::tpc::IDCAverageGroupCRU>::addValue(const unsigned int padInRegion, const float weight)
+{
+  mRobustAverage[mThreadNum].addValue(getUngroupedIDCVal(padInRegion) * Mapper::INVPADAREA[getRegion()], weight);
+}
+
+void o2::tpc::IDCAverageGroupHelper<o2::tpc::IDCAverageGroupCRU>::clearRobustAverage()
+{
+  mRobustAverage[mThreadNum].clear();
+}
+
+float o2::tpc::IDCAverageGroupHelper<o2::tpc::IDCAverageGroupTPC>::getGroupedIDCValGlobal(unsigned int urow, unsigned int upad) const
+{
+  return mIDCsGrouped.getValue(getSide(), mIDCGroupHelperSector.getIndexUngroupedGlobal(getSector(), getRegion(), urow, upad, mIntegrationInterval));
+}
+
+void o2::tpc::IDCAverageGroupHelper<o2::tpc::IDCAverageGroupTPC>::setGroupedIDC(const unsigned int glrow, const unsigned int padGrouped, const float val)
+{
+  const unsigned int index = mIDCGroupHelperSector.getOffsRow(getRegion(), glrow) + padGrouped + mOffsetGrouped;
+  mIDCsGrouped.setValue(val, getSide(), index);
+}
+
+float o2::tpc::IDCAverageGroupHelper<o2::tpc::IDCAverageGroupTPC>::getUngroupedIDCVal(const unsigned int padInRegion) const
+{
+  return mIDCsUngrouped.getValue(getSide(), padInRegion + mOffsetUngrouped);
+}
+
+void o2::tpc::IDCAverageGroupHelper<o2::tpc::IDCAverageGroupTPC>::setIntegrationInterval(const unsigned int integrationInterval)
+{
+  mIntegrationInterval = integrationInterval;
+  mOffsetUngrouped = (mIntegrationInterval * SECTORSPERSIDE + getSector() % SECTORSPERSIDE) * Mapper::getPadsInSector() + Mapper::GLOBALPADOFFSET[getRegion()];
+  mOffsetGrouped = mIDCGroupHelperSector.getIndexGrouped(getSector(), getRegion(), 0, 0, mIntegrationInterval);
+}
+
+void o2::tpc::IDCAverageGroupHelper<o2::tpc::IDCAverageGroupTPC>::setGroupedIDC(const unsigned int rowGrouped, const unsigned int padGrouped)
+{
+  const static auto& paramIDCGroup = ParameterIDCGroup::Instance();
+  switch (paramIDCGroup.Method) {
+    case o2::tpc::AveragingMethod::SLOW:
+    default:
+      setGroupedIDC(rowGrouped, padGrouped, mRobustAverage[mThreadNum].getFilteredAverage(paramIDCGroup.Sigma));
+      break;
+    case o2::tpc::AveragingMethod::FAST:
+      setGroupedIDC(rowGrouped, padGrouped, mRobustAverage[mThreadNum].getMean());
+      break;
+  }
+}
+
+void o2::tpc::IDCAverageGroupHelper<o2::tpc::IDCAverageGroupTPC>::addValue(const unsigned int padInRegion, const float weight)
+{
+  mRobustAverage[mThreadNum].addValue(getUngroupedIDCVal(padInRegion), weight);
+}
+
+void o2::tpc::IDCAverageGroupHelper<o2::tpc::IDCAverageGroupTPC>::clearRobustAverage()
+{
+  mRobustAverage[mThreadNum].clear();
+}

--- a/Detectors/TPC/calibration/src/IDCCCDBHelper.cxx
+++ b/Detectors/TPC/calibration/src/IDCCCDBHelper.cxx
@@ -10,141 +10,97 @@
 // or submit itself to any jurisdiction.
 
 #include "TPCCalibration/IDCCCDBHelper.h"
+#include "TPCCalibration/IDCDrawHelper.h"
+#include "TPCCalibration/IDCGroupHelperSector.h"
+#include "TPCCalibration/IDCContainer.h"
 #include "TPCBase/Mapper.h"
-#include "TPCBase/Painter.h"
-#include "TH2Poly.h"
-#include "TCanvas.h"
-#include "TLatex.h"
 
 template <typename DataT>
-std::string o2::tpc::IDCCCDBHelper<DataT>::getZAxisTitle(const o2::tpc::IDCType type) const
+void o2::tpc::IDCCCDBHelper<DataT>::loadIDCDelta()
 {
-  switch (type) {
-    case IDCType::IDCZero:
-    default:
-      return "#it{IDC_{0}}";
-      break;
-    case IDCType::IDCDelta:
-      return "#Delta#it{IDC}";
-      break;
-    case IDCType::IDCOne:
-    case IDCType::IDC:
-      return "Wrong Type";
-      break;
-  }
+  mIDCDelta = mCCDBManager.get<o2::tpc::IDCDelta<DataT>>("TPC/Calib/IDC/IDCDELTA");
 }
 
 template <typename DataT>
-void o2::tpc::IDCCCDBHelper<DataT>::drawSide(const o2::tpc::IDCType type, const o2::tpc::Side side, const unsigned int integrationInterval, const std::string filename) const
+void o2::tpc::IDCCCDBHelper<DataT>::loadIDCZero()
 {
-  const auto coords = o2::tpc::painter::getPadCoordinatesSector();
-  TH2Poly* poly = o2::tpc::painter::makeSideHist(side);
-  poly->SetContour(255);
-  poly->SetTitle(nullptr);
-  poly->GetXaxis()->SetTitleOffset(1.2f);
-  poly->GetYaxis()->SetTitleOffset(1.3f);
-  poly->GetZaxis()->SetTitleOffset(1.2f);
-  poly->GetZaxis()->SetTitle(getZAxisTitle(type).data());
-  poly->GetZaxis()->SetMaxDigits(3); // force exponential axis
-  poly->SetStats(0);
-
-  TCanvas* can = new TCanvas("can", "can", 650, 600);
-  can->SetTopMargin(0.04f);
-  can->SetRightMargin(0.14f);
-  can->SetLeftMargin(0.1f);
-  poly->Draw("colz");
-
-  unsigned int sectorStart = (side == Side::A) ? 0 : o2::tpc::SECTORSPERSIDE;
-  unsigned int sectorEnd = (side == Side::A) ? o2::tpc::SECTORSPERSIDE : Mapper::NSECTORS;
-  for (unsigned int sector = sectorStart; sector < sectorEnd; ++sector) {
-    for (unsigned int region = 0; region < Mapper::NREGIONS; ++region) {
-      for (unsigned int irow = 0; irow < Mapper::ROWSPERREGION[region]; ++irow) {
-        for (unsigned int ipad = 0; ipad < Mapper::PADSPERROW[region][irow]; ++ipad) {
-          const auto padNum = Mapper::getGlobalPadNumber(irow, ipad, region);
-          const float angDeg = 10.f + sector * 20;
-          auto coordinate = coords[padNum];
-          coordinate.rotate(angDeg);
-          const float yPos = 0.25f * static_cast<float>(coordinate.yVals[0] + coordinate.yVals[1] + coordinate.yVals[2] + coordinate.yVals[3]);
-          const float xPos = 0.25f * static_cast<float>(coordinate.xVals[0] + coordinate.xVals[1] + coordinate.xVals[2] + coordinate.xVals[3]);
-          const auto padTmp = (side == Side::A) ? ipad : (Mapper::PADSPERROW[region][irow] - ipad); // C-Side is mirrored
-          switch (type) {
-            case IDCType::IDCZero:
-            default:
-              poly->Fill(xPos, yPos, getIDCZeroVal(sector, region, irow, padTmp));
-              break;
-            case IDCType::IDCDelta:
-              poly->Fill(xPos, yPos, getIDCDeltaVal(sector, region, irow, padTmp, integrationInterval));
-              break;
-            case IDCType::IDC:
-              break;
-            case IDCType::IDCOne:
-              break;
-          }
-        }
-      }
-    }
-  }
-  if (!filename.empty()) {
-    can->SaveAs(filename.data());
-    delete poly;
-    delete can;
-  }
+  mIDCZero = mCCDBManager.get<o2::tpc::IDCZero>("TPC/Calib/IDC/IDC0");
 }
 
 template <typename DataT>
-void o2::tpc::IDCCCDBHelper<DataT>::drawSector(const IDCType type, const unsigned int sector, const unsigned int integrationInterval, const std::string filename) const
+void o2::tpc::IDCCCDBHelper<DataT>::loadIDCOne()
 {
-  const auto coords = o2::tpc::painter::getPadCoordinatesSector();
-  TH2Poly* poly = o2::tpc::painter::makeSectorHist("hSector", "Sector;local #it{x} (cm);local #it{y} (cm); #it{IDC}");
-  poly->SetContour(255);
-  poly->SetTitle(nullptr);
-  poly->GetYaxis()->SetTickSize(0.002f);
-  poly->GetYaxis()->SetTitleOffset(0.7f);
-  poly->GetZaxis()->SetTitleOffset(1.3f);
-  poly->SetStats(0);
-  poly->GetZaxis()->SetTitle(getZAxisTitle(type).data());
+  mIDCOne = mCCDBManager.get<o2::tpc::IDCOne>("TPC/Calib/IDC/IDC1");
+}
 
-  TCanvas* can = new TCanvas("can", "can", 2000, 1400);
-  can->SetRightMargin(0.14f);
-  can->SetLeftMargin(0.06f);
-  can->SetTopMargin(0.04f);
+template <typename DataT>
+float o2::tpc::IDCCCDBHelper<DataT>::getIDCZeroVal(const unsigned int sector, const unsigned int region, unsigned int urow, unsigned int upad) const
+{
+  /// if the number of pads of the IDC0 corresponds to the number of pads of one TPC side, then no grouping was applied
+  return mIDCZero->getNIDC0(Sector(sector).side()) == Mapper::getNumberOfPadsPerSide() ? mIDCZero->getValueIDCZero(Sector(sector).side(), getUngroupedIndexGlobal(sector, region, urow, upad, 0)) : mIDCZero->getValueIDCZero(Sector(sector).side(), mHelperSector->getIndexUngrouped(sector, region, urow, upad, 0));
+}
 
-  TLatex lat;
-  lat.SetTextFont(63);
-  lat.SetTextSize(2);
-  poly->Draw("colz");
+template <typename DataT>
+float o2::tpc::IDCCCDBHelper<DataT>::getIDCDeltaVal(const unsigned int sector, const unsigned int region, unsigned int urow, unsigned int upad, unsigned int localintegrationInterval) const
+{
+  return mIDCDelta->getValue(Sector(sector).side(), mHelperSector->getIndexUngrouped(sector, region, urow, upad, localintegrationInterval));
+}
 
-  for (unsigned int region = 0; region < Mapper::NREGIONS; ++region) {
-    for (unsigned int irow = 0; irow < Mapper::ROWSPERREGION[region]; ++irow) {
-      for (unsigned int ipad = 0; ipad < Mapper::PADSPERROW[region][irow]; ++ipad) {
-        const auto padNum = Mapper::getGlobalPadNumber(irow, ipad, region);
-        const auto coordinate = coords[padNum];
-        const float yPos = -0.5f * static_cast<float>(coordinate.yVals[0] + coordinate.yVals[2]); // local coordinate system is mirrored
-        const float xPos = 0.5f * static_cast<float>(coordinate.xVals[0] + coordinate.xVals[2]);
-        switch (type) {
-          case IDCType::IDCZero:
-          default:
-            poly->Fill(xPos, yPos, getIDCZeroVal(sector, region, irow, ipad));
-            break;
-          case IDCType::IDCDelta:
-            poly->Fill(xPos, yPos, getIDCDeltaVal(sector, region, irow, ipad, integrationInterval));
-            break;
-          case IDCType::IDC:
-            break;
-          case IDCType::IDCOne:
-            break;
-        }
-        // draw global pad number
-        lat.SetTextAlign(12);
-        lat.DrawLatex(xPos, yPos, Form("%i", ipad));
-      }
-    }
-  }
-  if (!filename.empty()) {
-    can->SaveAs(filename.data());
-    delete poly;
-    delete can;
-  }
+template <typename DataT>
+float o2::tpc::IDCCCDBHelper<DataT>::getIDCOneVal(const o2::tpc::Side side, const unsigned int localintegrationInterval) const
+{
+  return mIDCOne->getValueIDCOne(side, localintegrationInterval);
+}
+
+template <typename DataT>
+float o2::tpc::IDCCCDBHelper<DataT>::getIDCVal(const unsigned int sector, const unsigned int region, unsigned int urow, unsigned int upad, unsigned int localintegrationInterval) const
+{
+  return (getIDCDeltaVal(sector, region, urow, upad, localintegrationInterval) + 1.f) * getIDCZeroVal(sector, region, urow, upad) * getIDCOneVal(Sector(sector).side(), localintegrationInterval);
+}
+
+template <typename DataT>
+void o2::tpc::IDCCCDBHelper<DataT>::loadGroupingParameter()
+{
+  mHelperSector = std::make_unique<IDCGroupHelperSector>(IDCGroupHelperSector{*mCCDBManager.get<o2::tpc::ParameterIDCGroupCCDB>("TPC/Calib/IDC/GROUPINGPAR")});
+}
+
+template <typename DataT>
+void o2::tpc::IDCCCDBHelper<DataT>::drawIDCZeroHelper(const bool type, const o2::tpc::Sector sector, const std::string filename) const
+{
+  std::function<float(const unsigned int, const unsigned int, const unsigned int, const unsigned int)> idcFunc = [this](const unsigned int sector, const unsigned int region, const unsigned int irow, const unsigned int pad) {
+    return this->getIDCZeroVal(sector, region, irow, pad);
+  };
+
+  IDCDrawHelper::IDCDraw drawFun;
+  drawFun.mIDCFunc = idcFunc;
+  const std::string zAxisTitle = IDCDrawHelper::getZAxisTitle(IDCType::IDCZero);
+  type ? IDCDrawHelper::drawSide(drawFun, sector.side(), zAxisTitle, filename) : IDCDrawHelper::drawSector(drawFun, 0, Mapper::NREGIONS, sector, zAxisTitle, filename);
+}
+
+template <typename DataT>
+void o2::tpc::IDCCCDBHelper<DataT>::drawIDCDeltaHelper(const bool type, const Sector sector, const unsigned int integrationInterval, const std::string filename) const
+{
+  std::function<float(const unsigned int, const unsigned int, const unsigned int, const unsigned int)> idcFunc = [this, integrationInterval](const unsigned int sector, const unsigned int region, const unsigned int irow, const unsigned int pad) {
+    return this->getIDCDeltaVal(sector, region, irow, pad, integrationInterval);
+  };
+
+  IDCDrawHelper::IDCDraw drawFun;
+  drawFun.mIDCFunc = idcFunc;
+  const std::string zAxisTitle = IDCDrawHelper::getZAxisTitle(IDCType::IDCDelta);
+  type ? IDCDrawHelper::drawSide(drawFun, sector.side(), zAxisTitle, filename) : IDCDrawHelper::drawSector(drawFun, 0, Mapper::NREGIONS, sector, zAxisTitle, filename);
+}
+
+template <typename DataT>
+void o2::tpc::IDCCCDBHelper<DataT>::drawIDCHelper(const bool type, const Sector sector, const unsigned int integrationInterval, const std::string filename) const
+{
+  std::function<float(const unsigned int, const unsigned int, const unsigned int, const unsigned int)> idcFunc = [this, integrationInterval](const unsigned int sector, const unsigned int region, const unsigned int irow, const unsigned int pad) {
+    return this->getIDCVal(sector, region, irow, pad, integrationInterval);
+  };
+
+  IDCDrawHelper::IDCDraw drawFun;
+  drawFun.mIDCFunc = idcFunc;
+  const std::string zAxisTitle = IDCDrawHelper::getZAxisTitle(IDCType::IDC);
+  type ? IDCDrawHelper::drawSide(drawFun, sector.side(), zAxisTitle, filename) : IDCDrawHelper::drawSector(drawFun, 0, Mapper::NREGIONS, sector, zAxisTitle, filename);
 }
 
 /// load IDC-Delta, 0D-IDCs, grouping parameter
@@ -153,7 +109,14 @@ void o2::tpc::IDCCCDBHelper<DataT>::loadAll()
 {
   loadIDCDelta();
   loadIDCZero();
+  loadIDCOne();
   loadGroupingParameter();
+}
+
+template <typename DataT>
+unsigned int o2::tpc::IDCCCDBHelper<DataT>::getUngroupedIndexGlobal(const unsigned int sector, const unsigned int region, unsigned int urow, unsigned int upad, unsigned int integrationInterval) const
+{
+  return IDCGroupHelperSector::getUngroupedIndexGlobal(sector, region, urow, upad, integrationInterval);
 }
 
 template class o2::tpc::IDCCCDBHelper<float>;

--- a/Detectors/TPC/calibration/src/IDCDrawHelper.cxx
+++ b/Detectors/TPC/calibration/src/IDCDrawHelper.cxx
@@ -1,0 +1,136 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "TPCCalibration/IDCDrawHelper.h"
+#include "TPCBase/Painter.h"
+#include "TPCBase/Mapper.h"
+#include "TH2Poly.h"
+#include "TCanvas.h"
+#include "TLatex.h"
+
+void o2::tpc::IDCDrawHelper::drawSector(const IDCDraw& idc, const unsigned int startRegion, const unsigned int endRegion, const unsigned int sector, const std::string zAxisTitle, const std::string filename)
+{
+  const auto coords = o2::tpc::painter::getPadCoordinatesSector();
+  TH2Poly* poly = o2::tpc::painter::makeSectorHist("hSector", "Sector;local #it{x} (cm);local #it{y} (cm); #it{IDC}");
+  poly->SetContour(255);
+  poly->SetTitle(nullptr);
+  poly->GetYaxis()->SetTickSize(0.002f);
+  poly->GetYaxis()->SetTitleOffset(0.7f);
+  poly->GetZaxis()->SetTitleOffset(1.3f);
+  poly->SetStats(0);
+  poly->GetZaxis()->SetTitle(zAxisTitle.data());
+
+  TCanvas* can = new TCanvas("can", "can", 2000, 1400);
+  can->SetRightMargin(0.14f);
+  can->SetLeftMargin(0.06f);
+  can->SetTopMargin(0.04f);
+  poly->Draw("colz");
+
+  for (unsigned int region = startRegion; region < endRegion; ++region) {
+    for (unsigned int irow = 0; irow < Mapper::ROWSPERREGION[region]; ++irow) {
+      for (unsigned int ipad = 0; ipad < Mapper::PADSPERROW[region][irow]; ++ipad) {
+        const auto padNum = Mapper::getGlobalPadNumber(irow, ipad, region);
+        const auto coordinate = coords[padNum];
+        const float yPos = -static_cast<float>(coordinate.yVals[0] + coordinate.yVals[2]) / 2; // local coordinate system is mirrored
+        const float xPos = static_cast<float>(coordinate.xVals[0] + coordinate.xVals[2]) / 2;
+        poly->Fill(xPos, yPos, idc.getIDC(sector, region, irow, ipad));
+      }
+    }
+  }
+
+  painter::drawSectorLocalPadNumberPoly(kBlack);
+  painter::drawSectorInformationPoly(kRed, kRed);
+
+  if (!filename.empty()) {
+    can->SaveAs(filename.data());
+    delete poly;
+    delete can;
+  }
+}
+
+void o2::tpc::IDCDrawHelper::drawSide(const IDCDraw& idc, const o2::tpc::Side side, const std::string zAxisTitle, const std::string filename)
+{
+  const auto coords = o2::tpc::painter::getPadCoordinatesSector();
+  TH2Poly* poly = o2::tpc::painter::makeSideHist(side);
+  poly->SetContour(255);
+  poly->SetTitle(nullptr);
+  poly->GetXaxis()->SetTitleOffset(1.2f);
+  poly->GetYaxis()->SetTitleOffset(1.3f);
+  poly->GetZaxis()->SetTitleOffset(1.4f);
+  poly->GetZaxis()->SetTitle(zAxisTitle.data());
+  poly->GetZaxis()->SetMaxDigits(3); // force exponential axis
+  poly->SetStats(0);
+
+  TCanvas* can = new TCanvas("can", "can", 650, 600);
+  can->SetTopMargin(0.04f);
+  can->SetRightMargin(0.14f);
+  can->SetLeftMargin(0.1f);
+  poly->Draw("colz");
+
+  unsigned int sectorStart = (side == Side::A) ? 0 : o2::tpc::SECTORSPERSIDE;
+  unsigned int sectorEnd = (side == Side::A) ? o2::tpc::SECTORSPERSIDE : Mapper::NSECTORS;
+  for (unsigned int sector = sectorStart; sector < sectorEnd; ++sector) {
+    for (unsigned int region = 0; region < Mapper::NREGIONS; ++region) {
+      for (unsigned int irow = 0; irow < Mapper::ROWSPERREGION[region]; ++irow) {
+        for (unsigned int ipad = 0; ipad < Mapper::PADSPERROW[region][irow]; ++ipad) {
+          const auto padNum = Mapper::getGlobalPadNumber(irow, ipad, region);
+          const float angDeg = 10.f + sector * 20;
+          auto coordinate = coords[padNum];
+          coordinate.rotate(angDeg);
+          const float yPos = static_cast<float>(coordinate.yVals[0] + coordinate.yVals[1] + coordinate.yVals[2] + coordinate.yVals[3]) / 4;
+          const float xPos = static_cast<float>(coordinate.xVals[0] + coordinate.xVals[1] + coordinate.xVals[2] + coordinate.xVals[3]) / 4;
+          const auto padTmp = (side == Side::A) ? ipad : (Mapper::PADSPERROW[region][irow] - ipad); // C-Side is mirrored
+          poly->Fill(xPos, yPos, idc.getIDC(sector, region, irow, padTmp));
+        }
+      }
+    }
+  }
+  if (!filename.empty()) {
+    can->SaveAs(filename.data());
+    delete poly;
+    delete can;
+  }
+}
+
+std::string o2::tpc::IDCDrawHelper::getZAxisTitle(const IDCType type, const IDCDeltaCompression compression)
+{
+  switch (type) {
+    case IDCType::IDC:
+    default: {
+      return "#it{IDC} (ADC)";
+      break;
+    }
+    case IDCType::IDCZero: {
+      return "#it{IDC_{0}} (ADC)";
+      break;
+    }
+    case IDCType::IDCDelta:
+      switch (compression) {
+        case IDCDeltaCompression::NO:
+        default: {
+          return "#Delta#it{IDC}";
+          break;
+        }
+        case IDCDeltaCompression::MEDIUM: {
+          return "#Delta#it{IDC}_{medium compressed}";
+          break;
+        }
+        case IDCDeltaCompression::HIGH: {
+          return "#Delta#it{IDC}_{high compressed}";
+          break;
+        }
+      }
+    case IDCType::IDCOne: {
+      return "#Delta#it{IDC}_{1}";
+      break;
+    }
+  }
+}

--- a/Detectors/TPC/calibration/src/IDCFactorization.cxx
+++ b/Detectors/TPC/calibration/src/IDCFactorization.cxx
@@ -12,11 +12,8 @@
 #include "TPCCalibration/IDCFactorization.h"
 #include "CommonUtils/TreeStreamRedirector.h"
 #include "Framework/Logger.h"
-#include "TPCBase/Painter.h"
-#include "TH2Poly.h"
+#include "TPCCalibration/IDCDrawHelper.h"
 #include "TFile.h"
-#include "TCanvas.h"
-#include "TLatex.h"
 #include <functional>
 
 o2::tpc::IDCFactorization::IDCFactorization(const std::array<unsigned char, Mapper::NREGIONS>& groupPads, const std::array<unsigned char, Mapper::NREGIONS>& groupRows, const std::array<unsigned char, Mapper::NREGIONS>& groupLastRowsThreshold, const std::array<unsigned char, Mapper::NREGIONS>& groupLastPadsThreshold, const unsigned int timeFrames, const unsigned int timeframesDeltaIDC)
@@ -24,189 +21,6 @@ o2::tpc::IDCFactorization::IDCFactorization(const std::array<unsigned char, Mapp
 {
   for (auto& idc : mIDCs) {
     idc.resize(mTimeFrames);
-  }
-}
-
-void o2::tpc::IDCFactorization::drawSector(const IDCType type, const unsigned int sector, const unsigned int integrationInterval, const std::string filename, const IDCDeltaCompression compression) const
-{
-  const auto coords = o2::tpc::painter::getPadCoordinatesSector();
-  TH2Poly* poly = o2::tpc::painter::makeSectorHist("hSector", "Sector;local #it{x} (cm);local #it{y} (cm); #it{IDC}");
-  poly->SetContour(255);
-  poly->SetTitle(nullptr);
-  poly->GetYaxis()->SetTickSize(0.002f);
-  poly->GetYaxis()->SetTitleOffset(0.7f);
-  poly->GetZaxis()->SetTitleOffset(1.3f);
-  poly->SetStats(0);
-  poly->GetZaxis()->SetTitle(getZAxisTitle(type, compression).data());
-
-  TCanvas* can = new TCanvas("can", "can", 2000, 1400);
-  can->SetRightMargin(0.14f);
-  can->SetLeftMargin(0.06f);
-  can->SetTopMargin(0.04f);
-
-  TLatex lat;
-  lat.SetTextFont(63);
-  lat.SetTextSize(2);
-  poly->Draw("colz");
-
-  unsigned int chunk = 0;
-  unsigned int localintegrationInterval = 0;
-  getLocalIntegrationInterval(0, integrationInterval, chunk, localintegrationInterval);
-  for (unsigned int region = 0; region < Mapper::NREGIONS; ++region) {
-    for (unsigned int irow = 0; irow < Mapper::ROWSPERREGION[region]; ++irow) {
-      for (unsigned int ipad = 0; ipad < Mapper::PADSPERROW[region][irow]; ++ipad) {
-        const auto padNum = Mapper::getGlobalPadNumber(irow, ipad, region);
-        const auto coordinate = coords[padNum];
-        const float yPos = -0.5f * static_cast<float>(coordinate.yVals[0] + coordinate.yVals[2]); // local coordinate system is mirrored
-        const float xPos = 0.5f * static_cast<float>(coordinate.xVals[0] + coordinate.xVals[2]);
-
-        switch (type) {
-          case IDCType::IDC:
-          default:
-            poly->Fill(xPos, yPos, getIDCValUngrouped(sector, region, irow, ipad, integrationInterval));
-            break;
-          case IDCType::IDCZero:
-            poly->Fill(xPos, yPos, getIDCZeroVal(sector, region, irow, ipad));
-            break;
-          case IDCType::IDCDelta:
-            switch (compression) {
-              case IDCDeltaCompression::NO:
-              default: {
-                poly->Fill(xPos, yPos, getIDCDeltaVal(sector, region, irow, ipad, chunk, localintegrationInterval));
-                break;
-              }
-              case IDCDeltaCompression::MEDIUM: {
-                const static auto idcDeltaMedium = getIDCDeltaMediumCompressed(chunk); // make object static to avoid multiple creations of the object in the loop
-                const float val = idcDeltaMedium.getValue(Sector(sector).side(), getIndexUngrouped(sector, region, irow, ipad, localintegrationInterval));
-                poly->Fill(xPos, yPos, val);
-                break;
-              }
-              case IDCDeltaCompression::HIGH: {
-                const static auto idcDeltaHigh = getIDCDeltaHighCompressed(chunk); // make object static to avoid multiple creations of the object in the loop
-                const float val = idcDeltaHigh.getValue(Sector(sector).side(), getIndexUngrouped(sector, region, irow, ipad, localintegrationInterval));
-                poly->Fill(xPos, yPos, val);
-                break;
-              }
-            }
-          case IDCType::IDCOne:
-            break;
-        }
-        // draw global pad number
-        lat.SetTextAlign(12);
-        lat.DrawLatex(xPos, yPos, Form("%i", ipad));
-      }
-    }
-  }
-  if (!filename.empty()) {
-    can->SaveAs(filename.data());
-    delete poly;
-    delete can;
-  }
-}
-
-void o2::tpc::IDCFactorization::drawSide(const IDCType type, const o2::tpc::Side side, const unsigned int integrationInterval, const std::string filename, const IDCDeltaCompression compression) const
-{
-  const auto coords = o2::tpc::painter::getPadCoordinatesSector();
-  TH2Poly* poly = o2::tpc::painter::makeSideHist(side);
-  poly->SetContour(255);
-  poly->SetTitle(nullptr);
-  poly->GetXaxis()->SetTitleOffset(1.2f);
-  poly->GetYaxis()->SetTitleOffset(1.3f);
-  poly->GetZaxis()->SetTitleOffset(1.2f);
-  poly->GetZaxis()->SetTitle(getZAxisTitle(type, compression).data());
-  poly->GetZaxis()->SetMaxDigits(3); // force exponential axis
-  poly->SetStats(0);
-
-  TCanvas* can = new TCanvas("can", "can", 650, 600);
-  can->SetTopMargin(0.04f);
-  can->SetRightMargin(0.14f);
-  can->SetLeftMargin(0.1f);
-  poly->Draw("colz");
-
-  unsigned int chunk = 0;
-  unsigned int localintegrationInterval = 0;
-  getLocalIntegrationInterval(0, integrationInterval, chunk, localintegrationInterval);
-  unsigned int sectorStart = (side == Side::A) ? 0 : o2::tpc::SECTORSPERSIDE;
-  unsigned int sectorEnd = (side == Side::A) ? o2::tpc::SECTORSPERSIDE : Mapper::NSECTORS;
-  for (unsigned int sector = sectorStart; sector < sectorEnd; ++sector) {
-    for (unsigned int region = 0; region < Mapper::NREGIONS; ++region) {
-      for (unsigned int irow = 0; irow < Mapper::ROWSPERREGION[region]; ++irow) {
-        for (unsigned int ipad = 0; ipad < Mapper::PADSPERROW[region][irow]; ++ipad) {
-          const auto padNum = Mapper::getGlobalPadNumber(irow, ipad, region);
-          const float angDeg = 10.f + sector * 20;
-          auto coordinate = coords[padNum];
-          coordinate.rotate(angDeg);
-          const float yPos = 0.25f * static_cast<float>(coordinate.yVals[0] + coordinate.yVals[1] + coordinate.yVals[2] + coordinate.yVals[3]);
-          const float xPos = 0.25f * static_cast<float>(coordinate.xVals[0] + coordinate.xVals[1] + coordinate.xVals[2] + coordinate.xVals[3]);
-          const auto padTmp = (side == Side::A) ? ipad : (Mapper::PADSPERROW[region][irow] - ipad); // C-Side is mirrored
-          switch (type) {
-            case IDCType::IDC:
-            default:
-              poly->Fill(xPos, yPos, getIDCValUngrouped(sector, region, irow, padTmp, integrationInterval));
-              break;
-            case IDCType::IDCZero:
-              poly->Fill(xPos, yPos, getIDCZeroVal(sector, region, irow, padTmp));
-              break;
-            case IDCType::IDCDelta:
-              switch (compression) {
-                case IDCDeltaCompression::NO:
-                default: {
-                  poly->Fill(xPos, yPos, getIDCDeltaVal(sector, region, irow, padTmp, chunk, localintegrationInterval));
-                  break;
-                }
-                case IDCDeltaCompression::MEDIUM: {
-                  const static auto idcDeltaMedium = getIDCDeltaMediumCompressed(chunk); // make object static to avoid multiple creations of the object in the loop
-                  const float val = idcDeltaMedium.getValue(Sector(sector).side(), getIndexUngrouped(sector, region, irow, padTmp, localintegrationInterval));
-                  poly->Fill(xPos, yPos, val);
-                  break;
-                }
-                case IDCDeltaCompression::HIGH: {
-                  const static auto idcDeltaHigh = getIDCDeltaHighCompressed(chunk); // make object static to avoid multiple creations of the object in the loop
-                  const float val = idcDeltaHigh.getValue(Sector(sector).side(), getIndexUngrouped(sector, region, irow, padTmp, localintegrationInterval));
-                  poly->Fill(xPos, yPos, val);
-                  break;
-                }
-              }
-            case IDCType::IDCOne:
-              break;
-          }
-        }
-      }
-    }
-  }
-  if (!filename.empty()) {
-    can->SaveAs(filename.data());
-    delete poly;
-    delete can;
-  }
-}
-
-std::string o2::tpc::IDCFactorization::getZAxisTitle(const IDCType type, const IDCDeltaCompression compression) const
-{
-  switch (type) {
-    case IDCType::IDC:
-    default:
-      return "#it{IDC}";
-      break;
-    case IDCType::IDCZero:
-      return "#it{IDC_{0}}";
-      break;
-    case IDCType::IDCDelta:
-      switch (compression) {
-        case IDCDeltaCompression::NO:
-        default:
-          return "#Delta#it{IDC}";
-          break;
-        case IDCDeltaCompression::MEDIUM:
-          return "#Delta#it{IDC}_{medium compressed}";
-          break;
-        case IDCDeltaCompression::HIGH:
-          return "#Delta#it{IDC}_{high compressed}";
-          break;
-      }
-    case IDCType::IDCOne:
-      return "#Delta#it{IDC}_{1}";
-      break;
   }
 }
 
@@ -306,11 +120,11 @@ void o2::tpc::IDCFactorization::dumpToTree(int integrationIntervals, const char*
   pcstream.Close();
 }
 
-void o2::tpc::IDCFactorization::calcIDCZero()
+void o2::tpc::IDCFactorization::calcIDCZero(const bool norm)
 {
   const unsigned int nIDCsSide = mNIDCsPerSector * o2::tpc::SECTORSPERSIDE;
-  mIDCZero.reset(Side::A);
-  mIDCZero.reset(Side::C);
+  mIDCZero.clear(Side::A);
+  mIDCZero.clear(Side::C);
   mIDCZero.resize(Side::A, nIDCsSide);
   mIDCZero.resize(Side::C, nIDCsSide);
 
@@ -322,20 +136,23 @@ void o2::tpc::IDCFactorization::calcIDCZero()
     for (unsigned int timeframe = 0; timeframe < mTimeFrames; ++timeframe) {
       for (unsigned int idcs = 0; idcs < mIDCs[cru][timeframe].size(); ++idcs) {
         const unsigned int indexGlob = (idcs % mNIDCsPerCRU[region]) + factorIndexGlob;
+        if (norm) {
+          mIDCs[cru][timeframe][idcs] *= Mapper::INVPADAREA[region];
+        }
         mIDCZero.fillValueIDCZero(mIDCs[cru][timeframe][idcs], cruTmp.side(), indexGlob % nIDCsSide);
       }
     }
   }
-  std::transform(mIDCZero.mIDCZero[Side::A].begin(), mIDCZero.mIDCZero[Side::A].end(), mIDCZero.mIDCZero[Side::A].begin(), [norm = getNIntegrationIntervals()](auto& val) { return val / norm; });
-  std::transform(mIDCZero.mIDCZero[Side::C].begin(), mIDCZero.mIDCZero[Side::C].end(), mIDCZero.mIDCZero[Side::C].begin(), [norm = getNIntegrationIntervals()](auto& val) { return val / norm; });
+  std::transform(mIDCZero.mIDCZero[Side::A].begin(), mIDCZero.mIDCZero[Side::A].end(), mIDCZero.mIDCZero[Side::A].begin(), [normVal = getNIntegrationIntervals()](auto& val) { return val / normVal; });
+  std::transform(mIDCZero.mIDCZero[Side::C].begin(), mIDCZero.mIDCZero[Side::C].end(), mIDCZero.mIDCZero[Side::C].begin(), [normVal = getNIntegrationIntervals()](auto& val) { return val / normVal; });
 }
 
 void o2::tpc::IDCFactorization::calcIDCOne()
 {
   const unsigned int nIDCsSide = mNIDCsPerSector * SECTORSPERSIDE;
   const unsigned int integrationIntervals = getNIntegrationIntervals();
-  mIDCOne.reset(Side::A);
-  mIDCOne.reset(Side::C);
+  mIDCOne.clear(Side::A);
+  mIDCOne.clear(Side::C);
   mIDCOne.resize(Side::A, integrationIntervals);
   mIDCOne.resize(Side::C, integrationIntervals);
   const unsigned int crusPerSide = Mapper::NREGIONS * SECTORSPERSIDE;
@@ -431,10 +248,10 @@ void o2::tpc::IDCFactorization::getTF(const unsigned int region, unsigned int in
   }
 }
 
-void o2::tpc::IDCFactorization::factorizeIDCs()
+void o2::tpc::IDCFactorization::factorizeIDCs(const bool norm)
 {
   LOGP(info, "Using {} threads for factorization of IDCs", sNThreads);
-  calcIDCZero();
+  calcIDCZero(norm);
   calcIDCOne();
   calcIDCDelta();
 }
@@ -506,4 +323,70 @@ void o2::tpc::IDCFactorization::reset()
       idcs.clear();
     }
   }
+}
+
+void o2::tpc::IDCFactorization::drawIDCDeltaHelper(const bool type, const Sector sector, const unsigned int integrationInterval, const IDCDeltaCompression compression, const std::string filename) const
+{
+  std::function<float(const unsigned int, const unsigned int, const unsigned int, const unsigned int)> idcFunc;
+
+  unsigned int chunk = 0;
+  unsigned int localintegrationInterval = 0;
+  getLocalIntegrationInterval(0, integrationInterval, chunk, localintegrationInterval);
+  const std::string zAxisTitle = IDCDrawHelper::getZAxisTitle(IDCType::IDCDelta, compression);
+
+  IDCDrawHelper::IDCDraw drawFun;
+  switch (compression) {
+    case IDCDeltaCompression::NO:
+    default: {
+      idcFunc = [this, chunk, localintegrationInterval](const unsigned int sector, const unsigned int region, const unsigned int irow, const unsigned int pad) {
+        return this->getIDCDeltaVal(sector, region, irow, pad, chunk, localintegrationInterval);
+      };
+      drawFun.mIDCFunc = idcFunc;
+      type ? IDCDrawHelper::drawSide(drawFun, sector.side(), zAxisTitle, filename) : IDCDrawHelper::drawSector(drawFun, 0, Mapper::NREGIONS, sector, zAxisTitle, filename);
+      break;
+    }
+    case IDCDeltaCompression::MEDIUM: {
+      const auto idcDeltaMedium = this->getIDCDeltaMediumCompressed(chunk);
+      idcFunc = [this, &idcDeltaMedium, chunk, localintegrationInterval = localintegrationInterval](const unsigned int sector, const unsigned int region, const unsigned int irow, const unsigned int pad) {
+        return idcDeltaMedium.getValue(Sector(sector).side(), this->getIndexUngrouped(sector, region, irow, pad, localintegrationInterval));
+      };
+      drawFun.mIDCFunc = idcFunc;
+      type ? IDCDrawHelper::drawSide(drawFun, sector.side(), zAxisTitle, filename) : IDCDrawHelper::drawSector(drawFun, 0, Mapper::NREGIONS, sector, zAxisTitle, filename);
+      break;
+    }
+    case IDCDeltaCompression::HIGH: {
+      const auto idcDeltaHigh = this->getIDCDeltaHighCompressed(chunk);
+      idcFunc = [this, &idcDeltaHigh, chunk, localintegrationInterval](const unsigned int sector, const unsigned int region, const unsigned int irow, const unsigned int pad) {
+        return idcDeltaHigh.getValue(Sector(sector).side(), this->getIndexUngrouped(sector, region, irow, pad, localintegrationInterval));
+      };
+      drawFun.mIDCFunc = idcFunc;
+      type ? IDCDrawHelper::drawSide(drawFun, sector.side(), zAxisTitle, filename) : IDCDrawHelper::drawSector(drawFun, 0, Mapper::NREGIONS, sector, zAxisTitle, filename);
+      break;
+    }
+  }
+}
+
+void o2::tpc::IDCFactorization::drawIDCZeroHelper(const bool type, const Sector sector, const std::string filename) const
+{
+  std::function<float(const unsigned int, const unsigned int, const unsigned int, const unsigned int)> idcFunc = [this](const unsigned int sector, const unsigned int region, const unsigned int irow, const unsigned int pad) {
+    return this->getIDCZeroVal(sector, region, irow, pad);
+  };
+
+  IDCDrawHelper::IDCDraw drawFun;
+  drawFun.mIDCFunc = idcFunc;
+  const std::string zAxisTitle = IDCDrawHelper::getZAxisTitle(IDCType::IDCZero);
+  type ? IDCDrawHelper::drawSide(drawFun, sector.side(), zAxisTitle, filename) : IDCDrawHelper::drawSector(drawFun, 0, Mapper::NREGIONS, sector, zAxisTitle, filename);
+}
+
+void o2::tpc::IDCFactorization::drawIDCHelper(const bool type, const Sector sector, const unsigned int integrationInterval, const std::string filename) const
+{
+  std::function<float(const unsigned int, const unsigned int, const unsigned int, const unsigned int)> idcFunc = [this, integrationInterval](const unsigned int sector, const unsigned int region, const unsigned int irow, const unsigned int pad) {
+    return this->getIDCValUngrouped(sector, region, irow, pad, integrationInterval);
+  };
+
+  IDCDrawHelper::IDCDraw drawFun;
+  drawFun.mIDCFunc = idcFunc;
+
+  const std::string zAxisTitleDraw = IDCDrawHelper::getZAxisTitle(IDCType::IDC);
+  type ? IDCDrawHelper::drawSide(drawFun, sector.side(), zAxisTitleDraw, filename) : IDCDrawHelper::drawSector(drawFun, 0, Mapper::NREGIONS, sector, zAxisTitleDraw, filename);
 }

--- a/Detectors/TPC/calibration/src/IDCGroup.cxx
+++ b/Detectors/TPC/calibration/src/IDCGroup.cxx
@@ -11,12 +11,9 @@
 
 #include "TPCCalibration/IDCGroup.h"
 #include "CommonUtils/TreeStreamRedirector.h"
-#include "TPCBase/Painter.h"
+#include "TPCCalibration/IDCDrawHelper.h"
 #include "TPCBase/Mapper.h"
-#include "TH2Poly.h"
 #include "TFile.h"
-#include "TCanvas.h"
-#include "TLatex.h"
 #include <numeric>
 
 void o2::tpc::IDCGroup::dumpToTree(const char* outname) const
@@ -40,41 +37,14 @@ void o2::tpc::IDCGroup::dumpToTree(const char* outname) const
 
 void o2::tpc::IDCGroup::draw(const unsigned int integrationInterval, const std::string filename) const
 {
-  const auto coords = o2::tpc::painter::getPadCoordinatesSector();
-  TH2Poly* poly = o2::tpc::painter::makeSectorHist("hSector", "Sector;local #it{x} (cm);local #it{y} (cm); #it{IDC}");
-  poly->SetContour(255);
-  poly->SetTitle(nullptr);
-  poly->GetYaxis()->SetTickSize(0.002f);
-  poly->GetYaxis()->SetTitleOffset(0.7f);
-  poly->GetZaxis()->SetTitleOffset(1.3f);
-  poly->SetStats(0);
+  std::function<float(const unsigned int, const unsigned int, const unsigned int, const unsigned int)> idcFunc = [this, integrationInterval](const unsigned int, const unsigned int region, const unsigned int irow, const unsigned int pad) {
+    return (*this)(getGroupedRow(irow), getGroupedPad(pad, irow), integrationInterval);
+  };
 
-  TCanvas* can = new TCanvas("can", "can", 2000, 1400);
-  can->SetRightMargin(0.14f);
-  can->SetLeftMargin(0.06f);
-  can->SetTopMargin(0.04f);
-
-  TLatex lat;
-  lat.SetTextFont(63);
-  lat.SetTextSize(2);
-
-  poly->Draw("colz");
-  for (unsigned int irow = 0; irow < Mapper::ROWSPERREGION[mRegion]; ++irow) {
-    for (unsigned int ipad = 0; ipad < Mapper::PADSPERROW[mRegion][irow]; ++ipad) {
-      const auto padNum = getGlobalPadNumber(irow, ipad);
-      const auto coordinate = coords[padNum];
-      const float yPos = -0.5f * (coordinate.yVals[0] + coordinate.yVals[2]); // local coordinate system is mirrored
-      const float xPos = 0.5f * (coordinate.xVals[0] + coordinate.xVals[2]);
-      poly->Fill(xPos, yPos, (*this)(getGroupedRow(irow), getGroupedPad(ipad, irow), integrationInterval));
-      lat.SetTextAlign(12);
-      lat.DrawLatex(xPos, yPos, Form("%i", ipad));
-    }
-  }
-  if (!filename.empty()) {
-    can->SaveAs(filename.data());
-    delete poly;
-    delete can;
-  }
+  IDCDrawHelper::IDCDraw drawFun;
+  drawFun.mIDCFunc = idcFunc;
+  const std::string zAxisTitle = IDCDrawHelper::getZAxisTitle(IDCType::IDC);
+  IDCDrawHelper::drawSector(drawFun, mRegion, mRegion + 1, 0, zAxisTitle, filename);
 }
 
 void o2::tpc::IDCGroup::dumpToFile(const char* outFileName, const char* outName) const
@@ -91,19 +61,29 @@ float o2::tpc::IDCGroup::getValUngroupedGlobal(unsigned int ugrow, unsigned int 
 
 std::vector<float> o2::tpc::IDCGroup::get1DIDCs() const
 {
+  return get1DIDCs(mIDCsGrouped, getNIntegrationIntervals(), getNIDCsPerIntegrationInterval(), mRegion, true);
+}
+
+std::vector<float> o2::tpc::IDCGroup::get1DIDCsUngrouped(const std::vector<float> idc, const unsigned int region)
+{
+  const auto nIDCsPerIntegrationInterval = Mapper::PADSPERREGION[region];
+  return get1DIDCs(idc, idc.size() / nIDCsPerIntegrationInterval, nIDCsPerIntegrationInterval, region, false);
+}
+
+std::vector<float> o2::tpc::IDCGroup::get1DIDCs(const std::vector<float> idc, const unsigned int nIntervals, const unsigned int nIDCsPerIntegrationInterval, const unsigned int region, const bool normalize)
+{
   // integrate IDCs for each interval
-  std::vector<float> idc;
-  const unsigned int nIntervals = getNIntegrationIntervals();
-  idc.reserve(nIntervals);
+  std::vector<float> idcOne;
+  idcOne.reserve(nIntervals);
   for (unsigned int i = 0; i < nIntervals; ++i) {
     // set integration range for one integration interval
-    const auto start = mIDCsGrouped.begin() + i * getNIDCsPerIntegrationInterval();
-    const auto end = start + getNIDCsPerIntegrationInterval();
-    idc.emplace_back(std::accumulate(start, end, decltype(mIDCsGrouped)::value_type(0)));
+    const auto start = idc.begin() + i * nIDCsPerIntegrationInterval;
+    const auto end = start + nIDCsPerIntegrationInterval;
+    idcOne.emplace_back(std::accumulate(start, end, decltype(idc)::value_type(0)));
   }
   // normalize 1D-IDCs to absolute space charge
-  const float norm = Mapper::REGIONAREA[mRegion] / getNIDCsPerIntegrationInterval();
-  std::transform(idc.begin(), idc.end(), idc.begin(), [norm](auto& val) { return val * norm; });
+  const float norm = normalize ? Mapper::REGIONAREA[region] / nIDCsPerIntegrationInterval : 1.f / nIDCsPerIntegrationInterval;
+  std::transform(idcOne.begin(), idcOne.end(), idcOne.begin(), [norm](auto& val) { return val * norm; });
 
-  return idc;
+  return idcOne;
 }

--- a/Detectors/TPC/calibration/src/IDCGroupHelperRegion.cxx
+++ b/Detectors/TPC/calibration/src/IDCGroupHelperRegion.cxx
@@ -87,3 +87,8 @@ void o2::tpc::IDCGroupHelperRegion::dumpToFile(const char* outFileName, const ch
   fOut.WriteObject(this, outName);
   fOut.Close();
 }
+
+unsigned int o2::tpc::IDCGroupHelperRegion::getIndexUngroupedGlob(const unsigned int ugrow, const unsigned int upad, unsigned int integrationInterval) const
+{
+  return getIndexUngrouped(ugrow - o2::tpc::Mapper::ROWOFFSET[mRegion], upad, integrationInterval);
+}

--- a/Detectors/TPC/calibration/src/IDCGroupHelperSector.cxx
+++ b/Detectors/TPC/calibration/src/IDCGroupHelperSector.cxx
@@ -1,0 +1,62 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "TPCCalibration/IDCGroupHelperSector.h"
+#include "TPCCalibration/IDCGroupHelperRegion.h"
+#include <numeric>
+
+unsigned int o2::tpc::IDCGroupHelperSector::getGroupedPad(const unsigned int region, unsigned int ulrow, unsigned int upad) const
+{
+  return IDCGroupHelperRegion::getGroupedPad(upad, ulrow, region, mGroupingPar.GroupPads[region], mGroupingPar.GroupRows[region], mRows[region], mPadsPerRow[region]);
+}
+
+unsigned int o2::tpc::IDCGroupHelperSector::getGroupedRow(const unsigned int region, unsigned int ulrow) const
+{
+  return IDCGroupHelperRegion::getGroupedRow(ulrow, mGroupingPar.GroupRows[region], mRows[region]);
+}
+
+unsigned int o2::tpc::IDCGroupHelperSector::getLastRow(const unsigned int region) const
+{
+  const unsigned int nTotRows = Mapper::ROWSPERREGION[region];
+  const unsigned int rowsRemainder = nTotRows % mGroupingPar.GroupRows[region];
+  unsigned int lastRow = nTotRows - rowsRemainder;
+  if (rowsRemainder <= mGroupingPar.GroupLastRowsThreshold[region]) {
+    lastRow -= mGroupingPar.GroupRows[region];
+  }
+  return lastRow;
+}
+
+unsigned int o2::tpc::IDCGroupHelperSector::getLastPad(const unsigned int region, const unsigned int ulrow) const
+{
+  const unsigned int nPads = Mapper::PADSPERROW[region][ulrow] / 2;
+  const unsigned int padsRemainder = nPads % mGroupingPar.GroupPads[region];
+  int unsigned lastPad = (padsRemainder == 0) ? nPads - mGroupingPar.GroupPads[region] : nPads - padsRemainder;
+  if (padsRemainder && padsRemainder <= mGroupingPar.GroupLastPadsThreshold[region]) {
+    lastPad -= mGroupingPar.GroupPads[region];
+  }
+  return lastPad;
+}
+
+void o2::tpc::IDCGroupHelperSector::initIDCGroupHelperSector()
+{
+  for (unsigned int reg = 0; reg < Mapper::NREGIONS; ++reg) {
+    const IDCGroupHelperRegion groupTmp(mGroupingPar.GroupPads[reg], mGroupingPar.GroupRows[reg], mGroupingPar.GroupLastRowsThreshold[reg], mGroupingPar.GroupLastPadsThreshold[reg], reg);
+    mNIDCsPerCRU[reg] = groupTmp.getNIDCsPerIntegrationInterval();
+    mRows[reg] = groupTmp.getNRows();
+    mPadsPerRow[reg] = groupTmp.getPadsPerRow();
+    mOffsRow[reg] = groupTmp.getRowOffset();
+    if (reg > 0) {
+      const unsigned int lastInd = reg - 1;
+      mRegionOffs[reg] = mRegionOffs[lastInd] + mNIDCsPerCRU[lastInd];
+    }
+  }
+  mNIDCsPerSector = static_cast<unsigned int>(std::accumulate(mNIDCsPerCRU.begin(), mNIDCsPerCRU.end(), decltype(mNIDCsPerCRU)::value_type(0)));
+}

--- a/Detectors/TPC/calibration/src/RobustAverage.cxx
+++ b/Detectors/TPC/calibration/src/RobustAverage.cxx
@@ -57,3 +57,20 @@ float o2::tpc::RobustAverage::getMean(std::vector<float>::const_iterator begin, 
 {
   return std::accumulate(begin, end, decltype(mValues)::value_type(0)) / std::distance(begin, end);
 }
+
+float o2::tpc::RobustAverage::getWeightedMean(std::vector<float>::const_iterator beginValues, std::vector<float>::const_iterator endValues, std::vector<float>::const_iterator beginWeight, std::vector<float>::const_iterator endWeight) const
+{
+  return std::inner_product(beginValues, endValues, beginWeight, decltype(mValues)::value_type(0)) / std::accumulate(beginWeight, endWeight, decltype(mWeights)::value_type(0));
+}
+
+void o2::tpc::RobustAverage::clear()
+{
+  mValues.clear();
+  mWeights.clear();
+}
+
+void o2::tpc::RobustAverage::addValue(const float value, const float weight)
+{
+  mValues.emplace_back(value);
+  mWeights.emplace_back(weight);
+}

--- a/Detectors/TPC/calibration/src/TPCCalibrationLinkDef.h
+++ b/Detectors/TPC/calibration/src/TPCCalibrationLinkDef.h
@@ -40,7 +40,10 @@
 #pragma link C++ class o2::tpc::IDCGroupHelperSector +;
 #pragma link C++ struct o2::tpc::ParameterIDCGroup;
 #pragma link C++ struct o2::tpc::ParameterIDCCompression;
-#pragma link C++ class o2::tpc::IDCAverageGroup +;
+#pragma link C++ class o2::tpc::IDCAverageGroup<o2::tpc::IDCAverageGroupCRU> + ;
+#pragma link C++ class o2::tpc::IDCAverageGroup<o2::tpc::IDCAverageGroupTPC> + ;
+#pragma link C++ class o2::tpc::IDCAverageGroupBase<o2::tpc::IDCAverageGroupCRU> + ;
+#pragma link C++ class o2::tpc::IDCAverageGroupBase<o2::tpc::IDCAverageGroupTPC> + ;
 #pragma link C++ class o2::tpc::IDCFactorization +;
 #pragma link C++ struct o2::tpc::IDCDelta<float> +;
 #pragma link C++ struct o2::tpc::IDCDelta<short> +;
@@ -79,5 +82,6 @@
 #pragma link C++ class std::vector < std::vector < o2::tpc::TrackDump::ClusterGlobal>> + ;
 #pragma link C++ class o2::tpc::TrackDump::TrackInfo + ;
 #pragma link C++ class std::vector < o2::tpc::TrackDump::TrackInfo> + ;
+#pragma link C++ class o2::tpc::CalDet<o2::tpc::PadFlags> +;
 
 #endif

--- a/Detectors/TPC/spacecharge/macro/createSCHistosFromHits.C
+++ b/Detectors/TPC/spacecharge/macro/createSCHistosFromHits.C
@@ -832,7 +832,7 @@ float get1DIDCs(const CalPad& calPad, const o2::tpc::Side side)
       const int npads = mapper.getNumberOfPadsInRowROC(roc, irow);
       for (int ipad = 0; ipad < npads; ++ipad) {
         const auto idc = calPad.getValue(roc, irow, ipad);
-        mean += idc * o2::tpc::Mapper::PADAREA[region]; //PADAREA[NREGIONS] = inverse pad area
+        mean += idc * o2::tpc::Mapper::INVPADAREA[region]; //PADAREA[NREGIONS] = inverse pad area
         ++ww;
       }
     }

--- a/Detectors/TPC/workflow/CMakeLists.txt
+++ b/Detectors/TPC/workflow/CMakeLists.txt
@@ -157,15 +157,6 @@ o2_add_executable(idc-test-ft
                 SOURCES test/test_ft_EPN_Aggregator.cxx
                 PUBLIC_LINK_LIBRARIES O2::TPCWorkflow)
 
-o2_add_test(idc-test-ft-epn-aggregator
-        COMPONENT_NAME tpc
-        LABELS tpc idc-test-ft
-        SOURCES test/test_ft_EPN_Aggregator.cxx
-        PUBLIC_LINK_LIBRARIES O2::TPCWorkflow
-        TIMEOUT 30
-        NO_BOOST_TEST
-        COMMAND_LINE_ARGS --run --shm-segment-size 20000000)
-
 o2_add_executable(miptrack-filter
                   COMPONENT_NAME tpc
                   SOURCES src/tpc-miptrack-filter.cxx

--- a/Detectors/TPC/workflow/CMakeLists.txt
+++ b/Detectors/TPC/workflow/CMakeLists.txt
@@ -97,9 +97,9 @@ o2_add_executable(idc-integrate
                   SOURCES src/tpc-integrate-idc.cxx
                   PUBLIC_LINK_LIBRARIES O2::TPCWorkflow)
 
-o2_add_executable(idc-averagegroup
+o2_add_executable(idc-flp
                   COMPONENT_NAME tpc
-                  SOURCES src/tpc-averagegroup-idc.cxx
+                  SOURCES src/tpc-flp-idc.cxx
                   PUBLIC_LINK_LIBRARIES O2::TPCWorkflow)
 
 o2_add_executable(idc-distribute
@@ -156,6 +156,15 @@ o2_add_executable(idc-test-ft
                 COMPONENT_NAME tpc
                 SOURCES test/test_ft_EPN_Aggregator.cxx
                 PUBLIC_LINK_LIBRARIES O2::TPCWorkflow)
+
+o2_add_test(idc-test-ft-epn-aggregator
+        COMPONENT_NAME tpc
+        LABELS tpc idc-test-ft
+        SOURCES test/test_ft_EPN_Aggregator.cxx
+        PUBLIC_LINK_LIBRARIES O2::TPCWorkflow
+        TIMEOUT 30
+        NO_BOOST_TEST
+        COMMAND_LINE_ARGS --run --shm-segment-size 20000000)
 
 o2_add_executable(miptrack-filter
                   COMPONENT_NAME tpc

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCFactorizeIDCSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCFactorizeIDCSpec.h
@@ -27,6 +27,7 @@
 #include "Framework/DeviceSpec.h"
 #include "Headers/DataHeader.h"
 #include "TPCCalibration/IDCFactorization.h"
+#include "TPCCalibration/IDCAverageGroup.h"
 #include "CCDB/CcdbApi.h"
 #include "Framework/ConfigParamRegistry.h"
 #include "TPCCalibration/IDCGroupingParameter.h"
@@ -40,13 +41,41 @@ using namespace o2::tpc;
 namespace o2::tpc
 {
 
+template <class Type>
+struct TPCFactorizeIDCStruct;
+
+/// dummy class for template specialization
+class TPCFactorizeIDCSpecGroup;
+class TPCFactorizeIDCSpecNoGroup;
+
+template <>
+struct TPCFactorizeIDCStruct<TPCFactorizeIDCSpecNoGroup> {
+};
+
+template <>
+struct TPCFactorizeIDCStruct<TPCFactorizeIDCSpecGroup> {
+
+  TPCFactorizeIDCStruct(const std::array<unsigned char, Mapper::NREGIONS>& groupPads, const std::array<unsigned char, Mapper::NREGIONS>& groupRows, const std::array<unsigned char, Mapper::NREGIONS>& groupLastRowsThreshold, const std::array<unsigned char, Mapper::NREGIONS>& groupLastPadsThreshold, const float sigma = 3, const unsigned char overlapRows = 0, const unsigned char overlapPads = 0)
+    : mIDCs(groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold, sigma){};
+  IDCAverageGroup<IDCAverageGroupTPC> mIDCs; ///< object for averaging and grouping of the IDCs
+  inline static int sNThreads{1};            ///< number of threads which are used during the calculations
+};
+
+template <class Type>
 class TPCFactorizeIDCSpec : public o2::framework::Task
 {
  public:
+  template <bool IsEnabled = true, typename std::enable_if<(IsEnabled && (std::is_same<Type, TPCFactorizeIDCSpecNoGroup>::value)), int>::type = 0>
   TPCFactorizeIDCSpec(const std::vector<uint32_t>& crus, const unsigned int timeframes, const unsigned int timeframesDeltaIDC, std::array<unsigned char, Mapper::NREGIONS> groupPads,
                       std::array<unsigned char, Mapper::NREGIONS> groupRows, std::array<unsigned char, Mapper::NREGIONS> groupLastRowsThreshold,
                       std::array<unsigned char, Mapper::NREGIONS> groupLastPadsThreshold, const IDCDeltaCompression compression, const bool debug = false, const bool senddebug = false)
     : mCRUs{crus}, mIDCFactorization{groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold, timeframes, timeframesDeltaIDC}, mCompressionDeltaIDC{compression}, mDebug{debug}, mSendOutDebug{senddebug} {};
+
+  template <bool IsEnabled = true, typename std::enable_if<(IsEnabled && (std::is_same<Type, TPCFactorizeIDCSpecGroup>::value)), int>::type = 0>
+  TPCFactorizeIDCSpec(const std::vector<uint32_t>& crus, const unsigned int timeframes, const unsigned int timeframesDeltaIDC, std::array<unsigned char, Mapper::NREGIONS> groupPads,
+                      std::array<unsigned char, Mapper::NREGIONS> groupRows, std::array<unsigned char, Mapper::NREGIONS> groupLastRowsThreshold,
+                      std::array<unsigned char, Mapper::NREGIONS> groupLastPadsThreshold, const IDCDeltaCompression compression, const bool debug = false, const bool senddebug = false)
+    : mCRUs{crus}, mIDCFactorization{std::array<unsigned char, Mapper::NREGIONS>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, std::array<unsigned char, Mapper::NREGIONS>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, std::array<unsigned char, Mapper::NREGIONS>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, std::array<unsigned char, Mapper::NREGIONS>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, timeframes, timeframesDeltaIDC}, mIDCStruct{TPCFactorizeIDCStruct<TPCFactorizeIDCSpecGroup>(groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold)}, mCompressionDeltaIDC{compression}, mDebug{debug}, mSendOutDebug{senddebug} {};
 
   void init(o2::framework::InitContext& ic) final
   {
@@ -58,7 +87,11 @@ class TPCFactorizeIDCSpec : public o2::framework::Task
     // write struct containing grouping parameters to access grouped IDCs to CCDB
     if (mWriteToDB && mUpdateGroupingPar) {
       // validity for grouping parameters is from first TF to some really large TF (until it is updated) TODO do somewhere else?!
-      mDBapi.storeAsTFileAny<o2::tpc::ParameterIDCGroupCCDB>(&mIDCFactorization.getGroupingParameter(), "TPC/Calib/IDC/GROUPINGPAR", mMetadata, getFirstTF(), std::numeric_limits<uint32_t>::max());
+      if constexpr (std::is_same_v<Type, TPCFactorizeIDCSpecGroup>) {
+        mDBapi.storeAsTFileAny<o2::tpc::ParameterIDCGroupCCDB>(&mIDCStruct.mIDCs.getIDCGroupHelperSector().getGroupingParameter(), "TPC/Calib/IDC/GROUPINGPAR", mMetadata, getFirstTF(), std::numeric_limits<uint32_t>::max());
+      } else {
+        mDBapi.storeAsTFileAny<o2::tpc::ParameterIDCGroupCCDB>(&mIDCFactorization.getGroupingParameter(), "TPC/Calib/IDC/GROUPINGPAR", mMetadata, getFirstTF(), std::numeric_limits<uint32_t>::max());
+      }
       mUpdateGroupingPar = false; // write grouping parameters only once
     }
   }
@@ -83,9 +116,13 @@ class TPCFactorizeIDCSpec : public o2::framework::Task
     }
 
     if (mProcessedTFs == mIDCFactorization.getNTimeframes()) {
-      mTFRange[1] = getCurrentTF(pc);    // set the TF for last aggregated TF
-      mProcessedTFs = 0;                 // reset processed TFs for next aggregation interval
-      mIDCFactorization.factorizeIDCs(); // calculate DeltaIDC, 0D-IDC, 1D-IDC
+      mTFRange[1] = getCurrentTF(pc) + 1; // set the TF for last aggregated TF
+      mProcessedTFs = 0;                  // reset processed TFs for next aggregation interval
+      if constexpr (std::is_same_v<Type, TPCFactorizeIDCSpecGroup>) {
+        mIDCFactorization.factorizeIDCs(true); // calculate DeltaIDC, 0D-IDC, 1D-IDC
+      } else {
+        mIDCFactorization.factorizeIDCs(false); // calculate DeltaIDC, 0D-IDC, 1D-IDC
+      }
 
       if (mDebug) {
         LOGP(info, "dumping aggregated and factorized IDCs and FT to file");
@@ -109,7 +146,8 @@ class TPCFactorizeIDCSpec : public o2::framework::Task
  private:
   const std::vector<uint32_t> mCRUs{};              ///< CRUs to process in this instance
   int mProcessedTFs{0};                             ///< number of processed time frames to keep track of when the writing to CCDB will be done
-  IDCFactorization mIDCFactorization{};             ///< object aggregating the IDCs and performing the factorization of the IDCs
+  IDCFactorization mIDCFactorization;               ///< object aggregating the IDCs and performing the factorization of the IDCs
+  TPCFactorizeIDCStruct<Type> mIDCStruct{};         ///< object for averaging and grouping of the IDCs
   const IDCDeltaCompression mCompressionDeltaIDC{}; ///< compression type for IDC Delta
   const bool mDebug{false};                         ///< dump IDCs to tree for debugging
   const bool mSendOutDebug{false};                  ///< flag if the output will be send (for debugging)
@@ -133,15 +171,15 @@ class TPCFactorizeIDCSpec : public o2::framework::Task
   unsigned int getFirstTFDeltaIDC(const unsigned int iChunk) const { return getFirstTF() + iChunk * mIDCFactorization.getTimeFramesDeltaIDC(); }
 
   /// \return returns last TF for validity range when storing to IDCDelta CCDB
-  unsigned int getLastTFDeltaIDC(const unsigned int iChunk) const { return (iChunk == mIDCFactorization.getNChunks() - 1) ? (mIDCFactorization.getNTimeframes() - 1 + getFirstTF()) : (getFirstTFDeltaIDC(iChunk) + mIDCFactorization.getTimeFramesDeltaIDC() - 1); }
+  unsigned int getLastTFDeltaIDC(const unsigned int iChunk) const { return (iChunk == mIDCFactorization.getNChunks() - 1) ? (mIDCFactorization.getNTimeframes() + getFirstTF()) : (getFirstTFDeltaIDC(iChunk) + mIDCFactorization.getTimeFramesDeltaIDC()); }
 
   /// send output to next device for debugging
   void sendOutputDebug(DataAllocator& output)
   {
-    output.snapshot(Output{gDataOriginTPC, TPCFactorizeIDCSpec::getDataDescriptionIDC0()}, mIDCFactorization.getIDCZero());
-    output.snapshot(Output{gDataOriginTPC, TPCFactorizeIDCSpec::getDataDescriptionIDC1()}, mIDCFactorization.getIDCOne());
+    output.snapshot(Output{gDataOriginTPC, getDataDescriptionIDC0()}, mIDCFactorization.getIDCZero());
+    output.snapshot(Output{gDataOriginTPC, getDataDescriptionIDC1()}, mIDCFactorization.getIDCOne());
     for (unsigned int iChunk = 0; iChunk < mIDCFactorization.getNChunks(); ++iChunk) {
-      output.snapshot(Output{gDataOriginTPC, TPCFactorizeIDCSpec::getDataDescriptionIDCDelta(), o2::header::DataHeader::SubSpecificationType{iChunk}, Lifetime::Timeframe}, mIDCFactorization.getIDCDeltaUncompressed(iChunk));
+      output.snapshot(Output{gDataOriginTPC, getDataDescriptionIDCDelta(), o2::header::DataHeader::SubSpecificationType{iChunk}, Lifetime::Timeframe}, mIDCFactorization.getIDCDeltaUncompressed(iChunk));
     }
   }
 
@@ -158,20 +196,48 @@ class TPCFactorizeIDCSpec : public o2::framework::Task
       mDBapi.storeAsTFileAny<o2::tpc::IDCOne>(&mIDCFactorization.getIDCOne(), "TPC/Calib/IDC/IDC1", mMetadata, timeStampStart, timeStampEnd);
 
       for (unsigned int iChunk = 0; iChunk < mIDCFactorization.getNChunks(); ++iChunk) {
+        if constexpr (std::is_same_v<Type, TPCFactorizeIDCSpecGroup>) {
+          mIDCStruct.mIDCs.setIDCs(std::move(mIDCFactorization).getIDCDeltaUncompressed(iChunk));
+          LOGP(info, "averaging and grouping DeltaIDCs for TFs {} - {} for CRUs {} to {} using {} threads", getFirstTFDeltaIDC(iChunk), getLastTFDeltaIDC(iChunk), mCRUs.front(), mCRUs.back(), mIDCStruct.mIDCs.getNThreads());
+          mIDCStruct.mIDCs.processIDCs();
+          if (mDebug) {
+            mIDCStruct.mIDCs.dumpToFile(fmt::format("IDCDeltaAveraged_chunk{:02}_{:02}.root", iChunk, getFirstTFDeltaIDC(iChunk)).data());
+          }
+        }
+
         switch (mCompressionDeltaIDC) {
           case IDCDeltaCompression::MEDIUM:
           default: {
-            auto idcDeltaMediumCompressed = mIDCFactorization.getIDCDeltaMediumCompressed(iChunk);
-            mDBapi.storeAsTFileAny<o2::tpc::IDCDelta<short>>(&idcDeltaMediumCompressed, "TPC/Calib/IDC/IDCDELTA", mMetadata, getFirstTFDeltaIDC(iChunk), getLastTFDeltaIDC(iChunk));
+            using compType = short;
+            // perform grouping of IDC Delta if necessary
+            if constexpr (std::is_same_v<Type, TPCFactorizeIDCSpecGroup>) {
+              auto idcDeltaMediumCompressed = IDCDeltaCompressionHelper<compType>::getCompressedIDCs(mIDCStruct.mIDCs.getIDCGroupData());
+              mDBapi.storeAsTFileAny<o2::tpc::IDCDelta<compType>>(&idcDeltaMediumCompressed, "TPC/Calib/IDC/IDCDELTA", mMetadata, getFirstTFDeltaIDC(iChunk), getLastTFDeltaIDC(iChunk));
+            } else {
+              auto idcDeltaMediumCompressed = mIDCFactorization.getIDCDeltaMediumCompressed(iChunk);
+              mDBapi.storeAsTFileAny<o2::tpc::IDCDelta<compType>>(&idcDeltaMediumCompressed, "TPC/Calib/IDC/IDCDELTA", mMetadata, getFirstTFDeltaIDC(iChunk), getLastTFDeltaIDC(iChunk));
+            }
+
             break;
           }
           case IDCDeltaCompression::HIGH: {
-            auto idcDeltaHighCompressed = mIDCFactorization.getIDCDeltaHighCompressed(iChunk);
-            mDBapi.storeAsTFileAny<o2::tpc::IDCDelta<char>>(&idcDeltaHighCompressed, "TPC/Calib/IDC/IDCDELTA", mMetadata, getFirstTFDeltaIDC(iChunk), getLastTFDeltaIDC(iChunk));
+            using compType = char;
+            // perform grouping of IDC Delta if necessary
+            if constexpr (std::is_same_v<Type, TPCFactorizeIDCSpecGroup>) {
+              auto idcDeltaMediumCompressed = IDCDeltaCompressionHelper<compType>::getCompressedIDCs(mIDCStruct.mIDCs.getIDCGroupData());
+              mDBapi.storeAsTFileAny<o2::tpc::IDCDelta<compType>>(&idcDeltaMediumCompressed, "TPC/Calib/IDC/IDCDELTA", mMetadata, getFirstTFDeltaIDC(iChunk), getLastTFDeltaIDC(iChunk));
+            } else {
+              auto idcDeltaHighCompressed = mIDCFactorization.getIDCDeltaHighCompressed(iChunk);
+              mDBapi.storeAsTFileAny<o2::tpc::IDCDelta<compType>>(&idcDeltaHighCompressed, "TPC/Calib/IDC/IDCDELTA", mMetadata, getFirstTFDeltaIDC(iChunk), getLastTFDeltaIDC(iChunk));
+            }
             break;
           }
           case IDCDeltaCompression::NO:
-            mDBapi.storeAsTFileAny<o2::tpc::IDCDelta<float>>(&mIDCFactorization.getIDCDeltaUncompressed(iChunk), "TPC/Calib/IDC/IDCDELTA", mMetadata, getFirstTFDeltaIDC(iChunk), getLastTFDeltaIDC(iChunk));
+            if constexpr (std::is_same_v<Type, TPCFactorizeIDCSpecGroup>) {
+              mDBapi.storeAsTFileAny<o2::tpc::IDCDelta<float>>(&mIDCStruct.mIDCs.getIDCGroupData(), "TPC/Calib/IDC/IDCDELTA", mMetadata, getFirstTFDeltaIDC(iChunk), getLastTFDeltaIDC(iChunk));
+            } else {
+              mDBapi.storeAsTFileAny<o2::tpc::IDCDelta<float>>(&mIDCFactorization.getIDCDeltaUncompressed(iChunk), "TPC/Calib/IDC/IDCDELTA", mMetadata, getFirstTFDeltaIDC(iChunk), getLastTFDeltaIDC(iChunk));
+            }
             break;
         }
       }
@@ -181,13 +247,14 @@ class TPCFactorizeIDCSpec : public o2::framework::Task
   }
 };
 
+template <class Type>
 DataProcessorSpec getTPCFactorizeIDCSpec(const int lane, const std::vector<uint32_t>& crus, const unsigned int timeframes, const unsigned int timeframesDeltaIDC, const IDCDeltaCompression compression, const bool debug = false, const bool senddebug = false)
 {
   std::vector<OutputSpec> outputSpecs;
   if (senddebug) {
-    outputSpecs.emplace_back(ConcreteDataTypeMatcher{gDataOriginTPC, TPCFactorizeIDCSpec::getDataDescriptionIDC0()});
-    outputSpecs.emplace_back(ConcreteDataTypeMatcher{gDataOriginTPC, TPCFactorizeIDCSpec::getDataDescriptionIDC1()});
-    outputSpecs.emplace_back(ConcreteDataTypeMatcher{gDataOriginTPC, TPCFactorizeIDCSpec::getDataDescriptionIDCDelta()});
+    outputSpecs.emplace_back(ConcreteDataTypeMatcher{gDataOriginTPC, TPCFactorizeIDCSpec<Type>::getDataDescriptionIDC0()});
+    outputSpecs.emplace_back(ConcreteDataTypeMatcher{gDataOriginTPC, TPCFactorizeIDCSpec<Type>::getDataDescriptionIDC1()});
+    outputSpecs.emplace_back(ConcreteDataTypeMatcher{gDataOriginTPC, TPCFactorizeIDCSpec<Type>::getDataDescriptionIDCDelta()});
   }
 
   std::vector<InputSpec> inputSpecs; //{InputSpec{"idcagg", ConcreteDataTypeMatcher{gDataOriginTPC, TPCDistributeIDCSpec::getDataDescriptionIDC()}, Lifetime::Timeframe}};
@@ -210,10 +277,9 @@ DataProcessorSpec getTPCFactorizeIDCSpec(const int lane, const std::vector<uint3
     fmt::format("tpc-factorize-idc-{:02}", lane).data(),
     inputSpecs,
     outputSpecs,
-    AlgorithmSpec{adaptFromTask<TPCFactorizeIDCSpec>(crus, timeframes, timeframesDeltaIDC, groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold, compression, debug, senddebug)},
+    AlgorithmSpec{adaptFromTask<TPCFactorizeIDCSpec<Type>>(crus, timeframes, timeframesDeltaIDC, groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold, compression, debug, senddebug)},
     Options{{"ccdb-uri", VariantType::String, "http://ccdb-test.cern.ch:8080", {"URI for the CCDB access."}},
             {"update-not-grouping-parameter", VariantType::Bool, false, {"Do NOT Update/Writing grouping parameters to CCDB."}}}}; // end DataProcessorSpec
-
   spec.rank = lane;
   return spec;
 }

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCFourierTransformEPNSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCFourierTransformEPNSpec.h
@@ -26,7 +26,7 @@
 #include "Framework/InputRecordWalker.h"
 #include "Headers/DataHeader.h"
 #include "TPCCalibration/IDCFourierTransform.h"
-#include "TPCWorkflow/TPCAverageGroupIDCSpec.h"
+#include "TPCWorkflow/TPCFLPIDCSpec.h"
 #include "TPCBase/CRU.h"
 
 using namespace o2::framework;
@@ -80,12 +80,12 @@ class TPCFourierTransformEPNSpec : public o2::framework::Task
   static constexpr header::DataDescription getDataDescription() { return header::DataDescription{"FOURIERCOEFF"}; }
 
  private:
-  const std::vector<uint32_t> mCRUs{};                                                                                                                                                     ///< CRUs to process in this instance
-  IDCFourierTransform<IDCFourierTransformBaseEPN> mIDCFourierTransform{};                                                                                                                  ///< object for performing the fourier transform of 1D-IDCs
-  OneDIDCAggregator mOneDIDCAggregator{};                                                                                                                                                  ///< helper class for aggregation of 1D-IDCs
-  const bool mDebug{false};                                                                                                                                                                ///< dump IDCs to tree for debugging
-  int mReceivedCRUs = 0;                                                                                                                                                                   ///< counter to keep track of the number of received data from CRUs
-  const std::vector<InputSpec> mFilter = {{"1didcepn", ConcreteDataTypeMatcher{o2::header::gDataOriginTPC, TPCAverageGroupIDCDevice::getDataDescription1DIDCEPN()}, Lifetime::Timeframe}}; ///< filter for looping over input data
+  const std::vector<uint32_t> mCRUs{};                                                                                                                                                                  ///< CRUs to process in this instance
+  IDCFourierTransform<IDCFourierTransformBaseEPN> mIDCFourierTransform{};                                                                                                                               ///< object for performing the fourier transform of 1D-IDCs
+  OneDIDCAggregator mOneDIDCAggregator{};                                                                                                                                                               ///< helper class for aggregation of 1D-IDCs
+  const bool mDebug{false};                                                                                                                                                                             ///< dump IDCs to tree for debugging
+  int mReceivedCRUs = 0;                                                                                                                                                                                ///< counter to keep track of the number of received data from CRUs
+  const std::vector<InputSpec> mFilter = {{"1didcepn", ConcreteDataTypeMatcher{o2::header::gDataOriginTPC, TPCFLPIDCDevice<TPCFLPIDCDeviceGroup>::getDataDescription1DIDCEPN()}, Lifetime::Timeframe}}; ///< filter for looping over input data
 
   void sendOutput(DataAllocator& output)
   {
@@ -96,7 +96,7 @@ class TPCFourierTransformEPNSpec : public o2::framework::Task
 
 DataProcessorSpec getTPCFourierTransformEPNSpec(const std::vector<uint32_t>& crus, const unsigned int rangeIDC, const unsigned int nFourierCoefficientsSend, const bool debug = false)
 {
-  std::vector<InputSpec> inputSpecs{InputSpec{"1didcepn", ConcreteDataTypeMatcher{gDataOriginTPC, TPCAverageGroupIDCDevice::getDataDescription1DIDCEPN()}, Lifetime::Timeframe}};
+  std::vector<InputSpec> inputSpecs{InputSpec{"1didcepn", ConcreteDataTypeMatcher{gDataOriginTPC, TPCFLPIDCDevice<TPCFLPIDCDeviceGroup>::getDataDescription1DIDCEPN()}, Lifetime::Timeframe}};
   std::vector<OutputSpec> outputSpecs{ConcreteDataMatcher{gDataOriginTPC, TPCFourierTransformEPNSpec::getDataDescription(), header::DataHeader::SubSpecificationType{o2::tpc::Side::A}},
                                       ConcreteDataMatcher{gDataOriginTPC, TPCFourierTransformEPNSpec::getDataDescription(), header::DataHeader::SubSpecificationType{o2::tpc::Side::C}}};
 


### PR DESCRIPTION
Grouping on the aggregator:
- IDCs will just be propagated on the FLPs + calculation of 1D-IDCs
- renaming of device for grouping as it can be deactivated
- restructuring class for averaging the IDCs to switch between CRU and full TPC
- implementing averaging and grouping of DeltaIDCs only

Other changes:
- adding more generic way to draw IDCs for debugging
- RobustAverage: adding weighted average
- IDCAverageGroup: adding overlapping groups with weighting
- Grouping: adding possibility to set a map containing status flags for each pad
- Draw grouping
- adding test for fourier transform on EPNs and aggregator
- drawing IDCs from stored CCDB objects (obtain IDCs from IDCDelta, IDCOne, IDCZero