### PR TITLE
[EMCAL-507] Remove custom end-of-stream handling via EMCALBlockHeader

### DIFF
--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/RawToCellConverterSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/RawToCellConverterSpec.h
@@ -103,6 +103,15 @@ class RawToCellConverterSpec : public framework::Task
     int mHWAddressHG;          ///< HW address of HG (for monitoring)
   };
   bool isLostTimeframe(framework::ProcessingContext& ctx) const;
+
+  /// \brief Send data to output channels
+  /// \param cells Container with output cells for timeframe
+  /// \param triggers Container with trigger records for timeframe
+  /// \param decodingErrors Container with decoding errors for timeframe
+  ///
+  /// Send data to all output channels for the given subspecification. The subspecification
+  /// is determined on the fly in the run method and therefore used as parameter. Consumers
+  /// must use wildcard subspecification via ConcreteDataTypeMatcher.
   void sendData(framework::ProcessingContext& ctx, const std::vector<o2::emcal::Cell>& cells, const std::vector<o2::emcal::TriggerRecord>& triggers, const std::vector<ErrorTypeFEE>& decodingErrors) const;
 
   header::DataHeader::SubSpecificationType mSubspecification = 0;    ///< Subspecification for output channels

--- a/Detectors/EMCAL/workflow/src/AnalysisClusterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/AnalysisClusterSpec.cxx
@@ -14,7 +14,6 @@
 
 #include "DataFormatsEMCAL/Digit.h"
 #include "DataFormatsEMCAL/Cluster.h"
-#include "DataFormatsEMCAL/EMCALBlockHeader.h"
 #include "DataFormatsEMCAL/TriggerRecord.h"
 #include "EMCALWorkflow/AnalysisClusterSpec.h"
 #include "Framework/ControlService.h"
@@ -71,14 +70,6 @@ void AnalysisClusterSpec<InputType>::run(framework::ProcessingContext& ctx)
   } else if constexpr (std::is_same<InputType, o2::emcal::Cell>::value) {
     inputname = "cells";
     TrigName = "cellstrgr";
-  }
-
-  auto dataref = ctx.inputs().get(inputname.c_str());
-  auto const* emcheader = o2::framework::DataRefUtils::getHeader<o2::emcal::EMCALBlockHeader*>(dataref);
-  if (!emcheader->mHasPayload) {
-    LOG(debug) << "[EMCALClusterizer - run] No more cells/digits" << std::endl;
-    ctx.services().get<o2::framework::ControlService>().readyToQuit(framework::QuitRequest::Me);
-    return;
   }
 
   auto Inputs = ctx.inputs().get<gsl::span<InputType>>(inputname.c_str());

--- a/Detectors/EMCAL/workflow/src/CellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/CellConverterSpec.cxx
@@ -12,7 +12,6 @@
 #include "FairLogger.h"
 
 #include "DataFormatsEMCAL/Digit.h"
-#include "DataFormatsEMCAL/EMCALBlockHeader.h"
 #include "EMCALWorkflow/CellConverterSpec.h"
 #include "Framework/ControlService.h"
 #include "Framework/ConfigParamRegistry.h"

--- a/Detectors/EMCAL/workflow/src/ClusterizerSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/ClusterizerSpec.cxx
@@ -14,7 +14,6 @@
 
 #include "DataFormatsEMCAL/Digit.h"
 #include "DataFormatsEMCAL/Cluster.h"
-#include "DataFormatsEMCAL/EMCALBlockHeader.h"
 #include "DataFormatsEMCAL/TriggerRecord.h"
 #include "EMCALWorkflow/ClusterizerSpec.h"
 #include "Framework/ControlService.h"

--- a/Detectors/EMCAL/workflow/src/DigitsPrinterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/DigitsPrinterSpec.cxx
@@ -18,7 +18,6 @@
 
 #include "Framework/ControlService.h"
 #include "Framework/DataRefUtils.h"
-#include "DataFormatsEMCAL/EMCALBlockHeader.h"
 #include "DataFormatsEMCAL/Cell.h"
 #include "DataFormatsEMCAL/Digit.h"
 #include "DataFormatsEMCAL/TriggerRecord.h"

--- a/Detectors/EMCAL/workflow/src/PublisherSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/PublisherSpec.cxx
@@ -10,7 +10,6 @@
 // or submit itself to any jurisdiction.
 
 #include "DetectorsCommonDataFormats/NameConf.h"
-#include "DataFormatsEMCAL/EMCALBlockHeader.h"
 #include "EMCALWorkflow/PublisherSpec.h"
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/ControlService.h"
@@ -67,9 +66,8 @@ o2::framework::DataProcessorSpec createPublisherSpec(PublisherConf const& config
       }
 
       auto publish = [&processAttributes, &pc, propagateMC]() {
-        o2::emcal::EMCALBlockHeader emcheader(true);
         if (processAttributes->reader->next()) {
-          (*processAttributes->reader)(pc, emcheader);
+          (*processAttributes->reader)(pc);
         } else {
           processAttributes->reader.reset();
           return false;

--- a/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
@@ -21,7 +21,6 @@
 #include "Framework/InputRecordWalker.h"
 #include "Framework/Logger.h"
 #include "Framework/WorkflowSpec.h"
-#include "DataFormatsEMCAL/EMCALBlockHeader.h"
 #include "DataFormatsEMCAL/Constants.h"
 #include "DataFormatsEMCAL/TriggerRecord.h"
 #include "DataFormatsEMCAL/ErrorTypeFEE.h"
@@ -499,12 +498,12 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
         ncellsEvent++;
         mOutputCells.push_back(cell.mCellData);
       }
-      LOG(debug) << "Accepted " << ncellsEvent << " cells";
+      LOG(debug) << "Next event [Orbit " << bc.orbit << ", BC (" << bc.bc << "]: Accepted " << ncellsEvent << " cells";
     }
     mOutputTriggerRecords.emplace_back(bc, triggerBuffer[bc], eventstart, ncellsEvent);
   }
 
-  LOG(debug) << "[EMCALRawToCellConverter - run] Writing " << mOutputCells.size() << " cells ...";
+  LOG(info) << "[EMCALRawToCellConverter - run] Writing " << mOutputCells.size() << " cells from " << mOutputTriggerRecords.size() << " events ...";
   sendData(ctx, mOutputCells, mOutputTriggerRecords, mOutputDecoderErrors);
 }
 


### PR DESCRIPTION
Terminate condition checking the custom EMCALBlockHeader
added as additional payload by the publishers no longer needed.
- Remove publishing of EMCALBlockHeader
- Remove checkReady terminate condition in
  ROOTTreeWriterSpecs
- Remove includes of headers in various Spec

In addition increase verbosity level from LOG of the number
of cells at the end of run of the RawToCellConverter from debug
to info.