### PR TITLE
Introduces the Global Forward assessment workflow

### DIFF
--- a/Detectors/GlobalTracking/CMakeLists.txt
+++ b/Detectors/GlobalTracking/CMakeLists.txt
@@ -17,6 +17,7 @@ o2_add_library(GlobalTracking
                        src/MatchCosmics.cxx
                        src/MatchCosmicsParams.cxx
                        src/MatchGlobalFwd.cxx
+                       src/MatchGlobalFwdAssessment.cxx
                        src/MatchITSTPCQC.cxx
                        src/ITSTPCMatchingQCParams.cxx
                        src/MatchGlobalFwdParam.cxx
@@ -50,6 +51,7 @@ o2_target_root_dictionary(GlobalTracking
                           HEADERS include/GlobalTracking/MatchTPCITSParams.h
                                   include/GlobalTracking/MatchGlobalFwd.h
                                   include/GlobalTracking/MatchGlobalFwdParam.h
+                                  include/GlobalTracking/MatchGlobalFwdAssessment.h
                                   include/GlobalTracking/MatchTOF.h
                                   include/GlobalTracking/MatchCosmics.h
                                   include/GlobalTracking/MatchCosmicsParams.h

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchGlobalFwdAssessment.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchGlobalFwdAssessment.h
@@ -1,0 +1,304 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file MatchGlobalFwdAssessment.h
+/// \brief Class to perform assessment of GlobalForward Tracking
+/// \author rafael.pezzi at cern.ch
+
+#ifndef ALICEO2_GLOFWD_ASSESSMENT
+#define ALICEO2_GLOFWD_ASSESSMENT
+
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TH3F.h>
+#include <TCanvas.h>
+#include <TEfficiency.h>
+#include <TObjArray.h>
+#include "Framework/ProcessingContext.h"
+#include "SimulationDataFormat/MCCompLabel.h"
+#include "SimulationDataFormat/MCTrack.h"
+#include "DataFormatsMFT/TrackMFT.h"
+#include "DataFormatsMCH/TrackMCH.h"
+#include <DataFormatsITSMFT/ROFRecord.h>
+#include <DataFormatsITSMFT/CompCluster.h>
+#include "ReconstructionDataFormats/GlobalFwdTrack.h"
+#include "Steer/MCKinematicsReader.h"
+#include <unordered_map>
+#include <vector>
+
+namespace o2
+{
+
+namespace globaltracking
+{
+
+enum mMFTTrackTypes { kReco,
+                      kGen,
+                      kPairable,
+                      kRecoTrue,
+                      kNumberOfTrackTypes };
+
+using ClusterLabelsType = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
+using TrackLabelsType = std::vector<o2::MCCompLabel>;
+using MCTrack = o2::MCTrackT<float>;
+
+class GloFwdAssessment
+{
+ public:
+  GloFwdAssessment() = delete;
+  GloFwdAssessment(bool useMC) : mUseMC(useMC){};
+  ~GloFwdAssessment() = default;
+  void disableMIDFilter() { mMIDFilterEnabled = false; }
+
+  void init(bool finalizeAnalysis);
+  void createHistos();
+  bool loadHistos();
+  void deleteHistograms();
+
+  void reset();
+
+  void runBasicQC(o2::framework::ProcessingContext& ctx);
+  void processPairables();
+  void processRecoAndTrueTracks();
+  void addMCParticletoHistos(const MCTrack* mcTr, const int TrackType, const o2::dataformats::MCEventHeader& evH);
+
+  void finalizeAnalysis();
+
+  void getHistos(TObjArray& objar);
+  void setBz(float bz) { mBz = bz; }
+
+  double orbitToSeconds(uint32_t orbit, uint32_t refOrbit)
+  {
+    return (orbit - refOrbit) * o2::constants::lhc::LHCOrbitNS / 1E9;
+  }
+
+ private:
+  gsl::span<const o2::dataformats::GlobalFwdTrack> mGlobalFwdTracks;
+  gsl::span<const o2::mft::TrackMFT> mMFTTracks;
+  gsl::span<const o2::mch::TrackMCH> mMCHTracks;
+  gsl::span<const o2::itsmft::ROFRecord> mMFTTracksROF;
+  gsl::span<const o2::itsmft::CompClusterExt> mMFTClusters;
+  gsl::span<const o2::itsmft::ROFRecord> mMFTClustersROF;
+
+  // MC Labels
+  bool mUseMC = false;
+
+  gsl::span<const o2::MCCompLabel> mMFTTrackLabels;
+  gsl::span<const o2::MCCompLabel> mMCHTrackLabels;
+  gsl::span<const o2::MCCompLabel> mFwdTrackLabels;
+
+  o2::steer::MCKinematicsReader mcReader; // reader of MC information
+
+  // Histos for reconstructed tracks
+  std::unique_ptr<TH1F> mTrackNumberOfClusters = nullptr;
+  std::unique_ptr<TH1F> mTrackInvQPt = nullptr;
+  std::unique_ptr<TH1F> mTrackChi2 = nullptr;
+  std::unique_ptr<TH1F> mTrackCharge = nullptr;
+  std::unique_ptr<TH1F> mTrackPhi = nullptr;
+  std::unique_ptr<TH1F> mTrackEta = nullptr;
+  std::array<std::unique_ptr<TH1F>, 7> mTrackEtaNCls = {nullptr};
+  std::array<std::unique_ptr<TH1F>, 7> mTrackPhiNCls = {nullptr};
+  std::array<std::unique_ptr<TH2F>, 7> mTrackXYNCls = {nullptr};
+  std::array<std::unique_ptr<TH2F>, 7> mTrackEtaPhiNCls = {nullptr};
+  std::unique_ptr<TH1F> mTrackTanl = nullptr;
+
+  // Histos and data for MC analysis
+  std::vector<std::string> mNameOfTrackTypes = {"Rec",
+                                                "Gen",
+                                                "Pairable",
+                                                "RecoTrue"};
+
+  std::unique_ptr<TH2F> mHistPhiRecVsPhiGen = nullptr;
+  std::unique_ptr<TH2F> mHistEtaRecVsEtaGen = nullptr;
+
+  std::array<std::unique_ptr<TH2F>, kNumberOfTrackTypes> mHistPhiVsEta;
+  std::array<std::unique_ptr<TH2F>, kNumberOfTrackTypes> mHistPtVsEta;
+  std::array<std::unique_ptr<TH2F>, kNumberOfTrackTypes> mHistPhiVsPt;
+  std::array<std::unique_ptr<TH2F>, kNumberOfTrackTypes> mHistZvtxVsEta;
+  std::array<std::unique_ptr<TH2F>, kNumberOfTrackTypes> mHistRVsZ;
+
+  // Histos for reconstruction assessment
+
+  std::unique_ptr<TEfficiency> mChargeMatchEff = nullptr;
+
+  enum TH3HistosCodes {
+    kTH3GMTrackDeltaXDeltaYEta,
+    kTH3GMTrackDeltaXDeltaYPt,
+    kTH3GMTrackDeltaXVertexPtEta,
+    kTH3GMTrackDeltaYVertexPtEta,
+    kTH3GMTrackInvQPtResolutionPtEta,
+    kTH3GMTrackXPullPtEta,
+    kTH3GMTrackYPullPtEta,
+    kTH3GMTrackPhiPullPtEta,
+    kTH3GMTrackTanlPullPtEta,
+    kTH3GMTrackInvQPtPullPtEta,
+    kTH3GMTrackReducedChi2PtEta,
+    kNTH3Histos
+  };
+
+  std::map<int, const char*> TH3Names{
+    {kTH3GMTrackDeltaXDeltaYEta, "TH3GMTrackDeltaXDeltaYEta"},
+    {kTH3GMTrackDeltaXDeltaYPt, "TH3GMTrackDeltaXDeltaYPt"},
+    {kTH3GMTrackDeltaXVertexPtEta, "TH3GMTrackDeltaXVertexPtEta"},
+    {kTH3GMTrackDeltaYVertexPtEta, "TH3GMTrackDeltaYVertexPtEta"},
+    {kTH3GMTrackInvQPtResolutionPtEta, "TH3GMTrackInvQPtResolutionPtEta"},
+    {kTH3GMTrackXPullPtEta, "TH3GMTrackXPullPtEta"},
+    {kTH3GMTrackYPullPtEta, "TH3GMTrackYPullPtEta"},
+    {kTH3GMTrackPhiPullPtEta, "TH3GMTrackPhiPullPtEta"},
+    {kTH3GMTrackTanlPullPtEta, "TH3GMTrackTanlPullPtEta"},
+    {kTH3GMTrackInvQPtPullPtEta, "TH3GMTrackInvQPtPullPtEta"},
+    {kTH3GMTrackReducedChi2PtEta, "TH3GMTrackReducedChi2PtEta"}};
+
+  std::map<int, const char*> TH3Titles{
+    {kTH3GMTrackDeltaXDeltaYEta, "TH3GMTrackDeltaXDeltaYEta"},
+    {kTH3GMTrackDeltaXDeltaYPt, "TH3GMTrackDeltaXDeltaYPt"},
+    {kTH3GMTrackDeltaXVertexPtEta, "TH3GMTrackDeltaXVertexPtEta"},
+    {kTH3GMTrackDeltaYVertexPtEta, "TH3GMTrackDeltaYVertexPtEta"},
+    {kTH3GMTrackInvQPtResolutionPtEta, "TH3GMTrackInvQPtResolutionPtEta"},
+    {kTH3GMTrackXPullPtEta, "TH3GMTrackXPullPtEta"},
+    {kTH3GMTrackYPullPtEta, "TH3GMTrackYPullPtEta"},
+    {kTH3GMTrackPhiPullPtEta, "TH3GMTrackPhiPullPtEta"},
+    {kTH3GMTrackTanlPullPtEta, "TH3GMTrackTanlPullPtEta"},
+    {kTH3GMTrackInvQPtPullPtEta, "TH3GMTrackInvQPtPullPtEta"},
+    {kTH3GMTrackReducedChi2PtEta, "TH3GMTrackReducedChi2PtEta"}};
+
+  std::map<int, std::array<double, 9>> TH3Binning{
+    {kTH3GMTrackDeltaXDeltaYEta, {16, 2.2, 3.8, 1000, -1000, 1000, 1000, -1000, 1000}},
+    {kTH3GMTrackDeltaXDeltaYPt, {100, 0, 20, 1000, -1000, 1000, 1000, -1000, 1000}},
+    {kTH3GMTrackDeltaYVertexPtEta, {100, 0, 20, 16, 2.2, 3.8, 1000, -1000, 1000}},
+    {kTH3GMTrackDeltaXVertexPtEta, {100, 0, 20, 16, 2.2, 3.8, 1000, -1000, 1000}},
+    {kTH3GMTrackInvQPtResolutionPtEta, {100, 0, 20, 16, 2.2, 3.8, 1000, -50, 50}},
+    {kTH3GMTrackXPullPtEta, {100, 0, 20, 16, 2.2, 3.8, 200, -10, 10}},
+    {kTH3GMTrackYPullPtEta, {100, 0, 20, 16, 2.2, 3.8, 200, -10, 10}},
+    {kTH3GMTrackPhiPullPtEta, {100, 0, 20, 16, 2.2, 3.8, 200, -10, 10}},
+    {kTH3GMTrackTanlPullPtEta, {100, 0, 20, 16, 2.2, 3.8, 200, -10, 10}},
+    {kTH3GMTrackInvQPtPullPtEta, {100, 0, 20, 16, 2.2, 3.8, 200, -50, 50}},
+    {kTH3GMTrackReducedChi2PtEta, {100, 0, 20, 16, 2.2, 3.8, 1000, 0, 100}}};
+
+  std::map<int, const char*> TH3XaxisTitles{
+    {kTH3GMTrackDeltaXDeltaYEta, R"(\\eta)"},
+    {kTH3GMTrackDeltaXDeltaYPt, R"(p_{t})"},
+    {kTH3GMTrackDeltaXVertexPtEta, R"(p_{t})"},
+    {kTH3GMTrackDeltaYVertexPtEta, R"(p_{t})"},
+    {kTH3GMTrackInvQPtResolutionPtEta, R"(p_{t})"},
+    {kTH3GMTrackXPullPtEta, R"(p_{t})"},
+    {kTH3GMTrackYPullPtEta, R"(p_{t})"},
+    {kTH3GMTrackPhiPullPtEta, R"(p_{t})"},
+    {kTH3GMTrackTanlPullPtEta, R"(p_{t})"},
+    {kTH3GMTrackInvQPtPullPtEta, R"(p_{t})"},
+    {kTH3GMTrackReducedChi2PtEta, R"(p_{t})"}};
+
+  std::map<int, const char*> TH3YaxisTitles{
+    {kTH3GMTrackDeltaXDeltaYEta, R"(X_{residual \rightarrow vtx} (\mu m))"},
+    {kTH3GMTrackDeltaXDeltaYPt, R"(X_{residual \rightarrow vtx} (\mu m))"},
+    {kTH3GMTrackDeltaXVertexPtEta, R"(\eta)"},
+    {kTH3GMTrackDeltaYVertexPtEta, R"(\eta)"},
+    {kTH3GMTrackInvQPtResolutionPtEta, R"(\eta)"},
+    {kTH3GMTrackXPullPtEta, R"(\eta)"},
+    {kTH3GMTrackYPullPtEta, R"(\eta)"},
+    {kTH3GMTrackPhiPullPtEta, R"(\eta)"},
+    {kTH3GMTrackTanlPullPtEta, R"(\eta)"},
+    {kTH3GMTrackInvQPtPullPtEta, R"(\eta)"},
+    {kTH3GMTrackReducedChi2PtEta, R"(\eta)"}};
+
+  std::map<int, const char*> TH3ZaxisTitles{
+    {kTH3GMTrackDeltaXDeltaYEta, R"(Y_{residual \rightarrow vtx} (\mu m))"},
+    {kTH3GMTrackDeltaXDeltaYPt, R"(Y_{residual \rightarrow vtx} (\mu m))"},
+    {kTH3GMTrackDeltaXVertexPtEta, R"(X_{residual \rightarrow vtx} (\mu m))"},
+    {kTH3GMTrackDeltaYVertexPtEta, R"(Y_{residual \rightarrow vtx} (\mu m))"},
+    {kTH3GMTrackInvQPtResolutionPtEta, R"((q/p_{t})_{residual}/(q/p_{t}))"},
+    {kTH3GMTrackXPullPtEta, R"(\Delta X/\sigma_{X})"},
+    {kTH3GMTrackYPullPtEta, R"(\Delta Y/\sigma_{Y})"},
+    {kTH3GMTrackPhiPullPtEta, R"(\Delta \phi/\sigma_{\phi})"},
+    {kTH3GMTrackTanlPullPtEta, R"(\Delta \tan(\lambda)/\sigma_{tan(\lambda)})"},
+    {kTH3GMTrackInvQPtPullPtEta, R"((\Delta q/p_t)/\sigma_{q/p_{t}})"},
+    {kTH3GMTrackReducedChi2PtEta, R"(\chi^2/d.f.)"}};
+
+  enum TH3SlicedCodes {
+    kDeltaXVertexVsEta,
+    kDeltaXVertexVsPt,
+    kDeltaYVertexVsEta,
+    kDeltaYVertexVsPt,
+    kXPullVsEta,
+    kXPullVsPt,
+    kYPullVsEta,
+    kYPullVsPt,
+    kInvQPtResVsEta,
+    kInvQPtResVsPt,
+    kInvQPtResSeedVsEta,
+    kInvQPtResSeedVsPt,
+    kPhiPullVsEta,
+    kPhiPullVsPt,
+    kTanlPullVsEta,
+    kTanlPullVsPt,
+    kInvQPtPullVsEta,
+    kInvQPtPullVsPt,
+    kNSlicedTH3
+  };
+
+  std::map<int, const char*> TH3SlicedNames{
+    {kDeltaXVertexVsEta, "DeltaXVertexVsEta"},
+    {kDeltaXVertexVsPt, "DeltaXVertexVsPt"},
+    {kDeltaYVertexVsEta, "DeltaYVertexVsEta"},
+    {kDeltaYVertexVsPt, "DeltaYVertexVsPt"},
+    {kXPullVsEta, "XPullVsEta"},
+    {kXPullVsPt, "XPullVsPt"},
+    {kYPullVsEta, "YPullVsEta"},
+    {kYPullVsPt, "YPullVsPt"},
+    {kInvQPtResVsEta, "InvQPtResVsEta"},
+    {kInvQPtResVsPt, "InvQPtResVsPt"},
+    {kInvQPtResSeedVsEta, "InvQPtResSeedVsEta"},
+    {kInvQPtResSeedVsPt, "InvQPtResSeedVsPt"},
+    {kPhiPullVsEta, "PhiPullVsEta"},
+    {kPhiPullVsPt, "PhiPullVsPt"},
+    {kTanlPullVsEta, "TanlPullVsEta"},
+    {kTanlPullVsPt, "TanlPullVsPt"},
+    {kInvQPtPullVsEta, "InvQPtPullVsEta"},
+    {kInvQPtPullVsPt, "InvQPtPullVsPt"}};
+
+  std::map<int, int> TH3SlicedMap{
+    {kDeltaXVertexVsEta, kTH3GMTrackDeltaXVertexPtEta},
+    {kDeltaXVertexVsPt, kTH3GMTrackDeltaXVertexPtEta},
+    {kDeltaYVertexVsEta, kTH3GMTrackDeltaYVertexPtEta},
+    {kDeltaYVertexVsPt, kTH3GMTrackDeltaYVertexPtEta},
+    {kXPullVsEta, kTH3GMTrackXPullPtEta},
+    {kXPullVsPt, kTH3GMTrackXPullPtEta},
+    {kYPullVsEta, kTH3GMTrackYPullPtEta},
+    {kYPullVsPt, kTH3GMTrackYPullPtEta},
+    {kInvQPtResVsEta, kTH3GMTrackInvQPtResolutionPtEta},
+    {kInvQPtResVsPt, kTH3GMTrackInvQPtResolutionPtEta},
+    {kPhiPullVsEta, kTH3GMTrackPhiPullPtEta},
+    {kPhiPullVsPt, kTH3GMTrackPhiPullPtEta},
+    {kTanlPullVsEta, kTH3GMTrackTanlPullPtEta},
+    {kTanlPullVsPt, kTH3GMTrackTanlPullPtEta},
+    {kInvQPtPullVsEta, kTH3GMTrackInvQPtPullPtEta},
+    {kInvQPtPullVsPt, kTH3GMTrackInvQPtPullPtEta}};
+
+  std::array<std::unique_ptr<TH3F>, kNTH3Histos> mTH3Histos;
+  std::array<TCanvas*, kNSlicedTH3> mSlicedCanvas;
+  void TH3Slicer(TCanvas* canvas, std::unique_ptr<TH3F>& histo3D, std::vector<float> list, double window, int iPar, float marker_size = 1.5);
+
+  std::unordered_map<o2::MCCompLabel, bool> mPairables;
+  std::unordered_map<o2::MCCompLabel, bool> mMFTTrackables;
+
+  static constexpr std::array<short, 7> sMinNClustersList = {4, 5, 6, 7, 8, 9, 10};
+  uint32_t mRefOrbit = 0; // Reference orbit used in relative time calculation
+  float mBz = 0;
+  bool mMIDFilterEnabled = true;
+  bool mFinalizeAnalysis = false;
+
+  ClassDefNV(GloFwdAssessment, 1);
+};
+
+} // namespace globaltracking
+} // namespace o2
+
+#endif

--- a/Detectors/GlobalTracking/src/MatchGlobalFwdAssessment.cxx
+++ b/Detectors/GlobalTracking/src/MatchGlobalFwdAssessment.cxx
@@ -1,0 +1,446 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "GlobalTracking/MatchGlobalFwdAssessment.h"
+#include "Framework/InputSpec.h"
+#include "DetectorsBase/GeometryManager.h"
+#include <Framework/InputRecord.h>
+#include <TPaveText.h>
+#include <TLegend.h>
+#include <TStyle.h>
+#include <TFile.h>
+
+using namespace o2::globaltracking;
+
+//__________________________________________________________
+void GloFwdAssessment::init(bool finalizeAnalysis)
+{
+  mFinalizeAnalysis = finalizeAnalysis;
+  createHistos();
+}
+
+//__________________________________________________________
+void GloFwdAssessment::reset()
+{
+
+  mTrackNumberOfClusters->Reset();
+  mTrackInvQPt->Reset();
+  mTrackChi2->Reset();
+  mTrackCharge->Reset();
+  mTrackPhi->Reset();
+  mTrackEta->Reset();
+  for (auto minNClusters : sMinNClustersList) {
+    auto nHisto = minNClusters - sMinNClustersList[0];
+    mTrackEtaNCls[nHisto]->Reset();
+    mTrackPhiNCls[nHisto]->Reset();
+    mTrackXYNCls[nHisto]->Reset();
+    mTrackEtaPhiNCls[nHisto]->Reset();
+  }
+
+  mTrackTanl->Reset();
+
+  if (mUseMC) {
+    mPairables.clear();
+    mMFTTrackables.clear();
+
+    mHistPhiRecVsPhiGen->Reset();
+    mHistEtaRecVsEtaGen->Reset();
+    for (int trackType = 0; trackType < kNumberOfTrackTypes; trackType++) {
+      mHistPhiVsEta[trackType]->Reset();
+      mHistPtVsEta[trackType]->Reset();
+      mHistPhiVsPt[trackType]->Reset();
+      mHistZvtxVsEta[trackType]->Reset();
+      if (trackType == kGen || trackType == kPairable) {
+        mHistRVsZ[trackType]->Reset();
+      }
+    }
+
+    auto h = mChargeMatchEff->GetCopyTotalHisto();
+    h->Reset();
+    mChargeMatchEff->SetTotalHistogram(*h, "");
+    mChargeMatchEff->SetPassedHistogram(*h, "");
+
+    for (auto& h : mTH3Histos) {
+      h->Reset();
+    }
+  }
+}
+
+//__________________________________________________________
+void GloFwdAssessment::createHistos()
+{
+
+  // Creating data-only histos
+  mTrackNumberOfClusters = std::make_unique<TH1F>("mGlobalFwdNumberOfClusters",
+                                                  "Number Of Clusters Per Track; # clusters; # entries", 10, 0.5, 10.5);
+
+  mTrackInvQPt = std::make_unique<TH1F>("mGlobalFwdInvQPt", "Track q/p_{T}; q/p_{T} [1/GeV]; # entries", 50, -2, 2);
+
+  mTrackChi2 = std::make_unique<TH1F>("mGlobalFwdChi2", "Track #chi^{2}; #chi^{2}; # entries", 21, -0.5, 20.5);
+
+  mTrackCharge = std::make_unique<TH1F>("mGlobalFwdCharge", "Track Charge; q; # entries", 3, -1.5, 1.5);
+
+  mTrackPhi = std::make_unique<TH1F>("mGlobalFwdPhi", "Track #phi; #phi; # entries", 100, -3.2, 3.2);
+
+  mTrackEta = std::make_unique<TH1F>("mGlobalFwdEta", "Track #eta; #eta; # entries", 50, -4, -2);
+
+  for (auto minNClusters : sMinNClustersList) {
+    auto nHisto = minNClusters - sMinNClustersList[0];
+    mTrackEtaNCls[nHisto] = std::make_unique<TH1F>(Form("mGlobalFwdEta_%d_MinClusters", minNClusters), Form("Track #eta (NCls >= %d); #eta; # entries", minNClusters), 50, -4, -2);
+
+    mTrackPhiNCls[nHisto] = std::make_unique<TH1F>(Form("mGlobalFwdPhi_%d_MinClusters", minNClusters), Form("Track #phi (NCls >= %d); #phi; # entries", minNClusters), 100, -3.2, 3.2);
+
+    mTrackXYNCls[nHisto] = std::make_unique<TH2F>(Form("mGlobalFwdXY_%d_MinClusters", minNClusters), Form("Track Position (NCls >= %d); x; y", minNClusters), 320, -16, 16, 320, -16, 16);
+    mTrackXYNCls[nHisto]->SetOption("COLZ");
+
+    mTrackEtaPhiNCls[nHisto] = std::make_unique<TH2F>(Form("mGlobalFwdEtaPhi_%d_MinClusters", minNClusters), Form("Track #eta , #phi (NCls >= %d); #eta; #phi", minNClusters), 50, -4, -2, 100, -3.2, 3.2);
+    mTrackEtaPhiNCls[nHisto]->SetOption("COLZ");
+  }
+
+  mTrackTanl = std::make_unique<TH1F>("mGlobalFwdTanl", "Track tan #lambda; tan #lambda; # entries", 100, -25, 0);
+
+  // Creating MC-based histos
+  if (mUseMC) {
+
+    LOG(info) << "Initializing MC Reader";
+    if (!mcReader.initFromDigitContext("collisioncontext.root")) {
+      throw std::invalid_argument("initialization of MCKinematicsReader failed");
+    }
+
+    mHistPhiRecVsPhiGen = std::make_unique<TH2F>("mGMTrackPhiRecVsPhiGen", "Phi Rec Vs Phi Gen of true reco tracks ", 24, -TMath::Pi(), TMath::Pi(), 24, -TMath::Pi(), TMath::Pi());
+    mHistPhiRecVsPhiGen->SetXTitle((std::string("#phi of ") + mNameOfTrackTypes[kGen]).c_str());
+    mHistPhiRecVsPhiGen->SetYTitle((std::string("#phi of ") + mNameOfTrackTypes[kRecoTrue]).c_str());
+    mHistPhiRecVsPhiGen->Sumw2();
+    mHistPhiRecVsPhiGen->SetOption("COLZ");
+
+    mHistEtaRecVsEtaGen = std::make_unique<TH2F>("mGMTrackEtaRecVsEtaGen", "Eta Rec Vs Eta Gen of true reco tracks ", 35, 1.0, 4.5, 35, 1.0, 4.5);
+    mHistEtaRecVsEtaGen->SetXTitle((std::string("#eta of ") + mNameOfTrackTypes[kGen]).c_str());
+    mHistEtaRecVsEtaGen->SetYTitle((std::string("#eta of ") + mNameOfTrackTypes[kRecoTrue]).c_str());
+    mHistEtaRecVsEtaGen->Sumw2();
+    mHistEtaRecVsEtaGen->SetOption("COLZ");
+
+    for (int trackType = 0; trackType < kNumberOfTrackTypes; trackType++) {
+      // mHistPhiVsEta
+      mHistPhiVsEta[trackType] = std::make_unique<TH2F>((std::string("mGMTrackPhiVsEta") + mNameOfTrackTypes[trackType]).c_str(), (std::string("Phi Vs Eta of ") + mNameOfTrackTypes[trackType]).c_str(), 35, 1.0, 4.5, 24, -TMath::Pi(), TMath::Pi());
+      mHistPhiVsEta[trackType]->SetXTitle((std::string("#eta of ") + mNameOfTrackTypes[trackType]).c_str());
+      mHistPhiVsEta[trackType]->SetYTitle((std::string("#phi of ") + mNameOfTrackTypes[trackType]).c_str());
+      mHistPhiVsEta[trackType]->Sumw2();
+      mHistPhiVsEta[trackType]->SetOption("COLZ");
+
+      // mHistPtVsEta
+      mHistPtVsEta[trackType] = std::make_unique<TH2F>((std::string("mGMTrackPtVsEta") + mNameOfTrackTypes[trackType]).c_str(), (std::string("Pt Vs Eta of ") + mNameOfTrackTypes[trackType]).c_str(), 35, 1.0, 4.5, 40, 0., 10.);
+      mHistPtVsEta[trackType]->SetXTitle((std::string("#eta of ") + mNameOfTrackTypes[trackType]).c_str());
+      mHistPtVsEta[trackType]->SetYTitle((std::string("p_{T} (GeV/c) of ") + mNameOfTrackTypes[trackType]).c_str());
+      mHistPtVsEta[trackType]->Sumw2();
+      mHistPtVsEta[trackType]->SetOption("COLZ");
+
+      // mHistPhiVsPt
+      mHistPhiVsPt[trackType] = std::make_unique<TH2F>((std::string("mGMTrackPhiVsPt") + mNameOfTrackTypes[trackType]).c_str(), (std::string("Phi Vs Pt of ") + mNameOfTrackTypes[trackType]).c_str(), 40, 0., 10., 24, -TMath::Pi(), TMath::Pi());
+      mHistPhiVsPt[trackType]->SetXTitle((std::string("p_{T} (GeV/c) of ") + mNameOfTrackTypes[trackType]).c_str());
+      mHistPhiVsPt[trackType]->SetYTitle((std::string("#phi of ") + mNameOfTrackTypes[trackType]).c_str());
+      mHistPhiVsPt[trackType]->Sumw2();
+      mHistPhiVsPt[trackType]->SetOption("COLZ");
+
+      if (trackType != kReco) {
+        // mHistZvtxVsEta
+        mHistZvtxVsEta[trackType] = std::make_unique<TH2F>((std::string("mGMTrackZvtxVsEta") + mNameOfTrackTypes[trackType]).c_str(), (std::string("Z_{vtx} Vs Eta of ") + mNameOfTrackTypes[trackType]).c_str(), 35, 1.0, 4.5, 15, -15, 15);
+        mHistZvtxVsEta[trackType]->SetXTitle((std::string("#eta of ") + mNameOfTrackTypes[trackType]).c_str());
+        mHistZvtxVsEta[trackType]->SetYTitle((std::string("z_{vtx} (cm) of ") + mNameOfTrackTypes[trackType]).c_str());
+        mHistZvtxVsEta[trackType]->Sumw2();
+        mHistZvtxVsEta[trackType]->SetOption("COLZ");
+      }
+      // mHistRVsZ]
+      if (trackType == kGen || trackType == kPairable) {
+        mHistRVsZ[trackType] = std::make_unique<TH2F>((std::string("mGMTrackRVsZ") + mNameOfTrackTypes[trackType]).c_str(), (std::string("R Vs Z of ") + mNameOfTrackTypes[trackType]).c_str(), 400, -80., 20., 400, 0., 80.);
+        mHistRVsZ[trackType]->SetXTitle((std::string("z (cm) origin of ") + mNameOfTrackTypes[trackType]).c_str());
+        mHistRVsZ[trackType]->SetYTitle((std::string("R (cm) radius of origin of ") + mNameOfTrackTypes[trackType]).c_str());
+        mHistRVsZ[trackType]->Sumw2();
+        mHistRVsZ[trackType]->SetOption("COLZ");
+      }
+    }
+
+    // Histos for Reconstruction assessment
+
+    mChargeMatchEff = std::make_unique<TEfficiency>("mGMTrackQMatchEff", "Charge Match;p_t [GeV];#epsilon", 50, 0, 20);
+
+    const int nTH3Histos = TH3Names.size();
+    auto n3Histo = 0;
+    for (auto& h : mTH3Histos) {
+      h = std::make_unique<TH3F>(TH3Names[n3Histo], TH3Titles[n3Histo],
+                                 (int)TH3Binning[n3Histo][0],
+                                 TH3Binning[n3Histo][1],
+                                 TH3Binning[n3Histo][2],
+                                 (int)TH3Binning[n3Histo][3],
+                                 TH3Binning[n3Histo][4],
+                                 TH3Binning[n3Histo][5],
+                                 (int)TH3Binning[n3Histo][6],
+                                 TH3Binning[n3Histo][7],
+                                 TH3Binning[n3Histo][8]);
+      h->GetXaxis()->SetTitle(TH3XaxisTitles[n3Histo]);
+      h->GetYaxis()->SetTitle(TH3YaxisTitles[n3Histo]);
+      h->GetZaxis()->SetTitle(TH3ZaxisTitles[n3Histo]);
+      ++n3Histo;
+    }
+  }
+}
+
+//__________________________________________________________
+void GloFwdAssessment::runBasicQC(o2::framework::ProcessingContext& ctx)
+{
+
+  // get tracks
+  mMFTTracks = ctx.inputs().get<gsl::span<o2::mft::TrackMFT>>("mfttracks");
+  mMCHTracks = ctx.inputs().get<gsl::span<o2::mch::TrackMCH>>("mchtracks");
+  mGlobalFwdTracks = ctx.inputs().get<gsl::span<o2::dataformats::GlobalFwdTrack>>("fwdtracks");
+
+  if (mUseMC) {
+    // get labels
+    mMFTTrackLabels = ctx.inputs().get<gsl::span<MCCompLabel>>("mfttrklabels");
+    mMCHTrackLabels = ctx.inputs().get<gsl::span<MCCompLabel>>("mchtrklabels");
+    mFwdTrackLabels = ctx.inputs().get<gsl::span<MCCompLabel>>("fwdtrklabels");
+  }
+
+  for (auto& oneTrack : mGlobalFwdTracks) {
+    if (mMIDFilterEnabled and (oneTrack.getMIDMatchingChi2() < 0)) { // MID filter
+      continue;
+    }
+    const auto nClusters = mMFTTracks[oneTrack.getMFTTrackID()].getNumberOfPoints();
+    mTrackNumberOfClusters->Fill(nClusters);
+    mTrackInvQPt->Fill(oneTrack.getInvQPt());
+    mTrackChi2->Fill(oneTrack.getTrackChi2());
+    mTrackCharge->Fill(oneTrack.getCharge());
+    mTrackPhi->Fill(oneTrack.getPhi());
+    mTrackEta->Fill(oneTrack.getEta());
+    mTrackTanl->Fill(oneTrack.getTanl());
+
+    for (auto minNClusters : sMinNClustersList) {
+      if (nClusters >= minNClusters) {
+        mTrackEtaNCls[minNClusters - sMinNClustersList[0]]->Fill(oneTrack.getEta());
+        mTrackPhiNCls[minNClusters - sMinNClustersList[0]]->Fill(oneTrack.getPhi());
+        mTrackXYNCls[minNClusters - sMinNClustersList[0]]->Fill(oneTrack.getX(), oneTrack.getY());
+        mTrackEtaPhiNCls[minNClusters - sMinNClustersList[0]]->Fill(oneTrack.getEta(), oneTrack.getPhi());
+      }
+    }
+  }
+}
+
+//__________________________________________________________
+void GloFwdAssessment::processPairables()
+{
+  int trackID = 0, evnID = 0, srcID = 0;
+  bool fake = false;
+  std::unordered_map<o2::MCCompLabel, std::array<bool, 2>> mcPairables;
+
+  // Loop MCH Tracks
+  auto nMCHTracks = mMCHTracks.size();
+  for (int iTrk = 0; iTrk < nMCHTracks; ++iTrk) {
+    auto mchLabel = mMCHTrackLabels[iTrk];
+    // std::cout << "Starting pairability mchLabel = " << mchLabel << std::endl;
+
+    mchLabel.get(trackID, evnID, srcID, fake);
+    if (fake) {
+      continue;
+    }
+    // mcPairables.insert_or_assign(mchLabel, std::array<bool, 2>({true, false}));
+    // mcPairables.insert
+    mcPairables[mchLabel][0] = true;
+  }
+
+  // Loop MFT Tracks
+  auto nMFTTracks = mMFTTracks.size();
+  for (int iTrk = 0; iTrk < nMFTTracks; ++iTrk) {
+    auto mftLabel = mMFTTrackLabels[iTrk];
+    // std::cout << " Testing pairability mftLabel = " << mftLabel << std::endl;
+
+    mftLabel.get(trackID, evnID, srcID, fake);
+    if (fake) {
+      continue;
+    }
+    auto t = mcPairables.find(mftLabel);
+    if (t != mcPairables.end()) {
+      t->second[1] = true;
+      // mcPairables[mftLabel][1] = true;
+    }
+  }
+
+  // Loop MFT Tracks
+
+  // Identify and process pairables
+  for (auto& testPair : mcPairables) {
+    auto& boolPair = testPair.second;
+    if (boolPair[0] and boolPair[1]) {
+      mPairables[testPair.first] = true;
+      auto const* mcParticle = mcReader.getTrack(testPair.first);
+      srcID = testPair.first.getSourceID();
+      evnID = testPair.first.getEventID();
+      auto evH = mcReader.getMCEventHeader(srcID, evnID);
+      addMCParticletoHistos(mcParticle, kPairable, evH);
+    }
+  }
+}
+
+//__________________________________________________________
+void GloFwdAssessment::processRecoAndTrueTracks()
+{
+
+  auto trkId = 0;
+  for (auto fwdTrack : mGlobalFwdTracks) {
+    if (mMIDFilterEnabled and (fwdTrack.getMIDMatchingChi2() < 0)) { // MID filter
+      trkId++;
+      continue;
+    }
+    auto pt_Rec = fwdTrack.getPt();
+    auto invQPt_Rec = fwdTrack.getInvQPt();
+    auto eta_Rec = std::abs(fwdTrack.getEta());
+    auto phi_Rec = fwdTrack.getPhi();
+    auto nMFTClusters = mMFTTracks[fwdTrack.getMFTTrackID()].getNumberOfPoints();
+    auto Chi2_Rec = fwdTrack.getTrackChi2();
+    int Q_Rec = fwdTrack.getCharge();
+
+    auto TrackType = kReco;
+    mHistPtVsEta[TrackType]->Fill(eta_Rec, pt_Rec);
+    mHistPhiVsEta[TrackType]->Fill(eta_Rec, phi_Rec);
+    mHistPhiVsPt[TrackType]->Fill(pt_Rec, phi_Rec);
+
+    auto trackLabel = mFwdTrackLabels[trkId];
+    if (trackLabel.isCorrect()) {
+      TrackType = kRecoTrue;
+      auto evH = mcReader.getMCEventHeader(trackLabel.getSourceID(), trackLabel.getEventID());
+      auto zVtx = evH.GetZ();
+
+      auto const* mcParticle = mcReader.getTrack(trackLabel);
+      auto etaGen = std::abs(mcParticle->GetEta());
+      auto phiGen = TMath::ATan2(mcParticle->Py(), mcParticle->Px());
+      auto ptGen = mcParticle->GetPt();
+      auto vxGen = mcParticle->GetStartVertexCoordinatesX();
+      auto vyGen = mcParticle->GetStartVertexCoordinatesY();
+      auto vzGen = mcParticle->GetStartVertexCoordinatesZ();
+      auto tanlGen = mcParticle->Pz() / mcParticle->GetPt();
+
+      auto pdgcode_MC = mcParticle->GetPdgCode();
+      int Q_Gen;
+      if (TDatabasePDG::Instance()->GetParticle(pdgcode_MC)) {
+        Q_Gen = TDatabasePDG::Instance()->GetParticle(pdgcode_MC)->Charge() / 3;
+      } else {
+        continue;
+      }
+      auto invQPtGen = 1.0 * Q_Gen / ptGen;
+      fwdTrack.propagateToZ(vzGen, mBz);
+
+      // Residuals at vertex
+      auto x_res = fwdTrack.getX() - vxGen;
+      auto y_res = fwdTrack.getY() - vyGen;
+      auto eta_res = fwdTrack.getEta() - etaGen;
+      auto phi_res = fwdTrack.getPhi() - phiGen;
+      auto tanl_res = fwdTrack.getTanl() - tanlGen;
+      auto invQPt_res = invQPt_Rec - invQPtGen;
+      mHistPtVsEta[TrackType]->Fill(eta_Rec, pt_Rec);
+      mHistPhiVsEta[TrackType]->Fill(eta_Rec, phi_Rec);
+      mHistPhiVsPt[TrackType]->Fill(pt_Rec, phi_Rec);
+      mHistZvtxVsEta[TrackType]->Fill(eta_Rec, zVtx);
+
+      mHistPhiRecVsPhiGen->Fill(phiGen, phi_Rec);
+      mHistEtaRecVsEtaGen->Fill(etaGen, eta_Rec);
+
+      /// Reco assessment histos
+      auto d_Charge = Q_Rec - Q_Gen;
+      mChargeMatchEff->Fill(!d_Charge, ptGen);
+
+      mTH3Histos[kTH3GMTrackDeltaXVertexPtEta]->Fill(ptGen, etaGen, 1e4 * x_res);
+      mTH3Histos[kTH3GMTrackDeltaYVertexPtEta]->Fill(ptGen, etaGen, 1e4 * y_res);
+      mTH3Histos[kTH3GMTrackDeltaXDeltaYEta]->Fill(etaGen, 1e4 * x_res, 1e4 * y_res);
+      mTH3Histos[kTH3GMTrackDeltaXDeltaYPt]->Fill(ptGen, 1e4 * x_res, 1e4 * y_res);
+      mTH3Histos[kTH3GMTrackXPullPtEta]->Fill(ptGen, etaGen, x_res / sqrt(fwdTrack.getCovariances()(0, 0)));
+      mTH3Histos[kTH3GMTrackYPullPtEta]->Fill(ptGen, etaGen, y_res / sqrt(fwdTrack.getCovariances()(1, 1)));
+      mTH3Histos[kTH3GMTrackPhiPullPtEta]->Fill(ptGen, etaGen, phi_res / sqrt(fwdTrack.getCovariances()(2, 2)));
+      mTH3Histos[kTH3GMTrackTanlPullPtEta]->Fill(ptGen, etaGen, tanl_res / sqrt(fwdTrack.getCovariances()(3, 3)));
+      mTH3Histos[kTH3GMTrackInvQPtPullPtEta]->Fill(ptGen, etaGen, invQPt_res / sqrt(fwdTrack.getCovariances()(4, 4)));
+      mTH3Histos[kTH3GMTrackInvQPtResolutionPtEta]->Fill(ptGen, etaGen, (invQPt_Rec - invQPtGen) / invQPtGen);
+      mTH3Histos[kTH3GMTrackReducedChi2PtEta]->Fill(ptGen, etaGen, Chi2_Rec / (2 * nMFTClusters - 5)); // 5: number of fitting parameters
+    }
+    trkId++;
+  }
+}
+
+//__________________________________________________________
+void GloFwdAssessment::addMCParticletoHistos(const MCTrack* mcTr, const int TrackType, const o2::dataformats::MCEventHeader& evH)
+{
+  auto zVtx = evH.GetZ();
+
+  auto pt = mcTr->GetPt();
+  auto eta = -1 * mcTr->GetEta();
+  auto phi = mcTr->GetPhi();
+  o2::math_utils::bringToPMPiGend(phi);
+  auto z = mcTr->GetStartVertexCoordinatesZ();
+  auto R = sqrt(pow(mcTr->GetStartVertexCoordinatesX(), 2) + pow(mcTr->GetStartVertexCoordinatesY(), 2));
+
+  mHistPtVsEta[TrackType]->Fill(eta, pt);
+  mHistPhiVsEta[TrackType]->Fill(eta, phi);
+  mHistPhiVsPt[TrackType]->Fill(pt, phi);
+  mHistZvtxVsEta[TrackType]->Fill(eta, zVtx);
+  if (TrackType == kGen || TrackType == kPairable) {
+    mHistRVsZ[TrackType]->Fill(z, R);
+  }
+}
+
+//__________________________________________________________
+void GloFwdAssessment::getHistos(TObjArray& objar)
+{
+
+  objar.Add(mTrackNumberOfClusters.get());
+  objar.Add(mTrackInvQPt.get());
+  objar.Add(mTrackChi2.get());
+  objar.Add(mTrackCharge.get());
+  objar.Add(mTrackPhi.get());
+  objar.Add(mTrackEta.get());
+  for (auto minNClusters : sMinNClustersList) {
+    auto nHisto = minNClusters - sMinNClustersList[0];
+    objar.Add(mTrackEtaNCls[nHisto].get());
+    objar.Add(mTrackPhiNCls[nHisto].get());
+    objar.Add(mTrackXYNCls[nHisto].get());
+    objar.Add(mTrackEtaPhiNCls[nHisto].get());
+  }
+  objar.Add(mTrackTanl.get());
+
+  if (mUseMC) {
+    objar.Add(mHistPhiRecVsPhiGen.get());
+    objar.Add(mHistEtaRecVsEtaGen.get());
+    for (int TrackType = 0; TrackType < kNumberOfTrackTypes; TrackType++) {
+      objar.Add(mHistPhiVsEta[TrackType].get());
+      objar.Add(mHistPtVsEta[TrackType].get());
+      objar.Add(mHistPhiVsPt[TrackType].get());
+      objar.Add(mHistZvtxVsEta[TrackType].get());
+      if (TrackType == kGen || TrackType == kPairable) {
+        objar.Add(mHistRVsZ[TrackType].get());
+      }
+    }
+
+    // Histos for Reconstruction assessment
+
+    for (auto& h : mTH3Histos) {
+      objar.Add(h.get());
+    }
+
+    objar.Add(mChargeMatchEff.get());
+  }
+}
+
+//__________________________________________________________
+bool GloFwdAssessment::loadHistos()
+{
+
+  return true;
+}
+
+//__________________________________________________________
+void GloFwdAssessment::finalizeAnalysis()
+{
+}

--- a/Detectors/GlobalTracking/src/MatchGlobalFwdAssessment.cxx
+++ b/Detectors/GlobalTracking/src/MatchGlobalFwdAssessment.cxx
@@ -63,11 +63,19 @@ void GloFwdAssessment::reset()
       }
     }
 
