### PR TITLE
[O2-2748] Enable Compiler Warnings

### DIFF
--- a/dependencies/O2CompileFlags.cmake
+++ b/dependencies/O2CompileFlags.cmake
@@ -11,6 +11,64 @@
 
 include_guard()
 
+#
+# o2_build_warning_flags() builds a list of warning flags from their names.
+#
+set(O2_ENABLE_WARNINGS "OFF")
+if(DEFINED ENV{ALIBUILD_O2_WARNINGS})
+  set(O2_ENABLE_WARNINGS "ON")
+endif()
+
+function(o2_build_warning_flags)
+  cmake_parse_arguments(PARSE_ARGV 0 A "" "PREFIX;OUTPUTVARNAME" "WARNINGS")
+
+  if(A_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "Unexpected unparsed arguments: ${A_UNPARSED_ARGUMENTS}")
+  endif()
+
+  list(TRANSFORM A_WARNINGS STRIP)
+  list(TRANSFORM A_WARNINGS PREPEND ${A_PREFIX})
+  string(JOIN " " OUTPUT ${A_WARNINGS})
+  set(${A_OUTPUTVARNAME} ${OUTPUT} PARENT_SCOPE)
+
+endfunction()
+
+set(O2_C_WARNINGS "pointer-sign;override-init")
+set(O2_CXX_WARNINGS "catch-value;pessimizing-move;reorder;delete-non-virtual-dtor;deprecated-copy;redundant-move")
+set(O2_COMMON_WARNINGS "overloaded-virtual;address;bool-compare;bool-operation;\
+char-subscripts;comment;enum-compare;format;format-overflow;\
+format-truncation;int-in-bool-context;init-self;logical-not-parentheses;maybe-uninitialized;memset-elt-size;\
+memset-transposed-args;misleading-indentation;missing-attributes;\
+multistatement-macros;narrowing;nonnull;nonnull-compare;openmp-simd;parentheses;\
+restrict;return-type;sequence-point;sign-compare;sizeof-pointer-div;\
+sizeof-pointer-memaccess;strict-aliasing;strict-overflow;switch;tautological-compare;trigraphs;uninitialized;\
+unused-label;unused-value;unused-variable;volatile-register-var;zero-length-bounds;\
+unused-but-set-variable;stringop-truncation;clobbered;cast-function-type;\
+empty-body;ignored-qualifiers;implicit-fallthrough;missing-field-initializers;sign-compare;\
+string-compare;type-limits;uninitialized;shift-negative-value")
+
+
+if(O2_ENABLE_WARNINGS)
+
+o2_build_warning_flags(PREFIX "-W"
+              OUTPUTVARNAME O2_C_ENABLED_WARNINGS 
+              WARNINGS ${O2_COMMON_WARNINGS} ${O2_C_WARNINGS} "array-bounds=1")
+o2_build_warning_flags(PREFIX "-Wno-error="
+              OUTPUTVARNAME O2_C_ENABLED_WARNINGS_NO_ERROR 
+              WARNINGS ${O2_COMMON_WARNINGS} ${O2_C_WARNINGS} "array-bounds")
+o2_build_warning_flags(PREFIX "-W"
+              OUTPUTVARNAME O2_CXX_ENABLED_WARNINGS 
+              WARNINGS ${O2_COMMON_WARNINGS} ${O2_CXX_WARNINGS} "array-bounds=1")
+o2_build_warning_flags(PREFIX "-Wno-error="
+              OUTPUTVARNAME O2_CXX_ENABLED_WARNINGS_NO_ERROR 
+              WARNINGS ${O2_COMMON_WARNINGS} ${O2_CXX_WARNINGS} "array-bounds")
+else()
+ message(STATUS "Building without compiler warnings enabled.")
+endif()
+
+string(JOIN " " CMAKE_C_WARNINGS "-Wno-unknown-warning-option" ${O2_C_ENABLED_WARNINGS} ${O2_C_ENABLED_WARNINGS_NO_ERROR})
+string(JOIN " " CMAKE_CXX_WARNINGS "-Wno-unknown-warning-option" ${O2_CXX_ENABLED_WARNINGS} ${O2_CXX_ENABLED_WARNINGS_NO_ERROR})
+
 set(CMAKE_CXX_FLAGS_COVERAGE "-g -O2 -fprofile-arcs -ftest-coverage")
 set(CMAKE_C_FLAGS_COVERAGE "${CMAKE_CXX_FLAGS_COVERAGE}")
 set(CMAKE_Fortran_FLAGS_COVERAGE "-g -O2 -fprofile-arcs -ftest-coverage")
