### PR TITLE
[MFT] Restore full tracking by default

### DIFF
--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/MFTTrackingParam.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/MFTTrackingParam.h
@@ -36,7 +36,7 @@ struct MFTTrackingParam : public o2::conf::ConfigurableParamHelper<MFTTrackingPa
   Int_t trackmodel = MFTTrackModel::Optimized;
   double MFTRadLength = 0.042; // MFT average material budget within acceptance
   bool verbose = false;
-  bool forceZeroField = true; // Force MFT tracking with B=0 (default = true until alignment is applied)
+  bool forceZeroField = false; // Force MFT tracking with B=0
 
   /// tracking algorithm (LTF and CA) parameters
   /// minimum number of points for a LTF track
@@ -48,7 +48,7 @@ struct MFTTrackingParam : public o2::conf::ConfigurableParamHelper<MFTTrackingPa
   /// minimum number of detector stations for a CA track
   Int_t MinTrackStationsCA = 4;
   /// maximum distance for a cluster to be attached to a seed line (LTF)
-  Float_t LTFclsRCut = 0.200; // Temporary for misaligned detector. Default 0.0100
+  Float_t LTFclsRCut = 0.0100;
   /// maximum distance for a cluster to be attached to a seed line (CA road)
   Float_t ROADclsRCut = 0.0400;
   /// number of bins in r-direction


### PR DESCRIPTION
This PR restores MFT tracking default option to run full Kalman filter.

It renders obsolete O2DPG workflow option `--mft-reco-full`. Which will be suppressed once once this PR is merged.

Note that reconstruction of pilot beam data and TED shots will then require the corresponding adaptation to deal with a misaligned detector:  `MFTTracking.LTFclsRCut=0.2; MFTTracking.forceZeroField=true;`. @chiarazampolli, @catalinristea, @shahor02 and @julekm am keeping this PR as a draft while changes are made for pass4 and any other reconstruction with data that may be going on (such as ED). 