### PR TITLE
[Global Fwd Tracking] Enable to export True Pairing Eff for assessment of GlobalFwdTrack

### DIFF
--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchGlobalFwdAssessment.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchGlobalFwdAssessment.h
@@ -138,12 +138,16 @@ class GloFwdAssessment
 
   std::unique_ptr<TEfficiency> mChargeMatchEff = nullptr;
   std::unique_ptr<TH2D> mPairingEtaPt = nullptr;
+  std::unique_ptr<TH2D> mTruePairingEtaPt = nullptr;
 
   std::vector<std::unique_ptr<TH2D>> mPurityPtInnerVecTH2;
   std::vector<std::unique_ptr<TH2D>> mPurityPtOuterVecTH2;
   std::vector<std::unique_ptr<TH1D>> mPairingPtInnerVecTH1;
   std::vector<std::unique_ptr<TH1D>> mPairingPtOuterVecTH1;
+  std::vector<std::unique_ptr<TH1D>> mTruePairingPtInnerVecTH1;
+  std::vector<std::unique_ptr<TH1D>> mTruePairingPtOuterVecTH1;
   std::vector<std::unique_ptr<TH2D>> mPairingEtaPtVec;
+  std::vector<std::unique_ptr<TH2D>> mTruePairingEtaPtVec;
 
   enum TH3HistosCodes {
     kTH3GMTrackDeltaXDeltaYEta,
@@ -162,6 +166,7 @@ class GloFwdAssessment
     kTH3GMTrackPtEtaMatchScore,
     kTH3GMTruePtEtaChi2,
     kTH3GMTruePtEtaMatchScore,
+    kTH3GMTruePtEtaMatchScore_MC,
     kTH3GMCloseMatchPtEtaChi2,
     kTH3GMCloseMatchPtEtaMatchScore,
     kTH3GMPairablePtEtaZ,
@@ -187,7 +192,8 @@ class GloFwdAssessment
     {kTH3GMTrackPtEtaChi2, "TH3GMTrackPtEtaChi2"},
     {kTH3GMTrackPtEtaMatchScore, "TH3GMTrackPtEtaMatchScore"},
     {kTH3GMTruePtEtaChi2, "TH3GMTruePtEtaChi2"},
-    {kTH3GMTruePtEtaMatchScore, "TH3GMTruePtEtaMatchScore"}};
+    {kTH3GMTruePtEtaMatchScore, "TH3GMTruePtEtaMatchScore"},
+    {kTH3GMTruePtEtaMatchScore_MC, "TH3GMTruePtEtaMatchScore_MC"}};
 
   std::map<int, const char*> TH3Titles{
     {kTH3GMTrackDeltaXDeltaYEta, "TH3GMTrackDeltaXDeltaYEta"},
@@ -208,7 +214,8 @@ class GloFwdAssessment
     {kTH3GMTrackPtEtaChi2, "TH3GMTrackPtEtaChi2"},
     {kTH3GMTrackPtEtaMatchScore, "TH3GMTrackPtEtaMatchScore"},
     {kTH3GMTruePtEtaChi2, "TH3GMTruePtEtaChi2"},
-    {kTH3GMTruePtEtaMatchScore, "TH3GMTruePtEtaMatchScore"}};
+    {kTH3GMTruePtEtaMatchScore, "TH3GMTruePtEtaMatchScore"},
+    {kTH3GMTruePtEtaMatchScore_MC, "TH3GMTruePtEtaMatchScore_MC"}};
 
   std::map<int, std::array<double, 9>> TH3Binning{
     {kTH3GMTrackDeltaXDeltaYEta, {16, 2.2, 3.8, 1000, -1000, 1000, 1000, -1000, 1000}},
@@ -229,7 +236,8 @@ class GloFwdAssessment
     {kTH3GMTrackPtEtaChi2, {40, 0, 20, 16, 2.2, 3.8, 1000, 0, 100}},
     {kTH3GMTrackPtEtaMatchScore, {40, 0, 20, 16, 2.2, 3.8, 2000, 0, 20.0}},
     {kTH3GMTruePtEtaChi2, {40, 0, 20, 16, 2.2, 3.8, 1000, 0, 100}},
-    {kTH3GMTruePtEtaMatchScore, {40, 0, 20, 16, 2.2, 3.8, 2000, 0, 20.0}}};
+    {kTH3GMTruePtEtaMatchScore, {40, 0, 20, 16, 2.2, 3.8, 2000, 0, 20.0}},
+    {kTH3GMTruePtEtaMatchScore_MC, {40, 0, 20, 16, 2.2, 3.8, 2000, 0, 20.0}}};
 
   std::map<int, const char*> TH3XaxisTitles{
     {kTH3GMTrackDeltaXDeltaYEta, R"(\\eta_{MC})"},
@@ -244,13 +252,14 @@ class GloFwdAssessment
     {kTH3GMTrackTanlPullPtEta, R"(p_{t}_{MC})"},
     {kTH3GMTrackInvQPtPullPtEta, R"(p_{t}_{MC})"},
     {kTH3GMTrackReducedChi2PtEta, R"(p_{t}_{MC})"},
-    {kTH3GMCloseMatchPtEtaChi2, R"(p_{t}_{Fit}_{MC})"},
-    {kTH3GMCloseMatchPtEtaMatchScore, R"(p_{t}_{Fit}_{MC})"},
-    {kTH3GMPairablePtEtaZ, R"(p_{t}_{Fit}_{MC})"},
-    {kTH3GMTrackPtEtaChi2, R"(p_{t}_{Fit}_{MC})"},
-    {kTH3GMTrackPtEtaMatchScore, R"(p_{t}_{Fit}_{MC})"},
-    {kTH3GMTruePtEtaChi2, R"(p_{t}_{Fit}_{MC})"},
-    {kTH3GMTruePtEtaMatchScore, R"(p_{t}_{Fit}_{MC})"}};
+    {kTH3GMCloseMatchPtEtaChi2, R"(p_{t}_{Fit})"},
+    {kTH3GMCloseMatchPtEtaMatchScore, R"(p_{t}_{Fit})"},
+    {kTH3GMPairablePtEtaZ, R"(p_{t}_{MC})"},
+    {kTH3GMTrackPtEtaChi2, R"(p_{t}_{Fit})"},
+    {kTH3GMTrackPtEtaMatchScore, R"(p_{t}_{Fit})"},
+    {kTH3GMTruePtEtaChi2, R"(p_{t}_{Fit})"},
+    {kTH3GMTruePtEtaMatchScore, R"(p_{t}_{Fit})"},
+    {kTH3GMTruePtEtaMatchScore_MC, R"(p_{t}_{MC})"},};
 
   std::map<int, const char*> TH3YaxisTitles{
     {kTH3GMTrackDeltaXDeltaYEta, R"(X_{residual \rightarrow vtx} (\mu m))"},
@@ -271,7 +280,8 @@ class GloFwdAssessment
     {kTH3GMTrackPtEtaChi2, R"(\eta_{Fit})"},
     {kTH3GMTrackPtEtaMatchScore, R"(\eta_{Fit})"},
     {kTH3GMTruePtEtaChi2, R"(\eta_{Fit})"},
-    {kTH3GMTruePtEtaMatchScore, R"(\eta_{Fit})"}};
+    {kTH3GMTruePtEtaMatchScore, R"(\eta_{Fit})"},
+    {kTH3GMTruePtEtaMatchScore_MC, R"(\eta_{MC})"}};
 
   std::map<int, const char*> TH3ZaxisTitles{
     {kTH3GMTrackDeltaXDeltaYEta, R"(Y_{residual \rightarrow vtx} (\mu m))"},
@@ -292,7 +302,8 @@ class GloFwdAssessment
     {kTH3GMTrackPtEtaChi2, R"(Match \chi^2)"},
     {kTH3GMTrackPtEtaMatchScore, R"(Matching Score)"},
     {kTH3GMTruePtEtaChi2, R"(Match \chi^2)"},
-    {kTH3GMTruePtEtaMatchScore, R"(Matching Score)"}};
+    {kTH3GMTruePtEtaMatchScore, R"(Matching Score)"},
+    {kTH3GMTruePtEtaMatchScore_MC, R"(Matching Score)"}};
 
   enum TH3SlicedCodes {
     kDeltaXVertexVsEta,
@@ -368,6 +379,9 @@ class GloFwdAssessment
     kPairingEffPtOuter,
     kPairingEffPtInner,
     kPurityVsEfficiency,
+    kTruePairingEffPtOuter,
+    kTruePairingEffPtInner,
+    kPurityVsTrueEfficiency,
     kNGMAssesmentCanvases
   };
 
