### PR TITLE
IDCs: Adding functionality to not group pads near the sector edges

### DIFF
--- a/Detectors/TPC/base/include/TPCBase/Painter.h
+++ b/Detectors/TPC/base/include/TPCBase/Painter.h
@@ -115,7 +115,11 @@ template <class T>
 TH2* getHistogram2D(const CalArray<T>& calArray);
 
 /// make a sector-wise histogram with correct pad corners
-TH2Poly* makeSectorHist(const std::string_view name = "hSector", const std::string_view title = "Sector;local #it{x} (cm);local #it{y} (cm)");
+/// \param xMin minimum x coordinate of the histogram
+/// \param xMax maximum x coordinate of the histogram
+/// \param yMin minimum y coordinate of the histogram
+/// \param yMax maximum y coordinate of the histogram
+TH2Poly* makeSectorHist(const std::string_view name = "hSector", const std::string_view title = "Sector;local #it{x} (cm);local #it{y} (cm)", const float xMin = 83.65f, const float xMax = 247.7f, const float yMin = -43.7f, const float yMax = 43.7f);
 
 /// make a side-wise histogram with correct pad corners
 TH2Poly* makeSideHist(Side side);

--- a/Detectors/TPC/base/src/Painter.cxx
+++ b/Detectors/TPC/base/src/Painter.cxx
@@ -437,9 +437,9 @@ std::vector<TCanvas*> painter::makeSummaryCanvases(const std::string_view fileNa
 }
 
 //______________________________________________________________________________
-TH2Poly* painter::makeSectorHist(const std::string_view name, const std::string_view title)
+TH2Poly* painter::makeSectorHist(const std::string_view name, const std::string_view title, const float xMin, const float xMax, const float yMin, const float yMax)
 {
-  auto poly = new TH2Poly(name.data(), title.data(), 83.65, 247.7, -43.7, 43.7);
+  auto poly = new TH2Poly(name.data(), title.data(), xMin, xMax, yMin, yMax);
 
   auto coords = painter::getPadCoordinatesSector();
   for (const auto& coord : coords) {

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCAverageGroup.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCAverageGroup.h
@@ -97,8 +97,8 @@ class IDCAverageGroup : public IDCAverageGroupBase<Type>
   /// \param overlapRows define parameter for additional overlapping pads in row direction
   /// \param overlapPads define parameter for additional overlapping pads in pad direction
   template <bool IsEnabled = true, typename std::enable_if<(IsEnabled && (std::is_same<Type, IDCAverageGroupCRU>::value)), int>::type = 0>
-  IDCAverageGroup(const unsigned char groupPads = 4, const unsigned char groupRows = 4, const unsigned char groupLastRowsThreshold = 2, const unsigned char groupLastPadsThreshold = 2, const unsigned int region = 0, const Sector sector = Sector{0}, const unsigned char overlapRows = 0, const unsigned char overlapPads = 0)
-    : IDCAverageGroupBase<Type>{groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold, region, sector, sNThreads}, mOverlapRows{overlapRows}, mOverlapPads{overlapPads}
+  IDCAverageGroup(const unsigned char groupPads = 4, const unsigned char groupRows = 4, const unsigned char groupLastRowsThreshold = 2, const unsigned char groupLastPadsThreshold = 2, const unsigned char groupNotnPadsSectorEdges = 0, const unsigned int region = 0, const Sector sector = Sector{0}, const unsigned char overlapRows = 0, const unsigned char overlapPads = 0)
+    : IDCAverageGroupBase<Type>{groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold, groupNotnPadsSectorEdges, region, sector, sNThreads}, mOverlapRows{overlapRows}, mOverlapPads{overlapPads}
   {
     init();
   }
@@ -110,8 +110,8 @@ class IDCAverageGroup : public IDCAverageGroupBase<Type>
   /// \param overlapRows define parameter for additional overlapping pads in row direction
   /// \param overlapPads define parameter for additional overlapping pads in pad direction
   template <bool IsEnabled = true, typename std::enable_if<(IsEnabled && (std::is_same<Type, IDCAverageGroupTPC>::value)), int>::type = 0>
-  IDCAverageGroup(const std::array<unsigned char, Mapper::NREGIONS>& groupPads = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, const std::array<unsigned char, Mapper::NREGIONS>& groupRows = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, const std::array<unsigned char, Mapper::NREGIONS>& groupLastRowsThreshold = {}, const std::array<unsigned char, Mapper::NREGIONS>& groupLastPadsThreshold = {}, const unsigned char overlapRows = 0, const unsigned char overlapPads = 0)
-    : IDCAverageGroupBase<Type>{groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold, sNThreads}, mOverlapRows{overlapRows}, mOverlapPads{overlapPads}
+  IDCAverageGroup(const std::array<unsigned char, Mapper::NREGIONS>& groupPads = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, const std::array<unsigned char, Mapper::NREGIONS>& groupRows = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, const std::array<unsigned char, Mapper::NREGIONS>& groupLastRowsThreshold = {}, const std::array<unsigned char, Mapper::NREGIONS>& groupLastPadsThreshold = {}, const unsigned char groupNotnPadsSectorEdges = 0, const unsigned char overlapRows = 0, const unsigned char overlapPads = 0)
+    : IDCAverageGroupBase<Type>{groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold, groupNotnPadsSectorEdges, sNThreads}, mOverlapRows{overlapRows}, mOverlapPads{overlapPads}
   {
     init();
   }
@@ -203,6 +203,9 @@ class IDCAverageGroup : public IDCAverageGroupBase<Type>
 
   /// helper function for drawing
   void drawPadStatusMap(const bool type, const Sector sector, const std::string filename) const;
+
+  /// draw information of the grouping on the pads (grouping parameters and number of grouped pads)
+  void drawGroupingInformations(const int region, const int grPads, const int grRows, const int groupLastRowsThreshold, const int groupLastPadsThreshold, const int overlapRows, const int overlapPads, const int nIDCs, const int groupPadsSectorEdges) const;
 
   ClassDefNV(IDCAverageGroup, 1)
 };

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCAverageGroupHelper.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCAverageGroupHelper.h
@@ -61,6 +61,9 @@ class IDCAverageGroupHelper<IDCAverageGroupCRU>
   /// \return returns grouping parameter
   int getGroupPads() const { return static_cast<int>(mIDCsGrouped.getGroupPads()); }
 
+  /// \return returns the number of pads at the sector edges which are not grouped
+  unsigned int getGroupPadsSectorEdges() const { return mIDCsGrouped.getGroupPadsSectorEdges(); }
+
   /// \return returns last ungrouped row
   int getLastRow() const { return static_cast<int>(mIDCsGrouped.getLastRow()); }
 
@@ -115,6 +118,12 @@ class IDCAverageGroupHelper<IDCAverageGroupCRU>
   /// clearing the object for averaging
   void clearRobustAverage();
 
+  /// setting the IDC value at the edge of the sector
+  /// \param ulrow ungrouped local row
+  /// \param upad ungrouped pad
+  /// \param val value which will be stored
+  void setSectorEdgeIDC(const unsigned int ulrow, const unsigned int upad, const unsigned int padInRegion) { mIDCsGrouped.setValUngrouped(ulrow, upad, mIntegrationInterval, getUngroupedIDCVal(padInRegion) * Mapper::INVPADAREA[getRegion()]); }
+
  private:
   IDCGroup& mIDCsGrouped;                     ///< grouped and averaged IDC values
   const std::vector<float>& mWeightsPad{};    ///< storage of the weights in pad direction used if mOverlapPads>0
@@ -150,6 +159,9 @@ class IDCAverageGroupHelper<IDCAverageGroupTPC>
 
   /// \return returns grouping parameter
   int getGroupPads() const { return static_cast<int>(mIDCGroupHelperSector.getGroupingParameter().getGroupPads(getRegion())); }
+
+  /// \return returns the number of pads at the sector edges which are not grouped
+  unsigned int getGroupPadsSectorEdges() const { return mIDCGroupHelperSector.getGroupingParameter().getGroupPadsSectorEdges(); }
 
   /// \return returns last ungrouped row
   int getLastRow() const { return static_cast<int>(mIDCGroupHelperSector.getLastRow(getRegion())); }
@@ -192,12 +204,6 @@ class IDCAverageGroupHelper<IDCAverageGroupTPC>
   void addValue(const unsigned int padInRegion, const float weight);
 
   /// calculating and setting the grouped IDC value
-  /// \param glrow local row of the grouped IDCs
-  /// \param pad pad of the grouped IDCs
-  /// \param integrationInterval integration interval
-  void setGroupedIDC(const unsigned int glrow, const unsigned int padGrouped, const float val);
-
-  /// calculating and setting the grouped IDC value
   /// \param rowGrouped grouped row index
   /// \param padGrouped grouped pad index
   void setGroupedIDC(const unsigned int rowGrouped, const unsigned int padGrouped);
@@ -214,6 +220,12 @@ class IDCAverageGroupHelper<IDCAverageGroupTPC>
   /// clearing the object for averaging
   void clearRobustAverage();
 
+  /// setting the IDC value at the edge of the sector
+  /// \param ulrow ungrouped local row
+  /// \param upad ungrouped pad
+  /// \param val value which will be stored
+  void setSectorEdgeIDC(const unsigned int ulrow, const unsigned int upad, const unsigned int padInRegion);
+
  private:
   IDCDelta<float>& mIDCsGrouped;                                         ///< grouped and averaged IDC values
   const std::array<std::vector<float>, Mapper::NREGIONS>& mWeightsPad{}; ///< storage of the weights in pad direction used if mOverlapPads>0
@@ -226,6 +238,12 @@ class IDCAverageGroupHelper<IDCAverageGroupTPC>
   unsigned int mIntegrationInterval{};                                   ///< current integration interval
   unsigned int mOffsetUngrouped{};                                       ///< offset to calculate the index for the ungrouped IDCs
   unsigned int mOffsetGrouped{};                                         ///< offset to calculate the index for the grouped IDCs
+
+  /// calculating and setting the grouped IDC value
+  /// \param glrow local row of the grouped IDCs
+  /// \param pad pad of the grouped IDCs
+  /// \param integrationInterval integration interval
+  void setGroupedIDC(const unsigned int glrow, const unsigned int padGrouped, const float val);
 };
 
 /// Helper class for drawing the IDCs
