### PR TITLE
Removing unwanted std::move

### DIFF
--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -1158,7 +1158,7 @@ bool DataProcessingDevice::tryDispatchComputation(DataProcessorContext& context,
   auto getInputSpan = [&relayer = context.relayer,
                        &currentSetOfInputs](TimesliceSlot slot, bool consume = true) {
     if (consume) {
-      currentSetOfInputs = std::move(relayer->consumeAllInputsForTimeslice(slot));
+      currentSetOfInputs = relayer->consumeAllInputsForTimeslice(slot);
     } else {
       currentSetOfInputs = relayer->consumeExistingInputsForTimeslice(slot);
     }


### PR DESCRIPTION
The compiler is taking care of assigning by move, since the object
is provided by return value optimization. So we just make the two
assignments here consistent.