### PR TITLE
Gain map using tracks: Loading topology correction from CCDB

### DIFF
--- a/Detectors/TPC/calibration/doc/CalibPadGainTracks.md
+++ b/Detectors/TPC/calibration/doc/CalibPadGainTracks.md
@@ -47,7 +47,7 @@ The full residual gainmap extraction workflow can be executed in the following w
 ```
 o2-tpc-file-reader --input-type "clusters,tracks" --disable-mc \
 | o2-tpc-calib-gainmap-tracks -b --publish-after-tfs 100 --overflowBin true --debug true \
-| o2-tpc-calibrator-gainmap-tracks --ccdb-uri "http://localhost:8080" --min-entries 30 --tf-per-slot 100 --file-dump true
+| o2-tpc-calibrator-gainmap-tracks --ccdb-uri "http://localhost:8080" --min-entries 0 --tf-per-slot 100 --file-dump true --shm-segment-size 100000000000
 ```
 
 

--- a/Detectors/TPC/calibration/include/TPCCalibration/CalibPadGainTracksBase.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/CalibPadGainTracksBase.h
@@ -19,7 +19,6 @@
 
 // o2 includes
 #include "TPCBase/CalDet.h"
-#include "TPCBase/Mapper.h"
 #include "TPCCalibration/FastHisto.h"
 
 #include <gsl/span>
@@ -38,6 +37,13 @@ namespace tpc
 class CalibPadGainTracksBase
 {
  public:
+  /// normalization type of the extracted gain map
+  enum NormType : unsigned char {
+    none,  ///< no normalization
+    stack, ///< normalization per GEM stack
+    region ///< normalization per region
+  };
+
   using DataTHisto = FastHisto<unsigned int>;
   using DataTHistos = CalDet<DataTHisto>;
 
@@ -73,15 +79,21 @@ class CalibPadGainTracksBase
   bool hasEnoughData(const int minEntries) const;
 
   /// get the truncated mean and the sigma for each histogram and fill the extracted values in a CalPad object
+  /// \param minEntries minimum number of entries in pad-by-pad histogram to calculate the mean
+  /// \param minRelgain minimum accpeted relative gain (if the gain is below this value it will be set to 1)
+  /// \param maxRelgain maximum accpeted relative gain (if the gain is above this value it will be set to 1)
   /// \param low lower truncation range for calculating the rel gain
   /// \param high upper truncation range
-  void finalize(const float low = 0.05f, const float high = 0.6f);
+  void finalize(const int minEntries = 10, const float minRelgain = 0.1f, const float maxRelgain = 2.f, const float low = 0.05f, const float high = 0.6f);
 
   /// returns calpad containing pad-by-pad histograms
   const auto& getHistos() const { return mPadHistosDet; }
 
-  /// \return returns the gainmap object
+  /// \return returns the gainmap object as const reference
   const CalPad& getPadGainMap() const { return *mGainMap; }
+
+  /// \return returns the gainmap object as reference
+  CalPad& getPadGainMap() { return *mGainMap; }
 
   /// \return returns the gainmap object
   const CalPad& getSigmaMap() const { return *mSigmaMap; }
@@ -91,13 +103,13 @@ class CalibPadGainTracksBase
   /// \param region region of the TPC
   /// \param lrow local row in region
   /// \param pad pad in row
-  auto getHistogram(const int sector, const int region, const int lrow, const int pad) const { return mPadHistosDet->getValue(sector, Mapper::getGlobalPadNumber(lrow, pad, region)); }
+  auto getHistogram(const int sector, const int region, const int lrow, const int pad) const;
 
   /// \return return histogram which is used to extract the gain
   /// \param sector sector of the TPC
   /// \param grow global row in sector
   /// \param pad pad in row
-  auto getHistogram(const int sector, const int grow, const int pad) const { return mPadHistosDet->getValue(sector, Mapper::GLOBALPADOFFSET[Mapper::REGION[grow]] + Mapper::OFFSETCRUGLOBAL[grow] + pad); }
+  auto getHistogram(const int sector, const int grow, const int pad) const;
 
   /// draw gain map sector
   /// \param sector sector which will be drawn
@@ -146,6 +158,14 @@ class CalibPadGainTracksBase
   /// \param outName name of the object in the output file
   void dumpToFile(const char* outFileName = "calPadGainTracksBase.root", const char* outName = "calPadGain") const;
 
+  /// dump extracted gain map to tree
+  /// \filename name of the output file
+  void dumpGainMapToTree(const std::string filename = "gainmap_debug.root") const;
+
+  /// dump extracted sigma map to tree
+  /// \filename name of the output file
+  void dumpSigmaMapToTree(const std::string filename = "sigmamap_debug.root") const;
+
   /// setting a gain map from a file
   /// \param inpFile input file containing some caldet
   /// \param mapName name of the caldet
@@ -153,6 +173,12 @@ class CalibPadGainTracksBase
 
   /// setting a gain map from a file
   void setGainMap(const CalPad& gainmap) { mGainMap = std::make_unique<CalPad>(gainmap); }
+
+  /// set how the extracted gain map is normalized
+  void setNormalizationType(const NormType type) { mNormType = type; }
+
+  /// \return return how the extracted gain map is normalized
+  auto getNormalizationType() const { return mNormType; }
 
   /// resetting the histograms which are used for extraction of the gain map
   void resetHistos();
@@ -172,11 +198,27 @@ class CalibPadGainTracksBase
 
  private:
   std::unique_ptr<DataTHistos> mPadHistosDet; ///< Calibration object containing for each pad a histogram with normalized charge
-  std::unique_ptr<CalPad> mGainMap;           ///< Gain map object
-  std::unique_ptr<CalPad> mSigmaMap;          ///< standard dewviation map
+  std::unique_ptr<CalPad> mGainMap;           ///< Extracted gain map from tracks
+  std::unique_ptr<CalPad> mSigmaMap;          ///< standard deviation map
+  NormType mNormType = region;                ///< Normalization type for the extracted gain map
 
   /// Helper function for drawing the extracted gain map
   void drawExtractedGainMapHelper(const bool type, const int typeMap, const Sector sector, const std::string filename, const float minZ, const float maxZ, const bool norm = false) const;
+
+  /// normalizing an input vector
+  /// \param data vector which will be normalized
+  /// \param nPads intervals which will be used to calculate the median of the data vector for normalization
+  void normalize(std::vector<float>& data, const std::vector<int>& nPads);
+
+  /// normalize calpad per stack or per region
+  /// \calPad Calpad which will be normalized
+  void normalizeGain(CalPad& calPad);
+
+  /// helper function for normalizing the gain
+  std::vector<int> getNPadsForNormalization(const bool iroc) const;
+
+  /// normalize calpad per stack or per region
+  void normalizeGainMap() { normalizeGain(*mGainMap.get()); }
 };
 
 } // namespace tpc

--- a/Detectors/TPC/calibration/include/TPCCalibration/CalibPadGainTracksBase.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/CalibPadGainTracksBase.h
@@ -158,13 +158,9 @@ class CalibPadGainTracksBase
   /// \param outName name of the object in the output file
   void dumpToFile(const char* outFileName = "calPadGainTracksBase.root", const char* outName = "calPadGain") const;
 
-  /// dump extracted gain map to tree
+  /// dump extracted gain and sigma map to tree
   /// \filename name of the output file
