### PR TITLE
[EMCAL-753,EMCAL-763] Redesing DigitsWriteoutBuffer with past/future dequeue

### DIFF
--- a/Detectors/EMCAL/simulation/CMakeLists.txt
+++ b/Detectors/EMCAL/simulation/CMakeLists.txt
@@ -11,7 +11,7 @@
 
 o2_add_library(EMCALSimulation
                SOURCES src/Detector.cxx src/Digitizer.cxx src/SDigitizer.cxx
-                       src/DigitsWriteoutBuffer.cxx src/SpaceFrame.cxx src/SimParam.cxx
+                       src/DigitsWriteoutBuffer.cxx src/DigitsVectorStream.cxx src/SpaceFrame.cxx src/SimParam.cxx
                        src/LabeledDigit.cxx src/RawWriter.cxx
                PUBLIC_LINK_LIBRARIES O2::EMCALBase O2::DetectorsBase O2::SimConfig O2::SimulationDataFormat O2::Headers O2::DetectorsRaw O2::EMCALReconstruction)
 
@@ -20,6 +20,7 @@ o2_target_root_dictionary(EMCALSimulation
                                   include/EMCALSimulation/Digitizer.h
                                   include/EMCALSimulation/SDigitizer.h
                                   include/EMCALSimulation/DigitsWriteoutBuffer.h
+                                  include/EMCALSimulation/DigitsVectorStream.h
                                   include/EMCALSimulation/RawWriter.h
                                   include/EMCALSimulation/SpaceFrame.h
                                   include/EMCALSimulation/SimParam.h

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/Digitizer.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/Digitizer.h
@@ -26,8 +26,8 @@
 #include "EMCALSimulation/SimParam.h"
 #include "EMCALSimulation/LabeledDigit.h"
 #include "EMCALSimulation/DigitsWriteoutBuffer.h"
-
 #include "SimulationDataFormat/MCTruthContainer.h"
+#include "DataFormatsEMCAL/TriggerRecord.h"
 
 namespace o2
 {
@@ -49,76 +49,59 @@ class Digitizer : public TObject
   Digitizer& operator=(const Digitizer&) = delete;
 
   void init();
-  void initCycle();
   void clear();
-  void finish();
+
+  /// This is for the readout window that was interrupted by the end of the run
+  void finish() { mDigits.finish(); }
 
   /// Steer conversion of hits to digits
   void process(const std::vector<LabeledDigit>& labeledDigit);
 
-  void setEventTime(double t);
-  double getTriggerTime() const { return mTriggerTime; }
-  double getEventTime() const { return mEventTime; }
-  bool isLive(double t) const { return ((t - mTriggerTime) < mLiveTime); }
-  bool isLive() const { return (mEventTime < mLiveTime); }
+  void setEventTime(o2::InteractionTimeRecord record);
+  double getTriggerTime() const { return mDigits.getTriggerTime(); }
+  double getEventTime() const { return mDigits.getEventTime(); }
+  bool isLive(double t) const { return mDigits.isLive(t); }
+  bool isLive() const { return mDigits.isLive(); }
 
   void setWindowStartTime(int time) { mTimeWindowStart = time; }
 
   // function returns true if the collision occurs 600ns before the readout window is open
-  // Look here for more details https://alice.its.cern.ch/jira/browse/EMCAL-681
-  bool preTriggerCollision() const { return (mEventTime > (mLiveTime + mBusyTime - mPreTriggerTime)); }
-
-  // function returns true if the collision occurs 900ns after the readout window is open
-  bool afterTriggerCollision() const { return (mEventTime > mAfterTriggerTime && mEventTime < mLiveTime); }
-
-  bool isEmpty() const { return mEmpty; }
+  bool preTriggerCollision() const { return mDigits.preTriggerCollision(); }
 
   void fillOutputContainer(std::vector<Digit>& digits, o2::dataformats::MCTruthContainer<o2::emcal::MCLabel>& labels);
 
   bool doSmearEnergy() const { return mSmearEnergy; }
   double smearEnergy(double energy);
   bool doSimulateTimeResponse() const { return mSimulateTimeResponse; }
-  bool doRemoveDigitsBelowThreshold() const { return mRemoveDigitsBelowThreshold; }
-  bool doSimulateNoiseDigits() const { return mSimulateNoiseDigits; }
-  void addNoiseDigits(LabeledDigit&);
-
-  void setCoeffToNanoSecond(double cf) { mCoeffToNanoSecond = cf; }
-  double getCoeffToNanoSecond() const { return mCoeffToNanoSecond; }
 
   void sampleSDigit(const Digit& sdigit);
 
-  static double rawResponseFunction(double* x, double* par);
   /// raw pointers used here to allow interface with TF1
+  static double rawResponseFunction(double* x, double* par);
+
+  std::vector<o2::emcal::Digit> getDigits() { return mDigits.getDigits(); }
+  std::vector<o2::emcal::TriggerRecord> getTriggerRecords() { return mDigits.getTriggerRecords(); }
+  o2::dataformats::MCTruthContainer<o2::emcal::MCLabel> getMCLabels() { return mDigits.getMCLabels(); }
 
  private:
-  double mTriggerTime = -1e20;             ///< global trigger time
-  double mEventTime = 0;                   ///< global event time
-  short mEventTimeOffset = 0;              ///< event time difference from trigger time (in number of bins)
-  short mPhase = 0;                        ///< event phase
-  double mCoeffToNanoSecond = 1.0;         ///< coefficient to convert event time (Fair) to ns
-  UInt_t mROFrameMin = 0;                  ///< lowest RO frame of current digits
-  UInt_t mROFrameMax = 0;                  ///< highest RO frame of current digits
-  bool mSmearEnergy = true;                ///< do time and energy smearing
-  bool mSimulateTimeResponse = true;       ///< simulate time response
-  bool mRemoveDigitsBelowThreshold = true; ///< remove digits below threshold
-  bool mSimulateNoiseDigits = true;        ///< simulate noise digits
-  const SimParam* mSimParam = nullptr;     ///< SimParam object
-  bool mEmpty = true;                      ///< Digitizer contains no digits/labels
+  short mEventTimeOffset = 0;          ///< event time difference from trigger time (in number of bins)
+  short mPhase = 0;                    ///< event phase
+  UInt_t mROFrameMin = 0;              ///< lowest RO frame of current digits
+  UInt_t mROFrameMax = 0;              ///< highest RO frame of current digits
+  bool mSmearEnergy = true;            ///< do time and energy smearing
+  bool mSimulateTimeResponse = true;   ///< simulate time response
+  const SimParam* mSimParam = nullptr; ///< SimParam object
 
   std::vector<Digit> mTempDigitVector; ///< temporary digit storage
-  std::unordered_map<Int_t, std::list<LabeledDigit>> mDigits; ///< used to sort digits and labels by tower
-  // o2::emcal::DigitsWriteoutBuffer mDigits; ///< used to sort digits and labels by tower
+  // std::unordered_map<Int_t, std::list<LabeledDigit>> mDigits; ///< used to sort digits and labels by tower
+  o2::emcal::DigitsWriteoutBuffer mDigits; ///< used to sort digits and labels by tower
 
-  TRandom3* mRandomGenerator = nullptr;                  // random number generator
-  std::vector<int> mTimeBinOffset;                       // offset of first time bin
-  std::vector<std::vector<double>> mAmplitudeInTimeBins; // amplitude of signal for each time bin
+  TRandom3* mRandomGenerator = nullptr;                  ///< random number generator
+  std::vector<int> mTimeBinOffset;                       ///< offset of first time bin
+  std::vector<std::vector<double>> mAmplitudeInTimeBins; ///< amplitude of signal for each time bin
 
-  float mLiveTime = 1500;        // EMCal live time (ns)
-  float mBusyTime = 35000;       // EMCal busy time (ns)
-  float mAfterTriggerTime = 900; // The time (ns) after the readout window is open in which collisions that occurs will be discarded
-  float mPreTriggerTime = 600;   // The time (ns) before the readout window is open in which collisions that occurs before the readout window is open and make hits during the live time
-  int mTimeWindowStart = 4;      // The start of the time window
-  int mDelay = 7;                // number of (full) time bins corresponding to the signal time delay
+  int mTimeWindowStart = 7; ///< The start of the time window
+  int mDelay = 7;           ///< number of (full) time bins corresponding to the signal time delay
 
   ClassDefOverride(Digitizer, 1);
 };

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/Digitizer.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/Digitizer.h
@@ -97,7 +97,6 @@ class Digitizer : public TObject
   o2::emcal::DigitsWriteoutBuffer mDigits; ///< used to sort digits and labels by tower
 
   TRandom3* mRandomGenerator = nullptr;                  ///< random number generator
-  std::vector<int> mTimeBinOffset;                       ///< offset of first time bin
   std::vector<std::vector<double>> mAmplitudeInTimeBins; ///< amplitude of signal for each time bin
 
   int mTimeWindowStart = 7; ///< The start of the time window

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/DigitsVectorStream.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/DigitsVectorStream.h
@@ -17,6 +17,7 @@
 #include <vector>
 #include <deque>
 #include <list>
+#include <optional>
 #include <gsl/span>
 #include "TRandom3.h"
 #include "DataFormatsEMCAL/Digit.h"
@@ -38,11 +39,10 @@ namespace emcal
 /// \date 16/02/2022
 
 struct DigitTimebin {
-  unsigned long mTimestamp = 0;
   bool mRecordMode = false;
   bool mEndWindow = false;
   bool mTriggerColl = false;
-  o2::InteractionRecord mInterRecord;
+  std::optional<o2::InteractionRecord> mInterRecord;
   std::shared_ptr<std::unordered_map<int, std::list<LabeledDigit>>> mDigitMap = std::make_shared<std::unordered_map<int, std::list<LabeledDigit>>>();
 };
 
@@ -90,12 +90,6 @@ class DigitsVectorStream
 
   const SimParam* mSimParam = nullptr;  ///< SimParam object
   TRandom3* mRandomGenerator = nullptr; ///< random number generator
-
-  unsigned int mLiveTime = 1500;       ///< EMCal live time (ns)
-  unsigned int mBusyTime = 35000;      ///< EMCal busy time (ns)
-  unsigned int mPreTriggerTime = 600;  ///< EMCal pre-trigger time (ns)
-  unsigned int mTimeWindowStart = 700; ///< The start of the time window (ns)
-  unsigned int mDelay = 700;           ///< Signal delay time (ns)
 
   ClassDefNV(DigitsVectorStream, 1);
 };

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/DigitsVectorStream.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/DigitsVectorStream.h
@@ -1,0 +1,107 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_EMCAL_DIGITSVECTORSTREAM_H_
+#define ALICEO2_EMCAL_DIGITSVECTORSTREAM_H_
+
+#include <memory>
+#include <unordered_map>
+#include <vector>
+#include <deque>
+#include <list>
+#include <gsl/span>
+#include "TRandom3.h"
+#include "DataFormatsEMCAL/Digit.h"
+#include "EMCALSimulation/LabeledDigit.h"
+#include "DataFormatsEMCAL/TriggerRecord.h"
+#include "SimulationDataFormat/MCTruthContainer.h"
+#include "EMCALSimulation/SimParam.h"
+
+namespace o2
+{
+namespace emcal
+{
+
+/// \class DigitsVectorStream
+/// \brief Container class for Digits, MC lebels, and trigger records
+/// \ingroup EMCALsimulation
+/// \author Hadi Hassan, ORNL
+/// \author Markus Fasel, ORNL
+/// \date 16/02/2022
+
+struct DigitTimebin {
+  unsigned long mTimestamp = 0;
+  bool mRecordMode = false;
+  bool mEndWindow = false;
+  bool mTriggerColl = false;
+  o2::InteractionRecord mInterRecord;
+  std::shared_ptr<std::unordered_map<int, std::list<LabeledDigit>>> mDigitMap = std::make_shared<std::unordered_map<int, std::list<LabeledDigit>>>();
+};
+
+class DigitsVectorStream
+{
+
+ public:
+  /// Default constructor
+  DigitsVectorStream() = default;
+
+  /// Destructor
+  ~DigitsVectorStream() = default;
+
+  /// clear the container
+  void clear();
+
+  /// Initialize the streamer
+  void init();
+
+  /// Fill all the containers, digits, labels, and trigger records
+  void fill(gsl::span<o2::emcal::DigitTimebin> digitlist, o2::InteractionRecord record);
+
+  /// Getters for the finals data vectors, digits vector, labels vector, and trigger records vector
+  std::vector<o2::emcal::Digit> getDigits() { return mDigits; }
+  std::vector<o2::emcal::TriggerRecord> getTriggerRecords() { return mTriggerRecords; }
+  o2::dataformats::MCTruthContainer<o2::emcal::MCLabel> getMCLabels() { return mLabels; }
+
+  /// Flag whether to simulate noise to the digits
+  void doSimulateNoiseDigits(bool doNoise = true) { mSimulateNoiseDigits = doNoise; }
+  /// Add noise to this digit
+  void addNoiseDigits(LabeledDigit& d1);
+
+  /// Remove digits below the threshold
+  void doRemoveDigitsBelowThreshold(bool doThreshold = true) { mRemoveDigitsBelowThreshold = doThreshold; }
+
+ private:
+  unsigned int mStartIndex = 0; ///< Start index for the digits in the trigger recod for every readout window
+
+  std::vector<o2::emcal::Digit> mDigits;                         ///< Output vector for the digits
+  o2::dataformats::MCTruthContainer<o2::emcal::MCLabel> mLabels; ///< Output vector for the MC labels
+  std::vector<o2::emcal::TriggerRecord> mTriggerRecords;         ///< Output vector for the trigger records
+
+  bool mSimulateNoiseDigits = true;        ///< simulate noise digits
+  bool mRemoveDigitsBelowThreshold = true; ///< remove digits below threshold
+
+  const SimParam* mSimParam = nullptr;  ///< SimParam object
+  TRandom3* mRandomGenerator = nullptr; ///< random number generator
+
+  unsigned int mLiveTime = 1500;       ///< EMCal live time (ns)
+  unsigned int mBusyTime = 35000;      ///< EMCal busy time (ns)
+  unsigned int mPreTriggerTime = 600;  ///< EMCal pre-trigger time (ns)
+  unsigned int mTimeWindowStart = 700; ///< The start of the time window (ns)
+  unsigned int mDelay = 700;           ///< Signal delay time (ns)
+
+  ClassDefNV(DigitsVectorStream, 1);
+};
+
+} // namespace emcal
+
+} // namespace o2
+
+#endif /* ALICEO2_EMCAL_DIGITSVECTORSTREAM_H_ */

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/DigitsWriteoutBuffer.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/DigitsWriteoutBuffer.h
@@ -19,7 +19,9 @@
 #include <list>
 #include <gsl/span>
 #include "DataFormatsEMCAL/Digit.h"
