### PR TITLE
Utility for detector run status check in DCS processing + EMC example

### DIFF
--- a/Detectors/DCS/CMakeLists.txt
+++ b/Detectors/DCS/CMakeLists.txt
@@ -24,6 +24,7 @@ o2_add_library(
           src/GenericFunctions.cxx
           src/StringUtils.cxx
           src/Clock.cxx
+   src/RunStatusChecker.cxx
   PUBLIC_LINK_LIBRARIES O2::Headers O2::CommonUtils O2::CCDB
                         O2::DetectorsCalibration Microsoft.GSL::GSL)
 
@@ -31,7 +32,8 @@ o2_target_root_dictionary(
   DetectorsDCS
   HEADERS include/DetectorsDCS/DataPointCompositeObject.h
           include/DetectorsDCS/DataPointIdentifier.h
-          include/DetectorsDCS/DataPointValue.h)
+          include/DetectorsDCS/DataPointValue.h
+   include/DetectorsDCS/RunStatusChecker.h)
 
 if(OpenMP_CXX_FOUND)
   target_compile_definitions(${targetName} PRIVATE WITH_OPENMP)

--- a/Detectors/DCS/include/DetectorsDCS/RunStatusChecker.h
+++ b/Detectors/DCS/include/DetectorsDCS/RunStatusChecker.h
@@ -1,0 +1,82 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_RUN_STATUS_CHECKER_H
+#define O2_RUN_STATUS_CHECKER_H
+
+/// @author ruben.shahoyan@cern.ch
+
+#include "DataFormatsParameters/GRPECSObject.h"
+#include "DetectorsCommonDataFormats/DetID.h"
+
+/*
+  Utility class to check the status of the run with particular detectors participating
+  Usage: first create an instance for the mask of detectors which must be in the run, e.g.
+
+  RunStatusChecker runChecker{ o2::detectors::DetID::getMask("EMC,PHS") };
+  const o2::parameters::GRPECSObject* myGRPECS = nullptr;
+
+  Then, periodically check:
+
+  myGRPECS = runChecker.check();
+
+  The check will set the status of the run with selected detectors (can be inspected by getRunStatus() method).
+
+  if (check.getRunStatus() == o2::dcs::RunStatusChecker::RunStatus::NONE) {
+    LOGP(info, "No run with {} is ongoing or finished", o2::detectors::DetID::getNames(checker->getDetectorsMask()) );
+  }
+  else if (check.getRunStatus() == o2::dcs::RunStatusChecker::RunStatus::START) { // saw new run with wanted detectors
+    LOGP(info, "Run {} with {} has started", checker.getFollowedRun(), o2::detectors::DetID::getNames(checker->getDetectorsMask()) );
+  }
+  else if (check.getRunStatus() == o2::dcs::RunStatusChecker::RunStatus::ONGOING) { // run which was already seen is still ongoing
+    LOGP(info, "Run {} with {} is still ongoing", checker.getFollowedRun(), o2::detectors::DetID::getNames(checker->getDetectorsMask()) );
+  }
+  else if (check.getRunStatus() == o2::dcs::RunStatusChecker::RunStatus::STOP) { // run which was already seen was stopped (EOR seen)
+    LOGP(info, "Run {} with {} was stopped", checker.getFollowedRun(), o2::detectors::DetID::getNames(checker->getDetectorsMask()) );
+  }
+
+  In all cases except RunStatusChecker::NONE a const non-null pointer on the GRP of the followed run will be returned.
+
+  By default the check will be done for the current timestamp, for test purposes one can call it with arbitrary increasing timestamps
+*/
+
+namespace o2::dcs
+{
+
+class RunStatusChecker
+{
+ public:
+  enum class RunStatus { NONE,    // check did not find onging run with current detector
+                         START,   // check found a new run started
+                         ONGOING, // check found ongoing run which was already checked
+                         STOP     // check found that previously ongoing run was stopped
+  };
+
+  RunStatusChecker() = delete;
+  RunStatusChecker(o2::detectors::DetID::mask_t detmask) : mDetMask(detmask) {}
+
+  RunStatus getRunStatus() const { return mRunStatus; }
+  int getFollowedRun() const { return mRunFollowed; }
+  o2::detectors::DetID::mask_t getDetectorsMask() const { return mDetMask; }
+  const o2::parameters::GRPECSObject* check(long ts = -1);
+
+ private:
+  RunStatus mRunStatus = RunStatus::NONE;
+  o2::detectors::DetID::mask_t mDetMask{};
+  int mRunFollowed = -1; // particular run followed, assumption is that at the given moment there might be only run with particular detector
+  long mLastTimeStampChecked = -1;
+
+  ClassDefNV(RunStatusChecker, 0);
+};
+
+} // namespace o2::dcs
+
+#endif

