### PR TITLE
Apply TF ordering policy to all writers

### DIFF
--- a/Detectors/CPV/workflow/src/cluster-writer-workflow.cxx
+++ b/Detectors/CPV/workflow/src/cluster-writer-workflow.cxx
@@ -13,6 +13,7 @@
 #include <vector>
 #include "Framework/Variant.h"
 #include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
 #include "DPLUtils/MakeRootTreeWriterSpec.h"
 #include "CommonUtils/ConfigurableParam.h"
 #include "CPVWorkflow/WriterSpec.h"
@@ -26,6 +27,12 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
   std::vector<ConfigParamSpec> options{{"disable-mc", VariantType::Bool, false, {"Do not propagate MC labels"}},
                                        {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
   workflowOptions.insert(workflowOptions.end(), options.begin(), options.end());
+}
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:CPV|cpv).*[W,w]riter.*"));
 }
 
 #include "Framework/runDataProcessing.h"

--- a/Detectors/CPV/workflow/src/cpv-reco-workflow.cxx
+++ b/Detectors/CPV/workflow/src/cpv-reco-workflow.cxx
@@ -21,14 +21,23 @@
 #include "CommonUtils/ConfigurableParam.h"
 #include "DetectorsRaw/HBFUtilsInitializer.h"
 #include "Framework/CallbacksPolicy.h"
+#include "Framework/CompletionPolicyHelpers.h"
 
 #include <string>
 #include <stdexcept>
 #include <unordered_map>
 
+using namespace o2::framework;
+
 void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
 {
   o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:CPV|cpv).*[W,w]riter.*"));
 }
 
 // add workflow options, note that customization needs to be declared before

--- a/Detectors/CTF/workflow/src/ctf-writer-workflow.cxx
+++ b/Detectors/CTF/workflow/src/ctf-writer-workflow.cxx
@@ -14,6 +14,7 @@
 #include "Framework/Logger.h"
 #include "Framework/ControlService.h"
 #include "Framework/ConfigParamRegistry.h"
+#include "Framework/CompletionPolicyHelpers.h"
 #include "Framework/InputSpec.h"
 #include "CommonUtils/NameConf.h"
 #include "CTFWorkflow/CTFWriterSpec.h"
@@ -37,6 +38,12 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   options.push_back(ConfigParamSpec{"ctf-writer-verbosity", VariantType::Int, 0, {"verbosity level (0: summary per detector, 1: summary per block"}});
   options.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}});
   std::swap(workflowOptions, options);
+}
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:CTF|ctf).*[W,w]riter.*"));
 }
 
 // ------------------------------------------------------------------

--- a/Detectors/EMCAL/workflow/src/cell-writer-workflow.cxx
+++ b/Detectors/EMCAL/workflow/src/cell-writer-workflow.cxx
@@ -13,6 +13,7 @@
 #include <vector>
 #include "Framework/Variant.h"
 #include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
 #include "DPLUtils/MakeRootTreeWriterSpec.h"
 #include "DataFormatsEMCAL/MCLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
@@ -29,6 +30,12 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
   std::vector<ConfigParamSpec> options{{"disable-mc", VariantType::Bool, false, {"Do not propagate MC labels"}},
                                        {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
   workflowOptions.insert(workflowOptions.end(), options.begin(), options.end());
+}
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:EMC|emc).*[W,w]riter.*"));
 }
 
 #include "Framework/runDataProcessing.h"

--- a/Detectors/EMCAL/workflow/src/emc-reco-workflow.cxx
+++ b/Detectors/EMCAL/workflow/src/emc-reco-workflow.cxx
@@ -16,6 +16,7 @@
 
 #include "Framework/WorkflowSpec.h"
 #include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
 #include "EMCALWorkflow/RecoWorkflow.h"
 #include "Algorithm/RangeTokenizer.h"
 #include "DetectorsRaw/HBFUtilsInitializer.h"
@@ -26,9 +27,17 @@
 #include <stdexcept>
 #include <unordered_map>
 
+using namespace o2::framework;
+
 void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
 {
   o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:EMC|emc).*[W,w]riter.*"));
 }
 
 // add workflow options, note that customization needs to be declared before

--- a/Detectors/FIT/FDD/workflow/src/digits-writer-workflow.cxx
+++ b/Detectors/FIT/FDD/workflow/src/digits-writer-workflow.cxx
@@ -11,6 +11,7 @@
 
 #include "CommonUtils/ConfigurableParam.h"
 #include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
 
 using namespace o2::framework;
 
@@ -22,6 +23,12 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation even if available"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
   std::swap(workflowOptions, options);
+}
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:FDD|fdd).*[W,w]riter.*"));
 }
 
 #include "Framework/runDataProcessing.h"

--- a/Detectors/FIT/FDD/workflow/src/fdd-flp-workflow.cxx
+++ b/Detectors/FIT/FDD/workflow/src/fdd-flp-workflow.cxx
@@ -16,10 +16,16 @@
 #include "DataFormatsFDD/MCLabel.h"
 #include "FDDRaw/RawReaderFDDBase.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
+#include "Framework/CompletionPolicyHelpers.h"
 
 using namespace o2::framework;
 
 // ------------------------------------------------------------------
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:FDD|fdd).*[W,w]riter.*"));
+}
 
 // we need to add workflow options before including Framework/runDataProcessing
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)

