### PR TITLE
Prototype of the reco TF skimming workflow

### DIFF
--- a/DataFormats/Detectors/GlobalTracking/CMakeLists.txt
+++ b/DataFormats/Detectors/GlobalTracking/CMakeLists.txt
@@ -12,6 +12,7 @@
 o2_add_library(
   DataFormatsGlobalTracking
   SOURCES src/RecoContainer.cxx
+          src/FilteredRecoTF.cxx
   PUBLIC_LINK_LIBRARIES
     O2::DataFormatsTPC
     O2::DataFormatsITSMFT
@@ -34,3 +35,8 @@ o2_add_library(
     O2::GPUDataTypeHeaders
   PRIVATE_LINK_LIBRARIES
     O2::Framework)
+
+o2_target_root_dictionary(
+  DataFormatsGlobalTracking
+  HEADERS include/DataFormatsGlobalTracking/FilteredRecoTF.h
+)

--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/FilteredRecoTF.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/FilteredRecoTF.h
@@ -1,0 +1,62 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file FilteredRecoTF.h
+/// \brief Information filtered out from single TF
+
+#ifndef ALICEO2_FILTERED_RECO_TF_H
+#define ALICEO2_FILTERED_RECO_TF_H
+
+#include <vector>
+#include <string>
+#include <Rtypes.h>
+#include "DataFormatsITSMFT/ROFRecord.h"
+#include "DataFormatsITS/TrackITS.h"
+#include "DataFormatsITSMFT/CompCluster.h"
+#include "SimulationDataFormat/MCCompLabel.h"
+
+namespace o2::dataformats
+{
+
+struct FilteredRecoTF {
+  struct Header {
+    std::uint64_t run = 0;          // run number
+    std::uint64_t creationTime = 0; // creation time from the DataProcessingHeader
+    std::uint32_t firstTForbit = 0; // first orbit of time frame as unique identifier within the run
+
+    std::string asString() const;
+    void clear();
+
+    ClassDefNV(Header, 1);
+  };
+
+  Header header{};
+
+  // here we put the blocks corresponding to different data types
+
+  // ITS tracks
+  std::vector<o2::itsmft::ROFRecord> ITSTrackROFs{};
+  std::vector<o2::its::TrackITS> ITSTracks{};
+  std::vector<int> ITSClusterIndices{};
+  std::vector<o2::MCCompLabel> ITSTrackMCTruth{};
+  // ITS clusters
+  std::vector<o2::itsmft::ROFRecord> ITSClusterROFs{};
+  std::vector<o2::itsmft::CompClusterExt> ITSClusters{};
+  std::vector<unsigned char> ITSClusterPatterns{};
+
+  void clear();
+
+  ClassDefNV(FilteredRecoTF, 1);
+};
+
+} // namespace o2::dataformats
+
+#endif // ALICEO2_FILTERED_RECO_TF_Hxs

--- a/DataFormats/Detectors/GlobalTracking/src/DataFormatsGlobalTrackingLinkDef.h
+++ b/DataFormats/Detectors/GlobalTracking/src/DataFormatsGlobalTrackingLinkDef.h
@@ -1,0 +1,22 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifdef __CLING__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class o2::dataformats::FilteredRecoTF + ;
+#pragma link C++ class o2::dataformats::FilteredRecoTF::Header + ;
+#pragma link C++ class std::vector < o2::dataformats::FilteredRecoTF> + ;
+
+#endif

--- a/DataFormats/Detectors/GlobalTracking/src/FilteredRecoTF.cxx
+++ b/DataFormats/Detectors/GlobalTracking/src/FilteredRecoTF.cxx
@@ -1,0 +1,46 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file FilteredRecoTF.cxx
+/// \brief Information filtered out from single TF
+
+#include "DataFormatsGlobalTracking/FilteredRecoTF.h"
+#include <fmt/printf.h>
+#include <iostream>
+#include "CommonUtils/StringUtils.h"
+
+using namespace o2::dataformats;
+
+std::string FilteredRecoTF::Header::asString() const
+{
+  return fmt::format("Run:{}, TF 1st orbit:{}, creation time:{}", run, firstTForbit, creationTime);
+}
+
+void FilteredRecoTF::Header::clear()
+{
+  run = 0;
+  creationTime = 0;
+  firstTForbit = 0;
+}
+
+void FilteredRecoTF::clear()
+{
+  header.clear();
+  //
+  ITSTrackROFs.clear();
+  ITSTracks.clear();
+  ITSClusterIndices.clear();
+  ITSTrackMCTruth.clear();
+  // ITS clusters
+  ITSClusterROFs.clear();
+  ITSClusters.clear();
+  ITSClusterPatterns.clear();
+}

--- a/Detectors/CMakeLists.txt
+++ b/Detectors/CMakeLists.txt
@@ -38,6 +38,8 @@ if(BUILD_ANALYSIS)
 add_subdirectory(AOD)
 endif()
 
+add_subdirectory(Filtering)
+
 add_subdirectory(Calibration)
 add_subdirectory(DCS)
 

--- a/Detectors/Filtering/CMakeLists.txt
+++ b/Detectors/Filtering/CMakeLists.txt
@@ -1,0 +1,62 @@
+# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# All rights not expressly granted are reserved.
+#
+# This software is distributed under the terms of the GNU General Public
+# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+o2_add_executable(
+  workflow
+  COMPONENT_NAME reco-filtering
+  SOURCES src/filtering-workflow.cxx src/FilteringSpec.cxx
+  PUBLIC_LINK_LIBRARIES
+          O2::DataFormatsGlobalTracking
+          O2::DetectorsVertexing
+          O2::FT0Workflow
+          O2::FDDWorkflow
+          O2::FV0Workflow
+          O2::Framework
+          O2::GlobalTracking
+          O2::GlobalTrackingWorkflow
+          O2::ITSMFTWorkflow
+          O2::ITSWorkflow
+          O2::ITStracking
+          O2::MCHTracking
+          O2::MFTWorkflow
+          O2::MathUtils
+          O2::SimulationDataFormat
+          O2::Steer
+          O2::TPCWorkflow
+          O2::ZDCBase
+)
+
+o2_add_executable(
+  workflow
+  COMPONENT_NAME filtered-reco-tf-reader
+  SOURCES src/filtered-tf-reader-workflow.cxx
+          src/FilteredTFReaderSpec.cxx
+  PUBLIC_LINK_LIBRARIES
+          O2::Framework
+          O2::DataFormatsGlobalTracking
+          O2::SimulationDataFormat
+          O2::ReconstructionDataFormats
+          O2::DataFormatsGlobalTracking
+          O2::DetectorsCommonDataFormats
+          O2::DataFormatsITSMFT
+          O2::DataFormatsITS
+)
+
+o2_add_executable(
+  workflow
+  COMPONENT_NAME filtered-reco-tf-writer
+  SOURCES src/filtered-tf-writer-workflow.cxx
+          src/FilteredTFWriterSpec.cxx
+  PUBLIC_LINK_LIBRARIES
+          O2::Framework
+          O2::DPLUtils
+          O2::DataFormatsGlobalTracking
+)

