### PR TITLE
Material map

### DIFF
--- a/Common/SimConfig/CMakeLists.txt
+++ b/Common/SimConfig/CMakeLists.txt
@@ -14,6 +14,7 @@ o2_add_library(SimConfig
                        src/SimParams.cxx
                        src/SimUserDecay.cxx
                        src/DigiParams.cxx src/G4Params.cxx
+                       src/MatMapParams.cxx
                PUBLIC_LINK_LIBRARIES O2::CommonUtils
                                      O2::DetectorsCommonDataFormats
                                      FairRoot::Base Boost::program_options)
@@ -24,7 +25,8 @@ o2_target_root_dictionary(SimConfig
                                   include/SimConfig/SimParams.h
                                   include/SimConfig/SimUserDecay.h
 		include/SimConfig/DigiParams.h
-                                  include/SimConfig/G4Params.h)
+                                  include/SimConfig/G4Params.h
+                                  include/SimConfig/MatMapParams.h)
 
 o2_add_test(Config
             SOURCES test/TestConfig.cxx

--- a/Common/SimConfig/include/SimConfig/MatMapParams.h
+++ b/Common/SimConfig/include/SimConfig/MatMapParams.h
@@ -1,0 +1,49 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author A+Morsch
+
+#include <string>
+#ifndef ALICEO2_SIMCONFIG_MATMAPPARAMS_H_
+#define ALICEO2_SIMCONFIG_MATMAPPARAMS_H_
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "CommonUtils/ConfigurableParamHelper.h"
+
+namespace o2
+{
+namespace conf
+{ 
+/**
+ ** A parameter class/struct holding values for
+ ** material budget maps
+ **/
+struct MatMapParams : public o2::conf::ConfigurableParamHelper<MatMapParams> {
+  int nphi = 360;
+  float phimin = 0;
+  float phimax = 360.;
+  int ntheta = 0;
+  float thetamin = -45.;
+  float thetamax = 45.;
+  int neta = 0;
+  float etamin = -2.;
+  float etamax = 2.;  
+  int nzv = 0;
+  float zvmin = -50.;
+  float zvmax = 50.;  
+  float rmin = 0.;
+  float rmax = 290.;
+  float zmax = 2000;
+  O2ParamDef(MatMapParams, "matm");
+};
+} // end namespace o2
+} // end namespace conf
+#endif // ALICEO2_SIMCONFIG_MATMAPPARAMS_H_

--- a/Common/SimConfig/include/SimConfig/MatMapParams.h
+++ b/Common/SimConfig/include/SimConfig/MatMapParams.h
@@ -21,7 +21,7 @@
 namespace o2
 {
 namespace conf
-{ 
+{
 /**
  ** A parameter class/struct holding values for
  ** material budget maps
@@ -35,15 +35,15 @@ struct MatMapParams : public o2::conf::ConfigurableParamHelper<MatMapParams> {
   float thetamax = 45.;
   int neta = 0;
   float etamin = -2.;
-  float etamax = 2.;  
+  float etamax = 2.;
   int nzv = 0;
   float zvmin = -50.;
-  float zvmax = 50.;  
+  float zvmax = 50.;
   float rmin = 0.;
   float rmax = 290.;
   float zmax = 2000;
   O2ParamDef(MatMapParams, "matm");
 };
-} // end namespace o2
-} // end namespace conf
+} // namespace conf
+} // namespace o2
 #endif // ALICEO2_SIMCONFIG_MATMAPPARAMS_H_

--- a/Common/SimConfig/src/MatMapParams.cxx
+++ b/Common/SimConfig/src/MatMapParams.cxx
@@ -1,0 +1,13 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "SimConfig/MatMapParams.h"
+O2ParamImpl(o2::conf::MatMapParams);

--- a/Common/SimConfig/src/SimConfigLinkDef.h
+++ b/Common/SimConfig/src/SimConfigLinkDef.h
@@ -34,4 +34,6 @@
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::conf::G4Params> + ;
 
 #pragma link C++ struct o2::conf::MatMapParams + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::conf::MatMapParams> + ;
+
 #endif

--- a/Common/SimConfig/src/SimConfigLinkDef.h
+++ b/Common/SimConfig/src/SimConfigLinkDef.h
@@ -33,4 +33,5 @@
 #pragma link C++ struct o2::conf::G4Params + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::conf::G4Params> + ;
 
+#pragma link C++ struct o2::conf::MatMapParams + ;
 #endif

--- a/Generators/CMakeLists.txt
+++ b/Generators/CMakeLists.txt
@@ -38,6 +38,7 @@ o2_add_library(Generators
 		       src/QEDGenParam.cxx
                        src/GenCosmicsParam.cxx
                        src/GeneratorFactory.cxx
+                       src/GeneratorGeantinos.cxx
                        $<$<BOOL:${pythia6_FOUND}>:src/GeneratorPythia6.cxx>
                        $<$<BOOL:${pythia6_FOUND}>:src/GeneratorPythia6Param.cxx>
                        $<$<BOOL:${pythia_FOUND}>:src/GeneratorPythia8.cxx>
@@ -78,7 +79,9 @@ set(headers
     include/Generators/TriggerParticleParam.h
     include/Generators/BoxGunParam.h
     include/Generators/QEDGenParam.h
-    include/Generators/GenCosmicsParam.h)
+    include/Generators/GenCosmicsParam.h
+    include/Generators/GeneratorGeantinos.h
+    )
 
 if (pythia6_FOUND)
    list(APPEND headers include/Generators/GeneratorPythia6.h

--- a/Generators/include/Generators/GeneratorGeantinos.h
+++ b/Generators/include/Generators/GeneratorGeantinos.h
@@ -35,7 +35,7 @@ class GeneratorGeantinos : public FairGenerator
   GeneratorGeantinos(Int_t mode, Int_t nc1, Float_t c1min, Float_t c1max,
                      Int_t nc2, Float_t c2min, Float_t c2max,
                      Float_t rmin, Float_t rmax, Float_t zmax);
-  ~GeneratorGeantinos() {}
+  ~GeneratorGeantinos() override = default;
   Bool_t ReadEvent(FairPrimaryGenerator* primGen) override;
   // Getters
   Float_t ZMax() const { return mZMax; }

--- a/Generators/include/Generators/GeneratorGeantinos.h
+++ b/Generators/include/Generators/GeneratorGeantinos.h
@@ -1,0 +1,52 @@
+#ifndef ALICEO2_GENERATORGEANTINOS_H
+#define ALICEO2_GENERATORGEANTINOS_H
+
+///////////////////////////////////////////////////////////////////////////////
+//                                                                           //
+//                                                                           //
+//    Utility class to compute and draw Radiation Length Map                 //
+//                                                                           //
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////
+
+#include "FairGenerator.h"
+#include <TClonesArray.h>
+namespace o2
+{
+namespace eventgen
+{
+class GeneratorGeantinos:
+public FairGenerator
+{
+
+public: 
+    GeneratorGeantinos();
+    GeneratorGeantinos(Int_t mode, Int_t nc1, Float_t c1min, Float_t c1max,
+		     Int_t nc2, Float_t c2min, Float_t c2max,
+		     Float_t rmin, Float_t rmax, Float_t zmax);
+    virtual ~GeneratorGeantinos() {}
+    Bool_t ReadEvent(FairPrimaryGenerator* primGen) override;
+    // Getters	    
+    virtual Float_t ZMax()   const {return mZMax;}
+    virtual Float_t RadMax() const {return mRadMax;}
+    virtual Int_t   NCoor1() const {return mNCoor1;}
+    virtual Int_t   NCoor2() const {return mNCoor2;}
+    // Helpers    
+    Float_t         PropagateCylinder(Float_t *x, Float_t *v, Float_t r, Float_t z);
+ protected:
+    Int_t      mMode;               // generation mode
+    Float_t    mRadMin;             // Generation radius
+    Float_t    mRadMax;             // Maximum tracking radius
+    Float_t    mZMax;               // Maximum tracking Z
+    Int_t      mNCoor1;             // Number of bins in Coor1
+    Int_t      mNCoor2;             // Number of bins in Coor2
+
+    Float_t    mCoor1Min;           // Minimum Coor1
+    Float_t    mCoor1Max;           // Maximum Coor1
+    Float_t    mCoor2Min;           // Minimum Coor2
+    Float_t    mCoor2Max;           // Maximum Coor2 
+};
+}
+}
+#endif
+

--- a/Generators/include/Generators/GeneratorGeantinos.h
+++ b/Generators/include/Generators/GeneratorGeantinos.h
@@ -1,3 +1,16 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author A+Morsch - March 2022
+
 #ifndef ALICEO2_GENERATORGEANTINOS_H
 #define ALICEO2_GENERATORGEANTINOS_H
 
@@ -10,43 +23,41 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "FairGenerator.h"
-#include <TClonesArray.h>
 namespace o2
 {
 namespace eventgen
 {
-class GeneratorGeantinos:
-public FairGenerator
+class GeneratorGeantinos : public FairGenerator
 {
 
-public: 
-    GeneratorGeantinos();
-    GeneratorGeantinos(Int_t mode, Int_t nc1, Float_t c1min, Float_t c1max,
-		     Int_t nc2, Float_t c2min, Float_t c2max,
-		     Float_t rmin, Float_t rmax, Float_t zmax);
-    virtual ~GeneratorGeantinos() {}
-    Bool_t ReadEvent(FairPrimaryGenerator* primGen) override;
-    // Getters	    
-    virtual Float_t ZMax()   const {return mZMax;}
-    virtual Float_t RadMax() const {return mRadMax;}
-    virtual Int_t   NCoor1() const {return mNCoor1;}
-    virtual Int_t   NCoor2() const {return mNCoor2;}
-    // Helpers    
-    Float_t         PropagateCylinder(Float_t *x, Float_t *v, Float_t r, Float_t z);
+ public:
+  GeneratorGeantinos();
+  GeneratorGeantinos(Int_t mode, Int_t nc1, Float_t c1min, Float_t c1max,
+                     Int_t nc2, Float_t c2min, Float_t c2max,
+                     Float_t rmin, Float_t rmax, Float_t zmax);
+  ~GeneratorGeantinos() {}
+  Bool_t ReadEvent(FairPrimaryGenerator* primGen) override;
+  // Getters
+  Float_t ZMax() const { return mZMax; }
+  Float_t RadMax() const { return mRadMax; }
+  Int_t NCoor1() const { return mNCoor1; }
+  Int_t NCoor2() const { return mNCoor2; }
+  // Helpers
+  Float_t PropagateCylinder(Float_t* x, Float_t* v, Float_t r, Float_t z);
+
  protected:
-    Int_t      mMode;               // generation mode
-    Float_t    mRadMin;             // Generation radius
-    Float_t    mRadMax;             // Maximum tracking radius
-    Float_t    mZMax;               // Maximum tracking Z
-    Int_t      mNCoor1;             // Number of bins in Coor1
-    Int_t      mNCoor2;             // Number of bins in Coor2
+  Int_t mMode;     // generation mode
+  Float_t mRadMin; // Generation radius
+  Float_t mRadMax; // Maximum tracking radius
+  Float_t mZMax;   // Maximum tracking Z
+  Int_t mNCoor1;   // Number of bins in Coor1
+  Int_t mNCoor2;   // Number of bins in Coor2
 
-    Float_t    mCoor1Min;           // Minimum Coor1
-    Float_t    mCoor1Max;           // Maximum Coor1
-    Float_t    mCoor2Min;           // Minimum Coor2
-    Float_t    mCoor2Max;           // Maximum Coor2 
+  Float_t mCoor1Min; // Minimum Coor1
+  Float_t mCoor1Max; // Maximum Coor1
+  Float_t mCoor2Min; // Minimum Coor2
+  Float_t mCoor2Max; // Maximum Coor2
 };
-}
-}
+} // namespace eventgen
+} // namespace o2
 #endif
-

--- a/Generators/include/Generators/GeneratorGeantinos.h
+++ b/Generators/include/Generators/GeneratorGeantinos.h
@@ -43,7 +43,7 @@ class GeneratorGeantinos : public FairGenerator
   Int_t NCoor1() const { return mNCoor1; }
   Int_t NCoor2() const { return mNCoor2; }
   // Helpers
-  Float_t PropagateCylinder(Float_t* x, Float_t* v, Float_t r, Float_t z);
+  static Float_t PropagateCylinder(Float_t* x, Float_t* v, Float_t r, Float_t z);
 
  protected:
   Int_t mMode;     // generation mode

--- a/Generators/src/GeneratorGeantinos.cxx
+++ b/Generators/src/GeneratorGeantinos.cxx
@@ -104,8 +104,9 @@ Bool_t GeneratorGeantinos::ReadEvent(FairPrimaryGenerator* primGen)
         orig[0] = pmom[0] * t;
         orig[1] = pmom[1] * t;
         orig[2] = pmom[2] * t;
-        if (TMath::Abs(orig[2]) > mZMax)
+        if (TMath::Abs(orig[2]) > mZMax) {
           return kFALSE;
+        }
       }
       Float_t polar[3] = {0., 0., 0.};
       primGen->AddTrack(0, pmom[0], pmom[1], pmom[2], orig[0], orig[1], orig[2], -1, true, 0, 0, 1.);
@@ -134,12 +135,13 @@ Float_t GeneratorGeantinos::PropagateCylinder(Float_t* x, Float_t* v, Float_t r,
   d[0] *= hnorm;
   d[1] *= hnorm;
   d[2] *= hnorm;
-  if (d[2] > kSmall)
+  if (d[2] > kSmall) {
     sz = (z - x[2]) / d[2];
-  else if (d[2] < -kSmall)
+  } else if (d[2] < -kSmall) {
     sz = -(z + x[2]) / d[2];
-  else
+  } else {
     sz = 1.e10; // ---> Direction parallel to X-Y, no intersection
+  }
 
   t1 = d[0] * d[0] + d[1] * d[1];
   if (t1 <= kSmall2) {

--- a/Generators/src/GeneratorGeantinos.cxx
+++ b/Generators/src/GeneratorGeantinos.cxx
@@ -1,0 +1,148 @@
+
+
+//------------------------------------------------------------------------
+//        Generic Lego generator code
+//    Uses geantino rays to check the material distributions and detector's
+//    geometry
+//    Author: A.Morsch
+//------------------------------------------------------------------------
+
+#include "Generators/GeneratorGeantinos.h"
+#include <TParticle.h>
+#include <FairPrimaryGenerator.h>
+
+namespace o2
+{
+namespace eventgen
+{
+//_______________________________________________________________________
+GeneratorGeantinos::GeneratorGeantinos():
+  FairGenerator(),
+  mMode(-1),
+  mRadMin(0),
+  mRadMax(0),
+  mZMax(0),
+  mNCoor1(0),
+  mNCoor2(0),
+  mCoor1Min(0),
+  mCoor1Max(0),
+  mCoor2Min(0),
+  mCoor2Max(0)
+{
+}
+
+//_______________________________________________________________________
+GeneratorGeantinos::GeneratorGeantinos(Int_t mode, Int_t nc1, Float_t c1min,
+                                   Float_t c1max, Int_t nc2, 
+                                   Float_t c2min, Float_t c2max,
+                                   Float_t rmin, Float_t rmax, Float_t zmax):
+
+  FairGenerator(),
+  mMode(mode),
+  mRadMin(rmin),
+  mRadMax(rmax),
+  mZMax(zmax),
+  mNCoor1(nc1),
+  mNCoor2(nc2),
+  mCoor1Min(c1min),
+  mCoor1Max(c1max),
+  mCoor2Min(c2min),
+  mCoor2Max(c2max)
+{
+  //
+  // Standard generator for geantinos
+  //
+}
+
+//_______________________________________________________________________
+Bool_t GeneratorGeantinos::ReadEvent(FairPrimaryGenerator* primGen)
+{
+   Float_t orig[3], pmom[3];
+   Float_t t, cost, sint, cosp, sinp;
+   Float_t s1 = (mCoor1Max - mCoor1Min) / mNCoor1;
+   Float_t s2 = (mCoor2Max - mCoor2Min) / mNCoor2;
+   const Float_t g2rad = TMath::Pi() / 180.;
+   for (Int_t i = 0; i < mNCoor1; i++) {
+     for (Int_t j = 0; j < mNCoor2; j++) {
+       Float_t c1 = mCoor1Min + i * s1 + s1 / 2.;
+       Float_t c2 = mCoor2Min + j * s2 + s2 / 2.;
+       if (mMode == 2) {
+          sint = 1.; 
+          cost = 0.;
+       } else if (mMode == 1) {
+          Float_t theta = 2. * TMath::ATan(TMath::Exp(-c1));
+          sint = TMath::Sin(theta);
+          cost = TMath::Cos(theta);
+       } else {
+          cost      = TMath::Cos(c1 * g2rad);
+          sint      = TMath::Sin(c1 * g2rad);  
+       }
+       
+       cosp      = TMath::Cos(c2 * g2rad);
+       sinp      = TMath::Sin(c2 * g2rad);
+       
+       pmom[0] = cosp * sint;
+       pmom[1] = sinp * sint;
+       pmom[2] = cost;
+       
+   
+      // --- Where to start
+      orig[0] = orig[1] = orig[2] = 0;
+      if (mMode == 2) {
+        orig[2] = c1;
+      }
+      Float_t dalicz = 3000;
+      if (mRadMin > 0) {
+         t = PropagateCylinder(orig, pmom, mRadMin, dalicz);
+         orig[0] = pmom[0] * t;
+         orig[1] = pmom[1] * t;
+         orig[2] = pmom[2] * t;
+         if (TMath::Abs(orig[2]) > mZMax) return kFALSE;
+      }
+      Float_t polar[3]={0., 0., 0.};
+      primGen->AddTrack(0, pmom[0], pmom[1], pmom[2], orig[0], orig[1], orig[2], -1, true, 0, 0, 1.);
+     } // j
+   } // i
+   return kTRUE;
+}
+
+//_______________________________________________________________________
+Float_t GeneratorGeantinos::PropagateCylinder(Float_t *x, Float_t *v, Float_t r, 
+                                            Float_t z)
+{
+  //
+  // Propagate to cylinder from inside
+  //
+   Double_t hnorm, sz, t, t1, t2, t3, sr;
+   Double_t d[3];
+   const Float_t kSmall  = 1e-8;
+   const Float_t kSmall2 = kSmall * kSmall;
+
+// ---> Find intesection with Z planes
+   d[0]  = v[0];
+   d[1]  = v[1];
+   d[2]  = v[2];
+   hnorm = TMath::Sqrt(1 / (d[0] * d[0] + d[1] * d[1] + d[2] * d[2]));
+   d[0] *= hnorm;
+   d[1] *= hnorm;
+   d[2] *= hnorm;
+   if (d[2] > kSmall)       sz = (z - x[2]) / d[2];
+   else if (d[2] < -kSmall) sz = -(z + x[2]) / d[2];
+   else                     sz = 1.e10;  // ---> Direction parallel to X-Y, no intersection
+
+   t1 = d[0] * d[0] + d[1] * d[1];
+   if (t1 <= kSmall2) {
+      t = sz;  // ---> Track parallel to the z-axis, take distance to planes
+   } else {
+      t2 = x[0] * d[0] + x[1] * d[1];
+      t3 = x[0] * x[0] + x[1] * x[1];
+      // ---> It should be positive, but there may be numerical problems
+      sr = (-t2 + TMath::Sqrt(TMath::Max(t2 * t2 - (t3 - r * r) * t1, 0.))) / t1;
+      // ---> Find minimum distance between planes and cylinder
+      t  = TMath::Min(sz, sr);
+   }
+   return t;
+}
+}
+}
+

--- a/Generators/src/GeneratorGeantinos.cxx
+++ b/Generators/src/GeneratorGeantinos.cxx
@@ -1,10 +1,12 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.                                                                          // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.                                                     // All rights not expressly granted are reserved.                                                                                       //                                                                                                                                      // This software is distributed under the terms of the GNU General Public                                                               // License v3 (GPL Version 3), copied verbatim in the file "COPYING".                                                                   //                                                                                                                                      // In applying this license CERN does not waive the privileges and immunities                                                           // granted to it by virtue of its status as an Intergovernmental Organization                                                           // or submit itself to any jurisdiction.                                                                                                
+//
+/// \author A+Morsch - March 2022                                                                                                        
+
 
 
 //------------------------------------------------------------------------
-//        Generic Lego generator code
-//    Uses geantino rays to check the material distributions and detector's
+//    Generates geantino rays to check the material distributions and detector's
 //    geometry
-//    Author: A.Morsch
 //------------------------------------------------------------------------
 
 #include "Generators/GeneratorGeantinos.h"
@@ -16,38 +18,37 @@ namespace o2
 namespace eventgen
 {
 //_______________________________________________________________________
-GeneratorGeantinos::GeneratorGeantinos():
-  FairGenerator(),
-  mMode(-1),
-  mRadMin(0),
-  mRadMax(0),
-  mZMax(0),
-  mNCoor1(0),
-  mNCoor2(0),
-  mCoor1Min(0),
-  mCoor1Max(0),
-  mCoor2Min(0),
-  mCoor2Max(0)
+GeneratorGeantinos::GeneratorGeantinos() : FairGenerator(),
+                                           mMode(-1),
+                                           mRadMin(0),
+                                           mRadMax(0),
+                                           mZMax(0),
+                                           mNCoor1(0),
+                                           mNCoor2(0),
+                                           mCoor1Min(0),
+                                           mCoor1Max(0),
+                                           mCoor2Min(0),
+                                           mCoor2Max(0)
 {
 }
 
 //_______________________________________________________________________
 GeneratorGeantinos::GeneratorGeantinos(Int_t mode, Int_t nc1, Float_t c1min,
-                                   Float_t c1max, Int_t nc2, 
-                                   Float_t c2min, Float_t c2max,
-                                   Float_t rmin, Float_t rmax, Float_t zmax):
+                                       Float_t c1max, Int_t nc2,
+                                       Float_t c2min, Float_t c2max,
+                                       Float_t rmin, Float_t rmax, Float_t zmax) :
 
-  FairGenerator(),
-  mMode(mode),
-  mRadMin(rmin),
-  mRadMax(rmax),
-  mZMax(zmax),
-  mNCoor1(nc1),
-  mNCoor2(nc2),
-  mCoor1Min(c1min),
-  mCoor1Max(c1max),
-  mCoor2Min(c2min),
-  mCoor2Max(c2max)
+                                                                                   FairGenerator(),
+                                                                                   mMode(mode),
+                                                                                   mRadMin(rmin),
+                                                                                   mRadMax(rmax),
+                                                                                   mZMax(zmax),
+                                                                                   mNCoor1(nc1),
+                                                                                   mNCoor2(nc2),
+                                                                                   mCoor1Min(c1min),
+                                                                                   mCoor1Max(c1max),
+                                                                                   mCoor2Min(c2min),
+                                                                                   mCoor2Max(c2max)
 {
   //
   // Standard generator for geantinos
@@ -57,35 +58,34 @@ GeneratorGeantinos::GeneratorGeantinos(Int_t mode, Int_t nc1, Float_t c1min,
 //_______________________________________________________________________
 Bool_t GeneratorGeantinos::ReadEvent(FairPrimaryGenerator* primGen)
 {
-   Float_t orig[3], pmom[3];
-   Float_t t, cost, sint, cosp, sinp;
-   Float_t s1 = (mCoor1Max - mCoor1Min) / mNCoor1;
-   Float_t s2 = (mCoor2Max - mCoor2Min) / mNCoor2;
-   const Float_t g2rad = TMath::Pi() / 180.;
-   for (Int_t i = 0; i < mNCoor1; i++) {
-     for (Int_t j = 0; j < mNCoor2; j++) {
-       Float_t c1 = mCoor1Min + i * s1 + s1 / 2.;
-       Float_t c2 = mCoor2Min + j * s2 + s2 / 2.;
-       if (mMode == 2) {
-          sint = 1.; 
-          cost = 0.;
-       } else if (mMode == 1) {
-          Float_t theta = 2. * TMath::ATan(TMath::Exp(-c1));
-          sint = TMath::Sin(theta);
-          cost = TMath::Cos(theta);
-       } else {
-          cost      = TMath::Cos(c1 * g2rad);
-          sint      = TMath::Sin(c1 * g2rad);  
-       }
-       
-       cosp      = TMath::Cos(c2 * g2rad);
-       sinp      = TMath::Sin(c2 * g2rad);
-       
-       pmom[0] = cosp * sint;
-       pmom[1] = sinp * sint;
-       pmom[2] = cost;
-       
-   
+  Float_t orig[3], pmom[3];
+  Float_t t, cost, sint, cosp, sinp;
+  Float_t s1 = (mCoor1Max - mCoor1Min) / mNCoor1;
+  Float_t s2 = (mCoor2Max - mCoor2Min) / mNCoor2;
+  const Float_t g2rad = TMath::Pi() / 180.;
+  for (Int_t i = 0; i < mNCoor1; i++) {
+    for (Int_t j = 0; j < mNCoor2; j++) {
+      Float_t c1 = mCoor1Min + i * s1 + s1 / 2.;
+      Float_t c2 = mCoor2Min + j * s2 + s2 / 2.;
+      if (mMode == 2) {
+        sint = 1.;
+        cost = 0.;
+      } else if (mMode == 1) {
+        Float_t theta = 2. * TMath::ATan(TMath::Exp(-c1));
+        sint = TMath::Sin(theta);
+        cost = TMath::Cos(theta);
+      } else {
+        cost = TMath::Cos(c1 * g2rad);
+        sint = TMath::Sin(c1 * g2rad);
+      }
+
+      cosp = TMath::Cos(c2 * g2rad);
+      sinp = TMath::Sin(c2 * g2rad);
+
+      pmom[0] = cosp * sint;
+      pmom[1] = sinp * sint;
+      pmom[2] = cost;
+
       // --- Where to start
       orig[0] = orig[1] = orig[2] = 0;
       if (mMode == 2) {
@@ -93,56 +93,59 @@ Bool_t GeneratorGeantinos::ReadEvent(FairPrimaryGenerator* primGen)
       }
       Float_t dalicz = 3000;
       if (mRadMin > 0) {
-         t = PropagateCylinder(orig, pmom, mRadMin, dalicz);
-         orig[0] = pmom[0] * t;
-         orig[1] = pmom[1] * t;
-         orig[2] = pmom[2] * t;
-         if (TMath::Abs(orig[2]) > mZMax) return kFALSE;
+        t = PropagateCylinder(orig, pmom, mRadMin, dalicz);
+        orig[0] = pmom[0] * t;
+        orig[1] = pmom[1] * t;
+        orig[2] = pmom[2] * t;
+        if (TMath::Abs(orig[2]) > mZMax)
+          return kFALSE;
       }
-      Float_t polar[3]={0., 0., 0.};
+      Float_t polar[3] = {0., 0., 0.};
       primGen->AddTrack(0, pmom[0], pmom[1], pmom[2], orig[0], orig[1], orig[2], -1, true, 0, 0, 1.);
-     } // j
-   } // i
-   return kTRUE;
+    } // j
+  }   // i
+  return kTRUE;
 }
 
 //_______________________________________________________________________
-Float_t GeneratorGeantinos::PropagateCylinder(Float_t *x, Float_t *v, Float_t r, 
-                                            Float_t z)
+Float_t GeneratorGeantinos::PropagateCylinder(Float_t* x, Float_t* v, Float_t r,
+                                              Float_t z)
 {
   //
   // Propagate to cylinder from inside
   //
-   Double_t hnorm, sz, t, t1, t2, t3, sr;
-   Double_t d[3];
-   const Float_t kSmall  = 1e-8;
-   const Float_t kSmall2 = kSmall * kSmall;
+  Double_t hnorm, sz, t, t1, t2, t3, sr;
+  Double_t d[3];
+  const Float_t kSmall = 1e-8;
+  const Float_t kSmall2 = kSmall * kSmall;
 
-// ---> Find intesection with Z planes
-   d[0]  = v[0];
-   d[1]  = v[1];
-   d[2]  = v[2];
-   hnorm = TMath::Sqrt(1 / (d[0] * d[0] + d[1] * d[1] + d[2] * d[2]));
-   d[0] *= hnorm;
-   d[1] *= hnorm;
-   d[2] *= hnorm;
-   if (d[2] > kSmall)       sz = (z - x[2]) / d[2];
-   else if (d[2] < -kSmall) sz = -(z + x[2]) / d[2];
-   else                     sz = 1.e10;  // ---> Direction parallel to X-Y, no intersection
+  // ---> Find intesection with Z planes
+  d[0] = v[0];
+  d[1] = v[1];
+  d[2] = v[2];
+  hnorm = TMath::Sqrt(1 / (d[0] * d[0] + d[1] * d[1] + d[2] * d[2]));
+  d[0] *= hnorm;
+  d[1] *= hnorm;
+  d[2] *= hnorm;
+  if (d[2] > kSmall)
+    sz = (z - x[2]) / d[2];
+  else if (d[2] < -kSmall)
+    sz = -(z + x[2]) / d[2];
+  else
+    sz = 1.e10; // ---> Direction parallel to X-Y, no intersection
 
-   t1 = d[0] * d[0] + d[1] * d[1];
-   if (t1 <= kSmall2) {
-      t = sz;  // ---> Track parallel to the z-axis, take distance to planes
-   } else {
-      t2 = x[0] * d[0] + x[1] * d[1];
-      t3 = x[0] * x[0] + x[1] * x[1];
-      // ---> It should be positive, but there may be numerical problems
-      sr = (-t2 + TMath::Sqrt(TMath::Max(t2 * t2 - (t3 - r * r) * t1, 0.))) / t1;
-      // ---> Find minimum distance between planes and cylinder
-      t  = TMath::Min(sz, sr);
-   }
-   return t;
+  t1 = d[0] * d[0] + d[1] * d[1];
+  if (t1 <= kSmall2) {
+    t = sz; // ---> Track parallel to the z-axis, take distance to planes
+  } else {
+    t2 = x[0] * d[0] + x[1] * d[1];
+    t3 = x[0] * x[0] + x[1] * x[1];
+    // ---> It should be positive, but there may be numerical problems
+    sr = (-t2 + TMath::Sqrt(TMath::Max(t2 * t2 - (t3 - r * r) * t1, 0.))) / t1;
+    // ---> Find minimum distance between planes and cylinder
+    t = TMath::Min(sz, sr);
+  }
+  return t;
 }
-}
-}
-
+} // namespace eventgen
+} // namespace o2

--- a/Generators/src/GeneratorGeantinos.cxx
+++ b/Generators/src/GeneratorGeantinos.cxx
@@ -1,8 +1,15 @@
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.                                                                          // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.                                                     // All rights not expressly granted are reserved.                                                                                       //                                                                                                                                      // This software is distributed under the terms of the GNU General Public                                                               // License v3 (GPL Version 3), copied verbatim in the file "COPYING".                                                                   //                                                                                                                                      // In applying this license CERN does not waive the privileges and immunities                                                           // granted to it by virtue of its status as an Intergovernmental Organization                                                           // or submit itself to any jurisdiction.                                                                                                
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
 //
-/// \author A+Morsch - March 2022                                                                                                        
-
-
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+//
+/// \author A+Morsch - March 2022
 
 //------------------------------------------------------------------------
 //    Generates geantino rays to check the material distributions and detector's

--- a/Generators/src/GeneratorsLinkDef.h
+++ b/Generators/src/GeneratorsLinkDef.h
@@ -29,6 +29,7 @@
 #pragma link C++ class o2::eventgen::Generator + ;
 #pragma link C++ class o2::eventgen::GeneratorTGenerator + ;
 #pragma link C++ class o2::eventgen::GeneratorExternalParam + ;
+#pragma link C++ class o2::eventgen::GeneratorGeantinos + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::eventgen::GeneratorExternalParam> + ;
 #ifdef GENERATORS_WITH_HEPMC3
 #pragma link C++ class o2::eventgen::GeneratorHepMC + ;

--- a/Steer/CMakeLists.txt
+++ b/Steer/CMakeLists.txt
@@ -12,11 +12,13 @@
 o2_add_library(Steer
                SOURCES src/O2MCApplication.cxx src/InteractionSampler.cxx
                        src/HitProcessingManager.cxx src/MCKinematicsReader.cxx
+                       src/MaterialBudgetMap.cxx src/O2MCApplicationEvalMat.cxx
 		       PUBLIC_LINK_LIBRARIES O2::CommonDataFormat
 		                     O2::CommonConstants
                              O2::DetectorsBase
                                      O2::SimulationDataFormat
-                                     O2::DetectorsCommonDataFormats)
+                                     O2::DetectorsCommonDataFormats
+                                     O2::Generators)
 
 o2_add_executable(colcontexttool
                   COMPONENT_NAME steer
@@ -29,8 +31,9 @@ o2_target_root_dictionary(Steer
                                   include/Steer/O2RunSim.h
                                   include/Steer/O2MCApplication.h
                                   include/Steer/O2MCApplicationBase.h
-                                  include/Steer/MCKinematicsReader.h)
-
+                                  include/Steer/O2MCApplicationEvalMat.h
+                                  include/Steer/MCKinematicsReader.h
+                                  include/Steer/MaterialBudgetMap.h)
 o2_add_test(InteractionSampler
             PUBLIC_LINK_LIBRARIES O2::Steer
             SOURCES test/testInteractionSampler.cxx

--- a/Steer/include/Steer/MaterialBudgetMap.h
+++ b/Steer/include/Steer/MaterialBudgetMap.h
@@ -1,0 +1,66 @@
+#ifndef MATERIALBUDGETMAP_H
+#define MATERIALBUDGETMAP_H
+/* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
+ * See cxx source for full Copyright notice                               */
+
+/* $Id$ */
+
+///////////////////////////////////////////////////////////////////////////////
+//                                                                           //
+//                                                                           //
+//    Utility class to compute and draw Radiation Length Map                 //
+//                                                                           //
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////
+
+#include "TNamed.h"
+class TH2F;
+class TClonesArray;
+namespace o2
+{
+namespace steer
+{
+class MaterialBudgetMap : public TNamed  {
+
+public:
+  MaterialBudgetMap();
+  MaterialBudgetMap(const char *title, Int_t mode, Int_t nc1,Float_t c1min,
+	  Float_t c1max, Int_t nphi, Float_t phimin,
+	  Float_t phimax,Float_t rmin,Float_t rmax,Float_t zmax);
+  virtual ~MaterialBudgetMap();
+  virtual void  Stepping();
+  virtual void  BeginEvent();
+  virtual void  FinishPrimary(Float_t c1, Float_t c2);
+  virtual void  FinishEvent();
+private:
+   Int_t      mMode;             //!mode
+   Float_t    mTotRadl;          //!Total Radiation length
+   Float_t    mTotAbso;          //!Total absorption length
+   Float_t    mTotGcm2;          //!Total g/cm2 traversed
+   TH2F      *mHistRadl;         //!Radiation length map 
+   TH2F      *mHistAbso;         //!Interaction length map
+   TH2F      *mHistGcm2;         //!g/cm2 length map
+   TH2F      *mHistReta;         //!Radiation length map as a function of eta
+   TH2F      *mRZR;              //!Radiation lenghts at (R.Z)
+   TH2F      *mRZA;              //!Absorbtion lengths at (R,Z)
+   TH2F      *mRZG;              //!Density at (R,Z)
+   Bool_t     mStopped;          //!Scoring has been stopped 
+   Float_t    mRmin;             //!minimum radius
+   Float_t    mZmax;             //!maximum radius
+   Float_t    mRmax;             //!maximum z
+};
+}
+}
+
+#endif
+
+
+
+
+
+
+
+
+
+
+

--- a/Steer/include/Steer/MaterialBudgetMap.h
+++ b/Steer/include/Steer/MaterialBudgetMap.h
@@ -1,10 +1,21 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/*
+ *  Created on: March 17, 2022
+ *      Author: amorsch
+ */
+
 #ifndef MATERIALBUDGETMAP_H
 #define MATERIALBUDGETMAP_H
-/* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
- * See cxx source for full Copyright notice                               */
-
-/* $Id$ */
-
 ///////////////////////////////////////////////////////////////////////////////
 //                                                                           //
 //                                                                           //
@@ -13,54 +24,42 @@
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "TNamed.h"
 class TH2F;
-class TClonesArray;
 namespace o2
 {
 namespace steer
 {
-class MaterialBudgetMap : public TNamed  {
-
-public:
+class MaterialBudgetMap
+{
+ public:
   MaterialBudgetMap();
-  MaterialBudgetMap(const char *title, Int_t mode, Int_t nc1,Float_t c1min,
-	  Float_t c1max, Int_t nphi, Float_t phimin,
-	  Float_t phimax,Float_t rmin,Float_t rmax,Float_t zmax);
-  virtual ~MaterialBudgetMap();
-  virtual void  Stepping();
-  virtual void  BeginEvent();
-  virtual void  FinishPrimary(Float_t c1, Float_t c2);
-  virtual void  FinishEvent();
-private:
-   Int_t      mMode;             //!mode
-   Float_t    mTotRadl;          //!Total Radiation length
-   Float_t    mTotAbso;          //!Total absorption length
-   Float_t    mTotGcm2;          //!Total g/cm2 traversed
-   TH2F      *mHistRadl;         //!Radiation length map 
-   TH2F      *mHistAbso;         //!Interaction length map
-   TH2F      *mHistGcm2;         //!g/cm2 length map
-   TH2F      *mHistReta;         //!Radiation length map as a function of eta
-   TH2F      *mRZR;              //!Radiation lenghts at (R.Z)
-   TH2F      *mRZA;              //!Absorbtion lengths at (R,Z)
-   TH2F      *mRZG;              //!Density at (R,Z)
-   Bool_t     mStopped;          //!Scoring has been stopped 
-   Float_t    mRmin;             //!minimum radius
-   Float_t    mZmax;             //!maximum radius
-   Float_t    mRmax;             //!maximum z
+  MaterialBudgetMap(const char* title, Int_t mode, Int_t nc1, Float_t c1min,
+                    Float_t c1max, Int_t nphi, Float_t phimin,
+                    Float_t phimax, Float_t rmin, Float_t rmax, Float_t zmax);
+  ~MaterialBudgetMap();
+  void Stepping();
+  void BeginEvent();
+  void FinishPrimary(Float_t c1, Float_t c2);
+  void FinishEvent();
+
+ private:
+  Int_t mMode;      //! mode
+  Float_t mTotRadl; //! Total Radiation length
+  Float_t mTotAbso; //! Total absorption length
+  Float_t mTotGcm2; //! Total g/cm2 traversed
+  TH2F* mHistRadl;  //! Radiation length map
+  TH2F* mHistAbso;  //! Interaction length map
+  TH2F* mHistGcm2;  //! g/cm2 length map
+  TH2F* mHistReta;  //! Radiation length map as a function of eta
+  TH2F* mRZR;       //! Radiation lenghts at (R.Z)
+  TH2F* mRZA;       //! Absorbtion lengths at (R,Z)
+  TH2F* mRZG;       //! Density at (R,Z)
+  Bool_t mStopped;  //! Scoring has been stopped
+  Float_t mRmin;    //! minimum radius
+  Float_t mZmax;    //! maximum radius
+  Float_t mRmax;    //! maximum z
 };
-}
-}
+} // namespace steer
+} // namespace o2
 
 #endif
-
-
-
-
-
-
-
-
-
-
-

--- a/Steer/include/Steer/O2MCApplicationEvalMat.h
+++ b/Steer/include/Steer/O2MCApplicationEvalMat.h
@@ -37,7 +37,7 @@ class O2MCApplicationEvalMat : public O2MCApplicationBase
 {
  public:
   O2MCApplicationEvalMat() : O2MCApplicationBase() {}
-  O2MCApplicationEvalMat(const char* name, const char* title, TObjArray* ModList, const char* MatName) : O2MCApplicationBase(name, title, ModList, MatName), mMaterialBudgetMap(0), mPhi(0), mMode(-1) {}
+  O2MCApplicationEvalMat(const char* name, const char* title, TObjArray* ModList, const char* MatName) : O2MCApplicationBase(name, title, ModList, MatName), mMaterialBudgetMap(nullptr), mPhi(0), mMode(-1) {}
 
   ~O2MCApplicationEvalMat() override = default;
   void BeginPrimary() override;

--- a/Steer/include/Steer/O2MCApplicationEvalMat.h
+++ b/Steer/include/Steer/O2MCApplicationEvalMat.h
@@ -48,9 +48,9 @@ class O2MCApplicationEvalMat : public O2MCApplicationBase
 
  protected:
   MaterialBudgetMap* mMaterialBudgetMap;
-  Int_t   mMode;   // 0: theta-phi, 1: eta-phi, 2: z-phi
-  Float_t mC1[3];  // current coordinate 1
-  Float_t mPhi;    // current phi
+  Int_t mMode;    // 0: theta-phi, 1: eta-phi, 2: z-phi
+  Float_t mC1[3]; // current coordinate 1
+  Float_t mPhi;   // current phi
 
   ClassDefOverride(O2MCApplicationEvalMat, 1);
 };

--- a/Steer/include/Steer/O2MCApplicationEvalMat.h
+++ b/Steer/include/Steer/O2MCApplicationEvalMat.h
@@ -1,0 +1,61 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/*
+ * O2MCApplicationEvalMat.h
+ *
+ *  Created on: March 17, 2022
+ *      Author: amorsch
+ */
+
+#ifndef STEER_INCLUDE_STEER_O2MCAPPLICATIONEVALMAT_H_
+#define STEER_INCLUDE_STEER_O2MCAPPLICATIONEVALMAT_H_
+
+#include <Steer/O2MCApplicationBase.h>
+#include <Steer/MaterialBudgetMap.h>
+#include "Rtypes.h" // for Int_t, Bool_t, Double_t, etc
+#include <TVirtualMC.h>
+#include "SimConfig/SimParams.h"
+
+namespace o2
+{
+namespace steer
+{
+
+// O2 specific changes/overrides to FairMCApplication
+// Here in particular for custom adjustments to stepping logic
+// and tracking limits
+class O2MCApplicationEvalMat : public O2MCApplicationBase
+{
+ public:
+  O2MCApplicationEvalMat() : O2MCApplicationBase() {}
+  O2MCApplicationEvalMat(const char* name, const char* title, TObjArray* ModList, const char* MatName) : O2MCApplicationBase(name, title, ModList, MatName), mMaterialBudgetMap(0), mPhi(0), mMode(-1) {}
+
+  ~O2MCApplicationEvalMat() override = default;
+  void BeginPrimary() override;
+  void FinishPrimary() override;
+  void Stepping() override;
+  void BeginEvent() override;
+  void FinishEvent() override;
+
+ protected:
+  MaterialBudgetMap* mMaterialBudgetMap;
+  Int_t   mMode;   // 0: theta-phi, 1: eta-phi, 2: z-phi
+  Float_t mC1[3];  // current coordinate 1
+  Float_t mPhi;    // current phi
+
+  ClassDefOverride(O2MCApplicationEvalMat, 1);
+};
+
+} // end namespace steer
+} // end namespace o2
+
+#endif /* STEER_INCLUDE_STEER_O2MCAPPLICATIONEVALMAT_H_ */

--- a/Steer/include/Steer/O2RunSim.h
+++ b/Steer/include/Steer/O2RunSim.h
@@ -73,7 +73,7 @@ class O2RunSim : public FairRunSim
         fApp = new O2MCApplicationBase("Fair", "The Fair VMC App", ListOfModules, MatFname);
       } else {
         fApp = new O2MCApplicationEvalMat("Fair", "The Fair VMC App", ListOfModules, MatFname);
-     }
+      }
     }
 
     fApp->SetGenerator(fGen);
