### PR TITLE
MCH: implement handling of SAMPA reset at each TF

### DIFF
--- a/Detectors/MUON/MCH/Raw/Decoder/src/DataDecoder.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/DataDecoder.cxx
@@ -23,6 +23,7 @@
 #include "Headers/RAWDataHeader.h"
 #include "CommonConstants/LHCConstants.h"
 #include "DetectorsRaw/RDHUtils.h"
+#include "DetectorsRaw/HBFUtils.h"
 #include "MCHMappingInterface/Segmentation.h"
 #include "Framework/Logger.h"
 #include "MCHRawDecoder/ErrorCodes.h"
@@ -37,7 +38,6 @@ namespace raw
 {
 
 using namespace o2;
-//using namespace o2::framework;
 using namespace o2::mch::mapping;
 using RDH = o2::header::RDHAny;
 
@@ -241,8 +241,8 @@ bool DataDecoder::TimeFrameStartRecord::check(int32_t orbit, uint32_t bc, int32_
 DataDecoder::DataDecoder(SampaChannelHandler channelHandler, RdhHandler rdhHandler,
                          uint32_t sampaBcOffset,
                          std::string mapCRUfile, std::string mapFECfile,
-                         bool ds2manu, bool verbose, bool useDummyElecMap)
-  : mChannelHandler(channelHandler), mRdhHandler(rdhHandler), mSampaTimeOffset(sampaBcOffset), mMapCRUfile(mapCRUfile), mMapFECfile(mapFECfile), mDs2manu(ds2manu), mDebug(verbose), mUseDummyElecMap(useDummyElecMap)
+                         bool ds2manu, bool verbose, bool useDummyElecMap, TimeRecoMode timeRecoMode)
+  : mChannelHandler(channelHandler), mRdhHandler(rdhHandler), mSampaTimeOffset(sampaBcOffset), mMapCRUfile(mapCRUfile), mMapFECfile(mapFECfile), mDs2manu(ds2manu), mDebug(verbose), mUseDummyElecMap(useDummyElecMap), mTimeRecoMode(timeRecoMode)
 {
   init();
 }
@@ -648,39 +648,8 @@ void DataDecoder::decodePage(gsl::span<const std::byte> page)
 
 //_________________________________________________________________________________________________
 
-int32_t DataDecoder::getDigitTime(uint32_t orbitStart, uint32_t bcStart, uint32_t orbitDigit, uint32_t bcDigit)
-{
-  // We use the difference of orbits values to estimate the minimum and maximum allowed
-  // difference in bunch crossings
-  int64_t dOrbit = static_cast<int64_t>(orbitDigit) - static_cast<int64_t>(orbitStart);
-
-  // Digits might be sent out later than the orbit in which they were recorded.
-  // We account for this by allowing an extra -3 / +10 orbits when converting the
-  // difference from orbit numbers to bunch crossings.
-  int64_t dBcMin = (dOrbit - 50) * bcInOrbit;
-  int64_t dBcMax = (dOrbit + 3) * bcInOrbit;
-
-  // Difference in bunch crossing values
-  int64_t dBc = static_cast<int64_t>(bcDigit) - static_cast<int64_t>(bcStart);
-
-  if (dBc < dBcMin) {
-    // the difference is too small, so we assume that it needs to be
-    // incremented by one rollover factor
-    dBc += bcRollOver;
-  } else if (dBc > dBcMax) {
-    // the difference is too big, so we assume that it needs to be
-    // decremented by one rollover factor
-    dBc -= bcRollOver;
-  }
-
-  return static_cast<int32_t>(dBc);
-}
-
-//_________________________________________________________________________________________________
-
 bool DataDecoder::getTimeFrameStartRecord(const RawDigit& digit, uint32_t& orbitTF, uint32_t& bcTF)
 {
-  static constexpr uint32_t bcInOrbit = o2::constants::lhc::LHCMaxBunches;
   static constexpr uint32_t twentyBitsAtOne = 0xFFFFF;
 
   // first orbit of the current TF
@@ -714,7 +683,7 @@ bool DataDecoder::getTimeFrameStartRecord(const RawDigit& digit, uint32_t& orbit
 
   if (orbitHBP != orbitTF) {
     // we correct the BC from the last received HB packet, if it was recorded from an older TF
-    bcTF += (orbitTF - orbitHBP) * bcInOrbit;
+    bcTF += (orbitTF - orbitHBP) * mBcInOrbit;
     // only keep 20 bits
     bcTF &= twentyBitsAtOne;
 
@@ -728,10 +697,39 @@ bool DataDecoder::getTimeFrameStartRecord(const RawDigit& digit, uint32_t& orbit
 
 //_________________________________________________________________________________________________
 
-void DataDecoder::computeDigitsTime()
+int32_t DataDecoder::getDigitTimeHBPackets(uint32_t orbitStart, uint32_t bcStart, uint32_t orbitDigit, uint32_t bcDigit)
+{
+  // We use the difference of orbits values to estimate the minimum and maximum allowed
+  // difference in bunch crossings
+  int64_t dOrbit = static_cast<int64_t>(orbitDigit) - static_cast<int64_t>(orbitStart);
+
+  // Digits might be sent out later than the orbit in which they were recorded.
+  // We account for this by allowing an extra -3 / +10 orbits when converting the
+  // difference from orbit numbers to bunch crossings.
+  int64_t dBcMin = (dOrbit - 50) * bcInOrbit;
+  int64_t dBcMax = (dOrbit + 3) * bcInOrbit;
+
+  // Difference in bunch crossing values
+  int64_t dBc = static_cast<int64_t>(bcDigit) - static_cast<int64_t>(bcStart);
+
+  if (dBc < dBcMin) {
+    // the difference is too small, so we assume that it needs to be
+    // incremented by one rollover factor
+    dBc += bcRollOver;
+  } else if (dBc > dBcMax) {
+    // the difference is too big, so we assume that it needs to be
+    // decremented by one rollover factor
+    dBc -= bcRollOver;
+  }
+
+  return static_cast<int32_t>(dBc);
+}
+
+//_________________________________________________________________________________________________
+
+void DataDecoder::computeDigitsTimeHBPackets()
 {
   static constexpr int32_t timeInvalid = DataDecoder::tfTimeInvalid;
-  constexpr int BCINORBIT = o2::constants::lhc::LHCMaxBunches;
 
   auto setDigitTime = [&](Digit& d, int32_t tfTime) {
     d.setTime(tfTime);
@@ -752,11 +750,88 @@ void DataDecoder::computeDigitsTime()
       int solar = info.solar;
       int ds = info.ds;
       int chip = info.chip;
-      tfTime = DataDecoder::getDigitTime(orbitTF, bcTF, orbitDigit, bcDigit);
+      tfTime = DataDecoder::getDigitTimeHBPackets(orbitTF, bcTF, orbitDigit, bcDigit);
     }
 
     setDigitTime(d, tfTime);
     info.tfTime = tfTime;
+  }
+}
+
+//_________________________________________________________________________________________________
+
+int32_t DataDecoder::getDigitTimeBCRst(uint32_t orbitStart, uint32_t bcStart, uint32_t orbitDigit, uint32_t bcDigit)
+{
+  // We use the difference of orbits values to estimate the minimum and maximum allowed
+  // difference in bunch crossings
+  int64_t dOrbitRDH = static_cast<int64_t>(orbitDigit) - static_cast<int64_t>(orbitStart);
+
+  // Difference in bunch crossing values
+  int64_t dBc = static_cast<int64_t>(bcDigit) - static_cast<int64_t>(bcStart);
+  int64_t dOrbitSampa = dBc / mBcInOrbit;
+
+  if (dOrbitSampa > (dOrbitRDH + 1)) {
+    // The orbit inferred from the SAMPA BC is larger than the one from the RDH
+    // We interpret this as due to SAMPA packets generated before the BC reset is applied at the beginning of the TF
+    dBc -= mBcInOrbit * mOrbitsInTF;
+  }
+
+  return static_cast<int32_t>(dBc);
+}
+
+//_________________________________________________________________________________________________
+
+void DataDecoder::computeDigitsTimeBCRst()
+{
+  static constexpr int32_t timeInvalid = DataDecoder::tfTimeInvalid;
+
+  auto setDigitTime = [&](Digit& d, int32_t tfTime) {
+    d.setTime(tfTime);
+  };
+
+  for (auto& digit : mDigits) {
+    auto& d = digit.digit;
+    auto& info = digit.info;
+
+    uint32_t orbitTF = mFirstOrbitInTF;
+    uint32_t bcTF = 0;
+    int32_t tfTime = timeInvalid;
+
+    auto orbitDigit = info.orbit;
+    auto bcDigit = info.getBXTime();
+
+    tfTime = DataDecoder::getDigitTimeBCRst(orbitTF, bcTF, orbitDigit, bcDigit);
+
+    tfTime -= mSampaTimeOffset;
+
+    if (mDebug && tfTime < (-2 * mBcInOrbit)) {
+      int solar = info.solar;
+      int ds = info.ds;
+      int chip = info.chip;
+      std::cout << fmt::format("Out-of-time digit: S{} DS{} CHIP{}  TF {}/{}  DIGIT {}/{}  TIME {}",
+                               solar, ds, chip, orbitTF, bcTF, orbitDigit, bcDigit, tfTime)
+                << std::endl;
+    }
+
+    setDigitTime(d, tfTime);
+    info.tfTime = tfTime;
+  }
+}
+
+//_________________________________________________________________________________________________
+
+void DataDecoder::computeDigitsTime()
+{
+  switch (mTimeRecoMode) {
+    case TimeRecoMode::HBPackets:
+      computeDigitsTimeHBPackets();
+      break;
+    case TimeRecoMode::BCReset:
+      computeDigitsTimeBCRst();
+      break;
+    default:
+      LOGP(error, "Digit time reconstruction mode undefined");
+      break;
   }
 }
 
@@ -826,6 +901,9 @@ void DataDecoder::init()
 
   initFee2SolarMapper(mMapCRUfile);
   initElec2DetMapper(mMapFECfile);
+
+  mOrbitsInTF = o2::raw::HBFUtils::Instance().getNOrbitsPerTF();
+  mBcInOrbit = o2::constants::lhc::LHCMaxBunches;
 
   mTimeFrameStartRecords.resize(sReadoutChipsNum);
   std::fill(mTimeFrameStartRecords.begin(), mTimeFrameStartRecords.end(), TimeFrameStartRecord());

--- a/Detectors/MUON/MCH/Raw/Decoder/src/testDigitsTimeComputation.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/testDigitsTimeComputation.cxx
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_CASE(TimeDiffSameOrbitNoRollover)
   uint32_t orbit2 = 1;
   uint32_t bc1 = 0;
   uint32_t bc2 = BCINORBIT - 10;
-  auto diff = DataDecoder::getDigitTime(orbit1, bc1, orbit2, bc2);
+  auto diff = DataDecoder::getDigitTimeHBPackets(orbit1, bc1, orbit2, bc2);
   BOOST_CHECK_EQUAL(diff, bc2);
 }
 
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(TimeDiffSameOrbitWithRollover)
   uint32_t orbit2 = 1;
   uint32_t bc1 = BCROLLOVER - 10;
   uint32_t bc2 = 10;
-  auto diff = DataDecoder::getDigitTime(orbit1, bc1, orbit2, bc2);
+  auto diff = DataDecoder::getDigitTimeHBPackets(orbit1, bc1, orbit2, bc2);
   BOOST_CHECK_EQUAL(diff, 20);
 }
 
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(TimeDiffSameOrbitWithRollover2)
   uint32_t orbit2 = 1;
   uint32_t bc1 = 10;
   uint32_t bc2 = BCROLLOVER - 10;
-  auto diff = DataDecoder::getDigitTime(orbit1, bc1, orbit2, bc2);
+  auto diff = DataDecoder::getDigitTimeHBPackets(orbit1, bc1, orbit2, bc2);
   BOOST_CHECK_EQUAL(diff, -20);
 }
 

--- a/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
@@ -87,9 +87,17 @@ class DataDecoderTask
     auto mapFECfile = ic.options().get<std::string>("fec-map");
     auto useDummyElecMap = ic.options().get<bool>("dummy-elecmap");
     mErrorLogFrequency = ic.options().get<int>("error-log-frequency");
+    auto timeRecoModeString = ic.options().get<std::string>("time-reco-mode");
+
+    DataDecoder::TimeRecoMode timeRecoMode = DataDecoder::TimeRecoMode::HBPackets;
+    if (timeRecoModeString == "hbpackets") {
+      timeRecoMode = DataDecoder::TimeRecoMode::HBPackets;
+    } else if (timeRecoModeString == "bcreset") {
+      timeRecoMode = DataDecoder::TimeRecoMode::BCReset;
+    }
 
     mDecoder = new DataDecoder(channelHandler, rdhHandler, sampaBcOffset, mapCRUfile, mapFECfile, ds2manu, mDebug,
-                               useDummyElecMap);
+                               useDummyElecMap, timeRecoMode);
 
     auto stop = [this]() {
       LOG(info) << "mch-data-decoder: decoding duration = " << mTimeDecoding.count() * 1000 / mTFcount << " us / TF";
@@ -337,6 +345,7 @@ o2::framework::DataProcessorSpec getDecodingSpec(const char* specName, std::stri
             {"fec-map", VariantType::String, "", {"custom FEC mapping"}},
             {"dummy-elecmap", VariantType::Bool, false, {"use dummy electronic mapping (for debug, temporary)"}},
             {"ds2manu", VariantType::Bool, false, {"convert channel numbering from Run3 to Run1-2 order"}},
+            {"time-reco-mode", VariantType::String, "hbpackets", {"digit time reconstruction method [hbpackets, bcreset]"}},
             {"check-rofs", VariantType::Bool, false, {"perform consistency checks on the output ROFs"}},
             {"dummy-rofs", VariantType::Bool, false, {"disable the ROFs finding algorithm"}},
             {"error-log-frequency", VariantType::Int, 6000, {"log the error map at this frequency (in TF unit) (first TF is always logged, unless frequency is zero)"}}}};


### PR DESCRIPTION
The new code introduces a new method to compute the time of the MCH digits, which assumes a reset of the internal SAMPA bunch-crossing counters at the beginning of each Time Frame.
This new method does not rely on the decoding of Heart-Beat data packets in order to extract the reference SAMPA time at the TF start, hence it is more reliable in case of high data rates.

The choice of the method is driven by a new "--time-reco-mode" command-line option of the MCH decoder. Possible values are:
"hbpackets": the SAMPA time reference is computed from the time stamp of the Heart-Beat packets (old method)
"bcreset": a reset of the SAMPA bc counters is assumed at the beginning of each time frame (new method)