--- a/Detectors/FIT/FDD/workflow/src/fdd-reco-workflow.cxx
+++ b/Detectors/FIT/FDD/workflow/src/fdd-reco-workflow.cxx
@@ -14,6 +14,7 @@
 #include "CommonUtils/ConfigurableParam.h"
 #include "DetectorsRaw/HBFUtilsInitializer.h"
 #include "Framework/CallbacksPolicy.h"
+#include "Framework/CompletionPolicyHelpers.h"
 
 using namespace o2::framework;
 
@@ -21,6 +22,12 @@ using namespace o2::framework;
 void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
 {
   o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:FDD|fdd).*[W,w]riter.*"));
 }
 
 // we need to add workflow options before including Framework/runDataProcessing

--- a/Detectors/FIT/FT0/calibration/testWorkflow/calib-global-offsets.cxx
+++ b/Detectors/FIT/FT0/calibration/testWorkflow/calib-global-offsets.cxx
@@ -24,10 +24,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
   // option allowing to set parameters
   std::vector<o2::framework::ConfigParamSpec> options{
-    {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input reader"}},
-    {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writer"}},
     {"disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation"}},
-    {"info-sources", VariantType::String, std::string{GID::ALL}, {"comma-separated list of sources to use"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
 
   std::swap(workflowOptions, options);

--- a/Detectors/FIT/FT0/workflow/src/digits-writer-workflow.cxx
+++ b/Detectors/FIT/FT0/workflow/src/digits-writer-workflow.cxx
@@ -11,6 +11,7 @@
 
 #include "CommonUtils/ConfigurableParam.h"
 #include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
 
 using namespace o2::framework;
 
@@ -22,6 +23,12 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation even if available"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
   std::swap(workflowOptions, options);
+}
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:FT0|ft0).*[W,w]riter.*"));
 }
 
 #include "Framework/runDataProcessing.h"

--- a/Detectors/FIT/FT0/workflow/src/ft0-flp-workflow.cxx
+++ b/Detectors/FIT/FT0/workflow/src/ft0-flp-workflow.cxx
@@ -16,10 +16,16 @@
 #include "DataFormatsFT0/MCLabel.h"
 #include "FT0Raw/RawReaderFT0Base.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
+#include "Framework/CompletionPolicyHelpers.h"
 
 using namespace o2::framework;
 
 // ------------------------------------------------------------------
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:FT0|ft0).*[W,w]riter.*"));
+}
 
 // we need to add workflow options before including Framework/runDataProcessing
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)

--- a/Detectors/FIT/FT0/workflow/src/ft0-reco-workflow.cxx
+++ b/Detectors/FIT/FT0/workflow/src/ft0-reco-workflow.cxx
@@ -15,6 +15,7 @@
 #include "Framework/CallbacksPolicy.h"
 #include "CommonUtils/NameConf.h"
 #include <string>
+#include "Framework/CompletionPolicyHelpers.h"
 
 using namespace o2::framework;
 
@@ -22,6 +23,12 @@ using namespace o2::framework;
 void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
 {
   o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:FT0|ft0).*[W,w]riter.*"));
 }
 
 // we need to add workflow options before including Framework/runDataProcessing

--- a/Detectors/FIT/FV0/workflow/src/digits-writer-workflow.cxx
+++ b/Detectors/FIT/FV0/workflow/src/digits-writer-workflow.cxx
@@ -11,6 +11,7 @@
 
 #include "CommonUtils/ConfigurableParam.h"
 #include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
 
 using namespace o2::framework;
 
@@ -22,6 +23,12 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation even if available"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
   std::swap(workflowOptions, options);
+}
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:FV0|fv0).*[W,w]riter.*"));
 }
 
 #include "Framework/runDataProcessing.h"

--- a/Detectors/FIT/FV0/workflow/src/fv0-flp-workflow.cxx
+++ b/Detectors/FIT/FV0/workflow/src/fv0-flp-workflow.cxx
@@ -16,10 +16,16 @@
 #include "DataFormatsFV0/MCLabel.h"
 #include "FV0Raw/RawReaderFV0Base.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
+#include "Framework/CompletionPolicyHelpers.h"
 
 using namespace o2::framework;
 
 // ------------------------------------------------------------------
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:FV0|fv0).*[W,w]riter.*"));
+}
 
 // we need to add workflow options before including Framework/runDataProcessing
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)

--- a/Detectors/FIT/FV0/workflow/src/fv0-reco-workflow.cxx
+++ b/Detectors/FIT/FV0/workflow/src/fv0-reco-workflow.cxx
@@ -14,6 +14,7 @@
 #include "DetectorsRaw/HBFUtilsInitializer.h"
 #include "Framework/CallbacksPolicy.h"
 #include "CommonUtils/NameConf.h"
+#include "Framework/CompletionPolicyHelpers.h"
 #include <string>
 
 using namespace o2::framework;
@@ -22,6 +23,12 @@ using namespace o2::framework;
 void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
 {
   o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:FV0|fv0).*[W,w]riter.*"));
 }
 
 // we need to add workflow options before including Framework/runDataProcessing

--- a/Detectors/Filtering/src/filtered-tf-writer-workflow.cxx
+++ b/Detectors/Filtering/src/filtered-tf-writer-workflow.cxx
@@ -11,6 +11,7 @@
 
 #include "CommonUtils/ConfigurableParam.h"
 #include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
 
 using namespace o2::framework;
 
@@ -19,6 +20,11 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   // option allowing to set parameters
   std::vector<o2::framework::ConfigParamSpec> options{{"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
   std::swap(workflowOptions, options);
+}
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*filterer-reco-tf-writer.*"));
 }
 
 #include "Framework/runDataProcessing.h"

