### PR TITLE
[EMCAL-729] Add compression of trigger bits

### DIFF
--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/TriggerRecord.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/TriggerRecord.h
@@ -43,6 +43,7 @@ class TriggerRecord
 
   void setBCData(const BCData& data) { mBCData = data; }
   void setTriggerBits(uint32_t triggerbits) { mTriggerBits = triggerbits; }
+  void setTriggerBitsCompressed(uint16_t triggerbits);
   void setDataRange(int firstentry, int nentries) { mDataRange.set(firstentry, nentries); }
   void setIndexFirstObject(int firstentry) { mDataRange.setFirstEntry(firstentry); }
   void setNumberOfObjects(int nentries) { mDataRange.setEntries(nentries); }
@@ -50,12 +51,19 @@ class TriggerRecord
   const BCData& getBCData() const { return mBCData; }
   BCData& getBCData() { return mBCData; }
   uint32_t getTriggerBits() const { return mTriggerBits; }
+  uint16_t getTriggerBitsCompressed() const;
   int getNumberOfObjects() const { return mDataRange.getEntries(); }
   int getFirstEntry() const { return mDataRange.getFirstEntry(); }
 
   void printStream(std::ostream& stream) const;
 
  private:
+  /// \enum TriggerBitsCoded_t
+  /// \brief Position of trigger classes in compressed format
+  enum TriggerBitsCoded_t {
+    PHYSTRIGGER, ///< Physics trigger
+    CALIBTRIGGER ///< Calib trigger
+  };
   BCData mBCData;        /// Bunch crossing data of the trigger
   DataRange mDataRange;  /// Index of the triggering event (event index and first entry in the container)
   uint32_t mTriggerBits; /// Trigger bits as from the Raw Data Header

--- a/DataFormats/Detectors/EMCAL/src/TriggerRecord.cxx
+++ b/DataFormats/Detectors/EMCAL/src/TriggerRecord.cxx
@@ -12,12 +12,36 @@
 #include <bitset>
 #include <iostream>
 #include "DataFormatsEMCAL/TriggerRecord.h"
+#include "CommonConstants/Triggers.h"
 
 namespace o2
 {
 
 namespace emcal
 {
+
+uint16_t TriggerRecord::getTriggerBitsCompressed() const
+{
+  uint16_t result(0);
+  if (mTriggerBits & o2::trigger::PhT) {
+    result |= 1 << TriggerBitsCoded_t::PHYSTRIGGER;
+  }
+  if (mTriggerBits & o2::trigger::Cal) {
+    result |= 1 << TriggerBitsCoded_t::CALIBTRIGGER;
+  }
+  return result;
+}
+
+void TriggerRecord::setTriggerBitsCompressed(uint16_t triggerbits)
+{
+  mTriggerBits = 0;
+  if (triggerbits & (1 << TriggerBitsCoded_t::PHYSTRIGGER)) {
+    mTriggerBits |= o2::trigger::PhT;
+  }
+  if (triggerbits & (1 << TriggerBitsCoded_t::CALIBTRIGGER)) {
+    mTriggerBits |= o2::trigger::Cal;
+  }
+}
 
 void TriggerRecord::printStream(std::ostream& stream) const
 {

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CTFCoder.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CTFCoder.h
@@ -141,6 +141,7 @@ void CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VCELL& cellVec)
   o2::InteractionRecord ir(header.firstBC, header.firstOrbit);
 
   Cell cell;
+  TriggerRecord trg;
   for (uint32_t itrig = 0; itrig < header.nTriggers; itrig++) {
     // restore TrigRecord
     if (orbitInc[itrig]) {  // non-0 increment => new orbit
@@ -156,8 +157,10 @@ void CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VCELL& cellVec)
       cellVec.emplace_back(cell);
       cellCount++;
     }
-    uint32_t trigBits = trigger[itrig];
-    trigVec.emplace_back(ir, trigBits, firstEntry, entries[itrig]);
+    trg.setBCData(ir);
+    trg.setDataRange(firstEntry, entries[itrig]);
+    trg.setTriggerBitsCompressed(trigger[itrig]);
+    trigVec.emplace_back(trg);
   }
   assert(cellCount == header.nCells);
 }

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CTFHelper.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CTFHelper.h
@@ -135,7 +135,7 @@ class CTFHelper
   {
    public:
     using _Iter<Iter_trigger, TriggerRecord, uint16_t>::_Iter;
-    value_type operator*() const { return uint16_t(mData[mIndex].getTriggerBits() & 0xffff); }
+    value_type operator*() const { return mData[mIndex].getTriggerBitsCompressed(); }
   };
 
   //_______________________________________________


### PR DESCRIPTION
Reduction from 32 bit to 16 bit filtering the most
relevant triggers for EMCAL. For the moment
3 triggers are propagated
- TF trigger
- Physics trigger
- Calib trigger
In case other triggers will be included in the
compressed output, they need to be appended.