### PR TITLE
Add ShmManager utility

### DIFF
--- a/Utilities/ShmManager/CMakeLists.txt
+++ b/Utilities/ShmManager/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+# Copyright 2019-2022 CERN and copyright holders of ALICE O2.
 # See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 # All rights not expressly granted are reserved.
 #
@@ -9,11 +9,7 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-add_subdirectory(DataSampling)
-add_subdirectory(DataCompression)
-add_subdirectory(Mergers)
-add_subdirectory(PCG)
-add_subdirectory(rANS)
-add_subdirectory(Tools)
-add_subdirectory(EPNMonitoring)
-add_subdirectory(ShmManager)
+o2_add_executable(shm-manager
+                  COMPONENT_NAME epn
+                  SOURCES src/ShmManager.cxx
+                  PUBLIC_LINK_LIBRARIES FairMQ::FairMQ)

--- a/Utilities/ShmManager/src/ShmManager.cxx
+++ b/Utilities/ShmManager/src/ShmManager.cxx
@@ -1,0 +1,161 @@
+// Copyright 2019-2022 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <fairmq/shmem/Common.h>
+#include <fairmq/shmem/UnmanagedRegion.h>
+#include <fairmq/shmem/Segment.h>
+#include <fairmq/shmem/Monitor.h>
+
+#include <fairmq/tools/Unique.h>
+
+#include <fairlogger/Logger.h>
+
+#include <boost/algorithm/string.hpp>
+#include <boost/program_options.hpp>
+
+#include <csignal>
+
+#include <chrono>
+#include <map>
+#include <string>
+#include <thread>
+
+using namespace std;
+using namespace boost::program_options;
+
+namespace
+{
+volatile sig_atomic_t gStopping = 0;
+}
+
+void signalHandler(int /* signal */)
+{
+  gStopping = 1;
+}
+
+struct ShmManager {
+  ShmManager(uint64_t _shmId, const vector<string>& _segments, const vector<string>& _regions)
+    : shmId(fair::mq::shmem::makeShmIdStr(_shmId))
+  {
+    AddSegments(_segments);
+    AddRegions(_regions);
+  }
+
+  void AddSegments(const vector<string>& _segments)
+  {
+    for (const auto& s : _segments) {
+      vector<string> conf;
+      boost::algorithm::split(conf, s, boost::algorithm::is_any_of(","));
+      if (conf.size() != 2) {
+        LOG(error) << "incorrect format for --segments. Expecting pairs of <id>,<size>.";
+        fair::mq::shmem::Monitor::Cleanup(fair::mq::shmem::ShmId{shmId});
+        throw runtime_error("incorrect format for --segments. Expecting pairs of <id>,<size>.");
+      }
+      uint16_t id = stoi(conf.at(0));
+      uint64_t size = stoull(conf.at(1));
+      auto ret = segments.emplace(id, fair::mq::shmem::Segment(shmId, id, size, fair::mq::shmem::rbTreeBestFit));
+      fair::mq::shmem::Segment& segment = ret.first->second;
+      LOG(info) << "Created segment " << id << " of size " << segment.GetSize() << ", starting at " << segment.GetData() << ". Locking...";
+      segment.Lock();
+      LOG(info) << "Done.";
+      LOG(info) << "Zeroing...";
+      segment.Zero();
+      LOG(info) << "Done.";
+    }
+  }
+
+  void AddRegions(const vector<string>& _regions)
+  {
+    for (const auto& r : _regions) {
+      vector<string> conf;
+      boost::algorithm::split(conf, r, boost::algorithm::is_any_of(","));
+      if (conf.size() != 2) {
+        LOG(error) << "incorrect format for --regions. Expecting pairs of <id>,<size>.";
+        fair::mq::shmem::Monitor::Cleanup(fair::mq::shmem::ShmId{shmId});
+        throw runtime_error("incorrect format for --regions. Expecting pairs of <id>,<size>.");
+      }
+      uint16_t id = stoi(conf.at(0));
+      uint64_t size = stoull(conf.at(1));
+      auto ret = regions.emplace(id, make_unique<fair::mq::shmem::UnmanagedRegion>(shmId, id, size));
+      fair::mq::shmem::UnmanagedRegion& region = *(ret.first->second);
+      LOG(info) << "Created unamanged region " << id << " of size " << region.GetSize() << ", starting at " << region.GetData() << ". Locking...";
+      region.Lock();
+      LOG(info) << "Done.";
+      LOG(info) << "Zeroing...";
+      region.Zero();
+      LOG(info) << "Done.";
+    }
+  }
+
+  void ResetContent()
+  {
+    fair::mq::shmem::Monitor::ResetContent(fair::mq::shmem::ShmId{shmId});
+  }
+
+  void FullReset()
+  {
+    segments.clear();
+    regions.clear();
+    fair::mq::shmem::Monitor::Cleanup(fair::mq::shmem::ShmId{shmId});
+  }
+
+  ~ShmManager()
+  {
+    // clean all segments, regions and any other shmem objects belonging to this shmId
+    fair::mq::shmem::Monitor::Cleanup(fair::mq::shmem::ShmId{shmId});
+  }
+
+  std::string shmId;
+  map<uint16_t, fair::mq::shmem::Segment> segments;
+  map<uint16_t, unique_ptr<fair::mq::shmem::UnmanagedRegion>> regions;
+};
+
+int main(int argc, char** argv)
+{
+  fair::Logger::SetConsoleColor(true);
+
+  signal(SIGINT, signalHandler);
+  signal(SIGTERM, signalHandler);
+
+  try {
+    uint64_t shmId = 0;
+    vector<string> segments;
+    vector<string> regions;
+
+    options_description desc("Options");
+    desc.add_options()("shmid", value<uint64_t>(&shmId)->required(), "Shm id")("segments", value<vector<string>>(&segments)->multitoken()->composing(), "Segments, as <id>,<size> <id>,<size> <id>,<size> ...")("regions", value<vector<string>>(&regions)->multitoken()->composing(), "Regions, as <id>,<size> <id>,<size> <id>,<size> ...")("help,h", "Print help");
+
+    variables_map vm;
+    store(parse_command_line(argc, argv, desc), vm);
+
+    if (vm.count("help")) {
+      LOG(info) << "ShmManager"
+                << "\n"
+                << desc;
+      return 0;
+    }
+
+    notify(vm);
+
+    ShmManager shmManager(shmId, segments, regions);
+
+    while (!gStopping) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+
+    LOG(info) << "stopping.";
+  } catch (exception& e) {
+    LOG(error) << "Exception reached the top of main: " << e.what() << ", exiting";
+    return 2;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
- Starting code for the shm utility needed for R3C-646.
@davidrohr This can be already using in this form. Example config:
```
./shm-manager --shmid 1 --segments 1,1000 2,3000 --regions 1,2000 2,5000
[INFO] Created segment 1 of size 1000, starting at 0x7f3277c8e000. Locking...
[INFO] Done.
[INFO] Zeroing...
[INFO] Done.
[INFO] Created segment 2 of size 3000, starting at 0x7f3277c8d000. Locking...
[INFO] Done.
[INFO] Zeroing...
[INFO] Done.
[INFO] Created unamanged region 1 of size 2000, starting at 0x7f3277c8c000. Locking...
[INFO] Done.
[INFO] Zeroing...
[INFO] Done.
[INFO] Created unamanged region 2 of size 5000, starting at 0x7f3277c8a000. Locking...
[INFO] Done.
[INFO] Zeroing...
[INFO] Done.
^C[INFO] stopping.
[INFO] Cleaning up for shared memory id '00000001'...
[INFO] Found 2 unmanaged regions...
[INFO] Found RegionInfo with path: '', flags: 0, fDestroyed: 0.
[INFO] Successfully removed 'fmq_00000001_rg_2'.
[INFO] Found RegionInfo with path: '', flags: 0, fDestroyed: 0.
[INFO] Successfully removed 'fmq_00000001_rg_1'.
[INFO] Found 2 managed segments...
[INFO] Successfully removed 'fmq_00000001_m_2'.
[INFO] Successfully removed 'fmq_00000001_m_1'.
[INFO] Successfully removed 'fmq_00000001_mng'.
```