### PR TITLE
Correcting the indices to MCH and MFT tracks in FwdTracks table

### DIFF
--- a/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
+++ b/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
@@ -230,10 +230,10 @@ class AODProducerWorkflowDPL : public Task
   std::unordered_map<GIndex, int> mV0ToTableID;
   int mTableV0ID{0};
 
-//  std::unordered_map<int, int> mIndexTableFwd;
+  //  std::unordered_map<int, int> mIndexTableFwd;
   std::vector<int> mIndexTableFwd;
   int mIndexFwdID{0};
-//  std::unordered_map<int, int> mIndexTableMFT;
+  //  std::unordered_map<int, int> mIndexTableMFT;
   std::vector<int> mIndexTableMFT;
   int mIndexMFTID{0};
 

--- a/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
+++ b/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
@@ -230,9 +230,11 @@ class AODProducerWorkflowDPL : public Task
   std::unordered_map<GIndex, int> mV0ToTableID;
   int mTableV0ID{0};
 
-  std::unordered_map<int, int> mIndexTableFwd;
+//  std::unordered_map<int, int> mIndexTableFwd;
+  std::vector<int> mIndexTableFwd;
   int mIndexFwdID{0};
-  std::unordered_map<int, int> mIndexTableMFT;
+//  std::unordered_map<int, int> mIndexTableMFT;
+  std::vector<int> mIndexTableMFT;
   int mIndexMFTID{0};
 
   // zdc helper maps to avoid a number of "if" statements
@@ -384,7 +386,7 @@ class AODProducerWorkflowDPL : public Task
                                    AmbigFwdTracksCursorType& ambigFwdTracksCursor,
                                    const std::map<uint64_t, int>& bcsMap);
 
-  void fillFwdIndexTablesPerCollision(const o2::dataformats::VtxTrackRef& trackRef, const gsl::span<const GIndex>& GIndices);
+  void fillIndexTablesPerCollision(const o2::dataformats::VtxTrackRef& trackRef, const gsl::span<const GIndex>& GIndices);
 
   template <typename V0CursorType, typename CascadeCursorType>
   void fillSecondaryVertices(const o2::globaltracking::RecoContainer& data, V0CursorType& v0Cursor, CascadeCursorType& cascadeCursor);

--- a/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
+++ b/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
@@ -230,6 +230,11 @@ class AODProducerWorkflowDPL : public Task
   std::unordered_map<GIndex, int> mV0ToTableID;
   int mTableV0ID{0};
 
+  std::unordered_map<int, int> mIndexTableFwd;
+  int mIndexFwdID{0};
+  std::unordered_map<int, int> mIndexTableMFT;
+  int mIndexMFTID{0};
+
   // zdc helper maps to avoid a number of "if" statements
   // when filling ZDC table
   map<string, float> mZDCEnergyMap; // mapping detector name to a corresponding energy
@@ -378,6 +383,8 @@ class AODProducerWorkflowDPL : public Task
                                    FwdTracksCovCursorType& fwdTracksCovCursor,
                                    AmbigFwdTracksCursorType& ambigFwdTracksCursor,
                                    const std::map<uint64_t, int>& bcsMap);
+
+  void fillFwdIndexTablesPerCollision(const o2::dataformats::VtxTrackRef& trackRef, const gsl::span<const GIndex>& GIndices);
 
   template <typename V0CursorType, typename CascadeCursorType>
   void fillSecondaryVertices(const o2::globaltracking::RecoContainer& data, V0CursorType& v0Cursor, CascadeCursorType& cascadeCursor);

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -286,7 +286,7 @@ void AODProducerWorkflowDPL::addToMFTTracksTable(mftTracksCursorType& mftTracksC
   if (needBCSlice) {
     ambigMFTTracksCursor(0, mTableTrMFTID, bcSlice);
   }
-  mGIDToTableMFTID.emplace(trackID, mTableTrMFTID);
+//  mGIDToTableMFTID.emplace(trackID, mTableTrMFTID);
   mTableTrMFTID++;
 }
 
@@ -365,7 +365,6 @@ void AODProducerWorkflowDPL::fillIndexTablesPerCollision(const o2::dataformats::
           }
 
           mGIDToTableMFTID.emplace(trackIndex, mIndexMFTID);
