### PR TITLE
[EMCAL-651] Don't initialize geometry in the ClusterFactory

### DIFF
--- a/Detectors/EMCAL/base/include/EMCALBase/ClusterFactory.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/ClusterFactory.h
@@ -109,6 +109,21 @@ class ClusterFactory
     std::string mErrorMessage; ///< Error message
   };
 
+  /// \class GeometryNoSetException
+  /// \brief Exception thrown when the geometry is not set
+  class GeometryNotSetException final : public std::exception
+  {
+   public:
+    /// \brief Constructor
+    GeometryNotSetException() = default;
+    /// \brief Destructor
+    ~GeometryNotSetException() noexcept final = default;
+
+    /// \brief Provide error message
+    /// \return Error message connected to this exception
+    const char* what() const noexcept final { return "Geometry not set"; }
+  };
+
   class ClusterIterator
   {
    public:
@@ -172,7 +187,7 @@ class ClusterFactory
 
   ///
   /// Dummy constructor
-  ClusterFactory() = default;
+  ClusterFactory();
 
   ///
   /// \brief Constructor initializing the ClusterFactory
@@ -331,7 +346,7 @@ class ClusterFactory
   float etaToTheta(float arg) const;
 
  private:
-  o2::emcal::Geometry* mGeomPtr = Geometry::GetInstanceFromRunNumber(223409); //!<! Pointer to geometry for utilities
+  o2::emcal::Geometry* mGeomPtr = nullptr;
 
   float mCoreRadius = 10; ///<  The radius in which the core energy is evaluated
 

--- a/Detectors/EMCAL/base/src/ClusterFactory.cxx
+++ b/Detectors/EMCAL/base/src/ClusterFactory.cxx
@@ -25,9 +25,17 @@
 
 using namespace o2::emcal;
 
+template <typename InputType>
+ClusterFactory<InputType>::ClusterFactory()
+{
+  mGeomPtr = o2::emcal::Geometry::GetInstance();
+}
+
 template <class InputType>
 ClusterFactory<InputType>::ClusterFactory(gsl::span<const o2::emcal::Cluster> clustersContainer, gsl::span<const InputType> inputsContainer, gsl::span<const int> cellsIndices)
 {
+  mGeomPtr = o2::emcal::Geometry::GetInstance();
+
   setClustersContainer(clustersContainer);
   setCellsContainer(inputsContainer);
   setCellsIndicesContainer(cellsIndices);
@@ -49,6 +57,9 @@ o2::emcal::AnalysisCluster ClusterFactory<InputType>::buildCluster(int clusterIn
 {
   if (clusterIndex >= mClustersContainer.size()) {
     throw ClusterRangeException(clusterIndex, mClustersContainer.size());
+  }
+  if (!mGeomPtr) {
+    throw GeometryNotSetException();
   }
 
   o2::emcal::AnalysisCluster clusterAnalysis;
@@ -464,8 +475,6 @@ void ClusterFactory<InputType>::evalCoreEnergy(gsl::span<const int> inputsIndice
 template <class InputType>
 void ClusterFactory<InputType>::evalElipsAxis(gsl::span<const int> inputsIndices, AnalysisCluster& clusterAnalysis) const
 {
-  TString gn(mGeomPtr->GetName());
-
   double wtot = 0.;
   double x = 0.;
   double z = 0.;


### PR DESCRIPTION
Calling GetInstanceFromRunNumber
in header leads to the geometry
being constructed every time a
ClusterFactory is constructed.
Instead the Geometry should be
handled outside, and ClusterFactory
should only throw a error in case the
geometry is not initialized.