### PR TITLE
Fixes in MID raw data encoder

### DIFF
--- a/Detectors/MUON/MID/Raw/include/MIDRaw/Encoder.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/Encoder.h
@@ -54,10 +54,12 @@ class Encoder
 
  private:
   void completeWord(std::vector<char>& buffer);
-  void writePayload(uint16_t linkId, const InteractionRecord& ir);
+  void writePayload(uint16_t linkId, const InteractionRecord& ir, bool onlyNonEmpty = false);
   void onOrbitChange(uint32_t orbit);
   /// Returns the interaction record expected for the orbit trigger
   inline InteractionRecord getOrbitIR(uint32_t orbit) const { return {o2::constants::lhc::LHCMaxBunches - 1, orbit}; }
+  /// Initializes the last interaction record
+  void initIR();
 
   o2::raw::RawFileWriter mRawWriter{o2::header::gDataOriginMID}; /// Raw file writer
 

--- a/Detectors/MUON/MID/Raw/src/Encoder.cxx
+++ b/Detectors/MUON/MID/Raw/src/Encoder.cxx
@@ -109,22 +109,21 @@ void Encoder::completeWord(std::vector<char>& buffer)
   }
 }
 
-void Encoder::writePayload(uint16_t feeId, const InteractionRecord& ir)
+void Encoder::writePayload(uint16_t feeId, const InteractionRecord& ir, bool onlyNonEmpty)
 {
   /// Writes data
 
-  std::vector<char> buf;
+  std::vector<char> buf = mOrbitResponse[feeId];
   for (auto& gbtUniqueId : mFEEIdConfig.getGBTUniqueIdsInLink(feeId)) {
     if (!mGBTEncoders[gbtUniqueId].isEmpty()) {
       mGBTEncoders[gbtUniqueId].flush(buf, ir);
     }
   }
-  if (buf.empty()) {
+  if (onlyNonEmpty && buf.size() == mOrbitResponse[feeId].size()) {
     return;
   }
 
   // Add the orbit response
-  buf.insert(buf.begin(), mOrbitResponse[feeId].begin(), mOrbitResponse[feeId].end());
   completeWord(buf);
   mRawWriter.addData(feeId, feeId / 2, raw::sUserLogicLinkID, feeId % 2, ir, buf);
 }
@@ -132,19 +131,16 @@ void Encoder::writePayload(uint16_t feeId, const InteractionRecord& ir)
 void Encoder::finalize(bool closeFile)
 {
   /// Writes remaining data and closes the file
-  if (mLastIR.isDummy()) {
-    mLastIR = mRawWriter.getHBFUtils().getFirstSampledTFIR();
-  }
+  initIR();
   auto ir = getOrbitIR(mLastIR.orbit);
   auto nextIr = getOrbitIR(mLastIR.orbit + 1);
   for (uint16_t feeId = 0; feeId < 4; ++feeId) {
-    auto ir = getOrbitIR(mLastIR.orbit);
     // Write the last payload
-    writePayload(feeId, ir);
+    writePayload(feeId, ir, true);
     // Since the regional response comes after few clocks,
     // we might have the corresponding regional cards in the next orbit.
     // If this is the case, we flush all data of the next orbit
-    writePayload(feeId, nextIr);
+    writePayload(feeId, nextIr, true);
   }
   if (closeFile) {
     mRawWriter.close();
@@ -156,11 +152,16 @@ void Encoder::process(gsl::span<const ColumnData> data, InteractionRecord ir, Ev
   /// Encodes data
 
   // The CTP trigger arrives to the electronics with a delay
-  if (ir.differenceInBC(mRawWriter.getHBFUtils().getFirstSampledTFIR()) > mElectronicsDelay.localToBC) { // RS: not sure this is correct.
-    applyElectronicsDelay(ir.orbit, ir.bc, -mElectronicsDelay.localToBC);
+  if (ir.differenceInBC(mRawWriter.getHBFUtils().getFirstSampledTFIR()) < mElectronicsDelay.localToBC) {
+    // Due to the delay, these data would arrive in the TF before the first sampled one.
+    // We therefore reject them.
+    return;
   }
+  applyElectronicsDelay(ir.orbit, ir.bc, -mElectronicsDelay.localToBC);
 
-  if (ir.orbit != mLastIR.orbit && !mLastIR.isDummy()) {
+  initIR();
+
+  if (ir.orbit != mLastIR.orbit) {
     onOrbitChange(mLastIR.orbit);
   }
 
@@ -181,5 +182,13 @@ void Encoder::process(gsl::span<const ColumnData> data, InteractionRecord ir, Ev
   }
   mLastIR = ir;
 }
+
+void Encoder::initIR()
+{
+  if (mLastIR.isDummy()) {
+    mLastIR = mRawWriter.getHBFUtils().getFirstSampledTFIR();
+  }
+}
+
 } // namespace mid
 } // namespace o2

--- a/Steer/DigitizerWorkflow/src/MIDDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/MIDDigitizerSpec.cxx
@@ -91,9 +91,7 @@ class MIDDPLDigitizerTask : public o2::base::BaseDPLDigitizer
         labelsAccum.mergeAtBack(labels);
       }
       auto nEntries = digitsAccum.size() - firstEntry;
-      if (nEntries > 0) {
-        rofRecords.emplace_back(irecords[collID], EventType::Standard, firstEntry, nEntries);
-      }
+      rofRecords.emplace_back(irecords[collID], EventType::Standard, firstEntry, nEntries);
     }
 
     mDigitsMerger.process(digitsAccum, labelsAccum, rofRecords);


### PR DESCRIPTION
This PR fixes some issues in the MID raw data encoder. In particular it fixes the treatment of the delays between the HB trigger and the data.
Also, the regional response to CTP triggers was not correct for the GBT link in the regional board that only reads 1 LOC.
Finally, the last commit ensures that we always generate raw data in simulation, also in the case where we have no muon in the TF.
The commits are meant to be atomic: please do not squash