### PR TITLE
Timestamp propagation and use in digitizer workflow

### DIFF
--- a/CCDB/src/DownloadCCDBFile.cxx
+++ b/CCDB/src/DownloadCCDBFile.cxx
@@ -27,7 +27,7 @@ bool initOptionsAndParse(bpo::options_description& options, int argc, char* argv
     "dest,d", bpo::value<std::string>()->default_value("./"), "destination path")(
     "no-preserve-path", "Do not preserve path structure. If not set, the full path structure -- reflecting the '--path' argument will be put.")(
     "outfile,o", bpo::value<std::string>()->default_value("snapshot.root"), "Name of output file. If set to \"\", the name will be determined from the uploaded content.")(
-    "timestamp,t", bpo::value<long>()->default_value(-1), "timestamp - default -1 = now")(
+    "timestamp,t", bpo::value<long>()->default_value(-1), "timestamp in ms - default -1 = now")(
     "help,h", "Produce help message.");
 
   try {

--- a/Detectors/CPV/simulation/src/Digitizer.cxx
+++ b/Detectors/CPV/simulation/src/Digitizer.cxx
@@ -38,9 +38,10 @@ void Digitizer::init()
     auto& ccdbMgr = o2::ccdb::BasicCCDBManager::instance();
     ccdbMgr.setCaching(true);                     //make local cache of remote objects
     ccdbMgr.setLocalObjectValidityChecking(true); //query objects from remote site only when local one is not valid
-    //read calibration from ccdb (for now do it only at the beginning of dataprocessing)
-    //TODO: setup timestam according to anchors
-    ccdbMgr.setTimestamp(o2::ccdb::getCurrentTimestamp());
+    // read calibration from ccdb (for now do it only at the beginning of dataprocessing)
+    // TODO: setup timestam according to anchors
+    // Do not set timestamp here: This should be set from the framework and is done via the digitizer workflow
+    // ccdbMgr.setTimestamp(o2::ccdb::getCurrentTimestamp());
 
     LOG(info) << "CCDB: Reading o2::cpv::CalibParams from CPV/Calib/Gains";
     mCalibParams = ccdbMgr.get<o2::cpv::CalibParams>("CPV/Calib/Gains");

--- a/Detectors/TRD/workflow/src/TRDDigitizerSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDDigitizerSpec.cxx
@@ -63,8 +63,10 @@ class TRDDPLDigitizerTask : public o2::base::BaseDPLDigitizer
     bool mctruth = pc.outputs().isAllowed({"TRD", "LABELS", 0});
 
     Calibrations simcal;
-    auto timeStamp = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-    simcal.getCCDBObjects(timeStamp);
+    // the timestamp can be extracted from the DPL header (it is set in SimReader)
+    const auto ref = pc.inputs().getFirstValid(true);
+    auto creationTime = DataRefUtils::getHeader<DataProcessingHeader*>(ref)->creation;
+    simcal.getCCDBObjects(creationTime);
     mDigitizer.setCalibrations(&simcal);
 
     // read collision context from input

--- a/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
+++ b/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
@@ -24,6 +24,7 @@
 #include "CommonUtils/NameConf.h"
 #include "CommonUtils/ConfigurableParam.h"
 #include "DetectorsRaw/HBFUtils.h"
+#include "CCDB/BasicCCDBManager.h"
 
 // for TPC
 #include "TPCDigitizerSpec.h"
@@ -198,6 +199,32 @@ void customize(std::vector<o2::framework::DispatchPolicy>& policies)
   };
   policies.push_back({"prompt-for-simreader", matcher, DispatchOp::WhenReady});
 }
+
+void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
+{
+  // we customize the time information sent in DPL headers
+  policies.push_back(o2::framework::CallbacksPolicy{
+    [](o2::framework::DeviceSpec const& spec, o2::framework::ConfigContext const& context) -> bool {
+      return true;
+    },
+    [](o2::framework::CallbackService& service, o2::framework::InitContext& context) {
+      // simple linear enumeration from already updated HBFUtils (set via config key values)
+      service.set(o2::framework::CallbackService::Id::NewTimeslice,
+                  [](o2::header::DataHeader& dh, o2::framework::DataProcessingHeader& dph) {
+                    const auto& hbfu = o2::raw::HBFUtils::Instance();
+                    const auto offset = int64_t(hbfu.getFirstIRofTF({0, hbfu.orbitFirstSampled}).orbit);
+                    const auto increment = int64_t(hbfu.nHBFPerTF);
+                    const auto startTime = hbfu.startTime;
+                    const auto orbitFirst = hbfu.orbitFirst;
+                    dh.firstTForbit = offset + increment * dh.tfCounter;
+                    LOG(info) << "Setting firstTFOrbit to " << dh.firstTForbit;
+                    dph.creation = startTime + (dh.firstTForbit - orbitFirst) * o2::constants::lhc::LHCOrbitMUS * 1.e-3;
+                    LOG(info) << "Setting timeframe creation time to " << dph.creation;
+                  });
+    }} // end of struct
+  );
+}
+
 // ------------------------------------------------------------------
 
 #include "Framework/runDataProcessing.h"
@@ -396,6 +423,10 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     }
   }
   auto grpfile = o2::base::NameConf::getGRPFileName(simPrefixes[0]);
+  // init on a high level, the time for the CCDB queries
+  // we expect that digitizers do not play with the manager themselves
+  // this will only be needed until digitizers take CCDB objects via DPL mechanism
+  o2::ccdb::BasicCCDBManager::instance().setTimestamp(hbfu.startTime);
 
   // update the digitization configuration with the right geometry file
   // we take the geometry from the first simPrefix (could actually check if they are


### PR DESCRIPTION
The digitizer workflow is now calculating the timeframe's timestamp
based on the HBF parameters and is propagating this value through DPL
header properties. This is done is the same way as used in async
reconstruction.
To anchor digitization to a particular timestamp it suffices to set
`HBFUtils.startTime=xxx`.

Additional changes to use consistent timing in digitization:
* take out timestamp setting on BasicCCDBManager for CPV
  (the timing is set anyways by the master digitizer workflow)
* use new mechanism to retrieve and use timestamp in TRD