### PR TITLE
[QC-670] Add parameter to limit the size of the objects sent to the ccdb

### DIFF
--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -137,7 +137,7 @@ class CcdbApi //: public DatabaseInterface
 
   // interface for storing TObject via storeAsTFileAny
   void storeAsTFileAny(const TObject* rootobj, std::string const& path, std::map<std::string, std::string> const& metadata,
-                       long startValidityTimestamp = -1, long endValidityTimestamp = -1, std::vector<char>::size_type maxSize = 0  /*bytes*/) const
+                       long startValidityTimestamp = -1, long endValidityTimestamp = -1, std::vector<char>::size_type maxSize = 0 /*bytes*/) const
   {
     storeAsTFile(rootobj, path, metadata, startValidityTimestamp, endValidityTimestamp, maxSize);
   }
@@ -395,13 +395,13 @@ class CcdbApi //: public DatabaseInterface
    */
   void storeAsBinaryFile(const char* buffer, size_t size, const std::string& fileName, const std::string& objectType,
                          const std::string& path, const std::map<std::string, std::string>& metadata,
-                         long startValidityTimestamp, long endValidityTimestamp, std::vector<char>::size_type maxSize=0 /*in bytes*/) const;
+                         long startValidityTimestamp, long endValidityTimestamp, std::vector<char>::size_type maxSize = 0 /*in bytes*/) const;
 
   /**
    * A generic helper implementation to store an obj whose type is given by a std::type_info
    */
   void storeAsTFile_impl(const void* obj1, std::type_info const& info, std::string const& path, std::map<std::string, std::string> const& metadata,
-                         long startValidityTimestamp = -1, long endValidityTimestamp = -1, std::vector<char>::size_type maxSize=0 /*in bytes*/) const;
+                         long startValidityTimestamp = -1, long endValidityTimestamp = -1, std::vector<char>::size_type maxSize = 0 /*in bytes*/) const;
 
   /**
    * A generic helper implementation to query obj whose type is given by a std::type_info

--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -117,7 +117,7 @@ class CcdbApi //: public DatabaseInterface
      * @param endValidityTimestamp End of validity. If omitted, current timestamp + 1 day is used.
      */
   void storeAsTFile(const TObject* rootObject, std::string const& path, std::map<std::string, std::string> const& metadata,
-                    long startValidityTimestamp = -1, long endValidityTimestamp = -1) const;
+                    long startValidityTimestamp = -1, long endValidityTimestamp = -1, std::vector<char>::size_type maxSize = 0 /*bytes*/) const;
 
   /**
      * Store into the CCDB a TFile containing an object of type T (which needs to have a ROOT dictionary)
@@ -130,16 +130,16 @@ class CcdbApi //: public DatabaseInterface
      */
   template <typename T>
   void storeAsTFileAny(const T* obj, std::string const& path, std::map<std::string, std::string> const& metadata,
-                       long startValidityTimestamp = -1, long endValidityTimestamp = -1) const
+                       long startValidityTimestamp = -1, long endValidityTimestamp = -1, std::vector<char>::size_type maxSize = 0 /*bytes*/) const
   {
-    storeAsTFile_impl(reinterpret_cast<const void*>(obj), typeid(T), path, metadata, startValidityTimestamp, endValidityTimestamp);
+    storeAsTFile_impl(reinterpret_cast<const void*>(obj), typeid(T), path, metadata, startValidityTimestamp, endValidityTimestamp, maxSize);
   }
 
   // interface for storing TObject via storeAsTFileAny
   void storeAsTFileAny(const TObject* rootobj, std::string const& path, std::map<std::string, std::string> const& metadata,
-                       long startValidityTimestamp = -1, long endValidityTimestamp = -1) const
+                       long startValidityTimestamp = -1, long endValidityTimestamp = -1, std::vector<char>::size_type maxSize = 0  /*bytes*/) const
   {
-    storeAsTFile(rootobj, path, metadata, startValidityTimestamp, endValidityTimestamp);
+    storeAsTFile(rootobj, path, metadata, startValidityTimestamp, endValidityTimestamp, maxSize);
   }
 
   /**
@@ -395,13 +395,13 @@ class CcdbApi //: public DatabaseInterface
    */
   void storeAsBinaryFile(const char* buffer, size_t size, const std::string& fileName, const std::string& objectType,
                          const std::string& path, const std::map<std::string, std::string>& metadata,
-                         long startValidityTimestamp, long endValidityTimestamp) const;
+                         long startValidityTimestamp, long endValidityTimestamp, std::vector<char>::size_type maxSize=0 /*in bytes*/) const;
 
   /**
    * A generic helper implementation to store an obj whose type is given by a std::type_info
    */
   void storeAsTFile_impl(const void* obj1, std::type_info const& info, std::string const& path, std::map<std::string, std::string> const& metadata,
-                         long startValidityTimestamp = -1, long endValidityTimestamp = -1) const;
+                         long startValidityTimestamp = -1, long endValidityTimestamp = -1, std::vector<char>::size_type maxSize=0 /*in bytes*/) const;
 
   /**
    * A generic helper implementation to query obj whose type is given by a std::type_info

--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -115,8 +115,12 @@ class CcdbApi //: public DatabaseInterface
      * @param metadata Key-values representing the metadata for this object.
      * @param startValidityTimestamp Start of validity. If omitted, current timestamp is used.
      * @param endValidityTimestamp End of validity. If omitted, current timestamp + 1 day is used.
+     * @return 0 -> ok,
+     *         positive number -> curl error (https://curl.se/libcurl/c/libcurl-errors.html),
+     *         -1 : object bigger than maxSize,
+     *         -2 : curl initialization error
      */
