### PR TITLE
TRD fix tracklethcheader 1 option, should not be used.

### DIFF
--- a/DataFormats/Detectors/TRD/src/RawData.cxx
+++ b/DataFormats/Detectors/TRD/src/RawData.cxx
@@ -333,20 +333,16 @@ bool trackletHCHeaderSanityCheck(o2::trd::TrackletHCHeader& header)
   //figure out but for now, just approve.
   return true;
   if (header.one != 1) {
-    LOG(warn) << "Sanity check tracklethcheader.one is not 1";
     goodheader = false;
   }
   if (header.supermodule > 17) {
-    LOG(warn) << "Sanity check tracklethcheader.supermodule>17";
     goodheader = false;
   }
   //if(header.format != )  only certain format versions are permitted come back an fill in if needed.
   if (header.layer > 6) {
-    LOG(warn) << "Sanity check tracklethcheader.laywer>6";
     goodheader = false;
   }
   if (header.stack > 5) {
-    LOG(warn) << "Sanity check tracklethcheader.stack>5";
     goodheader = false;
   }
   return goodheader;


### PR DESCRIPTION
- due to the ambiguity of tracklethcheader and digithcheader, which option 1 enables it should not be used.
- however the data is in fact that format.
- the code now works for that option, up to the ambiguity.
 
Raw data tests will be finished before this finishes in the ci.