### PR TITLE
DPL Analysis: event mixing: allow for creating empty combinations

### DIFF
--- a/Framework/Core/include/Framework/ASoAHelpers.h
+++ b/Framework/Core/include/Framework/ASoAHelpers.h
@@ -787,7 +787,7 @@ struct CombinationsBlockUpperSameIndexPolicy : public CombinationsBlockSameIndex
       setRanges();
     }
   }
-  CombinationsBlockUpperSameIndexPolicy(const std::string& categoryColumnName, int categoryNeighbours, const T1& outsider, T&& table, Ts&&... tables) : CombinationsBlockSameIndexPolicyBase<T1, T, Ts...>(categoryColumnName, categoryNeighbours, outsider, 1, std::forward<T>(table), std::forward<Ts>(tables)...)
+  CombinationsBlockUpperSameIndexPolicy(const std::string& categoryColumnName, int categoryNeighbours, const T1& outsider, Ts&&... tables) : CombinationsBlockSameIndexPolicyBase<T1, Ts...>(categoryColumnName, categoryNeighbours, outsider, 1, std::forward<Ts>(tables)...)
   {
     if (!this->mIsEnd) {
       setRanges();
@@ -879,7 +879,7 @@ struct CombinationsBlockStrictlyUpperSameIndexPolicy : public CombinationsBlockS
     }
   }
 
-  CombinationsBlockStrictlyUpperSameIndexPolicy(const std::string& categoryColumnName, int categoryNeighbours, const T1& outsider, T&& table, Ts&&... tables) : CombinationsBlockSameIndexPolicyBase<T1, T, Ts...>(categoryColumnName, categoryNeighbours, outsider, sizeof...(Ts) + 1, std::forward<T>(table), std::forward<Ts>(tables)...)
+  CombinationsBlockStrictlyUpperSameIndexPolicy(const std::string& categoryColumnName, int categoryNeighbours, const T1& outsider, Ts&&... tables) : CombinationsBlockSameIndexPolicyBase<T1, Ts...>(categoryColumnName, categoryNeighbours, outsider, sizeof...(Ts) + 1, std::forward<Ts>(tables)...)
   {
     if (!this->mIsEnd) {
       setRanges();
@@ -975,7 +975,7 @@ struct CombinationsBlockFullSameIndexPolicy : public CombinationsBlockSameIndexP
       setRanges();
     }
   }
