### PR TITLE
DPL: make dispatcher lossy

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -47,6 +47,7 @@ o2_add_library(Framework
                        src/DataProcessingDevice.cxx
                        src/DataProcessingHeader.cxx
                        src/DataProcessingHelpers.cxx
+                       src/DataProcessorSpecHelpers.cxx
                        src/DataProcessorMatchers.cxx
                        src/DataRefUtils.cxx
                        src/SourceInfoHeader.cxx

--- a/Framework/Core/include/Framework/DataProcessorSpecHelpers.h
+++ b/Framework/Core/include/Framework/DataProcessorSpecHelpers.h
@@ -1,0 +1,23 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef O2_FRAMEWORK_DATAPROCESSORSPECHELPERS_H_
+#define O2_FRAMEWORK_DATAPROCESSORSPECHELPERS_H_
+
+#include "Framework/DataProcessorSpec.h"
+#include <vector>
+
+namespace o2::framework
+{
+struct DataProcessorSpecHelpers {
+  static bool hasLabel(DataProcessorSpec const& spec, char const* name);
+};
+} // namespace o2::framework
+#endif

--- a/Framework/Core/src/DataProcessorSpecHelpers.cxx
+++ b/Framework/Core/src/DataProcessorSpecHelpers.cxx
@@ -1,0 +1,23 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/DataProcessorSpecHelpers.h"
+#include <string>
+#include <algorithm>
+
+namespace o2::framework
+{
+bool DataProcessorSpecHelpers::hasLabel(DataProcessorSpec const& spec, char const* label)
+{
+  auto sameLabel = [other = DataProcessorLabel{{label}}](DataProcessorLabel const& label) { return label == other; };
+  return std::find_if(spec.labels.begin(), spec.labels.end(), sameLabel) != spec.labels.end();
+}
+} // namespace o2::framework

--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -1387,4 +1387,10 @@ boost::program_options::options_description DeviceSpecHelpers::getForwardedDevic
   return forwardedDeviceOptions;
 }
 
+bool DeviceSpecHelpers::hasLabel(DeviceSpec const& spec, char const* label)
+{
+  auto sameLabel = [other = DataProcessorLabel{{label}}](DataProcessorLabel const& label) { return label == other; };
+  return std::find_if(spec.labels.begin(), spec.labels.end(), sameLabel) != spec.labels.end();
+}
+
 } // namespace o2::framework

--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -1338,12 +1338,12 @@ void DeviceSpecHelpers::prepareArguments(bool defaultQuiet, bool defaultStopped,
     std::ostringstream str;
     for (size_t ai = 0; ai < execution.args.size() - 1; ai++) {
       if (execution.args[ai] == nullptr) {
-        LOG(ERROR) << "Bad argument for " << execution.args[ai - 1];
+        LOG(error) << "Bad argument for " << execution.args[ai - 1];
       }
       assert(execution.args[ai]);
       str << " " << execution.args[ai];
     }
-    LOG(DEBUG) << "The following options are being forwarded to " << spec.id << ":" << str.str();
+    LOG(debug) << "The following options are being forwarded to " << spec.id << ":" << str.str();
   }
 }
 

--- a/Framework/Core/src/DeviceSpecHelpers.h
+++ b/Framework/Core/src/DeviceSpecHelpers.h
@@ -163,6 +163,8 @@ struct DeviceSpecHelpers {
   /// return a description of all options to be forwarded to the device
   /// by default
   static boost::program_options::options_description getForwardedDeviceOptions();
+  /// @return whether a give DeviceSpec @a spec has a label @a label
+  static bool hasLabel(DeviceSpec const& spec, char const* label);
 };
 
 } // namespace o2::framework

