### PR TITLE
Synchronize MID data orbit with RDH orbit at TF limit

### DIFF
--- a/Detectors/MUON/MID/Raw/include/MIDRaw/Decoder.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/Decoder.h
@@ -50,11 +50,11 @@ class Decoder
     /// Processes the page
     auto feeId = o2::raw::RDHUtils::getFEEID(rdh);
 #if defined(MID_RAW_VECTORS)
-    mLinkDecoders[feeId]->process(payload, o2::raw::RDHUtils::getHeartBeatOrbit(rdh), mData, mROFRecords);
+    mLinkDecoders[feeId]->process(payload, o2::raw::RDHUtils::getHeartBeatOrbit(rdh), o2::raw::RDHUtils::getTriggerType(rdh), mData, mROFRecords);
 #else
     auto linkDecoder = mLinkDecoders.find(feeId);
     if (linkDecoder != mLinkDecoders.end()) {
-      linkDecoder->second->process(payload, o2::raw::RDHUtils::getHeartBeatOrbit(rdh), mData, mROFRecords);
+      linkDecoder->second->process(payload, o2::raw::RDHUtils::getHeartBeatOrbit(rdh), o2::raw::RDHUtils::getTriggerType(rdh), mData, mROFRecords);
     } else {
       LOG(alarm) << "Unexpected feeId " << feeId << " in RDH";
     }

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/ELinkDataShaper.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/ELinkDataShaper.h
@@ -35,7 +35,7 @@ class ELinkDataShaper
   /// Main function to be executed when decoding is done
   inline void onDone(const ELinkDecoder& decoder, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs) { std::invoke(mOnDone, this, decoder, data, rofs); }
 
-  void set(uint32_t orbit);
+  void set(uint32_t orbit, uint32_t trigger);
 
  private:
   uint8_t mUniqueId = 0;                /// UniqueId
@@ -58,7 +58,7 @@ class ELinkDataShaper
   void addLoc(const ELinkDecoder& decoder, EventType eventType, InteractionRecord ir, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs);
   bool checkLoc(const ELinkDecoder& decoder);
   EventType processCalibrationTrigger(const InteractionRecord& ir);
-  void processOrbitTrigger(uint16_t localClock, uint8_t triggerWord);
+  void processHBTrigger(uint16_t localClock, uint8_t triggerWord);
   EventType processSelfTriggered(InteractionRecord& ir);
   bool processTrigger(const ELinkDecoder& decoder, EventType& eventType, InteractionRecord& ir);
 };

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/ELinkManager.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/ELinkManager.h
@@ -36,7 +36,7 @@ class ELinkManager
  public:
   void init(uint16_t feeId, bool isDebugMode, bool isBare = false, const ElectronicsDelay& electronicsDelay = ElectronicsDelay(), const FEEIdConfig& feeIdConfig = FEEIdConfig());
 
-  void set(uint32_t orbit);
+  void set(uint32_t orbit, uint32_t trigger);
 
   /// Main function to be executed when decoding is done
   inline void onDone(const ELinkDecoder& decoder, uint8_t boardUniqueId, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs) { return onDone(decoder, raw::getCrateId(boardUniqueId), raw::getLocId(boardUniqueId), data, rofs); }

--- a/Detectors/MUON/MID/Raw/include/MIDRaw/LinkDecoder.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/LinkDecoder.h
@@ -34,17 +34,17 @@ namespace mid
 class LinkDecoder
 {
  public:
-  LinkDecoder(std::function<void(gsl::span<const uint8_t>, uint32_t orbit, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)> decode) : mDecode(decode) {}
-  void process(gsl::span<const uint8_t> payload, uint32_t orbit, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs);
+  LinkDecoder(std::function<void(gsl::span<const uint8_t>, uint32_t orbit, uint32_t trigger, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)> decode) : mDecode(decode) {}
+  void process(gsl::span<const uint8_t> payload, uint32_t orbit, uint32_t trigger, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs);
 
   template <class RDH>
   void process(gsl::span<const uint8_t> payload, const RDH& rdh, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)
   {
-    process(payload, o2::raw::RDHUtils::getHeartBeatOrbit(rdh), data, rofs);
+    process(payload, o2::raw::RDHUtils::getHeartBeatOrbit(rdh), o2::raw::RDHUtils::getTriggerType(rdh), data, rofs);
   }
 
  protected:
-  std::function<void(gsl::span<const uint8_t>, uint32_t orbit, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)> mDecode{nullptr};
+  std::function<void(gsl::span<const uint8_t>, uint32_t orbit, uint32_t trigger, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)> mDecode{nullptr};
 };
 
 std::unique_ptr<LinkDecoder> createGBTDecoder(const o2::header::RDHAny& rdh, uint16_t feeId, bool isDebugMode, uint8_t mask, const ElectronicsDelay& electronicsDelay);

