### PR TITLE
Add option to consider single half barrel for PV seeding

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
@@ -107,6 +107,7 @@ struct VertexingParameters {
   int clusterContributorsCut = 16;
   int phiSpan = -1;
   int zSpan = -1;
+  int ignoreHalfBarrel = 2;
 };
 
 struct VertexerHistogramsConfiguration {

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/IOUtils.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/IOUtils.h
@@ -64,10 +64,10 @@ enum class HalfBarrel { Top,
 
 void loadEventData(ROframe& events, gsl::span<const itsmft::CompClusterExt> clusters,
                    gsl::span<const unsigned char>::iterator& pattIt, const itsmft::TopologyDictionary& dict,
-                   const dataformats::MCTruthContainer<MCCompLabel>* clsLabels = nullptr, HalfBarrel ignBarrel = HalfBarrel::None);
+                   const dataformats::MCTruthContainer<MCCompLabel>* clsLabels = nullptr, int ignBarrel = 2);
 int loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& events, gsl::span<const itsmft::CompClusterExt> clusters,
                     gsl::span<const unsigned char>::iterator& pattIt, const itsmft::TopologyDictionary& dict,
-                    const dataformats::MCTruthContainer<MCCompLabel>* mClsLabels = nullptr, HalfBarrel ignBarrel = HalfBarrel::None);
+                    const dataformats::MCTruthContainer<MCCompLabel>* mClsLabels = nullptr, int ignBarrel = 2);
 
 void convertCompactClusters(gsl::span<const itsmft::CompClusterExt> clusters,
                             gsl::span<const unsigned char>::iterator& pattIt,

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/IOUtils.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/IOUtils.h
@@ -46,7 +46,7 @@ namespace itsmft
 {
 class CompClusterExt;
 class TopologyDictionary;
-}
+} // namespace itsmft
 
 namespace its
 {
@@ -58,12 +58,16 @@ constexpr float DefClusErrorCol = o2::itsmft::SegmentationAlpide::PitchCol * 0.5
 constexpr float DefClusError2Row = DefClusErrorRow * DefClusErrorRow;
 constexpr float DefClusError2Col = DefClusErrorCol * DefClusErrorCol;
 
+enum class HalfBarrel { Top,
+                        Bottom,
+                        None };
+
 void loadEventData(ROframe& events, gsl::span<const itsmft::CompClusterExt> clusters,
                    gsl::span<const unsigned char>::iterator& pattIt, const itsmft::TopologyDictionary& dict,
-                   const dataformats::MCTruthContainer<MCCompLabel>* clsLabels = nullptr);
+                   const dataformats::MCTruthContainer<MCCompLabel>* clsLabels = nullptr, HalfBarrel ignBarrel = HalfBarrel::None);
 int loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& events, gsl::span<const itsmft::CompClusterExt> clusters,
                     gsl::span<const unsigned char>::iterator& pattIt, const itsmft::TopologyDictionary& dict,
-                    const dataformats::MCTruthContainer<MCCompLabel>* mClsLabels = nullptr);
+                    const dataformats::MCTruthContainer<MCCompLabel>* mClsLabels = nullptr, HalfBarrel ignBarrel = HalfBarrel::None);
 
 void convertCompactClusters(gsl::span<const itsmft::CompClusterExt> clusters,
                             gsl::span<const unsigned char>::iterator& pattIt,

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
@@ -32,6 +32,7 @@ struct VertexerParamConfig : public o2::conf::ConfigurableParamHelper<VertexerPa
   int clusterContributorsCut = 16;
   int phiSpan = -1;
   int zSpan = -1;
+  int ignoreHalfBarrel = 2;
 
   O2ParamDef(VertexerParamConfig, "ITSVertexerParam");
 };

