### PR TITLE
MC: Optionally apply device-combine to a couple of workflows

### DIFF
--- a/Detectors/AOD/src/aod-producer-workflow.cxx
+++ b/Detectors/AOD/src/aod-producer-workflow.cxx
@@ -17,6 +17,7 @@
 #include "DetectorsCommonDataFormats/DetID.h"
 #include "DetectorsRaw/HBFUtilsInitializer.h"
 #include "Framework/CallbacksPolicy.h"
+#include "DetectorsBase/DPLWorkflowUtils.h"
 
 using namespace o2::framework;
 using GID = o2::dataformats::GlobalTrackID;
@@ -36,7 +37,8 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation"}},
     {"disable-secondary-vertices", o2::framework::VariantType::Bool, false, {"disable filling secondary vertices"}},
     {"info-sources", VariantType::String, std::string{GID::ALL}, {"comma-separated list of sources to use"}},
-    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}},
+    {"combine-source-devices", o2::framework::VariantType::Bool, false, {"merge DPL source devices"}}};
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
   std::swap(workflowOptions, options);
 }
@@ -59,11 +61,24 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   auto srcCls = src & ~(GID::getSourceMask(GID::MCH) | GID::getSourceMask(GID::MID)); // Don't read global MID and MCH clusters (those attached to tracks are always read)
   auto srcMtc = src & ~GID::getSourceMask(GID::MFTMCH); // Do not request MFTMCH matches
 
-  o2::globaltracking::InputHelper::addInputSpecs(configcontext, specs, srcCls, srcMtc, src, useMC, src);
-  o2::globaltracking::InputHelper::addInputSpecsPVertex(configcontext, specs, useMC);
+  WorkflowSpec inputspecs;
+  o2::globaltracking::InputHelper::addInputSpecs(configcontext, inputspecs, srcCls, srcMtc, src, useMC, src);
+  o2::globaltracking::InputHelper::addInputSpecsPVertex(configcontext, inputspecs, useMC);
   if (enableSV) {
-    o2::globaltracking::InputHelper::addInputSpecsSVertex(configcontext, specs);
+    o2::globaltracking::InputHelper::addInputSpecsSVertex(configcontext, inputspecs);
   }
+  if (configcontext.options().get<bool>("combine-source-devices")) {
+    std::vector<DataProcessorSpec> unmerged;
+    specs.push_back(specCombiner("AOD-input-reader", inputspecs, unmerged));
+    for (auto& is : unmerged) {
+      specs.push_back(is);
+    }
+  } else {
+    for (auto& s : inputspecs) {
+      specs.push_back(s);
+    }
+  }
+
   // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
   o2::raw::HBFUtilsInitializer hbfIni(configcontext, specs);
 

