### PR TITLE
o2-sim: Automatic timestamp setup from run number

### DIFF
--- a/CCDB/include/CCDB/BasicCCDBManager.h
+++ b/CCDB/include/CCDB/BasicCCDBManager.h
@@ -157,6 +157,10 @@ class CCDBManagerInstance
   /// set the fatal property (when false; nullptr object responses will not abort)
   void setFatalWhenNull(bool b) { mFatalWhenNull = b; }
 
+  /// a convenience function for MC to fetch
+  /// valid timestamps given an ALICE run number
+  std::pair<uint64_t, uint64_t> getRunDuration(int runnumber) const;
+
  private:
   // method to print (fatal) error
   void reportFatal(std::string_view s);

--- a/CCDB/src/BasicCCDBManager.cxx
+++ b/CCDB/src/BasicCCDBManager.cxx
@@ -13,6 +13,7 @@
 // Created by Sandro Wenzel on 2019-08-14.
 //
 #include "CCDB/BasicCCDBManager.h"
+#include <boost/lexical_cast.hpp>
 #include "FairLogger.h"
 #include <string>
 
@@ -45,6 +46,17 @@ void CCDBManagerInstance::setURL(std::string const& url)
 void CCDBManagerInstance::reportFatal(std::string_view err)
 {
   LOG(fatal) << err;
+}
+
+std::pair<uint64_t, uint64_t> CCDBManagerInstance::getRunDuration(int runnumber) const
+{
+  auto response = mCCDBAccessor.retrieveHeaders("RCT/RunInformation", std::map<std::string, std::string>(), runnumber);
+  if (response.size() == 0 || response.find("SOR") == response.end() || response.find("EOR") == response.end()) {
+    LOG(fatal) << "Empty or missing response from query to RCT/RunInformation for run " << runnumber;
+  }
+  auto sor = boost::lexical_cast<uint64_t>(response["SOR"]);
+  auto eor = boost::lexical_cast<uint64_t>(response["EOR"]);
+  return std::make_pair(sor, eor);
 }
 
 } // namespace ccdb

--- a/Common/SimConfig/include/SimConfig/SimConfig.h
+++ b/Common/SimConfig/include/SimConfig/SimConfig.h
@@ -26,6 +26,12 @@ enum SimFieldMode {
   kCCDB = 2
 };
 
