### PR TITLE
CPV: add gain calibrator

### DIFF
--- a/DataFormats/Detectors/CPV/include/DataFormatsCPV/Cluster.h
+++ b/DataFormats/Detectors/CPV/include/DataFormatsCPV/Cluster.h
@@ -65,9 +65,9 @@ class Cluster
     posX = mLocalPosX;
     posZ = mLocalPosZ;
   }
-  int getMultiplicity() const { return mMulDigit; } // gets the number of digits making this recpoint
-                                                    // 0: was no unfolging, -1: unfolding failed
-  char getModule() const { return mModule; }        // CPV module of a current cluster
+  unsigned char getMultiplicity() const { return mMulDigit; } // gets the number of digits making this recpoint
+                                                              // 0: was no unfolging, -1: unfolding failed
+  char getModule() const { return mModule; }                  // CPV module of a current cluster
 
   // 0: was no unfolging, -1: unfolding failed
   void setNExMax(char nmax = 1) { mNExMax = nmax; }
@@ -87,7 +87,7 @@ class Cluster
   uint8_t getPackedClusterStatus() const
   {
     CluStatus s = {0};
-    s.multiplicity = std::min(mMulDigit, static_cast<unsigned char>(31)); //5 bits available
+    s.multiplicity = std::min(mMulDigit, static_cast<unsigned char>(31)); // 5 bits available
     s.module = mModule - 2;
     s.unfolded = mNExMax > 1;
     return s.mBits;

--- a/DataFormats/Detectors/CPV/include/DataFormatsCPV/Hit.h
+++ b/DataFormats/Detectors/CPV/include/DataFormatsCPV/Hit.h
@@ -50,10 +50,6 @@ class Hit : public o2::BasicXYZEHit<float>
   /// \return True if points are the same (origin and detector), false otherwise
   Bool_t operator==(const Hit& rhs) const;
 
-  /// \brief Check whether the points are from the same SuperParent and in the same detector volume
-  /// \return True if points are the same (origin and detector), false otherwise
-  Bool_t operator=(const Hit& rhs) const;
-
   /// \brief Sorting points according to parent particle and detector volume
   /// \return True if this Hit is smaller, false otherwise
   Bool_t operator<(const Hit& rhs) const;
@@ -66,7 +62,8 @@ class Hit : public o2::BasicXYZEHit<float>
   /// \brief Creates a new Hit based on this Hit but adding the energy loss of the right hand side
   /// \param
   /// \return New Hit based on this Hit
-  Hit operator+(const Hit& rhs) const;
+  // Hit operator+(const Hit& rhs) const;
+  friend Hit operator+(const Hit& lhs, const Hit& rhs);
 
   /// \brief Destructor
   ~Hit() = default;

--- a/DataFormats/Detectors/CPV/src/Hit.cxx
+++ b/DataFormats/Detectors/CPV/src/Hit.cxx
@@ -43,14 +43,21 @@ Hit& Hit::operator+=(const Hit& rhs)
   return *this;
 }
 
-Hit Hit::operator+(const Hit& rhs) const
+// Hit Hit::operator+(const Hit& rhs) const
+// {
+//   Hit result(*this);
+//   if (rhs.GetEnergyLoss() > result.GetEnergyLoss()) {
+//     result.SetTime(rhs.GetTime());
+//   }
+//   result.SetEnergyLoss(result.GetEnergyLoss() + rhs.GetEnergyLoss());
+//   return result;
+// }
+Hit operator+(const Hit& lhs, const Hit& rhs)
 {
-  Hit result(*this);
-  if (rhs.GetEnergyLoss() > result.GetEnergyLoss()) {
-    result.SetTime(rhs.GetTime());
-  }
-  result.SetEnergyLoss(result.GetEnergyLoss() + rhs.GetEnergyLoss());
-  return result;
+  // Hit::Hit(int trackID, int detID, const math_utils::Point3D<float>& pos, double tof, double qLoss)
+  return Hit(lhs.GetTrackID(), lhs.GetDetectorID(), lhs.GetPos(),
+             lhs.GetEnergyLoss() > rhs.GetEnergyLoss() ? lhs.GetTime() : rhs.GetTime(),
+             lhs.GetEnergyLoss() + rhs.GetEnergyLoss());
 }
 
 std::ostream& operator<<(std::ostream& stream, const Hit& p)

--- a/DataFormats/Detectors/CPV/src/Hit.cxx
+++ b/DataFormats/Detectors/CPV/src/Hit.cxx
@@ -43,15 +43,6 @@ Hit& Hit::operator+=(const Hit& rhs)
   return *this;
 }
 
-// Hit Hit::operator+(const Hit& rhs) const
-// {
-//   Hit result(*this);
-//   if (rhs.GetEnergyLoss() > result.GetEnergyLoss()) {
-//     result.SetTime(rhs.GetTime());
-//   }
-//   result.SetEnergyLoss(result.GetEnergyLoss() + rhs.GetEnergyLoss());
-//   return result;
-// }
 Hit operator+(const Hit& lhs, const Hit& rhs)
 {
   // Hit::Hit(int trackID, int detID, const math_utils::Point3D<float>& pos, double tof, double qLoss)

--- a/Detectors/CPV/base/CMakeLists.txt
+++ b/Detectors/CPV/base/CMakeLists.txt
@@ -12,8 +12,10 @@
 o2_add_library(CPVBase
                SOURCES src/Geometry.cxx
                        src/CPVSimParams.cxx
+                       src/CPVCalibParams.cxx
                PUBLIC_LINK_LIBRARIES O2::SimulationDataFormat)
 
 o2_target_root_dictionary(CPVBase
                           HEADERS include/CPVBase/Geometry.h
-                                  include/CPVBase/CPVSimParams.h)
+                                  include/CPVBase/CPVSimParams.h
+                                  include/CPVBase/CPVCalibParams.h)

--- a/Detectors/CPV/base/include/CPVBase/CPVCalibParams.h
+++ b/Detectors/CPV/base/include/CPVBase/CPVCalibParams.h
@@ -25,34 +25,44 @@ namespace cpv
 struct CPVCalibParams : public o2::conf::ConfigurableParamHelper<CPVCalibParams> {
 
   // Parameters used in pedestal calibration
-  uint16_t mPedToleratedGapWidth = 5;    ///< Tolerated gap between bins: if |bin1 - bin2| < width -> bin1 and bin2 belongs to same peak
-  uint32_t mPedMinEvents = 100;          ///< Minimal number of events to produce calibration
-  float mPedSuspiciousPedestalRMS = 10.; ///< Take additional care for channel if its RMS >  mPedSuspiciousPedestalRMS
-  float mPedZSnSigmas = 3.;              ///< Zero Suppression threshold
+  uint16_t pedToleratedGapWidth = 5;    ///< Tolerated gap between bins: if |bin1 - bin2| < width -> bin1 and bin2 belongs to same peak
+  uint32_t pedMinEvents = 100;          ///< Minimal number of events to produce calibration
+  float pedSuspiciousPedestalRMS = 10.; ///< Take additional care for channel if its RMS >  mPedSuspiciousPedestalRMS
+  float pedZSnSigmas = 3.;              ///< Zero Suppression threshold
 
   // Parameters used in noise scan calibration
-  uint32_t mNoiseMinEvents = 100;                    ///< Minimal number of events to produce calibration
-  float mNoiseToleratedChannelEfficiencyLow = 0.9;   ///< Tolerated channel efficiency (lower limit)
-  float mNoiseToleratedChannelEfficiencyHigh = 1.01; ///< Tolerated channel efficiency (upper limit)
-  uint16_t mNoiseThreshold = 10;                     ///< ADC threshold
-  float mNoiseFrequencyCriteria = 0.5;               ///< Appearance frequency of noisy channels
+  uint32_t noiseMinEvents = 100;                    ///< Minimal number of events to produce calibration
+  float noiseToleratedChannelEfficiencyLow = 0.9;   ///< Tolerated channel efficiency (lower limit)
+  float noiseToleratedChannelEfficiencyHigh = 1.01; ///< Tolerated channel efficiency (upper limit)
+  uint16_t noiseThreshold = 10;                     ///< ADC threshold
+  float noiseFrequencyCriteria = 0.5;               ///< Appearance frequency of noisy channels
 
   // Parameters used in gain calibration
-  uint32_t mGainMinEvents = 1000;                  ///< Minimal number of events to produce calibration in one channel
-  uint32_t mGainMinNChannelsToCalibrate = 2000;    ///< Minimal number of channels ready to be calibrated to produce calibration
-  float mGainDesiredLandauMPV = 200.;              ///< Desired LandauMPV of the spectrum: gain coeff = 200./(max Ampl of the cluster)
-  float mGainToleratedChi2PerNDF = 100.;           ///< Tolerated max Chi2 of the fit
-  float mGainMinAllowedCoeff = 0.1;                ///< Min value of gain coeff
-  float mGainMaxAllowedCoeff = 10.;                ///< Max value of gain coeff
-  float mGainFitRangeL = 10.;                      ///< Fit range of amplitude spectrum (left)
-  float mGainFitRangeR = 1000.;                    ///< Fit range of amplitude spectrum (right)
-  unsigned char mGainMinClusterMultForCalib = 3;   ///< Min cluster multiplicity for calibration digit production
-  unsigned char mGainMaxClusterMultForCalib = 15;  ///< Max cluster multiplicity for calibration digit production
-  uint32_t mGainCheckForCalibrationInterval = 100; ///< Check interval (in TFs) if statistics is enough
+  uint32_t gainMinEvents = 1000;                  ///< Minimal number of events to produce calibration in one channel
+  uint32_t gainMinNChannelsToCalibrate = 2000;    ///< Minimal number of channels ready to be calibrated to produce calibration
+  float gainDesiredLandauMPV = 200.;              ///< Desired LandauMPV of the spectrum: gain coeff = 200./(max Ampl of the cluster)
+  float gainToleratedChi2PerNDF = 100.;           ///< Tolerated max Chi2 of the fit
+  float gainMinAllowedCoeff = 0.1;                ///< Min value of gain coeff
+  float gainMaxAllowedCoeff = 10.;                ///< Max value of gain coeff
+  float gainFitRangeL = 10.;                      ///< Fit range of amplitude spectrum (left)
+  float gainFitRangeR = 1000.;                    ///< Fit range of amplitude spectrum (right)
+  unsigned char gainMinClusterMultForCalib = 3;   ///< Min cluster multiplicity for calibration digit production
+  unsigned char gainMaxClusterMultForCalib = 15;  ///< Max cluster multiplicity for calibration digit production
+  uint32_t gainCheckForCalibrationInterval = 100; ///< Check interval (in TFs) if statistics is enough
 
   O2ParamDef(CPVCalibParams, "CPVCalibParams");
 };
 } // namespace cpv
+
+namespace framework
+{
+template <typename T>
+struct is_messageable;
+template <>
+struct is_messageable<o2::cpv::CPVCalibParams> : std::true_type {
+};
+} // namespace framework
+
 } // namespace o2
 
 #endif /* O2_CPV_CPVCALIBPARAMS_H_ */

--- a/Detectors/CPV/base/include/CPVBase/CPVCalibParams.h
+++ b/Detectors/CPV/base/include/CPVBase/CPVCalibParams.h
@@ -1,0 +1,58 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_CPV_CPVCALIBPARAMS_H_
+#define O2_CPV_CPVCALIBPARAMS_H_
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "CommonUtils/ConfigurableParamHelper.h"
+#include "CommonUtils/NameConf.h"
+
+namespace o2
+{
+namespace cpv
+{
+// parameters used in responce calculation and digitization
+// (mostly used in GEANT stepping and Digitizer)
+struct CPVCalibParams : public o2::conf::ConfigurableParamHelper<CPVCalibParams> {
+
+  // Parameters used in pedestal calibration
+  uint16_t mPedToleratedGapWidth = 5;    ///< Tolerated gap between bins: if |bin1 - bin2| < width -> bin1 and bin2 belongs to same peak
+  uint32_t mPedMinEvents = 100;          ///< Minimal number of events to produce calibration
+  float mPedSuspiciousPedestalRMS = 10.; ///< Take additional care for channel if its RMS >  mPedSuspiciousPedestalRMS
+  float mPedZSnSigmas = 3.;              ///< Zero Suppression threshold
+
+  // Parameters used in noise scan calibration
+  uint32_t mNoiseMinEvents = 100;                    ///< Minimal number of events to produce calibration
+  float mNoiseToleratedChannelEfficiencyLow = 0.9;   ///< Tolerated channel efficiency (lower limit)
+  float mNoiseToleratedChannelEfficiencyHigh = 1.01; ///< Tolerated channel efficiency (upper limit)
+  uint16_t mNoiseThreshold = 10;                     ///< ADC threshold
+  float mNoiseFrequencyCriteria = 0.5;               ///< Appearance frequency of noisy channels
+
+  // Parameters used in gain calibration
+  uint32_t mGainMinEvents = 1000;                  ///< Minimal number of events to produce calibration in one channel
+  uint32_t mGainMinNChannelsToCalibrate = 2000;    ///< Minimal number of channels ready to be calibrated to produce calibration
+  float mGainDesiredLandauMPV = 200.;              ///< Desired LandauMPV of the spectrum: gain coeff = 200./(max Ampl of the cluster)
+  float mGainToleratedChi2PerNDF = 100.;           ///< Tolerated max Chi2 of the fit
+  float mGainMinAllowedCoeff = 0.1;                ///< Min value of gain coeff
+  float mGainMaxAllowedCoeff = 10.;                ///< Max value of gain coeff
+  float mGainFitRangeL = 10.;                      ///< Fit range of amplitude spectrum (left)
+  float mGainFitRangeR = 1000.;                    ///< Fit range of amplitude spectrum (right)
+  unsigned char mGainMinClusterMultForCalib = 3;   ///< Min cluster multiplicity for calibration digit production
+  unsigned char mGainMaxClusterMultForCalib = 15;  ///< Max cluster multiplicity for calibration digit production
+  uint32_t mGainCheckForCalibrationInterval = 100; ///< Check interval (in TFs) if statistics is enough
+
+  O2ParamDef(CPVCalibParams, "CPVCalibParams");
+};
+} // namespace cpv
+} // namespace o2
+
+#endif /* O2_CPV_CPVCALIBPARAMS_H_ */

