### PR TITLE
DPL Analysis: Event mixing: Add a generic getter to dynamic columns, support dynamic in mixing

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1029,12 +1029,7 @@ class Table
     {
       using decayed = std::decay_t<CD>;
       static_assert(is_dynamic_t<decayed>(), "Requested column is not a dynamic column");
-      using all_columns = typename RowViewCore<IP, C...>::all_columns;
-      if constexpr (framework::has_type_v<decayed, all_columns>) {
-        return static_cast<decayed>(*this).template getDynamicValue<CDArgs...>();
-      } else {
-        return static_cast<int32_t>(-1);
-      }
+      return static_cast<decayed>(*this).template getDynamicValue<CDArgs...>();
     }
 
     using IP::size;
@@ -2021,7 +2016,7 @@ void notBoundTable(const char* tableName);
       return boundGetter(std::make_index_sequence<std::tuple_size_v<decltype(boundIterators)>>{}, freeArgs...);            \
     }                                                                                                                      \
     template <typename... FreeArgs>                                                                                        \
-    type _getDynamicValue_(FreeArgs... freeArgs) const                                                                     \
+    type getDynamicValue(FreeArgs... freeArgs) const                                                                       \
     {                                                                                                                      \
       return boundGetter(std::make_index_sequence<std::tuple_size_v<decltype(boundIterators)>>{}, freeArgs...);            \
     }                                                                                                                      \

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1024,6 +1024,20 @@ class Table
       }
     }
 
+    template <typename TI>
+    auto getDynamicColumn() const
+    {
+      using decayed = std::decay_t<TI>;
+      if constexpr (framework::has_type_v<decayed, bindings_pack_t>) {
+        constexpr auto idx = framework::has_type_at_v<decayed>(bindings_pack_t{});
+        return framework::pack_element_t<idx, external_index_columns_t>::getId();
+      } else if constexpr (std::is_same_v<decayed, Parent>) {
+        return this->globalIndex();
+      } else {
+        return static_cast<int32_t>(-1);
+      }
+    }
+
     using IP::size;
 
     using RowViewCore<IP, C...>::operator++;

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1408,6 +1408,63 @@ constexpr bool is_binding_compatible_v()
 }
 
 void notBoundTable(const char* tableName);
+
+namespace row_helpers
+{
+template <typename... Cs>
+std::array<arrow::ChunkedArray*, sizeof...(Cs)> getArrowColumns(arrow::Table* table, framework::pack<Cs...>)
+{
+  static_assert(std::conjunction_v<typename Cs::persistent...>, "BinningPolicy: only persistent columns accepted (not dynamic and not index ones");
+  return std::array<arrow::ChunkedArray*, sizeof...(Cs)>{o2::soa::getIndexFromLabel(table, Cs::columnLabel())...};
+}
+
+template <typename... Cs>
+std::array<std::shared_ptr<arrow::Array>, sizeof...(Cs)> getChunks(arrow::Table* table, framework::pack<Cs...>, uint64_t ci)
+{
+  static_assert(std::conjunction_v<typename Cs::persistent...>, "BinningPolicy: only persistent columns accepted (not dynamic and not index ones");
+  return std::array<std::shared_ptr<arrow::Array>, sizeof...(Cs)>{o2::soa::getIndexFromLabel(table, Cs::columnLabel())->chunk(ci)...};
+}
+
+template <typename C>
+typename C::type getSingleRowPersistentData(arrow::Table* table, uint64_t ci, uint64_t ai)
+{
+  return std::static_pointer_cast<o2::soa::arrow_array_for_t<typename C::type>>(o2::soa::getIndexFromLabel(table, C::columnLabel())->chunk(ci))->raw_values()[ai];
+}
+
+template <typename T, typename C>
+typename C::type getSingleRowDynamicData(T& rowIterator, uint64_t globalIndex)
+{
+  rowIterator.setCursor(globalIndex);
+  return rowIterator.template getDynamicColumn<C>();
+}
+
+template <typename T, typename C>
+typename C::type getSingleRowIndexData(T& rowIterator, uint64_t globalIndex)
+{
+  rowIterator.setCursor(globalIndex);
+  return rowIterator.template getId<C>();
+}
+
+template <typename T, typename C>
+typename C::type getSingleRowData(arrow::Table* table, T& rowIterator, uint64_t ci, uint64_t ai, uint64_t globalIndex)
+{
+  using decayed = std::decay_t<C>;
+  if constexpr (decayed::persistent::value) {
+    return getSingleRowPersistentData<C>(table, ci, ai);
+  } else if constexpr (o2::soa::is_dynamic_t<decayed>()) {
+    return getSingleRowDynamicData<T, C>(rowIterator, globalIndex);
+  } else if constexpr (o2::soa::is_index_column_v<decayed>) {
+    return getSingleRowIndexData<T, C>(rowIterator, globalIndex);
+  }
+}
+
+template <typename T, typename... Cs>
+std::tuple<typename Cs::type...> getRowData(arrow::Table* table, T rowIterator, uint64_t ci, uint64_t ai, uint64_t globalIndex)
+{
+  return std::make_tuple(getSingleRowData<T, Cs>(table, rowIterator, ci, ai, globalIndex)...);
+}
+} // namespace row_helpers
+
 } // namespace o2::soa
 
 #define DECLARE_SOA_STORE()                                                                         \

