### PR TITLE
CTF dictionaries are ready to be fetched from CCDB

### DIFF
--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/CTFDictHeader.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/CTFDictHeader.h
@@ -18,6 +18,7 @@
 
 #include <Rtypes.h>
 #include <string>
+#include "DetectorsCommonDataFormats/DetID.h"
 
 namespace o2
 {
@@ -26,6 +27,7 @@ namespace ctf
 
 /// Detector header base
 struct CTFDictHeader {
+  o2::detectors::DetID det{};
   uint32_t dictTimeStamp = 0; // dictionary creation time (seconds since epoch) / hash
   uint8_t majorVersion = 1;
   uint8_t minorVersion = 0;
@@ -41,7 +43,7 @@ struct CTFDictHeader {
   }
   std::string asString() const;
 
-  ClassDefNV(CTFDictHeader, 1);
+  ClassDefNV(CTFDictHeader, 2);
 };
 
 } // namespace ctf

--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/EncodedBlocks.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/EncodedBlocks.h
@@ -358,6 +358,15 @@ class EncodedBlocks
     return mBlocks[i];
   }
 
+  auto getFrequencyTable(int i) const
+  {
+    o2::rans::FrequencyTable ft;
+    const auto& bl = getBlock(i);
+    const auto& md = getMetadata(i);
+    ft.addFrequencies(bl.getDict(), bl.getDict() + bl.getNDict(), md.min, md.max);
+    return ft;
+  }
+
   void setANSHeader(const ANSHeader& h) { mANSHeader = h; }
   const ANSHeader& getANSHeader() const { return mANSHeader; }
   ANSHeader& getANSHeader() { return mANSHeader; }

--- a/DataFormats/Detectors/Common/src/CTFDictHeader.cxx
+++ b/DataFormats/Detectors/Common/src/CTFDictHeader.cxx
@@ -25,6 +25,6 @@ std::string CTFDictHeader::asString() const
   std::time_t temp = dictTimeStamp;
   std::tm* t = std::gmtime(&temp);
   std::stringstream ss;
-  ss << "Dict. v" << int(majorVersion) << '.' << int(minorVersion) << " from " << std::put_time(t, "%Y-%m-%d %I:%M:%S %p");
+  ss << "CTF Dict for " << det.getName() << ", v" << int(majorVersion) << '.' << int(minorVersion) << " from " << std::put_time(t, "%Y-%m-%d %I:%M:%S %p");
   return ss.str();
 }

--- a/DataFormats/Detectors/ZDC/include/DataFormatsZDC/CTF.h
+++ b/DataFormats/Detectors/ZDC/include/DataFormatsZDC/CTF.h
@@ -37,7 +37,7 @@ struct CTFHeader : public o2::ctf::CTFDictHeader {
   uint32_t firstOrbitEOData = 0;                 /// orbit of 1st end-of-orbit data
   uint16_t firstBC = 0;                          /// bc of 1st trigger
   std::array<uint16_t, NChannels> firstScaler{}; // inital scaler values
-  ClassDefNV(CTFHeader, 2);
+  ClassDefNV(CTFHeader, 3);
 };
 
 /// wrapper for the Entropy-encoded triggers and cells of the TF

--- a/Detectors/Base/CMakeLists.txt
+++ b/Detectors/Base/CMakeLists.txt
@@ -45,7 +45,6 @@ o2_target_root_dictionary(DetectorsBase
                                   include/DetectorsBase/MatCell.h
                                   include/DetectorsBase/MatLayerCyl.h
                                   include/DetectorsBase/MatLayerCylSet.h
-                                  include/DetectorsBase/CTFCoderBase.h
                                   include/DetectorsBase/Aligner.h)
 
 if(BUILD_SIMULATION)

--- a/Detectors/Base/include/DetectorsBase/CTFCoderBase.h
+++ b/Detectors/Base/include/DetectorsBase/CTFCoderBase.h
@@ -22,6 +22,7 @@
 #include "DetectorsCommonDataFormats/DetID.h"
 #include "DetectorsCommonDataFormats/NameConf.h"
 #include "DetectorsCommonDataFormats/CTFDictHeader.h"
+#include "DetectorsCommonDataFormats/CTFHeader.h"
 #include "rANS/rans.h"
 
 namespace o2
@@ -43,24 +44,15 @@ class CTFCoderBase
 
   CTFCoderBase() = delete;
   CTFCoderBase(int n, DetID det, float memFactor = 1.f) : mCoders(n), mDet(det), mMemMarginFactor(memFactor > 1.f ? memFactor : 1.f) {}
+  virtual ~CTFCoderBase() = default;
 
-  std::unique_ptr<TFile> loadDictionaryTreeFile(const std::string& dictPath, bool mayFail = false);
+  virtual void createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op) = 0;
 
   template <typename CTF>
-  std::vector<char> readDictionaryFromFile(const std::string& dictPath, bool mayFail = false)
-  {
-    std::vector<char> bufVec;
-    auto fileDict = loadDictionaryTreeFile(dictPath, mayFail);
-    if (fileDict) {
-      std::unique_ptr<TTree> tree((TTree*)fileDict->Get(std::string(o2::base::NameConf::CTFDICT).c_str()));
-      CTF::readFromTree(bufVec, *tree.get(), mDet.getName());
-      if (bufVec.size()) {
-        mExtHeader = static_cast<CTFDictHeader&>(CTF::get(bufVec.data())->getHeader());
-        LOGP(info, "Found {} {} in {}", mDet.getName(), mExtHeader.asString(), dictPath);
-      }
-    }
-    return bufVec;
-  }
+  std::vector<char> readDictionaryFromFile(const std::string& dictPath, bool mayFail = false);
+
+  template <typename CTF>
+  void createCodersFromFile(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op);
 
   template <typename S>
   void createCoder(OpType op, const o2::rans::FrequencyTable& freq, uint8_t probabilityBits, int slot)
@@ -92,6 +84,9 @@ class CTFCoderBase
   void setVerbosity(int v) { mVerbosity = v; }
   int getVerbosity() const { return mVerbosity; }
 
+  template <typename T>
+  static bool readFromTree(TTree& tree, const std::string brname, T& dest, int ev = 0);
+
  protected:
   std::string getPrefix() const { return o2::utils::Str::concat_string(mDet.getName(), "_CTF: "); }
   void assignDictVersion(CTFDictHeader& h) const
@@ -100,6 +95,7 @@ class CTFCoderBase
       h = mExtHeader;
     }
   }
+
   void checkDictVersion(const CTFDictHeader& h) const;
 
   std::vector<std::shared_ptr<void>> mCoders; // encoders/decoders
@@ -107,9 +103,89 @@ class CTFCoderBase
   CTFDictHeader mExtHeader; // external dictionary header
   float mMemMarginFactor = 1.0f; // factor for memory allocation in EncodedBlocks
   int mVerbosity = 0;
-
-  ClassDefNV(CTFCoderBase, 1);
 };
+
+///________________________________
+template <typename T>
+bool CTFCoderBase::readFromTree(TTree& tree, const std::string brname, T& dest, int ev)
+{
+  auto* br = tree.GetBranch(brname.c_str());
+  if (br && br->GetEntries() > ev) {
+    auto* ptr = &dest;
+    br->SetAddress(&ptr);
+    br->GetEntry(ev);
+    br->ResetAddress();
+    return true;
+  }
+  return false;
+}
+
+///________________________________
+template <typename CTF>
+void CTFCoderBase::createCodersFromFile(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op)
+{
+  bool mayFail = true;
+  auto buff = readDictionaryFromFile<CTF>(dictPath, mayFail);
+  if (!buff.size()) {
+    if (mayFail) {
+      return;
+    }
+    throw std::runtime_error("Failed to create CTF dictionaty");
+  }
+  createCoders(buff, op);
+}
+
+///________________________________
+template <typename CTF>
+std::vector<char> CTFCoderBase::readDictionaryFromFile(const std::string& dictPath, bool mayFail)
+{
+  std::vector<char> bufVec;
+  std::unique_ptr<TFile> fileDict(TFile::Open(dictPath.c_str()));
+  if (!fileDict || fileDict->IsZombie()) {
+    std::string errstr = fmt::format("CTF dictionary file {} for detector {} is absent", dictPath, mDet.getName());
+    if (mayFail) {
+      LOGP(info, "{}, will assume dictionary stored in CTF", errstr);
+    } else {
+      throw std::runtime_error(errstr);
+    }
+    return bufVec;
+  }
+  std::unique_ptr<TTree> tree((TTree*)fileDict->Get(std::string(o2::base::NameConf::CTFDICT).c_str()));
+  std::unique_ptr<std::vector<char>> bv((std::vector<char>*)fileDict->GetObjectChecked(o2::base::NameConf::CCDBOBJECT.data(), "std::vector<char>"));
+  if (tree) {
+    CTFHeader ctfHeader;
+    if (!readFromTree(*tree.get(), "CTFHeader", ctfHeader) || !ctfHeader.detectors[mDet]) {
+      std::string errstr = fmt::format("CTF dictionary file for detector {} is absent in the tree from file {}", mDet.getName(), dictPath);
+      if (mayFail) {
+        LOGP(info, "{}, will assume dictionary stored in CTF", errstr);
+      } else {
+        throw std::runtime_error(errstr);
+      }
+      return bufVec;
+    }
+    CTF::readFromTree(bufVec, *tree.get(), mDet.getName());
+  } else if (bv) {
+    bufVec.swap(*bv);
+    if (bufVec.size()) {
+      auto dictHeader = static_cast<o2::ctf::CTFDictHeader&>(CTF::get(bufVec.data())->getHeader());
+      if (dictHeader.det != mDet) {
+        throw std::runtime_error(fmt::format("{} contains dictionary vector for {}, expected {}", dictPath, dictHeader.det.getName(), mDet.getName()));
+      }
+    }
+  }
+  if (bufVec.size()) {
+    mExtHeader = static_cast<CTFDictHeader&>(CTF::get(bufVec.data())->getHeader());
+    LOGP(info, "Found {} in {}", mExtHeader.asString(), dictPath);
+  } else {
+    std::string errstr = fmt::format("CTF dictionary file for detector {} is empty", mDet.getName());
+    if (mayFail) {
+      LOGP(info, "{}, will assume dictionary stored in CTF", errstr);
+    } else {
+      throw std::runtime_error(errstr);
+    }
+  }
+  return bufVec;
+}
 
 } // namespace ctf
 } // namespace o2

--- a/Detectors/Base/src/CTFCoderBase.cxx
+++ b/Detectors/Base/src/CTFCoderBase.cxx
@@ -13,57 +13,9 @@
 /// \brief Defintions for CTFCoderBase class (support of external dictionaries)
 /// \author ruben.shahoyan@cern.ch
 
-#include "DetectorsCommonDataFormats/CTFHeader.h"
 #include "DetectorsBase/CTFCoderBase.h"
-#include <filesystem>
 
 using namespace o2::ctf;
-
-template <typename T>
-bool readFromTree(TTree& tree, const std::string brname, T& dest, int ev = 0)
-{
-  auto* br = tree.GetBranch(brname.c_str());
-  if (br && br->GetEntries() > ev) {
-    auto* ptr = &dest;
-    br->SetAddress(&ptr);
-    br->GetEntry(ev);
-    br->ResetAddress();
-    return true;
-  }
-  return false;
-}
-
-std::unique_ptr<TFile> CTFCoderBase::loadDictionaryTreeFile(const std::string& dictPath, bool mayFail)
-{
-  TDirectory* curd = gDirectory;
-  std::unique_ptr<TFile> fileDict(!std::filesystem::exists(dictPath) ? nullptr : TFile::Open(dictPath.c_str()));
-  if (!fileDict || fileDict->IsZombie()) {
-    if (mayFail) {
-      LOG(info) << "CTF dictionary file " << dictPath << " for detector " << mDet.getName() << " is absent, will use dictionaries stored in CTF";
-      fileDict.reset();
-      return std::move(fileDict);
-    }
-    LOG(error) << "Failed to open CTF dictionary file " << dictPath << " for detector " << mDet.getName();
-    throw std::runtime_error("Failed to open dictionary file");
-  }
-  auto tnm = std::string(o2::base::NameConf::CTFDICT);
-  std::unique_ptr<TTree> tree((TTree*)fileDict->Get(tnm.c_str()));
-  if (!tree) {
-    fileDict.reset();
-    LOG(error) << "Did not find CTF dictionary tree " << tnm << " in " << dictPath;
-    throw std::runtime_error("Did not fine CTF dictionary tree in the file");
-  }
-  CTFHeader ctfHeader;
-  if (!readFromTree(*tree.get(), "CTFHeader", ctfHeader) || !ctfHeader.detectors[mDet]) {
-    tree.reset();
-    fileDict.reset();
-    LOG(error) << "Did not find CTF dictionary header or Detector " << mDet.getName() << " in it";
-    if (!mayFail) {
-      throw std::runtime_error("did not find CTFHeader with needed detector");
-    }
-  }
-  return fileDict;
-}
 
 void CTFCoderBase::checkDictVersion(const CTFDictHeader& h) const
 {

--- a/Detectors/Base/src/DetectorsBaseLinkDef.h
+++ b/Detectors/Base/src/DetectorsBaseLinkDef.h
@@ -30,9 +30,6 @@
 #pragma link C++ class o2::base::MatBudget + ;
 #pragma link C++ class o2::base::MatLayerCyl + ;
 #pragma link C++ class o2::base::MatLayerCylSet + ;
-
-#pragma link C++ class o2::ctf::CTFCoderBase + ;
-
 #pragma link C++ class o2::base::Aligner + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::base::Aligner> + ;
 

--- a/Detectors/CPV/reconstruction/include/CPVReconstruction/CTFCoder.h
+++ b/Detectors/CPV/reconstruction/include/CPVReconstruction/CTFCoder.h
@@ -37,7 +37,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 {
  public:
   CTFCoder() : o2::ctf::CTFCoderBase(CTF::getNBlocks(), o2::detectors::DetID::CPV) {}
-  ~CTFCoder() = default;
+  ~CTFCoder() final = default;
 
   /// entropy-encode data to buffer with CTF
   template <typename VEC>
@@ -47,7 +47,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
   template <typename VTRG, typename VCLUSTER>
   void decode(const CTF::base& ec, VTRG& trigVec, VCLUSTER& cluVec);
 
-  void createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op);
+  void createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op) final;
 
  private:
   void appendToTree(TTree& tree, CTF& ec);

