### PR TITLE
o2-sim: Offer option to disable Geant transport

### DIFF
--- a/Common/SimConfig/include/SimConfig/SimConfig.h
+++ b/Common/SimConfig/include/SimConfig/SimConfig.h
@@ -52,6 +52,7 @@ struct SimConfigData {
   int mField;                                 // L3 field setting in kGauss: +-2,+-5 and 0
   bool mUniformField = false;                 // uniform magnetic field
   bool mAsService = false;                    // if simulation should be run as service/deamon (does not exit after run)
+  bool mNoGeant = false;                      // if Geant transport should be turned off (when one is only interested in the generated events)
 
   ClassDefNV(SimConfigData, 4);
 };
@@ -118,6 +119,7 @@ class SimConfig
   bool isFilterOutNoHitEvents() const { return mConfigData.mFilterNoHitEvents; }
   bool asService() const { return mConfigData.mAsService; }
   uint64_t getTimestamp() const { return mConfigData.mTimestamp; }
+  bool isNoGeant() const { return mConfigData.mNoGeant; }
 
  private:
   SimConfigData mConfigData; //!

--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -53,7 +53,8 @@ void SimConfig::initOptions(boost::program_options::options_description& options
     "noemptyevents", "only writes events with at least one hit")(
     "CCDBUrl", bpo::value<std::string>()->default_value("ccdb-test.cern.ch:8080"), "URL for CCDB to be used.")(
     "timestamp", bpo::value<uint64_t>(), "global timestamp value in ms (for anchoring) - default is now")(
-    "asservice", bpo::value<bool>()->default_value(false), "run in service/server mode");
+    "asservice", bpo::value<bool>()->default_value(false), "run in service/server mode")(
+    "noGeant", bpo::bool_switch(), "prohibits any Geant transport/physics (by using tight cuts)");
 }
 
 bool SimConfig::resetFromParsedMap(boost::program_options::variables_map const& vm)
@@ -168,6 +169,7 @@ bool SimConfig::resetFromParsedMap(boost::program_options::variables_map const& 
   }
   mConfigData.mCCDBUrl = vm["CCDBUrl"].as<std::string>();
   mConfigData.mAsService = vm["asservice"].as<bool>();
+  mConfigData.mNoGeant = vm["noGeant"].as<bool>();
   if (vm.count("noemptyevents")) {
     mConfigData.mFilterNoHitEvents = true;
   }

--- a/macro/o2sim.C
+++ b/macro/o2sim.C
@@ -35,6 +35,24 @@
 #endif
 #include "migrateSimFiles.C"
 
+void check_notransport()
+{
+  // Sometimes we just want to inspect
+  // the generator kinematics and prohibit any transport.
+
+  // We allow users to give the noGeant option. In this case
+  // we set the geometry cuts to almost zero. Other adjustments (disable physics procs) could
+  // be done on top.
+  // This is merely offered for user convenience as it can be done from outside as well.
+  auto& confref = o2::conf::SimConfig::Instance();
+  if (confref.isNoGeant()) {
+    LOG(info) << "Initializing without Geant transport by applying very tight geometry cuts";
+    o2::conf::ConfigurableParam::setValue("SimCutParams", "maxRTracking", 0.0000001);    // 1 nanometer of tracking
+    o2::conf::ConfigurableParam::setValue("SimCutParams", "maxAbsZTracking", 0.0000001); // 1 nanometer of tracking
+    // TODO: disable physics processes for material sitting at the vertex
+  }
+}
+
 FairRunSim* o2sim_init(bool asservice)
 {
   auto& confref = o2::conf::SimConfig::Instance();
@@ -49,6 +67,8 @@ FairRunSim* o2sim_init(bool asservice)
     LOG(info) << "Initialized CCDB Manager at URL: " << ccdbmgr.getURL();
     LOG(info) << "Initialized CCDB Manager with timestamp : " << ccdbmgr.getTimestamp();
   }
+
+  check_notransport();
 
   // update the parameters from an INI/JSON file, if given (overrides code-based version)
   o2::conf::ConfigurableParam::updateFromFile(confref.getConfigFile());


### PR DESCRIPTION
This is useful for cases when only the generator kinematics
is of interest.