### PR TITLE
TPC interpolation use correct global track index

### DIFF
--- a/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
+++ b/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
@@ -168,7 +168,7 @@ void TrackInterpolation::interpolateTrack(int iSeed)
   }
   if (gidTable[GTrackID::TRD].isIndexSet()) {
     LOG(debug) << "TRD available";
-    const auto& trkTRD = mRecoCont->getITSTPCTRDTrack<o2::trd::TrackTRD>(gidTable[GTrackID::TRD]);
+    const auto& trkTRD = mRecoCont->getITSTPCTRDTrack<o2::trd::TrackTRD>(gidTable[GTrackID::ITSTPCTRD]);
     for (int iLayer = o2::trd::constants::NLAYER - 1; iLayer >= 0; --iLayer) {
       int trkltIdx = trkTRD.getTrackletIndex(iLayer);
       if (trkltIdx < 0) {
@@ -271,7 +271,7 @@ void TrackInterpolation::interpolateTrack(int iSeed)
   trackData.chi2ITS = trkITS.getChi2();
   trackData.nClsTPC = trkTPC.getNClusterReferences();
   trackData.nClsITS = trkITS.getNumberOfClusters();
-  trackData.nTrkltsTRD = gidTable[GTrackID::TRD].isIndexSet() ? mRecoCont->getITSTPCTRDTrack<o2::trd::TrackTRD>(gidTable[GTrackID::TRD]).getNtracklets() : 0;
+  trackData.nTrkltsTRD = gidTable[GTrackID::TRD].isIndexSet() ? mRecoCont->getITSTPCTRDTrack<o2::trd::TrackTRD>(gidTable[GTrackID::ITSTPCTRD]).getNtracklets() : 0;
   trackData.clAvailTOF = gidTable[GTrackID::TOF].isIndexSet() ? 1 : 0;
   trackData.clIdx.setEntries(nMeasurements);
 


### PR DESCRIPTION
@davidrohr this fixes the crash of the track interpolation. For ITS-TPC-TRD-TOF tracks the index in the `GlobalIDSet` which is filled by the `RecoContainer::getSingleDetectorRefs()` method puts the GID of the global track into the TRD slot, since no standalone TRD track exists. With that index one cannot request the TRD track. One has to use the reference for the ITS-TPC-TRD track instead.
I think at that time of the development there was an issue with the TOF matching which lead to the fact that there were no ITS-TPC-TRD-TOF tracks existing and that is why I did not see it.