### PR TITLE
[EMCAL-582] Add static getters for EMCAL CCDB paths

### DIFF
--- a/Detectors/EMCAL/calib/include/EMCALCalib/CalibDB.h
+++ b/Detectors/EMCAL/calib/include/EMCALCalib/CalibDB.h
@@ -282,9 +282,38 @@ class CalibDB
     mInit = false;
   }
 
+  /// \brief Get CDB path for the bad channel map
+  /// \return Path of the bad channel map in the CCDB
+  static const char* getCDBPathBadChannelMap() { return "EMC/Calib/BadChannelMap"; }
+
+  /// \brief Get CDB path for the time calibration
+  /// \return Path of the time calibration in the CCDB
+  static const char* getCDBPathTimeCalibrationParams() { return "EMC/Calib/TimeCalibParams"; }
+
+  /// \brief Get CDB path for the L1 Phase
+  /// \return Path of the L1 phase in the CCDB
+  static const char* getCDBPathL1Phase() { return "EMC/Calib/TimeCalibParamsL1Phase"; }
+
+  /// \brief Get CDB path for the temperature calibration
+  /// \return Path of the temperature calibration in the CCDB
+  static const char* getCDBPathTemperatureCalibrationParams() { return "EMC/Calib/TempCalibParams"; }
+
+  /// \brief Get CDB path for the SM-dependent temperature calibration
+  /// \return Path of the SM-dependent temperature calibration in the CCDB
+  static const char* getCDBPathTemperatureCalibrationParamsSM() { return "EMC/Calib/TempCalibParamsSM"; }
+
+  /// \brief Get CDB path for the gain calibration
+  /// \return Path of the gain calibration in the CCDB
+  static const char* getCDBPathGainCalibrationParams() { return "EMC/Calib/GainCalibFactors"; }
+
+  /// \brief Get CDB path for the trigger DCS settings
+  /// \return Path of the trigger DCS settings in the CCDB
+  static const char* getCDBPathTriggerDCS() { return "EMC/Calib/TriggerDCS"; }
+
  private:
   /// \brief Initialize CCDB server (when new object is created or the server URL changes)
-  void init();
+  void
+    init();
 
   ccdb::CcdbApi mCCDBManager;                       ///< Handler for queries of the CCDB content
   std::string mCCDBServer = "emcccdb-test.cern.ch"; ///< Name of the CCDB server

--- a/Detectors/EMCAL/calib/src/CalibDB.cxx
+++ b/Detectors/EMCAL/calib/src/CalibDB.cxx
@@ -36,7 +36,7 @@ void CalibDB::storeBadChannelMap(BadChannelMap* bcm, const std::map<std::string,
   if (!mInit) {
     init();
   }
-  mCCDBManager.storeAsTFileAny(bcm, "EMC/BadChannelMap", metadata, rangestart, rangeend);
+  mCCDBManager.storeAsTFileAny(bcm, getCDBPathBadChannelMap(), metadata, rangestart, rangeend);
 }
 
 void CalibDB::storeTimeCalibParam(TimeCalibrationParams* tcp, const std::map<std::string, std::string>& metadata, ULong_t rangestart, ULong_t rangeend)
@@ -44,7 +44,7 @@ void CalibDB::storeTimeCalibParam(TimeCalibrationParams* tcp, const std::map<std
   if (!mInit) {
     init();
   }
-  mCCDBManager.storeAsTFileAny(tcp, "EMC/TimeCalibParams", metadata, rangestart, rangeend);
+  mCCDBManager.storeAsTFileAny(tcp, getCDBPathTimeCalibrationParams(), metadata, rangestart, rangeend);
 }
 
 void CalibDB::storeTimeCalibParamL1Phase(TimeCalibParamL1Phase* tcp, const std::map<std::string, std::string>& metadata, ULong_t rangestart, ULong_t rangeend)
@@ -52,7 +52,7 @@ void CalibDB::storeTimeCalibParamL1Phase(TimeCalibParamL1Phase* tcp, const std::
   if (!mInit) {
     init();
   }
-  mCCDBManager.storeAsTFileAny(tcp, "EMC/TimeCalibParamsL1Phase", metadata, rangestart, rangeend);
+  mCCDBManager.storeAsTFileAny(tcp, getCDBPathL1Phase(), metadata, rangestart, rangeend);
 }
 
 void CalibDB::storeTempCalibParam(TempCalibrationParams* tcp, const std::map<std::string, std::string>& metadata, ULong_t rangestart, ULong_t rangeend)
