### PR TITLE
[EMCAL-548] Adapting the cell converter to handle mc labels

### DIFF
--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Constants.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Constants.h
@@ -90,14 +90,16 @@ std::ostream& operator<<(std::ostream& stream, ChannelType_t chantype);
 namespace constants
 {
 
-constexpr int OVERFLOWCUT = 950;             ///< sample overflow
-constexpr int ORDER = 2;                     ///< Order of shaping stages of the signal conditioning unit
-constexpr double TAU = 2.35;                 ///< Approximate shaping time
-constexpr Double_t EMCAL_TIMESAMPLE = 100.;  ///< Width of a timebin in nanoseconds
-constexpr Double_t EMCAL_ADCENERGY = 0.0162; ///< Energy of one ADC count in GeV/c^2
-constexpr Int_t EMCAL_HGLGFACTOR = 16;       ///< Conversion from High to Low Gain
-constexpr Int_t EMCAL_HGLGTRANSITION = 800;  ///< Transition from High to Low Gain
-constexpr Int_t EMCAL_MAXTIMEBINS = 15;      ///< Maximum number of time bins for time response
+constexpr int OVERFLOWCUT = 950;               ///< sample overflow
+constexpr int ORDER = 2;                       ///< Order of shaping stages of the signal conditioning unit
+constexpr double TAU = 2.35;                   ///< Approximate shaping time
+constexpr Double_t EMCAL_TIMESAMPLE = 100.;    ///< Width of a timebin in nanoseconds
+constexpr Double_t EMCAL_ADCENERGY = 0.0162;   ///< Energy of one ADC count in GeV/c^2
+constexpr Int_t EMCAL_HGLGFACTOR = 16;         ///< Conversion from High to Low Gain
+constexpr Int_t EMCAL_HGLGTRANSITION = 1024;   ///< Transition from High to Low Gain
+constexpr Int_t EMCAL_MAXTIMEBINS = 15;        ///< Maximum number of time bins for time response
+constexpr int MAX_RANGE_ADC = 0x3FF;           ///< Dynamic range of the ADCs (10 bit ADC)
+constexpr double EMCAL_TRU_ADCENERGY = 0.0786; ///< resolution of the TRU digitizer, @TODO check exact value
 } // namespace constants
 
 enum FitAlgorithm {

--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Digit.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Digit.h
@@ -35,7 +35,8 @@ class Digit : public DigitBase
  public:
   Digit() = default;
 
-  Digit(Short_t tower, Double_t amplitudeGeV, Double_t time, ChannelType_t ctype = ChannelType_t::HIGH_GAIN);
+  Digit(Short_t tower, Double_t amplitudeGeV, Double_t time);
+  Digit(Short_t tower, uint16_t noiseLG, uint16_t noiseHG, double time);
   ~Digit() = default; // override
 
   bool operator<(const Digit& other) const { return getTimeStamp() < other.getTimeStamp(); }
@@ -57,38 +58,50 @@ class Digit : public DigitBase
   void setTower(Short_t tower) { mTower = tower; }
   Short_t getTower() const { return mTower; }
 
-  void setAmplitude(Double_t amplitude); // GeV
-  Double_t getAmplitude() const { return getAmplitudeADC() * constants::EMCAL_ADCENERGY; }
+  void setAmplitude(Double_t amplitude) { mAmplitudeGeV = amplitude; }
+  Double_t getAmplitude() const;
 
-  void setEnergy(Double_t energy) { setAmplitude(energy); }
-  Double_t getEnergy() const { return getAmplitude(); }
+  void setEnergy(Double_t energy) { mAmplitudeGeV = energy; }
+  Double_t getEnergy() const { return mAmplitudeGeV; }
 
   void setAmplitudeADC(Short_t amplitude, ChannelType_t ctype = ChannelType_t::HIGH_GAIN);
-  Int_t getAmplitudeADC(ChannelType_t ctype = ChannelType_t::HIGH_GAIN) const;
+  Int_t getAmplitudeADC(ChannelType_t ctype) const;
+  Int_t getAmplitudeADC() const { return getAmplitudeADC(getType()); };
 
-  void setType(ChannelType_t ctype) { mChannelType = ctype; }
-  ChannelType_t getType() const { return mChannelType; }
+  void setType(ChannelType_t ctype) {}
+  ChannelType_t getType() const;
 
-  void setHighGain() { mChannelType = ChannelType_t::HIGH_GAIN; }
-  Bool_t getHighGain() const { return mChannelType == ChannelType_t::HIGH_GAIN; }
+  void setHighGain() {}
+  Bool_t getHighGain() const { return (getType() == ChannelType_t::HIGH_GAIN); };
 
-  void setLowGain() { mChannelType = ChannelType_t::LOW_GAIN; }
-  Bool_t getLowGain() const { return mChannelType == ChannelType_t::LOW_GAIN; }
+  void setLowGain() {}
+  Bool_t getLowGain() const { return (getType() == ChannelType_t::LOW_GAIN); };
 
-  void setTRU() { mChannelType = ChannelType_t::TRU; }
-  Bool_t getTRU() const { return mChannelType == ChannelType_t::TRU; }
+  void setTRU() { mIsTRU = true; }
+  Bool_t getTRU() const { return mIsTRU; }
 
-  void setLEDMon() { mChannelType = ChannelType_t::LEDMON; }
-  Bool_t getLEDMon() const { return mChannelType == ChannelType_t::LEDMON; }
+  void setLEDMon() {}
+  Bool_t getLEDMon() const { return false; }
 
   void PrintStream(std::ostream& stream) const;
+
+  void setNoiseLG(uint16_t noise) { mNoiseLG = noise; }
+  uint16_t getNoiseLG() const { return mNoiseLG; }
+
+  void setNoiseHG(uint16_t noise) { mNoiseHG = noise; }
+  uint16_t getNoiseHG() const { return mNoiseHG; }
+
+  void setNoiseTRU(uint16_t noise) { mNoiseHG = noise; }
+  uint16_t getNoiseTRU() const { return mNoiseHG; }
 
  private:
   friend class boost::serialization::access;
 
-  Short_t mAmplitude = 0;                                ///< Amplitude (ADC counts)
-  Short_t mTower = -1;                                   ///< Tower index (absolute cell ID)
-  ChannelType_t mChannelType = ChannelType_t::HIGH_GAIN; ///< Channel type (high gain, low gain, TRU, LEDMON)
+  double mAmplitudeGeV = 0.; ///< Amplitude (GeV)
+  Short_t mTower = -1;       ///< Tower index (absolute cell ID)
+  bool mIsTRU = false;       ///< TRU flag
+  uint16_t mNoiseLG = 0;     ///< Noise of the low gain digits
+  uint16_t mNoiseHG = 0;     ///< Noise of the high gain digits or TRU digits (can never be at the same time)
 
   ClassDefNV(Digit, 2);
 };

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/AltroHelper.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/AltroHelper.h
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include <vector>
 #include <map>
