### PR TITLE
WP3: apply clang-tidy --checks=modernize-return-braced-init-list --fix

### DIFF
--- a/Common/Utils/src/ConfigurableParamHelper.cxx
+++ b/Common/Utils/src/ConfigurableParamHelper.cxx
@@ -167,13 +167,13 @@ std::string asString(TDataMember const& dm, char* pointer)
         for (int i = 0; i < constantlist->GetEntries(); ++i) {
           const auto e = (TEnumConstant*)(constantlist->At(i));
           if (val == std::to_string((int)e->GetValue())) {
-            return std::string(e->GetName());
+            return {e->GetName()};
           }
         }
       }
     }
 
-    return std::string(val);
+    return {val};
   }
 
   // if data member is a std::string just return

--- a/DataFormats/Detectors/TPC/src/ClusterNativeHelper.cxx
+++ b/DataFormats/Detectors/TPC/src/ClusterNativeHelper.cxx
@@ -66,7 +66,7 @@ std::unique_ptr<ClusterNativeAccess> ClusterNativeHelper::createClusterNativeInd
   for (int i = 0; i < clusters.size(); i++) {
     if (retVal->nClusters[clusters[i].sector][clusters[i].globalPadRow]) {
       LOG(error) << "Received two containers for the same sector / row";
-      return std::unique_ptr<ClusterNativeAccess>();
+      return {};
     }
     retVal->nClusters[clusters[i].sector][clusters[i].globalPadRow] = clusters[i].clusters.size();
     retVal->nClustersTotal += clusters[i].clusters.size();

--- a/Detectors/Base/src/GeometryManager.cxx
+++ b/Detectors/Base/src/GeometryManager.cxx
@@ -323,7 +323,7 @@ GeometryManager::MatBudgetExt GeometryManager::meanMaterialBudgetExt(float x0, f
   double length, startD[3] = {x0, y0, z0};
   double dir[3] = {x1 - x0, y1 - y0, z1 - z0};
   if ((length = dir[0] * dir[0] + dir[1] * dir[1] + dir[2] * dir[2]) < TGeoShape::Tolerance() * TGeoShape::Tolerance()) {
-    return MatBudgetExt(); // return empty struct
+    return {}; // return empty struct
   }
   length = TMath::Sqrt(length);
   double invlen = 1. / length;
@@ -335,7 +335,7 @@ GeometryManager::MatBudgetExt GeometryManager::meanMaterialBudgetExt(float x0, f
   TGeoNode* currentnode = gGeoManager->InitTrack(startD, dir);
   if (!currentnode) {
     LOG(error) << "start point out of geometry: " << x0 << ':' << y0 << ':' << z0;
-    return MatBudgetExt(); // return empty struct
+    return {}; // return empty struct
   }
 
   MatBudgetExt budTotal, budStep;
@@ -415,7 +415,7 @@ o2::base::MatBudget GeometryManager::meanMaterialBudget(float x0, float y0, floa
   double length, startD[3] = {x0, y0, z0};
   double dir[3] = {x1 - x0, y1 - y0, z1 - z0};
   if ((length = dir[0] * dir[0] + dir[1] * dir[1] + dir[2] * dir[2]) < TGeoShape::Tolerance() * TGeoShape::Tolerance()) {
-    return o2::base::MatBudget(); // return empty struct
+    return {}; // return empty struct
   }
   length = TMath::Sqrt(length);
   double invlen = 1. / length;
@@ -427,7 +427,7 @@ o2::base::MatBudget GeometryManager::meanMaterialBudget(float x0, float y0, floa
   TGeoNode* currentnode = gGeoManager->InitTrack(startD, dir);
   if (!currentnode) {
     LOG(error) << "start point out of geometry: " << x0 << ':' << y0 << ':' << z0;
-    return o2::base::MatBudget(); // return empty struct
+    return {}; // return empty struct
   }
 
   o2::base::MatBudget budTotal, budStep;

--- a/Detectors/DCS/src/DataPointCompositeObject.cxx
+++ b/Detectors/DCS/src/DataPointCompositeObject.cxx
@@ -85,7 +85,7 @@ std::string getValue(const DataPointCompositeObject& dpcom)
   if (dpcom.id.get_type() != o2::dcs::DeliveryType::RAW_STRING) {
     throw std::runtime_error("DPCOM is of unexpected type " + o2::dcs::show(dpcom.id.get_type()));
   }
-  return std::string((char*)&dpcom.data.payload_pt1);
+  return {(char*)&dpcom.data.payload_pt1};
 }
 
 } // namespace o2::dcs

--- a/Detectors/EMCAL/simulation/src/DigitsWriteoutBuffer.cxx
+++ b/Detectors/EMCAL/simulation/src/DigitsWriteoutBuffer.cxx
@@ -59,5 +59,5 @@ void DigitsWriteoutBuffer::forwardMarker(double eventTime)
 
 gsl::span<std::unordered_map<int, std::list<LabeledDigit>>> DigitsWriteoutBuffer::getLastNSamples(int nsamples)
 {
-  return {&mTimedDigits[int(mMarker.mPositionInBuffer - mTimedDigits.begin() - nsamples)], nsamples};
+  return {&mTimedDigits[int(mMarker.mPositionInBuffer - mTimedDigits.begin() - nsamples)], static_cast<std::size_t>(nsamples)};
 }

--- a/Detectors/EMCAL/simulation/src/DigitsWriteoutBuffer.cxx
+++ b/Detectors/EMCAL/simulation/src/DigitsWriteoutBuffer.cxx
@@ -59,5 +59,5 @@ void DigitsWriteoutBuffer::forwardMarker(double eventTime)
 
 gsl::span<std::unordered_map<int, std::list<LabeledDigit>>> DigitsWriteoutBuffer::getLastNSamples(int nsamples)
 {
-  return gsl::span<std::unordered_map<int, std::list<LabeledDigit>>>(&mTimedDigits[int(mMarker.mPositionInBuffer - mTimedDigits.begin() - nsamples)], nsamples);
+  return {&mTimedDigits[int(mMarker.mPositionInBuffer - mTimedDigits.begin() - nsamples)], nsamples};
 }

--- a/Detectors/MUON/MCH/Raw/Decoder/src/ROFFinder.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/ROFFinder.cxx
@@ -191,7 +191,7 @@ o2::InteractionRecord ROFFinder::digitTime2IR(const RawDigit& digit)
   }
 
   uint32_t orbit = digit.getTime() / BCINORBIT + firstOrbit;
-  int32_t bc = time % BCINORBIT;
+  uint16_t bc = static_cast<uint16_t>((time % BCINORBIT));
   return {bc, orbit};
 }
 

--- a/Detectors/MUON/MCH/Raw/Decoder/src/ROFFinder.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/ROFFinder.cxx
@@ -192,7 +192,7 @@ o2::InteractionRecord ROFFinder::digitTime2IR(const RawDigit& digit)
 
   uint32_t orbit = digit.getTime() / BCINORBIT + firstOrbit;
   int32_t bc = time % BCINORBIT;
-  return o2::InteractionRecord(bc, orbit);
+  return {bc, orbit};
 }
 
 //_________________________________________________________________________________________________

