### PR TITLE
MaterialManager improvement: Adding local density scaling (per module)

### DIFF
--- a/Common/SimConfig/include/SimConfig/SimParams.h
+++ b/Common/SimConfig/include/SimConfig/SimParams.h
@@ -41,6 +41,7 @@ struct SimCutParams : public o2::conf::ConfigurableParamHelper<SimCutParams> {
 // parameter influencing material manager
 struct SimMaterialParams : public o2::conf::ConfigurableParamHelper<SimMaterialParams> {
   float globalDensityFactor = 1.f;
+  std::string localDensityFactor;
 
   O2ParamDef(SimMaterialParams, "SimMaterialParams");
 };

--- a/Detectors/Base/include/DetectorsBase/MaterialManager.h
+++ b/Detectors/Base/include/DetectorsBase/MaterialManager.h
@@ -204,17 +204,16 @@ class MaterialManager
   // print out all registered media
   void printMedia() const;
 
-  /// set the density scaling factor
-  void setDensityScalingFactor(float f) { mDensityFactor = f; }
-  /// set the density scaling factor
-  float getDensityScalingFactor() const { return mDensityFactor; }
-
   /// print all tracking media inside a logical volume (specified by name)
   /// and all of its daughters
   static void printContainingMedia(std::string const& volumename);
 
  private:
-  MaterialManager() = default;
+  std::unordered_map<std::string, float> mDensityMap;
+  
+  void createDensityMap();
+  
+  MaterialManager() { createDensityMap(); }
 
   // Hide details by providing these private methods so it cannot happen that special settings
   // are applied as default settings by accident using a boolean flag
@@ -245,9 +244,6 @@ class MaterialManager
 
   std::map<std::string, int> mMaterialNameToGlobalIndexMap; // map of unique material name to global index
   std::map<std::string, int> mMediumNameToGlobalIndexMap;   // map of unique material name to global index
-
-  Float_t mDensityFactor = 1.; //! factor that is multiplied to all material densities (ONLY for
-  // systematic studies)
 
   /// In general, transport cuts and processes are properties of detector media. On the other hand different
   /// engines might provide different cuts and processes. Further, the naming convention might differ among

--- a/Detectors/Base/src/MaterialManager.cxx
+++ b/Detectors/Base/src/MaterialManager.cxx
@@ -31,6 +31,8 @@
 #include "rapidjson/istreamwrapper.h"
 #include "rapidjson/ostreamwrapper.h"
 #include "rapidjson/prettywriter.h"
+#include <algorithm>
+#include <SimConfig/SimParams.h>
 
 using namespace o2::base;
 namespace rj = rapidjson;
@@ -90,22 +92,66 @@ const std::unordered_map<ECut, const char*> MaterialManager::mCutIDToName = {
   {ECut::kDCUTM, "DCUTM"},
   {ECut::kPPCUTM, "PPCUTM"},
   {ECut::kTOFMAX, "TOFMAX"}};
+  
+// Constructing a map between module names and local material density values
+void MaterialManager::createDensityMap() {
+  std::string token;
+  std::istringstream input(
+      o2::conf::SimMaterialParams::Instance().localDensityFactor);
+  std::vector<std::string> inputModuleNames;
+  std::vector<std::string> inputDensityValues;
+  while (std::getline(input, token, ',')) {
+    std::size_t pos = token.find(':');
+    inputModuleNames.push_back(token.substr(0, pos));
+    inputDensityValues.push_back(token.substr(pos + 1));
+  }
+  std::vector<std::string> allModuleNames = {
+      "ABSO",   "CAVE", "COMP", "DIPO", "FRAME", "HALL", "MAG", "PIPE",
+      "SHIL",   "CPV",  "EMC",  "FDD",  "FT0",   "FV0",  "HMP", "ITS",
+      "MCH",    "MFT",  "MID",  "PHS",  "TOF",   "TPC",  "TRD", "ZDC",
+      "ALPIDE", "IT3",  "TRK",  "FT3",  "A3IP"};
+  if (o2::conf::SimMaterialParams::Instance().globalDensityFactor < 0) {
+    LOG(fatal) << "Negative value "
+               << o2::conf::SimMaterialParams::Instance().globalDensityFactor
+               << " found for global material density!\n";
+  }
+  for (std::size_t i = 0; i < allModuleNames.size(); i++) {
+    mDensityMap[allModuleNames[i]] =
+        o2::conf::SimMaterialParams::Instance().globalDensityFactor;
+  }
+  for (std::size_t i = 0; i < inputModuleNames.size(); i++) {
+    if (std::find(allModuleNames.begin(), allModuleNames.end(),
+                  inputModuleNames[i]) == allModuleNames.end()) {
+      LOG(fatal) << "Module name " << inputModuleNames[i]
+                 << " does not match the name of existing modules!\n";
+    }
+    if (std::stof(inputDensityValues[i]) < 0) {
+      LOG(fatal) << "Negative value " << std::stof(inputDensityValues[i])
+                 << " found for material density in module "
+                 << inputModuleNames[i] << "!\n";
+    }
+    mDensityMap[inputModuleNames[i]] = std::stof(inputDensityValues[i]);
+  }
+}
 
 void MaterialManager::Material(const char* modname, Int_t imat, const char* name, Float_t a, Float_t z, Float_t dens,
                                Float_t radl, Float_t absl, Float_t* buf, Int_t nwbuf)
 {
   TString uniquename = modname;
+  auto &densityFactor = mDensityMap[modname];
   uniquename.Append("_");
   uniquename.Append(name);
   if (TVirtualMC::GetMC()) {
     // Check this!!!
     int kmat = -1;
-    TVirtualMC::GetMC()->Material(kmat, uniquename.Data(), a, z, dens * mDensityFactor, radl, absl, buf, nwbuf);
+    TVirtualMC::GetMC()->Material(kmat, uniquename.Data(), a, z,
+                                  dens * densityFactor, radl, absl, buf, nwbuf);
     mMaterialMap[modname][imat] = kmat;
     insertMaterialName(uniquename.Data(), kmat);
   } else {
     auto uid = gGeoManager->GetListOfMaterials()->GetSize();
-    auto mat = gGeoManager->Material(uniquename.Data(), a, z, dens * mDensityFactor, uid, radl, absl);
+    auto mat = gGeoManager->Material(uniquename.Data(), a, z,
+                                     dens * densityFactor, uid, radl, absl);
     mMaterialMap[modname][imat] = uid;
     insertMaterialName(uniquename.Data(), uid);
   }
@@ -127,13 +173,15 @@ void MaterialManager::Mixture(const char* modname, Int_t imat, const char* name,
                               Int_t nlmat, Float_t* wmat)
 {
   TString uniquename = modname;
+  auto &densityFactor = mDensityMap[modname];
   uniquename.Append("_");
   uniquename.Append(name);
 
   if (TVirtualMC::GetMC()) {
     // Check this!!!
     int kmat = -1;
-    TVirtualMC::GetMC()->Mixture(kmat, uniquename.Data(), a, z, dens * mDensityFactor, nlmat, wmat);
+    TVirtualMC::GetMC()->Mixture(kmat, uniquename.Data(), a, z,
+                                 dens * densityFactor, nlmat, wmat);
     mMaterialMap[modname][imat] = kmat;
     insertMaterialName(uniquename.Data(), kmat);
 
@@ -150,7 +198,8 @@ void MaterialManager::Mixture(const char* modname, Int_t imat, const char* name,
         wmat[i] *= a[i] / amol;
       }
     }
-    auto mix = gGeoManager->Mixture(uniquename.Data(), a, z, dens * mDensityFactor, nlmat, wmat, uid);
+    auto mix = gGeoManager->Mixture(uniquename.Data(), a, z,
+                                    dens * densityFactor, nlmat, wmat, uid);
     mMaterialMap[modname][imat] = uid;
     insertMaterialName(uniquename.Data(), uid);
   }

--- a/macro/o2sim.C
+++ b/macro/o2sim.C
@@ -150,10 +150,6 @@ FairRunSim* o2sim_init(bool asservice, bool evalmat = false)
     aligner.setValue(fmt::format("{}.mDetectors", aligner.getName()), o2::detectors::DetID::getNames(detMaskAlign, ','));
   }
 
-  // set global density scaling factor
-  auto& matmgr = o2::base::MaterialManager::Instance();
-  matmgr.setDensityScalingFactor(o2::conf::SimMaterialParams::Instance().globalDensityFactor);
-
   // run init
   run->Init();
 
@@ -207,6 +203,7 @@ FairRunSim* o2sim_init(bool asservice, bool evalmat = false)
   // todo: save beam information in the grp
 
   // print summary about cuts and processes used
+  auto &matmgr = o2::base::MaterialManager::Instance();
   std::ofstream cutfile(o2::base::NameConf::getCutProcFileName(confref.getOutPrefix()));
   matmgr.printCuts(cutfile);
   matmgr.printProcesses(cutfile);


### PR DESCRIPTION
- SimParams.h: Adding the local density factor.
- MaterialManager.h: Defining the map between the module names and the density values. Modifying the constructor to create the map. Error handling of adding negative values and non-existing module names as input. Removing the old `setDensityScalingFactor()` and `setDensityScalingFactor()` as they are not needed anymore.
- MaterialManager.cxx: Implementing the creation of `MaterialManager::createDensityMap()`. Modifying `MaterialManager::Material` and `MaterialManager::Mixture` to use the given density values. 
- o2sim.C: Removing the usage of `setDensityScalingFactor()` as it doesn't exist anymore.