### PR TITLE
TPC: change track params in dEdx calibration

### DIFF
--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/CalibdEdxCorrection.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/CalibdEdxCorrection.h
@@ -16,6 +16,7 @@
 #define ALICEO2_TPC_CALIBDEDXCORRECTION_H_
 
 #include "GPUCommonDef.h"
+#include <cmath>
 #ifndef GPUCA_GPUCODE_DEVICE
 #include <string_view>
 #endif
@@ -48,14 +49,14 @@ class CalibdEdxCorrection
     if (mDims < 0) {
       return 1;
     }
-
+    snp = abs(snp);
     const auto& p = mParams[stackIndex(stack, charge)];
     float corr = p[0];
 
     if (mDims > 0) {
-      corr += p[1] * tgl + p[2] * tgl * tgl;
+      corr += tgl * (p[1] + p[2] * tgl);
       if (mDims > 1) {
-        corr += p[3] * snp + p[4] * tgl * snp + p[5] * snp * snp;
+        corr += snp * (p[3] + p[4] * tgl + p[5] * snp);
       }
     }
 

--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/Defs.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/Defs.h
@@ -78,9 +78,14 @@ struct StackID {
   GEMstack type{};
 
   /// Single number identification for the stacks
-  GPUdi() int index() const
+  GPUdi() int getIndex() const
   {
     return sector + type * SECTORSPERSIDE * SIDES;
+  }
+  GPUdi() void setIndex(int index)
+  {
+    sector = index % (SECTORSPERSIDE * SIDES);
+    type = static_cast<GEMstack>((index / (SECTORSPERSIDE * SIDES)) % GEMSTACKSPERSECTOR);
   }
 };
 

--- a/Detectors/TPC/calibration/include/TPCCalibration/CalibdEdx.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/CalibdEdx.h
@@ -118,9 +118,11 @@ class CalibdEdx
   /// Save the histograms to a TTree.
   void writeTTree(std::string_view fileName) const;
 
- private:
-  constexpr static float mipScale = 1.0 / 50.0; ///< Target value for MIP dE/dx
+  constexpr static float mipScale = 1.0 / 50.0; ///< Inverse of target MIP dE/dx value
 
+  constexpr static std::array<float, 4> tglScale{1.9, 1.5, 1.22, 1.02}; ///< Max Tgl values for each ROC type
+
+ private:
   float mField = -5;                ///< Magnetic field in kG, used for track propagation
   bool mApplyCuts{true};            ///< Wether or not to apply tracks cuts
   TrackCuts mCuts{0.4, 0.6, 60};    ///< Cut values

--- a/Detectors/TPC/calibration/include/TPCCalibration/CalibratordEdx.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/CalibratordEdx.h
@@ -44,13 +44,13 @@ class CalibratordEdx final : public o2::calibration::TimeSlotCalibration<o2::tpc
  public:
   CalibratordEdx() = default;
 
-  void setHistParams(float mindEdx, float maxdEdx, int dEdxBins, int zBins, int angularBins)
+  void setHistParams(int dEdxBins, float mindEdx, float maxdEdx, int angularBins, float maxTgl)
   {
+    mdEdxBins = dEdxBins;
     mMindEdx = mindEdx;
     mMaxdEdx = maxdEdx;
-    mdEdxBins = dEdxBins;
-    mZBins = zBins;
     mAngularBins = angularBins;
+    mMaxTgl = maxTgl;
   }
   void setCuts(const TrackCuts& cuts) { mCuts = cuts; }
   void setField(float field) { mField = field; }
@@ -92,10 +92,10 @@ class CalibratordEdx final : public o2::calibration::TimeSlotCalibration<o2::tpc
 
  private:
   int mdEdxBins{};               ///< Number of dEdx bins
-  int mZBins{};                  ///< Number of Z bins
-  int mAngularBins{};            ///< Number of bins for angular data, like Tgl and Snp
   float mMindEdx{};              ///< Minimum value for the dEdx histograms
   float mMaxdEdx{};              ///< Maximum value for the dEdx histograms
+  int mAngularBins{};            ///< Number of bins for angular data, like Tgl and Snp
+  float mMaxTgl{};               ///< maximum absolute value for Tgl histograms
   int mMinEntries{};             ///< Minimum amount of tracks in each time slot, to get enough statics
   CalibdEdx::FitCuts mFitCuts{}; ///< Minimum entries per stack to perform a 1D and 2D fit
   float mField{};                ///< Magnetic field

