### PR TITLE
[O2-2776] produce raw data dumps on ITS/MFT decoding errors

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/DecodingStat.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/DecodingStat.h
@@ -101,7 +101,7 @@ struct ChipStat {
     ErrActPropagate | ErrActDump, // LongData pattern has highest bit set
     ErrActPropagate | ErrActDump, // Region is not followed by Short or Long data
     ErrActPropagate | ErrActDump, // Unknown word was seen
-    ErrActPropagate | ErrActDump, // Same pixel fired more than once
+    ErrActPropagate,              // Same pixel fired more than once
     ErrActPropagate | ErrActDump, // Non-existing row decoded
     ErrActPropagate | ErrActDump, // lane entering strip data mode | See https://alice.its.cern.ch/jira/browse/O2-1717
     ErrActPropagate | ErrActDump, // lane exiting strip data mode
@@ -112,7 +112,7 @@ struct ChipStat {
     ErrActPropagate | ErrActDump, // FSM error (FATAL, SEU error, reached an unknown state)
     ErrActPropagate | ErrActDump, // pending detector events limit (FATAL)
     ErrActPropagate | ErrActDump, // pending detector events limit in packager(FATAL)
-    ErrActPropagate | ErrActDump, // DColumns non increasingx
+    ErrActPropagate | ErrActDump  // DColumns non increasing
   };
   uint16_t feeID = -1;
   size_t nHits = 0;

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/PayLoadSG.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/PayLoadSG.h
@@ -123,6 +123,10 @@ class PayLoadSG
     return currentPiece();
   }
 
+  const SGPiece* getPiece(int i) const { return &mBuffer[i]; }
+
+  size_t getNPieces() const { return mBuffer.size(); }
+
  private:
   std::vector<SGPiece> mBuffer;   // list of pieces to fetch
   size_t mCurrentPieceID = 0;     // current piece

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RUDecodeData.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RUDecodeData.h
@@ -40,7 +40,7 @@ struct RUDecodeData {
   std::array<uint8_t, MaxCablesPerRU> cableHWID;           // HW ID of cable whose data is in the corresponding slot of cableData
   std::array<uint8_t, MaxCablesPerRU> cableLinkID;         // ID of the GBT link transmitting this cable data
   std::array<GBTLink*, MaxCablesPerRU> cableLinkPtr;       // Ptr of the GBT link transmitting this cable data
-
+  std::unordered_map<uint64_t, uint32_t> linkHBFToDump;    // FEEID<<32+hbfEntry to dump in case of error
   int ruSWID = -1;         // SW (stave) ID
   int nCables = 0;         // total number of cables decoded for single trigger
   int nChipsFired = 0;     // number of chips with data or with errors

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelDecoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelDecoder.h
@@ -87,6 +87,7 @@ class RawPixelDecoder final : public PixelReader
   int getVerbosity() const { return mVerbosity; }
 
   void printReport(bool decstat = true, bool skipNoErr = true) const;
+  void produceRawDataDumps(int dump, const o2::header::DataHeader* dh);
 
   void clearStat();
 

--- a/Detectors/ITSMFT/common/reconstruction/src/DecodingStat.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/DecodingStat.cxx
@@ -32,36 +32,44 @@ uint32_t ChipStat::getNErrors() const
 
 ///_________________________________________________________________
 /// print link decoding statistics
-void ChipStat::addErrors(uint32_t mask, uint16_t chID, int verbosity)
+uint32_t ChipStat::addErrors(uint32_t mask, uint16_t chID, int verbosity)
 {
+  uint32_t res = 0;
   if (mask) {
     for (int i = NErrorsDefined; i--;) {
       if (mask & (0x1 << i)) {
+        res |= ErrActions[i] & ErrActPropagate;
         if (verbosity > -1 && (!errorCounts[i] || verbosity > 1)) {
           LOGP(important, "New error registered on the FEEID:{:#04x}: chip#{}: {}", feeID, chID, ErrNames[i]);
+          res |= ErrActions[i] & ErrActDump;
         }
         errorCounts[i]++;
       }
     }
   }
+  return res;
 }
 
 ///_________________________________________________________________
 /// print link decoding statistics
-void ChipStat::addErrors(const ChipPixelData& d, int verbosity)
+uint32_t ChipStat::addErrors(const ChipPixelData& d, int verbosity)
 {
+  uint32_t res = 0;
   if (d.getErrorFlags()) {
     for (int i = NErrorsDefined; i--;) {
       if (d.getErrorFlags() & (0x1 << i)) {
+        res |= ErrActions[i] & ErrActPropagate;
         if (verbosity > -1 && (!errorCounts[i] || verbosity > 1)) {
           LOGP(important, "New error registered at bc/orbit {}/{} on the FEEID:{:#04x} chip#{}: {}{}",
                d.getInteractionRecord().bc, d.getInteractionRecord().orbit,
                feeID, int16_t(d.getChipID()), ErrNames[i], d.getErrorDetails(i));
+          res |= ErrActions[i] & ErrActDump;
         }
         errorCounts[i]++;
       }
     }
   }
+  return res;
 }
 
 ///_________________________________________________________________

--- a/Detectors/ITSMFT/common/reconstruction/src/RUDecodeData.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/RUDecodeData.cxx
@@ -55,7 +55,10 @@ void RUDecodeData::fillChipStatistics(int icab, const ChipPixelData* chipData)
 {
   cableLinkPtr[icab]->chipStat.nHits += chipData->getData().size();
   //cableLinkPtr[icab]->chipStat.addErrors(chipData->getErrorFlags(), chipData->getChipID(), verbosity);
-  cableLinkPtr[icab]->chipStat.addErrors(*chipData, verbosity);
+  auto action = cableLinkPtr[icab]->chipStat.addErrors(*chipData, verbosity);
+  if (action & ChipStat::ErrActDump) {
+    linkHBFToDump[(uint64_t(cableLinkPtr[icab]->subSpec) << 32) + cableLinkPtr[icab]->hbfEntry] = cableLinkPtr[icab]->irHBF.orbit;
+  }
 }
 
 } // namespace itsmft