@@ -127,7 +127,7 @@ class O2RunSim : public FairRunSim
       ContList->Add(new TObjString(cont->GetName()));
     }
     if (par) {
-      par->SetContListStr(ContList);  
+      par->SetContListStr(ContList);
       par->SetRndSeed(gRandom->GetSeed());
       par->setChanged();
       par->setInputVersion(fRunId, 1);
@@ -148,10 +148,9 @@ class O2RunSim : public FairRunSim
   }
 
  private:
-  
   bool mDeviceMode{false};
   bool mEvalMat{false};
- 
+
   ClassDefOverride(O2RunSim, 0);
 };
 } // namespace steer

--- a/Steer/include/Steer/O2RunSim.h
+++ b/Steer/include/Steer/O2RunSim.h
@@ -40,6 +40,8 @@
 #include <TObjString.h>
 #include <Steer/O2MCApplication.h>
 
+#include <Steer/O2MCApplicationEvalMat.h>
+
 namespace o2
 {
 namespace steer
@@ -48,7 +50,7 @@ namespace steer
 class O2RunSim : public FairRunSim
 {
  public:
-  O2RunSim(bool devicemode) : FairRunSim(), mDeviceMode(devicemode) {}
+  O2RunSim(bool devicemode, bool evalmat) : FairRunSim(), mDeviceMode(devicemode), mEvalMat(evalmat) {}
   ~O2RunSim() override = default;
 
   void Init() final
@@ -67,7 +69,11 @@ class O2RunSim : public FairRunSim
     if (mDeviceMode) {
       fApp = new O2MCApplication("Fair", "The Fair VMC App", ListOfModules, MatFname);
     } else {
-      fApp = new O2MCApplicationBase("Fair", "The Fair VMC App", ListOfModules, MatFname);
+      if (!mEvalMat) {
+        fApp = new O2MCApplicationBase("Fair", "The Fair VMC App", ListOfModules, MatFname);
+      } else {
+        fApp = new O2MCApplicationEvalMat("Fair", "The Fair VMC App", ListOfModules, MatFname);
+     }
     }
 
     fApp->SetGenerator(fGen);
@@ -121,7 +127,7 @@ class O2RunSim : public FairRunSim
       ContList->Add(new TObjString(cont->GetName()));
     }
     if (par) {
-      par->SetContListStr(ContList);
+      par->SetContListStr(ContList);  
       par->SetRndSeed(gRandom->GetSeed());
       par->setChanged();
       par->setInputVersion(fRunId, 1);
@@ -142,8 +148,10 @@ class O2RunSim : public FairRunSim
   }
 
  private:
-  bool mDeviceMode = false;
-
+  
+  bool mDeviceMode{false};
+  bool mEvalMat{false};
+ 
   ClassDefOverride(O2RunSim, 0);
 };
 } // namespace steer

