### PR TITLE
Suppress unnecessary and wrong check of CCDB obj. pointer

### DIFF
--- a/Detectors/PHOS/workflow/src/CellConverterSpec.cxx
+++ b/Detectors/PHOS/workflow/src/CellConverterSpec.cxx
@@ -69,11 +69,7 @@ void CellConverterSpec::run(framework::ProcessingContext& ctx)
 
   // get BadMap from CCDB, once
   if (!mHasCalib) {
-    std::decay_t<decltype(ctx.inputs().get<o2::phos::BadChannelsMap*>("badmap"))> badMapPtr{};
-    badMapPtr = ctx.inputs().get<o2::phos::BadChannelsMap*>("badmap");
-    if (badMapPtr.get()) {
-      LOG(fatal) << "[PHOSCellConverter - run] can not get Bad Map";
-    }
+    auto badMapPtr = ctx.inputs().get<o2::phos::BadChannelsMap*>("badmap");
     mBadMap = std::make_unique<BadChannelsMap>(*(badMapPtr.get()));
     mHasCalib = true;
   }


### PR DESCRIPTION
@peressounko As I wrote to you before, you don't need to check the pointer of the ccdb object returned by the DPL fetcher: if the fetching fails, the fatal will be produced already on the fetcher level. You also don't need to use complicated 
```
    std::decay_t<decltype(ctx.inputs().get<o2::phos::BadChannelsMap*>("badmap"))> badMapPtr{};
    badMapPtr = ctx.inputs().get<o2::phos::BadChannelsMap*>("badmap");
    const o2::phos::BadChannelsMap* badMap = badMapPtr.get();
```
you can simply do
```
auto badMapPtr = ctx.inputs().get<o2::phos::BadChannelsMap*>("badmap");
const o2::phos::BadChannelsMap* badMap = badMapPtr.get();
```

Merging since currently the reconstruction is broken