### PR TITLE
TRD vDrift and ExB calibration updated

### DIFF
--- a/Detectors/TRD/calibration/include/TRDCalibration/CalibratorVdExB.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/CalibratorVdExB.h
@@ -20,6 +20,8 @@
 #include "DetectorsCalibration/TimeSlot.h"
 #include "DataFormatsTRD/Constants.h"
 #include "DataFormatsTRD/AngularResidHistos.h"
+#include "CCDB/CcdbObjectInfo.h"
+#include "DataFormatsTRD/CalVdriftExB.h"
 
 #include "Rtypes.h"
 #include "TProfile.h"
@@ -60,12 +62,17 @@ class CalibratorVdExB final : public o2::calibration::TimeSlotCalibration<o2::tr
   void finalizeSlot(Slot& slot) final;
   Slot& emplaceNewSlot(bool front, TFType tStart, TFType tEnd) final;
 
+  const std::vector<o2::trd::CalVdriftExB>& getCcdbObjectVector() const { return mObjectVector; }
+  std::vector<o2::ccdb::CcdbObjectInfo>& getCcdbObjectInfoVector() { return mInfoVector; }
+
   void initProcessing();
 
  private:
   bool mInitDone{false}; ///< flag to avoid creating the TProfiles multiple times
   size_t mMinEntries; ///< minimum total number of angular deviations (on average ~3 entries per bin for each TRD chamber)
   FitFunctor mFitFunctor; ///< used for minimization procedure
+  std::vector<o2::ccdb::CcdbObjectInfo> mInfoVector; ///< vector of CCDB infos; each element is filled with CCDB description of accompanying CCDB calibration object
+  std::vector<o2::trd::CalVdriftExB> mObjectVector;  ///< vector of CCDB calibration objects; the extracted vDrift and ExB per chamber for given slot
   ClassDefOverride(CalibratorVdExB, 1);
 };
 

--- a/Detectors/TRD/calibration/src/CalibratorVdExB.cxx
+++ b/Detectors/TRD/calibration/src/CalibratorVdExB.cxx
@@ -14,7 +14,6 @@
 /// \author Ole Schmidt
 
 #include "TRDCalibration/CalibratorVdExB.h"
-#include "DataFormatsTRD/CalVdriftExB.h"
 #include "Fit/Fitter.h"
 #include "TStopwatch.h"
 #include "CCDB/CcdbApi.h"
@@ -23,6 +22,7 @@
 #include <map>
 #include <memory>
 #include "CommonUtils/NameConf.h"
+#include "CommonUtils/MemFileHelper.h"
 
 using namespace o2::trd::constants;
 
@@ -89,8 +89,9 @@ using Slot = o2::calibration::TimeSlot<AngularResidHistos>;
 
 void CalibratorVdExB::initOutput()
 {
-  // prepare output objects which will go to CCDB
-  // nothing to be done
+  // reset the CCDB output vectors
+  mInfoVector.clear();
+  mObjectVector.clear();
 }
 
 void CalibratorVdExB::initProcessing()
@@ -153,11 +154,7 @@ void CalibratorVdExB::finalizeSlot(Slot& slot)
   timer.Stop();
   LOGF(info, "Done fitting angular residual histograms. CPU time: %f, real time: %f", timer.CpuTime(), timer.RealTime());
 
-  // write results to CCDB
-  o2::ccdb::CcdbApi ccdb;
-  ccdb.init(o2::base::NameConf::getCCDBServer());
-  // ccdb.init("http://localhost:8080");
-  std::map<std::string, std::string> metadata; // TODO: do we want to store any meta data?
+  // assemble CCDB object
   CalVdriftExB calObject;
   for (int iDet = 0; iDet < MAXCHAMBER; ++iDet) {
     // OS: what about chambers for which we had no data in this slot? should we use the initial parameters or something else?
@@ -165,10 +162,12 @@ void CalibratorVdExB::finalizeSlot(Slot& slot)
     calObject.setVdrift(iDet, vdFitResults[iDet]);
     calObject.setExB(iDet, laFitResults[iDet]);
   }
-  auto timeStamp = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-  auto timeStampEnd = timeStamp;
-  timeStampEnd += 1e3 * 60 * 60 * 24 * 7; // set validity of 7 days
-  ccdb.storeAsTFileAny(&calObject, "TRD/Calib/CalVdriftExB", metadata, timeStamp, timeStampEnd);
+  auto clName = o2::utils::MemFileHelper::getClassName(calObject);
+  auto flName = o2::ccdb::CcdbApi::generateFileName(clName);
+  std::map<std::string, std::string> metadata; // TODO: do we want to store any meta data?
+  long startValidity = slot.getStartTimeMS() - 10 * o2::ccdb::CcdbObjectInfo::SECOND;
+  mInfoVector.emplace_back("TRD/Calib/CalVdriftExB", clName, flName, metadata, startValidity, startValidity + o2::ccdb::CcdbObjectInfo::HOUR);
+  mObjectVector.push_back(calObject);
 }
 
 Slot& CalibratorVdExB::emplaceNewSlot(bool front, TFType tStart, TFType tEnd)