--- a/Detectors/TPC/calibration/src/CalibratordEdx.cxx
+++ b/Detectors/TPC/calibration/src/CalibratordEdx.cxx
@@ -61,7 +61,7 @@ CalibratordEdx::Slot& CalibratordEdx::emplaceNewSlot(bool front, TFType tstart, 
   auto& cont = getSlots();
   auto& slot = front ? cont.emplace_front(tstart, tend) : cont.emplace_back(tstart, tend);
 
-  auto container = std::make_unique<CalibdEdx>(mMindEdx, mMaxdEdx, mdEdxBins, mZBins, mAngularBins);
+  auto container = std::make_unique<CalibdEdx>(mdEdxBins, mMindEdx, mMaxdEdx, mAngularBins, mMaxTgl);
   container->setApplyCuts(mApplyCuts);
   container->setCuts(mCuts);
   container->setFitCuts(mFitCuts);

--- a/Detectors/TPC/workflow/src/CalibratordEdxSpec.cxx
+++ b/Detectors/TPC/workflow/src/CalibratordEdxSpec.cxx
@@ -21,14 +21,15 @@
 // o2 includes
 #include "CCDB/CcdbApi.h"
 #include "CCDB/CcdbObjectInfo.h"
+#include "CommonUtils/NameConf.h"
 #include "DataFormatsTPC/TrackTPC.h"
 #include "DataFormatsParameters/GRPObject.h"
-#include "CommonUtils/NameConf.h"
 #include "DetectorsCalibration/Utils.h"
 #include "Framework/Task.h"
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/ConfigParamRegistry.h"
 #include "TPCCalibration/CalibratordEdx.h"
+#include "TPCWorkflow/ProcessingHelpers.h"
 
 using namespace o2::framework;
 
@@ -40,22 +41,23 @@ class CalibratordEdxDevice : public Task
  public:
   void init(framework::InitContext& ic) final
   {
-    const int slotLength = ic.options().get<int>("tf-per-slot");
-    const int maxDelay = ic.options().get<int>("max-delay");
-    const int minEntries = ic.options().get<int>("min-entries");
+    const auto slotLength = ic.options().get<int>("tf-per-slot");
+    const auto maxDelay = ic.options().get<int>("max-delay");
+    const auto minEntries = ic.options().get<int>("min-entries");
 
-    const int minEntriesSector = ic.options().get<int>("min-entries-sector");
-    const int minEntries1D = ic.options().get<int>("min-entries-1d");
-    const int minEntries2D = ic.options().get<int>("min-entries-2d");
+    const auto minEntriesSector = ic.options().get<int>("min-entries-sector");
+    const auto minEntries1D = ic.options().get<int>("min-entries-1d");
+    const auto minEntries2D = ic.options().get<int>("min-entries-2d");
 
-    const int dEdxBins = ic.options().get<int>("dedxbins");
-    const int zBins = ic.options().get<int>("zbins");
-    const int angularBins = ic.options().get<int>("angularbins");
-    const float mindEdx = ic.options().get<float>("min-dedx");
-    const float maxdEdx = ic.options().get<float>("max-dedx");
+    const auto dEdxBins = ic.options().get<int>("dedxbins");
+    const auto mindEdx = ic.options().get<float>("min-dedx");
+    const auto maxdEdx = ic.options().get<float>("max-dedx");
+    const auto angularBins = ic.options().get<int>("angularbins");
+    const auto maxTgl = ic.options().get<float>("max-tgl");
+    const auto zBins = ic.options().get<int>("zbins");
 
-    const bool dumpData = ic.options().get<bool>("file-dump");
-    float field = ic.options().get<float>("field");
+    const auto dumpData = ic.options().get<bool>("file-dump");
+    auto field = ic.options().get<float>("field");
 
     if (field <= -10.f) {
       const auto inputGRP = o2::base::NameConf::getGRPFileName();
@@ -67,8 +69,9 @@ class CalibratordEdxDevice : public Task
     }
 
     mCalibrator = std::make_unique<tpc::CalibratordEdx>();
-    mCalibrator->setHistParams(mindEdx, maxdEdx, dEdxBins, zBins, angularBins);
+    mCalibrator->setHistParams(dEdxBins, mindEdx, maxdEdx, angularBins, maxTgl);
     mCalibrator->setApplyCuts(false);
+
     mCalibrator->setFitCuts({minEntriesSector, minEntries1D, minEntries2D});
     mCalibrator->setField(field);
     mCalibrator->setMinEntries(minEntries);
@@ -87,7 +90,7 @@ class CalibratordEdxDevice : public Task
     const auto tracks = pc.inputs().get<gsl::span<tpc::TrackTPC>>("tracks");
 
     LOGP(info, "Processing TF {} with {} tracks", tfcounter, tracks.size());
-
+    mRunNumber = processing_helpers::getRunNumber(pc);
     mCalibrator->process(tfcounter, tracks);
     sendOutput(pc.outputs());
 
@@ -124,6 +127,10 @@ class CalibratordEdxDevice : public Task
       info.setStartValidityTimestamp(intervals[i].first);
       info.setEndValidityTimestamp(timeEnd);
 
+      auto md = info.getMetaData();
+      md["runNumber"] = std::to_string(mRunNumber);
+      info.setMetaData(md);
+
       LOGP(info, "Sending object {} / {} of size {} bytes, valid for {} : {} ", info.getPath(), info.getFileName(), image->size(), info.getStartValidityTimestamp(), info.getEndValidityTimestamp());
 
       output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "TPC_CalibdEdx", i}, *image.get()); // vector<char>
