### PR TITLE
DPL Analysis: prevent spawner from creating DYN tables that are already provided

### DIFF
--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -101,8 +101,8 @@ struct Produces {
 /// given analysis task. Notice how the actual cursor is implemented by the
 /// means of the WritingCursor helper class, from which produces actually
 /// derives.
-template <typename... C>
-struct Produces<soa::Table<C...>> : WritingCursor<typename soa::PackToTable<typename soa::Table<C...>::persistent_columns_t>::table> {
+template <template <typename...> class T, typename... C>
+struct Produces<T<C...>> : WritingCursor<typename soa::PackToTable<typename T<C...>::table_t::persistent_columns_t>::table> {
   using table_t = soa::Table<C...>;
   using metadata = typename aod::MetadataTrait<table_t>::metadata;
 

--- a/Framework/Core/src/WorkflowHelpers.h
+++ b/Framework/Core/src/WorkflowHelpers.h
@@ -184,7 +184,8 @@ struct WorkflowHelpers {
   static void addMissingOutputsToReader(std::vector<OutputSpec> const& providedOutputs,
                                         std::vector<InputSpec> requestedInputs,
                                         DataProcessorSpec& publisher);
-  static void addMissingOutputsToSpawner(std::vector<InputSpec> const& requestedSpecials,
+  static void addMissingOutputsToSpawner(std::vector<OutputSpec> const& providedSpecials,
+                                         std::vector<InputSpec> const& requestedSpecials,
                                          std::vector<InputSpec>& requestedAODs,
                                          DataProcessorSpec& publisher);
   static void addMissingOutputsToBuilder(std::vector<InputSpec> const& requestedSpecials,


### PR DESCRIPTION
Supporting #8348 