### PR TITLE
Fixes in ITS and MFT noise calibration:

### DIFF
--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/NoiseMap.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/NoiseMap.h
@@ -93,15 +93,35 @@ class NoiseMap
     return dumpAboveThreshold(p * mNumOfStrobes);
   }
 
-  void applyProbThreshold(float t, long int n)
+  void applyProbThreshold(float t, long int n, float relErr = 0.2f)
   {
     // Remove from the maps all pixels with the firing probability below the threshold
+    if (n < 1) {
+      LOGP(alarm, "Cannot apply threshold with {} ROFs scanned", n);
+      return;
+    }
     mProbThreshold = t;
     mNumOfStrobes = n;
+    float minFiredForErr = 0.f;
+    if (relErr > 0) {
+      minFiredForErr = relErr * relErr - 1. / n;
+      if (minFiredForErr <= 0.f) {
+        LOGP(alarm, "Noise threshold {} with relative error {} is not reachable with {} ROFs processed, mask all permanently fired pixels", t, relErr);
+        minFiredForErr = n;
+      } else {
+        minFiredForErr = 1. / minFiredForErr;
+      }
+    }
+    int minFired = std::ceil(std::max(t * mNumOfStrobes, minFiredForErr)); // min number of fired pixels exceeding requested threshold
+    auto req = getMinROFs(t, relErr);
+    if (n < req) {
+      mProbThreshold = float(minFired) / n;
+      LOGP(alarm, "Requested relative error {} with prob.threshold {} needs > {} ROFs, {} provided: pixels with noise >{} will be masked", relErr, t, req, n, mProbThreshold);
+    }
+
     for (auto& map : mNoisyPixels) {
       for (auto it = map.begin(); it != map.end();) {
-        float prob = float(it->second) / mNumOfStrobes;
-        if (prob < mProbThreshold) {
+        if (it->second < minFired) {
           it = map.erase(it);
         } else {
           ++it;
@@ -154,6 +174,18 @@ class NoiseMap
     assert(chip < (int)mNoisyPixels.size());
     mNoisyPixels[chip].clear();
   }
+
+  static long getMinROFs(float t, float relErr)
+  {
+    // calculate min number of ROFs needed to reach threshold t with relative error relErr
+    relErr = relErr >= 0.f ? relErr : 0.1;
+    t = t >= 0.f ? t : 1e-6;
+    return std::ceil((1. + 1. / t) / (relErr * relErr));
+  }
+
+  void setNumOfStrobes(long n) { mNumOfStrobes = n; }
+  void addStrobes(long n) { mNumOfStrobes += n; }
+  long getNumberOfStrobes() const { return mNumOfStrobes; }
 
  private:
   static constexpr int SHIFT = 10, MASK = (0x1 << SHIFT) - 1;

--- a/Detectors/ITSMFT/ITS/calibration/include/ITSCalibration/NoiseCalibratorSpec.h
+++ b/Detectors/ITSMFT/ITS/calibration/include/ITSCalibration/NoiseCalibratorSpec.h
@@ -60,6 +60,7 @@ class NoiseCalibratorSpec : public Task
   size_t mNClustersProc = 0;
   int mValidityDays = 3;
   bool mUseClusters = false;
+  bool mStopMeOnly = false; // send QuitRequest::Me instead of QuitRequest::All
   TStopwatch mTimer{};
 };
 

--- a/Detectors/ITSMFT/ITS/calibration/src/NoiseCalibrator.cxx
+++ b/Detectors/ITSMFT/ITS/calibration/src/NoiseCalibrator.cxx
@@ -102,7 +102,7 @@ bool NoiseCalibrator::processTimeFrameClusters(gsl::span<const o2::itsmft::CompC
     hits.clear();
   }
   mNumberOfStrobes += rofs.size();
-  return (mNumberOfStrobes * mProbabilityThreshold * mNInstances >= mThreshold) ? true : false;
+  return (mNumberOfStrobes > mMinROFs) ? true : false;
 }
 
 bool NoiseCalibrator::processTimeFrameDigits(gsl::span<const o2::itsmft::Digit> const& digits,
@@ -140,13 +140,13 @@ bool NoiseCalibrator::processTimeFrameDigits(gsl::span<const o2::itsmft::Digit> 
     hits.clear();
   }
   mNumberOfStrobes += rofs.size();
-  return (mNumberOfStrobes * mProbabilityThreshold * mNInstances >= mThreshold) ? true : false;
+  return (mNumberOfStrobes > mMinROFs) ? true : false;
 }
 
 void NoiseCalibrator::finalize()
 {
   LOG(info) << "Number of processed strobes is " << mNumberOfStrobes;
-  mNoiseMap.applyProbThreshold(mProbabilityThreshold, mNumberOfStrobes);
+  mNoiseMap.applyProbThreshold(mProbabilityThreshold, mNumberOfStrobes, mProbRelErr);
   mNoiseMap.print();
 }
 

--- a/Detectors/ITSMFT/ITS/calibration/src/NoiseCalibratorSpec.cxx
+++ b/Detectors/ITSMFT/ITS/calibration/src/NoiseCalibratorSpec.cxx
@@ -41,9 +41,10 @@ void NoiseCalibratorSpec::init(InitContext& ic)
   auto onepix = ic.options().get<bool>("1pix-only");
   LOG(info) << "Fast 1=pixel calibration: " << onepix;
   auto probT = ic.options().get<float>("prob-threshold");
-  LOG(info) << "Setting the probability threshold to " << probT;
+  auto probTRelErr = ic.options().get<float>("prob-rel-err");
+  LOGP(info, "Setting the probability threshold to {} with relative error {}", probT, probTRelErr);
 
-  mCalibrator = std::make_unique<CALIBRATOR>(onepix, probT);
+  mCalibrator = std::make_unique<CALIBRATOR>(onepix, probT, probTRelErr);
   mCalibrator->setNThreads(ic.options().get<int>("nthreads"));
 
   mValidityDays = ic.options().get<int>("validity-days");
@@ -90,6 +91,11 @@ void NoiseCalibratorSpec::run(ProcessingContext& pc)
 
 void NoiseCalibratorSpec::sendOutput(DataAllocator& output)
 {
+  static bool done = false;
+  if (done) {
+    return;
+  }
+  done = true;
   mCalibrator->finalize();
 
   long tstart = o2::ccdb::getCurrentTimestamp();
@@ -100,7 +106,7 @@ void NoiseCalibratorSpec::sendOutput(DataAllocator& output)
   const auto& payload = mCalibrator->getNoiseMap();
 #endif
   std::map<std::string, std::string> md;
-  o2::ccdb::CcdbObjectInfo info("ITS/Noise", "NoiseMap", "noise.root", md, tstart, tend);
+  o2::ccdb::CcdbObjectInfo info("ITS/Calib/NoiseMap", "NoiseMap", "noise.root", md, tstart, tend);
 
   auto image = o2::ccdb::CcdbApi::createObjectImage(&payload, &info);
   LOG(info) << "Sending object " << info.getPath() << "/" << info.getFileName()
@@ -153,8 +159,8 @@ DataProcessorSpec getNoiseCalibratorSpec(bool useClusters)
     inputs.emplace_back("digits", "ITS", "DIGITS", 0, Lifetime::Timeframe);
     inputs.emplace_back("ROframes", "ITS", "DIGITSROF", 0, Lifetime::Timeframe);
   }
-  auto ccdbRequest = std::make_shared<o2::base::GRPGeomRequest>(true,                           // orbitResetTime
-                                                                true,                           // GRPECS=true
+  auto ccdbRequest = std::make_shared<o2::base::GRPGeomRequest>(false,                          // orbitResetTime
+                                                                false,                          // GRPECS=true
                                                                 false,                          // GRPLHCIF
                                                                 false,                          // GRPMagField
                                                                 false,                          // askMatLUT
@@ -172,6 +178,7 @@ DataProcessorSpec getNoiseCalibratorSpec(bool useClusters)
     Options{
       {"1pix-only", VariantType::Bool, false, {"Fast 1-pixel calibration only (cluster input only)"}},
       {"prob-threshold", VariantType::Float, 3.e-6f, {"Probability threshold for noisy pixels"}},
+      {"prob-rel-err", VariantType::Float, 0.2f, {"Relative error on channel noise to apply the threshold"}},
       {"nthreads", VariantType::Int, 1, {"Number of map-filling threads"}},
       {"validity-days", VariantType::Int, 3, {"Validity on days from upload time"}}}};
 }

--- a/Detectors/ITSMFT/ITS/calibration/src/NoiseSlotCalibrator.cxx
+++ b/Detectors/ITSMFT/ITS/calibration/src/NoiseSlotCalibrator.cxx
@@ -99,6 +99,7 @@ bool NoiseSlotCalibrator::processTimeFrame(gsl::span<const o2::itsmft::CompClust
     }
   }
 
+  noiseMap.addStrobes(rofs.size());
   mNumberOfStrobes += rofs.size();
   return hasEnoughData(slotTF);
 }
