### PR TITLE
TPC gain map using tracks: small fixes

### DIFF
--- a/Detectors/TPC/calibration/include/TPCCalibration/CalibPadGainTracks.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/CalibPadGainTracks.h
@@ -17,12 +17,11 @@
 #ifndef AliceO2_TPC_CalibPadGainTracks_H
 #define AliceO2_TPC_CalibPadGainTracks_H
 
-//o2 includes
+// o2 includes
 #include "DataFormatsTPC/TrackTPC.h"
 #include "DataFormatsTPC/ClusterNative.h"
 #include "TPCBase/CalDet.h"
 #include "TPCBase/Mapper.h"
-#include "TPCCalibration/FastHisto.h"
 #include "TPCCalibration/CalibPadGainTracksBase.h"
 
 #include <vector>
@@ -108,6 +107,14 @@ class CalibPadGainTracks : public CalibPadGainTracksBase
   /// \param field magnetic field in kG, used for track propagation
   void setField(const float field) { mField = field; }
 
+  /// setting a gain map from a file
+  /// \param inpFile input file containing some caldet
+  /// \param mapName name of the caldet
+  void setRefGainMap(const char* inpFile, const char* mapName);
+
+  /// setting a gain map from a file
+  void setRefGainMap(const CalPad& gainmap) { mGainMapRef = std::make_unique<CalPad>(gainmap); }
+
   /// \return returns minimum momentum of accepted tracks
   float getMomMin() const { return mMomMin; }
 
@@ -143,6 +150,7 @@ class CalibPadGainTracks : public CalibPadGainTracksBase
   std::vector<float> mDEdxOROC{};                                                     ///<! memory for dE/dx in OROC
   std::vector<o2::tpc::ClusterNative> mCLNat;                                         ///<! memory for clusters
   std::vector<std::tuple<unsigned char, unsigned char, unsigned char, float>> mClTrk; ///<! memory for cluster informations
+  std::unique_ptr<CalPad> mGainMapRef;                                                ///<! static Gain map object used for correcting the cluster charge
 
   /// calculate truncated mean for track
   /// \param track input track which will be processed
@@ -155,9 +163,9 @@ class CalibPadGainTracks : public CalibPadGainTracksBase
   /// \param pad pad in row
   static int getIndex(o2::tpc::PadSubset padSub, int padSubsetNumber, const int row, const int pad) { return mapper.getPadNumber(padSub, padSubsetNumber, row, pad); }
 
-  float getTrackTopologyCorrection(o2::tpc::TrackTPC& track, int iCl);
+  float getTrackTopologyCorrection(const o2::tpc::TrackTPC& track, const unsigned char rowIndex) const;
 
-  ///get the truncated mean for input vector and the truncation range low*nCl<nCl<high*nCl
+  /// get the truncated mean for input vector and the truncation range low*nCl<nCl<high*nCl
   /// \param vCharge vector containing all qmax values of the track
   /// \param low lower cluster cut of  0.05*nCluster
   /// \param high higher cluster cut of  0.6*nCluster

--- a/Detectors/TPC/calibration/include/TPCCalibration/CalibPadGainTracksBase.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/CalibPadGainTracksBase.h
@@ -17,16 +17,12 @@
 #ifndef ALICEO2_TPC_CALIBPADGAINTRACKSBASE_H
 #define ALICEO2_TPC_CALIBPADGAINTRACKSBASE_H
 
-//o2 includes
-#include "DataFormatsTPC/TrackTPC.h"
-#include "DataFormatsTPC/ClusterNative.h"
+// o2 includes
 #include "TPCBase/CalDet.h"
 #include "TPCBase/Mapper.h"
 #include "TPCCalibration/FastHisto.h"
 
-#include <vector>
 #include <gsl/span>
-#include <tuple>
 
 class TCanvas;
 

--- a/Detectors/TPC/calibration/include/TPCCalibration/FastHisto.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/FastHisto.h
@@ -17,7 +17,7 @@
 #ifndef AliceO2_TPC_FastHisto_H
 #define AliceO2_TPC_FastHisto_H
 
-//o2 includes
+// o2 includes
 #include "MathUtils/fit.h"
 #include "Framework/Logger.h"
 #include <sstream>
@@ -68,12 +68,12 @@ class FastHisto
   /// this function fills the histogram with given value and weight
   /// \param val value which will be filled in the histogram
   /// \param weight the weight of the filled value
-  void fill(T val, T weight = 1);
+  void fill(const float val, T weight = 1);
 
   /// this function returns the index (bin) for the input value
   /// \return the index of the bin
   /// \param val the value for which the bin index will be returned
-  int findBin(const T val) const;
+  int findBin(const float val) const;
 
   /// this function resets the bin content in the histogram
   void reset()
@@ -172,7 +172,7 @@ class FastHisto
 
 //______________________________________________________________________________
 template <class T>
