### PR TITLE
MRRTF-157: add the concept of trackable ROF for MCH digits

### DIFF
--- a/Detectors/MUON/MCH/Base/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Base/CMakeLists.txt
@@ -13,7 +13,14 @@ o2_add_library(MCHBase
          SOURCES
            src/PreCluster.cxx
            src/TrackBlock.cxx
+           src/Trackable.cxx
          PUBLIC_LINK_LIBRARIES O2::DataFormatsMCH)
 
 o2_target_root_dictionary(MCHBase
   HEADERS include/MCHBase/DecoderError.h)
+
+o2_add_test(trackable
+            SOURCES src/testTrackable.cxx
+            COMPONENT_NAME mch
+            PUBLIC_LINK_LIBRARIES O2::MCHBase
+            LABELS muon;mch)

--- a/Detectors/MUON/MCH/Base/include/MCHBase/Trackable.h
+++ b/Detectors/MUON/MCH/Base/include/MCHBase/Trackable.h
@@ -1,0 +1,93 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_MCH_TRACKABLE_H
+#define O2_MCH_TRACKABLE_H
+
+#include "DataFormatsMCH/ROFRecord.h"
+#include <array>
+#include <functional>
+#include <gsl/span>
+
+namespace o2::mch
+{
+
+/** Given a number of items (digits, (pre)clusters) per chamber, 
+  * decides if there's the minimum required information to 
+  * get any chance of producing tracks.
+  *
+  * @param itemsPerChamber integer array containing the number
+  * of items per chamber (10 chambers, so 10 integers required)
+  * @param requestStation boolean array to indicate which stations
+  * are required for the tracking (by default all 5 are needed)
+  * @param moreCandidates weaker tracking condition where only
+  * one item in each of station 4 and 5 is requested (instead of
+  * one item per chamber in station 4 and in station 5)
+  * */
+bool isTrackable(std::array<int, 10> itemsPerChamber,
+                 std::array<bool, 5> requestStation = {true, true, true, true, true},
+                 bool moreCandidates = false);
+
+/** Return the number of items per chamber. 
+  *
+  * @tparam T the type of items : implementation exists so far 
+  * only for mch::Digit (clusters and pre-clusters to come next)
+  */
+template <typename T>
+std::array<int, 10> perChamber(gsl::span<const T> items);
+
+/** Return the number of items per station (1 station==2 chambers). */
+template <typename T>
+std::array<int, 5> perStation(gsl::span<const T> items)
+{
+  std::array<int, 5> st{};
+  std::array<int, 10> ch = perChamber(items);
+  for (auto i = 0; i < st.size(); i += 2) {
+    st[i] = ch[i] + ch[i + 1];
+  }
+  return st;
+}
+
+/** Returns a ROFRecord filter that selects ROFs that are trackable.
+  *
+  * The returned filter is a function that takes a ROFRecord and returns
+  * a boolean.
+  *
+  * @param items : the items "pointed to" by the ROFRecords (digits, ...)
+  * @param onlyTrackable : if false the filter will always return true
+  * (i.e. will be a noop basically)
+  *
+  * @param requestStation : @ref isTrackable
+  * @param moreCandidates : @ref isTrackable
+  *
+  * @tparam : the type of the items pointed to by the ROFRecords
+  */
+template <typename T>
+std::function<bool(const ROFRecord&)>
+  createTrackableFilter(gsl::span<const T> items, bool onlyTrackable,
+                        std::array<bool, 5> requestStation = {true, true, true, true, true},
+                        bool moreCandidates = false)
+{
+  if (!onlyTrackable) {
+    // return an "always true" filter
+    return [](const ROFRecord&) {
+      return true;
+    };
+  }
+  return [items, requestStation, moreCandidates](const ROFRecord& rof) {
+    std::array<int, 10> nofItemsPerChamber = perChamber(items.subspan(rof.getFirstIdx(), rof.getNEntries()));
+    return isTrackable(nofItemsPerChamber, requestStation, moreCandidates);
+  };
+}
+
+} // namespace o2::mch
+
+#endif