@@ -60,7 +60,7 @@ void CalibDB::storeTempCalibParam(TempCalibrationParams* tcp, const std::map<std
   if (!mInit) {
     init();
   }
-  mCCDBManager.storeAsTFileAny(tcp, "EMC/TempCalibParams", metadata, rangestart, rangeend);
+  mCCDBManager.storeAsTFileAny(tcp, getCDBPathTemperatureCalibrationParams(), metadata, rangestart, rangeend);
 }
 
 void CalibDB::storeTempCalibParamSM(TempCalibParamSM* tcp, const std::map<std::string, std::string>& metadata, ULong_t rangestart, ULong_t rangeend)
@@ -68,7 +68,7 @@ void CalibDB::storeTempCalibParamSM(TempCalibParamSM* tcp, const std::map<std::s
   if (!mInit) {
     init();
   }
-  mCCDBManager.storeAsTFileAny(tcp, "EMC/TempCalibParamsSM", metadata, rangestart, rangeend);
+  mCCDBManager.storeAsTFileAny(tcp, getCDBPathTemperatureCalibrationParamsSM(), metadata, rangestart, rangeend);
 }
 
 void CalibDB::storeGainCalibFactors(GainCalibrationFactors* gcf, const std::map<std::string, std::string>& metadata, ULong_t rangestart, ULong_t rangeend)
@@ -76,7 +76,7 @@ void CalibDB::storeGainCalibFactors(GainCalibrationFactors* gcf, const std::map<
   if (!mInit) {
     init();
   }
-  mCCDBManager.storeAsTFileAny(gcf, "EMC/GainCalibFactors", metadata, rangestart, rangeend);
+  mCCDBManager.storeAsTFileAny(gcf, getCDBPathGainCalibrationParams(), metadata, rangestart, rangeend);
 }
 
 void CalibDB::storeTriggerDCSData(TriggerDCS* dcs, const std::map<std::string, std::string>& metadata, ULong_t rangestart, ULong_t rangeend)
@@ -84,7 +84,7 @@ void CalibDB::storeTriggerDCSData(TriggerDCS* dcs, const std::map<std::string, s
   if (!mInit) {
     init();
   }
-  mCCDBManager.storeAsTFileAny(dcs, "EMC/TriggerDCS", metadata, rangestart, rangeend);
+  mCCDBManager.storeAsTFileAny(dcs, getCDBPathTriggerDCS(), metadata, rangestart, rangeend);
 }
 
 BadChannelMap* CalibDB::readBadChannelMap(ULong_t timestamp, const std::map<std::string, std::string>& metadata)
@@ -92,9 +92,9 @@ BadChannelMap* CalibDB::readBadChannelMap(ULong_t timestamp, const std::map<std:
   if (!mInit) {
     init();
   }
-  BadChannelMap* result = mCCDBManager.retrieveFromTFileAny<o2::emcal::BadChannelMap>("EMC/BadChannelMap", metadata, timestamp);
+  BadChannelMap* result = mCCDBManager.retrieveFromTFileAny<o2::emcal::BadChannelMap>(getCDBPathBadChannelMap(), metadata, timestamp);
   if (!result) {
-    throw ObjectNotFoundException(mCCDBServer, "EMC/BadChannelMap", metadata, timestamp);
+    throw ObjectNotFoundException(mCCDBServer, getCDBPathBadChannelMap(), metadata, timestamp);
   }
   return result;
 }
@@ -104,9 +104,9 @@ TimeCalibrationParams* CalibDB::readTimeCalibParam(ULong_t timestamp, const std:
   if (!mInit) {
     init();
   }
-  TimeCalibrationParams* result = mCCDBManager.retrieveFromTFileAny<o2::emcal::TimeCalibrationParams>("EMC/TimeCalibParams", metadata, timestamp);
+  TimeCalibrationParams* result = mCCDBManager.retrieveFromTFileAny<o2::emcal::TimeCalibrationParams>(getCDBPathTimeCalibrationParams(), metadata, timestamp);
   if (!result) {
-    throw ObjectNotFoundException(mCCDBServer, "EMC/TimeCalibParams", metadata, timestamp);
+    throw ObjectNotFoundException(mCCDBServer, getCDBPathTimeCalibrationParams(), metadata, timestamp);
   }
   return result;
 }
