### PR TITLE
Inroduce different default ROF lengths for ITS and MFT

### DIFF
--- a/Detectors/ITSMFT/common/base/include/ITSMFTBase/DPLAlpideParam.h
+++ b/Detectors/ITSMFT/common/base/include/ITSMFTBase/DPLAlpideParam.h
@@ -22,21 +22,17 @@ namespace o2
 {
 namespace itsmft
 {
-/// allowed values: 1,2,3,4,6,9,11,12,18
-constexpr int DEFROFLengthBC = o2::constants::lhc::LHCMaxBunches / 4;       // default ROF length in BC for continuos mode
 constexpr float DEFStrobeDelay = o2::constants::lhc::LHCBunchSpacingNS * 4; // ~100 ns delay
 
 template <int N>
 struct DPLAlpideParam : public o2::conf::ConfigurableParamHelper<DPLAlpideParam<N>> {
-  static_assert(N == o2::detectors::DetID::ITS || N == o2::detectors::DetID::MFT, "only DetID::ITS orDetID:: MFT are allowed");
-  static_assert(o2::constants::lhc::LHCMaxBunches % DEFROFLengthBC == 0); // make sure ROF length is divisor of the orbit
 
   static constexpr std::string_view getParamName()
   {
     return N == o2::detectors::DetID::ITS ? ParamName[0] : ParamName[1];
   }
-  int roFrameLengthInBC = DEFROFLengthBC;             ///< ROF length in BC for continuos mode
-  float roFrameLengthTrig = 6000.;                    ///< length of RO frame in ns for triggered mode
+  int roFrameLengthInBC = DEFROFLengthBC();           ///< ROF length in BC for continuos mode
+  float roFrameLengthTrig = DEFROFLengthTrig();       ///< length of RO frame in ns for triggered mode
   float strobeDelay = DEFStrobeDelay;                 ///< strobe start (in ns) wrt ROF start
   float strobeLengthCont = -1.;                       ///< if < 0, full ROF length - delay
   float strobeLengthTrig = 100.;                      ///< length of the strobe in ns (sig. over threshold checked in this window only)
@@ -46,6 +42,20 @@ struct DPLAlpideParam : public o2::conf::ConfigurableParamHelper<DPLAlpideParam<
 
  private:
   static constexpr std::string_view ParamName[2] = {"ITSAlpideParam", "MFTAlpideParam"};
+
+  static constexpr int DEFROFLengthBC()
+  {
+    // default ROF length in BC for continuos mode
+    // allowed values: 1,2,3,4,6,9,11,12,18,22,27,33,36
+    return N == o2::detectors::DetID::ITS ? o2::constants::lhc::LHCMaxBunches / 4 : o2::constants::lhc::LHCMaxBunches / 18;
+  }
+  static constexpr float DEFROFLengthTrig()
+  {
+    // length of RO frame in ns for triggered mode
+    return N == o2::detectors::DetID::ITS ? 6000. : 6000.;
+  }
+  static_assert(N == o2::detectors::DetID::ITS || N == o2::detectors::DetID::MFT, "only DetID::ITS orDetID:: MFT are allowed");
+  static_assert(o2::constants::lhc::LHCMaxBunches % DEFROFLengthBC() == 0); // make sure ROF length is divisor of the orbit
 };
 
 template <int N>


### PR DESCRIPTION
Set defaults to values used in the pilot beam: 1/4 and 1/18 of orbit for ITS and MFT respectively.