### PR TITLE
Add separate option to enable PROCESS_REPORTING, so that we do not have to fake-set DDS_SESSION_ID, which can have side effects

### DIFF
--- a/Framework/Core/src/CallbacksPolicy.cxx
+++ b/Framework/Core/src/CallbacksPolicy.cxx
@@ -27,7 +27,9 @@ CallbacksPolicy epnProcessReporting()
   return {
     .matcher = [](DeviceSpec const&, ConfigContext const& context) -> bool {
       /// FIXME:
-      return getenv("DDS_SESSION_ID") != nullptr; },
+      static bool report = getenv("DDS_SESSION_ID") != nullptr || getenv("DPL_REPORT_PROCESSING") != nullptr;
+      return report;
+    },
     .policy = [](CallbackService& callbacks, InitContext& context) -> void {
       callbacks.set(CallbackService::Id::PreProcessing, [](ServiceRegistry& registry, int op) {
         auto& info = registry.get<TimingInfo>();


### PR DESCRIPTION
@ktf @shahor02 : I don't really like abusing the DDS_SESSION_ID to enable this reporting.
This PR adds a second env variable which can be used, which is in my opinion much cleaner. @ktf can comment if he prefers a different name. (Also caching the check in a static bool now to avoid checking the environment every time).