### PR TITLE
Options and fixes for use of CCDB in LHCphase and channel calib 

### DIFF
--- a/CCDB/include/CCDB/CcdbObjectInfo.h
+++ b/CCDB/include/CCDB/CcdbObjectInfo.h
@@ -32,6 +32,7 @@ class CcdbObjectInfo
   static constexpr long MONTH = 30 * DAY;
   static constexpr long YEAR = 364 * DAY;
   static constexpr long INFINITE_TIMESTAMP = 9999999999999;
+  static constexpr long INFINITE_TIMESTAMP_SECONDS = 2000000000; // not really inifinity, but close to std::numeric_limits<int>::max() till 18.05.2033
 
   CcdbObjectInfo() = default;
   CcdbObjectInfo(std::string path, std::string objType, std::string flName,

--- a/DataFormats/Detectors/TOF/include/DataFormatsTOF/CalibLHCphaseTOF.h
+++ b/DataFormats/Detectors/TOF/include/DataFormatsTOF/CalibLHCphaseTOF.h
@@ -45,7 +45,7 @@ class CalibLHCphaseTOF
 
  private:
   // LHCphase calibration
-  std::vector<std::pair<int, float>> mLHCphase; ///< <timestamp,LHCphase> from which the LHCphase measurement is valid
+  std::vector<std::pair<int, float>> mLHCphase; ///< <timestamp,LHCphase> from which the LHCphase measurement is valid; timestamp in seconds
 
   long mStartValidity = 0; ///< start validity of the object when put in CCDB
   long mEndValidity = 0;   ///< end validity of the object when put in CCDB

--- a/DataFormats/Detectors/TOF/include/DataFormatsTOF/CalibLHCphaseTOF.h
+++ b/DataFormats/Detectors/TOF/include/DataFormatsTOF/CalibLHCphaseTOF.h
@@ -37,11 +37,20 @@ class CalibLHCphaseTOF
 
   CalibLHCphaseTOF& operator+=(const CalibLHCphaseTOF& other);
 
+  long getStartValidity() const { return mStartValidity; }
+  long getEndValidity() const { return mEndValidity; }
+
+  void setStartValidity(long validity) { mStartValidity = validity; }
+  void setEndValidity(long validity) { mEndValidity = validity; }
+
  private:
   // LHCphase calibration
   std::vector<std::pair<int, float>> mLHCphase; ///< <timestamp,LHCphase> from which the LHCphase measurement is valid
 
-  ClassDefNV(CalibLHCphaseTOF, 1);
+  long mStartValidity = 0; ///< start validity of the object when put in CCDB
+  long mEndValidity = 0;   ///< end validity of the object when put in CCDB
+
+  ClassDefNV(CalibLHCphaseTOF, 2);
 };
 } // namespace dataformats
 } // namespace o2

--- a/DataFormats/Detectors/TOF/include/DataFormatsTOF/CalibTimeSlewingParamTOF.h
+++ b/DataFormats/Detectors/TOF/include/DataFormatsTOF/CalibTimeSlewingParamTOF.h
@@ -86,6 +86,12 @@ class CalibTimeSlewingParamTOF
   CalibTimeSlewingParamTOF& operator+=(const CalibTimeSlewingParamTOF& other);
   void bind();
 
+  long getStartValidity() const { return mStartValidity; }
+  long getEndValidity() const { return mEndValidity; }
+
+  void setStartValidity(long validity) { mStartValidity = validity; }
+  void setEndValidity(long validity) { mEndValidity = validity; }
+
  private:
   std::array<int, NCHANNELXSECTOR> mChannelStartSec0;
   std::array<float, NCHANNELXSECTOR> mGlobalOffsetSec0;
@@ -202,7 +208,10 @@ class CalibTimeSlewingParamTOF
   std::array<float, NCHANNELXSECTOR>* mFractionUnderPeak[NSECTORS] = {&mFractionUnderPeakSec0, &mFractionUnderPeakSec1, &mFractionUnderPeakSec2, &mFractionUnderPeakSec3, &mFractionUnderPeakSec4, &mFractionUnderPeakSec5, &mFractionUnderPeakSec6, &mFractionUnderPeakSec7, &mFractionUnderPeakSec8, &mFractionUnderPeakSec9, &mFractionUnderPeakSec10, &mFractionUnderPeakSec11, &mFractionUnderPeakSec12, &mFractionUnderPeakSec13, &mFractionUnderPeakSec14, &mFractionUnderPeakSec15, &mFractionUnderPeakSec16, &mFractionUnderPeakSec17}; //! array with the fraction of entries below the peak
   std::array<float, NCHANNELXSECTOR>* mSigmaPeak[NSECTORS] = {&mSigmaPeakSec0, &mSigmaPeakSec1, &mSigmaPeakSec2, &mSigmaPeakSec3, &mSigmaPeakSec4, &mSigmaPeakSec5, &mSigmaPeakSec6, &mSigmaPeakSec7, &mSigmaPeakSec8, &mSigmaPeakSec9, &mSigmaPeakSec10, &mSigmaPeakSec11, &mSigmaPeakSec12, &mSigmaPeakSec13, &mSigmaPeakSec14, &mSigmaPeakSec15, &mSigmaPeakSec16, &mSigmaPeakSec17};                                                                                                                                                         //! array with the sigma of the peak
 
-  ClassDefNV(CalibTimeSlewingParamTOF, 3); // class for TOF time slewing params
+  long mStartValidity = 0; ///< start validity of the object when put in CCDB
+  long mEndValidity = 0;   ///< end validity of the object when put in CCDB
+
+  ClassDefNV(CalibTimeSlewingParamTOF, 4); // class for TOF time slewing params
 };
 } // namespace dataformats
 } // namespace o2

--- a/Detectors/TOF/base/include/TOFBase/CalibTOFapi.h
+++ b/Detectors/TOF/base/include/TOFBase/CalibTOFapi.h
@@ -81,8 +81,11 @@ class CalibTOFapi
 
   SlewParam* getSlewParam() { return mSlewParam; }
   SlewParam& getSlewParamObj() { return *mSlewParam; }
+  void setSlewParam(SlewParam* obj) { mSlewParam = obj; }
   LhcPhase* getLhcPhase() { return mLHCphase; }
+  void setLhcPhase(LhcPhase* obj) { mLHCphase = obj; }
   Diagnostic* getDiagnostic() { return mDiaFreq; }
+  void setDiagnostic(Diagnostic* obj) { mDiaFreq = obj; }
 
   int getNoisyThreshold() const { return mNoisyThreshold; }
   void setNoisyThreshold(int val) { mNoisyThreshold = val; }