--- a/Detectors/MUON/MCH/Base/src/Trackable.cxx
+++ b/Detectors/MUON/MCH/Base/src/Trackable.cxx
@@ -1,0 +1,66 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "MCHBase/Trackable.h"
+#include "DataFormatsMCH/Cluster.h"
+#include "DataFormatsMCH/Digit.h"
+
+namespace o2::mch
+{
+
+bool isTrackable(std::array<int, 10> itemsPerChamber,
+                 std::array<bool, 5> requestStation,
+                 bool moreCandidates)
+{
+  // first check that the required stations are actually hit
+  for (auto i = 0; i < 5; i++) {
+    int inStation = itemsPerChamber[i * 2] + itemsPerChamber[i * 2 + 1];
+    if (requestStation[i] && inStation == 0) {
+      return false;
+    }
+  }
+  // then check that we have the right number of hit chambers in St45
+  int nChHitInSt4 = (itemsPerChamber[6] > 0 ? 1 : 0) + (itemsPerChamber[7] > 0 ? 1 : 0);
+  int nChHitInSt5 = (itemsPerChamber[8] > 0 ? 1 : 0) + (itemsPerChamber[9] > 0 ? 1 : 0);
+
+  if (moreCandidates) {
+    return nChHitInSt4 + nChHitInSt5 >= 2;
+  } else {
+    return nChHitInSt4 == 2 || nChHitInSt5 == 2;
+  }
+  return true;
+}
+
+/** Specialization of perChamber for integers (representing 
+  * detection element ids.
+  */
+template <>
+std::array<int, 10> perChamber(gsl::span<const int> deids)
+{
+  std::array<int, 10> nitems{};
+  for (const auto& d : deids) {
+    nitems[d / 100 - 1]++;
+  }
+  return nitems;
+}
+
+/** Specialization of perChamber for Digits */
+template <>
+std::array<int, 10> perChamber(gsl::span<const Digit> digits)
+{
+  std::array<int, 10> nofDigits{};
+  for (const auto& digit : digits) {
+    nofDigits[digit.getDetID() / 100 - 1]++;
+  }
+  return nofDigits;
+}
+
+} // namespace o2::mch

--- a/Detectors/MUON/MCH/Base/src/testTrackable.cxx
+++ b/Detectors/MUON/MCH/Base/src/testTrackable.cxx
@@ -1,8 +1,9 @@
-// Copyright CERN and copyright holders of ALICE O2. This software is
-// distributed under the terms of the GNU General Public License v3 (GPL
-// Version 3), copied verbatim in the file "COPYING".
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
 //
-// See http://alice-o2.web.cern.ch/license for full licensing information.
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 //
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization

--- a/Detectors/MUON/MCH/Base/src/testTrackable.cxx
+++ b/Detectors/MUON/MCH/Base/src/testTrackable.cxx
@@ -1,3 +1,13 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 #define BOOST_TEST_MODULE trackable test
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK

--- a/Detectors/MUON/MCH/Base/src/testTrackable.cxx
+++ b/Detectors/MUON/MCH/Base/src/testTrackable.cxx
@@ -1,0 +1,45 @@
+#define BOOST_TEST_MODULE trackable test
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include "MCHBase/Trackable.h"
+
+BOOST_AUTO_TEST_CASE(MissingRequiredStationMeansNotTrackable)
+{
+  std::array<int, 10> items = {0, 0, 3, 4, 5, 6, 7, 8, 9, 10};
+  std::array<bool, 5> requestStations = {true, true, true, true, true};
+  auto moreCandidates = false;
+
+  BOOST_CHECK_EQUAL(o2::mch::isTrackable(items, requestStations, moreCandidates),
+                    false);
+}
+
+BOOST_AUTO_TEST_CASE(MissingNotRequiredStationIsOK)
+{
+  std::array<int, 10> items = {0, 0, 1, 1, 1, 1, 1, 1, 1, 1};
+  std::array<bool, 5> requestStations = {false, true, true, true, true};
+  auto moreCandidates = false;
+
+  BOOST_CHECK_EQUAL(o2::mch::isTrackable(items, requestStations, moreCandidates),
+                    true);
+}
+
+BOOST_AUTO_TEST_CASE(WithoutMoreCandidatesOptionOnly2ItemsInSt45IsNotOK)
+{
+  std::array<int, 10> items = {1, 1, 1, 1, 1, 1, 0, 1, 0, 1};
+  std::array<bool, 5> requestStations = {true, true, true, true, true};
+  auto moreCandidates = false;
+
+  BOOST_CHECK_EQUAL(o2::mch::isTrackable(items, requestStations, moreCandidates),
+                    false);
+}
+
+BOOST_AUTO_TEST_CASE(WithMoreCandidatesOptionOnly2ItemsInSt45IsOK)
+{
+  std::array<int, 10> items = {1, 1, 1, 1, 1, 1, 0, 1, 0, 1};
+  std::array<bool, 5> requestStations = {true, true, true, true, true};
+  auto moreCandidates = true;
+
+  BOOST_CHECK_EQUAL(o2::mch::isTrackable(items, requestStations, moreCandidates),
+                    true);
+}

