### PR TITLE
DPL: honour correctly ccdb-run-dependent metadata

### DIFF
--- a/Framework/Core/src/CCDBHelpers.cxx
+++ b/Framework/Core/src/CCDBHelpers.cxx
@@ -269,7 +269,7 @@ AlgorithmSpec CCDBHelpers::fetchFromCCDB()
           for (auto& meta : route.matcher.metadata) {
             if (meta.name == "ccdb-path") {
               path = meta.defaultValue.get<std::string>();
-            } else if (meta.name == "ccdb-run-dependent") {
+            } else if (meta.name == "ccdb-run-dependent" && meta.defaultValue.get<bool>() == true) {
               metadata["runNumber"] = dtc.runNumber;
             } else if (isPrefix(ccdbMetadataPrefix, meta.name)) {
               std::string key = meta.name.substr(ccdbMetadataPrefix.size());


### PR DESCRIPTION
Checking if the metadata is there is not enough.