### PR TITLE
CTP: Make the NCOUNTERS variable constexpr

### DIFF
--- a/DataFormats/Detectors/CTP/include/DataFormatsCTP/Scalers.h
+++ b/DataFormats/Detectors/CTP/include/DataFormatsCTP/Scalers.h
@@ -86,7 +86,7 @@ class CTPRunScalers
   void setRunNumber(uint32_t rnumber) { mRunNumber = rnumber; };
   //
   int parseZMQScalers(std::string zmqscalers);
-  static const uint32_t NCOUNTERS = 1052;
+  static constexpr uint32_t NCOUNTERS = 1052;
   static std::vector<std::string> scalerNames;
 
  private:


### PR DESCRIPTION
This small change is required to fix O2 building under my CLion dev environment. What is strange is that an aliBuild build was successful - maybe the compiler parameters the IDE is using by default are different?