--- a/Steer/src/MaterialBudgetMap.cxx
+++ b/Steer/src/MaterialBudgetMap.cxx
@@ -45,13 +45,13 @@ MaterialBudgetMap::MaterialBudgetMap() : mMode(-1),
                                          mTotRadl(0),
                                          mTotAbso(0),
                                          mTotGcm2(0),
-                                         mHistRadl(0),
-                                         mHistAbso(0),
-                                         mHistGcm2(0),
-                                         mHistReta(0),
-                                         mRZR(0),
-                                         mRZA(0),
-                                         mRZG(0),
+                                         mHistRadl(nullptr),
+                                         mHistAbso(nullptr),
+                                         mHistGcm2(nullptr),
+                                         mHistReta(nullptr),
+                                         mRZR(nullptr),
+                                         mRZA(nullptr),
+                                         mRZG(nullptr),
                                          mStopped(0)
 {
   //
@@ -66,13 +66,13 @@ MaterialBudgetMap::MaterialBudgetMap(const char* title, Int_t mode, Int_t nc1, F
                                                                                  mTotRadl(0),
                                                                                  mTotAbso(0),
                                                                                  mTotGcm2(0),
-                                                                                 mHistRadl(0),
-                                                                                 mHistAbso(0),
-                                                                                 mHistGcm2(0),
-                                                                                 mHistReta(0),
-                                                                                 mRZR(0),
-                                                                                 mRZA(0),
-                                                                                 mRZG(0),
+                                                                                 mHistRadl(nullptr),
+                                                                                 mHistAbso(nullptr),
+                                                                                 mHistGcm2(nullptr),
+                                                                                 mHistReta(nullptr),
+                                                                                 mRZR(nullptr),
+                                                                                 mRZA(nullptr),
+                                                                                 mRZG(nullptr),
                                                                                  mStopped(0),
                                                                                  mRmin(rmin),
                                                                                  mRmax(rmax),
@@ -159,11 +159,17 @@ void MaterialBudgetMap::FinishEvent()
   f->Close();
   // Delete histograms from memory
   mHistRadl->Delete();
-  mHistRadl = 0;
+  mHistRadl = nullptr;
   mHistAbso->Delete();
-  mHistAbso = 0;
+  mHistAbso = nullptr;
   mHistGcm2->Delete();
-  mHistGcm2 = 0;
+  mHistGcm2 = nullptr;
+  mRZR->Delete();
+  mRZR = nullptr;
+  mRZA->Delete();
+  mRZA = nullptr;
+  mRZG->Delete();
+  mRZG = nullptr;
 }
 
 //_______________________________________________________________________
@@ -188,29 +194,26 @@ void MaterialBudgetMap::Stepping()
   TLorentzVector pos;
   TVirtualMC::GetMC()->TrackPosition(pos);
 
-  Int_t status = 0;
-  if (TVirtualMC::GetMC()->IsTrackEntering())
-    status = 1;
-  if (TVirtualMC::GetMC()->IsTrackExiting())
-    status = 2;
-
   TVirtualMC::GetMC()->CurrentMaterial(a, z, dens, radl, absl);
   Double_t r = TMath::Sqrt(pos[0] * pos[0] + pos[1] * pos[1]);
 
   mRZR->Fill(pos[2], r, step / radl);
   mRZA->Fill(pos[2], r, step / absl);
   mRZG->Fill(pos[2], r, step * dens);
-  if (z < 1)
+  if (z < 1) {
     return;
+  }
   // --- See if we have to stop now
   if (TMath::Abs(pos[2]) > TMath::Abs(mZmax) || r > mRmax) {
     if (!TVirtualMC::GetMC()->IsNewTrack()) {
       // Not the first step, add past contribution
       if (!mStopped) {
-        if (absl)
+        if (absl) {
           mTotAbso += t / absl;
-        if (radl)
+        }
+        if (radl) {
           mTotRadl += t / radl;
+        }
         mTotGcm2 += t * dens;
       } // not stooped
     }   // not a new track !
@@ -219,10 +222,12 @@ void MaterialBudgetMap::Stepping()
     return;
   } // outside scoring region ?
   if (step) {
-    if (absl)
+    if (absl) {
       mTotAbso += step / absl;
-    if (radl)
+    }
+    if (radl) {
       mTotRadl += step / radl;
+    }
     mTotGcm2 += step * dens;
   } // step
 }

