### PR TITLE
TRD update filename convention for mc to raw

### DIFF
--- a/Detectors/TRD/simulation/README.md
+++ b/Detectors/TRD/simulation/README.md
@@ -36,7 +36,7 @@ There are multiple options :
                                         input Trapsim digits file, empty string to have no digits.
 - -t [ --input-file-tracklets ] default of trdtracklets.root
                                         input Trapsim tracklets file
--   -l [ --fileper ] how to distrbute the data into raw files.
+-   -l [ --file-per ] how to distrbute the data into raw files.
     - all : 1 raw file
     - halfcru : 1 file per cru end point, so 2 files per cru.
     - cru : one file per cru

--- a/Detectors/TRD/simulation/src/Trap2CRU.cxx
+++ b/Detectors/TRD/simulation/src/Trap2CRU.cxx
@@ -50,6 +50,54 @@ namespace o2
 namespace trd
 {
 
+struct TRDCRUMapping {
+  uint32_t flpid;       // hostname of flp
+  uint32_t cruHWID = 0; // cru ID taken from ecs
+  uint32_t HCID = 0;    // hcid of first link
+};
+
+//this should probably come from ccdb or some authoritive source.
+//I doubt this is going to change very often, but ... famous last words.
+//
+const TRDCRUMapping trdHWMap[o2::trd::constants::NHALFCRU / 2] =
+  {
+    {166, 250, 0},
+    {166, 583, 0},
+    {166, 585, 0},
+    {167, 248, 0},
+    {167, 249, 0},
+    {167, 596, 0},
+    {168, 246, 0},
+    {168, 247, 0},
+    {168, 594, 0},
+    {169, 252, 0},
+    {169, 253, 0},
+    {169, 254, 0},
+    {170, 245, 0},
+    {170, 593, 0},
+    {170, 595, 0},
+    {171, 258, 0},
+    {171, 259, 0},
+    {171, 260, 0},
+    {172, 579, 0},
+    {172, 581, 0},
+    {172, 586, 0},
+    {173, 578, 0},
+    {173, 580, 0},
+    {173, 597, 0},
+    {174, 256, 0},
+    {174, 582, 0},
+    {174, 587, 0},
+    {175, 251, 0},
+    {175, 255, 0},
+    {175, 588, 0},
+    {176, 264, 0},
+    {176, 591, 0},
+    {176, 592, 0},
+    {177, 263, 0},
+    {177, 589, 0},
+    {177, 590, 0}};
+
 Trap2CRU::Trap2CRU(const std::string& outputDir, const std::string& inputdigitsfilename, const std::string& inputtrackletsfilename)
 {
   mOutputDir = outputDir;
@@ -221,11 +269,12 @@ void Trap2CRU::readTrapData()
     mLinkID = o2::trd::constants::TRDLINKID;
 
     std::string outFileLink;
-    std::string outPrefix = "trd";
+    std::string outPrefix = "TRD_";
+    outPrefix += "alio2-cr1-flp";
     std::string outSuffix = ".raw";
-    std::string trdside = mEndPointID ? "_h" : "_l"; // the side of cru lower or higher
     // filename structure of trd_cru_[CRU#]_[upper/lower].raw
-    std::string whichrun = mUseTrackletHCHeader ? "run3" : "run2";
+    auto flpid = trdHWMap[mCruID].flpid;
+    auto cruhwid = trdHWMap[mCruID].cruHWID;
     if (mFilePer == "all") { // single file for all links
       outFileLink = o2::utils::Str::concat_string(mOutputDir, "/", outPrefix, outSuffix);
     } else if (mFilePer == "sm") {
@@ -235,9 +284,9 @@ void Trap2CRU::readTrapData()
       std::string supermodule = ss.str();
       outFileLink = o2::utils::Str::concat_string(mOutputDir, "/", outPrefix, "_sm_", supermodule, outSuffix);
     } else if (mFilePer == "cru") {
-      outFileLink = o2::utils::Str::concat_string(mOutputDir, "/", outPrefix, "_cru_", std::to_string(mCruID), outSuffix);
+      outFileLink = o2::utils::Str::concat_string(mOutputDir, "/", outPrefix, std::to_string(flpid), "_cru", std::to_string(cruhwid), "_", std::to_string(mEndPointID), outSuffix);
     } else if (mFilePer == "halfcru") {
-      outFileLink = o2::utils::Str::concat_string(mOutputDir, "/", outPrefix, "_cru_", std::to_string(mCruID), trdside, outSuffix);
+      outFileLink = o2::utils::Str::concat_string(mOutputDir, "/", outPrefix, std::to_string(flpid), "_cru", std::to_string(cruhwid), "_", std::to_string(mEndPointID), outSuffix);
     } else {
       throw std::runtime_error("invalid option provided for file grouping");
     }

--- a/Detectors/TRD/simulation/src/trap2raw.cxx
+++ b/Detectors/TRD/simulation/src/trap2raw.cxx
@@ -69,7 +69,7 @@ int main(int argc, char** argv)
     //    add_option("input-file,i", bpo::value<std::string>()->default_value("trdtrapraw.root"), "input Trapsim raw file");
     add_option("input-file-digits,d", bpo::value<std::string>()->default_value("trddigits.root"), "input Trapsim digits file");
     add_option("input-file-tracklets,t", bpo::value<std::string>()->default_value("trdtracklets.root"), "input Trapsim tracklets file");
-    add_option("fileper,l", bpo::value<std::string>()->default_value("halfcru"), "all : raw file(false), halfcru : cru end point, cru : one file per cru, sm: one file per supermodule");
+    add_option("file-per,l", bpo::value<std::string>()->default_value("halfcru"), "all : raw file(false), halfcru : cru end point, cru : one file per cru, sm: one file per supermodule");
     add_option("output-dir,o", bpo::value<std::string>()->default_value("./"), "output directory for raw data");
     add_option("tracklethcheader,x", bpo::value<int>()->default_value(0), "include tracklet half chamber header (for run3). 0 never, 1 if there is tracklet data, 2 always");
     add_option("no-empty-hbf,e", bpo::value<bool>()->default_value(false)->implicit_value(true), "do not create empty HBF pages (except for HBF starting TF)");
@@ -104,7 +104,7 @@ int main(int argc, char** argv)
   o2::conf::ConfigurableParam::updateFromString(vm["configKeyValues"].as<std::string>());
 
   std::cout << "yay it ran" << std::endl;
-  trap2raw(vm["input-file-digits"].as<std::string>(), vm["input-file-tracklets"].as<std::string>(), vm["output-dir"].as<std::string>(), vm["digitrate"].as<int>(), vm["verbosity"].as<int>(), vm["fileper"].as<std::string>(), vm["rdh-version"].as<uint32_t>(), vm["no-empty-hbf"].as<bool>(), vm["tracklethcheader"].as<int>());
+  trap2raw(vm["input-file-digits"].as<std::string>(), vm["input-file-tracklets"].as<std::string>(), vm["output-dir"].as<std::string>(), vm["digitrate"].as<int>(), vm["verbosity"].as<int>(), vm["file-per"].as<std::string>(), vm["rdh-version"].as<uint32_t>(), vm["no-empty-hbf"].as<bool>(), vm["tracklethcheader"].as<int>());
 
   return 0;
 }

--- a/prodtests/full_system_test.sh
+++ b/prodtests/full_system_test.sh
@@ -129,7 +129,7 @@ taskwrapper phsraw.log o2-phos-digi2raw --file-for link -o raw/PHS
 taskwrapper cpvraw.log o2-cpv-digi2raw --file-for cru -o raw/CPV
 taskwrapper zdcraw.log o2-zdc-digi2raw --file-for cru -o raw/ZDC
 taskwrapper hmpraw.log o2-hmpid-digits-to-raw-workflow --file-for cru --outdir raw/HMP
-taskwrapper trdraw.log o2-trd-trap2raw -o raw/TRD --fileper halfcru
+taskwrapper trdraw.log o2-trd-trap2raw -o raw/TRD --file-per cru
 taskwrapper ctpraw.log o2-ctp-digi2raw -o raw/CTP --file-for cru
 
 cat raw/*/*.cfg > rawAll.cfg


### PR DESCRIPTION
- Make the name convention consistant with all the other subdetectors.
- option --fileper changes to --file-per (fixed in full_system_test.sh)
- 2 options are now identical --file-per cru and --file-per halfcru now produce the same thing. The halfcru option is left in so as not to break something.