### PR TITLE
IDCs: various code optimisations

### DIFF
--- a/Detectors/TPC/base/include/TPCBase/CalArray.h
+++ b/Detectors/TPC/base/include/TPCBase/CalArray.h
@@ -278,7 +278,7 @@ inline bool CalArray<T>::operator==(const CalArray<T>& other) const
     LOG(error) << "pad subset type of the objects it not compatible";
     return false;
   }
-  bool isSame = mData == other.mData;
+  bool isSame = (mData == other.mData);
   return isSame;
 }
 

--- a/Detectors/TPC/base/include/TPCBase/CalArray.h
+++ b/Detectors/TPC/base/include/TPCBase/CalArray.h
@@ -122,6 +122,9 @@ class CalArray
   /// Divide this by other channel by channel
   const CalArray& operator/=(const CalArray& other);
 
+  /// check for equality
+  bool operator==(const CalArray& other) const;
+
   /// Add value to all channels
   const CalArray& operator+=(const T& val);
 
@@ -265,6 +268,18 @@ inline const CalArray<T>& CalArray<T>::operator/=(const CalArray<T>& other)
     }
   }
   return *this;
+}
+
+//______________________________________________________________________________
+template <class T>
+inline bool CalArray<T>::operator==(const CalArray<T>& other) const
+{
+  if (!((mPadSubset == other.mPadSubset) && (mPadSubsetNumber == other.mPadSubsetNumber))) {
+    LOG(error) << "pad subset type of the objects it not compatible";
+    return false;
+  }
+  bool isSame = mData == other.mData;
+  return isSame;
 }
 
 //______________________________________________________________________________

--- a/Detectors/TPC/base/include/TPCBase/CalDet.h
+++ b/Detectors/TPC/base/include/TPCBase/CalDet.h
@@ -83,6 +83,7 @@ class CalDet
   const CalDet& operator-=(const CalDet& other);
   const CalDet& operator*=(const CalDet& other);
   const CalDet& operator/=(const CalDet& other);
+  bool operator==(const CalDet& other) const;
 
   const CalDet& operator+=(const T& val);
   const CalDet& operator-=(const T& val);
@@ -352,6 +353,25 @@ inline const CalDet<T>& CalDet<T>::operator=(const T& val)
     cal = val;
   }
   return *this;
+}
+
+//______________________________________________________________________________
+template <class T>
+inline bool CalDet<T>::operator==(const CalDet& other) const
+{
+  // make sure the calibration objects have the same substructure
+  // TODO: perhaps make it independed of this
+  if (mPadSubset != other.mPadSubset) {
+    LOG(error) << "Pad subste type of the objects it not compatible";
+    return false;
+  }
+
+  for (size_t i = 0; i < mData.size(); ++i) {
+    if (!(mData[i] == other.mData[i])) {
+      return false;
+    }
+  }
+  return true;
 }
 
 //______________________________________________________________________________

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCAverageGroup.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCAverageGroup.h
@@ -35,40 +35,6 @@ namespace o2::tpc
 template <class Type>
 class IDCAverageGroupHelper;
 
-template <typename T>
-struct Enable_enum_class_bitfield {
-  static constexpr bool value = false;
-};
-
-// operator overload for allowing bitfiedls with enum
-template <typename T>
-typename std::enable_if<std::is_enum<T>::value && Enable_enum_class_bitfield<T>::value, T>::type
-  operator&(T lhs, T rhs)
-{
-  typedef typename std::underlying_type<T>::type integer_type;
-  return static_cast<T>(static_cast<integer_type>(lhs) & static_cast<integer_type>(rhs));
-}
-
-template <typename T>
-typename std::enable_if<std::is_enum<T>::value && Enable_enum_class_bitfield<T>::value, T>::type
-  operator|(T lhs, T rhs)
-{
-  typedef typename std::underlying_type<T>::type integer_type;
-  return static_cast<T>(static_cast<integer_type>(lhs) | static_cast<integer_type>(rhs));
-}
-
-enum class PadFlags : unsigned short {
-  flagGoodPad = 1 << 0,     ///< flag for a good pad binary 0001
-  flagDeadPad = 1 << 1,     ///< flag for a dead pad binary 0010
-  flagUnknownPad = 1 << 2,  ///< flag for unknown status binary 0100
-  flagSaturatedPad = 1 << 3 ///< flag for unknown status binary 0100
-};
-
-template <>
-struct Enable_enum_class_bitfield<PadFlags> {
-  static constexpr bool value = true;
-};
-
 /// class for averaging and grouping IDCs
 /// usage:
 /// 1. Define grouping parameters
@@ -94,12 +60,12 @@ class IDCAverageGroup : public IDCAverageGroupBase<Type>
   /// \param groupLastRowsThreshold minimum number of pads in row direction for the last group in row direction
   /// \param groupLastPadsThreshold minimum number of pads in pad direction for the last group in pad direction
   /// \param groupPadsSectorEdges decoded number of pads at the sector edges which are grouped differently. First digit specifies the EdgePadGroupingMethod  (example: 0: no pads are grouped, 110: first two pads are not grouped, 3210: first pad is not grouped, second + third pads are grouped, fourth + fifth + sixth pads are grouped)
-  /// \param region region of the TPC
+  /// \param cru cru index
   /// \param overlapRows define parameter for additional overlapping pads in row direction
   /// \param overlapPads define parameter for additional overlapping pads in pad direction
   template <bool IsEnabled = true, typename std::enable_if<(IsEnabled && (std::is_same<Type, IDCAverageGroupCRU>::value)), int>::type = 0>
-  IDCAverageGroup(const unsigned char groupPads = 4, const unsigned char groupRows = 4, const unsigned char groupLastRowsThreshold = 2, const unsigned char groupLastPadsThreshold = 2, const unsigned int groupPadsSectorEdges = 0, const unsigned int region = 0, const Sector sector = Sector{0}, const unsigned char overlapRows = 0, const unsigned char overlapPads = 0)
-    : IDCAverageGroupBase<Type>{groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold, groupPadsSectorEdges, region, sector, sNThreads}, mOverlapRows{overlapRows}, mOverlapPads{overlapPads}
+  IDCAverageGroup(const unsigned char groupPads = 4, const unsigned char groupRows = 4, const unsigned char groupLastRowsThreshold = 2, const unsigned char groupLastPadsThreshold = 2, const unsigned int groupPadsSectorEdges = 0, const unsigned short cru = 0, const unsigned char overlapRows = 0, const unsigned char overlapPads = 0)
+    : IDCAverageGroupBase<Type>{groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold, groupPadsSectorEdges, cru, sNThreads}, mOverlapRows{overlapRows}, mOverlapPads{overlapPads}
   {
     init();
   }
@@ -118,16 +84,9 @@ class IDCAverageGroup : public IDCAverageGroupBase<Type>
     init();
   }
 
-  /// Update pad flag map from a local file
-  /// \param file file containing the caldet map  with the flags
-  // \param objName name of the object (TODO use a fixed name)
-  void updatePadStatusMapFromFile(const char* file, const char* objName);
-
-  /// TODO: Update pad flag map from the CCDB
-  // void updatePadStatusMapFromCCDB(const char* file, const char* objName);
-
   /// grouping and averaging of IDCs
-  void processIDCs();
+  /// \param padStatusFlags pointer to map containing status flags for each pad to skip dead pads etc.
+  void processIDCs(const CalDet<PadFlags>* padStatusFlags = nullptr);
 
   /// draw plot with information about the performed grouping
   /// \param filename name of the output file. If empty the name is chosen automatically
@@ -137,16 +96,6 @@ class IDCAverageGroup : public IDCAverageGroupBase<Type>
   /// \param outFileName name of the output file
   /// \param outName name of the object in the output file
   void dumpToFile(const char* outFileName = "IDCAverageGroup.root", const char* outName = "IDCAverageGroup") const;
-
-  /// draw the status map for the flags (for debugging) for a sector
-  /// \param sector sector which will be drawn
-  /// \param filename name of the output file. If empty the canvas is drawn.
-  void drawPadStatusMapSector(const unsigned int sector, const std::string filename = "PadStatusFlags_Sector.pdf") const { drawPadStatusMap(false, Sector(sector), filename); }
-
-  /// draw the status map for the flags (for debugging) for a full side
-  /// \param side side which will be drawn
-  /// \param filename name of the output file. If empty the canvas is drawn.
-  void drawPadStatusMapSide(const o2::tpc::Side side, const std::string filename = "PadStatusFlags_Side.pdf") const { drawPadStatusMap(true, side == Side::A ? Sector(0) : Sector(Sector::MAXSECTOR - 1), filename); }
 
   /// get the number of threads used for some of the calculations
   static int getNThreads() { return sNThreads; }
@@ -163,10 +112,6 @@ class IDCAverageGroup : public IDCAverageGroupBase<Type>
   /// set the number of threads used for some of the calculations
   static void setNThreads(const int nThreads) { sNThreads = nThreads; }
 
-  /// Set pad flag map directly
-  /// \param padStatus CalDet containing for each pad the status flag
-  void setPadStatusMap(const CalDet<PadFlags>& padStatus) { mPadStatus = std::make_unique<CalDet<PadFlags>>(padStatus); }
-
   /// load ungrouped and grouped IDCs from File
   /// \param fileName name of the input file
   /// \param name name of the object in the output file
@@ -182,10 +127,9 @@ class IDCAverageGroup : public IDCAverageGroupBase<Type>
   static void createDebugTreeForAllCRUs(const char* nameFile, const char* filename);
 
  private:
-  inline static int sNThreads{1};                                                                                                 ///< number of threads which are used during the calculations
-  const unsigned char mOverlapRows{0};                                                                                            ///< additional/overlapping pads in row direction (TODO overlap per region)
-  const unsigned char mOverlapPads{0};                                                                                            ///< additional/overlapping pads in pad direction (TODO overlap per region)
-  std::unique_ptr<CalDet<PadFlags>> mPadStatus{std::make_unique<CalDet<PadFlags>>(CalDet<PadFlags>("flags", PadSubset::Region))}; ///< status flag for each pad (i.e. if the pad is dead)
+  inline static int sNThreads{1};      ///< number of threads which are used during the calculations
+  const unsigned char mOverlapRows{0}; ///< additional/overlapping pads in row direction (TODO overlap per region)
+  const unsigned char mOverlapPads{0}; ///< additional/overlapping pads in pad direction (TODO overlap per region)
 
   /// init function
   void init();
@@ -201,10 +145,7 @@ class IDCAverageGroup : public IDCAverageGroupBase<Type>
   /// perform the loop over the IDCs by either perform the grouping or the drawing
   /// \param type containing necessary methods for either perform the grouping or the drawing
   template <class LoopType>
-  void loopOverGroups(IDCAverageGroupHelper<LoopType>& idcStruct);
-
-  /// helper function for drawing
-  void drawPadStatusMap(const bool type, const Sector sector, const std::string filename) const;
+  void loopOverGroups(IDCAverageGroupHelper<LoopType>& idcStruct, const CalDet<PadFlags>* padStatusFlags = nullptr);
 
   /// draw information of the grouping on the pads (grouping parameters and number of grouped pads)
   void drawGroupingInformations(const int region, const int grPads, const int grRows, const int groupLastRowsThreshold, const int groupLastPadsThreshold, const int overlapRows, const int overlapPads, const int nIDCs, const int groupPadsSectorEdges) const;

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCAverageGroupBase.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCAverageGroupBase.h
@@ -46,11 +46,10 @@ class IDCAverageGroupBase<IDCAverageGroupCRU>
   /// \param groupRows number of pads in row direction which will be grouped
   /// \param groupLastRowsThreshold minimum number of pads in row direction for the last group in row direction
   /// \param groupLastPadsThreshold minimum number of pads in pad direction for the last group in pad direction
-  /// \param region region of the TPC
-  /// \param sector processed sector
+  /// \param cru cru index
   /// \param nThreads number of CPU threads used
