### PR TITLE
[o2-sim] En-/disable hit creation per detector

### DIFF
--- a/Common/SimConfig/include/SimConfig/SimConfig.h
+++ b/Common/SimConfig/include/SimConfig/SimConfig.h
@@ -22,35 +22,36 @@ namespace conf
 
 // configuration struct (which can be passed around)
 struct SimConfigData {
-  std::vector<std::string> mActiveDetectors; // list of active detectors
-  std::string mMCEngine;                     // chosen VMC engine
-  std::string mGenerator;                    // chosen VMC generator
-  std::string mTrigger;                      // chosen VMC generator trigger
-  unsigned int mNEvents;                     // number of events to be simulated
-  std::string mExtKinFileName;               // file name of external kinematics file (needed for ext kinematics generator)
-  std::string mEmbedIntoFileName;            // filename containing the reference events to be used for the embedding
-  unsigned int mStartEvent;                  // index of first event to be taken
-  float mBMax;                               // maximum for impact parameter sampling
-  bool mIsMT;                                // chosen MT mode (Geant4 only)
-  std::string mOutputPrefix;                 // prefix to be used for output files
-  std::string mLogSeverity;                  // severity for FairLogger
-  std::string mLogVerbosity;                 // loglevel for FairLogger
-  std::string mKeyValueTokens;               // a string holding arbitrary sequence of key-value tokens
-                                             // Foo.parameter1=x,Bar.parameter2=y,Baz.paramter3=hello
-                                             // (can be used to **loosely** change any configuration parameter from command-line)
-  std::string mConfigFile;                   // path to a JSON or INI config file (file extension is required to determine type).
-                                             // values within the config file will override values set in code by the param classes
-                                             // but will themselves be overridden by any values given in mKeyValueTokens.
-  int mPrimaryChunkSize;                     // defining max granularity for input primaries of a sim job
-  int mInternalChunkSize;                    //
-  int mStartSeed;                            // base for random number seeds
-  int mSimWorkers = 1;                       // number of parallel sim workers (when it applies)
-  bool mFilterNoHitEvents = false;           // whether to filter out events not leaving any response
-  std::string mCCDBUrl;                      // the URL where to find CCDB
-  uint64_t mTimestamp;                       // timestamp in ms to anchor transport simulation to
-  int mField;                                // L3 field setting in kGauss: +-2,+-5 and 0
-  bool mUniformField = false;                // uniform magnetic field
-  bool mAsService = false;                   // if simulation should be run as service/deamon (does not exit after run)
+  std::vector<std::string> mActiveModules;    // list of active modules
+  std::vector<std::string> mReadoutDetectors; // list of readout detectors
+  std::string mMCEngine;                      // chosen VMC engine
+  std::string mGenerator;                     // chosen VMC generator
+  std::string mTrigger;                       // chosen VMC generator trigger
+  unsigned int mNEvents;                      // number of events to be simulated
+  std::string mExtKinFileName;                // file name of external kinematics file (needed for ext kinematics generator)
+  std::string mEmbedIntoFileName;             // filename containing the reference events to be used for the embedding
+  unsigned int mStartEvent;                   // index of first event to be taken
+  float mBMax;                                // maximum for impact parameter sampling
+  bool mIsMT;                                 // chosen MT mode (Geant4 only)
+  std::string mOutputPrefix;                  // prefix to be used for output files
+  std::string mLogSeverity;                   // severity for FairLogger
+  std::string mLogVerbosity;                  // loglevel for FairLogger
+  std::string mKeyValueTokens;                // a string holding arbitrary sequence of key-value tokens
+                                              // Foo.parameter1=x,Bar.parameter2=y,Baz.paramter3=hello
+                                              // (can be used to **loosely** change any configuration parameter from command-line)
+  std::string mConfigFile;                    // path to a JSON or INI config file (file extension is required to determine type).
+                                              // values within the config file will override values set in code by the param classes
+                                              // but will themselves be overridden by any values given in mKeyValueTokens.
+  int mPrimaryChunkSize;                      // defining max granularity for input primaries of a sim job
+  int mInternalChunkSize;                     //
+  int mStartSeed;                             // base for random number seeds
+  int mSimWorkers = 1;                        // number of parallel sim workers (when it applies)
+  bool mFilterNoHitEvents = false;            // whether to filter out events not leaving any response
+  std::string mCCDBUrl;                       // the URL where to find CCDB
+  uint64_t mTimestamp;                        // timestamp in ms to anchor transport simulation to
+  int mField;                                 // L3 field setting in kGauss: +-2,+-5 and 0
+  bool mUniformField = false;                 // uniform magnetic field
+  bool mAsService = false;                    // if simulation should be run as service/deamon (does not exit after run)
 
   ClassDefNV(SimConfigData, 4);
 };
