### PR TITLE
TRD KrClusterer skip shared digits

### DIFF
--- a/Detectors/TRD/calibration/src/KrClusterFinder.cxx
+++ b/Detectors/TRD/calibration/src/KrClusterFinder.cxx
@@ -170,11 +170,15 @@ void KrClusterFinder::findClusters()
         int colMax = 0;
         unsigned int iDigitMax = 0;
         for (int iDigit = 0; iDigit < nDigitsInDet; ++iDigit) {
+          uint64_t digitIdx = digitIdxArray[trig.getFirstDigit() + idxFirstDigitInDet[iDet] + iDigit]; // global index for array of all digits (mDigits)
+          if (mDigits[digitIdx].isSharedDigit()) {
+            // we need to skip the shared digits which are duplicates contained in the global digits array
+            continue;
+          }
           if (isDigitUsed[iDigit]) {
             // if a maximum has been found for this digit then all ADCs above threshold are already flagged as used
             continue;
           }
-          uint64_t digitIdx = digitIdxArray[trig.getFirstDigit() + idxFirstDigitInDet[iDet] + iDigit]; // global index for array of all digits (mDigits)
           int tbMaxADC = -1;
           auto maxAdcInDigit = mDigits[digitIdx].getADCmax(tbMaxADC);
           if (maxAdcInDigit > adcMax) {
@@ -202,6 +206,10 @@ void KrClusterFinder::findClusters()
         std::vector<uint64_t> constituentAdcIndices;
         for (unsigned int iDigit = 0; iDigit < nDigitsInDet; ++iDigit) {
           uint64_t digitIdx = digitIdxArray[trig.getFirstDigit() + idxFirstDigitInDet[iDet] + iDigit]; // global index for array of all digits (mDigits)
+          if (mDigits[digitIdx].isSharedDigit()) {
+            // we need to skip the shared digits which are duplicates contained in the global digits array
+            continue;
+          }
           int row = mDigits[digitIdx].getPadRow();
           if (std::abs(row - rowMax) > 1) {
             continue;


### PR DESCRIPTION
Forgot about the shared digits in the Kr cluster finder... I am reprocessing now all the digits stored in `/alice/data/2022/JAN_TRD/501483/raw` which should not take more than a couple of days to complete.