### PR TITLE
Digital and analog scan in ITS calibration workflow

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdCalibratorSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdCalibratorSpec.h
@@ -35,7 +35,7 @@
 #include "Framework/RawDeviceService.h"
 #include "Framework/WorkflowSpec.h"
 #include "Framework/Task.h"
-#include <FairMQDevice.h>
+#include <fairmq/Device.h>
 
 #include <ITSMFTReconstruction/RawPixelDecoder.h> //o2::itsmft::RawPixelDecoder
 #include "DetectorsCalibration/Utils.h"


### PR DESCRIPTION
Analysis for digital and analog scan included in calibration workflow. The analysis is the same for the two calibration scans. Options/Features added:

- ```--enable-cw-cnt-check```: allow to check if calibration word counter is the expected one when injections are finished on a given row
- ```--enable-single-pix-tag```: allow to enable/disable single-noisy-pix tagging in digital/analog scans 
-  Spurious hits removed when row is not the expected one 
- Digital/Analog scans produce a ROOT Tree with row, col, n_hits of every pixel injected and a DCS CCDB object (DCSConfigObject_t) with the list of bad pixels (if previous option enabled) and bad double columns to be masked for every chip. 
- Support for non-end-of-stream operations included also for digital and analog scans. 
cc @chiarazampolli @shahor02 