--- a/Detectors/TOF/calibration/include/TOFCalibration/TOFChannelCalibrator.h
+++ b/Detectors/TOF/calibration/include/TOFCalibration/TOFChannelCalibrator.h
@@ -116,6 +116,8 @@ class TOFChannelData
   void doPerStrip(bool val = true) { mPerStrip = val; }
   void doSafeMode(bool val = true) { mSafeMode = val; }
 
+  void resetAndReRange(float range);
+
  private:
   float mRange = o2::tof::Geo::BC_TIME_INPS * 0.5;
   int mNBins = 1000;

--- a/Detectors/TOF/calibration/src/LHCClockCalibrator.cxx
+++ b/Detectors/TOF/calibration/src/LHCClockCalibrator.cxx
@@ -96,9 +96,6 @@ void LHCClockCalibrator::finalizeSlot(Slot& slot)
     LOG(error) << "Fit failed with result = " << fitres;
   }
 
-  // TODO: the timestamp is now given with the TF index, but it will have
-  // to become an absolute time. This is true both for the lhc phase object itself
-  // and the CCDB entry
   std::map<std::string, std::string> md;
   LHCphase l;
   l.addLHCphase(0, fitValues[1]);
@@ -106,9 +103,11 @@ void LHCClockCalibrator::finalizeSlot(Slot& slot)
   auto clName = o2::utils::MemFileHelper::getClassName(l);
   auto flName = o2::ccdb::CcdbApi::generateFileName(clName);
 
-  auto starting = slot.getStartTimeMS() - 10000; // start 10 seconds before
-  auto stopping = slot.getEndTimeMS() + 10000;   // stop 10 seconds after
+  auto starting = slot.getStartTimeMS();
+  auto stopping = slot.getEndTimeMS() + 5 * getSlotLength() + getMaxSlotsDelay();
   LOG(info) << "starting = " << starting << " - stopping = " << stopping << " -> phase = " << fitValues[1] << " ps";
+  l.setStartValidity(starting);
+  l.setEndValidity(stopping);
 
   mInfoVector.emplace_back("TOF/Calib/LHCphase", clName, flName, md, starting, stopping);
   mLHCphaseVector.emplace_back(l);

--- a/Detectors/TOF/calibration/src/LHCClockCalibrator.cxx
+++ b/Detectors/TOF/calibration/src/LHCClockCalibrator.cxx
@@ -99,7 +99,7 @@ void LHCClockCalibrator::finalizeSlot(Slot& slot)
   std::map<std::string, std::string> md;
   LHCphase l;
   l.addLHCphase(0, fitValues[1]);
-  l.addLHCphase(999999999, fitValues[1]);
+  l.addLHCphase(o2::ccdb::CcdbObjectInfo::INFINITE_TIMESTAMP_SECONDS, fitValues[1]);
   auto clName = o2::utils::MemFileHelper::getClassName(l);
   auto flName = o2::ccdb::CcdbApi::generateFileName(clName);
 

--- a/Detectors/TOF/calibration/src/TOFChannelCalibrator.cxx
+++ b/Detectors/TOF/calibration/src/TOFChannelCalibrator.cxx
@@ -413,7 +413,7 @@ void TOFChannelData::resetAndReRange(float range)
   mV2Bin = mNBins / (2 * mRange);
   for (int isect = 0; isect < 18; isect++) {
     mHisto[isect] = boost::histogram::make_histogram(boost::histogram::axis::regular<>(mNBins, -mRange, mRange, "t-texp"),
-						   boost::histogram::axis::integer<>(0, mNElsPerSector, "channel index in sector" + std::to_string(isect)));
+                                                     boost::histogram::axis::integer<>(0, mNElsPerSector, "channel index in sector" + std::to_string(isect)));
   }
   return;
 }

--- a/Detectors/TOF/calibration/src/TOFChannelCalibrator.cxx
+++ b/Detectors/TOF/calibration/src/TOFChannelCalibrator.cxx
@@ -403,6 +403,21 @@ float TOFChannelData::integral(int ch) const
   return mEntries.at(ch);
 }
 
+//_____________________________________________
+void TOFChannelData::resetAndReRange(float range)
+{
+  // empty the container and redefine the range
+
+  setRange(range);
+  std::fill(mEntries.begin(), mEntries.end(), 0);
+  mV2Bin = mNBins / (2 * mRange);
+  for (int isect = 0; isect < 18; isect++) {
+    mHisto[isect] = boost::histogram::make_histogram(boost::histogram::axis::regular<>(mNBins, -mRange, mRange, "t-texp"),
+						   boost::histogram::axis::integer<>(0, mNElsPerSector, "channel index in sector" + std::to_string(isect)));
+  }
+  return;
+}
+
 //-------------------------------------------------------------------
 // TOF Channel Calibrator
 //-------------------------------------------------------------------

--- a/Detectors/TOF/calibration/src/TOFChannelCalibrator.cxx
+++ b/Detectors/TOF/calibration/src/TOFChannelCalibrator.cxx
@@ -609,7 +609,11 @@ void TOFChannelCalibrator<T>::finalizeSlotWithCosmics(Slot& slot)
 
   auto clName = o2::utils::MemFileHelper::getClassName(ts);
   auto flName = o2::ccdb::CcdbApi::generateFileName(clName);
-  mInfoVector.emplace_back("TOF/Calib/ChannelCalib", clName, flName, md, slot.getTFStart(), o2::ccdb::CcdbObjectInfo::INFINITE_TIMESTAMP);
+  auto startValidity = slot.getStartTimeMS();
+  auto endValidity = o2::ccdb::CcdbObjectInfo::MONTH * 2;
+  ts.setStartValidity(startValidity);
+  ts.setEndValidity(endValidity);
+  mInfoVector.emplace_back("TOF/Calib/ChannelCalib", clName, flName, md, startValidity, endValidity);
   mTimeSlewingVector.emplace_back(ts);
 
 #ifdef DEBUGGING
@@ -727,7 +731,11 @@ void TOFChannelCalibrator<T>::finalizeSlotWithTracks(Slot& slot)
   }   // end loop over sectors
   auto clName = o2::utils::MemFileHelper::getClassName(ts);
   auto flName = o2::ccdb::CcdbApi::generateFileName(clName);
-  mInfoVector.emplace_back("TOF/Calib/ChannelCalib", clName, flName, md, slot.getTFStart(), o2::ccdb::CcdbObjectInfo::INFINITE_TIMESTAMP);
+  auto startValidity = slot.getStartTimeMS();
+  auto endValidity = o2::ccdb::CcdbObjectInfo::MONTH * 2;
+  ts.setStartValidity(startValidity);
+  ts.setEndValidity(endValidity);
+  mInfoVector.emplace_back("TOF/Calib/ChannelCalib", clName, flName, md, startValidity, endValidity);
   mTimeSlewingVector.emplace_back(ts);
 
 #ifdef DEBUGGING

