### PR TITLE
[rANS] O2-2750 Fixes in rANS Frequency Table

### DIFF
--- a/Detectors/Base/include/DetectorsBase/CTFCoderBase.h
+++ b/Detectors/Base/include/DetectorsBase/CTFCoderBase.h
@@ -55,18 +55,18 @@ class CTFCoderBase
   void createCodersFromFile(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op);
 
   template <typename S>
-  void createCoder(OpType op, const o2::rans::FrequencyTable& freq, int slot)
+  void createCoder(OpType op, const o2::rans::RenormedFrequencyTable& renormedFrequencyTable, int slot)
   {
-    if (!freq.size()) {
+    if (renormedFrequencyTable.empty()) {
       LOG(warning) << "Empty dictionary provided for slot " << slot << ", " << (op == OpType::Encoder ? "encoding" : "decoding") << " will assume literal symbols only";
     }
 
     switch (op) {
       case OpType::Encoder:
-        mCoders[slot].reset(new o2::rans::LiteralEncoder64<S>(freq));
+        mCoders[slot].reset(new o2::rans::LiteralEncoder64<S>(renormedFrequencyTable));
         break;
       case OpType::Decoder:
-        mCoders[slot].reset(new o2::rans::LiteralDecoder64<S>(freq));
+        mCoders[slot].reset(new o2::rans::LiteralDecoder64<S>(renormedFrequencyTable));
         break;
     }
   }

--- a/Utilities/rANS/CMakeLists.txt
+++ b/Utilities/rANS/CMakeLists.txt
@@ -12,6 +12,7 @@
 o2_add_library(rANS
                TARGETVARNAME targetName
                SOURCES src/FrequencyTable.cxx
+                       src/RenormedFrequencyTable.cxx
                PUBLIC_LINK_LIBRARIES FairLogger::FairLogger)
 #target_compile_definitions(${targetName} PUBLIC O2_RANS_PRINT_PROCESSED_DATA)
 

--- a/Utilities/rANS/include/rANS/Decoder.h
+++ b/Utilities/rANS/include/rANS/Decoder.h
@@ -25,13 +25,8 @@
 
 #include <fairlogger/Logger.h>
 
-#include "rANS/FrequencyTable.h"
-#include "rANS/internal/DecoderSymbol.h"
-#include "rANS/internal/ReverseSymbolLookupTable.h"
-#include "rANS/internal/SymbolTable.h"
 #include "rANS/internal/Decoder.h"
 #include "rANS/internal/DecoderBase.h"
-#include "rANS/internal/helper.h"
 
 namespace o2
 {

--- a/Utilities/rANS/include/rANS/FrequencyTable.h
+++ b/Utilities/rANS/include/rANS/FrequencyTable.h
@@ -37,8 +37,6 @@ namespace o2
 namespace rans
 {
 
-class FrequencyTable;
-
 namespace detail
 {
 
@@ -64,9 +62,6 @@ class ExpirableProxy
 };
 
 } // namespace detail
-
-std::ostream&
-  operator<<(std::ostream& out, const FrequencyTable& fTable);
 
 class FrequencyTable
 {
@@ -153,12 +148,6 @@ class FrequencyTable
 
   inline size_t getNumSamples() const noexcept { return mNumSamples + this->getIncompressibleSymbolFrequency(); };
 
-  inline bool isRenormed() const noexcept { return this->hasIncompressibleSymbols() && internal::isPow2(this->getNumSamples()); };
-
-  size_t getRenormingBits() const;
-
-  bool isRenormedTo(size_t nBits) const noexcept;
-
   // operations
   template <typename Source_IT, std::enable_if_t<internal::isIntegralIter_v<Source_IT>, bool> = true>
   FrequencyTable& addSamples(Source_IT begin, Source_IT end, bool extendTable = true);
@@ -203,9 +192,7 @@ double_t computeEntropy(const FrequencyTable& table);
 
 count_t computeRenormingPrecision(const FrequencyTable& frequencyTable);
 
-FrequencyTable renorm(FrequencyTable oldTable, size_t newPrecision = 0);
-
-FrequencyTable renormCutoffIncompressible(FrequencyTable oldTable, uint8_t newPrecision = 0, uint8_t lowProbabilityCutoffBits = 3);
+std::ostream& operator<<(std::ostream& out, const FrequencyTable& fTable);
 
 } // namespace rans
 } // namespace o2
@@ -409,6 +396,22 @@ double_t computeEntropy(IT begin, IT end, symbol_t min)
     return entropy -= p * length;
   });
 };
+
+template <typename Source_IT, std::enable_if_t<internal::isIntegralIter_v<Source_IT>, bool> = true>
+inline FrequencyTable makeFrequencyTableFromSamples(Source_IT begin, Source_IT end, bool extendTable = true)
+{
+  FrequencyTable frequencyTable{};
+  frequencyTable.addSamples(begin, end, extendTable);
+  return frequencyTable;
+}
+
+template <typename Source_IT, std::enable_if_t<internal::isIntegralIter_v<Source_IT>, bool> = true>
+inline FrequencyTable makeFrequencyTableFromSamples(Source_IT begin, Source_IT end, symbol_t min, symbol_t max, bool extendTable = true)
+{
+  FrequencyTable frequencyTable{min, max};
+  frequencyTable.addSamples(begin, end, extendTable);
+  return frequencyTable;
+}
 
 } // namespace rans
 } // namespace o2