--- a/Detectors/Filtering/src/FilteredTFReaderSpec.cxx
+++ b/Detectors/Filtering/src/FilteredTFReaderSpec.cxx
@@ -1,0 +1,102 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   FilteredTFReaderSpec.cxx
+
+#include <cassert>
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "FilteredTFReaderSpec.h"
+#include "CommonUtils/NameConf.h"
+
+using namespace o2::framework;
+using namespace o2::dataformats;
+
+namespace o2::filtering
+{
+
+FilteredTFReader::FilteredTFReader(bool useMC)
+{
+  mUseMC = useMC;
+}
+
+void FilteredTFReader::init(InitContext& ic)
+{
+  mInputFileName = o2::utils::Str::concat_string(o2::utils::Str::rectifyDirectory(ic.options().get<std::string>("input-dir")),
+                                                 ic.options().get<std::string>("filtered-tf-infile"));
+  connectTree(mInputFileName);
+}
+
+void FilteredTFReader::run(ProcessingContext& pc)
+{
+  // FIXME: fill all output headers by TF specific info (extend findMessageHeaderStack)
+
+  auto ent = mTree->GetReadEntry() + 1;
+  assert(ent < mTree->GetEntries()); // this should not happen
+  mTree->GetEntry(ent);
+
+  LOG(info) << "Pushing filtered TF: " << mFiltTF.header.asString();
+  // ITS
+  pc.outputs().snapshot(Output{"ITS", "ITSTrackROF", 0, Lifetime::Timeframe}, mFiltTF.ITSTrackROFs);
+  pc.outputs().snapshot(Output{"ITS", "TRACKS", 0, Lifetime::Timeframe}, mFiltTF.ITSTracks);
+  pc.outputs().snapshot(Output{"ITS", "TRACKCLSID", 0, Lifetime::Timeframe}, mFiltTF.ITSClusterIndices);
+  if (mUseMC) {
+    pc.outputs().snapshot(Output{"ITS", "TRACKSMCTR", 0, Lifetime::Timeframe}, mFiltTF.ITSTrackMCTruth);
+  }
+  pc.outputs().snapshot(Output{"ITS", "CLUSTERSROF", 0, Lifetime::Timeframe}, mFiltTF.ITSClusterROFs);
+  pc.outputs().snapshot(Output{"ITS", "COMPCLUSTERS", 0, Lifetime::Timeframe}, mFiltTF.ITSClusters);
+  pc.outputs().snapshot(Output{"ITS", "PATTERNS", 0, Lifetime::Timeframe}, mFiltTF.ITSClusterPatterns);
+
+  if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
+    pc.services().get<ControlService>().endOfStream();
+    pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+  }
+}
+
+void FilteredTFReader::connectTree(const std::string& filename)
+{
+  mTree.reset(nullptr); // in case it was already loaded
+  mFile.reset(TFile::Open(filename.c_str()));
+  assert(mFile && !mFile->IsZombie());
+  mTree.reset((TTree*)mFile->Get(mInputTreeName.c_str()));
+  assert(mTree);
+  assert(mTree->GetBranch(mFTFBranchName.c_str()));
+  mTree->SetBranchAddress(mFTFBranchName.c_str(), &mFiltTFPtr);
+  LOG(info) << "Loaded tree from " << filename << " with " << mTree->GetEntries() << " entries";
+}
+
+DataProcessorSpec getFilteredTFReaderSpec(bool useMC)
+{
+
+  std::vector<OutputSpec> outputSpec;
+  // same as ITSWorkflow/TrackReaderSpec
+  outputSpec.emplace_back("ITS", "ITSTrackROF", 0, Lifetime::Timeframe);
+  outputSpec.emplace_back("ITS", "TRACKS", 0, Lifetime::Timeframe);
+  outputSpec.emplace_back("ITS", "TRACKCLSID", 0, Lifetime::Timeframe);
+  if (useMC) {
+    outputSpec.emplace_back("ITS", "TRACKSMCTR", 0, Lifetime::Timeframe);
+  }
+  // same as ITSMFTWorkflow/ClusterReaderSpec
+  outputSpec.emplace_back("ITS", "CLUSTERSROF", 0, Lifetime::Timeframe);
+  outputSpec.emplace_back("ITS", "COMPCLUSTERS", 0, Lifetime::Timeframe);
+  outputSpec.emplace_back("ITS", "PATTERNS", 0, Lifetime::Timeframe);
+
+  return DataProcessorSpec{
+    "filtered-reco-tf-reader",
+    Inputs{},
+    outputSpec,
+    AlgorithmSpec{adaptFromTask<FilteredTFReader>(useMC)},
+    Options{
+      {"filtered-tf-infile", VariantType::String, "o2_filtered_tf.root", {"Name of the input file"}},
+      {"input-dir", VariantType::String, "none", {"Input directory"}}}};
+}
+
+} // namespace o2::filtering

