### PR TITLE
[EMCAL-548] Reduce verbosity in digits to cell converter

### DIFF
--- a/Detectors/EMCAL/workflow/src/CellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/CellConverterSpec.cxx
@@ -84,7 +84,9 @@ void CellConverterSpec::run(framework::ProcessingContext& ctx)
             fitResults.setTime(0.);
           }
         } catch (CaloRawFitter::RawFitterError_t& fiterror) {
-          LOG(error) << "Failure in raw fitting: " << CaloRawFitter::createErrorMessage(fiterror);
+          if (fiterror != CaloRawFitter::RawFitterError_t::BUNCH_NOT_OK) {
+            LOG(error) << "Failure in raw fitting: " << CaloRawFitter::createErrorMessage(fiterror);
+          }
         }
 
         mOutputCells.emplace_back(tower, fitResults.getAmp() * CONVADCGEV, fitResults.getTime(), channelData.mChanType);


### PR DESCRIPTION
Do not print bunch selection error as the error appears very frequently at low E and is not a real problem as the bunches are at the limit of the readout.