@@ -93,7 +94,8 @@ class SimConfig
   // get MC engine
   std::string getMCEngine() const { return mConfigData.mMCEngine; }
   // get selected active detectors
-  std::vector<std::string> const& getActiveDetectors() const { return mConfigData.mActiveDetectors; }
+  std::vector<std::string> const& getActiveModules() const { return mConfigData.mActiveModules; }
+  std::vector<std::string> const& getReadoutDetectors() const { return mConfigData.mReadoutDetectors; }
   // get selected generator (to be used to select a genconfig)
   std::string getGenerator() const { return mConfigData.mGenerator; }
   std::string getTrigger() const { return mConfigData.mTrigger; }

--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -28,8 +28,10 @@ void SimConfig::initOptions(boost::program_options::options_description& options
     "mcEngine,e", bpo::value<std::string>()->default_value("TGeant3"), "VMC backend to be used.")(
     "generator,g", bpo::value<std::string>()->default_value("boxgen"), "Event generator to be used.")(
     "trigger,t", bpo::value<std::string>()->default_value(""), "Event generator trigger to be used.")(
-    "modules,m", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>({"all"}), "all modules"), "list of detectors")(
-    "skipModules", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>({""}), ""), "list of detectors to skip (precendence over -m")(
+    "modules,m", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>({"all"}), "all modules"), "list of modules included in geometry")(
+    "skipModules", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>({""}), ""), "list of modules excluded in geometry (precendence over -m")(
+    "readoutDetectors", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>(), ""), "list of detectors creating hits, all if not given; added to to active modules")(
+    "skipReadoutDetectors", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>(), ""), "list of detectors to skip hit creation (precendence over --readoutDetectors")(
     "nEvents,n", bpo::value<unsigned int>()->default_value(1), "number of events")(
     "startEvent", bpo::value<unsigned int>()->default_value(0), "index of first event to be used (when applicable)")(
     "extKinFile", bpo::value<std::string>()->default_value("Kinematics.root"),
@@ -58,35 +60,73 @@ bool SimConfig::resetFromParsedMap(boost::program_options::variables_map const& 
 {
   using o2::detectors::DetID;
   mConfigData.mMCEngine = vm["mcEngine"].as<std::string>();
-  mConfigData.mActiveDetectors = vm["modules"].as<std::vector<std::string>>();
-  auto& active = mConfigData.mActiveDetectors;
-  if (active.size() == 1 && active[0] == "all") {
-    active.clear();
+  mConfigData.mActiveModules = vm["modules"].as<std::vector<std::string>>();
+  auto& activeModules = mConfigData.mActiveModules;
+  if (activeModules.size() == 1 && activeModules[0] == "all") {
+    activeModules.clear();
     for (int d = DetID::First; d <= DetID::Last; ++d) {
 #ifdef ENABLE_UPGRADES
       if (d != DetID::IT3 && d != DetID::TRK && d != DetID::FT3) {
-        active.emplace_back(DetID::getName(d));
+        activeModules.emplace_back(DetID::getName(d));
       }
 #else
-      active.emplace_back(DetID::getName(d));
+      activeModules.emplace_back(DetID::getName(d));
 #endif
     }
     // add passive components manually (make a PassiveDetID for them!)
-    active.emplace_back("HALL");
-    active.emplace_back("MAG");
-    active.emplace_back("DIPO");
-    active.emplace_back("COMP");
-    active.emplace_back("PIPE");
-    active.emplace_back("ABSO");
-    active.emplace_back("SHIL");
+    activeModules.emplace_back("HALL");
+    activeModules.emplace_back("MAG");
+    activeModules.emplace_back("DIPO");
+    activeModules.emplace_back("COMP");
+    activeModules.emplace_back("PIPE");
+    activeModules.emplace_back("ABSO");
+    activeModules.emplace_back("SHIL");
   }
   // now we take out detectors listed as skipped
   auto& skipped = vm["skipModules"].as<std::vector<std::string>>();
   for (auto& s : skipped) {
-    auto iter = std::find(active.begin(), active.end(), s);
-    if (iter != active.end()) {
+    auto iter = std::find(activeModules.begin(), activeModules.end(), s);
+    if (iter != activeModules.end()) {
       // take it out
-      active.erase(iter);
+      activeModules.erase(iter);
+    }
+  }
+
+  // find all detectors that should be readout
+  auto enableReadout = vm["readoutDetectors"].as<std::vector<std::string>>();
+  auto& disableReadout = vm["skipReadoutDetectors"].as<std::vector<std::string>>();
+  auto& readoutDetectors = mConfigData.mReadoutDetectors;
+  readoutDetectors.clear();
+
+  auto isDet = [](std::string const& s) {
+    auto d = DetID::nameToID(s.c_str());
+#ifdef ENABLE_UPGRADES
+    return d >= DetID::First && d != DetID::IT3 && d != DetID::TRK && d != DetID::FT3;
+#else
+    return d >= DetID::First;
+#endif
+  };
+
+  if (enableReadout.empty()) {
+    // if no readout explicitly given, use all detectors from active modules
+    for (auto& am : activeModules) {
+      if (!isDet(am) || std::find(disableReadout.begin(), disableReadout.end(), am) != disableReadout.end()) {
+        // either we found a passive module or one with disabled readout ==> skip
+        continue;
+      }
+      readoutDetectors.emplace_back(am);
+    }
+  } else {
+    for (auto& er : enableReadout) {
+      if (!isDet(er) || std::find(disableReadout.begin(), disableReadout.end(), er) != disableReadout.end()) {
+        // either we found a passive module or one with disabled readout ==> skip
+        continue;
+      }
+      readoutDetectors.emplace_back(er);
+      if (std::find(activeModules.begin(), activeModules.end(), er) == activeModules.end()) {
+        // add to active modules if not yet there
+        activeModules.emplace_back(er);
+      }
     }
   }
 

--- a/Common/SimConfig/test/TestConfig.cxx
+++ b/Common/SimConfig/test/TestConfig.cxx
@@ -22,7 +22,7 @@ int main(int argc, char* argv[])
   std::cout << "Selected VMC engine " << conf.getMCEngine() << "\n";
   std::cout << "Selected Modules:\n";
 
-  auto v = conf.getActiveDetectors();
+  auto v = conf.getActiveModules();
   for (auto& m : v) {
     std::cout << "@ " << m << "\n";
   }
@@ -43,7 +43,7 @@ int main(int argc, char* argv[])
 
   if (inconfigdata) {
     conf.resetFromConfigData(*inconfigdata);
-    auto v2 = conf.getActiveDetectors();
+    auto v2 = conf.getActiveModules();
     for (auto& m : v2) {
       std::cout << "@ " << m << "\n";
     }

--- a/Detectors/ITSMFT/MFT/simulation/include/MFTSimulation/Detector.h
+++ b/Detectors/ITSMFT/MFT/simulation/include/MFTSimulation/Detector.h
@@ -49,6 +49,11 @@ namespace mft
 class Detector : public o2::base::DetImpl<Detector>
 {
  public:
+  /// Name : Detector Name
+  /// Active: kTRUE for active detectors (ProcessHits() will be called)
+  ///         kFALSE for inactive detectors
+  Detector(Bool_t active);
+
   /// Default constructor
   Detector();
 

--- a/Detectors/ITSMFT/MFT/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/MFT/simulation/src/Detector.cxx
@@ -42,6 +42,10 @@ Detector::Detector()
   : o2::base::DetImpl<Detector>("MFT", kTRUE), mVersion(1), mDensitySupportOverSi(0.036), mHits(o2::utils::createSimVector<o2::itsmft::Hit>()), mTrackData() {}
 
 //_____________________________________________________________________________
+Detector::Detector(Bool_t active)
+  : o2::base::DetImpl<Detector>("MFT", active), mVersion(1), mDensitySupportOverSi(0.036), mHits(o2::utils::createSimVector<o2::itsmft::Hit>()), mTrackData() {}
+
+//_____________________________________________________________________________
 Detector::Detector(const Detector& src)
   : o2::base::DetImpl<Detector>(src), mVersion(src.mVersion), mDensitySupportOverSi(src.mDensitySupportOverSi), mHits(o2::utils::createSimVector<o2::itsmft::Hit>()), mTrackData() {}
 

--- a/macro/build_geometry.C
+++ b/macro/build_geometry.C
@@ -59,10 +59,21 @@ void finalize_geometry(FairRunSim* run);
 bool isActivated(std::string s)
 {
   // access user configuration for list of wanted modules
-  auto& modulelist = o2::conf::SimConfig::Instance().getActiveDetectors();
+  auto& modulelist = o2::conf::SimConfig::Instance().getActiveModules();
   auto active = std::find(modulelist.begin(), modulelist.end(), s) != modulelist.end();
   if (active) {
     LOG(info) << "Activating " << s << " module";
+  }
+  return active;
+}
+
+bool isReadout(std::string s)
+{
+  // access user configuration for list of wanted modules
+  auto& modulelist = o2::conf::SimConfig::Instance().getReadoutDetectors();
+  auto active = std::find(modulelist.begin(), modulelist.end(), s) != modulelist.end();
+  if (active) {
+    LOG(info) << "Reading out " << s << " detector";
   }
   return active;
 }
@@ -151,119 +162,108 @@ void build_geometry(FairRunSim* run = nullptr)
   // the absorber
   if (isActivated("ABSO")) {
     // the frame structure to support other detectors
-    auto abso = new o2::passive::Absorber("ABSO", "Absorber");
-    run->AddModule(abso);
+    run->AddModule(new o2::passive::Absorber("ABSO", "Absorber"));
   }
 
   // the shil
   if (isActivated("SHIL")) {
-    auto shil = new o2::passive::Shil("SHIL", "Small angle beam shield");
-    run->AddModule(shil);
+    run->AddModule(new o2::passive::Shil("SHIL", "Small angle beam shield"));
   }
 
   if (isActivated("TOF") || isActivated("TRD") || isActivated("FRAME")) {
     // the frame structure to support other detectors
-    auto frame = new o2::passive::FrameStructure("FRAME", "Frame");
-    run->AddModule(frame);
+    run->AddModule(new o2::passive::FrameStructure("FRAME", "Frame"));
   }
 
   if (isActivated("TOF")) {
     // TOF
-    auto tof = new o2::tof::Detector(true);
-    run->AddModule(tof);
+    run->AddModule(new o2::tof::Detector(isReadout("TOF")));
   }
 
   if (isActivated("TRD")) {
     // TRD
-    auto trd = new o2::trd::Detector(true);
-    run->AddModule(trd);
+    run->AddModule(new o2::trd::Detector(isReadout("TRD")));
   }
 
   if (isActivated("TPC")) {
     // tpc
-    auto tpc = new o2::tpc::Detector(true);
-    run->AddModule(tpc);
+    run->AddModule(new o2::tpc::Detector(isReadout("TPC")));
   }
 #ifdef ENABLE_UPGRADES
   if (isActivated("IT3")) {
     // ITS3
-    auto its3 = new o2::its3::Detector(true);
-    run->AddModule(its3);
+    run->AddModule(new o2::its3::Detector(isReadout("IT3")));
   }
 
   if (isActivated("TRK")) {
     // ALICE 3 TRK
-    auto trk = new o2::trk::Detector(true);
-    run->AddModule(trk);
+    run->AddModule(new o2::trk::Detector(isReadout("TRK")));
   }
 
   if (isActivated("FT3")) {
     // ALICE 3 FT3
-    auto ft3 = new o2::ft3::Detector(true);
-    run->AddModule(ft3);
+    run->AddModule(new o2::ft3::Detector(isReadout("FT3")));
   }
 #endif
 
   if (isActivated("ITS")) {
     // its
-    auto its = new o2::its::Detector(true);
-    run->AddModule(its);
+    run->AddModule(new o2::its::Detector(isReadout("ITS")));
   }
 
   if (isActivated("MFT")) {
     // mft
-    auto mft = new o2::mft::Detector();
-    run->AddModule(mft);
+    run->AddModule(new o2::mft::Detector(isReadout("MFT")));
   }
 
   if (isActivated("MCH")) {
     // mch
-    run->AddModule(new o2::mch::Detector(true));
+    run->AddModule(new o2::mch::Detector(isReadout("MCH")));
   }
 
   if (isActivated("MID")) {
     // mid
-    run->AddModule(new o2::mid::Detector(true));
+    run->AddModule(new o2::mid::Detector(isReadout("MID")));
   }
 
   if (isActivated("EMC")) {
     // emcal
-    run->AddModule(new o2::emcal::Detector(true));
+    run->AddModule(new o2::emcal::Detector(isReadout("EMC")));
   }
 
   if (isActivated("PHS")) {
     // phos
-    run->AddModule(new o2::phos::Detector(true));
+    run->AddModule(new o2::phos::Detector(isReadout("PHS")));
   }
 
   if (isActivated("CPV")) {
     // cpv
-    run->AddModule(new o2::cpv::Detector(true));
+    run->AddModule(new o2::cpv::Detector(isReadout("CPV")));
   }
 
   if (isActivated("FT0")) {
     // FIT-T0
-    run->AddModule(new o2::ft0::Detector(true));
+    run->AddModule(new o2::ft0::Detector(isReadout("FT0")));
   }
 
   if (isActivated("FV0")) {
     // FIT-V0
-    run->AddModule(new o2::fv0::Detector(true));
+    run->AddModule(new o2::fv0::Detector(isReadout("FV0")));
   }
 
   if (isActivated("FDD")) {
     // FIT-FDD
-    run->AddModule(new o2::fdd::Detector(true));
+    run->AddModule(new o2::fdd::Detector(isReadout("FDD")));
   }
 
   if (isActivated("HMP")) {
     // HMP
-    run->AddModule(new o2::hmpid::Detector(true));
+    run->AddModule(new o2::hmpid::Detector(isReadout("HMP")));
   }
 
   if (isActivated("ZDC")) {
     // ZDC
-    run->AddModule(new o2::zdc::Detector(true));
+    run->AddModule(new o2::zdc::Detector(isReadout("ZDC")));
   }
 
   if (geomonly) {

--- a/run/O2HitMerger.h
+++ b/run/O2HitMerger.h
@@ -772,11 +772,11 @@ class O2HitMerger : public FairMQDevice
   }
 
   std::map<uint32_t, uint32_t> mPartsCheckSum; //! mapping event id -> part checksum used to detect when all info
-  std::string mOutFileName; //!
+  std::string mOutFileName;                    //!
 
   // structures for the final flush
-  TFile* mOutFile;                                     //! outfile for kinematics
-  TTree* mOutTree;                                     //! tree (kinematics) associated to mOutFile
+  TFile* mOutFile; //! outfile for kinematics
+  TTree* mOutTree; //! tree (kinematics) associated to mOutFile
 
   template <class K, class V>
   using Hashtable = tbb::concurrent_unordered_map<K, V>;
@@ -794,7 +794,7 @@ class O2HitMerger : public FairMQDevice
 
   int mEventChecksum = 0;   //! checksum for events
   int mNExpectedEvents = 0; //! number of events that we expect to receive
-  int mNextFlushID = 1;                           //! EventID to be flushed next
+  int mNextFlushID = 1;     //! EventID to be flushed next
   TStopwatch mTimer;
 
   bool mAsService = false; //! if run in deamonized mode
@@ -822,7 +822,7 @@ void O2HitMerger::initHitFiles(std::string prefix)
   // a little helper lambda
   auto isActivated = [](std::string s) -> bool {
     // access user configuration for list of wanted modules
-    auto& modulelist = o2::conf::SimConfig::Instance().getActiveDetectors();
+    auto& modulelist = o2::conf::SimConfig::Instance().getReadoutDetectors();
     auto active = std::find(modulelist.begin(), modulelist.end(), s) != modulelist.end();
     return active; };
 
@@ -843,7 +843,7 @@ void O2HitMerger::initDetInstances()
   // a little helper lambda
   auto isActivated = [](std::string s) -> bool {
     // access user configuration for list of wanted modules
-    auto& modulelist = o2::conf::SimConfig::Instance().getActiveDetectors();
+    auto& modulelist = o2::conf::SimConfig::Instance().getReadoutDetectors();
     auto active = std::find(modulelist.begin(), modulelist.end(), s) != modulelist.end();
     return active; };
 
@@ -865,7 +865,7 @@ void O2HitMerger::initDetInstances()
       counter++;
     }
     if (i == DetID::MFT) {
-      mDetectorInstances[i] = std::move(std::make_unique<o2::mft::Detector>());
+      mDetectorInstances[i] = std::move(std::make_unique<o2::mft::Detector>(true));
       counter++;
     }
     if (i == DetID::TRD) {


### PR DESCRIPTION
Be able to en-/disable hit creation of detectors while still building
the geometry. This is an extension to the -m/--skipModules options.

* introduce --readoutDetectors and --skipReadoutDetectors options

  if a passive module name is passed for either of the options it will
  be ignored

* --readoutDetectors det_1 ... det_N
  * if det_i specified, only the given detectors will be readout
  * if det_i not contained in active modules (see -m/--skipModules), it
    takes precedence and det_i is added to active modules
  * if not specified, all detectors will be readout which are in line
    with the -m and --skipModules options

* --skipReadoutDetectors det_1 ... det_N
  * given detectors will not produce any hits
  * has no effect on the constructed geometry

* take care of corner cases such as
  --skipModules m --readoutDetectors m --skipReadoutDetectors m
  in which case m is not built at all and therefore not readout