### PR TITLE
Parallelise ITS noise calibration, use digits by default

### DIFF
--- a/Detectors/ITSMFT/ITS/calibration/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/calibration/CMakeLists.txt
@@ -12,6 +12,7 @@
 add_subdirectory(macros)
 
 o2_add_library(ITSCalibration
+               TARGETVARNAME targetName
                SOURCES src/NoiseCalibrator.cxx
                SOURCES src/NoiseSlotCalibrator.cxx
                SOURCES src/NoiseCalibratorSpec.cxx
@@ -26,9 +27,13 @@ o2_target_root_dictionary(ITSCalibration
                           HEADERS include/ITSCalibration/NoiseSlotCalibrator.h
                           LINKDEF src/ITSCalibrationLinkDef.h)
 
-o2_add_executable(its-calib-workflow
-                  COMPONENT_NAME calibration
-                  SOURCES testWorkflow/its-calib-workflow.cxx
+o2_add_executable(noise-calib-workflow
+                  COMPONENT_NAME its
+                  SOURCES testWorkflow/its-noise-calib-workflow.cxx
                   PUBLIC_LINK_LIBRARIES O2::Framework
                                         O2::ITSCalibration)
 
+if (OpenMP_CXX_FOUND)
+    target_compile_definitions(${targetName} PRIVATE WITH_OPENMP)
+    target_link_libraries(${targetName} PRIVATE OpenMP::OpenMP_CXX)
+endif()

--- a/Detectors/ITSMFT/ITS/calibration/include/ITSCalibration/NoiseCalibrator.h
+++ b/Detectors/ITSMFT/ITS/calibration/include/ITSCalibration/NoiseCalibrator.h
@@ -18,6 +18,7 @@
 
 #include "DataFormatsITSMFT/TopologyDictionary.h"
 #include "DataFormatsITSMFT/NoiseMap.h"
+#include "ITSMFTReconstruction/PixelData.h"
 #include "gsl/span"
 
 namespace o2
@@ -45,17 +46,27 @@ class NoiseCalibrator
 
   void setThreshold(unsigned int t) { mThreshold = t; }
 
-  bool processTimeFrame(gsl::span<const o2::itsmft::CompClusterExt> const& clusters,
-                        gsl::span<const unsigned char> const& patterns,
-                        gsl::span<const o2::itsmft::ROFRecord> const& rofs);
+  bool processTimeFrameClusters(gsl::span<const o2::itsmft::CompClusterExt> const& clusters,
+                                gsl::span<const unsigned char> const& patterns,
+                                gsl::span<const o2::itsmft::ROFRecord> const& rofs);
+
+  bool processTimeFrameDigits(gsl::span<const o2::itsmft::Digit> const& digits,
+                              gsl::span<const o2::itsmft::ROFRecord> const& rofs);
 
   void finalize();
+
+  void setNThreads(int n) { mNThreads = n > 0 ? n : 1; }
 
   void loadDictionary(std::string fname)
   {
     mDict.readFromFile(fname);
   }
   const o2::itsmft::NoiseMap& getNoiseMap() const { return mNoiseMap; }
+
+  void setInstanceID(size_t i) { mInstanceID = i; }
+  void setNInstances(size_t n) { mNInstances = n; }
+  auto getInstanceID() const { return mInstanceID; }
+  auto getNInstances() const { return mNInstances; }
 
  private:
   o2::itsmft::TopologyDictionary mDict;
@@ -64,6 +75,11 @@ class NoiseCalibrator
   unsigned int mThreshold = 100;
   unsigned int mNumberOfStrobes = 0;
   bool m1pix = true;
+  int mNThreads = 1;
+  size_t mInstanceID = 0; // pipeline instance
+  size_t mNInstances = 1; // total number of pipelines
+  std::vector<int> mChipIDs;
+  std::vector<std::vector<o2::itsmft::PixelData>> mChipHits;
 };
 
 } // namespace its

