### PR TITLE
[MCH] add protections

### DIFF
--- a/Detectors/MUON/MCH/PreClustering/src/PreClusterFinder.cxx
+++ b/Detectors/MUON/MCH/PreClustering/src/PreClusterFinder.cxx
@@ -125,13 +125,22 @@ void PreClusterFinder::loadDigit(const Digit& digit)
 {
   /// fill the Mapping::MpDE structure with fired pad
 
-  int deIndex = mDEIndices[digit.getDetID()];
-  assert(deIndex >= 0 && deIndex < SNDEs);
+  int deIndex = mDEIndices.at(digit.getDetID());
 
   DetectionElement& de(*(mDEs[deIndex]));
 
+  if (digit.getPadID() < 0 || digit.getPadID() >= de.mapping->nPads[0] + de.mapping->nPads[1]) {
+    throw out_of_range("invalid pad index");
+  }
+
   uint16_t iPad = digit.getPadID();
   int iPlane = (iPad < de.mapping->nPads[0]) ? 0 : 1;
+
+  // check that the pad is not already fired
+  if (de.mapping->pads[iPad].useMe) {
+    LOG(error) << "multiple digits on the same pad (DE " << digit.getDetID() << ", pad " << iPad << ")";
+    return;
+  }
 
   // register this digit
   uint16_t iDigit = de.nFiredPads[0] + de.nFiredPads[1];


### PR DESCRIPTION
- add out-of-bound protection for internal DE and pad arrays (this is just extra protection of the code against bad memory access, since the validity of digits' pad and DE IDs should be guaranteed at this point)

- add protection against multiple digits on the same pad. I am not sure to which extend this can/should be addressed in e.g. the time clustering. For the moment I just keep the first digit and skip the others when that happens.