--- a/Detectors/TOF/calibration/src/TOFDiagnosticCalibrator.cxx
+++ b/Detectors/TOF/calibration/src/TOFDiagnosticCalibrator.cxx
@@ -33,8 +33,6 @@ void TOFDiagnosticCalibrator::initOutput()
 //----------------------------------------------------------
 void TOFDiagnosticCalibrator::finalizeSlot(Slot& slot)
 {
-  static const double TFlength = 1E-3 * o2::raw::HBFUtils::Instance().getNOrbitsPerTF() * o2::constants::lhc::LHCOrbitMUS; // in ms
-
   Diagnostic* diag = slot.getContainer();
   LOG(info) << "Finalizing slot";
   diag->print();
@@ -46,10 +44,9 @@ void TOFDiagnosticCalibrator::finalizeSlot(Slot& slot)
   auto clName = o2::utils::MemFileHelper::getClassName(*diag);
   auto flName = o2::ccdb::CcdbApi::generateFileName(clName);
 
-  uint64_t starting = slot.getTFStart() * TFlength - 10000; // start 10 seconds before
-  uint64_t stopping = slot.getTFEnd() * TFlength + 10000;   // stop 10 seconds after
-  LOG(info) << "starting = " << starting * 1E-3 << " - stopping = " << stopping * 1E-3;
-  mccdbInfoVector.emplace_back("TOF/Calib/Diagnostic", clName, flName, md, starting, stopping);
+  uint64_t startingMS = slot.getStartTimeMS() - 10000; // start 10 seconds before
+  uint64_t stoppingMS = slot.getEndTimeMS() + 10000;   // stop 10 seconds after
+  mccdbInfoVector.emplace_back("TOF/Calib/Diagnostic", clName, flName, md, startingMS, stoppingMS);
   mDiagnosticVector.emplace_back(*diag);
 }
 

--- a/Detectors/TOF/calibration/testWorkflow/LHCClockCalibratorSpec.h
+++ b/Detectors/TOF/calibration/testWorkflow/LHCClockCalibratorSpec.h
@@ -23,10 +23,13 @@
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/ControlService.h"
 #include "Framework/WorkflowSpec.h"
+#include "Framework/CCDBParamSpec.h"
 #include "CCDB/CcdbApi.h"
 #include "CCDB/CcdbObjectInfo.h"
 #include "DetectorsRaw/HBFUtils.h"
 #include "DetectorsBase/GRPGeomHelper.h"
+
+#include <TSystem.h>
 
 using namespace o2::framework;
 
@@ -41,7 +44,7 @@ class LHCClockCalibDevice : public o2::framework::Task
   using LHCphase = o2::dataformats::CalibLHCphaseTOF;
 
  public:
