### PR TITLE
Parallelization of ITS threshold calibration workflow + new features

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/workflow/CMakeLists.txt
@@ -10,6 +10,7 @@
 # or submit itself to any jurisdiction.
 
 o2_add_library(ITSWorkflow
+               TARGETVARNAME targetName
                SOURCES src/RecoWorkflow.cxx
                        src/ClusterWriterWorkflow.cxx
                        src/ClustererSpec.cxx
@@ -55,3 +56,9 @@ o2_add_executable(threshold-calib-workflow
                   SOURCES src/its-threshold-calib-workflow.cxx
                   COMPONENT_NAME its
                   PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
+
+if (OpenMP_CXX_FOUND)
+    target_compile_definitions(${targetName} PRIVATE WITH_OPENMP)
+    target_link_libraries(${targetName} PRIVATE OpenMP::OpenMP_CXX)
+endif()
+

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdCalibratorSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdCalibratorSpec.h
@@ -16,9 +16,11 @@
 
 #include <sys/stat.h>
 #include <filesystem>
-//#include <assert.h>
 #include <string>
 #include <vector>
+#include <array>
+#include <unistd.h>
+
 #include <iostream>
 #include <fstream>
 
@@ -42,11 +44,10 @@
 #include "TTree.h"
 #include "TH1F.h"
 #include "TF1.h"
+#include "TStopwatch.h"
 
 using namespace o2::framework;
 using namespace o2::itsmft;
-// using namespace o2::header;
-// using namespace o2::ccdb;
 
 namespace o2
 {
@@ -54,24 +55,6 @@ namespace its
 {
 
 constexpr int N_INJ = 50;
-
-struct ThresholdObj {
- public:
-  ThresholdObj(short _row, short _col, short _threshold, short _noise, bool _success) : row(_row), col(_col), threshold(_threshold), noise(_noise), success(_success){};
-
-  short int row = -1, col = -1;
-
-  // threshold * 10 saved as short int to save memory
-  short int threshold = -1, noise = -1;
-
-  // Whether or not the fit is good
-  bool success = false;
-};
-
-// Object for storing chip info in TTree
-typedef struct {
-  short int chipID, row, col;
-} Pixel;
 
 // List of the possible run types for reference
 enum RunTypes {
@@ -95,17 +78,11 @@ enum FitTypes {
   HITCOUNTING = 2
 };
 
-struct ThresholdMap {
- public:
-  ThresholdMap(const std::map<short int, std::vector<ThresholdObj>>& t) : thresholds(t){};
-  std::map<short int, std::vector<ThresholdObj>> thresholds;
-};
-
-class ITSCalibrator : public Task
+class ITSThresholdCalibrator : public Task
 {
  public:
-  ITSCalibrator();
-  ~ITSCalibrator() override;
+  ITSThresholdCalibrator();
+  ~ITSThresholdCalibrator() override;
 
   using ChipPixelData = o2::itsmft::ChipPixelData;
   o2::itsmft::ChipMappingITS mp;
@@ -121,9 +98,6 @@ class ITSCalibrator : public Task
  private:
   // detector information
   static constexpr short int N_COL = 1024; // column number in Alpide chip
-  // static constexpr short int N_ROW = 512;  // row number in Alpide chip
-  // static constexpr short int N_LAYER = 7;   // layer number in ITS detector
-  // static constexpr short int N_LAYER_IB = 3;
 
   const short int N_RU = o2::itsmft::ChipMappingITS::getNRUs();
 
@@ -139,30 +113,20 @@ class ITSCalibrator : public Task
   // The x-axis of the correct data fit chosen above
   short int* mX = nullptr;
 
-  // const short int NSubStave[N_LAYER] = {1, 1, 1, 2, 2, 2, 2};
-  // const short int NStaves[N_LAYER] = {12, 16, 20, 24, 30, 42, 48};
-  // const short int nHicPerStave[N_LAYER] = {1, 1, 1, 8, 8, 14, 14};
-  // const short int nChipsPerHic[N_LAYER] = {9, 9, 9, 14, 14, 14, 14};
-  // const short int ChipBoundary[N_LAYER + 1] = { 0, 108, 252, 432, 3120, 6480, 14712, 24120 };
-  // const short int StaveBoundary[N_LAYER + 1] = {0, 12, 28, 48, 72, 102, 144, 192};
-  // const short int ReduceFraction = 1; // TODO: move to Config file to define this number
-  // std::array<bool, N_LAYER> mEnableLayers = { false };
-
   // Hash tables to store the hit and threshold information per pixel
   std::unordered_map<short int, short int> mCurrentRow;
   std::unordered_map<short int, std::vector<std::vector<char>>> mPixelHits;
-  // std::map<short int, char**> mPixelHits;
-  //   Unordered vector for saving info to the output
-  std::unordered_map<short int, std::vector<ThresholdObj>> mThresholds;
-  // std::unordered_map<unsigned int, int> mHitPixelID_Hash[7][48][2][14][14]; //layer, stave, substave, hic, chip
+  //   Unordered map for saving sum of values (thr/ithr/vcasn) for avg calculation
+  std::unordered_map<short int, std::array<int, 5>> mThresholds;
 
   // Tree to save threshold info in full threshold scan case
   TFile* mRootOutfile = nullptr;
   TTree* mThresholdTree = nullptr;
-  Pixel mTreePixel;
-  // Save charge & counts as char (8-bit) to save memory, since values should be < 256
-  unsigned char mThreshold = 0, mNoise = 0;
-  bool mSuccess = false;
+  short int vChipid[N_COL];
+  short int vRow[N_COL];
+  short int vThreshold[N_COL];
+  bool vSuccess[N_COL];
+  unsigned char vNoise[N_COL];
 
   // Initialize pointers for doing error function fits
   TH1F* mFitHist = nullptr;
@@ -187,12 +151,12 @@ class ITSCalibrator : public Task
   bool findThresholdDerivative(const char*, const short int*, const short int&, float&, float&);
   bool findThresholdHitcounting(const char*, const short int*, const short int&, float&);
   bool isScanFinished(const short int&);
-  void findAverage(const std::vector<ThresholdObj>&, float&, float&);
-  void saveThreshold(const short int&, const short int&, const short int&, float*, float*, bool);
+  void findAverage(const std::array<int, 5>&, float&, float&, float&, float&);
+  void saveThreshold();
 
   // Helper functions for writing to the database
   void addDatabaseEntry(const short int&, const char*, const short int&,
-                        const float&, bool, o2::dcs::DCSconfigObject_t&);
+                        const float&, const short int&, const float&, bool, o2::dcs::DCSconfigObject_t&);
   void sendToCCDB(const char*, o2::dcs::DCSconfigObject_t&, EndOfStreamContext*);
 
   std::string mSelfName;
@@ -205,6 +169,7 @@ class ITSCalibrator : public Task
   std::string mEnvironmentID;
   std::string mOutputDir;
   std::string mMetafileDir = "/dev/null";
+  int mNThreads = 1;
   int mRunNumber = -1;
 
   // How many rows before starting new ROOT file

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdCalibratorSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdCalibratorSpec.h
@@ -19,7 +19,6 @@
 #include <string>
 #include <vector>
 #include <array>
-#include <unistd.h>
 
 #include <iostream>
 #include <fstream>
@@ -44,7 +43,6 @@
 #include "TTree.h"
 #include "TH1F.h"
 #include "TF1.h"
-#include "TStopwatch.h"
 
 using namespace o2::framework;
 using namespace o2::itsmft;


### PR DESCRIPTION
Changes applied:
- parallelization of thr extraction and sum of thr for avg calculation
- modification of avg and rms calculation: sum values as soon as they are calculated so that we don't take into memory all thresholds
- modification of tree format to allow parallelization: for each row we have now C arrays.
- class name changed from ITSCalibrator to ITSThresholdCalibrator (as suggested by Ruben)
- Removed commented lines of code (as suggested by Ruben)
- added option nthreads to chose the number of threads (def is 1) 
- added avg/rms calculation also for thr scan so that we push to CCDB also avg thr&noise and rms for each chip (as for the tuning scans)
