### PR TITLE
MCH: moved time calibration to digits filter

### DIFF
--- a/Detectors/MUON/MCH/DigitFiltering/README.md
+++ b/Detectors/MUON/MCH/DigitFiltering/README.md
@@ -11,12 +11,18 @@ o2-mch-digits-filtering-workflow
 
 Filter out some digits.
 
-Inputs :
+**Noise filtering :**
+
+The exact behavior of the noise filtering is governed by the [MCHDigitFilterParam](/Detectors/MUON/MCH/DigitFiltering/include/MCHDigitFiltering/DigitFilterParam.h) configurable param, where you can select the minimum ADC value to consider, and whether to select signal (i.e. killing as much background as possible, possibly killing some signal as well) and/or to reject background (while not killing signal).
+
+**Time calibration :**
+
+The time of the digits and ROFs can be shifted in the positive or negative direction in order to time-align the MCH data with the rest of the ALICE detectors. The time offset is passed through the [MCHDigitFilterParam](/Detectors/MUON/MCH/DigitFiltering/include/MCHDigitFiltering/DigitFilterParam.h)`.timeOffset` parameter.
+
+**Inputs :**
 - list of all digits ([Digit](/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h)) in the current time frame, with the (default) data description `DIGITS` (can be changed with `--input-digits-data-description` option)
 - the list of ROF records ([ROFRecord](/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the digits associated to each interaction, with the (default) data description `DIGITROFS` (can be changed with `--input-digit-rofs-data-description` option)
 
-Outputs :
-- list of digits that pass the filtering criteria (for the moment ADC>0), with the (default) data description `F-DIGITS`  (can be changed with `--output-digits-data-description` option)
+**Outputs :**
+- list of digits that pass the filtering criteria, with the (default) data description `F-DIGITS`  (can be changed with `--output-digits-data-description` option)
 - list of ROF records corresponding to the digits above, with a (default) data description of `F-DIGITROFS` (can be changed with `--output-digit-rofs-data-description` option)
-
-The exact behavior of the filtering is governed by the [MCHDigitFilterParam](/Detectors/MUON/MCH/DigitFiltering/include/MCHDigitFiltering/DigitFilterParam.h) configurable param, where you can select the minimum ADC value to consider, and whether to select signal (i.e. killing as much background as possible, possibly killing some signal as well) and/or to reject background (while not killing signal).

--- a/Detectors/MUON/MCH/DigitFiltering/include/MCHDigitFiltering/DigitFilterParam.h
+++ b/Detectors/MUON/MCH/DigitFiltering/include/MCHDigitFiltering/DigitFilterParam.h
@@ -28,6 +28,8 @@ struct DigitFilterParam : public o2::conf::ConfigurableParamHelper<DigitFilterPa
   uint32_t minADC = 1;           ///< digits with an ADC below this value are discarded
   bool rejectBackground = false; ///< attempts to reject background (loose background selection, don't kill signal)
   bool selectSignal = false;     ///< attempts to select only signal (strict background selection, might loose signal)
+  int timeOffset = 0;            ///< digit time calibration offset
+
   O2ParamDef(DigitFilterParam, "MCHDigitFilter");
 };
 

--- a/Detectors/MUON/MCH/DigitFiltering/src/DigitFilteringSpec.cxx
+++ b/Detectors/MUON/MCH/DigitFiltering/src/DigitFilteringSpec.cxx
@@ -144,7 +144,6 @@ class DigitFilteringTask
   bool mSanityCheck;
   bool mUseMC;
   DigitFilter mIsGoodDigit;
-  std::string mTimeCalibSource;
   int32_t mTimeCalib{0};
 };
 