+#include "CommonDataFormat/InteractionRecord.h"
 #include "EMCALSimulation/LabeledDigit.h"
+#include "EMCALSimulation/DigitsVectorStream.h"
 
 namespace o2
 {
@@ -37,36 +39,70 @@ class DigitsWriteoutBuffer
 {
  public:
   /// Default constructor
-  DigitsWriteoutBuffer(unsigned int nTimeBins = 30, unsigned int binWidth = 100);
+  DigitsWriteoutBuffer(unsigned int nTimeBins = 15);
 
   /// Destructor
   ~DigitsWriteoutBuffer() = default;
 
   /// clear the container
   void clear();
+
+  void init();
+
+  /// Reserve space for the future container
   void reserve();
+
+  /// This is for the readout window that was interrupted by the end of the run
+  void finish();
+
+  double getTriggerTime() const { return mTriggerTime; }
+  double getEventTime() const { return mLastEventTime; }
+  bool isLive(double t) const { return ((t - mTriggerTime) < mLiveTime || (t - mTriggerTime) >= (mLiveTime + mBusyTime - mPreTriggerTime)); }
+  bool isLive() const { return ((mLastEventTime - mTriggerTime) < mLiveTime || (mLastEventTime - mTriggerTime) >= (mLiveTime + mBusyTime - mPreTriggerTime)); }
+
+  // function returns true if the collision occurs 600ns before the readout window is open
+  // Look here for more details https://alice.its.cern.ch/jira/browse/EMCAL-681
+  bool preTriggerCollision() const { return ((mLastEventTime - mTriggerTime) >= (mLiveTime + mBusyTime - mPreTriggerTime)); }
 
   /// Add digit to the container
   /// \param towerID Cell ID
   /// \param dig Labaled digit to add
   /// \param eventTime The time of the event (w.r.t Tigger time)
-  void addDigit(unsigned int towerID, LabeledDigit dig, double eventTime);
+  void addDigits(unsigned int towerID, std::vector<LabeledDigit> digList);
 
-  /// Getter for the last N entries (time samples) in the ring buffer
-  /// \param nsample number of entries to be written
+  /// Getter for the last time samples in the ring buffer
   /// \return List of map of cell IDs and labeled digits in that cell
-  std::list<std::unordered_map<int, std::list<LabeledDigit>>> getLastNSamples(int nsample = 15);
+  gsl::span<o2::emcal::DigitTimebin> getLastSamples();
 
-  void setNumberReadoutSamples(unsigned int nsamples) { mNumberReadoutSamples = nsamples; }
+  /// Setting the buffer size
+  void setBufferSize(unsigned int nsamples) { mBufferSize = nsamples; }
 
-  std::deque<std::unordered_map<int, std::list<LabeledDigit>>> getTheWholeSample() { return mTimedDigits; }
+  /// forward the marker for every 100 ns
+  void forwardMarker(o2::InteractionTimeRecord record);
+
+  /// Setters for the live time, busy time, pre-trigger time
+  void setLiveTime(unsigned int liveTime) { mLiveTime = liveTime; }
+  void setBusyTime(unsigned int busyTime) { mBusyTime = busyTime; }
+  void setPreTriggerTime(unsigned int pretriggerTime) { mPreTriggerTime = pretriggerTime; }
+
+  unsigned int getPhase() { return mPhase; }
+
+  std::vector<o2::emcal::Digit> getDigits() { return mDigitStream.getDigits(); }
+  std::vector<o2::emcal::TriggerRecord> getTriggerRecords() { return mDigitStream.getTriggerRecords(); }
+  o2::dataformats::MCTruthContainer<o2::emcal::MCLabel> getMCLabels() { return mDigitStream.getMCLabels(); }
 
  private:
-  unsigned int mBufferSize = 30;                                             ///< The size of the buffer, it has to be at least 2 times the size of the readout cycle
-  unsigned int mTimeBinWidth = 100;                                          ///< The size of the time bin (ns)
-  unsigned int mNumberReadoutSamples = 15;                                   ///< The number of smaples in a readout window
-  double mLastEventTime = 1500;                                              ///< The event time of last collisions in the readout window
-  std::deque<std::unordered_map<int, std::list<LabeledDigit>>> mTimedDigits; ///< Container for time sampled digits per tower ID
+  unsigned int mBufferSize = 15;                          ///< The size of the buffer
+  unsigned int mLiveTime = 1500;                          ///< EMCal live time (ns)
+  unsigned int mBusyTime = 35000;                         ///< EMCal busy time (ns)
+  unsigned int mPreTriggerTime = 600;                     ///< EMCal pre-trigger time (ns)
+  unsigned long mTriggerTime = 600;                       ///< Time of the collision that fired the trigger (ns)
+  unsigned long mLastEventTime = 1500;                    ///< The event time of last collisions in the readout window
+  unsigned int mPhase = 0;                                ///< The event L1 phase
+  std::deque<o2::emcal::DigitTimebin> mTimedDigitsFuture; ///< Container for time sampled digits per tower ID for future digits
+  std::deque<o2::emcal::DigitTimebin> mTimedDigitsPast;   ///< Container for time sampled digits per tower ID for past digits
+
+  o2::emcal::DigitsVectorStream mDigitStream; ///< Output vector streamer
 
   ClassDefNV(DigitsWriteoutBuffer, 1);
 };

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/DigitsWriteoutBuffer.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/DigitsWriteoutBuffer.h
@@ -76,6 +76,7 @@ class DigitsWriteoutBuffer
 
   /// Setting the buffer size
   void setBufferSize(unsigned int nsamples) { mBufferSize = nsamples; }
+  unsigned int getBufferSize() const { return mBufferSize; }
 
   /// forward the marker for every 100 ns
   void forwardMarker(o2::InteractionTimeRecord record);
@@ -85,7 +86,7 @@ class DigitsWriteoutBuffer
   void setBusyTime(unsigned int busyTime) { mBusyTime = busyTime; }
   void setPreTriggerTime(unsigned int pretriggerTime) { mPreTriggerTime = pretriggerTime; }
 
-  unsigned int getPhase() { return mPhase; }
+  unsigned int getPhase() const { return mPhase; }
 
   std::vector<o2::emcal::Digit> getDigits() { return mDigitStream.getDigits(); }
   std::vector<o2::emcal::TriggerRecord> getTriggerRecords() { return mDigitStream.getTriggerRecords(); }
@@ -96,9 +97,10 @@ class DigitsWriteoutBuffer
   unsigned int mLiveTime = 1500;                          ///< EMCal live time (ns)
   unsigned int mBusyTime = 35000;                         ///< EMCal busy time (ns)
   unsigned int mPreTriggerTime = 600;                     ///< EMCal pre-trigger time (ns)
-  unsigned long mTriggerTime = 600;                       ///< Time of the collision that fired the trigger (ns)
-  unsigned long mLastEventTime = 1500;                    ///< The event time of last collisions in the readout window
+  unsigned long mTriggerTime = 0;                         ///< Time of the collision that fired the trigger (ns)
+  unsigned long mLastEventTime = 0;                       ///< The event time of last collisions in the readout window
   unsigned int mPhase = 0;                                ///< The event L1 phase
+  bool mFirstEvent = true;                                ///< Flag to the first event in the run
   std::deque<o2::emcal::DigitTimebin> mTimedDigitsFuture; ///< Container for time sampled digits per tower ID for future digits
   std::deque<o2::emcal::DigitTimebin> mTimedDigitsPast;   ///< Container for time sampled digits per tower ID for past digits
 

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/SimParam.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/SimParam.h
@@ -52,8 +52,10 @@ class SimParam : public o2::conf::ConfigurableParamHelper<SimParam>
   Float_t getECPrimaryThreshold() const { return mECPrimThreshold; }
 
   Float_t getSignalDelay() const { return mSignalDelay; }
+  unsigned int getTimeBinOffset() const { return mTimeWindowStart; }
   Float_t getLiveTime() const { return mLiveTime; }
   Float_t getBusyTime() const { return mBusyTime; }
+  Float_t getPreTriggerTime() const { return mPreTriggerTime; }
 
   Bool_t doSmearEnergy() const { return mSmearEnergy; }
   Bool_t doSimulateTimeResponse() const { return mSimulateTimeResponse; }
@@ -65,7 +67,6 @@ class SimParam : public o2::conf::ConfigurableParamHelper<SimParam>
   void PrintStream(std::ostream& stream) const;
 
  private:
-
   // Digitizer
   Int_t mDigitThreshold{3};              ///< Threshold for storing digits in EMC
   Int_t mMeanPhotonElectron{4400};       ///< number of photon electrons per GeV deposited energy
@@ -88,11 +89,13 @@ class SimParam : public o2::conf::ConfigurableParamHelper<SimParam>
   Float_t mECPrimThreshold{0.05}; ///< To store primary if EC Shower Elos > threshold
 
   // Timing
-  Float_t mSignalDelay{700}; ///< Signal delay time (ns)
-  Float_t mLiveTime{1500};   ///< EMCal live time (ns)
-  Float_t mBusyTime{35000};  ///< EMCal busy time (ns)
+  Float_t mSignalDelay{700};          ///< Signal delay time (ns)
+  unsigned int mTimeWindowStart{700}; ///< The start of the time window
+  Float_t mLiveTime{1500};            ///< EMCal live time (ns)
+  Float_t mBusyTime{35000};           ///< EMCal busy time (ns)
+  Float_t mPreTriggerTime{600};       ///< EMCal pre-trigger time (ns)
 
-  //Processing
+  // Processing
   Bool_t mSmearEnergy{true};                ///< do time and energy smearing
   Bool_t mSimulateTimeResponse{true};       ///< simulate time response
   Bool_t mRemoveDigitsBelowThreshold{true}; ///< remove digits below threshold

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/SimParam.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/SimParam.h
@@ -90,7 +90,7 @@ class SimParam : public o2::conf::ConfigurableParamHelper<SimParam>
 
   // Timing
   Float_t mSignalDelay{700};          ///< Signal delay time (ns)
-  unsigned int mTimeWindowStart{700}; ///< The start of the time window
+  unsigned int mTimeWindowStart{400}; ///< The start of the time window
   Float_t mLiveTime{1500};            ///< EMCal live time (ns)
   Float_t mBusyTime{35000};           ///< EMCal busy time (ns)
   Float_t mPreTriggerTime{600};       ///< EMCal pre-trigger time (ns)

--- a/Detectors/EMCAL/simulation/src/Digitizer.cxx
+++ b/Detectors/EMCAL/simulation/src/Digitizer.cxx
@@ -23,6 +23,7 @@
 #include <TRandom.h>
 #include <TF1.h>
 #include "FairLogger.h" // for LOG
+#include "CommonDataFormat/InteractionRecord.h"
 
 ClassImp(o2::emcal::Digitizer);
 
@@ -35,19 +36,18 @@ using namespace o2::emcal;
 void Digitizer::init()
 {
   mSimParam = &(o2::emcal::SimParam::Instance());
-  mLiveTime = mSimParam->getLiveTime();
-  mBusyTime = mSimParam->getBusyTime();
   mRandomGenerator = new TRandom3(std::chrono::high_resolution_clock::now().time_since_epoch().count());
 
   float tau = mSimParam->getTimeResponseTau();
   float N = mSimParam->getTimeResponsePower();
   float delay = std::fmod(mSimParam->getSignalDelay() / constants::EMCAL_TIMESAMPLE, 1);
   mDelay = ((int)(std::floor(mSimParam->getSignalDelay() / constants::EMCAL_TIMESAMPLE)));
+  mTimeWindowStart = ((unsigned int)(std::floor(mSimParam->getTimeBinOffset() / constants::EMCAL_TIMESAMPLE)));
 
   mSmearEnergy = mSimParam->doSmearEnergy();
   mSimulateTimeResponse = mSimParam->doSimulateTimeResponse();
-  mRemoveDigitsBelowThreshold = mSimParam->doRemoveDigitsBelowThreshold();
-  mSimulateNoiseDigits = mSimParam->doSimulateNoiseDigits();
+
+  mDigits.init();
 
   mTimeBinOffset.clear();
   mAmplitudeInTimeBins.clear();
@@ -91,31 +91,26 @@ double Digitizer::rawResponseFunction(double* x, double* par)
 }
 
 //_______________________________________________________________________
-void Digitizer::finish() {}
-
-//_______________________________________________________________________
-void Digitizer::initCycle()
-{
-  mEmpty = false;
-}
-
-//_______________________________________________________________________
 void Digitizer::clear()
 {
-  mTriggerTime = -1e20;
   mDigits.clear();
-  mEmpty = true;
 }
 
 //_______________________________________________________________________
 void Digitizer::process(const std::vector<LabeledDigit>& labeledSDigits)
 {
 
-  //mDigits.reserve();
-
   for (auto labeleddigit : labeledSDigits) {
 
+    int tower = labeleddigit.getTower();
+
     sampleSDigit(labeleddigit.getDigit());
+
+    if (mTempDigitVector.size() == 0) {
+      continue;
+    }
+
+    std::vector<LabeledDigit> listofLabeledDigit;
 
     for (auto digit : mTempDigitVector) {
       Int_t id = digit.getTower();
@@ -131,11 +126,10 @@ void Digitizer::process(const std::vector<LabeledDigit>& labeledSDigits)
         }
         d.addLabel(label);
       }
-      mDigits[id].push_back(d);
+      listofLabeledDigit.push_back(d);
     }
+    mDigits.addDigits(tower, listofLabeledDigit);
   }
