### PR TITLE
CPV: Remove unnecessary CCDB server check

### DIFF
--- a/Detectors/CPV/simulation/src/Digitizer.cxx
+++ b/Detectors/CPV/simulation/src/Digitizer.cxx
@@ -36,11 +36,6 @@ void Digitizer::init()
     LOG(info) << "[CPVDigitizer] No reading calibration from ccdb requested, set default";
   } else {
     auto& ccdbMgr = o2::ccdb::BasicCCDBManager::instance();
-    bool isCcdbReachable = ccdbMgr.isHostReachable(); //if host is not reachable we can use only dummy calibration
-    if (!isCcdbReachable) {
-      LOG(fatal) << "[CPVDigitizer] CCDB Host is not reachable!!!";
-      return;
-    }
     ccdbMgr.setCaching(true);                     //make local cache of remote objects
     ccdbMgr.setLocalObjectValidityChecking(true); //query objects from remote site only when local one is not valid
     //read calibration from ccdb (for now do it only at the beginning of dataprocessing)


### PR DESCRIPTION
Remove check if CCDB server is reachable, for the following
reasons:

- BasicCCDBManager fatals anyway when it can't deliver an object

- The error handling can be done depending on if we get an object or not

- The isHostReachable() check prevents use with local CCDB snapshots

- in removing this line, we are able to run the O2DPG MC workflow
  against a CVMFS CCDB snapshot (verified without network connection)