-  LHCClockCalibDevice(std::shared_ptr<o2::base::GRPGeomRequest> req) : mCCDBRequest(req) {}
+  LHCClockCalibDevice(std::shared_ptr<o2::base::GRPGeomRequest> req, bool useCCDB, bool followCCDBUpdates) : mCCDBRequest(req), mUseCCDB(useCCDB), mFollowCCDBUpdates(followCCDBUpdates) {}
 
   void init(o2::framework::InitContext& ic) final
   {
@@ -54,22 +57,24 @@ class LHCClockCalibDevice : public o2::framework::Task
     mCalibrator->setSlotLength(slotL);
     mCalibrator->setMaxSlotsDelay(delay);
 
-    // calibration objects set to zero
-    mPhase.addLHCphase(0, 0);
-    mPhase.addLHCphase(2000000000, 0);
-
-    TFile* fsleewing = TFile::Open("localTimeSlewing.root");
-    if (fsleewing) {
-      TimeSlewing* ob = (TimeSlewing*)fsleewing->Get("ccdb_object");
-      mTimeSlewing = *ob;
-      return;
-    }
-
-    for (int ich = 0; ich < TimeSlewing::NCHANNELS; ich++) {
-      mTimeSlewing.addTimeSlewingInfo(ich, 0, 0);
-      int sector = ich / TimeSlewing::NCHANNELXSECTOR;
-      int channelInSector = ich % TimeSlewing::NCHANNELXSECTOR;
-      mTimeSlewing.setFractionUnderPeak(sector, channelInSector, 1);
+    if (!mUseCCDB) {
+      // calibration objects set to zero
+      mPhase.addLHCphase(0, 0);
+      mPhase.addLHCphase(2000000000, 0);
+      if (gSystem->AccessPathName("localTimeSlewing.root") == false) {
+        TFile* fsleewing = TFile::Open("localTimeSlewing.root");
+        if (fsleewing) {
+          TimeSlewing* ob = (TimeSlewing*)fsleewing->Get("ccdb_object");
+          mTimeSlewing = *ob;
+        }
+      } else {
+        for (int ich = 0; ich < TimeSlewing::NCHANNELS; ich++) {
+          mTimeSlewing.addTimeSlewingInfo(ich, 0, 0);
+          int sector = ich / TimeSlewing::NCHANNELXSECTOR;
+          int channelInSector = ich % TimeSlewing::NCHANNELXSECTOR;
+          mTimeSlewing.setFractionUnderPeak(sector, channelInSector, 1);
+        }
+      }
     }
   }
 
@@ -79,14 +84,42 @@ class LHCClockCalibDevice : public o2::framework::Task
     auto data = pc.inputs().get<gsl::span<o2::dataformats::CalibInfoTOF>>("input");
     o2::base::TFIDInfoHelper::fillTFIDInfo(pc, mCalibrator->getCurrentTFInfo());
 
-    if (!mcalibTOFapi) {
-      mcalibTOFapi = new o2::tof::CalibTOFapi(long(0), &mPhase, &mTimeSlewing); // TODO: should we replace long(0) with tfcounter defined at the beginning of the method? we need the timestamp of the TF
-      mCalibrator->setCalibTOFapi(mcalibTOFapi);
+    if (mUseCCDB) { // read calibration objects from ccdb with the CCDB fetcher
+      const auto lhcPhaseIn = pc.inputs().get<LHCphase*>("tofccdbLHCphase");
+      const auto channelCalibIn = pc.inputs().get<TimeSlewing*>("tofccdbChannelCalib");
+      if (!mcalibTOFapi) {
+        LHCphase* lhcPhase = new LHCphase(std::move(*lhcPhaseIn));
+        TimeSlewing* channelCalib = new TimeSlewing(std::move(*channelCalibIn));
+        mcalibTOFapi = new o2::tof::CalibTOFapi(long(0), lhcPhase, channelCalib);
+      } else {
+        // if the calib objects were updated, we need to update the mcalibTOFapi
+        if (mUpdateCCDB) {
+          delete mcalibTOFapi;
+          LHCphase* lhcPhase = new LHCphase(*lhcPhaseIn);
+          TimeSlewing* channelCalib = new TimeSlewing(*channelCalibIn);
+          mcalibTOFapi = new o2::tof::CalibTOFapi(long(0), lhcPhase, channelCalib);
+        }
+      }
     }
+
+    else { // we use "fake" initial calibrations
+      if (!mcalibTOFapi) {
+        mcalibTOFapi = new o2::tof::CalibTOFapi(long(0), &mPhase, &mTimeSlewing); // TODO: should we replace long(0) with tfcounter defined at the beginning of the method? we need the timestamp of the TF
+      }
+    }
+
+    mCalibrator->setCalibTOFapi(mcalibTOFapi);
     if (data.size() == 0) {
       return;
     }
-    mcalibTOFapi->setTimeStamp(data[0].getTimestamp());
+
+    if (mUseCCDB) { // setting the timestamp to get the LHCPhase correction; if we don't use CCDB, then it can stay to 0 as set when creating the calibTOFapi above
+      const auto tfOrbitFirst = DataRefUtils::getHeader<o2::header::DataHeader*>(pc.inputs().getFirstValid(true))->firstTForbit;
+      auto tv = pc.inputs().get<std::vector<Long64_t>*>("orbitreset");
+      const auto orbitReset = tv->front();
+      const long tPrec = orbitReset + tfOrbitFirst * o2::constants::lhc::LHCOrbitMUS; // microsecond-precise time stamp
+      mcalibTOFapi->setTimeStamp(tPrec);
+    }
 
     LOG(info) << "Processing TF " << mCalibrator->getCurrentTFInfo().tfCounter << " with " << data.size() << " tracks";
     mCalibrator->process(data);
@@ -98,6 +131,17 @@ class LHCClockCalibDevice : public o2::framework::Task
   void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final
   {
     o2::base::GRPGeomHelper::instance().finaliseCCDB(matcher, obj);
+    mUpdateCCDB = false;
+    if (mFollowCCDBUpdates) {
+      if (matcher == ConcreteDataMatcher("TOF", "LHCphaseCal", 0)) {
+        mUpdateCCDB = true;
+        return;
+      }
+      if (matcher == ConcreteDataMatcher("TOF", "ChannelCalibCal", 0)) {
+        mUpdateCCDB = true;
+        return;
+      }
+    }
   }
 
   void endOfStream(o2::framework::EndOfStreamContext& ec) final
@@ -113,6 +157,9 @@ class LHCClockCalibDevice : public o2::framework::Task
   TimeSlewing mTimeSlewing;
   std::unique_ptr<o2::tof::LHCClockCalibrator> mCalibrator;
   std::shared_ptr<o2::base::GRPGeomRequest> mCCDBRequest;
+  bool mUpdateCCDB = false;
+  bool mUseCCDB = true;
+  bool mFollowCCDBUpdates = false;
 
   //________________________________________________________________
   void sendOutput(DataAllocator& output)
@@ -143,7 +190,7 @@ class LHCClockCalibDevice : public o2::framework::Task
 namespace framework
 {
 
-DataProcessorSpec getLHCClockCalibDeviceSpec()
+DataProcessorSpec getLHCClockCalibDeviceSpec(bool useCCDB, bool followCCDBUpdates = false)
 {
   using device = o2::calibration::LHCClockCalibDevice;
   using clbUtils = o2::calibration::Utils;
@@ -155,6 +202,13 @@ DataProcessorSpec getLHCClockCalibDeviceSpec()
                                                                 false,                          // askMatLUT
                                                                 o2::base::GRPGeomRequest::None, // geometry
                                                                 inputs);
+
+  if (useCCDB) {
+    inputs.emplace_back("tofccdbLHCphase", "TOF", "LHCphaseCal", 0, Lifetime::Condition, ccdbParamSpec("TOF/Calib/LHCphase"));
+    inputs.emplace_back("tofccdbChannelCalib", "TOF", "ChannelCalibCal", 0, Lifetime::Condition, ccdbParamSpec("TOF/Calib/ChannelCalib"));
+    inputs.emplace_back("orbitReset", o2::header::gDataOriginCTP, "ORBITRESET", 0, Lifetime::Condition, ccdbParamSpec("CTP/Calib/OrbitReset"));
+  }
+
   std::vector<OutputSpec> outputs;
   outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "TOF_LHCphase"}, Lifetime::Sporadic);
   outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "TOF_LHCphase"}, Lifetime::Sporadic);
@@ -162,7 +216,7 @@ DataProcessorSpec getLHCClockCalibDeviceSpec()
     "calib-lhcclock-calibration",
     inputs,
     outputs,
