### PR TITLE
Add runType to GRPECS + its creator

### DIFF
--- a/DataFormats/Parameters/include/DataFormatsParameters/GRPECSObject.h
+++ b/DataFormats/Parameters/include/DataFormatsParameters/GRPECSObject.h
@@ -40,7 +40,22 @@ class GRPECSObject
                       PRESENT = 0x1,
                       CONTINUOUS = PRESENT + (0x1 << 1),
                       TRIGGERING = PRESENT + (0x1 << 2) };
-
+  enum RunType : int {
+    NONE,
+    PHYSICS,
+    TECHNICAL,
+    PEDESTAL,
+    PULSER,
+    LASER,
+    CALIBRATION_ITHR_TUNING,
+    CALIBRATION_VCASN_TUNING,
+    CALIBRATION_THR_SCAN,
+    CALIBRATION_DIGITAL_SCAN,
+    CALIBRATION_ANALOG_SCAN,
+    CALIBRATION_FHR,
+    CALIBRATION_ALPIDE_SCAN,
+    NRUNTYPES
+  };
   GRPECSObject() = default;
   ~GRPECSObject() = default;
 
@@ -96,6 +111,9 @@ class GRPECSObject
   void setDetROMode(DetID id, ROMode status);
   ROMode getDetROMode(DetID id) const;
 
+  void setRunType(RunType t) { mRunType = t; }
+  auto getRunType() const { return mRunType; }
+
   bool isMC() const { return mIsMC; }
   void setIsMC(bool v = true) { mIsMC = v; }
 
@@ -120,10 +138,11 @@ class GRPECSObject
   DetID::mask_t mDetsContinuousRO; ///< mask of detectors read out in continuos mode
   DetID::mask_t mDetsTrigger;      ///< mask of detectors which provide trigger
   bool mIsMC = false;              ///< flag GRP for MC
-  int mRun = 0;                 ///< run identifier
-  std::string mDataPeriod = ""; ///< name of the period
+  int mRun = 0;                    ///< run identifier
+  RunType mRunType = NONE;         ///< run type
+  std::string mDataPeriod{};       ///< name of the period
 
-  ClassDefNV(GRPECSObject, 3);
+  ClassDefNV(GRPECSObject, 4);
 };
 
 } // namespace parameters