--- a/Detectors/MUON/MCH/Raw/Common/include/MCHRawCommon/CoDecParam.h
+++ b/Detectors/MUON/MCH/Raw/Common/include/MCHRawCommon/CoDecParam.h
@@ -20,8 +20,6 @@ namespace o2::mch
 
 struct CoDecParam : public o2::conf::ConfigurableParamHelper<CoDecParam> {
 
-  int sampaBcOffset = 0; // default global sampa bunch-crossing offset
-
   // default minimum allowed digit time, in orbit units
   int minDigitOrbitAccepted = -10;
   // default maximum allowed digit time, in orbit units

--- a/Detectors/MUON/MCH/Raw/Common/src/SampaBunchCrossingCounter.cxx
+++ b/Detectors/MUON/MCH/Raw/Common/src/SampaBunchCrossingCounter.cxx
@@ -24,9 +24,8 @@ constexpr int BCINORBIT = o2::constants::lhc::LHCMaxBunches;
 uint20_t sampaBunchCrossingCounter(uint32_t orbit, uint16_t bc,
                                    uint32_t firstOrbit)
 {
-  auto offset = CoDecParam::Instance().sampaBcOffset;
   orbit -= firstOrbit;
-  auto bunchCrossingCounter = (orbit * LHCMaxBunches + bc + offset) % ((1 << 20) - 1);
+  auto bunchCrossingCounter = (orbit * LHCMaxBunches + bc) % ((1 << 20) - 1);
   impl::assertNofBits("bunchCrossingCounter", bunchCrossingCounter, 20);
   return bunchCrossingCounter;
 }
@@ -34,9 +33,8 @@ uint20_t sampaBunchCrossingCounter(uint32_t orbit, uint16_t bc,
 std::tuple<uint32_t, uint16_t> orbitBC(uint20_t bunchCrossingCounter,
                                        uint32_t firstOrbit)
 {
-  auto offset = CoDecParam::Instance().sampaBcOffset;
   impl::assertNofBits("bunchCrossingCounter", bunchCrossingCounter, 20);
-  uint32_t orbit = (bunchCrossingCounter - offset) / LHCMaxBunches + firstOrbit;
+  uint32_t orbit = bunchCrossingCounter / LHCMaxBunches + firstOrbit;
   int32_t bc = bunchCrossingCounter % LHCMaxBunches;
   return {orbit, bc};
 }

--- a/Detectors/MUON/MCH/Raw/Common/test/testSampaBunchCrossingCounter.cxx
+++ b/Detectors/MUON/MCH/Raw/Common/test/testSampaBunchCrossingCounter.cxx
@@ -43,7 +43,6 @@ BOOST_AUTO_TEST_CASE(SampaBunchCrossingCounterToIRConversionMustNotThrowIfBxFitI
 
 BOOST_AUTO_TEST_CASE(SampaBunchCrossingCounterSpansABitLessThan294Orbits)
 {
-  o2::conf::ConfigurableParam::setValue("MCHCoDecParam", "sampaBcOffset", 0);
   uint32_t bx = BXMAX;
   auto [orbit, bc] = orbitBC(bx, 0);
   BOOST_CHECK_EQUAL(orbit, 294);

--- a/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DataDecoder.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DataDecoder.h
@@ -148,7 +148,6 @@ class DataDecoder
   using RawDigitVector = std::vector<RawDigit>;
 
   DataDecoder(SampaChannelHandler channelHandler, RdhHandler rdhHandler,
-              uint32_t sampaBcOffset,
               std::string mapCRUfile, std::string mapFECfile,
               bool ds2manu, bool verbose, bool useDummyElecMap, TimeRecoMode timeRecoMode = TimeRecoMode::HBPackets);
 
@@ -164,13 +163,6 @@ class DataDecoder
    *  abandonned simply.
    */
   bool decodeBuffer(gsl::span<const std::byte> buf);
-
-  /// Functions to set and get the calibration offset for the SAMPA time computation
-  void setSampaBcOffset(uint32_t offset) { mSampaTimeOffset = offset; }
-  uint32_t getSampaBcOffset() const { return mSampaTimeOffset; }
-  /// Helper function for subtracting the calibration offset from a given BC counter value
-  /// Returns the BC counter value after the offset correction
-  static uint32_t subtractBcOffset(uint32_t bc, uint32_t offset);
 
   /// For a given SAMPA chip, update the information about the BC counter value at the beginning of the TimeFrame
   void updateTimeFrameStartRecord(uint64_t chipId, uint32_t mFirstOrbitInTF, uint32_t bcTF);

--- a/Detectors/MUON/MCH/Raw/Decoder/src/DataDecoder.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/DataDecoder.cxx
@@ -240,10 +240,9 @@ bool DataDecoder::TimeFrameStartRecord::check(int32_t orbit, uint32_t bc, int32_
 //_________________________________________________________________________________________________
 
 DataDecoder::DataDecoder(SampaChannelHandler channelHandler, RdhHandler rdhHandler,
-                         uint32_t sampaBcOffset,
                          std::string mapCRUfile, std::string mapFECfile,
                          bool ds2manu, bool verbose, bool useDummyElecMap, TimeRecoMode timeRecoMode)
-  : mChannelHandler(channelHandler), mRdhHandler(rdhHandler), mSampaTimeOffset(sampaBcOffset), mMapCRUfile(mapCRUfile), mMapFECfile(mapFECfile), mDs2manu(ds2manu), mDebug(verbose), mUseDummyElecMap(useDummyElecMap), mTimeRecoMode(timeRecoMode)
+  : mChannelHandler(channelHandler), mRdhHandler(rdhHandler), mMapCRUfile(mapCRUfile), mMapFECfile(mapFECfile), mDs2manu(ds2manu), mDebug(verbose), mUseDummyElecMap(useDummyElecMap), mTimeRecoMode(timeRecoMode)
 {
   init();
 }
@@ -532,20 +531,6 @@ uint64_t DataDecoder::getChipId(uint32_t solar, uint32_t ds, uint32_t chip)
 
 //_________________________________________________________________________________________________
 
-uint32_t DataDecoder::subtractBcOffset(uint32_t bc, uint32_t offset)
-{
-  int64_t bcTF = static_cast<int64_t>(bc) - offset;
-
-  if (bcTF < 0) {
-    bcTF += bcRollOver;
-  }
-  uint32_t bc20bits = static_cast<uint32_t>(bcTF & twentyBitsAtOne);
-
-  return bc20bits;
-}
-
-//_________________________________________________________________________________________________
-
 void DataDecoder::updateTimeFrameStartRecord(uint64_t chipId, uint32_t mFirstOrbitInTF, uint32_t bcTF)
 {
   if (chipId < DataDecoder::sReadoutChipsNum) {
@@ -567,23 +552,21 @@ void DataDecoder::decodePage(gsl::span<const std::byte> page)
     auto solar = dsElecId.solarId();
     uint64_t chipId = getChipId(solar, ds, chip);
 
-    uint32_t bcTF = subtractBcOffset(bunchCrossing, mSampaTimeOffset);
-
     if (mDebug) {
       auto s = asString(dsElecId);
-      LOGP(info, "HeartBeat: {}-CHIP{} -> {}/{} offset {} -> bcTF {}",
-           s, chip, mFirstOrbitInTF, bunchCrossing, mSampaTimeOffset, bcTF);
+      LOGP(info, "HeartBeat: {}-CHIP{} -> {}/{}",
+           s, chip, mFirstOrbitInTF, bunchCrossing);
     }
 
     if (chipId >= DataDecoder::sReadoutChipsNum) {
       return;
     }
 
-    if (!mTimeFrameStartRecords[chipId].update(mFirstOrbitInTF, bcTF)) {
+    if (!mTimeFrameStartRecords[chipId].update(mFirstOrbitInTF, bunchCrossing)) {
       if (mErrorCount < MCH_DECODER_MAX_ERROR_COUNT) {
         auto s = asString(dsElecId);
         LOGP(warning, "Bad HeartBeat packet received: {}-CHIP{} {}/{} (last {}/{})",
-             s, chip, mFirstOrbitInTF, bcTF, mTimeFrameStartRecords[chipId].mOrbitPrev, mTimeFrameStartRecords[chipId].mBunchCrossingPrev);
+             s, chip, mFirstOrbitInTF, bunchCrossing, mTimeFrameStartRecords[chipId].mOrbitPrev, mTimeFrameStartRecords[chipId].mBunchCrossingPrev);
         mErrorCount += 1;
       }
     }
@@ -812,8 +795,6 @@ void DataDecoder::computeDigitsTimeBCRst()
     auto bcDigit = info.getBXTime();
 
     tfTime = DataDecoder::getDigitTimeBCRst(orbitTF, bcTF, orbitDigit, bcDigit);
-
-    tfTime -= mSampaTimeOffset;
 
     if (mDebug && tfTime < (-2 * mBcInOrbit)) {
       int solar = info.solar;

--- a/Detectors/MUON/MCH/Raw/Decoder/src/testDigitsTimeComputation.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/testDigitsTimeComputation.cxx
@@ -78,12 +78,11 @@ static std::vector<RawDigit> processDigits(const std::vector<RawDigit>& digits, 
   RdhHandler rdhHandler;
 
   bool ds2manu = false;
-  uint32_t sampaBcOffset = 0;
   bool mDebug = true;
   bool mCheckROFs = false;
   bool mDummyROFs = true;
   bool useDummyElecMap = false;
-  DataDecoder decoder{channelHandler, rdhHandler, sampaBcOffset, "", "", ds2manu, mDebug, useDummyElecMap};
+  DataDecoder decoder{channelHandler, rdhHandler, "", "", ds2manu, mDebug, useDummyElecMap};
 
   decoder.setFirstOrbitInTF(tfOrbit);
   decoder.setDigits(digits);

--- a/Detectors/MUON/MCH/Raw/test/codec-closure-test.sh
+++ b/Detectors/MUON/MCH/Raw/test/codec-closure-test.sh
@@ -27,14 +27,12 @@ o2-mch-digits-file-dumper --infile digits.sim.out \
 
 echo "=== Conversion digits -> raw (MCH)"
 o2-mch-digits-to-raw --input-file mchdigits.root \
---configKeyValues="MCHCoDecParam.sampaBcOffset=12345" \
 --output-dir ./raw/MCH --file-per-link $option &> \
 digits-to-raw.log
 
 echo "=== Conversion raw -> digit + real digits to mch binary format"
 o2-raw-file-reader-workflow --input-conf raw/MCH/MCHraw.cfg -b | \
-o2-mch-raw-to-digits-workflow ${option} \
---configKeyValues="MCHCoDecParam.sampaBcOffset=12345" -b | \
+o2-mch-raw-to-digits-workflow ${option} -b | \
 o2-mch-digits-writer-workflow -b --binary-file-format 3 --outfile \
 digits.real.out &> raw-to-digits.log
 

--- a/Detectors/MUON/MCH/Raw/test/testClosureCoDecDigit.cxx
+++ b/Detectors/MUON/MCH/Raw/test/testClosureCoDecDigit.cxx
@@ -128,7 +128,7 @@ template <typename T>
 std::vector<T> readDigits()
 {
   std::vector<T> result;
-  DataDecoder dd(handlePacketStoreAsVec<T>(result), nullptr, 0, "", "", false, false, useDummyElecMap);
+  DataDecoder dd(handlePacketStoreAsVec<T>(result), nullptr, "", "", false, false, useDummyElecMap);
 
   auto buffer = getBuffer("MCH.raw");
   dd.decodeBuffer(buffer);

--- a/Detectors/MUON/MCH/Raw/test/testClosureCoDecDigit.cxx
+++ b/Detectors/MUON/MCH/Raw/test/testClosureCoDecDigit.cxx
@@ -137,7 +137,6 @@ std::vector<T> readDigits()
 
 BOOST_AUTO_TEST_CASE(WrittenAndReadBackDigitsShouldBeTheSameStringVersion)
 {
-  o2::conf::ConfigurableParam::setValue("MCHCoDecParam", "sampaBcOffset", 0);
   std::vector<std::string> expected = {
     "S481-J5-DS1-CH58-ts-0-bc-3456-cs-1-q-959",
     "S481-J5-DS1-CH11-ts-0-bc-3456-cs-1-q-974",
@@ -172,7 +171,6 @@ BOOST_AUTO_TEST_CASE(WrittenAndReadBackDigitsShouldBeTheSameStringVersion)
 
 BOOST_AUTO_TEST_CASE(WrittenAndReadBackDigitsShouldBeTheSame)
 {
-  o2::conf::ConfigurableParam::setValue("MCHCoDecParam", "sampaBcOffset", 0);
   std::vector<DePadId> expected = {
     DePadId{923, 3959},
     DePadId{923, 3974},

--- a/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
@@ -79,7 +79,6 @@ class DataDecoderTask
     RdhHandler rdhHandler;
 
     auto ds2manu = ic.options().get<bool>("ds2manu");
-    auto sampaBcOffset = CoDecParam::Instance().sampaBcOffset;
     mDebug = ic.options().get<bool>("mch-debug");
     mCheckROFs = ic.options().get<bool>("check-rofs");
     mDummyROFs = ic.options().get<bool>("dummy-rofs");
@@ -96,7 +95,7 @@ class DataDecoderTask
       timeRecoMode = DataDecoder::TimeRecoMode::BCReset;
     }
 
-    mDecoder = new DataDecoder(channelHandler, rdhHandler, sampaBcOffset, mapCRUfile, mapFECfile, ds2manu, mDebug,
+    mDecoder = new DataDecoder(channelHandler, rdhHandler, mapCRUfile, mapFECfile, ds2manu, mDebug,
                                useDummyElecMap, timeRecoMode);
 
     auto stop = [this]() {


### PR DESCRIPTION
The time calibration is controlled by the `MCHDigitFilterParam.timeOffset` configuration parameter, that specifies the global offset (in BC units) applied to the time stamp of digits and ROFs.