--- a/Detectors/Filtering/src/FilteredTFReaderSpec.h
+++ b/Detectors/Filtering/src/FilteredTFReaderSpec.h
@@ -1,0 +1,58 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   FilteredTFReaderSpec.h
+/// @brief  Reader for the reconstructed and filtered TF
+
+#ifndef O2_FILTERED_TF_READER_H
+#define O2_FILTERED_TF_READER_H
+
+#include <TFile.h>
+#include <TTree.h>
+#include <vector>
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+#include "Headers/DataHeader.h"
+#include "DataFormatsGlobalTracking/FilteredRecoTF.h"
+
+namespace o2::filtering
+{
+
+class FilteredTFReader : public o2::framework::Task
+{
+
+ public:
+  FilteredTFReader(bool useMC = true);
+  ~FilteredTFReader() override = default;
+  void init(o2::framework::InitContext& ic) final;
+  void run(o2::framework::ProcessingContext& pc) final;
+
+ protected:
+  void connectTree(const std::string& filename);
+
+  o2::dataformats::FilteredRecoTF mFiltTF, *mFiltTFPtr = &mFiltTF;
+
+  bool mUseMC = true; // use MC truth
+
+  std::unique_ptr<TFile> mFile;
+  std::unique_ptr<TTree> mTree;
+  std::string mInputFileName = "";
+  std::string mInputTreeName = "o2sim";
+  std::string mFTFBranchName = "FilteredRecoTF";
+};
+
+/// create a processor spec
+/// read ITS track data from a root file
+framework::DataProcessorSpec getFilteredTFReaderSpec(bool useMC = true);
+
+} // namespace o2::filtering
+
+#endif // O2_FILTERED_TF_READER_H

--- a/Detectors/Filtering/src/FilteredTFWriterSpec.cxx
+++ b/Detectors/Filtering/src/FilteredTFWriterSpec.cxx
@@ -1,0 +1,37 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   FilteredTFWriterSpec.cxx
+
+#include "FilteredTFWriterSpec.h"
+#include "DataFormatsGlobalTracking/FilteredRecoTF.h"
+
+namespace o2::filtering
+{
+
+template <typename T>
+using BranchDefinition = framework::MakeRootTreeWriterSpec::BranchDefinition<T>;
+
+o2::framework::DataProcessorSpec getFilteredTFWriterSpec()
+{
+  using InputSpec = framework::InputSpec;
+  using MakeRootTreeWriterSpec = framework::MakeRootTreeWriterSpec;
+  // Spectators for logging
+  auto logger = [](const o2::dataformats::FilteredRecoTF& tf) {
+    LOG(debug) << "writing filtered TF: " << tf.header.asString();
+  };
+  return MakeRootTreeWriterSpec("filterer-reco-tf-writer",
+                                "o2_filtered_tf.root",
+                                MakeRootTreeWriterSpec::TreeAttributes{"o2sim", "Filtered reconstructed TF"},
+                                BranchDefinition<o2::dataformats::FilteredRecoTF>{InputSpec{"ftf", "GLO", "FILTERED_RECO_TF", 0}, "FTF", logger})();
+}
+
+} // end namespace o2::filtering

--- a/Detectors/Filtering/src/FilteredTFWriterSpec.h
+++ b/Detectors/Filtering/src/FilteredTFWriterSpec.h
@@ -1,0 +1,31 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   FilteredTFWriterSpec.h
+
+#ifndef O2_FILTERED_TF_WRITER_H
+#define O2_FILTERED_TF_WRITER_H
+
+#include "Framework/DataProcessorSpec.h"
+#include "DPLUtils/MakeRootTreeWriterSpec.h"
+#include "Framework/InputSpec.h"
+#include "DataFormatsGlobalTracking/FilteredRecoTF.h"
+
+using namespace o2::framework;
+
+namespace o2::filtering
+{
+
+framework::DataProcessorSpec getFilteredTFWriterSpec();
+
+} // namespace o2::filtering
+
+#endif /* O2_FILTERED_TF_WRITER_H */

