### PR TITLE
TPC: Decouple BetheBloch from Detector class

### DIFF
--- a/DataFormats/Detectors/TPC/CMakeLists.txt
+++ b/DataFormats/Detectors/TPC/CMakeLists.txt
@@ -62,7 +62,8 @@ o2_target_root_dictionary(
           include/DataFormatsTPC/CalibdEdxCorrection.h
           include/DataFormatsTPC/CalibdEdxTrackTopologyPol.h
           include/DataFormatsTPC/CalibdEdxContainer.h
-          include/DataFormatsTPC/CalibdEdxTrackTopologySpline.h)
+          include/DataFormatsTPC/CalibdEdxTrackTopologySpline.h
+          include/DataFormatsTPC/BetheBlochAleph.h)
 
 o2_add_test(
   ClusterNative

--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/BetheBlochAleph.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/BetheBlochAleph.h
@@ -1,0 +1,37 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef AliceO2_TPC_BETHEBLOCH_H_
+#define AliceO2_TPC_BETHEBLOCH_H_
+
+#include <cmath>
+
+namespace o2
+{
+namespace tpc
+{
+
+template <typename T>
+inline T BetheBlochAleph(T bg, T kp1, T kp2, T kp3, T kp4, T kp5)
+{
+  T beta = bg / std::sqrt(static_cast<T>(1.) + bg * bg);
+
+  T aa = std::pow(beta, kp4);
+  T bb = std::pow(static_cast<T>(1.) / bg, kp5);
+  bb = std::log(kp3 + bb);
+
+  return (kp2 - aa - bb) * kp1 / aa;
+}
+
+} // namespace tpc
+} // namespace o2
+
+#endif

--- a/Detectors/TPC/simulation/include/TPCSimulation/Detector.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/Detector.h
@@ -19,6 +19,7 @@
 
 #include "TPCSimulation/Point.h"
 #include "TPCBase/Sector.h"
+#include "DataFormatsTPC/BetheBlochAleph.h"
 
 class FairVolume; // lines 10-10
 
@@ -115,7 +116,10 @@ class Detector : public o2::base::DetImpl<Detector>
   /// @param kp* Parameters for the ALICE TPC
   /// @return Bethe-Bloch value in MIP units
   template <typename T>
-  static T BetheBlochAleph(T bg, T kp1, T kp2, T kp3, T kp4, T kp5);
+  static T BetheBlochAleph(T bg, T kp1, T kp2, T kp3, T kp4, T kp5)
+  {
+    return o2::tpc::BetheBlochAleph(bg, kp1, kp2, kp3, kp4, kp5);
+  }
 
   /// Copied from AliRoot - should go to someplace else
   /// Function to generate random numbers according to Gamma function
@@ -187,18 +191,6 @@ class Detector : public o2::base::DetImpl<Detector>
   friend class o2::base::DetImpl;
   ClassDefOverride(Detector, 1);
 };
-
-template <typename T>
-inline T Detector::BetheBlochAleph(T bg, T kp1, T kp2, T kp3, T kp4, T kp5)
-{
-  T beta = bg / std::sqrt(static_cast<T>(1.) + bg * bg);
-
-  T aa = std::pow(beta, kp4);
-  T bb = std::pow(static_cast<T>(1.) / bg, kp5);
-  bb = std::log(kp3 + bb);
-
-  return (kp2 - aa - bb) * kp1 / aa;
-}
 
 } // namespace tpc
 } // namespace o2


### PR DESCRIPTION
Provide function in standalone header. Clients (such as O2Physics)
should not have to include the whole TPC detector to have access to
this function.