--- a/Detectors/MUON/MCH/Workflow/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Workflow/CMakeLists.txt
@@ -9,6 +9,12 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
+
+add_library(obj-mch-reco OBJECT)
+target_sources(obj-mch-reco PRIVATE src/TimeClusterFinderSpec.cxx)
+target_link_libraries(obj-mch-reco PUBLIC O2::Framework O2::MCHTimeClustering
+ O2::MCHTracking)
+
 # MCHWorkflow library is (at least) needed by Detectors/CTF/workflow
 o2_add_library(MCHWorkflow
                SOURCES
@@ -16,7 +22,6 @@ o2_add_library(MCHWorkflow
                    src/ClusterReaderSpec.cxx
                    src/ClusterWriterSpec.cxx
                    src/DataDecoderSpec.cxx
-                   src/TimeClusterFinderSpec.cxx
                    src/PreClusterFinderSpec.cxx
                    src/SanityCheck.cxx
                    src/TrackReaderSpec.cxx
@@ -31,7 +36,6 @@ o2_add_library(MCHWorkflow
                    O2::MCHCTF
                    O2::MCHClustering
                    O2::MCHPreClustering
-                   O2::MCHTimeClustering
                    O2::MCHRawCommon
                    O2::MCHRawDecoder
                )
@@ -71,7 +75,9 @@ o2_add_executable(
         digits-to-timeclusters-workflow
         SOURCES src/digits-to-timeclusters-workflow.cxx
         COMPONENT_NAME mch
-        PUBLIC_LINK_LIBRARIES O2::MCHWorkflow)
+        PUBLIC_LINK_LIBRARIES O2::MCHBase
+        TARGETVARNAME mch-time-cluster-finder)
+target_link_libraries(${mch-time-cluster-finder} PRIVATE obj-mch-reco)
 
 o2_add_executable(
         digits-filtering-workflow
@@ -223,7 +229,8 @@ o2_add_executable(
             O2::MCHWorkflow
             O2::SimulationDataFormat
             O2::Steer
-        )
+        TARGETVARNAME mch-reco-workflow)
+target_link_libraries(${mch-reco-workflow} PRIVATE obj-mch-reco)
 
 o2_add_executable(tracks-file-dumper
         SOURCES src/tracks-file-dumper.cxx

--- a/Detectors/MUON/MCH/Workflow/src/TimeClusterFinderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TimeClusterFinderSpec.cxx
@@ -14,7 +14,7 @@
 ///
 /// \author Andrea Ferrero, CEA
 
-#include "MCHWorkflow/TimeClusterFinderSpec.h"
+#include "TimeClusterFinderSpec.h"
 
 #include <iostream>
 #include <fstream>
@@ -35,8 +35,9 @@
 #include "Framework/Task.h"
 #include "Framework/WorkflowSpec.h"
 
-#include "MCHRawDecoder/OrbitInfo.h"
 #include "MCHTimeClustering/ROFTimeClusterFinder.h"
+#include "MCHBase/Trackable.h"
+#include "MCHTracking/TrackerParam.h"
 
 namespace o2
 {
@@ -56,6 +57,7 @@ class TimeClusterFinderTask
     mNbinsInOneWindow = ic.options().get<int>("peak-search-nbins");
     mMinDigitPerROF = ic.options().get<int>("min-digits-per-rof");
     mDebug = ic.options().get<bool>("mch-debug");
+    mOnlyTrackable = ic.options().get<bool>("only-trackable");
 
     if (mDebug) {
       fair::Logger::SetConsoleColor(true);
@@ -69,10 +71,15 @@ class TimeClusterFinderTask
       mNbinsInOneWindow += 1;
     }
 
-    LOGP(info, "mTimeClusterWidth={} mNbinsInOneWindow={} mMinDigitPerROF={} mDebug={}",
-         mTimeClusterWidth, mNbinsInOneWindow, mMinDigitPerROF, mDebug);
+    LOGP(info, "max-cluster-width : {}", mTimeClusterWidth);
+    LOGP(info, "peak-search-nbins: {} ", mNbinsInOneWindow);
+    LOGP(info, "min-digits-per-rof: {}", mMinDigitPerROF);
+    LOGP(info, "only-trackable : {}", mOnlyTrackable);
+
     auto stop = [this]() {
-      LOGP(info, "\nfinder duration = {} us / TF\n", mTimeProcess.count() * 1000 / mTFcount);
+      if (mTFcount) {
+        LOGP(info, "\nduration = {} us / TF\n", mTimeProcess.count() * 1000 / mTFcount);
+      }
     };
     ic.services().get<CallbackService>().set(CallbackService::Id::Stop, stop);
   }
@@ -81,6 +88,7 @@ class TimeClusterFinderTask
   void run(framework::ProcessingContext& pc)
   {
     auto rofs = pc.inputs().get<gsl::span<o2::mch::ROFRecord>>("rofs");
+    auto digits = pc.inputs().get<gsl::span<o2::mch::Digit>>("digits");
 
     o2::mch::ROFTimeClusterFinder rofProcessor(rofs, mTimeClusterWidth, mNbinsInOneWindow, 0);
 
@@ -100,34 +108,54 @@ class TimeClusterFinderTask
     }
 
     auto& outRofs = pc.outputs().make<std::vector<ROFRecord>>(OutputRef{"rofs"});
-    std::copy_if(rofProcessor.getROFRecords().begin(),
-                 rofProcessor.getROFRecords().end(),
+    const auto& pRofs = rofProcessor.getROFRecords();
+
+    const auto& trackerParam = TrackerParam::Instance();
+    std::array<bool, 5> requestStation{
+      trackerParam.requestStation[0],
+      trackerParam.requestStation[1],
+      trackerParam.requestStation[2],
+      trackerParam.requestStation[3],
+      trackerParam.requestStation[4]};
+
+    auto tfilter = createTrackableFilter(digits, mOnlyTrackable,
+                                         requestStation,
+                                         trackerParam.moreCandidates);
+
+    std::copy_if(begin(pRofs),
+                 end(pRofs),
                  std::back_inserter(outRofs),
-                 [this](const o2::mch::ROFRecord& rof) {
-                   return rof.getNEntries() > mMinDigitPerROF;
+                 [this, tfilter](const o2::mch::ROFRecord& rof) {
+                   return rof.getNEntries() > mMinDigitPerROF &&
+                          tfilter(rof);
                  });
+
+    LOGP(info, "TF {} Processed {} input ROFs and time-clusterized them into {} output ROFs {}", mTFcount, rofs.size(), outRofs.size(), mOnlyTrackable ? "(only trackable ones)" : "");
     mTFcount += 1;
-    LOGP(info, "TF {} Processed {} input ROFs and time-clusterized them into {} output ROFs", mTFcount, rofs.size(), outRofs.size());
   }
 
  private:
-  std::chrono::duration<double, std::milli> mTimeProcess{}; ///< timer
+  std::chrono::duration<double, std::milli>
+    mTimeProcess{}; ///< timer
 
   uint32_t mTimeClusterWidth; ///< maximum size of one time cluster, in bunch crossings
   uint32_t mNbinsInOneWindow; ///< number of time bins considered for the peak search
   int mTFcount{0};            ///< number of processed time frames
   int mDebug{0};              ///< verbosity flag
   int mMinDigitPerROF;        ///< minimum digit per ROF threshold
+  bool mOnlyTrackable;        ///< only keep ROFs that are trackable
 };
 
 //_________________________________________________________________________________________________
 o2::framework::DataProcessorSpec
   getTimeClusterFinderSpec(const char* specName,
+                           std::string_view inputDigitDataDescription,
                            std::string_view inputDigitRofDataDescription,
                            std::string_view outputDigitRofDataDescription)
 {
-  std::string input = fmt::format("rofs:MCH/{}/0",
-                                  inputDigitRofDataDescription.data());
+  std::string input = fmt::format("rofs:MCH/{}/0;digits:MCH/{}/0",
+                                  inputDigitRofDataDescription.data(),
+                                  inputDigitDataDescription.data());
   std::string output = fmt::format("rofs:MCH/{}/0", outputDigitRofDataDescription.data());
 
   std::vector<OutputSpec> outputs;
@@ -144,6 +172,7 @@ o2::framework::DataProcessorSpec
     Options{{"mch-debug", VariantType::Bool, false, {"enable verbose output"}},
             {"max-cluster-width", VariantType::Int, 1000 / 25, {"maximum time width of time clusters, in BC units"}},
             {"peak-search-nbins", VariantType::Int, 5, {"number of time bins for the peak search algorithm (must be an odd number >= 3)"}},
+            {{"only-trackable"}, VariantType::Bool, false, {"remove digits for ROFs which are not trackable"}},
             {"min-digits-per-rof", VariantType::Int, 0, {"minimum number of digits per ROF (below that threshold ROF is discarded)"}}}};
 }
 

--- a/Detectors/MUON/MCH/Workflow/src/TimeClusterFinderSpec.h
+++ b/Detectors/MUON/MCH/Workflow/src/TimeClusterFinderSpec.h
@@ -26,6 +26,7 @@ namespace mch
 
 o2::framework::DataProcessorSpec
   getTimeClusterFinderSpec(const char* specName = "mch-time-cluster-finder",
+                           std::string_view inputDigitDataDescription = "F-DIGITS",
                            std::string_view inputDigitRofDataDescription = "F-DIGITROFS",
                            std::string_view outputDigitRofDataDescription = "TC-F-DIGITROFS");
 

--- a/Detectors/MUON/MCH/Workflow/src/digits-to-timeclusters-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/digits-to-timeclusters-workflow.cxx
@@ -19,13 +19,14 @@
 #include "Framework/CallbackService.h"
 #include "Framework/ControlService.h"
 #include "Framework/Task.h"
-#include "MCHWorkflow/TimeClusterFinderSpec.h"
+#include "TimeClusterFinderSpec.h"
 
 using namespace o2;
 using namespace o2::framework;
 
 void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
+  workflowOptions.push_back(ConfigParamSpec{"input-digits-data-description", VariantType::String, "F-DIGITS", {"description string for the input digit data"}});
   workflowOptions.push_back(ConfigParamSpec{"input-digitrofs-data-description", VariantType::String, "F-DIGITROFS", {"description string for the input digit rofs data"}});
   workflowOptions.push_back(ConfigParamSpec{"output-digitrofs-data-description", VariantType::String, "TC-F-DIGITROFS", {"description string for the output digit rofs data"}});
 }
