### PR TITLE
Excutable to create GRPECS CCDB entry

### DIFF
--- a/DataFormats/Parameters/include/DataFormatsParameters/GRPECSObject.h
+++ b/DataFormats/Parameters/include/DataFormatsParameters/GRPECSObject.h
@@ -48,6 +48,9 @@ class GRPECSObject
   timePoint getTimeStart() const { return mTimeStart; }
   void setTimeStart(timePoint t) { mTimeStart = t; }
 
+  timePoint getTimeEnd() const { return mTimeEnd; }
+  void setTimeEnd(timePoint t) { mTimeEnd = t; }
+
   void setNHBFPerTF(uint32_t n) { mNHBFPerTF = n; }
   uint32_t getNHBFPerTF() const { return mNHBFPerTF; }
 
@@ -109,6 +112,7 @@ class GRPECSObject
 
  private:
   timePoint mTimeStart = 0; ///< DAQ_time_start entry from DAQ logbook
+  timePoint mTimeEnd = 0;   ///< DAQ_time_end entry from DAQ logbook
 
   uint32_t mNHBFPerTF = 128; /// Number of HBFrames per TF
 
@@ -119,7 +123,7 @@ class GRPECSObject
   int mRun = 0;                 ///< run identifier
   std::string mDataPeriod = ""; ///< name of the period
 
-  ClassDefNV(GRPECSObject, 2);
+  ClassDefNV(GRPECSObject, 3);
 };
 
 } // namespace parameters