--- a/Detectors/DCS/src/DetectorsDCSLinkDef.h
+++ b/Detectors/DCS/src/DetectorsDCSLinkDef.h
@@ -14,6 +14,7 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
+#pragma link C++ class o2::dcs::RunStatusChecker;
 #pragma link C++ struct o2::dcs::DataPointCompositeObject + ;
 #pragma link C++ class o2::dcs::DataPointIdentifier + ;
 #pragma link C++ struct o2::dcs::DataPointValue + ;

--- a/Detectors/DCS/src/RunStatusChecker.cxx
+++ b/Detectors/DCS/src/RunStatusChecker.cxx
@@ -1,0 +1,69 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "DetectorsDCS/RunStatusChecker.h"
+#include "CCDB/BasicCCDBManager.h"
+#include "CCDB/CCDBTimeStampUtils.h"
+
+using namespace o2::dcs;
+
+const o2::parameters::GRPECSObject* RunStatusChecker::check(long ts)
+{
+  if (ts < 0) {
+    ts = o2::ccdb::getCurrentTimestamp();
+  }
+  if (ts <= mLastTimeStampChecked) {
+    LOGP(alarm, "RunStatusChecker::check was called with decreasing timestamp {}, previous was {}", ts, mLastTimeStampChecked);
+    return nullptr;
+  }
+  mLastTimeStampChecked = ts;
+
+  auto& mgr = o2::ccdb::BasicCCDBManager::instance();
+  bool fatalOn = mgr.getFatalWhenNull();
+  mgr.setFatalWhenNull(false);
+  if (mRunStatus == RunStatus::STOP) { // the STOP was detected at previous check
+    mRunFollowed = -1;
+    mRunStatus = RunStatus::NONE;
+  }
+  std::map<std::string, std::string> md;
+  if (mRunFollowed > 0) { // run start was seen
+    md["runNumber"] = std::to_string(mRunFollowed);
+  }
+  const auto* grp = mgr.getSpecific<o2::parameters::GRPECSObject>("GLO/Config/GRPECS", ts, md);
+  if (grp) { // some object was returned
+    if (mRunFollowed > 0) {
+      if ((ts > grp->getTimeEnd()) && (grp->getTimeEnd() > grp->getTimeStart())) { // this means that the EOR was registered
+        mRunStatus = RunStatus::STOP;
+      } else { // run still continues
+        mRunStatus = RunStatus::ONGOING;
+      }
+    } else {                                                // we were not following detector run, check if the current one has asked detectors
+      if ((grp->getDetsReadOut() & mDetMask) == mDetMask) { // we start following this run
+        if (grp->getTimeEnd() > grp->getTimeStart()) {
+          if (ts < grp->getTimeEnd()) { // only in tests with ad hoc ts the ts_EOR can be seen > ts
+            mRunStatus = RunStatus::START;
+            mRunFollowed = grp->getRun();
+          }
+        } else {
+          mRunStatus = RunStatus::START;
+          mRunFollowed = grp->getRun();
+        }
+      }
+    }
+  } else {                  // query did not return any GRP -> we are certainly not in the wanted detectors run
+    if (mRunFollowed > 0) { // normally this should not happen
+      LOGP(warning, "We were following {} run {} but the query at {} did not return any GRP, problem with EOR?", o2::detectors::DetID::getNames(mDetMask), mRunFollowed, ts);
+      mRunStatus = RunStatus::STOP;
+    }
+  }
+  mgr.setFatalWhenNull(fatalOn);
+  return mRunStatus == RunStatus::NONE ? nullptr : grp;
+}


### PR DESCRIPTION
Utility class to check the status of the run with particular detectors participating. 
Usage: 
```
  // first create an instance for the mask of detectors which must be in the run, e.g.
  RunStatusChecker runChecker{ o2::detectors::DetID::getMask("EMC,PHS") };
  const o2::parameters::GRPECSObject* myGRPECS = nullptr;

  // then, periodically check:
  myGRPECS = runChecker.check();
  auto dets = o2::detectors::DetID::getNames(checker->getDetectorsMask());
  using RunStatus = o2::dcs::RunStatusChecker::RunStatus;

  // the check will set the status of the run with selected detectors (can be inspected by getRunStatus() method).
  if (check.getRunStatus() == RunStatus::NONE) {
    LOGP(info, "No run with {} is ongoing or finished", dets);
  }
  else if (check.getRunStatus() == RunStatus::START) { // saw new run with wanted detectors
    LOGP(info, "Run {} with {} has started", checker.getFollowedRun(),  dets);
  }
  else if (check.getRunStatus() == RunStatus::ONGOING) { // run which was already seen is still ongoing
    LOGP(info, "Run {} with {} is still ongoing", checker.getFollowedRun(), dets);
  }
  else if (check.getRunStatus() == RunStatus::STOP) { // run which was already seen was stopped (EOR seen)
    LOGP(info, "Run {} with {} was stopped", checker.getFollowedRun(), dets);
  }
  // In all cases except RunStatus::NONE a const non-null pointer on the GRP of the followed run will be returned.
  // By default the check will be done for the current timestamp, for test purposes, one can call it with arbitrary increasing timestamps
```

@chiarazampolli @gvolpe79 
