### PR TITLE
DPL Analysis: fix for DYN propagation

### DIFF
--- a/Framework/Core/src/ArrowSupport.cxx
+++ b/Framework/Core/src/ArrowSupport.cxx
@@ -420,7 +420,7 @@ o2::framework::ServiceSpec ArrowSupport::arrowBackendSpec()
       std::vector<OutputSpec> providedDYNs;
 
       auto inputSpecLessThan = [](InputSpec const& lhs, InputSpec const& rhs) { return DataSpecUtils::describe(lhs) < DataSpecUtils::describe(rhs); };
-      auto outputSpecLessThan = [](OutputSpec const&lhs, OutputSpec const&rhs) { return DataSpecUtils::describe(lhs) < DataSpecUtils::describe(rhs); };
+      auto outputSpecLessThan = [](OutputSpec const& lhs, OutputSpec const& rhs) { return DataSpecUtils::describe(lhs) < DataSpecUtils::describe(rhs); };
 
       if (builder != workflow.end()) {
         // collect currently requested IDXs

--- a/Framework/Core/src/ArrowSupport.cxx
+++ b/Framework/Core/src/ArrowSupport.cxx
@@ -419,6 +419,9 @@ o2::framework::ServiceSpec ArrowSupport::arrowBackendSpec()
       std::vector<InputSpec> requestedDYNs;
       std::vector<OutputSpec> providedDYNs;
 
+      auto inputSpecLessThan = [](InputSpec const& lhs, InputSpec const& rhs) { return DataSpecUtils::describe(lhs) < DataSpecUtils::describe(rhs); };
+      auto outputSpecLessThan = [](OutputSpec const&lhs, OutputSpec const&rhs) { return DataSpecUtils::describe(lhs) < DataSpecUtils::describe(rhs); };
+
       if (builder != workflow.end()) {
         // collect currently requested IDXs
         std::vector<InputSpec> requestedIDXs;
@@ -460,13 +463,21 @@ o2::framework::ServiceSpec ArrowSupport::arrowBackendSpec()
             }
           }
         }
+        std::sort(requestedDYNs.begin(), requestedDYNs.end(), inputSpecLessThan);
+        std::sort(providedDYNs.begin(), providedDYNs.end(), outputSpecLessThan);
+        std::vector<InputSpec> spawnerInputs;
+        for (auto& input : requestedDYNs) {
+          if (std::none_of(providedDYNs.begin(), providedDYNs.end(), [&input](auto const& x) { return DataSpecUtils::match(input, x); })) {
+            spawnerInputs.emplace_back(input);
+          }
+        }
         // recreate inputs and outputs
         spawner->outputs.clear();
         spawner->inputs.clear();
         // replace AlgorithmSpec
         // FIXME: it should be made more generic, so it does not need replacement...
