### PR TITLE
TPC dEdx: Fix memory cooruption from owning pointer leaked into subobject

### DIFF
--- a/GPU/GPUTracking/DataTypes/CalibdEdxContainer.h
+++ b/GPU/GPUTracking/DataTypes/CalibdEdxContainer.h
@@ -267,7 +267,7 @@ class CalibdEdxContainer : public o2::gpu::FlatObject
 
 #if !defined(GPUCA_GPUCODE)
   template <class Type>
-  void cloneFromObject(Type*& obj, const Type* objOld, char* newFlatBufferPtr, const char* oldFlatBufferPtr);
+  void subobjectCloneFromObject(Type*& obj, const Type* objOld);
 
   /// this functions 'smoothes' a CalDet by calculating for each value in a pad the average value using the neighbouring pads, but do not take into account the current pad
   /// \return returns 'smoothed' CalDet object


### PR DESCRIPTION
@matthias-kleiner @wiechula : This fixes the problem with the memory corruption when updating TPC dEdx objects for me.
The bottom line is: You have the CalibdEdxContainer and inside it the CalibdEdxTrackTopologyPol, and the subobject CalibdEdxTrackTopologyPol must not have an owning pointer `mFlatBufferContainer != nullptr`.
In the `cloneObject` function, you were just passing on the newFlatBufferPtr to the subobject's `cloneObject`, and when cloneObject is called with a `nullptr` as buffer pointer, it creates a new buffer. I.e., `CalibdEdxContainer::cloneObject(foo, nullptr)` created a CalibdEdxTrackTopologyPol with its own owning buffer, instead of placing it into the buffer of CalibdEdxContainer.

My solution uses an approach similar to what you do in `setTopologyCorrection`, and it seems to work for me.
Probably, a direct memcpy in the target region with some `FlatObject::relocatePointer` might be more efficient, but I didn't check the object structure enough to be able to implement that without risking to mess something up.

Also, if I understand the code correctly, there can be only the `mCalibTrackTopologySpline` or the `mCalibTrackTopologyPol` active, since they are using the same memory. I tried to make that a bit more explicit.