### PR TITLE
Remaining fairLogger log level corrections

### DIFF
--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -1448,7 +1448,7 @@ void AODProducerWorkflowDPL::run(ProcessingContext& pc)
 
 void AODProducerWorkflowDPL::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(INFO, "aod producer dpl total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "aod producer dpl total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/Align/Workflow/src/BarrelAlignmentSpec.cxx
+++ b/Detectors/Align/Workflow/src/BarrelAlignmentSpec.cxx
@@ -106,7 +106,7 @@ void BarrelAlignmentSpec::run(ProcessingContext& pc)
 void BarrelAlignmentSpec::endOfStream(EndOfStreamContext& ec)
 {
   //mBarrelAlign.end();
-  LOGF(INFO, "Barrel alignment data pereparation total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "Barrel alignment data pereparation total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/Base/include/DetectorsBase/CTFCoderBase.h
+++ b/Detectors/Base/include/DetectorsBase/CTFCoderBase.h
@@ -56,7 +56,7 @@ class CTFCoderBase
       CTF::readFromTree(bufVec, *tree.get(), mDet.getName());
       if (bufVec.size()) {
         mExtHeader = static_cast<CTFDictHeader&>(CTF::get(bufVec.data())->getHeader());
-        LOGP(INFO, "Found {} {} in {}", mDet.getName(), mExtHeader.asString(), dictPath);
+        LOGP(info, "Found {} {} in {}", mDet.getName(), mExtHeader.asString(), dictPath);
       }
     }
     return bufVec;

--- a/Detectors/CPV/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/CPV/workflow/src/EntropyDecoderSpec.cxx
@@ -60,7 +60,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
 
 void EntropyDecoderSpec::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(INFO, "CPV Entropy Decoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "CPV Entropy Decoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/CPV/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/CPV/workflow/src/EntropyEncoderSpec.cxx
@@ -59,7 +59,7 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(INFO, "CPV Entropy Encoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "CPV Entropy Encoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/CPV/workflow/src/RawToDigitConverterSpec.cxx
+++ b/Detectors/CPV/workflow/src/RawToDigitConverterSpec.cxx
@@ -142,7 +142,7 @@ void RawToDigitConverterSpec::run(framework::ProcessingContext& ctx)
     if (dh->payloadSize == 0) { // send empty output
       auto maxWarn = o2::conf::VerbosityConfig::Instance().maxWarnDeadBeef;
       if (++contDeadBeef <= maxWarn) {
-        LOGP(WARNING, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
+        LOGP(warning, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
              dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize,
              contDeadBeef == maxWarn ? fmt::format(". {} such inputs in row received, stopping reporting", contDeadBeef) : "");
       }

--- a/Detectors/CTF/workflow/src/CTFReaderSpec.cxx
+++ b/Detectors/CTF/workflow/src/CTFReaderSpec.cxx
@@ -117,8 +117,8 @@ void CTFReaderSpec::stopReader()
   if (!mFileFetcher) {
     return;
   }
-  LOGP(INFO, "CTFReader stops processing, {} files read, {} files failed", mFilesRead - mNFailedFiles, mNFailedFiles);
-  LOGP(INFO, "CTF reading total timing: Cpu: {:.3f} Real: {:.3f} s for {} TFs in {} loops",
+  LOGP(info, "CTFReader stops processing, {} files read, {} files failed", mFilesRead - mNFailedFiles, mNFailedFiles);
+  LOGP(info, "CTF reading total timing: Cpu: {:.3f} Real: {:.3f} s for {} TFs in {} loops",
        mTimer.CpuTime(), mTimer.RealTime(), mCTFCounter, mFileFetcher->getNLoops());
   mRunning = false;
   mFileFetcher->stop();
@@ -189,7 +189,7 @@ void CTFReaderSpec::run(ProcessingContext& pc)
         processTF(pc);
         break;
       } else { // explict CTF ID selection list was provided and current entry is not selected
-        LOGP(INFO, "Skipping CTF${} ({} of {} in {})", mCTFCounter, mCurrTreeEntry, mCTFTree->GetEntries(), mCTFFile->GetName());
+        LOGP(info, "Skipping CTF${} ({} of {} in {})", mCTFCounter, mCurrTreeEntry, mCTFTree->GetEntries(), mCTFFile->GetName());
         checkTreeEntries();
         mCTFCounter++;
         continue;
@@ -276,7 +276,7 @@ void CTFReaderSpec::processTF(ProcessingContext& pc)
     mLastSendTime = tNow;
   }
   tNow = std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::system_clock::now()).time_since_epoch().count();
-  LOGP(INFO, "Read CTF#{} {} in {:.3f} s, {:.4f} s elapsed from previous CTF", mCTFCounter, entryStr, mTimer.CpuTime() - cput, 1e-6 * (tNow - mLastSendTime));
+  LOGP(info, "Read CTF#{} {} in {:.3f} s, {:.4f} s elapsed from previous CTF", mCTFCounter, entryStr, mTimer.CpuTime() - cput, 1e-6 * (tNow - mLastSendTime));
   mLastSendTime = tNow;
   mCTFCounter++;
 }

--- a/Detectors/CTF/workflow/src/CTFWriterSpec.cxx
+++ b/Detectors/CTF/workflow/src/CTFWriterSpec.cxx
@@ -354,7 +354,7 @@ void CTFWriterSpec::run(ProcessingContext& pc)
       size_t nc = 0;
       auto runNProp = std::stol(runNStr, &nc);
       if (nc != runNStr.size()) {
-        LOGP(ERROR, "Property runNumber={} is provided but is not a number, ignoring", runNStr);
+        LOGP(error, "Property runNumber={} is provided but is not a number, ignoring", runNStr);
       } else {
         mRun = runNProp;
       }
@@ -368,7 +368,7 @@ void CTFWriterSpec::run(ProcessingContext& pc)
     }
   }
   if ((oldRun != 0 && oldRun != mRun) || (!oldEnv.empty() && oldEnv != mEnvironmentID)) {
-    LOGP(WARNING, "RunNumber/Environment changed from {}/{} to {}/{}", oldRun, oldEnv, mRun, mEnvironmentID);
+    LOGP(warning, "RunNumber/Environment changed from {}/{} to {}/{}", oldRun, oldEnv, mRun, mEnvironmentID);
     closeTFTreeAndFile();
   }
   // check for the LHCPeriod
@@ -463,7 +463,7 @@ void CTFWriterSpec::finalize()
   if (mWriteCTF) {
     closeTFTreeAndFile();
   }
-  LOGF(INFO, "CTF writing total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "CTF writing total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
   mFinalized = true;
 }
@@ -482,7 +482,7 @@ void CTFWriterSpec::prepareTFTreeAndFile(const o2::header::DataHeader* dh)
         (mAccCTFSize && mMaxSize > mMinSize && ((mAccCTFSize + mCurrCTFSize) > mMaxSize))) { // this is not the 1st CTF in the file and the new size will exceed allowed max
       needToOpen = true;
     } else {
-      LOGP(INFO, "Will add new CTF of estimated size {} to existing file of size {}", mCurrCTFSize, mAccCTFSize);
+      LOGP(info, "Will add new CTF of estimated size {} to existing file of size {}", mCurrCTFSize, mAccCTFSize);
     }
   }
   if (needToOpen) {
@@ -715,7 +715,7 @@ size_t CTFWriterSpec::getAvailableDiskSpace(const std::string& path, int level)
   }
   const auto si = std::filesystem::space(path, ec);
   int64_t avail = int64_t(si.available) - nLocked * mChkSize + written; // account already written part of unfinished files
-  LOGP(DEBUG, "{} CTF files open (curr.size: {}) -> can use {} of {} bytes", nLocked, written, avail, si.available);
+  LOGP(debug, "{} CTF files open (curr.size: {}) -> can use {} of {} bytes", nLocked, written, avail, si.available);
   return avail > 0 ? avail : 0;
 }
 

