### PR TITLE
Ccdb fetcher

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -168,6 +168,7 @@ foreach(t
         BoostOptionsRetriever
         ConfigurationOptionsRetriever
         CallbackRegistry
+        CCDBHelpers
         ChannelSpecHelpers
         CheckTypes
         CompletionPolicy

--- a/Framework/Core/include/Framework/CCDBParamSpec.h
+++ b/Framework/Core/include/Framework/CCDBParamSpec.h
@@ -17,9 +17,15 @@
 namespace o2::framework
 {
 
+struct CCDBMetadata {
+  std::string key;
+  std::string value;
+};
+
 ConfigParamSpec ccdbPathSpec(std::string const& path);
 ConfigParamSpec ccdbRunDependent(bool defaultValue = true);
-std::vector<ConfigParamSpec> ccdbParamSpec(std::string const& path, bool runDependent = false);
+std::vector<ConfigParamSpec> ccdbParamSpec(std::string const& path, bool runDependent, std::vector<CCDBMetadata> metadata = {});
+std::vector<ConfigParamSpec> ccdbParamSpec(std::string const& path, std::vector<CCDBMetadata> metadata = {});
 ConfigParamSpec startTimeParamSpec(int64_t t);
 
 } // namespace o2::framework

--- a/Framework/Core/include/Framework/CallbackService.h
+++ b/Framework/Core/include/Framework/CallbackService.h
@@ -26,6 +26,7 @@ struct DataHeader;
 namespace o2::framework
 {
 
+struct ConcreteDataMatcher;
 class EndOfStreamContext;
 
 // A service that data processors can register callback functions invoked by the
@@ -69,7 +70,8 @@ class CallbackService
     /// to a timeslice with the wanted quantities.
     NewTimeslice,
     /// Invoked before the processing callback
-    PreProcessing
+    PreProcessing,
+    CCDBDeserialised
   };
 
   using StartCallback = std::function<void()>;
@@ -82,19 +84,21 @@ class CallbackService
   using RegionInfoCallback = std::function<void(FairMQRegionInfo const&)>;
   using NewTimesliceCallback = std::function<void(o2::header::DataHeader&, DataProcessingHeader&)>;
   using PreProcessingCallback = std::function<void(ServiceRegistry&, int)>;
+  using CCDBDeserializedCallback = std::function<void(ConcreteDataMatcher&, void*)>;
 
-  using Callbacks = CallbackRegistry<Id,                                                           //
-                                     RegistryPair<Id, Id::Start, StartCallback>,                   //
-                                     RegistryPair<Id, Id::Stop, StopCallback>,                     //
-                                     RegistryPair<Id, Id::Reset, ResetCallback>,                   //
-                                     RegistryPair<Id, Id::Idle, IdleCallback>,                     //
-                                     RegistryPair<Id, Id::ClockTick, ClockTickCallback>,           //
-                                     RegistryPair<Id, Id::DataConsumed, DataConsumedCallback>,     //
-                                     RegistryPair<Id, Id::EndOfStream, EndOfStreamCallback>,       //
-                                     RegistryPair<Id, Id::RegionInfoCallback, RegionInfoCallback>, //
-                                     RegistryPair<Id, Id::NewTimeslice, NewTimesliceCallback>,     //
-                                     RegistryPair<Id, Id::PreProcessing, PreProcessingCallback>    //
-                                     >;                                                            //
+  using Callbacks = CallbackRegistry<Id,                                                              //
+                                     RegistryPair<Id, Id::Start, StartCallback>,                      //
+                                     RegistryPair<Id, Id::Stop, StopCallback>,                        //
+                                     RegistryPair<Id, Id::Reset, ResetCallback>,                      //
+                                     RegistryPair<Id, Id::Idle, IdleCallback>,                        //
+                                     RegistryPair<Id, Id::ClockTick, ClockTickCallback>,              //
+                                     RegistryPair<Id, Id::DataConsumed, DataConsumedCallback>,        //
+                                     RegistryPair<Id, Id::EndOfStream, EndOfStreamCallback>,          //
+                                     RegistryPair<Id, Id::RegionInfoCallback, RegionInfoCallback>,    //
+                                     RegistryPair<Id, Id::NewTimeslice, NewTimesliceCallback>,        //
+                                     RegistryPair<Id, Id::PreProcessing, PreProcessingCallback>,      //
+                                     RegistryPair<Id, Id::CCDBDeserialised, CCDBDeserializedCallback> //
+                                     >;                                                               //
 
   // set callback for specified processing step
   template <typename U>

--- a/Framework/Core/include/Framework/DataProcessingDevice.h
+++ b/Framework/Core/include/Framework/DataProcessingDevice.h
@@ -26,6 +26,7 @@
 #include "Framework/ProcessingPolicies.h"
 #include "Framework/Tracing.h"
 #include "Framework/RunningWorkflowInfo.h"
+#include "Framework/ObjectCache.h"
 
 #include <fairmq/FairMQDevice.h>
 #include <fairmq/FairMQParts.h>
@@ -86,6 +87,7 @@ struct DataProcessorContext {
   AlgorithmSpec::ProcessCallback* statefulProcess = nullptr;
   AlgorithmSpec::ProcessCallback* statelessProcess = nullptr;
   AlgorithmSpec::ErrorCallback* error = nullptr;
+  ObjectCache objCache;
 
   /// Wether or not the associated DataProcessor can forward things early
   bool canForwardEarly = true;

--- a/Framework/Core/include/Framework/InputRecord.h
+++ b/Framework/Core/include/Framework/InputRecord.h
@@ -8,8 +8,8 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#ifndef FRAMEWORK_INPUTRECORD_H
-#define FRAMEWORK_INPUTRECORD_H
+#ifndef O2_FRAMEWORK_INPUTRECORD_H_
+#define O2_FRAMEWORK_INPUTRECORD_H_
 
 #include "Framework/DataRef.h"
 #include "Framework/DataRefUtils.h"
@@ -18,6 +18,9 @@
 #include "Framework/TableConsumer.h"
 #include "Framework/Traits.h"
 #include "Framework/RuntimeError.h"
+#include "Framework/Logger.h"
+#include "Framework/ObjectCache.h"
+
 #include "Headers/DataHeader.h"
 
 #include "CommonUtils/BoostSerializer.h"
@@ -34,9 +37,7 @@
 
 #include <fairmq/FwdDecls.h>
 
-namespace o2
-{
-namespace framework
+namespace o2::framework
 {
 
 struct InputSpec;
@@ -99,7 +100,8 @@ class InputRecord
   using DataHeader = o2::header::DataHeader;
 
   InputRecord(std::vector<InputRoute> const& inputs,
-              InputSpan& span);
+              InputSpan& span,
+              ObjectCache& cache);
 
   /// A deleter type to be used with unique_ptr, which can be marked that
   /// it does not own the underlying resource and thus should not delete it.
@@ -384,7 +386,39 @@ class InputRecord
         std::unique_ptr<ValueT const, Deleter<ValueT const>> result(DataRefUtils::as<ROOTSerialized<ValueT>>(ref).release());
         return result;
       } else if (method == o2::header::gSerializationMethodCCDB) {
-        std::unique_ptr<ValueT const, Deleter<ValueT const>> result(DataRefUtils::as<CCDBSerialized<ValueT>>(ref).release());
+        // This is to support deserialising objects from CCDB. Contrary to what happens for
+        // other objects, those objects are most likely long lived, so we
+        // keep around an instance of the associated object and deserialise it only when
+        // it's updated.
+        // FIXME: add ability to apply callbacks to deserialised objects.
+        auto id = ObjectCache::Id::fromRef(ref);
+        ConcreteDataMatcher matcher{header->dataOrigin, header->dataDescription, header->subSpecification};
+        // If the matcher does not have an entry in the cache, deserialise it
+        // and cache the deserialised object at the given id.
+        auto path = fmt::format("{}", DataSpecUtils::describe(matcher));
+        LOGP(info, "{}", path);
+        auto cacheEntry = mCache.matcherToId.find(path);
+        if (cacheEntry == mCache.matcherToId.end()) {
+          mCache.matcherToId.insert(std::make_pair(path, id));
+          std::unique_ptr<ValueT const, Deleter<ValueT const>> result(DataRefUtils::as<CCDBSerialized<ValueT>>(ref).release(), false);
+          mCache.idToObject[id] = (void*)result.get();
+          LOGP(info, "Caching in {} ptr to {} ({})", id.value, path, (void*)result.get());
+          return result;
+        }
+        auto& oldId = cacheEntry->second;
+        // The id in the cache is the same, let's simply return it.
+        if (oldId.value == id.value) {
+          std::unique_ptr<ValueT const, Deleter<ValueT const>> result((ValueT const*)mCache.idToObject[id], false);
+          LOGP(info, "Returning cached entry {} for {} ({})", id.value, path, (void*)result.get());
+          return result;
+        }
+        // The id in the cache is different. Let's destroy the old cached entry
+        // and create a new one.
+        delete reinterpret_cast<ValueT*>(mCache.idToObject[oldId]);
+        std::unique_ptr<ValueT const, Deleter<ValueT const>> result(DataRefUtils::as<CCDBSerialized<ValueT>>(ref).release(), false);
+        mCache.idToObject[id] = (void*)result.get();
+        LOGP(info, "Replacing cached entry {} with {} for {} ({})", oldId.value, id.value, path, (void*)result.get());
+        oldId.value = id.value;
         return result;
       } else {
         throw runtime_error("Attempt to extract object from message with unsupported serialization type");
@@ -627,11 +661,11 @@ class InputRecord
   }
 
  private:
+  ObjectCache& mCache;
   std::vector<InputRoute> const& mInputsSchema;
   InputSpan& mSpan;
 };
 
-} // namespace framework
-} // namespace o2
+} // namespace o2::framework
 