--- a/Detectors/CPV/reconstruction/include/CPVReconstruction/CTFHelper.h
+++ b/Detectors/CPV/reconstruction/include/CPVReconstruction/CTFHelper.h
@@ -33,7 +33,7 @@ class CTFHelper
 
   CTFHeader createHeader()
   {
-    CTFHeader h{0, 1, 0, // dummy timestamp, version 1.0
+    CTFHeader h{o2::detectors::DetID::CPV, 0, 1, 0, // dummy timestamp, version 1.0
                 uint32_t(mTrigData.size()), uint32_t(mCluData.size()), 0, 0};
     if (mTrigData.size()) {
       h.firstOrbit = mTrigData[0].getBCData().orbit;

--- a/Detectors/CPV/reconstruction/src/CTFCoder.cxx
+++ b/Detectors/CPV/reconstruction/src/CTFCoder.cxx
@@ -37,36 +37,16 @@ void CTFCoder::readFromTree(TTree& tree, int entry, std::vector<TriggerRecord>& 
 }
 
 ///________________________________
-void CTFCoder::createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op)
+void CTFCoder::createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op)
 {
-  bool mayFail = true; // RS FIXME if the dictionary file is not there, do not produce exception
-  auto buff = readDictionaryFromFile<CTF>(dictPath, mayFail);
-  if (!buff.size()) {
-    if (mayFail) {
-      return;
-    }
-    throw std::runtime_error("Failed to create CTF dictionaty");
-  }
-  const auto* ctf = CTF::get(buff.data());
-
-  auto getFreq = [ctf](CTF::Slots slot) -> o2::rans::FrequencyTable {
-    o2::rans::FrequencyTable ft;
-    auto bl = ctf->getBlock(slot);
-    auto md = ctf->getMetadata(slot);
-    ft.addFrequencies(bl.getDict(), bl.getDict() + bl.getNDict(), md.min, md.max);
-    return std::move(ft);
-  };
-  auto getProbBits = [ctf](CTF::Slots slot) -> int {
-    return ctf->getMetadata(slot).probabilityBits;
-  };
-
+  const auto ctf = CTF::getImage(bufVec.data());
   // just to get types
   uint16_t bcInc = 0, entries = 0, cluPosX = 0, cluPosZ = 0;
   uint32_t orbitInc = 0;
   uint8_t energy = 0, status = 0;
-#define MAKECODER(part, slot) createCoder<decltype(part)>(op, getFreq(slot), getProbBits(slot), int(slot))
+#define MAKECODER(part, slot) createCoder<decltype(part)>(op, ctf.getFrequencyTable(slot), ctf.getMetadata(slot).probabilityBits, int(slot))
   // clang-format off
-  MAKECODER(bcInc,      CTF::BLC_bcIncTrig); 
+  MAKECODER(bcInc,      CTF::BLC_bcIncTrig);
   MAKECODER(orbitInc,   CTF::BLC_orbitIncTrig);
   MAKECODER(entries,    CTF::BLC_entriesTrig);
   MAKECODER(cluPosX,    CTF::BLC_posX);

--- a/Detectors/CPV/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/CPV/workflow/src/EntropyDecoderSpec.cxx
@@ -35,7 +35,7 @@ void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
 {
   std::string dictPath = ic.options().get<std::string>("ctf-dict");
   if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
+    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
   }
 }
 

--- a/Detectors/CPV/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/CPV/workflow/src/EntropyEncoderSpec.cxx
@@ -36,7 +36,7 @@ void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
   std::string dictPath = ic.options().get<std::string>("ctf-dict");
   mCTFCoder.setMemMarginFactor(ic.options().get<float>("mem-factor"));
   if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
+    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
   }
 }
 

--- a/Detectors/CTF/README.md
+++ b/Detectors/CTF/README.md
@@ -18,7 +18,7 @@ o2-its-reco-workflow --entropy-encoding | o2-ctf-writer-workflow --onlyDet ITS
 
 For the storage optimization reason one can request multiple CTFs stored in the same output file (as entries of the `ctf` tree):
 ```bash
-o2-ctf-writer --min-file-size <min> --max-file-size <max> ...
+o2-ctf-writer-workflow --min-file-size <min> --max-file-size <max> ...
 ```
 will accumulate CTFs in entries of the same tree/file until its size fits exceeds `min` and does not exceed `max` (`max` check is disabled if `max<=min`) or EOS received.
 The `--max-file-size` limit will be ignored if the very first CTF already exceeds it.
@@ -41,6 +41,14 @@ By default only CTFs will written. If the upstream entropy compression is perfor
 In the dictionaries creation mode their data are accumulated over all CTFs procssed. User may request periodic (and incremental) saving of dictionaries after every `N` TFs processed by passing `--save-dict-after <N>` option.
 
 Option `--ctf-dict-dir <dir>` can be provided to indicate the (existing) directory where the dictionary will be stored.
+
+The external dictionaries created by the `o2-ctf-writer-workflow` containes a TTree (one for all participating detectos or single file per detector if `--dict-per-det` was provided). Since the TTrees cannot be used with CcdbAPI, one can
+run the macro `O2/Detectors/CTF/utils/CTFdict2CCDBfiles.C` (installed to $O2_ROOT/share/macro/CTFdict2CCDBfiles.C) which extracts the dictionary for every detector into separate file containing plain `vector<char>`. These files can be directly
+uploaded to CCDB and accessed via `CcdbAPI` (the reference of the vector should be provided to corresponding detector CTFCoder::createCoders method to build the run-time dictionary). These files can be also used as per-detector command-line
+parameters, on the same footing as tree-based dictionaries, e.g.
+```
+o2-ctf-reader-workflow --ctf-input input.lst --onlyDet ITS,TPC,TOF --its-entropy-decoder ' --ctf-dict ctfdict_ITS_v1.0_1626472046.root' --tpc-entropy-decoder ' --ctf-dict ctfdict_TPC_v1.0_1626472048.root' --tof-entropy-decoder  ' --ctf-dict ctfdict_TOF_v1.0_1626472048.root'
+```
 
 ## CTF reader workflow
 

