### PR TITLE
Fixing command line arguments of unit test

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -344,7 +344,7 @@ o2_add_test(
   NO_BOOST_TEST
   COMMAND_LINE_ARGS
     --global-config require-me --run ${DPL_WORKFLOW_TESTS_EXTRA_OPTIONS}
-    # Note: the group switch makes process consumer parse only the group
-    arguments --consumer
+    # Note: with group switch, process 'consumer' will only parse the group arguments
+    --consumer
     "--global-config consumer-config --local-option hello-aliceo2 --a-boolean3 --an-int2 20 --a-double2 22. --an-int64-2 50000000000000"
   )


### PR DESCRIPTION
This has been scrambled when migrating to modern cmake in
3f4eed12aaa5659c6b559fbd044fcaa81e584f94