--- a/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
@@ -18,6 +18,7 @@
 #include "Framework/InputRecordWalker.h"
 #include "CommonUtils/StringUtils.h"
 #include "CommonUtils/VerbosityConfig.h"
+#include <filesystem>
 
 #ifdef WITH_OPENMP
 #include <omp.h>
@@ -133,6 +134,7 @@ void RawPixelDecoder<Mapping>::startNewTF(InputRecord& inputs)
   }
   for (auto& ru : mRUDecodeVec) {
     ru.clear();
+    ru.linkHBFToDump.clear();
   }
   setupLinks(inputs);
   mNLinksDone = 0;
@@ -206,6 +208,7 @@ void RawPixelDecoder<Mapping>::setupLinks(InputRecord& inputs)
     if (lnkref.entry == -1) { // new link needs to be added
       lnkref.entry = int(mGBTLinks.size());
       auto& lnk = mGBTLinks.emplace_back(RDHUtils::getCRUID(rdh), RDHUtils::getFEEID(rdh), RDHUtils::getEndPointID(rdh), RDHUtils::getLinkID(rdh), lnkref.entry);
+      lnk.subSpec = dh->subSpecification;
       getCreateRUDecode(mMAP.FEEId2RUSW(RDHUtils::getFEEID(rdh))); // make sure there is a RU for this link
       lnk.verbosity = GBTLink::Verbosity(mVerbosity);
       lnk.format = mFormat;
@@ -405,6 +408,69 @@ void RawPixelDecoder<Mapping>::clearStat()
   // clear statistics
   for (auto& lnk : mGBTLinks) {
     lnk.clear(true, false);
+  }
+}
+
+///______________________________________________________________________
+template <class Mapping>
+void RawPixelDecoder<Mapping>::produceRawDataDumps(int dump, const o2::header::DataHeader* dh)
+{
+  bool dumpFullTF = false;
+  for (auto& ru : mRUDecodeVec) {
+    if (ru.linkHBFToDump.size()) {
+      if (dump == int(GBTLink::RawDataDumps::DUMP_TF)) {
+        dumpFullTF = true;
+        break;
+      }
+      for (auto it : ru.linkHBFToDump) {
+        if (dump == int(GBTLink::RawDataDumps::DUMP_HBF)) {
+          const auto& lnk = mGBTLinks[mSubsSpec2LinkID[it.first >> 32].entry];
+          int entry = it.first & 0xffffffff;
+          bool allHBFs = false;
+          std::string fnm;
+          if (entry >= lnk.rawData.getNPieces()) {
+            allHBFs = true;
+            entry = 0;
+            fnm = fmt::format("rawdump_{}_run{}_tf_orb{}_full_feeID{:#06x}.raw",
+                              Mapping::getName(), dh->runNumber, dh->firstTForbit, lnk.feeID);
+          } else {
+            fnm = fmt::format("rawdump_{}_run{}_tf_orb{}_hbf_orb{}_feeID{:#06x}.raw",
+                              Mapping::getName(), dh->runNumber, dh->firstTForbit, it.second, lnk.feeID);
+          }
+          std::ofstream ostrm(fnm, std::ios::binary);
+          if (!ostrm.good()) {
+            LOG(error) << "failed to open " << fnm;
+            continue;
+          }
+          while (entry < lnk.rawData.getNPieces()) {
+            const auto* piece = lnk.rawData.getPiece(entry);
+            if (!allHBFs && RDHUtils::getHeartBeatOrbit(reinterpret_cast<const RDH*>(piece->data)) != it.second) {
+              break;
+            }
+            ostrm.write(reinterpret_cast<const char*>(piece->data), piece->size);
+            entry++;
+          }
+          LOG(important) << "produced " << std::filesystem::current_path().c_str() << '/' << fnm;
+        }
+      }
+    }
+  }
+  while (dumpFullTF) {
+    std::string fnm = fmt::format("rawdump_{}_run{}_tf_orb{}_full.raw",
+                                  Mapping::getName(), dh->runNumber, dh->firstTForbit);
+    std::ofstream ostrm(fnm, std::ios::binary);
+    if (!ostrm.good()) {
+      LOG(error) << "failed to open " << fnm;
+      break;
+    }
+    for (const auto& lnk : mGBTLinks) {
+      for (size_t i = 0; i < lnk.rawData.getNPieces(); i++) {
+        const auto* piece = lnk.rawData.getPiece(i);
+        ostrm.write(reinterpret_cast<const char*>(piece->data), piece->size);
+      }
+    }
+    LOG(important) << "produced " << std::filesystem::current_path().c_str() << '/' << fnm;
+    break;
   }
 }
 