-          //          mIndexTableMFT.emplace(trackIndex.getIndex(), mIndexMFTID);
           mIndexTableMFT[trackIndex.getIndex()] = mIndexMFTID;
           mIndexMFTID++;
 
@@ -376,7 +375,6 @@ void AODProducerWorkflowDPL::fillIndexTablesPerCollision(const o2::dataformats::
 
           mGIDToTableFwdID.emplace(trackIndex, mIndexFwdID);
           if (src == GIndex::Source::MCH) {
-            //            mIndexTableFwd.emplace(trackIndex.getIndex(), mIndexFwdID);
             mIndexTableFwd[trackIndex.getIndex()] = mIndexFwdID;
           }
           mIndexFwdID++;
@@ -613,7 +611,7 @@ void AODProducerWorkflowDPL::addToFwdTracksTable(FwdTracksCursorType& fwdTracksC
   if (needBCSlice) {
     ambigFwdTracksCursor(0, mTableTrFwdID, bcSlice);
   }
-  mGIDToTableFwdID.emplace(trackID, mTableTrFwdID);
+//  mGIDToTableFwdID.emplace(trackID, mTableTrFwdID);
   mTableTrFwdID++;
 }
 
@@ -1533,9 +1531,6 @@ void AODProducerWorkflowDPL::run(ProcessingContext& pc)
     collisionID++;
   }
 
-  mGIDToTableFwdID.clear();
-  mGIDToTableMFTID.clear();
-
   // filling unassigned tracks first
   // so that all unassigned tracks are stored in the beginning of the table together
   auto& trackRef = primVer2TRefs.back(); // references to unassigned tracks are at the end
@@ -1668,6 +1663,11 @@ void AODProducerWorkflowDPL::run(ProcessingContext& pc)
   mTableCollID = 0;
   mV0ToTableID.clear();
   mTableV0ID = 0;
