### PR TITLE
Fetch CTF dicts from CCDB or local file + related changes

### DIFF
--- a/Common/Utils/src/FileSystemUtils.cxx
+++ b/Common/Utils/src/FileSystemUtils.cxx
@@ -57,7 +57,7 @@ std::vector<std::string> listFiles(std::string const& searchpattern)
 
 void createDirectoriesIfAbsent(std::string const& path)
 {
-  if (!std::filesystem::create_directories(path) && !std::filesystem::is_directory(path)) {
+  if (!path.empty() && !std::filesystem::create_directories(path) && !std::filesystem::is_directory(path)) {
     throw std::runtime_error(fmt::format("Failed to create {} directory", path));
   }
 }

--- a/DataFormats/Detectors/Common/src/CTFDictHeader.cxx
+++ b/DataFormats/Detectors/Common/src/CTFDictHeader.cxx
@@ -25,6 +25,6 @@ std::string CTFDictHeader::asString() const
   std::time_t temp = dictTimeStamp;
   std::tm* t = std::gmtime(&temp);
   std::stringstream ss;
-  ss << "CTF Dict for " << det.getName() << ", v" << int(majorVersion) << '.' << int(minorVersion) << " from " << std::put_time(t, "%Y-%m-%d %I:%M:%S %p");
+  ss << det.getName() << " CTF dictionary v" << int(majorVersion) << '.' << int(minorVersion) << '.' << dictTimeStamp << " (" << std::put_time(t, "%d/%m/%y %H:%M:%S") << " UTC)";
   return ss.str();
 }

--- a/Detectors/Base/include/DetectorsBase/CTFCoderBase.h
+++ b/Detectors/Base/include/DetectorsBase/CTFCoderBase.h
@@ -53,7 +53,7 @@ class CTFCoderBase
   std::vector<char> readDictionaryFromFile(const std::string& dictPath, bool mayFail = false);
 
   template <typename CTF>
-  void createCodersFromFile(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op);
+  void createCodersFromFile(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op, bool mayFail = false);
 
   template <typename S>
   void createCoder(OpType op, const o2::rans::RenormedFrequencyTable& renormedFrequencyTable, int slot)
@@ -123,9 +123,8 @@ bool CTFCoderBase::readFromTree(TTree& tree, const std::string brname, T& dest, 
 
 ///________________________________
 template <typename CTF>
-void CTFCoderBase::createCodersFromFile(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op)
+void CTFCoderBase::createCodersFromFile(const std::string& dictPath, o2::ctf::CTFCoderBase::OpType op, bool mayFail)
 {
-  bool mayFail = true;
   auto buff = readDictionaryFromFile<CTF>(dictPath, mayFail);
   if (!buff.size()) {
     if (mayFail) {

--- a/Detectors/Base/include/DetectorsBase/CTFCoderBase.h
+++ b/Detectors/Base/include/DetectorsBase/CTFCoderBase.h
@@ -25,9 +25,16 @@
 #include "DetectorsCommonDataFormats/CTFHeader.h"
 #include "rANS/rans.h"
 #include <filesystem>
+#include "Framework/InitContext.h"
+#include "Framework/ConcreteDataMatcher.h"
+#include "Framework/ConfigParamRegistry.h"
 
 namespace o2
 {
+namespace framework
+{
+class ProcessingContext;
+}
 namespace ctf
 {
 
@@ -45,6 +52,7 @@ class CTFCoderBase
 
   CTFCoderBase() = delete;
   CTFCoderBase(int n, DetID det, float memFactor = 1.f) : mCoders(n), mDet(det), mMemMarginFactor(memFactor > 1.f ? memFactor : 1.f) {}
+  CTFCoderBase(OpType op, int n, DetID det, float memFactor = 1.f) : mOpType(op), mCoders(n), mDet(det), mMemMarginFactor(memFactor > 1.f ? memFactor : 1.f) {}
   virtual ~CTFCoderBase() = default;
 
   virtual void createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op) = 0;
@@ -85,8 +93,22 @@ class CTFCoderBase
   void setVerbosity(int v) { mVerbosity = v; }
   int getVerbosity() const { return mVerbosity; }
 
+  const CTFDictHeader& getExtDictHeader() const { return mExtHeader; }
+
   template <typename T>
   static bool readFromTree(TTree& tree, const std::string brname, T& dest, int ev = 0);
+
+  // these are the helper methods for the parent encoding/decoding task
+  template <typename CTF>
+  void init(o2::framework::InitContext& ic);
+
+  template <typename CTF, typename BUF>
+  size_t finaliseCTFOutput(BUF& buffer);
+
+  template <typename CTF>
+  bool finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj);
+
+  void updateTimeDependentParams(o2::framework::ProcessingContext& pc);
 
  protected:
   std::string getPrefix() const { return o2::utils::Str::concat_string(mDet.getName(), "_CTF: "); }
@@ -103,6 +125,8 @@ class CTFCoderBase
   DetID mDet;
   CTFDictHeader mExtHeader;      // external dictionary header
   float mMemMarginFactor = 1.0f; // factor for memory allocation in EncodedBlocks
+  bool mLoadDictFromCCDB{true};
+  OpType mOpType; // Encoder or Decoder
   int mVerbosity = 0;
 };
 
@@ -170,7 +194,7 @@ std::vector<char> CTFCoderBase::readDictionaryFromFile(const std::string& dictPa
   } else if (bv) {
     bufVec.swap(*bv);
     if (bufVec.size()) {
-      auto dictHeader = static_cast<o2::ctf::CTFDictHeader&>(CTF::get(bufVec.data())->getHeader());
+      auto dictHeader = static_cast<const o2::ctf::CTFDictHeader&>(CTF::get(bufVec.data())->getHeader());
       if (dictHeader.det != mDet) {
         throw std::runtime_error(fmt::format("{} contains dictionary vector for {}, expected {}", dictPath, dictHeader.det.getName(), mDet.getName()));
       }
@@ -178,7 +202,7 @@ std::vector<char> CTFCoderBase::readDictionaryFromFile(const std::string& dictPa
   }
   if (bufVec.size()) {
     mExtHeader = static_cast<CTFDictHeader&>(CTF::get(bufVec.data())->getHeader());
-    LOGP(info, "Found {} in {}", mExtHeader.asString(), dictPath);
+    LOGP(debug, "Found {} in {}", mExtHeader.asString(), dictPath);
   } else {
     std::string errstr = fmt::format("CTF dictionary file for detector {} is empty", mDet.getName());
     if (mayFail) {
@@ -188,6 +212,57 @@ std::vector<char> CTFCoderBase::readDictionaryFromFile(const std::string& dictPa
     }
   }
   return bufVec;
+}
+
+///________________________________
+template <typename CTF>
+void CTFCoderBase::init(o2::framework::InitContext& ic)
+{
+  if (ic.options().hasOption("mem-factor")) {
+    setMemMarginFactor(ic.options().get<float>("mem-factor"));
+  }
+  auto dict = ic.options().get<std::string>("ctf-dict");
+  if (dict.empty()) { // load from CCDB
+    mLoadDictFromCCDB = true;
+  } else {
+    if (dict != "none") { // none means per-CTF dictionary will created on the fly
+      createCodersFromFile<CTF>(dict, mOpType);
+      LOGP(info, "Loaded {} from {}", mExtHeader.asString(), dict);
+    } else {
+      LOGP(info, "Internal per-TF CTF Dict will be created");
+    }
+    mLoadDictFromCCDB = false; // don't try to load from CCDB
+  }
+}
+
+///________________________________
+template <typename CTF, typename BUF>
+size_t CTFCoderBase::finaliseCTFOutput(BUF& buffer)
+{
+  auto eeb = CTF::get(buffer.data()); // cast to container pointer
+  eeb->compactify();                  // eliminate unnecessary padding
+  buffer.resize(eeb->size());         // shrink buffer to strictly necessary size
+  // eeb->print();
+  return eeb->size();
+}
+
+///________________________________
+template <typename CTF>
+bool CTFCoderBase::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+{
+  bool match = false;
+  if (mLoadDictFromCCDB && (match = (matcher == o2::framework::ConcreteDataMatcher(mDet.getDataOrigin(), "CTFDICT", 0)))) {
+    const auto* dict = (std::vector<char>*)obj;
+    if (dict->empty()) {
+      LOGP(info, "Empty dictionary object fetched from CCDB, internal per-TF CTF Dict will be created");
+    } else {
+      createCoders(*dict, mOpType);
+      mExtHeader = static_cast<const CTFDictHeader&>(CTF::get(dict->data())->getHeader());
+      LOGP(info, "Loaded {} from CCDB", mExtHeader.asString());
+    }
+    mLoadDictFromCCDB = false; // we read the dictionary at most once!
+  }
+  return match;
 }
 
 } // namespace ctf

--- a/Detectors/Base/src/CTFCoderBase.cxx
+++ b/Detectors/Base/src/CTFCoderBase.cxx
@@ -14,8 +14,12 @@
 /// \author ruben.shahoyan@cern.ch
 
 #include "DetectorsBase/CTFCoderBase.h"
+#include "Framework/ControlService.h"
+#include "Framework/ProcessingContext.h"
+#include "Framework/InputRecord.h"
 
 using namespace o2::ctf;
+using namespace o2::framework;
 
 void CTFCoderBase::checkDictVersion(const CTFDictHeader& h) const
 {
@@ -23,5 +27,12 @@ void CTFCoderBase::checkDictVersion(const CTFDictHeader& h) const
     if (h.isValidDictTimeStamp() && h != mExtHeader) {
       throw std::runtime_error(fmt::format("Mismatch in {} CTF dictionary: need {}, provided {}", mDet.getName(), h.asString(), mExtHeader.asString()));
     }
+  }
+}
+
+void CTFCoderBase::updateTimeDependentParams(ProcessingContext& pc)
+{
+  if (mLoadDictFromCCDB) {
+    pc.inputs().get<std::vector<char>*>("ctfdict"); // just to trigger the finaliseCCDB
   }
 }

--- a/Detectors/CPV/reconstruction/include/CPVReconstruction/CTFCoder.h
+++ b/Detectors/CPV/reconstruction/include/CPVReconstruction/CTFCoder.h
@@ -36,7 +36,7 @@ namespace cpv
 class CTFCoder : public o2::ctf::CTFCoderBase
 {
  public:
-  CTFCoder() : o2::ctf::CTFCoderBase(CTF::getNBlocks(), o2::detectors::DetID::CPV) {}
+  CTFCoder(o2::ctf::CTFCoderBase::OpType op) : o2::ctf::CTFCoderBase(op, CTF::getNBlocks(), o2::detectors::DetID::CPV) {}
   ~CTFCoder() final = default;
 
   /// entropy-encode data to buffer with CTF

--- a/Detectors/CPV/workflow/include/CPVWorkflow/EntropyDecoderSpec.h
+++ b/Detectors/CPV/workflow/include/CPVWorkflow/EntropyDecoderSpec.h
@@ -33,6 +33,7 @@ class EntropyDecoderSpec : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) final;
   void init(o2::framework::InitContext& ic) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
   o2::cpv::CTFCoder mCTFCoder;

--- a/Detectors/CPV/workflow/include/CPVWorkflow/EntropyEncoderSpec.h
+++ b/Detectors/CPV/workflow/include/CPVWorkflow/EntropyEncoderSpec.h
@@ -33,6 +33,7 @@ class EntropyEncoderSpec : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) final;
   void init(o2::framework::InitContext& ic) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
   o2::cpv::CTFCoder mCTFCoder;

--- a/Detectors/CPV/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/CPV/workflow/src/EntropyDecoderSpec.cxx
@@ -24,19 +24,23 @@ namespace o2
 namespace cpv
 {
 
-EntropyDecoderSpec::EntropyDecoderSpec(int verbosity)
+EntropyDecoderSpec::EntropyDecoderSpec(int verbosity) : mCTFCoder(o2::ctf::CTFCoderBase::OpType::Decoder)
 {
   mTimer.Stop();
   mTimer.Reset();
   mCTFCoder.setVerbosity(verbosity);
 }
 
+void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+{
+  if (mCTFCoder.finaliseCCDB<CTF>(matcher, obj)) {
+    return;
+  }
+}
+
 void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
 {
-  std::string dictPath = ic.options().get<std::string>("ctf-dict");
-  if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
-  }
+  mCTFCoder.init<CTF>(ic);
 }
 
 void EntropyDecoderSpec::run(ProcessingContext& pc)
@@ -44,6 +48,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
 
+  mCTFCoder.updateTimeDependentParams(pc);
   auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
 
   auto& triggers = pc.outputs().make<std::vector<TriggerRecord>>(OutputRef{"triggers"});
@@ -75,7 +80,7 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
     Inputs{InputSpec{"ctf", "CPV", "CTFDATA", sspec, Lifetime::Timeframe}},
     outputs,
     AlgorithmSpec{adaptFromTask<EntropyDecoderSpec>(verbosity)},
-    Options{{"ctf-dict", VariantType::String, o2::base::NameConf::getCTFDictFileName(), {"File of CTF decoding dictionary"}}}};
+    Options{{"ctf-dict", VariantType::String, "", {"CTF dictionary: empty=CCDB, none=no external dictionary otherwise: local filename"}}}};
 }
 
 } // namespace cpv

--- a/Detectors/CPV/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/CPV/workflow/src/EntropyEncoderSpec.cxx
@@ -15,6 +15,7 @@
 
 #include "Framework/ControlService.h"
 #include "Framework/ConfigParamRegistry.h"
+#include "Framework/CCDBParamSpec.h"
 #include "CPVWorkflow/EntropyEncoderSpec.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 
@@ -25,36 +26,37 @@ namespace o2
 namespace cpv
 {
 
-EntropyEncoderSpec::EntropyEncoderSpec()
+EntropyEncoderSpec::EntropyEncoderSpec() : mCTFCoder(o2::ctf::CTFCoderBase::OpType::Encoder)
 {
   mTimer.Stop();
   mTimer.Reset();
 }
 
+void EntropyEncoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+{
+  if (mCTFCoder.finaliseCCDB<CTF>(matcher, obj)) {
+    return;
+  }
+}
+
 void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
 {
-  std::string dictPath = ic.options().get<std::string>("ctf-dict");
-  mCTFCoder.setMemMarginFactor(ic.options().get<float>("mem-factor"));
-  if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
-  }
+  mCTFCoder.init<CTF>(ic);
 }
 
 void EntropyEncoderSpec::run(ProcessingContext& pc)
 {
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
+  mCTFCoder.updateTimeDependentParams(pc);
   auto triggers = pc.inputs().get<gsl::span<TriggerRecord>>("triggers");
   auto clusters = pc.inputs().get<gsl::span<Cluster>>("clusters");
 
   auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"CPV", "CTFDATA", 0, Lifetime::Timeframe});
   mCTFCoder.encode(buffer, triggers, clusters);
-  auto eeb = CTF::get(buffer.data()); // cast to container pointer
-  eeb->compactify();                  // eliminate unnecessary padding
-  buffer.resize(eeb->size());         // shrink buffer to strictly necessary size
-  //  eeb->print();
+  auto sz = mCTFCoder.finaliseCTFOutput<CTF>(buffer);
   mTimer.Stop();
-  LOG(info) << "Created encoded data of size " << eeb->size() << " for CPV in " << mTimer.CpuTime() - cput << " s";
+  LOG(info) << "Created encoded data of size " << sz << " for CPV in " << mTimer.CpuTime() - cput << " s";
 }
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
@@ -68,13 +70,14 @@ DataProcessorSpec getEntropyEncoderSpec()
   std::vector<InputSpec> inputs;
   inputs.emplace_back("triggers", "CPV", "CLUSTERTRIGRECS", 0, Lifetime::Timeframe);
   inputs.emplace_back("clusters", "CPV", "CLUSTERS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("ctfdict", "CPV", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("CPV/Calib/CTFDictionary"));
 
   return DataProcessorSpec{
     "cpv-entropy-encoder",
     inputs,
     Outputs{{"CPV", "CTFDATA", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<EntropyEncoderSpec>()},
-    Options{{"ctf-dict", VariantType::String, o2::base::NameConf::getCTFDictFileName(), {"File of CTF encoding dictionary"}},
+    Options{{"ctf-dict", VariantType::String, "", {"CTF dictionary: empty=CCDB, none=no external dictionary otherwise: local filename"}},
             {"mem-factor", VariantType::Float, 1.f, {"Memory allocation margin factor"}}}};
 }
 

--- a/Detectors/CTF/README.md
+++ b/Detectors/CTF/README.md
@@ -13,7 +13,7 @@ Every detector writing CTF data is expected to send an output with entropy-compr
 
 Example of usage:
 ```bash
-o2-its-reco-workflow --entropy-encoding | o2-ctf-writer-workflow --onlyDet ITS
+o2-its-reco-workflow | o2-itsmft-entropy-encoder-workflow | o2-ctf-writer-workflow --onlyDet ITS
 ```
 
 For the storage optimization reason one can request multiple CTFs stored in the same output file (as entries of the `ctf` tree):
@@ -48,6 +48,8 @@ parameters, on the same footing as tree-based dictionaries, e.g.
 ```
 o2-ctf-reader-workflow --ctf-input input.lst --onlyDet ITS,TPC,TOF --its-entropy-decoder ' --ctf-dict ctfdict_ITS_v1.0_1626472046.root' --tpc-entropy-decoder ' --ctf-dict ctfdict_TPC_v1.0_1626472048.root' --tof-entropy-decoder  ' --ctf-dict ctfdict_TOF_v1.0_1626472048.root'
 ```
+
+See below for the details of `--ctf-dict` option.
 
 ## CTF reader workflow
 
@@ -147,22 +149,27 @@ allows to alter the `subSpecification` used to send the CTFDATA from the reader 
 
 ## Support for externally provided encoding dictionaries
 
-By default encoding with generate for every TF and store in the CTF the dictionary information necessary to decode the CTF.
+In absence of the external dictionary the encoding with generate for every TF and store in the CTF the dictionary information necessary to decode the CTF.
 Since the time needed for the creation of dictionary and encoder/decoder may exceed encoding/decoding time, there is a possibility
 to create in a separate pass a dictionary stored in the CTF-like object and use it for further encoding/decoding.
 
+The option `--ctf-dict <OPT>` steers in all detectors entropy encoders the fething of the entropy dictionary. The choices for OPT are:
+1) `""`: empty string leads to using CCDB objec fetching by the DPL CCDB service (default)
+
+2) `<filename>`: use the dictionary from provided file (either tree-based format or flat one in CCDB format)
+
+3) `"none"`: do not use external dictionary, instead per-TF dictionaries will be stored in the CTF
+
+
 To create a dictionary run usual CTF creation chain but with extra option, e.g.:
 ```bash
-o2-its-reco-workflow --entropy-encoding | o2-ctf-writer-workflow --output-type dict --onlyDet ITS
+
+o2-its-reco-workflow | o2-itsmft-entropy-encoding-workflow --ctf-dict none | o2-ctf-writer-workflow --output-type dict --onlyDet ITS
 ```
-This will create a file `ctf_dictionary.root` containing dictionary data for all detectors processed by the `o2-ctf-writer-workflow`.
+This will create a file `ctf_dictionary_<date>_<NTF_used>.root` (linked to `ctf_dictionary.root`) containing dictionary data in a TTree format for all detectors processed by the `o2-ctf-writer-workflow`.
+Additionally, for every participation detector a `ctf_dictionary_<DET>_v<version>_<data>_<NTF_used>.root` file will be produced, with the dictionary in the flat format. These files can be directly uploaded to the CCDB.
 By default the dictionary file is written on the exit from the workflow, in `CTFWriterSpec::endOfStream()` which is currently not called if the workflow is stopped
 by `ctrl-C`. Periodic incremental saving of so-far accumulated dictionary data during processing can be triggered by providing an option
 ``--save-dict-after <N>``.
 
-Following encoding / decoding will use external dictionaries automatically if this file is found in the working directory (eventually it will be provided via CCDB).
-Note that if the file is found but dictionary data for some detector participating in the workflow are not found, an error will be printed and for given detector
-the workflows will use in-ctf dictionaries.
-The dictionaries must be provided for decoding of CTF data encoded using external dictionaries (otherwise an exception will be thrown).
-
-When decoding CTF containing dictionary data (i.e. encoded w/o external dictionaries), the CTF-specific dictionary will be created/used on the fly, ignoring eventually provided external dictionary data.
+When decoding CTF containing dictionary data (i.e. encoded w/o external dictionaries), externally provided dictionaries will be ignored.

--- a/Detectors/CTF/README.md
+++ b/Detectors/CTF/README.md
@@ -40,10 +40,9 @@ By default only CTFs will written. If the upstream entropy compression is perfor
 `--output-type both` (will store both dictionaries and CTF). This is the only valid mode for dictionaries creation (if one requests dictionary creation but the compression was done with external dictionaries, the newly created dictionaries will be empty).
 In the dictionaries creation mode their data are accumulated over all CTFs procssed. User may request periodic (and incremental) saving of dictionaries after every `N` TFs processed by passing `--save-dict-after <N>` option.
 
-Option `--ctf-dict-dir <dir>` can be provided to indicate the (existing) directory where the dictionary will be stored.
+Option `--ctf-dict-dir <dir>` can be provided to indicate the directory where the dictionary will be stored.
 
