### PR TITLE
[EMCAL-637, O2-2683] Fix extruding DCAL supermodules

### DIFF
--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/Detector.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/Detector.h
@@ -202,12 +202,13 @@ class Detector : public o2::base::DetImpl<Detector>
   Int_t mCurrentPrimaryID; //!<! ID of the current primary
   Int_t mCurrentParentID;  //!<! ID of the current parent
 
-  Double_t mSampleWidth; //!<! sample width = double(g->GetECPbRadThick()+g->GetECScintThick());
-  Double_t mSmodPar0;    //!<! x size of super module
-  Double_t mSmodPar1;    //!<! y size of super module
-  Double_t mSmodPar2;    //!<! z size of super module
-  Double_t mInnerEdge;   //!<! Inner edge of DCAL super module
-  Double_t mParEMOD[5];  //!<! parameters of EMCAL module (TRD1,2)
+  Double_t mSampleWidth;  //!<! sample width = double(g->GetECPbRadThick()+g->GetECScintThick());
+  Double_t mSmodPar0;     //!<! x size of super module
+  Double_t mSmodPar1;     //!<! y size of super module
+  Double_t mSmodPar2;     //!<! z size of super module
+  Double_t mInnerEdge;    //!<! Inner edge of DCAL super module
+  Double_t mDCALInnerGap; //!<! Gap added to inner part of the DCAL supermodule in order to prevent extruding due to tower tilting
+  Double_t mParEMOD[5];   //!<! parameters of EMCAL module (TRD1,2)
 
   template <typename Det>
   friend class o2::base::DetImpl;

--- a/Detectors/EMCAL/simulation/src/Detector.cxx
+++ b/Detectors/EMCAL/simulation/src/Detector.cxx
@@ -60,7 +60,8 @@ Detector::Detector(Bool_t active)
     mSmodPar0(0.),
     mSmodPar1(0.),
     mSmodPar2(0.),
-    mInnerEdge(0.)
+    mInnerEdge(0.),
+    mDCALInnerGap(7)
 {
   using boost::algorithm::contains;
   memset(mParEMOD, 0, sizeof(Double_t) * 5);
@@ -100,7 +101,8 @@ Detector::Detector(const Detector& rhs)
     mSmodPar0(rhs.mSmodPar0),
     mSmodPar1(rhs.mSmodPar1),
     mSmodPar2(rhs.mSmodPar2),
-    mInnerEdge(rhs.mInnerEdge)
+    mInnerEdge(rhs.mInnerEdge),
+    mDCALInnerGap(rhs.mDCALInnerGap)
 {
   for (int i = 0; i < 5; ++i) {
     mParEMOD[i] = rhs.mParEMOD[i];
@@ -819,7 +821,9 @@ void Detector::CreateSupermoduleGeometry(const std::string_view mother)
         case DCAL_STANDARD: {
           smName = "DCSM";
           parC[2] *= 2. / 3.;
-          zpos = mSmodPar2 + g->GetDCALInnerEdge() / 2.; // 21-sep-04
+          // Extend DCAL SM by 7 cm in inner direction in order to leave space for tilted towers
+          parC[2] += mDCALInnerGap / 2.;                                   // half gap as parameter uses half size (origin in centre of the SM)
+          zpos = mSmodPar2 + (g->GetDCALInnerEdge() - mDCALInnerGap) / 2.; // 21-sep-04
           break;
         }
         case DCAL_EXT: {
@@ -929,7 +933,9 @@ void Detector::CreateEmcalModuleGeometry(const std::string_view mother, const st
         if (iz < 8) {
           continue; //!!!DCSM from 8th to 23th
         }
-        zpos = mod.GetPosZ() - mSmodPar2 - g->GetDCALInnerEdge() / 2.;
+        // Correct pack supermodule center position after increasing size for extruding fix
+        // z-pos. := abs. module z - abs origin of the mother volume
+        zpos = mod.GetPosZ() - mSmodPar2 - (g->GetDCALInnerEdge() - mDCALInnerGap) / 2.;
       } else if (mother.compare("SMOD")) {
         LOG(error) << "Unknown super module Type!!";
       }


### PR DESCRIPTION
The size of the DCAL supermodules did not take into
account the projective layout and therefore not the
tiling of the inner DCAL modules, leading to extruding
at the inner edge in eta at the inner R. To compensate the
tilting the size of the supermodules had to be increased
by 7 cm, shifting the origin back in PHOS direction by 3.5
cm in order to fix the upper edge of the supermodule. The
relative tower z-position had to be adapted to the origin shift
in order ot keep the towers at the same position.