--- a/Steer/src/MaterialBudgetMap.cxx
+++ b/Steer/src/MaterialBudgetMap.cxx
@@ -1,0 +1,209 @@
+
+//////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////
+//                            
+//  Utility class to evaluate the material budget from
+//  a given radius to the surface of an arbitrary cylinder
+//  along radial directions from the centre:
+// 
+//   - radiation length
+//   - Interaction length
+//   - g/cm2
+// 
+//  Geantinos are shot in the bins in the fNtheta bins in theta
+//  and fNphi bins in phi with specified rectangular limits.
+//  The statistics are accumulated per
+//    fRadMin < r < fRadMax    and  <0 < z < fZMax
+//
+//////////////////////////////////////////////////////////////
+
+#include "TClonesArray.h"
+#include "TH2.h"
+#include "TMath.h"
+#include "TString.h"
+#include "TVirtualMC.h"
+#include "TFile.h"
+
+#include "Steer/MaterialBudgetMap.h"
+using namespace o2::steer;
+//_______________________________________________________________________
+MaterialBudgetMap::MaterialBudgetMap():
+  mMode(-1),
+  mTotRadl(0),
+  mTotAbso(0),
+  mTotGcm2(0),
+  mHistRadl(0),
+  mHistAbso(0),
+  mHistGcm2(0),
+  mHistReta(0),
+  mRZR(0),
+  mRZA(0),
+  mRZG(0),
+  mStopped(0)
+{
+  //
+  // Default constructor
+  //
+}
+
+
+//_______________________________________________________________________
+MaterialBudgetMap::MaterialBudgetMap(const char *title, Int_t mode, Int_t nc1, Float_t c1min, 
+                 Float_t c1max, Int_t nphi, Float_t phimin, Float_t phimax,
+                 Float_t rmin, Float_t rmax, Float_t zmax):
+  TNamed("MaterialBudgetMap",title),
+  mMode(mode),
+  mTotRadl(0),
+  mTotAbso(0),
+  mTotGcm2(0),
+  mHistRadl(0),
+  mHistAbso(0),
+  mHistGcm2(0),
+  mHistReta(0),
+  mRZR(0),
+  mRZA(0),
+  mRZG(0),
+  mStopped(0),
+  mRmin(rmin),
+  mRmax(rmax),
+  mZmax(zmax)
+{
+  //
+  // specify the angular limits and the size of the rectangular box
+  //
+   const char* xtitles[3] = {"#theta [degree]", "#eta", "z [cm]"};
+   mHistRadl = new TH2F("hradl","Radiation length map",    
+			nc1, c1min, c1max, nphi, phimin, phimax);
+   mHistRadl->SetYTitle("#phi [degree]");  
+   mHistRadl->SetXTitle(xtitles[mMode]);
+   mHistAbso = new TH2F("habso","Interaction length map",  
+			nc1, c1min, c1max, nphi, phimin, phimax);
+   mHistAbso->SetYTitle("#phi [degree]"); 
+   mHistAbso->SetXTitle(xtitles[mMode]);
+   mHistGcm2 = new TH2F("hgcm2","g/cm2 length map",        
+			nc1, c1min, c1max, nphi, phimin, phimax);
+   mHistGcm2->SetYTitle("#phi [degree]"); 
+   mHistGcm2->SetXTitle(xtitles[mMode]);
+   mRZR      = new TH2F("rzR","Radiation length @ (r,z)",
+			zmax,-zmax,zmax,(rmax-rmin),rmin,rmax);
+   mRZR->SetXTitle("#it{z} [cm]");
+   mRZR->SetYTitle("#it{r} [cm]");
+   mRZA     = static_cast<TH2F*>(mRZR->Clone("rzA"));
+   mRZA->SetTitle("Interaction length @ (r,z)");
+   mRZG     = static_cast<TH2F*>(mRZR->Clone("rzG"));
+   mRZG->SetTitle("g/cm^{2} @ (r,z)");
+}
+
+//_______________________________________________________________________
+MaterialBudgetMap::~MaterialBudgetMap()
+{
+  //
+  // Destructor
+  //
+  delete mHistRadl;
+  delete mHistAbso;
+  delete mHistGcm2;
+}
+
+//_______________________________________________________________________
+void MaterialBudgetMap::BeginEvent()
+{
+  //
+  // --- Set to 0 radiation length, absorption length and g/cm2 ---
+  //
+  mTotRadl = 0;
+  mTotAbso = 0;
+  mTotGcm2 = 0;
+  mStopped = 0;
+}
+
+//_______________________________________________________________________
+void MaterialBudgetMap::FinishPrimary(Float_t c1, Float_t c2)
+{
+  //
+  // Finish the event and update the histos
+  //
+  mHistRadl->Fill(c1, c2, mTotRadl);
+  mHistAbso->Fill(c1, c2, mTotAbso);
+  mHistGcm2->Fill(c1, c2, mTotGcm2);
+  mTotRadl = 0;
+  mTotAbso = 0;
+  mTotGcm2 = 0;
+  mStopped = 0;
+}
+
+//_______________________________________________________________________
+void MaterialBudgetMap::FinishEvent()
+{
+  //
+  // Store histograms in current Root file
+  //
+   printf("map::finish event \n");
+  auto f = new TFile("o2sim_matbudget.root", "recreate");
+  mHistRadl->Write();
+  mHistAbso->Write();
+  mHistGcm2->Write();
+  mRZR->Write();
+  mRZA->Write();
+  mRZG->Write();
+  f->Close();
+  // Delete histograms from memory
+  mHistRadl->Delete(); mHistRadl = 0;
+  mHistAbso->Delete(); mHistAbso = 0;
+  mHistGcm2->Delete(); mHistGcm2 = 0;
+}
+
+//_______________________________________________________________________
+void MaterialBudgetMap::Stepping() 
+{
+  //
+  // called from AliRun::Stepmanager from gustep.
+  // Accumulate the 3 parameters step by step
+  //
+  static Float_t t;
+  Float_t a, z, dens, radl, absl;
+  Int_t i, id, copy;
+  const char* vol;
+  static Float_t vect[3], dir[3];
+    
+  TString tmp1, tmp2;
+  copy = 1;
+  id  = TVirtualMC::GetMC()->CurrentVolID(copy);
+  vol = TVirtualMC::GetMC()->VolName(id);
+  Float_t step  = TVirtualMC::GetMC()->TrackStep();
+    
+  TLorentzVector pos; 
+  TVirtualMC::GetMC()->TrackPosition(pos);  
+  
+  Int_t status = 0;
+  if (TVirtualMC::GetMC()->IsTrackEntering()) status = 1;
+  if (TVirtualMC::GetMC()->IsTrackExiting())  status = 2; 
+  
+  
+  TVirtualMC::GetMC()->CurrentMaterial(a, z, dens, radl, absl);
+  Double_t r = TMath::Sqrt(pos[0] * pos[0] + pos[1] * pos[1]);
+  
+  mRZR->Fill(pos[2], r, step / radl);
+  mRZA->Fill(pos[2], r ,step / absl);
+  mRZG->Fill(pos[2], r, step * dens);
+  if (z < 1) return;
+  // --- See if we have to stop now
+  if (TMath::Abs(pos[2]) > TMath::Abs(mZmax)  || r > mRmax) {
+      if (!TVirtualMC::GetMC()->IsNewTrack()) {
+      // Not the first step, add past contribution
+      if (!mStopped) {
+        if (absl) mTotAbso += t / absl;
+        if (radl) mTotRadl += t / radl;
+        mTotGcm2 += t * dens;
+      } // not stooped
+    } // not a new track !
+    mStopped = kTRUE;
+    TVirtualMC::GetMC()->StopTrack();
+    return;
+  } // outside scoring region ?
+	if(step) {    
+    if (absl) mTotAbso += step / absl;
+    if (radl) mTotRadl += step / radl;
+    mTotGcm2 += step * dens;
+	} // step 
+}

