### PR TITLE
[QC-751] Add new QC flags

### DIFF
--- a/DataFormats/QualityControl/etc/flagReasons.csv
+++ b/DataFormats/QualityControl/etc/flagReasons.csv
@@ -7,7 +7,7 @@
 6,"CertifiedByExpert","Certified by Expert",0,0
 10,"NoDetectorData","No Detector Data",1,0
 11,"LimitedAcceptance","Limited acceptance",1,0
-12."BadPID","Bad PID",1,0
+12,"BadPID","Bad PID",1,0
 13,"BadTracking","Bad Tracking",1,0
 14,"BadHadronPID","Bad Hadron PID",1,0
 15,"BadElectronPID","Bad Electron PID",1,0

--- a/DataFormats/QualityControl/etc/flagReasons.csv
+++ b/DataFormats/QualityControl/etc/flagReasons.csv
@@ -4,7 +4,7 @@
 3,"MissingQualityObject","Missing Quality Object",1,0
 4,"MissingQuality","Missing Quality",1,0
 5,"UnknownQuality","Unknown Quality",1,0
-6,"Certified","Certified",0,0
+6,"CertifiedByExpert","Certified by Expert",0,0
 10,"DetectorOff","Detector off",1,0
 11,"LimitedAcceptance","Limited acceptance",1,0
 12."BadPID","Bad PID",1,0

--- a/DataFormats/QualityControl/etc/flagReasons.csv
+++ b/DataFormats/QualityControl/etc/flagReasons.csv
@@ -3,8 +3,16 @@
 2,"ProcessingError","Processing Error",1,0
 3,"MissingQualityObject","Missing Quality Object",1,0
 4,"MissingQuality","Missing Quality",1,0
+5,"UnknownQuality","Unknown Quality",1,0
+6,"Certified","Certified",0,0
 10,"DetectorOff","Detector off",1,0
 11,"LimitedAcceptance","Limited acceptance",1,0
+12."BadPID","Bad PID",1,0
+13,"BadTracking","Bad Tracking",1,0
+14,"BadHadronPID","Bad Hadron PID",1,0
+15,"BadElectronPID","Bad Electron PID",1,0
+16,"BadEMCalorimetry","Bad EM Calorimetry",1,0
+17,"BadPhotonCalorimetry","Bad Photon Calorimetry",1,0
 65500,"ObsoleteFlagExample","Obsolete flag example",1,1
 65501,"NotBadFlagExample","Not bad flag example",0,0
 65535,"Invalid","Invalid",1,0

--- a/DataFormats/QualityControl/etc/flagReasons.csv
+++ b/DataFormats/QualityControl/etc/flagReasons.csv
@@ -5,7 +5,7 @@
 4,"MissingQuality","Missing Quality",1,0
 5,"UnknownQuality","Unknown Quality",1,0
 6,"CertifiedByExpert","Certified by Expert",0,0
-10,"DetectorOff","Detector off",1,0
+10,"NoDetectorData","No Detector Data",1,0
 11,"LimitedAcceptance","Limited acceptance",1,0
 12."BadPID","Bad PID",1,0
 13,"BadTracking","Bad Tracking",1,0


### PR DESCRIPTION
These represent the typical problems in Run 2 and derive from the DPG Run 2 run list definitions.
ProcessingError, MissingQualityObject and MissingQuality are going to be removed after we stop using them in QC.