### PR TITLE
TRD modify verbose output to debug grid

### DIFF
--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
@@ -90,6 +90,11 @@ class CruRawReader
   void setDataBuffer(const char* val)
   {
     mDataBuffer = val;
+    if (mVerbose) {
+      if (val == nullptr) {
+        LOG(error) << "Data buffer is being assigned to a null ptr";
+      }
+    }
   };
   void setDataBufferSize(long val)
   {

--- a/Detectors/TRD/reconstruction/src/DataReaderTask.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReaderTask.cxx
@@ -268,7 +268,7 @@ void DataReaderTask::run(ProcessingContext& pc)
     tfCount = dh->tfCounter;
     auto payloadIn = ref.payload;
     auto payloadInSize = DataRefUtils::getPayloadSize(ref);
-    if (mVerbose) {
+    if (mHeaderVerbose) {
       LOGP(info, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : ",
            dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, payloadInSize);
     }


### PR DESCRIPTION
Grid async reconstruction of pilot beam data is dying it seems in rawreader.
It runs fine on the data in question on mine and other desktops and fine on epn.
Cant enable verbose as we lose the logs due to needing to much resources to write the logs in question.
Added a check if the incoming buffer is null, and some more detailed output for when rdh exceed the bounds of the mem.

Not sure how much this will help, will try run on grid now. 