### PR TITLE
Omit token check if internal CCDB is used

### DIFF
--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -5,7 +5,7 @@
 MYDIR="$(dirname $(realpath $0))"
 source $MYDIR/setenv.sh
 
-if [[ $EPNSYNCMODE == 0 ]]; then
+if [[ $EPNSYNCMODE == 0 ]] && [[ $DPL_CONDITION_BACKEND != "http://o2-ccdb.internal" ]]; then
   alien-token-info >& /dev/null
   if [[ $? != 0 ]]; then
     echo "No alien token present" 1>&2


### PR DESCRIPTION
Hi @davidrohr 
should we maybe avoid the check for the token in case we are using the internal CCDB on the EPNs? Otherwise one gets an error when trying to run the `start_tmux.sh` script, because this does not set the EPNSYNCMODE.