@@ -120,16 +121,16 @@ Slot& NoiseSlotCalibrator::emplaceNewSlot(bool front, calibration::TFType tstart
   return slot;
 }
 
-bool NoiseSlotCalibrator::hasEnoughData(const Slot&) const
+bool NoiseSlotCalibrator::hasEnoughData(const Slot& slot) const
 {
-  return (mNumberOfStrobes * mProbabilityThreshold >= mThreshold) ? true : false;
+  return slot.getContainer()->getNumberOfStrobes() > mMinROFs ? true : false;
 }
 
 void NoiseSlotCalibrator::finalizeSlot(Slot& slot)
 {
-  LOG(info) << "Number of processed strobes is " << mNumberOfStrobes;
   o2::itsmft::NoiseMap* map = slot.getContainer();
-  map->applyProbThreshold(mProbabilityThreshold, mNumberOfStrobes);
+  LOG(info) << "Number of processed strobes is " << map->getNumberOfStrobes();
+  map->applyProbThreshold(mProbabilityThreshold, map->getNumberOfStrobes(), mProbRelErr);
 }
 
 } // namespace its

--- a/Detectors/ITSMFT/MFT/calibration/include/MFTCalibration/NoiseCalibrator.h
+++ b/Detectors/ITSMFT/MFT/calibration/include/MFTCalibration/NoiseCalibrator.h
@@ -38,13 +38,12 @@ class NoiseCalibrator
 {
  public:
   NoiseCalibrator() = default;
-  NoiseCalibrator(float prob)
+  NoiseCalibrator(float prob, float relErr = 0.2) : mProbabilityThreshold(prob), mProbRelErr(relErr)
   {
-    mProbabilityThreshold = prob;
+    mMinROFs = 1.1 * o2::itsmft::NoiseMap::getMinROFs(prob, relErr);
+    LOGP(info, "Expect at least {} ROFs needed to apply threshold {} with relative error {}", mMinROFs, mProbabilityThreshold, mProbRelErr);
   }
   ~NoiseCalibrator() = default;
-
-  void setThreshold(unsigned int t) { mThreshold = t; }
 
   bool processTimeFrame(calibration::TFType tf,
                         gsl::span<const o2::itsmft::Digit> const& digits,
@@ -56,7 +55,7 @@ class NoiseCalibrator
                         gsl::span<const o2::itsmft::ROFRecord> const& rofs);
 
   void finalize();
-
+  void setMinROFs(long n) { mMinROFs = n; }
   void setClusterDictionary(const o2::itsmft::TopologyDictionary* d) { mDict = d; }
 
   const o2::itsmft::NoiseMap& getNoiseMap() const { return mNoiseMap; }
@@ -65,7 +64,8 @@ class NoiseCalibrator
   const o2::itsmft::TopologyDictionary* mDict = nullptr;
   o2::itsmft::NoiseMap mNoiseMap{936};
   float mProbabilityThreshold = 1e-6f;
-  unsigned int mThreshold = 100;
+  float mProbRelErr = 0.2; // relative error on channel noise to apply the threshold
+  long mMinROFs = 0;
   unsigned int mNumberOfStrobes = 0;
 };
 

