### PR TITLE
Do not have local ccdb URL parameters in configKeyValues initialized from NameConf

### DIFF
--- a/Common/SimConfig/include/SimConfig/DigiParams.h
+++ b/Common/SimConfig/include/SimConfig/DigiParams.h
@@ -27,7 +27,6 @@ namespace conf
 // Global parameters for digitization
 struct DigiParams : public o2::conf::ConfigurableParamHelper<DigiParams> {
 
-  std::string ccdb = o2::base::NameConf::getCCDBServer();
   std::string digitizationgeometry = "";              // with with geometry file to digitize -> leave empty as this needs to be filled by the digitizer workflow
   std::string grpfile = "";                           // which GRP file to use --> leave empty as this needs to be filled by the digitizer workflow
   bool mctruth = true;                                // whether to create labels

--- a/Detectors/CPV/base/include/CPVBase/CPVSimParams.h
+++ b/Detectors/CPV/base/include/CPVBase/CPVSimParams.h
@@ -24,8 +24,6 @@ namespace cpv
 // (mostly used in GEANT stepping and Digitizer)
 struct CPVSimParams : public o2::conf::ConfigurableParamHelper<CPVSimParams> {
 
-  std::string mCCDBPath = o2::base::NameConf::getCCDBServer(); ///< use "localtest" to avoid connecting ccdb server, otherwise use ccdb-test.cern.ch
-
   //Parameters used in conversion of deposited energy to APD response
   int mnCellX = 128;
   int mnCellZ = 60;

--- a/Detectors/CPV/simulation/src/Digitizer.cxx
+++ b/Detectors/CPV/simulation/src/Digitizer.cxx
@@ -28,15 +28,14 @@ using namespace o2::cpv;
 //_______________________________________________________________________
 void Digitizer::init()
 {
-  LOG(info) << "CPVDigitizer::init() : CCDB Url = " << o2::cpv::CPVSimParams::Instance().mCCDBPath.data();
-  if (o2::cpv::CPVSimParams::Instance().mCCDBPath.compare("localtest") == 0) {
+  LOG(info) << "CPVDigitizer::init() : CCDB Url = " << o2::base::NameConf::getCCDBServer();
+  if (o2::base::NameConf::getCCDBServer().compare("localtest") == 0) {
     mCalibParams = new CalibParams(1); // test default calibration
     mPedestals = new Pedestals(1);     // test default pedestals
     mBadMap = new BadChannelMap(1);    // test default bad channels
     LOG(info) << "[CPVDigitizer] No reading calibration from ccdb requested, set default";
   } else {
     auto& ccdbMgr = o2::ccdb::BasicCCDBManager::instance();
-    ccdbMgr.setURL(o2::cpv::CPVSimParams::Instance().mCCDBPath.data());
     bool isCcdbReachable = ccdbMgr.isHostReachable(); //if host is not reachable we can use only dummy calibration
     if (!isCcdbReachable) {
       LOG(fatal) << "[CPVDigitizer] CCDB Host is not reachable!!!";

--- a/Detectors/ZDC/simulation/src/digi2raw.cxx
+++ b/Detectors/ZDC/simulation/src/digi2raw.cxx
@@ -87,13 +87,7 @@ int main(int argc, char** argv)
   }
   o2::conf::ConfigurableParam::updateFromString(vm["configKeyValues"].as<std::string>());
 
-  std::string ccdb_url = o2::base::NameConf::getCCDBServer();
-  auto& dopt = o2::conf::DigiParams::Instance();
-  std::string ccdbHost = dopt.ccdb;
-  if (ccdb_url.length() > 0) {
-    ccdbHost = ccdb_url;
-    LOG(info) << "CCDB url set to " << ccdb_url;
-  }
+  std::string ccdbHost = o2::base::NameConf::getCCDBServer();
   LOG(info) << "CCDB url " << ccdbHost;
   digi2raw(vm["input-file"].as<std::string>(),
            vm["output-dir"].as<std::string>(),

--- a/Steer/DigitizerWorkflow/src/ZDCDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/ZDCDigitizerSpec.cxx
@@ -52,7 +52,7 @@ class ZDCDPLDigitizerTask : public o2::base::BaseDPLDigitizer
 
     auto& dopt = o2::conf::DigiParams::Instance();
 
-    mDigitizer.setCCDBServer(dopt.ccdb);
+    mDigitizer.setCCDBServer(o2::base::NameConf::getCCDBServer());
     auto enableHitInfo = ic.options().get<bool>("enable-hit-info");
     mDigitizer.setMaskTriggerBits(!enableHitInfo);
     mDigitizer.setSkipMCLabels(not mUseMC);


### PR DESCRIPTION
@shahor02 : This scheme of having one ConfigurableParam initialized from another one is conceptionally broken. It becomes a race condition which one is populated first, thus it is not well defined if the default value is taken, or the value after parsing the `--configurableParam` option.

This PR does away with ccdb settings in other configurableParams and uses the NameConf::CCDBServer for all.
I am not sure if this is the correct thing to do. It basically means that within one processor one cannot access different CCDB servers. But I don't see another way right now that is somewhat clean.
This will hopefully be solved once we have the proper CCDB API.

@sawenzel : In general, perhaps we should add a protection that no instance can be created before the parsing has happened?
Some days ago I also had a similar problem that someone was caching a value from a ConfigurableParam in a static variable, and that static variable was initialized at application startup time from the instace before the command line arguments were passed, so it hold the default value, and I could not set it via --configKeyValues. We should avoid such misleading behavior.