### PR TITLE
DPL Analysis: Set tables only once for event mixing

### DIFF
--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -27,8 +27,6 @@
 #include "Framework/ExpressionHelpers.h"
 #include "Framework/CommonServices.h"
 
-#include <iostream>
-
 namespace o2::framework
 {
 
@@ -47,15 +45,7 @@ struct GroupedCombinationManager<GroupedCombinationsGenerator<T1, GroupingPolicy
   {
     static_assert(sizeof...(T2s) > 0, "There must be associated tables in process() for a correct pair");
     static_assert(!soa::is_soa_iterator_t<std::decay_t<H>>::value, "Only full tables can be in process(), no grouping");
-    std::cout << "Combinations grouping type: " << typeid(G).name() << " received grouping type: " << typeid(TG).name() << std::endl;
-    std::cout << "Combinations associated type:" << std::endl;
-    print_pack<pack<As...>>();
-    std::cout << "received associated type:" << std::endl;
-    print_pack<pack<T2s...>>();
-    std::cout << "Combinations unique types:" << std::endl;
-    print_pack<pack<Us...>>();
     if constexpr (std::is_same_v<G, TG> && std::is_same_v<H, TH>) {
-      std::cout << "Setting tables in manager" << std::endl;
       // Take respective unique associated tables for grouping
       auto associatedTuple = std::tuple<Us...>(std::get<Us>(associated)...);
       comb.setTables(hashes, grouping, associatedTuple);

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -45,7 +45,7 @@ struct GroupedCombinationManager<GroupedCombinationsGenerator<T1, GroupingPolicy
   {
     static_assert(sizeof...(T2s) > 0, "There must be associated tables in process() for a correct pair");
     static_assert(!soa::is_soa_iterator_t<std::decay_t<H>>::value, "Only full tables can be in process(), no grouping");
-    if constexpr (std::is_same_v<G, TG> && std::is_same_v<H, TH>) {
+    if constexpr (std::is_same_v<G, TG> && std::is_same_v<H, TH> && std::conjunction_v<std::is_same<Us, T2s>...>) {
       // Take respective unique associated tables for grouping
       auto associatedTuple = std::tuple<Us...>(std::get<Us>(associated)...);
       comb.setTables(hashes, grouping, associatedTuple);

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -45,7 +45,7 @@ struct GroupedCombinationManager<GroupedCombinationsGenerator<T1, GroupingPolicy
   {
     static_assert(sizeof...(T2s) > 0, "There must be associated tables in process() for a correct pair");
     static_assert(!soa::is_soa_iterator_t<std::decay_t<H>>::value, "Only full tables can be in process(), no grouping");
-    if constexpr (std::is_same_v<G, TG> && std::is_same_v<H, TH> && std::conjunction_v<std::is_same<Us, T2s>...>) {
+    if constexpr (std::is_same_v<G, TG> && std::is_same_v<H, TH>) {
       // Take respective unique associated tables for grouping
       auto associatedTuple = std::tuple<Us...>(std::get<Us>(associated)...);
       comb.setTables(hashes, grouping, associatedTuple);

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -27,6 +27,8 @@
 #include "Framework/ExpressionHelpers.h"
 #include "Framework/CommonServices.h"
 
+#include <iostream>
+
 namespace o2::framework
 {
 
@@ -45,7 +47,15 @@ struct GroupedCombinationManager<GroupedCombinationsGenerator<T1, GroupingPolicy
   {
     static_assert(sizeof...(T2s) > 0, "There must be associated tables in process() for a correct pair");
     static_assert(!soa::is_soa_iterator_t<std::decay_t<H>>::value, "Only full tables can be in process(), no grouping");
-    if constexpr (std::conjunction_v<std::is_same<G, TG>, std::is_same<H, TH>>) {
+    std::cout << "Combinations grouping type: " << typeid(G).name() << " received grouping type: " << typeid(TG).name() << std::endl;
+    std::cout << "Combinations associated type:" << std::endl;
+    print_pack<pack<As...>>();
+    std::cout << "received associated type:" << std::endl;
+    print_pack<pack<T2s...>>();
+    std::cout << "Combinations unique types:" << std::endl;
+    print_pack<pack<Us...>>();
+    if constexpr (std::is_same_v<G, TG> && std::is_same_v<H, TH>) {
+      std::cout << "Setting tables in manager" << std::endl;
       // Take respective unique associated tables for grouping
       auto associatedTuple = std::tuple<Us...>(std::get<Us>(associated)...);
       comb.setTables(hashes, grouping, associatedTuple);

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -38,7 +38,6 @@
 #include <memory>
 #include <sstream>
 #include <iomanip>
-#include <iostream>
 namespace o2::framework
 {
 /// A more familiar task API for the DPL analysis framework.
@@ -316,7 +315,6 @@ struct AnalysisDataProcessorBuilder {
         associatedTables);
 
       // GroupedCombinations bound separately, as they should be set once for all associated tables
-      std::cout << "Analysis task applying tables to grouped combs" << std::endl;
       auto hashes = std::get<0>(associatedTables);
       auto realAssociated = tuple_tail(associatedTables);
       homogeneous_apply_refs([&groupingTable, &hashes, &realAssociated](auto& t) {

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -38,6 +38,7 @@
 #include <memory>
 #include <sstream>
 #include <iomanip>
+#include <iostream>
 namespace o2::framework
 {
 /// A more familiar task API for the DPL analysis framework.
@@ -315,6 +316,7 @@ struct AnalysisDataProcessorBuilder {
         associatedTables);
 
       // GroupedCombinations bound separately, as they should be set once for all associated tables
+      std::cout << "Analysis task applying tables to grouped combs" << std::endl;
       auto hashes = std::get<0>(associatedTables);
       auto realAssociated = tuple_tail(associatedTables);
       homogeneous_apply_refs([&groupingTable, &hashes, &realAssociated](auto& t) {

--- a/Framework/Core/include/Framework/GroupedCombinations.h
+++ b/Framework/Core/include/Framework/GroupedCombinations.h
@@ -17,6 +17,8 @@
 #include "Framework/Pack.h"
 #include <optional>
 
+#include <iostream>
+
 namespace o2::framework
 {
 
@@ -83,6 +85,7 @@ struct GroupedCombinationsGenerator<T1, GroupingPolicy, H, G, pack<Us...>, As...
 
     void setTables(const H& hashes, const G& grouping, std::shared_ptr<GroupSlicer<G, Us...>> slicer_ptr)
     {
+      std::cout << "Setting tables" << std::endl;
       mGrouping = std::make_shared<G>(std::vector{grouping.asArrowTable()});
       mSlicer = slicer_ptr;
       setMultipleGroupingTables<sizeof...(As)>(join(hashes, grouping));
@@ -94,6 +97,7 @@ struct GroupedCombinationsGenerator<T1, GroupingPolicy, H, G, pack<Us...>, As...
     template <std::size_t N, typename T, typename... Args>
     void setMultipleGroupingTables(const T& param, const Args&... args)
     {
+      std::cout << "Setting grouping tables" << std::endl;
       if constexpr (N == 1) {
         GroupingPolicy::setTables(param, args...);
       } else {
@@ -139,6 +143,7 @@ struct GroupedCombinationsGenerator<T1, GroupingPolicy, H, G, pack<Us...>, As...
    private:
     std::tuple<As...> getAssociatedTables()
     {
+      std::cout << "Getting associated tables" << std::endl;
       auto& currentGrouping = GroupingPolicy::mCurrent;
       constexpr auto k = sizeof...(As);
       auto slicerIterators = functionToTuple<k>(&GroupSlicer<G, Us...>::begin, *mSlicer);
@@ -171,6 +176,7 @@ struct GroupedCombinationsGenerator<T1, GroupingPolicy, H, G, pack<Us...>, As...
 
     void setCurrentGroupedCombination()
     {
+      std::cout << "Setting grouped combination" << std::endl;
       std::tuple<As...> initAssociatedTables = getAssociatedTables();
       constexpr auto k = sizeof...(As);
       bool moveForward = false;
@@ -193,11 +199,14 @@ struct GroupedCombinationsGenerator<T1, GroupingPolicy, H, G, pack<Us...>, As...
 
       if (!this->mIsEnd) {
         auto& currentGrouping = GroupingPolicy::mCurrent;
+        std::cout << "Received current grouping" << std::endl;
         o2::soa::for_<k>([&](auto i) {
           std::get<i.value>(associatedTables).bindExternalIndices(mGrouping.get());
         });
+        std::cout << "Bound associated tables" << std::endl;
 
         mCurrentGrouped.emplace(interleaveTuples(currentGrouping, associatedTables));
+        std::cout << "Interleaved tuples" << std::endl;
       }
     }
 
@@ -235,10 +244,13 @@ struct GroupedCombinationsGenerator<T1, GroupingPolicy, H, G, pack<Us...>, As...
 
   void setTables(H& hashes, G& grouping, std::tuple<Us...>& associated)
   {
-    std::shared_ptr slicer_ptr = std::make_shared<GroupSlicer<G, Us...>>(grouping, associated);
-    mBegin.setTables(hashes, grouping, slicer_ptr);
-    mEnd.setTables(hashes, grouping, slicer_ptr);
-    mEnd.moveToEnd();
+    std::cout << "Setting tables in generator" << std::endl;
+    if (mSlicer == nullptr) {
+      mSlicer = std::make_shared<GroupSlicer<G, Us...>>(grouping, associated);
+      mBegin.setTables(hashes, grouping, mSlicer);
+      mEnd.setTables(hashes, grouping, mSlicer);
+      mEnd.moveToEnd();
+    }
   }
 
  private:
@@ -247,6 +259,7 @@ struct GroupedCombinationsGenerator<T1, GroupingPolicy, H, G, pack<Us...>, As...
   const char* mCategory;
   const int mCatNeighbours;
   const T1 mOutsider;
+  std::shared_ptr<GroupSlicer<G, Us...>> mSlicer = nullptr;
 };
 
 // Aliases for 2-particle correlations

--- a/Framework/Core/include/Framework/GroupedCombinations.h
+++ b/Framework/Core/include/Framework/GroupedCombinations.h
@@ -231,6 +231,8 @@ struct GroupedCombinationsGenerator<T1, GroupingPolicy, H, G, pack<Us...>, As...
   {
     setTables(hashes, grouping, associated);
   }
+  GroupedCombinationsGenerator(GroupedCombinationsGenerator const&) = default;
+  GroupedCombinationsGenerator& operator=(GroupedCombinationsGenerator const&) = default;
   ~GroupedCombinationsGenerator() = default;
 
   void setTables(H& hashes, G& grouping, std::tuple<Us...>& associated)
@@ -257,13 +259,13 @@ struct GroupedCombinationsGenerator<T1, GroupingPolicy, H, G, pack<Us...>, As...
 template <typename H, typename G>
 using joinedCollisions = typename soa::Join<H, G>::table_t;
 template <typename H, typename G, typename A1, typename A2, typename T1 = int, typename GroupingPolicy = o2::soa::CombinationsBlockStrictlyUpperSameIndexPolicy<T1, joinedCollisions<H, G>, joinedCollisions<H, G>>>
-using Pair = GroupedCombinationsGenerator<T1, GroupingPolicy, H, G, unique_pack_t<pack<A1, A2>>>;
+using Pair = GroupedCombinationsGenerator<T1, GroupingPolicy, H, G, unique_pack_t<pack<A1, A2>>, A1, A2>;
 template <typename H, typename G, typename A, typename T1 = int, typename GroupingPolicy = o2::soa::CombinationsBlockStrictlyUpperSameIndexPolicy<T1, joinedCollisions<H, G>, joinedCollisions<H, G>>>
 using SameKindPair = GroupedCombinationsGenerator<T1, GroupingPolicy, H, G, pack<A>, A, A>;
 
 // Aliases for 3-particle correlations
 template <typename H, typename G, typename A1, typename A2, typename A3, typename T1 = int, typename GroupingPolicy = o2::soa::CombinationsBlockStrictlyUpperSameIndexPolicy<T1, joinedCollisions<H, G>, joinedCollisions<H, G>, joinedCollisions<H, G>>>
-using Triple = GroupedCombinationsGenerator<T1, GroupingPolicy, H, G, unique_pack_t<pack<A1, A2, A3>>>;
+using Triple = GroupedCombinationsGenerator<T1, GroupingPolicy, H, G, unique_pack_t<pack<A1, A2, A3>>, A1, A2, A3>;
 template <typename H, typename G, typename A, typename T1 = int, typename GroupingPolicy = o2::soa::CombinationsBlockStrictlyUpperSameIndexPolicy<T1, joinedCollisions<H, G>, joinedCollisions<H, G>, joinedCollisions<H, G>>>
 using SameKindTriple = GroupedCombinationsGenerator<T1, GroupingPolicy, H, G, pack<A>, A, A, A>;
 

--- a/Framework/Core/include/Framework/GroupedCombinations.h
+++ b/Framework/Core/include/Framework/GroupedCombinations.h
@@ -17,8 +17,6 @@
 #include "Framework/Pack.h"
 #include <optional>
 
-#include <iostream>
-
 namespace o2::framework
 {
 
@@ -85,7 +83,6 @@ struct GroupedCombinationsGenerator<T1, GroupingPolicy, H, G, pack<Us...>, As...
 
     void setTables(const H& hashes, const G& grouping, std::shared_ptr<GroupSlicer<G, Us...>> slicer_ptr)
     {
-      std::cout << "Setting tables" << std::endl;
       mGrouping = std::make_shared<G>(std::vector{grouping.asArrowTable()});
       mSlicer = slicer_ptr;
       setMultipleGroupingTables<sizeof...(As)>(join(hashes, grouping));
@@ -97,7 +94,6 @@ struct GroupedCombinationsGenerator<T1, GroupingPolicy, H, G, pack<Us...>, As...
     template <std::size_t N, typename T, typename... Args>
     void setMultipleGroupingTables(const T& param, const Args&... args)
     {
-      std::cout << "Setting grouping tables" << std::endl;
       if constexpr (N == 1) {
         GroupingPolicy::setTables(param, args...);
       } else {
@@ -143,7 +139,6 @@ struct GroupedCombinationsGenerator<T1, GroupingPolicy, H, G, pack<Us...>, As...
    private:
     std::tuple<As...> getAssociatedTables()
     {
-      std::cout << "Getting associated tables" << std::endl;
       auto& currentGrouping = GroupingPolicy::mCurrent;
       constexpr auto k = sizeof...(As);
       auto slicerIterators = functionToTuple<k>(&GroupSlicer<G, Us...>::begin, *mSlicer);
@@ -176,7 +171,6 @@ struct GroupedCombinationsGenerator<T1, GroupingPolicy, H, G, pack<Us...>, As...
 
     void setCurrentGroupedCombination()
     {
-      std::cout << "Setting grouped combination" << std::endl;
       std::tuple<As...> initAssociatedTables = getAssociatedTables();
       constexpr auto k = sizeof...(As);
       bool moveForward = false;
@@ -199,14 +193,11 @@ struct GroupedCombinationsGenerator<T1, GroupingPolicy, H, G, pack<Us...>, As...
 
       if (!this->mIsEnd) {
         auto& currentGrouping = GroupingPolicy::mCurrent;
-        std::cout << "Received current grouping" << std::endl;
         o2::soa::for_<k>([&](auto i) {
           std::get<i.value>(associatedTables).bindExternalIndices(mGrouping.get());
         });
-        std::cout << "Bound associated tables" << std::endl;
 
         mCurrentGrouped.emplace(interleaveTuples(currentGrouping, associatedTables));
-        std::cout << "Interleaved tuples" << std::endl;
       }
     }
 
@@ -244,7 +235,6 @@ struct GroupedCombinationsGenerator<T1, GroupingPolicy, H, G, pack<Us...>, As...
 
   void setTables(H& hashes, G& grouping, std::tuple<Us...>& associated)
   {
-    std::cout << "Setting tables in generator" << std::endl;
     if (mSlicer == nullptr) {
       mSlicer = std::make_shared<GroupSlicer<G, Us...>>(grouping, associated);
       mBegin.setTables(hashes, grouping, mSlicer);


### PR DESCRIPTION
Hi @ktf ,

This is a performance fix for event mixing, per Anton's suggestion.
I also got rid of one std::conjunction_v, what was suggested by you in one of previous mixing PRs.