### PR TITLE
Disable 3rd iteration until further optimisation

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -91,14 +91,11 @@ void TrackerDPL::init(InitContext& ic)
     mRunVertexer = true;
     if (mMode == "async") {
 
-      trackParams.resize(3);
+      trackParams.resize(2);
       trackParams[1].TrackletMinPt = 0.2f;
       trackParams[1].CellDeltaTanLambdaSigma *= 2.;
-      trackParams[2].TrackletMinPt = 0.1f;
-      trackParams[2].CellDeltaTanLambdaSigma *= 2.;
-      trackParams[2].MinTrackLength = 4;
-      trackParams[2].DeltaROF = 1;
-      memParams.resize(3);
+      trackParams[1].MinTrackLength = 4;
+      memParams.resize(2);
       LOG(info) << "Initializing tracker in async. phase reconstruction with " << trackParams.size() << " passes";
 
     } else if (mMode == "sync_misaligned") {


### PR DESCRIPTION
@shahor02 @sawenzel this should solve the issue with large Pb-Pb TF.
In the next few days I will be out of the office and I won't be able to produce a better fix, but at least with this the tests should be fast at the expenses of efficiency for pt < 150 MeV/c.