### PR TITLE
MCH: temporarily disable time clustering in MC reco

### DIFF
--- a/Detectors/MUON/MCH/Workflow/src/reco-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/reco-workflow.cxx
@@ -71,20 +71,23 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
                                                     "DIGITROFS", "F-DIGITROFS",
                                                     "DIGITLABELS", "F-DIGITLABELS"));
 
-  specs.emplace_back(o2::mch::getTimeClusterFinderSpec("mch-time-cluster-finder",
-                                                       "F-DIGITS",
-                                                       "F-DIGITROFS",
-                                                       "TC-F-DIGITROFS"));
+  if (!useMC) {
+    specs.emplace_back(o2::mch::getTimeClusterFinderSpec("mch-time-cluster-finder",
+                                                         "F-DIGITS",
+                                                         "F-DIGITROFS",
+                                                         "TC-F-DIGITROFS"));
+  }
 
   specs.emplace_back(o2::mch::getPreClusterFinderSpec("mch-precluster-finder",
                                                       "F-DIGITS",
-                                                      "TC-F-DIGITROFS"));
+                                                      useMC ? "F-DIGITROFS" : "TC-F-DIGITROFS"));
+
   specs.emplace_back(o2::mch::getClusterFinderOriginalSpec("mch-cluster-finder"));
   specs.emplace_back(o2::mch::getClusterTransformerSpec());
   specs.emplace_back(o2::mch::getTrackFinderSpec("mch-track-finder", digits));
   if (useMC) {
     specs.emplace_back(o2::mch::getTrackMCLabelFinderSpec("mch-track-mc-label-finder",
-                                                          "TC-F-DIGITROFS",
+                                                          "F-DIGITROFS",
                                                           "F-DIGITLABELS"));
   }
 


### PR DESCRIPTION
This temporary fix is to allow to reconstruct simulations generating
timeframes with more than 256 orbits, as the TimeClustering is bound to
this number (and real timeframes to 128 orbits, currently).

Actually the real solution would be to get the simulation to acknowledge
the fact that TFs cannot contain any number of orbits and correctly
 send data to the reco in batch of 256 (ot 128) orbits, like in real
 life.

But as it's not the case right now, this commit removes from the reco
the one device that currently has a hard limitation on the number of
orbits it can digest in a single time frame. This is currently possible
as the MCH simulation is still unrealistic (time wise) in the sense that
there's no time resolution at all, so even without time clustering the
digits are correctly associated to the relevant ROF. But as soon as the
MCH simulation will get better, we'll have to reconnect the time
clustering one way or another.

@pillot @rpezzi 