--- a/Detectors/Base/include/DetectorsBase/DPLWorkflowUtils.h
+++ b/Detectors/Base/include/DetectorsBase/DPLWorkflowUtils.h
@@ -1,0 +1,264 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+// some user-space helpers/utilities for DPL workflowspecs
+
+//
+// Created by Sandro Wenzel on 19.04.22.
+//
+
+#ifndef O2_DPLWORKFLOWUTILS_H
+#define O2_DPLWORKFLOWUTILS_H
+
+#include "Framework/RootSerializationSupport.h"
+#include "Framework/WorkflowSpec.h"
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/ConfigContext.h"
+#include "Framework/CompletionPolicy.h"
+#include "Framework/CompletionPolicyHelpers.h"
+#include "Framework/DeviceSpec.h"
+#include "Framework/DataSpecUtils.h"
+#include <vector>
+#include <unordered_map>
+
+namespace o2
+{
+namespace framework
+{
+
+// Finding out if the current process is the master DPL driver process,
+// first setting up the topology. Might be important to know when we write
+// files (to prevent that multiple processes write the same file)
+bool isMasterWorkflowDefinition(ConfigContext const& configcontext)
+{
+  int argc = configcontext.argc();
+  auto argv = configcontext.argv();
+  bool ismaster = true;
+  for (int argi = 0; argi < argc; ++argi) {
+    // when channel-config is present it means that this is started as
+    // as FairMQDevice which means it is already a forked process
+    if (strcmp(argv[argi], "--channel-config") == 0) {
+      ismaster = false;
+      break;
+    }
+  }
+  return ismaster;
+}
+
+// Finding out if we merely want to dump the DPL workflow json file.
+// In this case we could avoid some computation/initialization, when
+// this doesn't influence the topology.
+bool isDumpWorkflowInvocation(ConfigContext const& configcontext)
+{
+  int argc = configcontext.argc();
+  auto argv = configcontext.argv();
+  bool isdump = false;
+  for (int argi = 0; argi < argc; ++argi) {
+    if (strcmp(argv[argi], "--dump-config") == 0) {
+      isdump = true;
+      break;
+    }
+  }
+  return isdump;
+}
+
+// find out if we are an internal DPL device
+// (given the device name)
+bool isInternalDPL(std::string const& name)
+{
+  if (name.find("internal-dpl-") != std::string::npos) {
+    return true;
+  }
+  return false;
+}
+
+// find out the name of THIS DPL device at runtime
+// May be useful to know to prevent certain initializations for
+// say internal DPL devices or writer devices
+std::string whoAmI(ConfigContext const& configcontext)
+{
+  int argc = configcontext.argc();
+  auto argv = configcontext.argv();
+  // the name of this device is the string following the --id field in
+  // the argv invocation
+  for (int argi = 0; argi < argc; ++argi) {
+    if (strcmp(argv[argi], "--id") == 0) {
+      if (argi + 1 < argc) {
+        return std::string(argv[argi + 1]);
+      }
+    }
+  }
+  return std::string("");
+}
+
+// a utility combining multiple specs into one
+// (with some checking that it makes sense)
+// spits out the combined spec (merged inputs/outputs and AlgorithmSpec)
+// Can put policies later whether to multi-thread or serialize internally etc.
+// fills a "remaining" spec container for things it can't simply merge
+// (later on we could do a full topological sort / spec minimization approach)
+o2::framework::DataProcessorSpec specCombiner(std::string const& name, std::vector<DataProcessorSpec> const& speccollection,
+                                              std::vector<DataProcessorSpec>& remaining)
+{
+  std::vector<OutputSpec> combinedOutputSpec;
+  std::vector<InputSpec> combinedInputSpec;
+  std::vector<ConfigParamSpec> combinedOptions;
+
+  // this maps an option key to one of multiple specs where this is used
+  // we will need to introduce unambiguous options in case an option is present multiple times
+  std::unordered_map<std::string, std::vector<std::pair<std::string, ConfigParamSpec>>> optionMerger;
+
+  // maps a process name to a map holder conversion of "namespaced-keys" to original "keys"
+  std::unordered_map<std::string, std::unordered_map<std::string, std::string>> optionsRemap;
+
+  // keep track of which input bindings are already used
+  // (should not have duplicates ... since devices may fetch data just based on the binding)
+  std::unordered_map<std::string, bool> inputBindings;
+
+  // we collect all outputs once ---> this is to check that none of the inputs matches
+  // an output
+  std::vector<OutputSpec> allOutputs;
+  std::vector<DataProcessorSpec> mergableSpecs;
+  for (auto& spec : speccollection) {
+    // merge output specs
+    for (auto& os : spec.outputs) {
+      allOutputs.push_back(os);
+    }
+  }
+
+  for (auto& spec : speccollection) {
+    auto& procname = spec.name;
+    optionsRemap[procname] = std::unordered_map<std::string, std::string>();
+
+    // merge input specs ... but only after we have verified that the spec does
+    // not depend in internal outputs
+    bool inputCheckOk = true;
+    for (auto& is : spec.inputs) {
+      // let's see if input is part of outputs
+      // ... in which case we can't easily merge the spec here
+      // ... and just neglect it for the moment
+      for (auto& o : allOutputs) {
+        if (DataSpecUtils::match(is, o)) {
+          std::cerr << "Found internal connection " << is << " ... will take out spec " << procname << " .. from merging process \n";
+          inputCheckOk = false;
+          break;
+        }
+      }
+    }
+    if (!inputCheckOk) {
+      remaining.push_back(spec);
+      // directly to next task
+      continue;
+    }
+    for (auto& is : spec.inputs) {
+      if (inputBindings.find(is.binding) != inputBindings.end()) {
+        LOG(error) << "Found duplicate input binding " << is.binding;
+      }
+      combinedInputSpec.push_back(is);
+      inputBindings[is.binding] = 1;
+    }
+    mergableSpecs.push_back(spec);
+
+    // merge output specs
+    for (auto& os : spec.outputs) {
+      combinedOutputSpec.push_back(os);
+    }
+    // merge options (part 1)
+    for (auto& opt : spec.options) {
+      auto optkey = opt.name;
+      auto iter = optionMerger.find(optkey);
+      auto procconfigpair = std::pair<std::string, ConfigParamSpec>(procname, opt);
+      if (iter == optionMerger.end()) {
+        optionMerger[optkey] = std::vector<std::pair<std::string, ConfigParamSpec>>();
+      }
+      optionMerger[optkey].push_back(procconfigpair);
+    }
+  }
+  // merge options (part 2)
+  for (auto& iter : optionMerger) {
+    if (iter.second.size() > 1) {
+      // std::cerr << "Option " << iter.first << " duplicated in multiple procs --> applying namespacing \n";
+      for (auto& part : iter.second) {
+        auto procname = part.first;
+        auto originalSpec = part.second;
+        auto namespaced_name = procname + "." + originalSpec.name;
+        combinedOptions.push_back(ConfigParamSpec{namespaced_name,
+                                                  originalSpec.type, originalSpec.defaultValue, originalSpec.help, originalSpec.kind});
+        optionsRemap[procname][namespaced_name] = originalSpec.name;
+        // we need to back-apply
+      }
+    } else {
+      // we can stay with original option
+      for (auto& part : iter.second) {
+        combinedOptions.push_back(part.second);
+      }
+    }
+  }
+
+  // logic for combined task processing function --> target is to run one only
+  class CombinedTask
+  {
+   public:
+    CombinedTask(std::vector<DataProcessorSpec> const& s, std::unordered_map<std::string, std::unordered_map<std::string, std::string>> optionsRemap) : tasks(s), optionsRemap(optionsRemap) {}
+
+    void init(o2::framework::InitContext& ic)
+    {
+      std::cerr << "Init Combined\n";
+      for (auto& t : tasks) {
+        // the init function actually creates the onProcess function
+        // which we have to do here (maybe some more stuff needed)
+        auto& configRegistry = ic.mOptions;
+        // we can get hold of the store because the store is the only data member of configRegistry
+        static_assert(sizeof(o2::framework::ConfigParamRegistry) == sizeof(std::unique_ptr<o2::framework::ConfigParamStore>));
+        auto store = reinterpret_cast<std::unique_ptr<ConfigParamStore>*>(&(configRegistry));
+        auto& boost_store = (*store)->store(); // std::unique_ptr<boost::property_tree::ptree>
+        auto& originalDeviceName = t.name;
+        auto optionsiter = optionsRemap.find(originalDeviceName);
+        if (optionsiter != optionsRemap.end()) {
+          // we have options to remap
+          for (auto& key : optionsiter->second) {
+            //
+            // LOG(info) << "Applying value " << boost_store.get<std::string>(key.first) << " to original key " << key.second;
+            boost_store.put(key.second, boost_store.get<std::string>(key.first));
+          }
+        }
+        t.algorithm.onProcess = t.algorithm.onInit(ic);
+      }
+    }
+
+    void run(o2::framework::ProcessingContext& pc)
+    {
+      std::cerr << "Processing Combined\n";
+      for (auto& t : tasks) {
+        std::cerr << " Executing sub-device " << t.name << "\n";
+        t.algorithm.onProcess(pc);
+      }
+    }
+
+   private:
+    std::vector<DataProcessorSpec> tasks;
+    std::unordered_map<std::string, std::unordered_map<std::string, std::string>> optionsRemap;
+  };
+
+  return DataProcessorSpec{
+    name,
+    combinedInputSpec,
+    combinedOutputSpec,
+    AlgorithmSpec{adaptFromTask<CombinedTask>(mergableSpecs, optionsRemap)},
+    combinedOptions
+    /* a couple of other fields can be set ... */
+  };
+};
+
+} // namespace framework
+} // namespace o2
+
+#endif // O2_DPLWORKFLOWUTILS_H

--- a/Detectors/FIT/FDD/workflow/include/FDDWorkflow/DigitWriterSpec.h
+++ b/Detectors/FIT/FDD/workflow/include/FDDWorkflow/DigitWriterSpec.h
@@ -46,7 +46,7 @@ o2::framework::DataProcessorSpec getFDDDigitWriterSpec(bool mctruth = true, bool
       nent = n;
     }
     outputtree->SetEntries(nent);
-    outputtree->Write();
+    outputfile->Write();
     outputfile->Close();
   };
 
@@ -63,7 +63,7 @@ o2::framework::DataProcessorSpec getFDDDigitWriterSpec(bool mctruth = true, bool
     br->ResetAddress();
   };
 
-  auto labelsdef = BranchDefinition<std::vector<char>>{InputSpec{"labelinput", "FDD", "DIGITLBL"},
+  auto labelsdef = BranchDefinition<std::vector<char>>{InputSpec{"FDDlabelinput", "FDD", "DIGITLBL"},
                                                        "FDDDigitLabels", "labels-branch-name",
                                                        // this branch definition is disabled if MC labels are not processed
                                                        (mctruth ? 1 : 0),
@@ -73,17 +73,17 @@ o2::framework::DataProcessorSpec getFDDDigitWriterSpec(bool mctruth = true, bool
                                   "fdddigits.root",
                                   "o2sim",
                                   MakeRootTreeWriterSpec::CustomClose(finishWriting),
-                                  BranchDefinition<std::vector<o2::fdd::Digit>>{InputSpec{"digitBCinput", "FDD", "DIGITSBC"}, "FDDDigit"},
-                                  BranchDefinition<std::vector<o2::fdd::ChannelData>>{InputSpec{"digitChinput", "FDD", "DIGITSCH"}, "FDDDigitCh"},
-                                  BranchDefinition<std::vector<o2::fdd::DetTrigInput>>{InputSpec{"digitTrinput", "FDD", "TRIGGERINPUT"}, "TRIGGERINPUT"},
+                                  BranchDefinition<std::vector<o2::fdd::Digit>>{InputSpec{"FDDdigitBCinput", "FDD", "DIGITSBC"}, "FDDDigit"},
+                                  BranchDefinition<std::vector<o2::fdd::ChannelData>>{InputSpec{"FDDdigitChinput", "FDD", "DIGITSCH"}, "FDDDigitCh"},
+                                  BranchDefinition<std::vector<o2::fdd::DetTrigInput>>{InputSpec{"FDDdigitTrinput", "FDD", "TRIGGERINPUT"}, "TRIGGERINPUT"},
                                   std::move(labelsdef))();
   } else {
     return MakeRootTreeWriterSpec("FDDDigitWriterRaw",
                                   "o2_fdddigits.root",
                                   "o2sim",
                                   MakeRootTreeWriterSpec::CustomClose(finishWriting),
-                                  BranchDefinition<std::vector<o2::fdd::Digit>>{InputSpec{"digitBCinput", "FDD", "DIGITSBC"}, "FDDDigit"},
-                                  BranchDefinition<std::vector<o2::fdd::ChannelData>>{InputSpec{"digitChinput", "FDD", "DIGITSCH"}, "FDDDigitCh"},
+                                  BranchDefinition<std::vector<o2::fdd::Digit>>{InputSpec{"FDDdigitBCinput", "FDD", "DIGITSBC"}, "FDDDigit"},
+                                  BranchDefinition<std::vector<o2::fdd::ChannelData>>{InputSpec{"FDDdigitChinput", "FDD", "DIGITSCH"}, "FDDDigitCh"},
                                   std::move(labelsdef))();
   }
 }