-  IDCAverageGroupBase(const unsigned char groupPads, const unsigned char groupRows, const unsigned char groupLastRowsThreshold, const unsigned char groupLastPadsThreshold, const unsigned int groupNotnPadsSectorEdges, const unsigned int region, const Sector sector, const int nThreads)
-    : mIDCsGrouped{groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold, groupNotnPadsSectorEdges, region}, mSector{sector}, mRobustAverage(nThreads){};
+  IDCAverageGroupBase(const unsigned char groupPads, const unsigned char groupRows, const unsigned char groupLastRowsThreshold, const unsigned char groupLastPadsThreshold, const unsigned int groupNotnPadsSectorEdges, const unsigned short cru, const int nThreads)
+    : mIDCsGrouped{groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold, groupNotnPadsSectorEdges, cru}, mRobustAverage(nThreads), mSector{CRU(cru).sector()} {};
 
   /// \return returns number of integration intervals for stored ungrouped IDCs
   unsigned int getNIntegrationIntervals() const { return mIDCsUngrouped.size() / Mapper::PADSPERREGION[getRegion()]; }

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCAverageGroupHelper.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCAverageGroupHelper.h
@@ -105,13 +105,17 @@ class IDCAverageGroupHelper<IDCAverageGroupCRU>
   /// \param weight weight of the value
   void addValue(const unsigned int padInRegion, const float weight);
 
+  /// add a value to the averaging object
+  /// \param padInRegion pad index in the processed region to the value which will be added
+  void addValue(const unsigned int padInRegion);
+
   /// calculating and setting the grouped IDC value
   /// \param rowGrouped grouped row index
   /// \param padGrouped grouped pad index
-  void setGroupedIDC(const unsigned int rowGrouped, const unsigned int padGrouped) { mIDCsGrouped(rowGrouped, padGrouped, mIntegrationInterval) = getGroupedIDC(); }
+  void setGroupedIDC(const unsigned int rowGrouped, const unsigned int padGrouped, const bool withweights) { mIDCsGrouped(rowGrouped, padGrouped, mIntegrationInterval) = getGroupedIDC(withweights); }
 
   /// \return returns grouped and averaged IDC value
-  float getGroupedIDC() const;
+  float getGroupedIDC(const bool withweights) const;
 
   /// setting the members for correct data access
   /// \param threadNum thread index
@@ -128,7 +132,7 @@ class IDCAverageGroupHelper<IDCAverageGroupCRU>
   /// \param ulrow ungrouped local row
   /// \param upad ungrouped pad
   /// \param val value which will be stored
-  void setSectorEdgeIDC(const unsigned int ulrow, const unsigned int upad) { mIDCsGrouped.setValUngrouped(ulrow, upad, mIntegrationInterval, getGroupedIDC()); }
+  void setSectorEdgeIDC(const unsigned int ulrow, const unsigned int upad) { mIDCsGrouped.setValUngrouped(ulrow, upad, mIntegrationInterval, getGroupedIDC(false)); }
 
   /// \return returns which type of grouping is performed for the sector edge pads
   EdgePadGroupingMethod getEdgePadGroupingType() const { return mIDCsGrouped.getEdgePadGroupingType(); }
@@ -222,13 +226,17 @@ class IDCAverageGroupHelper<IDCAverageGroupTPC>
   /// \param weight weight of the value
   void addValue(const unsigned int padInRegion, const float weight);
 
+  /// add a value to the averaging object
+  /// \param padInRegion pad index in the processed region to the value which will be added
+  void addValue(const unsigned int padInRegion);
+
   /// calculating and setting the grouped IDC value
   /// \param rowGrouped grouped row index
   /// \param padGrouped grouped pad index
-  void setGroupedIDC(const unsigned int rowGrouped, const unsigned int padGrouped) { setGroupedIDC(rowGrouped, padGrouped, getGroupedIDC()); }
+  void setGroupedIDC(const unsigned int rowGrouped, const unsigned int padGrouped, const bool withweights) { setGroupedIDC(rowGrouped, padGrouped, getGroupedIDC(withweights)); }
 
   /// \return returns grouped and averaged IDC value
-  float getGroupedIDC() const;
+  float getGroupedIDC(const bool withweights) const;
 
   /// \param threadNum thread index
   void setThreadNum(const unsigned int threadNum) { mThreadNum = threadNum; }

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCContainer.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCContainer.h
@@ -411,6 +411,43 @@ struct FourierCoeff {
   ClassDefNV(FourierCoeff, 1)
 };
 
+template <typename T>
+struct Enable_enum_class_bitfield {
+  static constexpr bool value = false;
+};
+
+// operator overload for allowing bitfiedls with enum
+template <typename T>
+typename std::enable_if<std::is_enum<T>::value && Enable_enum_class_bitfield<T>::value, T>::type
+  operator&(T lhs, T rhs)
+{
+  typedef typename std::underlying_type<T>::type integer_type;
+  return static_cast<T>(static_cast<integer_type>(lhs) & static_cast<integer_type>(rhs));
+}
+
+template <typename T>
+typename std::enable_if<std::is_enum<T>::value && Enable_enum_class_bitfield<T>::value, T>::type
+  operator|(T lhs, T rhs)
+{
+  typedef typename std::underlying_type<T>::type integer_type;
+  return static_cast<T>(static_cast<integer_type>(lhs) | static_cast<integer_type>(rhs));
+}
+
+enum class PadFlags : unsigned short {
+  flagGoodPad = 1 << 0,      ///< flag for a good pad binary 0001
+  flagDeadPad = 1 << 1,      ///< flag for a dead pad binary 0010
+  flagUnknownPad = 1 << 2,   ///< flag for unknown status binary 0100
+  flagSaturatedPad = 1 << 3, ///< flag for saturated status binary 0100
+  flagHighPad = 1 << 4,      ///< flag for pad with extremly high IDC value
+  flagLowPad = 1 << 5,       ///< flag for pad with extremly low IDC value
+  flagSkip = 1 << 6          ///< flag for defining a pad which is just ignored during the calculation of I1 and IDCDelta
+};
+
+template <>
+struct Enable_enum_class_bitfield<PadFlags> {
+  static constexpr bool value = true;
+};
+
 } // namespace tpc
 } // namespace o2
 

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCFactorization.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCFactorization.h
@@ -255,7 +255,10 @@ class IDCFactorization : public IDCGroupHelperSector
   void dumpPadFlagMap(const char* outFile, const char* mapName);
 
   /// \return returns pointer to pad status map
