### PR TITLE
Truncate digitcontext output

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/DigitizationContext.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/DigitizationContext.h
@@ -72,7 +72,7 @@ class DigitizationContext
   void setMuPerBC(float m) { mMuBC = m; }
   float getMuPerBC() const { return mMuBC; }
 
-  void printCollisionSummary(bool withQED = false) const;
+  void printCollisionSummary(bool withQED = false, int truncateOutputTo = -1) const;
 
   // we need a method to fill the file names
   void setSimPrefixes(std::vector<std::string> const& p);

--- a/DataFormats/simulation/src/DigitizationContext.cxx
+++ b/DataFormats/simulation/src/DigitizationContext.cxx
@@ -20,7 +20,7 @@
 
 using namespace o2::steer;
 
-void DigitizationContext::printCollisionSummary(bool withQED) const
+void DigitizationContext::printCollisionSummary(bool withQED, int truncateOutputTo) const
 {
   std::cout << "Summary of DigitizationContext --\n";
   std::cout << "Maximal parts per collision " << mMaxPartNumber << "\n";
@@ -33,6 +33,10 @@ void DigitizationContext::printCollisionSummary(bool withQED) const
     std::cout << "Number of QED events " << mEventRecordsWithQED.size() - mEventRecords.size() << "\n";
     // loop over combined stuff
     for (int i = 0; i < mEventRecordsWithQED.size(); ++i) {
+      if (truncateOutputTo >= 0 && i > truncateOutputTo) {
+        std::cout << "--- Output truncated to " << truncateOutputTo << " ---\n";
+        break;
+      }
       std::cout << "Record " << i << " TIME " << mEventRecordsWithQED[i];
       for (auto& e : mEventPartsWithQED[i]) {
         std::cout << " (" << e.sourceID << " , " << e.entryID << ")";
@@ -42,6 +46,10 @@ void DigitizationContext::printCollisionSummary(bool withQED) const
   } else {
     std::cout << "Number of Collisions " << mEventRecords.size() << "\n";
     for (int i = 0; i < mEventRecords.size(); ++i) {
+      if (truncateOutputTo >= 0 && i > truncateOutputTo) {
+        std::cout << "--- Output truncated to " << truncateOutputTo << " ---\n";
+        break;
+      }
       std::cout << "Collision " << i << " TIME " << mEventRecords[i];
       for (auto& e : mEventParts[i]) {
         std::cout << " (" << e.sourceID << " , " << e.entryID << ")";

--- a/Steer/DigitizerWorkflow/src/SimReaderSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/SimReaderSpec.cxx
@@ -178,7 +178,7 @@ DataProcessorSpec getSimReaderSpec(SubspecRange range, const std::vector<std::st
 
         // get digitization context and add QED stuff
         mgr.getDigitizationContext().fillQED(qedprefix, qedinteractionrecords);
-        mgr.getDigitizationContext().printCollisionSummary(true);
+        mgr.getDigitizationContext().printCollisionSummary(true, 2000); // print with QED but truncate output
       }
       // --- end addition of QED contributions
 


### PR DESCRIPTION
With QED this may be very large otherwise.
The full output can still be obtained by
inspection of the context file.