-    AlgorithmSpec{adaptFromTask<device>(ccdbRequest)},
+    AlgorithmSpec{adaptFromTask<device>(ccdbRequest, useCCDB, followCCDBUpdates)},
     Options{
       {"tf-per-slot", VariantType::UInt32, 5u, {"number of TFs per calibration time slot"}},
       {"max-delay", VariantType::UInt32, 3u, {"number of slots in past to consider"}},

--- a/Detectors/TOF/calibration/testWorkflow/LHCClockCalibratorSpec.h
+++ b/Detectors/TOF/calibration/testWorkflow/LHCClockCalibratorSpec.h
@@ -60,7 +60,7 @@ class LHCClockCalibDevice : public o2::framework::Task
     if (!mUseCCDB) {
       // calibration objects set to zero
       mPhase.addLHCphase(0, 0);
-      mPhase.addLHCphase(2000000000, 0);
+      mPhase.addLHCphase(o2::ccdb::CcdbObjectInfo::INFINITE_TIMESTAMP_SECONDS, 0);
       if (gSystem->AccessPathName("localTimeSlewing.root") == false) {
         TFile* fsleewing = TFile::Open("localTimeSlewing.root");
         if (fsleewing) {
@@ -118,10 +118,7 @@ class LHCClockCalibDevice : public o2::framework::Task
 
     if (mUseCCDB) { // setting the timestamp to get the LHCPhase correction; if we don't use CCDB, then it can stay to 0 as set when creating the calibTOFapi above
       const auto tfOrbitFirst = DataRefUtils::getHeader<o2::header::DataHeader*>(pc.inputs().getFirstValid(true))->firstTForbit;
-      auto tv = pc.inputs().get<std::vector<Long64_t>*>("orbitResetTOF");
-      const auto orbitReset = tv->front();
-      const long tPrec = orbitReset + tfOrbitFirst * o2::constants::lhc::LHCOrbitMUS; // microsecond-precise time stamp
-      mcalibTOFapi->setTimeStamp(tPrec);
+      mcalibTOFapi->setTimeStamp(0.001 * (o2::base::GRPGeomHelper::instance().getOrbitResetTimeMS() + tfOrbitFirst * o2::constants::lhc::LHCOrbitMUS * 0.001)); // in seconds
     }
 
     LOG(info) << "Processing TF " << mCalibrator->getCurrentTFInfo().tfCounter << " with " << data.size() << " tracks";

--- a/Detectors/TOF/calibration/testWorkflow/TOFChannelCalibratorSpec.h
+++ b/Detectors/TOF/calibration/testWorkflow/TOFChannelCalibratorSpec.h
@@ -25,11 +25,14 @@
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/ControlService.h"
 #include "Framework/WorkflowSpec.h"
+#include "Framework/CCDBParamSpec.h"
 #include "CCDB/CcdbApi.h"
 #include "CCDB/CcdbObjectInfo.h"
 #include <limits>
 #include "TFile.h"
 #include "DetectorsBase/GRPGeomHelper.h"
+
+#include <TSystem.h>
 
 using namespace o2::framework;
 
@@ -46,7 +49,8 @@ class TOFChannelCalibDevice : public o2::framework::Task
   using LHCphase = o2::dataformats::CalibLHCphaseTOF;
 
  public:
-  explicit TOFChannelCalibDevice(std::shared_ptr<o2::base::GRPGeomRequest> req, bool useCCDB, bool attachChannelOffsetToLHCphase, bool isCosmics, bool perstrip = false, bool safe = false) : mCCDBRequest(req), mUseCCDB(useCCDB), mAttachToLHCphase(attachChannelOffsetToLHCphase), mCosmics(isCosmics), mDoPerStrip(perstrip), mSafeMode(safe) {}
+  explicit TOFChannelCalibDevice(std::shared_ptr<o2::base::GRPGeomRequest> req, bool useCCDB, bool followCCDBUpdates, bool attachChannelOffsetToLHCphase, bool isCosmics, bool perstrip = false, bool safe = false) : mCCDBRequest(req), mUseCCDB(useCCDB), mFollowCCDBUpdates(followCCDBUpdates), mAttachToLHCphase(attachChannelOffsetToLHCphase), mCosmics(isCosmics), mDoPerStrip(perstrip), mSafeMode(safe) {}
+
   void init(o2::framework::InitContext& ic) final
   {
     o2::base::GRPGeomHelper::instance().setRequest(mCCDBRequest);
@@ -86,18 +90,20 @@ class TOFChannelCalibDevice : public o2::framework::Task
     mPhase.addLHCphase(0, 0);
     mPhase.addLHCphase(2000000000, 0);
 
-    TFile* fsleewing = TFile::Open("localTimeSlewing.root");
-    if (fsleewing) {
-      TimeSlewing* ob = (TimeSlewing*)fsleewing->Get("ccdb_object");
-      mTimeSlewing = *ob;
-      return;
-    }
-
-    for (int ich = 0; ich < TimeSlewing::NCHANNELS; ich++) {
-      mTimeSlewing.addTimeSlewingInfo(ich, 0, 0);
-      int sector = ich / TimeSlewing::NCHANNELXSECTOR;
-      int channelInSector = ich % TimeSlewing::NCHANNELXSECTOR;
-      mTimeSlewing.setFractionUnderPeak(sector, channelInSector, 1);
+    if (gSystem->AccessPathName("localTimeSlewing.root") == false) {
+      TFile* fsleewing = TFile::Open("localTimeSlewing.root");
+      if (fsleewing) {
+        TimeSlewing* ob = (TimeSlewing*)fsleewing->Get("ccdb_object");
+        mTimeSlewing = *ob;
+        return;
+      }
+    } else {
+      for (int ich = 0; ich < TimeSlewing::NCHANNELS; ich++) {
+        mTimeSlewing.addTimeSlewingInfo(ich, 0, 0);
+        int sector = ich / TimeSlewing::NCHANNELXSECTOR;
+        int channelInSector = ich % TimeSlewing::NCHANNELXSECTOR;
+        mTimeSlewing.setFractionUnderPeak(sector, channelInSector, 1);
+      }
     }
   }
 
@@ -105,46 +111,29 @@ class TOFChannelCalibDevice : public o2::framework::Task
   void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final
   {
     o2::base::GRPGeomHelper::instance().finaliseCCDB(matcher, obj);
+    mUpdateCCDB = false;
+    if (mFollowCCDBUpdates) {
+      if (matcher == ConcreteDataMatcher("TOF", "LHCphaseCal", 0)) {
+        mUpdateCCDB = true;
+        return;
+      }
+      if (matcher == ConcreteDataMatcher("TOF", "ChannelCalibCal", 0)) {
+        mUpdateCCDB = true;
+        return;
+      }
+    }
   }
 
   void run(o2::framework::ProcessingContext& pc) final
   {
     o2::base::GRPGeomHelper::instance().checkUpdates(pc);
-    long startTimeLHCphase;
-    long startTimeChCalib;
+    long startTimeLHCphase = 0;
+    long startTimeChCalib = 0;
     o2::base::TFIDInfoHelper::fillTFIDInfo(pc, mCalibrator->getCurrentTFInfo());
     auto tfcounter = mCalibrator->getCurrentTFInfo().tfCounter;
 
     if (mUseCCDB) { // read calibration objects from ccdb
       LHCphase lhcPhaseObjTmp;
-      /*
-      // for now this part is not implemented; below, the sketch of how it should be done
-      if (mAttachToLHCphase) {
-        // if I want to take the LHCclockphase just produced, I need to loop over what the previous spec produces:
-        int nSlots = pc.inputs().getNofParts(0);
-        assert(pc.inputs().getNofParts(1) == nSlots);
-
-        int lhcphaseIndex = -1;
-        for (int isl = 0; isl < nSlots; isl++) {
-          const auto wrp = pc.inputs().get<CcdbObjectInfo*>("clbInfo", isl);
-          if (wrp->getStartValidityTimestamp() > tfcounter) { // replace tfcounter with the timestamp of the TF
-            lhxphaseIndex = isl - 1;
-            break;
-          }
-        }
-        if (lhcphaseIndex == -1) {
-          // no new object found, use CCDB
-         auto lhcPhase = pc.inputs().get<LHCphase*>("tofccdbLHCphase");
-          lhcPhaseObjTmp = std::move(*lhcPhase);
-        }
-        else {
-          const auto pld = pc.inputs().get<gsl::span<char>>("clbPayload", lhcphaseIndex); // this is actually an image of TMemFile
-          // now i need to make a LHCphase object; Ruben suggested how, I did not try yet
-         // ...
-        }
-      }
-      else {
-      */
       auto lhcPhase = pc.inputs().get<LHCphase*>("tofccdbLHCphase");
       lhcPhaseObjTmp = std::move(*lhcPhase);
       auto channelCalib = pc.inputs().get<TimeSlewing*>("tofccdbChannelCalib");
@@ -153,35 +142,44 @@ class TOFChannelCalibDevice : public o2::framework::Task
       mPhase = lhcPhaseObjTmp;
       mTimeSlewing = channelCalibObjTmp;
 
-      startTimeLHCphase = pc.inputs().get<long>("startTimeLHCphase");
-      startTimeChCalib = pc.inputs().get<long>("startTimeChCalib");
-    } else {
-      startTimeLHCphase = 0;
-      startTimeChCalib = 0;
+      startTimeLHCphase = mPhase.getStartValidity();
+      startTimeChCalib = mTimeSlewing.getStartValidity();
     }
 
     LOG(debug) << "startTimeLHCphase = " << startTimeLHCphase << ",  startTimeChCalib = " << startTimeChCalib;
 
-    mcalibTOFapi = new o2::tof::CalibTOFapi(long(0), &mPhase, &mTimeSlewing); // TODO: should we replace long(0) with tfcounter defined at the beginning of the method? we need the timestamp of the TF
+    if (!mcalibTOFapi) {
+      mcalibTOFapi = new o2::tof::CalibTOFapi(long(0), &mPhase, &mTimeSlewing);
+
+      // checking if the existing object is too old. This check we can do only once, because any other update will be from the same run (--> not too old)
+      long timeNow = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+      if ((timeNow - startTimeChCalib) > o2::ccdb::CcdbObjectInfo::DAY * 7) {
+        LOG(info) << "Enlarging the range of the booked histogram since the latest CCDB entry is too old";
+        mCalibrator->setRange(mCalibrator->getRange() * 10); // we enlarge the range for the calibration in case the last valid object is too old (older than 1 week)
+      }
+    } else {
+      if (mUseCCDB && mUpdateCCDB) {
+        mcalibTOFapi->setLhcPhase(&mPhase);
+        mcalibTOFapi->setSlewParam(&mTimeSlewing);
+      }
+    }
 
     mCalibrator->setCalibTOFapi(mcalibTOFapi);
 
-    if ((tfcounter - startTimeChCalib) > 60480000) { // number of TF in 1 week: 7*24*3600/10e-3 - with TF = 10 ms
-      LOG(info) << "Enlarging the range of the booked histogram since the latest CCDB entry is too old";
-      mCalibrator->setRange(mCalibrator->getRange() * 10); // we enlarge the range for the calibration in case the last valid object is too old (older than 1 week)
+    auto data = pc.inputs().get<gsl::span<T>>("input");
+    LOG(info) << "Processing TF " << tfcounter << " with " << data.size() << " tracks";
+
+    if (mUseCCDB) { // setting the timestamp to get the LHCPhase correction; if we don't use CCDB, then it can stay to 0 as set when creating the calibTOFapi above
+      const auto tfOrbitFirst = DataRefUtils::getHeader<o2::header::DataHeader*>(pc.inputs().getFirstValid(true))->firstTForbit;
+      auto tv = pc.inputs().get<std::vector<Long64_t>*>("orbitreset");
+      const auto orbitReset = tv->front();
+      const long tPrec = orbitReset + tfOrbitFirst * o2::constants::lhc::LHCOrbitMUS; // microsecond-precise time stamp
+      mcalibTOFapi->setTimeStamp(tPrec);
     }
 
-    if (!mCosmics) {
-      auto data = pc.inputs().get<gsl::span<T>>("input");
-      LOG(info) << "Processing TF " << tfcounter << " with " << data.size() << " tracks";
-      mCalibrator->process(data);
-      sendOutput(pc.outputs());
-    } else {
-      auto data = pc.inputs().get<gsl::span<T>>("input");
-      LOG(info) << "Processing TF " << tfcounter << " with " << data.size() << " tracks";
-      mCalibrator->process(data);
-      sendOutput(pc.outputs());
-    }
+    mCalibrator->process(data);
+
+    sendOutput(pc.outputs());
   }
 
   void endOfStream(o2::framework::EndOfStreamContext& ec) final
@@ -201,6 +199,8 @@ class TOFChannelCalibDevice : public o2::framework::Task
   bool mCosmics = false;
   bool mDoPerStrip = false;
   bool mSafeMode = false;
+  bool mFollowCCDBUpdates = false;
+  bool mUpdateCCDB = false;
 
   //________________________________________________________________
   void sendOutput(DataAllocator& output)
@@ -233,7 +233,7 @@ namespace framework
 {
 
 template <class T>
-DataProcessorSpec getTOFChannelCalibDeviceSpec(bool useCCDB, bool attachChannelOffsetToLHCphase = false, bool isCosmics = false, bool perstrip = false, bool safe = false)
+DataProcessorSpec getTOFChannelCalibDeviceSpec(bool useCCDB, bool followCCDBUpdates = false, bool attachChannelOffsetToLHCphase = false, bool isCosmics = false, bool perstrip = false, bool safe = false)
 {
   using device = o2::calibration::TOFChannelCalibDevice<T>;
   using clbUtils = o2::calibration::Utils;
@@ -256,17 +256,16 @@ DataProcessorSpec getTOFChannelCalibDeviceSpec(bool useCCDB, bool attachChannelO
                                                                 o2::base::GRPGeomRequest::None, // geometry
                                                                 inputs);
   if (useCCDB) {
-    inputs.emplace_back("tofccdbLHCphase", o2::header::gDataOriginTOF, "LHCphase");
-    inputs.emplace_back("tofccdbChannelCalib", o2::header::gDataOriginTOF, "ChannelCalib");
-    inputs.emplace_back("startTimeLHCphase", o2::header::gDataOriginTOF, "StartLHCphase");
-    inputs.emplace_back("startTimeChCalib", o2::header::gDataOriginTOF, "StartChCalib");
+    inputs.emplace_back("tofccdbLHCphase", o2::header::gDataOriginTOF, "LHCphase", 0, Lifetime::Condition, ccdbParamSpec("TOF/Calib/LHCphase"));
+    inputs.emplace_back("tofccdbChannelCalib", o2::header::gDataOriginTOF, "ChannelCalib", 0, Lifetime::Condition, ccdbParamSpec("TOF/Calib/ChannelCalib"));
+    inputs.emplace_back("orbitReset", o2::header::gDataOriginCTP, "ORBITRESET", 0, Lifetime::Condition, ccdbParamSpec("CTP/Calib/OrbitReset"));
   }
 
   return DataProcessorSpec{
     "calib-tofchannel-calibration",
     inputs,
     outputs,
-    AlgorithmSpec{adaptFromTask<device>(ccdbRequest, useCCDB, attachChannelOffsetToLHCphase, isCosmics, perstrip, safe)},
+    AlgorithmSpec{adaptFromTask<device>(ccdbRequest, useCCDB, followCCDBUpdates, attachChannelOffsetToLHCphase, isCosmics, perstrip, safe)},
     Options{
       {"min-entries", VariantType::Int, 500, {"minimum number of entries to fit channel histos"}},
       {"nbins", VariantType::Int, 1000, {"number of bins for t-texp"}},

--- a/Detectors/TOF/calibration/testWorkflow/TOFChannelCalibratorSpec.h
+++ b/Detectors/TOF/calibration/testWorkflow/TOFChannelCalibratorSpec.h
@@ -171,7 +171,7 @@ class TOFChannelCalibDevice : public o2::framework::Task
 
     if (mUseCCDB) { // setting the timestamp to get the LHCPhase correction; if we don't use CCDB, then it can stay to 0 as set when creating the calibTOFapi above
       const auto tfOrbitFirst = DataRefUtils::getHeader<o2::header::DataHeader*>(pc.inputs().getFirstValid(true))->firstTForbit;
-      auto tv = pc.inputs().get<std::vector<Long64_t>*>("orbitreset");
+      auto tv = pc.inputs().get<std::vector<Long64_t>*>("orbitReset");
       const auto orbitReset = tv->front();
       const long tPrec = orbitReset + tfOrbitFirst * o2::constants::lhc::LHCOrbitMUS; // microsecond-precise time stamp
       mcalibTOFapi->setTimeStamp(tPrec);
@@ -258,7 +258,7 @@ DataProcessorSpec getTOFChannelCalibDeviceSpec(bool useCCDB, bool followCCDBUpda
   if (useCCDB) {
     inputs.emplace_back("tofccdbLHCphase", o2::header::gDataOriginTOF, "LHCphase", 0, Lifetime::Condition, ccdbParamSpec("TOF/Calib/LHCphase"));
     inputs.emplace_back("tofccdbChannelCalib", o2::header::gDataOriginTOF, "ChannelCalib", 0, Lifetime::Condition, ccdbParamSpec("TOF/Calib/ChannelCalib"));
-    inputs.emplace_back("orbitReset", o2::header::gDataOriginCTP, "ORBITRESET", 0, Lifetime::Condition, ccdbParamSpec("CTP/Calib/OrbitReset"));
+    inputs.emplace_back("orbitReset", o2::header::gDataOriginCTP, "ORBITRESETTOF", 0, Lifetime::Condition, ccdbParamSpec("CTP/Calib/OrbitReset"));
   }
 
   return DataProcessorSpec{

--- a/Detectors/TOF/calibration/testWorkflow/lhc-clockphase-workflow.cxx
+++ b/Detectors/TOF/calibration/testWorkflow/lhc-clockphase-workflow.cxx
@@ -18,6 +18,7 @@ using namespace o2::framework;
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   // option allowing to set parameters
+  workflowOptions.push_back(ConfigParamSpec{"use-ccdb", o2::framework::VariantType::Bool, false, {"enable access to ccdb tof calibration objects"}});
 }
 
 // ------------------------------------------------------------------
@@ -27,6 +28,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 {
   WorkflowSpec specs;
-  specs.emplace_back(getLHCClockCalibDeviceSpec());
+  auto useCCDB = configcontext.options().get<bool>("use-ccdb");
+  specs.emplace_back(getLHCClockCalibDeviceSpec(useCCDB));
   return specs;
 }

--- a/Detectors/TOF/calibration/testWorkflow/tof-calib-workflow.cxx
+++ b/Detectors/TOF/calibration/testWorkflow/tof-calib-workflow.cxx
@@ -27,6 +27,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   workflowOptions.push_back(ConfigParamSpec{"cosmics", o2::framework::VariantType::Bool, false, {"for cosmics data"}});
   workflowOptions.push_back(ConfigParamSpec{"perstrip", o2::framework::VariantType::Bool, false, {"offsets per strip"}});
   workflowOptions.push_back(ConfigParamSpec{"safe-mode", o2::framework::VariantType::Bool, false, {"require safe mode (discard strange TF)"}});
+  workflowOptions.push_back(ConfigParamSpec{"follow-ccdb-updates", o2::framework::VariantType::Bool, false, {"whether to update the CCDB entries during calibration"}});
 }
 
 // ------------------------------------------------------------------
@@ -43,6 +44,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   auto isCosmics = configcontext.options().get<bool>("cosmics");
   auto perstrip = configcontext.options().get<bool>("perstrip");
   auto safe = configcontext.options().get<bool>("safe-mode");
+  auto followCCDBUpdates = configcontext.options().get<bool>("follow-ccdb-updates");
 
   if (isCosmics) {
     LOG(info) << "Cosmics set!!!! No LHC phase, Yes channel offset";
@@ -60,14 +62,16 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   LOG(info) << "doChannelOffsetCalib = " << doChannelOffsetCalib;
   LOG(info) << "useCCDB = " << useCCDB;
   LOG(info) << "attachChannelOffsetToLHCphase = " << attachChannelOffsetToLHCphase;
+  LOG(info) << "followCCDBUpdates = " << followCCDBUpdates;
+
   if (doLHCcalib) {
-    specs.emplace_back(getLHCClockCalibDeviceSpec());
+    specs.emplace_back(getLHCClockCalibDeviceSpec(useCCDB, followCCDBUpdates));
   }
   if (doChannelOffsetCalib) {
     if (!isCosmics) {
-      specs.emplace_back(getTOFChannelCalibDeviceSpec<o2::dataformats::CalibInfoTOF>(useCCDB, attachChannelOffsetToLHCphase, isCosmics, perstrip, safe));
+      specs.emplace_back(getTOFChannelCalibDeviceSpec<o2::dataformats::CalibInfoTOF>(useCCDB, followCCDBUpdates, attachChannelOffsetToLHCphase, isCosmics, perstrip, safe));
     } else {
-      specs.emplace_back(getTOFChannelCalibDeviceSpec<o2::tof::CalibInfoCluster>(useCCDB, attachChannelOffsetToLHCphase, isCosmics));
+      specs.emplace_back(getTOFChannelCalibDeviceSpec<o2::tof::CalibInfoCluster>(useCCDB, followCCDBUpdates, attachChannelOffsetToLHCphase, isCosmics));
     }
   }
   return specs;

--- a/prodtests/full-system-test/aggregator-workflow.sh
+++ b/prodtests/full-system-test/aggregator-workflow.sh
@@ -37,14 +37,14 @@ fi
 # TOF
 if [[ $CALIB_TOF_LHCPHASE == 1 ]] || [[ $CALIB_TOF_CHANNELOFFSETS == 1 ]]; then
     if [[ $CALIB_TOF_LHCPHASE == 1 ]]; then
-  EXTRA_WORKFLOW_CALIB+="o2-calibration-tof-calib-workflow $ARGS_ALL --do-lhc-phase --tf-per-slot 10 | "
+  EXTRA_WORKFLOW_CALIB+="o2-calibration-tof-calib-workflow $ARGS_ALL --do-lhc-phase --tf-per-slot 26400 --use-ccdb | "
     fi
     if [[ $CALIB_TOF_CHANNELOFFSETS == 1 ]]; then
-  EXTRA_WORKFLOW_CALIB+="o2-calibration-tof-calib-workflow $ARGS_ALL --do-channel-offset --update-at-end-of-run-only --min-entries 8 --range 100000 | "
+  EXTRA_WORKFLOW_CALIB+="o2-calibration-tof-calib-workflow $ARGS_ALL --do-channel-offset --update-interval 300000 --delta-update-interval 50000 --min-entries 100 --range 100000 --use-ccdb | "
     fi
 fi
 if [[ $CALIB_TOF_DIAGNOSTICS == 1 ]]; then
-    EXTRA_WORKFLOW_CALIB+="o2-calibration-tof-diagnostic-workflow $ARGS_ALL --tf-per-slot 26400 | "
+    EXTRA_WORKFLOW_CALIB+="o2-calibration-tof-diagnostic-workflow $ARGS_ALL --tf-per-slot 26400 --max-delay 1 | "
 fi
 
 # TRD

--- a/prodtests/full-system-test/aggregator-workflow.sh
+++ b/prodtests/full-system-test/aggregator-workflow.sh
@@ -40,7 +40,7 @@ if [[ $CALIB_TOF_LHCPHASE == 1 ]] || [[ $CALIB_TOF_CHANNELOFFSETS == 1 ]]; then
   EXTRA_WORKFLOW_CALIB+="o2-calibration-tof-calib-workflow $ARGS_ALL --do-lhc-phase --tf-per-slot 26400 --use-ccdb | "
     fi
     if [[ $CALIB_TOF_CHANNELOFFSETS == 1 ]]; then
-  EXTRA_WORKFLOW_CALIB+="o2-calibration-tof-calib-workflow $ARGS_ALL --do-channel-offset --update-interval 300000 --delta-update-interval 50000 --min-entries 100 --range 100000 --use-ccdb | "
+  EXTRA_WORKFLOW_CALIB+="o2-calibration-tof-calib-workflow $ARGS_ALL --do-channel-offset --update-interval 300000 --delta-update-interval 50000 --min-entries 100 --range 100000 --use-ccdb --follow-ccdb-updates | "
     fi
 fi
 if [[ $CALIB_TOF_DIAGNOSTICS == 1 ]]; then

--- a/prodtests/full-system-test/aggregator-workflow.sh
+++ b/prodtests/full-system-test/aggregator-workflow.sh
@@ -29,6 +29,19 @@ echo "CALIB_PHS_TURNONCALIB = $CALIB_PHS_TURNONCALIB" 1>&2
 echo "CALIB_PHS_RUNBYRUNCALIB = $CALIB_PHS_RUNBYRUNCALIB" 1>&2
 echo "CALIB_TRD_VDRIFTEXB = $CALIB_TRD_VDRIFTEXB" 1>&2
 
+# beamtype dependent settings
+LHCPHASE_TF_PER_SLOT=26400
+TOF_CHANNELOFFSETS_UPDATE=300000
+TOF_CHANNELOFFSETS_DELTA_UPDATE=50000
+
+if [[ $BEAMTYPE == "PbPb" ]]; then
+    LHCPHASE_TF_PER_SLOT=264
+    TOF_CHANNELOFFSETS_UPDATE=3000
+    TOF_CHANNELOFFSETS_DELTA_UPDATE=500
+fi
+
+# Calibration workflows
+
 # PrimVertex
 if [[ $CALIB_PRIMVTX_MEANVTX == 1 ]]; then
     EXTRA_WORKFLOW_CALIB+="o2-calibration-mean-vertex-calibration-workflow $ARGS_ALL | "
@@ -37,10 +50,10 @@ fi
 # TOF
 if [[ $CALIB_TOF_LHCPHASE == 1 ]] || [[ $CALIB_TOF_CHANNELOFFSETS == 1 ]]; then
     if [[ $CALIB_TOF_LHCPHASE == 1 ]]; then
-  EXTRA_WORKFLOW_CALIB+="o2-calibration-tof-calib-workflow $ARGS_ALL --do-lhc-phase --tf-per-slot 26400 --use-ccdb | "
+  EXTRA_WORKFLOW_CALIB+="o2-calibration-tof-calib-workflow $ARGS_ALL --do-lhc-phase --tf-per-slot $LHCPHASE_TF_PER_SLOT --use-ccdb | "
     fi
     if [[ $CALIB_TOF_CHANNELOFFSETS == 1 ]]; then
-  EXTRA_WORKFLOW_CALIB+="o2-calibration-tof-calib-workflow $ARGS_ALL --do-channel-offset --update-interval 300000 --delta-update-interval 50000 --min-entries 100 --range 100000 --use-ccdb --follow-ccdb-updates | "
+  EXTRA_WORKFLOW_CALIB+="o2-calibration-tof-calib-workflow $ARGS_ALL --do-channel-offset --update-interval $TOF_CHANNELOFFSETS_UPDATE --delta-update-interval $TOF_CHANNELOFFSETS_DELTA_UPDATE --min-entries 100 --range 100000 --use-ccdb --follow-ccdb-updates | "
     fi
 fi
 if [[ $CALIB_TOF_DIAGNOSTICS == 1 ]]; then


### PR DESCRIPTION
To be checked (@noferini ):
* for the channel calib, did we set the slots boundaries according to the data? I could not find it if it is so. So I changed the time used for the CCDB entry to use the one in MS from the slot;
* we need to add some settings for the LHCphase and slewing object to the api, to avoid destroy and recreate (also for the clusterer)

---> for the first point above: the data was used to define the timestamp for the LHCphase object read by the calibTOFapi --> now changed, it uses DPL timestamp and OrbitReset
---> setters implemented, but for now the clusterer is not touched.