### PR TITLE
MRRTF-154: MCH raw data decoder now catches exceptions

### DIFF
--- a/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DataDecoder.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DataDecoder.h
@@ -158,8 +158,12 @@ class DataDecoder
   /// Must be called before processing the TmeFrame buffer
   void setFirstOrbitInTF(uint32_t orbit);
 
-  /// Decode one TimeFrame buffer and fill the vector of digits
-  void decodeBuffer(gsl::span<const std::byte> buf);
+  /** Decode one TimeFrame buffer and fill the vector of digits.
+   *  @return true if decoding went ok, or false otherwise.
+   *  if false is returned, the decoding of the (rest of the) TF should be
+   *  abandonned simply.
+   */
+  bool decodeBuffer(gsl::span<const std::byte> buf);
 
   /// Functions to set and get the calibration offset for the SAMPA time computation
   void setSampaBcOffset(uint32_t offset) { mSampaTimeOffset = offset; }

--- a/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/ErrorCodes.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/ErrorCodes.h
@@ -22,20 +22,20 @@ namespace raw
 {
 
 enum ErrorCodes {
-  ErrorParity = 1,                    // 1
-  ErrorHammingCorrectable = 1 << 1,   // 2
-  ErrorHammingUncorrectable = 1 << 2, // 4
-  ErrorBadClusterSize = 1 << 3,       // 8
-  ErrorBadPacketType = 1 << 4,        // 16
-  ErrorBadHeartBeatPacket = 1 << 5,   // 32
-  ErrorBadIncompleteWord = 1 << 6,    // 64
-  ErrorTruncatedData = 1 << 7,        // 128
-  ErrorBadELinkID = 1 << 8,           // 256
-  ErrorBadLinkID = 1 << 9,            // 512
-  ErrorUnknownLinkID = 1 << 10,       // 1024
-  ErrorBadDigitTime = 1 << 11,        // 2048
-  ErrorInvalidDigitTime = 1 << 12     // 4096
-
+  ErrorParity = 1,                           // 1
+  ErrorHammingCorrectable = 1 << 1,          // 2
+  ErrorHammingUncorrectable = 1 << 2,        // 4
+  ErrorBadClusterSize = 1 << 3,              // 8
+  ErrorBadPacketType = 1 << 4,               // 16
+  ErrorBadHeartBeatPacket = 1 << 5,          // 32
+  ErrorBadIncompleteWord = 1 << 6,           // 64
+  ErrorTruncatedData = 1 << 7,               // 128
+  ErrorBadELinkID = 1 << 8,                  // 256
+  ErrorBadLinkID = 1 << 9,                   // 512
+  ErrorUnknownLinkID = 1 << 10,              // 1024
+  ErrorBadDigitTime = 1 << 11,               // 2048
+  ErrorInvalidDigitTime = 1 << 12,           // 4096
+  ErrorNonRecoverableDecodingError = 1 << 13 // 8192
 };
 
 uint32_t getErrorCodesSize();

--- a/Detectors/MUON/MCH/Raw/Decoder/src/ErrorCodes.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/ErrorCodes.cxx
@@ -20,7 +20,7 @@ namespace raw
 
 uint32_t getErrorCodesSize()
 {
-  return 13;
+  return 14;
 }
 
 void append(const char* msg, std::string& to)
@@ -75,6 +75,9 @@ std::string errorCodeAsString(uint32_t ec)
   }
   if (ec & ErrorInvalidDigitTime) {
     append("Invalid Digit Time", msg);
+  }
+  if (ec & ErrorNonRecoverableDecodingError) {
+    append("Non Recoverable", msg);
   }
   return msg;
 }


### PR DESCRIPTION
@aferrero2707 here's a proposal for the added protection to data decoder to avoid crashes. If there is an exception it is now "swallowed" and an error appended to the error vector. The error is associated to an invalid SolarId (=0) so QC could later on detect it's a global error.

For the record :  to test I've locally changed `Detectors/MUON/MCH/Raw/Common/src/SampaCluster.cxx
` assertion on clusterSize to test 9 bits instead of 10 : 
```
clusterSize(impl::assertIsInRange("clusterSize", clusterSize, 0, 0x1FF)), // FIXME: for debug, to trigger an exception
```


