### PR TITLE
Do not use static variable on GPU

### DIFF
--- a/GPU/GPUTracking/TPCClusterFinder/CfUtils.h
+++ b/GPU/GPUTracking/TPCClusterFinder/CfUtils.h
@@ -28,9 +28,9 @@ class CfUtils
 {
 
  public:
-  static GPUdi() bool isAtEdge(const ChargePos& pos)
+  static GPUdi() bool isAtEdge(const ChargePos& pos, tpccf::GlobalPad padsPerRow)
   {
-    return (pos.pad() < 2 || pos.pad() >= TPC_PADS_PER_ROW - 2);
+    return (pos.pad() < 2 || pos.pad() >= padsPerRow - 2);
   }
 
   static GPUdi() bool innerAboveThreshold(uchar aboveThreshold, ushort outerIdx)

--- a/GPU/GPUTracking/TPCClusterFinder/CfUtils.h
+++ b/GPU/GPUTracking/TPCClusterFinder/CfUtils.h
@@ -20,7 +20,6 @@
 #include "Array2D.h"
 #include "CfConsts.h"
 #include "GPUTPCClusterFinderKernels.h"
-#include "GPUTPCGeometry.h"
 
 namespace GPUCA_NAMESPACE::gpu
 {
@@ -31,9 +30,7 @@ class CfUtils
  public:
   static GPUdi() bool isAtEdge(const ChargePos& pos)
   {
-    static const o2::gpu::GPUTPCGeometry geo;
-    const unsigned char padsPerRow = geo.NPads(pos.row());
-    return (pos.pad() < 2 || pos.pad() >= padsPerRow - 2);
+    return (pos.pad() < 2 || pos.pad() >= TPC_PADS_PER_ROW - 2);
   }
 
   static GPUdi() bool innerAboveThreshold(uchar aboveThreshold, ushort outerIdx)

--- a/GPU/GPUTracking/TPCClusterFinder/ClusterAccumulator.h
+++ b/GPU/GPUTracking/TPCClusterFinder/ClusterAccumulator.h
@@ -30,6 +30,7 @@ namespace gpu
 {
 
 struct ChargePos;
+class GPUTPCGeometry;
 
 class ClusterAccumulator
 {
@@ -38,8 +39,8 @@ class ClusterAccumulator
   GPUd() tpccf::Charge updateInner(PackedCharge, tpccf::Delta2);
   GPUd() tpccf::Charge updateOuter(PackedCharge, tpccf::Delta2);
 
-  GPUd() void finalize(const ChargePos&, tpccf::Charge, tpccf::TPCTime);
-  GPUd() void toNative(const ChargePos&, tpccf::Charge, int, tpc::ClusterNative&) const;
+  GPUd() void finalize(const ChargePos&, tpccf::Charge, tpccf::TPCTime, const GPUTPCGeometry&);
+  GPUd() void toNative(const ChargePos&, tpccf::Charge, int, tpc::ClusterNative&, const GPUTPCGeometry&) const;
 
  private:
   float mQtot = 0;

--- a/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFClusterizer.cxx
+++ b/GPU/GPUTracking/TPCClusterFinder/GPUTPCCFClusterizer.cxx
@@ -75,10 +75,10 @@ GPUdii() void GPUTPCCFClusterizer::computeClustersImpl(int nBlocks, int nThreads
   if (idx >= clusternum || fragment.isOverlap(pos.time())) {
     return;
   }
-  pc.finalize(pos, charge, fragment.start);
+  pc.finalize(pos, charge, fragment.start, clusterer.Param().tpcGeometry);
 
   tpc::ClusterNative myCluster;
-  pc.toNative(pos, charge, calib.tpc.cfMinSplitNum, myCluster);
+  pc.toNative(pos, charge, calib.tpc.cfMinSplitNum, myCluster, clusterer.Param().tpcGeometry);
 
   bool aboveQTotCutoff = (myCluster.qTot > calib.tpc.cfQTotCutoff);
 


### PR DESCRIPTION
Constructor of the static variable will not be called, we have to pass in the Geometry from the ConstantMem region where it is initialized by GPUReconstruction.

@matthias-kleiner : sorry for not spotting this before. Your fix is correct on CPU but should not be done like this on the GPU.