### PR TITLE
MRRTF-145: only exes (not libs) should bake the mapping implementation

### DIFF
--- a/Detectors/MUON/MCH/Mapping/Interface/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Mapping/Interface/CMakeLists.txt
@@ -9,4 +9,7 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-o2_add_header_only_library(MCHMappingInterface)
+o2_add_header_only_library(MCHMappingInterface TARGETVARNAME target)
+if(APPLE)
+  target_link_options(${target} INTERFACE "LINKER:-undefined,dynamic_lookup")
+endif()

--- a/Detectors/MUON/MCH/Mapping/Interface/include/MCHMappingInterface/CathodeSegmentation.h
+++ b/Detectors/MUON/MCH/Mapping/Interface/include/MCHMappingInterface/CathodeSegmentation.h
@@ -65,11 +65,15 @@ class CathodeSegmentation
  public:
   /// This ctor throws if detElemId is invalid
   CathodeSegmentation(int detElemId, bool isBendingPlane)
-    : mImpl{mchCathodeSegmentationConstruct(detElemId, isBendingPlane)},
+    : mImpl{nullptr},
       mDualSampaIds{},
       mDetElemId{detElemId},
       mIsBendingPlane{isBendingPlane}
   {
+    if (&mchCathodeSegmentationConstruct == NULL) {
+      throw std::runtime_error("no mch mapping implementaion found : did you forget to link with an actual implementation library (e.g. O2MCHMappingImpl4) ? ");
+    }
+    mImpl = mchCathodeSegmentationConstruct(detElemId, isBendingPlane);
     if (!mImpl) {
       throw std::runtime_error("Can not create segmentation for DE " + std::to_string(detElemId) +
                                (mIsBendingPlane ? " Bending" : " NonBending"));

--- a/Detectors/MUON/MCH/Mapping/Interface/include/MCHMappingInterface/CathodeSegmentation.h
+++ b/Detectors/MUON/MCH/Mapping/Interface/include/MCHMappingInterface/CathodeSegmentation.h
@@ -70,7 +70,7 @@ class CathodeSegmentation
       mDetElemId{detElemId},
       mIsBendingPlane{isBendingPlane}
   {
-    if (&mchCathodeSegmentationConstruct == NULL) {
+    if (&mchCathodeSegmentationConstruct == nullptr) {
       throw std::runtime_error("no mch mapping implementaion found : did you forget to link with an actual implementation library (e.g. O2MCHMappingImpl4) ? ");
     }
     mImpl = mchCathodeSegmentationConstruct(detElemId, isBendingPlane);

--- a/Detectors/MUON/MCH/Mapping/Interface/include/MCHMappingInterface/CathodeSegmentationCInterface.h
+++ b/Detectors/MUON/MCH/Mapping/Interface/include/MCHMappingInterface/CathodeSegmentationCInterface.h
@@ -49,7 +49,7 @@ typedef void (*MchPadHandler)(void* clientData, int catPadIndex);
 MchCathodeSegmentationHandle mchCathodeSegmentationConstruct(int detElemId, bool isBendingPlane) __attribute__((weak));
 
 /// Delete a segmentation handle.
-void mchCathodeSegmentationDestruct(MchCathodeSegmentationHandle segHandle);
+void mchCathodeSegmentationDestruct(MchCathodeSegmentationHandle segHandle) __attribute__((weak));
 ///@}
 
 /** @name Pad Unique Identifier
@@ -62,7 +62,7 @@ void mchCathodeSegmentationDestruct(MchCathodeSegmentationHandle segHandle);
 ///@{
 
 /// Return > 0 if catPadIndex is a valid one or <= 1 if not
-int mchCathodeSegmentationIsPadValid(MchCathodeSegmentationHandle segHandle, int catPadIndex);
+int mchCathodeSegmentationIsPadValid(MchCathodeSegmentationHandle segHandle, int catPadIndex) __attribute__((weak));
 ///@}
 
 /** @name Pad finding.
@@ -75,10 +75,10 @@ int mchCathodeSegmentationIsPadValid(MchCathodeSegmentationHandle segHandle, int
 ///@{
 
 /// Find the pad at position (x,y) (in cm).
-int mchCathodeSegmentationFindPadByPosition(MchCathodeSegmentationHandle segHandle, double x, double y);
+int mchCathodeSegmentationFindPadByPosition(MchCathodeSegmentationHandle segHandle, double x, double y) __attribute__((weak));
 
 /// Find the pad connected to the given channel of the given dual sampa.
-int mchCathodeSegmentationFindPadByFEE(MchCathodeSegmentationHandle segHandle, int dualSampaId, int dualSampaChannel);
+int mchCathodeSegmentationFindPadByFEE(MchCathodeSegmentationHandle segHandle, int dualSampaId, int dualSampaChannel) __attribute__((weak));
 ///@}
 
 /** @name Pad information retrieval.
@@ -90,39 +90,39 @@ int mchCathodeSegmentationFindPadByFEE(MchCathodeSegmentationHandle segHandle, i
  * If catPadIndex is invalid, you are on your own.
  */
 /// @{
-double mchCathodeSegmentationPadPositionX(MchCathodeSegmentationHandle segHandle, int catPadIndex);
+double mchCathodeSegmentationPadPositionX(MchCathodeSegmentationHandle segHandle, int catPadIndex) __attribute__((weak));
 
-double mchCathodeSegmentationPadPositionY(MchCathodeSegmentationHandle segHandle, int catPadIndex);
+double mchCathodeSegmentationPadPositionY(MchCathodeSegmentationHandle segHandle, int catPadIndex) __attribute__((weak));
 
-double mchCathodeSegmentationPadSizeX(MchCathodeSegmentationHandle segHandle, int catPadIndex);
+double mchCathodeSegmentationPadSizeX(MchCathodeSegmentationHandle segHandle, int catPadIndex) __attribute__((weak));
 
-double mchCathodeSegmentationPadSizeY(MchCathodeSegmentationHandle segHandle, int catPadIndex);
+double mchCathodeSegmentationPadSizeY(MchCathodeSegmentationHandle segHandle, int catPadIndex) __attribute__((weak));
 
-int mchCathodeSegmentationPadDualSampaId(MchCathodeSegmentationHandle segHandle, int catPadIndex);
+int mchCathodeSegmentationPadDualSampaId(MchCathodeSegmentationHandle segHandle, int catPadIndex) __attribute__((weak));
 
-int mchCathodeSegmentationPadDualSampaChannel(MchCathodeSegmentationHandle segHandle, int catPadIndex);
+int mchCathodeSegmentationPadDualSampaChannel(MchCathodeSegmentationHandle segHandle, int catPadIndex) __attribute__((weak));
 ///@}
 
 /** @name ForEach methods.
  * Functions to loop over some items : detection elements, dual sampas, and pads.
  */
 ///@{
-void mchCathodeSegmentationForEachDetectionElement(MchDetectionElementHandler handler, void* clientData);
+void mchCathodeSegmentationForEachDetectionElement(MchDetectionElementHandler handler, void* clientData) __attribute__((weak));
 
-void mchCathodeSegmentationForOneDetectionElementOfEachSegmentationType(MchDetectionElementHandler handler, void* clientData);
+void mchCathodeSegmentationForOneDetectionElementOfEachSegmentationType(MchDetectionElementHandler handler, void* clientData) __attribute__((weak));
 
-void mchCathodeSegmentationForEachDualSampa(MchCathodeSegmentationHandle segHandle, MchDualSampaHandler handler, void* clientData);
+void mchCathodeSegmentationForEachDualSampa(MchCathodeSegmentationHandle segHandle, MchDualSampaHandler handler, void* clientData) __attribute__((weak));
 
 void mchCathodeSegmentationForEachPadInDualSampa(MchCathodeSegmentationHandle segHandle, int dualSampaId, MchPadHandler handler,
-                                                 void* clientData);
+                                                 void* clientData) __attribute__((weak));
 
 void mchCathodeSegmentationForEachPadInArea(MchCathodeSegmentationHandle segHandle, double xmin, double ymin, double xmax,
-                                            double ymax, MchPadHandler handler, void* clientData);
+                                            double ymax, MchPadHandler handler, void* clientData) __attribute__((weak));
 
-void mchCathodeSegmentationForEachPad(MchCathodeSegmentationHandle segHandle, MchPadHandler handler, void* clientData);
+void mchCathodeSegmentationForEachPad(MchCathodeSegmentationHandle segHandle, MchPadHandler handler, void* clientData) __attribute__((weak));
 
 void mchCathodeSegmentationForEachNeighbouringPad(MchCathodeSegmentationHandle segHandle, int catPadIndex, MchPadHandler handler,
-                                                  void* userData);
+                                                  void* userData) __attribute__((weak));
 ///@}
 
 #ifdef __cplusplus

--- a/Detectors/MUON/MCH/Mapping/Interface/include/MCHMappingInterface/CathodeSegmentationCInterface.h
+++ b/Detectors/MUON/MCH/Mapping/Interface/include/MCHMappingInterface/CathodeSegmentationCInterface.h
@@ -46,7 +46,7 @@ typedef void (*MchPadHandler)(void* clientData, int catPadIndex);
 ///@{
 
 /// Create a handle to a segmentation for a given plane of a detection element.
-MchCathodeSegmentationHandle mchCathodeSegmentationConstruct(int detElemId, bool isBendingPlane);
+MchCathodeSegmentationHandle mchCathodeSegmentationConstruct(int detElemId, bool isBendingPlane) __attribute__((weak));
 
 /// Delete a segmentation handle.
 void mchCathodeSegmentationDestruct(MchCathodeSegmentationHandle segHandle);

--- a/Detectors/MUON/MCH/Mapping/Interface/include/MCHMappingInterface/Segmentation.h
+++ b/Detectors/MUON/MCH/Mapping/Interface/include/MCHMappingInterface/Segmentation.h
@@ -165,7 +165,7 @@ class Segmentation
 /// the Segmentation ctor simply, and ensure by yourself
 /// that you are only creating it once in order not to incur
 /// the (high) price of the construction time of that Segmentation.
-const Segmentation& segmentation(int detElemId);
+const Segmentation& segmentation(int detElemId) __attribute__((weak));
 
 } // namespace mapping
 } // namespace mch

