### PR TITLE
MCH: do not ignore null UL words

### DIFF
--- a/Detectors/MUON/MCH/Raw/Decoder/src/UserLogicEndpointDecoder.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/UserLogicEndpointDecoder.h
@@ -109,9 +109,6 @@ size_t UserLogicEndpointDecoder<CHARGESUM, VERSION>::append(Payload buffer)
                     (static_cast<uint64_t>(buffer[i + 6]) << 48) |
                     (static_cast<uint64_t>(buffer[i + 7]) << 56);
 
-    if (word == 0) {
-      continue;
-    }
     if (word == 0xFEEDDEEDFEEDDEED) {
       continue;
     }


### PR DESCRIPTION
In zero-suppressed data null data words are possible and legitimate, and should not be skipped.