### PR TITLE
TPC: Restructure pad-wise calibration, implement missing workflows

### DIFF
--- a/Detectors/TPC/base/include/TPCBase/CalDet.h
+++ b/Detectors/TPC/base/include/TPCBase/CalDet.h
@@ -41,7 +41,7 @@ class CalDet
   using CalType = CalArray<T>;
 
  public:
-  CalDet() = default;
+  CalDet() { initData(); }
   CalDet(CalDet const&) = default;
   CalDet& operator=(CalDet const&) = default;
   ~CalDet() = default;
@@ -97,9 +97,9 @@ class CalDet
   friend CalDet<U> operator-(const CalDet<U>&, const CalDet<U>&);
 
  private:
-  std::string mName;          ///< name of the object
-  std::vector<CalType> mData; ///< internal CalArrays
-  PadSubset mPadSubset;       ///< Pad subset granularity
+  std::string mName;                     ///< name of the object
+  std::vector<CalType> mData;            ///< internal CalArrays
+  PadSubset mPadSubset = PadSubset::ROC; ///< Pad subset granularity
 
   /// initialize the data array depending on what is set as PadSubset
   void initData();

--- a/Detectors/TPC/base/src/CDBInterface.cxx
+++ b/Detectors/TPC/base/src/CDBInterface.cxx
@@ -58,7 +58,7 @@ const CalPad& CDBInterface::getPedestals()
     }
   } else {
     // return from CDB, assume that check for object existence are done there
-    return getObjectFromCDB<CalPad>(CDBTypeMap.at(CDBType::CalPedestal));
+    return getObjectFromCDB<CalPadMapType>(CDBTypeMap.at(CDBType::CalPedestalNoise)).at("Pedestals");
   }
 
   if (!mPedestals) {
@@ -82,7 +82,7 @@ const CalPad& CDBInterface::getNoise()
     }
   } else {
     // return from CDB, assume that check for object existence are done there
-    return getObjectFromCDB<CalPad>(CDBTypeMap.at(CDBType::CalNoise));
+    return getObjectFromCDB<CalPadMapType>(CDBTypeMap.at(CDBType::CalPedestalNoise)).at("Noise");
   }
 
   if (!mNoise) {
@@ -301,9 +301,9 @@ bool CDBStorage::checkMetaData(MetaData_t metaData) const
     "Optional"};
 
   const std::array<std::vector<std::string_view>, 3> tests{{
-    {"Responsible", "Reason", "Intervention"}, //errors
-    {"JIRA"},                                  //warnings
-    {"Comment"}                                //infos
+    {"Responsible", "Reason", "Intervention"}, // errors
+    {"JIRA"},                                  // warnings
+    {"Comment"}                                // infos
   }};
 
   std::array<int, 3> counts{};
@@ -346,8 +346,12 @@ void CDBStorage::uploadNoiseAndPedestal(std::string_view fileName, long first, l
     LOGP(fatal, "No valid noise object was loaded from file {}", fileName);
   }
 
-  storeObject(pedestals, CDBType::CalPedestal, first, last);
-  storeObject(noise, CDBType::CalNoise, first, last);
+  CDBInterface::CalPadMapType calib;
+
+  calib["Pedestals"] = *pedestals;
+  calib["Noise"] = *noise;
+
+  storeObject(&calib, CDBType::CalPedestalNoise, first, last);
 }
 
 //______________________________________________________________________________

--- a/Detectors/TPC/base/src/Painter.cxx
+++ b/Detectors/TPC/base/src/Painter.cxx
@@ -109,10 +109,10 @@ TCanvas* painter::draw(const CalDet<T>& calDet, int nbins1D, float xMin1D, float
   TH1::SetDefaultBufferSize(Sector::MAXSECTOR * mapper.getPadsInSector());
 
   auto hAside1D = new TH1F(fmt::format("h_Aside_1D_{}", name).data(), fmt::format("{} (A-Side)", title).data(),
-                           nbins1D, xMin1D, xMax1D); //TODO: modify ranges
+                           nbins1D, xMin1D, xMax1D); // TODO: modify ranges
 
   auto hCside1D = new TH1F(fmt::format("h_Cside_1D_{}", name).data(), fmt::format("{} (C-Side)", title).data(),
-                           nbins1D, xMin1D, xMax1D); //TODO: modify ranges
+                           nbins1D, xMin1D, xMax1D); // TODO: modify ranges
 
   auto hAside2D = new TH2F(fmt::format("h_Aside_2D_{}", name).data(), fmt::format("{} (A-Side);#it{{x}} (cm);#it{{y}} (cm)", title).data(),
                            330, -270, 270, 330, -270, 270);
@@ -387,7 +387,7 @@ std::vector<TCanvas*> painter::makeSummaryCanvases(const CalDet<T>& calDet, int 
     }
 
     // ===| 1D histogram |===
-    auto h1D = new TH1F(fmt::format("h_{}_{:02d}", calName, iroc).data(), fmt::format("{} distribution ROC {:02d} ({});ADC value", calName, iroc, getROCTitle(iroc)).data(), nbins1D, xMin1D, xMax1D);
+    auto h1D = new TH1F(fmt::format("h1_{}_{:02d}", calName, iroc).data(), fmt::format("{} distribution ROC {:02d} ({});ADC value", calName, iroc, getROCTitle(iroc)).data(), nbins1D, xMin1D, xMax1D);
     for (const auto& val : roc.getData()) {
       h1D->Fill(val);
     }