-  void dumpGainMapToTree(const std::string filename = "gainmap_debug.root") const;
-
-  /// dump extracted sigma map to tree
-  /// \filename name of the output file
-  void dumpSigmaMapToTree(const std::string filename = "sigmamap_debug.root") const;
+  void dumpToTree(const std::string filename = "map_debug.root") const;
 
   /// setting a gain map from a file
   /// \param inpFile input file containing some caldet

--- a/Detectors/TPC/calibration/include/TPCCalibration/FastHisto.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/FastHisto.h
@@ -141,7 +141,7 @@ class FastHisto
   bool isUnderflowSet() const { return mUseUnderflow; }
 
   /// \return returns if overflow bin is used in the histogram
-  bool isOverflowSet() const { return mUseUnderflow; }
+  bool isOverflowSet() const { return mUseOverflow; }
 
   /// \return returns status wether the bin is in the histogram range
   bool checkBin(int bin) const

--- a/Detectors/TPC/calibration/src/CalibPadGainTracks.cxx
+++ b/Detectors/TPC/calibration/src/CalibPadGainTracks.cxx
@@ -10,13 +10,19 @@
 // or submit itself to any jurisdiction.
 
 ///
-/// @file   CalibPadGainTracks.h
+/// @file   CalibPadGainTracks.cxx
 /// @author Matthias Kleiner, matthias.kleiner@cern.ch
 ///
 
 #include "TPCCalibration/CalibPadGainTracks.h"
 #include "TPCBase/PadPos.h"
 #include "TPCBase/ROC.h"
+#include "TPCBase/Mapper.h"
+#include "TPCCalibration/IDCDrawHelper.h"
+#include "GPUO2InterfaceRefit.h"
+#include "TPCReconstruction/TPCFastTransformHelperO2.h"
+#include "GPUO2Interface.h"
+#include "DataFormatsTPC/ClusterNative.h"
 
 // root includes
 #include "TFile.h"
@@ -25,12 +31,24 @@ using namespace o2::tpc;
 
 void CalibPadGainTracks::processTracks()
 {
+  if (!mPropagateTrack && !mFastTransform) {
+    mFastTransform = TPCFastTransformHelperO2::instance()->create(0);
+  }
+
+  std::unique_ptr<o2::gpu::GPUO2InterfaceRefit> refit;
+  if (!mPropagateTrack) {
+    mBufVec.resize(mClusterIndex->nClustersTotal);
+    o2::gpu::GPUO2InterfaceRefit::fillSharedClustersMap(mClusterIndex, *mTracks, mTPCTrackClIdxVecInput->data(), mBufVec.data());
+    mClusterShMapTPC = mBufVec.data();
+    refit = std::make_unique<o2::gpu::GPUO2InterfaceRefit>(mClusterIndex, mFastTransform.get(), mField, mTPCTrackClIdxVecInput->data(), mClusterShMapTPC);
+  }
+
   for (const auto& trk : *mTracks) {
-    processTrack(trk);
+    processTrack(trk, refit.get());
   }
 }
 
