### PR TITLE
Reporting and protection for interleaved chip data error

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/DecodingStat.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/DecodingStat.h
@@ -58,6 +58,7 @@ struct ChipStat {
     APE_OCCUPANCY_RATE_LIMIT,     // pending detector events limit (FATAL)
     APE_OCCUPANCY_RATE_LIMIT_2,   // pending detector events limit in packager(FATAL)
     WrongDColOrder,               // DColumns non increasing
+    InterleavedChipData,          // Chip data interleaved on the cable
     NErrorsDefined
   };
 
@@ -85,7 +86,8 @@ struct ChipStat {
     "APE_FSM_ERROR",                                // FSM error (FATAL, SEU error, reached an unknown state)
     "APE_OCCUPANCY_RATE_LIMIT",                     // pending detector events limit (FATAL)
     "APE_OCCUPANCY_RATE_LIMIT_2",                   // pending detector events limit in packager(FATAL)
-    "DColumns non-increasing"                       // DColumns non increasing
+    "DColumns non-increasing",                      // DColumns non increasing
+    "Chip data interleaved on the cable"            // Chip data interleaved on the cable
   };
 
   static constexpr std::array<uint32_t, NErrorsDefined> ErrActions = {
@@ -112,7 +114,8 @@ struct ChipStat {
     ErrActPropagate | ErrActDump, // FSM error (FATAL, SEU error, reached an unknown state)
     ErrActPropagate | ErrActDump, // pending detector events limit (FATAL)
     ErrActPropagate | ErrActDump, // pending detector events limit in packager(FATAL)
-    ErrActPropagate | ErrActDump  // DColumns non increasing
+    ErrActPropagate | ErrActDump, // DColumns non increasing
+    ErrActPropagate | ErrActDump  // Chip data interleaved on the cable
   };
   uint16_t feeID = -1;
   size_t nHits = 0;

--- a/Detectors/ITSMFT/common/reconstruction/src/Clusterer.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/Clusterer.cxx
@@ -66,9 +66,7 @@ void Clusterer::process(int nThreads, PixelReader& reader, CompClusCont* compClu
     if (nFired < nThreads) {
       nThreads = nFired;
     }
-#ifdef WITH_OPENMP
-    omp_set_num_threads(nThreads);
-#else
+#ifndef WITH_OPENMP
     nThreads = 1;
 #endif
     uint16_t chipStep = nThreads > 1 ? (nThreads == 2 ? 20 : (nThreads < 5 ? 5 : 1)) : nFired;
@@ -81,7 +79,7 @@ void Clusterer::process(int nThreads, PixelReader& reader, CompClusCont* compClu
       }
     }
 #ifdef WITH_OPENMP
-#pragma omp parallel for schedule(dynamic, dynGrp)
+#pragma omp parallel for schedule(dynamic, dynGrp) num_threads(nThreads)
     //>> start of MT region
     for (uint16_t ic = 0; ic < nFired; ic += chipStep) {
       auto ith = omp_get_thread_num();

--- a/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
@@ -84,9 +84,8 @@ int RawPixelDecoder<Mapping>::decodeNextTrigger()
   int nLinksWithData = 0, nru = mRUDecodeVec.size();
   do {
 #ifdef WITH_OPENMP
-    omp_set_num_threads(mNThreads);
-#pragma omp parallel for schedule(dynamic) reduction(+ \
-                                                     : nLinksWithData, mNChipsFiredROF, mNPixelsFiredROF)
+#pragma omp parallel for schedule(dynamic) num_threads(mNThreads) reduction(+ \
+                                                                            : nLinksWithData, mNChipsFiredROF, mNPixelsFiredROF)
 #endif
     for (int iru = 0; iru < nru; iru++) {
       nLinksWithData += decodeNextTrigger(iru);


### PR DESCRIPTION
Sometimes (noticed in the replay of injected MC data) the data of some chip appears interleaved with data of others (it seems it is not that the data of this chip is fragmented but some pieces of it can repeat after other chips data). As a result multiple instances of the ChipPixelData for the same chip where created, leading to race condition and eventual crash in the clusterization.
This PR detects such errors, reports them as `Chip data interleaved on the cable` to infologger and produces raw data dump (if requested). The excessive chip data is discarded.
