### PR TITLE
MCH: add first version of digit filtering

### DIFF
--- a/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h
+++ b/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h
@@ -36,6 +36,7 @@ class Digit
   ~Digit() = default;
 
   bool operator==(const Digit&) const;
+  bool operator<(const Digit&) const;
 
   // time in bunch crossing units, relative to the beginning of the TimeFrame
   void setTime(int32_t t) { mTFtime = t; }

--- a/DataFormats/Detectors/MUON/MCH/src/Digit.cxx
+++ b/DataFormats/Detectors/MUON/MCH/src/Digit.cxx
@@ -77,8 +77,9 @@ bool Digit::operator<(const Digit& other) const
         if (mADC == other.mADC) {
           if (mNofSamples == other.mNofSamples) {
             return mIsSaturated != other.mIsSaturated;
-          } else
+          } else {
             return mNofSamples < other.mNofSamples;
+          }
         } else {
           return mADC < other.mADC;
         }

--- a/DataFormats/Detectors/MUON/MCH/src/Digit.cxx
+++ b/DataFormats/Detectors/MUON/MCH/src/Digit.cxx
@@ -69,4 +69,28 @@ bool Digit::operator==(const Digit& other) const
          mNofSamples == other.mNofSamples;
 }
 
+bool Digit::operator<(const Digit& other) const
+{
+  if (mDetID == other.mDetID) {
+    if (mPadID == other.mPadID) {
+      if (mTFtime == other.mTFtime) {
+        if (mADC == other.mADC) {
+          if (mNofSamples == other.mNofSamples) {
+            return mIsSaturated != other.mIsSaturated;
+          } else
+            return mNofSamples < other.mNofSamples;
+        } else {
+          return mADC < other.mADC;
+        }
+      } else {
+        return mTFtime < other.mTFtime;
+      }
+    } else {
+      return mPadID < other.mPadID;
+    }
+  } else {
+    return mDetID < other.mDetID;
+  }
+}
+
 } // namespace o2::mch