-  void storeAsTFile(const TObject* rootObject, std::string const& path, std::map<std::string, std::string> const& metadata,
+  int storeAsTFile(const TObject* rootObject, std::string const& path, std::map<std::string, std::string> const& metadata,
                     long startValidityTimestamp = -1, long endValidityTimestamp = -1, std::vector<char>::size_type maxSize = 0 /*bytes*/) const;
 
   /**
@@ -127,19 +131,23 @@ class CcdbApi //: public DatabaseInterface
      * @param metadata Key-values representing the metadata for this object.
      * @param startValidityTimestamp Start of validity. If omitted, current timestamp is used.
      * @param endValidityTimestamp End of validity. If omitted, current timestamp + 1 day is used.
+     * @return 0 -> ok,
+     *         positive number -> curl error (https://curl.se/libcurl/c/libcurl-errors.html),
+     *         -1 : object bigger than maxSize,
+     *         -2 : curl initialization error
      */
   template <typename T>
-  void storeAsTFileAny(const T* obj, std::string const& path, std::map<std::string, std::string> const& metadata,
+  int storeAsTFileAny(const T* obj, std::string const& path, std::map<std::string, std::string> const& metadata,
                        long startValidityTimestamp = -1, long endValidityTimestamp = -1, std::vector<char>::size_type maxSize = 0 /*bytes*/) const
   {
-    storeAsTFile_impl(reinterpret_cast<const void*>(obj), typeid(T), path, metadata, startValidityTimestamp, endValidityTimestamp, maxSize);
+    return storeAsTFile_impl(reinterpret_cast<const void*>(obj), typeid(T), path, metadata, startValidityTimestamp, endValidityTimestamp, maxSize);
   }
 
   // interface for storing TObject via storeAsTFileAny
-  void storeAsTFileAny(const TObject* rootobj, std::string const& path, std::map<std::string, std::string> const& metadata,
+  int storeAsTFileAny(const TObject* rootobj, std::string const& path, std::map<std::string, std::string> const& metadata,
                        long startValidityTimestamp = -1, long endValidityTimestamp = -1, std::vector<char>::size_type maxSize = 0 /*bytes*/) const
   {
-    storeAsTFile(rootobj, path, metadata, startValidityTimestamp, endValidityTimestamp, maxSize);
+    return storeAsTFile(rootobj, path, metadata, startValidityTimestamp, endValidityTimestamp, maxSize);
   }
 
   /**
@@ -392,19 +400,31 @@ class CcdbApi //: public DatabaseInterface
  public:
   /**
    * A generic method to store a binary buffer (e.g. an image of the TMemFile)
+   * @return 0 -> ok,
+   *         positive number -> curl error (https://curl.se/libcurl/c/libcurl-errors.html),
+   *         -1 : object bigger than maxSize,
+   *         -2 : curl initialization error
    */
-  void storeAsBinaryFile(const char* buffer, size_t size, const std::string& fileName, const std::string& objectType,
+  int storeAsBinaryFile(const char* buffer, size_t size, const std::string& fileName, const std::string& objectType,
                          const std::string& path, const std::map<std::string, std::string>& metadata,
                          long startValidityTimestamp, long endValidityTimestamp, std::vector<char>::size_type maxSize = 0 /*in bytes*/) const;
 
   /**
    * A generic helper implementation to store an obj whose type is given by a std::type_info
+   * @return 0 -> ok,
+   *         positive number -> curl error (https://curl.se/libcurl/c/libcurl-errors.html),
+   *         -1 : object bigger than maxSize,
+   *         -2 : curl initialization error
    */
-  void storeAsTFile_impl(const void* obj1, std::type_info const& info, std::string const& path, std::map<std::string, std::string> const& metadata,
+  int storeAsTFile_impl(const void* obj1, std::type_info const& info, std::string const& path, std::map<std::string, std::string> const& metadata,
                          long startValidityTimestamp = -1, long endValidityTimestamp = -1, std::vector<char>::size_type maxSize = 0 /*in bytes*/) const;
 
   /**
    * A generic helper implementation to query obj whose type is given by a std::type_info
+   * @return 0 -> ok,
+   *         positive number -> curl error (https://curl.se/libcurl/c/libcurl-errors.html),
+   *         -1 : object bigger than maxSize,
+   *         -2 : curl initialization error
    */
   void* retrieveFromTFile(std::type_info const&, std::string const& path, std::map<std::string, std::string> const& metadata,
                           long timestamp = -1, std::map<std::string, std::string>* headers = nullptr, std::string const& etag = "",

--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -121,7 +121,7 @@ class CcdbApi //: public DatabaseInterface
      *         -2 : curl initialization error
      */
   int storeAsTFile(const TObject* rootObject, std::string const& path, std::map<std::string, std::string> const& metadata,
-                    long startValidityTimestamp = -1, long endValidityTimestamp = -1, std::vector<char>::size_type maxSize = 0 /*bytes*/) const;
+                   long startValidityTimestamp = -1, long endValidityTimestamp = -1, std::vector<char>::size_type maxSize = 0 /*bytes*/) const;
 
   /**
      * Store into the CCDB a TFile containing an object of type T (which needs to have a ROOT dictionary)
@@ -138,14 +138,14 @@ class CcdbApi //: public DatabaseInterface
      */
   template <typename T>
   int storeAsTFileAny(const T* obj, std::string const& path, std::map<std::string, std::string> const& metadata,
-                       long startValidityTimestamp = -1, long endValidityTimestamp = -1, std::vector<char>::size_type maxSize = 0 /*bytes*/) const
+                      long startValidityTimestamp = -1, long endValidityTimestamp = -1, std::vector<char>::size_type maxSize = 0 /*bytes*/) const
   {
     return storeAsTFile_impl(reinterpret_cast<const void*>(obj), typeid(T), path, metadata, startValidityTimestamp, endValidityTimestamp, maxSize);
   }
 
   // interface for storing TObject via storeAsTFileAny
   int storeAsTFileAny(const TObject* rootobj, std::string const& path, std::map<std::string, std::string> const& metadata,
-                       long startValidityTimestamp = -1, long endValidityTimestamp = -1, std::vector<char>::size_type maxSize = 0 /*bytes*/) const
+                      long startValidityTimestamp = -1, long endValidityTimestamp = -1, std::vector<char>::size_type maxSize = 0 /*bytes*/) const
   {
     return storeAsTFile(rootobj, path, metadata, startValidityTimestamp, endValidityTimestamp, maxSize);
   }
@@ -406,8 +406,8 @@ class CcdbApi //: public DatabaseInterface
    *         -2 : curl initialization error
    */
   int storeAsBinaryFile(const char* buffer, size_t size, const std::string& fileName, const std::string& objectType,
-                         const std::string& path, const std::map<std::string, std::string>& metadata,
-                         long startValidityTimestamp, long endValidityTimestamp, std::vector<char>::size_type maxSize = 0 /*in bytes*/) const;
+                        const std::string& path, const std::map<std::string, std::string>& metadata,
+                        long startValidityTimestamp, long endValidityTimestamp, std::vector<char>::size_type maxSize = 0 /*in bytes*/) const;
 
   /**
    * A generic helper implementation to store an obj whose type is given by a std::type_info
@@ -417,7 +417,7 @@ class CcdbApi //: public DatabaseInterface
    *         -2 : curl initialization error
    */
   int storeAsTFile_impl(const void* obj1, std::type_info const& info, std::string const& path, std::map<std::string, std::string> const& metadata,
-                         long startValidityTimestamp = -1, long endValidityTimestamp = -1, std::vector<char>::size_type maxSize = 0 /*in bytes*/) const;
+                        long startValidityTimestamp = -1, long endValidityTimestamp = -1, std::vector<char>::size_type maxSize = 0 /*in bytes*/) const;
 
   /**
    * A generic helper implementation to query obj whose type is given by a std::type_info

--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -140,12 +140,11 @@ void CcdbApi::storeAsTFile_impl(const void* obj, std::type_info const& tinfo, st
                     path, metadata, startValidityTimestamp, endValidityTimestamp, maxSize);
 }
 
-
 void CcdbApi::storeAsBinaryFile(const char* buffer, size_t size, const std::string& filename, const std::string& objectType,
                                 const std::string& path, const std::map<std::string, std::string>& metadata,
                                 long startValidityTimestamp, long endValidityTimestamp, std::vector<char>::size_type maxSize) const
 {
-  if(maxSize > 0 && size > maxSize) {
+  if (maxSize > 0 && size > maxSize) {
     LOG(debug2) << "object " << path << " is bigger than the maximum allowed size (" << maxSize << "B) - skipped";
     return;
   }

--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -129,22 +129,22 @@ std::unique_ptr<std::vector<char>> CcdbApi::createObjectImage(const TObject* roo
 }
 
 int CcdbApi::storeAsTFile_impl(const void* obj, std::type_info const& tinfo, std::string const& path,
-                                std::map<std::string, std::string> const& metadata,
-                                long startValidityTimestamp, long endValidityTimestamp,
-                                std::vector<char>::size_type maxSize) const
+                               std::map<std::string, std::string> const& metadata,
+                               long startValidityTimestamp, long endValidityTimestamp,
+                               std::vector<char>::size_type maxSize) const
 {
   // We need the TClass for this type; will verify if dictionary exists
   CcdbObjectInfo info;
   auto img = createObjectImage(obj, tinfo, &info);
   return storeAsBinaryFile(img->data(), img->size(), info.getFileName(), info.getObjectType(),
-                    path, metadata, startValidityTimestamp, endValidityTimestamp, maxSize);
+                           path, metadata, startValidityTimestamp, endValidityTimestamp, maxSize);
 }
 
 int CcdbApi::storeAsBinaryFile(const char* buffer, size_t size, const std::string& filename, const std::string& objectType,
-                                const std::string& path, const std::map<std::string, std::string>& metadata,
-                                long startValidityTimestamp, long endValidityTimestamp, std::vector<char>::size_type maxSize) const
+                               const std::string& path, const std::map<std::string, std::string>& metadata,
+                               long startValidityTimestamp, long endValidityTimestamp, std::vector<char>::size_type maxSize) const
 {
-  if(maxSize > 0 && size > maxSize) {
+  if (maxSize > 0 && size > maxSize) {
     return -1;
   }
 
@@ -219,7 +219,7 @@ int CcdbApi::storeAsBinaryFile(const char* buffer, size_t size, const std::strin
 }
 
 int CcdbApi::storeAsTFile(const TObject* rootObject, std::string const& path, std::map<std::string, std::string> const& metadata,
-                           long startValidityTimestamp, long endValidityTimestamp, std::vector<char>::size_type maxSize) const
+                          long startValidityTimestamp, long endValidityTimestamp, std::vector<char>::size_type maxSize) const
 {
   // Prepare file
   CcdbObjectInfo info;

--- a/CCDB/test/testCcdbApi.cxx
+++ b/CCDB/test/testCcdbApi.cxx
@@ -200,6 +200,21 @@ BOOST_AUTO_TEST_CASE(store_retrieve_TMemFile_templated_test, *utf::precondition(
   }
 }
 
+BOOST_AUTO_TEST_CASE(store_max_size_test, *utf::precondition(if_reachable()))
+{
+  test_fixture f;
+
+  // try to store a user defined class
+  // since we don't depend on anything, we are putting an object known to CCDB
+  o2::ccdb::IdPath path;
+  path.setPath("HelloWorld");
+
+  int result = f.api.storeAsTFileAny(&path, basePath + "CCDBPath", f.metadata); // ok
+  BOOST_CHECK_EQUAL(result, 0);
+  result = f.api.storeAsTFileAny(&path, basePath + "CCDBPath", f.metadata, -1, -1, 1 /* bytes */); // we know this will fail
+  BOOST_CHECK_EQUAL(result, -1);
+}
+
 /// A test verifying that the DB responds the correct result for given timestamps
 BOOST_AUTO_TEST_CASE(timestamptest, *utf::precondition(if_reachable()))
 {


### PR DESCRIPTION
We have encountered cases when the users would send very large objects to the CCDB and causing havoc later on. We would like to limit the size of the objects sent to the QCDB. 

I propose to add a parameter to the `store*` methods specifying such a maximum limit.

Doing it on the client side, i.e. in the QC, would mean that we have to do the gymnastic of serializing the object just to know its size although it is done any ways in the CcdbApi. Therfore, I prefer to do it in the ccdbapi to avoid doing it twice in particular given that it is a very expensive operation.

I also considered to have the max size as an object member. However one might want to vary the max size of the objects.

Last note: the logging of the message when an object is too big might be an issue as it could be repeated many times. On the other hand it is a debug message and it is quite important to be informed that the operation failed. I considered throwing an exception but it would change the interface of these methods and I was not sure it would be wise.

What do you think ? 



