### PR TITLE
Adding DataDescriptionMatcher operation 'Not'

### DIFF
--- a/Framework/Core/include/Framework/DataDescriptorMatcher.h
+++ b/Framework/Core/include/Framework/DataDescriptorMatcher.h
@@ -259,6 +259,7 @@ class DataDescriptorMatcher
 {
  public:
   enum struct Op { Just,
+                   Not,
                    Or,
                    And,
                    Xor };

--- a/Framework/Core/src/DataDescriptorMatcher.cxx
+++ b/Framework/Core/src/DataDescriptorMatcher.cxx
@@ -243,6 +243,8 @@ bool DataDescriptorMatcher::match(char const* d, VariableContext& context) const
   //     return std::visit(eval, mLeft) ^ std::visit(eval, mRight);
   //   case Op::Just:
   //     return std::visit(eval, mLeft);
+  //   case Op::Not:
+  //     return !std::visit(eval, mLeft);
   // }
   //  When we drop support for macOS 10.13
   if (auto pval0 = std::get_if<OriginValueMatcher>(&mLeft)) {
@@ -287,6 +289,9 @@ bool DataDescriptorMatcher::match(char const* d, VariableContext& context) const
   if (mOp == Op::Just) {
     return leftValue;
   }
+  if (mOp == Op::Not) {
+    return !leftValue;
+  }
 
   if (auto pval0 = std::get_if<OriginValueMatcher>(&mRight)) {
     auto dh = o2::header::get<header::DataHeader*>(d);
@@ -317,6 +322,8 @@ bool DataDescriptorMatcher::match(char const* d, VariableContext& context) const
       return leftValue ^ rightValue;
     case Op::Just:
       return leftValue;
+    case Op::Not:
+      return !leftValue;
   }
   throw runtime_error("Bad parsing tree");
 };
@@ -383,7 +390,11 @@ bool DataDescriptorMatcher::operator==(DataDescriptorMatcher const& other) const
   }
 
   if (mOp == Op::Just) {
-    return true;
+    return leftValue;
+  }
+
+  if (mOp == Op::Not) {
+    return leftValue;
   }
 
   {
@@ -478,6 +489,9 @@ std::ostream& operator<<(std::ostream& os, DataDescriptorMatcher::Op const& op)
       break;
     case DataDescriptorMatcher::Op::Just:
       os << "just";
+      break;
+    case DataDescriptorMatcher::Op::Not:
+      os << "not";
       break;
     case DataDescriptorMatcher::Op::Xor:
       os << "xor";

--- a/Framework/Core/test/test_DataDescriptorMatcher.cxx
+++ b/Framework/Core/test/test_DataDescriptorMatcher.cxx
@@ -153,6 +153,28 @@ BOOST_AUTO_TEST_CASE(TestMatcherInvariants)
           ConstantValueMatcher{true}))};
     BOOST_CHECK_EQUAL(matcherA, matcherB);
   }
+
+  {
+    DataDescriptorMatcher matcherA{
+      DataDescriptorMatcher::Op::Not,
+      OriginValueMatcher{"TPC"}};
+    DataDescriptorMatcher matcherB{
+      DataDescriptorMatcher::Op::Not,
+      DescriptionValueMatcher{"TRACKLET"}};
+    DataDescriptorMatcher matcherC{
+      DataDescriptorMatcher::Op::Not,
+      SubSpecificationTypeValueMatcher{1}};
+
+    BOOST_CHECK(matcherA.match(header0, context) == false);
+    BOOST_CHECK(matcherA.match(header1, context) == true);
+    BOOST_CHECK(matcherA.match(header4, context) == true);
+    BOOST_CHECK(matcherB.match(header0, context) == true);
+    BOOST_CHECK(matcherB.match(header1, context) == false);
+    BOOST_CHECK(matcherB.match(header4, context) == false);
+    BOOST_CHECK(matcherC.match(header0, context) == false);
+    BOOST_CHECK(matcherC.match(header1, context) == true);
+    BOOST_CHECK(matcherC.match(header4, context) == true);
+  }
 }
 
 BOOST_AUTO_TEST_CASE(TestSimpleMatching)


### PR DESCRIPTION
Need to check if using this negator operation can have implications
on the handling of concrete data types. No impact to existing code
however.