### PR TITLE
Possibility to disable whole ITS/MFT chip

### DIFF
--- a/DataFormats/Detectors/ITSMFT/common/src/NoiseMap.cxx
+++ b/DataFormats/Detectors/ITSMFT/common/src/NoiseMap.cxx
@@ -22,13 +22,19 @@ using namespace o2::itsmft;
 
 void NoiseMap::print()
 {
-  int nc = 0, np = 0;
+  int nc = 0, np = 0, nm = 0;
   for (const auto& map : mNoisyPixels) {
     if (!map.empty()) {
       nc++;
     }
     np += map.size();
+    if (map.find(getKey(-1, -1)) != map.end()) {
+      nm++;
+      nc--;
+      np--;
+    }
   }
+  LOG(info) << "Number of fully maske chips " << nm;
   LOG(info) << "Number of noisy chips: " << nc;
   LOG(info) << "Number of noisy pixels: " << np;
   LOG(info) << "Number of of strobes: " << mNumOfStrobes;


### PR DESCRIPTION
maskFullChip(chipID) and isFullChipMasked(chipID) allow to mask full chip and query if it is masked. 
These methods can be applied on top of masking specific pixels, i.e. the chip can be fully masked but to have at the same time also particular pixels flagged. 
To ensure that only full mask is set, call it as maskFullChip(chipID, true);

Note that the old method isNoisy(chip, row, col) does not check if the whole chip was masked. To have a combined check one should use isNoisyOrFullyMasked(chip, row, col);