### PR TITLE
DPL: allow keeping track of outgoing messages

### DIFF
--- a/Framework/Core/include/Framework/ArrowContext.h
+++ b/Framework/Core/include/Framework/ArrowContext.h
@@ -12,6 +12,7 @@
 #define O2_FRAMEWORK_ARROWCONTEXT_H_
 
 #include "Framework/FairMQDeviceProxy.h"
+#include "Framework/RoutingIndices.h"
 #include <cassert>
 #include <functional>
 #include <memory>
@@ -31,7 +32,7 @@ class FairMQResizableBuffer;
 class ArrowContext
 {
  public:
-  ArrowContext(FairMQDeviceProxy proxy)
+  ArrowContext(FairMQDeviceProxy& proxy)
     : mProxy{proxy}
   {
   }
@@ -43,7 +44,7 @@ class ArrowContext
     std::shared_ptr<FairMQResizableBuffer> buffer;
     /// The function to call to finalise the builder into the message
     std::function<void(std::shared_ptr<FairMQResizableBuffer>)> finalize;
-    std::string channel;
+    RouteIndex routeIndex;
   };
 
   using Messages = std::vector<MessageRef>;
@@ -51,12 +52,12 @@ class ArrowContext
   void addBuffer(std::unique_ptr<FairMQMessage> header,
                  std::shared_ptr<FairMQResizableBuffer> buffer,
                  std::function<void(std::shared_ptr<FairMQResizableBuffer>)> finalize,
-                 const std::string& channel)
+                 RouteIndex routeIndex)
   {
     mMessages.push_back(std::move(MessageRef{std::move(header),
                                              std::move(buffer),
                                              std::move(finalize),
-                                             channel}));
+                                             routeIndex}));
   }
 
   Messages::iterator begin()
@@ -128,7 +129,7 @@ class ArrowContext
   }
 
  private:
-  FairMQDeviceProxy mProxy;
+  FairMQDeviceProxy& mProxy;
   Messages mMessages;
   size_t mBytesSent = 0;
   size_t mBytesDestroyed = 0;

--- a/Framework/Core/include/Framework/DataAllocator.h
+++ b/Framework/Core/include/Framework/DataAllocator.h
@@ -27,6 +27,7 @@
 #include "Framework/CheckTypes.h"
 #include "Framework/ServiceRegistry.h"
 #include "Framework/RuntimeError.h"
+#include "Framework/RouteState.h"
 
 #include "Headers/DataHeader.h"
 #include <TClass.h>
@@ -106,35 +107,35 @@ class DataAllocator
       // plain buffer as polymorphic spectator std::vector, which does not run constructors / destructors
       using ValueType = typename T::value_type;
       auto& timingInfo = mRegistry->get<TimingInfo>();
-      std::string const& channel = matchDataHeader(spec, timingInfo.timeslice);
+      auto routeIndex = matchDataHeader(spec, timingInfo.timeslice);
       auto& context = mRegistry->get<MessageContext>();
 
       // Note: initial payload size is 0 and will be set by the context before sending
