### PR TITLE
DPL DataDescriptorQueryBuilder: Implementing support for property modifiers

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -182,6 +182,7 @@ foreach(t
         ConfigParamStore
         ConfigParamRegistry
         DataDescriptorMatcher
+        DataDescriptorQueryBuilder
         DataProcessorSpec
         DataRefUtils
         DataRelayer

--- a/Framework/Core/include/Framework/DataDescriptorQueryBuilder.h
+++ b/Framework/Core/include/Framework/DataDescriptorQueryBuilder.h
@@ -54,20 +54,15 @@ struct DataDescriptorQueryBuilder {
   /// config := spec;spec;...
   ///
   /// Example for config: x:TPC/CLUSTER/0;y:ITS/TRACKS/1
+  ///
+  /// FIXME: grammar has been extended, add documentation
   static std::vector<InputSpec> parse(const char* s = "");
 
-  /// Creates an inputspec from a configuration @a config string with the
-  /// following grammar.
-  ///
-  /// string := [a-zA-Z0-9_]*
-  /// origin := string
-  /// description := string
-  /// subspec := [0-9]*
-  /// spec := origin/description/subspec
-  /// config := spec;spec;...
-  ///
-  /// Example for config: TPC/CLUSTER/0;ITS/TRACKS/1
+  /// Internal method to build matcher list from a string of verified specs,
+  /// the fixed and verified input format allows simple scanning, no state based
+  /// parsing nor error handling implemented
   static DataDescriptorQuery buildFromKeepConfig(std::string const& config);
+  /// deprecated?
   static DataDescriptorQuery buildFromExtendedKeepConfig(std::string const& config);
   static std::unique_ptr<data_matcher::DataDescriptorMatcher> buildNode(std::string const& nodeString);
   static std::smatch getTokens(std::string const& nodeString);

--- a/Framework/Core/include/Framework/DataSpecUtils.h
+++ b/Framework/Core/include/Framework/DataSpecUtils.h
@@ -51,6 +51,16 @@ struct DataSpecUtils {
                     const o2::header::DataDescription& description,
                     const o2::header::DataHeader::SubSpecificationType& subSpec);
 
+  static bool match(const InputSpec& spec, o2::header::DataHeader const& dh)
+  {
+    return DataSpecUtils::match(spec, dh.dataOrigin, dh.dataDescription, dh.subSpecification);
+  }
+
+  static bool match(const OutputSpec& spec, o2::header::DataHeader const& dh)
+  {
+    return DataSpecUtils::match(spec, dh.dataOrigin, dh.dataDescription, dh.subSpecification);
+  }
+
   /// find a matching spec in the container
   /// @return std::optional with found spec or std::nullopt
   template <typename ContainerT>

--- a/Framework/Core/src/ArrowSupport.cxx
+++ b/Framework/Core/src/ArrowSupport.cxx
@@ -361,7 +361,8 @@ o2::framework::ServiceSpec ArrowSupport::arrowBackendSpec()
                          if (input.header == nullptr) {
                            continue;
                          }
-                         auto dh = o2::header::get<DataHeader*>(input.header);
+                         auto const* dh = DataRefUtils::getHeader<DataHeader*>(input);
+                         auto payloadSize = DataRefUtils::getPayloadSize(input);
                          if (dh->serialization != o2::header::gSerializationMethodArrow) {
                            LOGP(debug, "Message {}/{} is not of kind arrow, therefore we are not accounting its shared memory", dh->dataOrigin, dh->dataDescription);
                            continue;
@@ -369,7 +370,7 @@ o2::framework::ServiceSpec ArrowSupport::arrowBackendSpec()
                          auto dph = o2::header::get<DataProcessingHeader*>(input.header);
                          bool forwarded = false;
                          for (auto const& forward : ctx.services().get<DeviceSpec const>().forwards) {
-                           if (DataSpecUtils::match(forward.matcher, dh->dataOrigin, dh->dataDescription, dh->subSpecification)) {
+                           if (DataSpecUtils::match(forward.matcher, *dh)) {
                              forwarded = true;
                              break;
                            }
@@ -378,8 +379,8 @@ o2::framework::ServiceSpec ArrowSupport::arrowBackendSpec()
                            LOGP(debug, "Message {}/{} is forwarded so we are not returning its memory.", dh->dataOrigin, dh->dataDescription);
                            continue;
                          }
-                         LOGP(debug, "Message {}/{} is being deleted. We will return {}MB.", dh->dataOrigin, dh->dataDescription, dh->payloadSize / 1000000.);
-                         totalBytes += dh->payloadSize;
+                         LOGP(debug, "Message {}/{} is being deleted. We will return {}MB.", dh->dataOrigin, dh->dataDescription, payloadSize / 1000000.);
+                         totalBytes += payloadSize;
                          totalMessages += 1;
                        }
                        arrow->updateBytesDestroyed(totalBytes);

--- a/Framework/Core/src/DataDescriptorQueryBuilder.cxx
+++ b/Framework/Core/src/DataDescriptorQueryBuilder.cxx
@@ -41,6 +41,7 @@ enum QueryBuilderState {
   IN_END_QUERY,
   IN_STRING,
   IN_NUMBER,
+  IN_NEGATION,
   IN_ERROR,
   IN_BEGIN_ATTRIBUTES,
   IN_END_ATTRIBUTES,
@@ -79,6 +80,22 @@ std::vector<InputSpec> DataDescriptorQueryBuilder::parse(char const* config)
   };
 
   auto pushState = [&states](QueryBuilderState state) {
+    states.push_back(state);
+  };
+
+  auto checkModifier = [&states, &cur, &next, &error](QueryBuilderState state, const char* mod) {
+    const char* modifier = nullptr;
+    if (mod[0] != '\0' && (modifier = strpbrk(cur, mod)) != nullptr) {
+      switch (*modifier) {
+        case '!':
+          states.push_back(IN_NEGATION);
+          break;
+        default:
+          error("invalid modifier '" + std::string(modifier, 1) + "'");
+          return;
+      }
+      next = ++cur;
+    }
     states.push_back(state);
   };
 
@@ -141,6 +158,18 @@ std::vector<InputSpec> DataDescriptorQueryBuilder::parse(char const* config)
       }
     }
     return InputSpec{binding, std::move(*lastMatcher.release()), lifetime, attributes};
+  };
+
+  auto pushMatcher = [&nodes, &states](auto&& matcher) {
+    if (states.back() == IN_NEGATION) {
+      states.pop_back();
+      auto notMatcher = std::make_unique<DataDescriptorMatcher>(DataDescriptorMatcher::Op::Xor,
+                                                                std::move(matcher),
+                                                                data_matcher::ConstantValueMatcher{true});
+      nodes.push_back(std::move(notMatcher));
+    } else {
+      nodes.push_back(std::move(matcher));
+    }
   };
 
   while (states.empty() == false) {
@@ -224,21 +253,22 @@ std::vector<InputSpec> DataDescriptorQueryBuilder::parse(char const* config)
         }
       } break;
       case IN_BEGIN_SUBSPEC: {
-        pushState(IN_END_SUBSPEC);
+        checkModifier(IN_END_SUBSPEC, "!");
         token(IN_NUMBER, ";%?");
       } break;
       case IN_END_SUBSPEC: {
         if (*next == '%' && assignLastNumericMatch("subspec", currentSubSpec, IN_BEGIN_TIMEMODULO)) {
-          nodes.push_back(SubSpecificationTypeValueMatcher{*currentSubSpec});
         } else if (*next == '?' && assignLastNumericMatch("subspec", currentSubSpec, IN_BEGIN_ATTRIBUTES)) {
-          nodes.push_back(SubSpecificationTypeValueMatcher{*currentSubSpec});
         } else if (*next == ';' && assignLastNumericMatch("subspec", currentSubSpec, IN_END_MATCHER)) {
-          nodes.push_back(SubSpecificationTypeValueMatcher{*currentSubSpec});
         } else if (*next == '\0' && assignLastNumericMatch("subspec", currentSubSpec, IN_END_MATCHER)) {
-          nodes.push_back(SubSpecificationTypeValueMatcher{*currentSubSpec});
         } else {
           error("Expected a number");
+          break;
         }
+        auto backup = states.back();
+        states.pop_back();
+        pushMatcher(SubSpecificationTypeValueMatcher{*currentSubSpec});
+        states.push_back(backup);
       } break;
       case IN_BEGIN_TIMEMODULO: {
         pushState(IN_END_TIMEMODULO);
@@ -305,6 +335,9 @@ std::vector<InputSpec> DataDescriptorQueryBuilder::parse(char const* config)
       } break;
       case IN_END_ATTRIBUTES: {
         pushState(IN_END_MATCHER);
+      } break;
+      case IN_NEGATION: {
+        error("property modifiers should have been handled before when inserting previous matcher");
       } break;
       case IN_ERROR: {
         throw std::runtime_error("Parse error: " + errorString);

--- a/Framework/Core/src/DataDescriptorQueryBuilder.cxx
+++ b/Framework/Core/src/DataDescriptorQueryBuilder.cxx
@@ -217,7 +217,7 @@ std::vector<InputSpec> DataDescriptorQueryBuilder::parse(char const* config)
           nodes.push_back(DescriptionValueMatcher{*currentDescription});
         } else if (*next == '?' && assignLastStringMatch("description", 16, currentDescription, IN_BEGIN_ATTRIBUTES)) {
           nodes.push_back(DescriptionValueMatcher{*currentDescription});
-        } else if (*next == '\0' && assignLastStringMatch("description", 16, currentDescription, IN_BEGIN_ATTRIBUTES)) {
+        } else if (*next == '\0' && assignLastStringMatch("description", 16, currentDescription, IN_END_MATCHER)) {
           nodes.push_back(DescriptionValueMatcher{*currentDescription});
         } else {
           error("description needs to be between 1 and 16 char long");

--- a/Framework/Core/test/test_DataDescriptorQueryBuilder.cxx
+++ b/Framework/Core/test/test_DataDescriptorQueryBuilder.cxx
@@ -1,0 +1,49 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test Framework DataDescriptorQueryBuilder
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include "Framework/DataDescriptorMatcher.h"
+#include "Framework/DataDescriptorQueryBuilder.h"
+#include "Framework/DataSpecUtils.h"
+#include "Framework/Logger.h"
+#include "Framework/InputSpec.h"
+#include "Headers/Stack.h"
+
+#include <boost/test/unit_test.hpp>
+#include <variant>
+
+using namespace o2::framework;
+using namespace o2::header;
+using namespace o2::framework::data_matcher;
+
+BOOST_AUTO_TEST_CASE(TestQueryBuilder)
+{
+  VariableContext context;
+  DataHeader header0{"CLUSTERS", "TPC", 1};
+  DataHeader header1{"CLUSTERS", "TPC", 2};
+  DataHeader header2{"CLUSTERS", "ITS", 1};
+  DataHeader header3{"TRACKLET", "TPC", 3};
+
+  auto ispecs = DataDescriptorQueryBuilder::parse("A:TPC/CLUSTERS/1;B:ITS/CLUSTERS/1");
+  BOOST_REQUIRE(ispecs.size() == 2);
+  BOOST_CHECK(DataSpecUtils::match(ispecs[0], header0) == true);
+  BOOST_CHECK(DataSpecUtils::match(ispecs[0], header1) == false);
+  BOOST_CHECK(DataSpecUtils::match(ispecs[1], header2) == true);
+
+  ispecs = DataDescriptorQueryBuilder::parse("A:TPC/CLUSTERS/!1;B:ITS/CLUSTERS/1");
+  BOOST_REQUIRE(ispecs.size() == 2);
+  BOOST_CHECK(DataSpecUtils::match(ispecs[0], header0) == false);
+  BOOST_CHECK(DataSpecUtils::match(ispecs[0], header1) == true);
+  BOOST_CHECK(DataSpecUtils::match(ispecs[1], header2) == true);
+}


### PR DESCRIPTION
First implemented operation is negation of the subSpecification matcher to
realize "all but specification", e.g. `EMC/RAW/!0`
