### PR TITLE
TRD: allow vDrift calib with TPC-TRD tracks only

### DIFF
--- a/Detectors/TRD/workflow/src/trd-tracking-workflow.cxx
+++ b/Detectors/TRD/workflow/src/trd-tracking-workflow.cxx
@@ -82,12 +82,12 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   if (!configcontext.options().get<bool>("disable-root-output")) {
     if (GTrackID::includesSource(GTrackID::Source::ITSTPC, srcTRD)) {
       specs.emplace_back(o2::trd::getTRDGlobalTrackWriterSpec(useMC));
-      if (configcontext.options().get<bool>("enable-trackbased-calib")) {
-        specs.emplace_back(o2::trd::getTRDCalibWriterSpec());
-      }
     }
     if (GTrackID::includesSource(GTrackID::Source::TPC, srcTRD)) {
       specs.emplace_back(o2::trd::getTRDTPCTrackWriterSpec(useMC, strict));
+    }
+    if (configcontext.options().get<bool>("enable-trackbased-calib")) {
+      specs.emplace_back(o2::trd::getTRDCalibWriterSpec());
     }
   }
 


### PR DESCRIPTION
Trivial fix. Originally the vDrift calibration was only done for ITS-TPC-TRD tracks, but it can work as well with TPC-TRD only tracks.