### PR TITLE
TRD bug fix for mac m1

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawDataStats.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawDataStats.h
@@ -91,7 +91,8 @@ enum OptionBits {
   TRDEnableRootOutputBit,
   TRDFixSM1617Bit,
   TRDIgnore2StageTrigger,
-  TRDGenerateStats
+  TRDGenerateStats,
+  TRDM1Debug
 };
 
 class TRDDataCountersPerEvent

--- a/Detectors/TRD/reconstruction/CMakeLists.txt
+++ b/Detectors/TRD/reconstruction/CMakeLists.txt
@@ -9,7 +9,6 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-
 o2_add_library(TRDReconstruction
                SOURCES src/CTFCoder.cxx
                        src/CTFHelper.cxx

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
@@ -178,6 +178,7 @@ class CruRawReader
       ((TH2F*)mParsingErrors2d->At(hist))->Fill(sectorside, stack * constants::NLAYER + layer);
     }
   }
+  void dumpRDHAndNextHeader(const o2::header::RDHAny* rdh);
 
   inline void rewind()
   {
@@ -222,7 +223,7 @@ class CruRawReader
   int mMaxWarnPrinted = 20;
 
   long mDataBufferSize;
-  uint64_t mDataReadIn = 0;
+  uint32_t mDataReadIn = 0;
   const uint32_t* mDataPointer = nullptr; // pointer to the current position in the rdh
   const uint32_t* mDataPointerMax = nullptr;
   const uint32_t* mDataEndPointer = nullptr;
@@ -263,14 +264,14 @@ class CruRawReader
   uint32_t mDatareadfromhbf;
   uint32_t mTotalHBFPayLoad = 0; // total data payload of the heart beat frame in question.
   uint32_t mHBFoffset32 = 0;     // total data payload of the heart beat frame in question.
-  uint64_t mDigitWordsRead = 0;
-  uint64_t mDigitWordsRejected = 0;
-  uint64_t mTotalDigitWordsRead = 0;
-  uint64_t mTotalDigitWordsRejected = 0;
-  uint64_t mTrackletWordsRead = 0;
-  uint64_t mTrackletWordsRejected = 0;
-  uint64_t mTotalTrackletWordsRejected = 0;
-  uint64_t mTotalTrackletWordsRead = 0;
+  uint32_t mDigitWordsRead = 0;
+  uint32_t mDigitWordsRejected = 0;
+  uint32_t mTotalDigitWordsRead = 0;
+  uint32_t mTotalDigitWordsRejected = 0;
+  uint32_t mTrackletWordsRead = 0;
+  uint32_t mTrackletWordsRejected = 0;
+  uint32_t mTotalTrackletWordsRejected = 0;
+  uint32_t mTotalTrackletWordsRead = 0;
   //pointers to the data as we read them in, again no point in copying.
   HalfCRUHeader* mhalfcruheader;
 
@@ -283,8 +284,8 @@ class CruRawReader
   TrackletsParser mTrackletsParser;
   DigitsParser mDigitsParser;
   //used to surround the outgoing data with a coherent rdh coming from the incoming stream.
-  o2::header::RDHAny* mOpenRDH;
-  o2::header::RDHAny* mCloseRDH;
+  const o2::header::RDHAny* mOpenRDH;
+  const o2::header::RDHAny* mCloseRDH;
 
   uint32_t mEventCounter;
   uint32_t mFatalCounter;

--- a/Detectors/TRD/reconstruction/src/DataReader.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReader.cxx
@@ -50,6 +50,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"fixforoldtrigger", VariantType::Bool, false, {"Fix for the old data not having a 2 stage trigger stored in the cru header."}},
     {"tracklethcheader", VariantType::Int, 2, {"Status of TrackletHalfChamberHeader 0 off always, 1 iff tracklet data, 2 on always"}},
     {"histogramsfile", VariantType::String, "histos.root", {"Name of the histogram file, so one can run multiple per node"}},
+    {"trd-debugm1", VariantType::Bool, false, {"various output statements specific to debugging m1 problems."}},
     //{"generate-stats", VariantType::Bool, true, {"Generate the state message sent to qc"}},
     {"trd-datareader-enablebyteswapdata", VariantType::Bool, false, {"byteswap the incoming data, raw data needs it and simulation does not."}}};
   std::swap(workflowOptions, options);
@@ -101,7 +102,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   binaryoptions[o2::trd::TRDIgnore2StageTrigger] = cfgc.options().get<bool>("fixforoldtrigger");
   //binaryoptions[o2::trd::TRDGenerateStats] = cfgc.options().get<bool>("generate-stats");
   binaryoptions[o2::trd::TRDGenerateStats] = true; //cfgc.options().get<bool>("generate-stats");
-
+  binaryoptions[o2::trd::TRDM1Debug] = cfgc.options().get<bool>("trd-debugm1");
   AlgorithmSpec algoSpec;
   algoSpec = AlgorithmSpec{adaptFromTask<o2::trd::DataReaderTask>(tracklethcheader, halfchamberwords, halfchambermajor, cfgc.options().get<std::string>("histogramsfile"), binaryoptions)};
 

--- a/Detectors/TRD/reconstruction/src/DataReaderTask.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReaderTask.cxx
@@ -262,11 +262,11 @@ void DataReaderTask::run(ProcessingContext& pc)
 
   std::vector<InputSpec> sel{InputSpec{"filter", ConcreteDataTypeMatcher{"TRD", "RAWDATA"}}};
   uint64_t tfCount = 0;
-  for (const auto& ref : InputRecordWalker(pc.inputs(), sel)) {
+  for (auto& ref : InputRecordWalker(pc.inputs(), sel)) {
     auto inputprocessingstart = std::chrono::high_resolution_clock::now(); // measure total processing time
     const auto* dh = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
     tfCount = dh->tfCounter;
-    auto payloadIn = ref.payload;
+    const char* payloadIn = ref.payload;
     auto payloadInSize = DataRefUtils::getPayloadSize(ref);
     if (mHeaderVerbose) {
       LOGP(info, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : ",


### PR DESCRIPTION
This fixes a couple of things.
Handles the case of processHBF returning false (should never happen)
Correctly checks the bounds of the incoming rdh payload to ensure it fits in the allocated buffer for the half cru in question.

@chiarazampolli it appears to fix grid problem, I could not replicate grid problem with nightly and this executable and library running on top of the nightly last night.

@pzhristov Shout if this fixes your problems. I still running it through my series of timeframes i use for testing.