-
-  mEmpty = false;
 }
 
 //_______________________________________________________________________
@@ -155,18 +149,15 @@ void Digitizer::sampleSDigit(const Digit& sDigit)
 
   if (mSimulateTimeResponse) {
     for (int j = 0; j < mAmplitudeInTimeBins.at(mPhase).size(); j++) {
-      double val = energy * (mAmplitudeInTimeBins.at(mPhase).at(j));
 
+      double val = energy * (mAmplitudeInTimeBins.at(mPhase).at(j));
       double digitTime = (mEventTimeOffset + j - mTimeBinOffset.at(mPhase) + mDelay - mTimeWindowStart) * constants::EMCAL_TIMESAMPLE;
-      if (preTriggerCollision() && digitTime >= (mLiveTime + mBusyTime)) {
-        digitTime = digitTime - (mLiveTime + mBusyTime);
-      }
 
       Digit digit(tower, val, digitTime);
       mTempDigitVector.push_back(digit);
     }
   } else {
-    Digit digit(tower, energy, mEventTime + mDelay * constants::EMCAL_TIMESAMPLE);
+    Digit digit(tower, energy, (mDelay - mTimeWindowStart) * constants::EMCAL_TIMESAMPLE);
     mTempDigitVector.push_back(digit);
   }
 }
