### PR TITLE
Option to ignore object validity check/refetching if cache is available

### DIFF
--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -516,7 +516,9 @@ class CcdbApi //: public DatabaseInterface
   std::string mUniqueAgentID{}; // Unique User-Agent ID communicated to server for logging
   std::string mUrl{};
   std::vector<std::string> hostsPool{};
-  std::string mSnapshotTopPath{};
+  std::string mSnapshotTopPath{};    // root of the snaphot in the snapshot backend mode, i.e. with init("file://<dir>) call
+  std::string mSnapshotCachePath{};  // root of the local snapshot (to fill or impose, even if not in the snapshot backend mode)
+  bool mPreferSnapshotCache = false; // if snapshot is available, don't try to query its validity even in non-snapshot backend mode
   bool mInSnapshotMode = false;
   mutable TGrid* mAlienInstance = nullptr;                       // a cached connection to TGrid (needed for Alien locations)
   bool mHaveAlienToken = false;                                  // stores if an alien token is available

--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -361,6 +361,9 @@ class CcdbApi //: public DatabaseInterface
 #endif
 
  private:
+  // report what file is read and for which purpose
+  void logReading(const std::string& fname, const std::string& comment) const;
+
   /**
    * Initialize in local mode; Objects will be retrieved from snapshot
    *

--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -784,6 +784,7 @@ void* CcdbApi::extractFromTFile(TFile& file, TClass const* cl)
 
 void* CcdbApi::extractFromLocalFile(std::string const& filename, std::type_info const& tinfo, std::map<std::string, std::string>* headers) const
 {
+  logReading(filename, "retrieve");
   if (!std::filesystem::exists(filename)) {
     LOG(error) << "Local snapshot " << filename << " not found \n";
     return nullptr;
@@ -842,6 +843,7 @@ bool CcdbApi::initTGrid() const
 
 void* CcdbApi::downloadAlienContent(std::string const& url, std::type_info const& tinfo) const
 {
+  logReading(url, "retrieve");
   if (!initTGrid()) {
     return nullptr;
   }
@@ -1649,7 +1651,7 @@ void CcdbApi::navigateURLsAndLoadFileToMemory(o2::pmr::vector<char>& dest, CURL*
 void CcdbApi::loadFileToMemory(o2::pmr::vector<char>& dest, const std::string& path, std::map<std::string, std::string>* localHeaders) const
 {
   // Read file to memory as vector. For special case of the locally cached file retriev metadata stored directly in the file
-  LOGP(debug, "loading from {} to memory", path);
+  logReading(path, "load to memory");
   constexpr size_t MaxCopySize = 0x1L << 25;
   auto signalError = [&dest, localHeaders]() {
     dest.clear();
@@ -1731,6 +1733,11 @@ void CcdbApi::checkMetadataKeys(std::map<std::string, std::string> const& metada
     LOG(fatal) << "Some metadata keys have invalid characters, please fix!";
   }
   return;
+}
+
+void CcdbApi::logReading(const std::string& fname, const std::string& comment) const
+{
+  LOGP(info, "ccdb reads {} ({}, agent_id: {}), ", fname, comment, mUniqueAgentID);
 }
 
 } // namespace o2

--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -86,10 +86,43 @@ void CcdbApi::init(std::string const& host)
     initHostsPool(host);
     curlInit();
   }
+  // The environment option ALICEO2_CCDB_LOCALCACHE allows
+  // to reduce the number of queries to the server, by collecting the objects in a local
+  // cache folder, and serving from this folder for repeated queries.
+  // This is useful for instance for MC GRID productions in which we spawn
+  // many isolated processes, all querying the CCDB (for potentially the same objects and same timestamp).
+  // In addition, we can monitor exactly which objects are fetched and what is their content.
+  // One can also distribute so obtained caches to sites without network access.
+  //
+  // When used with the DPL CCDB fetcher (i.e. loadFileToMemory is called), in order to prefer the available snapshot w/o its validity
+  // check an extra variable IGNORE_VALIDITYCHECK_OF_CCDB_LOCALCACHE must be defined, otherwhise the object will be fetched from the
+  // server after the validity check and new snapshot will be created if needed
 
+  std::string snapshotReport{};
+  const char* cachedir = getenv("ALICEO2_CCDB_LOCALCACHE");
+  if (cachedir) {
+    if (cachedir[0] == 0) {
+      mSnapshotCachePath = ".";
+    } else {
+      mSnapshotCachePath = cachedir;
+    }
+    snapshotReport = fmt::format("(cache snapshots to dir={}", mSnapshotCachePath);
+  }
+  if (getenv("IGNORE_VALIDITYCHECK_OF_CCDB_LOCALCACHE")) {
+    mPreferSnapshotCache = true;
+    if (mSnapshotCachePath.empty()) {
+      LOGP(fatal, "IGNORE_VALIDITYCHECK_OF_CCDB_LOCALCACHE is defined but the ALICEO2_CCDB_LOCALCACHE is not");
+    }
+    snapshotReport += ", prefer if available";
+  }
+  if (!snapshotReport.empty()) {
+    snapshotReport += ')';
+  }
   // find out if we can can in principle connect to Alien
   mHaveAlienToken = checkAlienToken();
-  LOGP(info, "Init CcdApi with UserAgentID: {}, Host: {}{}, alien-token: {}", mUniqueAgentID, host, mInSnapshotMode ? "(snapshot readonly mode)" : "", mHaveAlienToken);
+
+  LOGP(info, "Init CcdApi with UserAgentID: {}, Host: {}{}, alien-token: {}", mUniqueAgentID, host,
+       mInSnapshotMode ? "(snapshot readonly mode)" : snapshotReport.c_str(), mHaveAlienToken);
 }
 
 /**
@@ -764,6 +797,9 @@ void* CcdbApi::extractFromLocalFile(std::string const& filename, std::type_info 
       *headers = *storedmeta; // do a simple deep copy
       delete storedmeta;
     }
+    if (isSnapshotMode() || mPreferSnapshotCache) { // generate dummy ETag to profit from the caching
+      (*headers)["ETag"] = filename;
+    }
   }
   return extractFromTFile(f, tcl);
 }
@@ -952,23 +988,11 @@ void* CcdbApi::retrieveFromTFile(std::type_info const& tinfo, std::string const&
                                  std::map<std::string, std::string>* headers, std::string const& etag,
                                  const std::string& createdNotAfter, const std::string& createdNotBefore) const
 {
-  // The environment option ALICEO2_CCDB_LOCALCACHE allows
-  // to reduce the number of queries to the server, by collecting the objects in a local
-  // cache folder, and serving from this folder for repeated queries.
-  // This is useful for instance for MC GRID productions in which we spawn
-  // many isolated processes, all querying the CCDB (for potentially the same objects and same timestamp).
-  // In addition, we can monitor exactly which objects are fetched and what is their content.
-  // One can also distribute so obtained caches to sites without network access.
-  const char* cachedir = getenv("ALICEO2_CCDB_LOCALCACHE");
-  const char* cwd = ".";
-  if (cachedir) {
-    if (cachedir[0] == 0) {
-      cachedir = cwd;
-    }
+  if (!mSnapshotCachePath.empty()) {
     // protect this sensitive section by a multi-process named semaphore
     boost::interprocess::named_semaphore* sem = nullptr;
     std::hash<std::string> hasher;
-    const auto semhashedstring = "aliceccdb" + std::to_string(hasher(std::string(cachedir) + path)).substr(0, 16);
+    const auto semhashedstring = "aliceccdb" + std::to_string(hasher(mSnapshotCachePath + path)).substr(0, 16);
     try {
       sem = new boost::interprocess::named_semaphore(boost::interprocess::open_or_create_t{}, semhashedstring.c_str(), 1);
     } catch (std::exception e) {
@@ -978,16 +1002,16 @@ void* CcdbApi::retrieveFromTFile(std::type_info const& tinfo, std::string const&
     if (sem) {
       sem->wait(); // wait until we can enter (no one else there)
     }
-    std::string logfile = std::string(cachedir) + "/log";
+    std::string logfile = mSnapshotCachePath + "/log";
     std::fstream out(logfile, ios_base::out | ios_base::app);
     if (out.is_open()) {
       out << "CCDB-access[" << getpid() << "] to " << path << " timestamp " << timestamp << "\n";
     }
-    auto snapshotfile = getSnapshotFile(cachedir, path);
+    auto snapshotfile = getSnapshotFile(mSnapshotCachePath, path);
     if (!std::filesystem::exists(snapshotfile)) {
       out << "CCDB-access[" << getpid() << "]  ... downloading to snapshot " << snapshotfile << "\n";
       // if file not already here and valid --> snapshot it
-      if (!retrieveBlob(path, cachedir, metadata, timestamp)) {
+      if (!retrieveBlob(path, mSnapshotCachePath, metadata, timestamp)) {
         out << "CCDB-access[" << getpid() << "]  ... failed to create directory for " << snapshotfile << "\n";
       }
     } else {
@@ -1424,9 +1448,16 @@ void CcdbApi::loadFileToMemory(o2::pmr::vector<char>& dest, std::string const& p
 
   // if we are in snapshot mode we can simply open the file, unless the etag is non-empty:
   // this would mean that the object was is already fetched and in this mode we don't to validity checks!
-  if (mInSnapshotMode) {
+  std::string snapshotpath{};
+  if (mInSnapshotMode) { // file must be there, otherwise a fatal will be produced
     loadFileToMemory(dest, getSnapshotFile(mSnapshotTopPath, path), headers);
-  } else {
+  } else if (mPreferSnapshotCache && std::filesystem::exists(snapshotpath = getSnapshotFile(mSnapshotCachePath, path))) {
+    // if file is available, use it, otherwise cache it below from the server. Do this only when etag is empty since otherwise the object was already fetched and cached
+    if (etag.empty()) {
+      loadFileToMemory(dest, snapshotpath, headers);
+    }
+    return;
+  } else { // look on the server
     CURL* curl_handle = curl_easy_init();
     string fullUrl = getFullUrlForRetrieval(curl_handle, path, metadata, timestamp);
 
@@ -1446,19 +1477,14 @@ void CcdbApi::loadFileToMemory(o2::pmr::vector<char>& dest, std::string const& p
   }
 
   // are we asked to create a snapshot ?
-  const char* cachedir = getenv("ALICEO2_CCDB_LOCALCACHE");
-  const char* cwd = ".";
-  if (cachedir) {
-    if (cachedir[0] == 0) {
-      cachedir = cwd;
-    }
-    if (mInSnapshotMode && mSnapshotTopPath == cachedir) { // do not save to itself
+  if (!mSnapshotCachePath.empty()) {
+    if (mInSnapshotMode && mSnapshotTopPath == mSnapshotCachePath) { // do not save to itself
       return;
     }
     // protect this sensitive section by a multi-process named semaphore
     boost::interprocess::named_semaphore* sem = nullptr;
     std::hash<std::string> hasher;
-    const auto semhashedstring = "aliceccdb" + std::to_string(hasher(std::string(cachedir) + path)).substr(0, 16);
+    const auto semhashedstring = "aliceccdb" + std::to_string(hasher(mSnapshotCachePath + path)).substr(0, 16);
     try {
       sem = new boost::interprocess::named_semaphore(boost::interprocess::open_or_create_t{}, semhashedstring.c_str(), 1);
     } catch (std::exception e) {
@@ -1468,10 +1494,10 @@ void CcdbApi::loadFileToMemory(o2::pmr::vector<char>& dest, std::string const& p
     if (sem) {
       sem->wait(); // wait until we can enter (no one else there)
     }
-    std::string logfile = std::string(cachedir) + "/log";
+    std::string logfile = mSnapshotCachePath + "/log";
     std::fstream out(logfile, ios_base::out | ios_base::app);
-    auto snapshotdir = getSnapshotDir(cachedir, path);
-    auto snapshotpath = getSnapshotFile(cachedir, path);
+    auto snapshotdir = getSnapshotDir(mSnapshotCachePath, path);
+    snapshotpath = getSnapshotFile(mSnapshotCachePath, path);
     o2::utils::createDirectoriesIfAbsent(snapshotdir);
     if (out.is_open()) {
       out << "CCDB-access[" << getpid() << "]  ... downloading to snapshot " << snapshotpath << "\n";
@@ -1675,7 +1701,7 @@ void CcdbApi::loadFileToMemory(o2::pmr::vector<char>& dest, const std::string& p
       *localHeaders = *storedmeta; // do a simple deep copy
       delete storedmeta;
     }
-    if (isSnapshotMode()) { // generate dummy ETag to profit from the caching
+    if (isSnapshotMode() || mPreferSnapshotCache) { // generate dummy ETag to profit from the caching
       (*localHeaders)["ETag"] = path;
     }
   }


### PR DESCRIPTION
When used with the DPL CCDB fetcher (i.e. loadFileToMemory is called) in order to prefer the available
snapshot w/o its validity check an extra variable `IGNORE_VALIDITYCHECK_OF_CCDB_LOCALCACHE` must be defined
otherwhise the object will be fetched from the server after the validity check and new snapshot will be created if needed.
`IGNORE_VALIDITYCHECK_OF_CCDB_LOCALCACHE` should be always accompanied by the `ALICEO2_CCDB_LOCALCACHE` env.var indicating the snapshot directory (if the directory of particular snapshots are absent, they will be populated at 1st call).

@sawenzel 