### PR TITLE
Optimising IDC processing

### DIFF
--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCFactorization.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCFactorization.h
@@ -45,7 +45,7 @@ class IDCFactorization : public IDCGroupHelperSector
   /// \param groupLastPadsThreshold minimum number of pads in pad direction for the last group in pad direction for all regions
   /// \param timeFrames number of time frames which will be stored
   /// \param timeframesDeltaIDC number of time frames stored for each DeltaIDC object
-  IDCFactorization(const std::array<unsigned char, Mapper::NREGIONS>& groupPads, const std::array<unsigned char, Mapper::NREGIONS>& groupRows, const std::array<unsigned char, Mapper::NREGIONS>& groupLastRowsThreshold, const std::array<unsigned char, Mapper::NREGIONS>& groupLastPadsThreshold, const unsigned int groupNotnPadsSectorEdges, const unsigned int timeFrames, const unsigned int timeframesDeltaIDC);
+  IDCFactorization(const std::array<unsigned char, Mapper::NREGIONS>& groupPads, const std::array<unsigned char, Mapper::NREGIONS>& groupRows, const std::array<unsigned char, Mapper::NREGIONS>& groupLastRowsThreshold, const std::array<unsigned char, Mapper::NREGIONS>& groupLastPadsThreshold, const unsigned int groupNotnPadsSectorEdges, const unsigned int timeFrames, const unsigned int timeframesDeltaIDC, const std::vector<uint32_t>& crus);
 
   /// default constructor for ROOT I/O
   IDCFactorization() = default;
@@ -100,10 +100,10 @@ class IDCFactorization : public IDCGroupHelperSector
 
   /// \return returns the number of stored integration intervals for given Delta IDC chunk
   /// \param chunk chunk of Delta IDC
-  unsigned long getNIntegrationIntervals(const unsigned int chunk) const;
+  unsigned long getNIntegrationIntervals(const unsigned int chunk, const int cru) const;
 
   /// \return returns the total number of stored integration intervals
-  unsigned long getNIntegrationIntervals() const;
+  unsigned long getNIntegrationIntervals(const int cru) const;
 
   /// \return returns stored IDC0 I_0(r,\phi) = <I(r,\phi,t)>_t
   /// \param side TPC side
@@ -271,6 +271,7 @@ class IDCFactorization : public IDCGroupHelperSector
   std::unique_ptr<CalDet<float>> mGainMap;                          ///<! static Gain map object used for filling missing IDC_0 values
   std::unique_ptr<CalDet<PadFlags>> mPadFlagsMap;                   ///< status flag for each pad (i.e. if the pad is dead)
   bool mInputGrouped{false};                                        ///< flag which is set to true if the input IDCs are grouped (checked via the grouping parameters from the constructor)
+  const std::vector<uint32_t> mCRUs{};                              ///< CRUs to process in this instance
 
   /// calculate I_0(r,\phi) = <I(r,\phi,t)>_t
   void calcIDCZero(const bool norm);

--- a/Detectors/TPC/workflow/include/TPCWorkflow/ProcessingHelpers.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/ProcessingHelpers.h
@@ -9,6 +9,11 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+namespace o2::ccdb
+{
+class BasicCCDBManager;
+}
+
 namespace o2::framework
 {
 class ProcessingContext;
@@ -26,6 +31,9 @@ uint32_t getCurrentTF(o2::framework::ProcessingContext& pc);
 
 /// \return returns creation time of tf
 uint64_t getCreationTime(o2::framework::ProcessingContext& pc);
+
+/// \return returns time stamp in microsecond-precission
+uint64_t getTimeStamp(o2::framework::ProcessingContext& pc, o2::ccdb::BasicCCDBManager& ccdbManager);
 
 } // namespace processing_helpers
 } // namespace o2::tpc

