### PR TITLE
DPL: do not initialise InfoLogger when not requested

### DIFF
--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -262,6 +262,9 @@ auto createInfoLoggerSinkHelper(InfoLogger* logger, InfoLoggerContext* ctx)
   };
 };
 
+struct MissingService {
+};
+
 o2::framework::ServiceSpec CommonServices::infologgerSpec()
 {
   return ServiceSpec{
@@ -270,6 +273,10 @@ o2::framework::ServiceSpec CommonServices::infologgerSpec()
       auto infoLoggerMode = options.GetPropertyAsString("infologger-mode");
       if (infoLoggerMode != "") {
         setenv("O2_INFOLOGGER_MODE", infoLoggerMode.c_str(), 1);
+      }
+      char const* infoLoggerEnv = getenv("O2_INFOLOGGER_MODE");
+      if (infoLoggerEnv == nullptr || strcmp(infoLoggerEnv, "none") == 0) {
+        return ServiceHandle{TypeIdHelpers::uniqueId<MissingService>(), nullptr};
       }
       auto infoLoggerService = new InfoLogger;
       auto infoLoggerContext = &services.get<InfoLoggerContext>();

--- a/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
@@ -18,14 +18,13 @@
 #include "Framework/RunningWorkflowInfo.h"
 #include "Framework/CallbackService.h"
 #include <FairMQDevice.h>
-#include <InfoLogger/InfoLogger.hxx>
 
+#include <iostream>
 #include <chrono>
 #include <thread>
 #include <vector>
 
 using namespace o2::framework;
-using namespace AliceO2::InfoLogger;
 
 struct WorkflowOptions {
   Configurable<int> anInt{"anInt", 1, ""};
@@ -77,11 +76,10 @@ WorkflowSpec defineDataProcessing(ConfigContext const& specs)
      {OutputSpec{{"a1"}, "TST", "A1"},
       OutputSpec{{"a2"}, "TST", "A2"}},
      AlgorithmSpec{adaptStateless(
-       [](DataAllocator& outputs, InfoLogger& logger, RawDeviceService& device, DataTakingContext& context) {
+       [](DataAllocator& outputs, RawDeviceService& device, DataTakingContext& context) {
          device.device()->WaitFor(std::chrono::seconds(rand() % 2));
          auto& aData = outputs.make<int>(OutputRef{"a1"}, 1);
          auto& bData = outputs.make<int>(OutputRef{"a2"}, 1);
-         logger.log("This goes to infologger");
        })},
      {ConfigParamSpec{"some-device-param", VariantType::Int, 1, {"Some device parameter"}}}},
     {"B",


### PR DESCRIPTION
Unless --infologger-mode or O2_INFOLOGGER_MODE is set to
a valid backend, we do not instanciate InfoLoggerClient.