### PR TITLE
MCH: change level of some (pre)clustering messages from error to info

### DIFF
--- a/Detectors/MUON/MCH/Clustering/src/ClusterFinderOriginal.cxx
+++ b/Detectors/MUON/MCH/Clustering/src/ClusterFinderOriginal.cxx
@@ -1288,7 +1288,7 @@ void ClusterFinderOriginal::cleanPixelArray(double threshold, std::vector<double
       }
     }
     if (iNeighbour < 0) {
-      LOG(error) << "There is no pixel above the threshold!?";
+      LOG(info) << "There is no pixel above the threshold!?";
       continue;
     }
 

--- a/Detectors/MUON/MCH/PreClustering/src/PreClusterFinder.cxx
+++ b/Detectors/MUON/MCH/PreClustering/src/PreClusterFinder.cxx
@@ -138,7 +138,7 @@ void PreClusterFinder::loadDigit(const Digit& digit)
 
   // check that the pad is not already fired
   if (de.mapping->pads[iPad].useMe) {
-    LOG(error) << "multiple digits on the same pad (DE " << digit.getDetID() << ", pad " << iPad << ")";
+    LOG(info) << "multiple digits on the same pad (DE " << digit.getDetID() << ", pad " << iPad << ")";
     return;
   }
 


### PR DESCRIPTION
So they do not pollute the infologger at pt2.
Exact reason for the preclustering message being investigated meanwhile.