-  CalDet<PadFlags>* getPadStatusMap() const { return mPadFlagsMap.get(); }
+  CalDet<PadFlags>* getPadStatusMapPtr() const { return mPadFlagsMap.get(); }
+
+  /// \return returns unique_ptr to pad status map
+  std::unique_ptr<CalDet<PadFlags>> getPadStatusMap() { return std::move(mPadFlagsMap); }
 
  private:
   const unsigned int mTimeFrames{};                                 ///< number of timeframes which are stored

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCFactorization.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCFactorization.h
@@ -32,6 +32,9 @@
 namespace o2::tpc
 {
 
+template <class T>
+class CalDet;
+
 class IDCFactorization : public IDCGroupHelperSector
 {
  public:
@@ -171,37 +174,49 @@ class IDCFactorization : public IDCGroupHelperSector
   /// \param sector sector which will be drawn
   /// \param integrationInterval which will be drawn
   /// \param filename name of the output file. If empty the canvas is drawn.
-  void drawIDCsSector(const unsigned int sector, const unsigned int integrationInterval, const std::string filename = "IDCsSector.pdf") const { drawIDCHelper(false, Sector(sector), integrationInterval, filename); }
+  void drawIDCsSector(const unsigned int sector, const unsigned int integrationInterval, const float minZ = 0, const float maxZ = -1, const std::string filename = "IDCsSector.pdf") const { drawIDCHelper(false, Sector(sector), integrationInterval, filename, minZ, maxZ); }
 
   /// draw IDC zero I_0(r,\phi) = <I(r,\phi,t)>_t
   /// \param sector sector which will be drawn
   /// \param filename name of the output file. If empty the canvas is drawn.
-  void drawIDCZeroSector(const unsigned int sector, const std::string filename = "IDCZeroSector.pdf") const { drawIDCZeroHelper(false, Sector(sector), filename); }
+  void drawIDCZeroSector(const unsigned int sector, const float minZ = 0, const float maxZ = -1, const std::string filename = "IDCZeroSector.pdf") const { drawIDCZeroHelper(false, Sector(sector), filename, minZ, maxZ); }
 
   /// draw IDCDelta for one sector for one integration interval
   /// \param sector sector which will be drawn
   /// \param integrationInterval which will be drawn
   /// \param compression compression of Delta IDCs. (setMaxCompressedIDCDelta() should be called first in case of non standard compression parameter)
   /// \param filename name of the output file. If empty the canvas is drawn.
-  void drawIDCDeltaSector(const unsigned int sector, const unsigned int integrationInterval, const IDCDeltaCompression compression = IDCDeltaCompression::NO, const std::string filename = "IDCDeltaSector.pdf") const { drawIDCDeltaHelper(false, Sector(sector), integrationInterval, compression, filename); }
+  void drawIDCDeltaSector(const unsigned int sector, const unsigned int integrationInterval, const float minZ = 0, const float maxZ = -1, const IDCDeltaCompression compression = IDCDeltaCompression::NO, const std::string filename = "IDCDeltaSector.pdf") const { drawIDCDeltaHelper(false, Sector(sector), integrationInterval, compression, filename, minZ, maxZ); }
 
   /// draw IDCs for one side for one integration interval
   /// \param side side which will be drawn
   /// \param integrationInterval which will be drawn
   /// \param filename name of the output file. If empty the canvas is drawn.
-  void drawIDCsSide(const o2::tpc::Side side, const unsigned int integrationInterval, const std::string filename = "IDCsSide.pdf") const { drawIDCHelper(true, side == Side::A ? Sector(0) : Sector(Sector::MAXSECTOR - 1), integrationInterval, filename); }
+  void drawIDCsSide(const o2::tpc::Side side, const unsigned int integrationInterval, const float minZ = 0, const float maxZ = -1, const std::string filename = "IDCsSide.pdf") const { drawIDCHelper(true, side == Side::A ? Sector(0) : Sector(Sector::MAXSECTOR - 1), integrationInterval, filename, minZ, maxZ); }
 
   /// draw IDC zero I_0(r,\phi) = <I(r,\phi,t)>_t
   /// \param side side which will be drawn
   /// \param filename name of the output file. If empty the canvas is drawn.
-  void drawIDCZeroSide(const o2::tpc::Side side, const std::string filename = "IDCZeroSide.pdf") const { drawIDCZeroHelper(true, side == Side::A ? Sector(0) : Sector(Sector::MAXSECTOR - 1), filename); }
+  void drawIDCZeroSide(const o2::tpc::Side side, const float minZ = 0, const float maxZ = -1, const std::string filename = "IDCZeroSide.pdf") const { drawIDCZeroHelper(true, side == Side::A ? Sector(0) : Sector(Sector::MAXSECTOR - 1), filename, minZ, maxZ); }
 
   /// draw IDCDelta for one side for one integration interval
   /// \param side side which will be drawn
   /// \param integrationInterval which will be drawn
   /// \param compression compression of Delta IDCs. (setMaxCompressedIDCDelta() should be called first in case of non standard compression parameter)
   /// \param filename name of the output file. If empty the canvas is drawn.
-  void drawIDCDeltaSide(const o2::tpc::Side side, const unsigned int integrationInterval, const IDCDeltaCompression compression = IDCDeltaCompression::NO, const std::string filename = "IDCDeltaSide.pdf") const { drawIDCDeltaHelper(true, side == Side::A ? Sector(0) : Sector(Sector::MAXSECTOR - 1), integrationInterval, compression, filename); }
+  void drawIDCDeltaSide(const o2::tpc::Side side, const unsigned int integrationInterval, const float minZ = 0, const float maxZ = -1, const IDCDeltaCompression compression = IDCDeltaCompression::NO, const std::string filename = "IDCDeltaSide.pdf") const { drawIDCDeltaHelper(true, side == Side::A ? Sector(0) : Sector(Sector::MAXSECTOR - 1), integrationInterval, compression, filename, minZ, maxZ); }
+
+  /// draw the status map for the flags (for debugging) for a sector
+  /// \param sector sector which will be drawn
+  /// \flag flag which will be drawn
+  /// \param filename name of the output file. If empty the canvas is drawn.
+  void drawPadStatusFlagsMapSector(const unsigned int sector, const PadFlags flag = PadFlags::flagSkip, const std::string filename = "PadStatusFlags_Sector.pdf") const { drawPadFlagMap(false, Sector(sector), filename, flag); }
+
+  /// draw the status map for the flags (for debugging) for a full side
+  /// \param side side which will be drawn
+  /// \flag flag which will be drawn
+  /// \param filename name of the output file. If empty the canvas is drawn.
+  void drawPadStatusFlagsMapSide(const o2::tpc::Side side, const PadFlags flag = PadFlags::flagSkip, const std::string filename = "PadStatusFlags_Side.pdf") const { drawPadFlagMap(true, side == Side::A ? Sector(0) : Sector(Sector::MAXSECTOR - 1), filename, flag); }
 
   /// dump object to disc
   /// \param outFileName name of the output file
@@ -218,6 +233,30 @@ class IDCFactorization : public IDCGroupHelperSector
   /// resetting aggregated IDCs
   void reset();
 
+  /// setting a gain map from a file
+  /// \param inpFile input file containing some caldet
+  /// \param mapName name of the caldet
+  void setGainMap(const char* inpFile, const char* mapName);
+
+  /// setting a gain map from a file
+  void setGainMap(const CalDet<float>& gainmap);
+
+  /// setting a map containing status flags for each pad
+  /// \param inpFile input file containing the object
+  /// \param mapName name of the caldet
+  void setPadFlagMap(const char* inpFile, const char* mapName);
+
+  /// setting a map containing status flags for each pad
+  void setPadFlagMap(const CalDet<PadFlags>& flagmap);
+
+  /// writing the pad status map to file
+  /// \param outFile output file name
+  /// \param mapName output name of the object
+  void dumpPadFlagMap(const char* outFile, const char* mapName);
+
+  /// \return returns pointer to pad status map
+  CalDet<PadFlags>* getPadStatusMap() const { return mPadFlagsMap.get(); }
+
  private:
   const unsigned int mTimeFrames{};                                 ///< number of timeframes which are stored
   const unsigned int mTimeFramesDeltaIDC{};                         ///< number of timeframes of which Delta IDCs are stored
@@ -226,9 +265,18 @@ class IDCFactorization : public IDCGroupHelperSector
   IDCOne mIDCOne{};                                                 ///< I_1(t) = <I(r,\phi,t) / I_0(r,\phi)>_{r,\phi}
   std::vector<IDCDelta<float>> mIDCDelta{};                         ///< uncompressed: chunk -> Delta IDC: \Delta I(r,\phi,t) = I(r,\phi,t) / ( I_0(r,\phi) * I_1(t) )
   inline static int sNThreads{1};                                   ///< number of threads which are used during the calculations
+  std::unique_ptr<CalDet<float>> mGainMap;                          ///<! static Gain map object used for filling missing IDC_0 values
+  std::unique_ptr<CalDet<PadFlags>> mPadFlagsMap;                   ///< status flag for each pad (i.e. if the pad is dead)
+  bool mInputGrouped{false};                                        ///< flag which is set to true if the input IDCs are grouped (checked via the grouping parameters from the constructor)
 
   /// calculate I_0(r,\phi) = <I(r,\phi,t)>_t
   void calcIDCZero(const bool norm);
+
+  /// fill I_0 values in case of dead pads,FECs etc.
+  void fillIDCZeroDeadPads();
+
+  /// create status map for pads which are dead or delivering extremly high values (static outliers will be mapped)
+  void createStatusMap();
 
   /// calculate I_1(t) = <I(r,\phi,t) / I_0(r,\phi)>_{r,\phi}
   void calcIDCOne();
@@ -237,13 +285,13 @@ class IDCFactorization : public IDCGroupHelperSector
   void calcIDCDelta();
 
   /// helper function for drawing IDCDelta
-  void drawIDCDeltaHelper(const bool type, const Sector sector, const unsigned int integrationInterval, const IDCDeltaCompression compression, const std::string filename) const;
+  void drawIDCDeltaHelper(const bool type, const Sector sector, const unsigned int integrationInterval, const IDCDeltaCompression compression, const std::string filename, const float minZ, const float maxZ) const;
 
   /// helper function for drawing IDCs
-  void drawIDCHelper(const bool type, const Sector sector, const unsigned int integrationInterval, const std::string filename) const;
+  void drawIDCHelper(const bool type, const Sector sector, const unsigned int integrationInterval, const std::string filename, const float minZ, const float maxZ) const;
 
   /// helper function for drawing IDCZero
-  void drawIDCZeroHelper(const bool type, const Sector sector, const std::string filename) const;
+  void drawIDCZeroHelper(const bool type, const Sector sector, const std::string filename, const float minZ, const float maxZ) const;
 
   /// get time frame and index of integrationInterval in the TF
   void getTF(const unsigned int region, unsigned int integrationInterval, unsigned int& timeFrame, unsigned int& interval) const;
@@ -253,6 +301,12 @@ class IDCFactorization : public IDCGroupHelperSector
 
   /// \return returns number of TFs for given chunk
   unsigned int getNTFsPerChunk(const unsigned int chunk) const;
+
+  /// \return returns the median of a vector
+  float getMedian(std::vector<float>& values);
+
+  /// helper function for drawing
+  void drawPadFlagMap(const bool type, const Sector sector, const std::string filename, const PadFlags flag) const;
 
   ClassDefNV(IDCFactorization, 1)
 };

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCGroup.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCGroup.h
@@ -19,9 +19,15 @@
 #include <vector>
 #include "Rtypes.h"
 #include "TPCCalibration/IDCGroupHelperRegion.h"
+#include "TPCBase/CRU.h"
 
 namespace o2::tpc
 {
+
+enum class PadFlags : unsigned short;
+
+template <class T>
+class CalDet;
 
 /// Class to hold grouped IDC values for one CRU for one TF
 
@@ -33,9 +39,9 @@ class IDCGroup : public IDCGroupHelperRegion
   /// \param groupRows number of pads in row direction which will be grouped
   /// \param groupLastRowsThreshold minimum number of pads in row direction for the last group in row direction
   /// \param groupLastPadsThreshold minimum number of pads in pad direction for the last group in pad direction
-  /// \param region region of the TPC
-  IDCGroup(const unsigned char groupPads = 4, const unsigned char groupRows = 4, const unsigned char groupLastRowsThreshold = 2, const unsigned char groupLastPadsThreshold = 2, const unsigned int groupNotnPadsSectorEdges = 0, const unsigned int region = 0)
-    : IDCGroupHelperRegion{groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold, groupNotnPadsSectorEdges, region}, mIDCsGrouped(getNIDCsPerIntegrationInterval()){};
+  /// \param cru cru index
+  IDCGroup(const unsigned char groupPads = 4, const unsigned char groupRows = 4, const unsigned char groupLastRowsThreshold = 2, const unsigned char groupLastPadsThreshold = 2, const unsigned int groupNotnPadsSectorEdges = 0, const unsigned short cru = 0)
+    : IDCGroupHelperRegion{groupPads, groupRows, groupLastRowsThreshold, groupLastPadsThreshold, groupNotnPadsSectorEdges, CRU(cru).region()}, mIDCsGrouped(getNIDCsPerIntegrationInterval()), mCRU{cru} {};
 
   /// extend the size of the grouped and averaged IDC values corresponding to the number of integration intervals. This has to be called befor filling values!
   /// without using this function the object can hold only one integration interval
@@ -103,14 +109,19 @@ class IDCGroup : public IDCGroupHelperRegion
 
   /// calculate and return 1D-IDCs for ungrouped IDCs
   /// \param idc vector containing the ungrouped IDCs for one region
-  /// \param region TPC region to which the IDCs corresponds to
-  static std::vector<float> get1DIDCsUngrouped(const std::vector<float> idc, const unsigned int region);
+  /// \param cru cru index
+  /// \param flagMap map which can be used to exclude pads during calculation of the 1D-IDCs
+  static std::vector<float> get1DIDCsUngrouped(const std::vector<float> idc, const unsigned short cru, const CalDet<PadFlags>* flagMap = nullptr);
+
+  /// \return returns cru
+  unsigned short getCRU() const { return mCRU; }
 
  private:
   std::vector<float> mIDCsGrouped{}; ///< grouped and averaged IDC values for n integration intervals for one CRU
+  const unsigned short mCRU{};       ///< cru of grouped IDCs
 
   /// calculate and return 1D-IDCs for a vector of IDCs
-  static std::vector<float> get1DIDCs(const std::vector<float> idc, const unsigned int nIntervals, const unsigned int nIDCsPerIntegrationInterval, const unsigned int region, const bool normalize);
+  static std::vector<float> get1DIDCs(const std::vector<float> idc, const unsigned int nIntervals, const unsigned int nIDCsPerIntegrationInterval, const unsigned short cru, const bool normalize, const CalDet<PadFlags>* flagMap);
 
   ClassDefNV(IDCGroup, 1)
 };

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCGroupingParameter.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCGroupingParameter.h
@@ -45,6 +45,8 @@ struct ParameterIDCGroup : public o2::conf::ConfigurableParamHelper<ParameterIDC
   unsigned int groupPadsSectorEdges{0};                                                 ///< decoded number of pads at the sector edges which are grouped differently. First digit specifies the EdgePadGroupingMethod  (example: 0: no pads are grouped, 110: first two pads are not grouped, 3210: first pad is not grouped, second + third pads are grouped, fourth + fifth + sixth pads are grouped)
   AveragingMethod method = AveragingMethod::FAST;                                       ///< method which is used for averaging
   float sigma = 3.f;                                                                    ///< sigma cut which can be used during the grouping for outlier filtering
+  float minIDC0Median = 0.5;                                                            ///< this value is used for identifying outliers (pads with high IDC0 values): "accpeted IDC 0 values > minIDC0Median*median_IDC0"
+  float maxIDC0Median = 1.5;                                                            ///< this value is used for identifying outliers (pads with high IDC0 values): "accpeted IDC 0 values < maxIDC0Median*median_IDC0"
 
   /// Helper function for setting the groupimg parameters from a string (can be "X": parameters in all regions are "X" or can be "1,2,3,4,5,6,7,8,9,10" for setting individual regions)
   /// \param sgroupPads string for grouping parameter in pad direction

--- a/Detectors/TPC/calibration/include/TPCCalibration/RobustAverage.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/RobustAverage.h
@@ -64,14 +64,17 @@ class RobustAverage
 
   /// \param value value which will be added to the list of stored values for averaging
   /// \param weight weight of the value
-  void addValue(const float value, const float weight = 1.f);
+  void addValue(const float value, const float weight);
+
+  /// \param value value which will be added to the list of stored values for averaging
+  void addValue(const float value);
 
   /// returns the filtered average value
   /// \param sigma maximum accepted standard deviation: sigma*stdev
   float getFilteredAverage(const float sigma = 3);
 
   /// \return returns mean of stored values
-  float getMean() const { return getMean(mValues.begin(), mValues.end()); }
+  float getMean() const { return mValues.empty() ? 0 : getMean(mValues.begin(), mValues.end()); }
 
   /// \return returns weighted mean of stored values
   float getWeightedMean() const { return getWeightedMean(mValues.begin(), mValues.end(), mWeights.begin(), mWeights.end()); }

--- a/Detectors/TPC/calibration/src/IDCAverageGroupHelper.cxx
+++ b/Detectors/TPC/calibration/src/IDCAverageGroupHelper.cxx
@@ -14,7 +14,7 @@
 #include "TPCCalibration/IDCContainer.h"
 #include "TPCCalibration/RobustAverage.h"
 
-float o2::tpc::IDCAverageGroupHelper<o2::tpc::IDCAverageGroupCRU>::getGroupedIDC() const
+float o2::tpc::IDCAverageGroupHelper<o2::tpc::IDCAverageGroupCRU>::getGroupedIDC(const bool withweights) const
 {
   const static auto& paramIDCGroup = ParameterIDCGroup::Instance();
   switch (paramIDCGroup.method) {
@@ -23,8 +23,7 @@ float o2::tpc::IDCAverageGroupHelper<o2::tpc::IDCAverageGroupCRU>::getGroupedIDC
       return mRobustAverage[mThreadNum].getFilteredAverage(paramIDCGroup.sigma);
       break;
     case o2::tpc::AveragingMethod::FAST:
-      const float mean = mRobustAverage[mThreadNum].getMean();
-      return mRobustAverage[mThreadNum].getMean();
+      return withweights ? mRobustAverage[mThreadNum].getWeightedMean() : mRobustAverage[mThreadNum].getMean();
       break;
   }
 }
@@ -39,6 +38,11 @@ void o2::tpc::IDCAverageGroupHelper<o2::tpc::IDCAverageGroupCRU>::set(const unsi
 void o2::tpc::IDCAverageGroupHelper<o2::tpc::IDCAverageGroupCRU>::addValue(const unsigned int padInRegion, const float weight)
 {
   mRobustAverage[mThreadNum].addValue(getUngroupedIDCVal(padInRegion) * Mapper::INVPADAREA[getRegion()], weight);
+}
+
+void o2::tpc::IDCAverageGroupHelper<o2::tpc::IDCAverageGroupCRU>::addValue(const unsigned int padInRegion)
+{
+  mRobustAverage[mThreadNum].addValue(getUngroupedIDCVal(padInRegion) * Mapper::INVPADAREA[getRegion()]);
 }
 
 void o2::tpc::IDCAverageGroupHelper<o2::tpc::IDCAverageGroupCRU>::clearRobustAverage()
@@ -70,7 +74,7 @@ void o2::tpc::IDCAverageGroupHelper<o2::tpc::IDCAverageGroupTPC>::setIntegration
   mOffsetGrouped = mIDCGroupHelperSector.getIndexGrouped(getSector(), getRegion(), 0, 0, mIntegrationInterval) - mIDCGroupHelperSector.getGroupingParameter().getGroupedPadsSectorEdges() * offs;
 }
 
-float o2::tpc::IDCAverageGroupHelper<o2::tpc::IDCAverageGroupTPC>::getGroupedIDC() const
+float o2::tpc::IDCAverageGroupHelper<o2::tpc::IDCAverageGroupTPC>::getGroupedIDC(const bool withweights) const
 {
   const static auto& paramIDCGroup = ParameterIDCGroup::Instance();
   switch (paramIDCGroup.method) {
@@ -79,7 +83,7 @@ float o2::tpc::IDCAverageGroupHelper<o2::tpc::IDCAverageGroupTPC>::getGroupedIDC
       return mRobustAverage[mThreadNum].getFilteredAverage(paramIDCGroup.sigma);
       break;
     case o2::tpc::AveragingMethod::FAST:
-      return mRobustAverage[mThreadNum].getMean();
+      return withweights ? mRobustAverage[mThreadNum].getWeightedMean() : mRobustAverage[mThreadNum].getMean();
       break;
   }
 }
@@ -87,6 +91,11 @@ float o2::tpc::IDCAverageGroupHelper<o2::tpc::IDCAverageGroupTPC>::getGroupedIDC
 void o2::tpc::IDCAverageGroupHelper<o2::tpc::IDCAverageGroupTPC>::addValue(const unsigned int padInRegion, const float weight)
 {
   mRobustAverage[mThreadNum].addValue(getUngroupedIDCVal(padInRegion), weight);
+}
+
+void o2::tpc::IDCAverageGroupHelper<o2::tpc::IDCAverageGroupTPC>::addValue(const unsigned int padInRegion)
+{
+  mRobustAverage[mThreadNum].addValue(getUngroupedIDCVal(padInRegion));
 }
 
 void o2::tpc::IDCAverageGroupHelper<o2::tpc::IDCAverageGroupTPC>::clearRobustAverage()
@@ -97,5 +106,5 @@ void o2::tpc::IDCAverageGroupHelper<o2::tpc::IDCAverageGroupTPC>::clearRobustAve
 void o2::tpc::IDCAverageGroupHelper<o2::tpc::IDCAverageGroupTPC>::setSectorEdgeIDC(const unsigned int ulrow, const unsigned int upad)
 {
   const int index = mIDCGroupHelperSector.getIndexUngrouped(getSector(), getRegion(), ulrow, upad, mIntegrationInterval);
-  mIDCsGrouped.setValue(getGroupedIDC(), getSide(), index);
+  mIDCsGrouped.setValue(getGroupedIDC(false), getSide(), index);
 }

--- a/Detectors/TPC/calibration/src/IDCFactorization.cxx
+++ b/Detectors/TPC/calibration/src/IDCFactorization.cxx
@@ -163,7 +163,7 @@ void o2::tpc::IDCFactorization::fillIDCZeroDeadPads()
     const int region = cruTmp.region();
     const int sector = cruTmp.sector();
     std::vector<unsigned int> padTmp;
-    padTmp.reserve(Mapper::PADSPERROW[region][Mapper::ROWSPERREGION[region]]);
+    padTmp.reserve(Mapper::PADSPERROW[region].back());
     for (unsigned int lrow = 0; lrow < Mapper::ROWSPERREGION[region]; ++lrow) {
       float idcRow = 0;
       int count = 0;
@@ -339,7 +339,7 @@ void o2::tpc::IDCFactorization::createStatusMap()
     const int region = cruTmp.region();
     const int sector = cruTmp.sector();
     std::vector<float> idcsRow;
-    const int maxValues = Mapper::PADSPERROW[region][Mapper::ROWSPERREGION[region]];
+    const auto maxValues = Mapper::PADSPERROW[region].back();
     idcsRow.reserve(maxValues);
     for (unsigned int lrow = 0; lrow < Mapper::ROWSPERREGION[region]; ++lrow) {
       // loop over pads in row in the first iteration and calculate median at the end

--- a/Detectors/TPC/calibration/src/IDCFactorization.cxx
+++ b/Detectors/TPC/calibration/src/IDCFactorization.cxx
@@ -14,6 +14,7 @@
 #include "Framework/Logger.h"
 #include "TPCCalibration/IDCDrawHelper.h"
 #include "TFile.h"
+#include "TPCBase/CalDet.h"
 #include <functional>
 
 o2::tpc::IDCFactorization::IDCFactorization(const std::array<unsigned char, Mapper::NREGIONS>& groupPads, const std::array<unsigned char, Mapper::NREGIONS>& groupRows, const std::array<unsigned char, Mapper::NREGIONS>& groupLastRowsThreshold, const std::array<unsigned char, Mapper::NREGIONS>& groupLastPadsThreshold, const unsigned int groupNotnPadsSectorEdges, const unsigned int timeFrames, const unsigned int timeframesDeltaIDC)
@@ -21,6 +22,13 @@ o2::tpc::IDCFactorization::IDCFactorization(const std::array<unsigned char, Mapp
 {
   for (auto& idc : mIDCs) {
     idc.resize(mTimeFrames);
+  }
+  // check if the input IDCs are grouped
+  for (int region = 0; region < Mapper::NREGIONS; ++region) {
+    if (mNIDCsPerCRU[region] != Mapper::PADSPERREGION[region]) {
+      mInputGrouped = true;
+      break;
+    }
   }
 }
 
@@ -129,15 +137,16 @@ void o2::tpc::IDCFactorization::calcIDCZero(const bool norm)
 #pragma omp parallel for num_threads(sNThreads)
   for (unsigned int cru = 0; cru < mIDCs.size(); ++cru) {
     const o2::tpc::CRU cruTmp(cru);
+    const auto side = cruTmp.side();
     const unsigned int region = cruTmp.region();
-    const auto factorIndexGlob = mRegionOffs[region] + mNIDCsPerSector * cruTmp.sector();
+    const auto factorIndexGlob = mRegionOffs[region] + mNIDCsPerSector * (cruTmp.sector() % o2::tpc::SECTORSPERSIDE);
     for (unsigned int timeframe = 0; timeframe < mTimeFrames; ++timeframe) {
       for (unsigned int idcs = 0; idcs < mIDCs[cru][timeframe].size(); ++idcs) {
         const unsigned int indexGlob = (idcs % mNIDCsPerCRU[region]) + factorIndexGlob;
-        if (norm) {
+        if (norm && mIDCs[cru][timeframe][idcs] > 0) {
           mIDCs[cru][timeframe][idcs] *= Mapper::INVPADAREA[region];
         }
-        mIDCZero.fillValueIDCZero(mIDCs[cru][timeframe][idcs], cruTmp.side(), indexGlob % nIDCsSide);
+        mIDCZero.fillValueIDCZero(mIDCs[cru][timeframe][idcs], side, indexGlob);
       }
     }
   }
@@ -145,32 +154,114 @@ void o2::tpc::IDCFactorization::calcIDCZero(const bool norm)
   std::transform(mIDCZero.mIDCZero[Side::C].begin(), mIDCZero.mIDCZero[Side::C].end(), mIDCZero.mIDCZero[Side::C].begin(), [normVal = getNIntegrationIntervals()](auto& val) { return val / normVal; });
 }
 
+void o2::tpc::IDCFactorization::fillIDCZeroDeadPads()
+{
+#pragma omp parallel for num_threads(sNThreads)
+  for (unsigned int cru = 0; cru < mIDCs.size(); ++cru) {
+    const o2::tpc::CRU cruTmp(cru);
+    const Side side = cruTmp.side();
+    const int region = cruTmp.region();
+    const int sector = cruTmp.sector();
+    std::vector<unsigned int> padTmp;
+    padTmp.reserve(Mapper::PADSPERROW[region][Mapper::ROWSPERREGION[region]]);
+    for (unsigned int lrow = 0; lrow < Mapper::ROWSPERREGION[region]; ++lrow) {
+      float idcRow = 0;
+      int count = 0;
+      const unsigned int integrationInterval = 0;
+      // loop over pad row and calculate mean of IDC0
+      for (unsigned int pad = 0; pad < Mapper::PADSPERROW[region][lrow]; ++pad) {
+        const auto index = getIndexUngrouped(sector, region, lrow, pad, integrationInterval);
+        const auto idcZeroVal = mIDCZero.mIDCZero[side][index];
+        if (idcZeroVal > 0) {
+          const auto globalPad = Mapper::getGlobalPadNumber(lrow, pad, region);
+          const float gain = (mGainMap ? mGainMap->getValue(sector, globalPad) : 1);
+          idcRow += idcZeroVal / gain;
+          ++count;
+        } else {
+          padTmp.emplace_back(pad);
+        }
+      }
+      // loop over dead pads and set value
+      for (const auto pad : padTmp) {
+        const float meanIDC0 = idcRow / count;
+        const auto globalPad = Mapper::getGlobalPadNumber(lrow, pad, region);
+        const float gain = (mGainMap ? mGainMap->getValue(sector, globalPad) : 1);
+        const float idcZero = gain * meanIDC0;
+        const auto index = getIndexUngrouped(sector, region, lrow, pad, integrationInterval);
+        mIDCZero.setValueIDCZero(idcZero, side, index);
+      }
+      padTmp.clear();
+    }
+  }
+}
+
 void o2::tpc::IDCFactorization::calcIDCOne()
 {
-  const unsigned int nIDCsSide = mNIDCsPerSector * SECTORSPERSIDE;
   const unsigned int integrationIntervals = getNIntegrationIntervals();
   mIDCOne.clear();
   mIDCOne.resize(integrationIntervals);
   const unsigned int crusPerSide = Mapper::NREGIONS * SECTORSPERSIDE;
 
+  unsigned int crusPerSideA = 0;
+  unsigned int crusPerSideC = 0;
+  for (unsigned int cru = 0; cru < crusPerSide; ++cru) {
+    if (mIDCs[cru].front().size() > 0) {
+      ++crusPerSideA;
+    }
+    if (mIDCs[cru + crusPerSide].front().size() > 0) {
+      ++crusPerSideC;
+    }
+  }
+
+  std::array<std::vector<std::vector<float>>, SIDES> idcOneSafe;
+  for (auto& vecSide : idcOneSafe) {
+    vecSide.resize(sNThreads);
+    for (auto& interavalvec : vecSide) {
+      interavalvec.resize(integrationIntervals);
+    }
+  }
+
 #pragma omp parallel for num_threads(sNThreads)
   for (unsigned int cru = 0; cru < mIDCs.size(); ++cru) {
     const o2::tpc::CRU cruTmp(cru);
     const unsigned int region = cruTmp.region();
-    const auto factorIDCOne = crusPerSide * mNIDCsPerCRU[region];
     const auto side = cruTmp.side();
-    const auto factorIndexGlob = mRegionOffs[region] + mNIDCsPerSector * cruTmp.sector();
+    const auto factorIndexGlob = mRegionOffs[region] + mNIDCsPerSector * (cruTmp.sector() % o2::tpc::SECTORSPERSIDE);
     unsigned int integrationIntervallast = 0;
+    std::vector<unsigned short> count(integrationIntervals);
+    std::vector<float> idcOneTmp(integrationIntervals);
     for (unsigned int timeframe = 0; timeframe < mTimeFrames; ++timeframe) {
       for (unsigned int idcs = 0; idcs < mIDCs[cru][timeframe].size(); ++idcs) {
         const unsigned int integrationInterval = idcs / mNIDCsPerCRU[region] + integrationIntervallast;
-        const unsigned int indexGlob = (idcs % mNIDCsPerCRU[region]) + factorIndexGlob;
-        const auto idcZeroVal = mIDCZero.mIDCZero[side][indexGlob % nIDCsSide];
-        if (idcZeroVal) {
-          mIDCOne.mIDCOne[side][integrationInterval] += mIDCs[cru][timeframe][idcs] / (factorIDCOne * idcZeroVal);
+        const unsigned int localPad = (idcs % mNIDCsPerCRU[region]);
+        const unsigned int indexGlob = localPad + factorIndexGlob;
+        const auto idcZeroVal = mIDCZero.mIDCZero[side][indexGlob];
+
+        // check pad in case of input is not grouped
+        if (!mInputGrouped && mPadFlagsMap) {
+          const o2::tpc::PadFlags flag = mPadFlagsMap->getCalArray(cru).getValue(localPad);
+          if ((flag & PadFlags::flagSkip) == PadFlags::flagSkip) {
+            continue;
+          }
+        }
+
+        if (idcZeroVal > 0 && mIDCs[cru][timeframe][idcs] > 0) {
+          idcOneTmp[integrationInterval] += mIDCs[cru][timeframe][idcs] / idcZeroVal;
+          ++count[integrationInterval];
         }
       }
       integrationIntervallast += mIDCs[cru][timeframe].size() / mNIDCsPerCRU[region];
+    }
+    const float crusTmp = (side == Side::A) ? crusPerSideA : crusPerSideC;
+    const int ithread = omp_get_thread_num();
+    for (int i = 0; i < integrationIntervals; ++i) {
+      idcOneSafe[side][ithread][i] += idcOneTmp[i] / (crusTmp * count[i]);
+    }
+  }
+
+  for (int side = 0; side < SIDES; ++side) {
+    for (const auto& interavalvec : idcOneSafe[side]) {
+      std::transform(mIDCOne.mIDCOne[side].begin(), mIDCOne.mIDCOne[side].end(), interavalvec.begin(), mIDCOne.mIDCOne[side].begin(), std::plus<float>());
     }
   }
 }
@@ -189,7 +280,7 @@ void o2::tpc::IDCFactorization::calcIDCDelta()
     const o2::tpc::CRU cruTmp(cru);
     const unsigned int region = cruTmp.region();
     const auto side = cruTmp.side();
-    const auto factorIndexGlob = mRegionOffs[region] + mNIDCsPerSector * cruTmp.sector();
+    const auto factorIndexGlob = mRegionOffs[region] + mNIDCsPerSector * (cruTmp.sector() % o2::tpc::SECTORSPERSIDE);
     unsigned int integrationIntervallast = 0;
     unsigned int integrationIntervallastLocal = 0;
     unsigned int lastChunk = 0;
@@ -204,19 +295,86 @@ void o2::tpc::IDCFactorization::calcIDCDelta()
         const unsigned int intervallocal = idcs / mNIDCsPerCRU[region];
         const unsigned int integrationIntervalGlobal = intervallocal + integrationIntervallast;
         const unsigned int integrationIntervalLocal = intervallocal + integrationIntervallastLocal;
-        const unsigned int indexGlob = (idcs % mNIDCsPerCRU[region]) + factorIndexGlob;
-        const unsigned int indexGlobMod = indexGlob % nIDCsSide;
-        const auto idcZero = mIDCZero.mIDCZero[side][indexGlobMod];
+        const unsigned int localPad = idcs % mNIDCsPerCRU[region];
+        const unsigned int indexGlob = localPad + factorIndexGlob;
+        const auto idcZero = mIDCZero.mIDCZero[side][indexGlob];
         const auto idcOne = mIDCOne.mIDCOne[side][integrationIntervalGlobal];
         const auto mult = idcZero * idcOne;
-        const auto val = (mult > 0) ? mIDCs[cru][timeframe][idcs] / mult : 0;
-        mIDCDelta[chunk].setIDCDelta(side, indexGlobMod + integrationIntervalLocal * nIDCsSide, val - 1.f);
+        auto val = (mult > 0 && mIDCs[cru][timeframe][idcs] > 0) ? mIDCs[cru][timeframe][idcs] / mult - 1 : 0;
+        if (!mInputGrouped && mPadFlagsMap) {
+          const o2::tpc::PadFlags flag = mPadFlagsMap->getCalArray(cru).getValue(localPad);
+          if ((flag & PadFlags::flagSkip) == PadFlags::flagSkip) {
+            val = 0;
+          }
+        }
+        mIDCDelta[chunk].setIDCDelta(side, indexGlob + integrationIntervalLocal * nIDCsSide, val);
       }
 
       const unsigned int intervals = mIDCs[cru][timeframe].size() / mNIDCsPerCRU[region];
       integrationIntervallast += intervals;
       integrationIntervallastLocal += intervals;
       lastChunk = chunk;
+    }
+  }
+}
+
+float o2::tpc::IDCFactorization::getMedian(std::vector<float>& values)
+{
+  if (values.empty()) {
+    return 0;
+  }
+  size_t n = values.size() / 2;
+  std::nth_element(values.begin(), values.begin() + n, values.end());
+  return values[n];
+}
+
+void o2::tpc::IDCFactorization::createStatusMap()
+{
+  const static auto& paramIDCGroup = ParameterIDCGroup::Instance();
+  mPadFlagsMap = std::make_unique<CalDet<PadFlags>>(CalDet<PadFlags>("flags", PadSubset::Region));
+#pragma omp parallel for num_threads(sNThreads)
+  for (unsigned int cru = 0; cru < mIDCs.size(); ++cru) {
+    const o2::tpc::CRU cruTmp(cru);
+    const Side side = cruTmp.side();
+    const int region = cruTmp.region();
+    const int sector = cruTmp.sector();
+    std::vector<float> idcsRow;
+    const int maxValues = Mapper::PADSPERROW[region][Mapper::ROWSPERREGION[region]];
+    idcsRow.reserve(maxValues);
+    for (unsigned int lrow = 0; lrow < Mapper::ROWSPERREGION[region]; ++lrow) {
+      // loop over pads in row in the first iteration and calculate median at the end
+      // in the second iteration check if the IDC value is to far away from the median
+      for (int iter = 0; iter < 2; ++iter) {
+        const unsigned int integrationInterval = 0;
+        const float median = (iter == 1) ? getMedian(idcsRow) : 0;
+        // loop over pad row and calculate mean of IDC0
+        for (unsigned int pad = 0; pad < Mapper::PADSPERROW[region][lrow]; ++pad) {
+          const auto index = getIndexUngrouped(sector, region, lrow, pad, integrationInterval);
+          const auto idcZeroVal = mIDCZero.mIDCZero[side][index];
+
+          if (iter == 0) {
+            // exclude dead pads
+            if (idcZeroVal > 0) {
+              idcsRow.emplace_back(idcZeroVal);
+            }
+          } else {
+            if (idcZeroVal <= 0) {
+              const unsigned int padInRegion = Mapper::OFFSETCRULOCAL[region][lrow] + pad;
+              const o2::tpc::PadFlags flag = o2::tpc::PadFlags::flagDeadPad | o2::tpc::PadFlags::flagSkip | mPadFlagsMap->getCalArray(cru).getValue(padInRegion);
+              mPadFlagsMap->getCalArray(cru).setValue(padInRegion, flag);
+            } else if (idcZeroVal > paramIDCGroup.maxIDC0Median * median) {
+              const unsigned int padInRegion = Mapper::OFFSETCRULOCAL[region][lrow] + pad;
+              const o2::tpc::PadFlags flag = o2::tpc::PadFlags::flagHighPad | o2::tpc::PadFlags::flagSkip | mPadFlagsMap->getCalArray(cru).getValue(padInRegion);
+              mPadFlagsMap->getCalArray(cru).setValue(padInRegion, flag);
+            } else if (idcZeroVal < paramIDCGroup.minIDC0Median * median) {
+              const unsigned int padInRegion = Mapper::OFFSETCRULOCAL[region][lrow] + pad;
+              const o2::tpc::PadFlags flag = o2::tpc::PadFlags::flagLowPad | o2::tpc::PadFlags::flagSkip | mPadFlagsMap->getCalArray(cru).getValue(padInRegion);
+              mPadFlagsMap->getCalArray(cru).setValue(padInRegion, flag);
+            }
+          }
+        } // loop over pads in row
+      }   // end iteration
+      idcsRow.clear();
     }
   }
 }
@@ -252,8 +410,15 @@ void o2::tpc::IDCFactorization::getTF(const unsigned int region, unsigned int in
 void o2::tpc::IDCFactorization::factorizeIDCs(const bool norm)
 {
   LOGP(info, "Using {} threads for factorization of IDCs", sNThreads);
+  LOGP(info, "Calculating IDC0");
   calcIDCZero(norm);
+  if (!mInputGrouped) {
+    LOGP(info, "Creating pad status map");
+    createStatusMap();
+  }
+  LOGP(info, "Calculating IDC1");
   calcIDCOne();
+  LOGP(info, "Calculating IDCDelta");
   calcIDCDelta();
 }
 
@@ -326,7 +491,7 @@ void o2::tpc::IDCFactorization::reset()
   }
 }
 
