### PR TITLE
--disable-tracking option for o2-its(mft)-reco-workflow

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/RecoWorkflow.cxx
@@ -44,15 +44,18 @@ framework::WorkflowSpec getWorkflow(bool useMC, bool useCAtracker, const std::st
   }
   if (!disableRootOutput) {
     specs.emplace_back(o2::its::getClusterWriterSpec(useMC));
-    specs.emplace_back(o2::its::getTrackWriterSpec(useMC));
-    specs.emplace_back(o2::globaltracking::getIRFrameWriterSpec("irfr:ITS/IRFRAMES/0", "o2_its_irframe.root", "irframe-writer-its"));
   }
-  if (useCAtracker) {
-    specs.emplace_back(o2::its::getTrackerSpec(useMC, trmode, dtype));
-  } else {
-    specs.emplace_back(o2::its::getCookedTrackerSpec(useMC, trmode));
+  if (!trmode.empty()) {
+    if (useCAtracker) {
+      specs.emplace_back(o2::its::getTrackerSpec(useMC, trmode, dtype));
+    } else {
+      specs.emplace_back(o2::its::getCookedTrackerSpec(useMC, trmode));
+    }
+    if (!disableRootOutput) {
+      specs.emplace_back(o2::its::getTrackWriterSpec(useMC));
+      specs.emplace_back(o2::globaltracking::getIRFrameWriterSpec("irfr:ITS/IRFRAMES/0", "o2_its_irframe.root", "irframe-writer-its"));
+    }
   }
-
   if (eencode) {
     specs.emplace_back(o2::itsmft::getEntropyEncoderSpec("ITS"));
   }

--- a/Detectors/ITSMFT/ITS/workflow/src/its-reco-workflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/its-reco-workflow.cxx
@@ -47,6 +47,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation even if available"}},
     {"trackerCA", o2::framework::VariantType::Bool, false, {"use trackerCA (default: trackerCM)"}},
     {"tracking-mode", o2::framework::VariantType::String, "sync", {"sync,async,cosmics"}},
+    {"disable-tracking", o2::framework::VariantType::Bool, false, {"disable tracking step"}},
     {"entropy-encoding", o2::framework::VariantType::Bool, false, {"produce entropy encoded data"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}},
     {"gpuDevice", o2::framework::VariantType::Int, 1, {"use gpu device: CPU=1,CUDA=2,HIP=3 (default: CPU)"}}};
@@ -70,6 +71,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   auto extClusters = configcontext.options().get<bool>("clusters-from-upstream");
   auto disableRootOutput = configcontext.options().get<bool>("disable-root-output");
   auto eencode = configcontext.options().get<bool>("entropy-encoding");
+  if (configcontext.options().get<bool>("disable-tracking")) {
+    trmode = "";
+  }
 
   std::transform(trmode.begin(), trmode.end(), trmode.begin(), [](unsigned char c) { return std::tolower(c); });
 

--- a/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/RecoWorkflow.h
+++ b/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/RecoWorkflow.h
@@ -23,7 +23,7 @@ namespace mft
 
 namespace reco_workflow
 {
-framework::WorkflowSpec getWorkflow(bool useMC, bool upstreamDigits, bool upstreamClusters, bool disableRootOutput, bool runAssessment, bool processGen);
+framework::WorkflowSpec getWorkflow(bool useMC, bool upstreamDigits, bool upstreamClusters, bool disableRootOutput, bool runAssessment, bool processGen, bool runTracking);
 }
 
 } // namespace mft

--- a/Detectors/ITSMFT/MFT/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/RecoWorkflow.cxx
@@ -28,7 +28,7 @@ namespace mft
 namespace reco_workflow
 {
 
-framework::WorkflowSpec getWorkflow(bool useMC, bool upstreamDigits, bool upstreamClusters, bool disableRootOutput, bool runAssessment, bool processGen)
+framework::WorkflowSpec getWorkflow(bool useMC, bool upstreamDigits, bool upstreamClusters, bool disableRootOutput, bool runAssessment, bool processGen, bool runTracking)
 {
   framework::WorkflowSpec specs;
 
@@ -41,14 +41,15 @@ framework::WorkflowSpec getWorkflow(bool useMC, bool upstreamDigits, bool upstre
   if (!disableRootOutput) {
     specs.emplace_back(o2::mft::getClusterWriterSpec(useMC));
   }
-  specs.emplace_back(o2::mft::getTrackerSpec(useMC));
-  if (!disableRootOutput) {
-    specs.emplace_back(o2::mft::getTrackWriterSpec(useMC));
+  if (runTracking) {
+    specs.emplace_back(o2::mft::getTrackerSpec(useMC));
+    if (!disableRootOutput) {
+      specs.emplace_back(o2::mft::getTrackWriterSpec(useMC));
+    }
+    if (runAssessment) {
+      specs.emplace_back(o2::mft::getMFTAssessmentSpec(useMC, processGen));
+    }
   }
-  if (runAssessment) {
-    specs.emplace_back(o2::mft::getMFTAssessmentSpec(useMC, processGen));
-  }
-
   return specs;
 }
 

--- a/Detectors/ITSMFT/MFT/workflow/src/mft-reco-workflow.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/mft-reco-workflow.cxx
@@ -37,6 +37,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"clusters-from-upstream", o2::framework::VariantType::Bool, false, {"clusters will be provided from upstream, skip clusterizer"}},
     {"disable-root-output", o2::framework::VariantType::Bool, false, {"do not write output root files"}},
     {"disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation even if available"}},
+    {"disable-tracking", o2::framework::VariantType::Bool, false, {"disable tracking step"}},
     {"run-assessment", o2::framework::VariantType::Bool, false, {"run MFT assessment workflow"}},
     {"disable-process-gen", o2::framework::VariantType::Bool, false, {"disable processing of all generated tracks (depends on --run-assessment)"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
@@ -59,8 +60,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   auto disableRootOutput = configcontext.options().get<bool>("disable-root-output");
   auto runAssessment = configcontext.options().get<bool>("run-assessment");
   auto processGen = !configcontext.options().get<bool>("disable-process-gen");
+  auto runTracking = !configcontext.options().get<bool>("disable-tracking");
 
-  auto wf = o2::mft::reco_workflow::getWorkflow(useMC, extDigits, extClusters, disableRootOutput, runAssessment, processGen);
+  auto wf = o2::mft::reco_workflow::getWorkflow(useMC, extDigits, extClusters, disableRootOutput, runAssessment, processGen, runTracking);
 
   // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
   o2::raw::HBFUtilsInitializer hbfIni(configcontext, wf);


### PR DESCRIPTION
With this option the tracking (and tracking-dependent) processes will not be connected, only clustering will be activated