--- a/Steer/src/MaterialBudgetMap.cxx
+++ b/Steer/src/MaterialBudgetMap.cxx
@@ -37,6 +37,7 @@
 #include "TString.h"
 #include "TVirtualMC.h"
 #include "TFile.h"
+#include <Generators/GeneratorGeantinos.h>
 
 #include "Steer/MaterialBudgetMap.h"
 using namespace o2::steer;
@@ -193,6 +194,8 @@ void MaterialBudgetMap::Stepping()
 
   TLorentzVector pos;
   TVirtualMC::GetMC()->TrackPosition(pos);
+  TLorentzVector mom;
+  TVirtualMC::GetMC()->TrackMomentum(mom);
 
   TVirtualMC::GetMC()->CurrentMaterial(a, z, dens, radl, absl);
   Double_t r = TMath::Sqrt(pos[0] * pos[0] + pos[1] * pos[1]);
@@ -221,6 +224,15 @@ void MaterialBudgetMap::Stepping()
     TVirtualMC::GetMC()->StopTrack();
     return;
   } // outside scoring region ?
+
+  // --- See how long we have to go
+  for (i = 0; i < 3; ++i) {
+    vect[i] = pos[i];
+    dir[i] = mom[i];
+  }
+
+  t = eventgen::GeneratorGeantinos::PropagateCylinder(vect, dir, mRmax, mZmax);
+
   if (step) {
     if (absl) {
       mTotAbso += step / absl;

--- a/Steer/src/MaterialBudgetMap.cxx
+++ b/Steer/src/MaterialBudgetMap.cxx
@@ -1,15 +1,30 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/*
+ *  Created on: March 17, 2022
+ *      Author: amorsch
+ */
 
 //////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////
-//                            
+//
 //  Utility class to evaluate the material budget from
 //  a given radius to the surface of an arbitrary cylinder
 //  along radial directions from the centre:
-// 
+//
 //   - radiation length
 //   - Interaction length
 //   - g/cm2
-// 
+//
 //  Geantinos are shot in the bins in the fNtheta bins in theta
 //  and fNphi bins in phi with specified rectangular limits.
 //  The statistics are accumulated per
@@ -17,7 +32,6 @@
 //
 //////////////////////////////////////////////////////////////
 
-#include "TClonesArray.h"
 #include "TH2.h"
 #include "TMath.h"
 #include "TString.h"
@@ -27,71 +41,67 @@
 #include "Steer/MaterialBudgetMap.h"
 using namespace o2::steer;
 //_______________________________________________________________________
-MaterialBudgetMap::MaterialBudgetMap():
-  mMode(-1),
-  mTotRadl(0),
-  mTotAbso(0),
-  mTotGcm2(0),
-  mHistRadl(0),
-  mHistAbso(0),
-  mHistGcm2(0),
-  mHistReta(0),
-  mRZR(0),
-  mRZA(0),
-  mRZG(0),
-  mStopped(0)
+MaterialBudgetMap::MaterialBudgetMap() : mMode(-1),
+                                         mTotRadl(0),
+                                         mTotAbso(0),
+                                         mTotGcm2(0),
+                                         mHistRadl(0),
+                                         mHistAbso(0),
+                                         mHistGcm2(0),
+                                         mHistReta(0),
+                                         mRZR(0),
+                                         mRZA(0),
+                                         mRZG(0),
+                                         mStopped(0)
 {
   //
   // Default constructor
   //
 }
 
-
 //_______________________________________________________________________
-MaterialBudgetMap::MaterialBudgetMap(const char *title, Int_t mode, Int_t nc1, Float_t c1min, 
-                 Float_t c1max, Int_t nphi, Float_t phimin, Float_t phimax,
-                 Float_t rmin, Float_t rmax, Float_t zmax):
-  TNamed("MaterialBudgetMap",title),
-  mMode(mode),
-  mTotRadl(0),
-  mTotAbso(0),
-  mTotGcm2(0),
-  mHistRadl(0),
-  mHistAbso(0),
-  mHistGcm2(0),
-  mHistReta(0),
-  mRZR(0),
-  mRZA(0),
-  mRZG(0),
-  mStopped(0),
-  mRmin(rmin),
-  mRmax(rmax),
-  mZmax(zmax)
+MaterialBudgetMap::MaterialBudgetMap(const char* title, Int_t mode, Int_t nc1, Float_t c1min,
+                                     Float_t c1max, Int_t nphi, Float_t phimin, Float_t phimax,
+                                     Float_t rmin, Float_t rmax, Float_t zmax) : mMode(mode),
+                                                                                 mTotRadl(0),
+                                                                                 mTotAbso(0),
+                                                                                 mTotGcm2(0),
+                                                                                 mHistRadl(0),
+                                                                                 mHistAbso(0),
+                                                                                 mHistGcm2(0),
+                                                                                 mHistReta(0),
+                                                                                 mRZR(0),
+                                                                                 mRZA(0),
+                                                                                 mRZG(0),
+                                                                                 mStopped(0),
+                                                                                 mRmin(rmin),
+                                                                                 mRmax(rmax),
+                                                                                 mZmax(zmax)
 {
   //
   // specify the angular limits and the size of the rectangular box
   //
-   const char* xtitles[3] = {"#theta [degree]", "#eta", "z [cm]"};
-   mHistRadl = new TH2F("hradl","Radiation length map",    
-			nc1, c1min, c1max, nphi, phimin, phimax);
-   mHistRadl->SetYTitle("#phi [degree]");  
-   mHistRadl->SetXTitle(xtitles[mMode]);
-   mHistAbso = new TH2F("habso","Interaction length map",  
-			nc1, c1min, c1max, nphi, phimin, phimax);
-   mHistAbso->SetYTitle("#phi [degree]"); 
-   mHistAbso->SetXTitle(xtitles[mMode]);
-   mHistGcm2 = new TH2F("hgcm2","g/cm2 length map",        
-			nc1, c1min, c1max, nphi, phimin, phimax);
-   mHistGcm2->SetYTitle("#phi [degree]"); 
-   mHistGcm2->SetXTitle(xtitles[mMode]);
-   mRZR      = new TH2F("rzR","Radiation length @ (r,z)",
-			zmax,-zmax,zmax,(rmax-rmin),rmin,rmax);
-   mRZR->SetXTitle("#it{z} [cm]");
-   mRZR->SetYTitle("#it{r} [cm]");
-   mRZA     = static_cast<TH2F*>(mRZR->Clone("rzA"));
-   mRZA->SetTitle("Interaction length @ (r,z)");
-   mRZG     = static_cast<TH2F*>(mRZR->Clone("rzG"));
-   mRZG->SetTitle("g/cm^{2} @ (r,z)");
+  const char* xtitles[3] = {"#theta [degree]", "#eta", "z [cm]"};
+  mHistRadl = new TH2F("hradl", "Radiation length map",
+                       nc1, c1min, c1max, nphi, phimin, phimax);
+  mHistRadl->SetYTitle("#phi [degree]");
+  mHistRadl->SetXTitle(xtitles[mMode]);
+  mHistAbso = new TH2F("habso", "Interaction length map",
+                       nc1, c1min, c1max, nphi, phimin, phimax);
+  mHistAbso->SetYTitle("#phi [degree]");
+  mHistAbso->SetXTitle(xtitles[mMode]);
+  mHistGcm2 = new TH2F("hgcm2", "g/cm2 length map",
+                       nc1, c1min, c1max, nphi, phimin, phimax);
+  mHistGcm2->SetYTitle("#phi [degree]");
+  mHistGcm2->SetXTitle(xtitles[mMode]);
+  mRZR = new TH2F("rzR", "Radiation length @ (r,z)",
+                  zmax, -zmax, zmax, (rmax - rmin), rmin, rmax);
+  mRZR->SetXTitle("#it{z} [cm]");
+  mRZR->SetYTitle("#it{r} [cm]");
+  mRZA = static_cast<TH2F*>(mRZR->Clone("rzA"));
+  mRZA->SetTitle("Interaction length @ (r,z)");
+  mRZG = static_cast<TH2F*>(mRZR->Clone("rzG"));
+  mRZG->SetTitle("g/cm^{2} @ (r,z)");
 }
 
 //_______________________________________________________________________
@@ -138,7 +148,7 @@ void MaterialBudgetMap::FinishEvent()
   //
   // Store histograms in current Root file
   //
-   printf("map::finish event \n");
+  printf("map::finish event \n");
   auto f = new TFile("o2sim_matbudget.root", "recreate");
   mHistRadl->Write();
   mHistAbso->Write();
@@ -148,13 +158,16 @@ void MaterialBudgetMap::FinishEvent()
   mRZG->Write();
   f->Close();
   // Delete histograms from memory
-  mHistRadl->Delete(); mHistRadl = 0;
-  mHistAbso->Delete(); mHistAbso = 0;
-  mHistGcm2->Delete(); mHistGcm2 = 0;
+  mHistRadl->Delete();
+  mHistRadl = 0;
+  mHistAbso->Delete();
+  mHistAbso = 0;
+  mHistGcm2->Delete();
+  mHistGcm2 = 0;
 }
 
 //_______________________________________________________________________
-void MaterialBudgetMap::Stepping() 
+void MaterialBudgetMap::Stepping()
 {
   //
   // called from AliRun::Stepmanager from gustep.
@@ -165,45 +178,51 @@ void MaterialBudgetMap::Stepping()
   Int_t i, id, copy;
   const char* vol;
   static Float_t vect[3], dir[3];
-    
+
   TString tmp1, tmp2;
   copy = 1;
-  id  = TVirtualMC::GetMC()->CurrentVolID(copy);
+  id = TVirtualMC::GetMC()->CurrentVolID(copy);
   vol = TVirtualMC::GetMC()->VolName(id);
-  Float_t step  = TVirtualMC::GetMC()->TrackStep();
-    
-  TLorentzVector pos; 
-  TVirtualMC::GetMC()->TrackPosition(pos);  
-  
+  Float_t step = TVirtualMC::GetMC()->TrackStep();
+
+  TLorentzVector pos;
+  TVirtualMC::GetMC()->TrackPosition(pos);
+
   Int_t status = 0;
-  if (TVirtualMC::GetMC()->IsTrackEntering()) status = 1;
-  if (TVirtualMC::GetMC()->IsTrackExiting())  status = 2; 
-  
-  
+  if (TVirtualMC::GetMC()->IsTrackEntering())
+    status = 1;
+  if (TVirtualMC::GetMC()->IsTrackExiting())
+    status = 2;
+
   TVirtualMC::GetMC()->CurrentMaterial(a, z, dens, radl, absl);
   Double_t r = TMath::Sqrt(pos[0] * pos[0] + pos[1] * pos[1]);
-  
+
   mRZR->Fill(pos[2], r, step / radl);
-  mRZA->Fill(pos[2], r ,step / absl);
+  mRZA->Fill(pos[2], r, step / absl);
   mRZG->Fill(pos[2], r, step * dens);
-  if (z < 1) return;
+  if (z < 1)
+    return;
   // --- See if we have to stop now
-  if (TMath::Abs(pos[2]) > TMath::Abs(mZmax)  || r > mRmax) {
-      if (!TVirtualMC::GetMC()->IsNewTrack()) {
+  if (TMath::Abs(pos[2]) > TMath::Abs(mZmax) || r > mRmax) {
+    if (!TVirtualMC::GetMC()->IsNewTrack()) {
       // Not the first step, add past contribution
       if (!mStopped) {
-        if (absl) mTotAbso += t / absl;
-        if (radl) mTotRadl += t / radl;
+        if (absl)
+          mTotAbso += t / absl;
+        if (radl)
+          mTotRadl += t / radl;
         mTotGcm2 += t * dens;
       } // not stooped
-    } // not a new track !
+    }   // not a new track !
     mStopped = kTRUE;
     TVirtualMC::GetMC()->StopTrack();
     return;
   } // outside scoring region ?
-	if(step) {    
-    if (absl) mTotAbso += step / absl;
-    if (radl) mTotRadl += step / radl;
+  if (step) {
+    if (absl)
+      mTotAbso += step / absl;
+    if (radl)
+      mTotRadl += step / radl;
     mTotGcm2 += step * dens;
-	} // step 
+  } // step
 }

--- a/Steer/src/O2MCApplicationEvalMat.cxx
+++ b/Steer/src/O2MCApplicationEvalMat.cxx
@@ -28,7 +28,8 @@ void O2MCApplicationEvalMat::BeginPrimary()
   fMC->TrackPosition(x, y, z);
 
   mPhi = p.Phi() * 180. / TMath::Pi();
-  if (mPhi < 0.) mPhi += 360.;
+  if (mPhi < 0.)
+    mPhi += 360.;
 
   mC1[0] = p.Theta() * 180. / TMath::Pi();
   mC1[1] = p.Eta();
@@ -37,13 +38,13 @@ void O2MCApplicationEvalMat::BeginPrimary()
 
 void O2MCApplicationEvalMat::FinishPrimary()
 {
-   mMaterialBudgetMap->FinishPrimary(mC1[mMode], mPhi);
-   FairMCApplication::FinishPrimary();
+  mMaterialBudgetMap->FinishPrimary(mC1[mMode], mPhi);
+  FairMCApplication::FinishPrimary();
 }
 
 void O2MCApplicationEvalMat::Stepping()
 {
-   // dispatch first to stepping function in FairRoot
+  // dispatch to MaterialBudget Map
   mMaterialBudgetMap->Stepping();
 }
 
@@ -59,7 +60,7 @@ void O2MCApplicationEvalMat::BeginEvent()
       n1 = p.ntheta;
       c1min = p.thetamin;
       c1max = p.thetamax;
-    } else if (p.neta !=0) {
+    } else if (p.neta != 0) {
       // eta-phi binning
       mMode = 1;
       n1 = p.neta;
@@ -74,13 +75,12 @@ void O2MCApplicationEvalMat::BeginEvent()
     }
     printf("MaterialBudgetMap: %5d %13.3f %13.3f %5d %13.3f %13.3f %13.3f %13.3f\n", n1, c1min, c1max, p.nphi, p.phimin, p.phimax, p.rmax, p.zmax);
     mMaterialBudgetMap = new MaterialBudgetMap("Map", mMode,
-    n1, c1min, c1max, p.nphi, p.phimin, p.phimax, p.rmin, p.rmax, p.zmax);
-  
+                                               n1, c1min, c1max, p.nphi, p.phimin, p.phimax, p.rmin, p.rmax, p.zmax);
+
     auto gen = GetGenerator();
     gen->GetListOfGenerators()->Clear();
     gen->AddGenerator(new o2::eventgen::GeneratorGeantinos(mMode, n1, c1min, c1max, p.nphi, p.phimin, p.phimax, p.rmin, p.rmax, p.zmax));
   }
