### PR TITLE
[EMCAL-760] Stand-alone publisher for digits

### DIFF
--- a/Detectors/EMCAL/workflow/CMakeLists.txt
+++ b/Detectors/EMCAL/workflow/CMakeLists.txt
@@ -58,6 +58,11 @@ o2_add_executable(cell-reader-workflow
                   SOURCES src/cell-reader-workflow.cxx
                   PUBLIC_LINK_LIBRARIES O2::EMCALWorkflow)
 
+o2_add_executable(digit-reader-workflow
+                  COMPONENT_NAME emcal
+                  SOURCES src/digit-reader-workflow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::EMCALWorkflow)
+
 o2_add_executable(standalone-aod-producer-workflow
                   COMPONENT_NAME emcal
                   SOURCES src/standalone-aod-producer-workflow.cxx

--- a/Detectors/EMCAL/workflow/src/digit-reader-workflow.cxx
+++ b/Detectors/EMCAL/workflow/src/digit-reader-workflow.cxx
@@ -13,7 +13,7 @@
 #include <vector>
 #include "Framework/Variant.h"
 #include "Framework/ConfigParamSpec.h"
-#include "DataFormatsEMCAL/Cell.h"
+#include "DataFormatsEMCAL/Digit.h"
 #include "DetectorsRaw/HBFUtilsInitializer.h"
 #include "EMCALWorkflow/PublisherSpec.h"
 #include "CommonUtils/ConfigurableParam.h"
@@ -38,19 +38,20 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
 
   WorkflowSpec specs;
-  specs.emplace_back(o2::emcal::getPublisherSpec<std::vector<o2::emcal::Cell>>(PublisherConf{
-                                                                                 "emcal-cell-reader",
-                                                                                 "o2sim",
-                                                                                 "emccells.root",
-                                                                                 {"cellbranch", "EMCALCell", "Cell branch"},
-                                                                                 {"celltriggerbranch", "EMCALCellTRGR", "Trigger record branch"},
-                                                                                 {"mcbranch", "EMCALCellMCTruth", "MC label branch"},
-                                                                                 o2::framework::OutputSpec{"EMC", "CELLS"},
-                                                                                 o2::framework::OutputSpec{"EMC", "CELLSTRGR"},
-                                                                                 o2::framework::OutputSpec{"EMC", "CELLSMCTR"}},
-                                                                               !disableMC));
+  specs.emplace_back(o2::emcal::getPublisherSpec<std::vector<o2::emcal::Digit>>(PublisherConf{
+                                                                                  "emcal-digit-reader",
+                                                                                  "o2sim",
+                                                                                  "emcdigits.root",
+                                                                                  {"digitbranch", "EMCALDigit", "Digit branch"},
+                                                                                  {"digittriggerbranch", "EMCALDigitTRGR", "Trigger record branch"},
+                                                                                  {"mcbranch", "EMCALDigitMCTruth", "MC label branch"},
+                                                                                  o2::framework::OutputSpec{"EMC", "DIGITS"},
+                                                                                  o2::framework::OutputSpec{"EMC", "DIGITSTRGR"},
+                                                                                  o2::framework::OutputSpec{"EMC", "DIGITSMCTR"}},
+                                                                                !disableMC));
 
   // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
   o2::raw::HBFUtilsInitializer hbfIni(cfgc, specs);
+
   return specs;
 }


### PR DESCRIPTION
Trivial stand-alone publisher for digits, based on the
publisher in the RecoWorkflow. Needed for the QC
in simulation.