--- a/Detectors/TPC/workflow/include/TPCWorkflow/ProcessingHelpers.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/ProcessingHelpers.h
@@ -9,11 +9,6 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-namespace o2::ccdb
-{
-class BasicCCDBManager;
-}
-
 namespace o2::framework
 {
 class ProcessingContext;
@@ -33,7 +28,7 @@ uint32_t getCurrentTF(o2::framework::ProcessingContext& pc);
 uint64_t getCreationTime(o2::framework::ProcessingContext& pc);
 
 /// \return returns time stamp in microsecond-precission
-uint64_t getTimeStamp(o2::framework::ProcessingContext& pc, o2::ccdb::BasicCCDBManager& ccdbManager);
+uint64_t getTimeStamp(o2::framework::ProcessingContext& pc, const Long64_t orbitReset);
 
 } // namespace processing_helpers
 } // namespace o2::tpc

--- a/Detectors/TPC/workflow/include/TPCWorkflow/ProcessingHelpers.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/ProcessingHelpers.h
@@ -28,7 +28,12 @@ uint32_t getCurrentTF(o2::framework::ProcessingContext& pc);
 uint64_t getCreationTime(o2::framework::ProcessingContext& pc);
 
 /// \return returns time stamp in microsecond-precission
-uint64_t getTimeStamp(o2::framework::ProcessingContext& pc, const Long64_t orbitReset);
+/// Note that the input spec has to be defined as: inputSpecs.emplace_back("orbitreset", "CTP", "ORBITRESET", 0, Lifetime::Condition, ccdbParamSpec("CTP/Calib/OrbitReset"));
+uint64_t getTimeStamp(o2::framework::ProcessingContext& pc);
+
+/// \return returns the orbit reset time
+/// Note that the input spec has to be defined as: inputSpecs.emplace_back("orbitreset", "CTP", "ORBITRESET", 0, Lifetime::Condition, ccdbParamSpec("CTP/Calib/OrbitReset"));
+Long64_t getOrbitReset(o2::framework::ProcessingContext& pc);
 
 } // namespace processing_helpers
 } // namespace o2::tpc

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCDistributeIDCSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCDistributeIDCSpec.h
@@ -44,7 +44,7 @@ class TPCDistributeIDCSpec : public o2::framework::Task
 {
  public:
   TPCDistributeIDCSpec(const std::vector<uint32_t>& crus, const unsigned int timeframes, const unsigned int outlanes, const bool loadFromFile, const int firstTF)
-    : mCRUs{crus}, mTimeFrames{timeframes}, mOutLanes{outlanes}, mLoadFromFile{loadFromFile}, mProcessedCRU{{std::vector<unsigned int>(timeframes), std::vector<unsigned int>(timeframes)}}, mDataSend{std::vector<bool>(timeframes), std::vector<bool>(timeframes)}, mTFStart{{firstTF, firstTF + timeframes}}, mTFEnd{{firstTF + timeframes - 1, mTFStart[1] + timeframes - 1}}
+    : mCRUs{crus}, mTimeFrames{timeframes}, mOutLanes{outlanes}, mLoadFromFile{loadFromFile}, mProcessedCRU{{std::vector<unsigned int>(timeframes), std::vector<unsigned int>(timeframes)}}, mDataSent{std::vector<bool>(timeframes), std::vector<bool>(timeframes)}, mTFStart{{firstTF, firstTF + timeframes}}, mTFEnd{{firstTF + timeframes - 1, mTFStart[1] + timeframes - 1}}
   {
     // sort vector for binary_search
     std::sort(mCRUs.begin(), mCRUs.end());
@@ -190,9 +190,9 @@ class TPCDistributeIDCSpec : public o2::framework::Task
     }
 
     // check if all CRUs for current TF are already aggregated and send data
-    if ((mProcessedCRU[currentBuffer][relTF] == 2 * mCRUs.size() || mLoadFromFile) && !mDataSend[currentBuffer][relTF]) {
+    if ((mProcessedCRU[currentBuffer][relTF] == 2 * mCRUs.size() || mLoadFromFile) && !mDataSent[currentBuffer][relTF]) {
       LOGP(info, "All data for current TF received. Sending data...");
-      mDataSend[currentBuffer][relTF] = true;
+      mDataSent[currentBuffer][relTF] = true;
       ++mProcessedTFs[currentBuffer];
       sendOutput(pc, currentOutLane, currentBuffer, relTF);
     }
@@ -209,7 +209,7 @@ class TPCDistributeIDCSpec : public o2::framework::Task
 
       mProcessedTFs[currentBuffer] = 0; // reset processed TFs for next aggregation interval
       std::fill(mProcessedCRU[currentBuffer].begin(), mProcessedCRU[currentBuffer].end(), 0);
-      std::fill(mDataSend[currentBuffer].begin(), mDataSend[currentBuffer].end(), false);
+      std::fill(mDataSent[currentBuffer].begin(), mDataSent[currentBuffer].end(), false);
 
       // set integration range for next integration interval
       mTFStart[mBuffer] = mTFEnd[!mBuffer] + 1;
@@ -241,7 +241,7 @@ class TPCDistributeIDCSpec : public o2::framework::Task
   std::array<std::array<std::vector<pmr::vector<float>>, CRU::MaxCRU>, 2> mIDCs{};     ///< grouped and integrated IDCs for the whole TPC. CRU -> time frame -> IDCs. Buffer used in case one FLP delivers the TF after the last TF for the current aggregation interval faster then the other FLPs the last TF.
   std::array<std::array<std::vector<pmr::vector<float>>, CRU::MaxCRU>, 2> mOneDIDCs{}; ///< 1D IDCs for the whole TPC. CRU -> time frame -> IDCs. Buffer used in case one FLP delivers the TF after the last TF for the current aggregation interval faster then the other FLPs the last TF.
   std::array<std::vector<unsigned int>, 2> mProcessedCRU{};                            ///< counter of received data from CRUs per TF to merge incoming data from FLPs. Buffer used in case one FLP delivers the TF after the last TF for the current aggregation interval faster then the other FLPs the last TF.
-  std::array<std::vector<bool>, 2> mDataSend{};                                        ///< to keep track if the data for a given tf has already been send
+  std::array<std::vector<bool>, 2> mDataSent{};                                        ///< to keep track if the data for a given tf has already been sent
   std::array<std::vector<std::unordered_map<unsigned int, bool>>, 2> mProcessedCRUs{}; ///< to keep track of the already processed CRUs ([buffer][relTF][CRU])
   std::array<long, 2> mTFStart{};                                                      ///< storing of first TF for buffer interval
   std::array<long, 2> mTFEnd{};                                                        ///< storing of last TF for buffer interval

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCDistributeIDCSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCDistributeIDCSpec.h
@@ -118,7 +118,7 @@ class TPCDistributeIDCSpec : public o2::framework::Task
     // check which buffer to use for current incoming data
     const auto tf = processing_helpers::getCurrentTF(pc);
 
-    // automatically detext firstTF in case firstTF was not specified
+    // automatically detect firstTF in case firstTF was not specified
     if (mTFStart.front() <= -1) {
       const auto firstTF = tf;
       const int offsetTF = std::abs(mTFStart.front() + 1);

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCDistributeIDCSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCDistributeIDCSpec.h
@@ -28,6 +28,7 @@
 #include "TPCWorkflow/TPCFLPIDCSpec.h"
 #include "TPCBase/CRU.h"
 #include "MemoryResources/MemoryResources.h"
+#include "TPCWorkflow/ProcessingHelpers.h"
 
 #include "TFile.h"
 #include "TKey.h"
@@ -42,9 +43,12 @@ namespace o2::tpc
 class TPCDistributeIDCSpec : public o2::framework::Task
 {
  public:
-  TPCDistributeIDCSpec(const std::vector<uint32_t>& crus, const unsigned int timeframes, const unsigned int outlanes, const bool loadFromFile, const unsigned int firstTF)
-    : mCRUs{crus}, mTimeFrames{timeframes}, mOutLanes{outlanes}, mLoadFromFile{loadFromFile}, mProcessedCRU{{std::vector<unsigned int>(timeframes), std::vector<unsigned int>(timeframes)}}, mTFStart{{firstTF, firstTF + timeframes}}, mTFEnd{{firstTF + timeframes - 1, mTFStart[1] + timeframes - 1}}
+  TPCDistributeIDCSpec(const std::vector<uint32_t>& crus, const unsigned int timeframes, const unsigned int outlanes, const bool loadFromFile, const int firstTF)
+    : mCRUs{crus}, mTimeFrames{timeframes}, mOutLanes{outlanes}, mLoadFromFile{loadFromFile}, mProcessedCRU{{std::vector<unsigned int>(timeframes), std::vector<unsigned int>(timeframes)}}, mDataSend{std::vector<bool>(timeframes), std::vector<bool>(timeframes)}, mTFStart{{firstTF, firstTF + timeframes}}, mTFEnd{{firstTF + timeframes - 1, mTFStart[1] + timeframes - 1}}
   {
+    // sort vector for binary_search
+    std::sort(mCRUs.begin(), mCRUs.end());
+
     for (auto& idcbuffer : mIDCs) {
       for (auto& idc : idcbuffer) {
         idc.resize(mTimeFrames);
@@ -53,6 +57,16 @@ class TPCDistributeIDCSpec : public o2::framework::Task
     for (auto& idcbuffer : mOneDIDCs) {
       for (auto& idc : idcbuffer) {
         idc.resize(mTimeFrames);
+      }
+    }
+
+    for (auto& processedCRUbuffer : mProcessedCRUs) {
+      processedCRUbuffer.resize(mTimeFrames);
+      for (auto& crusMap : processedCRUbuffer) {
+        crusMap.reserve(mCRUs.size());
+        for (const auto cruID : mCRUs) {
+          crusMap.emplace(cruID, false);
+        }
       }
     }
   };
@@ -102,28 +116,55 @@ class TPCDistributeIDCSpec : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) final
   {
     // check which buffer to use for current incoming data
-    const auto tf = getCurrentTF(pc);
+    const auto tf = processing_helpers::getCurrentTF(pc);
+
+    // automatically detext firstTF in case firstTF was not specified
+    if (mTFStart.front() <= -1) {
+      const auto firstTF = tf;
+      const int offsetTF = std::abs(mTFStart.front() + 1);
+      mTFStart = {firstTF + offsetTF, firstTF + offsetTF + mTimeFrames};
+      mTFEnd = {mTFStart[1] - 1, mTFStart[1] - 1 + mTimeFrames};
+      LOGP(info, "Setting {} as first TF", mTFStart[0]);
+      LOGP(info, "Using offset of {} TFs for setting the first TF", offsetTF);
+    }
+
     const bool currentBuffer = (tf > mTFEnd[mBuffer]) ? !mBuffer : mBuffer;
+    if (mTFStart[currentBuffer] > tf) {
+      LOGP(info, "all CRUs for current TF {} already received. Skipping this TF", tf);
+      return;
+    }
+
     const unsigned int currentOutLane = (tf > mTFEnd[mBuffer]) ? (mCurrentOutLane + 1) % mOutLanes : mCurrentOutLane;
     const auto relTF = tf - mTFStart[currentBuffer];
-    LOGP(info, "current TF: {}   relative TF: {}    current buffer: {}    current output lane", tf, relTF, currentBuffer, currentOutLane);
+    LOGP(info, "current TF: {}   relative TF: {}    current buffer: {}    current output lane: {}     mTFStart: {}", tf, relTF, currentBuffer, currentOutLane, mTFStart[currentBuffer]);
 
-    if (relTF > mProcessedCRU[currentBuffer].size()) {
-      LOGP(error, "Skipping tf {}: relative tf {} is larger than size of buffer: {}", tf, relTF, mProcessedCRU[currentBuffer].size());
+    if (relTF >= mProcessedCRU[currentBuffer].size()) {
+      LOGP(fatal, "Skipping tf {}: relative tf {} is larger than size of buffer: {}", tf, relTF, mProcessedCRU[currentBuffer].size());
       return;
     }
 
     if (!mLoadFromFile) {
       for (auto& ref : InputRecordWalker(pc.inputs(), mFilter)) {
-        ++mProcessedCRU[currentBuffer][relTF];
         auto const* tpcCRUHeader = o2::framework::DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
         const int cru = tpcCRUHeader->subSpecification >> 7;
+
+        // check if cru is specified in input cru list
+        if (!(std::binary_search(mCRUs.begin(), mCRUs.end(), cru))) {
+          LOGP(debug, "Received data from CRU: {} which was not specified as input. Skipping", cru);
+          continue;
+        }
+        // to keep track of processed CRUs
+        mProcessedCRUs[currentBuffer][relTF][cru] = true;
+
+        // count total number of processed CRUs for given TF
+        ++mProcessedCRU[currentBuffer][relTF];
+
         const auto descr = tpcCRUHeader->dataDescription;
         if (TPCFLPIDCDevice<TPCFLPIDCDeviceGroup>::getDataDescriptionIDCGroup() == descr) {
-          LOGP(info, "receiving IDCs for CRU: {}", cru);
+          LOGP(debug, "receiving IDCs for CRU: {}", cru);
           mIDCs[currentBuffer][cru][relTF] = std::move(pc.inputs().get<pmr::vector<float>>(ref));
         } else {
-          LOGP(info, "receiving 1D IDCs for CRU: {}", cru);
+          LOGP(debug, "receiving 1D IDCs for CRU: {}", cru);
           mOneDIDCs[currentBuffer][cru][relTF] = std::move(pc.inputs().get<pmr::vector<float>>(ref));
         }
       }
@@ -131,9 +172,27 @@ class TPCDistributeIDCSpec : public o2::framework::Task
 
     LOGP(info, "number of received CRUs for current TF: {}    Needed a total number of processed CRUs of: {}", mProcessedCRU[currentBuffer][relTF], 2 * mCRUs.size());
 
+    // check number of processed CRUs for previous TFs. If CRUs are missing for them, they are probably lost/not received
+    if (relTF == mTimeFrames - 1) {
+      for (int iTF = relTF - 1; iTF >= 0; --iTF) {
+        LOGP(info, "Checking rel TF: {} for missing CRUs", iTF);
+        if (mProcessedCRU[currentBuffer][iTF] != 2 * mCRUs.size()) {
+          LOGP(warning, "CRUs for TF: {} are missing!", tf - iTF);
+
+          // find actuall CRUs
+          for (auto& it : mProcessedCRUs[currentBuffer][iTF]) {
+            if (!it.second) {
+              LOGP(warning, "Couldnt find data for CRU {} possibly not received!", it.first);
+            }
+          }
+        }
+      }
+    }
+
     // check if all CRUs for current TF are already aggregated and send data
-    if (mProcessedCRU[currentBuffer][relTF] == 2 * mCRUs.size() || mLoadFromFile) {
+    if ((mProcessedCRU[currentBuffer][relTF] == 2 * mCRUs.size() || mLoadFromFile) && !mDataSend[currentBuffer][relTF]) {
       LOGP(info, "All data for current TF received. Sending data...");
+      mDataSend[currentBuffer][relTF] = true;
       ++mProcessedTFs[currentBuffer];
       sendOutput(pc, currentOutLane, currentBuffer, relTF);
     }
@@ -141,8 +200,16 @@ class TPCDistributeIDCSpec : public o2::framework::Task
     if (mProcessedTFs[currentBuffer] == mTimeFrames) {
       LOGP(info, "All TFs for current buffer received. Clearing buffer");
 
+      // resetting received CRUs
+      for (auto& crusMap : mProcessedCRUs[currentBuffer]) {
+        for (auto& it : crusMap) {
+          it.second = false;
+        }
+      }
+
       mProcessedTFs[currentBuffer] = 0; // reset processed TFs for next aggregation interval
       std::fill(mProcessedCRU[currentBuffer].begin(), mProcessedCRU[currentBuffer].end(), 0);
+      std::fill(mDataSend[currentBuffer].begin(), mDataSend[currentBuffer].end(), false);
 
       // set integration range for next integration interval
       mTFStart[mBuffer] = mTFEnd[!mBuffer] + 1;
@@ -166,7 +233,7 @@ class TPCDistributeIDCSpec : public o2::framework::Task
   static constexpr header::DataDescription getDataDescription1DIDC() { return header::DataDescription{"1IDCAGG"}; }
 
  private:
-  const std::vector<uint32_t> mCRUs{};                                                 ///< CRUs to process in this instance
+  std::vector<uint32_t> mCRUs{};                                                       ///< CRUs to process in this instance
   const unsigned int mTimeFrames{};                                                    ///< number of TFs per aggregation interval
   const unsigned int mOutLanes{};                                                      ///< number of output lanes
   const bool mLoadFromFile{};                                                          ///< if true data will be loaded from root file
@@ -174,15 +241,14 @@ class TPCDistributeIDCSpec : public o2::framework::Task
   std::array<std::array<std::vector<pmr::vector<float>>, CRU::MaxCRU>, 2> mIDCs{};     ///< grouped and integrated IDCs for the whole TPC. CRU -> time frame -> IDCs. Buffer used in case one FLP delivers the TF after the last TF for the current aggregation interval faster then the other FLPs the last TF.
   std::array<std::array<std::vector<pmr::vector<float>>, CRU::MaxCRU>, 2> mOneDIDCs{}; ///< 1D IDCs for the whole TPC. CRU -> time frame -> IDCs. Buffer used in case one FLP delivers the TF after the last TF for the current aggregation interval faster then the other FLPs the last TF.
   std::array<std::vector<unsigned int>, 2> mProcessedCRU{};                            ///< counter of received data from CRUs per TF to merge incoming data from FLPs. Buffer used in case one FLP delivers the TF after the last TF for the current aggregation interval faster then the other FLPs the last TF.
-  std::array<uint32_t, 2> mTFStart{};                                                  ///< storing of first TF used when setting the validity of the objects when writing to CCDB
-  std::array<uint32_t, 2> mTFEnd{};                                                    ///< storing of last TF used when setting the validity of the objects when writing to CCDB
+  std::array<std::vector<bool>, 2> mDataSend{};                                        ///< to keep track if the data for a given tf has already been send
+  std::array<std::vector<std::unordered_map<unsigned int, bool>>, 2> mProcessedCRUs{}; ///< to keep track of the already processed CRUs ([buffer][relTF][CRU])
+  std::array<long, 2> mTFStart{};                                                      ///< storing of first TF for buffer interval
+  std::array<long, 2> mTFEnd{};                                                        ///< storing of last TF for buffer interval
   unsigned int mCurrentOutLane{0};                                                     ///< index for keeping track of the current output lane
   bool mBuffer{false};                                                                 ///< buffer index
   const std::vector<InputSpec> mFilter = {{"idcsgroup", ConcreteDataTypeMatcher{o2::header::gDataOriginTPC, TPCFLPIDCDevice<TPCFLPIDCDeviceGroup>::getDataDescriptionIDCGroup()}, Lifetime::Timeframe},
                                           {"1didc", ConcreteDataTypeMatcher{o2::header::gDataOriginTPC, TPCFLPIDCDevice<TPCFLPIDCDeviceGroup>::getDataDescription1DIDC()}, Lifetime::Timeframe}}; ///< filter for looping over input data
-
-  /// \return returns TF of current processed data
-  uint32_t getCurrentTF(o2::framework::ProcessingContext& pc) const { return o2::framework::DataRefUtils::getHeader<o2::header::DataHeader*>(pc.inputs().getFirstValid(true))->tfCounter; }
 
   void sendOutput(o2::framework::ProcessingContext& pc, const unsigned int currentOutLane, const bool currentBuffer, const unsigned int relTF)
   {
@@ -201,7 +267,7 @@ class TPCDistributeIDCSpec : public o2::framework::Task
   }
 };
 
-DataProcessorSpec getTPCDistributeIDCSpec(const std::vector<uint32_t>& crus, const unsigned int timeframes, const unsigned int outlanes, const unsigned int firstTF, const bool loadFromFile)
+DataProcessorSpec getTPCDistributeIDCSpec(const std::vector<uint32_t>& crus, const unsigned int timeframes, const unsigned int outlanes, const int firstTF, const bool loadFromFile)
 {
   std::vector<InputSpec> inputSpecs;
   if (!loadFromFile) {

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCFactorizeIDCSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCFactorizeIDCSpec.h
@@ -102,7 +102,7 @@ class TPCFactorizeIDCSpec : public o2::framework::Task
     // set the min range of TFs for first TF
     if (mProcessedTFs == 0) {
       mTFFirst = processing_helpers::getCurrentTF(pc);
-      mTimeStampFirst = processing_helpers::getTimeStamp(pc, getOrbitReset(pc)) / 1000; // in milliseconds
+      mTimeStampFirst = processing_helpers::getTimeStamp(pc) / 1000; // in milliseconds
 
       // write struct containing grouping parameters to access grouped IDCs to CCDB
       if (mWriteToDB && mUpdateGroupingPar) {
@@ -195,13 +195,6 @@ class TPCFactorizeIDCSpec : public o2::framework::Task
   /// \return returns first time stamp for validity range when storing to IDCDelta CCDB
   auto getFirstTimeStampDeltaIDC(const unsigned int iChunk) const { return mTimeStampRangeIDCDelta[iChunk]; }
 
-  Long64_t getOrbitReset(o2::framework::ProcessingContext& pc) const
-  {
-    auto tv = pc.inputs().get<std::vector<Long64_t>*>("orbitreset");
-    const auto orbitReset = tv->front();
-    return orbitReset;
-  }
-
   /// check if current tf will be used to set the time stamp range
   bool findTimeStamp(o2::framework::ProcessingContext& pc)
   {
@@ -214,7 +207,7 @@ class TPCFactorizeIDCSpec : public o2::framework::Task
     auto it = std::find(mTFRangeIDCDelta.begin(), mTFRangeIDCDelta.end(), tf);
     if (it != mTFRangeIDCDelta.end()) {
       const int index = std::distance(mTFRangeIDCDelta.begin(), it);
-      mTimeStampRangeIDCDelta[index] = processing_helpers::getTimeStamp(pc, getOrbitReset(pc)) / 1000;
+      mTimeStampRangeIDCDelta[index] = processing_helpers::getTimeStamp(pc) / 1000;
       // TODO remove found tf?
       return true;
     }

--- a/Detectors/TPC/workflow/src/ProcessingHelpers.cxx
+++ b/Detectors/TPC/workflow/src/ProcessingHelpers.cxx
@@ -19,7 +19,6 @@
 #include "Framework/DataRefUtils.h"
 #include "Framework/InputRecord.h"
 #include "Framework/ServiceRegistry.h"
-#include "CCDB/BasicCCDBManager.h"
 #include "CommonConstants/LHCConstants.h"
 
 #include "TPCWorkflow/ProcessingHelpers.h"
@@ -64,10 +63,9 @@ uint64_t processing_helpers::getCreationTime(o2::framework::ProcessingContext& p
   return DataRefUtils::getHeader<DataProcessingHeader*>(pc.inputs().getFirstValid(true))->creation;
 }
 
-uint64_t processing_helpers::getTimeStamp(o2::framework::ProcessingContext& pc, o2::ccdb::BasicCCDBManager& ccdbManager)
+uint64_t processing_helpers::getTimeStamp(o2::framework::ProcessingContext& pc, const Long64_t orbitReset)
 {
   const auto tfOrbitFirst = DataRefUtils::getHeader<o2::header::DataHeader*>(pc.inputs().getFirstValid(true))->firstTForbit;
-  const auto* tv = ccdbManager.getForTimeStamp<std::vector<Long64_t>>("CTP/Calib/OrbitReset", processing_helpers::getCreationTime(pc));
-  const long tPrec = (*tv)[0] + tfOrbitFirst * o2::constants::lhc::LHCOrbitMUS; // microsecond-precise time stamp
+  const long tPrec = orbitReset + tfOrbitFirst * o2::constants::lhc::LHCOrbitMUS; // microsecond-precise time stamp
   return tPrec;
 }

--- a/Detectors/TPC/workflow/src/ProcessingHelpers.cxx
+++ b/Detectors/TPC/workflow/src/ProcessingHelpers.cxx
@@ -19,6 +19,8 @@
 #include "Framework/DataRefUtils.h"
 #include "Framework/InputRecord.h"
 #include "Framework/ServiceRegistry.h"
+#include "CCDB/BasicCCDBManager.h"
+#include "CommonConstants/LHCConstants.h"
 
 #include "TPCWorkflow/ProcessingHelpers.h"
 
@@ -60,4 +62,12 @@ uint32_t processing_helpers::getCurrentTF(o2::framework::ProcessingContext& pc)
 uint64_t processing_helpers::getCreationTime(o2::framework::ProcessingContext& pc)
 {
   return DataRefUtils::getHeader<DataProcessingHeader*>(pc.inputs().getFirstValid(true))->creation;
+}
+
+uint64_t processing_helpers::getTimeStamp(o2::framework::ProcessingContext& pc, o2::ccdb::BasicCCDBManager& ccdbManager)
+{
+  const auto tfOrbitFirst = DataRefUtils::getHeader<o2::header::DataHeader*>(pc.inputs().getFirstValid(true))->firstTForbit;
+  const auto* tv = ccdbManager.getForTimeStamp<std::vector<Long64_t>>("CTP/Calib/OrbitReset", processing_helpers::getCreationTime(pc));
+  const long tPrec = (*tv)[0] + tfOrbitFirst * o2::constants::lhc::LHCOrbitMUS; // microsecond-precise time stamp
+  return tPrec;
 }

--- a/Detectors/TPC/workflow/src/ProcessingHelpers.cxx
+++ b/Detectors/TPC/workflow/src/ProcessingHelpers.cxx
@@ -63,9 +63,16 @@ uint64_t processing_helpers::getCreationTime(o2::framework::ProcessingContext& p
   return DataRefUtils::getHeader<DataProcessingHeader*>(pc.inputs().getFirstValid(true))->creation;
 }
 
-uint64_t processing_helpers::getTimeStamp(o2::framework::ProcessingContext& pc, const Long64_t orbitReset)
+uint64_t processing_helpers::getTimeStamp(o2::framework::ProcessingContext& pc)
 {
   const auto tfOrbitFirst = DataRefUtils::getHeader<o2::header::DataHeader*>(pc.inputs().getFirstValid(true))->firstTForbit;
-  const long tPrec = orbitReset + tfOrbitFirst * o2::constants::lhc::LHCOrbitMUS; // microsecond-precise time stamp
+  const long tPrec = getOrbitReset(pc) + tfOrbitFirst * o2::constants::lhc::LHCOrbitMUS; // microsecond-precise time stamp
   return tPrec;
+}
+
+Long64_t processing_helpers::getOrbitReset(o2::framework::ProcessingContext& pc)
+{
+  auto tv = pc.inputs().get<std::vector<Long64_t>*>("orbitreset");
+  const auto orbitReset = tv->front();
+  return orbitReset;
 }

--- a/Detectors/TPC/workflow/src/tpc-distribute-idc.cxx
+++ b/Detectors/TPC/workflow/src/tpc-distribute-idc.cxx
@@ -36,7 +36,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
   std::vector<ConfigParamSpec> options{
     {"crus", VariantType::String, cruDefault.c_str(), {"List of CRUs, comma separated ranges, e.g. 0-3,7,9-15"}},
     {"timeframes", VariantType::Int, 2000, {"Number of TFs which will be aggregated per aggregation interval."}},
-    {"firstTF", VariantType::Int, 0, {"First time frame index."}},
+    {"firstTF", VariantType::Int, 0, {"First time frame index. (if set to -1 the first TF will be automatically detected. Values < -1 are setting an offset for skipping the first TFs)"}},
     {"load-from-file", VariantType::Bool, false, {"load average and grouped IDCs from IDCGroup.root file."}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}},
     {"output-lanes", VariantType::Int, 2, {"Number of parallel pipelines which will be used in the factorization device."}}};


### PR DESCRIPTION
Optimising distribute IDCs spec
- first TF can be detected automatically by setting --firstTF -1
- adding possibillity to set an offset for skipping first TFs in case of automatically detecting the first TF
- skipping CRUs in case they are received, but not specified in input list
- adding check for not received CRUs
- generally avoiding crashes, instead printing fatal log messages

IDC factorization
- fixing IDC factorization in case not all CRUs are used

IDCs on FLPS:
- Automatically loading the pad status map on the FLPS from the CCDB in case the map was updated

CCDB:
- Use precise time stamp when writting IDCs and pad status map to the CCDB