### PR TITLE
ITS and MFT fetch noise masks and clust.dict. from CCDB

### DIFF
--- a/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
+++ b/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
@@ -29,11 +29,13 @@
 #include "ReconstructionDataFormats/TrackCosmics.h"
 #include "ReconstructionDataFormats/TrackMCHMID.h"
 #include "DataFormatsITSMFT/TrkClusRef.h"
+#include "DataFormatsITSMFT/TopologyDictionary.h"
 // FIXME: ideally, the data formats definition should be independent of the framework
 // collectData is using the input of ProcessingContext to extract the first valid
 // header and the TF orbit from it
 #include "Framework/ProcessingContext.h"
 #include "Framework/DataRefUtils.h"
+#include "Framework/CCDBParamSpec.h"
 
 using namespace o2::globaltracking;
 using namespace o2::framework;
@@ -214,6 +216,7 @@ void DataRequest::requestITSClusters(bool mc)
   addInput({"clusITS", "ITS", "COMPCLUSTERS", 0, Lifetime::Timeframe});
   addInput({"clusITSPatt", "ITS", "PATTERNS", 0, Lifetime::Timeframe});
   addInput({"clusITSROF", "ITS", "CLUSTERSROF", 0, Lifetime::Timeframe});
+  addInput({"cldictITS", "ITS", "CLUSDICT", 0, Lifetime::Condition, ccdbParamSpec("ITS/Calib/ClusterDictionary")});
   if (mc) {
     addInput({"clusITSMC", "ITS", "CLUSTERSMCTR", 0, Lifetime::Timeframe});
   }
@@ -225,6 +228,7 @@ void DataRequest::requestMFTClusters(bool mc)
   addInput({"clusMFT", "MFT", "COMPCLUSTERS", 0, Lifetime::Timeframe});
   addInput({"clusMFTPatt", "MFT", "PATTERNS", 0, Lifetime::Timeframe});
   addInput({"clusMFTROF", "MFT", "CLUSTERSROF", 0, Lifetime::Timeframe});
+  addInput({"cldictMFT", "MFT", "CLUSDICT", 0, Lifetime::Condition, ccdbParamSpec("MFT/Calib/ClusterDictionary")});
   if (mc) {
     addInput({"clusMFTMC", "MFT", "CLUSTERSMCTR", 0, Lifetime::Timeframe});
   }
@@ -858,6 +862,7 @@ void RecoContainer::addITSClusters(ProcessingContext& pc, bool mc)
   commonPool[GTrackID::ITS].registerContainer(pc.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("clusITSROF"), CLUSREFS);
   commonPool[GTrackID::ITS].registerContainer(pc.inputs().get<gsl::span<o2::itsmft::CompClusterExt>>("clusITS"), CLUSTERS);
   commonPool[GTrackID::ITS].registerContainer(pc.inputs().get<gsl::span<unsigned char>>("clusITSPatt"), PATTERNS);
+  pc.inputs().get<o2::itsmft::TopologyDictionary*>("cldictITS"); // just to trigger the finaliseCCDB
   if (mc) {
     mcITSClusters = pc.inputs().get<const dataformats::MCTruthContainer<MCCompLabel>*>("clusITSMC");
   }
@@ -869,6 +874,7 @@ void RecoContainer::addMFTClusters(ProcessingContext& pc, bool mc)
   commonPool[GTrackID::MFT].registerContainer(pc.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("clusMFTROF"), CLUSREFS);
   commonPool[GTrackID::MFT].registerContainer(pc.inputs().get<gsl::span<o2::itsmft::CompClusterExt>>("clusMFT"), CLUSTERS);
   commonPool[GTrackID::MFT].registerContainer(pc.inputs().get<gsl::span<unsigned char>>("clusMFTPatt"), PATTERNS);
+  pc.inputs().get<o2::itsmft::TopologyDictionary*>("cldictMFT"); // just to trigger the finaliseCCDB
 }
 
 //__________________________________________________________

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TopologyDictionary.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TopologyDictionary.h
@@ -71,7 +71,7 @@ class TopologyDictionary
   TopologyDictionary();
   /// Constructor
   TopologyDictionary(const std::string& fileName);
-
+  TopologyDictionary& operator=(const TopologyDictionary& dict) = default;
   /// constexpr for the definition of the groups of rare topologies.
   /// The attritbution of the group ID is stringly dependent on the following parameters: it must be a power of 2.
   static constexpr int RowClassSpan = 4;                                                            ///< Row span of the classes of rare topologies

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchCosmics.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchCosmics.h
@@ -78,7 +78,7 @@ class MatchCosmics
     int matchID = MinusOne; ///< entry (none if MinusOne) of its match in the vector of matches
   };
   void setITSROFrameLengthMUS(float fums) { mITSROFrameLengthMUS = fums; }
-  void setITSDict(std::unique_ptr<o2::itsmft::TopologyDictionary>& dict) { mITSDict = std::move(dict); }
+  void setITSDict(const o2::itsmft::TopologyDictionary* dict) { mITSDict = dict; }
   void process(const o2::globaltracking::RecoContainer& data);
   void setUseMC(bool mc) { mUseMC = mc; }
   void init();
@@ -128,7 +128,7 @@ class MatchCosmics
   std::vector<MatchRecord> mRecords;
   std::vector<int> mWinners;
   std::unique_ptr<o2::gpu::TPCFastTransform> mTPCTransform; ///< TPC cluster transformation
-  std::unique_ptr<o2::itsmft::TopologyDictionary> mITSDict; // cluster patterns dictionary
+  const o2::itsmft::TopologyDictionary* mITSDict = nullptr; // cluster patterns dictionary
 
   int mTFCount = 0;
   float mTPCTBinMUS = 0.; ///< TPC time bin duration in microseconds

--- a/Detectors/GlobalTracking/src/MatchCosmics.cxx
+++ b/Detectors/GlobalTracking/src/MatchCosmics.cxx
@@ -550,7 +550,7 @@ std::vector<o2::BaseCluster<float>> MatchCosmics::prepareITSClusters(const o2::g
     const auto& patterns = data.getITSClustersPatterns();
     itscl.reserve(clusITS.size());
     auto pattIt = patterns.begin();
-    o2::its::ioutils::convertCompactClusters(clusITS, pattIt, itscl, *mITSDict);
+    o2::its::ioutils::convertCompactClusters(clusITS, pattIt, itscl, mITSDict);
   }
   return std::move(itscl);
 }

--- a/Detectors/GlobalTracking/src/MatchGlobalFwd.cxx
+++ b/Detectors/GlobalTracking/src/MatchGlobalFwd.cxx
@@ -215,7 +215,7 @@ bool MatchGlobalFwd::prepareMFTData()
   const auto patterns = inp.getMFTClustersPatterns();
   auto pattIt = patterns.begin();
   mMFTClusters.reserve(clusMFT.size());
-  o2::mft::ioutils::convertCompactClusters(clusMFT, pattIt, mMFTClusters, *mMFTDict);
+  o2::mft::ioutils::convertCompactClusters(clusMFT, pattIt, mMFTClusters, mMFTDict);
 
   // Load MFT tracks
   mMFTTracks = inp.getMFTTracks();

--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -534,7 +534,7 @@ bool MatchTPCITS::prepareITSData()
   const auto patterns = inp.getITSClustersPatterns();
   auto pattIt = patterns.begin();
   mITSClustersArray.reserve(clusITS.size());
-  o2::its::ioutils::convertCompactClusters(clusITS, pattIt, mITSClustersArray, *mITSDict);
+  o2::its::ioutils::convertCompactClusters(clusITS, pattIt, mITSClustersArray, mITSDict);
   if (mMCTruthON) {
     mITSClsLabels = inp.mcITSClusters.get();
   }

--- a/Detectors/ITSMFT/ITS/calibration/include/ITSCalibration/NoiseCalibrator.h
+++ b/Detectors/ITSMFT/ITS/calibration/include/ITSCalibration/NoiseCalibrator.h
@@ -57,10 +57,8 @@ class NoiseCalibrator
 
   void setNThreads(int n) { mNThreads = n > 0 ? n : 1; }
 
-  void loadDictionary(std::string fname)
-  {
-    mDict.readFromFile(fname);
-  }
+  void setClusterDictionary(const o2::itsmft::TopologyDictionary* d) { mDict = d; }
+
   const o2::itsmft::NoiseMap& getNoiseMap() const { return mNoiseMap; }
 
   void setInstanceID(size_t i) { mInstanceID = i; }
@@ -69,7 +67,7 @@ class NoiseCalibrator
   auto getNInstances() const { return mNInstances; }
 
  private:
-  o2::itsmft::TopologyDictionary mDict;
+  const o2::itsmft::TopologyDictionary* mDict = nullptr;
   o2::itsmft::NoiseMap mNoiseMap{24120};
   float mProbabilityThreshold = 3e-6f;
   unsigned int mThreshold = 100;

--- a/Detectors/ITSMFT/ITS/calibration/include/ITSCalibration/NoiseCalibratorSpec.h
+++ b/Detectors/ITSMFT/ITS/calibration/include/ITSCalibration/NoiseCalibratorSpec.h
@@ -48,9 +48,11 @@ class NoiseCalibratorSpec : public Task
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
   void endOfStream(EndOfStreamContext& ec) final;
