### PR TITLE
MCH: fixed BC rollover in digits merger

### DIFF
--- a/Detectors/MUON/MCH/Raw/Decoder/src/DataDecoder.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/DataDecoder.cxx
@@ -381,7 +381,7 @@ uint64_t DataDecoder::getMergerChannelBitmask(DualSampaChannelId channel)
 
 bool DataDecoder::mergeDigits(uint32_t mergerChannelId, uint32_t mergerBoardId, uint64_t mergerChannelBitmask, o2::mch::raw::SampaCluster& sc)
 {
-  static constexpr uint32_t BCROLLOVER = (1 << 20);
+  uint32_t BCROLLOVER = (mTimeRecoMode == TimeRecoMode::BCReset) ? (mBcInOrbit * mOrbitsInTF) : (1 << 20);
   static constexpr uint32_t ONEADCCLOCK = 4;
   static constexpr uint32_t MAXNOFSAMPLES = 0x3FF;
   static constexpr uint32_t TWENTYBITSATONE = 0xFFFFF;


### PR DESCRIPTION
The BC rollover constant is set to OrbitsInTF * 3564 in the case of the BC reset at each TF.