### PR TITLE
MCH: fixed computation of ROF orbit for out-of-time digits

### DIFF
--- a/Detectors/MUON/MCH/Raw/Decoder/src/ROFFinder.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/ROFFinder.cxx
@@ -189,7 +189,7 @@ o2::InteractionRecord ROFFinder::digitTime2IR(const RawDigit& digit)
     firstOrbit -= 1;
   }
 
-  uint32_t orbit = digit.getTime() / BCINORBIT + firstOrbit;
+  uint32_t orbit = time / BCINORBIT + firstOrbit;
   int32_t bc = time % BCINORBIT;
   return o2::InteractionRecord(bc, orbit);
 }


### PR DESCRIPTION
The commit fixes a bug in the computation of the ROF orbit in the case of digits that belong to the time-frame preceding the one being processed.