--- a/Detectors/MUON/MCH/Raw/ElecMap/src/DsDetId.cxx
+++ b/Detectors/MUON/MCH/Raw/ElecMap/src/DsDetId.cxx
@@ -34,7 +34,7 @@ DsDetId decodeDsDetId(uint32_t x)
 {
   uint16_t deId = static_cast<uint16_t>((x & 0xFFFF0000) >> 16);
   uint16_t dsId = static_cast<uint16_t>(x & 0xFFFF);
-  return DsDetId(deId, dsId);
+  return {deId, dsId};
 }
 
 std::ostream& operator<<(std::ostream& os, const DsDetId& id)

--- a/Detectors/MUON/MCH/Raw/ElecMap/src/FeeLinkId.cxx
+++ b/Detectors/MUON/MCH/Raw/ElecMap/src/FeeLinkId.cxx
@@ -31,7 +31,7 @@ FeeLinkId decodeFeeLinkId(uint32_t x)
 {
   uint16_t feeId = static_cast<uint16_t>((x & 0xFFFF0000) >> 16);
   uint8_t linkId = static_cast<uint8_t>(x & 0xF);
-  return FeeLinkId(feeId, linkId);
+  return {feeId, linkId};
 }
 
 std::ostream& operator<<(std::ostream& os, const FeeLinkId& id)

