### PR TITLE
Optionally use ITS/MFT NoiseMap to mask chips in digitization

### DIFF
--- a/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/ChipDigitsContainer.h
+++ b/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/ChipDigitsContainer.h
@@ -63,8 +63,12 @@ class ChipDigitsContainer
     return static_cast<UInt_t>(key >> (8 * sizeof(UInt_t)));
   }
 
+  bool isDisabled() const { return mDisabled; }
+  void disable(bool v) { mDisabled = v; }
+
  protected:
   UShort_t mChipIndex = 0;                           ///< chip index
+  bool mDisabled = false;
   std::map<ULong64_t, o2::itsmft::PreDigit> mDigits; ///< Map of fired pixels, possibly in multiple frames
 
   ClassDefNV(ChipDigitsContainer, 1);

--- a/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/DPLDigitizerParam.h
+++ b/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/DPLDigitizerParam.h
@@ -46,6 +46,8 @@ struct DPLDigitizerParam : public o2::conf::ConfigurableParamHelper<DPLDigitizer
   float IBVbb = 3.0; ///< back bias absolute value for ITS Inner Barrel (in Volt)
   float OBVbb = 3.0; ///< back bias absolute value for ITS Outter Barrel (in Volt)
 
+  std::string noiseFilePath{}; ///< optional noise masks file path. FIXME to be removed once switch to CCDBFetcher
+
   // boilerplate stuff + make principal key
   O2ParamDef(DPLDigitizerParam, getParamName().data());
 

--- a/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Digitizer.h
+++ b/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Digitizer.h
@@ -27,6 +27,7 @@
 #include "ITSMFTSimulation/Hit.h"
 #include "ITSMFTBase/GeometryTGeo.h"
 #include "DataFormatsITSMFT/Digit.h"
+#include "DataFormatsITSMFT/NoiseMap.h"
 #include "DataFormatsITSMFT/ROFRecord.h"
 #include "CommonDataFormat/InteractionRecord.h"
 #include "SimulationDataFormat/MCCompLabel.h"
@@ -55,9 +56,9 @@ class Digitizer : public TObject
   void setDigits(std::vector<o2::itsmft::Digit>* dig) { mDigits = dig; }
   void setMCLabels(o2::dataformats::MCTruthContainer<o2::MCCompLabel>* mclb) { mMCLabels = mclb; }
   void setROFRecords(std::vector<o2::itsmft::ROFRecord>* rec) { mROFRecords = rec; }
-
   o2::itsmft::DigiParams& getParams() { return (o2::itsmft::DigiParams&)mParams; }
   const o2::itsmft::DigiParams& getParams() const { return mParams; }
+  void setNoiseMap(const o2::itsmft::NoiseMap* mp);
 
   void init();
 
@@ -134,6 +135,7 @@ class Digitizer : public TObject
   std::vector<o2::itsmft::Digit>* mDigits = nullptr;                       //! output digits
   std::vector<o2::itsmft::ROFRecord>* mROFRecords = nullptr;               //! output ROF records
   o2::dataformats::MCTruthContainer<o2::MCCompLabel>* mMCLabels = nullptr; //! output labels
+  const o2::itsmft::NoiseMap* mNoiseMap = nullptr;
 
   ClassDefOverride(Digitizer, 2);
 };

--- a/Detectors/ITSMFT/common/simulation/src/Digitizer.cxx
+++ b/Detectors/ITSMFT/common/simulation/src/Digitizer.cxx
@@ -181,6 +181,9 @@ void Digitizer::fillOutputContainer(uint32_t frameLast)
 
     auto& extra = *(mExtraBuff.front().get());
     for (auto& chip : mChips) {
+      if (chip.isDisabled()) {
+        continue;
+      }
       chip.addNoise(mROFrameMin, mROFrameMin, &mParams);
       auto& buffer = chip.getPreDigits();
       if (buffer.empty()) {
@@ -228,6 +231,12 @@ void Digitizer::fillOutputContainer(uint32_t frameLast)
 void Digitizer::processHit(const o2::itsmft::Hit& hit, uint32_t& maxFr, int evID, int srcID)
 {
   // convert single hit to digits
+  int chipID = hit.GetDetectorID();
+  auto& chip = mChips[chipID];
+  if (chip.isDisabled()) {
+    LOG(info) << "skip disabled chip " << chipID;
+    return;
+  }
   float timeInROF = hit.GetTime() * sec2ns;
   if (timeInROF > 20e3) {
     const int maxWarn = 10;
@@ -323,7 +332,6 @@ void Digitizer::processHit(const o2::itsmft::Hit& hit, uint32_t& maxFr, int evID
   int rowPrev = -1, colPrev = -1, row, col;
   float cRowPix = 0.f, cColPix = 0.f; // local coordinated of the current pixel center
 
-  int chipID = hit.GetDetectorID();
   const o2::itsmft::AlpideSimResponse* resp = getChipResponse(chipID);
 
   // take into account that the AlpideSimResponse depth defintion has different min/max boundaries
@@ -369,7 +377,6 @@ void Digitizer::processHit(const o2::itsmft::Hit& hit, uint32_t& maxFr, int evID
 
   // fire the pixels assuming Poisson(n_response_electrons)
   o2::MCCompLabel lbl(hit.GetTrackID(), evID, srcID, false);
-  auto& chip = mChips[chipID];
   auto roFrameAbs = mNewROFrame + roFrameRel;
   for (int irow = rowSpan; irow--;) {
     uint16_t rowIS = irow + rowS;
@@ -441,4 +448,13 @@ void Digitizer::registerDigits(ChipDigitsContainer& chip, uint32_t roFrame, floa
       extra->emplace_back(lbl);
     }
   }
+}
+
+//________________________________________________________________________________
+void Digitizer::setNoiseMap(const o2::itsmft::NoiseMap* mp)
+{
+  for (int i = 0; i < mNumberOfChips; i++) {
+    mChips[i].disable(mp->isFullChipMasked(i));
+  }
+  mNoiseMap = mp;
 }

--- a/Detectors/ITSMFT/common/simulation/src/Digitizer.cxx
+++ b/Detectors/ITSMFT/common/simulation/src/Digitizer.cxx
@@ -234,7 +234,7 @@ void Digitizer::processHit(const o2::itsmft::Hit& hit, uint32_t& maxFr, int evID
   int chipID = hit.GetDetectorID();
   auto& chip = mChips[chipID];
   if (chip.isDisabled()) {
-    LOG(info) << "skip disabled chip " << chipID;
+    LOG(debug) << "skip disabled chip " << chipID;
     return;
   }
   float timeInROF = hit.GetTime() * sec2ns;


### PR DESCRIPTION
If the file ITSNoiseMap.root (MFTNosieMap.root) is found on the path `o2::itsmft::DPLDigitizerParam<DETID>.noiseFilePath`,
then it will be used to avoid digitization in the chips which have `map.isFullChipMasked(i) == true`.