### PR TITLE
Fixes for MID calibration

### DIFF
--- a/Detectors/MUON/MID/Calibration/include/MIDCalibration/ChannelCalibrator.h
+++ b/Detectors/MUON/MID/Calibration/include/MIDCalibration/ChannelCalibrator.h
@@ -87,9 +87,6 @@ class ChannelCalibrator final : public o2::calibration::TimeSlotCalibration<Colu
   /// Returns the bad channels
   const std::vector<ColumnData>& getBadChannels() const { return mBadChannels; }
 
-  /// Returns the TF end
-  TFType getTFEnd() { return mTFEnd; }
-
   /// Returns mask as string
   std::string getMasksAsString() { return mMasksString; }
 
@@ -97,8 +94,6 @@ class ChannelCalibrator final : public o2::calibration::TimeSlotCalibration<Colu
   void setReferenceMasks(const std::vector<ColumnData>& refMasks) { mRefMasks = refMasks; }
 
  private:
-  TFType mTFEnd = 0; /// Ending TF
-
   std::vector<ColumnData> mBadChannels; /// List of bad channels
   std::vector<ColumnData> mRefMasks;    /// Reference masks
   std::string mMasksString;             /// Masks as string

--- a/Detectors/MUON/MID/Calibration/src/ChannelCalibrator.cxx
+++ b/Detectors/MUON/MID/Calibration/src/ChannelCalibrator.cxx
@@ -77,8 +77,6 @@ void ChannelCalibrator::finalizeSlot(Slot& slot)
   LOG(info) << "Finalize slot " << slot.getTFStart() << " <= TF <= " << slot.getTFEnd();
 
   // Keep track of last TimeFrame, since the masks will be valid from now on
-  mTFEnd = slot.getTFEnd();
-
   mBadChannels = makeBadChannels(noiseData->getScalers(), mEventsCounter, mThreshold);
 
   // Get the masks for the electronics

--- a/Detectors/MUON/MID/Workflow/src/ChannelCalibratorSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/ChannelCalibratorSpec.cxx
@@ -119,7 +119,7 @@ class ChannelCalibratorDeviceDPL
   {
     o2::ccdb::CcdbObjectInfo info;
     std::map<std::string, std::string> md;
-    o2::calibration::Utils::prepareCCDBobjectInfo(payload, info, path, md, mCalibrator.getTFEnd(), o2::ccdb::CcdbObjectInfo::INFINITE_TIMESTAMP);
+    o2::calibration::Utils::prepareCCDBobjectInfo(payload, info, path, md, mCalibrator.getCurrentTFInfo().creation, mCalibrator.getCurrentTFInfo().creation + 5 * o2::ccdb::CcdbObjectInfo::DAY);
     auto image = o2::ccdb::CcdbApi::createObjectImage(&payload, &info);
     LOG(info) << "Sending object " << info.getPath() << "/" << info.getFileName() << " of size " << image->size()
               << " bytes, valid for " << info.getStartValidityTimestamp() << " : " << info.getEndValidityTimestamp();

--- a/Detectors/MUON/MID/Workflow/src/ChannelCalibratorSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/ChannelCalibratorSpec.cxx
@@ -59,11 +59,7 @@ class ChannelCalibratorDeviceDPL
     o2::base::GRPGeomHelper::instance().setRequest(mCCDBRequest);
     mThreshold = ic.options().get<double>("mid-mask-threshold");
 
-    auto slotL = ic.options().get<uint32_t>("tf-per-slot");
-    auto delay = ic.options().get<uint32_t>("max-delay");
-
-    mCalibrator.setSlotLength(slotL);
-    mCalibrator.setMaxSlotsDelay(delay);
+    mCalibrator.setSlotLength(calibration::INFINITE_TF);
     mCalibrator.setUpdateAtTheEndOfRunOnly();
   }
 
@@ -101,7 +97,7 @@ class ChannelCalibratorDeviceDPL
   }
 
  private:
-  ChannelCalibrator mCalibrator{};     ///< Calibrator
+  ChannelCalibrator mCalibrator{}; ///< Calibrator
   std::shared_ptr<o2::base::GRPGeomRequest> mCCDBRequest;
   std::vector<ColumnData> mRefMasks{}; ///< Reference masks
   double mThreshold{0.9};              ///< Occupancy threshold for producing a mask
@@ -157,10 +153,7 @@ of::DataProcessorSpec getChannelCalibratorSpec(const FEEIdConfig& feeIdConfig, c
     {inputSpecs},
     {outputSpecs},
     of::AlgorithmSpec{of::adaptFromTask<o2::mid::ChannelCalibratorDeviceDPL>(feeIdConfig, crateMasks, ccdbRequest)},
-    of::Options{
-      {"mid-mask-threshold", of::VariantType::Double, 0.9, {"Tolerated occupancy before producing a map"}},
-      {"tf-per-slot", of::VariantType::UInt32, ChannelCalibrator::INFINITE_TF, {"number of TFs per calibration time slot"}},
-      {"max-delay", of::VariantType::UInt32, 0u, {"number of slots in past to consider"}}}};
+    of::Options{{"mid-mask-threshold", of::VariantType::Double, 0.9, {"Tolerated occupancy before producing a map"}}}};
 }
 } // namespace mid
 } // namespace o2


### PR DESCRIPTION
This PR removes some unused options and fix the validity timestamp for MID calibration objects.
The commits are meant to be atomic: please do not squash.