### PR TITLE
MCH: add errors message in decoder

### DIFF
--- a/Detectors/MUON/MCH/Base/include/MCHBase/DecoderError.h
+++ b/Detectors/MUON/MCH/Base/include/MCHBase/DecoderError.h
@@ -31,7 +31,7 @@ class DecoderError
  public:
   DecoderError() = default;
 
-  DecoderError(int solarid, int dsid, int chip, uint32_t error) : mSolarID(solarid), mChipID(dsid * 2 + chip), mError(error) {}
+  DecoderError(int solarid, int dsid, int chip, uint32_t error) : mSolarID(solarid), mChipID(dsid * 2 + (chip % 2)), mError(error) {}
   ~DecoderError() = default;
 
   uint16_t getSolarID() const { return mSolarID; }

--- a/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DataDecoder.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DataDecoder.h
@@ -26,6 +26,7 @@
 
 #include "Headers/RDHAny.h"
 #include "DataFormatsMCH/Digit.h"
+#include "MCHBase/DecoderError.h"
 #include "MCHRawDecoder/OrbitInfo.h"
 #include "MCHRawDecoder/PageDecoder.h"
 
@@ -184,6 +185,8 @@ class DataDecoder
   const RawDigitVector& getDigits() const { return mDigits; }
   /// Get the list of orbits that have been found in the current TimeFrame for each CRU link
   const std::unordered_set<OrbitInfo, OrbitInfoHash>& getOrbits() const { return mOrbits; }
+  /// Get the list of decoding errors that have been found in the current TimeFrame
+  const std::vector<o2::mch::DecoderError>& getErrors() const { return mErrors; }
   /// Initialize the digits from an external vector. To be only used for unit tests.
   void setDigits(const RawDigitVector& digits) { mDigits = digits; }
 
@@ -234,6 +237,7 @@ class DataDecoder
 
   RawDigitVector mDigits;                               ///< vector of decoded digits
   std::unordered_set<OrbitInfo, OrbitInfoHash> mOrbits; ///< list of orbits in the processed buffer
+  std::vector<o2::mch::DecoderError> mErrors;           ///< list of decoding errors in the processed buffer
 
   uint32_t mOrbitsInTF{128};    ///< number of orbits in one time frame
   uint32_t mBcInOrbit;          ///< number of bunch crossings in one orbit

--- a/Detectors/MUON/MCH/Raw/Decoder/src/DataDecoder.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/DataDecoder.cxx
@@ -612,11 +612,15 @@ void DataDecoder::decodePage(gsl::span<const std::byte> page)
     updateMergerRecord(mergerChannelId, mergerBoardId, mergerChannelBitmask, mDigits.size() - 1);
   };
 
-  auto errorHandler = [&](DsElecId dsId,
+  auto errorHandler = [&](DsElecId dsElecId,
                           int8_t chip,
                           uint32_t error) {
-    std::string msg = fmt::format("{} chip {:2d} error {:4d} ({})", asString(dsId), chip, error, errorCodeAsString(error));
+    std::string msg = fmt::format("{} chip {:2d} error {:4d} ({})", asString(dsElecId), chip, error, errorCodeAsString(error));
     mErrorMap[msg]++;
+
+    auto solarId = dsElecId.solarId();
+    auto dsId = dsElecId.elinkId();
+    mErrors.emplace_back(o2::mch::DecoderError(solarId, dsId, chip, error));
   };
 
   patchPage(page, mDebug);

--- a/Detectors/MUON/MCH/Raw/Decoder/src/DataDecoder.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/DataDecoder.cxx
@@ -924,6 +924,7 @@ void DataDecoder::reset()
 {
   mDigits.clear();
   mOrbits.clear();
+  mErrors.clear();
   memset(mMergerRecordsReady.data(), 0, sizeof(uint64_t) * mMergerRecordsReady.size());
 }
 

--- a/Detectors/MUON/MCH/Raw/Decoder/src/ErrorCodes.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/ErrorCodes.cxx
@@ -48,7 +48,7 @@ std::string errorCodeAsString(uint32_t ec)
     append("Bad Packet Type", msg);
   }
   if (ec & ErrorBadHeartBeatPacket) {
-    append("Bad HeartBeat Packet", msg);
+    append("Bad HB Packet", msg);
   }
   if (ec & ErrorBadIncompleteWord) {
     append("Bad Incomplete Word", msg);


### PR DESCRIPTION
The additional message provides the list of decoding errors encountered in one TF.
The message can be used for example to plot and check the errors in QC.

The code for processing the errors message in QualityControl is introduced by AliceO2Group/QualityControl#1118.