### PR TITLE
Multiple changes in AODProducerWorkflowSpec

### DIFF
--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h
@@ -160,7 +160,7 @@ void o2::globaltracking::RecoContainer::createTracksVariadic(T creator) const
     for (unsigned i = 0; i < matchesTPCTRDTOF.size(); i++) {
       const auto& match = matchesTPCTRDTOF[i];
       auto gidx = match.getTrackRef(); // this should be corresponding ITS-TPC-TRD track
-      if (isUsed(gidx)) {              // RS FIXME: THIS IS TEMPORARY, until the TOF matching will use ITS-TPC-TRD as an input
+      if (isUsed(gidx)) {
         continue;
       }
       // no need to check isUsed: by construction this ITS-TPC-TRD was not used elsewhere

--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h
@@ -331,7 +331,6 @@ void o2::globaltracking::RecoContainer::createTracksVariadic(T creator) const
       int trlim = rofRec.getFirstEntry() + rofRec.getNEntries();
       for (int it = rofRec.getFirstEntry(); it < trlim; it++) {
         if (isUsed2(it, GTrackID::MFT)) {
-          flagUsed2(it, GTrackID::MFT);
           continue;
         }
         GTrackID gidMFT(it, GTrackID::MFT);

--- a/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
+++ b/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
@@ -1109,8 +1109,11 @@ RecoContainer::GlobalIDSet RecoContainer::getSingleDetectorRefs(GTrackID gidx) c
     table[parent1.getRefITS().getSource()] = parent1.getRefITS();
     table[GTrackID::TPC] = parent1.getRefTPC();
     table[GTrackID::TRD] = gidx; // there is no standalone TRD track, so use the index for the ITSTPCTRD track array
-  }
-  if (src == GTrackID::ITSTPCTOF) {
+  } else if (src == GTrackID::TPCTRD) {
+    const auto& parent0 = getTPCTRDTrack<o2::trd::TrackTRD>(gidx);
+    table[GTrackID::TPC] = parent0.getRefGlobalTrackId();
+    table[GTrackID::TRD] = gidx; // there is no standalone TRD track, so use the index for the TPCTRD track array
+  } else if (src == GTrackID::ITSTPCTOF) {
     const auto& parent0 = getTOFMatch(gidx); // ITS/TPC : TOF
     const auto& parent1 = getTPCITSTrack(parent0.getTrackRef());
     table[GTrackID::ITSTPC] = parent0.getTrackRef();
@@ -1126,6 +1129,7 @@ RecoContainer::GlobalIDSet RecoContainer::getSingleDetectorRefs(GTrackID gidx) c
     table[GTrackID::TOF] = {unsigned(parent0.getIdxTOFCl()), GTrackID::TOF};
     table[GTrackID::TPC] = parent2.getRefTPC();
     table[parent2.getRefITS().getSource()] = parent2.getRefITS(); // ITS source might be an ITS track or ITSAB tracklet
+    table[GTrackID::TRD] = gidx;                                  // there is no standalone TRD track, so use the index for the ITSTPCTRDTOF track array
   } else if (src == GTrackID::TPCTOF) {
     const auto& parent0 = getTPCTOFMatch(gidx); // TPC : TOF
     table[GTrackID::TOF] = {unsigned(parent0.getIdxTOFCl()), GTrackID::TOF};
@@ -1167,6 +1171,9 @@ GTrackID RecoContainer::getTPCContributorGID(GTrackID gidx) const
   } else if (src == GTrackID::TPCTOF) {
     const auto& parent0 = getTPCTOFMatch(gidx); // TPC : TOF
     return parent0.getTrackRef();
+  } else if (src == GTrackID::TPCTRD) {
+    const auto& parent0 = getTPCTRDTrack<o2::trd::TrackTRD>(gidx);
+    return parent0.getRefGlobalTrackId();
   } else if (src == GTrackID::ITSTPC) {
     const auto& parent0 = getTPCITSTrack(gidx);
     return parent0.getRefTPC();

--- a/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
+++ b/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
@@ -201,15 +201,15 @@ class AODProducerWorkflowDPL : public Task
   void endOfStream(framework::EndOfStreamContext& ec) final;
 
  private:
-  // takes a local vertex timing in NS and converts to a global BC information using the orbit offset from the simulation
-  uint64_t relativeTime_to_GlobalBC(double relativeTimeStampInNS)
-  {
-    return std::round((mStartIR.bc2ns() + relativeTimeStampInNS) / o2::constants::lhc::LHCBunchSpacingNS);
-  }
   // takes a local vertex timing in NS and converts to a lobal BC information relative to start of timeframe
-  uint64_t relativeTime_to_LocalBC(double relativeTimeStampInNS)
+  uint64_t relativeTime_to_LocalBC(double relativeTimeStampInNS) const
   {
-    return std::round(relativeTimeStampInNS / o2::constants::lhc::LHCBunchSpacingNS);
+    return relativeTimeStampInNS > 0. ? std::round(relativeTimeStampInNS / o2::constants::lhc::LHCBunchSpacingNS) : 0;
+  }
+  // takes a local vertex timing in NS and converts to a global BC information
+  uint64_t relativeTime_to_GlobalBC(double relativeTimeStampInNS) const
+  {
+    return std::uint64_t(mStartIR.toLong()) + relativeTime_to_LocalBC(relativeTimeStampInNS);
   }
 
   bool mUseMC = true;
@@ -230,14 +230,30 @@ class AODProducerWorkflowDPL : public Task
   TStopwatch mTimer;
 
   // unordered map connects global indices and table indices of barrel tracks
-  // the map is used for V0s and cascades
   std::unordered_map<GIndex, int> mGIDToTableID;
   int mTableTrID{0};
+  // unordered map connects global indices and table indices of fwd tracks
+  std::unordered_map<GIndex, int> mGIDToTableFwdID;
+  int mTableTrFwdID{0};
+  // unordered map connects global indices and table indices of MFT tracks
+  std::unordered_map<GIndex, int> mGIDToTableMFTID;
+  int mTableTrMFTID{0};
 
   // zdc helper maps to avoid a number of "if" statements
   // when filling ZDC table
   map<string, float> mZDCEnergyMap; // mapping detector name to a corresponding energy
   map<string, float> mZDCTDCMap;    // mapping TDC channel to a corresponding TDC value
+
+  std::vector<uint16_t> mITSTPCTRDTriggers; // mapping from TRD tracks ID to corresponding trigger (for tracks time extraction)
+  std::vector<uint16_t> mTPCTRDTriggers;    // mapping from TRD tracks ID to corresponding trigger (for tracks time extraction)
+  std::vector<uint16_t> mITSROFs;           // mapping from ITS tracks ID to corresponding ROF (for SA ITS tracks time extraction)
+  std::vector<uint16_t> mMFTROFs;           // mapping from MFT tracks ID to corresponding ROF (for SA MFT tracks time extraction)
+  std::vector<uint16_t> mMCHROFs;           // mapping from MCH tracks ID to corresponding ROF (for SA MCH tracks time extraction)
+  double mITSROFrameHalfLengthNS = -1;      // ITS ROF half length
+  double mMFTROFrameHalfLengthNS = -1;      // ITS ROF half length
+  double mNSigmaTimeTrack = -1;             // number track errors sigmas (for gaussian errors only) used in track-vertex matching
+  double mTimeMarginTrackTime = -1;         // safety margin in NS used for track-vertex matching (additive to track uncertainty)
+  double mTPCBinNS = -1;                    // inverse TPC time-bin in ns
 
   TripletsMap_t mToStore;
 
@@ -246,6 +262,7 @@ class AODProducerWorkflowDPL : public Task
 
   std::shared_ptr<DataRequest> mDataRequest;
 
+  static constexpr int TOFTimePrecPS = 16; // required max error in ps for TOF tracks
   // truncation is enabled by default
   uint32_t mCollisionPosition = 0xFFFFFFF0;    // 19 bits mantissa
   uint32_t mCollisionPositionCov = 0xFFFFE000; // 10 bits mantissa
@@ -257,6 +274,8 @@ class AODProducerWorkflowDPL : public Task
   uint32_t mTrackCovDiag = 0xFFFFFF00;         // 15 bits
   uint32_t mTrackCovOffDiag = 0xFFFF0000;      // 7 bits
   uint32_t mTrackSignal = 0xFFFFFF00;          // 15 bits
+  uint32_t mTrackTime = 0xFFFFFF00;            // 15 bits
+  uint32_t mTrackTimeError = 0xFFFFFF00;       // 15 bits
   uint32_t mTrackPosEMCAL = 0xFFFFFF00;        // 15 bits
   uint32_t mTracklets = 0xFFFFFF00;            // 15 bits
   uint32_t mMcParticleW = 0xFFFFFFF0;          // 19 bits
@@ -302,6 +321,7 @@ class AODProducerWorkflowDPL : public Task
     float trackPhiEMCAL = -999.f;
     float trackTime = -999.f;
     float trackTimeRes = -999.f;
+    int bcSlice[2] = {-1, -1};
   };
 
   // helper struct for mc track labels
@@ -314,7 +334,12 @@ class AODProducerWorkflowDPL : public Task
     uint8_t fwdLabelMask = 0;
   };
 
-  void collectBCs(o2::globaltracking::RecoContainer& data,
+  void updateTimeDependentParams(ProcessingContext& pc);
+
+  void addRefGlobalBCsForTOF(const o2::dataformats::VtxTrackRef& trackRef, const gsl::span<const GIndex>& GIndices,
+                             const o2::globaltracking::RecoContainer& data, std::map<uint64_t, int>& bcsMap);
+
+  void collectBCs(const o2::globaltracking::RecoContainer& data,
                   const std::vector<o2::InteractionTimeRecord>& mcRecords,
                   std::map<uint64_t, int>& bcsMap);
 
@@ -327,46 +352,61 @@ class AODProducerWorkflowDPL : public Task
   template <typename TracksExtraCursorType>
   void addToTracksExtraTable(TracksExtraCursorType& tracksExtraCursor, TrackExtraInfo& extraInfoHolder);
 
-  template <typename mftTracksCursorType>
-  void addToMFTTracksTable(mftTracksCursorType& mftTracksCursor, const o2::mft::TrackMFT& track, int collisionID);
+  template <typename mftTracksCursorType, typename AmbigMFTTracksCursorType>
+  void addToMFTTracksTable(mftTracksCursorType& mftTracksCursor, AmbigMFTTracksCursorType& ambigMFTTracksCursor,
+                           GIndex trackID, const o2::globaltracking::RecoContainer& data, int collisionID,
+                           std::uint64_t collisionBC, const std::map<uint64_t, int>& bcsMap);
 
-  template <typename fwdTracksCursorType, typename fwdTracksCovCursorType, typename fwdTrackType>
-  void addToFwdTracksTable(fwdTracksCursorType& fwdTracksCursor, fwdTracksCovCursorType& fwdTracksCovCursor, const fwdTrackType& track, int collisionID,
-                           const math_utils::Point3D<double>& vertex);
+  template <typename fwdTracksCursorType, typename fwdTracksCovCursorType, typename AmbigFwdTracksCursorType>
+  void addToFwdTracksTable(fwdTracksCursorType& fwdTracksCursor, fwdTracksCovCursorType& fwdTracksCovCursor, AmbigFwdTracksCursorType& ambigFwdTracksCursor,
+                           GIndex trackID, const o2::globaltracking::RecoContainer& data, int collisionID, std::uint64_t collisionBC, const std::map<uint64_t, int>& bcsMap);
+
+  TrackExtraInfo processBarrelTrack(int collisionID, std::uint64_t collisionBC, GIndex trackIndex, const o2::globaltracking::RecoContainer& data, const std::map<uint64_t, int>& bcsMap);
+
+  void cacheTriggers(const o2::globaltracking::RecoContainer& recoData);
 
   // helper for track tables
   // * fills tables collision by collision
   // * interaction time is for TOF information
-  template <typename TracksCursorType, typename TracksCovCursorType, typename TracksExtraCursorType, typename mftTracksCursorType, typename fwdTracksCursorType, typename fwdTracksCovCursorType>
+  template <typename TracksCursorType, typename TracksCovCursorType, typename TracksExtraCursorType, typename AmbigTracksCursorType,
+            typename MFTTracksCursorType, typename AmbigMFTTracksCursorType,
+            typename FwdTracksCursorType, typename FwdTracksCovCursorType, typename AmbigFwdTracksCursorType>
   void fillTrackTablesPerCollision(int collisionID,
-                                   double interactionTime,
+                                   std::uint64_t collisionBC,
                                    const o2::dataformats::VtxTrackRef& trackRef,
-                                   gsl::span<const GIndex>& GIndices,
-                                   o2::globaltracking::RecoContainer& data,
+                                   const gsl::span<const GIndex>& GIndices,
+                                   const o2::globaltracking::RecoContainer& data,
                                    TracksCursorType& tracksCursor,
                                    TracksCovCursorType& tracksCovCursor,
                                    TracksExtraCursorType& tracksExtraCursor,
-                                   mftTracksCursorType& mftTracksCursor,
-                                   fwdTracksCursorType& fwdTracksCursor,
-                                   fwdTracksCovCursorType& fwdTracksCovCursor,
-                                   const dataformats::PrimaryVertex& vertex);
+                                   AmbigTracksCursorType& ambigTracksCursor,
+                                   MFTTracksCursorType& mftTracksCursor,
+                                   AmbigMFTTracksCursorType& ambigMFTTracksCursor,
+                                   FwdTracksCursorType& fwdTracksCursor,
+                                   FwdTracksCovCursorType& fwdTracksCovCursor,
+                                   AmbigFwdTracksCursorType& ambigFwdTracksCursor,
+                                   const std::map<uint64_t, int>& bcsMap);
+
+  template <typename V0CursorType, typename CascadeCursorType>
+  void fillSecondaryVertices(const o2::globaltracking::RecoContainer& data, V0CursorType& v0Cursor, CascadeCursorType& cascadeCursor);
 
   template <typename MCParticlesCursorType>
-
   void fillMCParticlesTable(o2::steer::MCKinematicsReader& mcReader,
                             const MCParticlesCursorType& mcParticlesCursor,
-                            gsl::span<const o2::dataformats::VtxTrackRef>& primVer2TRefs,
-                            gsl::span<const GIndex>& GIndices,
-                            o2::globaltracking::RecoContainer& data,
-                            std::map<std::pair<int, int>, int> const& mcColToEvSrc);
+                            const gsl::span<const o2::dataformats::VtxTrackRef>& primVer2TRefs,
+                            const gsl::span<const GIndex>& GIndices,
+                            const o2::globaltracking::RecoContainer& data,
+                            const std::map<std::pair<int, int>, int>& mcColToEvSrc);
 
   template <typename MCTrackLabelCursorType, typename MCMFTTrackLabelCursorType, typename MCFwdTrackLabelCursorType>
   void fillMCTrackLabelsTable(const MCTrackLabelCursorType& mcTrackLabelCursor,
                               const MCMFTTrackLabelCursorType& mcMFTTrackLabelCursor,
                               const MCFwdTrackLabelCursorType& mcFwdTrackLabelCursor,
-                              o2::dataformats::VtxTrackRef const& trackRef,
-                              gsl::span<const GIndex>& primVerGIs,
-                              o2::globaltracking::RecoContainer& data);
+                              const o2::dataformats::VtxTrackRef& trackRef,
+                              const gsl::span<const GIndex>& primVerGIs,
+                              const o2::globaltracking::RecoContainer& data);
+
+  std::uint64_t fillBCSlice(int (&slice)[2], double tmin, double tmax, const std::map<uint64_t, int>& bcsMap) const;
 
   // helper for tpc clusters
   void countTPCClusters(const o2::tpc::TrackTPC& track,

--- a/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
+++ b/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
@@ -108,7 +108,9 @@ using MFTTracksTable = o2::soa::Table<o2::aod::fwdtrack::CollisionId,
                                       o2::aod::fwdtrack::Tgl,
                                       o2::aod::fwdtrack::Signed1Pt,
                                       o2::aod::fwdtrack::NClusters,
-                                      o2::aod::fwdtrack::Chi2>;
+                                      o2::aod::fwdtrack::Chi2,
+                                      o2::aod::fwdtrack::TrackTime,
+                                      o2::aod::fwdtrack::TrackTimeRes>;
 
 using FwdTracksTable = o2::soa::Table<o2::aod::fwdtrack::CollisionId,
                                       o2::aod::fwdtrack::TrackType,
@@ -238,6 +240,12 @@ class AODProducerWorkflowDPL : public Task
   // unordered map connects global indices and table indices of MFT tracks
   std::unordered_map<GIndex, int> mGIDToTableMFTID;
   int mTableTrMFTID{0};
+  // unordered map connects global indices and table indices of vertices
+  std::unordered_map<GIndex, int> mVtxToTableCollID;
+  int mTableCollID{0};
+  // unordered map connects global indices and table indices of V0s (needed for cascades references)
+  std::unordered_map<GIndex, int> mV0ToTableID;
+  int mTableV0ID{0};
 
   // zdc helper maps to avoid a number of "if" statements
   // when filling ZDC table

--- a/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
+++ b/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
@@ -280,6 +280,7 @@ class AODProducerWorkflowDPL : public Task
   uint32_t mTrackTgl = 0xFFFFFF00;             // 15 bits
   uint32_t mTrack1Pt = 0xFFFFFC00;             // 13 bits
   uint32_t mTrackCovDiag = 0xFFFFFF00;         // 15 bits
+  uint32_t mTrackChi2 = 0xFFFF0000;            // 7 bits
   uint32_t mTrackCovOffDiag = 0xFFFF0000;      // 7 bits
   uint32_t mTrackSignal = 0xFFFFFF00;          // 15 bits
   uint32_t mTrackTime = 0xFFFFFF00;            // 15 bits

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -230,10 +230,10 @@ void AODProducerWorkflowDPL::addToTracksExtraTable(TracksExtraCursorType& tracks
                     extraInfoHolder.tpcNClsFindableMinusCrossedRows,
                     extraInfoHolder.tpcNClsShared,
                     extraInfoHolder.trdPattern,
-                    truncateFloatFraction(extraInfoHolder.itsChi2NCl, mTrackCovOffDiag),
-                    truncateFloatFraction(extraInfoHolder.tpcChi2NCl, mTrackCovOffDiag),
-                    truncateFloatFraction(extraInfoHolder.trdChi2, mTrackCovOffDiag),
-                    truncateFloatFraction(extraInfoHolder.tofChi2, mTrackCovOffDiag),
+                    truncateFloatFraction(extraInfoHolder.itsChi2NCl, mTrackChi2),
+                    truncateFloatFraction(extraInfoHolder.tpcChi2NCl, mTrackChi2),
+                    truncateFloatFraction(extraInfoHolder.trdChi2, mTrackChi2),
+                    truncateFloatFraction(extraInfoHolder.tofChi2, mTrackChi2),
                     truncateFloatFraction(extraInfoHolder.tpcSignal, mTrackSignal),
                     truncateFloatFraction(extraInfoHolder.trdSignal, mTrackSignal),
                     truncateFloatFraction(extraInfoHolder.length, mTrackSignal),
@@ -269,12 +269,12 @@ void AODProducerWorkflowDPL::addToMFTTracksTable(mftTracksCursorType& mftTracksC
                   collisionID,
                   track.getX(),
                   track.getY(),
-                  track.getZ(),
-                  track.getPhi(),
-                  track.getTanl(),
-                  track.getInvQPt(),
+                  truncateFloatFraction(track.getZ(), mTrackX), // for the forward tracks Z has the same role as X in barrel
+                  truncateFloatFraction(track.getPhi(), mTrackAlpha),
+                  truncateFloatFraction(track.getTanl(), mTrackTgl),
+                  truncateFloatFraction(track.getInvQPt(), mTrack1Pt),
                   track.getNumberOfPoints(),
-                  track.getTrackChi2(),
+                  truncateFloatFraction(track.getTrackChi2(), mTrackChi2),
                   truncateFloatFraction(trackTime, mTrackTime),
                   truncateFloatFraction(trackTimeRes, mTrackTimeError));
   if (needBCSlice) {
@@ -532,17 +532,17 @@ void AODProducerWorkflowDPL::addToFwdTracksTable(FwdTracksCursorType& fwdTracksC
                   trackTypeId,
                   x,
                   y,
-                  z,
-                  phi,
-                  tanl,
-                  invqpt,
+                  truncateFloatFraction(z, mTrackX), // for the forward tracks Z has the same role as X in the barrel
+                  truncateFloatFraction(phi, mTrackAlpha),
+                  truncateFloatFraction(tanl, mTrackTgl),
+                  truncateFloatFraction(invqpt, mTrack1Pt),
                   nClusters,
-                  pdca,
-                  rabs,
-                  chi2,
-                  chi2matchmchmid,
-                  chi2matchmchmft,
-                  matchscoremchmft,
+                  truncateFloatFraction(pdca, mTrackX),
+                  truncateFloatFraction(rabs, mTrackX),
+                  truncateFloatFraction(chi2, mTrackChi2),
+                  truncateFloatFraction(chi2matchmchmid, mTrackChi2),
+                  truncateFloatFraction(chi2matchmchmft, mTrackChi2),
+                  truncateFloatFraction(matchscoremchmft, mTrackChi2),
                   matchmfttrackid,
                   matchmchtrackid,
                   mchBitMap,
@@ -552,11 +552,11 @@ void AODProducerWorkflowDPL::addToFwdTracksTable(FwdTracksCursorType& fwdTracksC
                   truncateFloatFraction(trackTimeRes, mTrackTimeError));
 
   fwdTracksCovCursor(0,
-                     sigX,
-                     sigY,
-                     sigPhi,
-                     sigTgl,
-                     sig1Pt,
+                     truncateFloatFraction(sigX, mTrackCovDiag),
+                     truncateFloatFraction(sigY, mTrackCovDiag),
+                     truncateFloatFraction(sigPhi, mTrackCovDiag),
+                     truncateFloatFraction(sigTgl, mTrackCovDiag),
+                     truncateFloatFraction(sig1Pt, mTrackCovDiag),
                      rhoXY,
                      rhoPhiX,
                      rhoPhiY,
@@ -1043,6 +1043,7 @@ void AODProducerWorkflowDPL::init(InitContext& ic)
     mTrackSnp = 0xFFFFFFFF;
     mTrackTgl = 0xFFFFFFFF;
     mTrack1Pt = 0xFFFFFFFF;
+    mTrackChi2 = 0xFFFFFFFF;
     mTrackCovDiag = 0xFFFFFFFF;
     mTrackCovOffDiag = 0xFFFFFFFF;
     mTrackSignal = 0xFFFFFFFF;

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -459,7 +459,8 @@ DECLARE_SOA_TABLE_FULL(StoredMFTTracks, "MFTTracks", "AOD", "MFTTRACK", //!
                        fwdtrack::Px<fwdtrack::Pt, fwdtrack::Phi>,
                        fwdtrack::Py<fwdtrack::Pt, fwdtrack::Phi>,
                        fwdtrack::Pz<fwdtrack::Pt, fwdtrack::Tgl>,
-                       fwdtrack::Sign<fwdtrack::Signed1Pt>, fwdtrack::Chi2);
+                       fwdtrack::Sign<fwdtrack::Signed1Pt>, fwdtrack::Chi2,
+                       fwdtrack::TrackTime, fwdtrack::TrackTimeRes);
 
 DECLARE_SOA_EXTENDED_TABLE(MFTTracks, StoredMFTTracks, "MFTTRACK", //!
                            aod::fwdtrack::Pt,

--- a/Framework/Core/include/Framework/DataTypes.h
+++ b/Framework/Core/include/Framework/DataTypes.h
@@ -29,7 +29,6 @@ namespace o2::aod::track
 {
 enum TrackTypeEnum : uint8_t {
   Track = 0,
-  ITSStandaloneTrack,
   Run2Track = 254,
   Run2Tracklet = 255
 };

--- a/Framework/Core/include/Framework/DataTypes.h
+++ b/Framework/Core/include/Framework/DataTypes.h
@@ -35,7 +35,8 @@ enum TrackTypeEnum : uint8_t {
 };
 enum TrackFlags {
   TrackTimeResIsRange = 0x1, // Gaussian or range
-  PVContributor = 0x2        // This track has contributed to the collision vertex fit
+  PVContributor = 0x2,       // This track has contributed to the collision vertex fit
+  OrphanTrack = 0x4          // Track has no association with any collision vertexd
   // NOTE Highest 4 (29..32) bits reserved for PID hypothesis
 };
 enum TrackFlagsRun2Enum {


### PR DESCRIPTION
### Multiple changes in AODProducerWorkflowSpec
    
*   Store ambiguous tracks only once, filling their BCslice corresponding to the time bracket as used in track-vertex matching.
*  Store BC slice for tracks w/o vertices
*  The time of ambiguous and orphan tracks is stored in ns wrt the globalBC corresponding to   bcSlice[0].
*  Add time info for MFT tracks
* Store in flags (at the moment for the barrel tracks only, since Fwd and MFT tracks have no  flags) the bit for the track being orphan, as well as the track time error being gaussian or  half-length of the range.
* Store in V0s and Cascades the collisonID.
* Add separate truncation data member for tracks time error.
* To guarantee required precision (set to 16ps) of the TOF tracks time the max distance to eventual reference globalBC is automatically estimated and if needed, dummy globalBCs are added to BCs table.

*   Add MFT track time and resolution to DataModel

*   Add flag for error being half-interval (non-gaussian)

*   Fix decomposition of TRD tracks indices

@jgrosseo The MFT tracks had no time info so I've added it to the model: https://github.com/shahor02/AliceO2/blob/384212ca1185de45b1885b50ab764677bb584890/Framework/Core/include/Framework/AnalysisDataModel.h#L463 but for some reason calling the cursor with time and error added does not work: if I uncoment https://github.com/shahor02/AliceO2/blob/384212ca1185de45b1885b50ab764677bb584890/Detectors/AOD/src/AODProducerWorkflowSpec.cxx#L277-L279 compilation fails with the complaint the too many arguments supplied. Any idea what could be the reason?

I see that for the Fwd and MFT tracks the precision truncation is not applied, was this done on purpose.

Currently, the flags exist only for barrel tracks (in Extra...), shall we add them also for the Fwd and MFT tracks?
 