@@ -180,113 +171,17 @@ double Digitizer::smearEnergy(double energy)
 }
 
 //_______________________________________________________________________
-void Digitizer::setEventTime(double t)
+void Digitizer::setEventTime(o2::InteractionTimeRecord record)
 {
-  // assign event time, it should be in a strictly increasing order
-  // convert to ns
-  t *= mCoeffToNanoSecond;
 
-  if (t < mEventTime) {
-    LOG(fatal) << "New event time (" << t << ") is < previous event time (" << mEventTime << ")";
-  }
+  mDigits.forwardMarker(record);
 
-  if ((t - mTriggerTime) >= (mLiveTime + mBusyTime)) {
-    mTriggerTime = t;
-  }
+  mPhase = mDigits.getPhase();
 
-  mEventTime = t - mTriggerTime;
-
-  mPhase = ((int)(std::fmod(mEventTime, 100) / 25));
-
-  mEventTimeOffset = ((int)((mEventTime - std::fmod(mEventTime, 100) + 0.1) / 100));
-
-  if (preTriggerCollision()) {
-    mEventTimeOffset = ((int)((mEventTime - std::fmod(mEventTime, 100) + 0.1) / 100)) - (mLiveTime + mBusyTime - mPreTriggerTime) / 100 + mAfterTriggerTime / 100;
-  }
+  mEventTimeOffset = 0;
 
   if (mPhase == 4) {
     mPhase = 0;
     mEventTimeOffset++;
   }
-}
-
-//_______________________________________________________________________
-void Digitizer::addNoiseDigits(LabeledDigit& d1)
-{
-  double amplitude = d1.getAmplitude();
-  double sigma = mSimParam->getPinNoise();
-  if (amplitude > constants::EMCAL_HGLGTRANSITION * constants::EMCAL_ADCENERGY) {
-    sigma = mSimParam->getPinNoiseLG();
-  }
-
-  double noise = std::abs(mRandomGenerator->Gaus(0, sigma));
-  MCLabel label(true, 1.0);
-  LabeledDigit d(d1.getTower(), noise, d1.getTimeStamp(), label);
-  d1 += d;
-}
-
-//_______________________________________________________________________
-void Digitizer::fillOutputContainer(std::vector<Digit>& digits, o2::dataformats::MCTruthContainer<o2::emcal::MCLabel>& labelsout)
-{
-  std::list<LabeledDigit> l;
-
-  for (auto [tower, digitsList] : mDigits) {
-
-    if (digitsList.size() == 0) {
-      continue;
-    }
-    digitsList.sort();
-
-    for (auto& ld : digitsList) {
-
-      // Loop over all digits in the time sample and sum the digits that falls in one time bin
-      for (auto ld1 = digitsList.begin(); ld1 != digitsList.end(); ++ld1) {
-
-        if (ld == *ld1) {
-          continue;
-        }
-
-        std::vector<decltype(digitsList.begin())> toDelete;
-
-        if (ld.canAdd(*ld1)) {
-          ld += *ld1;
-          toDelete.push_back(ld1);
-        }
-        for (auto del : toDelete) {
-          digitsList.erase(del);
-        }
-      }
-
-      if (mSimulateNoiseDigits) {
-        addNoiseDigits(ld);
-      }
-
-      if (mRemoveDigitsBelowThreshold && (ld.getAmplitude() < (mSimParam->getDigitThreshold() * constants::EMCAL_ADCENERGY))) {
-        continue;
-      }
-      if (ld.getAmplitude() < 0) {
-        continue;
-      }
-      if ((ld.getTimeStamp() >= mSimParam->getLiveTime()) || (ld.getTimeStamp() < 0)) {
-        continue;
-      }
-
-      l.push_back(ld);
-    }
-  }
-  l.sort();
-
-  for (auto d : l) {
-    Digit digit = d.getDigit();
-    std::vector<MCLabel> labels = d.getLabels();
-    digits.push_back(digit);
-
-    Int_t LabelIndex = labelsout.getIndexedSize();
-    for (auto label : labels) {
-      labelsout.addElementRandomAccess(LabelIndex, label);
-    }
-  }
-
-  mDigits.clear();
-  mEmpty = true;
 }

