### PR TITLE
fix the way ambigous tracks are written in AODs for muons

### DIFF
--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -290,17 +290,10 @@ void AODProducerWorkflowDPL::fillTrackTablesPerCollision(int collisionID,
           // FwdTracks tracks are treated separately since they are stored in a different table
           const auto& track = data.getMCHTrack(trackIndex);
           if (collisionID < 0) {
-            InteractionRecord meanIR;
-            auto rofsMCH = data.getMCHTracksROFRecords();
-            for (const auto& rof : rofsMCH) {
-              if (trackIndex >= rof.getFirstIdx() && trackIndex <= rof.getLastIdx()) {
-                meanIR = rof.getBCData() + rof.getBCWidth() / 2;
-              }
-              math_utils::Point3D<double> vertex{};
-              // FIXME: should we get better
-              // than {0,0,0} as vertex here ?
-              addToFwdTracksTable(fwdTracksCursor, fwdTracksCovCursor, track, -1, vertex);
-            }
+            // FIXME: should we get better
+            // than {0,0,0} as vertex here ?
+            math_utils::Point3D<double> vertex{};
+            addToFwdTracksTable(fwdTracksCursor, fwdTracksCovCursor, track, collisionID, vertex);
           } else {
             math_utils::Point3D<double> vtx{vertex.getX(),
                                             vertex.getY(), vertex.getZ()};


### PR DESCRIPTION
This is an attempt to fix the way ambiguous muon tracks are written in the AOD. In the current version, each ambiguous track is written for all compatible ROFs. This create incompatibility in track table and MC label length at a later stage.

In this fix, the loop over ROF is removed as it should not be necessary. Compatible ROFs for a given track can be find back using track time and track time error at later stages.

I have left the vertex to 0 0 0 for the moment. This could be change with a better value later (average BS x, y, z position?)
