### PR TITLE
TPC: reduce use of static keyword

### DIFF
--- a/Detectors/TPC/base/include/TPCBase/CalArray.h
+++ b/Detectors/TPC/base/include/TPCBase/CalArray.h
@@ -194,7 +194,7 @@ template <class T>
 inline void CalArray<T>::setValue(const size_t row, const size_t pad, const T& value)
 {
   /// \todo might need check for row, pad or position limits
-  static const auto& mapper = Mapper::instance();
+  const auto& mapper = Mapper::instance();
   size_t position = mapper.getPadNumber(mPadSubset, mPadSubsetNumber, row, pad);
   setValue(position, value);
 }
@@ -204,7 +204,7 @@ template <class T>
 inline const T CalArray<T>::getValue(const size_t row, const size_t pad) const
 {
   /// \todo might need check for row, pad or position limits
-  static const auto& mapper = Mapper::instance();
+  const auto& mapper = Mapper::instance();
   size_t position = mapper.getPadNumber(mPadSubset, mPadSubsetNumber, row, pad);
   return getValue(position);
 }

--- a/Detectors/TPC/base/include/TPCBase/CalDet.h
+++ b/Detectors/TPC/base/include/TPCBase/CalDet.h
@@ -131,7 +131,7 @@ template <class T>
 inline const T CalDet<T>::getValue(const ROC roc, const size_t row, const size_t pad) const
 {
   // TODO: might need speedup and beautification
-  static const Mapper& mapper = Mapper::instance();
+  const Mapper& mapper = Mapper::instance();
 
   // bind row and pad to the maximum rows and pads in the requested region
   const size_t nRows = mapper.getNumberOfRowsROC(roc);
@@ -163,7 +163,7 @@ template <class T>
 inline const T CalDet<T>::getValue(const CRU cru, const size_t row, const size_t pad) const
 {
   // TODO: might need speedup and beautification
-  static const Mapper& mapper = Mapper::instance();
+  const Mapper& mapper = Mapper::instance();
   const auto& info = mapper.getPadRegionInfo(cru.region());
 
   // bind row and pad to the maximum rows and pads in the requested region

--- a/Detectors/TPC/base/src/Painter.cxx
+++ b/Detectors/TPC/base/src/Painter.cxx
@@ -92,7 +92,7 @@ TCanvas* painter::draw(const CalDet<T>& calDet, int nbins1D, float xMin1D, float
   using DetType = CalDet<T>;
   using CalType = CalArray<T>;
 
-  static const Mapper& mapper = Mapper::instance();
+  const Mapper& mapper = Mapper::instance();
 
   // ===| name and title |======================================================
   std::string title = calDet.getName();
@@ -216,7 +216,7 @@ TCanvas* painter::draw(const CalArray<T>& calArray)
 template <class T>
 void painter::fillHistogram2D(TH2& h2D, const CalDet<T>& calDet, Side side)
 {
-  static const Mapper& mapper = Mapper::instance();
+  const Mapper& mapper = Mapper::instance();
 
   for (ROC roc; !roc.looped(); ++roc) {
     if (roc.side() != side) {
@@ -242,7 +242,7 @@ void painter::fillHistogram2D(TH2& h2D, const CalDet<T>& calDet, Side side)
 template <class T>
 void painter::fillHistogram2D(TH2& h2D, const CalArray<T>& calArray)
 {
-  static const Mapper& mapper = Mapper::instance();
+  const Mapper& mapper = Mapper::instance();
 
   const size_t position = calArray.getPadSubsetNumber();
   const PadSubset padSubset = calArray.getPadSubset();
@@ -283,7 +283,7 @@ TH2* painter::getHistogram2D(const CalDet<T>& calDet, Side side)
 template <class T>
 TH2* painter::getHistogram2D(const CalArray<T>& calArray)
 {
-  static const Mapper& mapper = Mapper::instance();
+  const Mapper& mapper = Mapper::instance();
 
   const size_t position = calArray.getPadSubsetNumber();
   const PadSubset padSubset = calArray.getPadSubset();
@@ -472,7 +472,7 @@ TH2Poly* painter::makeSideHist(Side side)
 template <class T>
 void painter::fillPoly2D(TH2Poly& h2D, const CalDet<T>& calDet, Side side)
 {
-  static const Mapper& mapper = Mapper::instance();
+  const Mapper& mapper = Mapper::instance();
 
   int bin = 1;
   for (const auto& calROC : calDet.getData()) {
@@ -595,7 +595,7 @@ void painter::drawSectorsXY(Side side, int sectorLineColor, int sectorTextColor)
 
 void painter::drawSectorLocalPadNumberPoly(short padTextColor, float lineScalePS)
 {
-  static const Mapper& mapper = Mapper::instance();
+  const Mapper& mapper = Mapper::instance();
   const auto coords = getPadCoordinatesSector();
   TLatex lat;
   lat.SetTextAlign(12);
@@ -619,7 +619,7 @@ void painter::drawSectorLocalPadNumberPoly(short padTextColor, float lineScalePS
 
 void painter::drawSectorInformationPoly(short regionLineColor, short rowTextColor)
 {
-  static const Mapper& mapper = Mapper::instance();
+  const Mapper& mapper = Mapper::instance();
 
   TLatex lat;
   lat.SetTextColor(rowTextColor);

--- a/Detectors/TPC/calibration/include/TPCCalibration/CalibPadGainTracks.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/CalibPadGainTracks.h
@@ -157,7 +157,6 @@ class CalibPadGainTracks : public CalibPadGainTracksBase
   const o2::tpc::ClusterNativeAccess* mClusterIndex{nullptr};                         ///<! needed to access clusternative with tpctracks
   DEdxType mMode = dedxTrack;                                                         ///< normalization type: type=DedxTrack use truncated mean, type=DedxBB use value from BB fit
   DEdxRegion mDedxRegion = stack;                                                     ///<  using the dE/dx per chamber, stack or per sector
-  inline static auto& mapper = Mapper::instance();                                    ///< initialize mapper object
   float mField{-5};                                                                   ///< Magnetic field in kG, used for track propagation
   float mMomMin{0.1f};                                                                ///< minimum momentum which is required by tracks
   float mMomMax{5.f};                                                                 ///< maximum momentum which is required by tracks
@@ -177,7 +176,7 @@ class CalibPadGainTracks : public CalibPadGainTracksBase
   /// \param padSubsetNumber index of the pad subset
   /// \param row corresponding pad row
   /// \param pad pad in row
-  static int getIndex(o2::tpc::PadSubset padSub, int padSubsetNumber, const int row, const int pad) { return mapper.getPadNumber(padSub, padSubsetNumber, row, pad); }
+  static int getIndex(o2::tpc::PadSubset padSub, int padSubsetNumber, const int row, const int pad) { return Mapper::instance().getPadNumber(padSub, padSubsetNumber, row, pad); }
 
   float getTrackTopologyCorrection(const o2::tpc::TrackTPC& track, const unsigned int region) const;
 

--- a/Detectors/TPC/calibration/src/CalibPadGainTracks.cxx
+++ b/Detectors/TPC/calibration/src/CalibPadGainTracks.cxx
@@ -54,7 +54,7 @@ void CalibPadGainTracks::processTrack(o2::tpc::TrackTPC track)
 
     // this function sets sectorIndex, rowIndex, clusterIndexNumb
     track.getClusterReference(*mTPCTrackClIdxVecInput, iCl, sectorIndex, rowIndex, clusterIndexNumb);
-    const float xPosition = mapper.getPadCentre(PadPos(rowIndex, 0)).X();
+    const float xPosition = Mapper::instance().getPadCentre(PadPos(rowIndex, 0)).X();
     const bool check = track.propagateTo(xPosition, mField); // propagate this track to the plane X=xk (cm) in the field "b" (kG)
     if (!check) {
       continue;
@@ -188,7 +188,7 @@ std::vector<float> CalibPadGainTracks::getTruncMean(std::vector<std::vector<floa
 
 float CalibPadGainTracks::getTrackTopologyCorrection(const o2::tpc::TrackTPC& track, const unsigned int region) const
 {
-  const float padLength = mapper.getPadRegionInfo(region).getPadHeight();
+  const float padLength = Mapper::instance().getPadRegionInfo(region).getPadHeight();
   const float sinPhi = track.getSnp();
   const float tgl = track.getTgl();
   const float snp2 = sinPhi * sinPhi;
@@ -243,7 +243,7 @@ void CalibPadGainTracks::resizedEdxBuffer()
     mDEdxBuffer[1].reserve(Mapper::getNumberOfRowsInOROC());
   } else if (mDedxRegion == sector) {
     mDEdxBuffer.resize(1);
-    mDEdxBuffer[0].reserve(mapper.getNumberOfRows());
+    mDEdxBuffer[0].reserve(Mapper::instance().getNumberOfRows());
   } else {
     LOGP(warning, "wrong dE/dx type");
   }

--- a/Detectors/TPC/calibration/src/IDCAverageGroup.cxx
+++ b/Detectors/TPC/calibration/src/IDCAverageGroup.cxx
@@ -230,7 +230,7 @@ void o2::tpc::IDCAverageGroup<Type>::drawGrouping(const std::string filename)
 template <class Type>
 void o2::tpc::IDCAverageGroup<Type>::drawGroupingInformations(const int region, const int grPads, const int grRows, const int groupLastRowsThreshold, const int groupLastPadsThreshold, const int overlapRows, const int overlapPads, const int nIDCs, const int groupPadsSectorEdges) const
 {
-  static const o2::tpc::Mapper& mapper = Mapper::instance();
+  const o2::tpc::Mapper& mapper = Mapper::instance();
 
   TLatex lat;
   lat.SetTextColor(kBlack);

--- a/Detectors/TPC/qc/src/Helpers.cxx
+++ b/Detectors/TPC/qc/src/Helpers.cxx
@@ -76,7 +76,7 @@ void helpers::setStyleHistogram2D(std::vector<TH2F>& histos)
 //______________________________________________________________________________
 bool helpers::newZSCalib(const o2::tpc::CalDet<float>& refPedestal, const o2::tpc::CalDet<float>& refNoise, const o2::tpc::CalDet<float>& pedestal)
 {
-  static const o2::tpc::Mapper& mapper = o2::tpc::Mapper::instance();
+  const o2::tpc::Mapper& mapper = o2::tpc::Mapper::instance();
 
   o2::tpc::CalDet<float> diffCalDet = refPedestal - pedestal;
 

--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitGlobalPad.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitGlobalPad.h
@@ -133,8 +133,8 @@ inline void DigitGlobalPad::fillOutputContainer(std::vector<Digit>& output,
                                                 o2::dataformats::LabelContainer<std::pair<MCCompLabel, int>, false>& labels,
                                                 float commonMode)
 {
-  const static Mapper& mapper = Mapper::instance();
-  static SAMPAProcessing& sampaProcessing = SAMPAProcessing::instance();
+  const Mapper& mapper = Mapper::instance();
+  SAMPAProcessing& sampaProcessing = SAMPAProcessing::instance();
   const PadPos pad = mapper.padPos(globalPad);
   static std::vector<std::pair<MCCompLabel, int>> labelCollector; // static workspace container for sorting
 

--- a/Detectors/TPC/simulation/include/TPCSimulation/DigitTime.h
+++ b/Detectors/TPC/simulation/include/TPCSimulation/DigitTime.h
@@ -113,7 +113,7 @@ inline void DigitTime::reset()
 inline float DigitTime::getCommonMode(const GEMstack& gemstack) const
 {
   /// simple case when there is no external capacitance on the ROC
-  static const Mapper& mapper = Mapper::instance();
+  const Mapper& mapper = Mapper::instance();
   const auto nPads = mapper.getNumberOfPads(gemstack);
   return mCommonMode[gemstack] / static_cast<float>(nPads);
 }
@@ -123,7 +123,7 @@ inline void DigitTime::fillOutputContainer(std::vector<Digit>& output, dataforma
                                            std::vector<CommonMode>& commonModeOutput, const Sector& sector, TimeBin timeBin,
                                            float commonMode)
 {
-  static Mapper& mapper = Mapper::instance();
+  Mapper& mapper = Mapper::instance();
   GlobalPadNumber globalPad = 0;
   for (size_t i = 0; i < mCommonMode.size(); ++i) {
     const float cm = getCommonMode(GEMstack(i));

--- a/Detectors/TPC/simulation/src/Digitizer.cxx
+++ b/Detectors/TPC/simulation/src/Digitizer.cxx
@@ -51,7 +51,7 @@ void Digitizer::init()
 void Digitizer::process(const std::vector<o2::tpc::HitGroup>& hits,
                         const int eventID, const int sourceID)
 {
-  const static Mapper& mapper = Mapper::instance();
+  const Mapper& mapper = Mapper::instance();
   auto& detParam = ParameterDetector::Instance();
   auto& eleParam = ParameterElectronics::Instance();
   auto& gemParam = ParameterGEM::Instance();
@@ -161,7 +161,7 @@ void Digitizer::flush(std::vector<o2::tpc::Digit>& digits,
                       std::vector<o2::tpc::CommonMode>& commonModeOutput,
                       bool finalFlush)
 {
-  static SAMPAProcessing& sampaProcessing = SAMPAProcessing::instance();
+  SAMPAProcessing& sampaProcessing = SAMPAProcessing::instance();
   mDigitContainer.fillOutputContainer(digits, labels, commonModeOutput, mSector, sampaProcessing.getTimeBinFromTime(mEventTime - mOutputDigitTimeOffset), mIsContinuous, finalFlush);
 }
 
@@ -198,7 +198,7 @@ void Digitizer::setUseSCDistortions(TFile& finp)
 
 void Digitizer::setStartTime(double time)
 {
-  static SAMPAProcessing& sampaProcessing = SAMPAProcessing::instance();
+  SAMPAProcessing& sampaProcessing = SAMPAProcessing::instance();
   sampaProcessing.updateParameters();
   mDigitContainer.setStartTime(sampaProcessing.getTimeBinFromTime(time - mOutputDigitTimeOffset));
 }

--- a/Detectors/TPC/spacecharge/macro/createSCHistosFromHits.C
+++ b/Detectors/TPC/spacecharge/macro/createSCHistosFromHits.C
@@ -197,16 +197,16 @@ void createSCHistosFromHits(const int ionDriftTime = 200, const int nEvIon = 1, 
   auto& cdb = CDBInterface::instance();
   cdb.setUseDefaults();
 
-  const static Mapper& mapper = Mapper::instance();
+  const Mapper& mapper = Mapper::instance();
 
-  static GEMAmplification& gemAmplification = GEMAmplification::instance();
+  GEMAmplification& gemAmplification = GEMAmplification::instance();
   gemAmplification.updateParameters();
 
-  static ElectronTransport& electronTransport = ElectronTransport::instance();
+  ElectronTransport& electronTransport = ElectronTransport::instance();
   electronTransport.updateParameters();
 
   auto& eleParam = ParameterElectronics::Instance();
-  static SAMPAProcessing& sampaProcessing = SAMPAProcessing::instance();
+  SAMPAProcessing& sampaProcessing = SAMPAProcessing::instance();
   sampaProcessing.updateParameters();
 
   const int nShapedPoints = eleParam.NShapedPoints;


### PR DESCRIPTION
static keyword has been used unnecessarily which led
to construction of TPC objects at library load time (such as mapper)
... even when TPC algorithms are not run.

The static keyword is not necessary here, since the mapper object
is in any case a singleton.