--- a/Detectors/FIT/FT0/workflow/src/FT0DigitWriterSpec.cxx
+++ b/Detectors/FIT/FT0/workflow/src/FT0DigitWriterSpec.cxx
@@ -51,19 +51,19 @@ o2::framework::DataProcessorSpec getFT0DigitWriterSpec(bool mctruth, bool trigIn
                                   "ft0digits.root",
                                   "o2sim",
                                   MakeRootTreeWriterSpec::CustomClose(finishWriting),
-                                  BranchDefinition<std::vector<o2::ft0::Digit>>{InputSpec{"digitBCinput", "FT0", "DIGITSBC"}, "FT0DIGITSBC", "ft0-digits-branch-name", 1,
+                                  BranchDefinition<std::vector<o2::ft0::Digit>>{InputSpec{"ft0digitBCinput", "FT0", "DIGITSBC"}, "FT0DIGITSBC", "ft0-digits-branch-name", 1,
                                                                                 logger},
-                                  BranchDefinition<std::vector<o2::ft0::ChannelData>>{InputSpec{"digitChinput", "FT0", "DIGITSCH"}, "FT0DIGITSCH", "ft0-chhdata-branch-name"},
-                                  BranchDefinition<std::vector<o2::ft0::DetTrigInput>>{InputSpec{"digitTrinput", "FT0", "TRIGGERINPUT"}, "TRIGGERINPUT", "ft0-triggerinput-branch-name"},
+                                  BranchDefinition<std::vector<o2::ft0::ChannelData>>{InputSpec{"ft0digitChinput", "FT0", "DIGITSCH"}, "FT0DIGITSCH", "ft0-chhdata-branch-name"},
+                                  BranchDefinition<std::vector<o2::ft0::DetTrigInput>>{InputSpec{"ft0digitTrinput", "FT0", "TRIGGERINPUT"}, "TRIGGERINPUT", "ft0-triggerinput-branch-name"},
                                   std::move(labelsdef))();
   } else {
     return MakeRootTreeWriterSpec("FT0DigitWriterRaw",
                                   "o2_ft0digits.root",
                                   "o2sim",
                                   MakeRootTreeWriterSpec::CustomClose(finishWriting),
-                                  BranchDefinition<std::vector<o2::ft0::Digit>>{InputSpec{"digitBCinput", "FT0", "DIGITSBC"}, "FT0DIGITSBC", "ft0-digits-branch-name", 1,
+                                  BranchDefinition<std::vector<o2::ft0::Digit>>{InputSpec{"ft0digitBCinput", "FT0", "DIGITSBC"}, "FT0DIGITSBC", "ft0-digits-branch-name", 1,
                                                                                 logger},
-                                  BranchDefinition<std::vector<o2::ft0::ChannelData>>{InputSpec{"digitChinput", "FT0", "DIGITSCH"}, "FT0DIGITSCH", "ft0-chhdata-branch-name"},
+                                  BranchDefinition<std::vector<o2::ft0::ChannelData>>{InputSpec{"ft0digitChinput", "FT0", "DIGITSCH"}, "FT0DIGITSCH", "ft0-chhdata-branch-name"},
                                   std::move(labelsdef))();
   }
 }

--- a/Detectors/GlobalTrackingWorkflow/src/primary-vertexing-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/primary-vertexing-workflow.cxx
@@ -28,6 +28,7 @@
 #include "Framework/CompletionPolicy.h"
 #include "Framework/ConfigParamSpec.h"
 #include "Framework/CompletionPolicyHelpers.h"
+#include "DetectorsBase/DPLWorkflowUtils.h"
 
 using namespace o2::framework;
 using GID = o2::dataformats::GlobalTrackID;
@@ -55,7 +56,8 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"vertexing-sources", VariantType::String, std::string{GID::ALL}, {"comma-separated list of sources to use in vertexing"}},
     {"validate-with-ft0", o2::framework::VariantType::Bool, false, {"use FT0 time for vertex validation"}},
     {"vertex-track-matching-sources", VariantType::String, std::string{GID::ALL}, {"comma-separated list of sources to use in vertex-track associations or \"none\" to disable matching"}},
-    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}},
+    {"combine-source-devices", o2::framework::VariantType::Bool, false, {"merge DPL source devices"}}};
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
   std::swap(workflowOptions, options);
 }
@@ -96,7 +98,25 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   auto srcMtc = srcComb & ~GID::getSourceMask(GID::MFTMCH); // Do not request MFTMCH matches
 
   // only TOF clusters are needed if TOF is involved, no clusters MC needed
-  o2::globaltracking::InputHelper::addInputSpecs(configcontext, specs, srcClus, srcMtc, srcComb, useMC, dummy);
+  WorkflowSpec inputspecs;
+  o2::globaltracking::InputHelper::addInputSpecs(configcontext, inputspecs, srcClus, srcMtc, srcComb, useMC, dummy);
+
+  if (configcontext.options().get<bool>("combine-source-devices")) {
+    std::vector<DataProcessorSpec> unmerged;
+    specs.push_back(specCombiner("PV-Input-Reader", inputspecs, unmerged));
+    // Note: Switch in future to core framework function, once it can handle duplicate options
+    // auto combined = o2::framework::workflow::combine("PV-Input-Reader", inputspecs, true);
+    // for (auto& c : combined) {
+    //  specs.push_back(c);
+    // }
+    if (unmerged.size() > 0) {
+      LOG(fatal) << "unexpected DPL merge error";
+    }
+  } else {
+    for (auto& s : inputspecs) {
+      specs.push_back(s);
+    }
+  }
 
   if (!disableRootOut) {
     specs.emplace_back(o2::vertexing::getPrimaryVertexWriterSpec(srcVT.none(), useMC));

--- a/Detectors/GlobalTrackingWorkflow/src/secondary-vertexing-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/secondary-vertexing-workflow.cxx
@@ -26,6 +26,7 @@
 #include "Framework/CompletionPolicy.h"
 #include "Framework/ConfigParamSpec.h"
 #include "Framework/CompletionPolicyHelpers.h"
+#include "DetectorsBase/DPLWorkflowUtils.h"
 
 using namespace o2::framework;
 using GID = o2::dataformats::GlobalTrackID;
@@ -51,7 +52,8 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writer"}},
     {"vertexing-sources", VariantType::String, std::string{GID::ALL}, {"comma-separated list of sources to use in vertexing"}},
     {"disable-cascade-finder", o2::framework::VariantType::Bool, false, {"do not run cascade finder"}},
-    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}},
+    {"combine-source-devices", o2::framework::VariantType::Bool, false, {"merge DPL source devices"}}};
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
   std::swap(workflowOptions, options);
 }
