### PR TITLE
GPU: Feature to update calibration data on GPU during run

### DIFF
--- a/GPU/GPUTracking/Base/GPUReconstruction.cxx
+++ b/GPU/GPUTracking/Base/GPUReconstruction.cxx
@@ -699,17 +699,19 @@ void GPUReconstruction::ResetRegisteredMemoryPointers(short ires)
 {
   GPUMemoryResource* res = &mMemoryResources[ires];
   if (!(res->mType & GPUMemoryResource::MEMORY_EXTERNAL) && (res->mType & GPUMemoryResource::MEMORY_HOST)) {
-    if (res->mReuse >= 0) {
-      res->SetPointers(mMemoryResources[res->mReuse].mPtr);
-    } else {
-      res->SetPointers(res->mPtr);
+    void* basePtr = res->mReuse >= 0 ? mMemoryResources[res->mReuse].mPtr : res->mPtr;
+    size_t size = (char*)res->SetPointers(basePtr) - (char*)basePtr;
+    if (basePtr && size > std::max(res->mSize, res->mOverrideSize)) {
+      std::cout << "Updated pointers exceed available memory size: " << size << " > " << std::max(res->mSize, res->mOverrideSize) << " - host - " << res->mName << "\n";
+      throw std::bad_alloc();
     }
   }
   if (IsGPU() && (res->mType & GPUMemoryResource::MEMORY_GPU)) {
-    if (res->mReuse >= 0) {
-      res->SetDevicePointers(mMemoryResources[res->mReuse].mPtrDevice);
-    } else {
-      res->SetDevicePointers(res->mPtrDevice);
+    void* basePtr = res->mReuse >= 0 ? mMemoryResources[res->mReuse].mPtrDevice : res->mPtrDevice;
+    size_t size = (char*)res->SetDevicePointers(basePtr) - (char*)basePtr;
+    if (basePtr && size > std::max(res->mSize, res->mOverrideSize)) {
+      std::cout << "Updated pointers exceed available memory size: " << size << " > " << std::max(res->mSize, res->mOverrideSize) << " - GPU - " << res->mName << "\n";
+      throw std::bad_alloc();
     }
   }
 }

--- a/GPU/GPUTracking/Definitions/GPUSettingsList.h
+++ b/GPU/GPUTracking/Definitions/GPUSettingsList.h
@@ -173,6 +173,7 @@ AddOption(ignoreNonFatalGPUErrors, bool, false, "", 0, "Continue running after h
 AddOption(tpcIncreasedMinClustersPerRow, unsigned int, 0, "", 0, "Impose a minimum buffer size for the clustersPerRow during TPC clusterization")
 AddOption(noGPUMemoryRegistration, bool, false, "", 0, "Do not register input / output memory for GPU dma transfer")
 AddOption(automaticQPtThresholds, bool, true, "", 0, "Update the QPt thresholde at initialization accoding to the B field (i.e. lower to 40% for B=0.2T)")
+AddOption(calibObjectsExtraMemorySize, unsigned long, 10ul * 1024 * 1024, "", 0, "Extra spare memory added for calibration object buffer, to allow fow updates with larger objects")
 AddVariable(eventDisplay, GPUCA_NAMESPACE::gpu::GPUDisplayFrontend*, nullptr)
 AddSubConfig(GPUSettingsProcessingRTC, rtc)
 AddHelp("help", 'h')

--- a/GPU/GPUTracking/Global/GPUChainTracking.h
+++ b/GPU/GPUTracking/Global/GPUChainTracking.h
@@ -184,6 +184,7 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
   void SetO2Propagator(const o2::base::Propagator* prop) { processors()->calibObjects.o2Propagator = prop; }
   void SetCalibObjects(const GPUCalibObjectsConst& obj) { processors()->calibObjects = obj; }
   void SetCalibObjects(const GPUCalibObjects& obj) { memcpy((void*)&processors()->calibObjects, (const void*)&obj, sizeof(obj)); }
+  void SetUpdateCalibObjects(const GPUCalibObjectsConst& obj);
   void SetDefaultO2PropagatorForGPU();
   void LoadClusterErrors();
   void SetOutputControlCompressedClusters(GPUOutputControl* v) { mSubOutputControls[GPUTrackingOutputs::getIndex(&GPUTrackingOutputs::compressedClusters)] = v; }
@@ -206,6 +207,8 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
     short mMemoryResFlat = -1;
     void* SetPointersFlatObjects(void* mem);
   };
+  void UpdateGPUCalibObjects(int stream);
+  void UpdateGPUCalibObjectsPtrs(int stream);
 
   struct eventStruct // Must consist only of void* ptr that will hold the GPU event ptrs!
   {
@@ -265,6 +268,8 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
   // (Ptrs to) configuration objects
   std::unique_ptr<GPUTPCCFChainContext> mCFContext;
   bool mTPCSliceScratchOnStack = false;
+  GPUCalibObjectsConst mNewCalibObjects;
+  bool mUpdateNewCalibObjects = false;
 
   // Upper bounds for memory allocation
   unsigned int mMaxTPCHits = 0;

--- a/GPU/GPUTracking/Interface/GPUO2Interface.cxx
+++ b/GPU/GPUTracking/Interface/GPUO2Interface.cxx
@@ -178,5 +178,6 @@ std::unique_ptr<o2::tpc::CalibdEdxContainer> GPUO2Interface::getCalibdEdxContain
 
 int GPUO2Interface::UpdateCalibration(const GPUCalibObjectsConst& newCalib)
 {
-  return 1;
+  mChain->SetUpdateCalibObjects(newCalib);
+  return 0;
 }


### PR DESCRIPTION
Should actually work as is, and tested that it doesn't break the normal workflow.
But didn't test yet with updating the calibration object on the fly, so leaving it as WIP in the meantime.