--- a/Detectors/GlobalTrackingWorkflow/src/cosmics-match-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/cosmics-match-workflow.cxx
@@ -11,6 +11,7 @@
 
 #include "CommonUtils/ConfigurableParam.h"
 #include "Framework/CompletionPolicy.h"
+#include "Framework/CompletionPolicyHelpers.h"
 #include "TPCReaderWorkflow/TPCSectorCompletionPolicy.h"
 #include "ITSWorkflow/TrackReaderSpec.h"
 #include "ITSMFTWorkflow/ClusterReaderSpec.h"
@@ -63,6 +64,7 @@ void customize(std::vector<o2::framework::CompletionPolicy>& policies)
   policies.push_back(o2::tpc::TPCSectorCompletionPolicy("cosmics-matcher",
                                                         o2::tpc::TPCSectorCompletionPolicy::Config::RequireAll,
                                                         InputSpec{"cluster", o2::framework::ConcreteDataTypeMatcher{"TPC", "CLUSTERNATIVE"}})());
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*cosm.*[W,w]riter.*"));
 }
 
 // ------------------------------------------------------------------

--- a/Detectors/GlobalTrackingWorkflow/src/globalfwd-matcher-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/globalfwd-matcher-workflow.cxx
@@ -13,6 +13,7 @@
 #include "DetectorsCommonDataFormats/DetID.h"
 #include "CommonUtils/ConfigurableParam.h"
 #include "Framework/DataProcessorSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
 #include "DetectorsRaw/HBFUtilsInitializer.h"
 #include "Framework/CallbacksPolicy.h"
 #include "GlobalTrackingWorkflow/GlobalFwdMatchingSpec.h"
@@ -27,6 +28,12 @@ using GID = o2::dataformats::GlobalTrackID;
 void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
 {
   o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:FWD|fwd).*[W,w]riter.*"));
 }
 
 // we need to add workflow options before including Framework/runDataProcessing

--- a/Detectors/GlobalTrackingWorkflow/src/primary-vertexing-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/primary-vertexing-workflow.cxx
@@ -27,6 +27,7 @@
 #include "CommonUtils/ConfigurableParam.h"
 #include "Framework/CompletionPolicy.h"
 #include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
 
 using namespace o2::framework;
 using GID = o2::dataformats::GlobalTrackID;
@@ -35,6 +36,12 @@ using DetID = o2::detectors::DetID;
 void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
 {
   o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*primary-vertex-writer.*"));
 }
 
 // we need to add workflow options before including Framework/runDataProcessing

--- a/Detectors/GlobalTrackingWorkflow/src/secondary-vertexing-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/secondary-vertexing-workflow.cxx
@@ -25,6 +25,7 @@
 #include "Framework/CallbacksPolicy.h"
 #include "Framework/CompletionPolicy.h"
 #include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
 
 using namespace o2::framework;
 using GID = o2::dataformats::GlobalTrackID;
@@ -33,6 +34,12 @@ using DetID = o2::detectors::DetID;
 void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
 {
   o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*secondary-vertex-writer.*"));
 }
 
 // we need to add workflow options before including Framework/runDataProcessing

--- a/Detectors/GlobalTrackingWorkflow/src/tfidinfo-writer-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/tfidinfo-writer-workflow.cxx
@@ -12,8 +12,15 @@
 #include "CommonUtils/ConfigurableParam.h"
 #include "Framework/ConfigParamSpec.h"
 #include "DetectorsBase/TFIDInfoHelper.h"
+#include "Framework/CompletionPolicyHelpers.h"
 
 using namespace o2::framework;
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*tfid-info-writer.*"));
+}
 
 // we need to add workflow options before including Framework/runDataProcessing
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)

--- a/Detectors/GlobalTrackingWorkflow/src/tof-eventtime-checker-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/tof-eventtime-checker-workflow.cxx
@@ -44,8 +44,6 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   // option allowing to set parameters
   std::vector<o2::framework::ConfigParamSpec> options{
     {"disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation even if available"}},
-    {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input reader"}},
-    {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writer"}},
     {"track-sources", VariantType::String, std::string{GID::ALL}, {"comma-separated list of sources to use: allowed TPC-TOF,ITS-TPC-TOF,TPC-TRD-TOF,ITS-TPC-TRD-TOF (all)"}},
     {"event-time-spread", o2::framework::VariantType::Float, 200.0f, {"Event time spread"}},
     {"lhc-phase", o2::framework::VariantType::Float, 0.0f, {"LHCp phase"}},
@@ -71,8 +69,6 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   o2::conf::ConfigurableParam::writeINI("o2eventtime-check-tof-workflow_configuration.ini");
 
   auto useMC = !configcontext.options().get<bool>("disable-mc");
-  auto disableRootIn = configcontext.options().get<bool>("disable-root-input");
-  auto disableRootOut = configcontext.options().get<bool>("disable-root-output");
 
   auto spread = configcontext.options().get<float>("event-time-spread");
   auto phase = configcontext.options().get<float>("lhc-phase");
@@ -118,9 +114,6 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 
   LOG(debug) << "TOF EVENTTIME CHECKER WORKFLOW configuration";
   LOG(debug) << "TOF track inputs = " << configcontext.options().get<std::string>("track-sources");
-  LOG(debug) << "TOF disable-mc = " << configcontext.options().get<std::string>("disable-mc");
-  LOG(debug) << "TOF disable-root-input = " << disableRootIn;
-  LOG(debug) << "TOF disable-root-output = " << disableRootOut;
 
   GID::mask_t alowedSources = GID::getSourcesMask("ITS-TPC-TOF,TPC-TOF,ITS-TPC-TRD-TOF,TPC-TRD-TOF,ITS-TPC,TPC,ITS-TPC-TRD,TPC-TRD");
 

--- a/Detectors/GlobalTrackingWorkflow/src/tof-match-checker-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/tof-match-checker-workflow.cxx
@@ -25,6 +25,7 @@
 #include "Algorithm/RangeTokenizer.h"
 #include "DetectorsRaw/HBFUtilsInitializer.h"
 #include "Framework/CallbacksPolicy.h"
+#include "Framework/CompletionPolicyHelpers.h"
 #include "GlobalTrackingWorkflowHelpers/InputHelper.h"
 
 using namespace o2::framework;
@@ -36,14 +37,18 @@ void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
   o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
 }
 
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:ITS|its).*[W,w]riter.*"));
+}
+
 // we need to add workflow options before including Framework/runDataProcessing
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   // option allowing to set parameters
   std::vector<o2::framework::ConfigParamSpec> options{
     {"disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation even if available"}},