--- a/Detectors/ITSMFT/MFT/calibration/include/MFTCalibration/NoiseCalibratorSpec.h
+++ b/Detectors/ITSMFT/MFT/calibration/include/MFTCalibration/NoiseCalibratorSpec.h
@@ -67,6 +67,7 @@ class NoiseCalibratorSpec : public Task
   int64_t mStart;
   int64_t mEnd;
   bool mDigits = false;
+  bool mStopMeOnly = false; // send QuitRequest::Me instead of QuitRequest::All
 };
 
 /// create a processor spec

--- a/Detectors/ITSMFT/MFT/calibration/include/MFTCalibration/NoiseSlotCalibrator.h
+++ b/Detectors/ITSMFT/MFT/calibration/include/MFTCalibration/NoiseSlotCalibrator.h
@@ -41,11 +41,12 @@ class NoiseSlotCalibrator : public o2::calibration::TimeSlotCalibration<o2::itsm
 
  public:
   NoiseSlotCalibrator() { setUpdateAtTheEndOfRunOnly(); }
-  NoiseSlotCalibrator(float prob)
+  NoiseSlotCalibrator(float prob, float relErr) : mProbabilityThreshold(prob), mProbRelErr(relErr)
   {
-    mProbabilityThreshold = prob;
     setUpdateAtTheEndOfRunOnly();
     setSlotLength(INFINITE_TF);
+    mMinROFs = 1.1 * o2::itsmft::NoiseMap::getMinROFs(prob, relErr);
+    LOGP(info, "At least {} ROFs needed to apply threshold {} with relative error {}", mMinROFs, mProbabilityThreshold, mProbRelErr);
   }
   ~NoiseSlotCalibrator() final = default;
 
