### PR TITLE
DPL Analysis: use internal selection cache for partitions

### DIFF
--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -492,30 +492,25 @@ struct Service {
 };
 
 template <typename T>
-o2::soa::Filtered<T>* getTableFromFilter(const T& table, gandiva::Selection& selection)
+auto getTableFromFilter(const T& table, soa::SelectionVector&& selection)
 {
   if constexpr (soa::is_soa_filtered_t<std::decay_t<T>>::value) {
-    return new o2::soa::Filtered<T>{{table}, selection};
+    return std::make_unique<o2::soa::Filtered<T>>(std::vector{table}, std::forward<soa::SelectionVector>(selection));
   } else {
-    return new o2::soa::Filtered<T>{{table.asArrowTable()}, selection};
+    return std::make_unique<o2::soa::Filtered<T>>(std::vector{table.asArrowTable()}, std::forward<soa::SelectionVector>(selection));
   }
 }
 
 template <typename T>
 struct Partition {
-  Partition(expressions::Node&& filter_) : filter{std::move(filter_)}
+  Partition(expressions::Node&& filter_) : filter{std::forward<expressions::Node>(filter_)}
   {
   }
 
-  void bindTable(T& table)
+  Partition(expressions::Node&& filter_, T const& table)
+    : filter{std::forward<expressions::Node>(filter_)}
   {
-    if (selection == nullptr) {
-      intializeCaches(table.asArrowTable()->schema());
-      selection = framework::expressions::createSelection(table.asArrowTable(), gfilter);
-    }
-    mFiltered.reset(getTableFromFilter(table, selection));
-    bindExternalIndices(&table);
-    getBoundToExternalIndices(table);
+    setTable(table);
   }
 
   void intializeCaches(std::shared_ptr<arrow::Schema> const& schema)
@@ -533,13 +528,10 @@ struct Partition {
     }
   }
 
-  void setTable(const T& table)
+  void setTable(T const& table)
   {
-    if (selection == nullptr) {
-      intializeCaches(table.asArrowTable()->schema());
-      selection = framework::expressions::createSelection(table.asArrowTable(), gfilter);
-    }
-    mFiltered.reset(getTableFromFilter(table, selection));
+    intializeCaches(table.asArrowTable()->schema());
+    mFiltered = getTableFromFilter(table, soa::selectionToVector(framework::expressions::createSelection(table.asArrowTable(), gfilter)));
   }
 
   template <typename... Ts>
@@ -565,14 +557,6 @@ struct Partition {
     }
   }
 
-  template <typename T2>
-  void getBoundToExternalIndices(T2& table)
-  {
-    if (mFiltered != nullptr) {
-      table.bindExternalIndices(mFiltered.get());
-    }
-  }
-
   void updatePlaceholders(InitContext& context)
   {
     expressions::updatePlaceholders(filter, context);
@@ -582,7 +566,6 @@ struct Partition {
   std::unique_ptr<o2::soa::Filtered<T>> mFiltered = nullptr;
   gandiva::NodePtr tree = nullptr;
   gandiva::FilterPtr gfilter = nullptr;
-  gandiva::Selection selection = nullptr;
 
   using iterator = typename o2::soa::Filtered<T>::iterator;
   using const_iterator = typename o2::soa::Filtered<T>::const_iterator;

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -528,6 +528,11 @@ struct Partition {
     }
   }
 
+  void inline bindTable(T const& table)
+  {
+    setTable(table);
+  }
+
   void setTable(T const& table)
   {
     intializeCaches(table.asArrowTable()->schema());

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -54,10 +54,6 @@ struct PartitionManager {
   static void updatePlaceholders(ANY&, InitContext&)
   {
   }
-
-  static void resetSelection(ANY&)
-  {
-  }
 };
 
 template <typename T>
@@ -90,20 +86,9 @@ struct PartitionManager<Partition<T>> {
     }
   }
 
-  template <typename... Ts>
-  static void getBoundToExternalIndices(Partition<T>& partition, Ts&... tables)
-  {
-    partition.getBoundToExternalIndices(tables...);
-  }
-
   static void updatePlaceholders(Partition<T>& partition, InitContext& context)
   {
     partition.updatePlaceholders(context);
-  }
-
-  static void resetSelection(Partition<T>& partition)
-  {
-    partition.selection = nullptr;
   }
 };
 

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -585,7 +585,6 @@ struct AnalysisDataProcessorBuilder {
       // single argument to process
       homogeneous_apply_refs([&groupingTable](auto& x) {
         PartitionManager<std::decay_t<decltype(x)>>::bindExternalIndices(x, &groupingTable);
-        PartitionManager<std::decay_t<decltype(x)>>::getBoundToExternalIndices(x, groupingTable);
         return true;
       },
                              task);
@@ -621,7 +620,6 @@ struct AnalysisDataProcessorBuilder {
         homogeneous_apply_refs([&x](auto& t) {
           PartitionManager<std::decay_t<decltype(t)>>::setPartition(t, x);
           PartitionManager<std::decay_t<decltype(t)>>::bindExternalIndices(t, &x);
-          PartitionManager<std::decay_t<decltype(t)>>::getBoundToExternalIndices(t, x);
           return true;
         },
                                task);
@@ -650,7 +648,6 @@ struct AnalysisDataProcessorBuilder {
           // bind partitions and grouping table
           homogeneous_apply_refs([&groupingTable](auto& x) {
             PartitionManager<std::decay_t<decltype(x)>>::bindExternalIndices(x, &groupingTable);
-            PartitionManager<std::decay_t<decltype(x)>>::getBoundToExternalIndices(x, groupingTable);
             return true;
           },
                                  task);
@@ -663,7 +660,6 @@ struct AnalysisDataProcessorBuilder {
         // bind partitions and grouping table
         homogeneous_apply_refs([&groupingTable](auto& x) {
           PartitionManager<std::decay_t<decltype(x)>>::bindExternalIndices(x, &groupingTable);
-          PartitionManager<std::decay_t<decltype(x)>>::getBoundToExternalIndices(x, groupingTable);
           return true;
         },
                                task);
@@ -942,7 +938,6 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
         },
         *task.get());
 
-      homogeneous_apply_refs([](auto&& x) { PartitionManager<std::decay_t<decltype(x)>>::resetSelection(x); return true; }, *task.get());
       homogeneous_apply_refs([&pc](auto&& x) { return OutputManager<std::decay_t<decltype(x)>>::finalize(pc, x); }, *task.get());
     };
   }};


### PR DESCRIPTION
* Use internal selection cache for partitions
* Use `std::make_unique` to prevent memory leak
* Remove redundant index binding (we never bind indices to partitions)