### PR TITLE
TPC Clusters: fix flag for edge cluster

### DIFF
--- a/GPU/GPUTracking/TPCClusterFinder/CfUtils.h
+++ b/GPU/GPUTracking/TPCClusterFinder/CfUtils.h
@@ -20,6 +20,7 @@
 #include "Array2D.h"
 #include "CfConsts.h"
 #include "GPUTPCClusterFinderKernels.h"
+#include "GPUTPCGeometry.h"
 
 namespace GPUCA_NAMESPACE::gpu
 {
@@ -30,7 +31,9 @@ class CfUtils
  public:
   static GPUdi() bool isAtEdge(const ChargePos& pos)
   {
-    return (pos.pad() < 2 || pos.pad() >= TPC_PADS_PER_ROW - 2);
+    static const o2::gpu::GPUTPCGeometry geo;
+    const unsigned char padsPerRow = geo.NPads(pos.row());
+    return (pos.pad() < 2 || pos.pad() >= padsPerRow - 2);
   }
 
   static GPUdi() bool innerAboveThreshold(uchar aboveThreshold, ushort outerIdx)


### PR DESCRIPTION
- since `TPC_PADS_PER_ROW` is always 144 the function `isAtEdge` always returns `false` for `pos.pad() >= TPC_PADS_PER_ROW - 2`