+#include "DataFormatsEMCAL/MCLabel.h"
 #include "DataFormatsEMCAL/Digit.h"
 #include "EMCALReconstruction/Bunch.h"
 
@@ -30,6 +31,8 @@ namespace emcal
 struct AltroBunch {
   int mStarttime;         ///< Start time of the bunch
   std::vector<int> mADCs; ///< ADCs belonging to the bunch
+  std::multimap<int, std::vector<o2::emcal::MCLabel>> mEnergyLabels;
+  std::vector<o2::emcal::MCLabel> mLabels;
 };
 
 /// \struct ChannelData
@@ -52,6 +55,7 @@ struct SRUDigitContainer {
 struct ChannelDigits {
   o2::emcal::ChannelType_t mChanType;
   std::vector<const o2::emcal::Digit*> mChannelDigits;
+  std::vector<gsl::span<const o2::emcal::MCLabel>> mChannelLabels;
 };
 
 /// \struct DigitContainerPerSRU
@@ -63,7 +67,10 @@ struct DigitContainerPerSRU {
 
 struct ChannelBunchData {
   o2::emcal::ChannelType_t mChanType;
-  std::vector<o2::emcal::Bunch> mChannelsBunches;
+  std::vector<o2::emcal::Bunch> mChannelsBunchesHG;
+  std::vector<o2::emcal::Bunch> mChannelsBunchesLG;
+  std::vector<std::vector<o2::emcal::MCLabel>> mChannelLabelsHG;
+  std::vector<std::vector<o2::emcal::MCLabel>> mChannelLabelsLG;
 };
 
 /// \struct SRUBunchContainer

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CaloRawFitter.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CaloRawFitter.h
@@ -172,6 +172,9 @@ class CaloRawFitter
                        double adcErr = 1,
                        double tau = 2.35) const;
 
+  int getMinTimeIndex() const { return mMinTimeIndex; }
+  int getMaxTimeIndex() const { return mMaxTimeIndex; }
+
  protected:
   std::array<double, constants::EMCAL_MAXTIMEBINS> mReversed; ///< Reversed sequence of samples (pedestalsubtracted)
 
@@ -194,7 +197,7 @@ class CaloRawFitter
   double mAmp; ///< The amplitude in entities of ADC counts
 
   ClassDefNV(CaloRawFitter, 1);
-}; //CaloRawFitter
+}; // CaloRawFitter
 
 } // namespace emcal
 

--- a/Detectors/EMCAL/reconstruction/src/CaloRawFitter.cxx
+++ b/Detectors/EMCAL/reconstruction/src/CaloRawFitter.cxx
@@ -68,7 +68,7 @@ CaloRawFitter::CaloRawFitter(const char* name, const char* nameshort) : mMinTime
                                                                         mMaxTimeIndex(-1),
                                                                         mAmpCut(4),
                                                                         mNsamplePed(3),
-                                                                        mIsZerosupressed(false),
+                                                                        mIsZerosupressed(true),
                                                                         mName(name),
                                                                         mNameShort(nameshort),
                                                                         mAlgo(FitAlgorithm::NONE),

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/Digitizer.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/Digitizer.h
@@ -111,7 +111,7 @@ class Digitizer : public TObject
   int mTimeWindowStart = 7; ///< The start of the time window
   int mDelay = 7;           ///< number of (full) time bins corresponding to the signal time delay
 
-  std::unique_ptr<o2::utils::TreeStreamRedirector> mDebugStream = 0x0;
+  std::unique_ptr<o2::utils::TreeStreamRedirector> mDebugStream = nullptr;
   bool mEnableDebugStreaming = false;
 
   ClassDefOverride(Digitizer, 1);

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/Digitizer.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/Digitizer.h
@@ -28,9 +28,14 @@
 #include "EMCALSimulation/DigitsWriteoutBuffer.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
 #include "DataFormatsEMCAL/TriggerRecord.h"
+#include "CommonUtils/TreeStreamRedirector.h"
 
 namespace o2
 {
+namespace utils
+{
+class TreeStreamRedirector;
+}
 namespace emcal
 {
 
@@ -67,6 +72,7 @@ class Digitizer : public TObject
   bool isLive() const { return mDigits.isLive(); }
 
   void setWindowStartTime(int time) { mTimeWindowStart = time; }
+  void setDebugStreaming(bool doStreaming) { mEnableDebugStreaming = doStreaming; }
 
   // function returns true if the collision occurs 600ns before the readout window is open
   bool preTriggerCollision() const { return mDigits.preTriggerCollision(); }
@@ -104,6 +110,9 @@ class Digitizer : public TObject
 
   int mTimeWindowStart = 7; ///< The start of the time window
   int mDelay = 7;           ///< number of (full) time bins corresponding to the signal time delay
+
+  std::unique_ptr<o2::utils::TreeStreamRedirector> mDebugStream = 0x0;
+  bool mEnableDebugStreaming = false;
 
   ClassDefOverride(Digitizer, 1);
 };

--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/LabeledDigit.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/LabeledDigit.h
@@ -37,7 +37,9 @@ class LabeledDigit
   LabeledDigit() = default;
 
   LabeledDigit(Digit digit, o2::emcal::MCLabel label);
-  LabeledDigit(Short_t tower, Double_t amplitudeGeV, Double_t time, o2::emcal::MCLabel label, ChannelType_t ctype = ChannelType_t::HIGH_GAIN);
+  LabeledDigit(Short_t tower, Double_t amplitudeGeV, Double_t time, o2::emcal::MCLabel label);
+  LabeledDigit(Short_t tower, uint16_t noiseLG, uint16_t noiseHG, Double_t time, o2::emcal::MCLabel label);
+
   ~LabeledDigit() = default; // override
 
   void setDigit(Digit d) { mDigit = d; }
@@ -49,7 +51,7 @@ class LabeledDigit
 
   bool operator<(const LabeledDigit& other) const { return getTimeStamp() < other.getTimeStamp(); }
   bool operator>(const LabeledDigit& other) const { return getTimeStamp() > other.getTimeStamp(); }
-  bool operator==(const LabeledDigit& other) const { return getTimeStamp() == other.getTimeStamp(); }
+  bool operator==(const LabeledDigit& other) const { return (getTimeStamp() == other.getTimeStamp()); }
 
   bool canAdd(const LabeledDigit other)
   {

--- a/Detectors/EMCAL/simulation/src/Digitizer.cxx
+++ b/Detectors/EMCAL/simulation/src/Digitizer.cxx
@@ -24,6 +24,7 @@
 #include <TF1.h>
 #include "FairLogger.h" // for LOG
 #include "CommonDataFormat/InteractionRecord.h"
+#include "CommonUtils/TreeStreamRedirector.h"
 
 ClassImp(o2::emcal::Digitizer);
 
@@ -67,6 +68,10 @@ void Digitizer::init()
       sf.push_back(RawResponse.Eval(j - mTimeWindowStart));
     }
     mAmplitudeInTimeBins.push_back(sf);
+  }
+
+  if (mEnableDebugStreaming) {
+    mDebugStream = std::make_unique<o2::utils::TreeStreamRedirector>("emcaldigitsDebug.root");
   }
 }
 
