### PR TITLE
TPC: change track params in dEdx calibration

### DIFF
--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/CalibdEdxCorrection.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/CalibdEdxCorrection.h
@@ -16,10 +16,12 @@
 #define ALICEO2_TPC_CALIBDEDXCORRECTION_H_
 
 #include "GPUCommonDef.h"
+#include "GPUCommonMath.h"
 #include "GPUCommonRtypes.h"
 
 #ifndef GPUCA_GPUCODE_DEVICE
 #include <string_view>
+#include <algorithm>
 #endif
 
 // o2 includes
@@ -31,8 +33,9 @@ namespace o2::tpc
 class CalibdEdxCorrection
 {
  public:
-  constexpr static int paramSize = 6;
-  constexpr static int fitSize = 288;
+  static constexpr int FitSize = 288; ///< Number of fitted corrections
+  static constexpr int ParamSize = 8; ///< Number of params per fit
+
 #if !defined(GPUCA_ALIGPUCODE)
   CalibdEdxCorrection()
   {
@@ -44,35 +47,39 @@ class CalibdEdxCorrection
 #endif
   ~CalibdEdxCorrection() CON_DEFAULT;
 
-  GPUd() float getCorrection(const StackID& stack, ChargeType charge, float z = 0, float tgl = 0) const
+  GPUd() float getCorrection(const StackID& stack, ChargeType charge, float tgl = 0, float snp = 0) const
   {
     // by default return 1 if no correction was loaded
     if (mDims < 0) {
       return 1;
     }
 
-    const auto& p = mParams[stackIndex(stack, charge)];
-    float corr = p[0];
-
+    tgl = o2::gpu::CAMath::Abs(tgl);
+    auto p = mParams[stackIndex(stack, charge)];
+    float result = p[0];
+    // Tgl part
     if (mDims > 0) {
-      corr += p[1] * z + p[2] * z * z;
-      if (mDims > 1) {
-        corr += p[3] * tgl + p[4] * z * tgl + p[5] * tgl * tgl;
-      }
+      result += tgl * (p[1] + tgl * (p[2] + tgl * (p[3] + tgl * p[4])));
     }
-
-    return corr;
+    // Snp and cross terms
+    if (mDims > 1) {
+      result += snp * (p[5] + snp * p[6] + tgl * p[7]);
+    }
+    return result;
   }
 
 #if !defined(GPUCA_GPUCODE)
-  float getChi2(const StackID& stack, ChargeType charge) const
+  const float* getParams(const StackID& stack, ChargeType charge) const
   {
-    return mChi2[stackIndex(stack, charge)];
+    return mParams[stackIndex(stack, charge)];
   }
+  float getChi2(const StackID& stack, ChargeType charge) const { return mChi2[stackIndex(stack, charge)]; }
+  int getEntries(const StackID& stack, ChargeType charge) const { return mEntries[stackIndex(stack, charge)]; }
   int getDims() const { return mDims; }
 
-  void setParams(const StackID& stack, ChargeType charge, const float* params) { std::copy(params, params + paramSize, mParams[stackIndex(stack, charge)]); }
+  void setParams(const StackID& stack, ChargeType charge, const float* params) { std::copy(params, params + ParamSize, mParams[stackIndex(stack, charge)]); }
   void setChi2(const StackID& stack, ChargeType charge, float chi2) { mChi2[stackIndex(stack, charge)] = chi2; }
+  void setEntries(const StackID& stack, ChargeType charge, int entries) { mEntries[stackIndex(stack, charge)] = entries; }
   void setDims(int dims) { mDims = dims; }
 
   void clear();
@@ -84,11 +91,12 @@ class CalibdEdxCorrection
  private:
   GPUd() static int stackIndex(const StackID& stack, ChargeType charge)
   {
-    return stack.index() + charge * SECTORSPERSIDE * SIDES * GEMSTACKSPERSECTOR;
+    return stack.getIndex() + charge * SECTORSPERSIDE * SIDES * GEMSTACKSPERSECTOR;
   }
 
-  float mParams[fitSize][paramSize];
-  float mChi2[fitSize];
+  float mParams[FitSize][ParamSize];
+  float mChi2[FitSize];
+  int mEntries[FitSize];
   int mDims{-1}; ///< Fit dimension
 
   ClassDefNV(CalibdEdxCorrection, 1);

--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/DCS.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/DCS.h
@@ -257,7 +257,7 @@ struct HV {
     // the counting is GEM1 top, bottom, GEM2 top, bottom, ...
     const int electrode = 2 * (gem - 1) + !isTop;
     const StackID stackID{sector, stack};
-    const int index = stackID.index() * 2 * GEMSPERSTACK + electrode;
+    const int index = stackID.getIndex() * 2 * GEMSPERSTACK + electrode;
 
     const auto type = sensor.back();
     // LOGP(info, "Fill type: {}, index: {} (sec: {}, stack: {}, gem: {}, elec: {}), time: {}, value: {}", type, index, sector, stack, gem, electrode, time, value);
@@ -276,7 +276,7 @@ struct HV {
     const StackID stackID{sector, stack};
 
     // TODO: check value for validity
-    states[stackID.index()].fill(time, static_cast<StackState>(value));
+    states[stackID.getIndex()].fill(time, static_cast<StackState>(value));
   }
 
   void sortAndClean()

--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/Defs.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/Defs.h
@@ -80,9 +80,14 @@ struct StackID {
   GEMstack type{};
 
   /// Single number identification for the stacks
-  GPUdi() int index() const
+  GPUdi() int getIndex() const
   {
     return sector + type * SECTORSPERSIDE * SIDES;
+  }
+  GPUdi() void setIndex(int index)
+  {
+    sector = index % (SECTORSPERSIDE * SIDES);
+    type = static_cast<GEMstack>((index / (SECTORSPERSIDE * SIDES)) % GEMSTACKSPERSECTOR);
   }
 };
 

--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/TrackCuts.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/TrackCuts.h
@@ -37,18 +37,22 @@ class TrackCuts
 {
  public:
   TrackCuts() = default;
-  TrackCuts(float PMin, float PMax, float NClusMin);
+  TrackCuts(float PMin, float PMax, float NClusMin, float dEdxMin = 0, float dEdxMax = 1e10);
 
   bool goodTrack(o2::tpc::TrackTPC const& track);
 
   void setPMin(float PMin) { mPMin = PMin; }
   void setPMax(float PMax) { mPMax = PMax; }
   void setNClusMin(float NClusMin) { mNClusMin = NClusMin; }
+  void setdEdxMin(float dEdxMin) { mdEdxMin = dEdxMin; }
+  void setdEdxMax(float dEdxMax) { mdEdxMax = dEdxMax; }
 
  private:
-  float mPMin{0};     // min momentum allowed
-  float mPMax{1e10};  // max momentum allowed
-  float mNClusMin{0}; // min number of clusters in track allowed
+  float mPMin{0};       ///< min momentum allowed
+  float mPMax{1e10};    ///< max momentum allowed
+  float mNClusMin{0};   ///< min number of clusters in track allowed
+  float mdEdxMin{0};    ///< min dEdx
+  float mdEdxMax{1e10}; ///< max dEdx
 
   ClassDefNV(TrackCuts, 1)
 };

--- a/DataFormats/Detectors/TPC/src/TrackCuts.cxx
+++ b/DataFormats/Detectors/TPC/src/TrackCuts.cxx
@@ -18,9 +18,12 @@ ClassImp(o2::tpc::TrackCuts);
 
 using namespace o2::tpc;
 
-TrackCuts::TrackCuts(float PMin, float PMax, float NClusMin) : mPMin(PMin),
-                                                               mPMax(PMax),
-                                                               mNClusMin(NClusMin)
+TrackCuts::TrackCuts(float PMin, float PMax, float NClusMin, float dEdxMin, float dEdxMax)
+  : mPMin(PMin),
+    mPMax(PMax),
+    mNClusMin(NClusMin),
+    mdEdxMin(dEdxMin),
+    mdEdxMax(dEdxMax)
 {
 }
 
@@ -28,7 +31,8 @@ TrackCuts::TrackCuts(float PMin, float PMax, float NClusMin) : mPMin(PMin),
 bool TrackCuts::goodTrack(o2::tpc::TrackTPC const& track)
 {
   const auto p = track.getP();
-  const auto nclusters = track.getNClusterReferences();
+  const auto nClusters = track.getNClusterReferences();
+  const auto dEdx = track.getdEdx().dEdxTotTPC;
 
   if (p > mPMax) {
     return false;
@@ -36,7 +40,13 @@ bool TrackCuts::goodTrack(o2::tpc::TrackTPC const& track)
   if (p < mPMin) {
     return false;
   }
-  if (nclusters < mNClusMin) {
+  if (nClusters < mNClusMin) {
+    return false;
+  }
+  if (dEdx > mdEdxMax) {
+    return false;
+  }
+  if (dEdx < mdEdxMin) {
     return false;
   }
   return true;

--- a/Detectors/TPC/calibration/doc/CalibdEdx.md
+++ b/Detectors/TPC/calibration/doc/CalibdEdx.md
@@ -1,39 +1,43 @@
 <!-- doxy
-\page refTPCcalibrationCalibdEdx dEdx Calibration
+\page refTPCcalibrationCalibdEdx Residual dEdx Calibration
 /doxy -->
 
-# dEdx Calibration
+# Residual dEdx Calibration
 
-The workflow `o2-tpc-miptrack-filter` is supposed to run in the EPNs, and will select only the track inside the defined cuts, the selected track in the streamed with the name `TPC/MIPS/0`. The cut values can be changed with these CLI options:
-
-```
---min-momentum (= 0.4)
---max-momentum (= 0.6)
---min-clusters (= 60)       Minimum number of cluster in a track.
-```
-
-The workflow `o2-tpc-calibratordedx` should run in an aggregation node. It will fill dEdx histograms using the data sended by the `o2-tpc-miptrack-filter`, and will compute corrections for the dE/dx values for every time slot.
+The workflow `o2-tpc-miptrack-filter` will run on the EPNs. It selects only the tracks inside the defined cuts and stream them with the name `TPC/MIPS/0`. The cut values can be changed with these CLI options:
 
 ```
---tf-per-slot
---max-delay
+--min-momentum (= 0.3)
+--max-momentum (= 0.7)
+--min-dedx (= 20)           Minimum dEdx cut
+--max-dedx (= 200)          Maximum dEdx cut
+--min-clusters (= 60)       Minimum number of cluster in a track
+```
+
+The workflow `o2-tpc-calibratordedx` should run on an aggregation node. It fills dEdx histograms using the data sent by the `o2-tpc-miptrack-filter`, and computes corrections for the dE/dx values for every time slot.
+
+```
+--tf-per-slot           TFs per calibration time slot
+--max-delay             Slots in past to consider
 --min-entries           Minimum number of entries per GEM stack to perform a fit
 
---min-entries-sector    Bellow the number of entries per stack every sector will be integrated before the fit
---min-entries-1d        Minimum entries per stack to perform a 1D fit, bellow it only calculate the mean
+--min-entries-sector    Minimum entries per GEM stack to enable sector by sector correction. Below this value we only perform one fit per ROC type (IROC, OROC1, ...; no side nor sector information)
+--min-entries-1d        Minimum entries per stack to perform a 1D fit, bellow it we only calculate the mean of each gem stack
 --min-entries-2d        Mininum entries per stack to perform a 2D fit
+--fit-passes            Number of fit iterations
+--fit-threshold         dEdx cut width around the MIP peak used in the fit
 
 --dedxbins              Number of dE/dx bins
---zbins                 Number of Z bins
 --angularbins           Number of angular bins, for values like Tgl and Snp
 --min-dedx              Min. dE/dx value
 --max-dedx              Max. dE/dx value
+--fit-snp               Enable Snp correction
 
 --file-dump             Save calibration correction to a file
 --field                 Magnetic field in kG, need for track propagations, this value will be overwritten if a grp file is present
 ```
 
-The workflow `o2-tpc-calibdedx` is similar to `o2-tpc-calibratordedx`, but only compute correction for a single set of data.
+The workflow `o2-tpc-calibdedx` is similar to `o2-tpc-calibratordedx`, but compute only one correction using all available time frames.
 
 ## Executing
 
@@ -43,18 +47,18 @@ The full dE/dx calibration workflow can be executed in the following way:
 o2-tpc-track-reader --disable-mc | o2-tpc-miptrack-filter | o2-tpc-calibrator-dedx --file-dump --min-entries 100 --tf-per-slot 10
 ```
 
-Where we enabled the option to save the corrections to a file, set the min. entires per time slot to 100 and defined that the time slots should have 10 time frames.
+Where we enabled the option to save the corrections to a file, set the min. entries per time slot to 100 and defined that the time slots should have 10 time frames.
 
 ## Simulating EPN workflow
 
 To simulate the EPN/Agregation node topology you can execute the following.
-Run the `o2-tpc-miptrack-filter` workflow, it will start listening to `TPC/MIPS/0`, waiting for tracks data to process.
+Run `o2-tpc-miptrack-filter` workflow, it will start listening to `TPC/MIPS/0`, waiting for tracks data to process.
 
 ```
 o2-dpl-raw-proxy --dataspec A:TPC/MIPS/0 --channel-config "name=readout-proxy,type=pull,method=bind,address=tcp://localhost:30453,rateLogging=1,transport=zeromq" | o2-tpc-calib-dedx
 ```
 
-Now, in a new shell, start the `o2-tpc-miptrack-filter`.
+Now, in a new shell, start `o2-tpc-miptrack-filter`.
 
 ```
 o2-tpc-track-reader --disable-mc | o2-tpc-miptrack-filter | o2-dpl-output-proxy --channel-config "name=downstream,method=connect,address=tcp://localhost:30453,type=push,transport=zeromq" --dataspec downstream:TPC/MIPS -b

--- a/Detectors/TPC/calibration/src/CalibratordEdx.cxx
+++ b/Detectors/TPC/calibration/src/CalibratordEdx.cxx
@@ -61,11 +61,14 @@ CalibratordEdx::Slot& CalibratordEdx::emplaceNewSlot(bool front, TFType tstart, 
   auto& cont = getSlots();
   auto& slot = front ? cont.emplace_front(tstart, tend) : cont.emplace_back(tstart, tend);
 
-  auto container = std::make_unique<CalibdEdx>(mMindEdx, mMaxdEdx, mdEdxBins, mZBins, mAngularBins);
+  auto container = std::make_unique<CalibdEdx>(mdEdxBins, mMindEdx, mMaxdEdx, mAngularBins, mFitSnp);
   container->setApplyCuts(mApplyCuts);
   container->setCuts(mCuts);
-  container->setFitCuts(mFitCuts);
+  container->setSectorFitThreshold(mFitThreshold[0]);
+  container->set1DFitThreshold(mFitThreshold[1]);
+  container->set2DFitThreshold(mFitThreshold[2]);
   container->setField(mField);
+  container->setElectronCut(mElectronCut.first, mElectronCut.second);
 
   slot.setContainer(std::move(container));
   return slot;

--- a/Detectors/TPC/workflow/src/CalibratordEdxSpec.cxx
+++ b/Detectors/TPC/workflow/src/CalibratordEdxSpec.cxx
@@ -21,14 +21,15 @@
 // o2 includes
 #include "CCDB/CcdbApi.h"
 #include "CCDB/CcdbObjectInfo.h"
+#include "CommonUtils/NameConf.h"
 #include "DataFormatsTPC/TrackTPC.h"
 #include "DataFormatsParameters/GRPObject.h"
-#include "CommonUtils/NameConf.h"
 #include "DetectorsCalibration/Utils.h"
 #include "Framework/Task.h"
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/ConfigParamRegistry.h"
 #include "TPCCalibration/CalibratordEdx.h"
+#include "TPCWorkflow/ProcessingHelpers.h"
 
 using namespace o2::framework;
 
@@ -40,22 +41,24 @@ class CalibratordEdxDevice : public Task
  public:
   void init(framework::InitContext& ic) final
   {
-    const int slotLength = ic.options().get<int>("tf-per-slot");
-    const int maxDelay = ic.options().get<int>("max-delay");
-    const int minEntries = ic.options().get<int>("min-entries");
+    const auto slotLength = ic.options().get<int>("tf-per-slot");
+    const auto maxDelay = ic.options().get<int>("max-delay");
+    const auto minEntries = ic.options().get<int>("min-entries");
 
-    const int minEntriesSector = ic.options().get<int>("min-entries-sector");
-    const int minEntries1D = ic.options().get<int>("min-entries-1d");
-    const int minEntries2D = ic.options().get<int>("min-entries-2d");
+    const auto minEntriesSector = ic.options().get<int>("min-entries-sector");
+    const auto minEntries1D = ic.options().get<int>("min-entries-1d");
+    const auto minEntries2D = ic.options().get<int>("min-entries-2d");
+    const auto fitPasses = ic.options().get<int>("fit-passes");
+    const auto fitThreshold = ic.options().get<float>("fit-threshold");
 
-    const int dEdxBins = ic.options().get<int>("dedxbins");
-    const int zBins = ic.options().get<int>("zbins");
-    const int angularBins = ic.options().get<int>("angularbins");
-    const float mindEdx = ic.options().get<float>("min-dedx");
-    const float maxdEdx = ic.options().get<float>("max-dedx");
+    const auto dEdxBins = ic.options().get<int>("dedxbins");
+    const auto mindEdx = ic.options().get<float>("min-dedx");
+    const auto maxdEdx = ic.options().get<float>("max-dedx");
+    const auto angularBins = ic.options().get<int>("angularbins");
+    const auto fitSnp = ic.options().get<bool>("fit-snp");
 
-    const bool dumpData = ic.options().get<bool>("file-dump");
-    float field = ic.options().get<float>("field");
+    const auto dumpData = ic.options().get<bool>("file-dump");
+    auto field = ic.options().get<float>("field");
 
     if (field <= -10.f) {
       const auto inputGRP = o2::base::NameConf::getGRPFileName();
@@ -67,14 +70,14 @@ class CalibratordEdxDevice : public Task
     }
 
     mCalibrator = std::make_unique<tpc::CalibratordEdx>();
-    mCalibrator->setHistParams(mindEdx, maxdEdx, dEdxBins, zBins, angularBins);
+    mCalibrator->setHistParams(dEdxBins, mindEdx, maxdEdx, angularBins, fitSnp);
     mCalibrator->setApplyCuts(false);
-    mCalibrator->setFitCuts({minEntriesSector, minEntries1D, minEntries2D});
+    mCalibrator->setFitThresholds(minEntriesSector, minEntries1D, minEntries2D);
     mCalibrator->setField(field);
     mCalibrator->setMinEntries(minEntries);
-
     mCalibrator->setSlotLength(slotLength);
     mCalibrator->setMaxSlotsDelay(maxDelay);
+    mCalibrator->setElectronCut({fitThreshold, fitPasses});
 
     if (dumpData) {
       mCalibrator->enableDebugOutput("calibratordEdx.root");
@@ -87,7 +90,7 @@ class CalibratordEdxDevice : public Task
     const auto tracks = pc.inputs().get<gsl::span<tpc::TrackTPC>>("tracks");
 
     LOGP(info, "Processing TF {} with {} tracks", tfcounter, tracks.size());
-
+    mRunNumber = processing_helpers::getRunNumber(pc);
     mCalibrator->process(tfcounter, tracks);
     sendOutput(pc.outputs());
 
@@ -98,7 +101,7 @@ class CalibratordEdxDevice : public Task
   void endOfStream(EndOfStreamContext& eos) final
   {
     LOGP(info, "Finalizing calibration");
-    constexpr calibration::TFType INFINITE_TF = 0xffffffffffffffff;
+    static constexpr calibration::TFType INFINITE_TF = 0xffffffffffffffff;
     mCalibrator->checkSlotsToFinalize(INFINITE_TF);
     sendOutput(eos.outputs());
 
@@ -110,10 +113,9 @@ class CalibratordEdxDevice : public Task
  private:
   void sendOutput(DataAllocator& output)
   {
-    using clbUtils = o2::calibration::Utils;
     const auto& calibrations = mCalibrator->getCalibs();
     auto& intervals = mCalibrator->getTFinterval();
-    const long timeEnd = 99999999999999;
+    const long timeEnd = o2::calibration::Utils::INFINITE_TIME;
 
     for (unsigned int i = 0; i < calibrations.size(); i++) {
       const auto& object = calibrations[i];
@@ -121,8 +123,13 @@ class CalibratordEdxDevice : public Task
       auto image = o2::ccdb::CcdbApi::createObjectImage(&object, &info);
 
       info.setPath("TPC/Calib/dEdx");
+      // FIXME: use time frame timestamp
       info.setStartValidityTimestamp(intervals[i].first);
       info.setEndValidityTimestamp(timeEnd);
+
+      auto md = info.getMetaData();
+      md["runNumber"] = std::to_string(mRunNumber);
+      info.setMetaData(md);
 
       LOGP(info, "Sending object {} / {} of size {} bytes, valid for {} : {} ", info.getPath(), info.getFileName(), image->size(), info.getStartValidityTimestamp(), info.getEndValidityTimestamp());
 
@@ -133,6 +140,7 @@ class CalibratordEdxDevice : public Task
   }
 
   std::unique_ptr<CalibratordEdx> mCalibrator;
+  uint64_t mRunNumber{0}; ///< processed run number
 };
 
 DataProcessorSpec getCalibratordEdxSpec()
@@ -149,19 +157,21 @@ DataProcessorSpec getCalibratordEdxSpec()
     outputs,
     adaptFromTask<CalibratordEdxDevice>(),
     Options{
-      {"tf-per-slot", VariantType::Int, 100, {"number of TFs per calibration time slot"}},
-      {"max-delay", VariantType::Int, 3, {"number of slots in past to consider"}},
-      {"min-entries", VariantType::Int, 50, {"minimum entries per stack to fit a single time slot"}},
+      {"tf-per-slot", VariantType::Int, 6000, {"number of TFs per calibration time slot"}},
+      {"max-delay", VariantType::Int, 10, {"number of slots in past to consider"}},
+      {"min-entries", VariantType::Int, 10000, {"minimum entries per stack to fit a single time slot"}},
 
-      {"min-entries-sector", VariantType::Int, 1000, {"bellow this number of entries per stack, higher dimensional fits will be perform only for GEM stacks types (IROC, OROC1, ...). The mean is still corrected for every stack"}},
-      {"min-entries-1d", VariantType::Int, 500, {"minimum entries per stack to fit 1D correction"}},
-      {"min-entries-2d", VariantType::Int, 2500, {"minimum entries per stack to fit 2D correction"}},
+      {"min-entries-sector", VariantType::Int, 1000, {"min entries per GEM stack to enable sector by sector correction. Below this value we only perform one fit per ROC type (IROC, OROC1, ...; no side nor sector information)."}},
+      {"min-entries-1d", VariantType::Int, 10000, {"minimum entries per stack to fit 1D correction"}},
+      {"min-entries-2d", VariantType::Int, 50000, {"minimum entries per stack to fit 2D correction"}},
+      {"fit-passes", VariantType::Int, 3, {"number of fit iterations"}},
+      {"fit-threshold", VariantType::Float, 0.2f, {"dEdx width around the MIP peak used in the fit"}},
 
-      {"dedxbins", VariantType::Int, 100, {"number of dEdx bins"}},
-      {"zbins", VariantType::Int, 20, {"number of Z bins"}},
-      {"angularbins", VariantType::Int, 18, {"number of bins for angular data, like Tgl and Snp"}},
-      {"min-dedx", VariantType::Float, 5.0f, {"minimum value for the dEdx histograms"}},
-      {"max-dedx", VariantType::Float, 100.0f, {"maximum value for the dEdx histograms"}},
+      {"dedxbins", VariantType::Int, 60, {"number of dEdx bins"}},
+      {"min-dedx", VariantType::Float, 20.0f, {"minimum value for dEdx histograms"}},
+      {"max-dedx", VariantType::Float, 90.0f, {"maximum value for dEdx histograms"}},
+      {"angularbins", VariantType::Int, 36, {"number of angular bins: Tgl and Snp"}},
+      {"fit-snp", VariantType::Bool, false, {"enable Snp correction"}},
 
       {"field", VariantType::Float, -100.f, {"magnetic field"}},
       {"file-dump", VariantType::Bool, false, {"directly dump calibration to file"}}}};

--- a/GPU/GPUTracking/DataTypes/CalibdEdxContainer.h
+++ b/GPU/GPUTracking/DataTypes/CalibdEdxContainer.h
@@ -138,7 +138,7 @@ class CalibdEdxContainer : public o2::gpu::FlatObject
   /// \param charge type of the charge (qMax or qTot)
   /// \param z z position
   /// \param tgl tracking parameter tgl
-  GPUd() float getResidualCorrection(const StackID& stack, const ChargeType charge, const float z = 0, const float tgl = 0) const { return mCalibResidualdEdx.getCorrection(stack, charge, z, tgl); }
+  GPUd() float getResidualCorrection(const StackID& stack, const ChargeType charge, const float tgl = 0, const float snp = 0) const { return mCalibResidualdEdx.getCorrection(stack, charge, tgl, snp); }
 
   /// \return returns if the full gain map will be used during the calculation of the dE/dx to correct the cluster charge
   GPUd() bool isUsageOfFullGainMap() const { return mApplyFullGainMap; }

--- a/GPU/GPUTracking/dEdx/GPUdEdx.h
+++ b/GPU/GPUTracking/dEdx/GPUdEdx.h
@@ -164,9 +164,8 @@ GPUdnii() void GPUdEdx::fillCluster(float qtot, float qmax, int padRow, unsigned
     slice,
     static_cast<tpc::GEMstack>(roc)};
 
-  // getting the residual dE/dx correction
-  const float qMaxResidualCorr = calibContainer->getResidualCorrection(stack, tpc::ChargeType::Max, z, trackTgl);
-  const float qTotResidualCorr = calibContainer->getResidualCorrection(stack, tpc::ChargeType::Tot, z, trackTgl);
+  const float qMaxResidualCorr = calibContainer->getResidualCorrection(stack, tpc::ChargeType::Max, trackTgl, trackSnp);
+  const float qTotResidualCorr = calibContainer->getResidualCorrection(stack, tpc::ChargeType::Tot, trackTgl, trackSnp);
   qmax /= qMaxResidualCorr;
   qtot /= qTotResidualCorr;
 


### PR DESCRIPTION
* Correct for Tgl and Snp, instead of Z and Tgl
* Iteractive fit method to remove electron tracks
* Snp correction is off by default
* Extended momentum range of input data using Beth-Bloch correction
* Tgl limits based on the max acceptance per ROC type

Minor changes:
* Save the run number as CCDB metadata
* Record number of tracks of each correction fit
* Method to convert boost hist into a THn