### PR TITLE
TRD fix bounds error in mc to raw

### DIFF
--- a/Detectors/TRD/simulation/include/TRDSimulation/Trap2CRU.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Trap2CRU.h
@@ -73,10 +73,10 @@ class Trap2CRU
 
  private:
   int mfileGranularity; /// per link or per half cru for each file
-  uint32_t mLinkID;     // always 15 for TRD
+  uint8_t mLinkID;      // always 15 for TRD
   uint16_t mCruID;      // built into the FeeID
-  uint64_t mFeeID;      // front end id defining the cru sm:8 bits, blank 3 bits, side:1,blank 3 bits, end point:1
-  uint32_t mEndPointID; // end point on the cru in question, there are 2 pci end points per cru
+  uint16_t mFeeID;      // front end id defining the cru sm:8 bits, blank 3 bits, side:1,blank 3 bits, end point:1
+  uint8_t mEndPointID;  // end point on the cru in question, there are 2 pci end points per cru
   std::string mFilePer; // how to split up the raw data files, sm:per supermodule, halfcru: per half cru, cru: per cru, all: singular file.
   //  std::string mInputFileName;
   std::string mOutputFileName;

--- a/Detectors/TRD/simulation/src/trap2raw.cxx
+++ b/Detectors/TRD/simulation/src/trap2raw.cxx
@@ -137,7 +137,6 @@ void trap2raw(const std::string& inpDigitsName, const std::string& inpTrackletsN
   }
 
   mc2raw.setTrackletHCHeader(trackletHCHeader);
-  LOG(info) << "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%;";
   mc2raw.readTrapData();
   wr.writeConfFile(wr.getOrigin().str, "RAWDATA", o2::utils::Str::concat_string(outDirName, wr.getOrigin().str, "raw.cfg"));
   //


### PR DESCRIPTION
- Memory over run found by @shahor02 fixed. while loop was not checking for exceeding the bounds of the tracklets and digits
- bounds checking also added to isTrackletOnLink and isDigitOnLink.

- mFEEID in Trap2Raw class changed from uint64_t to uint16_t, causing error on m1 for @ktf 