### PR TITLE
Possibility to attach multiple CCDB populators

### DIFF
--- a/Detectors/Calibration/workflow/ccdb-populator-workflow.cxx
+++ b/Detectors/Calibration/workflow/ccdb-populator-workflow.cxx
@@ -21,6 +21,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   // option allowing to set parameters
   std::vector<o2::framework::ConfigParamSpec> options{
+    {"name-extention", VariantType::String, "", {"optional extention of device name"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
 
   std::swap(workflowOptions, options);
@@ -43,6 +44,6 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 {
   WorkflowSpec specs;
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
-  specs.emplace_back(getCCDBPopulatorDeviceSpec(o2::base::NameConf::getCCDBServer()));
+  specs.emplace_back(getCCDBPopulatorDeviceSpec(o2::base::NameConf::getCCDBServer(), configcontext.options().get<std::string>("name-extention")));
   return specs;
 }


### PR DESCRIPTION
By default the `ccdb-populator-workflow` will upload to the CCDB the inputs with any `SubSpec`. There is a possibility to run with multiple `ccdb-populators`, e.g. each one writing to particular CCDB server
(this might be needed e.g. to populate the production CCDB and the transient CCDB for DCS exchange, with the same or different objects). This can be done by piping
two populators, one of which should have device name modified. Additionally, one can pass an option for each populator to process only inputs with specific `SubSpecs`.
E.g. if your calibration device sends to the output
```
output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "ObjA", 0}, *imageA.get());
output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "ObjA", 0}, wA);
output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "ObjB", 1}, *imageB.get());
output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "ObjB", 1}, wB);
output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "ObjC", 2}, *imageC.get());
output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "ObjC", 2}, wC);
```
in the workflow defined as:
```
<your_workflow> | o2-calibration-ccdb-populator-workflow --ccdb-path="http://localhost:8080" --name-extention loc  --sspec-min 1 --sspec-max 10 |
o2-calibration-ccdb-populator-workflow --sspec-min 0 --sspec-max 1  -b 
```
then the `ObjA` will be uploaded only to the default server (`http://alice-ccdb.cern.ch`), `ObjB` will be uploaded to both default and `local` server and
`ObjC` will be uploaded to the `local` server only.
