### PR TITLE
DPL: allow customising the DataRelayer pipeline length from policy

### DIFF
--- a/Framework/Core/include/Framework/CompletionPolicy.h
+++ b/Framework/Core/include/Framework/CompletionPolicy.h
@@ -24,6 +24,7 @@ namespace o2::framework
 struct DeviceSpec;
 struct InputRecord;
 struct InputSpan;
+struct DataRelayer;
 
 /// Policy to describe what to do for a matching DeviceSpec
 /// whenever a new message arrives. The InputRecord being passed to
@@ -57,6 +58,7 @@ struct CompletionPolicy {
   using InputSetElement = DataRef;
   using Callback = std::function<CompletionOp(InputSpan const&)>;
   using CallbackFull = std::function<CompletionOp(InputSpan const&, std::vector<InputSpec> const&)>;
+  using CallbackConfigureRelayer = std::function<void(DataRelayer&)>;
 
   /// Constructor
   CompletionPolicy()
@@ -76,6 +78,9 @@ struct CompletionPolicy {
   Callback callback = nullptr;
   /// Actual policy which decides what to do with a partial InputRecord, extended version
   CallbackFull callbackFull = nullptr;
+  /// A callback which allows you to configure the behavior of the data relayer associated
+  /// to the matching device.
+  CallbackConfigureRelayer configureRelayer = nullptr;
 
   /// Helper to create the default configuration.
   static std::vector<CompletionPolicy> createDefaultPolicies();

--- a/Framework/Core/src/DataRelayer.cxx
+++ b/Framework/Core/src/DataRelayer.cxx
@@ -432,14 +432,14 @@ DataRelayer::RelayChoice
       static std::atomic<size_t> obsoleteCount = 0;
       static std::atomic<size_t> mult = 1;
       if ((obsoleteCount++ % (1 * mult)) == 0) {
-        LOGP(WARNING, "Over {} incoming messages are already obsolete, not relaying.", obsoleteCount);
+        LOGP(warning, "Over {} incoming messages are already obsolete, not relaying.", obsoleteCount);
         if (obsoleteCount > mult * 10) {
           mult = mult * 10;
         }
       }
       return Dropped;
     case TimesliceIndex::ActionTaken::DropInvalid:
-      LOG(WARNING) << "Incoming data is invalid, not relaying.";
+      LOG(warning) << "Incoming data is invalid, not relaying.";
       mStats.malformedInputs++;
       mStats.droppedIncomingMessages++;
       for (size_t pi = 0; pi < nMessages; ++pi) {

--- a/Framework/Core/src/DataRelayer.cxx
+++ b/Framework/Core/src/DataRelayer.cxx
@@ -68,7 +68,11 @@ DataRelayer::DataRelayer(const CompletionPolicy& policy,
 {
   std::scoped_lock<LockableBase(std::recursive_mutex)> lock(mMutex);
 
-  setPipelineLength(DEFAULT_PIPELINE_LENGTH);
+  if (policy.configureRelayer == nullptr) {
+    setPipelineLength(DEFAULT_PIPELINE_LENGTH);
+  } else {
+    policy.configureRelayer(*this);
+  }
 
   // The queries are all the same, so we only have width 1
   auto numInputTypes = mDistinctRoutesIndex.size();


### PR DESCRIPTION
It does not make sense that all devices have the same pipeline length.
In particular slow ones should have very short pipelines so that
we avoid caching a lot of data before processing.