-    {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input reader"}},
-    {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writer"}},
     {"track-sources", VariantType::String, std::string{GID::ALL}, {"comma-separated list of sources to use: allowed TPC-TOF,ITS-TPC-TOF,TPC-TRD-TOF,ITS-TPC-TRD-TOF (all)"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
@@ -64,14 +69,10 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   o2::conf::ConfigurableParam::writeINI("o2match-check-tof-workflow_configuration.ini");
 
   auto useMC = !configcontext.options().get<bool>("disable-mc");
-  auto disableRootIn = configcontext.options().get<bool>("disable-root-input");
-  auto disableRootOut = configcontext.options().get<bool>("disable-root-output");
 
   LOG(debug) << "TOF MATCHER WORKFLOW configuration";
   LOG(debug) << "TOF track inputs = " << configcontext.options().get<std::string>("track-sources");
   LOG(debug) << "TOF disable-mc = " << configcontext.options().get<std::string>("disable-mc");
-  LOG(debug) << "TOF disable-root-input = " << disableRootIn;
-  LOG(debug) << "TOF disable-root-output = " << disableRootOut;
 
   GID::mask_t alowedSources = GID::getSourcesMask("ITS-TPC-TOF,TPC-TOF,ITS-TPC-TRD-TOF,TPC-TRD-TOF");
 

--- a/Detectors/GlobalTrackingWorkflow/src/tof-matcher-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/tof-matcher-workflow.cxx
@@ -12,6 +12,7 @@
 #include "CommonUtils/ConfigurableParam.h"
 #include "Framework/CompletionPolicy.h"
 #include "TPCReaderWorkflow/TPCSectorCompletionPolicy.h"
+#include "Framework/CompletionPolicyHelpers.h"
 #include "ITSWorkflow/TrackReaderSpec.h"
 #include "TPCReaderWorkflow/TrackReaderSpec.h"
 #include "TOFWorkflowIO/ClusterReaderSpec.h"
@@ -37,6 +38,12 @@ using GID = o2::dataformats::GlobalTrackID;
 void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
 {
   o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:TOF|tof).*[W,w]riter.*"));
 }
 
 // we need to add workflow options before including Framework/runDataProcessing

--- a/Detectors/GlobalTrackingWorkflow/src/tpcits-match-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/tpcits-match-workflow.cxx
@@ -22,6 +22,7 @@
 #include "DetectorsRaw/HBFUtilsInitializer.h"
 #include "Framework/CallbacksPolicy.h"
 #include "Framework/ConfigContext.h"
+#include "Framework/CompletionPolicyHelpers.h"
 
 using namespace o2::framework;
 using GID = o2::dataformats::GlobalTrackID;
@@ -55,6 +56,7 @@ void customize(std::vector<o2::framework::CompletionPolicy>& policies)
   policies.push_back(o2::tpc::TPCSectorCompletionPolicy("itstpc-track-matcher",
                                                         o2::tpc::TPCSectorCompletionPolicy::Config::RequireAll,
                                                         o2::framework::InputSpec{"cluster", o2::framework::ConcreteDataTypeMatcher{"TPC", "CLUSTERNATIVE"}})());
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*itstpc-track-writer.*"));
 }
 
 // ------------------------------------------------------------------

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-reco-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-reco-workflow.cxx
@@ -31,6 +31,7 @@
 #include "CommonUtils/NameConf.h"
 #include "DetectorsRaw/HBFUtilsInitializer.h"
 #include "Framework/CallbacksPolicy.h"
+#include "Framework/CompletionPolicyHelpers.h"
 
 #include <string>
 #include <stdexcept>
@@ -39,6 +40,12 @@
 void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
 {
   o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:TOF|tof).*[W,w]riter.*"));
 }
 
 // add workflow options, note that customization needs to be declared before

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/tpc-interpolation-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/tpc-interpolation-workflow.cxx
@@ -14,6 +14,7 @@
 #include "TPCReaderWorkflow/TPCSectorCompletionPolicy.h"
 #include "DetectorsRaw/HBFUtilsInitializer.h"
 #include "Framework/CallbacksPolicy.h"
+#include "Framework/CompletionPolicyHelpers.h"
 #include "ReconstructionDataFormats/GlobalTrackID.h"
 #include "GlobalTrackingWorkflowHelpers/InputHelper.h"
 #include "TPCInterpolationWorkflow/TPCInterpolationSpec.h"
@@ -53,6 +54,8 @@ void customize(std::vector<o2::framework::CompletionPolicy>& policies)
   policies.push_back(o2::tpc::TPCSectorCompletionPolicy("tpc-track-interpolation",
                                                         o2::tpc::TPCSectorCompletionPolicy::Config::RequireAll,
                                                         InputSpec{"cluster", o2::framework::ConcreteDataTypeMatcher{"TPC", "CLUSTERNATIVE"}})());
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*tpc-residuals-writer.*"));
 }
 
 // ------------------------------------------------------------------

