### PR TITLE
DPL Analysis: introduce slice/array self indices

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -249,8 +249,15 @@ class ColumnIterator : ChunkingPolicy
   decltype(auto) operator*() const
   {
     if constexpr (ChunkingPolicy::chunked) {
-      if (O2_BUILTIN_UNLIKELY(((mCurrent + (*mCurrentPos >> SCALE_FACTOR)) >= mLast))) {
-        nextChunk();
+      if constexpr (std::is_same_v<arrow_array_for_t<T>, arrow::ListArray>) {
+        auto list = std::static_pointer_cast<arrow::ListArray>(mColumn->chunk(mCurrentChunk));
+        if (O2_BUILTIN_UNLIKELY(*mCurrentPos - mFirstIndex >= list->length())) {
+          nextChunk();
+        }
+      } else {
+        if (O2_BUILTIN_UNLIKELY(((mCurrent + (*mCurrentPos >> SCALE_FACTOR)) >= mLast))) {
+          nextChunk();
+        }
       }
     }
     if constexpr (std::is_same_v<bool, std::decay_t<T>>) {
@@ -260,7 +267,7 @@ class ColumnIterator : ChunkingPolicy
       auto list = std::static_pointer_cast<arrow::ListArray>(mColumn->chunk(mCurrentChunk));
       auto offset = list->value_offset(*mCurrentPos - mFirstIndex);
       auto length = list->value_length(*mCurrentPos - mFirstIndex);
-      return gsl::span{mCurrent + offset, mCurrent + (offset + length)};
+      return gsl::span{mCurrent + mFirstIndex + offset, mCurrent + mFirstIndex + (offset + length)};
     } else {
       return *(mCurrent + (*mCurrentPos >> SCALE_FACTOR));
     }
@@ -1753,6 +1760,119 @@ constexpr auto is_binding_compatible_v()
                                                                       o2::framework::expressions::selectArrowType<_Type_>() }
 
 #define DECLARE_SOA_SELF_INDEX_COLUMN(_Name_, _Getter_) DECLARE_SOA_SELF_INDEX_COLUMN_FULL(_Name_, _Getter_, int32_t, #_Name_)
+/// SELF SLICE
+#define DECLARE_SOA_SELF_SLICE_INDEX_COLUMN_FULL(_Name_, _Getter_, _Type_, _Label_)                     \
+  struct _Name_##IdSlice : o2::soa::Column<_Type_[2], _Name_##IdSlice> {                                \
+    static_assert(std::is_integral_v<_Type_>, "Index type must be integral");                           \
+    static constexpr const char* mLabel = "fIndexSlice" _Label_;                                        \
+    using base = o2::soa::Column<_Type_[2], _Name_##IdSlice>;                                           \
+    using type = _Type_[2];                                                                             \
+    using column_t = _Name_##IdSlice;                                                                   \
+    using self_index_t = std::true_type;                                                                \
+    _Name_##IdSlice(arrow::ChunkedArray const* column)                                                  \
+      : o2::soa::Column<_Type_[2], _Name_##IdSlice>(o2::soa::ColumnIterator<type>(column))              \
+    {                                                                                                   \
+    }                                                                                                   \
+                                                                                                        \
+    _Name_##IdSlice() = default;                                                                        \
+    _Name_##IdSlice(_Name_##IdSlice const& other) = default;                                            \
+    _Name_##IdSlice& operator=(_Name_##IdSlice const& other) = default;                                 \
+    std::array<_Type_, 2> inline getIds() const                                                         \
+    {                                                                                                   \
+      return _Getter_##Ids();                                                                           \
+    }                                                                                                   \
+                                                                                                        \
+    bool has_##_Getter_() const                                                                         \
+    {                                                                                                   \
+      return (*mColumnIterator)[0] >= 0 && (*mColumnIterator)[1] >= 0;                                  \
+    }                                                                                                   \
+                                                                                                        \
+    std::array<_Type_, 2> _Getter_##Ids() const                                                         \
+    {                                                                                                   \
+      return std::array{(*mColumnIterator)[0], (*mColumnIterator)[1]};                                  \
+    }                                                                                                   \
+                                                                                                        \
+    template <typename T>                                                                               \
+    auto _Getter_##_as() const                                                                          \
+    {                                                                                                   \
+      assert(mBinding != nullptr);                                                                      \
+      if (O2_BUILTIN_UNLIKELY(!has_##_Getter_())) {                                                     \
+        return static_cast<T const*>(mBinding)->emptySlice();                                           \
+      }                                                                                                 \
+      auto t = static_cast<T const*>(mBinding)->rawSlice((*mColumnIterator)[0], (*mColumnIterator)[1]); \
+      static_cast<T const*>(mBinding)->copyIndexBindings(t);                                            \
+      return t;                                                                                         \
+    }                                                                                                   \
+                                                                                                        \
+    bool setCurrentRaw(void const* current)                                                             \
+    {                                                                                                   \
+      this->mBinding = current;                                                                         \
+      return true;                                                                                      \
+    }                                                                                                   \
+    void const* getCurrentRaw() const { return mBinding; }                                              \
+    void const* mBinding = nullptr;                                                                     \
+  };
+
+#define DECLARE_SOA_SELF_SLICE_INDEX_COLUMN(_Name_, _Getter_) DECLARE_SOA_SELF_SLICE_INDEX_COLUMN_FULL(_Name_, _Getter_, int32_t, #_Name_)
+/// SELF ARRAY
+#define DECLARE_SOA_SELF_ARRAY_INDEX_COLUMN_FULL(_Name_, _Getter_, _Type_, _Label_)              \
+  struct _Name_##Ids : o2::soa::Column<std::vector<_Type_>, _Name_##Ids> {                       \
+    static_assert(std::is_integral_v<_Type_>, "Index type must be integral");                    \
+    static constexpr const char* mLabel = "fIndexArray" _Label_;                                 \
+    using base = o2::soa::Column<std::vector<_Type_>, _Name_##Ids>;                              \
+    using type = std::vector<_Type_>;                                                            \
+    using column_t = _Name_##Ids;                                                                \
+    using self_index_t = std::true_type;                                                         \
+    _Name_##Ids(arrow::ChunkedArray const* column)                                               \
+      : o2::soa::Column<std::vector<_Type_>, _Name_##Ids>(o2::soa::ColumnIterator<type>(column)) \
+    {                                                                                            \
+    }                                                                                            \
+                                                                                                 \
+    _Name_##Ids() = default;                                                                     \
+    _Name_##Ids(_Name_##Ids const& other) = default;                                             \
+    _Name_##Ids& operator=(_Name_##Ids const& other) = default;                                  \
+    gsl::span<const _Type_> inline getIds() const                                                \
+    {                                                                                            \
+      return _Getter_##Ids();                                                                    \
+    }                                                                                            \
+                                                                                                 \
+    gsl::span<const _Type_> _Getter_##Ids() const                                                \
+    {                                                                                            \
+      return *mColumnIterator;                                                                   \
+    }                                                                                            \
+                                                                                                 \
+    bool has_##_Getter_() const                                                                  \
+    {                                                                                            \
+      return !(*mColumnIterator).empty();                                                        \
+    }                                                                                            \
+                                                                                                 \
+    template <typename T>                                                                        \
+    auto _Getter_##_as() const                                                                   \
+    {                                                                                            \
+      assert(mBinding != nullptr);                                                               \
+      return getIterators<T>();                                                                  \
+    }                                                                                            \
+                                                                                                 \
+    template <typename T>                                                                        \
+    auto getIterators() const                                                                    \
+    {                                                                                            \
+      auto result = std::vector<typename T::unfiltered_iterator>();                              \
+      for (auto& i : *mColumnIterator) {                                                         \
+        result.push_back(static_cast<T const*>(mBinding)->rawIteratorAt(i));                     \
+      }                                                                                          \
+      return result;                                                                             \
+    }                                                                                            \
+                                                                                                 \
+    bool setCurrentRaw(void const* current)                                                      \
+    {                                                                                            \
+      this->mBinding = current;                                                                  \
+      return true;                                                                               \
+    }                                                                                            \
+    void const* getCurrentRaw() const { return mBinding; }                                       \
+    void const* mBinding = nullptr;                                                              \
+  };
+
+#define DECLARE_SOA_SELF_ARRAY_INDEX_COLUMN(_Name_, _Getter_) DECLARE_SOA_SELF_ARRAY_INDEX_COLUMN_FULL(_Name_, _Getter_, int32_t, #_Name_)
 /// A dynamic column is a column whose values are derived
 /// from those of other real columns. These can be used for
 /// example to provide different coordinate systems (e.g. polar,

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -807,6 +807,8 @@ DECLARE_SOA_SELF_INDEX_COLUMN_FULL(Mother0, mother0, int, "McParticles_Mother0")
 DECLARE_SOA_SELF_INDEX_COLUMN_FULL(Mother1, mother1, int, "McParticles_Mother1");       //! Track index of the last mother
 DECLARE_SOA_SELF_INDEX_COLUMN_FULL(Daughter0, daughter0, int, "McParticles_Daughter0"); //! Track index of the first daugther
 DECLARE_SOA_SELF_INDEX_COLUMN_FULL(Daughter1, daughter1, int, "McParticles_Daughter1"); //! Track index of the last daugther
+DECLARE_SOA_SELF_SLICE_INDEX_COLUMN(Daughters, daughters);                              //! Daughter tracks (possibly empty) slice
+DECLARE_SOA_SELF_ARRAY_INDEX_COLUMN(Mothers, mothers);                                  //! Mother tracks (possible empty) array
 DECLARE_SOA_COLUMN(Weight, weight, float);                                              //! MC weight
 DECLARE_SOA_COLUMN(Px, px, float);                                                      //! Momentum in x in GeV/c
 DECLARE_SOA_COLUMN(Py, py, float);                                                      //! Momentum in y in GeV/c


### PR DESCRIPTION
* Slice self index: return slice of the same table (can be empty)
* Array self index: return a vector of iterators to the same table (can be empty)
* Update test
* Fix corner case for VLAs with many empty entries resulting in trying to move to next chunk erroneously

@jgrosseo I've also added the definitions for MC Particle table columns; this should also fix the crash with some data files that we've found earlier