### PR TITLE
DPL: full serialization of DataDescriptorMatcher in the worklfow dump

### DIFF
--- a/Framework/Core/include/Framework/DataDescriptorMatcher.h
+++ b/Framework/Core/include/Framework/DataDescriptorMatcher.h
@@ -297,6 +297,8 @@ class DataDescriptorMatcher
 
   Node const& getLeft() const { return mLeft; };
   Node const& getRight() const { return mRight; };
+  Node& getLeft() { return mLeft; };
+  Node& getRight() { return mRight; };
   Op getOp() const { return mOp; };
 
  private:

--- a/Framework/Core/src/WorkflowSerializationHelpers.cxx
+++ b/Framework/Core/src/WorkflowSerializationHelpers.cxx
@@ -277,13 +277,9 @@ struct WorkflowImporter : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
     } else if (in(State::IN_INPUT_LEFT_MATCHER)) {
       // this is a matcher leaf, i.e. last matcher of a branch
       // will be merged into the parent matcher
-      // insert a placeholder for empty objects
-      inputMatcherNodes.push_back(ConstantValueMatcher{false});
     } else if (in(State::IN_INPUT_RIGHT_MATCHER)) {
       // this is a matcher leaf, i.e. last matcher of a branch
       // will be merged into the parent matcher
-      // insert a placeholder for empty objects
-      inputMatcherNodes.push_back(ConstantValueMatcher{false});
     } else if (in(State::IN_OUTPUTS)) {
       push(State::IN_OUTPUT);
       outputHasSubSpec = false;
@@ -667,17 +663,14 @@ struct WorkflowImporter : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
     } else if (in(State::IN_INPUT_ORIGIN)) {
       origin.runtimeInit(s.c_str(), std::min(s.size(), 4UL));
       std::string v(s.c_str(), std::min(s.size(), 4UL));
-      inputMatcherNodes.pop_back();
       inputMatcherNodes.push_back(OriginValueMatcher{v});
     } else if (in(State::IN_INPUT_DESCRIPTION)) {
       description.runtimeInit(s.c_str(), std::min(s.size(), 16UL));
       std::string v(s.c_str(), std::min(s.size(), 16UL));
-      inputMatcherNodes.pop_back();
       inputMatcherNodes.push_back(DescriptionValueMatcher{v});
     } else if (in(State::IN_INPUT_STARTTIME)) {
       // we add StartTimeValueMatcher with ContextRef for starttime, no matter what
       // has been in the configuration.
-      inputMatcherNodes.pop_back();
       inputMatcherNodes.push_back(StartTimeValueMatcher(ContextRef{ContextPos::STARTTIME_POS}));
     } else if (in(State::IN_INPUT_MATCHER_OPERATION)) {
       // FIXME: need to implement operator>> to read the op parameter
@@ -746,7 +739,6 @@ struct WorkflowImporter : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
     debug << "Uint(" << i << ")" << std::endl;
     if (in(State::IN_INPUT_SUBSPEC)) {
       subspec = i;
-      inputMatcherNodes.pop_back();
       inputMatcherNodes.push_back(SubSpecificationTypeValueMatcher{i});
     } else if (in(State::IN_OUTPUT_SUBSPEC)) {
       subspec = i;

--- a/Framework/Core/src/WorkflowSerializationHelpers.cxx
+++ b/Framework/Core/src/WorkflowSerializationHelpers.cxx
@@ -732,6 +732,10 @@ struct WorkflowImporter : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
       push(State::IN_METADATUM_CHANNEL);
     } else if (in(State::IN_COMMAND)) {
       command.merge({s});
+    } else {
+      std::stringstream errstr;
+      errstr << "No string handling for argument '" << std::string(str, length) << "' in state " << states.back() << std::endl;
+      throw std::runtime_error(errstr.str());
     }
     pop();
     return true;


### PR DESCRIPTION
working version, cleanup to be done and unit test to be included in PR

The format for serialized matchers is something like:
```
"matcher": {
    "operation": "and",
    "left": {
        "origin": "TST"
    },
    "matcher": {
        "operation": "and",
        "left": {
            "description": "SAMPLE"
        },
        "matcher": {
            "operation": "just",
            "left": {
                "starttime": "$0"
            }
        }
    }
```
Fully qualified input specs which are represented by `ConcreteDataMatcher` are still saved in the simplified format:
```
"origin": "TST",
"description": "SAMPLE",
"subspec": 1,
```
We can add a helper to boil the matcher down to the most possible qualified representation, returning `ConcreteDataMatcher`, `ConreteDataTypeMatcher`, or `OriginValueMatcher`. And with this store the relevant keys in simplified format. But the existing helpers did not yet support this.