### PR TITLE
ITS THR WF - Added CCDB upload within the workflow + bug fixed for ITHR scan analyses

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdCalibratorSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdCalibratorSpec.h
@@ -168,6 +168,7 @@ class ITSThresholdCalibrator : public Task
   std::string mOutputDir;
   std::string mMetafileDir = "/dev/null";
   int mNThreads = 1;
+  std::string mCcdbUrl = "";
   int mRunNumber = -1;
 
   // How many rows before starting new ROOT file


### PR DESCRIPTION
Changes applied:
- upload of calibration objects to CCDB from the workflow itself (i.e. w/o ```ccdb-populator``` wf) in order the test full chain at P2
- bugs fixed on ITHR scan analysis
