### PR TITLE
Fixes for CCDB fetcher

### DIFF
--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -953,8 +953,12 @@ void* CcdbApi::retrieveFromTFile(std::type_info const& tinfo, std::string const&
   // many isolated processes, all querying the CCDB (for potentially the same objects and same timestamp).
   // In addition, we can monitor exactly which objects are fetched and what is their content.
   // One can also distribute so obtained caches to sites without network access.
-  auto cachedir = getenv("ALICEO2_CCDB_LOCALCACHE");
+  const char* cachedir = getenv("ALICEO2_CCDB_LOCALCACHE");
+  const char* cwd = ".";
   if (cachedir) {
+    if (cachedir[0] == 0) {
+      cachedir = cwd;
+    }
     // protect this sensitive section by a multi-process named semaphore
     boost::interprocess::named_semaphore* sem = nullptr;
     std::hash<std::string> hasher;
@@ -1418,8 +1422,12 @@ void CcdbApi::loadFileToMemory(o2::pmr::vector<char>& dest, std::string const& p
   // many isolated processes, all querying the CCDB (for potentially the same objects and same timestamp).
   // In addition, we can monitor exactly which objects are fetched and what is their content.
   // One can also distribute so obtained caches to sites without network access.
-  auto cachedir = getenv("ALICEO2_CCDB_LOCALCACHE");
+  const char* cachedir = getenv("ALICEO2_CCDB_LOCALCACHE");
+  const char* cwd = ".";
   if (cachedir) {
+    if (cachedir[0] == 0) {
+      cachedir = cwd;
+    }
     // protect this sensitive section by a multi-process named semaphore
     boost::interprocess::named_semaphore* sem = nullptr;
     std::hash<std::string> hasher;
@@ -1647,6 +1655,9 @@ void CcdbApi::loadFileToMemory(o2::pmr::vector<char>& dest, const std::string& p
     if (storedmeta) {
       *localHeaders = *storedmeta; // do a simple deep copy
       delete storedmeta;
+    }
+    if (isSnapshotMode()) { // generate dummy ETag to profit from the caching
+      (*localHeaders)["ETag"] = path;
     }
   }
   return;

--- a/Detectors/TRD/workflow/src/TRDTrackletTransformerWorkflow.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrackletTransformerWorkflow.cxx
@@ -25,7 +25,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"disable-mc", o2::framework::VariantType::Bool, false, {"Disable MC labels"}},
     {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input reader"}},
     {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writer"}},
-    {"timestamp", o2::framework::VariantType::Int, 555555, {"timestamp for CCDB calibration objects"}},
+    {"timestamp", o2::framework::VariantType::Int, 5555555, {"timestamp for CCDB calibration objects"}},
     {"filter-trigrec", o2::framework::VariantType::Bool, false, {"ignore interaction records without ITS data"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
 

--- a/Framework/Core/src/CCDBHelpers.cxx
+++ b/Framework/Core/src/CCDBHelpers.cxx
@@ -211,13 +211,14 @@ auto populateCacheWith(std::shared_ptr<CCDBFetcherHelper> const& helper,
         LOGP(info, "Caching {} for {} (DPL id {})", path, headers["ETag"], cacheId.value);
         // one could modify the    adoptContainer to take optional old cacheID to clean:
         // mapURL2DPLCache[URL] = ctx.outputs().adoptContainer(output, std::move(outputBuffer), true, mapURL2DPLCache[URL]);
+        continue;
       }
-      // cached object is fine
-      auto cacheId = helper->mapURL2DPLCache[path];
-      LOGP(info, "Reusing {} for {}", cacheId.value, path);
-      allocator.adoptFromCache(output, cacheId, header::gSerializationMethodCCDB);
-      // the outputBuffer was not used, can we destroy it?
     }
+    // cached object is fine
+    auto cacheId = helper->mapURL2DPLCache[path];
+    LOGP(info, "Reusing {} for {}", cacheId.value, path);
+    allocator.adoptFromCache(output, cacheId, header::gSerializationMethodCCDB);
+    // the outputBuffer was not used, can we destroy it?
   }
 };
 


### PR DESCRIPTION
@ktf I noticed that in case of pipelined devices their conditions are added to `helper->routes` and thus queried multiple times. This PR fixes this problem + cache usage when the particular CcdbApi is working in snapshot mode.