### PR TITLE
changes for macOS

### DIFF
--- a/prodtests/full-system-test/run-workflow-on-inputlist.sh
+++ b/prodtests/full-system-test/run-workflow-on-inputlist.sh
@@ -7,7 +7,7 @@ if [[ -z $1 || -z $2 ]]; then
   exit 1
 fi
 
-if [[ `which StfBuilder 2> /dev/null | wc -l` == "0" || -z $O2_ROOT ]]; then
+if [[ $1 == "DD" && `which StfBuilder 2> /dev/null | wc -l` -eq 0 ]] || [[ -z $O2_ROOT ]]; then
   echo "ERROR: DataDistribution or O2 environment not loaded"
   exit 1
 fi
@@ -30,7 +30,7 @@ LOG_PREFIX="log_$(date +%Y%m%d-%H%M%S)_"
 [[ -z $OVERRIDE_SESSION ]] && export OVERRIDE_SESSION=default_$$_$RANDOM
 [[ -z $INRAWCHANNAME ]] && export INRAWCHANNAME=tf-builder-$$-$RANDOM
 
-if [[ "0$IGNORE_EXISTING_SHMFILES" != "01" && `ls /dev/shm/*fmq* 2> /dev/null | wc -l` != "0" ]]; then
+if [[ "0$IGNORE_EXISTING_SHMFILES" != "01" && `ls /dev/shm/*fmq* 2> /dev/null | wc -l` -ne 0 ]]; then
   echo "ERROR: Existing SHM files (you can set IGNORE_EXISTING_SHMFILES=1 to ignore and allow multiple parallel reconstruction sessions)"
   exit 1
 fi
@@ -82,7 +82,7 @@ if [[ "0$4" != "00" ]]; then
 fi
 
 TIMEOUT_PHASE=0
-while [[ `jobs -rl | grep -v " $PID_LOG Running" | wc -l` != "0" ]]; do
+while [[ `jobs -rl | grep -v " $PID_LOG Running" | wc -l` -ne 0 ]]; do
   sleep 1
   if [[ ! -z $3 && $(date +%s) -ge $(($START_TIME + $TIMEOUT_PHASE * 20 + $3)) ]]; then
     RETVAL=1


### PR DESCRIPTION
@davidrohr I have a problem using this script on macOS because the string comparison of the `wc` command result does not work for me (probably because of the formatting of the command output). I propose these little modifications, which I suppose will work on all platforms. Do you think it's ok ?

I also conditioned the test of StfBuilder existence to the "DD" mode usage, since I suppose it is needed only in this mode.