### PR TITLE
MCH: filter input digits for time-clustering peak search

### DIFF
--- a/Detectors/MUON/MCH/TimeClustering/CMakeLists.txt
+++ b/Detectors/MUON/MCH/TimeClustering/CMakeLists.txt
@@ -11,7 +11,7 @@
 
 o2_add_library(MCHTimeClustering
         SOURCES src/ROFTimeClusterFinder.cxx src/TimeClusterizerParam.cxx src/TimeClusterFinderSpec.cxx
-        PUBLIC_LINK_LIBRARIES O2::MCHBase O2::Framework O2::MCHROFFiltering)
+        PUBLIC_LINK_LIBRARIES O2::MCHBase O2::Framework O2::MCHDigitFiltering O2::MCHROFFiltering)
 
 o2_target_root_dictionary(MCHTimeClustering HEADERS include/MCHTimeClustering/TimeClusterizerParam.h)
 

--- a/Detectors/MUON/MCH/TimeClustering/include/MCHTimeClustering/TimeClusterizerParam.h
+++ b/Detectors/MUON/MCH/TimeClustering/include/MCHTimeClustering/TimeClusterizerParam.h
@@ -24,10 +24,11 @@ namespace o2::mch
  */
 struct TimeClusterizerParam : public o2::conf::ConfigurableParamHelper<TimeClusterizerParam> {
 
-  bool onlyTrackable = true;       ///< only output ROFs that match the trackable condition @see MCHBase/Trackable.h
-  int maxClusterWidth = 1000 / 25; ///< maximum time width of time clusters, in BC units
-  int peakSearchNbins = 5;         ///< number of time bins for the peak search algorithm (must be an odd number >= 3)
-  int minDigitsPerROF = 0;         ///< minimum number of digits per ROF (below that threshold ROF is discarded)
+  bool onlyTrackable = true;        ///< only output ROFs that match the trackable condition @see MCHBase/Trackable.h
+  int maxClusterWidth = 1000 / 25;  ///< maximum time width of time clusters, in BC units
+  int peakSearchNbins = 5;          ///< number of time bins for the peak search algorithm (must be an odd number >= 3)
+  int minDigitsPerROF = 0;          ///< minimum number of digits per ROF (below that threshold ROF is discarded)
+  bool peakSearchSignalOnly = true; ///< only use signal-like hits in peak search
 
   O2ParamDef(TimeClusterizerParam, "MCHTimeClusterizer");
 };

--- a/Detectors/MUON/MCH/TimeClustering/src/TimeClusterFinderSpec.cxx
+++ b/Detectors/MUON/MCH/TimeClustering/src/TimeClusterFinderSpec.cxx
@@ -38,6 +38,7 @@
 #include "MCHBase/TrackerParam.h"
 #include "MCHROFFiltering/TrackableFilter.h"
 #include "MCHTimeClustering/ROFTimeClusterFinder.h"
+#include "MCHDigitFiltering/DigitFilter.h"
 #include "MCHTimeClustering/TimeClusterizerParam.h"
 
 namespace o2
@@ -59,6 +60,7 @@ class TimeClusterFinderTask
     mNbinsInOneWindow = param.peakSearchNbins;
     mMinDigitPerROF = param.minDigitsPerROF;
     mOnlyTrackable = param.onlyTrackable;
+    mPeakSearchSignalOnly = param.peakSearchSignalOnly;
     mDebug = ic.options().get<bool>("mch-debug");
 
     if (mDebug) {
@@ -92,7 +94,7 @@ class TimeClusterFinderTask
     auto rofs = pc.inputs().get<gsl::span<o2::mch::ROFRecord>>("rofs");
     auto digits = pc.inputs().get<gsl::span<o2::mch::Digit>>("digits");
 
-    o2::mch::ROFTimeClusterFinder rofProcessor(rofs, mTimeClusterWidth, mNbinsInOneWindow, 0);
+    o2::mch::ROFTimeClusterFinder rofProcessor(rofs, digits, mTimeClusterWidth, mNbinsInOneWindow, mPeakSearchSignalOnly, mDebug);
 
     if (mDebug) {
       LOGP(warning, "{:=>60} ", fmt::format("{:6d} Input ROFS", rofs.size()));
@@ -156,6 +158,7 @@ class TimeClusterFinderTask
   int mTFcount{0};            ///< number of processed time frames
   int mDebug{0};              ///< verbosity flag
   int mMinDigitPerROF;        ///< minimum digit per ROF threshold
+  bool mPeakSearchSignalOnly; ///< only use signal-like hits in peak search
   bool mOnlyTrackable;        ///< only keep ROFs that are trackable
 };
 

--- a/Detectors/MUON/MCH/TimeClustering/src/testROFTimeClusterFinder.cxx
+++ b/Detectors/MUON/MCH/TimeClustering/src/testROFTimeClusterFinder.cxx
@@ -55,8 +55,9 @@ static ROFVector makeROFs(std::vector<int> binEntries, uint32_t winSize, uint32_
 static ROFVector makeTimeROFs(std::vector<int> binEntries, uint32_t winSize, uint32_t nBinsInOneWindow)
 {
   const auto& rofRecords = makeROFs(binEntries, winSize, nBinsInOneWindow);
+  const std::vector<o2::mch::Digit> digits;
 
-  o2::mch::ROFTimeClusterFinder rofProcessor(rofRecords, winSize, nBinsInOneWindow, 1);
+  o2::mch::ROFTimeClusterFinder rofProcessor(rofRecords, digits, winSize, nBinsInOneWindow, false, 1);
   rofProcessor.process();
 
   const auto& rofTimeRecords = rofProcessor.getROFRecords();


### PR DESCRIPTION
The commit introduces the possibility to only use signal-like digits as input for the peak searching step.
The digits filtering is enable via the `MCHTimeClusterizerParam.peakSearchSignalOnly` configurable parameter (enabled by default).