--- a/Detectors/ITSMFT/ITS/calibration/include/ITSCalibration/NoiseCalibratorSpec.h
+++ b/Detectors/ITSMFT/ITS/calibration/include/ITSCalibration/NoiseCalibratorSpec.h
@@ -15,7 +15,7 @@
 #define O2_ITS_NOISECALIBRATORSPEC
 
 #include <string>
-
+#include <TStopwatch.h>
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
 
@@ -39,7 +39,10 @@ namespace its
 class NoiseCalibratorSpec : public Task
 {
  public:
-  NoiseCalibratorSpec() = default;
+  NoiseCalibratorSpec(bool useClusters = false) : mUseClusters(useClusters)
+  {
+    mTimer.Stop();
+  }
   ~NoiseCalibratorSpec() override = default;
 
   void init(InitContext& ic) final;
@@ -49,11 +52,15 @@ class NoiseCalibratorSpec : public Task
  private:
   void sendOutput(DataAllocator& output);
   std::unique_ptr<CALIBRATOR> mCalibrator = nullptr;
+  size_t mDataSizeStat = 0;
+  size_t mNClustersProc = 0;
+  bool mUseClusters = false;
+  TStopwatch mTimer{};
 };
 
 /// create a processor spec
 /// run ITS noise calibration
-DataProcessorSpec getNoiseCalibratorSpec();
+DataProcessorSpec getNoiseCalibratorSpec(bool useClusters);
 
 } // namespace its
 } // namespace o2

