### PR TITLE
CcdbApi - Add handling multiple addresses

### DIFF
--- a/CCDB/CMakeLists.txt
+++ b/CCDB/CMakeLists.txt
@@ -25,7 +25,7 @@ o2_add_library(CCDB
 o2_target_root_dictionary(CCDB
                           HEADERS
                                   include/CCDB/CcdbApi.h
-			          include/CCDB/CcdbObjectInfo.h
+                                  include/CCDB/CcdbObjectInfo.h
                                   include/CCDB/TObjectWrapper.h
                                   include/CCDB/IdPath.h
                                   include/CCDB/BasicCCDBManager.h
@@ -54,20 +54,26 @@ o2_add_test(CcdbApi
             LABELS ccdb)
 
 o2_add_test(CcdbApiConfigParam
-		SOURCES test/testCcdbApi_ConfigParam.cxx
-		COMPONENT_NAME ccdb
-		PUBLIC_LINK_LIBRARIES O2::CCDB O2::DetectorsVertexing
-		LABELS ccdb)
+    SOURCES test/testCcdbApi_ConfigParam.cxx
+    COMPONENT_NAME ccdb
+    PUBLIC_LINK_LIBRARIES O2::CCDB O2::DetectorsVertexing
+    LABELS ccdb)
 
 
 o2_add_test(CcdbApi-Alien
-		SOURCES test/testCcdbApi_alien.cxx
-		COMPONENT_NAME ccdb
-		PUBLIC_LINK_LIBRARIES O2::CCDB
-		LABELS ccdb)
+    SOURCES test/testCcdbApi_alien.cxx
+    COMPONENT_NAME ccdb
+    PUBLIC_LINK_LIBRARIES O2::CCDB
+    LABELS ccdb)
 
 o2_add_test(BasicCCDBManager
             SOURCES test/testBasicCCDBManager.cxx
+            COMPONENT_NAME ccdb
+            PUBLIC_LINK_LIBRARIES O2::CCDB
+            LABELS ccdb)
+
+o2_add_test(CcdbApiMultipleUrls
+            SOURCES test/testCcdbApiMultipleUrls.cxx
             COMPONENT_NAME ccdb
             PUBLIC_LINK_LIBRARIES O2::CCDB
             LABELS ccdb)

--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -26,6 +26,7 @@
 #include "CCDB/CcdbObjectInfo.h"
 #include <CommonUtils/ConfigurableParam.h>
 #include <type_traits>
+#include <vector>
 
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__ROOTCLING__) && !defined(__CLING__)
 #include <TJAlienCredentials.h>
@@ -62,9 +63,10 @@ class CcdbApi //: public DatabaseInterface
   /**
    * Initialize connection to CCDB
    *
-   * @param host The URL to the CCDB (e.g. "ccdb-test.cern.ch:8080" or to a local snapshot "file:///tmp/CCDBSnapshot")
+   * @param hosts The URLs to the CCDB (e.g. "ccdb-test.cern.ch:8080" or to a local snapshot "file:///tmp/CCDBSnapshot"),
+   * separated with "," or ";" ("https://localhost:8080,https://ccdb-test.cern.ch:8080")
    */
-  void init(std::string const& host);
+  void init(std::string const& hosts);
 
   /**
    * Query current URL
@@ -73,7 +75,7 @@ class CcdbApi //: public DatabaseInterface
   std::string const& getURL() const { return mUrl; }
 
   /**
-   * Create a binary image of the arbitrary type object, if CcdbObjectInfo pointer is provided, register there 
+   * Create a binary image of the arbitrary type object, if CcdbObjectInfo pointer is provided, register there
    *
    * the assigned object class name and the filename
    * @param obj: Raw pointer to the object to store.
@@ -86,7 +88,7 @@ class CcdbApi //: public DatabaseInterface
   }
 
   /**
-   * Create a binary image of the TObject, if CcdbObjectInfo pointer is provided, register there 
+   * Create a binary image of the TObject, if CcdbObjectInfo pointer is provided, register there
    *
    * the assigned object class name and the filename
    * @param obj: Raw pointer to the object to store.
@@ -95,7 +97,7 @@ class CcdbApi //: public DatabaseInterface
   static std::unique_ptr<std::vector<char>> createObjectImage(const TObject* obj, CcdbObjectInfo* info = nullptr);
 
   /**
-   * Create a binary image of the object, if CcdbObjectInfo pointer is provided, register there 
+   * Create a binary image of the object, if CcdbObjectInfo pointer is provided, register there
    *
    * the assigned object class name and the filename
    * @param obj: Raw pointer to the object to store.
@@ -271,7 +273,7 @@ class CcdbApi //: public DatabaseInterface
    */
   static void* extractFromTFile(TFile& file, TClass const* cl);
 
-  /** Get headers associated to a given CCDBEntry on the server. 
+  /** Get headers associated to a given CCDBEntry on the server.
    * @param url the url which refers to the objects
    * @param etag of the previous reply
    * @param headers the headers found in the request. Will be emptied when we return false.
@@ -351,7 +353,7 @@ class CcdbApi //: public DatabaseInterface
    */
   std::string getFullUrlForStorage(CURL* curl, const std::string& path, const std::string& objtype,
                                    const std::map<std::string, std::string>& metadata,
-                                   long startValidityTimestamp = -1, long endValidityTimestamp = -1) const;
+                                   long startValidityTimestamp = -1, long endValidityTimestamp = -1, int hostIndex = 0) const;
 
   /**
    * Build the full url to store an object.
@@ -361,7 +363,7 @@ class CcdbApi //: public DatabaseInterface
    * @return The full url to store an object (url / startValidity / endValidity / [metadata &]* )
    */
   std::string getFullUrlForRetrieval(CURL* curl, const std::string& path, const std::map<std::string, std::string>& metadata,
-                                     long timestamp = -1) const;
+                                     long timestamp = -1, int hostIndex = 0) const;
 
  public:
   /**
@@ -421,8 +423,39 @@ class CcdbApi //: public DatabaseInterface
   // convert type_info to TClass, throw on failure
   static TClass* tinfo2TClass(std::type_info const& tinfo);
 
+  // split string on delimiters and return tokens as vector
+  std::vector<std::string> splitString(std::string string, const char* delimiters);
+
+  typedef size_t (*CurlWriteCallback)(void*, size_t, size_t, void*);
+
+  void initCurlOptionsForRetrieve(CURL* curlHandle, void* pointer, CurlWriteCallback writeCallback, bool followRedirect = true) const;
+
+  void initHeadersForRetrieve(CURL* curlHandle, long timestamp, std::map<std::string, std::string>* headers, std::string const& etag,
+                              const std::string& createdNotAfter, const std::string& createdNotBefore) const;
+
+  bool receiveToFile(FILE* fileHandle, std::string const& path, std::map<std::string, std::string> const& metadata,
+                     long timestamp, std::map<std::string, std::string>* headers = nullptr, std::string const& etag = "",
+                     const std::string& createdNotAfter = "", const std::string& createdNotBefore = "", bool followRedirect = true) const;
+
+  bool receiveToMemory(void* chunk, std::string const& path, std::map<std::string, std::string> const& metadata,
+                       long timestamp, std::map<std::string, std::string>* headers = nullptr, std::string const& etag = "",
+                       const std::string& createdNotAfter = "", const std::string& createdNotBefore = "", bool followRedirect = true) const;
+
+  bool receiveObject(void* dataHolder, std::string const& path, std::map<std::string, std::string> const& metadata,
+                     long timestamp, std::map<std::string, std::string>* headers, std::string const& etag,
+                     const std::string& createdNotAfter, const std::string& createdNotBefore, bool followRedirect, CurlWriteCallback writeCallback) const;
+
+  /**
+  * Initialize hostsPool
+  * @param hosts string with hosts separated by "," or ";"
+  */
+  void initHostsPool(std::string hosts);
+
+  std::string getHostUrl(int hostIndex) const;
+
   /// Base URL of the CCDB (with port)
   std::string mUrl{};
