### PR TITLE
Fixes for TRD GPU tracking + related and unrelated cleanup

### DIFF
--- a/Detectors/Base/src/Propagator.cxx
+++ b/Detectors/Base/src/Propagator.cxx
@@ -612,10 +612,10 @@ GPUd() void PropagatorImpl<value_T>::getFieldXYZImpl(const math_utils::Point3D<T
     float bxyzF[3];
     f->GetField(xyz.X(), xyz.Y(), xyz.Z(), bxyzF);
     //copy and convert
+    constexpr value_type kCLight1 = 1. / 0.000299792458;
     for (uint i = 0; i < 3; ++i) {
-      bxyz[i] = static_cast<value_type>(bxyzF[i]);
+      bxyz[i] = static_cast<value_type>(bxyzF[i]) * kCLight1;
     }
-
   } else {
 #ifndef GPUCA_GPUCODE
     if (mFieldFast) {

--- a/Detectors/Base/src/Propagator.cxx
+++ b/Detectors/Base/src/Propagator.cxx
@@ -11,6 +11,7 @@
 
 #include "DetectorsBase/Propagator.h"
 #include "GPUCommonLogger.h"
+#include "GPUCommonConstants.h"
 #include "GPUCommonMath.h"
 #include "GPUTPCGMPolynomialField.h"
 #include "MathUtils/Utils.h"
@@ -612,7 +613,7 @@ GPUd() void PropagatorImpl<value_T>::getFieldXYZImpl(const math_utils::Point3D<T
     float bxyzF[3];
     f->GetField(xyz.X(), xyz.Y(), xyz.Z(), bxyzF);
     //copy and convert
-    constexpr value_type kCLight1 = 1. / 0.000299792458;
+    constexpr value_type kCLight1 = 1. / o2::gpu::gpu_common_constants::kCLight;
     for (uint i = 0; i < 3; ++i) {
       bxyz[i] = static_cast<value_type>(bxyzF[i]) * kCLight1;
     }

--- a/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
@@ -101,6 +101,7 @@ void TRDGlobalTracking::init(InitContext& ic)
   cfgRecoStep.outputs.clear();
   mRec = GPUReconstruction::CreateInstance("CPU", true);
   mRec->SetSettings(o2::base::Propagator::Instance()->getNominalBz(), &cfgRecoStep);
+  mRec->GetNonConstParam().rec.trd.useExternalO2DefaultPropagator = true;
 
   mChainTracking = mRec->AddChain<GPUChainTracking>();
 

--- a/GPU/Common/CMakeLists.txt
+++ b/GPU/Common/CMakeLists.txt
@@ -16,6 +16,7 @@ set(HDRS_INSTALL
     GPUCommonDef.h
     GPUCommonDefAPI.h
     GPUCommonDefSettings.h
+    GPUCommonConstants.h
     GPUCommonLogger.h
     GPUCommonMath.h
     GPUCommonRtypes.h

--- a/GPU/Common/GPUCommonConstants.h
+++ b/GPU/Common/GPUCommonConstants.h
@@ -1,0 +1,27 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file GPUCommonConstants.h
+/// \author David Rohr
+
+#ifndef GPUCOMMONCONSTANTS_H
+#define GPUCOMMONCONSTANTS_H
+
+#include "GPUCommonDef.h"
+
+#if !defined(__OPENCL__) || defined(__OPENCLCPP__)
+namespace GPUCA_NAMESPACE::gpu::gpu_common_constants
+{
+static CONSTEXPR float kCLight = 0.000299792458f;
+}
+#endif
+
+#endif

--- a/GPU/GPUTracking/Base/GPUParam.cxx
+++ b/GPU/GPUTracking/Base/GPUParam.cxx
@@ -16,6 +16,7 @@
 #include "GPUParamRTC.h"
 #include "GPUDef.h"
 #include "GPUCommonMath.h"
+#include "GPUCommonConstants.h"
 #include "GPUTPCGMPolynomialFieldManager.h"
 #include "GPUDataTypes.h"
 #include "GPUConstantMem.h"
@@ -82,8 +83,7 @@ void GPUParam::SetDefaults(float solenoidBz)
 
   par.dAlpha = 0.349066f;
   par.bzkG = solenoidBz;
-  constexpr double kCLight = 0.000299792458f;
-  par.constBz = solenoidBz * kCLight;
+  par.constBz = solenoidBz * GPUCA_NAMESPACE::gpu::gpu_common_constants::kCLight;
   par.dodEdx = 0;
 
   constexpr float plusZmin = 0.0529937;

--- a/GPU/GPUTracking/Base/GPUParam.cxx
+++ b/GPU/GPUTracking/Base/GPUParam.cxx
@@ -259,9 +259,11 @@ o2::base::Propagator* GPUParam::GetDefaultO2Propagator(bool useGPUField) const
 {
   o2::base::Propagator* prop = nullptr;
 #ifdef GPUCA_HAVE_O2HEADERS
+#ifdef GPUCA_STANDALONE
   if (useGPUField == false) {
     throw std::runtime_error("o2 propagator withouzt gpu field unsupported");
   }
+#endif
   prop = o2::base::Propagator::Instance(useGPUField);
   if (useGPUField) {
     prop->setGPUField(&polynomialField);

--- a/GPU/GPUTracking/Base/GPUReconstruction.cxx
+++ b/GPU/GPUTracking/Base/GPUReconstruction.cxx
@@ -326,6 +326,9 @@ int GPUReconstruction::InitPhaseBeforeDevice()
 
   mDeviceMemorySize = mHostMemorySize = 0;
   for (unsigned int i = 0; i < mChains.size(); i++) {
+    if (mChains[i]->EarlyConfigure()) {
+      return 1;
+    }
     mChains[i]->RegisterPermanentMemoryAndProcessors();
     size_t memPrimary, memPageLocked;
     mChains[i]->MemorySize(memPrimary, memPageLocked);

--- a/GPU/GPUTracking/Base/GPUReconstruction.h
+++ b/GPU/GPUTracking/Base/GPUReconstruction.h
@@ -236,6 +236,7 @@ class GPUReconstruction
   void SetSettings(const GPUSettingsGRP* grp, const GPUSettingsRec* rec = nullptr, const GPUSettingsProcessing* proc = nullptr, const GPURecoStepConfiguration* workflow = nullptr);
   void SetResetTimers(bool reset) { mProcessingSettings.resetTimers = reset; } // May update also after Init()
   void SetDebugLevelTmp(int level) { mProcessingSettings.debugLevel = level; } // Temporarily, before calling SetSettings()
+  GPUParam& GetNonConstParam() { return mHostConstantMem->param; }             // Kind of hack, but needed for manual updates after SetSettings(), if the default configKeyValues parsing for SetSettings() is used.
   void UpdateGRPSettings(const GPUSettingsGRP* g, const GPUSettingsProcessing* p = nullptr);
   void SetOutputControl(const GPUOutputControl& v) { mOutputControl = v; }
   void SetOutputControl(void* ptr, size_t size);

--- a/GPU/GPUTracking/Benchmark/standalone.cxx
+++ b/GPU/GPUTracking/Benchmark/standalone.cxx
@@ -430,6 +430,11 @@ int SetupReconstruction()
     }
   }
 
+#ifdef GPUCA_HAVE_O2HEADERS
+  procSet.useInternalO2Propagator = true;
+  procSet.internalO2PropagatorGPUField = true;
+#endif
+
   rec->SetSettings(&grp, &recSet, &procSet, &steps);
   if (configStandalone.proc.doublePipeline) {
     recPipeline->SetSettings(&grp, &recSet, &procSet, &steps);
@@ -461,16 +466,6 @@ int SetupReconstruction()
       recPipeline->SetOutputControl(outputmemoryPipeline.get(), configStandalone.outputcontrolmem);
     }
   }
-
-#ifdef GPUCA_HAVE_O2HEADERS
-  chainTracking->SetDefaultO2PropagatorForGPU();
-  if (configStandalone.testSyncAsync) {
-    chainTrackingAsync->SetDefaultO2PropagatorForGPU();
-  }
-  if (configStandalone.proc.doublePipeline) {
-    chainTrackingPipeline->SetDefaultO2PropagatorForGPU();
-  }
-#endif
 
   if (rec->Init()) {
     printf("Error initializing GPUReconstruction!\n");

--- a/GPU/GPUTracking/Definitions/GPUSettingsList.h
+++ b/GPU/GPUTracking/Definitions/GPUSettingsList.h
@@ -91,6 +91,7 @@ AddOptionRTC(extraRoadY, float, 2.f, "", 0, "Addition to search road around trac
 AddOptionRTC(extraRoadZ, float, 0.f, "", 0, "Addition to search road around track prolongation along Z in cm")
 AddOptionRTC(applyDeflectionCut, unsigned char, 0, "", 0, "Set to 1 to enable tracklet selection based on deflection")
 AddOptionRTC(stopTrkAfterNMissLy, unsigned char, 6, "", 0, "Abandon track following after N layers without a TRD match")
+AddOptionRTC(useExternalO2DefaultPropagator, unsigned char, 0, "", 0, "Use the default instance of the o2::Propagator, instead of the GPU Reconstruciton one with GPU B field")
 AddHelp("help", 'h')
 EndConfig()
 
@@ -174,6 +175,8 @@ AddOption(tpcIncreasedMinClustersPerRow, unsigned int, 0, "", 0, "Impose a minim
 AddOption(noGPUMemoryRegistration, bool, false, "", 0, "Do not register input / output memory for GPU dma transfer")
 AddOption(automaticQPtThresholds, bool, true, "", 0, "Update the QPt thresholde at initialization accoding to the B field (i.e. lower to 40% for B=0.2T)")
 AddOption(calibObjectsExtraMemorySize, unsigned long, 10ul * 1024 * 1024, "", 0, "Extra spare memory added for calibration object buffer, to allow fow updates with larger objects")
+AddOption(useInternalO2Propagator, bool, false, "", 0, "Uses an internal (in GPUChainTracking) version of o2::Propagator, which internal b-field, matlut, etc.")
+AddOption(internalO2PropagatorGPUField, bool, true, "", 0, "Makes the internal O2 propagator use the fast GPU polynomial b field approximation")
 AddVariable(eventDisplay, GPUCA_NAMESPACE::gpu::GPUDisplayFrontend*, nullptr)
 AddSubConfig(GPUSettingsProcessingRTC, rtc)
 AddHelp("help", 'h')

--- a/GPU/GPUTracking/Global/GPUChain.h
+++ b/GPU/GPUTracking/Global/GPUChain.h
@@ -41,6 +41,7 @@ class GPUChain
   virtual ~GPUChain() = default;
   virtual void RegisterPermanentMemoryAndProcessors() = 0;
   virtual void RegisterGPUProcessors() = 0;
+  virtual int EarlyConfigure() { return 0; };
   virtual int Init() = 0;
   virtual int PrepareEvent() = 0;
   virtual int Finalize() = 0;

--- a/GPU/GPUTracking/Global/GPUChainTracking.h
+++ b/GPU/GPUTracking/Global/GPUChainTracking.h
@@ -73,6 +73,7 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
   void RegisterPermanentMemoryAndProcessors() override;
   void RegisterGPUProcessors() override;
   int Init() override;
+  int EarlyConfigure() override;
   int PrepareEvent() override;
   int Finalize() override;
   int RunChain() override;
@@ -185,7 +186,7 @@ class GPUChainTracking : public GPUChain, GPUReconstructionHelpers::helperDelega
   void SetCalibObjects(const GPUCalibObjectsConst& obj) { processors()->calibObjects = obj; }
   void SetCalibObjects(const GPUCalibObjects& obj) { memcpy((void*)&processors()->calibObjects, (const void*)&obj, sizeof(obj)); }
   void SetUpdateCalibObjects(const GPUCalibObjectsConst& obj);
-  void SetDefaultO2PropagatorForGPU();
+  void SetDefaultInternalO2Propagator(bool useGPUField);
   void LoadClusterErrors();
   void SetOutputControlCompressedClusters(GPUOutputControl* v) { mSubOutputControls[GPUTrackingOutputs::getIndex(&GPUTrackingOutputs::compressedClusters)] = v; }
   void SetOutputControlClustersNative(GPUOutputControl* v) { mSubOutputControls[GPUTrackingOutputs::getIndex(&GPUTrackingOutputs::clustersNative)] = v; }

--- a/GPU/GPUTracking/Merger/GPUTPCGMMerger.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMMerger.cxx
@@ -39,6 +39,7 @@
 
 #include "GPUCommonMath.h"
 #include "GPUCommonAlgorithm.h"
+#include "GPUCommonConstants.h"
 
 #include "GPUTPCTrackParam.h"
 #include "GPUTPCSliceOutput.h"
@@ -1796,8 +1797,7 @@ GPUd() void GPUTPCGMMerger::CollectMergedTracks(int nBlocks, int nThreads, int i
     p1.DzDs() = p2.DzDs();
     p1.QPt() = p2.QPt();
     mergedTrack.SetAlpha(p2.Alpha());
-    const double kCLight = 0.000299792458;
-    if (CAMath::Abs(Param().polynomialField.GetNominalBz()) < (0.01 * kCLight)) {
+    if (CAMath::Abs(Param().polynomialField.GetNominalBz()) < (0.01f * gpu_common_constants::kCLight)) {
       p1.QPt() = 100.f / Param().rec.bz0Pt10MeV;
     }
 

--- a/GPU/GPUTracking/Merger/GPUTPCGMPolynomialField.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMPolynomialField.cxx
@@ -25,7 +25,7 @@ using namespace std;
 
 void GPUTPCGMPolynomialField::Print() const
 {
-  const double kCLight = 0.000299792458;
+  const double kCLight = gpu_common_constants::kCLight;
   typedef std::numeric_limits<float> flt;
   cout << std::scientific;
 #if __cplusplus >= 201103L

--- a/GPU/GPUTracking/Merger/GPUTPCGMPolynomialFieldManager.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMPolynomialFieldManager.cxx
@@ -12,6 +12,7 @@
 /// \file GPUTPCGMPolynomialFieldManager.cxx
 /// \author Sergey Gorbunov, David Rohr
 
+#include "GPUCommonConstants.h"
 #include "GPUTPCGMPolynomialFieldManager.h"
 #include "GPUTPCGMPolynomialField.h"
 #include <cmath>
@@ -105,8 +106,6 @@ int GPUTPCGMPolynomialFieldManager::GetPolynomialField(StoredField_t fieldType, 
 
   const float kItsSol5Bz[kItsM] = {1.00001418591e+00, -3.69126610167e-06, 7.76097112976e-06, -3.11396547659e-06, 1.64195810726e-07, 2.47078468796e-10, 2.39289423831e-08, 1.61199579907e-07, -3.16838866254e-09, -3.23542707292e-07};
 
-  const double kCLight = 0.000299792458;
-
   field.Reset();
 
   // check if GPUTPCGMPolynomialField class is ok
@@ -119,7 +118,7 @@ int GPUTPCGMPolynomialFieldManager::GetPolynomialField(StoredField_t fieldType, 
 
   const float *cTpcBx, *cTpcBy, *cTpcBz, *cTrdBx, *cTrdBy, *cTrdBz, *cItsBx, *cItsBy, *cItsBz;
 
-  double nominalBz = nominalFieldkG * kCLight;
+  double nominalBz = nominalFieldkG * gpu_common_constants::kCLight;
 
   if (fieldType == GPUTPCGMPolynomialFieldManager::kUniform) {
     cTpcBx = kSolUBx;
@@ -270,7 +269,6 @@ int GPUTPCGMPolynomialFieldManager::FitFieldTpc(AliMagF* inputFld, GPUTPCGMPolyn
   // Fit magnetic field with polynoms
   //
 
-  const double kCLight = 0.000299792458;
   const double kAlmost0Field = 1.e-13;
 
   AliMagF* fld = inputFld;
@@ -377,7 +375,7 @@ int GPUTPCGMPolynomialFieldManager::FitFieldTpc(AliMagF* inputFld, GPUTPCGMPolyn
   fittedField.SetFieldTpc(cX, cY, cZ);
 
   // scale result
-  double nominalBz = solenoidBzkG * kCLight;
+  double nominalBz = solenoidBzkG * gpu_common_constants::kCLight;
 
   for (int i = 0; i < M; i++) {
     cX[i] = nominalBz * cX[i];
@@ -451,7 +449,6 @@ int GPUTPCGMPolynomialFieldManager::FitFieldTrd(AliMagF* inputFld, GPUTPCGMPolyn
   // Fit magnetic field with polynoms
   //
 
-  const double kCLight = 0.000299792458;
   const double kAlmost0Field = 1.e-13;
 
   AliMagF* fld = inputFld;
@@ -554,7 +551,7 @@ int GPUTPCGMPolynomialFieldManager::FitFieldTrd(AliMagF* inputFld, GPUTPCGMPolyn
   fittedField.SetFieldTrd(cX, cY, cZ);
 
   // scale result
-  double nominalBz = solenoidBzkG * kCLight;
+  double nominalBz = solenoidBzkG * gpu_common_constants::kCLight;
 
   for (int i = 0; i < M; i++) {
     cX[i] = nominalBz * cX[i];
@@ -627,7 +624,6 @@ int GPUTPCGMPolynomialFieldManager::FitFieldIts(AliMagF* inputFld, GPUTPCGMPolyn
   // Fit magnetic field with polynoms
   //
 
-  const double kCLight = 0.000299792458;
   const double kAlmost0Field = 1.e-13;
 
   AliMagF* fld = inputFld;
@@ -740,7 +736,7 @@ int GPUTPCGMPolynomialFieldManager::FitFieldIts(AliMagF* inputFld, GPUTPCGMPolyn
   fittedField.SetFieldIts(cX, cY, cZ);
 
   // scale result
-  double nominalBz = solenoidBzkG * kCLight;
+  double nominalBz = solenoidBzkG * gpu_common_constants::kCLight;
 
   for (int i = 0; i < M; i++) {
     cX[i] = nominalBz * cX[i];

--- a/GPU/GPUTracking/Merger/GPUTPCGMPropagator.cxx
+++ b/GPU/GPUTracking/Merger/GPUTPCGMPropagator.cxx
@@ -35,7 +35,7 @@ GPUd() void GPUTPCGMPropagator::GetBxByBzBase(float cosAlpha, float sinAlpha, fl
   float gy = getGlobalY(cosAlpha, sinAlpha, X, Y);
 
 #if defined(GPUCA_GM_USE_FULL_FIELD)
-  const double kCLight = 0.000299792458;
+  const float kCLight = gpu_common_constants::kCLight;
   double r[3] = {gx, gy, Z};
   double bb[3];
   AliTracker::GetBxByBz(r, bb);
@@ -93,7 +93,7 @@ GPUd() float GPUTPCGMPropagator::GetBzBase(float cosAlpha, float sinAlpha, float
   float gy = getGlobalY(cosAlpha, sinAlpha, X, Y);
 
 #if defined(GPUCA_GM_USE_FULL_FIELD)
-  const double kCLight = 0.000299792458;
+  const float kCLight = gpu_common_constants::kCLight;
   double r[3] = {gx, gy, Z};
   double bb[3];
   AliTracker::GetBxByBz(r, bb);

--- a/GPU/GPUTracking/Merger/macros/checkPropagation.C
+++ b/GPU/GPUTracking/Merger/macros/checkPropagation.C
@@ -4,6 +4,7 @@
 #include "TMath.h"
 #include "TCanvas.h"
 #include "TH1F.h"
+#include "GPUCommonConstants.h"
 #include "GPUO2Interface.h"
 #include "GPUTPCGMPhysicalTrackModel.h"
 #endif
@@ -141,7 +142,7 @@ int checkPropagation()
 
         double cs = TMath::Cos(alpha);
         double sn = TMath::Sin(alpha);
-        const double kCLight = 0.000299792458;
+        const double kCLight = o2::gpu::gpu_common_constants::kCLight;
         double b[3] = {(B[0] * cs - B[1] * sn) / kCLight, (B[0] * sn + B[1] * cs) / kCLight, B[2] / kCLight};
         err = err & !t0.PropagateToBxByBz(xRow, b);
         // err = err & !t0.PropagateTo( xRow, b[2] );

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
@@ -286,20 +286,24 @@ void GPUTRDTracker_t<TRDTRK, PROP>::StartDebugging()
 #endif //! GPUCA_GPUCODE
 
 template <>
-GPUdi() const GPUTRDPropagatorGPU::propagatorParam* GPUTRDTracker_t<GPUTRDTrackGPU, GPUTRDPropagatorGPU>::getPropagatorParam()
+GPUdi() const GPUTRDPropagatorGPU::propagatorParam* GPUTRDTracker_t<GPUTRDTrackGPU, GPUTRDPropagatorGPU>::getPropagatorParam(bool externalDefaultO2Propagator)
 {
   return &Param().polynomialField;
 }
 
 template <class TRDTRK, class PROP>
-GPUdi() const typename PROP::propagatorParam* GPUTRDTracker_t<TRDTRK, PROP>::getPropagatorParam()
+GPUdi() const typename PROP::propagatorParam* GPUTRDTracker_t<TRDTRK, PROP>::getPropagatorParam(bool externalDefaultO2Propagator)
 {
 #ifdef GPUCA_GPUCODE
   return GetConstantMem()->calibObjects.o2Propagator;
 #elif defined GPUCA_ALIROOT_LIB
   return nullptr;
 #else
-  return o2::base::Propagator::Instance();
+  if (externalDefaultO2Propagator) {
+    return o2::base::Propagator::Instance();
+  } else {
+    return GetConstantMem()->calibObjects.o2Propagator;
+  }
 #endif
 }
 
@@ -402,7 +406,7 @@ GPUd() void GPUTRDTracker_t<TRDTRK, PROP>::DoTrackingThread(int iTrk, int thread
       return;
     }
   }
-  PROP prop(getPropagatorParam());
+  PROP prop(getPropagatorParam(Param().rec.trd.useExternalO2DefaultPropagator));
   mTracks[iTrk].setChi2(Param().rec.trd.penaltyChi2); // TODO check if this should not be higher
   auto trkStart = mTracks[iTrk];
   for (int iColl = 0; iColl < nCollisionIds; ++iColl) {

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.h
@@ -154,7 +154,7 @@ class GPUTRDTracker_t : public GPUProcessor
   GPUd() void DumpTracks();
 
   // utility
-  GPUd() const typename PROP::propagatorParam* getPropagatorParam();
+  GPUd() const typename PROP::propagatorParam* getPropagatorParam(bool externalDefaultO2Propagator);
 
  protected:
   float* mR;                               // radial position of each TRD chamber, alignment taken into account, radial spread within chambers < 7mm

--- a/GPU/GPUTracking/display/GPUDisplay.cxx
+++ b/GPU/GPUTracking/display/GPUDisplay.cxx
@@ -885,7 +885,7 @@ void GPUDisplay::DrawFinal(int iSlice, int /*iCol*/, GPUTPCGMPropagator* prop, s
       if constexpr (std::is_same_v<T, GPUTPCGMMergedTrack>) {
         if (mTRDTrackIds[i] != -1 && mIOPtrs->nTRDTracklets) {
           auto tmpDoTRDTracklets = [&](auto* trdTracks) {
-            auto& trk = mIOPtrs->trdTracks[mTRDTrackIds[i]];
+            auto& trk = trdTracks[mTRDTrackIds[i]];
             for (int k = 5; k >= 0; k--) {
               int cid = trk.getTrackletIndex(k);
               if (cid < 0) {

--- a/GPU/GPUTracking/display/GPUDisplay.cxx
+++ b/GPU/GPUTracking/display/GPUDisplay.cxx
@@ -882,38 +882,28 @@ void GPUDisplay::DrawFinal(int iSlice, int /*iCol*/, GPUTPCGMPropagator* prop, s
       }
 
       // Print TRD part of track
-      if constexpr (std::is_same_v<T, GPUTPCGMMergedTrack>) {
-        if (mTRDTrackIds[i] != -1 && mIOPtrs->nTRDTracklets) {
-          auto tmpDoTRDTracklets = [&](auto* trdTracks) {
-            auto& trk = trdTracks[mTRDTrackIds[i]];
-            for (int k = 5; k >= 0; k--) {
-              int cid = trk.getTrackletIndex(k);
-              if (cid < 0) {
-                continue;
-              }
-              drawing = true;
-              mVertexBuffer[iSlice].emplace_back(mGlobalPosTRD2[cid].x, mGlobalPosTRD2[cid].y, mCfgH.projectXY ? 0 : mGlobalPosTRD2[cid].z);
-              mVertexBuffer[iSlice].emplace_back(mGlobalPosTRD[cid].x, mGlobalPosTRD[cid].y, mCfgH.projectXY ? 0 : mGlobalPosTRD[cid].z);
-              mGlobalPosTRD[cid].w = tTRDATTACHED;
-            }
-          };
-          mIOPtrs->trdTracksO2 ? tmpDoTRDTracklets(mIOPtrs->trdTracksO2) : tmpDoTRDTracklets(mIOPtrs->trdTracks);
+      auto tmpDoTRDTracklets = [&](const auto& trk) {
+        for (int k = 5; k >= 0; k--) {
+          int cid = trk.getTrackletIndex(k);
+          if (cid < 0) {
+            continue;
+          }
+          drawing = true;
+          mVertexBuffer[iSlice].emplace_back(mGlobalPosTRD2[cid].x, mGlobalPosTRD2[cid].y, mCfgH.projectXY ? 0 : mGlobalPosTRD2[cid].z);
+          mVertexBuffer[iSlice].emplace_back(mGlobalPosTRD[cid].x, mGlobalPosTRD[cid].y, mCfgH.projectXY ? 0 : mGlobalPosTRD[cid].z);
+          mGlobalPosTRD[cid].w = tTRDATTACHED;
+        }
+      };
+      if (std::is_same_v<T, GPUTPCGMMergedTrack> || (!mIOPtrs->tpcLinkTRD && mIOPtrs->trdTracksO2)) {
+        if (mChain && ((int)mConfig.showTPCTracksFromO2Format == (int)mChain->GetProcessingSettings().trdTrackModelO2) && mTRDTrackIds[i] != -1 && mIOPtrs->nTRDTracklets) {
+          mIOPtrs->trdTracksO2 ? tmpDoTRDTracklets(mIOPtrs->trdTracksO2[mTRDTrackIds[i]]) : tmpDoTRDTracklets(mIOPtrs->trdTracks[mTRDTrackIds[i]]);
         }
       } else if constexpr (std::is_same_v<T, o2::tpc::TrackTPC>) {
         if (mIOPtrs->tpcLinkTRD && mIOPtrs->tpcLinkTRD[i] != -1 && mIOPtrs->nTRDTracklets) {
           if ((mIOPtrs->tpcLinkTRD[i] & 0x40000000) ? mIOPtrs->nTRDTracksITSTPCTRD : mIOPtrs->nTRDTracksTPCTRD) {
             const auto* container = (mIOPtrs->tpcLinkTRD[i] & 0x40000000) ? mIOPtrs->trdTracksITSTPCTRD : mIOPtrs->trdTracksTPCTRD;
             const auto& trk = container[mIOPtrs->tpcLinkTRD[i] & 0x3FFFFFFF];
-            for (int k = 5; k >= 0; k--) {
-              int cid = trk.getTrackletIndex(k);
-              if (cid < 0) {
-                continue;
-              }
-              drawing = true;
-              mVertexBuffer[iSlice].emplace_back(mGlobalPosTRD2[cid].x, mGlobalPosTRD2[cid].y, mCfgH.projectXY ? 0 : mGlobalPosTRD2[cid].z);
-              mVertexBuffer[iSlice].emplace_back(mGlobalPosTRD[cid].x, mGlobalPosTRD[cid].y, mCfgH.projectXY ? 0 : mGlobalPosTRD[cid].z);
-              mGlobalPosTRD[cid].w = tTRDATTACHED;
-            }
+            tmpDoTRDTracklets(trk);
           }
         }
       }

--- a/GPU/GPUTracking/qa/genEvents.cxx
+++ b/GPU/GPUTracking/qa/genEvents.cxx
@@ -173,8 +173,7 @@ int genEvents::GenerateEvent(const GPUParam& param, char* filename)
     prop.SetPolynomialField(&merger.Param().polynomialField);
   }
 
-  //  const double kCLight = 0.000299792458;
-  // Bz*=kCLight;
+  // Bz*=o2::gpu::gpu_common_constants::kCLight;
 
   std::vector<GenCluster> vClusters;
   int clusterId = 0; // Here we count up the cluster ids we fill (must be unique).

--- a/GPU/Workflow/src/GPUWorkflowSpec.cxx
+++ b/GPU/Workflow/src/GPUWorkflowSpec.cxx
@@ -243,6 +243,7 @@ DataProcessorSpec getGPURecoWorkflowSpec(gpuworkflow::CompletionPolicyData* poli
       // Create and forward data objects for TPC transformation, material LUT, ...
       if (confParam.transformationFile.size()) {
         processAttributes->fastTransform = nullptr;
+        LOG(info) << "Reading TPC transformation map from file " << confParam.transformationFile;
         config.configCalib.fastTransform = TPCFastTransform::loadFromFile(confParam.transformationFile.c_str());
       } else {
         processAttributes->fastTransform = std::move(TPCFastTransformHelperO2::instance()->create(0));
@@ -253,7 +254,11 @@ DataProcessorSpec getGPURecoWorkflowSpec(gpuworkflow::CompletionPolicyData* poli
       }
 
       if (confParam.matLUTFile.size()) {
+        LOGP(info, "Loading matlut file {}", confParam.matLUTFile.c_str());
         config.configCalib.matLUT = o2::base::MatLayerCylSet::loadFromFile(confParam.matLUTFile.c_str());
+        if (config.configCalib.matLUT == nullptr) {
+          LOGF(fatal, "Error loading matlut file");
+        }
       }
 
       // load from file


### PR DESCRIPTION
@martenole : this should fix the issue with TRD, and some other issues I encountered along the way. It also adds a couple of more options that can be used for debugging:
- The TRD rec settings now have `useExternalO2DefaultPropagator`. If true, the TRD tracker will just use the default instance of `o2::propagator`. I have set that to true for the GlobalTRDTracking workflow. If it is false, it uses the Instance created by GPUChainTracking.
- For GPUChainTracking, there is a similar option: `GPU_proc.useInternalO2Propagator` defines if an instance of the o2::propagator is created, that might be configured. If this is false (which is the default), also GPUChainTracking just uses o2::Propagator::instance();
- `GPU_proc.internalO2PropagatorGPUField` makes the propagator created by GPUChainTracking (only works if `GPU_proc.useInternalO2Propagator=1` use the gpu polynomial field map. So these options can now be used to test with the GPU polynomial field map also in the CPU part of GPUChainTracking, and also in the trd global tracking spec.

Then, in order to show TRD tracks in the display
- in case the TRD tracks are not coming externally (e.g. as in the o2-gpu- display binary) but are reconstructed in the current process,
- and in case the `GPU_proc.trdTrackModelO2=1` is set
One must also set `GPU_display.showTPCTracksFromO2Format=1`. (`--GLshowTPCTracksFromO2Format` in the standalone version)

The reason for the latter is: Otherwise it cannot build the relation between TPC tracks and TRD tracklets. Without `showTPCTracksFromO2Format=1` the display takes the TPC tracks before they were converted to the o2 format, which involves a filter, i.e. the index in the array is different. But with `trdTrackModelO2` the TRD track links to the tpc track in the o2 format. There is no index array storing the relation between tpc tracks in the original GPU format and in the o2 format (since the track in the GPU format is anyway just dripped), the the TRD tracks do not relate to the TPC tracks that are shown.

Could you test with the trd global tracking workflow? I am 99% sure I didn't break anything, but just to be sure.

Ah, and the problem with the propagation was just incorrect b-field units, which is also fixed.