--- a/Detectors/CPV/base/include/CPVBase/CPVSimParams.h
+++ b/Detectors/CPV/base/include/CPVBase/CPVSimParams.h
@@ -24,7 +24,7 @@ namespace cpv
 // (mostly used in GEANT stepping and Digitizer)
 struct CPVSimParams : public o2::conf::ConfigurableParamHelper<CPVSimParams> {
 
-  //Parameters used in conversion of deposited energy to APD response
+  // Parameters used in conversion of deposited energy to APD response
   int mnCellX = 128;
   int mnCellZ = 60;
   float mPadSizeX = 1.13;                                 ///<  overall size of CPV active size
@@ -38,7 +38,7 @@ struct CPVSimParams : public o2::conf::ConfigurableParamHelper<CPVSimParams> {
   float mB = 0.7;                                         ///<  Parameter to model CPV response
   inline float CellWr() const { return 0.5 * mPadSizeX; } ///<  Distance between wires (2 wires above 1 pad)
 
-  //Parameters used in electronic noise calculation and thresholds (Digitizer, Calibration)
+  // Parameters used in electronic noise calculation and thresholds (Digitizer, Calibration)
   float mReadoutTime = 5.;        ///< Read-out time in ns for default simulaionts
   float mDeadTime = 20.;          ///< PHOS dead time (includes Read-out time i.e. mDeadTime>=mReadoutTime)
   float mReadoutTimePU = 2000.;   ///< Read-out time in ns if pileup simulation on in DigitizerSpec
@@ -47,8 +47,7 @@ struct CPVSimParams : public o2::conf::ConfigurableParamHelper<CPVSimParams> {
   float mZSnSigmas = 3.;          ///< Zero Suppression threshold
   float mSortingDelta = 0.1;      ///< used in sorting clusters inverse sorting band in cm
 
-  //Parameters used in clusterization
-  //float mDigitMinEnergy = 0.01;       ///< Minimal amplitude of a digit to be used in cluster
+  // Parameters used in clusterization
   float mDigitMinEnergy = 5.;        ///< Minimal amplitude of a digit to be used in cluster
   float mClusteringThreshold = 10.;  ///< Seed digit minimal amplitude
   float mUnfogingEAccuracy = 1.e-3;  ///< Accuracy of energy calculation in unfoding prosedure (GeV)
@@ -57,18 +56,6 @@ struct CPVSimParams : public o2::conf::ConfigurableParamHelper<CPVSimParams> {
   float mLogWeight = 4.5;            ///< weight in cluster center of gravity calculation
   int mNMaxIterations = 10;          ///< Maximal number of iterations in unfolding procedure
   bool mUnfoldClusters = false;      ///< Perform cluster unfolding?
-
-  // Parameters used in pedestal calibration
-  uint16_t mPedClbToleratedGapWidth = 5;    ///< Tolerated gap between bins: if |bin1 - bin2| < width -> bin1 and bin2 belongs to same peak
-  uint32_t mPedClbMinEvents = 100;          ///< Minimal number of events to produce calibration
-  float mPedClbSuspiciousPedestalRMS = 10.; ///< Take additional care for channel if its RMS >  mPedClbSuspiciousPedestalRMS
-
-  // Parameters used in noise scan calibration
-  uint32_t mNoiseClbMinEvents = 100;                    ///< Minimal number of events to produce calibration
-  float mNoiseClbToleratedChannelEfficiencyLow = 0.9;   ///< Tolerated channel efficiency (lower limit)
-  float mNoiseClbToleratedChannelEfficiencyHigh = 1.01; ///< Tolerated channel efficiency (upper limit)
-  uint16_t mNoiseClbThreshold = 10;                     ///< ADC threshold
-  float mNoiseClbFrequencyCriteria = 0.5;               ///< Appearance frequency of noisy channels
 
   O2ParamDef(CPVSimParams, "CPVSimParams");
 };

--- a/Detectors/CPV/base/include/CPVBase/CPVSimParams.h
+++ b/Detectors/CPV/base/include/CPVBase/CPVSimParams.h
@@ -60,6 +60,16 @@ struct CPVSimParams : public o2::conf::ConfigurableParamHelper<CPVSimParams> {
   O2ParamDef(CPVSimParams, "CPVSimParams");
 };
 } // namespace cpv
+
+namespace framework
+{
+template <typename T>
+struct is_messageable;
+template <>
+struct is_messageable<o2::cpv::CPVSimParams> : std::true_type {
+};
+} // namespace framework
+
 } // namespace o2
 
 #endif /* O2_CPV_CPVSIMPARAMS_H_ */

--- a/Detectors/CPV/base/src/CPVCalibParams.cxx
+++ b/Detectors/CPV/base/src/CPVCalibParams.cxx
@@ -9,16 +9,5 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifdef __CLING__
-
-#pragma link off all globals;
-#pragma link off all classes;
-#pragma link off all functions;
-
-#pragma link C++ class o2::cpv::Geometry + ;
-#pragma link C++ class o2::cpv::CPVSimParams + ;
-#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::cpv::CPVSimParams> + ;
-#pragma link C++ class o2::cpv::CPVCalibParams + ;
-#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::cpv::CPVCalibParams> + ;
-
-#endif
+#include "CPVBase/CPVCalibParams.h"
+O2ParamImpl(o2::cpv::CPVCalibParams);

--- a/Detectors/CPV/calib/CMakeLists.txt
+++ b/Detectors/CPV/calib/CMakeLists.txt
@@ -32,6 +32,7 @@ o2_add_executable(cpv-calib-workflow
                   PUBLIC_LINK_LIBRARIES O2::Framework
                                         O2::CPVCalibration
                                         O2::DetectorsCalibration
+                                        O2::CPVBase
                                         O2::DataFormatsCPV)
 
 if(BUILD_TESTING)

--- a/Detectors/CPV/calib/CMakeLists.txt
+++ b/Detectors/CPV/calib/CMakeLists.txt
@@ -15,6 +15,7 @@ o2_add_library(CPVCalibration
                TARGETVARNAME targetName
                SOURCES src/NoiseCalibrator.cxx
                        src/PedestalCalibrator.cxx
+                       src/GainCalibrator.cxx
                PUBLIC_LINK_LIBRARIES O2::DataFormatsCPV
                                      O2::CPVBase
                                      O2::DetectorsCalibration
@@ -22,7 +23,8 @@ o2_add_library(CPVCalibration
 
 o2_target_root_dictionary(CPVCalibration
                           HEADERS include/CPVCalibration/NoiseCalibrator.h
-                                  include/CPVCalibration/PedestalCalibrator.h)
+                                  include/CPVCalibration/PedestalCalibrator.h
+                                  include/CPVCalibration/GainCalibrator.h)
 
 o2_add_executable(cpv-calib-workflow
                   COMPONENT_NAME calibration
@@ -34,11 +36,19 @@ o2_add_executable(cpv-calib-workflow
 
 if(BUILD_TESTING)
   o2_add_test_root_macro(macros/readPedestalsFromCCDB.C
-                         PUBLIC_LINK_LIBRARIES O2::CCDB O2::DataFormatsCPV
+                         PUBLIC_LINK_LIBRARIES O2::CCDB O2::CPVBase O2::DataFormatsCPV
                          LABELS CPV COMPILE_ONLY)
 
   o2_add_test_root_macro(macros/readBadChannelMapFromCCDB.C
                          PUBLIC_LINK_LIBRARIES O2::CCDB O2::CPVBase O2::DataFormatsCPV
+                         LABELS CPV COMPILE_ONLY)
+
+  o2_add_test_root_macro(macros/readCalibParamsFromCCDB.C
+                         PUBLIC_LINK_LIBRARIES O2::CCDB O2::CPVBase O2::DataFormatsCPV
+                         LABELS CPV COMPILE_ONLY)
+
+  o2_add_test_root_macro(macros/readGainCalibDataFromCCDB.C
+                         PUBLIC_LINK_LIBRARIES O2::CCDB O2::CPVBase O2::CPVCalibration
                          LABELS CPV COMPILE_ONLY)
 
   o2_add_test_root_macro(macros/readPedEfficienciesFromCCDB.C

--- a/Detectors/CPV/calib/CPVCalibWorkflow/src/CPVGainCalibDevice.cxx
+++ b/Detectors/CPV/calib/CPVCalibWorkflow/src/CPVGainCalibDevice.cxx
@@ -66,7 +66,7 @@ void CPVGainCalibDevice::run(o2::framework::ProcessingContext& ctx)
         // if problem in payload, try to continue
         continue;
       }
-      auto& header = rawreader.getRawHeader();
+      // auto& header = rawreader.getRawHeader();
       //       auto triggerBC = o2::raw::RDHUtils::getTriggerBC(header);
       //       auto triggerOrbit = o2::raw::RDHUtils::getTriggerOrbit(header);
       // use the altro decoder to decode the raw data, and extract the RCU trailer

--- a/Detectors/CPV/calib/CPVCalibWorkflow/src/CPVPedestalCalibDevice.cxx
+++ b/Detectors/CPV/calib/CPVCalibWorkflow/src/CPVPedestalCalibDevice.cxx
@@ -58,7 +58,7 @@ void CPVPedestalCalibDevice::run(o2::framework::ProcessingContext& ctx)
         // if problem in payload, try to continue
         continue;
       }
-      auto& header = rawreader.getRawHeader();
+      // auto& header = rawreader.getRawHeader();
       //       auto triggerBC = o2::raw::RDHUtils::getTriggerBC(header);
       //       auto triggerOrbit = o2::raw::RDHUtils::getTriggerOrbit(header);
       // use the decoder to decode the raw data, and extract signals

--- a/Detectors/CPV/calib/include/CPVCalibration/GainCalibrator.h
+++ b/Detectors/CPV/calib/include/CPVCalibration/GainCalibrator.h
@@ -90,17 +90,19 @@ class GainCalibrator final : public o2::calibration::TimeSlotCalibration<Digit, 
   GainTimeSlot& emplaceNewSlot(bool front, TFType tstart, TFType tend) final;
   void prepareForEnding();
   void setUpdateTFInterval(uint32_t interval) { mUpdateTFInterval = interval; }
+  // read configurable parameters from CPVCalibParams
+  void configParameters();
 
  private:
-  uint32_t mMinEvents;               ///< Minimal number of events to produce calibration
-  uint32_t mMinNChannelsToCalibrate; ///< Minimal number of channels per one calibration
-  float mDesiredLandauMPV;           ///< Desired LandauMPV of the spectrum: gain coeff = mDesiredLandauMPV/(max Ampl of the cluster)
-  float mToleratedChi2PerNDF;        ///< Tolerated max Chi2 of the fit
-  float mMinAllowedCoeff;            ///< Min value of gain coeff at which DesiredLandauMPV is achived
-  float mMaxAllowedCoeff;            ///< Max value of gain coeff at which DesiredLandauMPV is achived
-  float mFitRangeL;                  ///< Fit range of amplitude spectrum (left)
-  float mFitRangeR;                  ///< Fit range of amplitude spectrum (right)
-  uint32_t mUpdateTFInterval = 100;  ///< Update interval (in TF)
+  uint32_t mMinEvents = 1000;                ///< Minimal number of events to produce calibration
+  uint32_t mMinNChannelsToCalibrate = 10000; ///< Minimal number of channels per one calibration
+  float mDesiredLandauMPV = 200.;            ///< Desired LandauMPV of the spectrum: gain coeff = mDesiredLandauMPV/(max Ampl of the cluster)
+  float mToleratedChi2PerNDF = 100.;         ///< Tolerated max Chi2 of the fit
+  float mMinAllowedCoeff = 0.1;              ///< Min value of gain coeff at which DesiredLandauMPV is achived
+  float mMaxAllowedCoeff = 10.;              ///< Max value of gain coeff at which DesiredLandauMPV is achived
+  float mFitRangeL = 10.;                    ///< Fit range of amplitude spectrum (left)
+  float mFitRangeR = 1000.;                  ///< Fit range of amplitude spectrum (right)
+  uint32_t mUpdateTFInterval = 100;          ///< Update interval (in TF)
 
   std::unique_ptr<CalibParams> mPreviousGains = nullptr; ///< previous calibration read from CCDB
   std::unique_ptr<GainCalibData> mPreviousGainCalibData; ///< previous GainCalibData read from CCDB

--- a/Detectors/CPV/calib/include/CPVCalibration/GainCalibrator.h
+++ b/Detectors/CPV/calib/include/CPVCalibration/GainCalibrator.h
@@ -1,0 +1,118 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef CPV_GAIN_CALIBRATOR_H_
+#define CPV_GAIN_CALIBRATOR_H_
+
+#include "DetectorsCalibration/TimeSlotCalibration.h"
+#include "DetectorsCalibration/TimeSlot.h"
+#include "DataFormatsCPV/Digit.h"
+#include "DataFormatsCPV/CalibParams.h"
+#include "CCDB/CcdbObjectInfo.h"
+#include "CPVBase/Geometry.h"
+#include <TH1F.h>
+
+namespace o2
+{
+namespace cpv
+{
+//=============================================================================
+class AmplitudeSpectrum
+{
+ public:
+  static constexpr uint16_t nBins = 1000; // N bins of amplitude histo
+  static constexpr float lRange = 0.;     // Range (left) of amplitude histo
+  static constexpr float rRange = 1000.;  // Range (right) of amplitude histo
+
+  AmplitudeSpectrum();
+  ~AmplitudeSpectrum() = default;
+  AmplitudeSpectrum(const AmplitudeSpectrum&) = default;
+  void reset();
+  AmplitudeSpectrum& operator+=(const AmplitudeSpectrum& rhs);
+  void fill(float amplitude);
+  double getMean() const { return mSumA / mNEntries; }                                                  // return mean of distribution
+  double getRMS() const { return (mSumA2 / mNEntries) - ((mSumA * mSumA) / (mNEntries * mNEntries)); }; // return RMS of distribution
+  uint32_t getNEntries() const { return mNEntries; }
+  const uint32_t* getBinContent() { return mBinContent.data(); } // since C++17 std::array::data is constexpr
+  void fillBinData(TH1F* h);
+
+ private:
+  uint32_t mNEntries;
+  double mSumA;
+  double mSumA2;
+  std::array<uint32_t, nBins> mBinContent; // we are going use ROOT::Fit which works with doubles
+
+  ClassDef(AmplitudeSpectrum, 1);
+}; // end AmplitudeSpectrum
+//=============================================================================
+class GainCalibData
+{
+ public:
+  GainCalibData() = default;
+  ~GainCalibData() = default;
+
+  void fill(const gsl::span<const Digit> data);
+  void merge(const GainCalibData* prev);
+  void print() const;
+
+  std::array<AmplitudeSpectrum, Geometry::kNCHANNELS> mAmplitudeSpectra;
+
+  ClassDef(GainCalibData, 1);
+}; // end GainCalibData
+//=============================================================================
+using GainTimeSlot = o2::calibration::TimeSlot<GainCalibData>;
+class GainCalibrator final : public o2::calibration::TimeSlotCalibration<Digit, GainCalibData>
+{
+ public:
+  GainCalibrator();
+  ~GainCalibrator() final = default;
+  std::vector<o2::ccdb::CcdbObjectInfo>& getCcdbInfoGainsVector() { return mCcdbInfoGainsVec; }
+  const std::vector<CalibParams>& getGainsVector() const { return mGainsVec; }
+  std::vector<o2::ccdb::CcdbObjectInfo>& getCcdbInfoGainCalibDataVector() { return mCcdbInfoGainCalibDataVec; }
+  const std::vector<GainCalibData>& getGainCalibDataVector() const { return mGainCalibDataVec; }
+
+  void setPreviousGains(CalibParams* previousGains) { mPreviousGains.reset(previousGains); }
+  bool isSettedPreviousGains() { return mPreviousGains.get() == nullptr ? false : true; }
+  void setPreviousGainCalibData(GainCalibData* previousGainCalibData) { mPreviousGainCalibData.reset(previousGainCalibData); }
+  bool isSettedPreviousGainCalibData() { return mPreviousGainCalibData.get() == nullptr ? false : true; }
+
+  bool hasEnoughData(const GainTimeSlot& slot) const final;
+  void initOutput() final;
+  void finalizeSlot(GainTimeSlot& slot) final;
+  GainTimeSlot& emplaceNewSlot(bool front, TFType tstart, TFType tend) final;
+  void prepareForEnding();
+  void setUpdateTFInterval(uint32_t interval) { mUpdateTFInterval = interval; }
+
+ private:
+  uint32_t mMinEvents;               ///< Minimal number of events to produce calibration
+  uint32_t mMinNChannelsToCalibrate; ///< Minimal number of channels per one calibration
+  float mDesiredLandauMPV;           ///< Desired LandauMPV of the spectrum: gain coeff = mDesiredLandauMPV/(max Ampl of the cluster)
+  float mToleratedChi2PerNDF;        ///< Tolerated max Chi2 of the fit
+  float mMinAllowedCoeff;            ///< Min value of gain coeff at which DesiredLandauMPV is achived
+  float mMaxAllowedCoeff;            ///< Max value of gain coeff at which DesiredLandauMPV is achived
+  float mFitRangeL;                  ///< Fit range of amplitude spectrum (left)
+  float mFitRangeR;                  ///< Fit range of amplitude spectrum (right)
+  uint32_t mUpdateTFInterval = 100;  ///< Update interval (in TF)
+
+  std::unique_ptr<CalibParams> mPreviousGains = nullptr; ///< previous calibration read from CCDB
+  std::unique_ptr<GainCalibData> mPreviousGainCalibData; ///< previous GainCalibData read from CCDB
+  std::vector<o2::ccdb::CcdbObjectInfo> mCcdbInfoGainsVec;
+  std::vector<o2::ccdb::CcdbObjectInfo> mCcdbInfoGainCalibDataVec;
+  std::vector<CalibParams> mGainsVec;
+  std::vector<GainCalibData> mGainCalibDataVec;
+
+  ClassDef(GainCalibrator, 1);
+}; // end GainCalibrator
+
+} // namespace cpv
+} // namespace o2
+
+#endif /* CPV_GAIN_CALIBRATOR_H_ */

--- a/Detectors/CPV/calib/include/CPVCalibration/NoiseCalibrator.h
+++ b/Detectors/CPV/calib/include/CPVCalibration/NoiseCalibrator.h
@@ -25,11 +25,11 @@ namespace cpv
 //=========================================================================
 using Digit = o2::cpv::Digit;
 struct NoiseCalibData {
-  int mNEvents = 0;
-  int mNoiseThreshold = 10; //ADC counts threshold
+  uint32_t mNEvents = 0;
+  float mNoiseThreshold = 10.; // ADC counts threshold
   std::vector<int> mOccupancyMap;
 
-  NoiseCalibData();
+  NoiseCalibData(float noiseThreshold = 10.);
   ~NoiseCalibData() = default;
 
   void fill(const gsl::span<const o2::cpv::Digit> data);
@@ -63,15 +63,17 @@ class NoiseCalibrator final : public o2::calibration::TimeSlotCalibration<o2::cp
   void initOutput() final;
   void finalizeSlot(NoiseTimeSlot& slot) final;
   NoiseTimeSlot& emplaceNewSlot(bool front, TFType tstart, TFType tend) final;
+  void configParameters();
 
  private:
   std::unique_ptr<std::vector<float>> mPedEfficiencies = nullptr;
   std::unique_ptr<std::vector<int>> mDeadChannels = nullptr;
   std::unique_ptr<std::vector<int>> mHighPedChannels = nullptr;
-  int mMinEvents = 100;
+  uint32_t mMinEvents = 100;
   float mNoiseFrequencyCriteria = 0.5; // how often channel should appear to be considered as noisy
   float mToleratedChannelEfficiencyLow = 0.9;
   float mToleratedChannelEfficiencyHigh = 1.01;
+  float mNoiseThreshold = 10.;
   std::vector<o2::ccdb::CcdbObjectInfo> mCcdbInfoBadChannelMapVec;
   std::vector<o2::cpv::BadChannelMap> mBadChannelMapVec;
 

--- a/Detectors/CPV/calib/include/CPVCalibration/PedestalCalibrator.h
+++ b/Detectors/CPV/calib/include/CPVCalibration/PedestalCalibrator.h
@@ -29,7 +29,7 @@ using Digit = o2::cpv::Digit;
 class PedestalSpectrum
 {
  public:
-  PedestalSpectrum();
+  PedestalSpectrum(uint16_t toleratedGapWidth = 5, float nSigmasZS = 3., float suspiciousPedestalRMS = 20.);
   ~PedestalSpectrum() = default;
   PedestalSpectrum& operator+=(const PedestalSpectrum& rhs);
   void fill(uint16_t amplitude);
@@ -45,9 +45,9 @@ class PedestalSpectrum
   uint32_t mNEntries = 0;
   uint16_t mNPeaks = 0;
   bool mIsAnalyzed = false;
-  uint16_t mToleratedGapWidth = 5;
-  float mZSnSigmas = 3.;
-  float mSuspiciousPedestalRMS = 20.;
+  uint16_t mToleratedGapWidth;
+  float mZSnSigmas;
+  float mSuspiciousPedestalRMS;
   float mPedestalValue;
   float mPedestalRMS;
   std::vector<float> mMeanOfPeaks, mRMSOfPeaks;
@@ -60,14 +60,14 @@ struct PedestalCalibData {
   int mNEvents = 0;
   std::vector<PedestalSpectrum> mPedestalSpectra;
 
-  PedestalCalibData();
+  PedestalCalibData(uint16_t toleratedGapWidth = 5, float nSigmasZS = 3., float suspiciousPedestalRMS = 20.);
   ~PedestalCalibData() = default;
 
   void fill(const gsl::span<const o2::cpv::Digit> data);
   void merge(const PedestalCalibData* prev);
   void print();
 
-}; //end PedestalCalibData
+}; // end PedestalCalibData
 
 using PedestalTimeSlot = o2::calibration::TimeSlot<o2::cpv::PedestalCalibData>;
 //===================================================================
@@ -95,10 +95,13 @@ class PedestalCalibrator final : public o2::calibration::TimeSlotCalibration<o2:
   void initOutput() final;
   void finalizeSlot(PedestalTimeSlot& slot) final;
   PedestalTimeSlot& emplaceNewSlot(bool front, TFType tstart, TFType tend) final;
+  void configParameters();
 
  private:
-  int mMinEvents = 100;
+  uint32_t mMinEvents = 100;
   float mZSnSigmas = 3.;
+  uint16_t mToleratedGapWidth = 5;
+  float mSuspiciousPedestalRMS = 20.;
   std::vector<o2::ccdb::CcdbObjectInfo> mCcdbInfoPedestalsVec;
   std::vector<o2::cpv::Pedestals> mPedestalsVec;
   std::vector<o2::ccdb::CcdbObjectInfo> mCcdbInfoThresholdsFEEVec;
@@ -110,7 +113,7 @@ class PedestalCalibrator final : public o2::calibration::TimeSlotCalibration<o2:
   std::vector<o2::ccdb::CcdbObjectInfo> mCcdbInfoPedEfficienciesVec;
   std::vector<std::vector<float>> mPedEfficienciesVec;
 };
-} //end namespace cpv
-} //end namespace o2
+} // end namespace cpv
+} // end namespace o2
 
 #endif /* CPV_PEDESTAL_CALIBRATIOR_H_ */