@@ -117,14 +122,16 @@ void Digitizer::process(const std::vector<LabeledDigit>& labeledSDigits)
 
       auto labels = labeleddigit.getLabels();
       LabeledDigit d(digit, labels[0]);
+      int iLabel(0);
       for (auto& label : labels) {
-        if (digit.getAmplitude() == 0) {
+        if (digit.getAmplitude() < __DBL_EPSILON__) {
           label.setAmplitudeFraction(0);
         }
-        if (label == labels.front()) {
+        if (iLabel == 0) {
           continue;
         }
         d.addLabel(label);
+        iLabel++;
       }
       listofLabeledDigit.push_back(d);
     }
@@ -147,10 +154,12 @@ void Digitizer::sampleSDigit(const Digit& sDigit)
     return;
   }
 
+  Double_t energies[15];
   if (mSimulateTimeResponse) {
     for (int j = 0; j < mAmplitudeInTimeBins.at(mPhase).size(); j++) {
 
       double val = energy * (mAmplitudeInTimeBins.at(mPhase).at(j));
+      energies[j] = val;
       double digitTime = (mEventTimeOffset + mDelay - mTimeWindowStart) * constants::EMCAL_TIMESAMPLE;
       Digit digit(tower, val, digitTime);
       mTempDigitVector.push_back(digit);
@@ -158,6 +167,27 @@ void Digitizer::sampleSDigit(const Digit& sDigit)
   } else {
     Digit digit(tower, energy, (mDelay - mTimeWindowStart) * constants::EMCAL_TIMESAMPLE);
     mTempDigitVector.push_back(digit);
+  }
+
+  if (mEnableDebugStreaming) {
+    (*mDebugStream) << "DigitsTimeSamples"
+                    << "DigitEnergy=" << energy
+                    << "Sample0=" << energies[0]
+                    << "Sample1=" << energies[1]
+                    << "Sample2=" << energies[2]
+                    << "Sample3=" << energies[3]
+                    << "Sample4=" << energies[4]
+                    << "Sample5=" << energies[5]
+                    << "Sample6=" << energies[6]
+                    << "Sample7=" << energies[7]
+                    << "Sample8=" << energies[8]
+                    << "Sample9=" << energies[9]
+                    << "Sample10=" << energies[10]
+                    << "Sample11=" << energies[11]
+                    << "Sample12=" << energies[12]
+                    << "Sample13=" << energies[13]
+                    << "Sample14=" << energies[14]
+                    << "\n";
   }
 }
 

--- a/Detectors/EMCAL/simulation/src/Digitizer.cxx
+++ b/Detectors/EMCAL/simulation/src/Digitizer.cxx
@@ -71,7 +71,7 @@ void Digitizer::init()
   }
 
   if (mEnableDebugStreaming) {
-    mDebugStream = std::make_unique<o2::utils::TreeStreamRedirector>("emcaldigitsDebug.root");
+    mDebugStream = std::make_unique<o2::utils::TreeStreamRedirector>("emcaldigitsDebug.root", "RECREATE");
   }
 }
 
