### PR TITLE
change --ccdb-url to --ccdb-url-tof, no LOG(info) from workflow definition

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-reco-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-reco-workflow.cxx
@@ -52,7 +52,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"tof-sectors", o2::framework::VariantType::String, "0-17", {"TOF sector range, e.g. 5-7,8,9 ,TBI"}},
     {"tof-lanes", o2::framework::VariantType::Int, 1, {"number of parallel lanes up to the matcher, TBI"}},
     {"use-ccdb", o2::framework::VariantType::Bool, false, {"enable access to ccdb tof calibration objects"}},
-    {"ccdb-url", o2::framework::VariantType::String, "http://ccdb-test.cern.ch:8080", {"CCDB Url"}},
+    {"ccdb-url-tof", o2::framework::VariantType::String, "http://ccdb-test.cern.ch:8080", {"CCDB Url"}},
     {"input-desc", o2::framework::VariantType::String, "CRAWDATA", {"Input specs description string"}},
     {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input readers"}},
     {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writers"}},
@@ -138,66 +138,66 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   auto isCalibFromCluster = cfgc.options().get<bool>("calib-cluster");
   auto isCosmics = cfgc.options().get<bool>("cosmics");
   auto ignoreDistStf = cfgc.options().get<bool>("ignore-dist-stf");
-  auto ccdb_url = cfgc.options().get<std::string>("ccdb-url");
+  auto ccdb_url = cfgc.options().get<std::string>("ccdb-url-tof");
 
-  LOG(INFO) << "TOF RECO WORKFLOW configuration";
-  LOG(INFO) << "TOF input = " << cfgc.options().get<std::string>("input-type");
-  LOG(INFO) << "TOF output = " << cfgc.options().get<std::string>("output-type");
-  LOG(INFO) << "TOF sectors = " << cfgc.options().get<std::string>("tof-sectors");
-  LOG(INFO) << "TOF disable-mc = " << cfgc.options().get<std::string>("disable-mc");
-  LOG(INFO) << "TOF lanes = " << cfgc.options().get<std::string>("tof-lanes");
-  LOG(INFO) << "TOF use-ccdb = " << cfgc.options().get<std::string>("use-ccdb");
+  LOG(DEBUG) << "TOF RECO WORKFLOW configuration";
+  LOG(DEBUG) << "TOF input = " << cfgc.options().get<std::string>("input-type");
+  LOG(DEBUG) << "TOF output = " << cfgc.options().get<std::string>("output-type");
+  LOG(DEBUG) << "TOF sectors = " << cfgc.options().get<std::string>("tof-sectors");
+  LOG(DEBUG) << "TOF disable-mc = " << cfgc.options().get<std::string>("disable-mc");
+  LOG(DEBUG) << "TOF lanes = " << cfgc.options().get<std::string>("tof-lanes");
+  LOG(DEBUG) << "TOF use-ccdb = " << cfgc.options().get<std::string>("use-ccdb");
   if (useCCDB) {
-    LOG(INFO) << "CCDB url = " << cfgc.options().get<std::string>("ccdb-url");
+    LOG(DEBUG) << "CCDB url = " << cfgc.options().get<std::string>("ccdb-url-tof");
   }
-  LOG(INFO) << "TOF disable-root-input = " << disableRootInput;
-  LOG(INFO) << "TOF disable-root-output = " << disableRootOutput;
-  LOG(INFO) << "TOF conet-mode = " << conetmode;
-  LOG(INFO) << "TOF ignore Dist Stf = " << ignoreDistStf;
-  LOG(INFO) << "TOF disable-row-writing = " << disableROWwriting;
-  LOG(INFO) << "TOF write-decoding-errors = " << writeerr;
+  LOG(DEBUG) << "TOF disable-root-input = " << disableRootInput;
+  LOG(DEBUG) << "TOF disable-root-output = " << disableRootOutput;
+  LOG(DEBUG) << "TOF conet-mode = " << conetmode;
+  LOG(DEBUG) << "TOF ignore Dist Stf = " << ignoreDistStf;
+  LOG(DEBUG) << "TOF disable-row-writing = " << disableROWwriting;
+  LOG(DEBUG) << "TOF write-decoding-errors = " << writeerr;
 
   if (clusterinput && !disableRootInput) {
-    LOG(INFO) << "Insert TOF Cluster Reader";
+    LOG(DEBUG) << "Insert TOF Cluster Reader";
     specs.emplace_back(o2::tof::getClusterReaderSpec(useMC));
   } else if (dgtinput) {
     // TOF clusterizer
     if (!disableRootInput) {
-      LOG(INFO) << "Insert TOF Digit reader from file";
+      LOG(DEBUG) << "Insert TOF Digit reader from file";
       specs.emplace_back(o2::tof::getDigitReaderSpec(useMC));
     }
     if (writeraw) {
-      LOG(INFO) << "Insert TOF Raw writer";
+      LOG(DEBUG) << "Insert TOF Raw writer";
       specs.emplace_back(o2::tof::getTOFRawWriterSpec());
     }
   } else if (rawinput) {
-    LOG(INFO) << "Insert TOF Compressed Raw Decoder";
+    LOG(DEBUG) << "Insert TOF Compressed Raw Decoder";
     auto inputDesc = cfgc.options().get<std::string>("input-desc");
     specs.emplace_back(o2::tof::getCompressedDecodingSpec(inputDesc, conetmode, !ignoreDistStf));
     useMC = 0;
 
     if (writedigit && !disableRootOutput) {
       // add TOF digit writer without mc labels
-      LOG(INFO) << "Insert TOF Digit Writer";
+      LOG(DEBUG) << "Insert TOF Digit Writer";
       specs.emplace_back(o2::tof::getTOFDigitWriterSpec(0, writeerr));
     }
   }
 
   if (!clusterinput && writecluster) {
-    LOG(INFO) << "Insert TOF Clusterizer";
+    LOG(DEBUG) << "Insert TOF Clusterizer";
     specs.emplace_back(o2::tof::getTOFClusterizerSpec(useMC, useCCDB, isCalibFromCluster, isCosmics, ccdb_url.c_str()));
     if (writecluster && !disableRootOutput) {
-      LOG(INFO) << "Insert TOF Cluster Writer";
+      LOG(DEBUG) << "Insert TOF Cluster Writer";
       specs.emplace_back(o2::tof::getTOFClusterWriterSpec(useMC));
     }
   }
 
   if (writectf) {
-    LOG(INFO) << "Insert TOF CTF encoder";
+    LOG(DEBUG) << "Insert TOF CTF encoder";
     specs.emplace_back(o2::tof::getEntropyEncoderSpec());
   }
 
-  LOG(INFO) << "Number of active devices = " << specs.size();
+  LOG(DEBUG) << "Number of active devices = " << specs.size();
 
   // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
   o2::raw::HBFUtilsInitializer hbfIni(cfgc, specs);


### PR DESCRIPTION
The same option cannot be local and global at the same time, even in different devices.

Merging as currently the FST is brocken