### PR TITLE
Spec and workflow to inject DISTSUBTIMEFRAME message

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/helpers/src/GlobalTrackClusterReader.cxx
+++ b/Detectors/GlobalTrackingWorkflow/helpers/src/GlobalTrackClusterReader.cxx
@@ -13,6 +13,7 @@
 #include "ReconstructionDataFormats/GlobalTrackID.h"
 #include "CommonUtils/ConfigurableParam.h"
 #include "DetectorsRaw/HBFUtilsInitializer.h"
+#include "DetectorsRaw/DistSTFSenderSpec.h"
 #include "Framework/CallbacksPolicy.h"
 #include "Framework/ConfigContext.h"
 
@@ -32,6 +33,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"track-types", VariantType::String, std::string{GlobalTrackID::NONE}, {"comma-separated list of track sources to read"}},
     {"cluster-types", VariantType::String, std::string{GlobalTrackID::NONE}, {"comma-separated list of cluster sources to read"}},
     {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable reading root files, essentially making this workflow void, but needed for compatibility"}},
+    {"max-dist-stf", o2::framework::VariantType::Int, 0, {"max TFs with DISTSUBTIMEFRAME message (<1 = disable)"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
   std::swap(workflowOptions, options);
@@ -54,6 +56,11 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   auto srcMtc = srcTrk & ~GlobalTrackID::getSourceMask(GlobalTrackID::MFTMCH); // Do not request MFTMCH matches
 
   InputHelper::addInputSpecs(cfgc, specs, srcCl, srcMtc, srcTrk, useMC);
+
+  int maxDistSTF = cfgc.options().get<int>("max-dist-stf");
+  if (maxDistSTF > 0) {
+    specs.push_back(o2::raw::getDistSTFSenderSpec(maxDistSTF));
+  }
 
   // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
   o2::raw::HBFUtilsInitializer hbfIni(cfgc, specs);

--- a/Detectors/Raw/CMakeLists.txt
+++ b/Detectors/Raw/CMakeLists.txt
@@ -15,6 +15,7 @@ o2_add_library(DetectorsRaw
                        src/HBFUtils.cxx
                        src/RDHUtils.cxx
                        src/HBFUtilsInitializer.cxx
+                       src/DistSTFSenderSpec.cxx
                PUBLIC_LINK_LIBRARIES FairRoot::Base
                                      O2::Headers
                                      O2::CommonDataFormat
@@ -47,6 +48,11 @@ o2_add_executable(file-reader-workflow
                   src/RawFileReaderWorkflow.cxx
                   PUBLIC_LINK_LIBRARIES O2::DetectorsRaw)
 
+o2_add_executable(sender-workflow
+                  COMPONENT_NAME diststf
+                  SOURCES src/diststf-sender-workflow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::DetectorsRaw)
+
 
 o2_add_test(HBFUtils
             PUBLIC_LINK_LIBRARIES O2::DetectorsRaw
@@ -58,7 +64,7 @@ o2_add_test(HBFUtils
 o2_add_test(RawReaderWriter
             PUBLIC_LINK_LIBRARIES O2::DetectorsRaw
                                   O2::Steer
-                            O2::DPLUtils
+                                  O2::DPLUtils
             SOURCES test/testRawReaderWriter.cxx
             COMPONENT_NAME raw
             LABELS raw)

--- a/Detectors/Raw/include/DetectorsRaw/DistSTFSenderSpec.h
+++ b/Detectors/Raw/include/DetectorsRaw/DistSTFSenderSpec.h
@@ -1,0 +1,24 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_DIST_STF_SENDER_H
+#define O2_DIST_STF_SENDER_H
+
+/// @file DistSTFSenderSpec.h
+/// @brief sends DISTSUBTIMEFRAME messages
+
+#include "Framework/DataProcessorSpec.h"
+
+namespace o2::raw
+{
+o2::framework::DataProcessorSpec getDistSTFSenderSpec(int maxTF);
+}
+#endif

--- a/Detectors/Raw/src/DistSTFSenderSpec.cxx
+++ b/Detectors/Raw/src/DistSTFSenderSpec.cxx
@@ -1,0 +1,64 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "DetectorsRaw/DistSTFSenderSpec.h"
+#include "Framework/ConfigContext.h"
+#include "Framework/DeviceSpec.h"
+#include "Framework/DataRefUtils.h"
+#include "Framework/Task.h"
+#include "Framework/ControlService.h"
+#include "Framework/Logger.h"
+#include "Headers/DataHeader.h"
+#include "Headers/STFHeader.h"
+
+using namespace o2::framework;
+using namespace o2::header;
+
+namespace o2::raw
+{
+
+class DistSTFSender : public Task
+{
+ public:
+  DistSTFSender(int m) : mMaxTF(m) {}
+  void run(ProcessingContext& ctx) final;
+
+ private:
+  int mMaxTF = 1;
+  int mTFCount = 0;
+};
+
+//___________________________________________________________
+void DistSTFSender::run(ProcessingContext& pc)
+{
+  const auto* dh = DataRefUtils::getHeader<DataHeader*>(pc.inputs().getFirstValid(true));
+  auto creationTime = DataRefUtils::getHeader<DataProcessingHeader*>(pc.inputs().getFirstValid(true))->creation;
+  LOG(info) << "DIST STF for run " << dh->runNumber << " orbit " << dh->firstTForbit << " creation " << creationTime << " TFid: " << dh->tfCounter;
+  STFHeader stfHeader{dh->tfCounter, dh->firstTForbit, dh->runNumber};
+  pc.outputs().snapshot(o2::framework::Output{gDataOriginFLP, gDataDescriptionDISTSTF, 0}, stfHeader);
+  if (++mTFCount >= mMaxTF) {
+    pc.services().get<ControlService>().endOfStream();
+    pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+  }
+}
+
+//_________________________________________________________
+DataProcessorSpec getDistSTFSenderSpec(int maxTF)
+{
+  return DataProcessorSpec{
+    "dist-stf-sender",
+    Inputs{},
+    Outputs{OutputSpec{gDataOriginFLP, gDataDescriptionDISTSTF, 0}},
+    AlgorithmSpec{adaptFromTask<DistSTFSender>(maxTF)},
+    Options{}};
+}
+
+} // namespace o2::raw

--- a/Detectors/Raw/src/diststf-sender-workflow.cxx
+++ b/Detectors/Raw/src/diststf-sender-workflow.cxx
@@ -1,0 +1,50 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "DetectorsRaw/HBFUtilsInitializer.h"
+#include "DetectorsRaw/DistSTFSenderSpec.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "Framework/WorkflowSpec.h"
+#include "Framework/CallbacksPolicy.h"
+#include "Framework/Logger.h"
+#include <string>
+
+using namespace o2::framework;
+using namespace o2::raw;
+
+//_________________________________________________________
+void customize(std::vector<CallbacksPolicy>& policies)
+{
+  o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
+
+//_________________________________________________________
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  std::vector<ConfigParamSpec> options{
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}},
+    {"max-tf", o2::framework::VariantType::Int, 1, {"how many TFs to process"}}};
+  o2::raw::HBFUtilsInitializer::addConfigOption(options);
+  std::swap(workflowOptions, options);
+}
+
+#include "Framework/runDataProcessing.h" // the main driver
+
+//_________________________________________________________
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  WorkflowSpec specs;
+  int maxTF = configcontext.options().get<int>("max-tf");
+  specs.push_back(o2::raw::getDistSTFSenderSpec(maxTF > 0 ? maxTF : 1));
+  // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
+  o2::raw::HBFUtilsInitializer hbfIni(configcontext, specs);
+  return specs;
+}


### PR DESCRIPTION
For the workflows driven by the digits/clusters read from the root files we still have a
problem to synchronize the CCDB fetcher device with workflow TFs, since the former binds
to the `FLP/DISTSUBTIMEFRAME/0` message.

The DistSTFSenderSpec is a simple device which just injects the DISTSUBTIMEFRAME message.
It can be piped into the global workflow via o2-diststf-sender-workflow | ...
or added directly to the workflow containing the reader device, see how it is done in the
GlobalTrackClusterReader.
Since this device does not know how many TFs the readers will inject and cannot see their
endOfStream message, the user can provide the number of DISTSUBTIMEFRAME messages to
inject using --max-tf option. For the multi-TF processing CCDB will be queried for as
many (first) TFs as this option requests.