+
+  mIndexTableFwd.clear();
+  mIndexFwdID=0;
+  mIndexTableMFT.clear();
+  mIndexMFTID=0;
 
   originCursor(0, tfNumber);
 

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -352,7 +352,6 @@ void AODProducerWorkflowDPL::fillTrackTablesPerCollision(int collisionID,
 
 void AODProducerWorkflowDPL::fillIndexTablesPerCollision(const o2::dataformats::VtxTrackRef& trackRef, const gsl::span<const GIndex>& GIndices)
 {
-  //  for (int src = GIndex::NSources; src--;) {
   for (int src : {GIndex::Source::MFTMCH, GIndex::Source::MCH, GIndex::Source::MFT}) {
     int start = trackRef.getFirstEntryOfSource(src);
     int end = start + trackRef.getEntriesOfSource(src);

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -352,7 +352,7 @@ void AODProducerWorkflowDPL::fillTrackTablesPerCollision(int collisionID,
 
 void AODProducerWorkflowDPL::fillIndexTablesPerCollision(const o2::dataformats::VtxTrackRef& trackRef, const gsl::span<const GIndex>& GIndices)
 {
-//  for (int src = GIndex::NSources; src--;) {
+  //  for (int src = GIndex::NSources; src--;) {
   for (int src : {GIndex::Source::MFTMCH, GIndex::Source::MCH, GIndex::Source::MFT}) {
     int start = trackRef.getFirstEntryOfSource(src);
     int end = start + trackRef.getEntriesOfSource(src);
@@ -365,8 +365,8 @@ void AODProducerWorkflowDPL::fillIndexTablesPerCollision(const o2::dataformats::
           }
 
           mGIDToTableMFTID.emplace(trackIndex, mIndexMFTID);
-//          mIndexTableMFT.emplace(trackIndex.getIndex(), mIndexMFTID);
-    mIndexTableMFT[trackIndex.getIndex()] = mIndexMFTID;
+          //          mIndexTableMFT.emplace(trackIndex.getIndex(), mIndexMFTID);
+          mIndexTableMFT[trackIndex.getIndex()] = mIndexMFTID;
           mIndexMFTID++;
 
         } else if (src == GIndex::Source::MCH || src == GIndex::Source::MFTMCH) {
@@ -375,9 +375,9 @@ void AODProducerWorkflowDPL::fillIndexTablesPerCollision(const o2::dataformats::
           }
 
           mGIDToTableFwdID.emplace(trackIndex, mIndexFwdID);
-          if (src == GIndex::Source::MCH){
-//            mIndexTableFwd.emplace(trackIndex.getIndex(), mIndexFwdID);
-        mIndexTableFwd[trackIndex.getIndex()] = mIndexFwdID;
+          if (src == GIndex::Source::MCH) {
+            //            mIndexTableFwd.emplace(trackIndex.getIndex(), mIndexFwdID);
+            mIndexTableFwd[trackIndex.getIndex()] = mIndexFwdID;
           }
           mIndexFwdID++;
         }
@@ -1522,7 +1522,7 @@ void AODProducerWorkflowDPL::run(ProcessingContext& pc)
 
   int collisionID = 0;
   mIndexTableMFT.resize(recoData.getMFTTracks().size());
-  mIndexTableFwd.resize(recoData.getMCHTracks().size()*3);// take an upperbound to the size of the FwdTrack table
+  mIndexTableFwd.resize(recoData.getMCHTracks().size() * 3); // take an upperbound to the size of the FwdTrack table
 
   auto& trackReffwd = primVer2TRefs.back();
   fillIndexTablesPerCollision(trackReffwd, primVerGIs);

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -366,7 +366,7 @@ void AODProducerWorkflowDPL::fillIndexTablesPerCollision(const o2::dataformats::
 
           mGIDToTableMFTID.emplace(trackIndex, mIndexMFTID);
 //          mIndexTableMFT.emplace(trackIndex.getIndex(), mIndexMFTID);
-	  mIndexTableMFT[trackIndex.getIndex()] = mIndexMFTID;
+    mIndexTableMFT[trackIndex.getIndex()] = mIndexMFTID;
           mIndexMFTID++;
 
         } else if (src == GIndex::Source::MCH || src == GIndex::Source::MFTMCH) {
@@ -377,7 +377,7 @@ void AODProducerWorkflowDPL::fillIndexTablesPerCollision(const o2::dataformats::
           mGIDToTableFwdID.emplace(trackIndex, mIndexFwdID);
           if (src == GIndex::Source::MCH){
 //            mIndexTableFwd.emplace(trackIndex.getIndex(), mIndexFwdID);
-  	    mIndexTableFwd[trackIndex.getIndex()] = mIndexFwdID;
+        mIndexTableFwd[trackIndex.getIndex()] = mIndexFwdID;
           }
           mIndexFwdID++;
         }
@@ -1522,14 +1522,14 @@ void AODProducerWorkflowDPL::run(ProcessingContext& pc)
 
   int collisionID = 0;
   mIndexTableMFT.resize(recoData.getMFTTracks().size());
-  mIndexTableFwd.resize(recoData.getMCHTracks().size()*3);
+  mIndexTableFwd.resize(recoData.getMCHTracks().size()*3);// take an upperbound to the size of the FwdTrack table
 
   auto& trackReffwd = primVer2TRefs.back();
   fillIndexTablesPerCollision(trackReffwd, primVerGIs);
   collisionID = 0;
   for (auto& vertex : primVertices) {
     auto& trackReffwd = primVer2TRefs[collisionID];
-    fillIndexTablesPerCollision(trackReffwd, primVerGIs);
+    fillIndexTablesPerCollision(trackReffwd, primVerGIs); // this function must follow the same track order as 'fillTrackTablesPerCollision' to fill the map of track indices
     collisionID++;
   }
 

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -485,6 +485,8 @@ void AODProducerWorkflowDPL::addToFwdTracksTable(FwdTracksCursorType& fwdTracksC
     trackTimeRes = o2::constants::lhc::LHCBunchSpacingNS * bcWidth / 2; // half interval
     errGaussian = false;
 
+    matchmchtrackid = trackID.getIndex();
+
   } else {
     // This is a GlobalMuonTrack or a GlobalForwardTrack
     const auto track = data.getGlobalFwdTrack(trackID);

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -350,7 +350,7 @@ void AODProducerWorkflowDPL::fillTrackTablesPerCollision(int collisionID,
   }
 }
 
-void AODProducerWorkflowDPL::fillFwdIndexTablesPerCollision(const o2::dataformats::VtxTrackRef& trackRef, const gsl::span<const GIndex>& GIndices)
+void AODProducerWorkflowDPL::fillIndexTablesPerCollision(const o2::dataformats::VtxTrackRef& trackRef, const gsl::span<const GIndex>& GIndices)
 {
 //  for (int src = GIndex::NSources; src--;) {
   for (int src : {GIndex::Source::MFTMCH, GIndex::Source::MCH, GIndex::Source::MFT}) {
@@ -365,7 +365,8 @@ void AODProducerWorkflowDPL::fillFwdIndexTablesPerCollision(const o2::dataformat
           }
 
           mGIDToTableMFTID.emplace(trackIndex, mIndexMFTID);
-          mIndexTableMFT.emplace(trackIndex.getIndex(), mIndexMFTID);
+//          mIndexTableMFT.emplace(trackIndex.getIndex(), mIndexMFTID);
+	  mIndexTableMFT[trackIndex.getIndex()] = mIndexMFTID;
           mIndexMFTID++;
 
         } else if (src == GIndex::Source::MCH || src == GIndex::Source::MFTMCH) {
@@ -375,7 +376,8 @@ void AODProducerWorkflowDPL::fillFwdIndexTablesPerCollision(const o2::dataformat
 
           mGIDToTableFwdID.emplace(trackIndex, mIndexFwdID);
           if (src == GIndex::Source::MCH){
-            mIndexTableFwd.emplace(trackIndex.getIndex(), mIndexFwdID);
+//            mIndexTableFwd.emplace(trackIndex.getIndex(), mIndexFwdID);
+  	    mIndexTableFwd[trackIndex.getIndex()] = mIndexFwdID;
           }
           mIndexFwdID++;
         }
@@ -1518,12 +1520,16 @@ void AODProducerWorkflowDPL::run(ProcessingContext& pc)
 
   cacheTriggers(recoData);
 
-  auto& trackReffwd = primVer2TRefs.back();
-  fillFwdIndexTablesPerCollision(trackReffwd, primVerGIs);
   int collisionID = 0;
+  mIndexTableMFT.resize(recoData.getMFTTracks().size());
+  mIndexTableFwd.resize(recoData.getMCHTracks().size()*3);
+
+  auto& trackReffwd = primVer2TRefs.back();
+  fillIndexTablesPerCollision(trackReffwd, primVerGIs);
+  collisionID = 0;
   for (auto& vertex : primVertices) {
     auto& trackReffwd = primVer2TRefs[collisionID];
-    fillFwdIndexTablesPerCollision(trackReffwd, primVerGIs);
+    fillIndexTablesPerCollision(trackReffwd, primVerGIs);
     collisionID++;
   }
 

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -286,7 +286,7 @@ void AODProducerWorkflowDPL::addToMFTTracksTable(mftTracksCursorType& mftTracksC
   if (needBCSlice) {
     ambigMFTTracksCursor(0, mTableTrMFTID, bcSlice);
   }
-//  mGIDToTableMFTID.emplace(trackID, mTableTrMFTID);
+  //  mGIDToTableMFTID.emplace(trackID, mTableTrMFTID);
   mTableTrMFTID++;
 }
 
@@ -611,7 +611,7 @@ void AODProducerWorkflowDPL::addToFwdTracksTable(FwdTracksCursorType& fwdTracksC
   if (needBCSlice) {
     ambigFwdTracksCursor(0, mTableTrFwdID, bcSlice);
   }
-//  mGIDToTableFwdID.emplace(trackID, mTableTrFwdID);
+  //  mGIDToTableFwdID.emplace(trackID, mTableTrFwdID);
   mTableTrFwdID++;
 }
 
@@ -1665,9 +1665,9 @@ void AODProducerWorkflowDPL::run(ProcessingContext& pc)
   mTableV0ID = 0;
 
   mIndexTableFwd.clear();
-  mIndexFwdID=0;
+  mIndexFwdID = 0;
   mIndexTableMFT.clear();
-  mIndexMFTID=0;
+  mIndexMFTID = 0;
 
   originCursor(0, tfNumber);
 


### PR DESCRIPTION
Introduce a function "fillIndexTablesPerCollision" which fills two vectors (mIndexTableMFT, mIndexTableFwd) which map the trackIndices to the index inside the fwdtrack table. It respect the same order and is called before "fillTrackTablesPerCollision".
The two vectors are initialized respectively with sizes equal to "recoData.getMFTTracks().size()" and "recoData.getMCHTracks().size() * 3", taking an upperbound to the size of the FwdTrack table.