--- a/Detectors/ITSMFT/ITS/calibration/macros/MakeNoiseMapFromClusters.C
+++ b/Detectors/ITSMFT/ITS/calibration/macros/MakeNoiseMapFromClusters.C
@@ -60,7 +60,7 @@ void MakeNoiseMapFromClusters(std::string input = "o2clus_its.root", bool only1p
   auto nevents = clusTree->GetEntries();
   for (int n = 0; n < nevents; n++) {
     clusTree->GetEntry(n);
-    calib.processTimeFrame(*clusters, *patternsPtr, *rofVec);
+    calib.processTimeFrameClusters(*clusters, *patternsPtr, *rofVec);
   }
   calib.finalize();
 

--- a/Detectors/ITSMFT/ITS/calibration/src/NoiseCalibrator.cxx
+++ b/Detectors/ITSMFT/ITS/calibration/src/NoiseCalibrator.cxx
@@ -18,22 +18,37 @@
 #include "DataFormatsITSMFT/ClusterPattern.h"
 #include "DataFormatsITSMFT/CompCluster.h"
 #include "DataFormatsITSMFT/ROFRecord.h"
+#ifdef WITH_OPENMP
+#include <omp.h>
+#endif
 
 namespace o2
 {
 namespace its
 {
-bool NoiseCalibrator::processTimeFrame(gsl::span<const o2::itsmft::CompClusterExt> const& clusters,
-                                       gsl::span<const unsigned char> const& patterns,
-                                       gsl::span<const o2::itsmft::ROFRecord> const& rofs)
+
+bool NoiseCalibrator::processTimeFrameClusters(gsl::span<const o2::itsmft::CompClusterExt> const& clusters,
+                                               gsl::span<const unsigned char> const& patterns,
+                                               gsl::span<const o2::itsmft::ROFRecord> const& rofs)
 {
   static int nTF = 0;
   LOG(info) << "Processing TF# " << nTF++;
-
+  // extract hits
   auto pattIt = patterns.begin();
   for (const auto& rof : rofs) {
+    mChipIDs.clear();
+    int chipID = -1;
+    std::vector<o2::itsmft::PixelData>* currChip = nullptr;
     auto clustersInFrame = rof.getROFData(clusters);
     for (const auto& c : clustersInFrame) {
+      if (chipID != c.getSensorID()) { // data is sorted over chip IDs
+        chipID = c.getSensorID();
+        if (mChipHits.size() < mChipIDs.size() + 1) {
+          mChipHits.resize(mChipIDs.size() + 1);
+        }
+        currChip = &mChipHits[mChipIDs.size()];
+        mChipIDs.push_back(chipID);
+      }
       auto pattID = c.getPatternID();
       o2::itsmft::ClusterPattern patt;
       auto row = c.getRow();
@@ -55,53 +70,84 @@ bool NoiseCalibrator::processTimeFrame(gsl::span<const o2::itsmft::CompClusterEx
       } else {
         patt = mDict.getPattern(pattID);
       }
-      auto id = c.getSensorID();
       auto colSpan = patt.getColumnSpan();
       auto rowSpan = patt.getRowSpan();
-
       // Fast 1-pixel calibration
       if ((rowSpan == 1) && (colSpan == 1)) {
-        mNoiseMap.increaseNoiseCount(id, row, col);
+        currChip->emplace_back(row, col);
         continue;
       }
       if (m1pix) {
         continue;
       }
-
-      // All-pixel calibration
-      auto nBits = rowSpan * colSpan;
-      int ic = 0, ir = 0;
-      for (unsigned int i = 2; i < patt.getUsedBytes() + 2; i++) {
-        unsigned char tempChar = patt.getByte(i);
-        int s = 128; // 0b10000000
-        while (s > 0) {
-          if ((tempChar & s) != 0) {
-            mNoiseMap.increaseNoiseCount(id, row + ir, col + ic);
+      for (int ir = 0; ir < rowSpan; ir++) {
+        for (int ic = 0; ic < colSpan; ic++) {
+          if (patt.isSet(ir, ic)) {
+            currChip->emplace_back(row + ir, col + ic);
           }
-          ic++;
-          s >>= 1;
-          if ((ir + 1) * ic == nBits) {
-            break;
-          }
-          if (ic == colSpan) {
-            ic = 0;
-            ir++;
-          }
-        }
-        if ((ir + 1) * ic == nBits) {
-          break;
         }
       }
     }
   }
+  // distribute hits over the map
+#ifdef WITH_OPENMP
+#pragma omp parallel for schedule(dynamic) num_threads(mNThreads)
+#endif
+  for (size_t ic = 0; ic < mChipIDs.size(); ic++) {
+    int chipID = mChipIDs[ic];
+    auto& hits = mChipHits[ic];
+    for (const auto& hit : hits) {
+      mNoiseMap.increaseNoiseCount(chipID, hit.getRowDirect(), hit.getCol());
+    }
+    hits.clear();
+  }
   mNumberOfStrobes += rofs.size();
-  return (mNumberOfStrobes * mProbabilityThreshold >= mThreshold) ? true : false;
+  return (mNumberOfStrobes * mProbabilityThreshold * mNInstances >= mThreshold) ? true : false;
+}
+
+bool NoiseCalibrator::processTimeFrameDigits(gsl::span<const o2::itsmft::Digit> const& digits,
+                                             gsl::span<const o2::itsmft::ROFRecord> const& rofs)
+{
+  static int nTF = 0;
+  LOG(info) << "Processing TF# " << nTF++;
+  for (const auto& rof : rofs) {
+    mChipIDs.clear();
+    int chipID = -1;
+    std::vector<o2::itsmft::PixelData>* currChip = nullptr;
+    auto digitsInFrame = rof.getROFData(digits);
+    for (const auto& dig : digitsInFrame) {
+      if (chipID != dig.getChipIndex()) { // data is sorted over chip IDs
+        chipID = dig.getChipIndex();
+        if (mChipHits.size() < mChipIDs.size() + 1) {
+          mChipHits.resize(mChipIDs.size() + 1);
+        }
+        currChip = &mChipHits[mChipIDs.size()];
+        mChipIDs.push_back(chipID);
+      }
+      currChip->emplace_back(dig.getRow(), dig.getColumn());
+    }
+  }
+  // distribute hits over the map
+#ifdef WITH_OPENMP
+#pragma omp parallel for schedule(dynamic) num_threads(mNThreads)
+#endif
+  for (size_t ic = 0; ic < mChipIDs.size(); ic++) {
+    int chipID = mChipIDs[ic];
+    auto& hits = mChipHits[ic];
+    for (const auto& hit : hits) {
+      mNoiseMap.increaseNoiseCount(chipID, hit.getRowDirect(), hit.getCol());
+    }
+    hits.clear();
+  }
+  mNumberOfStrobes += rofs.size();
+  return (mNumberOfStrobes * mProbabilityThreshold * mNInstances >= mThreshold) ? true : false;
 }
 
 void NoiseCalibrator::finalize()
 {
   LOG(info) << "Number of processed strobes is " << mNumberOfStrobes;
   mNoiseMap.applyProbThreshold(mProbabilityThreshold, mNumberOfStrobes);
+  mNoiseMap.print();
 }
 
 } // namespace its

--- a/Detectors/ITSMFT/ITS/calibration/src/NoiseCalibratorSpec.cxx
+++ b/Detectors/ITSMFT/ITS/calibration/src/NoiseCalibratorSpec.cxx
@@ -19,9 +19,10 @@
 #include "DataFormatsITSMFT/CompCluster.h"
 #include "DataFormatsITSMFT/ROFRecord.h"
 
-#include "FairLogger.h"
+#include "Framework/Logger.h"
 #include "Framework/ControlService.h"
 #include "Framework/ConfigParamRegistry.h"
+#include "Framework/DeviceSpec.h"
 #include "DetectorsCommonDataFormats/DetectorNameConf.h"
 
 using namespace o2::framework;
@@ -39,6 +40,8 @@ void NoiseCalibratorSpec::init(InitContext& ic)
   LOG(info) << "Setting the probability threshold to " << probT;
 
   mCalibrator = std::make_unique<CALIBRATOR>(onepix, probT);
+  mCalibrator->setNThreads(ic.options().get<int>("nthreads"));
+
   std::string dictPath = o2::itsmft::ClustererParam<o2::detectors::DetID::ITS>::Instance().dictFilePath;
   std::string dictFile = o2::base::DetectorNameConf::getAlpideClusterDictionaryFileName(o2::detectors::DetID::ITS, dictPath);
   if (o2::utils::Str::pathExists(dictFile)) {
@@ -52,15 +55,37 @@ void NoiseCalibratorSpec::init(InitContext& ic)
 
 void NoiseCalibratorSpec::run(ProcessingContext& pc)
 {
-  const auto compClusters = pc.inputs().get<gsl::span<o2::itsmft::CompClusterExt>>("compClusters");
-  gsl::span<const unsigned char> patterns = pc.inputs().get<gsl::span<unsigned char>>("patterns");
-  const auto rofs = pc.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("ROframes");
-
-  if (mCalibrator->processTimeFrame(compClusters, patterns, rofs)) {
+  mTimer.Start(false);
+  static bool firstCall = true;
+  if (firstCall) {
+    firstCall = false;
+    mCalibrator->setInstanceID(pc.services().get<const o2::framework::DeviceSpec>().inputTimesliceId);
+    mCalibrator->setNInstances(pc.services().get<const o2::framework::DeviceSpec>().maxInputTimeslices);
+  }
+  bool done = false;
+  if (mUseClusters) {
+    const auto compClusters = pc.inputs().get<gsl::span<o2::itsmft::CompClusterExt>>("compClusters");
+    gsl::span<const unsigned char> patterns = pc.inputs().get<gsl::span<unsigned char>>("patterns");
+    const auto rofs = pc.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("ROframes");
+    mNClustersProc += compClusters.size();
+    mDataSizeStat +=
+      rofs.size() * sizeof(o2::itsmft::ROFRecord) + patterns.size() +
+      compClusters.size() * sizeof(o2::itsmft::CompClusterExt);
+    done = mCalibrator->processTimeFrameClusters(compClusters, patterns, rofs);
+  } else {
+    const auto digits = pc.inputs().get<gsl::span<o2::itsmft::Digit>>("digits");
+    const auto rofs = pc.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("ROframes");
+    mNClustersProc += digits.size();
+    mDataSizeStat += digits.size() * sizeof(o2::itsmft::Digit) + rofs.size() * sizeof(o2::itsmft::ROFRecord);
+    done = mCalibrator->processTimeFrameDigits(digits, rofs);
+  }
+  if (done) {
     LOG(info) << "Minimum number of noise counts has been reached !";
     sendOutput(pc.outputs());
     pc.services().get<ControlService>().readyToQuit(QuitRequest::All);
   }
+
+  mTimer.Stop();
 }
 
 void NoiseCalibratorSpec::sendOutput(DataAllocator& output)
@@ -82,10 +107,13 @@ void NoiseCalibratorSpec::sendOutput(DataAllocator& output)
             << " bytes, valid for " << info.getStartValidityTimestamp()
             << " : " << info.getEndValidityTimestamp();
 
-  using clbUtils = o2::calibration::Utils;
   output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "ITS_NOISE", 0}, *image.get());
   output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "ITS_NOISE", 0}, info);
   LOG(info) << "sending done";
+  LOGP(info, "Timing: {:.2f} CPU / {:.2f} Real s. in {} TFs for {} {} / {:.2f} GB",
+       mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1,
+       mUseClusters ? "clusters" : "digits",
+       mNClustersProc, double(mDataSizeStat) / (1024L * 1024L * 1024L));
 }
 
 void NoiseCalibratorSpec::endOfStream(o2::framework::EndOfStreamContext& ec)
@@ -93,14 +121,18 @@ void NoiseCalibratorSpec::endOfStream(o2::framework::EndOfStreamContext& ec)
   sendOutput(ec.outputs());
 }
 
-DataProcessorSpec getNoiseCalibratorSpec()
+DataProcessorSpec getNoiseCalibratorSpec(bool useClusters)
 {
   std::vector<InputSpec> inputs;
-  inputs.emplace_back("compClusters", "ITS", "COMPCLUSTERS", 0, Lifetime::Timeframe);
-  inputs.emplace_back("patterns", "ITS", "PATTERNS", 0, Lifetime::Timeframe);
-  inputs.emplace_back("ROframes", "ITS", "CLUSTERSROF", 0, Lifetime::Timeframe);
+  if (useClusters) {
+    inputs.emplace_back("compClusters", "ITS", "COMPCLUSTERS", 0, Lifetime::Timeframe);
+    inputs.emplace_back("patterns", "ITS", "PATTERNS", 0, Lifetime::Timeframe);
+    inputs.emplace_back("ROframes", "ITS", "CLUSTERSROF", 0, Lifetime::Timeframe);
+  } else {
+    inputs.emplace_back("digits", "ITS", "DIGITS", 0, Lifetime::Timeframe);
+    inputs.emplace_back("ROframes", "ITS", "DIGITSROF", 0, Lifetime::Timeframe);
+  }
 
-  using clbUtils = o2::calibration::Utils;
   std::vector<OutputSpec> outputs;
   outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "ITS_NOISE"}, Lifetime::Sporadic);
   outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "ITS_NOISE"}, Lifetime::Sporadic);
