### PR TITLE
Fix in elimination of pixels multiply fired in the same ROF

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/AlpideCoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/AlpideCoder.h
@@ -392,7 +392,7 @@ class AlpideCoder
       auto currPix = pixData.begin(), prevPix = currPix++;
       while (currPix != pixData.end()) {
         if (prevPix->getCol() == currPix->getCol() && prevPix->getRowDirect() == currPix->getRowDirect()) {
-          pixData.erase(prevPix);
+          currPix = pixData.erase(prevPix);
         }
         prevPix = currPix++;
       }


### PR DESCRIPTION
Trivial fix, merging since currently decoding of corrupted ITS data may fail.