### PR TITLE
Protection against unset chipID in case of Alpide data corruption

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RUDecodeData.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RUDecodeData.h
@@ -90,7 +90,7 @@ int RUDecodeData::decodeROF(const Mapping& mp)
 #ifdef ALPIDE_DECODING_STAT
       fillChipStatistics(icab, chipData);
 #endif
-      if (ret >= 0 /* && !chipData->isErrorSet()*/) { // make sure there was no error | upd: why? if there was a non fatal error, we use chip data
+      if (ret >= 0 && chipData->getChipID() < Mapping::getNChips()) { // make sure there was no error | upd: why? if there was a non fatal error, we use chip data
         if (chipData->isErrorSet() && nChipsFired && chipData->getChipID() == chipsData[nChipsFired - 1].getChipID()) {
           // we are still in the chip data whose decoding was aborted due to the error, reuse this chip data
           LOGP(debug, "re-entry into the data of the chip {} after previously detector error", chipData->getChipID());


### PR DESCRIPTION
Trivial fix, tested locally. Merging since current decoding may crash in case of Busy ON/OFF set.