--- a/Detectors/MUON/MID/Raw/src/ELinkManager.cxx
+++ b/Detectors/MUON/MID/Raw/src/ELinkManager.cxx
@@ -92,14 +92,14 @@ void ELinkManager::onDone(const ELinkDecoder& decoder, uint8_t crateId, uint8_t 
   return ds->second.onDone(decoder, data, rofs);
 }
 
-void ELinkManager::set(uint32_t orbit)
+void ELinkManager::set(uint32_t orbit, uint32_t trigger)
 {
   /// Setup the orbit
   for (auto& shaper : mDataShapers) {
 #if defined(MID_RAW_VECTORS)
-    shaper.set(orbit);
+    shaper.set(orbit, trigger);
 #else
-    shaper.second.set(orbit);
+    shaper.second.set(orbit, trigger);
 #endif
   }
 }

--- a/Detectors/MUON/MID/Raw/src/LinkDecoder.cxx
+++ b/Detectors/MUON/MID/Raw/src/LinkDecoder.cxx
@@ -38,10 +38,10 @@ class GBTUserLogicDecoderImplV2
     mELinkDecoder.setBareDecoder(false);
   }
 
-  void operator()(gsl::span<const uint8_t> payload, uint32_t orbit, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)
+  void operator()(gsl::span<const uint8_t> payload, uint32_t orbit, uint32_t trigger, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)
   {
     /// Decodes the buffer
-    mElinkManager.set(orbit);
+    mElinkManager.set(orbit, trigger);
     // for (auto& byte : payload) {
     auto it = payload.begin();
     auto end = payload.end();
@@ -79,10 +79,10 @@ class GBTUserLogicDecoderImplV1
     mElinkManager.init(feeId, isDebugMode, true, electronicsDelay);
   }
 
-  void operator()(gsl::span<const uint8_t> payload, uint32_t orbit, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)
+  void operator()(gsl::span<const uint8_t> payload, uint32_t orbit, uint32_t trigger, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)
   {
     /// Decodes the buffer
-    mElinkManager.set(orbit);
+    mElinkManager.set(orbit, trigger);
     // for (auto& byte : payload) {
     auto it = payload.begin();
     auto end = payload.end();
@@ -126,10 +126,10 @@ class GBTBareDecoderImplV1
     }
   }
 
-  void operator()(gsl::span<const uint8_t> payload, uint32_t orbit, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)
+  void operator()(gsl::span<const uint8_t> payload, uint32_t orbit, uint32_t trigger, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)
   {
     /// Decodes the buffer
-    mElinkManager.set(orbit);
+    mElinkManager.set(orbit, trigger);
     mData = &data;
     mROFs = &rofs;
 
@@ -209,10 +209,10 @@ class GBTBareDecoderImplV1
 
 } // namespace impl
 
-void LinkDecoder::process(gsl::span<const uint8_t> payload, uint32_t orbit, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)
+void LinkDecoder::process(gsl::span<const uint8_t> payload, uint32_t orbit, uint32_t trigger, std::vector<ROBoard>& data, std::vector<ROFRecord>& rofs)
 {
   /// Decodes the data
-  mDecode(payload, orbit, data, rofs);
+  mDecode(payload, orbit, trigger, data, rofs);
 }
 
 std::unique_ptr<LinkDecoder> createGBTDecoder(const o2::header::RDHAny& rdh, uint16_t feeId, bool isDebugMode, uint8_t mask, const ElectronicsDelay& electronicsDelay)

--- a/Detectors/MUON/MID/Workflow/src/RawGBTDecoderSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/RawGBTDecoderSpec.cxx
@@ -77,7 +77,7 @@ class RawGBTDecoderDeviceDPL
       dh = it.o2DataHeader();
       auto const* rdhPtr = reinterpret_cast<const o2::header::RDHAny*>(it.raw());
       gsl::span<const uint8_t> payload(it.data(), it.size());
-      mDecoder->process(payload, o2::raw::RDHUtils::getHeartBeatOrbit(rdhPtr), data, rofRecords);
+      mDecoder->process(payload, o2::raw::RDHUtils::getHeartBeatOrbit(rdhPtr), o2::raw::RDHUtils::getTriggerType(rdhPtr), data, rofRecords);
     }
 
     mTimerAlgo += std::chrono::high_resolution_clock::now() - tAlgoStart;


### PR DESCRIPTION
The CRU UL ensures that all data coming before the answer to an orbit trigger are flushed only at the TF limit.
There is no such check within a TF.
The decoder is modified accordingly. At the beginning of the TF we can trust that the data belong to the orbit written in the RDH.
Within a TF, on the other hand, we increment the orbit number based on the information in the payload.