### PR TITLE
[QC-310] Dump a property qcConfiguration for the QC devices

### DIFF
--- a/Framework/Core/include/Framework/O2ControlLabels.h
+++ b/Framework/Core/include/Framework/O2ControlLabels.h
@@ -31,6 +31,10 @@ const extern DataProcessorLabel uniqueProxyLabel;
 // Thus, AliECS will not perform host and port allocation automatically. It takes priority over `uniqueProxyLabel`.
 const extern DataProcessorLabel preserveRawChannelsLabel;
 
+// This label makes AliECS templates add the property `qcConfiguration` to the tasks, allowing them
+// to reconfigure in init with a freshly templated config.
+const extern DataProcessorLabel qcReconfigurable;
+
 } // namespace ecs
 } // namespace o2::framework
 

--- a/Framework/Core/src/O2ControlHelpers.cxx
+++ b/Framework/Core/src/O2ControlHelpers.cxx
@@ -204,19 +204,19 @@ void dumpQcConfig(std::ostream& dumpOut, const DeviceExecution& execution, const
 {
   // get the argument `--config`
   std::string configPath;
-  auto it = std::find_if (execution.args.begin(), execution.args.end(), [&](char * v) { if (v) return strcmp(v, "--config") == 0; else return false; });
+  auto it = std::find_if(execution.args.begin(), execution.args.end(), [&](char* v) { if (v) return strcmp(v, "--config") == 0; else return false; });
 
   // get the next argument and find `/o2/components/` in it, then take what comes after in the string.
-  if(it != execution.args.end()) {
+  if (it != execution.args.end()) {
     std::string configParam = *(++it);
     std::string prefix = "/o2/components/"; // keep only the path to the config file, i.e. stuff after "/o2/components/"
     size_t pos = configParam.find(prefix);
-    if(pos != std::string::npos) {
+    if (pos != std::string::npos) {
       configPath = configParam.substr(pos + prefix.length());
     }
   }
 
-  if(implementation::isQcReconfigurable(spec)) {
+  if (implementation::isQcReconfigurable(spec)) {
     dumpOut << indLevel << "properties:\n";
     dumpOut << indLevel << indScheme << "qcConfiguration: " << configPath << "\n";
   }

--- a/Framework/Core/src/O2ControlHelpers.cxx
+++ b/Framework/Core/src/O2ControlHelpers.cxx
@@ -200,11 +200,11 @@ bool isQcReconfigurable(const DeviceSpec& spec)
   return std::find(spec.labels.begin(), spec.labels.end(), ecs::qcReconfigurable) != spec.labels.end();
 }
 
-void dumpQcConfig(std::ostream& dumpOut, const DeviceExecution& execution, const DeviceSpec& spec, const std::string& indLevel)
+void dumpProperties(std::ostream& dumpOut, const DeviceExecution& execution, const DeviceSpec& spec, const std::string& indLevel)
 {
   // get the argument `--config`
   std::string configPath;
-  auto it = std::find_if(execution.args.begin(), execution.args.end(), [&](char* v) { if (v) { return strcmp(v, "--config") == 0;} else {return false;} });
+  auto it = std::find_if(execution.args.begin(), execution.args.end(), [](char* v) { return v != nullptr && strcmp(v, "--config") == 0; });
 
   // get the next argument and find `/o2/components/` in it, then take what comes after in the string.
   if (it != execution.args.end()) {
@@ -401,7 +401,7 @@ void dumpTask(std::ostream& dumpOut, const DeviceSpec& spec, const DeviceExecuti
     }
   }
 
-  implementation::dumpQcConfig(dumpOut, execution, spec, indLevel);
+  implementation::dumpProperties(dumpOut, execution, spec, indLevel);
 
   dumpOut << indLevel << "command:\n";
   implementation::dumpCommand(dumpOut, execution, indLevel + indScheme);

--- a/Framework/Core/src/O2ControlHelpers.cxx
+++ b/Framework/Core/src/O2ControlHelpers.cxx
@@ -216,10 +216,8 @@ void dumpProperties(std::ostream& dumpOut, const DeviceExecution& execution, con
     }
   }
 
-  if (implementation::isQcReconfigurable(spec)) {
-    dumpOut << indLevel << "properties:\n";
-    dumpOut << indLevel << indScheme << "qcConfiguration: " << configPath << "\n";
-  }
+  dumpOut << indLevel << "properties:\n";
+  dumpOut << indLevel << indScheme << "qcConfiguration: " << configPath << "\n";
 }
 
 void dumpCommand(std::ostream& dumpOut, const DeviceExecution& execution, std::string indLevel)
@@ -401,7 +399,9 @@ void dumpTask(std::ostream& dumpOut, const DeviceSpec& spec, const DeviceExecuti
     }
   }
 
-  implementation::dumpProperties(dumpOut, execution, spec, indLevel);
+  if(implementation::isQcReconfigurable(spec)) {
+    implementation::dumpProperties(dumpOut, execution, spec, indLevel);
+  }
 
   dumpOut << indLevel << "command:\n";
   implementation::dumpCommand(dumpOut, execution, indLevel + indScheme);

--- a/Framework/Core/src/O2ControlHelpers.cxx
+++ b/Framework/Core/src/O2ControlHelpers.cxx
@@ -204,7 +204,7 @@ void dumpQcConfig(std::ostream& dumpOut, const DeviceExecution& execution, const
 {
   // get the argument `--config`
   std::string configPath;
-  auto it = std::find_if(execution.args.begin(), execution.args.end(), [&](char* v) { if (v) return strcmp(v, "--config") == 0; else return false; });
+  auto it = std::find_if(execution.args.begin(), execution.args.end(), [&](char* v) { if (v) { return strcmp(v, "--config") == 0;} else {return false;} });
 
   // get the next argument and find `/o2/components/` in it, then take what comes after in the string.
   if (it != execution.args.end()) {

--- a/Framework/Core/src/O2ControlHelpers.cxx
+++ b/Framework/Core/src/O2ControlHelpers.cxx
@@ -399,7 +399,7 @@ void dumpTask(std::ostream& dumpOut, const DeviceSpec& spec, const DeviceExecuti
     }
   }
 
-  if(implementation::isQcReconfigurable(spec)) {
+  if (implementation::isQcReconfigurable(spec)) {
     implementation::dumpProperties(dumpOut, execution, spec, indLevel);
   }
 

--- a/Framework/Core/src/O2ControlLabels.cxx
+++ b/Framework/Core/src/O2ControlLabels.cxx
@@ -16,4 +16,6 @@ namespace o2::framework::ecs
 
 const DataProcessorLabel uniqueProxyLabel = {"ecs-unique-proxy"};
 const DataProcessorLabel preserveRawChannelsLabel = {"ecs-preserve-raw-channels"};
+const DataProcessorLabel qcReconfigurable = {"qc-reconfigurable"};
+
 }

--- a/Framework/Core/src/O2ControlLabels.cxx
+++ b/Framework/Core/src/O2ControlLabels.cxx
@@ -17,5 +17,4 @@ namespace o2::framework::ecs
 const DataProcessorLabel uniqueProxyLabel = {"ecs-unique-proxy"};
 const DataProcessorLabel preserveRawChannelsLabel = {"ecs-preserve-raw-channels"};
 const DataProcessorLabel qcReconfigurable = {"qc-reconfigurable"};
-
 }


### PR DESCRIPTION
Introduce a new label `qc-reconfigurable`.
Dump a property in the qc tasks pointing to the file in consul to reconfigure the tasks.