--- a/Detectors/GlobalTrackingWorkflow/writers/src/irframe-writer-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/writers/src/irframe-writer-workflow.cxx
@@ -10,8 +10,15 @@
 // or submit itself to any jurisdiction.
 
 #include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
 
 using namespace o2::framework;
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:IRFR|irfr).*[W,w]riter.*"));
+}
 
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {

--- a/Detectors/ITSMFT/ITS/workflow/src/its-cluster-writer-workflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/its-cluster-writer-workflow.cxx
@@ -11,8 +11,15 @@
 
 #include "ITSWorkflow/ClusterWriterWorkflow.h"
 #include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
 
 using namespace o2::framework;
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:ITS|its).*[W,w]riter.*"));
+}
 
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {

--- a/Detectors/ITSMFT/ITS/workflow/src/its-reco-workflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/its-reco-workflow.cxx
@@ -16,6 +16,7 @@
 #include "DetectorsRaw/HBFUtilsInitializer.h"
 #include "Framework/CallbacksPolicy.h"
 #include "Framework/ConfigContext.h"
+#include "Framework/CompletionPolicyHelpers.h"
 
 #include "GPUO2Interface.h"
 #include "GPUReconstruction.h"
@@ -27,6 +28,13 @@ using namespace o2::framework;
 void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
 {
   o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:ITS|its).*[W,w]riter.*"));
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*irframe-writer.*"));
 }
 
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)

--- a/Detectors/ITSMFT/MFT/workflow/src/mft-reco-workflow.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/mft-reco-workflow.cxx
@@ -13,12 +13,19 @@
 #include "CommonUtils/ConfigurableParam.h"
 #include "DetectorsRaw/HBFUtilsInitializer.h"
 #include "Framework/CallbacksPolicy.h"
+#include "Framework/CompletionPolicyHelpers.h"
 
 using namespace o2::framework;
 
 void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
 {
   o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:MFT|mft).*[W,w]riter.*"));
 }
 
 // we need to add workflow options before including Framework/runDataProcessing

--- a/Detectors/ITSMFT/common/workflow/src/digit-writer-workflow.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/digit-writer-workflow.cxx
@@ -12,10 +12,16 @@
 #include "ITSMFTWorkflow/DigitWriterSpec.h"
 #include "CommonUtils/ConfigurableParam.h"
 #include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
 
 using namespace o2::framework;
 
 // ------------------------------------------------------------------
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:ITS|its|MFT|mft).*[W,w]riter.*"));
+}
 
 // we need to add workflow options before including Framework/runDataProcessing
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)

--- a/Detectors/MUON/MCH/DevIO/Digits/digits-writer-workflow.cxx
+++ b/Detectors/MUON/MCH/DevIO/Digits/digits-writer-workflow.cxx
@@ -29,6 +29,7 @@
 #include "Framework/Output.h"
 #include "Framework/Task.h"
 #include "Framework/WorkflowSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
 #include "MCHRawDecoder/OrbitInfo.h"
 #include <fstream>
 #include <iostream>
@@ -47,6 +48,12 @@ constexpr const char* OPTNAME_NO_FILE = "no-file";
 constexpr const char* OPTNAME_BINARY_FORMAT = "binary-file-format";
 constexpr const char* OPTNAME_WITHOUT_ORBITS = "without-orbits";
 constexpr const char* OPTNAME_MAX_SIZE = "max-size";
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:MCH|mch).*[W,w]riter.*"));
+}
 
 template <typename T>
 using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;

--- a/Detectors/MUON/MCH/Workflow/src/clusters-writer-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/clusters-writer-workflow.cxx
@@ -12,8 +12,15 @@
 #include <vector>
 #include "Framework/ConfigParamSpec.h"
 #include "MCHWorkflow/ClusterWriterSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
 
 using namespace o2::framework;
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:MCH|mch).*[W,w]riter.*"));
+}
 
 // we need to add workflow options before including Framework/runDataProcessing
 void customize(std::vector<ConfigParamSpec>& workflowOptions)

--- a/Detectors/MUON/MCH/Workflow/src/reco-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/reco-workflow.cxx
@@ -15,6 +15,7 @@
 #include "DigitFilteringSpec.h"
 #include "DigitReaderSpec.h"
 #include "Framework/CallbacksPolicy.h"
+#include "Framework/CompletionPolicyHelpers.h"
 #include "Framework/ConfigContext.h"
 #include "Framework/Logger.h"
 #include "Framework/Variant.h"
@@ -28,14 +29,17 @@
 #include "TrackFitterSpec.h"
 #include "TrackMCLabelFinderSpec.h"
 