-#endif // FRAMEWORK_INPUTREGISTRY_H
+#endif // O2_FRAMEWORK_INPUTREGISTRY_H_

--- a/Framework/Core/include/Framework/ObjectCache.h
+++ b/Framework/Core/include/Framework/ObjectCache.h
@@ -1,0 +1,53 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef O2_FRAMEWORK_OBJECTCACHE_H_
+#define O2_FRAMEWORK_OBJECTCACHE_H_
+
+#include "Framework/DataRef.h"
+#include <unordered_map>
+
+namespace o2::framework
+{
+
+/// A cache for CCDB objects or objects in general
+/// which have more than one timeframe of lifetime.
+struct ObjectCache {
+  struct Id {
+    int64_t value;
+    static Id fromRef(DataRef& ref)
+    {
+      return {reinterpret_cast<int64_t>(ref.payload)};
+    }
+    bool operator==(const Id& other) const
+    {
+      return value == other.value;
+    }
+
+    struct hash_fn {
+      std::size_t operator()(const Id& id) const
+      {
+        return id.value;
+      }
+    };
+  };
+  /// A cache for deserialised objects.
+  /// This keeps a mapping so that we can tell if a given
+  /// path was already received and it's blob stored in
+  /// .second.
+  std::unordered_map<std::string, Id> matcherToId;
+  /// A map from a CacheId (which is the void* ptr of the previous map).
+  /// to an actual (type erased) pointer to the deserialised object.
+  std::unordered_map<Id, void*, Id::hash_fn> idToObject;
+};
+
+} // namespace o2::framework
+
+#endif // O2_FRAMEWORK_OBJECTCACHE_H_

--- a/Framework/Core/src/CCDBHelpers.cxx
+++ b/Framework/Core/src/CCDBHelpers.cxx
@@ -17,6 +17,10 @@
 #include "Framework/DataTakingContext.h"
 #include "Framework/RawDeviceService.h"
 #include "CCDB/CcdbApi.h"
+#include "CommonConstants/LHCConstants.h"
+#include <typeinfo>
+#include <TError.h>
+#include <TMemFile.h>
 
 namespace o2::framework
 {
@@ -56,66 +60,141 @@ AlgorithmSpec CCDBHelpers::fetchFromCCDB()
           }
         }
       }