--- a/DataFormats/Parameters/src/GRPECSObject.cxx
+++ b/DataFormats/Parameters/src/GRPECSObject.cxx
@@ -26,8 +26,10 @@ using o2::detectors::DetID;
 void GRPECSObject::print() const
 {
   // print itself
-  std::time_t t = mTimeStart; // system_clock::to_time_t(mTimeStart);
-  printf("Start: %s, isMC: %d", std::ctime(&t), isMC());
+  std::time_t ts = mTimeStart / 1000, te = mTimeEnd / 1000;
+  printf("Start: %s", std::ctime(&ts));
+  printf("End  : %s", std::ctime(&te));
+  printf("isMC : %d ", isMC());
   printf("Detectors: Cont.RO Triggers\n");
   for (auto i = DetID::First; i <= DetID::Last; i++) {
     if (!isDetReadOut(DetID(i))) {

--- a/Detectors/GRP/workflows/CMakeLists.txt
+++ b/Detectors/GRP/workflows/CMakeLists.txt
@@ -13,19 +13,28 @@ o2_add_library(GRPCalibrationWorkflow
   TARGETVARNAME targetName
                SOURCES src/GRPLHCIFfileSpec.cxx
                PUBLIC_LINK_LIBRARIES O2::Framework
-                     O2::Headers
-                     O2::CCDB
-                     O2::CommonUtils
-                     Microsoft.GSL::GSL
-         O2::GRPCalibration
-         O2::DataFormatsParameters
-         O2::DetectorsCalibration)
+                                     O2::Headers
+                                     O2::CCDB
+                                     O2::CommonUtils
+                                     Microsoft.GSL::GSL
+                                     O2::GRPCalibration
+                                     O2::DataFormatsParameters
+                                     O2::DetectorsCalibration)
 
 o2_add_executable(grp-lhc-if-file-workflow
                   COMPONENT_NAME calibration
                   SOURCES src/gpr-lhc-if-file-workflow.cxx
                   PUBLIC_LINK_LIBRARIES O2::Framework
-                  O2::CCDB
-      O2::GRPCalibrationWorkflow
-      O2::GRPCalibration
-      O2::DetectorsCalibration)
+                                        O2::CCDB
+                                        O2::GRPCalibrationWorkflow
+                                        O2::GRPCalibration
+                                        O2::DetectorsCalibration)
+
+o2_add_executable(grp-create
+                  COMPONENT_NAME ecs
+                  SOURCES src/create-grp-ecs.cxx
+                  PUBLIC_LINK_LIBRARIES O2::DetectorsCommonDataFormats
+                                        O2::DataFormatsParameters
+                                        O2::CommonUtils
+                                        O2::CCDB
+                                        Boost::program_options)

--- a/Detectors/GRP/workflows/src/create-grp-ecs.cxx
+++ b/Detectors/GRP/workflows/src/create-grp-ecs.cxx
@@ -1,0 +1,148 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <boost/program_options.hpp>
+#include <ctime>
+#include <chrono>
+#include "DataFormatsParameters/GRPECSObject.h"
+#include "DetectorsCommonDataFormats/DetID.h"
+#include "CCDB/CcdbApi.h"
+#include "CommonUtils/NameConf.h"
+#include "CommonUtils/StringUtils.h"
+
+using DetID = o2::detectors::DetID;
+using CcdbApi = o2::ccdb::CcdbApi;
+using GRPECSObject = o2::parameters::GRPECSObject;
+
+namespace bpo = boost::program_options;
+
+void createGRPECSObject(const std::string& dataPeriod,
+                        int run,
+                        int nHBPerTF,
+                        const std::string& detsReadout,
+                        const std::string& detsContinuousRO,
+                        const std::string& detsTrigger,
+                        long tstart,
+                        long tend,
+                        std::string ccdbServer = "")
+{
+  auto detMask = o2::detectors::DetID::getMask(detsReadout);
+  if (detMask.count() == 0) {
+    throw std::runtime_error("empty detectors list is provided");
+  }
+  auto detMaskCont = detMask & o2::detectors::DetID::getMask(detsContinuousRO);
+  auto detMaskTrig = detMask & o2::detectors::DetID::getMask(detsTrigger);
+  LOG(info) << tstart << " " << tend;
+  if (tstart == 0) {
+    tstart = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+  }
+  if (tend == 0) {
+    tend = tstart + 3 * 24 * 3600 * 1000UL;
+    LOG(info) << tstart << " -> " << tend;
+  }
+  GRPECSObject grpecs;
+  grpecs.setTimeStart(tstart);
+  grpecs.setTimeEnd(tend);
+
+  grpecs.setNHBFPerTF(nHBPerTF);
+  grpecs.setDetsReadOut(detMask);
+  grpecs.setDetsContinuousReadOut(detMaskCont);
+  grpecs.setDetsTrigger(detMaskTrig);
+  grpecs.setRun(run);
+  grpecs.setDataPeriod(dataPeriod);
+
+  grpecs.print();
+
+  if (!ccdbServer.empty()) {
+    CcdbApi api;
+    api.init(ccdbServer);
+    std::map<std::string, std::string> metadata;
+    metadata["responsible"] = "ECS";
+    metadata[o2::base::NameConf::CCDBRunTag.data()] = std::to_string(run);
+    // long ts = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+    api.storeAsTFileAny(&grpecs, "GLO/Config/GRPECS", metadata, tstart, tend); // making it 1-year valid to be sure we have something
+    LOG(info) << "Uploaded to " << ccdbServer << "/"
+              << "GLO/Config/GRPECS";
+  } else { // write a local file
+    auto fname = o2::base::NameConf::getGRPECSFileName();
+    TFile grpF(fname.c_str(), "recreate");
+    grpF.WriteObjectAny(&grpecs, grpecs.Class(), o2::base::NameConf::CCDBOBJECT.data());
+    LOG(info) << "Stored to local file " << fname;
+  }
+}
+
+int main(int argc, char** argv)
+{
+  bpo::variables_map vm;
+  bpo::options_description opt_general(
+    "Create GRP-ECS object and upload to the CCDB\n"
+    "Usage:\n  " +
+    std::string(argv[0]) +
+    "");
+  bpo::options_description opt_hidden("");
+  bpo::options_description opt_all;
+  bpo::positional_options_description opt_pos;
+
+  try {
+    auto add_option = opt_general.add_options();
+    add_option("help,h", "Print this help message");
+    add_option("period,p", bpo::value<std::string>(), "data taking period");
+    add_option("run,r", bpo::value<int>(), "run number");
+    add_option("hbf-per-tf,n", bpo::value<int>()->default_value(128), "number of HBFs per TF");
+    add_option("detectors,d", bpo::value<string>()->default_value("all"), "comma separated list of detectors");
+    add_option("continuous,c", bpo::value<string>()->default_value("ITS,TPC,TOF,MFT,MCH,MID,ZDC,FT0,FV0,FDD,CTP"), "comma separated list of detectors in continuous readout mode");
+    add_option("triggering,t", bpo::value<string>()->default_value("FT0,FV0"), "comma separated list of detectors providing a trigger");
+    add_option("start-time,s", bpo::value<long>()->default_value(0), "run start time in ms, now() if 0");
+    add_option("end-time,e", bpo::value<long>()->default_value(0), "run end time in ms, start-time+3days is used if 0");
+    add_option("ccdb-server", bpo::value<std::string>()->default_value("http://alice-ccdb.cern.ch"), "CCDB server for upload, local file if empty");
+
+    opt_all.add(opt_general).add(opt_hidden);
+    bpo::store(bpo::command_line_parser(argc, argv).options(opt_all).positional(opt_pos).run(), vm);
+
+    if (vm.count("help")) {
+      std::cout << opt_general << std::endl;
+      exit(0);
+    }
+
+    bpo::notify(vm);
+  } catch (bpo::error& e) {
+    std::cerr << "ERROR: " << e.what() << std::endl
+              << std::endl;
+    std::cerr << opt_general << std::endl;
+    exit(1);
+  } catch (std::exception& e) {
+    std::cerr << e.what() << ", application will now exit" << std::endl;
+    exit(2);
+  }
+  if (vm.count("run") == 0) {
+    std::cerr << "ERROR: "
+              << "obligator run number is missing" << std::endl;
+    std::cerr << opt_general << std::endl;
+    exit(3);
+  }
+  if (vm.count("period") == 0) {
+    std::cerr << "ERROR: "
+              << "obligator data taking period name is missing" << std::endl;
+    std::cerr << opt_general << std::endl;
+    exit(3);
+  }
+
+  createGRPECSObject(
+    vm["period"].as<std::string>(),
+    vm["run"].as<int>(),
+    vm["hbf-per-tf"].as<int>(),
+    vm["detectors"].as<std::string>(),
+    vm["continuous"].as<std::string>(),
+    vm["triggering"].as<std::string>(),
+    vm["start-time"].as<long>(),
+    vm["end-time"].as<long>(),
+    vm["ccdb-server"].as<std::string>());
+}


### PR DESCRIPTION
Only run-number and data taking period are obligatory.

```
o2-ecs-grp-create -h 
Create GRP-ECS object and upload to the CCDB
Usage:
  o2-ecs-grp-create 
  -h [ --help ]                         Print this help message
  -p [ --period ] arg                   data taking period
  -r [ --run ] arg                      run number
  -n [ --hbf-per-tf ] arg (=128)        number of HBFs per TF
  -d [ --detectors ] arg (=all)         comma separated list of detectors
  -c [ --continuous ] arg (=ITS,TPC,TOF,MFT,MCH,MID,ZDC,FT0,FV0,FDD,CTP) comma separated list of detectors in continuous readout mode
  -t [ --triggering ] arg (=FT0,FV0)    comma separated list of detectors providing a trigger
  -s [ --start-time ] arg (=0)          run start time in ms, now() if 0
  -e [ --end-time ] arg (=0)            run end time in ms, start-time+3days is used if 0
  --ccdb-server arg (=http://alice-ccdb.cern.ch) CCDB server for upload, local file if empty
```