--- a/Detectors/MUON/MID/Base/src/Mapping.cxx
+++ b/Detectors/MUON/MID/Base/src/Mapping.cxx
@@ -519,7 +519,7 @@ MpArea Mapping::stripByLocation(int strip, int cathode, int line, int column, in
     std::cout << "Warning: no non-bending strip " << strip << " in column " << column << " of DE " << deId << std::endl;
   }
 
-  return MpArea(x1, y1, x2, y2);
+  return {x1, y1, x2, y2};
 }
 
 //______________________________________________________________________________

--- a/Detectors/MUON/MID/Base/src/Mapping.cxx
+++ b/Detectors/MUON/MID/Base/src/Mapping.cxx
@@ -519,7 +519,11 @@ MpArea Mapping::stripByLocation(int strip, int cathode, int line, int column, in
     std::cout << "Warning: no non-bending strip " << strip << " in column " << column << " of DE " << deId << std::endl;
   }
 
-  return {x1, y1, x2, y2};
+  return {
+    static_cast<float>(x1),
+    static_cast<float>(y1),
+    static_cast<float>(x2),
+    static_cast<float>(y2)};
 }
 
 //______________________________________________________________________________

--- a/Detectors/TPC/calibration/src/CalibLaserTracks.cxx
+++ b/Detectors/TPC/calibration/src/CalibLaserTracks.cxx
@@ -318,7 +318,7 @@ void CalibLaserTracks::fillCalibData(LtrCalibData& calibData, const std::vector<
 TimePair CalibLaserTracks::fit(const std::vector<TimePair>& trackMatches) const
 {
   if (!trackMatches.size()) {
-    return TimePair();
+    return {};
   }
 
   static TLinearFitter fit(2, "pol1");

--- a/Detectors/TPC/reconstruction/src/TPCTrackingDigitsPreCheck.cxx
+++ b/Detectors/TPC/reconstruction/src/TPCTrackingDigitsPreCheck.cxx
@@ -92,5 +92,5 @@ TPCTrackingDigitsPreCheck::precheckModifiedData TPCTrackingDigitsPreCheck::runPr
     }
     return precheckModifiedData(std::move(retVal));
   }
-  return precheckModifiedData();
+  return {};
 }

--- a/Detectors/TPC/simulation/src/Detector.cxx
+++ b/Detectors/TPC/simulation/src/Detector.cxx
@@ -3172,9 +3172,9 @@ std::string Detector::getHitBranchNames(int probe) const
   if (probe >= 0 && probe < Sector::MAXSECTOR) {
     TString name;
     name.Form("%sHitsShiftedSector%d", GetName(), probe);
-    return std::string(name.Data());
+    return {name.Data()};
   }
-  return std::string();
+  return {};
 }
 
 ClassImp(o2::tpc::Detector);

--- a/Detectors/TRD/base/src/TrackletTransformer.cxx
+++ b/Detectors/TRD/base/src/TrackletTransformer.cxx
@@ -156,7 +156,7 @@ CalibratedTracklet TrackletTransformer::transformTracklet(Tracklet64 tracklet)
              << "y: " << sectorSpacePoint[1] << " | "
              << "z: " << sectorSpacePoint[2];
 
-  return CalibratedTracklet(sectorSpacePoint[0], sectorSpacePoint[1], sectorSpacePoint[2], dy);
+  return {sectorSpacePoint[0], sectorSpacePoint[1], sectorSpacePoint[2], dy};
 }
 
 double TrackletTransformer::getTimebin(int detector, double x)

--- a/Framework/AnalysisSupport/src/AODJAlienReaderHelpers.cxx
+++ b/Framework/AnalysisSupport/src/AODJAlienReaderHelpers.cxx
@@ -99,7 +99,7 @@ std::vector<std::string> getColumnNames(header::DataHeader dh)
   auto origin = std::string(dh.dataOrigin.str);
 
   // default: column names = {}
-  return std::vector<std::string>({});
+  return {{}};
 }
 
 using o2::monitoring::Metric;

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -1562,7 +1562,7 @@ std::unique_ptr<ConfigParamStore> DeviceConfigurationHelpers::getConfiguration(S
       // No overrides...
     }
   }