-    auto h = mChargeMatchEff->GetCopyTotalHisto();
-    h->Reset();
-    mChargeMatchEff->SetTotalHistogram(*h, "");
-    mChargeMatchEff->SetPassedHistogram(*h, "");
+    auto hC = mChargeMatchEff->GetCopyTotalHisto();
+    hC->Reset();
+    mChargeMatchEff->SetTotalHistogram(*hC, "");
+    mChargeMatchEff->SetPassedHistogram(*hC, "");
+    hC = mPurityPt->GetCopyTotalHisto();
+    mPurityPt->SetTotalHistogram(*hC, "");
+    mPurityPt->SetPassedHistogram(*hC, "");
+    mPurityPtInner->SetTotalHistogram(*hC, "");
+    mPurityPtInner->SetPassedHistogram(*hC, "");
+    mPurityPtOuter->SetTotalHistogram(*hC, "");
+    mPurityPtOuter->SetPassedHistogram(*hC, "");
 
+    mPairingEtaPt->Reset();
     for (auto& h : mTH3Histos) {
       h->Reset();
     }
@@ -79,7 +87,7 @@ void GloFwdAssessment::createHistos()
 {
 
   // Creating data-only histos
-  mTrackNumberOfClusters = std::make_unique<TH1F>("mGlobalFwdNumberOfClusters",
+  mTrackNumberOfClusters = std::make_unique<TH1F>("mGlobalFwdNumberOfMFTClusters",
                                                   "Number Of Clusters Per Track; # clusters; # entries", 10, 0.5, 10.5);
 
   mTrackInvQPt = std::make_unique<TH1F>("mGlobalFwdInvQPt", "Track q/p_{T}; q/p_{T} [1/GeV]; # entries", 50, -2, 2);
@@ -233,6 +241,20 @@ void GloFwdAssessment::runBasicQC(o2::framework::ProcessingContext& ctx)
 }
 
 //__________________________________________________________
+void GloFwdAssessment::processGeneratedTracks()
+{
+  for (auto src = 0; src < mcReader.getNSources(); src++) {
+    for (Int_t event = 0; event < mcReader.getNEvents(src); event++) {
+      const auto& mcTracks = mcReader.getTracks(src, event);
+      for (const auto& mcParticle : mcTracks) {
+        auto evh = mcReader.getMCEventHeader(src, event);
+        addMCParticletoHistos(&mcParticle, kGen, evh);
+      } // mcTracks
+    }   // events
+  }     // sources
+}
+
+//__________________________________________________________
 void GloFwdAssessment::processPairables()
 {
   int trackID = 0, evnID = 0, srcID = 0;
@@ -243,14 +265,11 @@ void GloFwdAssessment::processPairables()
   auto nMCHTracks = mMCHTracks.size();
   for (int iTrk = 0; iTrk < nMCHTracks; ++iTrk) {
     auto mchLabel = mMCHTrackLabels[iTrk];
-    // std::cout << "Starting pairability mchLabel = " << mchLabel << std::endl;
 
     mchLabel.get(trackID, evnID, srcID, fake);
     if (fake) {
       continue;
     }
-    // mcPairables.insert_or_assign(mchLabel, std::array<bool, 2>({true, false}));
-    // mcPairables.insert
     mcPairables[mchLabel][0] = true;
   }
 
@@ -258,7 +277,6 @@ void GloFwdAssessment::processPairables()
   auto nMFTTracks = mMFTTracks.size();
   for (int iTrk = 0; iTrk < nMFTTracks; ++iTrk) {
     auto mftLabel = mMFTTrackLabels[iTrk];
-    // std::cout << " Testing pairability mftLabel = " << mftLabel << std::endl;
 
     mftLabel.get(trackID, evnID, srcID, fake);
     if (fake) {
@@ -267,11 +285,8 @@ void GloFwdAssessment::processPairables()
     auto t = mcPairables.find(mftLabel);
     if (t != mcPairables.end()) {
       t->second[1] = true;
-      // mcPairables[mftLabel][1] = true;
     }
   }
-
-  // Loop MFT Tracks
 
   // Identify and process pairables
   for (auto& testPair : mcPairables) {
@@ -299,16 +314,28 @@ void GloFwdAssessment::processRecoAndTrueTracks()
     }
     auto pt_Rec = fwdTrack.getPt();
     auto invQPt_Rec = fwdTrack.getInvQPt();
+    auto px_mch = mMCHTracks[fwdTrack.getMCHTrackID()].getPx();
+    auto py_mch = mMCHTracks[fwdTrack.getMCHTrackID()].getPy();
+    auto invQPt_MCH = mMCHTracks[fwdTrack.getMCHTrackID()].getSign() / sqrt(px_mch * px_mch + py_mch * py_mch);
     auto eta_Rec = std::abs(fwdTrack.getEta());
     auto phi_Rec = fwdTrack.getPhi();
     auto nMFTClusters = mMFTTracks[fwdTrack.getMFTTrackID()].getNumberOfPoints();
     auto Chi2_Rec = fwdTrack.getTrackChi2();
     int Q_Rec = fwdTrack.getCharge();
+    auto matchChi2 = fwdTrack.getMFTMCHMatchingChi2();
+    auto matchMatchScore = fwdTrack.getMFTMCHMatchingScore();
 
     auto TrackType = kReco;
     mHistPtVsEta[TrackType]->Fill(eta_Rec, pt_Rec);
     mHistPhiVsEta[TrackType]->Fill(eta_Rec, phi_Rec);
     mHistPhiVsPt[TrackType]->Fill(pt_Rec, phi_Rec);
+
+    mTH3Histos[kTH3GMTrackPtEtaChi2]->Fill(pt_Rec, eta_Rec, matchChi2);
+    mTH3Histos[kTH3GMTrackPtEtaMatchScore]->Fill(pt_Rec, eta_Rec, matchMatchScore);
+    if (fwdTrack.isCloseMatch()) {
+      mTH3Histos[kTH3GMCloseMatchPtEtaChi2]->Fill(pt_Rec, eta_Rec, matchChi2);
+      mTH3Histos[kTH3GMCloseMatchPtEtaMatchScore]->Fill(pt_Rec, eta_Rec, matchMatchScore);
+    }
 
     auto trackLabel = mFwdTrackLabels[trkId];
     if (trackLabel.isCorrect()) {
@@ -364,7 +391,10 @@ void GloFwdAssessment::processRecoAndTrueTracks()
       mTH3Histos[kTH3GMTrackTanlPullPtEta]->Fill(ptGen, etaGen, tanl_res / sqrt(fwdTrack.getCovariances()(3, 3)));
       mTH3Histos[kTH3GMTrackInvQPtPullPtEta]->Fill(ptGen, etaGen, invQPt_res / sqrt(fwdTrack.getCovariances()(4, 4)));
       mTH3Histos[kTH3GMTrackInvQPtResolutionPtEta]->Fill(ptGen, etaGen, (invQPt_Rec - invQPtGen) / invQPtGen);
-      mTH3Histos[kTH3GMTrackReducedChi2PtEta]->Fill(ptGen, etaGen, Chi2_Rec / (2 * nMFTClusters - 5)); // 5: number of fitting parameters
+      mTH3Histos[kTH3GMTrackInvQPtResMCHPtEta]->Fill(ptGen, etaGen, (invQPt_MCH - invQPtGen) / invQPtGen);
+      mTH3Histos[kTH3GMTrackReducedChi2PtEta]->Fill(ptGen, etaGen, Chi2_Rec / (2 * nMFTClusters - 5));
+      mTH3Histos[kTH3GMTruePtEtaChi2]->Fill(pt_Rec, eta_Rec, matchChi2);
+      mTH3Histos[kTH3GMTruePtEtaMatchScore]->Fill(pt_Rec, eta_Rec, matchMatchScore);
     }
     trkId++;
   }
@@ -388,6 +418,9 @@ void GloFwdAssessment::addMCParticletoHistos(const MCTrack* mcTr, const int Trac
   mHistZvtxVsEta[TrackType]->Fill(eta, zVtx);
   if (TrackType == kGen || TrackType == kPairable) {
     mHistRVsZ[TrackType]->Fill(z, R);
+  }
+  if (TrackType == kPairable) {
+    mTH3Histos[kTH3GMPairablePtEtaZ]->Fill(pt, eta, zVtx);
   }
 }
 
@@ -430,6 +463,16 @@ void GloFwdAssessment::getHistos(TObjArray& objar)
     }
 
     objar.Add(mChargeMatchEff.get());
+    objar.Add(mPurityPt.get());
+    objar.Add(mPurityPtInner.get());
+    objar.Add(mPurityPtOuter.get());
+    objar.Add(mPairingEtaPt.get());
+
+    if (mFinalizeAnalysis) {
+      for (int slicedCanvas = 0; slicedCanvas < kNSlicedTH3; slicedCanvas++) {
+        objar.Add(mSlicedCanvas[slicedCanvas]);
+      }
+    }
   }
 }
 
