### PR TITLE
TRD: fix for Vd and ExB calibration and a bit more tracking QC

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/AngularResidHistos.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/AngularResidHistos.h
@@ -31,12 +31,14 @@ class AngularResidHistos
   AngularResidHistos() = default;
   AngularResidHistos(const AngularResidHistos&) = default;
   ~AngularResidHistos() = default;
+  void reset();
   bool addEntry(float deltaAlpha, float impactAngle, int chamberId);
   float getHistogramEntry(int index) const { return mHistogramEntries[index]; }
   int getBinCount(int index) const { return mNEntriesPerBin[index]; }
   size_t getNEntries() const { return mNEntriesTotal; }
 
-  void fill(const gsl::span<const AngularResidHistos> input);
+  void fill(const AngularResidHistos& input);
+  void fill(const gsl::span<const AngularResidHistos> input); // dummy!
   void merge(const AngularResidHistos* prev);
   void print();
 

--- a/DataFormats/Detectors/TRD/src/AngularResidHistos.cxx
+++ b/DataFormats/Detectors/TRD/src/AngularResidHistos.cxx
@@ -19,6 +19,13 @@
 using namespace o2::trd;
 using namespace o2::trd::constants;
 
+void AngularResidHistos::reset()
+{
+  mHistogramEntries.fill(0);
+  mNEntriesPerBin.fill(0);
+  mNEntriesTotal = 0;
+}
+
 bool AngularResidHistos::addEntry(float deltaAlpha, float impactAngle, int chamberId)
 {
   // add entry for given angular residual
@@ -36,15 +43,18 @@ bool AngularResidHistos::addEntry(float deltaAlpha, float impactAngle, int chamb
   return 0;
 }
 
+void AngularResidHistos::fill(const AngularResidHistos& input)
+{
+  for (int i = 0; i < MAXCHAMBER * NBINSANGLEDIFF; ++i) {
+    mHistogramEntries[i] += input.getHistogramEntry(i);
+    mNEntriesPerBin[i] += input.getBinCount(i);
+    mNEntriesTotal += input.getBinCount(i);
+  }
+}
+
 void AngularResidHistos::fill(const gsl::span<const AngularResidHistos> input)
 {
-  for (const auto& data : input) {
-    for (int i = 0; i < MAXCHAMBER * NBINSANGLEDIFF; ++i) {
-      mHistogramEntries[i] += data.getHistogramEntry(i);
-      mNEntriesPerBin[i] += data.getBinCount(i);
-      mNEntriesTotal += data.getBinCount(i);
-    }
-  }
+  LOG(fatal) << "This function must not be called. But it must be available for the compilation to work";
 }
 
 void AngularResidHistos::merge(const AngularResidHistos* prev)

--- a/Detectors/TRD/calibration/include/TRDCalibration/TrackBasedCalib.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/TrackBasedCalib.h
@@ -20,6 +20,7 @@
 #include "DataFormatsTRD/Tracklet64.h"
 #include "DataFormatsTRD/CalibratedTracklet.h"
 #include "DataFormatsTRD/AngularResidHistos.h"
+#include "DataFormatsTRD/NoiseCalibration.h"
 #include "DetectorsBase/Propagator.h"
 #include "TRDBase/RecoParam.h"
 
@@ -53,6 +54,9 @@ class TrackBasedCalib
   /// Initialize the input arrays
   void setInput(const o2::globaltracking::RecoContainer& input);
 
+  /// Reset the output
+  void reset();
+
   /// Main processing function for creating angular residual histograms for vDrift and ExB calibration
   void calculateAngResHistos();
 
@@ -74,6 +78,7 @@ class TrackBasedCalib
   MatCorrType mMatCorr{MatCorrType::USEMatCorrNONE}; ///< if material correction should be done
   RecoParam mRecoParam;                              ///< parameters required for TRD reconstruction
   AngularResidHistos mAngResHistos;                  ///< aggregated data for the track based calibration
+  NoiseStatusMCM* mNoiseCalib{nullptr};              ///< CCDB object with information of noisy MCMs
   // input arrays which should not be modified since they are provided externally
   gsl::span<const TrackTRD> mTracksInITSTPCTRD;        ///< TRD tracks reconstructed from TPC or ITS-TPC seeds
   gsl::span<const TrackTRD> mTracksInTPCTRD;           ///< TRD tracks reconstructed from TPC or TPC seeds

--- a/Detectors/TRD/calibration/src/CalibratorVdExB.cxx
+++ b/Detectors/TRD/calibration/src/CalibratorVdExB.cxx
@@ -101,7 +101,7 @@ void CalibratorVdExB::initProcessing()
   mFitFunctor.lowerBoundAngleFit = 80 * TMath::DegToRad();
   mFitFunctor.upperBoundAngleFit = 100 * TMath::DegToRad();
   mFitFunctor.vdPreCorr = 1.546;    // TODO: will be taken from CCDB in the future
-  mFitFunctor.laPreCorr = -0.16133; // TODO: will be taken from CCDB in the future
+  mFitFunctor.laPreCorr = 0.;       // TODO: will be taken from CCDB in the future
   for (int iDet = 0; iDet < MAXCHAMBER; ++iDet) {
     mFitFunctor.profiles[iDet] = std::make_unique<TProfile>(Form("profAngleDiff_%i", iDet), Form("profAngleDiff_%i", iDet), NBINSANGLEDIFF, -MAXIMPACTANGLE, MAXIMPACTANGLE);
   }
@@ -130,7 +130,7 @@ void CalibratorVdExB::finalizeSlot(Slot& slot)
     }
     ROOT::Fit::Fitter fitter;
     double paramsStart[2];