@@ -80,8 +82,25 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   specs.emplace_back(o2::vertexing::getSecondaryVertexingSpec(src, enableCasc));
 
   // only TOF clusters are needed if TOF is involved, no clusters MC needed
-  o2::globaltracking::InputHelper::addInputSpecs(configcontext, specs, srcClus, src, src, useMC, srcClus);
-  o2::globaltracking::InputHelper::addInputSpecsPVertex(configcontext, specs, useMC); // P-vertex is always needed
+  WorkflowSpec inputspecs;
+  o2::globaltracking::InputHelper::addInputSpecs(configcontext, inputspecs, srcClus, src, src, useMC, srcClus);
+  o2::globaltracking::InputHelper::addInputSpecsPVertex(configcontext, inputspecs, useMC); // P-vertex is always needed
+
+  if (configcontext.options().get<bool>("combine-source-devices")) {
+    std::vector<DataProcessorSpec> unmerged;
+    specs.push_back(specCombiner("SV-Input-Reader", inputspecs, unmerged));
+    if (unmerged.size() > 0) {
+      // LOG(fatal) << "unexpected DPL merge error";
+      for (auto& s : unmerged) {
+        specs.push_back(s);
+        LOG(info) << " adding unmerged spec " << s.name;
+      }
+    }
+  } else {
+    for (auto& s : inputspecs) {
+      specs.push_back(s);
+    }
+  }
 
   if (!disableRootOut) {
     specs.emplace_back(o2::vertexing::getSecondaryVertexWriterSpec());

--- a/Detectors/ITSMFT/common/workflow/src/DigitWriterSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/DigitWriterSpec.cxx
@@ -61,7 +61,10 @@ DataProcessorSpec getDigitWriterSpec(bool mctruth, bool dec, bool calib, o2::hea
       nent = n;
     }
     outputtree->SetEntries(nent);
-    outputtree->Write("", TObject::kOverwrite);
+    // do not use TTree::Write .. as this writes to default directory (not the associated file)
+    // instead of outputtree->Write("", TObject::kOverwrite)
+    // --> better use TFile::Write or TFile::WriteObject
+    outputfile->Write("", TObject::kOverwrite);
     outputfile->Close();
   };
 

--- a/Detectors/TOF/workflowIO/src/TOFDigitWriterSpec.cxx
+++ b/Detectors/TOF/workflowIO/src/TOFDigitWriterSpec.cxx
@@ -39,9 +39,9 @@ DataProcessorSpec getTOFDigitWriterSpec(bool useMC, bool writeErr)
   *nCalls = 0;
   // the callback to be set as hook at stop of processing for the framework
   auto finishWriting = [nCalls](TFile* outputfile, TTree* outputtree) {
-    printf("finish writing with %d entries in the tree\n", *nCalls);
+    printf("TOF finish writing with %d entries in the tree\n", *nCalls);
     outputtree->SetEntries(*nCalls);
-    outputtree->Write();
+    outputfile->Write();
     outputfile->Close();
   };
   // preprocessor callback
