### PR TITLE
[MFT] Fix digi2raw output segmentation

### DIFF
--- a/Detectors/ITSMFT/MFT/simulation/src/digi2raw.cxx
+++ b/Detectors/ITSMFT/MFT/simulation/src/digi2raw.cxx
@@ -186,111 +186,143 @@ void digi2raw(std::string_view inpName, std::string_view outDir, std::string_vie
   swTot.Print();
 }
 
+struct MFTRUMapping {
+  std::string flp{};
+  int feeID;
+  int cruHWID = 0;
+  int idInCRU = 0;
+  int endpoint = 0;
+};
+
+// FLP_Name, FEEId, CRU_HW, idInCRU, endpoint
+const MFTRUMapping mftHWMap[o2::itsmft::ChipMappingMFT::getNRUs()] = {
+  {"alio2-cr1-flp182", 0, 570, 0, 0},
+  {"alio2-cr1-flp182", 1, 570, 1, 0},
+  {"alio2-cr1-flp182", 2, 570, 2, 0},
+  {"alio2-cr1-flp182", 3, 570, 3, 0},
+  {"alio2-cr1-flp186", 64, 542, 4, 0},
+  {"alio2-cr1-flp186", 65, 542, 5, 0},
+  {"alio2-cr1-flp186", 66, 542, 6, 0},
+  {"alio2-cr1-flp186", 67, 542, 7, 0},
+  {"alio2-cr1-flp182", 4, 570, 4, 1},
+  {"alio2-cr1-flp182", 5, 570, 5, 1},
+  {"alio2-cr1-flp182", 6, 570, 6, 1},
+  {"alio2-cr1-flp182", 7, 570, 7, 1},
+  {"alio2-cr1-flp186", 68, 542, 8, 1},
+  {"alio2-cr1-flp186", 69, 542, 9, 1},
+  {"alio2-cr1-flp186", 70, 542, 10, 1},
+  {"alio2-cr1-flp186", 71, 542, 11, 1},
+  {"alio2-cr1-flp183", 8, 548, 0, 0},
+  {"alio2-cr1-flp183", 9, 548, 1, 0},
+  {"alio2-cr1-flp183", 10, 548, 2, 0},
+  {"alio2-cr1-flp183", 11, 548, 3, 0},
+  {"alio2-cr1-flp185", 72, 541, 4, 0},
+  {"alio2-cr1-flp185", 73, 541, 5, 0},
+  {"alio2-cr1-flp185", 74, 541, 6, 0},
+  {"alio2-cr1-flp185", 75, 541, 7, 0},
+  {"alio2-cr1-flp183", 12, 548, 4, 1},
+  {"alio2-cr1-flp183", 13, 548, 5, 1},
+  {"alio2-cr1-flp183", 14, 548, 6, 1},
+  {"alio2-cr1-flp183", 15, 548, 7, 1},
+  {"alio2-cr1-flp185", 76, 541, 8, 1},
+  {"alio2-cr1-flp185", 77, 541, 9, 1},
+  {"alio2-cr1-flp185", 78, 541, 10, 1},
+  {"alio2-cr1-flp185", 79, 541, 11, 1},
+  {"alio2-cr1-flp184", 16, 569, 0, 0},
+  {"alio2-cr1-flp184", 17, 569, 1, 0},
+  {"alio2-cr1-flp184", 18, 569, 2, 0},
+  {"alio2-cr1-flp184", 19, 569, 3, 0},
+  {"alio2-cr1-flp184", 80, 543, 4, 0},
+  {"alio2-cr1-flp184", 81, 543, 5, 0},
+  {"alio2-cr1-flp184", 82, 543, 6, 0},
+  {"alio2-cr1-flp184", 83, 543, 7, 0},
+  {"alio2-cr1-flp184", 20, 569, 4, 1},
+  {"alio2-cr1-flp184", 21, 569, 5, 1},
+  {"alio2-cr1-flp184", 22, 569, 6, 1},
+  {"alio2-cr1-flp184", 23, 569, 7, 1},
+  {"alio2-cr1-flp184", 84, 543, 8, 1},
+  {"alio2-cr1-flp184", 85, 543, 9, 1},
+  {"alio2-cr1-flp184", 86, 543, 10, 1},
+  {"alio2-cr1-flp184", 87, 543, 11, 1},
+  {"alio2-cr1-flp185", 24, 552, 0, 0},
+  {"alio2-cr1-flp185", 25, 552, 1, 0},
+  {"alio2-cr1-flp185", 26, 552, 2, 0},
+  {"alio2-cr1-flp185", 27, 552, 3, 0},
+  {"alio2-cr1-flp183", 88, 554, 4, 0},
+  {"alio2-cr1-flp183", 89, 554, 5, 0},
+  {"alio2-cr1-flp183", 90, 554, 6, 0},
+  {"alio2-cr1-flp183", 91, 554, 7, 0},
+  {"alio2-cr1-flp185", 28, 552, 4, 1},
+  {"alio2-cr1-flp185", 29, 552, 5, 1},
+  {"alio2-cr1-flp185", 30, 552, 6, 1},
+  {"alio2-cr1-flp185", 31, 552, 7, 1},
+  {"alio2-cr1-flp183", 92, 554, 8, 1},
+  {"alio2-cr1-flp183", 93, 554, 9, 1},
+  {"alio2-cr1-flp183", 94, 554, 10, 1},
+  {"alio2-cr1-flp183", 95, 554, 11, 1},
+  {"alio2-cr1-flp186", 32, 547, 0, 0},
+  {"alio2-cr1-flp186", 33, 547, 1, 0},
+  {"alio2-cr1-flp186", 34, 547, 2, 0},
+  {"alio2-cr1-flp186", 35, 547, 3, 0},
+  {"alio2-cr1-flp182", 96, 567, 4, 0},
+  {"alio2-cr1-flp182", 97, 567, 5, 0},
+  {"alio2-cr1-flp182", 98, 567, 6, 0},
+  {"alio2-cr1-flp182", 99, 567, 7, 0},
+  {"alio2-cr1-flp186", 36, 547, 4, 1},
+  {"alio2-cr1-flp186", 37, 547, 5, 1},
+  {"alio2-cr1-flp186", 38, 547, 6, 1},
+  {"alio2-cr1-flp186", 39, 547, 7, 1},
+  {"alio2-cr1-flp182", 100, 567, 8, 1},
+  {"alio2-cr1-flp182", 101, 567, 9, 1},
+  {"alio2-cr1-flp182", 102, 567, 10, 1},
+  {"alio2-cr1-flp182", 103, 567, 11, 1}};
+
 void setupLinks(o2::itsmft::MC2RawEncoder<MAP>& m2r, std::string_view outDir, std::string_view outPrefix, std::string_view fileFor)
 {
   // see the same file from ITS
-
-  constexpr int MaxLinksPerCRU = 8;
   const auto& mp = m2r.getMapping();
-
-  // MFT has 13 RU types (NRUTypes) and 1 link per RU:
-  int lnkAssign[13] = {7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 18, 19, 14};
-
-  std::vector<std::vector<int>> defRU{// number of RUs per CRU at each layer
-                                      {6, 6},
-                                      {8, 8},
-                                      {5, 5, 5, 5},
-                                      {12, 12},
-                                      {8, 7, 8, 7},
-                                      {11, 10, 11, 10},
-                                      {12, 12, 12, 12}};
-
-  // this is an arbitrary mapping
-  int nCRU = 0, nRUtot = 0, nRU = 0, nLinks = 0;
-  int linkID = 0, cruIDprev = -1, cruID = 0;
   std::string outFileLink;
+  o2::itsmft::ChipMappingMFT mftMapping;
 
-  int nruLr = mp.getNZonesPerLayer();
-  int ruHW = -1, ruSW = -1;
+  for (int ruID = 0; ruID < mftMapping.getNRUs(); ruID++) {
 
-  // loop over the lower half, then over the upper half
-  for (int h = 0; h < 2; h++) {
-    int cruIDtmp = h > 0 ? 1 : 0;
-    for (int ilr = 0; ilr < mp.getNLayers(); ilr++) {
+    if (ruID < m2r.getRUSWMin() || ruID > m2r.getRUSWMax()) { // ignored RUs ?
+      continue;
+    }
 
-      for (int ir = 0; ir < nruLr; ir++) {
+    auto FEEId = mftMapping.RUSW2FEEId(ruID);
+    uint16_t layer, ruOnLayer, linkId, zone = FEEId & 0x3;
+    mftMapping.expandFEEId(FEEId, layer, ruOnLayer, linkId);
 
-        if (h != (ir / 4)) {
-          continue;
-        }
+    m2r.getCreateRUDecode(ruID); // create RU container
 
-        // RU software id
-        ruSW = nruLr * ilr + (nruLr / 2) * (ir / 4) + (ir % 4);
-
-        // RU hardware id
-        ruHW = 0;
-        ruHW += (ir / 4) << 6;
-        ruHW += (ilr / 2) << 3; // disk
-        ruHW += (ilr % 2) << 2; // plane (disk face)
-        ruHW += (ir % 4);
-
-        int ruType = mp.getRUType(ir, ilr);
-        int lnkAs = lnkAssign[ruType];
-
-        int ruID = nRUtot++;
-        bool accept = !(ruSW < m2r.getRUSWMin() || ruSW > m2r.getRUSWMax()); // ignored RUs ?
-        if (accept) {
-          m2r.getCreateRUDecode(ruSW); // create RU container
-          nRU++;
-          nLinks++;
-          auto& ru = *m2r.getRUDecode(ruSW);
-          uint32_t lanes = mp.getCablesOnRUType(ru.ruInfo->ruType); // lanes patter of this RU
-          ru.links[0] = m2r.addGBTLink();
-          auto link = m2r.getGBTLink(ru.links[0]);
-          link->lanes = lanes;
-          link->idInCRU = linkID;
-          link->cruID = cruIDtmp * 100 + o2::detectors::DetID::MFT;
-          link->feeID = mp.RUSW2FEEId(ruSW);
-          link->endPointID = 0; // 0 or 1
-          // register the link in the writer, if not done here, its data will be dumped to common default file
-          //printf("Register link: FeeID 0x%02x , CRU ID 0x%x , link ID %2d \n", link->feeID, link->cruID, link->idInCRU);
-          //printf("RU SW: %2d   HW: 0x%02x   Type: %2d   %s \n", ruSW, ruHW, ruType, outFileLink.data());
-          //std::bitset<32> bv_lanes(link->lanes);
-          //LOG(info) << "with lanes " << bv_lanes;
-
-          if (fileFor == "all") { // single file for all links
-            outFileLink = o2::utils::Str::concat_string(outDir, "/", outPrefix, ".raw");
-          } else if (fileFor == "layer") {
-            outFileLink = o2::utils::Str::concat_string(outDir, "/", outPrefix, "_lr", std::to_string(ilr), ".raw");
-          } else if (fileFor == "cru") {
-            outFileLink = o2::utils::Str::concat_string(outDir, "/", outPrefix, "_cru", std::to_string(link->cruID), ".raw");
-          } else if (fileFor == "link") {
-            outFileLink = o2::utils::Str::concat_string(outDir, "/", outPrefix, "_cru", std::to_string(link->cruID),
-                                                        "_link", std::to_string(linkID), "_ep", std::to_string(link->endPointID), "_feeid", std::to_string(link->feeID), ".raw");
-          } else {
+    auto& ru = *m2r.getRUDecode(ruID);
+    ru.links[0] = m2r.addGBTLink();
+    uint32_t lanes = mp.getCablesOnRUType(mp.getRUType(zone, layer)); // lanes pattern of this RU
+    auto link = m2r.getGBTLink(ru.links[0]);
+    link->lanes = lanes;
+    link->feeID = mftHWMap[ruID].feeID;
+    link->idInCRU = mftHWMap[ruID].idInCRU;     // linkID
+    link->cruID = mftHWMap[ruID].cruHWID;       // CRU Serial Number
+    link->endPointID = mftHWMap[ruID].endpoint; // endpoint = face
+    outFileLink = o2::utils::Str::concat_string(outDir, "/", outPrefix);
+    if (fileFor != "all") { // single file for all links
+      outFileLink += fmt::format("_{}", mftHWMap[ruID].flp);
+      if (fileFor != "flp") {
+        outFileLink += fmt::format("_cru{}_{}", mftHWMap[ruID].cruHWID, link->endPointID);
+        if (fileFor != "cru") {
+          outFileLink += fmt::format("_lnk{}_feeid{}", link->idInCRU, link->feeID);
+          if (fileFor != "link") {
             throw std::runtime_error("invalid option provided for file grouping");
           }
-
-          m2r.getWriter().registerLink(link->feeID, link->cruID, link->idInCRU,
-                                       link->endPointID, outFileLink);
-
-          if (cruIDprev != cruIDtmp) { // just to count used CRUs
-            cruIDprev = cruIDtmp;
-            nCRU++;
-          }
-
-          if ((++linkID) >= MaxLinksPerCRU) {
-            linkID = 0;
-            cruIDtmp += 2;
-          }
-
-        } // end select RU SW ID range
-
-      } // end zone (RU) loop
-
-    } // end layer loop
-
-  } // end half loop
-
-  LOG(info) << "Distributed " << nLinks << " links on " << nRU << " RUs in " << nCRU << " CRUs";
+        }
+      }
+    }
+    outFileLink += ".raw";
+    m2r.getWriter().registerLink(link->feeID, link->cruID, link->idInCRU, link->endPointID, outFileLink);
+    if (m2r.getVerbosity()) {
+      LOG(info) << "RU" << ruID << '(' << mftHWMap[ruID].cruHWID << " on idInCRU " << mftHWMap[ruID].idInCRU << ") " << link->describe()
+                << " -> " << outFileLink;
+    }
+  }
 }

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ChipMappingMFT.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/ChipMappingMFT.h
@@ -106,6 +106,14 @@ class ChipMappingMFT
     ruOnLayer = 4 * half + zone;
   }
 