-void o2::tpc::IDCFactorization::drawIDCDeltaHelper(const bool type, const Sector sector, const unsigned int integrationInterval, const IDCDeltaCompression compression, const std::string filename) const
+void o2::tpc::IDCFactorization::drawIDCDeltaHelper(const bool type, const Sector sector, const unsigned int integrationInterval, const IDCDeltaCompression compression, const std::string filename, const float minZ, const float maxZ) const
 {
   std::function<float(const unsigned int, const unsigned int, const unsigned int, const unsigned int)> idcFunc;
 
@@ -343,7 +508,7 @@ void o2::tpc::IDCFactorization::drawIDCDeltaHelper(const bool type, const Sector
         return this->getIDCDeltaVal(sector, region, irow, pad, chunk, localintegrationInterval);
       };
       drawFun.mIDCFunc = idcFunc;
-      type ? IDCDrawHelper::drawSide(drawFun, sector.side(), zAxisTitle, filename) : IDCDrawHelper::drawSector(drawFun, 0, Mapper::NREGIONS, sector, zAxisTitle, filename);
+      type ? IDCDrawHelper::drawSide(drawFun, sector.side(), zAxisTitle, filename, minZ, maxZ) : IDCDrawHelper::drawSector(drawFun, 0, Mapper::NREGIONS, sector, zAxisTitle, filename, minZ, maxZ);
       break;
     }
     case IDCDeltaCompression::MEDIUM: {
@@ -352,7 +517,7 @@ void o2::tpc::IDCFactorization::drawIDCDeltaHelper(const bool type, const Sector
         return idcDeltaMedium.getValue(Sector(sector).side(), this->getIndexUngrouped(sector, region, irow, pad, localintegrationInterval));
       };
       drawFun.mIDCFunc = idcFunc;
-      type ? IDCDrawHelper::drawSide(drawFun, sector.side(), zAxisTitle, filename) : IDCDrawHelper::drawSector(drawFun, 0, Mapper::NREGIONS, sector, zAxisTitle, filename);
+      type ? IDCDrawHelper::drawSide(drawFun, sector.side(), zAxisTitle, filename, minZ, maxZ) : IDCDrawHelper::drawSector(drawFun, 0, Mapper::NREGIONS, sector, zAxisTitle, filename, minZ, maxZ);
       break;
     }
     case IDCDeltaCompression::HIGH: {
@@ -361,13 +526,13 @@ void o2::tpc::IDCFactorization::drawIDCDeltaHelper(const bool type, const Sector
         return idcDeltaHigh.getValue(Sector(sector).side(), this->getIndexUngrouped(sector, region, irow, pad, localintegrationInterval));
       };
       drawFun.mIDCFunc = idcFunc;
-      type ? IDCDrawHelper::drawSide(drawFun, sector.side(), zAxisTitle, filename) : IDCDrawHelper::drawSector(drawFun, 0, Mapper::NREGIONS, sector, zAxisTitle, filename);
+      type ? IDCDrawHelper::drawSide(drawFun, sector.side(), zAxisTitle, filename, minZ, maxZ) : IDCDrawHelper::drawSector(drawFun, 0, Mapper::NREGIONS, sector, zAxisTitle, filename, minZ, maxZ);
       break;
     }
   }
 }
 
