### PR TITLE
FT0: new decoder, based on AVX512

### DIFF
--- a/DataFormats/Detectors/FIT/common/include/DataFormatsFIT/Triggers.h
+++ b/DataFormats/Detectors/FIT/common/include/DataFormatsFIT/Triggers.h
@@ -32,10 +32,10 @@ class Triggers
   enum { bitA = 0,
          bitC = 1,      // alias of bitAIn (FT0/FDD)
          bitAIn = 1,    // alias of bitC (FV0)
-         bitVertex = 2, // alias of bitAOut (FT0/FDD)
+         bitSCen = 2,
          bitAOut = 2,   // alias of bitVertex (FV0)
          bitCen = 3,
-         bitSCen = 4,
+         bitVertex = 4, // alias of bitAOut (FT0/FDD)
          bitLaser = 5,             // indicates the laser was triggered in this BC
          bitOutputsAreBlocked = 6, // indicates that laser-induced pulses should arrive from detector to FEE in this BC (and trigger outputs are blocked)
          bitDataIsValid = 7 };
@@ -44,7 +44,7 @@ class Triggers
   static const int16_t DEFAULT_ZERO = 0;
 
   Triggers() = default;
-  Triggers(uint8_t signals, int8_t chanA, int8_t chanC, int32_t aamplA, int32_t aamplC, int16_t atimeA, int16_t atimeC)
+  Triggers(uint8_t signals, uint8_t chanA, uint8_t chanC, int32_t aamplA, int32_t aamplC, int16_t atimeA, int16_t atimeC)
   {
     triggersignals = signals;
     nChanA = chanA;
@@ -67,14 +67,14 @@ class Triggers
   bool getDataIsValid() const { return (triggersignals & (1 << bitDataIsValid)) != 0; }
 
   int8_t getTriggersignals() const { return triggersignals; }
-  int8_t getNChanA() const { return nChanA; }
-  int8_t getNChanC() const { return nChanC; }
+  uint8_t getNChanA() const { return nChanA; }
+  uint8_t getNChanC() const { return nChanC; }
   int32_t getAmplA() const { return amplA; }
   int32_t getAmplC() const { return amplC; }
   int16_t getTimeA() const { return timeA; }
   int16_t getTimeC() const { return timeC; }
 
-  void setTriggers(uint8_t trgsig, int8_t chanA, int8_t chanC, int32_t aamplA, int32_t aamplC, int16_t atimeA, int16_t atimeC)
+  void setTriggers(uint8_t trgsig, uint8_t chanA, uint8_t chanC, int32_t aamplA, int32_t aamplC, int16_t atimeA, int16_t atimeC)
   {
     triggersignals = trgsig;
     nChanA = chanA;
@@ -85,7 +85,7 @@ class Triggers
     timeC = atimeC;
   }
 
-  void setTriggers(Bool_t isA, Bool_t isC, Bool_t isVrtx, Bool_t isCnt, Bool_t isSCnt, int8_t chanA, int8_t chanC, int32_t aamplA,
+  void setTriggers(Bool_t isA, Bool_t isC, Bool_t isVrtx, Bool_t isCnt, Bool_t isSCnt, uint8_t chanA, uint8_t chanC, int32_t aamplA,
                    int32_t aamplC, int16_t atimeA, int16_t atimeC, Bool_t isLaser, Bool_t isOutputsAreBlocked, Bool_t isDataValid)
   {
     uint8_t trgsig = (isA << bitA) | (isC << bitC) | (isVrtx << bitVertex) | (isCnt << bitCen) | (isSCnt << bitSCen) | (isLaser << bitLaser) | (isOutputsAreBlocked << bitOutputsAreBlocked) | (isDataValid << bitDataIsValid);
@@ -112,14 +112,14 @@ class Triggers
 
  public:                                 // TODO: change to 'private' after modifying QC to use the setters/getters
   uint8_t triggersignals = DEFAULT_ZERO; // FIT trigger signals
-  int8_t nChanA = DEFAULT_ZERO;          // number of fired channels A side
-  int8_t nChanC = DEFAULT_ZERO;          // number of fired channels A side
+  uint8_t nChanA = DEFAULT_ZERO;          // number of fired channels A side
+  uint8_t nChanC = DEFAULT_ZERO;          // number of fired channels A side
   int32_t amplA = DEFAULT_AMP;           // sum amplitude A side
   int32_t amplC = DEFAULT_AMP;           // sum amplitude C side
   int16_t timeA = DEFAULT_TIME;          // average time A side (shouldn't be used if nChanA == 0)
   int16_t timeC = DEFAULT_TIME;          // average time C side (shouldn't be used if nChanC == 0)
 
-  ClassDefNV(Triggers, 4);
+  ClassDefNV(Triggers, 5);
 };
 
 } // namespace fit

--- a/DataFormats/Detectors/FIT/common/include/DataFormatsFIT/Triggers.h
+++ b/DataFormats/Detectors/FIT/common/include/DataFormatsFIT/Triggers.h
@@ -30,12 +30,12 @@ class Triggers
 {
  public:
   enum { bitA = 0,
-         bitC = 1,      // alias of bitAIn (FT0/FDD)
-         bitAIn = 1,    // alias of bitC (FV0)
+         bitC = 1,   // alias of bitAIn (FT0/FDD)
+         bitAIn = 1, // alias of bitC (FV0)
          bitSCen = 2,
-         bitAOut = 2,   // alias of bitVertex (FV0)
+         bitAOut = 2, // alias of bitVertex (FV0)
          bitCen = 3,
-         bitVertex = 4, // alias of bitAOut (FT0/FDD)
+         bitVertex = 4,            // alias of bitAOut (FT0/FDD)
          bitLaser = 5,             // indicates the laser was triggered in this BC
          bitOutputsAreBlocked = 6, // indicates that laser-induced pulses should arrive from detector to FEE in this BC (and trigger outputs are blocked)
          bitDataIsValid = 7 };
@@ -112,8 +112,8 @@ class Triggers
 
  public:                                 // TODO: change to 'private' after modifying QC to use the setters/getters
   uint8_t triggersignals = DEFAULT_ZERO; // FIT trigger signals
-  uint8_t nChanA = DEFAULT_ZERO;          // number of fired channels A side
-  uint8_t nChanC = DEFAULT_ZERO;          // number of fired channels A side
+  uint8_t nChanA = DEFAULT_ZERO;         // number of fired channels A side
+  uint8_t nChanC = DEFAULT_ZERO;         // number of fired channels A side
   int32_t amplA = DEFAULT_AMP;           // sum amplitude A side
   int32_t amplC = DEFAULT_AMP;           // sum amplitude C side
   int16_t timeA = DEFAULT_TIME;          // average time A side (shouldn't be used if nChanA == 0)

--- a/Detectors/FIT/FT0/workflow/CMakeLists.txt
+++ b/Detectors/FIT/FT0/workflow/CMakeLists.txt
@@ -9,6 +9,9 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
+CHECK_CXX_COMPILER_FLAG("-mavx512f -mavx512vl -mavx512bw -mavx512dq" FT0_DECODER_AVX512_GOOD_FLAGS)
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND FT0_DECODER_AVX512_GOOD_FLAGS)
+add_definitions(-DFT0_DECODER_AVX512)
 o2_add_library(FT0Workflow
                SOURCES src/RecoWorkflow.cxx
                        src/ReconstructionSpec.cxx
@@ -27,6 +30,34 @@ o2_add_library(FT0Workflow
                                      O2::Framework
                                      O2::DPLUtils
                                      O2::DataFormatsGlobalTracking)
+o2_add_library(FT0Decoder
+               SOURCES src/FT0DataDecoderDPLSpec.cxx
+                       PUBLIC_LINK_LIBRARIES O2::DataFormatsFT0
+                                     O2::Framework
+                                     O2::DetectorsCommonDataFormats
+                                     O2::DPLUtils
+                                     TARGETVARNAME targetDecoderAVX512)
+target_compile_options(${targetDecoderAVX512} PRIVATE -mavx512f -mavx512vl -mavx512bw -mavx512dq)
+else()
+o2_add_library(FT0Workflow
+               SOURCES src/RecoWorkflow.cxx
+                       src/ReconstructionSpec.cxx
+                       src/RecPointWriterSpec.cxx
+                       src/RecPointReaderSpec.cxx
+                       src/EntropyEncoderSpec.cxx
+                       src/EntropyDecoderSpec.cxx
+                       src/DigitReaderSpec.cxx
+                       src/FT0DigitWriterSpec.cxx
+                       src/RecoQCworkflow.cxx
+               PUBLIC_LINK_LIBRARIES O2::DataFormatsFT0
+                                     O2::FT0Reconstruction
+                                     O2::FT0Raw
+                                     O2::DetectorsCommonDataFormats
+                                     O2::Framework
+                                     O2::DPLUtils
+                                     O2::DataFormatsGlobalTracking)
+
+endif()
 
 o2_add_executable(reco-workflow
                   SOURCES src/ft0-reco-workflow.cxx
@@ -65,17 +96,6 @@ o2_add_executable(recpoints-reader-workflow
                   SOURCES src/recpoints-reader-workflow.cxx
                   COMPONENT_NAME ft0
                   PUBLIC_LINK_LIBRARIES O2::FT0Workflow)
-CHECK_CXX_COMPILER_FLAG("-mavx512f -mavx512vl -mavx512bw -mavx512dq" FT0_DECODER_AVX512_GOOD_FLAGS)
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND FT0_DECODER_AVX512_GOOD_FLAGS)
-o2_add_library(FT0Decoder
-               SOURCES src/FT0DataDecoderDPLSpec.cxx
-                       PUBLIC_LINK_LIBRARIES O2::DataFormatsFT0
-                                     O2::Framework
-                                     O2::DetectorsCommonDataFormats
-                                     O2::DPLUtils
-                                     TARGETVARNAME targetDecoderAVX512)
-target_compile_options(${targetDecoderAVX512} PRIVATE -mavx512f -mavx512vl -mavx512bw -mavx512dq)
-endif()
 if(NOT APPLE)
 
  set_property(TARGET ${fitrecoexe} PROPERTY LINK_WHAT_YOU_USE ON)

--- a/Detectors/FIT/FT0/workflow/CMakeLists.txt
+++ b/Detectors/FIT/FT0/workflow/CMakeLists.txt
@@ -22,6 +22,7 @@ o2_add_library(FT0Workflow
                PUBLIC_LINK_LIBRARIES O2::DataFormatsFT0
                                      O2::FT0Reconstruction
                                      O2::FT0Raw
+                                     O2::FT0Decoder
                                      O2::DetectorsCommonDataFormats
                                      O2::Framework
                                      O2::DPLUtils
@@ -64,7 +65,17 @@ o2_add_executable(recpoints-reader-workflow
                   SOURCES src/recpoints-reader-workflow.cxx
                   COMPONENT_NAME ft0
                   PUBLIC_LINK_LIBRARIES O2::FT0Workflow)
-
+CHECK_CXX_COMPILER_FLAG("-mavx512f -mavx512vl -mavx512bw -mavx512dq" FT0_DECODER_AVX512_GOOD_FLAGS)
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND FT0_DECODER_AVX512_GOOD_FLAGS)
+o2_add_library(FT0Decoder
+               SOURCES src/FT0DataDecoderDPLSpec.cxx
+                       PUBLIC_LINK_LIBRARIES O2::DataFormatsFT0
+                                     O2::Framework
+                                     O2::DetectorsCommonDataFormats
+                                     O2::DPLUtils
+                                     TARGETVARNAME targetDecoderAVX512)
+target_compile_options(${targetDecoderAVX512} PRIVATE -mavx512f -mavx512vl -mavx512bw -mavx512dq)
+endif()
 if(NOT APPLE)
 
  set_property(TARGET ${fitrecoexe} PROPERTY LINK_WHAT_YOU_USE ON)

--- a/Detectors/FIT/FT0/workflow/include/FT0Workflow/FT0DataDecoderDPLSpec.h
+++ b/Detectors/FIT/FT0/workflow/include/FT0Workflow/FT0DataDecoderDPLSpec.h
@@ -12,7 +12,7 @@
 /// @file   FT0DataDecoderDPLSpec.h
 
 #if defined(__has_include)
-#if defined(__linux__) && (defined(__x86_64) || defined(__x86_64__)) && __has_include(<emmintrin.h>) && __has_include(<immintrin.h>)
+#if defined(__linux__) && (defined(__x86_64) || defined(__x86_64__)) && __has_include(<emmintrin.h>) && __has_include(<immintrin.h>) && defined(FT0_DECODER_AVX512)
 
 #ifndef O2_FT0DATADECODERDPLSPEC_H
 #define O2_FT0DATADECODERPLSPEC_H

--- a/Detectors/FIT/FT0/workflow/include/FT0Workflow/FT0DataDecoderDPLSpec.h
+++ b/Detectors/FIT/FT0/workflow/include/FT0Workflow/FT0DataDecoderDPLSpec.h
@@ -11,7 +11,7 @@
 
 /// @file   FT0DataDecoderDPLSpec.h
 
-#if defined __has_include
+#if defined(__has_include)
 #if defined(__linux__) && (defined(__x86_64) || defined(__x86_64__)) && __has_include(<emmintrin.h>) && __has_include(<immintrin.h>)
 
 #ifndef O2_FT0DATADECODERDPLSPEC_H

--- a/Detectors/FIT/FT0/workflow/include/FT0Workflow/FT0DataDecoderDPLSpec.h
+++ b/Detectors/FIT/FT0/workflow/include/FT0Workflow/FT0DataDecoderDPLSpec.h
@@ -34,7 +34,6 @@
 #include <gsl/span>
 #include <chrono>
 #include "CommonUtils/VerbosityConfig.h"
-
 #include "DataFormatsFT0/Digit.h"
 #include "DataFormatsFT0/ChannelData.h"
 #include "DataFormatsFT0/LookUpTable.h"

--- a/Detectors/FIT/FT0/workflow/include/FT0Workflow/FT0DataDecoderDPLSpec.h
+++ b/Detectors/FIT/FT0/workflow/include/FT0Workflow/FT0DataDecoderDPLSpec.h
@@ -1,0 +1,133 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   FT0DataDecoderDPLSpec.h
+
+#if defined __has_include
+#if defined(__linux__) && (defined(__x86_64) || defined(__x86_64__)) && __has_include(<emmintrin.h>) && __has_include(<immintrin.h>)
+
+#ifndef O2_FT0DATADECODERDPLSPEC_H
+#define O2_FT0DATADECODERPLSPEC_H
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+#include "Framework/CallbackService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "Framework/Lifetime.h"
+#include "Framework/Output.h"
+#include "Framework/WorkflowSpec.h"
+#include "Framework/SerializationMethods.h"
+#include "DPLUtils/DPLRawParser.h"
+#include "Framework/InputRecordWalker.h"
+#include <string>
+#include <iostream>
+#include <algorithm>
+#include <vector>
+#include <gsl/span>
+#include <chrono>
+#include "CommonUtils/VerbosityConfig.h"
+
+#include "DataFormatsFT0/Digit.h"
+#include "DataFormatsFT0/ChannelData.h"
+#include "DataFormatsFT0/LookUpTable.h"
+#include "DataFormatsFIT/Triggers.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace ft0
+{
+class FT0DataDecoderDPLSpec : public Task
+{
+ public:
+  FT0DataDecoderDPLSpec() = default;
+  ~FT0DataDecoderDPLSpec() override = default;
+  using Digit_t = o2::ft0::Digit;
+  using ChannelData_t = o2::ft0::ChannelData;
+  using LookupTable_t = o2::ft0::SingleLUT;
+  static constexpr int sNorbits = 256;
+  static constexpr int sNBC = 3564;
+  static constexpr int sNlinksMax = 24;
+  using NChDataBC_t = std::array<uint32_t, sNBC + 4>;
+  using NChDataOrbitBC_t = std::array<NChDataBC_t, sNlinksMax>;
+  std::array<std::array<uint32_t, 16>, sNlinksMax> mLUT;
+  NChDataOrbitBC_t mPosChDataPerLinkOrbit[sNorbits];
+  uint8_t mFEEID_TCM;
+  void init(InitContext& ic) final
+  {
+
+    auto ccdbUrl = ic.options().get<std::string>("ccdb-path");
+    auto lutPath = ic.options().get<std::string>("lut-path");
+    mVecDigits.resize(sNorbits * sNBC);
+    mVecChannelData.resize(216 * sNorbits * sNBC);
+    mVecTriggers.resize(sNBC);
+    // mVecChannelDataBuf.resize(216*3564);
+    mVecChannelDataBuf.resize(143);
+    if (ccdbUrl != "") {
+      LookupTable_t::setCCDBurl(ccdbUrl);
+    }
+    if (lutPath != "") {
+      LookupTable_t::setLUTpath(lutPath);
+    }
+    LookupTable_t::Instance().printFullMap();
+
+    const auto& lut = LookupTable_t::Instance().getMapEntryPM2ChannelID();
+    const auto& tcm = LookupTable_t::Instance().getEntryCRU_TCM();
+    mFEEID_TCM = tcm.mLinkID + 12 * tcm.mEndPointID;
+    std::array<uint32_t, 16> tmpChunk;
+    std::fill_n(tmpChunk.begin(), 16, 0xff);
+    std::fill_n(mLUT.begin(), 16, tmpChunk);
+    for (const auto& entry : lut) {
+      const auto& key = entry.first;
+      const auto& value = entry.second;
+      const auto feeID = key.mEntryCRU.mLinkID + 12 * key.mEntryCRU.mEndPointID;
+
+      if (feeID >= sNlinksMax || key.mLocalChannelID >= 16) {
+        LOG(warning) << "Incorrect entry: " << key.mEntryCRU.mFEEID << " " << key.mLocalChannelID;
+      } else {
+        mLUT[feeID][key.mLocalChannelID] = value;
+      }
+    }
+  }
+  std::vector<o2::ft0::ChannelData> mVecChannelData;
+  std::vector<std::array<o2::ft0::ChannelData, 25 * 216>> mVecChannelDataBuf; // buffer per orbit
+  std::vector<o2::ft0::Digit> mVecDigits;
+  std::vector<o2::fit::Triggers> mVecTriggers;
+  void run(ProcessingContext& pc) final;
+};
+
+framework::DataProcessorSpec getFT0DataDecoderDPLSpec(bool askSTFDist)
+{
+  std::vector<OutputSpec> outputSpec;
+  outputSpec.emplace_back(o2::header::gDataOriginFT0, "DIGITSBC", 0, Lifetime::Timeframe);
+  outputSpec.emplace_back(o2::header::gDataOriginFT0, "DIGITSCH", 0, Lifetime::Timeframe);
+  std::vector<InputSpec> inputSpec{{"STF", ConcreteDataTypeMatcher{"FT0", "RAWDATA"}, Lifetime::Optional}};
+  if (askSTFDist) {
+    inputSpec.emplace_back("STFDist", "FLP", "DISTSUBTIMEFRAME", 0, Lifetime::Timeframe);
+  }
+  std::string dataProcName = "ft0-datadecoder-dpl";
+  LOG(info) << dataProcName;
+  return DataProcessorSpec{
+    dataProcName,
+    inputSpec,
+    outputSpec,
+    adaptFromTask<FT0DataDecoderDPLSpec>(),
+    {o2::framework::ConfigParamSpec{"ccdb-path", VariantType::String, "", {"CCDB url which contains LookupTable"}},
+     o2::framework::ConfigParamSpec{"lut-path", VariantType::String, "", {"LookupTable path, e.g. FT0/LookupTable"}}}};
+}
+
+} // namespace ft0
+} // namespace o2
+
+#endif /* O2_FITDATAREADERDPL_H */
+#endif
+#endif

--- a/Detectors/FIT/FT0/workflow/src/FT0DataDecoderDPLSpec.cxx
+++ b/Detectors/FIT/FT0/workflow/src/FT0DataDecoderDPLSpec.cxx
@@ -12,7 +12,7 @@
 /// @file   FITDataDecoderDPLSpec.cxx
 
 #if defined(__has_include)
-#if defined(__linux__) && (defined(__x86_64) || defined(__x86_64__)) && __has_include(<emmintrin.h>) && __has_include(<immintrin.h>)
+#if defined(__linux__) && (defined(__x86_64) || defined(__x86_64__)) && __has_include(<emmintrin.h>) && __has_include(<immintrin.h>) && defined(FT0_DECODER_AVX512)
 
 #include "FT0Workflow/FT0DataDecoderDPLSpec.h"
 #include <numeric>

--- a/Detectors/FIT/FT0/workflow/src/FT0DataDecoderDPLSpec.cxx
+++ b/Detectors/FIT/FT0/workflow/src/FT0DataDecoderDPLSpec.cxx
@@ -62,14 +62,11 @@ void FT0DataDecoderDPLSpec::run(ProcessingContext& pc)
   using ArrDataPerLink = std::array<std::vector<gsl::span<const uint8_t>>, sNlinksMax>;
   std::array<ArrRdhPtrPerLink, sNorbits> arrRdhPtrPerOrbit{};
   std::array<ArrDataPerLink, sNorbits> arrDataPerOrbit{};
-
   std::array<std::vector<const o2::header::RAWDataHeader*>, sNorbits> arrRdhTCMperOrbit{};
   std::array<std::vector<gsl::span<const uint8_t>>, sNorbits> arrDataTCMperOrbit{};
-
-  // const auto& arrLUT = LookupTable_t::Instance().getArrFEEIDandLocalChID();
   std::array<std::size_t, sNorbits> arrOrbitSizePages{};
-
   std::array<uint64_t, sNorbits> arrOrbit{};
+
   for (auto it = parser.begin(), end = parser.end(); it != end; ++it) {
     // Aggregating pages by orbit and FeeID
     if (!it.size()) {
@@ -96,7 +93,7 @@ void FT0DataDecoderDPLSpec::run(ProcessingContext& pc)
   uint64_t eventPosPerOrbit{0};
 
   uint64_t posChDataPerOrbit[sNorbits]{}; // position per orbit
-  uint64_t nChDataPerOrbit[sNorbits]{};   // position per orbit
+  uint64_t nChDataPerOrbit[sNorbits]{};   // number of events per orbit
   NChDataBC_t posChDataPerBC[sNorbits]{};
   for (int iOrbit = 0; iOrbit < sNorbits; iOrbit++) {
     if (!arrOrbitSizePages[iOrbit]) {
@@ -176,6 +173,7 @@ void FT0DataDecoderDPLSpec::run(ProcessingContext& pc)
     } // linkID
     // Channel data position within BC per LinkID
     memcpy(mPosChDataPerLinkOrbit[iOrbit].data(), bufBC.data(), (sNBC + 4) * 4 * sNlinksMax);
+    // TCM proccessing
     memset(mVecTriggers.data(), 0, 16 * 3564);
     uint8_t* ptrDstTCM = (uint8_t*)mVecTriggers.data();
     const auto& nPagesTCM = arrRdhTCMperOrbit[iOrbit].size();
@@ -251,7 +249,6 @@ void FT0DataDecoderDPLSpec::run(ProcessingContext& pc)
     NChDataBC_t buf_nPosPerBC{};
     uint64_t nChPerBC{0};
     uint64_t nEventOrbit{0};
-
     posChDataPerOrbit[iOrbit] = chPosOrbit; //
 
     __m512i zmm_mask_seq2 = _mm512_set_epi32(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);

--- a/Detectors/FIT/FT0/workflow/src/FT0DataDecoderDPLSpec.cxx
+++ b/Detectors/FIT/FT0/workflow/src/FT0DataDecoderDPLSpec.cxx
@@ -1,0 +1,521 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   FITDataDecoderDPLSpec.cxx
+
+#if defined __has_include
+#if defined(__linux__) && (defined(__x86_64) || defined(__x86_64__)) && __has_include(<emmintrin.h>) && __has_include(<immintrin.h>)
+
+#include "FT0Workflow/FT0DataDecoderDPLSpec.h"
+#include <numeric>
+#include <emmintrin.h>
+#include <immintrin.h>
+#include <algorithm>
+#include <cstdlib>
+#include <string.h>
+
+namespace o2
+{
+namespace ft0
+{
+
+void FT0DataDecoderDPLSpec::run(ProcessingContext& pc)
+{
+  auto t1 = std::chrono::high_resolution_clock::now();
+
+  // if we see requested data type input with 0xDEADBEEF subspec and 0 payload this means that the "delayed message"
+  // mechanism created it in absence of real data from upstream. Processor should send empty output to not block the workflow
+  {
+    static size_t contDeadBeef = 0; // number of times 0xDEADBEEF was seen continuously
+    std::vector<InputSpec> dummy{InputSpec{"dummy", ConcreteDataMatcher{"FT0", o2::header::gDataDescriptionRawData, 0xDEADBEEF}}};
+    for (const auto& ref : InputRecordWalker(pc.inputs(), dummy)) {
+      const auto dh = o2::framework::DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
+      auto payloadSize = DataRefUtils::getPayloadSize(ref);
+      if (payloadSize == 0) {
+        auto maxWarn = o2::conf::VerbosityConfig::Instance().maxWarnDeadBeef;
+        if (++contDeadBeef <= maxWarn) {
+          LOGP(warning, "Found input [{}/{}/{:#x}] TF#{} 1st_orbit:{} Payload {} : assuming no payload for all links in this TF{}",
+               dh->dataOrigin.str, dh->dataDescription.str, dh->subSpecification, dh->tfCounter, dh->firstTForbit, payloadSize,
+               contDeadBeef == maxWarn ? fmt::format(". {} such inputs in row received, stopping reporting", contDeadBeef) : "");
+        }
+        mVecDigits.resize(0);
+        pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginFT0, "DIGITSBC", 0, o2::framework::Lifetime::Timeframe}, mVecDigits);
+        mVecChannelData.resize(0);
+        pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginFT0, "DIGITSCH", 0, o2::framework::Lifetime::Timeframe}, mVecChannelData);
+        return;
+      }
+    }
+    contDeadBeef = 0; // if good data, reset the counter
+  }
+  std::vector<InputSpec> filter{InputSpec{"filter", ConcreteDataTypeMatcher{"FT0", o2::header::gDataDescriptionRawData}, Lifetime::Timeframe}};
+  DPLRawParser parser(pc.inputs(), filter);
+
+  using ArrRdhPtrPerLink = std::array<std::vector<const o2::header::RAWDataHeader*>, sNlinksMax>;
+  using ArrDataPerLink = std::array<std::vector<gsl::span<const uint8_t>>, sNlinksMax>;
+  std::array<ArrRdhPtrPerLink, sNorbits> arrRdhPtrPerOrbit{};
+  std::array<ArrDataPerLink, sNorbits> arrDataPerOrbit{};
+
+  std::array<std::vector<const o2::header::RAWDataHeader*>, sNorbits> arrRdhTCMperOrbit{};
+  std::array<std::vector<gsl::span<const uint8_t>>, sNorbits> arrDataTCMperOrbit{};
+
+  // const auto& arrLUT = LookupTable_t::Instance().getArrFEEIDandLocalChID();
+  std::array<std::size_t, sNorbits> arrOrbitSizePages{};
+
+  std::array<uint64_t, sNorbits> arrOrbit{};
+  for (auto it = parser.begin(), end = parser.end(); it != end; ++it) {
+    // Aggregating pages by orbit and FeeID
+    if (!it.size()) {
+      continue; // excluding pages without payload
+    }
+    auto rdhPtr = it.get_if<o2::header::RAWDataHeader>();
+    const uint16_t orbitTF = (rdhPtr->orbit) % 256;
+    // const uint16_t feeID=rdhPtr->feeId;
+    arrOrbit[orbitTF] = rdhPtr->orbit;
+    const auto& linkID = rdhPtr->linkID;
+    const auto& endPoint = rdhPtr->endPointID;
+    const uint16_t feeID = linkID + 12 * endPoint;
+    if (feeID == mFEEID_TCM) {
+      // Iterator is noncopyable, preparing RDH pointers and span objects
+      arrRdhTCMperOrbit[orbitTF].push_back(it.get_if<o2::header::RAWDataHeader>());
+      arrDataTCMperOrbit[orbitTF].emplace_back(it.data(), it.size());
+    } else {
+      arrOrbitSizePages[orbitTF] += it.size();
+      arrRdhPtrPerOrbit[orbitTF][feeID].push_back(it.get_if<o2::header::RAWDataHeader>());
+      arrDataPerOrbit[orbitTF][feeID].emplace_back(it.data(), it.size());
+    }
+  }
+  uint64_t chPosOrbit{0};
+  uint64_t eventPosPerOrbit{0};
+
+  uint64_t posChDataPerOrbit[sNorbits]{}; // position per orbit
+  uint64_t nChDataPerOrbit[sNorbits]{};   // position per orbit
+  NChDataBC_t posChDataPerBC[sNorbits]{};
+  for (int iOrbit = 0; iOrbit < sNorbits; iOrbit++) {
+    if (!arrOrbitSizePages[iOrbit]) {
+      continue;
+    }
+    const auto& orbit = arrOrbit[iOrbit];
+    NChDataOrbitBC_t bufBC{};
+    NChDataBC_t buf_nChPerBC{};
+    for (int iFeeID = 0; iFeeID < sNlinksMax; iFeeID++) {
+      if (iFeeID == mFEEID_TCM) {
+        continue;
+      }
+      const auto& nPages = arrRdhPtrPerOrbit[iOrbit][iFeeID].size();
+
+      for (int iPage = 0; iPage < nPages; iPage++) {
+        const auto& rdhPtr = arrRdhPtrPerOrbit[iOrbit][iFeeID][iPage];
+        const auto& payload = arrDataPerOrbit[iOrbit][iFeeID][iPage].data();
+        const auto& payloadSize = arrDataPerOrbit[iOrbit][iFeeID][iPage].size();
+        const uint8_t* src = (uint8_t*)payload;
+        const auto nNGBTwords = payloadSize / 16;
+        const int nNGBTwordsDiff = nNGBTwords % 16;
+        const int nChunks = nNGBTwords / 16 + static_cast<int>(nNGBTwordsDiff > 0);
+        const auto lastChunk = nChunks - 1;
+        const uint16_t mask = (0xffff << (16 - nNGBTwordsDiff)) | (0xffff * (nNGBTwordsDiff == 0));
+        __m512i zmm_pos1 = _mm512_set_epi32(0, 16, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240);
+        __m512i zmm_pos2 = _mm512_set1_epi32(6);
+        zmm_pos2 = _mm512_add_epi32(zmm_pos1, zmm_pos2);
+        for (int iChunk = 0; iChunk < nChunks; iChunk++) {
+          __mmask16 mask16_MaxGBTwords = _mm512_int2mask((0xffff * (iChunk != lastChunk)) | mask);
+          __m512i zmm_mask_zero = _mm512_setzero_epi32();
+
+          __m512i zmm_src_column0_part0 = _mm512_mask_i32gather_epi32(zmm_mask_zero, mask16_MaxGBTwords, zmm_pos1, src, 1);
+          __m512i zmm_src_column1_part1 = _mm512_mask_i32gather_epi32(zmm_mask_zero, mask16_MaxGBTwords, zmm_pos2, src, 1);
+          // ChID column(contains ChID in data and descriptor in header)
+          __m512i zmm_mask_localChID = _mm512_set1_epi32(0xf);
+          __m512i zmm_buf = _mm512_srai_epi32(zmm_src_column1_part1, 28);
+          __m512i zmm_ChID_column1 = _mm512_and_epi32(zmm_buf, zmm_mask_localChID);
+          // Header
+          __mmask16 mask16_header = _mm512_cmpeq_epi32_mask(zmm_ChID_column1, zmm_mask_localChID);
+          // NGBTwords column
+          zmm_buf = _mm512_srai_epi32(zmm_src_column1_part1, 24);
+          __m512i zmm_NGBTwords = _mm512_maskz_and_epi32(mask16_header, zmm_buf, zmm_mask_localChID);
+
+          // Checking for empty events which contains only header(NGBTwords=0), and getting last header position within chunk
+          __mmask16 mask16_header_final = _mm512_mask_cmpgt_epu32_mask(mask16_header, zmm_NGBTwords, zmm_mask_zero);
+
+          // BC
+          __m512i zmm_mask_time = _mm512_set1_epi32(0xfff);
+          __m512i zmm_bc = _mm512_mask_and_epi32(zmm_mask_zero, mask16_header_final, zmm_src_column0_part0, zmm_mask_time);
+
+          // Estimation for number of channels
+          __m512i zmm_Nchannels = _mm512_slli_epi32(zmm_NGBTwords, 1); // multiply by 2
+
+          __m512i zmm_last_word_pos = zmm_NGBTwords;
+          zmm_last_word_pos = _mm512_slli_epi32(zmm_last_word_pos, 4); // multiply by 16, byte position for last word
+          zmm_last_word_pos = _mm512_add_epi32(zmm_last_word_pos, zmm_pos1);
+          zmm_buf = _mm512_i32gather_epi32(zmm_last_word_pos, src + 8, 1);
+          zmm_buf = _mm512_srai_epi32(zmm_buf, 12);
+          __m512i zmm_ChID_last_column1 = _mm512_and_epi32(zmm_buf, zmm_mask_localChID);
+
+          __mmask16 mask16_half_word = _mm512_cmpeq_epi32_mask(zmm_ChID_last_column1, zmm_mask_zero);
+          __m512i zmm_mask_one = _mm512_set1_epi32(1);
+          __m512i zmm_Nch = _mm512_mask_sub_epi32(zmm_Nchannels, mask16_half_word, zmm_Nchannels, zmm_mask_one);
+          __m512i zmm_nEventPerBC = _mm512_mask_i32gather_epi32(zmm_mask_zero, mask16_header_final, zmm_bc, buf_nChPerBC.data(), 4);
+          zmm_buf = _mm512_add_epi32(zmm_nEventPerBC, zmm_Nch);
+          _mm512_mask_i32scatter_epi32(buf_nChPerBC.data(), mask16_header_final, zmm_bc, zmm_buf, 4);
+
+          zmm_buf = _mm512_set1_epi32(256);
+          zmm_pos1 = _mm512_add_epi32(zmm_buf, zmm_pos1);
+          zmm_pos2 = _mm512_add_epi32(zmm_buf, zmm_pos2);
+
+        } // chunk
+      }   // Page
+      if (iFeeID != sNlinksMax - 1) {
+        memcpy(bufBC[iFeeID + 1].data(), buf_nChPerBC.data(), (sNBC + 4) * 4);
+      }
+    } // linkID
+    // Channel data position within BC per LinkID
+    memcpy(mPosChDataPerLinkOrbit[iOrbit].data(), bufBC.data(), (sNBC + 4) * 4 * sNlinksMax);
+    memset(mVecTriggers.data(), 0, 16 * 3564);
+    uint8_t* ptrDstTCM = (uint8_t*)mVecTriggers.data();
+    const auto& nPagesTCM = arrRdhTCMperOrbit[iOrbit].size();
+    for (int iPage = 0; iPage < nPagesTCM; iPage++) {
+      const auto& rdhPtr = arrRdhTCMperOrbit[iOrbit][iPage];
+      const auto& payload = arrDataTCMperOrbit[iOrbit][iPage].data();
+      const auto& payloadSize = arrDataTCMperOrbit[iOrbit][iPage].size();
+      const uint8_t* src = (uint8_t*)payload;
+      const auto nNGBTwords = payloadSize / 16;
+      const int nNGBTwordsDiff = nNGBTwords % 16;
+      const int nChunks = nNGBTwords / 16 + static_cast<int>(nNGBTwordsDiff > 0);
+      const auto lastChunk = nChunks - 1;
+      const uint16_t mask = (0xffff << (16 - nNGBTwordsDiff)) | (0xffff * (nNGBTwordsDiff == 0));
+      __m512i zmm_pos1 = _mm512_set_epi32(0, 16, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240);
+      for (int iChunk = 0; iChunk < nChunks; iChunk++) {
+        __mmask16 mask16_MaxGBTwords = _mm512_int2mask((0xffff * (iChunk != lastChunk)) | mask);
+        __m512i zmm_mask_zero = _mm512_setzero_epi32();
+
+        __m512i zmm_src_header = _mm512_mask_i32gather_epi32(zmm_mask_zero, mask16_MaxGBTwords, zmm_pos1, src + 9, 1);
+
+        __m512i zmm_mask_header = _mm512_set1_epi32(0xf1); // one GBT word + descriptor
+        // Header
+        __mmask16 mask16_header = _mm512_cmpeq_epi32_mask(zmm_src_header, zmm_mask_header);
+        // BC
+        __m512i zmm_bc = _mm512_mask_i32gather_epi32(zmm_mask_zero, mask16_MaxGBTwords, zmm_pos1, src, 1);
+        __m512i zmm_mask_12bit = _mm512_set1_epi32(0xfff);
+
+        zmm_bc = _mm512_maskz_and_epi32(mask16_header, zmm_mask_12bit, zmm_bc);
+        // Position of first GBT word with data
+        __m512i zmm_pos2 = _mm512_set1_epi32(16);
+        zmm_pos2 = _mm512_maskz_add_epi32(mask16_header, zmm_pos1, zmm_pos2);
+
+        __m512i zmm_src_part0 = _mm512_mask_i32gather_epi32(zmm_mask_zero, mask16_header, zmm_pos2, src, 1);
+        __m512i zmm_src_part1 = _mm512_mask_i32gather_epi32(zmm_mask_zero, mask16_header, zmm_pos2, src + 3, 1);
+        __m512i zmm_src_part2 = _mm512_mask_i32gather_epi32(zmm_mask_zero, mask16_header, zmm_pos2, src + 7, 1);
+        // Trigger bits + NchanA + NchanC
+        __m512i zmm_mask_3byte = _mm512_set1_epi32(0xffffff);
+        __m512i zmm_dst_part0 = _mm512_and_epi32(zmm_src_part0, zmm_mask_3byte);
+        // Sum AmpA
+        __m512i zmm_mask_17bit = _mm512_set1_epi32(0x1ffff);
+        __m512i zmm_dst_part1 = _mm512_and_epi32(zmm_src_part1, zmm_mask_17bit);
+        // Sum AmpC
+        __m512i zmm_dst_part2 = _mm512_srai_epi32(zmm_src_part1, 18);
+        __m512i zmm_mask_14bit = _mm512_set1_epi32(0b11111111111111);
+        zmm_dst_part2 = _mm512_and_epi32(zmm_mask_14bit, zmm_dst_part2);
+
+        __m512i zmm_buf = _mm512_slli_epi32(zmm_src_part2, 14);
+        __m512i zmm_mask_3bit = _mm512_set1_epi32(0b11100000000000);
+        zmm_buf = _mm512_and_epi32(zmm_mask_3bit, zmm_buf);
+        zmm_dst_part2 = _mm512_or_epi32(zmm_dst_part2, zmm_buf);
+        // Average time A + C
+        __m512i zmm_dst_part3 = _mm512_srai_epi32(zmm_src_part2, 4);
+        __m512i zmm_mask_9bit = _mm512_set1_epi32(0x1ff);
+        zmm_dst_part3 = _mm512_and_epi32(zmm_dst_part3, zmm_mask_9bit);
+
+        zmm_buf = _mm512_slli_epi32(zmm_src_part2, 2);
+        __m512i zmm_mask_9bit_2 = _mm512_set1_epi32(0x1ff0000);
+        zmm_buf = _mm512_and_epi32(zmm_buf, zmm_mask_9bit_2);
+
+        zmm_dst_part3 = _mm512_or_epi32(zmm_buf, zmm_dst_part3);
+        // Position
+        __m512i zmm_dst_pos = _mm512_slli_epi32(zmm_bc, 4);
+        // Pushing data to buffer
+        _mm512_mask_i32scatter_epi32(ptrDstTCM, mask16_header, zmm_dst_pos, zmm_dst_part0, 1);
+        _mm512_mask_i32scatter_epi32(ptrDstTCM + 4, mask16_header, zmm_dst_pos, zmm_dst_part1, 1);
+        _mm512_mask_i32scatter_epi32(ptrDstTCM + 8, mask16_header, zmm_dst_pos, zmm_dst_part2, 1);
+        _mm512_mask_i32scatter_epi32(ptrDstTCM + 12, mask16_header, zmm_dst_pos, zmm_dst_part3, 1);
+
+        zmm_buf = _mm512_set1_epi32(256);
+        zmm_pos1 = _mm512_add_epi32(zmm_buf, zmm_pos1);
+      } // chunk
+    }   // page
+    NChDataBC_t buf_nPosPerBC{};
+    uint64_t nChPerBC{0};
+    uint64_t nEventOrbit{0};
+
+    posChDataPerOrbit[iOrbit] = chPosOrbit; //
+
+    __m512i zmm_mask_seq2 = _mm512_set_epi32(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
+    __m512i zmm_pos2 = _mm512_set_epi32(75, 70, 65, 60, 55, 50, 45, 40, 35, 30, 25, 20, 15, 10, 5, 0);
+    for (int iBC = 0; iBC < sNBC; iBC += 16) {
+      uint32_t buf0[16], buf1[16], buf2[16], buf3[16];
+      uint8_t* dst = (uint8_t*)&mVecDigits[eventPosPerOrbit + nEventOrbit];
+      __m512i zmm_nChPerBC = _mm512_loadu_si512(&buf_nChPerBC[iBC]);
+
+#define SUM(N)                       \
+  buf_nPosPerBC[iBC + N] = nChPerBC; \
+  nChPerBC += buf_nChPerBC[iBC + N];
+
+      SUM(0);
+      SUM(1);
+      SUM(2);
+      SUM(3);
+
+      SUM(4);
+      SUM(5);
+      SUM(6);
+      SUM(7);
+
+      SUM(8);
+      SUM(9);
+      SUM(10);
+      SUM(11);
+
+      SUM(12);
+      SUM(13);
+      SUM(14);
+      SUM(15);
+      __m512i zmm_mask_zero = _mm512_setzero_epi32();
+      __mmask16 mask16_bc = _mm512_cmpneq_epi32_mask(zmm_nChPerBC, zmm_mask_zero);
+      __m512i zmm_pos3 = _mm512_maskz_expand_epi32(mask16_bc, zmm_pos2);
+      const auto nEvents = _mm_popcnt_u32(_cvtmask16_u32(mask16_bc));
+      nEventOrbit += nEvents;
+      __m512i zmm_pos = _mm512_loadu_si512(&buf_nPosPerBC[iBC]);
+      __m512i zmm_pos_per_orbit = _mm512_set1_epi32(chPosOrbit);
+      zmm_pos = _mm512_add_epi32(zmm_pos, zmm_pos_per_orbit);
+      __m512i zmm_bc = _mm512_set1_epi32(iBC);
+      zmm_bc = _mm512_add_epi32(zmm_bc, zmm_mask_seq2);
+      __m512i zmm_orbit = _mm512_set1_epi32(orbit);
+
+      _mm512_mask_i32scatter_epi32(dst, mask16_bc, zmm_pos3, zmm_pos, 8);
+      _mm512_mask_i32scatter_epi32(dst + 4, mask16_bc, zmm_pos3, zmm_nChPerBC, 8);
+      _mm512_mask_i32scatter_epi32(dst + 28, mask16_bc, zmm_pos3, zmm_bc, 8);
+      _mm512_mask_i32scatter_epi32(dst + 32, mask16_bc, zmm_pos3, zmm_orbit, 8);
+      // TCM
+      __m512i zmm_src_pos = _mm512_slli_epi32(zmm_bc, 4);
+
+      __m512i zmm_dst_part0 = _mm512_mask_i32gather_epi32(zmm_mask_zero, mask16_bc, zmm_src_pos, ptrDstTCM, 1);
+      __m512i zmm_dst_part1 = _mm512_mask_i32gather_epi32(zmm_mask_zero, mask16_bc, zmm_src_pos, ptrDstTCM + 4, 1);
+      __m512i zmm_dst_part2 = _mm512_mask_i32gather_epi32(zmm_mask_zero, mask16_bc, zmm_src_pos, ptrDstTCM + 8, 1);
+      __m512i zmm_dst_part3 = _mm512_mask_i32gather_epi32(zmm_mask_zero, mask16_bc, zmm_src_pos, ptrDstTCM + 12, 1);
+
+      _mm512_mask_i32scatter_epi32(dst + 8, mask16_bc, zmm_pos3, zmm_dst_part0, 8);
+      _mm512_mask_i32scatter_epi32(dst + 12, mask16_bc, zmm_pos3, zmm_dst_part1, 8);
+      _mm512_mask_i32scatter_epi32(dst + 16, mask16_bc, zmm_pos3, zmm_dst_part2, 8);
+      _mm512_mask_i32scatter_epi32(dst + 20, mask16_bc, zmm_pos3, zmm_dst_part3, 8);
+
+    } // BC
+
+    const uint64_t buf_nChDataPerOrbit = nChPerBC;
+    chPosOrbit += nChPerBC;
+
+    nChDataPerOrbit[iOrbit] = nChPerBC;
+    eventPosPerOrbit += nEventOrbit;
+    memcpy(posChDataPerBC[iOrbit].data(), buf_nPosPerBC.data(), (sNBC + 4) * 4);
+
+  } // Orbit
+
+  mVecDigits.resize(eventPosPerOrbit);
+  mVecChannelData.resize(chPosOrbit);
+
+  for (int iOrbit = 0; iOrbit < sNorbits; iOrbit++) {
+    if (!arrOrbitSizePages[iOrbit]) {
+      continue;
+    }
+    const auto& orbit = arrOrbit[iOrbit];
+    const auto& posChDataOrbit = posChDataPerOrbit[iOrbit];
+    const auto& ptrPosChDataPerBC = posChDataPerBC[iOrbit].data();
+    void* ptrDst = (void*)mVecChannelDataBuf.data();
+    for (int iLink = 0; iLink < sNlinksMax; iLink++) {
+      if (iLink == mFEEID_TCM) {
+        continue;
+      }
+      const auto& nPages = arrRdhPtrPerOrbit[iOrbit][iLink].size();
+      const auto& ptrChDataPosPerLinks = mPosChDataPerLinkOrbit[iOrbit][iLink].data();
+      void const* lutPerLink = &mLUT[iLink][0];
+      __m512i zmm_lut = _mm512_loadu_si512((void const*)lutPerLink);
+      for (int iPage = 0; iPage < nPages; iPage++) {
+        const auto& rdhPtr = arrRdhPtrPerOrbit[iOrbit][iLink][iPage];
+        const auto& payload = arrDataPerOrbit[iOrbit][iLink][iPage].data();
+        const auto& payloadSize = arrDataPerOrbit[iOrbit][iLink][iPage].size();
+        const uint8_t* src = (uint8_t*)payload;
+        const auto nNGBTwords = payloadSize / 16;
+        const int nNGBTwordsDiff = nNGBTwords % 16;
+        const int nChunks = nNGBTwords / 16 + static_cast<int>(nNGBTwordsDiff > 0);
+        const auto lastChunk = nChunks - 1;
+        const uint16_t mask = (0xffff << (16 - nNGBTwordsDiff)) | (0xffff * (nNGBTwordsDiff == 0));
+
+        uint16_t firstBC{0};
+        uint8_t nGBTwordPrevChunk{0};
+        uint8_t nGBTwordPrevChunkDiff{0};
+        bool firstWordIsNotHeader{false};
+
+        __m512i zmm_pos1 = _mm512_set_epi32(0, 16, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240);
+        for (int iChunk = 0; iChunk < nChunks; iChunk++) {
+          __m512i zmm_mask_charge = _mm512_set1_epi32(0x1fff0000);
+          __m512i zmm_mask_PMbits = _mm512_set1_epi32(0xff00);
+          __m512i zmm_mask_localChID = _mm512_set1_epi32(0xf);
+          __m512i zmm_mask_time = _mm512_set1_epi32(0xfff);
+
+          __m512i zmm_buf, zmm_buf2, zmm_buf3;
+
+          __mmask16 mask16_MaxGBTwords = _mm512_int2mask((0xffff * (iChunk != lastChunk)) | mask);
+          __m512i zmm_mask_zero = _mm512_setzero_epi32();
+          // Gathering data from page
+          __m512i zmm_src_part0 = _mm512_mask_i32gather_epi32(zmm_mask_zero, mask16_MaxGBTwords, zmm_pos1, src, 1);
+          __m512i zmm_src_part1 = _mm512_mask_i32gather_epi32(zmm_mask_zero, mask16_MaxGBTwords, zmm_pos1, src + 3, 1);
+          __m512i zmm_src_part2 = _mm512_mask_i32gather_epi32(zmm_mask_zero, mask16_MaxGBTwords, zmm_pos1, src + 6, 1);
+          // Column 0
+          // Time
+          __m512i zmm_src_column0_time = _mm512_and_epi32(zmm_src_part0, zmm_mask_time);
+          // Charge
+          zmm_buf = _mm512_slli_epi32(zmm_src_part0, 4);
+          __m512i zmm_src_column0_charge = _mm512_and_epi32(zmm_buf, zmm_mask_charge);
+          __m512i zmm_dst_column0_part1 = _mm512_or_epi32(zmm_src_column0_time, zmm_src_column0_charge);
+          // PM bits
+          zmm_buf = _mm512_slli_epi32(zmm_src_part1, 7);
+          __m512i zmm_src_column0_PMbits = _mm512_and_epi32(zmm_buf, zmm_mask_PMbits);
+          // ChannelID
+          zmm_buf = _mm512_srai_epi32(zmm_src_part1, 12);
+          __m512i zmm_dst_column0_chID = _mm512_and_epi32(zmm_buf, zmm_mask_localChID);
+          __m512i zmm_dst_column0_globalChID = _mm512_permutexvar_epi32(zmm_dst_column0_chID, zmm_lut);
+          __m512i zmm_dst_column0_part0 = _mm512_or_epi32(zmm_dst_column0_globalChID, zmm_src_column0_PMbits);
+          // Column 1
+          // Time
+          zmm_buf = _mm512_srai_epi32(zmm_src_part1, 16);
+          __m512i zmm_src_column1_time = _mm512_and_epi32(zmm_buf, zmm_mask_time);
+          // Charge
+          zmm_buf = _mm512_slli_epi32(zmm_src_part2, 12);
+          __m512i zmm_src_column1_charge = _mm512_and_epi32(zmm_buf, zmm_mask_charge);
+          __m512i zmm_dst_column1_part1 = _mm512_or_epi32(zmm_src_column1_time, zmm_src_column1_charge);
+
+          // PM bits
+          zmm_buf = _mm512_srai_epi32(zmm_src_part2, 9);
+          __m512i zmm_src_column1_PMbits = _mm512_and_epi32(zmm_buf, zmm_mask_PMbits);
+          // ChannelID
+          zmm_buf = _mm512_srai_epi32(zmm_src_part2, 28);
+          __m512i zmm_dst_column1_chID = _mm512_and_epi32(zmm_buf, zmm_mask_localChID);
+          __m512i zmm_dst_column1_globalChID = _mm512_permutexvar_epi32(zmm_dst_column1_chID, zmm_lut);
+          __m512i zmm_dst_column1_part0 = _mm512_or_epi32(zmm_dst_column1_globalChID, zmm_src_column1_PMbits);
+          // Preparing masks for data
+          //  getting header and nGBTword masks
+          __mmask16 mask16_header = _mm512_cmpeq_epi32_mask(zmm_dst_column1_chID, zmm_mask_localChID); // check for header
+          zmm_buf = _mm512_srai_epi32(zmm_src_part2, 24);
+          __m512i zmm_NGBTwords = _mm512_maskz_and_epi32(mask16_header, zmm_buf, zmm_mask_localChID);
+          __mmask16 mask16_header_final = _mm512_mask_cmpgt_epu32_mask(mask16_header, zmm_NGBTwords, zmm_mask_zero);
+          __mmask16 mask16_data = _mm512_knot(mask16_header_final);
+
+          // main column wich contains also header descriptor 0xf
+          __m512i zmm_mask_maxLocalChID = _mm512_set1_epi32(12);
+          __mmask16 mask16_nonzeroChID = _mm512_mask_cmpneq_epi32_mask(mask16_data, zmm_dst_column1_chID, zmm_mask_zero);                  // check for non-zero channelIDs
+          __mmask16 mask16_column1_isData = _mm512_mask_cmple_epi32_mask(mask16_nonzeroChID, zmm_dst_column1_chID, zmm_mask_maxLocalChID); // check for max local channel ID - 12
+          // first column
+          mask16_nonzeroChID = _mm512_mask_cmpneq_epi32_mask(mask16_data, zmm_dst_column0_chID, zmm_mask_zero); // check for non-zero channelIDs
+          __mmask16 mask16_column0_isData = _mm512_mask_cmple_epi32_mask(mask16_nonzeroChID, zmm_dst_column0_chID, zmm_mask_maxLocalChID);
+
+          // BC
+          __m512i zmm_bc = _mm512_mask_and_epi32(zmm_mask_zero, mask16_header_final, zmm_src_part0, zmm_mask_time);
+          // Calculation for GBT word position
+          __m512i zmm_mask_seq2 = _mm512_set_epi32(15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
+
+          __m512i zmm_column0_data_seq = _mm512_maskz_expand_epi32(mask16_column0_isData, zmm_mask_seq2);
+          __mmask16 mask16_buf = _mm512_kor(mask16_header_final, mask16_column0_isData);
+          __m512i zmm_column0_data2header = _mm512_maskz_expand_epi32(mask16_buf, zmm_mask_seq2);
+
+          __m512i zmm_column1_data_seq = _mm512_maskz_expand_epi32(mask16_column1_isData, zmm_mask_seq2);
+          mask16_buf = _mm512_kor(mask16_header_final, mask16_column1_isData);
+          __m512i zmm_column1_data2header = _mm512_maskz_expand_epi32(mask16_buf, zmm_mask_seq2);
+
+          zmm_column0_data2header = _mm512_maskz_sub_epi32(mask16_column0_isData, zmm_column0_data2header, zmm_column0_data_seq);
+          zmm_column1_data2header = _mm512_maskz_sub_epi32(mask16_column1_isData, zmm_column1_data2header, zmm_column1_data_seq);
+
+          __m512i zmm_column0_NGBTwords = _mm512_setzero_epi32();
+          __m512i zmm_column1_NGBTwords = zmm_NGBTwords;
+          __mmask16 mask16_header_first = _mm512_int2mask(firstWordIsNotHeader * 0b1000000000000000); // fake header, to put metadata(BC and nGBTwords) from previous chunk
+          zmm_bc = _mm512_mask_set1_epi32(zmm_bc, mask16_header_first, firstBC);
+
+          zmm_column0_NGBTwords = _mm512_mask_set1_epi32(zmm_column0_NGBTwords, mask16_header_first, nGBTwordPrevChunkDiff);
+          zmm_column1_NGBTwords = _mm512_mask_set1_epi32(zmm_column1_NGBTwords, mask16_header_first, nGBTwordPrevChunk + nGBTwordPrevChunkDiff);
+          mask16_header_final = _mm512_kor(mask16_header_first, mask16_header_final);
+          uint32_t bufBC[16]{}, bufNGBTwords[16]{};
+
+          zmm_buf = _mm512_maskz_compress_epi32(mask16_header_final, zmm_bc);
+          zmm_buf2 = _mm512_i32gather_epi32(zmm_buf, ptrChDataPosPerLinks, 4);
+          zmm_buf3 = _mm512_i32gather_epi32(zmm_buf, ptrPosChDataPerBC, 4);
+          zmm_buf2 = _mm512_add_epi32(zmm_buf2, zmm_buf3);
+
+          __m512i zmm_column0_pos = _mm512_permutexvar_epi32(zmm_column0_data2header, zmm_buf2);
+          __m512i zmm_column1_pos = _mm512_permutexvar_epi32(zmm_column1_data2header, zmm_buf2);
+
+          // Column0
+          __m512i zmm_mask_seq3 = _mm512_set_epi32(16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1);
+          __m512i zmm_6 = _mm512_set1_epi32(6);
+          __m512i zmm_2 = _mm512_set1_epi32(2);
+
+          zmm_buf2 = _mm512_add_epi32(zmm_mask_seq2, zmm_column0_NGBTwords);
+          zmm_buf = _mm512_maskz_compress_epi32(mask16_header_final, zmm_buf2);
+
+          zmm_buf2 = _mm512_permutexvar_epi32(zmm_column0_data2header, zmm_buf);
+          zmm_buf = _mm512_maskz_sub_epi32(mask16_column0_isData, zmm_buf2, zmm_mask_seq3);
+
+          zmm_column0_pos = _mm512_maskz_add_epi32(mask16_column0_isData, zmm_column0_pos, zmm_buf);
+
+          __m512i zmm_column0_part0_pos = _mm512_maskz_mullo_epi32(mask16_column0_isData, zmm_column0_pos, zmm_6);
+          __m512i zmm_column0_part1_pos = _mm512_maskz_add_epi32(mask16_column0_isData, zmm_column0_part0_pos, zmm_2);
+
+          // Column1
+          zmm_buf2 = _mm512_add_epi32(zmm_mask_seq2, zmm_column1_NGBTwords);
+          zmm_buf = _mm512_maskz_compress_epi32(mask16_header_final, zmm_buf2);
+
+          zmm_buf2 = _mm512_permutexvar_epi32(zmm_column1_data2header, zmm_buf);
+          zmm_buf = _mm512_maskz_sub_epi32(mask16_column1_isData, zmm_buf2, zmm_mask_seq3);
+
+          zmm_column1_pos = _mm512_maskz_add_epi32(mask16_column1_isData, zmm_column1_pos, zmm_buf);
+          __m512i zmm_column1_part0_pos = _mm512_maskz_mullo_epi32(mask16_column1_isData, zmm_column1_pos, zmm_6); // Todo: exclude multilication, on fly calculation for byte position?
+          __m512i zmm_column1_part1_pos = _mm512_maskz_add_epi32(mask16_column1_isData, zmm_column1_part0_pos, zmm_2);
+          // Pushing data
+          _mm512_mask_i32scatter_epi32(ptrDst, mask16_column0_isData, zmm_column0_part0_pos, zmm_dst_column0_part0, 1);
+          _mm512_mask_i32scatter_epi32(ptrDst, mask16_column1_isData, zmm_column1_part0_pos, zmm_dst_column1_part0, 1);
+
+          _mm512_mask_i32scatter_epi32(ptrDst, mask16_column0_isData, zmm_column0_part1_pos, zmm_dst_column0_part1, 1);
+          _mm512_mask_i32scatter_epi32(ptrDst, mask16_column1_isData, zmm_column1_part1_pos, zmm_dst_column1_part1, 1);
+
+          // Getting last header position
+          _mm512_storeu_si512(bufBC, zmm_bc);
+          _mm512_storeu_si512(bufNGBTwords, zmm_NGBTwords);
+
+          const uint32_t header32 = _cvtmask16_u32(mask16_header_final);
+          const uint16_t lastHeaderPos = (__builtin_ctz(header32)) * (header32 > 0);
+          firstBC = bufBC[lastHeaderPos];
+          nGBTwordPrevChunk = bufNGBTwords[lastHeaderPos];
+          nGBTwordPrevChunkDiff = lastHeaderPos;
+          firstWordIsNotHeader = nGBTwordPrevChunk != lastHeaderPos;
+          nGBTwordPrevChunkDiff++;
+
+          zmm_buf = _mm512_set1_epi32(256);
+          zmm_pos1 = _mm512_add_epi32(zmm_buf, zmm_pos1);
+        } // chunk
+      }   // page
+    }     // link
+    memcpy(&mVecChannelData[posChDataOrbit], mVecChannelDataBuf.data(), 6 * nChDataPerOrbit[iOrbit]);
+  } // orbit
+  pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginFT0, "DIGITSBC", 0, o2::framework::Lifetime::Timeframe}, mVecDigits);
+  pc.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginFT0, "DIGITSCH", 0, o2::framework::Lifetime::Timeframe}, mVecChannelData);
+  auto t2 = std::chrono::high_resolution_clock::now();
+  auto delay = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1);
+  LOG(debug) << "Decoder delay: " << delay.count();
+}
+} // namespace ft0
+} // namespace o2
+
+#endif
+#endif