+enum TimeStampMode {
+  kNow = 0,
+  kManual = 1,
+  kRun = 2
+};
+
 // configuration struct (which can be passed around)
 struct SimConfigData {
   std::vector<std::string> mActiveModules;    // list of active modules
@@ -55,6 +61,8 @@ struct SimConfigData {
   bool mFilterNoHitEvents = false;            // whether to filter out events not leaving any response
   std::string mCCDBUrl;                       // the URL where to find CCDB
   uint64_t mTimestamp;                        // timestamp in ms to anchor transport simulation to
+  TimeStampMode mTimestampMode = kNow;        // telling of timestamp was given as option or defaulted to now
+  int mRunNumber = -1;                        // ALICE run number (if set != -1); the timestamp should be compatible
   int mField;                                 // L3 field setting in kGauss: +-2,+-5 and 0
   SimFieldMode mFieldMode = kDefault;         // uniform magnetic field
   bool mAsService = false;                    // if simulation should be run as service/deamon (does not exit after run)
@@ -125,6 +133,7 @@ class SimConfig
   bool isFilterOutNoHitEvents() const { return mConfigData.mFilterNoHitEvents; }
   bool asService() const { return mConfigData.mAsService; }
   uint64_t getTimestamp() const { return mConfigData.mTimestamp; }
+  int getRunNumber() const { return mConfigData.mRunNumber; }
   bool isNoGeant() const { return mConfigData.mNoGeant; }
 
  private:

--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -53,7 +53,8 @@ void SimConfig::initOptions(boost::program_options::options_description& options
     "nworkers,j", bpo::value<int>()->default_value(nsimworkersdefault), "number of parallel simulation workers (only for parallel mode)")(
     "noemptyevents", "only writes events with at least one hit")(
     "CCDBUrl", bpo::value<std::string>()->default_value("http://alice-ccdb.cern.ch"), "URL for CCDB to be used.")(
-    "timestamp", bpo::value<uint64_t>(), "global timestamp value in ms (for anchoring) - default is now")(
+    "timestamp", bpo::value<uint64_t>(), "global timestamp value in ms (for anchoring) - default is now ... or beginning of run if ALICE run number was given")(
+    "run", bpo::value<int>()->default_value(-1), "ALICE run number")(
     "asservice", bpo::value<bool>()->default_value(false), "run in service/server mode")(
     "noGeant", bpo::bool_switch(), "prohibits any Geant transport/physics (by using tight cuts)");
 }
@@ -160,9 +161,12 @@ bool SimConfig::resetFromParsedMap(boost::program_options::variables_map const& 
   mConfigData.mSimWorkers = vm["nworkers"].as<int>();
   if (vm.count("timestamp")) {
     mConfigData.mTimestamp = vm["timestamp"].as<uint64_t>();
+    mConfigData.mTimestampMode = kManual;
   } else {
     mConfigData.mTimestamp = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::system_clock::now()).time_since_epoch().count();
+    mConfigData.mTimestampMode = kNow;
   }
+  mConfigData.mRunNumber = vm["run"].as<int>();
   mConfigData.mCCDBUrl = vm["CCDBUrl"].as<std::string>();
   mConfigData.mAsService = vm["asservice"].as<bool>();
   mConfigData.mNoGeant = vm["noGeant"].as<bool>();

--- a/prodtests/sim_challenge.sh
+++ b/prodtests/sim_challenge.sh
@@ -10,10 +10,11 @@
 if [ -z "$SHMSIZE" ]; then export SHMSIZE=10000000000; fi
 
 # default run number
+# (for now set to a pilot beam run until we have all CCDB objects for default unanchored MC)
 runNumDef=300000
 
-# default time stamp
-startTimeDef=$(($(date +%s%N)/1000000))
+# default time stamp --> will be determined from run number during the sim stage
+# startTimeDef=$(($(date +%s%N)/1000000))
 
 # default number of events
 nevPP=10
@@ -111,8 +112,8 @@ fi
 
 if [ "$dosim" == "1" ]; then
   #---------------------------------------------------
-  echo "Running simulation for $nev $collSyst events with $gener generator and engine $engine"
-  taskwrapper sim.log o2-sim -n"$nev" --configKeyValues "Diamond.width[2]=6." -g "$gener" -e "$engine" $simWorker
+  echo "Running simulation for $nev $collSyst events with $gener generator and engine $engine and run number $runNumber"
+  taskwrapper sim.log o2-sim -n"$nev" --configKeyValues "Diamond.width[2]=6." -g "$gener" -e "$engine" $simWorker --run ${runNumber}
 
   ##------ extract number of hits
   taskwrapper hitstats.log root -q -b -l ${O2_ROOT}/share/macro/analyzeHits.C
@@ -121,7 +122,7 @@ fi
 if [ "$dodigi" == "1" ]; then
   echo "Running digitization for $intRate kHz interaction rate"
   intRate=$((1000*(intRate)));
-  taskwrapper digi.log o2-sim-digitizer-workflow $gloOpt --interactionRate $intRate $tpcLanes --configKeyValues \""HBFUtils.startTime=$startTime;HBFUtils.runNumber=$runNumber;"\"
+  taskwrapper digi.log o2-sim-digitizer-workflow $gloOpt --interactionRate $intRate $tpcLanes --configKeyValues "HBFUtils.runNumber=${runNumber}"
   echo "Return status of digitization: $?"
   # existing checks
   #root -b -q O2/Detectors/ITSMFT/ITS/macros/test/CheckDigits.C+


### PR DESCRIPTION
When a run number is given, o2-sim can now deduce a
consistent timestamps automatically, and propagate it
to digitization via GRP (and later via HBFUtils).

This is fixing an issue where arbitrary "now" timestamps
where used in un-unchored MC for which no CCDB objects were available.