### PR TITLE
Move alignment objects to DET/Calib/Align

### DIFF
--- a/Common/Utils/include/CommonUtils/NameConf.h
+++ b/Common/Utils/include/CommonUtils/NameConf.h
@@ -127,7 +127,7 @@ class NameConf : public o2::conf::ConfigurableParamHelper<NameConf>
   static constexpr std::string_view NOISEFILENAME = "NoiseMap";
   static constexpr std::string_view MATBUDLUT = "matbud";
   static constexpr std::string_view COLLISIONCONTEXT = "collisioncontext";
-  static constexpr std::string_view ALIGNPATH = "Align";
+  static constexpr std::string_view ALIGNPATH = "Calib/Align";
   static constexpr std::string_view TFIDINFO = "tfidinfo";
 
   // these are configurable paths for some commonly used files

--- a/macro/UploadDummyAlignment.C
+++ b/macro/UploadDummyAlignment.C
@@ -12,7 +12,7 @@
 using DetID = o2::detectors::DetID;
 
 // upload dummy alignment objects to CCDB
-void UploadDummyAlignment(const std::string& ccdbHost = "http://ccdb-test.cern.ch:8080", long tmin = 0, long tmax = -1, DetID::mask_t msk = DetID::FullMask)
+void UploadDummyAlignment(const std::string& ccdbHost = "http://ccdb-test.cern.ch:8080", long tmin = 1, long tmax = 99999999999999, DetID::mask_t msk = DetID::FullMask)
 {
   DetID::mask_t dets = msk & DetID::FullMask & (~DetID::getMask(DetID::CTP));
   LOG(info) << "Mask = " << dets;
@@ -27,6 +27,7 @@ void UploadDummyAlignment(const std::string& ccdbHost = "http://ccdb-test.cern.c
     map<string, string> metadata; // can be empty
     DetID det(id);
     metadata["comment"] = fmt::format("Empty alignment object for {}", det.getName());
+    metadata["default"] = "true";
     api.storeAsTFileAny(&params, o2::base::DetectorNameConf::getAlignmentPath(det), metadata, tmin, tmax);
     LOG(info) << "Uploaded dummy alignment for " << det.getName();
   }

--- a/macro/UploadDummyAlignment.C
+++ b/macro/UploadDummyAlignment.C
@@ -27,7 +27,7 @@ void UploadDummyAlignment(const std::string& ccdbHost = "http://ccdb-test.cern.c
     map<string, string> metadata; // can be empty
     DetID det(id);
     metadata["comment"] = fmt::format("Empty alignment object for {}", det.getName());
-    metadata["default"] = "true";
+    metadata["default"] = "true"; // tag default objects
     api.storeAsTFileAny(&params, o2::base::DetectorNameConf::getAlignmentPath(det), metadata, tmin, tmax);
     LOG(info) << "Uploaded dummy alignment for " << det.getName();
   }


### PR DESCRIPTION
Default (dummy) objects as well as ITS and MFT prealigments are re-uploaded to update directories.