### PR TITLE
Improving sensitive hit creation for FT0 in Detector.cxx

### DIFF
--- a/Detectors/FIT/FT0/simulation/include/FT0Simulation/Detector.h
+++ b/Detectors/FIT/FT0/simulation/include/FT0Simulation/Detector.h
@@ -247,6 +247,11 @@ class Detector : public o2::base::DetImpl<Detector>
 
   /// Container for data points
   std::vector<o2::ft0::HitType>* mHits = nullptr;
+  
+  // Define volume IDs
+  int regVolID = -1; 
+  int topVolID = -1; 
+  int mtoVolID = -1;
 
   /// Define the sensitive volumes of the geometry
   void defineSensitiveVolumes();

--- a/Detectors/FIT/FT0/simulation/include/FT0Simulation/Detector.h
+++ b/Detectors/FIT/FT0/simulation/include/FT0Simulation/Detector.h
@@ -249,9 +249,9 @@ class Detector : public o2::base::DetImpl<Detector>
   std::vector<o2::ft0::HitType>* mHits = nullptr;
 
   // Define volume IDs
-  int regVolID = -1;
-  int topVolID = -1;
-  int mtoVolID = -1;
+  int mREGVolID = -1;
+  int mTOPVolID = -1;
+  int mMTOVolID = -1;
 
   /// Define the sensitive volumes of the geometry
   void defineSensitiveVolumes();

--- a/Detectors/FIT/FT0/simulation/include/FT0Simulation/Detector.h
+++ b/Detectors/FIT/FT0/simulation/include/FT0Simulation/Detector.h
@@ -247,10 +247,10 @@ class Detector : public o2::base::DetImpl<Detector>
 
   /// Container for data points
   std::vector<o2::ft0::HitType>* mHits = nullptr;
-  
+
   // Define volume IDs
-  int regVolID = -1; 
-  int topVolID = -1; 
+  int regVolID = -1;
+  int topVolID = -1;
   int mtoVolID = -1;
 
   /// Define the sensitive volumes of the geometry

--- a/Detectors/FIT/FT0/simulation/src/Detector.cxx
+++ b/Detectors/FIT/FT0/simulation/src/Detector.cxx
@@ -68,6 +68,7 @@ void Detector::InitializeO2Detector()
     LOG(warn) << "@@@@ Sensitive volume 0REG not found!!!!!!!!";
   } else {
     AddSensitiveVolume(v);
+    regVolID = v->GetNumber();
   }
 
   TGeoVolume* vrad = gGeoManager->GetVolume("0TOP");
@@ -75,12 +76,14 @@ void Detector::InitializeO2Detector()
     LOG(warn) << "@@@@ Sensitive radiator not found!!!!!!!!";
   } else {
     AddSensitiveVolume(vrad);
+    topVolID = vrad->GetNumber();
   }
   TGeoVolume* vmcp = gGeoManager->GetVolume("0MTO");
   if (vmcp == nullptr) {
     LOG(warn) << "@@@@ Sensitive MCP glass not found!!!!!!!!";
   } else {
     AddSensitiveVolume(vmcp);
+    mtoVolID = vmcp->GetNumber();
   }
 }
 
@@ -872,9 +875,6 @@ Bool_t Detector::ProcessHits(FairVolume* v)
 
   Int_t copy;
   Int_t volID = fMC->CurrentVolID(copy);
-  Int_t volREG = fMC->VolId("0REG");
-  Int_t volTOP = fMC->VolId("0TOP");
-  Int_t volMTO = fMC->VolId("0MTO");
 
   TVirtualMCStack* stack = fMC->GetStack();
   Int_t quadrant, mcp;
@@ -887,14 +887,14 @@ Bool_t Detector::ProcessHits(FairVolume* v)
     int trackID = stack->GetCurrentTrackNumber();
     int detID = mSim2LUT[4 * mcp + quadrant - 1];
     int iPart = fMC->TrackPid();