--- a/Detectors/MUON/MCH/Workflow/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Workflow/CMakeLists.txt
@@ -19,6 +19,7 @@ o2_add_library(MCHWorkflow
                    src/EntropyDecoderSpec.cxx
                    src/TimeClusterFinderSpec.cxx
                    src/PreClusterFinderSpec.cxx
+                   src/SanityCheck.cxx
                    src/TrackReaderSpec.cxx
                    src/TrackTreeReader.cxx
                    src/TrackWriterSpec.cxx
@@ -74,6 +75,12 @@ o2_add_executable(
         PUBLIC_LINK_LIBRARIES O2::MCHWorkflow)
 
 o2_add_executable(
+        digits-filtering-workflow
+        SOURCES src/digits-filtering-workflow.cxx src/DigitFilteringSpec.cxx src/SanityCheck.cxx
+        COMPONENT_NAME mch
+        PUBLIC_LINK_LIBRARIES O2::Framework O2::MCHBase O2::SimulationDataFormat)
+
+o2_add_executable(
         digits-to-preclusters-workflow
         SOURCES src/digits-to-preclusters-workflow.cxx
         COMPONENT_NAME mch
@@ -101,7 +108,7 @@ o2_add_executable(
         preclusters-to-clusters-original-workflow
         SOURCES src/preclusters-to-clusters-original-workflow.cxx
         COMPONENT_NAME mch
-        PUBLIC_LINK_LIBRARIES O2::MCHWorkflow)
+        PUBLIC_LINK_LIBRARIES O2::MCHWorkflow O2::MCHClustering)
 
 o2_add_executable(
         clusters-sink-workflow
@@ -135,7 +142,7 @@ o2_add_executable(
 
 o2_add_executable(
         clusters-to-tracks-workflow
-        SOURCES src/TrackFinderSpec.cxx src/clusters-to-tracks-workflow.cxx
+        SOURCES src/TrackFinderSpec.cxx src/clusters-to-tracks-workflow.cxx src/SanityCheck.cxx
         COMPONENT_NAME mch
         PUBLIC_LINK_LIBRARIES O2::DataFormatsParameters O2::Framework O2::DataFormatsMCH O2::MCHTracking O2::DataFormatsParameters)
 
@@ -202,6 +209,7 @@ o2_add_executable(
         reco-workflow
         SOURCES
             src/ClusterTransformerSpec.cxx
+            src/DigitFilteringSpec.cxx
             src/DigitReaderSpec.cxx
             src/TrackAtVertexSpec.cxx
             src/TrackFinderSpec.cxx
@@ -232,5 +240,4 @@ o2_add_executable(rofs-histogrammer
         SOURCES src/rofs-histogrammer.cxx
         COMPONENT_NAME mch
         PUBLIC_LINK_LIBRARIES O2::Framework O2::DataFormatsMCH)
-
 

--- a/Detectors/MUON/MCH/Workflow/README.md
+++ b/Detectors/MUON/MCH/Workflow/README.md
@@ -8,6 +8,7 @@
 
 * [A note for developers](#a-note-for-developers)
 * [Raw to digits](#raw-to-digits)
+* [Digit filtering](#digit-filtering)
 * [Time clustering](#time-clustering)
 * [Preclustering](#preclustering)
 * [Clustering](#clustering)
@@ -76,6 +77,23 @@ dataOrigin = MCH
 dataDescription = RAWDATA
 filePath = /home/data/data-de819-ped-raw.raw
 ```
+
+## Digit filtering
+
+```shell
+o2-mch-digits-filtering-workflow
+```
+
+Filter out some digits. For the moment only removes digits that have a null ADC.
+
+Inputs :
+- list of all digits ([Digit](/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h)) in the current time frame, with the (default) data description `DIGITS` (can be changed with `--input-digits-data-description` option)
+- the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the digits associated to each interaction, with the (default) data description `DIGITROFS` (can be changed with `--input-digit-rofs-data-description` option)
+
+Outputs :
+- list of digits that pass the filtering criteria (for the moment ADC>0), with the (default) data description `F-DIGITS`  (can be changed with `--output-digits-data-description` option)
+- list of ROF records corresponding to the digits above, with a (default) data description of `F-DIGITROFS` (can be changed with `--output-digit-rofs-data-description` option) (can be changed with `--output-digit-rofs-data-description` option)
+
 
 ## Time clustering
 

--- a/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/PreClusterFinderSpec.h
+++ b/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/PreClusterFinderSpec.h
@@ -26,7 +26,8 @@ namespace mch
 
 o2::framework::DataProcessorSpec
   getPreClusterFinderSpec(const char* specName = "PreClusterFinder",
-                          const char* digitRofDataDescription = "DIGITROFS");
+                          std::string_view inputDigitDataDescription = "F-DIGITS",
+                          std::string_view inputDigitRofDataDescription = "TC-F-DIGITROFS");
 
 } // end namespace mch
 } // end namespace o2

--- a/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/TimeClusterFinderSpec.h
+++ b/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/TimeClusterFinderSpec.h
@@ -24,7 +24,10 @@ namespace o2
 namespace mch
 {
 
-o2::framework::DataProcessorSpec getTimeClusterFinderSpec(const char* specName = "mch-time-cluster-finder");
+o2::framework::DataProcessorSpec
+  getTimeClusterFinderSpec(const char* specName = "mch-time-cluster-finder",
+                           std::string_view inputDigitRofDataDescription = "F-DIGITROFS",
+                           std::string_view outputDigitRofDataDescription = "TC-F-DIGITROFS");
 
 } // end namespace mch
 } // end namespace o2

--- a/Detectors/MUON/MCH/Workflow/src/DigitFilteringSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/DigitFilteringSpec.cxx
@@ -1,0 +1,167 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "DigitFilteringSpec.h"
+
+#include "DataFormatsMCH/Digit.h"
+#include "DataFormatsMCH/ROFRecord.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/DataSpecUtils.h"
+#include "Framework/Logger.h"
+#include "Framework/OutputSpec.h"
+#include "Framework/Task.h"
+#include "Framework/WorkflowSpec.h"
+#include "SanityCheck.h"
+#include "SimulationDataFormat/MCCompLabel.h"
+#include "SimulationDataFormat/MCTruthContainer.h"
+#include <fmt/format.h>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace o2::dataformats;
+using namespace o2::framework;
+
+namespace o2::mch
+{
+class DigitFilteringTask
+{
+ public:
+  DigitFilteringTask(bool useMC) : mUseMC{useMC} {}
+
+  void init(InitContext& ic)
+  {
+    mSanityCheck = ic.options().get<bool>("sanity-check");
+    mMinADC = ic.options().get<int>("min-adc-value");
+  }
+
+  bool isGoodDigit(const Digit& digit) const
+  {
+    return digit.getADC() > mMinADC;
+  }
+
+  void run(ProcessingContext& pc)
+  {
+    // get input
+    auto iRofs = pc.inputs().get<gsl::span<ROFRecord>>("rofs");
+    auto iDigits = pc.inputs().get<gsl::span<Digit>>("digits");
+    auto iLabels = mUseMC ? pc.inputs().get<MCTruthContainer<MCCompLabel>*>("labels") : nullptr;
+
+    bool abort{false};
+
+    if (mSanityCheck) {
+      auto error = sanityCheck(iRofs, iDigits);
+
+      if (!isOK(error)) {
+        if (error.nofOutOfBounds > 0) {
+          LOGP(error, asString(error));
+          LOGP(error, "in a TF with {} rofs and {} digits", iRofs.size(), iDigits.size());
+          abort = true;
+        }
+      }
+    }
+
+    // create the output messages
+    auto& oRofs = pc.outputs().make<std::vector<ROFRecord>>(OutputRef{"rofs"});
+    auto& oDigits = pc.outputs().make<std::vector<Digit>>(OutputRef{"digits"});
+    auto oLabels = mUseMC ? &pc.outputs().make<MCTruthContainer<MCCompLabel>>(OutputRef{"labels"}) : nullptr;
+
+    if (!abort) {
+      int cursor{0};
+      for (auto i = 0; i < iRofs.size(); i++) {
+        const ROFRecord& irof = iRofs[i];
+
+        const auto digits = iDigits.subspan(irof.getFirstIdx(), irof.getNEntries());
+
+        // filter the digits from the current ROF
+        for (auto i = 0; i < digits.size(); i++) {
+          const auto& d = digits[i];
+          if (isGoodDigit(d)) {
+            oDigits.emplace_back(d);
+            if (iLabels) {
+              oLabels->addElements(oLabels->getIndexedSize(), iLabels->getLabels(i));
+            }
+          }
+        }
+        int nofGoodDigits = oDigits.size() - cursor;
+        if (nofGoodDigits > 0) {
+          // we create an ouput ROF only if at least one digit from
+          // the input ROF passed the filtering
+          oRofs.emplace_back(ROFRecord(irof.getBCData(),
+                                       cursor,
+                                       nofGoodDigits,
+                                       irof.getBCWidth()));
+          cursor += nofGoodDigits;
+        }
+      }
+    }
+
+    auto labelMsg = mUseMC ? fmt::format("| {} labels (out of {})", oLabels->getNElements(), iLabels->getNElements()) : "";
+
+    LOGP(info, "Kept after filtering : {} rofs (out of {}) | {} digits (out of {}) {}\n",
+         oRofs.size(), iRofs.size(),
+         oDigits.size(), iDigits.size(),
+         labelMsg);
+
+    if (abort) {
+      LOGP(error, "Sanity check failed");
+    }
+  }
+
+ private:
+  bool mSanityCheck;
+  bool mUseMC;
+  int mMinADC;
+};
+
+framework::DataProcessorSpec
+  getDigitFilteringSpec(bool useMC,
+                        std::string_view specName,
+                        std::string_view inputDigitDataDescription,
+                        std::string_view outputDigitDataDescription,
+                        std::string_view inputDigitRofDataDescription,
+                        std::string_view outputDigitRofDataDescription,
+                        std::string_view inputDigitLabelDataDescription,
+                        std::string_view outputDigitLabelDataDescription)
+
+{
+  std::string input =
+    fmt::format("digits:MCH/{}/0;rofs:MCH/{}/0",
+                inputDigitDataDescription,
+                inputDigitRofDataDescription);
+  if (useMC) {
+    input += fmt::format(";labels:MCH/{}/0", inputDigitLabelDataDescription);
+  }
+
+  std::string output =
+    fmt::format("digits:MCH/{}/0;rofs:MCH/{}/0",
+                outputDigitDataDescription,
+                outputDigitRofDataDescription);
+  if (useMC) {
+    output += fmt::format(";labels:MCH/{}/0", outputDigitLabelDataDescription);
+  }
+
+  std::vector<OutputSpec> outputs;
+  auto matchers = select(output.c_str());
+  for (auto& matcher : matchers) {
+    outputs.emplace_back(DataSpecUtils::asOutputSpec(matcher));
+  }
+
+  return DataProcessorSpec{
+    specName.data(),
+    Inputs{select(input.c_str())},
+    outputs,
+    AlgorithmSpec{adaptFromTask<DigitFilteringTask>(useMC)},
+    Options{
+      {"sanity-check", VariantType::Bool, false, {"perform a few sanity checks on input digits"}},
+      {"min-adc-value", VariantType::Int, 1, {"minumum ADC value to consider"}}}};
+}
+} // namespace o2::mch

--- a/Detectors/MUON/MCH/Workflow/src/DigitFilteringSpec.h
+++ b/Detectors/MUON/MCH/Workflow/src/DigitFilteringSpec.h
@@ -9,27 +9,24 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file TrackMCLabelFinderSpec.h
-/// \brief Definition of a data processor to match the reconstructed tracks with the simulated ones
-///
-/// \author Philippe Pillot, Subatech
-
-#ifndef O2_MCH_TRACKMCLABELFINDERSPEC_H_
-#define O2_MCH_TRACKMCLABELFINDERSPEC_H_
+#ifndef O2_MCH_DIGIT_FILTERING_SPEC_H
+#define O2_MCH_DIGIT_FILTERING_SPEC_H
 
 #include "Framework/DataProcessorSpec.h"
 
-namespace o2
-{
-namespace mch
+namespace o2::mch
 {
 
 o2::framework::DataProcessorSpec
-  getTrackMCLabelFinderSpec(const char* specName = "TrackMCLabelFinder",
-                            const char* digitRofDataDescription = "DIGITROFS",
-                            const char* digitLabelDataDescription = "DIGITLABELS");
+  getDigitFilteringSpec(
+    bool useMC,
+    std::string_view specName = "mch-digit-filtering",
+    std::string_view inputDigitDataDescription = "DIGITS",
+    std::string_view outputDigitDataDescription = "F-DIGITS",
+    std::string_view inputDigitRofDataDescription = "DIGITROFS",
+    std::string_view outputDigitRofDataDescription = "F-DIGITROFS",
+    std::string_view inputDigitLabelDataDescription = "DIGITLABELS",
+    std::string_view outputDigitLabelDataDescription = "F-DIGITLABELS");
 
-} // end namespace mch
-} // end namespace o2
-
-#endif // O2_MCH_TRACKMCLABELFINDERSPEC_H_
+}
+#endif

--- a/Detectors/MUON/MCH/Workflow/src/PreClusterFinderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/PreClusterFinderSpec.cxx
@@ -35,9 +35,13 @@
 #include "Framework/WorkflowSpec.h"
 
 #include "DataFormatsMCH/ROFRecord.h"
-#include "DataFormatsMCH/Digit.h"
 #include "MCHBase/PreCluster.h"
 #include "MCHPreClustering/PreClusterFinder.h"
+#include "SanityCheck.h"
+
+#include <iostream>
+#include <chrono>
+#include <vector>
 
 namespace o2
 {
@@ -89,6 +93,7 @@ class PreClusterFinderTask
     }
     mDiscardHighOccDEs = ic.options().get<bool>("discard-high-occupancy-des");
     mDiscardHighOccEvents = ic.options().get<bool>("discard-high-occupancy-events");
+    mSanityCheck = ic.options().get<bool>("sanity-check");
   }
 
   //_________________________________________________________________________________________________
@@ -100,74 +105,94 @@ class PreClusterFinderTask
     auto digitROFs = pc.inputs().get<gsl::span<ROFRecord>>("digitrofs");
     auto digits = pc.inputs().get<gsl::span<Digit>>("digits");
 
-    //LOG(INFO) << "received time frame with " << digitROFs.size() << " interactions";
+    bool abort{false};
+    if (mSanityCheck) {
+      auto error = sanityCheck(digitROFs, digits);
+
+      if (!isOK(error)) {
+        if (error.nofOutOfBounds > 0) {
+          // FIXME: replace this error log with a counters' message ?
+          LOGP(error, asString(error));
+          LOGP(error, "in a TF with {} rofs and {} digits", digitROFs.size(), digits.size());
+          abort = true;
+        }
+      }
+    }
 
     // create the output message for precluster ROFs
     auto& preClusterROFs = pc.outputs().make<std::vector<ROFRecord>>(OutputRef{"preclusterrofs"});
-    preClusterROFs.reserve(digitROFs.size());
 
     // prepare to receive new data
     mPreClusters.clear();
     mUsedDigits.clear();
-    mUsedDigits.reserve(digits.size());
-    int nRemovedDigits(0);
 
-    for (const auto& digitROF : digitROFs) {
+    if (!abort) {
 
-      //LOG(INFO) << "processing interaction: " << digitROF.getBCData() << "...";
+      preClusterROFs.reserve(digitROFs.size());
+      mUsedDigits.reserve(digits.size());
+      int nRemovedDigits(0);
 
-      // prepare to receive new data
-      auto tStart = std::chrono::high_resolution_clock::now();
-      mPreClusterFinder.reset();
-      auto tEnd = std::chrono::high_resolution_clock::now();
-      mTimeResetPreClusterFinder += tEnd - tStart;
+      for (const auto& digitROF : digitROFs) {
 
-      // load the digits to get the fired pads
-      tStart = std::chrono::high_resolution_clock::now();
-      mPreClusterFinder.loadDigits(digits.subspan(digitROF.getFirstIdx(), digitROF.getNEntries()));
-      tEnd = std::chrono::high_resolution_clock::now();
-      mTimeLoadDigits += tEnd - tStart;
+        // prepare to receive new data
+        auto tStart = std::chrono::high_resolution_clock::now();
+        mPreClusterFinder.reset();
+        auto tEnd = std::chrono::high_resolution_clock::now();
+        mTimeResetPreClusterFinder += tEnd - tStart;
 
-      // discard high-occupancy (noisy) DEs and/or events
-      tStart = std::chrono::high_resolution_clock::now();
-      nRemovedDigits += mPreClusterFinder.discardHighOccupancy(mDiscardHighOccDEs, mDiscardHighOccEvents);
-      tEnd = std::chrono::high_resolution_clock::now();
-      mTimeDiscardHighOccupancy += tEnd - tStart;
+        // load the digits to get the fired pads
+        tStart = std::chrono::high_resolution_clock::now();
+        mPreClusterFinder.loadDigits(digits.subspan(digitROF.getFirstIdx(), digitROF.getNEntries()));
+        tEnd = std::chrono::high_resolution_clock::now();
+        mTimeLoadDigits += tEnd - tStart;
 
-      // preclusterize
-      tStart = std::chrono::high_resolution_clock::now();
-      int nPreClusters = mPreClusterFinder.run();
-      tEnd = std::chrono::high_resolution_clock::now();
-      mTimePreClusterFinder += tEnd - tStart;
+        // discard high-occupancy (noisy) DEs and/or events
+        tStart = std::chrono::high_resolution_clock::now();
+        nRemovedDigits += mPreClusterFinder.discardHighOccupancy(mDiscardHighOccDEs, mDiscardHighOccEvents);
+        tEnd = std::chrono::high_resolution_clock::now();
+        mTimeDiscardHighOccupancy += tEnd - tStart;
 
-      // get the preclusters and associated digits
-      tStart = std::chrono::high_resolution_clock::now();
-      preClusterROFs.emplace_back(digitROF.getBCData(), mPreClusters.size(), nPreClusters, digitROF.getBCWidth());
-      mPreClusterFinder.getPreClusters(mPreClusters, mUsedDigits);
-      tEnd = std::chrono::high_resolution_clock::now();
-      mTimeStorePreClusters += tEnd - tStart;
+        // preclusterize
+        tStart = std::chrono::high_resolution_clock::now();
+        int nPreClusters = mPreClusterFinder.run();
+        tEnd = std::chrono::high_resolution_clock::now();
+        mTimePreClusterFinder += tEnd - tStart;
+
+        // get the preclusters and associated digits
+        tStart = std::chrono::high_resolution_clock::now();
+        preClusterROFs.emplace_back(digitROF.getBCData(), mPreClusters.size(), nPreClusters, digitROF.getBCWidth());
+        mPreClusterFinder.getPreClusters(mPreClusters, mUsedDigits);
+        tEnd = std::chrono::high_resolution_clock::now();
+        mTimeStorePreClusters += tEnd - tStart;
+      }
+
+      // check sizes of input and output digits vectors
+      bool digitsSizesDiffer = (nRemovedDigits + mUsedDigits.size() != digits.size());
+      switch (mCheckNoLeftoverDigits) {
+        case CHECK_NO_LEFTOVER_DIGITS_OFF:
+          break;
+        case CHECK_NO_LEFTOVER_DIGITS_ERROR:
+          if (digitsSizesDiffer) {
+            LOG(ERROR) << "some digits have been lost during the preclustering";
+          }
+          break;
+        case CHECK_NO_LEFTOVER_DIGITS_FATAL:
+          if (digitsSizesDiffer) {
+            throw runtime_error("some digits have been lost during the preclustering");
+          }
+          break;
+      };
     }
-
-    // check sizes of input and output digits vectors
-    bool digitsSizesDiffer = (nRemovedDigits + mUsedDigits.size() != digits.size());
-    switch (mCheckNoLeftoverDigits) {
-      case CHECK_NO_LEFTOVER_DIGITS_OFF:
-        break;
-      case CHECK_NO_LEFTOVER_DIGITS_ERROR:
-        if (digitsSizesDiffer) {
-          LOG(ERROR) << "some digits have been lost during the preclustering";
-        }
-        break;
-      case CHECK_NO_LEFTOVER_DIGITS_FATAL:
-        if (digitsSizesDiffer) {
-          throw runtime_error("some digits have been lost during the preclustering");
-        }
-        break;
-    };
 
     // create the output messages for preclusters and associated digits
     pc.outputs().snapshot(OutputRef{"preclusters"}, mPreClusters);
     pc.outputs().snapshot(OutputRef{"preclusterdigits"}, mUsedDigits);
+
+    LOGP(info, "Processed {} digit rofs with {} digits and output {} precluster rofs with {} preclusters and {} digits",
+         digitROFs.size(),
+         digits.size(),
+         preClusterROFs.size(),
+         mPreClusters.size(), mUsedDigits.size());
   }
 
  private:
@@ -175,10 +200,10 @@ class PreClusterFinderTask
   std::vector<PreCluster> mPreClusters{}; ///< vector of preclusters
   std::vector<Digit> mUsedDigits{};       ///< vector of digits in the preclusters
 
-  int mCheckNoLeftoverDigits{CHECK_NO_LEFTOVER_DIGITS_ERROR}; ///< digits vector size check option
-  bool mDiscardHighOccDEs = false;                            ///< discard DEs with occupancy > 20%
-  bool mDiscardHighOccEvents = false;                         ///< discard events with >= 5 DEs above 20% occupancy
-
+  int mCheckNoLeftoverDigits{CHECK_NO_LEFTOVER_DIGITS_ERROR};             ///< digits vector size check option
+  bool mDiscardHighOccDEs = false;                                        ///< discard DEs with occupancy > 20%
+  bool mDiscardHighOccEvents = false;                                     ///< discard events with >= 5 DEs above 20% occupancy
+  bool mSanityCheck = false;                                              ///< perform some input digit sanity checks
   std::chrono::duration<double, std::milli> mTimeResetPreClusterFinder{}; ///< timer
   std::chrono::duration<double, std::milli> mTimeLoadDigits{};            ///< timer
   std::chrono::duration<double, std::milli> mTimeDiscardHighOccupancy{};  ///< timer
@@ -188,12 +213,15 @@ class PreClusterFinderTask
 
 //_________________________________________________________________________________________________
 o2::framework::DataProcessorSpec getPreClusterFinderSpec(const char* specName,
-                                                         const char* digitRofDataDescription)
+                                                         std::string_view inputDigitDataDescription,
+                                                         std::string_view inputDigitRofDataDescription)
 {
-  std::string input = "digits:MCH/DIGITS/0;";
-  input += fmt::format("digitrofs:MCH/{}/0", digitRofDataDescription);
-
+  std::string input =
+    fmt::format("digits:MCH/{}/0;digitrofs:MCH/{}/0",
+                inputDigitDataDescription,
+                inputDigitRofDataDescription);
   std::string helpstr = "[off/error/fatal] check that all digits are included in pre-clusters";
+
   return DataProcessorSpec{
     specName,
     o2::framework::select(input.c_str()),
@@ -202,6 +230,7 @@ o2::framework::DataProcessorSpec getPreClusterFinderSpec(const char* specName,
             OutputSpec{{"preclusterdigits"}, "MCH", "PRECLUSTERDIGITS", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<PreClusterFinderTask>()},
     Options{{"check-no-leftover-digits", VariantType::String, "error", {helpstr}},
+            {{"sanity-check"}, VariantType::Bool, false, {"perform some input digit sanity checks"}},
             {"discard-high-occupancy-des", VariantType::Bool, false, {"discard DEs with occupancy > 20%"}},
             {"discard-high-occupancy-events", VariantType::Bool, false, {"discard events with >= 5 DEs above 20% occupancy"}}}};
 }

--- a/Detectors/MUON/MCH/Workflow/src/SanityCheck.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/SanityCheck.cxx
@@ -1,0 +1,31 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "SanityCheck.h"
+#include <fmt/core.h>
+
+namespace o2::mch
+{
+
+bool isOK(const SanityError& error)
+{
+  return error.nofDuplicatedIndices == 0 &&
+         error.nofDuplicatedItems == 0 &&
+         error.nofMissingItems == 0 &&
+         error.nofOutOfBounds == 0;
+}
+
+std::string asString(const SanityError& error)
+{
+  return fmt::format("error counts : {} duplicated items {} missing items {} out-of-bounds index {} duplicated index", error.nofDuplicatedItems, error.nofMissingItems, error.nofOutOfBounds, error.nofDuplicatedIndices);
+}
+
+} // namespace o2::mch

--- a/Detectors/MUON/MCH/Workflow/src/SanityCheck.h
+++ b/Detectors/MUON/MCH/Workflow/src/SanityCheck.h
@@ -1,0 +1,83 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "DataFormatsMCH/ROFRecord.h"
+#include "Framework/Logger.h"
+#include <gsl/span>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace o2::mch
+{
+struct Pad {
+  int detId;
+  int padId;
+
+  bool operator<(const Pad& other) const
+  {
+    if (detId == other.detId) {
+      return padId < other.padId;
+    }
+    return detId < other.detId;
+  }
+};
+
+struct SanityError {
+  uint32_t nofDuplicatedItems{0};
+  uint32_t nofDuplicatedIndices{0};
+  uint32_t nofMissingItems{0};
+  uint32_t nofOutOfBounds{0};
+};
+
+bool isOK(const SanityError& error);
+std::string asString(const SanityError& error);
+
+template <typename T>
+SanityError sanityCheck(gsl::span<const ROFRecord> rofs, gsl::span<const T> items)
+{
+  // check that :
+  // - all items indices are used in rofs
+  // - each item is referenced only once
+  // - all indices used in rofs are inbound of items.size()
+
+  SanityError error;
+
+  std::vector<int> indices;
+  indices.resize(items.size());
+
+  for (const auto& r : rofs) {
+    std::map<T, int> itemMap;
+    for (auto i = r.getFirstIdx(); i <= r.getLastIdx(); i++) {
+      if (i >= items.size()) {
+        error.nofOutOfBounds++;
+        continue;
+      }
+      indices[i]++;
+      const auto& item = items[i];
+      itemMap[item]++;
+    }
+    if (itemMap.size() != r.getNEntries()) {
+      error.nofDuplicatedItems += (r.getNEntries() - itemMap.size());
+    }
+  }
+  for (auto i = 0; i < indices.size(); i++) {
+    if (indices[i] == 0) {
+      error.nofMissingItems++;
+    }
+    if (indices[i] > 1) {
+      error.nofDuplicatedIndices++;
+    }
+  }
+
+  return error;
+}
+} // namespace o2::mch

--- a/Detectors/MUON/MCH/Workflow/src/TrackMCLabelFinderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackMCLabelFinderSpec.cxx
@@ -182,13 +182,14 @@ class TrackMCLabelFinderTask
 
 //_________________________________________________________________________________________________
 o2::framework::DataProcessorSpec getTrackMCLabelFinderSpec(const char* specName,
-                                                           const char* digitRofDataDescription)
+                                                           const char* digitRofDataDescription,
+                                                           const char* digitLabelDataDescription)
 {
   std::string input =
-    fmt::format("digitrofs:MCH/{}/0;", digitRofDataDescription);
+    fmt::format("digitrofs:MCH/{}/0;digitlabels:MCH/{}/0", digitRofDataDescription,
+                digitLabelDataDescription);
   input +=
-    "digitlabels:MCH/DIGITLABELS/0;"
-    "trackrofs:MCH/TRACKROFS/0;"
+    ";trackrofs:MCH/TRACKROFS/0;"
     "tracks:MCH/TRACKS/0;"
     "clusters:MCH/TRACKCLUSTERS/0";
   return DataProcessorSpec{

--- a/Detectors/MUON/MCH/Workflow/src/digits-filtering-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/digits-filtering-workflow.cxx
@@ -1,0 +1,48 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/CallbackService.h"
+#include "Framework/ControlService.h"
+#include "Framework/Task.h"
+#include "DigitFilteringSpec.h"
+
+using namespace o2;
+using namespace o2::framework;
+
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  workflowOptions.push_back(ConfigParamSpec{"input-digits-data-description", VariantType::String, "DIGITS", {"description string for the input digits data"}});
+  workflowOptions.push_back(ConfigParamSpec{"output-digits-data-description", VariantType::String, "F-DIGITS", {"description string for the output digits data"}});
+  workflowOptions.push_back(ConfigParamSpec{"input-digitrofs-data-description", VariantType::String, "DIGITROFS", {"description string for the input digit rofs data"}});
+  workflowOptions.push_back(ConfigParamSpec{"output-digitrofs-data-description", VariantType::String, "F-DIGITROFS", {"description string for the output digit rofs data"}});
+  workflowOptions.push_back(ConfigParamSpec{"input-digitlabels-data-description", VariantType::String, "DIGITLABELS", {"description string for the input digit labels data (not used if disable-mc is true)"}});
+  workflowOptions.push_back(ConfigParamSpec{"output-digitlabels-data-description", VariantType::String, "F-DIGITLABELS", {"description string for the output digit labels data (not used if disable-mc is true)"}});
+  workflowOptions.push_back(ConfigParamSpec{"disable-mc", VariantType::Bool, false, {"Do not propagate MC info"}});
+}
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(const ConfigContext& cc)
+{
+  WorkflowSpec wf;
+
+  wf.emplace_back(o2::mch::getDigitFilteringSpec(
+    not cc.options().get<bool>("disable-mc"),
+    "mch-digits-filtering",
+    cc.options().get<std::string>("input-digits-data-description"),
+    cc.options().get<std::string>("output-digits-data-description"),
+    cc.options().get<std::string>("input-digitrofs-data-description"),
+    cc.options().get<std::string>("output-digitrofs-data-description"),
+    cc.options().get<std::string>("input-digitlabels-data-description"),
+    cc.options().get<std::string>("output-digitlabels-data-description")));
+
+  return wf;
+}

--- a/Detectors/MUON/MCH/Workflow/src/digits-to-preclusters-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/digits-to-preclusters-workflow.cxx
@@ -27,13 +27,17 @@ using namespace o2::framework;
 
 void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
-  workflowOptions.push_back(ConfigParamSpec{"input-digitrofs-data-description", VariantType::String, "TIMECLUSTERROFS", {"description string for the input ROF data"}});
+  workflowOptions.emplace_back(ConfigParamSpec{"input-digitrofs-data-description", VariantType::String, "TC-F-DIGITROFS", {"description string for the input ROF data"}});
+  workflowOptions.emplace_back(ConfigParamSpec{"input-digits-data-description", VariantType::String, "F-DIGITS", {"description string for the input digits data"}});
 }
 
 #include "Framework/runDataProcessing.h"
 
-WorkflowSpec defineDataProcessing(const ConfigContext& configcontext)
+WorkflowSpec defineDataProcessing(const ConfigContext& cc)
 {
-  auto rofDesc = configcontext.options().get<std::string>("input-digitrofs-data-description");
-  return {o2::mch::getPreClusterFinderSpec(rofDesc.c_str())};
+  return {
+    o2::mch::getPreClusterFinderSpec(
+      "mch-preclustering",
+      cc.options().get<std::string>("input-digits-data-description"),
+      cc.options().get<std::string>("input-digitrofs-data-description"))};
 }

--- a/Detectors/MUON/MCH/Workflow/src/digits-to-timeclusters-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/digits-to-timeclusters-workflow.cxx
@@ -19,13 +19,24 @@
 #include "Framework/CallbackService.h"
 #include "Framework/ControlService.h"
 #include "Framework/Task.h"
-#include "Framework/runDataProcessing.h"
 #include "MCHWorkflow/TimeClusterFinderSpec.h"
 
 using namespace o2;
 using namespace o2::framework;
 
-WorkflowSpec defineDataProcessing(const ConfigContext&)
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
-  return {o2::mch::getTimeClusterFinderSpec()};
+  workflowOptions.push_back(ConfigParamSpec{"input-digitrofs-data-description", VariantType::String, "F-DIGITROFS", {"description string for the input digit rofs data"}});
+  workflowOptions.push_back(ConfigParamSpec{"output-digitrofs-data-description", VariantType::String, "TC-F-DIGITROFS", {"description string for the output digit rofs data"}});
+}
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(const ConfigContext& cc)
+{
+  return {
+    o2::mch::getTimeClusterFinderSpec(
+      "mch-time-clustering",
+      cc.options().get<std::string>("input-digitrofs-data-description"),
+      cc.options().get<std::string>("output-digitrofs-data-description"))};
 }

--- a/Detectors/MUON/MCH/Workflow/src/reco-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/reco-workflow.cxx
@@ -13,6 +13,7 @@
 #include "CommonUtils/ConfigurableParam.h"
 #include "DetectorsRaw/HBFUtilsInitializer.h"
 #include "Framework/CallbacksPolicy.h"
+#include "DigitFilteringSpec.h"
 #include "DigitReaderSpec.h"
 #include "Framework/ConfigContext.h"
 #include "Framework/Logger.h"
@@ -42,7 +43,6 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input reader"}},
     {"disable-root-output", o2::framework::VariantType::Bool, false, {"do not write output root files"}},
     {"disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation even if available"}},
-    {"disable-time-clustering", o2::framework::VariantType::Bool, false, {"disable time clustering step (for debug only)"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
 
   std::swap(workflowOptions, options);
@@ -57,27 +57,32 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   auto disableRootOutput = configcontext.options().get<bool>("disable-root-output");
   auto disableRootInput = configcontext.options().get<bool>("disable-root-input");
   auto useMC = !configcontext.options().get<bool>("disable-mc");
-  auto enableTimeClustering = !configcontext.options().get<bool>("disable-time-clustering");
-
-  const char* digitRofDataDescription =
-    enableTimeClustering ? "TIMECLUSTERROFS" : "DIGITROFS";
 
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
 
   if (!disableRootInput) {
     specs.emplace_back(o2::mch::getDigitReaderSpec(useMC, "mch-sim-digit-reader"));
   }
-  if (enableTimeClustering) {
-    specs.emplace_back(o2::mch::getTimeClusterFinderSpec("mch-time-cluster-finder"));
-  }
+
+  specs.emplace_back(o2::mch::getDigitFilteringSpec(useMC, "mch-digit-filtering",
+                                                    "DIGITS", "F-DIGITS",
+                                                    "DIGITROFS", "F-DIGITROFS",
+                                                    "DIGITLABELS", "F-DIGITLABELS"));
+
+  specs.emplace_back(o2::mch::getTimeClusterFinderSpec("mch-time-cluster-finder",
+                                                       "F-DIGITROFS",
+                                                       "TC-F-DIGITROFS"));
 
   specs.emplace_back(o2::mch::getPreClusterFinderSpec("mch-precluster-finder",
-                                                      digitRofDataDescription));
+                                                      "F-DIGITS",
+                                                      "TC-F-DIGITROFS"));
   specs.emplace_back(o2::mch::getClusterFinderOriginalSpec("mch-cluster-finder"));
   specs.emplace_back(o2::mch::getClusterTransformerSpec());
   specs.emplace_back(o2::mch::getTrackFinderSpec("mch-track-finder"));
   if (useMC) {
-    specs.emplace_back(o2::mch::getTrackMCLabelFinderSpec("mch-track-mc-label-finder", digitRofDataDescription));
+    specs.emplace_back(o2::mch::getTrackMCLabelFinderSpec("mch-track-mc-label-finder",
+                                                          "TC-F-DIGITROFS",
+                                                          "F-DIGITLABELS"));
   }
 
   if (!disableRootOutput) {


### PR DESCRIPTION
For the moment we only filter out the digits that end up with an ADC=0
(to protect the clustering). This is done by using the
`--min-adc-value` option (with default value=1).

Note that the addition of the digit filtering forces us to add a few
`--input-digits-xxx-data-description` options to other devices to be
able to select the digit (and digit rofs) data descriptions.

We also add a `--sanity-check` debug option to ensure some coherence
between digits and digit rofs, primarily to cross-check that no
out-of-bound indexing occur.