--- a/Detectors/MUON/MCH/Mapping/SegContour/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Mapping/SegContour/CMakeLists.txt
@@ -13,7 +13,7 @@ o2_add_library(MCHMappingSegContour
                SOURCES src/CathodeSegmentationContours.cxx
                        src/CathodeSegmentationSVGWriter.cxx
                        src/SegmentationContours.cxx
-               PUBLIC_LINK_LIBRARIES O2::MCHMappingImpl4 O2::MCHContour
+               PUBLIC_LINK_LIBRARIES O2::MCHMappingInterface O2::MCHContour
                                      Boost::boost)
 
 o2_add_executable(mapping-svg-segmentation3

--- a/Detectors/MUON/MCH/Mapping/SegContour/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Mapping/SegContour/CMakeLists.txt
@@ -19,5 +19,5 @@ o2_add_library(MCHMappingSegContour
 o2_add_executable(mapping-svg-segmentation3
                   COMPONENT_NAME mch
                   SOURCES src/SVGSegmentation.cxx
-                  PUBLIC_LINK_LIBRARIES O2::MCHMappingSegContour
+                  PUBLIC_LINK_LIBRARIES O2::MCHMappingSegContour O2::MCHMappingImpl3
                                         Boost::program_options)

--- a/Detectors/MUON/MCH/PreClustering/CMakeLists.txt
+++ b/Detectors/MUON/MCH/PreClustering/CMakeLists.txt
@@ -12,4 +12,4 @@
 o2_add_library(MCHPreClustering
         SOURCES src/PreClusterFinder.cxx
         src/PreClusterFinderMapping.cxx
-        PUBLIC_LINK_LIBRARIES O2::MCHMappingImpl4 O2::MCHBase O2::Framework)
+        PUBLIC_LINK_LIBRARIES O2::MCHMappingInterface O2::MCHBase O2::Framework)

--- a/Detectors/MUON/MCH/Raw/Decoder/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Raw/Decoder/CMakeLists.txt
@@ -20,7 +20,6 @@ o2_add_library(MCHRawDecoder
                 src/RDHManip.cxx
         PUBLIC_LINK_LIBRARIES O2::DetectorsRaw
                               O2::MCHBase
-                              O2::MCHMappingImpl4
                               O2::MCHMappingInterface
                               O2::MCHRawCommon
                               O2::MCHRawElecMap

--- a/Detectors/MUON/MCH/Raw/Encoder/Payload/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Raw/Encoder/Payload/CMakeLists.txt
@@ -21,7 +21,7 @@ o2_add_library(MCHRawEncoderPayload
         O2::CommonDataFormat
         O2::DetectorsRaw
         O2::MCHBase
-        O2::MCHMappingImpl4
+        O2::MCHMappingInterface
         O2::MCHRawCommon
         O2::MCHRawElecMap
         PRIVATE_LINK_LIBRARIES O2::MCHRawImplHelpers)

--- a/Detectors/MUON/MCH/Raw/test/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Raw/test/CMakeLists.txt
@@ -21,4 +21,5 @@ o2_add_test(closure-codec-digit
                 SOURCES testClosureCoDecDigit.cxx
                 COMPONENT_NAME mchraw
                 LABELS "muon;mch;raw"
-                PUBLIC_LINK_LIBRARIES O2::MCHRawEncoderDigit O2::MCHRawDecoder)
+                PUBLIC_LINK_LIBRARIES O2::MCHRawEncoderDigit O2::MCHRawDecoder
+                O2::MCHMappingImpl4)

--- a/Detectors/MUON/MCH/Simulation/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Simulation/CMakeLists.txt
@@ -24,7 +24,7 @@ o2_add_library(MCHSimulation
                                       O2::DetectorsRaw
                                       O2::MCHBase
                                       O2::MCHGeometryCreator
-                                      O2::MCHMappingImpl4
+                                      O2::MCHMappingInterface
                                       O2::SimulationDataFormat)
 
 o2_target_root_dictionary(MCHSimulation

--- a/Detectors/MUON/MCH/Simulation/test/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Simulation/test/CMakeLists.txt
@@ -22,6 +22,7 @@ o2_add_test(digitizer
                               O2::MCHBase
                               O2::MCHGeometryTest
                               O2::MCHSimulation
+                              O2::MCHMappingImpl4
         LABELS muon mch long sim)
 
 # o2_add_test(response

--- a/Detectors/MUON/MCH/Workflow/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Workflow/CMakeLists.txt
@@ -54,7 +54,7 @@ o2_add_executable(
         raw-to-digits-workflow
         SOURCES src/raw-to-digits-workflow.cxx
         COMPONENT_NAME mch
-        PUBLIC_LINK_LIBRARIES O2::MCHWorkflow)
+        PUBLIC_LINK_LIBRARIES O2::MCHWorkflow O2::MCHMappingImpl4)
 
 o2_add_executable(
         raw-debug-workflow
@@ -84,7 +84,7 @@ o2_add_executable(
         digits-to-preclusters-workflow
         SOURCES src/digits-to-preclusters-workflow.cxx
         COMPONENT_NAME mch
-        PUBLIC_LINK_LIBRARIES O2::MCHWorkflow)
+        PUBLIC_LINK_LIBRARIES O2::MCHWorkflow O2::MCHMappingImpl4)
 
 o2_add_executable(
         digits-reader-workflow
@@ -108,7 +108,7 @@ o2_add_executable(
         preclusters-to-clusters-original-workflow
         SOURCES src/preclusters-to-clusters-original-workflow.cxx
         COMPONENT_NAME mch
-        PUBLIC_LINK_LIBRARIES O2::MCHWorkflow O2::MCHClustering)
+        PUBLIC_LINK_LIBRARIES O2::MCHWorkflow O2::MCHClustering O2::MCHMappingImpl4)
 
 o2_add_executable(
         clusters-sink-workflow
@@ -219,6 +219,7 @@ o2_add_executable(
         COMPONENT_NAME mch
         PUBLIC_LINK_LIBRARIES
             O2::MCHGeometryTransformer
+            O2::MCHMappingImpl4
             O2::MCHTracking
             O2::MCHWorkflow
             O2::SimulationDataFormat

--- a/Steer/DigitizerWorkflow/CMakeLists.txt
+++ b/Steer/DigitizerWorkflow/CMakeLists.txt
@@ -46,7 +46,7 @@ o2_add_executable(digitizer-workflow
                                         O2::ITSSimulation
                                         O2::ITSMFTWorkflow
                                         O2::MCHSimulation
-                                        O2::MCHBase
+                                        O2::MCHMappingImpl4
                                         O2::DataFormatsMCH
                                         O2::MFTSimulation
                                         O2::MIDSimulation
@@ -103,7 +103,7 @@ o2_add_executable(digitizer-workflow
                                         O2::ITSSimulation
                                         O2::ITSMFTWorkflow
                                         O2::MCHSimulation
-                                        O2::MCHBase
+                                        O2::MCHMappingImpl4
                                         O2::MFTSimulation
                                         O2::MIDSimulation
                                         O2::PHOSSimulation

--- a/cmake/O2AddHeaderOnlyLibrary.cmake
+++ b/cmake/O2AddHeaderOnlyLibrary.cmake
@@ -23,7 +23,7 @@ function(o2_add_header_only_library baseTargetName)
                         1
                         A
                         ""
-                        ""
+                        "TARGETVARNAME"
                         "INCLUDE_DIRECTORIES;INTERFACE_LINK_LIBRARIES")
 
   if(A_UNPARSED_ARGUMENTS)
@@ -41,6 +41,10 @@ function(o2_add_header_only_library baseTargetName)
   # O2::${baseTargetName} as well (assuming the export is installed with
   # namespace O2::)
   set_property(TARGET ${target} PROPERTY EXPORT_NAME ${baseTargetName})
+
+  if(A_TARGETVARNAME)
+    set(${A_TARGETVARNAME} ${target} PARENT_SCOPE)
+  endif()
 
   if(NOT A_INCLUDE_DIRECTORIES)
     get_filename_component(dir include ABSOLUTE)


### PR DESCRIPTION
@pillot, as we discussed, this is an attempt to make the muon libraries independent from the actual mapping implementation (as they were intended to be in the first place but weren't really). 

The actual implementation should now only be chosen when building an executable. The current use case is to allow to have run2-compatible executables (using Impl3 of the mapping = run2 version) at the same time as Run3 executables (using Impl4 = current run3 version with e.g. one DS less).

Note that so far I've only tested it on my Mac (ctest and reco-related workflows). 

I'm not making it a draft (which it kind of is still for the moment) to see what the CI says on other platforms...
