### PR TITLE
DPL: allow custom tracing flags via commandline

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -64,6 +64,7 @@ o2_add_library(Framework
                        src/DeviceSpec.cxx
                        src/DeviceController.cxx
                        src/DeviceSpecHelpers.cxx
+                       src/DeviceStateHelpers.cxx
                        src/DPLMonitoringBackend.cxx
                        src/DriverControl.cxx
                        src/DriverClient.cxx
@@ -186,6 +187,7 @@ foreach(t
         DeviceMetricsInfo
         DeviceSpec
         DeviceSpecHelpers
+        DeviceStateHelpers
         Expressions
         ExternalFairMQDeviceProxy
         FairMQOptionsRetriever

--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -1483,6 +1483,7 @@ boost::program_options::options_description DeviceSpecHelpers::getForwardedDevic
     ("monitoring-backend", bpo::value<std::string>(), "monitoring connection string")                                                                                //
     ("infologger-mode", bpo::value<std::string>(), "O2_INFOLOGGER_MODE override")                                                                                    //
     ("infologger-severity", bpo::value<std::string>(), "minimun FairLogger severity which goes to info logger")                                                      //
+    ("dpl-tracing-flags", bpo::value<std::string>(), "pipe separated list of events to trace")                                                                       //
     ("child-driver", bpo::value<std::string>(), "external driver to start childs with (e.g. valgrind)");                                                             //
 
   return forwardedDeviceOptions;

--- a/Framework/Core/src/DeviceStateHelpers.cxx
+++ b/Framework/Core/src/DeviceStateHelpers.cxx
@@ -1,0 +1,92 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "DeviceStateHelpers.h"
+#include "Framework/DeviceState.h"
+#include <string_view>
+#include <cstring>
+
+namespace o2::framework
+{
+
+DeviceState::LoopReason loopReasonFromString(std::string_view reason)
+{
+  if (reason == "NO_REASON") {
+    return DeviceState::LoopReason::NO_REASON;
+  } else if (reason == "METRICS_MUST_FLUSH") {
+    return DeviceState::LoopReason::METRICS_MUST_FLUSH;
+  } else if (reason == "SIGNAL_ARRIVED") {
+    return DeviceState::LoopReason::SIGNAL_ARRIVED;
+  } else if (reason == "DATA_SOCKET_POLLED") {
+    return DeviceState::LoopReason::DATA_SOCKET_POLLED;
+  } else if (reason == "DATA_INCOMING") {
+    return DeviceState::LoopReason::DATA_INCOMING;
+  } else if (reason == "DATA_OUTGOING") {
+    return DeviceState::LoopReason::DATA_OUTGOING;
+  } else if (reason == "WS_COMMUNICATION") {
+    return DeviceState::LoopReason::WS_COMMUNICATION;
+  } else if (reason == "TIMER_EXPIRED") {
+    return DeviceState::LoopReason::TIMER_EXPIRED;
+  } else if (reason == "WS_CONNECTED") {
+    return DeviceState::LoopReason::WS_CONNECTED;
+  } else if (reason == "WS_CLOSING") {
+    return DeviceState::LoopReason::WS_CLOSING;
+  } else if (reason == "WS_READING") {
+    return DeviceState::LoopReason::WS_READING;
+  } else if (reason == "WS_WRITING") {
+    return DeviceState::LoopReason::WS_WRITING;
+  } else if (reason == "ASYNC_NOTIFICATION") {
+    return DeviceState::LoopReason::ASYNC_NOTIFICATION;
+  } else if (reason == "OOB_ACTIVITY") {
+    return DeviceState::LoopReason::OOB_ACTIVITY;
+  } else if (reason == "UNKNOWN") {
+    return DeviceState::LoopReason::UNKNOWN;
+  } else if (reason == "FIRST_LOOP") {
+    return DeviceState::LoopReason::FIRST_LOOP;
+  } else if (reason == "NEW_STATE_PENDING") {
+    return DeviceState::LoopReason::NEW_STATE_PENDING;
+  } else if (reason == "PREVIOUSLY_ACTIVE") {
+    return DeviceState::LoopReason::PREVIOUSLY_ACTIVE;
+  } else if (reason == "TRACE_CALLBACKS") {
+    return DeviceState::LoopReason::TRACE_CALLBACKS;
+  } else if (reason == "TRACE_USERCODE") {
+    return DeviceState::LoopReason::TRACE_USERCODE;
+  } else {
+    return DeviceState::LoopReason::UNKNOWN;
+  }
+}
+
+int DeviceStateHelpers::parseTracingFlags(std::string const& s)
+{
+  // split string by pipe and convert to int based
+  // on the LoopReason enum
+  std::vector<std::string_view> tokens;
+  char const* first = s.c_str();
+  char const* last = s.c_str();
+
+  while (true) {
+    char const* next = std::strchr(last, '|');
+    if (next) {
+      tokens.emplace_back(first, next - first);
+      first = next + 1;
+      last = first;
+    } else {
+      tokens.emplace_back(first, s.size() - (first - s.c_str()));
+      break;
+    }
+  }
+  int ret = 0;
+  for (auto const& token : tokens) {
+    ret |= static_cast<int>(loopReasonFromString(token));
+  }
+  return ret;
+}
+} // namespace o2::framework

--- a/Framework/Core/src/DeviceStateHelpers.h
+++ b/Framework/Core/src/DeviceStateHelpers.h
@@ -1,0 +1,28 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef O2_FRAMEWORK_DEVICESTATEHELPERS_H_
+#define O2_FRAMEWORK_DEVICESTATEHELPERS_H_
+
+#include <string>
+
+namespace o2::framework
+{
+struct DeviceStateHelpers {
+  /// @return a mask of DeviceState::LoopReason from
+  /// a string of | separated LoopReason names.
+  /// @example "METRICS_MUST_FLUSH|DATA_SOCKET_POLLED"
+  /// This will be eventually used to initialise the initial value of
+  /// DeviceState::traceFlags.
+  static int parseTracingFlags(std::string const& events);
+};
+
+} // namespace o2::framework
+#endif // O2_FRAMEWORK_DEVICESTATEHELPERS_H_

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -29,6 +29,7 @@
 #include "Framework/DeviceConfigInfo.h"
 #include "Framework/DeviceSpec.h"
 #include "Framework/DeviceState.h"
+#include "DeviceStateHelpers.h"
 #include "Framework/DevicesManager.h"
 #include "Framework/DebugGUI.h"
 #include "Framework/LocalRootFileService.h"
@@ -1027,6 +1028,7 @@ int doChild(int argc, char** argv, ServiceRegistry& serviceRegistry,
     optsDesc.add_options()("monitoring-backend", bpo::value<std::string>()->default_value("default"), "monitoring backend info")                                                           //
       ("driver-client-backend", bpo::value<std::string>()->default_value(defaultDriverClient), "backend for device -> driver communicataon: stdout://: use stdout, ws://: use websockets") //
       ("infologger-severity", bpo::value<std::string>()->default_value(""), "minimum FairLogger severity to send to InfoLogger")                                                           //
+      ("dpl-tracing-flags", bpo::value<std::string>()->default_value(""), "pipe `|` separate list of events to be traced")                                                                 //
       ("expected-region-callbacks", bpo::value<std::string>()->default_value("0"), "how many region callbacks we are expecting")                                                           //
       ("exit-transition-timeout", bpo::value<std::string>()->default_value(defaultExitTransitionTimeout), "how many second to wait before switching from RUN to READY")                    //
       ("timeframes-rate-limit", bpo::value<std::string>()->default_value("0"), "how many timeframe can be in fly at the same moment (0 disables)")                                         //
@@ -1055,6 +1057,7 @@ int doChild(int argc, char** argv, ServiceRegistry& serviceRegistry,
 
     deviceState = std::make_unique<DeviceState>();
     deviceState->loop = loop;
+    deviceState->tracingFlags = DeviceStateHelpers::parseTracingFlags(r.fConfig.GetPropertyAsString("dpl-tracing-flags"));
     serviceRegistry.registerService(ServiceRegistryHelpers::handleForService<DeviceState>(deviceState.get()));
 
     quotaEvaluator = std::make_unique<ComputingQuotaEvaluator>(uv_now(loop));
@@ -1646,6 +1649,14 @@ int runStateMachine(DataProcessorSpecs const& workflow,
       case DriverState::MERGE_CONFIGS: {
         try {
           controls.resize(runningWorkflow.devices.size());
+          /// Set the default value for tracingFlags of each control
+          /// to the command line value --dpl-tracing-flags
+          if (varmap.count("dpl-tracing-flags")) {
+            for (auto& control : controls) {
+              auto tracingFlags = DeviceStateHelpers::parseTracingFlags(varmap["dpl-tracing-flags"].as<std::string>());
+              control.tracingFlags = tracingFlags;
+            }
+          }
           deviceExecutions.resize(runningWorkflow.devices.size());
 
           // Options  which should be uniform across all

--- a/Framework/Core/test/test_DeviceStateHelpers.cxx
+++ b/Framework/Core/test/test_DeviceStateHelpers.cxx
@@ -1,0 +1,25 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#define BOOST_TEST_MODULE Test Framework DeviceSpec
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+#include "../src/DeviceStateHelpers.h"
+#include "Framework/DeviceState.h"
+
+BOOST_AUTO_TEST_CASE(TestDeviceStateHelpers)
+{
+  using namespace o2::framework;
+  BOOST_CHECK(DeviceStateHelpers::parseTracingFlags("WS_COMMUNICATION") == DeviceState::LoopReason::WS_COMMUNICATION);
+  BOOST_CHECK(DeviceStateHelpers::parseTracingFlags("WS_CONNECTED|WS_COMMUNICATION") == (DeviceState::LoopReason::WS_CONNECTED | DeviceState::LoopReason::WS_COMMUNICATION));
+  BOOST_CHECK(DeviceStateHelpers::parseTracingFlags("ABOBODABO") == DeviceState::LoopReason::UNKNOWN);
+}


### PR DESCRIPTION
This allows you to define the starting values for the traced events from the command-line, avoiding one go via the GUI.