### PR TITLE
Event Display: Add filter to only visualize tracks matching ITS readout frames & standardize workflow options

### DIFF
--- a/EventVisualisation/Workflow/README.md
+++ b/EventVisualisation/Workflow/README.md
@@ -50,13 +50,11 @@ o2-eve -j -d /home/ed/jsons -o
 |eve-hostname     |   |name of the host allowed to produce files (empty means no limit)   |
 |eve-dds-collection-index     |-1   |number of dpl collection allowed to produce files (-1 means no limit)   |  
 |number-of_files     |300   |maximum number of json files in folder (newer one will replace oldest)   |  
-|number-of_tracks     |-1   |maximum number of track stored in json file (-1 means no limit)   |  
-|enable-mc     |false   |enable visualization of MC data   |  
+|number-of_tracks     |-1   |maximum number of track stored in json file (-1 means no limit)   |
 |disable-mc     |false   |disable visualization of MC data   |  
 |display-clusters     |ITS,TPC,TRD,TOF   |comma-separated list of clusters to display   |  
 |display-tracks     |TPC,ITS,ITS-TPC,TPC-TRD,ITS-TPC-TRD,TPC-TOF,ITS-TPC-TOF   |comma-separated list of tracks to display   |  
-|read-from-files     |false   |   |  
-|disable-root-input     |false   |Disable root input overriding read-from-files   |  
+|disable-root-input     |false   | disable root-files input reader  |
 |configKeyValues     |   |Semicolon separated key=value strings ..."   | 
 
 

--- a/EventVisualisation/Workflow/include/EveWorkflow/EveWorkflowHelper.h
+++ b/EventVisualisation/Workflow/include/EveWorkflow/EveWorkflowHelper.h
@@ -27,6 +27,7 @@
 #include "TPCFastTransform.h"
 #include "TPCReconstruction/TPCFastTransformHelperO2.h"
 #include "Framework/AnalysisDataModel.h"
+#include "DetectorsVertexing/PVertexerParams.h"
 
 namespace o2::itsmft
 {
@@ -107,12 +108,21 @@ class EveWorkflowHelper
   using AODMFTTracks = aod::MFTTracks;
   using AODMFTTrack = AODMFTTracks::iterator;
 
-  EveWorkflowHelper();
+  enum Filter : uint8_t {
+    ITSROF,
+    TimeBracket,
+    TotalNTracks,
+    NFilters
+  };
+
+  using FilterSet = std::bitset<Filter::NFilters>;
+
+  EveWorkflowHelper(const FilterSet& enabledFilters = {}, std::size_t maxNTracks = -1);
   static std::vector<PNT> getTrackPoints(const o2::track::TrackPar& trc, float minR, float maxR, float maxStep, float minZ = -25000, float maxZ = 25000);
   void selectTracks(const CalibObjectsConst* calib, GID::mask_t maskCl,
                     GID::mask_t maskTrk, GID::mask_t maskMatch);
   void addTrackToEvent(const o2::track::TrackParCov& tr, GID gid, float trackTime, float dz, GID::Source source = GID::NSources);
-  void draw(int numberOfTracks);
+  void draw();
   void drawTPC(GID gid, float trackTime);
   void drawITS(GID gid, float trackTime);
   void drawMFT(GID gid, float trackTime);
@@ -150,6 +160,8 @@ class EveWorkflowHelper
             o2::header::DataHeader::RunNumberType runNumber,
             o2::framework::DataProcessingHeader::CreationTime creationTime);
 
+  FilterSet mEnabledFilters;
+  std::size_t mMaxNTracks;
   o2::globaltracking::RecoContainer mRecoCont;
   o2::globaltracking::RecoContainer& getRecoContainer() { return mRecoCont; }
   TracksSet mTrackSet;
@@ -159,6 +171,10 @@ class EveWorkflowHelper
   o2::mft::GeometryTGeo* mMFTGeom;
   o2::its::GeometryTGeo* mITSGeom;
   float mMUS2TPCTimeBins = 5.0098627;
+  float mITSROFrameLengthMUS = 0; ///< ITS RO frame in mus
+  float mMFTROFrameLengthMUS = 0; ///< MFT RO frame in mus
+  float mTPCBin2MUS = 0;
+  const o2::vertexing::PVertexerParams* mPVParams = nullptr;
 };
 } // namespace o2::event_visualisation
 