--- a/Detectors/CPV/calib/macros/readCalibParamsFromCCDB.C
+++ b/Detectors/CPV/calib/macros/readCalibParamsFromCCDB.C
@@ -1,0 +1,49 @@
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include "CCDB/BasicCCDBManager.h"
+#include "TH2F.h"
+#include "TCanvas.h"
+#include "CCDB/CCDBTimeStampUtils.h"
+#include "DataFormatsCPV/CalibParams.h"
+#include "CPVBase/Geometry.h"
+#include <iostream>
+#endif
+
+o2::cpv::CalibParams* readCalibParamsFromCCDB(long timeStamp = 0, const char* ccdbURI = "http://ccdb-test.cern.ch:8080")
+{
+  auto& ccdbMgr = o2::ccdb::BasicCCDBManager::instance();
+  ccdbMgr.setURL(ccdbURI);
+  if (!ccdbMgr.isHostReachable()) {
+    std::cerr << ccdbURI << " is not reachable!" << std::endl;
+    return 0x0;
+  }
+  if (timeStamp == 0) {
+    timeStamp = o2::ccdb::getCurrentTimestamp();
+  }
+  ccdbMgr.setTimestamp(timeStamp);
+  o2::cpv::CalibParams* gains = ccdbMgr.get<o2::cpv::CalibParams>("CPV/Calib/Gains");
+  if (!gains) {
+    std::cerr << "Cannot get gains from CCDB/CPV/Calib/Gains!" << std::endl;
+    return 0x0;
+  }
+
+  TH2F* hGains[3];
+  o2::cpv::Geometry geo;
+  short relId[3];
+  TCanvas* can = new TCanvas("Modules", "Modules");
+  can->Divide(3, 1);
+  for (int iMod = 0; iMod < 3; iMod++) {
+    hGains[iMod] = new TH2F(Form("hGainsM%d", iMod + 2),
+                            Form("Gains in M%d", iMod + 2),
+                            128, 0., 128., 60, 0., 60);
+    for (int iCh = iMod * 7680; iCh < (iMod + 1) * 7680; iCh++) {
+      geo.absToRelNumbering(iCh, relId);
+      hGains[iMod]->SetBinContent(relId[1] + 1, relId[2] + 1, gains->getGain(iCh));
+    }
+    // TCanvas* can = new TCanvas(Form("canM%d", iMod + 2), Form("module M%d", iMod + 2), 10 * iMod, 0, 1000 + 10 * iMod, 1000);
+    can->cd(iMod + 1);
+    hGains[iMod]->GetXaxis()->SetTitle("X pad");
+    hGains[iMod]->GetYaxis()->SetTitle("Z pad");
+    hGains[iMod]->Draw("colz");
+  }
+  return gains;
+}

