### PR TITLE
Fix IB and OB geometry to latest blueprints

### DIFF
--- a/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
@@ -101,7 +101,7 @@ static void configITS(Detector* its)
     {2.24, 2.34, 2.67, 9., 16.42, 12}, // for each inner layer: rMin,rMid,rMax,NChip/Stave, phi0, nStaves
     {3.01, 3.15, 3.46, 9., 12.18, 16},
     {3.78, 3.93, 4.21, 9., 9.55, 20},
-    {-1, 19.45, -1, 4., 7.5, 24},   // for others: -, rMid, -, NMod/HStave, phi0, nStaves // 24 was 49
+    {-1, 19.45, -1, 4., 7.5, 24},  // for others: -, rMid, -, NMod/HStave, phi0, nStaves // 24 was 49
     {-1, 24.40, -1, 4., 6., 30},   // 30 was 61
     {-1, 34.24, -1, 7., 4.29, 42}, // 42 was 88
     {-1, 39.20, -1, 7., 3.75, 48}  // 48 was 100

--- a/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
@@ -101,10 +101,10 @@ static void configITS(Detector* its)
     {2.24, 2.34, 2.67, 9., 16.42, 12}, // for each inner layer: rMin,rMid,rMax,NChip/Stave, phi0, nStaves
     {3.01, 3.15, 3.46, 9., 12.18, 16},
     {3.78, 3.93, 4.21, 9., 9.55, 20},
-    {-1, 19.6, -1, 4., 7.5, 24},   // for others: -, rMid, -, NMod/HStave, phi0, nStaves // 24 was 49
-    {-1, 24.55, -1, 4., 6., 30},   // 30 was 61
-    {-1, 34.34, -1, 7., 4.29, 42}, // 42 was 88
-    {-1, 39.30, -1, 7., 3.75, 48}  // 48 was 100
+    {-1, 19.45, -1, 4., 7.5, 24},   // for others: -, rMid, -, NMod/HStave, phi0, nStaves // 24 was 49
+    {-1, 24.40, -1, 4., 6., 30},   // 30 was 61
+    {-1, 34.24, -1, 7., 4.29, 42}, // 42 was 88
+    {-1, 39.20, -1, 7., 3.75, 48}  // 48 was 100
   };
   const int nChipsPerModule = 7;  // For OB: how many chips in a row
   const double zChipGap = 0.01;   // For OB: gap in Z between chips
@@ -117,7 +117,7 @@ static void configITS(Detector* its)
   its->setStaveModelOB(o2::its::Detector::kOBModel2);
 
   const int kNWrapVol = 3;
-  const double wrpRMin[kNWrapVol] = {2.1, 19.3, 33.32};
+  const double wrpRMin[kNWrapVol] = {2.1, 19.2, 33.32};
   const double wrpRMax[kNWrapVol] = {15.4, 29.14, 44.9};
   const double wrpZSpan[kNWrapVol] = {70., 93., 163.6};
 

--- a/Detectors/ITSMFT/ITS/simulation/src/V3Layer.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/V3Layer.cxx
@@ -54,8 +54,8 @@ const Int_t V3Layer::sIBNChipRows = 1;
 const Double_t V3Layer::sIBChipZGap = 150.0 * sMicron;
 
 const Double_t V3Layer::sIBModuleZLength = 27.12 * sCm;
-const Double_t V3Layer::sIBFPCWiderXPlus = 850.0 * sMicron;
-const Double_t V3Layer::sIBFPCWiderXNeg = 300.0 * sMicron;
+const Double_t V3Layer::sIBFPCWiderXPlus = 950.0 * sMicron;
+const Double_t V3Layer::sIBFPCWiderXNeg = 400.0 * sMicron;
 const Double_t V3Layer::sIBFlexCableAlThick = 25.0 * sMicron;
 const Double_t V3Layer::sIBFPCAlGNDWidth = (4.1 + 11.15) * sMm;
 const Double_t V3Layer::sIBFPCAlAnodeWidth1 = 13.0 * sMm;
@@ -571,12 +571,11 @@ Double_t V3Layer::createStaveInnerB(TGeoVolume* mother, const TGeoManager* mgr)
   // Build up the stave
   // Chips are rotated by 180deg around Y axis
   // in order to have the correct X and Z axis orientation
-  xpos = -xtot + (static_cast<TGeoBBox*>(chipVol->GetShape()))->GetDX() + sIBFPCWiderXNeg;
   ypos = ymod - mChipThickness;
 
   for (Int_t j = 0; j < sIBChipsPerRow; j++) {
     zpos = ztot - j * (2 * zchip + sIBChipZGap) - zchip;
-    mother->AddNode(chipVol, j, new TGeoCombiTrans(xpos, ypos, zpos, new TGeoRotation("", 0, 180, 180)));
+    mother->AddNode(chipVol, j, new TGeoCombiTrans(0, ypos, zpos, new TGeoRotation("", 0, 180, 180)));
     mHierarchy[kChip]++;
   }
   ytot = ymod;
@@ -584,8 +583,9 @@ Double_t V3Layer::createStaveInnerB(TGeoVolume* mother, const TGeoManager* mgr)
   // Place the FPC and glue
   if (mStaveModel == Detector::kIBModel4) {
     Double_t yvol = (static_cast<TGeoBBox*>(ibModule->GetShape()))->GetDY();
+    xpos = 0.5 * (xtot - xchip);
     ypos += (ymod + yvol);
-    mother->AddNode(ibModule, 1, new TGeoTranslation(0, ypos, 0));
+    mother->AddNode(ibModule, 1, new TGeoTranslation(xpos, ypos, 0));
     ytot += yvol;
   }
 


### PR DESCRIPTION
This commit fixes some small but important geometry mismatches with latest blueprints. The IB chip position was not centered wrt to the stave, and the FPC and glue volumes were smaller and centered; whereas now the chip volume is centered in the X coordinate while the FPC and glue have the correct transverse dimension and are properly aligned to one end of the stave. Lastly the radial position of the stave of all OB layers were reduced to the correct value.