### PR TITLE
DPL Analysis: Event mixing: Simplify mixing codes with sliceByCached. Mixing on Filtered and Join

### DIFF
--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -40,16 +40,15 @@ struct GroupedCombinationManager {
   }
 };
 
-template <typename T1, typename GroupingPolicy, typename BP, typename G, typename... Us, typename... As>
-struct GroupedCombinationManager<GroupedCombinationsGenerator<T1, GroupingPolicy, BP, G, pack<Us...>, As...>> {
+template <typename T1, typename GroupingPolicy, typename BP, typename G, typename... As>
+struct GroupedCombinationManager<GroupedCombinationsGenerator<T1, GroupingPolicy, BP, G, As...>> {
   template <typename TG, typename... T2s>
-  static void setGroupedCombination(GroupedCombinationsGenerator<T1, GroupingPolicy, BP, G, pack<Us...>, As...>& comb, TG& grouping, std::tuple<T2s...>& associated)
+  static void setGroupedCombination(GroupedCombinationsGenerator<T1, GroupingPolicy, BP, G, As...>& comb, TG& grouping, std::tuple<T2s...>& associated)
   {
     static_assert(sizeof...(T2s) > 0, "There must be associated tables in process() for a correct pair");
     if constexpr (std::is_same_v<G, TG>) {
-      // Take respective unique associated tables for grouping
-      auto associatedTuple = std::tuple<Us...>(std::get<Us>(associated)...);
-      comb.setTables(grouping, associatedTuple);
+      static_assert(std::conjunction_v<framework::has_type<As, pack<T2s...>>...>, "You didn't subscribed to all tables requested for mixing");
+      comb.setTables(grouping, associated);
     }
   }
 };


### PR DESCRIPTION
Hi @ktf , @jgrosseo ,

this change replaces GroupSlicer with `sliceByCached` for slicing tables. I need yet to see in the benchmarks whether and how much it will improve mixing performance (I expect that caching will help).
Additionally, this mixing already works well with Filtered and Joins, I will check how it can be used with partitions. So at least in this regard it is better than the previous version.