### PR TITLE
add TOF diagnostic from ccdb in digitisation (empty crates, TRM errors)

### DIFF
--- a/DataFormats/Detectors/TOF/include/DataFormatsTOF/Diagnostic.h
+++ b/DataFormats/Detectors/TOF/include/DataFormatsTOF/Diagnostic.h
@@ -33,10 +33,10 @@ class Diagnostic
   Diagnostic() = default;
   int fill(ULong64_t pattern);
   int fill(ULong64_t pattern, int frequency);
-  int getFrequency(ULong64_t pattern);                                                    // Get frequency
-  int getFrequencyROW() { return getFrequency(0); }                                       // Readout window frequency
-  int getFrequencyEmptyCrate(int crate) { return getFrequency(getEmptyCrateKey(crate)); } // empty crate frequency
-  int getFrequencyEmptyTOF() { return getFrequency(1); }                                  // empty crate frequency
+  int getFrequency(ULong64_t pattern) const;                                                    // Get frequency
+  int getFrequencyROW() const { return getFrequency(0); }                                       // Readout window frequency
+  int getFrequencyEmptyCrate(int crate) const { return getFrequency(getEmptyCrateKey(crate)); } // empty crate frequency
+  int getFrequencyEmptyTOF() const { return getFrequency(1); }                                  // empty crate frequency
   int fillNoisy(int channel, int frequency = 1) { return fill(getNoisyChannelKey(channel), frequency); }
   int fillROW() { return fill(0); }
   int fillEmptyCrate(int crate, int frequency = 1) { return fill(getEmptyCrateKey(crate), frequency); }
@@ -49,7 +49,8 @@ class Diagnostic
   void fill(const Diagnostic& diag);                       // for calibration
   void fill(const gsl::span<const o2::tof::Diagnostic>){}; // for calibration
   void merge(const Diagnostic* prev);
-  void getNoisyMap(Bool_t* output); // set true in output channel array
+  void getNoisyMap(Bool_t* output, int noisyThr = 1) const; // set true in output channel array
+  void getNoisyLevelMap(Char_t* output) const;              // set true in output channel array
   unsigned long size() const { return mVector.size(); }
   ULong64_t getPattern(int i) const
   {
@@ -63,6 +64,8 @@ class Diagnostic
   int getCrate(ULong64_t pattern) const;
   int getChannel(ULong64_t pattern) const;
   int getNoisyLevel(ULong64_t pattern) const;
+
+  const std::map<ULong64_t, uint32_t>& getVector() const { return mVector; }
 
  private:
   std::map<ULong64_t, uint32_t> mVector; // diagnostic frequency vector (key/pattern , frequency)

--- a/DataFormats/Detectors/TOF/src/Diagnostic.cxx
+++ b/DataFormats/Detectors/TOF/src/Diagnostic.cxx
@@ -49,7 +49,7 @@ int Diagnostic::fill(ULong64_t pattern, int frequency)
   return frequency;
 }
 
