### PR TITLE
new plots for ITSTrackTask / ClusterSize vs Chip (O2 modification, Tr…

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -193,7 +193,7 @@ void TrackerDPL::run(ProcessingContext& pc)
   std::vector<o2::its::TrackITSExt> tracks;
   auto& allClusIdx = pc.outputs().make<std::vector<int>>(Output{"ITS", "TRACKCLSID", 0, Lifetime::Timeframe});
   std::vector<o2::MCCompLabel> trackLabels;
-  auto& allTracks = pc.outputs().make<std::vector<o2::its::TrackITS>>(Output{"ITS", "TRACKS", 0, Lifetime::Timeframe});
+  auto& allTracks = pc.outputs().make<std::vector<o2::its::TrackITSExt>>(Output{"ITS", "TRACKS", 0, Lifetime::Timeframe});
   std::vector<o2::MCCompLabel> allTrackLabels;
 
   auto& vertROFvec = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{"ITS", "VERTICESROF", 0, Lifetime::Timeframe});


### PR DESCRIPTION
…ackITSExt Class Usage)

(TH2D) Corrected cluster size for track clusters vs Chip by Layer

(TH2D) Corrected cluster size for track clusters vs Chip Full Detector

O2 modification is implemented.
There is one modification for O2/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
TrackITS ->TrackITSExt (L196)
