### PR TITLE
Removed loading unused mtroot library

### DIFF
--- a/Detectors/gconfig/g4Config.C
+++ b/Detectors/gconfig/g4Config.C
@@ -76,7 +76,7 @@ void Config()
   ///    where EMonly = emStandard
   ///    Hadron = FTFP_BERT FTFP_BERT_TRV FTFP_BERT_HP FTFP_INCLXX FTFP_INCLXX_HP FTF_BIC LBE QBBC QGSP_BERT
   ///             QGSP_BERT_HP QGSP_BIC QGSP_BIC_HP QGSP_FTFP_BERT QGSP_INCLXX QGSP_INCLXX_HP QGS_BIC
-  ///	          Shielding ShieldingLEND
+  ///                  Shielding ShieldingLEND
   ///    EM =  _EMV _EMX _EMY _EMZ _LIV _PEN
   ///    Extra = extra optical radDecay
   ///    The Extra selections are cumulative, while Hadron selections are exlusive.

--- a/Detectors/gconfig/g4Config.C
+++ b/Detectors/gconfig/g4Config.C
@@ -46,7 +46,6 @@ R__LOAD_LIBRARY(libXmlVGM)
 R__LOAD_LIBRARY(libVMCLibrary)
 R__LOAD_LIBRARY(libg4root)
 R__LOAD_LIBRARY(libgeant4vmc)
-R__LOAD_LIBRARY(libmtroot)
 
 #if !defined(__CLING__) || defined(__ROOTCLING__)
 #include <iostream>


### PR DESCRIPTION
This prepares migration to Geant4 VMC 6.1 where this library is removed