@@ -806,7 +806,7 @@ std::vector<TCanvas*> painter::makeSummaryCanvases(const LtrCalibData& ltr, std:
     cLtrCoverage = new TCanvas("cLtrCoverage", "laser track coverage", size, 2. * size * 7 / 24 * 1.1);
     cCalibValues = new TCanvas("cCalibValues", "calibration values", size, 2. * size * 7 / 24 * 1.1);
 
-    //TODO: add cCalibValues
+    // TODO: add cCalibValues
   }
 
   auto getLtrStatHist = [](Side side) -> TH2F* {
@@ -849,7 +849,7 @@ std::vector<TCanvas*> painter::makeSummaryCanvases(const LtrCalibData& ltr, std:
 
     hltrCoverage->Fill(bundleID, trackID);
   }
-  //hltrCoverage->Scale(1.f/float(ltr->processedTFs));
+  // hltrCoverage->Scale(1.f/float(ltr->processedTFs));
 
   cLtrCoverage->Divide(1, 2);
 

--- a/Detectors/TPC/calibration/include/TPCCalibration/CalibPedestal.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/CalibPedestal.h
@@ -15,8 +15,10 @@
 /// \file   CalibPedestal.h
 /// \author Jens Wiechula, Jens.Wiechula@ikf.uni-frankfurt.de
 
+#include <string>
 #include <vector>
 #include <memory>
+#include <unordered_map>
 
 #include "Rtypes.h"
 
@@ -45,10 +47,10 @@ class CalibPedestal : public CalibRawBase
  public:
   using vectorType = std::vector<float>;
 
-  //enum class StatisticsType {
-  //GausFit,   ///< Use Gaus fit for pedestal and noise
-  //MeanStdDev ///< Use mean and standard deviation
-  //};
+  // enum class StatisticsType {
+  // GausFit,   ///< Use Gaus fit for pedestal and noise
+  // MeanStdDev ///< Use mean and standard deviation
+  // };
 
   /// default constructor
   CalibPedestal(PadSubset padSubset = PadSubset::ROC);
@@ -99,15 +101,17 @@ class CalibPedestal : public CalibRawBase
   /// Get the pedestal calibration object
   ///
   /// \return pedestal calibration object
-  const CalPad& getPedestal() const { return mPedestal; }
+  const CalPad& getPedestal() const { return mCalDets.at("Pedestals"); }
 
   /// Get the noise calibration object
   ///
   /// \return noise calibration object
-  const CalPad& getNoise() const { return mNoise; }
+  const CalPad& getNoise() const { return mCalDets.at("Noise"); }
+
+  const auto& getCalDets() const { return mCalDets; }
 
   /// return all pad clibrations as vector
-  const std::vector<const o2::tpc::CalDet<float>*> getCalDets() const { return std::vector<const o2::tpc::CalDet<float>*>{&mPedestal, &mNoise}; }
+  // const std::vector<const o2::tpc::CalDet<float>*> getCalDets() const { return std::vector<const o2::tpc::CalDet<float>*>{&mCalDets.at("Pedestals"), &mCalDets.at("Noise")}; }
 
   /// Get the statistics type
   StatisticsType getStatisticsType() const { return mStatisticsType; }
@@ -122,14 +126,13 @@ class CalibPedestal : public CalibRawBase
   TH2* createControlHistogram(ROC roc);
 
  private:
-  int mFirstTimeBin;              ///< first time bin used in analysis
-  int mLastTimeBin;               ///< first time bin used in analysis
-  int mADCMin;                    ///< minimum adc value
-  int mADCMax;                    ///< maximum adc value
-  int mNumberOfADCs;              ///< number of adc values (mADCMax-mADCMin+1)
-  StatisticsType mStatisticsType; ///< statistics type to be used for pedestal and noise evaluation
-  CalPad mPedestal;               ///< CalDet object with pedestal information
-  CalPad mNoise;                  ///< CalDet object with noise
+  int mFirstTimeBin;                                ///< first time bin used in analysis
+  int mLastTimeBin;                                 ///< first time bin used in analysis
+  int mADCMin;                                      ///< minimum adc value
+  int mADCMax;                                      ///< maximum adc value
+  int mNumberOfADCs;                                ///< number of adc values (mADCMax-mADCMin+1)
+  StatisticsType mStatisticsType;                   ///< statistics type to be used for pedestal and noise evaluation
+  std::unordered_map<std::string, CalPad> mCalDets; ///< CalDet objects for pedestal and noise
 
   std::vector<std::unique_ptr<vectorType>> mADCdata; //!< ADC data to calculate noise and pedestal
 

--- a/Detectors/TPC/calibration/include/TPCCalibration/CalibPulser.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/CalibPulser.h
@@ -17,6 +17,7 @@
 
 #include <vector>
 #include <memory>
+#include <unordered_map>
 
 #include "TH2S.h"
 
@@ -83,8 +84,8 @@ class CalibPulser : public CalibRawBase
   {
     mFirstTimeBin = first;
     mLastTimeBin = last;
-    //TODO: until automatic T0 calibration is done we use the same time range
-    //      as for the time bin selection
+    // TODO: until automatic T0 calibration is done we use the same time range
+    //       as for the time bin selection
     mXminT0 = mFirstTimeBin;
     mXmaxT0 = mLastTimeBin;
   }
@@ -134,15 +135,17 @@ class CalibPulser : public CalibRawBase
 
   /// Get the pulser mean time calibration object
   /// \return pedestal calibration object
-  const CalPad& getT0() const { return mT0; }
+  const CalPad& getT0() const { return mCalDets.at("T0"); }
 
   /// Get the pulser pulse with calibration object
   /// \return pulse width calibration object
-  const CalPad& getWidth() const { return mWidth; }
+  const CalPad& getWidth() const { return mCalDets.at("Width"); }
 
   /// Get the pulser total charge calibration object
   /// \return pulser total charge calibration object
-  const CalPad& getQtot() const { return mQtot; }
+  const CalPad& getQtot() const { return mCalDets.at("Qtot"); }
+
+  const auto& getCalDets() const { return mCalDets; }
 
   /// Dump the relevant data to file
   void dumpToFile(const std::string filename, uint32_t type = 0) final;
@@ -165,19 +168,17 @@ class CalibPulser : public CalibRawBase
   float mXminWidth; ///< xmin   of width reference histogram
   float mXmaxWidth; ///< xmax   of width reference histogram
 
-  int mFirstTimeBin;    ///< first time bin used in analysis
-  int mLastTimeBin;     ///< first time bin used in analysis
-  int mADCMin;          ///< minimum adc value
-  int mADCMax;          ///< maximum adc value
-  int mNumberOfADCs;    ///< number of adc values (mADCMax-mADCMin+1)
-  int mPeakIntMinus;    ///< lower bound from maximum for the peak integration, mean and std dev. calc
-  int mPeakIntPlus;     ///< upper bound from maximum for the peak integration, mean and std dev. calc
-  float mMinimumQtot;   ///< minimal Qtot accepted as pulser signal
-  float mMinimumQmax;   ///< minimal Qtot accepted as pulser signal
-  int mMaxTimeBinRange; ///< number of time bins around the one with the maximum number of entries arouch which to analyse
-  CalPad mT0;           ///< CalDet object with pulser time information
-  CalPad mWidth;        ///< CalDet object with pulser pulse width information
-  CalPad mQtot;         ///< CalDet object with pulser Qtot information
+  int mFirstTimeBin;                                ///< first time bin used in analysis
+  int mLastTimeBin;                                 ///< first time bin used in analysis
+  int mADCMin;                                      ///< minimum adc value
+  int mADCMax;                                      ///< maximum adc value
+  int mNumberOfADCs;                                ///< number of adc values (mADCMax-mADCMin+1)
+  int mPeakIntMinus;                                ///< lower bound from maximum for the peak integration, mean and std dev. calc
+  int mPeakIntPlus;                                 ///< upper bound from maximum for the peak integration, mean and std dev. calc
+  float mMinimumQtot;                               ///< minimal Qtot accepted as pulser signal
+  float mMinimumQmax;                               ///< minimal Qtot accepted as pulser signal
+  int mMaxTimeBinRange;                             ///< number of time bins around the one with the maximum number of entries arouch which to analyse
+  std::unordered_map<std::string, CalPad> mCalDets; ///< CalDet objects for pedestal and noise
 
   const CalPad* mPedestal; //!< Pedestal calibration object
   const CalPad* mNoise;    //!< Noise calibration object

--- a/Detectors/TPC/calibration/include/TPCCalibration/CalibPulserParam.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/CalibPulserParam.h
@@ -25,23 +25,24 @@ namespace tpc
 {
 
 struct CalibPulserParam : public o2::conf::ConfigurableParamHelper<CalibPulserParam> {
-  int NbinsT0{200};      ///< Number of bins for T0 reference histogram
-  float XminT0{-2};      ///< xmin   of T0 reference histogram
-  float XmaxT0{2};       ///< xmax   of T0 reference histogram
-  int NbinsQtot{200};    ///< Number of bins for Qtot reference histogram
-  float XminQtot{50};    ///< xmin   of Qtot reference histogram
-  float XmaxQtot{700};   ///< xmax   of Qtot reference histogram
-  int NbinsWidth{100};   ///< Number of bins for width reference histogram
-  float XminWidth{0.1};  ///< xmin   of width reference histogram
-  float XmaxWidth{5.1};  ///< xmax   of width reference histogram
-  int FirstTimeBin{10};  ///< first time bin used in analysis
-  int LastTimeBin{490};  ///< first time bin used in analysis
-  int ADCMin{5};         ///< minimum adc value
-  int ADCMax{1023};      ///< maximum adc value
-  int PeakIntMinus{2};   ///< lower bound from maximum for the peak integration, mean and std dev. calc
-  int PeakIntPlus{2};    ///< upper bound from maximum for the peak integration, mean and std dev. calc
-  float MinimumQtot{20}; ///< minimal Qtot accepted as pulser signal
-  float MinimumQmax{10}; ///< minimal Qmax accepted as pulser signal
+  int NbinsT0{200};       ///< Number of bins for T0 reference histogram
+  float XminT0{-2};       ///< xmin   of T0 reference histogram
+  float XmaxT0{2};        ///< xmax   of T0 reference histogram
+  int NbinsQtot{200};     ///< Number of bins for Qtot reference histogram
+  float XminQtot{50};     ///< xmin   of Qtot reference histogram
+  float XmaxQtot{700};    ///< xmax   of Qtot reference histogram
+  int NbinsWidth{100};    ///< Number of bins for width reference histogram
+  float XminWidth{0.1};   ///< xmin   of width reference histogram
+  float XmaxWidth{5.1};   ///< xmax   of width reference histogram
+  int FirstTimeBin{10};   ///< first time bin used in analysis
+  int LastTimeBin{490};   ///< first time bin used in analysis
+  int ADCMin{5};          ///< minimum adc value
+  int ADCMax{1023};       ///< maximum adc value
+  int PeakIntMinus{2};    ///< lower bound from maximum for the peak integration, mean and std dev. calc
+  int PeakIntPlus{2};     ///< upper bound from maximum for the peak integration, mean and std dev. calc
+  float MinimumQtot{20};  ///< minimal Qtot accepted as pulser signal
+  float MinimumQmax{10};  ///< minimal Qmax accepted as pulser signal
+  int MaxTimeBinRange{5}; ///< number of time bins around the one with the maximum number of entries arouch which to analyse
 
   O2ParamDef(CalibPulserParam, "TPCCalibPulser");
 };

--- a/Detectors/TPC/calibration/macro/drawNoiseAndPedestal.C
+++ b/Detectors/TPC/calibration/macro/drawNoiseAndPedestal.C
@@ -55,7 +55,7 @@ TObjArray* drawNoiseAndPedestal(std::string_view pedestalFile, int mode = 0, std
     if (pedestalFile.find("cdb-test") == 0) {
       cdb.setURL("http://ccdb-test.cern.ch:8080");
     } else if (pedestalFile.find("cdb-prod") == 0) {
-      cdb.setURL("");
+      cdb.setURL("http://alice-ccdb.cern.ch");
     }
     const auto timePos = pedestalFile.find("@");
     if (timePos != std::string_view::npos) {

--- a/Detectors/TPC/calibration/src/CalibPedestal.cxx
+++ b/Detectors/TPC/calibration/src/CalibPedestal.cxx
@@ -35,11 +35,11 @@ CalibPedestal::CalibPedestal(PadSubset padSubset)
     mADCMax(140),
     mNumberOfADCs(mADCMax - mADCMin + 1),
     mStatisticsType(StatisticsType::GausFitFast),
-    mPedestal("Pedestals", padSubset),
-    mNoise("Noise", padSubset),
     mADCdata()
 
 {
+  mCalDets["Pedestals"] = CalPad("Pedestals");
+  mCalDets["Noise"] = CalPad("Noise");
   mADCdata.resize(ROC::MaxROC);
 }
 //______________________________________________________________________________
@@ -72,7 +72,7 @@ Int_t CalibPedestal::updateROC(const Int_t roc, const Int_t row, const Int_t pad
   vectorType& adcVec = *getVector(ROC(roc), kTRUE);
   ++(adcVec[bin]);
 
-  //printf("bin: %5d, val: %.2f\n", bin, adcVec[bin]);
+  // printf("bin: %5d, val: %.2f\n", bin, adcVec[bin]);
 
   return 0;
 }
@@ -109,8 +109,8 @@ void CalibPedestal::analyse()
       continue;
     }
 
-    CalROC& calROCPedestal = mPedestal.getCalArray(roc);
-    CalROC& calROCNoise = mNoise.getCalArray(roc);
+    CalROC& calROCPedestal = mCalDets["Pedestals"].getCalArray(roc);
+    CalROC& calROCNoise = mCalDets["Noise"].getCalArray(roc);
 
     float* array = vec->data();
 
@@ -142,7 +142,7 @@ void CalibPedestal::analyse()
       calROCPedestal.setValue(ichannel, pedestal);
       calROCNoise.setValue(ichannel, noise);
 
-      //printf("roc: %2d, channel: %4d, pedestal: %.2f, noise: %.2f\n", roc.getRoc(), ichannel, pedestal, noise);
+      // printf("roc: %2d, channel: %4d, pedestal: %.2f, noise: %.2f\n", roc.getRoc(), ichannel, pedestal, noise);
     }
 
     ++roc;
@@ -166,8 +166,8 @@ void CalibPedestal::dumpToFile(const std::string filename, uint32_t type /* = 0*
 {
   auto f = std::unique_ptr<TFile>(TFile::Open(filename.c_str(), "recreate"));
   if (type == 0) {
-    f->WriteObject(&mPedestal, "Pedestals");
-    f->WriteObject(&mNoise, "Noise");
+    f->WriteObject(&mCalDets["Pedestals"], "Pedestals");
+    f->WriteObject(&mCalDets["Noise"], "Noise");
     f->Close();
   } else if (type == 1) {
     f->WriteObject(this, "CalibPedestal");

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/KrBoxClusterFinderParam.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/KrBoxClusterFinderParam.h
@@ -17,6 +17,8 @@
 #ifndef ALICEO2_TPC_KrBoxClusterFinderParam_H_
 #define ALICEO2_TPC_KrBoxClusterFinderParam_H_
 
+#include <string>
+
 #include "CommonUtils/ConfigurableParam.h"
 #include "CommonUtils/ConfigurableParamHelper.h"
 
@@ -55,6 +57,9 @@ struct KrBoxClusterFinderParam : public o2::conf::ConfigurableParamHelper<KrBoxC
   float CutQtotSizeSlope{0};     ///< Max Qtot over size slope for Qtot vs. size correlation cut
   unsigned char CutMaxSize{255}; ///< Max cluster size in number of digits
   bool ApplyCuts{false};         ///< if to apply cluster cuts above
+
+  std::string GainMapFile{};          ///< gain map file to apply during reconstruction
+  std::string GainMapName{"GainMap"}; ///< gain map file to apply during reconstruction
 
   O2ParamDef(KrBoxClusterFinderParam, "TPCKrBoxClusterFinder");
 };

--- a/Detectors/TPC/reconstruction/src/KrBoxClusterFinder.cxx
+++ b/Detectors/TPC/reconstruction/src/KrBoxClusterFinder.cxx
@@ -72,7 +72,7 @@ void KrBoxClusterFinder::fillADCValueInLastSlice(int cru, int rowInSector, int p
   int padNum = mMapperInstance.globalPadNumber(PadPos(rowInSector, padInRow));
   float correctionFactor = correctionFactorCalDet->getValue(mSector, padNum);
 
-  if (correctionFactor == 0) {
+  if (correctionFactor <= 0) {
     LOGP(warning, "Encountered correction factor which is zero.");
     LOGP(warning, "Digit will be set to 0!");
     adcValue = 0;
@@ -158,6 +158,11 @@ void KrBoxClusterFinder::init()
   mCutQtotSizeSlope = param.CutQtotSizeSlope;
   mCutMaxSize = param.CutMaxSize;
   mApplyCuts = param.ApplyCuts;
+
+  if (param.GainMapFile.size()) {
+    LOGP(info, "loading gain map '{}' from file {}", param.GainMapName, param.GainMapFile);
+    loadGainMapFromFile(param.GainMapFile, param.GainMapName);
+  }
 }
 
 //#################################################

--- a/Detectors/TPC/workflow/CMakeLists.txt
+++ b/Detectors/TPC/workflow/CMakeLists.txt
@@ -68,9 +68,9 @@ o2_add_executable(raw-to-digits-workflow
                   SOURCES src/tpc-raw-to-digits-workflow.cxx
                   PUBLIC_LINK_LIBRARIES O2::TPCWorkflow)
 
-o2_add_executable(calib-pedestal
+o2_add_executable(calib-pad-raw
                   COMPONENT_NAME tpc
-                  SOURCES src/tpc-calib-pedestal.cxx
+                  SOURCES src/tpc-calib-pad-raw.cxx
                   PUBLIC_LINK_LIBRARIES O2::TPCWorkflow)
 
 o2_add_executable(laser-tracks-calibrator

--- a/Detectors/TPC/workflow/include/TPCWorkflow/MonitorWorkflowSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/MonitorWorkflowSpec.h
@@ -24,7 +24,7 @@ namespace o2::tpc
 
 /// create a processor spec
 /// read simulated TPC clusters from file and publish
-o2::framework::DataProcessorSpec getMonitorWorkflowSpec(bool useDigitsAsInput, std::string inputSpec = "tpcraw:TPC/RAWDATA");
+o2::framework::DataProcessorSpec getMonitorWorkflowSpec(std::string inputSpec = "tpcraw:TPC/RAWDATA");
 
 } // namespace o2::tpc
 

--- a/Detectors/TPC/workflow/include/TPCWorkflow/RawToDigitsSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/RawToDigitsSpec.h
@@ -27,7 +27,7 @@ namespace tpc
 
 /// create a processor spec
 /// read simulated TPC clusters from file and publish
-o2::framework::DataProcessorSpec getRawToDigitsSpec(int channel, const std::string inputSpec, std::vector<int> const& tpcSectors);
+o2::framework::DataProcessorSpec getRawToDigitsSpec(int channel, const std::string inputSpec, std::vector<int> const& tpcSectors, bool sendCEdigits = false);
 
 } // end namespace tpc
 } // end namespace o2

--- a/Detectors/TPC/workflow/src/CalibProcessingHelper.cxx
+++ b/Detectors/TPC/workflow/src/CalibProcessingHelper.cxx
@@ -44,6 +44,15 @@ uint64_t calib_processing_helper::processRawData(o2::framework::InputRecord& inp
     sampledData = false;
     break;
   }
+  // used for online monitor
+  if (sampledData) {
+    filter = {{"sampled-rawdata", ConcreteDataTypeMatcher{"DS2", "RAWDATA"}, Lifetime::Timeframe}};
+    for ([[maybe_unused]] auto const& ref : InputRecordWalker(inputs, filter)) {
+      sampledData = false;
+      break;
+    }
+  }
+  // used for QC
   if (sampledData) {
     filter = {{"sampled-rawdata", ConcreteDataTypeMatcher{"DS", "RAWDATA"}, Lifetime::Timeframe}};
     LOGP(info, "Using sampled data");
@@ -126,7 +135,7 @@ uint64_t calib_processing_helper::processRawData(o2::framework::InputRecord& inp
           }
         }
 
-        //firstOrbit = RDHUtils::getHeartBeatOrbit(*rdhPtr);
+        // firstOrbit = RDHUtils::getHeartBeatOrbit(*rdhPtr);
         LOGP(info, "First orbit in present TF: {}", firstOrbit);
         readFirst = true;
       }
@@ -169,7 +178,7 @@ void processGBT(o2::framework::RawParser<>& parser, std::unique_ptr<RawReaderCRU
 
     const auto size = it.size();
     auto data = it.data();
-    //LOGP(info, "Data size: {}", size);
+    // LOGP(info, "Data size: {}", size);
 
     int iFrame = 0;
     for (int i = 0; i < size; i += 16) {
@@ -198,9 +207,9 @@ void processLinkZS(o2::framework::RawParser<>& parser, std::unique_ptr<RawReader
       throw std::runtime_error("could not get RDH from packet");
     }
     // workaround for MW2 data
-    //const bool useTimeBins = true;
-    //const auto cru = RDHUtils::getCRUID(*rdhPtr);
-    //const auto feeID = (RDHUtils::getFEEID(*rdhPtr) & 0x7f) | (cru << 7);
+    // const bool useTimeBins = true;
+    // const auto cru = RDHUtils::getCRUID(*rdhPtr);
+    // const auto feeID = (RDHUtils::getFEEID(*rdhPtr) & 0x7f) | (cru << 7);
 
     // skip all data that is not Link-base zero suppression
     const auto link = RDHUtils::getLinkID(*rdhPtr);

--- a/Detectors/TPC/workflow/src/MonitorWorkflowSpec.cxx
+++ b/Detectors/TPC/workflow/src/MonitorWorkflowSpec.cxx
@@ -161,12 +161,9 @@ class TPCMonitorDevice : public o2::framework::Task
   }
 };
 
-DataProcessorSpec getMonitorWorkflowSpec(bool useDigitsAsInput, std::string inputSpec)
+DataProcessorSpec getMonitorWorkflowSpec(std::string inputSpec)
 {
-  if (useDigitsAsInput) {
-    inputSpec = "tpcdigits:TPC/DIGITS";
-  }
-
+  const bool useDigitsAsInput = inputSpec.find("DIGITS") != std::string::npos;
   std::vector<OutputSpec> outputs;
 
   return DataProcessorSpec{

--- a/Detectors/TPC/workflow/src/RawToDigitsSpec.cxx
+++ b/Detectors/TPC/workflow/src/RawToDigitsSpec.cxx
@@ -10,6 +10,7 @@
 // or submit itself to any jurisdiction.
 
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 #include <string>
 #include "fmt/format.h"
@@ -45,7 +46,7 @@ namespace tpc
 class TPCDigitDumpDevice : public o2::framework::Task
 {
  public:
-  TPCDigitDumpDevice(const std::vector<int>& sectors) : mSectors(sectors) {}
+  TPCDigitDumpDevice(const std::vector<int>& sectors, bool sendCEdigits) : mSectors(sectors), mSendCEdigits(sendCEdigits) {}
 
   void init(o2::framework::InitContext& ic) final
   {
@@ -56,7 +57,11 @@ class TPCDigitDumpDevice : public o2::framework::Task
     mForceQuit = ic.options().get<bool>("force-quit");
     mCheckDuplicates = ic.options().get<bool>("check-for-duplicates");
     mRemoveDuplicates = ic.options().get<bool>("remove-duplicates");
-    mRemoveCEdigits = ic.options().get<bool>("remove-ce-digits");
+    if (mSendCEdigits) {
+      mRemoveCEdigits = true;
+    } else {
+      mRemoveCEdigits = ic.options().get<bool>("remove-ce-digits");
+    }
 
     if (mUseOldSubspec) {
       LOGP(info, "Using old subspecification (CruId << 16) | ((LinkId + 1) << (CruEndPoint == 1 ? 8 : 0))");
@@ -65,13 +70,15 @@ class TPCDigitDumpDevice : public o2::framework::Task
     // set up ADC value filling
     mRawReader.createReader("");
 
-    const auto inputGRP = o2::base::NameConf::getGRPFileName();
-    const auto grp = o2::parameters::GRPObject::loadFrom(inputGRP);
-    if (grp) {
-      const auto nhbf = (int)grp->getNHBFPerTF();
-      const int lastTimeBin = nhbf * 891 / 2;
-      mDigitDump.setTimeBinRange(0, lastTimeBin);
-      LOGP(info, "Using GRP NHBF = {} to set last time bin to {}, might be overwritte via --configKeyValues", nhbf, lastTimeBin);
+    if (!ic.options().get<bool>("ignore-grp")) {
+      const auto inputGRP = o2::base::NameConf::getGRPFileName();
+      const auto grp = o2::parameters::GRPObject::loadFrom(inputGRP);
+      if (grp) {
+        const auto nhbf = (int)grp->getNHBFPerTF();
+        const int lastTimeBin = nhbf * 891 / 2;
+        mDigitDump.setTimeBinRange(0, lastTimeBin);
+        LOGP(info, "Using GRP NHBF = {} to set last time bin to {}, might be overwritte via --configKeyValues", nhbf, lastTimeBin);
+      }
     }
 
     mDigitDump.init();
@@ -83,7 +90,11 @@ class TPCDigitDumpDevice : public o2::framework::Task
         auto& cdb = o2::ccdb::BasicCCDBManager::instance();
         cdb.setURL(pedestalFile);
         if (cdb.isHostReachable()) {
-          auto pedestal = cdb.get<CalPad>("TPC/Calib/Pedestal");
+          auto pedestalNoise = cdb.get<std::unordered_map<std::string, CalPad>>("TPC/Calib/PedestalNoise");
+          CalPad* pedestal = nullptr;
+          if (pedestalNoise) {
+            pedestal = &pedestalNoise->at("Pedestals");
+          }
           if (pedestal) {
             mDigitDump.setPedestals(pedestal);
           } else {
@@ -145,7 +156,7 @@ class TPCDigitDumpDevice : public o2::framework::Task
         pc.services().get<ControlService>().endOfStream();
         pc.services().get<ControlService>().readyToQuit(QuitRequest::All);
       } else {
-        //pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+        // pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
       }
     }
   }
@@ -175,6 +186,7 @@ class TPCDigitDumpDevice : public o2::framework::Task
   bool mCheckDuplicates{false};
   bool mRemoveDuplicates{false};
   bool mRemoveCEdigits{false};
+  bool mSendCEdigits{false};
   uint64_t mActiveSectors{0};  ///< bit mask of active sectors
   std::vector<int> mSectors{}; ///< tpc sector configuration
 
@@ -188,8 +200,9 @@ class TPCDigitDumpDevice : public o2::framework::Task
       mDigitDump.sortDigits();
     }
 
+    std::array<std::vector<Digit>, Sector::MAXSECTOR> ceDigits;
     if (mRemoveCEdigits) {
-      mDigitDump.removeCEdigits();
+      mDigitDump.removeCEdigits(10, 100, &ceDigits);
     }
 
     for (auto isector : mSectors) {
@@ -198,6 +211,10 @@ class TPCDigitDumpDevice : public o2::framework::Task
       // digit for now are transported per sector, not per lane
       output.snapshot(Output{"TPC", "DIGITS", static_cast<SubSpecificationType>(isector), Lifetime::Timeframe, header},
                       mDigitDump.getDigits(isector));
+      if (mSendCEdigits) {
+        output.snapshot(Output{"TPC", "CEDIGITS", static_cast<SubSpecificationType>(isector), Lifetime::Timeframe, header},
+                        ceDigits[isector]);
+      }
     }
     mDigitDump.clearDigits();
     mActiveSectors = 0;
@@ -211,20 +228,23 @@ class TPCDigitDumpDevice : public o2::framework::Task
   }
 };
 
-DataProcessorSpec getRawToDigitsSpec(int channel, const std::string inputSpec, std::vector<int> const& tpcSectors)
+DataProcessorSpec getRawToDigitsSpec(int channel, const std::string inputSpec, std::vector<int> const& tpcSectors, bool sendCEdigits)
 {
   using device = o2::tpc::TPCDigitDumpDevice;
 
   std::vector<OutputSpec> outputs;
   for (auto isector : tpcSectors) {
     outputs.emplace_back("TPC", "DIGITS", static_cast<SubSpecificationType>(isector), Lifetime::Timeframe);
+    if (sendCEdigits) {
+      outputs.emplace_back("TPC", "CEDIGITS", static_cast<SubSpecificationType>(isector), Lifetime::Timeframe);
+    }
   }
 
   return DataProcessorSpec{
     fmt::format("tpc-raw-to-digits-{}", channel),
     select(inputSpec.data()),
     outputs,
-    AlgorithmSpec{adaptFromTask<device>(tpcSectors)},
+    AlgorithmSpec{adaptFromTask<device>(tpcSectors, sendCEdigits)},
     Options{
       {"max-events", VariantType::Int, 0, {"maximum number of events to process"}},
       {"use-old-subspec", VariantType::Bool, false, {"use old subsecifiation definition"}},
@@ -234,6 +254,7 @@ DataProcessorSpec getRawToDigitsSpec(int channel, const std::string inputSpec, s
       {"check-for-duplicates", VariantType::Bool, false, {"check if duplicate digits exist and only report them"}},
       {"remove-duplicates", VariantType::Bool, false, {"check if duplicate digits exist and remove them"}},
       {"remove-ce-digits", VariantType::Bool, false, {"find CE position and remove digits around it"}},
+      {"ignore-grp", VariantType::Bool, false, {"ignore GRP file"}},
     } // end Options
   };  // end DataProcessorSpec
 }

--- a/Detectors/TPC/workflow/src/tpc-calib-pad-raw.cxx
+++ b/Detectors/TPC/workflow/src/tpc-calib-pad-raw.cxx
@@ -9,6 +9,10 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+/// @brief  TPC Pad-wise raw data calibration
+/// @author Jens Wiechula
+/// @author David Silvermyr
+//
 #include <fmt/format.h>
 #include "Algorithm/RangeTokenizer.h"
 #include "Framework/WorkflowSpec.h"
@@ -29,17 +33,19 @@
 #include <string>
 #include "DetectorsRaw/RDHUtils.h"
 #include "TPCBase/RDHUtils.h"
-#include "TPCWorkflow/TPCCalibPedestalSpec.h"
+#include "TPCWorkflow/TPCCalibPadRawSpec.h"
 #include "TPCWorkflow/CalDetMergerPublisherSpec.h"
 
 using namespace o2::framework;
 using RDHUtils = o2::raw::RDHUtils;
 
+const std::string DEFAULTINPUT = "A:TPC/RAWDATA";
+
 // customize the completion policy
 void customize(std::vector<o2::framework::CompletionPolicy>& policies)
 {
   using o2::framework::CompletionPolicy;
-  policies.push_back(CompletionPolicyHelpers::defineByName("calib-tpc-pedestal.*", CompletionPolicy::CompletionOp::Consume));
+  policies.push_back(CompletionPolicyHelpers::defineByName("calib-tpc-raw.*", CompletionPolicy::CompletionOp::Consume));
   policies.push_back(CompletionPolicyHelpers::defineByName("calib-tpc-caldet-merger-publisher", CompletionPolicy::CompletionOp::Consume));
 }
 
@@ -50,10 +56,11 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
   int defaultlanes = std::max(1u, std::thread::hardware_concurrency() / 2);
 
   std::vector<ConfigParamSpec> options{
-    {"input-spec", VariantType::String, "A:TPC/RAWDATA", {"selection string input specs"}},
+    {"input-spec", VariantType::String, DEFAULTINPUT, {"selection string input specs"}},
     {"publish-after-tfs", VariantType::Int, 0, {"number of time frames after which to force publishing the objects"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings (e.g.: 'TPCCalibPedestal.FirstTimeBin=10;...')"}},
     {"configFile", VariantType::String, "", {"configuration file for configurable parameters"}},
+    {"calib-type", VariantType::String, "pedestal", {"Calibration type to run: pedestal, pulser, ce"}},
     {"no-write-ccdb", VariantType::Bool, false, {"skip sending the calibration output to CCDB"}},
     {"lanes", VariantType::Int, defaultlanes, {"Number of parallel processing lanes."}},
     {"sectors", VariantType::String, sectorDefault.c_str(), {"List of TPC sectors, comma separated ranges, e.g. 0-3,7,9-15"}},
@@ -75,14 +82,24 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
   o2::conf::ConfigurableParam::updateFromString(config.options().get<std::string>("configKeyValues"));
   o2::conf::ConfigurableParam::writeINI("o2tpccalibration_configuration.ini");
 
-  const std::string inputSpec = config.options().get<std::string>("input-spec");
+  std::string inputSpec = config.options().get<std::string>("input-spec");
   const auto skipCCDB = config.options().get<bool>("no-write-ccdb");
   const auto publishAfterTFs = (uint32_t)config.options().get<int>("publish-after-tfs");
 
   const auto tpcsectors = o2::RangeTokenizer::tokenize<int>(config.options().get<std::string>("sectors"));
   const auto nSectors = (uint32_t)tpcsectors.size();
-  const auto nLanes = std::min((uint32_t)config.options().get<int>("lanes"), nSectors);
+  auto nLanes = std::min((uint32_t)config.options().get<int>("lanes"), nSectors);
   const auto sectorsPerLane = nSectors / nLanes + ((nSectors % nLanes) != 0);
+
+  CDBType rawType;
+  try {
+    rawType = CalibRawTypeMap.at(config.options().get<std::string>("calib-type"));
+    if ((rawType == CDBType::CalCE) && (inputSpec == DEFAULTINPUT)) {
+      inputSpec = "tpcdigits:TPC/CEDIGITS";
+    }
+  } catch (std::out_of_range&) {
+    throw std::invalid_argument(std::string("invalid writer-type type: ") + config.options().get<std::string>("calib-type"));
+  }
 
   WorkflowSpec workflow;
 
@@ -90,6 +107,11 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
     return workflow;
   }
 
+  const bool digitInput = inputSpec.find("DIGITS") != std::string::npos;
+  if (digitInput && nLanes != 1) {
+    LOGP(info, "only one lane allowed for DIGIT type input");
+    nLanes = 1;
+  }
   for (int ilane = 0; ilane < nLanes; ++ilane) {
     auto first = tpcsectors.begin() + ilane * sectorsPerLane;
     if (first >= tpcsectors.end()) {
@@ -97,7 +119,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
     }
     auto last = std::min(tpcsectors.end(), first + sectorsPerLane);
     std::vector<int> range(first, last);
-    workflow.emplace_back(getTPCCalibPedestalSpec(inputSpec, ilane, range, publishAfterTFs));
+    workflow.emplace_back(getTPCCalibPadRawSpec(inputSpec, ilane, range, publishAfterTFs, rawType));
   }
 
   workflow.emplace_back(getCalDetMergerPublisherSpec(nLanes, skipCCDB, publishAfterTFs > 0));

--- a/Detectors/TPC/workflow/src/tpc-monitor-workflow.cxx
+++ b/Detectors/TPC/workflow/src/tpc-monitor-workflow.cxx
@@ -45,11 +45,14 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 WorkflowSpec defineDataProcessing(ConfigContext const& cfg)
 {
   const bool useDigitsAsInput = cfg.options().get<bool>("use-digit-input");
-  const auto inputSpec = cfg.options().get<std::string>("input-spec");
+  auto inputSpec = cfg.options().get<std::string>("input-spec");
+  if (useDigitsAsInput) {
+    inputSpec = "tpcdigits:TPC/DIGITS";
+  }
 
   WorkflowSpec specs;
 
-  specs.emplace_back(o2::tpc::getMonitorWorkflowSpec(useDigitsAsInput, inputSpec));
+  specs.emplace_back(o2::tpc::getMonitorWorkflowSpec(inputSpec));
 
   return specs;
 }

--- a/Detectors/TPC/workflow/src/tpc-raw-to-digits-workflow.cxx
+++ b/Detectors/TPC/workflow/src/tpc-raw-to-digits-workflow.cxx
@@ -52,6 +52,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"tpc-lanes", VariantType::Int, defaultlanes, {laneshelp}},
     {"tpc-sectors", VariantType::String, sectorDefault.c_str(), {sectorshelp}},
     {"tpc-reco-output", VariantType::String, "", {tpcrthelp}},
+    {"send-ce-digits", VariantType::Bool, false, {"filter CE digits and publish them for analysis on a separate stream"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings (e.g.: 'TPCCalibPedestal.FirstTimeBin=10;...')"}},
     {"configFile", VariantType::String, "", {"configuration file for configurable parameters"}}};
 
@@ -86,11 +87,12 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 
   // for the moment no parallel workflow, so just one lane hard coded
   auto tpcSectors = o2::RangeTokenizer::tokenize<int>(configcontext.options().get<std::string>("tpc-sectors"));
-  auto lanes = 1; //getNumTPCLanes(tpcSectors, configcontext);
+  auto lanes = 1; // getNumTPCLanes(tpcSectors, configcontext);
+  const bool sendCEdigits = configcontext.options().get<bool>("send-ce-digits");
 
   int fanoutsize = 0;
   for (int l = 0; l < lanes; ++l) {
-    specs.emplace_back(o2::tpc::getRawToDigitsSpec(fanoutsize, configcontext.options().get<std::string>("input-spec"), tpcSectors));
+    specs.emplace_back(o2::tpc::getRawToDigitsSpec(fanoutsize, configcontext.options().get<std::string>("input-spec"), tpcSectors, sendCEdigits));
     fanoutsize++;
   }
 


### PR DESCRIPTION
* Generalize and rename pedestal workflow
      - to be able to process pulser and CE data
      - use digits as input
* Inernally use unordered_map of CalPad in pedestal and pulser calib
* Write Pedestal and Noise output to one ccdb entry
* CalDetMergerPublisherSpec can take unordered_map of CalPads
* MonitorWorkflowSpec can use digits as input