### PR TITLE
Applying Branson corrections to MCH track in FwdMatching workflow

### DIFF
--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchGlobalFwd.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchGlobalFwd.h
@@ -325,6 +325,7 @@ class MatchGlobalFwd
   bool mMCTruthON = false;      ///< Flag availability of MC truth
   bool mUseMIDMCHMatch = false; ///< Flag for using MCHMID matches (TrackMCHMID)
   int mSaveMode = 0;            ///< Output mode [0 = SaveBestMatch; 1 = SaveAllMatches; 2 = SaveTrainingData]
+  bool mUseBranson = true;      ///< Flag for applying Branson corrections
   MatchingType mMatchingType = MATCHINGUNDEFINED;
   TGeoManager* mGeoManager;
 };

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchGlobalFwdParam.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchGlobalFwdParam.h
@@ -39,6 +39,7 @@ struct GlobalFwdMatchingParam : public o2::conf::ConfigurableParamHelper<GlobalF
   double matchPlaneZ = -77.5;                             ///< MFT-MCH matching plane z coordinate
   bool useMIDMatch = false;                               ///< Use input from MCH-MID matching
   Int_t saveMode = kBestMatch;                            ///< Global Forward Tracks save mode
+  bool useBranson = true;                                 ///< Apply Branson corrections to matched MCH track
 
   bool
     isMatchUpstream() const

--- a/Detectors/GlobalTracking/src/MatchGlobalFwd.cxx
+++ b/Detectors/GlobalTracking/src/MatchGlobalFwd.cxx
@@ -558,12 +558,12 @@ void MatchGlobalFwd::fitGlobalMuonTrack(o2::dataformats::GlobalFwdTrack& gTrack)
 
   SMatrix55Sym lastParamCov;
 
-  if (mUseBranson){
-    o2::mch::TrackExtrap::extrapToVertex(mchparam, mftTrackOut.getX(), mftTrackOut.getY(), mftTrackOut.getZ(), 0, 0);  //Propagation of MCH to the first MFT cluster in the matching plane, applying Branson corrections to the MCH which is matched to MFT
+  if (mUseBranson) {
+    o2::mch::TrackExtrap::extrapToVertex(mchparam, mftTrackOut.getX(), mftTrackOut.getY(), mftTrackOut.getZ(), 0, 0); // Propagation of MCH to the first MFT cluster in the matching plane, applying Branson corrections to the MCH which is matched to MFT
     auto convertedTrack = MCHtoFwd(mchparam);
     gTrack.setInvQPt(convertedTrack.getInvQPt());
     lastParamCov(4, 4) = convertedTrack.getCovariances()(4, 4);
-  }else{
+  } else {
     gTrack.setInvQPt(gTrack.getInvQPt());
     lastParamCov(4, 4) = gTrack.getCovariances()(4, 4);
   }
@@ -577,7 +577,6 @@ void MatchGlobalFwd::fitGlobalMuonTrack(o2::dataformats::GlobalFwdTrack& gTrack)
 
   Double_t tanlsigma = TMath::Max(std::abs(mftTrackOut.getTanl()), .5);
   Double_t qptsigma = TMath::Max(std::abs(mftTrackOut.getInvQPt()), .5);
-
 
   lastParamCov(0, 0) = 10000. * mftTrackOut.getCovariances()(0, 0); // <X,X>
   lastParamCov(1, 1) = 10000. * mftTrackOut.getCovariances()(1, 1); // <Y,X>

--- a/Detectors/GlobalTracking/src/MatchGlobalFwd.cxx
+++ b/Detectors/GlobalTracking/src/MatchGlobalFwd.cxx
@@ -559,7 +559,7 @@ void MatchGlobalFwd::fitGlobalMuonTrack(o2::dataformats::GlobalFwdTrack& gTrack)
   SMatrix55Sym lastParamCov;
 
   if (mUseBranson) {
-    o2::mch::TrackExtrap::extrapToVertex(mchparam, mftTrackOut.getX(), mftTrackOut.getY(), mftTrackOut.getZ(), 0, 0); // Propagation of MCH to the first MFT cluster in the matching plane, applying Branson corrections to the MCH which is matched to MFT
+    o2::mch::TrackExtrap::extrapToVertex(mchparam, mftTrackOut.getX(), mftTrackOut.getY(), mftTrackOut.getZ(), 0, 0); // Propagation of MCH that are matched to MFT to the matching plane, applying Branson corrections
     auto convertedTrack = MCHtoFwd(mchparam);
     gTrack.setInvQPt(convertedTrack.getInvQPt());
     lastParamCov(4, 4) = convertedTrack.getCovariances()(4, 4);


### PR DESCRIPTION
During matching between MFT & MCH, the MCH tracks which are matched to an MFT track are propagated to the last MFT to the matching plane, applying Branson corrections to account for MCS going through the absorber. This has been tested to improve the transverse momentum resolution of the GlobalMuonTracks.