--- a/Detectors/CPV/calib/macros/readGainCalibDataFromCCDB.C
+++ b/Detectors/CPV/calib/macros/readGainCalibDataFromCCDB.C
@@ -1,0 +1,60 @@
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include "CCDB/BasicCCDBManager.h"
+#include "TH2F.h"
+#include "TCanvas.h"
+#include "CCDB/CCDBTimeStampUtils.h"
+#include "CPVCalibration/GainCalibrator.h"
+#include "CPVBase/Geometry.h"
+#include <iostream>
+#endif
+
+o2::cpv::GainCalibData* readGainCalibDataFromCCDB(long timeStamp = 0, const char* ccdbURI = "http://ccdb-test.cern.ch:8080")
+{
+  auto& ccdbMgr = o2::ccdb::BasicCCDBManager::instance();
+  ccdbMgr.setURL(ccdbURI);
+  if (!ccdbMgr.isHostReachable()) {
+    std::cerr << ccdbURI << " is not reachable!" << std::endl;
+    return 0x0;
+  }
+  if (timeStamp == 0) {
+    timeStamp = o2::ccdb::getCurrentTimestamp();
+  }
+  ccdbMgr.setTimestamp(timeStamp);
+  o2::cpv::GainCalibData* gcd = ccdbMgr.get<o2::cpv::GainCalibData>("CPV/PhysicsRun/GainCalibData");
+  if (!gcd) {
+    std::cerr << "Cannot get GainCalibData from CPV/PhysicsRun/GainCalibData!" << std::endl;
+    return 0x0;
+  }
+  gcd->print();
+
+  cout << "I passed print" << endl;
+  TH2F *hGCDEntries[3], *hGCDMean[3];
+  o2::cpv::Geometry geo;
+  short relId[3];
+  TCanvas* can = new TCanvas("Modules", "Modules");
+  can->Divide(3, 2);
+  for (int iMod = 0; iMod < 3; iMod++) {
+    hGCDEntries[iMod] = new TH2F(Form("hGCDEntriesM%d", iMod + 2),
+                                 Form("GainCalibData entries in M%d", iMod + 2),
+                                 128, 0., 128., 60, 0., 60);
+    hGCDMean[iMod] = new TH2F(Form("hGCDMeanM%d", iMod + 2),
+                              Form("GainCalibData means in M%d", iMod + 2),
+                              128, 0., 128., 60, 0., 60);
+    for (int iCh = iMod * 7680; iCh < (iMod + 1) * 7680; iCh++) {
+      geo.absToRelNumbering(iCh, relId);
+      hGCDEntries[iMod]->SetBinContent(relId[1] + 1, relId[2] + 1, gcd->mAmplitudeSpectra[iCh].getNEntries());
+      if (gcd->mAmplitudeSpectra[iCh].getNEntries() > 0) {
+        hGCDMean[iMod]->SetBinContent(relId[1] + 1, relId[2] + 1, gcd->mAmplitudeSpectra[iCh].getMean());
+      }
+    }
+    can->cd(iMod + 1);
+    hGCDEntries[iMod]->GetXaxis()->SetTitle("X pad");
+    hGCDEntries[iMod]->GetYaxis()->SetTitle("Z pad");
+    hGCDEntries[iMod]->Draw("colz");
+    can->cd(iMod + 4);
+    hGCDMean[iMod]->GetXaxis()->SetTitle("X pad");
+    hGCDMean[iMod]->GetYaxis()->SetTitle("Z pad");
+    hGCDMean[iMod]->Draw("colz");
+  }
+  return gcd;
+}

--- a/Detectors/CPV/calib/src/CPVCalibrationLinkDef.h
+++ b/Detectors/CPV/calib/src/CPVCalibrationLinkDef.h
@@ -26,4 +26,10 @@
 #pragma link C++ class o2::calibration::TimeSlotCalibration < o2::cpv::Digit, o2::cpv::NoiseCalibData> + ;
 #pragma link C++ class o2::cpv::NoiseCalibrator + ;
 
+#pragma link C++ class o2::cpv::AmplitudeSpectrum + ;
+#pragma link C++ class o2::cpv::GainCalibData + ;
+#pragma link C++ class o2::calibration::TimeSlot < o2::cpv::GainCalibData> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::cpv::Digit, o2::cpv::GainCalibData> + ;
+#pragma link C++ class o2::cpv::GainCalibrator + ;
+
 #endif

