### PR TITLE
[O2-2749] Fix MCH mapping library implementations link options on Ubuntu

### DIFF
--- a/Detectors/MUON/MCH/Mapping/Impl3/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Mapping/Impl3/CMakeLists.txt
@@ -48,4 +48,6 @@ if(APPLE)
                 TARGET ${targetName} POST_BUILD
                 COMMAND ${script} $<TARGET_LINKER_FILE:${targetName}> 19
                 COMMENT "Checking number of exported symbols in the library")
+else()
+        target_link_options(${targetName} PUBLIC "LINKER:--no-as-needed")
 endif()

--- a/Detectors/MUON/MCH/Mapping/Impl4/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Mapping/Impl4/CMakeLists.txt
@@ -48,4 +48,6 @@ if(APPLE)
                 TARGET ${targetName} POST_BUILD
                 COMMAND ${script} $<TARGET_LINKER_FILE:${targetName}> 19
                 COMMENT "Checking number of exported symbols in the library")
+else()
+	target_link_options(${targetName} PUBLIC "LINKER:--no-as-needed")
 endif()


### PR DESCRIPTION
To be accurate the change affects all non Apple platforms, but it's only on Ubuntu that it was not working properly without that fix.