--- a/Framework/Core/include/Framework/ASoAHelpers.h
+++ b/Framework/Core/include/Framework/ASoAHelpers.h
@@ -179,7 +179,6 @@ std::vector<BinningIndex> doGroupTable(const T& table, const BP<Cs...>& binningP
     }
   }
 
-  uint64_t globalIndex = 0;
   for (uint64_t ci = 0; ci < chunksCount; ++ci) {
     auto chunks = o2::framework::binning_helpers::getChunks(arrowTable, persistentColumns, ci);
     auto chunkLength = std::get<0>(chunks)->length();
@@ -199,12 +198,11 @@ std::vector<BinningIndex> doGroupTable(const T& table, const BP<Cs...>& binningP
     uint64_t ai = 0;
     while (ai < chunkLength) {
       if constexpr (soa::is_soa_filtered_t<T>::value) {
-        globalIndex += selectedRows[ind] - selInd;
         ai += selectedRows[ind] - selInd;
         selInd = selectedRows[ind];
       }
 
-      auto rowData = o2::framework::binning_helpers::getRowData<T, Cs...>(arrowTable, rowIterator, ci, ai, globalIndex);
+      auto rowData = o2::framework::binning_helpers::getRowData<decltype(rowIterator), Cs...>(arrowTable, rowIterator, ci, ai, ind);
 
       int val = binningPolicy.getBin(rowData);
       if (val != outsider) {
@@ -217,7 +215,6 @@ std::vector<BinningIndex> doGroupTable(const T& table, const BP<Cs...>& binningP
           break;
         }
       } else {
-        globalIndex++;
         ai++;
       }
     }

--- a/Framework/Core/include/Framework/ASoAHelpers.h
+++ b/Framework/Core/include/Framework/ASoAHelpers.h
@@ -171,7 +171,7 @@ std::vector<BinningIndex> doGroupTable(const T& table, const BP<Cs...>& binningP
 
   auto persistentColumns = typename BP<Cs...>::persistent_columns_t{};
   constexpr auto persistentColumnsCount = pack_size(persistentColumns);
-  auto arrowColumns = o2::framework::binning_helpers::getArrowColumns(arrowTable, persistentColumns);
+  auto arrowColumns = o2::soa::row_helpers::getArrowColumns(arrowTable, persistentColumns);
   auto chunksCount = arrowColumns[0]->num_chunks();
   for (int i = 1; i < persistentColumnsCount; i++) {
     if (arrowColumns[i]->num_chunks() != chunksCount) {
@@ -180,7 +180,7 @@ std::vector<BinningIndex> doGroupTable(const T& table, const BP<Cs...>& binningP
   }
 
   for (uint64_t ci = 0; ci < chunksCount; ++ci) {
-    auto chunks = o2::framework::binning_helpers::getChunks(arrowTable, persistentColumns, ci);
+    auto chunks = o2::soa::row_helpers::getChunks(arrowTable, persistentColumns, ci);
     auto chunkLength = std::get<0>(chunks)->length();
     for_<persistentColumnsCount - 1>([&chunks, &chunkLength](auto i) {
       if (std::get<i.value + 1>(chunks)->length() != chunkLength) {
@@ -202,7 +202,7 @@ std::vector<BinningIndex> doGroupTable(const T& table, const BP<Cs...>& binningP
         selInd = selectedRows[ind];
       }
 
-      auto rowData = o2::framework::binning_helpers::getRowData<decltype(rowIterator), Cs...>(arrowTable, rowIterator, ci, ai, ind);
+      auto rowData = o2::soa::row_helpers::getRowData<decltype(rowIterator), Cs...>(arrowTable, rowIterator, ci, ai, ind);
 
       int val = binningPolicy.getBin(rowData);
       if (val != outsider) {

--- a/Framework/Core/include/Framework/BinningPolicy.h
+++ b/Framework/Core/include/Framework/BinningPolicy.h
@@ -186,9 +186,7 @@ struct BinningPolicy {
     return getBinAt(i, j, k);
   }
 
-  using all_columns = pack<C, Cs...>;
   using persistent_columns_t = framework::selected_pack<o2::soa::is_persistent_t, C, Cs...>;
-  // pack<C, Cs...> getColumns() const { return pack<C, Cs...>{}; }
 
  private:
   // We substract 1 to account for VARIABLE_WIDTH in the bins vector
@@ -239,7 +237,6 @@ struct NoBinningPolicy {
   }
 
   using persistent_columns_t = framework::selected_pack<o2::soa::is_persistent_t, C>;
-  // pack<C> getColumns() const { return pack<C>{}; }
 };
 
 } // namespace o2::framework


### PR DESCRIPTION
Ciao @ktf, @jgrosseo, @aalkin 

the iteration on underlying arrow array works only with persistent columns, so the users could not use, e.g., multiplicity for event mixing.

I added also a bit of support for index columns in the binning policy, though I am not sure we would ever use index columns in making bins for block combinations / mixing...?