### PR TITLE
DPL: improve parsing of channel-config

### DIFF
--- a/Framework/Core/src/ChannelSpecHelpers.cxx
+++ b/Framework/Core/src/ChannelSpecHelpers.cxx
@@ -14,6 +14,7 @@
 #include <ostream>
 #include <cassert>
 #include <cctype>
+#include <regex>
 #if __has_include(<filesystem>)
 #include <filesystem>
 namespace fs = std::filesystem;
@@ -33,6 +34,94 @@ std::string getTmpFolder()
 
 namespace o2::framework
 {
+
+void OutputChannelSpecConfigParser::beginChannel()
+{
+  specs.push_back(OutputChannelSpec{});
+}
+
+void OutputChannelSpecConfigParser::endChannel()
+{
+}
+
+bool isIPAddress(const std::string& address)
+{
+  std::regex ipv4_regex("^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$");
+  if (std::regex_match(address, ipv4_regex)) {
+    return true;
+  }
+  return false;
+}
+
+void OutputChannelSpecConfigParser::property(std::string_view key, std::string_view value)
+{
+  std::string valueStr = value.data();
+  if (key == "address") {
+    auto parseAddress = [v = std::string(value), &outputChannelSpec = specs.back()]() {
+      auto value = v;
+      std::string protocol = "tcp";
+      std::string hostname = "127.0.0.1";
+      std::string port = "9090";
+      auto pos = value.find("://");
+      if (pos != std::string::npos) {
+        protocol = value.substr(0, pos);
+        value = value.substr(pos + 3);
+      }
+      if (protocol == "tcp") {
+        pos = value.find(':');
+        if (pos != std::string::npos) {
+          hostname = value.substr(0, pos);
+          value = value.substr(pos + 1);
+        } else {
+          throw runtime_error_f("Port not found in address '%s'", v.c_str());
+        }
+        port = value;
+        if (isIPAddress(hostname) == false) {
+          throw runtime_error_f("Invalid ip address '%s'", hostname.c_str());
+        }
+        outputChannelSpec.hostname = hostname;
+        outputChannelSpec.port = std::stoi(port);
+        outputChannelSpec.protocol = ChannelProtocol::Network;
+      } else if (protocol == "ipc") {
+        outputChannelSpec.hostname = value;
+        outputChannelSpec.port = 0;
+        outputChannelSpec.protocol = ChannelProtocol::IPC;
+      } else {
+        throw runtime_error_f("Unknown protocol '%s'", protocol.c_str());
+      }
+    };
+    parseAddress();
+  }
+  auto& outputChannelSpec = specs.back();
+  if (key == "name") {
+    outputChannelSpec.name = value;
+  } else if (key == "type" && value == "pub") {
+    outputChannelSpec.type = ChannelType::Pub;
+  } else if (key == "type" && value == "sub") {
+    outputChannelSpec.type = ChannelType::Sub;
+  } else if (key == "type" && value == "push") {
+    outputChannelSpec.type = ChannelType::Push;
+  } else if (key == "type" && value == "pull") {
+    outputChannelSpec.type = ChannelType::Pull;
+  } else if (key == "type" && value == "pair") {
+    outputChannelSpec.type = ChannelType::Pair;
+  } else if (key == "method" && value == "bind") {
+    outputChannelSpec.method = ChannelMethod::Bind;
+  } else if (key == "method" && value == "connect") {
+    outputChannelSpec.method = ChannelMethod::Connect;
+  } else if (key == "rateLogging") {
+    outputChannelSpec.rateLogging = std::stoi(valueStr);
+  } else if (key == "recvBufSize") {
+    outputChannelSpec.recvBufferSize = std::stoi(valueStr);
+  } else if (key == "sendBufSize") {
+    outputChannelSpec.recvBufferSize = std::stoi(valueStr);
+  }
+}
+
+void OutputChannelSpecConfigParser::error()
+{
+  throw runtime_error_f("Error in channel config.");
+}
 
 char const* ChannelSpecHelpers::typeAsString(enum ChannelType type)
 {
@@ -131,13 +220,16 @@ void ChannelSpecHelpers::parseChannelConfig(char const* config, FairMQChannelCon
   std::string_view key;
   std::string_view value;
   char const* nameKey = "name";
+  char const* lastError = "bad configuation string";
 
   while (true) {
     switch (state) {
       case ChannelConfigParserState::BEGIN: {
         if (*cur == '\0') {
+          lastError = "empty config string";
           state = ChannelConfigParserState::ERROR;
         } else if (!isalpha(*cur)) {
+          lastError = "first character is not alphabetic";
           state = ChannelConfigParserState::ERROR;
         } else {
           state = ChannelConfigParserState::BEGIN_CHANNEL;
@@ -147,6 +239,7 @@ void ChannelSpecHelpers::parseChannelConfig(char const* config, FairMQChannelCon
       case ChannelConfigParserState::BEGIN_CHANNEL: {
         next = strpbrk(cur, ":=;,");
         if (*next == ';' || *next == ',') {
+          lastError = "expected channel name";
           state = ChannelConfigParserState::ERROR;
           break;
         } else if (*next == ':') {
@@ -156,6 +249,11 @@ void ChannelSpecHelpers::parseChannelConfig(char const* config, FairMQChannelCon
           handler.property(key, value);
           state = ChannelConfigParserState::BEGIN_KEY;
           cur = next + 1;
+          if (*cur == '\0') {
+            state = ChannelConfigParserState::END_CHANNEL;
+          } else {
+            state = ChannelConfigParserState::BEGIN_KEY;
+          }
           break;
         }
         handler.beginChannel();
@@ -165,6 +263,7 @@ void ChannelSpecHelpers::parseChannelConfig(char const* config, FairMQChannelCon
       case ChannelConfigParserState::BEGIN_KEY: {
         next = strchr(cur, '=');
         if (next == nullptr) {
+          lastError = "expected '='";
           state = ChannelConfigParserState::ERROR;
         } else {
           key = std::string_view(cur, next - cur);
@@ -212,6 +311,7 @@ void ChannelSpecHelpers::parseChannelConfig(char const* config, FairMQChannelCon
           state = ChannelConfigParserState::BEGIN_CHANNEL;
           cur++;
         } else {
+          lastError = "expected ';'";
           state = ChannelConfigParserState::ERROR;
         }
         break;
@@ -220,7 +320,7 @@ void ChannelSpecHelpers::parseChannelConfig(char const* config, FairMQChannelCon
         return;
       }
       case ChannelConfigParserState::ERROR: {
-        throw runtime_error("Unable to parse channel config");
+        throw runtime_error_f("Unable to parse channel config: %s", lastError);
       }
     }
   }

--- a/Framework/Core/src/ChannelSpecHelpers.h
+++ b/Framework/Core/src/ChannelSpecHelpers.h
@@ -14,6 +14,7 @@
 #include "Framework/ChannelSpec.h"
 #include <iosfwd>
 #include <string_view>
+#include <vector>
 
 namespace o2::framework
 {
@@ -24,6 +25,16 @@ struct FairMQChannelConfigParser {
   virtual void endChannel() {}
   virtual void property(std::string_view /* key */, std::string_view /* value */) {}
   virtual void error() {}
+};
+
+/// A parser which creates an OutputChannelSpec from the --channel-config
+struct OutputChannelSpecConfigParser : FairMQChannelConfigParser {
+  void beginChannel() override;
+  void endChannel() override;
+  void property(std::string_view /* key */, std::string_view /* value */) override;
+  void error() override;
+  std::vector<OutputChannelSpec> specs;
+  int channelCount = 0;
 };
 
 /// A few helpers to convert enums to their actual representation in

--- a/Framework/Core/test/test_ChannelSpecHelpers.cxx
+++ b/Framework/Core/test/test_ChannelSpecHelpers.cxx
@@ -76,4 +76,44 @@ BOOST_AUTO_TEST_CASE(TestChannelParser)
   TestHandler h3;
   ChannelSpecHelpers::parseChannelConfig("foo:bar=fur,abc=cdf;name=bar,foo=a", h3);
   BOOST_REQUIRE_EQUAL(h3.str.str(), "@name=foobar=furabc=cdf*@name=barfoo=a*");
+
+  // Test the OutputChannelSpecConfigParser::parseChannelConfig method
+  OutputChannelSpecConfigParser p;
+  ChannelSpecHelpers::parseChannelConfig("name=foo", p);
+  BOOST_REQUIRE_EQUAL(p.specs.size(), 1);
+  BOOST_REQUIRE_EQUAL(p.specs.back().name, "foo");
+
+  OutputChannelSpecConfigParser p2;
+  ChannelSpecHelpers::parseChannelConfig("foo:", p2);
+  BOOST_REQUIRE_EQUAL(p2.specs.size(), 1);
+  BOOST_REQUIRE_EQUAL(p2.specs.back().name, "foo");
+
+  OutputChannelSpecConfigParser p3;
+  ChannelSpecHelpers::parseChannelConfig("name=foo,method=bind,type=pub", p3);
+  BOOST_REQUIRE_EQUAL(p3.specs.size(), 1);
+  BOOST_REQUIRE_EQUAL(p3.specs.back().name, "foo");
+  BOOST_REQUIRE_EQUAL(p3.specs.back().method, ChannelMethod::Bind);
+  BOOST_REQUIRE_EQUAL(p3.specs.back().type, ChannelType::Pub);
+
+  // Check the case for a channel with a protocol TPC
+  OutputChannelSpecConfigParser p4;
+  ChannelSpecHelpers::parseChannelConfig("name=foo,method=connect,type=sub,address=tcp://127.0.0.2:8080", p4);
+  BOOST_REQUIRE_EQUAL(p4.specs.size(), 1);
+  BOOST_REQUIRE_EQUAL(p4.specs.back().name, "foo");
+  BOOST_REQUIRE(p4.specs.back().method == ChannelMethod::Connect);
+  BOOST_REQUIRE(p4.specs.back().type == ChannelType::Sub);
+  BOOST_REQUIRE_EQUAL(p4.specs.back().hostname, "127.0.0.2");
+  BOOST_REQUIRE_EQUAL(p4.specs.back().port, 8080);
+  BOOST_REQUIRE(p4.specs.back().protocol == ChannelProtocol::Network);
+
+  // Check the case for a channel with a protocol IPC
+  OutputChannelSpecConfigParser p5;
+  ChannelSpecHelpers::parseChannelConfig("name=foo,method=connect,type=sub,address=ipc://@some_ipc_file_8080", p5);
+  BOOST_REQUIRE_EQUAL(p5.specs.size(), 1);
+  BOOST_REQUIRE_EQUAL(p5.specs.back().name, "foo");
+  BOOST_REQUIRE(p5.specs.back().method == ChannelMethod::Connect);
+  BOOST_REQUIRE(p5.specs.back().type == ChannelType::Sub);
+  BOOST_REQUIRE_EQUAL(p5.specs.back().hostname, "@some_ipc_file_8080");
+  BOOST_REQUIRE_EQUAL(p5.specs.back().port, 0);
+  BOOST_REQUIRE(p5.specs.back().protocol == ChannelProtocol::IPC);
 }


### PR DESCRIPTION
Now include parser which allows for creating a new set of `OutputChannelSpec`s. From a a provided --channel-config option string.