-  return std::unique_ptr<ConfigParamStore>(nullptr);
+  return {nullptr};
 }
 
 } // namespace o2::framework

--- a/Framework/Core/src/DataRelayer.cxx
+++ b/Framework/Core/src/DataRelayer.cxx
@@ -476,7 +476,7 @@ void DataRelayer::getReadyToProcess(std::vector<DataRelayer::RecordAction>& comp
     assert(cache.size() >= offset + numInputTypes);
     auto const start = cache.data() + offset;
     auto const end = cache.data() + offset + numInputTypes;
-    return gsl::span<MessageSet const>(start, end);
+    return {start, end};
   };
 
   // These two are trivial, but in principle the whole loop could be parallelised

--- a/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
+++ b/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
@@ -388,7 +388,7 @@ DataProcessorSpec specifyExternalFairMQDeviceProxy(char const* name,
             return route.channel;
           }
         }
-        return std::string("");
+        return {""};
       };
 
       auto checkEos = [&inputs]() -> bool {

--- a/Framework/Core/src/HistogramRegistry.cxx
+++ b/Framework/Core/src/HistogramRegistry.cxx
@@ -73,7 +73,7 @@ HistPtr HistogramRegistry::insert(const HistogramSpec& histSpec)
     }
   }
   LOGF(fatal, R"(Internal array of HistogramRegistry "%s" is full.)", mName);
-  return HistPtr();
+  return {};
 }
 
 // helper function that checks if histogram name can be used in registry

--- a/Framework/Core/src/ResourcesMonitoringHelper.cxx
+++ b/Framework/Core/src/ResourcesMonitoringHelper.cxx
@@ -28,7 +28,7 @@ inline static T retriveValue(T val)
 
 inline static std::string retriveValue(const std::reference_wrapper<const StringMetric> val)
 {
-  return std::string(val.get().data);
+  return {val.get().data};
 }
 
 template <typename T>

--- a/Framework/Core/src/WorkflowCustomizationHelpers.cxx
+++ b/Framework/Core/src/WorkflowCustomizationHelpers.cxx
@@ -24,7 +24,7 @@ std::string defaultIPCFolder()
   /// Find out a place where we can write the sockets
   char const* channelPrefix = getenv("TMPDIR");
   if (channelPrefix) {
-    return std::string(channelPrefix);
+    return {channelPrefix};
   }
   return access("/tmp", W_OK) == 0 ? "/tmp" : ".";
 #endif

--- a/Framework/GUISupport/src/FrameworkGUIDataRelayerUsage.cxx
+++ b/Framework/GUISupport/src/FrameworkGUIDataRelayerUsage.cxx
@@ -18,8 +18,8 @@
 #include <cstring>
 #include <cmath>
 
-static inline ImVec2 operator+(const ImVec2& lhs, const ImVec2& rhs) { return ImVec2(lhs.x + rhs.x, lhs.y + rhs.y); }
-static inline ImVec2 operator-(const ImVec2& lhs, const ImVec2& rhs) { return ImVec2(lhs.x - rhs.x, lhs.y - rhs.y); }
+static inline ImVec2 operator+(const ImVec2& lhs, const ImVec2& rhs) { return {lhs.x + rhs.x, lhs.y + rhs.y}; }
+static inline ImVec2 operator-(const ImVec2& lhs, const ImVec2& rhs) { return {lhs.x - rhs.x, lhs.y - rhs.y}; }
 
 namespace o2::framework::gui
 {

--- a/Framework/GUISupport/src/FrameworkGUIDebugger.cxx
+++ b/Framework/GUISupport/src/FrameworkGUIDebugger.cxx
@@ -266,7 +266,9 @@ void displaySparks(
             auto histoData = reinterpret_cast<HistoData*>(hData);
             size_t pos = (histoData->first + static_cast<size_t>(idx)) % histoData->mod;
             assert(pos >= 0 && pos < 1024);
-            return {histoData->time[pos], ((int*)(histoData->points))[pos]};
+            return {
+              static_cast<double>(histoData->time[pos]),
+              static_cast<double>(((int*)(histoData->points))[pos])};
           };
           ImPlot::PlotLineG("##plot", getter, &data, data.mod);
         } break;
