### PR TITLE
Fix the MID channel calibrator

### DIFF
--- a/Detectors/MUON/MID/Calibration/src/ChannelCalibrator.cxx
+++ b/Detectors/MUON/MID/Calibration/src/ChannelCalibrator.cxx
@@ -79,7 +79,7 @@ void ChannelCalibrator::finalizeSlot(Slot& slot)
   // Keep track of last TimeFrame, since the masks will be valid from now on
   mTFEnd = slot.getTFEnd();
 
-  mBadChannels = makeMasks(noiseData->getScalers(), mEventsCounter, mThreshold, mRefMasks);
+  mBadChannels = makeBadChannels(noiseData->getScalers(), mEventsCounter, mThreshold);
 
   // Get the masks for the electronics
   // First convert the dead channels into masks
@@ -91,7 +91,7 @@ void ChannelCalibrator::finalizeSlot(Slot& slot)
 
   // Convert column data masks to local board masks
   ColumnDataToLocalBoard colToBoard;
-  colToBoard.process(masksHandler.getMasks());
+  colToBoard.process(masksHandler.getMasks(), true);
 
   // Update local board configuration with the masks
   ROBoardConfigHandler roBoardCfgHandler;
@@ -101,13 +101,6 @@ void ChannelCalibrator::finalizeSlot(Slot& slot)
 
   mMasksString = ss.str();
 }
-
-// void ChannelCalibrator::endOfStream()
-// {
-//   // create the CCDB entry
-//   std::map<std::string, std::string> md;
-//   o2::calibration::Utils::prepareCCDBobjectInfo(mBadChannels, mBadChannelsInfo, "MID/Masks", md, mTFEnd, o2::calibration::Utils::INFINITE_TIME);
-// }
 
 } // namespace mid
 } // namespace o2

--- a/Detectors/MUON/MID/Filtering/src/MaskMaker.cxx
+++ b/Detectors/MUON/MID/Filtering/src/MaskMaker.cxx
@@ -119,7 +119,7 @@ std::vector<ColumnData> makeDefaultMasksFromCrateConfig(const FEEIdConfig& feeId
   std::vector<ColumnData> maskedBoards(aggregator.getData());
   ChannelMasksHandler masksHandler;
   masksHandler.setFromChannelMasks(makeDefaultMasks());
-  for (auto col : maskedBoards) {
+  for (auto& col : maskedBoards) {
     masksHandler.applyMask(col);
   }
 

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/ColumnDataToLocalBoard.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/ColumnDataToLocalBoard.h
@@ -32,7 +32,7 @@ namespace mid
 class ColumnDataToLocalBoard
 {
  public:
-  void process(gsl::span<const ColumnData> data);
+  void process(gsl::span<const ColumnData> data, bool allowEmpty = false);
   /// Gets the output data as a map
   const std::unordered_map<uint8_t, ROBoard> getDataMap() const { return mLocalBoardsMap; }
   /// Gets vector of ROBoard

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/ElectronicsDelay.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/ElectronicsDelay.h
@@ -28,7 +28,7 @@ namespace mid
 ///
 /// The delays are in local clocks, and correspond to the LHC clocks (aka BCs)
 struct ElectronicsDelay {
-  uint16_t calibToFET{19}; ///< Delay between calibration and FET
+  uint16_t calibToFET{20}; ///< Delay between calibration and FET
   uint16_t BCToLocal{93};  ///< Delay between collision BC and local clock
   uint16_t regToLocal{6};  ///< Delay between regional board and local board answers
 };

--- a/Detectors/MUON/MID/Raw/src/ColumnDataToLocalBoard.cxx
+++ b/Detectors/MUON/MID/Raw/src/ColumnDataToLocalBoard.cxx
@@ -24,7 +24,7 @@ namespace o2
 namespace mid
 {
 
-void ColumnDataToLocalBoard::process(gsl::span<const ColumnData> data)
+void ColumnDataToLocalBoard::process(gsl::span<const ColumnData> data, bool allowEmpty)
 {
   /// Converts incoming data to FEE format
   mLocalBoardsMap.clear();
@@ -33,7 +33,7 @@ void ColumnDataToLocalBoard::process(gsl::span<const ColumnData> data)
   // Each local board gets a unique id.
   for (auto& col : data) {
     for (int iline = mMapping.getFirstBoardBP(col.columnId, col.deId), lastLine = mMapping.getLastBoardBP(col.columnId, col.deId); iline <= lastLine; ++iline) {
-      if (col.getBendPattern(iline) || col.getNonBendPattern()) {
+      if (allowEmpty || col.getBendPattern(iline) || col.getNonBendPattern()) {
         auto uniqueLocId = mCrateMapper.deLocalBoardToRO(col.deId, col.columnId, iline);
         auto& roData = mLocalBoardsMap[uniqueLocId];
         roData.statusWord = raw::sSTARTBIT | raw::sCARDTYPE;

--- a/Detectors/MUON/MID/Raw/src/ROBoardConfigHandler.cxx
+++ b/Detectors/MUON/MID/Raw/src/ROBoardConfigHandler.cxx
@@ -131,10 +131,7 @@ void ROBoardConfigHandler::updateMasks(const std::vector<ROBoard>& masks)
   for (auto& mask : masks) {
     auto cfgIt = mROBoardConfigs.find(mask.boardId);
 
-    // First we check if some patterns has zeros.
-    // When set xORy for boards with no Y input.
-    // So in this case we explicitly mask Y.
-    bool isMasked = ((cfgIt->second.configWord & crateconfig::sXorY) != 0);
+    bool isMasked = false;
     for (int ich = 0; ich < 4; ++ich) {
       if (mask.patternsBP[ich] != 0xFFFF || mask.patternsNBP[ich] != 0xFFFF) {
         isMasked = true;
@@ -144,9 +141,7 @@ void ROBoardConfigHandler::updateMasks(const std::vector<ROBoard>& masks)
     if (isMasked) {
       cfgIt->second.configWord |= crateconfig::sMonmoff;
       cfgIt->second.masksBP = mask.patternsBP;
-      if ((cfgIt->second.configWord & crateconfig::sXorY) == 0) {
-        cfgIt->second.masksNBP = mask.patternsNBP;
-      }
+      cfgIt->second.masksNBP = mask.patternsNBP;
     }
   }
 }

--- a/Detectors/MUON/MID/Workflow/src/ChannelCalibratorSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/ChannelCalibratorSpec.cxx
@@ -102,7 +102,7 @@ class ChannelCalibratorDeviceDPL
   {
     // extract CCDB infos and calibration objects, convert it to TMemFile and send them to the output
     // TODO in principle, this routine is generic, can be moved to Utils.h
-    sendOutput(output, mCalibrator.getBadChannels(), "MID/BadChannels", 0);
+    sendOutput(output, mCalibrator.getBadChannels(), "MID/Calib/BadChannels", 0);
 
     TObjString masks(mCalibrator.getMasksAsString().c_str());
     sendOutput(output, masks, "MID/ElectronicsMasks", 1);


### PR DESCRIPTION
A bug in the code led to the swapping of bad channels and the corresponding masks.
Also, the analysis of data showed that the peak of the FET data arrives one BC later than the default one, which is therefore changed.
The commits are meant to be atomic. Please do not squash