### PR TITLE
Add HMP clustering to async workflow

### DIFF
--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -342,6 +342,7 @@ has_detector MFT && has_processing_step MFT_RECO && add_W o2-mft-reco-workflow "
 has_detector FDD && has_processing_step FDD_RECO && add_W o2-fdd-reco-workflow "$DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $DISABLE_MC"
 has_detector FV0 && has_processing_step FV0_RECO && add_W o2-fv0-reco-workflow "$DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $DISABLE_MC"
 has_detector ZDC && has_processing_step ZDC_RECO && add_W o2-zdc-digits-reco "$DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $DISABLE_MC"
+has_detector HMP && has_processing_step HMP_RECO && add_W o2-hmpid-digits-to-clusters-workflow
 has_detectors_reco MCH MID && has_detector_matching MCHMID && add_W o2-muon-tracks-matcher-workflow "$DISABLE_DIGIT_ROOT_INPUT $DISABLE_MC $DISABLE_ROOT_OUTPUT --pipeline $(get_N globalfwd-track-matcher MATCH REST 1)"
 has_detectors_reco MFT MCH && has_detector_matching MFTMCH && add_W o2-globalfwd-matcher-workflow "$DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $DISABLE_MC --pipeline $(get_N globalfwd-track-matcher MATCH REST 1)"
 


### PR DESCRIPTION
@gvolpe79 I've added the clustering to the async workflow, but I see that `o2-hmpid-digits-to-clusters-workflow` does not support option MC and is not able to read digits and write out clusters. This is not needed for the default dpl-workflow behaviour but usually, when we add some process to `dpl-workflow.sh` we do the same also for the MC based workflows (e.g. sim_challenge.sh). Therefore, you will need digit reader and cluster read/writer specs which should be added in the o2-hmpid-digits-to-clusters-workflow according to the standard options `--disable-root-input`, `--disable-root-output` and `--disable-mc`, see e.g. `FT0/workflow/src/ft0-reco-workflow.cxx`

Eventually, once you will have the matching device, it should be added to this workflow and it can be renamed to o2-hmpid-reco-workfow.
