### PR TITLE
[MFT] Increase search radius for linear tracks

### DIFF
--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/MFTTrackingParam.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/MFTTrackingParam.h
@@ -42,13 +42,13 @@ struct MFTTrackingParam : public o2::conf::ConfigurableParamHelper<MFTTrackingPa
   /// minimum number of points for a LTF track
   Int_t MinTrackPointsLTF = 5;
   /// minimum number of points for a CA track
-  Int_t MinTrackPointsCA = 4;
+  Int_t MinTrackPointsCA = 5;
   /// minimum number of detector stations for a LTF track
   Int_t MinTrackStationsLTF = 4;
   /// minimum number of detector stations for a CA track
   Int_t MinTrackStationsCA = 4;
   /// maximum distance for a cluster to be attached to a seed line (LTF)
-  Float_t LTFclsRCut = 0.100; // Temporary for misaligned detector. Default 0.0100
+  Float_t LTFclsRCut = 0.200; // Temporary for misaligned detector. Default 0.0100
   /// maximum distance for a cluster to be attached to a seed line (CA road)
   Float_t ROADclsRCut = 0.0400;
   /// number of bins in r-direction


### PR DESCRIPTION
Thanks to @robincaron13, we learned that the relative misalignment of parts of one half disk is slightly beyond the current search radius.
This PR increases the default search radius to 2 mm and adjust the minimum number of points for consistency in both track-finding methods.