### PR TITLE
o2-sim: Introduce persistent aligned geometry

### DIFF
--- a/Common/SimConfig/include/SimConfig/DigiParams.h
+++ b/Common/SimConfig/include/SimConfig/DigiParams.h
@@ -27,7 +27,7 @@ namespace conf
 // Global parameters for digitization
 struct DigiParams : public o2::conf::ConfigurableParamHelper<DigiParams> {
 
-  std::string digitizationgeometry = "";              // with with geometry file to digitize -> leave empty as this needs to be filled by the digitizer workflow
+  std::string digitizationgeometry_prefix = "";       // with which geometry prefix we digitized -> leave empty as this needs to be filled by the digitizer workflow
   std::string grpfile = "";                           // which GRP file to use --> leave empty as this needs to be filled by the digitizer workflow
   bool mctruth = true;                                // whether to create labels
 

--- a/Common/SimConfig/include/SimConfig/SimConfig.h
+++ b/Common/SimConfig/include/SimConfig/SimConfig.h
@@ -115,6 +115,7 @@ class SimConfig
   int getNSimWorkers() const { return mConfigData.mSimWorkers; }
   bool isFilterOutNoHitEvents() const { return mConfigData.mFilterNoHitEvents; }
   bool asService() const { return mConfigData.mAsService; }
+  long getTimestamp() const { return mConfigData.mTimestamp; }
 
  private:
   SimConfigData mConfigData; //!

--- a/Common/Utils/include/CommonUtils/NameConf.h
+++ b/Common/Utils/include/CommonUtils/NameConf.h
@@ -69,6 +69,7 @@ class NameConf : public o2::conf::ConfigurableParamHelper<NameConf>
 
   // Filename to store geometry file
   static std::string getGeomFileName(const std::string_view prefix = "");
+  static std::string getAlignedGeomFileName(const std::string_view prefix = "");
 
   // Filename to store material LUT file
   static std::string getMatLUTFileName(const std::string_view prefix = "");
@@ -116,6 +117,7 @@ class NameConf : public o2::conf::ConfigurableParamHelper<NameConf>
   static constexpr std::string_view KINE_STRING = "Kine";               // hardcoded
   static constexpr std::string_view MCHEADER_STRING = "MCHeader";       // hardcoded
   static constexpr std::string_view GEOM_FILE_STRING = "geometry";
+  static constexpr std::string_view ALIGNEDGEOM_FILE_STRING = "geometry-aligned";
   static constexpr std::string_view CUT_FILE_STRING = "proc-cut";
   static constexpr std::string_view CONFIG_STRING = "configuration";
   static constexpr std::string_view ROOT_EXT_STRING = "root";

--- a/Common/Utils/src/NameConf.cxx
+++ b/Common/Utils/src/NameConf.cxx
@@ -42,6 +42,12 @@ std::string NameConf::getGeomFileName(const std::string_view prefix)
   return buildFileName(prefix, "_", STANDARDSIMPREFIX, GEOM_FILE_STRING, ROOT_EXT_STRING, Instance().mDirGeom);
 }
 
