### PR TITLE
Fixed runType in ITS calib workflow

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/src/ThresholdCalibratorSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ThresholdCalibratorSpec.cxx
@@ -719,7 +719,7 @@ void ITSThresholdCalibrator::run(ProcessingContext& pc)
         }
 
         if (this->mRunType == -1) {
-          short int runtype = (short int)(calib.calibUserField >> 24);
+          short int runtype = ((short int)(calib.calibUserField >> 24)) & 0x68;
           this->setRunType(runtype);
         }
         this->mRunTypeUp = (short int)(calib.calibUserField >> 24);


### PR DESCRIPTION
Run type not converted correctly when DB version is different from 0. Added mask to work in all cases. 