### PR TITLE
Bugfix: using message size as payload size

### DIFF
--- a/Framework/Core/include/Framework/DataRefUtils.h
+++ b/Framework/Core/include/Framework/DataRefUtils.h
@@ -34,6 +34,7 @@ struct DataRefUtils {
   template <typename T>
   static auto as(DataRef const& ref)
   {
+    auto payloadSize = DataRefUtils::getPayloadSize(ref);
     // SFINAE makes this available only for the case we are using
     // trivially copyable type, this is to distinguish it from the
     // alternative below, which works for TObject (which are serialised).
@@ -43,11 +44,11 @@ struct DataRefUtils {
       if (header->payloadSerializationMethod != o2::header::gSerializationMethodNone) {
         throw runtime_error("Attempt to extract a POD from a wrong message kind");
       }
-      if ((header->payloadSize % sizeof(T)) != 0) {
+      if ((payloadSize % sizeof(T)) != 0) {
         throw runtime_error("Cannot extract POD from message as size do not match");
       }
       //FIXME: provide a const collection
-      return gsl::span<T>(reinterpret_cast<T*>(const_cast<char*>(ref.payload)), header->payloadSize / sizeof(T));
+      return gsl::span<T>(reinterpret_cast<T*>(const_cast<char*>(ref.payload)), payloadSize / sizeof(T));
     } else if constexpr (has_root_dictionary<T>::value == true &&
                          is_messageable<T>::value == false) {
       std::unique_ptr<T> result;
@@ -65,7 +66,7 @@ struct DataRefUtils {
           throw runtime_error("Attempt to extract a TMessage from non-ROOT serialised message");
         }
 
-        typename RSS::FairTMessage ftm(const_cast<char*>(ref.payload), header->payloadSize);
+        typename RSS::FairTMessage ftm(const_cast<char*>(ref.payload), payloadSize);
         auto* storedClass = ftm.GetClass();
         auto* requestedClass = RSS::TClass::GetClass(typeid(T));
         // should always have the class description if has_root_dictionary is true
@@ -140,7 +141,7 @@ struct DataRefUtils {
           throw runtime_error("ROOT serialization not supported, dictionary not found for data type");
         }
 
-        typename RSS::FairTMessage ftm(const_cast<char*>(ref.payload), header->payloadSize);
+        typename RSS::FairTMessage ftm(const_cast<char*>(ref.payload), payloadSize);
         result.reset(static_cast<wrapped*>(ftm.ReadObjectAny(cl)));
         if (result.get() == nullptr) {
           throw runtime_error_f("Unable to extract class %s", cl == nullptr ? "<name not available>" : cl->GetName());


### PR DESCRIPTION
This is a follow-up to 94ef6f641a2c8b4c8fb4eefd3b68d119b02d912e
where only the code in InputRecord.h has been adapted. Using the
correct payload size now also in the utility methods of DataRefUtils.

Relates to O2-2395