+// Filename to store geometry file
+std::string NameConf::getAlignedGeomFileName(const std::string_view prefix)
+{
+  return buildFileName(prefix, "_", STANDARDSIMPREFIX, ALIGNEDGEOM_FILE_STRING, ROOT_EXT_STRING, Instance().mDirGeom);
+}
+
 // Filename to store general run parameters (GRP)
 std::string NameConf::getCollisionContextFileName(const std::string_view prefix)
 {

--- a/Detectors/Base/include/DetectorsBase/GeometryManager.h
+++ b/Detectors/Base/include/DetectorsBase/GeometryManager.h
@@ -49,7 +49,9 @@ class GeometryManager : public TObject
 {
  public:
   ///< load geometry from file
-  static void loadGeometry(std::string_view geomFilePath = "", bool applyMisalignment = true);
+  ///< When applyMisalignedment == false --> read from unaligned file
+  ///< When preferAlignedFile == true and applyMisalignment == true : Prefer reading from existing aligned file
+  static void loadGeometry(std::string_view geomFilePath = "", bool applyMisalignment = true, bool preferAlignedFile = true);
   static bool isGeometryLoaded() { return gGeoManager != nullptr; }
   static void applyMisalignent(bool applyMisalignment = true);
 

--- a/Detectors/Base/include/DetectorsBase/GeometryManager.h
+++ b/Detectors/Base/include/DetectorsBase/GeometryManager.h
@@ -51,7 +51,7 @@ class GeometryManager : public TObject
   ///< load geometry from file
   ///< When applyMisalignedment == false --> read from unaligned file
   ///< When preferAlignedFile == true and applyMisalignment == true : Prefer reading from existing aligned file
-  static void loadGeometry(std::string_view geomFilePath = "", bool applyMisalignment = true, bool preferAlignedFile = true);
+  static void loadGeometry(std::string_view geomFilePath = "", bool applyMisalignment = true, bool preferAlignedFile = false);
   static bool isGeometryLoaded() { return gGeoManager != nullptr; }
   static void applyMisalignent(bool applyMisalignment = true);
 

--- a/Detectors/Base/src/BaseDPLDigitizer.cxx
+++ b/Detectors/Base/src/BaseDPLDigitizer.cxx
@@ -29,7 +29,7 @@ void BaseDPLDigitizer::init(o2::framework::InitContext& ic)
   // init basic stuff when this was asked for
   if (mNeedGeom) {
     LOG(info) << "Initializing geometry service";
-    o2::base::GeometryManager::loadGeometry(o2::conf::DigiParams::Instance().digitizationgeometry);
+    o2::base::GeometryManager::loadGeometry(o2::conf::DigiParams::Instance().digitizationgeometry_prefix, true, true /* read from existing aligned file */);
   }
 
   if (mNeedField) {

--- a/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
+++ b/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
@@ -399,8 +399,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   // update the digitization configuration with the right geometry file
   // we take the geometry from the first simPrefix (could actually check if they are
   // all compatible)
-  auto geomfilename = o2::base::NameConf::getGeomFileName(simPrefixes[0]);
-  ConfigurableParam::setValue("DigiParams.digitizationgeometry", geomfilename);
+  ConfigurableParam::setValue("DigiParams.digitizationgeometry_prefix", simPrefixes[0]);
   ConfigurableParam::setValue("DigiParams.grpfile", grpfile);
   LOG(info) << "MC-TRUTH " << !configcontext.options().get<bool>("disable-mc");
   bool mctruth = !configcontext.options().get<bool>("disable-mc");

--- a/Steer/src/O2MCApplication.cxx
+++ b/Steer/src/O2MCApplication.cxx
@@ -143,12 +143,9 @@ bool O2MCApplicationBase::MisalignGeometry()
     }
   }
 
-  // RS We want to store ideal geometry to be able to apply different alignments on the fly
-  // auto b = FairMCApplication::MisalignGeometry();
-
-  // we use this moment to stream our geometry (before other
-  // VMC engine dependent modifications are done)
-
+  // we stream out both unaligned geometry (to allow for
+  // dynamic post-alignment) as well as the aligned version
+  // which can be used by digitization etc. immediately
   auto& confref = o2::conf::SimConfig::Instance();
   auto geomfile = o2::base::NameConf::getGeomFileName(confref.getOutPrefix());
   // since in general the geometry is a CCDB object, it must be exported under the standard name
@@ -157,7 +154,11 @@ bool O2MCApplicationBase::MisalignGeometry()
 
   // apply alignment for included detectors AFTER exporting ideal geometry
   auto& aligner = o2::base::Aligner::Instance();
-  aligner.applyAlignment(0);
+  aligner.applyAlignment(confref.getTimestamp());
+
+  // export aligned geometry into different file
+  auto alignedgeomfile = o2::base::NameConf::getAlignedGeomFileName(confref.getOutPrefix());
+  gGeoManager->Export(alignedgeomfile.c_str());
 
   // return original return value of misalignment procedure
   return true;


### PR DESCRIPTION
We stream out an aligned version of the geometry file,
for direct use in digitization and other steps in the MC chain.
This prevents a lot of calls to CCDB and uncessary dynamic realignment.

Digitization is moved to using the new aligned geometry file.
We can think of doing same for other steps.

A couple of minor changes accompany this commit:
- use correct timestamp when aligning in o2-sim