-  // dispatch first to function in FairRoot
   mMaterialBudgetMap->BeginEvent();
 }
 
@@ -92,4 +92,3 @@ void O2MCApplicationEvalMat::FinishEvent()
 
 } // namespace steer
 } // namespace o2
-

--- a/Steer/src/O2MCApplicationEvalMat.cxx
+++ b/Steer/src/O2MCApplicationEvalMat.cxx
@@ -1,0 +1,95 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <Steer/O2MCApplicationEvalMat.h>
+#include <SimConfig/MatMapParams.h>
+#include <Generators/GeneratorGeantinos.h>
+#include <TObjArray.h>
+#include <TLorentzVector.h>
+#include <FairPrimaryGenerator.h>
+
+namespace o2
+{
+namespace steer
+{
+void O2MCApplicationEvalMat::BeginPrimary()
+{
+  TLorentzVector p;
+  fMC->TrackMomentum(p);
+  Float_t x, y, z;
+  fMC->TrackPosition(x, y, z);
+
+  mPhi = p.Phi() * 180. / TMath::Pi();
+  if (mPhi < 0.) mPhi += 360.;
+
+  mC1[0] = p.Theta() * 180. / TMath::Pi();
+  mC1[1] = p.Eta();
+  mC1[2] = z;
+}
+
+void O2MCApplicationEvalMat::FinishPrimary()
+{
+   mMaterialBudgetMap->FinishPrimary(mC1[mMode], mPhi);
+   FairMCApplication::FinishPrimary();
+}
+
+void O2MCApplicationEvalMat::Stepping()
+{
+   // dispatch first to stepping function in FairRoot
+  mMaterialBudgetMap->Stepping();
+}
+
+void O2MCApplicationEvalMat::BeginEvent()
+{
+  if (!mMaterialBudgetMap) {
+    auto& p = o2::conf::MatMapParams::Instance();
+    Float_t c1min, c1max;
+    Int_t n1;
+    if (p.ntheta != 0) {
+      // theta-phi binning
+      mMode = 0;
+      n1 = p.ntheta;
+      c1min = p.thetamin;
+      c1max = p.thetamax;
+    } else if (p.neta !=0) {
+      // eta-phi binning
+      mMode = 1;
+      n1 = p.neta;
+      c1min = p.etamin;
+      c1max = p.etamax;
+    } else if (p.nzv != 0) {
+      // z-phi binning
+      mMode = 2;
+      n1 = p.nzv;
+      c1min = p.zvmin;
+      c1max = p.zvmax;
+    }
+    printf("MaterialBudgetMap: %5d %13.3f %13.3f %5d %13.3f %13.3f %13.3f %13.3f\n", n1, c1min, c1max, p.nphi, p.phimin, p.phimax, p.rmax, p.zmax);
+    mMaterialBudgetMap = new MaterialBudgetMap("Map", mMode,
+    n1, c1min, c1max, p.nphi, p.phimin, p.phimax, p.rmin, p.rmax, p.zmax);
+  
+    auto gen = GetGenerator();
+    gen->GetListOfGenerators()->Clear();
+    gen->AddGenerator(new o2::eventgen::GeneratorGeantinos(mMode, n1, c1min, c1max, p.nphi, p.phimin, p.phimax, p.rmin, p.rmax, p.zmax));
+  }
+  // dispatch first to function in FairRoot
+  mMaterialBudgetMap->BeginEvent();
+}
+
+void O2MCApplicationEvalMat::FinishEvent()
+{
+  mMaterialBudgetMap->FinishEvent();
+  O2MCApplicationBase::FinishEvent();
+}
+
+} // namespace steer
+} // namespace o2
+

