### PR TITLE
Fix data races in simulation merging using TBB

### DIFF
--- a/Detectors/Base/CMakeLists.txt
+++ b/Detectors/Base/CMakeLists.txt
@@ -33,6 +33,7 @@ o2_add_library(DetectorsBase
                                      O2::SimConfig
                                      O2::CCDB
                                      MC::VMC
+                                     TBB::tbb
                PRIVATE_INCLUDE_DIRECTORIES ${CMAKE_SOURCE_DIR}/GPU/GPUTracking/Merger # Must not link to avoid cyclic dependency
                              )
 

--- a/dependencies/FindTBB.cmake
+++ b/dependencies/FindTBB.cmake
@@ -1,0 +1,35 @@
+# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# All rights not expressly granted are reserved.
+#
+# This software is distributed under the terms of the GNU General Public
+# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+set(PKGNAME ${CMAKE_FIND_PACKAGE_NAME})
+string(TOUPPER ${PKGNAME} PKGENVNAME)
+
+find_library(${PKGNAME}_LIBRARY_SHARED
+             NAMES libtbb.so libtbb.dylib)
+
+if(${PKGNAME}_LIBRARY_SHARED)
+  add_library(tbb SHARED IMPORTED)
+  set_target_properties(tbb
+                        PROPERTIES IMPORTED_LOCATION
+                                   ${${PKGNAME}_LIBRARY_SHARED})
+  # Promote the imported target to global visibility (so we can alias it)
+  set_target_properties(tbb PROPERTIES IMPORTED_GLOBAL TRUE)
+  add_library(TBB::tbb ALIAS tbb)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(${PKGNAME}
+                                  REQUIRED_VARS ${PKGNAME}_LIBRARY_SHARED)
+
+mark_as_advanced(${PKGNAME}_LIBRARY_SHARED)
+
+unset(PKGNAME)
+unset(PKGENVNAME)

--- a/dependencies/O2Dependencies.cmake
+++ b/dependencies/O2Dependencies.cmake
@@ -98,6 +98,10 @@ set_package_properties(RapidJSON PROPERTIES TYPE REQUIRED)
 find_package(CURL)
 set_package_properties(CURL PROPERTIES TYPE REQUIRED)
 
+set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
+find_package(TBB)
+set_package_properties(TBB PROPERTIES TYPE REQUIRED)
+
 find_package(JAliEnROOT MODULE)
 set_package_properties(JAliEnROOT PROPERTIES TYPE RECOMMENDED)
 


### PR DESCRIPTION
std::unordered_map is not thread-safe, when one
thread is inserting and another reading.

Fix this by using dedicated and efficient
thread-safe hashmaps from TBB.
This is preferred over manual access management with
mutexes.
