### PR TITLE
Fix OB Half Staves relative position and U-leg length

### DIFF
--- a/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
@@ -103,8 +103,8 @@ static void configITS(Detector* its)
     {3.78, 3.93, 4.21, 9., 9.55, 20},
     {-1, 19.6, -1, 4., 7.5, 24},   // for others: -, rMid, -, NMod/HStave, phi0, nStaves // 24 was 49
     {-1, 24.55, -1, 4., 6., 30},   // 30 was 61
-    {-1, 34.39, -1, 7., 4.29, 42}, // 42 was 88
-    {-1, 39.34, -1, 7., 3.75, 48}  // 48 was 100
+    {-1, 34.34, -1, 7., 4.29, 42}, // 42 was 88
+    {-1, 39.30, -1, 7., 3.75, 48}  // 48 was 100
   };
   const int nChipsPerModule = 7;  // For OB: how many chips in a row
   const double zChipGap = 0.01;   // For OB: gap in Z between chips

--- a/Detectors/ITSMFT/ITS/simulation/src/V3Layer.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/V3Layer.cxx
@@ -169,7 +169,7 @@ const Double_t V3Layer::sOBColdPlateZLenML = 87.55 * sCm;
 const Double_t V3Layer::sOBColdPlateZLenOL = 150.15 * sCm;
 const Double_t V3Layer::sOBColdPlateThick = 0.012 * sCm;
 const Double_t V3Layer::sOBHalfStaveYPos = 2.067 * sCm;
-const Double_t V3Layer::sOBHalfStaveYTrans = 1.76 * sMm;
+const Double_t V3Layer::sOBHalfStaveYTrans = 3.6 * sMm;
 const Double_t V3Layer::sOBHalfStaveXOverlap = 7.2 * sMm;
 const Double_t V3Layer::sOBGraphiteFoilThick = 30.0 * sMicron;
 const Double_t V3Layer::sOBCarbonFleeceThick = 20.0 * sMicron;
@@ -223,8 +223,8 @@ const Double_t V3Layer::sOBSFrameSideRibDiam = 1.25 * sMm;
 const Double_t V3Layer::sOBSFrameSideRibPhi = 70.0; // deg
 const Double_t V3Layer::sOBSFrameULegLen = 14.2 * sMm;
 const Double_t V3Layer::sOBSFrameULegWidth = 1.5 * sMm;
-const Double_t V3Layer::sOBSFrameULegHeight1 = 2.7 * sMm;
-const Double_t V3Layer::sOBSFrameULegHeight2 = 5.0 * sMm;
+const Double_t V3Layer::sOBSFrameULegHeight1 = 6.3 * sMm;
+const Double_t V3Layer::sOBSFrameULegHeight2 = 2.7 * sMm;
 const Double_t V3Layer::sOBSFrameULegThick = 0.3 * sMm;
 const Double_t V3Layer::sOBSFrameULegXPos = 12.9 * sMm;
 const Double_t V3Layer::sOBSFrameConnWidth = 42.0 * sMm;
@@ -522,7 +522,7 @@ TGeoVolume* V3Layer::createStave(const TGeoManager* /*mgr*/)
       if (mechStaveVol) {
         if (mBuildLevel < 6) { // Carbon
           staveVol->AddNode(mechStaveVol, 1,
-                            new TGeoCombiTrans(0, -sOBSFrameULegHeight1, 0, new TGeoRotation("", 180, 0, 0)));
+                            new TGeoCombiTrans(0, -sOBSFrameULegHeight2, 0, new TGeoRotation("", 180, 0, 0)));
         }
       }
     }


### PR DESCRIPTION
The relative separation of the two half staves in a OB stave was erroneously set to a smaller value than the actual one (1.76mm instead of 3.5mm). One of the two U-legs holding the two half staves to the stave structure was shorter than the real one (5.0mm instead of 6.3mm), and the right and left U-legs were swapped. All these errors are fixed with this PR.