--- a/Utilities/rANS/include/rANS/RenormedFrequencyTable.h
+++ b/Utilities/rANS/include/rANS/RenormedFrequencyTable.h
@@ -1,0 +1,94 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   RenormedFrequencyTable.h
+/// @author Michael Lettrich
+/// @since  2019-05-08
+/// @brief Histogram to depict frequencies of source symbols for rANS compression.
+
+#ifndef INCLUDE_RANS_RENORMEDFREQUENCYTABLE_H_
+#define INCLUDE_RANS_RENORMEDFREQUENCYTABLE_H_
+
+#include <fairlogger/Logger.h>
+
+#include "rANS/FrequencyTable.h"
+
+namespace o2
+{
+namespace rans
+{
+
+class RenormedFrequencyTable
+{
+ public:
+  using iterator_t = typename FrequencyTable::iterator_t;
+  using constIterator_t = typename FrequencyTable::constIterator_t;
+
+  // TODO(milettri): fix once ROOT cling respects the standard http://wg21.link/p1286r2
+  RenormedFrequencyTable() noexcept {}; // NOLINT
+
+  inline RenormedFrequencyTable(FrequencyTable frequencyTable, size_t renormingBits) : mRenormingBits(renormingBits), mFrequencyTable{std::move(frequencyTable)}
+  {
+    if (mFrequencyTable.getNumSamples() != internal::pow2(this->getRenormingBits())) {
+      throw std::runtime_error{fmt::format("FrequencyTable needs to be renormed to {} Bits.", this->getRenormingBits())};
+    }
+    if (!mFrequencyTable.hasIncompressibleSymbols()) {
+      throw std::runtime_error{fmt::format("FrequencyTable needs to have an incompressible symbol.")};
+    }
+  };
+
+  inline size_t getRenormingBits() const noexcept { return mRenormingBits; };
+
+  inline bool isRenormedTo(size_t nBits) const noexcept { return nBits == this->getRenormingBits(); };
+
+  inline const count_t* data() const noexcept { return mFrequencyTable.data(); };
+
+  inline constIterator_t begin() const noexcept { return mFrequencyTable.begin(); };
+
+  inline constIterator_t end() const noexcept { return mFrequencyTable.end(); };
+
+  inline constIterator_t cbegin() const noexcept { return this->begin(); };
+
+  inline constIterator_t cend() const noexcept { return this->end(); };
+
+  inline count_t operator[](size_t index) const { return mFrequencyTable[index]; };
+
+  inline count_t at(size_t index) const { return mFrequencyTable.at(index); };
+
+  inline symbol_t getMinSymbol() const noexcept { return mFrequencyTable.getMinSymbol(); };
+
+  inline symbol_t getMaxSymbol() const noexcept { return mFrequencyTable.getMaxSymbol(); };
+
+  inline size_t size() const noexcept { return mFrequencyTable.size(); };
+
+  inline bool empty() const noexcept { return mFrequencyTable.empty(); };
+
+  inline size_t getNUsedAlphabetSymbols() const { return mFrequencyTable.getNUsedAlphabetSymbols(); };
+
+  inline size_t getAlphabetRangeBits() const noexcept { return mFrequencyTable.getAlphabetRangeBits(); };
+
+  inline count_t getIncompressibleSymbolFrequency() const noexcept { return mFrequencyTable.getIncompressibleSymbolFrequency(); };
+
+  inline size_t getNumSamples() const noexcept { return mFrequencyTable.getNumSamples(); };
+
+ private:
+  size_t mRenormingBits{};
+  FrequencyTable mFrequencyTable{};
+};
+
+RenormedFrequencyTable renorm(FrequencyTable oldTable, size_t newPrecision = 0);
+
+RenormedFrequencyTable renormCutoffIncompressible(FrequencyTable oldTable, uint8_t newPrecision = 0, uint8_t lowProbabilityCutoffBits = 3);
+
+} // namespace rans
+} // namespace o2
+
+#endif /* INCLUDE_RANS_RENORMEDFREQUENCYTABLE_H_ */

--- a/Utilities/rANS/include/rANS/internal/DecoderBase.h
+++ b/Utilities/rANS/include/rANS/internal/DecoderBase.h
@@ -24,12 +24,11 @@
 
 #include <fairlogger/Logger.h>
 
-#include "rANS/FrequencyTable.h"
+#include "rANS/RenormedFrequencyTable.h"
 #include "rANS/internal/DecoderSymbol.h"
 #include "rANS/internal/ReverseSymbolLookupTable.h"
 #include "rANS/internal/SymbolTable.h"
 #include "rANS/internal/Decoder.h"
-#include "rANS/FrequencyTable.h"
 #include "rANS/internal/helper.h"
 
 namespace o2
@@ -55,7 +54,7 @@ class DecoderBase
 
   // TODO(milettri): fix once ROOT cling respects the standard http://wg21.link/p1286r2
   DecoderBase() noexcept {}; // NOLINT
-  explicit DecoderBase(const FrequencyTable& frequencyTable) : mSymbolTable{frequencyTable}, mReverseLUT{frequencyTable} {};
+  explicit DecoderBase(const RenormedFrequencyTable& frequencyTable) : mSymbolTable{frequencyTable}, mReverseLUT{frequencyTable} {};
 
   inline size_t getAlphabetRangeBits() const noexcept { return mSymbolTable.getAlphabetRangeBits(); }
   inline size_t getSymbolTablePrecision() const noexcept { return mSymbolTable.getPrecision(); }

--- a/Utilities/rANS/include/rANS/internal/EncoderBase.h
+++ b/Utilities/rANS/include/rANS/internal/EncoderBase.h
@@ -29,7 +29,7 @@
 #include "rANS/internal/EncoderSymbol.h"
 #include "rANS/internal/helper.h"
 #include "rANS/internal/SymbolTable.h"
