### PR TITLE
MRRTF-167: (optional) filter out MCH ROFs not matching any ITS-selected IRFrame

### DIFF
--- a/Detectors/MUON/MCH/ROFFiltering/CMakeLists.txt
+++ b/Detectors/MUON/MCH/ROFFiltering/CMakeLists.txt
@@ -10,6 +10,13 @@
 # or submit itself to any jurisdiction.
 
 o2_add_library(MCHROFFiltering
-        SOURCES src/TrackableFilter.cxx
+        SOURCES src/ROFFilter.cxx src/IRFrameFilter.cxx
         PUBLIC_LINK_LIBRARIES O2::MCHBase)
+
+o2_add_executable(
+        fake-irframe-generator-workflow
+        SOURCES src/fake-irframe-generator-workflow.cxx
+        COMPONENT_NAME mch
+        PUBLIC_LINK_LIBRARIES O2::Framework O2::MCHBase)
+
 

--- a/Detectors/MUON/MCH/ROFFiltering/include/MCHROFFiltering/IRFrameFilter.h
+++ b/Detectors/MUON/MCH/ROFFiltering/include/MCHROFFiltering/IRFrameFilter.h
@@ -1,0 +1,36 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_MCH_ROFFILTERING_IRFRAME_FILTER_H_
+#define O2_MCH_ROFFILTERING_IRFRAME_FILTER_H_
+
+#include <functional>
+#include <gsl/span>
+#include "MCHROFFiltering/ROFFilter.h"
+#include "CommonDataFormat/IRFrame.h"
+
+namespace o2::mch
+{
+/** Returns a ROFRecord filter that selects ROFs that overlap
+ * one of the given IRFrame.
+ *
+ * The returned filter is a function that takes a ROFRecord and returns
+ * a boolean.
+ *
+ * @param irframes : the IRFrames (intervals of interaction records)
+ * used to select ROFs
+ */
+
+ROFFilter createIRFrameFilter(gsl::span<const o2::dataformats::IRFrame> irframes);
+
+} // namespace o2::mch
+
+#endif

--- a/Detectors/MUON/MCH/ROFFiltering/include/MCHROFFiltering/MultiplicityFilter.h
+++ b/Detectors/MUON/MCH/ROFFiltering/include/MCHROFFiltering/MultiplicityFilter.h
@@ -14,9 +14,6 @@
 
 #include <functional>
 #include "DataFormatsMCH/ROFRecord.h"
-#include <array>
-#include <gsl/span>
-#include "MCHBase/Trackable.h"
 #include "MCHROFFiltering/ROFFilter.h"
 
 namespace o2::mch

--- a/Detectors/MUON/MCH/ROFFiltering/include/MCHROFFiltering/MultiplicityFilter.h
+++ b/Detectors/MUON/MCH/ROFFiltering/include/MCHROFFiltering/MultiplicityFilter.h
@@ -1,0 +1,44 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_MCH_ROFFILTERING_MULTIPLICITY_FILTER_H_
+#define O2_MCH_ROFFILTERING_MULTIPLICITY_FILTER_H_
+
+#include <functional>
+#include "DataFormatsMCH/ROFRecord.h"
+#include <array>
+#include <gsl/span>
+#include "MCHBase/Trackable.h"
+#include "MCHROFFiltering/ROFFilter.h"
+
+namespace o2::mch
+{
+/** Returns a basic ROFRecord filter that selects ROFs with a minimum number
+ * of entries.
+ *
+ * The returned filter is a function that takes a ROFRecord and returns
+ * a boolean.
+ *
+ * @param minMultiplicity
+ *
+ */
+
+inline ROFFilter
+  createMultiplicityFilter(int minMultiplicity)
+{
+  return [minMultiplicity](const ROFRecord& rof) {
+    return rof.getNEntries() >= minMultiplicity;
+  };
+}
+
+} // namespace o2::mch
+
+#endif