@@ -233,8 +251,8 @@ template <>
 class IDCAverageGroupHelper<IDCAverageGroupDraw> : public IDCGroupHelperRegion
 {
  public:
-  IDCAverageGroupHelper(const unsigned char groupPads, const unsigned char groupRows, const unsigned char groupLastRowsThreshold, const unsigned char groupLastPadsThreshold, const unsigned int region, const unsigned int nPads, const PadRegionInfo& padInf, TH2Poly& poly)
-    : IDCGroupHelperRegion{groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold, region}, mCountDraw(nPads), mPadInf{padInf}, mPoly{poly} {};
+  IDCAverageGroupHelper(const unsigned char groupPads, const unsigned char groupRows, const unsigned char groupLastRowsThreshold, const unsigned char groupLastPadsThreshold, const unsigned char groupNotnPadsSectorEdges, const unsigned int region, const unsigned int nPads, const PadRegionInfo& padInf, TH2Poly& poly)
+    : IDCGroupHelperRegion{groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold, groupNotnPadsSectorEdges, region}, mCountDraw(nPads), mPadInf{padInf}, mPoly{poly} {};
 
   std::vector<int> mCountDraw;                  ///< counter to keep track of the already drawn pads
   const PadRegionInfo& mPadInf;                 ///< object for storing pad region information

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCFactorization.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCFactorization.h
@@ -42,7 +42,7 @@ class IDCFactorization : public IDCGroupHelperSector
   /// \param groupLastPadsThreshold minimum number of pads in pad direction for the last group in pad direction for all regions
   /// \param timeFrames number of time frames which will be stored
   /// \param timeframesDeltaIDC number of time frames stored for each DeltaIDC object
-  IDCFactorization(const std::array<unsigned char, Mapper::NREGIONS>& groupPads, const std::array<unsigned char, Mapper::NREGIONS>& groupRows, const std::array<unsigned char, Mapper::NREGIONS>& groupLastRowsThreshold, const std::array<unsigned char, Mapper::NREGIONS>& groupLastPadsThreshold, const unsigned int timeFrames, const unsigned int timeframesDeltaIDC);
+  IDCFactorization(const std::array<unsigned char, Mapper::NREGIONS>& groupPads, const std::array<unsigned char, Mapper::NREGIONS>& groupRows, const std::array<unsigned char, Mapper::NREGIONS>& groupLastRowsThreshold, const std::array<unsigned char, Mapper::NREGIONS>& groupLastPadsThreshold, const unsigned char groupNotnPadsSectorEdges, const unsigned int timeFrames, const unsigned int timeframesDeltaIDC);
 
   /// default constructor for ROOT I/O
   IDCFactorization() = default;

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCGroup.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCGroup.h
@@ -34,8 +34,8 @@ class IDCGroup : public IDCGroupHelperRegion
   /// \param groupLastRowsThreshold minimum number of pads in row direction for the last group in row direction
   /// \param groupLastPadsThreshold minimum number of pads in pad direction for the last group in pad direction
   /// \param region region of the TPC
-  IDCGroup(const unsigned char groupPads = 4, const unsigned char groupRows = 4, const unsigned char groupLastRowsThreshold = 2, const unsigned char groupLastPadsThreshold = 2, const unsigned int region = 0)
-    : IDCGroupHelperRegion{groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold, region}, mIDCsGrouped(getNIDCsPerIntegrationInterval()){};
+  IDCGroup(const unsigned char groupPads = 4, const unsigned char groupRows = 4, const unsigned char groupLastRowsThreshold = 2, const unsigned char groupLastPadsThreshold = 2, const unsigned char groupNotnPadsSectorEdges = 0, const unsigned int region = 0)
+    : IDCGroupHelperRegion{groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold, groupNotnPadsSectorEdges, region}, mIDCsGrouped(getNIDCsPerIntegrationInterval()){};
 
   /// extend the size of the grouped and averaged IDC values corresponding to the number of integration intervals. This has to be called befor filling values!
   /// without using this function the object can hold only one integration interval
@@ -58,7 +58,7 @@ class IDCGroup : public IDCGroupHelperRegion
   /// \param ulrow local row in region of the ungrouped IDCs
   /// \param upad pad number of the ungrouped IDCs
   /// \param integrationInterval integration interval
-  float& setValUngrouped(unsigned int ulrow, unsigned int upad, unsigned int integrationInterval) { return mIDCsGrouped[getIndexUngrouped(ulrow, upad, integrationInterval)]; }
+  void setValUngrouped(unsigned int ulrow, unsigned int upad, unsigned int integrationInterval, const float value) { mIDCsGrouped[getIndexUngrouped(ulrow, upad, integrationInterval)] = value; }
 
   /// \return returns the stored value for local ungrouped pad row and ungrouped pad
   /// \param ulrow local row in region of the ungrouped IDCs

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCGroupHelperSector.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCGroupHelperSector.h
@@ -33,8 +33,8 @@ class IDCGroupHelperSector
   /// \param groupRows number of pads in row direction which will be grouped
   /// \param groupLastRowsThreshold minimum number of pads in row direction for the last group in row direction
   /// \param groupLastPadsThreshold minimum number of pads in pad direction for the last group in pad direction
-  IDCGroupHelperSector(const std::array<unsigned char, Mapper::NREGIONS>& groupPads, const std::array<unsigned char, Mapper::NREGIONS>& groupRows, const std::array<unsigned char, Mapper::NREGIONS>& groupLastRowsThreshold, const std::array<unsigned char, Mapper::NREGIONS>& groupLastPadsThreshold)
-    : mGroupingPar{groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold} { initIDCGroupHelperSector(); };
+  IDCGroupHelperSector(const std::array<unsigned char, Mapper::NREGIONS>& groupPads, const std::array<unsigned char, Mapper::NREGIONS>& groupRows, const std::array<unsigned char, Mapper::NREGIONS>& groupLastRowsThreshold, const std::array<unsigned char, Mapper::NREGIONS>& groupLastPadsThreshold, const unsigned char groupNotnPadsSectorEdges)
+    : mGroupingPar{groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold, groupNotnPadsSectorEdges} { initIDCGroupHelperSector(); };
 
   /// constructor
   /// \param groupingParameter struct holding the grouping parameter
@@ -57,7 +57,11 @@ class IDCGroupHelperSector
   /// \param ulrow local row of the ungrouped IDCs
   /// \param upad pad number of the ungrouped IDCs
   /// \param integrationInterval integration interval
-  unsigned int getIndexUngrouped(const unsigned int sector, const unsigned int region, unsigned int ulrow, unsigned int upad, unsigned int integrationInterval) const { return getIndexGrouped(sector, region, getGroupedRow(region, ulrow), getGroupedPad(region, ulrow, upad), integrationInterval); }
+  unsigned int getIndexUngrouped(const unsigned int sector, const unsigned int region, unsigned int ulrow, unsigned int upad, unsigned int integrationInterval) const { return getIndexGrouped(sector, region, getGroupedRow(region, ulrow), getGroupedPad(region, ulrow, upad), integrationInterval) + getOffsetForEdgePad(upad, ulrow, region); }
+
+  /// \return returns offset of the index for a pad which is not grouped (in the region where mGroupPadsSectorEdges is true).
+  /// returns for pads near local pad number = 0 negative value and for pads near local pad number = max value positive value
+  int getOffsetForEdgePad(const unsigned int upad, const unsigned int ulrow, const unsigned int region) const;
 
   /// \return returns the index to the grouped data with ungrouped inputs
   /// \param sector sector
@@ -83,6 +87,12 @@ class IDCGroupHelperSector
 
   /// \return returns number of IDCs for given region
   unsigned int getNIDCs(const unsigned int region) const { return mNIDCsPerCRU[region]; }
+
+  /// \return returns number of grouped rows for given region
+  unsigned int getNRows(const unsigned int region) const { return mRows[region]; }
+
+  /// \return returns region offset for calculating the index
+  unsigned int getRegionOffset(const unsigned int region) const { return mRegionOffs[region]; }
 
   /// \return returns number of IDCs for a whole sector
   unsigned int getNIDCsPerSector() const { return mNIDCsPerSector; }

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCGroupingParameter.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCGroupingParameter.h
@@ -33,12 +33,21 @@ enum class AveragingMethod : char {
 
 /// struct for setting the parameters for the grouping of IDCs
 struct ParameterIDCGroup : public o2::conf::ConfigurableParamHelper<ParameterIDCGroup> {
-  unsigned char GroupPads[Mapper::NREGIONS]{7, 7, 7, 7, 6, 6, 6, 6, 5, 5};              ///< grouping parameter in pad direction (how many pads are grouped)
-  unsigned char GroupRows[Mapper::NREGIONS]{5, 5, 5, 5, 4, 4, 4, 4, 3, 3};              ///< group parameter in row direction (how many rows are grouped)
-  unsigned char GroupLastRowsThreshold[Mapper::NREGIONS]{3, 3, 3, 3, 2, 2, 2, 2, 2, 2}; ///< if the last group (region edges) consists in row direction less then mGroupLastRowsThreshold pads then it will be grouped into the previous group
-  unsigned char GroupLastPadsThreshold[Mapper::NREGIONS]{3, 3, 3, 3, 2, 2, 2, 2, 1, 1}; ///< if the last group (sector edges) consists in pad direction less then mGroupLastPadsThreshold pads then it will be grouped into the previous group
-  AveragingMethod Method = AveragingMethod::SLOW;                                       ///< method which is used for averaging
-  float Sigma = 3.f;                                                                    ///< sigma cut which can be used during the grouping for outlier filtering
+  unsigned char groupPads[Mapper::NREGIONS]{7, 7, 7, 7, 6, 6, 6, 6, 5, 5};              ///< grouping parameter in pad direction (how many pads are grouped)
+  unsigned char groupRows[Mapper::NREGIONS]{5, 5, 5, 5, 4, 4, 4, 4, 3, 3};              ///< group parameter in row direction (how many rows are grouped)
+  unsigned char groupLastRowsThreshold[Mapper::NREGIONS]{3, 3, 3, 3, 2, 2, 2, 2, 2, 2}; ///< if the last group (region edges) consists in row direction less then mGroupLastRowsThreshold pads then it will be grouped into the previous group
+  unsigned char groupLastPadsThreshold[Mapper::NREGIONS]{3, 3, 3, 3, 2, 2, 2, 2, 1, 1}; ///< if the last group (sector edges) consists in pad direction less then mGroupLastPadsThreshold pads then it will be grouped into the previous group
+  unsigned char groupPadsSectorEdges{0};                                                ///< number of pads at the sector edges which are not grouped
+  AveragingMethod method = AveragingMethod::SLOW;                                       ///< method which is used for averaging
+  float sigma = 3.f;                                                                    ///< sigma cut which can be used during the grouping for outlier filtering
+
+  /// Helper function for setting the groupimg parameters from a string (can be "X": parameters in all regions are "X" or can be "1,2,3,4,5,6,7,8,9,10" for setting individual regions)
+  /// \param sgroupPads string for grouping parameter in pad direction
+  /// \param sgroupRows string for grouping parameter in row direction
+  /// \param sgroupLastRowsThreshold string for grouping parameter of last pads int row direction
+  /// \param sgroupLastPadsThreshold string for grouping parameter of last pads int pad direction
+  static void setGroupingParameterFromString(const std::string sgroupPads, const std::string sgroupRows, const std::string sgroupLastRowsThreshold, const std::string sgroupLastPadsThreshold);
+
   O2ParamDef(ParameterIDCGroup, "TPCIDCGroupParam");
 };
 
@@ -50,43 +59,48 @@ struct ParameterIDCGroupCCDB {
   /// \param groupRows number of pads in row direction which are grouped
   /// \param groupLastRowsThreshold minimum number of pads in row direction for the last group in row direction
   /// \param groupLastPadsThreshold minimum number of pads in pad direction for the last group in pad direction
-  ParameterIDCGroupCCDB(const std::array<unsigned char, Mapper::NREGIONS>& groupPads, const std::array<unsigned char, Mapper::NREGIONS>& groupRows, const std::array<unsigned char, Mapper::NREGIONS>& groupLastRowsThreshold, const std::array<unsigned char, Mapper::NREGIONS>& groupLastPadsThreshold)
-    : GroupPads{groupPads}, GroupRows{groupRows}, GroupLastRowsThreshold{groupLastRowsThreshold}, GroupLastPadsThreshold{groupLastPadsThreshold} {};
+  /// \param groupNotnPadsSectorEdges number of pads at the sector edges which are not getting grouped
+  ParameterIDCGroupCCDB(const std::array<unsigned char, Mapper::NREGIONS>& groupPads, const std::array<unsigned char, Mapper::NREGIONS>& groupRows, const std::array<unsigned char, Mapper::NREGIONS>& groupLastRowsThreshold, const std::array<unsigned char, Mapper::NREGIONS>& groupLastPadsThreshold, const unsigned char groupNotnPadsSectorEdges)
+    : groupPads{groupPads}, groupRows{groupRows}, groupLastRowsThreshold{groupLastRowsThreshold}, groupLastPadsThreshold{groupLastPadsThreshold}, groupPadsSectorEdges{groupNotnPadsSectorEdges} {};
 
   ParameterIDCGroupCCDB() = default;
 
   /// \return returns number of pads in pad direction which are grouped
   /// \parameter region TPC region
-  unsigned char getGroupPads(const unsigned int region) const { return GroupPads[region]; }
+  unsigned char getGroupPads(const unsigned int region) const { return groupPads[region]; }
 
   /// \return returns number of pads in row direction which are grouped
   /// \parameter region TPC region
-  unsigned char getGroupRows(const unsigned int region) const { return GroupRows[region]; }
+  unsigned char getGroupRows(const unsigned int region) const { return groupRows[region]; }
 
   /// \return returns minimum number of pads in row direction for the last group in row direction
   /// \parameter region TPC region
-  unsigned char getGroupLastRowsThreshold(const unsigned int region) const { return GroupLastRowsThreshold[region]; }
+  unsigned char getGroupLastRowsThreshold(const unsigned int region) const { return groupLastRowsThreshold[region]; }
 
   /// \return returns minimum number of pads in pad direction for the last group in pad direction
   /// \parameter region TPC region
-  unsigned char getGroupLastPadsThreshold(const unsigned int region) const { return GroupLastPadsThreshold[region]; }
+  unsigned char getGroupLastPadsThreshold(const unsigned int region) const { return groupLastPadsThreshold[region]; }
+
+  /// \return returns the number of pads at the sector edges which are not grouped
+  unsigned int getGroupPadsSectorEdges() const { return groupPadsSectorEdges; }
 
   /// \return returns number of pads in pad direction which are grouped for all regions
-  const std::array<unsigned char, Mapper::NREGIONS>& getGroupPads() const { return GroupPads; }
+  const std::array<unsigned char, Mapper::NREGIONS>& getGroupPads() const { return groupPads; }
 
   /// \return returns number of pads in row direction which are grouped for all regions
-  const std::array<unsigned char, Mapper::NREGIONS>& getGroupRows() const { return GroupRows; }
+  const std::array<unsigned char, Mapper::NREGIONS>& getGroupRows() const { return groupRows; }
 
   /// \return returns minimum number of pads in row direction for the last group in row direction for all regions
-  const std::array<unsigned char, Mapper::NREGIONS>& getGroupLastRowsThreshold() const { return GroupLastRowsThreshold; }
+  const std::array<unsigned char, Mapper::NREGIONS>& getGroupLastRowsThreshold() const { return groupLastRowsThreshold; }
 
   /// \return returns minimum number of pads in pad direction for the last group in pad direction for all regions
-  const std::array<unsigned char, Mapper::NREGIONS>& getGroupLastPadsThreshold() const { return GroupLastPadsThreshold; }
+  const std::array<unsigned char, Mapper::NREGIONS>& getGroupLastPadsThreshold() const { return groupLastPadsThreshold; }
 
-  std::array<unsigned char, Mapper::NREGIONS> GroupPads{};              ///< grouping parameter in pad direction (how many pads in pad direction are grouped)
-  std::array<unsigned char, Mapper::NREGIONS> GroupRows{};              ///< grouping parameter in pad direction (how many pads in pad direction are grouped)
-  std::array<unsigned char, Mapper::NREGIONS> GroupLastRowsThreshold{}; ///< if the last group (region edges) consists in row direction less then mGroupLastRowsThreshold pads then it will be grouped into the previous group
-  std::array<unsigned char, Mapper::NREGIONS> GroupLastPadsThreshold{}; ///< if the last group (sector edges) consists in pad direction less then mGroupLastPadsThreshold pads then it will be grouped into the previous group
+  std::array<unsigned char, Mapper::NREGIONS> groupPads{};              ///< grouping parameter in pad direction (how many pads in pad direction are grouped)
+  std::array<unsigned char, Mapper::NREGIONS> groupRows{};              ///< grouping parameter in pad direction (how many pads in pad direction are grouped)
+  std::array<unsigned char, Mapper::NREGIONS> groupLastRowsThreshold{}; ///< if the last group (region edges) consists in row direction less then mGroupLastRowsThreshold pads then it will be grouped into the previous group
+  std::array<unsigned char, Mapper::NREGIONS> groupLastPadsThreshold{}; ///< if the last group (sector edges) consists in pad direction less then mGroupLastPadsThreshold pads then it will be grouped into the previous group
+  unsigned char groupPadsSectorEdges{0};                                ///< number of pads at the sector edges which are not grouped
 };
 
 struct ParameterIDCCompression : public o2::conf::ConfigurableParamHelper<ParameterIDCCompression> {

--- a/Detectors/TPC/calibration/src/IDCAverageGroupBase.cxx
+++ b/Detectors/TPC/calibration/src/IDCAverageGroupBase.cxx
@@ -16,8 +16,7 @@
 void o2::tpc::IDCAverageGroupBase<o2::tpc::IDCAverageGroupCRU>::drawUngroupedIDCs(const unsigned int integrationInterval, const std::string filename) const
 {
   std::function<float(const unsigned int, const unsigned int, const unsigned int, const unsigned int)> idcFunc = [this, integrationInterval](const unsigned int, const unsigned int region, const unsigned int row, const unsigned int pad) {
-    const unsigned int indexIDC = integrationInterval * Mapper::PADSPERREGION[region] + Mapper::OFFSETCRULOCAL[region][row] + pad;
-    return this->mIDCsUngrouped[indexIDC] * Mapper::INVPADAREA[region];
+    return this->getUngroupedNormedIDCValLocal(row, pad, integrationInterval);
   };
 
   IDCDrawHelper::IDCDraw drawFun;

--- a/Detectors/TPC/calibration/src/IDCFactorization.cxx
+++ b/Detectors/TPC/calibration/src/IDCFactorization.cxx
@@ -16,8 +16,8 @@
 #include "TFile.h"
 #include <functional>
 
-o2::tpc::IDCFactorization::IDCFactorization(const std::array<unsigned char, Mapper::NREGIONS>& groupPads, const std::array<unsigned char, Mapper::NREGIONS>& groupRows, const std::array<unsigned char, Mapper::NREGIONS>& groupLastRowsThreshold, const std::array<unsigned char, Mapper::NREGIONS>& groupLastPadsThreshold, const unsigned int timeFrames, const unsigned int timeframesDeltaIDC)
-  : IDCGroupHelperSector{groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold}, mTimeFrames{timeFrames}, mTimeFramesDeltaIDC{timeframesDeltaIDC}, mIDCDelta{timeFrames / timeframesDeltaIDC + (timeFrames % timeframesDeltaIDC != 0)}
+o2::tpc::IDCFactorization::IDCFactorization(const std::array<unsigned char, Mapper::NREGIONS>& groupPads, const std::array<unsigned char, Mapper::NREGIONS>& groupRows, const std::array<unsigned char, Mapper::NREGIONS>& groupLastRowsThreshold, const std::array<unsigned char, Mapper::NREGIONS>& groupLastPadsThreshold, const unsigned char groupNotnPadsSectorEdges, const unsigned int timeFrames, const unsigned int timeframesDeltaIDC)
+  : IDCGroupHelperSector{groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold, groupNotnPadsSectorEdges}, mTimeFrames{timeFrames}, mTimeFramesDeltaIDC{timeframesDeltaIDC}, mIDCDelta{timeFrames / timeframesDeltaIDC + (timeFrames % timeframesDeltaIDC != 0)}
 {
   for (auto& idc : mIDCs) {
     idc.resize(mTimeFrames);
@@ -230,7 +230,9 @@ float o2::tpc::IDCFactorization::getIDCValUngrouped(const unsigned int sector, c
   if (mIDCs[sector * Mapper::NREGIONS + region][timeFrame].empty()) {
     return 0.f;
   }
-  return mIDCs[sector * Mapper::NREGIONS + region][timeFrame][interval * mNIDCsPerCRU[region] + mOffsRow[region][getGroupedRow(region, urow)] + getGroupedPad(region, urow, upad)];
+
+  const int index = interval * mNIDCsPerCRU[region] + mOffsRow[region][getGroupedRow(region, urow)] + getGroupedPad(region, urow, upad) + getOffsetForEdgePad(upad, urow, region);
+  return mIDCs[sector * Mapper::NREGIONS + region][timeFrame][index];
 }
 
 void o2::tpc::IDCFactorization::getTF(const unsigned int region, unsigned int integrationInterval, unsigned int& timeFrame, unsigned int& interval) const

--- a/Detectors/TPC/calibration/src/IDCGroup.cxx
+++ b/Detectors/TPC/calibration/src/IDCGroup.cxx
@@ -38,7 +38,7 @@ void o2::tpc::IDCGroup::dumpToTree(const char* outname) const
 void o2::tpc::IDCGroup::draw(const unsigned int integrationInterval, const std::string filename) const
 {
   std::function<float(const unsigned int, const unsigned int, const unsigned int, const unsigned int)> idcFunc = [this, integrationInterval](const unsigned int, const unsigned int region, const unsigned int irow, const unsigned int pad) {
-    return (*this)(getGroupedRow(irow), getGroupedPad(pad, irow), integrationInterval);
+    return this->getValUngrouped(irow, pad, integrationInterval);
   };
 
   IDCDrawHelper::IDCDraw drawFun;

--- a/Detectors/TPC/calibration/src/IDCGroupHelperRegion.cxx
+++ b/Detectors/TPC/calibration/src/IDCGroupHelperRegion.cxx
@@ -25,7 +25,7 @@ unsigned int o2::tpc::IDCGroupHelperRegion::getGroupedRow(const unsigned int ulr
   return (row >= groupedrows) ? (groupedrows - 1) : row;
 }
 
-unsigned int o2::tpc::IDCGroupHelperRegion::getGroupedPad(const unsigned int upad, const unsigned int ulrow, const unsigned int region, const unsigned int groupPads, const unsigned int groupRows, const unsigned int groupedrows, const std::vector<unsigned int>& padsPerRow)
+unsigned int o2::tpc::IDCGroupHelperRegion::getGroupedPad(const unsigned int upad, const unsigned int ulrow, const unsigned int region, const unsigned int groupPads, const unsigned int groupRows, const unsigned int groupedrows, const unsigned int groupPadsSectorEdges, const std::vector<unsigned int>& padsPerRow)
 {
   const int relPadHalf = static_cast<int>(std::floor((upad - 0.5f * Mapper::PADSPERROW[region][ulrow]) / groupPads));
   const unsigned int nGroupedPads = padsPerRow[getGroupedRow(ulrow, groupRows, groupedrows)];
@@ -34,6 +34,26 @@ unsigned int o2::tpc::IDCGroupHelperRegion::getGroupedPad(const unsigned int upa
     return std::signbit(relPadHalf) ? 0 : nGroupedPads - 1;
   }
   return static_cast<unsigned int>(static_cast<int>(nGroupedPadsHalf) + relPadHalf);
+}
+
+bool o2::tpc::IDCGroupHelperRegion::isSectorEdgePad(const unsigned int upad, const unsigned int ulrow, const unsigned int region, const unsigned int groupPadsSectorEdges)
+{
+  return (upad < groupPadsSectorEdges || (upad >= Mapper::PADSPERROW[region][ulrow] - groupPadsSectorEdges)) ? true : false;
+}
+
+int o2::tpc::IDCGroupHelperRegion::getOffsetForEdgePad(const unsigned int upad, const unsigned int ulrow, const unsigned int groupRows, const unsigned int groupPadsSectorEdges, const unsigned int region, const int lastRow)
+{
+  if (ulrow < lastRow) {
+    const int relPadinRow = ulrow % groupRows;
+    const int localPadOffset = relPadinRow * groupPadsSectorEdges; // offset from pads to the left
+    const int totalOff = upad < Mapper::PADSPERROW[region][ulrow] / 2 ? (localPadOffset + upad - groupPadsSectorEdges * groupRows) : (localPadOffset + upad - (Mapper::PADSPERROW[region][ulrow] - groupPadsSectorEdges) + 1);
+    return totalOff;
+  } else {
+    const int relPadinRow = ulrow - lastRow;
+    const int localPadOffset = relPadinRow * groupPadsSectorEdges; // offset from pads to the left
+    const int totalOff = upad < Mapper::PADSPERROW[region][ulrow] / 2 ? (localPadOffset + upad - groupPadsSectorEdges * (Mapper::ROWSPERREGION[region] - lastRow)) : (localPadOffset + upad - (Mapper::PADSPERROW[region][ulrow] - groupPadsSectorEdges) + 1);
+    return totalOff;
+  }
 }
 
 void o2::tpc::IDCGroupHelperRegion::setRows(const unsigned int nRows)
@@ -56,7 +76,7 @@ unsigned int o2::tpc::IDCGroupHelperRegion::getLastRow() const
 
 unsigned int o2::tpc::IDCGroupHelperRegion::getLastPad(const unsigned int ulrow) const
 {
-  const unsigned int nPads = Mapper::PADSPERROW[mRegion][ulrow] / 2;
+  const unsigned int nPads = Mapper::PADSPERROW[mRegion][ulrow] / 2 - mGroupPadsSectorEdges;
   const unsigned int padsRemainder = nPads % mGroupPads;
   int unsigned lastPad = (padsRemainder == 0) ? nPads - mGroupPads : nPads - padsRemainder;
   if (padsRemainder && padsRemainder <= mGroupLastPadsThreshold) {
@@ -74,11 +94,13 @@ void o2::tpc::IDCGroupHelperRegion::initIDCGroupHelperRegion()
     mPadsPerRow[irow] = 2 * (getLastPad(row) / mGroupPads + 1);
   }
 
-  mNIDCsPerCRU = std::accumulate(mPadsPerRow.begin(), mPadsPerRow.end(), decltype(mPadsPerRow)::value_type(0));
-  for (unsigned int i = 1; i < mRows; ++i) {
+  mNIDCsPerCRU = std::accumulate(mPadsPerRow.begin(), mPadsPerRow.end(), decltype(mPadsPerRow)::value_type(0)) + 2 * Mapper::ROWSPERREGION[mRegion] * mGroupPadsSectorEdges;
+  mOffsRow.front() = mGroupPadsSectorEdges * mGroupRows;
+  for (unsigned int i = 1; i < (mRows - 1); ++i) {
     const unsigned int lastInd = i - 1;
-    mOffsRow[i] = mOffsRow[lastInd] + mPadsPerRow[lastInd];
+    mOffsRow[i] = mOffsRow[lastInd] + mPadsPerRow[lastInd] + 2 * mGroupPadsSectorEdges * mGroupRows;
   }
+  mOffsRow.back() = mOffsRow[mRows - 2] + mPadsPerRow[mRows - 2] + mGroupPadsSectorEdges * (mGroupRows + (Mapper::ROWSPERREGION[mRegion] - getLastRow()));
 }
 
 void o2::tpc::IDCGroupHelperRegion::dumpToFile(const char* outFileName, const char* outName) const

--- a/Detectors/TPC/calibration/src/IDCGroupHelperSector.cxx
+++ b/Detectors/TPC/calibration/src/IDCGroupHelperSector.cxx
@@ -15,32 +15,33 @@
 
 unsigned int o2::tpc::IDCGroupHelperSector::getGroupedPad(const unsigned int region, unsigned int ulrow, unsigned int upad) const
 {
-  return IDCGroupHelperRegion::getGroupedPad(upad, ulrow, region, mGroupingPar.GroupPads[region], mGroupingPar.GroupRows[region], mRows[region], mPadsPerRow[region]);
+  return IDCGroupHelperRegion::getGroupedPad(upad, ulrow, region, mGroupingPar.groupPads[region], mGroupingPar.groupRows[region], mRows[region], mGroupingPar.groupPadsSectorEdges, mPadsPerRow[region]);
 }
 
 unsigned int o2::tpc::IDCGroupHelperSector::getGroupedRow(const unsigned int region, unsigned int ulrow) const
 {
-  return IDCGroupHelperRegion::getGroupedRow(ulrow, mGroupingPar.GroupRows[region], mRows[region]);
+  return IDCGroupHelperRegion::getGroupedRow(ulrow, mGroupingPar.groupRows[region], mRows[region]);
 }
 
 unsigned int o2::tpc::IDCGroupHelperSector::getLastRow(const unsigned int region) const
 {
   const unsigned int nTotRows = Mapper::ROWSPERREGION[region];
-  const unsigned int rowsRemainder = nTotRows % mGroupingPar.GroupRows[region];
+  const unsigned int rowsRemainder = nTotRows % mGroupingPar.groupRows[region];
   unsigned int lastRow = nTotRows - rowsRemainder;
-  if (rowsRemainder <= mGroupingPar.GroupLastRowsThreshold[region]) {
-    lastRow -= mGroupingPar.GroupRows[region];
+  if (rowsRemainder <= mGroupingPar.groupLastRowsThreshold[region]) {
+    lastRow -= mGroupingPar.groupRows[region];
   }
   return lastRow;
 }
 
+// TODO MAKE STATIC AND MOVE TO REGION HELPER
 unsigned int o2::tpc::IDCGroupHelperSector::getLastPad(const unsigned int region, const unsigned int ulrow) const
 {
-  const unsigned int nPads = Mapper::PADSPERROW[region][ulrow] / 2;
-  const unsigned int padsRemainder = nPads % mGroupingPar.GroupPads[region];
-  int unsigned lastPad = (padsRemainder == 0) ? nPads - mGroupingPar.GroupPads[region] : nPads - padsRemainder;
-  if (padsRemainder && padsRemainder <= mGroupingPar.GroupLastPadsThreshold[region]) {
-    lastPad -= mGroupingPar.GroupPads[region];
+  const unsigned int nPads = Mapper::PADSPERROW[region][ulrow] / 2 - mGroupingPar.groupPadsSectorEdges;
+  const unsigned int padsRemainder = nPads % mGroupingPar.groupPads[region];
+  int unsigned lastPad = (padsRemainder == 0) ? nPads - mGroupingPar.groupPads[region] : nPads - padsRemainder;
+  if (padsRemainder && padsRemainder <= mGroupingPar.groupLastPadsThreshold[region]) {
+    lastPad -= mGroupingPar.groupPads[region];
   }
   return lastPad;
 }
@@ -48,7 +49,7 @@ unsigned int o2::tpc::IDCGroupHelperSector::getLastPad(const unsigned int region
 void o2::tpc::IDCGroupHelperSector::initIDCGroupHelperSector()
 {
   for (unsigned int reg = 0; reg < Mapper::NREGIONS; ++reg) {
-    const IDCGroupHelperRegion groupTmp(mGroupingPar.GroupPads[reg], mGroupingPar.GroupRows[reg], mGroupingPar.GroupLastRowsThreshold[reg], mGroupingPar.GroupLastPadsThreshold[reg], reg);
+    const IDCGroupHelperRegion groupTmp(mGroupingPar.groupPads[reg], mGroupingPar.groupRows[reg], mGroupingPar.groupLastRowsThreshold[reg], mGroupingPar.groupLastPadsThreshold[reg], mGroupingPar.groupPadsSectorEdges, reg);
     mNIDCsPerCRU[reg] = groupTmp.getNIDCsPerIntegrationInterval();
     mRows[reg] = groupTmp.getNRows();
     mPadsPerRow[reg] = groupTmp.getPadsPerRow();
@@ -59,4 +60,9 @@ void o2::tpc::IDCGroupHelperSector::initIDCGroupHelperSector()
     }
   }
   mNIDCsPerSector = static_cast<unsigned int>(std::accumulate(mNIDCsPerCRU.begin(), mNIDCsPerCRU.end(), decltype(mNIDCsPerCRU)::value_type(0)));
+}
+
+int o2::tpc::IDCGroupHelperSector::getOffsetForEdgePad(const unsigned int upad, const unsigned int ulrow, const unsigned int region) const
+{
+  return (IDCGroupHelperRegion::isSectorEdgePad(upad, ulrow, region, mGroupingPar.groupPadsSectorEdges)) ? IDCGroupHelperRegion::getOffsetForEdgePad(upad, ulrow, mGroupingPar.groupRows[region], mGroupingPar.groupPadsSectorEdges, region, getLastRow(region)) : 0;
 }

--- a/Detectors/TPC/calibration/src/IDCGroupingParameter.cxx
+++ b/Detectors/TPC/calibration/src/IDCGroupingParameter.cxx
@@ -10,7 +10,65 @@
 // or submit itself to any jurisdiction.
 
 #include "TPCCalibration/IDCGroupingParameter.h"
+#include "Framework/Logger.h"
+#include <boost/lexical_cast.hpp>
+#include <boost/tokenizer.hpp>
 
 using namespace o2::tpc;
 O2ParamImpl(o2::tpc::ParameterIDCGroup);
 O2ParamImpl(o2::tpc::ParameterIDCCompression);
+
+void o2::tpc::ParameterIDCGroup::setGroupingParameterFromString(const std::string sgroupPads, const std::string sgroupRows, const std::string sgroupLastRowsThreshold, const std::string sgroupLastPadsThreshold)
+{
+  // convert input string to std::vector<unsigned char>
+  const boost::char_separator<char> sep(","); /// char separator for the tokenizer
+  const boost::tokenizer<boost::char_separator<char>> tgroupPads(sgroupPads, sep);
+  const boost::tokenizer<boost::char_separator<char>> tgroupRows(sgroupRows, sep);
+  const boost::tokenizer<boost::char_separator<char>> tgroupLastRowsThreshold(sgroupLastRowsThreshold, sep);
+  const boost::tokenizer<boost::char_separator<char>> tgroupLastPadsThreshold(sgroupLastPadsThreshold, sep);
+
+  std::vector<unsigned char> vgroupPads;
+  std::vector<unsigned char> vgroupRows;
+  std::vector<unsigned char> vgroupLastRowsThreshold;
+  std::vector<unsigned char> vgroupLastPadsThreshold;
+  vgroupPads.reserve(Mapper::NREGIONS);
+  vgroupRows.reserve(Mapper::NREGIONS);
+  vgroupLastRowsThreshold.reserve(Mapper::NREGIONS);
+  vgroupLastPadsThreshold.reserve(Mapper::NREGIONS);
+
+  std::transform(tgroupPads.begin(), tgroupPads.end(), std::back_inserter(vgroupPads), &boost::lexical_cast<int, std::string>);
+  std::transform(tgroupRows.begin(), tgroupRows.end(), std::back_inserter(vgroupRows), &boost::lexical_cast<int, std::string>);
+  std::transform(tgroupLastRowsThreshold.begin(), tgroupLastRowsThreshold.end(), std::back_inserter(vgroupLastRowsThreshold), &boost::lexical_cast<int, std::string>);
+  std::transform(tgroupLastPadsThreshold.begin(), tgroupLastPadsThreshold.end(), std::back_inserter(vgroupLastPadsThreshold), &boost::lexical_cast<int, std::string>);
+
+  if (vgroupPads.size() == 1) {
+    vgroupPads = std::vector<unsigned char>(Mapper::NREGIONS, vgroupPads.front());
+  } else if (vgroupPads.size() != Mapper::NREGIONS) {
+    LOGP(error, "wrong number of parameters inserted for groupPads (n={}). Number should be 1 or {}", vgroupPads.size(), Mapper::NREGIONS);
+  }
+
+  if (vgroupRows.size() == 1) {
+    vgroupRows = std::vector<unsigned char>(Mapper::NREGIONS, vgroupRows.front());
+  } else if (vgroupRows.size() != Mapper::NREGIONS) {
+    LOGP(error, "wrong number of parameters inserted for groupRows (n={}). Number should be 1 or {}", vgroupRows.size(), Mapper::NREGIONS);
+  }
+
+  if (vgroupLastRowsThreshold.size() == 1) {
+    vgroupLastRowsThreshold = std::vector<unsigned char>(Mapper::NREGIONS, vgroupLastRowsThreshold.front());
+  } else if (vgroupLastRowsThreshold.size() != Mapper::NREGIONS) {
+    LOGP(error, "wrong number of parameters inserted for groupLastRowsThreshold (n={}). Number should be 1 or {}", vgroupLastRowsThreshold.size(), Mapper::NREGIONS);
+  }
+
+  if (vgroupLastPadsThreshold.size() == 1) {
+    vgroupLastPadsThreshold = std::vector<unsigned char>(Mapper::NREGIONS, vgroupLastPadsThreshold.front());
+  } else if (vgroupLastPadsThreshold.size() != Mapper::NREGIONS) {
+    LOGP(error, "wrong number of parameters inserted for groupLastPadsThreshold (n={}). Number should be 1 or {}", vgroupLastPadsThreshold.size(), Mapper::NREGIONS);
+  }
+
+  for (int i = 0; i < Mapper::NREGIONS; ++i) {
+    o2::conf::ConfigurableParam::setValue<unsigned char>("TPCIDCGroupParam", fmt::format("groupPads[{}]", i).data(), vgroupPads[i]);
+    o2::conf::ConfigurableParam::setValue<unsigned char>("TPCIDCGroupParam", fmt::format("groupRows[{}]", i).data(), vgroupRows[i]);
+    o2::conf::ConfigurableParam::setValue<unsigned char>("TPCIDCGroupParam", fmt::format("groupLastRowsThreshold[{}]", i).data(), vgroupLastRowsThreshold[i]);
+    o2::conf::ConfigurableParam::setValue<unsigned char>("TPCIDCGroupParam", fmt::format("groupLastPadsThreshold[{}]", i).data(), vgroupLastPadsThreshold[i]);
+  }
+}

--- a/Detectors/TPC/calibration/src/IDCGroupingParameter.cxx
+++ b/Detectors/TPC/calibration/src/IDCGroupingParameter.cxx
@@ -11,8 +11,7 @@
 
 #include "TPCCalibration/IDCGroupingParameter.h"
 #include "Framework/Logger.h"
-#include <boost/lexical_cast.hpp>
-#include <boost/tokenizer.hpp>
+#include "Algorithm/RangeTokenizer.h"
 
 using namespace o2::tpc;
 O2ParamImpl(o2::tpc::ParameterIDCGroup);
@@ -20,47 +19,31 @@ O2ParamImpl(o2::tpc::ParameterIDCCompression);
 
 void o2::tpc::ParameterIDCGroup::setGroupingParameterFromString(const std::string sgroupPads, const std::string sgroupRows, const std::string sgroupLastRowsThreshold, const std::string sgroupLastPadsThreshold)
 {
-  // convert input string to std::vector<unsigned char>
-  const boost::char_separator<char> sep(","); /// char separator for the tokenizer
-  const boost::tokenizer<boost::char_separator<char>> tgroupPads(sgroupPads, sep);
-  const boost::tokenizer<boost::char_separator<char>> tgroupRows(sgroupRows, sep);
-  const boost::tokenizer<boost::char_separator<char>> tgroupLastRowsThreshold(sgroupLastRowsThreshold, sep);
-  const boost::tokenizer<boost::char_separator<char>> tgroupLastPadsThreshold(sgroupLastPadsThreshold, sep);
-
-  std::vector<unsigned char> vgroupPads;
-  std::vector<unsigned char> vgroupRows;
-  std::vector<unsigned char> vgroupLastRowsThreshold;
-  std::vector<unsigned char> vgroupLastPadsThreshold;
-  vgroupPads.reserve(Mapper::NREGIONS);
-  vgroupRows.reserve(Mapper::NREGIONS);
-  vgroupLastRowsThreshold.reserve(Mapper::NREGIONS);
-  vgroupLastPadsThreshold.reserve(Mapper::NREGIONS);
-
-  std::transform(tgroupPads.begin(), tgroupPads.end(), std::back_inserter(vgroupPads), &boost::lexical_cast<int, std::string>);
-  std::transform(tgroupRows.begin(), tgroupRows.end(), std::back_inserter(vgroupRows), &boost::lexical_cast<int, std::string>);
-  std::transform(tgroupLastRowsThreshold.begin(), tgroupLastRowsThreshold.end(), std::back_inserter(vgroupLastRowsThreshold), &boost::lexical_cast<int, std::string>);
-  std::transform(tgroupLastPadsThreshold.begin(), tgroupLastPadsThreshold.end(), std::back_inserter(vgroupLastPadsThreshold), &boost::lexical_cast<int, std::string>);
+  auto vgroupPads = o2::RangeTokenizer::tokenize<int>(sgroupPads);
+  auto vgroupRows = o2::RangeTokenizer::tokenize<int>(sgroupRows);
+  auto vgroupLastRowsThreshold = o2::RangeTokenizer::tokenize<int>(sgroupLastRowsThreshold);
+  auto vgroupLastPadsThreshold = o2::RangeTokenizer::tokenize<int>(sgroupLastPadsThreshold);
 
   if (vgroupPads.size() == 1) {
-    vgroupPads = std::vector<unsigned char>(Mapper::NREGIONS, vgroupPads.front());
+    vgroupPads = std::vector<int>(Mapper::NREGIONS, vgroupPads.front());
   } else if (vgroupPads.size() != Mapper::NREGIONS) {
     LOGP(error, "wrong number of parameters inserted for groupPads (n={}). Number should be 1 or {}", vgroupPads.size(), Mapper::NREGIONS);
   }
 
   if (vgroupRows.size() == 1) {
-    vgroupRows = std::vector<unsigned char>(Mapper::NREGIONS, vgroupRows.front());
+    vgroupRows = std::vector<int>(Mapper::NREGIONS, vgroupRows.front());
   } else if (vgroupRows.size() != Mapper::NREGIONS) {
     LOGP(error, "wrong number of parameters inserted for groupRows (n={}). Number should be 1 or {}", vgroupRows.size(), Mapper::NREGIONS);
   }
 
   if (vgroupLastRowsThreshold.size() == 1) {
-    vgroupLastRowsThreshold = std::vector<unsigned char>(Mapper::NREGIONS, vgroupLastRowsThreshold.front());
+    vgroupLastRowsThreshold = std::vector<int>(Mapper::NREGIONS, vgroupLastRowsThreshold.front());
   } else if (vgroupLastRowsThreshold.size() != Mapper::NREGIONS) {
     LOGP(error, "wrong number of parameters inserted for groupLastRowsThreshold (n={}). Number should be 1 or {}", vgroupLastRowsThreshold.size(), Mapper::NREGIONS);
   }
 
   if (vgroupLastPadsThreshold.size() == 1) {
-    vgroupLastPadsThreshold = std::vector<unsigned char>(Mapper::NREGIONS, vgroupLastPadsThreshold.front());
+    vgroupLastPadsThreshold = std::vector<int>(Mapper::NREGIONS, vgroupLastPadsThreshold.front());
   } else if (vgroupLastPadsThreshold.size() != Mapper::NREGIONS) {
     LOGP(error, "wrong number of parameters inserted for groupLastPadsThreshold (n={}). Number should be 1 or {}", vgroupLastPadsThreshold.size(), Mapper::NREGIONS);
   }

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCFLPIDCSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCFLPIDCSpec.h
@@ -74,7 +74,7 @@ class TPCFLPIDCDevice : public o2::framework::Task
       for (const auto& cru : mCRUs) {
         const CRU cruTmp(cru);
         const unsigned int reg = cruTmp.region();
-        mIDCStruct.mIDCs.emplace(cru, IDCAverageGroup<IDCAverageGroupCRU>(paramIDCGroup.GroupPads[reg], paramIDCGroup.GroupRows[reg], paramIDCGroup.GroupLastRowsThreshold[reg], paramIDCGroup.GroupLastPadsThreshold[reg], reg, cruTmp.sector()));
+        mIDCStruct.mIDCs.emplace(cru, IDCAverageGroup<IDCAverageGroupCRU>(paramIDCGroup.groupPads[reg], paramIDCGroup.groupRows[reg], paramIDCGroup.groupLastRowsThreshold[reg], paramIDCGroup.groupLastPadsThreshold[reg], paramIDCGroup.groupPadsSectorEdges, reg, cruTmp.sector()));
       }
     }
 

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCFactorizeIDCSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCFactorizeIDCSpec.h
@@ -279,7 +279,7 @@ DataProcessorSpec getTPCFactorizeIDCSpec(const int lane, const std::vector<uint3
     fmt::format("tpc-factorize-idc-{:02}", lane).data(),
     inputSpecs,
     outputSpecs,
-    AlgorithmSpec{adaptFromTask<TPCFactorizeIDCSpec<Type>>(crus, timeframes, timeframesDeltaIDC, groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold, compression, debug, senddebug)},
+    AlgorithmSpec{adaptFromTask<TPCFactorizeIDCSpec<Type>>(crus, timeframes, timeframesDeltaIDC, groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold, groupPadsSectorEdges, compression, debug, senddebug)},
     Options{{"ccdb-uri", VariantType::String, o2::base::NameConf::getCCDBServer(), {"URI for the CCDB access."}},
             {"update-not-grouping-parameter", VariantType::Bool, false, {"Do NOT Update/Writing grouping parameters to CCDB."}}}}; // end DataProcessorSpec
   spec.rank = lane;

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCFourierTransformAggregatorSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCFourierTransformAggregatorSpec.h
@@ -74,8 +74,8 @@ class TPCFourierTransformAggregatorSpec : public o2::framework::Task
     }
 
     if (mProcessedTFs == mTimeFrames) {
-      mTFRange[1] = getCurrentTF(pc); // set the TF for last aggregated TF
-      mProcessedTFs = 0;              // reset processed TFs for next aggregation interval
+      mTFRange[1] = getCurrentTF(pc) + 1; // set the TF for last aggregated TF
+      mProcessedTFs = 0;                  // reset processed TFs for next aggregation interval
 
       // perform fourier transform of 1D-IDCs
       auto intervals = mOneDIDCAggregator.getIntegrationIntervalsPerTF();

--- a/Detectors/TPC/workflow/src/tpc-factorize-idc.cxx
+++ b/Detectors/TPC/workflow/src/tpc-factorize-idc.cxx
@@ -48,6 +48,10 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"crus", VariantType::String, cruDefault.c_str(), {"List of CRUs, comma separated ranges, e.g. 0-3,7,9-15"}},
     {"compression", VariantType::Int, 1, {"compression of DeltaIDC: 0 -> No, 1 -> Medium (data compression ratio 2), 2 -> High (data compression ratio ~6)"}},
     {"input-lanes", VariantType::Int, 2, {"Number of parallel pipelines which were set in the TPCDistributeIDCSpec device."}},
+    {"groupPads", VariantType::String, "7,7,7,7,6,6,6,6,5,5", {"number of pads in a row which will be grouped per region"}},
+    {"groupRows", VariantType::String, "5,5,5,5,4,4,4,4,3,3", {"number of pads in row direction which will be grouped per region"}},
+    {"groupLastRowsThreshold", VariantType::String, "3,3,3,3,2,2,2,2,2,2", {"set threshold in row direction for merging the last group to the previous group per region"}},
+    {"groupLastPadsThreshold", VariantType::String, "3,3,3,3,2,2,2,2,1,1", {"set threshold in pad direction for merging the last group to the previous group per region"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings (e.g. for pp 50kHz: 'TPCIDCCompressionParam.MaxIDCDeltaValue=15;')"}}};
 
   std::swap(workflowOptions, options);
@@ -58,6 +62,12 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 WorkflowSpec defineDataProcessing(ConfigContext const& config)
 {
   using namespace o2::tpc;
+
+  const std::string sgroupPads = config.options().get<std::string>("groupPads");
+  const std::string sgroupRows = config.options().get<std::string>("groupRows");
+  const std::string sgroupLastRowsThreshold = config.options().get<std::string>("groupLastRowsThreshold");
+  const std::string sgroupLastPadsThreshold = config.options().get<std::string>("groupLastPadsThreshold");
+  ParameterIDCGroup::setGroupingParameterFromString(sgroupPads, sgroupRows, sgroupLastRowsThreshold, sgroupLastPadsThreshold);
 
   // set up configuration
   o2::conf::ConfigurableParam::updateFromFile(config.options().get<std::string>("configFile"));

--- a/Detectors/TPC/workflow/src/tpc-flp-idc.cxx
+++ b/Detectors/TPC/workflow/src/tpc-flp-idc.cxx
@@ -14,7 +14,6 @@
 #include <string>
 #include "Algorithm/RangeTokenizer.h"
 #include "Framework/WorkflowSpec.h"
-#include "Framework/Logger.h"
 #include "Framework/ConfigParamSpec.h"
 #include "Framework/CompletionPolicy.h"
 #include "Framework/CompletionPolicyHelpers.h"
@@ -23,9 +22,8 @@
 #include "TPCBase/CRU.h"
 #include "TPCBase/Mapper.h"
 #include "Framework/Variant.h"
-#include <boost/lexical_cast.hpp>
-#include <boost/tokenizer.hpp>
 #include "TPCCalibration/IDCAverageGroup.h"
+#include "TPCCalibration/IDCGroupingParameter.h"
 
 using namespace o2::framework;
 
@@ -86,58 +84,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
   const std::string sgroupRows = config.options().get<std::string>("groupRows");
   const std::string sgroupLastRowsThreshold = config.options().get<std::string>("groupLastRowsThreshold");
   const std::string sgroupLastPadsThreshold = config.options().get<std::string>("groupLastPadsThreshold");
-
-  // convert input string to std::vector<unsigned char>
-  const boost::char_separator<char> sep(","); /// char separator for the tokenizer
-  const boost::tokenizer<boost::char_separator<char>> tgroupPads(sgroupPads, sep);
-  const boost::tokenizer<boost::char_separator<char>> tgroupRows(sgroupRows, sep);
-  const boost::tokenizer<boost::char_separator<char>> tgroupLastRowsThreshold(sgroupLastRowsThreshold, sep);
-  const boost::tokenizer<boost::char_separator<char>> tgroupLastPadsThreshold(sgroupLastPadsThreshold, sep);
-
-  std::vector<unsigned char> vgroupPads;
-  std::vector<unsigned char> vgroupRows;
-  std::vector<unsigned char> vgroupLastRowsThreshold;
-  std::vector<unsigned char> vgroupLastPadsThreshold;
-  vgroupPads.reserve(Mapper::NREGIONS);
-  vgroupRows.reserve(Mapper::NREGIONS);
-  vgroupLastRowsThreshold.reserve(Mapper::NREGIONS);
-  vgroupLastPadsThreshold.reserve(Mapper::NREGIONS);
-
-  std::transform(tgroupPads.begin(), tgroupPads.end(), std::back_inserter(vgroupPads), &boost::lexical_cast<int, std::string>);
-  std::transform(tgroupRows.begin(), tgroupRows.end(), std::back_inserter(vgroupRows), &boost::lexical_cast<int, std::string>);
-  std::transform(tgroupLastRowsThreshold.begin(), tgroupLastRowsThreshold.end(), std::back_inserter(vgroupLastRowsThreshold), &boost::lexical_cast<int, std::string>);
-  std::transform(tgroupLastPadsThreshold.begin(), tgroupLastPadsThreshold.end(), std::back_inserter(vgroupLastPadsThreshold), &boost::lexical_cast<int, std::string>);
-
-  if (vgroupPads.size() == 1) {
-    vgroupPads = std::vector<unsigned char>(Mapper::NREGIONS, vgroupPads.front());
-  } else if (vgroupPads.size() != Mapper::NREGIONS) {
-    LOGP(error, "wrong number of parameters inserted for groupPads (n={}). Number should be 1 or {}", vgroupPads.size(), Mapper::NREGIONS);
-  }
-
-  if (vgroupRows.size() == 1) {
-    vgroupRows = std::vector<unsigned char>(Mapper::NREGIONS, vgroupRows.front());
-  } else if (vgroupRows.size() != Mapper::NREGIONS) {
-    LOGP(error, "wrong number of parameters inserted for groupRows (n={}). Number should be 1 or {}", vgroupRows.size(), Mapper::NREGIONS);
-  }
-
-  if (vgroupLastRowsThreshold.size() == 1) {
-    vgroupLastRowsThreshold = std::vector<unsigned char>(Mapper::NREGIONS, vgroupLastRowsThreshold.front());
-  } else if (vgroupLastRowsThreshold.size() != Mapper::NREGIONS) {
-    LOGP(error, "wrong number of parameters inserted for groupLastRowsThreshold (n={}). Number should be 1 or {}", vgroupLastRowsThreshold.size(), Mapper::NREGIONS);
-  }
-
-  if (vgroupLastPadsThreshold.size() == 1) {
-    vgroupLastPadsThreshold = std::vector<unsigned char>(Mapper::NREGIONS, vgroupLastPadsThreshold.front());
-  } else if (vgroupLastPadsThreshold.size() != Mapper::NREGIONS) {
-    LOGP(error, "wrong number of parameters inserted for groupLastPadsThreshold (n={}). Number should be 1 or {}", vgroupLastPadsThreshold.size(), Mapper::NREGIONS);
-  }
-
-  for (int i = 0; i < Mapper::NREGIONS; ++i) {
-    o2::conf::ConfigurableParam::setValue<unsigned char>("TPCIDCGroupParam", fmt::format("GroupPads[{}]", i).data(), vgroupPads[i]);
-    o2::conf::ConfigurableParam::setValue<unsigned char>("TPCIDCGroupParam", fmt::format("GroupRows[{}]", i).data(), vgroupRows[i]);
-    o2::conf::ConfigurableParam::setValue<unsigned char>("TPCIDCGroupParam", fmt::format("GroupLastRowsThreshold[{}]", i).data(), vgroupLastRowsThreshold[i]);
-    o2::conf::ConfigurableParam::setValue<unsigned char>("TPCIDCGroupParam", fmt::format("GroupLastPadsThreshold[{}]", i).data(), vgroupLastPadsThreshold[i]);
-  }
+  ParameterIDCGroup::setGroupingParameterFromString(sgroupPads, sgroupRows, sgroupLastRowsThreshold, sgroupLastPadsThreshold);
 
   // set up configuration
   o2::conf::ConfigurableParam::updateFromFile(config.options().get<std::string>("configFile"));


### PR DESCRIPTION
other changes
- [drawing grouping information on debug plots](https://github.com/AliceO2Group/AliceO2/files/7641329/grouping_rows_2_2_2_3_3_3_2_3_2_2_pads_5_6_7_9_4_5_6_7_11_16_rowThr_3_3_3_3_2_2_2_2_2_2_padThr_1_1_1_1_1_1_1_1_1_1_ovRows-0_ovPads-0.pdf)
- Moving helper function for setting grouping parameters from string
- Renaming members in struct (coding conventions)