### PR TITLE
Class to build the hit map for MID chamber efficiency calculations

### DIFF
--- a/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/Track.h
+++ b/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/Track.h
@@ -36,6 +36,10 @@ class Track
   /// Gets the track z position
   float getPositionZ() const { return mPosition[2]; }
 
+  /// Ses the track position
+  /// \param xPos x position
+  /// \param yPos y position
+  /// \param zPos z position
   void setPosition(float xPos, float yPos, float zPos);
 
   /// Gets the track x direction
@@ -45,6 +49,10 @@ class Track
   /// Gets the track z direction
   float getDirectionZ() const { return mDirection[2]; }
 
+  /// Ses the track direction
+  /// \param xDir x direction
+  /// \param yDir y direction
+  /// \param zDir z direction
   void setDirection(float xDir, float yDir, float zDir);
 
   enum class CovarianceParamIndex : int {
@@ -63,22 +71,43 @@ class Track
   {
     return mCovarianceParameters[static_cast<int>(covParam)];
   }
-  void setCovarianceParameters(float xErr2, float yErr2, float slopeXErr2, float slopeYErr2, float covXSlopeX,
-                               float covYSlopeY);
+
+  /// Sets the covariance parameters
+  /// \param xErr2 Variance on x position
+  /// \param yErr2 Variance on y position
+  /// \param slopeXErr2 Variance on x slope
+  /// \param slopeYErr2 Variance on y slope
+  /// \param covXSlopeX Covariance on x position and slope
+  /// \param covYSlopeY Covariance on y position and slope
+  void setCovarianceParameters(float xErr2, float yErr2, float slopeXErr2, float slopeYErr2, float covXSlopeX, float covYSlopeY);
 
   /// Sets the covariance matrix
+  /// \param covParam array with the covariance parameters
   void setCovarianceParameters(const std::array<float, 6>& covParam) { mCovarianceParameters = covParam; }
 
   /// Checks if covariance is set
   bool isCovarianceSet() { return (mCovarianceParameters[0] != 0.); }
 
+  /// Propagates the track parameter to z position with a linear extrapolation
+  /// \param zPosition Z position
+  /// \return false if the track parameters were already at the required z
   bool propagateToZ(float zPosition);
 
   /// Gets the matched clusters without bound checking
+  /// \param chamber Chamber ID (from 0 to 3)
   int getClusterMatchedUnchecked(int chamber) const { return mClusterMatched[chamber]; }
+  /// Gets the matched clusters
+  /// \param chamber Chamber ID (from 0 to 3)
   int getClusterMatched(int chamber) const;
+
   /// Sets the matched clusters without bound checking
+  /// \param chamber Chamber ID (from 0 to 3)
+  /// \param id Cluster ID
   void setClusterMatchedUnchecked(int chamber, int id) { mClusterMatched[chamber] = id; }
+
+  /// Sets the matched clusters
+  /// \param chamber Chamber ID (from 0 to 3)
+  /// \param id Cluster ID
   void setClusterMatched(int chamber, int id);
 
   /// Returns the chi2 of the track
@@ -92,17 +121,67 @@ class Track
   /// Returns the normalized chi2 of the track
   float getChi2OverNDF() const { return mChi2 / static_cast<float>(mNDF); }
 
+  /// Check if tracks are compatible within uncertainties
+  /// \param track Track for which compatibility is checked
+  /// \param chi2Cut Chi2 cut for the comparison
   bool isCompatible(const Track& track, float chi2Cut) const;
 
+  /// Sets the fired chamber
+  /// \param chamber Chamber ID (from 0 to 3)
+  /// \param cathode Cathode (0 or 1)
+  void setFiredChamber(int chamber, int cathode) { mEfficiencyWord |= 1 << (4 * cathode + chamber); }
+
+  /// Is fired chamber
+  /// \param chamber Chamber ID (from 0 to 3)
+  /// \param cathode Cathode (0 or 1)
+  /// \return true if the chamber was fired
+  bool idFiredChamber(int chamber, int cathode) const { return mEfficiencyWord & (1 << (4 * cathode + chamber)); }
+
+  /// Gets hit map
+  uint8_t getHitMap() const { return mEfficiencyWord & 0xFF; }
+
+  /// Sets the fired local board for efficiency calculation
+  /// \param locId local board ID in the range 1-234
+  void setFiredLocalBoard(int locId) { setEfficiencyWord(8, 0xFF, locId); }
+
+  /// Gets the fired local board for efficiency calculation
+  int getFiredLocalBoard() const { return (mEfficiencyWord >> 8) & 0xFF; }
+
+  /// Sets the fired detection element ID for efficiency calculation
+  /// \param deId detection element ID in the range 1-234
+  void setFiredDeId(int deId) { setEfficiencyWord(16, 0xFF, deId); }
+
+  /// Gets the fired detection element ID for efficiency calculation
+  int getFiredDeId() const { return (mEfficiencyWord >> 16) & 0xFF; }
+
+  /// Sets the flag for efficiency calculation
+  /// \param effFlag efficiency flag
+  void setEfficiencyFlag(int effFlag) { setEfficiencyWord(24, 0xF, effFlag); }
+
+  /// Gets the flag for efficiency calculation
+  /// \return
+  /// \li \c 0 track cannot be used for efficiency calculation
+  /// \li \c 1 track can be used to estimate chamber efficiency
+  /// \li \c 2 track can be used to estimate detection element efficiency
+  /// \li \c 3 track can be used to estimate local board efficiency
+  int getEfficiencyFlag() const { return (mEfficiencyWord >> 24) & 0xF; }
+
+  /// Overload ostream operator for MID track
   friend std::ostream& operator<<(std::ostream& stream, const Track& track);
 
  private:
+  /// Set portions of the efficiency word
+  /// \param pos Position in the word
+  /// \param mask Maximum size of the bits
+  /// \param value Value to be set
+  void setEfficiencyWord(int pos, int mask, int value);
   std::array<float, 3> mPosition = {};             ///< Position
   std::array<float, 3> mDirection = {};            ///< Direction
   std::array<float, 6> mCovarianceParameters = {}; ///< Covariance parameters
   std::array<int, 4> mClusterMatched = {};         ///< Matched cluster index
   float mChi2 = 0.;                                ///< Chi2 of track
   int mNDF = 0;                                    ///< Number of chi2 degrees of freedom
+  uint32_t mEfficiencyWord = 0;                    ///< Efficiency word
 
   ClassDefNV(Track, 1);
 };

