### PR TITLE
[MID] add configurable params and protection against too many tracks

### DIFF
--- a/Detectors/MUON/MID/Tracking/CMakeLists.txt
+++ b/Detectors/MUON/MID/Tracking/CMakeLists.txt
@@ -11,8 +11,12 @@
 
 o2_add_library(
   MIDTracking
-  SOURCES src/HitMapBuilder.cxx src/Tracker.cxx
+  SOURCES src/HitMapBuilder.cxx src/Tracker.cxx src/TrackerParam.cxx
   PUBLIC_LINK_LIBRARIES O2::DataFormatsMID O2::MIDBase Microsoft.GSL::GSL)
+
+o2_target_root_dictionary(
+  MIDTracking
+  HEADERS include/MIDTracking/TrackerParam.h)
 
 if(BUILD_TESTING)
   add_subdirectory(test)

--- a/Detectors/MUON/MID/Tracking/README.md
+++ b/Detectors/MUON/MID/Tracking/README.md
@@ -7,6 +7,8 @@
 The MID tracking takes as input the clusters and returns a vector of reconstructed tracks.
 The magnetic field in the trigger chambers, placed behind an iron wall, is negligible, so a straight track is used.
 
+The algorithm has some configurable parameters in [TrackerParam.h](include/MIDTracking/TrackerParam.h).
+Option `--configKeyValues "key1=value1;key2=value2;..."` allows to change them from the command line.
 
 ## Execution
 ### Start clusterizer

--- a/Detectors/MUON/MID/Tracking/include/MIDTracking/Tracker.h
+++ b/Detectors/MUON/MID/Tracking/include/MIDTracking/Tracker.h
@@ -35,16 +35,8 @@ class Tracker
  public:
   Tracker(const GeometryTransformer& geoTrans);
 
-  /// Sets impact parameter cut
-  void setImpactParamCut(float impactParamCut) { mImpactParamCut = impactParamCut; }
   /// Gets the impact parameter cut
   inline float getImpactParamCut() const { return mImpactParamCut; }
-  /// Sets number of sigmas for cuts
-  void setSigmaCut(float sigmaCut)
-  {
-    mSigmaCut = sigmaCut;
-    mMaxChi2 = 2. * sigmaCut * sigmaCut;
-  }
   /// Gets number of sigmas for cuts
   inline float getSigmaCut() const { return mSigmaCut; }
 

--- a/Detectors/MUON/MID/Tracking/include/MIDTracking/Tracker.h
+++ b/Detectors/MUON/MID/Tracking/include/MIDTracking/Tracker.h
@@ -84,6 +84,7 @@ class Tracker
   std::vector<Track> mTracks{};                ///< Vector of tracks
   std::vector<ROFRecord> mTrackROFRecords{};   ///< List of track RO frame records
   std::vector<ROFRecord> mClusterROFRecords{}; ///< List of cluster RO frame records
+  size_t mFirstTrackOffset{0};                 ///! Offset for the first track in the current event
   size_t mTrackOffset{0};                      ///! Offset for the track in the current event
   int mNTracksStep1{0};                        ///! Number of tracks found in the first tracking step
 

--- a/Detectors/MUON/MID/Tracking/include/MIDTracking/TrackerParam.h
+++ b/Detectors/MUON/MID/Tracking/include/MIDTracking/TrackerParam.h
@@ -30,6 +30,8 @@ struct TrackerParam : public o2::conf::ConfigurableParamHelper<TrackerParam> {
   float impactParamCut = 210.; ///< impact parameter cut to select track seeds
   float sigmaCut = 5.;         ///< sigma cut to select clusters and tracks during tracking
 
+  std::size_t maxCandidates = 1000000; ///< maximum number of track candidates above which the tracking abort
+
   O2ParamDef(TrackerParam, "MIDTracking");
 };
 

--- a/Detectors/MUON/MID/Tracking/include/MIDTracking/TrackerParam.h
+++ b/Detectors/MUON/MID/Tracking/include/MIDTracking/TrackerParam.h
@@ -1,0 +1,39 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TrackerParam.h
+/// \brief Configurable parameters for MID tracking
+/// \author Philippe Pillot, Subatech
+
+#ifndef O2_MID_TRACKERPARAM_H_
+#define O2_MID_TRACKERPARAM_H_
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "CommonUtils/ConfigurableParamHelper.h"
+
+namespace o2
+{
+namespace mid
+{
+
+/// Configurable parameters for MID tracking
+struct TrackerParam : public o2::conf::ConfigurableParamHelper<TrackerParam> {
+
+  float impactParamCut = 210.; ///< impact parameter cut to select track seeds
+  float sigmaCut = 5.;         ///< sigma cut to select clusters and tracks during tracking
+
+  O2ParamDef(TrackerParam, "MIDTracking");
+};
+
+} // namespace mid
+} // end namespace o2
+
+#endif // O2_MID_TRACKERPARAM_H_

--- a/Detectors/MUON/MID/Tracking/src/MIDTrackingLinkDef.h
+++ b/Detectors/MUON/MID/Tracking/src/MIDTrackingLinkDef.h
@@ -1,0 +1,21 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifdef __CLING__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class o2::mid::TrackerParam + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::mid::TrackerParam> + ;
+
+#endif

