### PR TITLE
DPL: add method to rescan DataRelayer / TimesliceIndex

### DIFF
--- a/Framework/Core/include/Framework/DataRelayer.h
+++ b/Framework/Core/include/Framework/DataRelayer.h
@@ -142,6 +142,10 @@ class DataRelayer
   /// Remove all pending messages
   void clear();
 
+  /// Rescan the whole data to see if there is anything new we should do,
+  /// e.g. as consequnce of an OOB event.
+  void rescan() { mTimesliceIndex.rescan(); };
+
  private:
   monitoring::Monitoring& mMetrics;
 

--- a/Framework/Core/include/Framework/TimesliceIndex.h
+++ b/Framework/Core/include/Framework/TimesliceIndex.h
@@ -69,11 +69,13 @@ class TimesliceIndex
 
   TimesliceIndex(size_t maxLanes);
   inline void resize(size_t s);
-  inline size_t size() const;
-  inline bool isValid(TimesliceSlot const& slot) const;
-  inline bool isDirty(TimesliceSlot const& slot) const;
+  [[nodiscard]] inline size_t size() const;
+  [[nodiscard]] inline bool isValid(TimesliceSlot const& slot) const;
+  [[nodiscard]] inline bool isDirty(TimesliceSlot const& slot) const;
   inline void markAsDirty(TimesliceSlot slot, bool value);
   inline void markAsInvalid(TimesliceSlot slot);
+  /// Mark all the cachelines as invalid, e.g. due to an out of band event
+  inline void rescan();
   /// Publish a slot to be sent via metrics.
   inline void publishSlot(TimesliceSlot slot);
   /// Associated the @a timestamp to the given @a slot. Notice that

--- a/Framework/Core/include/Framework/TimesliceIndex.inc
+++ b/Framework/Core/include/Framework/TimesliceIndex.inc
@@ -66,6 +66,13 @@ inline void TimesliceIndex::markAsDirty(TimesliceSlot slot, bool value)
   mDirty[slot.index] = value;
 }
 
+inline void TimesliceIndex::rescan()
+{
+  for (size_t i = 0; i < mDirty.size(); i++) {
+    mDirty[i] = true;
+  }
+}
+
 inline void TimesliceIndex::markAsInvalid(TimesliceSlot slot)
 {
   assert(mVariables.size() > slot.index);


### PR DESCRIPTION
This is needed to make sure external events, like OOB channels, or
certain completion policy related ones work correctly.