### PR TITLE
Fix not filling dummy a vertex in per-rof entry

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -275,6 +275,7 @@ void TrackerDPL::run(ProcessingContext& pc)
       for (auto& v : vtxVecLoc) {
         vertices.push_back(v);
       }
+      timeFrame->addPrimaryVertices(vtxVecLoc);
     }
   }
 


### PR DESCRIPTION
@shahor02 : the issue was introduced by me in last pr, this is why we started seeing this only now.
Pushing a dummy vertex entry per each roframe is restored  in cosmics mode.
It runs with no errors, did not check the data, though.

@mpuccio for knowledge.