### PR TITLE
DPL Analysis: workaround for setting self-index binding before invoking process()

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -340,6 +340,9 @@ struct Column {
   Column() = default;
   Column(Column const&) = default;
   Column& operator=(Column const&) = default;
+  
+  Column(Column&&) = default;
+  Column& operator=(Column&&) = default;
 
   using persistent = std::true_type;
   using type = T;

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -340,7 +340,7 @@ struct Column {
   Column() = default;
   Column(Column const&) = default;
   Column& operator=(Column const&) = default;
-  
+
   Column(Column&&) = default;
   Column& operator=(Column&&) = default;
 

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -351,7 +351,7 @@ struct AnalysisDataProcessorBuilder {
         }
       } else {
         // non-grouping case
-
+        overwriteInternalIndices(associatedTables, associatedTables);
         // bind partitions and grouping table
         homogeneous_apply_refs([&groupingTable](auto& x) {
           PartitionManager<std::decay_t<decltype(x)>>::bindExternalIndices(x, &groupingTable);

--- a/Framework/Core/test/test_ASoA.cxx
+++ b/Framework/Core/test/test_ASoA.cxx
@@ -811,7 +811,7 @@ BOOST_AUTO_TEST_CASE(TestAdvancedIndices)
   }
   auto t3 = b3.finalize();
   auto pst = PointsSelfIndex{t3};
-  pst.bindInternalIndices();
+  pst.bindInternalIndicesTo(&pst);
   auto i = 0;
   c1 = 0;
   c2 = 0;


### PR DESCRIPTION
@fgrosa this explicitly sets the self-index binding, so that your code works with https://github.com/AliceO2Group/O2Physics/pull/668 reverted. 