--- a/Detectors/MUON/MCH/ROFFiltering/include/MCHROFFiltering/ROFFilter.h
+++ b/Detectors/MUON/MCH/ROFFiltering/include/MCHROFFiltering/ROFFilter.h
@@ -1,0 +1,32 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_MCH_ROFFILTERING_ROF_FILTER_H_
+#define O2_MCH_ROFFILTERING_ROF_FILTER_H_
+
+#include <functional>
+#include "DataFormatsMCH/ROFRecord.h"
+#include <gsl/span>
+
+namespace o2::mch
+{
+
+/* A ROFFilter is a function that takes a ROFRecord and returns true
+ * if that ROF satisfies the filter criteria.
+ */
+typedef std::function<bool(const ROFRecord&)> ROFFilter;
+
+/** createROFFilter returns a filter that is the AND of the filters in vector.*/
+ROFFilter createROFFilter(gsl::span<const ROFFilter> filters);
+
+} // namespace o2::mch
+
+#endif

--- a/Detectors/MUON/MCH/ROFFiltering/include/MCHROFFiltering/TrackableFilter.h
+++ b/Detectors/MUON/MCH/ROFFiltering/include/MCHROFFiltering/TrackableFilter.h
@@ -17,6 +17,7 @@
 #include <array>
 #include <gsl/span>
 #include "MCHBase/Trackable.h"