@@ -170,7 +170,11 @@ void Digitizer::sampleSDigit(const Digit& sDigit)
   }
 
   if (mEnableDebugStreaming) {
+    double timeStamp = sDigit.getTimeStamp();
+    (*mDebugStream).GetFile()->cd();
     (*mDebugStream) << "DigitsTimeSamples"
+                    << "Tower=" << tower
+                    << "Time=" << timeStamp
                     << "DigitEnergy=" << energy
                     << "Sample0=" << energies[0]
                     << "Sample1=" << energies[1]

--- a/Detectors/EMCAL/simulation/src/DigitsVectorStream.cxx
+++ b/Detectors/EMCAL/simulation/src/DigitsVectorStream.cxx
@@ -36,14 +36,15 @@ void DigitsVectorStream::init()
 void DigitsVectorStream::addNoiseDigits(LabeledDigit& d1)
 {
   double amplitude = d1.getAmplitude();
-  double sigma = mSimParam->getPinNoise();
-  if (amplitude > constants::EMCAL_HGLGTRANSITION * constants::EMCAL_ADCENERGY) {
-    sigma = mSimParam->getPinNoiseLG();
-  }
+  double sigmaHG = mSimParam->getPinNoise();
+  double sigmaLG = mSimParam->getPinNoiseLG();
 
-  double noise = std::abs(mRandomGenerator->Gaus(0, sigma));
+  uint16_t noiseHG = std::floor(std::abs(mRandomGenerator->Gaus(0, sigmaHG) / constants::EMCAL_ADCENERGY));                                 // ADC
+  uint16_t noiseLG = std::floor(std::abs(mRandomGenerator->Gaus(0, sigmaLG) / (constants::EMCAL_ADCENERGY * constants::EMCAL_HGLGFACTOR))); // ADC
+
   MCLabel label(true, 1.0);
-  LabeledDigit d(d1.getTower(), noise, d1.getTimeStamp(), label);
+  LabeledDigit d(d1.getTower(), noiseLG, noiseHG, d1.getTimeStamp(), label);
+
   d1 += d;
 }
 
@@ -61,24 +62,23 @@ void DigitsVectorStream::fill(std::deque<o2::emcal::DigitTimebin>& digitlist, o2
       }
       digitsList.sort();
 
+      int digIndex = 0;
       for (auto& ld : digitsList) {
 
         // Loop over all digits in the time sample and sum the digits that belongs to the same tower and falls in one time bin
+        int digIndex1 = 0;
         for (auto ld1 = digitsList.begin(); ld1 != digitsList.end(); ++ld1) {
 
-          if (ld == *ld1) {
+          if (digIndex == digIndex1) {
+            digIndex1++;
             continue;
           }
 
-          std::vector<decltype(digitsList.begin())> toDelete;
-
           if (ld.canAdd(*ld1)) {
             ld += *ld1;
-            toDelete.push_back(ld1);
+            digitsList.erase(ld1);
           }
-          for (auto del : toDelete) {
-            digitsList.erase(del);
-          }
+          digIndex1++;
         }
 
         if (mSimulateNoiseDigits) {
@@ -96,6 +96,7 @@ void DigitsVectorStream::fill(std::deque<o2::emcal::DigitTimebin>& digitlist, o2
         }
 
         outputList[tower].push_back(ld);
+        digIndex++;
       }
     }
   }

--- a/Detectors/EMCAL/simulation/src/DigitsVectorStream.cxx
+++ b/Detectors/EMCAL/simulation/src/DigitsVectorStream.cxx
@@ -76,7 +76,7 @@ void DigitsVectorStream::fill(std::deque<o2::emcal::DigitTimebin>& digitlist, o2
 
           if (ld.canAdd(*ld1)) {
             ld += *ld1;
-            digitsList.erase(ld1);
+            digitsList.erase(ld1--);
           }
           digIndex1++;
         }

--- a/Detectors/EMCAL/simulation/src/LabeledDigit.cxx
+++ b/Detectors/EMCAL/simulation/src/LabeledDigit.cxx
@@ -20,8 +20,14 @@ LabeledDigit::LabeledDigit(Digit digit, o2::emcal::MCLabel label)
   mLabels.push_back(label);
 }
 
-LabeledDigit::LabeledDigit(Short_t tower, Double_t amplitudeGeV, Double_t time, o2::emcal::MCLabel label, ChannelType_t ctype)
-  : mDigit(tower, amplitudeGeV, time, ctype)
+LabeledDigit::LabeledDigit(Short_t tower, Double_t amplitudeGeV, Double_t time, o2::emcal::MCLabel label)
+  : mDigit(tower, amplitudeGeV, time)
+{
+  mLabels.push_back(label);
+}
+
+LabeledDigit::LabeledDigit(Short_t tower, uint16_t noiseLG, uint16_t noiseHG, Double_t time, o2::emcal::MCLabel label)
+  : mDigit(tower, noiseLG, noiseHG, time)
 {
   mLabels.push_back(label);
 }
