### PR TITLE
o2-sim: Fix inconsistency in timestamp assignment

### DIFF
--- a/Common/SimConfig/include/SimConfig/SimConfig.h
+++ b/Common/SimConfig/include/SimConfig/SimConfig.h
@@ -47,7 +47,7 @@ struct SimConfigData {
   int mSimWorkers = 1;                       // number of parallel sim workers (when it applies)
   bool mFilterNoHitEvents = false;           // whether to filter out events not leaving any response
   std::string mCCDBUrl;                      // the URL where to find CCDB
-  long mTimestamp;                           // timestamp to anchor transport simulation to
+  uint64_t mTimestamp;                       // timestamp in ms to anchor transport simulation to
   int mField;                                // L3 field setting in kGauss: +-2,+-5 and 0
   bool mUniformField = false;                // uniform magnetic field
   bool mAsService = false;                   // if simulation should be run as service/deamon (does not exit after run)
@@ -115,7 +115,7 @@ class SimConfig
   int getNSimWorkers() const { return mConfigData.mSimWorkers; }
   bool isFilterOutNoHitEvents() const { return mConfigData.mFilterNoHitEvents; }
   bool asService() const { return mConfigData.mAsService; }
-  long getTimestamp() const { return mConfigData.mTimestamp; }
+  uint64_t getTimestamp() const { return mConfigData.mTimestamp; }
 
  private:
   SimConfigData mConfigData; //!

--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -16,6 +16,7 @@
 #include <FairLogger.h>
 #include <thread>
 #include <cmath>
+#include <chrono>
 
 using namespace o2::conf;
 namespace bpo = boost::program_options;
@@ -49,7 +50,7 @@ void SimConfig::initOptions(boost::program_options::options_description& options
     "nworkers,j", bpo::value<int>()->default_value(nsimworkersdefault), "number of parallel simulation workers (only for parallel mode)")(
     "noemptyevents", "only writes events with at least one hit")(
     "CCDBUrl", bpo::value<std::string>()->default_value("ccdb-test.cern.ch:8080"), "URL for CCDB to be used.")(
-    "timestamp", bpo::value<long>()->default_value(-1), "global timestamp value (for anchoring) - default is now")(
+    "timestamp", bpo::value<uint64_t>(), "global timestamp value in ms (for anchoring) - default is now")(
     "asservice", bpo::value<bool>()->default_value(false), "run in service/server mode");
 }
 
@@ -106,7 +107,11 @@ bool SimConfig::resetFromParsedMap(boost::program_options::variables_map const& 
   mConfigData.mInternalChunkSize = vm["chunkSizeI"].as<int>();
   mConfigData.mStartSeed = vm["seed"].as<int>();
   mConfigData.mSimWorkers = vm["nworkers"].as<int>();
-  mConfigData.mTimestamp = vm["timestamp"].as<long>();
+  if (vm.count("timestamp")) {
+    mConfigData.mTimestamp = vm["timestamp"].as<uint64_t>();
+  } else {
+    mConfigData.mTimestamp = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::system_clock::now()).time_since_epoch().count();
+  }
   mConfigData.mCCDBUrl = vm["CCDBUrl"].as<std::string>();
   mConfigData.mAsService = vm["asservice"].as<bool>();
   if (vm.count("noemptyevents")) {


### PR DESCRIPTION
Forward timestamp argument to grp, so that it can be further
propagated to digitization etc.