### PR TITLE
switch to disable fall-back to TGeo if MatLUT is missing

### DIFF
--- a/Detectors/Base/include/DetectorsBase/Propagator.h
+++ b/Detectors/Base/include/DetectorsBase/Propagator.h
@@ -121,7 +121,8 @@ class PropagatorImpl
 
   // Bz at the origin
   GPUd() value_type getNominalBz() const { return mBz; }
-
+  GPUd() void setTGeoFallBackAllowed(bool v) { mTGeoFallBackAllowed = v; }
+  GPUd() bool isTGeoFallBackAllowed() const { return mTGeoFallBackAllowed; }
   GPUd() void setMatLUT(const o2::base::MatLayerCylSet* lut) { mMatLUT = lut; }
   GPUd() const o2::base::MatLayerCylSet* getMatLUT() const { return mMatLUT; }
   GPUd() void setGPUField(const o2::gpu::GPUTPCGMPolynomialField* field) { mGPUField = field; }
@@ -160,6 +161,7 @@ class PropagatorImpl
   o2::field::MagneticField* mField = nullptr;          ///< External nominal field map
   value_type mBz = 0;                                  ///< nominal field
 
+  bool mTGeoFallBackAllowed = true;                            ///< allow fall back to TGeo if requested MatLUT is not available
   const o2::base::MatLayerCylSet* mMatLUT = nullptr;           // externally set LUT
   const o2::gpu::GPUTPCGMPolynomialField* mGPUField = nullptr; // externally set GPU Field
 

--- a/Detectors/Base/src/Propagator.cxx
+++ b/Detectors/Base/src/Propagator.cxx
@@ -585,8 +585,15 @@ template <typename value_T>
 GPUd() MatBudget PropagatorImpl<value_T>::getMatBudget(PropagatorImpl<value_type>::MatCorrType corrType, const math_utils::Point3D<value_type>& p0, const math_utils::Point3D<value_type>& p1) const
 {
 #if !defined(GPUCA_STANDALONE) && !defined(GPUCA_GPUCODE)
-  if (corrType == MatCorrType::USEMatCorrTGeo || !mMatLUT) {
+  if (corrType == MatCorrType::USEMatCorrTGeo) {
     return GeometryManager::meanMaterialBudget(p0, p1);
+  }
+  if (!mMatLUT) {
+    if (mTGeoFallBackAllowed) {
+      return GeometryManager::meanMaterialBudget(p0, p1);
+    } else {
+      throw std::runtime_error("requested MatLUT is absent and fall-back to TGeo is disabled");
+    }
   }
 #endif
   return mMatLUT->getMatBudget(p0.X(), p0.Y(), p0.Z(), p1.X(), p1.Y(), p1.Z());


### PR DESCRIPTION
@jgrosseo @victor-gonzalez 
With this PR, `o2::base::Propagator::Instance()->setTGeoFallBackAllowed(false);` will throw an exception if the matLUT is requested but not attached