### PR TITLE
TRD remove straggling error output and add option for trigger fix

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawDataStats.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawDataStats.h
@@ -90,6 +90,7 @@ enum OptionBits {
   TRDIgnoreTrackletHCHeaderBit,
   TRDEnableRootOutputBit,
   TRDFixSM1617Bit,
+  TRDIgnore2StageTrigger,
   TRDGenerateStats
 };
 

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/DigitsParser.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/DigitsParser.h
@@ -71,8 +71,6 @@ class DigitsParser
   void clear() { mDigits.clear(); }
   uint64_t getDumpedDataCount() { return mWordsDumped; }
   uint64_t getDataWordsParsed() { return mDataWordsParsed; }
-  void tryFindMCMHeaderAndDisplay(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator mStartParse);
-  //void tryFindMCMHeaderAndDisplay(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator mStartParse);
   void OutputIncomingData();
   void setParsingHisto(TH1F* parsingerrors, TList* parsingerrors2d)
   {

--- a/Detectors/TRD/reconstruction/src/CruRawReader.cxx
+++ b/Detectors/TRD/reconstruction/src/CruRawReader.cxx
@@ -542,7 +542,7 @@ int CruRawReader::processHalfCRU(int cruhbfstartoffset)
       ** DIGITS NOW ***
       *****************/
       // Check if we have a calibration trigger ergo we do actually have digits data. check if we are now at the end of the data due to bugs, i.e. if trackletparsing read padding words.
-      if (linkstart != linkend && mCurrentHalfCRUHeader.EventType == o2::trd::constants::ETYPECALIBRATIONTRIGGER) { // calibration trigger
+      if (linkstart != linkend && (mCurrentHalfCRUHeader.EventType == o2::trd::constants::ETYPECALIBRATIONTRIGGER || mOptions[TRDIgnore2StageTrigger])) { // calibration trigger
         if (mHeaderVerbose) {
           LOG(info) << "*** Digit Parsing : starting at " << std::hex << linkstart << " at hbfoffset: " << std::dec << mHBFoffset32 << " linkhbf start pos:" << hbfoffsetatstartoflink;
         }

--- a/Detectors/TRD/reconstruction/src/DataReader.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReader.cxx
@@ -53,6 +53,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"halfchambermajor", VariantType::Int, 0, {"Fix half chamber for when it is version is 0.0 integer value of major version, ignored if version is not 0.0"}},
     {"ignore-digithcheader", VariantType::Bool, false, {"Ignore the digithalf chamber header for cross referencing, take rdh/cru as authorative."}},
     {"fixsm1617", VariantType::Bool, false, {"Fix the missing bit in the tracklet hc header of supermodules 16 and 17. Requires option tracklethcheader 2"}},
+    {"fixforoldtrigger", VariantType::Bool, false, {"Fix for the old data not having a 2 stage trigger stored in the cru header."}},
     {"tracklethcheader", VariantType::Int, 2, {"Status of TrackletHalfChamberHeader 0 off always, 1 iff tracklet data, 2 on always"}},
     {"histogramsfile", VariantType::String, "histos.root", {"Name of the histogram file, so one can run multiple per node"}},
     //{"generate-stats", VariantType::Bool, true, {"Generate the state message sent to qc"}},
@@ -104,6 +105,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   binaryoptions[o2::trd::TRDEnableRootOutputBit] = cfgc.options().get<bool>("enable-root-output");
   binaryoptions[o2::trd::TRDByteSwapBit] = cfgc.options().get<bool>("trd-datareader-enablebyteswapdata");
   binaryoptions[o2::trd::TRDFixSM1617Bit] = cfgc.options().get<bool>("fixsm1617");
+  binaryoptions[o2::trd::TRDIgnore2StageTrigger] = cfgc.options().get<bool>("fixforoldtrigger");
   //binaryoptions[o2::trd::TRDGenerateStats] = cfgc.options().get<bool>("generate-stats");
   binaryoptions[o2::trd::TRDGenerateStats] = true; //cfgc.options().get<bool>("generate-stats");
 

--- a/Detectors/TRD/reconstruction/src/DigitsParser.cxx
+++ b/Detectors/TRD/reconstruction/src/DigitsParser.cxx
@@ -180,7 +180,6 @@ int DigitsParser::Parse(bool verbose)
         }
         if (mDigitMCMHeader->mcm < lastmcmread && mDigitMCMHeader->rob == lastrobread) {
           incParsingError(TRDParsingDigitMCMNotIncreasing);
-          printDigitMCMHeader(*mDigitMCMHeader);
         }
         lastmcmread = mDigitMCMHeader->mcm;
         lastrobread = mDigitMCMHeader->rob;
@@ -207,7 +206,6 @@ int DigitsParser::Parse(bool verbose)
           if (!digitMCMADCMaskSanityCheck(*mDigitMCMADCMask, bitsinmask)) {
             incParsingError(TRDParsingDigitADCMaskMismatch);
             mWordsDumped += std::distance(word, mEndParse) - 1;
-            // tryFindMCMHeaderAndDisplay(word);
             word = mEndParse;
           }
           overchannelcount = 0;
@@ -374,29 +372,5 @@ int DigitsParser::Parse(bool verbose)
   return mDataWordsParsed;
 }
 
-void DigitsParser::tryFindMCMHeaderAndDisplay(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator word)
-{
-  // given something has gone wrong, assume its a 16 bit shift and see if we can find a valid mcmheader,
-  // note the mcm and rob and output to log
-  // merely for debugging to see if we can find a pattern in where the 16 bit shifts/losses occur.
-  // maybe more recoverly logic later.
-  uint32_t current = *word;
-  uint32_t next = *(std::next(word, 1));
-  uint32_t previous = *(std::prev(word, 1));
-  DigitMCMHeader firstguess; // 16 bits somewhere before the mcmheader got dropped, manifesting as directly before.
-  DigitMCMHeader secondguess;
-  DigitMCMHeader thirdguess;
-  //first  last 16 bits of previous and first 16 bits of current
-  uint32_t a = previous & 0xffff << 16;
-  uint32_t b = current & 0xffff;
-  firstguess.word = a + b;
-  if (digitMCMHeaderSanityCheck(&firstguess)) {
-    //sanity check passed to prossibly correct.
-    //LOG(warn) << "***DigitMCMHeader GUESS ??? to follow";
-    printDigitMCMHeader(firstguess);
-  } else {
-    // LOG(warn) << "***DigitMCMHeader GUESS failed " << std::hex << firstguess.word << " words were 0x" << previous << " 0x" << current << " 0x" << next;
-  }
-}
 
 } // namespace o2::trd


### PR DESCRIPTION
- option --fixforoldtrigger ignore the 2 step trigger for physics/calibration nodigit/digit data.
- remove a straggling text output for non sequential ROB, printing digit mcm header.