### PR TITLE
DPL: update what "now" means before setting the timer

### DIFF
--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -542,6 +542,7 @@ void DataProcessingDevice::initPollers()
     auto* timer = (uv_timer_t*)malloc(sizeof(uv_timer_t));
     uv_timer_init(mState.loop, timer);
     timer->data = &mState;
+    uv_update_time(mState.loop);
     uv_timer_start(timer, on_idle_timer, 2000, 2000);
     mState.activeTimers.push_back(timer);
   }
@@ -779,6 +780,7 @@ void DataProcessingDevice::Run()
         auto timeout = mDeviceContext.exitTransitionTimeout;
         if (timeout != 0 && mState.streaming != StreamingState::Idle) {
           mState.transitionHandling = TransitionHandlingState::Requested;
+          uv_update_time(mState.loop);
           uv_timer_start(mDeviceContext.gracePeriodTimer, on_transition_requested_expired, timeout * 1000, 0);
           if (mProcessingPolicies.termination == TerminationPolicy::QUIT) {
             LOGP(info, "New state requested. Waiting for {} seconds before quitting.", timeout);


### PR DESCRIPTION
Due to the fact we do not invoke uv_run unless there is
some idle time between some data and the other, the concept
of "now" in libuv is not updated. This means that when
we setup a timer, libuv things it's still the past. However
when we run uv_run e.g. because data is not
arriving anymore, the time suddenly switches to the correct one,
triggering the callback immediately, because the 20 seconds from
the moment in the past have already passed.

This explains why end of stream is missed (FairMQ simply switched
already to the READY state) or why some race condition which should not
be so frequent (like the one for START-STOP-START), is so frequent.