### PR TITLE
AOD: also keep particles marked as keepPhysics

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/MCUtils.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCUtils.h
@@ -33,6 +33,11 @@ class MCTrackNavigator
   /// (of which p needs to be a part itself). The container can be fetched via MCKinematicsReader.
   static bool isPhysicalPrimary(o2::MCTrack const& p, std::vector<o2::MCTrack> const& pcontainer);
 
+  /// return true of particle is to be kept for physics analysis in any case
+  /// (follows logic used in particle stack class
+  static bool isKeepPhysics(o2::MCTrack const& p, std::vector<o2::MCTrack> const& pcontainer);
+  static bool isFromPrimaryDecayChain(o2::MCTrack const& p, std::vector<o2::MCTrack> const& pcontainer);
+
   // some convenience functions for navigation
 
   /// Given an MCTrack p; Return the first primary mother particle in the upward parent chain (follow

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -53,6 +53,7 @@
 #include "SimulationDataFormat/MCEventLabel.h"
 #include "SimulationDataFormat/MCTrack.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
+#include "SimulationDataFormat/MCUtils.h"
 #include "GPUTPCGMMergedTrackHit.h"
 #include "TOFBase/Utils.h"
 #include "O2Version.h"
@@ -623,6 +624,14 @@ void AODProducerWorkflowDPL::fillMCParticlesTable(o2::steer::MCKinematicsReader&
       for (int particle = mcParticles.size() - 1; particle >= 0; particle--) {
         // we store all primary particles == particles put by generator
         if (mcParticles[particle].isPrimary()) {
+          mToStore[Triplet_t(source, event, particle)] = 1;
+          continue;
+        }
+        if (o2::mcutils::MCTrackNavigator::isPhysicalPrimary(mcParticles[particle], mcParticles)) {
+          mToStore[Triplet_t(source, event, particle)] = 1;
+          continue;
+        }
+        if (o2::mcutils::MCTrackNavigator::isKeepPhysics(mcParticles[particle], mcParticles)) {
           mToStore[Triplet_t(source, event, particle)] = 1;
           continue;
         }


### PR DESCRIPTION
This should fix the K0 -> pipi branching ratio analysis. Now also copying all particles
which were originally marked as "keepPhysics" in the MC stack treatment (this seems to be needed
in addition to isPhysicalPrimary()).