-using o2::framework::ConfigContext;
-using o2::framework::ConfigParamSpec;
-using o2::framework::VariantType;
-using o2::framework::WorkflowSpec;
+using namespace o2::framework;
 
 void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
 {
   o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:MCH|mch).*[W,w]riter.*"));
 }
 
 void customize(std::vector<ConfigParamSpec>& workflowOptions)

--- a/Detectors/MUON/MCH/Workflow/src/tracks-writer-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/tracks-writer-workflow.cxx
@@ -11,9 +11,16 @@
 
 #include <vector>
 #include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
 #include "MCHWorkflow/TrackWriterSpec.h"
 
 using namespace o2::framework;
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:MCH|mch).*[W,w]riter.*"));
+}
 
 // we need to add workflow options before including Framework/runDataProcessing
 void customize(std::vector<ConfigParamSpec>& workflowOptions)

--- a/Detectors/MUON/MID/Workflow/src/decoded-digits-writer-workflow.cxx
+++ b/Detectors/MUON/MID/Workflow/src/decoded-digits-writer-workflow.cxx
@@ -18,6 +18,7 @@
 #include <vector>
 #include "Framework/Variant.h"
 #include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
 
 using namespace o2::framework;
 
@@ -28,6 +29,12 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     options{
       {"output-filename", VariantType::String, "mid-digits-decoded.root", {"Decoded digits output file"}}};
   workflowOptions.insert(workflowOptions.end(), options.begin(), options.end());
+}
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:MID|mid).*[W,w]riter.*"));
 }
 
 #include "Framework/runDataProcessing.h"

--- a/Detectors/MUON/MID/Workflow/src/reco-workflow.cxx
+++ b/Detectors/MUON/MID/Workflow/src/reco-workflow.cxx
@@ -19,6 +19,7 @@
 #include <vector>
 #include "Framework/Variant.h"
 #include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
 #include "DPLUtils/MakeRootTreeWriterSpec.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
@@ -32,6 +33,12 @@
 #include "CommonUtils/ConfigurableParam.h"
 
 using namespace o2::framework;
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:MID|mid).*[W,w]riter.*"));
+}
 
 // we need to add workflow options before including Framework/runDataProcessing
 void customize(std::vector<ConfigParamSpec>& workflowOptions)

--- a/Detectors/MUON/Workflow/src/tracks-writer-workflow.cxx
+++ b/Detectors/MUON/Workflow/src/tracks-writer-workflow.cxx
@@ -14,10 +14,17 @@
 ///
 /// \author Philippe Pillot, Subatech
 
-#include "Framework/runDataProcessing.h"
 #include "TrackWriterSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
 
 using namespace o2::framework;
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:MCH|mch).*[W,w]riter.*"));
+}
+
+#include "Framework/runDataProcessing.h"
 
 WorkflowSpec defineDataProcessing(const ConfigContext&)
 {

--- a/Detectors/PHOS/workflow/src/cell-writer-workflow.cxx
+++ b/Detectors/PHOS/workflow/src/cell-writer-workflow.cxx
@@ -16,6 +16,7 @@
 #include "DPLUtils/MakeRootTreeWriterSpec.h"
 #include "CommonUtils/ConfigurableParam.h"
 #include "PHOSWorkflow/WriterSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
 
 using namespace o2::framework;
 using namespace o2::phos;
@@ -26,6 +27,12 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
   std::vector<ConfigParamSpec> options{{"disable-mc", VariantType::Bool, false, {"Do not propagate MC labels"}},
                                        {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
   workflowOptions.insert(workflowOptions.end(), options.begin(), options.end());
+}
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:PHO?S|pho?s).*[W,w]riter.*"));
 }
 
 #include "Framework/runDataProcessing.h"

--- a/Detectors/PHOS/workflow/src/phos-reco-workflow.cxx
+++ b/Detectors/PHOS/workflow/src/phos-reco-workflow.cxx
@@ -21,14 +21,23 @@
 #include "CommonUtils/ConfigurableParam.h"
 #include "DetectorsRaw/HBFUtilsInitializer.h"
 #include "Framework/CallbacksPolicy.h"
+#include "Framework/CompletionPolicyHelpers.h"
 
 #include <string>
 #include <stdexcept>
 #include <unordered_map>
 
+using namespace o2::framework;
+
 void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
 {
   o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:PHO?S|pho?s).*[W,w]riter.*"));
 }
 
 // add workflow options, note that customization needs to be declared before

--- a/Detectors/TOF/workflow/src/cluster-writer-commissioning.cxx
+++ b/Detectors/TOF/workflow/src/cluster-writer-commissioning.cxx
@@ -12,6 +12,7 @@
 #include "TOFWorkflowIO/TOFClusterWriterSplitterSpec.h"
 #include "CommonUtils/ConfigurableParam.h"
 #include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
 
 using namespace o2::framework;
 
@@ -24,6 +25,11 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   workflowOptions.push_back(ConfigParamSpec{"ntf", o2::framework::VariantType::Int, 1, {"number of timeframe written for output file"}});
 }
 
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:TOF|tof).*[W,w]riter.*"));
+}
 // ------------------------------------------------------------------
 
 #include "Framework/runDataProcessing.h"

--- a/Detectors/TOF/workflow/src/digit-writer-commissioning.cxx
+++ b/Detectors/TOF/workflow/src/digit-writer-commissioning.cxx
@@ -12,10 +12,16 @@
 #include "TOFWorkflowIO/TOFDigitWriterSplitterSpec.h"
 #include "CommonUtils/ConfigurableParam.h"
 #include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
 
 using namespace o2::framework;
 
 // ------------------------------------------------------------------
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:TOF|tof).*[W,w]riter.*"));
+}
 
 // we need to add workflow options before including Framework/runDataProcessing
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)

