### PR TITLE
Fixes/macros for new GRP objects, retrofit Pilot Beam GRPs

### DIFF
--- a/Common/Constants/include/CommonConstants/LHCConstants.h
+++ b/Common/Constants/include/CommonConstants/LHCConstants.h
@@ -23,8 +23,8 @@ namespace constants
 namespace lhc
 {
 // LHC Beam1 and Beam2 definitions
-enum BeamDirection : int { BeamClockWise,     // beamC = beam 1,
-                           BeamAntiClockWise, // beamA = beam 2
+enum BeamDirection : int { BeamA, // beamA = beam 0,
+                           BeamC, // beamC = beam 1
                            NBeamDirections,
                            InteractingBC = -1 // as used in the BunchFilling class
 };
@@ -37,8 +37,8 @@ constexpr double LHCBunchSpacingMUS = LHCBunchSpacingNS * 1e-3;  // bunch spacin
 constexpr double LHCOrbitMUS = LHCOrbitNS * 1e-3;                // orbit duration in \mus
 constexpr unsigned int MaxNOrbits = 0xffffffff;
 
-// Offsets of clockwise and anticlockwise beam bunches at P2
-constexpr int BunchOffsetsP2[2] = {3017, 344};
+// Offsets of A, C beam bunches at P2
+constexpr int BunchOffsetsP2[2] = {344, 3017};
 
 // convert LHC bunch ID to BC for 2 beam directions
 constexpr int LHCBunch2P2BC(int bunch, BeamDirection dir)

--- a/DataFormats/Parameters/src/GRPLHCIFData.cxx
+++ b/DataFormats/Parameters/src/GRPLHCIFData.cxx
@@ -31,7 +31,7 @@ const std::unordered_map<unsigned int, unsigned int> GRPLHCIFData::mZtoA =
 void GRPLHCIFData::setBeamAZ(beamDirection beam)
 {
   // set both A and Z of the beam in direction 'beam'
-  if (beam == beamDirection::BeamClockWise) {
+  if (beam == beamDirection::BeamC) {
     auto atomicNum = mZtoA.find(getAtomicNumberB1());
     if (atomicNum == mZtoA.end()) {
       LOG(fatal) << "We don't know the Mass Number for Z = " << getAtomicNumberB1();
@@ -53,16 +53,16 @@ void GRPLHCIFData::setBeamAZ()
 {
 
   // setting A and Z for both beams
-  setBeamAZ(BeamClockWise);
-  setBeamAZ(BeamAntiClockWise);
+  setBeamAZ(BeamC);
+  setBeamAZ(BeamA);
 }
 
 //_______________________________________________
 float GRPLHCIFData::getSqrtS() const
 {
   // get center of mass energy
-  double e0 = getBeamEnergyPerNucleon(BeamClockWise);
-  double e1 = getBeamEnergyPerNucleon(BeamAntiClockWise);
+  double e0 = getBeamEnergyPerNucleon(BeamC);
+  double e1 = getBeamEnergyPerNucleon(BeamA);
   if (e0 <= MassProton || e1 <= MassProton) {
     return 0.f;
   }

--- a/DataFormats/Parameters/src/GRPObject.cxx
+++ b/DataFormats/Parameters/src/GRPObject.cxx
@@ -29,8 +29,8 @@ using o2::detectors::DetID;
 float GRPObject::getSqrtS() const
 {
   // get center of mass energy
-  double e0 = getBeamEnergyPerNucleon(BeamClockWise);
-  double e1 = getBeamEnergyPerNucleon(BeamAntiClockWise);
+  double e0 = getBeamEnergyPerNucleon(BeamC);
+  double e1 = getBeamEnergyPerNucleon(BeamA);
   if (e0 <= MassProton || e1 <= MassProton) {
     return 0.f;
   }
@@ -53,10 +53,10 @@ void GRPObject::print() const
   t = mTimeEnd; // system_clock::to_time_t(mTimeEnd);
   printf("End  : %s", std::ctime(&t));
   printf("1st orbit: %u, %u orbits per TF\n", mFirstOrbit, mNHBFPerTF);
-  printf("Beam0: Z:A = %3d:%3d, Energy = %.3f\n", getBeamZ(BeamClockWise), getBeamA(BeamClockWise),
-         getBeamEnergyPerNucleon(BeamClockWise));
-  printf("Beam1: Z:A = %3d:%3d, Energy = %.3f\n", getBeamZ(BeamAntiClockWise), getBeamA(BeamAntiClockWise),
-         getBeamEnergyPerNucleon(BeamAntiClockWise));
+  printf("Beam0: Z:A = %3d:%3d, Energy = %.3f\n", getBeamZ(BeamC), getBeamA(BeamC),
+         getBeamEnergyPerNucleon(BeamC));
+  printf("Beam1: Z:A = %3d:%3d, Energy = %.3f\n", getBeamZ(BeamA), getBeamA(BeamA),
+         getBeamEnergyPerNucleon(BeamA));
   printf("sqrt[s]    = %.3f\n", getSqrtS());
   printf("crossing angle (radian) = %e\n", getCrossingAngle());
   printf("magnet currents (A) L3 = %.3f, Dipole = %.f\n", getL3Current(), getDipoleCurrent());

--- a/DataFormats/common/include/CommonDataFormat/BunchFilling.h
+++ b/DataFormats/common/include/CommonDataFormat/BunchFilling.h
@@ -28,7 +28,7 @@ class BunchFilling
   using Pattern = std::bitset<o2::constants::lhc::LHCMaxBunches>;
 
   BunchFilling() = default;
-  BunchFilling(const std::string& beamA, const std::string& beanC);
+  BunchFilling(const std::string& beamA, const std::string& beamC);
   BunchFilling(const std::string& interactingBC);
 
   // this is a pattern creator similar to Run1/2 AliTriggerBCMask
@@ -38,16 +38,19 @@ class BunchFilling
   //  - spaces, new lines are white characters
   static Pattern createPattern(const std::string& p);
 
+  // create pattern string from filled bucket
+  static std::string buckets2PatternString(const std::vector<int>& buckets, int ibeam);
+
   // get interacting bunches pattern (B)
   const auto& getBCPattern() const { return mPattern; }
 
-  // get pattern or clockwise (1, A) and anticlockwise (0, C) beams at P2
+  // get pattern or clockwise (0, A) and anticlockwise (1, C) beams at P2
   const auto& getBeamPattern(int beam) const { return mBeamAC[beam]; }
 
   // get pattern of interacting BCs (-1) or beams filled BCs at P2 (0,1)
   const auto& getPattern(int dir = -1) const { return dir < 0 ? getBCPattern() : getBeamPattern(dir); }
 
-  // get number of interacting bunches (-1) and number of filled bunches for clockwise (1, A) and anticlockwise (0, C) beams
+  // get number of interacting bunches (-1) and number of filled bunches for clockwise (0, A) and anticlockwise (1, C) beams
   int getNBunches(int dir = -1) const { return dir < 0 ? mPattern.count() : mBeamAC[dir].count(); }
 
   // test interacting bunch
@@ -56,7 +59,7 @@ class BunchFilling
   // test bean bunch
   bool testBeamBunch(int bcID, int dir) const { return mBeamAC[dir][bcID]; }
 
-  // test interacting (-1) or clockwise (1, A) and anticlockwise (0, C) beams bunch
+  // test interacting (-1) or clockwise (0, A) and anticlockwise (1, C) beams bunch
   bool testBC(int bcID, int dir = -1) const { return dir < 0 ? testInteractingBC(bcID) : testBeamBunch(bcID, dir); }
 
   // BC setters, dir=-1 is for interacting bunches pattern, 0, 1 for clockwise (C) and anticlockwise (A) beams
@@ -94,7 +97,7 @@ class BunchFilling
   static bool parsePattern(const unsigned char*& input, Pattern& patt, int& ibit, int& level);
 
   Pattern mPattern{};                                                 // Pattern of interacting BCs at P2
-  std::array<Pattern, o2::constants::lhc::NBeamDirections> mBeamAC{}; // pattern of 2 beam bunches at P2, 0 for C, 1 for A beam
+  std::array<Pattern, o2::constants::lhc::NBeamDirections> mBeamAC{}; // pattern of 2 beam bunches at P2, 0 for A, 1 for C beam
 
   ClassDefNV(BunchFilling, 2);
 };

--- a/DataFormats/common/src/BunchFilling.cxx
+++ b/DataFormats/common/src/BunchFilling.cxx
@@ -183,6 +183,30 @@ BunchFilling::Pattern BunchFilling::createPattern(const std::string& p)
 }
 
 //_________________________________________________
+std::string BunchFilling::buckets2PatternString(const std::vector<int>& buckets, int ibeam)
+{
+  // create bunches pattern string from filled buckets, in the format parsed by o2::BunchFilling::createPattern
+  Pattern patt;
+  std::string pattS;
+  for (int b : buckets) {
+    patt[o2::constants::lhc::LHCBunch2P2BC(b / 10, o2::constants::lhc::BeamDirection(ibeam))] = true;
+  }
+  int nh = 0;
+  for (int i = 0; i < o2::constants::lhc::LHCMaxBunches; i++) {
+    if (patt[i]) {
+      if (nh) {
+        pattS += fmt::format("{}L", nh);
+        nh = 0; // reset holes
+      }
+      pattS += "H";
+    } else {
+      nh++;
+    }
+  }
+  return pattS;
+}
+
+//_________________________________________________
 bool BunchFilling::parsePattern(const unsigned char*& input, BunchFilling::Pattern& patt, int& ibit, int& level)
 {
   // this is analog of AliTriggerBCMask::Bcm2Bits

--- a/DataFormats/common/src/CommonDataFormatLinkDef.h
+++ b/DataFormats/common/src/CommonDataFormatLinkDef.h
@@ -49,6 +49,7 @@
 #pragma link C++ class o2::InteractionRecord + ;
 #pragma link C++ class o2::InteractionTimeRecord + ;
 #pragma link C++ class o2::BunchFilling + ;
+#pragma link C++ class std::pair < long, o2::BunchFilling> + ;
 
 #pragma link C++ class o2::math_utils::detail::Bracket < o2::InteractionRecord> + ;
 #pragma link C++ class o2::dataformats::IRFrame + ;

--- a/macro/CMakeLists.txt
+++ b/macro/CMakeLists.txt
@@ -57,6 +57,7 @@ install(FILES CheckDigits_mft.C
               CreateCTPOrbitResetObject.C
               CreateGRPECSObject.C
               CreateGRPMagFieldObject.C
+              CreateGRPLHCIFObject.C
         DESTINATION share/macro/)
 
 # FIXME: a lot of macros that are here should really be elsewhere. Those which
@@ -356,6 +357,12 @@ o2_add_test_root_macro(CreateGRPECSObject.C
 o2_add_test_root_macro(CreateGRPMagFieldObject.C
                        PUBLIC_LINK_LIBRARIES O2::DataFormatsParameters
                                              O2::CommonTypes
+                                             O2::CCDB)
+
+o2_add_test_root_macro(CreateGRPLHCIFObject.C
+                       PUBLIC_LINK_LIBRARIES O2::DataFormatsParameters
+                                             O2::CommonTypes
+                                             O2::CommonDataFormat
                                              O2::CCDB)
 
 o2_add_test_root_macro(UploadMatBudLUT.C

--- a/macro/CreateGRPECSObject.C
+++ b/macro/CreateGRPECSObject.C
@@ -19,7 +19,7 @@
 
 #endif
 
-using timePoint = std::time_t;
+using timePoint = long;
 using DetID = o2::detectors::DetID;
 using CcdbApi = o2::ccdb::CcdbApi;
 using GRPECSObject = o2::parameters::GRPECSObject;

--- a/macro/CreateGRPLHCIFObject.C
+++ b/macro/CreateGRPLHCIFObject.C
@@ -1,0 +1,50 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+
+#include <ctime>
+#include <chrono>
+#include "DataFormatsParameters/GRPLHCIFData.h"
+#include "CommonDataFormat/BunchFilling.h"
+#include "CCDB/CcdbApi.h"
+
+#endif
+
+using timePoint = long;
+using CcdbApi = o2::ccdb::CcdbApi;
+using GRPLHCIFData = o2::parameters::GRPLHCIFData;
+
+// Simple macro to exemplify how to fill a GRPLHCIF object (GRP object containing the information from the LHC)
+
+void CreateGRPLHCIFObject(timePoint start, int egev, int fill, const std::string& injScheme, const std::string& beamAFilling,
+                          const std::string& beamCFilling = "", int A1 = 1, int A2 = 1, float crossAngle = 0.f,
+                          timePoint end = -1, std::string ccdbPath = "http://ccdb-test.cern.ch:8080")
+{
+  GRPLHCIFData grp;
+  grp.setBeamEnergyPerZWithTime(start, egev);
+  grp.setFillNumberWithTime(start, fill);
+  grp.setInjectionSchemeWithTime(start, injScheme);
+  grp.setAtomicNumberB1WithTime(start, A1);
+  grp.setAtomicNumberB2WithTime(start, A2);
+  grp.setBeamAZ();
+  grp.setCrossingAngleWithTime(start, crossAngle);
+  o2::BunchFilling bf(beamAFilling, beamCFilling);
+
+  CcdbApi api;
+  api.init(ccdbPath);
+  std::map<std::string, std::string> metadata;
+  metadata["responsible"] = "LHCIF";
+  if (end < 0) {
+    end = (start + 60 * 60 * 15) * 1000; // start + 15h, in ms
+  }
+  api.storeAsTFileAny(&grp, "GLO/Config/GRPLHCIF", metadata, start * 1000, end); // making it 1-year valid to be sure we have something
+}

--- a/macro/CreateGRPMagFieldObject.C
+++ b/macro/CreateGRPMagFieldObject.C
@@ -19,7 +19,7 @@
 
 #endif
 
-using timePoint = std::time_t;
+using timePoint = long;
 using CcdbApi = o2::ccdb::CcdbApi;
 using GRPMagField = o2::parameters::GRPMagField;
 using current = o2::units::Current_t;
@@ -38,7 +38,7 @@ using current = o2::units::Current_t;
  CreateGRPMagFieldObject(l3, dipole, tStart, runNb, tEnd, isUniform)
 */
 
-void CreateGRPMagFieldObject(current l3, current dipole, timePoint start, int run, timePoint end = -1, bool isUniform = true, std::string ccdbPath = "http://ccdb-test.cern.ch:8080")
+void CreateGRPMagFieldObject(current l3, current dipole, timePoint start, timePoint end = -1, bool isUniform = true, std::string ccdbPath = "http://ccdb-test.cern.ch:8080")
 {
 
   GRPMagField grp;
@@ -50,7 +50,6 @@ void CreateGRPMagFieldObject(current l3, current dipole, timePoint start, int ru
   api.init(ccdbPath);
   std::map<std::string, std::string> metadata;
   metadata["responsible"] = "DCS";
-  metadata["run_number"] = std::to_string(run);
   //long ts = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
   if (end < 0) {
     end = (start + 60 * 60 * 10) * 1000; // start + 10h, in ms


### PR DESCRIPTION
`GRPLHCIFData`, `GRPMagFieldObject` and `GRPECSObject` are retrofitted to 
`GLO/Config/GRPLHCIF`, `GLO/Config/GRPMagField` and `GLO/Config/GRPECS` URLs of both 
[test](http://ccdb-test.cern.ch:8080/browse/GLO/Config?report=true) and [production](http://alice-ccdb.cern.ch/browse/GLO/Config) CCDBs using attached macro [retrofitPilotBeamGRP.C.gz](https://github.com/AliceO2Group/AliceO2/files/7695830/retrofitPilotBeamGRP.C.gz)

@chiarazampolli note that I left only GRPECSObject with the run tag, the two others are not associated with a particular run.