@@ -443,4 +486,140 @@ bool GloFwdAssessment::loadHistos()
 //__________________________________________________________
 void GloFwdAssessment::finalizeAnalysis()
 {
+  if (mFinalizeAnalysis) {
+    std::vector<float> ptList({.5, 5., 10., 18.0});
+    float ptWindow = 1.0;
+    std::vector<float> etaList({2.5, 3.0});
+    float etaWindow = 0.5;
+
+    std::vector<float> sliceList;
+    float sliceWindow;
+
+    for (int nCanvas = 0; nCanvas < kNSlicedTH3; nCanvas++) {
+      if (nCanvas % 2) {
+        sliceList = etaList;
+        sliceWindow = etaWindow;
+      } else {
+        sliceList = ptList;
+        sliceWindow = ptWindow;
+      }
+      mSlicedCanvas[nCanvas] = new TCanvas(TH3SlicedNames[nCanvas], TH3SlicedNames[nCanvas], 1080, 1080);
+      TH3Slicer(mSlicedCanvas[nCanvas], mTH3Histos[TH3SlicedMap[nCanvas]], sliceList, sliceWindow, 2);
+    }
+
+    auto& Reco = mTH3Histos[kTH3GMTrackPtEtaMatchScore];
+    auto& hTrue = mTH3Histos[kTH3GMTruePtEtaMatchScore];
+    auto& hPairable = mTH3Histos[kTH3GMPairablePtEtaZ];
+
+    auto RecoEtaPt = (TH2D*)Reco->Project3D("xy COLZ");
+    auto PairableEtaPt = (TH2D*)hPairable->Project3D("xy COLZ");
+
+    auto RecoPtProj = (TH1*)Reco->ProjectionX();
+    auto TruePtProj = (TH1*)hTrue->ProjectionX();
+    mPurityPt = std::make_unique<TEfficiency>(*TruePtProj, *RecoPtProj);
+    mPurityPt->SetNameTitle("GMTrackPurity", "GMTrackPurity");
+    auto minBin = Reco->GetYaxis()->FindBin(3.0);
+    auto maxBin = Reco->GetYaxis()->FindBin(3.6);
+    auto RecoPtProjInner = (TH1*)Reco->ProjectionX("InnerReco", minBin, maxBin);
+    auto TruePtProjInner = (TH1*)hTrue->ProjectionX("InnerTrue", minBin, maxBin);
+    mPurityPtInner = std::make_unique<TEfficiency>(*TruePtProjInner, *RecoPtProjInner);
+    mPurityPtInner->SetNameTitle("GMTrackPurityInnerEta", "GMTrackPurity (3.0 < #eta < 3.6 )");
+
+    minBin = Reco->GetYaxis()->FindBin(2.4);
+    maxBin = Reco->GetYaxis()->FindBin(3.0);
+    auto RecoPtProjOuter = (TH1*)Reco->ProjectionX("OuterReco", minBin, maxBin);
+    auto TruePtProjOuter = (TH1*)hTrue->ProjectionX("OuterTrue", minBin, maxBin);
+    mPurityPtOuter = std::make_unique<TEfficiency>(*TruePtProjOuter, *RecoPtProjOuter);
+    mPurityPtOuter->SetNameTitle("GMTrackPurityOuterEta", "GMTrackPurity (2.4 < #eta < 3.0 )");
+
+    mPairingEtaPt = (std::unique_ptr<TH2D>)static_cast<TH2D*>(RecoEtaPt->Clone());
+    mPairingEtaPt->Divide(PairableEtaPt);
+    mPairingEtaPt->SetNameTitle("GMTrackPairingEffEtaPt", "PairingEffEtaPt");
+    mPairingEtaPt->SetOption("COLZ");
+  }
+}
+
+//__________________________________________________________
+void GloFwdAssessment::TH3Slicer(TCanvas* canvas, std::unique_ptr<TH3F>& histo3D, std::vector<float> list, double window, int iPar, float marker_size)
+{
+  gStyle->SetOptTitle(kFALSE);
+  gStyle->SetOptStat(0); // Remove title of first histogram from canvas
+  gStyle->SetMarkerStyle(kFullCircle);
+  gStyle->SetMarkerSize(marker_size);
+  canvas->UseCurrentStyle();
+  canvas->cd();
+  std::string cname = canvas->GetName();
+  std::string ctitle = cname;
+  std::string option;
+  std::string option2 = "PLC PMC same";
+
+  TObjArray aSlices;
+  histo3D->GetYaxis()->SetRange(0, 0);
+  histo3D->GetXaxis()->SetRange(0, 0);
+  bool first = true;
+  if (cname.find("VsEta") < cname.length()) {
+    for (auto ptmin : list) {
+      auto ptmax = ptmin + window;
+      histo3D->GetXaxis()->SetRangeUser(ptmin, ptmax);
+
+      std::string ytitle = "\\sigma (";
+      ytitle += histo3D->GetZaxis()->GetTitle();
+      ytitle += ")";
+      auto title = Form("_%1.2f_%1.2f_yz", ptmin, ptmax);
+      auto aDBG = (TH2F*)histo3D->Project3D(title);
+      aDBG->GetXaxis()->SetRangeUser(0, 0);
+
+      aDBG->FitSlicesX(nullptr, 0, -1, 4, "QNR", &aSlices);
+      auto th1DBG = (TH1F*)aSlices[iPar];
+      th1DBG->SetTitle(Form("%1.2f < p_t < %1.2f", ptmin, ptmax));
+      th1DBG->SetStats(0);
+      th1DBG->SetYTitle(ytitle.c_str());
+      if (first) {
+        option = "PLC PMC";
+      } else {
+        option = "SAME PLC PMC";
+      }
+      first = false;
+      th1DBG->DrawClone(option.c_str());
+    }
+  } else if (cname.find("VsPt") < cname.length()) {
+    for (auto etamin : list) {
+      auto etamax = etamin + window;
+      histo3D->GetYaxis()->SetRangeUser(etamin, etamax);
+      std::string ytitle = "\\sigma (" + std::string(histo3D->GetZaxis()->GetTitle()) + ")";
+      auto title = Form("_%1.2f_%1.2f_xz", etamin, etamax);
+      auto aDBG = (TH2F*)histo3D->Project3D(title);
+      aDBG->FitSlicesX(nullptr, 0, -1, 4, "QNR", &aSlices);
+      auto th1DBG = (TH1F*)aSlices[iPar];
+      th1DBG->SetTitle(Form("%1.2f < \\eta < %1.2f", etamin, etamax));
+      th1DBG->SetStats(0);
+      th1DBG->SetYTitle(ytitle.c_str());
+      if (first) {
+        option = "PLC PMC";
+      } else {
+        option = "SAME PLC PMC";
+      }
+      first = false;
+      th1DBG->DrawClone(option.c_str());
+    }
+  } else {
+    exit(1);
+  }
+
+  histo3D->GetYaxis()->SetRange(0, 0);
+  histo3D->GetXaxis()->SetRange(0, 0);
+
+  TPaveText* t = new TPaveText(0.2223748, 0.9069355, 0.7776252, 0.965, "brNDC"); // left-up
+  t->SetBorderSize(0);
+  t->SetFillColor(gStyle->GetTitleFillColor());
+  t->AddText(ctitle.c_str());
+  t->Draw();
+
+  canvas->BuildLegend();
+  canvas->SetTicky();
+  canvas->SetGridy();
+  if (0) {
+    cname += ".png";
+    canvas->Print(cname.c_str());
+  }
 }

