### PR TITLE
DPL: support VariantType::Dict in merged workflows

### DIFF
--- a/Framework/Core/include/Framework/VariantJSONHelpers.h
+++ b/Framework/Core/include/Framework/VariantJSONHelpers.h
@@ -375,6 +375,8 @@ void writeVariant(std::ostream& o, Variant const& v)
       writeArray2D(v.get<Array2D<type>>());
     } else if constexpr (isLabeledArray<V>()) {
       writeLabeledArray(v.get<LabeledArray<type>>());
+    } else if constexpr (V == VariantType::Dict) {
+      // nothing to do for dicts
     }
     w.EndObject();
   }
@@ -435,6 +437,8 @@ struct VariantJSONHelpers {
       case VariantType::LabeledArrayDouble:
         writeVariant<VariantType::LabeledArrayDouble>(o, v);
         break;
+      case VariantType::Dict:
+        writeVariant<VariantType::Dict>(o, v);
       default:
         break;
     }

--- a/Framework/Core/src/Variant.cxx
+++ b/Framework/Core/src/Variant.cxx
@@ -109,6 +109,9 @@ std::ostream& operator<<(std::ostream& oss, Variant const& val)
       break;
     case VariantType::Empty:
       break;
+    case VariantType::Dict:
+      oss << "{}";
+      break;
     default:
       oss << "undefined";
       break;

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -901,8 +901,8 @@ WorkflowParsingState WorkflowHelpers::verifyWorkflow(const o2::framework::Workfl
     for (auto& option : spec.options) {
       if (option.defaultValue.type() != VariantType::Empty &&
           option.type != option.defaultValue.type()) {
-        ss << "Mismatch between declared option type and default value type"
-           << " for " << option.name << " in DataProcessorSpec of "
+        ss << "Mismatch between declared option type (" << (int)option.type << ") and default value type (" << (int)option.defaultValue.type()
+           << ") for " << option.name << " in DataProcessorSpec of "
            << spec.name;
         throw std::runtime_error(ss.str());
       }

--- a/Framework/Core/src/WorkflowSerializationHelpers.cxx
+++ b/Framework/Core/src/WorkflowSerializationHelpers.cxx
@@ -376,6 +376,9 @@ struct WorkflowImporter : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
         case VariantType::LabeledArrayDouble:
           opt = std::make_unique<ConfigParamSpec>(optionName, optionType, VariantJSONHelpers::read<VariantType::LabeledArrayDouble>(is), HelpString{optionHelp}, optionKind);
           break;
+        case VariantType::Dict:
+          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, emptyDict(), HelpString{optionHelp}, optionKind);
+          break;
         default:
           opt = std::make_unique<ConfigParamSpec>(optionName, optionType, optionDefault, HelpString{optionHelp}, optionKind);
       }
@@ -840,6 +843,7 @@ void WorkflowSerializationHelpers::dump(std::ostream& out,
         case VariantType::LabeledArrayInt:
         case VariantType::LabeledArrayFloat:
         case VariantType::LabeledArrayDouble:
+        case VariantType::Dict:
           VariantJSONHelpers::write(oss, option.defaultValue);
           break;
         default:


### PR DESCRIPTION
While it's still not serialised correctly, this should
allow a placeholder dict to be provide and then filled from
e.g. AliECS