### PR TITLE
O2-2743: Enable Cerenkov photons for HMP

### DIFF
--- a/Detectors/HMPID/simulation/include/HMPIDSimulation/Detector.h
+++ b/Detectors/HMPID/simulation/include/HMPIDSimulation/Detector.h
@@ -50,6 +50,7 @@ class Detector : public o2::base::DetImpl<Detector>
   void IdealPositionCradle(int iCh, TGeoHMatrix* pMatrix);
   void createMaterials();
   void ConstructGeometry() override;
+  void ConstructOpGeometry() override;
   void defineOpticalProperties();
   void EndOfEvent() override { Reset(); }
 


### PR DESCRIPTION
Cerenkov/optical properties where defined in the code,
but not actually called from anywhere.

Call needs to be done from within ConstructOpGeometry() hook.

Slight adjustment of code since fMC is not available during
ConstructOpGeometry() time and so we fall back to VirtualMC::GetMC()
singleton.