### PR TITLE
[EMCAL-566]: Optimized EMCal time calibration

### DIFF
--- a/Detectors/EMCAL/calibration/CMakeLists.txt
+++ b/Detectors/EMCAL/calibration/CMakeLists.txt
@@ -14,6 +14,7 @@ o2_add_library(EMCALCalibration
                SOURCES  src/EMCALChannelData.cxx
                         src/EMCALTimeCalibData.cxx
                         src/EMCALCalibExtractor.cxx
+                        src/EMCALCalibParams.cxx
                PUBLIC_LINK_LIBRARIES O2::CCDB O2::EMCALBase
                                      O2::EMCALCalib
                                      O2::CommonUtils
@@ -29,6 +30,7 @@ o2_target_root_dictionary(EMCALCalibration
                                   include/EMCALCalibration/EMCALChannelCalibrator.h
                                   include/EMCALCalibration/EMCALChannelData.h
                                   include/EMCALCalibration/EMCALTimeCalibData.h
+                                  include/EMCALCalibration/EMCALCalibParams.h
                           LINKDEF src/EMCALCalibrationLinkDef.h)
 
 o2_add_executable(emcal-channel-calib-workflow

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibParams.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibParams.h
@@ -1,0 +1,42 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \class EMCALCalibInitParams
+/// \brief  Init parameters for emcal calibrations
+/// \author Joshua Koenig
+/// \ingroup EMCALCalib
+/// \since Apr 5, 2022
+
+#ifndef EMCAL_CALIB_INIT_PARAMS_H_
+#define EMCAL_CALIB_INIT_PARAMS_H_
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "CommonUtils/ConfigurableParamHelper.h"
+
+namespace o2
+{
+namespace emcal
+{
+
+// class containing the parameters to trigger the calibrations
+struct EMCALCalibParams : public o2::conf::ConfigurableParamHelper<EMCALCalibParams> {
+
+  unsigned int minNEvents = 1e6;
+  unsigned int minNEntries = 1e5;
+  bool useNEventsForCalib = true;
+
+  O2ParamDef(EMCALCalibParams, "EMCALCalibParams");
+};
+
+} // namespace emcal
+} // namespace o2
+
+#endif /*EMCAL_CALIB_INIT_PARAMS_H_ */

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelCalibrator.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelCalibrator.h
@@ -21,6 +21,7 @@
 #include "EMCALCalibration/EMCALTimeCalibData.h"
 #include "EMCALCalibration/EMCALChannelData.h"
 #include "EMCALCalibration/EMCALCalibExtractor.h"
+#include "EMCALCalibration/EMCALCalibParams.h"
 #include "DetectorsCalibration/TimeSlotCalibration.h"
 #include "DetectorsCalibration/TimeSlot.h"
 #include "DataFormatsEMCAL/Cell.h"
@@ -73,28 +74,23 @@ class EMCALChannelCalibrator : public o2::calibration::TimeSlotCalibration<o2::e
   void setIsTest(bool isTest) { mTest = isTest; }
   bool isTest() const { return mTest; }
 
-  ///\brief Set number of entries required to trigger calibration
-  void setMinNEntries(const int nEntr) { minEntries = nEntr; }
-  int getMinNEntries() const { return minEntries; }
-
-  ///\brief Set number of entries required to trigger calibration
+  ///\brief Set path to local root file for storage of calibration histograms
   void setLocalStorePath(const std::string path) { namePathStoreLocal = path; }
   std::string getLocalStorePath() const { return namePathStoreLocal; }
 
   const CcdbObjectInfoVector& getInfoVector() const { return mInfoVector; }
   const std::vector<DataOutput>& getOutputVector() const { return mCalibObjectVector; }
 
-  // Configure the calibrator
+  /// \brief Configure the calibrator
   std::shared_ptr<EMCALCalibExtractor> getCalibExtractor() { return mCalibrator; } // return shared pointer!
+  /// \brief setter for mCalibrator
   void SetCalibExtractor(std::shared_ptr<EMCALCalibExtractor> extr) { mCalibrator = extr; };
-  // setter for mCalibrator
 
  private:
   int mNBins = 0;     ///< bins of the histogram for passing
   float mRange = 0.;  ///< range of the histogram for passing
   bool mTest = false; ///< flag to be used when running in test mode: it simplify the processing (e.g. does not go through all channels)
   std::shared_ptr<EMCALCalibExtractor> mCalibrator;
-  double minEntries = 1e3;
   std::string namePathStoreLocal;
 
   // output
@@ -109,6 +105,8 @@ template <typename DataInput, typename DataOutput, typename HistContainer>
 void EMCALChannelCalibrator<DataInput, DataOutput, HistContainer>::initOutput()
 {
   mInfoVector.clear();
+  mCalibObjectVector.clear();
+  // mNEvents = 0;
   return;
 }
 
@@ -117,7 +115,7 @@ template <typename DataInput, typename DataOutput, typename HistContainer>
 bool EMCALChannelCalibrator<DataInput, DataOutput, HistContainer>::hasEnoughData(const o2::calibration::TimeSlot<DataInput>& slot) const
 {
   const DataInput* c = slot.getContainer();
-  return (mTest ? true : c->hasEnoughData(minEntries));
+  return (mTest ? true : c->hasEnoughData());
 }
 
 //_____________________________________________
@@ -139,9 +137,12 @@ void EMCALChannelCalibrator<DataInput, DataOutput, HistContainer>::finalizeSlot(
     mCalibObjectVector.push_back(bcm);
   } else if constexpr (std::is_same<DataInput, o2::emcal::EMCALTimeCalibData>::value) {
     auto tcd = mCalibrator->calibrateTime(c->getHisto());
+
     // for the CCDB entry
     auto clName = o2::utils::MemFileHelper::getClassName(slot);
     auto flName = o2::ccdb::CcdbApi::generateFileName(clName);
+
+    //prepareCCDBobjectInfo
     mInfoVector.emplace_back(CalibDB::getCDBPathTimeCalibrationParams(), clName, flName, md, slot.getTFStart(), 99999999999999);
     mCalibObjectVector.push_back(tcd);
 

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelData.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelData.h
@@ -24,6 +24,7 @@
 // #include "EMCALCalib/BadChannelMap.h"
 // #include "EMCALCalib/TimeCalibrationParams.h"
 #include "EMCALCalibration/EMCALCalibExtractor.h"
+#include "EMCALCalibration/EMCALCalibParams.h"
 #include "DataFormatsEMCAL/Cell.h"
 #include "EMCALBase/Geometry.h"
 // #include "CCDB/CcdbObjectInfo.h"
@@ -84,8 +85,10 @@ class EMCALChannelData
   void fill(const gsl::span<const o2::emcal::Cell> data);
   /// \brief Merge the data of two slots.
   void merge(const EMCALChannelData* prev);
-  int findBin(float v) const;
-  bool hasEnoughData(const int minNEntries) const;
+  // int findBin(float v) const;
+  /// \brief Check if enough stataistics was accumulated to perform calibration
+  bool hasEnoughData() const;
+  /// \brief Get current calibration histogram
   boostHisto& getHisto() { return mHisto; }
   const boostHisto& getHisto() const { return mHisto; }
 
@@ -102,13 +105,13 @@ class EMCALChannelData
   void setNbins(int nb) { mNBins = nb; }
 
   int getNEvents() const { return mEvents; }
-  void setNEvents(int ne) { mEvents = ne; }
+  void setNEvents(int nevt) { mEvents = nevt; }
 
  private:
   float mRange = 0.35; // looked at old QA plots where max was 0.35 GeV, might need to be changed
   int mNBins = 1000;
   boostHisto mHisto;
-  int mEvents = 1;
+  int mEvents = 0;
   boostHisto mEsumHisto;                                ///< contains the average energy per hit for each cell
   boostHisto mEsumHistoScaled;                          ///< contains the average energy (scaled) per hit for each cell
   boostHisto mCellAmplitude;                            ///< is the input for the calibration, hist of cell E vs. ID

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALTimeCalibData.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALTimeCalibData.h
@@ -24,6 +24,7 @@
 #include "EMCALBase/Geometry.h"
 #include "CCDB/CcdbObjectInfo.h"
 #include "EMCALCalib/TimeCalibrationParams.h"
+#include "EMCALCalibration/EMCALCalibParams.h"
 
 #include "Framework/Logger.h"
 #include "CommonUtils/MemFileHelper.h"
@@ -74,20 +75,21 @@ class EMCALTimeCalibData
   void merge(const EMCALTimeCalibData* prev);
 
   /// \brief Check if enough data for calibration has been accumulated
-  bool hasEnoughData(int minNEntries) const;
+  bool hasEnoughData() const;
 
   /// \brief Print a useful message about the container.
   void print();
 
+  /// \brief Set number of events available for calibration
+  void setNEvents(int nevt) { mEvents = nevt; }
+  /// \brief Add number of events available for calibration
+  void AddEvents(int nevt) { mEvents += nevt; }
   /// \brief Get number of events currently available for calibration
   int getNEvents() const { return mEvents; }
 
   /// \brief Get current histogram
   boostHisto& getHisto() { return mTimeHisto; }
   const boostHisto& getHisto() const { return mTimeHisto; }
-
-  /// \brief Set number of events available for calibration
-  void setNEvents(int ne) { mEvents = ne; }
 
   void PrintStream(std::ostream& stream) const;
 

--- a/Detectors/EMCAL/calibration/src/EMCALCalibParams.cxx
+++ b/Detectors/EMCAL/calibration/src/EMCALCalibParams.cxx
@@ -1,0 +1,13 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "EMCALCalibration/EMCALCalibParams.h"
+O2ParamImpl(o2::emcal::EMCALCalibParams);

--- a/Detectors/EMCAL/calibration/src/EMCALCalibrationLinkDef.h
+++ b/Detectors/EMCAL/calibration/src/EMCALCalibrationLinkDef.h
@@ -23,4 +23,7 @@
 #pragma link C++ class o2::calibration::TimeSlot < o2::emcal::EMCALTimeCalibData> + ;
 #pragma link C++ class o2::calibration::TimeSlotCalibration < o2::emcal::Cell, o2::emcal::EMCALTimeCalibData> + ;
 
+#pragma link C++ class o2::emcal::EMCALCalibParams + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::emcal::EMCALCalibParams> + ;
+
 #endif

--- a/Detectors/EMCAL/calibration/src/EMCALChannelData.cxx
+++ b/Detectors/EMCAL/calibration/src/EMCALChannelData.cxx
@@ -47,6 +47,8 @@ std::ostream& operator<<(std::ostream& stream, const EMCALChannelData& emcdata)
 //_____________________________________________
 void EMCALChannelData::fill(const gsl::span<const o2::emcal::Cell> data)
 {
+  //the fill function is called once per event
+  mEvents++;
   for (auto cell : data) {
     Double_t cellEnergy = cell.getEnergy();
     Int_t id = cell.getTower();
@@ -67,19 +69,19 @@ void EMCALChannelData::merge(const EMCALChannelData* prev)
 }
 
 //_____________________________________________
-bool EMCALChannelData::hasEnoughData(const int minNEntries) const
+bool EMCALChannelData::hasEnoughData() const
 {
-  // true if we have enough data, also want to check for the sync trigger
-  // this is stil to be finalized, simply a skeletron for now
-
-  // if we have the sync trigger, finalize the slot anyway
-
-  //finalizeOldestSlot(Slot& slot);
-
-  // TODO: use event counter here to specify the value of enough
-  // guess and then adjust number of events as needed
-  // checking mEvents
-  bool enough;
+  bool enough = false;
+  double entries = boost::histogram::algorithm::sum(mEsumHisto);
+  LOG(debug) << "entries: " << entries << " needed: " << EMCALCalibParams::Instance().minNEntries << "  mEvents = " << mEvents;
+  // use enrties in histogram for calibration
+  if (!EMCALCalibParams::Instance().useNEventsForCalib && entries > EMCALCalibParams::Instance().minNEntries) {
+    enough = true;
+  }
+  // use number of events (from emcal trigger record) for calibration
+  if (EMCALCalibParams::Instance().useNEventsForCalib && mEvents > EMCALCalibParams::Instance().minNEvents) {
+    enough = true;
+  }
 
   return enough;
 }

--- a/Detectors/EMCAL/calibration/testWorkflow/emc-channel-calib-workflow.cxx
+++ b/Detectors/EMCAL/calibration/testWorkflow/emc-channel-calib-workflow.cxx
@@ -35,8 +35,7 @@ using namespace o2::emcal;
 // including Framework/runDataProcessing
 void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
-  std::vector<ConfigParamSpec> options{{"minNumEntries", VariantType::Int, 10000, {"minimum number of entries in histogram to trigger calibration"}},
-                                       {"calibMode", VariantType::String, "badcell", {"specify time for time calib or badcell for bad channel calib"}},
+  std::vector<ConfigParamSpec> options{{"calibMode", VariantType::String, "badcell", {"specify time for time calib or badcell for bad channel calib"}},
                                        {"localRootFilePath", VariantType::String, "", {"path to local root file for storage of calibration params"}},
                                        {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
 
@@ -47,13 +46,13 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  int minNEntries = cfgc.options().get<int>("minNumEntries");
   std::string strCalibType = cfgc.options().get<std::string>("calibMode");
   std::string strFilePath = cfgc.options().get<std::string>("localRootFilePath");
 
   WorkflowSpec specs;
+  specs.emplace_back(getEMCALChannelCalibDeviceSpec(strCalibType, strFilePath));
+
   o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
-  specs.emplace_back(getEMCALChannelCalibDeviceSpec(minNEntries, strCalibType, strFilePath));
 
   // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
   // o2::raw::HBFUtilsInitializer hbfIni(cfgc, specs);


### PR DESCRIPTION
- Writing to the ccdb now implemented (and checked using the test-ccdb)
- Included EMCALCalibParams to steer when the calibration should be
triggered. Can be done on the basis of entres in the histogram or the
number of events obtained from the EMCAL trigger record
- Fixed resetting of the histograms after the calibration is
triggered