@@ -37,6 +38,7 @@ WorkflowSpec defineDataProcessing(const ConfigContext& cc)
   return {
     o2::mch::getTimeClusterFinderSpec(
       "mch-time-clustering",
+      cc.options().get<std::string>("input-digits-data-description"),
       cc.options().get<std::string>("input-digitrofs-data-description"),
       cc.options().get<std::string>("output-digitrofs-data-description"))};
 }

--- a/Detectors/MUON/MCH/Workflow/src/reco-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/reco-workflow.cxx
@@ -12,17 +12,17 @@
 #include "ClusterTransformerSpec.h"
 #include "CommonUtils/ConfigurableParam.h"
 #include "DetectorsRaw/HBFUtilsInitializer.h"
-#include "Framework/CallbacksPolicy.h"
 #include "DigitFilteringSpec.h"
 #include "DigitReaderSpec.h"
+#include "Framework/CallbacksPolicy.h"
 #include "Framework/ConfigContext.h"
 #include "Framework/Logger.h"
 #include "Framework/Variant.h"
 #include "Framework/WorkflowSpec.h"
 #include "MCHWorkflow/ClusterFinderOriginalSpec.h"
 #include "MCHWorkflow/PreClusterFinderSpec.h"
-#include "MCHWorkflow/TimeClusterFinderSpec.h"
 #include "MCHWorkflow/TrackWriterSpec.h"
+#include "TimeClusterFinderSpec.h"
 #include "TrackFinderSpec.h"
 #include "TrackFitterSpec.h"
 #include "TrackMCLabelFinderSpec.h"
@@ -70,6 +70,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
                                                     "DIGITLABELS", "F-DIGITLABELS"));
 
   specs.emplace_back(o2::mch::getTimeClusterFinderSpec("mch-time-cluster-finder",
+                                                       "F-DIGITS",
                                                        "F-DIGITROFS",
                                                        "TC-F-DIGITROFS"));
 


### PR DESCRIPTION
A trackable (digit-)ROF is a ROF which points to a set of digits which has
a non-zero chance of producing tracks. The "chance" is given by the
number of digits per chamber : if those numbers satisfy the minimum
tracking requirements (e.g at least 1 digit in each of the first 3 stations
and at least 2 digits in stations 4+5), then the ROF is deemed trackable.

Note that in the end a trackable ROF *might* not end up with tracks
(because e.g. its digits won't produce enough (pre)clusters or for some
other reasons down the line), but a non trackable ROF would *never* have
ended up with tracks.