--- a/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
+++ b/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
@@ -97,12 +97,7 @@ void customize(std::vector<o2::framework::CompletionPolicy>& policies)
   policies.push_back(CompletionPolicyHelpers::defineByName("tpc-cluster-decoder.*", CompletionPolicy::CompletionOp::Consume));
   policies.push_back(CompletionPolicyHelpers::defineByName("tpc-clusterer.*", CompletionPolicy::CompletionOp::Consume));
   // ordered policies for the writers
-  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered("tpc-digits-writer.*"));
-  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered("tpc-clusterhardware-writer.*"));
-  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered("tpc-native-cluster-writer.*"));
-  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered("tpc-track-writer.*"));
-  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered("tpc-compcluster-writer.*"));
-
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:TPC|tpc).*[w,W]riter.*"));
   // the custom completion policy for the tracker
   policies.push_back(o2::tpc::TPCSectorCompletionPolicy("tpc-tracker.*", o2::tpc::TPCSectorCompletionPolicy::Config::RequireAll, &gPolicyData, &gTpcSectorMask)());
 }

--- a/Detectors/TRD/workflow/io/src/TRDCalibratedTrackletWriterSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDCalibratedTrackletWriterSpec.cxx
@@ -30,7 +30,7 @@ o2::framework::DataProcessorSpec getTRDCalibratedTrackletWriterSpec(bool useMC)
 {
   using MakeRootTreeWriterSpec = framework::MakeRootTreeWriterSpec;
 
-  return MakeRootTreeWriterSpec("calibrated-tracklet-writer",
+  return MakeRootTreeWriterSpec("trd-calibrated-tracklet-writer",
                                 "trdcalibratedtracklets.root",
                                 "ctracklets",
                                 BranchDefinition<std::vector<CalibratedTracklet>>{InputSpec{"ctracklets", "TRD", "CTRACKLETS"}, "CTracklets"},

--- a/Detectors/TRD/workflow/io/src/TRDTrackletWriterSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDTrackletWriterSpec.cxx
@@ -45,7 +45,7 @@ o2::framework::DataProcessorSpec getTRDTrackletWriterSpec(bool useMC)
       output << " 10 " << endl;
   }*/
   //LOG(info) << "before writing out the tracklet size is " << Tracklet->size();
-  return MakeRootTreeWriterSpec("TRDTrkltWrt",
+  return MakeRootTreeWriterSpec("TRD-tracklet-writer",
                                 "trdtracklets.root",
                                 "o2sim",
                                 BranchDefinition<std::vector<o2::trd::Tracklet64>>{InputSpec{"tracklets", "TRD", "TRACKLETS"}, "Tracklet"},

--- a/Detectors/TRD/workflow/io/src/TRDTrapRawWriterSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDTrapRawWriterSpec.cxx
@@ -37,7 +37,7 @@ o2::framework::DataProcessorSpec getTRDTrapRawWriterSpec()
 {
   //  using InputSpec = framework::InputSpec;
   using MakeRootTreeWriterSpec = framework::MakeRootTreeWriterSpec;
-  return MakeRootTreeWriterSpec("TRDTrkltRawWrt",
+  return MakeRootTreeWriterSpec("TRDTrkltRawWriter",
                                 "trdtrapraw.root",
                                 "o2sim",
                                 BranchDefinition<std::vector<uint32_t>>{InputSpec{"trapraw", "TRD", "RAWDATA"}, "TrapRaw"},

--- a/Detectors/TRD/workflow/io/src/trd-digittracklet-writer-workflow.cxx
+++ b/Detectors/TRD/workflow/io/src/trd-digittracklet-writer-workflow.cxx
@@ -14,6 +14,7 @@
 #include "Framework/ConfigParamSpec.h"
 #include "TRDWorkflowIO/TRDTrackletWriterSpec.h"
 #include "TRDWorkflowIO/TRDDigitWriterSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
 
 using namespace o2::framework;
 
@@ -29,6 +30,12 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
 
   std::swap(workflowOptions, options);
+}
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:TRD|trd).*[W,w]riter.*"));
 }
 
 // ------------------------------------------------------------------

--- a/Detectors/TRD/workflow/src/TRDTrackletTransformerWorkflow.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrackletTransformerWorkflow.cxx
@@ -16,12 +16,19 @@
 #include "DetectorsRaw/HBFUtilsInitializer.h"
 #include "CommonUtils/ConfigurableParam.h"
 #include "Framework/CompletionPolicy.h"
+#include "Framework/CompletionPolicyHelpers.h"
 
 using namespace o2::framework;
 
 void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
 {
   o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:TRD|trd).*[W,w]riter.*"));
 }
 
 void customize(std::vector<ConfigParamSpec>& workflowOptions)

--- a/Detectors/TRD/workflow/src/TRDTrapSimulatorWorkFlow.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrapSimulatorWorkFlow.cxx
@@ -17,6 +17,7 @@
 #include "Algorithm/RangeTokenizer.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 #include "CommonUtils/ConfigurableParam.h"
+#include "Framework/CompletionPolicyHelpers.h"
 
 // for TRD
 #include "TRDWorkflow/TRDTrapSimulatorSpec.h"
@@ -36,6 +37,11 @@
 using namespace o2::framework;
 
 // ------------------------------------------------------------------
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:TRD|trd).*[W,w]riter.*"));
+}
 
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowoptions)
 {

--- a/Detectors/TRD/workflow/src/trd-kr-clusterer.cxx
+++ b/Detectors/TRD/workflow/src/trd-kr-clusterer.cxx
@@ -11,6 +11,7 @@
 
 #include "CommonUtils/ConfigurableParam.h"
 #include "Framework/CompletionPolicy.h"
+#include "Framework/CompletionPolicyHelpers.h"
 #include "TRDWorkflow/KrClustererSpec.h"
 #include "TRDWorkflowIO/TRDDigitReaderSpec.h"
 #include "TRDWorkflowIO/KrClusterWriterSpec.h"
@@ -31,6 +32,11 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   std::swap(workflowOptions, options);
 }
 
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:TRD|trd).*[W,w]riter.*"));
+}
 // ------------------------------------------------------------------
 
 #include "Framework/runDataProcessing.h"