-    if (fMC->TrackCharge() && volID == volREG) { //charge particles for MCtrue
+    if (fMC->TrackCharge() && volID == regVolID) { //charge particles for MCtrue
       AddHit(x, y, z, time, 10, trackID, detID);
     }
     if (iPart == 50000050) { // If particle is photon then ...
       float etot = fMC->Etot();
       float enDep = fMC->Edep();
       Int_t parentID = stack->GetCurrentTrack()->GetMother(0);
-      if (volID == volTOP) {
+      if (volID == topVolID) {
         if (!RegisterPhotoE(etot)) {
           fMC->StopTrack();
           return kFALSE;
@@ -902,7 +902,7 @@ Bool_t Detector::ProcessHits(FairVolume* v)
         mTrackIdTop = trackID;
       }
 
-      if (volID == volMTO) {
+      if (volID == mtoVolID) {
         if (trackID != mTrackIdTop) {
           if (!RegisterPhotoE(etot)) {
             fMC->StopTrack();
@@ -912,7 +912,7 @@ Bool_t Detector::ProcessHits(FairVolume* v)
         }
       }
 
-      if (volID == volREG) {
+      if (volID == regVolID) {
         if (trackID != mTrackIdTop && trackID != mTrackIdMCPtop) {
           if (RegisterPhotoE(etot)) {
             AddHit(x, y, z, time, enDep, parentID, detID);

--- a/Detectors/FIT/FT0/simulation/src/Detector.cxx
+++ b/Detectors/FIT/FT0/simulation/src/Detector.cxx
@@ -870,7 +870,11 @@ void Detector::defineFrameTransformations()
 Bool_t Detector::ProcessHits(FairVolume* v)
 {
 
-  TString volname = fMC->CurrentVolName();
+  Int_t copy;
+  Int_t volID = fMC->CurrentVolID(copy);
+  Int_t volREG = fMC->VolId("0REG");
+  Int_t volTOP = fMC->VolId("0TOP");
+  Int_t volMTO = fMC->VolId("0MTO");
 
   TVirtualMCStack* stack = fMC->GetStack();
   Int_t quadrant, mcp;
@@ -882,15 +886,15 @@ Bool_t Detector::ProcessHits(FairVolume* v)
     float time = fMC->TrackTime() * 1.0e9; //time from seconds to ns
     int trackID = stack->GetCurrentTrackNumber();
     int detID = mSim2LUT[4 * mcp + quadrant - 1];
-    float etot = fMC->Etot();
     int iPart = fMC->TrackPid();
-    float enDep = fMC->Edep();
-    Int_t parentID = stack->GetCurrentTrack()->GetMother(0);
-    if (fMC->TrackCharge() && volname.Contains("0REG")) { //charge particles for MCtrue
+    if (fMC->TrackCharge() && volID == volREG) { //charge particles for MCtrue
       AddHit(x, y, z, time, 10, trackID, detID);
     }
-    if (iPart == 50000050) { // If particles is photon then ...
-      if (volname.Contains("0TOP")) {
+    if (iPart == 50000050) { // If particle is photon then ...
+      float etot = fMC->Etot();
+      float enDep = fMC->Edep();
+      Int_t parentID = stack->GetCurrentTrack()->GetMother(0);
+      if (volID == volTOP) {
         if (!RegisterPhotoE(etot)) {
           fMC->StopTrack();
           return kFALSE;
@@ -898,7 +902,7 @@ Bool_t Detector::ProcessHits(FairVolume* v)
         mTrackIdTop = trackID;
       }
 
-      if (volname.Contains("0MTO")) {
+      if (volID == volMTO) {
         if (trackID != mTrackIdTop) {
           if (!RegisterPhotoE(etot)) {
             fMC->StopTrack();
@@ -908,7 +912,7 @@ Bool_t Detector::ProcessHits(FairVolume* v)
         }
       }
 
-      if (volname.Contains("0REG")) {
+      if (volID == volREG) {
         if (trackID != mTrackIdTop && trackID != mTrackIdMCPtop) {
           if (RegisterPhotoE(etot)) {
             AddHit(x, y, z, time, enDep, parentID, detID);

--- a/Detectors/FIT/FT0/simulation/src/Detector.cxx
+++ b/Detectors/FIT/FT0/simulation/src/Detector.cxx
@@ -68,7 +68,7 @@ void Detector::InitializeO2Detector()
     LOG(warn) << "@@@@ Sensitive volume 0REG not found!!!!!!!!";
   } else {
     AddSensitiveVolume(v);
-    regVolID = v->GetNumber();
+    mREGVolID = v->GetNumber();
   }
 
   TGeoVolume* vrad = gGeoManager->GetVolume("0TOP");
@@ -76,14 +76,14 @@ void Detector::InitializeO2Detector()
     LOG(warn) << "@@@@ Sensitive radiator not found!!!!!!!!";
   } else {
     AddSensitiveVolume(vrad);
-    topVolID = vrad->GetNumber();
+    mTOPVolID = vrad->GetNumber();
   }
   TGeoVolume* vmcp = gGeoManager->GetVolume("0MTO");
   if (vmcp == nullptr) {
     LOG(warn) << "@@@@ Sensitive MCP glass not found!!!!!!!!";
   } else {
     AddSensitiveVolume(vmcp);
-    mtoVolID = vmcp->GetNumber();
+    mMTOVolID = vmcp->GetNumber();
   }
 }
 
@@ -887,14 +887,14 @@ Bool_t Detector::ProcessHits(FairVolume* v)
     int trackID = stack->GetCurrentTrackNumber();
     int detID = mSim2LUT[4 * mcp + quadrant - 1];
     int iPart = fMC->TrackPid();
-    if (fMC->TrackCharge() && volID == regVolID) { //charge particles for MCtrue
+    if (fMC->TrackCharge() && volID == mREGVolID) { //charge particles for MCtrue
       AddHit(x, y, z, time, 10, trackID, detID);
     }
     if (iPart == 50000050) { // If particle is photon then ...
       float etot = fMC->Etot();
       float enDep = fMC->Edep();
       Int_t parentID = stack->GetCurrentTrack()->GetMother(0);
-      if (volID == topVolID) {
+      if (volID == mTOPVolID) {
         if (!RegisterPhotoE(etot)) {
           fMC->StopTrack();
           return kFALSE;
@@ -902,7 +902,7 @@ Bool_t Detector::ProcessHits(FairVolume* v)
         mTrackIdTop = trackID;
       }
 
-      if (volID == mtoVolID) {
+      if (volID == mMTOVolID) {
         if (trackID != mTrackIdTop) {
           if (!RegisterPhotoE(etot)) {
             fMC->StopTrack();
@@ -912,7 +912,7 @@ Bool_t Detector::ProcessHits(FairVolume* v)
         }
       }
 
-      if (volID == regVolID) {
+      if (volID == mREGVolID) {
         if (trackID != mTrackIdTop && trackID != mTrackIdMCPtop) {
           if (RegisterPhotoE(etot)) {
             AddHit(x, y, z, time, enDep, parentID, detID);


### PR DESCRIPTION
- The Detector::ProcessHits(FairVolume* v) function had too many string comparisons which made it slow. The comparison was modified to be based on integer IDs instead.
- The calculation of some quantities (etot, enDep, parentID) were moved inside the relevant if() statement block (i.e. when the particle is a photon), so they are only calculated when necessary.