--- a/Detectors/CTF/utils/CMakeLists.txt
+++ b/Detectors/CTF/utils/CMakeLists.txt
@@ -15,6 +15,7 @@
 
 install(FILES extractCTF.C
               dumpCTF.C
+              CTFdict2CCDBfiles.C
         DESTINATION share/macro/)
 
 o2_add_test_root_macro(extractCTF.C
@@ -24,3 +25,7 @@ o2_add_test_root_macro(extractCTF.C
 o2_add_test_root_macro(dumpCTF.C
                        PUBLIC_LINK_LIBRARIES O2::CTFWorkflow
                        LABELS ctf)
+
+o2_add_test_root_macro(CTFdict2CCDBfiles.C
+                       PUBLIC_LINK_LIBRARIES O2::CTFWorkflow
+                       LABELS ctf COMPILE_ONLY)

--- a/Detectors/CTF/utils/CTFdict2CCDBfiles.C
+++ b/Detectors/CTF/utils/CTFdict2CCDBfiles.C
@@ -1,0 +1,97 @@
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include "DetectorsBase/CTFCoderBase.h"
+#include "DetectorsCommonDataFormats/CTFDictHeader.h"
+#include "DetectorsCommonDataFormats/CTFHeader.h"
+#include "DetectorsCommonDataFormats/NameConf.h"
+#include "DataFormatsITSMFT/CTF.h"
+#include "DataFormatsTPC/CTF.h"
+#include "DataFormatsTRD/CTF.h"
+#include "DataFormatsFT0/CTF.h"
+#include "DataFormatsFV0/CTF.h"
+#include "DataFormatsFDD/CTF.h"
+#include "DataFormatsTOF/CTF.h"
+#include "DataFormatsMID/CTF.h"
+#include "DataFormatsMCH/CTF.h"
+#include "DataFormatsEMCAL/CTF.h"
+#include "DataFormatsPHOS/CTF.h"
+#include "DataFormatsCPV/CTF.h"
+#include "DataFormatsZDC/CTF.h"
+#include "DataFormatsHMP/CTF.h"
+#include "DataFormatsCTP/CTF.h"
+#endif
+
+using DetID = o2::detectors::DetID;
+
+template <typename T>
+bool readFromTree(TTree& tree, const std::string brname, T& dest, int ev = 0)
+{
+  auto* br = tree.GetBranch(brname.c_str());
+  if (br && br->GetEntries() > ev) {
+    auto* ptr = &dest;
+    br->SetAddress(&ptr);
+    br->GetEntry(ev);
+    br->ResetAddress();
+    return true;
+  }
+  return false;
+}
+
+template <typename C>
+void extractDictionary(TTree& tree, o2::detectors::DetID det, DetID::mask_t detMask)
+{
+  std::vector<char> bufVec;
+  if (!detMask[det]) {
+    return;
+  }
+  o2::ctf::CTFHeader ctfHeader;
+  readFromTree(tree, "CTFHeader", ctfHeader);
+  if (!ctfHeader.detectors[det]) {
+    LOGP(warning, "Dictionary for {} was requested but absent", det.getName());
+    return;
+  }
+  C::readFromTree(bufVec, tree, det.getName());
+  auto& dictHeader = static_cast<o2::ctf::CTFDictHeader&>(C::get(bufVec.data())->getHeader());
+  dictHeader.det = det; // impose detector, since in early versions it is absent
+  std::string outName = fmt::format("ctfdict_{}_v{}.{}_{}.root", det.getName(), int(dictHeader.majorVersion), int(dictHeader.minorVersion), dictHeader.dictTimeStamp);
+  TFile flout(outName.c_str(), "recreate");
+  flout.WriteObject(&bufVec, o2::base::NameConf::CCDBOBJECT.data());
+  flout.Close();
+  LOG(info) << "Wrote " << dictHeader.asString() << " to " << outName;
+}
+
+// This macro allows to convert tree-based CTF dictionary (produced by the ctf-writer-workflow) to per-detector files with plain vector, suitable for the CCDB use.
+void CTFdict2CCDBfiles(const std::string& fname = "ctf_dictionary.root", const std::string dets = "all")
+{
+  std::string allowedDetectors = "ITS,TPC,TRD,TOF,PHS,CPV,EMC,HMP,MFT,MCH,MID,ZDC,FT0,FV0,FDD,CTP";
+  auto detMask = DetID::getMask(dets) & DetID::getMask(allowedDetectors);
+
+  std::unique_ptr<TFile> dictFile(TFile::Open(fname.c_str()));
+  if (!dictFile) {
+    LOG(error) << "Failed to open CTF dictionary file " << fname;
+    return;
+  }
+  std::unique_ptr<TTree> tree((TTree*)dictFile->Get(std::string(o2::base::NameConf::CTFDICT).c_str()));
+  if (!tree) {
+    LOG(error) << "Did not find CTF dictionary tree in " << fname;
+    return;
+  }
+  extractDictionary<o2::itsmft::CTF>(*tree, DetID::ITS, detMask);
+  extractDictionary<o2::itsmft::CTF>(*tree, DetID::MFT, detMask);
+  extractDictionary<o2::emcal::CTF>(*tree, DetID::EMC, detMask);
+  extractDictionary<o2::hmpid::CTF>(*tree, DetID::HMP, detMask);
+  extractDictionary<o2::phos::CTF>(*tree, DetID::PHS, detMask);
+  extractDictionary<o2::tpc::CTF>(*tree, DetID::TPC, detMask);
+  extractDictionary<o2::trd::CTF>(*tree, DetID::TRD, detMask);
+  extractDictionary<o2::ft0::CTF>(*tree, DetID::FT0, detMask);
+  extractDictionary<o2::fv0::CTF>(*tree, DetID::FV0, detMask);
+  extractDictionary<o2::fdd::CTF>(*tree, DetID::FDD, detMask);
+  extractDictionary<o2::tof::CTF>(*tree, DetID::TOF, detMask);
+  extractDictionary<o2::mid::CTF>(*tree, DetID::MID, detMask);
+  extractDictionary<o2::mch::CTF>(*tree, DetID::MCH, detMask);
+  extractDictionary<o2::cpv::CTF>(*tree, DetID::CPV, detMask);
+  extractDictionary<o2::zdc::CTF>(*tree, DetID::ZDC, detMask);
+  extractDictionary<o2::ctp::CTF>(*tree, DetID::CTP, detMask);
+
+  tree.reset();
+  dictFile.reset();
+}

--- a/Detectors/CTF/workflow/src/CTFWriterSpec.cxx
+++ b/Detectors/CTF/workflow/src/CTFWriterSpec.cxx
@@ -276,6 +276,7 @@ size_t CTFWriterSpec::processDet(o2::framework::ProcessingContext& pc, DetID det
       mHeaders[det] = ctfImage.cloneHeader();
       auto& hb = *static_cast<o2::ctf::CTFDictHeader*>(mHeaders[det].get());
       hb.dictTimeStamp = uint32_t(std::time(nullptr));
+      hb.det = det;
     }
     for (int ib = 0; ib < C::getNBlocks(); ib++) {
       const auto& bl = ctfImage.getBlock(ib);

--- a/Detectors/CTP/reconstruction/include/CTPReconstruction/CTFCoder.h
+++ b/Detectors/CTP/reconstruction/include/CTPReconstruction/CTFCoder.h
@@ -37,7 +37,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 {
  public:
   CTFCoder() : o2::ctf::CTFCoderBase(CTF::getNBlocks(), o2::detectors::DetID::CTP) {}
-  ~CTFCoder() = default;
+  ~CTFCoder() final = default;
 
   /// entropy-encode data to buffer with CTF
   template <typename VEC>
@@ -47,7 +47,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
   template <typename VTRG>
   void decode(const CTF::base& ec, VTRG& data);
 
-  void createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op);
+  void createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op) final;
 
  private:
   void appendToTree(TTree& tree, CTF& ec);

--- a/Detectors/CTP/reconstruction/include/CTPReconstruction/CTFHelper.h
+++ b/Detectors/CTP/reconstruction/include/CTPReconstruction/CTFHelper.h
@@ -37,7 +37,7 @@ class CTFHelper
 
   CTFHeader createHeader()
   {
-    CTFHeader h{0, 1, 0, // dummy timestamp, version 1.0
+    CTFHeader h{o2::detectors::DetID::CTP, 0, 1, 0, // dummy timestamp, version 1.0
                 uint32_t(mData.size()), 0, 0};
     if (mData.size()) {
       h.firstOrbit = mData[0].intRecord.orbit;

--- a/Detectors/CTP/reconstruction/src/CTFCoder.cxx
+++ b/Detectors/CTP/reconstruction/src/CTFCoder.cxx
@@ -37,34 +37,14 @@ void CTFCoder::readFromTree(TTree& tree, int entry, std::vector<CTPDigit>& data)
 }
 
 ///________________________________
-void CTFCoder::createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op)
+void CTFCoder::createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op)
 {
-  bool mayFail = true; // RS FIXME if the dictionary file is not there, do not produce exception
-  auto buff = readDictionaryFromFile<CTF>(dictPath, mayFail);
-  if (!buff.size()) {
-    if (mayFail) {
-      return;
-    }
-    throw std::runtime_error("Failed to create CTF dictionaty");
-  }
-  const auto* ctf = CTF::get(buff.data());
-
-  auto getFreq = [ctf](CTF::Slots slot) -> o2::rans::FrequencyTable {
-    o2::rans::FrequencyTable ft;
-    auto bl = ctf->getBlock(slot);
-    auto md = ctf->getMetadata(slot);
-    ft.addFrequencies(bl.getDict(), bl.getDict() + bl.getNDict(), md.min, md.max);
-    return std::move(ft);
-  };
-  auto getProbBits = [ctf](CTF::Slots slot) -> int {
-    return ctf->getMetadata(slot).probabilityBits;
-  };
-
+  const auto ctf = CTF::getImage(bufVec.data());
   // just to get types
   uint16_t bcInc = 0;
   uint32_t orbitInc = 0;
   uint8_t bytesInput = 0, bytesClass = 0;
-#define MAKECODER(part, slot) createCoder<decltype(part)>(op, getFreq(slot), getProbBits(slot), int(slot))
+#define MAKECODER(part, slot) createCoder<decltype(part)>(op, ctf.getFrequencyTable(slot), ctf.getMetadata(slot).probabilityBits, int(slot))
   // clang-format off
   MAKECODER(bcInc,      CTF::BLC_bcIncTrig);
   MAKECODER(orbitInc,   CTF::BLC_orbitIncTrig);

--- a/Detectors/CTP/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/CTP/workflow/src/EntropyDecoderSpec.cxx
@@ -34,7 +34,7 @@ void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
 {
   std::string dictPath = ic.options().get<std::string>("ctf-dict");
   if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
+    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
   }
 }
 

--- a/Detectors/CTP/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/CTP/workflow/src/EntropyEncoderSpec.cxx
@@ -36,7 +36,7 @@ void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
   std::string dictPath = ic.options().get<std::string>("ctf-dict");
   mCTFCoder.setMemMarginFactor(ic.options().get<float>("mem-factor"));
   if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
+    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
   }
 }
 

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CTFCoder.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CTFCoder.h
@@ -37,7 +37,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 {
  public:
   CTFCoder() : o2::ctf::CTFCoderBase(CTF::getNBlocks(), o2::detectors::DetID::EMC) {}
-  ~CTFCoder() = default;
+  ~CTFCoder() final = default;
 
   /// entropy-encode data to buffer with CTF
   template <typename VEC>
@@ -47,7 +47,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
   template <typename VTRG, typename VCELL>
   void decode(const CTF::base& ec, VTRG& trigVec, VCELL& cellVec);
 
-  void createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op);
+  void createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op) final;
 
  private:
   void appendToTree(TTree& tree, CTF& ec);

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CTFHelper.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CTFHelper.h
@@ -33,7 +33,7 @@ class CTFHelper
 
   CTFHeader createHeader()
   {
-    CTFHeader h{0, 1, 0, // dummy timestamp, version 1.0
+    CTFHeader h{o2::detectors::DetID::EMC, 0, 1, 0, // dummy timestamp, version 1.0
                 uint32_t(mTrigData.size()), uint32_t(mCellData.size()), 0, 0};
     if (mTrigData.size()) {
       h.firstOrbit = mTrigData[0].getBCData().orbit;

--- a/Detectors/EMCAL/reconstruction/src/CTFCoder.cxx
+++ b/Detectors/EMCAL/reconstruction/src/CTFCoder.cxx
@@ -37,34 +37,14 @@ void CTFCoder::readFromTree(TTree& tree, int entry, std::vector<TriggerRecord>& 
 }
 
 ///________________________________
-void CTFCoder::createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op)
+void CTFCoder::createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op)
 {
-  bool mayFail = true; // RS FIXME if the dictionary file is not there, do not produce exception
-  auto buff = readDictionaryFromFile<CTF>(dictPath, mayFail);
-  if (!buff.size()) {
-    if (mayFail) {
-      return;
-    }
-    throw std::runtime_error("Failed to create CTF dictionaty");
-  }
-  const auto* ctf = CTF::get(buff.data());
-
-  auto getFreq = [ctf](CTF::Slots slot) -> o2::rans::FrequencyTable {
-    o2::rans::FrequencyTable ft;
-    auto bl = ctf->getBlock(slot);
-    auto md = ctf->getMetadata(slot);
-    ft.addFrequencies(bl.getDict(), bl.getDict() + bl.getNDict(), md.min, md.max);
-    return std::move(ft);
-  };
-  auto getProbBits = [ctf](CTF::Slots slot) -> int {
-    return ctf->getMetadata(slot).probabilityBits;
-  };
-
+  const auto ctf = CTF::getImage(bufVec.data());
   // just to get types
   uint16_t bcInc = 0, entries = 0, cellTime = 0, energy = 0, tower = 0, trigger = 0;
   uint32_t orbitInc = 0;
   uint8_t status = 0;
-#define MAKECODER(part, slot) createCoder<decltype(part)>(op, getFreq(slot), getProbBits(slot), int(slot))
+#define MAKECODER(part, slot) createCoder<decltype(part)>(op, ctf.getFrequencyTable(slot), ctf.getMetadata(slot).probabilityBits, int(slot))
   // clang-format off
   MAKECODER(bcInc,      CTF::BLC_bcIncTrig);
   MAKECODER(orbitInc,   CTF::BLC_orbitIncTrig);

--- a/Detectors/EMCAL/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/EntropyDecoderSpec.cxx
@@ -35,7 +35,7 @@ void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
 {
   std::string dictPath = ic.options().get<std::string>("ctf-dict");
   if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
+    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
   }
 }
 

--- a/Detectors/EMCAL/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/EntropyEncoderSpec.cxx
@@ -36,7 +36,7 @@ void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
   std::string dictPath = ic.options().get<std::string>("ctf-dict");
   mCTFCoder.setMemMarginFactor(ic.options().get<float>("mem-factor"));
   if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
+    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
   }
 }
 

--- a/Detectors/FIT/FDD/reconstruction/CMakeLists.txt
+++ b/Detectors/FIT/FDD/reconstruction/CMakeLists.txt
@@ -11,17 +11,16 @@
 
 o2_add_library(FDDReconstruction
                SOURCES src/Reconstructor.cxx
-	       	       src/ReadRaw.cxx
+                       src/ReadRaw.cxx
                        src/CTFCoder.cxx
                PUBLIC_LINK_LIBRARIES O2::FDDBase
-	       			     O2::DataFormatsFDD
-	       			     O2::DetectorsRaw)
+                O2::DataFormatsFDD
+                O2::DetectorsRaw)
 
 o2_target_root_dictionary(
   FDDReconstruction
   HEADERS include/FDDReconstruction/Reconstructor.h
-          include/FDDReconstruction/ReadRaw.h
-          include/FDDReconstruction/CTFCoder.h)
+          include/FDDReconstruction/ReadRaw.h)
 
 o2_add_executable(
   test-raw2digit

--- a/Detectors/FIT/FDD/reconstruction/include/FDDReconstruction/CTFCoder.h
+++ b/Detectors/FIT/FDD/reconstruction/include/FDDReconstruction/CTFCoder.h
@@ -38,7 +38,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 {
  public:
   CTFCoder() : o2::ctf::CTFCoderBase(CTF::getNBlocks(), o2::detectors::DetID::FDD) {}
-  ~CTFCoder() = default;
+  ~CTFCoder() final = default;
 
   /// entropy-encode digits to buffer with CTF
   template <typename VEC>
@@ -48,7 +48,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
   template <typename VDIG, typename VCHAN>
   void decode(const CTF::base& ec, VDIG& digitVec, VCHAN& channelVec);
 
-  void createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op);
+  void createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op) final;
 
  private:
   /// compres digits clusters to CompressedDigits
@@ -61,8 +61,6 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 
   void appendToTree(TTree& tree, CTF& ec);
   void readFromTree(TTree& tree, int entry, std::vector<Digit>& digitVec, std::vector<ChannelData>& channelVec);
-
-  ClassDefNV(CTFCoder, 1);
 };
 
 /// entropy-encode clusters to buffer with CTF

--- a/Detectors/FIT/FDD/reconstruction/src/CTFCoder.cxx
+++ b/Detectors/FIT/FDD/reconstruction/src/CTFCoder.cxx
@@ -46,6 +46,7 @@ void CTFCoder::compress(CompressedDigits& cd, const gsl::span<const Digit>& digi
     return;
   }
   const auto& dig0 = digitVec[0];
+  cd.header.det = mDet;
   cd.header.nTriggers = digitVec.size();
   cd.header.firstOrbit = dig0.mIntRecord.orbit;
   cd.header.firstBC = dig0.mIntRecord.bc;
@@ -98,31 +99,11 @@ void CTFCoder::compress(CompressedDigits& cd, const gsl::span<const Digit>& digi
 }
 
 ///________________________________
-void CTFCoder::createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op)
+void CTFCoder::createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op)
 {
-  bool mayFail = true; // RS FIXME if the dictionary file is not there, do not produce exception
-  auto buff = readDictionaryFromFile<CTF>(dictPath, mayFail);
-  if (!buff.size()) {
-    if (mayFail) {
-      return;
-    }
-    throw std::runtime_error("Failed to create CTF dictionaty");
-  }
-  const auto* ctf = CTF::get(buff.data());
-
-  auto getFreq = [ctf](CTF::Slots slot) -> o2::rans::FrequencyTable {
-    o2::rans::FrequencyTable ft;
-    auto bl = ctf->getBlock(slot);
-    auto md = ctf->getMetadata(slot);
-    ft.addFrequencies(bl.getDict(), bl.getDict() + bl.getNDict(), md.min, md.max);
-    return std::move(ft);
-  };
-  auto getProbBits = [ctf](CTF::Slots slot) -> int {
-    return ctf->getMetadata(slot).probabilityBits;
-  };
-
+  const auto ctf = CTF::getImage(bufVec.data());
   CompressedDigits cd; // just to get member types
-#define MAKECODER(part, slot) createCoder<decltype(part)::value_type>(op, getFreq(slot), getProbBits(slot), int(slot))
+#define MAKECODER(part, slot) createCoder<decltype(part)::value_type>(op, ctf.getFrequencyTable(slot), ctf.getMetadata(slot).probabilityBits, int(slot))
   // clang-format off
   MAKECODER(cd.trigger,   CTF::BLC_trigger);
   MAKECODER(cd.bcInc,     CTF::BLC_bcInc);

--- a/Detectors/FIT/FDD/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/FIT/FDD/workflow/src/EntropyDecoderSpec.cxx
@@ -35,7 +35,7 @@ void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
 {
   std::string dictPath = ic.options().get<std::string>("ctf-dict");
   if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
+    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
   }
 }
 

