### PR TITLE
Fix MID tracks labels request/fetching in RecoContainer

### DIFF
--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
@@ -80,6 +80,7 @@ class Cluster;
 class ROFRecord;
 class Track;
 class MCClusterLabel;
+class MCLabel;
 } // namespace o2::mid
 
 namespace o2::itsmft
@@ -299,6 +300,7 @@ struct RecoContainer {
   std::unique_ptr<const o2::dataformats::MCTruthContainer<o2::emcal::MCLabel>> mcEMCCells;
   std::unique_ptr<const o2::dataformats::MCTruthContainer<o2::mid::MCClusterLabel>> mcMIDTrackClusters;
   std::unique_ptr<const o2::dataformats::MCTruthContainer<o2::mid::MCClusterLabel>> mcMIDClusters;
+  std::unique_ptr<const o2::dataformats::MCTruthContainer<o2::MCCompLabel>> mcMIDTracks; // temporary, why MID stores MCTruthContainer for tracks and not single label?
 
   gsl::span<const unsigned char> clusterShMapTPC; ///< externally set TPC clusters sharing map
 
@@ -477,7 +479,8 @@ struct RecoContainer {
   auto getMIDTracksROFRecords() const { return getSpan<o2::mid::ROFRecord>(GTrackID::MID, TRACKREFS); }
   auto getMIDTrackClusters() const { return getSpan<o2::mid::Cluster>(GTrackID::MID, INDICES); }
   auto getMIDTrackClustersROFRecords() const { return getSpan<o2::mid::ROFRecord>(GTrackID::MID, MATCHES); }
-  auto getMIDTracksMCLabels() const { return getSpan<o2::MCCompLabel>(GTrackID::MID, MCLABELS); }
+  // auto getMIDTracksMCLabels() const { return getSpan<o2::MCCompLabel>(GTrackID::MID, MCLABELS); }
+  const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* getMIDTracksMCLabels() const; // temporary?
   const o2::dataformats::MCTruthContainer<o2::mid::MCClusterLabel>* getMIDTracksClusterMCLabels() const;
 
   // MID clusters

--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h
@@ -30,6 +30,7 @@
 #include "DataFormatsMID/Cluster.h"
 #include "DataFormatsMID/Track.h"
 #include "DataFormatsMID/MCClusterLabel.h"
+#include "DataFormatsMID/MCLabel.h"
 
 #include "DataFormatsTPC/TrackTPC.h"
 #include "DataFormatsTOF/Cluster.h"

--- a/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
+++ b/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
@@ -779,9 +779,16 @@ void RecoContainer::addMIDTracks(ProcessingContext& pc, bool mc)
   commonPool[GTrackID::MID].registerContainer(pc.inputs().get<gsl::span<o2::mid::Cluster>>("trackMIDTRACKCLUSTERS"), INDICES);
   commonPool[GTrackID::MID].registerContainer(pc.inputs().get<gsl::span<o2::mid::ROFRecord>>("trackClMIDROF"), MATCHES);
   if (mc) {
-    commonPool[GTrackID::MID].registerContainer(pc.inputs().get<gsl::span<o2::MCCompLabel>>("trackMIDMCTR"), MCLABELS);
+    //    commonPool[GTrackID::MID].registerContainer(pc.inputs().get<gsl::span<o2::MCCompLabel>>("trackMIDMCTR"), MCLABELS);
+    mcMIDTracks = pc.inputs().get<const dataformats::MCTruthContainer<o2::MCCompLabel>*>("trackMIDMCTR");
     mcMIDTrackClusters = pc.inputs().get<const dataformats::MCTruthContainer<o2::mid::MCClusterLabel>*>("trackMIDMCTRCL");
   }
+}
+
+//________________________________________________________
+const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* RecoContainer::getMIDTracksMCLabels() const
+{
+  return mcMIDTracks.get(); // temporary ? see comment on mcMIDTracks
 }
 
 //________________________________________________________


### PR DESCRIPTION
This fixes the problem revealed by the PR8434

@sawenzel @TimoWilken @davidrohr  : the https://github.com/AliceO2Group/AliceO2/pull/8434 breaks `aod-producer` in the sim_challenge.ch but nevertheless, it has passed the fullCI. Do you understand why?