--- a/Detectors/EMCAL/simulation/src/Digitizer.cxx
+++ b/Detectors/EMCAL/simulation/src/Digitizer.cxx
@@ -48,8 +48,11 @@ void Digitizer::init()
   mSimulateTimeResponse = mSimParam->doSimulateTimeResponse();
 
   mDigits.init();
+  if ((mDelay - mTimeWindowStart) != 0) {
+    mDigits.setBufferSize(mDigits.getBufferSize() + (mDelay - mTimeWindowStart));
+    mDigits.reserve();
+  }
 
-  mTimeBinOffset.clear();
   mAmplitudeInTimeBins.clear();
 
   // for each phase create a template distribution
@@ -57,8 +60,6 @@ void Digitizer::init()
   RawResponse.SetParameters(1., 0., tau, N, 0.);
 
   for (int i = 0; i < 4; i++) {
-    int offset = 0;
-    mTimeBinOffset.push_back(offset);
 
     std::vector<double> sf;
     RawResponse.SetParameter(1, 0.25 * i);
@@ -151,7 +152,7 @@ void Digitizer::sampleSDigit(const Digit& sDigit)
     for (int j = 0; j < mAmplitudeInTimeBins.at(mPhase).size(); j++) {
 
       double val = energy * (mAmplitudeInTimeBins.at(mPhase).at(j));
-      double digitTime = (mEventTimeOffset + j - mTimeBinOffset.at(mPhase) + mDelay - mTimeWindowStart) * constants::EMCAL_TIMESAMPLE;
+      double digitTime = (mEventTimeOffset + mDelay - mTimeWindowStart) * constants::EMCAL_TIMESAMPLE;
 
       Digit digit(tower, val, digitTime);
       mTempDigitVector.push_back(digit);

--- a/Detectors/EMCAL/simulation/src/DigitsVectorStream.cxx
+++ b/Detectors/EMCAL/simulation/src/DigitsVectorStream.cxx
@@ -1,0 +1,151 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <unordered_map>
+#include <vector>
+#include <list>
+#include <deque>
+#include <iostream>
+#include <gsl/span>
+#include "FairLogger.h"
+#include "EMCALSimulation/LabeledDigit.h"
+#include "EMCALSimulation/DigitsVectorStream.h"
+#include "CommonConstants/Triggers.h"
+
+using namespace o2::emcal;
+
+void DigitsVectorStream::init()
+{
+  mSimParam = &(o2::emcal::SimParam::Instance());
+
+  mLiveTime = mSimParam->getLiveTime();
+  mBusyTime = mSimParam->getBusyTime();
+  mPreTriggerTime = mSimParam->getPreTriggerTime();
+
+  mRandomGenerator = new TRandom3(std::chrono::high_resolution_clock::now().time_since_epoch().count());
+
+  mRemoveDigitsBelowThreshold = mSimParam->doRemoveDigitsBelowThreshold();
+  mSimulateNoiseDigits = mSimParam->doSimulateNoiseDigits();
+
+  mDelay = (unsigned int)mSimParam->getSignalDelay();
+  mTimeWindowStart = (unsigned int)mSimParam->getTimeBinOffset();
+}
+
+//_______________________________________________________________________
+void DigitsVectorStream::addNoiseDigits(LabeledDigit& d1)
+{
+  double amplitude = d1.getAmplitude();
+  double sigma = mSimParam->getPinNoise();
+  if (amplitude > constants::EMCAL_HGLGTRANSITION * constants::EMCAL_ADCENERGY) {
+    sigma = mSimParam->getPinNoiseLG();
+  }
+
+  double noise = std::abs(mRandomGenerator->Gaus(0, sigma));
+  MCLabel label(true, 1.0);
+  LabeledDigit d(d1.getTower(), noise, d1.getTimeStamp(), label);
+  d1 += d;
+}
+
+//_______________________________________________________________________
+void DigitsVectorStream::fill(gsl::span<o2::emcal::DigitTimebin> digitlist, o2::InteractionRecord record)
+{
+  std::map<unsigned int, std::list<LabeledDigit>> outputList;
+
+  o2::emcal::DigitTimebin triggerNode;
+  for (auto& digitTimebin : digitlist) {
+    if (digitTimebin.mTriggerColl) {
+      triggerNode = digitTimebin;
+      break;
+    }
+  }
+
+  for (auto& digitsTimeBin : digitlist) {
+
+    for (auto& [tower, digitsList] : *digitsTimeBin.mDigitMap) {
+
+      if (digitsList.size() == 0) {
+        continue;
+      }
+      digitsList.sort();
+
+      for (auto& ld : digitsList) {
+
+        /// This is to reset the time of the pre-trigger digits
+        if (ld.getTimeStamp() >= (mLiveTime + mBusyTime - mPreTriggerTime)) {
+          ld.setTimeStamp(digitsTimeBin.mTimestamp - triggerNode.mTimestamp + mDelay - mTimeWindowStart);
+        }
+
+        // Loop over all digits in the time sample and sum the digits that belongs to the same tower and falls in one time bin
+        for (auto ld1 = digitsList.begin(); ld1 != digitsList.end(); ++ld1) {
+
+          if (ld == *ld1) {
+            continue;
+          }
+
+          std::vector<decltype(digitsList.begin())> toDelete;
+
+          if (ld.canAdd(*ld1)) {
+            ld += *ld1;
+            toDelete.push_back(ld1);
+          }
+          for (auto del : toDelete) {
+            digitsList.erase(del);
+          }
+        }
+
+        if (mSimulateNoiseDigits) {
+          addNoiseDigits(ld);
+        }
+
+        if (mRemoveDigitsBelowThreshold && (ld.getAmplitude() < (mSimParam->getDigitThreshold() * constants::EMCAL_ADCENERGY))) {
+          continue;
+        }
+        if (ld.getAmplitude() < 0) {
+          continue;
+        }
+        if ((ld.getTimeStamp() >= mSimParam->getLiveTime()) || (ld.getTimeStamp() < 0)) {
+          continue;
+        }
+
+        outputList[tower].push_back(ld);
+      }
+    }
+  }
+
+  for (auto [tower, outdiglist] : outputList) {
+    for (auto d : outdiglist) {
+      outdiglist.sort();
+
+      Digit digit = d.getDigit();
+      std::vector<MCLabel> labels = d.getLabels();
+      mDigits.push_back(digit);
+
+      Int_t LabelIndex = mLabels.getIndexedSize();
+      for (auto label : labels) {
+        mLabels.addElementRandomAccess(LabelIndex, label);
+      }
+    }
+  }
+
+  mTriggerRecords.emplace_back(record, o2::trigger::PhT, mStartIndex, mDigits.size());
+  mStartIndex = mDigits.size();
+
+  LOG(info) << "Have " << mStartIndex << " digits ";
+}
+
+//_______________________________________________________________________
+void DigitsVectorStream::clear()
+{
+  mDigits.clear();
+  mLabels.clear();
+  mTriggerRecords.clear();
+  mStartIndex = 0;
+}

--- a/Detectors/EMCAL/simulation/src/DigitsWriteoutBuffer.cxx
+++ b/Detectors/EMCAL/simulation/src/DigitsWriteoutBuffer.cxx
@@ -42,13 +42,11 @@ void DigitsWriteoutBuffer::init()
 
 void DigitsWriteoutBuffer::clear()
 {
-  for (auto iNode : mTimedDigitsFuture) {
-    iNode.mTimestamp = 0;
+  for (auto& iNode : mTimedDigitsFuture) {
     iNode.mRecordMode = false;
     iNode.mEndWindow = false;
     iNode.mDigitMap->clear();
   }
-
   mTimedDigitsPast.clear();
 }
 
@@ -66,16 +64,14 @@ void DigitsWriteoutBuffer::reserve()
 void DigitsWriteoutBuffer::addDigits(unsigned int towerID, std::vector<LabeledDigit> digList)
 {
 
-  for (int ientry = 0; ientry < mBufferSize; ientry++) {
-
+  for (int ientry = 0; ientry < digList.size(); ientry++) {
     auto& buffEntry = mTimedDigitsFuture[ientry];
-    auto dig = digList.at(ientry);
+    auto& dig = digList.at(ientry);
 
     auto towerEntry = buffEntry.mDigitMap->find(towerID);
     if (towerEntry == buffEntry.mDigitMap->end()) {
       towerEntry = buffEntry.mDigitMap->insert(std::pair<int, std::list<o2::emcal::LabeledDigit>>(towerID, std::list<o2::emcal::LabeledDigit>())).first;
     }
-    dig.setTimeStamp(dig.getTimeStamp() + ((mLastEventTime - mTriggerTime) / 100) * 100);
     towerEntry->second.push_back(dig);
   }
 }
@@ -111,39 +107,57 @@ void DigitsWriteoutBuffer::forwardMarker(o2::InteractionTimeRecord record)
 
     // If it is the end of the readout window write all the digits, labels, and trigger record into the streamer
     if (mTimedDigitsPast.back().mEndWindow) {
-      mDigitStream.fill(getLastSamples(), mTimedDigitsPast.front().mInterRecord);
+
+      // Find the trigger time bin
+      o2::emcal::DigitTimebin triggerNode;
+      for (auto& digitTimebin : mTimedDigitsPast) {
+        if (digitTimebin.mTriggerColl) {
+          triggerNode = digitTimebin;
+          break;
+        }
+      }
+      mDigitStream.fill(getLastSamples(), triggerNode.mInterRecord.value());
       clear();
     }
   }
 
   // If we have a trigger, all the time bins in the future buffer will be set to record mode
   // the last time bin will the end of the readout window since it will be mTriggerTime + 1500 ns
-  if ((eventTime - mTriggerTime) >= (mLiveTime + mBusyTime)) {
+  if ((eventTime - mTriggerTime) >= (mLiveTime + mBusyTime) || mFirstEvent) {
     mTriggerTime = eventTime;
     mTimedDigitsFuture.front().mTriggerColl = true;
     mTimedDigitsFuture.front().mInterRecord = record;
-    mTimedDigitsFuture.back().mEndWindow = true;
+    mTimedDigitsFuture[(mLiveTime / 100) - 1].mEndWindow = true;
 
-    unsigned long timeStamp = int(eventTime / 100) * 100; /// This is to make the event time multiple of 100s
+    long timeStamp = (eventTime / 100) * 100; /// This is to make the event time multiple of 100s
     for (auto& iNode : mTimedDigitsFuture) {
+      long diff = (timeStamp - eventTime);
+      if (TMath::Abs(diff) > mLiveTime) {
+        break;
+      }
       iNode.mRecordMode = true;
-      iNode.mTimestamp = timeStamp;
       timeStamp += 100;
     }
   }
 
   // If we have a pre-trigger collision, all the time bins in the future buffer will be set to record mode
   if ((eventTime - mTriggerTime) >= (mLiveTime + mBusyTime - mPreTriggerTime)) {
-    unsigned long timeStamp = int(eventTime / 100) * 100; /// This is to make the event time multiple of 100s
+    long timeStamp = (eventTime / 100) * 100; /// This is to make the event time multiple of 100s
     for (auto& iNode : mTimedDigitsFuture) {
+      long diff = (timeStamp - eventTime);
+      if (TMath::Abs(diff) > mLiveTime) {
+        break;
+      }
       iNode.mRecordMode = true;
-      iNode.mTimestamp = timeStamp;
       timeStamp += 100;
     }
   }
 
   mLastEventTime = eventTime;
   mPhase = ((int)(std::fmod(mLastEventTime, 100) / 25));
+  if (mFirstEvent) {
+    mFirstEvent = false;
+  }
 }
 
 /// For the end of the run only write all the remaining digits into the streamer
@@ -163,7 +177,17 @@ void DigitsWriteoutBuffer::finish()
     }
 
     if (mTimedDigitsPast.back().mEndWindow) {
-      mDigitStream.fill(getLastSamples(), mTimedDigitsPast.front().mInterRecord);
+
+      // Find the trigger time bin
+      o2::emcal::DigitTimebin triggerNode;
+      for (auto& digitTimebin : mTimedDigitsPast) {
+        if (digitTimebin.mTriggerColl) {
+          triggerNode = digitTimebin;
+          break;
+        }
+      }
+
+      mDigitStream.fill(getLastSamples(), triggerNode.mInterRecord.value());
       clear();
       break;
     }
@@ -172,5 +196,20 @@ void DigitsWriteoutBuffer::finish()
 
 gsl::span<o2::emcal::DigitTimebin> DigitsWriteoutBuffer::getLastSamples()
 {
+
+  // Setting the digit time
+  // If we have a delay the first digit in the buffer will start from mDelay,
+  // If we also have digits coming from pre-trigger collisions, also their time will start from mDelay,
+  // so, to shift the digits back to zero, their time has to be subtracted by the extra digits (with time [0,mDelay])
+  int timeStamp = mLiveTime - (mTimedDigitsPast.size() * 100);
+  for (auto& buffEntry : mTimedDigitsPast) {
+    for (auto& [tower, digitList] : *buffEntry.mDigitMap) {
+      for (auto& digit : digitList) {
+        digit.setTimeStamp(digit.getTimeStamp() + timeStamp);
+      }
+    }
+    timeStamp += 100;
+  }
+
   return gsl::span<o2::emcal::DigitTimebin>(&mTimedDigitsPast[0], mTimedDigitsPast.size());
 }

--- a/Detectors/EMCAL/simulation/src/DigitsWriteoutBuffer.cxx
+++ b/Detectors/EMCAL/simulation/src/DigitsWriteoutBuffer.cxx
@@ -17,65 +17,160 @@
 #include <gsl/span>
 #include "EMCALSimulation/LabeledDigit.h"
 #include "EMCALSimulation/DigitsWriteoutBuffer.h"
+#include "CommonDataFormat/InteractionRecord.h"
+#include "TMath.h"
 
 using namespace o2::emcal;
 
-DigitsWriteoutBuffer::DigitsWriteoutBuffer(unsigned int nTimeBins, unsigned int binWidth) : mBufferSize(nTimeBins),
-                                                                                            mTimeBinWidth(binWidth)
+DigitsWriteoutBuffer::DigitsWriteoutBuffer(unsigned int nTimeBins) : mBufferSize(nTimeBins)
 {
   for (int itime = 0; itime < nTimeBins; itime++) {
-    mTimedDigits.push_back(std::unordered_map<int, std::list<LabeledDigit>>());
+    mTimedDigitsFuture.push_back(o2::emcal::DigitTimebin());
   }
+}
+
+void DigitsWriteoutBuffer::init()
+{
+  const SimParam* simParam = &(o2::emcal::SimParam::Instance());
+
+  mLiveTime = simParam->getLiveTime();
+  mBusyTime = simParam->getBusyTime();
+  mPreTriggerTime = simParam->getPreTriggerTime();
+
+  mDigitStream.init();
 }
 
 void DigitsWriteoutBuffer::clear()
 {
-  std::cout << "Clearing ..." << std::endl;
-  mTimedDigits.clear();
+  for (auto iNode : mTimedDigitsFuture) {
+    iNode.mTimestamp = 0;
+    iNode.mRecordMode = false;
+    iNode.mEndWindow = false;
+    iNode.mDigitMap->clear();
+  }
+
+  mTimedDigitsPast.clear();
 }
 
 void DigitsWriteoutBuffer::reserve()
 {
-  //Fill in the missing entries
-  for (int itime = 0; itime < (mBufferSize - mTimedDigits.size()); itime++) {
-    mTimedDigits.push_back(std::unordered_map<int, std::list<LabeledDigit>>());
+  if (mTimedDigitsFuture.size() < mBufferSize - 1) {
+    int originalSize = mTimedDigitsFuture.size();
+    for (int itime = 0; itime < (mBufferSize - originalSize); itime++) {
+      mTimedDigitsFuture.push_back(o2::emcal::DigitTimebin());
+    }
   }
 }
 
-void DigitsWriteoutBuffer::addDigit(unsigned int towerID, LabeledDigit dig, double eventTime)
+// Add digits to the buffer
+void DigitsWriteoutBuffer::addDigits(unsigned int towerID, std::vector<LabeledDigit> digList)
 {
-  int nsamples = int(eventTime / mTimeBinWidth);
 
-  if (nsamples >= mTimedDigits.size()) {
-    mTimedDigits.pop_front();
-    mTimedDigits.push_back(std::unordered_map<int, std::list<LabeledDigit>>());
-    nsamples = mTimedDigits.size() - 1;
+  for (int ientry = 0; ientry < mBufferSize; ientry++) {
+
+    auto& buffEntry = mTimedDigitsFuture[ientry];
+    auto dig = digList.at(ientry);
+
+    auto towerEntry = buffEntry.mDigitMap->find(towerID);
+    if (towerEntry == buffEntry.mDigitMap->end()) {
+      towerEntry = buffEntry.mDigitMap->insert(std::pair<int, std::list<o2::emcal::LabeledDigit>>(towerID, std::list<o2::emcal::LabeledDigit>())).first;
+    }
+    dig.setTimeStamp(dig.getTimeStamp() + ((mLastEventTime - mTriggerTime) / 100) * 100);
+    towerEntry->second.push_back(dig);
+  }
+}
+
+// When the current time is forwarded (every 100 ns) the entry 0 of the future dequeue
+// is removed and pushed at the end of the past dequeue. At the same time a new entry in
+// the future dequeue is pushed at the end, and - in case the past dequeue reached 15 entries
+// the first entry of the past dequeue is removed.
+void DigitsWriteoutBuffer::forwardMarker(o2::InteractionTimeRecord record)
+{
+
+  unsigned long eventTime = record.getTimeNS();
+
+  // To see how much the marker will forwarded, or see how much of the future buffer will be written into the past past buffer
+  int sampleDifference = (eventTime - mTriggerTime) / 100 - (mLastEventTime - mTriggerTime) / 100;
+
+  for (int idel = 0; idel < sampleDifference; idel++) {
+
+    // Stop reading if record mode is false to save memory
+    if (!mTimedDigitsFuture.front().mRecordMode) {
+      break;
+    }
+
+    // with sampleDifference, the future buffer will written into the past buffer
+    // the added entries will be removed the future, and the same number will added as empty bins
+    mTimedDigitsPast.push_back(mTimedDigitsFuture.front());
+    mTimedDigitsFuture.pop_front();
+    mTimedDigitsFuture.push_back(o2::emcal::DigitTimebin());
+
+    if (mTimedDigitsPast.size() > mBufferSize) {
+      mTimedDigitsPast.pop_front();
+    }
+
+    // If it is the end of the readout window write all the digits, labels, and trigger record into the streamer
+    if (mTimedDigitsPast.back().mEndWindow) {
+      mDigitStream.fill(getLastSamples(), mTimedDigitsPast.front().mInterRecord);
+      clear();
+    }
   }
 
-  auto& timeEntry = mTimedDigits[nsamples];
+  // If we have a trigger, all the time bins in the future buffer will be set to record mode
+  // the last time bin will the end of the readout window since it will be mTriggerTime + 1500 ns
+  if ((eventTime - mTriggerTime) >= (mLiveTime + mBusyTime)) {
+    mTriggerTime = eventTime;
+    mTimedDigitsFuture.front().mTriggerColl = true;
+    mTimedDigitsFuture.front().mInterRecord = record;
+    mTimedDigitsFuture.back().mEndWindow = true;
 
-  auto towerEntry = timeEntry.find(towerID);
-  if (towerEntry == timeEntry.end()) {
-    towerEntry = timeEntry.insert(std::pair<int, std::list<o2::emcal::LabeledDigit>>(towerID, std::list<o2::emcal::LabeledDigit>())).first;
+    unsigned long timeStamp = int(eventTime / 100) * 100; /// This is to make the event time multiple of 100s
+    for (auto& iNode : mTimedDigitsFuture) {
+      iNode.mRecordMode = true;
+      iNode.mTimestamp = timeStamp;
+      timeStamp += 100;
+    }
   }
 
-  towerEntry->second.push_back(dig);
+  // If we have a pre-trigger collision, all the time bins in the future buffer will be set to record mode
+  if ((eventTime - mTriggerTime) >= (mLiveTime + mBusyTime - mPreTriggerTime)) {
+    unsigned long timeStamp = int(eventTime / 100) * 100; /// This is to make the event time multiple of 100s
+    for (auto& iNode : mTimedDigitsFuture) {
+      iNode.mRecordMode = true;
+      iNode.mTimestamp = timeStamp;
+      timeStamp += 100;
+    }
+  }
 
   mLastEventTime = eventTime;
+  mPhase = ((int)(std::fmod(mLastEventTime, 100) / 25));
 }
 
-std::list<std::unordered_map<int, std::list<LabeledDigit>>> DigitsWriteoutBuffer::getLastNSamples(int nsamples)
+/// For the end of the run only write all the remaining digits into the streamer
+void DigitsWriteoutBuffer::finish()
 {
-  int startingPosition = int(mLastEventTime / mTimeBinWidth) - nsamples;
-  if (startingPosition < 0) {
-    startingPosition = 0;
-  }
+  for (unsigned int ibin = 0; ibin < mBufferSize; ibin++) {
 
-  std::list<std::unordered_map<int, std::list<LabeledDigit>>> output;
+    if (!mTimedDigitsFuture.front().mRecordMode || mTimedDigitsFuture.front().mDigitMap->empty()) {
+      break;
+    }
 
-  for (int ientry = startingPosition; ientry < startingPosition + nsamples; ientry++) {
-    output.push_back(mTimedDigits[ientry]);
+    mTimedDigitsPast.push_back(mTimedDigitsFuture.front());
+    mTimedDigitsFuture.pop_front();
+
+    if (mTimedDigitsPast.size() > mBufferSize) {
+      mTimedDigitsPast.pop_front();
+    }
+
+    if (mTimedDigitsPast.back().mEndWindow) {
+      mDigitStream.fill(getLastSamples(), mTimedDigitsPast.front().mInterRecord);
+      clear();
+      break;
+    }
   }
-  return output;
-  //return gsl::span<std::unordered_map<int, std::list<LabeledDigit>>>(&mTimedDigits[startingPosition], nsamples);
+}
+
+gsl::span<o2::emcal::DigitTimebin> DigitsWriteoutBuffer::getLastSamples()
+{
+  return gsl::span<o2::emcal::DigitTimebin>(&mTimedDigitsPast[0], mTimedDigitsPast.size());
 }

--- a/Detectors/EMCAL/simulation/src/EMCALSimulationLinkDef.h
+++ b/Detectors/EMCAL/simulation/src/EMCALSimulationLinkDef.h
@@ -20,6 +20,7 @@
 #pragma link C++ class o2::emcal::Digitizer + ;
 #pragma link C++ class o2::emcal::SDigitizer + ;
 #pragma link C++ class o2::emcal::DigitsWriteoutBuffer + ;
+#pragma link C++ class o2::emcal::DigitsVectorStream + ;
 #pragma link C++ class o2::emcal::SimParam + ;
 #pragma link C++ class o2::emcal::LabeledDigit + ;
 #pragma link C++ class o2::emcal::RawWriter + ;

--- a/Detectors/EMCAL/simulation/src/SimParam.cxx
+++ b/Detectors/EMCAL/simulation/src/SimParam.cxx
@@ -43,8 +43,10 @@ void SimParam::PrintStream(std::ostream& stream) const
   stream << "\nEMCal::SimParam.mB = " << mB;
   stream << "\nEMCal::SimParam.mECPrimThreshold = " << mECPrimThreshold;
   stream << "\nEMCal::SimParam.mSignalDelay = " << mSignalDelay;
+  stream << "\nEMCal::SimParam.mTimeWindowStart = " << mTimeWindowStart;
   stream << "\nEMCal::SimParam.mLiveTime = " << mLiveTime;
   stream << "\nEMCal::SimParam.mBusyTime = " << mBusyTime;
+  stream << "\nEMCal::SimParam.mPreTriggerTime = " << mPreTriggerTime;
   stream << "\nEMCal::SimParam.mSmearEnergy = " << ((mSmearEnergy) ? "true" : "false");
   stream << "\nEMCal::SimParam.mSimulateTimeResponse = " << ((mSimulateTimeResponse) ? "true" : "false");
   stream << "\nEMCal::SimParam.mRemoveDigitsBelowThreshold = " << ((mRemoveDigitsBelowThreshold) ? "true" : "false");
@@ -60,6 +62,6 @@ Double_t SimParam::getTimeResolution(Double_t energy) const
   }
 
   // parametrization above is for ns. Convert to seconds:
-  //return res*1e-9;
+  // return res*1e-9;
   return res;
 }

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/EMCALDigitizerSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/EMCALDigitizerSpec.h
@@ -63,11 +63,8 @@ class DigitizerSpec final : public o2::base::BaseDPLDigitizer
   Bool_t mFinished = false;            ///< Flag for digitization finished
   Digitizer mDigitizer;                ///< Digitizer object
   o2::emcal::SDigitizer mSumDigitizer; ///< Summed digitizer
+  std::vector<Hit> mHits;              ///< Vector with input hits
   std::vector<TChain*> mSimChains;
-  std::vector<Hit> mHits;                ///< Vector with input hits
-  std::vector<Digit> mDigits;            ///< Vector with non-accumulated digits (per collision)
-  std::vector<Digit> mAccumulatedDigits; ///< Vector with accumulated digits (time frame)
-  dataformats::MCTruthContainer<MCLabel> mLabels;
 };
 
 /// \brief Create new digitizer spec

--- a/Detectors/EMCAL/workflow/src/EMCALDigitizerSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/EMCALDigitizerSpec.cxx
@@ -73,64 +73,17 @@ void DigitizerSpec::run(framework::ProcessingContext& ctx)
 
   LOG(info) << " CALLING EMCAL DIGITIZATION ";
   o2::dataformats::MCTruthContainer<o2::emcal::MCLabel> labelAccum;
-  std::vector<TriggerRecord> triggers;
 
   auto& eventParts = context->getEventParts();
-  mDigitizer.clear();
-  mAccumulatedDigits.clear();
-  int trigID = 0;
-  int indexStart = mAccumulatedDigits.size();
 
-  bool preTriggerColl = false;
   // loop over all composite collisions given from context
   // (aka loop over all the interaction records)
   for (int collID = 0; collID < timesview.size(); ++collID) {
 
-    mDigitizer.setEventTime(timesview[collID].getTimeNS());
-
-    if (!mDigitizer.isEmpty() && (o2::emcal::SimParam::Instance().isDisablePileup() || !mDigitizer.isLive()) && !preTriggerColl) {
-      // copy digits into accumulator
-      mDigits.clear();
-      mLabels.clear();
-      mDigitizer.fillOutputContainer(mDigits, mLabels);
-      std::copy(mDigits.begin(), mDigits.end(), std::back_inserter(mAccumulatedDigits));
-      labelAccum.mergeAtBack(mLabels);
-      LOG(info) << "Have " << mAccumulatedDigits.size() << " digits ";
-      triggers.emplace_back(timesview[trigID], o2::trigger::PhT, indexStart, mDigits.size());
-      indexStart = mAccumulatedDigits.size();
-      mDigits.clear();
-      mLabels.clear();
-    }
+    mDigitizer.setEventTime(timesview[collID]);
 
     if (!mDigitizer.isLive()) {
-      // Take collisions that occurs 600 ns before the readout window is open
-      if (mDigitizer.preTriggerCollision()) {
-        for (auto& part : eventParts[collID]) {
-          mSumDigitizer.setCurrEvID(part.entryID);
-          mSumDigitizer.setCurrSrcID(part.sourceID);
-
-          // get the hits for this event and this source
-          mHits.clear();
-          context->retrieveHits(mSimChains, "EMCHit", part.sourceID, part.entryID, &mHits);
-
-          LOG(info) << "For collision " << collID << " eventID " << part.entryID << " found " << mHits.size() << " hits ";
-
-          std::vector<o2::emcal::LabeledDigit> summedDigits = mSumDigitizer.process(mHits);
-
-          // call actual digitization procedure
-          mDigitizer.process(summedDigits);
-
-          preTriggerColl = true;
-        }
-      }
       continue;
-    } else {
-      preTriggerColl = false;
-    }
-
-    if (mDigitizer.isEmpty()) {
-      mDigitizer.initCycle();
-      trigID = collID;
     }
 
     // for each collision, loop over the constituents event and source IDs
@@ -153,26 +106,13 @@ void DigitizerSpec::run(framework::ProcessingContext& ctx)
     }
   }
 
-  if (!mDigitizer.isEmpty()) {
-    // copy digits into accumulator
-    mDigits.clear();
-    mLabels.clear();
-    mDigitizer.fillOutputContainer(mDigits, mLabels);
-    std::copy(mDigits.begin(), mDigits.end(), std::back_inserter(mAccumulatedDigits));
-    labelAccum.mergeAtBack(mLabels);
-    LOG(info) << "Have " << mAccumulatedDigits.size() << " digits ";
-    triggers.emplace_back(timesview[trigID], o2::trigger::PhT, indexStart, mDigits.size());
-    indexStart = mAccumulatedDigits.size();
-    mDigits.clear();
-    mLabels.clear();
-  }
+  mDigitizer.finish();
 
-  LOG(info) << "Have " << labelAccum.getNElements() << " EMCAL labels ";
   // here we have all digits and we can send them to consumer (aka snapshot it onto output)
-  ctx.outputs().snapshot(Output{"EMC", "DIGITS", 0, Lifetime::Timeframe}, mAccumulatedDigits);
-  ctx.outputs().snapshot(Output{"EMC", "TRGRDIG", 0, Lifetime::Timeframe}, triggers);
+  ctx.outputs().snapshot(Output{"EMC", "DIGITS", 0, Lifetime::Timeframe}, mDigitizer.getDigits());
+  ctx.outputs().snapshot(Output{"EMC", "TRGRDIG", 0, Lifetime::Timeframe}, mDigitizer.getTriggerRecords());
   if (ctx.outputs().isAllowed({"EMC", "DIGITSMCTR", 0})) {
-    ctx.outputs().snapshot(Output{"EMC", "DIGITSMCTR", 0, Lifetime::Timeframe}, labelAccum);
+    ctx.outputs().snapshot(Output{"EMC", "DIGITSMCTR", 0, Lifetime::Timeframe}, mDigitizer.getMCLabels());
   }
   // EMCAL is always a triggering detector
   const o2::parameters::GRPObject::ROMode roMode = o2::parameters::GRPObject::TRIGGERING;


### PR DESCRIPTION
The digits writeout buffer has been redesigned. The basic data containers of the ringbuffer will be 2 std::dequeues, one for past and one for future. The future dequeue will be initialized with a size 15, the past dequeue will not be initialized with a fixed size but expanded until a constant size of 15 is reached. The entry 0 in the future dequeue always represents the current time. When we sample the digits we fill the dequeue in future direction always with the digit time sample (digit time + delay) relative to the current timesample. 