--- a/EventVisualisation/Workflow/include/EveWorkflow/O2DPLDisplay.h
+++ b/EventVisualisation/Workflow/include/EveWorkflow/O2DPLDisplay.h
@@ -50,8 +50,8 @@ class O2DPLDisplaySpec : public o2::framework::Task
   O2DPLDisplaySpec(bool useMC, o2::dataformats::GlobalTrackID::mask_t trkMask,
                    o2::dataformats::GlobalTrackID::mask_t clMask,
                    std::shared_ptr<o2::globaltracking::DataRequest> dataRequest, std::string jsonPath,
-                   std::chrono::milliseconds timeInterval, int numberOfFiles, int numberOfTracks, bool eveHostNameMatch, bool noEmptyOutput)
-    : mUseMC(useMC), mTrkMask(trkMask), mClMask(clMask), mDataRequest(dataRequest), mJsonPath(jsonPath), mTimeInteval(timeInterval), mNumberOfFiles(numberOfFiles), mNumberOfTracks(numberOfTracks), mEveHostNameMatch(eveHostNameMatch), mNoEmptyOutput(noEmptyOutput)
+                   std::chrono::milliseconds timeInterval, int numberOfFiles, int numberOfTracks, bool eveHostNameMatch, bool noEmptyOutput, bool filterITSROF)
+    : mUseMC(useMC), mTrkMask(trkMask), mClMask(clMask), mDataRequest(dataRequest), mJsonPath(jsonPath), mTimeInteval(timeInterval), mNumberOfFiles(numberOfFiles), mNumberOfTracks(numberOfTracks), mEveHostNameMatch(eveHostNameMatch), mNoEmptyOutput(noEmptyOutput), mFilterITSROF(filterITSROF)
   {
     this->mTimeStamp = std::chrono::high_resolution_clock::now() - timeInterval; // first run meets condition
   }
@@ -67,6 +67,7 @@ class O2DPLDisplaySpec : public o2::framework::Task
   bool mUseMC = false;
   bool mEveHostNameMatch;                 // empty or correct hostname
   bool mNoEmptyOutput;                    // don't create files with no tracks/clusters
+  bool mFilterITSROF;                     // don't display tracks outside ITS readout frame
   std::string mJsonPath;                  // folder where files are stored
   std::chrono::milliseconds mTimeInteval; // minimal interval between files in miliseconds
   int mNumberOfFiles;                     // maximun number of files in folder - newer replaces older

--- a/EventVisualisation/Workflow/src/EveWorkflowHelper.cxx
+++ b/EventVisualisation/Workflow/src/EveWorkflowHelper.cxx
@@ -25,33 +25,100 @@
 #include "MCHTracking/TrackParam.h"
 #include "MCHTracking/TrackExtrap.h"
 #include "DataFormatsITSMFT/TrkClusRef.h"