-The external dictionaries created by the `o2-ctf-writer-workflow` containes a TTree (one for all participating detectos or single file per detector if `--dict-per-det` was provided). Since the TTrees cannot be used with CcdbAPI, one can
-run the macro `O2/Detectors/CTF/utils/CTFdict2CCDBfiles.C` (installed to $O2_ROOT/share/macro/CTFdict2CCDBfiles.C) which extracts the dictionary for every detector into separate file containing plain `vector<char>`. These files can be directly
+The external dictionaries created by the `o2-ctf-writer-workflow` containes a TTree (one for all participating detectos) and separate dictionaries per detector which can be uploaded to the CCDB. The per-detector dictionaries compatible with CCDB can be also extracted from the common TTree-based dictionary file using the macro `O2/Detectors/CTF/utils/CTFdict2CCDBfiles.C` (installed to $O2_ROOT/share/macro/CTFdict2CCDBfiles.C) which extracts the dictionary for every detector into separate file containing plain `vector<char>`. These per-detector files can be directly
 uploaded to CCDB and accessed via `CcdbAPI` (the reference of the vector should be provided to corresponding detector CTFCoder::createCoders method to build the run-time dictionary). These files can be also used as per-detector command-line
 parameters, on the same footing as tree-based dictionaries, e.g.
 ```

--- a/Detectors/CTF/test/test_ctf_io_cpv.cxx
+++ b/Detectors/CTF/test/test_ctf_io_cpv.cxx
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(CTFTest)
   sw.Start();
   std::vector<o2::ctf::BufferType> vec;
   {
-    CTFCoder coder;
+    CTFCoder coder(o2::ctf::CTFCoderBase::OpType::Encoder);
     coder.encode(vec, triggers, clusters); // compress
   }
   sw.Stop();
@@ -92,7 +92,7 @@ BOOST_AUTO_TEST_CASE(CTFTest)
   sw.Start();
   const auto ctfImage = o2::cpv::CTF::getImage(vec.data());
   {
-    CTFCoder coder;
+    CTFCoder coder(o2::ctf::CTFCoderBase::OpType::Decoder);
     coder.decode(ctfImage, triggersD, clustersD); // decompress
   }
   sw.Stop();

--- a/Detectors/CTF/test/test_ctf_io_ctp.cxx
+++ b/Detectors/CTF/test/test_ctf_io_ctp.cxx
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_CASE(CTFTest, *boost::unit_test::enabled())
   sw.Start();
   std::vector<o2::ctf::BufferType> vec;
   {
-    CTFCoder coder;
+    CTFCoder coder(o2::ctf::CTFCoderBase::OpType::Encoder);
     coder.encode(vec, digits); // compress
   }
   sw.Stop();
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(CTFTest, *boost::unit_test::enabled())
   sw.Start();
   const auto ctfImage = o2::ctp::CTF::getImage(vec.data());
   {
-    CTFCoder coder;
+    CTFCoder coder(o2::ctf::CTFCoderBase::OpType::Decoder);
     coder.decode(ctfImage, digitsD); // decompress
   }
   sw.Stop();

--- a/Detectors/CTF/test/test_ctf_io_emcal.cxx
+++ b/Detectors/CTF/test/test_ctf_io_emcal.cxx
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(CTFTest)
   sw.Start();
   std::vector<o2::ctf::BufferType> vec;
   {
-    CTFCoder coder;
+    CTFCoder coder(o2::ctf::CTFCoderBase::OpType::Encoder);
     coder.encode(vec, triggers, cells); // compress
   }
   sw.Stop();
@@ -89,7 +89,7 @@ BOOST_AUTO_TEST_CASE(CTFTest)
   sw.Start();
   const auto ctfImage = o2::emcal::CTF::getImage(vec.data());
   {
-    CTFCoder coder;
+    CTFCoder coder(o2::ctf::CTFCoderBase::OpType::Decoder);
     coder.decode(ctfImage, triggersD, cellsD); // decompress
   }
   sw.Stop();

--- a/Detectors/CTF/test/test_ctf_io_fdd.cxx
+++ b/Detectors/CTF/test/test_ctf_io_fdd.cxx
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE(CTFTest)
   sw.Start();
   std::vector<o2::ctf::BufferType> vec;
   {
-    CTFCoder coder;
+    CTFCoder coder(o2::ctf::CTFCoderBase::OpType::Encoder);
     coder.encode(vec, digits, channels); // compress
   }
   sw.Stop();
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(CTFTest)
   sw.Start();
   const auto ctfImage = o2::fdd::CTF::getImage(vec.data());
   {
-    CTFCoder coder;
+    CTFCoder coder(o2::ctf::CTFCoderBase::OpType::Decoder);
     coder.decode(ctfImage, digitsD, channelsD); // decompress
   }
   sw.Stop();

--- a/Detectors/CTF/test/test_ctf_io_ft0.cxx
+++ b/Detectors/CTF/test/test_ctf_io_ft0.cxx
@@ -86,7 +86,7 @@ BOOST_AUTO_TEST_CASE(CTFTest)
   sw.Start();
   std::vector<o2::ctf::BufferType> vec;
   {
-    CTFCoder coder;
+    CTFCoder coder(o2::ctf::CTFCoderBase::OpType::Encoder);
     coder.encode(vec, digits, channels); // compress
   }
   sw.Stop();
@@ -123,7 +123,7 @@ BOOST_AUTO_TEST_CASE(CTFTest)
   sw.Start();
   const auto ctfImage = o2::ft0::CTF::getImage(vec.data());
   {
-    CTFCoder coder;
+    CTFCoder coder(o2::ctf::CTFCoderBase::OpType::Decoder);
     coder.decode(ctfImage, digitsD, channelsD); // decompress
   }
   sw.Stop();

--- a/Detectors/CTF/test/test_ctf_io_fv0.cxx
+++ b/Detectors/CTF/test/test_ctf_io_fv0.cxx
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(CTFTest)
   sw.Start();
   std::vector<o2::ctf::BufferType> vec;
   {
-    CTFCoder coder;
+    CTFCoder coder(o2::ctf::CTFCoderBase::OpType::Encoder);
     coder.encode(vec, digits, channels); // compress
   }
   sw.Stop();
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE(CTFTest)
   sw.Start();
   const auto ctfImage = o2::fv0::CTF::getImage(vec.data());
   {
-    CTFCoder coder;
+    CTFCoder coder(o2::ctf::CTFCoderBase::OpType::Decoder);
     coder.decode(ctfImage, digitsD, channelsD); // decompress
   }
   sw.Stop();

--- a/Detectors/CTF/test/test_ctf_io_hmpid.cxx
+++ b/Detectors/CTF/test/test_ctf_io_hmpid.cxx
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(CTFTest)
   sw.Start();
   std::vector<o2::ctf::BufferType> vec;
   {
-    CTFCoder coder;
+    CTFCoder coder(o2::ctf::CTFCoderBase::OpType::Encoder);
     coder.encode(vec, triggers, digits); // compress
   }
   sw.Stop();
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(CTFTest)
   sw.Start();
   const auto ctfImage = o2::hmpid::CTF::getImage(vec.data());
   {
-    CTFCoder coder;
+    CTFCoder coder(o2::ctf::CTFCoderBase::OpType::Decoder);
     coder.decode(ctfImage, triggersD, digitsD); // decompress
   }
   sw.Stop();

--- a/Detectors/CTF/test/test_ctf_io_itsmft.cxx
+++ b/Detectors/CTF/test/test_ctf_io_itsmft.cxx
@@ -71,7 +71,7 @@ BOOST_AUTO_TEST_CASE(CompressedClustersTest)
   sw.Start();
   std::vector<o2::ctf::BufferType> vec;
   {
-    CTFCoder coder(o2::detectors::DetID::ITS);
+    CTFCoder coder(o2::ctf::CTFCoderBase::OpType::Encoder, o2::detectors::DetID::ITS);
     coder.encode(vec, rofRecVec, cclusVec, pattVec); // compress
   }
   sw.Stop();
@@ -109,7 +109,7 @@ BOOST_AUTO_TEST_CASE(CompressedClustersTest)
   sw.Start();
   const auto ctfImage = o2::itsmft::CTF::getImage(vec.data());
   {
-    CTFCoder coder(o2::detectors::DetID::ITS);
+    CTFCoder coder(o2::ctf::CTFCoderBase::OpType::Decoder, o2::detectors::DetID::ITS);
     coder.decode(ctfImage, rofRecVecD, cclusVecD, pattVecD, nullptr, clPattLookup); // decompress
   }
   sw.Stop();

--- a/Detectors/CTF/test/test_ctf_io_mch.cxx
+++ b/Detectors/CTF/test/test_ctf_io_mch.cxx
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(CTFTest, *boost::unit_test::enabled())
   sw.Start();
   std::vector<o2::ctf::BufferType> vec;
   {
-    CTFCoder coder;
+    CTFCoder coder(o2::ctf::CTFCoderBase::OpType::Encoder);
     coder.encode(vec, rofs, digs); // compress
   }
   sw.Stop();
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE(CTFTest, *boost::unit_test::enabled())
   sw.Start();
   const auto ctfImage = o2::mch::CTF::getImage(vec.data());
   {
-    CTFCoder coder;
+    CTFCoder coder(o2::ctf::CTFCoderBase::OpType::Decoder);
     coder.decode(ctfImage, rofsD, digsD); // decompress
   }
   sw.Stop();

--- a/Detectors/CTF/test/test_ctf_io_mid.cxx
+++ b/Detectors/CTF/test/test_ctf_io_mid.cxx
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(CTFTest)
   sw.Start();
   std::vector<o2::ctf::BufferType> vec;
   {
-    CTFCoder coder;
+    CTFCoder coder(o2::ctf::CTFCoderBase::OpType::Encoder);
     coder.encode(vec, tfData); // compress
   }
   sw.Stop();
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE(CTFTest)
   sw.Start();
   const auto ctfImage = o2::mid::CTF::getImage(vec.data());
   {
-    CTFCoder coder;
+    CTFCoder coder(o2::ctf::CTFCoderBase::OpType::Decoder);
     coder.decode(ctfImage, rofDataD, colDataD); // decompress
   }
   sw.Stop();

--- a/Detectors/CTF/test/test_ctf_io_phos.cxx
+++ b/Detectors/CTF/test/test_ctf_io_phos.cxx
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(CTFTest)
   sw.Start();
   std::vector<o2::ctf::BufferType> vec;
   {
-    CTFCoder coder;
+    CTFCoder coder(o2::ctf::CTFCoderBase::OpType::Encoder);
     coder.encode(vec, triggers, cells); // compress
   }
   sw.Stop();
@@ -87,7 +87,7 @@ BOOST_AUTO_TEST_CASE(CTFTest)
   sw.Start();
   const auto ctfImage = o2::phos::CTF::getImage(vec.data());
   {
-    CTFCoder coder;
+    CTFCoder coder(o2::ctf::CTFCoderBase::OpType::Decoder);
     coder.decode(ctfImage, triggersD, cellsD); // decompress
   }
   sw.Stop();

--- a/Detectors/CTF/test/test_ctf_io_tof.cxx
+++ b/Detectors/CTF/test/test_ctf_io_tof.cxx
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(CompressedClustersTest)
   sw.Start();
   std::vector<o2::ctf::BufferType> vec;
   {
-    CTFCoder coder;
+    CTFCoder coder(o2::ctf::CTFCoderBase::OpType::Encoder);
     coder.encode(vec, rows, digits, pattVec); // compress
   }
   sw.Stop();
@@ -122,7 +122,7 @@ BOOST_AUTO_TEST_CASE(CompressedClustersTest)
   sw.Start();
   const auto ctfImage = CTF::getImage(vec.data());
   {
-    CTFCoder coder;
+    CTFCoder coder(o2::ctf::CTFCoderBase::OpType::Decoder);
     coder.decode(ctfImage, rowsD, digitsD, pattVecD); // decompress
   }
   sw.Stop();

--- a/Detectors/CTF/test/test_ctf_io_tpc.cxx
+++ b/Detectors/CTF/test/test_ctf_io_tpc.cxx
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE(CTFTest)
   ccFlat = reinterpret_cast<CompressedClustersFlat*>(bVec.data());
   auto buff = reinterpret_cast<void*>(reinterpret_cast<char*>(bVec.data()) + sizeCFlatBody);
   {
-    CTFCoder coder;
+    CTFCoder coder(o2::ctf::CTFCoderBase::OpType::Encoder);
     coder.setCompClusAddresses(c, buff);
     coder.setCombineColumns(true);
   }
@@ -86,7 +86,7 @@ BOOST_AUTO_TEST_CASE(CTFTest)
   sw.Start();
   std::vector<o2::ctf::BufferType> vecIO;
   {
-    CTFCoder coder;
+    CTFCoder coder(o2::ctf::CTFCoderBase::OpType::Decoder);
     coder.setCombineColumns(true);
     coder.encode(vecIO, c); // compress
   }
@@ -122,7 +122,7 @@ BOOST_AUTO_TEST_CASE(CTFTest)
   sw.Start();
   const auto ctfImage = o2::tpc::CTF::getImage(vecIO.data());
   {
-    CTFCoder coder;
+    CTFCoder coder(o2::ctf::CTFCoderBase::OpType::Decoder);
     coder.setCombineColumns(true);
     coder.decode(ctfImage, vecIn); // decompress
   }

--- a/Detectors/CTF/test/test_ctf_io_trd.cxx
+++ b/Detectors/CTF/test/test_ctf_io_trd.cxx
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(CTFTest)
   sw.Start();
   std::vector<o2::ctf::BufferType> vec;
   {
-    CTFCoder coder;
+    CTFCoder coder(o2::ctf::CTFCoderBase::OpType::Encoder);
     coder.encode(vec, triggers, tracklets, digits); // compress
   }
   sw.Stop();
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE(CTFTest)
   sw.Start();
   const auto ctfImage = o2::trd::CTF::getImage(vec.data());
   {
-    CTFCoder coder;
+    CTFCoder coder(o2::ctf::CTFCoderBase::OpType::Decoder);
     coder.decode(ctfImage, triggersD, trackletsD, digitsD); // decompress
   }
   sw.Stop();

--- a/Detectors/CTF/test/test_ctf_io_zdc.cxx
+++ b/Detectors/CTF/test/test_ctf_io_zdc.cxx
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE(CTFTest)
   sw.Start();
   std::vector<o2::ctf::BufferType> vec;
   {
-    CTFCoder coder;
+    CTFCoder coder(o2::ctf::CTFCoderBase::OpType::Encoder);
     coder.encode(vec, bcdata, chandata, pedsdata); // compress
   }
   sw.Stop();
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE(CTFTest)
   sw.Start();
   const auto ctfImage = o2::zdc::CTF::getImage(vec.data());
   {
-    CTFCoder coder;
+    CTFCoder coder(o2::ctf::CTFCoderBase::OpType::Decoder);
     coder.decode(ctfImage, bcdataD, chandataD, pedsdataD); // decompress
   }
   sw.Stop();

--- a/Detectors/CTF/utils/CTFdict2CCDBfiles.C
+++ b/Detectors/CTF/utils/CTFdict2CCDBfiles.C
@@ -55,6 +55,7 @@ void extractDictionary(TTree& tree, o2::detectors::DetID det, DetID::mask_t detM
   std::string outName = fmt::format("ctfdict_{}_v{}.{}_{}.root", det.getName(), int(dictHeader.majorVersion), int(dictHeader.minorVersion), dictHeader.dictTimeStamp);
   TFile flout(outName.c_str(), "recreate");
   flout.WriteObject(&bufVec, o2::base::NameConf::CCDBOBJECT.data());
+  flout.WriteObject(&dictHeader, fmt::format("ctf_dict_header_{}", det.getName()).c_str());
   flout.Close();
   LOG(info) << "Wrote " << dictHeader.asString() << " to " << outName;
 }

--- a/Detectors/CTF/workflow/src/CTFWriterSpec.cxx
+++ b/Detectors/CTF/workflow/src/CTFWriterSpec.cxx
@@ -103,9 +103,6 @@ class CTFWriterSpec : public o2::framework::Task
   template <typename C>
   void storeDictionary(DetID det, CTFHeader& header);
   void storeDictionaries();
-  void prepareDictionaryTreeAndFile(DetID det);
-  void closeDictionaryTreeAndFile(CTFHeader& header);
-  std::string dictionaryFileName(const std::string& detName = "");
   void closeTFTreeAndFile();
   void prepareTFTreeAndFile(const o2::header::DataHeader* dh);
   size_t estimateCTFSize(ProcessingContext& pc);
@@ -118,12 +115,13 @@ class CTFWriterSpec : public o2::framework::Task
   bool mFinalized = false;
   bool mWriteCTF = true;
   bool mCreateDict = false;
-  bool mDictPerDetector = false;
   bool mCreateRunEnvDir = true;
   bool mStoreMetaFile = false;
   int mVerbosity = 0;
   int mSaveDictAfter = 0; // if positive and mWriteCTF==true, save dictionary after each mSaveDictAfter TFs processed
   int mFlagMinDet = 1;    // append list of detectors to LHC period if their number is <= mFlagMinDet
+  uint32_t mPrevDictTimeStamp = 0; // timestamp of the previously stored dictionary
+  uint32_t mDictTimeStamp = 0;     // timestamp of the currently stored dictionary
   uint64_t mRun = 0;
   size_t mMinSize = 0;               // if > 0, accumulate CTFs in the same tree until the total size exceeds this minimum
   size_t mMaxSize = 0;               // if > MinSize, and accumulated size will exceed this value, stop accumulation (even if mMinSize is not reached)
@@ -131,6 +129,7 @@ class CTFWriterSpec : public o2::framework::Task
   size_t mAccCTFSize = 0;            // so far accumulated size (if any)
   size_t mCurrCTFSize = 0;           // size of currently processed CTF
   size_t mNCTF = 0;                  // total number of CTFs written
+  size_t mNCTFPrevDict = 0;          // total number of CTFs used for previous dictionary version
   size_t mNAccCTF = 0;               // total number of CTFs accumulated in the current file
   size_t mCTFAutoSave = 0;           // if > 0, autosave after so many TFs
   size_t mNCTFFiles = 0;             // total number of CTF files written
@@ -151,7 +150,6 @@ class CTFWriterSpec : public o2::framework::Task
   int mLockFD = -1;
   std::unique_ptr<TFile> mCTFFileOut;
   std::unique_ptr<TTree> mCTFTreeOut;
-  std::unique_ptr<o2::dataformats::FileMetaData> mCTFFileMetaData;
 
   std::unique_ptr<TFile> mDictFileOut; // file to store dictionary
   std::unique_ptr<TTree> mDictTreeOut; // tree to store dictionary
@@ -181,7 +179,6 @@ CTFWriterSpec::CTFWriterSpec(DetID::mask_t dm, uint64_t r, const std::string& ou
 //___________________________________________________________________
 void CTFWriterSpec::init(InitContext& ic)
 {
-  mDictPerDetector = ic.options().get<bool>("dict-per-det");
   // auto outmode = ic.options().get<std::string>("output-type"); // RS FIXME once global/local options clash is solved, --output-type will become device option
   auto outmode = mOutputType;
   if (outmode == "ctf") {
@@ -230,18 +227,11 @@ void CTFWriterSpec::init(InitContext& ic)
   o2::utils::createDirectoriesIfAbsent(LOCKFileDir);
 
   if (mCreateDict) { // make sure that there is no local dictonary
-    for (int id = 0; id < DetID::nDetectors; id++) {
-      DetID det(id);
-      if (isPresent(det)) {
-        auto dictName = dictionaryFileName(det.getName());
-        if (std::filesystem::exists(dictName)) {
-          throw std::runtime_error(o2::utils::Str::concat_string("CTF dictionary creation is requested but ", dictName, " already exists, remove it!"));
-        }
-        if (!mDictPerDetector) {
-          break; // no point in checking further
-        }
-      }
+    std::string dictFileName = fmt::format("{}{}.root", mDictDir, o2::base::NameConf::CTFDICT);
+    if (std::filesystem::exists(dictFileName)) {
+      throw std::runtime_error(o2::utils::Str::concat_string("CTF dictionary creation is requested but ", dictFileName, " already exists, remove it!"));
     }
+    o2::utils::createDirectoriesIfAbsent(mDictDir);
   }
 }
 
@@ -269,7 +259,6 @@ size_t CTFWriterSpec::processDet(o2::framework::ProcessingContext& pc, DetID det
     if (!mHeaders[det]) { // store 1st header
       mHeaders[det] = ctfImage.cloneHeader();
       auto& hb = *static_cast<o2::ctf::CTFDictHeader*>(mHeaders[det].get());
-      hb.dictTimeStamp = uint32_t(std::time(nullptr));
       hb.det = det;
     }
     for (int ib = 0; ib < C::getNBlocks(); ib++) {
@@ -291,28 +280,38 @@ size_t CTFWriterSpec::processDet(o2::framework::ProcessingContext& pc, DetID det
 template <typename C>
 void CTFWriterSpec::storeDictionary(DetID det, CTFHeader& header)
 {
+  // create vector whose data contains dictionary in CTF format (EncodedBlock)
   if (!isPresent(det) || !mFreqsAccumulation[det].size()) {
     return;
   }
-  prepareDictionaryTreeAndFile(det);
-  // create vector whose data contains dictionary in CTF format (EncodedBlock)
   auto dictBlocks = C::createDictionaryBlocks(mFreqsAccumulation[det], mFreqsMetaData[det]);
   auto& h = C::get(dictBlocks.data())->getHeader();
   h = *reinterpret_cast<typename std::remove_reference<decltype(h)>::type*>(mHeaders[det].get());
   auto& hb = static_cast<o2::ctf::CTFDictHeader&>(h);
   hb = *static_cast<const o2::ctf::CTFDictHeader*>(mHeaders[det].get());
+  hb.dictTimeStamp = mDictTimeStamp;
+
+  auto getFileName = [this, det, &hb](bool curr) {
+    return fmt::format("{}{}_{}_v{}.{}_{}_{}.root", this->mDictDir, o2::base::NameConf::CTFDICT, det.getName(), int(hb.majorVersion), int(hb.minorVersion),
+                       curr ? this->mDictTimeStamp : this->mPrevDictTimeStamp, curr ? this->mNCTF : this->mNCTFPrevDict);
+  };
 
   C::get(dictBlocks.data())->print(o2::utils::Str::concat_string("Storing dictionary for ", det.getName(), ": "));
-  C::get(dictBlocks.data())->appendToTree(*mDictTreeOut.get(), det.getName()); // cast to EncodedBlock
-  //  mFreqsAccumulation[det].clear();
-  //  mFreqsMetaData[det].clear();
-  if (mDictPerDetector) {
-    header.detectors.reset();
+  auto outName = getFileName(true);
+  TFile flout(outName.c_str(), "recreate");
+  flout.WriteObject(&dictBlocks, o2::base::NameConf::CCDBOBJECT.data());
+  flout.WriteObject(&hb, fmt::format("ctf_dict_header_{}", det.getName()).c_str());
+  flout.Close();
+  LOGP(info, "Saved {} with {} TFs to {}", hb.asString(), mNCTF, outName);
+  if (mPrevDictTimeStamp) {
+    auto outNamePrev = getFileName(false);
+    if (std::filesystem::exists(outNamePrev)) {
+      std::filesystem::remove(outNamePrev);
+      LOGP(info, "Removed previous dictionary version {}", outNamePrev);
+    }
   }
+  C::get(dictBlocks.data())->appendToTree(*mDictTreeOut.get(), det.getName()); // cast to EncodedBlock and attach to dictionaries tree
   header.detectors.set(det);
-  if (mDictPerDetector) {
-    closeDictionaryTreeAndFile(header);
-  }
 }
 
 //___________________________________________________________________
@@ -495,16 +494,15 @@ void CTFWriterSpec::prepareTFTreeAndFile(const o2::header::DataHeader* dh)
     }
     if (mCreateRunEnvDir && !mEnvironmentID.empty()) {
       ctfDir += fmt::format("{}_{}/", mEnvironmentID, mRun);
-      o2::utils::createDirectoriesIfAbsent(ctfDir);
-      LOG(info) << "Created {} directory for CTFs output" << ctfDir;
+      if (!ctfDir.empty()) {
+        o2::utils::createDirectoriesIfAbsent(ctfDir);
+        LOGP(info, "Created {} directory for CTFs output", ctfDir);
+      }
     }
     mCurrentCTFFileName = o2::base::NameConf::getCTFFileName(mRun, dh->firstTForbit, dh->tfCounter);
     mCurrentCTFFileNameFull = fmt::format("{}{}", ctfDir, mCurrentCTFFileName);
     mCTFFileOut.reset(TFile::Open(fmt::format("{}{}", mCurrentCTFFileNameFull, TMPFileEnding).c_str(), "recreate")); // to prevent premature external usage, use temporary name
     mCTFTreeOut = std::make_unique<TTree>(std::string(o2::base::NameConf::CTFTREENAME).c_str(), "O2 CTF tree");
-    if (mStoreMetaFile) {
-      mCTFFileMetaData = std::make_unique<o2::dataformats::FileMetaData>();
-    }
 
     mNCTFFiles++;
   }
@@ -525,16 +523,17 @@ void CTFWriterSpec::closeTFTreeAndFile()
       }
       // write CTF file metaFile data
       if (mStoreMetaFile) {
-        mCTFFileMetaData->fillFileData(mCurrentCTFFileNameFull);
-        mCTFFileMetaData->run = mRun;
-        mCTFFileMetaData->LHCPeriod = mLHCPeriod;
-        mCTFFileMetaData->type = "raw";
-        mCTFFileMetaData->priority = "high";
+        o2::dataformats::FileMetaData ctfMetaData;
+        ctfMetaData.fillFileData(mCurrentCTFFileNameFull);
+        ctfMetaData.run = mRun;
+        ctfMetaData.LHCPeriod = mLHCPeriod;
+        ctfMetaData.type = "raw";
+        ctfMetaData.priority = "high";
         auto metaFileNameTmp = fmt::format("{}{}.tmp", mCTFMetaFileDir, mCurrentCTFFileName);
         auto metaFileName = fmt::format("{}{}.done", mCTFMetaFileDir, mCurrentCTFFileName);
         try {
           std::ofstream metaFileOut(metaFileNameTmp);
-          metaFileOut << *mCTFFileMetaData.get();
+          metaFileOut << ctfMetaData;
           metaFileOut << "TFOrbits: ";
           for (size_t i = 0; i < mTFOrbits.size(); i++) {
             metaFileOut << fmt::format("{}{}", i ? ", " : "", mTFOrbits[i]);
@@ -545,7 +544,6 @@ void CTFWriterSpec::closeTFTreeAndFile()
         } catch (std::exception const& e) {
           LOG(error) << "Failed to store CTF meta data file " << metaFileName << ", reason: " << e.what();
         }
-        mCTFFileMetaData.reset();
       }
     } catch (std::exception const& e) {
       LOG(error) << "Failed to finalize CTF file " << mCurrentCTFFileNameFull << ", reason: " << e.what();
@@ -558,38 +556,17 @@ void CTFWriterSpec::closeTFTreeAndFile()
 }
 
 //___________________________________________________________________
-void CTFWriterSpec::prepareDictionaryTreeAndFile(DetID det)
-{
-  if (mDictPerDetector) {
-    if (mDictTreeOut) {
-      mDictTreeOut->SetEntries(1);
-      mDictTreeOut->Write();
-      mDictTreeOut.reset();
-      mDictFileOut.reset();
-    }
-  }
-  if (!mDictTreeOut) {
-    mDictFileOut.reset(TFile::Open(dictionaryFileName(det.getName()).c_str(), "recreate"));
-    mDictTreeOut = std::make_unique<TTree>(std::string(o2::base::NameConf::CTFDICT).c_str(), "O2 CTF dictionary");
-  }
-}
-
-//___________________________________________________________________
-std::string CTFWriterSpec::dictionaryFileName(const std::string& detName)
-{
-  if (mDictPerDetector) {
-    if (detName.empty()) {
-      throw std::runtime_error("Per-detector dictionary files are requested but detector name is not provided");
-    }
-    return o2::utils::Str::concat_string(mDictDir, detName, '_', o2::base::NameConf::CTFDICT, ".root");
-  } else {
-    return o2::utils::Str::concat_string(mDictDir, o2::base::NameConf::CTFDICT, ".root");
-  }
-}
-
-//___________________________________________________________________
 void CTFWriterSpec::storeDictionaries()
 {
+  // monolitic dictionary in tree format
+  mDictTimeStamp = uint32_t(std::time(nullptr));
+  auto getFileName = [this](bool curr) {
+    return fmt::format("{}{}_{}_{}.root", this->mDictDir, o2::base::NameConf::CTFDICT, curr ? this->mDictTimeStamp : this->mPrevDictTimeStamp, curr ? this->mNCTF : this->mNCTFPrevDict);
+  };
+  auto dictFileName = getFileName(true);
+  mDictFileOut.reset(TFile::Open(dictFileName.c_str(), "recreate"));
+  mDictTreeOut = std::make_unique<TTree>(std::string(o2::base::NameConf::CTFDICT).c_str(), "O2 CTF dictionary");
+
   CTFHeader header{mRun, uint32_t(mNCTF)};
   storeDictionary<o2::itsmft::CTF>(DetID::ITS, header);
   storeDictionary<o2::itsmft::CTF>(DetID::MFT, header);
@@ -607,25 +584,27 @@ void CTFWriterSpec::storeDictionaries()
   storeDictionary<o2::zdc::CTF>(DetID::ZDC, header);
   storeDictionary<o2::hmpid::CTF>(DetID::HMP, header);
   storeDictionary<o2::ctp::CTF>(DetID::CTP, header);
-
-  // close remnants
-  if (mDictTreeOut) {
-    closeDictionaryTreeAndFile(header);
+  mDictFileOut->cd();
+  appendToTree(*mDictTreeOut.get(), "CTFHeader", header);
+  mDictTreeOut->SetEntries(1);
+  mDictTreeOut->Write(mDictTreeOut->GetName(), TObject::kSingleKey);
+  mDictTreeOut.reset();
+  mDictFileOut.reset();
+  std::string dictFileNameLnk = fmt::format("{}{}.root", mDictDir, o2::base::NameConf::CTFDICT);
+  if (std::filesystem::exists(dictFileNameLnk)) {
+    std::filesystem::remove(dictFileNameLnk);
   }
-  LOG(info) << "Saved CTF dictionary after " << mNCTF << " TFs processed";
-}
-
-//___________________________________________________________________
-void CTFWriterSpec::closeDictionaryTreeAndFile(CTFHeader& header)
-{
-  if (mDictTreeOut) {
-    mDictFileOut->cd();
-    appendToTree(*mDictTreeOut.get(), "CTFHeader", header);
-    mDictTreeOut->SetEntries(1);
-    mDictTreeOut->Write(mDictTreeOut->GetName(), TObject::kSingleKey);
-    mDictTreeOut.reset();
-    mDictFileOut.reset();
+  std::filesystem::create_symlink(dictFileName, dictFileNameLnk);
+  LOGP(info, "Saved CTF dictionaries tree with {} TFs to {} and linked to {}", mNCTF, dictFileName, dictFileNameLnk);
+  if (mPrevDictTimeStamp) {
+    auto dictFileNamePrev = getFileName(false);
+    if (std::filesystem::exists(dictFileNamePrev)) {
+      std::filesystem::remove(dictFileNamePrev);
+      LOGP(info, "Removed previous dictionary version {}", dictFileNamePrev);
+    }
   }
+  mNCTFPrevDict = mNCTF;
+  mPrevDictTimeStamp = mDictTimeStamp;
 }
 
 //___________________________________________________________________
@@ -729,7 +708,6 @@ DataProcessorSpec getCTFWriterSpec(DetID::mask_t dets, uint64_t run, const std::
             {"save-ctf-after", VariantType::Int, 0, {"if > 0, autosave CTF tree with multiple CTFs after every N CTFs"}},
             {"save-dict-after", VariantType::Int, 0, {"if > 0, in dictionary generation mode save it dictionary after certain number of TFs processed"}},
             {"ctf-dict-dir", VariantType::String, "none", {"CTF dictionary directory, must exist"}},
-            {"dict-per-det", VariantType::Bool, false, {"create dictionary file per detector"}},
             {"output-dir", VariantType::String, "none", {"CTF output directory, must exist"}},
             {"output-dir-alt", VariantType::String, "/dev/null", {"Alternative CTF output directory, must exist (if not /dev/null)"}},
             {"meta-output-dir", VariantType::String, "/dev/null", {"CTF metadata output directory, must exist (if not /dev/null)"}},

--- a/Detectors/CTP/reconstruction/include/CTPReconstruction/CTFCoder.h
+++ b/Detectors/CTP/reconstruction/include/CTPReconstruction/CTFCoder.h
@@ -36,7 +36,7 @@ namespace ctp
 class CTFCoder : public o2::ctf::CTFCoderBase
 {
  public:
-  CTFCoder() : o2::ctf::CTFCoderBase(CTF::getNBlocks(), o2::detectors::DetID::CTP) {}
+  CTFCoder(o2::ctf::CTFCoderBase::OpType op) : o2::ctf::CTFCoderBase(op, CTF::getNBlocks(), o2::detectors::DetID::CTP) {}
   ~CTFCoder() final = default;
 
   /// entropy-encode data to buffer with CTF

--- a/Detectors/CTP/workflow/include/CTPWorkflow/EntropyDecoderSpec.h
+++ b/Detectors/CTP/workflow/include/CTPWorkflow/EntropyDecoderSpec.h
@@ -33,6 +33,7 @@ class EntropyDecoderSpec : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) final;
   void init(o2::framework::InitContext& ic) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
   o2::ctp::CTFCoder mCTFCoder;

--- a/Detectors/CTP/workflow/include/CTPWorkflow/EntropyEncoderSpec.h
+++ b/Detectors/CTP/workflow/include/CTPWorkflow/EntropyEncoderSpec.h
@@ -33,6 +33,7 @@ class EntropyEncoderSpec : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) final;
   void init(o2::framework::InitContext& ic) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
   o2::ctp::CTFCoder mCTFCoder;

--- a/Detectors/CTP/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/CTP/workflow/src/EntropyDecoderSpec.cxx
@@ -24,18 +24,22 @@ namespace o2
 namespace ctp
 {
 
-EntropyDecoderSpec::EntropyDecoderSpec(int verbosity)
+EntropyDecoderSpec::EntropyDecoderSpec(int verbosity) : mCTFCoder(o2::ctf::CTFCoderBase::OpType::Decoder)
 {
   mTimer.Stop();
   mTimer.Reset();
 }
 
+void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+{
+  if (mCTFCoder.finaliseCCDB<CTF>(matcher, obj)) {
+    return;
+  }
+}
+
 void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
 {
-  std::string dictPath = ic.options().get<std::string>("ctf-dict");
-  if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
-  }
+  mCTFCoder.init<CTF>(ic);
 }
 
 void EntropyDecoderSpec::run(ProcessingContext& pc)
@@ -43,6 +47,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
 
+  mCTFCoder.updateTimeDependentParams(pc);
   auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
 
   auto& digits = pc.outputs().make<std::vector<CTPDigit>>(OutputRef{"digits"});
@@ -72,7 +77,7 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
     Inputs{InputSpec{"ctf", "CTP", "CTFDATA", sspec, Lifetime::Timeframe}},
     outputs,
     AlgorithmSpec{adaptFromTask<EntropyDecoderSpec>(verbosity)},
-    Options{{"ctf-dict", VariantType::String, o2::base::NameConf::getCTFDictFileName(), {"File of CTF decoding dictionary"}}}};
+    Options{{"ctf-dict", VariantType::String, "", {"CTF dictionary: empty=CCDB, none=no external dictionary otherwise: local filename"}}}};
 }
 
 } // namespace ctp

--- a/Detectors/CTP/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/CTP/workflow/src/EntropyEncoderSpec.cxx
@@ -15,6 +15,7 @@
 
 #include "Framework/ControlService.h"
 #include "Framework/ConfigParamRegistry.h"
+#include "Framework/CCDBParamSpec.h"
 #include "CTPWorkflow/EntropyEncoderSpec.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 
@@ -25,35 +26,35 @@ namespace o2
 namespace ctp
 {
 
-EntropyEncoderSpec::EntropyEncoderSpec()
+EntropyEncoderSpec::EntropyEncoderSpec() : mCTFCoder(o2::ctf::CTFCoderBase::OpType::Encoder)
 {
   mTimer.Stop();
   mTimer.Reset();
 }
 
+void EntropyEncoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+{
+  if (mCTFCoder.finaliseCCDB<CTF>(matcher, obj)) {
+    return;
+  }
+}
+
 void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
 {
-  std::string dictPath = ic.options().get<std::string>("ctf-dict");
-  mCTFCoder.setMemMarginFactor(ic.options().get<float>("mem-factor"));
-  if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
-  }
+  mCTFCoder.init<CTF>(ic);
 }
 
 void EntropyEncoderSpec::run(ProcessingContext& pc)
 {
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
+  mCTFCoder.updateTimeDependentParams(pc);
   auto digits = pc.inputs().get<gsl::span<CTPDigit>>("digits");
-
   auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"CTP", "CTFDATA", 0, Lifetime::Timeframe});
   mCTFCoder.encode(buffer, digits);
-  auto eeb = CTF::get(buffer.data()); // cast to container pointer
-  eeb->compactify();                  // eliminate unnecessary padding
-  buffer.resize(eeb->size());         // shrink buffer to strictly necessary size
-  //  eeb->print();
+  auto sz = mCTFCoder.finaliseCTFOutput<CTF>(buffer);
   mTimer.Stop();
-  LOG(info) << "Created encoded data of size " << eeb->size() << " for CTP in " << mTimer.CpuTime() - cput << " s";
+  LOG(info) << "Created encoded data of size " << sz << " for CTP in " << mTimer.CpuTime() - cput << " s";
 }
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
@@ -66,13 +67,14 @@ DataProcessorSpec getEntropyEncoderSpec()
 {
   std::vector<InputSpec> inputs;
   inputs.emplace_back("digits", "CTP", "DIGITS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("ctfdict", "CTP", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("CTP/Calib/CTFDictionary"));
 
   return DataProcessorSpec{
     "ctp-entropy-encoder",
     inputs,
     Outputs{{"CTP", "CTFDATA", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<EntropyEncoderSpec>()},
-    Options{{"ctf-dict", VariantType::String, o2::base::NameConf::getCTFDictFileName(), {"File of CTF encoding dictionary"}},
+    Options{{"ctf-dict", VariantType::String, "", {"CTF dictionary: empty=CCDB, none=no external dictionary otherwise: local filename"}},
             {"mem-factor", VariantType::Float, 1.f, {"Memory allocation margin factor"}}}};
 }
 

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CTFCoder.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CTFCoder.h
@@ -36,7 +36,7 @@ namespace emcal
 class CTFCoder : public o2::ctf::CTFCoderBase
 {
  public:
-  CTFCoder() : o2::ctf::CTFCoderBase(CTF::getNBlocks(), o2::detectors::DetID::EMC) {}
+  CTFCoder(o2::ctf::CTFCoderBase::OpType op) : o2::ctf::CTFCoderBase(op, CTF::getNBlocks(), o2::detectors::DetID::EMC) {}
   ~CTFCoder() final = default;
 
   /// entropy-encode data to buffer with CTF

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/EntropyDecoderSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/EntropyDecoderSpec.h
@@ -33,6 +33,7 @@ class EntropyDecoderSpec : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) final;
   void init(o2::framework::InitContext& ic) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
   o2::emcal::CTFCoder mCTFCoder;

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/EntropyEncoderSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/EntropyEncoderSpec.h
@@ -33,6 +33,7 @@ class EntropyEncoderSpec : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) final;
   void init(o2::framework::InitContext& ic) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
   o2::emcal::CTFCoder mCTFCoder;

--- a/Detectors/EMCAL/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/EntropyDecoderSpec.cxx
@@ -24,19 +24,23 @@ namespace o2
 namespace emcal
 {
 
-EntropyDecoderSpec::EntropyDecoderSpec(int verbosity)
+EntropyDecoderSpec::EntropyDecoderSpec(int verbosity) : mCTFCoder(o2::ctf::CTFCoderBase::OpType::Decoder)
 {
   mTimer.Stop();
   mTimer.Reset();
   mCTFCoder.setVerbosity(verbosity);
 }
 
+void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+{
+  if (mCTFCoder.finaliseCCDB<CTF>(matcher, obj)) {
+    return;
+  }
+}
+
 void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
 {
-  std::string dictPath = ic.options().get<std::string>("ctf-dict");
-  if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
-  }
+  mCTFCoder.init<CTF>(ic);
 }
 
 void EntropyDecoderSpec::run(ProcessingContext& pc)
@@ -44,6 +48,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
 
+  mCTFCoder.updateTimeDependentParams(pc);
   auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
 
   auto& triggers = pc.outputs().make<std::vector<TriggerRecord>>(OutputRef{"triggers"});
@@ -75,7 +80,7 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
     Inputs{InputSpec{"ctf", "EMC", "CTFDATA", sspec, Lifetime::Timeframe}},
     outputs,
     AlgorithmSpec{adaptFromTask<EntropyDecoderSpec>(verbosity)},
-    Options{{"ctf-dict", VariantType::String, o2::base::NameConf::getCTFDictFileName(), {"File of CTF decoding dictionary"}}}};
+    Options{{"ctf-dict", VariantType::String, "", {"CTF dictionary: empty=CCDB, none=no external dictionary otherwise: local filename"}}}};
 }
 
 } // namespace emcal

--- a/Detectors/EMCAL/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/EntropyEncoderSpec.cxx
@@ -15,6 +15,7 @@
 
 #include "Framework/ControlService.h"
 #include "Framework/ConfigParamRegistry.h"
+#include "Framework/CCDBParamSpec.h"
 #include "EMCALWorkflow/EntropyEncoderSpec.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 
@@ -25,36 +26,37 @@ namespace o2
 namespace emcal
 {
 
-EntropyEncoderSpec::EntropyEncoderSpec()
+EntropyEncoderSpec::EntropyEncoderSpec() : mCTFCoder(o2::ctf::CTFCoderBase::OpType::Encoder)
 {
   mTimer.Stop();
   mTimer.Reset();
 }
 
+void EntropyEncoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+{
+  if (mCTFCoder.finaliseCCDB<CTF>(matcher, obj)) {
+    return;
+  }
+}
+
 void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
 {
-  std::string dictPath = ic.options().get<std::string>("ctf-dict");
-  mCTFCoder.setMemMarginFactor(ic.options().get<float>("mem-factor"));
-  if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
-  }
+  mCTFCoder.init<CTF>(ic);
 }
 
 void EntropyEncoderSpec::run(ProcessingContext& pc)
 {
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
+  mCTFCoder.updateTimeDependentParams(pc);
   auto triggers = pc.inputs().get<gsl::span<TriggerRecord>>("triggers");
   auto cells = pc.inputs().get<gsl::span<Cell>>("cells");
 
   auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"EMC", "CTFDATA", 0, Lifetime::Timeframe});
   mCTFCoder.encode(buffer, triggers, cells);
-  auto eeb = CTF::get(buffer.data()); // cast to container pointer
-  eeb->compactify();                  // eliminate unnecessary padding
-  buffer.resize(eeb->size());         // shrink buffer to strictly necessary size
-  //  eeb->print();
+  auto sz = mCTFCoder.finaliseCTFOutput<CTF>(buffer);
   mTimer.Stop();
-  LOG(info) << "Created encoded data of size " << eeb->size() << " for EMCAL in " << mTimer.CpuTime() - cput << " s";
+  LOG(info) << "Created encoded data of size " << sz << " for EMCAL in " << mTimer.CpuTime() - cput << " s";
 }
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
@@ -68,13 +70,14 @@ DataProcessorSpec getEntropyEncoderSpec()
   std::vector<InputSpec> inputs;
   inputs.emplace_back("triggers", "EMC", "CELLSTRGR", 0, Lifetime::Timeframe);
   inputs.emplace_back("cells", "EMC", "CELLS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("ctfdict", "EMC", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("EMC/Calib/CTFDictionary"));
 
   return DataProcessorSpec{
     "emcal-entropy-encoder",
     inputs,
     Outputs{{"EMC", "CTFDATA", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<EntropyEncoderSpec>()},
-    Options{{"ctf-dict", VariantType::String, o2::base::NameConf::getCTFDictFileName(), {"File of CTF encoding dictionary"}},
+    Options{{"ctf-dict", VariantType::String, "", {"CTF dictionary: empty=CCDB, none=no external dictionary otherwise: local filename"}},
             {"mem-factor", VariantType::Float, 1.f, {"Memory allocation margin factor"}}}};
 }
 

--- a/Detectors/FIT/FDD/reconstruction/include/FDDReconstruction/CTFCoder.h
+++ b/Detectors/FIT/FDD/reconstruction/include/FDDReconstruction/CTFCoder.h
@@ -37,7 +37,7 @@ namespace fdd
 class CTFCoder : public o2::ctf::CTFCoderBase
 {
  public:
-  CTFCoder() : o2::ctf::CTFCoderBase(CTF::getNBlocks(), o2::detectors::DetID::FDD) {}
+  CTFCoder(o2::ctf::CTFCoderBase::OpType op) : o2::ctf::CTFCoderBase(op, CTF::getNBlocks(), o2::detectors::DetID::FDD) {}
   ~CTFCoder() final = default;
 
   /// entropy-encode digits to buffer with CTF

--- a/Detectors/FIT/FDD/workflow/include/FDDWorkflow/EntropyDecoderSpec.h
+++ b/Detectors/FIT/FDD/workflow/include/FDDWorkflow/EntropyDecoderSpec.h
@@ -33,6 +33,7 @@ class EntropyDecoderSpec : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) final;
   void init(o2::framework::InitContext& ic) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
   o2::fdd::CTFCoder mCTFCoder;

--- a/Detectors/FIT/FDD/workflow/include/FDDWorkflow/EntropyEncoderSpec.h
+++ b/Detectors/FIT/FDD/workflow/include/FDDWorkflow/EntropyEncoderSpec.h
@@ -33,6 +33,7 @@ class EntropyEncoderSpec : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) final;
   void init(o2::framework::InitContext& ic) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
   o2::fdd::CTFCoder mCTFCoder;

--- a/Detectors/FIT/FDD/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/FIT/FDD/workflow/src/EntropyEncoderSpec.cxx
@@ -15,6 +15,7 @@
 
 #include "Framework/ControlService.h"
 #include "Framework/ConfigParamRegistry.h"
+#include "Framework/CCDBParamSpec.h"
 #include "FDDWorkflow/EntropyEncoderSpec.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 
@@ -25,35 +26,37 @@ namespace o2
 namespace fdd
 {
 
-EntropyEncoderSpec::EntropyEncoderSpec()
+EntropyEncoderSpec::EntropyEncoderSpec() : mCTFCoder(o2::ctf::CTFCoderBase::OpType::Encoder)
 {
   mTimer.Stop();
   mTimer.Reset();
 }
 
+void EntropyEncoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+{
+  if (mCTFCoder.finaliseCCDB<CTF>(matcher, obj)) {
+    return;
+  }
+}
+
 void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
 {
-  std::string dictPath = ic.options().get<std::string>("ctf-dict");
-  mCTFCoder.setMemMarginFactor(ic.options().get<float>("mem-factor"));
-  if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
-  }
+  mCTFCoder.init<CTF>(ic);
 }
 
 void EntropyEncoderSpec::run(ProcessingContext& pc)
 {
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
+  mCTFCoder.updateTimeDependentParams(pc);
   auto digits = pc.inputs().get<gsl::span<o2::fdd::Digit>>("digits");
   auto channels = pc.inputs().get<gsl::span<o2::fdd::ChannelData>>("channels");
 
   auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"FDD", "CTFDATA", 0, Lifetime::Timeframe});
   mCTFCoder.encode(buffer, digits, channels);
-  auto eeb = CTF::get(buffer.data()); // cast to container pointer
-  eeb->compactify();                  // eliminate unnecessary padding
-  buffer.resize(eeb->size());         // shrink buffer to strictly necessary size
+  auto sz = mCTFCoder.finaliseCTFOutput<CTF>(buffer);
   mTimer.Stop();
-  LOG(info) << "Created encoded data of size " << eeb->size() << " for FDD in " << mTimer.CpuTime() - cput << " s";
+  LOG(info) << "Created encoded data of size " << sz << " for FDD in " << mTimer.CpuTime() - cput << " s";
 }
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
@@ -67,13 +70,14 @@ DataProcessorSpec getEntropyEncoderSpec()
   std::vector<InputSpec> inputs;
   inputs.emplace_back("digits", "FDD", "DIGITSBC", 0, Lifetime::Timeframe);
   inputs.emplace_back("channels", "FDD", "DIGITSCH", 0, Lifetime::Timeframe);
+  inputs.emplace_back("ctfdict", "FDD", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("FDD/Calib/CTFDictionary"));
 
   return DataProcessorSpec{
     "fdd-entropy-encoder",
     inputs,
     Outputs{{"FDD", "CTFDATA", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<EntropyEncoderSpec>()},
-    Options{{"ctf-dict", VariantType::String, o2::base::NameConf::getCTFDictFileName(), {"File of CTF encoding dictionary"}},
+    Options{{"ctf-dict", VariantType::String, "", {"CTF dictionary: empty=CCDB, none=no external dictionary otherwise: local filename"}},
             {"mem-factor", VariantType::Float, 1.f, {"Memory allocation margin factor"}}}};
 }
 

--- a/Detectors/FIT/FT0/reconstruction/include/FT0Reconstruction/CTFCoder.h
+++ b/Detectors/FIT/FT0/reconstruction/include/FT0Reconstruction/CTFCoder.h
@@ -38,7 +38,7 @@ namespace ft0
 class CTFCoder : public o2::ctf::CTFCoderBase
 {
  public:
-  CTFCoder() : o2::ctf::CTFCoderBase(CTF::getNBlocks(), o2::detectors::DetID::FT0) {}
+  CTFCoder(o2::ctf::CTFCoderBase::OpType op) : o2::ctf::CTFCoderBase(op, CTF::getNBlocks(), o2::detectors::DetID::FT0) {}
   ~CTFCoder() final = default;
 
   /// entropy-encode digits to buffer with CTF

--- a/Detectors/FIT/FT0/workflow/include/FT0Workflow/EntropyDecoderSpec.h
+++ b/Detectors/FIT/FT0/workflow/include/FT0Workflow/EntropyDecoderSpec.h
@@ -33,6 +33,7 @@ class EntropyDecoderSpec : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) final;
   void init(o2::framework::InitContext& ic) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
   o2::ft0::CTFCoder mCTFCoder;

--- a/Detectors/FIT/FT0/workflow/include/FT0Workflow/EntropyEncoderSpec.h
+++ b/Detectors/FIT/FT0/workflow/include/FT0Workflow/EntropyEncoderSpec.h
@@ -33,6 +33,7 @@ class EntropyEncoderSpec : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) final;
   void init(o2::framework::InitContext& ic) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
   o2::ft0::CTFCoder mCTFCoder;

--- a/Detectors/FIT/FT0/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/FIT/FT0/workflow/src/EntropyDecoderSpec.cxx
@@ -24,19 +24,23 @@ namespace o2
 namespace ft0
 {
 
-EntropyDecoderSpec::EntropyDecoderSpec(int verbosity)
+EntropyDecoderSpec::EntropyDecoderSpec(int verbosity) : mCTFCoder(o2::ctf::CTFCoderBase::OpType::Decoder)
 {
   mTimer.Stop();
   mTimer.Reset();
   mCTFCoder.setVerbosity(verbosity);
 }
 
+void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+{
+  if (mCTFCoder.finaliseCCDB<CTF>(matcher, obj)) {
+    return;
+  }
+}
+
 void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
 {
-  std::string dictPath = ic.options().get<std::string>("ctf-dict");
-  if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
-  }
+  mCTFCoder.init<CTF>(ic);
 }
 
 void EntropyDecoderSpec::run(ProcessingContext& pc)
@@ -44,6 +48,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
 
+  mCTFCoder.updateTimeDependentParams(pc);
   auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
 
   auto& digits = pc.outputs().make<std::vector<o2::ft0::Digit>>(OutputRef{"digits"});
@@ -75,7 +80,7 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
     Inputs{InputSpec{"ctf", "FT0", "CTFDATA", sspec, Lifetime::Timeframe}},
     outputs,
     AlgorithmSpec{adaptFromTask<EntropyDecoderSpec>(verbosity)},
-    Options{{"ctf-dict", VariantType::String, o2::base::NameConf::getCTFDictFileName(), {"File of CTF decoding dictionary"}}}};
+    Options{{"ctf-dict", VariantType::String, "", {"CTF dictionary: empty=CCDB, none=no external dictionary otherwise: local filename"}}}};
 }
 
 } // namespace ft0

--- a/Detectors/FIT/FT0/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/FIT/FT0/workflow/src/EntropyEncoderSpec.cxx
@@ -15,6 +15,7 @@
 
 #include "Framework/ControlService.h"
 #include "Framework/ConfigParamRegistry.h"
+#include "Framework/CCDBParamSpec.h"
 #include "FT0Workflow/EntropyEncoderSpec.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 
@@ -25,35 +26,37 @@ namespace o2
 namespace ft0
 {
 
-EntropyEncoderSpec::EntropyEncoderSpec()
+EntropyEncoderSpec::EntropyEncoderSpec() : mCTFCoder(o2::ctf::CTFCoderBase::OpType::Encoder)
 {
   mTimer.Stop();
   mTimer.Reset();
 }
 
+void EntropyEncoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+{
+  if (mCTFCoder.finaliseCCDB<CTF>(matcher, obj)) {
+    return;
+  }
+}
+
 void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
 {
-  std::string dictPath = ic.options().get<std::string>("ctf-dict");
-  mCTFCoder.setMemMarginFactor(ic.options().get<float>("mem-factor"));
-  if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
-  }
+  mCTFCoder.init<CTF>(ic);
 }
 
 void EntropyEncoderSpec::run(ProcessingContext& pc)
 {
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
+  mCTFCoder.updateTimeDependentParams(pc);
   auto digits = pc.inputs().get<gsl::span<o2::ft0::Digit>>("digits");
   auto channels = pc.inputs().get<gsl::span<o2::ft0::ChannelData>>("channels");
 
   auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"FT0", "CTFDATA", 0, Lifetime::Timeframe});
   mCTFCoder.encode(buffer, digits, channels);
-  auto eeb = CTF::get(buffer.data()); // cast to container pointer
-  eeb->compactify();                  // eliminate unnecessary padding
-  buffer.resize(eeb->size());         // shrink buffer to strictly necessary size
+  auto sz = mCTFCoder.finaliseCTFOutput<CTF>(buffer);
   mTimer.Stop();
-  LOG(debug) << "Created encoded data of size " << eeb->size() << " for FT0 in " << mTimer.CpuTime() - cput << " s";
+  LOG(debug) << "Created encoded data of size " << sz << " for FT0 in " << mTimer.CpuTime() - cput << " s";
 }
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
@@ -67,13 +70,14 @@ DataProcessorSpec getEntropyEncoderSpec()
   std::vector<InputSpec> inputs;
   inputs.emplace_back("digits", "FT0", "DIGITSBC", 0, Lifetime::Timeframe);
   inputs.emplace_back("channels", "FT0", "DIGITSCH", 0, Lifetime::Timeframe);
+  inputs.emplace_back("ctfdict", "FT0", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("FT0/Calib/CTFDictionary"));
 
   return DataProcessorSpec{
     "ft0-entropy-encoder",
     inputs,
     Outputs{{"FT0", "CTFDATA", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<EntropyEncoderSpec>()},
-    Options{{"ctf-dict", VariantType::String, o2::base::NameConf::getCTFDictFileName(), {"File of CTF encoding dictionary"}},
+    Options{{"ctf-dict", VariantType::String, "", {"CTF dictionary: empty=CCDB, none=no external dictionary otherwise: local filename"}},
             {"mem-factor", VariantType::Float, 1.f, {"Memory allocation margin factor"}}}};
 }
 

--- a/Detectors/FIT/FV0/reconstruction/include/FV0Reconstruction/CTFCoder.h
+++ b/Detectors/FIT/FV0/reconstruction/include/FV0Reconstruction/CTFCoder.h
@@ -32,7 +32,7 @@ namespace fv0
 class CTFCoder : public o2::ctf::CTFCoderBase
 {
  public:
-  CTFCoder() : o2::ctf::CTFCoderBase(CTF::getNBlocks(), o2::detectors::DetID::FV0) {}
+  CTFCoder(o2::ctf::CTFCoderBase::OpType op) : o2::ctf::CTFCoderBase(op, CTF::getNBlocks(), o2::detectors::DetID::FV0) {}
   ~CTFCoder() final = default;
 
   /// entropy-encode digits to buffer with CTF

--- a/Detectors/FIT/FV0/workflow/include/FV0Workflow/EntropyDecoderSpec.h
+++ b/Detectors/FIT/FV0/workflow/include/FV0Workflow/EntropyDecoderSpec.h
@@ -33,6 +33,7 @@ class EntropyDecoderSpec : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) final;
   void init(o2::framework::InitContext& ic) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
   o2::fv0::CTFCoder mCTFCoder;

--- a/Detectors/FIT/FV0/workflow/include/FV0Workflow/EntropyEncoderSpec.h
+++ b/Detectors/FIT/FV0/workflow/include/FV0Workflow/EntropyEncoderSpec.h
@@ -33,6 +33,7 @@ class EntropyEncoderSpec : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) final;
   void init(o2::framework::InitContext& ic) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
   o2::fv0::CTFCoder mCTFCoder;

--- a/Detectors/FIT/FV0/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/FIT/FV0/workflow/src/EntropyDecoderSpec.cxx
@@ -24,19 +24,23 @@ namespace o2
 namespace fv0
 {
 
-EntropyDecoderSpec::EntropyDecoderSpec(int verbosity)
+EntropyDecoderSpec::EntropyDecoderSpec(int verbosity) : mCTFCoder(o2::ctf::CTFCoderBase::OpType::Decoder)
 {
   mTimer.Stop();
   mTimer.Reset();
   mCTFCoder.setVerbosity(verbosity);
 }
 
+void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+{
+  if (mCTFCoder.finaliseCCDB<CTF>(matcher, obj)) {
+    return;
+  }
+}
+
 void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
 {
-  std::string dictPath = ic.options().get<std::string>("ctf-dict");
-  if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
-  }
+  mCTFCoder.init<CTF>(ic);
 }
 
 void EntropyDecoderSpec::run(ProcessingContext& pc)
@@ -44,6 +48,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
 
+  mCTFCoder.updateTimeDependentParams(pc);
   auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
 
   auto& digits = pc.outputs().make<std::vector<o2::fv0::Digit>>(OutputRef{"digits"});
@@ -75,7 +80,7 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
     Inputs{InputSpec{"ctf", "FV0", "CTFDATA", sspec, Lifetime::Timeframe}},
     outputs,
     AlgorithmSpec{adaptFromTask<EntropyDecoderSpec>(verbosity)},
-    Options{{"ctf-dict", VariantType::String, o2::base::NameConf::getCTFDictFileName(), {"File of CTF decoding dictionary"}}}};
+    Options{{"ctf-dict", VariantType::String, "", {"CTF dictionary: empty=CCDB, none=no external dictionary otherwise: local filename"}}}};
 }
 
 } // namespace fv0

--- a/Detectors/FIT/FV0/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/FIT/FV0/workflow/src/EntropyEncoderSpec.cxx
@@ -15,6 +15,7 @@
 
 #include "Framework/ControlService.h"
 #include "Framework/ConfigParamRegistry.h"
+#include "Framework/CCDBParamSpec.h"
 #include "FV0Workflow/EntropyEncoderSpec.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 
@@ -25,35 +26,37 @@ namespace o2
 namespace fv0
 {
 
-EntropyEncoderSpec::EntropyEncoderSpec()
+EntropyEncoderSpec::EntropyEncoderSpec() : mCTFCoder(o2::ctf::CTFCoderBase::OpType::Encoder)
 {
   mTimer.Stop();
   mTimer.Reset();
 }
 
+void EntropyEncoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+{
+  if (mCTFCoder.finaliseCCDB<CTF>(matcher, obj)) {
+    return;
+  }
+}
+
 void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
 {
-  std::string dictPath = ic.options().get<std::string>("ctf-dict");
-  mCTFCoder.setMemMarginFactor(ic.options().get<float>("mem-factor"));
-  if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
-  }
+  mCTFCoder.init<CTF>(ic);
 }
 
 void EntropyEncoderSpec::run(ProcessingContext& pc)
 {
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
+  mCTFCoder.updateTimeDependentParams(pc);
   auto digits = pc.inputs().get<gsl::span<o2::fv0::Digit>>("digits");
   auto channels = pc.inputs().get<gsl::span<o2::fv0::ChannelData>>("channels");
 
   auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"FV0", "CTFDATA", 0, Lifetime::Timeframe});
   mCTFCoder.encode(buffer, digits, channels);
-  auto eeb = CTF::get(buffer.data()); // cast to container pointer
-  eeb->compactify();                  // eliminate unnecessary padding
-  buffer.resize(eeb->size());         // shrink buffer to strictly necessary size
+  auto sz = mCTFCoder.finaliseCTFOutput<CTF>(buffer);
   mTimer.Stop();
-  LOG(debug) << "Created encoded data of size " << eeb->size() << " for FV0 in " << mTimer.CpuTime() - cput << " s";
+  LOG(debug) << "Created encoded data of size " << sz << " for FV0 in " << mTimer.CpuTime() - cput << " s";
 }
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
@@ -67,13 +70,14 @@ DataProcessorSpec getEntropyEncoderSpec()
   std::vector<InputSpec> inputs;
   inputs.emplace_back("digits", "FV0", "DIGITSBC", 0, Lifetime::Timeframe);
   inputs.emplace_back("channels", "FV0", "DIGITSCH", 0, Lifetime::Timeframe);
+  inputs.emplace_back("ctfdict", "FV0", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("FV0/Calib/CTFDictionary"));
 
   return DataProcessorSpec{
     "fv0-entropy-encoder",
     inputs,
     Outputs{{"FV0", "CTFDATA", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<EntropyEncoderSpec>()},
-    Options{{"ctf-dict", VariantType::String, o2::base::NameConf::getCTFDictFileName(), {"File of CTF encoding dictionary"}},
+    Options{{"ctf-dict", VariantType::String, "", {"CTF dictionary: empty=CCDB, none=no external dictionary otherwise: local filename"}},
             {"mem-factor", VariantType::Float, 1.f, {"Memory allocation margin factor"}}}};
 }
 

--- a/Detectors/HMPID/reconstruction/include/HMPIDReconstruction/CTFCoder.h
+++ b/Detectors/HMPID/reconstruction/include/HMPIDReconstruction/CTFCoder.h
@@ -36,7 +36,7 @@ namespace hmpid
 class CTFCoder : public o2::ctf::CTFCoderBase
 {
  public:
-  CTFCoder() : o2::ctf::CTFCoderBase(CTF::getNBlocks(), o2::detectors::DetID::HMP) {}
+  CTFCoder(o2::ctf::CTFCoderBase::OpType op) : o2::ctf::CTFCoderBase(op, CTF::getNBlocks(), o2::detectors::DetID::HMP) {}
   ~CTFCoder() final = default;
 
   /// entropy-encode data to buffer with CTF

--- a/Detectors/HMPID/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/HMPID/workflow/src/EntropyDecoderSpec.cxx
@@ -34,25 +34,30 @@ class EntropyDecoderSpec : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) final;
   void init(o2::framework::InitContext& ic) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
   o2::hmpid::CTFCoder mCTFCoder;
   TStopwatch mTimer;
 };
 
-EntropyDecoderSpec::EntropyDecoderSpec(int verbosity)
+EntropyDecoderSpec::EntropyDecoderSpec(int verbosity) : mCTFCoder(o2::ctf::CTFCoderBase::OpType::Decoder)
 {
   mTimer.Stop();
   mTimer.Reset();
   mCTFCoder.setVerbosity(verbosity);
 }
 
+void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+{
+  if (mCTFCoder.finaliseCCDB<CTF>(matcher, obj)) {
+    return;
+  }
+}
+
 void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
 {
-  std::string dictPath = ic.options().get<std::string>("ctf-dict");
-  if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
-  }
+  mCTFCoder.init<CTF>(ic);
 }
 
 void EntropyDecoderSpec::run(ProcessingContext& pc)
@@ -60,6 +65,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
 
+  mCTFCoder.updateTimeDependentParams(pc);
   auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
 
   auto& triggers = pc.outputs().make<std::vector<Trigger>>(OutputRef{"triggers"});
@@ -91,7 +97,7 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
     Inputs{InputSpec{"ctf", "HMP", "CTFDATA", sspec, Lifetime::Timeframe}},
     outputs,
     AlgorithmSpec{adaptFromTask<EntropyDecoderSpec>(verbosity)},
-    Options{{"ctf-dict", VariantType::String, o2::base::NameConf::getCTFDictFileName(), {"File of CTF decoding dictionary"}}}};
+    Options{{"ctf-dict", VariantType::String, "", {"CTF dictionary: empty=CCDB, none=no external dictionary otherwise: local filename"}}}};
 }
 
 } // namespace hmpid

--- a/Detectors/HMPID/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/HMPID/workflow/src/EntropyEncoderSpec.cxx
@@ -15,6 +15,7 @@
 
 #include "Framework/ControlService.h"
 #include "Framework/ConfigParamRegistry.h"
+#include "Framework/CCDBParamSpec.h"
 #include "HMPIDWorkflow/EntropyEncoderSpec.h"
 #include "HMPIDReconstruction/CTFCoder.h"
 #include "DetectorsCommonDataFormats/DetID.h"
@@ -35,42 +36,44 @@ class EntropyEncoderSpec : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) final;
   void init(o2::framework::InitContext& ic) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
   o2::hmpid::CTFCoder mCTFCoder;
   TStopwatch mTimer;
 };
 
-EntropyEncoderSpec::EntropyEncoderSpec()
+EntropyEncoderSpec::EntropyEncoderSpec() : mCTFCoder(o2::ctf::CTFCoderBase::OpType::Encoder)
 {
   mTimer.Stop();
   mTimer.Reset();
 }
 
+void EntropyEncoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+{
+  if (mCTFCoder.finaliseCCDB<CTF>(matcher, obj)) {
+    return;
+  }
+}
+
 void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
 {
-  std::string dictPath = ic.options().get<std::string>("ctf-dict");
-  mCTFCoder.setMemMarginFactor(ic.options().get<float>("mem-factor"));
-  if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
-  }
+  mCTFCoder.init<CTF>(ic);
 }
 
 void EntropyEncoderSpec::run(ProcessingContext& pc)
 {
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
+  mCTFCoder.updateTimeDependentParams(pc);
   auto triggers = pc.inputs().get<gsl::span<Trigger>>("triggers");
   auto digits = pc.inputs().get<gsl::span<Digit>>("digits");
 
   auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"HMP", "CTFDATA", 0, Lifetime::Timeframe});
   mCTFCoder.encode(buffer, triggers, digits);
-  auto eeb = CTF::get(buffer.data()); // cast to container pointer
-  eeb->compactify();                  // eliminate unnecessary padding
-  buffer.resize(eeb->size());         // shrink buffer to strictly necessary size
-  //  eeb->print();
+  auto sz = mCTFCoder.finaliseCTFOutput<CTF>(buffer);
   mTimer.Stop();
-  LOG(info) << "Created encoded data of size " << eeb->size() << " for HMPID in " << mTimer.CpuTime() - cput << " s";
+  LOG(info) << "Created encoded data of size " << sz << " for HMPID in " << mTimer.CpuTime() - cput << " s";
 }
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
@@ -84,13 +87,14 @@ DataProcessorSpec getEntropyEncoderSpec()
   std::vector<InputSpec> inputs;
   inputs.emplace_back("triggers", "HMP", "INTRECORDS", 0, Lifetime::Timeframe);
   inputs.emplace_back("digits", "HMP", "DIGITS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("ctfdict", "HMP", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("HMP/Calib/CTFDictionary"));
 
   return DataProcessorSpec{
     "hmpid-entropy-encoder",
     inputs,
     Outputs{{"HMP", "CTFDATA", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<EntropyEncoderSpec>()},
-    Options{{"ctf-dict", VariantType::String, o2::base::NameConf::getCTFDictFileName(), {"File of CTF encoding dictionary"}},
+    Options{{"ctf-dict", VariantType::String, "", {"CTF dictionary: empty=CCDB, none=no external dictionary otherwise: local filename"}},
             {"mem-factor", VariantType::Float, 1.f, {"Memory allocation margin factor"}}}};
 }
 

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/CTFCoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/CTFCoder.h
@@ -46,7 +46,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
   using PMatrix = std::array<std::array<bool, ClusterPattern::MaxRowSpan + 2>, ClusterPattern::MaxColSpan + 2>;
   using RowColBuff = std::vector<PixelData>;
 
-  CTFCoder(o2::detectors::DetID det) : o2::ctf::CTFCoderBase(CTF::getNBlocks(), det) {}
+  CTFCoder(o2::ctf::CTFCoderBase::OpType op, o2::detectors::DetID det) : o2::ctf::CTFCoderBase(op, CTF::getNBlocks(), det) {}
   ~CTFCoder() final = default;
 
   /// entropy-encode clusters to buffer with CTF

--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/EntropyEncoderSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/EntropyEncoderSpec.h
@@ -34,6 +34,8 @@ class EntropyEncoderSpec : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) final;
   void init(o2::framework::InitContext& ic) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+  void updateTimeDependentParams(o2::framework::ProcessingContext& pc);
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
   o2::header::DataOrigin mOrigin = o2::header::gDataOriginInvalid;

--- a/Detectors/ITSMFT/common/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/EntropyDecoderSpec.cxx
@@ -29,7 +29,7 @@ namespace itsmft
 {
 
 EntropyDecoderSpec::EntropyDecoderSpec(o2::header::DataOrigin orig, int verbosity, bool getDigits)
-  : mOrigin(orig), mCTFCoder(orig == o2::header::gDataOriginITS ? o2::detectors::DetID::ITS : o2::detectors::DetID::MFT), mGetDigits(getDigits)
+  : mOrigin(orig), mCTFCoder(o2::ctf::CTFCoderBase::OpType::Decoder, orig == o2::header::gDataOriginITS ? o2::detectors::DetID::ITS : o2::detectors::DetID::MFT), mGetDigits(getDigits)
 {
   assert(orig == o2::header::gDataOriginITS || orig == o2::header::gDataOriginMFT);
   mTimer.Stop();
@@ -39,8 +39,7 @@ EntropyDecoderSpec::EntropyDecoderSpec(o2::header::DataOrigin orig, int verbosit
 
 void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
 {
-  auto detID = mOrigin == o2::header::gDataOriginITS ? o2::detectors::DetID::ITS : o2::detectors::DetID::MFT;
-  mCTFDictPath = ic.options().get<std::string>("ctf-dict");
+  mCTFCoder.init<CTF>(ic);
   mMaskNoise = ic.options().get<bool>("mask-noise");
   mUseClusterDictionary = !ic.options().get<bool>("ignore-cluster-dictionary");
 }
@@ -88,23 +87,22 @@ void EntropyDecoderSpec::updateTimeDependentParams(ProcessingContext& pc)
   if (mGetDigits || mMaskNoise) {
     pc.inputs().get<o2::itsmft::NoiseMap*>("cldict");
   }
-  static bool coderUpdated = false; // with dicts loaded from CCDB one should check also the validity of current object
-  if (!coderUpdated) {
-    coderUpdated = true;
-    if (!mCTFDictPath.empty() && mCTFDictPath != "none") {
-      mCTFCoder.createCodersFromFile<CTF>(mCTFDictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
-    }
-  }
+  mCTFCoder.updateTimeDependentParams(pc);
 }
 
 void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
 {
   if (matcher == ConcreteDataMatcher(mOrigin, "NOISEMAP", 0)) {
     LOG(info) << mOrigin.as<std::string>() << " noise map updated";
+    return;
   }
   if (matcher == ConcreteDataMatcher(mOrigin, "CLUSDICT", 0)) {
     LOG(info) << mOrigin.as<std::string>() << " cluster dictionary updated" << (!mUseClusterDictionary ? " but its using is disabled" : "");
     mPattIdConverter.setDictionary((const TopologyDictionary*)obj);
+    return;
+  }
+  if (mCTFCoder.finaliseCCDB<CTF>(matcher, obj)) {
+    return;
   }
 }
 
@@ -121,10 +119,9 @@ DataProcessorSpec getEntropyDecoderSpec(o2::header::DataOrigin orig, int verbosi
   }
   std::vector<InputSpec> inputs;
   inputs.emplace_back("ctf", orig, "CTFDATA", sspec, Lifetime::Timeframe);
-  inputs.emplace_back("noise", orig, "NOISEMAP", 0, Lifetime::Condition,
-                      ccdbParamSpec(fmt::format("{}/Calib/NoiseMap", orig.as<std::string>())));
-  inputs.emplace_back("cldict", orig, "CLUSDICT", 0, Lifetime::Condition,
-                      ccdbParamSpec(fmt::format("{}/Calib/ClusterDictionary", orig.as<std::string>())));
+  inputs.emplace_back("noise", orig, "NOISEMAP", 0, Lifetime::Condition, ccdbParamSpec(fmt::format("{}/Calib/NoiseMap", orig.as<std::string>())));
+  inputs.emplace_back("cldict", orig, "CLUSDICT", 0, Lifetime::Condition, ccdbParamSpec(fmt::format("{}/Calib/ClusterDictionary", orig.as<std::string>())));
+  inputs.emplace_back("ctfdict", orig, "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec(fmt::format("{}/Calib/CTFDictionary", orig.as<std::string>())));
 
   return DataProcessorSpec{
     EntropyDecoderSpec::getName(orig),
@@ -132,7 +129,7 @@ DataProcessorSpec getEntropyDecoderSpec(o2::header::DataOrigin orig, int verbosi
     outputs,
     AlgorithmSpec{adaptFromTask<EntropyDecoderSpec>(orig, verbosity, getDigits)},
     Options{
-      {"ctf-dict", VariantType::String, o2::base::NameConf::getCTFDictFileName(), {"File of CTF decoding dictionary"}},
+      {"ctf-dict", VariantType::String, "", {"CTF dictionary: empty=CCDB, none=no external dictionary otherwise: local filename"}},
       {"mask-noise", VariantType::Bool, false, {"apply noise mask to digits or clusters (involves reclusterization)"}},
       {"ignore-cluster-dictionary", VariantType::Bool, false, {"do not use cluster dictionary, always store explicit patterns"}}}};
 }

--- a/Detectors/ITSMFT/common/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/EntropyEncoderSpec.cxx
@@ -15,6 +15,7 @@
 
 #include "Framework/ControlService.h"
 #include "Framework/ConfigParamRegistry.h"
+#include "Framework/CCDBParamSpec.h"
 #include "DataFormatsITSMFT/CompCluster.h"
 #include "ITSMFTWorkflow/EntropyEncoderSpec.h"
 #include "DetectorsCommonDataFormats/DetID.h"
@@ -27,7 +28,7 @@ namespace itsmft
 {
 
 EntropyEncoderSpec::EntropyEncoderSpec(o2::header::DataOrigin orig)
-  : mOrigin(orig), mCTFCoder(orig == o2::header::gDataOriginITS ? o2::detectors::DetID::ITS : o2::detectors::DetID::MFT)
+  : mOrigin(orig), mCTFCoder(o2::ctf::CTFCoderBase::OpType::Encoder, orig == o2::header::gDataOriginITS ? o2::detectors::DetID::ITS : o2::detectors::DetID::MFT)
 {
   assert(orig == o2::header::gDataOriginITS || orig == o2::header::gDataOriginMFT);
   mTimer.Stop();
@@ -36,29 +37,24 @@ EntropyEncoderSpec::EntropyEncoderSpec(o2::header::DataOrigin orig)
 
 void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
 {
-  std::string dictPath = ic.options().get<std::string>("ctf-dict");
-  mCTFCoder.setMemMarginFactor(ic.options().get<float>("mem-factor"));
-  if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
-  }
+  mCTFCoder.init<CTF>(ic);
 }
 
 void EntropyEncoderSpec::run(ProcessingContext& pc)
 {
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
+  updateTimeDependentParams(pc);
+
   auto compClusters = pc.inputs().get<gsl::span<o2::itsmft::CompClusterExt>>("compClusters");
   auto pspan = pc.inputs().get<gsl::span<unsigned char>>("patterns");
   auto rofs = pc.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("ROframes");
 
   auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{mOrigin, "CTFDATA", 0, Lifetime::Timeframe});
   mCTFCoder.encode(buffer, rofs, compClusters, pspan);
-  auto eeb = CTF::get(buffer.data()); // cast to container pointer
-  eeb->compactify();                  // eliminate unnecessary padding
-  buffer.resize(eeb->size());         // shrink buffer to strictly necessary size
-  //  eeb->print();
+  auto sz = mCTFCoder.finaliseCTFOutput<CTF>(buffer);
   mTimer.Stop();
-  LOG(info) << "Created encoded data of size " << eeb->size() << " for " << mOrigin.as<std::string>() << " in " << mTimer.CpuTime() - cput << " s";
+  LOG(info) << "Created encoded data of size " << sz << " for " << mOrigin.as<std::string>() << " in " << mTimer.CpuTime() - cput << " s";
 }
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
@@ -67,19 +63,30 @@ void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
        mOrigin.as<std::string>(), mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 
+void EntropyEncoderSpec::updateTimeDependentParams(ProcessingContext& pc)
+{
+  mCTFCoder.updateTimeDependentParams(pc);
+}
+
+void EntropyEncoderSpec::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
+{
+  mCTFCoder.finaliseCCDB<CTF>(matcher, obj);
+}
+
 DataProcessorSpec getEntropyEncoderSpec(o2::header::DataOrigin orig)
 {
   std::vector<InputSpec> inputs;
   inputs.emplace_back("compClusters", orig, "COMPCLUSTERS", 0, Lifetime::Timeframe);
   inputs.emplace_back("patterns", orig, "PATTERNS", 0, Lifetime::Timeframe);
   inputs.emplace_back("ROframes", orig, "CLUSTERSROF", 0, Lifetime::Timeframe);
+  inputs.emplace_back("ctfdict", orig, "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec(fmt::format("{}/Calib/CTFDictionary", orig.as<std::string>())));
 
   return DataProcessorSpec{
     orig == o2::header::gDataOriginITS ? "its-entropy-encoder" : "mft-entropy-encoder",
     inputs,
     Outputs{{orig, "CTFDATA", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<EntropyEncoderSpec>(orig)},
-    Options{{"ctf-dict", VariantType::String, o2::base::NameConf::getCTFDictFileName(), {"File of CTF encoding dictionary"}},
+    Options{{"ctf-dict", VariantType::String, "", {"CTF dictionary: empty=CCDB, none=no external dictionary otherwise: local filename"}},
             {"mem-factor", VariantType::Float, 1.f, {"Memory allocation margin factor"}}}};
 }
 

--- a/Detectors/MUON/MCH/CTF/include/MCHCTF/CTFCoder.h
+++ b/Detectors/MUON/MCH/CTF/include/MCHCTF/CTFCoder.h
@@ -38,7 +38,7 @@ namespace mch
 class CTFCoder : public o2::ctf::CTFCoderBase
 {
  public:
-  CTFCoder() : o2::ctf::CTFCoderBase(CTF::getNBlocks(), o2::detectors::DetID::MCH) {}
+  CTFCoder(o2::ctf::CTFCoderBase::OpType op) : o2::ctf::CTFCoderBase(op, CTF::getNBlocks(), o2::detectors::DetID::MCH) {}
   ~CTFCoder() final = default;
 
   /// entropy-encode data to buffer with CTF

--- a/Detectors/MUON/MCH/Workflow/src/entropy-encoder-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/entropy-encoder-workflow.cxx
@@ -15,6 +15,7 @@
 #include "Framework/ConfigParamSpec.h"
 #include "Framework/ControlService.h"
 #include "Framework/DataProcessorSpec.h"
+#include "Framework/CCDBParamSpec.h"
 #include "Framework/Task.h"
 #include "MCHCTF/CTFCoder.h"
 #include <TStopwatch.h>
@@ -35,43 +36,45 @@ class EntropyEncoderSpec : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) final;
   void init(o2::framework::InitContext& ic) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
   o2::mch::CTFCoder mCTFCoder;
   TStopwatch mTimer;
 };
 
-EntropyEncoderSpec::EntropyEncoderSpec()
+EntropyEncoderSpec::EntropyEncoderSpec() : mCTFCoder(o2::ctf::CTFCoderBase::OpType::Encoder)
 {
   mTimer.Stop();
   mTimer.Reset();
 }
 
+void EntropyEncoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+{
+  if (mCTFCoder.finaliseCCDB<CTF>(matcher, obj)) {
+    return;
+  }
+}
+
 void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
 {
-  std::string dictPath = ic.options().get<std::string>("ctf-dict");
-  mCTFCoder.setMemMarginFactor(ic.options().get<float>("mem-factor"));
-  if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
-  }
+  mCTFCoder.init<CTF>(ic);
 }
 
 void EntropyEncoderSpec::run(ProcessingContext& pc)
 {
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
+  mCTFCoder.updateTimeDependentParams(pc);
   auto rofs = pc.inputs().get<gsl::span<o2::mch::ROFRecord>>("rofs");
   auto digits = pc.inputs().get<gsl::span<o2::mch::Digit>>("digits");
 
   auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"MCH", "CTFDATA", 0, Lifetime::Timeframe});
   mCTFCoder.encode(buffer, rofs, digits);
-  auto eeb = CTF::get(buffer.data()); // cast to container pointer
-  eeb->compactify();                  // eliminate unnecessary padding
-  buffer.resize(eeb->size());         // shrink buffer to strictly necessary size
-  //  eeb->print();
+  auto sz = mCTFCoder.finaliseCTFOutput<CTF>(buffer);
   mTimer.Stop();
   LOG(info) << fmt::format("Created encoded data ({} digits and {} rofs) of size {} ({:5.1f} MB) for MCH in {:5.1f} s ",
-                           digits.size(), rofs.size(), eeb->size(), eeb->size() / 1024.0 / 1024, mTimer.CpuTime() - cput);
+                           digits.size(), rofs.size(), sz, sz / 1024.0 / 1024, mTimer.CpuTime() - cput);
 }
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
@@ -85,13 +88,14 @@ DataProcessorSpec getEntropyEncoderSpec(const char* specName)
   std::vector<InputSpec> inputs;
   inputs.emplace_back("rofs", "MCH", "DIGITROFS", 0, Lifetime::Timeframe);
   inputs.emplace_back("digits", "MCH", "DIGITS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("ctfdict", "MCH", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("MCH/Calib/CTFDictionary"));
 
   return DataProcessorSpec{
     specName,
     inputs,
     Outputs{{"MCH", "CTFDATA", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<EntropyEncoderSpec>()},
-    Options{{"ctf-dict", VariantType::String, o2::base::NameConf::getCTFDictFileName(), {"Path to pre-computed CTF encoding dictionary to be used for encoding"}},
+    Options{{"ctf-dict", VariantType::String, "", {"CTF dictionary: empty=CCDB, none=no external dictionary otherwise: local filename"}},
             {"mem-factor", VariantType::Float, 1.f, {"Memory allocation margin factor"}}}};
 }
 

--- a/Detectors/MUON/MID/CTF/include/MIDCTF/CTFCoder.h
+++ b/Detectors/MUON/MID/CTF/include/MIDCTF/CTFCoder.h
@@ -38,7 +38,7 @@ namespace mid
 class CTFCoder : public o2::ctf::CTFCoderBase
 {
  public:
-  CTFCoder() : o2::ctf::CTFCoderBase(CTF::getNBlocks(), o2::detectors::DetID::MID) {}
+  CTFCoder(o2::ctf::CTFCoderBase::OpType op) : o2::ctf::CTFCoderBase(op, CTF::getNBlocks(), o2::detectors::DetID::MID) {}
   ~CTFCoder() final = default;
 
   /// entropy-encode data to buffer with CTF

--- a/Detectors/MUON/MID/Workflow/include/MIDWorkflow/EntropyDecoderSpec.h
+++ b/Detectors/MUON/MID/Workflow/include/MIDWorkflow/EntropyDecoderSpec.h
@@ -33,6 +33,7 @@ class EntropyDecoderSpec : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) final;
   void init(o2::framework::InitContext& ic) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
   o2::mid::CTFCoder mCTFCoder;

--- a/Detectors/MUON/MID/Workflow/include/MIDWorkflow/EntropyEncoderSpec.h
+++ b/Detectors/MUON/MID/Workflow/include/MIDWorkflow/EntropyEncoderSpec.h
@@ -34,6 +34,7 @@ class EntropyEncoderSpec : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) final;
   void init(o2::framework::InitContext& ic) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
   o2::mid::CTFCoder mCTFCoder;

--- a/Detectors/MUON/MID/Workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/EntropyDecoderSpec.cxx
@@ -26,19 +26,23 @@ namespace o2
 namespace mid
 {
 
-EntropyDecoderSpec::EntropyDecoderSpec(int verbosity)
+EntropyDecoderSpec::EntropyDecoderSpec(int verbosity) : mCTFCoder(o2::ctf::CTFCoderBase::OpType::Decoder)
 {
   mTimer.Stop();
   mTimer.Reset();
   mCTFCoder.setVerbosity(verbosity);
 }
 
+void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+{
+  if (mCTFCoder.finaliseCCDB<CTF>(matcher, obj)) {
+    return;
+  }
+}
+
 void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
 {
-  std::string dictPath = ic.options().get<std::string>("ctf-dict");
-  if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
-  }
+  mCTFCoder.init<CTF>(ic);
 }
 
 void EntropyDecoderSpec::run(ProcessingContext& pc)
@@ -46,6 +50,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
 
+  mCTFCoder.updateTimeDependentParams(pc);
   auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
   std::array<std::vector<o2::mid::ROFRecord>, NEvTypes> rofs{};
   std::array<std::vector<o2::mid::ColumnData>, NEvTypes> cols{};
@@ -86,7 +91,7 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
     Inputs{InputSpec{"ctf", "MID", "CTFDATA", sspec, Lifetime::Timeframe}},
     outputs,
     AlgorithmSpec{adaptFromTask<EntropyDecoderSpec>(verbosity)},
-    Options{{"ctf-dict", VariantType::String, o2::base::NameConf::getCTFDictFileName(), {"File of CTF decoding dictionary"}}}};
+    Options{{"ctf-dict", VariantType::String, "", {"CTF dictionary: empty=CCDB, none=no external dictionary otherwise: local filename"}}}};
 }
 
 } // namespace mid

--- a/Detectors/MUON/MID/Workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/EntropyEncoderSpec.cxx
@@ -19,6 +19,7 @@
 #include <unordered_map>
 #include "Framework/ControlService.h"
 #include "Framework/ConfigParamRegistry.h"
+#include "Framework/CCDBParamSpec.h"
 #include "Framework/DataRef.h"
 #include "Framework/InputRecordWalker.h"
 #include "Headers/DataHeader.h"
@@ -32,26 +33,29 @@ namespace o2
 namespace mid
 {
 
-EntropyEncoderSpec::EntropyEncoderSpec()
+EntropyEncoderSpec::EntropyEncoderSpec() : mCTFCoder(o2::ctf::CTFCoderBase::OpType::Encoder)
 {
   mTimer.Stop();
   mTimer.Reset();
 }
 
+void EntropyEncoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+{
+  if (mCTFCoder.finaliseCCDB<CTF>(matcher, obj)) {
+    return;
+  }
+}
+
 void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
 {
-  std::string dictPath = ic.options().get<std::string>("ctf-dict");
-  mCTFCoder.setMemMarginFactor(ic.options().get<float>("mem-factor"));
-  if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
-  }
+  mCTFCoder.init<CTF>(ic);
 }
 
 void EntropyEncoderSpec::run(ProcessingContext& pc)
 {
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
-
+  mCTFCoder.updateTimeDependentParams(pc);
   CTFHelper::TFData tfData;
   std::vector<InputSpec>
     filter = {
@@ -75,12 +79,9 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
 
   auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{header::gDataOriginMID, "CTFDATA", 0, Lifetime::Timeframe});
   mCTFCoder.encode(buffer, tfData);
-  auto eeb = CTF::get(buffer.data()); // cast to container pointer
-  eeb->compactify();                  // eliminate unnecessary padding
-  buffer.resize(eeb->size());         // shrink buffer to strictly necessary size
-  //  eeb->print();
+  auto sz = mCTFCoder.finaliseCTFOutput<CTF>(buffer);
   mTimer.Stop();
-  LOG(info) << "Created encoded data of size " << eeb->size() << " for MID in " << mTimer.CpuTime() - cput << " s";
+  LOG(info) << "Created encoded data of size " << sz << " for MID in " << mTimer.CpuTime() - cput << " s";
 }
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
@@ -94,13 +95,14 @@ DataProcessorSpec getEntropyEncoderSpec()
   std::vector<InputSpec> inputs;
   inputs.emplace_back("rofs", ConcreteDataTypeMatcher(header::gDataOriginMID, "DATAROF"), Lifetime::Timeframe);
   inputs.emplace_back("cols", ConcreteDataTypeMatcher(header::gDataOriginMID, "DATA"), Lifetime::Timeframe);
+  inputs.emplace_back("ctfdict", header::gDataOriginMID, "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("MID/Calib/CTFDictionary"));
 
   return DataProcessorSpec{
     "mid-entropy-encoder",
     inputs,
     Outputs{{header::gDataOriginMID, "CTFDATA", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<EntropyEncoderSpec>()},
-    Options{{"ctf-dict", VariantType::String, o2::base::NameConf::getCTFDictFileName(), {"File of CTF encoding dictionary"}},
+    Options{{"ctf-dict", VariantType::String, "", {"CTF dictionary: empty=CCDB, none=no external dictionary otherwise: local filename"}},
             {"mem-factor", VariantType::Float, 1.f, {"Memory allocation margin factor"}}}};
 }
 

--- a/Detectors/PHOS/reconstruction/include/PHOSReconstruction/CTFCoder.h
+++ b/Detectors/PHOS/reconstruction/include/PHOSReconstruction/CTFCoder.h
@@ -36,7 +36,7 @@ namespace phos
 class CTFCoder : public o2::ctf::CTFCoderBase
 {
  public:
-  CTFCoder() : o2::ctf::CTFCoderBase(CTF::getNBlocks(), o2::detectors::DetID::PHS) {}
+  CTFCoder(o2::ctf::CTFCoderBase::OpType op) : o2::ctf::CTFCoderBase(op, CTF::getNBlocks(), o2::detectors::DetID::PHS) {}
   ~CTFCoder() final = default;
 
   /// entropy-encode data to buffer with CTF

--- a/Detectors/PHOS/workflow/include/PHOSWorkflow/EntropyDecoderSpec.h
+++ b/Detectors/PHOS/workflow/include/PHOSWorkflow/EntropyDecoderSpec.h
@@ -33,6 +33,7 @@ class EntropyDecoderSpec : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) final;
   void init(o2::framework::InitContext& ic) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
   o2::phos::CTFCoder mCTFCoder;

--- a/Detectors/PHOS/workflow/include/PHOSWorkflow/EntropyEncoderSpec.h
+++ b/Detectors/PHOS/workflow/include/PHOSWorkflow/EntropyEncoderSpec.h
@@ -33,6 +33,7 @@ class EntropyEncoderSpec : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) final;
   void init(o2::framework::InitContext& ic) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
   o2::phos::CTFCoder mCTFCoder;

--- a/Detectors/PHOS/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/PHOS/workflow/src/EntropyDecoderSpec.cxx
@@ -24,19 +24,23 @@ namespace o2
 namespace phos
 {
 
-EntropyDecoderSpec::EntropyDecoderSpec(int verbosity)
+EntropyDecoderSpec::EntropyDecoderSpec(int verbosity) : mCTFCoder(o2::ctf::CTFCoderBase::OpType::Decoder)
 {
   mTimer.Stop();
   mTimer.Reset();
   mCTFCoder.setVerbosity(verbosity);
 }
 
+void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+{
+  if (mCTFCoder.finaliseCCDB<CTF>(matcher, obj)) {
+    return;
+  }
+}
+
 void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
 {
-  std::string dictPath = ic.options().get<std::string>("ctf-dict");
-  if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
-  }
+  mCTFCoder.init<CTF>(ic);
 }
 
 void EntropyDecoderSpec::run(ProcessingContext& pc)
@@ -44,6 +48,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
 
+  mCTFCoder.updateTimeDependentParams(pc);
   auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
 
   auto& triggers = pc.outputs().make<std::vector<TriggerRecord>>(OutputRef{"triggers"});
@@ -76,7 +81,7 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
     Inputs{InputSpec{"ctf", "PHS", "CTFDATA", sspec, Lifetime::Timeframe}},
     outputs,
     AlgorithmSpec{adaptFromTask<EntropyDecoderSpec>(verbosity)},
-    Options{{"ctf-dict", VariantType::String, o2::base::NameConf::getCTFDictFileName(), {"File of CTF decoding dictionary"}}}};
+    Options{{"ctf-dict", VariantType::String, "", {"CTF dictionary: empty=CCDB, none=no external dictionary otherwise: local filename"}}}};
 }
 
 } // namespace phos

--- a/Detectors/PHOS/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/PHOS/workflow/src/EntropyEncoderSpec.cxx
@@ -15,6 +15,7 @@
 
 #include "Framework/ControlService.h"
 #include "Framework/ConfigParamRegistry.h"
+#include "Framework/CCDBParamSpec.h"
 #include "PHOSWorkflow/EntropyEncoderSpec.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 
@@ -25,36 +26,37 @@ namespace o2
 namespace phos
 {
 
-EntropyEncoderSpec::EntropyEncoderSpec()
+EntropyEncoderSpec::EntropyEncoderSpec() : mCTFCoder(o2::ctf::CTFCoderBase::OpType::Encoder)
 {
   mTimer.Stop();
   mTimer.Reset();
 }
 
+void EntropyEncoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+{
+  if (mCTFCoder.finaliseCCDB<CTF>(matcher, obj)) {
+    return;
+  }
+}
+
 void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
 {
-  std::string dictPath = ic.options().get<std::string>("ctf-dict");
-  mCTFCoder.setMemMarginFactor(ic.options().get<float>("mem-factor"));
-  if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
-  }
+  mCTFCoder.init<CTF>(ic);
 }
 
 void EntropyEncoderSpec::run(ProcessingContext& pc)
 {
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
+  mCTFCoder.updateTimeDependentParams(pc);
   auto triggers = pc.inputs().get<gsl::span<TriggerRecord>>("triggers");
   auto cells = pc.inputs().get<gsl::span<Cell>>("cells");
 
   auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"PHS", "CTFDATA", 0, Lifetime::Timeframe});
   mCTFCoder.encode(buffer, triggers, cells);
-  auto eeb = CTF::get(buffer.data()); // cast to container pointer
-  eeb->compactify();                  // eliminate unnecessary padding
-  buffer.resize(eeb->size());         // shrink buffer to strictly necessary size
-  //  eeb->print();
+  auto sz = mCTFCoder.finaliseCTFOutput<CTF>(buffer);
   mTimer.Stop();
-  LOG(info) << "Created encoded data of size " << eeb->size() << " for PHOS in " << mTimer.CpuTime() - cput << " s";
+  LOG(info) << "Created encoded data of size " << sz << " for PHOS in " << mTimer.CpuTime() - cput << " s";
 }
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
@@ -68,13 +70,14 @@ DataProcessorSpec getEntropyEncoderSpec()
   std::vector<InputSpec> inputs;
   inputs.emplace_back("triggers", "PHS", "CELLTRIGREC", 0, Lifetime::Timeframe);
   inputs.emplace_back("cells", "PHS", "CELLS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("ctfdict", "PHS", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("PHS/Calib/CTFDictionary"));
 
   return DataProcessorSpec{
     "phos-entropy-encoder",
     inputs,
     Outputs{{"PHS", "CTFDATA", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<EntropyEncoderSpec>()},
-    Options{{"ctf-dict", VariantType::String, o2::base::NameConf::getCTFDictFileName(), {"File of CTF encoding dictionary"}},
+    Options{{"ctf-dict", VariantType::String, "", {"CTF dictionary: empty=CCDB, none=no external dictionary otherwise: local filename"}},
             {"mem-factor", VariantType::Float, 1.f, {"Memory allocation margin factor"}}}};
 }
 

--- a/Detectors/TOF/reconstruction/include/TOFReconstruction/CTFCoder.h
+++ b/Detectors/TOF/reconstruction/include/TOFReconstruction/CTFCoder.h
@@ -35,7 +35,7 @@ namespace tof
 class CTFCoder : public o2::ctf::CTFCoderBase
 {
  public:
-  CTFCoder() : o2::ctf::CTFCoderBase(CTF::getNBlocks(), o2::detectors::DetID::TOF) {}
+  CTFCoder(o2::ctf::CTFCoderBase::OpType op) : o2::ctf::CTFCoderBase(op, CTF::getNBlocks(), o2::detectors::DetID::TOF) {}
   ~CTFCoder() final = default;
 
   /// entropy-encode clusters to buffer with CTF

--- a/Detectors/TOF/workflow/include/TOFWorkflowUtils/EntropyDecoderSpec.h
+++ b/Detectors/TOF/workflow/include/TOFWorkflowUtils/EntropyDecoderSpec.h
@@ -34,6 +34,7 @@ class EntropyDecoderSpec : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) final;
   void init(o2::framework::InitContext& ic) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
   o2::tof::CTFCoder mCTFCoder;

--- a/Detectors/TOF/workflow/include/TOFWorkflowUtils/EntropyEncoderSpec.h
+++ b/Detectors/TOF/workflow/include/TOFWorkflowUtils/EntropyEncoderSpec.h
@@ -34,6 +34,7 @@ class EntropyEncoderSpec : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) final;
   void init(o2::framework::InitContext& ic) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
   o2::tof::CTFCoder mCTFCoder;

--- a/Detectors/TOF/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/TOF/workflow/src/EntropyDecoderSpec.cxx
@@ -24,19 +24,23 @@ namespace o2
 namespace tof
 {
 
-EntropyDecoderSpec::EntropyDecoderSpec(int verbosity)
+EntropyDecoderSpec::EntropyDecoderSpec(int verbosity) : mCTFCoder(o2::ctf::CTFCoderBase::OpType::Decoder)
 {
   mTimer.Stop();
   mTimer.Reset();
   mCTFCoder.setVerbosity(verbosity);
 }
 
+void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+{
+  if (mCTFCoder.finaliseCCDB<CTF>(matcher, obj)) {
+    return;
+  }
+}
+
 void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
 {
-  std::string dictPath = ic.options().get<std::string>("ctf-dict");
-  if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
-  }
+  mCTFCoder.init<CTF>(ic);
 }
 
 void EntropyDecoderSpec::run(ProcessingContext& pc)
@@ -44,6 +48,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
 
+  mCTFCoder.updateTimeDependentParams(pc);
   auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
 
   auto& digitheader = pc.outputs().make<DigitHeader>(OutputRef{"digitheader"});
@@ -94,7 +99,7 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
     Inputs{InputSpec{"ctf", o2::header::gDataOriginTOF, "CTFDATA", sspec, Lifetime::Timeframe}},
     outputs,
     AlgorithmSpec{adaptFromTask<EntropyDecoderSpec>(verbosity)},
-    Options{{"ctf-dict", VariantType::String, o2::base::NameConf::getCTFDictFileName(), {"File of CTF decoding dictionary"}}}};
+    Options{{"ctf-dict", VariantType::String, "", {"CTF dictionary: empty=CCDB, none=no external dictionary otherwise: local filename"}}}};
 }
 
 } // namespace tof

--- a/Detectors/TOF/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/TOF/workflow/src/EntropyEncoderSpec.cxx
@@ -15,6 +15,7 @@
 
 #include "Framework/ControlService.h"
 #include "Framework/ConfigParamRegistry.h"
+#include "Framework/CCDBParamSpec.h"
 #include "TOFBase/Digit.h"
 #include "TOFWorkflowUtils/EntropyEncoderSpec.h"
 
@@ -25,37 +26,38 @@ namespace o2
 namespace tof
 {
 
-EntropyEncoderSpec::EntropyEncoderSpec()
+EntropyEncoderSpec::EntropyEncoderSpec() : mCTFCoder(o2::ctf::CTFCoderBase::OpType::Encoder)
 {
   mTimer.Stop();
   mTimer.Reset();
 }
 
+void EntropyEncoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+{
+  if (mCTFCoder.finaliseCCDB<CTF>(matcher, obj)) {
+    return;
+  }
+}
+
 void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
 {
-  std::string dictPath = ic.options().get<std::string>("ctf-dict");
-  mCTFCoder.setMemMarginFactor(ic.options().get<float>("mem-factor"));
-  if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
-  }
+  mCTFCoder.init<CTF>(ic);
 }
 
 void EntropyEncoderSpec::run(ProcessingContext& pc)
 {
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
+  mCTFCoder.updateTimeDependentParams(pc);
   auto compDigits = pc.inputs().get<gsl::span<Digit>>("compDigits");
   auto pspan = pc.inputs().get<gsl::span<uint8_t>>("patterns");
   auto rofs = pc.inputs().get<gsl::span<ReadoutWindowData>>("ROframes");
 
   auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{o2::header::gDataOriginTOF, "CTFDATA", 0, Lifetime::Timeframe});
   mCTFCoder.encode(buffer, rofs, compDigits, pspan);
-  auto eeb = CTF::get(buffer.data()); // cast to container pointer
-  eeb->compactify();                  // eliminate unnecessary padding
-  buffer.resize(eeb->size());         // shrink buffer to strictly necessary size
-  //  eeb->print();
+  auto sz = mCTFCoder.finaliseCTFOutput<CTF>(buffer);
   mTimer.Stop();
-  LOG(debug) << "Created encoded data of size " << eeb->size() << " for TOF in " << mTimer.CpuTime() - cput << " s";
+  LOG(debug) << "Created encoded data of size " << sz << " for TOF in " << mTimer.CpuTime() - cput << " s";
 }
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
@@ -70,13 +72,14 @@ DataProcessorSpec getEntropyEncoderSpec()
   inputs.emplace_back("compDigits", o2::header::gDataOriginTOF, "DIGITS", 0, Lifetime::Timeframe);
   inputs.emplace_back("patterns", o2::header::gDataOriginTOF, "PATTERNS", 0, Lifetime::Timeframe);
   inputs.emplace_back("ROframes", o2::header::gDataOriginTOF, "READOUTWINDOW", 0, Lifetime::Timeframe);
+  inputs.emplace_back("ctfdict", "TOF", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("TOF/Calib/CTFDictionary"));
 
   return DataProcessorSpec{
     "tof-entropy-encoder",
     inputs,
     Outputs{{o2::header::gDataOriginTOF, "CTFDATA", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<EntropyEncoderSpec>()},
-    Options{{"ctf-dict", VariantType::String, o2::base::NameConf::getCTFDictFileName(), {"File of CTF encoding dictionary"}},
+    Options{{"ctf-dict", VariantType::String, "", {"CTF dictionary: empty=CCDB, none=no external dictionary otherwise: local filename"}},
             {"mem-factor", VariantType::Float, 1.f, {"Memory allocation margin factor"}}}};
 }
 

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/CTFCoder.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/CTFCoder.h
@@ -102,7 +102,8 @@ struct MergedColumnsDecoder {
 class CTFCoder : public o2::ctf::CTFCoderBase
 {
  public:
-  CTFCoder() : o2::ctf::CTFCoderBase(CTF::getNBlocks(), o2::detectors::DetID::TPC) {}
+  CTFCoder(o2::ctf::CTFCoderBase::OpType op) : o2::ctf::CTFCoderBase(op, CTF::getNBlocks(), o2::detectors::DetID::TPC) {}
+  ~CTFCoder() final = default;
 
   /// entropy-encode compressed clusters to flat buffer
   template <typename VEC>

--- a/Detectors/TPC/workflow/include/TPCWorkflow/EntropyDecoderSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/EntropyDecoderSpec.h
@@ -28,7 +28,7 @@ namespace tpc
 class EntropyDecoderSpec : public o2::framework::Task
 {
  public:
-  EntropyDecoderSpec(int verbosity)
+  EntropyDecoderSpec(int verbosity) : mCTFCoder(o2::ctf::CTFCoderBase::OpType::Decoder)
   {
     mTimer.Stop();
     mTimer.Reset();
@@ -38,6 +38,7 @@ class EntropyDecoderSpec : public o2::framework::Task
   void init(o2::framework::InitContext& ic) final;
   void run(o2::framework::ProcessingContext& pc) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
   o2::tpc::CTFCoder mCTFCoder;

--- a/Detectors/TPC/workflow/include/TPCWorkflow/EntropyEncoderSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/EntropyEncoderSpec.h
@@ -29,7 +29,7 @@ namespace tpc
 class EntropyEncoderSpec : public o2::framework::Task
 {
  public:
-  EntropyEncoderSpec(bool fromFile) : mFromFile(fromFile)
+  EntropyEncoderSpec(bool fromFile) : mCTFCoder(o2::ctf::CTFCoderBase::OpType::Encoder), mFromFile(fromFile)
   {
     mTimer.Stop();
     mTimer.Reset();
@@ -38,6 +38,7 @@ class EntropyEncoderSpec : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) final;
   void init(o2::framework::InitContext& ic) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
   o2::tpc::CTFCoder mCTFCoder;

--- a/Detectors/TPC/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/TPC/workflow/src/EntropyEncoderSpec.cxx
@@ -17,6 +17,7 @@
 #include "TPCWorkflow/EntropyEncoderSpec.h"
 #include "DataFormatsTPC/CompressedClusters.h"
 #include "Framework/ConfigParamRegistry.h"
+#include "Framework/CCDBParamSpec.h"
 #include "Headers/DataHeader.h"
 
 using namespace o2::framework;
@@ -27,18 +28,22 @@ namespace o2
 namespace tpc
 {
 
+void EntropyEncoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+{
+  if (mCTFCoder.finaliseCCDB<CTF>(matcher, obj)) {
+    return;
+  }
+}
+
 void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
 {
+  mCTFCoder.init<CTF>(ic);
   mCTFCoder.setCombineColumns(!ic.options().get<bool>("no-ctf-columns-combining"));
-  mCTFCoder.setMemMarginFactor(ic.options().get<float>("mem-factor"));
-  std::string dictPath = ic.options().get<std::string>("ctf-dict");
-  if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
-  }
 }
 
 void EntropyEncoderSpec::run(ProcessingContext& pc)
 {
+  mCTFCoder.updateTimeDependentParams(pc);
   CompressedClusters clusters;
 
   if (mFromFile) {
@@ -61,12 +66,9 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
 
   auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"TPC", "CTFDATA", 0, Lifetime::Timeframe});
   mCTFCoder.encode(buffer, clusters);
-  auto encodedBlocks = CTF::get(buffer.data()); // cast to container pointer
-  encodedBlocks->compactify();                  // eliminate unnecessary padding
-  buffer.resize(encodedBlocks->size());         // shrink buffer to strictly necessary size
-  // encodedBlocks->print();
+  auto sz = mCTFCoder.finaliseCTFOutput<CTF>(buffer);
   mTimer.Stop();
-  LOG(info) << "Created encoded data of size " << encodedBlocks->size() << " for TPC in " << mTimer.CpuTime() - cput << " s";
+  LOG(info) << "Created encoded data of size " << sz << " for TPC in " << mTimer.CpuTime() - cput << " s";
 }
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
@@ -79,12 +81,15 @@ DataProcessorSpec getEntropyEncoderSpec(bool inputFromFile)
 {
   std::vector<InputSpec> inputs;
   header::DataDescription inputType = inputFromFile ? header::DataDescription("COMPCLUSTERS") : header::DataDescription("COMPCLUSTERSFLAT");
+  inputs.emplace_back("input", "TPC", inputType, 0, Lifetime::Timeframe);
+  inputs.emplace_back("ctfdict", "TPC", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("TPC/Calib/CTFDictionary"));
+
   return DataProcessorSpec{
     "tpc-entropy-encoder", // process id
-    Inputs{{"input", "TPC", inputType, 0, Lifetime::Timeframe}},
+    inputs,
     Outputs{{"TPC", "CTFDATA", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<EntropyEncoderSpec>(inputFromFile)},
-    Options{{"ctf-dict", VariantType::String, o2::base::NameConf::getCTFDictFileName(), {"File of CTF encoding dictionary"}},
+    Options{{"ctf-dict", VariantType::String, "", {"CTF dictionary: empty=CCDB, none=no external dictionary otherwise: local filename"}},
             {"no-ctf-columns-combining", VariantType::Bool, false, {"Do not combine correlated columns in CTF"}},
             {"mem-factor", VariantType::Float, 1.f, {"Memory allocation margin factor"}}}};
 }

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CTFCoder.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CTFCoder.h
@@ -36,7 +36,7 @@ namespace trd
 class CTFCoder : public o2::ctf::CTFCoderBase
 {
  public:
-  CTFCoder() : o2::ctf::CTFCoderBase(CTF::getNBlocks(), o2::detectors::DetID::TRD) {}
+  CTFCoder(o2::ctf::CTFCoderBase::OpType op) : o2::ctf::CTFCoderBase(op, CTF::getNBlocks(), o2::detectors::DetID::TRD) {}
   ~CTFCoder() final = default;
 
   /// entropy-encode data to buffer with CTF

--- a/Detectors/TRD/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/TRD/workflow/src/EntropyDecoderSpec.cxx
@@ -34,25 +34,30 @@ class EntropyDecoderSpec : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) final;
   void init(o2::framework::InitContext& ic) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
   o2::trd::CTFCoder mCTFCoder;
   TStopwatch mTimer;
 };
 
-EntropyDecoderSpec::EntropyDecoderSpec(int verbosity)
+EntropyDecoderSpec::EntropyDecoderSpec(int verbosity) : mCTFCoder(o2::ctf::CTFCoderBase::OpType::Decoder)
 {
   mTimer.Stop();
   mTimer.Reset();
   mCTFCoder.setVerbosity(verbosity);
 }
 
+void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+{
+  if (mCTFCoder.finaliseCCDB<CTF>(matcher, obj)) {
+    return;
+  }
+}
+
 void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
 {
-  std::string dictPath = ic.options().get<std::string>("ctf-dict");
-  if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
-  }
+  mCTFCoder.init<CTF>(ic);
 }
 
 void EntropyDecoderSpec::run(ProcessingContext& pc)
@@ -60,6 +65,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
 
+  mCTFCoder.updateTimeDependentParams(pc);
   auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
 
   auto& triggers = pc.outputs().make<std::vector<TriggerRecord>>(OutputRef{"triggers"});
@@ -94,7 +100,7 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
     Inputs{InputSpec{"ctf", "TRD", "CTFDATA", sspec, Lifetime::Timeframe}},
     outputs,
     AlgorithmSpec{adaptFromTask<EntropyDecoderSpec>(verbosity)},
-    Options{{"ctf-dict", VariantType::String, o2::base::NameConf::getCTFDictFileName(), {"File of CTF decoding dictionary"}}}};
+    Options{{"ctf-dict", VariantType::String, "", {"CTF dictionary: empty=CCDB, none=no external dictionary otherwise: local filename"}}}};
 }
 
 } // namespace trd

--- a/Detectors/TRD/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/TRD/workflow/src/EntropyEncoderSpec.cxx
@@ -15,6 +15,7 @@
 
 #include "Framework/ControlService.h"
 #include "Framework/ConfigParamRegistry.h"
+#include "Framework/CCDBParamSpec.h"
 #include "TRDWorkflow/EntropyEncoderSpec.h"
 #include "TRDReconstruction/CTFCoder.h"
 #include "DetectorsCommonDataFormats/DetID.h"
@@ -35,43 +36,45 @@ class EntropyEncoderSpec : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) final;
   void init(o2::framework::InitContext& ic) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
   o2::trd::CTFCoder mCTFCoder;
   TStopwatch mTimer;
 };
 
-EntropyEncoderSpec::EntropyEncoderSpec()
+EntropyEncoderSpec::EntropyEncoderSpec() : mCTFCoder(o2::ctf::CTFCoderBase::OpType::Encoder)
 {
   mTimer.Stop();
   mTimer.Reset();
 }
 
+void EntropyEncoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+{
+  if (mCTFCoder.finaliseCCDB<CTF>(matcher, obj)) {
+    return;
+  }
+}
+
 void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
 {
-  std::string dictPath = ic.options().get<std::string>("ctf-dict");
-  mCTFCoder.setMemMarginFactor(ic.options().get<float>("mem-factor"));
-  if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
-  }
+  mCTFCoder.init<CTF>(ic);
 }
 
 void EntropyEncoderSpec::run(ProcessingContext& pc)
 {
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
+  mCTFCoder.updateTimeDependentParams(pc);
   auto triggers = pc.inputs().get<gsl::span<TriggerRecord>>("triggers");
   auto tracklets = pc.inputs().get<gsl::span<Tracklet64>>("tracklets");
   auto digits = pc.inputs().get<gsl::span<Digit>>("digits");
 
   auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"TRD", "CTFDATA", 0, Lifetime::Timeframe});
   mCTFCoder.encode(buffer, triggers, tracklets, digits);
-  auto eeb = CTF::get(buffer.data()); // cast to container pointer
-  eeb->compactify();                  // eliminate unnecessary padding
-  buffer.resize(eeb->size());         // shrink buffer to strictly necessary size
-  //  eeb->print();
+  auto sz = mCTFCoder.finaliseCTFOutput<CTF>(buffer);
   mTimer.Stop();
-  LOG(info) << "Created encoded data of size " << eeb->size() << " for TRD in " << mTimer.CpuTime() - cput << " s";
+  LOG(info) << "Created encoded data of size " << sz << " for TRD in " << mTimer.CpuTime() - cput << " s";
 }
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
@@ -86,13 +89,14 @@ DataProcessorSpec getEntropyEncoderSpec()
   inputs.emplace_back("triggers", "TRD", "TRKTRGRD", 0, Lifetime::Timeframe);
   inputs.emplace_back("tracklets", "TRD", "TRACKLETS", 0, Lifetime::Timeframe);
   inputs.emplace_back("digits", "TRD", "DIGITS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("ctfdict", "TRD", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("TRD/Calib/CTFDictionary"));
 
   return DataProcessorSpec{
     "trd-entropy-encoder",
     inputs,
     Outputs{{"TRD", "CTFDATA", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<EntropyEncoderSpec>()},
-    Options{{"ctf-dict", VariantType::String, o2::base::NameConf::getCTFDictFileName(), {"File of CTF encoding dictionary"}},
+    Options{{"ctf-dict", VariantType::String, "", {"CTF dictionary: empty=CCDB, none=no external dictionary otherwise: local filename"}},
             {"mem-factor", VariantType::Float, 1.f, {"Memory allocation margin factor"}}}};
 }
 

--- a/Detectors/ZDC/reconstruction/include/ZDCReconstruction/CTFCoder.h
+++ b/Detectors/ZDC/reconstruction/include/ZDCReconstruction/CTFCoder.h
@@ -36,7 +36,7 @@ namespace zdc
 class CTFCoder : public o2::ctf::CTFCoderBase
 {
  public:
-  CTFCoder() : o2::ctf::CTFCoderBase(CTF::getNBlocks(), o2::detectors::DetID::ZDC) {}
+  CTFCoder(o2::ctf::CTFCoderBase::OpType op) : o2::ctf::CTFCoderBase(op, CTF::getNBlocks(), o2::detectors::DetID::ZDC) {}
   ~CTFCoder() final = default;
 
   /// entropy-encode data to buffer with CTF

--- a/Detectors/ZDC/workflow/include/ZDCWorkflow/EntropyDecoderSpec.h
+++ b/Detectors/ZDC/workflow/include/ZDCWorkflow/EntropyDecoderSpec.h
@@ -33,6 +33,7 @@ class EntropyDecoderSpec : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) final;
   void init(o2::framework::InitContext& ic) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
   o2::zdc::CTFCoder mCTFCoder;

--- a/Detectors/ZDC/workflow/include/ZDCWorkflow/EntropyEncoderSpec.h
+++ b/Detectors/ZDC/workflow/include/ZDCWorkflow/EntropyEncoderSpec.h
@@ -34,6 +34,7 @@ class EntropyEncoderSpec : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) final;
   void init(o2::framework::InitContext& ic) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
   o2::zdc::CTFCoder mCTFCoder;

--- a/Detectors/ZDC/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/ZDC/workflow/src/EntropyDecoderSpec.cxx
@@ -24,19 +24,23 @@ namespace o2
 namespace zdc
 {
 
-EntropyDecoderSpec::EntropyDecoderSpec(int verbosity)
+EntropyDecoderSpec::EntropyDecoderSpec(int verbosity) : mCTFCoder(o2::ctf::CTFCoderBase::OpType::Decoder)
 {
   mTimer.Stop();
   mTimer.Reset();
   mCTFCoder.setVerbosity(verbosity);
 }
 
+void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+{
+  if (mCTFCoder.finaliseCCDB<CTF>(matcher, obj)) {
+    return;
+  }
+}
+
 void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
 {
-  std::string dictPath = ic.options().get<std::string>("ctf-dict");
-  if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Decoder);
-  }
+  mCTFCoder.init<CTF>(ic);
 }
 
 void EntropyDecoderSpec::run(ProcessingContext& pc)
@@ -44,6 +48,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
 
+  mCTFCoder.updateTimeDependentParams(pc);
   auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
 
   auto& bcdata = pc.outputs().make<std::vector<o2::zdc::BCData>>(OutputRef{"trig"});
@@ -77,7 +82,7 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
     Inputs{InputSpec{"ctf", "ZDC", "CTFDATA", sspec, Lifetime::Timeframe}},
     outputs,
     AlgorithmSpec{adaptFromTask<EntropyDecoderSpec>(verbosity)},
-    Options{{"ctf-dict", VariantType::String, o2::base::NameConf::getCTFDictFileName(), {"File of CTF decoding dictionary"}}}};
+    Options{{"ctf-dict", VariantType::String, "", {"CTF dictionary: empty=CCDB, none=no external dictionary otherwise: local filename"}}}};
 }
 
 } // namespace zdc

--- a/Detectors/ZDC/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/ZDC/workflow/src/EntropyEncoderSpec.cxx
@@ -17,6 +17,7 @@
 
 #include "Framework/ControlService.h"
 #include "Framework/ConfigParamRegistry.h"
+#include "Framework/CCDBParamSpec.h"
 #include "ZDCWorkflow/EntropyEncoderSpec.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 
@@ -27,37 +28,38 @@ namespace o2
 namespace zdc
 {
 
-EntropyEncoderSpec::EntropyEncoderSpec()
+EntropyEncoderSpec::EntropyEncoderSpec() : mCTFCoder(o2::ctf::CTFCoderBase::OpType::Encoder)
 {
   mTimer.Stop();
   mTimer.Reset();
 }
 
+void EntropyEncoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+{
+  if (mCTFCoder.finaliseCCDB<CTF>(matcher, obj)) {
+    return;
+  }
+}
+
 void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
 {
-  std::string dictPath = ic.options().get<std::string>("ctf-dict");
-  mCTFCoder.setMemMarginFactor(ic.options().get<float>("mem-factor"));
-  if (!dictPath.empty() && dictPath != "none") {
-    mCTFCoder.createCodersFromFile<CTF>(dictPath, o2::ctf::CTFCoderBase::OpType::Encoder);
-  }
+  mCTFCoder.init<CTF>(ic);
 }
 
 void EntropyEncoderSpec::run(ProcessingContext& pc)
 {
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
+  mCTFCoder.updateTimeDependentParams(pc);
   auto bcdata = pc.inputs().get<gsl::span<o2::zdc::BCData>>("trig");
   auto chans = pc.inputs().get<gsl::span<o2::zdc::ChannelData>>("chan");
   auto peds = pc.inputs().get<gsl::span<o2::zdc::OrbitData>>("peds");
 
   auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"ZDC", "CTFDATA", 0, Lifetime::Timeframe});
   mCTFCoder.encode(buffer, bcdata, chans, peds);
-  auto eeb = CTF::get(buffer.data()); // cast to container pointer
-  eeb->compactify();                  // eliminate unnecessary padding
-  buffer.resize(eeb->size());         // shrink buffer to strictly necessary size
-  //  eeb->print();
+  auto sz = mCTFCoder.finaliseCTFOutput<CTF>(buffer);
   mTimer.Stop();
-  LOG(info) << "Created encoded data of size " << eeb->size() << " for ZDC in " << mTimer.CpuTime() - cput << " s";
+  LOG(info) << "Created encoded data of size " << sz << " for ZDC in " << mTimer.CpuTime() - cput << " s";
 }
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
@@ -72,13 +74,14 @@ DataProcessorSpec getEntropyEncoderSpec()
   inputs.emplace_back("trig", "ZDC", "DIGITSBC", 0, Lifetime::Timeframe);
   inputs.emplace_back("chan", "ZDC", "DIGITSCH", 0, Lifetime::Timeframe);
   inputs.emplace_back("peds", "ZDC", "DIGITSPD", 0, Lifetime::Timeframe);
+  inputs.emplace_back("ctfdict", "ZDC", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("ZDC/Calib/CTFDictionary"));
 
   return DataProcessorSpec{
     "zdc-entropy-encoder",
     inputs,
     Outputs{{"ZDC", "CTFDATA", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<EntropyEncoderSpec>()},
-    Options{{"ctf-dict", VariantType::String, o2::base::NameConf::getCTFDictFileName(), {"File of CTF encoding dictionary"}},
+    Options{{"ctf-dict", VariantType::String, "", {"CTF dictionary: empty=CCDB, none=no external dictionary otherwise: local filename"}},
             {"mem-factor", VariantType::Float, 1.f, {"Memory allocation margin factor"}}}};
 }
 

--- a/Framework/Core/include/Framework/ConfigParamRegistry.h
+++ b/Framework/Core/include/Framework/ConfigParamRegistry.h
@@ -62,6 +62,11 @@ class ConfigParamRegistry
     return mStore->store().count(key);
   }
 
+  bool hasOption(const char* key) const
+  {
+    return mStore->store().get_child_optional(key).is_initialized();
+  }
+
   bool isDefault(const char* key) const
   {
     return mStore->store().count(key) > 0 && mStore->provenance(key) != "default";

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -11,7 +11,7 @@ if [ -z $FILEWORKDIRRUN ]; then FILEWORKDIRRUN=$FILEWORKDIR; fi              # d
 #Some additional settings used in this workflow
 if [[ -z $OPTIMIZED_PARALLEL_ASYNC ]]; then OPTIMIZED_PARALLEL_ASYNC=0; fi     # Enable tuned process multiplicities for async processing on the EPN
 if [[ -z $CTF_DIR ]];                  then CTF_DIR=$FILEWORKDIR; fi           # Directory where to store CTFs
-if [[ -z $CTF_DICT_DIR ]];             then CTF_DICT_DIR=$FILEWORKDIR; fi      # Directory of CTF dictionaries
+if [[ -z $CTF_DICT ]];                 then CTF_DICT="ctf_dictionary.root"; fi # Local dictionary file name if its creation is request
 if [[ -z $CTF_METAFILES_DIR ]];        then CTF_METAFILES_DIR="/dev/null"; fi  # Directory where to store CTF files metada, /dev/null : skip their writing
 if [[ -z $RECO_NUM_NODES_WORKFLOW ]];  then RECO_NUM_NODES_WORKFLOW=250; fi    # Number of EPNs running this workflow in parallel, to increase multiplicities if necessary, by default assume we are 1 out of 250 servers
 if [[ -z $CTF_MINSIZE ]];              then CTF_MINSIZE="2000000000"; fi        # accumulate CTFs until file size reached
@@ -27,10 +27,6 @@ fi
 workflow_has_parameter CTF && export SAVECTF=1
 workflow_has_parameter GPU && { export GPUTYPE=HIP; export NGPUS=4; }
 
-[[ -z $ITSCLUSDICT ]] && ITSCLUSDICT="${FILEWORKDIR}/ITSdictionary.bin"
-[[ -z $MFTCLUSDICT ]] && MFTCLUSDICT="${FILEWORKDIR}/MFTdictionary.bin"
-[[ -z $ITS_NOISE ]] && ITS_NOISE="${FILEWORKDIR}"
-[[ -z $MFT_NOISE ]] && MFT_NOISE="${FILEWORKDIR}"
 [[ -z $ITS_STROBE ]] && ITS_STROBE="891"
 [[ -z $MFT_STROBE ]] && MFT_STROBE="198"
 
@@ -43,9 +39,10 @@ if [[ $(uname) == "Darwin" ]]; then
     NITSDECTHREADS=1
     NMFTDECTHREADS=1
 fi
-CTF_DICT=${CTF_DICT_DIR}/ctf_dictionary.root
 
-ITSMFT_FILES="ITSClustererParam.dictFilePath=$ITSCLUSDICT;MFTClustererParam.dictFilePath=$MFTCLUSDICT";
+ITSMFT_STROBES=""
+[[ -z $ITS_STROBE ]] && ITSMFT_STROBES+="ITSAlpideParam.roFrameLengthInBC=$ITS_STROBE;"
+[[ -z $MFT_STROBE ]] && ITSMFT_STROBES+="MFTAlpideParam.roFrameLengthInBC=$MFT_STROBE;"
 
 LIST_OF_ASYNC_RECO_STEPS="MID MCH MFT FDD FV0 ZDC"
 
@@ -160,7 +157,6 @@ has_detector_flp_processing CPV && CPV_INPUT=digits
 
 if [[ $EPNSYNCMODE == 1 ]]; then
   EVE_CONFIG+=" --eve-dds-collection-index 0"
-  ITSMFT_FILES+=";ITSClustererParam.noiseFilePath=$ITS_NOISE;MFTClustererParam.noiseFilePath=$MFT_NOISE;ITSAlpideParam.roFrameLengthInBC=$ITS_STROBE;MFTAlpideParam.roFrameLengthInBC=$MFT_STROBE;"
   MIDDEC_CONFIG+=" --feeId-config-file \"$MID_FEEID_MAP\""
   GPU_CONFIG_KEY+="GPU_proc.tpcIncreasedMinClustersPerRow=500000;GPU_proc.ignoreNonFatalGPUErrors=1;"
   # Options for decoding current TRD real raw data (not needed for data converted from MC)
@@ -337,7 +333,7 @@ if [[ $CTFINPUT == 1 ]]; then
   [[ ! -z $INPUT_FILE_LIST ]] && CTFName=$INPUT_FILE_LIST
   if [[ -z $CTFName && $WORKFLOWMODE != "print" ]]; then echo "No CTF file given!"; exit 1; fi
   if [[ $NTIMEFRAMES == -1 ]]; then NTIMEFRAMES_CMD= ; else NTIMEFRAMES_CMD="--max-tf $NTIMEFRAMES"; fi
-  add_W o2-ctf-reader-workflow "--delay $TFDELAY --loop $TFLOOP $NTIMEFRAMES_CMD --ctf-input ${CTFName} ${INPUT_FILE_COPY_CMD+--copy-cmd} ${INPUT_FILE_COPY_CMD} --ctf-dict ${CTF_DICT} --onlyDet $WORKFLOW_DETECTORS --pipeline $(get_N tpc-entropy-decoder TPC REST 1 TPCENTDEC)"
+  add_W o2-ctf-reader-workflow "--delay $TFDELAY --loop $TFLOOP $NTIMEFRAMES_CMD --ctf-input ${CTFName} ${INPUT_FILE_COPY_CMD+--copy-cmd} ${INPUT_FILE_COPY_CMD} --onlyDet $WORKFLOW_DETECTORS --pipeline $(get_N tpc-entropy-decoder TPC REST 1 TPCENTDEC)"
 elif [[ $RAWTFINPUT == 1 ]]; then
   TFName=`ls -t $RAWINPUTDIR/o2_*.tf 2> /dev/null | head -n1`
   [[ -z $TFName && $WORKFLOWMODE == "print" ]] && TFName='$TFName'
@@ -401,8 +397,8 @@ if [[ $CTFINPUT == 0 && $DIGITINPUT == 0 ]]; then
     add_W o2-tpc-raw-to-digits-workflow "--input-spec \"A:TPC/RAWDATA;dd:FLP/DISTSUBTIMEFRAME/0\" --remove-duplicates --pipeline $(get_N tpc-raw-to-digits-0 TPC RAW 1 TPCRAWDEC)"
     add_W o2-tpc-reco-workflow "--input-type digitizer --output-type zsraw,disable-writer --pipeline $(get_N tpc-zsEncoder TPC RAW 1 TPCRAWDEC)"
   fi
-  has_detector ITS && add_W o2-itsmft-stf-decoder-workflow "--nthreads ${NITSDECTHREADS} --raw-data-dumps $ALPIDE_ERR_DUMPS --pipeline $(get_N its-stf-decoder ITS RAW 1 ITSRAWDEC)" "$ITSMFT_FILES"
-  has_detector MFT && add_W o2-itsmft-stf-decoder-workflow "--nthreads ${NMFTDECTHREADS} --raw-data-dumps $ALPIDE_ERR_DUMPS --pipeline $(get_N mft-stf-decoder MFT RAW 1 MFTRAWDEC) --runmft true" "$ITSMFT_FILES"
+  has_detector ITS && add_W o2-itsmft-stf-decoder-workflow "--nthreads ${NITSDECTHREADS} --raw-data-dumps $ALPIDE_ERR_DUMPS --pipeline $(get_N its-stf-decoder ITS RAW 1 ITSRAWDEC)" "$ITSMFT_STROBES"
+  has_detector MFT && add_W o2-itsmft-stf-decoder-workflow "--nthreads ${NMFTDECTHREADS} --raw-data-dumps $ALPIDE_ERR_DUMPS --pipeline $(get_N mft-stf-decoder MFT RAW 1 MFTRAWDEC) --runmft true" "$ITSMFT_STROBES"
   has_detector FT0 && ! has_detector_flp_processing FT0 && add_W o2-ft0-flp-dpl-workflow "$DISABLE_ROOT_OUTPUT --pipeline $(get_N ft0-datareader-dpl FT0 RAW 1)"
   has_detector FV0 && ! has_detector_flp_processing FV0 && add_W o2-fv0-flp-dpl-workflow "$DISABLE_ROOT_OUTPUT --pipeline $(get_N fv0-datareader-dpl FV0 RAW 1)"
   has_detector MID && add_W o2-mid-raw-to-digits-workflow "$MIDDEC_CONFIG --pipeline $(get_N MIDRawDecoder MID RAW 1),$(get_N MIDDecodedDataAggregator MID RAW 1)"
@@ -422,19 +418,19 @@ fi
 # Common reconstruction workflows
 (has_detector_reco TPC || has_detector_ctf TPC) && WORKFLOW+="o2-gpu-reco-workflow ${ARGS_ALL//-severity $SEVERITY/-severity $SEVERITY_TPC} --input-type=$GPU_INPUT $DISABLE_MC --output-type $GPU_OUTPUT --pipeline gpu-reconstruction:${N_TPCTRK:-1} $GPU_CONFIG $ARGS_EXTRA_PROCESS_o2_gpu_reco_workflow --configKeyValues \"$ARGS_ALL_CONFIG;GPU_global.deviceType=$GPUTYPE;GPU_proc.debugLevel=0;$GPU_CONFIG_KEY;$CONFIG_EXTRA_PROCESS_o2_gpu_reco_workflow\" | "
 (has_detector_reco TOF || has_detector_ctf TOF) && add_W o2-tof-reco-workflow "$TOF_CONFIG --input-type $TOF_INPUT --output-type $TOF_OUTPUT $DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $DISABLE_MC --pipeline $(get_N tof-compressed-decoder TOF RAW 1),$(get_N TOFClusterer TOF REST 1)"
-has_detector_reco ITS && add_W o2-its-reco-workflow "--trackerCA $ITS_CONFIG $DISABLE_MC $DISABLE_DIGIT_CLUSTER_INPUT $DISABLE_ROOT_OUTPUT --pipeline $(get_N its-tracker ITS REST 1 ITSTRK)" "$ITS_CONFIG_KEY;$ITSMFT_FILES"
-has_detectors_reco ITS TPC && has_detector_matching ITSTPC && add_W o2-tpcits-match-workflow "$DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $DISABLE_MC --pipeline $(get_N itstpc-track-matcher MATCH REST 1 TPCITS)" "$ITSMFT_FILES"
+has_detector_reco ITS && add_W o2-its-reco-workflow "--trackerCA $ITS_CONFIG $DISABLE_MC $DISABLE_DIGIT_CLUSTER_INPUT $DISABLE_ROOT_OUTPUT --pipeline $(get_N its-tracker ITS REST 1 ITSTRK)" "$ITS_CONFIG_KEY;$ITSMFT_STROBES"
+has_detectors_reco ITS TPC && has_detector_matching ITSTPC && add_W o2-tpcits-match-workflow "$DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $DISABLE_MC --pipeline $(get_N itstpc-track-matcher MATCH REST 1 TPCITS)" "$ITSMFT_STROBES"
 has_detector_reco FT0 && add_W o2-ft0-reco-workflow "$DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $DISABLE_MC --pipeline $(get_N ft0-reconstructor FT0 REST 1)"
 has_detector_reco TRD && add_W o2-trd-tracklet-transformer "$DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $DISABLE_MC $TRD_FILTER_CONFIG --pipeline $(get_N TRDTRACKLETTRANSFORMER TRD REST 1 TRDTRK)"
-has_detector_reco TRD && [[ ! -z "$TRD_SOURCES" ]] && add_W o2-trd-global-tracking "$DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $DISABLE_MC $TRD_CONFIG $TRD_FILTER_CONFIG --track-sources $TRD_SOURCES" "$TRD_CONFIG_KEY;$ITSMFT_FILES"
-has_detector_reco TOF && [[ ! -z "$TOF_SOURCES" ]] && add_W o2-tof-matcher-workflow "$DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $DISABLE_MC --track-sources $TOF_SOURCES --pipeline $(get_N tof-matcher TOF REST 1 TOFMATCH)" "$ITSMFT_FILES"
+has_detector_reco TRD && [[ ! -z "$TRD_SOURCES" ]] && add_W o2-trd-global-tracking "$DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $DISABLE_MC $TRD_CONFIG $TRD_FILTER_CONFIG --track-sources $TRD_SOURCES" "$TRD_CONFIG_KEY;$ITSMFT_STROBES"
+has_detector_reco TOF && [[ ! -z "$TOF_SOURCES" ]] && add_W o2-tof-matcher-workflow "$DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $DISABLE_MC --track-sources $TOF_SOURCES --pipeline $(get_N tof-matcher TOF REST 1 TOFMATCH)" "$ITSMFT_STROBES"
 has_detectors TPC && [ -z "$DISABLE_ROOT_OUTPUT" ] && add_W o2-tpc-reco-workflow "--input-type pass-through --output-type clusters,tracks,send-clusters-per-sector $DISABLE_MC"
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Reconstruction workflows normally active only in async mode in async mode ($LIST_OF_ASYNC_RECO_STEPS), but can be forced via $WORKFLOW_EXTRA_PROCESSING_STEPS
 has_detector MID && has_processing_step MID_RECO && add_W o2-mid-reco-workflow "$DISABLE_ROOT_OUTPUT $DISABLE_MC --pipeline $(get_N MIDClusterizer MID REST 1),$(get_N MIDTracker MID REST 1)"
 has_detector MCH && has_processing_step MCH_RECO && add_W o2-mch-reco-workflow "$DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $DISABLE_MC --pipeline $(get_N mch-track-finder MCH REST 1 MCHTRK),$(get_N mch-cluster-finder MCH REST 1),$(get_N mch-cluster-transformer MCH REST 1)"
-has_detector MFT && has_processing_step MFT_RECO && add_W o2-mft-reco-workflow "$DISABLE_DIGIT_CLUSTER_INPUT $DISABLE_MC $DISABLE_ROOT_OUTPUT --pipeline $(get_N mft-tracker MFT REST 1 MFTTRK)" "$ITSMFT_FILES"
+has_detector MFT && has_processing_step MFT_RECO && add_W o2-mft-reco-workflow "$DISABLE_DIGIT_CLUSTER_INPUT $DISABLE_MC $DISABLE_ROOT_OUTPUT --pipeline $(get_N mft-tracker MFT REST 1 MFTTRK)" "$ITSMFT_STROBES"
 has_detector FDD && has_processing_step FDD_RECO && add_W o2-fdd-reco-workflow "$DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $DISABLE_MC"
 has_detector FV0 && has_processing_step FV0_RECO && add_W o2-fv0-reco-workflow "$DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $DISABLE_MC"
 has_detector ZDC && has_processing_step ZDC_RECO && add_W o2-zdc-digits-reco "$DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $DISABLE_MC"
@@ -453,36 +449,31 @@ fi
 # Entropy encoding / ctf creation workflows - disabled in async mode
 if has_processing_step ENTROPY_ENCODER && [[ ! -z "$WORKFLOW_DETECTORS_CTF" ]] && [[ $WORKFLOW_DETECTORS_CTF != "NONE" ]]; then
   # Entropy encoder workflows
-  has_detector_ctf MFT && add_W o2-itsmft-entropy-encoder-workflow "--ctf-dict \"${CTF_DICT}\" --mem-factor ${MFT_ENC_MEMFACT:-1.5} --runmft true --pipeline $(get_N mft-entropy-encoder MFT CTF 1)"
-  has_detector_ctf FT0 && add_W o2-ft0-entropy-encoder-workflow "--ctf-dict \"${CTF_DICT}\" --mem-factor ${FT0_ENC_MEMFACT:-1.5} --pipeline $(get_N ft0-entropy-encoder FT0 CTF 1)"
-  has_detector_ctf FV0 && add_W o2-fv0-entropy-encoder-workflow "--ctf-dict \"${CTF_DICT}\" --mem-factor ${FV0_ENC_MEMFACT:-1.5} --pipeline $(get_N fv0-entropy-encoder FV0 CTF 1)"
-  has_detector_ctf MID && add_W o2-mid-entropy-encoder-workflow "--ctf-dict \"${CTF_DICT}\" --mem-factor ${MID_ENC_MEMFACT:-1.5} --pipeline $(get_N mid-entropy-encoder MID CTF 1)"
-  has_detector_ctf MCH && add_W o2-mch-entropy-encoder-workflow "--ctf-dict \"${CTF_DICT}\" --mem-factor ${MCH_ENC_MEMFACT:-1.5} --pipeline $(get_N mch-entropy-encoder MCH CTF 1)"
-  has_detector_ctf PHS && add_W o2-phos-entropy-encoder-workflow "--ctf-dict \"${CTF_DICT}\" --mem-factor ${PHS_ENC_MEMFACT:-1.5} --pipeline $(get_N phos-entropy-encoder PHS CTF 1)"
-  has_detector_ctf CPV && add_W o2-cpv-entropy-encoder-workflow "--ctf-dict \"${CTF_DICT}\" --mem-factor ${CPV_ENC_MEMFACT:-1.5} --pipeline $(get_N cpv-entropy-encoder CPV CTF 1)"
-  has_detector_ctf EMC && add_W o2-emcal-entropy-encoder-workflow "--ctf-dict \"${CTF_DICT}\" --mem-factor ${EMC_ENC_MEMFACT:-1.5} --pipeline $(get_N emcal-entropy-encoder EMC CTF 1)"
-  has_detector_ctf ZDC && add_W o2-zdc-entropy-encoder-workflow "--ctf-dict \"${CTF_DICT}\" --mem-factor ${ZDC_ENC_MEMFACT:-1.5} --pipeline $(get_N zdc-entropy-encoder ZDC CTF 1)"
-  has_detector_ctf FDD && add_W o2-fdd-entropy-encoder-workflow "--ctf-dict \"${CTF_DICT}\" --mem-factor ${FDD_ENC_MEMFACT:-1.5} --pipeline $(get_N fdd-entropy-encoder FDD CTF 1)"
-  has_detector_ctf HMP && add_W o2-hmpid-entropy-encoder-workflow "--ctf-dict \"${CTF_DICT}\" --mem-factor ${HMP_ENC_MEMFACT:-1.5} --pipeline $(get_N hmpid-entropy-encoder HMP CTF 1)"
-  has_detector_ctf TOF && add_W o2-tof-entropy-encoder-workflow "--ctf-dict \"${CTF_DICT}\" --mem-factor ${TOF_ENC_MEMFACT:-1.5} --pipeline $(get_N tof-entropy-encoder TOF CTF 1)"
-  has_detector_ctf ITS && add_W o2-itsmft-entropy-encoder-workflow "--ctf-dict \"${CTF_DICT}\" --mem-factor ${ITS_ENC_MEMFACT:-1.5} --pipeline $(get_N its-entropy-encoder ITS CTF 1)"
-  has_detector_ctf TRD && add_W o2-trd-entropy-encoder-workflow "--ctf-dict \"${CTF_DICT}\" --mem-factor ${TRD_ENC_MEMFACT:-1.5} --pipeline $(get_N trd-entropy-encoder TRD CTF 1 TRDENT)"
-  has_detector_ctf TPC && add_W o2-tpc-reco-workflow "--ctf-dict \"${CTF_DICT}\" --input-type compressed-clusters-flat --output-type encoded-clusters,disable-writer --mem-factor ${TPC_ENC_MEMFACT:-1.5} --pipeline $(get_N tpc-entropy-encoder TPC CTF 1 TPCENT)"
-  has_detector_ctf CTP && add_W o2-ctp-entropy-encoder-workflow "--ctf-dict \"${CTF_DICT}\" --mem-factor ${CTP_ENC_MEMFACT:-1.5} --pipeline $(get_N its-entropy-encoder CTP CTF 1)"
+  has_detector_ctf MFT && add_W o2-itsmft-entropy-encoder-workflow "--runmft true --pipeline $(get_N mft-entropy-encoder MFT CTF 1)"
+  has_detector_ctf FT0 && add_W o2-ft0-entropy-encoder-workflow "--pipeline $(get_N ft0-entropy-encoder FT0 CTF 1)"
+  has_detector_ctf FV0 && add_W o2-fv0-entropy-encoder-workflow "--pipeline $(get_N fv0-entropy-encoder FV0 CTF 1)"
+  has_detector_ctf MID && add_W o2-mid-entropy-encoder-workflow "--pipeline $(get_N mid-entropy-encoder MID CTF 1)"
+  has_detector_ctf MCH && add_W o2-mch-entropy-encoder-workflow "--pipeline $(get_N mch-entropy-encoder MCH CTF 1)"
+  has_detector_ctf PHS && add_W o2-phos-entropy-encoder-workflow "--pipeline $(get_N phos-entropy-encoder PHS CTF 1)"
+  has_detector_ctf CPV && add_W o2-cpv-entropy-encoder-workflow "--pipeline $(get_N cpv-entropy-encoder CPV CTF 1)"
+  has_detector_ctf EMC && add_W o2-emcal-entropy-encoder-workflow "--pipeline $(get_N emcal-entropy-encoder EMC CTF 1)"
+  has_detector_ctf ZDC && add_W o2-zdc-entropy-encoder-workflow "--pipeline $(get_N zdc-entropy-encoder ZDC CTF 1)"
+  has_detector_ctf FDD && add_W o2-fdd-entropy-encoder-workflow "--pipeline $(get_N fdd-entropy-encoder FDD CTF 1)"
+  has_detector_ctf HMP && add_W o2-hmpid-entropy-encoder-workflow "--pipeline $(get_N hmpid-entropy-encoder HMP CTF 1)"
+  has_detector_ctf TOF && add_W o2-tof-entropy-encoder-workflow "--pipeline $(get_N tof-entropy-encoder TOF CTF 1)"
+  has_detector_ctf ITS && add_W o2-itsmft-entropy-encoder-workflow "--pipeline $(get_N its-entropy-encoder ITS CTF 1)"
+  has_detector_ctf TRD && add_W o2-trd-entropy-encoder-workflow "--pipeline $(get_N trd-entropy-encoder TRD CTF 1 TRDENT)"
+  has_detector_ctf TPC && add_W o2-tpc-reco-workflow "--input-type compressed-clusters-flat --output-type encoded-clusters,disable-writer --pipeline $(get_N tpc-entropy-encoder TPC CTF 1 TPCENT)"
+  has_detector_ctf CTP && add_W o2-ctp-entropy-encoder-workflow "--pipeline $(get_N its-entropy-encoder CTP CTF 1)"
 
-  # CTF / dictionary writer workflow
-  if [[ $SAVECTF == 1 && $WORKFLOWMODE == "run" ]]; then
-    mkdir -p $CTF_DIR
-  fi
   if [[ $CREATECTFDICT == 1 && $WORKFLOWMODE == "run" ]] ; then
-    mkdir -p $CTF_DICT_DIR;
-    rm -f $CTF_DICT
+    [[ -f $CTF_DICT ]] && rm -f $CTF_DICT
   fi
   CTF_OUTPUT_TYPE="none"
   if [[ $CREATECTFDICT == 1 ]] && [[ $SAVECTF == 1 ]]; then CTF_OUTPUT_TYPE="both"; fi
   if [[ $CREATECTFDICT == 1 ]] && [[ $SAVECTF == 0 ]]; then CTF_OUTPUT_TYPE="dict"; fi
   if [[ $CREATECTFDICT == 0 ]] && [[ $SAVECTF == 1 ]]; then CTF_OUTPUT_TYPE="ctf"; fi
-  CONFIG_CTF="--output-dir \"$CTF_DIR\" --ctf-dict-dir \"$CTF_DICT_DIR\" --output-type $CTF_OUTPUT_TYPE --min-file-size ${CTF_MINSIZE} --max-ctf-per-file ${CTF_MAX_PER_FILE} --onlyDet $WORKFLOW_DETECTORS_CTF --append-det-to-period $CTF_MAXDETEXT --meta-output-dir $CTF_METAFILES_DIR"
+  CONFIG_CTF="--output-dir \"$CTF_DIR\" --output-type $CTF_OUTPUT_TYPE --min-file-size ${CTF_MINSIZE} --max-ctf-per-file ${CTF_MAX_PER_FILE} --onlyDet $WORKFLOW_DETECTORS_CTF --append-det-to-period $CTF_MAXDETEXT --meta-output-dir $CTF_METAFILES_DIR"
   if [[ $CREATECTFDICT == 1 ]] && [[ $EXTINPUT == 1 ]]; then CONFIG_CTF+=" --save-dict-after $SAVE_CTFDICT_NTIMEFRAMES"; fi
   add_W o2-ctf-writer-workflow "$CONFIG_CTF"
 fi
@@ -496,7 +487,7 @@ workflow_has_parameter CALIB && { source $MYDIR/calib-workflow.sh; [[ $? != 0 ]]
 # RS this is a temporary setting
 [[ -z "$ED_TRACKS" ]] && ED_TRACKS=$TRACK_SOURCES
 [[ -z "$ED_CLUSTERS" ]] && ED_CLUSTERS=$TRACK_SOURCES
-workflow_has_parameter EVENT_DISPLAY && [[ $NUMAID == 0 ]] && [[ ! -z "$ED_TRACKS" ]] && [[ ! -z "$ED_CLUSTERS" ]] && add_W o2-eve-display "--display-tracks $ED_TRACKS --display-clusters $ED_CLUSTERS --skipOnEmptyInput --number-of_tracks 50000 $EVE_CONFIG $DISABLE_MC" "$ITSMFT_FILES"
+workflow_has_parameter EVENT_DISPLAY && [[ $NUMAID == 0 ]] && [[ ! -z "$ED_TRACKS" ]] && [[ ! -z "$ED_CLUSTERS" ]] && add_W o2-eve-display "--display-tracks $ED_TRACKS --display-clusters $ED_CLUSTERS --skipOnEmptyInput --number-of_tracks 50000 $EVE_CONFIG $DISABLE_MC" "$ITSMFT_STROBES"
 
 # ---------------------------------------------------------------------------------------------------------------------
 # AOD

--- a/prodtests/full_system_test.sh
+++ b/prodtests/full_system_test.sh
@@ -159,7 +159,32 @@ fi
 STAGES+=" ASYNC"
 
 # give a possibility to run the FST with external existing dictionary (i.e. with CREATECTFDICT=0 full_system_test.sh)
-[ ! -z "$CREATECTFDICT" ] && SYNCMODEDOCTFDICT="$CREATECTFDICT" || SYNCMODEDOCTFDICT=1
+[[ ! -z "$CREATECTFDICT" ]] && SYNCMODEDOCTFDICT="$CREATECTFDICT" || SYNCMODEDOCTFDICT=1
+
+# this is default local tree-based CTF dictionary file
+[[ -z "$CTFDICTFILE" ]] && CTFDICTFILE="ctf_dictionary.root"
+
+# if dictionary creation is requested, the encoders should not use any external dictionary, neither local one (--ctf-dict <file>) not from CCDB (--ctf-dict "")
+[[ "$SYNCMODEDOCTFDICT" = "1" ]] && USECTFDICTFILE="none" || USECTFDICTFILE="$CTFDICTFILE"
+export ARGS_EXTRA_PROCESS_o2_itsmft_entropy_encoder_workflow+="--ctf-dict $USECTFDICTFILE"
+export ARGS_EXTRA_PROCESS_o2_ft0_entropy_encoder_workflow+="--ctf-dict $USECTFDICTFILE"
+export ARGS_EXTRA_PROCESS_o2_fv0_entropy_encoder_workflow+="--ctf-dict $USECTFDICTFILE"
+export ARGS_EXTRA_PROCESS_o2_mid_entropy_encoder_workflow+="--ctf-dict $USECTFDICTFILE"
+export ARGS_EXTRA_PROCESS_o2_mch_entropy_encoder_workflow+="--ctf-dict $USECTFDICTFILE"
+export ARGS_EXTRA_PROCESS_o2_phos_entropy_encoder_workflow+="--ctf-dict $USECTFDICTFILE"
+export ARGS_EXTRA_PROCESS_o2_cpv_entropy_encoder_workflow+="--ctf-dict $USECTFDICTFILE"
+export ARGS_EXTRA_PROCESS_o2_emcal_entropy_encoder_workflow+="--ctf-dict $USECTFDICTFILE"
+export ARGS_EXTRA_PROCESS_o2_zdc_entropy_encoder_workflow+="--ctf-dict $USECTFDICTFILE"
+export ARGS_EXTRA_PROCESS_o2_fdd_entropy_encoder_workflow+="--ctf-dict $USECTFDICTFILE"
+export ARGS_EXTRA_PROCESS_o2_hmpid_entropy_encoder_workflow+="--ctf-dict $USECTFDICTFILE"
+export ARGS_EXTRA_PROCESS_o2_tof_entropy_encoder_workflow+="--ctf-dict $USECTFDICTFILE"
+export ARGS_EXTRA_PROCESS_o2_trd_entropy_encoder_workflow+="--ctf-dict $USECTFDICTFILE"
+export ARGS_EXTRA_PROCESS_o2_tpc_reco_workflow+="--ctf-dict $USECTFDICTFILE"
+export ARGS_EXTRA_PROCESS_o2_ctp_entropy_encoder_workflow+="--ctf-dict $USECTFDICTFILE"
+
+# for decoding we use either just produced or externally provided common local file
+export ARGS_EXTRA_PROCESS_o2_ctf_reader_workflow+="--ctf-dict $CTFDICTFILE"
+
 
 for STAGE in $STAGES; do
   logfile=reco_${STAGE}.log


### PR DESCRIPTION
* Fetch entropy dicts from CCDB(default) or local file
Option --ctf-dict <OPT> steers for entropy encoders and decoders of all detectors
where the entropy dictionary is taken from. The choices for the OPT are:

 1. "": empty string leads to using CCDB objec fetching by the DPL CCDB service (default)
 2. filename: use the dictionary from provided file (either tree-based format or flat one in CCDB format)
 3. "none": do not use external dictionary, instead per-TF dictionaries will be stored in the CTF

* Produce per-detector ctf dictionaries
on top of the single file with tree-based dictionaries. These per-detector dictionaries are ready to be uploaded to the CCDB.