-      
-      return adaptStateless([helper](RawDeviceService &device, DataTakingContext& dtc, DataAllocator& allocator, TimingInfo &timingInfo) {
-          LOGP(info, "Fetching objects. Run: {}. OrbitResetTime: {}", dtc.runNumber, dtc.orbitResetTime);
 
-          for (auto &route : helper->routes) {
-            LOGP(info, "Fetching object for route {}", route.matcher);
+      auto getOrbitResetTime = [](o2::pmr::vector<char> const& v) -> Long64_t {
+        Int_t previousErrorLevel = gErrorIgnoreLevel;
+        gErrorIgnoreLevel = kFatal;
+        TMemFile memFile("name", const_cast<char*>(v.data()), v.size(), "READ");
+        gErrorIgnoreLevel = previousErrorLevel;
+        if (memFile.IsZombie()) {
+          throw runtime_error_f("CTP is Zombie");
+        }
+        TClass* tcl = TClass::GetClass(typeid(std::vector<Long64_t>));
+        void* result = ccdb::CcdbApi::extractFromTFile(memFile, tcl);
+        if (!result) {
+          throw runtime_error_f("Couldn't retrieve object corresponding to %s from TFile", tcl->GetName());
+        }
+        memFile.Close();
+        std::vector<Long64_t>* ctp = (std::vector<Long64_t>*)result;
+        return (*ctp)[0];
+      };
 
-            auto concrete = DataSpecUtils::asConcreteDataMatcher(route.matcher);
-            Output output{concrete.origin, concrete.description, concrete.subSpec, route.matcher.lifetime};
-            auto &&v = allocator.makeVector<char>(output);
-            std::map<std::string, std::string> metadata;
-            std::map<std::string, std::string> headers;
-            std::string path = "";
-            std::string etag = "";
-            std::string createdNotBefore = "0";
-            std::string createdNotAfter = "0";
-            for (auto& meta : route.matcher.metadata) {
-              if (meta.name == "ccdb-path") {
-                path = meta.defaultValue.get<std::string>();
-                break;
-              }
-            }
-            const auto url2uuid = helper->mapURL2UUID.find(path);
-            if (url2uuid != helper->mapURL2UUID.end()) {
-              etag = url2uuid->second;
-            }
+      return adaptStateless([helper, &getOrbitResetTime](RawDeviceService& device, DataTakingContext& dtc, DataAllocator& allocator, TimingInfo& timingInfo) {
+        static Long64_t orbitResetTime = -1;
+        // Fetch the CCDB object for the CTP
+        {
+          // FIXME: this (the static) is needed because for now I cannot get
+          // a pointer for the cachedObject in the fetcher itself.
+          // Will be fixed at a later point.
+          std::string path = "CTP/Calib/OrbitReset";
+          std::map<std::string, std::string> metadata;
+          std::map<std::string, std::string> headers;
+          std::string createdNotBefore = "0";
+          std::string createdNotAfter = "0";
+          std::string etag;
+          const auto url2uuid = helper->mapURL2UUID.find(path);
+          if (url2uuid != helper->mapURL2UUID.end()) {
+            etag = url2uuid->second;
+          }
+          Output output{"CTP", "OrbitReset", 0, Lifetime::Condition};
+          auto&& v = allocator.makeVector<char>(output);
+          helper->api.loadFileToMemory(v, path, metadata, timingInfo.timeslice, &headers, etag, createdNotAfter, createdNotBefore);
 
-            LOGP(info, "{} {} {}\n", timingInfo.timeslice, timingInfo.tfCounter, timingInfo.creation);
-            helper->api.loadFileToMemory(v, path, metadata, timingInfo.timeslice, &headers, etag, createdNotAfter, createdNotBefore);
-            if ((headers.count("Error") != 0) || (etag.empty() && v.empty())) {
-              LOGP(error, "Unable to find object {}/{}", path, timingInfo.timeslice);
-              //FIXME: I should send a dummy message.
-              continue;
-            }
-            if (etag.empty()) {
-              helper->mapURL2UUID[path] = headers["ETag"]; // update uuid
-              auto cacheId = allocator.adoptContainer(output, std::move(v), true, header::gSerializationMethodCCDB);
-              helper->mapURL2DPLCache[path] = cacheId;
-              LOGP(info, "Caching {} for {} (DPL id {})", path, headers["ETag"], cacheId.value);
-              continue;
-            }
-            if (v.size()) { // but should be overridden by fresh object
+          if ((headers.count("Error") != 0) || (etag.empty() && v.empty())) {
+            LOGP(error, "Unable to find object {}/{}", path, timingInfo.timeslice);
+            //FIXME: I should send a dummy message.
+            return;
+          }
+          Long64_t newOrbitResetTime = orbitResetTime;
+          if (etag.empty()) {
+            helper->mapURL2UUID[path] = headers["ETag"]; // update uuid
+            newOrbitResetTime = getOrbitResetTime(v);
+            auto cacheId = allocator.adoptContainer(output, std::move(v), true, header::gSerializationMethodNone);
+            helper->mapURL2DPLCache[path] = cacheId;
+            LOGP(debug, "Caching {} for {} (DPL id {})", path, headers["ETag"], cacheId.value);
+          } else if (v.size()) { // but should be overridden by fresh object
+            // somewhere here pruneFromCache should be called
+            helper->mapURL2UUID[path] = headers["ETag"]; // update uuid
+            newOrbitResetTime = getOrbitResetTime(v);
+            auto cacheId = allocator.adoptContainer(output, std::move(v), true, header::gSerializationMethodNone);
+            helper->mapURL2DPLCache[path] = cacheId;
+            LOGP(debug, "Caching {} for {} (DPL id {})", path, headers["ETag"], cacheId.value);
+            // one could modify the    adoptContainer to take optional old cacheID to clean:
+            // mapURL2DPLCache[URL] = ctx.outputs().adoptContainer(output, std::move(outputBuffer), true, mapURL2DPLCache[URL]);
+          } else { // cached object is fine
+            auto cacheId = helper->mapURL2DPLCache[path];
+            LOGP(debug, "Reusing {} for {}", cacheId.value, path);
+            allocator.adoptFromCache(output, cacheId, header::gSerializationMethodNone);
+            // We need to find a way to get "v" also in this case.
+            // orbitResetTime = getOrbitResetTime(v);
+            // the outputBuffer was not used, can we destroy it?
+          }
+          if (newOrbitResetTime != orbitResetTime) {
+            LOGP(info, "Orbit reset time now at {} (was {})",
+                 newOrbitResetTime, orbitResetTime);
+            orbitResetTime = newOrbitResetTime;
+          }
+        }
 
-              // somewhere here pruneFromCache should be called
+        int64_t timestamp = ceilf((timingInfo.firstTFOrbit * o2::constants::lhc::LHCOrbitNS / 1000 + orbitResetTime) / 1000);
+        // Fetch the rest of the objects.
+        LOGP(info, "Fetching objects. Run: {}. OrbitResetTime: {}, Timestamp: {}, firstTFOrbit: {}",
+             dtc.runNumber, dtc.orbitResetTime, timestamp, timingInfo.firstTFOrbit);
 
-              helper->mapURL2UUID[path] = headers["ETag"]; // update uuid
-              auto cacheId = allocator.adoptContainer(output, std::move(v), true, header::gSerializationMethodCCDB);
-              helper->mapURL2DPLCache[path] = cacheId;
-              LOGP(info, "Caching {} for {} (DPL id {})", path, headers["ETag"], cacheId.value);
-              // one could modify the    adoptContainer to take optional old cacheID to clean:
-              // mapURL2DPLCache[URL] = ctx.outputs().adoptContainer(output, std::move(outputBuffer), true, mapURL2DPLCache[URL]);
-            } else { // cached object is fine
-              auto cacheId = helper->mapURL2DPLCache[path];
-              LOGP(info, "Reusing {} for {}", cacheId.value, path);
-              allocator.adoptFromCache(output, cacheId, header::gSerializationMethodCCDB);
-              // the outputBuffer was not used, can we destroy it?
+        for (auto& route : helper->routes) {
+          LOGP(info, "Fetching object for route {}", route.matcher);
+
+          auto concrete = DataSpecUtils::asConcreteDataMatcher(route.matcher);
+          Output output{concrete.origin, concrete.description, concrete.subSpec, route.matcher.lifetime};
+          auto&& v = allocator.makeVector<char>(output);
+          std::map<std::string, std::string> metadata;
+          std::map<std::string, std::string> headers;
+          std::string path = "";
+          std::string etag = "";
+          std::string createdNotBefore = "0";
+          std::string createdNotAfter = "0";
+          for (auto& meta : route.matcher.metadata) {
+            if (meta.name == "ccdb-path") {
+              path = meta.defaultValue.get<std::string>();
+              break;
             }
           }
-          device.waitFor(5000);
-                              }); });
+          const auto url2uuid = helper->mapURL2UUID.find(path);
+          if (url2uuid != helper->mapURL2UUID.end()) {
+            etag = url2uuid->second;
+          }
+
+          helper->api.loadFileToMemory(v, path, metadata, timestamp, &headers, etag, createdNotAfter, createdNotBefore);
+          if ((headers.count("Error") != 0) || (etag.empty() && v.empty())) {
+            LOGP(error, "Unable to find object {}/{}", path, timingInfo.timeslice);
+            //FIXME: I should send a dummy message.
+            continue;
+          }
+          if (etag.empty()) {
+            helper->mapURL2UUID[path] = headers["ETag"]; // update uuid
+            auto cacheId = allocator.adoptContainer(output, std::move(v), true, header::gSerializationMethodCCDB);
+            helper->mapURL2DPLCache[path] = cacheId;
+            LOGP(info, "Caching {} for {} (DPL id {})", path, headers["ETag"], cacheId.value);
+            continue;
+          }
+          if (v.size()) { // but should be overridden by fresh object
+
+            // somewhere here pruneFromCache should be called
+
+            helper->mapURL2UUID[path] = headers["ETag"]; // update uuid
+            auto cacheId = allocator.adoptContainer(output, std::move(v), true, header::gSerializationMethodCCDB);
+            helper->mapURL2DPLCache[path] = cacheId;
+            LOGP(info, "Caching {} for {} (DPL id {})", path, headers["ETag"], cacheId.value);
+            // one could modify the    adoptContainer to take optional old cacheID to clean:
+            // mapURL2DPLCache[URL] = ctx.outputs().adoptContainer(output, std::move(outputBuffer), true, mapURL2DPLCache[URL]);
+          } else { // cached object is fine
+            auto cacheId = helper->mapURL2DPLCache[path];
+            LOGP(info, "Reusing {} for {}", cacheId.value, path);
+            allocator.adoptFromCache(output, cacheId, header::gSerializationMethodCCDB);
+            // the outputBuffer was not used, can we destroy it?
+          }
+        }
+      }); });
 }
 
 } // namespace o2::framework