--- a/Detectors/MUON/MID/Tracking/src/Tracker.cxx
+++ b/Detectors/MUON/MID/Tracking/src/Tracker.cxx
@@ -17,6 +17,9 @@
 
 #include <cmath>
 #include <functional>
+#include <stdexcept>
+
+#include "Framework/Logger.h"
 #include "MIDBase/DetectorParameters.h"
 #include "MIDTracking/TrackerParam.h"
 
@@ -120,21 +123,27 @@ void Tracker::process(gsl::span<const Cluster> clusters, bool accumulate)
 
   // Load the digits to get the fired pads
   if (loadClusters(clusters)) {
-    // Right and left side can be processed in parallel
-    // Right inward
-    mTrackOffset = mTracks.size();
-    mNTracksStep1 = 0;
-    processSide(true, true);
-    mNTracksStep1 = mTracks.size() - mTrackOffset;
-    // Right outward
-    processSide(true, false);
-    // Left inward
-    mTrackOffset = mTracks.size();
-    mNTracksStep1 = 0;
-    processSide(false, true);
-    mNTracksStep1 = mTracks.size() - mTrackOffset;
-    // left outward
-    processSide(false, false);
+    mFirstTrackOffset = mTracks.size();
+    try {
+      // Right and left side can be processed in parallel
+      // Right inward
+      mTrackOffset = mTracks.size();
+      mNTracksStep1 = 0;
+      processSide(true, true);
+      mNTracksStep1 = mTracks.size() - mTrackOffset;
+      // Right outward
+      processSide(true, false);
+      // Left inward
+      mTrackOffset = mTracks.size();
+      mNTracksStep1 = 0;
+      processSide(false, true);
+      mNTracksStep1 = mTracks.size() - mTrackOffset;
+      // left outward
+      processSide(false, false);
+    } catch (std::exception const& e) {
+      LOG(error) << e.what() << " --> abort";
+      mTracks.erase(mTracks.begin() + mFirstTrackOffset, mTracks.end());
+    }
   }
 }
 
@@ -255,6 +264,7 @@ bool Tracker::findAllClusters(const Track& track, bool isRight, int chamber, int
   /// Find all compatible clusters in these RPCs and attach them to a copy of the track
   /// For each of them look for further compatible clusters in the next chamber, if any
   /// Either exclude the excludedClusters from the search or add the new clusters found in the list
+  /// Throw an exception if the maximum number of tracks is exceeded
 
   int rpcOffset = detparams::getDEId(isRight, chamber, 0);
   bool clusterFound = false;
@@ -283,6 +293,10 @@ bool Tracker::findAllClusters(const Track& track, bool isRight, int chamber, int
       // store this track extrapolated to MT11 unless compatible clusters are found in the next chamber (if any)
       if (nextChamber < 0 || !findAllClusters(newTrack, isRight, nextChamber, getFirstNeighbourRPC(irpc),
                                               getLastNeighbourRPC(irpc), -1, excludedClusters, false)) {
+        if (mTracks.size() - mFirstTrackOffset >= TrackerParam::Instance().maxCandidates) {
+          throw std::length_error(std::string("Too many track candidates (") +
+                                  (mTracks.size() - mFirstTrackOffset) + ")");
+        }
         newTrack.propagateToZ(SMT11Z);
         mTracks.emplace_back(newTrack);
       }

--- a/Detectors/MUON/MID/Tracking/src/Tracker.cxx
+++ b/Detectors/MUON/MID/Tracking/src/Tracker.cxx
@@ -18,6 +18,7 @@
 #include <cmath>
 #include <functional>
 #include "MIDBase/DetectorParameters.h"
+#include "MIDTracking/TrackerParam.h"
 
 namespace o2
 {
@@ -40,6 +41,10 @@ bool Tracker::init(bool keepAll)
   } else {
     mFollowTrack = &Tracker::followTrackKeepBest;
   }
+
+  mImpactParamCut = TrackerParam::Instance().impactParamCut;
+  mSigmaCut = TrackerParam::Instance().sigmaCut;
+  mMaxChi2 = 2. * mSigmaCut * mSigmaCut;
 
   return true;
 }

--- a/Detectors/MUON/MID/Tracking/src/TrackerParam.cxx
+++ b/Detectors/MUON/MID/Tracking/src/TrackerParam.cxx
@@ -1,0 +1,18 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TrackerParam.cxx
+/// \brief Configurable parameters for MID tracking
+/// \author Philippe Pillot, Subatech
+
+#include "MIDTracking/TrackerParam.h"
+
+O2ParamImpl(o2::mid::TrackerParam);


### PR DESCRIPTION
The 1st commit moves the MID tracking parameters that may need to be adjusted into configurable params.

The 2nd commit add a protection to abort the tracking if too many tracks (number is configurable) are found in the same ROF. I added this protection only for the algorithm tracking every possible candidates (the one to be used for pp and PbPb data in principle), because it cannot cope with extreme multiplicities like in the TED shots. The other algorithm, tracking only the best candidates, already has an intrinsic limitation and shows no problem to reconstruct the TED shots.

@dstocco is it ok for you?
