### PR TITLE
TrackletTransformer uses DPL CCDB mechanism

### DIFF
--- a/Detectors/TRD/base/include/TRDBase/TrackletTransformer.h
+++ b/Detectors/TRD/base/include/TRDBase/TrackletTransformer.h
@@ -16,7 +16,6 @@
 #include "DataFormatsTRD/Tracklet64.h"
 #include "DataFormatsTRD/CalibratedTracklet.h"
 #include "DataFormatsTRD/CalVdriftExB.h"
-#include "CCDB/BasicCCDBManager.h"
 
 namespace o2
 {
@@ -26,8 +25,10 @@ namespace trd
 class TrackletTransformer
 {
  public:
-  TrackletTransformer();
+  TrackletTransformer() = default;
   ~TrackletTransformer() = default;
+
+  void init();
 
   float getXCathode() { return mXCathode; }
   float getXAnode() { return mXAnode; }
@@ -39,12 +40,7 @@ class TrackletTransformer
   void setXDrift(float x) { mXDrift = x; }
   void setXtb0(float x) { mXtb0 = x; }
 
-  bool hasCalibration() { return mCalibration != nullptr; }
-
-  void loadPadPlane(int hcid);
-
-  // use 555555 for default calibration values
-  void loadCalibrationParameters(int timestamp);
+  void setCalVdriftExB(const CalVdriftExB* cal) { mCalVdriftExB = cal; };
 
   float calculateY(int hcid, int column, int position);
 
@@ -61,15 +57,15 @@ class TrackletTransformer
   double getTimebin(int detector, double x);
 
  private:
-  o2::trd::Geometry* mGeo;
-  const o2::trd::PadPlane* mPadPlane;
+  Geometry* mGeo{nullptr};
+  const PadPlane* mPadPlane{nullptr};
 
   float mXCathode;
   float mXAnode;
   float mXDrift;
   float mXtb0;
 
-  o2::trd::CalVdriftExB* mCalibration;
+  const CalVdriftExB* mCalVdriftExB{nullptr};
 };
 
 } // namespace trd

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrackletTransformerSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrackletTransformerSpec.h
@@ -23,19 +23,21 @@ namespace trd
 class TRDTrackletTransformerSpec : public o2::framework::Task
 {
  public:
-  TRDTrackletTransformerSpec(std::shared_ptr<o2::globaltracking::DataRequest> dataRequest, bool trigRecFilterActive, int timestamp) : mDataRequest(dataRequest), mTrigRecFilterActive(trigRecFilterActive), mTimestamp(timestamp){};
+  TRDTrackletTransformerSpec(std::shared_ptr<o2::globaltracking::DataRequest> dataRequest, bool trigRecFilterActive) : mDataRequest(dataRequest), mTrigRecFilterActive(trigRecFilterActive){};
   ~TRDTrackletTransformerSpec() override = default;
   void init(o2::framework::InitContext& ic) override;
   void run(o2::framework::ProcessingContext& pc) override;
+  void finaliseCCDB(framework::ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
+  void updateTimeDependentParams(framework::ProcessingContext& pc);
+
   bool mTrigRecFilterActive; ///< if true, transform only TRD tracklets for which ITS data is available
   std::shared_ptr<o2::globaltracking::DataRequest> mDataRequest;
-  int mTimestamp;
   TrackletTransformer mTransformer;
 };
 
-o2::framework::DataProcessorSpec getTRDTrackletTransformerSpec(bool trigRecFilterActive, int timestamp);
+o2::framework::DataProcessorSpec getTRDTrackletTransformerSpec(bool trigRecFilterActive);
 
 } // end namespace trd
 } // end namespace o2

--- a/Detectors/TRD/workflow/src/TRDTrackletTransformerWorkflow.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrackletTransformerWorkflow.cxx
@@ -25,7 +25,6 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"disable-mc", o2::framework::VariantType::Bool, false, {"Disable MC labels"}},
     {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input reader"}},
     {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writer"}},
-    {"timestamp", o2::framework::VariantType::Int, 5555555, {"timestamp for CCDB calibration objects"}},
     {"filter-trigrec", o2::framework::VariantType::Bool, false, {"ignore interaction records without ITS data"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
 
@@ -42,7 +41,6 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   // MC labels are passed through for the global tracking downstream
   // in case ROOT output is requested the tracklet labels are duplicated
   bool useMC = !configcontext.options().get<bool>("disable-mc");
-  int timestamp = configcontext.options().get<int>("timestamp");
 
   WorkflowSpec spec;
 
@@ -55,7 +53,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     o2::globaltracking::InputHelper::addInputSpecsIRFramesITS(configcontext, spec);
   }
 
-  spec.emplace_back(o2::trd::getTRDTrackletTransformerSpec(trigRecFilterActive, timestamp));
+  spec.emplace_back(o2::trd::getTRDTrackletTransformerSpec(trigRecFilterActive));
 
   if (!configcontext.options().get<bool>("disable-root-output")) {
     spec.emplace_back(o2::trd::getTRDCalibratedTrackletWriterSpec(useMC));


### PR DESCRIPTION
Hi @shahor02 
with this patch the tracklet transformer uses the DPL CCDB fetching mechanism. The time stamp option has been removed.
Cheers,
Ole