### PR TITLE
Use HBFUtilsInitializer in FIT digit reader workflows

### DIFF
--- a/Detectors/FIT/FDD/workflow/src/digits-reader-workflow.cxx
+++ b/Detectors/FIT/FDD/workflow/src/digits-reader-workflow.cxx
@@ -15,13 +15,20 @@
 /// \author ruben.shahoyan@cern.ch
 
 #include "Framework/CallbackService.h"
+#include "Framework/CallbacksPolicy.h"
 #include "Framework/ControlService.h"
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/Task.h"
 #include "FDDWorkflow/DigitReaderSpec.h"
+#include "DetectorsRaw/HBFUtilsInitializer.h"
 #include "CommonUtils/ConfigurableParam.h"
 
 using namespace o2::framework;
+
+void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
+{
+  o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
 
 // we need to add workflow options before including Framework/runDataProcessing
 void customize(std::vector<ConfigParamSpec>& workflowOptions)
@@ -31,6 +38,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation even if available"}}};
   std::string keyvaluehelp("Semicolon separated key=value strings");
   options.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {keyvaluehelp}});
+  o2::raw::HBFUtilsInitializer::addConfigOption(options);
   std::swap(workflowOptions, options);
 }
 
@@ -42,5 +50,9 @@ WorkflowSpec defineDataProcessing(const ConfigContext& ctx)
   o2::conf::ConfigurableParam::updateFromString(ctx.options().get<std::string>("configKeyValues"));
   DataProcessorSpec producer = o2::fdd::getFDDDigitReaderSpec(ctx.options().get<bool>("disable-mc"));
   specs.push_back(producer);
+
+  // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
+  o2::raw::HBFUtilsInitializer hbfIni(ctx, specs);
+
   return specs;
 }

--- a/Detectors/FIT/FT0/workflow/src/digits-reader-workflow.cxx
+++ b/Detectors/FIT/FT0/workflow/src/digits-reader-workflow.cxx
@@ -15,13 +15,20 @@
 /// \author ruben.shahoyan@cern.ch
 
 #include "Framework/CallbackService.h"
+#include "Framework/CallbacksPolicy.h"
 #include "Framework/ControlService.h"
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/Task.h"
 #include "FT0Workflow/DigitReaderSpec.h"
+#include "DetectorsRaw/HBFUtilsInitializer.h"
 #include "CommonUtils/ConfigurableParam.h"
 
 using namespace o2::framework;
+
+void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
+{
+  o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
 
 // we need to add workflow options before including Framework/runDataProcessing
 void customize(std::vector<ConfigParamSpec>& workflowOptions)
@@ -32,6 +39,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
   options.push_back(ConfigParamSpec{"disable-trigger-input", o2::framework::VariantType::Bool, false, {"Disable trigger input DPL channel"}});
   std::string keyvaluehelp("Semicolon separated key=value strings");
   options.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {keyvaluehelp}});
+  o2::raw::HBFUtilsInitializer::addConfigOption(options);
   std::swap(workflowOptions, options);
 }
 
@@ -43,5 +51,9 @@ WorkflowSpec defineDataProcessing(const ConfigContext& ctx)
   o2::conf::ConfigurableParam::updateFromString(ctx.options().get<std::string>("configKeyValues"));
   DataProcessorSpec producer = o2::ft0::getDigitReaderSpec(ctx.options().get<bool>("disable-mc"), ctx.options().get<bool>("disable-trigger-input"));
   specs.push_back(producer);
+
+  // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
+  o2::raw::HBFUtilsInitializer hbfIni(ctx, specs);
+
   return specs;
 }

--- a/Detectors/FIT/FV0/workflow/src/digits-reader-workflow.cxx
+++ b/Detectors/FIT/FV0/workflow/src/digits-reader-workflow.cxx
@@ -15,13 +15,20 @@
 /// \author ruben.shahoyan@cern.ch
 
 #include "Framework/CallbackService.h"
+#include "Framework/CallbacksPolicy.h"
 #include "Framework/ControlService.h"
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/Task.h"
 #include "FV0Workflow/DigitReaderSpec.h"
+#include "DetectorsRaw/HBFUtilsInitializer.h"
 #include "CommonUtils/ConfigurableParam.h"
 
 using namespace o2::framework;
+
+void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
+{
+  o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
 
 // we need to add workflow options before including Framework/runDataProcessing
 void customize(std::vector<ConfigParamSpec>& workflowOptions)
@@ -32,6 +39,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
   options.push_back(ConfigParamSpec{"disable-trigger-input", o2::framework::VariantType::Bool, false, {"Disable trigger input DPL channel"}});
   std::string keyvaluehelp("Semicolon separated key=value strings");
   options.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {keyvaluehelp}});
+  o2::raw::HBFUtilsInitializer::addConfigOption(options);
   std::swap(workflowOptions, options);
 }
 
@@ -43,5 +51,9 @@ WorkflowSpec defineDataProcessing(const ConfigContext& ctx)
   o2::conf::ConfigurableParam::updateFromString(ctx.options().get<std::string>("configKeyValues"));
   DataProcessorSpec producer = o2::fv0::getDigitReaderSpec(ctx.options().get<bool>("disable-mc"), ctx.options().get<bool>("disable-trigger-input"));
   specs.push_back(producer);
+
+  // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
+  o2::raw::HBFUtilsInitializer hbfIni(ctx, specs);
+
   return specs;
 }


### PR DESCRIPTION
@mslupeck not all FIT digit readers follow the standard behaviour for all readers: 
1) the files from MC can be read as is, correct timestamp/orbit  will be injected: o2simdigitizerworkflow_configuration.ini created in digitization will be used (equivalent to default `--hbfutils-config o2simdigitizerworkflow_configuration.ini `
2) files from raw data processing using o2-tfidinfo-writer-workflow (which creates o2_tfidinfo.root file) should be read with `--hbfutils-config o2_tfidinfo.root` 
3) files from raw data processing produced w/o  o2-tfidinfo-writer-workflow: at the moment you will need to create an ini file containing a block like
```
[HBFUtils]
nHBFPerTF=128
obligatorySOR=true
orbitFirst=0
runNumber=300001
orbitFirstSampled=12800
maxNOrbits=4294967295
startTime=1546300800000
```
and use it with `--hbfutils-config <ini file>` .
The i-th TF will be injected with timestamp `startTime+i*nHBFPerTF*orbit_duration` and the injected TF 1st orbit will be `1st_orbit_of_TF_containig_orbitFirstSamled + i*nHBFPerTF`
4) to ignore time/orbit injection (i.e. recover old behaviour of your readers): use `--hbfutils-config none` option.

