### PR TITLE
Fix TRD tracking in standalone version for TFs

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/HelperMethods.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/HelperMethods.h
@@ -138,7 +138,6 @@ struct HelperMethods {
     int detector = hcid / 2;
     int supermodule = hcid / 60;
     int chamberside = hcid % 2; // 0 for side 0, 1 for side 1;
-    int ori = -1;
     // now offset for supermodule (+60*supermodule);
     return HelperMethods::getORIinSuperModule(detector, chamberside) + 60 * supermodule; // it takes readoutboard but only cares if its odd or even hence side here.
   }

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Hit.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Hit.h
@@ -25,7 +25,7 @@ class Hit : public o2::BasicXYZQHit<float>
  public:
   using BasicXYZQHit<float>::BasicXYZQHit;
   Hit(float x, float y, float z, float lCol, float lRow, float lTime, float tof, int charge, int trackId, int detId, bool drift)
-    : mInDrift(drift), locC(lCol), locR(lRow), locT(lTime), BasicXYZQHit(x, y, z, tof, charge, trackId, detId){};
+    : BasicXYZQHit(x, y, z, tof, charge, trackId, detId), mInDrift(drift), locC(lCol), locR(lRow), locT(lTime){};
   bool isFromDriftRegion() const { return mInDrift; }
   void setLocalC(float lCol) { locC = lCol; }
   void setLocalR(float lRow) { locR = lRow; }

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/LinkRecord.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/LinkRecord.h
@@ -50,12 +50,12 @@ class LinkRecord
   void setSide(const int side) { mLinkId |= ((side << sidebs) & sidemask); }
   void setSpare(const int spare = 0) { mLinkId |= ((spare << sparebs) & sparemask); }
 
-  const uint32_t getLinkId() { return mLinkId; }
+  uint32_t getLinkId() const { return mLinkId; }
   //TODO come backwith a ccdb lookup.  const uint32_t getLinkHCID() { return mLinkId & 0x7ff; } // the last 11 bits.
-  const uint32_t getSector() { return (mLinkId & supermodulemask) >> supermodulebs; }
-  const uint32_t getStack() { return (mLinkId & stackmask) >> stackbs; }
-  const uint32_t getLayer() { return (mLinkId & layermask) >> layerbs; }
-  const uint32_t getSide() { return (mLinkId & sidemask) >> sidebs; }
+  uint32_t getSector() const { return (mLinkId & supermodulemask) >> supermodulebs; }
+  uint32_t getStack() const { return (mLinkId & stackmask) >> stackbs; }
+  uint32_t getLayer() const { return (mLinkId & layermask) >> layerbs; }
+  uint32_t getSide() const { return (mLinkId & sidemask) >> sidebs; }
   int getNumberOfObjects() const { return mDataRange.getEntries(); }
   int getFirstEntry() const { return mDataRange.getFirstEntry(); }
   static uint32_t getHalfChamberLinkId(uint32_t detector, uint32_t rob);

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/TriggerRecord.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/TriggerRecord.h
@@ -33,7 +33,7 @@ class TriggerRecord
 
  public:
   TriggerRecord() = default;
-  TriggerRecord(const BCData& bunchcrossing, int digitentry, int ndigitentries, int trackletentry = 0, int ntrackletentries = 0) : mBCData(bunchcrossing), mTrackletDataRange(trackletentry, ntrackletentries), mDigitDataRange(digitentry, ndigitentries) {}
+  TriggerRecord(const BCData& bunchcrossing, int digitentry, int ndigitentries, int trackletentry = 0, int ntrackletentries = 0) : mBCData(bunchcrossing), mDigitDataRange(digitentry, ndigitentries), mTrackletDataRange(trackletentry, ntrackletentries) {}
   // The above default of 0 for tracklet info, makes the digitizer look more decent as one can simply not put in the tracklet info as you dont have it.
   ~TriggerRecord() = default;
 

--- a/DataFormats/Detectors/TRD/src/AngularResidHistos.cxx
+++ b/DataFormats/Detectors/TRD/src/AngularResidHistos.cxx
@@ -54,6 +54,7 @@ void AngularResidHistos::fill(const AngularResidHistos& input)
 
 void AngularResidHistos::fill(const gsl::span<const AngularResidHistos> input)
 {
+  (void)input;
   LOG(fatal) << "This function must not be called. But it must be available for the compilation to work";
 }
 