@@ -277,7 +279,9 @@ void displaySparks(
             auto histoData = reinterpret_cast<HistoData*>(hData);
             size_t pos = (histoData->first + static_cast<size_t>(idx)) % histoData->mod;
             assert(pos >= 0 && pos < 1024);
-            return {histoData->time[pos], ((uint64_t*)histoData->points)[pos]};
+            return {
+              static_cast<double>(histoData->time[pos]),
+              static_cast<double>(((uint64_t*)histoData->points)[pos])};
           };
           ImPlot::PlotLineG("##plot", getter, &data, data.mod, 0);
         } break;
@@ -288,7 +292,9 @@ void displaySparks(
             auto histoData = reinterpret_cast<HistoData*>(hData);
             size_t pos = (histoData->first + static_cast<size_t>(idx)) % histoData->mod;
             assert(pos >= 0 && pos < 1024);
-            return {histoData->time[pos], ((float*)histoData->points)[pos]};
+            return {
+              static_cast<double>(histoData->time[pos]),
+              static_cast<double>(((float*)histoData->points)[pos])};
           };
           ImPlot::PlotLineG("##plot", getter, &data, data.mod, 0);
         } break;

--- a/Framework/GUISupport/src/FrameworkGUIDebugger.cxx
+++ b/Framework/GUISupport/src/FrameworkGUIDebugger.cxx
@@ -38,8 +38,8 @@
 // Simplify debugging
 template class std::vector<o2::framework::DeviceMetricsInfo>;
 
-static inline ImVec2 operator+(const ImVec2& lhs, const ImVec2& rhs) { return ImVec2(lhs.x + rhs.x, lhs.y + rhs.y); }
-static inline ImVec2 operator-(const ImVec2& lhs, const ImVec2& rhs) { return ImVec2(lhs.x - rhs.x, lhs.y - rhs.y); }
+static inline ImVec2 operator+(const ImVec2& lhs, const ImVec2& rhs) { return {lhs.x + rhs.x, lhs.y + rhs.y}; }
+static inline ImVec2 operator-(const ImVec2& lhs, const ImVec2& rhs) { return {lhs.x - rhs.x, lhs.y - rhs.y}; }
 
 namespace o2::framework::gui
 {
@@ -68,7 +68,7 @@ ImVec4 colorForLogLevel(LogParsingHelpers::LogLevel logLevel)
     case LogParsingHelpers::LogLevel::Info:
       return PaletteHelpers::GREEN;
     case LogParsingHelpers::LogLevel::Debug:
-      return ImVec4(153. / 255, 61. / 255, 61. / 255, 255. / 255);
+      return {153. / 255, 61. / 255, 61. / 255, 255. / 255};
     case LogParsingHelpers::LogLevel::Warning:
       return PaletteHelpers::DARK_YELLOW;
     case LogParsingHelpers::LogLevel::Error:
@@ -76,9 +76,9 @@ ImVec4 colorForLogLevel(LogParsingHelpers::LogLevel logLevel)
     case LogParsingHelpers::LogLevel::Fatal:
       return PaletteHelpers::RED;
     case LogParsingHelpers::LogLevel::Unknown:
-      return ImVec4(194. / 255, 195. / 255, 199. / 255, 255. / 255);
+      return {194. / 255, 195. / 255, 199. / 255, 255. / 255};
     default:
-      return ImVec4(194. / 255, 195. / 255, 199. / 255, 255. / 255);
+      return {194. / 255, 195. / 255, 199. / 255, 255. / 255};
   };
 }
 
@@ -266,7 +266,7 @@ void displaySparks(
             auto histoData = reinterpret_cast<HistoData*>(hData);
             size_t pos = (histoData->first + static_cast<size_t>(idx)) % histoData->mod;
             assert(pos >= 0 && pos < 1024);
-            return ImPlotPoint(histoData->time[pos], ((int*)(histoData->points))[pos]);
+            return {histoData->time[pos], ((int*)(histoData->points))[pos]};
           };
           ImPlot::PlotLineG("##plot", getter, &data, data.mod);
         } break;
@@ -277,7 +277,7 @@ void displaySparks(
             auto histoData = reinterpret_cast<HistoData*>(hData);
             size_t pos = (histoData->first + static_cast<size_t>(idx)) % histoData->mod;
             assert(pos >= 0 && pos < 1024);
-            return ImPlotPoint(histoData->time[pos], ((uint64_t*)histoData->points)[pos]);
+            return {histoData->time[pos], ((uint64_t*)histoData->points)[pos]};
           };
           ImPlot::PlotLineG("##plot", getter, &data, data.mod, 0);
         } break;