+#include "MCHROFFiltering/ROFFilter.h"
 
 namespace o2::mch
 {
@@ -26,8 +27,6 @@ namespace o2::mch
  * a boolean.
  *
  * @param items : the items "pointed to" by the ROFRecords (digits, ...)
- * @param onlyTrackable : if false the filter will always return true
- * (i.e. will be a noop basically)
  *
  * @param requestStation : @ref isTrackable
  * @param moreCandidates : @ref isTrackable
@@ -36,17 +35,11 @@ namespace o2::mch
  */
 
 template <typename T>
-std::function<bool(const ROFRecord&)>
-  createTrackableFilter(gsl::span<const T> items, bool onlyTrackable,
+ROFFilter
+  createTrackableFilter(gsl::span<const T> items,
                         std::array<bool, 5> requestStation = {true, true, true, true, true},
                         bool moreCandidates = false)
 {
-  if (!onlyTrackable) {
-    // return an "always true" filter
-    return [](const ROFRecord&) {
-      return true;
-    };
-  }
   return [items, requestStation, moreCandidates](const ROFRecord& rof) {
     std::array<int, 10> nofItemsPerChamber = perChamber(items.subspan(rof.getFirstIdx(), rof.getNEntries()));
     return isTrackable(nofItemsPerChamber, requestStation, moreCandidates);

--- a/Detectors/MUON/MCH/ROFFiltering/src/IRFrameFilter.cxx
+++ b/Detectors/MUON/MCH/ROFFiltering/src/IRFrameFilter.cxx
@@ -11,7 +11,6 @@
 
 #include "MCHROFFiltering/IRFrameFilter.h"
 #include "CommonDataFormat/InteractionRecord.h"
-#include "Framework/Logger.h"
 
 using o2::InteractionRecord;
 using o2::dataformats::IRFrame;
@@ -25,7 +24,6 @@ ROFFilter createIRFrameFilter(gsl::span<const o2::dataformats::IRFrame> irframes
     InteractionRecord rofEnd = rofStart + rof.getBCWidth();
     IRFrame ref(rofStart, rofEnd);
     for (const auto& ir : irframes) {
-      // LOGP(info, "TOTO ref {} vs ir {}", ref.asString(), ir.asString());
       auto overlap = ref.getOverlap(ir);
       if (overlap.isValid() && !overlap.isZeroLength()) {
         return true;

--- a/Detectors/MUON/MCH/ROFFiltering/src/IRFrameFilter.cxx
+++ b/Detectors/MUON/MCH/ROFFiltering/src/IRFrameFilter.cxx
@@ -1,0 +1,37 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "MCHROFFiltering/IRFrameFilter.h"
+#include "CommonDataFormat/InteractionRecord.h"
+#include "Framework/Logger.h"
+
+using o2::InteractionRecord;
+using o2::dataformats::IRFrame;
+
+namespace o2::mch
+{
+ROFFilter createIRFrameFilter(gsl::span<const o2::dataformats::IRFrame> irframes)
+{
+  return [irframes](const ROFRecord& rof) {
+    InteractionRecord rofStart{rof.getBCData()};
+    InteractionRecord rofEnd = rofStart + rof.getBCWidth();
+    IRFrame ref(rofStart, rofEnd);
+    for (const auto& ir : irframes) {
+      // LOGP(info, "TOTO ref {} vs ir {}", ref.asString(), ir.asString());
+      auto overlap = ref.getOverlap(ir);
+      if (overlap.isValid() && !overlap.isZeroLength()) {
+        return true;
+      }
+    }
+    return false;
+  };
+}
+} // namespace o2::mch

--- a/Detectors/MUON/MCH/ROFFiltering/src/IRFrameFilter.cxx
+++ b/Detectors/MUON/MCH/ROFFiltering/src/IRFrameFilter.cxx
@@ -21,11 +21,11 @@ ROFFilter createIRFrameFilter(gsl::span<const o2::dataformats::IRFrame> irframes
 {
   return [irframes](const ROFRecord& rof) {
     InteractionRecord rofStart{rof.getBCData()};
-    InteractionRecord rofEnd = rofStart + rof.getBCWidth();
+    InteractionRecord rofEnd = rofStart + rof.getBCWidth() - 1;
     IRFrame ref(rofStart, rofEnd);
     for (const auto& ir : irframes) {
       auto overlap = ref.getOverlap(ir);
-      if (overlap.isValid() && !overlap.isZeroLength()) {
+      if (overlap.isValid()) {
         return true;
       }
     }

--- a/Detectors/MUON/MCH/ROFFiltering/src/ROFFilter.cxx
+++ b/Detectors/MUON/MCH/ROFFiltering/src/ROFFilter.cxx
@@ -9,4 +9,19 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#include "MCHROFFiltering/TrackableFilter.h"
+#include "MCHROFFiltering/ROFFilter.h"
+
+namespace o2::mch
+{
+ROFFilter createROFFilter(gsl::span<const ROFFilter> filters)
+{
+  return [filters](const ROFRecord& rof) {
+    for (const auto& filter : filters) {
+      if (!filter(rof)) {
+        return false;
+      }
+    }
+    return true;
+  };
+}
+} // namespace o2::mch

--- a/Detectors/MUON/MCH/ROFFiltering/src/fake-irframe-generator-workflow.cxx
+++ b/Detectors/MUON/MCH/ROFFiltering/src/fake-irframe-generator-workflow.cxx
@@ -1,0 +1,118 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "DataFormatsMCH/Digit.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/ControlService.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/DataSpecUtils.h"
+#include "Framework/Lifetime.h"
+#include "Framework/Logger.h"
+#include "Framework/Output.h"
+#include "Framework/Task.h"
+#include "Framework/WorkflowSpec.h"
+#include "CommonDataFormat/IRFrame.h"
+#include "CommonDataFormat/InteractionRecord.h"
+#include <array>
+#include <chrono>
+#include <cstring>
+#include <fmt/format.h>
+#include <fstream>
+#include <iostream>
+#include <random>
+#include <stdexcept>
+#include <vector>
+#include <rapidjson/document.h>
+#include <rapidjson/istreamwrapper.h>
+
+using namespace o2::mch;
+using namespace o2::framework;
+
+/** A utility class to inject fake ITS/IRFRAMES into a workflow.
+ *
+ * For debug only, of course.
+ *
+ */
+class IRFrameGenerator : public Task
+{
+ public:
+  void init(InitContext& ic)
+  {
+    std::stringstream in(ic.options().get<std::string>("irframes"));
+    rapidjson::IStreamWrapper isw(in);
+    rapidjson::Document d;
+    d.ParseStream(isw);
+
+    if (!d.IsArray()) {
+      throw std::runtime_error(fmt::format("input string is not expected json : {}", in.str()));
+    }
+    for (auto& v : d.GetArray()) {
+      const auto& jstart = v["min"].GetObject();
+      o2::InteractionRecord start{static_cast<uint16_t>(std::stoi(jstart["bc"].GetString())),
+                                  static_cast<uint32_t>(std::stoi(jstart["orbit"].GetString()))};
+      const auto& jend = v["max"].GetObject();
+      o2::InteractionRecord end{static_cast<uint16_t>(std::stoi(jend["bc"].GetString())),
+                                static_cast<uint32_t>(std::stoi(jend["orbit"].GetString()))};
+      mIRFrames.emplace_back(start, end);
+    }
+    LOGP(info, "Fake IRFrames to be used");
+    for (const auto& ir : mIRFrames) {
+      LOGP(info, "{}", ir.asString());
+    }
+  }
+
+  void run(ProcessingContext& pc)
+  {
+    pc.outputs().snapshot(OutputRef{"irframes"}, mIRFrames);
+  }
+
+ private:
+  std::vector<o2::dataformats::IRFrame> mIRFrames;
+};
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(const ConfigContext& cc)
+{
+  std::string defaultFrames = R"(
+[
+  {
+    "min": {
+      "bc": "0",
+      "orbit": "1021"
+    },
+    "max": {
+      "bc": "1000",
+      "orbit": "1021"
+    }
+  },
+  {
+    "min": {
+      "bc": "2000",
+      "orbit": "1023"
+    },
+    "max": {
+      "bc": "2500",
+      "orbit": "1023"
+    }
+  }
+])";
+  return WorkflowSpec{
+    DataProcessorSpec{
+      "mch-fake-irframe-generator",
+      Inputs{InputSpec{"digits", "MCH", "DIGITS", 0, Lifetime::Timeframe}},
+      Outputs{
+        OutputSpec{{"irframes"}, "ITS", "IRFRAMES", 0, Lifetime::Timeframe}},
+      AlgorithmSpec{adaptFromTask<IRFrameGenerator>()},
+      Options{
+        {"irframes", VariantType::String, defaultFrames, {"list of IRFrame to fake (json format)"}}}}};
+}

--- a/Detectors/MUON/MCH/ROFFiltering/src/fake-irframe-generator-workflow.cxx
+++ b/Detectors/MUON/MCH/ROFFiltering/src/fake-irframe-generator-workflow.cxx
@@ -22,13 +22,8 @@
 #include "Framework/WorkflowSpec.h"
 #include "CommonDataFormat/IRFrame.h"
 #include "CommonDataFormat/InteractionRecord.h"
-#include <array>
-#include <chrono>
-#include <cstring>
 #include <fmt/format.h>
-#include <fstream>
-#include <iostream>
-#include <random>
+#include <sstream>
 #include <stdexcept>
 #include <vector>
 #include <rapidjson/document.h>

--- a/Detectors/MUON/MCH/ROFFiltering/src/fake-irframe-generator-workflow.cxx
+++ b/Detectors/MUON/MCH/ROFFiltering/src/fake-irframe-generator-workflow.cxx
@@ -45,7 +45,7 @@ using namespace o2::framework;
 class IRFrameGenerator : public Task
 {
  public:
-  void init(InitContext& ic)
+  void init(InitContext& ic) override
   {
     std::stringstream in(ic.options().get<std::string>("irframes"));
     rapidjson::IStreamWrapper isw(in);
@@ -70,7 +70,7 @@ class IRFrameGenerator : public Task
     }
   }
 
-  void run(ProcessingContext& pc)
+  void run(ProcessingContext& pc) override
   {
     pc.outputs().snapshot(OutputRef{"irframes"}, mIRFrames);
   }

--- a/Detectors/MUON/MCH/TimeClustering/include/MCHTimeClustering/TimeClusterFinderSpec.h
+++ b/Detectors/MUON/MCH/TimeClustering/include/MCHTimeClustering/TimeClusterFinderSpec.h
@@ -28,7 +28,8 @@ o2::framework::DataProcessorSpec
   getTimeClusterFinderSpec(const char* specName = "mch-time-cluster-finder",
                            std::string_view inputDigitDataDescription = "F-DIGITS",
                            std::string_view inputDigitRofDataDescription = "F-DIGITROFS",
-                           std::string_view outputDigitRofDataDescription = "TC-F-DIGITROFS");
+                           std::string_view outputDigitRofDataDescription = "TC-F-DIGITROFS",
+                           std::string_view inputIRFrameDataDescription = "ITS/IRFRAMES");
 
 } // end namespace mch
 } // end namespace o2

--- a/Detectors/MUON/MCH/TimeClustering/include/MCHTimeClustering/TimeClusterizerParam.h
+++ b/Detectors/MUON/MCH/TimeClustering/include/MCHTimeClustering/TimeClusterizerParam.h
@@ -24,11 +24,13 @@ namespace o2::mch
  */
 struct TimeClusterizerParam : public o2::conf::ConfigurableParamHelper<TimeClusterizerParam> {
 
-  bool onlyTrackable = true;        ///< only output ROFs that match the trackable condition @see MCHBase/Trackable.h
+  bool onlyTrackable = true; ///< only output ROFs that match the trackable condition @see MCHROFFiltering/TrackableFilter
+
   int maxClusterWidth = 1000 / 25;  ///< maximum time width of time clusters, in BC units
   int peakSearchNbins = 5;          ///< number of time bins for the peak search algorithm (must be an odd number >= 3)
   int minDigitsPerROF = 0;          ///< minimum number of digits per ROF (below that threshold ROF is discarded)
   bool peakSearchSignalOnly = true; ///< only use signal-like hits in peak search
+  bool irFramesOnly = false;        ///< only output ROFs that overlap one of the IRFrames (provided externally, e.g. by ITS) @see MCHROFFiltering/IRFrameFilter
 
   O2ParamDef(TimeClusterizerParam, "MCHTimeClusterizer");
 };

--- a/Detectors/MUON/MCH/TimeClustering/src/TimeClusterFinderSpec.cxx
+++ b/Detectors/MUON/MCH/TimeClustering/src/TimeClusterFinderSpec.cxx
@@ -191,6 +191,7 @@ o2::framework::DataProcessorSpec
                                   inputDigitRofDataDescription.data(),
                                   inputDigitDataDescription.data());
   if (TimeClusterizerParam::Instance().irFramesOnly && inputIRFrameDataDescription.size()) {
+    LOGP(info, "will select IRFrames from {}", inputIRFrameDataDescription);
     input += ";irframes:";
     input += inputIRFrameDataDescription;
   }

--- a/Detectors/MUON/MCH/TimeClustering/src/TimeClusterFinderSpec.cxx
+++ b/Detectors/MUON/MCH/TimeClustering/src/TimeClusterFinderSpec.cxx
@@ -20,10 +20,11 @@
 #include <fstream>
 #include <chrono>
 #include <vector>
-
 #include <stdexcept>
 
 #include <fmt/core.h>
+
+#include "CommonDataFormat/IRFrame.h"
 
 #include "Framework/CallbackService.h"
 #include "Framework/ConfigParamRegistry.h"
@@ -36,9 +37,11 @@
 #include "Framework/WorkflowSpec.h"
 
 #include "MCHBase/TrackerParam.h"
+#include "MCHDigitFiltering/DigitFilter.h"
+#include "MCHROFFiltering/IRFrameFilter.h"
+#include "MCHROFFiltering/MultiplicityFilter.h"
 #include "MCHROFFiltering/TrackableFilter.h"
 #include "MCHTimeClustering/ROFTimeClusterFinder.h"
-#include "MCHDigitFiltering/DigitFilter.h"
 #include "MCHTimeClustering/TimeClusterizerParam.h"
 
 namespace o2
@@ -61,6 +64,7 @@ class TimeClusterFinderTask
     mMinDigitPerROF = param.minDigitsPerROF;
     mOnlyTrackable = param.onlyTrackable;
     mPeakSearchSignalOnly = param.peakSearchSignalOnly;
+    mIRFramesOnly = param.irFramesOnly;
     mDebug = ic.options().get<bool>("mch-debug");
 
     if (mDebug) {
@@ -75,10 +79,12 @@ class TimeClusterFinderTask
       mNbinsInOneWindow += 1;
     }
 
-    LOGP(info, "max-cluster-width : {}", mTimeClusterWidth);
-    LOGP(info, "peak-search-nbins: {} ", mNbinsInOneWindow);
-    LOGP(info, "min-digits-per-rof: {}", mMinDigitPerROF);
-    LOGP(info, "only-trackable : {}", mOnlyTrackable);
+    LOGP(info, "TimeClusterWidth    : {}", mTimeClusterWidth);
+    LOGP(info, "BinsInOneWindow     : {} ", mNbinsInOneWindow);
+    LOGP(info, "MinDigitPerROF      : {}", mMinDigitPerROF);
+    LOGP(info, "OnlyTrackable       : {}", mOnlyTrackable);
+    LOGP(info, "PeakSearchSignalOnly: {}", mPeakSearchSignalOnly);
+    LOGP(info, "IRFramesOnly        : {}", mIRFramesOnly);
 
     auto stop = [this]() {
       if (mTFcount) {
@@ -98,7 +104,6 @@ class TimeClusterFinderTask
 
     if (mDebug) {
       LOGP(warning, "{:=>60} ", fmt::format("{:6d} Input ROFS", rofs.size()));
-      // rofProcessor.dumpInputROFs();
     }
 
     auto tStart = std::chrono::high_resolution_clock::now();
@@ -108,31 +113,44 @@ class TimeClusterFinderTask
 
     if (mDebug) {
       LOGP(warning, "{:=>60} ", fmt::format("{:6d} Output ROFS", rofProcessor.getROFRecords().size()));
-      // rofProcessor.dumpOutputROFs();
     }
 
     auto& outRofs = pc.outputs().make<std::vector<ROFRecord>>(OutputRef{"rofs"});
     const auto& pRofs = rofProcessor.getROFRecords();
 
-    const auto& trackerParam = TrackerParam::Instance();
-    std::array<bool, 5> requestStation{
-      trackerParam.requestStation[0],
-      trackerParam.requestStation[1],
-      trackerParam.requestStation[2],
-      trackerParam.requestStation[3],
-      trackerParam.requestStation[4]};
+    // prepare the list of filters we want to apply to ROFs
+    std::vector<ROFFilter> filters;
 
-    auto tfilter = createTrackableFilter(digits, mOnlyTrackable,
-                                         requestStation,
-                                         trackerParam.moreCandidates);
+    if (mOnlyTrackable) {
+      // selects only ROFs that are trackable
+      const auto& trackerParam = TrackerParam::Instance();
+      std::array<bool, 5> requestStation{
+        trackerParam.requestStation[0],
+        trackerParam.requestStation[1],
+        trackerParam.requestStation[2],
+        trackerParam.requestStation[3],
+        trackerParam.requestStation[4]};
+      filters.emplace_back(createTrackableFilter(digits,
+                                                 requestStation,
+                                                 trackerParam.moreCandidates));
+    }
+    if (mMinDigitPerROF > 0) {
+      // selects only those ROFs have that minimum number of digits
+      filters.emplace_back(createMultiplicityFilter(mMinDigitPerROF));
+    }
+    if (mIRFramesOnly) {
+      // selects only those ROFs that overlop some IRFrame
+      auto irFrames = pc.inputs().get<gsl::span<o2::dataformats::IRFrame>>("irframes");
+      filters.emplace_back(createIRFrameFilter(irFrames));
+    }
+
+    // a single filter which is the AND combination of the elements of the filters vector
+    auto filter = createROFFilter(filters);
 
     std::copy_if(begin(pRofs),
                  end(pRofs),
                  std::back_inserter(outRofs),
-                 [this, tfilter](const o2::mch::ROFRecord& rof) {
-                   return rof.getNEntries() > mMinDigitPerROF &&
-                          tfilter(rof);
-                 });
+                 filter);
 
     const float p1 = rofs.size() > 0 ? 100. * pRofs.size() / rofs.size() : 0;
     const float p2 = rofs.size() > 0 ? 100. * outRofs.size() / rofs.size() : 0;
@@ -140,12 +158,10 @@ class TimeClusterFinderTask
     LOGP(info,
          "TF {} Processed {} input ROFs, "
          "time-clusterized them into {} ROFs ({:3.0f}%) "
-         "and output {} ({:3.0f}%) "
-         "of them {}",
+         "and output {} ({:3.0f}%) of them",
          mTFcount, rofs.size(),
          pRofs.size(), p1,
-         outRofs.size(), p2,
-         mOnlyTrackable ? "(only trackable ones)" : "");
+         outRofs.size(), p2);
     mTFcount += 1;
   }
 
@@ -160,6 +176,7 @@ class TimeClusterFinderTask
   int mMinDigitPerROF;        ///< minimum digit per ROF threshold
   bool mPeakSearchSignalOnly; ///< only use signal-like hits in peak search
   bool mOnlyTrackable;        ///< only keep ROFs that are trackable
+  bool mIRFramesOnly;         ///< only keep ROFs that overlap some IRFrame
 };
 
 //_________________________________________________________________________________________________
@@ -167,11 +184,16 @@ o2::framework::DataProcessorSpec
   getTimeClusterFinderSpec(const char* specName,
                            std::string_view inputDigitDataDescription,
                            std::string_view inputDigitRofDataDescription,
-                           std::string_view outputDigitRofDataDescription)
+                           std::string_view outputDigitRofDataDescription,
+                           std::string_view inputIRFrameDataDescription)
 {
   std::string input = fmt::format("rofs:MCH/{}/0;digits:MCH/{}/0",
                                   inputDigitRofDataDescription.data(),
                                   inputDigitDataDescription.data());
+  if (TimeClusterizerParam::Instance().irFramesOnly && inputIRFrameDataDescription.size()) {
+    input += ";irframes:";
+    input += inputIRFrameDataDescription;
+  }
   std::string output = fmt::format("rofs:MCH/{}/0", outputDigitRofDataDescription.data());
 
   std::vector<OutputSpec> outputs;


### PR DESCRIPTION
@aferrero2707 here's the introduction of the filter on IRFrames. When applied, it is done at the end of the [`TimeClusterFinderSpec.cxx`](https://github.com/AliceO2Group/AliceO2/compare/dev...aphecetche:mrrtf-167-filter-rof-using-its-irframes?expand=1#diff-a4c8993892ed009dcbbfbab877f0e1f7de716da869dc7c9d8e4ba0c6409570d1), like e.g. the trackable-only filter.

@pillot note that the trackable filter is now always doing something (https://github.com/AliceO2Group/AliceO2/pull/8833#discussion_r873669287) : the no-op was removed.

I did not test it with "real" `ITS/IRFRAMES` but with fake (and thus controlled) ones using a custom made test device :  [`fake-irframe-generator-workflow.cxx`](https://github.com/AliceO2Group/AliceO2/compare/dev...aphecetche:mrrtf-167-filter-rof-using-its-irframes?expand=1#diff-1e0ebb71dfa0d44aa07800d4c76c948a02f6b6fc2f9af7fcec31bd6199ff7bc6)