--- a/Detectors/GlobalTrackingWorkflow/CMakeLists.txt
+++ b/Detectors/GlobalTrackingWorkflow/CMakeLists.txt
@@ -26,6 +26,7 @@ o2_add_library(GlobalTrackingWorkflow
                        src/TOFMatchChecker.cxx
                        src/TOFEventTimeChecker.cxx
                        src/GlobalFwdTrackWriterSpec.cxx
+                       src/GlobalFwdMatchingAssessmentSpec.cxx
                        src/MatchedMFTMCHWriterSpec.cxx
                PUBLIC_LINK_LIBRARIES O2::GlobalTracking
                                      O2::GlobalTrackingWorkflowReaders
@@ -88,6 +89,11 @@ o2_add_executable(match-eventtime-workflow
 o2_add_executable(matcher-workflow
                   COMPONENT_NAME globalfwd
                   SOURCES src/globalfwd-matcher-workflow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::GlobalTrackingWorkflow)
+
+o2_add_executable(assessment-workflow
+                  COMPONENT_NAME globalfwd
+                  SOURCES src/globalfwd-assessment-workflow.cxx
                   PUBLIC_LINK_LIBRARIES O2::GlobalTrackingWorkflow)
 
 o2_add_executable(writer-workflow

--- a/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/GlobalFwdMatchingAssessmentSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/GlobalFwdMatchingAssessmentSpec.h
@@ -1,0 +1,67 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef GLOFWD_ASSESSMENT_DEVICE_H
+#define GLOFWD_ASSESSMENT_DEVICE_H
+
+/// @file   GlobalFwdMatchingAssessmentSpec.h
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+#include "GlobalTracking/MatchGlobalFwdAssessment.h"
+#include "TStopwatch.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace globaltracking
+{
+class GlobalFwdAssessmentSpec : public Task
+{
+ public:
+  GlobalFwdAssessmentSpec(bool useMC, bool processGen, bool midFilterDisabled, bool finalizeAnalysis = false) : mUseMC(useMC),
+                                                                                                                mMIDFilterDisabled(midFilterDisabled),
+                                                                                                                mProcessGen(processGen),
+                                                                                                                mFinalizeAnalysis(finalizeAnalysis){};
+  void init(o2::framework::InitContext& ic) final;
+  void run(o2::framework::ProcessingContext& pc) final;
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+
+ private:
+  void sendOutput(DataAllocator& output);
+  std::unique_ptr<o2::globaltracking::GloFwdAssessment> mGloFwdAssessment;
+  bool mUseMC = true;
+  bool mProcessGen = false;
+  bool mFinalizeAnalysis = false;
+  bool mMIDFilterDisabled = false;
+  enum TimerIDs { SWTot,
+                  SWQCAsync,
+                  SWTrackables,
+                  SWGenerated,
+                  SWRecoAndTrue,
+                  SWAnalysis,
+                  NStopWatches };
+  static constexpr std::string_view TimerName[] = {"Total",
+                                                   "ProcessAsync",
+                                                   "ProcessTrackables",
+                                                   "ProcessGenerated",
+                                                   "ProcessRecoAndTrue",
+                                                   "Analysis"};
+  TStopwatch mTimer[NStopWatches];
+};
+
+DataProcessorSpec getGlobaFwdAssessmentSpec(bool useMC, bool processGen, bool midFilterDisabled, bool finalizeAnalysis = false);
+
+} // namespace globaltracking
+} // namespace o2
+
+#endif

--- a/Detectors/GlobalTrackingWorkflow/src/GlobalFwdMatchingAssessmentSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/GlobalFwdMatchingAssessmentSpec.cxx
@@ -71,7 +71,7 @@ void GlobalFwdAssessmentSpec::run(o2::framework::ProcessingContext& pc)
 
     if (mProcessGen) {
       mTimer[SWGenerated].Start(false);
-      // mGloFwdAssessment->processGeneratedTracks();
+      mGloFwdAssessment->processGeneratedTracks();
       mTimer[SWGenerated].Stop();
     }
     mTimer[SWRecoAndTrue].Start(false);

--- a/Detectors/GlobalTrackingWorkflow/src/GlobalFwdMatchingAssessmentSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/GlobalFwdMatchingAssessmentSpec.cxx
@@ -1,0 +1,140 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file GlobalFwdAssessmentSpec.cxx
+
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/Logger.h"
+#include "GlobalTrackingWorkflow/GlobalFwdMatchingAssessmentSpec.h"
+#include "DetectorsBase/Propagator.h"
+#include "Field/MagneticField.h"
+#include "TGeoGlobalMagField.h"
+#include "CommonUtils/NameConf.h"
+#include <TFile.h>
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace globaltracking
+{
+
+//_____________________________________________________________
+void GlobalFwdAssessmentSpec::init(InitContext& ic)
+{
+  mGloFwdAssessment = std::make_unique<o2::globaltracking::GloFwdAssessment>(mUseMC);
+
+  if (mMIDFilterDisabled) {
+    mGloFwdAssessment->disableMIDFilter();
+  }
+  auto filename = o2::base::NameConf::getGRPFileName();
+  const auto grp = o2::parameters::GRPObject::loadFrom(filename.c_str());
+  if (grp) {
+    o2::base::Propagator::initFieldFromGRP(grp);
+    auto field = static_cast<o2::field::MagneticField*>(TGeoGlobalMagField::Instance()->GetField());
+    double centerMFT[3] = {0, 0, -61.4}; // Field at center of MFT
+    auto Bz = field->getBz(centerMFT);
+    mGloFwdAssessment->setBz(Bz);
+  }
+
+  for (int sw = 0; sw < NStopWatches; sw++) {
+    mTimer[sw].Stop();
+    mTimer[sw].Reset();
+  }
+
+  mTimer[SWTot].Start(false);
+  mGloFwdAssessment->init(mFinalizeAnalysis);
+}
+
+//_____________________________________________________________
+void GlobalFwdAssessmentSpec::run(o2::framework::ProcessingContext& pc)
+{
+
+  mTimer[SWQCAsync].Start(false);
+  mGloFwdAssessment->runBasicQC(pc);
+  mTimer[SWQCAsync].Stop();
+
+  if (mUseMC) {
+
+    mTimer[SWTrackables].Start(false);
+    mGloFwdAssessment->processPairables();
+    mTimer[SWTrackables].Stop();
+
+    if (mProcessGen) {
+      mTimer[SWGenerated].Start(false);
+      // mGloFwdAssessment->processGeneratedTracks();
+      mTimer[SWGenerated].Stop();
+    }
+    mTimer[SWRecoAndTrue].Start(false);
+    mGloFwdAssessment->processRecoAndTrueTracks();
+    mTimer[SWRecoAndTrue].Stop();
+  }
+}
+
+//_____________________________________________________________
+void GlobalFwdAssessmentSpec::endOfStream(o2::framework::EndOfStreamContext& ec)
+{
+  if (mFinalizeAnalysis) {
+    mTimer[SWAnalysis].Start(false);
+    mGloFwdAssessment->finalizeAnalysis();
+    mTimer[SWAnalysis].Stop();
+  }
+
+  sendOutput(ec.outputs());
+  mTimer[SWTot].Stop();
+
+  for (int i = 0; i < NStopWatches; i++) {
+    LOGF(info, "Timing %18s: Cpu: %.3e s; Real: %.3e s in %d slots", TimerName[i], mTimer[i].CpuTime(), mTimer[i].RealTime(), mTimer[i].Counter() - 1);
+  }
+}
+
+//_____________________________________________________________
+void GlobalFwdAssessmentSpec::sendOutput(DataAllocator& output)
+{
+  TObjArray objar;
+  mGloFwdAssessment->getHistos(objar);
+
+  output.snapshot(Output{"GLO", "FWDASSESSMENT", 0, Lifetime::Timeframe}, objar);
+
+  TFile* f = new TFile(Form("GlobalForwardAssessment.root"), "RECREATE");
+  objar.Write();
+  f->Close();
+}
+
+//_____________________________________________________________
+DataProcessorSpec getGlobaFwdAssessmentSpec(bool useMC, bool processGen, bool midFilterDisabled, bool finalizeAnalysis)
+{
+  std::vector<InputSpec> inputs;
+  std::vector<OutputSpec> outputs;
+
+  inputs.emplace_back("fwdtracks", "GLO", "GLFWD", 0, Lifetime::Timeframe);
+  inputs.emplace_back("mfttracks", "MFT", "TRACKS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("mchtracks", "MCH", "TRACKS", 0, Lifetime::Timeframe);
+
+  if (useMC) {
+    inputs.emplace_back("mfttrklabels", "MFT", "TRACKSMCTR", 0, Lifetime::Timeframe);
+    inputs.emplace_back("mchtrklabels", "MCH", "TRACKLABELS", 0, Lifetime::Timeframe);
+    inputs.emplace_back("fwdtrklabels", "GLO", "GLFWD_MC", 0, Lifetime::Timeframe);
+  }
+
+  outputs.emplace_back("GLO", "FWDASSESSMENT", 0, Lifetime::Timeframe);
+
+  return DataProcessorSpec{
+    "glofwd-assessment",
+    inputs,
+    outputs,
+    AlgorithmSpec{adaptFromTask<o2::globaltracking::GlobalFwdAssessmentSpec>(useMC, processGen, midFilterDisabled, finalizeAnalysis)},
+    Options{{}}};
+}
+
+} // namespace globaltracking
+} // namespace o2

--- a/Detectors/GlobalTrackingWorkflow/src/globalfwd-assessment-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/globalfwd-assessment-workflow.cxx
@@ -23,7 +23,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"disable-mc", o2::framework::VariantType::Bool, false, {"disable use of MC information even if available"}},
     {"disable-process-gen", o2::framework::VariantType::Bool, false, {"disable processing of all generated tracks"}},
     {"disable-MID-filter", o2::framework::VariantType::Bool, false, {"disable MID filter"}},
-    {"finalize-analysis", o2::framework::VariantType::Bool, false, {"Process collected assssment data"}},
+    {"finalize-analysis", o2::framework::VariantType::Bool, false, {"Process collected assment data"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
   std::swap(workflowOptions, options);
 }

--- a/Detectors/GlobalTrackingWorkflow/src/globalfwd-assessment-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/globalfwd-assessment-workflow.cxx
@@ -1,0 +1,49 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/DataProcessorSpec.h"
+#include "GlobalTrackingWorkflow/GlobalFwdMatchingAssessmentSpec.h"
+#include "CommonUtils/ConfigurableParam.h"
+
+using namespace o2::framework;
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  std::vector<o2::framework::ConfigParamSpec> options{
+    {"disable-mc", o2::framework::VariantType::Bool, false, {"disable use of MC information even if available"}},
+    {"disable-process-gen", o2::framework::VariantType::Bool, false, {"disable processing of all generated tracks"}},
+    {"disable-MID-filter", o2::framework::VariantType::Bool, false, {"disable MID filter"}},
+    {"finalize-analysis", o2::framework::VariantType::Bool, false, {"Process collected assssment data"}},
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
+  std::swap(workflowOptions, options);
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  // Update the (declared) parameters if changed from the command line
+  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
+  // write the configuration used for the workflow
+  o2::conf::ConfigurableParam::writeINI("o2-globalfwd-assessment.ini");
+  auto useMC = !configcontext.options().get<bool>("disable-mc");
+  auto processGen = !configcontext.options().get<bool>("disable-process-gen");
+  auto finalizeAnalysis = configcontext.options().get<bool>("finalize-analysis");
+  auto midFilterDisabled = configcontext.options().get<bool>("disable-MID-filter");
+
+  WorkflowSpec specs;
+  specs.emplace_back(o2::globaltracking::getGlobaFwdAssessmentSpec(useMC, processGen, midFilterDisabled, finalizeAnalysis));
+  return specs;
+}

--- a/Detectors/ITSMFT/MFT/tracking/src/TrackFitter.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/TrackFitter.cxx
@@ -131,10 +131,13 @@ bool TrackFitter<T>::initTrack(T& track, bool outward)
     deltaY = track.getYCoordinates()[first_cls] - track.getYCoordinates()[next_cls];
     deltaZ = track.getZCoordinates()[first_cls] - track.getZCoordinates()[next_cls];
     deltaR = TMath::Sqrt(deltaX * deltaX + deltaY * deltaY);
-    auto phi0 = TMath::ATan2(deltaY, deltaX) - 0.5 * Hz * invQPt0 * std::abs(deltaZ) * k / tanl0;
+    double phi0;
     if (outward) {
-      phi0 += TMath::Pi();
+      phi0 = TMath::ATan2(-deltaY, -deltaX) - 0.5 * Hz * invQPt0 * deltaZ * k / tanl0;
+    } else {
+      phi0 = TMath::ATan2(deltaY, deltaX) - 0.5 * Hz * invQPt0 * deltaZ * k / tanl0;
     }
+    // The low momentum phi0 correction may be irrelevant and may require a call to o2::math_utils::bringToPMPiGend(phi0);
 
     track.setX(x0);
     track.setY(y0);
@@ -201,9 +204,11 @@ bool TrackFitter<T>::initTrack(T& track, bool outward)
     auto deltaZ = track.getZCoordinates()[first_cls] - track.getZCoordinates()[next_cls];
     auto deltaR = TMath::Sqrt(deltaX * deltaX + deltaY * deltaY);
     auto tanl0 = -std::abs(deltaZ) / deltaR;
-    auto phi0 = TMath::ATan2(deltaY, deltaX);
+    double phi0;
     if (outward) {
-      phi0 += TMath::Pi();
+      phi0 = TMath::ATan2(-deltaY, -deltaX);
+    } else {
+      phi0 = TMath::ATan2(deltaY, deltaX);
     }
 
     track.setX(x0);


### PR DESCRIPTION

Usage modes:
  1. Plug in to matching workflow:
    -  `o2-globalfwd-matcher-workflow | o2-globalfwd-assessment-workflow`
  2. Reading data on disk:
    - `o2-global-track-cluster-reader --track-types MFT,MCH,MFT-MCH | o2-globalfwd-assessment-workflow`
  
  By default the workflow only collects data. Analysis of collected data can be executed by `--finalize-analysis`, producing objects that cannot be merged. Finalization evaluates reconstruction performance, the pairing efficiency and purity of global muon tracks. The finalization is expected to be improved in the near future.