### PR TITLE
[MCH MID] enable input/output tracks readers/writer from/to root file

### DIFF
--- a/Detectors/ITSMFT/MFT/README.md
+++ b/Detectors/ITSMFT/MFT/README.md
@@ -92,14 +92,7 @@ More details about these workflows are available at the documentation for [MCH](
 
 ### MCH-MID matching
 
-Workflow: `MCH and MID track reader workflows -> Muon tracks matcher workflow`
-
-Example:
-```bash
-o2-mch-tracks-reader-workflow | o2-mid-tracks-reader-workflow | o2-muon-tracks-matcher-workflow | o2-muon-tracks-writer-workflow
-```
-
-The muon matcher workflows produces `muontracks.root`, which containes only track-matching information, as defined in [TrackMCHMID.h](../../../DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackMCHMID.h).
+`o2-muon-tracks-matcher-workflow` runs MCH-MID matching, using MCH tracks (`mchtracks.root`) and MID tracks (`mid-reco.root`). By default it produces `muontracks.root`, which contains only track-matching information, as defined in [TrackMCHMID.h](../../../DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackMCHMID.h).
 
 ### MFT-MCH-MID matching
 

--- a/Detectors/MUON/Matching/README.md
+++ b/Detectors/MUON/Matching/README.md
@@ -24,7 +24,7 @@ The sigma cut is configurable via the command line or an INI or JSON configurati
 
 ## Example of workflow
 
-`o2-mch-tracks-reader-workflow | o2-mid-tracks-reader-workflow | o2-muon-tracks-matcher-workflow | o2-muon-tracks-writer-workflow`
+`o2-muon-tracks-matcher-workflow --disable-mc`
 
 This takes as input the root files with MCH and MID tracks and ROFs and gives as ouput a root file with the matched tracks.
 

--- a/Detectors/MUON/Workflow/CMakeLists.txt
+++ b/Detectors/MUON/Workflow/CMakeLists.txt
@@ -11,9 +11,9 @@
 
 o2_add_executable(
         tracks-matcher-workflow
-        SOURCES src/TrackMatcherSpec.cxx src/tracks-matcher-workflow.cxx
+        SOURCES src/TrackMatcherSpec.cxx src/TrackWriterSpec.cxx src/tracks-matcher-workflow.cxx
         COMPONENT_NAME muon
-        PUBLIC_LINK_LIBRARIES O2::Framework O2::MUONMatching)
+        PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::MCHWorkflow O2::MIDWorkflow O2::MUONMatching)
 
 o2_add_executable(
         tracks-writer-workflow

--- a/Detectors/MUON/Workflow/README.md
+++ b/Detectors/MUON/Workflow/README.md
@@ -17,7 +17,13 @@
 o2-muon-tracks-matcher-workflow
 ```
 
-Take as input the lists of MCH tracks ([TrackMCH](../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)), MCH ROF records ([ROFRecord](../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)), MID tracks ([Track](../../../DataFormats/Detectors/MUON/MID/include/DataFormatsMID/Track.h)) and MID ROF records ([ROFRecord](../../../DataFormats/Detectors/MUON/MID/include/DataFormatsMID/ROFRecord.h)) in the current time frame, with the data descriptions  "MCH/TRACKS", "MCH/TRACKROFS", "MID/TRACKS" and "MID/TRACKROFS", respectively. Send the list of matched tracks ([TrackMCHMID](../../../DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackMCHMID.h)) in the time frame, with the data description "GLO/MCHMID".
+Take as input the lists of MCH tracks ([TrackMCH](../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)), MCH ROF records ([ROFRecord](../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)), MID tracks ([Track](../../../DataFormats/Detectors/MUON/MID/include/DataFormatsMID/Track.h)) and MID ROF records ([ROFRecord](../../../DataFormats/Detectors/MUON/MID/include/DataFormatsMID/ROFRecord.h)) in the current time frame, with the data descriptions "MCH/TRACKS", "MCH/TRACKROFS", "MID/TRACKS" and "MID/TRACKROFS", respectively. Send the list of matched tracks ([TrackMCHMID](../../../DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackMCHMID.h)) in the time frame, with the data description "GLO/MCHMID".
+
+Option `--disable-root-input` disables the reading of the input MCH and MID tracks from `mchtracks.root` and `mid-reco.root`, respectively.
+
+Option `--disable-root-output` disables the writing of the ouput matched tracks to `muontracks.root`.
+
+Option `--disable-mc` disables the reading, processing and writing of the MC label informations.
 
 Option `--config "file.json"` or `--config "file.ini"` allows to change the matching parameters from a configuration file. This file can be either in JSON or in INI format, as described below:
 

--- a/Detectors/MUON/Workflow/src/TrackWriterSpec.h
+++ b/Detectors/MUON/Workflow/src/TrackWriterSpec.h
@@ -24,7 +24,7 @@ namespace o2
 namespace muon
 {
 
-framework::DataProcessorSpec getTrackWriterSpec(const char* specName = "TrackWriter",
+framework::DataProcessorSpec getTrackWriterSpec(const char* specName = "muon-track-writer",
                                                 const char* fileName = "muontracks.root");
 
 } // namespace muon

--- a/Detectors/MUON/Workflow/src/tracks-matcher-workflow.cxx
+++ b/Detectors/MUON/Workflow/src/tracks-matcher-workflow.cxx
@@ -16,6 +16,7 @@
 
 #include <string>
 #include <vector>
+#include "Framework/CompletionPolicyHelpers.h"
 #include "Framework/ConfigParamSpec.h"
 #include "Framework/ConfigContext.h"
 #include "Framework/WorkflowSpec.h"
@@ -27,6 +28,12 @@
 #include "TrackWriterSpec.h"
 
 using namespace o2::framework;
+
+void customize(std::vector<CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:MUON|muon).*[W,w]riter.*"));
+}
 
 // we need to add workflow options before including Framework/runDataProcessing
 void customize(std::vector<ConfigParamSpec>& workflowOptions)

--- a/Detectors/MUON/Workflow/src/tracks-writer-workflow.cxx
+++ b/Detectors/MUON/Workflow/src/tracks-writer-workflow.cxx
@@ -21,7 +21,7 @@ using namespace o2::framework;
 void customize(std::vector<o2::framework::CompletionPolicy>& policies)
 {
   // ordered policies for the writers
-  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:MCH|mch).*[W,w]riter.*"));
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:MUON|muon).*[W,w]riter.*"));
 }
 
 #include "Framework/runDataProcessing.h"

--- a/prodtests/sim_challenge.sh
+++ b/prodtests/sim_challenge.sh
@@ -180,7 +180,7 @@ if [ "$doreco" == "1" ]; then
   echo "Return status of midreco: $?"
 
   echo "Running MCH-MID matching flow"
-  taskwrapper mchmidMatch.log "o2-mch-tracks-reader-workflow | o2-mid-tracks-reader-workflow | o2-muon-tracks-matcher-workflow | o2-muon-tracks-writer-workflow $gloOpt"
+  taskwrapper mchmidMatch.log "o2-muon-tracks-matcher-workflow $gloOpt"
   echo "Return status of mchmidmatch: $?"
 
   echo "Running ITS-TPC matching flow"


### PR DESCRIPTION
This will allow to add this workflow to the full system test with the standard input/output options