@@ -52,16 +52,16 @@ DataProcessorSpec getTOFDigitWriterSpec(bool useMC, bool writeErr)
   auto loggerH = [nCalls](HeaderType const& indata) {
   };
   auto logger = [nCalls](OutputType const& indata) {
-    //    LOG(info) << "RECEIVED DIGITS SIZE " << indata.size();
+    //    LOG(info) << "TOF: RECEIVED DIGITS SIZE " << indata.size();
   };
   auto loggerROW = [nCalls](ReadoutWinType const& row) {
-    //    LOG(info) << "RECEIVED READOUT WINDOWS " << row.size();
+    //    LOG(info) << "TOF: RECEIVED READOUT WINDOWS " << row.size();
   };
   auto loggerPatterns = [nCalls](PatternType const& patterns) {
-    //    LOG(info) << "RECEIVED PATTERNS " << patterns.size();
+    //    LOG(info) << "TOF: RECEIVED PATTERNS " << patterns.size();
   };
   auto loggerErrors = [nCalls](ErrorType const& errors) {
-    //    LOG(info) << "RECEIVED PATTERNS " << patterns.size();
+    //    LOG(info) << "TOF: Error logger ";
   };
   return MakeRootTreeWriterSpec("TOFDigitWriter",
                                 "tofdigits.root",
@@ -69,32 +69,32 @@ DataProcessorSpec getTOFDigitWriterSpec(bool useMC, bool writeErr)
                                 // the preprocessor only increments the call count, we keep this functionality
                                 // of the original implementation
                                 MakeRootTreeWriterSpec::Preprocessor{preprocessor},
-                                BranchDefinition<HeaderType>{InputSpec{"digitheader", gDataOriginTOF, "DIGITHEADER", 0},
+                                BranchDefinition<HeaderType>{InputSpec{"tofdigitheader", gDataOriginTOF, "DIGITHEADER", 0},
                                                              "TOFHeader",
                                                              "tofdigitheader-branch-name",
                                                              1,
                                                              loggerH},
-                                BranchDefinition<OutputType>{InputSpec{"digits", gDataOriginTOF, "DIGITS", 0},
+                                BranchDefinition<OutputType>{InputSpec{"tofdigits", gDataOriginTOF, "DIGITS", 0},
                                                              "TOFDigit",
                                                              "tofdigits-branch-name",
                                                              1,
                                                              logger},
-                                BranchDefinition<ReadoutWinType>{InputSpec{"rowindow", gDataOriginTOF, "READOUTWINDOW", 0},
+                                BranchDefinition<ReadoutWinType>{InputSpec{"tofrowindow", gDataOriginTOF, "READOUTWINDOW", 0},
                                                                  "TOFReadoutWindow",
                                                                  "rowindow-branch-name",
                                                                  1,
                                                                  loggerROW},
-                                BranchDefinition<PatternType>{InputSpec{"patterns", gDataOriginTOF, "PATTERNS", 0},
+                                BranchDefinition<PatternType>{InputSpec{"tofpatterns", gDataOriginTOF, "PATTERNS", 0},
                                                               "TOFPatterns",
                                                               "patterns-branch-name",
                                                               1,
                                                               loggerPatterns},
-                                BranchDefinition<ErrorType>{InputSpec{"errors", gDataOriginTOF, "ERRORS", 0},
+                                BranchDefinition<ErrorType>{InputSpec{"toferrors", gDataOriginTOF, "ERRORS", 0},
                                                             "TOFErrors",
                                                             "errors-branch-name",
                                                             (writeErr ? 1 : 0), // one branch if mc labels enabled
                                                             loggerErrors},
-                                BranchDefinition<LabelsType>{InputSpec{"labels", gDataOriginTOF, "DIGITSMCTR", 0},
+                                BranchDefinition<LabelsType>{InputSpec{"toflabels", gDataOriginTOF, "DIGITSMCTR", 0},
                                                              "TOFDigitMCTruth",
                                                              (useMC ? 1 : 0), // one branch if mc labels enabled
                                                              "digitlabels-branch-name"})();

--- a/Detectors/TOF/workflowIO/src/TOFMatchedWriterSpec.cxx
+++ b/Detectors/TOF/workflowIO/src/TOFMatchedWriterSpec.cxx
@@ -25,6 +25,7 @@
 #include "DataFormatsTOF/CalibInfoTOF.h"
 #include "DataFormatsTOF/Cluster.h"
 #include "CommonUtils/StringUtils.h"
+#include <sstream>
 
 using namespace o2::framework;
 
@@ -65,19 +66,26 @@ DataProcessorSpec getTOFMatchedWriterSpec(bool useMC, const char* outdef, bool w
     taskName = match_name_strict[mode];
   }
 
+  // inputBindings better be unique for each data spec, otherwise
+  // they can not be "combined" into a single DPL device
+  std::stringstream inputBinding1, inputBinding2, inputBinding3;
+  inputBinding1 << "tofmatching_" << mode;
+  inputBinding2 << "tpctofTracks_" << mode;
+  inputBinding3 << "matchtoflabels_" << mode;
+
   return MakeRootTreeWriterSpec(taskName,
                                 outdef,
                                 "matchTOF",
-                                BranchDefinition<MatchInfo>{InputSpec{"tofmatching", gDataOriginTOF, ddMatchInfo[mode], ss},
+                                BranchDefinition<MatchInfo>{InputSpec{inputBinding1.str().c_str(), gDataOriginTOF, ddMatchInfo[mode], ss},
                                                             "TOFMatchInfo",
                                                             "TOFMatchInfo-branch-name",
                                                             1,
                                                             loggerMatched},
-                                BranchDefinition<TrackInfo>{InputSpec{"tpctofTracks", gDataOriginTOF, "TOFTRACKS_TPC", ss},
+                                BranchDefinition<TrackInfo>{InputSpec{inputBinding2.str().c_str(), gDataOriginTOF, "TOFTRACKS_TPC", ss},
                                                             "TPCTOFTracks",
                                                             "TPCTOFTracks-branch-name",
                                                             writeTracks},
-                                BranchDefinition<LabelsType>{InputSpec{"matchtoflabels", gDataOriginTOF, ddMCMatchTOF[mode], ss},
+                                BranchDefinition<LabelsType>{InputSpec{inputBinding3.str().c_str(), gDataOriginTOF, ddMCMatchTOF[mode], ss},
                                                              "MatchTOFMCTruth",
                                                              "MatchTOFMCTruth-branch-name",
                                                              (useMC ? 1 : 0), // one branch if mc labels enabled

--- a/Steer/DigitizerWorkflow/src/FT0DigitWriterSpec.h
+++ b/Steer/DigitizerWorkflow/src/FT0DigitWriterSpec.h
@@ -38,10 +38,10 @@ o2::framework::DataProcessorSpec getFT0DigitWriterSpec(bool mctruth)
                                 "ft0digits.root",
                                 "o2sim",
                                 1,
-                                BranchDefinition<std::vector<o2::ft0::Digit>>{InputSpec{"digitBCinput", "FT0", "DIGITSBC"}, "FT0DIGITSBC"},
-                                BranchDefinition<std::vector<o2::ft0::ChannelData>>{InputSpec{"digitChinput", "FT0", "DIGITSCH"}, "FT0DIGITSCH"},
-                                BranchDefinition<std::vector<o2::ft0::DetTrigInput>>{InputSpec{"digitTrinput", "FT0", "TRIGGERINPUT"}, "TRIGGERINPUT"},
-                                BranchDefinition<o2::dataformats::MCTruthContainer<o2::ft0::MCLabel>>{InputSpec{"labelinput", "FT0", "DIGITSMCTR"}, "FT0DIGITSMCTR", mctruth ? 1 : 0})();
+                                BranchDefinition<std::vector<o2::ft0::Digit>>{InputSpec{"FT0digitBCinput", "FT0", "DIGITSBC"}, "FT0DIGITSBC"},
+                                BranchDefinition<std::vector<o2::ft0::ChannelData>>{InputSpec{"FT0digitChinput", "FT0", "DIGITSCH"}, "FT0DIGITSCH"},
+                                BranchDefinition<std::vector<o2::ft0::DetTrigInput>>{InputSpec{"FT0digitTrinput", "FT0", "TRIGGERINPUT"}, "TRIGGERINPUT"},
+                                BranchDefinition<o2::dataformats::MCTruthContainer<o2::ft0::MCLabel>>{InputSpec{"FT0labelinput", "FT0", "DIGITSMCTR"}, "FT0DIGITSMCTR", mctruth ? 1 : 0})();
 }
 
 } // namespace ft0

--- a/Steer/DigitizerWorkflow/src/FV0DigitWriterSpec.h
+++ b/Steer/DigitizerWorkflow/src/FV0DigitWriterSpec.h
@@ -37,10 +37,10 @@ o2::framework::DataProcessorSpec getFV0DigitWriterSpec(bool mctruth = true)
                                 "fv0digits.root",
                                 "o2sim",
                                 1,
-                                BranchDefinition<std::vector<o2::fv0::Digit>>{InputSpec{"digitBCinput", "FV0", "DIGITSBC"}, "FV0DigitBC"},
-                                BranchDefinition<std::vector<o2::fv0::ChannelData>>{InputSpec{"digitChinput", "FV0", "DIGITSCH"}, "FV0DigitCh"},
-                                BranchDefinition<std::vector<o2::fv0::DetTrigInput>>{InputSpec{"digitTrinput", "FV0", "TRIGGERINPUT"}, "TRIGGERINPUT"},
-                                BranchDefinition<o2::dataformats::MCTruthContainer<o2::fv0::MCLabel>>{InputSpec{"labelinput", "FV0", "DIGITLBL"}, "FV0DigitLabels", mctruth ? 1 : 0})();
+                                BranchDefinition<std::vector<o2::fv0::Digit>>{InputSpec{"fv0digitBCinput", "FV0", "DIGITSBC"}, "FV0DigitBC"},
+                                BranchDefinition<std::vector<o2::fv0::ChannelData>>{InputSpec{"fv0digitChinput", "FV0", "DIGITSCH"}, "FV0DigitCh"},
+                                BranchDefinition<std::vector<o2::fv0::DetTrigInput>>{InputSpec{"fv0digitTrinput", "FV0", "TRIGGERINPUT"}, "TRIGGERINPUT"},
+                                BranchDefinition<o2::dataformats::MCTruthContainer<o2::fv0::MCLabel>>{InputSpec{"fv0labelinput", "FV0", "DIGITLBL"}, "FV0DigitLabels", mctruth ? 1 : 0})();
 }
 
 } // namespace fv0

--- a/Steer/DigitizerWorkflow/src/HMPIDDigitWriterSpec.h
+++ b/Steer/DigitizerWorkflow/src/HMPIDDigitWriterSpec.h
@@ -36,9 +36,9 @@ o2::framework::DataProcessorSpec getHMPIDDigitWriterSpec(bool mctruth = true)
                                 "hmpiddigits.root",
                                 "o2sim",
                                 1,
-                                BranchDefinition<std::vector<o2::hmpid::Digit>>{InputSpec{"digitinput", "HMP", "DIGITS"}, "HMPDigit"},
-                                BranchDefinition<std::vector<o2::hmpid::Trigger>>{InputSpec{"interactionrecods", "HMP", "INTRECORDS"}, "InteractionRecords"},
-                                BranchDefinition<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>{InputSpec{"labelinput", "HMP", "DIGITLBL"}, "HMPDigitLabels", mctruth ? 1 : 0})();
+                                BranchDefinition<std::vector<o2::hmpid::Digit>>{InputSpec{"hmpdigitinput", "HMP", "DIGITS"}, "HMPDigit"},
+                                BranchDefinition<std::vector<o2::hmpid::Trigger>>{InputSpec{"hmpinteractionrecords", "HMP", "INTRECORDS"}, "InteractionRecords"},
+                                BranchDefinition<o2::dataformats::MCTruthContainer<o2::MCCompLabel>>{InputSpec{"hmplabelinput", "HMP", "DIGITLBL"}, "HMPDigitLabels", mctruth ? 1 : 0})();
 }
 
 } // end namespace hmpid

