### PR TITLE
Use Root units for geometry and material construction

### DIFF
--- a/macro/o2sim.C
+++ b/macro/o2sim.C
@@ -93,6 +93,9 @@ FairRunSim* o2sim_init(bool asservice)
   run->SetMCEventHeader(header);
 
   // construct geometry / including magnetic field
+  auto flg = TGeoManager::LockDefaultUnits(false);
+  TGeoManager::SetDefaultUnits(TGeoManager::kRootUnits);
+  TGeoManager::LockDefaultUnits(flg);
   build_geometry(run);
 
   // setup generator


### PR DESCRIPTION
materials had wrong radiation length because TGeo
was using G4 units internally (probably introduced
without us knowing). Now switching explicitely back to Root units.