--- a/Detectors/FIT/FDD/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/FIT/FDD/workflow/src/EntropyEncoderSpec.cxx
@@ -36,7 +36,7 @@ void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
   std::string dictPath = ic.options().get<std::string>("ctf-dict");
   mCTFCoder.setMemMarginFactor(ic.options().get<float>("mem-factor"));
   if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
+    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
   }
 }
 

--- a/Detectors/FIT/FT0/reconstruction/CMakeLists.txt
+++ b/Detectors/FIT/FT0/reconstruction/CMakeLists.txt
@@ -31,9 +31,7 @@ o2_target_root_dictionary(
   FT0Reconstruction
   HEADERS include/FT0Reconstruction/CollisionTimeRecoTask.h
           include/FT0Reconstruction/ReadRaw.h
-          include/FT0Reconstruction/CTFCoder.h
-          include/FT0Reconstruction/InteractionTag.h
-  )
+          include/FT0Reconstruction/InteractionTag.h)
 
 o2_add_executable(
   test-raw-conversion

--- a/Detectors/FIT/FT0/reconstruction/include/FT0Reconstruction/CTFCoder.h
+++ b/Detectors/FIT/FT0/reconstruction/include/FT0Reconstruction/CTFCoder.h
@@ -39,7 +39,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 {
  public:
   CTFCoder() : o2::ctf::CTFCoderBase(CTF::getNBlocks(), o2::detectors::DetID::FT0) {}
-  ~CTFCoder() = default;
+  ~CTFCoder() final = default;
 
   /// entropy-encode digits to buffer with CTF
   template <typename VEC>
@@ -49,7 +49,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
   template <typename VDIG, typename VCHAN>
   void decode(const CTF::base& ec, VDIG& digitVec, VCHAN& channelVec);
 
-  void createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op);
+  void createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op) final;
 
  private:
   /// compres digits clusters to CompressedDigits
@@ -64,8 +64,6 @@ class CTFCoder : public o2::ctf::CTFCoderBase
   void readFromTree(TTree& tree, int entry, std::vector<Digit>& digitVec, std::vector<ChannelData>& channelVec);
   // DigitizationParameters const &mParameters;
   //  o2::ft0::Geometry mGeometry;
-
-  ClassDefNV(CTFCoder, 1);
 };
 
 /// entropy-encode clusters to buffer with CTF

--- a/Detectors/FIT/FT0/reconstruction/src/CTFCoder.cxx
+++ b/Detectors/FIT/FT0/reconstruction/src/CTFCoder.cxx
@@ -47,6 +47,7 @@ void CTFCoder::compress(CompressedDigits& cd, const gsl::span<const Digit>& digi
     return;
   }
   const auto& dig0 = digitVec[0];
+  cd.header.det = mDet;
   cd.header.nTriggers = digitVec.size();
   cd.header.firstOrbit = dig0.getOrbit();
   cd.header.firstBC = dig0.getBC();
@@ -102,31 +103,11 @@ void CTFCoder::compress(CompressedDigits& cd, const gsl::span<const Digit>& digi
 }
 
 ///________________________________
-void CTFCoder::createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op)
+void CTFCoder::createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op)
 {
-  bool mayFail = true; // RS FIXME if the dictionary file is not there, do not produce exception
-  auto buff = readDictionaryFromFile<CTF>(dictPath, mayFail);
-  if (!buff.size()) {
-    if (mayFail) {
-      return;
-    }
-    throw std::runtime_error("Failed to create CTF dictionaty");
-  }
-  const auto* ctf = CTF::get(buff.data());
-
-  auto getFreq = [ctf](CTF::Slots slot) -> o2::rans::FrequencyTable {
-    o2::rans::FrequencyTable ft;
-    auto bl = ctf->getBlock(slot);
-    auto md = ctf->getMetadata(slot);
-    ft.addFrequencies(bl.getDict(), bl.getDict() + bl.getNDict(), md.min, md.max);
-    return std::move(ft);
-  };
-  auto getProbBits = [ctf](CTF::Slots slot) -> int {
-    return ctf->getMetadata(slot).probabilityBits;
-  };
-
+  const auto ctf = CTF::getImage(bufVec.data());
   CompressedDigits cd; // just to get member types
-#define MAKECODER(part, slot) createCoder<decltype(part)::value_type>(op, getFreq(slot), getProbBits(slot), int(slot))
+#define MAKECODER(part, slot) createCoder<decltype(part)::value_type>(op, ctf.getFrequencyTable(slot), ctf.getMetadata(slot).probabilityBits, int(slot))
   // clang-format off
   MAKECODER(cd.trigger,      CTF::BLC_trigger);
   MAKECODER(cd.bcInc,        CTF::BLC_bcInc);

--- a/Detectors/FIT/FT0/reconstruction/src/FT0ReconstructionLinkDef.h
+++ b/Detectors/FIT/FT0/reconstruction/src/FT0ReconstructionLinkDef.h
@@ -17,7 +17,6 @@
 
 #pragma link C++ class o2::ft0::CollisionTimeRecoTask + ;
 #pragma link C++ class o2::ft0::ReadRaw + ;
-#pragma link C++ class o2::ft0::CTFCoder + ;
 #pragma link C++ class o2::ft0::InteractionTag + ;
 
 #endif

--- a/Detectors/FIT/FT0/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/FIT/FT0/workflow/src/EntropyDecoderSpec.cxx
@@ -35,7 +35,7 @@ void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
 {
   std::string dictPath = ic.options().get<std::string>("ctf-dict");
   if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
+    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
   }
 }
 

--- a/Detectors/FIT/FT0/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/FIT/FT0/workflow/src/EntropyEncoderSpec.cxx
@@ -36,7 +36,7 @@ void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
   std::string dictPath = ic.options().get<std::string>("ctf-dict");
   mCTFCoder.setMemMarginFactor(ic.options().get<float>("mem-factor"));
   if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
+    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
   }
 }
 

--- a/Detectors/FIT/FV0/reconstruction/CMakeLists.txt
+++ b/Detectors/FIT/FV0/reconstruction/CMakeLists.txt
@@ -27,8 +27,7 @@ o2_add_library(FV0Reconstruction
 
 o2_target_root_dictionary(FV0Reconstruction
         HEADERS include/FV0Reconstruction/BaseRecoTask.h
-                include/FV0Reconstruction/ReadRaw.h
-                include/FV0Reconstruction/CTFCoder.h)
+                include/FV0Reconstruction/ReadRaw.h)
 
 o2_add_executable(
   test-raw2digit

--- a/Detectors/FIT/FV0/reconstruction/include/FV0Reconstruction/CTFCoder.h
+++ b/Detectors/FIT/FV0/reconstruction/include/FV0Reconstruction/CTFCoder.h
@@ -38,7 +38,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 {
  public:
   CTFCoder() : o2::ctf::CTFCoderBase(CTF::getNBlocks(), o2::detectors::DetID::FV0) {}
-  ~CTFCoder() = default;
+  ~CTFCoder() final = default;
 
   /// entropy-encode digits to buffer with CTF
   template <typename VEC>
@@ -48,7 +48,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
   template <typename VDIG, typename VCHAN>
   void decode(const CTF::base& ec, VDIG& digitVec, VCHAN& channelVec);
 
-  void createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op);
+  void createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op) final;
 
  private:
   /// compres digits clusters to CompressedDigits
@@ -61,8 +61,6 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 
   void appendToTree(TTree& tree, CTF& ec);
   void readFromTree(TTree& tree, int entry, std::vector<BCData>& digitVec, std::vector<ChannelData>& channelVec);
-
-  ClassDefNV(CTFCoder, 1);
 };
 
 /// entropy-encode clusters to buffer with CTF

--- a/Detectors/FIT/FV0/reconstruction/src/CTFCoder.cxx
+++ b/Detectors/FIT/FV0/reconstruction/src/CTFCoder.cxx
@@ -46,6 +46,7 @@ void CTFCoder::compress(CompressedDigits& cd, const gsl::span<const BCData>& dig
     return;
   }
   const auto& dig0 = digitVec[0];
+  cd.header.det = mDet;
   cd.header.nTriggers = digitVec.size();
   cd.header.firstOrbit = dig0.ir.orbit;
   cd.header.firstBC = dig0.ir.bc;
@@ -96,31 +97,11 @@ void CTFCoder::compress(CompressedDigits& cd, const gsl::span<const BCData>& dig
 }
 
 ///________________________________
-void CTFCoder::createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op)
+void CTFCoder::createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op)
 {
-  bool mayFail = true; // RS FIXME if the dictionary file is not there, do not produce exception
-  auto buff = readDictionaryFromFile<CTF>(dictPath, mayFail);
-  if (!buff.size()) {
-    if (mayFail) {
-      return;
-    }
-    throw std::runtime_error("Failed to create CTF dictionaty");
-  }
-  const auto* ctf = CTF::get(buff.data());
-
-  auto getFreq = [ctf](CTF::Slots slot) -> o2::rans::FrequencyTable {
-    o2::rans::FrequencyTable ft;
-    auto bl = ctf->getBlock(slot);
-    auto md = ctf->getMetadata(slot);
-    ft.addFrequencies(bl.getDict(), bl.getDict() + bl.getNDict(), md.min, md.max);
-    return std::move(ft);
-  };
-  auto getProbBits = [ctf](CTF::Slots slot) -> int {
-    return ctf->getMetadata(slot).probabilityBits;
-  };
-
+  const auto ctf = CTF::getImage(bufVec.data());
   CompressedDigits cd; // just to get member types
-#define MAKECODER(part, slot) createCoder<decltype(part)::value_type>(op, getFreq(slot), getProbBits(slot), int(slot))
+#define MAKECODER(part, slot) createCoder<decltype(part)::value_type>(op, ctf.getFrequencyTable(slot), ctf.getMetadata(slot).probabilityBits, int(slot))
   // clang-format off
   MAKECODER(cd.bcInc,     CTF::BLC_bcInc);
   MAKECODER(cd.orbitInc,  CTF::BLC_orbitInc);

--- a/Detectors/FIT/FV0/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/FIT/FV0/workflow/src/EntropyDecoderSpec.cxx
@@ -35,7 +35,7 @@ void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
 {
   std::string dictPath = ic.options().get<std::string>("ctf-dict");
   if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
+    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
   }
 }
 

--- a/Detectors/FIT/FV0/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/FIT/FV0/workflow/src/EntropyEncoderSpec.cxx
@@ -36,7 +36,7 @@ void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
   std::string dictPath = ic.options().get<std::string>("ctf-dict");
   mCTFCoder.setMemMarginFactor(ic.options().get<float>("mem-factor"));
   if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
+    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
   }
 }
 

--- a/Detectors/HMPID/reconstruction/include/HMPIDReconstruction/CTFCoder.h
+++ b/Detectors/HMPID/reconstruction/include/HMPIDReconstruction/CTFCoder.h
@@ -37,7 +37,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 {
  public:
   CTFCoder() : o2::ctf::CTFCoderBase(CTF::getNBlocks(), o2::detectors::DetID::HMP) {}
-  ~CTFCoder() = default;
+  ~CTFCoder() final = default;
 
   /// entropy-encode data to buffer with CTF
   template <typename VEC>
@@ -47,7 +47,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
   template <typename VTRG, typename VDIG>
   void decode(const CTF::base& ec, VTRG& trigVec, VDIG& digVec);
 
-  void createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op);
+  void createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op) final;
 
  private:
   void appendToTree(TTree& tree, CTF& ec);