-    paramsStart[ParamIndex::LA] = -7.5 * TMath::DegToRad();
+    paramsStart[ParamIndex::LA] = 0. * TMath::DegToRad();
     paramsStart[ParamIndex::VD] = 1.;
     fitter.SetFCN<FitFunctor>(2, mFitFunctor, paramsStart);
     fitter.Config().ParSettings(ParamIndex::LA).SetLimits(-0.7, 0.7);

--- a/Detectors/TRD/qc/include/TRDQC/Tracking.h
+++ b/Detectors/TRD/qc/include/TRDQC/Tracking.h
@@ -63,8 +63,12 @@ struct TrackQC {
   std::array<float, constants::NLAYER> trackletY{};     ///< y-position of tracklet used for track update (including correction)
   std::array<float, constants::NLAYER> trackletZ{};     ///< z-position of tracklet used for track update (including correction)
   std::array<float, constants::NLAYER> trackletDy{};    ///< tracklet deflection over drift length obtained from CalibratedTracklet
-  std::array<float, constants::NLAYER> trackletSlope{}; ///< the raw slope from Tracklet64
-  std::array<float, constants::NLAYER> trackletDet{};   ///< the chamber of the tracklet
+  std::array<int, constants::NLAYER> trackletSlope{};   ///< the raw slope from Tracklet64 (signed integer)
+  std::array<int, constants::NLAYER> trackletDet{};     ///< the chamber of the tracklet
+  // some tracklet details to identify its global MCM number to check if it is from noisy MCM
+  std::array<int, constants::NLAYER> trackletHCId{};    ///< the half-chamber ID of the tracklet
+  std::array<int, constants::NLAYER> trackletRob{};     ///< the ROB number of the tracklet
+  std::array<int, constants::NLAYER> trackletMcm{};     ///< the MCM number of the tracklet
   std::array<float, constants::NLAYER> trackletChi2{};  ///< estimated chi2 for the update of the track with the given tracklet
   ClassDefNV(TrackQC, 1);
 };

--- a/Detectors/TRD/qc/src/Tracking.cxx
+++ b/Detectors/TRD/qc/src/Tracking.cxx
@@ -106,8 +106,11 @@ void Tracking::checkTrack(const TrackTRD& trkTrd, bool isTPCTRD)
     qcStruct.trackletY[iLayer] = trkltPosUp[0];
     qcStruct.trackletZ[iLayer] = trkltPosUp[1];
     qcStruct.trackletDy[iLayer] = mTrackletsCalib[trkltId].getDy();
-    qcStruct.trackletSlope[iLayer] = mTrackletsRaw[trkltId].getSlope();
+    qcStruct.trackletSlope[iLayer] = mTrackletsRaw[trkltId].getSlopeBinSigned();
     qcStruct.trackletDet[iLayer] = trkltDet;
+    qcStruct.trackletHCId[iLayer] = mTrackletsRaw[trkltId].getHCID();
+    qcStruct.trackletRob[iLayer] = mTrackletsRaw[trkltId].getROB();
+    qcStruct.trackletMcm[iLayer] = mTrackletsRaw[trkltId].getMCM();
     qcStruct.trackletChi2[iLayer] = chi2trklt;
   }
   mTrackQC.push_back(qcStruct);

