### PR TITLE
adding LOG and exception handling in the clean cache

### DIFF
--- a/Common/Utils/src/FileSystemUtils.cxx
+++ b/Common/Utils/src/FileSystemUtils.cxx
@@ -42,7 +42,6 @@ std::vector<std::string> listFiles(std::string const& dir, std::string const& se
       	}
     	}
     }catch(...){
-      LOG(info) << "Invalid file " << p << " from /tmp ";
       continue;
    }
   }

--- a/Common/Utils/src/FileSystemUtils.cxx
+++ b/Common/Utils/src/FileSystemUtils.cxx
@@ -18,6 +18,8 @@
 #include <vector>
 #include <regex>
 #include <iostream>
+#include "FairLogger.h"
+
 
 namespace o2::utils
 {
@@ -32,12 +34,17 @@ std::vector<std::string> listFiles(std::string const& dir, std::string const& se
   std::regex str_expr(rs);
 
   for (auto& p : std::filesystem::directory_iterator(dir)) {
-    if (!p.is_directory()) {
-      auto fn = p.path().filename().string();
-      if (regex_match(fn, str_expr)) {
-        filenames.push_back(p.path().string());
-      }
-    }
+    try {
+    	if (!p.is_directory()) {
+     		 auto fn = p.path().filename().string();
+      		if (regex_match(fn, str_expr)) {
+        	filenames.push_back(p.path().string());
+      	}
+    	}
+    }catch(...){
+      LOG(info) << "Invalid file " << p << " from /tmp ";
+      continue;
+   }
   }
   return filenames;
 }

--- a/run/o2sim_parallel.cxx
+++ b/run/o2sim_parallel.cxx
@@ -71,17 +71,29 @@ void remove_tmp_files()
 {
   // remove all (known) socket files in /tmp
   // using the naming convention /tmp/o2sim-.*PID
+  //printf("remove_tmp_files\n");     
+  LOG(info) << "remove_tmp_files: BEGIN ";
   std::stringstream searchstr;
   searchstr << "o2sim-.*-" << getpid() << "$";
   auto filenames = o2::utils::listFiles("/tmp/", searchstr.str());
+  LOG(info) << "remove_tmp_files: list files ";
   // remove those files
   for (auto& fn : filenames) {
-    std::filesystem::remove(std::filesystem::path(fn));
+    LOG(info) << "Removing file " << fn << " from /tmp ";
+    continue;
+    try{
+    	std::filesystem::remove(std::filesystem::path(fn));
+    }
+    catch(...){
+        LOG(info) << "Invalid file " << fn << " from /tmp ";
+    }
   }
+  LOG(info) << "remove_tmp_files: END ";
 }
 
 void cleanup()
 {
+  LOG(info) << "cleanup: BEGIN ";
   remove_tmp_files();
   o2::utils::ShmManager::Instance().release();
 

--- a/run/o2sim_parallel.cxx
+++ b/run/o2sim_parallel.cxx
@@ -76,16 +76,14 @@ void remove_tmp_files()
   std::stringstream searchstr;
   searchstr << "o2sim-.*-" << getpid() << "$";
   auto filenames = o2::utils::listFiles("/tmp/", searchstr.str());
-  LOG(info) << "remove_tmp_files: list files ";
   // remove those files
   for (auto& fn : filenames) {
-    LOG(info) << "Removing file " << fn << " from /tmp ";
     continue;
     try{
     	std::filesystem::remove(std::filesystem::path(fn));
     }
     catch(...){
-        LOG(info) << "Invalid file " << fn << " from /tmp ";
+        LOG(warn) << "Invalid file " << fn << " from /tmp ";
     }
   }
   LOG(info) << "remove_tmp_files: END ";
@@ -93,7 +91,6 @@ void remove_tmp_files()
 
 void cleanup()
 {
-  LOG(info) << "cleanup: BEGIN ";
   remove_tmp_files();
   o2::utils::ShmManager::Instance().release();
 


### PR DESCRIPTION
Hello @sawenzel 

These changes solved the cache clean-up problems I described in an earlier email. 
It was important to include their try-catch in the file listing

The logging is too verbose, I kept it verbose to demonstrate the problem. Feel free to remove the part that is not necessary.
