### PR TITLE
Introduce flag to run FST in in batch mode

### DIFF
--- a/prodtests/full-system-test/start_tmux.sh
+++ b/prodtests/full-system-test/start_tmux.sh
@@ -49,15 +49,9 @@ if [ "0$FST_TMUX_KILLCHAINS" == "01" ]; then
 fi
 
 if [ "0$FST_TMUX_LOGPREFIX" != "0" ]; then
-  if [ "0$FST_TMUX_BATCH_MODE" == "01" ]; then
-    LOGCMD0=" &> ${FST_TMUX_LOGPREFIX}_0.log"
-    LOGCMD1=" &> ${FST_TMUX_LOGPREFIX}_1.log"
-    LOGCMD2=" &> ${FST_TMUX_LOGPREFIX}_2.log"
-  else
-    LOGCMD0=" |& tee ${FST_TMUX_LOGPREFIX}_0.log"
-    LOGCMD1=" |& tee ${FST_TMUX_LOGPREFIX}_1.log"
-    LOGCMD2=" |& tee ${FST_TMUX_LOGPREFIX}_2.log"
-  fi
+  LOGCMD0=" &> ${FST_TMUX_LOGPREFIX}_0.log"
+  LOGCMD1=" &> ${FST_TMUX_LOGPREFIX}_1.log"
+  LOGCMD2=" &> ${FST_TMUX_LOGPREFIX}_2.log"
 fi
 
 FST_SLEEP0=0

--- a/prodtests/full-system-test/start_tmux.sh
+++ b/prodtests/full-system-test/start_tmux.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "0$1" == "0" ]; then
+if [ "0$1" != "0dd" ] && [ "0$1" != "0rr" ]; then
   echo Please indicate whether to start with raw-reader [rr] or with DataDistribution [dd]
   exit 1
 fi
@@ -49,8 +49,15 @@ if [ "0$FST_TMUX_KILLCHAINS" == "01" ]; then
 fi
 
 if [ "0$FST_TMUX_LOGPREFIX" != "0" ]; then
-  LOGCMD0=" &> ${FST_TMUX_LOGPREFIX}_0.log"
-  LOGCMD1=" &> ${FST_TMUX_LOGPREFIX}_1.log"
+  if [ "0$FST_TMUX_BATCH_MODE" == "01" ]; then
+    LOGCMD0=" &> ${FST_TMUX_LOGPREFIX}_0.log"
+    LOGCMD1=" &> ${FST_TMUX_LOGPREFIX}_1.log"
+    LOGCMD2=" &> ${FST_TMUX_LOGPREFIX}_2.log"
+  else
+    LOGCMD0=" |& tee ${FST_TMUX_LOGPREFIX}_0.log"
+    LOGCMD1=" |& tee ${FST_TMUX_LOGPREFIX}_1.log"
+    LOGCMD2=" |& tee ${FST_TMUX_LOGPREFIX}_2.log"
+  fi
 fi
 
 FST_SLEEP0=0
@@ -68,8 +75,15 @@ else
   FST_SLEEP2=30
 fi
 
-tmux -L FST \
+if [ "0$FST_TMUX_BATCH_MODE" == "01" ]; then
+  { sleep $FST_SLEEP0; eval "NUMAID=0 $MYDIR/dpl-workflow.sh $LOGCMD0"; eval "$ENDCMD"; } &
+  { sleep $FST_SLEEP1; eval "NUMAID=1 $MYDIR/dpl-workflow.sh $LOGCMD1"; eval "$ENDCMD"; } &
+  { sleep $FST_SLEEP2; eval "SEVERITY=debug numactl --interleave=all $MYDIR/$CMD $LOGCMD2"; eval "$KILLCMD $ENDCMD"; } &
+  wait
+else
+  tmux -L FST \
     new-session  "sleep $FST_SLEEP0; NUMAID=0 $MYDIR/dpl-workflow.sh $LOGCMD0; $ENDCMD" \; \
     split-window "sleep $FST_SLEEP1; NUMAID=1 $MYDIR/dpl-workflow.sh $LOGCMD1; $ENDCMD" \; \
     split-window "sleep $FST_SLEEP2; SEVERITY=debug numactl --interleave=all $MYDIR/$CMD; $KILLCMD $ENDCMD" \; \
     select-layout even-vertical
+fi


### PR DESCRIPTION
Allow to run FST unattended by setting FST_TMUX_BATCH_MODE=1. Runs quietly if logging is enabled.
Additionally: 
  - improved logging in TMUX mode by showing output and logging to file simultaneously.
  - explicitly check cmd line parameters

Tested locally and via ssh. Somehow only works if a tty is allocated, otherwise only one numa domain starts but I don't see how this is caused by this script.