### PR TITLE
Revert "Workaround: temporarily support multiple ms_gsl versions"

### DIFF
--- a/Framework/Core/include/Framework/TMessageSerializer.h
+++ b/Framework/Core/include/Framework/TMessageSerializer.h
@@ -19,13 +19,9 @@
 #include <TMessage.h>
 #include <TObjArray.h>
 #include <TStreamerInfo.h>
-#include <gsl/span>
-#if __has_include(<gsl/util>)
 #include <gsl/util>
+#include <gsl/span>
 #include <gsl/narrow>
-#else
-#include <gsl/gsl_util>
-#endif
 #include <memory>
 #include <mutex>
 #include <cstddef>


### PR DESCRIPTION
This drops support folder older ms_gsl versions. @ktf : what do you think? I think in the meantime we can merge this?