### PR TITLE
CCDB fetcher remapping to different hosts or local files

### DIFF
--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -76,6 +76,12 @@ class CcdbApi //: public DatabaseInterface
   std::string const& getURL() const { return mUrl; }
 
   /**
+   * Check if we are in a snapshot mode
+   *
+   */
+  bool isSnapshotMode() const { return mInSnapshotMode; }
+
+  /**
    * Create a binary image of the arbitrary type object, if CcdbObjectInfo pointer is provided, register there
    *
    * the assigned object class name and the filename

--- a/Framework/Core/src/CCDBHelpers.cxx
+++ b/Framework/Core/src/CCDBHelpers.cxx
@@ -44,11 +44,15 @@ struct CCDBFetcherHelper {
   std::unordered_map<std::string, DataAllocator::CacheId> mapURL2DPLCache;
   std::string createdNotBefore = "0";
   std::string createdNotAfter = "3385078236000";
-
-  o2::ccdb::CcdbApi api;
+  std::unordered_map<std::string, o2::ccdb::CcdbApi> apis;
   std::vector<OutputRoute> routes;
   std::map<int64_t, CCDBCacheInfo> cache;
   std::unordered_map<std::string, std::string> remappings;
+  o2::ccdb::CcdbApi& getAPI(const std::string& path)
+  {
+    auto entry = remappings.find(path);
+    return apis[entry == remappings.end() ? "" : entry->second];
+  }
 };
 
 bool isPrefix(std::string_view prefix, std::string_view full)
@@ -79,8 +83,8 @@ CCDBHelpers::ParserResult CCDBHelpers::parseRemappings(char const* str)
         state = IN_BEGIN_URL;
       }
       case IN_BEGIN_URL: {
-        if (*str != '/' && (strncmp("http://", str, 6) != 0) && (strncmp("https://", str, 7) != 0)) {
-          return {remappings, "URL should start with either / or http:// / https://"};
+        if ((strncmp("http://", str, 7) != 0) && (strncmp("https://", str, 8) != 0 && (strncmp("file://", str, 7) != 0))) {
+          return {remappings, "URL should start with either http:// or https:// or file://"};
         }
         state = IN_END_URL;
       } break;
@@ -136,16 +140,25 @@ AlgorithmSpec CCDBHelpers::fetchFromCCDB()
       std::shared_ptr<CCDBFetcherHelper> helper = std::make_shared<CCDBFetcherHelper>();
       auto backend = options.get<std::string>("condition-backend");
       LOGP(info, "CCDB Backend at: {}", backend);
-      helper->api.init(options.get<std::string>("condition-backend"));
-      helper->createdNotBefore = std::to_string(options.get<int64_t>("condition-not-before"));
-      helper->createdNotAfter = std::to_string(options.get<int64_t>("condition-not-after"));
+      const auto& defHost = options.get<std::string>("condition-backend");
       auto remapString = options.get<std::string>("condition-remap");
       ParserResult result = CCDBHelpers::parseRemappings(remapString.c_str());
       if (!result.error.empty()) {
         throw runtime_error_f("Error while parsing remapping string %s", result.error.c_str());
       }
-
       helper->remappings = result.remappings;
+      helper->apis[""].init(defHost); // default backend
+      LOGP(info, "Initialised default CCDB host {}", defHost);
+      //
+      for (auto& entry : helper->remappings) { // init api instances for every host seen in the remapping
+        if (helper->apis.find(entry.second) == helper->apis.end()) {
+          helper->apis[entry.second].init(entry.second);
+          LOGP(info, "Initialised custom CCDB host {}", entry.second);
+        }
+        LOGP(info, "{} is remapped to {}", entry.first, entry.second);
+      }
+      helper->createdNotBefore = std::to_string(options.get<int64_t>("condition-not-before"));
+      helper->createdNotAfter = std::to_string(options.get<int64_t>("condition-not-after"));
 
       for (auto &route : spec.outputs) {
         if (route.matcher.lifetime != Lifetime::Condition) {
@@ -194,41 +207,41 @@ AlgorithmSpec CCDBHelpers::fetchFromCCDB()
             etag = url2uuid->second;
           }
           Output output{"CTP", "OrbitReset", 0, Lifetime::Condition};
-          auto&& v = allocator.makeVector<char>(output);
-          helper->api.loadFileToMemory(v, path, metadata, timingInfo.creation,
-                                       &headers, etag,
-                                       helper->createdNotAfter,
-                                       helper->createdNotBefore);
-
-          if ((headers.count("Error") != 0) || (etag.empty() && v.empty())) {
-            LOGP(error, "Unable to find object {}/{}", path, timingInfo.creation);
-            //FIXME: I should send a dummy message.
-            return;
-          }
           Long64_t newOrbitResetTime = orbitResetTime;
-          if (etag.empty()) {
-            helper->mapURL2UUID[path] = headers["ETag"]; // update uuid
-            newOrbitResetTime = getOrbitResetTime(v);
-            auto cacheId = allocator.adoptContainer(output, std::move(v), true, header::gSerializationMethodNone);
-            helper->mapURL2DPLCache[path] = cacheId;
-            LOGP(debug, "Caching {} for {} (DPL id {})", path, headers["ETag"], cacheId.value);
-          } else if (v.size()) { // but should be overridden by fresh object
-            // somewhere here pruneFromCache should be called
-            helper->mapURL2UUID[path] = headers["ETag"]; // update uuid
-            newOrbitResetTime = getOrbitResetTime(v);
-            auto cacheId = allocator.adoptContainer(output, std::move(v), true, header::gSerializationMethodNone);
-            helper->mapURL2DPLCache[path] = cacheId;
-            LOGP(debug, "Caching {} for {} (DPL id {})", path, headers["ETag"], cacheId.value);
-            // one could modify the    adoptContainer to take optional old cacheID to clean:
-            // mapURL2DPLCache[URL] = ctx.outputs().adoptContainer(output, std::move(outputBuffer), true, mapURL2DPLCache[URL]);
-          } else { // cached object is fine
-            auto cacheId = helper->mapURL2DPLCache[path];
-            LOGP(debug, "Reusing {} for {}", cacheId.value, path);
-            allocator.adoptFromCache(output, cacheId, header::gSerializationMethodNone);
-            // We need to find a way to get "v" also in this case.
-            // orbitResetTime = getOrbitResetTime(v);
-            // the outputBuffer was not used, can we destroy it?
+          auto&& v = allocator.makeVector<char>(output);
+          const auto& api = helper->getAPI(path);
+          if (!api.isSnapshotMode() || etag.empty()) { // in the snapshot mode the object needs to be fetched only once
+            api.loadFileToMemory(v, path, metadata, timingInfo.creation, &headers, etag, helper->createdNotAfter, helper->createdNotBefore);
+            if ((headers.count("Error") != 0) || (etag.empty() && v.empty())) {
+              LOGP(error, "Unable to find object {}/{}", path, timingInfo.creation);
+              // FIXME: I should send a dummy message.
+              return;
+            }
+            if (etag.empty()) {
+              helper->mapURL2UUID[path] = headers["ETag"]; // update uuid
+              newOrbitResetTime = getOrbitResetTime(v);
+              auto cacheId = allocator.adoptContainer(output, std::move(v), true, header::gSerializationMethodNone);
+              helper->mapURL2DPLCache[path] = cacheId;
+              LOGP(debug, "Caching {} for {} (DPL id {})", path, headers["ETag"], cacheId.value);
+            } else if (v.size()) { // but should be overridden by fresh object
+              // somewhere here pruneFromCache should be called
+              helper->mapURL2UUID[path] = headers["ETag"]; // update uuid
+              newOrbitResetTime = getOrbitResetTime(v);
+              auto cacheId = allocator.adoptContainer(output, std::move(v), true, header::gSerializationMethodNone);
+              helper->mapURL2DPLCache[path] = cacheId;
+              LOGP(debug, "Caching {} for {} (DPL id {})", path, headers["ETag"], cacheId.value);
+              // one could modify the adoptContainer to take optional old cacheID to clean:
+              // mapURL2DPLCache[URL] = ctx.outputs().adoptContainer(output, std::move(outputBuffer), true, mapURL2DPLCache[URL]);
+            }
+            // cached object is fine
           }
+          auto cacheId = helper->mapURL2DPLCache[path];
+          LOGP(debug, "Reusing {} for {}", cacheId.value, path);
+          allocator.adoptFromCache(output, cacheId, header::gSerializationMethodNone);
+          // We need to find a way to get "v" also in this case.
+          // orbitResetTime = getOrbitResetTime(v);
+          // the outputBuffer was not used, can we destroy it?
+
           if (newOrbitResetTime != orbitResetTime) {
             LOGP(info, "Orbit reset time now at {} (was {})",
                  newOrbitResetTime, orbitResetTime);
@@ -256,13 +269,6 @@ AlgorithmSpec CCDBHelpers::fetchFromCCDB()
           for (auto& meta : route.matcher.metadata) {
             if (meta.name == "ccdb-path") {
               path = meta.defaultValue.get<std::string>();
-              auto prefix = helper->remappings.find(path);
-              // FIXME: for now assume that we can pass the whole URL to
-              // the CCDB API. It might be better to have multiple instances...
-              if (prefix != helper->remappings.end()) {
-                LOGP(error, "Remapping {} to {}", path, prefix->second + path);
-                path = prefix->second + path;
-              }
             } else if (meta.name == "ccdb-run-dependent") {
               metadata["runNumber"] = dtc.runNumber;
             } else if (isPrefix(ccdbMetadataPrefix, meta.name)) {
@@ -276,29 +282,31 @@ AlgorithmSpec CCDBHelpers::fetchFromCCDB()
           if (url2uuid != helper->mapURL2UUID.end()) {
             etag = url2uuid->second;
           }
-
-          helper->api.loadFileToMemory(v, path, metadata, timestamp, &headers, etag, helper->createdNotAfter, helper->createdNotBefore);
-          if ((headers.count("Error") != 0) || (etag.empty() && v.empty())) {
-            LOGP(debug, "Unable to find object {}/{}", path, timingInfo.timeslice);
-            //FIXME: I should send a dummy message.
-            continue;
-          }
-          if (etag.empty()) {
-            helper->mapURL2UUID[path] = headers["ETag"]; // update uuid
-            auto cacheId = allocator.adoptContainer(output, std::move(v), true, header::gSerializationMethodCCDB);
-            helper->mapURL2DPLCache[path] = cacheId;
-            LOGP(debug, "Caching {} for {} (DPL id {})", path, headers["ETag"], cacheId.value);
-            continue;
-          }
-          if (v.size()) { // but should be overridden by fresh object
-            // somewhere here pruneFromCache should be called
-            helper->mapURL2UUID[path] = headers["ETag"]; // update uuid
-            auto cacheId = allocator.adoptContainer(output, std::move(v), true, header::gSerializationMethodCCDB);
-            helper->mapURL2DPLCache[path] = cacheId;
-            LOGP(info, "Caching {} for {} (DPL id {})", path, headers["ETag"], cacheId.value);
-            // one could modify the    adoptContainer to take optional old cacheID to clean:
-            // mapURL2DPLCache[URL] = ctx.outputs().adoptContainer(output, std::move(outputBuffer), true, mapURL2DPLCache[URL]);
-          } else { // cached object is fine
+          const auto& api = helper->getAPI(path);
+          if (!api.isSnapshotMode() || etag.empty()) { // in the snapshot mode the object needs to be fetched only once
+            api.loadFileToMemory(v, path, metadata, timestamp, &headers, etag, helper->createdNotAfter, helper->createdNotBefore);
+            if ((headers.count("Error") != 0) || (etag.empty() && v.empty())) {
+              LOGP(debug, "Unable to find object {}/{}", path, timingInfo.timeslice);
+              // FIXME: I should send a dummy message.
+              continue;
+            }
+            if (etag.empty()) {
+              helper->mapURL2UUID[path] = headers["ETag"]; // update uuid
+              auto cacheId = allocator.adoptContainer(output, std::move(v), true, header::gSerializationMethodCCDB);
+              helper->mapURL2DPLCache[path] = cacheId;
+              LOGP(debug, "Caching {} for {} (DPL id {})", path, headers["ETag"], cacheId.value);
+              continue;
+            }
+            if (v.size()) { // but should be overridden by fresh object
+              // somewhere here pruneFromCache should be called
+              helper->mapURL2UUID[path] = headers["ETag"]; // update uuid
+              auto cacheId = allocator.adoptContainer(output, std::move(v), true, header::gSerializationMethodCCDB);
+              helper->mapURL2DPLCache[path] = cacheId;
+              LOGP(info, "Caching {} for {} (DPL id {})", path, headers["ETag"], cacheId.value);
+              // one could modify the    adoptContainer to take optional old cacheID to clean:
+              // mapURL2DPLCache[URL] = ctx.outputs().adoptContainer(output, std::move(outputBuffer), true, mapURL2DPLCache[URL]);
+            }
+            // cached object is fine
             auto cacheId = helper->mapURL2DPLCache[path];
             LOGP(info, "Reusing {} for {}", cacheId.value, path);
             allocator.adoptFromCache(output, cacheId, header::gSerializationMethodCCDB);

--- a/Framework/Core/test/test_CCDBHelpers.cxx
+++ b/Framework/Core/test/test_CCDBHelpers.cxx
@@ -24,7 +24,7 @@ BOOST_AUTO_TEST_CASE(TestSorting)
   BOOST_CHECK_EQUAL(result.error, ""); // not an error
 
   result = CCDBHelpers::parseRemappings("https");
-  BOOST_CHECK_EQUAL(result.error, "URL should start with either / or http:// / https://");
+  BOOST_CHECK_EQUAL(result.error, "URL should start with either http:// or https:// or file://");
 
   result = CCDBHelpers::parseRemappings("https://alice.cern.ch:8000");
   BOOST_CHECK_EQUAL(result.error, "Expecting at least one target path, missing `='?");
@@ -36,16 +36,16 @@ BOOST_AUTO_TEST_CASE(TestSorting)
   BOOST_CHECK_EQUAL(result.error, "Empty target");
 
   result = CCDBHelpers::parseRemappings("https://alice.cern.ch:8000=/foo/bar,/foo/bar;");
-  BOOST_CHECK_EQUAL(result.error, "URL should start with either / or http:// / https://");
+  BOOST_CHECK_EQUAL(result.error, "URL should start with either http:// or https:// or file://");
 
-  result = CCDBHelpers::parseRemappings("https://alice.cern.ch:8000=/foo/bar,/foo/barbar;/user/test=/foo/barr");
+  result = CCDBHelpers::parseRemappings("https://alice.cern.ch:8000=/foo/bar,/foo/barbar;file://user/test=/foo/barr");
   BOOST_CHECK_EQUAL(result.error, "");
   BOOST_CHECK_EQUAL(result.remappings.size(), 3);
   BOOST_CHECK_EQUAL(result.remappings["/foo/bar"], "https://alice.cern.ch:8000");
   BOOST_CHECK_EQUAL(result.remappings["/foo/barbar"], "https://alice.cern.ch:8000");
-  BOOST_CHECK_EQUAL(result.remappings["/foo/barr"], "/user/test");
+  BOOST_CHECK_EQUAL(result.remappings["/foo/barr"], "file://user/test");
 
-  result = CCDBHelpers::parseRemappings("https://alice.cern.ch:8000=/foo/bar;/user/test=/foo/bar");
+  result = CCDBHelpers::parseRemappings("https://alice.cern.ch:8000=/foo/bar;file://user/test=/foo/bar");
   BOOST_CHECK_EQUAL(result.remappings.size(), 1);
   BOOST_CHECK_EQUAL(result.error, "Path /foo/bar requested more than once.");
 }


### PR DESCRIPTION
Allows remapping certain conditions to different hosts or local directories, e.g.
```
 --condition-remap “http://alice-ccdb.cern.ch/user/username:TOF/Calib/LHCPhace,TOF/Calib/Diagnostics;\
http://ccdb-test.cern.ch:8080:ITS/Calib/Align;\
file:///<localDirectory>:GLO/Config/GRPECS” 
```