-        spawner->algorithm = readers::AODReaderHelpers::aodSpawnerCallback(requestedDYNs);
-        WorkflowHelpers::addMissingOutputsToSpawner(providedDYNs, requestedDYNs, requestedAODs, *spawner);
+        spawner->algorithm = readers::AODReaderHelpers::aodSpawnerCallback(spawnerInputs);
+        WorkflowHelpers::addMissingOutputsToSpawner({}, spawnerInputs, requestedAODs, *spawner);
       }
 
       if (writer != workflow.end()) {
@@ -502,7 +513,7 @@ o2::framework::ServiceSpec ArrowSupport::arrowBackendSpec()
       // ATTENTION: if there are dangling outputs the getGlobalAODSink
       // has to be created in any case!
       std::vector<InputSpec> outputsInputsAOD;
-      auto isAOD = [](InputSpec const& spec) { return DataSpecUtils::partialMatch(spec, header::DataOrigin("AOD")); };
+      auto isAOD = [](InputSpec const& spec) { return (DataSpecUtils::partialMatch(spec, header::DataOrigin("AOD")) || DataSpecUtils::partialMatch(spec, header::DataOrigin("DYN"))); };
 
       for (auto ii = 0u; ii < outputsInputs.size(); ii++) {
         if (isAOD(outputsInputs[ii])) {

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -390,24 +390,19 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
           break;
       }
       if (DataSpecUtils::partialMatch(input, header::DataOrigin{"AOD"})) {
-        requestedAODs.emplace_back(input);
+        DataSpecUtils::updateInputList(requestedAODs, InputSpec{input});
       }
       if (DataSpecUtils::partialMatch(input, header::DataOrigin{"DYN"})) {
-        if (std::find_if(requestedDYNs.begin(), requestedDYNs.end(), [&](InputSpec const& spec) { return input.binding == spec.binding; }) == requestedDYNs.end()) {
-          requestedDYNs.emplace_back(input);
-        }
+        DataSpecUtils::updateInputList(requestedDYNs, InputSpec{input});
       }
       if (DataSpecUtils::partialMatch(input, header::DataOrigin{"IDX"})) {
-        if (std::find_if(requestedIDXs.begin(), requestedIDXs.end(), [&](InputSpec const& spec) { return input.binding == spec.binding; }) == requestedIDXs.end()) {
-          requestedIDXs.emplace_back(input);
-        }
+        DataSpecUtils::updateInputList(requestedIDXs, InputSpec{input});
       }
     }
 
     std::stable_sort(timer.outputs.begin(), timer.outputs.end(), [](OutputSpec const& a, OutputSpec const& b) { return *DataSpecUtils::getOptionalSubSpec(a) < *DataSpecUtils::getOptionalSubSpec(b); });
 
-    for (size_t oi = 0; oi < processor.outputs.size(); ++oi) {
-      auto& output = processor.outputs[oi];
+    for (auto& output : processor.outputs) {
       if (DataSpecUtils::partialMatch(output, header::DataOrigin{"AOD"})) {
         providedAODs.emplace_back(output);
       } else if (DataSpecUtils::partialMatch(output, header::DataOrigin{"DYN"})) {
@@ -426,20 +421,23 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
       }
     }
   }
-  auto sortingEquals = [](InputSpec const& a, InputSpec const& b) { return DataSpecUtils::describe(a) == DataSpecUtils::describe(b); };
-  std::sort(requestedDYNs.begin(), requestedDYNs.end(), sortingEquals);
-  auto last = std::unique(requestedDYNs.begin(), requestedDYNs.end());
-  requestedDYNs.erase(last, requestedDYNs.end());
 
-  std::sort(requestedIDXs.begin(), requestedIDXs.end(), sortingEquals);
-  last = std::unique(requestedIDXs.begin(), requestedIDXs.end());
-  requestedIDXs.erase(last, requestedIDXs.end());
+  auto inputSpecLessThan = [](InputSpec const& lhs, InputSpec const& rhs) { return DataSpecUtils::describe(lhs) < DataSpecUtils::describe(rhs); };
+  auto outputSpecLessThan = [](OutputSpec const& lhs, OutputSpec const& rhs) { return DataSpecUtils::describe(lhs) < DataSpecUtils::describe(rhs); };
+  std::sort(requestedDYNs.begin(), requestedDYNs.end(), inputSpecLessThan);
+  std::sort(providedDYNs.begin(), providedDYNs.end(), outputSpecLessThan);
+  std::vector<InputSpec> spawnerInputs;
+  for (auto& input : requestedDYNs) {
+    if (std::none_of(providedDYNs.begin(), providedDYNs.end(), [&input](auto const& x) { return DataSpecUtils::match(input, x); })) {
+      spawnerInputs.emplace_back(input);
+    }
+  }
 
   DataProcessorSpec aodSpawner{
     "internal-dpl-aod-spawner",
     {},
     {},
-    readers::AODReaderHelpers::aodSpawnerCallback(requestedDYNs),
+    readers::AODReaderHelpers::aodSpawnerCallback(spawnerInputs),
     {}};
 
   DataProcessorSpec indexBuilder{
@@ -450,7 +448,7 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
     {}};
 
   addMissingOutputsToBuilder(requestedIDXs, requestedAODs, requestedDYNs, indexBuilder);
-  addMissingOutputsToSpawner(providedDYNs, requestedDYNs, requestedAODs, aodSpawner);
+  addMissingOutputsToSpawner({}, spawnerInputs, requestedAODs, aodSpawner);
 
   addMissingOutputsToReader(providedAODs, requestedAODs, aodReader);
   addMissingOutputsToReader(providedCCDBs, requestedCCDBs, ccdbBackend);
@@ -605,7 +603,7 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
   // ATTENTION: if there are dangling outputs the getGlobalAODSink
   // has to be created in any case!
   std::vector<InputSpec> outputsInputsAOD;
-  auto isAOD = [](InputSpec const& spec) { return DataSpecUtils::partialMatch(spec, header::DataOrigin("AOD")); };
+  auto isAOD = [](InputSpec const& spec) { return (DataSpecUtils::partialMatch(spec, header::DataOrigin("AOD")) || DataSpecUtils::partialMatch(spec, header::DataOrigin("DYN"))); };
   for (auto ii = 0u; ii < outputsInputs.size(); ii++) {
     if (isAOD(outputsInputs[ii])) {
       auto ds = dod->getDataOutputDescriptors(outputsInputs[ii]);


### PR DESCRIPTION
* allows analysis tasks to produce DYN tables
* makes sure the dangling DYN outputs are not discarded immediately
* improves formation of DYN input and output lists