### PR TITLE
Fixing compilation warnings in DataFormat/Headers

### DIFF
--- a/Algorithm/test/headerstack.cxx
+++ b/Algorithm/test/headerstack.cxx
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE(test_headerstack)
   dh.payloadSize = 0;
 
   using Name8Header = o2::header::NameHeader<8>;
-  Name8Header nh("NAMEDHDR");
+  Name8Header nh("NAMEHDR");
 
   o2::header::Stack stack(dh, nh);
 

--- a/DataFormats/Headers/include/Headers/DataHeader.h
+++ b/DataFormats/Headers/include/Headers/DataHeader.h
@@ -299,7 +299,7 @@ struct Descriptor {
       --len;
     }
     std::string ret(str, len);
-    return std::move(ret);
+    return ret;
   }
 };
 


### PR DESCRIPTION
```
DataFormats/Headers/include/Headers/DataHeader.h:302:25: warning: moving a local object in a return statement prevents copy elision [-Wpessimizing-move]
DataFormats/Headers/include/Headers/NameHeader.h:60:12: warning: 'char* strncpy(char*, const char*, size_t)' output truncated before terminating nul copying 8 bytes from a string of the same length [-Wstringop-truncation]
DataFormats/Headers/include/Headers/NameHeader.h:60:12: warning: 'char* strncpy(char*, const char*, size_t)' output truncated copying 7 bytes from a string of length 8 [-Wstringop-truncation]
```