--- a/Framework/Core/src/SendingPolicy.cxx
+++ b/Framework/Core/src/SendingPolicy.cxx
@@ -24,7 +24,7 @@ std::vector<SendingPolicy> SendingPolicy::createDefaultPolicies()
   return {SendingPolicy{
             .name = "dispatcher",
             .matcher = [](DeviceSpec const& spec, ConfigContext const& ctx) { return spec.name == "Dispatcher" || DeviceSpecHelpers::hasLabel(spec, "Dispatcher"); },
-            .send = [](FairMQDevice& device, FairMQParts& parts, std::string const& channel) { device.Send(parts, channel, 0, 0); }},
+            .send = [](FairMQDevice& device, FairMQParts& parts, std::string const& channel) { device.Send(parts, channel, 0, -1); }},
           SendingPolicy{
             .name = "default",
             .matcher = [](DeviceSpec const& spec, ConfigContext const& ctx) { return true; },

--- a/Framework/Core/src/SendingPolicy.cxx
+++ b/Framework/Core/src/SendingPolicy.cxx
@@ -24,7 +24,7 @@ std::vector<SendingPolicy> SendingPolicy::createDefaultPolicies()
   return {SendingPolicy{
             .name = "dispatcher",
             .matcher = [](DeviceSpec const& spec, ConfigContext const& ctx) { return spec.name == "Dispatcher" || DeviceSpecHelpers::hasLabel(spec, "Dispatcher"); },
-            .send = [](FairMQDevice& device, FairMQParts& parts, std::string const& channel) { device.Send(parts, channel, 0, 0); }},
+            .send = [](FairMQDevice& device, FairMQParts& parts, std::string const& channel) { device.Send(parts, channel, 0, 1); }},
           SendingPolicy{
             .name = "default",
             .matcher = [](DeviceSpec const& spec, ConfigContext const& ctx) { return true; },

--- a/Framework/Core/src/SendingPolicy.cxx
+++ b/Framework/Core/src/SendingPolicy.cxx
@@ -10,6 +10,8 @@
 // or submit itself to any jurisdiction.
 
 #include "Framework/SendingPolicy.h"
+#include "Framework/DeviceSpec.h"
+#include "DeviceSpecHelpers.h"
 #include <fairmq/Device.h>
 
 #pragma GCC diagnostic push
@@ -20,8 +22,12 @@ namespace o2::framework
 std::vector<SendingPolicy> SendingPolicy::createDefaultPolicies()
 {
   return {SendingPolicy{
-    .name = "default",
-    .matcher = [](DeviceSpec const& spec, ConfigContext const& ctx) { return true; },
-    .send = [](FairMQDevice& device, FairMQParts& parts, std::string const& channel) { device.Send(parts, channel, 0); }}};
+            .name = "dispatcher",
+            .matcher = [](DeviceSpec const& spec, ConfigContext const& ctx) { return spec.name == "Dispatcher" || DeviceSpecHelpers::hasLabel(spec, "Dispatcher"); },
+            .send = [](FairMQDevice& device, FairMQParts& parts, std::string const& channel) { device.Send(parts, channel, 0, 0); }},
+          SendingPolicy{
+            .name = "default",
+            .matcher = [](DeviceSpec const& spec, ConfigContext const& ctx) { return true; },
+            .send = [](FairMQDevice& device, FairMQParts& parts, std::string const& channel) { device.Send(parts, channel, 0); }}};
 }
 } // namespace o2::framework

--- a/Framework/Core/src/SendingPolicy.cxx
+++ b/Framework/Core/src/SendingPolicy.cxx
@@ -24,7 +24,7 @@ std::vector<SendingPolicy> SendingPolicy::createDefaultPolicies()
   return {SendingPolicy{
             .name = "dispatcher",
             .matcher = [](DeviceSpec const& spec, ConfigContext const& ctx) { return spec.name == "Dispatcher" || DeviceSpecHelpers::hasLabel(spec, "Dispatcher"); },
-            .send = [](FairMQDevice& device, FairMQParts& parts, std::string const& channel) { device.Send(parts, channel, 0, 1); }},
+            .send = [](FairMQDevice& device, FairMQParts& parts, std::string const& channel) { device.Send(parts, channel, 0, 0); }},
           SendingPolicy{
             .name = "default",
             .matcher = [](DeviceSpec const& spec, ConfigContext const& ctx) { return true; },

--- a/Framework/Core/test/test_DataProcessorSpec.cxx
+++ b/Framework/Core/test/test_DataProcessorSpec.cxx
@@ -15,21 +15,29 @@
 
 #include <boost/test/unit_test.hpp>
 #include "Framework/DataProcessorSpec.h"
+#include "Framework/DataProcessorSpecHelpers.h"
+#include "Framework/ConfigParamSpec.h"
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 
 BOOST_AUTO_TEST_CASE(TestServiceRegistry)
 {
   using namespace o2::framework;
-  DataProcessorSpec spec{"test",
-                         {},
-                         {},
-                         AlgorithmSpec{[](ProcessingContext& ctx) {}},
-                         {ConfigParamSpec{
+  DataProcessorSpec spec{.name = "test",
+                         .algorithm = AlgorithmSpec{[](ProcessingContext& ctx) {}},
+                         .options = {ConfigParamSpec{
                            "channel-config",
                            VariantType::String,
                            "name=foo,type=sub,method=connect,address=tcp://localhost:5450,rateLogging=1",
                            {"Out-of-band channel config"}}},
-                         {},
-                         {DataProcessorLabel{"label"}}};
+                         .labels = {DataProcessorLabel{"label"},
+                                    DataProcessorLabel{"label3"}}};
 
-  BOOST_CHECK_EQUAL(spec.labels.size(), 1);
+  BOOST_CHECK_EQUAL(spec.labels.size(), 2);
+  BOOST_CHECK_EQUAL(DataProcessorSpecHelpers::hasLabel(spec, "label"), true);
+  BOOST_CHECK_EQUAL(DataProcessorSpecHelpers::hasLabel(spec, "label2"), false);
+  BOOST_CHECK_EQUAL(DataProcessorSpecHelpers::hasLabel(spec, "label3"), true);
 }
+
+#pragma diagnostic pop


### PR DESCRIPTION
This makes the QC dispatcher drop data if the receiving side is not
ready to process them, avoiding building backpressure. Notice
that this also depends on the length of the message queues in FairMQ,
which by default is 4 (which could be already too much) and which
can be user customized.