### PR TITLE
Split of the ITS threshold wf: Calibrator + aggregator - ADDED support for no EoS case

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/workflow/CMakeLists.txt
@@ -24,18 +24,20 @@ o2_add_library(ITSWorkflow
                        src/VertexReaderSpec.cxx
                        src/ThresholdCalibrationWorkflow.cxx
                        src/ThresholdCalibratorSpec.cxx
+                       src/ThresholdAggregatorWorkflow.cxx
+                       src/ThresholdAggregatorSpec.cxx
          PUBLIC_LINK_LIBRARIES O2::Framework
-                                     O2::SimConfig
-                                     O2::DataFormatsITS
-                                     O2::DataFormatsDCS
-                                     O2::SimulationDataFormat
-                                     O2::ITStracking
-                                     O2::ITSReconstruction
-                                     O2::ITSMFTReconstruction
-                                     O2::ITSMFTWorkflow
-                                     O2::DetectorsCalibration
-                                     O2::CCDB
-                                     O2::GPUTracking)
+                               O2::SimConfig
+                               O2::DataFormatsITS
+                               O2::DataFormatsDCS
+                               O2::SimulationDataFormat
+                               O2::ITStracking
+                               O2::ITSReconstruction
+                               O2::ITSMFTReconstruction
+                               O2::ITSMFTWorkflow
+                               O2::DetectorsCalibration
+                               O2::CCDB
+                               O2::GPUTracking)
 
 o2_add_executable(reco-workflow
                   SOURCES src/its-reco-workflow.cxx
@@ -57,8 +59,12 @@ o2_add_executable(threshold-calib-workflow
                   COMPONENT_NAME its
                   PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
 
+o2_add_executable(threshold-aggregator-workflow
+                  SOURCES src/its-threshold-aggregator-workflow.cxx
+                  COMPONENT_NAME its
+                  PUBLIC_LINK_LIBRARIES O2::ITSWorkflow)
+
 if (OpenMP_CXX_FOUND)
     target_compile_definitions(${targetName} PRIVATE WITH_OPENMP)
     target_link_libraries(${targetName} PRIVATE OpenMP::OpenMP_CXX)
 endif()
-

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdAggregatorSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdAggregatorSpec.h
@@ -1,0 +1,95 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   ThresholdAggregatorSpec.h
+
+#ifndef O2_ITS_THRESHOLD_AGGREGATOR_
+#define O2_ITS_THRESHOLD_AGGREGATOR_
+
+#include <string>
+#include <vector>
+#include <iostream>
+#include <fstream>
+
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/WorkflowSpec.h"
+#include "Framework/Task.h"
+#include <FairMQDevice.h>
+
+#include <ITSMFTReconstruction/RawPixelDecoder.h> //o2::itsmft::RawPixelDecoder
+
+#include "Framework/RawDeviceService.h"
+#include "Headers/DataHeader.h"
+#include "DetectorsCalibration/Utils.h"
+#include "CCDB/CcdbObjectInfo.h"
+#include "CCDB/CcdbApi.h"
+#include "DataFormatsDCS/DCSConfigObject.h"
+
+using namespace o2::framework;
+using namespace o2::itsmft;
+
+namespace o2
+{
+namespace its
+{
+
+class ITSThresholdAggregator : public Task
+{
+ public:
+  ITSThresholdAggregator();
+  ~ITSThresholdAggregator() override = default;
+
+  void init(InitContext& ic) final;
+  void run(ProcessingContext& pc) final;
+  void endOfStream(EndOfStreamContext& ec) final;
+
+  void finalize(EndOfStreamContext* ec);
+  void stop() final;
+
+  //////////////////////////////////////////////////////////////////
+ private:
+  void finalizeOutput();
+  void updateLHCPeriod(ProcessingContext&);
+  void updateRunID(ProcessingContext&);
+
+  std::unique_ptr<o2::ccdb::CcdbObjectInfo> mWrapper = nullptr;
+  std::string mOutputStr;
+  std::string mType;
+
+  std::string mSelfName;
+
+  // Helper functions for writing to the database
+  bool mVerboseOutput = false;
+
+  // Keep track of whether the endOfStream() or stop() has been called
+  bool mStopped = false;
+
+  o2::dcs::DCSconfigObject_t tuningMerge;
+  short int mRunType = -1;
+  // Either "T" for threshold, "V" for VCASN, or "I" for ITHR
+  char mScanType = '\0';
+  // Either "derivative"=0, "fit"=1, or "hitcounting=2
+  char mFitType;
+
+  std::string mLHCPeriod;
+  //Ccdb url for ccdb upload withing the wf
+  std::string mCcdbUrl = "";
+  //Run number
+  int mRunNumber = -1;
+};
+
+// Create a processor spec
+o2::framework::DataProcessorSpec getITSThresholdAggregatorSpec();
+
+} // namespace its
+} // namespace o2
+
+#endif

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdAggregatorWorkflow.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdAggregatorWorkflow.h
@@ -1,0 +1,33 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   ThresholdAggregatorWorkflow.h
+
+#ifndef O2_ITS_THRESHOLD_AGGREGATOR_WORKFLOW_H
+#define O2_ITS_THRESHOLD_AGGREGATOR_WORKFLOW_H
+
+#include "Framework/WorkflowSpec.h"
+
+namespace o2
+{
+namespace its
+{
+
+namespace threshold_aggregator_workflow
+{
+
+framework::WorkflowSpec getWorkflow();
+
+}
+
+} // namespace its
+} // namespace o2
+#endif

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdCalibratorSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdCalibratorSpec.h
@@ -93,6 +93,7 @@ class ITSThresholdCalibrator : public Task
   void endOfStream(EndOfStreamContext& ec) final;
 
   void finalize(EndOfStreamContext* ec);
+  void stop() final;
 
   //////////////////////////////////////////////////////////////////
  private:
@@ -197,7 +198,6 @@ class ITSThresholdCalibrator : public Task
   // Flag to check if endOfStream is available
   bool mCheckEos = false;
   int mCounter = 0;
-  bool isFinalized = false;
 };
 
 // Create a processor spec

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdCalibratorSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdCalibratorSpec.h
@@ -23,6 +23,9 @@
 #include <iostream>
 #include <fstream>
 
+// Boost library for easy access of host name
+#include <boost/asio/ip/host_name.hpp>
+
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
 #include "Framework/ControlService.h"
@@ -90,7 +93,6 @@ class ITSThresholdCalibrator : public Task
   void endOfStream(EndOfStreamContext& ec) final;
 
   void finalize(EndOfStreamContext* ec);
-  void stop() final;
 
   //////////////////////////////////////////////////////////////////
  private:
@@ -155,7 +157,7 @@ class ITSThresholdCalibrator : public Task
   // Helper functions for writing to the database
   void addDatabaseEntry(const short int&, const char*, const short int&,
                         const float&, const short int&, const float&, bool, o2::dcs::DCSconfigObject_t&);
-  void sendToCCDB(const char*, o2::dcs::DCSconfigObject_t&, EndOfStreamContext*);
+  void sendToAggregator(o2::dcs::DCSconfigObject_t&, EndOfStreamContext*);
 
   std::string mSelfName;
   std::string mDictName;
@@ -183,8 +185,8 @@ class ITSThresholdCalibrator : public Task
   // Get threshold method (fit == 1, derivative == 0, or hitcounting == 2)
   char mFitType = -1;
 
-  // Keep track of whether the endOfStream() or stop() has been called
-  bool mStopped = false;
+  //Machine hostname
+  std::string mHostname;
 };
 
 // Create a processor spec

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdCalibratorSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdCalibratorSpec.h
@@ -156,8 +156,8 @@ class ITSThresholdCalibrator : public Task
 
   // Helper functions for writing to the database
   void addDatabaseEntry(const short int&, const char*, const short int&,
-                        const float&, const short int&, const float&, bool, o2::dcs::DCSconfigObject_t&);
-  void sendToAggregator(o2::dcs::DCSconfigObject_t&, EndOfStreamContext*);
+                        const float&, const short int&, const float&, bool);
+  void sendToAggregator(EndOfStreamContext*);
 
   std::string mSelfName;
   std::string mDictName;