--- a/Detectors/TRD/workflow/src/trd-calib-workflow.cxx
+++ b/Detectors/TRD/workflow/src/trd-calib-workflow.cxx
@@ -20,7 +20,8 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   // option allowing to set parameters
   std::vector<o2::framework::ConfigParamSpec> options{
-    {"enable-root-input", o2::framework::VariantType::Bool, false, {"enable root-files input readers"}}};
+    {"enable-root-input", o2::framework::VariantType::Bool, false, {"enable root-files input readers"}},
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
 
   std::swap(workflowOptions, options);
 }

--- a/prodtests/full-system-test/calib-workflow.sh
+++ b/prodtests/full-system-test/calib-workflow.sh
@@ -8,6 +8,7 @@ fi
 if [[ $BEAMTYPE != "cosmic" ]]; then
   has_detector_calib TPC && has_detectors TPC ITS TRD TOF && add_W o2-tpc-scdcalib-interpolation-workflow "$DISABLE_ROOT_OUTPUT --disable-root-input --pipeline $(get_N tpc-track-interpolation TPC REST)" "$ITSMFT_FILES"
   has_detector_calib ITS && has_detectors ITS && has_detectors_reco ITS && has_detector_matching PRIMVTX && [[ ! -z "$VERTEXING_SOURCES" ]] && add_W o2-calibration-mean-vertex-calibration-workflow
+  has_detector_calib TRD && has_detector ITS TPC TRD && add_W o2-calibration-trd-vdrift-exb
 fi
 
 true # everything OK up to this point, so the script should return 0 (it is !=0 already if a has_detector check fails)

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -118,10 +118,12 @@ if [[ $SYNCMODE == 1 ]]; then
     ITS_CONFIG_KEY+="fastMultConfig.cutMultClusLow=30;fastMultConfig.cutMultClusHigh=2000;fastMultConfig.cutMultVtxHigh=500;"
     [[ -z ${ITS_CONFIG+x} ]] && ITS_CONFIG=" --tracking-mode sync"
     [[ -z ${PVERTEXING_CONFIG_KEY+x} ]] && PVERTEXING_CONFIG_KEY+="pvertexer.maxChi2TZDebris=2000;"
+    workflow_has_parameter CALIB && TRD_CONFIG+=" --enable-trackbased-calib"
   elif [[ $BEAMTYPE == "pp" ]]; then
     ITS_CONFIG_KEY+="fastMultConfig.cutMultClusLow=-1;fastMultConfig.cutMultClusHigh=-1;fastMultConfig.cutMultVtxHigh=-1;ITSVertexerParam.phiCut=0.5;ITSVertexerParam.clusterContributorsCut=3;ITSVertexerParam.tanLambdaCut=0.2"
     [[ -z ${ITS_CONFIG+x} ]] && ITS_CONFIG=" --tracking-mode sync"
     [[ -z ${PVERTEXING_CONFIG_KEY+x} ]] && PVERTEXING_CONFIG_KEY+="pvertexer.maxChi2TZDebris=10;"
+    workflow_has_parameter CALIB && TRD_CONFIG+=" --enable-trackbased-calib"
   elif [[ $BEAMTYPE == "cosmic" ]]; then
     [[ -z ${ITS_CONFIG+x} ]] && ITS_CONFIG=" --tracking-mode cosmics"
   else
@@ -134,10 +136,12 @@ else
   if [[ $BEAMTYPE == "PbPb" ]]; then
     [[ -z ${ITS_CONFIG+x} ]] && ITS_CONFIG=" --tracking-mode async"
     [[ -z ${PVERTEXING_CONFIG_KEY+x} ]] && PVERTEXING_CONFIG_KEY+="pvertexer.maxChi2TZDebris=2000;"
+    workflow_has_parameter CALIB && TRD_CONFIG+=" --enable-trackbased-calib"
   elif [[ $BEAMTYPE == "pp" ]]; then
     ITS_CONFIG_KEY+="ITSVertexerParam.phiCut=0.5;ITSVertexerParam.clusterContributorsCut=3;ITSVertexerParam.tanLambdaCut=0.2"
     [[ -z ${ITS_CONFIG+x} ]] && ITS_CONFIG=" --tracking-mode async"
     [[ -z ${PVERTEXING_CONFIG_KEY+x} ]] && PVERTEXING_CONFIG_KEY+="pvertexer.maxChi2TZDebris=10;"
+    workflow_has_parameter CALIB && TRD_CONFIG+=" --enable-trackbased-calib"
   elif [[ $BEAMTYPE == "cosmic" ]]; then
     [[ -z ${ITS_CONFIG+x} ]] && ITS_CONFIG=" --tracking-mode cosmics"
   else


### PR DESCRIPTION
To send CCDB object without relying on the CCDB manager.

Not sure if we want to merge the second commit. This would enable the calibration per default in the FST.