### PR TITLE
DPL Analysis: inspect Configurables in tasks recursively

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -896,7 +896,7 @@ using is_soa_iterator_t = typename framework::is_base_of_template<RowViewCore, T
 template <typename T>
 constexpr bool is_soa_iterator_v()
 {
-  return is_soa_iterator_t<T>::value || framework::is_specialization<T, RowViewCore>::value;
+  return is_soa_iterator_t<T>::value || framework::is_specialization_v<T, RowViewCore>;
 }
 
 template <typename T>
@@ -1991,10 +1991,10 @@ struct Concat : ConcatBase<T1, T2> {
 };
 
 template <typename T>
-using is_soa_join_t = typename framework::is_specialization<T, soa::Join>;
+inline constexpr bool is_soa_join_v = framework::is_specialization_v<T, soa::Join>;
 
 template <typename T>
-using is_soa_concat_t = typename framework::is_specialization<T, soa::Concat>;
+inline constexpr bool is_soa_concat_v = framework::is_specialization_v<T, soa::Concat>;
 
 template <typename T>
 class FilteredBase : public T

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1991,10 +1991,16 @@ struct Concat : ConcatBase<T1, T2> {
 };
 
 template <typename T>
-inline constexpr bool is_soa_join_v = framework::is_specialization_v<T, soa::Join>;
+using is_soa_join_t = framework::is_specialization<T, soa::Join>;
 
 template <typename T>
-inline constexpr bool is_soa_concat_v = framework::is_specialization_v<T, soa::Concat>;
+using is_soa_concat_t = framework::is_specialization<T, soa::Concat>;
+
+template <typename T>
+inline constexpr bool is_soa_join_v = is_soa_join_t<T>::value;
+
+template <typename T>
+inline constexpr bool is_soa_concat_v = is_soa_concat_t<T>::value;
 
 template <typename T>
 class FilteredBase : public T

--- a/Framework/Core/include/Framework/Configurable.h
+++ b/Framework/Core/include/Framework/Configurable.h
@@ -105,5 +105,22 @@ std::ostream& operator<<(std::ostream& os, Configurable<T, K, IP> const& c)
   return os;
 }
 
+/// Can be used to group together a number of Configurables
+/// to overcome the limit of 100 Configurables per task.
+/// In order to do so you can do:
+///
+/// struct MyTask {
+///   struct MyGroup : ConfigurableGroup {
+///     Configurable<int> aCut{...};
+///     Configurable<float> bCut{...};
+///   } group;
+/// };
+///
+/// and access it with
+///
+/// group.aCut;
+struct ConfigurableGroup {
+};
+
 } // namespace o2::framework
 #endif // O2_FRAMEWORK_CONFIGURABLE_H_

--- a/Framework/Core/include/Framework/DataRefUtils.h
+++ b/Framework/Core/include/Framework/DataRefUtils.h
@@ -119,7 +119,7 @@ struct DataRefUtils {
       });
 
       return std::move(result);
-    } else if constexpr (is_specialization<T, ROOTSerialized>::value == true) {
+    } else if constexpr (is_specialization_v<T, ROOTSerialized> == true) {
       // See above. SFINAE allows us to use this to extract a ROOT-serialized object
       // with a somewhat uniform API. ROOT serialization method is enforced by using
       // type wrapper @a ROOTSerialized
@@ -151,7 +151,7 @@ struct DataRefUtils {
         }
       });
       return std::move(result);