--- a/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
+++ b/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
@@ -10,6 +10,7 @@
 // or submit itself to any jurisdiction.
 
 #include <boost/program_options.hpp>
+#include <boost/lexical_cast.hpp>
 
 #include "Framework/RootSerializationSupport.h"
 #include "DetectorsBase/Propagator.h"
@@ -109,6 +110,8 @@
 #include <sstream>
 #include <cmath>
 #include <unistd.h> // for getppid
+#include <type_traits>
+#include "DetectorsBase/DPLWorkflowUtils.h"
 
 using namespace o2::framework;
 
@@ -188,6 +191,8 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 
   // option to use or not use the Trap Simulator after digitisation (debate of digitization or reconstruction is for others)
   workflowOptions.push_back(ConfigParamSpec{"disable-trd-trapsim", VariantType::Bool, false, {"disable the trap simulation of the TRD"}});
+
+  workflowOptions.push_back(ConfigParamSpec{"combine-devices", VariantType::Bool, false, {"combined multiple DPL worker/writer devices"}});
 }
 
 void customize(std::vector<o2::framework::DispatchPolicy>& policies)
@@ -277,8 +282,25 @@ void initTPC()
 }
 
 // ------------------------------------------------------------------
+void publish_master_env(const char* key, const char* value)
+{
+  // publish env variables as process master
+  std::stringstream str;
+  str << "O2SIMDIGIINTERNAL_" << getpid() << "_" << key;
+  LOG(info) << "Publishing master key " << str.str();
+  setenv(str.str().c_str(), value, 1);
+}
 
