### PR TITLE
[FT0] Fix uninitialized Members in Digits

### DIFF
--- a/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/Digit.h
+++ b/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/Digit.h
@@ -96,8 +96,8 @@ struct DetTrigInput {
   static constexpr char sChannelNameDPL[] = "TRIGGERINPUT";
   static constexpr char sDigitName[] = "DetTrigInput";
   static constexpr char sDigitBranchName[] = "FT0TRIGGERINPUT";
-  o2::InteractionRecord mIntRecord; // bc/orbit of the intpur
-  std::bitset<5> mInputs;           // pattern of inputs.
+  o2::InteractionRecord mIntRecord{}; // bc/orbit of the intpur
+  std::bitset<5> mInputs{};           // pattern of inputs.
   DetTrigInput() = default;
   DetTrigInput(const o2::InteractionRecord& iRec, Bool_t isA, Bool_t isC, Bool_t isVrtx, Bool_t isCnt, Bool_t isSCnt)
     : mIntRecord(iRec),
@@ -115,11 +115,11 @@ struct Digit {
   static constexpr char sChannelNameDPL[] = "DIGITSBC";
   static constexpr char sDigitName[] = "Digit";
   static constexpr char sDigitBranchName[] = "FT0DIGITSBC";
-  o2::dataformats::RangeReference<int, int> ref;
-  Triggers mTriggers;               // pattern of triggers  in this BC
-  uint8_t mEventStatus;             //Status of event from FT0, such as Pileup , etc
-  o2::InteractionRecord mIntRecord; // Interaction record (orbit, bc)
-  int mEventID;
+  o2::dataformats::RangeReference<int, int> ref{};
+  Triggers mTriggers{};               // pattern of triggers  in this BC
+  uint8_t mEventStatus = 0;           //Status of event from FT0, such as Pileup , etc
+  o2::InteractionRecord mIntRecord{}; // Interaction record (orbit, bc)
+  int mEventID = 0;
   enum EEventStatus {
     kPileup
   };
@@ -166,9 +166,9 @@ struct TriggersExt {
   static constexpr char sDigitBranchName[] = "FT0DIGITSTRGEXT";
   TriggersExt(std::array<uint32_t, 20> triggerWords) : mTriggerWords(triggerWords) {}
   TriggersExt() = default;
-  o2::InteractionRecord mIntRecord;
+  o2::InteractionRecord mIntRecord{};
   void setTrgWord(uint32_t trgWord, std::size_t pos) { mTriggerWords[pos] = trgWord; }
-  std::array<uint32_t, 20> mTriggerWords;
+  std::array<uint32_t, 20> mTriggerWords{};
   void printLog() const;
   ClassDefNV(TriggersExt, 2);
 };


### PR DESCRIPTION
The FT0 Digits class has some uninitialized members which will lead to random values being written to the CTF. As a direct consequence, the CTF compression will be very inefficient and waste an unnecessary amount of space.