-      FairMQMessagePtr headerMessage = headerMessageFromOutput(spec, channel, o2::header::gSerializationMethodNone, 0);
+      FairMQMessagePtr headerMessage = headerMessageFromOutput(spec, routeIndex, o2::header::gSerializationMethodNone, 0);
       return context.add<MessageContext::VectorObject<ValueType, MessageContext::ContainerRefObject<std::vector<ValueType, o2::pmr::NoConstructAllocator<ValueType>>>>>(
-                      std::move(headerMessage), channel, 0, std::forward<Args>(args)...)
+                      std::move(headerMessage), routeIndex, 0, std::forward<Args>(args)...)
         .get();
     } else if constexpr (is_specialization_v<T, std::vector> && has_messageable_value_type<T>::value) {
       // this catches all std::vector objects with messageable value type before checking if is also
       // has a root dictionary, so non-serialized transmission is preferred
       using ValueType = typename T::value_type;
       auto& timingInfo = mRegistry->get<TimingInfo>();
-      std::string const& channel = matchDataHeader(spec, timingInfo.timeslice);
+      auto routeIndex = matchDataHeader(spec, timingInfo.timeslice);
       auto& context = mRegistry->get<MessageContext>();
 
       // Note: initial payload size is 0 and will be set by the context before sending
-      FairMQMessagePtr headerMessage = headerMessageFromOutput(spec, channel, o2::header::gSerializationMethodNone, 0);
-      return context.add<MessageContext::VectorObject<ValueType>>(std::move(headerMessage), channel, 0, std::forward<Args>(args)...).get();
+      FairMQMessagePtr headerMessage = headerMessageFromOutput(spec, routeIndex, o2::header::gSerializationMethodNone, 0);
+      return context.add<MessageContext::VectorObject<ValueType>>(std::move(headerMessage), routeIndex, 0, std::forward<Args>(args)...).get();
     } else if constexpr (has_root_dictionary<T>::value == true && is_messageable<T>::value == false) {
       // Extended support for types implementing the Root ClassDef interface, both TObject
       // derived types and others
       auto& timingInfo = mRegistry->get<TimingInfo>();
-      std::string const& channel = matchDataHeader(spec, timingInfo.timeslice);
+      auto routeIndex = matchDataHeader(spec, timingInfo.timeslice);
       auto& context = mRegistry->get<MessageContext>();
 
       // Note: initial payload size is 0 and will be set by the context before sending
-      FairMQMessagePtr headerMessage = headerMessageFromOutput(spec, channel, o2::header::gSerializationMethodROOT, 0);
-      return context.add<MessageContext::RootSerializedObject<T>>(std::move(headerMessage), channel, std::forward<Args>(args)...).get();
+      FairMQMessagePtr headerMessage = headerMessageFromOutput(spec, routeIndex, o2::header::gSerializationMethodROOT, 0);
+      return context.add<MessageContext::RootSerializedObject<T>>(std::move(headerMessage), routeIndex, std::forward<Args>(args)...).get();
     } else if constexpr (std::is_base_of_v<std::string, T>) {
       auto* s = new std::string(args...);
       adopt(spec, s);
@@ -172,11 +173,11 @@ class DataAllocator
           auto [nElements] = std::make_tuple(args...);
           auto size = nElements * sizeof(T);
           auto& timingInfo = mRegistry->get<TimingInfo>();
-          std::string const& channel = matchDataHeader(spec, timingInfo.timeslice);
+          auto routeIndex = matchDataHeader(spec, timingInfo.timeslice);
           auto& context = mRegistry->get<MessageContext>();
 
-          FairMQMessagePtr headerMessage = headerMessageFromOutput(spec, channel, o2::header::gSerializationMethodNone, size);
-          return context.add<MessageContext::SpanObject<T>>(std::move(headerMessage), channel, 0, nElements).get();
+          FairMQMessagePtr headerMessage = headerMessageFromOutput(spec, routeIndex, o2::header::gSerializationMethodNone, size);
+          return context.add<MessageContext::SpanObject<T>>(std::move(headerMessage), routeIndex, 0, nElements).get();
         }
       } else if constexpr (std::is_same_v<FirstArg, std::shared_ptr<arrow::Schema>>) {
         if constexpr (std::is_base_of_v<arrow::ipc::RecordBatchWriter, T>) {
@@ -239,10 +240,10 @@ class DataAllocator
 
     char* payload = reinterpret_cast<char*>(ptr);
     auto& timingInfo = mRegistry->get<TimingInfo>();
-    std::string const& channel = matchDataHeader(spec, timingInfo.timeslice);
+    auto routeIndex = matchDataHeader(spec, timingInfo.timeslice);
     // the correct payload size is set later when sending the
     // RawBufferContext, see DataProcessor::doSend
-    auto header = headerMessageFromOutput(spec, channel, o2::header::gSerializationMethodNone, 0);
+    auto header = headerMessageFromOutput(spec, routeIndex, o2::header::gSerializationMethodNone, 0);
 
     auto lambdaSerialize = [voidPtr = payload]() {
       return o2::utils::BoostSerialize<type>(*(reinterpret_cast<type*>(voidPtr)));
@@ -253,7 +254,7 @@ class DataAllocator
       delete tmpPtr;
     };
 
-    mRegistry->get<RawBufferContext>().addRawBuffer(std::move(header), std::move(payload), std::move(channel), std::move(lambdaSerialize), std::move(lambdaDestructor));
+    mRegistry->get<RawBufferContext>().addRawBuffer(std::move(header), std::move(payload), routeIndex, std::move(lambdaSerialize), std::move(lambdaDestructor));
   }
 
   /// Send a snapshot of an object, depending on the object type it is serialized before.
@@ -278,12 +279,13 @@ class DataAllocator
   template <typename T>
   void snapshot(const Output& spec, T const& object)
   {
-    auto proxy = mRegistry->get<MessageContext>().proxy();
+    auto& proxy = mRegistry->get<MessageContext>().proxy();
     FairMQMessagePtr payloadMessage;
     auto serializationType = o2::header::gSerializationMethodNone;
+    RouteIndex routeIndex = matchDataHeader(spec, mRegistry->get<TimingInfo>().timeslice);
     if constexpr (is_messageable<T>::value == true) {
       // Serialize a snapshot of a trivially copyable, non-polymorphic object,
-      payloadMessage = proxy.createMessage(sizeof(T));
+      payloadMessage = proxy.createMessage(routeIndex, sizeof(T));
       memcpy(payloadMessage->GetData(), &object, sizeof(T));
 
       serializationType = o2::header::gSerializationMethodNone;
@@ -296,7 +298,7 @@ class DataAllocator
         // reference object
         constexpr auto elementSizeInBytes = sizeof(ElementType);
         auto sizeInBytes = elementSizeInBytes * object.size();
-        payloadMessage = proxy.createMessage(sizeInBytes);
+        payloadMessage = proxy.createMessage(routeIndex, sizeInBytes);
 
         if constexpr (std::is_pointer<typename T::value_type>::value == false) {
           // vector of elements
@@ -324,7 +326,7 @@ class DataAllocator
       }
     } else if constexpr (has_root_dictionary<T>::value == true || is_specialization_v<T, ROOTSerialized> == true) {
       // Serialize a snapshot of an object with root dictionary
-      payloadMessage = proxy.createMessage();
+      payloadMessage = proxy.createMessage(routeIndex);
       if constexpr (is_specialization_v<T, ROOTSerialized> == true) {
         // Explicitely ROOT serialize a snapshot of object.
         // An object wrapped into type `ROOTSerialized` is explicitely marked to be ROOT serialized
@@ -403,9 +405,9 @@ class DataAllocator
   o2::pmr::FairMQMemoryResource* getMemoryResource(const Output& spec)
   {
     auto& timingInfo = mRegistry->get<TimingInfo>();
-    std::string const& channel = matchDataHeader(spec, timingInfo.timeslice);
-    auto& context = mRegistry->get<MessageContext>();
-    return *context.proxy().getTransport(channel);
+    auto& proxy = mRegistry->get<FairMQDeviceProxy>();
+    RouteIndex routeIndex = matchDataHeader(spec, timingInfo.timeslice);
+    return *proxy.getTransport(routeIndex);
   }
 
   //make a stl (pmr) vector
@@ -486,9 +488,9 @@ class DataAllocator
   AllowedOutputRoutes mAllowedOutputRoutes;
   ServiceRegistry* mRegistry;
 
-  std::string const& matchDataHeader(const Output& spec, size_t timeframeId);
+  RouteIndex matchDataHeader(const Output& spec, size_t timeframeId);
   FairMQMessagePtr headerMessageFromOutput(Output const& spec,                                  //
-                                           std::string const& channel,                          //
+                                           RouteIndex index,                                    //
                                            o2::header::SerializationMethod serializationMethod, //
                                            size_t payloadSize);                                 //
 
@@ -504,12 +506,12 @@ DataAllocator::CacheId DataAllocator::adoptContainer(const Output& spec, Contain
   // Find a matching channel, extract the message for it form the container
   // and put it in the queue to be sent at the end of the processing
   auto& timingInfo = mRegistry->get<TimingInfo>();
-  std::string const& channel = matchDataHeader(spec, timingInfo.timeslice);
+  auto routeIndex = matchDataHeader(spec, timingInfo.timeslice);
 
   auto& context = mRegistry->get<MessageContext>();
-  FairMQMessagePtr payloadMessage = o2::pmr::getMessage(std::forward<ContainerT>(container), *context.proxy().getTransport(channel));
-
-  FairMQMessagePtr headerMessage = headerMessageFromOutput(spec, channel,            //
+  auto* transport = mRegistry->get<FairMQDeviceProxy>().getTransport(routeIndex);
+  FairMQMessagePtr payloadMessage = o2::pmr::getMessage(std::forward<ContainerT>(container), *transport);
+  FairMQMessagePtr headerMessage = headerMessageFromOutput(spec, routeIndex,         //
                                                            method,                   //
                                                            payloadMessage->GetSize() //
   );
@@ -522,7 +524,7 @@ DataAllocator::CacheId DataAllocator::adoptContainer(const Output& spec, Contain
     cacheId.value = context.addToCache(payloadMessage);
   }
 
-  context.add<MessageContext::TrivialObject>(std::move(headerMessage), std::move(payloadMessage), channel);
+  context.add<MessageContext::TrivialObject>(std::move(headerMessage), std::move(payloadMessage), routeIndex);
   return cacheId;
 }
 

--- a/Framework/Core/include/Framework/DataSender.h
+++ b/Framework/Core/include/Framework/DataSender.h
@@ -11,6 +11,7 @@
 #ifndef O2_FRAMEWORK_DATASENDER_H_
 #define O2_FRAMEWORK_DATASENDER_H_
 
+#include "Framework/RoutingIndices.h"
 #include "Framework/SendingPolicy.h"
 #include "Framework/Tracing.h"
 #include "Framework/OutputSpec.h"
@@ -32,11 +33,11 @@ class DataSender
  public:
   DataSender(ServiceRegistry& registry,
              SendingPolicy const& policy);
-  void send(FairMQParts&, std::string const& s);
-  std::unique_ptr<FairMQMessage> create();
+  void send(FairMQParts&, ChannelIndex index);
+  std::unique_ptr<FairMQMessage> create(RouteIndex index);
 
  private:
-  void* mContext;
+  FairMQDeviceProxy& mProxy;
   ServiceRegistry& mRegistry;
   DeviceSpec const& mSpec;
   std::vector<OutputSpec> mOutputs;

--- a/Framework/Core/include/Framework/DispatchControl.h
+++ b/Framework/Core/include/Framework/DispatchControl.h
@@ -8,23 +8,23 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#ifndef FRAMEWORK_DISPATCHCONTROL_H
-#define FRAMEWORK_DISPATCHCONTROL_H
+#ifndef O2_FRAMEWORK_DISPATCHCONTROL_H_
+#define O2_FRAMEWORK_DISPATCHCONTROL_H_
 
 #include "Framework/DispatchPolicy.h"
+#include "Framework/OutputRoute.h"
+#include "Framework/RoutingIndices.h"
 #include <functional>
 #include <string>
 
 #include <fairmq/FwdDecls.h>
 
-namespace o2
-{
-namespace header
+namespace o2::header
 {
 struct DataHeader;
 }
 
-namespace framework
+namespace o2::framework
 {
 /// @struct DispatchControl
 /// @brief Control for the message dispatching within message context.
@@ -33,7 +33,7 @@ namespace framework
 /// is used to decide when to sent the scheduled messages via the actual dispatch
 /// callback.
 struct DispatchControl {
-  using DispatchCallback = std::function<void(FairMQParts&& message, std::string const&, int)>;
+  using DispatchCallback = std::function<void(FairMQParts&& message, ChannelIndex index, int)>;
   using DispatchTrigger = std::function<bool(o2::header::DataHeader const&)>;
   // dispatcher callback
   DispatchCallback dispatch;
@@ -41,6 +41,5 @@ struct DispatchControl {
   DispatchTrigger trigger;
 };
 
-} // namespace framework
-} // namespace o2
-#endif // FRAMEWORK_DISPATCHCONTROL_H
+} // namespace o2::framework
+#endif // O2_FRAMEWORK_DISPATCHCONTROL_H_

--- a/Framework/Core/include/Framework/FairMQDeviceProxy.h
+++ b/Framework/Core/include/Framework/FairMQDeviceProxy.h
@@ -8,16 +8,18 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#ifndef FRAMEWORK_FAIRMQDEVICEPROXY_H
-#define FRAMEWORK_FAIRMQDEVICEPROXY_H
+#ifndef O2_FRAMEWORK_FAIRMQDEVICEPROXY_H_
+#define O2_FRAMEWORK_FAIRMQDEVICEPROXY_H_
 
 #include <memory>
 
+#include "Framework/RoutingIndices.h"
+#include "Framework/RouteState.h"
+#include "Framework/OutputRoute.h"
 #include <fairmq/FwdDecls.h>
+#include <vector>
 
-namespace o2
-{
-namespace framework
+namespace o2::framework
 {
 /// Helper class to hide FairMQDevice headers in the DataAllocator header.
 /// This is done because FairMQDevice brings in a bunch of boost.mpl /
@@ -25,29 +27,26 @@ namespace framework
 class FairMQDeviceProxy
 {
  public:
-  FairMQDeviceProxy(FairMQDevice* device)
-    : mDevice{device}
-  {
-  }
+  FairMQDeviceProxy() = default;
+  FairMQDeviceProxy(FairMQDeviceProxy const&) = delete;
+  void bindRoutes(std::vector<OutputRoute> const& routes, FairMQDevice& device);
 
-  /// To be used in DataAllocator.cxx to avoid reimplenting any device
-  /// API.
-  FairMQDevice* getDevice()
-  {
-    return mDevice;
-  }
+  /// Retrieve the transport associated to a given route.
+  fair::mq::TransportFactory* getTransport(RouteIndex routeIndex) const;
+  /// ChannelIndex from a RouteIndex
+  ChannelIndex getChannelIndex(RouteIndex routeIndex) const;
+  /// Retrieve the channel associated to a given route.
+  fair::mq::Channel* getChannel(ChannelIndex channelIndex) const;
 
-  /// Looks like what we really need in the headers is just the transport.
-  FairMQTransportFactory* getTransport();
-  FairMQTransportFactory* getTransport(const std::string& channel, int index = 0);
-  std::unique_ptr<FairMQMessage> createMessage() const;
-  std::unique_ptr<FairMQMessage> createMessage(const size_t size) const;
+  std::unique_ptr<FairMQMessage> createMessage(RouteIndex routeIndex) const;
+  std::unique_ptr<FairMQMessage> createMessage(RouteIndex routeIndex, const size_t size) const;
+  size_t getNumChannels() const { return mChannels.size(); }
 
  private:
-  FairMQDevice* mDevice;
+  std::vector<RouteState> mRoutes;
+  std::vector<fair::mq::Channel*> mChannels;
 };
 
-} // namespace framework
-} // namespace o2
+} // namespace o2::framework
 
-#endif // FRAMEWORK_FAIRMQDEVICEPROXY_H
+#endif // O2_FRAMEWORK_FAIRMQDEVICEPROXY_H_

--- a/Framework/Core/include/Framework/MessageContext.h
+++ b/Framework/Core/include/Framework/MessageContext.h
@@ -13,6 +13,9 @@
 
 #include "Framework/DispatchControl.h"
 #include "Framework/FairMQDeviceProxy.h"
+#include "Framework/OutputRoute.h"
+#include "Framework/RouteState.h"
+#include "Framework/RoutingIndices.h"
 #include "Framework/RuntimeError.h"
 #include "Framework/TMessageSerializer.h"
 #include "Framework/DataProcessingHeader.h"
@@ -45,12 +48,12 @@ class MessageContext
   // so far we are only using one instance per named channel
   static constexpr int DefaultChannelIndex = 0;
 
-  MessageContext(FairMQDeviceProxy proxy)
+  MessageContext(FairMQDeviceProxy& proxy)
     : mProxy{proxy}
   {
   }
 
-  MessageContext(FairMQDeviceProxy proxy, DispatchControl&& dispatcher)
+  MessageContext(FairMQDeviceProxy& proxy, DispatchControl&& dispatcher)
     : mProxy{proxy}, mDispatchControl{dispatcher}
   {
   }
@@ -65,17 +68,19 @@ class MessageContext
   {
    public:
     ContextObject() = delete;
-    ContextObject(FairMQMessagePtr&& headerMsg, FairMQMessagePtr&& payloadMsg, const std::string& bindingChannel)
-      : mParts{}, mChannel{bindingChannel}
+    ContextObject(FairMQMessagePtr&& headerMsg, FairMQMessagePtr&& payloadMsg, RouteIndex routeIndex)
+      : mParts{}, mRouteIndex{routeIndex}
     {
       mParts.AddPart(std::move(headerMsg));
       mParts.AddPart(std::move(payloadMsg));
     }
-    ContextObject(FairMQMessagePtr&& headerMsg, const std::string& bindingChannel)
-      : mParts{}, mChannel{bindingChannel}
+
+    ContextObject(FairMQMessagePtr&& headerMsg, RouteIndex routeIndex)
+      : mParts{}, mRouteIndex{routeIndex}
     {
       mParts.AddPart(std::move(headerMsg));
     }
+
     virtual ~ContextObject() = default;
 
     /// @brief Finalize the object and return the parts by move
@@ -97,9 +102,9 @@ class MessageContext
     }
 
     /// @brief return the channel name
-    const std::string& channel() const
+    RouteIndex route() const
     {
-      return mChannel;
+      return mRouteIndex;
     }
 
     bool empty() const
@@ -135,7 +140,7 @@ class MessageContext
 
    protected:
     FairMQParts mParts;
-    std::string const& mChannel;
+    RouteIndex mRouteIndex{-1};
   };
 
   /// TrivialObject handles a message object
@@ -146,14 +151,14 @@ class MessageContext
     TrivialObject() = delete;
     /// constructor consuming the header and payload messages for a given channel by move
     template <typename ContextType>
-    TrivialObject(ContextType* context, FairMQMessagePtr&& headerMsg, FairMQMessagePtr&& payloadMsg, const std::string& bindingChannel)
-      : ContextObject(std::forward<FairMQMessagePtr>(headerMsg), std::forward<FairMQMessagePtr>(payloadMsg), context->getChannelRef(bindingChannel))
+    TrivialObject(ContextType* context, FairMQMessagePtr&& headerMsg, FairMQMessagePtr&& payloadMsg, RouteIndex routeIndex)
+      : ContextObject(std::forward<FairMQMessagePtr>(headerMsg), std::forward<FairMQMessagePtr>(payloadMsg), routeIndex)
     {
     }
     /// constructor taking header message by move and creating the paypload message
     template <typename ContextType, typename... Args>
-    TrivialObject(ContextType* context, FairMQMessagePtr&& headerMsg, const std::string& bindingChannel, int index, Args... args)
-      : ContextObject(std::forward<FairMQMessagePtr>(headerMsg), context->createMessage(bindingChannel, index, std::forward<Args>(args)...), context->getChannelRef(bindingChannel))
+    TrivialObject(ContextType* context, FairMQMessagePtr&& headerMsg, RouteIndex routeIndex, int index, Args... args)
+      : ContextObject(std::forward<FairMQMessagePtr>(headerMsg), context->createMessage(routeIndex, index, std::forward<Args>(args)...), routeIndex)
     {
     }
     ~TrivialObject() override = default;
@@ -241,10 +246,10 @@ class MessageContext
     ContainerRefObject() = delete;
     /// constructor taking header message by move and creating the paypload message
     template <typename ContextType, typename... Args>
-    ContainerRefObject(ContextType* context, FairMQMessagePtr&& headerMsg, const std::string& bindingChannel, int index, Args&&... args)
-      : ContextObject(std::forward<FairMQMessagePtr>(headerMsg), context->getChannelRef(bindingChannel)),
+    ContainerRefObject(ContextType* context, FairMQMessagePtr&& headerMsg, RouteIndex routeIndex, int index, Args&&... args)
+      : ContextObject(std::forward<FairMQMessagePtr>(headerMsg), routeIndex),
         // the transport factory
-        mFactory{context->proxy().getTransport(bindingChannel, index)},
+        mFactory{context->proxy().getTransport(routeIndex)},
         // the memory resource takes ownership of the message
         mResource{mFactory ? AlignedMemoryResource(mFactory->GetMemoryResource()) : AlignedMemoryResource(nullptr)},
         // create the vector with apropriate underlying memory resource for the message
@@ -253,10 +258,10 @@ class MessageContext
       // FIXME: drop this repeated check and make sure at initial setup of devices that everything is fine
       // introduce error policy
       if (mFactory == nullptr) {
-        throw runtime_error_f("failed to get transport factory for channel %s", bindingChannel.c_str());
+        throw runtime_error_f("failed to get transport factory for route %d", routeIndex);
       }
       if (mResource.isValid() == false) {
-        throw runtime_error_f("no memory resource for channel %s", bindingChannel.c_str());
+        throw runtime_error_f("no memory resource for channel %d", routeIndex);
       }
     }
     ~ContainerRefObject() override = default;
@@ -321,12 +326,12 @@ class MessageContext
     SpanObject() = delete;
     /// constructor taking header message by move and creating the payload message for the span
     template <typename ContextType>
-    SpanObject(ContextType* context, FairMQMessagePtr&& headerMsg, const std::string& bindingChannel, int index, size_t nElements)
-      : ContextObject(std::forward<FairMQMessagePtr>(headerMsg), context->getChannelRef(bindingChannel))
+    SpanObject(ContextType* context, FairMQMessagePtr&& headerMsg, RouteIndex routeIndex, int index, size_t nElements)
+      : ContextObject(std::forward<FairMQMessagePtr>(headerMsg), routeIndex)
     {
       // create the span object for the memory of the payload message
       // TODO: we probably also want to check consistency of the header message, i.e. payloadSize member
-      auto payloadMsg = context->createMessage(bindingChannel, index, nElements * sizeof(T));
+      auto payloadMsg = context->createMessage(routeIndex, index, nElements * sizeof(T));
       mValue = value_type(reinterpret_cast<T*>(payloadMsg->GetData()), nElements);
       assert(mParts.Size() == 1);
       mParts.AddPart(std::move(payloadMsg));
@@ -363,11 +368,11 @@ class MessageContext
     RootSerializedObject() = delete;
     /// constructor taking header message by move and creating the object from variadic argument list
     template <typename ContextType, typename... Args>
-    RootSerializedObject(ContextType* context, FairMQMessagePtr&& headerMsg, const std::string& bindingChannel, Args&&... args)
-      : ContextObject(std::forward<FairMQMessagePtr>(headerMsg), context->getChannelRef(bindingChannel))
+    RootSerializedObject(ContextType* context, FairMQMessagePtr&& headerMsg, RouteIndex routeIndex, Args&&... args)
+      : ContextObject(std::forward<FairMQMessagePtr>(headerMsg), routeIndex)
     {
       mObject = std::make_unique<value_type>(std::forward<Args>(args)...);
-      mPayloadMsg = context->proxy().createMessage();
+      mPayloadMsg = context->proxy().createMessage(routeIndex);
     }
     ~RootSerializedObject() override = default;
 
@@ -488,17 +493,22 @@ class MessageContext
     if (mDispatchControl.dispatch != nullptr) {
       // send all scheduled messages if there is no trigger callback or its result is true
       if (mDispatchControl.trigger == nullptr || mDispatchControl.trigger(*header)) {
-        std::unordered_map<std::string const*, FairMQParts> outputs;
+        std::vector<FairMQParts> outputsPerChannel;
+        outputsPerChannel.resize(mProxy.getNumChannels());
         for (auto& message : mScheduledMessages) {
           FairMQParts parts = message->finalize();
           assert(message->empty());
           assert(parts.Size() == 2);
           for (auto& part : parts) {
-            outputs[&(message->channel())].AddPart(std::move(part));
+            outputsPerChannel[mProxy.getChannelIndex(message->route()).value].AddPart(std::move(part));
           }
         }
-        for (auto& [channel, parts] : outputs) {
-          mDispatchControl.dispatch(std::move(parts), *channel, DefaultChannelIndex);
+        for (int ci = 0; ci < mProxy.getNumChannels(); ++ci) {
+          auto& parts = outputsPerChannel[ci];
+          if (parts.Size() == 0) {
+            continue;
+          }
+          mDispatchControl.dispatch(std::move(parts), ChannelIndex{ci}, DefaultChannelIndex);
         }
         mDidDispatch = mScheduledMessages.empty() == false;
         mScheduledMessages.clear();
@@ -533,20 +543,6 @@ class MessageContext
     mMessages.clear();
   }
 
-  /// Get a reference to channel string unique within the context
-  /// The unique references are stored in context objects instead of allocating string objects.
-  /// Based on the references, messages going over the same channel are grouped together in a
-  /// multimessage.
-  std::string const& getChannelRef(std::string const& channel)
-  {
-    auto ref = mChannelRefs.find(channel);
-    if (ref != mChannelRefs.end()) {
-      return *(ref->second);
-    }
-    mChannelRefs[channel] = std::make_unique<std::string>(channel);
-    return *(mChannelRefs[channel]);
-  }
-
   FairMQDeviceProxy& proxy()
   {
     return mProxy;
@@ -564,8 +560,8 @@ class MessageContext
   /// we don't implement in the header to avoid including the FairMQDevice header here
   /// that's why the different versions need to be implemented as individual functions
   // FIXME: can that be const?
-  FairMQMessagePtr createMessage(const std::string& channel, int index, size_t size);
-  FairMQMessagePtr createMessage(const std::string& channel, int index, void* data, size_t size, fairmq_free_fn* ffn, void* hint);
+  FairMQMessagePtr createMessage(RouteIndex routeIndex, int index, size_t size);
+  FairMQMessagePtr createMessage(RouteIndex routeIndex, int index, void* data, size_t size, fairmq_free_fn* ffn, void* hint);
 
   /// return the headers of the 1st (from the end) matching message checking first in mMessages then in mScheduledMessages
   o2::header::DataHeader* findMessageHeader(const Output& spec);
@@ -575,12 +571,11 @@ class MessageContext
   std::pair<o2::header::DataHeader*, o2::framework::DataProcessingHeader*> findMessageHeaders(const Output& spec);
 
  private:
-  FairMQDeviceProxy mProxy;
+  FairMQDeviceProxy& mProxy;
   Messages mMessages;
   Messages mScheduledMessages;
   bool mDidDispatch = false;
   DispatchControl mDispatchControl;
-  std::unordered_map<std::string, std::unique_ptr<std::string>> mChannelRefs;
   /// Cached messages, in case we want to reuse them.
   std::unordered_map<int64_t, std::unique_ptr<FairMQMessage>> mMessageCache;
 };

--- a/Framework/Core/include/Framework/OutputRoute.h
+++ b/Framework/Core/include/Framework/OutputRoute.h
@@ -8,16 +8,14 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#ifndef FRAMEWORK_OUTPUTROUTE_H
-#define FRAMEWORK_OUTPUTROUTE_H
+#ifndef O2_FRAMEWORK_OUTPUTROUTE_H_
+#define O2_FRAMEWORK_OUTPUTROUTE_H_
 
 #include "Framework/OutputSpec.h"
 #include <cstddef>
 #include <string>
 
-namespace o2
-{
-namespace framework
+namespace o2::framework
 {
 
 // This uniquely identifies a route out of the device if
@@ -29,6 +27,5 @@ struct OutputRoute {
   std::string channel;
 };
 
-} // namespace framework
-} // namespace o2
-#endif
+} // namespace o2::framework
+#endif // O2_FRAMEWORK_OUTPUTROUTE_H_

--- a/Framework/Core/include/Framework/RawBufferContext.h
+++ b/Framework/Core/include/Framework/RawBufferContext.h
@@ -13,6 +13,7 @@
 #define O2_FRAMEWORK_RAWBUFFERCONTEXT_H_
 
 #include "Framework/FairMQDeviceProxy.h"
+#include "Framework/RoutingIndices.h"
 #include "CommonUtils/BoostSerializer.h"
 #include <vector>
 #include <string>
@@ -28,7 +29,7 @@ namespace o2::framework
 class RawBufferContext
 {
  public:
-  RawBufferContext(FairMQDeviceProxy proxy)
+  RawBufferContext(FairMQDeviceProxy& proxy)
     : mProxy{proxy}
   {
   }
@@ -37,7 +38,7 @@ class RawBufferContext
   struct MessageRef {
     std::unique_ptr<FairMQMessage> header;
     char* payload;
-    std::string channel;
+    RouteIndex routeIndex;
     std::function<std::ostringstream()> serializeMsg;
     std::function<void()> destroyPayload;
   };
@@ -46,7 +47,7 @@ class RawBufferContext
 
   void addRawBuffer(std::unique_ptr<FairMQMessage> header,
                     char* payload,
-                    std::string channel,
+                    RouteIndex routeIndex,
                     std::function<std::ostringstream()> serialize,
                     std::function<void()> destructor);
 
@@ -75,7 +76,7 @@ class RawBufferContext
   int countDeviceOutputs(bool excludeDPLOrigin);
 
  private:
-  FairMQDeviceProxy mProxy;
+  FairMQDeviceProxy& mProxy;
   Messages mMessages;
 };
 

--- a/Framework/Core/include/Framework/RouteState.h
+++ b/Framework/Core/include/Framework/RouteState.h
@@ -8,23 +8,19 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#ifndef O2_FRAMEWORK_COMMONMESSAGEBACKENDS_H_
-#define O2_FRAMEWORK_COMMONMESSAGEBACKENDS_H_
+#ifndef O2_FRAMEWORK_ROUTESTATE_H_
+#define O2_FRAMEWORK_ROUTESTATE_H_
 
-#include "Framework/ServiceSpec.h"
-#include "Framework/TypeIdHelpers.h"
+#include "Framework/RoutingIndices.h"
 
 namespace o2::framework
 {
-
-/// A few ServiceSpecs data sending backends
-struct CommonMessageBackends {
-  static ServiceSpec fairMQDeviceProxy();
-  static ServiceSpec fairMQBackendSpec();
-  static ServiceSpec stringBackendSpec();
-  static ServiceSpec rawBufferBackendSpec();
+/// Keeps current state of a given route.
+struct RouteState {
+  // The channel associated with this route.
+  ChannelIndex channel = {-1};
+  int present = false;
 };
 
 } // namespace o2::framework
-
-#endif // O2_FRAMEWORK_COMMONMESSAGEBACKENDS_H_
+#endif // O2_FRAMEWORK_ROUTESTATE_H_

--- a/Framework/Core/include/Framework/RoutingIndices.h
+++ b/Framework/Core/include/Framework/RoutingIndices.h
@@ -24,6 +24,13 @@ struct RouteIndex {
   explicit operator int() const { return value; }
 };
 
+/// An index in the space of the available channels.
+/// Keep in mind that multiple inputs, routes can
+/// use the same channel.
+struct ChannelIndex {
+  int value;
+};
+
 // An index in the space of the declared InputSpec
 // This does not take multiple input routes into account
 struct InputIndex {

--- a/Framework/Core/include/Framework/SendingPolicy.h
+++ b/Framework/Core/include/Framework/SendingPolicy.h
@@ -12,6 +12,7 @@
 #define O2_FRAMEWORK_SENDINGPOLICY_H_
 
 #include "Framework/DataProcessorMatchers.h"
+#include "Framework/RoutingIndices.h"
 #include <fairmq/FwdDecls.h>
 #include <vector>
 #include <functional>
@@ -20,8 +21,10 @@
 namespace o2::framework
 {
 
+class FairMQDeviceProxy;
+
 struct SendingPolicy {
-  using SendingCallback = std::function<void(FairMQDevice&, FairMQParts&, std::string const& channel)>;
+  using SendingCallback = std::function<void(FairMQDeviceProxy&, FairMQParts&, ChannelIndex channelIndex)>;
   std::string name = "invalid";
   DeviceMatcher matcher = nullptr;
   SendingCallback send = nullptr;

--- a/Framework/Core/include/Framework/StringContext.h
+++ b/Framework/Core/include/Framework/StringContext.h
@@ -12,6 +12,8 @@
 #define O2_FRAMEWORK_STRINGCONTEXT_H_
 
 #include "Framework/FairMQDeviceProxy.h"
+#include "Framework/RouteState.h"
+#include "Framework/RoutingIndices.h"
 #include <vector>
 #include <string>
 #include <memory>
@@ -27,22 +29,22 @@ namespace o2::framework
 class StringContext
 {
  public:
-  StringContext(FairMQDeviceProxy proxy)
-    : mProxy{proxy}
+  StringContext(FairMQDeviceProxy& proxy)
+    : mProxy(proxy)
   {
   }
 
   struct MessageRef {
     std::unique_ptr<FairMQMessage> header;
     std::unique_ptr<std::string> payload;
-    std::string channel;
+    RouteIndex routeIndex;
   };
 
   using Messages = std::vector<MessageRef>;
 
   void addString(std::unique_ptr<FairMQMessage> header,
                  std::unique_ptr<std::string> s,
-                 const std::string& channel);
+                 RouteIndex routeIndex);
 
   Messages::iterator begin()
   {
@@ -61,13 +63,8 @@ class StringContext
 
   void clear();
 
-  FairMQDeviceProxy& proxy()
-  {
-    return mProxy;
-  }
-
  private:
-  FairMQDeviceProxy mProxy;
+  FairMQDeviceProxy& mProxy;
   Messages mMessages;
 };
 

--- a/Framework/Core/src/CommonMessageBackends.cxx
+++ b/Framework/Core/src/CommonMessageBackends.cxx
@@ -44,18 +44,34 @@ namespace o2::framework
 class EndOfStreamContext;
 class ProcessingContext;
 
+o2::framework::ServiceSpec CommonMessageBackends::fairMQDeviceProxy()
+{
+  return ServiceSpec{
+    .name = "fairmq-device-proxy",
+    .init = [](ServiceRegistry&, DeviceState&, fair::mq::ProgOptions& options) -> ServiceHandle {
+      auto* proxy = new FairMQDeviceProxy();
+      return ServiceHandle{.hash = TypeIdHelpers::uniqueId<FairMQDeviceProxy>(), .instance = proxy, .kind = ServiceKind::Serial};
+    },
+    .start = [](ServiceRegistry& services, void* instance) {
+      auto* proxy = static_cast<FairMQDeviceProxy*>(instance);
+      auto& routes = services.get<DeviceSpec const>().outputs;
+      auto* device = services.get<RawDeviceService>().device();
+      proxy->bindRoutes(routes, *device); },
+  };
+}
+
 o2::framework::ServiceSpec CommonMessageBackends::fairMQBackendSpec()
 {
   return ServiceSpec{
     .name = "fairmq-backend",
     .init = [](ServiceRegistry& services, DeviceState&, fair::mq::ProgOptions&) -> ServiceHandle {
-      auto& device = services.get<RawDeviceService>();
-      auto context = new MessageContext(FairMQDeviceProxy{device.device()});
+      auto& proxy = services.get<FairMQDeviceProxy>();
+      auto context = new MessageContext(proxy);
       auto& spec = services.get<DeviceSpec const>();
       auto& dataSender = services.get<DataSender>();
 
-      auto dispatcher = [&dataSender](FairMQParts&& parts, std::string const& channel, unsigned int) {
-        dataSender.send(parts, channel);
+      auto dispatcher = [&dataSender](FairMQParts&& parts, ChannelIndex channelIndex, unsigned int) {
+        dataSender.send(parts, channelIndex);
       };
 
       auto matcher = [policy = spec.dispatchPolicy](o2::header::DataHeader const& header) {

--- a/Framework/Core/src/CommonMessageBackendsHelpers.h
+++ b/Framework/Core/src/CommonMessageBackendsHelpers.h
@@ -30,8 +30,8 @@ struct CommonMessageBackendsHelpers {
   static ServiceInit createCallback()
   {
     return [](ServiceRegistry& services, DeviceState&, fair::mq::ProgOptions& options) {
-      auto& device = services.get<RawDeviceService>();
-      return ServiceHandle{TypeIdHelpers::uniqueId<T>(), new T(FairMQDeviceProxy{device.device()})};
+      auto& proxy = services.get<FairMQDeviceProxy>();
+      return ServiceHandle{TypeIdHelpers::uniqueId<T>(), new T(proxy)};
     };
   }
 

--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -746,6 +746,7 @@ std::vector<ServiceSpec> CommonServices::defaultServices(int numThreads)
     parallelSpec(),
     callbacksSpec(),
     dataRelayer(),
+    CommonMessageBackends::fairMQDeviceProxy(),
     dataSender(),
     dataProcessingStats(),
     objectCache(),

--- a/Framework/Core/src/DataAllocator.cxx
+++ b/Framework/Core/src/DataAllocator.cxx
@@ -42,12 +42,13 @@ DataAllocator::DataAllocator(ServiceRegistry* contextRegistry,
 {
 }
 
-std::string const& DataAllocator::matchDataHeader(const Output& spec, size_t timeslice)
+RouteIndex DataAllocator::matchDataHeader(const Output& spec, size_t timeslice)
 {
   // FIXME: we should take timeframeId into account as well.
-  for (auto& output : mAllowedOutputRoutes) {
-    if (DataSpecUtils::match(output.matcher, spec.origin, spec.description, spec.subSpec) && ((timeslice % output.maxTimeslices) == output.timeslice)) {
-      return output.channel;
+  for (auto ri = 0; ri < mAllowedOutputRoutes.size(); ++ri) {
+    auto& route = mAllowedOutputRoutes[ri];
+    if (DataSpecUtils::match(route.matcher, spec.origin, spec.description, spec.subSpec) && ((timeslice % route.maxTimeslices) == route.timeslice)) {
+      return RouteIndex{ri};
     }
   }
   throw runtime_error_f(
@@ -61,14 +62,14 @@ std::string const& DataAllocator::matchDataHeader(const Output& spec, size_t tim
 DataChunk& DataAllocator::newChunk(const Output& spec, size_t size)
 {
   auto& timingInfo = mRegistry->get<TimingInfo>();
-  std::string const& channel = matchDataHeader(spec, timingInfo.timeslice);
+  RouteIndex routeIndex = matchDataHeader(spec, timingInfo.timeslice);
   auto& context = mRegistry->get<MessageContext>();
 
-  FairMQMessagePtr headerMessage = headerMessageFromOutput(spec, channel,                        //
+  FairMQMessagePtr headerMessage = headerMessageFromOutput(spec, routeIndex,                     //
                                                            o2::header::gSerializationMethodNone, //
                                                            size                                  //
   );
-  auto& co = context.add<MessageContext::ContainerRefObject<DataChunk>>(std::move(headerMessage), channel, 0, size);
+  auto& co = context.add<MessageContext::ContainerRefObject<DataChunk>>(std::move(headerMessage), routeIndex, 0, size);
   return co;
 }
 
@@ -76,20 +77,20 @@ void DataAllocator::adoptChunk(const Output& spec, char* buffer, size_t size, fa
 {
   // Find a matching channel, create a new message for it and put it in the
   // queue to be sent at the end of the processing
-  std::string const& channel = matchDataHeader(spec, mRegistry->get<TimingInfo>().timeslice);
+  RouteIndex routeIndex = matchDataHeader(spec, mRegistry->get<TimingInfo>().timeslice);
 
-  FairMQMessagePtr headerMessage = headerMessageFromOutput(spec, channel,                        //
+  FairMQMessagePtr headerMessage = headerMessageFromOutput(spec, routeIndex,                     //
                                                            o2::header::gSerializationMethodNone, //
                                                            size                                  //
   );
 
   // FIXME: how do we want to use subchannels? time based parallelism?
   auto& context = mRegistry->get<MessageContext>();
-  context.add<MessageContext::TrivialObject>(std::move(headerMessage), channel, 0, buffer, size, freefn, hint);
+  context.add<MessageContext::TrivialObject>(std::move(headerMessage), routeIndex, 0, buffer, size, freefn, hint);
 }
 
 FairMQMessagePtr DataAllocator::headerMessageFromOutput(Output const& spec,                     //
-                                                        std::string const& channel,             //
+                                                        RouteIndex routeIndex,                  //
                                                         o2::header::SerializationMethod method, //
                                                         size_t payloadSize)                     //
 {
@@ -106,8 +107,10 @@ FairMQMessagePtr DataAllocator::headerMessageFromOutput(Output const& spec,     
 
   DataProcessingHeader dph{timingInfo.timeslice, 1, timingInfo.creation};
   auto& context = mRegistry->get<MessageContext>();
+  auto& proxy = mRegistry->get<FairMQDeviceProxy>();
+  auto* transport = proxy.getTransport(routeIndex);
 
-  auto channelAlloc = o2::pmr::getTransportAllocator(context.proxy().getTransport(channel, 0));
+  auto channelAlloc = o2::pmr::getTransportAllocator(transport);
   return o2::pmr::getMessage(o2::header::Stack{channelAlloc, dh, dph, spec.metaHeader});
 }
 
@@ -115,8 +118,8 @@ void DataAllocator::addPartToContext(FairMQMessagePtr&& payloadMessage, const Ou
                                      o2::header::SerializationMethod serializationMethod)
 {
   auto& timingInfo = mRegistry->get<TimingInfo>();
-  std::string const& channel = matchDataHeader(spec, timingInfo.timeslice);
-  auto headerMessage = headerMessageFromOutput(spec, channel, serializationMethod, 0);
+  RouteIndex routeIndex = matchDataHeader(spec, timingInfo.timeslice);
+  auto headerMessage = headerMessageFromOutput(spec, routeIndex, serializationMethod, 0);
 
   // FIXME: this is kind of ugly, we know that we can change the content of the
   // header message because we have just created it, but the API declares it const
@@ -127,18 +130,18 @@ void DataAllocator::addPartToContext(FairMQMessagePtr&& payloadMessage, const Ou
   // make_scoped creates the context object inside of a scope handler, since it goes out of
   // scope immediately, the created object is scheduled and can be directly sent if the context
   // is configured with the dispatcher callback
-  context.make_scoped<MessageContext::TrivialObject>(std::move(headerMessage), std::move(payloadMessage), channel);
+  context.make_scoped<MessageContext::TrivialObject>(std::move(headerMessage), std::move(payloadMessage), routeIndex);
 }
 
 void DataAllocator::adopt(const Output& spec, std::string* ptr)
 {
   std::unique_ptr<std::string> payload(ptr);
   auto& timingInfo = mRegistry->get<TimingInfo>();
-  std::string const& channel = matchDataHeader(spec, timingInfo.timeslice);
+  RouteIndex routeIndex = matchDataHeader(spec, timingInfo.timeslice);
   // the correct payload size is set later when sending the
   // StringContext, see DataProcessor::doSend
-  auto header = headerMessageFromOutput(spec, channel, o2::header::gSerializationMethodNone, 0);
-  mRegistry->get<StringContext>().addString(std::move(header), std::move(payload), channel);
+  auto header = headerMessageFromOutput(spec, routeIndex, o2::header::gSerializationMethodNone, 0);
+  mRegistry->get<StringContext>().addString(std::move(header), std::move(payload), routeIndex);
   assert(payload.get() == nullptr);
 }
 
@@ -192,11 +195,15 @@ void doWriteTable(std::shared_ptr<FairMQResizableBuffer> b, arrow::Table* table)
 void DataAllocator::adopt(const Output& spec, TableBuilder* tb)
 {
   auto& timingInfo = mRegistry->get<TimingInfo>();
-  std::string const& channel = matchDataHeader(spec, timingInfo.timeslice);
-  auto header = headerMessageFromOutput(spec, channel, o2::header::gSerializationMethodArrow, 0);
+  RouteIndex routeIndex = matchDataHeader(spec, timingInfo.timeslice);
+  auto header = headerMessageFromOutput(spec, routeIndex, o2::header::gSerializationMethodArrow, 0);
   auto& context = mRegistry->get<ArrowContext>();
+  auto* transport = context.proxy().getTransport(routeIndex);
+  assert(transport != nullptr);
 
-  auto creator = [device = context.proxy().getDevice()](size_t s) -> std::unique_ptr<FairMQMessage> { return device->NewMessage(s); };
+  auto creator = [transport](size_t s) -> std::unique_ptr<FairMQMessage> {
+    return transport->CreateMessage(s);
+  };
   auto buffer = std::make_shared<FairMQResizableBuffer>(creator);
 
   /// To finalise this we write the table to the buffer.
@@ -208,19 +215,19 @@ void DataAllocator::adopt(const Output& spec, TableBuilder* tb)
     doWriteTable(b, table.get());
   };
 
-  context.addBuffer(std::move(header), buffer, std::move(finalizer), channel);
+  context.addBuffer(std::move(header), buffer, std::move(finalizer), routeIndex);
 }
 
 void DataAllocator::adopt(const Output& spec, TreeToTable* t2t)
 {
   auto& timingInfo = mRegistry->get<TimingInfo>();
-  std::string const& channel = matchDataHeader(spec, timingInfo.timeslice);
+  RouteIndex routeIndex = matchDataHeader(spec, timingInfo.timeslice);
 
-  auto header = headerMessageFromOutput(spec, channel, o2::header::gSerializationMethodArrow, 0);
+  auto header = headerMessageFromOutput(spec, routeIndex, o2::header::gSerializationMethodArrow, 0);
   auto& context = mRegistry->get<ArrowContext>();
 
-  auto creator = [device = context.proxy().getDevice()](size_t s) -> std::unique_ptr<FairMQMessage> {
-    return device->NewMessage(s);
+  auto creator = [transport = context.proxy().getTransport(routeIndex)](size_t s) -> std::unique_ptr<FairMQMessage> {
+    return transport->CreateMessage(s);
   };
   auto buffer = std::make_shared<FairMQResizableBuffer>(creator);
 
@@ -233,18 +240,18 @@ void DataAllocator::adopt(const Output& spec, TreeToTable* t2t)
     delete payload;
   };
 
-  context.addBuffer(std::move(header), buffer, std::move(finalizer), channel);
+  context.addBuffer(std::move(header), buffer, std::move(finalizer), routeIndex);
 }
 
 void DataAllocator::adopt(const Output& spec, std::shared_ptr<arrow::Table> ptr)
 {
   auto& timingInfo = mRegistry->get<TimingInfo>();
-  std::string const& channel = matchDataHeader(spec, timingInfo.timeslice);
-  auto header = headerMessageFromOutput(spec, channel, o2::header::gSerializationMethodArrow, 0);
+  RouteIndex routeIndex = matchDataHeader(spec, timingInfo.timeslice);
+  auto header = headerMessageFromOutput(spec, routeIndex, o2::header::gSerializationMethodArrow, 0);
   auto& context = mRegistry->get<ArrowContext>();
 
-  auto creator = [device = context.proxy().getDevice()](size_t s) -> std::unique_ptr<FairMQMessage> {
-    return device->NewMessage(s);
+  auto creator = [transport = context.proxy().getTransport(routeIndex)](size_t s) -> std::unique_ptr<FairMQMessage> {
+    return transport->CreateMessage(s);
   };
   auto buffer = std::make_shared<FairMQResizableBuffer>(creator);
 
@@ -252,14 +259,17 @@ void DataAllocator::adopt(const Output& spec, std::shared_ptr<arrow::Table> ptr)
     doWriteTable(b, table.get());
   };
 
-  context.addBuffer(std::move(header), buffer, std::move(writer), channel);
+  context.addBuffer(std::move(header), buffer, std::move(writer), routeIndex);
 }
 
 void DataAllocator::snapshot(const Output& spec, const char* payload, size_t payloadSize,
                              o2::header::SerializationMethod serializationMethod)
 {
-  auto& proxy = mRegistry->get<MessageContext>().proxy();
-  FairMQMessagePtr payloadMessage(proxy.createMessage(payloadSize));
+  auto& proxy = mRegistry->get<FairMQDeviceProxy>();
+  auto& timingInfo = mRegistry->get<TimingInfo>();
+
+  RouteIndex routeIndex = matchDataHeader(spec, timingInfo.timeslice);
+  FairMQMessagePtr payloadMessage(proxy.createMessage(routeIndex, payloadSize));
   memcpy(payloadMessage->GetData(), payload, payloadSize);
 
   addPartToContext(std::move(payloadMessage), spec, serializationMethod);
@@ -296,17 +306,17 @@ void DataAllocator::adoptFromCache(const Output& spec, CacheId id, header::Seria
   // Find a matching channel, extract the message for it form the container
   // and put it in the queue to be sent at the end of the processing
   auto& timingInfo = mRegistry->get<TimingInfo>();
-  std::string const& channel = matchDataHeader(spec, timingInfo.timeslice);
+  RouteIndex routeIndex = matchDataHeader(spec, timingInfo.timeslice);
 
   auto& context = mRegistry->get<MessageContext>();
   FairMQMessagePtr payloadMessage = context.cloneFromCache(id.value);
 
-  FairMQMessagePtr headerMessage = headerMessageFromOutput(spec, channel,            //
+  FairMQMessagePtr headerMessage = headerMessageFromOutput(spec, routeIndex,         //
                                                            method,                   //
                                                            payloadMessage->GetSize() //
   );
 
-  context.add<MessageContext::TrivialObject>(std::move(headerMessage), std::move(payloadMessage), channel);
+  context.add<MessageContext::TrivialObject>(std::move(headerMessage), std::move(payloadMessage), routeIndex);
 }
 
 } // namespace o2::framework

--- a/Framework/Core/src/DataSender.cxx
+++ b/Framework/Core/src/DataSender.cxx
@@ -45,7 +45,7 @@ std::vector<size_t>
 
 DataSender::DataSender(ServiceRegistry& registry,
                        SendingPolicy const& policy)
-  : mContext{registry.get<RawDeviceService>().device()},
+  : mProxy{registry.get<FairMQDeviceProxy>()},
     mRegistry{registry},
     mSpec{registry.get<DeviceSpec const>()},
     mDistinctRoutesIndex{createDistinctOutputRouteIndex(mSpec.outputs)},
@@ -69,16 +69,14 @@ DataSender::DataSender(ServiceRegistry& registry,
   }
 }
 
-std::unique_ptr<FairMQMessage> DataSender::create()
+std::unique_ptr<FairMQMessage> DataSender::create(RouteIndex routeIndex)
 {
-  auto* device = (FairMQDevice*)mContext;
-  return device->NewMessage();
+  return mProxy.getTransport(routeIndex)->CreateMessage();
 }
 
-void DataSender::send(FairMQParts& parts, std::string const& channel)
+void DataSender::send(FairMQParts& parts, ChannelIndex channelIndex)
 {
-  auto* device = (FairMQDevice*)mContext;
-  mPolicy.send(*device, parts, channel);
+  mPolicy.send(mProxy, parts, channelIndex);
 }
 
 } // namespace o2::framework

--- a/Framework/Core/src/MessageContext.cxx
+++ b/Framework/Core/src/MessageContext.cxx
@@ -11,19 +11,22 @@
 
 #include "Framework/Output.h"
 #include "Framework/MessageContext.h"
+#include "Framework/OutputRoute.h"
 #include "fairmq/FairMQDevice.h"
 
 namespace o2::framework
 {
 
-FairMQMessagePtr MessageContext::createMessage(const std::string& channel, int index, size_t size)
+FairMQMessagePtr MessageContext::createMessage(RouteIndex routeIndex, int index, size_t size)
 {
-  return proxy().getDevice()->NewMessageFor(channel, 0, size, fair::mq::Alignment{64});
+  auto* transport = mProxy.getTransport(routeIndex);
+  return transport->CreateMessage(size, fair::mq::Alignment{64});
 }
 
-FairMQMessagePtr MessageContext::createMessage(const std::string& channel, int index, void* data, size_t size, fairmq_free_fn* ffn, void* hint)
+FairMQMessagePtr MessageContext::createMessage(RouteIndex routeIndex, int index, void* data, size_t size, fairmq_free_fn* ffn, void* hint)
 {
-  return proxy().getDevice()->NewMessageFor(channel, 0, data, size, ffn, hint);
+  auto* transport = mProxy.getTransport(routeIndex);
+  return transport->CreateMessage(data, size, ffn, hint);
 }
 
 o2::header::DataHeader* MessageContext::findMessageHeader(const Output& spec)

--- a/Framework/Core/src/RawBufferContext.cxx
+++ b/Framework/Core/src/RawBufferContext.cxx
@@ -18,11 +18,11 @@ namespace o2::framework
 
 void RawBufferContext::addRawBuffer(std::unique_ptr<FairMQMessage> header,
                                     char* payload,
-                                    std::string channel,
+                                    RouteIndex routeIndex,
                                     std::function<std::ostringstream()> serialize,
                                     std::function<void()> destructor)
 {
-  mMessages.push_back(MessageRef{std::move(header), std::move(payload), std::move(channel), std::move(serialize), std::move(destructor)});
+  mMessages.push_back(MessageRef{std::move(header), std::move(payload), routeIndex, std::move(serialize), std::move(destructor)});
 }
 
 void RawBufferContext::clear()

--- a/Framework/Core/src/SendingPolicy.cxx
+++ b/Framework/Core/src/SendingPolicy.cxx
@@ -27,10 +27,14 @@ std::vector<SendingPolicy> SendingPolicy::createDefaultPolicies()
   return {SendingPolicy{
             .name = "dispatcher",
             .matcher = [](DeviceSpec const& spec, ConfigContext const&) { return spec.name == "Dispatcher" || DeviceSpecHelpers::hasLabel(spec, "Dispatcher"); },
-            .send = [](FairMQDevice& device, FairMQParts& parts, std::string const& channel) { device.Send(parts, channel, 0, -1); }},
+            .send = [](FairMQDeviceProxy& proxy, FairMQParts& parts, ChannelIndex channelIndex) {
+              auto *channel = proxy.getChannel(channelIndex);
+              channel->Send(parts, -1); }},
           SendingPolicy{
             .name = "default",
             .matcher = [](DeviceSpec const&, ConfigContext const&) { return true; },
-            .send = [](FairMQDevice& device, FairMQParts& parts, std::string const& channel) { device.Send(parts, channel, 0); }}};
+            .send = [](FairMQDeviceProxy& proxy, FairMQParts& parts, ChannelIndex channelIndex) { 
+              auto *channel = proxy.getChannel(channelIndex);
+              channel->Send(parts); }}};
 }
 } // namespace o2::framework

--- a/Framework/Core/src/StringContext.cxx
+++ b/Framework/Core/src/StringContext.cxx
@@ -18,11 +18,11 @@ namespace o2::framework
 
 void StringContext::addString(std::unique_ptr<FairMQMessage> header,
                               std::unique_ptr<std::string> s,
-                              const std::string& channel)
+                              RouteIndex routeIndex)
 {
   mMessages.push_back(std::move(MessageRef{std::move(header),
                                            std::move(s),
-                                           channel}));
+                                           routeIndex}));
 }
 
 void StringContext::clear()

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -1053,6 +1053,7 @@ int doChild(int argc, char** argv, ServiceRegistry& serviceRegistry,
   std::unique_ptr<SimpleRawDeviceService> simpleRawDeviceService;
   std::unique_ptr<DeviceState> deviceState;
   std::unique_ptr<ComputingQuotaEvaluator> quotaEvaluator;
+  std::unique_ptr<FairMQDeviceProxy> deviceProxy;
 
   auto afterConfigParsingCallback = [&simpleRawDeviceService,
                                      &runningWorkflow,
@@ -1061,6 +1062,7 @@ int doChild(int argc, char** argv, ServiceRegistry& serviceRegistry,
                                      &quotaEvaluator,
                                      &serviceRegistry,
                                      &deviceState,
+                                     &deviceProxy,
                                      &processingPolicies,
                                      &loop](fair::mq::DeviceRunner& r) {
     simpleRawDeviceService = std::make_unique<SimpleRawDeviceService>(nullptr, spec);

--- a/Framework/Core/test/test_ParallelPipeline.cxx
+++ b/Framework/Core/test/test_ParallelPipeline.cxx
@@ -193,11 +193,12 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
       });
       return adaptStateless([checkMap, bindings = std::move(bindings)](InputRecord& inputs) {
         bool haveDataIn = false;
+        size_t index = 0;
         for (auto const& input : inputs) {
           if (!DataRefUtils::isValid(input)) {
             continue;
           }
-          LOG(debug) << "consuming : " << *input.spec << ": " << *((int*)input.payload);
+          LOG(info) << "consuming : " << *input.spec << ": " << *((int*)input.payload);
           auto const* dataheader = DataRefUtils::getHeader<o2::header::DataHeader*>(input);
           if (input.spec->binding.compare(0, 6, "datain") == 0) {
             if (input.spec->binding != bindings.at(dataheader->subSpecification)) {

--- a/Framework/Core/test/test_StaggeringWorkflow.cxx
+++ b/Framework/Core/test/test_StaggeringWorkflow.cxx
@@ -111,6 +111,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const&)
       }
       nActiveInputs++;
     }
+    LOG(info) << "processed " << nActiveInputs << " inputs";
     // since we publish with delays, and two channels are always sent together
     ASSERT_ERROR(nActiveInputs == 2);
   };

--- a/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
+++ b/Framework/TestWorkflows/src/o2DiamondWorkflow.cxx
@@ -47,9 +47,10 @@ void customize(std::vector<SendingPolicy>& policies)
 {
   policies.push_back(SendingPolicy{
     .matcher = DeviceMatchers::matchByName("A"),
-    .send = [](FairMQDevice& device, FairMQParts& parts, std::string const& channel) {
+    .send = [](FairMQDeviceProxy& proxy, FairMQParts& parts, ChannelIndex channelIndex) {
       LOG(info) << "A custom policy for sending invoked!";
-      device.Send(parts, channel, 0);
+      auto* channel = proxy.getChannel(channelIndex);
+      channel->Send(parts, 0);
     }});
 }
 


### PR DESCRIPTION
This reworks how sending messages works, by keeping track of
the specific routes used to send messages, rather than simply
keeping track of the FairMQ channel name. This should allow
us to assess wether or not a given route has messages associated
to it and therefore wether or not:

* Mandatory inputs are there
* Sporadic inputs are not

As a bonus, we get rid of the convoluted and slow matching by string,
we possibly avoid a copy when the message is created using the wrong
transport and we isolate even further message sending in
FairMQDeviceProxy.

FIXME: does not actually work because the
FairMQDeviceProxy::bindRoutes() method is not yet implemented. I will
look at it tomorrow.