### PR TITLE
[WIP] Tesbench for CCDB fetcher callback 

### DIFF
--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/EntropyDecoderSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/EntropyDecoderSpec.h
@@ -15,6 +15,7 @@
 #ifndef O2_ITSMFT_ENTROPYDECODER_SPEC
 #define O2_ITSMFT_ENTROPYDECODER_SPEC
 
+#include "Framework/CCDBParamSpec.h"
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
 #include "Headers/DataHeader.h"
@@ -37,12 +38,14 @@ class EntropyDecoderSpec : public o2::framework::Task
   void init(o2::framework::InitContext& ic) final;
   void run(o2::framework::ProcessingContext& pc) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
 
   static auto getName(o2::header::DataOrigin orig) { return std::string{orig == o2::header::gDataOriginITS ? ITSDeviceName : MFTDeviceName}; }
 
  private:
   void updateTimeDependentParams(o2::framework::ProcessingContext& pc);
-
+  bool mAlpParUpd = false;
+  bool mGRPParUpd = false;
   static constexpr std::string_view ITSDeviceName = "its-entropy-decoder";
   static constexpr std::string_view MFTDeviceName = "mft-entropy-decoder";
   o2::header::DataOrigin mOrigin = o2::header::gDataOriginInvalid;

--- a/Framework/Core/include/Framework/CallbackService.h
+++ b/Framework/Core/include/Framework/CallbackService.h
@@ -15,6 +15,7 @@
 #include "Framework/ServiceHandle.h"
 #include "Framework/DataProcessingHeader.h"
 #include "ServiceRegistry.h"
+#include "Framework/Logger.h"
 
 #include <fairmq/FwdDecls.h>
 
@@ -111,6 +112,9 @@ class CallbackService
   template <typename... TArgs>
   auto operator()(Id id, TArgs&&... args)
   {
+    if (id == Id::CCDBDeserialised) {
+      LOG(info) << "CallBack entry " << int(id);
+    }
     mCallbacks(id, std::forward<TArgs>(args)...);
   }
 

--- a/Framework/Core/include/Framework/Task.h
+++ b/Framework/Core/include/Framework/Task.h
@@ -14,6 +14,7 @@
 #include "Framework/AlgorithmSpec.h"
 #include "Framework/CallbackService.h"
 #include "Framework/EndOfStreamContext.h"
+#include "Framework/Logger.h"
 #include <utility>
 #include <memory>
 
@@ -122,6 +123,7 @@ AlgorithmSpec adaptFromTask(Args&&... args)
       });
     }
     if constexpr (has_finaliseCCDB<T>::value) {
+      LOG(info) << "Setting finaliseCCDB hook";
       auto& callbacks = ic.services().get<CallbackService>();
       callbacks.set(CallbackService::Id::CCDBDeserialised, [task](ConcreteDataMatcher& matcher, void* obj) {
         task->finaliseCCDB(matcher, obj);


### PR DESCRIPTION
Hi @ktf,

the 1st 3 commits are necessary for the fetcher to work properly, the last 3 others are temporary patches for extra verbosity and testbench: overall it works fine except the callback: I see that it is recognized since 
https://github.com/shahor02/AliceO2/blob/a8fc9aaa63b504937d2823dc6eb74ece8450d8a5/Framework/Core/include/Framework/Task.h#L126 is printed and an attempt to call it is made since https://github.com/AliceO2Group/AliceO2/blob/a8fc9aaa63b504937d2823dc6eb74ece8450d8a5/Framework/Core/include/Framework/CallbackService.h#L116 logs the call. But then the https://github.com/shahor02/AliceO2/blob/a8fc9aaa63b504937d2823dc6eb74ece8450d8a5/Detectors/ITSMFT/common/workflow/src/EntropyDecoderSpec.cxx#L147 is never called. 

The problem can be reproduced by unpacking https://cernbox.cern.ch/index.php/s/EVFNwBQHH2S2GWM and running 
```
o2-ctf-reader-workflow --max-tf 80 --onlyDet MFT  --ctf-input o2_ctf_run00507092_orbit0000000252_tf0000000001.root --condition-backend http://ccdb-test.cern.ch:8080  --run | tee xx.log
```
It will process 80 TFs, fetching specially tailored `Test/GRP/Data` and `Test/MFT/AlpideParam` objects (there are 7 updates over the timespan of these 80 TFs.