--- a/DataFormats/Detectors/MUON/MID/src/Track.cxx
+++ b/DataFormats/Detectors/MUON/MID/src/Track.cxx
@@ -17,17 +17,15 @@
 #include "DataFormatsMID/Track.h"
 
 #include <iostream>
+#include <fmt/format.h>
 
 namespace o2
 {
 namespace mid
 {
 
-//______________________________________________________________________________
-void Track::setCovarianceParameters(float xErr2, float yErr2, float slopeXErr2, float slopeYErr2, float covXSlopeX,
-                                    float covYSlopeY)
+void Track::setCovarianceParameters(float xErr2, float yErr2, float slopeXErr2, float slopeYErr2, float covXSlopeX, float covYSlopeY)
 {
-  /// Sets the covariance parameters
   mCovarianceParameters[static_cast<int>(CovarianceParamIndex::VarX)] = xErr2;
   mCovarianceParameters[static_cast<int>(CovarianceParamIndex::VarY)] = yErr2;
   mCovarianceParameters[static_cast<int>(CovarianceParamIndex::VarSlopeX)] = slopeXErr2;
@@ -36,24 +34,18 @@ void Track::setCovarianceParameters(float xErr2, float yErr2, float slopeXErr2, 
   mCovarianceParameters[static_cast<int>(CovarianceParamIndex::CovYSlopeY)] = covYSlopeY;
 }
 
-//______________________________________________________________________________
 void Track::setDirection(float xDir, float yDir, float zDir)
 {
-  /// Sets the track direction parameters
   mDirection = {xDir, yDir, zDir};
 }
 
-//______________________________________________________________________________
 void Track::setPosition(float xPos, float yPos, float zPos)
 {
-  /// Sets the track starting position
   mPosition = {xPos, yPos, zPos};
 }
 
-//______________________________________________________________________________
 int Track::getClusterMatched(int chamber) const
 {
-  /// Gets the matched clusters
   if (chamber < 0 || chamber > 3) {
     std::cerr << "Error: chamber must be in range [0, 3]\n";
     return 0;
@@ -61,10 +53,8 @@ int Track::getClusterMatched(int chamber) const
   return mClusterMatched[chamber];
 }
 
-//______________________________________________________________________________
 void Track::setClusterMatched(int chamber, int id)
 {
-  /// Sets the matched clusters
   if (chamber < 0 || chamber > 3) {
     std::cerr << "Error: chamber must be in range [0, 3]\n";
     return;
@@ -72,12 +62,8 @@ void Track::setClusterMatched(int chamber, int id)
   mClusterMatched[chamber] = id;
 }
 
-//______________________________________________________________________________
 bool Track::propagateToZ(float zPosition)
 {
-  /// Propagate track to the specified zPosition
-  /// A linear extraplation is performed
-
   // Nothing to be done if we're already at zPosition
   // Notice that the z position is typically the z of the cluster,
   // which is provided in float precision as well.
@@ -112,10 +98,8 @@ bool Track::propagateToZ(float zPosition)
   return true;
 }
 
-//______________________________________________________________________________
 bool Track::isCompatible(const Track& track, float chi2Cut) const
 {
-  /// Check if tracks are compatible within uncertainties
   if (track.mPosition[2] != mPosition[2]) {
     Track copyTrack(track);
     copyTrack.propagateToZ(mPosition[2]);
@@ -177,10 +161,14 @@ bool Track::isCompatible(const Track& track, float chi2Cut) const
   return true;
 }
 
-//______________________________________________________________________________
+void Track::setEfficiencyWord(int pos, int mask, int value)
+{
+  mEfficiencyWord &= ~(mask << pos);
+  mEfficiencyWord |= (value << pos);
+}
+
 std::ostream& operator<<(std::ostream& stream, const Track& track)
 {
-  /// Overload ostream operator
   stream << "Position: (" << track.mPosition[0] << ", " << track.mPosition[1] << ", " << track.mPosition[2] << ")";
   stream << " Direction: (" << track.mDirection[0] << ", " << track.mDirection[1] << ", " << track.mDirection[2] << ")";
   stream << " Covariance (X, Y, SlopeX, SlopeY, X-SlopeX, Y-SlopeY): (";
@@ -188,6 +176,8 @@ std::ostream& operator<<(std::ostream& stream, const Track& track)
     stream << track.mCovarianceParameters[ival];
     stream << ((ival == 5) ? ")" : ", ");
   }
+  stream << fmt::format(" chi2/ndf: {:g}/{:d}", track.getChi2(), track.getNDF());
+  stream << fmt::format(" hitMap: 0x{:x} locId: {:d} deId: {:d} effFlag {:d}", track.getHitMap(), track.getFiredLocalBoard(), track.getFiredDeId(), track.getEfficiencyFlag());
   return stream;
 }
 

--- a/Detectors/MUON/MID/Base/CMakeLists.txt
+++ b/Detectors/MUON/MID/Base/CMakeLists.txt
@@ -1,22 +1,24 @@
-# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
-# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# Copyright 2019-2020 CERN and copyright holders of ALICE O2. See
+# https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 # All rights not expressly granted are reserved.
 #
-# This software is distributed under the terms of the GNU General Public
-# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+# This software is distributed under the terms of the GNU General Public License
+# v3 (GPL Version 3), copied verbatim in the file "COPYING".
 #
 # In applying this license CERN does not waive the privileges and immunities
-# granted to it by virtue of its status as an Intergovernmental Organization
-# or submit itself to any jurisdiction.
+# granted to it by virtue of its status as an Intergovernmental Organization or
+# submit itself to any jurisdiction.
 
-o2_add_library(MIDBase
-               SOURCES src/ChamberEfficiency.cxx
-                       src/DetectorParameters.cxx
-                       src/GeometryParameters.cxx
-                       src/GeometryTransformer.cxx
-                       src/Mapping.cxx
-                       src/MpArea.cxx
-               PUBLIC_LINK_LIBRARIES O2::MathUtils O2::DataFormatsMID)
+o2_add_library(
+  MIDBase
+  SOURCES src/ChamberEfficiency.cxx
+          src/DetectorParameters.cxx
+          src/GeometryParameters.cxx
+          src/GeometryTransformer.cxx
+          src/HitFinder.cxx
+          src/Mapping.cxx
+          src/MpArea.cxx
+  PUBLIC_LINK_LIBRARIES O2::MathUtils O2::DataFormatsMID)
 
 if(BUILD_TESTING)
   add_subdirectory(test)

--- a/Detectors/MUON/MID/Base/include/MIDBase/HitFinder.h
+++ b/Detectors/MUON/MID/Base/include/MIDBase/HitFinder.h
@@ -9,7 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file   MIDTestingSimTools/HitFinder.h
+/// \file   MIDBase/HitFinder.h
 /// \brief  Hit finder for MID
 /// \author Diego Stocco <Diego.Stocco at cern.ch>
 /// \date   14 March 2018
@@ -30,20 +30,57 @@ namespace mid
 class HitFinder
 {
  public:
+  /// Constructor
+  /// \param geoTrans Geometry transformer
   HitFinder(const GeometryTransformer& geoTrans);
 
+  /// Default destructor
+  ~HitFinder() = default;
+
+  /// Returns the geometry transformer
+  const GeometryTransformer& getGeometryTransformer() const { return mGeometryTransformer; }
+
+  /// Gets the potentially fired detection elements
+  /// \param track MID track
+  /// \param chamber Chamber ID (0-3)
+  /// \return Vector with the list of the detection element IDs potentially fired
   std::vector<int> getFiredDE(const Track& track, int chamber) const;
+
+  /// Gets the list of track-deId intersection in local coordinates, expressed as clusters
+  /// \param track MID track
+  /// \param chamber Chamber ID (0-3)
+  /// \param withUncertainties Add also the extrapolated uncertainties to the local point
+  /// \return Vector of intersection cluster(s) with the detection element(s)
   std::vector<Cluster> getLocalPositions(const Track& track, int chamber, bool withUncertainties = false) const;
 
  private:
+  /// Get the intersection point in the default chamber plane
+  /// \param track MID track
+  /// \param chamber chamber plane (from 0 to 3)
+  /// \return Intersection of the track and the deID
   math_utils::Point3D<double> getIntersectInDefaultPlane(const Track& track, int chamber) const;
+
+  /// Get the intersection point in the specified detection elements
+  /// The point is expressed in local coordinates
+  /// \param track MID track
+  /// \param deId Detection element ID
+  /// \return Intersection of the track and the deID, expressed as a cluster with no uncertainties
   Cluster getIntersect(const Track& track, int deId) const;
+
+  /// Guesses the RPC form the y position
+  /// \param yPos y position
+  /// \param chamber chamber plane (from 0 to 3)
+  /// \return the possible detection element ID
   int guessRPC(double yPos, int chamber) const;
+
+  /// Adds uncertainties to cluster
+  /// \param cl Cluster to be modified
+  /// \param track MID track in local coordinates
   void addUncertainty(Cluster& cl, Track track) const;
 
   GeometryTransformer mGeometryTransformer; ///< Geometry transformer
   const double mTanTheta;                   ///< Tangent of the angle between y and z
-  const double mCosTheta;                   ///< Cosinus of the beam angle
+  const double mCosTheta;                   ///< Cosine of the beam angle
 };
 } // namespace mid
 } // namespace o2

--- a/Detectors/MUON/MID/Filtering/test/bench_Filter.cxx
+++ b/Detectors/MUON/MID/Filtering/test/bench_Filter.cxx
@@ -18,9 +18,9 @@
 #include <random>
 #include "DataFormatsMID/Cluster.h"
 #include "DataFormatsMID/Track.h"
+#include "MIDBase/HitFinder.h"
 #include "MIDBase/Mapping.h"
 #include "MIDBase/MpArea.h"
-#include "MIDTestingSimTools/HitFinder.h"
 #include "MIDTestingSimTools/TrackGenerator.h"
 #include "MIDTracking/Tracker.h"
 

--- a/Detectors/MUON/MID/Simulation/test/testSimulation.cxx
+++ b/Detectors/MUON/MID/Simulation/test/testSimulation.cxx
@@ -20,6 +20,7 @@
 #include "DataFormatsMID/Cluster.h"
 #include "DataFormatsMID/ColumnData.h"
 #include "DataFormatsMID/Track.h"
+#include "MIDBase/HitFinder.h"
 #include "MIDBase/Mapping.h"
 #include "MIDBase/GeometryTransformer.h"
 #include "MIDSimulation/ChamberResponseParams.h"
@@ -35,7 +36,6 @@
 #include "MIDClustering/PreClusterizer.h"
 #include "MIDTracking/Tracker.h"
 #include "MIDTestingSimTools/TrackGenerator.h"
-#include "MIDTestingSimTools/HitFinder.h"
 
 namespace o2
 {
@@ -89,7 +89,6 @@ struct SimClustering {
   SimClustering() : correlation(), preClusterizer(), clusterizer(), preClusterHelper(), preClusterLabeler(), clusterLabeler()
   {
     correlation.clear();
-    preClusterizer.init();
     clusterizer.init([&](size_t baseIndex, size_t relatedIndex) { correlation.push_back({baseIndex, relatedIndex}); });
   }
 };

--- a/Detectors/MUON/MID/TestingSimTools/CMakeLists.txt
+++ b/Detectors/MUON/MID/TestingSimTools/CMakeLists.txt
@@ -1,14 +1,15 @@
-# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
-# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# Copyright 2019-2020 CERN and copyright holders of ALICE O2. See
+# https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 # All rights not expressly granted are reserved.
 #
-# This software is distributed under the terms of the GNU General Public
-# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+# This software is distributed under the terms of the GNU General Public License
+# v3 (GPL Version 3), copied verbatim in the file "COPYING".
 #
 # In applying this license CERN does not waive the privileges and immunities
-# granted to it by virtue of its status as an Intergovernmental Organization
-# or submit itself to any jurisdiction.
+# granted to it by virtue of its status as an Intergovernmental Organization or
+# submit itself to any jurisdiction.
 
-o2_add_library(MIDTestingSimTools
-               SOURCES src/HitFinder.cxx src/TrackGenerator.cxx
-               PUBLIC_LINK_LIBRARIES O2::DataFormatsMID O2::MIDBase)
+o2_add_library(
+  MIDTestingSimTools
+  SOURCES src/TrackGenerator.cxx
+  PUBLIC_LINK_LIBRARIES O2::DataFormatsMID O2::MIDBase)

--- a/Detectors/MUON/MID/Tracking/CMakeLists.txt
+++ b/Detectors/MUON/MID/Tracking/CMakeLists.txt
@@ -1,18 +1,19 @@
-# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
-# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# Copyright 2019-2020 CERN and copyright holders of ALICE O2. See
+# https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 # All rights not expressly granted are reserved.
 #
-# This software is distributed under the terms of the GNU General Public
-# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+# This software is distributed under the terms of the GNU General Public License
+# v3 (GPL Version 3), copied verbatim in the file "COPYING".
 #
 # In applying this license CERN does not waive the privileges and immunities
-# granted to it by virtue of its status as an Intergovernmental Organization
-# or submit itself to any jurisdiction.
+# granted to it by virtue of its status as an Intergovernmental Organization or
+# submit itself to any jurisdiction.
 
-o2_add_library(MIDTracking
-               SOURCES src/Tracker.cxx
-               PUBLIC_LINK_LIBRARIES O2::DataFormatsMID O2::MIDBase
-                                     O2::MIDTestingSimTools Microsoft.GSL::GSL)
+o2_add_library(
+  MIDTracking
+  SOURCES src/HitMapBuilder.cxx src/Tracker.cxx
+  PUBLIC_LINK_LIBRARIES O2::DataFormatsMID O2::MIDBase O2::MIDTestingSimTools
+                        Microsoft.GSL::GSL)
 
 if(BUILD_TESTING)
   add_subdirectory(test)

--- a/Detectors/MUON/MID/Tracking/include/MIDTracking/HitMapBuilder.h
+++ b/Detectors/MUON/MID/Tracking/include/MIDTracking/HitMapBuilder.h
@@ -1,0 +1,85 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDTracking/HitMapBuilder.h
+/// \brief  Utility to build the MID track hit maps
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   10 December 2021
+
+#ifndef O2_MID_HITMAPBUILDER_H
+#define O2_MID_HITMAPBUILDER_H
+
+#include <vector>
+#include <unordered_set>
+#include <gsl/gsl>
+#include "DataFormatsMID/Cluster.h"
+#include "DataFormatsMID/ROFRecord.h"
+#include "DataFormatsMID/Track.h"
+#include "MIDBase/GeometryTransformer.h"
+#include "MIDBase/HitFinder.h"
+#include "MIDBase/Mapping.h"
+
+namespace o2
+{
+namespace mid
+{
+/// Hit map builder for MID
+class HitMapBuilder
+{
+ public:
+  /// Constructor
+  /// \param geoTrans Geometry transformer
+  HitMapBuilder(const GeometryTransformer& geoTrans);
+
+  /// Default destructor
+  ~HitMapBuilder() = default;
+
+  /// Builds the track infos
+  /// \param track Reconstructed track: it will be modified
+  /// \param clusters gsl::span of associated clusters (in local coordinates)
+  /// \return TrackInfo object with the track hit map and other information
+  void buildTrackInfo(Track& track, gsl::span<const Cluster> clusters) const;
+
+  /// Builds the track infos for the tracks in the vector
+  /// \param tracks Vector of reconstructed tracks: it will be modified
+  /// \param clusters gsl::span of associated clusters (in local coordinates)
+  /// \return TrackInfo object with the track hit map and other information
+  void process(std::vector<Track>& tracks, gsl::span<const Cluster> clusters) const;
+
+ private:
+  /// Checks if the track crossed the same element
+  /// \param fired Vector of fired elements
+  /// \param nonFired Vector of non-fired elements
+  /// \return true if the track crossed the same element
+  bool crossCommonElement(const std::vector<int>& fired, const std::vector<int>& nonFired) const;
+
+  /// Returns the efficiency flag
+  /// \param firedRPCLines Vector of fired RPC lines
+  /// \param nonFiredRPCLines Vector of non-fired RPC lines
+  /// \param firedLocIds Vector of fired Local board Ids
+  /// \param nonFiredLocIds Vector of non-fired Local board Ids
+  /// \return the efficiency flag
+  int getEffFlag(const std::vector<int>& firedRPCLines, const std::vector<int>& nonFiredRPCLines, const std::vector<int>& firedLocIds, const std::vector<int>& nonFiredLocIds) const;
+
+  /// Function to extract the local board ID of the cluster
+  /// \param xp cluster x coordinate
+  /// \param yp cluster y coordinate
+  /// \param deId cluster Detection Element ID
+  /// \return the Local board ID
+  int getLocId(double xp, double yp, uint8_t deId) const;
+
+  Mapping mMapping;     ///< Mapping
+  HitFinder mHitFinder; ///< Hit finder
+};
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_HITMAPBUILDER_H */

--- a/Detectors/MUON/MID/Tracking/src/HitMapBuilder.cxx
+++ b/Detectors/MUON/MID/Tracking/src/HitMapBuilder.cxx
@@ -1,0 +1,112 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Tracking/src/HitMapBuilder.cxx
+/// \brief  Utility to build the MID track hit maps
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   10 December 2021
+#include "MIDTracking/HitMapBuilder.h"
+namespace o2
+{
+namespace mid
+{
+
+HitMapBuilder::HitMapBuilder(const GeometryTransformer& geoTrans) : mMapping(), mHitFinder(geoTrans) {}
+
+bool HitMapBuilder::crossCommonElement(const std::vector<int>& fired, const std::vector<int>& nonFired) const
+{
+  // First check that all elements in fired are the same
+  auto refIt = fired.begin();
+  for (auto it = fired.begin() + 1, end = fired.end(); it != end; ++it) {
+    if (*it != *refIt) {
+      return false;
+    }
+  }
+
+  // If there is no element in nonFired, then return true
+  if (nonFired.empty()) {
+    return true;
+  }
+
+  // Check that at least one element in nonFired matches the reference elements
+  for (auto it = nonFired.begin(), end = nonFired.end(); it != end; ++it) {
+    if (*it == *refIt) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+int HitMapBuilder::getEffFlag(const std::vector<int>& firedRPCLines, const std::vector<int>& nonFiredRPCLines, const std::vector<int>& firedLocIds, const std::vector<int>& nonFiredLocIds) const
+{
+  if (crossCommonElement(firedRPCLines, nonFiredRPCLines)) {
+    if (crossCommonElement(firedLocIds, nonFiredLocIds)) {
+      return 3;
+    }
+    return 2;
+  }
+  return 1;
+}
+
+int HitMapBuilder::getLocId(double xp, double yp, uint8_t deId) const
+{
+  auto stripIndex = mMapping.stripByPosition(xp, yp, 0, deId);
+  return mMapping.getBoardId(stripIndex.line, stripIndex.column, deId);
+}
+
+void HitMapBuilder::buildTrackInfo(Track& track, gsl::span<const Cluster> clusters) const
+{
+  std::vector<int> firedLocIds, nonFiredLocIds;
+  std::vector<int> firedDeIds, firedRPCLines, nonFiredRPCLines;
+  bool outsideAcceptance = false;
+  for (int ich = 0; ich < 4; ++ich) {
+    auto icl = track.getClusterMatched(ich);
+    if (icl >= 0) {
+      auto& cl = clusters[icl];
+      firedDeIds.emplace_back(cl.deId);
+      firedRPCLines.emplace_back(detparams::getRPCLine(cl.deId));
+      firedLocIds.emplace_back(getLocId(cl.xCoor, cl.yCoor, cl.deId));
+      // auto localPt = mHitFinder.getGeometryTransformer().globalToLocal(cl.deId, cl.xCoor, cl.yCoor, cl.zCoor);
+      for (int icath = 0; icath < 2; ++icath) {
+        if (cl.isFired(icath)) {
+          track.setFiredChamber(ich, icath);
+        }
+      }
+    } else {
+      auto impactPts = mHitFinder.getLocalPositions(track, ich);
+      for (auto& impactPt : impactPts) {
+        nonFiredRPCLines.emplace_back(detparams::getRPCLine(impactPt.deId));
+        nonFiredLocIds.emplace_back(getLocId(impactPt.xCoor, impactPt.yCoor, impactPt.deId));
+        if (nonFiredLocIds.back() == 0) {
+          outsideAcceptance = true;
+        }
+      }
+    }
+  }
+  track.setFiredDeId(firedDeIds.front());
+  track.setFiredLocalBoard(firedLocIds.front());
+  int effFlag = 0;
+  if (!outsideAcceptance) {
+    effFlag = getEffFlag(firedRPCLines, nonFiredRPCLines, firedLocIds, nonFiredLocIds);
+  }
+  track.setEfficiencyFlag(effFlag);
+}
+
+void HitMapBuilder::process(std::vector<Track>& tracks, gsl::span<const Cluster> clusters) const
+{
+  for (auto& track : tracks) {
+    buildTrackInfo(track, clusters);
+  }
+}
+
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/Tracking/test/bench_Tracker.cxx
+++ b/Detectors/MUON/MID/Tracking/test/bench_Tracker.cxx
@@ -18,9 +18,9 @@
 #include <random>
 #include "DataFormatsMID/Cluster.h"
 #include "DataFormatsMID/Track.h"
+#include "MIDBase/HitFinder.h"
 #include "MIDBase/Mapping.h"
 #include "MIDBase/MpArea.h"
-#include "MIDTestingSimTools/HitFinder.h"
 #include "MIDTestingSimTools/TrackGenerator.h"
 #include "MIDTracking/Tracker.h"
 

--- a/Detectors/MUON/MID/Tracking/test/testTracker.cxx
+++ b/Detectors/MUON/MID/Tracking/test/testTracker.cxx
@@ -26,9 +26,9 @@
 #include <vector>
 #include "DataFormatsMID/Cluster.h"
 #include "DataFormatsMID/Track.h"
+#include "MIDBase/HitFinder.h"
 #include "MIDBase/Mapping.h"
 #include "MIDBase/MpArea.h"
-#include "MIDTestingSimTools/HitFinder.h"
 #include "MIDTestingSimTools/TrackGenerator.h"
 #include "MIDTracking/Tracker.h"
 


### PR DESCRIPTION
This PR consists of 2 commits:
- the first one moves a class that was used only for testing purposes until now in the Base folder. The class is indeed rather generic (it allows to estimate the impact point of a track in the detection elements) and will be used by the new class for hit map determination as well as by other testing classes in other MID libraries
- the second implements the class that builds the MID hit map

The commits are meant to be atomic. Please do not squash.