@@ -59,6 +60,8 @@ class NoiseSlotCalibrator : public o2::calibration::TimeSlotCalibration<o2::itsm
                         gsl::span<const o2::itsmft::CompClusterExt> const& clusters,
                         gsl::span<const unsigned char> const& patterns,
                         gsl::span<const o2::itsmft::ROFRecord> const& rofs);
+
+  void setMinROFs(long n) { mMinROFs = n; }
 
   void finalize()
   {
@@ -86,6 +89,8 @@ class NoiseSlotCalibrator : public o2::calibration::TimeSlotCalibration<o2::itsm
 
  private:
   float mProbabilityThreshold = 1e-6f;
+  float mProbRelErr = 0.2; // relative error on channel noise to apply the threshold
+  long mMinROFs = 0;
   unsigned int mThreshold = 100;
   unsigned int mNumberOfStrobes = 0;
 };

--- a/Detectors/ITSMFT/MFT/calibration/src/NoiseCalibrator.cxx
+++ b/Detectors/ITSMFT/MFT/calibration/src/NoiseCalibrator.cxx
@@ -42,7 +42,7 @@ bool NoiseCalibrator::processTimeFrame(calibration::TFType tf,
     }
   }
   mNumberOfStrobes += rofs.size();
-  return (mNumberOfStrobes * mProbabilityThreshold >= mThreshold) ? true : false;
+  return (mNumberOfStrobes > mMinROFs) ? true : false;
 }
 
 bool NoiseCalibrator::processTimeFrame(calibration::TFType tf,
@@ -115,13 +115,14 @@ bool NoiseCalibrator::processTimeFrame(calibration::TFType tf,
     }
   }
   mNumberOfStrobes += rofs.size();
-  return (mNumberOfStrobes * mProbabilityThreshold >= mThreshold) ? true : false;
+  return (mNumberOfStrobes > mMinROFs) ? true : false;
 }
 
 void NoiseCalibrator::finalize()
 {
   LOG(info) << "Number of processed strobes is " << mNumberOfStrobes;
   mNoiseMap.applyProbThreshold(mProbabilityThreshold, mNumberOfStrobes);
+  mNoiseMap.print();
 }
 
 } // namespace mft