--- a/DataFormats/Parameters/src/GRPECSObject.cxx
+++ b/DataFormats/Parameters/src/GRPECSObject.cxx
@@ -27,6 +27,7 @@ void GRPECSObject::print() const
 {
   // print itself
   std::time_t ts = mTimeStart / 1000, te = mTimeEnd / 1000;
+  printf("Run %d of type %d, period %s\n", mRun, int(mRunType), mDataPeriod.c_str());
   printf("Start: %s", std::ctime(&ts));
   printf("End  : %s", std::ctime(&te));
   printf("isMC : %d ", isMC());

--- a/Detectors/GRP/workflows/src/create-grp-ecs.cxx
+++ b/Detectors/GRP/workflows/src/create-grp-ecs.cxx
@@ -102,7 +102,7 @@ int main(int argc, char** argv)
     add_option("help,h", "Print this help message");
     add_option("period,p", bpo::value<std::string>(), "data taking period");
     add_option("run,r", bpo::value<int>(), "run number");
-    add_option("run-type,t", bpo::value<int>->default_value(int(GRPECSObject::RunType::NONE)), "run type");
+    add_option("run-type,t", bpo::value<int>()->default_value(int(GRPECSObject::RunType::NONE)), "run type");
     add_option("hbf-per-tf,n", bpo::value<int>()->default_value(128), "number of HBFs per TF");
     add_option("detectors,d", bpo::value<string>()->default_value("all"), "comma separated list of detectors");
     add_option("continuous,c", bpo::value<string>()->default_value("ITS,TPC,TOF,MFT,MCH,MID,ZDC,FT0,FV0,FDD,CTP"), "comma separated list of detectors in continuous readout mode");

--- a/Detectors/GRP/workflows/src/create-grp-ecs.cxx
+++ b/Detectors/GRP/workflows/src/create-grp-ecs.cxx
@@ -102,7 +102,7 @@ int main(int argc, char** argv)
     add_option("help,h", "Print this help message");
     add_option("period,p", bpo::value<std::string>(), "data taking period");
     add_option("run,r", bpo::value<int>(), "run number");
-    add_option("run-type,t", bpo::value<int>(int(GRPECSObject::RunType::NONE)), "run type");
+    add_option("run-type,t", bpo::value<int>->default_value(int(GRPECSObject::RunType::NONE)), "run type");
     add_option("hbf-per-tf,n", bpo::value<int>()->default_value(128), "number of HBFs per TF");
     add_option("detectors,d", bpo::value<string>()->default_value("all"), "comma separated list of detectors");
     add_option("continuous,c", bpo::value<string>()->default_value("ITS,TPC,TOF,MFT,MCH,MID,ZDC,FT0,FV0,FDD,CTP"), "comma separated list of detectors in continuous readout mode");

--- a/Detectors/GRP/workflows/src/create-grp-ecs.cxx
+++ b/Detectors/GRP/workflows/src/create-grp-ecs.cxx
@@ -21,11 +21,11 @@
 using DetID = o2::detectors::DetID;
 using CcdbApi = o2::ccdb::CcdbApi;
 using GRPECSObject = o2::parameters::GRPECSObject;
-
 namespace bpo = boost::program_options;
 
 void createGRPECSObject(const std::string& dataPeriod,
                         int run,
+                        int runType,
                         int nHBPerTF,
                         const std::string& detsReadout,
                         const std::string& detsContinuousRO,
@@ -38,15 +38,21 @@ void createGRPECSObject(const std::string& dataPeriod,
   if (detMask.count() == 0) {
     throw std::runtime_error("empty detectors list is provided");
   }
+  if (runType < 0 || runType >= int(GRPECSObject::RunType::NRUNTYPES)) {
+    LOGP(warning, "run type {} is not recognized, consider updating GRPECSObject.h", runType);
+  }
   auto detMaskCont = detMask & o2::detectors::DetID::getMask(detsContinuousRO);
   auto detMaskTrig = detMask & o2::detectors::DetID::getMask(detsTrigger);
   LOG(info) << tstart << " " << tend;
   if (tstart == 0) {
     tstart = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
   }
-  if (tend == 0) {
-    tend = tstart + 3 * 24 * 3600 * 1000UL;
+  long tendVal = 0;
+  if (tend < tstart) {
+    tendVal = tstart + 2 * 24 * 3600 * 1000UL; // assume that we will never have run longer than 2 days
     LOG(info) << tstart << " -> " << tend;
+  } else if (tendVal < tend) {
+    tendVal = tend + 3600 * 1000UL; // we want the version with EOR to fully override the version w/o EOR
   }
   GRPECSObject grpecs;
   grpecs.setTimeStart(tstart);
@@ -57,6 +63,7 @@ void createGRPECSObject(const std::string& dataPeriod,
   grpecs.setDetsContinuousReadOut(detMaskCont);
   grpecs.setDetsTrigger(detMaskTrig);
   grpecs.setRun(run);
+  grpecs.setRunType((GRPECSObject::RunType)runType);
   grpecs.setDataPeriod(dataPeriod);
 
   grpecs.print();
@@ -68,9 +75,8 @@ void createGRPECSObject(const std::string& dataPeriod,
     metadata["responsible"] = "ECS";
     metadata[o2::base::NameConf::CCDBRunTag.data()] = std::to_string(run);
     // long ts = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-    api.storeAsTFileAny(&grpecs, "GLO/Config/GRPECS", metadata, tstart, tend); // making it 1-year valid to be sure we have something
-    LOG(info) << "Uploaded to " << ccdbServer << "/"
-              << "GLO/Config/GRPECS";
+    api.storeAsTFileAny(&grpecs, "GLO/Config/GRPECS", metadata, tstart, tendVal); // making it 1-year valid to be sure we have something
+    LOGP(info, "Uploaded to {}/{} with validity {}:{}", ccdbServer, "GLO/Config/GRPECS", tstart, tendVal);
   } else { // write a local file
     auto fname = o2::base::NameConf::getGRPECSFileName();
     TFile grpF(fname.c_str(), "recreate");
@@ -96,10 +102,11 @@ int main(int argc, char** argv)
     add_option("help,h", "Print this help message");
     add_option("period,p", bpo::value<std::string>(), "data taking period");
     add_option("run,r", bpo::value<int>(), "run number");
+    add_option("run-type,t", bpo::value<int>(int(GRPECSObject::RunType::NONE)), "run type");
     add_option("hbf-per-tf,n", bpo::value<int>()->default_value(128), "number of HBFs per TF");
     add_option("detectors,d", bpo::value<string>()->default_value("all"), "comma separated list of detectors");
     add_option("continuous,c", bpo::value<string>()->default_value("ITS,TPC,TOF,MFT,MCH,MID,ZDC,FT0,FV0,FDD,CTP"), "comma separated list of detectors in continuous readout mode");
-    add_option("triggering,t", bpo::value<string>()->default_value("FT0,FV0"), "comma separated list of detectors providing a trigger");
+    add_option("triggering,g", bpo::value<string>()->default_value("FT0,FV0"), "comma separated list of detectors providing a trigger");
     add_option("start-time,s", bpo::value<long>()->default_value(0), "run start time in ms, now() if 0");
     add_option("end-time,e", bpo::value<long>()->default_value(0), "run end time in ms, start-time+3days is used if 0");
     add_option("ccdb-server", bpo::value<std::string>()->default_value("http://alice-ccdb.cern.ch"), "CCDB server for upload, local file if empty");
@@ -138,6 +145,7 @@ int main(int argc, char** argv)
   createGRPECSObject(
     vm["period"].as<std::string>(),
     vm["run"].as<int>(),
+    vm["run-type"].as<int>(),
     vm["hbf-per-tf"].as<int>(),
     vm["detectors"].as<std::string>(),
     vm["continuous"].as<std::string>(),


### PR DESCRIPTION
Also, change the way the EOR time is registered: at SOR the ECS must call the executable
with EOR time set to 0 (default), which will be recorded in the GRPECS object but the object
will be stored with validity SOR_time : SOR_time + 2days (to be queriable for the online
processing, assuming longest run duration of 2 days).
o2-ecs-grp-create -r <run> -p <period> -s <SOR_TIME>

Then, at the EOR, the ECS should call the creator with the same options + EOR_time:
o2-ecs-grp-create -r <run> -p <period> -s <SOR_TIME> -e <EOR_TIME>
which will update the object with validity max(SOR_time + 2days, EOR_time+1h).