--- a/Framework/Core/src/CCDBHelpers.cxx
+++ b/Framework/Core/src/CCDBHelpers.cxx
@@ -12,24 +12,109 @@
 #include "CCDBHelpers.h"
 #include "Framework/DeviceSpec.h"
 #include "Framework/Logger.h"
+#include "Framework/TimingInfo.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/DataTakingContext.h"
+#include "Framework/RawDeviceService.h"
+#include "CCDB/CcdbApi.h"
 
 namespace o2::framework
 {
 
+struct CCDBFetcherHelper {
+  struct CCDBCacheInfo {
+    std::string path;
+    int64_t cacheId;
+    std::string etag;
+  };
+
+  std::unordered_map<std::string, std::string> mapURL2UUID;
+  std::unordered_map<std::string, DataAllocator::CacheId> mapURL2DPLCache;
+
+  o2::ccdb::CcdbApi api;
+  std::vector<OutputRoute> routes;
+  std::map<int64_t, CCDBCacheInfo> cache;
+};
+
 AlgorithmSpec CCDBHelpers::fetchFromCCDB()
 {
-  return adaptStateful([](DeviceSpec const& spec) { 
+  return adaptStateful([](ConfigParamRegistry const& options, DeviceSpec const& spec) { 
+      std::shared_ptr<CCDBFetcherHelper> helper = std::make_shared<CCDBFetcherHelper>();
+      auto backend = options.get<std::string>("condition-backend");
+      LOGP(info, "CCDB Backend at: {}", backend);
+      helper->api.init(options.get<std::string>("condition-backend"));
+
       for (auto &route : spec.outputs) {
         if (route.matcher.lifetime != Lifetime::Condition) {
           continue;
         }
+        helper->routes.push_back(route);
         LOGP(info, "The following route is a condition {}", route.matcher);
         for (auto& metadata : route.matcher.metadata) {
-          LOGP(info, "- {}", metadata.name);
+          if (metadata.type == VariantType::String) { 
+            LOGP(info, "- {}: {}", metadata.name, metadata.defaultValue);
+          }
         }
       }
       
-      return adaptStateless([](DataAllocator& ctx) {
+      return adaptStateless([helper](RawDeviceService &device, DataTakingContext& dtc, DataAllocator& allocator, TimingInfo &timingInfo) {
+          LOGP(info, "Fetching objects. Run: {}. OrbitResetTime: {}", dtc.runNumber, dtc.orbitResetTime);
+
+          for (auto &route : helper->routes) {
+            LOGP(info, "Fetching object for route {}", route.matcher);
+
+            auto concrete = DataSpecUtils::asConcreteDataMatcher(route.matcher);
+            Output output{concrete.origin, concrete.description, concrete.subSpec, route.matcher.lifetime};
+            auto &&v = allocator.makeVector<char>(output);
+            std::map<std::string, std::string> metadata;
+            std::map<std::string, std::string> headers;
+            std::string path = "";
+            std::string etag = "";
+            std::string createdNotBefore = "0";
+            std::string createdNotAfter = "0";
+            for (auto& meta : route.matcher.metadata) {
+              if (meta.name == "ccdb-path") {
+                path = meta.defaultValue.get<std::string>();
+                break;
+              }
+            }
+            const auto url2uuid = helper->mapURL2UUID.find(path);
+            if (url2uuid != helper->mapURL2UUID.end()) {
+              etag = url2uuid->second;
+            }
+
+            LOGP(info, "{} {} {}\n", timingInfo.timeslice, timingInfo.tfCounter, timingInfo.creation);
+            helper->api.loadFileToMemory(v, path, metadata, timingInfo.timeslice, &headers, etag, createdNotAfter, createdNotBefore);
+            if ((headers.count("Error") != 0) || (etag.empty() && v.empty())) {
+              LOGP(error, "Unable to find object {}/{}", path, timingInfo.timeslice);
+              //FIXME: I should send a dummy message.
+              continue;
+            }
+            if (etag.empty()) {
+              helper->mapURL2UUID[path] = headers["ETag"]; // update uuid
+              auto cacheId = allocator.adoptContainer(output, std::move(v), true, header::gSerializationMethodCCDB);
+              helper->mapURL2DPLCache[path] = cacheId;
+              LOGP(info, "Caching {} for {} (DPL id {})", path, headers["ETag"], cacheId.value);
+              continue;
+            }
+            if (v.size()) { // but should be overridden by fresh object
+
+              // somewhere here pruneFromCache should be called
+
+              helper->mapURL2UUID[path] = headers["ETag"]; // update uuid
+              auto cacheId = allocator.adoptContainer(output, std::move(v), true, header::gSerializationMethodCCDB);
+              helper->mapURL2DPLCache[path] = cacheId;
+              LOGP(info, "Caching {} for {} (DPL id {})", path, headers["ETag"], cacheId.value);
+              // one could modify the    adoptContainer to take optional old cacheID to clean:
+              // mapURL2DPLCache[URL] = ctx.outputs().adoptContainer(output, std::move(outputBuffer), true, mapURL2DPLCache[URL]);
+            } else { // cached object is fine
+              auto cacheId = helper->mapURL2DPLCache[path];
+              LOGP(info, "Reusing {} for {}", cacheId.value, path);
+              allocator.adoptFromCache(output, cacheId, header::gSerializationMethodCCDB);
+              // the outputBuffer was not used, can we destroy it?
+            }
+          }
+          device.waitFor(5000);
                               }); });
 }
 

--- a/Framework/Core/src/CCDBHelpers.h
+++ b/Framework/Core/src/CCDBHelpers.h
@@ -12,11 +12,19 @@
 #define O2_FRAMEWORK_CCDBHELPERS_H_
 
 #include "Framework/AlgorithmSpec.h"
+#include <unordered_map>
+#include <string>
 
 namespace o2::framework
 {
+
 struct CCDBHelpers {
+  struct ParserResult {
+    std::unordered_map<std::string, std::string> remappings;
+    std::string error;
+  };
   static AlgorithmSpec fetchFromCCDB();
+  static ParserResult parseRemappings(char const*);
 };
 
 } // namespace o2::framework

--- a/Framework/Core/src/CCDBParamSpec.cxx
+++ b/Framework/Core/src/CCDBParamSpec.cxx
@@ -26,14 +26,32 @@ ConfigParamSpec ccdbRunDependent(bool defaultValue)
   return ConfigParamSpec{"ccdb-run-dependent", VariantType::Bool, defaultValue, {"Give object for specific run number"}, ConfigParamKind::kGeneric};
 }
 
-std::vector<ConfigParamSpec> ccdbParamSpec(std::string const& path, bool runDependent)
+ConfigParamSpec ccdbMetadataSpec(std::string const& key, std::string const& defaultValue)
+{
+  return ConfigParamSpec{fmt::format("ccdb-metadata-{}", key),
+                         VariantType::String,
+                         defaultValue,
+                         {fmt::format("CCDB metadata {}", key)},
+                         ConfigParamKind::kGeneric};
+}
+
+std::vector<ConfigParamSpec> ccdbParamSpec(std::string const& path, std::vector<CCDBMetadata> metadata)
+{
+  return ccdbParamSpec(path, false, metadata);
+}
+
+std::vector<ConfigParamSpec> ccdbParamSpec(std::string const& path, bool runDependent, std::vector<CCDBMetadata> metadata)
 {
   // Add here CCDB objecs which should be considered run dependent
   static std::vector<std::string> runDependentObjects = {"GLO/GRP"};
   if (std::any_of(runDependentObjects.begin(), runDependentObjects.end(), [&path](std::string const& s) { return path == s; })) {
     runDependent = true;
   }
-  return {ccdbPathSpec(path), ccdbRunDependent(runDependent)};
+  std::vector<ConfigParamSpec> result{ccdbPathSpec(path), ccdbRunDependent(runDependent)};
+  for (auto& [key, value] : metadata) {
+    result.push_back(ccdbMetadataSpec(key, value));
+  }
+  return result;
 }
 
 ConfigParamSpec startTimeParamSpec(int64_t t)

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -300,8 +300,6 @@ void DataProcessingDevice::Init()
     auto& name = mSpec.inputChannels[ci].name;
     if (name.find(mSpec.channelPrefix + "from_internal-dpl-clock") == 0) {
       mState.inputChannelInfos[ci].state = InputChannelState::Pull;
-    } else if (name.find(mSpec.channelPrefix + "from_internal-dpl-ccdb-backend") == 0) {
-      mState.inputChannelInfos[ci].state = InputChannelState::Pull;
     }
   }
 
@@ -424,7 +422,10 @@ void DataProcessingDevice::InitTask()
   // We add a timer only in case a channel poller is not there.
   if ((mStatefulProcess != nullptr) || (mStatelessProcess != nullptr)) {
     for (auto& x : fChannels) {
-      if ((x.first.rfind("from_internal-dpl", 0) == 0) && (x.first.rfind("from_internal-dpl-aod", 0) != 0) && (x.first.rfind("from_internal-dpl-injected", 0)) != 0) {
+      if ((x.first.rfind("from_internal-dpl", 0) == 0) &&
+          (x.first.rfind("from_internal-dpl-aod", 0) != 0) &&
+          (x.first.rfind("from_internal-dpl-ccdb-backend", 0) != 0) &&
+          (x.first.rfind("from_internal-dpl-injected", 0)) != 0) {
         LOG(debug) << x.first << " is an internal channel. Skipping as no input will come from there." << std::endl;
         continue;
       }

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -1436,7 +1436,10 @@ bool DataProcessingDevice::tryDispatchComputation(DataProcessorContext& context,
     bool shouldConsume = action.op == CompletionPolicy::CompletionOp::Consume ||
                          action.op == CompletionPolicy::CompletionOp::Discard;
     InputSpan span = getInputSpan(action.slot, shouldConsume);
-    InputRecord record{context.deviceContext->spec->inputs, span, context.objCache};
+    InputRecord record{context.deviceContext->spec->inputs,
+                       span,
+                       context.objCache,
+                       context.registry->get<CallbackService>()};
     ProcessingContext processContext{record, *context.registry, *context.allocator};
     {
       ZoneScopedN("service pre processing");

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -1436,7 +1436,7 @@ bool DataProcessingDevice::tryDispatchComputation(DataProcessorContext& context,
     bool shouldConsume = action.op == CompletionPolicy::CompletionOp::Consume ||
                          action.op == CompletionPolicy::CompletionOp::Discard;
     InputSpan span = getInputSpan(action.slot, shouldConsume);
-    InputRecord record{context.deviceContext->spec->inputs, span};
+    InputRecord record{context.deviceContext->spec->inputs, span, context.objCache};
     ProcessingContext processContext{record, *context.registry, *context.allocator};
     {
       ZoneScopedN("service pre processing");

--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -46,6 +46,9 @@
 #include <sys/resource.h>
 #include <csignal>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+
 namespace bpo = boost::program_options;
 
 using namespace o2::framework;
@@ -712,16 +715,16 @@ void DeviceSpecHelpers::processInEdgeActions(std::vector<DeviceSpec>& devices,
     switch (consumer.inputs[edge.consumerInputIndex].lifetime) {
       case Lifetime::OutOfBand:
         route.configurator = {
-          ExpirationHandlerHelpers::fairmqDrivenConfiguration(inputSpec, consumerDevice.inputTimesliceId, consumerDevice.maxInputTimeslices),
-          ExpirationHandlerHelpers::danglingOutOfBandConfigurator(),
-          ExpirationHandlerHelpers::expiringOutOfBandConfigurator(inputSpec)};
+          .creatorConfigurator = ExpirationHandlerHelpers::fairmqDrivenConfiguration(inputSpec, consumerDevice.inputTimesliceId, consumerDevice.maxInputTimeslices),
+          .danglingConfigurator = ExpirationHandlerHelpers::danglingOutOfBandConfigurator(),
+          .expirationConfigurator = ExpirationHandlerHelpers::expiringOutOfBandConfigurator(inputSpec)};
         break;
-      case Lifetime::Condition:
-        route.configurator = {
-          ExpirationHandlerHelpers::dataDrivenConfigurator(),
-          ExpirationHandlerHelpers::danglingConditionConfigurator(),
-          ExpirationHandlerHelpers::expiringConditionConfigurator(inputSpec, sourceChannel)};
-        break;
+        //      case Lifetime::Condition:
+        //        route.configurator = {
+        //          ExpirationHandlerHelpers::dataDrivenConfigurator(),
+        //          ExpirationHandlerHelpers::danglingConditionConfigurator(),
+        //          ExpirationHandlerHelpers::expiringConditionConfigurator(inputSpec, sourceChannel)};
+        //        break;
       case Lifetime::QA:
         route.configurator = {
           ExpirationHandlerHelpers::dataDrivenConfigurator(),

--- a/Framework/Core/src/InputRecord.cxx
+++ b/Framework/Core/src/InputRecord.cxx
@@ -12,6 +12,7 @@
 #include "Framework/InputSpan.h"
 #include "Framework/InputSpec.h"
 #include "Framework/ObjectCache.h"
+#include "Framework/CallbackService.h"
 #include <fairmq/FairMQMessage.h>
 #include <cassert>
 
@@ -34,10 +35,12 @@ namespace o2::framework
 
 InputRecord::InputRecord(std::vector<InputRoute> const& inputsSchema,
                          InputSpan& span,
-                         ObjectCache& cache)
+                         ObjectCache& cache,
+                         CallbackService& callbacks)
   : mInputsSchema{inputsSchema},
     mSpan{span},
-    mCache{cache}
+    mCache{cache},
+    mCallbacks{callbacks}
 {
 }
 

--- a/Framework/Core/src/InputRecord.cxx
+++ b/Framework/Core/src/InputRecord.cxx
@@ -11,6 +11,7 @@
 #include "Framework/InputRecord.h"
 #include "Framework/InputSpan.h"
 #include "Framework/InputSpec.h"
+#include "Framework/ObjectCache.h"
 #include <fairmq/FairMQMessage.h>
 #include <cassert>
 
@@ -32,9 +33,11 @@ namespace o2::framework
 {
 
 InputRecord::InputRecord(std::vector<InputRoute> const& inputsSchema,
-                         InputSpan& span)
+                         InputSpan& span,
+                         ObjectCache& cache)
   : mInputsSchema{inputsSchema},
-    mSpan{span}
+    mSpan{span},
+    mCache{cache}
 {
 }
 

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -228,7 +228,7 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
                "ENUM",
                static_cast<DataAllocator::SubSpecificationType>(compile_time_hash("internal-dpl-ccdb-backend")),
                Lifetime::Enumeration}},
-    {},
+    {OutputSpec{"CTP", "OrbitReset", 0}},
     CCDBHelpers::fetchFromCCDB(),
     {ConfigParamSpec{"condition-backend", VariantType::String, "http://alice-ccdb.cern.ch", {"URL for CCDB"}},
      ConfigParamSpec{"orbit-offset-enumeration", VariantType::Int64, 0ll, {"initial value for the orbit"}},

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -223,7 +223,7 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
 
   DataProcessorSpec ccdbBackend{
     .name = "internal-dpl-ccdb-backend",
-    .outputs = {{"CTP", "OrbitReset", 0}},
+    .outputs = {},
     .algorithm = CCDBHelpers::fetchFromCCDB(),
     .options = {{"condition-backend", VariantType::String, "http://alice-ccdb.cern.ch", {"URL for CCDB"}},
                 {"condition-not-before", VariantType::Int64, 0ll, {"do not fetch from CCDB objects created before provide timestamp"}},
@@ -490,6 +490,7 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
   }
 
   if (ccdbBackend.outputs.empty() == false) {
+    ccdbBackend.outputs.push_back(OutputSpec{"CTP", "OrbitReset", 0});
     bool hasDISTSTF = false;
     InputSpec matcher{"dstf", "FLP", "DISTSUBTIMEFRAME"};
     ConcreteDataMatcher dstf{"FLP", "DISTSUBTIMEFRAME", 0};

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -222,16 +222,17 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
   }};
 
   DataProcessorSpec ccdbBackend{
-    "internal-dpl-ccdb-backend",
-    {},
-    {OutputSpec{"CTP", "OrbitReset", 0}},
-    CCDBHelpers::fetchFromCCDB(),
-    {ConfigParamSpec{"condition-backend", VariantType::String, "http://alice-ccdb.cern.ch", {"URL for CCDB"}},
-     ConfigParamSpec{"orbit-offset-enumeration", VariantType::Int64, 0ll, {"initial value for the orbit"}},
-     ConfigParamSpec{"orbit-multiplier-enumeration", VariantType::Int64, 0ll, {"multiplier to get the orbit from the counter"}},
-     ConfigParamSpec{"start-value-enumeration", VariantType::Int64, 0ll, {"initial value for the enumeration"}},
-     ConfigParamSpec{"end-value-enumeration", VariantType::Int64, -1ll, {"final value for the enumeration"}},
-     ConfigParamSpec{"step-value-enumeration", VariantType::Int64, 1ll, {"step between one value and the other"}}},
+    .name = "internal-dpl-ccdb-backend",
+    .outputs = {{"CTP", "OrbitReset", 0}},
+    .algorithm = CCDBHelpers::fetchFromCCDB(),
+    .options = {{"condition-backend", VariantType::String, "http://alice-ccdb.cern.ch", {"URL for CCDB"}},
+                {"condition-not-before", VariantType::Int64, 0ll, {"do not fetch from CCDB objects created before provide timestamp"}},
+                {"condition-not-after", VariantType::Int64, 3385078236000ll, {"do not fetch from CCDB objects created after the timestamp"}},
+                {"orbit-offset-enumeration", VariantType::Int64, 0ll, {"initial value for the orbit"}},
+                {"orbit-multiplier-enumeration", VariantType::Int64, 0ll, {"multiplier to get the orbit from the counter"}},
+                {"start-value-enumeration", VariantType::Int64, 0ll, {"initial value for the enumeration"}},
+                {"end-value-enumeration", VariantType::Int64, -1ll, {"final value for the enumeration"}},
+                {"step-value-enumeration", VariantType::Int64, 1ll, {"step between one value and the other"}}},
   };
   DataProcessorSpec transientStore{"internal-dpl-transient-store",
                                    {},

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -223,11 +223,7 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
 
   DataProcessorSpec ccdbBackend{
     "internal-dpl-ccdb-backend",
-    {InputSpec{"enumeration",
-               "DPL",
-               "ENUM",
-               static_cast<DataAllocator::SubSpecificationType>(compile_time_hash("internal-dpl-ccdb-backend")),
-               Lifetime::Enumeration}},
+    {},
     {OutputSpec{"CTP", "OrbitReset", 0}},
     CCDBHelpers::fetchFromCCDB(),
     {ConfigParamSpec{"condition-backend", VariantType::String, "http://alice-ccdb.cern.ch", {"URL for CCDB"}},
@@ -443,11 +439,6 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
 
   std::vector<DataProcessorSpec> extraSpecs;
 
-  if (ccdbBackend.outputs.empty() == false) {
-    extraSpecs.push_back(ccdbBackend);
-    auto concrete = DataSpecUtils::asConcreteDataMatcher(ccdbBackend.inputs[0]);
-    timer.outputs.emplace_back(OutputSpec{concrete.origin, concrete.description, concrete.subSpec, Lifetime::Enumeration});
-  }
   if (transientStore.outputs.empty() == false) {
     extraSpecs.push_back(transientStore);
   }
@@ -495,6 +486,39 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
     extraSpecs.push_back(timePipeline(aodReader, ctx.options().get<int64_t>("readers")));
     auto concrete = DataSpecUtils::asConcreteDataMatcher(aodReader.inputs[0]);
     timer.outputs.emplace_back(OutputSpec{concrete.origin, concrete.description, concrete.subSpec, Lifetime::Enumeration});
+  }
+
+  if (ccdbBackend.outputs.empty() == false) {
+    bool hasDISTSTF = false;
+    InputSpec matcher{"dstf", "FLP", "DISTSUBTIMEFRAME"};
+    ConcreteDataMatcher dstf{"FLP", "DISTSUBTIMEFRAME", 0};
+    for (auto& dp : workflow) {
+      for (auto& output : dp.outputs) {
+        if (DataSpecUtils::match(matcher, output)) {
+          hasDISTSTF = true;
+          dstf = DataSpecUtils::asConcreteDataMatcher(output);
+          break;
+        }
+      }
+      if (hasDISTSTF) {
+        break;
+      }
+    }
+    if (aodReader.outputs.empty() == false) {
+      ccdbBackend.inputs.push_back(InputSpec{"tfn", "TFN", "TFNumber"});
+    } else if (hasDISTSTF) {
+      ccdbBackend.inputs.push_back(InputSpec{"tfn", dstf});
+    } else {
+      InputSpec input{"enumeration",
+                      "DPL",
+                      "ENUM",
+                      static_cast<DataAllocator::SubSpecificationType>(compile_time_hash("internal-dpl-ccdb-backend")),
+                      Lifetime::Enumeration};
+      ccdbBackend.inputs.push_back(input);
+      auto concrete = DataSpecUtils::asConcreteDataMatcher(input);
+      timer.outputs.emplace_back(OutputSpec{concrete.origin, concrete.description, concrete.subSpec, Lifetime::Enumeration});
+    }
+    extraSpecs.push_back(ccdbBackend);
   }
 
   // add the timer

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -228,6 +228,7 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
     .options = {{"condition-backend", VariantType::String, "http://alice-ccdb.cern.ch", {"URL for CCDB"}},
                 {"condition-not-before", VariantType::Int64, 0ll, {"do not fetch from CCDB objects created before provide timestamp"}},
                 {"condition-not-after", VariantType::Int64, 3385078236000ll, {"do not fetch from CCDB objects created after the timestamp"}},
+                {"condition-remap", VariantType::String, "", {"remap condition path in CCDB based on the provided string."}},
                 {"orbit-offset-enumeration", VariantType::Int64, 0ll, {"initial value for the orbit"}},
                 {"orbit-multiplier-enumeration", VariantType::Int64, 0ll, {"multiplier to get the orbit from the counter"}},
                 {"start-value-enumeration", VariantType::Int64, 0ll, {"initial value for the enumeration"}},

--- a/Framework/Core/test/benchmark_InputRecord.cxx
+++ b/Framework/Core/test/benchmark_InputRecord.cxx
@@ -48,7 +48,9 @@ static void BM_InputRecordGenericGetters(benchmark::State& state)
   // First of all we test if an empty registry behaves as expected, raising a
   // bunch of exceptions.
   InputSpan span{[](size_t) { return DataRef{nullptr, nullptr, nullptr}; }, 0};
-  InputRecord emptyRecord(schema, span);
+  CallbackService callbacks;
+  ObjectCache cache;
+  InputRecord emptyRecord(schema, span, cache, callbacks);
 
   std::vector<void*> inputs;
 
@@ -82,7 +84,7 @@ static void BM_InputRecordGenericGetters(benchmark::State& state)
   createMessage(dh2, 2);
   createEmpty();
   InputSpan span2{[&inputs](size_t i) { return DataRef{nullptr, static_cast<char const*>(inputs[2 * i]), static_cast<char const*>(inputs[2 * i + 1])}; }, inputs.size() / 2};
-  InputRecord record{schema, span2};
+  InputRecord record{schema, span2, cache, callbacks};
 
   for (auto _ : state) {
     // Checking we can get the whole ref by name

--- a/Framework/Core/test/test_CCDBHelpers.cxx
+++ b/Framework/Core/test/test_CCDBHelpers.cxx
@@ -1,0 +1,47 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test Framework CCDBHelpers
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+#include "../src/CCDBHelpers.h"
+
+using namespace o2::framework;
+
+BOOST_AUTO_TEST_CASE(TestSorting)
+{
+  auto result = CCDBHelpers::parseRemappings("");
+  BOOST_CHECK_EQUAL(result.error, "Empty string provided");
+
+  result = CCDBHelpers::parseRemappings("https");
+  BOOST_CHECK_EQUAL(result.error, "URL should start with either / or http:// / https://");
+
+  result = CCDBHelpers::parseRemappings("https://alice.cern.ch:8000");
+  BOOST_CHECK_EQUAL(result.error, "Expecting at least one target path, missing `='?");
+
+  result = CCDBHelpers::parseRemappings("https://alice.cern.ch:8000=");
+  BOOST_CHECK_EQUAL(result.error, "Empty target");
+
+  result = CCDBHelpers::parseRemappings("https://alice.cern.ch:8000=/foo/bar,");
+  BOOST_CHECK_EQUAL(result.error, "Empty target");
+
+  result = CCDBHelpers::parseRemappings("https://alice.cern.ch:8000=/foo/bar,/foo/bar;");
+  BOOST_CHECK_EQUAL(result.error, "URL should start with either / or http:// / https://");
+
+  result = CCDBHelpers::parseRemappings("https://alice.cern.ch:8000=/foo/bar,/foo/barbar;/user/test=/foo/barr");
+  BOOST_CHECK_EQUAL(result.error, "");
+  BOOST_CHECK_EQUAL(result.remappings.size(), 3);
+  BOOST_CHECK_EQUAL(result.remappings["/foo/bar"], "https://alice.cern.ch:8000");
+  BOOST_CHECK_EQUAL(result.remappings["/foo/barbar"], "https://alice.cern.ch:8000");
+  BOOST_CHECK_EQUAL(result.remappings["/foo/barr"], "/user/test");
+}

--- a/Framework/Core/test/test_InputRecord.cxx
+++ b/Framework/Core/test/test_InputRecord.cxx
@@ -51,7 +51,9 @@ BOOST_AUTO_TEST_CASE(TestInputRecord)
   InputSpan span{
     [](size_t) { return DataRef{nullptr, nullptr, nullptr}; },
     0};
-  InputRecord emptyRecord(schema, span);
+  CallbackService callbacks;
+  ObjectCache cache;
+  InputRecord emptyRecord(schema, span, cache, callbacks);
 
   BOOST_CHECK_EXCEPTION(emptyRecord.get("x"), RuntimeErrorRef, any_exception);
   BOOST_CHECK_EXCEPTION(emptyRecord.get("y"), RuntimeErrorRef, any_exception);
@@ -93,7 +95,7 @@ BOOST_AUTO_TEST_CASE(TestInputRecord)
   createMessage(dh2, 2);
   createEmpty();
   InputSpan span2{[&inputs](size_t i) { return DataRef{nullptr, static_cast<char const*>(inputs[2 * i]), static_cast<char const*>(inputs[2 * i + 1])}; }, inputs.size() / 2};
-  InputRecord record{schema, span2};
+  InputRecord record{schema, span2, cache, callbacks};
 
   // Checking we can get the whole ref by name
   BOOST_CHECK_NO_THROW(record.get("x"));

--- a/Framework/Core/test/test_WorkflowHelpers.cxx
+++ b/Framework/Core/test/test_WorkflowHelpers.cxx
@@ -226,7 +226,14 @@ BOOST_AUTO_TEST_CASE(TestSimpleConnection)
   WorkflowHelpers::injectServiceDevices(workflow, *context);
   // The fourth one is the dummy sink for the
   // timeframe reporting messages
-  BOOST_CHECK_EQUAL(workflow.size(), 4);
+  std::vector<std::string> expectedNames = {"A", "B", "internal-dpl-clock", "internal-dpl-injected-dummy-sink"};
+  BOOST_CHECK_EQUAL(workflow.size(), expectedNames.size());
+  for (size_t wi = 0, we = workflow.size(); wi != we; ++wi) {
+    BOOST_TEST_CONTEXT("With parameter wi = " << wi)
+    {
+      BOOST_CHECK_EQUAL(workflow[wi].name, expectedNames[wi]);
+    }
+  }
   WorkflowHelpers::constructGraph(workflow, logicalEdges,
                                   outputs,
                                   availableForwardsInfo);

--- a/Framework/TestWorkflows/src/test_CCDBFetcher.cxx
+++ b/Framework/TestWorkflows/src/test_CCDBFetcher.cxx
@@ -26,8 +26,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
   return WorkflowSpec{
     {
       "A",
-      {InputSpec{"somecondition", "TOF", "LHCphase", 0, Lifetime::Condition, ccdbParamSpec("TOF/LHCphase")},
-       InputSpec{"sometimer", "TST", "BAR", 0, Lifetime::Timer, {startTimeParamSpec(1638548475371)}}},
+      {InputSpec{"somecondition", "TOF", "LHCphase", 0, Lifetime::Condition, ccdbParamSpec("TOF/LHCphase")}},
       {OutputSpec{"TST", "A1", 0, Lifetime::Timeframe}},
       AlgorithmSpec{
         adaptStateless([](DataAllocator& outputs, InputRecord& inputs, ControlService& control) {

--- a/Framework/TestWorkflows/src/test_CCDBFetcher.cxx
+++ b/Framework/TestWorkflows/src/test_CCDBFetcher.cxx
@@ -40,7 +40,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
           for (size_t pi = 0; pi < condition->size(); pi++) {
             LOGP(info, "Phase at {} for timestamp {} is {}", pi, condition->timestamp(pi), condition->LHCphase(pi));
           }
-          control.readyToQuit(QuitRequest::All);
+          //          control.readyToQuit(QuitRequest::All);
         })},
       Options{
         {"test-option", VariantType::String, "test", {"A test option"}}},

--- a/Framework/TestWorkflows/src/test_CCDBFetcher.cxx
+++ b/Framework/TestWorkflows/src/test_CCDBFetcher.cxx
@@ -27,9 +27,10 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
     {
       "A",
       {InputSpec{"somecondition", "TOF", "LHCphase", 0, Lifetime::Condition, ccdbParamSpec("TOF/LHCphase")}},
+      //{InputSpec{"somecondition", "TOF", "LHCphase", 0, Lifetime::Condition, ccdbParamSpec("TOF/LHCphase", {{"some", "metadata"}})}},
       {OutputSpec{"TST", "A1", 0, Lifetime::Timeframe}},
       AlgorithmSpec{
-        adaptStateless([](DataAllocator& outputs, InputRecord& inputs, ControlService& control) {
+        adaptStateless([](InputRecord& inputs) {
           auto ref = inputs.get("somecondition");
           auto payloadSize = DataRefUtils::getPayloadSize(ref);
           if (payloadSize != 2048) {
@@ -37,7 +38,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const&)
           }
           auto condition = inputs.get<o2::dataformats::CalibLHCphaseTOF*>("somecondition");
           LOG(error) << "Condition size" << condition->size();
-          for (size_t pi = 0; pi < condition->size(); pi++) {
+          for (int pi = 0; pi < condition->size(); pi++) {
             LOGP(info, "Phase at {} for timestamp {} is {}", pi, condition->timestamp(pi), condition->LHCphase(pi));
           }
           //          control.readyToQuit(QuitRequest::All);

--- a/Framework/Utils/test/RawPageTestData.cxx
+++ b/Framework/Utils/test/RawPageTestData.cxx
@@ -86,7 +86,9 @@ DataSet createData(std::vector<InputSpec> const& inputspecs, std::vector<DataHea
     }
   }
 
-  return {std::move(schema), std::move(messages), std::move(checkValues)};
+  static ObjectCache cache;
+  static CallbackService callbacks;
+  return {std::move(schema), std::move(messages), std::move(checkValues), cache, callbacks};
 }
 
 } // namespace test

--- a/Framework/Utils/test/RawPageTestData.h
+++ b/Framework/Utils/test/RawPageTestData.h
@@ -41,7 +41,7 @@ static const size_t PAGESIZE = 8192;
 struct DataSet {
   // not nice with the double vector but for quick unit test ok
   using Messages = std::vector<std::vector<std::unique_ptr<std::vector<char>>>>;
-  DataSet(std::vector<InputRoute>&& s, Messages&& m, std::vector<int>&& v)
+  DataSet(std::vector<InputRoute>&& s, Messages&& m, std::vector<int>&& v, ObjectCache& cache, CallbackService& callbacks)
     : schema{std::move(s)},
       messages{std::move(m)},
       span{[this](size_t i, size_t part) {
@@ -50,7 +50,7 @@ struct DataSet {
              return DataRef{nullptr, header, payload};
            },
            [this](size_t i) { return i < this->messages.size() ? messages[i].size() / 2 : 0; }, this->messages.size()},
-      record{schema, span},
+      record{schema, span, cache, callbacks},
       values{std::move(v)}
   {
   }

--- a/Framework/Utils/test/test_RootTreeWriter.cxx
+++ b/Framework/Utils/test/test_RootTreeWriter.cxx
@@ -221,9 +221,13 @@ BOOST_AUTO_TEST_CASE(test_RootTreeWriter)
     return DataRef{nullptr, static_cast<char const*>(store[2 * i]->GetData()), static_cast<char const*>(store[2 * i + 1]->GetData())};
   };
   InputSpan span{getter, store.size() / 2};
+  ObjectCache cache;
+  CallbackService callbacks;
   InputRecord inputs{
     schema,
-    span};
+    span,
+    cache,
+    callbacks};
 
   writer(inputs);
   writer.close();


### PR DESCRIPTION
Ongoing:

- [x] Understand why my changes to the CCDBApi seem to crash some other tests.
- [x] Add the fetching of the CTP and associated calculation of the timestamp based on OrbitResetTime and firstTFOrbit
- [x] Do not deserialise the objects every timeframe
- [x] Add a callback when it actually needs to happen.
- [x] Use DISTSUBTIMEFRAME / TF/TFNUM where appropriate to get the time for the data
- [x] Add ConfigParamSpec for createdNotAfter and createdNotBefore
- [x] Support for metadata on query in the InputSpec
- [x] Allow configuring the CCDB path / backend on a per input basis.
- [ ] Support for headers as result message.
- [ ] Better strategy to cleanup the cache and eventually support prefetching of CCDB objects / multiple in-fly objects for the same path.
