### PR TITLE
[EMCAL-566]: Updated EMCal time calibration

### DIFF
--- a/Common/Utils/include/CommonUtils/BoostHistogramUtils.h
+++ b/Common/Utils/include/CommonUtils/BoostHistogramUtils.h
@@ -398,8 +398,46 @@ std::vector<double> fitBoostHistoWithGaus(boost::histogram::histogram<axes...>& 
 /// \brief Convert a 1D root histogram to a Boost histogram
 boostHisto1d boosthistoFromRoot_1D(TH1D* inHist1D);
 
-// \brief Convert a 2D root histogram to a Boost histogram
+/// \brief Convert a 2D root histogram to a Boost histogram
 boostHisto2d boostHistoFromRoot_2D(TH2D* inHist2D);
+
+/// \brief Convert a 2D boost histogram to a root histogram
+template <class BoostHist>
+TH1F TH1FFromBoost(BoostHist hist, const char* name = "hist")
+{
+  const int nbinsx = hist.axis(0).size();
+  const double binxlow = hist.axis(0).bin(0).lower();
+  const double binxhigh = hist.axis(0).bin(nbinsx - 1).upper();
+
+  TH1F hRoot(name, name, nbinsx, binxlow, binxhigh);
+  // trasfer the acutal values
+  for (int x = 0; x < nbinsx; x++) {
+    hRoot.SetBinContent(x + 1, hist.at(x));
+  }
+  return hRoot;
+}
+
+/// \brief Convert a 2D boost histogram to a root histogram
+// template <typename valuetype, typename... axes>
+template <class BoostHist>
+TH2F TH2FFromBoost(BoostHist hist, const char* name = "hist")
+{
+  const int nbinsx = hist.axis(0).size();
+  const int nbinsy = hist.axis(1).size();
+  const double binxlow = hist.axis(0).bin(0).lower();
+  const double binxhigh = hist.axis(0).bin(nbinsx - 1).upper();
+  const double binylow = hist.axis(1).bin(0).lower();
+  const double binyhigh = hist.axis(1).bin(nbinsy - 1).upper();
+
+  TH2F hRoot(name, name, nbinsx, binxlow, binxhigh, nbinsy, binylow, binyhigh);
+  // trasfer the acutal values
+  for (int x = 0; x < nbinsx; x++) {
+    for (int y = 0; y < nbinsy; y++) {
+      hRoot.SetBinContent(x + 1, y + 1, hist.at(x, y));
+    }
+  }
+  return hRoot;
+}
 
 /// \brief Function to project 2d boost histogram onto x-axis
 /// \param hist2d 2d boost histogram

--- a/Detectors/EMCAL/calibration/CMakeLists.txt
+++ b/Detectors/EMCAL/calibration/CMakeLists.txt
@@ -36,6 +36,7 @@ o2_add_executable(emcal-channel-calib-workflow
                   SOURCES testWorkflow/emc-channel-calib-workflow.cxx
                   PUBLIC_LINK_LIBRARIES O2::Framework
                                         O2::EMCALCalibration
+                                        O2::DetectorsRaw
                                         O2::DetectorsCalibration)
 
 o2_add_executable(run-calib-offline

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelData.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelData.h
@@ -85,7 +85,7 @@ class EMCALChannelData
   /// \brief Merge the data of two slots.
   void merge(const EMCALChannelData* prev);
   int findBin(float v) const;
-  bool hasEnoughData() const;
+  bool hasEnoughData(const int minNEntries) const;
   boostHisto& getHisto() { return mHisto; }
   const boostHisto& getHisto() const { return mHisto; }
 

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALTimeCalibData.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALTimeCalibData.h
@@ -62,6 +62,7 @@ class EMCALTimeCalibData
   {
     // boost histogram with amplitude vs. cell ID, specify the range and binning of the amplitude axis
     mTimeHisto = boost::histogram::make_histogram(boost::histogram::axis::regular<>(par.mTimeBins, par.mTimeRange.at(0), par.mTimeRange.at(1), "t (ns)"), boost::histogram::axis::integer<>(0, NCELLS, "CELL ID"));
+    LOG(debug) << "initialize time histogram with " << NCELLS << " cells";
   }
 
   ~EMCALTimeCalibData() = default;
@@ -73,7 +74,7 @@ class EMCALTimeCalibData
   void merge(const EMCALTimeCalibData* prev);
 
   /// \brief Check if enough data for calibration has been accumulated
-  bool hasEnoughData() const;
+  bool hasEnoughData(int minNEntries) const;
 
   /// \brief Print a useful message about the container.
   void print();

--- a/Detectors/EMCAL/calibration/src/EMCALCalibExtractor.cxx
+++ b/Detectors/EMCAL/calibration/src/EMCALCalibExtractor.cxx
@@ -27,7 +27,7 @@ boostHisto EMCALCalibExtractor::buildHitAndEnergyMean(double emin, double emax, 
   // (2) slice the existing histogram for one cell ranging from emin to emax
   // (3) calculate the mean of that sliced histogram using BoostHistoramUtils.h
   // (4) fill the next histogram with this value
-  for (int cellID = 0; cellID < NCELLS; cellID++) {
+  for (int cellID = 0; cellID < mNcells; cellID++) {
     // create a slice for each cell with energies ranging from emin to emax
     auto tempSlice = boost::histogram::algorithm::reduce(cellAmplitude, boost::histogram::algorithm::shrink(cellID, cellID), boost::histogram::algorithm::shrink(emin, emax));
     // calculate the mean of the slice
@@ -56,13 +56,13 @@ boostHisto EMCALCalibExtractor::buildHitAndEnergyMean(double emin, double emax, 
 boostHisto EMCALCalibExtractor::buildHitAndEnergyMeanScaled(double emin, double emax, boostHisto cellAmplitude)
 {
   // create the output histogram
-  auto eSumHistoScaled = boost::histogram::make_histogram(boost::histogram::axis::regular<>(100, 0, 100, "t-texp"), boost::histogram::axis::integer<>(0, 17665, "CELL ID"));
+  auto eSumHistoScaled = boost::histogram::make_histogram(boost::histogram::axis::regular<>(100, 0, 100, "t-texp"), boost::histogram::axis::integer<>(0, mNcells, "CELL ID"));
 
   // create a slice for each cell with energies ranging from emin to emax
   auto hEnergyCol = boost::histogram::make_histogram(boost::histogram::axis::regular<>(100, 0, 100., "t-texp"));
   auto hEnergyRow = boost::histogram::make_histogram(boost::histogram::axis::regular<>(250, 0, 250., "t-texp"));
   // temp histogram used to get the scaled energies
-  auto hEnergyScaled = boost::histogram::make_histogram(boost::histogram::axis::regular<>(100, 0, 100, "t-texp"), boost::histogram::axis::integer<>(0, NCELLS, "CELL ID"));
+  auto hEnergyScaled = boost::histogram::make_histogram(boost::histogram::axis::regular<>(100, 0, 100, "t-texp"), boost::histogram::axis::integer<>(0, mNcells, "CELL ID"));
 
   //...........................................
   //start iterative process of scaling of cells
@@ -72,7 +72,7 @@ boostHisto EMCALCalibExtractor::buildHitAndEnergyMeanScaled(double emin, double 
     std::vector<double> vecCol[100];
     std::vector<double> vecRow[250];
 
-    for (int cellID = 0; cellID < NCELLS; cellID++) {
+    for (int cellID = 0; cellID < mNcells; cellID++) {
       auto tempSlice = boost::histogram::algorithm::reduce(cellAmplitude, boost::histogram::algorithm::shrink(cellID, cellID), boost::histogram::algorithm::shrink(emin, emax));
       auto geo = Geometry::GetInstance();
       // (0 - row, 1 - column)
@@ -127,7 +127,7 @@ boostHisto EMCALCalibExtractor::buildHitAndEnergyMeanScaled(double emin, double 
     double meanValCol = colResult.at(1);
 
     //Scale each cell by the deviation of the mean of the column and the global mean
-    for (int iCell = 0; iCell < NCELLS; iCell++) {
+    for (int iCell = 0; iCell < mNcells; iCell++) {
       auto geo = Geometry::GetInstance();
       // (0 - row, 1 - column)
       auto position = geo->GlobalRowColFromIndex(iCell);
@@ -141,7 +141,7 @@ boostHisto EMCALCalibExtractor::buildHitAndEnergyMeanScaled(double emin, double 
     }
 
     //Scale each cell by the deviation of the mean of the row and the global mean
-    for (int iCell = 0; iCell < NCELLS; iCell++) {
+    for (int iCell = 0; iCell < mNcells; iCell++) {
       auto geo = Geometry::GetInstance();
       // (0 - row, 1 - column)
       auto position = geo->GlobalRowColFromIndex(iCell);
@@ -163,7 +163,7 @@ boostHisto EMCALCalibExtractor::buildHitAndEnergyMeanScaled(double emin, double 
   //............................................................................................
   //..here the average hit per event and the average energy per hit is caluclated for each cell.
   //............................................................................................
-  for (Int_t cell = 0; cell < NCELLS; cell++) {
+  for (Int_t cell = 0; cell < mNcells; cell++) {
     Double_t Esum = 0;
     Double_t Nsum = 0;
 

--- a/Detectors/EMCAL/calibration/src/EMCALChannelData.cxx
+++ b/Detectors/EMCAL/calibration/src/EMCALChannelData.cxx
@@ -67,7 +67,7 @@ void EMCALChannelData::merge(const EMCALChannelData* prev)
 }
 
 //_____________________________________________
-bool EMCALChannelData::hasEnoughData() const
+bool EMCALChannelData::hasEnoughData(const int minNEntries) const
 {
   // true if we have enough data, also want to check for the sync trigger
   // this is stil to be finalized, simply a skeletron for now


### PR DESCRIPTION
- implemented arguments to optimize the time calibration: time window,
minimum number of entries needed for calibration
- Added option to store time distributions and calibration coefficients
in local root file
- Fixed initialization of EMCALCalibExtractor