--- a/Detectors/ITSMFT/MFT/calibration/src/NoiseCalibratorSpec.cxx
+++ b/Detectors/ITSMFT/MFT/calibration/src/NoiseCalibratorSpec.cxx
@@ -44,14 +44,15 @@ void NoiseCalibratorSpec::init(InitContext& ic)
 {
   o2::base::GRPGeomHelper::instance().setRequest(mCCDBRequest);
   auto probT = ic.options().get<float>("prob-threshold");
-  LOG(info) << "Setting the probability threshold to " << probT;
+  auto probTRelErr = ic.options().get<float>("prob-rel-err");
+  LOGP(info, "Setting the probability threshold to {} with relative error {}", probT, probTRelErr);
 
   mPath = ic.options().get<std::string>("path-CCDB");
   mMeta = ic.options().get<std::string>("meta");
   mStart = ic.options().get<int64_t>("tstart");
   mEnd = ic.options().get<int64_t>("tend");
 
-  mCalibrator = std::make_unique<CALIBRATOR>(probT);
+  mCalibrator = std::make_unique<CALIBRATOR>(probT, probTRelErr);
 
   mPathDcs = ic.options().get<std::string>("path-DCS");
   mOutputType = ic.options().get<std::string>("send-to-server");
@@ -69,7 +70,7 @@ void NoiseCalibratorSpec::run(ProcessingContext& pc)
     if (mCalibrator->processTimeFrame(tfcounter, digits, rofs)) {
       LOG(info) << "Minimum number of noise counts has been reached !";
       sendOutputCcdb(pc.outputs());
-      pc.services().get<ControlService>().readyToQuit(QuitRequest::All);
+      pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
     }
   } else {
     const auto compClusters = pc.inputs().get<gsl::span<o2::itsmft::CompClusterExt>>("compClusters");
@@ -330,10 +331,10 @@ DataProcessorSpec getNoiseCalibratorSpec(bool useDigits)
     inputs.emplace_back("compClusters", detOrig, "COMPCLUSTERS", 0, Lifetime::Timeframe);
     inputs.emplace_back("patterns", detOrig, "PATTERNS", 0, Lifetime::Timeframe);
     inputs.emplace_back("ROframes", detOrig, "CLUSTERSROF", 0, Lifetime::Timeframe);
-    inputs.emplace_back("cldict", "ITS", "CLUSDICT", 0, Lifetime::Condition, ccdbParamSpec("MFT/Calib/ClusterDictionary"));
+    inputs.emplace_back("cldict", "MFT", "CLUSDICT", 0, Lifetime::Condition, ccdbParamSpec("MFT/Calib/ClusterDictionary"));
   }
-  auto ccdbRequest = std::make_shared<o2::base::GRPGeomRequest>(true,                           // orbitResetTime
-                                                                true,                           // GRPECS=true
+  auto ccdbRequest = std::make_shared<o2::base::GRPGeomRequest>(false,                          // orbitResetTime
+                                                                false,                          // GRPECS=true
                                                                 false,                          // GRPLHCIF
                                                                 false,                          // GRPMagField
                                                                 false,                          // askMatLUT
@@ -351,13 +352,13 @@ DataProcessorSpec getNoiseCalibratorSpec(bool useDigits)
     AlgorithmSpec{adaptFromTask<NoiseCalibratorSpec>(useDigits, ccdbRequest)},
     Options{
       {"prob-threshold", VariantType::Float, 1.e-6f, {"Probability threshold for noisy pixels"}},
+      {"prob-rel-err", VariantType::Float, 0.2f, {"Relative error on channel noise to apply the threshold"}},
       {"tstart", VariantType::Int64, -1ll, {"Start of validity timestamp"}},
       {"tend", VariantType::Int64, -1ll, {"End of validity timestamp"}},
       {"path-CCDB", VariantType::String, "/MFT/Calib/NoiseMap", {"Path to write to in CCDB"}},
       {"path-DCS", VariantType::String, "/MFT/Config/NoiseMap", {"Path to write to in CCDB"}},
       {"meta", VariantType::String, "", {"meta data to write in CCDB"}},
-      {"send-to-server", VariantType::String, "CCDB-DCS", {"meta data to write in DCS-CCDB"}},
-      {"hb-per-tf", VariantType::Int, 256, {"Number of HBF per TF"}}}};
+      {"send-to-server", VariantType::String, "CCDB-DCS", {"meta data to write in DCS-CCDB"}}}};
 }
 
 } // namespace mft

--- a/Detectors/ITSMFT/MFT/calibration/src/NoiseSlotCalibrator.cxx
+++ b/Detectors/ITSMFT/MFT/calibration/src/NoiseSlotCalibrator.cxx
@@ -44,7 +44,7 @@ bool NoiseSlotCalibrator::processTimeFrame(calibration::TFType nTF,
       noiseMap.increaseNoiseCount(id, row, col);
     }
   }
-
+  noiseMap.addStrobes(rofs.size());
   mNumberOfStrobes += rofs.size();
   return hasEnoughData(slotTF);
 }
@@ -107,7 +107,7 @@ bool NoiseSlotCalibrator::processTimeFrame(calibration::TFType nTF,
       }
     }
   }
-
+  noiseMap.addStrobes(rofs.size());
   mNumberOfStrobes += rofs.size();
   return hasEnoughData(slotTF);
 }
@@ -129,16 +129,16 @@ Slot& NoiseSlotCalibrator::emplaceNewSlot(bool front, calibration::TFType tstart
   return slot;
 }
 