--- a/Detectors/CPV/calib/src/GainCalibrator.cxx
+++ b/Detectors/CPV/calib/src/GainCalibrator.cxx
@@ -114,15 +114,19 @@ GainCalibrator::GainCalibrator()
 {
   LOG(info) << "GainCalibrator::GainCalibrator() : "
             << "Gain calibrator created!";
+}
+//_____________________________________________________________________________
+void GainCalibrator::configParameters()
+{
   auto& cpvParams = o2::cpv::CPVCalibParams::Instance();
-  mMinEvents = cpvParams.mGainMinEvents;
-  mMinNChannelsToCalibrate = cpvParams.mGainMinNChannelsToCalibrate;
-  mDesiredLandauMPV = cpvParams.mGainDesiredLandauMPV;
-  mToleratedChi2PerNDF = cpvParams.mGainToleratedChi2PerNDF;
-  mMinAllowedCoeff = cpvParams.mGainMinAllowedCoeff;
-  mMaxAllowedCoeff = cpvParams.mGainMaxAllowedCoeff;
-  mFitRangeL = cpvParams.mGainFitRangeL;
-  mFitRangeR = cpvParams.mGainFitRangeR;
+  mMinEvents = cpvParams.gainMinEvents;
+  mMinNChannelsToCalibrate = cpvParams.gainMinNChannelsToCalibrate;
+  mDesiredLandauMPV = cpvParams.gainDesiredLandauMPV;
+  mToleratedChi2PerNDF = cpvParams.gainToleratedChi2PerNDF;
+  mMinAllowedCoeff = cpvParams.gainMinAllowedCoeff;
+  mMaxAllowedCoeff = cpvParams.gainMaxAllowedCoeff;
+  mFitRangeL = cpvParams.gainFitRangeL;
+  mFitRangeR = cpvParams.gainFitRangeR;
   // adjust fit ranges to descrete binned values
   if (mFitRangeL < AmplitudeSpectrum::lRange) {
     mFitRangeL = AmplitudeSpectrum::lRange;
@@ -133,7 +137,8 @@ GainCalibrator::GainCalibrator()
   double binWidth = (AmplitudeSpectrum::rRange - AmplitudeSpectrum::lRange) / AmplitudeSpectrum::nBins;
   mFitRangeL = AmplitudeSpectrum::lRange + std::floor((mFitRangeL - AmplitudeSpectrum::lRange) / binWidth) * binWidth;
   mFitRangeR = AmplitudeSpectrum::lRange + std::floor((mFitRangeR - AmplitudeSpectrum::lRange) / binWidth) * binWidth;
-  LOG(info) << "Parameters used: ";
+
+  LOG(info) << "GainCalibrator::configParameters() : Parameters used: ";
   LOG(info) << "mMinEvents = " << mMinEvents;
   LOG(info) << "mDesiredLandauMPV = " << mDesiredLandauMPV;
   LOG(info) << "mToleratedChi2PerNDF = " << mToleratedChi2PerNDF;

--- a/Detectors/CPV/calib/src/GainCalibrator.cxx
+++ b/Detectors/CPV/calib/src/GainCalibrator.cxx
@@ -1,0 +1,281 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/Logger.h"
+#include "CPVCalibration/GainCalibrator.h"
+#include "CommonUtils/MemFileHelper.h"
+#include "DetectorsCalibration/Utils.h"
+#include "CPVBase/Geometry.h"
+#include "CPVBase/CPVCalibParams.h"
+#include "CCDB/CcdbApi.h"
+#include "CCDB/CCDBTimeStampUtils.h"
+#include <TF1.h>
+#include <TFitResult.h>
+#include "MathUtils/fit.h"
+
+namespace o2
+{
+namespace cpv
+{
+using GainTimeSlot = o2::calibration::TimeSlot<GainCalibData>;
+//_____________________________________________________________________________
+// AmplitudeSpectrum
+//_____________________________________________________________________________
+AmplitudeSpectrum::AmplitudeSpectrum() : mNEntries(0),
+                                         mSumA(0.),
+                                         mSumA2(0.)
+{
+  mBinContent.fill(0);
+}
+//_____________________________________________________________________________
+void AmplitudeSpectrum::reset()
+{
+  mNEntries = 0;
+  mSumA = 0.;
+  mSumA2 = 0.;
+  mBinContent.fill(0);
+}
+//_____________________________________________________________________________
+AmplitudeSpectrum& AmplitudeSpectrum::operator+=(const AmplitudeSpectrum& rhs)
+{
+  mSumA += rhs.mSumA;
+  mSumA2 += rhs.mSumA2;
+  mNEntries += rhs.mNEntries;
+  for (int i = 0; i < nBins; i++) {
+    mBinContent[i] += rhs.mBinContent[i];
+  }
+  return *this;
+}
+//_____________________________________________________________________________
+void AmplitudeSpectrum::fill(float amplitude)
+{
+  if ((lRange <= amplitude) && (amplitude < rRange)) {
+    int bin = (amplitude - lRange) / nBins;
+    mBinContent[bin]++;
+    mNEntries++;
+    mSumA += amplitude;
+    mSumA2 += amplitude * amplitude;
+  }
+}
+//_____________________________________________________________________________
+void AmplitudeSpectrum::fillBinData(TH1F* h)
+{
+  for (uint16_t i = 0; i < nBins; i++) {
+    h->SetBinContent(i + 1, float(mBinContent[i]));
+    h->SetBinError(i + 1, sqrt(float(mBinContent[i])));
+  }
+}
+//_____________________________________________________________________________
+// GainCalibData
+//_____________________________________________________________________________
+void GainCalibData::fill(const gsl::span<const Digit> digits)
+{
+  for (auto& dig : digits) {
+    mAmplitudeSpectra[dig.getAbsId()].fill(dig.getAmplitude());
+  }
+}
+//_____________________________________________________________________________
+void GainCalibData::merge(const GainCalibData* prev)
+{
+  for (int i = 0; i < Geometry::kNCHANNELS; i++) {
+    mAmplitudeSpectra[i] += prev->mAmplitudeSpectra[i];
+  }
+  LOG(info) << "Merged GainCalibData with previous one.";
+  print();
+}
+//_____________________________________________________________________________
+void GainCalibData::print() const
+{
+  int nNonEmptySpectra = 0;
+  uint64_t nTotalEntries = 0;
+  for (int i = 0; i < Geometry::kNCHANNELS; i++) {
+    if (mAmplitudeSpectra[i].getNEntries()) {
+      nNonEmptySpectra++;
+      nTotalEntries += mAmplitudeSpectra[i].getNEntries();
+    }
+  }
+  LOG(info) << "GainCalibData::print() : "
+            << "I have " << nNonEmptySpectra
+            << " non-empty amplitude spectra with " << nTotalEntries
+            << " entries total ranged in (" << AmplitudeSpectrum::lRange << "; " << AmplitudeSpectrum::rRange << ").";
+}
+//_____________________________________________________________________________
+// GainCalibrator
+//_____________________________________________________________________________
+GainCalibrator::GainCalibrator()
+{
+  LOG(info) << "GainCalibrator::GainCalibrator() : "
+            << "Gain calibrator created!";
+  auto& cpvParams = o2::cpv::CPVCalibParams::Instance();
+  mMinEvents = cpvParams.mGainMinEvents;
+  mMinNChannelsToCalibrate = cpvParams.mGainMinNChannelsToCalibrate;
+  mDesiredLandauMPV = cpvParams.mGainDesiredLandauMPV;
+  mToleratedChi2PerNDF = cpvParams.mGainToleratedChi2PerNDF;
+  mMinAllowedCoeff = cpvParams.mGainMinAllowedCoeff;
+  mMaxAllowedCoeff = cpvParams.mGainMaxAllowedCoeff;
+  mFitRangeL = cpvParams.mGainFitRangeL;
+  mFitRangeR = cpvParams.mGainFitRangeR;
+  // adjust fit ranges to descrete binned values
+  if (mFitRangeL < AmplitudeSpectrum::lRange) {
+    mFitRangeL = AmplitudeSpectrum::lRange;
+  }
+  if (mFitRangeR > AmplitudeSpectrum::rRange) {
+    mFitRangeR = AmplitudeSpectrum::rRange;
+  }
+  double binWidth = (AmplitudeSpectrum::rRange - AmplitudeSpectrum::lRange) / AmplitudeSpectrum::nBins;
+  mFitRangeL = AmplitudeSpectrum::lRange + std::floor((mFitRangeL - AmplitudeSpectrum::lRange) / binWidth) * binWidth;
+  mFitRangeR = AmplitudeSpectrum::lRange + std::floor((mFitRangeR - AmplitudeSpectrum::lRange) / binWidth) * binWidth;
+  LOG(info) << "Parameters used: ";
+  LOG(info) << "mMinEvents = " << mMinEvents;
+  LOG(info) << "mDesiredLandauMPV = " << mDesiredLandauMPV;
+  LOG(info) << "mToleratedChi2PerNDF = " << mToleratedChi2PerNDF;
+  LOG(info) << "mMinAllowedCoeff = " << mMinAllowedCoeff;
+  LOG(info) << "mMaxAllowedCoeff = " << mMaxAllowedCoeff;
+  LOG(info) << "mFitRangeL = " << mFitRangeL;
+  LOG(info) << "mFitRangeR = " << mFitRangeR;
+}
+//_____________________________________________________________________________
+void GainCalibrator::initOutput()
+{
+  LOG(info) << "GainCalibrator::initOutput() : output vectors cleared";
+  mCcdbInfoGainsVec.clear();
+  mGainsVec.clear();
+  mCcdbInfoGainCalibDataVec.clear();
+  mGainCalibDataVec.clear();
+}
+//_____________________________________________________________________________
+void GainCalibrator::finalizeSlot(GainTimeSlot& slot)
+{
+  GainCalibData* calibData = slot.getContainer();
+  LOG(info) << "GainCalibrator::finalizeSlot() : finalizing slot "
+            << slot.getTFStart() << " <= TF <= " << slot.getTFEnd();
+  slot.getContainer()->print();
+  CalibParams* newGains = new CalibParams(1);
+
+  // estimate new gains by fitting amplitude spectra
+  int nChannelsCalibrated = 0, nChannelsTooSmallCoeff = 0, nChannelsTooLargeCoeff = 0;
+  TF1* fLandau = new TF1("fLandau", "landau", mFitRangeL, mFitRangeR);
+  fLandau->SetParLimits(0, 0., 1.E6);
+  fLandau->SetParLimits(1, mDesiredLandauMPV / mMaxAllowedCoeff, mDesiredLandauMPV / mMinAllowedCoeff);
+  fLandau->SetParLimits(1, 0., 1.E3);
+  TH1F h("histoCPVMaxAmplSpectrum", "", AmplitudeSpectrum::nBins, AmplitudeSpectrum::lRange, AmplitudeSpectrum::rRange);
+  // double binWidth = (AmplitudeSpectrum::rRange - AmplitudeSpectrum::lRange) / AmplitudeSpectrum::nBins;
+  // size_t nBinsToFit = (mFitRangeR - mFitRangeL) / binWidth;
+  // uint32_t xMin = (mFitRangeL - AmplitudeSpectrum::lRange) / binWidth;
+  // uint32_t xMax = (mFitRangeR - AmplitudeSpectrum::lRange) / binWidth;
+  int nCalibratedChannels = 0;
+  for (int i = 0; i < Geometry::kNCHANNELS; i++) {
+    // print some info
+    if ((i % 500) == 0) {
+      LOG(info) << "GainCalibrator::finalizeSlot() : checking channel " << i;
+    }
+    if (slot.getContainer()->mAmplitudeSpectra[i].getNEntries() > mMinEvents) { // we are ready to fit
+      h.Reset();
+      slot.getContainer()->mAmplitudeSpectra[i].fillBinData(&h);
+      // set some starting values
+      double mean = slot.getContainer()->mAmplitudeSpectra[i].getMean();
+      double rms = slot.getContainer()->mAmplitudeSpectra[i].getRMS();
+      double startingValue = slot.getContainer()->mAmplitudeSpectra[i].getBinContent()[(int)mean];
+      fLandau->SetParameters(startingValue, mean, rms);
+      auto fitResult = h.Fit(fLandau, "SQL0N", "", mFitRangeL, mFitRangeR);
+      // auto fitResult = o2::math_utils::fit<uint32_t>(nBinsToFit, &(slot.getContainer()->mAmplitudeSpectra[i].getBinContent()[xMin]), xMin, xMax, *fLandau);
+      if (fitResult->Chi2() / fitResult->Ndf() > mToleratedChi2PerNDF) {
+        //  in case of bad fit -> do something sofisticated. but what?
+        // continue;
+        LOG(info) << "GainCalibrator::finalizeSlot() : bad chi2/ndf in fit of spectrum in channel " << i;
+        fitResult->Print("V");
+      }
+      // calib coeffs are defined as mDesiredLandauMPV/actualMPV*previousCoeff
+      float coeff = mDesiredLandauMPV / fLandau->GetParameter(1) * mPreviousGains.get()->getGain(i);
+      slot.getContainer()->mAmplitudeSpectra[i].reset();
+      if (mMinAllowedCoeff <= coeff && coeff <= mMaxAllowedCoeff) {
+        newGains->setGain(i, coeff);
+        nChannelsCalibrated++;
+      } else if (mMinAllowedCoeff >= coeff) {
+        newGains->setGain(i, mMinAllowedCoeff);
+      } else {
+        newGains->setGain(i, mMaxAllowedCoeff);
+      }
+    }
+  }
+  delete fLandau;
+  LOG(info) << "GainCalibrator::finalizeSlot() : succesfully calibrated " << nChannelsCalibrated << "channels";
+
+  // prepare new ccdb entries for sending
+  mGainsVec.push_back(*newGains);
+  // metadata for o2::cpv::CalibParams
+  std::map<std::string, std::string> metaData;
+  auto className = o2::utils::MemFileHelper::getClassName(newGains);
+  auto fileName = o2::ccdb::CcdbApi::generateFileName(className);
+  auto timeStamp = o2::ccdb::getCurrentTimestamp();
+  mCcdbInfoGainsVec.emplace_back("CPV/Calib/Gains", className, fileName, metaData, timeStamp, timeStamp + 31536000000); // one year validity time (in milliseconds!)
+
+  mPreviousGainCalibData.reset(new GainCalibData(*slot.getContainer())); // Slot is going to be closed and removed after finalisation -> save calib data for next Slot
+  mPreviousGains.reset(newGains);                                        // save new obtained gains as previous ones
+}
+//_____________________________________________________________________________
+void GainCalibrator::prepareForEnding()
+{
+  auto& cont = getSlots();
+  if (cont.empty()) {
+    LOG(warning) << "GainCalibrator::prepareForEnding() : have no TimeSlots to end. Sorry about that.";
+    return;
+  }
+  // we assume only one single slot
+  auto& slot = cont.back();
+  LOG(info) << "GainCalibrator::prepareForEnding() : sending GainCalibData from slot("
+            << slot.getTFStart() << " <= TF <= " << slot.getTFEnd() << ") to CCDB";
+  slot.getContainer()->print();
+  // metadata for o2::cpv::GainCalibData
+  std::map<std::string, std::string> metaData;
+  mGainCalibDataVec.push_back(*(slot.getContainer()));
+  auto className = o2::utils::MemFileHelper::getClassName(*(slot.getContainer()));
+  auto fileName = o2::ccdb::CcdbApi::generateFileName(className);
+  auto timeStamp = o2::ccdb::getCurrentTimestamp();
+  mCcdbInfoGainCalibDataVec.emplace_back("CPV/PhysicsRun/GainCalibData", className, fileName, metaData, timeStamp, timeStamp + 604800000); // 1 week validity time (in milliseconds!)
+}
+//_____________________________________________________________________________
+GainTimeSlot& GainCalibrator::emplaceNewSlot(bool front, TFType tstart, TFType tend)
+{
+  LOG(info) << "GainCalibrator::emplaceNewSlot() : emplacing new Slot from tstart = " << tstart << " to " << tend;
+  auto& cont = getSlots();
+  auto& slot = front ? cont.emplace_front(tstart, tend) : cont.emplace_back(tstart, tend);
+  slot.setContainer(std::make_unique<GainCalibData>());
+  slot.getContainer()->merge(mPreviousGainCalibData.get());
+  return slot;
+}
+//_____________________________________________________________________________
+bool GainCalibrator::hasEnoughData(const GainTimeSlot& slot) const
+{
+  if (mCurrentTFInfo.tfCounter % mUpdateTFInterval != 0) {
+    return false; // check once per N TFs if enough statistics
+  }
+  int nChannelsToCalibrate = 0;
+  for (int i = 0; i < Geometry::kNCHANNELS; i++) {
+    if (slot.getContainer()->mAmplitudeSpectra[i].getNEntries() > mMinEvents) {
+      nChannelsToCalibrate++;
+    }
+  }
+  if (nChannelsToCalibrate >= mMinNChannelsToCalibrate) {
+    LOG(info) << "GainCalibrator::hasEnoughtData() : slot "
+              << slot.getTFStart() << " <= TF <= " << slot.getTFEnd() << " is ready for calibration ("
+              << nChannelsToCalibrate << " are going to be calibrated).";
+    return true;
+  } else {
+    LOG(info) << "GainCalibrator::hasEnoughtData() : slot "
+              << slot.getTFStart() << " <= TF <= " << slot.getTFEnd() << " is not ready for calibration ("
+              << nChannelsToCalibrate << " channels to be calibrated wich is not enough).";
+  }
+  return false;
+}
+//_____________________________________________________________________________
+} // end namespace cpv
+} // end namespace o2

--- a/Detectors/CPV/calib/src/NoiseCalibrator.cxx
+++ b/Detectors/CPV/calib/src/NoiseCalibrator.cxx
@@ -14,7 +14,7 @@
 #include "CommonUtils/MemFileHelper.h"
 #include "DetectorsCalibration/Utils.h"
 #include "CPVBase/Geometry.h"
-#include "CPVBase/CPVSimParams.h"
+#include "CPVBase/CPVCalibParams.h"
 #include "CCDB/CcdbApi.h"
 #include "CCDB/CCDBTimeStampUtils.h"
 
@@ -27,8 +27,8 @@ using NoiseTimeSlot = o2::calibration::TimeSlot<o2::cpv::NoiseCalibData>;
 //_____________________________________________________________________________
 NoiseCalibData::NoiseCalibData()
 {
-  auto& cpvParams = o2::cpv::CPVSimParams::Instance();
-  mNoiseThreshold = cpvParams.mNoiseClbThreshold;
+  auto& cpvParams = CPVCalibParams::Instance();
+  mNoiseThreshold = cpvParams.mNoiseThreshold;
   for (int i = 0; i < Geometry::kNCHANNELS; i++) {
     mOccupancyMap.push_back(0);
   }
@@ -64,11 +64,11 @@ NoiseCalibrator::NoiseCalibrator()
 {
   LOG(info) << "NoiseCalibrator::NoiseCalibrator() : "
             << "Noise calibrator created!";
-  auto& cpvParams = o2::cpv::CPVSimParams::Instance();
-  mMinEvents = cpvParams.mNoiseClbMinEvents;
-  mToleratedChannelEfficiencyLow = cpvParams.mNoiseClbToleratedChannelEfficiencyLow;
-  mToleratedChannelEfficiencyHigh = cpvParams.mNoiseClbToleratedChannelEfficiencyHigh;
-  mNoiseFrequencyCriteria = cpvParams.mNoiseClbFrequencyCriteria;
+  auto& cpvParams = CPVCalibParams::Instance();
+  mMinEvents = cpvParams.mNoiseMinEvents;
+  mToleratedChannelEfficiencyLow = cpvParams.mNoiseToleratedChannelEfficiencyLow;
+  mToleratedChannelEfficiencyHigh = cpvParams.mNoiseToleratedChannelEfficiencyHigh;
+  mNoiseFrequencyCriteria = cpvParams.mNoiseFrequencyCriteria;
 }
 //_____________________________________________________________________________
 void NoiseCalibrator::initOutput()

--- a/Detectors/CPV/calib/src/NoiseCalibrator.cxx
+++ b/Detectors/CPV/calib/src/NoiseCalibrator.cxx
@@ -25,10 +25,9 @@ namespace cpv
 using NoiseTimeSlot = o2::calibration::TimeSlot<o2::cpv::NoiseCalibData>;
 // NoiseCalibData
 //_____________________________________________________________________________
-NoiseCalibData::NoiseCalibData()
+NoiseCalibData::NoiseCalibData(float noiseThreshold)
 {
-  auto& cpvParams = CPVCalibParams::Instance();
-  mNoiseThreshold = cpvParams.mNoiseThreshold;
+  mNoiseThreshold = noiseThreshold;
   for (int i = 0; i < Geometry::kNCHANNELS; i++) {
     mOccupancyMap.push_back(0);
   }
@@ -64,11 +63,22 @@ NoiseCalibrator::NoiseCalibrator()
 {
   LOG(info) << "NoiseCalibrator::NoiseCalibrator() : "
             << "Noise calibrator created!";
+}
+//_____________________________________________________________________________
+void NoiseCalibrator::configParameters()
+{
   auto& cpvParams = CPVCalibParams::Instance();
-  mMinEvents = cpvParams.mNoiseMinEvents;
-  mToleratedChannelEfficiencyLow = cpvParams.mNoiseToleratedChannelEfficiencyLow;
-  mToleratedChannelEfficiencyHigh = cpvParams.mNoiseToleratedChannelEfficiencyHigh;
-  mNoiseFrequencyCriteria = cpvParams.mNoiseFrequencyCriteria;
+  mMinEvents = cpvParams.noiseMinEvents;
+  mToleratedChannelEfficiencyLow = cpvParams.noiseToleratedChannelEfficiencyLow;
+  mToleratedChannelEfficiencyHigh = cpvParams.noiseToleratedChannelEfficiencyHigh;
+  mNoiseFrequencyCriteria = cpvParams.noiseFrequencyCriteria;
+  mNoiseThreshold = cpvParams.noiseThreshold;
+  LOG(info) << "NoiseCalibrator::configParameters() : following parameters configured:";
+  LOG(info) << "mMinEvents = " << mMinEvents;
+  LOG(info) << "mToleratedChannelEfficiencyLow = " << mToleratedChannelEfficiencyLow;
+  LOG(info) << "mToleratedChannelEfficiencyHigh = " << mToleratedChannelEfficiencyHigh;
+  LOG(info) << "mNoiseFrequencyCriteria = " << mNoiseFrequencyCriteria;
+  LOG(info) << "mNoiseThreshold = " << mNoiseThreshold;
 }
 //_____________________________________________________________________________
 void NoiseCalibrator::initOutput()
@@ -142,7 +152,7 @@ NoiseTimeSlot& NoiseCalibrator::emplaceNewSlot(bool front, TFType tstart, TFType
   LOG(info) << "NoiseCalibrator::emplaceNewSlot() : emplacing new Slot from tstart = " << tstart << " to " << tend;
   auto& cont = getSlots();
   auto& slot = front ? cont.emplace_front(tstart, tend) : cont.emplace_back(tstart, tend);
-  slot.setContainer(std::make_unique<NoiseCalibData>());
+  slot.setContainer(std::make_unique<NoiseCalibData>(mNoiseThreshold));
   return slot;
 }
 //_____________________________________________________________________________

--- a/Detectors/CPV/calib/src/PedestalCalibrator.cxx
+++ b/Detectors/CPV/calib/src/PedestalCalibrator.cxx
@@ -14,7 +14,7 @@
 #include "CommonUtils/MemFileHelper.h"
 #include "DetectorsCalibration/Utils.h"
 #include "CPVBase/Geometry.h"
-#include "CPVBase/CPVSimParams.h"
+#include "CPVBase/CPVCalibParams.h"
 #include "CCDB/CcdbApi.h"
 #include "CCDB/CCDBTimeStampUtils.h"
 
@@ -26,10 +26,10 @@ namespace cpv
 //___________________________________________________________________
 PedestalSpectrum::PedestalSpectrum()
 {
-  auto& cpvParams = o2::cpv::CPVSimParams::Instance();
-  mToleratedGapWidth = cpvParams.mPedClbToleratedGapWidth;
-  mZSnSigmas = cpvParams.mZSnSigmas;
-  mSuspiciousPedestalRMS = cpvParams.mPedClbSuspiciousPedestalRMS;
+  auto& cpvParams = CPVCalibParams::Instance();
+  mToleratedGapWidth = cpvParams.mPedToleratedGapWidth;
+  mZSnSigmas = cpvParams.mPedZSnSigmas;
+  mSuspiciousPedestalRMS = cpvParams.mPedSuspiciousPedestalRMS;
 }
 //___________________________________________________________________
 PedestalSpectrum& PedestalSpectrum::operator+=(const PedestalSpectrum& rhs)
@@ -224,9 +224,9 @@ void PedestalCalibData::print()
 //___________________________________________________________________
 PedestalCalibrator::PedestalCalibrator()
 {
-  auto& cpvParams = o2::cpv::CPVSimParams::Instance();
-  mMinEvents = cpvParams.mPedClbMinEvents;
-  mZSnSigmas = cpvParams.mZSnSigmas;
+  auto& cpvParams = o2::cpv::CPVCalibParams::Instance();
+  mMinEvents = cpvParams.mPedMinEvents;
+  mZSnSigmas = cpvParams.mPedZSnSigmas;
 }
 //___________________________________________________________________
 void PedestalCalibrator::initOutput()
@@ -274,7 +274,7 @@ void PedestalCalibrator::finalizeSlot(PedestalTimeSlot& slot)
     peds->setPedSigma(i, sigma);
 
     // efficiencies
-    float efficiency = 1. * calibData->mPedestalSpectra[i].getNEntries() / calibData->mNEvents;
+    efficiency = 1. * calibData->mPedestalSpectra[i].getNEntries() / calibData->mNEvents;
     efficiencies.push_back(efficiency);
 
     // dead channels

--- a/Detectors/CPV/calib/src/PedestalCalibrator.cxx
+++ b/Detectors/CPV/calib/src/PedestalCalibrator.cxx
@@ -24,12 +24,11 @@ namespace cpv
 {
 //=======================PedestalSpectrum============================
 //___________________________________________________________________
-PedestalSpectrum::PedestalSpectrum()
+PedestalSpectrum::PedestalSpectrum(uint16_t toleratedGapWidth, float nSigmasZS, float suspiciousPedestalRMS)
 {
-  auto& cpvParams = CPVCalibParams::Instance();
-  mToleratedGapWidth = cpvParams.mPedToleratedGapWidth;
-  mZSnSigmas = cpvParams.mPedZSnSigmas;
-  mSuspiciousPedestalRMS = cpvParams.mPedSuspiciousPedestalRMS;
+  mToleratedGapWidth = toleratedGapWidth;
+  mZSnSigmas = nSigmasZS;
+  mSuspiciousPedestalRMS = suspiciousPedestalRMS;
 }
 //___________________________________________________________________
 PedestalSpectrum& PedestalSpectrum::operator+=(const PedestalSpectrum& rhs)
@@ -191,10 +190,10 @@ float PedestalSpectrum::getPedestalRMS()
 
 //========================PedestalCalibData==========================
 //___________________________________________________________________
-PedestalCalibData::PedestalCalibData()
+PedestalCalibData::PedestalCalibData(uint16_t toleratedGapWidth, float nSigmasZS, float suspiciousPedestalRMS)
 {
   for (int i = 0; i < Geometry::kNCHANNELS; i++) {
-    mPedestalSpectra.emplace_back();
+    mPedestalSpectra.emplace_back(toleratedGapWidth, nSigmasZS, suspiciousPedestalRMS);
   }
 }
 //___________________________________________________________________
@@ -224,9 +223,23 @@ void PedestalCalibData::print()
 //___________________________________________________________________
 PedestalCalibrator::PedestalCalibrator()
 {
+  LOG(info) << "PedestalCalibrator::PedestalCalibrator() : pedestal calibrator created!";
+}
+//___________________________________________________________________
+void PedestalCalibrator::configParameters()
+{
   auto& cpvParams = o2::cpv::CPVCalibParams::Instance();
-  mMinEvents = cpvParams.mPedMinEvents;
-  mZSnSigmas = cpvParams.mPedZSnSigmas;
+  mMinEvents = cpvParams.pedMinEvents;
+  mZSnSigmas = cpvParams.pedZSnSigmas;
+  mToleratedGapWidth = cpvParams.pedToleratedGapWidth;
+  mZSnSigmas = cpvParams.pedZSnSigmas;
+  mSuspiciousPedestalRMS = cpvParams.pedSuspiciousPedestalRMS;
+  LOG(info) << "PedestalCalibrator::configParameters() : following parameters configured:";
+  LOG(info) << "mMinEvents = " << mMinEvents;
+  LOG(info) << "mZSnSigmas = " << mZSnSigmas;
+  LOG(info) << "mToleratedGapWidth = " << mToleratedGapWidth;
+  LOG(info) << "mZSnSigmas = " << mZSnSigmas;
+  LOG(info) << "mSuspiciousPedestalRMS = " << mSuspiciousPedestalRMS;
 }
 //___________________________________________________________________
 void PedestalCalibrator::initOutput()

--- a/Detectors/CPV/calib/testWorkflow/GainCalibratorSpec.h
+++ b/Detectors/CPV/calib/testWorkflow/GainCalibratorSpec.h
@@ -1,0 +1,190 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/Task.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "Framework/WorkflowSpec.h"
+#include "Framework/CCDBParamSpec.h"
+#include "CCDB/CcdbApi.h"
+#include "CCDB/CcdbObjectInfo.h"
+#include "DetectorsCalibration/Utils.h"
+#include "CPVCalibration/GainCalibrator.h"
+#include "DataFormatsCPV/Digit.h"
+#include "DataFormatsCPV/TriggerRecord.h"
+#include "DetectorsBase/GRPGeomHelper.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace calibration
+{
+class CPVGainCalibratorSpec : public o2::framework::Task
+{
+ public:
+  CPVGainCalibratorSpec(std::shared_ptr<o2::base::GRPGeomRequest> req) : mCCDBRequest(req) {}
+
+  //_________________________________________________________________
+  void init(o2::framework::InitContext& ic) final
+  {
+    o2::base::GRPGeomHelper::instance().setRequest(mCCDBRequest);
+    // auto slotL = ic.options().get<uint32_t>("tf-per-slot");
+    // auto delay = ic.options().get<uint32_t>("max-delay");
+    auto updateInterval = ic.options().get<uint32_t>("updateInterval"); // in TF
+    bool updateAtTheEndOfRunOnly = ic.options().get<bool>("updateAtTheEndOfRunOnly");
+    mCalibrator = std::make_unique<o2::cpv::GainCalibrator>();
+    mCalibrator->setSlotLength(0);
+    mCalibrator->setMaxSlotsDelay(1000);
+    if (updateAtTheEndOfRunOnly) {
+      mCalibrator->setUpdateAtTheEndOfRunOnly();
+    }
+    mCalibrator->setCheckIntervalInfiniteSlot(updateInterval);
+    mCalibrator->setUpdateTFInterval(updateInterval);
+    LOG(info) << "CPVGainCalibratorSpec initialized";
+    LOG(info) << "tf-per-slot = 0 (inconfigurable for this calibrator)";
+    LOG(info) << "max-delay = 1000 (inconfigurable for this calibrator)";
+    LOG(info) << "updateInterval = " << updateInterval;
+    LOG(info) << "updateAtTheEndOfRunOnly = " << updateAtTheEndOfRunOnly;
+  }
+
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final
+  {
+    o2::base::GRPGeomHelper::instance().finaliseCCDB(matcher, obj);
+  }
+
+  //_________________________________________________________________
+  void run(o2::framework::ProcessingContext& pc) final
+  {
+    o2::base::GRPGeomHelper::instance().checkUpdates(pc);
+    o2::base::TFIDInfoHelper::fillTFIDInfo(pc, mCalibrator->getCurrentTFInfo());
+    TFType tfcounter = mCalibrator->getCurrentTFInfo().startTime;
+    auto&& digits = pc.inputs().get<gsl::span<o2::cpv::Digit>>("calibdigs");
+
+    // previous gains
+    if (!mCalibrator->isSettedPreviousGains()) {
+      const auto previousGains = o2::framework::DataRefUtils::as<CCDBSerialized<o2::cpv::CalibParams>>(pc.inputs().get("gains"));
+      if (previousGains) {
+        mCalibrator->setPreviousGains(new o2::cpv::CalibParams(*previousGains));
+        LOG(info) << "GainCalibratorSpec()::run() : I got previous gains";
+      }
+    }
+
+    // previous calib data
+    if (!mCalibrator->isSettedPreviousGainCalibData()) {
+      const auto previousGainCalibData = o2::framework::DataRefUtils::as<CCDBSerialized<o2::cpv::GainCalibData>>(pc.inputs().get("calibdata"));
+      if (previousGainCalibData) {
+        mCalibrator->setPreviousGainCalibData(new o2::cpv::GainCalibData(*previousGainCalibData));
+        LOG(info) << "GainCalibratorSpec()::run() : I got previous GainCalibData: ";
+        previousGainCalibData->print();
+      }
+    }
+
+    // fill statistics
+    LOG(info) << "Processing TF " << tfcounter << " with " << digits.size() << " digits";
+    mCalibrator->process(digits); // fill TimeSlot with digits from 1 event and check slots for finalization
+
+    // inform about results and send output to ccdb
+    auto gainsInfoVecSize = mCalibrator->getCcdbInfoGainsVector().size();
+    if (gainsInfoVecSize) {
+      LOG(info) << "Created " << gainsInfoVecSize << " o2::cpv::CalibParams objects.";
+      sendOutput(pc.outputs());
+    }
+
+    // and send results to CCDB (if any)
+    if (gainsInfoVecSize) {
+      sendOutput(pc.outputs());
+    }
+  }
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final
+  {
+    // prepare GainCalibData outputs and send it to ccdb
+    mCalibrator->prepareForEnding();
+    auto gainCDInfoVecSize = mCalibrator->getCcdbInfoGainCalibDataVector().size();
+    if (gainCDInfoVecSize) {
+      LOG(info) << "Created " << gainCDInfoVecSize << " o2::cpv::GainCalibData objects.";
+      sendOutput(ec.outputs());
+    }
+  }
+  //_________________________________________________________________
+ private:
+  std::unique_ptr<o2::cpv::GainCalibrator> mCalibrator;
+  std::shared_ptr<o2::base::GRPGeomRequest> mCCDBRequest;
+  //_________________________________________________________________
+  void sendOutput(DataAllocator& output)
+  {
+    bool isSomethingSent = false;
+    isSomethingSent = sendOutputWhat<o2::cpv::CalibParams>(mCalibrator->getGainsVector(), mCalibrator->getCcdbInfoGainsVector(), "CPV_Gains", output);
+    isSomethingSent += sendOutputWhat<o2::cpv::GainCalibData>(mCalibrator->getGainCalibDataVector(), mCalibrator->getCcdbInfoGainCalibDataVector(), "CPV_GainCD", output);
+
+    if (isSomethingSent) {
+      mCalibrator->initOutput(); // reset the outputs once they are already sent
+    }
+  }
+
+  template <class Payload>
+  bool sendOutputWhat(const std::vector<Payload>& payloadVec, std::vector<o2::ccdb::CcdbObjectInfo>& infoVec, header::DataDescription what, DataAllocator& output)
+  {
+    assert(payloadVec.size() == infoVec.size());
+    if (!payloadVec.size()) {
+      return false;
+    }
+
+    for (uint32_t i = 0; i < payloadVec.size(); i++) {
+      auto& w = infoVec[i];
+      auto image = o2::ccdb::CcdbApi::createObjectImage(&payloadVec[i], &w);
+      LOG(info) << "Sending object " << w.getPath() << "/" << w.getFileName() << " of size " << image->size()
+                << " bytes, valid for " << w.getStartValidityTimestamp() << " : " << w.getEndValidityTimestamp();
+      output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, what, i}, *image.get()); // vector<char>
+      output.snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, what, i}, w);            // root-serialized
+    }
+
+    return true;
+  }
+  //_________________________________________________________________
+}; // class CPVGainCalibratorSpec
+} // namespace calibration
+
+namespace framework
+{
+DataProcessorSpec getCPVGainCalibratorSpec()
+{
+  using device = o2::calibration::CPVGainCalibratorSpec;
+
+  std::vector<InputSpec> inputs;
+  inputs.emplace_back("calibdigs", "CPV", "CALIBDIGITS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("calibdata", "CPV", "CPV_GainCD", 0, Lifetime::Condition, ccdbParamSpec("CPV/PhysicsRun/GainCalibData"));
+  inputs.emplace_back("gains", "CPV", "CPV_Gains", 0, Lifetime::Condition, ccdbParamSpec("CPV/Calib/Gains"));
+  auto ccdbRequest = std::make_shared<o2::base::GRPGeomRequest>(true,                           // orbitResetTime
+                                                                true,                           // GRPECS=true
+                                                                false,                          // GRPLHCIF
+                                                                false,                          // GRPMagField
+                                                                false,                          // askMatLUT
+                                                                o2::base::GRPGeomRequest::None, // geometry
+                                                                inputs);
+  std::vector<OutputSpec> outputs;
+  // Length of data description ("CPV_Pedestals") must be < 16 characters.
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "CPV_Gains"}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "CPV_Gains"}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "CPV_GainCD"}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "CPV_GainCD"}, Lifetime::Sporadic);
+
+  return DataProcessorSpec{
+    "cpv-gain-calibration",
+    inputs,
+    outputs,
+    AlgorithmSpec{adaptFromTask<device>(ccdbRequest)},
+    Options{
+      {"updateAtTheEndOfRunOnly", VariantType::Bool, false, {"finalize the slots and prepare the CCDB entries only at the end of the run."}},
+      {"updateInterval", VariantType::UInt32, 100u, {"try to finalize the slot (and produce calibration) when the updateInterval has passed."}}}};
+}
+} // namespace framework
+} // namespace o2

