### PR TITLE
Fix Partition<Filtered>, add separate sliceByCached for joins, filtered and nested filtered

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1196,7 +1196,7 @@ class Table
   {
     uint64_t offset = 0;
     std::shared_ptr<arrow::Table> result = nullptr;
-    if (!this->getSliceFor(value, node.name.c_str(), result, offset)) {
+    if (!this->getSliceFor(value, node.name.c_str(), result, offset).ok()) {
       o2::framework::throw_error(o2::framework::runtime_error("Failed to slice table"));
     }
     auto t = table_t({result}, offset);
@@ -2136,7 +2136,7 @@ struct Join : JoinBase<Ts...> {
   {
     uint64_t offset = 0;
     std::shared_ptr<arrow::Table> result = nullptr;
-    if (!this->getSliceFor(value, node.name.c_str(), result, offset)) {
+    if (!this->getSliceFor(value, node.name.c_str(), result, offset).ok()) {
       o2::framework::throw_error(o2::framework::runtime_error("Failed to slice table"));
     }
     auto t = Join<Ts...>({result}, offset);
@@ -2329,7 +2329,7 @@ class FilteredBase : public T
   {
     uint64_t offset = 0;
     std::shared_ptr<arrow::Table> result = nullptr;
-    if (!((table_t*)this)->getSliceFor(value, node.name.c_str(), result, offset)) {
+    if (!((table_t*)this)->getSliceFor(value, node.name.c_str(), result, offset).ok()) {
       o2::framework::throw_error(o2::framework::runtime_error("Failed to slice table"));
     }
     if (offset >= this->tableSize()) {
@@ -2541,7 +2541,7 @@ class Filtered : public FilteredBase<T>
   {
     uint64_t offset = 0;
     std::shared_ptr<arrow::Table> result = nullptr;
-    if (!((table_t*)this)->getSliceFor(value, node.name.c_str(), result, offset)) {
+    if (!((table_t*)this)->getSliceFor(value, node.name.c_str(), result, offset).ok()) {
       o2::framework::throw_error(o2::framework::runtime_error("Failed to slice table"));
     }
     if (offset >= this->tableSize()) {
@@ -2672,7 +2672,7 @@ class Filtered<Filtered<T>> : public FilteredBase<typename T::table_t>
   {
     uint64_t offset = 0;
     std::shared_ptr<arrow::Table> result = nullptr;
-    if (!((table_t*)this)->getSliceFor(value, node.name.c_str(), result, offset)) {
+    if (!((table_t*)this)->getSliceFor(value, node.name.c_str(), result, offset).ok()) {
       o2::framework::throw_error(o2::framework::runtime_error("Failed to slice table"));
     }
     auto start = offset;

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -2343,7 +2343,7 @@ class FilteredBase : public T
     auto stop_iterator = std::lower_bound(start_iterator, mSelectedRows.end(), end);
     SelectionVector slicedSelection{start_iterator, stop_iterator};
     std::transform(slicedSelection.begin(), slicedSelection.end(), slicedSelection.begin(),
-                   [&](int64_t idx) {
+                   [&start](int64_t idx) {
                      return idx - static_cast<int64_t>(start);
                    });
     self_t fresult{{result}, std::move(slicedSelection), start};
@@ -2555,7 +2555,7 @@ class Filtered : public FilteredBase<T>
     auto stop_iterator = std::lower_bound(start_iterator, this->getSelectedRows().end(), end);
     SelectionVector slicedSelection{start_iterator, stop_iterator};
     std::transform(slicedSelection.begin(), slicedSelection.end(), slicedSelection.begin(),
-                   [&](int64_t idx) {
+                   [&start](int64_t idx) {
                      return idx - static_cast<int64_t>(start);
                    });
     auto slicedSize = slicedSelection.size();
@@ -2681,7 +2681,7 @@ class Filtered<Filtered<T>> : public FilteredBase<typename T::table_t>
     auto stop_iterator = std::lower_bound(start_iterator, this->getSelectedRows().end(), end);
     SelectionVector slicedSelection{start_iterator, stop_iterator};
     std::transform(slicedSelection.begin(), slicedSelection.end(), slicedSelection.begin(),
-                   [&](int64_t idx) {
+                   [&start](int64_t idx) {
                      return idx - static_cast<int64_t>(start);
                    });
     SelectionVector copy = slicedSelection;


### PR DESCRIPTION
Hi @ktf @aalkin 

the Join method is a copy of the Table `sliceByCached()`, and Filtered is a copy of FilteredBase method. The problem is in returning exact O2 table type, what apparently cannot be done without copies or making `sliceByCached()` a standalone function and changing the UI. I need the exact type so as to use `sliceByCached()` for faster event mixing, which will come in another PR.

The changes in Partition constructor fix a newly discovered bug in creating Partitions on Filtered. The buggy methods were called when creating `Partitions<Filtered>` inside `process()` or calling `sliceByCached()` on `Partitions<Filtered>`.