### PR TITLE
[EMCAL-751] Temporal fix for the digitizer

### DIFF
--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/Digitizer.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/Digitizer.h
@@ -106,8 +106,8 @@ class Digitizer : public TObject
   bool mEmpty = true;                      ///< Digitizer contains no digits/labels
 
   std::vector<Digit> mTempDigitVector; ///< temporary digit storage
-  //std::unordered_map<Int_t, std::list<LabeledDigit>> mDigits; ///< used to sort digits and labels by tower
-  o2::emcal::DigitsWriteoutBuffer mDigits; ///< used to sort digits and labels by tower
+  std::unordered_map<Int_t, std::list<LabeledDigit>> mDigits; ///< used to sort digits and labels by tower
+  // o2::emcal::DigitsWriteoutBuffer mDigits; ///< used to sort digits and labels by tower
 
   TRandom3* mRandomGenerator = nullptr;                  // random number generator
   std::vector<int> mTimeBinOffset;                       // offset of first time bin

--- a/Detectors/EMCAL/workflow/src/EMCALDigitizerSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/EMCALDigitizerSpec.cxx
@@ -126,10 +126,6 @@ void DigitizerSpec::run(framework::ProcessingContext& ctx)
       continue;
     } else {
       preTriggerColl = false;
-      // Discard collisions that occurs 900 ns after the readout window is open
-      if (mDigitizer.afterTriggerCollision()) {
-        continue;
-      }
     }
 
     if (mDigitizer.isEmpty()) {


### PR DESCRIPTION
Temporal fix for the digitizer by disabling the "DigitsRighOutBuffer" and adding normal "std::unordered_map" instead.