### PR TITLE
ITS GPU: Fix uninitialised array for HIP

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
@@ -478,6 +478,9 @@ void VertexerTraitsGPU::computeTrackletMatching()
 
     size_t bufferSize = mTimeFrameGPU->getConfig().tmpCUBBufferSize;
 
+    // Reset used tracklets
+    checkGPUError(cudaMemset(mTimeFrameGPU->getDeviceUsedTracklets(rofId), false, sizeof(unsigned char) * mTimeFrameGPU->getConfig().maxTrackletsPerCluster * mTimeFrameGPU->getNClustersLayer(rofId, 1)), __FILE__, __LINE__);
+
     gpu::trackletSelectionKernel<true><<<blocksGrid, threadsPerBlock>>>(
       mTimeFrameGPU->getDeviceClustersOnLayer(rofId, 0),
       mTimeFrameGPU->getDeviceClustersOnLayer(rofId, 1),


### PR DESCRIPTION
AMD does not initalise arrays of bool to `false` as nvidia does. This fixes HIP vertexer unpredictable behaviour.