@@ -116,9 +116,9 @@ TimeCalibParamL1Phase* CalibDB::readTimeCalibParamL1Phase(ULong_t timestamp, con
   if (!mInit) {
     init();
   }
-  TimeCalibParamL1Phase* result = mCCDBManager.retrieveFromTFileAny<o2::emcal::TimeCalibParamL1Phase>("EMC/TimeCalibParamsL1Phase", metadata, timestamp);
+  TimeCalibParamL1Phase* result = mCCDBManager.retrieveFromTFileAny<o2::emcal::TimeCalibParamL1Phase>(getCDBPathL1Phase(), metadata, timestamp);
   if (!result) {
-    throw ObjectNotFoundException(mCCDBServer, "EMC/TimeCalibParamsL1Phase", metadata, timestamp);
+    throw ObjectNotFoundException(mCCDBServer, getCDBPathL1Phase(), metadata, timestamp);
   }
   return result;
 }
@@ -128,9 +128,9 @@ TempCalibrationParams* CalibDB::readTempCalibParam(ULong_t timestamp, const std:
   if (!mInit) {
     init();
   }
-  TempCalibrationParams* result = mCCDBManager.retrieveFromTFileAny<o2::emcal::TempCalibrationParams>("EMC/TempCalibParams", metadata, timestamp);
+  TempCalibrationParams* result = mCCDBManager.retrieveFromTFileAny<o2::emcal::TempCalibrationParams>(getCDBPathTemperatureCalibrationParams(), metadata, timestamp);
   if (!result) {
-    throw ObjectNotFoundException(mCCDBServer, "EMC/TempCalibParams", metadata, timestamp);
+    throw ObjectNotFoundException(mCCDBServer, getCDBPathTemperatureCalibrationParams(), metadata, timestamp);
   }
   return result;
 }
@@ -140,9 +140,9 @@ TempCalibParamSM* CalibDB::readTempCalibParamSM(ULong_t timestamp, const std::ma
   if (!mInit) {
     init();
   }
-  TempCalibParamSM* result = mCCDBManager.retrieveFromTFileAny<o2::emcal::TempCalibParamSM>("EMC/TempCalibParamsSM", metadata, timestamp);
+  TempCalibParamSM* result = mCCDBManager.retrieveFromTFileAny<o2::emcal::TempCalibParamSM>(getCDBPathTemperatureCalibrationParamsSM(), metadata, timestamp);
   if (!result) {
-    throw ObjectNotFoundException(mCCDBServer, "EMC/TempCalibParamsSM", metadata, timestamp);
+    throw ObjectNotFoundException(mCCDBServer, getCDBPathTemperatureCalibrationParamsSM(), metadata, timestamp);
   }
   return result;
 }
@@ -152,9 +152,9 @@ GainCalibrationFactors* CalibDB::readGainCalibFactors(ULong_t timestamp, const s
   if (!mInit) {
     init();
   }
-  GainCalibrationFactors* result = mCCDBManager.retrieveFromTFileAny<o2::emcal::GainCalibrationFactors>("EMC/GainCalibFactors", metadata, timestamp);
+  GainCalibrationFactors* result = mCCDBManager.retrieveFromTFileAny<o2::emcal::GainCalibrationFactors>(getCDBPathGainCalibrationParams(), metadata, timestamp);
   if (!result) {
-    throw ObjectNotFoundException(mCCDBServer, "EMC/GainCalibFactors", metadata, timestamp);
+    throw ObjectNotFoundException(mCCDBServer, getCDBPathGainCalibrationParams(), metadata, timestamp);
   }
   return result;
 }
@@ -164,9 +164,9 @@ TriggerDCS* CalibDB::readTriggerDCSData(ULong_t timestamp, const std::map<std::s
   if (!mInit) {
     init();
   }
-  TriggerDCS* result = mCCDBManager.retrieveFromTFileAny<o2::emcal::TriggerDCS>("EMC/TriggerDCS", metadata, timestamp);
+  TriggerDCS* result = mCCDBManager.retrieveFromTFileAny<o2::emcal::TriggerDCS>(getCDBPathTriggerDCS(), metadata, timestamp);
   if (!result) {
-    throw ObjectNotFoundException(mCCDBServer, "EMC/TriggerDCS", metadata, timestamp);
+    throw ObjectNotFoundException(mCCDBServer, getCDBPathTriggerDCS(), metadata, timestamp);
   }
   return result;
 }


### PR DESCRIPTION
Provide static getters for common CDB paths, to be used
in the CalibDB itself and in other classes dealing with CDB
objects.