--- a/Detectors/CPV/calib/testWorkflow/NoiseCalibratorSpec.h
+++ b/Detectors/CPV/calib/testWorkflow/NoiseCalibratorSpec.h
@@ -96,22 +96,22 @@ class CPVNoiseCalibratorSpec : public o2::framework::Task
     LOG(info) << "Processing TF " << tfcounter << " with " << digits.size() << " digits in " << trigrecs.size() << " trigger records.";
     auto& slotTF = mCalibrator->getSlotForTF(tfcounter);
 
-    for (auto trigrec = trigrecs.begin(); trigrec != trigrecs.end(); trigrec++) { //event loop
+    for (auto trigrec = trigrecs.begin(); trigrec != trigrecs.end(); trigrec++) { // event loop
       // here we're filling TimeSlot event by event
       // and when last event is reached we call mCalibrator->process() to finalize the TimeSlot
       auto&& digitsInOneEvent = digits.subspan((*trigrec).getFirstEntry(), (*trigrec).getNumberOfObjects());
-      if ((trigrec + 1) == trigrecs.end()) { //last event in current TF, let's process corresponding TimeSlot
-        //LOG(info) << "last event, I call mCalibrator->process()";
+      if ((trigrec + 1) == trigrecs.end()) { // last event in current TF, let's process corresponding TimeSlot
+        // LOG(info) << "last event, I call mCalibrator->process()";
         mCalibrator->process(digitsInOneEvent); // fill TimeSlot with digits from 1 event and check slots for finalization
       } else {
-        slotTF.getContainer()->fill(digitsInOneEvent); //fill TimeSlot with digits from 1 event
+        slotTF.getContainer()->fill(digitsInOneEvent); // fill TimeSlot with digits from 1 event
       }
     }
 
     auto infoVecSize = mCalibrator->getCcdbInfoBadChannelMapVector().size();
     auto badMapVecSize = mCalibrator->getBadChannelMapVector().size();
     if (infoVecSize > 0) {
-      LOG(info) << "Created " << infoVecSize << " ccdb infos and " << badMapVecSize << " pedestal objects for TF " << tfcounter;
+      LOG(info) << "Created " << infoVecSize << " ccdb infos and " << badMapVecSize << " BadChannelMap objects for TF " << tfcounter;
     }
     sendOutput(pc.outputs());
   }

--- a/Detectors/CPV/calib/testWorkflow/NoiseCalibratorSpec.h
+++ b/Detectors/CPV/calib/testWorkflow/NoiseCalibratorSpec.h
@@ -18,6 +18,7 @@
 #include "CCDB/CcdbObjectInfo.h"
 #include "DetectorsCalibration/Utils.h"
 #include "CPVCalibration/NoiseCalibrator.h"
+#include "CPVBase/CPVCalibParams.h"
 #include "DataFormatsCPV/Digit.h"
 #include "DataFormatsCPV/TriggerRecord.h"
 #include "DetectorsBase/GRPGeomHelper.h"
@@ -66,8 +67,17 @@ class CPVNoiseCalibratorSpec : public o2::framework::Task
     o2::base::GRPGeomHelper::instance().checkUpdates(pc);
     o2::base::TFIDInfoHelper::fillTFIDInfo(pc, mCalibrator->getCurrentTFInfo());
     TFType tfcounter = mCalibrator->getCurrentTFInfo().startTime;
-    auto&& digits = pc.inputs().get<gsl::span<o2::cpv::Digit>>("digits");
-    auto&& trigrecs = pc.inputs().get<gsl::span<o2::cpv::TriggerRecord>>("trigrecs");
+
+    // update config
+    static bool isConfigFetched = false;
+    if (!isConfigFetched) {
+      LOG(info) << "NoiseCalibratorSpec::run() : fetching o2::cpv::CPVCalibParams from CCDB";
+      pc.inputs().get<o2::cpv::CPVCalibParams*>("calibparams");
+      LOG(info) << "NoiseCalibratorSpec::run() : o2::cpv::CPVCalibParams::Instance() now is following:";
+      o2::cpv::CPVCalibParams::Instance().printKeyValues();
+      mCalibrator->configParameters();
+      isConfigFetched = true;
+    }
 
     // read pedestal efficiencies, dead and high ped channels from pedestal run
     // do it only once as they don't change during noise scan
@@ -79,19 +89,25 @@ class CPVNoiseCalibratorSpec : public o2::framework::Task
       }
     }
     if (!mCalibrator->isSettedDeadChannels()) {
-      const auto deadChs = o2::framework::DataRefUtils::as<CCDBSerialized<std::vector<int>>>(pc.inputs().get("deadchs"));
+      // const auto deadChs = o2::framework::DataRefUtils::as<CCDBSerialized<std::vector<int>>>(pc.inputs().get("deadchs"));
+      const auto deadChs = pc.inputs().get<std::vector<int>*>("deadchs");
       if (deadChs) {
         mCalibrator->setDeadChannels(new std::vector<int>(deadChs->begin(), deadChs->end()));
         LOG(info) << "NoiseCalibratorSpec()::run() : I got dead channels vetor of size " << deadChs->size();
       }
     }
     if (!mCalibrator->isSettedHighPedChannels()) {
-      const auto highPeds = o2::framework::DataRefUtils::as<CCDBSerialized<std::vector<int>>>(pc.inputs().get("highpeds"));
+      // const auto highPeds = o2::framework::DataRefUtils::as<CCDBSerialized<std::vector<int>>>(pc.inputs().get("highpeds"));
+      const auto highPeds = pc.inputs().get<std::vector<int>*>("highpeds");
       if (highPeds) {
         mCalibrator->setHighPedChannels(new std::vector<int>(highPeds->begin(), highPeds->end()));
         LOG(info) << "NoiseCalibratorSpec()::run() : I got high pedestal channels vetor of size " << highPeds->size();
       }
     }