--- a/Steer/src/O2MCApplicationEvalMat.cxx
+++ b/Steer/src/O2MCApplicationEvalMat.cxx
@@ -28,8 +28,9 @@ void O2MCApplicationEvalMat::BeginPrimary()
   fMC->TrackPosition(x, y, z);
 
   mPhi = p.Phi() * 180. / TMath::Pi();
-  if (mPhi < 0.)
+  if (mPhi < 0.) {
     mPhi += 360.;
+  }
 
   mC1[0] = p.Theta() * 180. / TMath::Pi();
   mC1[1] = p.Eta();

--- a/Steer/src/SteerLinkDef.h
+++ b/Steer/src/SteerLinkDef.h
@@ -18,7 +18,9 @@
 #pragma link C++ class o2::steer::HitProcessingManager;
 #pragma link C++ class o2::steer::O2RunSim + ;
 #pragma link C++ class o2::steer::O2MCApplicationBase + ;
+#pragma link C++ class o2::steer::O2MCApplicationEvalMat + ;
 #pragma link C++ class o2::steer::O2MCApplication + ;
 #pragma link C++ class o2::steer::MCKinematicsReader + ;
+#pragma link C++ class o2::steer::MaterialBudgetMap + 
 
 #endif

--- a/Steer/src/SteerLinkDef.h
+++ b/Steer/src/SteerLinkDef.h
@@ -21,6 +21,6 @@
 #pragma link C++ class o2::steer::O2MCApplicationEvalMat + ;
 #pragma link C++ class o2::steer::O2MCApplication + ;
 #pragma link C++ class o2::steer::MCKinematicsReader + ;