@@ -29,9 +35,9 @@ LabeledDigit::LabeledDigit(Short_t tower, Double_t amplitudeGeV, Double_t time, 
 LabeledDigit& LabeledDigit::operator+=(const LabeledDigit& other)
 {
   if (canAdd(other)) {
-    Int_t a1 = getAmplitudeADC();
-    Int_t a2 = other.getAmplitudeADC();
-    Double_t r = ((a1 + a2) != 0) ? 1.0 / (a1 + a2) : 0.0;
+    double a1 = getAmplitude();
+    double a2 = other.getAmplitude();
+    double r = ((a1 + a2) != 0) ? 1.0 / (a1 + a2) : 0.0;
     mDigit += other.getDigit();
 
     for (int j = 0; j < mLabels.size(); j++) {
@@ -49,7 +55,7 @@ LabeledDigit& LabeledDigit::operator+=(const LabeledDigit& other)
 
 void LabeledDigit::PrintStream(std::ostream& stream) const
 {
-  stream << "EMCAL LabeledDigit: Tower " << getTower() << ", Time " << getTimeStamp() << ", Amplitude " << getAmplitude() << " GeV, Type " << getType() << ", Labels ( ";
+  stream << "EMCAL LabeledDigit: Tower " << getTower() << ", Time " << getTimeStamp() << ", Amplitude " << getAmplitude() << " GeV, Type " << channelTypeToString(getType()) << ", Labels ( ";
   for (auto label : mLabels) {
     stream << label.getRawValue() << " ";
   }

--- a/Detectors/EMCAL/simulation/src/SDigitizer.cxx
+++ b/Detectors/EMCAL/simulation/src/SDigitizer.cxx
@@ -67,7 +67,7 @@ std::vector<o2::emcal::LabeledDigit> SDigitizer::process(const std::vector<Hit>&
       Digit digit(tower, energy, hit.GetTime());
 
       MCLabel label(hit.GetTrackID(), mCurrEvID, mCurrSrcID, false, 1.0);
-      if (digit.getAmplitude() == 0) {
+      if (digit.getAmplitude() < __DBL_EPSILON__) {
         label.setAmplitudeFraction(0);
       }
       LabeledDigit d(digit, label);

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/CellConverterSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/CellConverterSpec.h
@@ -12,12 +12,14 @@
 #include <vector>
 
 #include "DataFormatsEMCAL/Cell.h"
+#include "DataFormatsEMCAL/MCLabel.h"
 #include "DataFormatsEMCAL/TriggerRecord.h"
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
 #include "EMCALBase/Geometry.h"
 #include "EMCALReconstruction/CaloRawFitter.h"
 #include "EMCALReconstruction/AltroHelper.h"
+#include "SimulationDataFormat/MCTruthContainer.h"
 
 namespace o2
 {
@@ -72,16 +74,21 @@ class CellConverterSpec : public framework::Task
   void run(framework::ProcessingContext& ctx) final;
 
  protected:
-  std::vector<o2::emcal::SRUBunchContainer> digitsToBunches(gsl::span<const o2::emcal::Digit> digits);
+  std::vector<o2::emcal::SRUBunchContainer> digitsToBunches(gsl::span<const o2::emcal::Digit> digits, std::vector<gsl::span<const o2::emcal::MCLabel>>& mcLabels);
 
-  std::vector<AltroBunch> findBunches(const std::vector<const o2::emcal::Digit*>& channelDigits);
+  std::vector<AltroBunch> findBunches(const std::vector<const o2::emcal::Digit*>& channelDigits, const std::vector<gsl::span<const o2::emcal::MCLabel>>& mcLabels, ChannelType_t channelType);
+
+  void mergeLabels(std::vector<o2::emcal::AltroBunch>& channelBunches);
+
+  int selectMaximumBunch(const gsl::span<const Bunch>& bunchvector);
 
  private:
-  bool mPropagateMC = false;                             ///< Switch whether to process MC true labels
-  o2::emcal::Geometry* mGeometry = nullptr;              ///!<! Geometry pointer
-  std::unique_ptr<o2::emcal::CaloRawFitter> mRawFitter;  ///!<! Raw fitter
-  std::vector<o2::emcal::Cell> mOutputCells;             ///< Container with output cells
-  std::vector<o2::emcal::TriggerRecord> mOutputTriggers; ///< Container with output trigger records
+  bool mPropagateMC = false;                                           ///< Switch whether to process MC true labels
+  o2::emcal::Geometry* mGeometry = nullptr;                            ///!<! Geometry pointer
+  std::unique_ptr<o2::emcal::CaloRawFitter> mRawFitter;                ///!<! Raw fitter
+  std::vector<o2::emcal::Cell> mOutputCells;                           ///< Container with output cells
+  std::vector<o2::emcal::TriggerRecord> mOutputTriggers;               ///< Container with output trigger records
+  o2::dataformats::MCTruthContainer<o2::emcal::MCLabel> mOutputLabels; ///< Container with output MC labels
 };
 
 /// \brief Creating DataProcessorSpec for the EMCAL Cell Converter Spec

--- a/Detectors/EMCAL/workflow/src/CellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/CellConverterSpec.cxx
@@ -95,10 +95,8 @@ void CellConverterSpec::run(framework::ProcessingContext& ctx)
             fitResults = mRawFitter->evaluate(channelData.mChannelsBunchesLG);
             fitResults.setAmp(fitResults.getAmp() * o2::emcal::constants::EMCAL_HGLGFACTOR);
             channelType = ChannelType_t::LOW_GAIN;
-            std::cout << "The high gain bunch was saturated ... fitting the low gain\n";
           } else {
             channelType = ChannelType_t::HIGH_GAIN;
-            std::cout << "The high gain bunch was not saturated ... settting the cell to high gain\n";
           }
 
           if (fitResults.getAmp() < 0) {
@@ -116,7 +114,7 @@ void CellConverterSpec::run(framework::ProcessingContext& ctx)
         mOutputCells.emplace_back(tower, fitResults.getAmp() * CONVADCGEV, fitResults.getTime(), channelType);
         if (mPropagateMC) {
           Int_t LabelIndex = mOutputLabels.getIndexedSize();
-          if (channelType = ChannelType_t::HIGH_GAIN) {
+          if (channelType == ChannelType_t::HIGH_GAIN) {
             // if this channel has no bunches, then fill an empty label
             if (channelData.mChannelLabelsHG.size() == 0) {
               const o2::emcal::MCLabel label = o2::emcal::MCLabel(false, 1.);

--- a/Detectors/EMCAL/workflow/src/CellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/CellConverterSpec.cxx
@@ -275,7 +275,6 @@ std::vector<o2::emcal::AltroBunch> CellConverterSpec::findBunches(const std::vec
         // check if the ALTRO bunch has a minimum amount of 3 ADCs
         if (currentBunch.mADCs.size() >= 3) {
           // Bunch selected, set start time and push to bunches
-          currentBunch.mStarttime = itime + 1;
           result.push_back(currentBunch);
           currentBunch = AltroBunch();
           bunchStarted = false;
@@ -292,7 +291,6 @@ std::vector<o2::emcal::AltroBunch> CellConverterSpec::findBunches(const std::vec
         // check if the ALTRO bunch has a minimum amount of ADCs
         if (currentBunch.mADCs.size() >= 3) {
           // Bunch selected, set start time and push to bunches
-          currentBunch.mStarttime = itime + 1;
           result.push_back(currentBunch);
           currentBunch = AltroBunch();
           bunchStarted = false;
@@ -302,6 +300,7 @@ std::vector<o2::emcal::AltroBunch> CellConverterSpec::findBunches(const std::vec
     // Valid ADC value, if the bunch is closed we start a new bunch
     if (!bunchStarted) {
       bunchStarted = true;
+      currentBunch.mStarttime = itime;
     }
     currentBunch.mADCs.emplace_back(adc);
     if (mPropagateMC) {
@@ -315,7 +314,6 @@ std::vector<o2::emcal::AltroBunch> CellConverterSpec::findBunches(const std::vec
   // if we have a last bunch set time start time to the time bin of teh previous digit
   if (bunchStarted) {
     if (currentBunch.mADCs.size() >= 3) {
-      currentBunch.mStarttime = itime + 1;
       result.push_back(currentBunch);
     }
   }

--- a/Detectors/EMCAL/workflow/src/CellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/CellConverterSpec.cxx
@@ -9,6 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 #include <gsl/span>
+#include <boost/range/combine.hpp>
 #include "FairLogger.h"
 
 #include "DataFormatsEMCAL/Digit.h"
@@ -52,9 +53,12 @@ void CellConverterSpec::run(framework::ProcessingContext& ctx)
   const double CONVADCGEV = 0.016; // Conversion from ADC counts to energy: E = 16 MeV / ADC
 
   mOutputCells.clear();
+  mOutputLabels.clear();
   mOutputTriggers.clear();
   auto digitsAll = ctx.inputs().get<gsl::span<o2::emcal::Digit>>("digits");
   auto triggers = ctx.inputs().get<gsl::span<o2::emcal::TriggerRecord>>("triggers");
+  auto truthcont = ctx.inputs().get<o2::dataformats::MCTruthContainer<o2::emcal::MCLabel>*>("digitsmctr");
+
   LOG(debug) << "[EMCALCellConverter - run]  Received " << digitsAll.size() << " digits from " << triggers.size() << " trigger ...";
   int currentstart = mOutputCells.size(), ncellsTrigger = 0;
   for (const auto& trg : triggers) {
@@ -62,9 +66,17 @@ void CellConverterSpec::run(framework::ProcessingContext& ctx)
       mOutputTriggers.emplace_back(trg.getBCData(), trg.getTriggerBits(), currentstart, ncellsTrigger);
       continue;
     }
-    gsl::span<const o2::emcal::Digit> digits(digitsAll.data() + trg.getFirstEntry(), trg.getNumberOfObjects());
 
-    for (const auto& srucont : digitsToBunches(digits)) {
+    gsl::span<const o2::emcal::Digit> digits(digitsAll.data() + trg.getFirstEntry(), trg.getNumberOfObjects());
+    std::vector<gsl::span<const o2::emcal::MCLabel>> mcLabels;
+
+    if (mPropagateMC) {
+      for (int digitIndex = trg.getFirstEntry(); digitIndex < (trg.getFirstEntry() + trg.getNumberOfObjects()); digitIndex++) {
+        mcLabels.push_back(truthcont->getLabels(digitIndex));
+      }
+    }
+
+    for (const auto& srucont : digitsToBunches(digits, mcLabels)) {
 
       if (srucont.mSRUid == 21 || srucont.mSRUid == 22 || srucont.mSRUid == 36 || srucont.mSRUid == 39) {
         continue;
@@ -73,9 +85,21 @@ void CellConverterSpec::run(framework::ProcessingContext& ctx)
       for (const auto& [tower, channelData] : srucont.mChannelsData) {
 
         // define the conatiner for the fit results, and perform the raw fitting using the stadnard raw fitter
+        ChannelType_t channelType = channelData.mChanType;
         CaloFitResults fitResults;
         try {
-          fitResults = mRawFitter->evaluate(channelData.mChannelsBunches);
+          fitResults = mRawFitter->evaluate(channelData.mChannelsBunchesHG);
+
+          // If the high gain bunch is saturated then fit the low gain
+          if (fitResults.getAmp() > o2::emcal::constants::OVERFLOWCUT) {
+            fitResults = mRawFitter->evaluate(channelData.mChannelsBunchesLG);
+            fitResults.setAmp(fitResults.getAmp() * o2::emcal::constants::EMCAL_HGLGFACTOR);
+            channelType = ChannelType_t::LOW_GAIN;
+            std::cout << "The high gain bunch was saturated ... fitting the low gain\n";
+          } else {
+            channelType = ChannelType_t::HIGH_GAIN;
+            std::cout << "The high gain bunch was not saturated ... settting the cell to high gain\n";
+          }
 
           if (fitResults.getAmp() < 0) {
             fitResults.setAmp(0.);
@@ -89,7 +113,35 @@ void CellConverterSpec::run(framework::ProcessingContext& ctx)
           }
         }
 
-        mOutputCells.emplace_back(tower, fitResults.getAmp() * CONVADCGEV, fitResults.getTime(), channelData.mChanType);
+        mOutputCells.emplace_back(tower, fitResults.getAmp() * CONVADCGEV, fitResults.getTime(), channelType);
+        if (mPropagateMC) {
+          Int_t LabelIndex = mOutputLabels.getIndexedSize();
+          if (channelType = ChannelType_t::HIGH_GAIN) {
+            // if this channel has no bunches, then fill an empty label
+            if (channelData.mChannelLabelsHG.size() == 0) {
+              const o2::emcal::MCLabel label = o2::emcal::MCLabel(false, 1.);
+              mOutputLabels.addElementRandomAccess(LabelIndex, label);
+            } else {
+              // Fill only labels that corresponds to bunches with maximum ADC
+              const int bunchindex = selectMaximumBunch(channelData.mChannelsBunchesHG);
+              for (const auto& label : channelData.mChannelLabelsHG[bunchindex]) {
+                mOutputLabels.addElementRandomAccess(LabelIndex, label);
+              }
+            }
+          } else {
+            // if this channel has no bunches, then fill an empty label
+            if (channelData.mChannelLabelsLG.size() == 0) {
+              const o2::emcal::MCLabel label = o2::emcal::MCLabel(false, 1.);
+              mOutputLabels.addElementRandomAccess(LabelIndex, label);
+            } else {
+              // Fill only labels that corresponds to bunches with maximum ADC
+              const int bunchindex = selectMaximumBunch(channelData.mChannelsBunchesLG);
+              for (const auto& label : channelData.mChannelLabelsLG[bunchindex]) {
+                mOutputLabels.addElementRandomAccess(LabelIndex, label);
+              }
+            }
+          }
+        }
         ncellsTrigger++;
       }
     }
@@ -101,14 +153,11 @@ void CellConverterSpec::run(framework::ProcessingContext& ctx)
   ctx.outputs().snapshot(o2::framework::Output{"EMC", "CELLS", 0, o2::framework::Lifetime::Timeframe}, mOutputCells);
   ctx.outputs().snapshot(o2::framework::Output{"EMC", "CELLSTRGR", 0, o2::framework::Lifetime::Timeframe}, mOutputTriggers);
   if (mPropagateMC) {
-    // copy mc truth container without modification
-    // as indexing doesn't change
-    auto truthcont = ctx.inputs().get<o2::dataformats::MCTruthContainer<o2::emcal::MCLabel>*>("digitsmctr");
-    ctx.outputs().snapshot(o2::framework::Output{"EMC", "CELLSMCTR", 0, o2::framework::Lifetime::Timeframe}, *truthcont);
+    ctx.outputs().snapshot(o2::framework::Output{"EMC", "CELLSMCTR", 0, o2::framework::Lifetime::Timeframe}, mOutputLabels);
   }
 }
 
-std::vector<o2::emcal::SRUBunchContainer> CellConverterSpec::digitsToBunches(gsl::span<const o2::emcal::Digit> digits)
+std::vector<o2::emcal::SRUBunchContainer> CellConverterSpec::digitsToBunches(gsl::span<const o2::emcal::Digit> digits, std::vector<gsl::span<const o2::emcal::MCLabel>>& mcLabels)
 {
 
   std::vector<o2::emcal::SRUBunchContainer> sruBunchContainer;
@@ -125,8 +174,10 @@ std::vector<o2::emcal::SRUBunchContainer> CellConverterSpec::digitsToBunches(gsl
   }
 
   std::vector<const o2::emcal::Digit*>* bunchDigits;
+  std::vector<gsl::span<const o2::emcal::MCLabel>>* bunchLabels;
   int lasttower = -1;
-  for (auto& dig : digits) {
+  // for (auto& dig : digits) {
+  for (const auto& [dig, labels] : boost::combine(digits, mcLabels)) {
     auto tower = dig.getTower();
     if (tower != lasttower) {
       lasttower = tower;
@@ -139,11 +190,18 @@ std::vector<o2::emcal::SRUBunchContainer> CellConverterSpec::digitsToBunches(gsl
 
       auto towerdata = sruDigitContainer[sruID].mChannelsDigits.find(tower);
       if (towerdata == sruDigitContainer[sruID].mChannelsDigits.end()) {
-        sruDigitContainer[sruID].mChannelsDigits[tower] = {dig.getType(), std::vector<const o2::emcal::Digit*>(o2::emcal::constants::EMCAL_MAXTIMEBINS)};
+        sruDigitContainer[sruID].mChannelsDigits[tower] = {dig.getType(), std::vector<const o2::emcal::Digit*>(o2::emcal::constants::EMCAL_MAXTIMEBINS), mPropagateMC ? std::vector<gsl::span<const o2::emcal::MCLabel>>(o2::emcal::constants::EMCAL_MAXTIMEBINS) : std::vector<gsl::span<const o2::emcal::MCLabel>>()};
         bunchDigits = &(sruDigitContainer[sruID].mChannelsDigits[tower].mChannelDigits);
         memset(bunchDigits->data(), 0, sizeof(o2::emcal::Digit*) * o2::emcal::constants::EMCAL_MAXTIMEBINS);
+        if (mPropagateMC) {
+          bunchLabels = &(sruDigitContainer[sruID].mChannelsDigits[tower].mChannelLabels);
+          memset(bunchLabels->data(), 0, sizeof(gsl::span<const o2::emcal::MCLabel>) * o2::emcal::constants::EMCAL_MAXTIMEBINS);
+        }
       } else {
         bunchDigits = &(towerdata->second.mChannelDigits);
+        if (mPropagateMC) {
+          bunchLabels = &(towerdata->second.mChannelLabels);
+        }
       }
     }
 
@@ -156,6 +214,9 @@ std::vector<o2::emcal::SRUBunchContainer> CellConverterSpec::digitsToBunches(gsl
       continue;
     }
     (*bunchDigits)[timesample] = &dig;
+    if (mPropagateMC) {
+      (*bunchLabels)[timesample] = labels;
+    }
   }
 
   for (auto srucont : sruDigitContainer) {
@@ -166,22 +227,41 @@ std::vector<o2::emcal::SRUBunchContainer> CellConverterSpec::digitsToBunches(gsl
 
     for (const auto& [tower, channelDigits] : srucont.mChannelsDigits) {
 
-      std::vector<o2::emcal::Bunch> rawbunches;
-      for (auto& bunch : findBunches(channelDigits.mChannelDigits)) {
-        rawbunches.emplace_back(bunch.mADCs.size(), bunch.mStarttime);
+      std::vector<o2::emcal::Bunch> rawbunchesHG;
+      std::vector<o2::emcal::Bunch> rawbunchesLG;
+      std::vector<std::vector<o2::emcal::MCLabel>> rawLabelsHG;
+      std::vector<std::vector<o2::emcal::MCLabel>> rawLabelsLG;
+
+      // Creating the high gain bunch with labels
+      for (auto& bunch : findBunches(channelDigits.mChannelDigits, channelDigits.mChannelLabels, ChannelType_t::HIGH_GAIN)) {
+        rawbunchesHG.emplace_back(bunch.mADCs.size(), bunch.mStarttime);
         for (auto adc : bunch.mADCs) {
-          rawbunches.back().addADC(adc);
+          rawbunchesHG.back().addADC(adc);
+        }
+        if (mPropagateMC) {
+          rawLabelsHG.push_back(bunch.mLabels);
         }
       }
 
-      sruBunchContainer[srucont.mSRUid].mChannelsData[tower] = {channelDigits.mChanType, rawbunches};
+      // Creating the low gain bunch with labels
+      for (auto& bunch : findBunches(channelDigits.mChannelDigits, channelDigits.mChannelLabels, ChannelType_t::LOW_GAIN)) {
+        rawbunchesLG.emplace_back(bunch.mADCs.size(), bunch.mStarttime);
+        for (auto adc : bunch.mADCs) {
+          rawbunchesLG.back().addADC(adc);
+        }
+        if (mPropagateMC) {
+          rawLabelsLG.push_back(bunch.mLabels);
+        }
+      }
+
+      sruBunchContainer[srucont.mSRUid].mChannelsData[tower] = {channelDigits.mChanType, rawbunchesHG, rawbunchesLG, rawLabelsHG, rawLabelsLG};
     }
   }
 
   return sruBunchContainer;
 }
 
-std::vector<o2::emcal::AltroBunch> CellConverterSpec::findBunches(const std::vector<const o2::emcal::Digit*>& channelDigits)
+std::vector<o2::emcal::AltroBunch> CellConverterSpec::findBunches(const std::vector<const o2::emcal::Digit*>& channelDigits, const std::vector<gsl::span<const o2::emcal::MCLabel>>& mcLabels, ChannelType_t channelType)
 {
   std::vector<AltroBunch> result;
   AltroBunch currentBunch;
@@ -190,6 +270,7 @@ std::vector<o2::emcal::AltroBunch> CellConverterSpec::findBunches(const std::vec
   int itime;
   for (itime = channelDigits.size() - 1; itime >= 0; itime--) {
     auto dig = channelDigits[itime];
+    auto labels = mcLabels[itime];
     if (!dig) {
       if (bunchStarted) {
         // we have a bunch which is started and needs to be closed
@@ -204,7 +285,7 @@ std::vector<o2::emcal::AltroBunch> CellConverterSpec::findBunches(const std::vec
       }
       continue;
     }
-    int adc = dig->getAmplitudeADC();
+    int adc = dig->getAmplitudeADC(channelType);
     if (adc < 3) {
       // ADC value below threshold
       // in case we have an open bunch it needs to be stopped bunch
@@ -225,6 +306,13 @@ std::vector<o2::emcal::AltroBunch> CellConverterSpec::findBunches(const std::vec
       bunchStarted = true;
     }
     currentBunch.mADCs.emplace_back(adc);
+    if (mPropagateMC) {
+      std::vector<o2::emcal::MCLabel> vectorLabels;
+      for (auto& label : labels) {
+        vectorLabels.push_back(label);
+      }
+      currentBunch.mEnergyLabels.insert(std::pair<int, std::vector<o2::emcal::MCLabel>>(adc, vectorLabels));
+    }
   }
   // if we have a last bunch set time start time to the time bin of teh previous digit
   if (bunchStarted) {
@@ -233,7 +321,67 @@ std::vector<o2::emcal::AltroBunch> CellConverterSpec::findBunches(const std::vec
       result.push_back(currentBunch);
     }
   }
+
+  if (mPropagateMC) {
+    mergeLabels(result);
+  }
   return result;
+}
+
+void CellConverterSpec::mergeLabels(std::vector<o2::emcal::AltroBunch>& channelBunches)
+{
+  for (auto& altroBunch : channelBunches) {
+    std::vector<o2::emcal::MCLabel> mcLabels;
+    std::map<uint64_t, std::vector<o2::emcal::MCLabel>> LabelsPerSource;
+    double totalEnergy = 0;
+    for (auto& [energy, Labels] : altroBunch.mEnergyLabels) {
+      for (auto& trueLabel : Labels) {
+        o2::emcal::MCLabel newLabel = trueLabel;
+        newLabel.setAmplitudeFraction(trueLabel.getAmplitudeFraction() * energy);
+        LabelsPerSource[newLabel.getRawValue()].push_back(newLabel);
+      }
+      totalEnergy += energy;
+    }
+
+    for (auto& [trackID, labels] : LabelsPerSource) {
+      o2::emcal::MCLabel newLabel = labels[0];
+      for (int ilabel = 0; ilabel < labels.size(); ilabel++) {
+        auto& trueLabel = labels[ilabel];
+        if (ilabel == 0) {
+          continue;
+        }
+        newLabel.setAmplitudeFraction(newLabel.getAmplitudeFraction() + trueLabel.getAmplitudeFraction());
+      }
+      newLabel.setAmplitudeFraction(newLabel.getAmplitudeFraction() / totalEnergy);
+      mcLabels.push_back(newLabel);
+    }
+
+    std::sort(mcLabels.begin(), mcLabels.end(), [](o2::emcal::MCLabel label1, o2::emcal::MCLabel label2) { return label1.getAmplitudeFraction() > label2.getAmplitudeFraction(); });
+
+    altroBunch.mLabels = mcLabels;
+    // std::copy(mcLabels.begin(), mcLabels.end(), std::back_inserter(altroBunch.mLabels));
+    // altroBunch.mLabels = gsl::span<o2::emcal::MCLabel>(&mcLabels[0], mcLabels.size());
+    altroBunch.mEnergyLabels.clear();
+  }
+}
+
+int CellConverterSpec::selectMaximumBunch(const gsl::span<const Bunch>& bunchvector)
+{
+  int bunchindex = -1;
+  int indexMaxInBunch(0), maxADCallBunches(-1);
+
+  for (unsigned int i = 0; i < bunchvector.size(); i++) {
+    auto [maxADC, maxIndex] = mRawFitter->getMaxAmplitudeBunch(bunchvector[i]); // CRAP PTH, bug fix, trouble if more than one bunches
+    if (mRawFitter->isInTimeRange(maxIndex, mRawFitter->getMaxTimeIndex(), mRawFitter->getMinTimeIndex())) {
+      if (maxADC > maxADCallBunches) {
+        bunchindex = i;
+        indexMaxInBunch = maxIndex;
+        maxADCallBunches = maxADC;
+      }
+    }
+  }
+
+  return bunchindex;
 }
 
 o2::framework::DataProcessorSpec o2::emcal::reco_workflow::getCellConverterSpec(bool propagateMC)

--- a/Detectors/EMCAL/workflow/src/EMCALDigitizerSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/EMCALDigitizerSpec.cxx
@@ -46,6 +46,9 @@ void DigitizerSpec::initDigitizerTask(framework::InitContext& ctx)
 
   mSumDigitizer.setGeometry(geom);
 
+  if (ctx.options().get<bool>("debug-stream")) {
+    mDigitizer.setDebugStreaming(true);
+  }
   mDigitizer.init();
 
   mFinished = false;
@@ -146,7 +149,9 @@ o2::framework::DataProcessorSpec getEMCALDigitizerSpec(int channel, bool mctruth
     "EMCALDigitizer", Inputs{InputSpec{"collisioncontext", "SIM", "COLLISIONCONTEXT", static_cast<SubSpecificationType>(channel), Lifetime::Timeframe}},
     outputs,
     AlgorithmSpec{o2::framework::adaptFromTask<DigitizerSpec>()},
-    Options{{"pileup", VariantType::Int, 1, {"whether to run in continuous time mode"}}}
+    Options{
+      {"pileup", VariantType::Int, 1, {"whether to run in continuous time mode"}},
+      {"debug-stream", VariantType::Bool, false, {"Enable debug streaming"}}}
     // I can't use VariantType::Bool as it seems to have a problem
   };
 }

--- a/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
@@ -429,7 +429,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
                   hwAddressHG = chan.getHardwareAddress();
                 }
                 int fecID = mMapper->getFEEForChannelInDDL(feeID, chan.getFECIndex(), chan.getBranchIndex());
-                currentCellContainer->push_back({o2::emcal::Cell(CellID, amp, fitResults.getTime() - timeshift, chantype),
+                currentCellContainer->push_back({o2::emcal::Cell(CellID, amp, fitResults.getTime() - timeshift, flagChanType),
                                                  lgNoHG,
                                                  hgOutOfRange,
                                                  fecID, feeID, hwAddressLG, hwAddressHG});


### PR DESCRIPTION
The digit to cell converter using the raw fitter has been adapted to handle mc labels. When converting the sampled digits to bunches the mc labels of the different digits are added using weighted average. The sampled digits are converted into two bunches, one high gain and one low gain. The difference between these bunches is the noise added to the sampled digits. Then these bunches will be fitted separately. First we fit the HG bunch, if is saturated we fit the LG bunch and the cell will be LG. If the HG bunch is not saturated then the cell will be high gain.

Another change is the changing the format of the Digit object. Now the digit object stores the GeV energy in "double" instead of ADC int. The reason for that is because the digit is originally initialized with GeV and then it gets converted to ADC in which it will be stored which will lead to the loss of precision of the energy. 
Other change on the Digit object is that, now it stores two kinds of noise, HG noise and LG noise (in uint16_t). The reason for that is to make the simulation pretty similar to data, in which the sampled digits will be converted into two bunches HG and LG.
Also the channel type object in the digit has been removed, and the type will be determined on fly (when getting it).