--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/STFDecoderSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/STFDecoderSpec.h
@@ -69,6 +69,7 @@ class STFDecoder : public Task
   bool mUnmutExtraLanes = false;
   bool mFinalizeDone = false;
   bool mAllowReporting = true;
+  int mDumpOnError = 0;
   int mNThreads = 1;
   int mVerbosity = 0;
   size_t mTFCounter = 0;


### PR DESCRIPTION
o2-itsmft-stf-decoder-workflow decoder option raw-data-dumps added to allow producing local files
with raw data dump when decoding error is encountered
0: no dumps produced
1 (default): produce dump only for the link and only for the HBF with error (unless if the error
             was in the RDH decoding, in which case full TF for this link is dumped)
2: dump data of all links for the full TF

The policy for producing the dumps is the same as for logging an error:  
only for the 1st instance of every error type for every chip or FEEID, and, if there are multiple decoders running in the workflow, only from the 1st decoder instance.

Example of `o2-itsmft-stf-decoder-workflow --runmft --raw-data-dumps 1`:
```
[2476637:mft-stf-decoder]: [23:26:09][IMPORTANT] New error registered at bc/orbit 0/336373882 on the FEEID:0x103 chip#-1: APE_PROTOCOL_ERROR
[2476637:mft-stf-decoder]: [23:26:09][IMPORTANT] New error registered at bc/orbit 0/336373882 on the FEEID:0x143 chip#-1: APE_PROTOCOL_ERROR
[2476637:mft-stf-decoder]: [23:26:09][IMPORTANT] New error registered at bc/orbit 0/336373882 on the FEEID:0x243 chip#-1: APE_OOT_START
...
[2476637:mft-stf-decoder]: [23:26:09][IMPORTANT] New error registered at bc/orbit 2376/336373930 on the FEEID:0x101 chip#24: DColumns non-increasing
[2476637:mft-stf-decoder]: [23:26:09][IMPORTANT] New error registered at bc/orbit 3168/336373930 on the FEEID:0x101 chip#24: BusyViolation flag ON
...
[2476637:mft-stf-decoder]: [23:26:09][IMPORTANT] produced /home/shahoian/Downloads/mft/rawdump_MFT_run505582_tf_orb336373882_hbf_orb336373930_feeID0x0101.raw
[2476637:mft-stf-decoder]: [23:26:09][IMPORTANT] produced /home/shahoian/Downloads/mft/rawdump_MFT_run505582_tf_orb336373882_hbf_orb336373882_feeID0x0103.raw
[2476637:mft-stf-decoder]: [23:26:09][IMPORTANT] produced /home/shahoian/Downloads/mft/rawdump_MFT_run505582_tf_orb336373882_hbf_orb336373882_feeID0x0243.raw
[2476637:mft-stf-decoder]: [23:26:09][IMPORTANT] produced /home/shahoian/Downloads/mft/rawdump_MFT_run505582_tf_orb336373882_hbf_orb336373882_feeID0x0143.raw
...
```
The same data with `o2-itsmft-stf-decoder-workflow --runmft --raw-data-dumps 2`: 
```
# same errors
...
[2476883:mft-stf-decoder]: [23:26:35][IMPORTANT] produced /home/shahoian/Downloads/mft/rawdump_MFT_run505582_tf_orb336373882_full.raw
```