-bool NoiseSlotCalibrator::hasEnoughData(const Slot&) const
+bool NoiseSlotCalibrator::hasEnoughData(const Slot& slot) const
 {
-  return (mNumberOfStrobes * mProbabilityThreshold >= mThreshold) ? true : false;
+  return slot.getContainer()->getNumberOfStrobes() > mMinROFs ? true : false;
 }
 
 void NoiseSlotCalibrator::finalizeSlot(Slot& slot)
 {
-  LOG(info) << "Number of processed strobes is " << mNumberOfStrobes;
   o2::itsmft::NoiseMap* map = slot.getContainer();
-  map->applyProbThreshold(mProbabilityThreshold, mNumberOfStrobes);
+  LOG(info) << "Number of processed strobes is " << map->getNumberOfStrobes();
+  map->applyProbThreshold(mProbabilityThreshold, map->getNumberOfStrobes(), mProbRelErr);
 }
 
 } // namespace mft

--- a/Detectors/ITSMFT/MFT/workflow/CMakeLists.txt
+++ b/Detectors/ITSMFT/MFT/workflow/CMakeLists.txt
@@ -40,3 +40,8 @@ o2_add_executable(assessment-workflow
                   SOURCES src/mft-assessment-workflow.cxx
                   COMPONENT_NAME mft
                   PUBLIC_LINK_LIBRARIES O2::MFTWorkflow)
+
+o2_add_executable(cluster-writer-workflow
+                  SOURCES src/mft-cluster-writer-workflow.cxx
+                  COMPONENT_NAME mft
+                  PUBLIC_LINK_LIBRARIES O2::MFTWorkflow)

--- a/Detectors/ITSMFT/MFT/workflow/src/mft-cluster-writer-workflow.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/mft-cluster-writer-workflow.cxx
@@ -1,0 +1,39 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "MFTWorkflow/ClusterWriterSpec.h"
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
+
+using namespace o2::framework;
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:MFT|mft).*[W,w]riter.*"));
+}
+
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  workflowOptions.push_back(
+    ConfigParamSpec{"disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation even if available"}});
+}
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/Logger.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  auto useMC = !configcontext.options().get<bool>("disable-mc");
+  WorkflowSpec specs;
+  specs.emplace_back(o2::mft::getClusterWriterSpec(useMC));
+  return specs;
+}

--- a/Detectors/ITSMFT/common/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/EntropyDecoderSpec.cxx
@@ -82,10 +82,10 @@ void EntropyDecoderSpec::endOfStream(EndOfStreamContext& ec)
 void EntropyDecoderSpec::updateTimeDependentParams(ProcessingContext& pc)
 {
   if (mMaskNoise) {
-    mNoiseMap = pc.inputs().get<o2::itsmft::NoiseMap*>("noise").get();
+    pc.inputs().get<o2::itsmft::NoiseMap*>("noise").get();
   }
   if (mGetDigits || mMaskNoise) {
-    pc.inputs().get<o2::itsmft::NoiseMap*>("cldict");
+    pc.inputs().get<o2::itsmft::TopologyDictionary*>("cldict");
   }
   mCTFCoder.updateTimeDependentParams(pc);
 }
@@ -93,6 +93,7 @@ void EntropyDecoderSpec::updateTimeDependentParams(ProcessingContext& pc)
 void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
 {
   if (matcher == ConcreteDataMatcher(mOrigin, "NOISEMAP", 0)) {
+    mNoiseMap = (o2::itsmft::NoiseMap*)obj;
     LOG(info) << mOrigin.as<std::string>() << " noise map updated";
     return;
   }


### PR DESCRIPTION
NoiseMap class: there was a risk of good pixels masking if target statistics 100/threshold_prob was
not reached, since the pixel was masked if r = n_fired / nRofs > threshold_prob.
Now we additionally require that the relative error on the pixel firing rate is below certain
threshold (20% by default -> ~25 hits at least).
Requirement is not applied if requested error is <=0.

MFT: Suppress unneeded option, ClusterDictionary request (ITS was used)
ITS: Fix CCDB output patch to ITS/Calib/NoiseMap

both:
1) at the moment disable timestamp and GRPECS requests since they are not used.
2) estimated needed number of ROFs from required probability threshold and its noise rate
relative error.
3) In case of TimeSlot based calibration: require needed ROFs statistics per slot instead of total counts