@@ -29,22 +87,22 @@ IF (NOT CMAKE_BUILD_TYPE)
 ENDIF (NOT CMAKE_BUILD_TYPE)
 
 IF(ENABLE_CASSERT) #For the CI, we want to have <cassert> assertions enabled
-    set(CMAKE_CXX_FLAGS_RELEASE "-O2")
-    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g")
+    set(CMAKE_CXX_FLAGS_RELEASE "-O2 ${CMAKE_CXX_WARNINGS}")
+    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g ${CMAKE_CXX_WARNINGS}")
 ELSE()
-    set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
-    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -DNDEBUG")
+    set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG ${CMAKE_CXX_WARNINGS}")
+    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -DNDEBUG ${CMAKE_CXX_WARNINGS}")
     if (CMAKE_BUILD_TYPE STREQUAL "RELEASE" OR CMAKE_BUILD_TYPE STREQUAL "RELWITHDEBINFO")
       set(FAIR_MIN_SEVERITY "info")
     endif()
 ENDIF()
-set(CMAKE_C_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
+set(CMAKE_C_FLAGS_RELEASE "-O2 ${CMAKE_C_WARNINGS}")
 set(CMAKE_Fortran_FLAGS_RELEASE "-O2")
-set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O2 -g ${CMAKE_C_WARNINGS}")
 set(CMAKE_Fortran_FLAGS_RELWITHDEBINFO "-O2 -g")
 # make sure Debug build not optimized (does not seem to work without CACHE + FORCE)
-set(CMAKE_CXX_FLAGS_DEBUG "-g -O0" CACHE STRING "Debug mode build flags" FORCE)
-set(CMAKE_C_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}" CACHE STRING "Debug mode build flags" FORCE)
+set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 ${CMAKE_CXX_WARNINGS}" CACHE STRING "Debug mode build flags" FORCE)
+set(CMAKE_C_FLAGS_DEBUG "-g -O0 ${CMAKE_C_WARNINGS}" CACHE STRING "Debug mode build flags" FORCE)
 set(CMAKE_Fortran_FLAGS_DEBUG "-g -O0" CACHE STRING "Debug mode build flags" FORCE)
 
 if(APPLE)

--- a/scripts/filter-warnings.sh
+++ b/scripts/filter-warnings.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+o2Warnings=(
+'pointer-sign'
+'override-init'
+'catch-value'
+'pessimizing-move'
+'reorder'
+'delete-non-virtual-dtor'
+'deprecated-copy'
+'redundant-move'
+'overloaded-virtual'
+'address'
+'bool-compare'
+'bool-operation'
+'char-subscripts'
+'comment'
+'enum-compare'
+'format'
+'format-overflow'
+'format-truncation'
+'int-in-bool-context'
+'init-self'
+'logical-not-parentheses'
+'maybe-uninitialized'
+'memset-elt-size'
+'memset-transposed-args'
+'misleading-indentation'
+'missing-attributes'
+'multistatement-macros'
+'narrowing'
+'nonnull'
+'nonnull-compare'
+'openmp-simd'
+'parentheses'
+'restrict'
+'return-type'
+'sequence-point'
+'sign-compare'
+'sizeof-pointer-div'
+'sizeof-pointer-memaccess'
+'strict-aliasing'
+'strict-overflow'
+'switch'
+'tautological-compare'
+'trigraphs'
+'uninitialized'
+'unused-label'
+'unused-value'
+'unused-variable'
+'volatile-register-var'
+'zero-length-bounds'
+'unused-but-set-variable'
+'stringop-truncation'
+'clobbered'
+'cast-function-type'
+'empty-body'
+'ignored-qualifiers'
+'implicit-fallthrough'
+'missing-field-initializers'
+'sign-compare'
+'string-compare'
+'type-limits'
+'uninitialized'
+'shift-negative-value'
+	)
+
+logFile=${1}
+warningsFile="$(dirname "${logFile}" )/warnings"
+
+grep "warning:" ${logFile} | sort | uniq > ${warningsFile}
+
+nTotalWarnings="$(cat ${warningsFile} | grep -c "warning:")"
+
+printf "Total warnings: ${nTotalWarnings}\n" 
+printf "##################################\n"
+for warning in ${o2Warnings[@]}; do
+	nWarnings=$(cat ${warningsFile} | grep -c "${warning}")
+	printf '%-30s:\t%6s\t%8s\n' "${warning}" "${nWarnings}" "$(python3 -c "print(\"{:>.1%} \".format(${nWarnings} / ${nTotalWarnings}))")"
+done


### PR DESCRIPTION
Enable most warnings in `- Wall` and `-Wextra` in O2, but make sure they don't lead to compile errors even if `-Werror` is enabled. 

DO NOT MERGE - this tests the different behaviors on clang and GCC.