### PR TITLE
Fix updateTimeDependentParams on MFT Workflows

### DIFF
--- a/Detectors/ITSMFT/MFT/workflow/src/ClustererSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/ClustererSpec.cxx
@@ -86,6 +86,7 @@ void ClustererDPL::init(InitContext& ic)
 
 void ClustererDPL::run(ProcessingContext& pc)
 {
+  updateTimeDependentParams(pc);
   auto digits = pc.inputs().get<gsl::span<o2::itsmft::Digit>>("digits");
   auto rofs = pc.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("ROframes");
 

--- a/Detectors/ITSMFT/MFT/workflow/src/MFTAssessmentSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/MFTAssessmentSpec.cxx
@@ -55,7 +55,7 @@ void MFTAssessmentSpec::init(InitContext& ic)
 //_____________________________________________________________
 void MFTAssessmentSpec::run(o2::framework::ProcessingContext& pc)
 {
-
+  updateTimeDependentParams(pc);
   mTimer[SWQCAsync].Start(false);
   mMFTAssessment->runASyncQC(pc);
   mTimer[SWQCAsync].Stop();


### PR DESCRIPTION
As it is, the MFT clusterizer and assessment workflows are not fetching the cluster topology dictionary from CCDB.