### PR TITLE
MCH: DCS DP change from RAW to DPVAL

### DIFF
--- a/Detectors/MUON/Common/src/dcs-ccdb.cxx
+++ b/Detectors/MUON/Common/src/dcs-ccdb.cxx
@@ -109,7 +109,7 @@ void makeCCDBEntryForDCS(const std::string ccdbUrl, uint64_t timestamp)
   DPID dpidtmp;
   for (const auto& a : aliases) {
     auto legitName = o2::muon::replaceDotByUnderscore(a);
-    DPID::FILL(dpidtmp, legitName, o2::dcs::DeliveryType::RAW_DOUBLE);
+    DPID::FILL(dpidtmp, legitName, o2::dcs::DeliveryType::DPVAL_DOUBLE);
     dpid2DataDesc[dpidtmp] = fmt::format("{}DATAPOINTS", o2::muon ::subsysname());
   }
 
@@ -120,7 +120,10 @@ void makeCCDBEntryForDCS(const std::string ccdbUrl, uint64_t timestamp)
             << o2::muon::subsysname() << " data points to "
             << CcdbDpConfName() << "\n";
 
-  api.storeAsTFileAny(&dpid2DataDesc, CcdbDpConfName(), md, timestamp);
+  uint64_t endOfValidity = 99999999999999;
+
+  api.storeAsTFileAny(&dpid2DataDesc, CcdbDpConfName(), md, timestamp,
+                      endOfValidity);
 }
 
 bool match(const std::vector<std::string>& queries, const char* pattern)


### PR DESCRIPTION
also make the DCSDPconfig valid up to infinity (instead of the default 1 day)

@chiarazampolli I hope I interpreted correctly the change that was necessary. 

Note that I've updated the MCH DP config in ccdb-test.cern.ch:8080 with this change

(if that works I'll do the same for MID during Monday's tests)
 