### PR TITLE
Change URL of FIT LUTs to <DET>/Config/LookupTable

### DIFF
--- a/DataFormats/Detectors/FIT/FDD/include/DataFormatsFDD/LookUpTable.h
+++ b/DataFormats/Detectors/FIT/FDD/include/DataFormatsFDD/LookUpTable.h
@@ -215,7 +215,7 @@ class SingleLUT : public LUT
 
  public:
   static constexpr char sDetectorName[] = "FDD";
-  static constexpr char sDefaultLUTpath[] = "FDD/LookUpTable";
+  static constexpr char sDefaultLUTpath[] = "FDD/Config/LookupTable";
   inline static std::string sCurrentCCDBpath = "";
   inline static std::string sCurrentLUTpath = sDefaultLUTpath;
   //Before instance() call, setup url and path

--- a/DataFormats/Detectors/FIT/FDD/include/DataFormatsFDD/LookUpTable.h
+++ b/DataFormats/Detectors/FIT/FDD/include/DataFormatsFDD/LookUpTable.h
@@ -233,7 +233,6 @@ class SingleLUT : public LUT
 } //namespace new_lut
 
 using SingleLUT = new_lut::SingleLUT<o2::fit::LookupTableBase<>>;
-//using SingleLUT = deprecated::SingleLUT;
 
 } // namespace fdd
 } // namespace o2

--- a/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/LookUpTable.h
+++ b/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/LookUpTable.h
@@ -372,7 +372,7 @@ class SingleLUT : public LUT
 
  public:
   static constexpr char sDetectorName[] = "FT0";
-  static constexpr char sDefaultLUTpath[] = "FT0/LookUpTableNew";
+  static constexpr char sDefaultLUTpath[] = "FT0/Config/LookupTable";
   inline static std::string sCurrentCCDBpath = "";
   inline static std::string sCurrentLUTpath = sDefaultLUTpath;
   //Before instance() call, setup url and path

--- a/DataFormats/Detectors/FIT/FV0/include/DataFormatsFV0/LookUpTable.h
+++ b/DataFormats/Detectors/FIT/FV0/include/DataFormatsFV0/LookUpTable.h
@@ -211,7 +211,7 @@ class SingleLUT : public LUT
 
  public:
   static constexpr char sDetectorName[] = "FV0";
-  static constexpr char sDefaultLUTpath[] = "FV0/LookUpTable";
+  static constexpr char sDefaultLUTpath[] = "FV0/Config/LookupTable";
   inline static std::string sCurrentCCDBpath = "";
   inline static std::string sCurrentLUTpath = sDefaultLUTpath;
   //Before instance() call, setup url and path


### PR DESCRIPTION
Latest objects from old paths `FDD/LookUpTable`, `FT0/LookUpTableNew` and `FV0/LookUpTable` are uploaded to 
`FDD/Config/LookupTable`, `FT0/Config/LookupTable` and `FV0/Config/LookupTable`
on both `http://alice-ccdb.cern.ch` and `http://ccdb-test.cern.ch:8080`