### PR TITLE
[EMCAL-660, EMCAL-703] Add option to auto-configure subspecification

### DIFF
--- a/Detectors/EMCAL/base/include/EMCALBase/Mapper.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/Mapper.h
@@ -353,6 +353,13 @@ class MappingHandler
   /// \param branch Branch index (0 or 1) in DDL
   int getFEEForChannelInDDL(int dll, int channelFEC, int branch);
 
+  /// \brief Get index of the FLP based on the DDL ID
+  /// \param ddl Absolute DDL index
+  /// \return FLP index
+  ///
+  /// Current DDL - FLP indexing can be found in EMCAL-660
+  int getFLPIndex(int ddl);
+
  private:
   std::array<Mapper, 4> mMappings; ///< Mapping container
 

--- a/Detectors/EMCAL/base/src/Mapper.cxx
+++ b/Detectors/EMCAL/base/src/Mapper.cxx
@@ -131,6 +131,17 @@ int MappingHandler::getFEEForChannelInDDL(int ddl, int channelFEC, int branch)
   return fecID;
 }
 
+int MappingHandler::getFLPIndex(int ddl)
+{
+  if ((ddl >= 0 && ddl <= 23) || ddl == 44) {
+    return 146; // EMCAL Links (44 - STU) -> FLP 146
+  }
+  if ((ddl >= 24 && ddl <= 38) || ddl == 45) {
+    return 147; // DCAL Links (45 - STU) -> FLP 147
+  }
+  throw DDLInvalid(ddl);
+}
+
 std::ostream& o2::emcal::operator<<(std::ostream& stream, const Mapper::ChannelID& channel)
 {
   stream << "Row " << static_cast<int>(channel.mRow) << ", Column " << static_cast<int>(channel.mColumn) << ", type " << o2::emcal::channelTypeToString(channel.mChannelType);

--- a/Detectors/EMCAL/reconstruction/src/CaloRawFitterGamma2.cxx
+++ b/Detectors/EMCAL/reconstruction/src/CaloRawFitterGamma2.cxx
@@ -98,7 +98,7 @@ float CaloRawFitterGamma2::doFit_1peak(int firstTimeBin, int nSamples, float& am
 
   float chi2(0.);
 
-  // fit using gamma-2 function 	(ORDER =2 assumed)
+  // fit using gamma-2 function (ORDER =2 assumed)
   if (nSamples < 3) {
     throw RawFitterError_t::FIT_ERROR;
   }

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/RecoWorkflow.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/RecoWorkflow.h
@@ -48,7 +48,6 @@ enum struct OutputType { Digits,          ///< EMCAL digits
 /// \param propagateMC If true MC labels are propagated to the output files
 /// \param askDISTSTF If true the Raw->Cell converter subscribes to FLP/DISTSUBTIMEFRAME
 /// \param enableDigitsPrinter If true then the simple digits printer is added as dummy task
-/// \param subspecification Subspecification in case of running on different FLPs
 /// \param cfgInput Input objects processed in the workflow
 /// \param cfgOutput Output objects created in the workflow
 /// \return EMCAL reconstruction workflow for the configuration provided
@@ -56,7 +55,6 @@ enum struct OutputType { Digits,          ///< EMCAL digits
 framework::WorkflowSpec getWorkflow(bool propagateMC = true,
                                     bool askDISTSTF = true,
                                     bool enableDigitsPrinter = false,
-                                    int subspecification = 0,
                                     std::string const& cfgInput = "digits",
                                     std::string const& cfgOutput = "clusters",
                                     bool disableRootInput = false,

--- a/Detectors/EMCAL/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/EMCAL/workflow/src/RecoWorkflow.cxx
@@ -47,7 +47,6 @@ namespace reco_workflow
 o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
                                         bool askDISTSTF,
                                         bool enableDigitsPrinter,
-                                        int subspecification,
                                         std::string const& cfgInput,
                                         std::string const& cfgOutput,
                                         bool disableRootInput,
@@ -172,7 +171,7 @@ o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
       specs.emplace_back(o2::emcal::reco_workflow::getCellConverterSpec(propagateMC));
     } else if (inputType == InputType::Raw) {
       // raw data will come from upstream
-      specs.emplace_back(o2::emcal::reco_workflow::getRawToCellConverterSpec(askDISTSTF, subspecification));
+      specs.emplace_back(o2::emcal::reco_workflow::getRawToCellConverterSpec(askDISTSTF));
     }
   }
 
@@ -273,10 +272,10 @@ o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
         specs.push_back(makeWriterSpec_CellsTR_noerrors("emcal-cells-writer",
                                                         "emccells.root",
                                                         "o2sim",
-                                                        BranchDefinition<CellsDataType>{o2::framework::InputSpec{"data", "EMC", "CELLS", 0},
+                                                        BranchDefinition<CellsDataType>{o2::framework::InputSpec{"data", framework::ConcreteDataTypeMatcher("EMC", "CELLS")},
                                                                                         "EMCALCell",
                                                                                         "cell-branch-name"},
-                                                        BranchDefinition<TriggerRecordDataType>{o2::framework::InputSpec{"trigger", "EMC", "CELLSTRGR", 0},
+                                                        BranchDefinition<TriggerRecordDataType>{o2::framework::InputSpec{"trigger", framework::ConcreteDataTypeMatcher("EMC", "CELLSTRGR")},
                                                                                                 "EMCALCellTRGR",
                                                                                                 "celltrigger-branch-name"})());
 
@@ -285,13 +284,13 @@ o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
         specs.push_back(makeWriterSpec_CellsTR("emcal-cells-writer",
                                                "emccells.root",
                                                "o2sim",
-                                               BranchDefinition<CellsDataType>{o2::framework::InputSpec{"data", "EMC", "CELLS", 0},
+                                               BranchDefinition<CellsDataType>{o2::framework::InputSpec{"data", framework::ConcreteDataTypeMatcher("EMC", "CELLS")},
                                                                                "EMCALCell",
                                                                                "cell-branch-name"},
-                                               BranchDefinition<TriggerRecordDataType>{o2::framework::InputSpec{"trigger", "EMC", "CELLSTRGR", 0},
+                                               BranchDefinition<TriggerRecordDataType>{o2::framework::InputSpec{"trigger", framework::ConcreteDataTypeMatcher("EMC", "CELLSTRGR")},
                                                                                        "EMCALCellTRGR",
                                                                                        "celltrigger-branch-name"},
-                                               BranchDefinition<DecoderErrorsDataType>{o2::framework::InputSpec{"errors", "EMC", "DECODERERR", 0},
+                                               BranchDefinition<DecoderErrorsDataType>{o2::framework::InputSpec{"errors", framework::ConcreteDataTypeMatcher("EMC", "CELLSTRGR")},
                                                                                        "EMCALDECODERERR",
                                                                                        "decodererror-branch-name"})());
       }

--- a/Detectors/EMCAL/workflow/src/emc-reco-workflow.cxx
+++ b/Detectors/EMCAL/workflow/src/emc-reco-workflow.cxx
@@ -70,7 +70,6 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
   auto wf = o2::emcal::reco_workflow::getWorkflow(!cfgc.options().get<bool>("disable-mc"),
                                                   !cfgc.options().get<bool>("ignore-dist-stf"),
                                                   cfgc.options().get<bool>("enable-digits-printer"),
-                                                  cfgc.options().get<int>("subspecification"),
                                                   cfgc.options().get<std::string>("input-type"),
                                                   cfgc.options().get<std::string>("output-type"),
                                                   cfgc.options().get<bool>("disable-root-input"),


### PR DESCRIPTION
In case of auto-configure mode the subspecification
is determined based on the first header in the
payload using the ID of the FLP determined via the
FEE ID. The output specs are defined with wildcard
subspecification according to the discussion in
https://alice-talk.web.cern.ch/t/flp-specific-subspecifications/1035/6.
In case of empty timeframe empty cell containers are
sent to the deadbeaf subspecification which must be
caught by receiver processors.