### PR TITLE
Fix unsigned DPL option in TPC raw2digits

### DIFF
--- a/Detectors/TPC/workflow/src/RawToDigitsSpec.cxx
+++ b/Detectors/TPC/workflow/src/RawToDigitsSpec.cxx
@@ -257,7 +257,7 @@ DataProcessorSpec getRawToDigitsSpec(int channel, const std::string inputSpec, s
       {"remove-duplicates", VariantType::Bool, false, {"check if duplicate digits exist and remove them"}},
       {"remove-ce-digits", VariantType::Bool, false, {"find CE position and remove digits around it"}},
       {"ignore-grp", VariantType::Bool, false, {"ignore GRP file"}},
-      {"sync-offset-reference", VariantType::UInt32, 144, {"Reference BCs used for the global sync offset in the CRUs"}},
+      {"sync-offset-reference", VariantType::UInt32, 144u, {"Reference BCs used for the global sync offset in the CRUs"}},
     } // end Options
   };  // end DataProcessorSpec
 }


### PR DESCRIPTION
Hi @wiechula .
I opened this to possibly get it in the next nightly.
Unfortunately, DPL seems to be **very** sensitive with respect to the default value type. I could not even manually set the parameter, because then I still get
```
[marten@epn155 ~]$ o2-tpc-raw-to-digits-workflow -b --sync-offset-reference 144u
[ERROR] invalid workflow in o2-tpc-raw-to-digits-workflow: Mismatch between declared option type (19) and default value type (0) for sync-offset-reference in DataProcessorSpec of tpc-raw-to-digits-0
```
