### PR TITLE
Force HBF orbit assignment if RDH page0 is lost

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/GBTLink.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/GBTLink.h
@@ -218,7 +218,7 @@ GBTLink::CollectedDataStatus GBTLink::collectROFCableData(const Mapping& chmap)
       hbfEntry = hbfEntrySav; // critical check of RDH passed
       lastRDH = rdh;
       statistics.nPackets++;
-      if (RDHUtils::getPageCounter(*rdh) == 0) {
+      if (RDHUtils::getPageCounter(*rdh) == 0 || irHBF.isDummy()) { // for the threshold scan data it is not guaranteed that the page0 is found)
         irHBF = RDHUtils::getHeartBeatIR(*rdh);
         hbfEntry = rawData.currentPieceID();
       }


### PR DESCRIPTION
In the threshold scan data the HBF may be split between 2 TFs, so the 1st RDH of the TF is not
guaranteed to have page counter 0, from which the HBF orbit was assigned.

Trivial, merging.