### PR TITLE
Fixes SOR/EOR assignment in CreateGRPECSObject.C

### DIFF
--- a/macro/CreateGRPECSObject.C
+++ b/macro/CreateGRPECSObject.C
@@ -15,6 +15,7 @@
 #include <chrono>
 #include "DataFormatsParameters/GRPECSObject.h"
 #include "DetectorsCommonDataFormats/DetID.h"
+#include "CommonUtils/NameConf.h"
 #include "CCDB/CcdbApi.h"
 
 #endif
@@ -32,8 +33,8 @@ using GRPECSObject = o2::parameters::GRPECSObject;
 // e.g.
 /*
  .L CreateGRPECSObject.C+
- std::time_t tStart = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count()
- std::time_t tEnd = (tStart + 60 * 60 * 24 * 365) * 1000; // 1 year validity, just an example
+ std::time_t tStart = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count()
+ std::time_t tEnd = tStart + 60 * 60 * 24 * 365 * 1000; // 1 year validity, just an example
  o2::detectors::DetID::mask_t detsRO = o2::detectors::DetID::getMask("ITS, TPC, TRD, TOF, CPV, PHS, EMC, MID, MFT, MCH, FT0, FV0, FDD, CTP");
  o2::detectors::DetID::mask_t detsContRO = o2::detectors::DetID::getMask("TOF, TPC, ITS")
  o2::detectors::DetID::mask_t detsTrig = o2::detectors::DetID::getMask("FV0")
@@ -45,6 +46,7 @@ void CreateGRPECSObject(timePoint start, uint32_t nHBPerTF, DetID::mask_t detsRe
 
   GRPECSObject grpecs;
   grpecs.setTimeStart(start);
+  grpecs.setTimeEnd(end);
   grpecs.setNHBFPerTF(nHBPerTF);
   grpecs.setDetsReadOut(detsReadout);
   grpecs.setDetsContinuousReadOut(detsContinuousRO);
@@ -59,7 +61,9 @@ void CreateGRPECSObject(timePoint start, uint32_t nHBPerTF, DetID::mask_t detsRe
   metadata[o2::base::NameConf::CCDBRunTag.data()] = std::to_string(run);
   //long ts = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
   if (end < 0) {
-    end = (start + 60 * 60 * 10) * 1000; // start + 10h, in ms
+    end = (start + 60 * 60 * 10 * 1000); // start + 10h, in ms
+  } else {
+    end += 2 * 60 * 60 * 1000; // 2h in ms
   }
-  api.storeAsTFileAny(&grpecs, "GLO/Config/GRPECS", metadata, start * 1000, end); // making it 1-year valid to be sure we have something
+  api.storeAsTFileAny(&grpecs, "GLO/Config/GRPECS", metadata, start - 1000, end);
 }


### PR DESCRIPTION
Retrofifted again pilot beam GRPECS with SOR/EOR assigned (steering macro : [retrofitPilotBeamGRP.C.gz](https://github.com/AliceO2Group/AliceO2/files/8366358/retrofitPilotBeamGRP.C.gz))