+
+    // process data
+    auto&& digits = pc.inputs().get<gsl::span<o2::cpv::Digit>>("digits");
+    auto&& trigrecs = pc.inputs().get<gsl::span<o2::cpv::TriggerRecord>>("trigrecs");
 
     LOG(info) << "Processing TF " << tfcounter << " with " << digits.size() << " digits in " << trigrecs.size() << " trigger records.";
     auto& slotTF = mCalibrator->getSlotForTF(tfcounter);
@@ -157,6 +173,7 @@ DataProcessorSpec getCPVNoiseCalibratorSpec()
   inputs.emplace_back("pedeffs", "CPV", "CPV_PedEffs", 0, Lifetime::Condition, ccdbParamSpec("CPV/PedestalRun/ChannelEfficiencies"));
   inputs.emplace_back("deadchs", "CPV", "CPV_DeadChnls", 0, Lifetime::Condition, ccdbParamSpec("CPV/PedestalRun/DeadChannels"));
   inputs.emplace_back("highpeds", "CPV", "CPV_HighThrs", 0, Lifetime::Condition, ccdbParamSpec("CPV/PedestalRun/HighPedChannels"));
+  inputs.emplace_back("calibparams", "CPV", "CPV_CalibPars", 0, Lifetime::Condition, ccdbParamSpec("CPV/Config/CPVCalibParams"));
   auto ccdbRequest = std::make_shared<o2::base::GRPGeomRequest>(true,                           // orbitResetTime
                                                                 true,                           // GRPECS=true
                                                                 false,                          // GRPLHCIF

--- a/Detectors/CPV/calib/testWorkflow/cpv-calib-workflow.cxx
+++ b/Detectors/CPV/calib/testWorkflow/cpv-calib-workflow.cxx
@@ -12,6 +12,7 @@
 #include "Framework/DataProcessorSpec.h"
 #include "PedestalCalibratorSpec.h"
 #include "NoiseCalibratorSpec.h"
+#include "GainCalibratorSpec.h"
 
 using namespace o2::framework;
 
@@ -21,8 +22,8 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   // option allowing to set parameters
   workflowOptions.push_back(ConfigParamSpec{"pedestals", o2::framework::VariantType::Bool, false, {"do pedestal calibration"}});
   workflowOptions.push_back(ConfigParamSpec{"noise", o2::framework::VariantType::Bool, false, {"do noise scan calibration"}});
-  //workflowOptions.push_back(ConfigParamSpec{"gains", o2::framework::VariantType::Bool, false, {"do gain calibration"}});
-  //workflowOptions.push_back(ConfigParamSpec{"badmap", o2::framework::VariantType::Bool, false, {"do bad map calibration"}});
+  workflowOptions.push_back(ConfigParamSpec{"gains", o2::framework::VariantType::Bool, false, {"do gain calibration"}});
+  // workflowOptions.push_back(ConfigParamSpec{"badmap", o2::framework::VariantType::Bool, false, {"do bad map calibration"}});
   workflowOptions.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}});
 }
 
@@ -36,18 +37,19 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
   auto doPedestals = configcontext.options().get<bool>("pedestals");
   auto doNoise = configcontext.options().get<bool>("noise");
