### PR TITLE
[MCH] add protection against too many track candidates

### DIFF
--- a/Detectors/MUON/MCH/Tracking/include/MCHTracking/TrackFinder.h
+++ b/Detectors/MUON/MCH/Tracking/include/MCHTracking/TrackFinder.h
@@ -83,6 +83,7 @@ class TrackFinder
   void finalize();
 
   void createTrack(const Cluster& cl1, const Cluster& cl2);
+  std::list<Track>::iterator addTrack(const std::list<Track>::iterator& pos, const Track& track);
 
   bool isAcceptable(const TrackParam& param) const;
 

--- a/Detectors/MUON/MCH/Tracking/include/MCHTracking/TrackFinderOriginal.h
+++ b/Detectors/MUON/MCH/Tracking/include/MCHTracking/TrackFinderOriginal.h
@@ -55,6 +55,7 @@ class TrackFinderOriginal
   std::list<Track>::iterator findTrackCandidates(int ch1, int ch2, bool skipUsedPairs = false);
   bool areUsed(const Cluster& cl1, const Cluster& cl2);
   void createTrack(const Cluster& cl1, const Cluster& cl2);
+  std::list<Track>::iterator addTrack(const std::list<Track>::iterator& pos, const Track& track);
   bool isAcceptable(const TrackParam& param) const;
   void removeDuplicateTracks();
   void removeConnectedTracks(int stMin, int stMax);

--- a/Detectors/MUON/MCH/Tracking/include/MCHTracking/TrackerParam.h
+++ b/Detectors/MUON/MCH/Tracking/include/MCHTracking/TrackerParam.h
@@ -42,6 +42,8 @@ struct TrackerParam : public o2::conf::ConfigurableParamHelper<TrackerParam> {
   bool moreCandidates = false; ///< find more track candidates starting from 1 cluster in each of station (1..) 4 and 5
   bool refineTracks = true;    ///< refine the tracks in the end using cluster resolution
 
+  std::size_t maxCandidates = 100000; ///< maximum number of track candidates above which the tracking abort
+
   O2ParamDef(TrackerParam, "MCHTracking");
 };
 


### PR DESCRIPTION
This is to limit the memory footprint and running time by aborting the tracking if the combinatoric is too high, which can happen in case of high correlated noise in stations 3, 4, 5.