-    } else if constexpr (is_specialization<T, CCDBSerialized>::value == true) {
+    } else if constexpr (is_specialization_v<T, CCDBSerialized> == true) {
       using wrapped = typename T::wrapped_type;
       using DataHeader = o2::header::DataHeader;
       std::unique_ptr<wrapped> result(static_cast<wrapped*>(DataRefUtils::decodeCCDB(ref, typeid(wrapped))));

--- a/Framework/Core/include/Framework/GroupSlicer.h
+++ b/Framework/Core/include/Framework/GroupSlicer.h
@@ -73,7 +73,7 @@ struct GroupSlicer {
       constexpr auto index = framework::has_type_at_v<std::decay_t<T>>(associated_pack_t{});
       if constexpr (relatedByIndex<std::decay_t<G>, std::decay_t<T>>()) {
         auto name = getLabelFromType<std::decay_t<T>>();
-        if constexpr (!framework::is_specialization<std::decay_t<T>, soa::SmallGroups>::value) {
+        if constexpr (!framework::is_specialization_v<std::decay_t<T>, soa::SmallGroups>) {
           if (table.size() == 0) {
             return;
           }
@@ -279,7 +279,7 @@ struct GroupSlicer {
         } else {
           pos = position;
         }
-        if constexpr (!framework::is_specialization<std::decay_t<A1>, soa::SmallGroups>::value) {
+        if constexpr (!framework::is_specialization_v<std::decay_t<A1>, soa::SmallGroups>) {
           if (originalTable.size() == 0) {
             return originalTable;
           }

--- a/Framework/Core/test/test_AnalysisTask.cxx
+++ b/Framework/Core/test/test_AnalysisTask.cxx
@@ -129,6 +129,16 @@ struct JTask {
   }
 };
 
+struct KTask {
+  struct : public ConfigurableGroup {
+    Configurable<int> anInt{"someConfigurable", {}, "Some Configurable Object"};
+    Configurable<int> anotherInt{"someOtherConfigurable", {}, "Some Configurable Object"};
+  } foo;
+  Configurable<int> anThirdInt{"someThirdConfigurable", {}, "Some Configurable Object"};
+  std::unique_ptr<int> someInt;
+  std::shared_ptr<int> someSharedInt;
+};
+
 BOOST_AUTO_TEST_CASE(AdaptorCompilation)
 {
   auto cfgc = makeEmptyConfigContext();
@@ -182,6 +192,9 @@ BOOST_AUTO_TEST_CASE(AdaptorCompilation)
   BOOST_CHECK_EQUAL(task9.inputs.size(), 4);
 
   auto task10 = adaptAnalysisTask<JTask>(*cfgc, TaskName{"test10"});
+
+  auto task11 = adaptAnalysisTask<KTask>(*cfgc, TaskName{"test11"});
+  BOOST_CHECK_EQUAL(task11.options.size(), 3);
 }
 
 BOOST_AUTO_TEST_CASE(TestPartitionIteration)

--- a/Framework/Core/test/test_TypeTraits.cxx
+++ b/Framework/Core/test/test_TypeTraits.cxx
@@ -36,12 +36,12 @@ BOOST_AUTO_TEST_CASE(TestIsSpecialization)
   std::list<int> c;
   int d;
 
-  bool test1 = is_specialization<decltype(a), std::vector>::value;
-  bool test2 = is_specialization<decltype(b), std::vector>::value;
-  bool test3 = is_specialization<decltype(b), std::list>::value;
-  bool test4 = is_specialization<decltype(c), std::list>::value;
-  bool test5 = is_specialization<decltype(c), std::vector>::value;
-  bool test6 = is_specialization<decltype(d), std::vector>::value;
+  bool test1 = is_specialization_v<decltype(a), std::vector>;
+  bool test2 = is_specialization_v<decltype(b), std::vector>;
+  bool test3 = is_specialization_v<decltype(b), std::list>;
+  bool test4 = is_specialization_v<decltype(c), std::list>;
+  bool test5 = is_specialization_v<decltype(c), std::vector>;
+  bool test6 = is_specialization_v<decltype(d), std::vector>;
   BOOST_REQUIRE_EQUAL(test1, true);
   BOOST_REQUIRE_EQUAL(test2, true);
   BOOST_REQUIRE_EQUAL(test3, false);
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(TestIsSpecialization)
   BOOST_REQUIRE_EQUAL(test6, false);
 
   ROOTSerialized<decltype(d)> e(d);
-  bool test7 = is_specialization<decltype(e), ROOTSerialized>::value;
+  bool test7 = is_specialization_v<decltype(e), ROOTSerialized>;
   BOOST_REQUIRE_EQUAL(test7, true);
 }
 

--- a/Framework/Foundation/include/Framework/StructToTuple.h
+++ b/Framework/Foundation/include/Framework/StructToTuple.h
@@ -276,11 +276,12 @@ constexpr long brace_constructible_size()
     return std::vector<decltype(l(p0))>{DPL_FENUM_##d##0(l, p, )}; \
   }
 
-template <typename L, class T>
-auto constexpr homogeneous_apply_refs(L l, T&& object)
+template <bool B = false, typename L, class T>
+auto homogeneous_apply_refs(L l, T&& object)
 {
   using type = std::decay_t<T>;
-  constexpr unsigned long numElements = brace_constructible_size<T>();
+  constexpr int nesting = B ? 1 : 0;
+  constexpr unsigned long numElements = brace_constructible_size<T>() - nesting;
   // clang-format off
   if DPL_HOMOGENEOUS_APPLY_ENTRY (9, 9)
   else if DPL_HOMOGENEOUS_APPLY_ENTRY (9, 8)

--- a/Framework/Foundation/include/Framework/Traits.h
+++ b/Framework/Foundation/include/Framework/Traits.h
@@ -27,6 +27,9 @@ template <template <typename...> class Ref, typename... Args>
 struct is_specialization<Ref<Args...>, Ref> : std::true_type {
 };
 
+template <typename T, template <typename...> class Ref>
+inline constexpr bool is_specialization_v = is_specialization<T, Ref>::value;
+
 template <typename A, typename B>
 struct is_overriding : public std::bool_constant<std::is_same_v<A, B> == false && std::is_member_function_pointer_v<A> && std::is_member_function_pointer_v<B>> {
 };

--- a/Framework/Foundation/test/test_StructToTuple.cxx
+++ b/Framework/Foundation/test/test_StructToTuple.cxx
@@ -109,6 +109,18 @@ struct FooMax {
   int foo139 = 39;
 };
 
+struct FooNested {
+  int foo;
+};
+
+struct Foo2 {
+  FooNested foo{
+    .foo = 100};
+  FooNested foo2{
+    .foo = 20};
+  int foo3 = 40;
+};
+
 BOOST_AUTO_TEST_CASE(TestStructToTuple)
 {
   FooMax fooMax;
@@ -117,4 +129,14 @@ BOOST_AUTO_TEST_CASE(TestStructToTuple)
   BOOST_CHECK_EQUAL(t5[0], false);
   BOOST_CHECK_EQUAL(t5[19], false);
   BOOST_CHECK_EQUAL(t5[20], true);
+  Foo2 nestedFoo;
+  auto t6 = o2::framework::homogeneous_apply_refs([](auto e) -> bool {
+    if constexpr (std::is_same_v<decltype(e), FooNested>) {
+      o2::framework::homogeneous_apply_refs([](auto n) -> bool { return n > 20; }, e);
+      return true;
+    } else {
+      return e > 20;
+    }
+  },
+                                                  nestedFoo);
 }

--- a/Framework/Utils/include/DPLUtils/RootTreeReader.h
+++ b/Framework/Utils/include/DPLUtils/RootTreeReader.h
@@ -510,7 +510,7 @@ class GenericRootTreeReader
       mPublishingMode = def;
     } else if constexpr (std::is_same<U, SpecialPublishHook*>::value) {
       mPublishHook = def;
-    } else if constexpr (is_specialization<U, BranchDefinition>::value) {
+    } else if constexpr (is_specialization_v<U, BranchDefinition>) {
       cargs.emplace_back(key_type(def.key), def.name);
       using type = BranchConfigurationElement<typename U::type, BASE>;
       return std::move(createBranchConfiguration<0, type>(std::move(cargs), std::forward<Args>(args)...));

--- a/Framework/Utils/include/DPLUtils/RootTreeWriter.h
+++ b/Framework/Utils/include/DPLUtils/RootTreeWriter.h
@@ -502,7 +502,7 @@ class RootTreeWriter
   // vectors of messageable types
   template <typename T>
   struct StructureElementTypeTrait<T, std::enable_if_t<has_messageable_value_type<T>::value &&
-                                                       is_specialization<T, std::vector>::value>> {
+                                                       is_specialization_v<T, std::vector>>> {
     using value_type = T;
     using store_type = value_type*;
     using specialization_id = MessageableVectorSpecialization;
@@ -520,7 +520,8 @@ class RootTreeWriter
 
   // types marked as ROOT serialized
   template <typename T>
-  struct StructureElementTypeTrait<T, std::enable_if_t<is_specialization<T, ROOTSerialized>::value == true>> {
+  struct StructureElementTypeTrait<T,
+                                   std::enable_if_t<is_specialization_v<T, ROOTSerialized> == true>> {
     using value_type = typename T::wrapped_type;
     using store_type = value_type*;
     using specialization_id = ROOTTypeSpecialization;


### PR DESCRIPTION
This will inspect any member of a task recursively, looking for
"Configurables", providing the ability to nest them inside
other structures. This effectively allows making any number of
configurables as long as:
* there is no more than 100 elements in the toplevel struct or in the nested ones.
* the configurables are named uniquely (at least for the moment).