-std::shared_ptr<o2::parameters::GRPObject> readGRP(std::string inputGRP)
+const char* get_master_env(const char* key)
+{
+  // access internal env variables published by master process
+  std::stringstream str;
+  str << "O2SIMDIGIINTERNAL_" << getppid() << "_" << key;
+  // LOG(info) << "Looking up master key " << str.str();
+  return getenv(str.str().c_str());
+}
+
+std::shared_ptr<o2::parameters::GRPObject> readGRP(std::string const& inputGRP)
 {
   auto grp = o2::parameters::GRPObject::loadFrom(inputGRP);
   if (!grp) {
@@ -294,7 +316,7 @@ std::shared_ptr<o2::parameters::GRPObject> readGRP(std::string inputGRP)
 // ------------------------------------------------------------------
 
 // Split a given string on a separator character
-std::vector<std::string> splitString(std::string src, char sep)
+std::vector<std::string> splitString(std::string const& src, char sep)
 {
   std::vector<std::string> fields;
   std::string token;
@@ -318,7 +340,7 @@ struct DetFilterer {
   // mustContain: The nature of this DetFilterer. If true, it is a white lister
   //              i.e. option defines the list of allowed detectors. If false
   //              it is a black lister i.e defines the list of disallowed detectors.
-  DetFilterer(std::string detlist, std::string unsetVal, char separator, bool doWhiteListing)
+  DetFilterer(std::string const& detlist, std::string const& unsetVal, char separator, bool doWhiteListing)
   {
     // option is not set, nothing to do
     if (detlist.compare(unsetVal) == 0) {
@@ -328,7 +350,7 @@ struct DetFilterer {
     std::vector<std::string> tokens = splitString(detlist, separator);
 
     // Convert a vector of strings to one of o2::detectors::DetID
-    for (auto token : tokens) {
+    for (auto& token : tokens) {
       ids.emplace_back(token.c_str());
     }
 
@@ -366,25 +388,6 @@ DetFilterer blacklister(std::string optionVal, std::string unsetValue, char sepa
   return DetFilterer(optionVal, unsetValue, separator, false);
 }
 
-// Finding out if the current process is the master DPL driver process,
-// first setting up the topology. Might be important to know when we write
-// files (to prevent that multiple processes write the same file)
-bool isMasterWorkflowDefinition(ConfigContext const& configcontext)
-{
-  int argc = configcontext.argc();
-  auto argv = configcontext.argv();
-  bool ismaster = true;
-  for (int argi = 0; argi < argc; ++argi) {
-    // when channel-config is present it means that this is started as
-    // as FairMQDevice which means it is already a forked process
-    if (strcmp(argv[argi], "--channel-config") == 0) {
-      ismaster = false;
-      break;
-    }
-  }
-  return ismaster;
-}
-
 // ------------------------------------------------------------------
 
 /// This function is required to be implemented to define the workflow
@@ -397,10 +400,16 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   bool ismaster = isMasterWorkflowDefinition(configcontext);
   gIsMaster = ismaster;
 
-  // Reserve one entry which fill be filled with the SimReaderSpec
+  std::string dplProcessName = whoAmI(configcontext);
+  bool isDPLinternal = isInternalDPL(dplProcessName);
+  bool isDumpWorkflow = isDumpWorkflowInvocation(configcontext);
+  bool initServices = !isDPLinternal && !isDumpWorkflow && !ismaster;
+  // Reserve one entry which will be filled with the SimReaderSpec
   // at the end. This places the processor at the beginning of the
   // workflow in the upper left corner of the GUI.
   WorkflowSpec specs(1);
+  WorkflowSpec digitizerSpecs; // collecting everything producing digits
+  WorkflowSpec writerSpecs;    // collecting everything writing digits to files
 
   using namespace o2::conf;
   ConfigurableParam::updateFromFile(configcontext.options().get<std::string>("configFile"));
@@ -415,30 +424,57 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   auto simPrefixes = splitString(configcontext.options().get<std::string>("sims"), ',');
   // First, read the GRP to detect which components need instantiations
   std::shared_ptr<o2::parameters::GRPObject const> grp(nullptr);
+
+  // lambda to access the GRP time start
+  auto getGRPStartTime = [](o2::parameters::GRPObject const* grp) {
+    const auto GRPTIMEKEY = "GRPTIMESTART";
+    if (gIsMaster && grp) {
+      // we publish a couple of things as environment variables
+      // this saves loading from ROOT file and hence duplicated file reading and
+      // initialization of the ROOT engine in each DPL device
+      auto t = grp->getTimeStart();
+      publish_master_env(GRPTIMEKEY, std::to_string(t).c_str());
+      return t;
+    } else {
+      auto tstr = get_master_env(GRPTIMEKEY);
+      if (!tstr) {
+        LOG(fatal) << "Expected env value not found";
+      }
+      // LOG(info) << "Found entry " << tstr;
+      return boost::lexical_cast<uint64_t>(tstr);
+    }
+  };
+
   if (!helpasked) {
-    grp = readGRP(simPrefixes[0]);
-    if (!grp) {
-      return WorkflowSpec{};
+    if (gIsMaster) {
+      grp = readGRP(simPrefixes[0]);
+      if (!grp) {
+        return WorkflowSpec{};
+      }
+      getGRPStartTime(grp.get());
     }
     if (!hbfu.startTime) { // HBFUtils.startTime was not set from the command line, set it from GRP
-      hbfu.setValue("HBFUtils.startTime", std::to_string(grp->getTimeStart()));
+      hbfu.setValue("HBFUtils.startTime", std::to_string(getGRPStartTime(grp.get())));
     }
   }
-  auto grpfile = o2::base::NameConf::getGRPFileName(simPrefixes[0]);
-  // init on a high level, the time for the CCDB queries
-  // we expect that digitizers do not play with the manager themselves
-  // this will only be needed until digitizers take CCDB objects via DPL mechanism
-  o2::ccdb::BasicCCDBManager::instance().setTimestamp(hbfu.startTime);
-  // activate caching
-  o2::ccdb::BasicCCDBManager::instance().setCaching(true);
-  // without this, caching does not seem to work
-  o2::ccdb::BasicCCDBManager::instance().setLocalObjectValidityChecking(true);
 
+  auto grpfile = o2::base::NameConf::getGRPFileName(simPrefixes[0]);
+  if (initServices) {
+    // init on a high level, the time for the CCDB queries
+    // we expect that digitizers do not play with the manager themselves
+    // this will only be needed until digitizers take CCDB objects via DPL mechanism
+    o2::ccdb::BasicCCDBManager::instance().setTimestamp(hbfu.startTime);
+    // activate caching
+    o2::ccdb::BasicCCDBManager::instance().setCaching(true);
+    // without this, caching does not seem to work
+    o2::ccdb::BasicCCDBManager::instance().setLocalObjectValidityChecking(true);
+  }
   // update the digitization configuration with the right geometry file
   // we take the geometry from the first simPrefix (could actually check if they are
   // all compatible)
   ConfigurableParam::setValue("DigiParams.digitizationgeometry_prefix", simPrefixes[0]);
   ConfigurableParam::setValue("DigiParams.grpfile", grpfile);
+
   LOG(info) << "MC-TRUTH " << !configcontext.options().get<bool>("disable-mc");
   bool mctruth = !configcontext.options().get<bool>("disable-mc");
   ConfigurableParam::setValue("DigiParams", "mctruth", mctruth);
@@ -470,6 +506,23 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   // lambda to extract detectors which are enabled in the workflow
   // will complain if user gave wrong input in construction of DetID
   auto isEnabled = [&configcontext, &filterers, accept, grp, helpasked](o2::detectors::DetID id) {
+    auto isInGRPReadout = [grp](o2::detectors::DetID id) {
+      std::stringstream str;
+      str << "GRPDETKEY_" << id.getName();
+      if (gIsMaster and grp.get() != nullptr) {
+        auto ok = grp->isDetReadOut(id);
+        if (ok) {
+          publish_master_env(str.str().c_str(), "ON");
+        }
+        return ok;
+      } else {
+        // we should have published important GRP info as
+        // environment variables in order to not having to read GRP via ROOT
+        // in all the processes
+        return get_master_env(str.str().c_str()) != nullptr;
+      }
+    };
+
     if (helpasked) {
       return true;
     }
@@ -478,7 +531,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
       return false;
     }
     auto accepted = accept(id);
-    bool is_ingrp = grp->isDetReadOut(id);
+    bool is_ingrp = isInGRPReadout(id);
     if (gIsMaster) {
       LOG(info) << id.getName()
                 << " is in grp? " << (is_ingrp ? "yes" : "no") << ";"
@@ -523,9 +576,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   if (isEnabled(o2::detectors::DetID::ITS)) {
     detList.emplace_back(o2::detectors::DetID::ITS);
     // connect the ITS digitization
-    specs.emplace_back(o2::itsmft::getITSDigitizerSpec(fanoutsize++, mctruth));
+    digitizerSpecs.emplace_back(o2::itsmft::getITSDigitizerSpec(fanoutsize++, mctruth));
     // connect ITS digit writer
-    specs.emplace_back(o2::itsmft::getITSDigitWriterSpec(mctruth));
+    writerSpecs.emplace_back(o2::itsmft::getITSDigitWriterSpec(mctruth));
   }
 
 #ifdef ENABLE_UPGRADES
@@ -543,9 +596,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   if (isEnabled(o2::detectors::DetID::MFT)) {
     detList.emplace_back(o2::detectors::DetID::MFT);
     // connect the MFT digitization
-    specs.emplace_back(o2::itsmft::getMFTDigitizerSpec(fanoutsize++, mctruth));
+    digitizerSpecs.emplace_back(o2::itsmft::getMFTDigitizerSpec(fanoutsize++, mctruth));
     // connect MFT digit writer
-    specs.emplace_back(o2::itsmft::getMFTDigitWriterSpec(mctruth));
+    writerSpecs.emplace_back(o2::itsmft::getMFTDigitWriterSpec(mctruth));
   }
 
   // the TOF part
@@ -561,54 +614,54 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     if (CCDBsa) {
       useCCDB = true;
     }
-    specs.emplace_back(o2::tof::getTOFDigitizerSpec(fanoutsize++, useCCDB, mctruth, ccdb_url_tof.c_str(), timestamp, CCDBsa));
+    digitizerSpecs.emplace_back(o2::tof::getTOFDigitizerSpec(fanoutsize++, useCCDB, mctruth, ccdb_url_tof.c_str(), timestamp, CCDBsa));
     // add TOF digit writer
-    specs.emplace_back(o2::tof::getTOFDigitWriterSpec(mctruth));
+    writerSpecs.emplace_back(o2::tof::getTOFDigitWriterSpec(mctruth));
   }
 
   // the FT0 part
   if (isEnabled(o2::detectors::DetID::FT0)) {
     detList.emplace_back(o2::detectors::DetID::FT0);
     // connect the FIT digitization
-    specs.emplace_back(o2::ft0::getFT0DigitizerSpec(fanoutsize++, mctruth));
+    digitizerSpecs.emplace_back(o2::ft0::getFT0DigitizerSpec(fanoutsize++, mctruth));
     // connect the FIT digit writer
-    specs.emplace_back(o2::ft0::getFT0DigitWriterSpec(mctruth));
+    writerSpecs.emplace_back(o2::ft0::getFT0DigitWriterSpec(mctruth));
   }
 
   // the FV0 part
   if (isEnabled(o2::detectors::DetID::FV0)) {
     detList.emplace_back(o2::detectors::DetID::FV0);
     // connect the FV0 digitization
-    specs.emplace_back(o2::fv0::getFV0DigitizerSpec(fanoutsize++, mctruth));
+    digitizerSpecs.emplace_back(o2::fv0::getFV0DigitizerSpec(fanoutsize++, mctruth));
     // connect the FV0 digit writer
-    specs.emplace_back(o2::fv0::getFV0DigitWriterSpec(mctruth));
+    writerSpecs.emplace_back(o2::fv0::getFV0DigitWriterSpec(mctruth));
   }
 
   // the EMCal part
   if (isEnabled(o2::detectors::DetID::EMC)) {
     detList.emplace_back(o2::detectors::DetID::EMC);
     // connect the EMCal digitization
-    specs.emplace_back(o2::emcal::getEMCALDigitizerSpec(fanoutsize++, mctruth));
+    digitizerSpecs.emplace_back(o2::emcal::getEMCALDigitizerSpec(fanoutsize++, mctruth));
     // connect the EMCal digit writer
-    specs.emplace_back(o2::emcal::getEMCALDigitWriterSpec(mctruth));
+    writerSpecs.emplace_back(o2::emcal::getEMCALDigitWriterSpec(mctruth));
   }
 
   // add HMPID
   if (isEnabled(o2::detectors::DetID::HMP)) {
     detList.emplace_back(o2::detectors::DetID::HMP);
     // connect the HMP digitization
-    specs.emplace_back(o2::hmpid::getHMPIDDigitizerSpec(fanoutsize++, mctruth));
+    digitizerSpecs.emplace_back(o2::hmpid::getHMPIDDigitizerSpec(fanoutsize++, mctruth));
     // connect the HMP digit writer
-    specs.emplace_back(o2::hmpid::getHMPIDDigitWriterSpec(mctruth));
+    writerSpecs.emplace_back(o2::hmpid::getHMPIDDigitWriterSpec(mctruth));
   }
 
   // add ZDC
   if (isEnabled(o2::detectors::DetID::ZDC)) {
     detList.emplace_back(o2::detectors::DetID::ZDC);
     // connect the ZDC digitization
-    specs.emplace_back(o2::zdc::getZDCDigitizerSpec(fanoutsize++, mctruth));
+    digitizerSpecs.emplace_back(o2::zdc::getZDCDigitizerSpec(fanoutsize++, mctruth));
     // connect the ZDC digit writer
-    specs.emplace_back(o2::zdc::getZDCDigitWriterDPLSpec(mctruth, true));
+    writerSpecs.emplace_back(o2::zdc::getZDCDigitWriterDPLSpec(mctruth, true));
   }
 
   // add TRD
@@ -631,45 +684,45 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   if (isEnabled(o2::detectors::DetID::MCH)) {
     detList.emplace_back(o2::detectors::DetID::MCH);
     //connect the MUON MCH digitization
-    specs.emplace_back(o2::mch::getMCHDigitizerSpec(fanoutsize++, mctruth));
+    digitizerSpecs.emplace_back(o2::mch::getMCHDigitizerSpec(fanoutsize++, mctruth));
     //connect the MUON MCH digit writer
-    specs.emplace_back(o2::mch::getMCHDigitWriterSpec(mctruth));
+    writerSpecs.emplace_back(o2::mch::getMCHDigitWriterSpec(mctruth));
   }
 
   // add MID
   if (isEnabled(o2::detectors::DetID::MID)) {
     detList.emplace_back(o2::detectors::DetID::MID);
     // connect the MID digitization
-    specs.emplace_back(o2::mid::getMIDDigitizerSpec(fanoutsize++, mctruth));
+    digitizerSpecs.emplace_back(o2::mid::getMIDDigitizerSpec(fanoutsize++, mctruth));
     // connect the MID digit writer
-    specs.emplace_back(o2::mid::getMIDDigitWriterSpec(mctruth));
+    writerSpecs.emplace_back(o2::mid::getMIDDigitWriterSpec(mctruth));
   }
 
   // add FDD
   if (isEnabled(o2::detectors::DetID::FDD)) {
     detList.emplace_back(o2::detectors::DetID::FDD);
     // connect the FDD digitization
-    specs.emplace_back(o2::fdd::getFDDDigitizerSpec(fanoutsize++, mctruth));
+    digitizerSpecs.emplace_back(o2::fdd::getFDDDigitizerSpec(fanoutsize++, mctruth));
     // connect the FDD digit writer
-    specs.emplace_back(o2::fdd::getFDDDigitWriterSpec(mctruth));
+    writerSpecs.emplace_back(o2::fdd::getFDDDigitWriterSpec(mctruth));
   }
 
   // the PHOS part
   if (isEnabled(o2::detectors::DetID::PHS)) {
     detList.emplace_back(o2::detectors::DetID::PHS);
     // connect the PHOS digitization
-    specs.emplace_back(o2::phos::getPHOSDigitizerSpec(fanoutsize++, mctruth));
+    digitizerSpecs.emplace_back(o2::phos::getPHOSDigitizerSpec(fanoutsize++, mctruth));
     // add PHOS writer
-    specs.emplace_back(o2::phos::getPHOSDigitWriterSpec(mctruth));
+    writerSpecs.emplace_back(o2::phos::getPHOSDigitWriterSpec(mctruth));
   }
 
   // the CPV part
   if (isEnabled(o2::detectors::DetID::CPV)) {
     detList.emplace_back(o2::detectors::DetID::CPV);
     // connect the CPV digitization
-    specs.emplace_back(o2::cpv::getCPVDigitizerSpec(fanoutsize++, mctruth));
+    digitizerSpecs.emplace_back(o2::cpv::getCPVDigitizerSpec(fanoutsize++, mctruth));
     // add PHOS writer
-    specs.emplace_back(o2::cpv::getCPVDigitWriterSpec(mctruth));
+    writerSpecs.emplace_back(o2::cpv::getCPVDigitWriterSpec(mctruth));
   }
   // the CTP part
   if (isEnabled(o2::detectors::DetID::CTP)) {
@@ -681,11 +734,27 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   }
   // GRP updater: must come after all detectors since requires their list
   if (!configcontext.options().get<bool>("only-context")) {
-    specs.emplace_back(o2::parameters::getGRPUpdaterSpec(grpfile, detList));
+    writerSpecs.emplace_back(o2::parameters::getGRPUpdaterSpec(grpfile, detList));
+  }
+
+  bool combine = configcontext.options().get<bool>("combine-devices");
+  if (!combine) {
+    for (auto& s : digitizerSpecs) {
+      specs.push_back(s);
+    }
+    for (auto& s : writerSpecs) {
+      specs.push_back(s);
+    }
+  } else {
+    std::vector<DataProcessorSpec> remaining;
+    specs.push_back(specCombiner("Digitizations", digitizerSpecs, remaining));
+    specs.push_back(specCombiner("Writers", writerSpecs, remaining));
+    for (auto& s : remaining) {
+      specs.push_back(s);
+    }
   }
 
   // The SIM Reader. NEEDS TO BE LAST
   specs[0] = o2::steer::getSimReaderSpec({firstOtherChannel, fanoutsize}, simPrefixes, tpcsectors);
-
   return specs;
 }

--- a/Utilities/Tools/jobutils2.sh
+++ b/Utilities/Tools/jobutils2.sh
@@ -206,9 +206,9 @@ taskwrapper() {
   fi
 
   # with or without memory monitoring ?
-  finalcommand="TIME=\"#walltime %e\" ${TIMECOMMAND} ./${SCRIPTNAME}"
+  finalcommand="TIME=\"#walltime %e\\n#systime %S\\n#usertime %U\" ${TIMECOMMAND} ./${SCRIPTNAME}"
   if [[ "$(uname)" != "Darwin" && "${JOBUTILS_MONITORMEM}" ]]; then
-    finalcommand="TIME=\"#walltime %e\" ${O2_ROOT}/share/scripts/monitor-mem.sh ${TIMECOMMAND} './${SCRIPTNAME}'"
+    finalcommand="TIME=\"#walltime %e\\n#systime %S\\n#usertime %U\" ${O2_ROOT}/share/scripts/monitor-mem.sh ${TIMECOMMAND} './${SCRIPTNAME}'"
   fi
   echo "Running: ${finalcommand}" > ${logfile}
 


### PR DESCRIPTION
The novel ability to combine multiple DataProccesorSpecs (devices)
into a single one is applied (optionally) in a couple of workflows for
MC:
- digitization
- TOC-TPC-ITC matching
- primary vertex finding
- secondary vertex finding
- AOD creation

In all cases, we batch together multiple ROOT reader or writer devices.
In case of digitization, we also combine multiple detector digitizers together.

The benefits are reduction of load time, less CPU system usage, and importantly
a significant reduction in memory (~1GB for AOD creation alone). We also share
more objects like geometry/field between multiple digitizers.

Nothing changes by default: The combinations need to be activated via special
`--combine-devices` (or similar) flags.

In order to make this work, a couple of things needed to be changed/adapted:
- small changes in RootTreeWriter to allow treatment of multiple TTree-TFiles
  pairs in the same process
- usage of unique InputSpec binding-labels in some detector specs
  ... otherwise these InputSpecs cannot be combined into a single device
- for now use of a custom device-combine method until native DPL
  framework::workflow::combine can support combination of devices that
  have same option keys (such as multiple RootTreeWriters together).