### PR TITLE
DPL DataSpecUtils: adding helper to create optional ConcreteDataMatcher

### DIFF
--- a/Framework/Core/include/Framework/DataSpecUtils.h
+++ b/Framework/Core/include/Framework/DataSpecUtils.h
@@ -205,6 +205,10 @@ struct DataSpecUtils {
   /// Build a DataDescriptMatcher which does not care about the subSpec and origin.
   static data_matcher::DataDescriptorMatcher dataDescriptorMatcherFrom(header::DataDescription const& origin);
 
+  /// return fully qualified ConcreteDataMatcher if DataMatcher is connecting unique properties
+  /// via 'and' operation
+  static std::optional<framework::ConcreteDataMatcher> optionalConcreteDataMatcherFrom(data_matcher::DataDescriptorMatcher const& matcher);
+
   /// Checks if left includes right (or is equal to)
   static bool includes(const InputSpec& left, const InputSpec& right);
 

--- a/Framework/Core/src/DataSpecUtils.cxx
+++ b/Framework/Core/src/DataSpecUtils.cxx
@@ -553,6 +553,82 @@ DataDescriptorMatcher DataSpecUtils::dataDescriptorMatcherFrom(header::DataDescr
   return std::move(matchOnlyOrigin);
 }
 
+std::optional<framework::ConcreteDataMatcher> DataSpecUtils::optionalConcreteDataMatcherFrom(data_matcher::DataDescriptorMatcher const& matcher)
+{
+  using namespace data_matcher;
+  using ops = DataDescriptorMatcher::Op;
+
+  MatcherInfo state;
+  auto nodeWalker = overloaded{
+    [&state](EdgeActions::EnterNode action) {
+      if (state.hasError) {
+        return VisitNone;
+      }
+      if (action.node->getOp() == ops::Just) {
+        return VisitLeft;
+      }
+      // a ConcreteDataMatcher requires only 'and' operations
+      // which have an OR, so we reset all the uniqueness attributes.
+      if (action.node->getOp() == ops::And) {
+        return VisitBoth;
+      }
+      // simply use the error state to indicate that the operation does not match the
+      // requirement for fully qualified ConcreteDataMatcher
+      state.hasError = true;
+      return VisitNone;
+    },
+    [](auto) { return VisitNone; }};
+
+  auto leafWalker = overloaded{
+    [&state](OriginValueMatcher const& valueMatcher) {
+      // if this is not the first OriginValueMatcher, the value can not be unique
+      if (state.hasOrigin) {
+        state.hasUniqueOrigin = false;
+        return;
+      }
+      state.hasOrigin = true;
+
+      valueMatcher.visit(overloaded{
+        [&state](std::string const& s) {
+          strncpy(state.origin.str, s.data(), 4);
+          state.hasUniqueOrigin = true;
+        },
+        [&state](auto) { state.hasUniqueOrigin = false; }});
+    },
+    [&state](DescriptionValueMatcher const& valueMatcher) {
+      if (state.hasDescription) {
+        state.hasUniqueDescription = false;
+        return;
+      }
+      state.hasDescription = true;
+      valueMatcher.visit(overloaded{
+        [&state](std::string const& s) {
+          strncpy(state.description.str, s.data(), 16);
+          state.hasUniqueDescription = true;
+        },
+        [&state](auto) { state.hasUniqueDescription = false; }});
+    },
+    [&state](SubSpecificationTypeValueMatcher const& valueMatcher) {
+      if (state.hasSubSpec) {
+        state.hasUniqueSubSpec = false;
+        return;
+      }
+      state.hasSubSpec = true;
+      valueMatcher.visit(overloaded{
+        [&state](uint32_t const& data) {
+          state.subSpec = data;
+          state.hasUniqueSubSpec = true;
+        },
+        [&state](auto) { state.hasUniqueSubSpec = false; }});
+    },
+    [](auto t) {}};
+  DataMatcherWalker::walk(matcher, nodeWalker, leafWalker);
+  if (state.hasError == false && state.hasUniqueOrigin && state.hasUniqueDescription && state.hasUniqueSubSpec) {
+    return std::make_optional(ConcreteDataMatcher{state.origin, state.description, state.subSpec});
+  }
+  return {};
+}
+
 InputSpec DataSpecUtils::matchingInput(OutputSpec const& spec)
 {
   return std::visit(overloaded{


### PR DESCRIPTION
Helper method to create optional ConcreteDataMatcher from DataDescriptorMatcher if this
describes fully qualified data spec with unique origin, description and subspec