--- a/Detectors/FIT/FT0/workflow/src/FT0DataDecoderDPLSpec.cxx
+++ b/Detectors/FIT/FT0/workflow/src/FT0DataDecoderDPLSpec.cxx
@@ -20,8 +20,8 @@
 #include <immintrin.h>
 #include <algorithm>
 #include <cstdlib>
-#include <string.h>
-
+#include <cstring>
+#include <string>
 namespace o2
 {
 namespace ft0

--- a/Detectors/FIT/FT0/workflow/src/FT0DataDecoderDPLSpec.cxx
+++ b/Detectors/FIT/FT0/workflow/src/FT0DataDecoderDPLSpec.cxx
@@ -11,7 +11,7 @@
 
 /// @file   FITDataDecoderDPLSpec.cxx
 
-#if defined __has_include
+#if defined(__has_include)
 #if defined(__linux__) && (defined(__x86_64) || defined(__x86_64__)) && __has_include(<emmintrin.h>) && __has_include(<immintrin.h>)
 
 #include "FT0Workflow/FT0DataDecoderDPLSpec.h"

--- a/Detectors/FIT/FT0/workflow/src/ft0-flp-workflow.cxx
+++ b/Detectors/FIT/FT0/workflow/src/ft0-flp-workflow.cxx
@@ -17,6 +17,11 @@
 #include "FT0Raw/RawReaderFT0Base.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
 #include "Framework/CompletionPolicyHelpers.h"
+#if defined __has_include
+#if defined(__linux__) && (defined(__x86_64) || defined(__x86_64__)) && __has_include(<emmintrin.h>) && __has_include(<immintrin.h>)
+#include "FT0Workflow/FT0DataDecoderDPLSpec.h"
+#endif
+#endif
 
 using namespace o2::framework;
 
@@ -26,7 +31,6 @@ void customize(std::vector<o2::framework::CompletionPolicy>& policies)
   // ordered policies for the writers
   policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:FT0|ft0).*[W,w]riter.*"));
 }
