### PR TITLE
Suppress header exposing filesystem to clang

### DIFF
--- a/Detectors/CTF/utils/CTFdict2CCDBfiles.C
+++ b/Detectors/CTF/utils/CTFdict2CCDBfiles.C
@@ -1,5 +1,4 @@
 #if !defined(__CLING__) || defined(__ROOTCLING__)
-#include "DetectorsBase/CTFCoderBase.h"
 #include "DetectorsCommonDataFormats/CTFDictHeader.h"
 #include "DetectorsCommonDataFormats/CTFHeader.h"
 #include "CommonUtils/NameConf.h"


### PR DESCRIPTION
Merging since the CI on cs8 is broken.