### PR TITLE
MCH: added workflow for extracting CRU pages from TF files

### DIFF
--- a/Detectors/MUON/MCH/Workflow/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Workflow/CMakeLists.txt
@@ -46,6 +46,12 @@ o2_add_executable(
         COMPONENT_NAME mch
         PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsRaw O2::DPLUtils Boost::program_options)
 
+o2_add_executable(
+        dump-pages-workflow
+        SOURCES src/dump-pages-workflow.cxx
+        COMPONENT_NAME mch
+        PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsRaw O2::DPLUtils Boost::program_options)
+
 # to be deprecated : use DevIO/digits-writer instead
 o2_add_executable(
         digits-sink-workflow

--- a/Detectors/MUON/MCH/Workflow/src/dump-pages-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/dump-pages-workflow.cxx
@@ -63,7 +63,7 @@ class DumpPagesTask
   void init(framework::InitContext& ic)
   {
     /// Get the input file and other options from the context
-    LOG(INFO) << "initializing pager dumper";
+    LOG(info) << "initializing pager dumper";
 
     auto outputFileName = ic.options().get<std::string>("outfile");
     mOutputFile.open(outputFileName, std::ios::binary);
@@ -73,7 +73,7 @@ class DumpPagesTask
 
     auto stop = [this]() {
       /// close the input file
-      LOG(INFO) << "stop file reader";
+      LOG(info) << "stop file reader";
       this->mOutputFile.close();
     };
     ic.services().get<CallbackService>().set(CallbackService::Id::Stop, stop);
@@ -91,23 +91,14 @@ class DumpPagesTask
         continue;
       }
       size_t payloadSize = it.size();
-//
-//      auto rdhVersion = o2::raw::RDHUtils::getVersion(rdh);
-//      auto rdhHeaderSize = o2::raw::RDHUtils::getHeaderSize(rdh);
-//      if (mPrint) {
-//        std::cout << "header_version=" << (int)rdhVersion << std::endl;
-//      }
-//      if (rdhVersion < 4 || rdhVersion > 6 || rdhHeaderSize != 64) {
-//        return;
-//      }
 
       mOutputFile.write(reinterpret_cast<const char*>(raw), sizeof(RDH) + payloadSize);
     }
   }
 
  private:
-  std::string mInputSpec{"TF:MCH/RAWDATA"};            /// selection string for the input data
-  std::ofstream mOutputFile{}; ///< input file
+  std::string mInputSpec{"TF:MCH/RAWDATA"}; /// selection string for the input data
+  std::ofstream mOutputFile{};              ///< input file
 };
 
 //_________________________________________________________________________________________________

