### PR TITLE
[DPL Analysis] [Event mixing] Introducing Binning Policy for block combinations

### DIFF
--- a/Framework/Core/include/Framework/ASoAHelpers.h
+++ b/Framework/Core/include/Framework/ASoAHelpers.h
@@ -174,12 +174,12 @@ std::vector<std::pair<uint64_t, uint64_t>> doGroupTable(const T& table, const Bi
     auto chunks = o2::framework::binning_helpers::getChunks(arrowTable, binningColumns, ci);
     auto chunkLength = std::get<0>(chunks)->length();
     // TODO: Are such checks needed or can we safely assume chunks are always the same?
-    constexpr auto cn = binningPolicy.mColumnsCount - 1;
-    for_<cn>([&chunks, &chunkLength](auto i) {
-      if (std::get<i.value + 1>(chunks)->length() != chunkLength) {
-        throw o2::framework::runtime_error("Combinations: data size varies between selected columns");
-      }
-    });
+    //constexpr auto cn = binningPolicy.mColumnsCount - 1;
+    //for_<cn>([&chunks, &chunkLength](auto i) {
+    //  if (std::get<i.value + 1>(chunks)->length() != chunkLength) {
+    //    throw o2::framework::runtime_error("Combinations: data size varies between selected columns");
+    //  }
+    //});
 
     if constexpr (soa::is_soa_filtered_t<T>::value) {
       if (selectedRows[ind] >= selInd + chunkLength) {

--- a/Framework/Core/include/Framework/ASoAHelpers.h
+++ b/Framework/Core/include/Framework/ASoAHelpers.h
@@ -96,7 +96,8 @@ std::vector<std::pair<uint64_t, uint64_t>> groupTable(const T& table, const Binn
     auto chunks = o2::framework::binning_helpers::getChunks(arrowTable, binningColumns, ci);
     auto chunkLength = std::get<0>(chunks)->length();
     // TODO: Are such checks needed or can we safely assume chunks are always the same?
-    for_<binningPolicy.mColumnsCount - 1>([&chunks, &chunkLength](auto i) {
+    constexpr auto cn = binningPolicy.mColumnsCount - 1;
+    for_<cn>([&chunks, &chunkLength](auto i) {
       if (std::get<i.value + 1>(chunks)->length() != chunkLength) {
         throw o2::framework::runtime_error("Combinations: data size varies between selected columns");
       }

--- a/Framework/Core/include/Framework/ASoAHelpers.h
+++ b/Framework/Core/include/Framework/ASoAHelpers.h
@@ -82,7 +82,8 @@ std::vector<std::pair<uint64_t, uint64_t>> groupTable(const T& table, const Binn
     selectedRows = table.getSelectedRows(); // vector<int64_t>
   }
 
-  auto arrowColumns = binning_arrow_helpers::getArrowColumns(arrowTable);
+  auto binningColumns = binningPolicy.getColumns();
+  auto arrowColumns = o2::framework::binning_helpers::getArrowColumns(arrowTable, binningColumns);
   auto chunksCount = arrowColumns[0]->num_chunks();
   // TODO: Are such checks needed or can we safely assume chunks are always the same?
   for (int i = 1; i < binningPolicy.mColumnsCount; i++) {
@@ -92,7 +93,7 @@ std::vector<std::pair<uint64_t, uint64_t>> groupTable(const T& table, const Binn
   }
 
   for (uint64_t ci = 0; ci < chunksCount; ++ci) {
-    auto chunks = binning_arrow_helpers::getChunks(arrowTable, ci);
+    auto chunks = o2::framework::binning_helpers::getChunks(arrowTable, binningColumns, ci);
     auto chunkLength = std::get<0>(chunks)->length();
     // TODO: Are such checks needed or can we safely assume chunks are always the same?
     for_<binningPolicy.mColumnsCount - 1>([&chunks, &chunkLength](auto i) {
@@ -115,7 +116,7 @@ std::vector<std::pair<uint64_t, uint64_t>> groupTable(const T& table, const Binn
         selInd = selectedRows[ind];
       }
 
-      auto rowData = binning_arrow_helpers::getRowData(arrowTable, ci, ai);
+      auto rowData = o2::framework::binning_helpers::getRowData(arrowTable, binningColumns, ci, ai);
       int val = binningPolicy.getBin(rowData);
       if (val != outsider) {
         groupedIndices.emplace_back(val, ind);

--- a/Framework/Core/include/Framework/ASoAHelpers.h
+++ b/Framework/Core/include/Framework/ASoAHelpers.h
@@ -525,7 +525,7 @@ struct CombinationsBlockUpperIndexPolicy : public CombinationsBlockIndexPolicyBa
   }
   void setTables(Ts&&... tables)
   {
-    CombinationsBlockIndexPolicyBase<T, Ts...>::setTables(std::forward<Ts>(tables)...);
+    CombinationsBlockIndexPolicyBase<BinningPolicy, T, Ts...>::setTables(std::forward<Ts>(tables)...);
     setRanges();
   }
 
@@ -638,7 +638,7 @@ struct CombinationsBlockFullIndexPolicy : public CombinationsBlockIndexPolicyBas
   }
   void setTables(Ts&&... tables)
   {
-    CombinationsBlockIndexPolicyBase<T, Ts...>::setTables(std::forward<Ts>(tables)...);
+    CombinationsBlockIndexPolicyBase<BinningPolicy, T, Ts...>::setTables(std::forward<Ts>(tables)...);
     setRanges();
   }
 
@@ -756,7 +756,7 @@ struct CombinationsBlockSameIndexPolicyBase : public CombinationsIndexPolicyBase
       setRanges(table);
     }
   }
-  CombinationsBlockSameIndexPolicyBase(const BinningPolicy& binningPolicy, int categoryNeighbours, const T1& outsider, int minWindowSize, T&& table, Ts&&... tables) : CombinationsIndexPolicyBase<BinningPolicy, T, Ts...>(std::forward<T>(table), std::forward<Ts>(tables)...), mSlidingWindowSize(categoryNeighbours + 1), mBinningPolicy(binningPolicy), mCategoryNeighbours(categoryNeighbours), mOutsider(outsider), mMinWindowSize(minWindowSize)
+  CombinationsBlockSameIndexPolicyBase(const BinningPolicy& binningPolicy, int categoryNeighbours, const T1& outsider, int minWindowSize, T&& table, Ts&&... tables) : CombinationsIndexPolicyBase<T, Ts...>(std::forward<T>(table), std::forward<Ts>(tables)...), mSlidingWindowSize(categoryNeighbours + 1), mBinningPolicy(binningPolicy), mCategoryNeighbours(categoryNeighbours), mOutsider(outsider), mMinWindowSize(minWindowSize)
   {
     if (!this->mIsEnd) {
       setRanges();
@@ -849,7 +849,7 @@ struct CombinationsBlockUpperSameIndexPolicy : public CombinationsBlockSameIndex
   }
   void setTables(Ts&&... tables)
   {
-    CombinationsBlockSameIndexPolicyBase<T1, Ts...>::setTables(std::forward<Ts>(tables)...);
+    CombinationsBlockSameIndexPolicyBase<BinningPolicy, T1, Ts...>::setTables(std::forward<Ts>(tables)...);
     setRanges();
   }
 
@@ -932,7 +932,7 @@ struct CombinationsBlockStrictlyUpperSameIndexPolicy : public CombinationsBlockS
     }
   }
 
-  CombinationsBlockStrictlyUpperSameIndexPolicy(const BinningPolicy& binningPolicy, int categoryNeighbours, const T1& outsider, Ts&&... tables) : CombinationsBlockSameIndexPolicyBase<BinningPolicy, T1, Ts...>(binningPolicy, categoryNeighbours, outsider, sizeof...(Ts) + 1, std::forward<Ts>(tables)...)
+  CombinationsBlockStrictlyUpperSameIndexPolicy(const BinningPolicy& binningPolicy, int categoryNeighbours, const T1& outsider, Ts&&... tables) : CombinationsBlockSameIndexPolicyBase<BinningPolicy, T1, Ts...>(binningPolicy, categoryNeighbours, outsider, sizeof...(Ts), std::forward<Ts>(tables)...)
   {
     if (!this->mIsEnd) {
       setRanges();
@@ -948,7 +948,7 @@ struct CombinationsBlockStrictlyUpperSameIndexPolicy : public CombinationsBlockS
   }
   void setTables(Ts&&... tables)
   {
-    CombinationsBlockSameIndexPolicyBase<T1, Ts...>::setTables(std::forward<Ts>(tables)...);
+    CombinationsBlockSameIndexPolicyBase<BinningPolicy, T1, Ts...>::setTables(std::forward<Ts>(tables)...);
     if (!this->mIsEnd) {
       setRanges();
     }
@@ -1049,7 +1049,7 @@ struct CombinationsBlockFullSameIndexPolicy : public CombinationsBlockSameIndexP
   }
   void setTables(Ts&&... tables)
   {
-    CombinationsBlockSameIndexPolicyBase<T1, Ts...>::setTables(std::forward<Ts>(tables)...);
+    CombinationsBlockSameIndexPolicyBase<BinningPolicy, T1, Ts...>::setTables(std::forward<Ts>(tables)...);
     setRanges();
   }
 

--- a/Framework/Core/include/Framework/BinningPolicy.h
+++ b/Framework/Core/include/Framework/BinningPolicy.h
@@ -95,13 +95,14 @@ struct SingleBinningPolicy : public BinningPolicyBase<C> {
       }
     }
 
-    for (unsigned int i = 2; i < xBins.size(); i++) {
+    unsigned int i = 2;
+    for (i; i < xBins.size(); i++) {
       if (val1 < xBins[i]) {
         return i - 1;
       }
     }
     // overflow
-    return this->mIgnoreOverflows ? -1 : xBins.size() - 1;
+    return this->mIgnoreOverflows ? -1 : i - 1;
   }
 
   using BinningPolicyBase<C>::getArrowColumns;
@@ -149,15 +150,16 @@ struct PairBinningPolicy : public BinningPolicyBase<C1, C2> {
       }
     }
 
-    for (unsigned int i = 2; i < xBins.size(); i++) {
+    unsigned int i = 2, j = 2;
+    for (i; i < xBins.size(); i++) {
       if (val1 < xBins[i]) {
-        for (unsigned int j = 2; j < yBins.size(); j++) {
+        for (j; j < yBins.size(); j++) {
           if (val2 < yBins[j]) {
-            return (i - 1) + (j - 1) * xBins.size();
+            return getBinAt(i, j);
           }
         }
         // overflow for yBins only
-        return this->mIgnoreOverflows ? -1 : (i - 1) + (yBins.size() - 1) * xBins.size();
+        return this->mIgnoreOverflows ? -1 : return getBinAt(i, j);
       }
     }
 
@@ -167,14 +169,14 @@ struct PairBinningPolicy : public BinningPolicyBase<C1, C2> {
     }
 
     // overflow for xBins only
-    for (int j = 1; j < yBins.size(); j++) {
+    for (j = 2; j < yBins.size(); j++) {
       if (val2 < yBins[j]) {
-        return (xBins.size() - 1) + (j - 1) * xBins.size();
+        return getBinAt(i, j);
       }
     }
 
     // overflow for both bins
-    return xBins.size() * yBins.size() - 1;
+    return getBinAt(i, j);
   }
 
   using BinningPolicyBase<C1, C2>::getArrowColumns;
@@ -183,6 +185,11 @@ struct PairBinningPolicy : public BinningPolicyBase<C1, C2> {
   using BinningPolicyBase<C1, C2>::getRowData;
 
  private:
+  int getBinAt(unsigned int i, unsigned int j)
+  {
+    return (i - 1) + (j - 1) * this->mBins[0].size();
+  }
+
   void expandConstantBinning(std::vector<double> const& xBins, std::vector<double> const& yBins)
   {
     if (xBins[0] != VARIABLE_WIDTH) {
@@ -240,11 +247,11 @@ struct TripleBinningPolicy : public BinningPolicyBase<C1, C2, C3> {
           if (val2 < yBins[j]) {
             for (k; k < zBins.size(); k++) {
               if (val3 < zBins[k]) {
-                return (i - 1) + (j - 1) * xBins.size() + (k - 1) * (xBins.size() + yBins.size());
+                return getBinAt(i, j, k);
               }
             }
             // overflow for zBins only
-            return this->mIgnoreOverflows ? -1 : (i - 1) + (j - 1) * xBins.size() + (k - 1) * (xBins.size() + yBins.size);
+            return this->mIgnoreOverflows ? -1 : getBinAt(i, j, k);
           }
         }
         if (this->mIgnoreOverflows) {
@@ -253,11 +260,11 @@ struct TripleBinningPolicy : public BinningPolicyBase<C1, C2, C3> {
         // overflow for yBins only
         for (k = 2; k < zBins.size(); k++) {
           if (val3 < zBins[k]) {
-            return (i - 1) + (j - 1) * xBins.size() + (k - 1) * (xBins.size + yBins.size());
+            return getBinAt(i, j, k);
           }
         }
         // overflow for zBins and yBins
-        return (i - 1) + (j - 1) * xBins.size() + (k - 1) * (xBins.size() + yBins.size());
+        return getBinAt(i, j, k);
       }
     }
 
@@ -271,24 +278,24 @@ struct TripleBinningPolicy : public BinningPolicyBase<C1, C2, C3> {
       if (val2 < yBins[j]) {
         for (k = 2; k < zBins.size(); k++) {
           if (val3 < zBins[k]) {
-            return (i - 1) + (j - 1) * xBins.size() + (k - 1) * (xBins.size() + yBins.size());
+            return getBinAt(i, j, k);
           }
         }
 
         // overflow for xBins and zBins
-        return (i - 1) + (j - 1) * xBins.size() + (k - 1) * (xBins.size() + yBins.size());
+        return getBinAt(i, j, k);
       }
     }
 
     // overflow for xBins and yBins
     for (k = 2; k < zBins.size(); k++) {
       if (val3 < zBins[k]) {
-        return (i - 1) + (j - 1) * xBins.size() + (k - 1) * (xBins.size() + yBins.size());
+        return getBinAt(i, j, k);
       }
     }
 
     // overflow for all bins
-    return (i - 1) + (j - 1) * xBins.size() + (k - 1) * (xBins.size() + yBins.size());
+    return getBinAt(i, j, k);
   }
 
   using BinningPolicyBase<C1, C2, C3>::getArrowColumns;
@@ -297,6 +304,11 @@ struct TripleBinningPolicy : public BinningPolicyBase<C1, C2, C3> {
   using BinningPolicyBase<C1, C2, C3>::getRowData;
 
  private:
+  int getBinAt(unsigned int i, unsigned int j, unsigned int k)
+  {
+    return (i - 1) + (j - 1) * this->mBins[0].size() + (k - 1) * (this->mBins[0].size() + this->mBins[1].size());
+  }
+
   void expandConstantBinning(std::vector<double> const& xBins, std::vector<double> const& yBins, std::vector<double> const& zBins)
   {
     if (xBins[0] != VARIABLE_WIDTH) {

--- a/Framework/Core/include/Framework/BinningPolicy.h
+++ b/Framework/Core/include/Framework/BinningPolicy.h
@@ -1,0 +1,287 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef FRAMEWORK_BINNINGPOLICY_H
+#define FRAMEWORK_BINNINGPOLICY_H
+
+#include "Framework/ASoAHelpers.h"
+#include "Framework/Pack.h"
+#include <optional>
+
+namespace o2::framework
+{
+
+struct BinningPolicyBase {
+  BinningPolicyBase(std::vector<AxisSpec>& bins, bool ignoreOverflows = true) : mBins(bins), mIgnoreOverflows(ignoreOverflows) {}
+
+  template <typename... Bs>
+  int getBin(Bs...)
+  {
+    return -1;
+  }
+
+  std::vector<AxisSpec> mBins;
+  bool mIgnoreOverflows;
+};
+
+struct NoBinningPolicy {
+  // Just take the bin number from the column data
+  NoBinningPolicy(std::string const& xColName) : BinningPolicyBase(AxisSpec{{}, nullopt, xColName}) {}
+
+  template <typename B1>
+  int getBin(B1 val1)
+  {
+    return val1;
+  }
+}
+
+struct SingleBinningPolicy {
+  template <typename B1>
+  SingleBinningPolicy(std::string const& xColName, std::vector<B1> xBins, bool ignoreOverflows = true) : BinningPolicyBase({AxisSpec{xBins, std::nullopt, xColName}}, ignoreOverflows)
+  {
+    expandConstantBinning(xBins);
+  }
+  template <typename B1>
+  SingleBinningPolicy(std::string const& xColName, int xNBins, B1 xBinMin, B1 xBinMax, bool ignoreOverflows = true) : SingleBinningPolicy(xColName, {xNBins, xBinMin, xBinMax}, ignoreOverflows)
+  {
+  }
+
+  template <typename B1>
+  int getBin(B1 val1)
+  {
+    auto xBins = this->mBins[0].binEdges;
+    if (mIgnoreOverflows) {
+      // underflow
+      if (val1 < xBins[1]) { // xBins[0] is a dummy VARIABLE_WIDTH
+        return -1;
+      }
+    }
+
+    for (unsigned int i = 2; i < xBins.size(); i++) {
+      if (val1 < xBins[i]) {
+        return i - 1;
+      }
+    }
+    // overflow
+    return ignoreOverflows ? -1 : xBins.size() - 1;
+  }
+
+ private:
+  template <typename B1, typename B2>
+  void expandConstantBinning(std::vector<B1> const& xBins, std::vector<B2> const& yBins)
+  {
+    if (xBins[0] != VARIABLE_WIDTH) {
+      int nBins = static_cast<int>(xBins[0]);
+      this->mBins[0].binEdges.clear;
+      this->mBins[0].resize(nBins + 2);
+      this->mBins[0][0] = VARIABLE_WIDTH;
+      std::iota(std::begin(this->mBins[0].binEdges) + 1, std::end(this->mBins[0].binEdges), xBins[2] - xBins[1] / nBins);
+    }
+  }
+};
+
+struct PairBinningPolicy {
+  PairBinningPolicy(std::string const& xColName, ConfigurableAxis& xBins, std::string const& yColName, ConfigurableAxis& yBins, bool ignoreOverflows = true) : BinningPolicyBase({AxisSpec{xBins, std::nullopt, xColName}, AxisSpec{yBins, std::nullopt, yColName}}, ignoreOverflows)
+  {
+    expandConstantBinning(xBins, yBins);
+  }
+  template <typename B1, typename B2>
+  PairBinningPolicy(std::string const& xColName, std::vector<B1> const& xBins, std::string const& yColName, std::vector<B2> const& yBins, bool ignoreOverflows = true) : BinningPolicyBase({AxisSpec{xBins, std::nullopt, xColName}, AxisSpec{yBins, std::nullopt, yColName}}, ignoreOverflows)
+  {
+    expandConstantBinning(xBins, yBins);
+  }
+  template <typename B1, typename B2>
+  PairBinningPolicy(std::string const& xColName, int xNBins, B1 xBinMin, B1 xBinMax, std::string const& yColName, int yNBins, B2 yBinMin, B2 yBinMax, bool ignoreOverflows = true) : PairBinningPolicy(xColName, {xNBins, xBinMin, xBinMax}, yColName, {yNBins, yBinMin, yBinMax}, zColName, {zNBins, zBinMin, zBinMax}, ignoreOverflows)
+  {
+  }
+
+  template <typename B1, typename B2>
+  int getBin(B1 val1, B2 val2)
+  {
+    auto xBins = this->mBins[0].binEdges;
+    auto yBins = this->mBins[1].binEdges;
+    if (mIgnoreOverflows) {
+      // underflow
+      if (val1 < xBins[1]) { // xBins[0] is a dummy VARIABLE_WIDTH
+        return -1;
+      }
+      if (val2 < yBins[1]) { // yBins[0] is a dummy VARIABLE_WIDTH
+        return -1;
+      }
+    }
+
+    for (unsigned int i = 2; i < xBins.size(); i++) {
+      if (val1 < xBins[i]) {
+        for (unsigned int j = 2; j < yBins.size(); j++) {
+          if (val2 < yBins[j]) {
+            return (i - 1) + (j - 1) * xBins.size();
+          }
+        }
+        // overflow for yBins only
+        return mIgnoreOverflows ? -1 : (i - 1) + (yBins.size() - 1) * xBins.size();
+      }
+    }
+
+    if (mIgnoreOverflows) {
+      // overflow
+      return -1;
+    }
+
+    // overflow for xBins only
+    for (int j = 1; j < yBins.size(); j++) {
+      if (val2 < yBins[j]) {
+        return (xBins.size() - 1) + (j - 1) * xBins.size();
+      }
+    }
+
+    // overflow for both bins
+    return xBins.size() * yBins.size() - 1;
+  }
+
+ private:
+  template <typename B1, typename B2>
+  void expandConstantBinning(std::vector<B1> const& xBins, std::vector<B2> const& yBins)
+  {
+    if (xBins[0] != VARIABLE_WIDTH) {
+      int nBins = static_cast<int>(xBins[0]);
+      this->mBins[0].binEdges.clear;
+      this->mBins[0].resize(nBins + 2);
+      this->mBins[0][0] = VARIABLE_WIDTH;
+      std::iota(std::begin(this->mBins[0].binEdges) + 1, std::end(this->mBins[0].binEdges), xBins[2] - xBins[1] / nBins);
+    }
+    if (yBins[0] != VARIABLE_WIDTH) {
+      int nBins = static_cast<int>(yBins[0]);
+      this->mBins[1].binEdges.clear;
+      this->mBins[1].resize(nBins + 2);
+      this->mBins[1][0] = VARIABLE_WIDTH;
+      std::iota(std::begin(this->mBins[1].binEdges) + 1, std::end(this->mBins[1].binEdges), xBins[2] - xBins[1] / nBins);
+    }
+  }
+};
+
+struct TripleBinningPolicy {
+  template <typename B1, typename B2, typename B3>
+  TripleBinningPolicy(std::string const& xColName, std::vector<B1> const& xBins, std::string const& yColName, std::vector<B2> const& yBins, std::string const& zColName, std::vector<B2> const& zBins, bool ignoreOverflows = true) : BinningPolicyBase({AxisSpec{xBins, std::nullopt, xColName}, AxisSpec{yBins, std::nullopt, yColName}, AxisSpec{zBins, std::nullopt, zColName}}, ignoreOverflows)
+  {
+    expandConstantBinning(xBins, yBins, zBins);
+  }
+  template <typename B1, typename B2, typename B3>
+  TripleBinningPolicy(std::string const& xColName, int xNBins, B1 xBinMin, B1 xBinMax, std::string const& yColName, int yNBins, B2 yBinMin, B2 yBinMax, std::string const& zColName, int zNBins, B3 zBinMin, B3 zBinMax, bool ignoreOverflows = true) : TripleBinningPolicy(xColName, {xNBins, xBinMin, xBinMax}, yColName, {yNBins, yBinMin, yBinMax}, zColName, {zNBins, zBinMin, zBinMax}, ignoreOverflows)
+  {
+  }
+
+  template <typename B1, typename B2, typename B3>
+  int getBin(B1 val1, B2 val2, B3 val3)
+  {
+    auto xBins = std::get<0>(this->mBins);
+    auto yBins = std::get<1>(this->mBins);
+    auto zBins = std::get<2>(this->mBins);
+    if (mIgnoreOverflows) {
+      // underflow
+      if (val1 < xBins[1]) { // xBins[0] is a dummy VARIABLE_WIDTH
+        return -1;
+      }
+      if (val2 < yBins[1]) { // yBins[0] is a dummy VARIABLE_WIDTH
+        return -1;
+      }
+      if (val3 < zBins[1]) { // zBins[0] is a dummy VARIABLE_WIDTH
+        return -1;
+      }
+    }
+
+    unsigned int i = 2, j = 2, k = 2;
+    for (i; i < xBins.size(); i++) {
+      if (val1 < xBins[i]) {
+        for (j; j < yBins.size(); j++) {
+          if (val2 < yBins[j]) {
+            for (k; k < zBins.size(); k++) {
+              if (val3 < zBins[k]) {
+                return (i - 1) + (j - 1) * xBins.size() + (k - 1) * (xBins.size() + yBins.size());
+              }
+            }
+            // overflow for zBins only
+            return mIgnoreOverflows ? -1 : (i - 1) + (j - 1) * xBins.size() + (k - 1) * (xBins.size() + yBins.size);
+          }
+        }
+        if (mIgnoreOverflows) {
+          return -1;
+        }
+        // overflow for yBins only
+        for (k = 2; k < zBins.size(); k++) {
+          if (val3 < zBins[k]) {
+            return (i - 1) + (j - 1) * xBins.size() + (k - 1) * (xBins.size + yBins.size());
+          }
+        }
+        // overflow for zBins and yBins
+        return (i - 1) + (j - 1) * xBins.size() + (k - 1) * (xBins.size() + yBins.size());
+      }
+    }
+
+    if (mIgnoreOverflows) {
+      // overflow
+      return -1;
+    }
+
+    // overflow for xBins only
+    for (j = 2; j < yBins.size(); j++) {
+      if (val2 < yBins[j]) {
+        for (k = 2; k < zBins.size(); k++) {
+          if (val3 < zBins[k]) {
+            return (i - 1) + (j - 1) * xBins.size() + (k - 1) * (xBins.size() + yBins.size());
+          }
+        }
+
+        // overflow for xBins and zBins
+        return (i - 1) + (j - 1) * xBins.size() + (k - 1) * (xBins.size() + yBins.size());
+      }
+    }
+
+    // overflow for xBins and yBins
+    for (k = 2; k < zBins.size(); k++) {
+      if (val3 < zBins[k]) {
+        return (i - 1) + (j - 1) * xBins.size() + (k - 1) * (xBins.size() + yBins.size());
+      }
+    }
+
+    // overflow for all bins
+    return (i - 1) + (j - 1) * xBins.size() + (k - 1) * (xBins.size() + yBins.size());
+  }
+
+ private:
+  template <typename B1, typename B2, typename B3>
+  void expandConstantBinning(std::vector<B1> const& xBins, std::vector<B2> const& yBins)
+  {
+    if (xBins[0] != VARIABLE_WIDTH) {
+      int nBins = static_cast<int>(xBins[0]);
+      this->mBins[0].binEdges.clear;
+      this->mBins[0].resize(nBins + 2);
+      this->mBins[0][0] = VARIABLE_WIDTH;
+      std::iota(std::begin(this->mBins[0].binEdges) + 1, std::end(this->mBins[0].binEdges), xBins[2] - xBins[1] / nBins);
+    }
+    if (yBins[0] != VARIABLE_WIDTH) {
+      int nBins = static_cast<int>(yBins[0]);
+      this->mBins[1].binEdges.clear;
+      this->mBins[1].resize(nBins + 2);
+      this->mBins[1][0] = VARIABLE_WIDTH;
+      std::iota(std::begin(this->mBins[1].binEdges) + 1, std::end(this->mBins[1].binEdges), yBins[2] - yBins[1] / nBins);
+    }
+    if (zBins[0] != VARIABLE_WIDTH) {
+      int nBins = static_cast<int>(zBins[0]);
+      this->mBins[2].binEdges.clear;
+      this->mBins[2].resize(nBins + 2);
+      this->mBins[2][0] = VARIABLE_WIDTH;
+      std::iota(std::begin(this->mBins[2].binEdges) + 1, std::end(this->mBins[2].binEdges), zBins[2] - zBins[1] / nBins);
+    }
+  }
+};
+
+} // namespace o2::framework
+#endif // FRAMEWORK_BINNINGPOLICY_H_

--- a/Framework/Core/include/Framework/BinningPolicy.h
+++ b/Framework/Core/include/Framework/BinningPolicy.h
@@ -97,7 +97,7 @@ struct SingleBinningPolicy : public BinningPolicyBase<C> {
     }
 
     unsigned int i = 2;
-    for (i; i < xBins.size(); i++) {
+    for (; i < xBins.size(); i++) {
       if (val1 < xBins[i]) {
         return i - 1;
       }
@@ -149,9 +149,9 @@ struct PairBinningPolicy : public BinningPolicyBase<C1, C2> {
     }
 
     unsigned int i = 2, j = 2;
-    for (i; i < xBins.size(); i++) {
+    for (; i < xBins.size(); i++) {
       if (val1 < xBins[i]) {
-        for (j; j < yBins.size(); j++) {
+        for (; j < yBins.size(); j++) {
           if (val2 < yBins[j]) {
             return getBinAt(i, j);
           }
@@ -236,11 +236,11 @@ struct TripleBinningPolicy : public BinningPolicyBase<C1, C2, C3> {
     }
 
     unsigned int i = 2, j = 2, k = 2;
-    for (i; i < xBins.size(); i++) {
+    for (; i < xBins.size(); i++) {
       if (val1 < xBins[i]) {
-        for (j; j < yBins.size(); j++) {
+        for (; j < yBins.size(); j++) {
           if (val2 < yBins[j]) {
-            for (k; k < zBins.size(); k++) {
+            for (; k < zBins.size(); k++) {
               if (val3 < zBins[k]) {
                 return getBinAt(i, j, k);
               }

--- a/Framework/Core/include/Framework/GroupedCombinations.h
+++ b/Framework/Core/include/Framework/GroupedCombinations.h
@@ -258,15 +258,15 @@ struct GroupedCombinationsGenerator<T1, GroupingPolicy, H, G, pack<Us...>, As...
 // 'Pair' and 'Triple' can be used for same kind pair/triple, too, just specify the same type twice
 template <typename H, typename G>
 using joinedCollisions = typename soa::Join<H, G>::table_t;
-template <typename H, typename G, typename A1, typename A2, typename T1 = int, typename GroupingPolicy = o2::soa::CombinationsBlockStrictlyUpperSameIndexPolicy<T1, joinedCollisions<H, G>, joinedCollisions<H, G>>>
+template <typename H, typename G, typename A1, typename A2, typename T1 = int, typename GroupingPolicy = o2::soa::CombinationsBlockStrictlyUpperSameIndexPolicy<std::string, T1, joinedCollisions<H, G>, joinedCollisions<H, G>>>
 using Pair = GroupedCombinationsGenerator<T1, GroupingPolicy, H, G, unique_pack_t<pack<A1, A2>>, A1, A2>;
-template <typename H, typename G, typename A, typename T1 = int, typename GroupingPolicy = o2::soa::CombinationsBlockStrictlyUpperSameIndexPolicy<T1, joinedCollisions<H, G>, joinedCollisions<H, G>>>
+template <typename H, typename G, typename A, typename T1 = int, typename GroupingPolicy = o2::soa::CombinationsBlockStrictlyUpperSameIndexPolicy<std::string, T1, joinedCollisions<H, G>, joinedCollisions<H, G>>>
 using SameKindPair = GroupedCombinationsGenerator<T1, GroupingPolicy, H, G, pack<A>, A, A>;
 
 // Aliases for 3-particle correlations
-template <typename H, typename G, typename A1, typename A2, typename A3, typename T1 = int, typename GroupingPolicy = o2::soa::CombinationsBlockStrictlyUpperSameIndexPolicy<T1, joinedCollisions<H, G>, joinedCollisions<H, G>, joinedCollisions<H, G>>>
+template <typename H, typename G, typename A1, typename A2, typename A3, typename T1 = int, typename GroupingPolicy = o2::soa::CombinationsBlockStrictlyUpperSameIndexPolicy<std::string, T1, joinedCollisions<H, G>, joinedCollisions<H, G>, joinedCollisions<H, G>>>
 using Triple = GroupedCombinationsGenerator<T1, GroupingPolicy, H, G, unique_pack_t<pack<A1, A2, A3>>, A1, A2, A3>;
-template <typename H, typename G, typename A, typename T1 = int, typename GroupingPolicy = o2::soa::CombinationsBlockStrictlyUpperSameIndexPolicy<T1, joinedCollisions<H, G>, joinedCollisions<H, G>, joinedCollisions<H, G>>>
+template <typename H, typename G, typename A, typename T1 = int, typename GroupingPolicy = o2::soa::CombinationsBlockStrictlyUpperSameIndexPolicy<std::string, T1, joinedCollisions<H, G>, joinedCollisions<H, G>, joinedCollisions<H, G>>>
 using SameKindTriple = GroupedCombinationsGenerator<T1, GroupingPolicy, H, G, pack<A>, A, A, A>;
 
 } // namespace o2::framework

--- a/Framework/Core/test/benchmark_ASoAHelpers.cxx
+++ b/Framework/Core/test/benchmark_ASoAHelpers.cxx
@@ -454,12 +454,13 @@ static void BM_ASoAHelpersCombGenSimplePairsSameCategories(benchmark::State& sta
 
   using Test = o2::soa::Table<test::X>;
   Test tests{table};
+  NoBinningPolicy<test::X> noBinning;
 
   int64_t count = 0;
 
   for (auto _ : state) {
     count = 0;
-    for (auto& comb : combinations(CombinationsBlockUpperSameIndexPolicy("x", 2, -1, tests, tests))) {
+    for (auto& comb : combinations(CombinationsBlockUpperSameIndexPolicy(noBinning, 2, -1, tests, tests))) {
       count++;
     }
     benchmark::DoNotOptimize(count);
@@ -486,12 +487,13 @@ static void BM_ASoAHelpersCombGenSimpleFivesSameCategories(benchmark::State& sta
 
   using Test = o2::soa::Table<test::X>;
   Test tests{table};
+  NoBinningPolicy<test::X> noBinning;
 
   int64_t count = 0;
 
   for (auto _ : state) {
     count = 0;
-    for (auto& comb : combinations(CombinationsBlockUpperSameIndexPolicy("x", 5, -1, tests, tests, tests, tests, tests))) {
+    for (auto& comb : combinations(CombinationsBlockUpperSameIndexPolicy(noBinning, 5, -1, tests, tests, tests, tests, tests))) {
       count++;
     }
     benchmark::DoNotOptimize(count);
@@ -518,12 +520,13 @@ static void BM_ASoAHelpersCombGenSimplePairsCategories(benchmark::State& state)
 
   using Test = o2::soa::Table<test::X>;
   Test tests{table};
+  NoBinningPolicy<test::X> noBinning;
 
   int64_t count = 0;
 
   for (auto _ : state) {
     count = 0;
-    for (auto& comb : combinations(CombinationsBlockUpperIndexPolicy("x", 2, -1, tests, tests))) {
+    for (auto& comb : combinations(CombinationsBlockUpperIndexPolicy(noBinning, 2, -1, tests, tests))) {
       count++;
     }
     benchmark::DoNotOptimize(count);
@@ -550,12 +553,13 @@ static void BM_ASoAHelpersCombGenSimpleFivesCategories(benchmark::State& state)
 
   using Test = o2::soa::Table<test::X>;
   Test tests{table};
+  NoBinningPolicy<test::X> noBinning;
 
   int64_t count = 0;
 
   for (auto _ : state) {
     count = 0;
-    for (auto& comb : combinations(CombinationsBlockUpperIndexPolicy("x", 2, -1, tests, tests, tests, tests, tests))) {
+    for (auto& comb : combinations(CombinationsBlockUpperIndexPolicy(noBinning, 2, -1, tests, tests, tests, tests, tests))) {
       count++;
     }
     benchmark::DoNotOptimize(count);
@@ -587,12 +591,13 @@ static void BM_ASoAHelpersCombGenCollisionsPairsSameCategories(benchmark::State&
   auto table = builder.finalize();
 
   o2::aod::Collisions collisions{table};
+  NoBinningPolicy<o2::aod::collision::NumContrib> noBinning;
 
   int64_t count = 0;
 
   for (auto _ : state) {
     count = 0;
-    for (auto& comb : combinations(CombinationsBlockUpperSameIndexPolicy("fNumContrib", 2, -1, collisions, collisions))) {
+    for (auto& comb : combinations(CombinationsBlockUpperSameIndexPolicy(noBinning, 2, -1, collisions, collisions))) {
       count++;
     }
     benchmark::DoNotOptimize(count);
@@ -624,12 +629,13 @@ static void BM_ASoAHelpersCombGenCollisionsFivesSameCategories(benchmark::State&
   auto table = builder.finalize();
 
   o2::aod::Collisions collisions{table};
+  NoBinningPolicy<o2::aod::collision::NumContrib> noBinning;
 
   int64_t count = 0;
 
   for (auto _ : state) {
     count = 0;
-    for (auto& comb : combinations(CombinationsBlockUpperSameIndexPolicy("fNumContrib", 5, -1, collisions, collisions, collisions, collisions, collisions))) {
+    for (auto& comb : combinations(CombinationsBlockUpperSameIndexPolicy(noBinning, 5, -1, collisions, collisions, collisions, collisions, collisions))) {
       count++;
     }
     benchmark::DoNotOptimize(count);
@@ -661,12 +667,13 @@ static void BM_ASoAHelpersCombGenCollisionsPairsCategories(benchmark::State& sta
   auto table = builder.finalize();
 
   o2::aod::Collisions collisions{table};
+  NoBinningPolicy<o2::aod::collision::NumContrib> noBinning;
 
   int64_t count = 0;
 
   for (auto _ : state) {
     count = 0;
-    for (auto& comb : combinations(CombinationsBlockUpperIndexPolicy("fNumContrib", 2, -1, collisions, collisions))) {
+    for (auto& comb : combinations(CombinationsBlockUpperIndexPolicy(noBinning, 2, -1, collisions, collisions))) {
       count++;
     }
     benchmark::DoNotOptimize(count);
@@ -698,12 +705,13 @@ static void BM_ASoAHelpersCombGenCollisionsFivesCategories(benchmark::State& sta
   auto table = builder.finalize();
 
   o2::aod::Collisions collisions{table};
+  NoBinningPolicy<o2::aod::collision::NumContrib> noBinning;
 
   int64_t count = 0;
 
   for (auto _ : state) {
     count = 0;
-    for (auto& comb : combinations(CombinationsBlockUpperIndexPolicy("fNumContrib", 5, -1, collisions, collisions, collisions, collisions, collisions))) {
+    for (auto& comb : combinations(CombinationsBlockUpperIndexPolicy(noBinning, 5, -1, collisions, collisions, collisions, collisions, collisions))) {
       count++;
     }
     benchmark::DoNotOptimize(count);

--- a/Framework/Core/test/test_ASoAHelpers.cxx
+++ b/Framework/Core/test/test_ASoAHelpers.cxx
@@ -130,10 +130,10 @@ BOOST_AUTO_TEST_CASE(CombinationsGeneratorConstruction)
   // Grouped data:
   // [3, 5] [0, 4, 7], [1, 6], [2]
   // Assuming bins intervals: [ , )
-  std::vector<uint32_t> yBins{VARIABLE_WIDTH, 0, 5, 10, 20, 30, 40, 50, 101};
-  std::vector<float> zBins{VARIABLE_WIDTH, -7.0f, -5.0f, -3.0f, -1.0f, 1.0f, 3.0f, 5.0f, 7.0f};
+  std::vector<double> yBins{VARIABLE_WIDTH, 0, 5, 10, 20, 30, 40, 50, 101};
+  std::vector<double> zBins{VARIABLE_WIDTH, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0};
 
-  PairBinningPolicy pairBinning{"y", yBins, "floatZ", zBins, false};
+  PairBinningPolicy<test::X, test::FloatZ> pairBinning{yBins, zBins, false};
 
   CombinationsGenerator<CombinationsStrictlyUpperIndexPolicy<TestA, TestA>>::CombinationsIterator combIt(CombinationsStrictlyUpperIndexPolicy(testsA, testsA));
   BOOST_REQUIRE_NE(static_cast<test::X>(std::get<0>(*(combIt))).getIterator().mCurrentPos, nullptr);
@@ -293,8 +293,8 @@ BOOST_AUTO_TEST_CASE(CombinationsGeneratorConstruction)
 
   auto combBlock = combinations(CombinationsBlockStrictlyUpperSameIndexPolicy(pairBinning, 2, -1, testsA, testsA));
 
-  static_assert(std::is_same_v<decltype(combBlock.begin()), CombinationsGenerator<CombinationsBlockStrictlyUpperSameIndexPolicy<int32_t, TestsA, TestsA>>::CombinationsIterator>, "Wrong iterator type");
-  static_assert(std::is_same_v<decltype(*(combBlock.begin())), CombinationsBlockStrictlyUpperSameIndexPolicy<int32_t, TestsA, TestsA>::CombinationType&>, "Wrong combination type");
+  static_assert(std::is_same_v<decltype(combBlock.begin()), CombinationsGenerator<CombinationsBlockStrictlyUpperSameIndexPolicy<PairBinningPolicy<test::X, test::FloatZ>, int32_t, TestA, TestA>>::CombinationsIterator>, "Wrong iterator type");
+  static_assert(std::is_same_v<decltype(*(combBlock.begin())), CombinationsBlockStrictlyUpperSameIndexPolicy<PairBinningPolicy<test::X, test::FloatZ>, int32_t, TestA, TestA>::CombinationType&>, "Wrong combination type");
 
   auto beginBlockCombination = *(combBlock.begin());
   BOOST_REQUIRE_NE(static_cast<test::X>(std::get<0>(beginBlockCombination)).getIterator().mCurrentPos, nullptr);
@@ -937,7 +937,7 @@ BOOST_AUTO_TEST_CASE(BlockCombinations)
   rowWriterAHalf(0, 3, 103, 2.0f);
   rowWriterAHalf(0, 4, 28, -6.0f);
   auto tableAHalf = builderAHalf.finalize();
-  BOOST_REQUIRE_EQUAHalfL(tableAHalf->num_rows(), 10);
+  BOOST_REQUIRE_EQUAL(tableAHalf->num_rows(), 5);
 
   TestA testAHalf{tableAHalf};
   BOOST_REQUIRE_EQUAL(5, testAHalf.size());
@@ -945,11 +945,11 @@ BOOST_AUTO_TEST_CASE(BlockCombinations)
   // Grouped data:
   // [3, 5] [0, 4, 7], [1, 6], [2, 8, 9]
   // Assuming bins intervals: [ , )
-  std::vector<uint32_t> yBins{VARIABLE_WIDTH, 0, 5, 10, 20, 30, 40, 50, 101};
-  std::vector<float> zBins{VARIABLE_WIDTH, -7.0f, -5.0f, -3.0f, -1.0f, 1.0f, 3.0f, 5.0f, 7.0f};
+  std::vector<double> yBins{VARIABLE_WIDTH, 0, 5, 10, 20, 30, 40, 50, 101};
+  std::vector<double> zBins{VARIABLE_WIDTH, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0};
 
-  PairBinningPolicy pairBinning{"y", yBins, "floatZ", zBins, false};
-  PairBinningPolicy pairBinningNoOverflows{"y", yBins, "floatZ", zBins, true};
+  PairBinningPolicy<test::Y, test::FloatZ> pairBinning{yBins, zBins, false};
+  PairBinningPolicy<test::Y, test::FloatZ> pairBinningNoOverflows{yBins, zBins, true};
 
   // 2, 3, 5, 8, 9 have overflows in testA
   std::vector<std::tuple<int32_t, int32_t>> expectedFullPairsNoOverflows{
@@ -996,7 +996,7 @@ BOOST_AUTO_TEST_CASE(BlockCombinations)
   std::vector<std::tuple<int32_t, int32_t, int32_t>> expectedUpperTriples{
     {0, 0, 0}, {0, 0, 4}, {0, 4, 4}, {4, 4, 4}, {4, 4, 7}, {4, 7, 7}, {7, 7, 7}, {1, 1, 1}, {1, 1, 6}, {1, 6, 6}, {6, 6, 6}, {3, 3, 3}, {3, 3, 5}, {3, 5, 5}, {5, 5, 5}, {2, 2, 2}, {2, 2, 8}, {2, 8, 8}, {8, 8, 8}, {8, 8, 9}, {8, 9, 9}, {9, 9, 9}};
   count = 0;
-  for (auto& [c0, c1, c2] : combinations(CombinationsBlockUpperIndexPolicy(pairBinning, 1, -1, testx, testA, testA))) {
+  for (auto& [c0, c1, c2] : combinations(CombinationsBlockUpperIndexPolicy(pairBinning, 1, -1, testA, testA, testA))) {
     BOOST_CHECK_EQUAL(c0.x(), std::get<0>(expectedUpperTriples[count]));
     BOOST_CHECK_EQUAL(c1.x(), std::get<1>(expectedUpperTriples[count]));
     BOOST_CHECK_EQUAL(c2.x(), std::get<2>(expectedUpperTriples[count]));
@@ -1244,10 +1244,10 @@ BOOST_AUTO_TEST_CASE(CombinationsHelpers)
   // Grouped data:
   // [3, 5] [0, 4, 7], [1, 6], [2, 8, 9]
   // Assuming bins intervals: [ , )
-  std::vector<uint32_t> yBins{VARIABLE_WIDTH, 0, 5, 10, 20, 30, 40, 50, 101};
-  std::vector<float> zBins{VARIABLE_WIDTH, -7.0f, -5.0f, -3.0f, -1.0f, 1.0f, 3.0f, 5.0f, 7.0f};
+  std::vector<double> yBins{VARIABLE_WIDTH, 0, 5, 10, 20, 30, 40, 50, 101};
+  std::vector<double> zBins{VARIABLE_WIDTH, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0};
 
-  PairBinningPolicy pairBinning{"y", yBins, "floatZ", zBins, false};
+  PairBinningPolicy<test::Y, test::FloatZ> pairBinning{yBins, zBins, false};
 
   std::vector<std::tuple<int32_t, int32_t>> expectedStrictlyUpperPairs{
     {0, 4}, {0, 7}, {4, 7}, {1, 6}, {3, 5}, {2, 8}, {2, 9}, {8, 9}};
@@ -1274,7 +1274,7 @@ BOOST_AUTO_TEST_CASE(CombinationsHelpers)
 BOOST_AUTO_TEST_CASE(ConstructorsWithoutTables)
 {
   using TestA = o2::soa::Table<o2::soa::Index<>, test::X, test::Y>;
-  NoBinningPolicy noBinning{"y"};
+  NoBinningPolicy<test::Y> noBinning;
 
   int count = 0;
   for (auto& [t0, t1] : pairCombinations<TestA>()) {
@@ -1289,15 +1289,14 @@ BOOST_AUTO_TEST_CASE(ConstructorsWithoutTables)
   BOOST_CHECK_EQUAL(count, 0);
 
   count = 0;
-  for (auto& [c0, c1] : selfPairCombinations<int, TestA>(noBinning, 2, -1)) {
+  for (auto& [c0, c1] : selfPairCombinations<NoBinningPolicy<test::Y>, int, TestA>(noBinning, 2, -1)) {
     count++;
   }
   BOOST_CHECK_EQUAL(count, 0);
 
   count = 0;
-  for (auto& [c0, c1, c2] : selfTripleCombinations<int, TestA>(noBinning, 2, -1)) {
+  for (auto& [c0, c1, c2] : selfTripleCombinations<NoBinningPolicy<test::Y>, int, TestA>(noBinning, 2, -1)) {
     count++;
   }
   BOOST_CHECK_EQUAL(count, 0);
-}
 }

--- a/Framework/Core/test/test_ASoAHelpers.cxx
+++ b/Framework/Core/test/test_ASoAHelpers.cxx
@@ -1162,6 +1162,35 @@ BOOST_AUTO_TEST_CASE(BlockCombinations)
     count++;
   }
   BOOST_CHECK_EQUAL(count, 0);
+
+  // Testing bin calculations for triple binning
+  // Grouped data:
+  // [3, 5] [0, 4], [7], [1, 6], [2], [8, 9]
+  // Assuming bins intervals: [ , )
+  std::vector<double> xBins{VARIABLE_WIDTH, 0, 7, 10};
+  TripleBinningPolicy<test::X, test::Y, test::FloatZ> tripleBinning{xBins, yBins, zBins, false};
+  TripleBinningPolicy<test::X, test::Y, test::FloatZ> tripleBinningNoOverflows{xBins, yBins, zBins, true};
+
+  // 2, 3, 5, 8, 9 have overflows in testA
+  std::vector<std::tuple<int32_t, int32_t>> expectedFullPairsTripleBinningNoOverflows{
+    {0, 0}, {0, 4}, {4, 0}, {4, 4}, {7, 7}, {1, 1}, {1, 6}, {6, 1}, {6, 6}};
+  count = 0;
+  for (auto& [c0, c1] : combinations(CombinationsBlockFullIndexPolicy(tripleBinningNoOverflows, 1, -1, testA, testA))) {
+    BOOST_CHECK_EQUAL(c0.x(), std::get<0>(expectedFullPairsTripleBinningNoOverflows[count]));
+    BOOST_CHECK_EQUAL(c1.x(), std::get<1>(expectedFullPairsTripleBinningNoOverflows[count]));
+    count++;
+  }
+  BOOST_CHECK_EQUAL(count, expectedFullPairsTripleBinningNoOverflows.size());
+
+  std::vector<std::tuple<int32_t, int32_t>> expectedFullPairsTripleBinning{
+    {0, 0}, {0, 4}, {4, 0}, {4, 4}, {7, 7}, {1, 1}, {1, 6}, {6, 1}, {6, 6}, {3, 3}, {3, 5}, {5, 3}, {5, 5}, {2, 2}, {8, 8}, {8, 9}, {9, 8}, {9, 9}};
+  count = 0;
+  for (auto& [c0, c1] : combinations(CombinationsBlockFullIndexPolicy(tripleBinning, 2, -1, testA, testA))) {
+    BOOST_CHECK_EQUAL(c0.x(), std::get<0>(expectedFullPairsTripleBinning[count]));
+    BOOST_CHECK_EQUAL(c1.x(), std::get<1>(expectedFullPairsTripleBinning[count]));
+    count++;
+  }
+  BOOST_CHECK_EQUAL(count, expectedFullPairsTripleBinning.size());
 }
 
 BOOST_AUTO_TEST_CASE(CombinationsHelpers)

--- a/Framework/Core/test/test_ASoAHelpers.cxx
+++ b/Framework/Core/test/test_ASoAHelpers.cxx
@@ -133,7 +133,7 @@ BOOST_AUTO_TEST_CASE(CombinationsGeneratorConstruction)
   std::vector<double> yBins{VARIABLE_WIDTH, 0, 5, 10, 20, 30, 40, 50, 101};
   std::vector<double> zBins{VARIABLE_WIDTH, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0};
 
-  PairBinningPolicy<test::X, test::FloatZ> pairBinning{yBins, zBins, false};
+  BinningPolicy<test::Y, test::FloatZ> pairBinning{{yBins, zBins}, false};
 
   CombinationsGenerator<CombinationsStrictlyUpperIndexPolicy<TestA, TestA>>::CombinationsIterator combIt(CombinationsStrictlyUpperIndexPolicy(testsA, testsA));
   BOOST_REQUIRE_NE(static_cast<test::X>(std::get<0>(*(combIt))).getIterator().mCurrentPos, nullptr);
@@ -293,8 +293,8 @@ BOOST_AUTO_TEST_CASE(CombinationsGeneratorConstruction)
 
   auto combBlock = combinations(CombinationsBlockStrictlyUpperSameIndexPolicy(pairBinning, 2, -1, testsA, testsA));
 
-  static_assert(std::is_same_v<decltype(combBlock.begin()), CombinationsGenerator<CombinationsBlockStrictlyUpperSameIndexPolicy<PairBinningPolicy<test::X, test::FloatZ>, int32_t, TestA, TestA>>::CombinationsIterator>, "Wrong iterator type");
-  static_assert(std::is_same_v<decltype(*(combBlock.begin())), CombinationsBlockStrictlyUpperSameIndexPolicy<PairBinningPolicy<test::X, test::FloatZ>, int32_t, TestA, TestA>::CombinationType&>, "Wrong combination type");
+  static_assert(std::is_same_v<decltype(combBlock.begin()), CombinationsGenerator<CombinationsBlockStrictlyUpperSameIndexPolicy<BinningPolicy<test::Y, test::FloatZ>, int32_t, TestA, TestA>>::CombinationsIterator>, "Wrong iterator type");
+  static_assert(std::is_same_v<decltype(*(combBlock.begin())), CombinationsBlockStrictlyUpperSameIndexPolicy<BinningPolicy<test::Y, test::FloatZ>, int32_t, TestA, TestA>::CombinationType&>, "Wrong combination type");
 
   auto beginBlockCombination = *(combBlock.begin());
   BOOST_REQUIRE_NE(static_cast<test::X>(std::get<0>(beginBlockCombination)).getIterator().mCurrentPos, nullptr);
@@ -948,8 +948,8 @@ BOOST_AUTO_TEST_CASE(BlockCombinations)
   std::vector<double> yBins{VARIABLE_WIDTH, 0, 5, 10, 20, 30, 40, 50, 101};
   std::vector<double> zBins{VARIABLE_WIDTH, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0};
 
-  PairBinningPolicy<test::Y, test::FloatZ> pairBinning{yBins, zBins, false};
-  PairBinningPolicy<test::Y, test::FloatZ> pairBinningNoOverflows{yBins, zBins, true};
+  BinningPolicy<test::Y, test::FloatZ> pairBinning{{yBins, zBins}, false};
+  BinningPolicy<test::Y, test::FloatZ> pairBinningNoOverflows{{yBins, zBins}, true};
 
   // 2, 3, 5, 8, 9 have overflows in testA
   std::vector<std::tuple<int32_t, int32_t>> expectedFullPairsNoOverflows{
@@ -1168,8 +1168,8 @@ BOOST_AUTO_TEST_CASE(BlockCombinations)
   // [3, 5] [0, 4], [7], [1, 6], [2], [8, 9]
   // Assuming bins intervals: [ , )
   std::vector<double> xBins{VARIABLE_WIDTH, 0, 7, 10};
-  TripleBinningPolicy<test::X, test::Y, test::FloatZ> tripleBinning{xBins, yBins, zBins, false};
-  TripleBinningPolicy<test::X, test::Y, test::FloatZ> tripleBinningNoOverflows{xBins, yBins, zBins, true};
+  BinningPolicy<test::X, test::Y, test::FloatZ> tripleBinning{{xBins, yBins, zBins}, false};
+  BinningPolicy<test::X, test::Y, test::FloatZ> tripleBinningNoOverflows{{xBins, yBins, zBins}, true};
 
   // 2, 3, 5, 8, 9 have overflows in testA
   std::vector<std::tuple<int32_t, int32_t>> expectedFullPairsTripleBinningNoOverflows{
@@ -1276,7 +1276,7 @@ BOOST_AUTO_TEST_CASE(CombinationsHelpers)
   std::vector<double> yBins{VARIABLE_WIDTH, 0, 5, 10, 20, 30, 40, 50, 101};
   std::vector<double> zBins{VARIABLE_WIDTH, -7.0, -5.0, -3.0, -1.0, 1.0, 3.0, 5.0, 7.0};
 
-  PairBinningPolicy<test::Y, test::FloatZ> pairBinning{yBins, zBins, false};
+  BinningPolicy<test::Y, test::FloatZ> pairBinning{{yBins, zBins}, false};
 
   std::vector<std::tuple<int32_t, int32_t>> expectedStrictlyUpperPairs{
     {0, 4}, {0, 7}, {4, 7}, {1, 6}, {3, 5}, {2, 8}, {2, 9}, {8, 9}};


### PR DESCRIPTION
Ciao @ktf,

The BinningPolicy classes replace the special hash task / table for block combinations.

Sorry for a huge PR, but I needed to modify in tests all lines that call block combinations, otherwise it won't compile.
The core changes are: new BinningPolicy.h and rewritten `groupTable()` in ASoAHelpers.h.