@@ -133,6 +140,7 @@ class CalibratordEdxDevice : public Task
   }
 
   std::unique_ptr<CalibratordEdx> mCalibrator;
+  uint64_t mRunNumber{0}; ///< processed run number
 };
 
 DataProcessorSpec getCalibratordEdxSpec()
@@ -153,15 +161,16 @@ DataProcessorSpec getCalibratordEdxSpec()
       {"max-delay", VariantType::Int, 3, {"number of slots in past to consider"}},
       {"min-entries", VariantType::Int, 50, {"minimum entries per stack to fit a single time slot"}},
 
-      {"min-entries-sector", VariantType::Int, 1000, {"bellow this number of entries per stack, higher dimensional fits will be perform only for GEM stacks types (IROC, OROC1, ...). The mean is still corrected for every stack"}},
+      {"min-entries-sector", VariantType::Int, 1000, {"bellow this number of entries per, stack higher dimensional fits will be perform only for GEM stacks types (IROC, OROC1, ...). The mean is still corrected for every stack"}},
       {"min-entries-1d", VariantType::Int, 500, {"minimum entries per stack to fit 1D correction"}},
       {"min-entries-2d", VariantType::Int, 2500, {"minimum entries per stack to fit 2D correction"}},
 
       {"dedxbins", VariantType::Int, 100, {"number of dEdx bins"}},
-      {"zbins", VariantType::Int, 20, {"number of Z bins"}},
-      {"angularbins", VariantType::Int, 18, {"number of bins for angular data, like Tgl and Snp"}},
-      {"min-dedx", VariantType::Float, 5.0f, {"minimum value for the dEdx histograms"}},
-      {"max-dedx", VariantType::Float, 100.0f, {"maximum value for the dEdx histograms"}},
+      {"min-dedx", VariantType::Float, 5.0f, {"minimum value for dEdx histograms"}},
+      {"max-dedx", VariantType::Float, 100.0f, {"maximum value for dEdx histograms"}},
+      {"angularbins", VariantType::Int, 18, {"number angular bins: Tgl and Snp"}},
+      {"max-tgl", VariantType::Float, 1.5f, {"maximum absolute value for Tgl histograms"}},
+      {"zbins", VariantType::Int, 20, {"number of Z bins. Not used for now"}},
 
       {"field", VariantType::Float, -100.f, {"magnetic field"}},
       {"file-dump", VariantType::Bool, false, {"directly dump calibration to file"}}}};

--- a/GPU/GPUTracking/dEdx/GPUdEdx.h
+++ b/GPU/GPUTracking/dEdx/GPUdEdx.h
@@ -147,8 +147,8 @@ GPUdnii() void GPUdEdx::fillCluster(float qtot, float qmax, int padRow, unsigned
     slice,
     static_cast<tpc::GEMstack>(roc)};
 
-  const float qMaxResidualCorr = residualCalib->getCorrection(stack, tpc::ChargeType::Max, z, trackTgl);
-  const float qTotResidualCorr = residualCalib->getCorrection(stack, tpc::ChargeType::Tot, z, trackTgl);
+  const float qMaxResidualCorr = residualCalib->getCorrection(stack, tpc::ChargeType::Max, trackTgl, trackSnp, z);
+  const float qTotResidualCorr = residualCalib->getCorrection(stack, tpc::ChargeType::Tot, trackTgl, trackSnp, z);
   qmax /= qMaxResidualCorr;
   qtot /= qTotResidualCorr;
 


### PR DESCRIPTION
Correct for Tgl and Snp, insted of Z and Tgl

Other  changes:
* Save run number as CCDB metadata
* ajustable Tgl limits
* record number of tracks of each correction fit
* Method to convert a boost hist into a THn