--- a/Detectors/MUON/MCH/Workflow/src/dump-pages-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/dump-pages-workflow.cxx
@@ -1,0 +1,150 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+///
+/// \file    cru-page-reader-workflow.cxx
+/// \author  Andrea Ferrero
+///
+/// \brief This is an executable that reads a data file from disk and sends the individual CRU pages via DPL.
+///
+/// This is an executable that reads a data file from disk and sends the individual CRU pages via the Data Processing Layer.
+/// It can be used as a data source for O2 development. For example, one can do:
+/// \code{.sh}
+/// o2-mch-cru-page-reader-workflow --infile=some_data_file | o2-mch-raw-to-digits-workflow
+/// \endcode
+///
+
+#include <random>
+#include <iostream>
+#include <queue>
+#include <fstream>
+#include <stdexcept>
+#include "Framework/CallbackService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Lifetime.h"
+#include "Framework/Output.h"
+#include "Framework/Task.h"
+#include "Framework/WorkflowSpec.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/runDataProcessing.h"
+
+#include "DPLUtils/DPLRawParser.h"
+#include "Headers/RAWDataHeader.h"
+#include "DetectorsRaw/RDHUtils.h"
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::raw;
+
+namespace o2
+{
+namespace mch
+{
+namespace raw
+{
+
+using RDH = o2::header::RDHAny;
+
+class DumpPagesTask
+{
+ public:
+  DumpPagesTask(std::string spec) : mInputSpec(spec) {}
+  //_________________________________________________________________________________________________
+  void init(framework::InitContext& ic)
+  {
+    /// Get the input file and other options from the context
+    LOG(INFO) << "initializing pager dumper";
+
+    auto outputFileName = ic.options().get<std::string>("outfile");
+    mOutputFile.open(outputFileName, std::ios::binary);
+    if (!mOutputFile.is_open()) {
+      throw std::invalid_argument("Cannot open output file \"" + outputFileName + "\"");
+    }
+
+    auto stop = [this]() {
+      /// close the input file
+      LOG(INFO) << "stop file reader";
+      this->mOutputFile.close();
+    };
+    ic.services().get<CallbackService>().set(CallbackService::Id::Stop, stop);
+  }
+
+  //_________________________________________________________________________________________________
+  void run(framework::ProcessingContext& pc)
+  {
+    // get the input buffer
+    auto& inputs = pc.inputs();
+    DPLRawParser parser(inputs, o2::framework::select(mInputSpec.c_str()));
+    for (auto it = parser.begin(), end = parser.end(); it != end; ++it) {
+      auto const* raw = it.raw();
+      if (!raw) {
+        continue;
+      }
+      size_t payloadSize = it.size();
+//
+//      auto rdhVersion = o2::raw::RDHUtils::getVersion(rdh);
+//      auto rdhHeaderSize = o2::raw::RDHUtils::getHeaderSize(rdh);
+//      if (mPrint) {
+//        std::cout << "header_version=" << (int)rdhVersion << std::endl;
+//      }
+//      if (rdhVersion < 4 || rdhVersion > 6 || rdhHeaderSize != 64) {
+//        return;
+//      }
+
+      mOutputFile.write(reinterpret_cast<const char*>(raw), sizeof(RDH) + payloadSize);
+    }
+  }
+
+ private:
+  std::string mInputSpec{"TF:MCH/RAWDATA"};            /// selection string for the input data
+  std::ofstream mOutputFile{}; ///< input file
+};
+
+//_________________________________________________________________________________________________
+// clang-format off
+o2::framework::DataProcessorSpec getDumpPagesSpec(const char* specName)
+{
+  auto inputs = o2::framework::select("TF:MCH/RAWDATA");
+  for (auto& inp : inputs) {
+    // mark input as optional in order not to block the workflow
+    // if our raw data happen to be missing in some TFs
+    inp.lifetime = Lifetime::Optional;
+  }
+  //o2::mch::raw::DumpPagesTask task("TF:MCH/RAWDATA");
+  return DataProcessorSpec{
+    specName,
+    inputs,
+    Outputs{},
+    //AlgorithmSpec{adaptFromTask<o2::mch::raw::DumpPagesTask>(std::move(task))},
+    AlgorithmSpec{adaptFromTask<o2::mch::raw::DumpPagesTask>("TF:MCH/RAWDATA")},
+    Options{{"outfile", VariantType::String, "data.raw", {"output file name"}}}};
+}
+// clang-format on
+
+} // end namespace raw
+} // end namespace mch
+} // end namespace o2
+
+using namespace o2;
+using namespace o2::framework;
+
+WorkflowSpec defineDataProcessing(const ConfigContext&)
+{
+  WorkflowSpec specs;
+
+  // The producer to generate some data in the workflow
+  DataProcessorSpec producer = mch::raw::getDumpPagesSpec("mch-page-dumper");
+  specs.push_back(producer);
+
+  return specs;
+}


### PR DESCRIPTION
The workflow writes the raw CRU pages into an output file, which can then be parsed with the MCH low-level debugging tools as if it was directly recorded with the readout process.

Useful for detailed low-level debugging of the MCH data.