### PR TITLE
RecoContainer: Better support for MFTMCH and MFTMCHMID tracks

### DIFF
--- a/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
+++ b/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
@@ -1134,6 +1134,13 @@ RecoContainer::GlobalIDSet RecoContainer::getSingleDetectorRefs(GTrackID gidx) c
     const auto& parent0 = getTPCITSTrack(gidx);
     table[GTrackID::TPC] = parent0.getRefTPC();
     table[parent0.getRefITS().getSource()] = parent0.getRefITS(); // ITS source might be an ITS track or ITSAB tracklet
+  } else if (src == GTrackID::MFTMCH || src == GTrackID::MFTMCHMID) {
+    const auto& parent0 = getGlobalFwdTrack(gidx);
+    table[GTrackID::MFT] = parent0.getMFTTrackID();
+    table[GTrackID::MCH] = parent0.getMCHTrackID();
+    if (parent0.getMIDTrackID() != -1) {
+      table[GTrackID::MID] = parent0.getMIDTrackID();
+    }
   }
   return std::move(table);
 }

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/MatchInfoFwd.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/MatchInfoFwd.h
@@ -56,6 +56,8 @@ class MatchInfoFwd
   const auto& getMCHTrackID() const { return mMCHTrackID; }
   void setMFTTrackID(int ID) { mMFTTrackID = ID; }
   const auto& getMFTTrackID() const { return mMFTTrackID; }
+  void setMIDTrackID(int ID) { mMIDTrackID = ID; }
+  const auto& getMIDTrackID() const { return mMIDTrackID; }
 
   const timeEst& getTimeMUS() const { return mTimeMUS; }
   timeEst& getTimeMUS() { return mTimeMUS; }
@@ -71,6 +73,7 @@ class MatchInfoFwd
   float mMCHMIDMatchingChi2 = -1.0;                         ///< MCH-MID Matching Chi2
   int mMFTTrackID = -1;                                     ///< Track ID of best MFT-match
   int mMCHTrackID = -1;                                     ///< MCH Track ID
+  int mMIDTrackID = -1;                                     ///< MID Track ID
   int mNMFTCandidates = 0;                                  ///< Number of MFT candidates within search cut
   bool mCloseMatch = false;                                 ///< Close match = correct MFT pair tested (MC-only)
   timeEst mTimeMUS;                                         ///< time estimate in ns

--- a/Detectors/GlobalTracking/src/MatchGlobalFwd.cxx
+++ b/Detectors/GlobalTracking/src/MatchGlobalFwd.cxx
@@ -186,11 +186,13 @@ bool MatchGlobalFwd::processMCHMIDMatches()
 
     for (const auto& MIDMatch : mMCHMIDMatches) {
       const auto& MCHId = MIDMatch.getMCHRef().getIndex();
+      const auto& MIDId = MIDMatch.getMIDRef().getIndex();
       auto& thisMuonTrack = mMCHWork[MCHId];
       const auto& IR = MIDMatch.getIR();
       int nBC = IR.differenceInBC(mStartIR);
       float tMin = nBC * o2::constants::lhc::LHCBunchSpacingMUS;
       float tMax = tMin + o2::constants::lhc::LHCBunchSpacingMUS;
+      thisMuonTrack.setMIDTrackID(MIDId);
       thisMuonTrack.tBracket.set(tMin, tMax);
       thisMuonTrack.setMIDMatchingChi2(MIDMatch.getMatchChi2OverNDF());
     }


### PR DESCRIPTION
Includes  MFTMCH and MFTMCHMID tracks on `RecoContainer::getSingleDetectorRefs(GTrackID gidx)`