@@ -178,6 +178,9 @@ class ITSThresholdCalibrator : public Task
   unsigned int mRowCounter = 0;
 
   short int mRunType = -1;
+  short int mRunTypeUp;
+  short int mRunTypeChip[24120] = {0};
+  bool mIsChipDone[24120] = {false};
   // Either "T" for threshold, "V" for VCASN, or "I" for ITHR
   char mScanType = '\0';
   short int mMin = -1, mMax = -1;
@@ -185,8 +188,16 @@ class ITSThresholdCalibrator : public Task
   // Get threshold method (fit == 1, derivative == 0, or hitcounting == 2)
   char mFitType = -1;
 
-  //Machine hostname
+  // Machine hostname
   std::string mHostname;
+
+  // DCS config object
+  o2::dcs::DCSconfigObject_t mTuning;
+
+  // Flag to check if endOfStream is available
+  bool mCheckEos = false;
+  int mCounter = 0;
+  bool isFinalized = false;
 };
 
 // Create a processor spec

--- a/Detectors/ITSMFT/ITS/workflow/src/ThresholdAggregatorSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ThresholdAggregatorSpec.cxx
@@ -46,23 +46,23 @@ void ITSThresholdAggregator::init(InitContext& ic)
 void ITSThresholdAggregator::run(ProcessingContext& pc)
 {
 
-  //take run type and scan type at the beginning
+  // take run type and scan type at the beginning
   if (this->mRunType == -1) {
-    this->mRunType = pc.inputs().get<short int>("runtype");
-    this->mScanType = pc.inputs().get<char>("scantype");
-    this->mFitType = pc.inputs().get<char>("fittype");
-    this->updateRunID(pc); // run number
+    mRunType = pc.inputs().get<short int>("runtype");
+    mScanType = pc.inputs().get<char>("scantype");
+    mFitType = pc.inputs().get<char>("fittype");
+    updateRunID(pc); // run number
   }
 
-  if (this->mLHCPeriod.empty()) {
-    this->updateLHCPeriod(pc);
+  if (mLHCPeriod.empty()) {
+    updateLHCPeriod(pc);
   }
 
   // Read strings with tuning info
-  const auto tunString = pc.inputs().get<o2::dcs::DCSconfigObject_t>("tunestring");
-  std::string tmpString(tunString.begin(), tunString.end());
-  //Merge all strings coming from several sources (EPN)
-  std::copy(tmpString.begin(), tmpString.end(), std::back_inserter(tuningMerge));
+  const auto tunString = pc.inputs().get<gsl::span<char>>("tunestring");
+  // std::string tmpString(tunString.begin(), tunString.end());
+  // Merge all strings coming from several sources (EPN)
+  std::copy(tunString.begin(), tunString.end(), std::back_inserter(tuningMerge));
 
   return;
 }
@@ -73,10 +73,8 @@ void ITSThresholdAggregator::finalize(EndOfStreamContext* ec)
   LOGF(info, "endOfStream report:", mSelfName);
 
   // Below is CCDB stuff
-  long tstart, tend;
-  tstart = o2::ccdb::getCurrentTimestamp();
-  constexpr long SECONDSPERYEAR = 365 * 24 * 60 * 60;
-  tend = o2::ccdb::getFutureTimestamp(SECONDSPERYEAR);
+  long tstart = o2::ccdb::getCurrentTimestamp();
+  long tend = tstart + 365L * 24 * 3600 * 1000;
 
   auto class_name = o2::utils::MemFileHelper::getClassName(tuningMerge);
 

--- a/Detectors/ITSMFT/ITS/workflow/src/ThresholdAggregatorSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ThresholdAggregatorSpec.cxx
@@ -1,0 +1,220 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   ThresholdAggregatorSpec.cxx
+
+#include "ITSWorkflow/ThresholdAggregatorSpec.h"
+
+#ifdef WITH_OPENMP
+#include <omp.h>
+#endif
+
+namespace o2
+{
+namespace its
+{
+
+//////////////////////////////////////////////////////////////////////////////
+// Default constructor
+ITSThresholdAggregator::ITSThresholdAggregator()
+{
+  mSelfName = o2::utils::Str::concat_string(ChipMappingITS::getName(), "ITSThresholdAggregator");
+}
+
+//////////////////////////////////////////////////////////////////////////////
+void ITSThresholdAggregator::init(InitContext& ic)
+{
+  LOGF(info, "ITSThresholdAggregator init...", mSelfName);
+
+  this->mVerboseOutput = ic.options().get<bool>("verbose");
+  this->mCcdbUrl = ic.options().get<std::string>("ccdb-url");
+
+  return;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Main running function
+// Get DCSconfigObject_t from EPNs and aggregate them in 1 object
+void ITSThresholdAggregator::run(ProcessingContext& pc)
+{
+
+  //take run type and scan type at the beginning
+  if (this->mRunType == -1) {
+    this->mRunType = pc.inputs().get<short int>("runtype");
+    this->mScanType = pc.inputs().get<char>("scantype");
+    this->mFitType = pc.inputs().get<char>("fittype");
+    this->updateRunID(pc); // run number
+  }
+
+  if (this->mLHCPeriod.empty()) {
+    this->updateLHCPeriod(pc);
+  }
+
+  // Read strings with tuning info
+  const auto tunString = pc.inputs().get<o2::dcs::DCSconfigObject_t>("tunestring");
+  std::string tmpString(tunString.begin(), tunString.end());
+  //Merge all strings coming from several sources (EPN)
+  std::copy(tmpString.begin(), tmpString.end(), std::back_inserter(tuningMerge));
+
+  return;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+void ITSThresholdAggregator::finalize(EndOfStreamContext* ec)
+{
+  LOGF(info, "endOfStream report:", mSelfName);
+
+  // Below is CCDB stuff
+  long tstart, tend;
+  tstart = o2::ccdb::getCurrentTimestamp();
+  constexpr long SECONDSPERYEAR = 365 * 24 * 60 * 60;
+  tend = o2::ccdb::getFutureTimestamp(SECONDSPERYEAR);
+
+  auto class_name = o2::utils::MemFileHelper::getClassName(tuningMerge);
+
+  // Create metadata for database object
+  std::string ft = this->mFitType == 0 ? "derivative" : this->mFitType == 1 ? "fit"
+                                                                            : "hitcounting";
+  std::map<std::string, std::string> md = {
+    {"fittype", ft}, {"runtype", std::to_string(this->mRunType)}};
+  if (!(this->mLHCPeriod.empty())) {
+    md.insert({"LHC_period", this->mLHCPeriod});
+  }
+  if (!mCcdbUrl.empty()) { // add only if we write here otherwise ccdb-populator-wf add it already
+    md.insert({"runNumber", std::to_string(this->mRunNumber)});
+  }
+
+  std::string path("ITS/Calib/");
+  std::string name_str = this->mScanType == 'V' ? "VCASN" : this->mScanType == 'I' ? "ITHR"
+                                                                                   : "THR";
+  o2::ccdb::CcdbObjectInfo info((path + name_str), "threshold_map", "calib_scan.root", md, tstart, tend);
+  auto image = o2::ccdb::CcdbApi::createObjectImage(&tuningMerge, &info);
+  std::string file_name = "calib_scan_" + name_str + ".root";
+  info.setFileName(file_name);
+
+  if (ec) { // send to ccdb-populator wf only if there is an EndOfStreamContext
+    LOG(info) << "Class Name: " << class_name << " | File Name: " << file_name
+              << "\nSending to ccdb-populator the object " << info.getPath() << "/" << info.getFileName()
+              << " of size " << image->size() << " bytes, valid for "
+              << info.getStartValidityTimestamp() << " : "
+              << info.getEndValidityTimestamp();
+
+    if (this->mScanType == 'V') {
+      ec->outputs().snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "VCASN", 0}, *image);
+      ec->outputs().snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "VCASN", 0}, info);
+    } else if (this->mScanType == 'I') {
+      ec->outputs().snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "ITHR", 0}, *image);
+      ec->outputs().snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "ITHR", 0}, info);
+    } else if (this->mScanType == 'T') {
+      ec->outputs().snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "THR", 0}, *image);
+      ec->outputs().snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "THR", 0}, info);
+    }
+  }
+
+  if (!mCcdbUrl.empty()) { // if url is specified, send object to ccdb from THIS wf
+
+    LOG(info) << "Sending object " << info.getFileName() << " to " << mCcdbUrl << "/browse/" << info.getPath() << " from the ITS calib workflow";
+    o2::ccdb::CcdbApi mApi;
+    mApi.init(mCcdbUrl);
+    mApi.storeAsBinaryFile(&image->at(0), image->size(), info.getFileName(), info.getObjectType(), info.getPath(),
+                           info.getMetaData(), info.getStartValidityTimestamp(), info.getEndValidityTimestamp());
+  }
+
+  return;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// fairMQ functionality; called automatically when the DDS stops processing
+void ITSThresholdAggregator::stop()
+{
+  if (!mStopped) {
+    this->finalize(nullptr);
+    this->mStopped = true;
+  }
+  return;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// O2 functionality allowing to do post-processing when the upstream device
+// tells that there will be no more input data
+void ITSThresholdAggregator::endOfStream(EndOfStreamContext& ec)
+{
+  if (!mStopped) {
+    this->finalize(&ec);
+    this->mStopped = true;
+  }
+  return;
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// Search current month  or LHCperiod
+void ITSThresholdAggregator::updateLHCPeriod(ProcessingContext& pc)
+{
+  auto conf = pc.services().get<RawDeviceService>().device()->fConfig;
+  const std::string LHCPeriodStr = conf->GetProperty<std::string>("LHCPeriod", "");
+  if (!(LHCPeriodStr.empty())) {
+    this->mLHCPeriod = LHCPeriodStr;
+  } else {
+    const char* months[12] = {"JAN", "FEB", "MAR", "APR", "MAY", "JUN",
+                              "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"};
+    std::time_t now = std::time(nullptr);
+    std::tm* ltm = std::gmtime(&now);
+    this->mLHCPeriod = (std::string)months[ltm->tm_mon];
+    LOG(warning) << "LHCPeriod is not available, using current month " << this->mLHCPeriod;
+  }
+  this->mLHCPeriod += "_ITS";
+
+  return;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Retrieve Run Number
+void ITSThresholdAggregator::updateRunID(ProcessingContext& pc)
+{
+  const auto dh = DataRefUtils::getHeader<o2::header::DataHeader*>(
+    pc.inputs().getFirstValid(true));
+  if (dh->runNumber != 0) {
+    this->mRunNumber = dh->runNumber;
+  }
+
+  return;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+DataProcessorSpec getITSThresholdAggregatorSpec()
+{
+  std::vector<InputSpec> inputs;
+  inputs.emplace_back("tunestring", "ITS", "TSTR", 0);
+  inputs.emplace_back("runtype", "ITS", "RUNT", 0);
+  inputs.emplace_back("scantype", "ITS", "SCANT", 0);
+  inputs.emplace_back("fittype", "ITS", "FITT", 0);
+
+  std::vector<OutputSpec> outputs;
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "VCASN"});
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "VCASN"});
+
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "ITHR"});
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "ITHR"});
+
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "THR"});
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "THR"});
+
+  return DataProcessorSpec{
+    "its-aggregator",
+    inputs,
+    outputs,
+    AlgorithmSpec{adaptFromTask<o2::its::ITSThresholdAggregator>()},
+    Options{
+      {"verbose", VariantType::Bool, false, {"Use verbose output mode"}},
+      {"ccdb-url", VariantType::String, "", {"CCDB url, default is empty (i.e. no upload to CCDB)"}}}};
+}
+} // namespace its
+} // namespace o2