@@ -109,10 +141,11 @@ DataProcessorSpec getNoiseCalibratorSpec()
     "its-noise-calibrator",
     inputs,
     outputs,
-    AlgorithmSpec{adaptFromTask<NoiseCalibratorSpec>()},
+    AlgorithmSpec{adaptFromTask<NoiseCalibratorSpec>(useClusters)},
     Options{
-      {"1pix-only", VariantType::Bool, false, {"Fast 1-pixel calibration only"}},
-      {"prob-threshold", VariantType::Float, 3.e-6f, {"Probability threshold for noisy pixels"}}}};
+      {"1pix-only", VariantType::Bool, false, {"Fast 1-pixel calibration only (cluster input only)"}},
+      {"prob-threshold", VariantType::Float, 3.e-6f, {"Probability threshold for noisy pixels"}},
+      {"nthreads", VariantType::Int, 1, {"Number of map-filling threads"}}}};
 }
 
 } // namespace its

--- a/Detectors/ITSMFT/ITS/calibration/testWorkflow/README.md
+++ b/Detectors/ITSMFT/ITS/calibration/testWorkflow/README.md
@@ -4,13 +4,13 @@
 
 # ITS calibration workflows
 
-## Generation of fixed-pattern noise maps out of pass1 clusters:
+## Generation of fixed-pattern noise maps out of clusters:
 
 This will read clusters from a ROOT file and write a noise map to a local CCDB running on port 8080:
 
 ```shell
 o2-its-cluster-reader-workflow -b | \
-o2-calibration-its-calib-workflow -b | \
+o2-its-noise-calib-workflow --use-clusters --nthreads 5 -b | \
 o2-calibration-ccdb-populator-workflow --ccdb-path="http://localhost:8080" -b
 ```
 The same as above, but starting from raw data, could be done like this:
@@ -18,6 +18,15 @@ The same as above, but starting from raw data, could be done like this:
 ```shell
 o2-raw-file-reader-workflow --detect-tf0 --input-conf run.cfg --delay 0.1 | \
 o2-itsmft-stf-decoder-workflow -b --nthreads 4 --shm-segment-size 16000000000 | \
-o2-calibration-its-calib-workflow -b | \
+o2-its-noise-calib-workflow --use-clusters --nthreads 5 -b | \
+o2-calibration-ccdb-populator-workflow --ccdb-path="http://localhost:8080" -b
+```
+
+It is faster to produce noise masks directly from digits:
+
+```shell
+o2-raw-file-reader-workflow --detect-tf0 --input-conf run.cfg --delay 0.1 | \
+o2-itsmft-stf-decoder-workflow -b --nthreads 4 --no-clusters --digits --shm-segment-size 16000000000 | \
+o2-its-noise-calib-workflow --nthreads 5 -b | \
 o2-calibration-ccdb-populator-workflow --ccdb-path="http://localhost:8080" -b
 ```

--- a/Detectors/ITSMFT/ITS/calibration/testWorkflow/its-noise-calib-workflow.cxx
+++ b/Detectors/ITSMFT/ITS/calibration/testWorkflow/its-noise-calib-workflow.cxx
@@ -18,18 +18,8 @@ using namespace o2::framework;
 void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
   // option allowing to set parameters
-  workflowOptions.push_back(
-    ConfigParamSpec{
-      "doNoise",
-      VariantType::Bool,
-      true,
-      {"Generate noisy-pixel maps"}});
-  workflowOptions.push_back(
-    ConfigParamSpec{
-      "configKeyValues",
-      VariantType::String,
-      "",
-      {"Semicolon separated key=value strings"}});
+  workflowOptions.push_back(ConfigParamSpec{"use-clusters", VariantType::Bool, false, {"Use clusters instead of digits"}});
+  workflowOptions.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}});
 }
 
 // ------------------------------------------------------------------
@@ -42,14 +32,6 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 {
   WorkflowSpec specs;
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
-  auto doNoise = configcontext.options().get<bool>("doNoise");
-
-  LOG(info) << "ITS calibration workflow options";
-  LOG(info) << "Generate noisy-pixel maps: " << doNoise;
-
-  if (doNoise) {
-    specs.emplace_back(o2::its::getNoiseCalibratorSpec());
-  }
-
+  specs.emplace_back(o2::its::getNoiseCalibratorSpec(configcontext.options().get<bool>("use-clusters")));
   return specs;
 }


### PR DESCRIPTION
Also, the calibration workflow is renamed to o2-its-noise-calib-workflow