### PR TITLE
DPL Analysis: introduce filter selection caching

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -2072,6 +2072,13 @@ class FilteredBase : public T
     return result;
   }
 
+  auto select(framework::expressions::Filter const& f) const
+  {
+    auto t = o2::soa::select(*this, f);
+    copyIndexBindings(t);
+    return t;
+  }
+
  protected:
   auto slice(uint64_t start, uint64_t end)
   {

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -915,15 +915,7 @@ static constexpr auto extractBindings(framework::pack<Is...>)
 template <typename T>
 class Filtered;
 
-static inline SelectionVector selectionToVector(gandiva::Selection const& sel)
-{
-  SelectionVector rows;
-  rows.resize(sel->GetNumSlots());
-  for (auto i = 0; i < sel->GetNumSlots(); ++i) {
-    rows[i] = sel->GetIndex(i);
-  }
-  return rows;
-}
+SelectionVector selectionToVector(gandiva::Selection const& sel);
 
 template <typename T>
 auto select(T const& t, framework::expressions::Filter const& f)

--- a/Framework/Core/include/Framework/ASoAHelpers.h
+++ b/Framework/Core/include/Framework/ASoAHelpers.h
@@ -202,7 +202,7 @@ struct CombinationsIndexPolicyBase {
   using CombinationType = std::tuple<typename Ts::iterator...>;
   using IndicesType = typename NTupleType<uint64_t, sizeof...(Ts)>::type;
 
-  CombinationsIndexPolicyBase(const Ts&... tables) : mTables(std::tie(tables...)),
+  CombinationsIndexPolicyBase(const Ts&... tables) : mTables(tables...),
                                                      mIsEnd(false),
                                                      mMaxOffset(tables.end().index...),
                                                      mCurrent(tables.begin()...)
@@ -235,7 +235,7 @@ struct CombinationsIndexPolicyBase {
 
   void addOne() {}
 
-  std::tuple<Ts const&...> mTables;
+  std::tuple<Ts...> mTables;
   CombinationType mCurrent;
 
   IndicesType mMaxOffset; // one position past maximum acceptable position for each element of combination
@@ -1045,9 +1045,9 @@ auto combinations(const o2::framework::expressions::Filter& filter, const T2& ta
 }
 
 template <template <typename...> typename P2, typename... T2s>
-CombinationsGenerator<P2<Filtered<T2s>...>> combinations(const P2<T2s...>&, const o2::framework::expressions::Filter& filter, const T2s&... tables)
+CombinationsGenerator<P2<Filtered<T2s>...>> combinations(P2<T2s...>&&, const o2::framework::expressions::Filter& filter, const T2s&... tables)
 {
-  return CombinationsGenerator<P2<Filtered<T2s>...>>(P2<Filtered<T2s>...>({o2::soa::select(tables, filter)}...));
+  return CombinationsGenerator<P2<Filtered<T2s>...>>(P2<Filtered<T2s>...>(tables.select(filter)...));
 }
 
 // This shortened version cannot be used for Filtered

--- a/Framework/Core/include/Framework/ASoAHelpers.h
+++ b/Framework/Core/include/Framework/ASoAHelpers.h
@@ -71,7 +71,7 @@ std::vector<std::pair<uint64_t, uint64_t>> doGroupTable(const T& table, const st
 
   uint64_t ind = 0;
   uint64_t selInd = 0;
-  soa::SelectionVector selectedRows;
+  gsl::span<int64_t const> selectedRows;
   std::vector<std::pair<uint64_t, uint64_t>> groupedIndices;
 
   // Separate check to account for Filtered size different from arrow table

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -509,7 +509,11 @@ struct Partition {
 
   void bindTable(T& table)
   {
-    mFiltered.reset(getTableFromFilter(table, filter));
+    if (selection == nullptr) {
+      intializeCaches(table.asArrowTable()->schema());
+      selection = framework::expressions::createSelection(table.asArrowTable(), gfilter);
+    }
+    mFiltered.reset(getTableFromFilter(table, selection));
     bindExternalIndices(&table);
     getBoundToExternalIndices(table);
   }

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -54,6 +54,10 @@ struct PartitionManager {
   static void updatePlaceholders(ANY&, InitContext&)
   {
   }
+
+  static void resetSelection(ANY&)
+  {
+  }
 };
 
 template <typename T>
@@ -95,6 +99,11 @@ struct PartitionManager<Partition<T>> {
   static void updatePlaceholders(Partition<T>& partition, InitContext& context)
   {
     partition.updatePlaceholders(context);
+  }
+
+  static void resetSelection(Partition<T>& partition)
+  {
+    partition.selection = nullptr;
   }
 };
 

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -875,7 +875,7 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
 
   // no static way to check if the task defines any processing, we can only make sure it subscribes to at least something
   if (inputs.empty() == true) {
-    LOG(WARN) << "Task " << name_str << " has no inputs";
+    LOG(warn) << "Task " << name_str << " has no inputs";
   }
 
   homogeneous_apply_refs([&outputs, &hash](auto& x) { return OutputManager<std::decay_t<decltype(x)>>::appendOutput(outputs, x, hash); }, *task.get());

--- a/Framework/Core/include/Framework/Expressions.h
+++ b/Framework/Core/include/Framework/Expressions.h
@@ -43,6 +43,11 @@ class Filter;
 #include <memory>
 #include <typeinfo>
 #include <set>
+namespace gandiva
+{
+using Selection = std::shared_ptr<gandiva::SelectionVector>;
+using FilterPtr = std::shared_ptr<gandiva::Filter>;
+} // namespace gandiva
 
 using atype = arrow::Type;
 struct ExpressionInfo {
@@ -51,6 +56,8 @@ struct ExpressionInfo {
   std::set<size_t> hashes;
   gandiva::SchemaPtr schema;
   gandiva::NodePtr tree;
+  gandiva::FilterPtr filter;
+  gandiva::Selection selection;
 };
 
 namespace o2::framework::expressions
@@ -406,11 +413,10 @@ struct Filter {
 
 using Projector = Filter;
 
-using Selection = std::shared_ptr<gandiva::SelectionVector>;
 /// Function for creating gandiva selection from our internal filter tree
-Selection createSelection(std::shared_ptr<arrow::Table> const& table, Filter const& expression);
+gandiva::Selection createSelection(std::shared_ptr<arrow::Table> const& table, Filter const& expression);
 /// Function for creating gandiva selection from prepared gandiva expressions tree
-Selection createSelection(std::shared_ptr<arrow::Table> const& table, std::shared_ptr<gandiva::Filter> gfilter);
+gandiva::Selection createSelection(std::shared_ptr<arrow::Table> const& table, std::shared_ptr<gandiva::Filter> gfilter);
 
 struct ColumnOperationSpec;
 using Operations = std::vector<ColumnOperationSpec>;

--- a/Framework/Core/include/Framework/Expressions.h
+++ b/Framework/Core/include/Framework/Expressions.h
@@ -58,6 +58,7 @@ struct ExpressionInfo {
   gandiva::NodePtr tree;
   gandiva::FilterPtr filter;
   gandiva::Selection selection;
+  bool resetSelection = false;
 };
 
 namespace o2::framework::expressions

--- a/Framework/Core/include/Framework/Expressions.h
+++ b/Framework/Core/include/Framework/Expressions.h
@@ -416,7 +416,7 @@ using Projector = Filter;
 /// Function for creating gandiva selection from our internal filter tree
 gandiva::Selection createSelection(std::shared_ptr<arrow::Table> const& table, Filter const& expression);
 /// Function for creating gandiva selection from prepared gandiva expressions tree
-gandiva::Selection createSelection(std::shared_ptr<arrow::Table> const& table, std::shared_ptr<gandiva::Filter> gfilter);
+gandiva::Selection createSelection(std::shared_ptr<arrow::Table> const& table, std::shared_ptr<gandiva::Filter> const& gfilter);
 
 struct ColumnOperationSpec;
 using Operations = std::vector<ColumnOperationSpec>;

--- a/Framework/Core/include/Framework/HistogramRegistry.h
+++ b/Framework/Core/include/Framework/HistogramRegistry.h
@@ -233,7 +233,8 @@ void HistFiller::fillHistAny(std::shared_ptr<R> hist, const T& table, const o2::
     LOGF(FATAL, "Table filling is not (yet?) supported for StepTHn.");
     return;
   }
-  auto filtered = o2::soa::Filtered<T>{{table.asArrowTable()}, o2::framework::expressions::createSelection(table.asArrowTable(), filter)};
+  auto s = o2::framework::expressions::createSelection(table.asArrowTable(), filter);
+  auto filtered = o2::soa::Filtered<T>{{table.asArrowTable()}, s};
   for (auto& t : filtered) {
     fillHistAny(hist, (*(static_cast<Cs>(t).getIterator()))...);
   }

--- a/Framework/Core/src/ASoA.cxx
+++ b/Framework/Core/src/ASoA.cxx
@@ -17,6 +17,15 @@
 
 namespace o2::soa
 {
+SelectionVector selectionToVector(gandiva::Selection const& sel)
+{
+  SelectionVector rows;
+  rows.resize(sel->GetNumSlots());
+  for (auto i = 0; i < sel->GetNumSlots(); ++i) {
+    rows[i] = sel->GetIndex(i);
+  }
+  return rows;
+}
 
 std::shared_ptr<arrow::Table> ArrowHelpers::joinTables(std::vector<std::shared_ptr<arrow::Table>>&& tables)
 {

--- a/Framework/Core/src/Expressions.cxx
+++ b/Framework/Core/src/Expressions.cxx
@@ -421,7 +421,7 @@ std::shared_ptr<gandiva::Projector>
   return createProjector(Schema, createOperations(p), std::move(result));
 }
 
-gandiva::Selection createSelection(std::shared_ptr<arrow::Table> const& table, std::shared_ptr<gandiva::Filter> gfilter)
+gandiva::Selection createSelection(std::shared_ptr<arrow::Table> const& table, std::shared_ptr<gandiva::Filter> const& gfilter)
 {
   gandiva::Selection selection;
   auto s = gandiva::SelectionVector::MakeInt64(table->num_rows(),

--- a/Framework/Core/src/Expressions.cxx
+++ b/Framework/Core/src/Expressions.cxx
@@ -421,9 +421,9 @@ std::shared_ptr<gandiva::Projector>
   return createProjector(Schema, createOperations(p), std::move(result));
 }
 
-Selection createSelection(std::shared_ptr<arrow::Table> const& table, std::shared_ptr<gandiva::Filter> gfilter)
+gandiva::Selection createSelection(std::shared_ptr<arrow::Table> const& table, std::shared_ptr<gandiva::Filter> gfilter)
 {
-  Selection selection;
+  gandiva::Selection selection;
   auto s = gandiva::SelectionVector::MakeInt64(table->num_rows(),
                                                arrow::default_memory_pool(),
                                                &selection);
@@ -452,8 +452,8 @@ Selection createSelection(std::shared_ptr<arrow::Table> const& table, std::share
   return selection;
 }
 
-Selection createSelection(std::shared_ptr<arrow::Table> const& table,
-                          Filter const& expression)
+gandiva::Selection createSelection(std::shared_ptr<arrow::Table> const& table,
+                                   Filter const& expression)
 {
   return createSelection(table, createFilter(table->schema(), createOperations(std::move(expression))));
 }

--- a/Framework/Core/test/test_ASoA.cxx
+++ b/Framework/Core/test/test_ASoA.cxx
@@ -333,7 +333,7 @@ BOOST_AUTO_TEST_CASE(TestConcatTables)
   using FilteredTest = Filtered<TestA>;
   using namespace o2::framework;
   expressions::Filter testf = (test::x == 1) || (test::x == 3);
-  expressions::Selection selection;
+  gandiva::Selection selection;
   auto status = gandiva::SelectionVector::MakeInt32(tests.size(), arrow::default_memory_pool(), &selection);
   BOOST_REQUIRE(status.ok());
 
@@ -363,7 +363,7 @@ BOOST_AUTO_TEST_CASE(TestConcatTables)
   auto st = filter->Evaluate(*batch, selection);
   BOOST_REQUIRE_EQUAL(st.ToString(), "OK");
 
-  expressions::Selection selection_f = expressions::createSelection(tableA, testf);
+  gandiva::Selection selection_f = expressions::createSelection(tableA, testf);
 
   TestA testA{tableA};
   FilteredTest filtered{{testA.asArrowTable()}, selection_f};
@@ -381,7 +381,7 @@ BOOST_AUTO_TEST_CASE(TestConcatTables)
   // Hardcode a selection for the first 5 odd numbers
   using FilteredConcatTest = Filtered<ConcatTest::table_t>;
   using namespace o2::framework;
-  expressions::Selection selectionConcat;
+  gandiva::Selection selectionConcat;
   status = gandiva::SelectionVector::MakeInt32(tests.size(), arrow::default_memory_pool(), &selectionConcat);
   BOOST_CHECK_EQUAL(status.ok(), true);
   selectionConcat->SetIndex(0, 0);
@@ -411,7 +411,7 @@ BOOST_AUTO_TEST_CASE(TestConcatTables)
 
   // Test with a Joined table
   using FilteredJoinTest = Filtered<JoinedTest::table_t>;
-  expressions::Selection selectionJoin;
+  gandiva::Selection selectionJoin;
   status = gandiva::SelectionVector::MakeInt32(tests.size(), arrow::default_memory_pool(), &selectionJoin);
   BOOST_CHECK_EQUAL(status.ok(), true);
   selectionJoin->SetIndex(0, 0);

--- a/Framework/Core/test/test_ASoA.cxx
+++ b/Framework/Core/test/test_ASoA.cxx
@@ -334,7 +334,7 @@ BOOST_AUTO_TEST_CASE(TestConcatTables)
   using namespace o2::framework;
   expressions::Filter testf = (test::x == 1) || (test::x == 3);
   gandiva::Selection selection;
-  auto status = gandiva::SelectionVector::MakeInt32(tests.size(), arrow::default_memory_pool(), &selection);
+  auto status = gandiva::SelectionVector::MakeInt64(tests.size(), arrow::default_memory_pool(), &selection);
   BOOST_REQUIRE(status.ok());
 
   auto fptr = tableA->schema()->GetFieldByName("x");
@@ -382,7 +382,7 @@ BOOST_AUTO_TEST_CASE(TestConcatTables)
   using FilteredConcatTest = Filtered<ConcatTest::table_t>;
   using namespace o2::framework;
   gandiva::Selection selectionConcat;
-  status = gandiva::SelectionVector::MakeInt32(tests.size(), arrow::default_memory_pool(), &selectionConcat);
+  status = gandiva::SelectionVector::MakeInt64(tests.size(), arrow::default_memory_pool(), &selectionConcat);
   BOOST_CHECK_EQUAL(status.ok(), true);
   selectionConcat->SetIndex(0, 0);
   selectionConcat->SetIndex(1, 5);
@@ -412,7 +412,7 @@ BOOST_AUTO_TEST_CASE(TestConcatTables)
   // Test with a Joined table
   using FilteredJoinTest = Filtered<JoinedTest::table_t>;
   gandiva::Selection selectionJoin;
-  status = gandiva::SelectionVector::MakeInt32(tests.size(), arrow::default_memory_pool(), &selectionJoin);
+  status = gandiva::SelectionVector::MakeInt64(tests.size(), arrow::default_memory_pool(), &selectionJoin);
   BOOST_CHECK_EQUAL(status.ok(), true);
   selectionJoin->SetIndex(0, 0);
   selectionJoin->SetIndex(1, 2);
@@ -536,11 +536,13 @@ BOOST_AUTO_TEST_CASE(TestFilteredOperators)
   expressions::Filter f2 = test::y > 13;
 
   TestA testA{tableA};
-  FilteredTest filtered1{{testA.asArrowTable()}, expressions::createSelection(testA.asArrowTable(), f1)};
+  auto s1 = expressions::createSelection(testA.asArrowTable(), f1);
+  FilteredTest filtered1{{testA.asArrowTable()}, s1};
   BOOST_CHECK_EQUAL(4, filtered1.size());
   BOOST_CHECK(filtered1.begin() != filtered1.end());
 
-  FilteredTest filtered2{{testA.asArrowTable()}, expressions::createSelection(testA.asArrowTable(), f2)};
+  auto s2 = expressions::createSelection(testA.asArrowTable(), f2);
+  FilteredTest filtered2{{testA.asArrowTable()}, s2};
   BOOST_CHECK_EQUAL(2, filtered2.size());
   BOOST_CHECK(filtered2.begin() != filtered2.end());
 
@@ -568,7 +570,8 @@ BOOST_AUTO_TEST_CASE(TestFilteredOperators)
   BOOST_CHECK_EQUAL(i, 0);
 
   expressions::Filter f3 = test::x < 3;
-  FilteredTest filtered3{{testA.asArrowTable()}, expressions::createSelection(testA.asArrowTable(), f3)};
+  auto s3 = expressions::createSelection(testA.asArrowTable(), f3);
+  FilteredTest filtered3{{testA.asArrowTable()}, s3};
   BOOST_CHECK_EQUAL(3, filtered3.size());
   BOOST_CHECK(filtered3.begin() != filtered3.end());
 
@@ -611,11 +614,13 @@ BOOST_AUTO_TEST_CASE(TestNestedFiltering)
   expressions::Filter f3 = test::x < 3;
 
   TestA testA{tableA};
-  FilteredTest filtered{{testA.asArrowTable()}, expressions::createSelection(testA.asArrowTable(), f1)};
+  auto s1 = expressions::createSelection(testA.asArrowTable(), f1);
+  FilteredTest filtered{{testA.asArrowTable()}, s1};
   BOOST_CHECK_EQUAL(4, filtered.size());
   BOOST_CHECK(filtered.begin() != filtered.end());
 
-  NestedFilteredTest nestedFiltered{{filtered}, expressions::createSelection(filtered.asArrowTable(), f2)};
+  auto s2 = expressions::createSelection(filtered.asArrowTable(), f2);
+  NestedFilteredTest nestedFiltered{{filtered}, s2};
   BOOST_CHECK_EQUAL(2, nestedFiltered.size());
   auto i = 0;
   for (auto& f : nestedFiltered) {
@@ -626,7 +631,8 @@ BOOST_AUTO_TEST_CASE(TestNestedFiltering)
   }
   BOOST_CHECK_EQUAL(i, 2);
 
-  TripleNestedFilteredTest tripleFiltered{{nestedFiltered}, expressions::createSelection(nestedFiltered.asArrowTable(), f3)};
+  auto s3 = expressions::createSelection(nestedFiltered.asArrowTable(), f3);
+  TripleNestedFilteredTest tripleFiltered{{nestedFiltered}, s3};
   BOOST_CHECK_EQUAL(1, tripleFiltered.size());
   i = 0;
   for (auto& f : tripleFiltered) {

--- a/Framework/Core/test/test_ASoAHelpers.cxx
+++ b/Framework/Core/test/test_ASoAHelpers.cxx
@@ -16,6 +16,7 @@
 #include "Framework/ASoAHelpers.h"
 #include "Framework/TableBuilder.h"
 #include "Framework/AnalysisDataModel.h"
+#include "Framework/ExpressionHelpers.h"
 #include <boost/test/unit_test.hpp>
 
 using namespace o2::framework;
@@ -212,7 +213,8 @@ BOOST_AUTO_TEST_CASE(CombinationsGeneratorConstruction)
   BOOST_REQUIRE_EQUAL(static_cast<test::X>(std::get<1>(endCombination)).getIterator().mCurrentChunk, 0);
 
   o2::framework::expressions::Filter filter = test::x > 3;
-  auto filtered = Filtered<TestA>{{testsA.asArrowTable()}, o2::framework::expressions::createSelection(testsA.asArrowTable(), filter)};
+  auto s1 = o2::framework::expressions::createSelection(testsA.asArrowTable(), filter);
+  auto filtered = Filtered<TestA>{{testsA.asArrowTable()}, s1};
 
   CombinationsGenerator<CombinationsStrictlyUpperIndexPolicy<Filtered<TestA>, Filtered<TestA>>>::CombinationsIterator combItFiltered(CombinationsStrictlyUpperIndexPolicy(filtered, filtered));
   BOOST_REQUIRE_NE(static_cast<test::X>(std::get<0>(*(combItFiltered))).getIterator().mCurrentPos, nullptr);

--- a/Framework/Core/test/test_AnalysisTask.cxx
+++ b/Framework/Core/test/test_AnalysisTask.cxx
@@ -222,7 +222,7 @@ BOOST_AUTO_TEST_CASE(TestPartitionIteration)
   BOOST_CHECK_EQUAL(i, 4);
 
   expressions::Filter f1 = aod::test::x < 4.0f;
-  FilteredTest filtered{{testA.asArrowTable()}, expressions::createSelection(testA.asArrowTable(), f1)};
+  FilteredTest filtered{{testA.asArrowTable()}, o2::soa::selectionToVector(expressions::createSelection(testA.asArrowTable(), f1))};
   PartitionFilteredTest p2 = aod::test::y > 9.0f;
   p2.setTable(filtered);
 


### PR DESCRIPTION
* Renamed `FilteredPolicy` to `FilteredBase` to better describe its role.
* `Filtered<>` now uses span to handle the selection, backed either by internal cache or external buffer. 
* Framework-managed `Filtered` and `Partition` now have their selections and gandiva filters cached by the framework per data frame, improving performance in cases where they are used in several `process()` functions
* Derived `Filtered` objects (sum or intersection) switch to internal cache automatically
* Combinations with filters will use internal caches
* Fixed bug in Combinations where temporary `Filtered` objects were not owned