### PR TITLE
ITS: Get ITS TimeFrame from GPUReco

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/TrackerSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/TrackerSpec.h
@@ -58,6 +58,7 @@ class TrackerDPL : public framework::Task
   std::string mMode = "sync";
   const o2::itsmft::TopologyDictionary* mDict = nullptr;
   std::unique_ptr<o2::gpu::GPUReconstruction> mRecChain = nullptr;
+  std::unique_ptr<o2::gpu::GPUChainITS> mChainITS = nullptr;
   std::unique_ptr<parameters::GRPObject> mGRP = nullptr;
   std::unique_ptr<Tracker> mTracker = nullptr;
   std::unique_ptr<Vertexer> mVertexer = nullptr;

--- a/GPU/GPUTracking/Base/GPUReconstruction.cxx
+++ b/GPU/GPUTracking/Base/GPUReconstruction.cxx
@@ -126,6 +126,11 @@ void GPUReconstruction::GetITSTraits(std::unique_ptr<o2::its::TrackerTraits>* tr
   }
 }
 
+void GPUReconstruction::GetITSTimeframe(std::unique_ptr<o2::its::TimeFrame>* timeFrame)
+{
+  timeFrame->reset(new o2::its::TimeFrame);
+}
+
 int GPUReconstruction::SetNOMPThreads(int n)
 {
 #ifdef WITH_OPENMP

--- a/GPU/GPUTracking/Base/GPUReconstruction.h
+++ b/GPU/GPUTracking/Base/GPUReconstruction.h
@@ -39,6 +39,7 @@ namespace its
 {
 class TrackerTraits;
 class VertexerTraits;
+class TimeFrame;
 } // namespace its
 } // namespace o2
 
@@ -221,6 +222,7 @@ class GPUReconstruction
 
   // Helpers to fetch processors from other shared libraries
   virtual void GetITSTraits(std::unique_ptr<o2::its::TrackerTraits>* trackerTraits, std::unique_ptr<o2::its::VertexerTraits>* vertexerTraits);
+  virtual void GetITSTimeframe(std::unique_ptr<o2::its::TimeFrame>* timeFrame);
   bool slavesExist() { return mSlaves.size() || mMaster; }
 
   // Getters / setters for parameters

--- a/GPU/GPUTracking/Global/GPUChainITS.cxx
+++ b/GPU/GPUTracking/Global/GPUChainITS.cxx
@@ -64,6 +64,11 @@ VertexerTraits* GPUChainITS::GetITSVertexerTraits()
 #endif
   return mITSVertexerTraits.get();
 }
+TimeFrame* GPUChainITS::GetITSTimeframe()
+{
+  mRec->GetITSTimeframe(&mITSTimeFrame);
+  return mITSTimeFrame.get();
+}
 
 int GPUChainITS::PrepareEvent() { return 0; }
 

--- a/GPU/GPUTracking/Global/GPUChainITS.h
+++ b/GPU/GPUTracking/Global/GPUChainITS.h
@@ -46,12 +46,13 @@ class GPUChainITS : public GPUChain
 
   o2::its::TrackerTraits* GetITSTrackerTraits();
   o2::its::VertexerTraits* GetITSVertexerTraits();
+  o2::its::TimeFrame* GetITSTimeframe();
 
  protected:
   GPUChainITS(GPUReconstruction* rec, unsigned int maxTracks = GPUCA_MAX_ITS_FIT_TRACKS);
   std::unique_ptr<o2::its::TrackerTraits> mITSTrackerTraits;
   std::unique_ptr<o2::its::VertexerTraits> mITSVertexerTraits;
-
+  std::unique_ptr<o2::its::TimeFrame> mITSTimeFrame;
   unsigned int mMaxTracks;
 };
 } // namespace GPUCA_NAMESPACE::gpu


### PR DESCRIPTION
@davidrohr this is in preparation for getting the o2::its::TimeFrame also for ITS GPU reconstruction.
@mpuccio fyi

Differently from what we do for the vtxer and tracker traits, we don't need to check whether thet pointer is non null, because we just recreate the o2::its::TimeFrame* at each `run()`.