### PR TITLE
Minor fixes on Global Reader and sim_challenge.sh

### DIFF
--- a/Detectors/GlobalTracking/src/MatchGlobalFwd.cxx
+++ b/Detectors/GlobalTracking/src/MatchGlobalFwd.cxx
@@ -410,9 +410,9 @@ void MatchGlobalFwd::ROFMatch(int MFTROFId, int firstMCHROFId, int lastMCHROFId)
 
   } // /loop over MCH tracks seeds
 
-  LOG(info) << "Finished matching MFT ROF " << MFTROFId << ": " << nMFTTracks << " MFT tracks and " << nMCHTracks << "  MCH Tracks.";
+  LOG(debug) << "Finished matching MFT ROF " << MFTROFId << ": " << nMFTTracks << " MFT tracks and " << nMCHTracks << "  MCH Tracks.";
   if (mMCTruthON) {
-    LOG(info) << "   nFakes = " << nFakes << " nTrue = " << nTrue;
+    LOG(debug) << "   nFakes = " << nFakes << " nTrue = " << nTrue;
   }
 }
 

--- a/Detectors/GlobalTrackingWorkflow/helpers/src/GlobalTrackClusterReader.cxx
+++ b/Detectors/GlobalTrackingWorkflow/helpers/src/GlobalTrackClusterReader.cxx
@@ -50,7 +50,10 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   if (!cfgc.helpOnCommandLine() && srcTrk.none() && srcCl.none()) {
     throw std::runtime_error("no tracks or clusters requested");
   }
-  InputHelper::addInputSpecs(cfgc, specs, srcCl, srcTrk, srcTrk, useMC);
+
+  auto srcMtc = srcTrk & ~GlobalTrackID::getSourceMask(GlobalTrackID::MFTMCH); // Do not request MFTMCH matches
+
+  InputHelper::addInputSpecs(cfgc, specs, srcCl, srcMtc, srcTrk, useMC);
 
   // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
   o2::raw::HBFUtilsInitializer hbfIni(cfgc, specs);

--- a/prodtests/sim_challenge.sh
+++ b/prodtests/sim_challenge.sh
@@ -237,6 +237,6 @@ if [ "$doreco" == "1" ]; then
   echo "Return status of CPV reconstruction: $?"
 
   echo "Producing AOD"
-  taskwrapper aod.log o2-aod-producer-workflow --aod-writer-keep dangling --aod-writer-resfile "AO2D" --aod-writer-resmode UPDATE --aod-timeframe-id 1
+  taskwrapper aod.log o2-aod-producer-workflow $gloOpt --aod-writer-keep dangling --aod-writer-resfile "AO2D" --aod-writer-resmode UPDATE --aod-timeframe-id 1
   echo "Return status of AOD production: $?"
 fi


### PR DESCRIPTION
- GlobalTrackClusterReader: filter MFTMCH matches (only tracks are of general interest and produced by default)
- sim_challenge: increase SHM size on aod-producer-workflow
- GlobalFwdMatcher: Reduce verbosity