+  std::vector<std::string> hostsPool{};
   std::string mSnapshotTopPath{};
   bool mInSnapshotMode = false;
   mutable TGrid* mAlienInstance = nullptr;                       // a cached connection to TGrid (needed for Alien locations)

--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -38,6 +38,7 @@
 #include <mutex>
 #include <boost/interprocess/sync/named_semaphore.hpp>
 #include <regex>
+#include <cstdio>
 
 namespace o2
 {
@@ -75,6 +76,7 @@ void CcdbApi::init(std::string const& host)
     LOG(info) << "Initializing CcdbApi in snapshot readonly mode ... reading snapshot from path " << path;
     initInSnapshotMode(path);
   } else {
+    initHostsPool(host);
     curlInit();
   }
 
@@ -156,37 +158,44 @@ void CcdbApi::storeAsBinaryFile(const char* buffer, size_t size, const std::stri
 
   // Curl preparation
   CURL* curl = nullptr;
-  struct curl_httppost* formpost = nullptr;
-  struct curl_httppost* lastptr = nullptr;
-  struct curl_slist* headerlist = nullptr;
-  static const char buf[] = "Expect:";
-  curl_formadd(&formpost,
-               &lastptr,
-               CURLFORM_COPYNAME, "send",
-               CURLFORM_BUFFER, filename.c_str(),
-               CURLFORM_BUFFERPTR, buffer, //.Buffer(),
-               CURLFORM_BUFFERLENGTH, size,
-               CURLFORM_END);
-
   curl = curl_easy_init();
-  headerlist = curl_slist_append(headerlist, buf);
+
   if (curl != nullptr) {
-    string fullUrl = getFullUrlForStorage(curl, path, objectType, metadata, sanitizedStartValidityTimestamp, sanitizedEndValidityTimestamp);
-    LOG(debug3) << "Full URL Encoded: " << fullUrl;
-    /* what URL that receives this POST */
-    curl_easy_setopt(curl, CURLOPT_URL, fullUrl.c_str());
+    struct curl_httppost* formpost = nullptr;
+    struct curl_httppost* lastptr = nullptr;
+    curl_formadd(&formpost,
+                 &lastptr,
+                 CURLFORM_COPYNAME, "send",
+                 CURLFORM_BUFFER, filename.c_str(),
+                 CURLFORM_BUFFERPTR, buffer, //.Buffer(),
+                 CURLFORM_BUFFERLENGTH, size,
+                 CURLFORM_END);
+
+    struct curl_slist* headerlist = nullptr;
+    static const char buf[] = "Expect:";
+    headerlist = curl_slist_append(headerlist, buf);
+
+    curlSetSSLOptions(curl);
+
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headerlist);
     curl_easy_setopt(curl, CURLOPT_HTTPPOST, formpost);
     curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
 
-    curlSetSSLOptions(curl);
+    CURLcode res = CURL_LAST;
 
-    /* Perform the request, res will get the return code */
-    CURLcode res = curl_easy_perform(curl);
-    /* Check for errors */
-    if (res != CURLE_OK) {
-      fprintf(stderr, "curl_easy_perform() failed: %s\n",
-              curl_easy_strerror(res));
+    for (int hostIndex = 0; hostIndex < hostsPool.size() && res > 0; hostIndex++) {
+      string fullUrl = getFullUrlForStorage(curl, path, objectType, metadata, sanitizedStartValidityTimestamp, sanitizedEndValidityTimestamp, hostIndex);
+      LOG(debug3) << "Full URL Encoded: " << fullUrl;
+      /* what URL that receives this POST */
+      curl_easy_setopt(curl, CURLOPT_URL, fullUrl.c_str());
+
+      /* Perform the request, res will get the return code */
+      res = curl_easy_perform(curl);
+      /* Check for errors */
+      if (res != CURLE_OK) {
+        fprintf(stderr, "curl_easy_perform() failed: %s\n",
+                curl_easy_strerror(res));
+      }
     }
 
     /* always cleanup */
@@ -212,13 +221,15 @@ void CcdbApi::storeAsTFile(const TObject* rootObject, std::string const& path, s
 
 string CcdbApi::getFullUrlForStorage(CURL* curl, const string& path, const string& objtype,
                                      const map<string, string>& metadata,
-                                     long startValidityTimestamp, long endValidityTimestamp) const
+                                     long startValidityTimestamp, long endValidityTimestamp, int hostIndex) const
 {
   // Prepare timestamps
   string startValidityString = getTimestampString(startValidityTimestamp < 0 ? getCurrentTimestamp() : startValidityTimestamp);
   string endValidityString = getTimestampString(endValidityTimestamp < 0 ? getFutureTimestamp(60 * 60 * 24 * 1) : endValidityTimestamp);
+  // Get url
+  string url = getHostUrl(hostIndex);
   // Build URL
-  string fullUrl = mUrl + "/" + path + "/" + startValidityString + "/" + endValidityString + "/";
+  string fullUrl = url + "/" + path + "/" + startValidityString + "/" + endValidityString + "/";
   // Add type as part of metadata
   // we need to URL encode the object type, since in case it has special characters (like the "<", ">" for templated classes) it won't work otherwise
   char* objtypeEncoded = curl_easy_escape(curl, objtype.c_str(), objtype.size());
@@ -244,7 +255,7 @@ std::string getSnapshotPath(std::string const& topdir, const string& path)
 }
 
 // todo make a single method of the one above and below
-string CcdbApi::getFullUrlForRetrieval(CURL* curl, const string& path, const map<string, string>& metadata, long timestamp) const
+string CcdbApi::getFullUrlForRetrieval(CURL* curl, const string& path, const map<string, string>& metadata, long timestamp, int hostIndex) const
 {
   if (mInSnapshotMode) {
     return getSnapshotPath(mSnapshotTopPath, path);
@@ -252,8 +263,10 @@ string CcdbApi::getFullUrlForRetrieval(CURL* curl, const string& path, const map
 
   // Prepare timestamps
   string validityString = getTimestampString(timestamp < 0 ? getCurrentTimestamp() : timestamp);
+  // Get host url
+  string hostUrl = getHostUrl(hostIndex);
   // Build URL
-  string fullUrl = mUrl + "/" + path + "/" + validityString + "/";
+  string fullUrl = hostUrl + "/" + path + "/" + validityString + "/";
   // Add metadata
   for (auto& kv : metadata) {
     string mfirst = kv.first;
@@ -269,8 +282,8 @@ string CcdbApi::getFullUrlForRetrieval(CURL* curl, const string& path, const map
 }
 
 /**
- * Struct to store the data we will receive from the CCDB with CURL.
- */
+  * Struct to store the data we will receive from the CCDB with CURL.
+  */
 struct MemoryStruct {
   char* memory;
   unsigned int size;
@@ -370,100 +383,14 @@ void CcdbApi::curlSetSSLOptions(CURL* curl_handle)
   // CURLcode ret = curl_easy_setopt(curl_handle, CURLOPT_SSL_CTX_FUNCTION, *ssl_ctx_callback);
 }
 
-TObject* CcdbApi::retrieve(std::string const& path, std::map<std::string, std::string> const& metadata,
-                           long timestamp) const
+typedef size_t (*CurlWriteCallback)(void*, size_t, size_t, void*);
+
+void CcdbApi::initCurlOptionsForRetrieve(CURL* curlHandle, void* chunk, CurlWriteCallback writeCallback, bool followRedirect) const
 {
-  // Note : based on https://curl.haxx.se/libcurl/c/getinmemory.html
-  // Thus it does not comply to our coding guidelines as it is a copy paste.
-
-  // Prepare CURL
-  CURL* curl_handle;
-  CURLcode res;
-  struct MemoryStruct chunk {
-    (char*)malloc(1) /*memory*/, 0 /*size*/
-  };
-  TObject* result = nullptr;
-
-  curlSetSSLOptions(curl_handle);
-
-  /* init the curl session */
-  curl_handle = curl_easy_init();
-
-  string fullUrl = getFullUrlForRetrieval(curl_handle, path, metadata, timestamp);
-
-  /* specify URL to get */
-  curl_easy_setopt(curl_handle, CURLOPT_URL, fullUrl.c_str());
-
-  /* send all data to this function  */
-  curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, WriteMemoryCallback);
-
-  /* we pass our 'chunk' struct to the callback function */
-  curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, (void*)&chunk);
-
-  /* some servers don't like requests that are made without a user-agent
-     field, so we provide one */
-  curl_easy_setopt(curl_handle, CURLOPT_USERAGENT, "libcurl-agent/1.0");
-
-  /* if redirected , we tell libcurl to follow redirection */
-  curl_easy_setopt(curl_handle, CURLOPT_FOLLOWLOCATION, 1L);
-
-  curlSetSSLOptions(curl_handle);
-
-  /* get it! */
-  res = curl_easy_perform(curl_handle);
-
-  /* check for errors */
-  if (res != CURLE_OK) {
-    fprintf(stderr, "curl_easy_perform() failed: %s\n",
-            curl_easy_strerror(res));
-  } else {
-    /*
-     * Now, our chunk.memory points to a memory block that is chunk.size
-     * bytes big and contains the remote file.
-     */
-
-    //    printf("%lu bytes retrieved\n", (long) chunk.size);
-
-    long response_code;
-    res = curl_easy_getinfo(curl_handle, CURLINFO_RESPONSE_CODE, &response_code);
-    if ((res == CURLE_OK) && (response_code != 404)) {
-      std::lock_guard<std::mutex> guard(gIOMutex);
-      TMessage mess(kMESS_OBJECT);
-      mess.SetBuffer(chunk.memory, chunk.size, kFALSE);
-      mess.SetReadMode();
-      mess.Reset();
-      result = (TObject*)(mess.ReadObjectAny(mess.GetClass()));
-      if (result == nullptr) {
-        cerr << "couldn't retrieve the object " << path << endl;
-      }
-    } else {
-      cerr << "invalid URL : " << fullUrl << endl;
-    }
-
-    // Print data
-    //    cout << "size : " << chunk.size << endl;
-    //    cout << "data : " << endl;
-    //    char* mem = (char*)chunk.memory;
-    //    for (int i = 0 ; i < chunk.size/4 ; i++)  {
-    //      cout << mem;
-    //      mem += 4;
-    //    }
-  }
-
-  /* cleanup curl stuff */
-  curl_easy_cleanup(curl_handle);
-
-  free(chunk.memory);
-
-  return result;
-}
-
-std::string CcdbApi::generateFileName(const std::string& inp)
-{
-  // generate file name for the CCDB object  (for now augment the input string by the timestamp)
-  std::string str = inp;
-  str += "_" + std::to_string(o2::ccdb::getCurrentTimestamp()) + ".root";
-  return str;
+  curl_easy_setopt(curlHandle, CURLOPT_WRITEFUNCTION, writeCallback);
+  curl_easy_setopt(curlHandle, CURLOPT_WRITEDATA, chunk);
+  curl_easy_setopt(curlHandle, CURLOPT_USERAGENT, "libcurl-agent/1.0");
+  curl_easy_setopt(curlHandle, CURLOPT_FOLLOWLOCATION, followRedirect ? 1L : 0L);
 }
 
 namespace
@@ -483,43 +410,9 @@ size_t header_map_callback(char* buffer, size_t size, size_t nitems, void* userd
 }
 } // namespace
 
-TObject* CcdbApi::retrieveFromTFile(std::string const& path, std::map<std::string, std::string> const& metadata,
-                                    long timestamp, std::map<std::string, std::string>* headers, std::string const& etag,
-                                    const std::string& createdNotAfter, const std::string& createdNotBefore) const
+void CcdbApi::initHeadersForRetrieve(CURL* curlHandle, long timestamp, std::map<std::string, std::string>* headers, std::string const& etag,
+                                     const std::string& createdNotAfter, const std::string& createdNotBefore) const
 {
-  // Note : based on https://curl.haxx.se/libcurl/c/getinmemory.html
-  // Thus it does not comply to our coding guidelines as it is a copy paste.
-
-  //  std::map<std::string, std::string> headers2;
-
-  // Prepare CURL
-  CURL* curl_handle;
-  CURLcode res;
-  struct MemoryStruct chunk {
-    (char*)malloc(1) /*memory*/, 0 /*size*/
-  };
-
-  /* init the curl session */
-  curl_handle = curl_easy_init();
-
-  string fullUrl = getFullUrlForRetrieval(curl_handle, path, metadata, timestamp);
-
-  /* specify URL to get */
-  curl_easy_setopt(curl_handle, CURLOPT_URL, fullUrl.c_str());
-
-  /* send all data to this function  */
-  curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, WriteMemoryCallback);
-
-  /* we pass our 'chunk' struct to the callback function */
-  curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, (void*)&chunk);
-
-  /* some servers don't like requests that are made without a user-agent
-     field, so we provide one */
-  curl_easy_setopt(curl_handle, CURLOPT_USERAGENT, "libcurl-agent/1.0");
-
-  /* if redirected , we tell libcurl to follow redirection */
-  curl_easy_setopt(curl_handle, CURLOPT_FOLLOWLOCATION, 1L);
-
   struct curl_slist* list = nullptr;
   if (!etag.empty()) {
     list = curl_slist_append(list, ("If-None-Match: " + etag).c_str());
@@ -533,58 +426,118 @@ TObject* CcdbApi::retrieveFromTFile(std::string const& path, std::map<std::strin
     list = curl_slist_append(list, ("If-Not-Before: " + createdNotBefore).c_str());
   }
 
-  // setup curl for headers handling
   if (headers != nullptr) {
     list = curl_slist_append(list, ("If-None-Match: " + to_string(timestamp)).c_str());
-    curl_easy_setopt(curl_handle, CURLOPT_HEADERFUNCTION, header_map_callback<>);
-    curl_easy_setopt(curl_handle, CURLOPT_HEADERDATA, headers);
+    curl_easy_setopt(curlHandle, CURLOPT_HEADERFUNCTION, header_map_callback<>);
+    curl_easy_setopt(curlHandle, CURLOPT_HEADERDATA, headers);
   }
 
   if (list) {
-    curl_easy_setopt(curl_handle, CURLOPT_HTTPHEADER, list);
+    curl_easy_setopt(curlHandle, CURLOPT_HTTPHEADER, list);
   }
+}
 
-  curlSetSSLOptions(curl_handle);
+bool CcdbApi::receiveToFile(FILE* fileHandle, std::string const& path, std::map<std::string, std::string> const& metadata,
+                            long timestamp, std::map<std::string, std::string>* headers, std::string const& etag,
+                            const std::string& createdNotAfter, const std::string& createdNotBefore, bool followRedirect) const
+{
+  return receiveObject((void*)fileHandle, path, metadata, timestamp, headers, etag, createdNotAfter, createdNotBefore, followRedirect, (CurlWriteCallback)&WriteToFileCallback);
+}
 
-  /* get it! */
-  res = curl_easy_perform(curl_handle);
-  std::string errStr;
-  TObject* result = nullptr;
-  if (res == CURLE_OK) {
-    long response_code;
-    res = curl_easy_getinfo(curl_handle, CURLINFO_RESPONSE_CODE, &response_code);
-    if ((res == CURLE_OK) && (response_code != 404)) {
-      Int_t previousErrorLevel = gErrorIgnoreLevel;
-      gErrorIgnoreLevel = kFatal;
-      std::lock_guard<std::mutex> guard(gIOMutex);
-      TMemFile memFile("name", chunk.memory, chunk.size, "READ");
-      gErrorIgnoreLevel = previousErrorLevel;
-      if (!memFile.IsZombie()) {
-        result = (TObject*)extractFromTFile(memFile, TClass::GetClass("TObject"));
-        if (result == nullptr) {
-          errStr = o2::utils::Str::concat_string("Couldn't retrieve the object ", path);
-          LOG(error) << errStr;
-        }
-        memFile.Close();
+bool CcdbApi::receiveToMemory(void* chunk, std::string const& path, std::map<std::string, std::string> const& metadata,
+                              long timestamp, std::map<std::string, std::string>* headers, std::string const& etag,
+                              const std::string& createdNotAfter, const std::string& createdNotBefore, bool followRedirect) const
+{
+  return receiveObject((void*)chunk, path, metadata, timestamp, headers, etag, createdNotAfter, createdNotBefore, followRedirect, (CurlWriteCallback)&WriteMemoryCallback);
+}
+
+bool CcdbApi::receiveObject(void* dataHolder, std::string const& path, std::map<std::string, std::string> const& metadata,
+                            long timestamp, std::map<std::string, std::string>* headers, std::string const& etag,
+                            const std::string& createdNotAfter, const std::string& createdNotBefore, bool followRedirect, CurlWriteCallback writeCallback) const
+{
+  CURL* curlHandle;
+
+  curlHandle = curl_easy_init();
+
+  if (curlHandle != nullptr) {
+
+    curlSetSSLOptions(curlHandle);
+    initCurlOptionsForRetrieve(curlHandle, dataHolder, writeCallback, followRedirect);
+    initHeadersForRetrieve(curlHandle, timestamp, headers, etag, createdNotAfter, createdNotBefore);
+
+    long responseCode = 0;
+    CURLcode curlResultCode = CURL_LAST;
+
+    for (int hostIndex = 0; hostIndex < hostsPool.size() && (responseCode >= 400 || curlResultCode > 0); hostIndex++) {
+      string fullUrl = getFullUrlForRetrieval(curlHandle, path, metadata, timestamp, hostIndex);
+      curl_easy_setopt(curlHandle, CURLOPT_URL, fullUrl.c_str());
+
+      curlResultCode = curl_easy_perform(curlHandle);
+
+      if (curlResultCode != CURLE_OK) {
+        fprintf(stderr, "curl_easy_perform() failed: %s\n",
+                curl_easy_strerror(curlResultCode));
       } else {
-        LOG(debug) << "Object " << path << " is stored in a TMemFile";
+        curlResultCode = curl_easy_getinfo(curlHandle, CURLINFO_RESPONSE_CODE, &responseCode);
+        if ((curlResultCode == CURLE_OK) && (responseCode < 300)) {
+          curl_easy_cleanup(curlHandle);
+          return true;
+        } else {
+          if (curlResultCode != CURLE_OK) {
+            cerr << "invalid URL : " << fullUrl << endl;
+          } else {
+            cerr << "not found under link: " << fullUrl << endl;
+          }
+        }
       }
-    } else {
-      errStr = o2::utils::Str::concat_string("Invalid URL : ", fullUrl);
-      LOG(error) << errStr;
     }
-  } else {
-    errStr = o2::utils::Str::concat_string("curl_easy_perform() failed: ", curl_easy_strerror(res));
-    fprintf(stderr, "%s", errStr.c_str());
+
+    curl_easy_cleanup(curlHandle);
+  }
+  return false;
+}
+
+TObject* CcdbApi::retrieve(std::string const& path, std::map<std::string, std::string> const& metadata,
+                           long timestamp) const
+{
+  struct MemoryStruct chunk {
+    (char*)malloc(1) /*memory*/, 0 /*size*/
+  };
+
+  TObject* result = nullptr;
+
+  bool res = receiveToMemory((void*)&chunk, path, metadata, timestamp);
+
+  if (res) {
+    std::lock_guard<std::mutex> guard(gIOMutex);
+    TMessage mess(kMESS_OBJECT);
+    mess.SetBuffer(chunk.memory, chunk.size, kFALSE);
+    mess.SetReadMode();
+    mess.Reset();
+    result = (TObject*)(mess.ReadObjectAny(mess.GetClass()));
+    if (result == nullptr) {
+      cerr << "couldn't retrieve the object " << path << endl;
+    }
   }
 
-  if (!errStr.empty() && headers) {
-    (*headers)["Error"] = errStr;
-  }
-
-  curl_easy_cleanup(curl_handle);
   free(chunk.memory);
+
   return result;
+}
+
+std::string CcdbApi::generateFileName(const std::string& inp)
+{
+  // generate file name for the CCDB object  (for now augment the input string by the timestamp)
+  std::string str = inp;
+  str += "_" + std::to_string(o2::ccdb::getCurrentTimestamp()) + ".root";
+  return str;
+}
+
+TObject* CcdbApi::retrieveFromTFile(std::string const& path, std::map<std::string, std::string> const& metadata,
+                                    long timestamp, std::map<std::string, std::string>* headers, std::string const& etag,
+                                    const std::string& createdNotAfter, const std::string& createdNotBefore) const
+{
+  return (TObject*)retrieveFromTFile(typeid(TObject), path, metadata, timestamp, headers, etag, createdNotAfter, createdNotBefore);
 }
 
 bool CcdbApi::retrieveBlob(std::string const& path, std::string const& targetdir, std::map<std::string, std::string> const& metadata,
@@ -660,16 +613,11 @@ bool CcdbApi::retrieveBlob(std::string const& path, std::string const& targetdir
 
     // Prepare CURL
     CURL* curl_handle;
-    CURLcode res;
+    CURLcode res = CURL_LAST;
+    long response_code = 404;
 
     /* init the curl session */
     curl_handle = curl_easy_init();
-
-    // we can construct download URL direclty from the headers obtained above
-    string fullUrl = mUrl + "/download/" + ETag; // getFullUrlForRetrieval(curl_handle, path, metadata, timestamp);
-
-    /* specify URL to get */
-    curl_easy_setopt(curl_handle, CURLOPT_URL, fullUrl.c_str());
 
     /* send all data to this function  */
     curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, WriteToFileCallback);
@@ -686,22 +634,29 @@ bool CcdbApi::retrieveBlob(std::string const& path, std::string const& targetdir
 
     curlSetSSLOptions(curl_handle);
 
-    /* get it! */
-    res = curl_easy_perform(curl_handle);
+    for (int i = 0; i < hostsPool.size() && res > 0 && response_code >= 400; i++) {
+      // we can construct download URL direclty from the headers obtained above
+      string fullUrl = getHostUrl(i) + "/download/" + ETag; // getFullUrlForRetrieval(curl_handle, path, metadata, timestamp);
 
-    void* result = nullptr;
-    success = true;
-    if (res == CURLE_OK) {
-      long response_code;
-      res = curl_easy_getinfo(curl_handle, CURLINFO_RESPONSE_CODE, &response_code);
-      if ((res == CURLE_OK) && (response_code != 404)) {
+      /* specify URL to get */
+      curl_easy_setopt(curl_handle, CURLOPT_URL, fullUrl.c_str());
+
+      /* get it! */
+      res = curl_easy_perform(curl_handle);
+
+      void* result = nullptr;
+      success = true;
+      if (res == CURLE_OK) {
+        res = curl_easy_getinfo(curl_handle, CURLINFO_RESPONSE_CODE, &response_code);
+        if ((res == CURLE_OK) && (response_code != 404)) {
+        } else {
+          LOG(error) << "Invalid URL : " << fullUrl;
+          success = false;
+        }
       } else {
         LOG(error) << "Invalid URL : " << fullUrl;
         success = false;
       }
-    } else {
-      LOG(error) << "Invalid URL : " << fullUrl;
-      success = false;
     }
 
     if (fp) {
@@ -890,20 +845,14 @@ void* CcdbApi::navigateURLsAndRetrieveContent(CURL* curl_handle, std::string con
   // otherwise make an HTTP/CURL request
   // specify URL to get
   curl_easy_setopt(curl_handle, CURLOPT_URL, url.c_str());
-  // some servers don't like requests that are made without a user-agent
-  // field, so we provide one
-  curl_easy_setopt(curl_handle, CURLOPT_USERAGENT, "libcurl-agent/1.0");
-  // if redirected , we tell libcurl NOT to follow redirection
-  curl_easy_setopt(curl_handle, CURLOPT_FOLLOWLOCATION, 0L);
+
+  MemoryStruct chunk{(char*)malloc(1), 0};
+  initCurlOptionsForRetrieve(curl_handle, (void*)&chunk, WriteMemoryCallback, false);
+
   curl_easy_setopt(curl_handle, CURLOPT_HEADERFUNCTION, header_map_callback<decltype(headerData)>);
   headerData.clear();
   curl_easy_setopt(curl_handle, CURLOPT_HEADERDATA, (void*)&headerData);
 
-  MemoryStruct chunk{(char*)malloc(1), 0};
-
-  // send all data to this function
-  curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, WriteMemoryCallback);
-  curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, (void*)&chunk);
   curlSetSSLOptions(curl_handle);
 
   auto res = curl_easy_perform(curl_handle);
@@ -1048,29 +997,20 @@ void* CcdbApi::retrieveFromTFile(std::type_info const& tinfo, std::string const&
   // normal mode follows
 
   CURL* curl_handle = curl_easy_init();
-  string fullUrl = getFullUrlForRetrieval(curl_handle, path, metadata, timestamp);
+  string fullUrl = getFullUrlForRetrieval(curl_handle, path, metadata, timestamp); // todo check if function still works correctly in case mInSnapshotMode
   // if we are in snapshot mode we can simply open the file; extract the object and return
   if (mInSnapshotMode) {
     return extractFromLocalFile(fullUrl, tinfo, headers);
   }
 
-  // add some global options to the curl query
-  struct curl_slist* list = nullptr;
-  if (!etag.empty()) {
-    list = curl_slist_append(list, ("If-None-Match: " + etag).c_str());
-  }
-  if (!createdNotAfter.empty()) {
-    list = curl_slist_append(list, ("If-Not-After: " + createdNotAfter).c_str());
-  }
-  if (!createdNotBefore.empty()) {
-    list = curl_slist_append(list, ("If-Not-Before: " + createdNotBefore).c_str());
-  }
-  if (headers) {
-    list = curl_slist_append(list, ("If-None-Match: " + to_string(timestamp)).c_str());
-  }
-  curl_easy_setopt(curl_handle, CURLOPT_HTTPHEADER, list);
-
+  initHeadersForRetrieve(curl_handle, timestamp, headers, etag, createdNotAfter, createdNotBefore);
   auto content = navigateURLsAndRetrieveContent(curl_handle, fullUrl, tinfo, headers);
+
+  for (int hostIndex = 1; hostIndex < hostsPool.size() && !(content); hostIndex++) {
+    fullUrl = getFullUrlForRetrieval(curl_handle, path, metadata, timestamp, hostIndex);
+    content = navigateURLsAndRetrieveContent(curl_handle, fullUrl, tinfo, headers);
+  }
+
   curl_easy_cleanup(curl_handle);
   return content;
 }
@@ -1093,16 +1033,11 @@ size_t CurlWrite_CallbackFunc_StdString2(void* contents, size_t size, size_t nme
 std::string CcdbApi::list(std::string const& path, bool latestOnly, std::string const& returnFormat) const
 {
   CURL* curl;
-  CURLcode res;
-  string fullUrl = mUrl;
-  fullUrl += latestOnly ? "/latest/" : "/browse/";
-  fullUrl += path;
+  CURLcode res = CURL_LAST;
   std::string result;
 
   curl = curl_easy_init();
   if (curl != nullptr) {
-
-    curl_easy_setopt(curl, CURLOPT_URL, fullUrl.c_str());
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, CurlWrite_CallbackFunc_StdString2);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &result);
 
@@ -1113,10 +1048,18 @@ std::string CcdbApi::list(std::string const& path, bool latestOnly, std::string 
 
     curlSetSSLOptions(curl);
 
+    string fullUrl;
     // Perform the request, res will get the return code
-    res = curl_easy_perform(curl);
-    if (res != CURLE_OK) {
-      fprintf(stderr, "curl_easy_perform() failed: %s\n", curl_easy_strerror(res));
+    for (int hostIndex = 0; hostIndex < hostsPool.size() && res != CURLE_OK; hostIndex++) {
+      fullUrl = getHostUrl(hostIndex);
+      fullUrl += latestOnly ? "/latest/" : "/browse/";
+      fullUrl += path;
+      curl_easy_setopt(curl, CURLOPT_URL, fullUrl.c_str());
+
+      res = curl_easy_perform(curl);
+      if (res != CURLE_OK) {
+        fprintf(stderr, "curl_easy_perform() failed: %s\n", curl_easy_strerror(res));
+      }
     }
     curl_slist_free_all(headers);
     curl_easy_cleanup(curl);
@@ -1139,21 +1082,22 @@ void CcdbApi::deleteObject(std::string const& path, long timestamp) const
   stringstream fullUrl;
   long timestampLocal = timestamp == -1 ? getCurrentTimestamp() : timestamp;
 
-  fullUrl << mUrl << "/" << path << "/" << timestampLocal;
-
   curl = curl_easy_init();
   if (curl != nullptr) {
     curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "DELETE");
-    curl_easy_setopt(curl, CURLOPT_URL, fullUrl.str().c_str());
-
     curlSetSSLOptions(curl);
 
-    // Perform the request, res will get the return code
-    res = curl_easy_perform(curl);
-    if (res != CURLE_OK) {
-      fprintf(stderr, "curl_easy_perform() failed: %s\n", curl_easy_strerror(res));
+    for (int hostIndex = 0; hostIndex < hostsPool.size(); hostIndex++) {
+      fullUrl << getHostUrl(hostIndex) << "/" << path << "/" << timestampLocal;
+      curl_easy_setopt(curl, CURLOPT_URL, fullUrl.str().c_str());
+
+      // Perform the request, res will get the return code
+      res = curl_easy_perform(curl);
+      if (res != CURLE_OK) {
+        fprintf(stderr, "curl_easy_perform() failed: %s\n", curl_easy_strerror(res));
+      }
+      curl_easy_cleanup(curl);
     }
-    curl_easy_cleanup(curl);
   }
 }
 
@@ -1162,20 +1106,23 @@ void CcdbApi::truncate(std::string const& path) const
   CURL* curl;
   CURLcode res;
   stringstream fullUrl;
-  fullUrl << mUrl << "/truncate/" << path;
+  for (int i = 0; i < hostsPool.size(); i++) {
+    string url = getHostUrl(i);
+    fullUrl << url << "/truncate/" << path;
 
-  curl = curl_easy_init();
-  if (curl != nullptr) {
-    curl_easy_setopt(curl, CURLOPT_URL, fullUrl.str().c_str());
+    curl = curl_easy_init();
+    if (curl != nullptr) {
+      curl_easy_setopt(curl, CURLOPT_URL, fullUrl.str().c_str());
 
-    curlSetSSLOptions(curl);
+      curlSetSSLOptions(curl);
 
-    // Perform the request, res will get the return code
-    res = curl_easy_perform(curl);
-    if (res != CURLE_OK) {
-      fprintf(stderr, "curl_easy_perform() failed: %s\n", curl_easy_strerror(res));
+      // Perform the request, res will get the return code
+      res = curl_easy_perform(curl);
+      if (res != CURLE_OK) {
+        fprintf(stderr, "curl_easy_perform() failed: %s\n", curl_easy_strerror(res));
+      }
+      curl_easy_cleanup(curl);
     }
-    curl_easy_cleanup(curl);
   }
 }
 
@@ -1187,16 +1134,18 @@ size_t write_data(void* buffer, size_t size, size_t nmemb, void* userp)
 bool CcdbApi::isHostReachable() const
 {
   CURL* curl;
-  CURLcode res;
+  CURLcode res = CURL_LAST;
   bool result = false;
 
   curl = curl_easy_init();
   if (curl) {
-    curl_easy_setopt(curl, CURLOPT_URL, mUrl.data());
-    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_data);
-    curlSetSSLOptions(curl);
-    res = curl_easy_perform(curl);
-    result = (res == CURLE_OK);
+    for (int hostIndex = 0; hostIndex < hostsPool.size() && res != CURLE_OK; hostIndex++) {
+      curl_easy_setopt(curl, CURLOPT_URL, mUrl.data());
+      curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_data);
+      curlSetSSLOptions(curl);
+      res = curl_easy_perform(curl);
+      result = (res == CURLE_OK);
+    }
 
     /* always cleanup */
     curl_easy_cleanup(curl);
@@ -1243,9 +1192,8 @@ size_t header_callback(char* buffer, size_t size, size_t nitems, void* userdata)
 
 std::map<std::string, std::string> CcdbApi::retrieveHeaders(std::string const& path, std::map<std::string, std::string> const& metadata, long timestamp) const
 {
-
   CURL* curl = curl_easy_init();
-  CURLcode res;
+  CURLcode res = CURL_LAST;
   string fullUrl = getFullUrlForRetrieval(curl, path, metadata, timestamp);
   std::map<std::string, std::string> headers;
 
@@ -1254,7 +1202,7 @@ std::map<std::string, std::string> CcdbApi::retrieveHeaders(std::string const& p
     list = curl_slist_append(list, ("If-None-Match: " + std::to_string(timestamp)).c_str());
 
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, list);
-    curl_easy_setopt(curl, CURLOPT_URL, fullUrl.c_str());
+
     /* get us the resource without a body! */
     curl_easy_setopt(curl, CURLOPT_NOBODY, 1L);
     curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
@@ -1264,16 +1212,23 @@ std::map<std::string, std::string> CcdbApi::retrieveHeaders(std::string const& p
     curlSetSSLOptions(curl);
 
     // Perform the request, res will get the return code
-    res = curl_easy_perform(curl);
-    if (res != CURLE_OK && res != CURLE_UNSUPPORTED_PROTOCOL) {
-      // We take out the unsupported protocol error because we are only querying
-      // header info which is returned in any case. Unsupported protocol error
-      // occurs sometimes because of redirection to alien for blobs.
-      LOG(error) << "curl_easy_perform() failed: " << curl_easy_strerror(res);
+
+    long httpCode = 404;
+    CURLcode getCodeRes = CURL_LAST;
+    for (int hostIndex = 0; hostIndex < hostsPool.size() && (httpCode >= 400 || res > 0 || getCodeRes > 0); hostIndex++) {
+      curl_easy_setopt(curl, CURLOPT_URL, fullUrl.c_str());
+      res = curl_easy_perform(curl);
+      if (res != CURLE_OK && res != CURLE_UNSUPPORTED_PROTOCOL) {
+        // We take out the unsupported protocol error because we are only querying
+        // header info which is returned in any case. Unsupported protocol error
+        // occurs sometimes because of redirection to alien for blobs.
+        LOG(error) << "curl_easy_perform() failed: " << curl_easy_strerror(res);
+      }
+
+      getCodeRes = curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &httpCode);
     }
-    long http_code = 0;
-    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
-    if (http_code == 404) {
+
+    if (httpCode == 404) {
       headers.clear();
     }
 
@@ -1307,7 +1262,7 @@ bool CcdbApi::getCCDBEntryHeaders(std::string const& url, std::string const& eta
 
   /* Perform the request */
   curl_easy_perform(curl);
-  long http_code = 0;
+  long http_code = 404;
   curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
   if (http_code == 304) {
     return false;
@@ -1385,41 +1340,67 @@ TClass* CcdbApi::tinfo2TClass(std::type_info const& tinfo)
 
 void CcdbApi::updateMetadata(std::string const& path, std::map<std::string, std::string> const& metadata, long timestamp, std::string const& id)
 {
-  CURL* curl;
-  CURLcode res;
-  stringstream fullUrl;
-  fullUrl << mUrl << "/" << path << "/" << timestamp;
-  if (!id.empty()) {
-    fullUrl << "/" << id;
-  }
-  fullUrl << "?";
-
-  curl = curl_easy_init();
-
-  for (auto& kv : metadata) {
-    string mfirst = kv.first;
-    string msecond = kv.second;
-    // same trick for the metadata as for the object type
-    char* mfirstEncoded = curl_easy_escape(curl, mfirst.c_str(), mfirst.size());
-    char* msecondEncoded = curl_easy_escape(curl, msecond.c_str(), msecond.size());
-    fullUrl << string(mfirstEncoded) + "=" + string(msecondEncoded) + "&";
-    curl_free(mfirstEncoded);
-    curl_free(msecondEncoded);
-  }
-
+  CURL* curl = curl_easy_init();
   if (curl != nullptr) {
-    curl_easy_setopt(curl, CURLOPT_URL, fullUrl.str().c_str());
-    curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PUT"); // make sure we use PUT
+    CURLcode res;
+    stringstream fullUrl;
+    for (int hostIndex = 0; hostIndex < hostsPool.size(); hostIndex++) {
+      fullUrl << getHostUrl(hostIndex) << "/" << path << "/" << timestamp;
+      if (!id.empty()) {
+        fullUrl << "/" << id;
+      }
+      fullUrl << "?";
 
-    curlSetSSLOptions(curl);
+      for (auto& kv : metadata) {
+        string mfirst = kv.first;
+        string msecond = kv.second;
+        // same trick for the metadata as for the object type
+        char* mfirstEncoded = curl_easy_escape(curl, mfirst.c_str(), mfirst.size());
+        char* msecondEncoded = curl_easy_escape(curl, msecond.c_str(), msecond.size());
+        fullUrl << string(mfirstEncoded) + "=" + string(msecondEncoded) + "&";
+        curl_free(mfirstEncoded);
+        curl_free(msecondEncoded);
+      }
 
-    // Perform the request, res will get the return code
-    res = curl_easy_perform(curl);
-    if (res != CURLE_OK) {
-      fprintf(stderr, "curl_easy_perform() failed: %s\n", curl_easy_strerror(res));
+      if (curl != nullptr) {
+        curl_easy_setopt(curl, CURLOPT_URL, fullUrl.str().c_str());
+        curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PUT"); // make sure we use PUT
+
+        curlSetSSLOptions(curl);
+
+        // Perform the request, res will get the return code
+        res = curl_easy_perform(curl);
+        if (res != CURLE_OK) {
+          fprintf(stderr, "curl_easy_perform() failed: %s\n", curl_easy_strerror(res));
+        }
+        curl_easy_cleanup(curl);
+      }
     }
-    curl_easy_cleanup(curl);
   }
+}
+
+std::vector<std::string> CcdbApi::splitString(std::string string, const char* delimiters)
+{
+  std::vector<std::string> tokens;
+  char* stringForStrTok = new char[string.length() + 1];
+  strcpy(stringForStrTok, string.c_str());
+  char* token = strtok(stringForStrTok, delimiters);
+  while (token != nullptr) {
+    tokens.push_back(token);
+    token = strtok(nullptr, delimiters);
+  }
+  free(stringForStrTok);
+  return tokens;
+}
+
+void CcdbApi::initHostsPool(std::string hosts)
+{
+  hostsPool = splitString(hosts, ",;");
+}
+
+std::string CcdbApi::getHostUrl(int hostIndex) const
+{
+  return hostsPool.at(hostIndex);
 }
 
 } // namespace ccdb

--- a/CCDB/test/testCcdbApi.cxx
+++ b/CCDB/test/testCcdbApi.cxx
@@ -176,6 +176,7 @@ BOOST_AUTO_TEST_CASE(store_retrieve_TMemFile_templated_test, *utf::precondition(
   // std::filesystem does not yet provide boost::filesystem::unique_path() equivalent, and usin tmpnam generate a warning
   auto ph = o2::utils::Str::create_unique_path(std::filesystem::temp_directory_path().native());
   std::filesystem::create_directories(ph);
+  std::cout << "Creating snapshot at " << ph << "\n";
   f.api.snapshot(basePath, ph, o2::ccdb::getCurrentTimestamp());
   std::cout << "Creating snapshot at " << ph << "\n";
 

--- a/CCDB/test/testCcdbApiMultipleUrls.cxx
+++ b/CCDB/test/testCcdbApiMultipleUrls.cxx
@@ -1,0 +1,98 @@
+// Copyright 2019-2021 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE CCDB
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include "CCDB/CcdbApi.h"
+#include "CCDB/CCDBTimeStampUtils.h"
+#include <boost/test/unit_test.hpp>
+#include <cstdio>
+#include <TH1F.h>
+
+using namespace std;
+using namespace o2::ccdb;
+namespace utf = boost::unit_test;
+namespace tt = boost::test_tools;
+
+static string ccdbUrl;
+static string basePath;
+bool hostReachable = false;
+
+/**
+ * Global fixture, ie general setup and teardown
+ */
+struct Fixture {
+  Fixture()
+  {
+    CcdbApi api;
+    ccdbUrl = "https://localhost:22,https://localhost:8080,http://ccdb-test.cern.ch:8080";
+    api.init(ccdbUrl);
+    cout << "ccdb url: " << ccdbUrl << endl;
+    hostReachable = api.isHostReachable();
+    cout << "Is host reachable ? --> " << hostReachable << endl;
+    basePath = string("Test/pid") + getpid() + "/";
+    cout << "Path we will use in this test suite : " + basePath << endl;
+  }
+  ~Fixture()
+  {
+    if (hostReachable) {
+      CcdbApi api;
+      map<string, string> metadata;
+      api.init(ccdbUrl);
+      api.truncate(basePath + "*");
+      cout << "Test data truncated (" << basePath << ")" << endl;
+    }
+  }
+};
+BOOST_GLOBAL_FIXTURE(Fixture);
+
+/**
+ * Just an accessor to the hostReachable variable to be used to determine whether tests can be ran or not.
+ */
+struct if_reachable {
+  tt::assertion_result operator()(utf::test_unit_id)
+  {
+    return hostReachable;
+  }
+};
+
+/**
+ * Fixture for the tests, i.e. code is ran in every test that uses it, i.e. it is like a setup and teardown for tests.
+ */
+struct test_fixture {
+  test_fixture()
+  {
+    api.init(ccdbUrl);
+    metadata["Hello"] = "World";
+    std::cout << "*** " << boost::unit_test::framework::current_test_case().p_name << " ***" << std::endl;
+  }
+  ~test_fixture() = default;
+
+  CcdbApi api;
+  map<string, string> metadata;
+};
+
+BOOST_AUTO_TEST_CASE(storeAndRetrieve, *utf::precondition(if_reachable()))
+{
+  test_fixture f;
+
+  TH1F h1("th1name", "th1name", 100, 0, 99);
+  h1.FillRandom("gaus", 10000);
+  BOOST_CHECK_EQUAL(h1.ClassName(), "TH1F");
+  cout << "ccdb/TObject/TEST" << endl;
+  long timestamp = getCurrentTimestamp();
+  f.api.storeAsTFile(&h1, "ccdb/TObject/TEST", f.metadata, timestamp);
+
+  TObject* returnResult = f.api.retrieve("ccdb/TObject/TEST/" + to_string(timestamp), f.metadata, timestamp);
+  BOOST_CHECK(returnResult != nullptr);
+}

--- a/CCDB/test/testCcdbApiMultipleUrls.cxx
+++ b/CCDB/test/testCcdbApiMultipleUrls.cxx
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 CERN and copyright holders of ALICE O2.
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //


### PR DESCRIPTION
Add hosts pool.

To use hosts pool, string parameter with address should has hosts addresses separated with commas or semicolons.

It is initial implementation, it must be discussed and improved (but preferably in next PRs).

Methods, which behaviour should be discussed:
- delete - for now it iterates over all addresses and delete object everywhere
- truncate - like above
- list - take first response. As I discussed with Costin, it should rather ask all hosts and merge response. Is it correct, or current semantics is fine?

For others methods looping over addresses in case error (currently `404`, change to above `400`?) seems reasonable for me. But please, review it deeply, I am not C++ expert ;).

If you prefer, I can split changes into smaller PRs - just let me know.