### PR TITLE
Do not discard decoded chip data if decoding error was set

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RUDecodeData.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RUDecodeData.h
@@ -90,7 +90,12 @@ int RUDecodeData::decodeROF(const Mapping& mp)
 #ifdef ALPIDE_DECODING_STAT
       fillChipStatistics(icab, chipData);
 #endif
-      if (ret >= 0 && !chipData->isErrorSet()) { // make sure there was no error
+      if (ret >= 0 /* && !chipData->isErrorSet()*/) { // make sure there was no error | upd: why? if there was a non fatal error, we use chip data
+        if (chipData->isErrorSet() && nChipsFired && chipData->getChipID() == chipsData[nChipsFired - 1].getChipID()) {
+          // we are still in the chip data whose decoding was aborted due to the error, reuse this chip data
+          LOGP(debug, "re-entry into the data of the chip {} after previously detector error", chipData->getChipID());
+          continue;
+        }
         ntot += chipData->getData().size();
         if (++nChipsFired < chipsData.size()) { // fetch next free chip
           chipData = &chipsData[nChipsFired];

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelDecoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelDecoder.h
@@ -181,14 +181,12 @@ int RawPixelDecoder<ChipMappingMFT>::fillDecodedDigits(DigitContainer& digits, R
   }
   mTimerFetchData.Start(false);
   int ref = digits.size();
-  while (!mOrderedChipsPtr.empty()) {
-    const auto& chipData = *mOrderedChipsPtr.back();
-    assert(mLastReadChipID < chipData.getChipID());
-    mLastReadChipID = chipData.getChipID();
-    for (const auto& hit : chipData.getData()) {
+  for (auto chipData = mOrderedChipsPtr.rbegin(); chipData != mOrderedChipsPtr.rend(); ++chipData) {
+    assert(mLastReadChipID < (*chipData)->getChipID());
+    mLastReadChipID = (*chipData)->getChipID();
+    for (const auto& hit : (*chipData)->getData()) {
       digits.emplace_back(mLastReadChipID, hit.getRow(), hit.getCol());
     }
-    mOrderedChipsPtr.pop_back();
   }
   int nFilled = digits.size() - ref;
   rofs.emplace_back(mInteractionRecord, mROFCounter, ref, nFilled);


### PR DESCRIPTION
Also, preserve the sorted fired MFT chips after filling the digits, to be used for the clustering if both digits and clusters were requested from the decoder. 