+  ///< decompose FEEid to face, disk, half
+  void expandFEEIdFaceDiskHalf(uint16_t feeID, uint16_t& face, uint16_t& disk, uint16_t& half) const
+  {
+    half = (feeID >> 6) & 0x1;
+    disk = (feeID >> 3) & 0x7;
+    face = (feeID >> 2) & 0x1;
+  }
+
   ///< get info on sw RU
   const RUInfo* getRUInfoFEEId(Int_t feeID) const { return &mRUInfo[FEEId2RUSW(feeID)]; }
 


### PR DESCRIPTION
This PR adapts the MFT MC to raw converter to produce one file per CRU endpoint. `o2-mft-digi2raw --file-for cru` produces the following raw files:

```
MFT_alio2-cr1-flp182_cru567_0.raw
MFT_alio2-cr1-flp182_cru567_1.raw
MFT_alio2-cr1-flp182_cru570_0.raw
MFT_alio2-cr1-flp182_cru570_1.raw
MFT_alio2-cr1-flp183_cru548_0.raw
MFT_alio2-cr1-flp183_cru548_1.raw
MFT_alio2-cr1-flp183_cru554_0.raw
MFT_alio2-cr1-flp183_cru554_1.raw
MFT_alio2-cr1-flp184_cru543_0.raw
MFT_alio2-cr1-flp184_cru543_1.raw
MFT_alio2-cr1-flp184_cru569_0.raw
MFT_alio2-cr1-flp184_cru569_1.raw
MFT_alio2-cr1-flp185_cru541_0.raw
MFT_alio2-cr1-flp185_cru541_1.raw
MFT_alio2-cr1-flp185_cru552_0.raw
MFT_alio2-cr1-flp185_cru552_1.raw
MFT_alio2-cr1-flp186_cru542_0.raw
MFT_alio2-cr1-flp186_cru542_1.raw
MFT_alio2-cr1-flp186_cru547_0.raw
MFT_alio2-cr1-flp186_cru547_1.raw
```