--- a/Detectors/HMPID/reconstruction/include/HMPIDReconstruction/CTFHelper.h
+++ b/Detectors/HMPID/reconstruction/include/HMPIDReconstruction/CTFHelper.h
@@ -44,7 +44,7 @@ class CTFHelper
 
   CTFHeader createHeader()
   {
-    CTFHeader h{0, 1, 0, // dummy timestamp, version 1.0
+    CTFHeader h{o2::detectors::DetID::HMP, 0, 1, 0, // dummy timestamp, version 1.0
                 uint32_t(mTrigRec.size()), uint32_t(mDigData.size()), 0, 0};
     if (mTrigRec.size()) {
       h.firstOrbit = mTrigRec[0].getOrbit();

--- a/Detectors/HMPID/reconstruction/src/CTFCoder.cxx
+++ b/Detectors/HMPID/reconstruction/src/CTFCoder.cxx
@@ -37,37 +37,17 @@ void CTFCoder::readFromTree(TTree& tree, int entry, std::vector<Trigger>& trigVe
 }
 
 ///________________________________
-void CTFCoder::createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op)
+void CTFCoder::createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op)
 {
-  bool mayFail = true; // RS FIXME if the dictionary file is not there, do not produce exception
-  auto buff = readDictionaryFromFile<CTF>(dictPath, mayFail);
-  if (!buff.size()) {
-    if (mayFail) {
-      return;
-    }
-    throw std::runtime_error("Failed to create CTF dictionaty");
-  }
-  const auto* ctf = CTF::get(buff.data());
-
-  auto getFreq = [ctf](CTF::Slots slot) -> o2::rans::FrequencyTable {
-    o2::rans::FrequencyTable ft;
-    auto bl = ctf->getBlock(slot);
-    auto md = ctf->getMetadata(slot);
-    ft.addFrequencies(bl.getDict(), bl.getDict() + bl.getNDict(), md.min, md.max);
-    return std::move(ft);
-  };
-  auto getProbBits = [ctf](CTF::Slots slot) -> int {
-    return ctf->getMetadata(slot).probabilityBits;
-  };
-
+  const auto ctf = CTF::getImage(bufVec.data());
   // just to get types
   uint16_t bcInc, HCIDTrk, q;
   uint32_t orbitInc, entriesDig;
   uint8_t chID, ph, x, y;
 
-#define MAKECODER(part, slot) createCoder<decltype(part)>(op, getFreq(slot), getProbBits(slot), int(slot))
+#define MAKECODER(part, slot) createCoder<decltype(part)>(op, ctf.getFrequencyTable(slot), ctf.getMetadata(slot).probabilityBits, int(slot))
   // clang-format off
-  MAKECODER(bcInc,      CTF::BLC_bcIncTrig); 
+  MAKECODER(bcInc,      CTF::BLC_bcIncTrig);
   MAKECODER(orbitInc,   CTF::BLC_orbitIncTrig);
   MAKECODER(entriesDig, CTF::BLC_entriesDig);
 

--- a/Detectors/HMPID/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/HMPID/workflow/src/EntropyDecoderSpec.cxx
@@ -51,7 +51,7 @@ void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
 {
   std::string dictPath = ic.options().get<std::string>("ctf-dict");
   if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
+    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
   }
 }
 

--- a/Detectors/HMPID/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/HMPID/workflow/src/EntropyEncoderSpec.cxx
@@ -52,7 +52,7 @@ void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
   std::string dictPath = ic.options().get<std::string>("ctf-dict");
   mCTFCoder.setMemMarginFactor(ic.options().get<float>("mem-factor"));
   if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
+    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
   }
 }
 

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/CTFCoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/CTFCoder.h
@@ -47,7 +47,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
   using RowColBuff = std::vector<PixelData>;
 
   CTFCoder(o2::detectors::DetID det) : o2::ctf::CTFCoderBase(CTF::getNBlocks(), det) {}
-  ~CTFCoder() = default;
+  ~CTFCoder() final = default;
 
   /// entropy-encode clusters to buffer with CTF
   template <typename VEC>
@@ -61,7 +61,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
   template <typename VROF, typename VDIG>
   void decode(const CTF::base& ec, VROF& rofRecVec, VDIG& digVec, const NoiseMap* noiseMap, const LookUp& clPattLookup);
 
-  void createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op);
+  void createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op) final;
 
  private:
   CompressedClusters decodeCompressedClusters(const CTF::base& ec);
@@ -80,8 +80,6 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 
   void appendToTree(TTree& tree, CTF& ec);
   void readFromTree(TTree& tree, int entry, std::vector<ROFRecord>& rofRecVec, std::vector<CompClusterExt>& cclusVec, std::vector<unsigned char>& pattVec, const NoiseMap* noiseMap, const LookUp& clPattLookup);
-
-  ClassDefNV(CTFCoder, 1);
 };
 
 /// entropy-encode clusters to buffer with CTF

--- a/Detectors/ITSMFT/common/reconstruction/src/CTFCoder.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/CTFCoder.cxx
@@ -49,6 +49,7 @@ void CTFCoder::compress(CompressedClusters& cc,
     return;
   }
   const auto& rofRec0 = rofRecVec[0];
+  cc.header.det = mDet;
   cc.header.nROFs = rofRecVec.size();
   cc.header.firstOrbit = rofRec0.getBCData().orbit;
   cc.header.firstBC = rofRec0.getBCData().bc;
@@ -142,31 +143,11 @@ void CTFCoder::compress(CompressedClusters& cc,
 }
 
 ///________________________________
-void CTFCoder::createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op)
+void CTFCoder::createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op)
 {
-  bool mayFail = true; // RS FIXME if the dictionary file is not there, do not produce exception
-  auto buff = readDictionaryFromFile<CTF>(dictPath, mayFail);
-  if (!buff.size()) {
-    if (mayFail) {
-      return;
-    }
-    throw std::runtime_error("Failed to create CTF dictionaty");
-  }
-  const auto* ctf = CTF::get(buff.data());
-
-  auto getFreq = [ctf](CTF::Slots slot) -> o2::rans::FrequencyTable {
-    o2::rans::FrequencyTable ft;
-    auto bl = ctf->getBlock(slot);
-    auto md = ctf->getMetadata(slot);
-    ft.addFrequencies(bl.getDict(), bl.getDict() + bl.getNDict(), md.min, md.max);
-    return std::move(ft);
-  };
-  auto getProbBits = [ctf](CTF::Slots slot) -> int {
-    return ctf->getMetadata(slot).probabilityBits;
-  };
-
+  const auto ctf = CTF::getImage(bufVec.data());
   CompressedClusters cc; // just to get member types
-#define MAKECODER(part, slot) createCoder<decltype(part)::value_type>(op, getFreq(slot), getProbBits(slot), int(slot))
+#define MAKECODER(part, slot) createCoder<decltype(part)::value_type>(op, ctf.getFrequencyTable(slot), ctf.getMetadata(slot).probabilityBits, int(slot))
   // clang-format off
   MAKECODER(cc.firstChipROF, CTF::BLCfirstChipROF);
   MAKECODER(cc.bcIncROF,     CTF::BLCbcIncROF    );

--- a/Detectors/ITSMFT/common/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/EntropyDecoderSpec.cxx
@@ -87,7 +87,7 @@ void EntropyDecoderSpec::updateTimeDependentParams(ProcessingContext& pc)
   if (!coderUpdated) {
     coderUpdated = true;
     if (!mCTFDictPath.empty() && mCTFDictPath != "none") {
-      mCTFCoder.createCoders(mCTFDictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
+      mCTFCoder.createCodersFromFile<CTF>(mCTFDictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
     }
 
     if (mMaskNoise) {

--- a/Detectors/ITSMFT/common/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/EntropyEncoderSpec.cxx
@@ -39,7 +39,7 @@ void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
   std::string dictPath = ic.options().get<std::string>("ctf-dict");
   mCTFCoder.setMemMarginFactor(ic.options().get<float>("mem-factor"));
   if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
+    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
   }
 }
 

--- a/Detectors/MUON/MCH/CTF/include/MCHCTF/CTFCoder.h
+++ b/Detectors/MUON/MCH/CTF/include/MCHCTF/CTFCoder.h
@@ -39,7 +39,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 {
  public:
   CTFCoder() : o2::ctf::CTFCoderBase(CTF::getNBlocks(), o2::detectors::DetID::MCH) {}
-  ~CTFCoder() = default;
+  ~CTFCoder() final = default;
 
   /// entropy-encode data to buffer with CTF
   template <typename VEC>
@@ -49,7 +49,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
   template <typename VROF, typename VCOL>
   void decode(const CTF::base& ec, VROF& rofVec, VCOL& digVec);
 
-  void createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op);
+  void createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op) final;
 
  private:
   void appendToTree(TTree& tree, CTF& ec);

--- a/Detectors/MUON/MCH/CTF/include/MCHCTF/CTFHelper.h
+++ b/Detectors/MUON/MCH/CTF/include/MCHCTF/CTFHelper.h
@@ -35,7 +35,7 @@ class CTFHelper
 
   CTFHeader createHeader()
   {
-    CTFHeader h{0, 1, 0, // dummy timestamp, version 1.0
+    CTFHeader h{o2::detectors::DetID::MCH, 0, 1, 0, // dummy timestamp, version 1.0
                 uint32_t(mROFData.size()), uint32_t(mDigData.size()), 0, 0};
     if (mROFData.size()) {
       h.firstOrbit = mROFData[0].getBCData().orbit;

--- a/Detectors/MUON/MCH/CTF/src/CTFCoder.cxx
+++ b/Detectors/MUON/MCH/CTF/src/CTFCoder.cxx
@@ -37,39 +37,19 @@ void CTFCoder::readFromTree(TTree& tree, int entry, std::vector<ROFRecord>& rofV
 }
 
 ///________________________________
-void CTFCoder::createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op)
+void CTFCoder::createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op)
 {
-  bool mayFail = true; // RS FIXME if the dictionary file is not there, do not produce exception
-  auto buff = readDictionaryFromFile<CTF>(dictPath, mayFail);
-  if (!buff.size()) {
-    if (mayFail) {
-      return;
-    }
-    throw std::runtime_error("Failed to create CTF dictionaty");
-  }
-  const auto* ctf = CTF::get(buff.data());
-
-  auto getFreq = [ctf](CTF::Slots slot) -> o2::rans::FrequencyTable {
-    o2::rans::FrequencyTable ft;
-    auto bl = ctf->getBlock(slot);
-    auto md = ctf->getMetadata(slot);
-    ft.addFrequencies(bl.getDict(), bl.getDict() + bl.getNDict(), md.min, md.max);
-    return std::move(ft);
-  };
-  auto getProbBits = [ctf](CTF::Slots slot) -> int {
-    return ctf->getMetadata(slot).probabilityBits;
-  };
-
+  const auto ctf = CTF::getImage(bufVec.data());
   // just to get types
   uint16_t bcInc, nDigits, nSamples;
   uint32_t orbitInc, ADC;
   int32_t tfTime;
   int16_t detID, padID;
   uint8_t isSaturated;
-#define MAKECODER(part, slot) createCoder<decltype(part)>(op, getFreq(slot), getProbBits(slot), int(slot))
+#define MAKECODER(part, slot) createCoder<decltype(part)>(op, ctf.getFrequencyTable(slot), ctf.getMetadata(slot).probabilityBits, int(slot))
 
   // clang-format off
-  MAKECODER(bcInc,       CTF::BLC_bcIncROF); 
+  MAKECODER(bcInc,       CTF::BLC_bcIncROF);
   MAKECODER(orbitInc,    CTF::BLC_orbitIncROF);
   MAKECODER(nDigits,     CTF::BLC_nDigitsROF);
   MAKECODER(tfTime,      CTF::BLC_tfTime);

--- a/Detectors/MUON/MCH/Workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/EntropyDecoderSpec.cxx
@@ -52,7 +52,7 @@ void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
 {
   std::string dictPath = ic.options().get<std::string>("ctf-dict");
   if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
+    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
   }
 }
 

--- a/Detectors/MUON/MCH/Workflow/src/entropy-encoder-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/entropy-encoder-workflow.cxx
@@ -52,7 +52,7 @@ void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
   std::string dictPath = ic.options().get<std::string>("ctf-dict");
   mCTFCoder.setMemMarginFactor(ic.options().get<float>("mem-factor"));
   if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
+    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
   }
 }
 

--- a/Detectors/MUON/MID/CTF/include/MIDCTF/CTFCoder.h
+++ b/Detectors/MUON/MID/CTF/include/MIDCTF/CTFCoder.h
@@ -39,7 +39,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 {
  public:
   CTFCoder() : o2::ctf::CTFCoderBase(CTF::getNBlocks(), o2::detectors::DetID::MID) {}
-  ~CTFCoder() = default;
+  ~CTFCoder() final = default;
 
   /// entropy-encode data to buffer with CTF
   template <typename VEC>
@@ -49,7 +49,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
   template <typename VROF, typename VCOL>
   void decode(const CTF::base& ec, std::array<VROF, NEvTypes>& rofVec, std::array<VCOL, NEvTypes>& colVec);
 
-  void createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op);
+  void createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op) final;
 
  private:
   void appendToTree(TTree& tree, CTF& ec);

