### PR TITLE
Fix in the setting of cosmic parameters

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/CookedTrackerSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/CookedTrackerSpec.h
@@ -43,6 +43,7 @@ class CookedTrackerDPL : public Task
   int mState = 0;
   bool mUseMC = true;
   bool mRunVertexer = true;
+  std::string mMode = "async";
   o2::itsmft::TopologyDictionary mDict;
   std::unique_ptr<o2::parameters::GRPObject> mGRP = nullptr;
   o2::its::CookedTracker mTracker;

--- a/Detectors/ITSMFT/ITS/workflow/src/CookedTrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/CookedTrackerSpec.cxx
@@ -49,13 +49,8 @@ namespace its
 
 using Vertex = o2::dataformats::Vertex<o2::dataformats::TimeStamp<int>>;
 
-CookedTrackerDPL::CookedTrackerDPL(bool useMC, const std::string& trMode) : mUseMC(useMC)
+CookedTrackerDPL::CookedTrackerDPL(bool useMC, const std::string& trMode) : mUseMC(useMC), mMode(trMode)
 {
-  if (trMode == "cosmics") {
-    LOG(info) << "Tracking mode \"cosmics\"";
-    mTracker.setParametersCosmics();
-    mRunVertexer = false;
-  }
   mVertexerTraitsPtr = std::make_unique<VertexerTraits>();
   mVertexerPtr = std::make_unique<Vertexer>(mVertexerTraitsPtr.get());
 }
@@ -82,6 +77,12 @@ void CookedTrackerDPL::init(InitContext& ic)
     mTracker.setGeometry(geom);
 
     mTracker.setConfigParams();
+    LOG(info) << "Tracking mode " << mMode;
+    if (mMode == "cosmics") {
+      LOG(info) << "Setting cosmics parameters...";
+      mTracker.setParametersCosmics();
+      mRunVertexer = false;
+    }
 
     double origD[3] = {0., 0., 0.};
     mTracker.setBz(field->getBz(origD));


### PR DESCRIPTION
With this fix, we avoid the situation when default values for configurable parameters overwrite  the values set by the "cosmics" command-line option. 