### PR TITLE
TPC simulation: fix bug where not all hits are stored when a track crosses the centre of a sector

### DIFF
--- a/Detectors/TPC/simulation/include/TPCSimulation/Detector.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/Detector.h
@@ -147,6 +147,7 @@ class Detector : public o2::base::DetImpl<Detector>
   int mHitCounter = 0;
   int mElectronCounter = 0;
   int mStepCounter = 0;
+  ElementalHit mHitLast{}; ///<! buffer last processed hit to be able to fill it to mHitsPerSectorCollection
 
   /// Create the detector materials
   virtual void CreateMaterials();

--- a/Detectors/TPC/simulation/src/Detector.cxx
+++ b/Detectors/TPC/simulation/src/Detector.cxx
@@ -223,12 +223,24 @@ Bool_t Detector::ProcessHits(FairVolume* vol)
     mHitCounter++;
     mElectronCounter += numberOfElectrons;
     currentgroup->addHit(position.X(), position.Y(), position.Z(), time, numberOfElectrons);
+
+    // add last buffered hit, which was not yet added to the currentgroup
+    if (mHitLast.GetEnergyLoss() >= 0) {
+      currentgroup->addHit(mHitLast.GetX(), mHitLast.GetY(), mHitLast.GetZ(), mHitLast.GetTime(), mHitLast.GetEnergyLoss());
+      mHitLast.mELoss = -1;
+      groupCounter++;
+      mHitCounter++;
+      mElectronCounter += mHitLast.GetEnergyLoss();
+    }
   }
   // finish group
   else {
     oldTrackId = trackID;
     oldSectorId = sectorID;
     groupCounter = 0;
+
+    // buffer this hit, otherwise it wouldnt be stored in the HitGroup
+    mHitLast = ElementalHit(position.X(), position.Y(), position.Z(), time, numberOfElectrons);
   }
 
   // LOG(info) << "tpc::AddHit" << FairLogger::endl


### PR DESCRIPTION
When the shifted sector (centre of the sector) or the track ID changes during storage of the hits in the simulation, the first hit of the new sector/particle were not stored.
This led to lower cluster charge in the centre of a sector for tracks which crosses the centre of a sector.