### PR TITLE
[EMCAL-750] Add file per C-RORC, fix filenames

### DIFF
--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/RawWriter.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/RawWriter.h
@@ -77,6 +77,7 @@ class RawWriter
   enum class FileFor_t {
     kFullDet, ///< Full detector (EMCAL + DCAL)
     kSubDet,  ///< Subdetector (EMCAL/DCAL separate)
+    kCRORC,   ///< C-RORC card
     kLink     ///< Per link
   };
 

--- a/Detectors/EMCAL/simulation/src/RawCreator.cxx
+++ b/Detectors/EMCAL/simulation/src/RawCreator.cxx
@@ -105,8 +105,12 @@ int main(int argc, const char** argv)
     granularity = o2::emcal::RawWriter::FileFor_t::kFullDet;
   } else if (filefor == "subdet") {
     granularity = o2::emcal::RawWriter::FileFor_t::kSubDet;
+  } else if (filefor == "crorc") {
+    granularity = o2::emcal::RawWriter::FileFor_t::kCRORC;
   } else if (filefor == "link") {
     granularity = o2::emcal::RawWriter::FileFor_t::kLink;
+  } else {
+    LOG(fatal) << "Unknown granularity, supported: all, subdet, crorc, link";
   }
 
   o2::emcal::RawWriter rawwriter;

--- a/Detectors/EMCAL/simulation/src/RawWriter.cxx
+++ b/Detectors/EMCAL/simulation/src/RawWriter.cxx
@@ -50,23 +50,22 @@ void RawWriter::init()
     }
 
     auto [crorc, link] = mGeometry->getLinkAssignment(iddl);
+    auto flpID = (iddl <= 23) ? 146 : 147;
     std::string rawfilename = mOutputLocation;
     switch (mFileFor) {
       case FileFor_t::kFullDet:
         rawfilename += "/emcal.raw";
         break;
-      case FileFor_t::kSubDet: {
-        std::string detstring;
-        if (iddl < 22) {
-          detstring = "emcal";
-        } else {
-          detstring = "dcal";
-        }
-        rawfilename += fmt::format("/{:s}.raw", detstring.data());
+      case FileFor_t::kSubDet:
+        rawfilename += fmt::format("/EMC_alio2-cr1-flp{:d}.raw", flpID);
         break;
-      };
+      case FileFor_t::kCRORC:
+        rawfilename += fmt::format("/EMC_alio2-cr1-flp{:d}_cru{:d}.raw", flpID, crorc);
+        break;
       case FileFor_t::kLink:
-        rawfilename += fmt::format("/emcal_{:d}_{:d}.raw", crorc, link);
+        // Pileup simulation based on DigitsWriteoutBuffer (EMCAL-681) - AliceO2 – H. Hassan
+        rawfilename += fmt::format("/EMC_alio2-cr1-flp{:d}_cru{:d}_lnk{:d}.raw", flpID, crorc, link);
+        break;
     }
     mRawWriter->registerLink(iddl, crorc, link, 0, rawfilename.data());
   }


### PR DESCRIPTION
- Add option to encode each C-RORC card to a separate file
- Encode source ID in the filename based on the granularity
  selected.