### PR TITLE
Fix for walking through DataDescriptorMatcher structure

### DIFF
--- a/Framework/Core/src/DataDescriptorMatcher.cxx
+++ b/Framework/Core/src/DataDescriptorMatcher.cxx
@@ -454,7 +454,8 @@ std::ostream& operator<<(std::ostream& os, DataDescriptorMatcher const& matcher)
   auto edgeWalker = overloaded{
     [&os](EdgeActions::EnterNode action) {
       os << "(" << action.node->mOp;
-      if (action.node->mOp == DataDescriptorMatcher::Op::Just) {
+      if (action.node->mOp == DataDescriptorMatcher::Op::Just ||
+          action.node->mOp == DataDescriptorMatcher::Op::Not) {
         return ChildAction::VisitLeft;
       }
       return ChildAction::VisitBoth;


### PR DESCRIPTION
- Only visit the left node for operation 'not'.
- Additional small change for DataDescriptorMatcher created from
ConcreteDataTypeMatcher to be in line with the structure used
in all other cases.

Follow up to #8565 