### PR TITLE
DPL: automatically subscribe the ccdbBackend to the correct clock

### DIFF
--- a/DataFormats/Headers/include/Headers/STFHeader.h
+++ b/DataFormats/Headers/include/Headers/STFHeader.h
@@ -22,6 +22,7 @@ struct STFHeader { // fake header to mimic DD SubTimeFrame::Header sent with DIS
   uint64_t id = uint64_t(-1);
   uint32_t firstOrbit = uint32_t(-1);
   std::uint32_t runNumber = 0;
+  [[nodiscard]] size_t size() const { return sizeof(STFHeader); }
 
   std::string asString();
 };

--- a/Framework/Core/include/Framework/CallbackService.h
+++ b/Framework/Core/include/Framework/CallbackService.h
@@ -27,7 +27,7 @@ namespace o2::framework
 {
 
 struct ConcreteDataMatcher;
-class EndOfStreamContext;
+struct EndOfStreamContext;
 
 // A service that data processors can register callback functions invoked by the
 // framework at defined steps in the process flow

--- a/Framework/Core/include/Framework/CommonServices.h
+++ b/Framework/Core/include/Framework/CommonServices.h
@@ -31,7 +31,7 @@ struct CommonServices {
   template <typename I, typename T>
   static ServiceInit simpleServiceInit()
   {
-    return [](ServiceRegistry&, DeviceState&, fair::mq::ProgOptions& options) -> ServiceHandle {
+    return [](ServiceRegistry&, DeviceState&, fair::mq::ProgOptions&) -> ServiceHandle {
       return ServiceHandle{TypeIdHelpers::uniqueId<I>(), new T, ServiceKind::Serial, typeid(T).name()};
     };
   }
@@ -40,7 +40,7 @@ struct CommonServices {
   template <typename I, typename T>
   static ServiceInit singletonServiceInit()
   {
-    return [](ServiceRegistry&, DeviceState&, fair::mq::ProgOptions& options) -> ServiceHandle {
+    return [](ServiceRegistry&, DeviceState&, fair::mq::ProgOptions&) -> ServiceHandle {
       return ServiceHandle{TypeIdHelpers::uniqueId<I>(), T::instance(), ServiceKind::Serial, typeid(T).name()};
     };
   }
@@ -69,6 +69,7 @@ struct CommonServices {
   static ServiceSpec dataProcessingStats();
   static ServiceSpec objectCache();
   static ServiceSpec timingInfoSpec();
+  static ServiceSpec ccdbSupportSpec();
 
   static std::vector<ServiceSpec> defaultServices(int numWorkers = 0);
   static std::vector<ServiceSpec> requiredServices();

--- a/Framework/Core/src/DataAllocator.cxx
+++ b/Framework/Core/src/DataAllocator.cxx
@@ -121,7 +121,7 @@ void DataAllocator::addPartToContext(FairMQMessagePtr&& payloadMessage, const Ou
   // FIXME: this is kind of ugly, we know that we can change the content of the
   // header message because we have just created it, but the API declares it const
   const DataHeader* cdh = o2::header::get<DataHeader*>(headerMessage->GetData());
-  DataHeader* dh = const_cast<DataHeader*>(cdh);
+  auto* dh = const_cast<DataHeader*>(cdh);
   dh->payloadSize = payloadMessage->GetSize();
   auto& context = mRegistry->get<MessageContext>();
   // make_scoped creates the context object inside of a scope handler, since it goes out of

--- a/Framework/Core/src/DataSender.cxx
+++ b/Framework/Core/src/DataSender.cxx
@@ -71,13 +71,13 @@ DataSender::DataSender(ServiceRegistry& registry,
 
 std::unique_ptr<FairMQMessage> DataSender::create()
 {
-  FairMQDevice* device = (FairMQDevice*)mContext;
+  auto* device = (FairMQDevice*)mContext;
   return device->NewMessage();
 }
 
 void DataSender::send(FairMQParts& parts, std::string const& channel)
 {
-  FairMQDevice* device = (FairMQDevice*)mContext;
+  auto* device = (FairMQDevice*)mContext;
   mPolicy.send(*device, parts, channel);
 }
 

--- a/Framework/Core/src/SendingPolicy.cxx
+++ b/Framework/Core/src/SendingPolicy.cxx
@@ -11,6 +11,9 @@
 
 #include "Framework/SendingPolicy.h"
 #include "Framework/DeviceSpec.h"
+#include "Framework/DataRefUtils.h"
+#include "Framework/DataProcessingHeader.h"
+#include "Headers/STFHeader.h"
 #include "DeviceSpecHelpers.h"
 #include <fairmq/Device.h>
 
@@ -23,11 +26,11 @@ std::vector<SendingPolicy> SendingPolicy::createDefaultPolicies()
 {
   return {SendingPolicy{
             .name = "dispatcher",
-            .matcher = [](DeviceSpec const& spec, ConfigContext const& ctx) { return spec.name == "Dispatcher" || DeviceSpecHelpers::hasLabel(spec, "Dispatcher"); },
+            .matcher = [](DeviceSpec const& spec, ConfigContext const&) { return spec.name == "Dispatcher" || DeviceSpecHelpers::hasLabel(spec, "Dispatcher"); },
             .send = [](FairMQDevice& device, FairMQParts& parts, std::string const& channel) { device.Send(parts, channel, 0, -1); }},
           SendingPolicy{
             .name = "default",
-            .matcher = [](DeviceSpec const& spec, ConfigContext const& ctx) { return true; },
+            .matcher = [](DeviceSpec const&, ConfigContext const&) { return true; },
             .send = [](FairMQDevice& device, FairMQParts& parts, std::string const& channel) { device.Send(parts, channel, 0); }}};
 }
 } // namespace o2::framework


### PR DESCRIPTION
* If someone provides the DISTSUBTIMEFRAME message, use it
* If someone provides the analogous for analysis, use it
* If someone requires a timer (and only a timer) use the timer.
* If no one provides the DISTSUBTIMEFRAME message, add it to the
  first device which only gets an enumeration.