### PR TITLE
Send dummy output if data was not found in TF

### DIFF
--- a/Detectors/Raw/TFReaderDD/include/TFReaderDD/SubTimeFrameFile.h
+++ b/Detectors/Raw/TFReaderDD/include/TFReaderDD/SubTimeFrameFile.h
@@ -267,6 +267,21 @@ std::ostream& operator<<(std::ostream& pStream, const SubTimeFrameFileDataIndex&
 namespace std
 {
 template <>
+struct hash<o2::header::DataOrigin> {
+  typedef o2::header::DataOrigin argument_type;
+  typedef std::uint32_t result_type;
+
+  result_type operator()(argument_type const& a) const noexcept
+  {
+
+    static_assert(sizeof(o2::header::DataOrigin::ItgType) == sizeof(uint32_t) &&
+                    sizeof(o2::header::DataOrigin) == 4,
+                  "DataOrigin must be 4B long (uint32_t itg[1])");
+    return std::hash<o2::header::DataOrigin::ItgType>{}(a.itg[0]);
+  }
+};
+
+template <>
 struct hash<o2::header::DataDescription> {
   typedef o2::header::DataDescription argument_type;
   typedef std::uint64_t result_type;
@@ -280,22 +295,6 @@ struct hash<o2::header::DataDescription> {
 
     return std::hash<o2::header::DataDescription::ItgType>{}(a.itg[0]) ^
            std::hash<o2::header::DataDescription::ItgType>{}(a.itg[1]);
-  }
-};
-
-template <>
-struct hash<o2::header::DataOrigin> {
-  typedef o2::header::DataOrigin argument_type;
-  typedef std::uint32_t result_type;
-
-  result_type operator()(argument_type const& a) const noexcept
-  {
-
-    static_assert(sizeof(o2::header::DataOrigin::ItgType) == sizeof(uint32_t) &&
-                    sizeof(o2::header::DataOrigin) == 4,
-                  "DataOrigin must be 4B long (uint32_t itg[1])");
-
-    return std::hash<o2::header::DataOrigin::ItgType>{}(a.itg[0]);
   }
 };
 

--- a/Detectors/Raw/TFReaderDD/include/TFReaderDD/SubTimeFrameFileReader.h
+++ b/Detectors/Raw/TFReaderDD/include/TFReaderDD/SubTimeFrameFileReader.h
@@ -14,6 +14,7 @@
 #ifndef ALICEO2_SUBTIMEFRAME_FILE_READER_RAWDD_H_
 #define ALICEO2_SUBTIMEFRAME_FILE_READER_RAWDD_H_
 
+#include "TFReaderDD/SubTimeFrameFile.h"
 #include <Headers/DataHeader.h>
 #include <Headers/STFHeader.h>
 #include "DetectorsCommonDataFormats/DetID.h"

--- a/Detectors/Raw/TFReaderDD/src/SubTimeFrameFileReader.cxx
+++ b/Detectors/Raw/TFReaderDD/src/SubTimeFrameFileReader.cxx
@@ -11,7 +11,6 @@
 
 // Adapthed with minimal changes from Gvozden Nescovic code to read sTFs files created by DataDistribution
 
-#include "TFReaderDD/SubTimeFrameFile.h"
 #include "TFReaderDD/SubTimeFrameFileReader.h"
 #include "DetectorsRaw/RDHUtils.h"
 #include "Framework/Logger.h"

--- a/Detectors/Raw/TFReaderDD/src/TFReaderSpec.cxx
+++ b/Detectors/Raw/TFReaderDD/src/TFReaderSpec.cxx
@@ -25,6 +25,7 @@
 #include <fairmq/FairMQDevice.h>
 #include "TFReaderSpec.h"
 #include "TFReaderDD/SubTimeFrameFileReader.h"
+#include "TFReaderDD/SubTimeFrameFile.h"
 #include "CommonUtils/FileFetcher.h"
 #include "CommonUtils/FIFO.h"
 #include <unistd.h>
@@ -45,9 +46,14 @@ namespace o2f = o2::framework;
 class TFReaderSpec : public o2f::Task
 {
  public:
+  struct SubSpecCount {
+    uint32_t defSubSpec = 0xdeadbeef;
+    int count = -1;
+  };
+
   using TFMap = std::unordered_map<std::string, std::unique_ptr<FairMQParts>>; // map of channel / TFparts
 
-  explicit TFReaderSpec(const TFReaderInp& rinp) : mInput(rinp) {}
+  explicit TFReaderSpec(const TFReaderInp& rinp);
   void init(o2f::InitContext& ic) final;
   void run(o2f::ProcessingContext& ctx) final;
   void endOfStream(o2f::EndOfStreamContext& ec) final;
@@ -61,12 +67,22 @@ class TFReaderSpec : public o2f::Task
   std::vector<o2f::OutputRoute> mOutputRoutes;
   std::unique_ptr<o2::utils::FileFetcher> mFileFetcher;
   o2::utils::FIFO<std::unique_ptr<TFMap>> mTFQueue{}; // queued TFs
+  //  std::unordered_map<o2::header::DataIdentifier, SubSpecCount, std::hash<o2::header::DataIdentifier>> mSeenOutputMap;
+  std::unordered_map<o2::header::DataIdentifier, SubSpecCount> mSeenOutputMap;
   int mTFCounter = 0;
   int mTFBuilderCounter = 0;
   bool mRunning = false;
   TFReaderInp mInput; // command line inputs
   std::thread mTFBuilderThread{};
 };
+
+//___________________________________________________________
+TFReaderSpec::TFReaderSpec(const TFReaderInp& rinp) : mInput(rinp)
+{
+  for (const auto& hd : rinp.hdVec) {
+    mSeenOutputMap[o2::header::DataIdentifier{hd.dataDescription.str, hd.dataOrigin.str}].defSubSpec = hd.subSpecification;
+  }
+}
 
 //___________________________________________________________
 void TFReaderSpec::init(o2f::InitContext& ic)
@@ -81,8 +97,8 @@ void TFReaderSpec::init(o2f::InitContext& ic)
 void TFReaderSpec::run(o2f::ProcessingContext& ctx)
 {
   if (!mTFCounter) { // RS FIXME: this is a temporary hack to avoid late-starting devices to lose the input
-    LOG(warning) << "This is a hack, sleeping 10 s at startup";
-    usleep(10000000);
+    LOG(warning) << "This is a hack, sleeping 2 s at startup";
+    usleep(2000000);
   }
   if (!mDevice) {
     mDevice = ctx.services().get<o2f::RawDeviceService>().device();
@@ -99,6 +115,73 @@ void TFReaderSpec::run(o2f::ProcessingContext& ctx)
     throw std::runtime_error(fmt::format("FMQDevice has changed, old={} new={}", fmt::ptr(mDevice), fmt::ptr(device)));
   }
 
+  auto acknowledgeOutput = [this](FairMQParts& parts) {
+    int np = parts.Size();
+    for (int ip = 0; ip < np; ip += 2) {
+      const auto& msgh = parts[ip];
+      const auto* hd = o2::header::get<o2::header::DataHeader*>(msgh.GetData());
+      if (hd->splitPayloadIndex == 0) { // check the 1st one only
+        auto& entry = this->mSeenOutputMap[{hd->dataDescription.str, hd->dataOrigin.str}];
+        if (entry.count != this->mTFCounter) {
+          entry.count = this->mTFCounter; // acknowledge identifier seen in the data
+          LOG(debug) << "Found a part " << ip << " of " << np << " | " << hd->dataOrigin.as<std::string>() << "/" << hd->dataDescription.as<std::string>()
+                     << "/" << hd->subSpecification << " part " << hd->splitPayloadIndex << " of " << hd->splitPayloadParts << " for TF " << this->mTFCounter;
+        }
+      }
+    }
+  };
+
+  auto findOutputChannel = [&ctx, this](o2::header::DataHeader& h) {
+    if (!this->mInput.rawChannelConfig.empty()) {
+      return std::string{this->mInput.rawChannelConfig};
+    } else {
+      auto outputRoutes = ctx.services().get<o2f::RawDeviceService>().spec().outputs;
+      for (auto& oroute : outputRoutes) {
+        LOG(debug) << "comparing with matcher to route " << oroute.matcher << " TSlice:" << oroute.timeslice;
+        if (o2f::DataSpecUtils::match(oroute.matcher, h.dataOrigin, h.dataDescription, h.subSpecification) && ((h.tfCounter % oroute.maxTimeslices) == oroute.timeslice)) {
+          LOG(debug) << "picking the route:" << o2f::DataSpecUtils::describe(oroute.matcher) << " channel " << oroute.channel;
+          return std::string{oroute.channel};
+        }
+      }
+    }
+    LOGP(error, "Failed to find output channel for {}/{}/{} @ timeslice {}", h.dataOrigin.str, h.dataDescription.str, h.subSpecification, h.tfCounter);
+    return std::string{};
+  };
+
+  auto addMissingParts = [this, &findOutputChannel](TFMap& msgMap) {
+    // at least the 1st header is guaranteed to be filled by the reader, use it for extra info
+    const auto* dataptr = (*msgMap.begin()->second.get())[0].GetData();
+    const auto* hd0 = o2::header::get<o2::header::DataHeader*>(dataptr);
+    const auto* dph = o2::header::get<o2::framework::DataProcessingHeader*>(dataptr);
+    for (auto& out : this->mSeenOutputMap) {
+      if (out.second.count == this->mTFCounter) { // was seen in the data
+        continue;
+      }
+      LOG(debug) << "Adding dummy output for " << out.first.dataOrigin.as<std::string>() << "/" << out.first.dataDescription.as<std::string>()
+                 << "/" << out.second.defSubSpec << " for TF " << this->mTFCounter;
+      o2::header::DataHeader outHeader(out.first.dataDescription, out.first.dataOrigin, out.second.defSubSpec, 0);
+      outHeader.payloadSerializationMethod = o2::header::gSerializationMethodNone;
+      outHeader.firstTForbit = hd0->firstTForbit;
+      outHeader.tfCounter = hd0->tfCounter;
+      const auto fmqChannel = findOutputChannel(outHeader);
+      if (fmqChannel.empty()) { // no output channel
+        continue;
+      }
+      auto fmqFactory = this->mDevice->GetChannel(fmqChannel, 0).Transport();
+      o2::header::Stack headerStack{outHeader, *dph};
+      auto hdMessage = fmqFactory->CreateMessage(headerStack.size(), fair::mq::Alignment{64});
+      auto plMessage = fmqFactory->CreateMessage(0, fair::mq::Alignment{64});
+      memcpy(hdMessage->GetData(), headerStack.data(), headerStack.size());
+      FairMQParts* parts = msgMap[fmqChannel].get();
+      if (!parts) {
+        msgMap[fmqChannel] = std::make_unique<FairMQParts>();
+        parts = msgMap[fmqChannel].get();
+      }
+      parts->AddPart(std::move(hdMessage));
+      parts->AddPart(std::move(plMessage));
+    }
+  };
+
   while (1) {
     if (mTFCounter >= mInput.maxTFs) { // done
       stopProcessing(ctx);
@@ -111,6 +194,13 @@ void TFReaderSpec::run(o2f::ProcessingContext& ctx)
         LOG(error) << "Builder provided nullptr TF pointer";
         continue;
       }
+      if (mInput.sendDummyForMissing) {
+        for (auto& msgIt : *tfPtr.get()) { // complete with empty output for the specs which were requested but not seen in the data
+          acknowledgeOutput(*msgIt.second.get());
+        }
+        addMissingParts(*tfPtr.get());
+      }
+
       auto tNow = std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::system_clock::now()).time_since_epoch().count();
       auto tDiff = tNow - tLastTF + 2 * deltaSending;
       if (mTFCounter && tDiff < mInput.delay_us) {
@@ -119,6 +209,7 @@ void TFReaderSpec::run(o2f::ProcessingContext& ctx)
       size_t nparts = 0;
       auto tSend = std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::system_clock::now()).time_since_epoch().count();
       for (auto& msgIt : *tfPtr.get()) {
+        acknowledgeOutput(*msgIt.second.get());
         nparts += msgIt.second->Size() / 2;
         device->Send(*msgIt.second.get(), msgIt.first);
       }
@@ -240,6 +331,7 @@ o2f::DataProcessorSpec o2::rawdd::getTFReaderSpec(o2::rawdd::TFReaderInp& rinp)
       if (rinp.detMask[id]) {
         if (!rinp.detMaskNonRawOnly[id]) {
           spec.outputs.emplace_back(o2f::OutputSpec{o2f::ConcreteDataTypeMatcher{DetID::getDataOrigin(id), "RAWDATA"}});
+          rinp.hdVec.emplace_back(o2::header::DataHeader{"RAWDATA", DetID::getDataOrigin(id), 0xDEADBEEF, 0}); // in abcence of real data this will be sent
         }
         //
         if (rinp.detMaskRawOnly[id]) { // used asked to not open non-raw channels
@@ -248,20 +340,31 @@ o2f::DataProcessorSpec o2::rawdd::getTFReaderSpec(o2::rawdd::TFReaderInp& rinp)
         // in case detectors were processed on FLP
         if (id == DetID::TOF) {
           spec.outputs.emplace_back(o2f::OutputSpec{o2f::ConcreteDataTypeMatcher{DetID::getDataOrigin(DetID::TOF), "CRAWDATA"}});
+          rinp.hdVec.emplace_back(o2::header::DataHeader{"CRAWDATA", DetID::getDataOrigin(DetID::TOF), 0xDEADBEEF, 0}); // in abcence of real data this will be sent
         } else if (id == DetID::FT0 || id == DetID::FV0 || id == DetID::FDD) {
           spec.outputs.emplace_back(o2f::OutputSpec{DetID::getDataOrigin(id), "DIGITSBC", 0});
           spec.outputs.emplace_back(o2f::OutputSpec{DetID::getDataOrigin(id), "DIGITSCH", 0});
+          rinp.hdVec.emplace_back(o2::header::DataHeader{"DIGITSBC", DetID::getDataOrigin(id), 0, 0}); // in abcence of real data this will be sent
+          rinp.hdVec.emplace_back(o2::header::DataHeader{"DIGITSCH", DetID::getDataOrigin(id), 0, 0}); // in abcence of real data this will be sent
         } else if (id == DetID::PHS) {
           spec.outputs.emplace_back(o2f::OutputSpec{DetID::getDataOrigin(id), "CELLS", 0});
           spec.outputs.emplace_back(o2f::OutputSpec{DetID::getDataOrigin(id), "CELLTRIGREC", 0});
+          rinp.hdVec.emplace_back(o2::header::DataHeader{"CELLS", DetID::getDataOrigin(id), 0, 0});       // in abcence of real data this will be sent
+          rinp.hdVec.emplace_back(o2::header::DataHeader{"CELLTRIGREC", DetID::getDataOrigin(id), 0, 0}); // in abcence of real data this will be sent
         } else if (id == DetID::CPV) {
           spec.outputs.emplace_back(o2f::OutputSpec{DetID::getDataOrigin(id), "DIGITS", 0});
           spec.outputs.emplace_back(o2f::OutputSpec{DetID::getDataOrigin(id), "DIGITTRIGREC", 0});
           spec.outputs.emplace_back(o2f::OutputSpec{DetID::getDataOrigin(id), "RAWHWERRORS", 0});
+          rinp.hdVec.emplace_back(o2::header::DataHeader{"DIGITS", DetID::getDataOrigin(id), 0, 0});       // in abcence of real data this will be sent
+          rinp.hdVec.emplace_back(o2::header::DataHeader{"DIGITTRIGREC", DetID::getDataOrigin(id), 0, 0}); // in abcence of real data this will be sent
+          rinp.hdVec.emplace_back(o2::header::DataHeader{"RAWHWERRORS", DetID::getDataOrigin(id), 0, 0});  // in abcence of real data this will be sent
         } else if (id == DetID::EMC) {
           spec.outputs.emplace_back(o2f::OutputSpec{o2f::ConcreteDataTypeMatcher{DetID::getDataOrigin(id), "CELLS"}});
           spec.outputs.emplace_back(o2f::OutputSpec{o2f::ConcreteDataTypeMatcher{DetID::getDataOrigin(id), "CELLSTRGR"}});
           spec.outputs.emplace_back(o2f::OutputSpec{o2f::ConcreteDataTypeMatcher{DetID::getDataOrigin(id), "DECODERERR"}});
+          rinp.hdVec.emplace_back(o2::header::DataHeader{"CELLS", DetID::getDataOrigin(id), 0, 0});      // in abcence of real data this will be sent
+          rinp.hdVec.emplace_back(o2::header::DataHeader{"CELLSTRGR", DetID::getDataOrigin(id), 0, 0});  // in abcence of real data this will be sent
+          rinp.hdVec.emplace_back(o2::header::DataHeader{"DECODERERR", DetID::getDataOrigin(id), 0, 0}); // in abcence of real data this will be sent
         }
       }
     }

--- a/Detectors/Raw/TFReaderDD/src/TFReaderSpec.h
+++ b/Detectors/Raw/TFReaderDD/src/TFReaderSpec.h
@@ -16,6 +16,7 @@
 
 #include "Framework/WorkflowSpec.h"
 #include "DetectorsCommonDataFormats/DetID.h"
+#include "Headers/DataHeader.h"
 
 namespace o2
 {
@@ -39,6 +40,8 @@ struct TFReaderInp {
   int64_t delay_us = 0;
   int maxLoops = 0;
   int maxTFs = -1;
+  bool sendDummyForMissing = true;
+  std::vector<o2::header::DataHeader> hdVec;
 };
 
 o2::framework::DataProcessorSpec getTFReaderSpec(o2::rawdd::TFReaderInp& rinp);

--- a/Detectors/Raw/TFReaderDD/src/tf-reader-workflow.cxx
+++ b/Detectors/Raw/TFReaderDD/src/tf-reader-workflow.cxx
@@ -37,6 +37,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
   options.push_back(ConfigParamSpec{"max-cached-files", VariantType::Int, 3, {"max TF files queued (copied for remote source)"}});
   options.push_back(ConfigParamSpec{"tf-reader-verbosity", VariantType::Int, 0, {"verbosity level (1 or 2: check RDH, print DH/DPH for 1st or all slices, >2 print RDH)"}});
   options.push_back(ConfigParamSpec{"raw-channel-config", VariantType::String, "", {"optional raw FMQ channel for non-DPL output"}});
+  options.push_back(ConfigParamSpec{"disable-dummy-output", VariantType::Bool, false, {"Disable sending empty output if corresponding data is not found in the data"}});
   options.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {"semicolon separated key=value strings"}});
   // options for error-check suppression
 
@@ -65,6 +66,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   rinp.copyCmd = configcontext.options().get<std::string>("copy-cmd");
   rinp.tffileRegex = configcontext.options().get<std::string>("tf-file-regex");
   rinp.remoteRegex = configcontext.options().get<std::string>("remote-regex");
+  rinp.sendDummyForMissing = !configcontext.options().get<bool>("disable-dummy-output");
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
 
   WorkflowSpec specs;


### PR DESCRIPTION
RawTF reader will send a dummy message (with subspec 0xDEADBEEF for *RAWDATA and 0 otherwhise)
for every defined output whose data was not found in the rawTF. Can be disable by `--disable-dummy-output option`