### PR TITLE
its-vertexer: Use single vector to store number of found tracklets

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -136,11 +136,11 @@ class TimeFrame final
   // Vertexer
   void computeTrackletsScans();
   std::vector<int>& getIndexTableL0(int tf);
-  std::array<std::vector<int>, 2>& getNTrackletsCluster(int tf);
   int& getNTrackletsROf(int combId, int tf);
   std::vector<Line>& getLines(int tf);
   std::vector<ClusterLines>& getTrackletClusters(int tf);
   gsl::span<const Tracklet> getFoundTracklets(int rofId, int combId) const;
+  gsl::span<int> getNTrackletsCluster(int rofId, int combId);
   // \Vertexer
 
   void initialiseRoadLabels();
@@ -208,9 +208,10 @@ class TimeFrame final
   std::vector<std::pair<unsigned long long, bool>> mRoadLabels;
   int mCutClusterMult;
   int mCutVertexMult;
+
   // Vertexer
   std::vector<std::vector<int>> mIndexTablesL0;
-  std::vector<std::array<std::vector<int>, 2>> mNTrackletsPerCluster; // TODO: remove in favour of mNTrackletsPerROf
+  std::array<std::vector<int>, 2> mNTrackletsPerCluster; // TODO: remove in favour of mNTrackletsPerROf
   std::vector<std::vector<int>> mNTrackletsPerROf;
   std::vector<std::vector<Line>> mLines;
   std::vector<std::vector<ClusterLines>> mTrackletClusters;
@@ -387,9 +388,13 @@ inline const unsigned long long& TimeFrame::getRoadLabel(int i) const
   return mRoadLabels[i].first;
 }
 
-inline std::array<std::vector<int>, 2>& TimeFrame::getNTrackletsCluster(int tf)
+inline gsl::span<int> TimeFrame::getNTrackletsCluster(int rofId, int combId)
 {
-  return mNTrackletsPerCluster[tf];
+  if (rofId < 0 || rofId >= mNrof) {
+    return gsl::span<int>();
+  }
+  auto startIdx{mROframesClusters[1][rofId]};
+  return {&mNTrackletsPerCluster[combId][startIdx], static_cast<gsl::span<int>::size_type>(mROframesClusters[1][rofId + 1] - startIdx)};
 }
 
 inline int& TimeFrame::getNTrackletsROf(int combId, int tf)

--- a/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
@@ -108,7 +108,7 @@ int TimeFrame::loadROFrameData(const o2::itsmft::ROFRecord& rof, gsl::span<const
   for (unsigned int iL{0}; iL < mUnsortedClusters.size(); ++iL) {
     mROframesClusters[iL].push_back(mUnsortedClusters[iL].size());
     if (iL < 2) {
-      mTrackletsIndexROf[iL].push_back(mUnsortedClusters[1].size()); // Tracklets used in vertexer are always computed wrt clusters on the second layer
+      mTrackletsIndexROf[iL].push_back(mUnsortedClusters[1].size()); // Tracklets used in vertexer are always computed starting from L1
     }
   }
   if (mcLabels) {
@@ -169,6 +169,11 @@ int TimeFrame::loadROFrameData(gsl::span<o2::itsmft::ROFRecord> rofs,
     }
     mNrof++;
   }
+
+  for (auto& v : mNTrackletsPerCluster) {
+    v.resize(mUnsortedClusters[1].size());
+  }
+
   if (mcLabels) {
     mClusterLabels = mcLabels;
   }
@@ -221,7 +226,6 @@ void TimeFrame::initialise(const int iteration, const MemoryParameters& memParam
     mLines.resize(mNrof);
     mTrackletClusters.resize(mNrof);
     mNTrackletsPerROf.resize(2, std::vector<int>(mNrof + 1, 0));
-    mNTrackletsPerCluster.resize(mNrof);
 
     std::vector<ClusterHelper> cHelper;
     std::vector<int> clsPerBin(trkParam.PhiBins * trkParam.ZBins, 0);


### PR DESCRIPTION
Using a single flat buffer to store this info will be more impactful on the GPU code, this pr is to align the two approaches.