-int Diagnostic::getFrequency(ULong64_t pattern)
+int Diagnostic::getFrequency(ULong64_t pattern) const
 {
   auto pairC = mVector.find(pattern);
   if (pairC != mVector.end()) {
@@ -61,7 +61,7 @@ int Diagnostic::getFrequency(ULong64_t pattern)
 
 void Diagnostic::print() const
 {
-  LOG(INFO) << "Diagnostic patterns";
+  LOG(info) << "Diagnostic patterns";
   for (const auto& [key, value] : mVector) {
     std::cout << key << " = " << value << "; ";
   }
@@ -120,22 +120,22 @@ int Diagnostic::getNoisyLevel(ULong64_t pattern) const
 
 void Diagnostic::fill(const Diagnostic& diag)
 {
-  LOG(DEBUG) << "Filling diagnostic word";
+  LOG(debug) << "Filling diagnostic word";
   for (auto const& el : diag.mVector) {
-    LOG(DEBUG) << "Filling diagnostic pattern " << el.first << " adding " << el.second << " to " << getFrequency(el.first) << " --> " << el.second + getFrequency(el.first);
+    LOG(debug) << "Filling diagnostic pattern " << el.first << " adding " << el.second << " to " << getFrequency(el.first) << " --> " << el.second + getFrequency(el.first);
     fill(el.first, el.second);
   }
 }
 
 void Diagnostic::merge(const Diagnostic* prev)
 {
-  LOG(DEBUG) << "Merging diagnostic words";
+  LOG(debug) << "Merging diagnostic words";
   for (auto const& el : prev->mVector) {
     fill(el.first, el.second + getFrequency(el.first));
   }
 }
 
-void Diagnostic::getNoisyMap(Bool_t* output)
+void Diagnostic::getNoisyLevelMap(Char_t* output) const
 {
   // set true in output channel array
   for (auto pair : mVector) {
@@ -146,6 +146,23 @@ void Diagnostic::getNoisyMap(Bool_t* output)
       continue;
     }
 
-    output[getChannel(key)] = true;
+    output[getChannel(key)] = getNoisyLevel(key);
+  }
+}
+
+void Diagnostic::getNoisyMap(Bool_t* output, int noisyThr) const
+{
+  // set true in output channel array
+  for (auto pair : mVector) {
+    auto key = pair.first;
+    int slot = getSlot(key);
+
+    if (slot != 14) {
+      continue;
+    }
+
+    if (getNoisyLevel(key) >= noisyThr) {
+      output[getChannel(key)] = true;
+    }
   }
 }

--- a/Detectors/TOF/base/include/TOFBase/Strip.h
+++ b/Detectors/TOF/base/include/TOFBase/Strip.h
@@ -85,6 +85,7 @@ class Strip
   void fillOutputContainer(std::vector<o2::tof::Digit>& digits);
 
   static int mDigitMerged;
+  std::map<ULong64_t, o2::tof::Digit>& getDigitMap() { return mDigits; }
 
  protected:
   Int_t mStripIndex = -1;                      ///< Strip ID

--- a/Detectors/TOF/base/src/CalibTOFapi.cxx
+++ b/Detectors/TOF/base/src/CalibTOFapi.cxx
@@ -16,9 +16,24 @@ using namespace o2::tof;
 
 ClassImp(o2::tof::CalibTOFapi);
 
+void CalibTOFapi::resetDia()
+{
+  memset(mEmptyCrateProb, 0., Geo::kNCrate * 4);
+  mTRMerrorProb.clear();
+  mTRMmask.clear();
+  mNoisy.clear();
+}
+
+CalibTOFapi::CalibTOFapi()
+{
+  resetDia();
+}
+
+//______________________________________________________________________
+
 CalibTOFapi::CalibTOFapi(const std::string url)
 {
-
+  CalibTOFapi();
   // setting the URL to the CCDB manager
 
   setURL(url);
@@ -45,6 +60,70 @@ void CalibTOFapi::readTimeSlewingParam()
 
   auto& mgr = CcdbManager::instance();
   mSlewParam = mgr.getForTimeStamp<SlewParam>("TOF/Calib/ChannelCalib", mTimeStamp);
+}
+
+//______________________________________________________________________
+
+void CalibTOFapi::readDiagnosticFrequencies()
+{
+  static const int NCH_PER_CRATE = Geo::NSTRIPXSECTOR * Geo::NPADS;
+  // getting the Diagnostic Frequency calibration
+  // needed for simulation
+
+  auto& mgr = CcdbManager::instance();
+  mDiaFreq = mgr.getForTimeStamp<Diagnostic>("TOF/Calib/Diagnostic", mTimeStamp);
+
+  resetDia();
+
+  if (!mDiaFreq->getFrequencyROW()) {
+    return;
+  }
+
+  float nrow = (float)mDiaFreq->getFrequencyROW();
+  mEmptyTOF = mDiaFreq->getFrequencyEmptyTOF() / nrow;
+
+  nrow -= mDiaFreq->getFrequencyEmptyTOF();
+
+  if (nrow < 1) {
+    return;
+  }
+
+  // fill empty crates
+  int ncrate[Geo::kNCrate];
+  for (int i = 0; i < Geo::kNCrate; i++) {
+    ncrate[i] = mDiaFreq->getFrequencyEmptyCrate(i) - mDiaFreq->getFrequencyEmptyTOF(); // counts of empty crate for non-empty event
+    mEmptyCrateProb[i] = ncrate[i] / nrow;
+  }
+
+  const auto vectorDia = mDiaFreq->getVector();
+  // fill TRM errors and noisy
+  for (auto pair : vectorDia) {
+    auto key = pair.first;
+    int slot = mDiaFreq->getSlot(key);
+
+    if (slot < 13 && slot > 2) { // is TRM
+      int icrate = mDiaFreq->getCrate(key);
+      int crateslot = icrate * 100 + slot;
+      mTRMerrorProb.push_back(std::make_pair(crateslot, pair.second / (nrow - ncrate[icrate])));
+      mTRMmask.push_back(key - mDiaFreq->getTRMKey(icrate, slot)); // remove crate and slot from the key (28 bit errors remaining)
+      continue;
+    }
+
+    int channel = mDiaFreq->getChannel(key);
+    if (channel > -1) { // noisy
+      int crate = channel / NCH_PER_CRATE;
+      mNoisy.push_back(std::make_pair(channel, pair.second / (nrow - ncrate[crate])));
+      continue;
+    }
+  }
+
+  std::sort(mTRMerrorProb.begin(), mTRMerrorProb.end(), [](const auto& a, const auto& b) {
+    return a.first < b.first;
+  });
+
+  std::sort(mNoisy.begin(), mNoisy.end(), [](const auto& a, const auto& b) {
+    return a.first < b.first;
+  });
 }
 
 //______________________________________________________________________

--- a/Detectors/TOF/base/src/WindowFiller.cxx
+++ b/Detectors/TOF/base/src/WindowFiller.cxx
@@ -456,27 +456,27 @@ void WindowFiller::fillDiagnosticFrequency()
       int slot = 0;
       if (mReadoutWindowData[j].isEmptyCrate(ic)) {
         mDiagnosticFrequency.fillEmptyCrate(ic);
-      } else {
-        isTOFempty = false;
-      }
-      if (dia) {
-        int fd = mReadoutWindowData[j].firstDia();
-        int lastdia = fd + dia;
+        if (dia) {
+          int fd = mReadoutWindowData[j].firstDia();
+          int lastdia = fd + dia;
 
-        ULong64_t key;
-        for (int dd = fd; dd < lastdia; dd++) {
-          if (mPatterns[dd] >= 28) {
-            slot = mPatterns[dd] - 28;
-            key = mDiagnosticFrequency.getTRMKey(ic, slot);
-            continue;
-          }
+          ULong64_t key;
+          for (int dd = fd; dd < lastdia; dd++) {
+            if (mPatterns[dd] >= 28) {
+              slot = mPatterns[dd] - 28;
+              key = mDiagnosticFrequency.getTRMKey(ic, slot);
+              continue;
+            }
 
-          key += (1 << mPatterns[dd]);
+            key += (1 << mPatterns[dd]);
 
-          if (dd + 1 == lastdia || mPatterns[dd + 1] >= 28) {
-            mDiagnosticFrequency.fill(key);
+            if (dd + 1 == lastdia || mPatterns[dd + 1] >= 28) {
+              mDiagnosticFrequency.fill(key);
+            }
           }
         }
+      } else {
+        isTOFempty = false;
       }
     }
   }

--- a/Detectors/TOF/workflow/src/TOFClusterizerSpec.cxx
+++ b/Detectors/TOF/workflow/src/TOFClusterizerSpec.cxx
@@ -125,7 +125,9 @@ class TOFDPLClustererTask
     if (mUseCCDB) {
       calibapi.setURL(mCCDBurl.c_str());
       calibapi.setTimeStamp(0);
+      calibapi.readLHCphase();
       calibapi.readTimeSlewingParam();
+      calibapi.readDiagnosticFrequencies();
     }
 
     mClusterer.setCalibApi(&calibapi);
@@ -187,7 +189,7 @@ class TOFDPLClustererTask
 
   void endOfStream(EndOfStreamContext& ec)
   {
-    LOGF(DEBUG, "TOF Clusterer total timing: Cpu: %.3e Real: %.3e s in %d slots",
+    LOGF(debug, "TOF Clusterer total timing: Cpu: %.3e Real: %.3e s in %d slots",
          mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
   }
 

--- a/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
+++ b/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
@@ -182,6 +182,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 
   // option to use/not use CCDB for TOF
   workflowOptions.push_back(ConfigParamSpec{"use-ccdb-tof", o2::framework::VariantType::Bool, false, {"enable access to ccdb tof calibration objects"}});
+  workflowOptions.push_back(ConfigParamSpec{"ccdb-url-tof", o2::framework::VariantType::String, "http://ccdb-test.cern.ch:8080", {"CCDB Url"}});
 
   // option to use or not use the Trap Simulator after digitisation (debate of digitization or reconstruction is for others)
   workflowOptions.push_back(ConfigParamSpec{"disable-trd-trapsim", VariantType::Bool, false, {"disable the trap simulation of the TRD"}});
@@ -509,9 +510,10 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   // the TOF part
   if (isEnabled(o2::detectors::DetID::TOF)) {
     auto useCCDB = configcontext.options().get<bool>("use-ccdb-tof");
+    auto ccdb_url_tof = configcontext.options().get<std::string>("ccdb-url-tof");
     detList.emplace_back(o2::detectors::DetID::TOF);
     // connect the TOF digitization
-    specs.emplace_back(o2::tof::getTOFDigitizerSpec(fanoutsize++, useCCDB, mctruth));
+    specs.emplace_back(o2::tof::getTOFDigitizerSpec(fanoutsize++, useCCDB, mctruth, ccdb_url_tof.c_str()));
     // add TOF digit writer
     specs.emplace_back(o2::tof::getTOFDigitWriterSpec(mctruth));
   }

--- a/Steer/DigitizerWorkflow/src/TOFDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TOFDigitizerSpec.cxx
@@ -41,8 +41,7 @@ namespace tof
 class TOFDPLDigitizerTask : public o2::base::BaseDPLDigitizer
 {
  public:
-  TOFDPLDigitizerTask(bool useCCDB) : mUseCCDB{useCCDB},
-                                      o2::base::BaseDPLDigitizer(o2::base::InitServices::FIELD | o2::base::InitServices::GEOM){};
+  TOFDPLDigitizerTask(bool useCCDB, std::string ccdb_url) : mUseCCDB{useCCDB}, mCCDBurl(ccdb_url), o2::base::BaseDPLDigitizer(o2::base::InitServices::FIELD | o2::base::InitServices::GEOM){};
 
   void initDigitizerTask(framework::InitContext& ic) override
   {
@@ -93,7 +92,8 @@ class TOFDPLDigitizerTask : public o2::base::BaseDPLDigitizer
     o2::dataformats::CalibLHCphaseTOF lhcPhaseObj;
     o2::dataformats::CalibTimeSlewingParamTOF channelCalibObj;
 
-    if (mUseCCDB) { // read calibration objects from ccdb
+    /* 
+   if (mUseCCDB) { // read calibration objects from ccdb
       // check LHC phase
       auto lhcPhase = pc.inputs().get<o2::dataformats::CalibLHCphaseTOF*>("tofccdbLHCphase");
       auto channelCalib = pc.inputs().get<o2::dataformats::CalibTimeSlewingParamTOF*>("tofccdbChannelCalib");
@@ -115,9 +115,17 @@ class TOFDPLDigitizerTask : public o2::base::BaseDPLDigitizer
         channelCalibObj.setFractionUnderPeak(sector, channelInSector, 1);
       }
     }
+*/
 
     o2::tof::CalibTOFapi calibapi(long(0), &lhcPhaseObj, &channelCalibObj);
     mDigitizer->setCalibApi(&calibapi);
+
+    if (mUseCCDB) {
+      calibapi.setURL(mCCDBurl.c_str());
+      calibapi.setTimeStamp(0);
+      calibapi.readTimeSlewingParam();
+      calibapi.readDiagnosticFrequencies();
+    }
 
     static std::vector<o2::tof::HitType> hits;
 
@@ -165,7 +173,7 @@ class TOFDPLDigitizerTask : public o2::base::BaseDPLDigitizer
     pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "READOUTWINDOW", 0, Lifetime::Timeframe}, *readoutwindow);
 
     // send empty pattern from digitizer (it may change in future)
-    static std::vector<uint32_t> patterns;
+    std::vector<uint8_t>& patterns = mDigitizer->getPatterns();
     pc.outputs().snapshot(Output{o2::header::gDataOriginTOF, "PATTERNS", 0, Lifetime::Timeframe}, patterns);
 
     DigitHeader& digitH = mDigitizer->getDigitHeader();
@@ -189,9 +197,10 @@ class TOFDPLDigitizerTask : public o2::base::BaseDPLDigitizer
   std::unique_ptr<std::vector<o2::tof::Digit>> mDigits;
   std::unique_ptr<o2::dataformats::MCTruthContainer<o2::MCCompLabel>> mLabels;
   bool mUseCCDB = false;
+  std::string mCCDBurl;
 };
 
-DataProcessorSpec getTOFDigitizerSpec(int channel, bool useCCDB, bool mctruth)
+DataProcessorSpec getTOFDigitizerSpec(int channel, bool useCCDB, bool mctruth, std::string ccdb_url)
 {
   // create the full data processor spec using
   //  a name identifier
@@ -200,10 +209,10 @@ DataProcessorSpec getTOFDigitizerSpec(int channel, bool useCCDB, bool mctruth)
   //  options that can be used for this processor (here: input file names where to take the hits)
   std::vector<InputSpec> inputs;
   inputs.emplace_back("collisioncontext", "SIM", "COLLISIONCONTEXT", static_cast<SubSpecificationType>(channel), Lifetime::Timeframe);
-  if (useCCDB) {
-    inputs.emplace_back("tofccdbLHCphase", o2::header::gDataOriginTOF, "LHCphase");
-    inputs.emplace_back("tofccdbChannelCalib", o2::header::gDataOriginTOF, "ChannelCalib");
-  }
+  //  if (useCCDB) {
+  //    inputs.emplace_back("tofccdbLHCphase", o2::header::gDataOriginTOF, "LHCphase");
+  //    inputs.emplace_back("tofccdbChannelCalib", o2::header::gDataOriginTOF, "ChannelCalib");
+  //  }
   std::vector<OutputSpec> outputs;
   outputs.emplace_back(o2::header::gDataOriginTOF, "DIGITHEADER", 0, Lifetime::Timeframe);
   outputs.emplace_back(o2::header::gDataOriginTOF, "DIGITS", 0, Lifetime::Timeframe);
@@ -217,7 +226,7 @@ DataProcessorSpec getTOFDigitizerSpec(int channel, bool useCCDB, bool mctruth)
     "TOFDigitizer",
     inputs,
     outputs,
-    AlgorithmSpec{adaptFromTask<TOFDPLDigitizerTask>(useCCDB)},
+    AlgorithmSpec{adaptFromTask<TOFDPLDigitizerTask>(useCCDB, ccdb_url)},
     Options{{"pileup", VariantType::Int, 1, {"whether to run in continuous time mode"}}}
     // I can't use VariantType::Bool as it seems to have a problem
   };

--- a/Steer/DigitizerWorkflow/src/TOFDigitizerSpec.h
+++ b/Steer/DigitizerWorkflow/src/TOFDigitizerSpec.h
@@ -19,7 +19,7 @@ namespace o2
 namespace tof
 {
 
-o2::framework::DataProcessorSpec getTOFDigitizerSpec(int channel, bool useCCDB, bool mctruth);
+o2::framework::DataProcessorSpec getTOFDigitizerSpec(int channel, bool useCCDB, bool mctruth, std::string ccdb_url);
 
 } // end namespace tof
 } // end namespace o2


### PR DESCRIPTION
Changes in simulation (@chiarazampolli ) to read from ccdb
- offset calibration (to decalibrate)
- diagnostic words -> switch off crates, add TRM errors words

tested with pythia 1000 events@50 kHz  (1 TF) using diagnostic of a run with only 1 crate -> digit QC as expected (matching data QC)