-void o2::tpc::IDCFactorization::drawIDCZeroHelper(const bool type, const Sector sector, const std::string filename) const
+void o2::tpc::IDCFactorization::drawIDCZeroHelper(const bool type, const Sector sector, const std::string filename, const float minZ, const float maxZ) const
 {
   std::function<float(const unsigned int, const unsigned int, const unsigned int, const unsigned int)> idcFunc = [this](const unsigned int sector, const unsigned int region, const unsigned int irow, const unsigned int pad) {
     return this->getIDCZeroVal(sector, region, irow, pad);
@@ -376,10 +541,10 @@ void o2::tpc::IDCFactorization::drawIDCZeroHelper(const bool type, const Sector 
   IDCDrawHelper::IDCDraw drawFun;
   drawFun.mIDCFunc = idcFunc;
   const std::string zAxisTitle = IDCDrawHelper::getZAxisTitle(IDCType::IDCZero);
-  type ? IDCDrawHelper::drawSide(drawFun, sector.side(), zAxisTitle, filename) : IDCDrawHelper::drawSector(drawFun, 0, Mapper::NREGIONS, sector, zAxisTitle, filename);
+  type ? IDCDrawHelper::drawSide(drawFun, sector.side(), zAxisTitle, filename, minZ, maxZ) : IDCDrawHelper::drawSector(drawFun, 0, Mapper::NREGIONS, sector, zAxisTitle, filename, minZ, maxZ);
 }
 
-void o2::tpc::IDCFactorization::drawIDCHelper(const bool type, const Sector sector, const unsigned int integrationInterval, const std::string filename) const
+void o2::tpc::IDCFactorization::drawIDCHelper(const bool type, const Sector sector, const unsigned int integrationInterval, const std::string filename, const float minZ, const float maxZ) const
 {
   std::function<float(const unsigned int, const unsigned int, const unsigned int, const unsigned int)> idcFunc = [this, integrationInterval](const unsigned int sector, const unsigned int region, const unsigned int irow, const unsigned int pad) {
     return this->getIDCValUngrouped(sector, region, irow, pad, integrationInterval);
@@ -389,5 +554,75 @@ void o2::tpc::IDCFactorization::drawIDCHelper(const bool type, const Sector sect
   drawFun.mIDCFunc = idcFunc;
 
   const std::string zAxisTitleDraw = IDCDrawHelper::getZAxisTitle(IDCType::IDC);
-  type ? IDCDrawHelper::drawSide(drawFun, sector.side(), zAxisTitleDraw, filename) : IDCDrawHelper::drawSector(drawFun, 0, Mapper::NREGIONS, sector, zAxisTitleDraw, filename);
+  type ? IDCDrawHelper::drawSide(drawFun, sector.side(), zAxisTitleDraw, filename, minZ, maxZ) : IDCDrawHelper::drawSector(drawFun, 0, Mapper::NREGIONS, sector, zAxisTitleDraw, filename, minZ, maxZ);
+}
+
+void o2::tpc::IDCFactorization::setGainMap(const char* inpFile, const char* mapName)
+{
+  TFile f(inpFile, "READ");
+  o2::tpc::CalDet<float>* gainMap = nullptr;
+  f.GetObject(mapName, gainMap);
+
+  if (!gainMap) {
+    LOGP(info, "GainMap {} not found returning", mapName);
+    return;
+  }
+  setGainMap(*gainMap);
+  delete gainMap;
+}
+
+void o2::tpc::IDCFactorization::setGainMap(const CalDet<float>& gainmap)
+{
+  mGainMap = std::make_unique<CalDet<float>>(gainmap);
+}
+
+void o2::tpc::IDCFactorization::setPadFlagMap(const char* inpFile, const char* mapName)
+{
+  TFile f(inpFile, "READ");
+  o2::tpc::CalDet<PadFlags>* statusmap = nullptr;
+  f.GetObject(mapName, statusmap);
+
+  if (!statusmap) {
+    LOGP(info, "Pad flag map {} not found returning", mapName);
+    return;
+  }
+  setPadFlagMap(*statusmap);
+  delete statusmap;
+}
+
+void o2::tpc::IDCFactorization::setPadFlagMap(const CalDet<PadFlags>& flagmap)
+{
+  mPadFlagsMap = std::make_unique<CalDet<PadFlags>>(flagmap);
+}
+
+void o2::tpc::IDCFactorization::drawPadFlagMap(const bool type, const Sector sector, const std::string filename, const PadFlags flag) const
+{
+  if (!mPadFlagsMap) {
+    LOGP(info, "Status map not set returning");
+  }
+
+  std::function<float(const unsigned int, const unsigned int, const unsigned int, const unsigned int)> idcFunc = [this, flag](const unsigned int sector, const unsigned int region, const unsigned int row, const unsigned int pad) {
+    const unsigned int padInRegion = Mapper::OFFSETCRULOCAL[region][row] + pad;
+    const auto flagDraw = mPadFlagsMap->getCalArray(region + sector * Mapper::NREGIONS).getValue(padInRegion);
+    if ((flagDraw & flag) == flag) {
+      return 1;
+    } else {
+      return 0;
+    }
+  };
+
+  IDCDrawHelper::IDCDraw drawFun;
+  drawFun.mIDCFunc = idcFunc;
+  const std::string zAxisTitle = "status flag";
+  type ? IDCDrawHelper::drawSide(drawFun, sector.side(), zAxisTitle, filename) : IDCDrawHelper::drawSector(drawFun, 0, Mapper::NREGIONS, sector, zAxisTitle, filename);
+}
+
+void o2::tpc::IDCFactorization::dumpPadFlagMap(const char* outFile, const char* mapName)
+{
+  if (!mPadFlagsMap) {
+    LOGP(info, "Status map not set returning");
+  }
+  TFile fOut(outFile, "RECREATE");
+  fOut.WriteObject(mPadFlagsMap.get(), mapName);
+  fOut.Close();
 }

--- a/Detectors/TPC/calibration/src/IDCGroup.cxx
+++ b/Detectors/TPC/calibration/src/IDCGroup.cxx
@@ -12,7 +12,9 @@
 #include "TPCCalibration/IDCGroup.h"
 #include "CommonUtils/TreeStreamRedirector.h"
 #include "TPCCalibration/IDCDrawHelper.h"
+#include "TPCCalibration/IDCContainer.h"
 #include "TPCBase/Mapper.h"
+#include "TPCBase/CalDet.h"
 #include "TFile.h"
 #include <numeric>
 
@@ -61,28 +63,48 @@ float o2::tpc::IDCGroup::getValUngroupedGlobal(unsigned int ugrow, unsigned int 
 
 std::vector<float> o2::tpc::IDCGroup::get1DIDCs() const
 {
-  return get1DIDCs(mIDCsGrouped, getNIntegrationIntervals(), getNIDCsPerIntegrationInterval(), mRegion, true);
+  return get1DIDCs(mIDCsGrouped, getNIntegrationIntervals(), getNIDCsPerIntegrationInterval(), mCRU, true, nullptr);
 }
 
-std::vector<float> o2::tpc::IDCGroup::get1DIDCsUngrouped(const std::vector<float> idc, const unsigned int region)
+std::vector<float> o2::tpc::IDCGroup::get1DIDCsUngrouped(const std::vector<float> idc, const unsigned short cru, const CalDet<PadFlags>* flagMap)
 {
-  const auto nIDCsPerIntegrationInterval = Mapper::PADSPERREGION[region];
-  return get1DIDCs(idc, idc.size() / nIDCsPerIntegrationInterval, nIDCsPerIntegrationInterval, region, false);
+  const auto nIDCsPerIntegrationInterval = Mapper::PADSPERREGION[CRU(cru).region()];
+  return get1DIDCs(idc, idc.size() / nIDCsPerIntegrationInterval, nIDCsPerIntegrationInterval, cru, false, flagMap);
 }
 
-std::vector<float> o2::tpc::IDCGroup::get1DIDCs(const std::vector<float> idc, const unsigned int nIntervals, const unsigned int nIDCsPerIntegrationInterval, const unsigned int region, const bool normalize)
+std::vector<float> o2::tpc::IDCGroup::get1DIDCs(const std::vector<float> idc, const unsigned int nIntervals, const unsigned int nIDCsPerIntegrationInterval, const unsigned short cru, const bool normalize, const CalDet<PadFlags>* flagMap)
 {
   // integrate IDCs for each interval
   std::vector<float> idcOne;
   idcOne.reserve(nIntervals);
+  int count = 0; // counter for good pads which are not skipped
+
   for (unsigned int i = 0; i < nIntervals; ++i) {
     // set integration range for one integration interval
     const auto start = idc.begin() + i * nIDCsPerIntegrationInterval;
     const auto end = start + nIDCsPerIntegrationInterval;
-    idcOne.emplace_back(std::accumulate(start, end, decltype(idc)::value_type(0)));
+
+    if (flagMap) {
+      size_t index = 0;
+      float sum = 0;
+      for (auto it = start; it != end; ++it) {
+        const auto flag = flagMap->getCalArray(cru).getValue(index++);
+        if ((flag & PadFlags::flagSkip) != PadFlags::flagSkip) {
+          sum += *it;
+          // only count for first iteration
+          if (i == 0) {
+            ++count;
+          }
+        }
+      }
+      idcOne.emplace_back(sum);
+    } else {
+      idcOne.emplace_back(std::accumulate(start, end, decltype(idc)::value_type(0)));
+    }
   }
   // normalize 1D-IDCs to absolute space charge
-  const float norm = normalize ? Mapper::REGIONAREA[region] / nIDCsPerIntegrationInterval : 1.f / nIDCsPerIntegrationInterval;
+  const float normFac = (count > 0) ? count : nIDCsPerIntegrationInterval;
+  const float norm = normalize ? Mapper::REGIONAREA[CRU(cru).region()] / normFac : 1.f / normFac;
   std::transform(idcOne.begin(), idcOne.end(), idcOne.begin(), [norm](auto& val) { return val * norm; });
 
   return idcOne;

--- a/Detectors/TPC/calibration/src/RobustAverage.cxx
+++ b/Detectors/TPC/calibration/src/RobustAverage.cxx
@@ -74,3 +74,8 @@ void o2::tpc::RobustAverage::addValue(const float value, const float weight)
   mValues.emplace_back(value);
   mWeights.emplace_back(weight);
 }
+
+void o2::tpc::RobustAverage::addValue(const float value)
+{
+  mValues.emplace_back(value);
+}

--- a/Detectors/TPC/workflow/include/TPCWorkflow/ProcessingHelpers.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/ProcessingHelpers.h
@@ -21,5 +21,11 @@ namespace processing_helpers
 
 uint64_t getRunNumber(o2::framework::ProcessingContext& pc);
 
-}
+/// \return returns tf from tfCounter
+uint32_t getCurrentTF(o2::framework::ProcessingContext& pc);
+
+/// \return returns creation time of tf
+uint64_t getCreationTime(o2::framework::ProcessingContext& pc);
+
+} // namespace processing_helpers
 } // namespace o2::tpc

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCFactorizeIDCSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCFactorizeIDCSpec.h
@@ -34,6 +34,7 @@
 #include "TPCWorkflow/TPCDistributeIDCSpec.h"
 #include "TPCBase/CRU.h"
 #include "CommonUtils/NameConf.h"
+#include "TPCWorkflow/ProcessingHelpers.h"
 
 using namespace o2::framework;
 using o2::header::gDataOriginTPC;
@@ -91,34 +92,30 @@ class TPCFactorizeIDCSpec : public o2::framework::Task
       mIDCFactorization.setGainMap(refGainMapFile.data(), "GainMap");
     }
 
-    mTFRangeIDCDelta[0].resize(mIDCFactorization.getNChunks());
-    mTFRangeIDCDelta[1].resize(mIDCFactorization.getNChunks());
-    mTimeStampRangeIDCDelta[0].resize(mIDCFactorization.getNChunks());
-    // mTimeStampRangeIDCDelta[1].resize(mIDCFactorization.getNChunks());
-    mTimeStampRangeIDCDelta[1] = std::vector<uint64_t>(mIDCFactorization.getNChunks(), 99999999999999);
+    mTFRangeIDCDelta.resize(mIDCFactorization.getNChunks());
+    mTimeStampRangeIDCDelta.resize(mIDCFactorization.getNChunks());
   }
 
   void run(o2::framework::ProcessingContext& pc) final
   {
     // set the min range of TFs for first TF
     if (mProcessedTFs == 0) {
-      mTFFirst = getCurrentTF(pc);
-      mTimeStampRange[0] = getCurrentTimeStamp(pc);
+      mTFFirst = processing_helpers::getCurrentTF(pc);
+      mTimeStampFirst = processing_helpers::getCreationTime(pc);
 
       // write struct containing grouping parameters to access grouped IDCs to CCDB
       if (mWriteToDB && mUpdateGroupingPar) {
         // validity for grouping parameters is from first TF to some really large TF (until it is updated) TODO do somewhere else?!
         if constexpr (std::is_same_v<Type, TPCFactorizeIDCSpecGroup>) {
-          mDBapi.storeAsTFileAny<o2::tpc::ParameterIDCGroupCCDB>(&mIDCStruct.mIDCs.getIDCGroupHelperSector().getGroupingParameter(), "TPC/Calib/IDC/GROUPINGPAR", mMetadata, mTimeStampRange[0], 99999999999999);
+          mDBapi.storeAsTFileAny<o2::tpc::ParameterIDCGroupCCDB>(&mIDCStruct.mIDCs.getIDCGroupHelperSector().getGroupingParameter(), "TPC/Calib/IDC/GROUPINGPAR", mMetadata, mTimeStampFirst, 99999999999999);
         } else {
-          mDBapi.storeAsTFileAny<o2::tpc::ParameterIDCGroupCCDB>(&mIDCFactorization.getGroupingParameter(), "TPC/Calib/IDC/GROUPINGPAR", mMetadata, mTimeStampRange[0], 99999999999999);
+          mDBapi.storeAsTFileAny<o2::tpc::ParameterIDCGroupCCDB>(&mIDCFactorization.getGroupingParameter(), "TPC/Calib/IDC/GROUPINGPAR", mMetadata, mTimeStampFirst, 99999999999999);
         }
         mUpdateGroupingPar = false; // write grouping parameters only once
       }
 
       for (unsigned int iChunk = 0; iChunk < mIDCFactorization.getNChunks(); ++iChunk) {
-        mTFRangeIDCDelta[0][iChunk] = getFirstTFDeltaIDC(iChunk);
-        mTFRangeIDCDelta[1][iChunk] = 999999999; //getLastTFDeltaIDC(iChunk);
+        mTFRangeIDCDelta[iChunk] = getFirstTFDeltaIDC(iChunk);
       }
     }
 
@@ -136,8 +133,7 @@ class TPCFactorizeIDCSpec : public o2::framework::Task
     LOGP(info, "aggregated TFs: {}", mProcessedTFs);
 
     if (mProcessedTFs == mIDCFactorization.getNTimeframes()) {
-      mTimeStampRange[1] = 99999999999999; // getCurrentTimeStamp(pc);
-      mProcessedTFs = 0;                   // reset processed TFs for next aggregation interval
+      mProcessedTFs = 0; // reset processed TFs for next aggregation interval
       if constexpr (std::is_same_v<Type, TPCFactorizeIDCSpecGroup>) {
         mIDCFactorization.factorizeIDCs(true); // calculate DeltaIDC, 0D-IDC, 1D-IDC
       } else {
@@ -146,7 +142,7 @@ class TPCFactorizeIDCSpec : public o2::framework::Task
 
       if (mDebug) {
         LOGP(info, "dumping aggregated and factorized IDCs to file");
-        mIDCFactorization.dumpToFile(fmt::format("IDCFactorized_{:02}.root", getCurrentTF(pc)).data());
+        mIDCFactorization.dumpToFile(fmt::format("IDCFactorized_{:02}.root", processing_helpers::getCurrentTF(pc)).data());
         mIDCFactorization.dumpPadFlagMap("padstatusmap.root", "PadStatus");
       }
 
@@ -165,28 +161,23 @@ class TPCFactorizeIDCSpec : public o2::framework::Task
   static constexpr header::DataDescription getDataDescriptionIDCDelta() { return header::DataDescription{"IDCDELTA"}; }
 
  private:
-  const std::vector<uint32_t> mCRUs{};                            ///< CRUs to process in this instance
-  int mProcessedTFs{0};                                           ///< number of processed time frames to keep track of when the writing to CCDB will be done
-  IDCFactorization mIDCFactorization;                             ///< object aggregating the IDCs and performing the factorization of the IDCs
-  TPCFactorizeIDCStruct<Type> mIDCStruct{};                       ///< object for averaging and grouping of the IDCs
-  const IDCDeltaCompression mCompressionDeltaIDC{};               ///< compression type for IDC Delta
-  const bool mDebug{false};                                       ///< dump IDCs to tree for debugging
-  const bool mSendOutDebug{false};                                ///< flag if the output will be send (for debugging)
-  o2::ccdb::CcdbApi mDBapi;                                       ///< API for storing the IDCs in the CCDB
-  std::map<std::string, std::string> mMetadata;                   ///< meta data of the stored object in CCDB
-  bool mWriteToDB{};                                              ///< flag if writing to CCDB will be done
-  uint32_t mTFFirst{};                                            ///< first TF of current aggregation interval
-  std::array<uint64_t, 2> mTimeStampRange{};                      ///< storing of first and last time stamp range used when setting the validity of the objects when writing to CCDB
-  std::array<std::vector<uint32_t>, 2> mTFRangeIDCDelta{};        ///< tf range for storing IDCDelta
-  std::array<std::vector<uint64_t>, 2> mTimeStampRangeIDCDelta{}; ///< time stamp range of IDCDelta
-  bool mUpdateGroupingPar{true};                                  ///< flag to set if grouping parameters should be updated or not
-  int mLaneId{0};                                                 ///< the id of the current process within the parallel pipeline
-
-  /// \return returns TF of current processed data
-  uint32_t getCurrentTF(o2::framework::ProcessingContext& pc) const { return o2::framework::DataRefUtils::getHeader<o2::header::DataHeader*>(pc.inputs().getFirstValid(true))->tfCounter; }
-
-  /// \return returns time stamp of current processed data
-  uint64_t getCurrentTimeStamp(o2::framework::ProcessingContext& pc) const { return DataRefUtils::getHeader<DataProcessingHeader*>(pc.inputs().getFirstValid(true))->creation; }
+  const std::vector<uint32_t> mCRUs{};              ///< CRUs to process in this instance
+  int mProcessedTFs{0};                             ///< number of processed time frames to keep track of when the writing to CCDB will be done
+  IDCFactorization mIDCFactorization;               ///< object aggregating the IDCs and performing the factorization of the IDCs
+  TPCFactorizeIDCStruct<Type> mIDCStruct{};         ///< object for averaging and grouping of the IDCs
+  const IDCDeltaCompression mCompressionDeltaIDC{}; ///< compression type for IDC Delta
+  const bool mDebug{false};                         ///< dump IDCs to tree for debugging
+  const bool mSendOutDebug{false};                  ///< flag if the output will be send (for debugging)
+  o2::ccdb::CcdbApi mDBapi;                         ///< API for storing the IDCs in the CCDB
+  std::map<std::string, std::string> mMetadata;     ///< meta data of the stored object in CCDB
+  bool mWriteToDB{};                                ///< flag if writing to CCDB will be done
+  uint32_t mTFFirst{};                              ///< first TF of current aggregation interval
+  uint64_t mTimeStampFirst{};                       ///< storing of first and last time stamp range used when setting the validity of the objects when writing to CCDB
+  std::vector<uint32_t> mTFRangeIDCDelta{};         ///< tf range for storing IDCDelta
+  std::vector<uint64_t> mTimeStampRangeIDCDelta{};  ///< time stamp range of IDCDelta
+  bool mUpdateGroupingPar{true};                    ///< flag to set if grouping parameters should be updated or not
+  int mLaneId{0};                                   ///< the id of the current process within the parallel pipeline
+  std::unique_ptr<CalDet<PadFlags>> mPadFlagsMap;   ///< status flag for each pad (i.e. if the pad is dead). This map is buffered to check if something changed, when a new map is created
 
   /// \return returns first TF for validity range when storing to CCDB
   uint32_t getFirstTF() const { return mTFFirst; }
@@ -198,25 +189,21 @@ class TPCFactorizeIDCSpec : public o2::framework::Task
   unsigned int getLastTFDeltaIDC(const unsigned int iChunk) const { return (iChunk == mIDCFactorization.getNChunks() - 1) ? (mIDCFactorization.getNTimeframes() + getFirstTF()) : (getFirstTFDeltaIDC(iChunk) + mIDCFactorization.getTimeFramesDeltaIDC()); }
 
   /// \return returns first time stamp for validity range when storing to IDCDelta CCDB
-  auto getFirstTimeStampDeltaIDC(const unsigned int iChunk) const { return mTimeStampRangeIDCDelta[0][iChunk]; }
-
-  /// \return returns last time stamp for validity range when storing to IDCDelta CCDB
-  auto getLastTimeStampDeltaIDC(const unsigned int iChunk) const { return mTimeStampRangeIDCDelta[1][iChunk]; }
+  auto getFirstTimeStampDeltaIDC(const unsigned int iChunk) const { return mTimeStampRangeIDCDelta[iChunk]; }
 
   /// check if current tf will be used to set the time stamp range
   bool findTimeStamp(o2::framework::ProcessingContext& pc)
   {
-    const auto tf = getCurrentTF(pc);
-    return findTimeStamp(true, tf, pc) ? 1 : findTimeStamp(false, tf, pc);
+    const auto tf = processing_helpers::getCurrentTF(pc);
+    return findTimeStamp(tf, pc);
   }
 
-  bool findTimeStamp(const bool first, const uint32_t tf, o2::framework::ProcessingContext& pc)
+  bool findTimeStamp(const uint32_t tf, o2::framework::ProcessingContext& pc)
   {
-    const int ind = first ? 0 : 1;
-    auto it = std::find(mTFRangeIDCDelta[ind].begin(), mTFRangeIDCDelta[ind].end(), tf);
-    if (it != mTFRangeIDCDelta[ind].end()) {
-      const int index = std::distance(mTFRangeIDCDelta[ind].begin(), it);
-      mTimeStampRangeIDCDelta[ind][index] = getCurrentTimeStamp(pc);
+    auto it = std::find(mTFRangeIDCDelta.begin(), mTFRangeIDCDelta.end(), tf);
+    if (it != mTFRangeIDCDelta.end()) {
+      const int index = std::distance(mTFRangeIDCDelta.begin(), it);
+      mTimeStampRangeIDCDelta[index] = processing_helpers::getCreationTime(pc);
       // TODO remove found tf?
       return true;
     }
@@ -240,18 +227,30 @@ class TPCFactorizeIDCSpec : public o2::framework::Task
     }
 
     if (mWriteToDB) {
-      const auto timeStampStart = mTimeStampRange[0];
-      const auto timeStampEnd = mTimeStampRange[1];
+      const auto timeStampStart = mTimeStampFirst;
+      const auto timeStampEnd = 99999999999999;
 
       LOGP(info, "Writing IDCs to CCDB");
       mDBapi.storeAsTFileAny<o2::tpc::IDCZero>(&mIDCFactorization.getIDCZero(), "TPC/Calib/IDC/IDC0", mMetadata, timeStampStart, timeStampEnd);
       mDBapi.storeAsTFileAny<o2::tpc::IDCOne>(&mIDCFactorization.getIDCOne(), "TPC/Calib/IDC/IDC1", mMetadata, timeStampStart, timeStampEnd);
 
-      const auto padStatusMap = mIDCFactorization.getPadStatusMap();
+      auto padStatusMap = mIDCFactorization.getPadStatusMap();
       if (padStatusMap) {
-        LOGP(info, "Writing pad status map to CCDB");
-        mDBapi.storeAsTFileAny<CalDet<PadFlags>>(padStatusMap, "TPC/Calib/IDC/PadStatusMap", mMetadata, 1635378515832, timeStampEnd);
-        LOGP(info, "Pad status map written to CCDB");
+        // store map in case it is nullptr
+        if (!mPadFlagsMap) {
+          mPadFlagsMap = std::move(padStatusMap);
+          LOGP(info, "Writing pad status map to CCDB.");
+          mDBapi.storeAsTFileAny<CalDet<PadFlags>>(mPadFlagsMap.get(), "TPC/Calib/IDC/PadStatusMap", mMetadata, timeStampStart, timeStampEnd);
+          LOGP(info, "Pad status map written to CCDB");
+        } else {
+          // check if map changed. if it changed update the map in the CCDB and store new map in buffer
+          if (!(*padStatusMap.get() == *mPadFlagsMap.get())) {
+            LOGP(info, "Pad status map changed");
+            LOGP(info, "Writing pad status map to CCDB");
+            mDBapi.storeAsTFileAny<CalDet<PadFlags>>(mPadFlagsMap.get(), "TPC/Calib/IDC/PadStatusMap", mMetadata, timeStampStart, timeStampEnd);
+            LOGP(info, "Pad status map written to CCDB");
+          }
+        }
       }
 
       for (unsigned int iChunk = 0; iChunk < mIDCFactorization.getNChunks(); ++iChunk) {
@@ -259,7 +258,7 @@ class TPCFactorizeIDCSpec : public o2::framework::Task
           // perform grouping of IDC Delta if necessary
           mIDCStruct.mIDCs.setIDCs(std::move(mIDCFactorization).getIDCDeltaUncompressed(iChunk));
           LOGP(info, "averaging and grouping DeltaIDCs for TFs {} - {} for CRUs {} to {} using {} threads", getFirstTFDeltaIDC(iChunk), getLastTFDeltaIDC(iChunk), mCRUs.front(), mCRUs.back(), mIDCStruct.mIDCs.getNThreads());
-          mIDCStruct.mIDCs.processIDCs(padStatusMap);
+          mIDCStruct.mIDCs.processIDCs(mPadFlagsMap.get());
           if (mDebug) {
             mIDCStruct.mIDCs.dumpToFile(fmt::format("IDCDeltaAveraged_chunk{:02}_{:02}.root", iChunk, getFirstTFDeltaIDC(iChunk)).data());
           }
@@ -271,10 +270,10 @@ class TPCFactorizeIDCSpec : public o2::framework::Task
             using compType = unsigned short;
             if constexpr (std::is_same_v<Type, TPCFactorizeIDCSpecGroup>) {
               auto idcDeltaMediumCompressed = IDCDeltaCompressionHelper<compType>::getCompressedIDCs(mIDCStruct.mIDCs.getIDCGroupData());
-              mDBapi.storeAsTFileAny<o2::tpc::IDCDelta<compType>>(&idcDeltaMediumCompressed, "TPC/Calib/IDC/IDCDELTA", mMetadata, getFirstTimeStampDeltaIDC(iChunk), getLastTimeStampDeltaIDC(iChunk));
+              mDBapi.storeAsTFileAny<o2::tpc::IDCDelta<compType>>(&idcDeltaMediumCompressed, "TPC/Calib/IDC/IDCDELTA", mMetadata, getFirstTimeStampDeltaIDC(iChunk), timeStampEnd);
             } else {
               auto idcDeltaMediumCompressed = mIDCFactorization.getIDCDeltaMediumCompressed(iChunk);
-              mDBapi.storeAsTFileAny<o2::tpc::IDCDelta<compType>>(&idcDeltaMediumCompressed, "TPC/Calib/IDC/IDCDELTA", mMetadata, getFirstTimeStampDeltaIDC(iChunk), getLastTimeStampDeltaIDC(iChunk));
+              mDBapi.storeAsTFileAny<o2::tpc::IDCDelta<compType>>(&idcDeltaMediumCompressed, "TPC/Calib/IDC/IDCDELTA", mMetadata, getFirstTimeStampDeltaIDC(iChunk), timeStampEnd);
             }
 
             break;
@@ -283,18 +282,18 @@ class TPCFactorizeIDCSpec : public o2::framework::Task
             using compType = unsigned char;
             if constexpr (std::is_same_v<Type, TPCFactorizeIDCSpecGroup>) {
               auto idcDeltaMediumCompressed = IDCDeltaCompressionHelper<compType>::getCompressedIDCs(mIDCStruct.mIDCs.getIDCGroupData());
-              mDBapi.storeAsTFileAny<o2::tpc::IDCDelta<compType>>(&idcDeltaMediumCompressed, "TPC/Calib/IDC/IDCDELTA", mMetadata, getFirstTimeStampDeltaIDC(iChunk), getLastTimeStampDeltaIDC(iChunk));
+              mDBapi.storeAsTFileAny<o2::tpc::IDCDelta<compType>>(&idcDeltaMediumCompressed, "TPC/Calib/IDC/IDCDELTA", mMetadata, getFirstTimeStampDeltaIDC(iChunk), timeStampEnd);
             } else {
               auto idcDeltaHighCompressed = mIDCFactorization.getIDCDeltaHighCompressed(iChunk);
-              mDBapi.storeAsTFileAny<o2::tpc::IDCDelta<compType>>(&idcDeltaHighCompressed, "TPC/Calib/IDC/IDCDELTA", mMetadata, getFirstTimeStampDeltaIDC(iChunk), getLastTimeStampDeltaIDC(iChunk));
+              mDBapi.storeAsTFileAny<o2::tpc::IDCDelta<compType>>(&idcDeltaHighCompressed, "TPC/Calib/IDC/IDCDELTA", mMetadata, getFirstTimeStampDeltaIDC(iChunk), timeStampEnd);
             }
             break;
           }
           case IDCDeltaCompression::NO:
             if constexpr (std::is_same_v<Type, TPCFactorizeIDCSpecGroup>) {
-              mDBapi.storeAsTFileAny<o2::tpc::IDCDelta<float>>(&mIDCStruct.mIDCs.getIDCGroupData(), "TPC/Calib/IDC/IDCDELTA", mMetadata, getFirstTimeStampDeltaIDC(iChunk), getLastTimeStampDeltaIDC(iChunk));
+              mDBapi.storeAsTFileAny<o2::tpc::IDCDelta<float>>(&mIDCStruct.mIDCs.getIDCGroupData(), "TPC/Calib/IDC/IDCDELTA", mMetadata, getFirstTimeStampDeltaIDC(iChunk), timeStampEnd);
             } else {
-              mDBapi.storeAsTFileAny<o2::tpc::IDCDelta<float>>(&mIDCFactorization.getIDCDeltaUncompressed(iChunk), "TPC/Calib/IDC/IDCDELTA", mMetadata, getFirstTimeStampDeltaIDC(iChunk), getLastTimeStampDeltaIDC(iChunk));
+              mDBapi.storeAsTFileAny<o2::tpc::IDCDelta<float>>(&mIDCFactorization.getIDCDeltaUncompressed(iChunk), "TPC/Calib/IDC/IDCDELTA", mMetadata, getFirstTimeStampDeltaIDC(iChunk), timeStampEnd);
             }
             break;
         }

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCFourierTransformAggregatorSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCFourierTransformAggregatorSpec.h
@@ -58,7 +58,7 @@ class TPCFourierTransformAggregatorSpec : public o2::framework::Task
   {
     // set the min range of TFs for first TF
     if (mProcessedTFs == 0) {
-      mTFRange[0] = getCurrentTF(pc);
+      mTimeStampRange[0] = getCurrentTimeStamp(pc);
     }
 
     for (int i = 0; i < mCRUs.size(); ++i) {
@@ -69,13 +69,11 @@ class TPCFourierTransformAggregatorSpec : public o2::framework::Task
     }
     ++mProcessedTFs;
 
-    if (!(mProcessedTFs % ((mTimeFrames + 5) / 5))) {
-      LOGP(info, "aggregated TFs: {}", mProcessedTFs);
-    }
+    LOGP(info, "aggregated TFs: {}", mProcessedTFs);
 
     if (mProcessedTFs == mTimeFrames) {
-      mTFRange[1] = getCurrentTF(pc) + 1; // set the TF for last aggregated TF
-      mProcessedTFs = 0;                  // reset processed TFs for next aggregation interval
+      mTimeStampRange[1] = getCurrentTimeStamp(pc);
+      mProcessedTFs = 0; // reset processed TFs for next aggregation interval
 
       // perform fourier transform of 1D-IDCs
       auto intervals = mOneDIDCAggregator.getIntegrationIntervalsPerTF();
@@ -109,11 +107,13 @@ class TPCFourierTransformAggregatorSpec : public o2::framework::Task
   o2::ccdb::CcdbApi mDBapi;                     ///< API for storing the IDCs in the CCDB
   std::map<std::string, std::string> mMetadata; ///< meta data of the stored object in CCDB
   bool mWriteToDB{};                            ///< flag if writing to CCDB will be done
-  std::array<uint32_t, 2> mTFRange{};           ///< storing of first and last TF used when setting the validity of the objects when writing to CCDB
+  std::array<uint64_t, 2> mTimeStampRange{};    ///< storing of first and last time stamp used when setting the validity of the objects when writing to CCDB
   int mProcessedTFs{0};                         ///< number of processed time frames to keep track of when the writing to CCDB will be done
 
   /// \return returns TF of current processed data
   uint32_t getCurrentTF(o2::framework::ProcessingContext& pc) const { return o2::framework::DataRefUtils::getHeader<o2::header::DataHeader*>(pc.inputs().getFirstValid(true))->tfCounter; }
+
+  uint64_t getCurrentTimeStamp(o2::framework::ProcessingContext& pc) const { return DataRefUtils::getHeader<DataProcessingHeader*>(pc.inputs().getFirstValid(true))->creation; }
 
   void sendOutput(DataAllocator& output)
   {
@@ -122,7 +122,7 @@ class TPCFourierTransformAggregatorSpec : public o2::framework::Task
     }
 
     if (mWriteToDB) {
-      mDBapi.storeAsTFileAny<o2::tpc::FourierCoeff>(&mIDCFourierTransform.getFourierCoefficients(), "TPC/Calib/IDC/FOURIER", mMetadata, mTFRange[0], mTFRange[1]);
+      mDBapi.storeAsTFileAny<o2::tpc::FourierCoeff>(&mIDCFourierTransform.getFourierCoefficients(), "TPC/Calib/IDC/FOURIER", mMetadata, mTimeStampRange[0], mTimeStampRange[1]);
     }
   }
 };

--- a/Detectors/TPC/workflow/src/ProcessingHelpers.cxx
+++ b/Detectors/TPC/workflow/src/ProcessingHelpers.cxx
@@ -51,3 +51,13 @@ uint64_t processing_helpers::getRunNumber(ProcessingContext& pc)
 
   return run;
 }
+
+uint32_t processing_helpers::getCurrentTF(o2::framework::ProcessingContext& pc)
+{
+  return o2::framework::DataRefUtils::getHeader<o2::header::DataHeader*>(pc.inputs().getFirstValid(true))->tfCounter;
+}
+
+uint64_t processing_helpers::getCreationTime(o2::framework::ProcessingContext& pc)
+{
+  return DataRefUtils::getHeader<DataProcessingHeader*>(pc.inputs().getFirstValid(true))->creation;
+}

--- a/Detectors/TPC/workflow/src/tpc-flp-idc.cxx
+++ b/Detectors/TPC/workflow/src/tpc-flp-idc.cxx
@@ -44,6 +44,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"configFile", VariantType::String, "", {"configuration file for configurable parameters"}},
     {"debug", VariantType::Bool, false, {"create debug files"}},
     {"propagateIDCs", VariantType::Bool, false, {"IDCs will not be grouped and just send out."}},
+    {"loadStatusMap", VariantType::Bool, false, {"Loading pad status map from the CCDB."}},
     {"lanes", VariantType::Int, defaultlanes, {"Number of parallel processing lanes (crus are split per device)."}},
     {"time-lanes", VariantType::Int, 1, {"Number of parallel processing lanes (timeframes are split per device)."}},
     {"nthreads", VariantType::Int, 1, {"Number of threads which will be used during averaging and grouping."}},
@@ -73,6 +74,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
   const auto crusPerLane = nCRUs / nLanes + ((nCRUs % nLanes) != 0);
   const auto debug = config.options().get<bool>("debug");
   const auto propagateIDCs = config.options().get<bool>("propagateIDCs");
+  const auto loadStatusMap = config.options().get<bool>("loadStatusMap");
   const auto nthreads = static_cast<unsigned long>(config.options().get<int>("nthreads"));
   IDCAverageGroup<IDCAverageGroupCRU>::setNThreads(nthreads);
   const auto rangeIDC = static_cast<unsigned int>(config.options().get<int>("rangeIDC"));
@@ -102,7 +104,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
     }
     const auto last = std::min(tpcCRUs.end(), first + crusPerLane);
     const std::vector<uint32_t> rangeCRUs(first, last);
-    propagateIDCs ? workflow.emplace_back(timePipeline(getTPCFLPIDCSpec<TPCFLPIDCDeviceNoGroup>(ilane, rangeCRUs, rangeIDC, debug, loadFromFile), time_lanes)) : workflow.emplace_back(timePipeline(getTPCFLPIDCSpec<TPCFLPIDCDeviceGroup>(ilane, rangeCRUs, rangeIDC, debug, loadFromFile), time_lanes));
+    propagateIDCs ? workflow.emplace_back(timePipeline(getTPCFLPIDCSpec<TPCFLPIDCDeviceNoGroup>(ilane, rangeCRUs, rangeIDC, debug, loadFromFile, loadStatusMap), time_lanes)) : workflow.emplace_back(timePipeline(getTPCFLPIDCSpec<TPCFLPIDCDeviceGroup>(ilane, rangeCRUs, rangeIDC, debug, loadFromFile, loadStatusMap), time_lanes));
   }
 
   return workflow;


### PR DESCRIPTION
- creation of status map for pads which are dead or delivering high IDC values using IDC0 map
- applying pad status map on FLPs when calculating 1D-IDCs
- fix race condition when using multithreading during calculation of IDC1
- using the timestamp information instead of TFid when writing IDCs to CCDB
- printing of debug informations
- do not use weights during averaging/grouping in case no weights were set
- setting of the z-axis when drawing factorized IDCs