-
 // we need to add workflow options before including Framework/runDataProcessing
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
@@ -58,6 +62,12 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
                     o2::framework::VariantType::Bool,
                     false,
                     {"do not subscribe to FLP/DISTSUBTIMEFRAME/0 message (no lost TF recovery)"}});
+
+  workflowOptions.push_back(
+    ConfigParamSpec{"new-decoder",
+                    o2::framework::VariantType::Bool,
+                    false,
+                    {"New decoder which uses AVX-512 CPU instractions"}});
 }
 
 // ------------------------------------------------------------------
@@ -71,27 +81,36 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   auto isExtendedMode = configcontext.options().get<bool>("tcm-extended-mode");
   auto disableRootOut = configcontext.options().get<bool>("disable-root-output");
   auto askSTFDist = !configcontext.options().get<bool>("ignore-dist-stf");
+  auto isNewDecoder = configcontext.options().get<bool>("new-decoder");
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
   LOG(info) << "WorkflowSpec FLPWorkflow";
-  //Type aliases
-  //using RawReaderFT0trgInput = o2::fit::RawReaderFIT<o2::ft0::RawReaderFT0BaseNorm,true>;
+  // Type aliases
+  // using RawReaderFT0trgInput = o2::fit::RawReaderFIT<o2::ft0::RawReaderFT0BaseNorm,true>;
   using RawReaderFT0 = o2::fit::RawReaderFIT<o2::ft0::RawReaderFT0BaseNorm, false>;