--- a/Detectors/CTP/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/CTP/workflow/src/EntropyDecoderSpec.cxx
@@ -59,7 +59,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
 
 void EntropyDecoderSpec::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(INFO, "CTP Entropy Decoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "CTP Entropy Decoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/CTP/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/CTP/workflow/src/EntropyEncoderSpec.cxx
@@ -58,7 +58,7 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(INFO, "CTP Entropy Encoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "CTP Entropy Encoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/CTP/workflow/src/RawToDigitConverterSpec.cxx
+++ b/Detectors/CTP/workflow/src/RawToDigitConverterSpec.cxx
@@ -49,7 +49,7 @@ void RawToDigitConverterSpec::run(framework::ProcessingContext& ctx)
       if (dh->payloadSize == 0) {
         auto maxWarn = o2::conf::VerbosityConfig::Instance().maxWarnDeadBeef;
         if (++contDeadBeef <= maxWarn) {
-          LOGP(WARNING, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
+          LOGP(warning, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
                dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize,
                contDeadBeef == maxWarn ? fmt::format(". {} such inputs in row received, stopping reporting", contDeadBeef) : "");
         }

--- a/Detectors/Calibration/include/DetectorsCalibration/TimeSlot.h
+++ b/Detectors/Calibration/include/DetectorsCalibration/TimeSlot.h
@@ -65,7 +65,7 @@ class TimeSlot
 
   void print() const
   {
-    LOGF(INFO, "Calibration slot %5d <=TF<=  %5d", mTFStart, mTFEnd);
+    LOGF(info, "Calibration slot %5d <=TF<=  %5d", mTFStart, mTFEnd);
     mContainer->print();
   }
 

--- a/Detectors/DCS/testWorkflow/src/DCStoDPLconverter.h
+++ b/Detectors/DCS/testWorkflow/src/DCStoDPLconverter.h
@@ -116,7 +116,7 @@ o2f::InjectorFunction dcs2dpl(std::unordered_map<DPID, o2h::DataDescription>& dp
         memcpy(hdMessage->GetData(), headerStack.data(), headerStack.size());
         memcpy(plMessage->GetData(), it.second.data(), hdr.payloadSize);
         if (verbose) {
-          LOGP(INFO, "Pushing {} DPs to output for TimeSlice", it.second.size(), it.first, *timesliceId, hdr);
+          LOGP(info, "Pushing {} DPs to output for TimeSlice", it.second.size(), it.first, *timesliceId, hdr);
         }
         it.second.clear();
         FairMQParts outParts;

--- a/Detectors/EMCAL/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/EntropyDecoderSpec.cxx
@@ -60,7 +60,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
 
 void EntropyDecoderSpec::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(INFO, "EMCAL Entropy Decoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "EMCAL Entropy Decoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/EMCAL/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/EntropyEncoderSpec.cxx
@@ -59,7 +59,7 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(INFO, "EMCAL Entropy Encoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "EMCAL Entropy Encoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
@@ -521,7 +521,7 @@ bool RawToCellConverterSpec::isLostTimeframe(framework::ProcessingContext& ctx) 
     if (dh->payloadSize == 0) {
       auto maxWarn = o2::conf::VerbosityConfig::Instance().maxWarnDeadBeef;
       if (++contDeadBeef <= maxWarn) {
-        LOGP(WARNING, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
+        LOGP(warning, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
              dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize,
              contDeadBeef == maxWarn ? fmt::format(". {} such inputs in row received, stopping reporting", contDeadBeef) : "");
       }

--- a/Detectors/EMCAL/workflow/src/StandaloneAODProducerSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/StandaloneAODProducerSpec.cxx
@@ -142,7 +142,7 @@ void StandaloneAODProducerSpec::run(ProcessingContext& pc)
 
 void StandaloneAODProducerSpec::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(INFO, "EMCAL Standalone AOD Producer total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "EMCAL Standalone AOD Producer total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/FIT/FDD/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/FIT/FDD/workflow/src/EntropyDecoderSpec.cxx
@@ -60,7 +60,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
 
 void EntropyDecoderSpec::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(INFO, "FDD Entropy Decoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "FDD Entropy Decoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/FIT/FDD/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/FIT/FDD/workflow/src/EntropyEncoderSpec.cxx
@@ -58,7 +58,7 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(INFO, "FDD Entropy Encoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "FDD Entropy Encoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/FIT/FT0/calibration/src/RecoCalibInfoWorkflow.cxx
+++ b/Detectors/FIT/FT0/calibration/src/RecoCalibInfoWorkflow.cxx
@@ -88,7 +88,7 @@ void RecoCalibInfoWorkflow::run(o2::framework::ProcessingContext& pc)
 }
 void RecoCalibInfoWorkflow::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(INFO, "Reco calib info workflow  dpl total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "Reco calib info workflow  dpl total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/FIT/FT0/macros/FT0Misaligner.C
+++ b/Detectors/FIT/FT0/macros/FT0Misaligner.C
@@ -42,7 +42,7 @@ void FT0Misaligner(const std::string& ccdbHost = "http://ccdb-test.cern.ch:8080"
 
   if (!ccdbHost.empty()) {
     std::string path = objectPath.empty() ? o2::base::NameConf::getAlignmentPath(detFT0) : objectPath;
-    LOGP(INFO, "Storing alignment object on {}/{}", ccdbHost, path);
+    LOGP(info, "Storing alignment object on {}/{}", ccdbHost, path);
     o2::ccdb::CcdbApi api;
     map<string, string> metadata; // can be empty
     api.init(ccdbHost.c_str());   // or http://localhost:8080 for a local installation
@@ -51,7 +51,7 @@ void FT0Misaligner(const std::string& ccdbHost = "http://ccdb-test.cern.ch:8080"
   }
 
   if (!fileName.empty()) {
-    LOGP(INFO, "Storing FT0 alignment in local file {}", fileName);
+    LOGP(info, "Storing FT0 alignment in local file {}", fileName);
     TFile algFile(fileName.c_str(), "recreate");
     algFile.WriteObjectAny(&params, "std::vector<o2::detectors::AlignParam>", "alignment");
     algFile.Close();

--- a/Detectors/FIT/FT0/workflow/include/FT0Workflow/FT0DataReaderDPLSpec.h
+++ b/Detectors/FIT/FT0/workflow/include/FT0Workflow/FT0DataReaderDPLSpec.h
@@ -57,7 +57,7 @@ class FT0DataReaderDPLSpec : public Task
         if (dh->payloadSize == 0) {
           auto maxWarn = o2::conf::VerbosityConfig::Instance().maxWarnDeadBeef;
           if (++contDeadBeef <= maxWarn) {
-            LOGP(WARNING, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
+            LOGP(warning, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
                  dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize,
                  contDeadBeef == maxWarn ? fmt::format(". {} such inputs in row received, stopping reporting", contDeadBeef) : "");
           }

--- a/Detectors/FIT/FT0/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/FIT/FT0/workflow/src/EntropyDecoderSpec.cxx
@@ -60,7 +60,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
 
 void EntropyDecoderSpec::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(INFO, "FT0 Entropy Decoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "FT0 Entropy Decoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/FIT/FT0/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/FIT/FT0/workflow/src/EntropyEncoderSpec.cxx
@@ -59,7 +59,7 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(INFO, "FT0 Entropy Encoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "FT0 Entropy Encoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/FIT/FT0/workflow/src/ReconstructionSpec.cxx
+++ b/Detectors/FIT/FT0/workflow/src/ReconstructionSpec.cxx
@@ -86,7 +86,7 @@ void ReconstructionDPL::run(ProcessingContext& pc)
 
 void ReconstructionDPL::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(INFO, "FT0 reconstruction total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "FT0 reconstruction total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/FIT/FV0/macro/FV0Misaligner.C
+++ b/Detectors/FIT/FV0/macro/FV0Misaligner.C
@@ -35,7 +35,7 @@ void FV0Misaligner(const std::string& ccdbHost = "http://ccdb-test.cern.ch:8080"
 
   if (!ccdbHost.empty()) {
     std::string path = objectPath.empty() ? o2::base::NameConf::getAlignmentPath(detFV0) : objectPath;
-    LOGP(INFO, "Storing alignment object on {}/{}", ccdbHost, path);
+    LOGP(info, "Storing alignment object on {}/{}", ccdbHost, path);
     o2::ccdb::CcdbApi api;
     map<string, string> metadata; // can be empty
     api.init(ccdbHost.c_str());   // or http://localhost:8080 for a local installation
@@ -44,7 +44,7 @@ void FV0Misaligner(const std::string& ccdbHost = "http://ccdb-test.cern.ch:8080"
   }
 
   if (!fileName.empty()) {
-    LOGP(INFO, "Storing FV0 alignment in local file {}", fileName);
+    LOGP(info, "Storing FV0 alignment in local file {}", fileName);
     TFile algFile(fileName.c_str(), "recreate");
     algFile.WriteObjectAny(&params, "std::vector<o2::detectors::AlignParam>", "alignment");
     algFile.Close();

--- a/Detectors/FIT/FV0/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/FIT/FV0/workflow/src/EntropyDecoderSpec.cxx
@@ -60,7 +60,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
 
 void EntropyDecoderSpec::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(INFO, "FV0 Entropy Decoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "FV0 Entropy Decoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/FIT/FV0/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/FIT/FV0/workflow/src/EntropyEncoderSpec.cxx
@@ -58,7 +58,7 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(INFO, "FV0 Entropy Encoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "FV0 Entropy Encoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/FIT/FV0/workflow/src/ReconstructionSpec.cxx
+++ b/Detectors/FIT/FV0/workflow/src/ReconstructionSpec.cxx
@@ -77,7 +77,7 @@ void ReconstructionDPL::run(ProcessingContext& pc)
 
 void ReconstructionDPL::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(INFO, "FV0 reconstruction total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "FV0 reconstruction total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/FIT/workflow/include/FITWorkflow/FITDataReaderDPLSpec.h
+++ b/Detectors/FIT/workflow/include/FITWorkflow/FITDataReaderDPLSpec.h
@@ -80,7 +80,7 @@ class FITDataReaderDPLSpec : public Task
         if (dh->payloadSize == 0) {
           auto maxWarn = o2::conf::VerbosityConfig::Instance().maxWarnDeadBeef;
           if (++contDeadBeef <= maxWarn) {
-            LOGP(WARNING, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
+            LOGP(warning, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
                  dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize,
                  contDeadBeef == maxWarn ? fmt::format(". {} such inputs in row received, stopping reporting", contDeadBeef) : "");
           }

--- a/Detectors/GlobalTracking/src/MatchCosmics.cxx
+++ b/Detectors/GlobalTracking/src/MatchCosmics.cxx
@@ -292,7 +292,7 @@ void MatchCosmics::selectWinners()
         continue;
       }
     }
-    LOGF(INFO, "iter %d Validated %d of %d remaining matches", iter, nValidated, nRemaining);
+    LOGF(info, "iter %d Validated %d of %d remaining matches", iter, nValidated, nRemaining);
     iter++;
   } while (nValidated);
 }

--- a/Detectors/GlobalTracking/src/MatchTOF.cxx
+++ b/Detectors/GlobalTracking/src/MatchTOF.cxx
@@ -93,7 +93,7 @@ void MatchTOF::run(const o2::globaltracking::RecoContainer& inp)
   mTimerTot.Start();
   bool isPrepareTOFClusters = prepareTOFClusters();
   mTimerTot.Stop();
-  LOGF(INFO, "Timing prepareTOFCluster: Cpu: %.3e s Real: %.3e s in %d slots", mTimerTot.CpuTime(), mTimerTot.RealTime(), mTimerTot.Counter() - 1);
+  LOGF(info, "Timing prepareTOFCluster: Cpu: %.3e s Real: %.3e s in %d slots", mTimerTot.CpuTime(), mTimerTot.RealTime(), mTimerTot.Counter() - 1);
 
   if (!isPrepareTOFClusters) { // check cluster before of tracks to see also if MC is required
     return;
@@ -104,14 +104,14 @@ void MatchTOF::run(const o2::globaltracking::RecoContainer& inp)
     return;
   }
   mTimerTot.Stop();
-  LOGF(INFO, "Timing prepare TPC tracks: Cpu: %.3e s Real: %.3e s in %d slots", mTimerTot.CpuTime(), mTimerTot.RealTime(), mTimerTot.Counter() - 1);
+  LOGF(info, "Timing prepare TPC tracks: Cpu: %.3e s Real: %.3e s in %d slots", mTimerTot.CpuTime(), mTimerTot.RealTime(), mTimerTot.Counter() - 1);
 
   mTimerTot.Start();
   if (!prepareFITData()) {
     return;
   }
   mTimerTot.Stop();
-  LOGF(INFO, "Timing prepare FIT data: Cpu: %.3e s Real: %.3e s in %d slots", mTimerTot.CpuTime(), mTimerTot.RealTime(), mTimerTot.Counter() - 1);
+  LOGF(info, "Timing prepare FIT data: Cpu: %.3e s Real: %.3e s in %d slots", mTimerTot.CpuTime(), mTimerTot.RealTime(), mTimerTot.Counter() - 1);
 
   mTimerTot.Start();
   for (int sec = o2::constants::math::NSectors; sec--;) {
@@ -139,9 +139,9 @@ void MatchTOF::run(const o2::globaltracking::RecoContainer& inp)
   mIsITSTPCTRDused = false;
 
   mTimerTot.Stop();
-  LOGF(INFO, "Timing Do Matching:             Cpu: %.3e s Real: %.3e s in %d slots", mTimerTot.CpuTime(), mTimerTot.RealTime(), mTimerTot.Counter() - 1);
-  LOGF(INFO, "Timing Do Matching Constrained: Cpu: %.3e s Real: %.3e s in %d slots", mTimerMatchITSTPC.CpuTime(), mTimerMatchITSTPC.RealTime(), mTimerMatchITSTPC.Counter() - 1);
-  LOGF(INFO, "Timing Do Matching TPC        : Cpu: %.3e s Real: %.3e s in %d slots", mTimerMatchTPC.CpuTime(), mTimerMatchTPC.RealTime(), mTimerMatchTPC.Counter() - 1);
+  LOGF(info, "Timing Do Matching:             Cpu: %.3e s Real: %.3e s in %d slots", mTimerTot.CpuTime(), mTimerTot.RealTime(), mTimerTot.Counter() - 1);
+  LOGF(info, "Timing Do Matching Constrained: Cpu: %.3e s Real: %.3e s in %d slots", mTimerMatchITSTPC.CpuTime(), mTimerMatchITSTPC.RealTime(), mTimerMatchITSTPC.Counter() - 1);
+  LOGF(info, "Timing Do Matching TPC        : Cpu: %.3e s Real: %.3e s in %d slots", mTimerMatchTPC.CpuTime(), mTimerMatchTPC.RealTime(), mTimerMatchTPC.Counter() - 1);
 }
 //______________________________________________
 void MatchTOF::print() const

--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -117,7 +117,7 @@ void MatchTPCITS::run(const o2::globaltracking::RecoContainer& inp)
 
   if (mParams->verbosity > 0) {
     for (int i = 0; i < NStopWatches; i++) {
-      LOGF(INFO, "Timing for %15s: Cpu: %.3e Real: %.3e s in %d slots of TF#%d", TimerName[i], mTimer[i].CpuTime(), mTimer[i].RealTime(), mTimer[i].Counter() - 1, mTFCount);
+      LOGF(info, "Timing for %15s: Cpu: %.3e Real: %.3e s in %d slots of TF#%d", TimerName[i], mTimer[i].CpuTime(), mTimer[i].RealTime(), mTimer[i].Counter() - 1, mTFCount);
     }
   }
   mTFCount++;
@@ -268,14 +268,14 @@ void MatchTPCITS::selectBestMatches()
       }
     }
     if (mParams->verbosity > 0) {
-      LOGP(INFO, "iter {}: Validated {} of {} remaining matches", iter, nValidated, nremaining);
+      LOGP(info, "iter {}: Validated {} of {} remaining matches", iter, nValidated, nremaining);
     }
     iter++;
     nValidatedTotal += nValidated;
   } while (nValidated);
 
   mTimer[SWSelectBest].Stop();
-  LOGP(INFO, "Validated {} matches for {} TPC tracks in {} iterations", nValidatedTotal, mTPCWork.size(), iter);
+  LOGP(info, "Validated {} matches for {} TPC tracks in {} iterations", nValidatedTotal, mTPCWork.size(), iter);
 }
 
 //______________________________________________
@@ -1288,8 +1288,8 @@ bool MatchTPCITS::refitTrackTPCITS(int iTPC, int& iITS)
     nclRefit++;
   }
   if (nclRefit != ncl) {
-    LOGP(DEBUG, "Refit in ITS failed after ncl={}, match between TPC track #{} and ITS track #{}", nclRefit, tTPC.sourceID, tITS.sourceID);
-    LOGP(DEBUG, "{:s}", trfit.asString());
+    LOGP(debug, "Refit in ITS failed after ncl={}, match between TPC track #{} and ITS track #{}", nclRefit, tTPC.sourceID, tITS.sourceID);
+    LOGP(debug, "{:s}", trfit.asString());
     mMatchedTracks.pop_back(); // destroy failed track
     return false;
   }
@@ -1412,8 +1412,8 @@ bool MatchTPCITS::refitABTrack(int iITSAB, const TPCABSeed& seed)
     nclRefit++;
   }
   if (nclRefit != ncl) {
-    LOGP(DEBUG, "AfterBurner refit in ITS failed after ncl={}, match between TPC track #{} and ITS tracklet #{}", nclRefit, tTPC.sourceID, iITSAB);
-    LOGP(DEBUG, "{:s}", tracOut.asString());
+    LOGP(debug, "AfterBurner refit in ITS failed after ncl={}, match between TPC track #{} and ITS tracklet #{}", nclRefit, tTPC.sourceID, iITSAB);
+    LOGP(debug, "{:s}", tracOut.asString());
     mMatchedTracks.pop_back(); // destroy failed track
     return false;
   }
@@ -1596,7 +1596,7 @@ void MatchTPCITS::runAfterBurner()
   mTimer[SWABSeeds].Start(false);
   prepareABSeeds();
   int nIntCand = mInteractions.size(), nABSeeds = mTPCABSeeds.size();
-  LOGP(INFO, "Afterburner will check {} seeds from {} TPC tracks and {} interaction candidates", nABSeeds, mTPCABIndexCache.size(), nIntCand); // TMP
+  LOGP(info, "Afterburner will check {} seeds from {} TPC tracks and {} interaction candidates", nABSeeds, mTPCABIndexCache.size(), nIntCand); // TMP
   mTimer[SWABSeeds].Stop();
   if (!nIntCand || !mTPCABSeeds.size()) {
     return;

--- a/Detectors/GlobalTrackingWorkflow/src/CosmicsMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/CosmicsMatchingSpec.cxx
@@ -134,7 +134,7 @@ void CosmicsMatchingSpec::run(ProcessingContext& pc)
 void CosmicsMatchingSpec::endOfStream(EndOfStreamContext& ec)
 {
   mMatching.end();
-  LOGF(INFO, "Cosmics matching total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "Cosmics matching total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/GlobalTrackingWorkflow/src/GlobalFwdMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/GlobalFwdMatchingSpec.cxx
@@ -116,7 +116,7 @@ void GlobalFwdMatchingDPL::run(ProcessingContext& pc)
 
 void GlobalFwdMatchingDPL::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(INFO, "Forward matcher total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "Forward matcher total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/GlobalTrackingWorkflow/src/PrimaryVertexingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/PrimaryVertexingSpec.cxx
@@ -173,7 +173,7 @@ void PrimaryVertexingSpec::run(ProcessingContext& pc)
 void PrimaryVertexingSpec::endOfStream(EndOfStreamContext& ec)
 {
   mVertexer.end();
-  LOGF(INFO, "Primary vertexing total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "Primary vertexing total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/GlobalTrackingWorkflow/src/SecondaryVertexingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/SecondaryVertexingSpec.cxx
@@ -108,7 +108,7 @@ void SecondaryVertexingSpec::run(ProcessingContext& pc)
 
 void SecondaryVertexingSpec::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(INFO, "Secondary vertexing total timing: Cpu: %.3e Real: %.3e s in %d slots, nThreads = %d",
+  LOGF(info, "Secondary vertexing total timing: Cpu: %.3e Real: %.3e s in %d slots, nThreads = %d",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1, mVertexer.getNThreads());
 }
 

--- a/Detectors/GlobalTrackingWorkflow/src/TOFEventTimeChecker.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TOFEventTimeChecker.cxx
@@ -569,7 +569,7 @@ void TOFEventTimeChecker::run(ProcessingContext& pc)
 
 void TOFEventTimeChecker::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(DEBUG, "TOF matching total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(debug, "TOF matching total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 
   mFout->cd();

--- a/Detectors/GlobalTrackingWorkflow/src/TOFMatchChecker.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TOFMatchChecker.cxx
@@ -214,7 +214,7 @@ void TOFMatchChecker::run(ProcessingContext& pc)
 
 void TOFMatchChecker::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(DEBUG, "TOF matching total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(debug, "TOF matching total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/GlobalTrackingWorkflow/src/TOFMatcherSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TOFMatcherSpec.cxx
@@ -161,7 +161,7 @@ void TOFMatcherSpec::run(ProcessingContext& pc)
 
 void TOFMatcherSpec::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(DEBUG, "TOF matching total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(debug, "TOF matching total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
@@ -160,7 +160,7 @@ void TPCITSMatchingDPL::run(ProcessingContext& pc)
 void TPCITSMatchingDPL::endOfStream(EndOfStreamContext& ec)
 {
   mMatching.end();
-  LOGF(INFO, "TPC-ITS matching total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "TPC-ITS matching total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/GlobalTrackingWorkflow/src/VertexTrackMatcherSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/VertexTrackMatcherSpec.cxx
@@ -78,7 +78,7 @@ void VertexTrackMatcherSpec::run(ProcessingContext& pc)
 
 void VertexTrackMatcherSpec::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(INFO, "Primary vertex - track matching total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "Primary vertex - track matching total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/GlobalTrackingWorkflow/src/tfidinfo-writer-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/tfidinfo-writer-workflow.cxx
@@ -52,7 +52,7 @@ class TFIDInfoWriter : public o2::framework::Task
   {
     TFile fl(mOutFileName.c_str(), "recreate");
     fl.WriteObjectAny(&mData, "std::vector<o2::dataformats::TFIDInfo>", "tfidinfo");
-    LOGP(INFO, "Wrote TFIDInfo vector with {} entries to {}", mData.size(), fl.GetName());
+    LOGP(info, "Wrote TFIDInfo vector with {} entries to {}", mData.size(), fl.GetName());
   }
 
  private:

--- a/Detectors/GlobalTrackingWorkflow/src/tof-matcher-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/tof-matcher-workflow.cxx
@@ -103,7 +103,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 
   GID::mask_t src = alowedSources & GID::getSourcesMask(configcontext.options().get<std::string>("track-sources"));
   if (strict && (src & ~GID::getSourcesMask("TPC,TPC-TRD")).any()) {
-    LOGP(WARNING, "In strict matching mode only TPC and TPC-TRD sources allowed, {} asked, redefining", GID::getSourcesNames(src));
+    LOGP(warning, "In strict matching mode only TPC and TPC-TRD sources allowed, {} asked, redefining", GID::getSourcesNames(src));
     src &= GID::getSourcesMask("TPC,TPC-TRD");
   }
   GID::mask_t mcmaskcl;

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/RecoWorkflowSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/RecoWorkflowSpec.cxx
@@ -116,7 +116,7 @@ class TOFDPLRecoWorkflowTask
 
   void endOfStream(EndOfStreamContext& ec)
   {
-    LOGF(INFO, "TOF Matching total timing: Cpu: %.3e Real: %.3e s in %d slots",
+    LOGF(info, "TOF Matching total timing: Cpu: %.3e Real: %.3e s in %d slots",
          mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
   }
 

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
@@ -116,7 +116,7 @@ void TPCInterpolationDPL::run(ProcessingContext& pc)
 
   mInterpolation.process(recoData, gids, gidTables, seeds, trkTimes);
   mTimer.Stop();
-  LOGF(INFO, "TPC insterpolation timing: Cpu: %.3e Real: %.3e s", mTimer.CpuTime(), mTimer.RealTime());
+  LOGF(info, "TPC insterpolation timing: Cpu: %.3e Real: %.3e s", mTimer.CpuTime(), mTimer.RealTime());
   mTimer.Start(0);
   //mResidualProcessor.setInputData(mInterpolation.getReferenceTracks(), mInterpolation.getClusterResiduals());
   //mResidualProcessor.convertToLocalResiduals(); // FIXME this will create one output file per TPC sector with local residuals. TODO Add filtering of residuals
@@ -128,7 +128,7 @@ void TPCInterpolationDPL::run(ProcessingContext& pc)
 
 void TPCInterpolationDPL::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(INFO, "TPC residuals extraction total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "TPC residuals extraction total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/HMPID/workflow/src/DataDecoderSpec.cxx
+++ b/Detectors/HMPID/workflow/src/DataDecoderSpec.cxx
@@ -176,7 +176,7 @@ void DataDecoderTask::decodeTF(framework::ProcessingContext& pc)
       if (dh->payloadSize == 0) {
         auto maxWarn = o2::conf::VerbosityConfig::Instance().maxWarnDeadBeef;
         if (++contDeadBeef <= maxWarn) {
-          LOGP(WARNING, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
+          LOGP(warning, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
                dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize,
                contDeadBeef == maxWarn ? fmt::format(". {} such inputs in row received, stopping reporting", contDeadBeef) : "");
         }

--- a/Detectors/HMPID/workflow/src/DataDecoderSpec2.cxx
+++ b/Detectors/HMPID/workflow/src/DataDecoderSpec2.cxx
@@ -186,7 +186,7 @@ void DataDecoderTask2::decodeTF(framework::ProcessingContext& pc)
       if (dh->payloadSize == 0) {
         auto maxWarn = o2::conf::VerbosityConfig::Instance().maxWarnDeadBeef;
         if (++contDeadBeef <= maxWarn) {
-          LOGP(WARNING, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
+          LOGP(warning, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
                dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize,
                contDeadBeef == maxWarn ? fmt::format(". {} such inputs in row received, stopping reporting", contDeadBeef) : "");
         }

--- a/Detectors/HMPID/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/HMPID/workflow/src/EntropyDecoderSpec.cxx
@@ -76,7 +76,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
 
 void EntropyDecoderSpec::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(INFO, "HMPID Entropy Decoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "HMPID Entropy Decoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/HMPID/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/HMPID/workflow/src/EntropyEncoderSpec.cxx
@@ -75,7 +75,7 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(INFO, "HMPID Entropy Encoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "HMPID Entropy Encoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/ITSMFT/ITS/macros/test/ITSMisaligner.C
+++ b/Detectors/ITSMFT/ITS/macros/test/ITSMisaligner.C
@@ -76,7 +76,7 @@ void ITSMisaligner(const std::string& ccdbHost = "http://localhost:8080", long t
 
   if (!ccdbHost.empty()) {
     std::string path = objectPath.empty() ? o2::base::NameConf::getAlignmentPath(detITS) : objectPath;
-    LOGP(INFO, "Storing alignment object on {}/{}", ccdbHost, path);
+    LOGP(info, "Storing alignment object on {}/{}", ccdbHost, path);
     o2::ccdb::CcdbApi api;
     map<string, string> metadata; // can be empty
     api.init(ccdbHost.c_str());   // or http://localhost:8080 for a local installation
@@ -85,7 +85,7 @@ void ITSMisaligner(const std::string& ccdbHost = "http://localhost:8080", long t
   }
 
   if (!fileName.empty()) {
-    LOGP(INFO, "Storing ITS alignment in local file {}", fileName);
+    LOGP(info, "Storing ITS alignment in local file {}", fileName);
     TFile algFile(fileName.c_str(), "recreate");
     algFile.WriteObjectAny(&params, "std::vector<o2::detectors::AlignParam>", "alignment");
     algFile.Close();

--- a/Detectors/ITSMFT/ITS/workflow/src/CookedTrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/CookedTrackerSpec.cxx
@@ -214,7 +214,7 @@ void CookedTrackerDPL::run(ProcessingContext& pc)
 
 void CookedTrackerDPL::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(INFO, "ITS Cooked-Tracker total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "ITS Cooked-Tracker total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/ITSMFT/MFT/simulation/src/GeometryMisAligner.cxx
+++ b/Detectors/ITSMFT/MFT/simulation/src/GeometryMisAligner.cxx
@@ -493,7 +493,7 @@ void GeometryMisAligner::MisAlign(Bool_t verbose, const std::string& ccdbHost, l
 
   if (!ccdbHost.empty()) {
     std::string path = objectPath.empty() ? o2::base::NameConf::getAlignmentPath(o2::detectors::DetID::MFT) : objectPath;
-    LOGP(INFO, "Storing alignment object on {}/{}", ccdbHost, path);
+    LOGP(info, "Storing alignment object on {}/{}", ccdbHost, path);
     o2::ccdb::CcdbApi api;
     std::map<std::string, std::string> metadata; // can be empty
     api.init(ccdbHost.c_str());                  // or http://localhost:8080 for a local installation
@@ -502,7 +502,7 @@ void GeometryMisAligner::MisAlign(Bool_t verbose, const std::string& ccdbHost, l
   }
 
   if (!fileName.empty()) {
-    LOGP(INFO, "Storing MFT alignment in local file {}", fileName);
+    LOGP(info, "Storing MFT alignment in local file {}", fileName);
     TFile algFile(fileName.c_str(), "recreate");
     algFile.WriteObjectAny(&lAPvec, "std::vector<o2::detectors::AlignParam>", "alignment");
     algFile.Close();

--- a/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
@@ -237,7 +237,7 @@ void TrackerDPL::run(ProcessingContext& pc)
 
 void TrackerDPL::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(INFO, "MFT Tracker total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "MFT Tracker total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/ITSMFT/common/reconstruction/src/GBTLink.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/GBTLink.cxx
@@ -82,7 +82,7 @@ void GBTLink::printTrigger(const GBTTrigger* gbtTrg)
 void GBTLink::printCalibrationWord(const GBTCalibration* gbtCal)
 {
   gbtCal->printX();
-  LOGF(INFO, "Calibration word %5d | user_data 0x%06lx", gbtCal->calibCounter, gbtCal->calibUserField);
+  LOGF(info, "Calibration word %5d | user_data 0x%06lx", gbtCal->calibCounter, gbtCal->calibUserField);
 }
 
 ///_________________________________________________________________
@@ -120,14 +120,14 @@ void GBTLink::printDiagnostic(const GBTDiagnostic* gbtD)
 void GBTLink::printCableDiagnostic(const GBTCableDiagnostic* gbtD)
 {
   gbtD->printX();
-  LOGF(INFO, "Diagnostic for %s Lane %d | errorID: %d data 0x%016lx", gbtD->isIB() ? "IB" : "OB", gbtD->getCableID(), gbtD->laneErrorID, gbtD->diagnosticData);
+  LOGF(info, "Diagnostic for %s Lane %d | errorID: %d data 0x%016lx", gbtD->isIB() ? "IB" : "OB", gbtD->getCableID(), gbtD->laneErrorID, gbtD->diagnosticData);
 }
 
 ///_________________________________________________________________
 void GBTLink::printCableStatus(const GBTCableStatus* gbtS)
 {
   gbtS->printX();
-  LOGF(INFO, "Status data, not processed at the moment");
+  LOGF(info, "Status data, not processed at the moment");
 }
 
 ///====================================================================

--- a/Detectors/ITSMFT/common/reconstruction/src/GBTWord.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/GBTWord.cxx
@@ -22,11 +22,11 @@ void GBTWord::printX(bool padded) const
 {
   /// print in right aligned hex format, optionally padding to 128 bits
   if (padded) {
-    LOGF(INFO, "0x: %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x",
+    LOGF(info, "0x: %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x",
          data8[15], data8[14], data8[13], data8[12], data8[11], data8[10],
          data8[9], data8[8], data8[7], data8[6], data8[5], data8[4], data8[3], data8[2], data8[1], data8[0]);
   } else {
-    LOGF(INFO, "0x: %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x",
+    LOGF(info, "0x: %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x",
          data8[9], data8[8], data8[7], data8[6], data8[5], data8[4], data8[3], data8[2], data8[1], data8[0]);
   }
 }
@@ -43,5 +43,5 @@ void GBTWord::printB(bool padded) const
       ss << ((v & (0x1 << j)) ? '1' : '0');
     }
   }
-  LOGF(INFO, "0b: %s", ss.str());
+  LOGF(info, "0b: %s", ss.str());
 }

--- a/Detectors/ITSMFT/common/reconstruction/src/RUInfo.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/RUInfo.cxx
@@ -35,5 +35,5 @@ std::string ChipInfo::asString() const
 
 void ChipInfo::print() const
 {
-  LOGP(INFO, asString());
+  LOGP(info, asString());
 }

--- a/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
@@ -185,7 +185,7 @@ void RawPixelDecoder<Mapping>::setupLinks(InputRecord& inputs)
       if (dh->payloadSize == 0) {
         auto maxWarn = o2::conf::VerbosityConfig::Instance().maxWarnDeadBeef;
         if (++contDeadBeef <= maxWarn) {
-          LOGP(WARNING, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
+          LOGP(warning, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
                dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize,
                contDeadBeef == maxWarn ? fmt::format(". {} such inputs in row received, stopping reporting", contDeadBeef) : "");
         }

--- a/Detectors/ITSMFT/common/simulation/src/MC2RawEncoder.cxx
+++ b/Detectors/ITSMFT/common/simulation/src/MC2RawEncoder.cxx
@@ -38,7 +38,7 @@ void MC2RawEncoder<Mapping>::init()
       if (link) {
         auto subspec = RDHUtils::getSubSpec(link->cruID, link->idInCRU, link->endPointID, link->feeID);
         if (!mWriter.isLinkRegistered(subspec)) {
-          LOGF(INFO, "RU%3d FEEId 0x%04x Link %02d of CRU=0x%94x will be writing to default sink %s",
+          LOGF(info, "RU%3d FEEId 0x%04x Link %02d of CRU=0x%94x will be writing to default sink %s",
                int(ru), link->feeID, link->idInCRU, link->cruID, mDefaultSinkName);
           mWriter.registerLink(link->feeID, link->cruID, link->idInCRU, link->endPointID, mDefaultSinkName);
         }
@@ -61,7 +61,7 @@ void MC2RawEncoder<Mapping>::init()
       link->endPointID = 0;
       link->packetCounter = 0;
       mWriter.registerLink(link->feeID, link->cruID, link->idInCRU, link->endPointID, mDefaultSinkName);
-      LOGF(INFO, "RU%3d FEEId 0x%04x Link %02d of CRU=0x%04x Lanes: %s -> %s", int(ru), link->feeID,
+      LOGF(info, "RU%3d FEEId 0x%04x Link %02d of CRU=0x%04x Lanes: %s -> %s", int(ru), link->feeID,
            link->idInCRU, link->cruID, std::bitset<28>(link->lanes).to_string(), mDefaultSinkName);
       mNLinks++;
     }
@@ -220,7 +220,7 @@ void MC2RawEncoder<Mapping>::fillGBTLinks(RUDecodeData& ru)
     //    gbtTrailer.lanesStops = link->lanes; // RS CURRENTLY NOT USED
     gbtTrailer.packetDone = true;                                // RS CURRENTLY NOT USED
     link->data.addFast(gbtTrailer.getW8(), GBTPaddedWordLength); // write GBT trailer for the last packet
-    LOGF(DEBUG, "Filled %s with %d GBT words", link->describe(), nPayLoadWordsNeeded + 3);
+    LOGF(debug, "Filled %s with %d GBT words", link->describe(), nPayLoadWordsNeeded + 3);
 
     // flush to writer
     mWriter.addData(link->feeID, link->cruID, link->idInCRU, link->endPointID, mCurrIR, gsl::span((char*)link->data.data(), link->data.getSize()));

--- a/Detectors/ITSMFT/common/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/EntropyDecoderSpec.cxx
@@ -77,7 +77,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
 
 void EntropyDecoderSpec::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(INFO, "%s Entropy Decoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "%s Entropy Decoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mOrigin.as<std::string>(), mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/ITSMFT/common/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/EntropyEncoderSpec.cxx
@@ -63,7 +63,7 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(INFO, "%s Entropy Encoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "%s Entropy Encoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mOrigin.as<std::string>(), mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
@@ -233,8 +233,8 @@ void STFDecoder<Mapping>::finalize()
     return;
   }
   mFinalizeDone = true;
-  LOGF(INFO, "%s statistics:", mSelfName);
-  LOGF(INFO, "%s Total STF decoding%s timing (w/o disk IO): Cpu: %.3e Real: %.3e s in %d slots", mSelfName,
+  LOGF(info, "%s statistics:", mSelfName);
+  LOGF(info, "%s Total STF decoding%s timing (w/o disk IO): Cpu: %.3e Real: %.3e s in %d slots", mSelfName,
        mDoClusters ? "/clustering" : "", mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
   if (mDecoder && mAllowReporting) {
     mDecoder->printReport();

--- a/Detectors/PHOS/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/PHOS/workflow/src/EntropyDecoderSpec.cxx
@@ -61,7 +61,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
 
 void EntropyDecoderSpec::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(INFO, "PHOS Entropy Decoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "PHOS Entropy Decoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/PHOS/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/PHOS/workflow/src/EntropyEncoderSpec.cxx
@@ -59,7 +59,7 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(INFO, "PHOS Entropy Encoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "PHOS Entropy Encoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/PHOS/workflow/src/RawToCellConverterSpec.cxx
+++ b/Detectors/PHOS/workflow/src/RawToCellConverterSpec.cxx
@@ -111,7 +111,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
     if (dh->payloadSize == 0) { // send empty output
       auto maxWarn = o2::conf::VerbosityConfig::Instance().maxWarnDeadBeef;
       if (++contDeadBeef <= maxWarn) {
-        LOGP(WARNING, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
+        LOGP(warning, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
              dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize,
              contDeadBeef == maxWarn ? fmt::format(". {} such inputs in row received, stopping reporting", contDeadBeef) : "");
       }

--- a/Detectors/Raw/TFReaderDD/include/TFReaderDD/SubTimeFrameFileReader.h
+++ b/Detectors/Raw/TFReaderDD/include/TFReaderDD/SubTimeFrameFileReader.h
@@ -88,9 +88,9 @@ class SubTimeFrameFileReader
     const std::uint64_t lToRead = std::min(pLen, mFileSize - mFileMapOffset);
 
     if (lToRead != pLen) {
-      LOGP(ERROR, "FileReader: request to read beyond the file end. pos={} size={} len={}",
+      LOGP(error, "FileReader: request to read beyond the file end. pos={} size={} len={}",
            mFileMapOffset, mFileSize, pLen);
-      LOGP(ERROR, "Closing the file {}. The read data is invalid.", mFileName);
+      LOGP(error, "Closing the file {}. The read data is invalid.", mFileName);
       mFileMap.close();
       mFileMapOffset = 0;
       mFileSize = 0;
@@ -112,9 +112,9 @@ class SubTimeFrameFileReader
   {
     const std::size_t lToIgnore = std::min(pLen, std::size_t(mFileSize - mFileMapOffset));
     if (pLen != lToIgnore) {
-      LOGP(ERROR, "FileReader: request to ignore bytes beyond the file end. pos={} size={} len={}",
+      LOGP(error, "FileReader: request to ignore bytes beyond the file end. pos={} size={} len={}",
            mFileMapOffset, mFileSize, pLen);
-      LOGP(ERROR, "Closing the file {}. The read data is invalid.", mFileName);
+      LOGP(error, "Closing the file {}. The read data is invalid.", mFileName);
       mFileMap.close();
       mFileMapOffset = 0;
       mFileSize = 0;

--- a/Detectors/Raw/TFReaderDD/src/SubTimeFrameFileReader.cxx
+++ b/Detectors/Raw/TFReaderDD/src/SubTimeFrameFileReader.cxx
@@ -110,7 +110,7 @@ std::size_t SubTimeFrameFileReader::getHeaderStackSize() // throws ios_base::fai
   set_position(lFilePosStart);
 
   if (lNumHeaders >= cMaxHeaders) {
-    LOGP(ERROR, "FileReader: Reached max number of headers allowed: {}.", cMaxHeaders);
+    LOGP(error, "FileReader: Reached max number of headers allowed: {}.", cMaxHeaders);
     return 0;
   }
 
@@ -157,9 +157,9 @@ Stack SubTimeFrameFileReader::getHeaderStack(std::size_t& pOrigsize)
     if (lBaseOfDH->headerVersion == 1 || lBaseOfDH->headerVersion == 2) {
       /* nothing to do for the upgrade */
     } else {
-      LOGP(ERROR, "FileReader: DataHeader v{} read from file is not upgraded to the current version {}",
+      LOGP(error, "FileReader: DataHeader v{} read from file is not upgraded to the current version {}",
            lBaseOfDH->headerVersion, DataHeader::sVersion);
-      LOGP(ERROR, "Try using a newer version of DataDistribution or file a BUG");
+      LOGP(error, "Try using a newer version of DataDistribution or file a BUG");
     }
 
     if (lBaseOfDH->size() == lStackSize) {
@@ -229,7 +229,7 @@ std::unique_ptr<MessagesPerRoute> SubTimeFrameFileReader::read(FairMQDevice* dev
   auto printStack = [tfID](const o2::header::Stack& st) {
     auto dph = o2::header::get<o2f::DataProcessingHeader*>(st.data());
     auto dh = o2::header::get<o2::header::DataHeader*>(st.data());
-    LOGP(INFO, "TF#{} Header for {}/{}/{} @ timeslice {} run {} | {} of {} size {}, TForbit {} | DPH: {}/{}/{}", tfID,
+    LOGP(info, "TF#{} Header for {}/{}/{} @ timeslice {} run {} | {} of {} size {}, TForbit {} | DPH: {}/{}/{}", tfID,
          dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->runNumber,
          dh->splitPayloadIndex, dh->splitPayloadParts, dh->payloadSize, dh->firstTForbit,
          dph ? dph->startTime : 0, dph ? dph->duration : 0, dph ? dph->creation : 0);
@@ -250,7 +250,7 @@ std::unique_ptr<MessagesPerRoute> SubTimeFrameFileReader::read(FairMQDevice* dev
 
   // verify we're actually reading the correct data in
   if (!(SubTimeFrameFileMeta::getDataHeader().dataDescription == lStfMetaDataHdr->dataDescription)) {
-    LOGP(WARNING, "Reading bad data: SubTimeFrame META header");
+    LOGP(warning, "Reading bad data: SubTimeFrame META header");
     mFileMap.close();
     return nullptr;
   }
@@ -258,14 +258,14 @@ std::unique_ptr<MessagesPerRoute> SubTimeFrameFileReader::read(FairMQDevice* dev
   // prepare to read the TF data
   const auto lStfSizeInFile = lStfFileMeta.mStfSizeInFile;
   if (lStfSizeInFile == (sizeof(DataHeader) + sizeof(SubTimeFrameFileMeta))) {
-    LOGP(WARNING, "Reading an empty TF from file. Only meta information present");
+    LOGP(warning, "Reading an empty TF from file. Only meta information present");
     mFileMap.close();
     return nullptr;
   }
 
   // check there's enough data in the file
   if ((lTfStartPosition + lStfSizeInFile) > this->size()) {
-    LOGP(WARNING, "Not enough data in file for this TF. Required: {}, available: {}", lStfSizeInFile, (this->size() - lTfStartPosition));
+    LOGP(warning, "Not enough data in file for this TF. Required: {}, available: {}", lStfSizeInFile, (this->size() - lTfStartPosition));
     mFileMap.close();
     return nullptr;
   }

--- a/Detectors/Raw/TFReaderDD/src/TFReaderSpec.cxx
+++ b/Detectors/Raw/TFReaderDD/src/TFReaderSpec.cxx
@@ -124,7 +124,7 @@ void TFReaderSpec::run(o2f::ProcessingContext& ctx)
       }
       tNow = std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::system_clock::now()).time_since_epoch().count();
       deltaSending = mTFCounter ? tNow - tLastTF : 0;
-      LOGP(INFO, "Sent TF {} of {} parts, {:.4f} s elapsed from previous TF.", mTFCounter, nparts, double(deltaSending) * 1e-6);
+      LOGP(info, "Sent TF {} of {} parts, {:.4f} s elapsed from previous TF.", mTFCounter, nparts, double(deltaSending) * 1e-6);
       deltaSending -= mInput.delay_us;
       if (!mTFCounter || deltaSending < 0) {
         deltaSending = 0; // correction for next delay
@@ -218,7 +218,7 @@ void TFReaderSpec::TFBuilder()
         mFileFetcher->popFromQueue(mFileFetcher->getNLoops() >= mInput.maxLoops);
       }
     } /*catch (...) {
-      LOGP(ERROR, "Error when building {}-th TF from file {}", locID, tfFileName);
+      LOGP(error, "Error when building {}-th TF from file {}", locID, tfFileName);
       mFileFetcher->popFromQueue(mFileFetcher->getNLoops() >= mInput.maxLoops); // remove faile TF file
     } */
   }

--- a/Detectors/Raw/src/HBFUtilsInitializer.cxx
+++ b/Detectors/Raw/src/HBFUtilsInitializer.cxx
@@ -106,7 +106,7 @@ std::vector<o2::dataformats::TFIDInfo> HBFUtilsInitializer::readTFIDInfoVector(c
 void HBFUtilsInitializer::assignDataHeader(const std::vector<o2::dataformats::TFIDInfo>& tfinfoVec, o2::header::DataHeader& dh)
 {
   const auto tfinf = tfinfoVec[dh.tfCounter % tfinfoVec.size()];
-  LOGP(DEBUG, "Setting DH for {}/{} from tfCounter={} firstTForbit={} runNumber={} to tfCounter={} firstTForbit={} runNumber={}",
+  LOGP(debug, "Setting DH for {}/{} from tfCounter={} firstTForbit={} runNumber={} to tfCounter={} firstTForbit={} runNumber={}",
        dh.dataOrigin.as<std::string>(), dh.dataDescription.as<std::string>(), dh.tfCounter, dh.firstTForbit, dh.runNumber, tfinf.tfCounter, tfinf.firstTForbit, tfinf.runNumber);
   dh.firstTForbit = tfinf.firstTForbit;
   dh.tfCounter = tfinf.tfCounter;

--- a/Detectors/Raw/src/RDHUtils.cxx
+++ b/Detectors/Raw/src/RDHUtils.cxx
@@ -26,10 +26,10 @@ using namespace o2::header;
 void RDHUtils::printRDH(const RAWDataHeaderV4& rdh)
 {
   std::bitset<32> trb(rdh.triggerType);
-  LOGF(INFO, "EP:%d CRU:0x%04x Link:%-3d FEEID:0x%04x Packet:%-3d MemSize:%-4d OffsNext:%-4d prio.:%d BL:%-5d HS:%-2d HV:%d",
+  LOGF(info, "EP:%d CRU:0x%04x Link:%-3d FEEID:0x%04x Packet:%-3d MemSize:%-4d OffsNext:%-4d prio.:%d BL:%-5d HS:%-2d HV:%d",
        int(rdh.endPointID), int(rdh.cruID), int(rdh.linkID), int(rdh.feeId), int(rdh.packetCounter), int(rdh.memorySize),
        int(rdh.offsetToNext), int(rdh.priority), int(rdh.blockLength), int(rdh.headerSize), int(rdh.version));
-  LOGF(INFO, "HBOrb:%-9u TrOrb:%-9u Trg:%32s HBBC:%-4d TrBC:%-4d Page:%-5d Stop:%d Par:%-5d DetFld:0x%04x", //
+  LOGF(info, "HBOrb:%-9u TrOrb:%-9u Trg:%32s HBBC:%-4d TrBC:%-4d Page:%-5d Stop:%d Par:%-5d DetFld:0x%04x", //
        rdh.heartbeatOrbit, rdh.triggerOrbit, trb.to_string().c_str(), int(rdh.heartbeatBC), int(rdh.triggerBC),
        int(rdh.pageCnt), int(rdh.stop), int(rdh.par), int(rdh.detectorField));
 }
@@ -38,10 +38,10 @@ void RDHUtils::printRDH(const RAWDataHeaderV4& rdh)
 void RDHUtils::printRDH(const RAWDataHeaderV5& rdh)
 {
   std::bitset<32> trb(rdh.triggerType);
-  LOGF(INFO, "EP:%d CRU:0x%04x Link:%-3d FEEID:0x%04x Packet:%-3d MemSize:%-5d OffsNext:%-5d  prio.:%d HS:%-2d HV:%d",
+  LOGF(info, "EP:%d CRU:0x%04x Link:%-3d FEEID:0x%04x Packet:%-3d MemSize:%-5d OffsNext:%-5d  prio.:%d HS:%-2d HV:%d",
        int(rdh.endPointID), int(rdh.cruID), int(rdh.linkID), int(rdh.feeId), int(rdh.packetCounter), int(rdh.memorySize),
        int(rdh.offsetToNext), int(rdh.priority), int(rdh.headerSize), int(rdh.version));
-  LOGF(INFO, "Orbit:%-9u BC:%-4d Stop:%d Page:%-5d Trg:%32s Par:%-5d DetFld:0x%04x",
+  LOGF(info, "Orbit:%-9u BC:%-4d Stop:%d Page:%-5d Trg:%32s Par:%-5d DetFld:0x%04x",
        rdh.orbit, int(rdh.bunchCrossing), int(rdh.stop), int(rdh.pageCnt), trb.to_string().c_str(),
        int(rdh.detectorPAR), int(rdh.detectorField));
 }
@@ -50,10 +50,10 @@ void RDHUtils::printRDH(const RAWDataHeaderV5& rdh)
 void RDHUtils::printRDH(const RAWDataHeaderV6& rdh)
 {
   std::bitset<32> trb(rdh.triggerType);
-  LOGF(INFO, "EP:%d CRU:0x%04x Link:%-3d FEEID:0x%04x SrcID:%s[%d] Packet:%-3d MemSize:%-5d OffsNext:%-5d  prio.:%d HS:%-2d HV:%d",
+  LOGF(info, "EP:%d CRU:0x%04x Link:%-3d FEEID:0x%04x SrcID:%s[%d] Packet:%-3d MemSize:%-5d OffsNext:%-5d  prio.:%d HS:%-2d HV:%d",
        int(rdh.endPointID), int(rdh.cruID), int(rdh.linkID), int(rdh.feeId), DAQID::DAQtoO2(rdh.sourceID).str, int(rdh.sourceID), int(rdh.packetCounter),
        int(rdh.memorySize), int(rdh.offsetToNext), int(rdh.priority), int(rdh.headerSize), int(rdh.version));
-  LOGF(INFO, "Orbit:%-9u BC:%-4d Stop:%d Page:%-5d Trg:%32s Par:%-5d DetFld:0x%04x",
+  LOGF(info, "Orbit:%-9u BC:%-4d Stop:%d Page:%-5d Trg:%32s Par:%-5d DetFld:0x%04x",
        rdh.orbit, int(rdh.bunchCrossing), int(rdh.stop), int(rdh.pageCnt), trb.to_string().c_str(),
        int(rdh.detectorPAR), int(rdh.detectorField));
 }
@@ -87,7 +87,7 @@ void RDHUtils::dumpRDH(const void* rdhP)
   const uint32_t* w32 = reinterpret_cast<const uint32_t*>(rdhP);
   for (int i = 0; i < 4; i++) {
     int l = 4 * i;
-    LOGF(INFO, "[rdh%d] 0x%08x 0x%08x 0x%08x 0x%08x", i, w32[l + 3], w32[l + 2], w32[l + 1], w32[l]);
+    LOGF(info, "[rdh%d] 0x%08x 0x%08x 0x%08x 0x%08x", i, w32[l + 3], w32[l + 2], w32[l + 1], w32[l]);
   }
 }
 

--- a/Detectors/Raw/src/RawFileReaderWorkflow.cxx
+++ b/Detectors/Raw/src/RawFileReaderWorkflow.cxx
@@ -168,7 +168,7 @@ void RawReaderSpecs::run(o2f::ProcessingContext& ctx)
         }
       }
     }
-    LOGP(ERROR, "Failed to find output channel for {}/{}/{} @ timeslice {}", h.dataOrigin.str, h.dataDescription.str, h.subSpecification, h.tfCounter);
+    LOGP(error, "Failed to find output channel for {}/{}/{} @ timeslice {}", h.dataOrigin.str, h.dataDescription.str, h.subSpecification, h.tfCounter);
     return std::string{};
   };
 
@@ -199,9 +199,9 @@ void RawReaderSpecs::run(o2f::ProcessingContext& ctx)
       LOG(info) << "Starting new loop " << mLoopsDone << " from the beginning of data";
     } else {
       mTimer[TimerTotal].Stop();
-      LOGF(INFO, "Finished: payload of %zu bytes in %zu messages sent for %d TFs", mSentSize, mSentMessages, mTFCounter);
+      LOGF(info, "Finished: payload of %zu bytes in %zu messages sent for %d TFs", mSentSize, mSentMessages, mTFCounter);
       for (int i = 0; i < NTimers; i++) {
-        LOGF(INFO, "Timing for %15s: Cpu: %.3e Real: %.3e s in %d slots", TimerName[i], mTimer[i].CpuTime(), mTimer[i].RealTime(), mTimer[i].Counter() - 1);
+        LOGF(info, "Timing for %15s: Cpu: %.3e Real: %.3e s in %d slots", TimerName[i], mTimer[i].CpuTime(), mTimer[i].RealTime(), mTimer[i].Counter() - 1);
       }
       ctx.services().get<o2f::ControlService>().endOfStream();
       ctx.services().get<o2f::ControlService>().readyToQuit(o2f::QuitRequest::Me);
@@ -275,7 +275,7 @@ void RawReaderSpecs::run(o2f::ProcessingContext& ctx)
 
       addPart(std::move(hdMessage), std::move(plMessage), fmqChannel);
     }
-    LOGF(DEBUG, "Added %d parts for TF#%d(%d in iteration %d) of %s/%s/0x%u", hdrTmpl.splitPayloadParts, mTFCounter, tfID,
+    LOGF(debug, "Added %d parts for TF#%d(%d in iteration %d) of %s/%s/0x%u", hdrTmpl.splitPayloadParts, mTFCounter, tfID,
          mLoopsDone, link.origin.as<std::string>(), link.description.as<std::string>(), link.subspec);
   }
 
@@ -307,7 +307,7 @@ void RawReaderSpecs::run(o2f::ProcessingContext& ctx)
   }
   mTimer[TimerTotal].Stop();
 
-  LOGF(INFO, "Sent payload of %zu bytes in %zu parts in %zu messages for TF %d | Timing (total/IO): %.3e / %.3e", tfSize, tfNParts,
+  LOGF(info, "Sent payload of %zu bytes in %zu parts in %zu messages for TF %d | Timing (total/IO): %.3e / %.3e", tfSize, tfNParts,
        messagesPerRoute.size(), mTFCounter, mTimer[TimerTotal].CpuTime() - tTotStart, mTimer[TimerIO].CpuTime() - tIOStart);
 
   mSentSize += tfSize;

--- a/Detectors/Raw/src/RawFileWriter.cxx
+++ b/Detectors/Raw/src/RawFileWriter.cxx
@@ -148,10 +148,10 @@ RawFileWriter::LinkData& RawFileWriter::registerLink(uint16_t fee, uint16_t cru,
   }
   if (!linkData.fileName.empty()) { // this link was already declared and associated with a file
     if (linkData.fileName == outFileName) {
-      LOGF(INFO, "Link 0x%ux was already declared with same output, do nothing", sspec);
+      LOGF(info, "Link 0x%ux was already declared with same output, do nothing", sspec);
       return linkData;
     } else {
-      LOGF(ERROR, "Link 0x%ux was already connected to different output file %s", sspec, linkData.fileName);
+      LOGF(error, "Link 0x%ux was already connected to different output file %s", sspec, linkData.fileName);
       throw std::runtime_error("redifinition of the link output file");
     }
   }
@@ -169,7 +169,7 @@ RawFileWriter::LinkData& RawFileWriter::registerLink(uint16_t fee, uint16_t cru,
   linkData.updateIR = mHBFUtils.getFirstIR();
   linkData.buffer.reserve(mSuperPageSize);
   RDHUtils::printRDH(linkData.rdhCopy);
-  LOGF(INFO, "Registered %s with output to %s", linkData.describe(), outFileName);
+  LOGF(info, "Registered %s with output to %s", linkData.describe(), outFileName);
   return linkData;
 }
 
@@ -180,7 +180,7 @@ void RawFileWriter::addData(uint16_t feeid, uint16_t cru, uint8_t lnk, uint8_t e
   auto sspec = RDHUtils::getSubSpec(cru, lnk, endpoint, feeid);
   auto& link = getLinkWithSubSpec(sspec);
   if (mVerbosity > 10) {
-    LOGP(INFO, "addData for {}  on IR BCid:{} Orbit: {}, payload: {}, preformatted: {}, trigger: {}, detField: {}", link.describe(), ir.bc, ir.orbit, data.size(), preformatted, trigger, detField);
+    LOGP(info, "addData for {}  on IR BCid:{} Orbit: {}, payload: {}, preformatted: {}, trigger: {}, detField: {}", link.describe(), ir.bc, ir.orbit, data.size(), preformatted, trigger, detField);
   }
   if (isCRUDetector() && (data.size() % RDHUtils::GBTWord)) {
     LOG(error) << "provided payload size " << data.size() << " is not multiple of GBT word size";
@@ -233,7 +233,7 @@ RawFileWriter::LinkData& RawFileWriter::getLinkWithSubSpec(LinkSubSpec_t ss)
 {
   auto lnkIt = mSSpec2Link.find(ss);
   if (lnkIt == mSSpec2Link.end()) {
-    LOGF(ERROR, "The link for SubSpec=0x%u was not registered", ss);
+    LOGF(error, "The link for SubSpec=0x%u was not registered", ss);
     throw std::runtime_error("data for non-registered GBT link supplied");
   }
   return lnkIt->second;
@@ -549,7 +549,7 @@ void RawFileWriter::LinkData::openHBFPage(const RDHAny& rdhn, uint32_t trigger)
   if ((RDHUtils::getTriggerType(rdhn) & o2::trigger::TF) ||
       (writer->isRORCDetector() && writer->mHBFUtils.getTF(updateIR - 1) < writer->mHBFUtils.getTF(RDHUtils::getTriggerIR(rdhn)))) {
     if (writer->mVerbosity > -10) {
-      LOGF(INFO, "Starting new TF for link FEEId 0x%04x", RDHUtils::getFEEID(rdhn));
+      LOGF(info, "Starting new TF for link FEEId 0x%04x", RDHUtils::getFEEID(rdhn));
     }
     if (writer->mStartTFOnNewSPage && nTFWritten) { // don't flush if 1st TF
       forceNewPage = true;
@@ -581,7 +581,7 @@ void RawFileWriter::LinkData::flushSuperPage(bool keepLastPage)
   // write link superpage data to file (if requested, only up to the last page)
   size_t pgSize = (lastRDHoffset < 0 || !keepLastPage) ? buffer.size() : lastRDHoffset;
   if (writer->mVerbosity) {
-    LOGF(INFO, "Flushing super page of %u bytes for %s", pgSize, describe());
+    LOGF(info, "Flushing super page of %u bytes for %s", pgSize, describe());
   }
   writer->mFName2File.find(fileName)->second.write(buffer.data(), pgSize);
   auto toMove = buffer.size() - pgSize;
@@ -669,7 +669,7 @@ std::string RawFileWriter::LinkData::describe() const
 //____________________________________________
 void RawFileWriter::LinkData::print() const
 {
-  LOGF(INFO, "Summary for %s : NTF: %u NRDH: %u Nbytes: %u", describe(), nTFWritten, nRDHWritten, nBytesWritten);
+  LOGF(info, "Summary for %s : NTF: %u NRDH: %u Nbytes: %u", describe(), nTFWritten, nRDHWritten, nBytesWritten);
 }
 
 //____________________________________________
@@ -720,7 +720,7 @@ void RawFileWriter::DetLazinessCheck::completeLinks(RawFileWriter* wr, const IR&
     auto res = linksDone.find(it.first);
     if (res == linksDone.end()) {
       if (wr->mVerbosity > 10) {
-        LOGP(INFO, "Complete {} for IR BCid:{} Orbit: {}", it.second.describe(), ir.bc, ir.orbit);
+        LOGP(info, "Complete {} for IR BCid:{} Orbit: {}", it.second.describe(), ir.bc, ir.orbit);
       }
       completeCount++;
       it.second.addData(ir, gsl::span<char>{}, preformatted, trigger, detField);

--- a/Detectors/TOF/reconstruction/include/TOFReconstruction/CTFCoder.h
+++ b/Detectors/TOF/reconstruction/include/TOFReconstruction/CTFCoder.h
@@ -188,14 +188,14 @@ void CTFCoder::decompress(const CompressedInfos& cc, VROF& rofRecVec, VDIG& cdig
     digCopy.resize(cc.ndigROF[irof]);
     for (uint32_t idig = 0; idig < cc.ndigROF[irof]; idig++) {
       auto& digit = digCopy[idig]; //cdigVec[digCount];
-      LOGF(DEBUG, "%d) TF=%d, TDC=%d, STRIP=%d, CH=%d", idig, cc.timeFrameInc[digCount], cc.timeTDCInc[digCount], cc.stripID[digCount], cc.chanInStrip[digCount]);
+      LOGF(debug, "%d) TF=%d, TDC=%d, STRIP=%d, CH=%d", idig, cc.timeFrameInc[digCount], cc.timeTDCInc[digCount], cc.stripID[digCount], cc.chanInStrip[digCount]);
       if (cc.timeFrameInc[digCount]) { // new time frame
         ctdc = cc.timeTDCInc[digCount];
         ctimeframe += cc.timeFrameInc[digCount];
       } else {
         ctdc += cc.timeTDCInc[digCount];
       }
-      LOGF(DEBUG, "BC=%ld, TDC=%d, TOT=%d, CH=%d", uint32_t(ctimeframe) * 64 + ctdc / 1024 + BCrow, ctdc % 1024, cc.tot[digCount], uint32_t(cc.stripID[digCount]) * 96 + cc.chanInStrip[digCount]);
+      LOGF(debug, "BC=%ld, TDC=%d, TOT=%d, CH=%d", uint32_t(ctimeframe) * 64 + ctdc / 1024 + BCrow, ctdc % 1024, cc.tot[digCount], uint32_t(cc.stripID[digCount]) * 96 + cc.chanInStrip[digCount]);
 
       digit.setBC(uint32_t(ctimeframe) * 64 + ctdc / 1024 + BCrow);
       digit.setTDC(ctdc % 1024);

--- a/Detectors/TOF/reconstruction/src/CTFCoder.cxx
+++ b/Detectors/TOF/reconstruction/src/CTFCoder.cxx
@@ -50,7 +50,7 @@ void CTFCoder::compress(CompressedInfos& cc,
   const auto& rofRec0 = rofRecVec[0];
   int nrof = rofRecVec.size();
 
-  LOGF(DEBUG, "TOF compress %d ReadoutWindow with %ld digits", nrof, cdigVec.size());
+  LOGF(debug, "TOF compress %d ReadoutWindow with %ld digits", nrof, cdigVec.size());
 
   cc.header.nROFs = nrof;
   cc.header.firstOrbit = rofRec0.getBCData().orbit;
@@ -147,8 +147,8 @@ void CTFCoder::compress(CompressedInfos& cc,
       cc.stripID[idig] = chan / Geo::NPADS;
       cc.chanInStrip[idig] = chan % Geo::NPADS;
       cc.tot[idig] = dig.getTOT();
-      LOGF(DEBUG, "%d) TOFBC = %d, deltaBC = %d, TDC = %d, CH=%d", irof, rofInBC, deltaBC, cTDC, chan);
-      LOGF(DEBUG, "%d) TF=%d, TDC=%d, STRIP=%d, CH=%d, TOT=%d", idig, cc.timeFrameInc[idig], cc.timeTDCInc[idig], cc.stripID[idig], cc.chanInStrip[idig], cc.tot[idig]);
+      LOGF(debug, "%d) TOFBC = %d, deltaBC = %d, TDC = %d, CH=%d", irof, rofInBC, deltaBC, cTDC, chan);
+      LOGF(debug, "%d) TF=%d, TDC=%d, STRIP=%d, CH=%d, TOT=%d", idig, cc.timeFrameInc[idig], cc.timeTDCInc[idig], cc.stripID[idig], cc.chanInStrip[idig], cc.tot[idig]);
     }
   }
   memcpy(cc.pattMap.data(), pattVec.data(), cc.header.nPatternBytes); // RSTODO: do we need this?

--- a/Detectors/TOF/workflow/src/CompressedDecodingTask.cxx
+++ b/Detectors/TOF/workflow/src/CompressedDecodingTask.cxx
@@ -154,7 +154,7 @@ void CompressedDecodingTask::run(ProcessingContext& pc)
 
 void CompressedDecodingTask::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(DEBUG, "TOF CompressedDecoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(debug, "TOF CompressedDecoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 
@@ -172,7 +172,7 @@ void CompressedDecodingTask::decodeTF(ProcessingContext& pc)
       if (dh->payloadSize == 0) {
         auto maxWarn = o2::conf::VerbosityConfig::Instance().maxWarnDeadBeef;
         if (++contDeadBeef <= maxWarn) {
-          LOGP(WARNING, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
+          LOGP(warning, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
                dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize,
                contDeadBeef == maxWarn ? fmt::format(". {} such inputs in row received, stopping reporting", contDeadBeef) : "");
         }

--- a/Detectors/TOF/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/TOF/workflow/src/EntropyDecoderSpec.cxx
@@ -74,7 +74,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
 
 void EntropyDecoderSpec::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(INFO, "TOF Entropy Decoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "TOF Entropy Decoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/TOF/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/TOF/workflow/src/EntropyEncoderSpec.cxx
@@ -60,7 +60,7 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(DEBUG, "TOF Entropy Encoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(debug, "TOF Entropy Encoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/TOF/workflow/src/TOFClusterizerSpec.cxx
+++ b/Detectors/TOF/workflow/src/TOFClusterizerSpec.cxx
@@ -187,7 +187,7 @@ class TOFDPLClustererTask
 
   void endOfStream(EndOfStreamContext& ec)
   {
-    LOGF(DEBUG, "TOF Clusterer total timing: Cpu: %.3e Real: %.3e s in %d slots",
+    LOGF(debug, "TOF Clusterer total timing: Cpu: %.3e Real: %.3e s in %d slots",
          mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
   }
 

--- a/Detectors/TRD/calibration/src/CalibratorVdExB.cxx
+++ b/Detectors/TRD/calibration/src/CalibratorVdExB.cxx
@@ -147,10 +147,10 @@ void CalibratorVdExB::finalizeSlot(Slot& slot)
     auto fitResult = fitter.Result();
     laFitResults[iDet] = fitResult.Parameter(ParamIndex::LA);
     vdFitResults[iDet] = fitResult.Parameter(ParamIndex::VD);
-    LOGF(DEBUG, "Fit result for chamber %i: vd=%f, la=%f", iDet, vdFitResults[iDet], laFitResults[iDet] * TMath::RadToDeg());
+    LOGF(debug, "Fit result for chamber %i: vd=%f, la=%f", iDet, vdFitResults[iDet], laFitResults[iDet] * TMath::RadToDeg());
   }
   timer.Stop();
-  LOGF(INFO, "Done fitting angular residual histograms. CPU time: %f, real time: %f", timer.CpuTime(), timer.RealTime());
+  LOGF(info, "Done fitting angular residual histograms. CPU time: %f, real time: %f", timer.CpuTime(), timer.RealTime());
 
   // write results to CCDB
   o2::ccdb::CcdbApi ccdb;

--- a/Detectors/TRD/reconstruction/src/DataReaderTask.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReaderTask.cxx
@@ -235,7 +235,7 @@ bool DataReaderTask::isTimeFrameEmpty(ProcessingContext& pc)
     if (dh->payloadSize == 0) {
       auto maxWarn = o2::conf::VerbosityConfig::Instance().maxWarnDeadBeef;
       if (++contDeadBeef <= maxWarn) {
-        LOGP(WARNING, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
+        LOGP(warning, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
              dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize,
              contDeadBeef == maxWarn ? fmt::format(". {} such inputs in row received, stopping reporting", contDeadBeef) : "");
       }

--- a/Detectors/TRD/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/TRD/workflow/src/EntropyDecoderSpec.cxx
@@ -78,7 +78,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
 
 void EntropyDecoderSpec::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(INFO, "TRD Entropy Decoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "TRD Entropy Decoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/TRD/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/TRD/workflow/src/EntropyEncoderSpec.cxx
@@ -76,7 +76,7 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(INFO, "TRD Entropy Encoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "TRD Entropy Encoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/TRD/workflow/src/TRDDigitizerSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDDigitizerSpec.cxx
@@ -146,9 +146,9 @@ class TRDDPLDigitizerTask : public o2::base::BaseDPLDigitizer
     if (mctruth) {
       labelsAccum.mergeAtBack(labels);
     }
-    LOGF(INFO, "List of TRD chambers with at least one drift velocity out of range: %s", mDigitizer.dumpFlaggedChambers());
+    LOGF(info, "List of TRD chambers with at least one drift velocity out of range: %s", mDigitizer.dumpFlaggedChambers());
     timer.Stop();
-    LOGF(INFO, "TRD digitization timing: Cpu: %.3e Real: %.3e s", timer.CpuTime(), timer.RealTime());
+    LOGF(info, "TRD digitization timing: Cpu: %.3e Real: %.3e s", timer.CpuTime(), timer.RealTime());
 
     LOG(info) << "TRD: Sending " << digitsAccum.size() << " digits";
     pc.outputs().snapshot(Output{"TRD", "DIGITS", 0, Lifetime::Timeframe}, digitsAccum);

--- a/Detectors/TRD/workflow/src/TRDTrackletTransformerSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrackletTransformerSpec.cxx
@@ -71,16 +71,16 @@ void TRDTrackletTransformerSpec::run(o2::framework::ProcessingContext& pc)
           }
         }
       }
-      LOGF(DEBUG, "ITS IR Frame start: %li, end: %li", irFrame.getMin().toLong(), irFrame.getMax().toLong());
+      LOGF(debug, "ITS IR Frame start: %li, end: %li", irFrame.getMin().toLong(), irFrame.getMax().toLong());
     }
     /*
     // for debugging: print TRD trigger times which are accepted and which are filtered out
     for (int j = 0; j < trigRecs.size(); ++j) {
       const auto& trigRec = trigRecs[j];
       if (!trigRecBitfield[j]) {
-        LOGF(DEBUG, "Could not find ITS info for TRD trigger %i: %li", j, trigRec.getBCData().toLong());
+        LOGF(debug, "Could not find ITS info for TRD trigger %i: %li", j, trigRec.getBCData().toLong());
       } else {
-        LOGF(DEBUG, "Found ITS info for TRD trigger %i: %li", j, trigRec.getBCData().toLong());
+        LOGF(debug, "Found ITS info for TRD trigger %i: %li", j, trigRec.getBCData().toLong());
       }
     }
     */
@@ -110,7 +110,7 @@ void TRDTrackletTransformerSpec::run(o2::framework::ProcessingContext& pc)
     }
   }
 
-  LOGF(INFO, "Found %lu tracklets. Applied filter for ITS IR frames: %i. Transformed %i tracklets.", tracklets.size(), mTrigRecFilterActive, nTrackletsTransformed);
+  LOGF(info, "Found %lu tracklets. Applied filter for ITS IR frames: %i. Transformed %i tracklets.", tracklets.size(), mTrigRecFilterActive, nTrackletsTransformed);
 
   pc.outputs().snapshot(Output{"TRD", "CTRACKLETS", 0, Lifetime::Timeframe}, calibratedTracklets);
   pc.outputs().snapshot(Output{"TRD", "TRIGRECMASK", 0, Lifetime::Timeframe}, trigRecBitfield);

--- a/Detectors/Vertexing/src/PVertexerHelpers.cxx
+++ b/Detectors/Vertexing/src/PVertexerHelpers.cxx
@@ -20,7 +20,7 @@ using namespace o2::vertexing;
 void VertexSeed::print() const
 {
   auto terr2 = tMeanAccErr > 0 ? 1. / tMeanAccErr : 0.;
-  LOGF(INFO, "VtxSeed: Scale: %+e ScalePrev: %+e |NScaleIncreased: %d NSlowDecrease: %d| WChi2: %e WSum: %e | TMean: %e TMeanE: %e\n",
+  LOGF(info, "VtxSeed: Scale: %+e ScalePrev: %+e |NScaleIncreased: %d NSlowDecrease: %d| WChi2: %e WSum: %e | TMean: %e TMeanE: %e\n",
        scaleSigma2, scaleSigma2Prev, nScaleIncrease, nScaleSlowConvergence, wghChi2, wghSum, tMeanAcc * terr2, std::sqrt(terr2));
   double dZP, rmsZP, dZN, rmsZN, dTP, rmsTP, dTN, rmsTN;
   double dZ, rmsZ, dT, rmsT;

--- a/Detectors/ZDC/raw/src/RawReaderZDC.cxx
+++ b/Detectors/ZDC/raw/src/RawReaderZDC.cxx
@@ -266,10 +266,10 @@ void RawReaderZDC::setTriggerMask()
     }
     printTriggerMask += "]";
     uint32_t mytmask = mTriggerMask >> (im * NChPerModule);
-    LOGF(INFO, "Trigger mask for module %d 0123 %c%c%c%c", im,
+    LOGF(info, "Trigger mask for module %d 0123 %c%c%c%c", im,
          mytmask & 0x1 ? 'T' : 'N', mytmask & 0x2 ? 'T' : 'N', mytmask & 0x4 ? 'T' : 'N', mytmask & 0x8 ? 'T' : 'N');
   }
-  LOGF(INFO, "trigger_mask=0x%08x %s", mTriggerMask, printTriggerMask.c_str());
+  LOGF(info, "trigger_mask=0x%08x %s", mTriggerMask, printTriggerMask.c_str());
 }
 } // namespace zdc
 } // namespace o2

--- a/Detectors/ZDC/reconstruction/src/DigiReco.cxx
+++ b/Detectors/ZDC/reconstruction/src/DigiReco.cxx
@@ -498,7 +498,7 @@ int DigiReco::reconstruct(int ibeg, int iend)
             }
             rec.ezdc[ich] = sum * ropt.energy_calib[ich];
           } else {
-            LOGF(WARN, "%d.%-4d CH %2d %s missing pedestal", rec.ir.orbit, rec.ir.bc, ich, ChannelNames[ich].data());
+            LOGF(warn, "%d.%-4d CH %2d %s missing pedestal", rec.ir.orbit, rec.ir.bc, ich, ChannelNames[ich].data());
           }
         } else {
           LOG(fatal) << "Serious mess in reconstruction code";
@@ -550,10 +550,10 @@ void DigiReco::updateOffsets(int ibun)
 
   for (int ich = 0; ich < NChannels; ich++) {
     if (mSource[ich] == PedND) {
-      LOGF(ERROR, "Missing pedestal for ch %2d %s orbit %u ", ich, ChannelNames[ich], mOffsetOrbit);
+      LOGF(error, "Missing pedestal for ch %2d %s orbit %u ", ich, ChannelNames[ich], mOffsetOrbit);
     }
 #ifdef O2_ZDC_DEBUG
-    LOGF(INFO, "Pedestal for ch %2d %s orbit %u %s: %f", ich, ChannelNames[ich], mOffsetOrbit, mSource[ich] == PedOr ? "OR" : (mSource[ich] == PedQC ? "QC" : "??"), mOffset[ich]);
+    LOGF(info, "Pedestal for ch %2d %s orbit %u %s: %f", ich, ChannelNames[ich], mOffsetOrbit, mSource[ich] == PedOr ? "OR" : (mSource[ich] == PedQC ? "QC" : "??"), mOffset[ich]);
 #endif
   }
 } // updateOffsets
@@ -913,7 +913,7 @@ void DigiReco::interpolate(int itdc, int ibeg, int iend)
         if (mSource[ich] != PedND) {
           amp = mOffset[ich] - amp;
         } else {
-          LOGF(ERROR, "%u.%-4d Missing pedestal for TDC %d %s ", mBCData[ibun].ir.orbit, mBCData[ibun].ir.bc, itdc, ChannelNames[TDCSignal[itdc]]);
+          LOGF(error, "%u.%-4d Missing pedestal for TDC %d %s ", mBCData[ibun].ir.orbit, mBCData[ibun].ir.bc, itdc, ChannelNames[TDCSignal[itdc]]);
           amp = std::numeric_limits<float>::infinity();
         }
         int tdc = isam_amp % nsbun;
@@ -948,7 +948,7 @@ void DigiReco::interpolate(int itdc, int ibeg, int iend)
       if (mSource[ich] != PedND) {
         amp = mOffset[ich] - amp;
       } else {
-        LOGF(ERROR, "%u.%-4d Missing pedestal for TDC %d %s ", mBCData[ibun].ir.orbit, mBCData[ibun].ir.bc, itdc, ChannelNames[TDCSignal[itdc]]);
+        LOGF(error, "%u.%-4d Missing pedestal for TDC %d %s ", mBCData[ibun].ir.orbit, mBCData[ibun].ir.bc, itdc, ChannelNames[TDCSignal[itdc]]);
         amp = std::numeric_limits<float>::infinity();
       }
       int tdc = isam_amp % nsbun;

--- a/Detectors/ZDC/simulation/src/Digitizer.cxx
+++ b/Detectors/ZDC/simulation/src/Digitizer.cxx
@@ -555,10 +555,10 @@ void Digitizer::setTriggerMask()
     }
     printTriggerMask += "]";
     uint32_t mytmask = mTriggerMask >> (im * NChPerModule);
-    LOGF(INFO, "Trigger mask for module %d 0123 %c%c%c%c\n", im,
+    LOGF(info, "Trigger mask for module %d 0123 %c%c%c%c\n", im,
          mytmask & 0x1 ? 'T' : 'N', mytmask & 0x2 ? 'T' : 'N', mytmask & 0x4 ? 'T' : 'N', mytmask & 0x8 ? 'T' : 'N');
   }
-  LOGF(INFO, "TriggerMask=0x%08x %s\n", mTriggerMask, printTriggerMask.c_str());
+  LOGF(info, "TriggerMask=0x%08x %s\n", mTriggerMask, printTriggerMask.c_str());
 }
 
 //______________________________________________________________________________
@@ -584,10 +584,10 @@ void Digitizer::setReadoutMask()
     }
     printReadoutMask += "]";
     uint32_t myrmask = mReadoutMask >> (im * NChPerModule);
-    LOGF(INFO, "Readout mask for module %d 0123 %c%c%c%c\n", im,
+    LOGF(info, "Readout mask for module %d 0123 %c%c%c%c\n", im,
          myrmask & 0x1 ? 'R' : 'N', myrmask & 0x2 ? 'R' : 'N', myrmask & 0x4 ? 'R' : 'N', myrmask & 0x8 ? 'R' : 'N');
   }
-  LOGF(INFO, "ReadoutMask=0x%08x %s\n", mReadoutMask, printReadoutMask.c_str());
+  LOGF(info, "ReadoutMask=0x%08x %s\n", mReadoutMask, printReadoutMask.c_str());
 }
 
 //______________________________________________________________________________

--- a/Detectors/ZDC/workflow/src/DigitRecoSpec.cxx
+++ b/Detectors/ZDC/workflow/src/DigitRecoSpec.cxx
@@ -210,7 +210,7 @@ void DigitRecoSpec::run(ProcessingContext& pc)
 void DigitRecoSpec::endOfStream(EndOfStreamContext& ec)
 {
   mDR.eor();
-  LOGF(INFO, "ZDC Reconstruction total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "ZDC Reconstruction total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/ZDC/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/ZDC/workflow/src/EntropyDecoderSpec.cxx
@@ -61,7 +61,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
 
 void EntropyDecoderSpec::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(INFO, "ZDC Entropy Decoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "ZDC Entropy Decoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/ZDC/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/ZDC/workflow/src/EntropyEncoderSpec.cxx
@@ -62,7 +62,7 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
 {
-  LOGF(INFO, "ZDC Entropy Encoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
+  LOGF(info, "ZDC Entropy Encoding total timing: Cpu: %.3e Real: %.3e s in %d slots",
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 

--- a/Detectors/ZDC/workflow/src/ZDCDataReaderDPLSpec.cxx
+++ b/Detectors/ZDC/workflow/src/ZDCDataReaderDPLSpec.cxx
@@ -46,7 +46,7 @@ void ZDCDataReaderDPLSpec::run(ProcessingContext& pc)
       if (dh->payloadSize == 0) {
         auto maxWarn = o2::conf::VerbosityConfig::Instance().maxWarnDeadBeef;
         if (++contDeadBeef <= maxWarn) {
-          LOGP(WARNING, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
+          LOGP(warning, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
                dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize,
                contDeadBeef == maxWarn ? fmt::format(". {} such inputs in row received, stopping reporting", contDeadBeef) : "");
         }


### PR DESCRIPTION
tested locally that this fixes the remaining FairLogger warnings during compilation.
Fixes log messages that were merged meanwhile, and my original script only caught LOG, but not LOGP/LOGF in Detectors.