### PR TITLE
Add missing HBFUtilsInitializer calls + MCH cru-page-reader time/run assignment

### DIFF
--- a/Detectors/EMCAL/workflow/src/cell-reader-workflow.cxx
+++ b/Detectors/EMCAL/workflow/src/cell-reader-workflow.cxx
@@ -13,6 +13,7 @@
 #include <vector>
 #include "Framework/Variant.h"
 #include "Framework/ConfigParamSpec.h"
+#include "Framework/CallbacksPolicy.h"
 #include "DataFormatsEMCAL/Cell.h"
 #include "DetectorsRaw/HBFUtilsInitializer.h"
 #include "EMCALWorkflow/PublisherSpec.h"
@@ -20,6 +21,11 @@
 
 using namespace o2::framework;
 using namespace o2::emcal;
+
+void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
+{
+  o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
 
 // we need to add workflow options before including Framework/runDataProcessing
 void customize(std::vector<ConfigParamSpec>& workflowOptions)

--- a/Detectors/EMCAL/workflow/src/digit-reader-workflow.cxx
+++ b/Detectors/EMCAL/workflow/src/digit-reader-workflow.cxx
@@ -13,13 +13,21 @@
 #include <vector>
 #include "Framework/Variant.h"
 #include "Framework/ConfigParamSpec.h"
+#include "Framework/CallbacksPolicy.h"
 #include "DataFormatsEMCAL/Digit.h"
 #include "DetectorsRaw/HBFUtilsInitializer.h"
 #include "EMCALWorkflow/PublisherSpec.h"
 #include "CommonUtils/ConfigurableParam.h"
+#include "DetectorsRaw/HBFUtils.h"
 
 using namespace o2::framework;
 using namespace o2::emcal;
+
+// ------------------------------------------------------------------
+void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
+{
+  o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
 
 // we need to add workflow options before including Framework/runDataProcessing
 void customize(std::vector<ConfigParamSpec>& workflowOptions)

--- a/Detectors/MUON/Workflow/src/tracks-matcher-workflow.cxx
+++ b/Detectors/MUON/Workflow/src/tracks-matcher-workflow.cxx
@@ -20,6 +20,7 @@
 #include "Framework/ConfigParamSpec.h"
 #include "Framework/ConfigContext.h"
 #include "Framework/WorkflowSpec.h"
+#include "Framework/CallbacksPolicy.h"
 #include "CommonUtils/ConfigurableParam.h"
 #include "DetectorsRaw/HBFUtilsInitializer.h"
 #include "MCHWorkflow/TrackReaderSpec.h"
@@ -28,6 +29,12 @@
 #include "TrackWriterSpec.h"
 
 using namespace o2::framework;
+
+// ------------------------------------------------------------------
+void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
+{
+  o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
 
 void customize(std::vector<CompletionPolicy>& policies)
 {
@@ -47,6 +54,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
                                ConfigParamSpec::HelpString{"disable MC propagation even if available"});
   workflowOptions.emplace_back("configKeyValues", VariantType::String, "",
                                ConfigParamSpec::HelpString{"Semicolon separated key=value strings"});
+  o2::raw::HBFUtilsInitializer::addConfigOption(workflowOptions);
 }
 
 #include "Framework/runDataProcessing.h"

--- a/Detectors/TPC/workflow/src/ChunkedDigitPublisher.cxx
+++ b/Detectors/TPC/workflow/src/ChunkedDigitPublisher.cxx
@@ -74,6 +74,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   // option to disable MC truth
   workflowOptions.push_back(ConfigParamSpec{"disable-mc", o2::framework::VariantType::Bool, false, {"disable  mc-truth"}});
   workflowOptions.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}});
+  o2::raw::HBFUtilsInitializer::addConfigOption(workflowOptions);
 }
 
 // ------------------------------------------------------------------

--- a/Detectors/ZDC/calib/src/zdc-intercalib-workflow.cxx
+++ b/Detectors/ZDC/calib/src/zdc-intercalib-workflow.cxx
@@ -10,10 +10,17 @@
 // or submit itself to any jurisdiction.
 
 #include "Framework/DataProcessorSpec.h"
+#include "Framework/CallbacksPolicy.h"
 #include "DetectorsRaw/HBFUtilsInitializer.h"
 #include "ZDCCalib/InterCalibSpec.h"
 
 using namespace o2::framework;
+
+// ------------------------------------------------------------------
+void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
+{
+  o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
 
 // we need to add workflow options before including Framework/runDataProcessing
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)


### PR DESCRIPTION
@aphecetche when testing your workflow, the ccdb fetcher was failing since the reader was not injecting the TF time. So, I am adding this commit on top of few cases of incomplete HBFUtilsInitializer usage.
As I wrote before, the reader has a problem that it does not send the output for every `run()` call. Therefore I changed its output to `Lifetime::Sporadic`, though still something prevents to use it in the workflow with the CCDB fetcher.

* Minimal changes for cru-page-reader to inject timestamp and runNumber
In case the cru-page-reader should inject to the DataHeader and DataProcessingHeader
the info like runNumber, orbitFirst and creation time, it can be imposed via e.g.
`--configKeyValues HBFUtils.startTime=1651562466196;HBFUtils.runNumber=514769;HBFUtils.orbitFirst=128`
Note that this info will be added as is, i.e. DataProcessingHeader.creation will be always the same as
passed startTime. If needed, one should apply more elaborate logic depending what is read out from the file.
Thie is minimum needed for the DPL CCDB fetcher functionality.