### PR TITLE
GPU: Was not using clang and llvm-spirv from the alidist clang installation

### DIFF
--- a/GPU/GPUTracking/Base/opencl2/CMakeLists.txt
+++ b/GPU/GPUTracking/Base/opencl2/CMakeLists.txt
@@ -83,7 +83,7 @@ if(OPENCL2_ENABLED_SPIRV) # BUILD OpenCL2 intermediate code for SPIR-V target
   # executes clang to create llvm IL code
   add_custom_command(
       OUTPUT ${CL_BIN}.bc
-      COMMAND clang
+      COMMAND ${LLVM_CLANG}
               -O0
               -emit-llvm --target=spir64-unknown-unknown
               ${OCL_FLAGS}
@@ -124,7 +124,7 @@ if(OPENCL2_ENABLED) # BUILD OpenCL2 source code for runtime compilation target
   # executes clang to preprocess
   add_custom_command(
       OUTPUT ${CL_BIN}.src
-      COMMAND clang
+      COMMAND ${LLVM_CLANG}
               ${OCL_DEFINECL} -cl-no-stdinc
               -E ${CL_SRC} > ${CL_BIN}.src
       MAIN_DEPENDENCY ${CL_SRC}

--- a/dependencies/FindO2GPU.cmake
+++ b/dependencies/FindO2GPU.cmake
@@ -129,7 +129,8 @@ if(ENABLE_OPENCL2)
   endif()
   find_program(CLANG_OCL clang-ocl PATHS "${ROCM_ROOT}/bin")
   find_program(ROCM_AGENT_ENUMERATOR rocm_agent_enumerator PATHS "${ROCM_ROOT}/bin")
-  find_program(LLVM_SPIRV llvm-spirv)
+  find_program(LLVM_SPIRV llvm-spirv HINTS "${Clang_DIR}/../../../bin-safe")
+  find_program(LLVM_CLANG clang HINTS "${Clang_DIR}/../../../bin-safe")
   if(Clang_FOUND
      AND LLVM_FOUND
      AND LLVM_PACKAGE_VERSION VERSION_GREATER_EQUAL 13.0)


### PR DESCRIPTION
We had lost the OpenCL2 part in the FullCI when we switched to the alidist clang, since it couldn't find the binaries in the bin-safe folder.