### PR TITLE
CCDB: Option to disable alien-token check

### DIFF
--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -766,12 +766,16 @@ bool CcdbApi::checkAlienToken() const
   LOG(debug) << "On macOS we simply rely on TGrid::Connect(\"alien\").";
   return true;
 #endif
-  // a somewhat weird construction to programmatically find out if we
-  // have a GRID token; Can be replaced with something more elegant once
-  // alien-token-info does not ask for passwords interactively
+  if (getenv("ALICEO2_CCDB_NOTOKENCHECK")) {
+    // will be the default soon
+    return true;
+  }
   if (getenv("JALIEN_TOKEN_CERT")) {
     return true;
   }
+  // a somewhat weird construction to programmatically find out if we
+  // have a GRID token; Can be replaced with something more elegant once
+  // alien-token-info does not ask for passwords interactively
   auto returncode = system("alien-token-info > /dev/null 2> /dev/null");
   if (returncode == -1) {
     LOG(error) << "system(\"alien-token-info\") call failed with internal fork/wait error";


### PR DESCRIPTION
Since now the ALIEN token is mandatory, there will be no need
to check for it's presence (to determine code paths) anymore.
Eventually, the check can be disabled completely.

For now providing a env variable in order to be able
to study some speed improvements (in a switchable way).