+  void finaliseCCDB(ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
   void sendOutput(DataAllocator& output);
+  void updateTimeDependentParams(ProcessingContext& pc);
   std::unique_ptr<CALIBRATOR> mCalibrator = nullptr;
   size_t mDataSizeStat = 0;
   size_t mNClustersProc = 0;

--- a/Detectors/ITSMFT/ITS/calibration/src/NoiseCalibrator.cxx
+++ b/Detectors/ITSMFT/ITS/calibration/src/NoiseCalibrator.cxx
@@ -53,7 +53,7 @@ bool NoiseCalibrator::processTimeFrameClusters(gsl::span<const o2::itsmft::CompC
       o2::itsmft::ClusterPattern patt;
       auto row = c.getRow();
       auto col = c.getCol();
-      if (mDict.getSize() == 0) {
+      if (mDict->getSize() == 0) {
         if (pattID == o2::itsmft::CompCluster::InvalidPatternID) {
           patt.acquirePattern(pattIt);
         } else {
@@ -61,14 +61,14 @@ bool NoiseCalibrator::processTimeFrameClusters(gsl::span<const o2::itsmft::CompC
         }
       } else if (pattID == o2::itsmft::CompCluster::InvalidPatternID) {
         patt.acquirePattern(pattIt);
-      } else if (mDict.isGroup(pattID)) {
+      } else if (mDict->isGroup(pattID)) {
         patt.acquirePattern(pattIt);
         float xCOG = 0., zCOG = 0.;
         patt.getCOG(xCOG, zCOG); // for grouped patterns the reference pixel is at COG
         row -= round(xCOG);
         col -= round(zCOG);
       } else {
-        patt = mDict.getPattern(pattID);
+        patt = mDict->getPattern(pattID);
       }
       auto colSpan = patt.getColumnSpan();
       auto rowSpan = patt.getRowSpan();

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTracker.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/CookedTracker.h
@@ -127,7 +127,7 @@ class CookedTracker
   using TrackInserter = std::function<int(const TrackITSExt& t)>;
   // These functions must be implemented
   template <typename U, typename V>
-  void process(gsl::span<const CompClusterExt> clusters, gsl::span<const unsigned char>::iterator& it, const o2::itsmft::TopologyDictionary& dict, U& tracks, V& clusIdx, o2::itsmft::ROFRecord& rof)
+  void process(gsl::span<const CompClusterExt> clusters, gsl::span<const unsigned char>::iterator& it, const o2::itsmft::TopologyDictionary* dict, U& tracks, V& clusIdx, o2::itsmft::ROFRecord& rof)
   {
     TrackInserter inserter = [&tracks, &clusIdx, this](const TrackITSExt& t) -> int {
       // convert internal track to output format
@@ -145,7 +145,7 @@ class CookedTracker
     };
     process(clusters, it, dict, inserter, rof);
   }
-  void process(gsl::span<const CompClusterExt> const& clusters, gsl::span<const unsigned char>::iterator& it, const o2::itsmft::TopologyDictionary& dict, TrackInserter& inserter, o2::itsmft::ROFRecord& rof);
+  void process(gsl::span<const CompClusterExt> const& clusters, gsl::span<const unsigned char>::iterator& it, const o2::itsmft::TopologyDictionary* dict, TrackInserter& inserter, o2::itsmft::ROFRecord& rof);
   const Cluster* getCluster(Int_t index) const;
 
   void setGeometry(o2::its::GeometryTGeo* geom);

--- a/Detectors/ITSMFT/ITS/reconstruction/src/CookedTracker.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/CookedTracker.cxx
@@ -498,7 +498,7 @@ std::vector<TrackITSExt> CookedTracker::trackInThread(Int_t first, Int_t last)
 
 void CookedTracker::process(gsl::span<const o2::itsmft::CompClusterExt> const& clusters,
                             gsl::span<const unsigned char>::iterator& pattIt,
-                            const o2::itsmft::TopologyDictionary& dict,
+                            const o2::itsmft::TopologyDictionary* dict,
                             TrackInserter& inserter,
                             o2::itsmft::ROFRecord& rof)
 {
@@ -525,15 +525,15 @@ void CookedTracker::process(gsl::span<const o2::itsmft::CompClusterExt> const& c
     if (pattID != itsmft::CompCluster::InvalidPatternID) {
       sigmaY2 = gSigma2; //dict.getErr2X(pattID);
       sigmaZ2 = gSigma2; //dict.getErr2Z(pattID);
-      if (!dict.isGroup(pattID)) {
-        locXYZ = dict.getClusterCoordinates(comp);
+      if (!dict->isGroup(pattID)) {
+        locXYZ = dict->getClusterCoordinates(comp);
       } else {
         o2::itsmft::ClusterPattern patt(pattIt);
-        locXYZ = dict.getClusterCoordinates(comp, patt);
+        locXYZ = dict->getClusterCoordinates(comp, patt);
       }
     } else {
       o2::itsmft::ClusterPattern patt(pattIt);
-      locXYZ = dict.getClusterCoordinates(comp, patt, false);
+      locXYZ = dict->getClusterCoordinates(comp, patt, false);
     }
     auto sensorID = comp.getSensorID();
     // Inverse transformation to the local --> tracking

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/IOUtils.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/IOUtils.h
@@ -59,16 +59,16 @@ constexpr float DefClusError2Row = DefClusErrorRow * DefClusErrorRow;
 constexpr float DefClusError2Col = DefClusErrorCol * DefClusErrorCol;
 
 void loadEventData(ROframe& events, gsl::span<const itsmft::CompClusterExt> clusters,
-                   gsl::span<const unsigned char>::iterator& pattIt, const itsmft::TopologyDictionary& dict,
+                   gsl::span<const unsigned char>::iterator& pattIt, const itsmft::TopologyDictionary* dict,
                    const dataformats::MCTruthContainer<MCCompLabel>* clsLabels = nullptr);
 int loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& events, gsl::span<const itsmft::CompClusterExt> clusters,
-                    gsl::span<const unsigned char>::iterator& pattIt, const itsmft::TopologyDictionary& dict,
+                    gsl::span<const unsigned char>::iterator& pattIt, const itsmft::TopologyDictionary* dict,
                     const dataformats::MCTruthContainer<MCCompLabel>* mClsLabels = nullptr);
 
 void convertCompactClusters(gsl::span<const itsmft::CompClusterExt> clusters,
                             gsl::span<const unsigned char>::iterator& pattIt,
                             std::vector<o2::BaseCluster<float>>& output,
-                            const itsmft::TopologyDictionary& dict);
+                            const itsmft::TopologyDictionary* dict);
 
 inline static const o2::itsmft::ChipMappingITS& getChipMappingITS()
 {

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -68,7 +68,7 @@ class TimeFrame final
                       const dataformats::MCTruthContainer<MCCompLabel>* mcLabels = nullptr);
 
   int loadROFrameData(gsl::span<o2::itsmft::ROFRecord> rofs, gsl::span<const itsmft::CompClusterExt> clusters, gsl::span<const unsigned char>::iterator& pattIt,
-                      const itsmft::TopologyDictionary& dict, const dataformats::MCTruthContainer<MCCompLabel>* mcLabels = nullptr);
+                      const itsmft::TopologyDictionary* dict, const dataformats::MCTruthContainer<MCCompLabel>* mcLabels = nullptr);
   int getTotalClusters() const;
   bool empty() const;
 

--- a/Detectors/ITSMFT/ITS/tracking/src/IOUtils.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/IOUtils.cxx
@@ -53,7 +53,7 @@ void from_json(const nlohmann::json& j, MemoryParameters& par);
 void ioutils::convertCompactClusters(gsl::span<const itsmft::CompClusterExt> clusters,
                                      gsl::span<const unsigned char>::iterator& pattIt,
                                      std::vector<o2::BaseCluster<float>>& output,
-                                     const itsmft::TopologyDictionary& dict)
+                                     const itsmft::TopologyDictionary* dict)
 {
   GeometryTGeo* geom = GeometryTGeo::Instance();
   bool applyMisalignment = false;
@@ -71,17 +71,17 @@ void ioutils::convertCompactClusters(gsl::span<const itsmft::CompClusterExt> clu
     o2::math_utils::Point3D<float> locXYZ;
     float sigmaY2 = ioutils::DefClusError2Row, sigmaZ2 = ioutils::DefClusError2Col, sigmaYZ = 0; //Dummy COG errors (about half pixel size)
     if (pattID != itsmft::CompCluster::InvalidPatternID) {
-      sigmaY2 = dict.getErr2X(pattID);
-      sigmaZ2 = dict.getErr2Z(pattID);
-      if (!dict.isGroup(pattID)) {
-        locXYZ = dict.getClusterCoordinates(c);
+      sigmaY2 = dict->getErr2X(pattID);
+      sigmaZ2 = dict->getErr2Z(pattID);
+      if (!dict->isGroup(pattID)) {
+        locXYZ = dict->getClusterCoordinates(c);
       } else {
         o2::itsmft::ClusterPattern patt(pattIt);
-        locXYZ = dict.getClusterCoordinates(c, patt);
+        locXYZ = dict->getClusterCoordinates(c, patt);
       }
     } else {
       o2::itsmft::ClusterPattern patt(pattIt);
-      locXYZ = dict.getClusterCoordinates(c, patt, false);
+      locXYZ = dict->getClusterCoordinates(c, patt, false);
     }
     auto& cl3d = output.emplace_back(c.getSensorID(), geom->getMatrixT2L(c.getSensorID()) ^ locXYZ); // local --> tracking
     if (applyMisalignment) {
@@ -94,7 +94,7 @@ void ioutils::convertCompactClusters(gsl::span<const itsmft::CompClusterExt> clu
 }
 
 void ioutils::loadEventData(ROframe& event, gsl::span<const itsmft::CompClusterExt> clusters,
-                            gsl::span<const unsigned char>::iterator& pattIt, const itsmft::TopologyDictionary& dict,
+                            gsl::span<const unsigned char>::iterator& pattIt, const itsmft::TopologyDictionary* dict,
                             const dataformats::MCTruthContainer<MCCompLabel>* clsLabels)
 {
   if (clusters.empty()) {
@@ -113,17 +113,17 @@ void ioutils::loadEventData(ROframe& event, gsl::span<const itsmft::CompClusterE
     o2::math_utils::Point3D<float> locXYZ;
     float sigmaY2 = ioutils::DefClusError2Row, sigmaZ2 = ioutils::DefClusError2Col, sigmaYZ = 0; //Dummy COG errors (about half pixel size)
     if (pattID != itsmft::CompCluster::InvalidPatternID) {
-      sigmaY2 = dict.getErr2X(pattID);
-      sigmaZ2 = dict.getErr2Z(pattID);
-      if (!dict.isGroup(pattID)) {
-        locXYZ = dict.getClusterCoordinates(c);
+      sigmaY2 = dict->getErr2X(pattID);
+      sigmaZ2 = dict->getErr2Z(pattID);
+      if (!dict->isGroup(pattID)) {
+        locXYZ = dict->getClusterCoordinates(c);
       } else {
         o2::itsmft::ClusterPattern patt(pattIt);
-        locXYZ = dict.getClusterCoordinates(c, patt);
+        locXYZ = dict->getClusterCoordinates(c, patt);
       }
     } else {
       o2::itsmft::ClusterPattern patt(pattIt);
-      locXYZ = dict.getClusterCoordinates(c, patt, false);
+      locXYZ = dict->getClusterCoordinates(c, patt, false);
     }
     auto sensorID = c.getSensorID();
     // Inverse transformation to the local --> tracking
@@ -146,7 +146,7 @@ void ioutils::loadEventData(ROframe& event, gsl::span<const itsmft::CompClusterE
   }
 }
 
-int ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& event, gsl::span<const itsmft::CompClusterExt> clusters, gsl::span<const unsigned char>::iterator& pattIt, const itsmft::TopologyDictionary& dict,
+int ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& event, gsl::span<const itsmft::CompClusterExt> clusters, gsl::span<const unsigned char>::iterator& pattIt, const itsmft::TopologyDictionary* dict,
                              const dataformats::MCTruthContainer<MCCompLabel>* mcLabels)
 {
   event.clear();
@@ -163,17 +163,17 @@ int ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& event, g
     o2::math_utils::Point3D<float> locXYZ;
     float sigmaY2 = ioutils::DefClusError2Row, sigmaZ2 = ioutils::DefClusError2Col, sigmaYZ = 0; //Dummy COG errors (about half pixel size)
     if (pattID != itsmft::CompCluster::InvalidPatternID) {
-      sigmaY2 = dict.getErr2X(pattID);
-      sigmaZ2 = dict.getErr2Z(pattID);
-      if (!dict.isGroup(pattID)) {
-        locXYZ = dict.getClusterCoordinates(c);
+      sigmaY2 = dict->getErr2X(pattID);
+      sigmaZ2 = dict->getErr2Z(pattID);
+      if (!dict->isGroup(pattID)) {
+        locXYZ = dict->getClusterCoordinates(c);
       } else {
         o2::itsmft::ClusterPattern patt(pattIt);
-        locXYZ = dict.getClusterCoordinates(c, patt);
+        locXYZ = dict->getClusterCoordinates(c, patt);
       }
     } else {
       o2::itsmft::ClusterPattern patt(pattIt);
-      locXYZ = dict.getClusterCoordinates(c, patt, false);
+      locXYZ = dict->getClusterCoordinates(c, patt, false);
     }
     auto sensorID = c.getSensorID();
     // Inverse transformation to the local --> tracking

--- a/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
@@ -114,7 +114,7 @@ int TimeFrame::loadROFrameData(const o2::itsmft::ROFRecord& rof, gsl::span<const
   return clusters_in_frame.size();
 }
 
-int TimeFrame::loadROFrameData(gsl::span<o2::itsmft::ROFRecord> rofs, gsl::span<const itsmft::CompClusterExt> clusters, gsl::span<const unsigned char>::iterator& pattIt, const itsmft::TopologyDictionary& dict, const dataformats::MCTruthContainer<MCCompLabel>* mcLabels)
+int TimeFrame::loadROFrameData(gsl::span<o2::itsmft::ROFRecord> rofs, gsl::span<const itsmft::CompClusterExt> clusters, gsl::span<const unsigned char>::iterator& pattIt, const itsmft::TopologyDictionary* dict, const dataformats::MCTruthContainer<MCCompLabel>* mcLabels)
 {
   GeometryTGeo* geom = GeometryTGeo::Instance();
   geom->fillMatrixCache(o2::math_utils::bit2Mask(o2::math_utils::TransformType::T2L, o2::math_utils::TransformType::L2G));
@@ -129,17 +129,17 @@ int TimeFrame::loadROFrameData(gsl::span<o2::itsmft::ROFRecord> rofs, gsl::span<
     o2::math_utils::Point3D<float> locXYZ;
     float sigmaY2 = DefClusError2Row, sigmaZ2 = DefClusError2Col, sigmaYZ = 0; //Dummy COG errors (about half pixel size)
     if (pattID != itsmft::CompCluster::InvalidPatternID) {
-      sigmaY2 = dict.getErr2X(pattID);
-      sigmaZ2 = dict.getErr2Z(pattID);
-      if (!dict.isGroup(pattID)) {
-        locXYZ = dict.getClusterCoordinates(c);
+      sigmaY2 = dict->getErr2X(pattID);
+      sigmaZ2 = dict->getErr2Z(pattID);
+      if (!dict->isGroup(pattID)) {
+        locXYZ = dict->getClusterCoordinates(c);
       } else {
         o2::itsmft::ClusterPattern patt(pattIt);
-        locXYZ = dict.getClusterCoordinates(c, patt);
+        locXYZ = dict->getClusterCoordinates(c, patt);
       }
     } else {
       o2::itsmft::ClusterPattern patt(pattIt);
-      locXYZ = dict.getClusterCoordinates(c, patt, false);
+      locXYZ = dict->getClusterCoordinates(c, patt, false);
     }
     auto sensorID = c.getSensorID();
     // Inverse transformation to the local --> tracking

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ClustererSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ClustererSpec.h
@@ -40,11 +40,15 @@ class ClustererDPL : public Task
   ~ClustererDPL() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
+  void finaliseCCDB(ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
+  void updateTimeDependentParams(ProcessingContext& pc);
+
   int mState = 0;
   bool mUseMC = true;
   bool mPatterns = true;
+  bool mUseClusterDictionary = true;
   int mNThreads = 1;
   std::unique_ptr<std::ifstream> mFile = nullptr;
   std::unique_ptr<o2::itsmft::Clusterer> mClusterer = nullptr;

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/CookedTrackerSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/CookedTrackerSpec.h
@@ -38,13 +38,17 @@ class CookedTrackerDPL : public Task
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
   void endOfStream(framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(ConcreteDataMatcher& matcher, void* obj) final;
+  void setClusterDictionary(const o2::itsmft::TopologyDictionary* d) { mDict = d; }
 
  private:
+  void updateTimeDependentParams(ProcessingContext& pc);
+
   int mState = 0;
   bool mUseMC = true;
   bool mRunVertexer = true;
   std::string mMode = "async";
-  o2::itsmft::TopologyDictionary mDict;
+  const o2::itsmft::TopologyDictionary* mDict = nullptr;
   std::unique_ptr<o2::parameters::GRPObject> mGRP = nullptr;
   o2::its::CookedTracker mTracker;
   std::unique_ptr<VertexerTraits> mVertexerTraitsPtr = nullptr;

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/TrackerSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/TrackerSpec.h
@@ -45,13 +45,17 @@ class TrackerDPL : public framework::Task
   void init(framework::InitContext& ic) final;
   void run(framework::ProcessingContext& pc) final;
   void endOfStream(framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(framework::ConcreteDataMatcher& matcher, void* obj) final;
+  void setClusterDictionary(const o2::itsmft::TopologyDictionary* d) { mDict = d; }
 
  private:
+  void updateTimeDependentParams(framework::ProcessingContext& pc);
+
   bool mIsMC = false;
   bool mRunVertexer = true;
   float mBz = 0.f;
   std::string mMode = "sync";
-  o2::itsmft::TopologyDictionary mDict;
+  const o2::itsmft::TopologyDictionary* mDict = nullptr;
   std::unique_ptr<o2::gpu::GPUReconstruction> mRecChain = nullptr;
   std::unique_ptr<parameters::GRPObject> mGRP = nullptr;
   std::unique_ptr<Tracker> mTracker = nullptr;

--- a/Detectors/ITSMFT/ITS/workflow/src/ClustererSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ClustererSpec.cxx
@@ -136,7 +136,7 @@ void ClustererDPL::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
   if (matcher == ConcreteDataMatcher("ITS", "CLUSDICT", 0)) {
     LOG(info) << "cluster dictionary updated" << (!mUseClusterDictionary ? " but its using is disabled" : "");
     if (mUseClusterDictionary) {
-      mClusterer->setDictionary((const TopologyDictionary*)obj);
+      mClusterer->setDictionary((const o2::itsmft::TopologyDictionary*)obj);
     }
   }
 }

--- a/Detectors/ITSMFT/ITS/workflow/src/ClustererSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ClustererSpec.cxx
@@ -15,10 +15,12 @@
 
 #include "Framework/ControlService.h"
 #include "Framework/ConfigParamRegistry.h"
+#include "Framework/CCDBParamSpec.h"
 #include "ITSWorkflow/ClustererSpec.h"
 #include "DataFormatsITSMFT/Digit.h"
 #include "ITSMFTReconstruction/ChipMappingITS.h"
 #include "ITSMFTReconstruction/ClustererParam.h"
+#include "DataFormatsITSMFT/TopologyDictionary.h"
 #include "DataFormatsITSMFT/CompCluster.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/ConstMCTruthContainer.h"
@@ -30,6 +32,7 @@
 #include "DetectorsCommonDataFormats/DetectorNameConf.h"
 
 using namespace o2::framework;
+using namespace o2::itsmft;
 
 namespace o2
 {
@@ -40,7 +43,7 @@ void ClustererDPL::init(InitContext& ic)
 {
   mClusterer = std::make_unique<o2::itsmft::Clusterer>();
   mClusterer->setNChips(o2::itsmft::ChipMappingITS::getNChips());
-
+  mUseClusterDictionary = !ic.options().get<bool>("ignore-cluster-dictionary");
   auto filenameGRP = ic.options().get<std::string>("grp-file");
   const auto grp = o2::parameters::GRPObject::loadFrom(filenameGRP.c_str());
 
@@ -63,20 +66,13 @@ void ClustererDPL::init(InitContext& ic)
   mClusterer->setMaxBCSeparationToMask(nbc);
   mClusterer->setMaxRowColDiffToMask(clParams.maxRowColDiffToMask);
 
-  std::string dictPath = o2::itsmft::ClustererParam<o2::detectors::DetID::ITS>::Instance().dictFilePath;
-  std::string dictFile = o2::base::DetectorNameConf::getAlpideClusterDictionaryFileName(o2::detectors::DetID::ITS, dictPath);
-  if (o2::utils::Str::pathExists(dictFile)) {
-    mClusterer->loadDictionary(dictFile);
-    LOG(info) << "ITSClusterer running with a provided dictionary: " << dictFile;
-  } else {
-    LOG(info) << "Dictionary " << dictFile << " is absent, ITSClusterer expects cluster patterns";
-  }
   mState = 1;
   mClusterer->print();
 }
 
 void ClustererDPL::run(ProcessingContext& pc)
 {
+  updateTimeDependentParams(pc);
   auto digits = pc.inputs().get<gsl::span<o2::itsmft::Digit>>("digits");
   auto rofs = pc.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("ROframes");
 
@@ -128,11 +124,29 @@ void ClustererDPL::run(ProcessingContext& pc)
   LOG(info) << "ITSClusterer pushed " << clusCompVec.size() << " clusters, in " << clusROFVec.size() << " RO frames";
 }
 
+///_______________________________________
+void ClustererDPL::updateTimeDependentParams(ProcessingContext& pc)
+{
+  pc.inputs().get<TopologyDictionary*>("cldict"); // just to trigger the finaliseCCDB
+}
+
+///_______________________________________
+void ClustererDPL::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
+{
+  if (matcher == ConcreteDataMatcher("ITS", "CLUSDICT", 0)) {
+    LOG(info) << "cluster dictionary updated" << (!mUseClusterDictionary ? " but its using is disabled" : "");
+    if (mUseClusterDictionary) {
+      mClusterer->setDictionary((const TopologyDictionary*)obj);
+    }
+  }
+}
+
 DataProcessorSpec getClustererSpec(bool useMC)
 {
   std::vector<InputSpec> inputs;
   inputs.emplace_back("digits", "ITS", "DIGITS", 0, Lifetime::Timeframe);
   inputs.emplace_back("ROframes", "ITS", "DIGITSROF", 0, Lifetime::Timeframe);
+  inputs.emplace_back("cldict", "ITS", "CLUSDICT", 0, Lifetime::Condition, ccdbParamSpec("ITS/Calib/ClusterDictionary"));
 
   std::vector<OutputSpec> outputs;
   outputs.emplace_back("ITS", "COMPCLUSTERS", 0, Lifetime::Timeframe);
@@ -154,6 +168,7 @@ DataProcessorSpec getClustererSpec(bool useMC)
     Options{
       {"grp-file", VariantType::String, "o2sim_grp.root", {"Name of the grp file"}},
       {"no-patterns", o2::framework::VariantType::Bool, false, {"Do not save rare cluster patterns"}},
+      {"ignore-cluster-dictionary", VariantType::Bool, false, {"do not use cluster dictionary, always store explicit patterns"}},
       {"nthreads", VariantType::Int, 1, {"Number of clustering threads"}}}};
 }
 

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -17,6 +17,7 @@
 
 #include "Framework/ControlService.h"
 #include "Framework/ConfigParamRegistry.h"
+#include "Framework/CCDBParamSpec.h"
 #include "ITSWorkflow/TrackerSpec.h"
 #include "DataFormatsITSMFT/CompCluster.h"
 #include "DataFormatsITS/TrackITS.h"
@@ -155,20 +156,12 @@ void TrackerDPL::init(InitContext& ic)
   } else {
     throw std::runtime_error(o2::utils::Str::concat_string("Cannot retrieve GRP from the ", filename));
   }
-
-  std::string dictPath = o2::itsmft::ClustererParam<o2::detectors::DetID::ITS>::Instance().dictFilePath;
-  std::string dictFile = o2::base::DetectorNameConf::getAlpideClusterDictionaryFileName(o2::detectors::DetID::ITS, dictPath);
-  if (o2::utils::Str::pathExists(dictFile)) {
-    mDict.readFromFile(dictFile);
-    LOG(info) << "Tracker running with a provided dictionary: " << dictFile;
-  } else {
-    LOG(info) << "Dictionary " << dictFile << " is absent, Tracker expects cluster patterns";
-  }
 }
 
 void TrackerDPL::run(ProcessingContext& pc)
 {
   mTimer.Start(false);
+  updateTimeDependentParams(pc);
   auto compClusters = pc.inputs().get<gsl::span<o2::itsmft::CompClusterExt>>("compClusters");
   gsl::span<const unsigned char> patterns = pc.inputs().get<gsl::span<unsigned char>>("patterns");
 
@@ -336,6 +329,21 @@ void TrackerDPL::run(ProcessingContext& pc)
   mTimer.Stop();
 }
 
+///_______________________________________
+void TrackerDPL::updateTimeDependentParams(ProcessingContext& pc)
+{
+  pc.inputs().get<o2::itsmft::TopologyDictionary*>("cldict"); // just to trigger the finaliseCCDB
+}
+
+///_______________________________________
+void TrackerDPL::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
+{
+  if (matcher == ConcreteDataMatcher("ITS", "CLUSDICT", 0)) {
+    LOG(info) << "cluster dictionary updated";
+    setClusterDictionary((const o2::itsmft::TopologyDictionary*)obj);
+  }
+}
+
 void TrackerDPL::endOfStream(EndOfStreamContext& ec)
 {
   LOGF(info, "ITS CA-Tracker total timing: Cpu: %.3e Real: %.3e s in %d slots",
@@ -348,6 +356,7 @@ DataProcessorSpec getTrackerSpec(bool useMC, const std::string& trModeS, o2::gpu
   inputs.emplace_back("compClusters", "ITS", "COMPCLUSTERS", 0, Lifetime::Timeframe);
   inputs.emplace_back("patterns", "ITS", "PATTERNS", 0, Lifetime::Timeframe);
   inputs.emplace_back("ROframes", "ITS", "CLUSTERSROF", 0, Lifetime::Timeframe);
+  inputs.emplace_back("cldict", "ITS", "CLUSDICT", 0, Lifetime::Condition, ccdbParamSpec("ITS/Calib/ClusterDictionary"));
 
   std::vector<OutputSpec> outputs;
   outputs.emplace_back("ITS", "TRACKS", 0, Lifetime::Timeframe);

--- a/Detectors/ITSMFT/MFT/assessment/include/MFTAssessment/MFTAssessment.h
+++ b/Detectors/ITSMFT/MFT/assessment/include/MFTAssessment/MFTAssessment.h
@@ -76,14 +76,14 @@ class MFTAssessment
   void getHistos(TObjArray& objar);
   void deleteHistograms();
   void setBz(float bz) { mBz = bz; }
-
+  void setClusterDictionary(const o2::itsmft::TopologyDictionary* d) { mDictionary = d; }
   double orbitToSeconds(uint32_t orbit, uint32_t refOrbit)
   {
     return (orbit - refOrbit) * o2::constants::lhc::LHCOrbitNS / 1E9;
   }
 
  private:
-  o2::itsmft::TopologyDictionary mDictionary; // cluster patterns dictionary
+  const o2::itsmft::TopologyDictionary* mDictionary = nullptr; // cluster patterns dictionary
 
   gsl::span<const o2::mft::TrackMFT> mMFTTracks;
   gsl::span<const o2::itsmft::ROFRecord> mMFTTracksROF;

--- a/Detectors/ITSMFT/MFT/assessment/src/MFTAssessment.cxx
+++ b/Detectors/ITSMFT/MFT/assessment/src/MFTAssessment.cxx
@@ -31,17 +31,6 @@ void MFTAssessment::init(bool finalizeAnalysis)
   //get geometry
   o2::base::GeometryManager::loadGeometry("", true);
 
-  //load the cluster dictionary
-  std::string dictPath = o2::itsmft::ClustererParam<o2::detectors::DetID::MFT>::Instance().dictFilePath;
-  std::string dictFile = o2::base::DetectorNameConf::getAlpideClusterDictionaryFileName(o2::detectors::DetID::MFT, dictPath);
-  if (o2::utils::Str::pathExists(dictFile)) {
-    mDictionary.readBinaryFile(dictFile);
-    LOG(info) << "MFTAssessment running with a provided dictionary: " << dictFile;
-    printf("DictPath is %s\n", dictPath.c_str());
-  } else {
-    LOG(fatal) << "Dictionary " << dictFile << " is absent, MFTAssessment expects cluster patterns";
-  }
-
   mUnusedChips.fill(true);
 }
 

--- a/Detectors/ITSMFT/MFT/calibration/include/MFTCalibration/NoiseCalibrator.h
+++ b/Detectors/ITSMFT/MFT/calibration/include/MFTCalibration/NoiseCalibrator.h
@@ -57,15 +57,12 @@ class NoiseCalibrator
 
   void finalize();
 
-  void loadDictionary(std::string fname)
-  {
-    mDict.readBinaryFile(fname);
-  }
+  void setClusterDictionary(const o2::itsmft::TopologyDictionary* d) { mDict = d; }
 
   const o2::itsmft::NoiseMap& getNoiseMap() const { return mNoiseMap; }
 
  private:
-  o2::itsmft::TopologyDictionary mDict;
+  const o2::itsmft::TopologyDictionary* mDict = nullptr;
   o2::itsmft::NoiseMap mNoiseMap{936};
   float mProbabilityThreshold = 1e-6f;
   unsigned int mThreshold = 100;

--- a/Detectors/ITSMFT/MFT/calibration/include/MFTCalibration/NoiseCalibratorSpec.h
+++ b/Detectors/ITSMFT/MFT/calibration/include/MFTCalibration/NoiseCalibratorSpec.h
@@ -44,8 +44,10 @@ class NoiseCalibratorSpec : public Task
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
   void endOfStream(EndOfStreamContext& ec) final;
+  void finaliseCCDB(ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
+  void updateTimeDependentParams(ProcessingContext& pc);
   void sendOutput(DataAllocator& output);
   o2::itsmft::NoiseMap mNoiseMap{936};
   std::unique_ptr<CALIBRATOR> mCalibrator = nullptr;

--- a/Detectors/ITSMFT/MFT/calibration/src/NoiseCalibrator.cxx
+++ b/Detectors/ITSMFT/MFT/calibration/src/NoiseCalibrator.cxx
@@ -61,7 +61,7 @@ bool NoiseCalibrator::processTimeFrame(calibration::TFType tf,
       o2::itsmft::ClusterPattern patt;
       auto row = c.getRow();
       auto col = c.getCol();
-      if (mDict.getSize() == 0) {
+      if (mDict->getSize() == 0) {
         if (pattID == o2::itsmft::CompCluster::InvalidPatternID) {
           patt.acquirePattern(pattIt);
         } else {
@@ -69,14 +69,14 @@ bool NoiseCalibrator::processTimeFrame(calibration::TFType tf,
         }
       } else if (pattID == o2::itsmft::CompCluster::InvalidPatternID) {
         patt.acquirePattern(pattIt);
-      } else if (mDict.isGroup(pattID)) {
+      } else if (mDict->isGroup(pattID)) {
         patt.acquirePattern(pattIt);
         float xCOG = 0., zCOG = 0.;
         patt.getCOG(xCOG, zCOG); // for grouped patterns the reference pixel is at COG
         row -= round(xCOG);
         col -= round(zCOG);
       } else {
-        patt = mDict.getPattern(pattID);
+        patt = mDict->getPattern(pattID);
       }
       auto id = c.getSensorID();
       auto colSpan = patt.getColumnSpan();

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/IOUtils.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/IOUtils.h
@@ -58,13 +58,13 @@ constexpr float DefClusError2Col = DefClusErrorCol * DefClusErrorCol;
 
 template <typename T>
 int loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe<T>& events, gsl::span<const itsmft::CompClusterExt> clusters,
-                    gsl::span<const unsigned char>::iterator& pattIt, const itsmft::TopologyDictionary& dict,
+                    gsl::span<const unsigned char>::iterator& pattIt, const itsmft::TopologyDictionary* dict,
                     const dataformats::MCTruthContainer<MCCompLabel>* mClsLabels = nullptr, const o2::mft::Tracker<T>* tracker = nullptr);
 
 void convertCompactClusters(gsl::span<const itsmft::CompClusterExt> clusters,
                             gsl::span<const unsigned char>::iterator& pattIt,
                             std::vector<o2::BaseCluster<float>>& output,
-                            const itsmft::TopologyDictionary& dict);
+                            const itsmft::TopologyDictionary* dict);
 } // namespace ioutils
 } // namespace mft
 } // namespace o2

--- a/Detectors/ITSMFT/MFT/tracking/src/IOUtils.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/IOUtils.cxx
@@ -37,7 +37,7 @@ namespace mft
 
 //_________________________________________________________
 template <typename T>
-int ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe<T>& event, gsl::span<const itsmft::CompClusterExt> clusters, gsl::span<const unsigned char>::iterator& pattIt, const itsmft::TopologyDictionary& dict, const dataformats::MCTruthContainer<MCCompLabel>* mcLabels, const o2::mft::Tracker<T>* tracker)
+int ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe<T>& event, gsl::span<const itsmft::CompClusterExt> clusters, gsl::span<const unsigned char>::iterator& pattIt, const itsmft::TopologyDictionary* dict, const dataformats::MCTruthContainer<MCCompLabel>* mcLabels, const o2::mft::Tracker<T>* tracker)
 {
   event.clear();
   GeometryTGeo* geom = GeometryTGeo::Instance();
@@ -52,17 +52,17 @@ int ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe<T>& event
     o2::math_utils::Point3D<float> locXYZ;
     float sigmaX2 = ioutils::DefClusError2Row, sigmaY2 = ioutils::DefClusError2Col; //Dummy COG errors (about half pixel size)
     if (pattID != itsmft::CompCluster::InvalidPatternID) {
-      sigmaX2 = dict.getErr2X(pattID); // ALPIDE local X coordinate => MFT global X coordinate (ALPIDE rows)
-      sigmaY2 = dict.getErr2Z(pattID); // ALPIDE local Z coordinate => MFT global Y coordinate (ALPIDE columns)
-      if (!dict.isGroup(pattID)) {
-        locXYZ = dict.getClusterCoordinates(c);
+      sigmaX2 = dict->getErr2X(pattID); // ALPIDE local X coordinate => MFT global X coordinate (ALPIDE rows)
+      sigmaY2 = dict->getErr2Z(pattID); // ALPIDE local Z coordinate => MFT global Y coordinate (ALPIDE columns)
+      if (!dict->isGroup(pattID)) {
+        locXYZ = dict->getClusterCoordinates(c);
       } else {
         o2::itsmft::ClusterPattern patt(pattIt);
-        locXYZ = dict.getClusterCoordinates(c, patt);
+        locXYZ = dict->getClusterCoordinates(c, patt);
       }
     } else {
       o2::itsmft::ClusterPattern patt(pattIt);
-      locXYZ = dict.getClusterCoordinates(c, patt, false);
+      locXYZ = dict->getClusterCoordinates(c, patt, false);
     }
     // Transformation to the local --> global
     auto gloXYZ = geom->getMatrixL2G(sensorID) * locXYZ;
@@ -89,7 +89,7 @@ int ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe<T>& event
 void ioutils::convertCompactClusters(gsl::span<const itsmft::CompClusterExt> clusters,
                                      gsl::span<const unsigned char>::iterator& pattIt,
                                      std::vector<o2::BaseCluster<float>>& output,
-                                     const itsmft::TopologyDictionary& dict)
+                                     const itsmft::TopologyDictionary* dict)
 {
   GeometryTGeo* geom = GeometryTGeo::Instance();
   geom->fillMatrixCache(o2::math_utils::bit2Mask(o2::math_utils::TransformType::T2L, o2::math_utils::TransformType::L2G));
@@ -100,17 +100,17 @@ void ioutils::convertCompactClusters(gsl::span<const itsmft::CompClusterExt> clu
     o2::math_utils::Point3D<float> locXYZ;
     float sigmaX2 = DefClusError2Row, sigmaY2 = DefClusError2Col;
     if (pattID != itsmft::CompCluster::InvalidPatternID) {
-      sigmaX2 = dict.getErr2X(pattID); // ALPIDE local Y coordinate => MFT global X coordinate (ALPIDE rows)
-      sigmaY2 = dict.getErr2Z(pattID); // ALPIDE local Z coordinate => MFT global Y coordinate (ALPIDE columns)
-      if (!dict.isGroup(pattID)) {
-        locXYZ = dict.getClusterCoordinates(c);
+      sigmaX2 = dict->getErr2X(pattID); // ALPIDE local Y coordinate => MFT global X coordinate (ALPIDE rows)
+      sigmaY2 = dict->getErr2Z(pattID); // ALPIDE local Z coordinate => MFT global Y coordinate (ALPIDE columns)
+      if (!dict->isGroup(pattID)) {
+        locXYZ = dict->getClusterCoordinates(c);
       } else {
         o2::itsmft::ClusterPattern patt(pattIt);
-        locXYZ = dict.getClusterCoordinates(c, patt);
+        locXYZ = dict->getClusterCoordinates(c, patt);
       }
     } else {
       o2::itsmft::ClusterPattern patt(pattIt);
-      locXYZ = dict.getClusterCoordinates(c, patt, false);
+      locXYZ = dict->getClusterCoordinates(c, patt, false);
     }
 
     // Transformation to the local --> global
@@ -121,11 +121,11 @@ void ioutils::convertCompactClusters(gsl::span<const itsmft::CompClusterExt> clu
   }
 }
 template int o2::mft::ioutils::loadROFrameData<o2::mft::TrackLTF>(const o2::itsmft::ROFRecord&, ROframe<o2::mft::TrackLTF>&, gsl::span<const itsmft::CompClusterExt>,
-                                                                  gsl::span<const unsigned char>::iterator&, const itsmft::TopologyDictionary&,
+                                                                  gsl::span<const unsigned char>::iterator&, const itsmft::TopologyDictionary*,
                                                                   const dataformats::MCTruthContainer<MCCompLabel>*, const o2::mft::Tracker<o2::mft::TrackLTF>*);
 
 template int o2::mft::ioutils::loadROFrameData<o2::mft::TrackLTFL>(const o2::itsmft::ROFRecord&, ROframe<o2::mft::TrackLTFL>&, gsl::span<const itsmft::CompClusterExt>,
-                                                                   gsl::span<const unsigned char>::iterator&, const itsmft::TopologyDictionary&,
+                                                                   gsl::span<const unsigned char>::iterator&, const itsmft::TopologyDictionary*,
                                                                    const dataformats::MCTruthContainer<MCCompLabel>*, const o2::mft::Tracker<o2::mft::TrackLTFL>*);
 
 } // namespace mft

--- a/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/ClustererSpec.h
+++ b/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/ClustererSpec.h
@@ -35,11 +35,15 @@ class ClustererDPL : public Task
   ~ClustererDPL() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
+  void finaliseCCDB(ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
+  void updateTimeDependentParams(ProcessingContext& pc);
+
   int mState = 0;
   bool mUseMC = true;
   bool mPatterns = true;
+  bool mUseClusterDictionary = true;
   int mNThreads = 1;
   std::unique_ptr<std::ifstream> mFile = nullptr;
   std::unique_ptr<o2::itsmft::Clusterer> mClusterer = nullptr;

--- a/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/MFTAssessmentSpec.h
+++ b/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/MFTAssessmentSpec.h
@@ -34,8 +34,10 @@ class MFTAssessmentSpec : public Task
   void init(o2::framework::InitContext& ic) final;
   void run(o2::framework::ProcessingContext& pc) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
+  void updateTimeDependentParams(ProcessingContext& pc);
   void sendOutput(DataAllocator& output);
   std::unique_ptr<o2::mft::MFTAssessment> mMFTAssessment;
   bool mUseMC = true;

--- a/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/TrackerSpec.h
+++ b/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/TrackerSpec.h
@@ -35,14 +35,17 @@ class TrackerDPL : public o2::framework::Task
  public:
   TrackerDPL(bool useMC) : mUseMC(useMC) {}
   ~TrackerDPL() override = default;
-  void init(o2::framework::InitContext& ic) final;
-  void run(o2::framework::ProcessingContext& pc) final;
+  void init(framework::InitContext& ic) final;
+  void run(framework::ProcessingContext& pc) final;
   void endOfStream(framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(framework::ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
+  void updateTimeDependentParams(framework::ProcessingContext& pc);
+
   bool mUseMC = false;
   bool mFieldOn = true;
-  o2::itsmft::TopologyDictionary mDict;
+  const o2::itsmft::TopologyDictionary* mDict = nullptr;
   std::unique_ptr<o2::parameters::GRPObject> mGRP = nullptr;
   std::unique_ptr<o2::mft::Tracker<TrackLTF>> mTracker = nullptr;
   std::unique_ptr<o2::mft::Tracker<TrackLTFL>> mTrackerL = nullptr;

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/Clusterer.h
@@ -222,6 +222,7 @@ class Clusterer
 
   ///< load the dictionary of cluster topologies
   void loadDictionary(const std::string& fileName) { mPattIdConverter.loadDictionary(fileName); }
+  void setDictionary(const TopologyDictionary* dict) { mPattIdConverter.setDictionary(dict); }
 
   TStopwatch& getTimer() { return mTimer; } // cannot be const
   TStopwatch& getTimerMerge() { return mTimerMerge; } // cannot be const

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/LookUp.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/LookUp.h
@@ -39,6 +39,7 @@ class LookUp
   int findGroupID(int nRow, int nCol, const unsigned char patt[ClusterPattern::MaxPatternBytes]) const;
   int getTopologiesOverThreshold() const { return mTopologiesOverThreshold; }
   void loadDictionary(std::string fileName);
+  void setDictionary(const TopologyDictionary* dict);
   bool isGroup(int id) const { return mDictionary.isGroup(id); }
   int size() const { return mDictionary.getSize(); }
   auto getPattern(int id) const { return mDictionary.getPattern(id); }

--- a/Detectors/ITSMFT/common/reconstruction/src/LookUp.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/LookUp.cxx
@@ -38,6 +38,14 @@ void LookUp::loadDictionary(std::string fileName)
   mTopologiesOverThreshold = mDictionary.mCommonMap.size();
 }
 
+void LookUp::setDictionary(const TopologyDictionary* dict)
+{
+  if (dict) {
+    mDictionary = *dict;
+  }
+  mTopologiesOverThreshold = mDictionary.mCommonMap.size();
+}
+
 int LookUp::groupFinder(int nRow, int nCol)
 {
   int row_index = nRow / TopologyDictionary::RowClassSpan;

--- a/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/ChipDigitsContainer.h
+++ b/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/ChipDigitsContainer.h
@@ -20,6 +20,7 @@
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "ITSMFTBase/SegmentationAlpide.h"
 #include "ITSMFTSimulation/PreDigit.h"
+#include "DataFormatsITSMFT/NoiseMap.h"
 #include <map>
 #include <vector>
 
@@ -43,7 +44,8 @@ class ChipDigitsContainer
 
   std::map<ULong64_t, o2::itsmft::PreDigit>& getPreDigits() { return mDigits; }
   bool isEmpty() const { return mDigits.empty(); }
-
+  void setNoiseMap(const o2::itsmft::NoiseMap* mp) { mNoiseMap = mp; }
+  void setDeadChanMap(const o2::itsmft::NoiseMap* mp) { mDeadChanMap = mp; }
   void setChipIndex(UShort_t ind) { mChipIndex = ind; }
   UShort_t getChipIndex() const { return mChipIndex; }
 
@@ -69,6 +71,8 @@ class ChipDigitsContainer
  protected:
   UShort_t mChipIndex = 0;                           ///< chip index
   bool mDisabled = false;
+  const o2::itsmft::NoiseMap* mNoiseMap = nullptr;
+  const o2::itsmft::NoiseMap* mDeadChanMap = nullptr;
   std::map<ULong64_t, o2::itsmft::PreDigit> mDigits; ///< Map of fired pixels, possibly in multiple frames
 
   ClassDefNV(ChipDigitsContainer, 1);

--- a/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Digitizer.h
+++ b/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Digitizer.h
@@ -59,6 +59,7 @@ class Digitizer : public TObject
   o2::itsmft::DigiParams& getParams() { return (o2::itsmft::DigiParams&)mParams; }
   const o2::itsmft::DigiParams& getParams() const { return mParams; }
   void setNoiseMap(const o2::itsmft::NoiseMap* mp);
+  void setDeadChannelsMap(const o2::itsmft::NoiseMap* mp);
 
   void init();
 
@@ -136,6 +137,7 @@ class Digitizer : public TObject
   std::vector<o2::itsmft::ROFRecord>* mROFRecords = nullptr;               //! output ROF records
   o2::dataformats::MCTruthContainer<o2::MCCompLabel>* mMCLabels = nullptr; //! output labels
   const o2::itsmft::NoiseMap* mNoiseMap = nullptr;
+  const o2::itsmft::NoiseMap* mDeadChanMap = nullptr;
 
   ClassDefOverride(Digitizer, 2);
 };

--- a/Detectors/ITSMFT/common/simulation/src/ChipDigitsContainer.cxx
+++ b/Detectors/ITSMFT/common/simulation/src/ChipDigitsContainer.cxx
@@ -39,6 +39,12 @@ void ChipDigitsContainer::addNoise(UInt_t rofMin, UInt_t rofMax, const o2::itsmf
     for (Int_t i = 0; i < nhits; ++i) {
       row = gRandom->Integer(maxRows);
       col = gRandom->Integer(maxCols);
+      if (mNoiseMap && mNoiseMap->isNoisy(mChipIndex, row, col)) {
+        continue;
+      }
+      if (mDeadChanMap && mDeadChanMap->isNoisy(mChipIndex, row, col)) {
+        continue;
+      }
       // RS TODO: why the noise was added with 0 charge? It should be above the threshold!
       auto key = getOrderingKey(rof, row, col);
       if (!findDigit(key)) {

--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/EntropyDecoderSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/EntropyDecoderSpec.h
@@ -37,6 +37,7 @@ class EntropyDecoderSpec : public o2::framework::Task
   void init(o2::framework::InitContext& ic) final;
   void run(o2::framework::ProcessingContext& pc) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
 
   static auto getName(o2::header::DataOrigin orig) { return std::string{orig == o2::header::gDataOriginITS ? ITSDeviceName : MFTDeviceName}; }
 
@@ -47,13 +48,14 @@ class EntropyDecoderSpec : public o2::framework::Task
   static constexpr std::string_view MFTDeviceName = "mft-entropy-decoder";
   o2::header::DataOrigin mOrigin = o2::header::gDataOriginInvalid;
   o2::itsmft::CTFCoder mCTFCoder;
-  std::unique_ptr<NoiseMap> mNoiseMap;
+  const NoiseMap* mNoiseMap = nullptr;
   LookUp mPattIdConverter;
   bool mGetDigits{false};
   bool mMaskNoise{false};
+  bool mUseClusterDictionary{true};
+
   std::string mCTFDictPath{};
   std::string mClusDictPath{};
-  std::string mNoiseFilePath{};
   TStopwatch mTimer;
 };
 

--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/STFDecoderSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/STFDecoderSpec.h
@@ -57,8 +57,10 @@ class STFDecoder : public Task
   void run(ProcessingContext& pc) final;
   void endOfStream(EndOfStreamContext& ec) final { finalize(); }
   void stop() final { finalize(); }
+  void finaliseCCDB(ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
+  void updateTimeDependentParams(ProcessingContext& pc);
   void finalize();
   std::unique_ptr<o2::itsmft::Clusterer> setupClusterer(const std::string& dictName);
   TStopwatch mTimer;
@@ -69,6 +71,8 @@ class STFDecoder : public Task
   bool mUnmutExtraLanes = false;
   bool mFinalizeDone = false;
   bool mAllowReporting = true;
+  bool mApplyNoiseMap = true;
+  bool mUseClusterDictionary = true;
   int mDumpOnError = 0;
   int mNThreads = 1;
   int mVerbosity = 0;
@@ -80,8 +84,6 @@ class STFDecoder : public Task
   size_t mEstNROF = 0;
   std::string mInputSpec;
   std::string mSelfName;
-  std::string mDictName;
-  std::string mNoiseName;
   std::unique_ptr<RawPixelDecoder<Mapping>> mDecoder;
   std::unique_ptr<Clusterer> mClusterer;
 };

--- a/Detectors/ITSMFT/common/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/EntropyDecoderSpec.cxx
@@ -15,6 +15,7 @@
 
 #include "Framework/ControlService.h"
 #include "Framework/ConfigParamRegistry.h"
+#include "Framework/CCDBParamSpec.h"
 #include "DataFormatsITSMFT/CompCluster.h"
 #include "ITSMFTWorkflow/EntropyDecoderSpec.h"
 #include "ITSMFTReconstruction/ClustererParam.h"
@@ -43,8 +44,7 @@ void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
   mClusDictPath = o2::header::gDataOriginITS ? o2::itsmft::ClustererParam<o2::detectors::DetID::ITS>::Instance().dictFilePath : o2::itsmft::ClustererParam<o2::detectors::DetID::MFT>::Instance().dictFilePath;
   mClusDictPath = o2::base::DetectorNameConf::getAlpideClusterDictionaryFileName(detID, mClusDictPath);
   mMaskNoise = ic.options().get<bool>("mask-noise");
-  mNoiseFilePath = o2::header::gDataOriginITS ? o2::itsmft::ClustererParam<o2::detectors::DetID::ITS>::Instance().noiseFilePath : o2::itsmft::ClustererParam<o2::detectors::DetID::MFT>::Instance().noiseFilePath;
-  mNoiseFilePath = o2::base::DetectorNameConf::getNoiseFileName(detID, mNoiseFilePath, "root");
+  mUseClusterDictionary = !ic.options().get<bool>("ignore-cluster-dictionary");
 }
 
 void EntropyDecoderSpec::run(ProcessingContext& pc)
@@ -61,7 +61,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   if (mGetDigits) {
     auto& digits = pc.outputs().make<std::vector<o2::itsmft::Digit>>(OutputRef{"Digits"});
     if (buff.size()) {
-      mCTFCoder.decode(o2::itsmft::CTF::getImage(buff.data()), rofs, digits, mNoiseMap.get(), mPattIdConverter);
+      mCTFCoder.decode(o2::itsmft::CTF::getImage(buff.data()), rofs, digits, mNoiseMap, mPattIdConverter);
     }
     mTimer.Stop();
     LOG(info) << "Decoded " << digits.size() << " digits in " << rofs.size() << " RO frames in " << mTimer.CpuTime() - cput << " s";
@@ -69,7 +69,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
     auto& compcl = pc.outputs().make<std::vector<o2::itsmft::CompClusterExt>>(OutputRef{"compClusters"});
     auto& patterns = pc.outputs().make<std::vector<unsigned char>>(OutputRef{"patterns"});
     if (buff.size()) {
-      mCTFCoder.decode(o2::itsmft::CTF::getImage(buff.data()), rofs, compcl, patterns, mNoiseMap.get(), mPattIdConverter);
+      mCTFCoder.decode(o2::itsmft::CTF::getImage(buff.data()), rofs, compcl, patterns, mNoiseMap, mPattIdConverter);
     }
     mTimer.Stop();
     LOG(info) << "Decoded " << compcl.size() << " clusters in " << rofs.size() << " RO frames in " << mTimer.CpuTime() - cput << " s";
@@ -84,32 +84,29 @@ void EntropyDecoderSpec::endOfStream(EndOfStreamContext& ec)
 
 void EntropyDecoderSpec::updateTimeDependentParams(ProcessingContext& pc)
 {
+  if (mMaskNoise) {
+    mNoiseMap = pc.inputs().get<o2::itsmft::NoiseMap*>("noise").get();
+  }
+  if (mGetDigits || mMaskNoise) {
+    pc.inputs().get<o2::itsmft::NoiseMap*>("cldict");
+  }
   static bool coderUpdated = false; // with dicts loaded from CCDB one should check also the validity of current object
   if (!coderUpdated) {
     coderUpdated = true;
     if (!mCTFDictPath.empty() && mCTFDictPath != "none") {
       mCTFCoder.createCodersFromFile<CTF>(mCTFDictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
     }
+  }
+}
 
-    if (mMaskNoise) {
-      if (o2::utils::Str::pathExists(mNoiseFilePath)) {
-        TFile* f = TFile::Open(mNoiseFilePath.data(), "old");
-        mNoiseMap.reset((NoiseMap*)f->Get("ccdb_object"));
-        LOG(info) << "Loaded noise map from " << mNoiseFilePath;
-      }
-      if (!mNoiseMap) {
-        throw std::runtime_error("Noise masking was requested but noise mask was not provided");
-      }
-    }
-
-    if (mGetDigits || mMaskNoise) {
-      if (o2::utils::Str::pathExists(mClusDictPath)) {
-        mPattIdConverter.loadDictionary(mClusDictPath);
-        LOG(info) << "Loaded cluster topology dictionary from " << mClusDictPath;
-      } else {
-        LOG(info) << "Cluster topology dictionary is absent, all cluster patterns expected to be stored explicitly";
-      }
-    }
+void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+{
+  if (matcher == ConcreteDataMatcher(mOrigin, "NOISEMAP", 0)) {
+    LOG(info) << mOrigin.as<std::string>() << " noise map updated";
+  }
+  if (matcher == ConcreteDataMatcher(mOrigin, "CLUSDICT", 0)) {
+    LOG(info) << mOrigin.as<std::string>() << " cluster dictionary updated" << (!mUseClusterDictionary ? " but its using is disabled" : "");
+    mPattIdConverter.setDictionary((const TopologyDictionary*)obj);
   }
 }
 
@@ -124,6 +121,12 @@ DataProcessorSpec getEntropyDecoderSpec(o2::header::DataOrigin orig, int verbosi
     outputs.emplace_back(OutputSpec{{"ROframes"}, orig, "CLUSTERSROF", 0, Lifetime::Timeframe});
     outputs.emplace_back(OutputSpec{{"patterns"}, orig, "PATTERNS", 0, Lifetime::Timeframe});
   }
+  std::vector<InputSpec> inputs;
+  inputs.emplace_back("ctf", orig, "CTFDATA", 0, Lifetime::Timeframe);
+  inputs.emplace_back("noise", orig, "NOISEMAP", 0, Lifetime::Condition,
+                      ccdbParamSpec(fmt::format("{}/Calib/NoiseMap", orig.as<std::string>())));
+  inputs.emplace_back("cldict", orig, "CLUSDICT", 0, Lifetime::Condition,
+                      ccdbParamSpec(fmt::format("{}/Calib/ClusterDictionary", orig.as<std::string>())));
 
   return DataProcessorSpec{
     EntropyDecoderSpec::getName(orig),
@@ -132,7 +135,8 @@ DataProcessorSpec getEntropyDecoderSpec(o2::header::DataOrigin orig, int verbosi
     AlgorithmSpec{adaptFromTask<EntropyDecoderSpec>(orig, verbosity, getDigits)},
     Options{
       {"ctf-dict", VariantType::String, o2::base::NameConf::getCTFDictFileName(), {"File of CTF decoding dictionary"}},
-      {"mask-noise", VariantType::Bool, false, {"apply noise mask to digits or clusters (involves reclusterization)"}}}};
+      {"mask-noise", VariantType::Bool, false, {"apply noise mask to digits or clusters (involves reclusterization)"}},
+      {"ignore-cluster-dictionary", VariantType::Bool, false, {"do not use cluster dictionary, always store explicit patterns"}}}};
 }
 
 } // namespace itsmft

--- a/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
@@ -19,6 +19,7 @@
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/ControlService.h"
 #include "Framework/DeviceSpec.h"
+#include "Framework/CCDBParamSpec.h"
 #include "DataFormatsITSMFT/Digit.h"
 #include "DataFormatsITSMFT/ROFRecord.h"
 #include "ITSMFTReconstruction/RawPixelDecoder.h"
@@ -74,16 +75,8 @@ void STFDecoder<Mapping>::init(InitContext& ic)
   }
 
   auto detID = Mapping::getDetID();
-  if (detID == o2::detectors::DetID::ITS) {
-    mDictName = o2::itsmft::ClustererParam<o2::detectors::DetID::ITS>::Instance().dictFilePath;
-    mNoiseName = o2::itsmft::ClustererParam<o2::detectors::DetID::ITS>::Instance().noiseFilePath;
-  } else {
-    mDictName = o2::itsmft::ClustererParam<o2::detectors::DetID::MFT>::Instance().dictFilePath;
-    mNoiseName = o2::itsmft::ClustererParam<o2::detectors::DetID::MFT>::Instance().noiseFilePath;
-  }
-  mNoiseName = o2::base::DetectorNameConf::getNoiseFileName(detID, mNoiseName, "root");
-  mDictName = o2::base::DetectorNameConf::getAlpideClusterDictionaryFileName(detID, mDictName);
-
+  mApplyNoiseMap = !ic.options().get<bool>("ignore-noise-map");
+  mUseClusterDictionary = !ic.options().get<bool>("ignore-cluster-dictionary");
   try {
     mNThreads = std::max(1, ic.options().get<int>("nthreads"));
     mDecoder->setNThreads(mNThreads);
@@ -100,14 +93,6 @@ void STFDecoder<Mapping>::init(InitContext& ic)
     }
     mDecoder->setRawDumpDirectory(dumpDir);
     mDecoder->setFillCalibData(mDoCalibData);
-    if (o2::utils::Str::pathExists(mNoiseName)) {
-      TFile* f = TFile::Open(mNoiseName.data(), "old");
-      auto pnoise = (NoiseMap*)f->Get("ccdb_object");
-      AlpideCoder::setNoisyPixels(pnoise);
-      LOG(info) << mSelfName << " loading noise map file: " << mNoiseName;
-    } else {
-      LOG(info) << mSelfName << " Noise file " << mNoiseName << " is absent, " << Mapping::getName() << " running without noise suppression";
-    }
   } catch (const std::exception& e) {
     LOG(error) << "exception was thrown in decoder configuration: " << e.what();
     throw;
@@ -134,13 +119,6 @@ void STFDecoder<Mapping>::init(InitContext& ic)
       nbc += mClusterer->isContinuousReadOut() ? alpParams.roFrameLengthInBC : (alpParams.roFrameLengthTrig / o2::constants::lhc::LHCBunchSpacingNS);
       mClusterer->setMaxBCSeparationToMask(nbc);
       mClusterer->setMaxRowColDiffToMask(clParams.maxRowColDiffToMask);
-
-      if (o2::utils::Str::pathExists(mDictName)) {
-        mClusterer->loadDictionary(mDictName);
-        LOG(info) << mSelfName << " clusterer running with a provided dictionary: " << mDictName;
-      } else {
-        LOG(info) << mSelfName << " Dictionary " << mDictName << " is absent, " << Mapping::getName() << " clusterer expects cluster patterns";
-      }
       mClusterer->print();
     } catch (const std::exception& e) {
       LOG(error) << "exception was thrown in clustrizer configuration: " << e.what();
@@ -156,6 +134,7 @@ void STFDecoder<Mapping>::init(InitContext& ic)
 template <class Mapping>
 void STFDecoder<Mapping>::run(ProcessingContext& pc)
 {
+  updateTimeDependentParams(pc);
   static bool firstCall = true;
   if (firstCall) {
     firstCall = false;
@@ -238,6 +217,7 @@ void STFDecoder<Mapping>::run(ProcessingContext& pc)
   LOG(debug) << mSelfName << " Total time for TF " << tfID << '(' << mTFCounter << ") : CPU: " << mTimer.CpuTime() - timeCPU0 << " Real: " << mTimer.RealTime() - timeReal0;
   mTFCounter++;
 }
+
 ///_______________________________________
 template <class Mapping>
 void STFDecoder<Mapping>::finalize()
@@ -257,6 +237,34 @@ void STFDecoder<Mapping>::finalize()
   }
 }
 
+///_______________________________________
+template <class Mapping>
+void STFDecoder<Mapping>::updateTimeDependentParams(ProcessingContext& pc)
+{
+  // we call these methods just to trigger finaliseCCDB callback
+  pc.inputs().get<o2::itsmft::NoiseMap*>("noise");
+  pc.inputs().get<o2::itsmft::TopologyDictionary*>("cldict");
+}
+
+///_______________________________________
+template <class Mapping>
+void STFDecoder<Mapping>::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+{
+  if (matcher == ConcreteDataMatcher(Mapping::getOrigin(), "NOISEMAP", 0)) {
+    LOG(info) << Mapping::getName() << " noise map updated" << (!mApplyNoiseMap ? " but masking is disabled" : "");
+    if (mApplyNoiseMap) {
+      AlpideCoder::setNoisyPixels((const NoiseMap*)obj);
+    }
+  }
+  if (matcher == ConcreteDataMatcher(Mapping::getOrigin(), "CLUSDICT", 0)) {
+    LOG(info) << Mapping::getName() << " cluster dictionary updated" << (!mUseClusterDictionary ? " but its using is disabled" : "");
+    if (mUseClusterDictionary) {
+      mClusterer->setDictionary((const TopologyDictionary*)obj);
+    }
+  }
+}
+
+///_______________________________________
 DataProcessorSpec getSTFDecoderSpec(const STFDecoderInp& inp)
 {
   std::vector<OutputSpec> outputs;
@@ -284,6 +292,10 @@ DataProcessorSpec getSTFDecoderSpec(const STFDecoderInp& inp)
     // request the input FLP/DISTSUBTIMEFRAME/0 that is _guaranteed_ to be present, even if none of our raw data is present.
     inputs.emplace_back("stfDist", "FLP", "DISTSUBTIMEFRAME", 0, o2::framework::Lifetime::Timeframe);
   }
+  inputs.emplace_back("noise", inp.origin, "NOISEMAP", 0, Lifetime::Condition,
+                      o2::framework::ccdbParamSpec(fmt::format("{}/Calib/NoiseMap", inp.origin.as<std::string>())));
+  inputs.emplace_back("cldict", inp.origin, "CLUSDICT", 0, Lifetime::Condition,
+                      o2::framework::ccdbParamSpec(fmt::format("{}/Calib/ClusterDictionary", inp.origin.as<std::string>())));
 
   return DataProcessorSpec{
     inp.deviceName,
@@ -296,7 +308,9 @@ DataProcessorSpec getSTFDecoderSpec(const STFDecoderInp& inp)
       {"decoder-verbosity", VariantType::Int, 0, {"Verbosity level (-1: silent, 0: errors, 1: headers, 2: data) of 1st lane"}},
       {"raw-data-dumps", VariantType::Int, int(GBTLink::RawDataDumps::DUMP_NONE), {"Raw data dumps on error (0: none, 1: HBF for link, 2: whole TF for all links"}},
       {"raw-data-dumps-directory", VariantType::String, "", {"Destination directory for the raw data dumps"}},
-      {"unmute-extra-lanes", VariantType::Bool, false, {"allow extra lanes to be as verbose as 1st one"}}}};
+      {"unmute-extra-lanes", VariantType::Bool, false, {"allow extra lanes to be as verbose as 1st one"}},
+      {"ignore-noise-map", VariantType::Bool, false, {"do not mask pixels flagged in the noise map"}},
+      {"ignore-cluster-dictionary", VariantType::Bool, false, {"do not use cluster dictionary, always store explicit patterns"}}}};
 }
 
 } // namespace itsmft

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDGlobalTrackingSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDGlobalTrackingSpec.h
@@ -47,10 +47,11 @@ class TRDGlobalTracking : public o2::framework::Task
   TRDGlobalTracking(bool useMC, std::shared_ptr<o2::globaltracking::DataRequest> dataRequest, o2::dataformats::GlobalTrackID::mask_t src, bool trigRecFilterActive, bool strict) : mUseMC(useMC), mDataRequest(dataRequest), mTrkMask(src), mTrigRecFilter(trigRecFilterActive), mStrict(strict) {}
   ~TRDGlobalTracking() override = default;
   void init(o2::framework::InitContext& ic) final;
-  void updateTimeDependentParams();
+  void updateTimeDependentParams(o2::framework::ProcessingContext& pc);
   void fillMCTruthInfo(const TrackTRD& trk, o2::MCCompLabel lblSeed, std::vector<o2::MCCompLabel>& lblContainerTrd, std::vector<o2::MCCompLabel>& lblContainerMatch, const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* trkltLabels) const;
   void fillTrackTriggerRecord(const std::vector<TrackTRD>& tracks, std::vector<TrackTriggerRecord>& trigRec, const gsl::span<const o2::trd::TriggerRecord>& trackletTrigRec) const;
   void run(o2::framework::ProcessingContext& pc) final;
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
   bool refitITSTPCTRDTrack(TrackTRD& trk, float timeTRD, o2::globaltracking::RecoContainer* recoCont);
   bool refitTPCTRDTrack(TrackTRD& trk, float timeTRD, o2::globaltracking::RecoContainer* recoCont);
   bool refitTRDTrack(TrackTRD& trk, float& chi2, bool inwards);
@@ -83,7 +84,7 @@ class TRDGlobalTracking : public o2::framework::Task
   gsl::span<const int> mITSTrackClusIdx;                              ///< input ITS track cluster indices span
   gsl::span<const int> mITSABTrackClusIdx;                            ///< input ITSAB track cluster indices span
   std::vector<o2::BaseCluster<float>> mITSClustersArray;              ///< ITS clusters created in run() method from compact clusters
-  o2::itsmft::TopologyDictionary mITSDict;                            ///< cluster patterns dictionary
+  const o2::itsmft::TopologyDictionary* mITSDict = nullptr;           ///< cluster patterns dictionary
 };
 
 /// create a processor spec

--- a/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
@@ -85,16 +85,6 @@ void TRDGlobalTracking::init(InitContext& ic)
     LOG(info) << "Material LUT " << matLUTFile << " file is absent, only TGeo can be used";
   }
 
-  // this is a hack to provide ITS dictionary from the local file, in general will be provided by the framework from CCDB
-  auto dictFile = o2::itsmft::ClustererParam<o2::detectors::DetID::ITS>::Instance().dictFilePath;
-  dictFile = o2::base::DetectorNameConf::getAlpideClusterDictionaryFileName(o2::detectors::DetID::ITS, dictFile);
-  if (o2::utils::Str::pathExists(dictFile)) {
-    mITSDict.readFromFile(dictFile);
-    LOG(info) << "Matching is running with a provided ITS dictionary: " << dictFile;
-  } else {
-    LOG(info) << "Dictionary " << dictFile << " is absent, Matching expects ITS cluster patterns";
-  }
-
   //-------- init GPU reconstruction --------//
   GPURecoStepConfiguration cfgRecoStep;
   cfgRecoStep.steps = GPUDataTypes::RecoStep::NoRecoStep;
@@ -131,10 +121,13 @@ void TRDGlobalTracking::init(InitContext& ic)
   mTimer.Reset();
 }
 
-void TRDGlobalTracking::updateTimeDependentParams()
+void TRDGlobalTracking::updateTimeDependentParams(ProcessingContext& pc)
 {
   // strictly speaking, one should do this only in case of the CCDB objects update
   // TODO: add CCDB interface
+
+  // pc.inputs().get<TopologyDictionary*>("cldict"); // called by the RecoContainer to trigger finaliseCCDB
+
   auto& elParam = o2::tpc::ParameterElectronics::Instance();
   auto& gasParam = o2::tpc::ParameterGas::Instance();
   mTPCTBinMUS = elParam.ZbinWidth;
@@ -261,7 +254,7 @@ void TRDGlobalTracking::run(ProcessingContext& pc)
   }
 
   mTracker->Reset();
-  updateTimeDependentParams();
+  updateTimeDependentParams(pc);
   mRec->PrepareEvent();
   mRec->SetupGPUProcessor(mTracker, true);
 
@@ -619,6 +612,14 @@ bool TRDGlobalTracking::refitTRDTrack(TrackTRD& trk, float& chi2, bool inwards)
     }
   }
   return true;
+}
+
+void TRDGlobalTracking::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
+{
+  if (matcher == ConcreteDataMatcher("ITS", "CLUSDICT", 0)) {
+    LOG(info) << "cluster dictionary updated";
+    mITSDict = (const o2::itsmft::TopologyDictionary*)obj;
+  }
 }
 
 void TRDGlobalTracking::endOfStream(EndOfStreamContext& ec)

--- a/EventVisualisation/Workflow/src/EveWorkflowHelper.cxx
+++ b/EventVisualisation/Workflow/src/EveWorkflowHelper.cxx
@@ -206,7 +206,7 @@ void EveWorkflowHelper::prepareITSClusters(const o2::itsmft::TopologyDictionary&
     const auto& patterns = mRecoCont.getITSClustersPatterns();
     auto pattIt = patterns.begin();
     mITSClustersArray.reserve(clusITS.size());
-    o2::its::ioutils::convertCompactClusters(clusITS, pattIt, mITSClustersArray, dict);
+    o2::its::ioutils::convertCompactClusters(clusITS, pattIt, mITSClustersArray, &dict);
   }
 }
 
@@ -218,7 +218,7 @@ void EveWorkflowHelper::prepareMFTClusters(const o2::itsmft::TopologyDictionary&
     const auto& patterns = this->mRecoCont.getMFTClustersPatterns();
     auto pattIt = patterns.begin();
     this->mMFTClustersArray.reserve(clusMFT.size());
-    o2::mft::ioutils::convertCompactClusters(clusMFT, pattIt, this->mMFTClustersArray, dict);
+    o2::mft::ioutils::convertCompactClusters(clusMFT, pattIt, this->mMFTClustersArray, &dict);
   }
 }
 

--- a/GPU/Workflow/helper/src/GPUWorkflowHelper.cxx
+++ b/GPU/Workflow/helper/src/GPUWorkflowHelper.cxx
@@ -39,7 +39,7 @@ std::shared_ptr<const GPUWorkflowHelper::tmpDataContainer> GPUWorkflowHelper::fi
         const auto& patterns = recoCont.getITSClustersPatterns();
         auto pattIt = patterns.begin();
         retVal->ITSClustersArray.reserve(clusITS.size());
-        o2::its::ioutils::convertCompactClusters(clusITS, pattIt, retVal->ITSClustersArray, *calib->itsPatternDict);
+        o2::its::ioutils::convertCompactClusters(clusITS, pattIt, retVal->ITSClustersArray, calib->itsPatternDict);
         ioPtr.itsClusters = retVal->ITSClustersArray.data();
       }
       ioPtr.nItsClusters = clusITS.size();

--- a/macro/run_trac_ca_its.C
+++ b/macro/run_trac_ca_its.C
@@ -229,14 +229,14 @@ void run_trac_ca_its(bool cosmics = false,
 
   o2::its::TimeFrame tf;
   gsl::span<o2::itsmft::ROFRecord> rofspan(*rofs);
-  tf.loadROFrameData(rofspan, clSpan, pattIt, dict, labels);
+  tf.loadROFrameData(rofspan, clSpan, pattIt, &dict, labels);
   pattIt = patt.begin();
   int rofId{0};
   for (auto& rof : *rofs) {
 
     auto start = std::chrono::high_resolution_clock::now();
     auto it = pattIt;
-    o2::its::ioutils::loadROFrameData(rof, event, clSpan, pattIt, dict, labels);
+    o2::its::ioutils::loadROFrameData(rof, event, clSpan, pattIt, &dict, labels);
 
     vertexer.initialiseVertexer(&event);
     vertexer.findTracklets();

--- a/macro/run_trac_its.C
+++ b/macro/run_trac_its.C
@@ -176,7 +176,7 @@ void run_trac_its(std::string path = "./", std::string outputfile = "o2trac_its.
     auto clSpan = gsl::span(cclusters->data(), cclusters->size());
     for (auto& rof : *rofs) {
       auto it = pattIt;
-      o2::its::ioutils::loadROFrameData(rof, event, clSpan, pattIt, dict, labels);
+      o2::its::ioutils::loadROFrameData(rof, event, clSpan, pattIt, &dict, labels);
       vertexer.clustersToVertices(event, mcTruth);
       auto verticesL = vertexer.exportVertices();
 
@@ -190,7 +190,7 @@ void run_trac_its(std::string path = "./", std::string outputfile = "o2trac_its.
         verticesL.emplace_back();
       }
       tracker.setVertices(verticesL);
-      tracker.process(clSpan, it, dict, tracksITS, trackClIdx, rof);
+      tracker.process(clSpan, it, &dict, tracksITS, trackClIdx, rof);
     }
     outTree.Fill();
     if (mcTruth) {


### PR DESCRIPTION
Needs https://github.com/AliceO2Group/AliceO2/pull/8267

Cluster dictionaries used for the pilot beam run are uploaded to http://alice-ccdb.cern.ch/browse/ITS/Calib/NoiseMap as default (same for the MFT).
Empty noise map is uploaded to http://alice-ccdb.cern.ch/browse/ITS/Calib/NoiseMap as default and 2 chip-level only objects are added for specific pilot-beam time ranges.