--- a/Detectors/MUON/MID/CTF/include/MIDCTF/CTFHelper.h
+++ b/Detectors/MUON/MID/CTF/include/MIDCTF/CTFHelper.h
@@ -45,7 +45,7 @@ class CTFHelper
 
   CTFHeader createHeader()
   {
-    CTFHeader h{0, 1, 0, // dummy timestamp, version 1.0
+    CTFHeader h{o2::detectors::DetID::MID, 0, 1, 0, // dummy timestamp, version 1.0
                 uint32_t(mTFData.rofDataRefs.size()), uint32_t(mTFData.colDataRefs.size()), 0, 0};
     if (h.nROFs) {
       auto id0 = mTFData.rofDataRefs.front();

--- a/Detectors/MUON/MID/CTF/src/CTFCoder.cxx
+++ b/Detectors/MUON/MID/CTF/src/CTFCoder.cxx
@@ -38,34 +38,14 @@ void CTFCoder::readFromTree(TTree& tree, int entry, std::array<std::vector<ROFRe
 }
 
 ///________________________________
-void CTFCoder::createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op)
+void CTFCoder::createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op)
 {
-  bool mayFail = true; // RS FIXME if the dictionary file is not there, do not produce exception
-  auto buff = readDictionaryFromFile<CTF>(dictPath, mayFail);
-  if (!buff.size()) {
-    if (mayFail) {
-      return;
-    }
-    throw std::runtime_error("Failed to create CTF dictionaty");
-  }
-  const auto* ctf = CTF::get(buff.data());
-
-  auto getFreq = [ctf](CTF::Slots slot) -> o2::rans::FrequencyTable {
-    o2::rans::FrequencyTable ft;
-    auto bl = ctf->getBlock(slot);
-    auto md = ctf->getMetadata(slot);
-    ft.addFrequencies(bl.getDict(), bl.getDict() + bl.getNDict(), md.min, md.max);
-    return std::move(ft);
-  };
-  auto getProbBits = [ctf](CTF::Slots slot) -> int {
-    return ctf->getMetadata(slot).probabilityBits;
-  };
-
+  const auto ctf = CTF::getImage(bufVec.data());
   // just to get types
   uint16_t bcInc = 0, entries = 0, pattern = 0;
   uint32_t orbitInc = 0;
   uint8_t evType = 0, deId = 0, colId = 0;
-#define MAKECODER(part, slot) createCoder<decltype(part)>(op, getFreq(slot), getProbBits(slot), int(slot))
+#define MAKECODER(part, slot) createCoder<decltype(part)>(op, ctf.getFrequencyTable(slot), ctf.getMetadata(slot).probabilityBits, int(slot))
   // clang-format off
   MAKECODER(bcInc,    CTF::BLC_bcIncROF);
   MAKECODER(orbitInc, CTF::BLC_orbitIncROF);

--- a/Detectors/MUON/MID/Workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/EntropyDecoderSpec.cxx
@@ -37,7 +37,7 @@ void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
 {
   std::string dictPath = ic.options().get<std::string>("ctf-dict");
   if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
+    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
   }
 }
 

--- a/Detectors/MUON/MID/Workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/EntropyEncoderSpec.cxx
@@ -43,7 +43,7 @@ void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
   std::string dictPath = ic.options().get<std::string>("ctf-dict");
   mCTFCoder.setMemMarginFactor(ic.options().get<float>("mem-factor"));
   if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
+    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
   }
 }
 

--- a/Detectors/PHOS/reconstruction/include/PHOSReconstruction/CTFCoder.h
+++ b/Detectors/PHOS/reconstruction/include/PHOSReconstruction/CTFCoder.h
@@ -37,7 +37,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 {
  public:
   CTFCoder() : o2::ctf::CTFCoderBase(CTF::getNBlocks(), o2::detectors::DetID::PHS) {}
-  ~CTFCoder() = default;
+  ~CTFCoder() final = default;
 
   /// entropy-encode data to buffer with CTF
   template <typename VEC>
@@ -47,7 +47,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
   template <typename VTRG, typename VCELL>
   void decode(const CTF::base& ec, VTRG& trigVec, VCELL& cellVec);
 
-  void createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op);
+  void createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op) final;
 
  private:
   void appendToTree(TTree& tree, CTF& ec);

--- a/Detectors/PHOS/reconstruction/include/PHOSReconstruction/CTFHelper.h
+++ b/Detectors/PHOS/reconstruction/include/PHOSReconstruction/CTFHelper.h
@@ -33,7 +33,7 @@ class CTFHelper
 
   CTFHeader createHeader()
   {
-    CTFHeader h{0, 1, 0, // dummy timestamp, version 1.0
+    CTFHeader h{o2::detectors::DetID::PHS, 0, 1, 0, // dummy timestamp, version 1.0
                 uint32_t(mTrigData.size()), uint32_t(mCellData.size()), 0, 0};
     if (mTrigData.size()) {
       h.firstOrbit = mTrigData[0].getBCData().orbit;

--- a/Detectors/PHOS/reconstruction/src/CTFCoder.cxx
+++ b/Detectors/PHOS/reconstruction/src/CTFCoder.cxx
@@ -37,36 +37,16 @@ void CTFCoder::readFromTree(TTree& tree, int entry, std::vector<TriggerRecord>& 
 }
 
 ///________________________________
-void CTFCoder::createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op)
+void CTFCoder::createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op)
 {
-  bool mayFail = true; // RS FIXME if the dictionary file is not there, do not produce exception
-  auto buff = readDictionaryFromFile<CTF>(dictPath, mayFail);
-  if (!buff.size()) {
-    if (mayFail) {
-      return;
-    }
-    throw std::runtime_error("Failed to create CTF dictionaty");
-  }
-  const auto* ctf = CTF::get(buff.data());
-
-  auto getFreq = [ctf](CTF::Slots slot) -> o2::rans::FrequencyTable {
-    o2::rans::FrequencyTable ft;
-    auto bl = ctf->getBlock(slot);
-    auto md = ctf->getMetadata(slot);
-    ft.addFrequencies(bl.getDict(), bl.getDict() + bl.getNDict(), md.min, md.max);
-    return std::move(ft);
-  };
-  auto getProbBits = [ctf](CTF::Slots slot) -> int {
-    return ctf->getMetadata(slot).probabilityBits;
-  };
-
+  const auto ctf = CTF::getImage(bufVec.data());
   // just to get types
   uint16_t bcInc = 0, entries = 0, cellTime = 0, energy = 0, packedid = 0;
   uint32_t orbitInc = 0;
   uint8_t status = 0;
-#define MAKECODER(part, slot) createCoder<decltype(part)>(op, getFreq(slot), getProbBits(slot), int(slot))
+#define MAKECODER(part, slot) createCoder<decltype(part)>(op, ctf.getFrequencyTable(slot), ctf.getMetadata(slot).probabilityBits, int(slot))
   // clang-format off
-  MAKECODER(bcInc,      CTF::BLC_bcIncTrig); 
+  MAKECODER(bcInc,      CTF::BLC_bcIncTrig);
   MAKECODER(orbitInc,   CTF::BLC_orbitIncTrig);
   MAKECODER(entries,    CTF::BLC_entriesTrig);
   MAKECODER(packedid,   CTF::BLC_packedID);

--- a/Detectors/PHOS/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/PHOS/workflow/src/EntropyDecoderSpec.cxx
@@ -35,7 +35,7 @@ void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
 {
   std::string dictPath = ic.options().get<std::string>("ctf-dict");
   if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
+    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
   }
 }
 

--- a/Detectors/PHOS/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/PHOS/workflow/src/EntropyEncoderSpec.cxx
@@ -36,7 +36,7 @@ void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
   std::string dictPath = ic.options().get<std::string>("ctf-dict");
   mCTFCoder.setMemMarginFactor(ic.options().get<float>("mem-factor"));
   if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
+    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
   }
 }
 

--- a/Detectors/TOF/reconstruction/CMakeLists.txt
+++ b/Detectors/TOF/reconstruction/CMakeLists.txt
@@ -12,7 +12,7 @@
 o2_add_library(TOFReconstruction
                SOURCES src/DataReader.cxx src/Clusterer.cxx
                        src/ClustererTask.cxx src/Encoder.cxx
-               	       src/DecoderBase.cxx
+                       src/DecoderBase.cxx
                        src/Decoder.cxx
                        src/CTFCoder.cxx
                        src/CosmicProcessor.cxx
@@ -30,5 +30,4 @@ o2_target_root_dictionary(TOFReconstruction
                                   include/TOFReconstruction/Encoder.h
                                   include/TOFReconstruction/DecoderBase.h
                                   include/TOFReconstruction/Decoder.h
-                                  include/TOFReconstruction/CTFCoder.h
                                   include/TOFReconstruction/CosmicProcessor.h)

--- a/Detectors/TOF/reconstruction/include/TOFReconstruction/CTFCoder.h
+++ b/Detectors/TOF/reconstruction/include/TOFReconstruction/CTFCoder.h
@@ -36,7 +36,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 {
  public:
   CTFCoder() : o2::ctf::CTFCoderBase(CTF::getNBlocks(), o2::detectors::DetID::TOF) {}
-  ~CTFCoder() = default;
+  ~CTFCoder() final = default;
 
   /// entropy-encode clusters to buffer with CTF
   template <typename VEC>
@@ -46,7 +46,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
   template <typename VROF, typename VDIG, typename VPAT>
   void decode(const CTF::base& ec, VROF& rofRecVec, VDIG& cdigVec, VPAT& pattVec);
 
-  void createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op);
+  void createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op) final;
 
  private:
   /// compres compact clusters to CompressedInfos
@@ -58,9 +58,6 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 
   void appendToTree(TTree& tree, CTF& ec);
   void readFromTree(TTree& tree, int entry, std::vector<ReadoutWindowData>& rofRecVec, std::vector<Digit>& cdigVec, std::vector<uint8_t>& pattVec);
-
- protected:
-  ClassDefNV(CTFCoder, 1);
 };
 
 ///___________________________________________________________________________________

--- a/Detectors/TOF/reconstruction/src/CTFCoder.cxx
+++ b/Detectors/TOF/reconstruction/src/CTFCoder.cxx
@@ -51,7 +51,7 @@ void CTFCoder::compress(CompressedInfos& cc,
   int nrof = rofRecVec.size();
 
   LOGF(debug, "TOF compress %d ReadoutWindow with %ld digits", nrof, cdigVec.size());
-
+  cc.header.det = mDet;
   cc.header.nROFs = nrof;
   cc.header.firstOrbit = rofRec0.getBCData().orbit;
   cc.header.firstBC = rofRec0.getBCData().bc;
@@ -155,31 +155,11 @@ void CTFCoder::compress(CompressedInfos& cc,
 }
 
 ///________________________________
-void CTFCoder::createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op)
+void CTFCoder::createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op)
 {
-  bool mayFail = true; // RS FIXME if the dictionary file is not there, do not produce exception
-  auto buff = readDictionaryFromFile<CTF>(dictPath, mayFail);
-  if (!buff.size()) {
-    if (mayFail) {
-      return;
-    }
-    throw std::runtime_error("Failed to create CTF dictionaty");
-  }
-  const auto* ctf = CTF::get(buff.data());
-
-  auto getFreq = [ctf](CTF::Slots slot) -> o2::rans::FrequencyTable {
-    o2::rans::FrequencyTable ft;
-    auto bl = ctf->getBlock(slot);
-    auto md = ctf->getMetadata(slot);
-    ft.addFrequencies(bl.getDict(), bl.getDict() + bl.getNDict(), md.min, md.max);
-    return std::move(ft);
-  };
-  auto getProbBits = [ctf](CTF::Slots slot) -> int {
-    return ctf->getMetadata(slot).probabilityBits;
-  };
-
+  const auto ctf = CTF::getImage(bufVec.data());
   CompressedInfos cc; // just to get member types
-#define MAKECODER(part, slot) createCoder<decltype(part)::value_type>(op, getFreq(slot), getProbBits(slot), int(slot))
+#define MAKECODER(part, slot) createCoder<decltype(part)::value_type>(op, ctf.getFrequencyTable(slot), ctf.getMetadata(slot).probabilityBits, int(slot))
   // clang-format off
   MAKECODER(cc.bcIncROF,     CTF::BLCbcIncROF);
   MAKECODER(cc.orbitIncROF,  CTF::BLCorbitIncROF);

--- a/Detectors/TOF/reconstruction/src/TOFReconstructionLinkDef.h
+++ b/Detectors/TOF/reconstruction/src/TOFReconstructionLinkDef.h
@@ -21,7 +21,6 @@
 #pragma link C++ class o2::tof::ClustererTask + ;
 #pragma link C++ class o2::tof::raw::Encoder + ;
 #pragma link C++ class o2::tof::compressed::Decoder + ;
-#pragma link C++ class o2::tof::CTFCoder + ;
 #pragma link C++ class o2::tof::CosmicProcessor + ;
 
 #endif

--- a/Detectors/TOF/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/TOF/workflow/src/EntropyDecoderSpec.cxx
@@ -35,7 +35,7 @@ void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
 {
   std::string dictPath = ic.options().get<std::string>("ctf-dict");
   if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
+    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
   }
 }
 

--- a/Detectors/TOF/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/TOF/workflow/src/EntropyEncoderSpec.cxx
@@ -36,7 +36,7 @@ void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
   std::string dictPath = ic.options().get<std::string>("ctf-dict");
   mCTFCoder.setMemMarginFactor(ic.options().get<float>("mem-factor"));
   if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
+    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
   }
 }
 

--- a/Detectors/TPC/reconstruction/CMakeLists.txt
+++ b/Detectors/TPC/reconstruction/CMakeLists.txt
@@ -57,7 +57,6 @@ o2_target_root_dictionary(
           include/TPCReconstruction/HardwareClusterDecoder.h
           include/TPCReconstruction/DigitalCurrentClusterIntegrator.h
           include/TPCReconstruction/TPCFastTransformHelperO2.h
-          include/TPCReconstruction/CTFCoder.h
           include/TPCReconstruction/RawProcessingHelpers.h)
 
 o2_add_executable(read-gbtframes

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/CTFCoder.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/CTFCoder.h
@@ -111,7 +111,8 @@ class CTFCoder : public o2::ctf::CTFCoderBase
   template <typename VEC>
   void decode(const CTF::base& ec, VEC& buff);
 
-  void createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op);
+  void createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op) final;
+
   size_t estimateCompressedSize(const CompressedClusters& ccl);
 
   static size_t constexpr Alignment = 16;