-inline void FastHisto<T>::fill(T val, T weight)
+inline void FastHisto<T>::fill(const float val, T weight)
 {
   const int indexBin = findBin(val);
   if (indexBin == -1) { // if no underflow/overflow bin is used, but the value should be in the underflow/overflow bin return
@@ -295,8 +295,8 @@ inline math_utils::StatisticsData FastHisto<T>::getStatisticsData(const float lo
     return data;
   }
 
-  //set last bin
-  //TODO move to upper loop
+  // set last bin
+  // TODO move to upper loop
   const float xcenter = mXmin + (bin + 0.5f + shiftBin) * binWidth;
   const T upFrac = mBinCont[bin] - (static_cast<float>(countContent) - upperBound);
   const float tmpMean = upFrac * xcenter;
@@ -317,7 +317,7 @@ inline math_utils::StatisticsData FastHisto<T>::getStatisticsData(const float lo
 }
 
 template <class T>
-inline int FastHisto<T>::findBin(const T val) const
+inline int FastHisto<T>::findBin(const float val) const
 {
   if (val < mXmin) {
     if (!mUseUnderflow) {

--- a/Detectors/TPC/calibration/src/CalibPadGainTracksBase.cxx
+++ b/Detectors/TPC/calibration/src/CalibPadGainTracksBase.cxx
@@ -14,14 +14,11 @@
 
 #include "TPCCalibration/CalibPadGainTracksBase.h"
 #include "TPCCalibration/IDCDrawHelper.h"
-#include "TPCBase/PadPos.h"
 #include "TPCBase/ROC.h"
 #include "TPCBase/Painter.h"
-#include "CommonUtils/TreeStreamRedirector.h"
 
-//root includes
+// root includes
 #include "TFile.h"
-#include "TTree.h"
 #include "TCanvas.h"
 
 using namespace o2::tpc;
@@ -150,7 +147,7 @@ bool CalibPadGainTracksBase::hasEnoughData(const int minEntries) const
 
 void CalibPadGainTracksBase::finalize(const float low, const float high)
 {
-  //fill the gain values in CalPad object
+  // fill the gain values in CalPad object
   unsigned long int iROC = 0; // roc: 0...71
   for (auto& calArray : mGainMap->getData()) {
     unsigned int pad = 0; // pad in roc

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCCalibPadGainTracksSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCCalibPadGainTracksSpec.h
@@ -50,6 +50,12 @@ class TPCCalibPadGainTracksDevice : public o2::framework::Task
     const auto overflowBin = ic.options().get<bool>("overflowBin");
     mPadGainTracks.init(nBins, reldEdxMin, reldEdxMax, underflowBin, overflowBin);
 
+    const std::string refGainMapFile = ic.options().get<std::string>("refGainMapFile");
+    if (!refGainMapFile.empty()) {
+      LOGP(info, "Loading GainMap from file {}", refGainMapFile);
+      mPadGainTracks.setRefGainMap(refGainMapFile.data(), "GainMap");
+    }
+
     float field = ic.options().get<float>("field");
     if (field <= -10.f) {
       const auto inputGRP = o2::base::NameConf::getGRPFileName();
@@ -136,6 +142,7 @@ DataProcessorSpec getTPCCalibPadGainTracksSpec(const uint32_t publishAfterTFs, c
       {"momMax", VariantType::Float, 5.f, {"maximum momentum of the tracks which are used for the pad-by-pad gain map"}},
       {"etaMax", VariantType::Float, 1.f, {"maximum eta of the tracks which are used for the pad-by-pad gain map"}},
       {"minClusters", VariantType::Int, 50, {"minimum number of clusters of tracks which are used for the pad-by-pad gain map"}},
+      {"refGainMapFile", VariantType::String, "", {"file to reference gain map, which will be used for correcting the cluster charge"}},
     }}; // end DataProcessorSpec
 }
 

--- a/Detectors/TPC/workflow/src/tpc-calib-gainmap-tracks.cxx
+++ b/Detectors/TPC/workflow/src/tpc-calib-gainmap-tracks.cxx
@@ -36,7 +36,8 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
   std::vector<ConfigParamSpec> options{
     {"debug", VariantType::Bool, false, {"create debug tree"}},
     {"configFile", VariantType::String, "", {"configuration file for configurable parameters"}},
-    {"publish-after-tfs", VariantType::Int, 0, {"number of time frames after which to force publishing the objects"}}};
+    {"publish-after-tfs", VariantType::Int, 0, {"number of time frames after which to force publishing the objects"}},
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
 
   std::swap(workflowOptions, options);
 }
@@ -49,6 +50,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
 
   // set up configuration
   o2::conf::ConfigurableParam::updateFromFile(config.options().get<std::string>("configFile"));
+  o2::conf::ConfigurableParam::updateFromString(config.options().get<std::string>("configKeyValues"));
   o2::conf::ConfigurableParam::writeINI("o2tpcpadgaintrackscalibrator_configuration.ini");
 
   const auto debug = config.options().get<bool>("debug");


### PR DESCRIPTION
- removing not needed headers
- fixing bug in FastHisto class when filling
- adding possibility to use a reference gainmap when extracting the residual gain map
- small code optimisations

Tested procedure using real data (6000 TFs):
[Extracted map without reference gain map](https://github.com/AliceO2Group/AliceO2/files/8049269/GainMapA_Extracted.pdf)
[Extracted map with reference gain map (residual gain map)](https://github.com/AliceO2Group/AliceO2/files/8049277/GainMapA_residual.pdf)
[Reference Kr gain map](https://github.com/AliceO2Group/AliceO2/files/8049265/GainMapA_Krypton.pdf)