-  CombinationsBlockFullSameIndexPolicy(const std::string& categoryColumnName, int categoryNeighbours, const T1& outsider, T&& table, Ts&&... tables) : CombinationsBlockSameIndexPolicyBase<T1, T, Ts...>(categoryColumnName, categoryNeighbours, outsider, 1, std::forward<T>(table), std::forward<Ts>(tables)...), mCurrentlyFixed(0)
+  CombinationsBlockFullSameIndexPolicy(const std::string& categoryColumnName, int categoryNeighbours, const T1& outsider, Ts&&... tables) : CombinationsBlockSameIndexPolicyBase<T1, Ts...>(categoryColumnName, categoryNeighbours, outsider, 1, std::forward<Ts>(tables)...), mCurrentlyFixed(0)
   {
     if (!this->mIsEnd) {
       setRanges();
@@ -1232,7 +1232,7 @@ auto combinations(const o2::framework::expressions::Filter& filter, const T2s&..
   if constexpr (isSameType<T2s...>()) {
     return CombinationsGenerator<CombinationsStrictlyUpperIndexPolicy<Filtered<T2s>...>>(CombinationsStrictlyUpperIndexPolicy(tables.select(filter)...));
   } else {
-    return CombinationsGenerator<CombinationsUpperIndexPolicy<Filtered<T2>, Filtered<T2s>...>>(CombinationsUpperIndexPolicy(table.select(filter), tables.select(filter)...));
+    return CombinationsGenerator<CombinationsUpperIndexPolicy<Filtered<T2s>...>>(CombinationsUpperIndexPolicy(tables.select(filter)...));
   }
 }
 

--- a/Framework/Core/include/Framework/ASoAHelpers.h
+++ b/Framework/Core/include/Framework/ASoAHelpers.h
@@ -202,26 +202,32 @@ struct CombinationsIndexPolicyBase {
   using CombinationType = std::tuple<typename Ts::iterator...>;
   using IndicesType = typename NTupleType<uint64_t, sizeof...(Ts)>::type;
 
-  template <typename... Tss>
-  CombinationsIndexPolicyBase(const Tss&... tables) : mIsEnd(false),
-                                                      mMaxOffset(tables.end().index...),
-                                                      mCurrent(tables.begin()...)
-
+  CombinationsIndexPolicyBase() : mIsEnd(true) {}
+  CombinationsIndexPolicyBase(const Ts&... tables) : mIsEnd(false),
+                                                     mMaxOffset(tables.end().index...),
+                                                     mCurrent(tables.begin()...)
   {
     if (((tables.size() == 0) || ...)) {
       this->mIsEnd = true;
     }
   }
-
   template <typename... Tss>
   CombinationsIndexPolicyBase(Tss&&... tables) : mTables(std::make_shared<std::tuple<Tss...>>(std::make_tuple(std::move(tables)...))),
                                                  mIsEnd(false)
-
   {
     std::apply([&](auto&&... x) mutable { mMaxOffset = IndicesType{x.end().index...}; mCurrent = CombinationType{x.begin()...}; }, *mTables);
-
     if (
       std::apply([](auto&&... x) -> bool { return ((x.size() == 0) || ...); }, *mTables)) {
+      this->mIsEnd = true;
+    }
+  }
+
+  void setTables(const Ts&... tables)
+  {
+    mIsEnd = false;
+    mMaxOffset = IndicesType(tables.end().index...);
+    mCurrent = CombinationType(tables.begin()...);
+    if (((tables.size() == 0) || ...)) {
       this->mIsEnd = true;
     }
   }
@@ -239,7 +245,6 @@ struct CombinationsIndexPolicyBase {
 
   std::shared_ptr<std::tuple<Ts...>> mTables;
   CombinationType mCurrent;
-
   IndicesType mMaxOffset; // one position past maximum acceptable position for each element of combination
   bool mIsEnd;            // whether there are any more tuples available
 };
@@ -254,6 +259,7 @@ template <typename... Ts>
 struct CombinationsUpperIndexPolicy : public CombinationsIndexPolicyBase<Ts...> {
   using CombinationType = typename CombinationsIndexPolicyBase<Ts...>::CombinationType;
 
+  CombinationsUpperIndexPolicy() : CombinationsIndexPolicyBase<Ts...>() {}
   CombinationsUpperIndexPolicy(const Ts&... tables) : CombinationsIndexPolicyBase<Ts...>(tables...) {}
   CombinationsUpperIndexPolicy(Ts&&... tables) : CombinationsIndexPolicyBase<Ts...>(std::forward<Ts>(tables)...) {}
 
@@ -287,10 +293,18 @@ template <typename... Ts>
 struct CombinationsStrictlyUpperIndexPolicy : public CombinationsIndexPolicyBase<Ts...> {
   using CombinationType = typename CombinationsIndexPolicyBase<Ts...>::CombinationType;
 
+  CombinationsStrictlyUpperIndexPolicy() : CombinationsIndexPolicyBase<Ts...>() {}
   CombinationsStrictlyUpperIndexPolicy(const Ts&... tables) : CombinationsIndexPolicyBase<Ts...>(tables...)
   {
+    if (!this->mIsEnd) {
+      setRanges(tables...);
+    }
+  }
+  CombinationsStrictlyUpperIndexPolicy(Ts&&... tables) : CombinationsIndexPolicyBase<Ts...>(std::forward<Ts>(tables)...)
+  {
     constexpr auto k = sizeof...(Ts);
-    if (((tables.size() < k) || ...)) {
+    if (
+      std::apply([](auto&&... x) -> bool { return ((x.size() < k) || ...); }, *this->mTables)) {
       this->mIsEnd = true;
       return;
     }
@@ -300,11 +314,16 @@ struct CombinationsStrictlyUpperIndexPolicy : public CombinationsIndexPolicyBase
     });
   }
 
-  CombinationsStrictlyUpperIndexPolicy(Ts&&... tables) : CombinationsIndexPolicyBase<Ts...>(std::forward<Ts>(tables)...)
+  void setTables(const Ts&... tables)
+  {
+    CombinationsIndexPolicyBase<Ts...>::setTables(tables...);
+    setRanges(tables...);
+  }
+
+  void setRanges(const Ts&... tables)
   {
     constexpr auto k = sizeof...(Ts);
-    if (
-      std::apply([](auto&&... x) -> bool { return ((x.size() < k) || ...); }, *this->mTables)) {
+    if (((tables.size() < k) || ...)) {
       this->mIsEnd = true;
       return;
     }
@@ -344,6 +363,7 @@ template <typename... Ts>
 struct CombinationsFullIndexPolicy : public CombinationsIndexPolicyBase<Ts...> {
   using CombinationType = typename CombinationsIndexPolicyBase<Ts...>::CombinationType;
 
+  CombinationsFullIndexPolicy() : CombinationsIndexPolicyBase<Ts...>() {}
   CombinationsFullIndexPolicy(const Ts&... tables) : CombinationsIndexPolicyBase<Ts...>(tables...) {}
   CombinationsFullIndexPolicy(Ts&&... tables) : CombinationsIndexPolicyBase<Ts...>(std::forward<Ts>(tables)...) {}
 
@@ -374,35 +394,13 @@ struct CombinationsBlockIndexPolicyBase : public CombinationsIndexPolicyBase<Ts.
   using CombinationType = typename CombinationsIndexPolicyBase<Ts...>::CombinationType;
   using IndicesType = typename NTupleType<uint64_t, sizeof...(Ts)>::type;
 
-  CombinationsBlockIndexPolicyBase(const std::string& categoryColumnName, int categoryNeighbours, const T& outsider, const Ts&... tables) : CombinationsIndexPolicyBase<Ts...>(tables...), mSlidingWindowSize(categoryNeighbours + 1)
+  CombinationsBlockIndexPolicyBase(const std::string& categoryColumnName, int categoryNeighbours, const T& outsider) : CombinationsIndexPolicyBase<Ts...>(), mSlidingWindowSize(categoryNeighbours + 1), mCategoryColumnName(categoryColumnName), mCategoryNeighbours(categoryNeighbours), mOutsider(outsider) {}
+  CombinationsBlockIndexPolicyBase(const std::string& categoryColumnName, int categoryNeighbours, const T& outsider, const Ts&... tables) : CombinationsIndexPolicyBase<Ts...>(tables...), mSlidingWindowSize(categoryNeighbours + 1), mCategoryColumnName(categoryColumnName), mCategoryNeighbours(categoryNeighbours), mOutsider(outsider)
   {
-    constexpr auto k = sizeof...(Ts);
-    if (this->mIsEnd) {
-      return;
+    if (!this->mIsEnd) {
+      setRanges(tables...);
     }
-    if (mSlidingWindowSize < 1) {
-      this->mIsEnd = true;
-      return;
-    }
-
-    int tableIndex = 0;
-    ((this->mGroupedIndices[tableIndex++] = groupTable(tables, categoryColumnName, 1, outsider)), ...);
-
-    // Synchronize categories across tables
-    syncCategories(this->mGroupedIndices);
-
-    for (int i = 0; i < k; i++) {
-      if (this->mGroupedIndices[i].size() == 0) {
-        this->mIsEnd = true;
-        return;
-      }
-    }
-
-    for_<k>([this](auto i) {
-      std::get<i.value>(this->mCurrentIndices) = 0;
-    });
   }
-
   CombinationsBlockIndexPolicyBase(const std::string& categoryColumnName, int categoryNeighbours, const T& outsider, Ts&&... tables) : CombinationsIndexPolicyBase<Ts...>(std::forward<Ts>(tables)...), mSlidingWindowSize(categoryNeighbours + 1)
   {
     constexpr auto k = sizeof...(Ts);
@@ -435,28 +433,69 @@ struct CombinationsBlockIndexPolicyBase : public CombinationsIndexPolicyBase<Ts.
     });
   }
 
+  void setTables(const Ts&... tables)
+  {
+    CombinationsIndexPolicyBase<Ts...>::setTables(tables...);
+    setRanges(tables...);
+  }
+
+  void setRanges(const Ts&... tables)
+  {
+    constexpr auto k = sizeof...(Ts);
+    if (mSlidingWindowSize < 1) {
+      this->mIsEnd = true;
+      return;
+    }
+
+    int tableIndex = 0;
+    ((this->mGroupedIndices[tableIndex++] = groupTable(tables, this->mCategoryColumnName, 1, this->mOutsider)), ...);
+
+    // Synchronize categories across tables
+    syncCategories(this->mGroupedIndices);
+
+    for (int i = 0; i < k; i++) {
+      if (this->mGroupedIndices[i].size() == 0) {
+        this->mIsEnd = true;
+        return;
+      }
+    }
+
+    for_<k>([this](auto i) {
+      std::get<i.value>(this->mCurrentIndices) = 0;
+    });
+  }
+
   std::array<std::vector<std::pair<uint64_t, uint64_t>>, sizeof...(Ts)> mGroupedIndices;
   IndicesType mCurrentIndices;
   IndicesType mBeginIndices;
   uint64_t mSlidingWindowSize;
+  const std::string mCategoryColumnName;
+  const int mCategoryNeighbours;
+  const T mOutsider;
 };
 
 template <typename T, typename... Ts>
 struct CombinationsBlockUpperIndexPolicy : public CombinationsBlockIndexPolicyBase<T, Ts...> {
   using CombinationType = typename CombinationsBlockIndexPolicyBase<T, Ts...>::CombinationType;
 
+  CombinationsBlockUpperIndexPolicy(const std::string& categoryColumnName, int categoryNeighbours, const T& outsider) : CombinationsBlockIndexPolicyBase<T, Ts...>(categoryColumnName, categoryNeighbours, outsider) {}
   CombinationsBlockUpperIndexPolicy(const std::string& categoryColumnName, int categoryNeighbours, const T& outsider, const Ts&... tables) : CombinationsBlockIndexPolicyBase<T, Ts...>(categoryColumnName, categoryNeighbours, outsider, tables...)
   {
     if (!this->mIsEnd) {
       setRanges();
     }
   }
-
   CombinationsBlockUpperIndexPolicy(const std::string& categoryColumnName, int categoryNeighbours, const T& outsider, Ts&&... tables) : CombinationsBlockIndexPolicyBase<T, Ts...>(categoryColumnName, categoryNeighbours, outsider, std::forward<Ts>(tables)...)
   {
     if (!this->mIsEnd) {
       setRanges();
     }
+  }
+
+  void setTables(const Ts&... tables)
+  {
+    CombinationsBlockIndexPolicyBase<T, Ts...>::setTables(tables...);
+    setRanges();
   }
 
   void setRanges()
@@ -547,18 +586,24 @@ struct CombinationsBlockFullIndexPolicy : public CombinationsBlockIndexPolicyBas
   using CombinationType = typename CombinationsBlockIndexPolicyBase<T, Ts...>::CombinationType;
   using IndicesType = typename NTupleType<uint64_t, sizeof...(Ts)>::type;
 
+  CombinationsBlockFullIndexPolicy(const std::string& categoryColumnName, int categoryNeighbours, const T& outsider) : CombinationsBlockIndexPolicyBase<T, Ts...>(categoryColumnName, categoryNeighbours, outsider), mCurrentlyFixed(0) {}
   CombinationsBlockFullIndexPolicy(const std::string& categoryColumnName, int categoryNeighbours, const T& outsider, const Ts&... tables) : CombinationsBlockIndexPolicyBase<T, Ts...>(categoryColumnName, categoryNeighbours, outsider, tables...), mCurrentlyFixed(0)
   {
     if (!this->mIsEnd) {
       setRanges();
     }
   }
-
   CombinationsBlockFullIndexPolicy(const std::string& categoryColumnName, int categoryNeighbours, const T& outsider, Ts&&... tables) : CombinationsBlockIndexPolicyBase<T, Ts...>(categoryColumnName, categoryNeighbours, outsider, std::forward<Ts>(tables)...), mCurrentlyFixed(0)
   {
     if (!this->mIsEnd) {
       setRanges();
     }
+  }
+
+  void setTables(const Ts&... tables)
+  {
+    CombinationsBlockIndexPolicyBase<T, Ts...>::setTables(tables...);
+    setRanges();
   }
 
   void setRanges()
@@ -668,25 +713,13 @@ struct CombinationsBlockSameIndexPolicyBase : public CombinationsIndexPolicyBase
   using CombinationType = typename CombinationsIndexPolicyBase<T, Ts...>::CombinationType;
   using IndicesType = typename NTupleType<uint64_t, sizeof...(Ts) + 1>::type;
 
-  CombinationsBlockSameIndexPolicyBase(const std::string& categoryColumnName, int categoryNeighbours, const T1& outsider, int minWindowSize, const T& table, const Ts&... tables) : CombinationsIndexPolicyBase<T, Ts...>(table, tables...), mSlidingWindowSize(categoryNeighbours + 1)
+  CombinationsBlockSameIndexPolicyBase(const std::string& categoryColumnName, int categoryNeighbours, const T1& outsider, int minWindowSize) : CombinationsIndexPolicyBase<T, Ts...>(), mSlidingWindowSize(categoryNeighbours + 1), mCategoryColumnName(categoryColumnName), mCategoryNeighbours(categoryNeighbours), mOutsider(outsider), mMinWindowSize(minWindowSize) {}
+  CombinationsBlockSameIndexPolicyBase(const std::string& categoryColumnName, int categoryNeighbours, const T1& outsider, int minWindowSize, const T& table, const Ts&... tables) : CombinationsIndexPolicyBase<T, Ts...>(table, tables...), mSlidingWindowSize(categoryNeighbours + 1), mCategoryColumnName(categoryColumnName), mCategoryNeighbours(categoryNeighbours), mOutsider(outsider), mMinWindowSize(minWindowSize)
   {
-    constexpr auto k = sizeof...(Ts) + 1;
-    // minWindowSize == 1 for upper and full, and k for strictly upper k-combination
-    if (mSlidingWindowSize < minWindowSize) {
-      this->mIsEnd = true;
-      return;
+    if (!this->mIsEnd) {
+      setRanges(table);
     }
-
-    this->mGroupedIndices = groupTable(table, categoryColumnName, minWindowSize, outsider);
-
-    if (this->mGroupedIndices.size() == 0) {
-      this->mIsEnd = true;
-      return;
-    }
-
-    std::get<0>(this->mCurrentIndices) = 0;
   }
-
   CombinationsBlockSameIndexPolicyBase(const std::string& categoryColumnName, int categoryNeighbours, const T1& outsider, int minWindowSize, T&& table, Ts&&... tables) : CombinationsIndexPolicyBase<T, Ts...>(std::forward<T>(table), std::forward<Ts>(tables)...), mSlidingWindowSize(categoryNeighbours + 1)
   {
     constexpr auto k = sizeof...(Ts) + 1;
@@ -706,22 +739,53 @@ struct CombinationsBlockSameIndexPolicyBase : public CombinationsIndexPolicyBase
     std::get<0>(this->mCurrentIndices) = 0;
   }
 
+  void setTables(const T& table, const Ts&... tables)
+  {
+    CombinationsIndexPolicyBase<T, Ts...>::setTables(table, tables...);
+    if (!this->mIsEnd) {
+      setRanges(table);
+    }
+  }
+
+  void setRanges(const T& table)
+  {
+    constexpr auto k = sizeof...(Ts) + 1;
+    // minWindowSize == 1 for upper and full, and k for strictly upper k-combination
+    if (mSlidingWindowSize < mMinWindowSize) {
+      this->mIsEnd = true;
+      return;
+    }
+
+    this->mGroupedIndices = groupTable(table, mCategoryColumnName, mMinWindowSize, mOutsider);
+
+    if (this->mGroupedIndices.size() == 0) {
+      this->mIsEnd = true;
+      return;
+    }
+
+    std::get<0>(this->mCurrentIndices) = 0;
+  }
+
   std::vector<std::pair<uint64_t, uint64_t>> mGroupedIndices;
   IndicesType mCurrentIndices;
-  uint64_t mSlidingWindowSize;
+  const uint64_t mSlidingWindowSize;
+  const int mMinWindowSize;
+  const std::string mCategoryColumnName;
+  const int mCategoryNeighbours;
+  const T1 mOutsider;
 };
 
-template <typename T1, typename T, typename... Ts>
-struct CombinationsBlockUpperSameIndexPolicy : public CombinationsBlockSameIndexPolicyBase<T1, T, Ts...> {
-  using CombinationType = typename CombinationsBlockSameIndexPolicyBase<T1, T, Ts...>::CombinationType;
+template <typename T1, typename... Ts>
+struct CombinationsBlockUpperSameIndexPolicy : public CombinationsBlockSameIndexPolicyBase<T1, Ts...> {
+  using CombinationType = typename CombinationsBlockSameIndexPolicyBase<T1, Ts...>::CombinationType;
 
-  CombinationsBlockUpperSameIndexPolicy(const std::string& categoryColumnName, int categoryNeighbours, const T1& outsider, const T& table, const Ts&... tables) : CombinationsBlockSameIndexPolicyBase<T1, T, Ts...>(categoryColumnName, categoryNeighbours, outsider, 1, table, tables...)
+  CombinationsBlockUpperSameIndexPolicy(const std::string& categoryColumnName, int categoryNeighbours, const T1& outsider) : CombinationsBlockSameIndexPolicyBase<T1, Ts...>(categoryColumnName, categoryNeighbours, outsider, 1) {}
+  CombinationsBlockUpperSameIndexPolicy(const std::string& categoryColumnName, int categoryNeighbours, const T1& outsider, const Ts&... tables) : CombinationsBlockSameIndexPolicyBase<T1, Ts...>(categoryColumnName, categoryNeighbours, outsider, 1, tables...)
   {
     if (!this->mIsEnd) {
       setRanges();
     }
   }
-
   CombinationsBlockUpperSameIndexPolicy(const std::string& categoryColumnName, int categoryNeighbours, const T1& outsider, T&& table, Ts&&... tables) : CombinationsBlockSameIndexPolicyBase<T1, T, Ts...>(categoryColumnName, categoryNeighbours, outsider, 1, std::forward<T>(table), std::forward<Ts>(tables)...)
   {
     if (!this->mIsEnd) {
@@ -729,9 +793,15 @@ struct CombinationsBlockUpperSameIndexPolicy : public CombinationsBlockSameIndex
     }
   }
 
+  void setTables(const Ts&... tables)
+  {
+    CombinationsBlockSameIndexPolicyBase<T1, Ts...>::setTables(tables...);
+    setRanges();
+  }
+
   void setRanges()
   {
-    constexpr auto k = sizeof...(Ts) + 1;
+    constexpr auto k = sizeof...(Ts);
     auto catBegin = this->mGroupedIndices.begin() + std::get<0>(this->mCurrentIndices);
     auto range = std::equal_range(catBegin, this->mGroupedIndices.end(), *catBegin, sameCategory);
     uint64_t offset = std::distance(this->mGroupedIndices.begin(), range.second);
@@ -745,7 +815,7 @@ struct CombinationsBlockUpperSameIndexPolicy : public CombinationsBlockSameIndex
 
   void addOne()
   {
-    constexpr auto k = sizeof...(Ts) + 1;
+    constexpr auto k = sizeof...(Ts);
     bool modify = true;
     for_<k - 1>([&, this](auto i) {
       if (modify) {
@@ -796,11 +866,12 @@ struct CombinationsBlockUpperSameIndexPolicy : public CombinationsBlockSameIndex
   }
 };
 
-template <typename T1, typename T, typename... Ts>
-struct CombinationsBlockStrictlyUpperSameIndexPolicy : public CombinationsBlockSameIndexPolicyBase<T1, T, Ts...> {
-  using CombinationType = typename CombinationsBlockSameIndexPolicyBase<T1, T, Ts...>::CombinationType;
+template <typename T1, typename... Ts>
+struct CombinationsBlockStrictlyUpperSameIndexPolicy : public CombinationsBlockSameIndexPolicyBase<T1, Ts...> {
+  using CombinationType = typename CombinationsBlockSameIndexPolicyBase<T1, Ts...>::CombinationType;
 
-  CombinationsBlockStrictlyUpperSameIndexPolicy(const std::string& categoryColumnName, int categoryNeighbours, const T1& outsider, const T& table, const Ts&... tables) : CombinationsBlockSameIndexPolicyBase<T1, T, Ts...>(categoryColumnName, categoryNeighbours, outsider, sizeof...(Ts) + 1, table, tables...)
+  CombinationsBlockStrictlyUpperSameIndexPolicy(const std::string& categoryColumnName, int categoryNeighbours, const T1& outsider) : CombinationsBlockSameIndexPolicyBase<T1, Ts...>(categoryColumnName, categoryNeighbours, outsider, sizeof...(Ts)) {}
+  CombinationsBlockStrictlyUpperSameIndexPolicy(const std::string& categoryColumnName, int categoryNeighbours, const T1& outsider, const Ts&... tables) : CombinationsBlockSameIndexPolicyBase<T1, Ts...>(categoryColumnName, categoryNeighbours, outsider, sizeof...(Ts), tables...)
   {
     if (!this->mIsEnd) {
       setRanges();
@@ -814,9 +885,17 @@ struct CombinationsBlockStrictlyUpperSameIndexPolicy : public CombinationsBlockS
     }
   }
 
+  void setTables(const Ts&... tables)
+  {
+    CombinationsBlockSameIndexPolicyBase<T1, Ts...>::setTables(tables...);
+    if (!this->mIsEnd) {
+      setRanges();
+    }
+  }
+
   void setRanges()
   {
-    constexpr auto k = sizeof...(Ts) + 1;
+    constexpr auto k = sizeof...(Ts);
     auto catBegin = this->mGroupedIndices.begin() + std::get<0>(this->mCurrentIndices);
     auto lastIt = std::upper_bound(catBegin, this->mGroupedIndices.end(), *catBegin, sameCategory);
     uint64_t lastOffset = std::distance(this->mGroupedIndices.begin(), lastIt);
@@ -830,7 +909,7 @@ struct CombinationsBlockStrictlyUpperSameIndexPolicy : public CombinationsBlockS
 
   void addOne()
   {
-    constexpr auto k = sizeof...(Ts) + 1;
+    constexpr auto k = sizeof...(Ts);
     bool modify = true;
     for_<k - 1>([&, this](auto i) {
       if (modify) {
@@ -884,17 +963,17 @@ struct CombinationsBlockStrictlyUpperSameIndexPolicy : public CombinationsBlockS
   }
 };
 
-template <typename T1, typename T, typename... Ts>
-struct CombinationsBlockFullSameIndexPolicy : public CombinationsBlockSameIndexPolicyBase<T1, T, Ts...> {
-  using CombinationType = typename CombinationsBlockSameIndexPolicyBase<T1, T, Ts...>::CombinationType;
+template <typename T1, typename... Ts>
+struct CombinationsBlockFullSameIndexPolicy : public CombinationsBlockSameIndexPolicyBase<T1, Ts...> {
+  using CombinationType = typename CombinationsBlockSameIndexPolicyBase<T1, Ts...>::CombinationType;
 
-  CombinationsBlockFullSameIndexPolicy(const std::string& categoryColumnName, int categoryNeighbours, const T1& outsider, const T& table, const Ts&... tables) : CombinationsBlockSameIndexPolicyBase<T1, T, Ts...>(categoryColumnName, categoryNeighbours, outsider, 1, table, tables...), mCurrentlyFixed(0)
+  CombinationsBlockFullSameIndexPolicy(const std::string& categoryColumnName, int categoryNeighbours, const T1& outsider) : CombinationsBlockSameIndexPolicyBase<T1, Ts...>(categoryColumnName, categoryNeighbours, outsider, 1), mCurrentlyFixed(0) {}
+  CombinationsBlockFullSameIndexPolicy(const std::string& categoryColumnName, int categoryNeighbours, const T1& outsider, const Ts&... tables) : CombinationsBlockSameIndexPolicyBase<T1, Ts...>(categoryColumnName, categoryNeighbours, outsider, 1, tables...), mCurrentlyFixed(0)
   {
     if (!this->mIsEnd) {
       setRanges();
     }
   }
-
   CombinationsBlockFullSameIndexPolicy(const std::string& categoryColumnName, int categoryNeighbours, const T1& outsider, T&& table, Ts&&... tables) : CombinationsBlockSameIndexPolicyBase<T1, T, Ts...>(categoryColumnName, categoryNeighbours, outsider, 1, std::forward<T>(table), std::forward<Ts>(tables)...), mCurrentlyFixed(0)
   {
     if (!this->mIsEnd) {
@@ -902,9 +981,15 @@ struct CombinationsBlockFullSameIndexPolicy : public CombinationsBlockSameIndexP
     }
   }
 
+  void setTables(const Ts&... tables)
+  {
+    CombinationsBlockSameIndexPolicyBase<T1, Ts...>::setTables(tables...);
+    setRanges();
+  }
+
   void setRanges()
   {
-    constexpr auto k = sizeof...(Ts) + 1;
+    constexpr auto k = sizeof...(Ts);
     auto catBegin = this->mGroupedIndices.begin() + std::get<0>(this->mCurrentIndices);
     auto range = std::equal_range(catBegin, this->mGroupedIndices.end(), *catBegin, sameCategory);
     this->mBeginIndex = std::get<0>(this->mCurrentIndices);
@@ -919,7 +1004,7 @@ struct CombinationsBlockFullSameIndexPolicy : public CombinationsBlockSameIndexP
 
   void addOne()
   {
-    constexpr auto k = sizeof...(Ts) + 1;
+    constexpr auto k = sizeof...(Ts);
     bool modify = true;
     for_<k>([&, this](auto i) {
       if (modify) {
@@ -1083,53 +1168,101 @@ struct CombinationsGenerator {
   iterator mEnd;
 };
 
-template <typename T1, typename T2, typename... T2s>
-auto selfCombinations(const char* categoryColumnName, int categoryNeighbours, const T1& outsider, const T2& table, const T2s&... tables)
+template <typename T2, typename... T2s>
+constexpr bool isSameType()
 {
-  static_assert(std::conjunction_v<std::is_same<T2, T2s>...>, "Tables must have the same type for self combinations");
-  return CombinationsGenerator<CombinationsBlockStrictlyUpperSameIndexPolicy<T1, T2, T2s...>>(CombinationsBlockStrictlyUpperSameIndexPolicy(categoryColumnName, categoryNeighbours, outsider, table, tables...));
+  return std::conjunction_v<std::is_same<T2, T2s>...>;
+}
+
+template <typename T1, typename... T2s>
+auto selfCombinations(const char* categoryColumnName, int categoryNeighbours, const T1& outsider, const T2s&... tables)
+{
+  static_assert(isSameType<T2s...>(), "Tables must have the same type for self combinations");
+  return CombinationsGenerator<CombinationsBlockStrictlyUpperSameIndexPolicy<T1, T2s...>>(CombinationsBlockStrictlyUpperSameIndexPolicy<T1, T2s...>(categoryColumnName, categoryNeighbours, outsider, tables...));
+}
+
+template <typename T1, typename T2>
+auto selfPairCombinations(const char* categoryColumnName, int categoryNeighbours, const T1& outsider)
+{
+  return CombinationsGenerator<CombinationsBlockStrictlyUpperSameIndexPolicy<T1, T2, T2>>(CombinationsBlockStrictlyUpperSameIndexPolicy<T1, T2, T2>(categoryColumnName, categoryNeighbours, outsider));
 }
 
 template <typename T1, typename T2>
 auto selfPairCombinations(const char* categoryColumnName, int categoryNeighbours, const T1& outsider, const T2& table)
 {
-  return CombinationsGenerator<CombinationsBlockStrictlyUpperSameIndexPolicy<T1, T2, T2>>(CombinationsBlockStrictlyUpperSameIndexPolicy(categoryColumnName, categoryNeighbours, outsider, table, table));
+  return CombinationsGenerator<CombinationsBlockStrictlyUpperSameIndexPolicy<T1, T2, T2>>(CombinationsBlockStrictlyUpperSameIndexPolicy<T1, T2, T2>(categoryColumnName, categoryNeighbours, outsider, table, table));
+}
+
+template <typename T1, typename T2>
+auto selfTripleCombinations(const char* categoryColumnName, int categoryNeighbours, const T1& outsider)
+{
+  return CombinationsGenerator<CombinationsBlockStrictlyUpperSameIndexPolicy<T1, T2, T2, T2>>(CombinationsBlockStrictlyUpperSameIndexPolicy<T1, T2, T2, T2>(categoryColumnName, categoryNeighbours, outsider));
 }
 
 template <typename T1, typename T2>
 auto selfTripleCombinations(const char* categoryColumnName, int categoryNeighbours, const T1& outsider, const T2& table)
 {
-  return CombinationsGenerator<CombinationsBlockStrictlyUpperSameIndexPolicy<T1, T2, T2, T2>>(CombinationsBlockStrictlyUpperSameIndexPolicy(categoryColumnName, categoryNeighbours, outsider, table, table, table));
+  return CombinationsGenerator<CombinationsBlockStrictlyUpperSameIndexPolicy<T1, T2, T2, T2>>(CombinationsBlockStrictlyUpperSameIndexPolicy<T1, T2, T2, T2>(categoryColumnName, categoryNeighbours, outsider, table, table, table));
 }
 
-template <typename T1, typename T2, typename... T2s>
-auto combinations(const char* categoryColumnName, int categoryNeighbours, const T1& outsider, const T2& table, const T2s&... tables)
+template <typename T1, typename... T2s>
+auto combinations(const char* categoryColumnName, int categoryNeighbours, const T1& outsider, const T2s&... tables)
 {
-  if constexpr (std::conjunction_v<std::is_same<T2, T2s>...>) {
-    return CombinationsGenerator<CombinationsBlockStrictlyUpperSameIndexPolicy<T1, T2, T2s...>>(CombinationsBlockStrictlyUpperSameIndexPolicy(categoryColumnName, categoryNeighbours, outsider, table, tables...));
+  if constexpr (isSameType<T2s...>()) {
+    return CombinationsGenerator<CombinationsBlockStrictlyUpperSameIndexPolicy<T1, T2s...>>(CombinationsBlockStrictlyUpperSameIndexPolicy<T1, T2s...>(categoryColumnName, categoryNeighbours, outsider, tables...));
   } else {
-    return CombinationsGenerator<CombinationsBlockUpperIndexPolicy<T1, T2, T2s...>>(CombinationsBlockUpperIndexPolicy(categoryColumnName, categoryNeighbours, outsider, table, tables...));
+    return CombinationsGenerator<CombinationsBlockUpperIndexPolicy<T1, T2s...>>(CombinationsBlockUpperIndexPolicy<T1, T2s...>(categoryColumnName, categoryNeighbours, outsider, tables...));
   }
 }
 
-template <typename T1, typename T2, typename... T2s>
-auto combinations(const char* categoryColumnName, int categoryNeighbours, const T1& outsider, const o2::framework::expressions::Filter& filter, const T2& table, const T2s&... tables)
+template <typename T1, typename... T2s>
+auto combinations(const char* categoryColumnName, int categoryNeighbours, const T1& outsider, const o2::framework::expressions::Filter& filter, const T2s&... tables)
 {
-  if constexpr (std::conjunction_v<std::is_same<T2, T2s>...>) {
-    return CombinationsGenerator<CombinationsBlockStrictlyUpperSameIndexPolicy<T1, Filtered<T2>, Filtered<T2s>...>>(CombinationsBlockStrictlyUpperSameIndexPolicy(categoryColumnName, categoryNeighbours, outsider, table.select(filter), tables.select(filter)...));
+  if constexpr (isSameType<T2s...>()) {
+    return CombinationsGenerator<CombinationsBlockStrictlyUpperSameIndexPolicy<T1, Filtered<T2s>...>>(CombinationsBlockStrictlyUpperSameIndexPolicy(categoryColumnName, categoryNeighbours, outsider, tables.select(filter)...));
   } else {
-    return CombinationsGenerator<CombinationsBlockUpperIndexPolicy<T1, Filtered<T2>, Filtered<T2s>...>>(CombinationsBlockUpperIndexPolicy(categoryColumnName, categoryNeighbours, outsider, table.select(filter), tables.select(filter)...));
+    return CombinationsGenerator<CombinationsBlockUpperIndexPolicy<T1, Filtered<T2s>...>>(CombinationsBlockUpperIndexPolicy(categoryColumnName, categoryNeighbours, outsider, tables.select(filter)...));
   }
 }
 
-template <typename T2, typename... T2s>
-auto combinations(const T2& table, const T2s&... tables)
+template <typename... T2s>
+auto combinations(const o2::framework::expressions::Filter& filter, const T2s&... tables)
 {
-  if constexpr (std::conjunction_v<std::is_same<T2, T2s>...>) {
-    return CombinationsGenerator<CombinationsStrictlyUpperIndexPolicy<T2, T2s...>>(CombinationsStrictlyUpperIndexPolicy(table, tables...));
+  if constexpr (isSameType<T2s...>()) {
+    return CombinationsGenerator<CombinationsStrictlyUpperIndexPolicy<Filtered<T2s>...>>(CombinationsStrictlyUpperIndexPolicy(tables.select(filter)...));
   } else {
-    return CombinationsGenerator<CombinationsUpperIndexPolicy<T2, T2s...>>(CombinationsUpperIndexPolicy(table, tables...));
+    return CombinationsGenerator<CombinationsUpperIndexPolicy<Filtered<T2>, Filtered<T2s>...>>(CombinationsUpperIndexPolicy(table.select(filter), tables.select(filter)...));
   }
+}
+
+// This shortened version cannot be used for Filtered
+// (unless users create filtered tables themselves before policy creation)
+template <template <typename...> typename P2, typename... T2s>
+CombinationsGenerator<P2<T2s...>> combinations(const P2<T2s...>& policy)
+{
+  return CombinationsGenerator<P2<T2s...>>(policy);
+}
+
+template <template <typename...> typename P2, typename... T2s>
+CombinationsGenerator<P2<Filtered<T2s>...>> combinations(P2<T2s...>&&, const o2::framework::expressions::Filter& filter, const T2s&... tables)
+{
+  return CombinationsGenerator<P2<Filtered<T2s>...>>(P2<Filtered<T2s>...>(tables.select(filter)...));
+}
+
+template <typename... T2s>
+auto combinations(const T2s&... tables)
+{
+  if constexpr (isSameType<T2s...>()) {
+    return CombinationsGenerator<CombinationsStrictlyUpperIndexPolicy<T2s...>>(CombinationsStrictlyUpperIndexPolicy<T2s...>(tables...));
+  } else {
+    return CombinationsGenerator<CombinationsUpperIndexPolicy<T2s...>>(CombinationsUpperIndexPolicy<T2s...>(tables...));
+  }
+}
+
+template <typename T2>
+auto pairCombinations()
+{
+  return CombinationsGenerator<CombinationsStrictlyUpperIndexPolicy<T2, T2>>(CombinationsStrictlyUpperIndexPolicy<T2, T2>());
 }
 
 template <typename T2>
@@ -1139,33 +1272,15 @@ auto pairCombinations(const T2& table)
 }
 
 template <typename T2>
+auto tripleCombinations()
+{
+  return CombinationsGenerator<CombinationsStrictlyUpperIndexPolicy<T2, T2, T2>>(CombinationsStrictlyUpperIndexPolicy<T2, T2, T2>());
+}
+
+template <typename T2>
 auto tripleCombinations(const T2& table)
 {
   return CombinationsGenerator<CombinationsStrictlyUpperIndexPolicy<T2, T2, T2>>(CombinationsStrictlyUpperIndexPolicy(table, table, table));
-}
-
-template <typename T2, typename... T2s>
-auto combinations(const o2::framework::expressions::Filter& filter, const T2& table, const T2s&... tables)
-{
-  if constexpr (std::conjunction_v<std::is_same<T2, T2s>...>) {
-    return CombinationsGenerator<CombinationsStrictlyUpperIndexPolicy<Filtered<T2>, Filtered<T2s>...>>(CombinationsStrictlyUpperIndexPolicy(table.select(filter), tables.select(filter)...));
-  } else {
-    return CombinationsGenerator<CombinationsUpperIndexPolicy<Filtered<T2>, Filtered<T2s>...>>(CombinationsUpperIndexPolicy(table.select(filter), tables.select(filter)...));
-  }
-}
-
-template <template <typename...> typename P2, typename... T2s>
-CombinationsGenerator<P2<Filtered<T2s>...>> combinations(P2<T2s...>&&, const o2::framework::expressions::Filter& filter, const T2s&... tables)
-{
-  return CombinationsGenerator<P2<Filtered<T2s>...>>(P2<Filtered<T2s>...>(tables.select(filter)...));
-}
-
-// This shortened version cannot be used for Filtered
-// (unless users create filtered tables themselves before policy creation)
-template <template <typename...> typename P2, typename... T2s>
-CombinationsGenerator<P2<T2s...>> combinations(const P2<T2s...>& policy)
-{
-  return CombinationsGenerator<P2<T2s...>>(policy);
 }
 
 } // namespace o2::soa

--- a/Framework/Core/include/Framework/ASoAHelpers.h
+++ b/Framework/Core/include/Framework/ASoAHelpers.h
@@ -203,9 +203,10 @@ struct CombinationsIndexPolicyBase {
   using IndicesType = typename NTupleType<uint64_t, sizeof...(Ts)>::type;
 
   CombinationsIndexPolicyBase() : mIsEnd(true) {}
-  CombinationsIndexPolicyBase(const Ts&... tables) : mIsEnd(false),
-                                                     mMaxOffset(tables.end().index...),
-                                                     mCurrent(tables.begin()...)
+  template <typename... Tss>
+  CombinationsIndexPolicyBase(const Tss&... tables) : mIsEnd(false),
+                                                      mMaxOffset(tables.end().index...),
+                                                      mCurrent(tables.begin()...)
   {
     if (((tables.size() == 0) || ...)) {
       this->mIsEnd = true;

--- a/Framework/Core/test/test_ASoAHelpers.cxx
+++ b/Framework/Core/test/test_ASoAHelpers.cxx
@@ -224,7 +224,7 @@ BOOST_AUTO_TEST_CASE(CombinationsGeneratorConstruction)
   BOOST_REQUIRE_EQUAL(*(static_cast<test::X>(std::get<1>(*(combItFiltered))).getIterator().mCurrentPos), 5);
   BOOST_REQUIRE_EQUAL(static_cast<test::X>(std::get<1>(*(combItFiltered))).getIterator().mCurrentChunk, 0);
 
-  auto comb2Filter = combinations(CombinationsStrictlyUpperIndexPolicy(testsA, testsA), filter, testsA, testsA);
+  auto comb2Filter = combinations(CombinationsStrictlyUpperIndexPolicy<TestA, TestA>(), filter, testsA, testsA);
 
   static_assert(std::is_same_v<decltype(comb2Filter.begin()), CombinationsGenerator<CombinationsStrictlyUpperIndexPolicy<Filtered<TestA>, Filtered<TestA>>>::CombinationsIterator>, "Wrong iterator type");
   static_assert(std::is_same_v<decltype(*(comb2Filter.begin())), CombinationsStrictlyUpperIndexPolicy<Filtered<TestA>, Filtered<TestA>>::CombinationType&>, "Wrong combination type");
@@ -432,7 +432,7 @@ BOOST_AUTO_TEST_CASE(Combinations)
   count = 0;
   i = 4;
   j = 5;
-  for (auto& [t0, t1] : combinations(CombinationsStrictlyUpperIndexPolicy(testsA, testsA), pairsFilter, testsA, testsA)) {
+  for (auto& [t0, t1] : combinations(CombinationsStrictlyUpperIndexPolicy<TestA, TestA>(), pairsFilter, testsA, testsA)) {
     BOOST_CHECK_EQUAL(t0.x(), i);
     BOOST_CHECK_EQUAL(t1.x(), j);
     count++;

--- a/Framework/Core/test/test_ASoAHelpers.cxx
+++ b/Framework/Core/test/test_ASoAHelpers.cxx
@@ -1350,3 +1350,32 @@ BOOST_AUTO_TEST_CASE(CombinationsHelpers)
   }
   BOOST_CHECK_EQUAL(count, expectedStrictlyUpperTriples.size());
 }
+
+BOOST_AUTO_TEST_CASE(ConstructorsWithoutTables)
+{
+  using TestA = o2::soa::Table<o2::soa::Index<>, test::X, test::Y>;
+
+  int count = 0;
+  for (auto& [t0, t1] : pairCombinations<TestA>()) {
+    count++;
+  }
+  BOOST_CHECK_EQUAL(count, 0);
+
+  count = 0;
+  for (auto& [t0, t1, t2] : tripleCombinations<TestA>()) {
+    count++;
+  }
+  BOOST_CHECK_EQUAL(count, 0);
+
+  count = 0;
+  for (auto& [c0, c1] : selfPairCombinations<TestA>("y", 2, -1)) {
+    count++;
+  }
+  BOOST_CHECK_EQUAL(count, 0);
+
+  count = 0;
+  for (auto& [c0, c1, c2] : selfTripleCombinations<TestA>("y", 2, -1)) {
+    count++;
+  }
+  BOOST_CHECK_EQUAL(count, 0);
+}

--- a/Framework/Core/test/test_ASoAHelpers.cxx
+++ b/Framework/Core/test/test_ASoAHelpers.cxx
@@ -1368,13 +1368,13 @@ BOOST_AUTO_TEST_CASE(ConstructorsWithoutTables)
   BOOST_CHECK_EQUAL(count, 0);
 
   count = 0;
-  for (auto& [c0, c1] : selfPairCombinations<TestA>("y", 2, -1)) {
+  for (auto& [c0, c1] : selfPairCombinations<int, TestA>("y", 2, -1)) {
     count++;
   }
   BOOST_CHECK_EQUAL(count, 0);
 
   count = 0;
-  for (auto& [c0, c1, c2] : selfTripleCombinations<TestA>("y", 2, -1)) {
+  for (auto& [c0, c1, c2] : selfTripleCombinations<int, TestA>("y", 2, -1)) {
     count++;
   }
   BOOST_CHECK_EQUAL(count, 0);


### PR DESCRIPTION
First prerequisite for event mixing - allowing empty combinations, so they can be defined outside `process()`.
Simplified some template parameters.