@@ -149,8 +150,6 @@ class CTFCoder : public o2::ctf::CTFCoderBase
   void buildCoder(ctf::CTFCoderBase::OpType coderType, const CTF::container_t& ctf, CTF::Slots slot);
 
   bool mCombineColumns = false; // combine correlated columns
-
-  ClassDefNV(CTFCoder, 1);
 };
 
 template <typename source_T>
@@ -212,7 +211,7 @@ void CTFCoder::encode(VEC& buff, const CompressedClusters& ccl)
   if (mCombineColumns) {
     flags |= CTFHeader::CombinedColumns;
   }
-  ec->setHeader(CTFHeader{0, 1, 0, // dummy timestamp, version 1.0
+  ec->setHeader(CTFHeader{o2::detectors::DetID::TPC, 0, 1, 0, // dummy timestamp, version 1.0
                           ccl, flags});
   assignDictVersion(static_cast<o2::ctf::CTFDictHeader&>(ec->getHeader()));
   ec->getANSHeader().majorVersion = 0;

--- a/Detectors/TPC/reconstruction/src/CTFCoder.cxx
+++ b/Detectors/TPC/reconstruction/src/CTFCoder.cxx
@@ -90,67 +90,58 @@ void CTFCoder::setCompClusAddresses(CompressedClusters& c, void*& buff)
 }
 
 ///________________________________
-void CTFCoder::createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op)
+void CTFCoder::createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op)
 {
   using namespace detail;
-
-  bool mayFail = true; // RS FIXME if the dictionary file is not there, do not produce exception
-  auto buff = readDictionaryFromFile<CTF>(dictPath, mayFail);
-  if (!buff.size()) {
-    if (mayFail) {
-      return;
-    }
-    throw std::runtime_error("Failed to create CTF dictionaty");
-  }
-  const CTF::container_t* ctf = CTF::get(buff.data());
-  mCombineColumns = ctf->getHeader().flags & CTFHeader::CombinedColumns;
+  const CTF::container_t ctf = CTF::getImage(bufVec.data());
+  mCombineColumns = ctf.getHeader().flags & CTFHeader::CombinedColumns;
   LOG(info) << "TPC CTF Columns Combining " << (mCombineColumns ? "ON" : "OFF");
 
   const CompressedClusters cc; // just to get member types
   if (mCombineColumns) {
-    buildCoder<combinedType_t<CTF::NBitsQTot, CTF::NBitsQMax>>(op, *ctf, CTF::BLCqTotA);
+    buildCoder<combinedType_t<CTF::NBitsQTot, CTF::NBitsQMax>>(op, ctf, CTF::BLCqTotA);
   } else {
-    buildCoder<std::remove_pointer_t<decltype(cc.qTotA)>>(op, *ctf, CTF::BLCqTotA);
+    buildCoder<std::remove_pointer_t<decltype(cc.qTotA)>>(op, ctf, CTF::BLCqTotA);
   }
-  buildCoder<std::remove_pointer_t<decltype(cc.qMaxA)>>(op, *ctf, CTF::BLCqMaxA);
-  buildCoder<std::remove_pointer_t<decltype(cc.flagsA)>>(op, *ctf, CTF::BLCflagsA);
+  buildCoder<std::remove_pointer_t<decltype(cc.qMaxA)>>(op, ctf, CTF::BLCqMaxA);
+  buildCoder<std::remove_pointer_t<decltype(cc.flagsA)>>(op, ctf, CTF::BLCflagsA);
   if (mCombineColumns) {
-    buildCoder<combinedType_t<CTF::NBitsRowDiff, CTF::NBitsSliceLegDiff>>(op, *ctf, CTF::BLCrowDiffA); // merged rowDiffA and sliceLegDiffA
+    buildCoder<combinedType_t<CTF::NBitsRowDiff, CTF::NBitsSliceLegDiff>>(op, ctf, CTF::BLCrowDiffA); // merged rowDiffA and sliceLegDiffA
 
   } else {
-    buildCoder<std::remove_pointer_t<decltype(cc.rowDiffA)>>(op, *ctf, CTF::BLCrowDiffA);
+    buildCoder<std::remove_pointer_t<decltype(cc.rowDiffA)>>(op, ctf, CTF::BLCrowDiffA);
   }
-  buildCoder<std::remove_pointer_t<decltype(cc.sliceLegDiffA)>>(op, *ctf, CTF::BLCsliceLegDiffA);
-  buildCoder<std::remove_pointer_t<decltype(cc.padResA)>>(op, *ctf, CTF::BLCpadResA);
-  buildCoder<std::remove_pointer_t<decltype(cc.timeResA)>>(op, *ctf, CTF::BLCtimeResA);
+  buildCoder<std::remove_pointer_t<decltype(cc.sliceLegDiffA)>>(op, ctf, CTF::BLCsliceLegDiffA);
+  buildCoder<std::remove_pointer_t<decltype(cc.padResA)>>(op, ctf, CTF::BLCpadResA);
+  buildCoder<std::remove_pointer_t<decltype(cc.timeResA)>>(op, ctf, CTF::BLCtimeResA);
   if (mCombineColumns) {
-    buildCoder<combinedType_t<CTF::NBitsSigmaPad, CTF::NBitsSigmaTime>>(op, *ctf, CTF::BLCsigmaPadA); // merged sigmaPadA and sigmaTimeA
+    buildCoder<combinedType_t<CTF::NBitsSigmaPad, CTF::NBitsSigmaTime>>(op, ctf, CTF::BLCsigmaPadA); // merged sigmaPadA and sigmaTimeA
   } else {
-    buildCoder<std::remove_pointer_t<decltype(cc.sigmaPadA)>>(op, *ctf, CTF::BLCsigmaPadA);
+    buildCoder<std::remove_pointer_t<decltype(cc.sigmaPadA)>>(op, ctf, CTF::BLCsigmaPadA);
   }
-  buildCoder<std::remove_pointer_t<decltype(cc.sigmaTimeA)>>(op, *ctf, CTF::BLCsigmaTimeA);
-  buildCoder<std::remove_pointer_t<decltype(cc.qPtA)>>(op, *ctf, CTF::BLCqPtA);
-  buildCoder<std::remove_pointer_t<decltype(cc.rowA)>>(op, *ctf, CTF::BLCrowA);
-  buildCoder<std::remove_pointer_t<decltype(cc.sliceA)>>(op, *ctf, CTF::BLCsliceA);
-  buildCoder<std::remove_pointer_t<decltype(cc.timeA)>>(op, *ctf, CTF::BLCtimeA);
-  buildCoder<std::remove_pointer_t<decltype(cc.padA)>>(op, *ctf, CTF::BLCpadA);
+  buildCoder<std::remove_pointer_t<decltype(cc.sigmaTimeA)>>(op, ctf, CTF::BLCsigmaTimeA);
+  buildCoder<std::remove_pointer_t<decltype(cc.qPtA)>>(op, ctf, CTF::BLCqPtA);
+  buildCoder<std::remove_pointer_t<decltype(cc.rowA)>>(op, ctf, CTF::BLCrowA);
+  buildCoder<std::remove_pointer_t<decltype(cc.sliceA)>>(op, ctf, CTF::BLCsliceA);
+  buildCoder<std::remove_pointer_t<decltype(cc.timeA)>>(op, ctf, CTF::BLCtimeA);
+  buildCoder<std::remove_pointer_t<decltype(cc.padA)>>(op, ctf, CTF::BLCpadA);
   if (mCombineColumns) {
-    buildCoder<combinedType_t<CTF::NBitsQTot, CTF::NBitsQMax>>(op, *ctf, CTF::BLCqTotU); // merged qTotU and qMaxU
+    buildCoder<combinedType_t<CTF::NBitsQTot, CTF::NBitsQMax>>(op, ctf, CTF::BLCqTotU); // merged qTotU and qMaxU
   } else {
-    buildCoder<std::remove_pointer_t<decltype(cc.qTotU)>>(op, *ctf, CTF::BLCqTotU);
+    buildCoder<std::remove_pointer_t<decltype(cc.qTotU)>>(op, ctf, CTF::BLCqTotU);
   }
-  buildCoder<std::remove_pointer_t<decltype(cc.qMaxU)>>(op, *ctf, CTF::BLCqMaxU);
-  buildCoder<std::remove_pointer_t<decltype(cc.flagsU)>>(op, *ctf, CTF::BLCflagsU);
-  buildCoder<std::remove_pointer_t<decltype(cc.padDiffU)>>(op, *ctf, CTF::BLCpadDiffU);
-  buildCoder<std::remove_pointer_t<decltype(cc.timeDiffU)>>(op, *ctf, CTF::BLCtimeDiffU);
+  buildCoder<std::remove_pointer_t<decltype(cc.qMaxU)>>(op, ctf, CTF::BLCqMaxU);
+  buildCoder<std::remove_pointer_t<decltype(cc.flagsU)>>(op, ctf, CTF::BLCflagsU);
+  buildCoder<std::remove_pointer_t<decltype(cc.padDiffU)>>(op, ctf, CTF::BLCpadDiffU);
+  buildCoder<std::remove_pointer_t<decltype(cc.timeDiffU)>>(op, ctf, CTF::BLCtimeDiffU);
   if (mCombineColumns) {
-    buildCoder<combinedType_t<CTF::NBitsSigmaPad, CTF::NBitsSigmaTime>>(op, *ctf, CTF::BLCsigmaPadU); // merged sigmaPadU and sigmaTimeU
+    buildCoder<combinedType_t<CTF::NBitsSigmaPad, CTF::NBitsSigmaTime>>(op, ctf, CTF::BLCsigmaPadU); // merged sigmaPadU and sigmaTimeU
   } else {
-    buildCoder<std::remove_pointer_t<decltype(cc.sigmaPadU)>>(op, *ctf, CTF::BLCsigmaPadU);
+    buildCoder<std::remove_pointer_t<decltype(cc.sigmaPadU)>>(op, ctf, CTF::BLCsigmaPadU);
   }
-  buildCoder<std::remove_pointer_t<decltype(cc.sigmaTimeU)>>(op, *ctf, CTF::BLCsigmaTimeU);
-  buildCoder<std::remove_pointer_t<decltype(cc.nTrackClusters)>>(op, *ctf, CTF::BLCnTrackClusters);
-  buildCoder<std::remove_pointer_t<decltype(cc.nSliceRowClusters)>>(op, *ctf, CTF::BLCnSliceRowClusters);
+  buildCoder<std::remove_pointer_t<decltype(cc.sigmaTimeU)>>(op, ctf, CTF::BLCsigmaTimeU);
+  buildCoder<std::remove_pointer_t<decltype(cc.nTrackClusters)>>(op, ctf, CTF::BLCnTrackClusters);
+  buildCoder<std::remove_pointer_t<decltype(cc.nSliceRowClusters)>>(op, ctf, CTF::BLCnSliceRowClusters);
 }
 
 /// make sure loaded dictionaries (if any) are consistent with data
@@ -176,27 +167,27 @@ size_t CTFCoder::estimateCompressedSize(const CompressedClusters& ccl)
 #define ESTSIZE(slot, ptr, n) mCoders[int(slot)] ? \
     rans::calculateMaxBufferSize(n, reinterpret_cast<const o2::rans::LiteralEncoder64<std::remove_pointer<decltype(ptr)>::type>*>(mCoders[int(slot)].get())->getAlphabetRangeBits(), \
                                  sizeof(std::remove_pointer<decltype(ptr)>::type)) : n*sizeof(std::remove_pointer<decltype(ptr)>)
-  sz += ESTSIZE(CTF::BLCqTotA,	           ccl.qTotA,  	          ccl.nAttachedClusters);
-  sz += ESTSIZE(CTF::BLCqMaxA,	           ccl.qMaxA,  	          ccl.nAttachedClusters);
-  sz += ESTSIZE(CTF::BLCflagsA,	           ccl.flagsA, 	          ccl.nAttachedClusters);
-  sz += ESTSIZE(CTF::BLCrowDiffA,	   ccl.rowDiffA,	  ccl.nAttachedClustersReduced);
+  sz += ESTSIZE(CTF::BLCqTotA,            ccl.qTotA,             ccl.nAttachedClusters);
+  sz += ESTSIZE(CTF::BLCqMaxA,            ccl.qMaxA,             ccl.nAttachedClusters);
+  sz += ESTSIZE(CTF::BLCflagsA,            ccl.flagsA,            ccl.nAttachedClusters);
+  sz += ESTSIZE(CTF::BLCrowDiffA,    ccl.rowDiffA,   ccl.nAttachedClustersReduced);
   sz += ESTSIZE(CTF::BLCsliceLegDiffA,     ccl.sliceLegDiffA,     ccl.nAttachedClustersReduced);
