### PR TITLE
[EMCAL-614,EMCAL-685,EMCAL-681] Implement pileup simulation for pre-trigger collisions

### DIFF
--- a/DataFormats/Detectors/EMCAL/src/Digit.cxx
+++ b/DataFormats/Detectors/EMCAL/src/Digit.cxx
@@ -43,10 +43,10 @@ Digit& Digit::operator+=(const Digit& other)
 void Digit::setAmplitudeADC(Short_t amplitude, ChannelType_t ctype)
 {
   if (ctype == ChannelType_t::LOW_GAIN) {
-    if (amplitude > constants::EMCAL_HGLGTRANSITION / constants::EMCAL_HGLGFACTOR) {
+    if (amplitude > (constants::EMCAL_HGLGTRANSITION / constants::EMCAL_HGLGFACTOR)) {
       mAmplitude = amplitude;
       mChannelType = ChannelType_t::LOW_GAIN;
-    } else if (amplitude < -0x8000 / constants::EMCAL_HGLGFACTOR) {
+    } else if (amplitude < (-0x8000 / constants::EMCAL_HGLGFACTOR)) {
       mAmplitude = -0x8000;
       mChannelType = ChannelType_t::HIGH_GAIN;
     } else {
@@ -85,12 +85,12 @@ Int_t Digit::getAmplitudeADC(ChannelType_t ctype) const
 
 void Digit::setAmplitude(Double_t amplitude)
 {
-  if (amplitude < -0x8000 * constants::EMCAL_ADCENERGY) {
+  if (amplitude < (-0x8000 * constants::EMCAL_ADCENERGY)) {
     setAmplitudeADC(-0x8000, ChannelType_t::HIGH_GAIN);
-  } else if (amplitude <= constants::EMCAL_HGLGTRANSITION * constants::EMCAL_ADCENERGY) {
+  } else if (amplitude <= (constants::EMCAL_HGLGTRANSITION * constants::EMCAL_ADCENERGY)) {
     Short_t a = (Short_t)(std::floor(amplitude / constants::EMCAL_ADCENERGY));
     setAmplitudeADC(a, ChannelType_t::HIGH_GAIN);
-  } else if (amplitude <= 0x7fff * constants::EMCAL_ADCENERGY * constants::EMCAL_HGLGFACTOR) {
+  } else if (amplitude <= (0x7fff * constants::EMCAL_ADCENERGY * constants::EMCAL_HGLGFACTOR)) {
     Short_t a = (Short_t)(std::floor(amplitude / (constants::EMCAL_ADCENERGY * constants::EMCAL_HGLGFACTOR)));
     setAmplitudeADC(a, ChannelType_t::LOW_GAIN);
   } else {

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/Digitizer.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/Digitizer.h
@@ -59,8 +59,17 @@ class Digitizer : public TObject
   void setEventTime(double t);
   double getTriggerTime() const { return mTriggerTime; }
   double getEventTime() const { return mEventTime; }
-  bool isLive(double t) const { return (t - mTriggerTime < mLiveTime); }
+  bool isLive(double t) const { return ((t - mTriggerTime) < mLiveTime); }
   bool isLive() const { return (mEventTime < mLiveTime); }
+
+  void setWindowStartTime(int time) { mTimeWindowStart = time; }
+
+  // function returns true if the collision occurs 600ns before the readout window is open
+  // Look here for more details https://alice.its.cern.ch/jira/browse/EMCAL-681
+  bool preTriggerCollision() const { return (mEventTime > (mLiveTime + mBusyTime - mPreTriggerTime)); }
+
+  // function returns true if the collision occurs 900ns after the readout window is open
+  bool afterTriggerCollision() const { return (mEventTime > mAfterTriggerTime && mEventTime < mLiveTime); }
 
   bool isEmpty() const { return mEmpty; }
 
@@ -96,16 +105,20 @@ class Digitizer : public TObject
   const SimParam* mSimParam = nullptr;     ///< SimParam object
   bool mEmpty = true;                      ///< Digitizer contains no digits/labels
 
-  std::vector<Digit> mTempDigitVector;                        ///< temporary digit storage
-  std::unordered_map<Int_t, std::list<LabeledDigit>> mDigits; ///< used to sort digits and labels by tower
+  std::vector<Digit> mTempDigitVector; ///< temporary digit storage
+  //std::unordered_map<Int_t, std::list<LabeledDigit>> mDigits; ///< used to sort digits and labels by tower
+  o2::emcal::DigitsWriteoutBuffer mDigits; ///< used to sort digits and labels by tower
 
   TRandom3* mRandomGenerator = nullptr;                  // random number generator
   std::vector<int> mTimeBinOffset;                       // offset of first time bin
   std::vector<std::vector<double>> mAmplitudeInTimeBins; // amplitude of signal for each time bin
 
-  float mLiveTime = 1500;  // EMCal live time (ns)
-  float mBusyTime = 35000; // EMCal busy time (ns)
-  int mDelay = 7;          // number of (full) time bins corresponding to the signal time delay
+  float mLiveTime = 1500;        // EMCal live time (ns)
+  float mBusyTime = 35000;       // EMCal busy time (ns)
+  float mAfterTriggerTime = 900; // The time (ns) after the readout window is open in which collisions that occurs will be discarded
+  float mPreTriggerTime = 600;   // The time (ns) before the readout window is open in which collisions that occurs before the readout window is open and make hits during the live time
+  int mTimeWindowStart = 4;      // The start of the time window
+  int mDelay = 7;                // number of (full) time bins corresponding to the signal time delay
 
   ClassDefOverride(Digitizer, 1);
 };

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/DigitsWriteoutBuffer.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/DigitsWriteoutBuffer.h
@@ -44,6 +44,7 @@ class DigitsWriteoutBuffer
 
   /// clear the container
   void clear();
+  void reserve();
 
   /// Add digit to the container
   /// \param towerID Cell ID
@@ -53,28 +54,18 @@ class DigitsWriteoutBuffer
 
   /// Getter for the last N entries (time samples) in the ring buffer
   /// \param nsample number of entries to be written
-  /// \return Vector of map of cell IDs and labeled digits in that cell
-  gsl::span<std::unordered_map<int, std::list<LabeledDigit>>> getLastNSamples(int nsample = 15);
-
-  /// Forwards the marker to the next time sample every mTimeBinWidth
-  void forwardMarker(double eventTime);
+  /// \return List of map of cell IDs and labeled digits in that cell
+  std::list<std::unordered_map<int, std::list<LabeledDigit>>> getLastNSamples(int nsample = 15);
 
   void setNumberReadoutSamples(unsigned int nsamples) { mNumberReadoutSamples = nsamples; }
 
-  /// Getter for current position in the ring buffer
-  /// \return current position
-  std::tuple<double, int> getCurrentTimeAndPosition() const { return std::make_tuple(mMarker.mReferenceTime, mMarker.mPositionInBuffer - mTimedDigits.begin()); }
+  std::deque<std::unordered_map<int, std::list<LabeledDigit>>> getTheWholeSample() { return mTimedDigits; }
 
  private:
-  struct Marker {
-    double mReferenceTime;
-    std::deque<std::unordered_map<int, std::list<LabeledDigit>>>::iterator mPositionInBuffer;
-  };
-
   unsigned int mBufferSize = 30;                                             ///< The size of the buffer, it has to be at least 2 times the size of the readout cycle
   unsigned int mTimeBinWidth = 100;                                          ///< The size of the time bin (ns)
   unsigned int mNumberReadoutSamples = 15;                                   ///< The number of smaples in a readout window
-  Marker mMarker;                                                            ///< Marker for the current time sample
+  double mLastEventTime = 1500;                                              ///< The event time of last collisions in the readout window
   std::deque<std::unordered_map<int, std::list<LabeledDigit>>> mTimedDigits; ///< Container for time sampled digits per tower ID
 
   ClassDefNV(DigitsWriteoutBuffer, 1);

--- a/Detectors/EMCAL/simulation/src/Digitizer.cxx
+++ b/Detectors/EMCAL/simulation/src/Digitizer.cxx
@@ -52,20 +52,20 @@ void Digitizer::init()
   mTimeBinOffset.clear();
   mAmplitudeInTimeBins.clear();
 
+  // for each phase create a template distribution
   TF1 RawResponse("RawResponse", rawResponseFunction, 0, 256, 5);
   RawResponse.SetParameters(1., 0., tau, N, 0.);
 
   for (int i = 0; i < 4; i++) {
-    int offset = ((int)(std::floor(tau - delay - 0.25 * i)));
+    int offset = 0;
     mTimeBinOffset.push_back(offset);
 
     std::vector<double> sf;
-    RawResponse.SetParameter(1, 0.25 * i + delay);
+    RawResponse.SetParameter(1, 0.25 * i);
 
     for (int j = 0; j < constants::EMCAL_MAXTIMEBINS; j++) {
-      sf.push_back(RawResponse.Eval(j - offset));
+      sf.push_back(RawResponse.Eval(j - mTimeWindowStart));
     }
-
     mAmplitudeInTimeBins.push_back(sf);
   }
 }
@@ -78,6 +78,8 @@ double Digitizer::rawResponseFunction(double* x, double* par)
   double n = par[3];
   double ped = par[4];
   double xx = (x[0] - par[1] + tau) / tau;
+
+  // par[0] amp, par[1] peak time
 
   if (xx <= 0) {
     signal = ped;
@@ -109,6 +111,8 @@ void Digitizer::clear()
 void Digitizer::process(const std::vector<LabeledDigit>& labeledSDigits)
 {
 
+  mDigits.reserve();
+
   for (auto labeleddigit : labeledSDigits) {
 
     sampleSDigit(labeleddigit.getDigit());
@@ -116,12 +120,18 @@ void Digitizer::process(const std::vector<LabeledDigit>& labeledSDigits)
     for (auto digit : mTempDigitVector) {
       Int_t id = digit.getTower();
 
-      MCLabel label(labeleddigit.getLabels()[0]);
-      if (digit.getAmplitude() == 0) {
-        label.setAmplitudeFraction(0);
+      auto labels = labeleddigit.getLabels();
+      LabeledDigit d(digit, labels[0]);
+      for (auto label : labels) {
+        if (digit.getAmplitude() == 0) {
+          label.setAmplitudeFraction(0);
+        }
+        if (label == labels.front()) {
+          continue;
+        }
+        d.addLabel(label);
       }
-      LabeledDigit d(digit, label);
-      mDigits[id].push_back(d);
+      mDigits.addDigit(id, d, mEventTime);
     }
   }
 
@@ -139,15 +149,15 @@ void Digitizer::sampleSDigit(const Digit& sDigit)
     energy = smearEnergy(energy);
   }
 
-  // Convert the amplitude from energy GeV to ADC
-  energy = energy / constants::EMCAL_ADCENERGY;
+  if (energy < __DBL_EPSILON__) {
+    return;
+  }
 
-  if (mSimulateTimeResponse && (energy != 0)) {
+  if (mSimulateTimeResponse) {
     for (int j = 0; j < mAmplitudeInTimeBins.at(mPhase).size(); j++) {
       double val = energy * (mAmplitudeInTimeBins.at(mPhase).at(j));
 
-      // @TODO check if the time is set correctly
-      Digit digit(tower, val, (mEventTimeOffset + j - mTimeBinOffset.at(mPhase) + mDelay) * constants::EMCAL_TIMESAMPLE);
+      Digit digit(tower, val, (mEventTimeOffset + j - mTimeBinOffset.at(mPhase) + mDelay - mTimeWindowStart) * constants::EMCAL_TIMESAMPLE);
       mTempDigitVector.push_back(digit);
     }
   } else {
@@ -175,13 +185,14 @@ void Digitizer::setEventTime(double t)
     LOG(fatal) << "New event time (" << t << ") is < previous event time (" << mEventTime << ")";
   }
 
-  if (t - mTriggerTime >= mLiveTime + mBusyTime) {
+  if ((t - mTriggerTime) >= (mLiveTime + mBusyTime)) {
     mTriggerTime = t;
   }
 
   mEventTime = t - mTriggerTime;
 
-  mPhase = ((int)((std::fmod(mEventTime, 100) + 12.5) / 25));
+  mPhase = ((int)(std::fmod(mEventTime, 100) / 25));
+
   mEventTimeOffset = ((int)((mEventTime - std::fmod(mEventTime, 100) + 0.1) / 100));
   if (mPhase == 4) {
     mPhase = 0;
@@ -209,26 +220,59 @@ void Digitizer::fillOutputContainer(std::vector<Digit>& digits, o2::dataformats:
 {
   std::list<LabeledDigit> l;
 
-  for (auto [tower, digitsList] : mDigits) {
-    digitsList.sort();
+  auto listMaps = mDigits.getLastNSamples();
 
-    for (auto ld : digitsList) {
+  for (auto digsMap = listMaps.begin(); digsMap != listMaps.end(); ++digsMap) {
 
-      if (mSimulateNoiseDigits) {
-        addNoiseDigits(ld);
-      }
+    for (auto& [tower, digitsList] : *digsMap) {
 
-      if (mRemoveDigitsBelowThreshold && (ld.getAmplitude() < mSimParam->getDigitThreshold() * (constants::EMCAL_ADCENERGY))) {
+      if (digitsList.size() == 0) {
         continue;
       }
-      if (ld.getAmplitude() < 0) {
-        continue;
-      }
-      if (ld.getTimeStamp() >= mSimParam->getLiveTime()) {
-        continue;
-      }
+      digitsList.sort();
 
-      l.push_back(ld);
+      for (auto& ld : digitsList) {
+
+        // Loop over all digits in the time sample and sum the digits that falls in one time bin
+        for (auto compDigMap = digsMap; compDigMap != listMaps.end(); ++compDigMap) {
+
+          if (digsMap == compDigMap) {
+            continue;
+          }
+          std::vector<decltype(digitsList.begin())> toDelete;
+
+          auto towerEntry = compDigMap->find(tower);
+          if (towerEntry == compDigMap->end()) {
+            continue;
+          }
+
+          for (auto ld1 = towerEntry->second.begin(); ld1 != towerEntry->second.end(); ++ld1) { // must be iterator in order to know the position in the container for erasing
+            if (ld.canAdd(*ld1)) {
+              ld += *ld1;
+              toDelete.push_back(ld1);
+            }
+          }
+          for (auto del : toDelete) {
+            towerEntry->second.erase(del);
+          }
+        }
+
+        if (mSimulateNoiseDigits) {
+          addNoiseDigits(ld);
+        }
+
+        if (mRemoveDigitsBelowThreshold && (ld.getAmplitude() < (mSimParam->getDigitThreshold() * constants::EMCAL_ADCENERGY))) {
+          continue;
+        }
+        if (ld.getAmplitude() < 0) {
+          continue;
+        }
+        if ((ld.getTimeStamp() >= (mSimParam->getLiveTime() + (mDelay - mTimeWindowStart) * constants::EMCAL_TIMESAMPLE)) || (ld.getTimeStamp() < ((mDelay - mTimeWindowStart) * constants::EMCAL_TIMESAMPLE))) {
+          continue;
+        }
+
+        l.push_back(ld);
+      }
     }
   }
   l.sort();

--- a/Detectors/EMCAL/simulation/src/DigitsWriteoutBuffer.cxx
+++ b/Detectors/EMCAL/simulation/src/DigitsWriteoutBuffer.cxx
@@ -13,6 +13,7 @@
 #include <vector>
 #include <list>
 #include <deque>
+#include <iostream>
 #include <gsl/span>
 #include "EMCALSimulation/LabeledDigit.h"
 #include "EMCALSimulation/DigitsWriteoutBuffer.h"
@@ -22,42 +23,59 @@ using namespace o2::emcal;
 DigitsWriteoutBuffer::DigitsWriteoutBuffer(unsigned int nTimeBins, unsigned int binWidth) : mBufferSize(nTimeBins),
                                                                                             mTimeBinWidth(binWidth)
 {
-  mTimedDigits.resize(nTimeBins);
-  mMarker.mReferenceTime = 0.;
-  mMarker.mPositionInBuffer = mTimedDigits.begin();
+  for (int itime = 0; itime < nTimeBins; itime++) {
+    mTimedDigits.push_back(std::unordered_map<int, std::list<LabeledDigit>>());
+  }
 }
 
 void DigitsWriteoutBuffer::clear()
 {
+  std::cout << "Clearing ..." << std::endl;
   mTimedDigits.clear();
-  mMarker.mReferenceTime = 0.;
-  mMarker.mPositionInBuffer = mTimedDigits.begin();
+}
+
+void DigitsWriteoutBuffer::reserve()
+{
+  //Fill in the missing entries
+  for (int itime = 0; itime < (mBufferSize - mTimedDigits.size()); itime++) {
+    mTimedDigits.push_back(std::unordered_map<int, std::list<LabeledDigit>>());
+  }
 }
 
 void DigitsWriteoutBuffer::addDigit(unsigned int towerID, LabeledDigit dig, double eventTime)
 {
+  int nsamples = int(eventTime / mTimeBinWidth);
 
-  int nsamples = int((eventTime - mMarker.mReferenceTime) / mTimeBinWidth);
-  auto timeEntry = mMarker.mPositionInBuffer;
-  timeEntry[nsamples][towerID].push_back(dig);
-}
-
-void DigitsWriteoutBuffer::forwardMarker(double eventTime)
-{
-  mMarker.mReferenceTime = eventTime;
-  mMarker.mPositionInBuffer++;
-
-  // Allocate new memory at the end
-  mTimedDigits.push_back(std::unordered_map<int, std::list<LabeledDigit>>());
-
-  // Drop entry at the front, because it is outside the current readout window
-  // only done if we have at least 15 entries
-  if (mMarker.mPositionInBuffer - mTimedDigits.begin() > mNumberReadoutSamples) {
+  if (nsamples >= mTimedDigits.size()) {
     mTimedDigits.pop_front();
+    mTimedDigits.push_back(std::unordered_map<int, std::list<LabeledDigit>>());
+    nsamples = mTimedDigits.size() - 1;
   }
+
+  auto& timeEntry = mTimedDigits[nsamples];
+
+  auto towerEntry = timeEntry.find(towerID);
+  if (towerEntry == timeEntry.end()) {
+    towerEntry = timeEntry.insert(std::pair<int, std::list<o2::emcal::LabeledDigit>>(towerID, std::list<o2::emcal::LabeledDigit>())).first;
+  }
+
+  towerEntry->second.push_back(dig);
+
+  mLastEventTime = eventTime;
 }
 
-gsl::span<std::unordered_map<int, std::list<LabeledDigit>>> DigitsWriteoutBuffer::getLastNSamples(int nsamples)
+std::list<std::unordered_map<int, std::list<LabeledDigit>>> DigitsWriteoutBuffer::getLastNSamples(int nsamples)
 {
-  return gsl::span<std::unordered_map<int, std::list<LabeledDigit>>>(&mTimedDigits[int(mMarker.mPositionInBuffer - mTimedDigits.begin() - nsamples)], nsamples);
+  int startingPosition = int(mLastEventTime / mTimeBinWidth) - nsamples;
+  if (startingPosition < 0) {
+    startingPosition = 0;
+  }
+
+  std::list<std::unordered_map<int, std::list<LabeledDigit>>> output;
+
+  for (int ientry = startingPosition; ientry < startingPosition + nsamples; ientry++) {
+    output.push_back(mTimedDigits[ientry]);
+  }
+  return output;
+  //return gsl::span<std::unordered_map<int, std::list<LabeledDigit>>>(&mTimedDigits[startingPosition], nsamples);
 }

--- a/Detectors/EMCAL/simulation/src/SDigitizer.cxx
+++ b/Detectors/EMCAL/simulation/src/SDigitizer.cxx
@@ -70,8 +70,8 @@ std::vector<o2::emcal::LabeledDigit> SDigitizer::process(const std::vector<Hit>&
       if (digit.getAmplitude() == 0) {
         label.setAmplitudeFraction(0);
       }
-
       LabeledDigit d(digit, label);
+
       digitsPerTower[tower].push_back(d);
 
     } catch (InvalidPositionException& e) {
@@ -86,11 +86,8 @@ std::vector<o2::emcal::LabeledDigit> SDigitizer::process(const std::vector<Hit>&
 
     o2::emcal::LabeledDigit Sdigit = std::accumulate(std::next(labeledDigits.begin()), labeledDigits.end(), labeledDigits.front());
 
-    // Check whether the Sdigit is high gain or low gain
-    if (Sdigit.getAmplitude() > constants::EMCAL_HGLGTRANSITION * constants::EMCAL_ADCENERGY) {
-      Sdigit.setLowGain();
-    } else {
-      Sdigit.setHighGain();
+    if (Sdigit.getAmplitude() < __DBL_EPSILON__) {
+      continue;
     }
 
     digitsVector.push_back(Sdigit);


### PR DESCRIPTION
The pileup simulation for pre-trigger and after trigger collisions has been implemented in the digitizer workflow.

Other modifications:
1. Ring buffer has been fixed and tested.
2. Sampled digits time has been corrected implemented with the raw response function
3. Adding brackets for the Digit class to make the if statements more understandable.