@@ -288,7 +288,7 @@ void displaySparks(
             auto histoData = reinterpret_cast<HistoData*>(hData);
             size_t pos = (histoData->first + static_cast<size_t>(idx)) % histoData->mod;
             assert(pos >= 0 && pos < 1024);
-            return ImPlotPoint(histoData->time[pos], ((float*)histoData->points)[pos]);
+            return {histoData->time[pos], ((float*)histoData->points)[pos]};
           };
           ImPlot::PlotLineG("##plot", getter, &data, data.mod, 0);
         } break;

--- a/Framework/GUISupport/src/FrameworkGUIDevicesGraph.cxx
+++ b/Framework/GUISupport/src/FrameworkGUIDevicesGraph.cxx
@@ -27,8 +27,8 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
-static inline ImVec2 operator+(const ImVec2& lhs, const ImVec2& rhs) { return ImVec2(lhs.x + rhs.x, lhs.y + rhs.y); }
-static inline ImVec2 operator-(const ImVec2& lhs, const ImVec2& rhs) { return ImVec2(lhs.x - rhs.x, lhs.y - rhs.y); }
+static inline ImVec2 operator+(const ImVec2& lhs, const ImVec2& rhs) { return {lhs.x + rhs.x, lhs.y + rhs.y}; }
+static inline ImVec2 operator-(const ImVec2& lhs, const ImVec2& rhs) { return {lhs.x - rhs.x, lhs.y - rhs.y}; }
 
 namespace o2::framework::gui
 {
@@ -190,14 +190,14 @@ struct NodePos {
     ImVec2 const& pos = positions[nodeId].pos;
     ImVec2 const& size = infos[nodeId].Size;
     float inputsCount = infos[nodeId].InputsCount;
-    return ImVec2(pos.x, pos.y + size.y * ((float)slot_no + 1) / (inputsCount + 1));
+    return {pos.x, pos.y + size.y * ((float)slot_no + 1) / (inputsCount + 1)};
   }
   static ImVec2 GetOutputSlotPos(ImVector<Node> const& infos, ImVector<NodePos> const& positions, int nodeId, int slot_no)
   {
     ImVec2 const& pos = positions[nodeId].pos;
     ImVec2 const& size = infos[nodeId].Size;
     float outputsCount = infos[nodeId].OutputsCount;
-    return ImVec2(pos.x + size.x, pos.y + size.y * ((float)slot_no + 1) / (outputsCount + 1));
+    return {pos.x + size.x, pos.y + size.y * ((float)slot_no + 1) / (outputsCount + 1)};
   }
 };
 

--- a/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
+++ b/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
@@ -328,13 +328,13 @@ struct DetFilterer {
 // Helper function to define a white listing DetFilterer
 DetFilterer whitelister(std::string optionVal, std::string unsetValue, char separator)
 {
-  return DetFilterer(optionVal, unsetValue, separator, true);
+  return {optionVal, unsetValue, separator, true};
 }
 
 // Helper function to define a black listing DetFilterer
 DetFilterer blacklister(std::string optionVal, std::string unsetValue, char separator)
 {
-  return DetFilterer(optionVal, unsetValue, separator, false);
+  return {optionVal, unsetValue, separator, false};
 }
 
 // Finding out if the current process is the master DPL driver process,

--- a/Utilities/DataSampling/src/DataSampling.cxx
+++ b/Utilities/DataSampling/src/DataSampling.cxx
@@ -33,7 +33,7 @@ namespace o2::utilities
 
 std::string DataSampling::createDispatcherName()
 {
-  return std::string("Dispatcher"); //_") + getenv("HOSTNAME");
+  return {"Dispatcher"}; //_") + getenv("HOSTNAME");
 }
 
 void DataSampling::GenerateInfrastructure(WorkflowSpec& workflow, const std::string& policiesSource, size_t threads, const std::string& host)


### PR DESCRIPTION
as agreed in WP3 meeting, here are the fixes for the `modernize-return-braced-init-list` warnings from `clang-tidy`. This PR is to see if nothing breaks.