### PR TITLE
Include TPC unconstrained track to S.Vertexing

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/src/secondary-vertexing-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/secondary-vertexing-workflow.cxx
@@ -55,7 +55,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 
 WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 {
-  GID::mask_t allowedSources = GID::getSourcesMask("ITS,ITS-TPC,TPC-TRD,TPC-TOF,ITS-TPC-TRD,ITS-TPC-TOF");
+  GID::mask_t allowedSources = GID::getSourcesMask("ITS,ITS-TPC,TPC-TRD,TPC-TOF,ITS-TPC-TRD,ITS-TPC-TOF,TPC");
 
   // Update the (declared) parameters if changed from the command line
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
@@ -66,7 +66,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   auto enableCasc = !configcontext.options().get<bool>("disable-cascade-finder");
 
   GID::mask_t src = allowedSources & GID::getSourcesMask(configcontext.options().get<std::string>("vertexing-sources"));
-  GID::mask_t dummy, srcClus = GID::includesDet(DetID::TOF, src) ? GID::getSourceMask(GID::TOF) : dummy;
+  GID::mask_t dummy, srcClus = GID::includesDet(DetID::TOF, src) ? GID::getSourceMask(GID::TOF) : dummy; // eventually, TPC clusters will be needed for refit
 
   WorkflowSpec specs;
 

--- a/Detectors/Vertexing/include/DetectorsVertexing/SVertexer.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/SVertexer.h
@@ -26,6 +26,7 @@
 #include "DetectorsVertexing/DCAFitterN.h"
 #include "DetectorsVertexing/SVertexerParams.h"
 #include "DetectorsVertexing/SVertexHypothesis.h"
+#include "DataFormatsTPC/TrackTPC.h"
 #include <numeric>
 #include <algorithm>
 
@@ -73,11 +74,15 @@ class SVertexer
   void setEnableCascades(bool v) { mEnableCascades = v; }
   void init();
   void process(const o2::globaltracking::RecoContainer& recoTracks); // accessor to various tracks
-  bool acceptTrack(GIndex gid, const o2::track::TrackParCov& trc) const;
   auto& getMeanVertex() const { return mMeanVertex; }
   void setMeanVertex(const o2d::VertexBase& v) { mMeanVertex = v; }
   void setNThreads(int n);
   int getNThreads() const { return mNThreads; }
+  void setTPCTBin(int nbc)
+  {
+    // set TPC time bin in BCs
+    mMUS2TPCBin = 1.f / (nbc * o2::constants::lhc::LHCBunchSpacingMUS);
+  }
 
   template <typename V0CONT, typename V0REFCONT, typename CASCCONT, typename CASCREFCONT>
   void extractSecondaryVertices(V0CONT& v0s, V0REFCONT& vtx2V0Refs, CASCCONT& cascades, CASCREFCONT& vtx2CascRefs);
@@ -88,6 +93,9 @@ class SVertexer
   void setupThreads();
   void buildT2V(const o2::globaltracking::RecoContainer& recoTracks);
   void updateTimeDependentParams();
+  bool acceptTrack(GIndex gid, const o2::track::TrackParCov& trc) const;
+  bool processTPCTrack(const o2::tpc::TrackTPC& trTPC, GIndex gid, int vtxid);
+  float correctTPCTrack(o2::track::TrackParCov& trc, const o2::tpc::TrackTPC tTPC, float tmus, float tmusErr) const;
 
   uint64_t getPairIdx(GIndex id1, GIndex id2) const
   {
@@ -116,6 +124,8 @@ class SVertexer
   float mMaxTgl2V0 = 2. * 2.;
   float mMinPt2Casc = 1e-4;
   float mMaxTgl2Casc = 2. * 2.;
+  float mMUS2TPCBin = 1.f / (8 * o2::constants::lhc::LHCBunchSpacingMUS);
+  float mTPCBin2Z = 0;
   bool mEnableCascades = true;
 };
 

--- a/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
@@ -57,16 +57,15 @@ struct SVertexerParams : public o2::conf::ConfigurableParamHelper<SVertexerParam
   float causalityRTolerance = 1.; ///< V0 radius cannot exceed its contributors minR by more than this value
   float maxV0ToProngsRDiff = 50.; ///< V0 radius cannot be lower than this ammount wrt minR of contributors
 
-  float minCosPAXYMeanVertex = 0.85;      ///< min cos of PA to beam line (mean vertex) in tr. plane for prompt V0 candidates
+  float minCosPAXYMeanVertex = 0.95;      ///< min cos of PA to beam line (mean vertex) in tr. plane for prompt V0 candidates
   float minCosPAXYMeanVertexCascV0 = 0.8; ///< min cos of PA to beam line (mean vertex) in tr. plane for V0 of cascade cand.
 
   float maxRToMeanVertexCascV0 = 80; // don't consider as a cascade V0 seed if above this R
   float minCosPACascV0 = 0.8;        // min cos of pointing angle to PV for cascade V0 candidates
-
   float minCosPA = 0.9; ///< min cos of PA to PV for prompt V0 candidates
 
   float minRDiffV0Casc = 0.2; ///< cascade should be at least this radial distance below V0
-  float maxRIniCasc = 50.;    // don't consider as a cascade seed (circles/line intersection) if its R exceeds this
+  float maxRIniCasc = 90.;    // don't consider as a cascade seed (circles/line intersection) if its R exceeds this
 
   float maxDCAXYCasc = 0.3; // max DCA of cascade to PV in XY // TODO RS: shall we use real chi2 to vertex?
   float maxDCAZCasc = 0.3;  // max DCA of cascade to PV in Z


### PR DESCRIPTION
At the moment TPC tracks are cloned for every vertex candidate, with track Z simply shifted
to account for the vertex timing.