### PR TITLE
[EMCAL-551] Use std::round for energy and time truncation

### DIFF
--- a/DataFormats/Detectors/EMCAL/src/Cell.cxx
+++ b/DataFormats/Detectors/EMCAL/src/Cell.cxx
@@ -13,6 +13,7 @@
 #include "DataFormatsEMCAL/Cell.h"
 #include <iostream>
 #include <bitset>
+#include <cmath>
 
 using namespace o2::emcal;
 
@@ -46,7 +47,7 @@ void Cell::setTimeStamp(float timestamp)
   } else if (timestamp > TIME_MAX) {
     timestamp = TIME_MAX;
   }
-  getDataRepresentation()->mTime = static_cast<uint16_t>((timestamp + TIME_SHIFT) / TIME_RESOLUTION);
+  getDataRepresentation()->mTime = static_cast<uint16_t>(std::round((timestamp + TIME_SHIFT) / TIME_RESOLUTION));
 }
 
 float Cell::getTimeStamp() const
@@ -62,7 +63,7 @@ void Cell::setEnergy(float energy)
   } else if (truncatedEnergy > ENERGY_TRUNCATION) {
     truncatedEnergy = ENERGY_TRUNCATION;
   }
-  getDataRepresentation()->mEnergy = static_cast<int16_t>(truncatedEnergy / ENERGY_RESOLUTION);
+  getDataRepresentation()->mEnergy = static_cast<int16_t>(std::round(truncatedEnergy / ENERGY_RESOLUTION));
 }
 
 float Cell::getEnergy() const


### PR DESCRIPTION
Brute force trunctation leading to
precision loss resulting in approx
2% shift of the pi0 mass peak.
The usage of std::round before
conversion to int recovers the
precision loss within the range
of precision of the detector.