### PR TITLE
ITS THR SCAN: multiple decoder pipelines + fixed minor bugs

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdCalibratorSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdCalibratorSpec.h
@@ -46,6 +46,7 @@
 #include "TTree.h"
 #include "TH1F.h"
 #include "TF1.h"
+#include "TStopwatch.h"
 
 using namespace o2::framework;
 using namespace o2::itsmft;
@@ -98,7 +99,8 @@ class ITSThresholdCalibrator : public Task
   //////////////////////////////////////////////////////////////////
  private:
   // detector information
-  static constexpr short int N_COL = 1024; // column number in Alpide chip
+  static constexpr short int N_COL = 1024;  // column number in Alpide chip
+  static constexpr short int N_ROW_MEM = 5; // number of rows we keep in memory for each chip
 
   const short int N_RU = o2::itsmft::ChipMappingITS::getNRUs();
 
@@ -115,8 +117,8 @@ class ITSThresholdCalibrator : public Task
   short int* mX = nullptr;
 
   // Hash tables to store the hit and threshold information per pixel
-  std::unordered_map<short int, short int> mCurrentRow;
-  std::unordered_map<short int, std::vector<std::vector<char>>> mPixelHits;
+  std::unordered_map<short int, std::unordered_map<short int, std::vector<std::vector<char>>>> mPixelHits;
+  std::unordered_map<short int, std::vector<short int>> mForbiddenRows;
   //   Unordered map for saving sum of values (thr/ithr/vcasn) for avg calculation
   std::unordered_map<short int, std::array<int, 5>> mThresholds;
 
@@ -135,7 +137,7 @@ class ITSThresholdCalibrator : public Task
 
   // Some private helper functions
   // Helper functions related to the running over data
-  void extractAndUpdate(const short int&);
+  void extractAndUpdate(const short int&, const short int&);
   void extractThresholdRow(const short int&, const short int&);
   void finalizeOutput();
 
@@ -151,7 +153,7 @@ class ITSThresholdCalibrator : public Task
   bool findThresholdFit(const char*, const short int*, const short int&, float&, float&);
   bool findThresholdDerivative(const char*, const short int*, const short int&, float&, float&);
   bool findThresholdHitcounting(const char*, const short int*, const short int&, float&);
-  bool isScanFinished(const short int&);
+  bool isScanFinished(const short int&, const short int&);
   void findAverage(const std::array<int, 5>&, float&, float&, float&, float&);
   void saveThreshold();
 
@@ -197,7 +199,6 @@ class ITSThresholdCalibrator : public Task
 
   // Flag to check if endOfStream is available
   bool mCheckEos = false;
-  int mCounter = 0;
 };
 
 // Create a processor spec

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdCalibratorSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdCalibratorSpec.h
@@ -98,7 +98,7 @@ class ITSThresholdCalibrator : public Task
   //////////////////////////////////////////////////////////////////
  private:
   // detector information
-  static constexpr short int N_COL = 1024;  // column number in Alpide chip
+  static constexpr short int N_COL = 1024; // column number in Alpide chip
 
   const short int N_RU = o2::itsmft::ChipMappingITS::getNRUs();
 

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdCalibratorSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdCalibratorSpec.h
@@ -46,7 +46,6 @@
 #include "TTree.h"
 #include "TH1F.h"
 #include "TF1.h"
-#include "TStopwatch.h"
 
 using namespace o2::framework;
 using namespace o2::itsmft;
@@ -100,7 +99,6 @@ class ITSThresholdCalibrator : public Task
  private:
   // detector information
   static constexpr short int N_COL = 1024;  // column number in Alpide chip
-  static constexpr short int N_ROW_MEM = 5; // number of rows we keep in memory for each chip
 
   const short int N_RU = o2::itsmft::ChipMappingITS::getNRUs();
 

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdCalibratorSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdCalibratorSpec.h
@@ -19,6 +19,8 @@
 #include <string>
 #include <vector>
 #include <array>
+#include <set>
+#include <deque>
 
 #include <iostream>
 #include <fstream>
@@ -115,10 +117,10 @@ class ITSThresholdCalibrator : public Task
   short int* mX = nullptr;
 
   // Hash tables to store the hit and threshold information per pixel
-  std::unordered_map<short int, std::unordered_map<short int, std::vector<std::vector<char>>>> mPixelHits;
-  std::unordered_map<short int, std::vector<short int>> mForbiddenRows;
+  std::map<short int, std::map<int, std::vector<std::vector<char>>>> mPixelHits;
+  std::map<short int, std::deque<short int>> mForbiddenRows;
   //   Unordered map for saving sum of values (thr/ithr/vcasn) for avg calculation
-  std::unordered_map<short int, std::array<int, 5>> mThresholds;
+  std::map<short int, std::array<int, 5>> mThresholds;
 
   // Tree to save threshold info in full threshold scan case
   TFile* mRootOutfile = nullptr;

--- a/Detectors/ITSMFT/ITS/workflow/src/ThresholdCalibratorSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ThresholdCalibratorSpec.cxx
@@ -829,15 +829,6 @@ void ITSThresholdCalibrator::addDatabaseEntry(
   char stave[6];
   sprintf(stave, "L%d_%02d", lay, sta);
 
-  // Build string to be used to get configDB chipid
-  std::string key = "";
-  if (lay < 3) {
-    key = std::string(stave) + "_M" + std::to_string(mod) + "_C" + std::to_string(chipInMod);
-  } else {
-    std::string uorl = !ssta ? "L" : "U";
-    key = std::string(stave) + uorl + "_M" + std::to_string(mod) + "_C" + std::to_string(chipInMod);
-  }
-
   o2::dcs::addConfigItem(this->mTuning, "Stave", std::string(stave));
   o2::dcs::addConfigItem(this->mTuning, "Hs_pos", std::to_string(ssta));
   o2::dcs::addConfigItem(this->mTuning, "Hic_Pos", std::to_string(mod));


### PR DESCRIPTION
Changes included:

- added possibility to work with multiple decoder pipelines in o2-its-threshold-calib-workflow: now more rows per chip are stored in memory and as soon as a row is completed, thresholds are extracted and the hits of that row are deleted. 
- fixed minor bugs: return value of threshold calculation methods, repetitions in ROOT trees, simplification of finalize(). 
- removed multithreading for sum calculation. Not scaling with multi-thread. 
- Improved timing performance of run() method. 