### PR TITLE
Revert "Merge pull request #7881 from ktf/remove-region-callback-mutex"

### DIFF
--- a/Framework/Core/include/Framework/DataProcessingDevice.h
+++ b/Framework/Core/include/Framework/DataProcessingDevice.h
@@ -133,14 +133,12 @@ class DataProcessingDevice : public FairMQDevice
   static void handleData(DataProcessorContext& context, InputChannelInfo&);
   static bool tryDispatchComputation(DataProcessorContext& context, std::vector<DataRelayer::RecordAction>& completed);
   std::vector<DataProcessorContext> mDataProcessorContexes;
-  constexpr static int MAX_REGION_INFOS = 2048; /// Maximum number of unhandled region info
 
  protected:
   void error(const char* msg);
   void fillContext(DataProcessorContext& context, DeviceContext& deviceContext);
 
  private:
-  void handleRegionCallbacks();
   DeviceContext mDeviceContext;
   /// The specification used to create the initial state of this device
   DeviceSpec const& mSpec;
@@ -166,9 +164,7 @@ class DataProcessingDevice : public FairMQDevice
   uint64_t mLastMetricFlushedTimestamp = 0;          /// The timestamp of the last time we actually flushed metrics
   uint64_t mBeginIterationTimestamp = 0;             /// The timestamp of when the current ConditionalRun was started
   DataProcessingStats mStats;                        /// Stats about the actual data processing.
-  FairMQRegionInfo mPendingRegionInfos[MAX_REGION_INFOS]; /// Where the region info should be notified
-  std::atomic<int> mLowRegionNotification = 0;            /// First region info to notify, modulo MAX_REGION_INFO
-  std::atomic<int> mHiRegionNotification = 0;             /// Last region info to notify, modulo MAX_REGION_INFO
+  std::vector<FairMQRegionInfo> mPendingRegionInfos; /// A list of the region infos not yet notified.
   std::mutex mRegionInfoMutex;
   ProcessingPolicies mProcessingPolicies;                        /// User policies related to data processing
   bool mWasActive = false;                                       /// Whether or not the device was active at last iteration.


### PR DESCRIPTION
This reverts commit 6fdc8d8c1dc16dab66e15da8f0856bc4c2e8929a.

@ktf : Contrary to what I said before, this commit was broken. There are no region callbacks at all any more with it. (Before I checked only that it didn't crash, but didn't check that the callbacks are coming correctly).