--- a/Detectors/TRD/workflow/include/TRDWorkflow/VdAndExBCalibSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/VdAndExBCalibSpec.h
@@ -39,7 +39,7 @@ class VdAndExBCalibDevice : public o2::framework::Task
  public:
   void init(o2::framework::InitContext& ic) final
   {
-    int minEnt = std::max(100'000, ic.options().get<int>("min-entries"));
+    int minEnt = ic.options().get<int>("min-entries");
     int slotL = ic.options().get<int>("tf-per-slot");
     int delay = ic.options().get<int>("max-delay");
     mCalibrator = std::make_unique<o2::trd::CalibratorVdExB>(minEnt);
@@ -50,8 +50,8 @@ class VdAndExBCalibDevice : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) final
   {
     auto tfcounter = o2::header::get<o2::framework::DataProcessingHeader*>(pc.inputs().get("input").header)->startTime;
-    auto data = pc.inputs().get<gsl::span<o2::trd::AngularResidHistos>>("input");
-    LOG(info) << "Processing TF " << tfcounter << " with " << data.size() << " AngularResidHistos objects";
+    auto data = pc.inputs().get<o2::trd::AngularResidHistos>("input");
+    LOG(info) << "Processing TF " << tfcounter << " with " << data.getNEntries() << " AngularResidHistos entries";
     mCalibrator->process(tfcounter, data);
     sendOutput(pc.outputs());
   }

--- a/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDCalibReaderSpec.h
+++ b/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDCalibReaderSpec.h
@@ -40,7 +40,7 @@ class TRDCalibReader : public o2::framework::Task
   std::unique_ptr<TTree> mTree;
   std::string mInFileName{"trdangreshistos.root"};
   std::string mInTreeName{"calibdata"};
-  std::vector<o2::trd::AngularResidHistos> mAngResids, *mAngResidPtr = &mAngResids;
+  o2::trd::AngularResidHistos mAngResids, *mAngResidPtr = &mAngResids;
 };
 
 /// create a processor spec

--- a/Detectors/TRD/workflow/io/src/TRDCalibReaderSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDCalibReaderSpec.cxx
@@ -52,11 +52,7 @@ void TRDCalibReader::run(ProcessingContext& pc)
   auto currEntry = mTree->GetReadEntry() + 1;
   assert(currEntry < mTree->GetEntries()); // this should not happen
   mTree->GetEntry(currEntry);
-  if (mAngResids.size() > 0) {
-    LOG(info) << "Pushing angular residual histograms filled with " << mAngResids.at(0).getNEntries() << " entries at tree entry " << currEntry;
-  } else {
-    LOG(warning) << "No TRD calibration data available in the tree";
-  }
+  LOG(info) << "Pushing angular residual histograms filled with " << mAngResids.getNEntries() << " entries at tree entry " << currEntry;
   pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "ANGRESHISTS", 0, Lifetime::Timeframe}, mAngResids);
 
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {

--- a/Detectors/TRD/workflow/io/src/TRDCalibWriterSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDCalibWriterSpec.cxx
@@ -31,7 +31,7 @@ o2::framework::DataProcessorSpec getTRDCalibWriterSpec()
   return MakeRootTreeWriterSpec("TRDCalibWriter",
                                 "trdangreshistos.root",
                                 "calibdata",
-                                BranchDefinition<std::vector<o2::trd::AngularResidHistos>>{InputSpec{"calibdata", "TRD", "ANGRESHISTS"}, "AngularResids"})();
+                                BranchDefinition<o2::trd::AngularResidHistos>{InputSpec{"calibdata", "TRD", "ANGRESHISTS"}, "AngularResids"})();
 };
 
 } // end namespace trd

--- a/Detectors/TRD/workflow/src/TRDGlobalTrackingQCSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDGlobalTrackingQCSpec.cxx
@@ -70,7 +70,7 @@ void TRDGlobalTrackingQC::endOfStream(EndOfStreamContext& ec)
 {
   // for now just dump the results to a file, should become an option to be used in debugging mode
   auto fOut = std::make_unique<TFile>("trdQC.root", "recreate");
-  auto tree = std::make_unique<TTree>("trdtrackingqc", "Track based QC for TRD");
+  auto tree = std::make_unique<TTree>("qc", "Track based QC for TRD");
   auto vec = mQC.getTrackQC();
   auto vecPtr = &vec;
   tree->Branch("trackQC", &vecPtr);


### PR DESCRIPTION
We use `o2::trd::AngularResidHistos` as container for our vDrift and ExB calibration. Since we only collect sums of histogram bin entries and the number of bins these are trivially merged and we don't need to have a vector or span of these objects. During the processing this should be fine now as it is. When the histograms are written to a root file there is still one entry in the tree per time frame and this makes the root file very large for longer productions. But I don't see a way at the moment to avoid this, because the logic of the time-slot-based calibration requires one entry per TF for the processing.
When processing 50k TFs from the pilot beam I get a 1.2 GB large file which could in principle be reduced to less than 1 MB. But as said during the processing on the aggregator node it will accumulate the data and not keep so many objects in the memory in parallel so for now this might be fine.
Maybe I could add a custom writer and add an option to the calibrator (the one which would run on the aggregator node) such that in case it is processing from a ROOT file then it requires only 1 TF per slot.