### PR TITLE
GPU benchmark: Add --raw output option, fix float chunk size TP

### DIFF
--- a/GPU/GPUbenchmark/Shared/Utils.h
+++ b/GPU/GPUbenchmark/Shared/Utils.h
@@ -171,7 +171,7 @@ inline float computeThroughput(Test test, float result, float chunkSizeGB, int n
   // https://docs.nvidia.com/cuda/cuda-c-best-practices-guide/index.html
   // Eff_bandwidth (GB/s) = (B_r + B_w) / (~1e9 * Time (s))
 
-  return 1e3 * chunkSizeGB * ntests / result;
+  return 1e3 * chunkSizeGB * (float)ntests / result;
 }
 
 template <class chunk_t>
@@ -222,6 +222,7 @@ struct benchmarkOpts {
   int numBlocks = -1;
   int kernelLaunches = 1;
   int nTests = 1;
+  bool raw = false;
   int streams = 8;
   int prime = 0;
   std::string outFileName = "benchmark_result";

--- a/GPU/GPUbenchmark/cuda/benchmark.cu
+++ b/GPU/GPUbenchmark/cuda/benchmark.cu
@@ -37,6 +37,7 @@ bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
     "nruns,n", bpo::value<int>()->default_value(1), "Number of times each test is run.")(
     "outfile,o", bpo::value<std::string>()->default_value("benchmark_result"), "Output file name to store results.")(
     "prime,p", bpo::value<int>()->default_value(0), "Prime number to be used for the test.")(
+    "raw,r", "Display raw output.")(
     "streams,s", bpo::value<int>()->default_value(8), "Size of the pool of streams available for concurrent tests.")(
     "test,t", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>{"read", "write", "copy", "rread", "rwrite", "rcopy"}, "read write copy rread rwrite rcopy"), "Tests to be performed.")(
     "version,v", "Print version.")(
@@ -62,6 +63,10 @@ bool parseArgs(o2::benchmark::benchmarkOpts& conf, int argc, const char* argv[])
 
     if (vm.count("inspect")) {
       conf.dumpChunks = true;
+    }
+
+    if (vm.count("raw")) {
+      conf.raw = true;
     }
 
     bpo::notify(vm);


### PR DESCRIPTION
@davidrohr relevant fix is e.g. Kernels.cu:#L798.
Added a `--raw` option: minimal metrics/parameters. Can be extended at occurrence.
I know the code it's becoming a bit 🍝 ... ;)