--- a/Detectors/TRD/workflow/src/trd-tracking-workflow.cxx
+++ b/Detectors/TRD/workflow/src/trd-tracking-workflow.cxx
@@ -11,6 +11,7 @@
 
 #include "CommonUtils/ConfigurableParam.h"
 #include "Framework/CompletionPolicy.h"
+#include "Framework/CompletionPolicyHelpers.h"
 #include "DetectorsRaw/HBFUtilsInitializer.h"
 #include "Framework/CallbacksPolicy.h"
 #include "ReconstructionDataFormats/GlobalTrackID.h"
@@ -28,6 +29,12 @@ using GTrackID = o2::dataformats::GlobalTrackID;
 void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
 {
   o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:TRD|trd).*[W,w]riter.*"));
 }
 
 // we need to add workflow options before including Framework/runDataProcessing

--- a/Detectors/Upgrades/IT3/workflow/src/digit-writer-workflow.cxx
+++ b/Detectors/Upgrades/IT3/workflow/src/digit-writer-workflow.cxx
@@ -12,10 +12,16 @@
 #include "ITS3Workflow/DigitWriterSpec.h"
 #include "CommonUtils/ConfigurableParam.h"
 #include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
 
 using namespace o2::framework;
 
 // ------------------------------------------------------------------
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:IT|it).*[W,w]riter.*"));
+}
 
 // we need to add workflow options before including Framework/runDataProcessing
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)

--- a/Detectors/Upgrades/IT3/workflow/src/its3-reco-workflow.cxx
+++ b/Detectors/Upgrades/IT3/workflow/src/its3-reco-workflow.cxx
@@ -15,6 +15,7 @@
 #include "ITStracking/Configuration.h"
 #include "DetectorsRaw/HBFUtilsInitializer.h"
 #include "Framework/CallbacksPolicy.h"
+#include "Framework/CompletionPolicyHelpers.h"
 
 #include "GPUO2Interface.h"
 #include "GPUReconstruction.h"
@@ -26,6 +27,12 @@ using namespace o2::framework;
 void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
 {
   o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:ITS|its)3.*[W,w]riter.*"));
 }
 
 // we need to add workflow options before including Framework/runDataProcessing

--- a/Detectors/ZDC/workflow/src/o2-zdc-raw2digits.cxx
+++ b/Detectors/ZDC/workflow/src/o2-zdc-raw2digits.cxx
@@ -11,6 +11,7 @@
 
 #include "CommonUtils/ConfigurableParam.h"
 #include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
 
 using namespace o2::framework;
 
@@ -28,6 +29,12 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"ignore-dist-stf", VariantType::Bool, false, {"do not subscribe to FLP/DISTSUBTIMEFRAME/0 message (no lost TF recovery)"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
   std::swap(workflowOptions, options);
+}
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:ZDC|zdc).*[W,w]riter.*"));
 }
 
 // ------------------------------------------------------------------

--- a/Detectors/ZDC/workflow/src/reco-writer-workflow.cxx
+++ b/Detectors/ZDC/workflow/src/reco-writer-workflow.cxx
@@ -11,6 +11,7 @@
 
 #include "ZDCWorkflow/ZDCRecoWriterDPLSpec.h"
 #include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
 
 using namespace o2::framework;
 
@@ -22,6 +23,12 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
       o2::framework::VariantType::Bool,
       false,
       {"disable MC propagation even if available"}});
+}
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:ZDC|zdc).*[W,w]riter.*"));
 }
 
 #include "Framework/runDataProcessing.h"

--- a/Detectors/ZDC/workflow/src/zdc-reco-workflow.cxx
+++ b/Detectors/ZDC/workflow/src/zdc-reco-workflow.cxx
@@ -13,6 +13,7 @@
 #include "CommonUtils/ConfigurableParam.h"
 #include "DetectorsRaw/HBFUtilsInitializer.h"
 #include "Framework/CallbacksPolicy.h"
+#include "Framework/CompletionPolicyHelpers.h"
 
 using namespace o2::framework;
 
@@ -20,6 +21,12 @@ using namespace o2::framework;
 void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
 {
   o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:ZDC|zdc).*[W,w]riter.*"));
 }
 
 // we need to add workflow options before including Framework/runDataProcessing


### PR DESCRIPTION
In case the TFcounter order of the input data is not strictly incremental due to the upstream pipelines, order TFs before writing. 
Will not work if there are holes in TF counter (e.g. after the Dispatcher).