--- a/GPU/GPUTracking/Standalone/README.md
+++ b/GPU/GPUTracking/Standalone/README.md
@@ -2,20 +2,20 @@
 \page refGPUTrackingStandalone Standalone benchmark
 /doxy -->
 
-GPU Tracking Standalone benchmark
+# GPU Tracking Standalone benchmark
 
 This is the standalone benchmark for the GPU tracking.
 
 In order to build: Use the CMake in this folder. The build can be configured using config.cmake. By default, the cmake process will link the src folder as symlink src in the installation folder, as well as the config.cmake, and provide a makefile there to trigger a rebuild and reinstall.
 In order to have all dependencies ready for the standalone build:
 - Either have them all as system packages.
-- Or build O2 with aliBuild, and then you can use the O2 dependencies by running O2/GPU/GPUTracking/Standalone/cmake/prepare.sh from your alice folder (or set `ALIBUILD_WORK_DIR` accordingly)
+- Or build O2 with aliBuild, and then you can use the O2 dependencies by sourcing O2/GPU/GPUTracking/Standalone/cmake/prepare.sh from your alice folder (or set `ALIBUILD_WORK_DIR` accordingly)
 
 Afterwards, you can build the standalone benchmark in that shell:
 ```
 mkdir -p standalone/build
 cd standalone/build
-cmake -DCMAKE_INSTALL_PREFIX=../ $O2_ROOT/GPU/GPUTracking/Standalone
+cmake -DCMAKE_INSTALL_PREFIX=../ $ALIBUILD_WORK_DIR/../O2/GPU/GPUTracking/Standalone
 make -j install
 ```
 
@@ -31,4 +31,3 @@ In order to extract data dumps from O2 to be run in the standalone benchmark:
 - Run the `o2-gpu-reco-workflow` with `--configKeyValues="GPU_global.dump=1;"`.
 - move all the created `*.dump` files to `standalone/events/[some_name]`.
 - Run `./ca -e [some_name]`.
-

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
@@ -518,7 +518,10 @@ GPUd() bool GPUTRDTracker_t<TRDTRK, PROP>::FollowProlongation(PROP* prop, TRDTRK
   // -> returns false if prolongation could not be executed fully
   //    or track does not fullfill threshold conditions
   //--------------------------------------------------------------------
-  //GPUInfo("Start track following for track %i at x=%f with pt=%f", t->getRefGlobalTrackIdRaw(), t->getX(), t->getPt());
+
+  if (ENABLE_INFO) {
+    GPUInfo("Start track following for track %i at x=%f with pt=%f", t->getRefGlobalTrackIdRaw(), t->getX(), t->getPt());
+  }
   mDebug->Reset();
   t->setChi2(0.f);
   float zShiftTrk = 0.f;

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.h
@@ -96,7 +96,7 @@ class GPUTRDTracker_t : public GPUProcessor
 
     GPUd() float GetReducedChi2() { return mLayers > 0 ? mChi2 / mLayers : mChi2; }
     GPUd() Hypothesis() : mLayers(0), mCandidateId(-1), mTrackletId(-1), mChi2(9999.f) {}
-    GPUd() Hypothesis(int layers, int candidateId, int trackletId, float chi2, float chi2YZPhi = -1.f) : mLayers(layers), mCandidateId(candidateId), mTrackletId(trackletId), mChi2(chi2) {}
+    GPUd() Hypothesis(int layers, int candidateId, int trackletId, float chi2) : mLayers(layers), mCandidateId(candidateId), mTrackletId(trackletId), mChi2(chi2) {}
   };
 
   short MemoryPermanent() const { return mMemoryPermanent; }


### PR DESCRIPTION
Before the tracker could not handle a TF with multiple collisions. I did not notice it so far, since I only tested with the box generator and a single event..
@davidrohr for the GPU track type I need a time estimate, similar to the `TrackTPC::getTime0()`. Directly in `GPUTPCGMMergedTrack` I could not see it. I assume I need to translate the track's Z into a time coordinate (using a vertex estimate and track eta?) in order to find the matching TRD trigger times. Can I do this using the default TPC vDrift value? And then open the road rather wide in Z accordingly?

There are some unrelated minor code changes in some of the TRD libraries in this PR, since as I learned today we might enable some additional compiler warnings in the future (`-Wreorder` for example).