### PR TITLE
Using DataRefUtils to get payload size

### DIFF
--- a/Detectors/CPV/workflow/src/RawToDigitConverterSpec.cxx
+++ b/Detectors/CPV/workflow/src/RawToDigitConverterSpec.cxx
@@ -12,6 +12,7 @@
 #include "FairLogger.h"
 #include "CommonDataFormat/InteractionRecord.h"
 #include "Framework/InputRecordWalker.h"
+#include "Framework/DataRefUtils.h"
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/ControlService.h"
 #include "Framework/WorkflowSpec.h"
@@ -140,11 +141,12 @@ void RawToDigitConverterSpec::run(framework::ProcessingContext& ctx)
   std::vector<o2::framework::InputSpec> dummy{o2::framework::InputSpec{"dummy", o2::framework::ConcreteDataMatcher{"CPV", o2::header::gDataDescriptionRawData, 0xDEADBEEF}}};
   for (const auto& ref : framework::InputRecordWalker(ctx.inputs(), dummy)) {
     const auto dh = o2::framework::DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
-    if (dh->payloadSize == 0) { // send empty output
+    auto payloadSize = o2::framework::DataRefUtils::getPayloadSize(ref);
+    if (payloadSize == 0) { // send empty output
       auto maxWarn = o2::conf::VerbosityConfig::Instance().maxWarnDeadBeef;
       if (++contDeadBeef <= maxWarn) {
         LOGP(warning, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
-             dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize,
+             dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, payloadSize,
              contDeadBeef == maxWarn ? fmt::format(". {} such inputs in row received, stopping reporting", contDeadBeef) : "");
       }
       mOutputDigits.clear();

--- a/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
@@ -19,6 +19,7 @@
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/ControlService.h"
 #include "Framework/InputRecordWalker.h"
+#include "Framework/DataRefUtils.h"
 #include "Framework/Logger.h"
 #include "Framework/WorkflowSpec.h"
 #include "DataFormatsEMCAL/Constants.h"
@@ -517,11 +518,12 @@ bool RawToCellConverterSpec::isLostTimeframe(framework::ProcessingContext& ctx) 
   static size_t contDeadBeef = 0; // number of times 0xDEADBEEF was seen continuously
   for (const auto& ref : o2::framework::InputRecordWalker(ctx.inputs(), {dummy})) {
     const auto dh = o2::framework::DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
-    if (dh->payloadSize == 0) {
+    auto payloadSize = o2::framework::DataRefUtils::getPayloadSize(ref);
+    if (payloadSize == 0) {
       auto maxWarn = o2::conf::VerbosityConfig::Instance().maxWarnDeadBeef;
       if (++contDeadBeef <= maxWarn) {
         LOGP(warning, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
-             dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize,
+             dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, payloadSize,
              contDeadBeef == maxWarn ? fmt::format(". {} such inputs in row received, stopping reporting", contDeadBeef) : "");
       }
       return true;

--- a/Detectors/FIT/FT0/workflow/include/FT0Workflow/FT0DataReaderDPLSpec.h
+++ b/Detectors/FIT/FT0/workflow/include/FT0Workflow/FT0DataReaderDPLSpec.h
@@ -54,11 +54,12 @@ class FT0DataReaderDPLSpec : public Task
       std::vector<InputSpec> dummy{InputSpec{"dummy", ConcreteDataMatcher{o2::header::gDataOriginFT0, o2::header::gDataDescriptionRawData, 0xDEADBEEF}}};
       for (const auto& ref : InputRecordWalker(pc.inputs(), dummy)) {
         const auto dh = o2::framework::DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
-        if (dh->payloadSize == 0) {
+        auto payloadSize = DataRefUtils::getPayloadSize(ref);
+        if (payloadSize == 0) {
           auto maxWarn = o2::conf::VerbosityConfig::Instance().maxWarnDeadBeef;
           if (++contDeadBeef <= maxWarn) {
             LOGP(warning, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
-                 dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize,
+                 dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, payloadSize,
                  contDeadBeef == maxWarn ? fmt::format(". {} such inputs in row received, stopping reporting", contDeadBeef) : "");
           }
           mRawReader.makeSnapshot(pc); // send empty output

--- a/Detectors/FIT/workflow/include/FITWorkflow/FITDataReaderDPLSpec.h
+++ b/Detectors/FIT/workflow/include/FITWorkflow/FITDataReaderDPLSpec.h
@@ -77,11 +77,12 @@ class FITDataReaderDPLSpec : public Task
       std::vector<InputSpec> dummy{InputSpec{"dummy", ConcreteDataMatcher{mRawReader.mDataOrigin, o2::header::gDataDescriptionRawData, 0xDEADBEEF}}};
       for (const auto& ref : InputRecordWalker(pc.inputs(), dummy)) {
         const auto dh = o2::framework::DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
-        if (dh->payloadSize == 0) {
+        auto payloadSize = DataRefUtils::getPayloadSize(ref);
+        if (payloadSize == 0) {
           auto maxWarn = o2::conf::VerbosityConfig::Instance().maxWarnDeadBeef;
           if (++contDeadBeef <= maxWarn) {
             LOGP(warning, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
-                 dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize,
+                 dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, payloadSize,
                  contDeadBeef == maxWarn ? fmt::format(". {} such inputs in row received, stopping reporting", contDeadBeef) : "");
           }
           mRawReader.makeSnapshot(pc); // send empty output

--- a/Detectors/HMPID/workflow/src/DataDecoderSpec2.cxx
+++ b/Detectors/HMPID/workflow/src/DataDecoderSpec2.cxx
@@ -183,11 +183,12 @@ void DataDecoderTask2::decodeTF(framework::ProcessingContext& pc)
     std::vector<InputSpec> dummy{InputSpec{"dummy", ConcreteDataMatcher{"HMP", "RAWDATA", 0xDEADBEEF}}};
     for (const auto& ref : InputRecordWalker(inputs, dummy)) {
       const auto dh = o2::framework::DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
-      if (dh->payloadSize == 0) {
+      auto payloadSize = DataRefUtils::getPayloadSize(ref);
+      if (payloadSize == 0) {
         auto maxWarn = o2::conf::VerbosityConfig::Instance().maxWarnDeadBeef;
         if (++contDeadBeef <= maxWarn) {
           LOGP(warning, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
-               dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize,
+               dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, payloadSize,
                contDeadBeef == maxWarn ? fmt::format(". {} such inputs in row received, stopping reporting", contDeadBeef) : "");
         }
         return;

--- a/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
@@ -16,6 +16,7 @@
 #include "ITSMFTReconstruction/RawPixelDecoder.h"
 #include "DPLUtils/DPLRawParser.h"
 #include "Framework/InputRecordWalker.h"
+#include "Framework/DataRefUtils.h"
 #include "CommonUtils/StringUtils.h"
 #include "CommonUtils/VerbosityConfig.h"
 
@@ -182,11 +183,12 @@ void RawPixelDecoder<Mapping>::setupLinks(InputRecord& inputs)
     std::vector<InputSpec> dummy{InputSpec{"dummy", ConcreteDataMatcher{origin, datadesc, 0xDEADBEEF}}};
     for (const auto& ref : InputRecordWalker(inputs, dummy)) {
       const auto dh = o2::framework::DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
-      if (dh->payloadSize == 0) {
+      auto payloadSize = o2::framework::DataRefUtils::getPayloadSize(ref);
+      if (payloadSize == 0) {
         auto maxWarn = o2::conf::VerbosityConfig::Instance().maxWarnDeadBeef;
         if (++contDeadBeef <= maxWarn) {
           LOGP(warning, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
-               dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize,
+               dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, payloadSize,
                contDeadBeef == maxWarn ? fmt::format(". {} such inputs in row received, stopping reporting", contDeadBeef) : "");
         }
         return;

--- a/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
@@ -180,11 +180,12 @@ class DataDecoderTask
                                                                   0xDEADBEEF}};
     for (const auto& ref : o2::framework::InputRecordWalker(pc.inputs(), {dummy})) {
       const auto dh = o2::framework::DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
-      if (dh->payloadSize == 0) {
+      auto payloadSize = DataRefUtils::getPayloadSize(ref);
+      if (payloadSize == 0) {
         auto maxWarn = o2::conf::VerbosityConfig::Instance().maxWarnDeadBeef;
         if (++contDeadBeef <= maxWarn) {
           LOGP(warning, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
-               dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize,
+               dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, payloadSize,
                contDeadBeef == maxWarn ? fmt::format(". {} such inputs in row received, stopping reporting", contDeadBeef) : "");
         }
         return true;

--- a/Detectors/MUON/MID/Workflow/src/RawInputSpecHandler.cxx
+++ b/Detectors/MUON/MID/Workflow/src/RawInputSpecHandler.cxx
@@ -32,11 +32,12 @@ bool isDroppedTF(o2::framework::ProcessingContext& pc, o2::header::DataOrigin or
   std::vector<o2::framework::InputSpec> dummy{o2::framework::InputSpec{"dummy", o2::framework::ConcreteDataMatcher{origin, o2::header::gDataDescriptionRawData, 0xDEADBEEF}}};
   for (const auto& ref : o2::framework::InputRecordWalker(pc.inputs(), dummy)) {
     const auto dh = o2::framework::DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
-    if (dh->payloadSize == 0) {
+    auto payloadSize = o2::framework::DataRefUtils::getPayloadSize(ref);
+    if (payloadSize == 0) {
       auto maxWarn = o2::conf::VerbosityConfig::Instance().maxWarnDeadBeef;
       if (++contDeadBeef <= maxWarn) {
         LOGP(warning, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
-             dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize,
+             dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, payloadSize,
              contDeadBeef == maxWarn ? fmt::format(". {} such inputs in row received, stopping reporting", contDeadBeef) : "");
       }
       return true;

--- a/Detectors/PHOS/workflow/src/RawToCellConverterSpec.cxx
+++ b/Detectors/PHOS/workflow/src/RawToCellConverterSpec.cxx
@@ -18,6 +18,7 @@
 #include "DataFormatsPHOS/TriggerRecord.h"
 #include "DetectorsRaw/RDHUtils.h"
 #include "Framework/InputRecordWalker.h"
+#include "Framework/DataRefUtils.h"
 #include "CCDB/CcdbApi.h"
 #include "PHOSBase/Mapping.h"
 #include "PHOSBase/PHOSSimParams.h"
@@ -108,11 +109,12 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
   std::vector<o2::framework::InputSpec> dummy{o2::framework::InputSpec{"dummy", o2::framework::ConcreteDataMatcher{"PHS", o2::header::gDataDescriptionRawData, 0xDEADBEEF}}};
   for (const auto& ref : framework::InputRecordWalker(ctx.inputs(), dummy)) {
     const auto dh = o2::framework::DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
-    if (dh->payloadSize == 0) { // send empty output
+    auto payloadSize = o2::framework::DataRefUtils::getPayloadSize(ref);
+    if (payloadSize == 0) { // send empty output
       auto maxWarn = o2::conf::VerbosityConfig::Instance().maxWarnDeadBeef;
       if (++contDeadBeef <= maxWarn) {
         LOGP(warning, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
-             dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize,
+             dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, payloadSize,
              contDeadBeef == maxWarn ? fmt::format(". {} such inputs in row received, stopping reporting", contDeadBeef) : "");
       }
       mOutputCells.clear();

--- a/Detectors/TOF/compression/src/CompressorTask.cxx
+++ b/Detectors/TOF/compression/src/CompressorTask.cxx
@@ -81,6 +81,7 @@ void CompressorTask<RDH, verbose, paranoid>::run(ProcessingContext& pc)
 
     /** store parts in map **/
     auto headerIn = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
+    auto payloadInSize = DataRefUtils::getPayloadSize(ref);
     auto subspec = headerIn->subSpecification;
     subspecPartMap[subspec].push_back(ref);
 
@@ -88,7 +89,7 @@ void CompressorTask<RDH, verbose, paranoid>::run(ProcessingContext& pc)
     if (!subspecBufferSize.count(subspec)) {
       subspecBufferSize[subspec] = 0;
     }
-    subspecBufferSize[subspec] += headerIn->payloadSize;
+    subspecBufferSize[subspec] += payloadInSize;
     //  }
   }
 
@@ -118,7 +119,7 @@ void CompressorTask<RDH, verbose, paranoid>::run(ProcessingContext& pc)
       auto headerIn = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
       auto dataProcessingHeaderIn = DataRefUtils::getHeader<o2::framework::DataProcessingHeader*>(ref);
       auto payloadIn = ref.payload;
-      auto payloadInSize = headerIn->payloadSize;
+      auto payloadInSize = DataRefUtils::getPayloadSize(ref);
 
       /** prepare compressor **/
       mCompressor.setDecoderBuffer(payloadIn);

--- a/Detectors/TOF/workflow/src/CompressedAnalysisTask.cxx
+++ b/Detectors/TOF/workflow/src/CompressedAnalysisTask.cxx
@@ -87,7 +87,7 @@ void CompressedAnalysisTask::run(ProcessingContext& pc)
 
       const auto* headerIn = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
       auto payloadIn = ref.payload;
-      auto payloadInSize = headerIn->payloadSize;
+      auto payloadInSize = DataRefUtils::getPayloadSize(ref);
 
       mAnalysis->setDecoderBuffer(payloadIn);
       mAnalysis->setDecoderBufferSize(payloadInSize);

--- a/Detectors/TOF/workflow/src/CompressedDecodingTask.cxx
+++ b/Detectors/TOF/workflow/src/CompressedDecodingTask.cxx
@@ -172,11 +172,12 @@ void CompressedDecodingTask::decodeTF(ProcessingContext& pc)
     std::vector<InputSpec> dummy{InputSpec{"dummy", ConcreteDataMatcher{"TOF", mDataDesc, 0xDEADBEEF}}};
     for (const auto& ref : InputRecordWalker(inputs, dummy)) {
       const auto dh = o2::framework::DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
-      if (dh->payloadSize == 0) {
+      auto payloadSize = DataRefUtils::getPayloadSize(ref);
+      if (payloadSize == 0) {
         auto maxWarn = o2::conf::VerbosityConfig::Instance().maxWarnDeadBeef;
         if (++contDeadBeef <= maxWarn) {
           LOGP(warning, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
-               dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize,
+               dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, payloadSize,
                contDeadBeef == maxWarn ? fmt::format(". {} such inputs in row received, stopping reporting", contDeadBeef) : "");
         }
         return;
@@ -197,7 +198,7 @@ void CompressedDecodingTask::decodeTF(ProcessingContext& pc)
     //    for (auto const& ref : iit) {
     const auto* headerIn = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
     auto payloadIn = ref.payload;
-    auto payloadInSize = headerIn->payloadSize;
+    auto payloadInSize = DataRefUtils::getPayloadSize(ref);
 
     DecoderBase::setDecoderBuffer(payloadIn);
     DecoderBase::setDecoderBufferSize(payloadInSize);

--- a/Detectors/TOF/workflow/src/CompressedInspectorTask.cxx
+++ b/Detectors/TOF/workflow/src/CompressedInspectorTask.cxx
@@ -104,7 +104,7 @@ void CompressedInspectorTask<RDH>::run(ProcessingContext& pc)
 
       const auto* headerIn = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
       auto payloadIn = ref.payload;
-      auto payloadInSize = headerIn->payloadSize;
+      auto payloadInSize = DataRefUtils::getPayloadSize(ref);
 
       DecoderBaseT<RDH>::setDecoderBuffer(payloadIn);
       DecoderBaseT<RDH>::setDecoderBufferSize(payloadInSize);

--- a/Detectors/TPC/workflow/src/CalibProcessingHelper.cxx
+++ b/Detectors/TPC/workflow/src/CalibProcessingHelper.cxx
@@ -73,8 +73,9 @@ uint64_t calib_processing_helper::processRawData(o2::framework::InputRecord& inp
 
   for (auto const& ref : InputRecordWalker(inputs, filter)) {
     const auto* dh = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
+    auto payloadSize = DataRefUtils::getPayloadSize(ref);
     // skip empty HBF
-    if (dh->payloadSize == 2 * sizeof(o2::header::RAWDataHeader)) {
+    if (payloadSize == 2 * sizeof(o2::header::RAWDataHeader)) {
       continue;
     }
 
@@ -108,7 +109,7 @@ uint64_t calib_processing_helper::processRawData(o2::framework::InputRecord& inp
     rdh_utils::getMapping(feeID, cruID, endPoint, linkID);
     const auto globalLinkID = linkID + endPoint * 12;
     LOGP(debug, "Specifier: {}/{}/{} Part {} of {}", dh->dataOrigin, dh->dataDescription, subSpecification, dh->splitPayloadIndex, dh->splitPayloadParts);
-    LOGP(debug, "Payload size: {}", dh->payloadSize);
+    LOGP(debug, "Payload size: {}", payloadSize);
     LOGP(debug, "CRU: {}; linkID: {}; endPoint: {}; globalLinkID: {}", cruID, linkID, endPoint, globalLinkID);
     // ^^^^^^
 
@@ -148,7 +149,7 @@ uint64_t calib_processing_helper::processRawData(o2::framework::InputRecord& inp
 
     } catch (const std::exception& e) {
       LOGP(alarm, "EXCEPTIION in processRawData: {} -> skipping part:{}/{} of spec:{}/{}/{}, size:{}", e.what(), dh->splitPayloadIndex, dh->splitPayloadParts,
-           dh->dataOrigin, dh->dataDescription, subSpecification, dh->payloadSize);
+           dh->dataOrigin, dh->dataDescription, subSpecification, payloadSize);
       errorCount++;
       continue;
     }
@@ -234,8 +235,9 @@ uint32_t getBCsyncOffsetReference(InputRecord& inputs, const std::vector<InputSp
 
   for (auto const& ref : InputRecordWalker(inputs, filter)) {
     const auto* dh = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
+    auto payloadSize = DataRefUtils::getPayloadSize(ref);
     // skip empty HBF
-    if (dh->payloadSize == 2 * sizeof(o2::header::RAWDataHeader)) {
+    if (payloadSize == 2 * sizeof(o2::header::RAWDataHeader)) {
       continue;
     }
 

--- a/Detectors/TPC/workflow/src/LinkZSToDigitsSpec.cxx
+++ b/Detectors/TPC/workflow/src/LinkZSToDigitsSpec.cxx
@@ -119,6 +119,7 @@ o2::framework::DataProcessorSpec getLinkZSToDigitsSpec(int channel, const std::s
       // loop over all inputs
       for (auto& input : pc.inputs()) {
         const auto* dh = DataRefUtils::getHeader<o2::header::DataHeader*>(input);
+        auto payloadSize = DataRefUtils::getPayloadSize(input);
 
         // select only RAW data
         if (dh->dataDescription != o2::header::gDataDescriptionRawData) {
@@ -143,11 +144,11 @@ o2::framework::DataProcessorSpec getLinkZSToDigitsSpec(int channel, const std::s
         processAttributes->activeSectors |= (0x1 << sector);
 
         LOGP(debug, "Specifier: {}/{}/{}", dh->dataOrigin, dh->dataDescription, dh->subSpecification);
-        LOGP(debug, "Payload size: {}", dh->payloadSize);
+        LOGP(debug, "Payload size: {}", payloadSize);
         LOGP(debug, "CRU: {}; linkID: {}; dataWrapperID: {}; globalLinkID: {}", cruID, linkID, dataWrapperID, globalLinkID);
 
         try {
-          o2::framework::RawParser parser(input.payload, dh->payloadSize);
+          o2::framework::RawParser parser(input.payload, payloadSize);
 
           for (auto it = parser.begin(), end = parser.end(); it != end; ++it) {
             auto* rdhPtr = it.get_if<o2::header::RAWDataHeader>();
@@ -280,7 +281,7 @@ o2::framework::DataProcessorSpec getLinkZSToDigitsSpec(int channel, const std::s
 
         } catch (const std::runtime_error& e) {
           LOG(alarm) << "can not create raw parser form input data";
-          o2::header::hexDump("payload", input.payload, dh->payloadSize, 64);
+          o2::header::hexDump("payload", input.payload, payloadSize, 64);
           LOG(alarm) << e.what();
         }
       }

--- a/Detectors/TRD/reconstruction/src/CruCompressorTask.cxx
+++ b/Detectors/TRD/reconstruction/src/CruCompressorTask.cxx
@@ -134,7 +134,7 @@ void CruCompressorTask::run(ProcessingContext& pc)
       auto headerIn = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
       auto dataProcessingHeaderIn = DataRefUtils::getHeader<o2::framework::DataProcessingHeader*>(ref);
       auto payloadIn = ref.payload;
-      auto payloadInSize = headerIn->payloadSize;
+      auto payloadInSize = DataRefUtils::getPayloadSize(ref);
       std::cout << "payload In is : " << std::hex << payloadIn << std::endl;
       std::cout << "payload In is : " << std::dec << payloadIn << std::endl;
       std::cout << "payload In size is : " << std::dec << payloadInSize << std::endl;

--- a/Detectors/TRD/reconstruction/src/DataReaderTask.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReaderTask.cxx
@@ -21,6 +21,7 @@
 #include "Framework/DeviceSpec.h"
 #include "Framework/DataSpecUtils.h"
 #include "Framework/InputRecordWalker.h"
+#include "Framework/DataRefUtils.h"
 #include "CommonUtils/VerbosityConfig.h"
 
 #include "DataFormatsTRD/Constants.h"
@@ -232,11 +233,12 @@ bool DataReaderTask::isTimeFrameEmpty(ProcessingContext& pc)
   static size_t contDeadBeef = 0; // number of times 0xDEADBEEF was seen continuously
   for (const auto& ref : o2::framework::InputRecordWalker(pc.inputs(), {dummy})) {
     const auto dh = o2::framework::DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
-    if (dh->payloadSize == 0) {
+    auto payloadSize = o2::framework::DataRefUtils::getPayloadSize(ref);
+    if (payloadSize == 0) {
       auto maxWarn = o2::conf::VerbosityConfig::Instance().maxWarnDeadBeef;
       if (++contDeadBeef <= maxWarn) {
         LOGP(warning, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
-             dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize,
+             dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, payloadSize,
              contDeadBeef == maxWarn ? fmt::format(". {} such inputs in row received, stopping reporting", contDeadBeef) : "");
       }
       return true;
@@ -264,18 +266,18 @@ void DataReaderTask::run(ProcessingContext& pc)
     auto inputprocessingstart = std::chrono::high_resolution_clock::now(); // measure total processing time
     const auto* dh = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
     tfCount = dh->tfCounter;
+    auto payloadIn = ref.payload;
+    auto payloadInSize = DataRefUtils::getPayloadSize(ref);
     if (mVerbose) {
       LOGP(info, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : ",
-           dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize);
+           dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, payloadInSize);
     }
-    auto payloadIn = ref.payload;
-    auto payloadInSize = dh->payloadSize;
     if (!mCompressedData) { //we have raw data coming in from flp
       if (mVerbose) {
         LOG(info) << " parsing non compressed data in the data reader task with a payload of " << payloadInSize << " payload size";
       }
-      //          LOG(info) << "start of data is at ref.payload=0x"<< std::hex << " dh->payloadSize:0x" << dh->payloadSize <<" dh->headerSize:0x" <<dh->headerSize;
-      total1 += dh->payloadSize;
+      //          LOG(info) << "start of data is at ref.payload=0x"<< std::hex << " payloadSize:0x" << payloadInSize <<" dh->headerSize:0x" <<dh->headerSize;
+      total1 += payloadInSize;
       total2 += dh->headerSize;
       //          LOG(info) << "start of data is at ref.payload=0x"<< std::hex << " total1:0x" << total1 <<" total2:0x" <<total2;
       mReader.setDataBuffer(payloadIn);

--- a/Detectors/ZDC/raw/src/raw-parser.cxx
+++ b/Detectors/ZDC/raw/src/raw-parser.cxx
@@ -84,7 +84,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
                   } else {
                     rdhprintout << " " + std::to_string(dh->splitPayloadParts) + " part(s)";
                   }
-                  rdhprintout << " payload size " << dh->payloadSize << std::endl;
+                  rdhprintout << " payload size " << payloadSize << std::endl;
                 }
                 if (!rdhprintout.str().empty()) {
                   LOG(info) << rdhprintout.str();

--- a/Detectors/ZDC/workflow/src/ZDCDataReaderDPLSpec.cxx
+++ b/Detectors/ZDC/workflow/src/ZDCDataReaderDPLSpec.cxx
@@ -44,11 +44,12 @@ void ZDCDataReaderDPLSpec::run(ProcessingContext& pc)
     std::vector<InputSpec> dummy{InputSpec{"dummy", ConcreteDataMatcher{o2::header::gDataOriginZDC, o2::header::gDataDescriptionRawData, 0xDEADBEEF}}};
     for (const auto& ref : InputRecordWalker(pc.inputs(), dummy)) {
       const auto dh = o2::framework::DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
-      if (dh->payloadSize == 0) {
+      auto payloadSize = DataRefUtils::getPayloadSize(ref);
+      if (payloadSize == 0) {
         auto maxWarn = o2::conf::VerbosityConfig::Instance().maxWarnDeadBeef;
         if (++contDeadBeef <= maxWarn) {
           LOGP(warning, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
-               dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, dh->payloadSize,
+               dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, payloadSize,
                contDeadBeef == maxWarn ? fmt::format(". {} such inputs in row received, stopping reporting", contDeadBeef) : "");
         }
         mRawReader.makeSnapshot(pc); // send empty output


### PR DESCRIPTION
When sending payload data with pruned headers, payload size is taken
from message size, handled in DataRefUtils::getpayloadSize.

Most of the changes actually concern a piece of duplicated code spilled over all detectors, we should do something with that.