--- a/Detectors/ITSMFT/ITS/workflow/src/ThresholdAggregatorSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ThresholdAggregatorSpec.cxx
@@ -60,7 +60,6 @@ void ITSThresholdAggregator::run(ProcessingContext& pc)
 
   // Read strings with tuning info
   const auto tunString = pc.inputs().get<gsl::span<char>>("tunestring");
-  // std::string tmpString(tunString.begin(), tunString.end());
   // Merge all strings coming from several sources (EPN)
   std::copy(tunString.begin(), tunString.end(), std::back_inserter(tuningMerge));
 

--- a/Detectors/ITSMFT/ITS/workflow/src/ThresholdAggregatorWorkflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ThresholdAggregatorWorkflow.cxx
@@ -1,0 +1,33 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   ThresholdAggregatorWorkflow.cxx
+
+#include "ITSWorkflow/ThresholdAggregatorWorkflow.h"
+#include "ITSWorkflow/ThresholdAggregatorSpec.h"
+
+namespace o2
+{
+namespace its
+{
+namespace threshold_aggregator_workflow
+{
+framework::WorkflowSpec getWorkflow()
+{
+  framework::WorkflowSpec specs;
+
+  specs.emplace_back(o2::its::getITSThresholdAggregatorSpec());
+
+  return specs;
+}
+} // namespace threshold_aggregator_workflow
+} // namespace its
+} // namespace o2

--- a/Detectors/ITSMFT/ITS/workflow/src/its-threshold-aggregator-workflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/its-threshold-aggregator-workflow.cxx
@@ -1,0 +1,25 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "ITSWorkflow/ThresholdAggregatorWorkflow.h"
+#include "ITSWorkflow/ThresholdAggregatorSpec.h"
+
+using namespace o2::framework;
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/Logger.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  LOG(info) << "Initializing O2 ITS Threshold Aggregator:-))))))";
+
+  return std::move(o2::its::threshold_aggregator_workflow::getWorkflow());
+}


### PR DESCRIPTION
Changes included:
- o2-its-threshold-calib-workflow (already existing): foreseen to run on every EPN, ship DCSconfigObjects_t to aggregator in the endOfStream.
- o2-its-threshold-aggregator-workflow (new): foreseen to run on 1 EPN aggregator node, collects and merge all the DCSConfigObjects_t coming from every EPN. Prepare CCDB wrapper and payload and can ship this to ccdb-populator-wf (if endOfStream exists) or directly to CCDB with CCDBApi (i.e. no ccdb-populator-wf)
- fixes for ITHR tuning analysis
