### PR TITLE
Do not include ZDC fastsim pointers in dictionary

### DIFF
--- a/Detectors/ZDC/simulation/include/ZDCSimulation/Detector.h
+++ b/Detectors/ZDC/simulation/include/ZDCSimulation/Detector.h
@@ -227,16 +227,16 @@ class Detector : public o2::base::DetImpl<Detector>
 
 // fastsim model wrapper
 #ifdef ZDC_FASTSIM_ONNX
-  fastsim::NeuralFastSimulation* mFastSimClassifier = nullptr;
-  fastsim::NeuralFastSimulation* mFastSimModel = nullptr;
+  fastsim::NeuralFastSimulation* mFastSimClassifier = nullptr; //! no ROOT serialization
+  fastsim::NeuralFastSimulation* mFastSimModel = nullptr;      //!
 
   // Scalers for models inputs
-  fastsim::processors::StandardScaler mClassifierScaler;
-  fastsim::processors::StandardScaler mModelScaler;
+  fastsim::processors::StandardScaler mClassifierScaler; //!
+  fastsim::processors::StandardScaler mModelScaler;      //!
 
   // container for fastsim model responses
-  using FastSimResults = std::vector<std::array<long, 5>>;
-  FastSimResults mFastSimResults;
+  using FastSimResults = std::vector<std::array<long, 5>>; //!
+  FastSimResults mFastSimResults;                          //!
 #endif
 
   template <typename Det>


### PR DESCRIPTION
Fixes a problem where consecutive sims crashed when
started in same directionary and ZDC included