-  sz += ESTSIZE(CTF::BLCpadResA,	   ccl.padResA,	          ccl.nAttachedClustersReduced);
-  sz += ESTSIZE(CTF::BLCtimeResA,	   ccl.timeResA,	  ccl.nAttachedClustersReduced);
-  sz += ESTSIZE(CTF::BLCsigmaPadA,	   ccl.sigmaPadA,	  ccl.nAttachedClusters);
-  sz += ESTSIZE(CTF::BLCsigmaTimeA,	   ccl.sigmaTimeA,	  ccl.nAttachedClusters);
-  sz += ESTSIZE(CTF::BLCqPtA, 	           ccl.qPtA,		  ccl.nTracks);
-  sz += ESTSIZE(CTF::BLCrowA, 	           ccl.rowA,		  ccl.nTracks);
-  sz += ESTSIZE(CTF::BLCsliceA,	           ccl.sliceA, 	          ccl.nTracks);
-  sz += ESTSIZE(CTF::BLCtimeA,	           ccl.timeA,  	          ccl.nTracks);
-  sz += ESTSIZE(CTF::BLCpadA, 	           ccl.padA,		  ccl.nTracks);
-  sz += ESTSIZE(CTF::BLCqTotU,	           ccl.qTotU,  	          ccl.nUnattachedClusters);
-  sz += ESTSIZE(CTF::BLCqMaxU,	           ccl.qMaxU,  	          ccl.nUnattachedClusters);
-  sz += ESTSIZE(CTF::BLCflagsU,	           ccl.flagsU, 	          ccl.nUnattachedClusters);
-  sz += ESTSIZE(CTF::BLCpadDiffU,	   ccl.padDiffU,	  ccl.nUnattachedClusters);
-  sz += ESTSIZE(CTF::BLCtimeDiffU,	   ccl.timeDiffU,	  ccl.nUnattachedClusters);
-  sz += ESTSIZE(CTF::BLCsigmaPadU,	   ccl.sigmaPadU,	  ccl.nUnattachedClusters);
-  sz += ESTSIZE(CTF::BLCsigmaTimeU,	   ccl.sigmaTimeU,	  ccl.nUnattachedClusters);
+  sz += ESTSIZE(CTF::BLCpadResA,    ccl.padResA,           ccl.nAttachedClustersReduced);
+  sz += ESTSIZE(CTF::BLCtimeResA,    ccl.timeResA,   ccl.nAttachedClustersReduced);
+  sz += ESTSIZE(CTF::BLCsigmaPadA,    ccl.sigmaPadA,   ccl.nAttachedClusters);
+  sz += ESTSIZE(CTF::BLCsigmaTimeA,    ccl.sigmaTimeA,   ccl.nAttachedClusters);
+  sz += ESTSIZE(CTF::BLCqPtA,             ccl.qPtA,    ccl.nTracks);
+  sz += ESTSIZE(CTF::BLCrowA,             ccl.rowA,    ccl.nTracks);
+  sz += ESTSIZE(CTF::BLCsliceA,            ccl.sliceA,            ccl.nTracks);
+  sz += ESTSIZE(CTF::BLCtimeA,            ccl.timeA,             ccl.nTracks);
+  sz += ESTSIZE(CTF::BLCpadA,             ccl.padA,    ccl.nTracks);
+  sz += ESTSIZE(CTF::BLCqTotU,            ccl.qTotU,             ccl.nUnattachedClusters);
+  sz += ESTSIZE(CTF::BLCqMaxU,            ccl.qMaxU,             ccl.nUnattachedClusters);
+  sz += ESTSIZE(CTF::BLCflagsU,            ccl.flagsU,            ccl.nUnattachedClusters);
+  sz += ESTSIZE(CTF::BLCpadDiffU,    ccl.padDiffU,   ccl.nUnattachedClusters);
+  sz += ESTSIZE(CTF::BLCtimeDiffU,    ccl.timeDiffU,   ccl.nUnattachedClusters);
+  sz += ESTSIZE(CTF::BLCsigmaPadU,    ccl.sigmaPadU,   ccl.nUnattachedClusters);
+  sz += ESTSIZE(CTF::BLCsigmaTimeU,    ccl.sigmaTimeU,   ccl.nUnattachedClusters);
   sz += ESTSIZE(CTF::BLCnTrackClusters,    ccl.nTrackClusters,    ccl.nTracks);
   sz += ESTSIZE(CTF::BLCnSliceRowClusters, ccl.nSliceRowClusters, ccl.nSliceRows);
   // clang-format on

--- a/Detectors/TPC/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/TPC/workflow/src/EntropyDecoderSpec.cxx
@@ -29,7 +29,7 @@ void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
 {
   std::string dictPath = ic.options().get<std::string>("ctf-dict");
   if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
+    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
   }
 }
 

--- a/Detectors/TPC/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/TPC/workflow/src/EntropyEncoderSpec.cxx
@@ -33,7 +33,7 @@ void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
   mCTFCoder.setMemMarginFactor(ic.options().get<float>("mem-factor"));
   std::string dictPath = ic.options().get<std::string>("ctf-dict");
   if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
+    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
   }
 }
 

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CTFCoder.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CTFCoder.h
@@ -37,7 +37,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 {
  public:
   CTFCoder() : o2::ctf::CTFCoderBase(CTF::getNBlocks(), o2::detectors::DetID::TRD) {}
-  ~CTFCoder() = default;
+  ~CTFCoder() final = default;
 
   /// entropy-encode data to buffer with CTF
   template <typename VEC>
@@ -47,7 +47,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
   template <typename VTRG, typename VTRK, typename VDIG>
   void decode(const CTF::base& ec, VTRG& trigVec, VTRK& trkVec, VDIG& digVec);
 
-  void createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op);
+  void createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op) final;
 
  private:
   void appendToTree(TTree& tree, CTF& ec);

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CTFHelper.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CTFHelper.h
@@ -49,7 +49,7 @@ class CTFHelper
 
   CTFHeader createHeader()
   {
-    CTFHeader h{0, 1, 0, // dummy timestamp, version 1.0
+    CTFHeader h{o2::detectors::DetID::TRD, 0, 1, 0, // dummy timestamp, version 1.0
                 uint32_t(mTrigRec.size()), uint32_t(mTrkData.size()), uint32_t(mDigData.size()), 0, 0, 0};
     if (mTrigRec.size()) {
       h.firstOrbit = mTrigRec[0].getBCData().orbit;

--- a/Detectors/TRD/reconstruction/src/CTFCoder.cxx
+++ b/Detectors/TRD/reconstruction/src/CTFCoder.cxx
@@ -37,35 +37,15 @@ void CTFCoder::readFromTree(TTree& tree, int entry, std::vector<TriggerRecord>& 
 }
 
 ///________________________________
-void CTFCoder::createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op)
+void CTFCoder::createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op)
 {
-  bool mayFail = true; // RS FIXME if the dictionary file is not there, do not produce exception
-  auto buff = readDictionaryFromFile<CTF>(dictPath, mayFail);
-  if (!buff.size()) {
-    if (mayFail) {
-      return;
-    }
-    throw std::runtime_error("Failed to create CTF dictionaty");
-  }
-  const auto* ctf = CTF::get(buff.data());
-
-  auto getFreq = [ctf](CTF::Slots slot) -> o2::rans::FrequencyTable {
-    o2::rans::FrequencyTable ft;
-    auto bl = ctf->getBlock(slot);
-    auto md = ctf->getMetadata(slot);
-    ft.addFrequencies(bl.getDict(), bl.getDict() + bl.getNDict(), md.min, md.max);
-    return std::move(ft);
-  };
-  auto getProbBits = [ctf](CTF::Slots slot) -> int {
-    return ctf->getMetadata(slot).probabilityBits;
-  };
-
+  const auto ctf = CTF::getImage(bufVec.data());
   // just to get types
   uint16_t bcInc, HCIDTrk, posTrk, CIDDig, ADCDig;
   uint32_t orbitInc, entriesTrk, entriesDig, pidTrk;
   uint8_t padrowTrk, colTrk, slopeTrk, ROBDig, MCMDig, chanDig;
 
-#define MAKECODER(part, slot) createCoder<decltype(part)>(op, getFreq(slot), getProbBits(slot), int(slot))
+#define MAKECODER(part, slot) createCoder<decltype(part)>(op, ctf.getFrequencyTable(slot), ctf.getMetadata(slot).probabilityBits, int(slot))
   // clang-format off
   MAKECODER(bcInc,      CTF::BLC_bcIncTrig);
   MAKECODER(orbitInc,   CTF::BLC_orbitIncTrig);

--- a/Detectors/TRD/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/TRD/workflow/src/EntropyDecoderSpec.cxx
@@ -51,7 +51,7 @@ void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
 {
   std::string dictPath = ic.options().get<std::string>("ctf-dict");
   if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
+    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
   }
 }
 

--- a/Detectors/TRD/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/TRD/workflow/src/EntropyEncoderSpec.cxx
@@ -52,7 +52,7 @@ void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
   std::string dictPath = ic.options().get<std::string>("ctf-dict");
   mCTFCoder.setMemMarginFactor(ic.options().get<float>("mem-factor"));
   if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
+    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
   }
 }
 

--- a/Detectors/ZDC/reconstruction/include/ZDCReconstruction/CTFCoder.h
+++ b/Detectors/ZDC/reconstruction/include/ZDCReconstruction/CTFCoder.h
@@ -37,7 +37,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 {
  public:
   CTFCoder() : o2::ctf::CTFCoderBase(CTF::getNBlocks(), o2::detectors::DetID::ZDC) {}
-  ~CTFCoder() = default;
+  ~CTFCoder() final = default;
 
   /// entropy-encode data to buffer with CTF
   template <typename VEC>
@@ -47,7 +47,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
   template <typename VTRG, typename VCHAN, typename VPED>
   void decode(const CTF::base& ec, VTRG& trigVec, VCHAN& chanVec, VPED& pedVec);
 
-  void createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op);
+  void createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op) final;
 
  private:
   void appendToTree(TTree& tree, CTF& ec);

--- a/Detectors/ZDC/reconstruction/include/ZDCReconstruction/CTFHelper.h
+++ b/Detectors/ZDC/reconstruction/include/ZDCReconstruction/CTFHelper.h
@@ -39,7 +39,7 @@ class CTFHelper
 
   CTFHeader createHeader()
   {
-    CTFHeader h{0, 1, 0, // dummy timestamp, version 1.0
+    CTFHeader h{o2::detectors::DetID::ZDC, 0, 1, 0, // dummy timestamp, version 1.0
                 uint32_t(mTrigData.size()), uint32_t(mChanData.size()), uint32_t(mEOData.size()), 0, 0, 0};
     if (mTrigData.size()) {
       h.firstOrbit = mTrigData[0].ir.orbit;

--- a/Detectors/ZDC/reconstruction/src/CTFCoder.cxx
+++ b/Detectors/ZDC/reconstruction/src/CTFCoder.cxx
@@ -37,34 +37,14 @@ void CTFCoder::readFromTree(TTree& tree, int entry, std::vector<BCData>& trigVec
 }
 
 ///________________________________
-void CTFCoder::createCoders(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op)
+void CTFCoder::createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op)
 {
-  bool mayFail = true; // RS FIXME if the dictionary file is not there, do not produce exception
-  auto buff = readDictionaryFromFile<CTF>(dictPath, mayFail);
-  if (!buff.size()) {
-    if (mayFail) {
-      return;
-    }
-    throw std::runtime_error("Failed to create CTF dictionaty");
-  }
-  const auto* ctf = CTF::get(buff.data());
-
-  auto getFreq = [ctf](CTF::Slots slot) -> o2::rans::FrequencyTable {
-    o2::rans::FrequencyTable ft;
-    auto bl = ctf->getBlock(slot);
-    auto md = ctf->getMetadata(slot);
-    ft.addFrequencies(bl.getDict(), bl.getDict() + bl.getNDict(), md.min, md.max);
-    return std::move(ft);
-  };
-  auto getProbBits = [ctf](CTF::Slots slot) -> int {
-    return ctf->getMetadata(slot).probabilityBits;
-  };
-
+  const auto ctf = CTF::getImage(bufVec.data());
   // just to get types
   uint16_t bcIncTrig, moduleTrig, nchanTrig, chanData, pedData, sclInc, triggersHL, channelsHL;
   uint32_t orbitIncTrig, orbitIncEOD;
   uint8_t extTriggers, chanID;
-#define MAKECODER(part, slot) createCoder<decltype(part)>(op, getFreq(slot), getProbBits(slot), int(slot))
+#define MAKECODER(part, slot) createCoder<decltype(part)>(op, ctf.getFrequencyTable(slot), ctf.getMetadata(slot).probabilityBits, int(slot))
   // clang-format off
   MAKECODER(bcIncTrig,         CTF::BLC_bcIncTrig);
   MAKECODER(orbitIncTrig,      CTF::BLC_orbitIncTrig);

--- a/Detectors/ZDC/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/ZDC/workflow/src/EntropyDecoderSpec.cxx
@@ -35,7 +35,7 @@ void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
 {
   std::string dictPath = ic.options().get<std::string>("ctf-dict");
   if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
+    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
   }
 }
 

--- a/Detectors/ZDC/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/ZDC/workflow/src/EntropyEncoderSpec.cxx
@@ -38,7 +38,7 @@ void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
   std::string dictPath = ic.options().get<std::string>("ctf-dict");
   mCTFCoder.setMemMarginFactor(ic.options().get<float>("mem-factor"));
   if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCoders(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
+    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
   }
 }
 


### PR DESCRIPTION
+ macro to create plain vector-based per-detector dictionaries from the global tree-based CTF dictionary produced by the `o2-ctf-writer-workflow`.

The dictionaries used for the commissioning are uploaded to http://alice-ccdb.cern.ch/<DET>/Calib/CTFDictionary with validity from 16/07/21 to 12/05/22.

@MichaelLettrich note there were some changes in the createCoders methods.