-  //auto doGain = configcontext.options().get<bool>("gains");
-  //auto doBadMap = configcontext.options().get<bool>("badmap");
-  if (doPedestals && doNoise) {
-    LOG(error) << "Can not run pedestal and noise calibration simulteneously";
+  auto doGain = configcontext.options().get<bool>("gains");
+  // auto doBadMap = configcontext.options().get<bool>("badmap");
+  int nProcessors = (int)doPedestals + (int)doNoise + (int)doGain;
+  if (nProcessors > 1) {
+    LOG(error) << "Can not run several calibrations simulteneously in one executable";
     return specs;
   }
-  //if (doGain) {
-  //  specs.emplace_back(getCPVGainCalibDeviceSpec());
-  //}
-  //if (doBadMap) {
-  //  specs.emplace_back(getCPVBadMapCalibDeviceSpec());
-  //}
+  if (doGain) {
+    specs.emplace_back(getCPVGainCalibratorSpec());
+  }
+  //  if (doBadMap) {
+  //    specs.emplace_back(getCPVBadMapCalibratorSpec());
+  //  }
   if (doPedestals) {
     specs.emplace_back(getCPVPedestalCalibratorSpec());
   }

--- a/Detectors/CPV/reconstruction/include/CPVReconstruction/Clusterer.h
+++ b/Detectors/CPV/reconstruction/include/CPVReconstruction/Clusterer.h
@@ -16,8 +16,6 @@
 #include "DataFormatsCPV/Digit.h"
 #include "DataFormatsCPV/Cluster.h"
 #include "CPVReconstruction/FullCluster.h"
-#include "DataFormatsCPV/CalibParams.h"
-#include "DataFormatsCPV/BadChannelMap.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
 #include "DataFormatsCPV/TriggerRecord.h"
 
@@ -36,7 +34,8 @@ class Clusterer
   void process(gsl::span<const Digit> digits, gsl::span<const TriggerRecord> dtr,
                const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* dmc,
                std::vector<Cluster>* clusters, std::vector<TriggerRecord>* trigRec,
-               o2::dataformats::MCTruthContainer<o2::MCCompLabel>* cluMC);
+               o2::dataformats::MCTruthContainer<o2::MCCompLabel>* cluMC,
+               std::vector<Digit>* calibDigits);
 
   void makeClusters(gsl::span<const Digit> digits);
   void evalCluProperties(gsl::span<const Digit> digits, std::vector<Cluster>* clusters,
@@ -46,7 +45,8 @@ class Clusterer
   float responseShape(float dx, float dz); // Parameterization of EM shower
   void propagateMC(bool toRun = true) { mRunMC = toRun; }
 
-  void makeUnfoldings(gsl::span<const Digit> digits); // Find and unfold clusters with few local maxima
+  void makeUnfoldingsAndCalibDigits(gsl::span<const Digit> digits, std::vector<Digit>* calibDigits); // Find and unfold clusters with few local maxima
+  void makeCalibDigits(std::vector<Digit>* calibDigits);                                             // Find clusters with 1 local maximum and make calibDigits using them
   void unfoldOneCluster(FullCluster& iniClu, char nMax, gsl::span<int> digitId, gsl::span<const Digit> digits);
 
  protected:

--- a/Detectors/CPV/reconstruction/include/CPVReconstruction/FullCluster.h
+++ b/Detectors/CPV/reconstruction/include/CPVReconstruction/FullCluster.h
@@ -55,7 +55,7 @@ class FullCluster : public Cluster
 
   const std::vector<CluElement>* getElementList() const { return &mElementList; }
 
-  //Counts local maxima and returns their positions
+  // Counts local maxima and returns their positions
   char getNumberOfLocalMax(gsl::span<int> maxAt) const;
 
   void purify(); // Removes digits below threshold

--- a/Detectors/CPV/reconstruction/src/Clusterer.cxx
+++ b/Detectors/CPV/reconstruction/src/Clusterer.cxx
@@ -157,8 +157,8 @@ void Clusterer::makeCalibDigits(std::vector<Digit>* calibDigits)
   for (auto& clu : mClusters) {
     if (clu.getNumberOfLocalMax(maxAt) == 1) { // cluster with only one local maximum
                                                // and appropriate size
-      if ((o2::cpv::CPVCalibParams::Instance().mGainMinClusterMultForCalib <= clu.getMultiplicity()) &&
-          (o2::cpv::CPVCalibParams::Instance().mGainMaxClusterMultForCalib >= clu.getMultiplicity())) {
+      if ((o2::cpv::CPVCalibParams::Instance().gainMinClusterMultForCalib <= clu.getMultiplicity()) &&
+          (o2::cpv::CPVCalibParams::Instance().gainMaxClusterMultForCalib >= clu.getMultiplicity())) {
         const FullCluster::CluElement& maxElement = clu.getElementList()->at(maxAt[0]);
         calibDigits->emplace_back(maxElement.absId, maxElement.energy, maxElement.label);
       }
@@ -187,8 +187,8 @@ void Clusterer::makeUnfoldingsAndCalibDigits(gsl::span<const Digit> digits, std:
     } else {
       clu.setNExMax(nMax); // Only one local maximum
       // make calib digits from cluster with only one local maximum and appropriate size
-      if ((o2::cpv::CPVCalibParams::Instance().mGainMinClusterMultForCalib <= clu.getMultiplicity()) &&
-          (o2::cpv::CPVCalibParams::Instance().mGainMaxClusterMultForCalib >= clu.getMultiplicity())) {
+      if ((o2::cpv::CPVCalibParams::Instance().gainMinClusterMultForCalib <= clu.getMultiplicity()) &&
+          (o2::cpv::CPVCalibParams::Instance().gainMaxClusterMultForCalib >= clu.getMultiplicity())) {
         const FullCluster::CluElement& maxElement = clu.getElementList()->at(maxAt[0]);
         calibDigits->emplace_back(maxElement.absId, maxElement.energy, maxElement.label);
       }

--- a/Detectors/CPV/reconstruction/src/Clusterer.cxx
+++ b/Detectors/CPV/reconstruction/src/Clusterer.cxx
@@ -20,7 +20,8 @@
 #include "DataFormatsCPV/Digit.h"
 #include "CCDB/CcdbApi.h"
 #include "CPVBase/CPVSimParams.h"
-
+#include "CPVBase/CPVCalibParams.h"
+#include <bitset>
 #include "FairLogger.h" // for LOG
 
 using namespace o2::cpv;
@@ -38,10 +39,12 @@ void Clusterer::initialize()
 void Clusterer::process(gsl::span<const Digit> digits, gsl::span<const TriggerRecord> dtr,
                         const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* dmc,
                         std::vector<Cluster>* clusters, std::vector<TriggerRecord>* trigRec,
-                        o2::dataformats::MCTruthContainer<o2::MCCompLabel>* cluMC)
+                        o2::dataformats::MCTruthContainer<o2::MCCompLabel>* cluMC,
+                        std::vector<Digit>* calibDigits)
 {
   clusters->clear(); // final out list of clusters
   trigRec->clear();
+  calibDigits->clear();
   if (mRunMC) {
     cluMC->clear();
   }
@@ -58,11 +61,15 @@ void Clusterer::process(gsl::span<const Digit> digits, gsl::span<const TriggerRe
     // Collect digits to clusters
     makeClusters(digits);
 
-    // // Unfold overlapped clusters
-    // // Split clusters with several local maxima if necessary
-    // if (o2::cpv::CPVSimParams::Instance().mUnfoldClusters) {
-    //   makeUnfoldings(digits);
-    // }
+    // Unfold overlapped clusters
+    // Split clusters with several local maxima if necessary
+    if (o2::cpv::CPVSimParams::Instance().mUnfoldClusters) {
+      // calibdigits will be prepared in this routine
+      makeUnfoldingsAndCalibDigits(digits, calibDigits);
+    } else {
+      // otherwise prepare calibdigits only
+      makeCalibDigits(calibDigits);
+    }
 
     // Calculate properties of collected clusters (Local position, energy, disp etc.)
     evalCluProperties(digits, clusters, dmc, cluMC);
@@ -144,7 +151,22 @@ void Clusterer::makeClusters(gsl::span<const Digit> digits)
   }   // energy theshold
 }
 //__________________________________________________________________________
-void Clusterer::makeUnfoldings(gsl::span<const Digit> digits)
+void Clusterer::makeCalibDigits(std::vector<Digit>* calibDigits)
+{
+  std::array<int, NLMMax> maxAt; // NLMMax:Maximal number of local maxima
+  for (auto& clu : mClusters) {
+    if (clu.getNumberOfLocalMax(maxAt) == 1) { // cluster with only one local maximum
+                                               // and appropriate size
+      if ((o2::cpv::CPVCalibParams::Instance().mGainMinClusterMultForCalib <= clu.getMultiplicity()) &&
+          (o2::cpv::CPVCalibParams::Instance().mGainMaxClusterMultForCalib >= clu.getMultiplicity())) {
+        const FullCluster::CluElement& maxElement = clu.getElementList()->at(maxAt[0]);
+        calibDigits->emplace_back(maxElement.absId, maxElement.energy, maxElement.label);
+      }
+    }
+  }
+}
+//__________________________________________________________________________
+void Clusterer::makeUnfoldingsAndCalibDigits(gsl::span<const Digit> digits, std::vector<Digit>* calibDigits)
 {
   // Split cluster if several local maxima are found
 
@@ -164,6 +186,12 @@ void Clusterer::makeUnfoldings(gsl::span<const Digit> digits)
       clu.setEnergy(0); // will be skipped later
     } else {
       clu.setNExMax(nMax); // Only one local maximum
+      // make calib digits from cluster with only one local maximum and appropriate size
+      if ((o2::cpv::CPVCalibParams::Instance().mGainMinClusterMultForCalib <= clu.getMultiplicity()) &&
+          (o2::cpv::CPVCalibParams::Instance().mGainMaxClusterMultForCalib >= clu.getMultiplicity())) {
+        const FullCluster::CluElement& maxElement = clu.getElementList()->at(maxAt[0]);
+        calibDigits->emplace_back(maxElement.absId, maxElement.energy, maxElement.label);
+      }
     }
   }
 }

--- a/Detectors/CPV/reconstruction/src/RawDecoder.cxx
+++ b/Detectors/CPV/reconstruction/src/RawDecoder.cxx
@@ -26,8 +26,8 @@ RawDecoder::RawDecoder(RawReaderMemory& reader) : mRawReader(reader),
 
 RawErrorType_t RawDecoder::decode()
 {
-  auto& rdh = mRawReader.getRawHeader();
-  //   short linkID = o2::raw::RDHUtils::getLinkID(rdh);
+  // auto& rdh = mRawReader.getRawHeader();
+  //    short linkID = o2::raw::RDHUtils::getLinkID(rdh);
   mDigits.clear();
   mBCRecords.clear();
 

--- a/Detectors/CPV/simulation/src/RawCreator.cxx
+++ b/Detectors/CPV/simulation/src/RawCreator.cxx
@@ -116,7 +116,9 @@ int main(int argc, const char** argv)
   // Loop over all entries in the tree, where each tree entry corresponds to a time frame
   // First version of for loop causes fault Optimizer???
   //  for (auto evnt = treereader->begin(); evnt != treereader->end(); ++evnt) {
-  for (auto evnt : *treereader) {
+  // for (auto evnt : *treereader) {
+  while (treereader->Next()) {
+    // (void*)evnt;
     rawwriter.digitsToRaw(*digitbranch, *triggerbranch);
   }
   rawwriter.getWriter().writeConfFile("CPV", "RAWDATA", o2::utils::Str::concat_string(outputdir, "/CPVraw.cfg"));

--- a/Detectors/CPV/workflow/include/CPVWorkflow/ClusterizerSpec.h
+++ b/Detectors/CPV/workflow/include/CPVWorkflow/ClusterizerSpec.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "DataFormatsCPV/Cluster.h"
+#include "DataFormatsCPV/Digit.h"
 #include "CPVBase/Geometry.h"
 #include "CPVReconstruction/Clusterer.h"
 #include "Framework/DataProcessorSpec.h"
@@ -62,6 +63,7 @@ class ClusterizerSpec : public framework::Task
   o2::cpv::Clusterer mClusterizer; ///< Clusterizer object
   std::vector<o2::cpv::Cluster> mOutputClusters;
   std::vector<o2::cpv::TriggerRecord> mOutputClusterTrigRecs;
+  std::vector<o2::cpv::Digit> mCalibDigits;
   o2::dataformats::MCTruthContainer<o2::MCCompLabel> mOutputTruthCont;
 };
 

--- a/Detectors/CPV/workflow/src/ClusterizerSpec.cxx
+++ b/Detectors/CPV/workflow/src/ClusterizerSpec.cxx
@@ -36,11 +36,12 @@ void ClusterizerSpec::run(framework::ProcessingContext& ctx)
 
   if (!digits.size()) { // nothing to process
     LOG(info) << "ClusterizerSpec::run() : no digits; moving on";
-    //ctx.services().get<o2::framework::ControlService>().readyToQuit(framework::QuitRequest::Me);
     mOutputClusters.clear();
     ctx.outputs().snapshot(o2::framework::Output{"CPV", "CLUSTERS", 0, o2::framework::Lifetime::Timeframe}, mOutputClusters);
     mOutputClusterTrigRecs.clear();
     ctx.outputs().snapshot(o2::framework::Output{"CPV", "CLUSTERTRIGRECS", 0, o2::framework::Lifetime::Timeframe}, mOutputClusterTrigRecs);
+    mCalibDigits.clear();
+    ctx.outputs().snapshot(o2::framework::Output{"CPV", "CALIBDIGITS", 0, o2::framework::Lifetime::Timeframe}, mCalibDigits);
     if (mPropagateMC) {
       mOutputTruthCont.clear();
       ctx.outputs().snapshot(o2::framework::Output{"CPV", "CLUSTERTRUEMC", 0, o2::framework::Lifetime::Timeframe}, mOutputTruthCont);
@@ -49,13 +50,13 @@ void ClusterizerSpec::run(framework::ProcessingContext& ctx)
   }
   auto digitsTR = ctx.inputs().get<std::vector<o2::cpv::TriggerRecord>>("digitTriggerRecords");
 
-  //const o2::dataformats::MCTruthContainer<MCCompLabel>* truthcont = nullptr;
-  // DO NOT TRY TO USE const pointer for MCTruthContainer, it is somehow spoiling whole array
+  // const o2::dataformats::MCTruthContainer<MCCompLabel>* truthcont = nullptr;
+  //  DO NOT TRY TO USE const pointer for MCTruthContainer, it is somehow spoiling whole array
   if (mPropagateMC) {
     auto truthcont = ctx.inputs().get<o2::dataformats::MCTruthContainer<o2::MCCompLabel>*>("digitsmctr");
-    mClusterizer.process(digits, digitsTR, truthcont.get(), &mOutputClusters, &mOutputClusterTrigRecs, &mOutputTruthCont); // Find clusters with MC Truth
+    mClusterizer.process(digits, digitsTR, truthcont.get(), &mOutputClusters, &mOutputClusterTrigRecs, &mOutputTruthCont, &mCalibDigits); // Find clusters with MC Truth
   } else {
-    mClusterizer.process(digits, digitsTR, nullptr, &mOutputClusters, &mOutputClusterTrigRecs, &mOutputTruthCont); // Find clusters without MC Truth
+    mClusterizer.process(digits, digitsTR, nullptr, &mOutputClusters, &mOutputClusterTrigRecs, &mOutputTruthCont, &mCalibDigits); // Find clusters without MC Truth
   }
 
   LOG(debug) << "CPVClusterizer::run() : Received " << digitsTR.size() << " TR, calling clusterizer ...";
@@ -65,6 +66,7 @@ void ClusterizerSpec::run(framework::ProcessingContext& ctx)
   if (mPropagateMC) {
     ctx.outputs().snapshot(o2::framework::Output{"CPV", "CLUSTERTRUEMC", 0, o2::framework::Lifetime::Timeframe}, mOutputTruthCont);
   }
+  ctx.outputs().snapshot(o2::framework::Output{"CPV", "CALIBDIGITS", 0, o2::framework::Lifetime::Timeframe}, mCalibDigits);
   LOG(info) << "Finished, wrote  " << mOutputClusters.size() << " clusters, " << mOutputClusterTrigRecs.size() << "TR and " << mOutputTruthCont.getIndexedSize() << " Labels";
 }
 o2::framework::DataProcessorSpec o2::cpv::reco_workflow::getClusterizerSpec(bool propagateMC)
@@ -81,6 +83,7 @@ o2::framework::DataProcessorSpec o2::cpv::reco_workflow::getClusterizerSpec(bool
   if (propagateMC) {
     outputs.emplace_back("CPV", "CLUSTERTRUEMC", 0, o2::framework::Lifetime::Timeframe);
   }
+  outputs.emplace_back("CPV", "CALIBDIGITS", 0, o2::framework::Lifetime::Timeframe);
 
   return o2::framework::DataProcessorSpec{"CPVClusterizerSpec",
                                           inputs,

--- a/Detectors/CPV/workflow/src/ClusterizerSpec.cxx
+++ b/Detectors/CPV/workflow/src/ClusterizerSpec.cxx
@@ -15,6 +15,8 @@
 #include "DataFormatsCPV/CPVBlockHeader.h"
 #include "CPVWorkflow/ClusterizerSpec.h"
 #include "Framework/ControlService.h"
+#include "CPVBase/CPVSimParams.h"
+#include "Framework/CCDBParamSpec.h"
 
 using namespace o2::cpv::reco_workflow;
 
@@ -31,6 +33,16 @@ void ClusterizerSpec::run(framework::ProcessingContext& ctx)
 {
   LOG(info) << "Starting ClusterizerSpec::run() ";
   LOG(debug) << "CPVClusterizer - run on digits called";
+
+  // update config
+  static bool isConfigFetched = false;
+  if (!isConfigFetched) {
+    LOG(info) << "ClusterizerSpec::run() : fetching o2::cpv::CPVSimParams from CCDB";
+    ctx.inputs().get<o2::cpv::CPVSimParams*>("simparams");
+    LOG(info) << "ClusterizerSpec::run() : o2::cpv::CPVSimParams::Instance() now is following:";
+    o2::cpv::CPVSimParams::Instance().printKeyValues();
+    isConfigFetched = true;
+  }
 
   auto digits = ctx.inputs().get<std::vector<Digit>>("digits");
 
@@ -73,6 +85,7 @@ o2::framework::DataProcessorSpec o2::cpv::reco_workflow::getClusterizerSpec(bool
 {
   std::vector<o2::framework::InputSpec> inputs;
   std::vector<o2::framework::OutputSpec> outputs;
+  inputs.emplace_back("simparams", "CPV", "CPV_SimPars", 0, o2::framework::Lifetime::Condition, o2::framework::ccdbParamSpec("CPV/Config/CPVSimParams"));
   inputs.emplace_back("digits", o2::header::gDataOriginCPV, "DIGITS", 0, o2::framework::Lifetime::Timeframe);
   inputs.emplace_back("digitTriggerRecords", o2::header::gDataOriginCPV, "DIGITTRIGREC", 0, o2::framework::Lifetime::Timeframe);
   if (propagateMC) {

--- a/Detectors/CPV/workflow/src/cpv-reco-workflow.cxx
+++ b/Detectors/CPV/workflow/src/cpv-reco-workflow.cxx
@@ -92,5 +92,5 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
   // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
   o2::raw::HBFUtilsInitializer hbfIni(cfgc, wf);
 
-  return std::move(wf);
+  return wf;
 }


### PR DESCRIPTION
Hello!

cpv gain calibrator created. It picks up CALIBDIGITS produced by Clusterizer, prepares GainCalibData (which is struct representing 23040 histos with 1000 bins each, bin content is stored as uint32_t) and produces CalibParams object with gains when collected statistics is enough. GainCalibData is saved to CCDB at the end of each run and is read read back from CCDB when new run starts. When statistics is enough to calibrate 10000 channels then calibration is produces for ready channels, statistics in those is resetted. In channels which were not ready, statistics continues to be collected. 

Also several warnings for cpv are fixed. 