-void CalibPadGainTracks::processTrack(o2::tpc::TrackTPC track)
+void CalibPadGainTracks::processTrack(o2::tpc::TrackTPC track, o2::gpu::GPUO2InterfaceRefit* refit)
 {
   // make momentum cut
   const float mom = track.getP();
@@ -48,6 +66,11 @@ void CalibPadGainTracks::processTrack(o2::tpc::TrackTPC track)
   for (int iCl = 0; iCl < nClusters; iCl++) { // loop over cluster
     const o2::tpc::ClusterNative& cl = track.getCluster(*mTPCTrackClIdxVecInput, iCl, *mClusterIndex);
 
+    const auto flagsCl = cl.getFlags();
+    if ((flagsCl & ClusterNative::flagSingle) == ClusterNative::flagSingle) {
+      continue;
+    }
+
     unsigned char sectorIndex = 0;
     unsigned char rowIndex = 0;
     unsigned int clusterIndexNumb = 0;
@@ -55,17 +78,22 @@ void CalibPadGainTracks::processTrack(o2::tpc::TrackTPC track)
     // this function sets sectorIndex, rowIndex, clusterIndexNumb
     track.getClusterReference(*mTPCTrackClIdxVecInput, iCl, sectorIndex, rowIndex, clusterIndexNumb);
     const float xPosition = Mapper::instance().getPadCentre(PadPos(rowIndex, 0)).X();
-    const bool check = track.propagateTo(xPosition, mField); // propagate this track to the plane X=xk (cm) in the field "b" (kG)
-    if (!check) {
+    if (!mPropagateTrack) {
+      refit->setTrackReferenceX(xPosition);
+    }
+    const bool check = mPropagateTrack ? track.propagateTo(xPosition, mField) : ((refit->RefitTrackAsGPU(track, false, true) < 0) ? false : true); // propagate this track to the plane X=xk (cm) in the field "b" (kG)
+
+    if (!check || std::isnan(track.getParam(1))) {
       continue;
     }
 
     const int region = Mapper::REGION[rowIndex];
-    const float effectiveLength = mCalibTrackTopologyPol ? getTrackTopologyCorrectionPol(track, cl, region) : getTrackTopologyCorrection(track, region);
+    const float charge = (mChargeType == ChargeType::Max) ? cl.qMax : cl.qTot;
+    const float effectiveLength = mCalibTrackTopologyPol ? getTrackTopologyCorrectionPol(track, cl, region, charge) : getTrackTopologyCorrection(track, region);
 
-    const unsigned char pad = static_cast<unsigned char>(cl.getPad() + 0.5f); // the left side of the pad ist defined at e.g. 3.5 and the right side at 4.5
+    const unsigned char pad = static_cast<unsigned char>(cl.getPad() + 0.5f); // the left side of the pad is defined at e.g. 3.5 and the right side at 4.5
     const float gain = mGainMapRef ? mGainMapRef->getValue(sectorIndex, rowIndex, pad) : 1;
-    const float chargeNorm = cl.qMax / (effectiveLength * gain);
+    const float chargeNorm = charge / (effectiveLength * gain);
 
     if (mMode == dedxTracking) {
       const auto& dEdx = track.getdEdx();
@@ -75,29 +103,29 @@ void CalibPadGainTracks::processTrack(o2::tpc::TrackTPC track)
       if (mDedxRegion == stack) {
         const auto stack = cru.gemStack();
         if (stack == GEMstack::IROCgem && dEdx.NHitsIROC > mMinClusters) {
-          dedx = dEdx.dEdxMaxIROC;
-        } else if (stack == GEMstack::OROC1gem && dEdx.dEdxMaxOROC1 > mMinClusters) {
-          dedx = dEdx.dEdxMaxOROC1;
-        } else if (stack == GEMstack::OROC2gem && dEdx.dEdxMaxOROC2 > mMinClusters) {
-          dedx = dEdx.dEdxMaxOROC2;
-        } else if (stack == GEMstack::OROC3gem && dEdx.dEdxMaxOROC3 > mMinClusters) {
-          dedx = dEdx.dEdxMaxOROC3;
+          dedx = getdEdxIROC(dEdx);
+        } else if (stack == GEMstack::OROC1gem && dEdx.NHitsOROC1 > mMinClusters) {
+          dedx = getdEdxOROC1(dEdx);
+        } else if (stack == GEMstack::OROC2gem && dEdx.NHitsOROC2 > mMinClusters) {
+          dedx = getdEdxOROC2(dEdx);
+        } else if (stack == GEMstack::OROC3gem && dEdx.NHitsOROC3 > mMinClusters) {
+          dedx = getdEdxOROC3(dEdx);
         }
       } else if (mDedxRegion == chamber) {
         if (cru.isIROC() && dEdx.NHitsIROC > mMinClusters) {
-          dedx = dEdx.dEdxMaxIROC;
+          dedx = getdEdxIROC(dEdx);
         } else {
           int count = 0;
           if (dEdx.NHitsOROC1 > mMinClusters) {
-            dedx += dEdx.dEdxMaxOROC1;
+            dedx += getdEdxOROC1(dEdx);
             ++count;
           }
           if (dEdx.NHitsOROC2 > mMinClusters) {
-            dedx += dEdx.dEdxMaxOROC2;
+            dedx += getdEdxOROC2(dEdx);
             ++count;
           }
           if (dEdx.NHitsOROC3 > mMinClusters) {
-            dedx += dEdx.dEdxMaxOROC3;
+            dedx += getdEdxOROC3(dEdx);
             ++count;
           }
           if (count > 0) {
@@ -105,7 +133,7 @@ void CalibPadGainTracks::processTrack(o2::tpc::TrackTPC track)
           }
         }
       } else if (mDedxRegion == sector) {
-        dedx = dEdx.dEdxMaxTPC;
+        dedx = getdEdxTPC(dEdx);
       }
 
       if (dedx <= 0) {
@@ -123,7 +151,15 @@ void CalibPadGainTracks::processTrack(o2::tpc::TrackTPC track)
 
     if (mMode == dedxTrack) {
       const int indexBuffer = getdEdxBufferIndex(region);
-      mDEdxBuffer[indexBuffer].emplace_back(chargeNorm);
+
+      const bool isEdge = (flagsCl & ClusterNative::flagEdge) == ClusterNative::flagEdge;
+      const int isSectorCentre = std::abs(static_cast<int>(pad) - static_cast<int>(Mapper::PADSPERROW[region][rowIndex] / 2)); // do not use clusters at the centre of a sector for dE/dx calculation
+      const int nPadsSector = 1;
+
+      if (!isEdge && (isSectorCentre > nPadsSector)) {
+        mDEdxBuffer[indexBuffer].emplace_back(chargeNorm);
+      }
+
       mClTrk.emplace_back(std::make_tuple(sectorIndex, rowIndex, pad, chargeNorm)); // fill with dummy dedx value
     }
   }
@@ -196,7 +232,7 @@ float CalibPadGainTracks::getTrackTopologyCorrection(const o2::tpc::TrackTPC& tr
   return effectiveLength;
 }
 
-float CalibPadGainTracks::getTrackTopologyCorrectionPol(const o2::tpc::TrackTPC& track, const o2::tpc::ClusterNative& cl, const unsigned int region) const
+float CalibPadGainTracks::getTrackTopologyCorrectionPol(const o2::tpc::TrackTPC& track, const o2::tpc::ClusterNative& cl, const unsigned int region, const float charge) const
 {
   const float trackSnp = track.getSnp();
   const float maxSnp = mCalibTrackTopologyPol->getMaxSinPhi();
@@ -219,7 +255,8 @@ float CalibPadGainTracks::getTrackTopologyCorrectionPol(const o2::tpc::TrackTPC&
   const float padTmp = cl.getPad();
   const float absRelPad = std::abs(padTmp - int(padTmp + 0.5f));
   const float relTime = cl.getTime() - int(cl.getTime() + 0.5f);
-  const float effectiveLength = mCalibTrackTopologyPol->getCorrectionqMax(region, tanTheta, snp, z, absRelPad, relTime);
+
+  const float effectiveLength = (mChargeType == ChargeType::Max) ? mCalibTrackTopologyPol->getCorrectionqMax(region, tanTheta, snp, z, absRelPad, relTime) : mCalibTrackTopologyPol->getCorrectionqTot(region, tanTheta, snp, z, 3.5f /*dummy threshold for now*/, std::clamp(charge, mCalibTrackTopologyPol->getMinqTot(), mCalibTrackTopologyPol->getMaxqTot()));
   return effectiveLength;
 }
 
@@ -307,4 +344,45 @@ void CalibPadGainTracks::loadPolTopologyCorrectionFromFile(std::string_view file
 {
   mCalibTrackTopologyPol = std::make_unique<CalibdEdxTrackTopologyPol>();
   mCalibTrackTopologyPol->loadFromFile(fileName.data(), "CalibdEdxTrackTopologyPol");
+}
+
+void CalibPadGainTracks::setPolTopologyCorrectionFromContainer(const CalibdEdxTrackTopologyPolContainer& polynomials)
+{
+  mCalibTrackTopologyPol = std::make_unique<CalibdEdxTrackTopologyPol>();
+  mCalibTrackTopologyPol->setFromContainer(polynomials);
+}
+
+void CalibPadGainTracks::drawRefGainMapHelper(const bool type, const Sector sector, const std::string filename, const float minZ, const float maxZ) const
+{
+  if (!mGainMapRef) {
+    LOGP(error, "Map not set");
+    return;
+  }
+
+  std::function<float(const unsigned int, const unsigned int, const unsigned int, const unsigned int)> idcFunc = [mapTmp = mGainMapRef.get()](const unsigned int sector, const unsigned int region, const unsigned int lrow, const unsigned int pad) {
+    return mapTmp->getValue(sector, Mapper::getGlobalPadNumber(lrow, pad, region));
+  };
+
+  IDCDrawHelper::IDCDraw drawFun;
+  drawFun.mIDCFunc = idcFunc;
+  const std::string zAxisTitle = "rel. gain";
+  type ? IDCDrawHelper::drawSide(drawFun, sector.side(), zAxisTitle, filename, minZ, maxZ) : IDCDrawHelper::drawSector(drawFun, 0, Mapper::NREGIONS, sector, zAxisTitle, filename, minZ, maxZ);
+}
+
+void CalibPadGainTracks::dumpReferenceExtractedGainMap(const char* outFileName, const char* outName) const
+{
+  if (!mGainMapRef) {
+    LOGP(error, "Map not set");
+    return;
+  }
+  CalDet gainMapRef(*mGainMapRef.get());
+  gainMapRef *= getPadGainMap();
+
+  TFile f(outFileName, "RECREATE");
+  f.WriteObject(&gainMapRef, outName);
+}
+
+int CalibPadGainTracks::getIndex(o2::tpc::PadSubset padSub, int padSubsetNumber, const int row, const int pad)
+{
+  return Mapper::instance().getPadNumber(padSub, padSubsetNumber, row, pad);
 }

--- a/Detectors/TPC/calibration/src/CalibPadGainTracksBase.cxx
+++ b/Detectors/TPC/calibration/src/CalibPadGainTracksBase.cxx
@@ -71,25 +71,19 @@ void CalibPadGainTracksBase::drawExtractedGainMapHelper(const bool type, const i
   type ? IDCDrawHelper::drawSide(drawFun, sector.side(), zAxisTitle, filename, minZ, maxZ) : IDCDrawHelper::drawSector(drawFun, 0, Mapper::NREGIONS, sector, zAxisTitle, filename, minZ, maxZ);
 }
 
-void CalibPadGainTracksBase::dumpGainMapToTree(const std::string filename) const
+void CalibPadGainTracksBase::dumpToTree(const std::string filename) const
 {
   if (!mGainMap) {
     LOGP(error, "Map not set. Returning");
     return;
   }
   CalibTreeDump dump;
-  dump.add(mGainMap.get());
-  dump.dumpToFile(filename);
-}
-
-void CalibPadGainTracksBase::dumpSigmaMapToTree(const std::string filename) const
-{
-  if (!mSigmaMap) {
-    LOGP(error, "Map not set. Returning");
-    return;
+  if (mGainMap) {
+    dump.add(mGainMap.get());
   }
-  CalibTreeDump dump;
-  dump.add(mSigmaMap.get());
+  if (mSigmaMap) {
+    dump.add(mSigmaMap.get());
+  }
   dump.dumpToFile(filename);
 }
 

--- a/Detectors/TPC/calibration/src/CalibPadGainTracksBase.cxx
+++ b/Detectors/TPC/calibration/src/CalibPadGainTracksBase.cxx
@@ -16,6 +16,8 @@
 #include "TPCCalibration/IDCDrawHelper.h"
 #include "TPCBase/ROC.h"
 #include "TPCBase/Painter.h"
+#include "TPCCalibration/CalibTreeDump.h"
+#include "TPCBase/Mapper.h"
 
 // root includes
 #include "TFile.h"
@@ -67,6 +69,28 @@ void CalibPadGainTracksBase::drawExtractedGainMapHelper(const bool type, const i
   drawFun.mIDCFunc = idcFunc;
   const std::string zAxisTitle = (typeMap == 0) ? "rel. gain" : (norm ? "sigma / rel. gain" : "sigma");
   type ? IDCDrawHelper::drawSide(drawFun, sector.side(), zAxisTitle, filename, minZ, maxZ) : IDCDrawHelper::drawSector(drawFun, 0, Mapper::NREGIONS, sector, zAxisTitle, filename, minZ, maxZ);
+}
+
+void CalibPadGainTracksBase::dumpGainMapToTree(const std::string filename) const
+{
+  if (!mGainMap) {
+    LOGP(error, "Map not set. Returning");
+    return;
+  }
+  CalibTreeDump dump;
+  dump.add(mGainMap.get());
+  dump.dumpToFile(filename);
+}
+
+void CalibPadGainTracksBase::dumpSigmaMapToTree(const std::string filename) const
+{
+  if (!mSigmaMap) {
+    LOGP(error, "Map not set. Returning");
+    return;
+  }
+  CalibTreeDump dump;
+  dump.add(mSigmaMap.get());
+  dump.dumpToFile(filename);
 }
 
 void CalibPadGainTracksBase::divideGainMap(const char* inpFile, const char* mapName)
@@ -146,6 +170,10 @@ void CalibPadGainTracksBase::print() const
 
 bool CalibPadGainTracksBase::hasEnoughData(const int minEntries) const
 {
+  if (minEntries == 0) {
+    return true;
+  }
+
   for (auto& calArray : mPadHistosDet->getData()) {
     for (auto& tHist : calArray.getData()) {
       const auto entries = tHist.getEntries();
@@ -157,14 +185,77 @@ bool CalibPadGainTracksBase::hasEnoughData(const int minEntries) const
   return true;
 }
 
-void CalibPadGainTracksBase::finalize(const float low, const float high)
+void CalibPadGainTracksBase::finalize(const int minEntries, const float minRelgain, const float maxRelgain, const float low, const float high)
 {
   for (int roc = 0; roc < ROC::MaxROC; ++roc) {
     const auto padsInRoc = ROC(roc).isIROC() ? Mapper::getPadsInIROC() : Mapper::getPadsInOROC();
     for (int pad = 0; pad < padsInRoc; ++pad) {
-      const auto stat = mPadHistosDet->getCalArray(roc).getData()[pad].getStatisticsData(low, high);
-      mGainMap->getCalArray(roc).getData()[pad] = stat.mCOG;
-      mSigmaMap->getCalArray(roc).getData()[pad] = stat.mStdDev;
+      const auto& histo = mPadHistosDet->getCalArray(roc).getData()[pad];
+      unsigned int entries = histo.getEntries();
+      const auto stat = histo.getStatisticsData(low, high);
+      const auto cog = std::clamp(static_cast<float>(stat.mCOG), minRelgain, maxRelgain);
+
+      // subtract underflow and overflow entries to check if only the valid entries are > 0
+      if (histo.isUnderflowSet()) {
+        entries -= histo.getBinContent(0);
+      }
+
+      if (histo.isOverflowSet()) {
+        const unsigned int binOverflow = histo.getNBins() + histo.isUnderflowSet();
+        entries -= histo.getBinContent(binOverflow);
+      }
+
+      if (entries >= minEntries) {
+        mGainMap->getCalArray(roc).getData()[pad] = cog;
+        mSigmaMap->getCalArray(roc).getData()[pad] = stat.mStdDev;
+      } else {
+        mGainMap->getCalArray(roc).getData()[pad] = 1;
+        mSigmaMap->getCalArray(roc).getData()[pad] = 0;
+      }
     }
   }
+  normalizeGain(*mGainMap.get());
+}
+
+void CalibPadGainTracksBase::normalizeGain(CalPad& calPad)
+{
+  for (auto& data : calPad.getData()) {
+    const bool isIROC = data.getPadSubsetNumber() < 36;
+    normalize(data.getData(), getNPadsForNormalization(isIROC));
+  }
+}
+
+std::vector<int> CalibPadGainTracksBase::getNPadsForNormalization(const bool iroc) const
+{
+  if (mNormType == NormType::stack) {
+    // normalize per stack
+    const std::vector<int> nPads = iroc ? std::vector<int>{Mapper::getPadsInIROC()} : std::vector<int>{Mapper::getPadsInOROC1(), Mapper::getPadsInOROC2(), Mapper::getPadsInOROC3()};
+    return nPads;
+  } else if (mNormType == NormType::region) {
+    // normalize per region
+    const std::vector<int> nPads = iroc ? std::vector<int>{Mapper::PADSPERREGION[0], Mapper::PADSPERREGION[1], Mapper::PADSPERREGION[2], Mapper::PADSPERREGION[3]} : std::vector<int>{Mapper::PADSPERREGION[4], Mapper::PADSPERREGION[5], Mapper::PADSPERREGION[6], Mapper::PADSPERREGION[7], Mapper::PADSPERREGION[8], Mapper::PADSPERREGION[9]};
+    return nPads;
+  } else {
+    return std::vector<int>();
+  }
+}
+
+void CalibPadGainTracksBase::normalize(std::vector<float>& data, const std::vector<int>& nPads)
+{
+  int padStart = 0;
+  for (const auto pads : nPads) {
+    auto median = TMath::Median(pads, data.data() + padStart);
+    std::for_each(data.data() + padStart, data.data() + padStart + pads, [median](auto& val) { val /= (val > 0) ? median : 1; });
+    padStart += pads;
+  }
+}
+
+auto CalibPadGainTracksBase::getHistogram(const int sector, const int region, const int lrow, const int pad) const
+{
+  return mPadHistosDet->getValue(sector, Mapper::getGlobalPadNumber(lrow, pad, region));
+}
+
+auto CalibPadGainTracksBase::getHistogram(const int sector, const int grow, const int pad) const
+{
+  return mPadHistosDet->getValue(sector, Mapper::GLOBALPADOFFSET[Mapper::REGION[grow]] + Mapper::OFFSETCRUGLOBAL[grow] + pad);
 }

--- a/Detectors/TPC/workflow/include/TPCWorkflow/CalibratorPadGainTracksSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/CalibratorPadGainTracksSpec.h
@@ -25,7 +25,6 @@
 #include "TPCBase/CDBInterface.h"
 #include "TPCWorkflow/ProcessingHelpers.h"
 #include "DetectorsBase/GRPGeomHelper.h"
-#include "DetectorsCalibration/Utils.h"
 
 using namespace o2::framework;
 using o2::header::gDataOriginTPC;
@@ -109,8 +108,7 @@ class CalibratorPadGainTracksDevice : public Task
       if (mWriteToDB) {
         LOGP(info, "Writing pad-by-pad gain map to CCDB for TF {} to {}", firstTF, lastTF);
         mMetadata["runNumber"] = std::to_string(mRunNumber);
-        const auto timeStampEnd = o2::calibration::Utils::INFINITE_TIME;
-        mDBapi.storeAsTFileAny<std::unordered_map<std::string, CalPad>>(&calib, CDBTypeMap.at(CDBType::CalPadGainResidual), mMetadata, mCreationTime, timeStampEnd);
+        mDBapi.storeAsTFileAny<std::unordered_map<std::string, CalPad>>(&calib, CDBTypeMap.at(CDBType::CalPadGainResidual), mMetadata, mCreationTime, o2::calibration::INFINITE_TF);
       }
     }
     mCalibrator->initOutput(); // empty the outputs after they are send
@@ -119,11 +117,11 @@ class CalibratorPadGainTracksDevice : public Task
   const bool mUseLastExtractedMapAsReference{false};    ///< whether to use the last extracted gain map as a reference gain map
   std::unique_ptr<CalibratorPadGainTracks> mCalibrator; ///< calibrator object for creating the pad-by-pad gain map
   std::shared_ptr<o2::base::GRPGeomRequest> mCCDBRequest;
-  bool mWriteToDB{};                                    ///< flag if writing to CCDB will be done
-  o2::ccdb::CcdbApi mDBapi;                             ///< API for storing the gain map in the CCDB
-  std::map<std::string, std::string> mMetadata;         ///< meta data of the stored object in CCDB
-  uint64_t mRunNumber{0};                               ///< processed run number
-  uint64_t mCreationTime{0};                            ///< creation time of current TF
+  bool mWriteToDB{};                            ///< flag if writing to CCDB will be done
+  o2::ccdb::CcdbApi mDBapi;                     ///< API for storing the gain map in the CCDB
+  std::map<std::string, std::string> mMetadata; ///< meta data of the stored object in CCDB
+  uint64_t mRunNumber{0};                       ///< processed run number
+  uint64_t mCreationTime{0};                    ///< creation time of current TF
 };
 
 /// create a processor spec

--- a/Detectors/TPC/workflow/include/TPCWorkflow/CalibratorPadGainTracksSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/CalibratorPadGainTracksSpec.h
@@ -19,16 +19,16 @@
 #include "Framework/DataProcessorSpec.h"
 #include "TPCCalibration/CalibratorPadGainTracks.h"
 #include "CCDB/CcdbApi.h"
-#include "CCDB/CcdbObjectInfo.h"
 #include "CommonUtils/NameConf.h"
 #include "Framework/Task.h"
-#include "Framework/DataProcessorSpec.h"
 #include "Framework/ConfigParamRegistry.h"
 #include "TPCBase/CDBInterface.h"
 #include "TPCWorkflow/ProcessingHelpers.h"
 #include "DetectorsBase/GRPGeomHelper.h"
+#include "DetectorsCalibration/Utils.h"
 
 using namespace o2::framework;
+using o2::header::gDataOriginTPC;
 
 namespace o2::tpc
 {
@@ -36,23 +36,31 @@ namespace o2::tpc
 class CalibratorPadGainTracksDevice : public Task
 {
  public:
-  CalibratorPadGainTracksDevice(std::shared_ptr<o2::base::GRPGeomRequest> req) : mCCDBRequest(req) {}
+  CalibratorPadGainTracksDevice(std::shared_ptr<o2::base::GRPGeomRequest> req, const bool useLastExtractedMapAsReference) : mUseLastExtractedMapAsReference(useLastExtractedMapAsReference), mCCDBRequest(req) {}
   void init(framework::InitContext& ic) final
   {
     o2::base::GRPGeomHelper::instance().setRequest(mCCDBRequest);
     const auto slotLength = ic.options().get<uint32_t>("tf-per-slot");
     const auto maxDelay = ic.options().get<uint32_t>("max-delay");
     const int minEntries = ic.options().get<int>("min-entries");
+    const int gainNorm = ic.options().get<int>("gainNorm");
     const bool debug = ic.options().get<bool>("file-dump");
     const auto lowTrunc = ic.options().get<float>("lowTrunc");
     const auto upTrunc = ic.options().get<float>("upTrunc");
+    const auto minAcceptedRelgain = ic.options().get<float>("minAcceptedRelgain");
+    const auto maxAcceptedRelgain = ic.options().get<float>("maxAcceptedRelgain");
+    const int minEntriesMean = ic.options().get<int>("minEntriesMean");
 
     mCalibrator = std::make_unique<CalibratorPadGainTracks>();
     mCalibrator->setMinEntries(minEntries);
     mCalibrator->setSlotLength(slotLength);
     mCalibrator->setMaxSlotsDelay(maxDelay);
     mCalibrator->setTruncationRange(lowTrunc, upTrunc);
+    mCalibrator->setRelGainRange(minAcceptedRelgain, maxAcceptedRelgain);
     mCalibrator->setWriteDebug(debug);
+    mCalibrator->setNormalizationType(static_cast<CalibPadGainTracksBase::NormType>(gainNorm));
+    mCalibrator->setUseLastExtractedMapAsReference(mUseLastExtractedMapAsReference);
+    mCalibrator->setMinEntriesMean(minEntriesMean);
 
     // setting up the CCDB
     mDBapi.init(ic.options().get<std::string>("ccdb-uri")); // or http://localhost:8080 for a local installation
@@ -71,11 +79,12 @@ class CalibratorPadGainTracksDevice : public Task
     o2::base::TFIDInfoHelper::fillTFIDInfo(pc, mCalibrator->getCurrentTFInfo());
     mCalibrator->process(*histomaps.get());
     const auto& infoVec = mCalibrator->getTFinterval();
-    LOGP(info, "Created {} objects for TF {}", infoVec.size(), mCalibrator->getCurrentTFInfo().tfCounter);
+    LOGP(info, "Created {} objects for TF {} and time stamp {}", infoVec.size(), mCalibrator->getCurrentTFInfo().tfCounter, mCalibrator->getCurrentTFInfo().creation);
 
     if (mCalibrator->hasCalibrationData()) {
       mRunNumber = mCalibrator->getCurrentTFInfo().runNumber;
-      sendOutput(pc.outputs());
+      mCreationTime = mCalibrator->getCurrentTFInfo().creation;
+      sendOutput();
     }
   }
 
@@ -83,15 +92,16 @@ class CalibratorPadGainTracksDevice : public Task
   {
     LOGP(info, "Finalizing calibration");
     mCalibrator->checkSlotsToFinalize(o2::calibration::INFINITE_TF);
-    sendOutput(eos.outputs());
+    sendOutput();
   }
 
  private:
-  void sendOutput(DataAllocator& output)
+  void sendOutput()
   {
-    const auto& calibrations = mCalibrator->getCalibs();
+    auto calibrations = std::move(*mCalibrator).getCalibs();
+
     for (uint32_t iCalib = 0; iCalib < calibrations.size(); ++iCalib) {
-      const auto& calib = calibrations[iCalib];
+      auto& calib = calibrations[iCalib];
       const auto& infoVec = mCalibrator->getTFinterval();
       const auto firstTF = infoVec[iCalib].first;
       const auto lastTF = infoVec[iCalib].second;
@@ -99,22 +109,25 @@ class CalibratorPadGainTracksDevice : public Task
       if (mWriteToDB) {
         LOGP(info, "Writing pad-by-pad gain map to CCDB for TF {} to {}", firstTF, lastTF);
         mMetadata["runNumber"] = std::to_string(mRunNumber);
-        mDBapi.storeAsTFileAny<std::unordered_map<std::string, CalPad>>(&calib, CDBTypeMap.at(CDBType::CalPadGainResidual), mMetadata, firstTF, lastTF + 1);
+        const auto timeStampEnd = o2::calibration::Utils::INFINITE_TIME;
+        mDBapi.storeAsTFileAny<std::unordered_map<std::string, CalPad>>(&calib, CDBTypeMap.at(CDBType::CalPadGainResidual), mMetadata, mCreationTime, timeStampEnd);
       }
     }
     mCalibrator->initOutput(); // empty the outputs after they are send
   }
 
+  const bool mUseLastExtractedMapAsReference{false};    ///< whether to use the last extracted gain map as a reference gain map
   std::unique_ptr<CalibratorPadGainTracks> mCalibrator; ///< calibrator object for creating the pad-by-pad gain map
   std::shared_ptr<o2::base::GRPGeomRequest> mCCDBRequest;
   bool mWriteToDB{};                                    ///< flag if writing to CCDB will be done
   o2::ccdb::CcdbApi mDBapi;                             ///< API for storing the gain map in the CCDB
   std::map<std::string, std::string> mMetadata;         ///< meta data of the stored object in CCDB
   uint64_t mRunNumber{0};                               ///< processed run number
+  uint64_t mCreationTime{0};                            ///< creation time of current TF
 };
 
 /// create a processor spec
-o2::framework::DataProcessorSpec getTPCCalibPadGainTracksSpec()
+o2::framework::DataProcessorSpec getTPCCalibPadGainTracksSpec(const bool useLastExtractedMapAsReference)
 {
   std::vector<OutputSpec> outputs;
   std::vector<InputSpec> inputs{{"gainhistos", "TPC", "TRACKGAINHISTOS"}};
@@ -129,14 +142,18 @@ o2::framework::DataProcessorSpec getTPCCalibPadGainTracksSpec()
     "tpc-calibrator-gainmap-tracks",
     inputs,
     outputs,
-    adaptFromTask<CalibratorPadGainTracksDevice>(ccdbRequest),
+    adaptFromTask<CalibratorPadGainTracksDevice>(ccdbRequest, useLastExtractedMapAsReference),
     Options{
       {"ccdb-uri", VariantType::String, o2::base::NameConf::getCCDBServer(), {"URI for the CCDB access."}},
       {"tf-per-slot", VariantType::UInt32, 100u, {"number of TFs per calibration time slot"}},
       {"max-delay", VariantType::UInt32, 3u, {"number of slots in past to consider"}},
-      {"min-entries", VariantType::Int, 50, {"minimum entries per pad-by-pad histogram which are required"}},
+      {"min-entries", VariantType::Int, 0, {"minimum entries per pad-by-pad histogram which are required"}},
       {"lowTrunc", VariantType::Float, 0.05f, {"lower truncation range for calculating the rel gain"}},
       {"upTrunc", VariantType::Float, 0.6f, {"upper truncation range for calculating the rel gain"}},
+      {"minAcceptedRelgain", VariantType::Float, 0.1f, {"minimum accpeted relative gain (if the gain is below this value it will be set to 1)"}},
+      {"maxAcceptedRelgain", VariantType::Float, 2.f, {"maximum accpeted relative gain (if the gain is above this value it will be set to 1)"}},
+      {"gainNorm", VariantType::Int, 2, {"normalization method for the extracted gain map: 0=no normalization, 1=median per stack, 2=median per region"}},
+      {"minEntriesMean", VariantType::Int, 10, {"minEntries minimum number of entries in pad-by-pad histogram to calculate the mean"}},
       {"file-dump", VariantType::Bool, false, {"directly write calibration to a file"}}}};
 }
 

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCCalibPadGainTracksSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCCalibPadGainTracksSpec.h
@@ -16,15 +16,16 @@
 #define O2_CALIBRATION_TPCCALIBPADGAINTRACKSSPEC_H
 
 #include "Framework/Task.h"
-#include "Framework/ControlService.h"
 #include "Framework/Logger.h"
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/DataProcessorSpec.h"
-#include "Framework/DeviceSpec.h"
 #include "TPCCalibration/CalibPadGainTracks.h"
 #include "CommonUtils/NameConf.h"
 #include "DataFormatsTPC/WorkflowHelper.h"
 #include "DataFormatsParameters/GRPObject.h"
+#include "TPCWorkflow/ProcessingHelpers.h"
+#include "Framework/CCDBParamSpec.h"
+#include "TPCBase/CDBInterface.h"
 
 using namespace o2::framework;
 using o2::header::gDataOriginTPC;
@@ -38,7 +39,14 @@ namespace tpc
 class TPCCalibPadGainTracksDevice : public o2::framework::Task
 {
  public:
-  TPCCalibPadGainTracksDevice(const uint32_t publishAfterTFs, const bool debug) : mPublishAfter(publishAfterTFs), mDebug(debug) {}
+  TPCCalibPadGainTracksDevice(const uint32_t publishAfterTFs, const bool debug, const bool useLastExtractedMapAsReference, const std::string polynomialsFile, const bool disablePolynomialsCCDB) : mPublishAfter(publishAfterTFs), mDebug(debug), mUseLastExtractedMapAsReference(useLastExtractedMapAsReference), mDisablePolynomialsCCDB(disablePolynomialsCCDB)
+  {
+    if (!polynomialsFile.empty()) {
+      LOGP(info, "Loading polynomials from file {}", polynomialsFile);
+      mPadGainTracks.loadPolTopologyCorrectionFromFile(polynomialsFile.data());
+      mDisablePolynomialsCCDB = true;
+    }
+  }
 
   void init(o2::framework::InitContext& ic) final
   {
@@ -50,22 +58,23 @@ class TPCCalibPadGainTracksDevice : public o2::framework::Task
     const auto overflowBin = ic.options().get<bool>("overflowBin");
     mPadGainTracks.init(nBins, reldEdxMin, reldEdxMax, underflowBin, overflowBin);
 
-    const auto dedxRegionType = ic.options().get<bool>("dedxRegionType");
+    const auto propagateTrack = ic.options().get<bool>("propagateTrack");
+    mPadGainTracks.setPropagateTrack(propagateTrack);
+
+    const auto dedxRegionType = ic.options().get<int>("dedxRegionType");
     mPadGainTracks.setdEdxRegion(static_cast<CalibPadGainTracks::DEdxRegion>(dedxRegionType));
 
-    const auto dedxType = ic.options().get<bool>("dedxType");
+    const auto dedxType = ic.options().get<int>("dedxType");
     mPadGainTracks.setMode(static_cast<CalibPadGainTracks::DEdxType>(dedxType));
 
-    const std::string refGainMapFile = ic.options().get<std::string>("refGainMapFile");
-    if (!refGainMapFile.empty()) {
-      LOGP(info, "Loading GainMap from file {}", refGainMapFile);
-      mPadGainTracks.setRefGainMap(refGainMapFile.data(), "GainMap");
-    }
+    const auto chargeType = ic.options().get<int>("chargeType");
+    assert(chargeType == 0 || chargeType == 1);
+    mPadGainTracks.setChargeType(static_cast<ChargeType>(chargeType));
 
-    const std::string polynomialsFile = ic.options().get<std::string>("polynomialsFile");
-    if (!polynomialsFile.empty()) {
-      LOGP(info, "Loading polynomials from file {}", polynomialsFile);
-      mPadGainTracks.loadPolTopologyCorrectionFromFile(polynomialsFile.data());
+    const std::string gainMapFile = ic.options().get<std::string>("gainMapFile");
+    if (!gainMapFile.empty()) {
+      LOGP(info, "Loading GainMap from file {}", gainMapFile);
+      mPadGainTracks.setRefGainMap(gainMapFile.data(), "GainMap");
     }
 
     float field = ic.options().get<float>("field");
@@ -73,7 +82,7 @@ class TPCCalibPadGainTracksDevice : public o2::framework::Task
       const auto inputGRP = o2::base::NameConf::getGRPFileName();
       const auto grp = o2::parameters::GRPObject::loadFrom(inputGRP);
       if (grp != nullptr) {
-        field = 5.00668f * grp->getL3Current() / 30000.;
+        field = 5.00668f * grp->getL3Current() / 30000.f;
         LOGP(info, "Using GRP file to set the magnetic field to {} kG", field);
       }
     }
@@ -93,33 +102,68 @@ class TPCCalibPadGainTracksDevice : public o2::framework::Task
     mPadGainTracks.setMomentumRange(momMin, momMax);
   }
 
+  void finaliseCCDB(ConcreteDataMatcher& matcher, void* obj) final
+  {
+    LOGP(info, "finaliseCCDB");
+    if (matcher == ConcreteDataMatcher(gDataOriginTPC, "RESIDUALGAINMAP", 0)) {
+      if (!mUsingDefaultGainMapForFirstIter) {
+        LOGP(info, "Updating reference gain map from previous iteration from CCDB");
+        const auto* gainMapResidual = static_cast<std::unordered_map<string, o2::tpc::CalDet<float>>*>(obj);
+        mPadGainTracks.setRefGainMap(gainMapResidual->at("GainMap"));
+      } else {
+        // just skip for the first time asking for an object -> not gain map will be used as reference
+        LOGP(info, "Skipping loading reference gain map for first iteration from CCDB");
+        mUsingDefaultGainMapForFirstIter = false;
+      }
+    } else if (matcher == ConcreteDataMatcher(gDataOriginTPC, "TOPOLOGYGAIN", 0)) {
+      LOGP(info, "Updating Q topology correction from CCDB");
+      const auto* topologyCorr = static_cast<o2::tpc::CalibdEdxTrackTopologyPolContainer*>(obj);
+      mPadGainTracks.setPolTopologyCorrectionFromContainer(*topologyCorr);
+    }
+  }
+
   void run(o2::framework::ProcessingContext& pc) final
   {
+    ++mProcessedTFs;
     auto tracks = pc.inputs().get<gsl::span<o2::tpc::TrackTPC>>("trackTPC");
     auto clRefs = pc.inputs().get<gsl::span<o2::tpc::TPCClRefElem>>("trackTPCClRefs");
     const auto& clusters = getWorkflowTPCInput(pc);
-    LOGP(info, "Processing TF {} with {} tracks", getCurrentTF(pc), tracks.size());
+    const auto nTracks = tracks.size();
+    if (nTracks == 0) {
+      return;
+    }
+    LOGP(info, "Processing TF {} with {} tracks", processing_helpers::getCurrentTF(pc), nTracks);
+
+    if (!mDisablePolynomialsCCDB) {
+      pc.inputs().get<o2::tpc::CalibdEdxTrackTopologyPolContainer*>("tpctopologygain");
+    }
+
+    if (mUseLastExtractedMapAsReference) {
+      LOGP(info, "fetching residual gain map");
+      pc.inputs().get<std::unordered_map<std::string, o2::tpc::CalDet<float>>*>("tpcresidualgainmap");
+    }
 
     mPadGainTracks.setMembers(&tracks, &clRefs, clusters->clusterIndex);
     mPadGainTracks.processTracks();
 
-    if ((mPublishAfter && (++mProcessedTFs % mPublishAfter) == 0)) {
+    if ((mPublishAfter && (mProcessedTFs % mPublishAfter) == 0)) {
       LOGP(info, "Publishing after {} TFs", mProcessedTFs);
       mProcessedTFs = 0;
       if (mDebug) {
-        mPadGainTracks.dumpToFile(fmt::format("calPadGain_TF{}.root", getCurrentTF(pc)).data());
+        mPadGainTracks.dumpToFile(fmt::format("calPadGain_TF{}.root", processing_helpers::getCurrentTF(pc)).data());
       }
       sendOutput(pc.outputs());
     }
   }
 
  private:
-  const uint32_t mPublishAfter{0};          ///< number of TFs after which to dump the calibration
-  const bool mDebug{false};                 ///< create debug output
-  uint32_t mProcessedTFs{0};                ///< counter to keep track of the processed TFs
-  CalibPadGainTracks mPadGainTracks{false}; ///< class for creating the pad-by-pad gain map
-
-  uint32_t getCurrentTF(o2::framework::ProcessingContext& pc) const { return o2::framework::DataRefUtils::getHeader<o2::header::DataHeader*>(pc.inputs().getFirstValid(true))->tfCounter; }
+  const uint32_t mPublishAfter{0};                   ///< number of TFs after which to dump the calibration
+  const bool mDebug{false};                          ///< create debug output
+  const bool mUseLastExtractedMapAsReference{false}; ///< using the last extracted gain map as the reference map which will be applied
+  bool mDisablePolynomialsCCDB{false};               ///< do not load the polynomials from the CCDB
+  uint32_t mProcessedTFs{0};                         ///< counter to keep track of the processed TFs
+  CalibPadGainTracks mPadGainTracks{false};          ///< class for creating the pad-by-pad gain map
+  bool mUsingDefaultGainMapForFirstIter{true};       ///< using no reference gain map for the first iteration
 
   void sendOutput(DataAllocator& output)
   {
@@ -128,36 +172,46 @@ class TPCCalibPadGainTracksDevice : public o2::framework::Task
   }
 };
 
-DataProcessorSpec getTPCCalibPadGainTracksSpec(const uint32_t publishAfterTFs, const bool debug)
+DataProcessorSpec getTPCCalibPadGainTracksSpec(const uint32_t publishAfterTFs, const bool debug, const bool useLastExtractedMapAsReference, const std::string polynomialsFile, const bool disablePolynomialsCCDB)
 {
   std::vector<InputSpec> inputs;
-  inputs.emplace_back("trackTPC", "TPC", "TRACKS", 0, Lifetime::Timeframe);
-  inputs.emplace_back("trackTPCClRefs", "TPC", "CLUSREFS", 0, Lifetime::Timeframe);
-  inputs.emplace_back("clusTPC", ConcreteDataTypeMatcher{"TPC", "CLUSTERNATIVE"}, Lifetime::Timeframe);
+  inputs.emplace_back("trackTPC", gDataOriginTPC, "TRACKS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("trackTPCClRefs", gDataOriginTPC, "CLUSREFS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("clusTPC", ConcreteDataTypeMatcher{gDataOriginTPC, "CLUSTERNATIVE"}, Lifetime::Timeframe);
+
+  if (polynomialsFile.empty() || disablePolynomialsCCDB) {
+    inputs.emplace_back("tpctopologygain", gDataOriginTPC, "TOPOLOGYGAIN", 0, Lifetime::Condition, ccdbParamSpec(CDBTypeMap.at(CDBType::CalTopologyGain)));
+  }
+
+  if (useLastExtractedMapAsReference) {
+    inputs.emplace_back("tpcresidualgainmap", gDataOriginTPC, "RESIDUALGAINMAP", 0, Lifetime::Condition, ccdbParamSpec(CDBTypeMap.at(CDBType::CalPadGainResidual)));
+  }
+
   std::vector<OutputSpec> outputs;
-  outputs.emplace_back("TPC", "TRACKGAINHISTOS", 0, o2::framework::Lifetime::Timeframe);
+  outputs.emplace_back(gDataOriginTPC, "TRACKGAINHISTOS", 0, o2::framework::Lifetime::Timeframe);
 
   return DataProcessorSpec{
     "calib-tpc-gainmap-tracks",
     inputs,
     outputs,
-    AlgorithmSpec{adaptFromTask<TPCCalibPadGainTracksDevice>(publishAfterTFs, debug)},
+    AlgorithmSpec{adaptFromTask<TPCCalibPadGainTracksDevice>(publishAfterTFs, debug, useLastExtractedMapAsReference, polynomialsFile, disablePolynomialsCCDB)},
     Options{
       {"ccdb-uri", VariantType::String, o2::base::NameConf::getCCDBServer(), {"URI for the CCDB access"}},
       {"nBins", VariantType::Int, 20, {"Number of bins per histogram"}},
       {"reldEdxMin", VariantType::Int, 0, {"Minimum x coordinate of the histogram for Q/(dE/dx)"}},
       {"reldEdxMax", VariantType::Int, 3, {"Maximum x coordinate of the histogram for Q/(dE/dx)"}},
       {"underflowBin", VariantType::Bool, false, {"Using under flow bin"}},
-      {"overflowBin", VariantType::Bool, false, {"Using under flow bin"}},
+      {"overflowBin", VariantType::Bool, true, {"Using under flow bin"}},
       {"field", VariantType::Float, -100.f, {"Magnetic field in kG, need for track propagations, this value will be overwritten if a grp file is present"}},
-      {"momMin", VariantType::Float, 0.1f, {"minimum momentum of the tracks which are used for the pad-by-pad gain map"}},
-      {"momMax", VariantType::Float, 5.f, {"maximum momentum of the tracks which are used for the pad-by-pad gain map"}},
+      {"momMin", VariantType::Float, 0.3f, {"minimum momentum of the tracks which are used for the pad-by-pad gain map"}},
+      {"momMax", VariantType::Float, 1.f, {"maximum momentum of the tracks which are used for the pad-by-pad gain map"}},
       {"etaMax", VariantType::Float, 1.f, {"maximum eta of the tracks which are used for the pad-by-pad gain map"}},
       {"minClusters", VariantType::Int, 50, {"minimum number of clusters of tracks which are used for the pad-by-pad gain map"}},
-      {"refGainMapFile", VariantType::String, "", {"file to reference gain map, which will be used for correcting the cluster charge"}},
-      {"polynomialsFile", VariantType::String, "", {"file containing the polynomials for the track topology correction"}},
-      {"dedxRegionType", VariantType::Int, 1, {"using the dE/dx per chamber (0), stack (1) or per sector (2)"}},
+      {"gainMapFile", VariantType::String, "", {"file to reference gain map, which will be used for correcting the cluster charge"}},
+      {"dedxRegionType", VariantType::Int, 2, {"using the dE/dx per chamber (0), stack (1) or per sector (2)"}},
       {"dedxType", VariantType::Int, 0, {"recalculating the dE/dx (0), using it from tracking (1)"}},
+      {"chargeType", VariantType::Int, 0, {"Using qMax (0) or qTot (1) for the dE/dx and the pad-by-pad histograms"}},
+      {"propagateTrack", VariantType::Bool, false, {"Propagating the track instead of performing a refit for obtaining track parameters."}},
     }}; // end DataProcessorSpec
 }
 

--- a/Detectors/TPC/workflow/src/tpc-calibrator-gainmap-tracks.cxx
+++ b/Detectors/TPC/workflow/src/tpc-calibrator-gainmap-tracks.cxx
@@ -16,24 +16,15 @@
 #include <string>
 #include "Framework/WorkflowSpec.h"
 #include "Framework/ConfigParamSpec.h"
-#include "Framework/CompletionPolicy.h"
-#include "Framework/CompletionPolicyHelpers.h"
 #include "CommonUtils/ConfigurableParam.h"
 #include "TPCWorkflow/CalibratorPadGainTracksSpec.h"
 
 using namespace o2::framework;
 
-// customize the completion policy
-void customize(std::vector<o2::framework::CompletionPolicy>& policies)
-{
-  using o2::framework::CompletionPolicy;
-  policies.push_back(CompletionPolicyHelpers::defineByName("tpc-calibrator-gainmap-tracks.*", CompletionPolicy::CompletionOp::Consume));
-}
-
-// we need to add workflow options before including Framework/runDataProcessing
 void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
   std::vector<ConfigParamSpec> options{
+    {"useLastExtractedMapAsReference", VariantType::Bool, false, {"enabling iterative extraction of the gain map: Multiplying the extracted gain map with the latest extracted map stored in the CCDB"}},
     {"configFile", VariantType::String, "", {"configuration file for configurable parameters"}}};
 
   std::swap(workflowOptions, options);
@@ -48,7 +39,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
   // set up configuration
   o2::conf::ConfigurableParam::updateFromFile(config.options().get<std::string>("configFile"));
   o2::conf::ConfigurableParam::writeINI("o2tpcpadgaintrackscalibrator_configuration.ini");
+  const bool useLastExtractedMapAsReference = config.options().get<bool>("useLastExtractedMapAsReference");
 
-  WorkflowSpec workflow{getTPCCalibPadGainTracksSpec()};
+  WorkflowSpec workflow{getTPCCalibPadGainTracksSpec(useLastExtractedMapAsReference)};
   return workflow;
 }


### PR DESCRIPTION
other changes:
- adding normalization of extracted gain map per stack,region or none
- adding drawing of reference gain map
- some small fixes and code documentation
- debugging: dumping extracted maps to tree, creating merged gain map
- add option to performing refit of the tracks instead of propagating the track to extract precise track parameters
- add option to set charge type used for gain map extraction
- optimising default parameters
- option to use the last extracted gain map as a reference gain map