### PR TITLE
TPC Fasttransform: fix compiler warnings, fix standalone compilation, remove unnecessary includes

### DIFF
--- a/GPU/Common/GPUCommonRtypes.h
+++ b/GPU/Common/GPUCommonRtypes.h
@@ -22,6 +22,7 @@
     #define ClassDefNV(name, id)
     #define ClassDefOverride(name, id)
     #define ClassImp(name)
+    #define templateClassImp(name)
     #ifndef GPUCA_GPUCODE_DEVICE
       typedef unsigned long long int ULong64_t;
       typedef unsigned int UInt_t;

--- a/GPU/TPCFastTransformation/BandMatrixSolver.h
+++ b/GPU/TPCFastTransformation/BandMatrixSolver.h
@@ -18,7 +18,7 @@
 #define ALICEO2_GPUCOMMON_TPCFASTTRANSFORMATION_BANDMATRIXSOLVER_H
 
 #include "GPUCommonDef.h"
-#include "Rtypes.h"
+#include "GPUCommonRtypes.h"
 #include <vector>
 #include <cassert>
 #include <cstdlib>

--- a/GPU/TPCFastTransformation/CMakeLists.txt
+++ b/GPU/TPCFastTransformation/CMakeLists.txt
@@ -18,23 +18,28 @@ set(SRCS
     Spline1DSpec.cxx
     Spline1D.cxx
     Spline1DHelperOld.cxx
-    Spline1DHelper.cxx
     Spline2DSpec.cxx
     Spline2D.cxx
-    Spline2DHelper.cxx
     ChebyshevFit1D.cxx
-    SymMatrixSolver.cxx
-    BandMatrixSolver.cxx
-    devtools/IrregularSpline1D.cxx
-    devtools/IrregularSpline2D3D.cxx
-    devtools/SemiregularSpline2D3D.cxx
-    devtools/IrregularSpline2D3DCalibrator.cxx
     TPCFastTransformGeo.cxx
     TPCFastSpaceChargeCorrection.cxx
     TPCFastTransform.cxx
     MultivariatePolynomial.cxx
     MultivariatePolynomialHelper.cxx
 )
+
+if(NOT ALIGPU_BUILD_TYPE STREQUAL "Standalone")
+  set(SRCS ${SRCS}
+      Spline1DHelper.cxx
+      Spline2DHelper.cxx
+      SymMatrixSolver.cxx
+      BandMatrixSolver.cxx
+      devtools/IrregularSpline1D.cxx
+      devtools/IrregularSpline2D3D.cxx
+      devtools/SemiregularSpline2D3D.cxx
+      devtools/IrregularSpline2D3DCalibrator.cxx
+  )
+endif()
 
 string(REPLACE ".cxx" ".h" HDRS_CINT_O2 "${SRCS}")
 set(HDRS_CINT_O2 ${HDRS_CINT_O2} SplineUtil.h devtools/RegularSpline1D.h)
@@ -43,13 +48,13 @@ if(${ALIGPU_BUILD_TYPE} STREQUAL "O2")
   o2_add_library(${MODULE}
                  TARGETVARNAME targetName
                  SOURCES ${SRCS}
-                 PUBLIC_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_LIST_DIR} 
-                                            devtools 
+                 PUBLIC_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_LIST_DIR}
+                                            devtools
                                             ${CMAKE_SOURCE_DIR}/GPU/Common
                  PUBLIC_LINK_LIBRARIES O2::GPUCommon
                                        O2::GPUUtils
                                        Vc::Vc
-                                       ROOT::Core ROOT::Matrix ROOT::Tree ROOT::Gpad                
+                                       ROOT::Core ROOT::Matrix ROOT::Tree ROOT::Gpad
                              )
                  
   o2_target_root_dictionary(${MODULE}

--- a/GPU/TPCFastTransformation/Spline1DHelper.cxx
+++ b/GPU/TPCFastTransformation/Spline1DHelper.cxx
@@ -14,8 +14,6 @@
 ///
 /// \author  Sergey Gorbunov <sergey.gorbunov@cern.ch>
 
-#if !defined(GPUCA_GPUCODE) && !defined(GPUCA_STANDALONE)
-
 #include "Spline1DHelper.h"
 #include "BandMatrixSolver.h"
 #include "SymMatrixSolver.h"
@@ -736,5 +734,3 @@ int Spline1DHelper<DataT>::test(const bool draw, const bool drawDataPoints)
 
 template class GPUCA_NAMESPACE::gpu::Spline1DHelper<float>;
 template class GPUCA_NAMESPACE::gpu::Spline1DHelper<double>;
-
-#endif

--- a/GPU/TPCFastTransformation/Spline2DHelper.cxx
+++ b/GPU/TPCFastTransformation/Spline2DHelper.cxx
@@ -14,8 +14,6 @@
 ///
 /// \author  Sergey Gorbunov <sergey.gorbunov@cern.ch>
 
-#if !defined(GPUCA_GPUCODE) && !defined(GPUCA_STANDALONE)
-
 #include "Spline2DHelper.h"
 #include "Spline1DHelper.h"
 
@@ -673,5 +671,3 @@ int Spline2DHelper<DataT>::test(const bool draw, const bool drawDataPoints)
 
 template class GPUCA_NAMESPACE::gpu::Spline2DHelper<float>;
 template class GPUCA_NAMESPACE::gpu::Spline2DHelper<double>;
-
-#endif

--- a/GPU/TPCFastTransformation/Spline2DSpec.h
+++ b/GPU/TPCFastTransformation/Spline2DSpec.h
@@ -318,10 +318,10 @@ class Spline2DSpec<DataT, YdimT, 0>
     const auto nYdimTmp = SplineUtil::getNdim<YdimT>(inpYdim);
     const int nYdim = nYdimTmp.get();
 
-    const auto maxYdim = SplineUtil::getMaxNdim<YdimT>(inpYdim);
-    const int maxYdim4 = 4 * maxYdim.get();
+    // const auto maxYdim = SplineUtil::getMaxNdim<YdimT>(inpYdim);
+    // const int maxYdim4 = 4 * maxYdim.get();
 
-    const auto nYdim2 = nYdim * 2;
+    // const auto nYdim2 = nYdim * 2;
     const auto nYdim4 = nYdim * 4;
 
     const DataT& u = u1;

--- a/GPU/TPCFastTransformation/SymMatrixSolver.cxx
+++ b/GPU/TPCFastTransformation/SymMatrixSolver.cxx
@@ -22,11 +22,6 @@
 #include <iomanip>
 #include <chrono>
 
-#include "TMath.h"
-#include "TMatrixD.h"
-#include "TVectorD.h"
-#include "TDecompBK.h"
-
 using namespace std;
 using namespace GPUCA_NAMESPACE::gpu;
 

--- a/GPU/TPCFastTransformation/TPCFastSpaceChargeCorrection.cxx
+++ b/GPU/TPCFastTransformation/TPCFastSpaceChargeCorrection.cxx
@@ -225,7 +225,7 @@ void TPCFastSpaceChargeCorrection::print() const
         for (int j = 0; j < spline.getGridX2().getNumberOfKnots(); j++, k++) {
           LOG(info) << d[k] << " ";
         }
-        LOG(info);
+        LOG(info) << "";
       }
     }
     //    LOG(info) << "inverse correction: slice " << slice


### PR DESCRIPTION
@sgorbuno : The only real change is that I removed several ROOT includes from `GPU/TPCFastTransformation/SymMatrixSolver.cxx` which are apparently not needed.