### PR TITLE
Pass-trough mode for PVertexer, use it in cosmic

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/PrimaryVertexingSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/include/GlobalTrackingWorkflow/PrimaryVertexingSpec.h
@@ -24,7 +24,7 @@ namespace vertexing
 {
 
 /// create a processor spec
-o2::framework::DataProcessorSpec getPrimaryVertexingSpec(o2::dataformats::GlobalTrackID::mask_t src, bool validateWithFT0, bool useMC);
+o2::framework::DataProcessorSpec getPrimaryVertexingSpec(o2::dataformats::GlobalTrackID::mask_t src, bool skip, bool validateWithFT0, bool useMC);
 
 } // namespace vertexing
 } // namespace o2

--- a/Detectors/GlobalTrackingWorkflow/src/PrimaryVertexingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/PrimaryVertexingSpec.cxx
@@ -45,8 +45,8 @@ namespace o2d = o2::dataformats;
 class PrimaryVertexingSpec : public Task
 {
  public:
-  PrimaryVertexingSpec(std::shared_ptr<DataRequest> dr, bool validateWithIR, bool useMC)
-    : mDataRequest(dr), mUseMC(useMC), mValidateWithIR(validateWithIR) {}
+  PrimaryVertexingSpec(std::shared_ptr<DataRequest> dr, bool skip, bool validateWithIR, bool useMC)
+    : mDataRequest(dr), mSkip(skip), mUseMC(useMC), mValidateWithIR(validateWithIR) {}
   ~PrimaryVertexingSpec() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
@@ -55,6 +55,7 @@ class PrimaryVertexingSpec : public Task
  private:
   std::shared_ptr<DataRequest> mDataRequest;
   o2::vertexing::PVertexer mVertexer;
+  bool mSkip{false};           ///< skip vertexing
   bool mUseMC{false};          ///< MC flag
   bool mValidateWithIR{false}; ///< require vertex validation with IR (e.g. from FT0)
   float mITSROFrameLengthMUS = 0.;
@@ -102,61 +103,58 @@ void PrimaryVertexingSpec::run(ProcessingContext& pc)
   double timeCPU0 = mTimer.CpuTime(), timeReal0 = mTimer.RealTime();
   mTimer.Start(false);
 
-  o2::globaltracking::RecoContainer recoData;
-  recoData.collectData(pc, *mDataRequest.get());
-  // select tracks of needed type, with minimal cuts, the real selected will be done in the vertexer
-
-  std::vector<TrackWithTimeStamp> tracks;
-  std::vector<o2::MCCompLabel> tracksMCInfo;
-  std::vector<o2d::GlobalTrackID> gids;
-  auto maxTrackTimeError = PVertexerParams::Instance().maxTimeErrorMUS;
-  auto halfROFITS = 0.5 * mITSROFrameLengthMUS;
-  auto hw2ErrITS = 2.f / std::sqrt(12.f) * mITSROFrameLengthMUS; // conversion from half-width to error for ITS
-
-  auto creator = [maxTrackTimeError, hw2ErrITS, halfROFITS, &tracks, &gids](auto& _tr, GTrackID _origID, float t0, float terr) {
-    if (!_origID.includesDet(DetID::ITS)) {
-      return true; // just in case this selection was not done on RecoContainer filling level
-    }
-    if constexpr (isITSTrack<decltype(_tr)>()) {
-      t0 += halfROFITS;  // ITS time is supplied in \mus as beginning of ROF
-      terr *= hw2ErrITS; // error is supplied as a half-ROF duration, convert to \mus
-    }
-    // for all other tracks the time is in \mus with gaussian error
-    if constexpr (std::is_base_of_v<o2::track::TrackParCov, std::decay_t<decltype(_tr)>>) {
-      if (terr < maxTrackTimeError) {
-        tracks.emplace_back(TrackWithTimeStamp{_tr, {t0, terr}});
-        gids.emplace_back(_origID);
-      }
-    }
-
-    return true;
-  };
-
-  recoData.createTracksVariadic(creator); // create track sample considered for vertexing
-
-  if (mUseMC) {
-    recoData.fillTrackMCLabels(gids, tracksMCInfo);
-  }
   std::vector<PVertex> vertices;
   std::vector<GIndex> vertexTrackIDs;
   std::vector<V2TRef> v2tRefs;
   std::vector<o2::MCEventLabel> lblVtx;
 
-  // RS FIXME this will not have effect until the 1st orbit is propagated, until that will work only for TF starting at orbit 0
-  mVertexer.setStartIR({0, DataRefUtils::getHeader<o2::header::DataHeader*>(pc.inputs().getFirstValid(true))->firstTForbit});
+  if (!mSkip) {
+    o2::globaltracking::RecoContainer recoData;
+    recoData.collectData(pc, *mDataRequest.get()); // select tracks of needed type, with minimal cuts, the real selected will be done in the vertexer
+    std::vector<TrackWithTimeStamp> tracks;
+    std::vector<o2::MCCompLabel> tracksMCInfo;
+    std::vector<o2d::GlobalTrackID> gids;
+    auto maxTrackTimeError = PVertexerParams::Instance().maxTimeErrorMUS;
+    auto halfROFITS = 0.5 * mITSROFrameLengthMUS;
+    auto hw2ErrITS = 2.f / std::sqrt(12.f) * mITSROFrameLengthMUS; // conversion from half-width to error for ITS
 
-  std::vector<o2::InteractionRecord> ft0Data;
-  if (mValidateWithIR) { // select BCs for validation
-    const o2::ft0::InteractionTag& ft0Params = o2::ft0::InteractionTag::Instance();
-    auto ft0all = recoData.getFT0RecPoints();
-    for (const auto& ftRP : ft0all) {
-      if (ft0Params.isSelected(ftRP)) {
-        ft0Data.push_back(ftRP.getInteractionRecord());
+    auto creator = [maxTrackTimeError, hw2ErrITS, halfROFITS, &tracks, &gids](auto& _tr, GTrackID _origID, float t0, float terr) {
+      if (!_origID.includesDet(DetID::ITS)) {
+        return true; // just in case this selection was not done on RecoContainer filling level
+      }
+      if constexpr (isITSTrack<decltype(_tr)>()) {
+        t0 += halfROFITS;  // ITS time is supplied in \mus as beginning of ROF
+        terr *= hw2ErrITS; // error is supplied as a half-ROF duration, convert to \mus
+      }
+      // for all other tracks the time is in \mus with gaussian error
+      if constexpr (std::is_base_of_v<o2::track::TrackParCov, std::decay_t<decltype(_tr)>>) {
+        if (terr < maxTrackTimeError) {
+          tracks.emplace_back(TrackWithTimeStamp{_tr, {t0, terr}});
+          gids.emplace_back(_origID);
+        }
+      }
+      return true;
+    };
+
+    recoData.createTracksVariadic(creator); // create track sample considered for vertexing
+
+    if (mUseMC) {
+      recoData.fillTrackMCLabels(gids, tracksMCInfo);
+    }
+    mVertexer.setStartIR(recoData.startIR);
+    std::vector<o2::InteractionRecord> ft0Data;
+    if (mValidateWithIR) { // select BCs for validation
+      const o2::ft0::InteractionTag& ft0Params = o2::ft0::InteractionTag::Instance();
+      auto ft0all = recoData.getFT0RecPoints();
+      for (const auto& ftRP : ft0all) {
+        if (ft0Params.isSelected(ftRP)) {
+          ft0Data.push_back(ftRP.getInteractionRecord());
+        }
       }
     }
+    mVertexer.process(tracks, gids, ft0Data, vertices, vertexTrackIDs, v2tRefs, tracksMCInfo, lblVtx);
   }
 
-  mVertexer.process(tracks, gids, ft0Data, vertices, vertexTrackIDs, v2tRefs, tracksMCInfo, lblVtx);
   pc.outputs().snapshot(Output{"GLO", "PVTX", 0, Lifetime::Timeframe}, vertices);
   pc.outputs().snapshot(Output{"GLO", "PVTX_CONTIDREFS", 0, Lifetime::Timeframe}, v2tRefs);
   pc.outputs().snapshot(Output{"GLO", "PVTX_CONTID", 0, Lifetime::Timeframe}, vertexTrackIDs);
@@ -177,7 +175,7 @@ void PrimaryVertexingSpec::endOfStream(EndOfStreamContext& ec)
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 
-DataProcessorSpec getPrimaryVertexingSpec(GTrackID::mask_t src, bool validateWithFT0, bool useMC)
+DataProcessorSpec getPrimaryVertexingSpec(GTrackID::mask_t src, bool skip, bool validateWithFT0, bool useMC)
 {
   std::vector<OutputSpec> outputs;
   auto dataRequest = std::make_shared<DataRequest>();
@@ -199,7 +197,7 @@ DataProcessorSpec getPrimaryVertexingSpec(GTrackID::mask_t src, bool validateWit
     "primary-vertexing",
     dataRequest->inputs,
     outputs,
-    AlgorithmSpec{adaptFromTask<PrimaryVertexingSpec>(dataRequest, validateWithFT0, useMC)},
+    AlgorithmSpec{adaptFromTask<PrimaryVertexingSpec>(dataRequest, skip, validateWithFT0, useMC)},
     Options{{"material-lut-path", VariantType::String, "", {"Path of the material LUT file"}}}};
 }
 

--- a/Detectors/GlobalTrackingWorkflow/src/primary-vertexing-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/primary-vertexing-workflow.cxx
@@ -54,6 +54,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input reader"}},
     {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writer"}},
     {"vertexing-sources", VariantType::String, std::string{GID::ALL}, {"comma-separated list of sources to use in vertexing"}},
+    {"skip", VariantType::Bool, false, {"pass-through mode (skip vertexing)"}},
     {"validate-with-ft0", o2::framework::VariantType::Bool, false, {"use FT0 time for vertex validation"}},
     {"vertex-track-matching-sources", VariantType::String, std::string{GID::ALL}, {"comma-separated list of sources to use in vertex-track associations or \"none\" to disable matching"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}},
@@ -81,6 +82,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   auto useMC = !configcontext.options().get<bool>("disable-mc");
   auto disableRootOut = configcontext.options().get<bool>("disable-root-output");
   auto validateWithFT0 = configcontext.options().get<bool>("validate-with-ft0");
+  auto skip = configcontext.options().get<bool>("skip");
 
   GID::mask_t srcPV = allowedSourcesPV & GID::getSourcesMask(configcontext.options().get<std::string>("vertexing-sources"));
   GID::mask_t srcVT = allowedSourcesVT & GID::getSourcesMask(configcontext.options().get<std::string>("vertex-track-matching-sources"));
@@ -90,10 +92,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   GID::mask_t srcComb = srcPV | srcVT;
   GID::mask_t dummy, srcClus = GID::includesDet(DetID::TOF, srcComb) ? GID::getSourceMask(GID::TOF) : dummy;
 
-  specs.emplace_back(o2::vertexing::getPrimaryVertexingSpec(srcPV, validateWithFT0, useMC));
-  if (!srcVT.none()) {
-    specs.emplace_back(o2::vertexing::getVertexTrackMatcherSpec(srcVT));
-  }
+  specs.emplace_back(o2::vertexing::getPrimaryVertexingSpec(srcPV, skip, validateWithFT0, useMC));
+  specs.emplace_back(o2::vertexing::getVertexTrackMatcherSpec(srcVT));
 
   auto srcMtc = srcComb & ~GID::getSourceMask(GID::MFTMCH); // Do not request MFTMCH matches
 

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -345,8 +345,11 @@ has_detectors_reco MFT MCH && has_detector_matching MFTMCH && add_W o2-globalfwd
 # Reconstruction workflows needed only in case QC was requested
 has_detector_qc PHS && workflow_has_parameter QC && add_W o2-phos-reco-workflow "--input-type cells --output-type clusters $DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $DISABLE_MC --pipeline $(get_N PHOSClusterizerSpec PHS REST 1)"
 
+# always run vertexing if requested and if there are some sources, but in cosmic mode we work in pass-trough mode (create record for non-associated tracks)
+[[ $BEAMTYPE != "cosmic" ]] && PVTXSKIP="--skip" || PVTXSKIP=
+has_detector_matching PRIMVTX && [[ ! -z "$VERTEXING_SOURCES" ]] && add_W o2-primary-vertexing-workflow "$PVTXSKIP $DISABLE_MC $DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $PVERTEX_CONFIG --pipeline $(get_N primary-vertexing MATCH REST 1)" "${PVERTEXING_CONFIG_KEY}"
+
 if [[ $BEAMTYPE != "cosmic" ]]; then
-  has_detectors_reco ITS && has_detector_matching PRIMVTX && [[ ! -z "$VERTEXING_SOURCES" ]] && add_W o2-primary-vertexing-workflow "$DISABLE_MC $DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $PVERTEX_CONFIG --pipeline $(get_N primary-vertexing MATCH REST 1)" "${PVERTEXING_CONFIG_KEY}"
   has_detectors_reco ITS && has_detector_matching SECVTX && [[ ! -z "$VERTEXING_SOURCES" ]] && add_W o2-secondary-vertexing-workflow "$DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT --vertexing-sources $VERTEXING_SOURCES --pipeline $(get_N secondary-vertexing MATCH REST 1)"
 fi
 


### PR DESCRIPTION
Since the aod creation is based on the vertex-tracks associations, the vertexer must
always run, even if there is no chance to find any vertex: in this case a special
VtxTrackRef record for non-associated tracks will be created.
Therefore the pvertexer is enabled in the dpl-workflow.sh even in absence of the ITS.
In the cosmic mode a special pass-through mode is deployed, which will simply create
empty vertex output.