### PR TITLE
GPU: dEdx container must be dumped and loaded as FlatObject, not as struct

### DIFF
--- a/GPU/GPUTracking/Global/GPUChainTrackingIO.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTrackingIO.cxx
@@ -291,7 +291,7 @@ void GPUChainTracking::DumpSettings(const char* dir)
   if (processors()->calibObjects.dEdxCalibContainer != nullptr) {
     f = dir;
     f += "dEdxCalibContainer.dump";
-    DumpStructToFile(processors()->calibObjects.dEdxCalibContainer, f.c_str());
+    DumpFlatObjectToFile(processors()->calibObjects.dEdxCalibContainer, f.c_str());
   }
   if (processors()->calibObjects.matLUT != nullptr) {
     f = dir;
@@ -321,7 +321,7 @@ void GPUChainTracking::ReadSettings(const char* dir)
 #ifdef GPUCA_HAVE_O2HEADERS
   f = dir;
   f += "dEdxCalibContainer.dump";
-  mdEdxCalibContainerU = ReadStructFromFile<o2::tpc::CalibdEdxContainer>(f.c_str());
+  mdEdxCalibContainerU = ReadFlatObjectFromFile<o2::tpc::CalibdEdxContainer>(f.c_str());
   processors()->calibObjects.dEdxCalibContainer = mdEdxCalibContainerU.get();
   f = dir;
   f += "matlut.dump";


### PR DESCRIPTION
trivial, merging