### PR TITLE
:MCH: introduce digit time errors in raw decoder

### DIFF
--- a/Detectors/MUON/MCH/Raw/Common/include/MCHRawCommon/CoDecParam.h
+++ b/Detectors/MUON/MCH/Raw/Common/include/MCHRawCommon/CoDecParam.h
@@ -22,6 +22,12 @@ struct CoDecParam : public o2::conf::ConfigurableParamHelper<CoDecParam> {
 
   int sampaBcOffset = 0; // default global sampa bunch-crossing offset
 
+  // default minimum allowed digit time, in orbit units
+  int minDigitOrbitAccepted = -10;
+  // default maximum allowed digit time, in orbit units
+  // a negative value forces the value to be equal to the time-frame length
+  int maxDigitOrbitAccepted = -1;
+
   O2ParamDef(CoDecParam, "MCHCoDecParam")
 };
 

--- a/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DataDecoder.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DataDecoder.h
@@ -180,6 +180,7 @@ class DataDecoder
   /// Compute the time of all the digits that have been decoded in the current TimeFrame
   void computeDigitsTimeBCRst();
   void computeDigitsTime();
+  void checkDigitsTime(int minDigitTimeAccepted, int maxDigitTimeAccepted);
 
   /// Get the vector of digits that have been decoded in the current TimeFrame
   const RawDigitVector& getDigits() const { return mDigits; }

--- a/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/ErrorCodes.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/ErrorCodes.h
@@ -32,8 +32,13 @@ enum ErrorCodes {
   ErrorTruncatedData = 1 << 7,        // 128
   ErrorBadELinkID = 1 << 8,           // 256
   ErrorBadLinkID = 1 << 9,            // 512
-  ErrorUnknownLinkID = 1 << 10        // 1024
+  ErrorUnknownLinkID = 1 << 10,       // 1024
+  ErrorBadDigitTime = 1 << 11,        // 2048
+  ErrorInvalidDigitTime = 1 << 12     // 4096
+
 };
+
+uint32_t getErrorCodesSize();
 
 std::string errorCodeAsString(uint32_t code);
 

--- a/Detectors/MUON/MCH/Raw/Decoder/src/DataDecoder.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/DataDecoder.cxx
@@ -824,6 +824,31 @@ void DataDecoder::computeDigitsTimeBCRst()
 
 //_________________________________________________________________________________________________
 
+void DataDecoder::checkDigitsTime(int minDigitOrbitAccepted, int maxDigitOrbitAccepted)
+{
+  if (maxDigitOrbitAccepted < 0) {
+    maxDigitOrbitAccepted = mOrbitsInTF - 1;
+  }
+
+  for (auto& digit : mDigits) {
+    auto& d = digit.digit;
+    auto& info = digit.info;
+    auto tfTime = d.getTime();
+    if (tfTime == DataDecoder::tfTimeInvalid) {
+      // add invalid digit time error
+      mErrors.emplace_back(o2::mch::DecoderError(info.solar, info.ds, info.chip, ErrorInvalidDigitTime));
+    } else {
+      auto orbit = tfTime / o2::constants::lhc::LHCMaxBunches;
+      if (orbit < minDigitOrbitAccepted || orbit > maxDigitOrbitAccepted) {
+        // add bad digit time error
+        mErrors.emplace_back(o2::mch::DecoderError(info.solar, info.ds, info.chip, ErrorBadDigitTime));
+      }
+    }
+  }
+}
+
+//_________________________________________________________________________________________________
+
 void DataDecoder::computeDigitsTime()
 {
   switch (mTimeRecoMode) {

--- a/Detectors/MUON/MCH/Raw/Decoder/src/ErrorCodes.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/ErrorCodes.cxx
@@ -18,6 +18,11 @@ namespace mch
 namespace raw
 {
 
+uint32_t getErrorCodesSize()
+{
+  return 13;
+}
+
 void append(const char* msg, std::string& to)
 {
   std::string s = to.size() ? "& " + to : "";
@@ -64,6 +69,12 @@ std::string errorCodeAsString(uint32_t ec)
   }
   if (ec & ErrorUnknownLinkID) {
     append("Unknown Link ID", msg);
+  }
+  if (ec & ErrorBadDigitTime) {
+    append("Bad Digit Time", msg);
+  }
+  if (ec & ErrorInvalidDigitTime) {
+    append("Invalid Digit Time", msg);
   }
   return msg;
 }

--- a/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
@@ -241,6 +241,9 @@ class DataDecoderTask
       }
     }
     mDecoder->computeDigitsTime();
+    int minDigitOrbitAccepted = CoDecParam::Instance().minDigitOrbitAccepted;
+    int maxDigitOrbitAccepted = CoDecParam::Instance().maxDigitOrbitAccepted;
+    mDecoder->checkDigitsTime(minDigitOrbitAccepted, maxDigitOrbitAccepted);
     auto tEnd = std::chrono::high_resolution_clock::now();
     mTimeDecoding += tEnd - tStart;
 


### PR DESCRIPTION
The code introduces a check of the digit time values in the data decoder, and two new error codes to notify when the digit time is not ok:
- `ErrorInvalidDigitTime` is emitted when the digit time is equal to `DataDecoder::tfTimeInvalid`
- `ErrorBadDigitTime` is emitted when the digit time is outside user-defined limits

The acceptable limits are expressed in units of orbits since the start of time-frame, and can be set via the `MCHCoDecParam ` interface.