-#include "rANS/FrequencyTable.h"
+#include "rANS/RenormedFrequencyTable.h"
 
 namespace o2
 {
@@ -52,7 +52,7 @@ class EncoderBase
 
   // TODO(milettri): fix once ROOT cling respects the standard http://wg21.link/p1286r2
   EncoderBase() noexcept {}; // NOLINT
-  explicit EncoderBase(const FrequencyTable& frequencyTable) : mSymbolTable{frequencyTable} {};
+  explicit EncoderBase(const RenormedFrequencyTable& frequencyTable) : mSymbolTable{frequencyTable} {};
 
   inline size_t getSymbolTablePrecision() const noexcept { return mSymbolTable.getPrecision(); };
   inline size_t getAlphabetRangeBits() const noexcept { return mSymbolTable.getAlphabetRangeBits(); };

--- a/Utilities/rANS/include/rANS/internal/ReverseSymbolLookupTable.h
+++ b/Utilities/rANS/include/rANS/internal/ReverseSymbolLookupTable.h
@@ -23,7 +23,7 @@
 
 #include "rANS/definitions.h"
 #include "rANS/internal/helper.h"
-#include "rANS/FrequencyTable.h"
+#include "rANS/RenormedFrequencyTable.h"
 
 namespace o2
 {
@@ -40,13 +40,9 @@ class ReverseSymbolLookupTable
   // TODO(milettri): fix once ROOT cling respects the standard http://wg21.link/p1286r2
   ReverseSymbolLookupTable() noexcept {}; // NOLINT
 
-  explicit ReverseSymbolLookupTable(const FrequencyTable& frequencyTable)
+  explicit ReverseSymbolLookupTable(const RenormedFrequencyTable& frequencyTable)
   {
     LOG(trace) << "start building reverse symbol lookup table";
-
-    if (!frequencyTable.isRenormed()) {
-      throw std::runtime_error("Trying to build ReverseSymbolLookupTable from non-renormed FrequencyTable.");
-    }
 
     mLut.resize(frequencyTable.getNumSamples());
     // go over all normal symbols

--- a/Utilities/rANS/include/rANS/internal/SymbolTable.h
+++ b/Utilities/rANS/include/rANS/internal/SymbolTable.h
@@ -23,7 +23,7 @@
 #include <fairlogger/Logger.h>
 
 #include "rANS/definitions.h"
-#include "rANS/FrequencyTable.h"
+#include "rANS/RenormedFrequencyTable.h"
 
 namespace o2
 {
@@ -40,7 +40,7 @@ class SymbolTable
   // TODO(milettri): fix once ROOT cling respects the standard http://wg21.link/p1286r2
   SymbolTable() noexcept {}; // NOLINT
 
-  explicit SymbolTable(const FrequencyTable& frequencyTable);
+  explicit SymbolTable(const RenormedFrequencyTable& frequencyTable);
 
   inline size_t size() const noexcept { return mIndex.size(); };
 
@@ -64,13 +64,9 @@ class SymbolTable
 };
 
 template <typename T>
-SymbolTable<T>::SymbolTable(const FrequencyTable& frequencyTable) : mOffset{frequencyTable.getMinSymbol()}, mPrecision{frequencyTable.getRenormingBits()}
+SymbolTable<T>::SymbolTable(const RenormedFrequencyTable& frequencyTable) : mOffset{frequencyTable.getMinSymbol()}, mPrecision{frequencyTable.getRenormingBits()}
 {
   LOG(trace) << "start building symbol table";
-
-  if (!frequencyTable.isRenormed()) {
-    throw std::runtime_error("Trying to build SymbolTable from non-renormed FrequencyTable.");
-  }
 
   mIndex.reserve(frequencyTable.size() + 1); // +1 for incompressible symbol
   mSymbols.reserve(frequencyTable.getNUsedAlphabetSymbols());

--- a/Utilities/rANS/include/rANS/rans.h
+++ b/Utilities/rANS/include/rANS/rans.h
@@ -18,6 +18,7 @@
 #define RANS_RANS_H
 
 #include "rANS/FrequencyTable.h"
+#include "rANS/RenormedFrequencyTable.h"
 #include "rANS/Encoder.h"
 #include "rANS/Decoder.h"
 #include "rANS/DedupEncoder.h"

--- a/Utilities/rANS/run/bin-encode-decode.cxx
+++ b/Utilities/rANS/run/bin-encode-decode.cxx
@@ -115,16 +115,15 @@ int main(int argc, char* argv[])
     std::vector<source_t> tokens;
     readFile(filename, &tokens);
 
-    o2::rans::FrequencyTable frequencies;
-    frequencies.addSamples(std::begin(tokens), std::end(tokens));
+    const auto renormedFrequencies = o2::rans::renorm(o2::rans::makeFrequencyTableFromSamples(std::begin(tokens), std::end(tokens)));
 
     std::vector<stream_t> encoderBuffer;
-    const o2::rans::Encoder64<source_t> encoder{frequencies};
+    const o2::rans::Encoder64<source_t> encoder{renormedFrequencies};
     encoder.process(std::begin(tokens), std::end(tokens), std::back_inserter(encoderBuffer));
 
     std::vector<source_t> decoderBuffer(tokens.size());
     [&]() {
-      o2::rans::Decoder64<source_t> decoder{frequencies};
+      o2::rans::Decoder64<source_t> decoder{renormedFrequencies};
       decoder.process(encoderBuffer.end(), decoderBuffer.begin(), std::distance(std::begin(tokens), std::end(tokens)));
     }();
 

--- a/Utilities/rANS/src/FrequencyTable.cxx
+++ b/Utilities/rANS/src/FrequencyTable.cxx
@@ -54,42 +54,6 @@ FrequencyTable& FrequencyTable::resize(symbol_t min, symbol_t max, bool truncate
   }
 }
 
-size_t FrequencyTable::getRenormingBits() const
-{
-  if (this->isRenormed()) {
-    return internal::log2UInt(this->getNumSamples());
-  } else {
-    throw std::runtime_error("Non-renormed FrequencyTable");
-  }
-}
-
-bool FrequencyTable::isRenormedTo(size_t nBits) const noexcept
-{
-  if (this->isRenormed()) {
-    return this->getRenormingBits() == nBits;
-  } // namespace rans
-  else {
-    return false;
-  }
-}
-
-std::ostream& operator<<(std::ostream& out, const FrequencyTable& fTable)
-{
-  out << "FrequencyTable: {"
-      << "numSymbols: " << fTable.getNumSamples() << ", "
-      << "alphabetRange: " << fTable.getAlphabetRangeBits() << ", "
-      << "alphabetSize: " << fTable.getNUsedAlphabetSymbols() << ", "
-      << "isRenormed: " << fTable.isRenormed() << ", "
-      << "minSymbol: " << fTable.getMinSymbol() << ", "
-      << "maxSymbol: " << fTable.getMaxSymbol() << ", "
-      << "incompressibleSymbolFrequency: " << fTable.getIncompressibleSymbolFrequency() << ", "
-      << "sizeFrequencyTable: " << fTable.size() << ", "
-      << "sizeFrequencyTableB: " << fTable.size() * sizeof(typename rans::symbol_t) << ", "
-      << "entropy: " << computeEntropy(fTable) << "}";
-
-  return out;
-}
-
 inline double_t computeEntropy(const FrequencyTable& table)
 {
   double_t entropy = std::accumulate(table.begin(), table.end(), 0, [&table](double_t entropy, count_t frequency) {
@@ -115,206 +79,20 @@ count_t computeRenormingPrecision(const FrequencyTable& frequencyTable)
   return std::min(minThreshold, maxThreshold);
 };
 
-FrequencyTable renorm(FrequencyTable frequencyTable, size_t newPrecision)
+std::ostream& operator<<(std::ostream& out, const FrequencyTable& fTable)
 {
+  out << "FrequencyTable: {"
+      << "numSymbols: " << fTable.getNumSamples() << ", "
+      << "alphabetRange: " << fTable.getAlphabetRangeBits() << ", "
+      << "alphabetSize: " << fTable.getNUsedAlphabetSymbols() << ", "
+      << "minSymbol: " << fTable.getMinSymbol() << ", "
+      << "maxSymbol: " << fTable.getMaxSymbol() << ", "
+      << "incompressibleSymbolFrequency: " << fTable.getIncompressibleSymbolFrequency() << ", "
+      << "sizeFrequencyTable: " << fTable.size() << ", "
+      << "sizeFrequencyTableB: " << fTable.size() * sizeof(typename o2::rans::symbol_t) << ", "
+      << "entropy: " << computeEntropy(fTable) << "}";
 
-  using namespace internal;
-  LOG(trace) << "start rescaling frequency table";
-  RANSTimer t;
-  t.start();
-
-  if (frequencyTable.empty()) {
-    LOG(warning) << "rescaling Frequency Table for empty message";
-  }
-
-  if (newPrecision == 0) {
-    newPrecision = computeRenormingPrecision(frequencyTable);
-  }
-
-  count_t nSamples = frequencyTable.getNumSamples();
-  count_t nIncompressible = frequencyTable.getIncompressibleSymbolFrequency();
-  count_t nUsedAlphabetSymbols = frequencyTable.getNUsedAlphabetSymbols();
-  const symbol_t offset = frequencyTable.getMinSymbol();
-
-  // add an incompressible symbol if not present
-  if (!frequencyTable.hasIncompressibleSymbols()) {
-    nIncompressible = 1;
-    nSamples += nIncompressible;
-    nUsedAlphabetSymbols += 1;
-  }
-
-  histogram_t frequencies = std::move(frequencyTable).release();
-  frequencies.push_back(nIncompressible);
-
-  histogram_t cumulativeFrequencies(frequencies.size() + 1);
-  cumulativeFrequencies[0] = 0;
-  std::inclusive_scan(frequencies.begin(), frequencies.end(), ++cumulativeFrequencies.begin());
-
-  auto getFrequency = [&cumulativeFrequencies](count_t i) { return cumulativeFrequencies[i + 1] - cumulativeFrequencies[i]; };
-
-  const auto sortIdx = [&]() {
-    std::vector<size_t> indices;
-    indices.reserve(nUsedAlphabetSymbols);
-
-    // we will sort only those memorize only those entries which can be used
-    for (size_t i = 0; i < frequencies.size(); i++) {
-      if (frequencies[i] != 0) {
-        indices.push_back(i);
-      }
-    }
-    std::sort(indices.begin(), indices.end(), [&](count_t i, count_t j) { return getFrequency(i) < getFrequency(j); });
-
-    return indices;
-  }();
-
-  // resample distribution based on cumulative frequencies
-  const count_t newCumulatedFrequency = pow2(newPrecision);
-  assert(newCumulatedFrequency >= nUsedAlphabetSymbols);
-  size_t needsShift = 0;
-  for (size_t i = 0; i < sortIdx.size(); i++) {
-    if (static_cast<count_t>(getFrequency(sortIdx[i])) * (newCumulatedFrequency - needsShift) / nSamples >= 1) {
-      break;
-    }
-    needsShift++;
-  }
-
-  size_t shift = 0;
-  auto beforeUpdate = cumulativeFrequencies[0];
-  for (size_t i = 0; i < frequencies.size(); i++) {
-    if (frequencies[i] && static_cast<uint64_t>(cumulativeFrequencies[i + 1] - beforeUpdate) * (newCumulatedFrequency - needsShift) / nSamples < 1) {
-      shift++;
-    }
-    beforeUpdate = cumulativeFrequencies[i + 1];
-    cumulativeFrequencies[i + 1] = (static_cast<uint64_t>(newCumulatedFrequency - needsShift) * cumulativeFrequencies[i + 1]) / nSamples + shift;
-  }
-  assert(shift == needsShift);
-
-  // verify
-#if !defined(NDEBUG)
-  assert(cumulativeFrequencies.front() == 0 &&
-         cumulativeFrequencies.back() == newCumulatedFrequency);
-  for (size_t i = 0; i < frequencies.size(); i++) {
-    if (frequencies[i] == 0) {
-      assert(cumulativeFrequencies[i + 1] == cumulativeFrequencies[i]);
-    } else {
-      assert(cumulativeFrequencies[i + 1] > cumulativeFrequencies[i]);
-    }
-  }
-#endif
-
-  // calculate updated frequencies
-  for (size_t i = 0; i < frequencies.size(); i++) {
-    frequencies[i] = getFrequency(i);
-  }
-
-  assert(frequencies.size() >= 1);
-  FrequencyTable rescaledFrequencies{frequencies.begin(), --frequencies.end(), offset, frequencies.back()};
-
-  t.stop();
-  LOG(debug1) << __func__ << " inclusive time (ms): " << t.getDurationMS();
-
-  LOG(trace) << "done rescaling frequency table";
-  return rescaledFrequencies;
-};
-
-FrequencyTable renormCutoffIncompressible(FrequencyTable frequencyTable, uint8_t newPrecision, uint8_t lowProbabilityCutoffBits)
-{
-  using namespace internal;
-  LOG(trace) << "start rescaling frequency table";
-  RANSTimer t;
-  t.start();
-
-  if (frequencyTable.empty()) {
-    LOG(warning) << "rescaling Frequency Table for empty message";
-  }
-
-  if (newPrecision == 0) {
-    newPrecision = computeRenormingPrecision(frequencyTable);
-  }
-
-  const count_t nSamplesRescaled = 1 << newPrecision;
-  const double_t probabilityCutOffThreshold = 1 / static_cast<double_t>(1 << (newPrecision + lowProbabilityCutoffBits));
-
-  // scaling
-  double_t incompressibleSymbolProbability = static_cast<double_t>(frequencyTable.getIncompressibleSymbolFrequency()) / nSamplesRescaled;
-  count_t nSamplesRescaledUncorrected = 0;
-  std::vector<size_t> correctableIndices;
-  correctableIndices.reserve(frequencyTable.getNUsedAlphabetSymbols());
-
-  auto scaleFrequency = [nSamplesRescaled](double_t symbolProbability) { return symbolProbability * nSamplesRescaled; };
-  auto roundDownFrequency = [](double_t i) { return static_cast<count_t>(i); };
-  auto roundUpFrequency = [roundDownFrequency](count_t i) { return roundDownFrequency(i) + 1; };
-  auto roundFrequency = [roundDownFrequency, roundUpFrequency](double_t rescaledFrequency) {
-    if (rescaledFrequency * rescaledFrequency <= (roundDownFrequency(rescaledFrequency) * roundUpFrequency(rescaledFrequency))) {
-      return roundDownFrequency(rescaledFrequency);
-    } else {
-      return roundUpFrequency(rescaledFrequency);
-    }
-  };
-
-  histogram_t rescaledFrequencies(frequencyTable.size());
-
-  for (size_t i = 0; i < frequencyTable.size(); ++i) {
-    const count_t frequency = frequencyTable.at(i);
-    const double_t symbolProbability = static_cast<double_t>(frequency) / static_cast<double_t>(frequencyTable.getNumSamples());
-    if (symbolProbability < probabilityCutOffThreshold) {
-      incompressibleSymbolProbability += symbolProbability;
-      rescaledFrequencies[i] = 0;
-    } else {
-      const double_t scaledFrequencyD = scaleFrequency(symbolProbability);
-      count_t rescaledFrequency = roundFrequency(scaledFrequencyD);
-      assert(rescaledFrequency > 0);
-      rescaledFrequencies[i] = rescaledFrequency;
-      nSamplesRescaledUncorrected += rescaledFrequency;
-      if (rescaledFrequency > 1) {
-        correctableIndices.push_back(i);
-      }
-    }
-  }
-
-  // treat incompressible symbol
-  const count_t incompressibleSymbolFrequency = std::max(static_cast<count_t>(1), static_cast<count_t>(incompressibleSymbolProbability * nSamplesRescaled));
-  nSamplesRescaledUncorrected += incompressibleSymbolFrequency;
-
-  // correction
-  std::stable_sort(correctableIndices.begin(), correctableIndices.end(), [&rescaledFrequencies](const count_t& a, const count_t& b) { return rescaledFrequencies[a] < rescaledFrequencies[b]; });
-
-  int32_t nCorrections = nSamplesRescaled - nSamplesRescaledUncorrected;
-  const double_t rescalingFactor = static_cast<double_t>(nSamplesRescaled) / static_cast<double_t>(nSamplesRescaledUncorrected);
-
-  for (auto index : correctableIndices) {
-    if (std::abs(nCorrections) > 0) {
-      const count_t uncorrectedFrequency = rescaledFrequencies[index];
-      int32_t correction = uncorrectedFrequency - roundFrequency(uncorrectedFrequency * rescalingFactor);
-
-      if (nCorrections < 0) {
-        // overshoot - correct downwards by subtracting correction in [1,|nCorrections|]
-        correction = std::max(1, std::min(correction, std::abs(nCorrections)));
-      } else {
-        // correct upwards by subtracting correction in [-1, -nCorrections]
-        correction = std::min(-1, std::max(correction, -nCorrections));
-      }
-
-      // the corrected frequency must be at least 1 though
-      const count_t correctedFrequency = std::max(1u, uncorrectedFrequency - correction);
-      nCorrections += uncorrectedFrequency - correctedFrequency;
-      rescaledFrequencies[index] = correctedFrequency;
-    } else {
-      break;
-    }
-  }
-
-  if (std::abs(nCorrections) > 0) {
-    throw std::runtime_error(fmt::format("rANS rescaling incomplete: {} corrections Remaining", nCorrections));
-  }
-
-  FrequencyTable newFrequencyTable{rescaledFrequencies.begin(), rescaledFrequencies.end(), frequencyTable.getMinSymbol(), incompressibleSymbolFrequency};
-
-  t.stop();
-  LOG(debug1) << __func__ << " inclusive time (ms): " << t.getDurationMS();
-
-  LOG(trace) << "done rescaling frequency table";
-  return newFrequencyTable;
+  return out;
 }
 
 } // namespace rans

--- a/Utilities/rANS/src/RenormedFrequencyTable.cxx
+++ b/Utilities/rANS/src/RenormedFrequencyTable.cxx
@@ -1,0 +1,227 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   RenormedFrequencyTable.cxx
+/// @author Michael Lettrich
+/// @since  Aug 1, 2020
+/// @brief Implementation of a frequency table for rANS symbole (i.e. a histogram)
+
+#include "rANS/RenormedFrequencyTable.h"
+
+namespace o2
+{
+namespace rans
+{
+
+RenormedFrequencyTable renorm(FrequencyTable frequencyTable, size_t newPrecision)
+{
+
+  using namespace internal;
+  LOG(trace) << "start rescaling frequency table";
+  RANSTimer t;
+  t.start();
+
+  if (frequencyTable.empty()) {
+    LOG(warning) << "rescaling Frequency Table for empty message";
+  }
+
+  if (newPrecision == 0) {
+    newPrecision = computeRenormingPrecision(frequencyTable);
+  }
+
+  count_t nSamples = frequencyTable.getNumSamples();
+  count_t nIncompressible = frequencyTable.getIncompressibleSymbolFrequency();
+  count_t nUsedAlphabetSymbols = frequencyTable.getNUsedAlphabetSymbols();
+  const symbol_t offset = frequencyTable.getMinSymbol();
+
+  // add an incompressible symbol if not present
+  if (!frequencyTable.hasIncompressibleSymbols()) {
+    nIncompressible = 1;
+    nSamples += nIncompressible;
+    nUsedAlphabetSymbols += 1;
+  }
+
+  histogram_t frequencies = std::move(frequencyTable).release();
+  frequencies.push_back(nIncompressible);
+
+  histogram_t cumulativeFrequencies(frequencies.size() + 1);
+  cumulativeFrequencies[0] = 0;
+  std::inclusive_scan(frequencies.begin(), frequencies.end(), ++cumulativeFrequencies.begin());
+
+  auto getFrequency = [&cumulativeFrequencies](count_t i) { return cumulativeFrequencies[i + 1] - cumulativeFrequencies[i]; };
+
+  const auto sortIdx = [&]() {
+    std::vector<size_t> indices;
+    indices.reserve(nUsedAlphabetSymbols);
+
+    // we will sort only those memorize only those entries which can be used
+    for (size_t i = 0; i < frequencies.size(); i++) {
+      if (frequencies[i] != 0) {
+        indices.push_back(i);
+      }
+    }
+    std::sort(indices.begin(), indices.end(), [&](count_t i, count_t j) { return getFrequency(i) < getFrequency(j); });
+
+    return indices;
+  }();
+
+  // resample distribution based on cumulative frequencies
+  const count_t newCumulatedFrequency = pow2(newPrecision);
+  assert(newCumulatedFrequency >= nUsedAlphabetSymbols);
+  size_t needsShift = 0;
+  for (size_t i = 0; i < sortIdx.size(); i++) {
+    if (static_cast<count_t>(getFrequency(sortIdx[i])) * (newCumulatedFrequency - needsShift) / nSamples >= 1) {
+      break;
+    }
+    needsShift++;
+  }
+
+  size_t shift = 0;
+  auto beforeUpdate = cumulativeFrequencies[0];
+  for (size_t i = 0; i < frequencies.size(); i++) {
+    if (frequencies[i] && static_cast<uint64_t>(cumulativeFrequencies[i + 1] - beforeUpdate) * (newCumulatedFrequency - needsShift) / nSamples < 1) {
+      shift++;
+    }
+    beforeUpdate = cumulativeFrequencies[i + 1];
+    cumulativeFrequencies[i + 1] = (static_cast<uint64_t>(newCumulatedFrequency - needsShift) * cumulativeFrequencies[i + 1]) / nSamples + shift;
+  }
+  assert(shift == needsShift);
+
+  // verify
+#if !defined(NDEBUG)
+  assert(cumulativeFrequencies.front() == 0 &&
+         cumulativeFrequencies.back() == newCumulatedFrequency);
+  for (size_t i = 0; i < frequencies.size(); i++) {
+    if (frequencies[i] == 0) {
+      assert(cumulativeFrequencies[i + 1] == cumulativeFrequencies[i]);
+    } else {
+      assert(cumulativeFrequencies[i + 1] > cumulativeFrequencies[i]);
+    }
+  }
+#endif
+
+  // calculate updated frequencies
+  for (size_t i = 0; i < frequencies.size(); i++) {
+    frequencies[i] = getFrequency(i);
+  }
+
+  assert(frequencies.size() >= 1);
+  FrequencyTable rescaledFrequencies{frequencies.begin(), --frequencies.end(), offset, frequencies.back()};
+
+  t.stop();
+  LOG(debug1) << __func__ << " inclusive time (ms): " << t.getDurationMS();
+
+  LOG(trace) << "done rescaling frequency table";
+  return RenormedFrequencyTable{std::move(rescaledFrequencies), newPrecision};
+};
+
+RenormedFrequencyTable renormCutoffIncompressible(FrequencyTable frequencyTable, uint8_t newPrecision, uint8_t lowProbabilityCutoffBits)
+{
+  using namespace internal;
+  LOG(trace) << "start rescaling frequency table";
+  RANSTimer t;
+  t.start();
+
+  if (frequencyTable.empty()) {
+    LOG(warning) << "rescaling Frequency Table for empty message";
+  }
+
+  if (newPrecision == 0) {
+    newPrecision = computeRenormingPrecision(frequencyTable);
+  }
+
+  const count_t nSamplesRescaled = 1 << newPrecision;
+  const double_t probabilityCutOffThreshold = 1 / static_cast<double_t>(1 << (newPrecision + lowProbabilityCutoffBits));
+
+  // scaling
+  double_t incompressibleSymbolProbability = static_cast<double_t>(frequencyTable.getIncompressibleSymbolFrequency()) / nSamplesRescaled;
+  count_t nSamplesRescaledUncorrected = 0;
+  std::vector<size_t> correctableIndices;
+  correctableIndices.reserve(frequencyTable.getNUsedAlphabetSymbols());
+
+  auto scaleFrequency = [nSamplesRescaled](double_t symbolProbability) { return symbolProbability * nSamplesRescaled; };
+  auto roundDownFrequency = [](double_t i) { return static_cast<count_t>(i); };
+  auto roundUpFrequency = [roundDownFrequency](count_t i) { return roundDownFrequency(i) + 1; };
+  auto roundFrequency = [roundDownFrequency, roundUpFrequency](double_t rescaledFrequency) {
+    if (rescaledFrequency * rescaledFrequency <= (roundDownFrequency(rescaledFrequency) * roundUpFrequency(rescaledFrequency))) {
+      return roundDownFrequency(rescaledFrequency);
+    } else {
+      return roundUpFrequency(rescaledFrequency);
+    }
+  };
+
+  histogram_t rescaledFrequencies(frequencyTable.size());
+
+  for (size_t i = 0; i < frequencyTable.size(); ++i) {
+    const count_t frequency = frequencyTable.at(i);
+    const double_t symbolProbability = static_cast<double_t>(frequency) / static_cast<double_t>(frequencyTable.getNumSamples());
+    if (symbolProbability < probabilityCutOffThreshold) {
+      incompressibleSymbolProbability += symbolProbability;
+      rescaledFrequencies[i] = 0;
+    } else {
+      const double_t scaledFrequencyD = scaleFrequency(symbolProbability);
+      count_t rescaledFrequency = roundFrequency(scaledFrequencyD);
+      assert(rescaledFrequency > 0);
+      rescaledFrequencies[i] = rescaledFrequency;
+      nSamplesRescaledUncorrected += rescaledFrequency;
+      if (rescaledFrequency > 1) {
+        correctableIndices.push_back(i);
+      }
+    }
+  }
+
+  // treat incompressible symbol
+  const count_t incompressibleSymbolFrequency = std::max(static_cast<count_t>(1), static_cast<count_t>(incompressibleSymbolProbability * nSamplesRescaled));
+  nSamplesRescaledUncorrected += incompressibleSymbolFrequency;
+
+  // correction
+  std::stable_sort(correctableIndices.begin(), correctableIndices.end(), [&rescaledFrequencies](const count_t& a, const count_t& b) { return rescaledFrequencies[a] < rescaledFrequencies[b]; });
+
+  int32_t nCorrections = nSamplesRescaled - nSamplesRescaledUncorrected;
+  const double_t rescalingFactor = static_cast<double_t>(nSamplesRescaled) / static_cast<double_t>(nSamplesRescaledUncorrected);
+
+  for (auto index : correctableIndices) {
+    if (std::abs(nCorrections) > 0) {
+      const count_t uncorrectedFrequency = rescaledFrequencies[index];
+      int32_t correction = uncorrectedFrequency - roundFrequency(uncorrectedFrequency * rescalingFactor);
+
+      if (nCorrections < 0) {
+        // overshoot - correct downwards by subtracting correction in [1,|nCorrections|]
+        correction = std::max(1, std::min(correction, std::abs(nCorrections)));
+      } else {
+        // correct upwards by subtracting correction in [-1, -nCorrections]
+        correction = std::min(-1, std::max(correction, -nCorrections));
+      }
+
+      // the corrected frequency must be at least 1 though
+      const count_t correctedFrequency = std::max(1u, uncorrectedFrequency - correction);
+      nCorrections += uncorrectedFrequency - correctedFrequency;
+      rescaledFrequencies[index] = correctedFrequency;
+    } else {
+      break;
+    }
+  }
+
+  if (std::abs(nCorrections) > 0) {
+    throw std::runtime_error(fmt::format("rANS rescaling incomplete: {} corrections Remaining", nCorrections));
+  }
+
+  FrequencyTable newFrequencyTable{rescaledFrequencies.begin(), rescaledFrequencies.end(), frequencyTable.getMinSymbol(), incompressibleSymbolFrequency};
+
+  t.stop();
+  LOG(debug1) << __func__ << " inclusive time (ms): " << t.getDurationMS();
+
+  LOG(trace) << "done rescaling frequency table";
+  return RenormedFrequencyTable{std::move(newFrequencyTable), newPrecision};
+}
+
+} // namespace rans
+} // namespace o2

--- a/Utilities/rANS/test/test_ransEncodeDecode.cxx
+++ b/Utilities/rANS/test/test_ransEncodeDecode.cxx
@@ -79,9 +79,7 @@ struct EncodeDecodeBase {
   {
     dictString_T source;
     std::string& s = source.data;
-    o2::rans::FrequencyTable frequencyTable;
-    frequencyTable.addSamples(std::begin(s), std::end(s));
-    frequencyTable = o2::rans::renorm(std::move(frequencyTable), params_t::symbolTablePrecision);
+    o2::rans::RenormedFrequencyTable frequencyTable = o2::rans::renorm(o2::rans::makeFrequencyTableFromSamples(std::begin(s), std::end(s)), params_t::symbolTablePrecision);
 
     encoder = decltype(encoder)(frequencyTable);
     decoder = decltype(decoder)(frequencyTable);

--- a/Utilities/rANS/test/test_ransFrequencyTable.cxx
+++ b/Utilities/rANS/test/test_ransFrequencyTable.cxx
@@ -368,36 +368,33 @@ BOOST_AUTO_TEST_CASE(test_renorm)
 {
   o2::rans::histogram_t frequencies{1, 1, 2, 2, 2, 2, 6, 8, 4, 10, 8, 14, 10, 19, 26, 30, 31, 35, 41, 45, 51, 44, 47, 39, 58, 52, 42, 53, 50, 34, 50, 30, 32, 24, 30, 20, 17, 12, 16, 6, 8, 5, 6, 4, 4, 2, 2, 2, 1};
   o2::rans::FrequencyTable frequencyTable{frequencies.begin(), frequencies.end(), 0};
-  BOOST_CHECK_EQUAL(frequencyTable.isRenormed(), false);
 
   const size_t scaleBits = 8;
 
-  auto newFrequencyTable = o2::rans::renorm(std::move(frequencyTable), scaleBits);
+  auto renormedFrequencyTable = o2::rans::renorm(std::move(frequencyTable), scaleBits);
   const o2::rans::histogram_t rescaledFrequencies{1, 1, 1, 2, 1, 2, 1, 2, 2, 2, 2, 3, 3, 4, 6, 7, 7, 9, 9, 11, 12, 10, 11, 9, 13, 12, 10, 13, 11, 8, 12, 7, 7, 6, 7, 4, 4, 3, 4, 1, 2, 1, 2, 2, 2, 1, 2, 1, 1};
-  BOOST_CHECK_EQUAL(newFrequencyTable.isRenormed(), true);
-  BOOST_CHECK_EQUAL(newFrequencyTable.getNumSamples(), 1 << scaleBits);
-  BOOST_CHECK_EQUAL(newFrequencyTable.getMinSymbol(), 0);
-  BOOST_CHECK_EQUAL(newFrequencyTable.getMaxSymbol(), 48);
-  BOOST_CHECK_EQUAL(newFrequencyTable.getIncompressibleSymbolFrequency(), 2);
-  BOOST_CHECK_EQUAL_COLLECTIONS(newFrequencyTable.begin(), newFrequencyTable.end(), rescaledFrequencies.begin(), rescaledFrequencies.end());
+  BOOST_CHECK_EQUAL(renormedFrequencyTable.isRenormedTo(scaleBits), true);
+  BOOST_CHECK_EQUAL(renormedFrequencyTable.getNumSamples(), 1 << scaleBits);
+  BOOST_CHECK_EQUAL(renormedFrequencyTable.getMinSymbol(), 0);
+  BOOST_CHECK_EQUAL(renormedFrequencyTable.getMaxSymbol(), 48);
+  BOOST_CHECK_EQUAL(renormedFrequencyTable.getIncompressibleSymbolFrequency(), 2);
+  BOOST_CHECK_EQUAL_COLLECTIONS(renormedFrequencyTable.begin(), renormedFrequencyTable.end(), rescaledFrequencies.begin(), rescaledFrequencies.end());
 }
 
 BOOST_AUTO_TEST_CASE(test_renormIncompressible)
 {
   o2::rans::histogram_t frequencies{1, 1, 2, 2, 2, 2, 6, 8, 4, 10, 8, 14, 10, 19, 26, 30, 31, 35, 41, 45, 51, 44, 47, 39, 58, 52, 42, 53, 50, 34, 50, 30, 32, 24, 30, 20, 17, 12, 16, 6, 8, 5, 6, 4, 4, 2, 2, 2, 1};
   o2::rans::FrequencyTable frequencyTable{frequencies.begin(), frequencies.end(), 0};
-  BOOST_CHECK_EQUAL(frequencyTable.isRenormed(), false);
 
   const size_t scaleBits = 8;
 
-  auto newFrequencyTable = o2::rans::renormCutoffIncompressible(std::move(frequencyTable), scaleBits, 1);
+  auto renormedFrequencyTable = o2::rans::renormCutoffIncompressible(std::move(frequencyTable), scaleBits, 1);
 
   const o2::rans::histogram_t rescaledFrequencies{1, 2, 1, 3, 2, 3, 3, 5, 6, 7, 8, 9, 10, 11, 13, 11, 12, 10, 14, 13, 10, 13, 12, 8, 12, 7, 8, 6, 7, 5, 4, 3, 4, 2, 2, 1, 2, 1, 1};
-  BOOST_CHECK_EQUAL(newFrequencyTable.isRenormed(), true);
-  BOOST_CHECK_EQUAL(newFrequencyTable.isRenormedTo(scaleBits), true);
-  BOOST_CHECK_EQUAL(newFrequencyTable.getNumSamples(), 1 << scaleBits);
-  BOOST_CHECK_EQUAL(newFrequencyTable.getMinSymbol(), 6);
-  BOOST_CHECK_EQUAL(newFrequencyTable.getMaxSymbol(), 44);
-  BOOST_CHECK_EQUAL(newFrequencyTable.getIncompressibleSymbolFrequency(), 4);
-  BOOST_CHECK_EQUAL_COLLECTIONS(newFrequencyTable.begin(), newFrequencyTable.end(), rescaledFrequencies.begin(), rescaledFrequencies.end());
+  BOOST_CHECK_EQUAL(renormedFrequencyTable.isRenormedTo(scaleBits), true);
+  BOOST_CHECK_EQUAL(renormedFrequencyTable.getNumSamples(), 1 << scaleBits);
+  BOOST_CHECK_EQUAL(renormedFrequencyTable.getMinSymbol(), 6);
+  BOOST_CHECK_EQUAL(renormedFrequencyTable.getMaxSymbol(), 44);
+  BOOST_CHECK_EQUAL(renormedFrequencyTable.getIncompressibleSymbolFrequency(), 4);
+  BOOST_CHECK_EQUAL_COLLECTIONS(renormedFrequencyTable.begin(), renormedFrequencyTable.end(), rescaledFrequencies.begin(), rescaledFrequencies.end());
 }

--- a/Utilities/rANS/test/test_ransReverseSymbolLookupTable.cxx
+++ b/Utilities/rANS/test/test_ransReverseSymbolLookupTable.cxx
@@ -31,8 +31,8 @@ size_t getNUniqueSymbols(const T& container)
 
 BOOST_AUTO_TEST_CASE(test_empty)
 {
-  const auto frequencyTable = o2::rans::renorm(o2::rans::FrequencyTable{});
-  const o2::rans::internal::ReverseSymbolLookupTable rLut{frequencyTable};
+  const auto renormedFrequencyTable = o2::rans::renorm(o2::rans::FrequencyTable{});
+  const o2::rans::internal::ReverseSymbolLookupTable rLut{renormedFrequencyTable};
 
   const auto size = 1 << o2::rans::MinRenormThreshold;
   BOOST_CHECK_EQUAL(rLut.size(), size);
@@ -48,10 +48,8 @@ BOOST_AUTO_TEST_CASE(test_buildRLUT)
   const size_t scaleBits = 17;
   const auto size = 1 << scaleBits;
 
-  o2::rans::FrequencyTable ft;
-  ft.addSamples(A.begin(), A.end());
-  ft = o2::rans::renorm(std::move(ft), scaleBits);
-  const o2::rans::internal::ReverseSymbolLookupTable rLut{ft};
+  const auto renormedFrequencyTable = o2::rans::renorm(o2::rans::makeFrequencyTableFromSamples(A.begin(), A.end()), scaleBits);
+  const o2::rans::internal::ReverseSymbolLookupTable rLut{renormedFrequencyTable};
 
   BOOST_CHECK_EQUAL(rLut.size(), size);
 

--- a/Utilities/rANS/test/test_ransSymbolTable.cxx
+++ b/Utilities/rANS/test/test_ransSymbolTable.cxx
@@ -68,10 +68,8 @@ BOOST_AUTO_TEST_CASE(test_symbolTable)
   const size_t scaleBits = 17;
   const int32_t min = *std::min_element(A.begin(), A.end());
 
-  FrequencyTable f;
-  f.addSamples(A.begin(), A.end());
-  f = renorm(std::move(f), scaleBits);
-  const internal::SymbolTable<internal::DecoderSymbol> symbolTable{f};
+  RenormedFrequencyTable frequencyTable = renorm(makeFrequencyTableFromSamples(A.begin(), A.end()), scaleBits);
+  const internal::SymbolTable<internal::DecoderSymbol> symbolTable{frequencyTable};
 
   BOOST_CHECK_EQUAL(symbolTable.getMinSymbol(), min);
   BOOST_CHECK_EQUAL(symbolTable.getMaxSymbol(), *std::max_element(A.begin(), A.end()) + 1);


### PR DESCRIPTION
* Bugfix: `FrequencyTable` sometimes returned wrong number of used alphabet symbols. This results in resizing a vector in the `SymbolTable` constructor which leads to invalidated pointers and thus a wrong `SymbolTable`.
*  Hardening: CTF Coders under certain conditions would not renorm a `FrequencyTable`
*  Improvement:  Introduce `RenormedFrequencyTable` as an immutable wrapper around `FrequencyTable`, returned by renorming algorithms. 
* Constructors of rANS Encoder/Decoder classes and SymbolTable require to be passed `RenormedFrequencyTable` instances which allows to push renorming checks from run time to compile time.
* `RenormedFrequencyTable` avoids confusion and potential bugs by library users.