-  //using RawReaderFT0trgInputExt = o2::fit::RawReaderFIT<o2::ft0::RawReaderFT0BaseExt,true>;
+  // using RawReaderFT0trgInputExt = o2::fit::RawReaderFIT<o2::ft0::RawReaderFT0BaseExt,true>;
   using RawReaderFT0ext = o2::fit::RawReaderFIT<o2::ft0::RawReaderFT0BaseExt, false>;
   using MCLabelCont = o2::dataformats::MCTruthContainer<o2::ft0::MCLabel>;
   o2::header::DataOrigin dataOrigin = o2::header::gDataOriginFT0;
   //
   WorkflowSpec specs;
-  if (isExtendedMode) {
-    specs.emplace_back(o2::fit::getFITDataReaderDPLSpec(RawReaderFT0ext{dataOrigin, dumpReader}, askSTFDist));
-    if (!disableRootOut) {
-      specs.emplace_back(o2::fit::FITDigitWriterSpecHelper<RawReaderFT0ext, MCLabelCont>::getFITDigitWriterSpec(false, false, dataOrigin));
+  if (!isNewDecoder) {
+    if (isExtendedMode) {
+      specs.emplace_back(o2::fit::getFITDataReaderDPLSpec(RawReaderFT0ext{dataOrigin, dumpReader}, askSTFDist));
+      if (!disableRootOut) {
+        specs.emplace_back(o2::fit::FITDigitWriterSpecHelper<RawReaderFT0ext, MCLabelCont>::getFITDigitWriterSpec(false, false, dataOrigin));
+      }
+    } else {
+      specs.emplace_back(o2::fit::getFITDataReaderDPLSpec(RawReaderFT0{dataOrigin, dumpReader}, askSTFDist));
+      if (!disableRootOut) {
+        specs.emplace_back(o2::fit::FITDigitWriterSpecHelper<RawReaderFT0, MCLabelCont>::getFITDigitWriterSpec(false, false, dataOrigin));
+      }
     }
   } else {
-    specs.emplace_back(o2::fit::getFITDataReaderDPLSpec(RawReaderFT0{dataOrigin, dumpReader}, askSTFDist));
-    if (!disableRootOut) {
-      specs.emplace_back(o2::fit::FITDigitWriterSpecHelper<RawReaderFT0, MCLabelCont>::getFITDigitWriterSpec(false, false, dataOrigin));
-    }
+#if defined __has_include
+#if defined(__linux__) && (defined(__x86_64) || defined(__x86_64__)) && __has_include(<emmintrin.h>) && __has_include(<immintrin.h>)
+    specs.emplace_back(o2::ft0::getFT0DataDecoderDPLSpec(askSTFDist));
+#endif
+#endif
   }
   return std::move(specs);
 }

--- a/Detectors/FIT/FT0/workflow/src/ft0-flp-workflow.cxx
+++ b/Detectors/FIT/FT0/workflow/src/ft0-flp-workflow.cxx
@@ -18,7 +18,7 @@
 #include "SimulationDataFormat/MCTruthContainer.h"
 #include "Framework/CompletionPolicyHelpers.h"
 #if defined(__has_include)
-#if defined(__linux__) && (defined(__x86_64) || defined(__x86_64__)) && __has_include(<emmintrin.h>) && __has_include(<immintrin.h>)
+#if defined(__linux__) && (defined(__x86_64) || defined(__x86_64__)) && __has_include(<emmintrin.h>) && __has_include(<immintrin.h>) && defined(FT0_DECODER_AVX512)
 #include "FT0Workflow/FT0DataDecoderDPLSpec.h"
 #endif
 #endif
@@ -107,7 +107,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     }
   } else {
 #if defined(__has_include)
-#if defined(__linux__) && (defined(__x86_64) || defined(__x86_64__)) && __has_include(<emmintrin.h>) && __has_include(<immintrin.h>)
+#if defined(__linux__) && (defined(__x86_64) || defined(__x86_64__)) && __has_include(<emmintrin.h>) && __has_include(<immintrin.h>) && defined(FT0_DECODER_AVX512)
     specs.emplace_back(o2::ft0::getFT0DataDecoderDPLSpec(askSTFDist));
 #endif
 #endif

--- a/Detectors/FIT/FT0/workflow/src/ft0-flp-workflow.cxx
+++ b/Detectors/FIT/FT0/workflow/src/ft0-flp-workflow.cxx
@@ -17,7 +17,7 @@
 #include "FT0Raw/RawReaderFT0Base.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
 #include "Framework/CompletionPolicyHelpers.h"
-#if defined __has_include
+#if defined(__has_include)
 #if defined(__linux__) && (defined(__x86_64) || defined(__x86_64__)) && __has_include(<emmintrin.h>) && __has_include(<immintrin.h>)
 #include "FT0Workflow/FT0DataDecoderDPLSpec.h"
 #endif
@@ -106,7 +106,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
       }
     }
   } else {
-#if defined __has_include
+#if defined(__has_include)
 #if defined(__linux__) && (defined(__x86_64) || defined(__x86_64__)) && __has_include(<emmintrin.h>) && __has_include(<immintrin.h>)
     specs.emplace_back(o2::ft0::getFT0DataDecoderDPLSpec(askSTFDist));
 #endif


### PR DESCRIPTION
New decoder for FT0, contains a lot of low level code based on AVX512 CPU instructions. Can be used only at production FLP machines. Best option if this code can be compiled only  for FLPSuite package(via predefinitions?).

TODO:
- BC-orbit protection
- empty raw data protection(in case if data block contains only header, w/o data)
- additional enhancement via pre-caching for buffers(make more cache friendly code).

This decoder is tested(full chain readout+StfB+DPL+StfS) at FLP machine on dummy data samples which emulates maximum 600Mb/(link*second) data flow(1 TF ~ 250Mb).