### PR TITLE
[EMCAL-566] Improved ROOT to boost histogram conversion 

### DIFF
--- a/Common/Utils/include/CommonUtils/BoostHistogramUtils.h
+++ b/Common/Utils/include/CommonUtils/BoostHistogramUtils.h
@@ -47,6 +47,9 @@
 using boostHisto2d = boost::histogram::histogram<std::tuple<boost::histogram::axis::regular<double, boost::use_default, boost::use_default, boost::use_default>, boost::histogram::axis::regular<double, boost::use_default, boost::use_default, boost::use_default>>, boost::histogram::unlimited_storage<std::allocator<char>>>;
 using boostHisto1d = boost::histogram::histogram<std::tuple<boost::histogram::axis::regular<double, boost::use_default, boost::use_default, boost::use_default>>, boost::histogram::unlimited_storage<std::allocator<char>>>;
 
+using boostHisto2d_VarAxis = boost::histogram::histogram<std::tuple<boost::histogram::axis::variable<double, boost::use_default, boost::use_default, std::allocator<double>>, boost::histogram::axis::variable<double, boost::use_default, boost::use_default, std::allocator<double>>>>;
+using boostHisto1d_VarAxis = boost::histogram::histogram<std::tuple<boost::histogram::axis::variable<double, boost::use_default, boost::use_default, std::allocator<double>>>>;
+
 namespace o2
 {
 namespace utils
@@ -396,10 +399,10 @@ std::vector<double> fitBoostHistoWithGaus(boost::histogram::histogram<axes...>& 
 }
 
 /// \brief Convert a 1D root histogram to a Boost histogram
-boostHisto1d boosthistoFromRoot_1D(TH1D* inHist1D);
+boostHisto1d_VarAxis boosthistoFromRoot_1D(TH1D* inHist1D);
 
 /// \brief Convert a 2D root histogram to a Boost histogram
-boostHisto2d boostHistoFromRoot_2D(TH2D* inHist2D);
+boostHisto2d_VarAxis boostHistoFromRoot_2D(TH2D* inHist2D);
 
 /// \brief Convert a 2D boost histogram to a root histogram
 template <class BoostHist>

--- a/Common/Utils/src/BoostHistogramUtils.cxx
+++ b/Common/Utils/src/BoostHistogramUtils.cxx
@@ -19,14 +19,15 @@ namespace o2
 namespace utils
 {
 
-boostHisto1d boosthistoFromRoot_1D(TH1D* inHist1D)
+boostHisto1d_VarAxis boosthistoFromRoot_1D(TH1D* inHist1D)
 {
   // first setup the proper boost histogram
   int nBins = inHist1D->GetNbinsX();
-  int xMin = inHist1D->GetXaxis()->GetXmin();
-  int xMax = inHist1D->GetXaxis()->GetXmax();
-  const char* title = inHist1D->GetXaxis()->GetTitle();
-  auto mHisto = boost::histogram::make_histogram(boost::histogram::axis::regular<>(nBins, xMin, xMax, title));
+  std::vector<double> binEdges;
+  for (int i = 0; i < nBins + 1; i++) {
+    binEdges.push_back(inHist1D->GetBinLowEdge(i + 1));
+  }
+  boostHisto1d_VarAxis mHisto = boost::histogram::make_histogram(boost::histogram::axis::variable<>(binEdges));
 
   // trasfer the acutal values
   for (Int_t x = 1; x < nBins + 1; x++) {
@@ -35,19 +36,23 @@ boostHisto1d boosthistoFromRoot_1D(TH1D* inHist1D)
   return mHisto;
 }
 
-boostHisto2d boostHistoFromRoot_2D(TH2D* inHist2D)
+boostHisto2d_VarAxis boostHistoFromRoot_2D(TH2D* inHist2D)
 {
-  // first setup the proper boost histogram
-  int nBinsX = inHist2D->GetNbinsX();
-  int xMin = inHist2D->GetXaxis()->GetXmin();
-  int xMax = inHist2D->GetXaxis()->GetXmax();
-  const char* xTitle = inHist2D->GetXaxis()->GetTitle();
-  int nBinsY = inHist2D->GetNbinsY();
-  int yMin = inHist2D->GetYaxis()->GetXmin();
-  int yMax = inHist2D->GetYaxis()->GetXmax();
-  const char* yTitle = inHist2D->GetYaxis()->GetTitle();
-  auto mHisto = boost::histogram::make_histogram(boost::histogram::axis::regular<>(nBinsX, xMin, xMax, xTitle), boost::histogram::axis::regular<>(nBinsY, yMin,
-                                                                                                                                                  yMax, yTitle));
+  // Get Xaxis binning
+  const int nBinsX = inHist2D->GetNbinsX();
+  std::vector<double> binEdgesX;
+  for (int i = 0; i < nBinsX + 1; i++) {
+    binEdgesX.push_back(inHist2D->GetXaxis()->GetBinLowEdge(i + 1));
+  }
+  // Get Yaxis binning
+  const int nBinsY = inHist2D->GetNbinsY();
+  std::vector<double> binEdgesY;
+  for (int i = 0; i < nBinsY + 1; i++) {
+    binEdgesY.push_back(inHist2D->GetYaxis()->GetBinLowEdge(i + 1));
+  }
+
+  boostHisto2d_VarAxis mHisto = boost::histogram::make_histogram(boost::histogram::axis::variable<>(binEdgesX), boost::histogram::axis::variable<>(binEdgesY));
+
   // trasfer the acutal values
   for (Int_t x = 1; x < nBinsX + 1; x++) {
     for (Int_t y = 1; y < nBinsY + 1; y++) {

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibExtractor.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibExtractor.h
@@ -104,6 +104,7 @@ class EMCALCalibExtractor
   /// \param hist -- 2d boost histogram: cell-time vs. cell-ID
   /// \param minTime -- min. time considered for fit
   /// \param maxTime -- max. time considered for fit
+  /// \param restrictFitRangeToMax -- restrict the fit range to the maximum entry in the histogram in the range +-restrictFitRangeToMax (default: 25ns)
   template <typename... axes>
   o2::emcal::TimeCalibrationParams calibrateTime(boost::histogram::histogram<axes...>& hist, double minTime = 0, double maxTime = 1000, double restrictFitRangeToMax = 25)
   {
@@ -127,9 +128,11 @@ class EMCALCalibExtractor
 
     for (unsigned int i = 0; i < mNcells; ++i) {
       // project boost histogram to 1d just for 1 cell
-      auto boostHist1d = o2::utils::ProjectBoostHistoXFast(histReduced, i, i + 1);
+      const int indexLow = histReduced.axis(1).index(i);
+      const int indexHigh = histReduced.axis(1).index(i + 1);
+      auto boostHist1d = o2::utils::ProjectBoostHistoXFast(histReduced, indexLow, indexHigh);
 
-      LOG(debug) << "calibrate cell " << i;
+      LOG(debug) << "calibrate cell time " << i << " of " << mNcells;
       // Restrict fit range to maximum +- restrictFitRangeToMax
       if (restrictFitRangeToMax > 0) {
         int maxElementIndex = std::max_element(boostHist1d.begin(), boostHist1d.end()) - boostHist1d.begin() - 1;

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibParams.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibParams.h
@@ -29,9 +29,13 @@ namespace emcal
 // class containing the parameters to trigger the calibrations
 struct EMCALCalibParams : public o2::conf::ConfigurableParamHelper<EMCALCalibParams> {
 
-  unsigned int minNEvents = 1e6;
-  unsigned int minNEntries = 1e5;
-  bool useNEventsForCalib = true;
+  unsigned int minNEvents = 1e6;              ///< minimum number of events to trigger the calibration
+  unsigned int minNEntries = 1e5;             ///< minimum number of entries to trigger the calibration
+  bool useNEventsForCalib = true;             ///< use the minimum number of events to trigger the calibration
+  std::string calibType = "time";             ///< type of calibration to run
+  std::string localRootFilePath = "";         ///< path to local root file in order to store the calibration histograms (off by default, only to be used for testing)
+  bool useScaledHistoForBadChannelMap = true; ///< use the scaled histogram for the bad channel map
+  bool enableTestMode = false;                ///< enable test mode for calibration
 
   O2ParamDef(EMCALCalibParams, "EMCALCalibParams");
 };

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelCalibrator.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelCalibrator.h
@@ -74,10 +74,6 @@ class EMCALChannelCalibrator : public o2::calibration::TimeSlotCalibration<o2::e
   void setIsTest(bool isTest) { mTest = isTest; }
   bool isTest() const { return mTest; }
 
-  ///\brief Set path to local root file for storage of calibration histograms
-  void setLocalStorePath(const std::string path) { namePathStoreLocal = path; }
-  std::string getLocalStorePath() const { return namePathStoreLocal; }
-
   const CcdbObjectInfoVector& getInfoVector() const { return mInfoVector; }
   const std::vector<DataOutput>& getOutputVector() const { return mCalibObjectVector; }
 
@@ -91,7 +87,6 @@ class EMCALChannelCalibrator : public o2::calibration::TimeSlotCalibration<o2::e
   float mRange = 0.;  ///< range of the histogram for passing
   bool mTest = false; ///< flag to be used when running in test mode: it simplify the processing (e.g. does not go through all channels)
   std::shared_ptr<EMCALCalibExtractor> mCalibrator;
-  std::string namePathStoreLocal;
 
   // output
   CcdbObjectInfoVector mInfoVector; // vector of CCDB Infos , each element is filled with the CCDB description of the accompanying TimeSlewing object
@@ -146,8 +141,8 @@ void EMCALChannelCalibrator<DataInput, DataOutput, HistContainer>::finalizeSlot(
     mInfoVector.emplace_back(CalibDB::getCDBPathTimeCalibrationParams(), clName, flName, md, slot.getStartTimeMS(), o2::ccdb::CcdbObjectInfo::INFINITE_TIMESTAMP);
     mCalibObjectVector.push_back(tcd);
 
-    if (namePathStoreLocal.find(".root") != std::string::npos) {
-      TFile fLocalStorage(namePathStoreLocal.c_str(), "update");
+    if ((EMCALCalibParams::Instance().localRootFilePath).find(".root") != std::string::npos) {
+      TFile fLocalStorage((EMCALCalibParams::Instance().localRootFilePath).c_str(), "update");
       fLocalStorage.cd();
       TH1F* histTCparams = (TH1F*)tcd.getHistogramRepresentation(false);
       std::string nameTCHist = "TCParams_" + std::to_string(slot.getStartTimeMS());

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALTimeCalibData.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALTimeCalibData.h
@@ -54,7 +54,7 @@ class EMCALTimeCalibData
 {
  public:
   using Cells = o2::emcal::Cell;
-  using boostHisto = boost::histogram::histogram<std::tuple<boost::histogram::axis::regular<double, boost::use_default, boost::use_default, boost::use_default>, boost::histogram::axis::integer<>>, boost::histogram::unlimited_storage<std::allocator<char>>>;
+  using boostHisto = boost::histogram::histogram<std::tuple<boost::histogram::axis::regular<double, boost::use_default, boost::use_default, boost::use_default>, boost::histogram::axis::regular<>>, boost::histogram::unlimited_storage<std::allocator<char>>>;
 
   o2::emcal::Geometry* mGeometry = o2::emcal::Geometry::GetInstanceFromRunNumber(300000);
   int NCELLS = mGeometry->GetNCells();
@@ -62,7 +62,7 @@ class EMCALTimeCalibData
   EMCALTimeCalibData(const TimeCalibInitParams& par)
   {
     // boost histogram with amplitude vs. cell ID, specify the range and binning of the amplitude axis
-    mTimeHisto = boost::histogram::make_histogram(boost::histogram::axis::regular<>(par.mTimeBins, par.mTimeRange.at(0), par.mTimeRange.at(1), "t (ns)"), boost::histogram::axis::integer<>(0, NCELLS, "CELL ID"));
+    mTimeHisto = boost::histogram::make_histogram(boost::histogram::axis::regular<>(par.mTimeBins, par.mTimeRange.at(0), par.mTimeRange.at(1), "t (ns)"), boost::histogram::axis::regular<>(NCELLS, -0.5, NCELLS - 0.5, "CELL ID"));
     LOG(debug) << "initialize time histogram with " << NCELLS << " cells";
   }
 

--- a/Detectors/EMCAL/calibration/testWorkflow/emc-channel-calib-workflow.cxx
+++ b/Detectors/EMCAL/calibration/testWorkflow/emc-channel-calib-workflow.cxx
@@ -35,9 +35,8 @@ using namespace o2::emcal;
 // including Framework/runDataProcessing
 void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
-  std::vector<ConfigParamSpec> options{{"calibMode", VariantType::String, "badcell", {"specify time for time calib or badcell for bad channel calib"}},
-                                       {"localRootFilePath", VariantType::String, "", {"path to local root file for storage of calibration params"}},
-                                       {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
+  std::vector<ConfigParamSpec> options{
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
 
   std::swap(workflowOptions, options);
 }
@@ -46,11 +45,8 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  std::string strCalibType = cfgc.options().get<std::string>("calibMode");
-  std::string strFilePath = cfgc.options().get<std::string>("localRootFilePath");
-
   WorkflowSpec specs;
-  specs.emplace_back(getEMCALChannelCalibDeviceSpec(strCalibType, strFilePath));
+  specs.emplace_back(getEMCALChannelCalibDeviceSpec());
 
   o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
 


### PR DESCRIPTION
- Switched conversion from ROOT to boost histograms to variable binned
boost histograms. This is necessary for the bad channel calibration as
the energy is not binned equidistant
- Moved all settings/parameters for the EMCal bad channel and time
calibration to dedicated parameter class