--- a/Detectors/Filtering/src/FilteringSpec.cxx
+++ b/Detectors/Filtering/src/FilteringSpec.cxx
@@ -1,0 +1,354 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   FilteringSpec.cxx
+
+#include "FilteringSpec.h"
+#include "DataFormatsFT0/RecPoints.h"
+#include "DataFormatsFDD/RecPoint.h"
+#include "DataFormatsGlobalTracking/RecoContainer.h"
+#include "DataFormatsCTP/Digits.h"
+#include "DataFormatsITS/TrackITS.h"
+#include "DataFormatsMCH/ROFRecord.h"
+#include "DataFormatsMCH/TrackMCH.h"
+#include "DataFormatsMFT/TrackMFT.h"
+#include "DataFormatsTPC/TrackTPC.h"
+#include "DataFormatsZDC/ZDCEnergy.h"
+#include "DataFormatsZDC/ZDCTDCData.h"
+#include "CommonUtils/NameConf.h"
+#include "MathUtils/Utils.h"
+#include "DetectorsBase/GeometryManager.h"
+#include "CCDB/BasicCCDBManager.h"
+#include "CommonConstants/PhysicsConstants.h"
+#include "CommonDataFormat/InteractionRecord.h"
+#include "DataFormatsTRD/TrackTRD.h"
+#include "DataFormatsTRD/TrackTriggerRecord.h"
+#include "DataFormatsGlobalTracking/RecoContainer.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/DataTypes.h"
+#include "Framework/InputRecordWalker.h"
+#include "Framework/Logger.h"
+#include "Framework/TableBuilder.h"
+#include "Framework/TableTreeHelpers.h"
+#include "Framework/CCDBParamSpec.h"
+#include "FDDBase/Constants.h"
+#include "FT0Base/Geometry.h"
+#include "FV0Base/Geometry.h"
+#include "GlobalTracking/MatchTOF.h"
+#include "ReconstructionDataFormats/Cascade.h"
+#include "MCHTracking/TrackExtrap.h"
+#include "MCHTracking/TrackParam.h"
+#include "ITSMFTBase/DPLAlpideParam.h"
+#include "DetectorsVertexing/PVertexerParams.h"
+#include "ReconstructionDataFormats/GlobalTrackID.h"
+#include "ReconstructionDataFormats/Track.h"
+#include "ReconstructionDataFormats/TrackTPCITS.h"
+#include "ReconstructionDataFormats/GlobalFwdTrack.h"
+#include "ReconstructionDataFormats/V0.h"
+#include "ReconstructionDataFormats/VtxTrackIndex.h"
+#include "ReconstructionDataFormats/VtxTrackRef.h"
+#include "SimulationDataFormat/DigitizationContext.h"
+#include "SimulationDataFormat/MCEventLabel.h"
+#include "SimulationDataFormat/MCTrack.h"
+#include "SimulationDataFormat/MCTruthContainer.h"
+#include "SimulationDataFormat/MCUtils.h"
+#include "ZDCBase/Constants.h"
+#include "TPCBase/ParameterElectronics.h"
+#include "GPUTPCGMMergedTrackHit.h"
+#include "TOFBase/Utils.h"
+#include "TMath.h"
+#include "MathUtils/Utils.h"
+#include <map>
+#include <unordered_map>
+#include <string>
+#include <vector>
+
+using namespace o2::framework;
+using namespace o2::math_utils::detail;
+using PVertex = o2::dataformats::PrimaryVertex;
+using GIndex = o2::dataformats::VtxTrackIndex;
+using DataRequest = o2::globaltracking::DataRequest;
+using GID = o2::dataformats::GlobalTrackID;
+using DetID = o2::detectors::DetID;
+
+namespace o2::filtering
+{
+
+void FilteringSpec::run(ProcessingContext& pc)
+{
+  mTimer.Start(false);
+  updateTimeDependentParams(pc);
+  o2::globaltracking::RecoContainer recoData;
+  recoData.collectData(pc, *mDataRequest);
+  mStartIR = recoData.startIR;
+
+  auto primVer2TRefs = recoData.getPrimaryVertexMatchedTrackRefs();
+  /*
+  // examples of accessing different reco data objects
+
+  auto primVertices = recoData.getPrimaryVertices();
+  auto primVerLabels = recoData.getPrimaryVertexMCLabels();
+
+  auto fddChData = recoData.getFDDChannelsData();
+  auto fddRecPoints = recoData.getFDDRecPoints();
+  auto ft0ChData = recoData.getFT0ChannelsData();
+  auto ft0RecPoints = recoData.getFT0RecPoints();
+  auto fv0ChData = recoData.getFV0ChannelsData();
+  auto fv0RecPoints = recoData.getFV0RecPoints();
+
+  auto zdcEnergies = recoData.getZDCEnergy();
+  auto zdcBCRecData = recoData.getZDCBCRecData();
+  auto zdcTDCData = recoData.getZDCTDCData();
+
+  // get calo information
+  auto caloEMCCells = recoData.getEMCALCells();
+  auto caloEMCCellsTRGR = recoData.getEMCALTriggers();
+
+  auto ctpDigits = recoData.getCTPDigits();
+  // std::unique_ptr<o2::steer::MCKinematicsReader> mcReader = std::make_unique<o2::steer::MCKinematicsReader>("collisioncontext.root");
+  */
+
+  // process tracks associated with vertices, note that the last entry corresponds to orphan tracks (no vertex)
+  for (const auto& trackRef : primVer2TRefs) {
+    processTracksOfVertex(trackRef, recoData);
+  }
+
+  if (mNeedToSave) {
+    fillData(recoData);
+    auto dref = pc.inputs().getFirstValid(true);
+    const auto* dh = DataRefUtils::getHeader<o2::header::DataHeader*>(dref);
+    const auto* dph = DataRefUtils::getHeader<DataProcessingHeader*>(dref);
+
+    mFTF.header.run = dh->runNumber;
+    mFTF.header.firstTForbit = dh->firstTForbit;
+    mFTF.header.creationTime = dph->creation;
+
+    pc.outputs().snapshot(Output{"GLO", "FILTERED_RECO_TF", 0}, mFTF);
+    clear(); // clear caches, safe after the snapshot
+  }
+
+  mTimer.Stop();
+}
+
+void FilteringSpec::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
+{
+  if (matcher == ConcreteDataMatcher("ITS", "CLUSTERDICT", 0)) {
+    LOG(info) << "ITS cluster dictionary updated";
+  }
+}
+
+void FilteringSpec::init(InitContext& ic)
+{
+}
+
+void FilteringSpec::clear()
+{
+  mNeedToSave = false;
+  mFTF.clear(); // we can clear immidiately after the snapshot
+  mGIDToTableID.clear();
+  mITSTrackIDCache.clear();
+  mITSClusterIDCache.clear();
+}
+
+void FilteringSpec::fillData(const o2::globaltracking::RecoContainer& recoData)
+{
+  // actual data filling
+
+  // ITS tracks
+  if (!mITSTrackIDCache.empty()) {
+    const auto tracksOrig = recoData.getITSTracks();
+    const auto tracksOrigLbl = recoData.getITSTracksMCLabels();
+    const auto clusRefOrig = recoData.getITSTracksClusterRefs();
+    const auto rofsOrig = recoData.getITSTracksROFRecords();
+    auto trIt = mITSTrackIDCache.begin(); // tracks sorted in their ID
+    for (unsigned irof = 0; irof < rofsOrig.size() && trIt != mITSTrackIDCache.end(); irof++) {
+      const auto& rofOrig = rofsOrig[irof];
+      int startID = rofOrig.getFirstEntry(), endID = startID + rofOrig.getNEntries();
+      if (trIt->first >= endID) {
+        continue; // nothing from this ROF is selected
+      }
+      auto& rofSave = mFTF.ITSTrackROFs.emplace_back(rofOrig);
+      rofSave.setFirstEntry(mFTF.ITSTracks.size());
+      while (trIt != mITSTrackIDCache.end() && trIt->first < endID) {
+        trIt->second = mFTF.ITSTracks.size(); // this for the further bookkeeping?
+        const auto& trOr = tracksOrig[trIt->first];
+        auto& trSave = mFTF.ITSTracks.emplace_back(trOr);
+        trSave.setFirstClusterEntry(mFTF.ITSClusterIndices.size()); // N cluster entries is set correctly at creation
+        for (int i = 0; i < trOr.getNClusters(); i++) {
+          int clID = trOr.getClusterEntry(i);
+          mFTF.ITSClusterIndices.push_back(clID); // later will be remapped to actually stored cluster indices
+          mITSClusterIDCache[clID] = 0;           // flag used cluster
+        }
+        if (mUseMC) {
+          mFTF.ITSTrackMCTruth.push_back(tracksOrigLbl[trIt->first]);
+        }
+        trIt++;
+      }
+      rofSave.setNEntries(mFTF.ITSTracks.size() - rofSave.getFirstEntry());
+    }
+  }
+  // ITS clusters info for selected tracks
+  if (!mITSClusterIDCache.empty()) {
+    const auto clusOrig = recoData.getITSClusters();
+    const auto pattOrig = recoData.getITSClustersPatterns();
+    const auto rofsOrig = recoData.getITSClustersROFRecords();
+    auto clIt = mITSClusterIDCache.begin(); // clusters sorted in their ID
+    auto pattItOrig = pattOrig.begin(), pattItOrigPrev = pattItOrig;
+    for (unsigned irof = 0; irof < rofsOrig.size() && clIt != mITSClusterIDCache.end(); irof++) {
+      const auto& rofOrig = rofsOrig[irof];
+      int startID = rofOrig.getFirstEntry(), endID = startID + rofOrig.getNEntries();
+      if (clIt->first >= endID) {
+        continue; // nothing from this ROF is selected
+      }
+      auto& rofSave = mFTF.ITSClusterROFs.emplace_back(rofOrig);
+      rofSave.setFirstEntry(mFTF.ITSTracks.size());
+      while (clIt != mITSClusterIDCache.end() && clIt->first < endID) {
+        clIt->second = mFTF.ITSClusters.size(); // new index of the stored cluster
+        const auto& clOr = clusOrig[clIt->first];
+        auto& clSave = mFTF.ITSClusters.emplace_back(clOr);
+        // cluster pattern
+        auto pattID = clOr.getPatternID();
+        o2::itsmft::ClusterPattern patt;
+        if (pattID == o2::itsmft::CompCluster::InvalidPatternID || mDictITS->isGroup(pattID)) {
+          patt.acquirePattern(pattItOrig);
+        }
+        while (pattItOrigPrev != pattItOrig) { // the difference, if any, is the explicitly stored pattern
+          mFTF.ITSClusterPatterns.push_back(*pattItOrigPrev);
+          pattItOrigPrev++;
+        }
+        clIt++;
+      }
+      rofSave.setNEntries(mFTF.ITSClusters.size() - rofSave.getFirstEntry());
+    }
+  }
+  // now remap cluster indices to stored values
+  for (auto& clID : mFTF.ITSClusterIndices) {
+    clID = mITSClusterIDCache[clID];
+  }
+}
+
+void FilteringSpec::processTracksOfVertex(const o2::dataformats::VtxTrackRef& trackRef, const o2::globaltracking::RecoContainer& recoData)
+{
+  auto GIndices = recoData.getPrimaryVertexMatchedTracks(); // Global IDs of all tracks
+  int vtxID = trackRef.getVtxID();                          // -1 means that we are processing orphan tracks
+
+  for (int src = GIndex::NSources; src--;) { // loop over all possible types of tracks
+    int start = trackRef.getFirstEntryOfSource(src);
+    int end = start + trackRef.getEntriesOfSource(src);
+    for (int ti = start; ti < end; ti++) {
+      auto& trackIndex = GIndices[ti];
+      if (GIndex::includesSource(src, mInputSources)) { // should we consider this source
+
+        if (trackIndex.isAmbiguous()) { // this trak was matched to multiple vertices
+          const auto res = mGIDToTableID.find(trackIndex);
+          if (res != mGIDToTableID.end()) { // and was already processed
+            if (res->second < 0) {          // was selected, just register its vertex
+              // registerVertex // FIXME: will be done once processing of all track types is complete
+            }
+            continue;
+          }
+        }
+        // here we select barrel tracks only (they must have TPC or ITS contributions)
+        if (!trackIndex.includesDet(DetID::ITS) && !trackIndex.includesDet(DetID::TPC)) {
+          continue;
+        }
+
+        int selRes = processBarrelTrack(trackIndex, recoData); // was track selected?
+        if (trackIndex.isAmbiguous()) {                        // remember decision on this track, if will appear again
+          mGIDToTableID[trackIndex] = selRes;                  // negative answer means rejection
+        }
+      }
+    }
+  }
+}
+
+int FilteringSpec::processBarrelTrack(GIndex idx, const o2::globaltracking::RecoContainer& recoData)
+{
+  int res = selectTrack(idx, recoData);
+  if (res < 0) {
+    return res;
+  }
+  mNeedToSave = true;
+  auto contributorsGID = recoData.getSingleDetectorRefs(idx);
+  //
+  // here is example of processing the ITS track
+  if (contributorsGID[GID::ITS].isIndexSet()) {
+    mITSTrackIDCache[contributorsGID[GID::ITS]] = 0;
+  }
+
+  return res;
+}
+
+bool FilteringSpec::selectTrack(GIndex id, const o2::globaltracking::RecoContainer& recoData)
+{
+  o2::track::TrackParCov t;
+  auto src = id.getSource();
+  if (src == GID::ITSTPCTRDTOF) {
+    t = recoData.getTrack<o2::track::TrackParCov>(recoData.getITSTPCTRDTOFMatches()[id].getTrackRef()); // ITSTPCTRDTOF is ITSTPCTRD + TOF cluster
+  } else if (src == GID::TPCTRDTOF) {
+    t = recoData.getTrack<o2::track::TrackParCov>(recoData.getTPCTRDTOFMatches()[id].getTrackRef()); // TPCTRDTOF is TPCTRD + TOF cluster
+  } else if (src == GID::ITSTPCTOF) {
+    t = recoData.getTrack<o2::track::TrackParCov>(recoData.getTOFMatch(id).getTrackRef()); // ITSTPCTOF is ITSTPC + TOF cluster
+  } else {                                                                                 // for the rest, get the track directly
+    t = recoData.getTrack<o2::track::TrackParCov>(id);
+  }
+  // select on track kinematics, for example, on pT
+  if (t.getPt() < 2.) {
+    return false;
+  }
+  return true;
+}
+
+void FilteringSpec::endOfStream(EndOfStreamContext& ec)
+{
+  LOGF(info, "data filtering total timing: Cpu: %.3e Real: %.3e s in %d slots", mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
+}
+
+void FilteringSpec::updateTimeDependentParams(ProcessingContext& pc)
+{
+  mDictITS = pc.inputs().get<o2::itsmft::TopologyDictionary*>("itsDict").get();
+}
+
+DataProcessorSpec getDataFilteringSpec(GID::mask_t src, bool enableSV, bool useMC)
+{
+  std::vector<OutputSpec> outputs;
+  outputs.emplace_back("GLO", "FILTERED_RECO_TF", 0, o2::framework::Lifetime::Sporadic); // sporadic to avoid sensing TFs which had no selected stuff
+
+  auto dataRequest = std::make_shared<DataRequest>();
+
+  dataRequest->requestTracks(src, useMC);
+  dataRequest->requestPrimaryVertertices(useMC);
+  if (src[GID::CTP]) {
+    LOGF(info, "Requesting CTP digits");
+    dataRequest->requestCTPDigits(useMC);
+  }
+  if (enableSV) {
+    dataRequest->requestSecondaryVertertices(useMC);
+  }
+  if (src[GID::TPC]) {
+    dataRequest->requestClusters(GIndex::getSourcesMask("TPC"), false); // no need to ask for TOF clusters as they are requested with TOF tracks
+  }
+  if (src[GID::EMC]) {
+    dataRequest->requestEMCALCells(useMC);
+  }
+
+  dataRequest->inputs.emplace_back("itsDict", "ITS", "CLUSTERDICT", 0, Lifetime::Condition, ccdbParamSpec("ITS/Calib/ClusterDictionary"));
+
+  return DataProcessorSpec{
+    "reco-data-filter",
+    dataRequest->inputs,
+    outputs,
+    AlgorithmSpec{adaptFromTask<FilteringSpec>(src, dataRequest, enableSV, useMC)},
+    Options{/*ConfigParamSpec{"reco-mctracks-only", VariantType::Int, 0, {"Store only reconstructed MC tracks and their mothers/daughters. 0 -- off, != 0 -- on"}}*/}};
+}
+
+} // namespace o2::filtering

--- a/Detectors/Filtering/src/FilteringSpec.h
+++ b/Detectors/Filtering/src/FilteringSpec.h
@@ -1,0 +1,106 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   FilteringSpec.h
+
+#ifndef O2_DATA_FILTERING_SPEC
+#define O2_DATA_FILTERING_SPEC
+
+#include "DataFormatsGlobalTracking/FilteredRecoTF.h"
+
+#include "CCDB/BasicCCDBManager.h"
+#include "DataFormatsFT0/RecPoints.h"
+#include "DataFormatsFDD/RecPoint.h"
+#include "DataFormatsFV0/RecPoints.h"
+#include "DataFormatsGlobalTracking/RecoContainer.h"
+#include "DataFormatsITS/TrackITS.h"
+#include "DataFormatsMFT/TrackMFT.h"
+#include "DataFormatsMCH/TrackMCH.h"
+#include "DataFormatsTPC/TrackTPC.h"
+#include "DataFormatsTRD/TrackTRD.h"
+#include "DataFormatsZDC/BCRecData.h"
+#include "DataFormatsEMCAL/EventHandler.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+#include "Framework/ConcreteDataMatcher.h"
+#include "DataFormatsGlobalTracking/FilteredRecoTF.h"
+#include "ReconstructionDataFormats/GlobalTrackID.h"
+#include "ReconstructionDataFormats/PrimaryVertex.h"
+#include "ReconstructionDataFormats/TrackTPCITS.h"
+#include "ReconstructionDataFormats/VtxTrackIndex.h"
+#include "SimulationDataFormat/MCCompLabel.h"
+#include "Steer/MCKinematicsReader.h"
+#include "TMap.h"
+#include "TStopwatch.h"
+
+#include "DataFormatsITSMFT/TopologyDictionary.h"
+
+#include <boost/functional/hash.hpp>
+#include <boost/tuple/tuple.hpp>
+#include <boost/unordered_map.hpp>
+#include <string>
+#include <vector>
+
+using namespace o2::framework;
+using GID = o2::dataformats::GlobalTrackID;
+using GIndex = o2::dataformats::VtxTrackIndex;
+using DataRequest = o2::globaltracking::DataRequest;
+
+namespace o2::filtering
+{
+
+class FilteringSpec : public Task
+{
+ public:
+  FilteringSpec(GID::mask_t src, std::shared_ptr<DataRequest> dataRequest, bool enableSV, bool useMC = true)
+    : mInputSources(src), mDataRequest(dataRequest), mEnableSV(enableSV), mUseMC(useMC) {}
+  ~FilteringSpec() override = default;
+  void init(InitContext& ic) final;
+  void run(ProcessingContext& pc) final;
+  void endOfStream(framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(ConcreteDataMatcher&, void*) final;
+
+ private:
+  void fillData(const o2::globaltracking::RecoContainer& recoData);
+  void processTracksOfVertex(const o2::dataformats::VtxTrackRef& vtxref, const o2::globaltracking::RecoContainer& recoData);
+  int processBarrelTrack(GIndex idx, const o2::globaltracking::RecoContainer& recoData);
+  bool selectTrack(GIndex id, const o2::globaltracking::RecoContainer& recoData);
+  void updateTimeDependentParams(ProcessingContext& pc);
+  void clear();
+
+  o2::dataformats::FilteredRecoTF mFTF{};
+
+  bool mUseMC = true;
+  bool mEnableSV = true; // enable secondary vertices
+
+  o2::InteractionRecord mStartIR{};
+  GID::mask_t mInputSources;
+  TStopwatch mTimer;
+
+  bool mNeedToSave = false;                // flag that there was something selected to save
+  std::map<int, int> mITSTrackIDCache{};   // cache for selected ITS track IDS
+  std::map<int, int> mITSClusterIDCache{}; // cache for selected ITS clusters
+
+  // unordered map connects global indices and table indices of barrel tracks
+  std::unordered_map<GIndex, int> mGIDToTableID;
+
+  std::shared_ptr<DataRequest> mDataRequest;
+
+  // CCDB conditions
+  const o2::itsmft::TopologyDictionary* mDictITS = nullptr;
+};
+
+/// create a processor spec
+framework::DataProcessorSpec getDataFilteringSpec(GID::mask_t src, bool enableSV, bool useMC);
+
+} // namespace o2::filtering
+
+#endif /* O2_DATA_FILTERING_SPEC */

--- a/Detectors/Filtering/src/filtered-tf-reader-workflow.cxx
+++ b/Detectors/Filtering/src/filtered-tf-reader-workflow.cxx
@@ -1,0 +1,38 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/ConfigParamSpec.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "Framework/CallbacksPolicy.h"
+
+using namespace o2::framework;
+
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  std::vector<ConfigParamSpec> options{
+    ConfigParamSpec{"disable-mc", VariantType::Bool, false, {"disable mc truth"}},
+    ConfigParamSpec{"configKeyValues", VariantType::String, "", {"semicolon separated key=value strings"}}};
+  std::swap(workflowOptions, options);
+}
+
+#include "Framework/runDataProcessing.h"
+#include "FilteredTFReaderSpec.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cc)
+{
+  WorkflowSpec specs;
+  o2::conf::ConfigurableParam::updateFromString(cc.options().get<std::string>("configKeyValues"));
+  auto useMC = !cc.options().get<bool>("disable-mc");
+
+  specs.emplace_back(o2::filtering::getFilteredTFReaderSpec(useMC));
+
+  return specs;
+}

--- a/Detectors/Filtering/src/filtered-tf-writer-workflow.cxx
+++ b/Detectors/Filtering/src/filtered-tf-writer-workflow.cxx
@@ -1,0 +1,34 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "Framework/ConfigParamSpec.h"
+
+using namespace o2::framework;
+
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  std::vector<o2::framework::ConfigParamSpec> options{{"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
+  std::swap(workflowOptions, options);
+}
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/WorkflowSpec.h"
+#include "FilteredTFWriterSpec.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
+  WorkflowSpec specs;
+  specs.emplace_back(o2::filtering::getFilteredTFWriterSpec());
+  return std::move(specs);
+}

--- a/Detectors/Filtering/src/filtering-workflow.cxx
+++ b/Detectors/Filtering/src/filtering-workflow.cxx
@@ -1,0 +1,74 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "FilteringSpec.h"
+#include "Framework/CompletionPolicy.h"
+#include "ReconstructionDataFormats/GlobalTrackID.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "GlobalTrackingWorkflowHelpers/InputHelper.h"
+#include "DetectorsCommonDataFormats/DetID.h"
+#include "DetectorsRaw/HBFUtilsInitializer.h"
+#include "DetectorsRaw/DistSTFSenderSpec.h"
+#include "Framework/CallbacksPolicy.h"
+
+using namespace o2::framework;
+using GID = o2::dataformats::GlobalTrackID;
+using DetID = o2::detectors::DetID;
+
+void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
+{
+  o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
+
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  std::vector<o2::framework::ConfigParamSpec> options{
+    {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input reader"}},
+    {"disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation"}},
+    {"disable-secondary-vertices", o2::framework::VariantType::Bool, false, {"disable filling secondary vertices"}},
+    {"data-sources", VariantType::String, std::string{GID::ALL}, {"comma-separated list of sources to use"}},
+    {"max-dist-stf", o2::framework::VariantType::Int, 1, {"max TFs with DISTSUBTIMEFRAME message (<1 = disable)"}},
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
+  o2::raw::HBFUtilsInitializer::addConfigOption(options);
+  std::swap(workflowOptions, options);
+}
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
+  auto useMC = !configcontext.options().get<bool>("disable-mc");
+  bool enableSV = !configcontext.options().get<bool>("disable-secondary-vertices");
+  GID::mask_t allowedSrc = GID::getSourcesMask("ITS,TPC,ITS-TPC,ITS-TPC-TOF,TPC-TOF,FT0,FV0,FDD,TPC-TRD,ITS-TPC-TRD,FT0,FV0,FDD,CTP");
+  GID::mask_t src = allowedSrc & GID::getSourcesMask(configcontext.options().get<std::string>("data-sources"));
+
+  WorkflowSpec specs;
+  specs.emplace_back(o2::filtering::getDataFilteringSpec(src, enableSV, useMC));
+
+  o2::globaltracking::InputHelper::addInputSpecs(configcontext, specs, src, src, src, useMC, src);
+  o2::globaltracking::InputHelper::addInputSpecsPVertex(configcontext, specs, useMC);
+  if (enableSV) {
+    o2::globaltracking::InputHelper::addInputSpecsSVertex(configcontext, specs);
+  }
+
+  // if digits reading is requested, generate dist-stf message unless it is explicitly forbidden
+  int maxDistSTF = configcontext.options().get<int>("max-dist-stf");
+  if (maxDistSTF > 0 && !configcontext.options().get<bool>("disable-root-input")) {
+    specs.push_back(o2::raw::getDistSTFSenderSpec(maxDistSTF));
+  }
+
+  // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
+  o2::raw::HBFUtilsInitializer hbfIni(configcontext, specs);
+
+  return std::move(specs);
+}

--- a/Detectors/GlobalTrackingWorkflow/helpers/src/GlobalTrackClusterReader.cxx
+++ b/Detectors/GlobalTrackingWorkflow/helpers/src/GlobalTrackClusterReader.cxx
@@ -13,6 +13,7 @@
 #include "ReconstructionDataFormats/GlobalTrackID.h"
 #include "CommonUtils/ConfigurableParam.h"
 #include "DetectorsRaw/HBFUtilsInitializer.h"
+#include "DetectorsRaw/DistSTFSenderSpec.h"
 #include "Framework/CallbacksPolicy.h"
 #include "Framework/ConfigContext.h"
 
@@ -32,6 +33,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"track-types", VariantType::String, std::string{GlobalTrackID::NONE}, {"comma-separated list of track sources to read"}},
     {"cluster-types", VariantType::String, std::string{GlobalTrackID::NONE}, {"comma-separated list of cluster sources to read"}},
     {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable reading root files, essentially making this workflow void, but needed for compatibility"}},
+    {"max-dist-stf", o2::framework::VariantType::Int, 0, {"max TFs with DISTSUBTIMEFRAME message (<1 = disable)"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
   std::swap(workflowOptions, options);
@@ -54,6 +56,11 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   auto srcMtc = srcTrk & ~GlobalTrackID::getSourceMask(GlobalTrackID::MFTMCH); // Do not request MFTMCH matches
 
   InputHelper::addInputSpecs(cfgc, specs, srcCl, srcMtc, srcTrk, useMC);
+
+  int maxDistSTF = cfgc.options().get<int>("max-dist-stf");
+  if (maxDistSTF > 0) {
+    specs.push_back(o2::raw::getDistSTFSenderSpec(maxDistSTF));
+  }
 
   // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
   o2::raw::HBFUtilsInitializer hbfIni(cfgc, specs);

--- a/Detectors/Raw/CMakeLists.txt
+++ b/Detectors/Raw/CMakeLists.txt
@@ -15,6 +15,7 @@ o2_add_library(DetectorsRaw
                        src/HBFUtils.cxx
                        src/RDHUtils.cxx
                        src/HBFUtilsInitializer.cxx
+                       src/DistSTFSenderSpec.cxx
                PUBLIC_LINK_LIBRARIES FairRoot::Base
                                      O2::Headers
                                      O2::CommonDataFormat
@@ -47,6 +48,11 @@ o2_add_executable(file-reader-workflow
                   src/RawFileReaderWorkflow.cxx
                   PUBLIC_LINK_LIBRARIES O2::DetectorsRaw)
 
+o2_add_executable(sender-workflow
+                  COMPONENT_NAME diststf
+                  SOURCES src/diststf-sender-workflow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::DetectorsRaw)
+
 
 o2_add_test(HBFUtils
             PUBLIC_LINK_LIBRARIES O2::DetectorsRaw
@@ -58,7 +64,7 @@ o2_add_test(HBFUtils
 o2_add_test(RawReaderWriter
             PUBLIC_LINK_LIBRARIES O2::DetectorsRaw
                                   O2::Steer
-                            O2::DPLUtils
+                                  O2::DPLUtils
             SOURCES test/testRawReaderWriter.cxx
             COMPONENT_NAME raw
             LABELS raw)

--- a/Detectors/Raw/include/DetectorsRaw/DistSTFSenderSpec.h
+++ b/Detectors/Raw/include/DetectorsRaw/DistSTFSenderSpec.h
@@ -1,0 +1,24 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_DIST_STF_SENDER_H
+#define O2_DIST_STF_SENDER_H
+
+/// @file DistSTFSenderSpec.h
+/// @brief sends DISTSUBTIMEFRAME messages
+
+#include "Framework/DataProcessorSpec.h"
+
+namespace o2::raw
+{
+o2::framework::DataProcessorSpec getDistSTFSenderSpec(int maxTF);
+}
+#endif

--- a/Detectors/Raw/src/DistSTFSenderSpec.cxx
+++ b/Detectors/Raw/src/DistSTFSenderSpec.cxx
@@ -1,0 +1,64 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "DetectorsRaw/DistSTFSenderSpec.h"
+#include "Framework/ConfigContext.h"
+#include "Framework/DeviceSpec.h"
+#include "Framework/DataRefUtils.h"
+#include "Framework/Task.h"
+#include "Framework/ControlService.h"
+#include "Framework/Logger.h"
+#include "Headers/DataHeader.h"
+#include "Headers/STFHeader.h"
+
+using namespace o2::framework;
+using namespace o2::header;
+
+namespace o2::raw
+{
+
+class DistSTFSender : public Task
+{
+ public:
+  DistSTFSender(int m) : mMaxTF(m) {}
+  void run(ProcessingContext& ctx) final;
+
+ private:
+  int mMaxTF = 1;
+  int mTFCount = 0;
+};
+
+//___________________________________________________________
+void DistSTFSender::run(ProcessingContext& pc)
+{
+  const auto* dh = DataRefUtils::getHeader<DataHeader*>(pc.inputs().getFirstValid(true));
+  auto creationTime = DataRefUtils::getHeader<DataProcessingHeader*>(pc.inputs().getFirstValid(true))->creation;
+  LOG(info) << "DIST STF for run " << dh->runNumber << " orbit " << dh->firstTForbit << " creation " << creationTime << " TFid: " << dh->tfCounter;
+  STFHeader stfHeader{dh->tfCounter, dh->firstTForbit, dh->runNumber};
+  pc.outputs().snapshot(o2::framework::Output{gDataOriginFLP, gDataDescriptionDISTSTF, 0}, stfHeader);
+  if (++mTFCount >= mMaxTF) {
+    pc.services().get<ControlService>().endOfStream();
+    pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+  }
+}
+
+//_________________________________________________________
+DataProcessorSpec getDistSTFSenderSpec(int maxTF)
+{
+  return DataProcessorSpec{
+    "dist-stf-sender",
+    Inputs{},
+    Outputs{OutputSpec{gDataOriginFLP, gDataDescriptionDISTSTF, 0}},
+    AlgorithmSpec{adaptFromTask<DistSTFSender>(maxTF)},
+    Options{}};
+}
+
+} // namespace o2::raw

--- a/Detectors/Raw/src/diststf-sender-workflow.cxx
+++ b/Detectors/Raw/src/diststf-sender-workflow.cxx
@@ -1,0 +1,50 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "DetectorsRaw/HBFUtilsInitializer.h"
+#include "DetectorsRaw/DistSTFSenderSpec.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "Framework/WorkflowSpec.h"
+#include "Framework/CallbacksPolicy.h"
+#include "Framework/Logger.h"
+#include <string>
+
+using namespace o2::framework;
+using namespace o2::raw;
+
+//_________________________________________________________
+void customize(std::vector<CallbacksPolicy>& policies)
+{
+  o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
+
+//_________________________________________________________
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  std::vector<ConfigParamSpec> options{
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}},
+    {"max-tf", o2::framework::VariantType::Int, 1, {"how many TFs to process"}}};
+  o2::raw::HBFUtilsInitializer::addConfigOption(options);
+  std::swap(workflowOptions, options);
+}
+
+#include "Framework/runDataProcessing.h" // the main driver
+
+//_________________________________________________________
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  WorkflowSpec specs;
+  int maxTF = configcontext.options().get<int>("max-tf");
+  specs.push_back(o2::raw::getDistSTFSenderSpec(maxTF > 0 ? maxTF : 1));
+  // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
+  o2::raw::HBFUtilsInitializer hbfIni(configcontext, specs);
+  return specs;
+}


### PR DESCRIPTION
@wiechula @miranov25, @marslandALICE

At the moment filters to the output only ITS tracks/clusters. Once processing of all
track types is done, creation of the skimmed vertex and track-to-vertex attachment list
should be implemented.
To test: produce some data by e.g. 
`$O2_ROOT/prodtests/sim_challenge.sh` script then run
o2-reco-filtering-workflow | o2-filtered-reco-tf-writer-workflow

