### PR TITLE
A few improvements for TPC CCDB access in digitization

### DIFF
--- a/Detectors/TPC/simulation/src/Digitizer.cxx
+++ b/Detectors/TPC/simulation/src/Digitizer.cxx
@@ -40,6 +40,12 @@ void Digitizer::init()
   if (mUseSCDistortions) {
     mSpaceCharge->init();
   }
+  auto& gemAmplification = GEMAmplification::instance();
+  gemAmplification.updateParameters();
+  auto& electronTransport = ElectronTransport::instance();
+  electronTransport.updateParameters();
+  auto& sampaProcessing = SAMPAProcessing::instance();
+  sampaProcessing.updateParameters();
 }
 
 void Digitizer::process(const std::vector<o2::tpc::HitGroup>& hits,
@@ -50,12 +56,9 @@ void Digitizer::process(const std::vector<o2::tpc::HitGroup>& hits,
   auto& eleParam = ParameterElectronics::Instance();
   auto& gemParam = ParameterGEM::Instance();
 
-  static GEMAmplification& gemAmplification = GEMAmplification::instance();
-  gemAmplification.updateParameters();
-  static ElectronTransport& electronTransport = ElectronTransport::instance();
-  electronTransport.updateParameters();
-  static SAMPAProcessing& sampaProcessing = SAMPAProcessing::instance();
-  sampaProcessing.updateParameters();
+  auto& gemAmplification = GEMAmplification::instance();
+  auto& electronTransport = ElectronTransport::instance();
+  auto& sampaProcessing = SAMPAProcessing::instance();
 
   const int nShapedPoints = eleParam.NShapedPoints;
   const auto amplificationMode = gemParam.AmplMode;

--- a/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
+++ b/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
@@ -427,6 +427,10 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   // we expect that digitizers do not play with the manager themselves
   // this will only be needed until digitizers take CCDB objects via DPL mechanism
   o2::ccdb::BasicCCDBManager::instance().setTimestamp(hbfu.startTime);
+  // activate caching
+  o2::ccdb::BasicCCDBManager::instance().setCaching(true);
+  // without this, caching does not seem to work
+  o2::ccdb::BasicCCDBManager::instance().setLocalObjectValidityChecking(true);
 
   // update the digitization configuration with the right geometry file
   // we take the geometry from the first simPrefix (could actually check if they are


### PR DESCRIPTION
Following
https://alice.its.cern.ch/jira/browse/O2-2858

a couple of things have been discovered:

a) TPC makes too many requests to CCDB (even within a timeframe)
b) The caching mechanism from BasicCCDBManager was not really active
   (and is probably faulty without setting setLocalObjectValidityChecking + having ALICEO2_CCDB_LOCALCACHE)

This commit alleviates both.

This fixes O2-2858 for me. However, it would still be good to understand
why there were crashes before.