### PR TITLE
TRD fixes for tracklets in trap 2 raw

### DIFF
--- a/DataFormats/Detectors/TRD/src/RawData.cxx
+++ b/DataFormats/Detectors/TRD/src/RawData.cxx
@@ -68,6 +68,7 @@ uint16_t buildTRDFeeID(int supermodule, int side, int endpoint)
 
 void buildTrackletMCMData(TrackletMCMData& trackletword, const uint slope, const uint pos, const uint q0, const uint q1, const uint q2)
 {
+  trackletword.word = 0;
   trackletword.slope = slope;
   trackletword.pos = pos;
   trackletword.pid = (q0 & 0x7f) & ((q1 & 0x1f) << 7); //q2 sits with upper 2 bits of q1 in the header pid word, hence the 0x1f so 5 bits are used here.
@@ -143,7 +144,7 @@ uint32_t getQFromRaw(const o2::trd::TrackletMCMHeader* header, const o2::trd::Tr
    *     -------------------------
    *
    * TDP: This can be one of these fields HPID0/1/2 (=TrackletHCHeader::pid0/1/2) depending on
-   * 	  the MCM-CPU.
+   *      the MCM-CPU.
    *
    *     |11|10|09|08|07|06|05|04|03|02|01|00|
    *     -------------------------------------

--- a/Detectors/TRD/reconstruction/src/CruRawReader.cxx
+++ b/Detectors/TRD/reconstruction/src/CruRawReader.cxx
@@ -144,6 +144,8 @@ bool CruRawReader::processHBFs(int datasizealreadyread, bool verbose)
   uint32_t currentsaveddatacount = 0;
   mTotalHBFPayLoad = 0;
   int loopcount = 0;
+  int counthalfcru = 0;
+  mHBFoffset32 = 0;
   // loop until RDH stop header
   while (!o2::raw::RDHUtils::getStop(rdh)) { // carry on till the end of the event.
     if (mHeaderVerbose) {
@@ -215,8 +217,6 @@ bool CruRawReader::processHBFs(int datasizealreadyread, bool verbose)
   }
 
   // at this point the entire HBF data payload is sitting in mHBFPayload and the total data count is mTotalHBFPayLoad
-  int counthalfcru = 0;
-  mHBFoffset32 = 0;
 
   while ((mHBFoffset32 < ((mTotalHBFPayLoad) / 4))) { // the blank event of eeeeee at the end
     if (mHeaderVerbose) {
@@ -246,9 +246,6 @@ bool CruRawReader::processHBFs(int datasizealreadyread, bool verbose)
       mHBFoffset32 += 8;
     }
     counthalfcru++;
-    if (counthalfcru == 1) {
-      break;
-    }
   } // loop of halfcru's while there is still data in the heart beat frame.
   if (totaldataread > 0) {
     mDatareadfromhbf = totaldataread;

--- a/Detectors/TRD/simulation/macros/CheckTRDFST.C
+++ b/Detectors/TRD/simulation/macros/CheckTRDFST.C
@@ -1,0 +1,193 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file CheckTRDFST.C
+/// \brief Simple macro to check TRD digits and tracklets post sim to post reconstruction
+
+// a couple of steps are not included in this:
+// It is assumed that the raw-to-tf is run in the directory you run the fst.
+// you reconstruct to trddigits and trdtracklets in the fst/raw/timeframe directory
+//
+// alienv enter O2PDPSuite/latest-o2 Readout/latest-o2
+// DISABLE_PROCESSING=1 NEvents=20 NEventsQED=100 SHMSIZE=128000000000 TPCTRACKERSCRATCHMEMORY=40000000000 SPLITTRDDIGI=0 GENERATE_ITSMFT_DICTIONARIES=1 $O2_ROOT/prodtests/full_system_test.sh
+// $O2_ROOT/prodtests/full-system-test/convert-raw-to-tf-file.sh
+// cd raw/timeframe
+// o2-raw-tf-reader-workflow --input-data o2_rawtf_run00000000_tf00000001_???????.tf | o2-trd-datareader --fixsm1617 --enable-root-output | o2-dpl-run --run -b
+// Then run this script.
+// the convert-raw-to-tf-file.sh must be run on a machine with >200G the rest can be run anywhere.
+//
+
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include <TFile.h>
+#include <TTree.h>
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TProfile.h>
+#include <TCanvas.h>
+#include <TLegend.h>
+
+#include "FairLogger.h"
+#include "DataFormatsTRD/Digit.h"
+#include "DataFormatsTRD/Tracklet64.h"
+#include "DataFormatsTRD/Constants.h"
+#include "DataFormatsTRD/HelperMethods.h"
+#endif
+
+using namespace o2::trd;
+
+constexpr int kMINENTRIES = 100;
+
+void CheckTRDFST(std::string fstbasedir = "./",
+                 std::string digitfile = "trddigits.root", std::string trackletfile = "trdtracklets.root",
+                 std::string recodigitfile = "trddigits.root", std::string recotrackletfile = "trdtracklets.root")
+{
+  TFile* dfin = TFile::Open(Form("%s%s", fstbasedir.data(), digitfile.data()));
+  TTree* digitTree = (TTree*)dfin->Get("o2sim");
+  std::vector<Digit>* digits = nullptr;
+  digitTree->SetBranchAddress("TRDDigit", &digits);
+  int ndigitev = digitTree->GetEntries();
+
+  TFile* tfin = TFile::Open(Form("%s%s", fstbasedir.data(), trackletfile.data()));
+  TTree* trackletTree = (TTree*)tfin->Get("o2sim");
+  std::vector<Tracklet64>* tracklets = nullptr;
+  trackletTree->SetBranchAddress("Tracklet", &tracklets);
+  int ntrackletev = trackletTree->GetEntries();
+
+  TFile* dfinreco = TFile::Open(Form("%s/raw/timeframe/%s", fstbasedir.data(), recodigitfile.data()));
+  TTree* digitTreereco = (TTree*)dfinreco->Get("o2sim");
+  std::vector<Digit>* digitsreco = nullptr;
+  digitTreereco->SetBranchAddress("TRDDigit", &digitsreco);
+  int ndigitevreco = digitTreereco->GetEntries();
+
+  TFile* tfinreco = TFile::Open(Form("%s/raw/timeframe/%s", fstbasedir.data(), recotrackletfile.data()));
+  TTree* trackletTreereco = (TTree*)tfinreco->Get("o2sim");
+  std::vector<Tracklet64>* trackletsreco = nullptr;
+  trackletTreereco->SetBranchAddress("Tracklet", &trackletsreco);
+  int ntrackletevreco = trackletTreereco->GetEntries();
+
+  TH2F* hDigitsPerLayer[6];
+  TH2F* hTrackletsPerLayer[6];
+  TH2F* hDigitsPerLayer_reco[6];
+  TH2F* hTrackletsPerLayer_reco[6];
+  TH2F* hDigitsPerLayer_diff[6];
+  TH2F* hTrackletsPerLayer_diff[6];
+  for (int layer = 0; layer < 6; layer++) {
+    hDigitsPerLayer[layer] = new TH2F(Form("Digit_layer%d", layer), ";stack;sector", 5, 0, 5, 35, 0, 35);
+    hDigitsPerLayer[layer]->SetTitle(Form("Layer %d", layer));
+    hTrackletsPerLayer[layer] = new TH2F(Form("Tracklets_layer%d", layer), ";stack;sector", 5, 0, 5, 35, 0, 35);
+    hTrackletsPerLayer[layer]->SetTitle(Form("Layer %d", layer));
+    hDigitsPerLayer_reco[layer] = new TH2F(Form("Digit_layer%d_reco", layer), ";stack;sector", 5, 0, 5, 35, 0, 35);
+    hDigitsPerLayer_reco[layer]->SetTitle(Form("Layer %d", layer));
+    hTrackletsPerLayer_reco[layer] = new TH2F(Form("Tracklets_layer%d_reco", layer), ";stack;sector", 5, 0, 5, 35, 0, 35);
+    hTrackletsPerLayer_reco[layer]->SetTitle(Form("Layer %d", layer));
+    hDigitsPerLayer_diff[layer] = new TH2F(Form("Digit_layer%d_diff", layer), ";stack;sector", 5, 0, 5, 35, 0, 35);
+    hDigitsPerLayer_diff[layer]->SetTitle(Form("Layer %d difference", layer));
+    hTrackletsPerLayer_diff[layer] = new TH2F(Form("Tracklets_layer%d_diff", layer), ";stack;sector", 5, 0, 5, 35, 0, 35);
+    hTrackletsPerLayer_diff[layer]->SetTitle(Form("Layer %d difference", layer));
+  }
+
+  LOG(info) << ndigitev << " digits entries found";
+  LOG(info) << ntrackletev << " tracklet entries found";
+  for (int iev = 0; iev < ntrackletev; ++iev) {
+    digitTree->GetEvent(iev);
+    trackletTree->GetEvent(iev);
+    for (const auto& digit : *digits) {
+      int det = digit.getDetector(); // chamber
+      int row = digit.getPadRow();   // pad row
+      int col = digit.getPadCol();   // pad column
+      int stack = o2::trd::HelperMethods::getStack(det);
+      int layer = o2::trd::HelperMethods::getLayer(det);
+      int sector = o2::trd::HelperMethods::getSector(det);
+      hDigitsPerLayer[layer]->Fill(stack, sector * 2 + digit.getROB() % 2);
+    }
+    for (const auto& tracklet : *tracklets) {
+      int det = tracklet.getHCID() / 2; // chamber
+      int hcid = tracklet.getHCID();
+      int stack = o2::trd::HelperMethods::getStack(det);
+      int layer = o2::trd::HelperMethods::getLayer(det);
+      int sector = o2::trd::HelperMethods::getSector(det);
+      hTrackletsPerLayer[layer]->Fill(stack, sector * 2 + tracklet.getHCID() % 2);
+    }
+    LOG(info) << ndigitevreco << " digits entries found";
+    LOG(info) << ntrackletevreco << " tracklet entries found";
+    for (int iev = 0; iev < ntrackletevreco; ++iev) {
+      digitTreereco->GetEvent(iev);
+      trackletTreereco->GetEvent(iev);
+      for (const auto& digit : *digitsreco) {
+        int det = digit.getDetector(); // chamber
+        int stack = o2::trd::HelperMethods::getStack(det);
+        int layer = o2::trd::HelperMethods::getLayer(det);
+        int sector = o2::trd::HelperMethods::getSector(det);
+        hDigitsPerLayer_reco[layer]->Fill(stack, sector * 2 + digit.getROB() % 2);
+      }
+      for (const auto& tracklet : *trackletsreco) {
+        int det = tracklet.getHCID() / 2; // chamber
+        int hcid = tracklet.getHCID();
+        int stack = o2::trd::HelperMethods::getStack(det);
+        int layer = o2::trd::HelperMethods::getLayer(det);
+        int sector = o2::trd::HelperMethods::getSector(det);
+        hTrackletsPerLayer_reco[layer]->Fill(stack, sector * 2 + tracklet.getHCID() % 2);
+      }
+    }
+  }
+  //post simulation
+  TCanvas* c = new TCanvas("c", "trd digits distribution", 800, 800);
+  c->Divide(3, 2, 0.05, 0.05);
+  for (int layer = 0; layer < 6; ++layer) {
+    c->cd(layer + 1);
+    hDigitsPerLayer[layer]->Draw("COLZ");
+  }
+  c->SaveAs("DigitsPerLayerAfterSim.pdf");
+  TCanvas* c1 = new TCanvas("c1", "trd tracklet distribution", 800, 800);
+  c1->Divide(3, 2, 0.05, 0.05);
+  for (int layer = 0; layer < 6; ++layer) {
+    c1->cd(layer + 1);
+    hTrackletsPerLayer[layer]->Draw("COLZ");
+  }
+  c1->SaveAs("TrackletsPerLayerAfterSim.pdf");
+  //post simulation
+  TCanvas* c2 = new TCanvas("c2", "trd digits distribution reconstruction", 800, 800);
+  c2->Divide(3, 2, 0.05, 0.05);
+  for (int layer = 0; layer < 6; ++layer) {
+    c2->cd(layer + 1);
+    hDigitsPerLayer_reco[layer]->Draw("COLZ");
+  }
+  c2->SaveAs("DigitsPerLayerAfterReco.pdf");
+  TCanvas* c3 = new TCanvas("c3", "trd tracklet distribution reconstruction", 800, 800);
+  c3->Divide(3, 2, 0.05, 0.05);
+  for (int layer = 0; layer < 6; ++layer) {
+    c3->cd(layer + 1);
+    hTrackletsPerLayer_reco[layer]->Draw("COLZ");
+  }
+  c3->SaveAs("TrackletsPerLayerAfterReco.pdf");
+  // calculate spectra differences, and the spectra should be empty.
+  for (int layer = 0; layer < 6; layer++) {
+    hDigitsPerLayer_diff[layer]->Add(hDigitsPerLayer[layer], hDigitsPerLayer_reco[layer], 1, -1);
+    std::cout << "Digit Difference layer: " << layer << " sim - reco : " << hDigitsPerLayer_diff[layer]->Integral() << std::endl;
+    hTrackletsPerLayer_diff[layer]->Add(hTrackletsPerLayer[layer], hTrackletsPerLayer_reco[layer], 1, -1);
+    std::cout << "Tracklet Difference layer: " << layer << " sim - reco : " << hTrackletsPerLayer_diff[layer]->Integral() << std::endl;
+  }
+  TCanvas* c4 = new TCanvas("c4", "trd digits distribution diff", 800, 800);
+  c4->Divide(3, 2, 0.05, 0.05);
+  for (int layer = 0; layer < 6; ++layer) {
+    c4->cd(layer + 1);
+    hDigitsPerLayer_diff[layer]->Draw("COLZ");
+  }
+  c4->SaveAs("DigitsPerLayerDiff.pdf");
+  TCanvas* c5 = new TCanvas("c5", "trd tracklet distribution diff", 800, 800);
+  c5->Divide(3, 2, 0.05, 0.05);
+  for (int layer = 0; layer < 6; ++layer) {
+    c5->cd(layer + 1);
+    hTrackletsPerLayer_diff[layer]->Draw("COLZ");
+  }
+  c5->SaveAs("TrackletsPerLayerDiff.pdf");
+  // the _diff spectra *should* be empty
+}

--- a/Detectors/TRD/simulation/src/trap2raw.cxx
+++ b/Detectors/TRD/simulation/src/trap2raw.cxx
@@ -71,7 +71,7 @@ int main(int argc, char** argv)
     add_option("input-file-tracklets,t", bpo::value<std::string>()->default_value("trdtracklets.root"), "input Trapsim tracklets file");
     add_option("file-per,l", bpo::value<std::string>()->default_value("halfcru"), "all : raw file(false), halfcru : cru end point, cru : one file per cru, sm: one file per supermodule");
     add_option("output-dir,o", bpo::value<std::string>()->default_value("./"), "output directory for raw data");
-    add_option("tracklethcheader,x", bpo::value<int>()->default_value(0), "include tracklet half chamber header (for run3). 0 never, 1 if there is tracklet data, 2 always");
+    add_option("tracklethcheader,x", bpo::value<int>()->default_value(2), "include tracklet half chamber header (for run3). 0 never, 1 if there is tracklet data, 2 always");
     add_option("no-empty-hbf,e", bpo::value<bool>()->default_value(false)->implicit_value(true), "do not create empty HBF pages (except for HBF starting TF)");
     add_option("rdh-version,r", bpo::value<uint32_t>()->default_value(6), "rdh version in use default");
     add_option("configKeyValues", bpo::value<std::string>()->default_value(""), "comma-separated configKeyValues");

--- a/cmake/O2RootMacroExclusionList.cmake
+++ b/cmake/O2RootMacroExclusionList.cmake
@@ -30,6 +30,7 @@ list(APPEND O2_ROOT_MACRO_EXCLUSION_LIST
             Detectors/TRD/base/macros/PrintTrapConfig.C
             Detectors/TRD/base/macros/TestTrapSim.C
             Detectors/TRD/macros/convertRun2ToRun3Digits.C
+            Detectors/TRD/simulation/macros/CheckTRDFST.C
             Detectors/gconfig/g4Config.C
             Detectors/TRD/macros/ParseTrapRawOutput.C
             Detectors/EMCAL/calib/macros/ReadTestBadChannelMap_CCDBApi.C


### PR DESCRIPTION
- remove a restriction on only 1 half cru header per start stop of heart beats frames.
- move 2 zeroings of variables to prevent the "good luck" messages in parsing.
- fix the digits vector going out of bounds if the last event only has digits.
- fixes a mixup between a linkid and an hcid.
- changes the default option to trap2raw to be tracklethcheader 2.
- adds a macro to compare the digits and tracklets before and after and calculates the diff which should be zero.
- The plots could be made prettier, but its functional for now. The test is not automatic, but instructions for what to do before hand is at the top.