+#include "ITSMFTBase/DPLAlpideParam.h"
+#include "CommonDataFormat/IRFrame.h"
 
 using namespace o2::event_visualisation;
 
 void EveWorkflowHelper::selectTracks(const CalibObjectsConst* calib,
                                      GID::mask_t maskCl, GID::mask_t maskTrk, GID::mask_t maskMatch)
 {
-  auto creator = [maskTrk, this](auto& trk, GID gid, float time, float) {
+  using TBracket = o2::math_utils::Bracketf_t;
+
+  std::vector<TBracket> itsROFBrackets;
+
+  if (mEnabledFilters.test(Filter::ITSROF)) {
+    const auto irFrames = getRecoContainer().getIRFramesITS();
+
+    static int BCDiffErrCount = 0;
+    constexpr int MAXBCDiffErrCount = 5;
+
+    auto bcDiffToTFTimeMUS = [startIR = getRecoContainer().startIR](const o2::InteractionRecord& ir) {
+      auto bcd = ir.differenceInBC(startIR);
+      if (uint64_t(bcd) > o2::constants::lhc::LHCMaxBunches * 256 && BCDiffErrCount < MAXBCDiffErrCount) {
+        LOGP(alarm, "ATTENTION: wrong bunches diff. {} for current IR {} wrt 1st TF orbit {}", bcd, ir, startIR);
+        BCDiffErrCount++;
+      }
+      return bcd * o2::constants::lhc::LHCBunchSpacingNS * 1e-3;
+    };
+
+    for (const auto& irFrame : irFrames) {
+      itsROFBrackets.emplace_back(bcDiffToTFTimeMUS(irFrame.getMin()), bcDiffToTFTimeMUS(irFrame.getMax()));
+    }
+  }
+
+  auto correctTrackTime = [this](auto& _tr, float t0, float terr) {
+    if constexpr (isTPCTrack<decltype(_tr)>()) {
+      // unconstrained TPC track, with t0 = TrackTPC.getTime0+0.5*(DeltaFwd-DeltaBwd) and terr = 0.5*(DeltaFwd+DeltaBwd) in TimeBins
+      t0 *= this->mTPCBin2MUS;
+      terr *= this->mTPCBin2MUS;
+    } else if constexpr (isITSTrack<decltype(_tr)>()) {
+      t0 += 0.5f * this->mITSROFrameLengthMUS;          // ITS time is supplied in \mus as beginning of ROF
+      terr *= this->mITSROFrameLengthMUS;               // error is supplied as a half-ROF duration, convert to \mus
+    } else if constexpr (isMFTTrack<decltype(_tr)>()) { // Same for MFT
+      t0 += 0.5f * this->mMFTROFrameLengthMUS;
+      terr *= this->mMFTROFrameLengthMUS;
+    } else if constexpr (isGlobalFwdTrack<decltype(_tr)>()) {
+      t0 = _tr.getTimeMUS().getTimeStamp();
+      terr = _tr.getTimeMUS().getTimeStampError() * mPVParams->nSigmaTimeTrack; // gaussian errors must be scaled by requested n-sigma
+    } else {
+      terr *= mPVParams->nSigmaTimeTrack; // gaussian errors must be scaled by requested n-sigma
+    }
+    // for all other tracks the time is in \mus with gaussian error
+    terr += mPVParams->timeMarginTrackTime;
+
+    return TBracket{t0 - terr, t0 + terr};
+  };
+
+  auto isInsideITSROF = [&itsROFBrackets](const TBracket& br) {
+    for (const auto& ir : itsROFBrackets) {
+      const auto overlap = ir.getOverlap(br);
+
+      if (overlap.isValid()) {
+        return true;
+      }
+    }
+
+    return false;
+  };
+
+  auto creator = [maskTrk, this, &correctTrackTime, &isInsideITSROF](auto& trk, GID gid, float time, float terr) {
     if (!maskTrk[gid.getSource()]) {
       return true;
     }
-    if constexpr (isTPCTrack<decltype(trk)>()) { // unconstrained TPC track, with t0 = TrackTPC.getTime0+0.5*(DeltaFwd-DeltaBwd) and terr = 0.5*(DeltaFwd+DeltaBwd) in TimeBins
-      time = trk.getTime0();                     // for TPC we need internal time, not the center of the possible interval
+
+    if (mEnabledFilters.test(Filter::TotalNTracks) && mTrackSet.trackGID.size() >= mMaxNTracks) {
+      return true;
     }
+
+    auto bracket = correctTrackTime(trk, time, terr);
+
+    if (mEnabledFilters.test(Filter::ITSROF) && !isInsideITSROF(bracket)) {
+      return true;
+    }
+
     mTrackSet.trackGID.push_back(gid);
-    mTrackSet.trackTime.push_back(time);
+    mTrackSet.trackTime.push_back(bracket.mean());
+
     return true;
   };
+
   this->mRecoCont.createTracksVariadic(creator);
 }
 
-void EveWorkflowHelper::draw(int numberOfTracks)
+void EveWorkflowHelper::draw()
 {
-  size_t nTracks = mTrackSet.trackGID.size();
-  if (numberOfTracks != -1 && numberOfTracks < nTracks) {
-    nTracks = numberOfTracks; // less than available
-  }
-  for (size_t it = 0; it < nTracks; it++) {
+  for (size_t it = 0; it < mTrackSet.trackGID.size(); it++) {
     const auto& gid = mTrackSet.trackGID[it];
     auto tim = mTrackSet.trackTime[it];
     // LOG(info) << "EveWorkflowHelper::draw " << gid.asString();
@@ -306,7 +373,7 @@ void EveWorkflowHelper::drawAODMFT(AODMFTTrack const& track, float trackTime)
                                  .PID = o2::track::PID::Muon,
                                  .startXYZ = {(float)tr.getX(), (float)tr.getY(), (float)tr.getZ()},
                                  .phi = (float)tr.getPhi(),
-                                 .theta = (float)tr.getTanl(),
+                                 .theta = (float)tr.getTheta(),
                                  .eta = (float)tr.getEta(),
                                  .gid = GID::getSourceName(GID::MFT),
                                  .source = GID::MFT});
@@ -456,8 +523,8 @@ void EveWorkflowHelper::drawMFT(GID gid, float trackTime)
                                  .PID = o2::track::PID::Muon,
                                  .startXYZ = {(float)tr.getX(), (float)tr.getY(), (float)tr.getZ()},
                                  .phi = (float)tr.getPhi(),
-                                 .theta = (float)tr.getTanl(),
-                                 .eta = (float)0,
+                                 .theta = (float)tr.getTheta(),
+                                 .eta = (float)tr.getEta(),
                                  .gid = gid.asString(),
                                  .source = GID::MFT});
   for (auto zPos : zPositions) {
@@ -575,7 +642,7 @@ void EveWorkflowHelper::drawTRDClusters(const o2::trd::TrackTRD& tpcTrdTrack, fl
   }
 }
 
-EveWorkflowHelper::EveWorkflowHelper()
+EveWorkflowHelper::EveWorkflowHelper(const FilterSet& enabledFilters, std::size_t maxNTracks) : mEnabledFilters(enabledFilters), mMaxNTracks(maxNTracks)
 {
   o2::mch::TrackExtrap::setField();
   this->mMFTGeom = o2::mft::GeometryTGeo::Instance();
@@ -585,6 +652,17 @@ EveWorkflowHelper::EveWorkflowHelper()
   this->mTPCFastTransform = (o2::tpc::TPCFastTransformHelperO2::instance()->create(0));
   const auto& elParams = o2::tpc::ParameterElectronics::Instance();
   mMUS2TPCTimeBins = 1. / elParams.ZbinWidth;
+  mTPCBin2MUS = elParams.ZbinWidth;
+
+  std::unique_ptr<o2::parameters::GRPObject> grp{o2::parameters::GRPObject::loadFrom()};
+
+  const auto& alpParamsITS = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance();
+  mITSROFrameLengthMUS = grp->isDetContinuousReadOut(o2::detectors::DetID::ITS) ? alpParamsITS.roFrameLengthInBC * o2::constants::lhc::LHCBunchSpacingMUS : alpParamsITS.roFrameLengthTrig * 1.e-3;
+
+  const auto& alpParamsMFT = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::MFT>::Instance();
+  mMFTROFrameLengthMUS = grp->isDetContinuousReadOut(o2::detectors::DetID::MFT) ? alpParamsMFT.roFrameLengthInBC * o2::constants::lhc::LHCBunchSpacingMUS : alpParamsMFT.roFrameLengthTrig * 1.e-3;
+
+  mPVParams = &o2::vertexing::PVertexerParams::Instance();
 }
 
 GID::Source EveWorkflowHelper::detectorMapToGIDSource(uint8_t dm)

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -487,7 +487,7 @@ workflow_has_parameter CALIB && { source $MYDIR/calib-workflow.sh; [[ $? != 0 ]]
 # RS this is a temporary setting
 [[ -z "$ED_TRACKS" ]] && ED_TRACKS=$TRACK_SOURCES
 [[ -z "$ED_CLUSTERS" ]] && ED_CLUSTERS=$TRACK_SOURCES
-workflow_has_parameter EVENT_DISPLAY && [[ $NUMAID == 0 ]] && [[ ! -z "$ED_TRACKS" ]] && [[ ! -z "$ED_CLUSTERS" ]] && add_W o2-eve-display "--display-tracks $ED_TRACKS --display-clusters $ED_CLUSTERS --skipOnEmptyInput --number-of_tracks 50000 $EVE_CONFIG $DISABLE_MC" "$ITSMFT_STROBES"
+workflow_has_parameter EVENT_DISPLAY && [[ $NUMAID == 0 ]] && [[ ! -z "$ED_TRACKS" ]] && [[ ! -z "$ED_CLUSTERS" ]] && add_W o2-eve-display "--display-tracks $ED_TRACKS --display-clusters $ED_CLUSTERS --skipOnEmptyInput $DISABLE_DIGIT_ROOT_INPUT --number-of_tracks 50000 $EVE_CONFIG $DISABLE_MC" "$ITSMFT_STROBES"
 
 # ---------------------------------------------------------------------------------------------------------------------
 # AOD


### PR DESCRIPTION
Requires update of the PDP workflow script to include the `--disable-root-input` for ED.