@@ -376,7 +390,10 @@ class GloFwdAssessment
     {kPurityPtInner, "PurityPtInner"},
     {kPairingEffPtOuter, "PairingEffPtOuter"},
     {kPairingEffPtInner, "PairingEffPtInner"},
-    {kPurityVsEfficiency, "PurityVsEfficiency"}};
+    {kTruePairingEffPtOuter, "TruePairingEffPtOuter"},
+    {kTruePairingEffPtInner, "TruePairingEffPtInner"},
+    {kPurityVsEfficiency, "PurityVsEfficiency"},
+    {kPurityVsTrueEfficiency, "PurityVsTrueEfficiency"}};
 
   std::array<TCanvas*, kNGMAssesmentCanvases> mAssessmentCanvas;
 

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchGlobalFwdAssessment.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchGlobalFwdAssessment.h
@@ -259,7 +259,7 @@ class GloFwdAssessment
     {kTH3GMTrackPtEtaMatchScore, R"(p_{t}_{Fit})"},
     {kTH3GMTruePtEtaChi2, R"(p_{t}_{Fit})"},
     {kTH3GMTruePtEtaMatchScore, R"(p_{t}_{Fit})"},
-    {kTH3GMTruePtEtaMatchScore_MC, R"(p_{t}_{MC})"},};
+    {kTH3GMTruePtEtaMatchScore_MC, R"(p_{t}_{MC})"}};
 
   std::map<int, const char*> TH3YaxisTitles{
     {kTH3GMTrackDeltaXDeltaYEta, R"(X_{residual \rightarrow vtx} (\mu m))"},

--- a/Detectors/GlobalTracking/src/MatchGlobalFwdAssessment.cxx
+++ b/Detectors/GlobalTracking/src/MatchGlobalFwdAssessment.cxx
@@ -620,8 +620,8 @@ void GloFwdAssessment::finalizePurityAndEff()
   auto PairablePtProjOuter = (TH1*)hPairable->ProjectionX("PairableOuter", minBin, midBin);
 
   auto RecoEtaPt = (TH2D*)Reco->Project3D("xy COLZ");
-  auto TrueEtaPt = (TH2D *)hTrue->Project3D("xy COLZ");
-  auto TrueEtaPt_MC = (TH2D *)hTrue_MC->Project3D("xy COLZ");
+  auto TrueEtaPt = (TH2D*)hTrue->Project3D("xy COLZ");
+  auto TrueEtaPt_MC = (TH2D*)hTrue_MC->Project3D("xy COLZ");
   auto PairableEtaPt = (TH2D*)hPairable->Project3D("xy COLZ");
   auto PairablePt = (TH1D*)hPairable->Project3D("x");
 
@@ -631,13 +631,13 @@ void GloFwdAssessment::finalizePurityAndEff()
 
     auto RecoPtProj = (TH1*)Reco->ProjectionX(Form("_RecoPtProj%.2f", scoreCut));
     auto TruePtProj = (TH1*)hTrue->ProjectionX(Form("_TruePtProj%.2f", scoreCut));
-    auto TruePtProj_MC = (TH1 *)hTrue_MC->ProjectionX(Form("_TruePtProj_MC%.2f", scoreCut));
+    auto TruePtProj_MC = (TH1*)hTrue_MC->ProjectionX(Form("_TruePtProj_MC%.2f", scoreCut));
 
     // Inner pseudorapidity
     auto maxScoreBin = Reco->GetZaxis()->FindBin(scoreCut);
     auto RecoPtProjInner = (TH1*)Reco->ProjectionX(Form("_InnerRecoCut_%.2f", scoreCut), midBin, maxBin, 0, maxScoreBin);
     auto TruePtProjInner = (TH1*)hTrue->ProjectionX(Form("_InnerTrueCut_%.2f", scoreCut), midBin, maxBin, 0, maxScoreBin);
-    auto TruePtProjInner_MC = (TH1 *)hTrue_MC->ProjectionX(Form("_InnerTrueCut_MC_%.2f", scoreCut), midBin, maxBin, 0, maxScoreBin);
+    auto TruePtProjInner_MC = (TH1*)hTrue_MC->ProjectionX(Form("_InnerTrueCut_MC_%.2f", scoreCut), midBin, maxBin, 0, maxScoreBin);
 
     auto& hPurityInner = mPurityPtInnerVecTH2.emplace_back((std::unique_ptr<TH2D>)static_cast<TH2D*>(TruePtProjInner->Clone()));
     hPurityInner->Divide(RecoPtProjInner); // Global Pairing Purity = N_true / N_reco
@@ -657,7 +657,7 @@ void GloFwdAssessment::finalizePurityAndEff()
     hPairingEffInner->SetMinimum(0.0);
     hPairingEffInner->SetMaximum(1.8);
 
-    auto &hTruePairingEffInner = mTruePairingPtInnerVecTH1.emplace_back((std::unique_ptr<TH1D>)static_cast<TH1D *>(TruePtProjInner_MC->Clone()));
+    auto& hTruePairingEffInner = mTruePairingPtInnerVecTH1.emplace_back((std::unique_ptr<TH1D>)static_cast<TH1D*>(TruePtProjInner_MC->Clone()));
     hTruePairingEffInner->Divide(PairablePtProjInner);
     hTruePairingEffInner->SetNameTitle(Form("GMTrackTruePairingEffInnerPtCut_%.2f", scoreCut), Form("%.2f cut", scoreCut));
     hTruePairingEffInner->GetYaxis()->SetTitle("True Pairing Efficiency [ N_{True} / N_{pairable}]");
@@ -669,7 +669,7 @@ void GloFwdAssessment::finalizePurityAndEff()
     // Outer pseudorapidity
     auto RecoPtProjOuter = (TH1*)Reco->ProjectionX(Form("_OuterRecoCut_%.2f", scoreCut), minBin, midBin, 0, maxScoreBin);
     auto TruePtProjOuter = (TH1*)hTrue->ProjectionX(Form("_OuterTrueCut_%.2f", scoreCut), minBin, midBin, 0, maxScoreBin);
-    auto TruePtProjOuter_MC = (TH1 *)hTrue_MC->ProjectionX(Form("_OuterTrueCut_MC_%.2f", scoreCut), minBin, midBin, 0, maxScoreBin);
+    auto TruePtProjOuter_MC = (TH1*)hTrue_MC->ProjectionX(Form("_OuterTrueCut_MC_%.2f", scoreCut), minBin, midBin, 0, maxScoreBin);
 
     auto& hPurityOuter = mPurityPtOuterVecTH2.emplace_back((std::unique_ptr<TH2D>)static_cast<TH2D*>(TruePtProjOuter->Clone()));
     hPurityOuter->Divide(RecoPtProjOuter); // Global Pairing Purity = N_true / N_reco
@@ -689,7 +689,7 @@ void GloFwdAssessment::finalizePurityAndEff()
     hPairingEffOuter->SetMinimum(0.0);
     hPairingEffOuter->SetMaximum(1.8);
 
-    auto &hTruePairingEffOuter = mTruePairingPtOuterVecTH1.emplace_back((std::unique_ptr<TH1D>)static_cast<TH1D *>(TruePtProjOuter_MC->Clone()));
+    auto& hTruePairingEffOuter = mTruePairingPtOuterVecTH1.emplace_back((std::unique_ptr<TH1D>)static_cast<TH1D*>(TruePtProjOuter_MC->Clone()));
     hTruePairingEffOuter->Divide(PairablePtProjOuter);
     hTruePairingEffOuter->SetNameTitle(Form("GMTrackTruePairingEffOuterPtCut_%.2f", scoreCut), Form("%.2f cut", scoreCut));
     hTruePairingEffOuter->GetYaxis()->SetTitle("True Pairing Efficiency [ N_{True} / N_{pairable}]");
@@ -703,7 +703,7 @@ void GloFwdAssessment::finalizePurityAndEff()
     mPairingEtaPtVec.back()->SetNameTitle(Form("GMTrackPairingEffEtaPtCut_%.2f", scoreCut), Form("%.2f", scoreCut));
     mPairingEtaPtVec.back()->SetOption("COLZ");
 
-    mTruePairingEtaPtVec.emplace_back((std::unique_ptr<TH2D>)static_cast<TH2D *>(TrueEtaPt_MC->Clone()));
+    mTruePairingEtaPtVec.emplace_back((std::unique_ptr<TH2D>)static_cast<TH2D*>(TrueEtaPt_MC->Clone()));
     mTruePairingEtaPtVec.back()->Divide(PairableEtaPt);
     mTruePairingEtaPtVec.back()->SetNameTitle(Form("GMTrackTruePairingEffEtaPtCut_%.2f", scoreCut), Form("%.2f", scoreCut));
     mTruePairingEtaPtVec.back()->SetOption("COLZ");
@@ -858,10 +858,10 @@ void GloFwdAssessment::finalizePurityAndEff()
   mAssessmentCanvas[nCanvas]->cd();
   first = true;
 
-  for (auto &th2 : mTruePairingPtOuterVecTH1){
-    if (first){
+  for (auto& th2 : mTruePairingPtOuterVecTH1) {
+    if (first) {
       option = "hist P PMC";
-    }else{
+    } else {
       option = "hist SAME P PMC";
     }
     first = false;
@@ -887,10 +887,10 @@ void GloFwdAssessment::finalizePurityAndEff()
   mAssessmentCanvas[nCanvas]->cd();
   first = true;
 
-  for (auto &th2 : mTruePairingPtInnerVecTH1){
-    if (first){
+  for (auto& th2 : mTruePairingPtInnerVecTH1) {
+    if (first) {
       option = "hist P PMC";
-    }else{
+    } else {
       option = "hist SAME P PMC";
     }
     first = false;
@@ -957,7 +957,7 @@ void GloFwdAssessment::finalizePurityAndEff()
   canvasName = GMAssesmentNames[nCanvas];
   mAssessmentCanvas[nCanvas] = new TCanvas(canvasName, canvasName, 1080, 800);
 
-  TGraph *gr2 = new TGraph(highPtInnerTrueEff.size(), &highPtInnerTrueEff[0], &highPtInnerPurity[0]);
+  TGraph* gr2 = new TGraph(highPtInnerTrueEff.size(), &highPtInnerTrueEff[0], &highPtInnerPurity[0]);
   gr2->SetMinimum(0);
   gr2->SetMaximum(1.01);
 


### PR DESCRIPTION
This change enable to export these plots.

- True Pairing Efficiency vs pT_{MC} (Inner pseudo rapidity region 2.4 < \eta < 3.0)
- True Pairing Efficiency vs pT_{MC} (Outer pseudo rapidity region 3.0 < \eta < 3.6)
- 2D distribution of pT_{MC} and \eta_{MC} for True Pairing Efficiency
- True Pairing Efficiency vs Pairing Purity (pT = 0.25, 0.75, 2.25 ; \eta = Inner, Outer)

For the calculation of True Pairing Efficiency, MC parameter of True matched track and Pairable track is used. Pairing Efficiency is already merged into O2 but there is difference which parameter(MC or Fit) is used for between numerator and denominator. When reconstructed global muon track include many Fake matched track, Pairing Efficiency will not work well due to this problem. So True Pairing Efficiency will help you to understand efficiency of MFT-MCH track matching.