### PR TITLE
Use TRandom::GetSeed to get what was set

### DIFF
--- a/Generators/src/GeneratorFactory.cxx
+++ b/Generators/src/GeneratorFactory.cxx
@@ -71,7 +71,7 @@ void GeneratorFactory::setPrimaryGenerator(o2::conf::SimConfig const& conf, Fair
       LOG(info) << "Reading \'Pythia8\' base configuration: " << config << std::endl;
       gen->readFile(config);
     }
-    auto seed = (gRandom->GetSeed() % 900000000);
+    auto seed = (gRandom->TRandom::GetSeed() % 900000000);
     LOG(info) << "Using random seed from gRandom % 900000000: " << seed;
     gen->readString("Random:setSeed on");
     gen->readString("Random:seed " + std::to_string(seed));


### PR DESCRIPTION
As documented in ROOT (yet completely misleading!)
```
Starting ROOT version 6.26/02.
root [0] gRandom->GetSeed()
(unsigned int) 624
root [1] gRandom->SetSeed(1)
root [2] gRandom->GetSeed()
(unsigned int) 624
```
but
```
root [16] gRandom->TRandom::GetSeed()
(unsigned int) 1
```