--- a/Detectors/ITSMFT/ITS/tracking/src/IOUtils.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/IOUtils.cxx
@@ -95,7 +95,7 @@ void ioutils::convertCompactClusters(gsl::span<const itsmft::CompClusterExt> clu
 
 void ioutils::loadEventData(ROframe& event, gsl::span<const itsmft::CompClusterExt> clusters,
                             gsl::span<const unsigned char>::iterator& pattIt, const itsmft::TopologyDictionary& dict,
-                            const dataformats::MCTruthContainer<MCCompLabel>* clsLabels, HalfBarrel ignBarrel)
+                            const dataformats::MCTruthContainer<MCCompLabel>* clsLabels, int ignBarrel)
 {
   if (clusters.empty()) {
     std::cerr << "Missing clusters." << std::endl;
@@ -107,8 +107,8 @@ void ioutils::loadEventData(ROframe& event, gsl::span<const itsmft::CompClusterE
   int clusterId{0};
 
   for (auto& c : clusters) {
-    if (geom->getHalfBarrel(c.getSensorID()) == (int)ignBarrel) { // Top barrel Id: 0, Bot: 1, never ignored otherwise
-      LOG(info) << "Ignoring cluster with half barrel id: " << geom->getHalfBarrel(c.getSensorID());
+    if (geom->getHalfBarrel(c.getSensorID()) == ignBarrel) { // Top barrel Id: 0, Bot: 1, never ignored otherwise
+      LOG(debug) << "Ignoring cluster with half barrel id: " << geom->getHalfBarrel(c.getSensorID());
       continue;
     }
 
@@ -151,7 +151,7 @@ void ioutils::loadEventData(ROframe& event, gsl::span<const itsmft::CompClusterE
 }
 
 int ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& event, gsl::span<const itsmft::CompClusterExt> clusters, gsl::span<const unsigned char>::iterator& pattIt, const itsmft::TopologyDictionary& dict,
-                             const dataformats::MCTruthContainer<MCCompLabel>* mcLabels, HalfBarrel ignBarrel)
+                             const dataformats::MCTruthContainer<MCCompLabel>* mcLabels, int ignBarrel)
 {
   event.clear();
   GeometryTGeo* geom = GeometryTGeo::Instance();
@@ -161,8 +161,8 @@ int ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& event, g
   auto first = rof.getFirstEntry();
   auto clusters_in_frame = rof.getROFData(clusters);
   for (auto& c : clusters_in_frame) {
-    if (geom->getHalfBarrel(c.getSensorID()) == (int)ignBarrel) { // Top barrel Id: 0, Bot: 1, never ignored otherwise
-      LOG(info) << "Ignoring cluster with half barrel id: " << geom->getHalfBarrel(c.getSensorID());
+    if (geom->getHalfBarrel(c.getSensorID()) == ignBarrel) { // Top barrel Id: 0, Bot: 1, never ignored otherwise
+      LOG(debug) << "Ignoring cluster with half barrel id: " << geom->getHalfBarrel(c.getSensorID());
       continue;
     }
 

--- a/Detectors/ITSMFT/ITS/tracking/src/Vertexer.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Vertexer.cxx
@@ -76,6 +76,7 @@ void Vertexer::getGlobalConfiguration()
   verPar.tanLambdaCut = vc.tanLambdaCut;
   verPar.clusterContributorsCut = vc.clusterContributorsCut;
   verPar.phiSpan = vc.phiSpan;
+  verPar.ignoreHalfBarrel = vc.ignoreHalfBarrel;
 
   mTraits->updateVertexingParameters(verPar);
 }

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -230,7 +230,7 @@ void TrackerDPL::run(ProcessingContext& pc)
   std::vector<bool> processingMask;
   int cutClusterMult{0}, cutVertexMult{0}, cutTotalMult{0};
   for (auto& rof : rofspan) {
-    nclUsed += ioutils::loadROFrameData(rof, event, compClusters, pattIt, mDict, labels);
+    nclUsed += ioutils::loadROFrameData(rof, event, compClusters, pattIt, mDict, labels, mVertexer->getVertParameters().ignoreHalfBarrel);
     // prepare in advance output ROFRecords, even if this ROF to be rejected
     int first = allTracks.size();
 


### PR DESCRIPTION
@iouribelikov: this should do what we discussed yesterday at WP2. I tested it on some monte carlo data, seems to be working.
I cannot carry on studies on the pilot beam data at the moment, hope it can help you anyways.

To enable the switch:

```bash
o2-its-reco-workflow --trackerCA --configKeyValues="ITSVertexerParam.ignoreHalfBarrel=0"
```
One can ignore the halfbarrel IDs 0 and 1 provided by https://github.com/AliceO2Group/AliceO2/blob/5c0bb3432b94c54877509b6ac6ce7f143647aa50/Detectors/ITSMFT/ITS/base/src/GeometryTGeo.cxx#L145
Default value is 2 that does the usual thing.
If `LOG(debug)` is too strong I can also remove the message entirely.

PS. this change affects the PV finder only. Tracker uses another data loader. Soon the two approaches are going to be unfied.