-#pragma link C++ class o2::steer::MaterialBudgetMap + 
+#pragma link C++ class o2::steer::MaterialBudgetMap +
 
 #endif

--- a/macro/o2sim.C
+++ b/macro/o2sim.C
@@ -53,7 +53,7 @@ void check_notransport()
   }
 }
 
-FairRunSim* o2sim_init(bool asservice)
+FairRunSim* o2sim_init(bool asservice, bool evalmat = false)
 {
   auto& confref = o2::conf::SimConfig::Instance();
   // initialize CCDB service
@@ -84,7 +84,7 @@ FairRunSim* o2sim_init(bool asservice)
   LOG(info) << "RNG INITIAL SEED " << seed;
 
   auto genconfig = confref.getGenerator();
-  FairRunSim* run = new o2::steer::O2RunSim(asservice);
+  FairRunSim* run = new o2::steer::O2RunSim(asservice, evalmat);
   run->SetImportTGeoToVMC(false); // do not import TGeo to VMC since the latter is built together with TGeo
   run->SetSimSetup([confref]() { o2::SimSetup::setup(confref.getMCEngine().c_str()); });
   run->SetRunId(confref.getTimestamp());
@@ -258,9 +258,9 @@ void o2sim_run(FairRunSim* run, bool asservice)
 }
 
 // asservice: in a parallel device-based context?
-void o2sim(bool asservice = false)
+void o2sim(bool asservice = false, bool evalmat = false)
 {
-  auto run = o2sim_init(asservice);
+  auto run = o2sim_init(asservice, evalmat);
   o2sim_run(run, asservice);
   delete run;
 }

--- a/run/CMakeLists.txt
+++ b/run/CMakeLists.txt
@@ -54,6 +54,10 @@ o2_add_executable(serial
                   COMPONENT_NAME sim
                   SOURCES o2sim.cxx
                   PUBLIC_LINK_LIBRARIES internal::allsim)
+o2_add_executable(evalmat
+                  COMPONENT_NAME sim
+                  SOURCES o2sim_evalmat.cxx
+                  PUBLIC_LINK_LIBRARIES internal::allsim)
 
 o2_add_executable(sim
                   SOURCES o2sim_parallel.cxx

--- a/run/o2sim_evalmat.cxx
+++ b/run/o2sim_evalmat.cxx
@@ -1,0 +1,47 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "../macro/o2sim.C"
+#include <SimConfig/SimConfig.h>
+#include <SimConfig/MatMapParams.h>
+#include <TStopwatch.h>
+#include <FairLogger.h>
+
+int main(int argc, char* argv[])
+{
+  TStopwatch timer;
+  timer.Start();
+  auto& conf = o2::conf::SimConfig::Instance();
+  auto& matmapP = o2::conf::MatMapParams::Instance();
+  if (!conf.resetFromArguments(argc, argv)) {
+    return 1;
+  }
+  // custom number of events
+  // customize the level of output
+  FairLogger::GetLogger()->SetLogScreenLevel(conf.getLogSeverity().c_str());
+  FairLogger::GetLogger()->SetLogVerbosityLevel(conf.getLogVerbosity().c_str());
+
+  // call o2sim "macro"
+  o2sim(false, true);
+
+  o2::utils::ShmManager::Instance().release();
+
+  // print total time
+  LOG(info) << "Simulation process took " << timer.RealTime() << " s";
+
+  // We do this instead of return 0
+  // for the reason that we see lots of problems
+  // with TROOTs atexit mechanism often triggering double-free or delete symptoms.
+  // While this is not optimal ... I think it is for the moment
+  // better to have a stable simulation runtime in contrast to
+  // having to debug complicated "atexit" memory problems.
+  _exit(0);
+}

--- a/run/o2sim_mbudget.cxx
+++ b/run/o2sim_mbudget.cxx
@@ -1,0 +1,45 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "../macro/o2sim.C"
+#include <SimConfig/SimConfig.h>
+#include <TStopwatch.h>
+#include <FairLogger.h>
+
+int main(int argc, char* argv[])
+{
+  TStopwatch timer;
+  timer.Start();
+  auto& conf = o2::conf::SimConfig::Instance();
+  if (!conf.resetFromArguments(argc, argv)) {
+    return 1;
+  }
+
+  // customize the level of output
+  FairLogger::GetLogger()->SetLogScreenLevel(conf.getLogSeverity().c_str());
+  FairLogger::GetLogger()->SetLogVerbosityLevel(conf.getLogVerbosity().c_str());
+
+  // call o2sim "macro"
+  o2sim(false, true);
+
+  o2::utils::ShmManager::Instance().release();
+
+  // print total time
+  LOG(info) << "Simulation process took " << timer.RealTime() << " s";
+
+  // We do this instead of return 0
+  // for the reason that we see lots of problems
+  // with TROOTs atexit mechanism often triggering double-free or delete symptoms.
+  // While this is not optimal ... I think it is for the moment
+  // better to have a stable simulation runtime in contrast to
+  // having to debug complicated "atexit" memory problems.
+  _exit(0);
+}


### PR DESCRIPTION
A new executable  _o2-sim-evalmat_  _allows_ to calculate maps of path integrated material properties (radiation length, absorption length and density). The calculation is performed during the transport of geantinos.
The geantinos are generated in the class _GeneratorGeantinos_.
The map is calculated in a helper class _MaterialBudgetMap_ owned by a specific _O2MCApplication_ class, _O2MCApplicationEvalMat_.
Three types of maps are supported:
_theta-phi
eta-phi
zv-phi_
