### PR TITLE
Report detector contribution to CTF before/after compression

### DIFF
--- a/DataFormats/Detectors/Common/CMakeLists.txt
+++ b/DataFormats/Detectors/Common/CMakeLists.txt
@@ -15,6 +15,7 @@ o2_add_library(DetectorsCommonDataFormats
                        src/EncodedBlocks.cxx
                        src/CTFHeader.cxx
                        src/CTFDictHeader.cxx
+                       src/CTFIOSize.cxx
          src/FileMetaData.cxx
                PUBLIC_LINK_LIBRARIES
                ROOT::Core
@@ -36,6 +37,7 @@ o2_target_root_dictionary(
           include/DetectorsCommonDataFormats/EncodedBlocks.h
           include/DetectorsCommonDataFormats/CTFHeader.h
           include/DetectorsCommonDataFormats/CTFDictHeader.h
+          include/DetectorsCommonDataFormats/CTFIOSize.h
           include/DetectorsCommonDataFormats/DetMatrixCache.h)
 
 configure_file(UpgradesStatus.h.in

--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/CTFIOSize.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/CTFIOSize.h
@@ -1,0 +1,55 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @brief  pair of input and output size
+
+#ifndef ALICEO2_CTFIO_SIZE_H
+#define ALICEO2_CTFIO_SIZE_H
+
+#include "GPUCommonRtypes.h"
+#include <string>
+
+namespace o2::ctf
+{
+struct CTFIOSize {
+  size_t rawIn = 0;  // input size to compression
+  size_t ctfIn = 0;  // input size to entropy encoding
+  size_t ctfOut = 0; // encoded output
+
+  bool operator==(const CTFIOSize& other) const { return (rawIn == other.rawIn) && (ctfIn == other.ctfIn) && (ctfOut == other.ctfOut); }
+  bool operator!=(const CTFIOSize& other) const { return (rawIn != other.rawIn) || (ctfIn != other.ctfIn) || (ctfOut != other.ctfOut); }
+  CTFIOSize operator+(const CTFIOSize& other) const { return {rawIn + other.rawIn, ctfIn + other.ctfIn, ctfOut + other.ctfOut}; }
+  CTFIOSize operator-(const CTFIOSize& other) const { return {rawIn - other.rawIn, ctfIn + other.ctfIn, ctfOut - other.ctfOut}; }
+
+  CTFIOSize& operator+=(const CTFIOSize& other)
+  {
+    rawIn += other.rawIn;
+    ctfIn += other.ctfIn;
+    ctfOut += other.ctfOut;
+    return *this;
+  }
+
+  CTFIOSize& operator-=(const CTFIOSize& other)
+  {
+    rawIn -= other.rawIn;
+    ctfIn -= other.ctfIn;
+    ctfOut -= other.ctfOut;
+    return *this;
+  }
+
+  std::string asString() const;
+
+  ClassDefNV(CTFIOSize, 1);
+};
+
+} // namespace o2::ctf
+
+#endif

--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/EncodedBlocks.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/EncodedBlocks.h
@@ -27,6 +27,7 @@
 #include "CommonUtils/StringUtils.h"
 #include "Framework/Logger.h"
 #include "DetectorsCommonDataFormats/CTFDictHeader.h"
+#include "DetectorsCommonDataFormats/CTFIOSize.h"
 
 namespace o2
 {
@@ -121,6 +122,8 @@ struct Metadata {
   int nDataWords = 0;
   int nLiteralWords = 0;
 
+  size_t getUncompressedSize() const { return messageLength * messageWordSize; }
+  size_t getCompressedSize() const { return (nDictWords + nDataWords + nLiteralWords) * streamSize; }
   void clear()
   {
     min = max = 0;
@@ -432,22 +435,22 @@ class EncodedBlocks
 
   /// encode vector src to bloc at provided slot
   template <typename VE, typename buffer_T>
-  inline void encode(const VE& src, int slot, uint8_t symbolTablePrecision, Metadata::OptStore opt, buffer_T* buffer = nullptr, const void* encoderExt = nullptr, float memfc = 1.f)
+  inline o2::ctf::CTFIOSize encode(const VE& src, int slot, uint8_t symbolTablePrecision, Metadata::OptStore opt, buffer_T* buffer = nullptr, const void* encoderExt = nullptr, float memfc = 1.f)
   {
-    encode(std::begin(src), std::end(src), slot, symbolTablePrecision, opt, buffer, encoderExt, memfc);
+    return encode(std::begin(src), std::end(src), slot, symbolTablePrecision, opt, buffer, encoderExt, memfc);
   }
 
   /// encode vector src to bloc at provided slot
   template <typename input_IT, typename buffer_T>
-  void encode(const input_IT srcBegin, const input_IT srcEnd, int slot, uint8_t symbolTablePrecision, Metadata::OptStore opt, buffer_T* buffer = nullptr, const void* encoderExt = nullptr, float memfc = 1.f);
+  o2::ctf::CTFIOSize encode(const input_IT srcBegin, const input_IT srcEnd, int slot, uint8_t symbolTablePrecision, Metadata::OptStore opt, buffer_T* buffer = nullptr, const void* encoderExt = nullptr, float memfc = 1.f);
 
   /// decode block at provided slot to destination vector (will be resized as needed)
   template <class container_T, class container_IT = typename container_T::iterator>
-  void decode(container_T& dest, int slot, const void* decoderExt = nullptr) const;
+  o2::ctf::CTFIOSize decode(container_T& dest, int slot, const void* decoderExt = nullptr) const;
 
   /// decode block at provided slot to destination pointer, the needed space assumed to be available
   template <typename D_IT, std::enable_if_t<detail::is_iterator_v<D_IT>, bool> = true>
-  void decode(D_IT dest, int slot, const void* decoderExt = nullptr) const;
+  o2::ctf::CTFIOSize decode(D_IT dest, int slot, const void* decoderExt = nullptr) const;
 
   /// create a special EncodedBlocks containing only dictionaries made from provided vector of frequency tables
   static std::vector<char> createDictionaryBlocks(const std::vector<o2::rans::FrequencyTable>& vfreq, const std::vector<Metadata>& prbits);
@@ -753,20 +756,20 @@ void EncodedBlocks<H, N, W>::print(const std::string& prefix, int verbosity) con
 ///_____________________________________________________________________________
 template <typename H, int N, typename W>
 template <class container_T, class container_IT>
-inline void EncodedBlocks<H, N, W>::decode(container_T& dest,            // destination container
-                                           int slot,                     // slot of the block to decode
-                                           const void* decoderExt) const // optional externally provided decoder
+inline o2::ctf::CTFIOSize EncodedBlocks<H, N, W>::decode(container_T& dest,            // destination container
+                                                         int slot,                     // slot of the block to decode
+                                                         const void* decoderExt) const // optional externally provided decoder
 {
   dest.resize(mMetadata[slot].messageLength); // allocate output buffer
-  decode(std::begin(dest), slot, decoderExt);
+  return decode(std::begin(dest), slot, decoderExt);
 }
 
 ///_____________________________________________________________________________
 template <typename H, int N, typename W>
 template <typename D_IT, std::enable_if_t<detail::is_iterator_v<D_IT>, bool>>
-void EncodedBlocks<H, N, W>::decode(D_IT dest,                    // iterator to destination
-                                    int slot,                     // slot of the block to decode
-                                    const void* decoderExt) const // optional externally provided decoder
+o2::ctf::CTFIOSize EncodedBlocks<H, N, W>::decode(D_IT dest,                    // iterator to destination
+                                                  int slot,                     // slot of the block to decode
+                                                  const void* decoderExt) const // optional externally provided decoder
 {
   // get references to the right data
   const auto& block = mBlocks[slot];
@@ -810,19 +813,20 @@ void EncodedBlocks<H, N, W>::decode(D_IT dest,                    // iterator to
       // std::memcpy(dest, block.payload, md.messageLength * sizeof(dest_t));
     }
   }
+  return {0, md.getUncompressedSize(), md.getCompressedSize()};
 }
 
 ///_____________________________________________________________________________
 template <typename H, int N, typename W>
 template <typename input_IT, typename buffer_T>
-void EncodedBlocks<H, N, W>::encode(const input_IT srcBegin,      // iterator begin of source message
-                                    const input_IT srcEnd,        // iterator end of source message
-                                    int slot,                     // slot in encoded data to fill
-                                    uint8_t symbolTablePrecision, // encoding into
-                                    Metadata::OptStore opt,       // option for data compression
-                                    buffer_T* buffer,             // optional buffer (vector) providing memory for encoded blocks
-                                    const void* encoderExt,       // optional external encoder
-                                    float memfc)                  // memory allocation margin factor
+o2::ctf::CTFIOSize EncodedBlocks<H, N, W>::encode(const input_IT srcBegin,      // iterator begin of source message
+                                                  const input_IT srcEnd,        // iterator end of source message
+                                                  int slot,                     // slot in encoded data to fill
+                                                  uint8_t symbolTablePrecision, // encoding into
+                                                  Metadata::OptStore opt,       // option for data compression
+                                                  buffer_T* buffer,             // optional buffer (vector) providing memory for encoded blocks
+                                                  const void* encoderExt,       // optional external encoder
+                                                  float memfc)                  // memory allocation margin factor
 {
 
   using storageBuffer_t = W;
@@ -848,7 +852,7 @@ void EncodedBlocks<H, N, W>::encode(const input_IT srcBegin,      // iterator be
   // case 1: empty source message
   if (messageLength == 0) {
     mMetadata[slot] = Metadata{0, 0, sizeof(input_t), sizeof(ransState_t), sizeof(ransStream_t), symbolTablePrecision, Metadata::OptStore::NODATA, 0, 0, 0, 0, 0};
-    return;
+    return {};
   }
 
   auto* thisBlock = &mBlocks[slot];
@@ -955,6 +959,7 @@ void EncodedBlocks<H, N, W>::encode(const input_IT srcBegin,      // iterator be
 
     *thisMetadata = Metadata{messageLength, 0, sizeof(input_t), sizeof(ransState_t), sizeof(storageBuffer_t), symbolTablePrecision, opt, 0, 0, 0, static_cast<int>(nBufferElems), 0};
   }
+  return {0, thisMetadata->getUncompressedSize(), thisMetadata->getCompressedSize()};
 }
 
 /// create a special EncodedBlocks containing only dictionaries made from provided vector of frequency tables

--- a/DataFormats/Detectors/Common/src/CTFIOSize.cxx
+++ b/DataFormats/Detectors/Common/src/CTFIOSize.cxx
@@ -1,0 +1,22 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @brief  pair of input and output size
+
+#include "DetectorsCommonDataFormats/CTFIOSize.h"
+#include "Framework/Logger.h"
+
+using namespace o2::ctf;
+
+std::string CTFIOSize::asString() const
+{
+  return fmt::format("raw input:{}/input to encode:{}/ctf size:{} bytes", rawIn, ctfIn, ctfOut);
+}

--- a/DataFormats/Detectors/Common/src/DetectorsCommonDataFormatsLinkDef.h
+++ b/DataFormats/Detectors/Common/src/DetectorsCommonDataFormatsLinkDef.h
@@ -36,5 +36,6 @@
 #pragma link C++ class o2::ctf::Block < uint8_t> + ;
 #pragma link C++ class o2::ctf::Metadata + ;
 #pragma link C++ class o2::ctf::ANSHeader + ;
+#pragma link C++ class o2::ctf::CTFIOSize + ;
 
 #endif

--- a/Detectors/Base/include/DetectorsBase/CTFCoderBase.h
+++ b/Detectors/Base/include/DetectorsBase/CTFCoderBase.h
@@ -23,6 +23,7 @@
 #include "CommonUtils/NameConf.h"
 #include "DetectorsCommonDataFormats/CTFDictHeader.h"
 #include "DetectorsCommonDataFormats/CTFHeader.h"
+#include "DetectorsCommonDataFormats/CTFIOSize.h"
 #include "rANS/rans.h"
 #include <filesystem>
 #include "Framework/InitContext.h"

--- a/Detectors/CPV/reconstruction/include/CPVReconstruction/CTFCoder.h
+++ b/Detectors/CPV/reconstruction/include/CPVReconstruction/CTFCoder.h
@@ -41,11 +41,11 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 
   /// entropy-encode data to buffer with CTF
   template <typename VEC>
-  void encode(VEC& buff, const gsl::span<const TriggerRecord>& trigData, const gsl::span<const Cluster>& cluData);
+  o2::ctf::CTFIOSize encode(VEC& buff, const gsl::span<const TriggerRecord>& trigData, const gsl::span<const Cluster>& cluData);
 
   /// entropy decode data from buffer with CTF
   template <typename VTRG, typename VCLUSTER>
-  void decode(const CTF::base& ec, VTRG& trigVec, VCLUSTER& cluVec);
+  o2::ctf::CTFIOSize decode(const CTF::base& ec, VTRG& trigVec, VCLUSTER& cluVec);
 
   void createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op) final;
 
@@ -56,7 +56,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 
 /// entropy-encode clusters to buffer with CTF
 template <typename VEC>
-void CTFCoder::encode(VEC& buff, const gsl::span<const TriggerRecord>& trigData, const gsl::span<const Cluster>& cluData)
+o2::ctf::CTFIOSize CTFCoder::encode(VEC& buff, const gsl::span<const TriggerRecord>& trigData, const gsl::span<const Cluster>& cluData)
 {
   using MD = o2::ctf::Metadata::OptStore;
   // what to do which each field: see o2::ctd::Metadata explanation
@@ -84,23 +84,27 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const TriggerRecord>& trigData,
   ec->getANSHeader().majorVersion = 0;
   ec->getANSHeader().minorVersion = 1;
   // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
+  o2::ctf::CTFIOSize iosize;
 #define ENCODECPV(beg, end, slot, bits) CTF::get(buff.data())->encode(beg, end, int(slot), bits, optField[int(slot)], &buff, mCoders[int(slot)].get(), getMemMarginFactor());
   // clang-format off
-  ENCODECPV(helper.begin_bcIncTrig(),    helper.end_bcIncTrig(),     CTF::BLC_bcIncTrig,    0);
-  ENCODECPV(helper.begin_orbitIncTrig(), helper.end_orbitIncTrig(),  CTF::BLC_orbitIncTrig, 0);
-  ENCODECPV(helper.begin_entriesTrig(),  helper.end_entriesTrig(),   CTF::BLC_entriesTrig,  0);
+  iosize += ENCODECPV(helper.begin_bcIncTrig(),    helper.end_bcIncTrig(),     CTF::BLC_bcIncTrig,    0);
+  iosize += ENCODECPV(helper.begin_orbitIncTrig(), helper.end_orbitIncTrig(),  CTF::BLC_orbitIncTrig, 0);
+  iosize += ENCODECPV(helper.begin_entriesTrig(),  helper.end_entriesTrig(),   CTF::BLC_entriesTrig,  0);
 
-  ENCODECPV(helper.begin_posX(),        helper.end_posX(),           CTF::BLC_posX,         0);
-  ENCODECPV(helper.begin_posZ(),        helper.end_posZ(),           CTF::BLC_posZ,         0);
-  ENCODECPV(helper.begin_energy(),      helper.end_energy(),         CTF::BLC_energy,       0);
-  ENCODECPV(helper.begin_status(),      helper.end_status(),         CTF::BLC_status,       0);
+  iosize += ENCODECPV(helper.begin_posX(),        helper.end_posX(),           CTF::BLC_posX,         0);
+  iosize += ENCODECPV(helper.begin_posZ(),        helper.end_posZ(),           CTF::BLC_posZ,         0);
+  iosize += ENCODECPV(helper.begin_energy(),      helper.end_energy(),         CTF::BLC_energy,       0);
+  iosize += ENCODECPV(helper.begin_status(),      helper.end_status(),         CTF::BLC_status,       0);
   // clang-format on
   CTF::get(buff.data())->print(getPrefix(), mVerbosity);
+  finaliseCTFOutput<CTF>(buff);
+  iosize.rawIn = trigData.size() * sizeof(TriggerRecord) + cluData.size() * sizeof(Cluster);
+  return iosize;
 }
 
 /// decode entropy-encoded clusters to standard compact clusters
 template <typename VTRG, typename VCLUSTER>
-void CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VCLUSTER& cluVec)
+o2::ctf::CTFIOSize CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VCLUSTER& cluVec)
 {
   auto header = ec.getHeader();
   checkDictVersion(static_cast<const o2::ctf::CTFDictHeader&>(header));
@@ -109,15 +113,16 @@ void CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VCLUSTER& cluVec)
   std::vector<uint32_t> orbitInc;
   std::vector<uint8_t> energy, status;
 
+  o2::ctf::CTFIOSize iosize;
 #define DECODECPV(part, slot) ec.decode(part, int(slot), mCoders[int(slot)].get())
   // clang-format off
-  DECODECPV(bcInc,       CTF::BLC_bcIncTrig);
-  DECODECPV(orbitInc,    CTF::BLC_orbitIncTrig);
-  DECODECPV(entries,     CTF::BLC_entriesTrig);
-  DECODECPV(posX,        CTF::BLC_posX);
-  DECODECPV(posZ,        CTF::BLC_posZ);
-  DECODECPV(energy,      CTF::BLC_energy);
-  DECODECPV(status,      CTF::BLC_status);
+  iosize += DECODECPV(bcInc,       CTF::BLC_bcIncTrig);
+  iosize += DECODECPV(orbitInc,    CTF::BLC_orbitIncTrig);
+  iosize += DECODECPV(entries,     CTF::BLC_entriesTrig);
+  iosize += DECODECPV(posX,        CTF::BLC_posX);
+  iosize += DECODECPV(posZ,        CTF::BLC_posZ);
+  iosize += DECODECPV(energy,      CTF::BLC_energy);
+  iosize += DECODECPV(status,      CTF::BLC_status);
   // clang-format on
   //
   trigVec.clear();
@@ -147,6 +152,8 @@ void CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VCLUSTER& cluVec)
     trigVec.emplace_back(ir, firstEntry, entries[itrig]);
   }
   assert(cluCount == header.nClusters);
+  iosize.rawIn = trigVec.size() * sizeof(TriggerRecord) + cluVec.size() * sizeof(Cluster);
+  return iosize;
 }
 
 } // namespace cpv

--- a/Detectors/CPV/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/CPV/workflow/src/EntropyDecoderSpec.cxx
@@ -48,6 +48,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
 {
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
+  o2::ctf::CTFIOSize iosize;
 
   mCTFCoder.updateTimeDependentParams(pc);
   auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
@@ -58,10 +59,11 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   // since the buff is const, we cannot use EncodedBlocks::relocate directly, instead we wrap its data to another flat object
   if (buff.size()) {
     const auto ctfImage = o2::cpv::CTF::getImage(buff.data());
-    mCTFCoder.decode(ctfImage, triggers, clusters);
+    iosize = mCTFCoder.decode(ctfImage, triggers, clusters);
   }
+  pc.outputs().snapshot({"ctfrep", 0}, iosize);
   mTimer.Stop();
-  LOG(info) << "Decoded " << clusters.size() << " CPV clusters in " << triggers.size() << " triggers in " << mTimer.CpuTime() - cput << " s";
+  LOG(info) << "Decoded " << clusters.size() << " CPV clusters in " << triggers.size() << " triggers, (" << iosize.asString() << ") in " << mTimer.CpuTime() - cput << " s";
 }
 
 void EntropyDecoderSpec::endOfStream(EndOfStreamContext& ec)
@@ -74,7 +76,8 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
 {
   std::vector<OutputSpec> outputs{
     OutputSpec{{"triggers"}, "CPV", "CLUSTERTRIGRECS", 0, Lifetime::Timeframe},
-    OutputSpec{{"clusters"}, "CPV", "CLUSTERS", 0, Lifetime::Timeframe}};
+    OutputSpec{{"clusters"}, "CPV", "CLUSTERS", 0, Lifetime::Timeframe},
+    OutputSpec{{"ctfrep"}, "CPV", "CTFDECREP", 0, Lifetime::Timeframe}};
 
   std::vector<InputSpec> inputs;
   inputs.emplace_back("ctf", "CPV", "CTFDATA", sspec, Lifetime::Timeframe);

--- a/Detectors/CTP/reconstruction/include/CTPReconstruction/CTFCoder.h
+++ b/Detectors/CTP/reconstruction/include/CTPReconstruction/CTFCoder.h
@@ -41,11 +41,11 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 
   /// entropy-encode data to buffer with CTF
   template <typename VEC>
-  void encode(VEC& buff, const gsl::span<const CTPDigit>& data);
+  o2::ctf::CTFIOSize encode(VEC& buff, const gsl::span<const CTPDigit>& data);
 
   /// entropy decode data from buffer with CTF
   template <typename VTRG>
-  void decode(const CTF::base& ec, VTRG& data);
+  o2::ctf::CTFIOSize decode(const CTF::base& ec, VTRG& data);
 
   void createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op) final;
 
@@ -56,7 +56,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 
 /// entropy-encode clusters to buffer with CTF
 template <typename VEC>
-void CTFCoder::encode(VEC& buff, const gsl::span<const CTPDigit>& data)
+o2::ctf::CTFIOSize CTFCoder::encode(VEC& buff, const gsl::span<const CTPDigit>& data)
 {
   using MD = o2::ctf::Metadata::OptStore;
   // what to do which each field: see o2::ctd::Metadata explanation
@@ -81,21 +81,23 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const CTPDigit>& data)
   ec->getANSHeader().majorVersion = 0;
   ec->getANSHeader().minorVersion = 1;
   // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
+  o2::ctf::CTFIOSize iosize;
 #define ENCODECTP(beg, end, slot, bits) CTF::get(buff.data())->encode(beg, end, int(slot), bits, optField[int(slot)], &buff, mCoders[int(slot)].get(), getMemMarginFactor());
   // clang-format off
-  ENCODECTP(helper.begin_bcIncTrig(),    helper.end_bcIncTrig(),     CTF::BLC_bcIncTrig,    0);
-  ENCODECTP(helper.begin_orbitIncTrig(), helper.end_orbitIncTrig(),  CTF::BLC_orbitIncTrig, 0);
-
-  ENCODECTP(helper.begin_bytesInput(),  helper.end_bytesInput(),     CTF::BLC_bytesInput,   0);
-  ENCODECTP(helper.begin_bytesClass(),  helper.end_bytesClass(),     CTF::BLC_bytesClass,   0);
-
+  iosize += ENCODECTP(helper.begin_bcIncTrig(),    helper.end_bcIncTrig(),     CTF::BLC_bcIncTrig,    0);
+  iosize += ENCODECTP(helper.begin_orbitIncTrig(), helper.end_orbitIncTrig(),  CTF::BLC_orbitIncTrig, 0);
+  iosize += ENCODECTP(helper.begin_bytesInput(),  helper.end_bytesInput(),     CTF::BLC_bytesInput,   0);
+  iosize += ENCODECTP(helper.begin_bytesClass(),  helper.end_bytesClass(),     CTF::BLC_bytesClass,   0);
   // clang-format on
   CTF::get(buff.data())->print(getPrefix(), mVerbosity);
+  finaliseCTFOutput<CTF>(buff);
+  iosize.rawIn = data.size() * sizeof(CTPDigit);
+  return iosize;
 }
 
 /// decode entropy-encoded digits
 template <typename VTRG>
-void CTFCoder::decode(const CTF::base& ec, VTRG& data)
+o2::ctf::CTFIOSize CTFCoder::decode(const CTF::base& ec, VTRG& data)
 {
   auto header = ec.getHeader();
   checkDictVersion(static_cast<const o2::ctf::CTFDictHeader&>(header));
@@ -104,12 +106,13 @@ void CTFCoder::decode(const CTF::base& ec, VTRG& data)
   std::vector<uint32_t> orbitInc;
   std::vector<uint8_t> bytesInput, bytesClass;
 
+  o2::ctf::CTFIOSize iosize;
 #define DECODECTP(part, slot) ec.decode(part, int(slot), mCoders[int(slot)].get())
   // clang-format off
-  DECODECTP(bcInc,       CTF::BLC_bcIncTrig);
-  DECODECTP(orbitInc,    CTF::BLC_orbitIncTrig);
-  DECODECTP(bytesInput,  CTF::BLC_bytesInput);
-  DECODECTP(bytesClass,  CTF::BLC_bytesClass);
+  iosize += DECODECTP(bcInc,       CTF::BLC_bcIncTrig);
+  iosize += DECODECTP(orbitInc,    CTF::BLC_orbitIncTrig);
+  iosize += DECODECTP(bytesInput,  CTF::BLC_bytesInput);
+  iosize += DECODECTP(bytesClass,  CTF::BLC_bytesClass);
   // clang-format on
   //
   data.clear();
@@ -138,6 +141,8 @@ void CTFCoder::decode(const CTF::base& ec, VTRG& data)
   }
   assert(itInp == bytesInput.end());
   assert(itCls == bytesClass.end());
+  iosize.rawIn = data.size() * sizeof(CTPDigit);
+  return iosize;
 }
 
 } // namespace ctp

--- a/Detectors/CTP/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/CTP/workflow/src/EntropyEncoderSpec.cxx
@@ -51,10 +51,10 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
   mCTFCoder.updateTimeDependentParams(pc);
   auto digits = pc.inputs().get<gsl::span<CTPDigit>>("digits");
   auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"CTP", "CTFDATA", 0, Lifetime::Timeframe});
-  mCTFCoder.encode(buffer, digits);
-  auto sz = mCTFCoder.finaliseCTFOutput<CTF>(buffer);
+  auto iosize = mCTFCoder.encode(buffer, digits);
+  pc.outputs().snapshot({"ctfrep", 0}, iosize);
   mTimer.Stop();
-  LOG(info) << "Created encoded data of size " << sz << " for CTP in " << mTimer.CpuTime() - cput << " s";
+  LOG(info) << iosize.asString() << " in " << mTimer.CpuTime() - cput << " s";
 }
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
@@ -72,7 +72,8 @@ DataProcessorSpec getEntropyEncoderSpec()
   return DataProcessorSpec{
     "ctp-entropy-encoder",
     inputs,
-    Outputs{{"CTP", "CTFDATA", 0, Lifetime::Timeframe}},
+    Outputs{{"CTP", "CTFDATA", 0, Lifetime::Timeframe},
+            {{"ctfrep"}, "CTP", "CTFENCREP", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<EntropyEncoderSpec>()},
     Options{{"ctf-dict", VariantType::String, "ccdb", {"CTF dictionary: empty or ccdb=CCDB, none=no external dictionary otherwise: local filename"}},
             {"mem-factor", VariantType::Float, 1.f, {"Memory allocation margin factor"}}}};

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CTFCoder.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CTFCoder.h
@@ -41,11 +41,11 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 
   /// entropy-encode data to buffer with CTF
   template <typename VEC>
-  void encode(VEC& buff, const gsl::span<const TriggerRecord>& trigData, const gsl::span<const Cell>& cellData);
+  o2::ctf::CTFIOSize encode(VEC& buff, const gsl::span<const TriggerRecord>& trigData, const gsl::span<const Cell>& cellData);
 
   /// entropy decode data from buffer with CTF
   template <typename VTRG, typename VCELL>
-  void decode(const CTF::base& ec, VTRG& trigVec, VCELL& cellVec);
+  o2::ctf::CTFIOSize decode(const CTF::base& ec, VTRG& trigVec, VCELL& cellVec);
 
   void createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op) final;
 
@@ -56,7 +56,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 
 /// entropy-encode clusters to buffer with CTF
 template <typename VEC>
-void CTFCoder::encode(VEC& buff, const gsl::span<const TriggerRecord>& trigData, const gsl::span<const Cell>& cellData)
+o2::ctf::CTFIOSize CTFCoder::encode(VEC& buff, const gsl::span<const TriggerRecord>& trigData, const gsl::span<const Cell>& cellData)
 {
   using MD = o2::ctf::Metadata::OptStore;
   // what to do which each field: see o2::ctd::Metadata explanation
@@ -86,25 +86,29 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const TriggerRecord>& trigData,
   ec->getANSHeader().majorVersion = 0;
   ec->getANSHeader().minorVersion = 1;
   // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
+  o2::ctf::CTFIOSize iosize;
 #define ENCODEEMC(beg, end, slot, bits) CTF::get(buff.data())->encode(beg, end, int(slot), bits, optField[int(slot)], &buff, mCoders[int(slot)].get(), getMemMarginFactor());
   // clang-format off
-  ENCODEEMC(helper.begin_bcIncTrig(),    helper.end_bcIncTrig(),     CTF::BLC_bcIncTrig,    0);
-  ENCODEEMC(helper.begin_orbitIncTrig(), helper.end_orbitIncTrig(),  CTF::BLC_orbitIncTrig, 0);
-  ENCODEEMC(helper.begin_entriesTrig(),  helper.end_entriesTrig(),   CTF::BLC_entriesTrig,  0);
+  iosize += ENCODEEMC(helper.begin_bcIncTrig(),    helper.end_bcIncTrig(),     CTF::BLC_bcIncTrig,    0);
+  iosize += ENCODEEMC(helper.begin_orbitIncTrig(), helper.end_orbitIncTrig(),  CTF::BLC_orbitIncTrig, 0);
+  iosize += ENCODEEMC(helper.begin_entriesTrig(),  helper.end_entriesTrig(),   CTF::BLC_entriesTrig,  0);
 
-  ENCODEEMC(helper.begin_towerID(),     helper.end_towerID(),      CTF::BLC_towerID,     0);
-  ENCODEEMC(helper.begin_time(),        helper.end_time(),         CTF::BLC_time,        0);
-  ENCODEEMC(helper.begin_energy(),      helper.end_energy(),       CTF::BLC_energy,      0);
-  ENCODEEMC(helper.begin_status(),      helper.end_status(),       CTF::BLC_status,      0);
+  iosize += ENCODEEMC(helper.begin_towerID(),     helper.end_towerID(),      CTF::BLC_towerID,     0);
+  iosize += ENCODEEMC(helper.begin_time(),        helper.end_time(),         CTF::BLC_time,        0);
+  iosize += ENCODEEMC(helper.begin_energy(),      helper.end_energy(),       CTF::BLC_energy,      0);
+  iosize += ENCODEEMC(helper.begin_status(),      helper.end_status(),       CTF::BLC_status,      0);
   // extra slot was added in the end
-  ENCODEEMC(helper.begin_trigger(),  helper.end_trigger(),         CTF::BLC_trigger,     0);
+  iosize += ENCODEEMC(helper.begin_trigger(),  helper.end_trigger(),         CTF::BLC_trigger,     0);
   // clang-format on
   CTF::get(buff.data())->print(getPrefix(), mVerbosity);
+  finaliseCTFOutput<CTF>(buff);
+  iosize.rawIn = sizeof(TriggerRecord) * trigData.size() + sizeof(Cell) * cellData.size();
+  return iosize;
 }
 
 /// decode entropy-encoded clusters to standard compact clusters
 template <typename VTRG, typename VCELL>
-void CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VCELL& cellVec)
+o2::ctf::CTFIOSize CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VCELL& cellVec)
 {
   const auto& header = ec.getHeader();
   checkDictVersion(static_cast<const o2::ctf::CTFDictHeader&>(header));
@@ -113,18 +117,19 @@ void CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VCELL& cellVec)
   std::vector<uint32_t> orbitInc;
   std::vector<uint8_t> status;
 
+  o2::ctf::CTFIOSize iosize;
 #define DECODEEMCAL(part, slot) ec.decode(part, int(slot), mCoders[int(slot)].get())
   // clang-format off
-  DECODEEMCAL(bcInc,       CTF::BLC_bcIncTrig);
-  DECODEEMCAL(orbitInc,    CTF::BLC_orbitIncTrig);
-  DECODEEMCAL(entries,     CTF::BLC_entriesTrig);
-  DECODEEMCAL(tower,       CTF::BLC_towerID);
+  iosize += DECODEEMCAL(bcInc,       CTF::BLC_bcIncTrig);
+  iosize += DECODEEMCAL(orbitInc,    CTF::BLC_orbitIncTrig);
+  iosize += DECODEEMCAL(entries,     CTF::BLC_entriesTrig);
+  iosize += DECODEEMCAL(tower,       CTF::BLC_towerID);
 
-  DECODEEMCAL(cellTime,    CTF::BLC_time);
-  DECODEEMCAL(energy,      CTF::BLC_energy);
-  DECODEEMCAL(status,      CTF::BLC_status);
+  iosize += DECODEEMCAL(cellTime,    CTF::BLC_time);
+  iosize += DECODEEMCAL(energy,      CTF::BLC_energy);
+  iosize += DECODEEMCAL(status,      CTF::BLC_status);
   // extra slot was added in the end
-  DECODEEMCAL(trigger,     CTF::BLC_trigger);
+  iosize += DECODEEMCAL(trigger,     CTF::BLC_trigger);
   // triggers were added later, in old data they are absent:
   if (trigger.empty()) {
     trigger.resize(header.nTriggers);
@@ -163,6 +168,8 @@ void CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VCELL& cellVec)
     trigVec.emplace_back(trg);
   }
   assert(cellCount == header.nCells);
+  iosize.rawIn = sizeof(TriggerRecord) * trigVec.size() + sizeof(Cell) * cellVec.size();
+  return iosize;
 }
 
 } // namespace emcal

--- a/Detectors/EMCAL/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/EntropyDecoderSpec.cxx
@@ -48,6 +48,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
 {
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
+  o2::ctf::CTFIOSize iosize;
 
   mCTFCoder.updateTimeDependentParams(pc);
   auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
@@ -58,10 +59,11 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   // since the buff is const, we cannot use EncodedBlocks::relocate directly, instead we wrap its data to another flat object
   if (buff.size()) {
     const auto ctfImage = o2::emcal::CTF::getImage(buff.data());
-    mCTFCoder.decode(ctfImage, triggers, cells);
+    iosize = mCTFCoder.decode(ctfImage, triggers, cells);
   }
+  pc.outputs().snapshot({"ctfrep", 0}, iosize);
   mTimer.Stop();
-  LOG(info) << "Decoded " << cells.size() << " EMCAL cells in " << triggers.size() << " triggers in " << mTimer.CpuTime() - cput << " s";
+  LOG(info) << "Decoded " << cells.size() << " EMCAL cells in " << triggers.size() << " triggers, (" << iosize.asString() << ") in " << mTimer.CpuTime() - cput << " s";
 }
 
 void EntropyDecoderSpec::endOfStream(EndOfStreamContext& ec)
@@ -74,7 +76,8 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
 {
   std::vector<OutputSpec> outputs{
     OutputSpec{{"triggers"}, "EMC", "CELLSTRGR", 0, Lifetime::Timeframe},
-    OutputSpec{{"cells"}, "EMC", "CELLS", 0, Lifetime::Timeframe}};
+    OutputSpec{{"cells"}, "EMC", "CELLS", 0, Lifetime::Timeframe},
+    OutputSpec{{"ctfrep"}, "EMC", "CTFDECREP", 0, Lifetime::Timeframe}};
 
   std::vector<InputSpec> inputs;
   inputs.emplace_back("ctf", "EMC", "CTFDATA", sspec, Lifetime::Timeframe);

--- a/Detectors/EMCAL/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/EntropyEncoderSpec.cxx
@@ -53,10 +53,10 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
   auto cells = pc.inputs().get<gsl::span<Cell>>("cells");
 
   auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"EMC", "CTFDATA", 0, Lifetime::Timeframe});
-  mCTFCoder.encode(buffer, triggers, cells);
-  auto sz = mCTFCoder.finaliseCTFOutput<CTF>(buffer);
+  auto iosize = mCTFCoder.encode(buffer, triggers, cells);
+  pc.outputs().snapshot({"ctfrep", 0}, iosize);
   mTimer.Stop();
-  LOG(info) << "Created encoded data of size " << sz << " for EMCAL in " << mTimer.CpuTime() - cput << " s";
+  LOG(info) << iosize.asString() << " in " << mTimer.CpuTime() - cput << " s";
 }
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
@@ -75,10 +75,12 @@ DataProcessorSpec getEntropyEncoderSpec()
   return DataProcessorSpec{
     "emcal-entropy-encoder",
     inputs,
-    Outputs{{"EMC", "CTFDATA", 0, Lifetime::Timeframe}},
+    Outputs{{"EMC", "CTFDATA", 0, Lifetime::Timeframe},
+            {{"ctfrep"}, "EMC", "CTFENCREP", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<EntropyEncoderSpec>()},
-    Options{{"ctf-dict", VariantType::String, "ccdb", {"CTF dictionary: empty or ccdb=CCDB, none=no external dictionary otherwise: local filename"}},
-            {"mem-factor", VariantType::Float, 1.f, {"Memory allocation margin factor"}}}};
+    Options{
+      {"ctf-dict", VariantType::String, "ccdb", {"CTF dictionary: empty or ccdb=CCDB, none=no external dictionary otherwise: local filename"}},
+      {"mem-factor", VariantType::Float, 1.f, {"Memory allocation margin factor"}}}};
 }
 
 } // namespace emcal

--- a/Detectors/FIT/FDD/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/FIT/FDD/workflow/src/EntropyDecoderSpec.cxx
@@ -48,6 +48,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
 {
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
+  o2::ctf::CTFIOSize iosize;
 
   mCTFCoder.updateTimeDependentParams(pc);
   auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
@@ -58,10 +59,11 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   // since the buff is const, we cannot use EncodedBlocks::relocate directly, instead we wrap its data to another flat object
   if (buff.size()) {
     const auto ctfImage = o2::fdd::CTF::getImage(buff.data());
-    mCTFCoder.decode(ctfImage, digits, channels);
+    iosize = mCTFCoder.decode(ctfImage, digits, channels);
   }
+  pc.outputs().snapshot({"ctfrep", 0}, iosize);
   mTimer.Stop();
-  LOG(info) << "Decoded " << channels.size() << " FDD channels in " << digits.size() << " digits in " << mTimer.CpuTime() - cput << " s";
+  LOG(info) << "Decoded " << channels.size() << " FDD channels in " << digits.size() << " digits, (" << iosize.asString() << ") in " << mTimer.CpuTime() - cput << " s";
 }
 
 void EntropyDecoderSpec::endOfStream(EndOfStreamContext& ec)
@@ -74,7 +76,8 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
 {
   std::vector<OutputSpec> outputs{
     OutputSpec{{"digits"}, "FDD", "DIGITSBC", 0, Lifetime::Timeframe},
-    OutputSpec{{"channels"}, "FDD", "DIGITSCH", 0, Lifetime::Timeframe}};
+    OutputSpec{{"channels"}, "FDD", "DIGITSCH", 0, Lifetime::Timeframe},
+    OutputSpec{{"ctfrep"}, "FDD", "CTFDECREP", 0, Lifetime::Timeframe}};
 
   std::vector<InputSpec> inputs;
   inputs.emplace_back("ctf", "FDD", "CTFDATA", sspec, Lifetime::Timeframe);

--- a/Detectors/FIT/FDD/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/FIT/FDD/workflow/src/EntropyEncoderSpec.cxx
@@ -53,10 +53,9 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
   auto channels = pc.inputs().get<gsl::span<o2::fdd::ChannelData>>("channels");
 
   auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"FDD", "CTFDATA", 0, Lifetime::Timeframe});
-  mCTFCoder.encode(buffer, digits, channels);
-  auto sz = mCTFCoder.finaliseCTFOutput<CTF>(buffer);
+  auto iosize = mCTFCoder.encode(buffer, digits, channels);
   mTimer.Stop();
-  LOG(info) << "Created encoded data of size " << sz << " for FDD in " << mTimer.CpuTime() - cput << " s";
+  LOG(info) << iosize.asString() << " in " << mTimer.CpuTime() - cput << " s";
 }
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)

--- a/Detectors/FIT/FT0/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/FIT/FT0/workflow/src/EntropyDecoderSpec.cxx
@@ -48,6 +48,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
 {
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
+  o2::ctf::CTFIOSize iosize;
 
   mCTFCoder.updateTimeDependentParams(pc);
   auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
@@ -58,10 +59,11 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   // since the buff is const, we cannot use EncodedBlocks::relocate directly, instead we wrap its data to another flat object
   if (buff.size()) {
     const auto ctfImage = o2::ft0::CTF::getImage(buff.data());
-    mCTFCoder.decode(ctfImage, digits, channels);
+    iosize = mCTFCoder.decode(ctfImage, digits, channels);
   }
+  pc.outputs().snapshot({"ctfrep", 0}, iosize);
   mTimer.Stop();
-  LOG(info) << "Decoded " << channels.size() << " FT0 channels in " << digits.size() << " digits in " << mTimer.CpuTime() - cput << " s";
+  LOG(info) << "Decoded " << channels.size() << " FT0 channels in " << digits.size() << " digits, (" << iosize.asString() << ") in " << mTimer.CpuTime() - cput << " s";
 }
 
 void EntropyDecoderSpec::endOfStream(EndOfStreamContext& ec)
@@ -74,7 +76,8 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
 {
   std::vector<OutputSpec> outputs{
     OutputSpec{{"digits"}, "FT0", "DIGITSBC", 0, Lifetime::Timeframe},
-    OutputSpec{{"channels"}, "FT0", "DIGITSCH", 0, Lifetime::Timeframe}};
+    OutputSpec{{"channels"}, "FT0", "DIGITSCH", 0, Lifetime::Timeframe},
+    OutputSpec{{"ctfrep"}, "FT0", "CTFDECREP", 0, Lifetime::Timeframe}};
 
   std::vector<InputSpec> inputs;
   inputs.emplace_back("ctf", "FT0", "CTFDATA", sspec, Lifetime::Timeframe);

--- a/Detectors/FIT/FT0/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/FIT/FT0/workflow/src/EntropyEncoderSpec.cxx
@@ -53,10 +53,9 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
   auto channels = pc.inputs().get<gsl::span<o2::ft0::ChannelData>>("channels");
 
   auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"FT0", "CTFDATA", 0, Lifetime::Timeframe});
-  mCTFCoder.encode(buffer, digits, channels);
-  auto sz = mCTFCoder.finaliseCTFOutput<CTF>(buffer);
+  auto iosize = mCTFCoder.encode(buffer, digits, channels);
   mTimer.Stop();
-  LOG(debug) << "Created encoded data of size " << sz << " for FT0 in " << mTimer.CpuTime() - cput << " s";
+  LOG(info) << iosize.asString() << " in " << mTimer.CpuTime() - cput << " s";
 }
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)

--- a/Detectors/FIT/FV0/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/FIT/FV0/workflow/src/EntropyDecoderSpec.cxx
@@ -48,6 +48,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
 {
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
+  o2::ctf::CTFIOSize iosize;
 
   mCTFCoder.updateTimeDependentParams(pc);
   auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
@@ -58,10 +59,11 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   // since the buff is const, we cannot use EncodedBlocks::relocate directly, instead we wrap its data to another flat object
   if (buff.size()) {
     const auto ctfImage = o2::fv0::CTF::getImage(buff.data());
-    mCTFCoder.decode(ctfImage, digits, channels);
+    iosize = mCTFCoder.decode(ctfImage, digits, channels);
   }
+  pc.outputs().snapshot({"ctfrep", 0}, iosize);
   mTimer.Stop();
-  LOG(info) << "Decoded " << channels.size() << " FV0 channels in " << digits.size() << " digits in " << mTimer.CpuTime() - cput << " s";
+  LOG(info) << "Decoded " << channels.size() << " FV0 channels in " << digits.size() << " digits, (" << iosize.asString() << ") in " << mTimer.CpuTime() - cput << " s";
 }
 
 void EntropyDecoderSpec::endOfStream(EndOfStreamContext& ec)
@@ -74,7 +76,8 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
 {
   std::vector<OutputSpec> outputs{
     OutputSpec{{"digits"}, "FV0", "DIGITSBC", 0, Lifetime::Timeframe},
-    OutputSpec{{"channels"}, "FV0", "DIGITSCH", 0, Lifetime::Timeframe}};
+    OutputSpec{{"channels"}, "FV0", "DIGITSCH", 0, Lifetime::Timeframe},
+    OutputSpec{{"ctfrep"}, "FV0", "CTFDECREP", 0, Lifetime::Timeframe}};
 
   std::vector<InputSpec> inputs;
   inputs.emplace_back("ctf", "FV0", "CTFDATA", sspec, Lifetime::Timeframe);

--- a/Detectors/FIT/FV0/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/FIT/FV0/workflow/src/EntropyEncoderSpec.cxx
@@ -51,12 +51,11 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
   mCTFCoder.updateTimeDependentParams(pc);
   auto digits = pc.inputs().get<gsl::span<o2::fv0::Digit>>("digits");
   auto channels = pc.inputs().get<gsl::span<o2::fv0::ChannelData>>("channels");
-
   auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"FV0", "CTFDATA", 0, Lifetime::Timeframe});
-  mCTFCoder.encode(buffer, digits, channels);
-  auto sz = mCTFCoder.finaliseCTFOutput<CTF>(buffer);
+  auto iosize = mCTFCoder.encode(buffer, digits, channels);
+  pc.outputs().snapshot({"ctfrep", 0}, iosize);
   mTimer.Stop();
-  LOG(debug) << "Created encoded data of size " << sz << " for FV0 in " << mTimer.CpuTime() - cput << " s";
+  LOG(info) << iosize.asString() << " in " << mTimer.CpuTime() - cput << " s";
 }
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
@@ -75,7 +74,8 @@ DataProcessorSpec getEntropyEncoderSpec()
   return DataProcessorSpec{
     "fv0-entropy-encoder",
     inputs,
-    Outputs{{"FV0", "CTFDATA", 0, Lifetime::Timeframe}},
+    Outputs{{"FV0", "CTFDATA", 0, Lifetime::Timeframe},
+            {{"ctfrep"}, "FV0", "CTFENCREP", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<EntropyEncoderSpec>()},
     Options{{"ctf-dict", VariantType::String, "ccdb", {"CTF dictionary: empty or ccdb=CCDB, none=no external dictionary otherwise: local filename"}},
             {"mem-factor", VariantType::Float, 1.f, {"Memory allocation margin factor"}}}};

--- a/Detectors/HMPID/reconstruction/include/HMPIDReconstruction/CTFCoder.h
+++ b/Detectors/HMPID/reconstruction/include/HMPIDReconstruction/CTFCoder.h
@@ -41,11 +41,11 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 
   /// entropy-encode data to buffer with CTF
   template <typename VEC>
-  void encode(VEC& buff, const gsl::span<const Trigger>& trigData, const gsl::span<const Digit>& digData);
+  o2::ctf::CTFIOSize encode(VEC& buff, const gsl::span<const Trigger>& trigData, const gsl::span<const Digit>& digData);
 
   /// entropy decode data from buffer with CTF
   template <typename VTRG, typename VDIG>
-  void decode(const CTF::base& ec, VTRG& trigVec, VDIG& digVec);
+  o2::ctf::CTFIOSize decode(const CTF::base& ec, VTRG& trigVec, VDIG& digVec);
 
   void createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op) final;
 
@@ -56,7 +56,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 
 /// entropy-encode digits and to buffer with CTF
 template <typename VEC>
-void CTFCoder::encode(VEC& buff, const gsl::span<const Trigger>& trigData, const gsl::span<const Digit>& digData)
+o2::ctf::CTFIOSize CTFCoder::encode(VEC& buff, const gsl::span<const Trigger>& trigData, const gsl::span<const Digit>& digData)
 {
   using MD = o2::ctf::Metadata::OptStore;
   // what to do which each field: see o2::ctd::Metadata explanation
@@ -85,25 +85,29 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const Trigger>& trigData, const
   ec->getANSHeader().majorVersion = 0;
   ec->getANSHeader().minorVersion = 1;
   // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
+  o2::ctf::CTFIOSize iosize;
 #define ENCODEHMP(beg, end, slot, bits) CTF::get(buff.data())->encode(beg, end, int(slot), bits, optField[int(slot)], &buff, mCoders[int(slot)].get(), getMemMarginFactor());
   // clang-format off
-  ENCODEHMP(helper.begin_bcIncTrig(),    helper.end_bcIncTrig(),     CTF::BLC_bcIncTrig,    0);
-  ENCODEHMP(helper.begin_orbitIncTrig(), helper.end_orbitIncTrig(),  CTF::BLC_orbitIncTrig, 0);
-  ENCODEHMP(helper.begin_entriesDig(),   helper.end_entriesDig(),    CTF::BLC_entriesDig,   0);
+  iosize += ENCODEHMP(helper.begin_bcIncTrig(),    helper.end_bcIncTrig(),     CTF::BLC_bcIncTrig,    0);
+  iosize += ENCODEHMP(helper.begin_orbitIncTrig(), helper.end_orbitIncTrig(),  CTF::BLC_orbitIncTrig, 0);
+  iosize += ENCODEHMP(helper.begin_entriesDig(),   helper.end_entriesDig(),    CTF::BLC_entriesDig,   0);
 
-  ENCODEHMP(helper.begin_ChID(),         helper.end_ChID(),          CTF::BLC_ChID,         0);
-  ENCODEHMP(helper.begin_Q(),            helper.end_Q(),             CTF::BLC_Q,            0);
-  ENCODEHMP(helper.begin_Ph(),           helper.end_Ph(),            CTF::BLC_Ph,           0);
-  ENCODEHMP(helper.begin_X(),            helper.end_X(),             CTF::BLC_X,            0);
-  ENCODEHMP(helper.begin_Y(),            helper.end_Y(),             CTF::BLC_Y,            0);
+  iosize += ENCODEHMP(helper.begin_ChID(),         helper.end_ChID(),          CTF::BLC_ChID,         0);
+  iosize += ENCODEHMP(helper.begin_Q(),            helper.end_Q(),             CTF::BLC_Q,            0);
+  iosize += ENCODEHMP(helper.begin_Ph(),           helper.end_Ph(),            CTF::BLC_Ph,           0);
+  iosize += ENCODEHMP(helper.begin_X(),            helper.end_X(),             CTF::BLC_X,            0);
+  iosize += ENCODEHMP(helper.begin_Y(),            helper.end_Y(),             CTF::BLC_Y,            0);
 
   // clang-format on
   CTF::get(buff.data())->print(getPrefix(), mVerbosity);
+  finaliseCTFOutput<CTF>(buff);
+  iosize.rawIn = trigData.size() * sizeof(Trigger) + digData.size() * sizeof(Digit);
+  return iosize;
 }
 
 /// decode entropy-encoded data to digits
 template <typename VTRG, typename VDIG>
-void CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VDIG& digVec)
+o2::ctf::CTFIOSize CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VDIG& digVec)
 {
   auto header = ec.getHeader();
   checkDictVersion(static_cast<const o2::ctf::CTFDictHeader&>(header));
@@ -112,17 +116,18 @@ void CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VDIG& digVec)
   std::vector<uint32_t> orbitInc, entriesDig;
   std::vector<uint8_t> chID, ph, x, y;
 
+  o2::ctf::CTFIOSize iosize;
 #define DECODEHMP(part, slot) ec.decode(part, int(slot), mCoders[int(slot)].get())
   // clang-format off
-  DECODEHMP(bcInc,       CTF::BLC_bcIncTrig);
-  DECODEHMP(orbitInc,    CTF::BLC_orbitIncTrig);
-  DECODEHMP(entriesDig,  CTF::BLC_entriesDig);
+  iosize += DECODEHMP(bcInc,       CTF::BLC_bcIncTrig);
+  iosize += DECODEHMP(orbitInc,    CTF::BLC_orbitIncTrig);
+  iosize += DECODEHMP(entriesDig,  CTF::BLC_entriesDig);
 
-  DECODEHMP(chID,        CTF::BLC_ChID);
-  DECODEHMP(q,           CTF::BLC_Q);
-  DECODEHMP(ph,          CTF::BLC_Ph);
-  DECODEHMP(x,           CTF::BLC_X);
-  DECODEHMP(y,           CTF::BLC_Y);
+  iosize += DECODEHMP(chID,        CTF::BLC_ChID);
+  iosize += DECODEHMP(q,           CTF::BLC_Q);
+  iosize += DECODEHMP(ph,          CTF::BLC_Ph);
+  iosize += DECODEHMP(x,           CTF::BLC_X);
+  iosize += DECODEHMP(y,           CTF::BLC_Y);
   // clang-format on
   //
   trigVec.clear();
@@ -153,6 +158,8 @@ void CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VDIG& digVec)
     trigVec.emplace_back(ir, firstEntryDig, entriesDig[itrig]);
   }
   assert(digCount == header.nDigits);
+  iosize.rawIn = trigVec.size() * sizeof(Trigger) + digVec.size() * sizeof(Digit);
+  return iosize;
 }
 
 } // namespace hmpid

--- a/Detectors/HMPID/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/HMPID/workflow/src/EntropyDecoderSpec.cxx
@@ -65,6 +65,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
 {
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
+  o2::ctf::CTFIOSize iosize;
 
   mCTFCoder.updateTimeDependentParams(pc);
   auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
@@ -75,10 +76,11 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   // since the buff is const, we cannot use EncodedBlocks::relocate directly, instead we wrap its data to another flat object
   if (buff.size()) {
     const auto ctfImage = o2::hmpid::CTF::getImage(buff.data());
-    mCTFCoder.decode(ctfImage, triggers, digits);
+    iosize = mCTFCoder.decode(ctfImage, triggers, digits);
   }
+  pc.outputs().snapshot({"ctfrep", 0}, iosize);
   mTimer.Stop();
-  LOG(info) << "Decoded " << digits.size() << " HMPID digits in " << triggers.size() << " triggers in " << mTimer.CpuTime() - cput << " s";
+  LOG(info) << "Decoded " << digits.size() << " HMPID digits in " << triggers.size() << " triggers, (" << iosize.asString() << ") in " << mTimer.CpuTime() - cput << " s";
 }
 
 void EntropyDecoderSpec::endOfStream(EndOfStreamContext& ec)
@@ -91,7 +93,8 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
 {
   std::vector<OutputSpec> outputs{
     OutputSpec{{"triggers"}, "HMP", "INTRECORDS", 0, Lifetime::Timeframe},
-    OutputSpec{{"digits"}, "HMP", "DIGITS", 0, Lifetime::Timeframe}};
+    OutputSpec{{"digits"}, "HMP", "DIGITS", 0, Lifetime::Timeframe},
+    OutputSpec{{"ctfrep"}, "HMP", "CTFDECREP", 0, Lifetime::Timeframe}};
 
   std::vector<InputSpec> inputs;
   inputs.emplace_back("ctf", "HMP", "CTFDATA", sspec, Lifetime::Timeframe);

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/CTFCoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/CTFCoder.h
@@ -51,20 +51,20 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 
   /// entropy-encode clusters to buffer with CTF
   template <typename VEC>
-  void encode(VEC& buff, const gsl::span<const ROFRecord>& rofRecVec, const gsl::span<const CompClusterExt>& cclusVec, const gsl::span<const unsigned char>& pattVec);
+  o2::ctf::CTFIOSize encode(VEC& buff, const gsl::span<const ROFRecord>& rofRecVec, const gsl::span<const CompClusterExt>& cclusVec, const gsl::span<const unsigned char>& pattVec);
 
   /// entropy decode clusters from buffer with CTF
   template <typename VROF, typename VCLUS, typename VPAT>
-  void decode(const CTF::base& ec, VROF& rofRecVec, VCLUS& cclusVec, VPAT& pattVec, const NoiseMap* noiseMap, const LookUp& clPattLookup);
+  o2::ctf::CTFIOSize decode(const CTF::base& ec, VROF& rofRecVec, VCLUS& cclusVec, VPAT& pattVec, const NoiseMap* noiseMap, const LookUp& clPattLookup);
 
   /// entropy decode digits from buffer with CTF
   template <typename VROF, typename VDIG>
-  void decode(const CTF::base& ec, VROF& rofRecVec, VDIG& digVec, const NoiseMap* noiseMap, const LookUp& clPattLookup);
+  o2::ctf::CTFIOSize decode(const CTF::base& ec, VROF& rofRecVec, VDIG& digVec, const NoiseMap* noiseMap, const LookUp& clPattLookup);
 
   void createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op) final;
 
  private:
-  CompressedClusters decodeCompressedClusters(const CTF::base& ec);
+  CompressedClusters decodeCompressedClusters(const CTF::base& ec, o2::ctf::CTFIOSize& sz);
 
   /// compres compact clusters to CompressedClusters
   void compress(CompressedClusters& compCl, const gsl::span<const ROFRecord>& rofRecVec, const gsl::span<const CompClusterExt>& cclusVec, const gsl::span<const unsigned char>& pattVec);
@@ -84,7 +84,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 
 /// entropy-encode clusters to buffer with CTF
 template <typename VEC>
-void CTFCoder::encode(VEC& buff, const gsl::span<const ROFRecord>& rofRecVec, const gsl::span<const CompClusterExt>& cclusVec, const gsl::span<const unsigned char>& pattVec)
+o2::ctf::CTFIOSize CTFCoder::encode(VEC& buff, const gsl::span<const ROFRecord>& rofRecVec, const gsl::span<const CompClusterExt>& cclusVec, const gsl::span<const unsigned char>& pattVec)
 {
   using MD = o2::ctf::Metadata::OptStore;
   // what to do which each field: see o2::ctd::Metadata explanation
@@ -114,37 +114,46 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const ROFRecord>& rofRecVec, co
   ec->getANSHeader().majorVersion = 0;
   ec->getANSHeader().minorVersion = 1;
   // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
+  o2::ctf::CTFIOSize iosize;
 #define ENCODEITSMFT(part, slot, bits) CTF::get(buff.data())->encode(part, int(slot), bits, optField[int(slot)], &buff, mCoders[int(slot)].get(), getMemMarginFactor());
   // clang-format off
-  ENCODEITSMFT(compCl.firstChipROF, CTF::BLCfirstChipROF, 0);
-  ENCODEITSMFT(compCl.bcIncROF, CTF::BLCbcIncROF, 0);
-  ENCODEITSMFT(compCl.orbitIncROF, CTF::BLCorbitIncROF, 0);
-  ENCODEITSMFT(compCl.nclusROF, CTF::BLCnclusROF, 0);
+  iosize += ENCODEITSMFT(compCl.firstChipROF, CTF::BLCfirstChipROF, 0);
+  iosize += ENCODEITSMFT(compCl.bcIncROF, CTF::BLCbcIncROF, 0);
+  iosize += ENCODEITSMFT(compCl.orbitIncROF, CTF::BLCorbitIncROF, 0);
+  iosize += ENCODEITSMFT(compCl.nclusROF, CTF::BLCnclusROF, 0);
   //
-  ENCODEITSMFT(compCl.chipInc, CTF::BLCchipInc, 0);
-  ENCODEITSMFT(compCl.chipMul, CTF::BLCchipMul, 0);
-  ENCODEITSMFT(compCl.row, CTF::BLCrow, 0);
-  ENCODEITSMFT(compCl.colInc, CTF::BLCcolInc, 0);
-  ENCODEITSMFT(compCl.pattID, CTF::BLCpattID, 0);
-  ENCODEITSMFT(compCl.pattMap, CTF::BLCpattMap, 0);
+  iosize += ENCODEITSMFT(compCl.chipInc, CTF::BLCchipInc, 0);
+  iosize += ENCODEITSMFT(compCl.chipMul, CTF::BLCchipMul, 0);
+  iosize += ENCODEITSMFT(compCl.row, CTF::BLCrow, 0);
+  iosize += ENCODEITSMFT(compCl.colInc, CTF::BLCcolInc, 0);
+  iosize += ENCODEITSMFT(compCl.pattID, CTF::BLCpattID, 0);
+  iosize += ENCODEITSMFT(compCl.pattMap, CTF::BLCpattMap, 0);
   // clang-format on
   //CTF::get(buff.data())->print(getPrefix());
+  iosize.rawIn = rofRecVec.size() * sizeof(ROFRecord) + cclusVec.size() * sizeof(CompClusterExt) + pattVec.size() * sizeof(unsigned char);
+  return iosize;
 }
 
 /// decode entropy-encoded clusters to standard compact clusters
 template <typename VROF, typename VCLUS, typename VPAT>
-void CTFCoder::decode(const CTF::base& ec, VROF& rofRecVec, VCLUS& cclusVec, VPAT& pattVec, const NoiseMap* noiseMap, const LookUp& clPattLookup)
+o2::ctf::CTFIOSize CTFCoder::decode(const CTF::base& ec, VROF& rofRecVec, VCLUS& cclusVec, VPAT& pattVec, const NoiseMap* noiseMap, const LookUp& clPattLookup)
 {
-  auto compCl = decodeCompressedClusters(ec);
+  o2::ctf::CTFIOSize iosize;
+  auto compCl = decodeCompressedClusters(ec, iosize);
   decompress(compCl, rofRecVec, cclusVec, pattVec, noiseMap, clPattLookup);
+  iosize.rawIn = rofRecVec.size() * sizeof(ROFRecord) + cclusVec.size() * sizeof(CompClusterExt) + pattVec.size() * sizeof(unsigned char);
+  return iosize;
 }
 
 /// decode entropy-encoded clusters to digits
 template <typename VROF, typename VDIG>
-void CTFCoder::decode(const CTF::base& ec, VROF& rofRecVec, VDIG& digVec, const NoiseMap* noiseMap, const LookUp& clPattLookup)
+o2::ctf::CTFIOSize CTFCoder::decode(const CTF::base& ec, VROF& rofRecVec, VDIG& digVec, const NoiseMap* noiseMap, const LookUp& clPattLookup)
 {
-  auto compCl = decodeCompressedClusters(ec);
+  o2::ctf::CTFIOSize iosize;
+  auto compCl = decodeCompressedClusters(ec, iosize);
   decompress(compCl, rofRecVec, digVec, noiseMap, clPattLookup);
+  iosize.rawIn += rofRecVec.size() * sizeof(ROFRecord) + digVec.size() * sizeof(Digit);
+  return iosize;
 }
 
 /// decompress compressed clusters to standard compact clusters

--- a/Detectors/ITSMFT/common/reconstruction/src/CTFCoder.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/CTFCoder.cxx
@@ -186,7 +186,7 @@ size_t CTFCoder::estimateCompressedSize(const CompressedClusters& cc)
 }
 
 ///________________________________
-CompressedClusters CTFCoder::decodeCompressedClusters(const CTF::base& ec)
+CompressedClusters CTFCoder::decodeCompressedClusters(const CTF::base& ec, o2::ctf::CTFIOSize& iosize)
 {
   CompressedClusters cc;
   cc.header = ec.getHeader();
@@ -194,17 +194,17 @@ CompressedClusters CTFCoder::decodeCompressedClusters(const CTF::base& ec)
   ec.print(getPrefix(), mVerbosity);
 #define DECODEITSMFT(part, slot) ec.decode(part, int(slot), mCoders[int(slot)].get())
   // clang-format off
-  DECODEITSMFT(cc.firstChipROF, CTF::BLCfirstChipROF);
-  DECODEITSMFT(cc.bcIncROF,     CTF::BLCbcIncROF);
-  DECODEITSMFT(cc.orbitIncROF,  CTF::BLCorbitIncROF);
-  DECODEITSMFT(cc.nclusROF,     CTF::BLCnclusROF);
+  iosize += DECODEITSMFT(cc.firstChipROF, CTF::BLCfirstChipROF);
+  iosize += DECODEITSMFT(cc.bcIncROF,     CTF::BLCbcIncROF);
+  iosize += DECODEITSMFT(cc.orbitIncROF,  CTF::BLCorbitIncROF);
+  iosize += DECODEITSMFT(cc.nclusROF,     CTF::BLCnclusROF);
   //
-  DECODEITSMFT(cc.chipInc,      CTF::BLCchipInc);
-  DECODEITSMFT(cc.chipMul,      CTF::BLCchipMul);
-  DECODEITSMFT(cc.row,          CTF::BLCrow);
-  DECODEITSMFT(cc.colInc,       CTF::BLCcolInc);
-  DECODEITSMFT(cc.pattID,       CTF::BLCpattID);
-  DECODEITSMFT(cc.pattMap,      CTF::BLCpattMap);
+  iosize += DECODEITSMFT(cc.chipInc,      CTF::BLCchipInc);
+  iosize += DECODEITSMFT(cc.chipMul,      CTF::BLCchipMul);
+  iosize += DECODEITSMFT(cc.row,          CTF::BLCrow);
+  iosize += DECODEITSMFT(cc.colInc,       CTF::BLCcolInc);
+  iosize += DECODEITSMFT(cc.pattID,       CTF::BLCpattID);
+  iosize += DECODEITSMFT(cc.pattMap,      CTF::BLCpattMap);
   // clang-format on
   return cc;
 }

--- a/Detectors/MUON/MCH/CTF/include/MCHCTF/CTFCoder.h
+++ b/Detectors/MUON/MCH/CTF/include/MCHCTF/CTFCoder.h
@@ -43,11 +43,11 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 
   /// entropy-encode data to buffer with CTF
   template <typename VEC>
-  void encode(VEC& buff, const gsl::span<const ROFRecord>& rofData, const gsl::span<const Digit>& digData);
+  o2::ctf::CTFIOSize encode(VEC& buff, const gsl::span<const ROFRecord>& rofData, const gsl::span<const Digit>& digData);
 
   /// entropy decode data from buffer with CTF
   template <typename VROF, typename VCOL>
-  void decode(const CTF::base& ec, VROF& rofVec, VCOL& digVec);
+  o2::ctf::CTFIOSize decode(const CTF::base& ec, VROF& rofVec, VCOL& digVec);
 
   void createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op) final;
 
@@ -58,7 +58,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 
 /// entropy-encode clusters to buffer with CTF
 template <typename VEC>
-void CTFCoder::encode(VEC& buff, const gsl::span<const ROFRecord>& rofData, const gsl::span<const Digit>& digData)
+o2::ctf::CTFIOSize CTFCoder::encode(VEC& buff, const gsl::span<const ROFRecord>& rofData, const gsl::span<const Digit>& digData)
 {
   using MD = o2::ctf::Metadata::OptStore;
   // what to do which each field: see o2::ctd::Metadata explanation
@@ -87,25 +87,29 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const ROFRecord>& rofData, cons
   ec->getANSHeader().majorVersion = 0;
   ec->getANSHeader().minorVersion = 1;
   // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
+  o2::ctf::CTFIOSize iosize;
 #define ENCODEMCH(beg, end, slot, bits) CTF::get(buff.data())->encode(beg, end, int(slot), bits, optField[int(slot)], &buff, mCoders[int(slot)].get(), getMemMarginFactor());
   // clang-format off
-  ENCODEMCH(helper.begin_bcIncROF(),    helper.end_bcIncROF(),     CTF::BLC_bcIncROF,     0);
-  ENCODEMCH(helper.begin_orbitIncROF(), helper.end_orbitIncROF(),  CTF::BLC_orbitIncROF,  0);
-  ENCODEMCH(helper.begin_nDigitsROF(),  helper.end_nDigitsROF(),   CTF::BLC_nDigitsROF,   0);
+  iosize += ENCODEMCH(helper.begin_bcIncROF(),    helper.end_bcIncROF(),     CTF::BLC_bcIncROF,     0);
+  iosize += ENCODEMCH(helper.begin_orbitIncROF(), helper.end_orbitIncROF(),  CTF::BLC_orbitIncROF,  0);
+  iosize += ENCODEMCH(helper.begin_nDigitsROF(),  helper.end_nDigitsROF(),   CTF::BLC_nDigitsROF,   0);
 
-  ENCODEMCH(helper.begin_tfTime(),      helper.end_tfTime(),       CTF::BLC_tfTime,       0);
-  ENCODEMCH(helper.begin_nSamples(),    helper.end_nSamples(),     CTF::BLC_nSamples,     0);
-  ENCODEMCH(helper.begin_isSaturated(), helper.end_isSaturated(),  CTF::BLC_isSaturated,  0);
-  ENCODEMCH(helper.begin_detID(),       helper.end_detID(),        CTF::BLC_detID,        0);
-  ENCODEMCH(helper.begin_padID(),       helper.end_padID(),        CTF::BLC_padID,        0);
-  ENCODEMCH(helper.begin_ADC()  ,       helper.end_ADC(),          CTF::BLC_ADC,          0);
+  iosize += ENCODEMCH(helper.begin_tfTime(),      helper.end_tfTime(),       CTF::BLC_tfTime,       0);
+  iosize += ENCODEMCH(helper.begin_nSamples(),    helper.end_nSamples(),     CTF::BLC_nSamples,     0);
+  iosize += ENCODEMCH(helper.begin_isSaturated(), helper.end_isSaturated(),  CTF::BLC_isSaturated,  0);
+  iosize += ENCODEMCH(helper.begin_detID(),       helper.end_detID(),        CTF::BLC_detID,        0);
+  iosize += ENCODEMCH(helper.begin_padID(),       helper.end_padID(),        CTF::BLC_padID,        0);
+  iosize += ENCODEMCH(helper.begin_ADC()  ,       helper.end_ADC(),          CTF::BLC_ADC,          0);
   // clang-format on
   CTF::get(buff.data())->print(getPrefix(), mVerbosity);
+  finaliseCTFOutput<CTF>(buff);
+  iosize.rawIn = sizeof(ROFRecord) * rofData.size() + sizeof(Digit) * digData.size();
+  return iosize;
 }
 
 /// decode entropy-encoded clusters to standard compact clusters
 template <typename VROF, typename VCOL>
-void CTFCoder::decode(const CTF::base& ec, VROF& rofVec, VCOL& digVec)
+o2::ctf::CTFIOSize CTFCoder::decode(const CTF::base& ec, VROF& rofVec, VCOL& digVec)
 {
   auto header = ec.getHeader();
   checkDictVersion(static_cast<const o2::ctf::CTFDictHeader&>(header));
@@ -117,18 +121,19 @@ void CTFCoder::decode(const CTF::base& ec, VROF& rofVec, VCOL& digVec)
   std::vector<int16_t> detID, padID;
   std::vector<uint8_t> isSaturated;
 
+  o2::ctf::CTFIOSize iosize;
 #define DECODEMCH(part, slot) ec.decode(part, int(slot), mCoders[int(slot)].get())
   // clang-format off
-  DECODEMCH(bcInc,       CTF::BLC_bcIncROF);
-  DECODEMCH(orbitInc,    CTF::BLC_orbitIncROF);
-  DECODEMCH(nDigits,     CTF::BLC_nDigitsROF);
+  iosize += DECODEMCH(bcInc,       CTF::BLC_bcIncROF);
+  iosize += DECODEMCH(orbitInc,    CTF::BLC_orbitIncROF);
+  iosize += DECODEMCH(nDigits,     CTF::BLC_nDigitsROF);
 
-  DECODEMCH(tfTime,      CTF::BLC_tfTime);
-  DECODEMCH(nSamples,    CTF::BLC_nSamples);
-  DECODEMCH(isSaturated, CTF::BLC_isSaturated);
-  DECODEMCH(detID,       CTF::BLC_detID);
-  DECODEMCH(padID,       CTF::BLC_padID);
-  DECODEMCH(ADC,         CTF::BLC_ADC);
+  iosize += DECODEMCH(tfTime,      CTF::BLC_tfTime);
+  iosize += DECODEMCH(nSamples,    CTF::BLC_nSamples);
+  iosize += DECODEMCH(isSaturated, CTF::BLC_isSaturated);
+  iosize += DECODEMCH(detID,       CTF::BLC_detID);
+  iosize += DECODEMCH(padID,       CTF::BLC_padID);
+  iosize += DECODEMCH(ADC,         CTF::BLC_ADC);
   // clang-format on
   //
   rofVec.clear();
@@ -158,6 +163,8 @@ void CTFCoder::decode(const CTF::base& ec, VROF& rofVec, VCOL& digVec)
   }
   assert(rofVec.size() == header.nROFs);
   assert(digCount == header.nDigits);
+  iosize.rawIn = sizeof(ROFRecord) * rofVec.size() + sizeof(Digit) * digVec.size();
+  return iosize;
 }
 
 } // namespace mch

--- a/Detectors/MUON/MID/CTF/include/MIDCTF/CTFCoder.h
+++ b/Detectors/MUON/MID/CTF/include/MIDCTF/CTFCoder.h
@@ -43,11 +43,11 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 
   /// entropy-encode data to buffer with CTF
   template <typename VEC>
-  void encode(VEC& buff, const CTFHelper::TFData& tfData);
+  o2::ctf::CTFIOSize encode(VEC& buff, const CTFHelper::TFData& tfData);
 
   /// entropy decode data from buffer with CTF
   template <typename VROF, typename VCOL>
-  void decode(const CTF::base& ec, std::array<VROF, NEvTypes>& rofVec, std::array<VCOL, NEvTypes>& colVec);
+  o2::ctf::CTFIOSize decode(const CTF::base& ec, std::array<VROF, NEvTypes>& rofVec, std::array<VCOL, NEvTypes>& colVec);
 
   void createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op) final;
 
@@ -58,7 +58,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 
 /// entropy-encode clusters to buffer with CTF
 template <typename VEC>
-void CTFCoder::encode(VEC& buff, const CTFHelper::TFData& tfData)
+o2::ctf::CTFIOSize CTFCoder::encode(VEC& buff, const CTFHelper::TFData& tfData)
 {
   using MD = o2::ctf::Metadata::OptStore;
   // what to do which each field: see o2::ctd::Metadata explanation
@@ -85,23 +85,27 @@ void CTFCoder::encode(VEC& buff, const CTFHelper::TFData& tfData)
   ec->getANSHeader().majorVersion = 0;
   ec->getANSHeader().minorVersion = 1;
   // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
+  o2::ctf::CTFIOSize iosize;
 #define ENCODEMID(beg, end, slot, bits) CTF::get(buff.data())->encode(beg, end, int(slot), bits, optField[int(slot)], &buff, mCoders[int(slot)].get(), getMemMarginFactor());
   // clang-format off
-  ENCODEMID(helper.begin_bcIncROF(),    helper.end_bcIncROF(),     CTF::BLC_bcIncROF,    0);
-  ENCODEMID(helper.begin_orbitIncROF(), helper.end_orbitIncROF(),  CTF::BLC_orbitIncROF, 0);
-  ENCODEMID(helper.begin_entriesROF(),  helper.end_entriesROF(),   CTF::BLC_entriesROF,  0);
-  ENCODEMID(helper.begin_evtypeROF(),   helper.end_evtypeROF(),    CTF::BLC_evtypeROF,   0);
+  iosize += ENCODEMID(helper.begin_bcIncROF(),    helper.end_bcIncROF(),     CTF::BLC_bcIncROF,    0);
+  iosize += ENCODEMID(helper.begin_orbitIncROF(), helper.end_orbitIncROF(),  CTF::BLC_orbitIncROF, 0);
+  iosize += ENCODEMID(helper.begin_entriesROF(),  helper.end_entriesROF(),   CTF::BLC_entriesROF,  0);
+  iosize += ENCODEMID(helper.begin_evtypeROF(),   helper.end_evtypeROF(),    CTF::BLC_evtypeROF,   0);
 
-  ENCODEMID(helper.begin_pattern(),     helper.end_pattern(),      CTF::BLC_pattern,     0);
-  ENCODEMID(helper.begin_deId(),        helper.end_deId(),         CTF::BLC_deId,        0);
-  ENCODEMID(helper.begin_colId(),       helper.end_colId(),        CTF::BLC_colId,       0);
+  iosize += ENCODEMID(helper.begin_pattern(),     helper.end_pattern(),      CTF::BLC_pattern,     0);
+  iosize += ENCODEMID(helper.begin_deId(),        helper.end_deId(),         CTF::BLC_deId,        0);
+  iosize += ENCODEMID(helper.begin_colId(),       helper.end_colId(),        CTF::BLC_colId,       0);
   // clang-format on
   CTF::get(buff.data())->print(getPrefix(), mVerbosity);
+  finaliseCTFOutput<CTF>(buff);
+  iosize.rawIn = iosize.ctfIn;
+  return iosize;
 }
 
 /// decode entropy-encoded clusters to standard compact clusters
 template <typename VROF, typename VCOL>
-void CTFCoder::decode(const CTF::base& ec, std::array<VROF, NEvTypes>& rofVec, std::array<VCOL, NEvTypes>& colVec)
+o2::ctf::CTFIOSize CTFCoder::decode(const CTF::base& ec, std::array<VROF, NEvTypes>& rofVec, std::array<VCOL, NEvTypes>& colVec)
 {
   auto header = ec.getHeader();
   checkDictVersion(static_cast<const o2::ctf::CTFDictHeader&>(header));
@@ -110,16 +114,17 @@ void CTFCoder::decode(const CTF::base& ec, std::array<VROF, NEvTypes>& rofVec, s
   std::vector<uint32_t> orbitInc;
   std::vector<uint8_t> evType, deId, colId;
 
+  o2::ctf::CTFIOSize iosize;
 #define DECODEMID(part, slot) ec.decode(part, int(slot), mCoders[int(slot)].get())
   // clang-format off
-  DECODEMID(bcInc,       CTF::BLC_bcIncROF);
-  DECODEMID(orbitInc,    CTF::BLC_orbitIncROF);
-  DECODEMID(entries,     CTF::BLC_entriesROF);
-  DECODEMID(evType,      CTF::BLC_evtypeROF);
+  iosize += DECODEMID(bcInc,       CTF::BLC_bcIncROF);
+  iosize += DECODEMID(orbitInc,    CTF::BLC_orbitIncROF);
+  iosize += DECODEMID(entries,     CTF::BLC_entriesROF);
+  iosize += DECODEMID(evType,      CTF::BLC_evtypeROF);
 
-  DECODEMID(pattern,     CTF::BLC_pattern);
-  DECODEMID(deId,        CTF::BLC_deId);
-  DECODEMID(colId,       CTF::BLC_colId);
+  iosize += DECODEMID(pattern,     CTF::BLC_pattern);
+  iosize += DECODEMID(deId,        CTF::BLC_deId);
+  iosize += DECODEMID(colId,       CTF::BLC_colId);
   // clang-format on
   //
   for (uint32_t i = 0; i < NEvTypes; i++) {
@@ -150,6 +155,8 @@ void CTFCoder::decode(const CTF::base& ec, std::array<VROF, NEvTypes>& rofVec, s
     rofVec[evType[irof]].emplace_back(ROFRecord{ir, EventType(evType[irof]), firstEntry, entries[irof]});
   }
   assert(colCount == header.nColumns);
+  iosize.rawIn = iosize.ctfIn;
+  return iosize;
 }
 
 } // namespace mid

--- a/Detectors/MUON/MID/Workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/EntropyDecoderSpec.cxx
@@ -50,27 +50,30 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
 {
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
+  o2::ctf::CTFIOSize iosize;
 
   mCTFCoder.updateTimeDependentParams(pc);
   auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
   std::array<std::vector<o2::mid::ROFRecord>, NEvTypes> rofs{};
   std::array<std::vector<o2::mid::ColumnData>, NEvTypes> cols{};
-
   // since the buff is const, we cannot use EncodedBlocks::relocate directly, instead we wrap its data to another flat object
   if (buff.size()) {
     const auto ctfImage = o2::mid::CTF::getImage(buff.data());
-    mCTFCoder.decode(ctfImage, rofs, cols);
+    iosize = mCTFCoder.decode(ctfImage, rofs, cols);
   }
-
+  size_t insize = 0;
   for (uint32_t it = 0; it < NEvTypes; it++) {
+    insize += cols[it].size() * sizeof(o2::mid::ColumnData);
     pc.outputs().snapshot(Output{o2::header::gDataOriginMID, "DATA", it, Lifetime::Timeframe}, cols[it]);
+    insize += rofs[it].size() * sizeof(o2::mid::ROFRecord);
     pc.outputs().snapshot(Output{o2::header::gDataOriginMID, "DATAROF", it, Lifetime::Timeframe}, rofs[it]);
   }
-
+  iosize.rawIn = insize;
+  pc.outputs().snapshot({"ctfrep", 0}, iosize);
   mTimer.Stop();
   LOG(info) << "Decoded {" << cols[0].size() << ',' << cols[1].size() << ',' << cols[2].size()
             << "} MID columns for {" << rofs[0].size() << ',' << rofs[1].size() << ',' << rofs[2].size()
-            << "} ROFRecords in " << mTimer.CpuTime() - cput << " s";
+            << "} ROFRecords, (" << iosize.asString() << ") in " << mTimer.CpuTime() - cput << " s";
 }
 
 void EntropyDecoderSpec::endOfStream(EndOfStreamContext& ec)
@@ -86,7 +89,7 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
     outputs.emplace_back(OutputSpec{header::gDataOriginMID, "DATA", subSpec});
     outputs.emplace_back(OutputSpec{header::gDataOriginMID, "DATAROF", subSpec});
   }
-
+  outputs.emplace_back(OutputSpec{{"ctfrep"}, "PHS", "CTFDECREP", 0, Lifetime::Timeframe});
   std::vector<InputSpec> inputs;
   inputs.emplace_back("ctf", "MID", "CTFDATA", sspec, Lifetime::Timeframe);
   inputs.emplace_back("ctfdict", "MID", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("MID/Calib/CTFDictionary"));

--- a/Detectors/PHOS/reconstruction/include/PHOSReconstruction/CTFCoder.h
+++ b/Detectors/PHOS/reconstruction/include/PHOSReconstruction/CTFCoder.h
@@ -41,11 +41,11 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 
   /// entropy-encode data to buffer with CTF
   template <typename VEC>
-  void encode(VEC& buff, const gsl::span<const TriggerRecord>& trigData, const gsl::span<const Cell>& cellData);
+  o2::ctf::CTFIOSize encode(VEC& buff, const gsl::span<const TriggerRecord>& trigData, const gsl::span<const Cell>& cellData);
 
   /// entropy decode data from buffer with CTF
   template <typename VTRG, typename VCELL>
-  void decode(const CTF::base& ec, VTRG& trigVec, VCELL& cellVec);
+  o2::ctf::CTFIOSize decode(const CTF::base& ec, VTRG& trigVec, VCELL& cellVec);
 
   void createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op) final;
 
@@ -56,7 +56,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 
 /// entropy-encode clusters to buffer with CTF
 template <typename VEC>
-void CTFCoder::encode(VEC& buff, const gsl::span<const TriggerRecord>& trigData, const gsl::span<const Cell>& cellData)
+o2::ctf::CTFIOSize CTFCoder::encode(VEC& buff, const gsl::span<const TriggerRecord>& trigData, const gsl::span<const Cell>& cellData)
 {
   using MD = o2::ctf::Metadata::OptStore;
   // what to do which each field: see o2::ctd::Metadata explanation
@@ -84,23 +84,27 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const TriggerRecord>& trigData,
   ec->getANSHeader().majorVersion = 0;
   ec->getANSHeader().minorVersion = 1;
   // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
+  o2::ctf::CTFIOSize iosize;
 #define ENCODEPHS(beg, end, slot, bits) CTF::get(buff.data())->encode(beg, end, int(slot), bits, optField[int(slot)], &buff, mCoders[int(slot)].get(), getMemMarginFactor());
   // clang-format off
-  ENCODEPHS(helper.begin_bcIncTrig(),    helper.end_bcIncTrig(),     CTF::BLC_bcIncTrig,    0);
-  ENCODEPHS(helper.begin_orbitIncTrig(), helper.end_orbitIncTrig(),  CTF::BLC_orbitIncTrig, 0);
-  ENCODEPHS(helper.begin_entriesTrig(),  helper.end_entriesTrig(),   CTF::BLC_entriesTrig,  0);
+  iosize += ENCODEPHS(helper.begin_bcIncTrig(),    helper.end_bcIncTrig(),     CTF::BLC_bcIncTrig,    0);
+  iosize += ENCODEPHS(helper.begin_orbitIncTrig(), helper.end_orbitIncTrig(),  CTF::BLC_orbitIncTrig, 0);
+  iosize += ENCODEPHS(helper.begin_entriesTrig(),  helper.end_entriesTrig(),   CTF::BLC_entriesTrig,  0);
 
-  ENCODEPHS(helper.begin_packedID(),    helper.end_packedID(),     CTF::BLC_packedID,    0);
-  ENCODEPHS(helper.begin_time(),        helper.end_time(),         CTF::BLC_time,        0);
-  ENCODEPHS(helper.begin_energy(),      helper.end_energy(),       CTF::BLC_energy,      0);
-  ENCODEPHS(helper.begin_status(),      helper.end_status(),       CTF::BLC_status,      0);
+  iosize += ENCODEPHS(helper.begin_packedID(),    helper.end_packedID(),     CTF::BLC_packedID,    0);
+  iosize += ENCODEPHS(helper.begin_time(),        helper.end_time(),         CTF::BLC_time,        0);
+  iosize += ENCODEPHS(helper.begin_energy(),      helper.end_energy(),       CTF::BLC_energy,      0);
+  iosize += ENCODEPHS(helper.begin_status(),      helper.end_status(),       CTF::BLC_status,      0);
   // clang-format on
   CTF::get(buff.data())->print(getPrefix(), mVerbosity);
+  finaliseCTFOutput<CTF>(buff);
+  iosize.rawIn = trigData.size() * sizeof(TriggerRecord) + cellData.size() * sizeof(Cell);
+  return iosize;
 }
 
 /// decode entropy-encoded clusters to standard compact clusters
 template <typename VTRG, typename VCELL>
-void CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VCELL& cellVec)
+o2::ctf::CTFIOSize CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VCELL& cellVec)
 {
   const auto& header = ec.getHeader();
   checkDictVersion(static_cast<const o2::ctf::CTFDictHeader&>(header));
@@ -109,16 +113,17 @@ void CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VCELL& cellVec)
   std::vector<uint32_t> orbitInc;
   std::vector<uint8_t> status;
 
+  o2::ctf::CTFIOSize iosize;
 #define DECODEPHOS(part, slot) ec.decode(part, int(slot), mCoders[int(slot)].get())
   // clang-format off
-  DECODEPHOS(bcInc,       CTF::BLC_bcIncTrig);
-  DECODEPHOS(orbitInc,    CTF::BLC_orbitIncTrig);
-  DECODEPHOS(entries,     CTF::BLC_entriesTrig);
-  DECODEPHOS(packedID,    CTF::BLC_packedID);
+  iosize += DECODEPHOS(bcInc,       CTF::BLC_bcIncTrig);
+  iosize += DECODEPHOS(orbitInc,    CTF::BLC_orbitIncTrig);
+  iosize += DECODEPHOS(entries,     CTF::BLC_entriesTrig);
+  iosize += DECODEPHOS(packedID,    CTF::BLC_packedID);
 
-  DECODEPHOS(cellTime,    CTF::BLC_time);
-  DECODEPHOS(energy,      CTF::BLC_energy);
-  DECODEPHOS(status,      CTF::BLC_status);
+  iosize += DECODEPHOS(cellTime,    CTF::BLC_time);
+  iosize += DECODEPHOS(energy,      CTF::BLC_energy);
+  iosize += DECODEPHOS(status,      CTF::BLC_status);
   // clang-format on
   //
   trigVec.clear();
@@ -148,6 +153,8 @@ void CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VCELL& cellVec)
     trigVec.emplace_back(ir, firstEntry, entries[itrig]);
   }
   assert(cellCount == header.nCells);
+  iosize.rawIn = trigVec.size() * sizeof(TriggerRecord) + cellVec.size() * sizeof(Cell);
+  return iosize;
 }
 
 } // namespace phos

--- a/Detectors/PHOS/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/PHOS/workflow/src/EntropyDecoderSpec.cxx
@@ -48,6 +48,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
 {
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
+  o2::ctf::CTFIOSize iosize;
 
   mCTFCoder.updateTimeDependentParams(pc);
   auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
@@ -58,11 +59,11 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   // since the buff is const, we cannot use EncodedBlocks::relocate directly, instead we wrap its data to another flat object
   if (buff.size()) {
     const auto ctfImage = o2::phos::CTF::getImage(buff.data());
-    mCTFCoder.decode(ctfImage, triggers, cells);
+    iosize = mCTFCoder.decode(ctfImage, triggers, cells);
   }
-
+  pc.outputs().snapshot({"ctfrep", 0}, iosize);
   mTimer.Stop();
-  LOG(info) << "Decoded " << cells.size() << " PHOS cells in " << triggers.size() << " triggers in " << mTimer.CpuTime() - cput << " s";
+  LOG(info) << "Decoded " << cells.size() << " PHOS cells in " << triggers.size() << " triggers, (" << iosize.asString() << ") in " << mTimer.CpuTime() - cput << " s";
 }
 
 void EntropyDecoderSpec::endOfStream(EndOfStreamContext& ec)
@@ -75,7 +76,8 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
 {
   std::vector<OutputSpec> outputs{
     OutputSpec{{"triggers"}, "PHS", "CELLTRIGREC", 0, Lifetime::Timeframe},
-    OutputSpec{{"cells"}, "PHS", "CELLS", 0, Lifetime::Timeframe}};
+    OutputSpec{{"cells"}, "PHS", "CELLS", 0, Lifetime::Timeframe},
+    OutputSpec{{"ctfrep"}, "PHS", "CTFDECREP", 0, Lifetime::Timeframe}};
 
   std::vector<InputSpec> inputs;
   inputs.emplace_back("ctf", "PHS", "CTFDATA", sspec, Lifetime::Timeframe);

--- a/Detectors/PHOS/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/PHOS/workflow/src/EntropyEncoderSpec.cxx
@@ -53,10 +53,10 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
   auto cells = pc.inputs().get<gsl::span<Cell>>("cells");
 
   auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"PHS", "CTFDATA", 0, Lifetime::Timeframe});
-  mCTFCoder.encode(buffer, triggers, cells);
-  auto sz = mCTFCoder.finaliseCTFOutput<CTF>(buffer);
+  auto iosize = mCTFCoder.encode(buffer, triggers, cells);
+  pc.outputs().snapshot({"ctfrep", 0}, iosize);
   mTimer.Stop();
-  LOG(info) << "Created encoded data of size " << sz << " for PHOS in " << mTimer.CpuTime() - cput << " s";
+  LOG(info) << iosize.asString() << " in " << mTimer.CpuTime() - cput << " s";
 }
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
@@ -75,7 +75,8 @@ DataProcessorSpec getEntropyEncoderSpec()
   return DataProcessorSpec{
     "phos-entropy-encoder",
     inputs,
-    Outputs{{"PHS", "CTFDATA", 0, Lifetime::Timeframe}},
+    Outputs{{"PHS", "CTFDATA", 0, Lifetime::Timeframe},
+            {{"ctfrep"}, "PHS", "CTFENCREP", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<EntropyEncoderSpec>()},
     Options{{"ctf-dict", VariantType::String, "ccdb", {"CTF dictionary: empty or ccdb=CCDB, none=no external dictionary otherwise: local filename"}},
             {"mem-factor", VariantType::Float, 1.f, {"Memory allocation margin factor"}}}};

--- a/Detectors/TOF/compression/src/Compressor.cxx
+++ b/Detectors/TOF/compression/src/Compressor.cxx
@@ -21,7 +21,8 @@
 #include <cstring>
 #include <iostream>
 
-//#define DECODER_PARANOID
+// o2::ctf::CTFIOSize iosize;
+#define ENCODER_PARANOID
 //#define CHECKER_COUNTER
 
 #ifdef DECODER_PARANOID

--- a/Detectors/TOF/reconstruction/include/TOFReconstruction/CTFCoder.h
+++ b/Detectors/TOF/reconstruction/include/TOFReconstruction/CTFCoder.h
@@ -40,11 +40,11 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 
   /// entropy-encode clusters to buffer with CTF
   template <typename VEC>
-  void encode(VEC& buff, const gsl::span<const ReadoutWindowData>& rofRecVec, const gsl::span<const Digit>& cdigVec, const gsl::span<const uint8_t>& pattVec);
+  o2::ctf::CTFIOSize encode(VEC& buff, const gsl::span<const ReadoutWindowData>& rofRecVec, const gsl::span<const Digit>& cdigVec, const gsl::span<const uint8_t>& pattVec);
 
   /// entropy decode clusters from buffer with CTF
   template <typename VROF, typename VDIG, typename VPAT>
-  void decode(const CTF::base& ec, VROF& rofRecVec, VDIG& cdigVec, VPAT& pattVec);
+  o2::ctf::CTFIOSize decode(const CTF::base& ec, VROF& rofRecVec, VDIG& cdigVec, VPAT& pattVec);
 
   void createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op) final;
 
@@ -63,7 +63,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 ///___________________________________________________________________________________
 /// entropy-encode digits to buffer with CTF
 template <typename VEC>
-void CTFCoder::encode(VEC& buff, const gsl::span<const ReadoutWindowData>& rofRecVec, const gsl::span<const Digit>& cdigVec, const gsl::span<const uint8_t>& pattVec)
+o2::ctf::CTFIOSize CTFCoder::encode(VEC& buff, const gsl::span<const ReadoutWindowData>& rofRecVec, const gsl::span<const Digit>& cdigVec, const gsl::span<const uint8_t>& pattVec)
 {
   using MD = o2::ctf::Metadata::OptStore;
   // what to do which each field: see o2::ctd::Metadata explanation
@@ -94,49 +94,56 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const ReadoutWindowData>& rofRe
   ec->getANSHeader().majorVersion = 0;
   ec->getANSHeader().minorVersion = 1;
   // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
+  o2::ctf::CTFIOSize iosize;
 #define ENCODETOF(part, slot, bits) CTF::get(buff.data())->encode(part, int(slot), bits, optField[int(slot)], &buff, mCoders[int(slot)].get(), getMemMarginFactor());
   // clang-format off
-  ENCODETOF(cc.bcIncROF,     CTF::BLCbcIncROF,     0);
-  ENCODETOF(cc.orbitIncROF,  CTF::BLCorbitIncROF,  0);
-  ENCODETOF(cc.ndigROF,      CTF::BLCndigROF,      0);
-  ENCODETOF(cc.ndiaROF,      CTF::BLCndiaROF,      0);
-  ENCODETOF(cc.ndiaCrate,    CTF::BLCndiaCrate,    0);
-  ENCODETOF(cc.timeFrameInc, CTF::BLCtimeFrameInc, 0);
-  ENCODETOF(cc.timeTDCInc,   CTF::BLCtimeTDCInc,   0);
-  ENCODETOF(cc.stripID,      CTF::BLCstripID,      0);
-  ENCODETOF(cc.chanInStrip,  CTF::BLCchanInStrip,  0);
-  ENCODETOF(cc.tot,          CTF::BLCtot,          0);
-  ENCODETOF(cc.pattMap,      CTF::BLCpattMap,      0);
+  iosize += ENCODETOF(cc.bcIncROF,     CTF::BLCbcIncROF,     0);
+  iosize += ENCODETOF(cc.orbitIncROF,  CTF::BLCorbitIncROF,  0);
+  iosize += ENCODETOF(cc.ndigROF,      CTF::BLCndigROF,      0);
+  iosize += ENCODETOF(cc.ndiaROF,      CTF::BLCndiaROF,      0);
+  iosize += ENCODETOF(cc.ndiaCrate,    CTF::BLCndiaCrate,    0);
+  iosize += ENCODETOF(cc.timeFrameInc, CTF::BLCtimeFrameInc, 0);
+  iosize += ENCODETOF(cc.timeTDCInc,   CTF::BLCtimeTDCInc,   0);
+  iosize += ENCODETOF(cc.stripID,      CTF::BLCstripID,      0);
+  iosize += ENCODETOF(cc.chanInStrip,  CTF::BLCchanInStrip,  0);
+  iosize += ENCODETOF(cc.tot,          CTF::BLCtot,          0);
+  iosize += ENCODETOF(cc.pattMap,      CTF::BLCpattMap,      0);
   // clang-format on
   CTF::get(buff.data())->print(getPrefix(), mVerbosity);
+  finaliseCTFOutput<CTF>(buff);
+  iosize.rawIn = sizeof(ReadoutWindowData) * rofRecVec.size() + sizeof(Digit) * cdigVec.size() + sizeof(uint8_t) * pattVec.size();
+  return iosize;
 }
 
 ///___________________________________________________________________________________
 /// decode entropy-encoded digits to standard compact digits
 template <typename VROF, typename VDIG, typename VPAT>
-void CTFCoder::decode(const CTF::base& ec, VROF& rofRecVec, VDIG& cdigVec, VPAT& pattVec)
+o2::ctf::CTFIOSize CTFCoder::decode(const CTF::base& ec, VROF& rofRecVec, VDIG& cdigVec, VPAT& pattVec)
 {
   CompressedInfos cc;
   ec.print(getPrefix(), mVerbosity);
   cc.header = ec.getHeader();
   checkDictVersion(static_cast<const o2::ctf::CTFDictHeader&>(cc.header));
+  o2::ctf::CTFIOSize iosize;
 #define DECODETOF(part, slot) ec.decode(part, int(slot), mCoders[int(slot)].get())
   // clang-format off
-  DECODETOF(cc.bcIncROF,     CTF::BLCbcIncROF);
-  DECODETOF(cc.orbitIncROF,  CTF::BLCorbitIncROF);
-  DECODETOF(cc.ndigROF,      CTF::BLCndigROF);
-  DECODETOF(cc.ndiaROF,      CTF::BLCndiaROF);
-  DECODETOF(cc.ndiaCrate,    CTF::BLCndiaCrate);
+  iosize += DECODETOF(cc.bcIncROF,     CTF::BLCbcIncROF);
+  iosize += DECODETOF(cc.orbitIncROF,  CTF::BLCorbitIncROF);
+  iosize += DECODETOF(cc.ndigROF,      CTF::BLCndigROF);
+  iosize += DECODETOF(cc.ndiaROF,      CTF::BLCndiaROF);
+  iosize += DECODETOF(cc.ndiaCrate,    CTF::BLCndiaCrate);
 
-  DECODETOF(cc.timeFrameInc, CTF::BLCtimeFrameInc);
-  DECODETOF(cc.timeTDCInc,   CTF::BLCtimeTDCInc);
-  DECODETOF(cc.stripID,      CTF::BLCstripID);
-  DECODETOF(cc.chanInStrip,  CTF::BLCchanInStrip);
-  DECODETOF(cc.tot,          CTF::BLCtot);
-  DECODETOF(cc.pattMap,      CTF::BLCpattMap);
+  iosize += DECODETOF(cc.timeFrameInc, CTF::BLCtimeFrameInc);
+  iosize += DECODETOF(cc.timeTDCInc,   CTF::BLCtimeTDCInc);
+  iosize += DECODETOF(cc.stripID,      CTF::BLCstripID);
+  iosize += DECODETOF(cc.chanInStrip,  CTF::BLCchanInStrip);
+  iosize += DECODETOF(cc.tot,          CTF::BLCtot);
+  iosize += DECODETOF(cc.pattMap,      CTF::BLCpattMap);
   // clang-format on
   //
   decompress(cc, rofRecVec, cdigVec, pattVec);
+  iosize.rawIn = sizeof(ReadoutWindowData) * rofRecVec.size() + sizeof(Digit) * cdigVec.size() + sizeof(uint8_t) * pattVec.size();
+  return iosize;
 }
 ///___________________________________________________________________________________
 /// decompress compressed infos to standard compact digits

--- a/Detectors/TOF/reconstruction/src/DecoderBase.cxx
+++ b/Detectors/TOF/reconstruction/src/DecoderBase.cxx
@@ -21,8 +21,10 @@
 #include <cstring>
 #include <iostream>
 
-//#define DECODER_PARANOID
-//#define DECODER_VERBOSE
+// o2::ctf::CTFIOSize iosize;
+#define ENCODER_PARANOID
+// o2::ctf::CTFIOSize iosize;
+#define ENCODER_VERBOSE
 
 #ifdef DECODER_PARANOID
 #warning "Building code with DecoderParanoid option. This may limit the speed."

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/CTFCoder.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/CTFCoder.h
@@ -107,10 +107,10 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 
   /// entropy-encode compressed clusters to flat buffer
   template <typename VEC>
-  void encode(VEC& buff, const CompressedClusters& ccl);
+  o2::ctf::CTFIOSize encode(VEC& buff, const CompressedClusters& ccl);
 
   template <typename VEC>
-  void decode(const CTF::base& ec, VEC& buff);
+  o2::ctf::CTFIOSize decode(const CTF::base& ec, VEC& buff);
 
   void createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op) final;
 
@@ -161,7 +161,7 @@ void CTFCoder::buildCoder(ctf::CTFCoderBase::OpType coderType, const CTF::contai
 
 /// entropy-encode clusters to buffer with CTF
 template <typename VEC>
-void CTFCoder::encode(VEC& buff, const CompressedClusters& ccl)
+o2::ctf::CTFIOSize CTFCoder::encode(VEC& buff, const CompressedClusters& ccl)
 {
   using MD = o2::ctf::Metadata::OptStore;
   using namespace detail;
@@ -207,10 +207,11 @@ void CTFCoder::encode(VEC& buff, const CompressedClusters& ccl)
   ec->getANSHeader().majorVersion = 0;
   ec->getANSHeader().minorVersion = 1;
 
-  auto encodeTPC = [&buff, &optField, &coders = mCoders, mfc = this->getMemMarginFactor()](auto begin, auto end, CTF::Slots slot, size_t probabilityBits) {
+  o2::ctf::CTFIOSize iosize;
+  auto encodeTPC = [&buff, &optField, &coders = mCoders, mfc = this->getMemMarginFactor(), &iosize](auto begin, auto end, CTF::Slots slot, size_t probabilityBits) {
     // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
     const auto slotVal = static_cast<int>(slot);
-    CTF::get(buff.data())->encode(begin, end, slotVal, probabilityBits, optField[slotVal], &buff, coders[slotVal].get(), mfc);
+    iosize += CTF::get(buff.data())->encode(begin, end, slotVal, probabilityBits, optField[slotVal], &buff, coders[slotVal].get(), mfc);
   };
 
   if (mCombineColumns) {
@@ -276,11 +277,14 @@ void CTFCoder::encode(VEC& buff, const CompressedClusters& ccl)
   encodeTPC(ccl.nTrackClusters, ccl.nTrackClusters + ccl.nTracks, CTF::BLCnTrackClusters, 0);
   encodeTPC(ccl.nSliceRowClusters, ccl.nSliceRowClusters + ccl.nSliceRows, CTF::BLCnSliceRowClusters, 0);
   CTF::get(buff.data())->print(getPrefix(), mVerbosity);
+  finaliseCTFOutput<CTF>(buff);
+  iosize.rawIn = iosize.ctfIn;
+  return iosize;
 }
 
 /// decode entropy-encoded bloks to TPC CompressedClusters into the externally provided vector (e.g. PMR vector from DPL)
 template <typename VEC>
-void CTFCoder::decode(const CTF::base& ec, VEC& buffVec)
+o2::ctf::CTFIOSize CTFCoder::decode(const CTF::base& ec, VEC& buffVec)
 {
   using namespace detail;
   CompressedClusters cc;
@@ -302,9 +306,10 @@ void CTFCoder::decode(const CTF::base& ec, VEC& buffVec)
   ec.print(getPrefix(), mVerbosity);
 
   // decode encoded data directly to destination buff
-  auto decodeTPC = [&ec, &coders = mCoders](auto begin, CTF::Slots slot) {
+  o2::ctf::CTFIOSize iosize;
+  auto decodeTPC = [&ec, &coders = mCoders, &iosize](auto begin, CTF::Slots slot) {
     const auto slotVal = static_cast<int>(slot);
-    ec.decode(begin, slotVal, coders[slotVal].get());
+    iosize += ec.decode(begin, slotVal, coders[slotVal].get());
   };
 
   if (mCombineColumns) {
@@ -359,6 +364,8 @@ void CTFCoder::decode(const CTF::base& ec, VEC& buffVec)
 
   decodeTPC(cc.nTrackClusters, CTF::BLCnTrackClusters);
   decodeTPC(cc.nSliceRowClusters, CTF::BLCnSliceRowClusters);
+  iosize.rawIn = iosize.ctfIn;
+  return iosize;
 }
 
 } // namespace tpc

--- a/Detectors/TPC/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/TPC/workflow/src/EntropyEncoderSpec.cxx
@@ -65,10 +65,10 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
   mTimer.Start(false);
 
   auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"TPC", "CTFDATA", 0, Lifetime::Timeframe});
-  mCTFCoder.encode(buffer, clusters);
-  auto sz = mCTFCoder.finaliseCTFOutput<CTF>(buffer);
+  auto iosize = mCTFCoder.encode(buffer, clusters);
+  pc.outputs().snapshot({"ctfrep", 0}, iosize);
   mTimer.Stop();
-  LOG(info) << "Created encoded data of size " << sz << " for TPC in " << mTimer.CpuTime() - cput << " s";
+  LOG(info) << iosize.asString() << " in " << mTimer.CpuTime() - cput << " s";
 }
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
@@ -87,7 +87,8 @@ DataProcessorSpec getEntropyEncoderSpec(bool inputFromFile)
   return DataProcessorSpec{
     "tpc-entropy-encoder", // process id
     inputs,
-    Outputs{{"TPC", "CTFDATA", 0, Lifetime::Timeframe}},
+    Outputs{{"TPC", "CTFDATA", 0, Lifetime::Timeframe},
+            {{"ctfrep"}, "TPC", "CTFENCREP", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<EntropyEncoderSpec>(inputFromFile)},
     Options{{"ctf-dict", VariantType::String, "ccdb", {"CTF dictionary: empty or ccdb=CCDB, none=no external dictionary otherwise: local filename"}},
             {"no-ctf-columns-combining", VariantType::Bool, false, {"Do not combine correlated columns in CTF"}},

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CTFCoder.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CTFCoder.h
@@ -41,11 +41,11 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 
   /// entropy-encode data to buffer with CTF
   template <typename VEC>
-  void encode(VEC& buff, const gsl::span<const TriggerRecord>& trigData, const gsl::span<const Tracklet64>& trkData, const gsl::span<const Digit>& digData);
+  o2::ctf::CTFIOSize encode(VEC& buff, const gsl::span<const TriggerRecord>& trigData, const gsl::span<const Tracklet64>& trkData, const gsl::span<const Digit>& digData);
 
   /// entropy decode data from buffer with CTF
   template <typename VTRG, typename VTRK, typename VDIG>
-  void decode(const CTF::base& ec, VTRG& trigVec, VTRK& trkVec, VDIG& digVec);
+  o2::ctf::CTFIOSize decode(const CTF::base& ec, VTRG& trigVec, VTRK& trkVec, VDIG& digVec);
 
   void createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op) final;
 
@@ -56,7 +56,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 
 /// entropy-encode digits and tracklets to buffer with CTF
 template <typename VEC>
-void CTFCoder::encode(VEC& buff, const gsl::span<const TriggerRecord>& trigData, const gsl::span<const Tracklet64>& trkData, const gsl::span<const Digit>& digData)
+o2::ctf::CTFIOSize CTFCoder::encode(VEC& buff, const gsl::span<const TriggerRecord>& trigData, const gsl::span<const Tracklet64>& trkData, const gsl::span<const Digit>& digData)
 {
   using MD = o2::ctf::Metadata::OptStore;
   // what to do which each field: see o2::ctd::Metadata explanation
@@ -92,33 +92,37 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const TriggerRecord>& trigData,
   ec->getANSHeader().majorVersion = 0;
   ec->getANSHeader().minorVersion = 1;
   // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
+  o2::ctf::CTFIOSize iosize;
 #define ENCODETRD(beg, end, slot, bits) CTF::get(buff.data())->encode(beg, end, int(slot), bits, optField[int(slot)], &buff, mCoders[int(slot)].get(), getMemMarginFactor());
   // clang-format off
-  ENCODETRD(helper.begin_bcIncTrig(),    helper.end_bcIncTrig(),     CTF::BLC_bcIncTrig,    0);
-  ENCODETRD(helper.begin_orbitIncTrig(), helper.end_orbitIncTrig(),  CTF::BLC_orbitIncTrig, 0);
-  ENCODETRD(helper.begin_entriesTrk(),   helper.end_entriesTrk(),    CTF::BLC_entriesTrk,   0);
-  ENCODETRD(helper.begin_entriesDig(),   helper.end_entriesDig(),    CTF::BLC_entriesDig,   0);
+  iosize += ENCODETRD(helper.begin_bcIncTrig(),    helper.end_bcIncTrig(),     CTF::BLC_bcIncTrig,    0);
+  iosize += ENCODETRD(helper.begin_orbitIncTrig(), helper.end_orbitIncTrig(),  CTF::BLC_orbitIncTrig, 0);
+  iosize += ENCODETRD(helper.begin_entriesTrk(),   helper.end_entriesTrk(),    CTF::BLC_entriesTrk,   0);
+  iosize += ENCODETRD(helper.begin_entriesDig(),   helper.end_entriesDig(),    CTF::BLC_entriesDig,   0);
 
-  ENCODETRD(helper.begin_HCIDTrk(),      helper.end_HCIDTrk(),       CTF::BLC_HCIDTrk,      0);
-  ENCODETRD(helper.begin_padrowTrk(),    helper.end_padrowTrk(),     CTF::BLC_padrowTrk,    0);
-  ENCODETRD(helper.begin_colTrk(),       helper.end_colTrk(),        CTF::BLC_colTrk,       0);
-  ENCODETRD(helper.begin_posTrk(),       helper.end_posTrk(),        CTF::BLC_posTrk,       0);
-  ENCODETRD(helper.begin_slopeTrk(),     helper.end_slopeTrk(),      CTF::BLC_slopeTrk,     0);
-  ENCODETRD(helper.begin_pidTrk(),       helper.end_pidTrk(),        CTF::BLC_pidTrk,       0);
+  iosize += ENCODETRD(helper.begin_HCIDTrk(),      helper.end_HCIDTrk(),       CTF::BLC_HCIDTrk,      0);
+  iosize += ENCODETRD(helper.begin_padrowTrk(),    helper.end_padrowTrk(),     CTF::BLC_padrowTrk,    0);
+  iosize += ENCODETRD(helper.begin_colTrk(),       helper.end_colTrk(),        CTF::BLC_colTrk,       0);
+  iosize += ENCODETRD(helper.begin_posTrk(),       helper.end_posTrk(),        CTF::BLC_posTrk,       0);
+  iosize += ENCODETRD(helper.begin_slopeTrk(),     helper.end_slopeTrk(),      CTF::BLC_slopeTrk,     0);
+  iosize += ENCODETRD(helper.begin_pidTrk(),       helper.end_pidTrk(),        CTF::BLC_pidTrk,       0);
 
-  ENCODETRD(helper.begin_CIDDig(),       helper.end_CIDDig(),        CTF::BLC_CIDDig,       0);
-  ENCODETRD(helper.begin_ROBDig(),       helper.end_ROBDig(),        CTF::BLC_ROBDig,       0);
-  ENCODETRD(helper.begin_MCMDig(),       helper.end_MCMDig(),        CTF::BLC_MCMDig,       0);
-  ENCODETRD(helper.begin_chanDig(),      helper.end_chanDig(),       CTF::BLC_chanDig,      0);
-  ENCODETRD(helper.begin_ADCDig(),       helper.end_ADCDig(),        CTF::BLC_ADCDig,       0);
+  iosize += ENCODETRD(helper.begin_CIDDig(),       helper.end_CIDDig(),        CTF::BLC_CIDDig,       0);
+  iosize += ENCODETRD(helper.begin_ROBDig(),       helper.end_ROBDig(),        CTF::BLC_ROBDig,       0);
+  iosize += ENCODETRD(helper.begin_MCMDig(),       helper.end_MCMDig(),        CTF::BLC_MCMDig,       0);
+  iosize += ENCODETRD(helper.begin_chanDig(),      helper.end_chanDig(),       CTF::BLC_chanDig,      0);
+  iosize += ENCODETRD(helper.begin_ADCDig(),       helper.end_ADCDig(),        CTF::BLC_ADCDig,       0);
 
   // clang-format on
   CTF::get(buff.data())->print(getPrefix(), mVerbosity);
+  finaliseCTFOutput<CTF>(buff);
+  iosize.rawIn = trigData.size() * sizeof(TriggerRecord) + sizeof(Tracklet64) * trkData.size() + sizeof(Digit) * digData.size();
+  return iosize;
 }
 
 /// decode entropy-encoded data to tracklets and digits
 template <typename VTRG, typename VTRK, typename VDIG>
-void CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VTRK& trkVec, VDIG& digVec)
+o2::ctf::CTFIOSize CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VTRK& trkVec, VDIG& digVec)
 {
   auto header = ec.getHeader();
   checkDictVersion(static_cast<const o2::ctf::CTFDictHeader&>(header));
@@ -127,25 +131,26 @@ void CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VTRK& trkVec, VDIG& di
   std::vector<uint32_t> orbitInc, entriesTrk, entriesDig, pidTrk;
   std::vector<uint8_t> padrowTrk, colTrk, slopeTrk, ROBDig, MCMDig, chanDig;
 
+  o2::ctf::CTFIOSize iosize;
 #define DECODETRD(part, slot) ec.decode(part, int(slot), mCoders[int(slot)].get())
   // clang-format off
-  DECODETRD(bcInc,       CTF::BLC_bcIncTrig);
-  DECODETRD(orbitInc,    CTF::BLC_orbitIncTrig);
-  DECODETRD(entriesTrk,  CTF::BLC_entriesTrk);
-  DECODETRD(entriesDig,  CTF::BLC_entriesDig);
+  iosize += DECODETRD(bcInc,       CTF::BLC_bcIncTrig);
+  iosize += DECODETRD(orbitInc,    CTF::BLC_orbitIncTrig);
+  iosize += DECODETRD(entriesTrk,  CTF::BLC_entriesTrk);
+  iosize += DECODETRD(entriesDig,  CTF::BLC_entriesDig);
 
-  DECODETRD(HCIDTrk,     CTF::BLC_HCIDTrk);
-  DECODETRD(padrowTrk,   CTF::BLC_padrowTrk);
-  DECODETRD(colTrk,      CTF::BLC_colTrk);
-  DECODETRD(posTrk,      CTF::BLC_posTrk);
-  DECODETRD(slopeTrk,    CTF::BLC_slopeTrk);
-  DECODETRD(pidTrk,      CTF::BLC_pidTrk);
+  iosize += DECODETRD(HCIDTrk,     CTF::BLC_HCIDTrk);
+  iosize += DECODETRD(padrowTrk,   CTF::BLC_padrowTrk);
+  iosize += DECODETRD(colTrk,      CTF::BLC_colTrk);
+  iosize += DECODETRD(posTrk,      CTF::BLC_posTrk);
+  iosize += DECODETRD(slopeTrk,    CTF::BLC_slopeTrk);
+  iosize += DECODETRD(pidTrk,      CTF::BLC_pidTrk);
 
-  DECODETRD(CIDDig,      CTF::BLC_CIDDig);
-  DECODETRD(ROBDig,      CTF::BLC_ROBDig);
-  DECODETRD(MCMDig,      CTF::BLC_MCMDig);
-  DECODETRD(chanDig,     CTF::BLC_chanDig);
-  DECODETRD(ADCDig,      CTF::BLC_ADCDig);
+  iosize += DECODETRD(CIDDig,      CTF::BLC_CIDDig);
+  iosize += DECODETRD(ROBDig,      CTF::BLC_ROBDig);
+  iosize += DECODETRD(MCMDig,      CTF::BLC_MCMDig);
+  iosize += DECODETRD(chanDig,     CTF::BLC_chanDig);
+  iosize += DECODETRD(ADCDig,      CTF::BLC_ADCDig);
   // clang-format on
   //
   trigVec.clear();
@@ -188,6 +193,8 @@ void CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VTRK& trkVec, VDIG& di
     trigVec.emplace_back(ir, firstEntryDig, entriesDig[itrig], firstEntryTrk, entriesTrk[itrig]);
   }
   assert(digCount == header.nDigits && trkCount == header.nTracklets && adcCount == (int)ADCDig.size());
+  iosize.rawIn = trigVec.size() * sizeof(TriggerRecord) + sizeof(Tracklet64) * trkVec.size() + sizeof(Digit) * digVec.size();
+  return iosize;
 }
 
 } // namespace trd

--- a/Detectors/TRD/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/TRD/workflow/src/EntropyEncoderSpec.cxx
@@ -71,10 +71,10 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
   auto digits = pc.inputs().get<gsl::span<Digit>>("digits");
 
   auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"TRD", "CTFDATA", 0, Lifetime::Timeframe});
-  mCTFCoder.encode(buffer, triggers, tracklets, digits);
-  auto sz = mCTFCoder.finaliseCTFOutput<CTF>(buffer);
+  auto iosize = mCTFCoder.encode(buffer, triggers, tracklets, digits);
+  pc.outputs().snapshot({"ctfrep", 0}, iosize);
   mTimer.Stop();
-  LOG(info) << "Created encoded data of size " << sz << " for TRD in " << mTimer.CpuTime() - cput << " s";
+  LOG(info) << iosize.asString() << " in " << mTimer.CpuTime() - cput << " s";
 }
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
@@ -94,7 +94,8 @@ DataProcessorSpec getEntropyEncoderSpec()
   return DataProcessorSpec{
     "trd-entropy-encoder",
     inputs,
-    Outputs{{"TRD", "CTFDATA", 0, Lifetime::Timeframe}},
+    Outputs{{"TRD", "CTFDATA", 0, Lifetime::Timeframe},
+            {{"ctfrep"}, "TRD", "CTFENCREP", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<EntropyEncoderSpec>()},
     Options{{"ctf-dict", VariantType::String, "ccdb", {"CTF dictionary: empty or ccdb=CCDB, none=no external dictionary otherwise: local filename"}},
             {"mem-factor", VariantType::Float, 1.f, {"Memory allocation margin factor"}}}};

--- a/Detectors/ZDC/reconstruction/include/ZDCReconstruction/CTFCoder.h
+++ b/Detectors/ZDC/reconstruction/include/ZDCReconstruction/CTFCoder.h
@@ -41,11 +41,11 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 
   /// entropy-encode data to buffer with CTF
   template <typename VEC>
-  void encode(VEC& buff, const gsl::span<const BCData>& trgData, const gsl::span<const ChannelData>& chanData, const gsl::span<const OrbitData>& pedData);
+  o2::ctf::CTFIOSize encode(VEC& buff, const gsl::span<const BCData>& trgData, const gsl::span<const ChannelData>& chanData, const gsl::span<const OrbitData>& pedData);
 
   /// entropy decode data from buffer with CTF
   template <typename VTRG, typename VCHAN, typename VPED>
-  void decode(const CTF::base& ec, VTRG& trigVec, VCHAN& chanVec, VPED& pedVec);
+  o2::ctf::CTFIOSize decode(const CTF::base& ec, VTRG& trigVec, VCHAN& chanVec, VPED& pedVec);
 
   void createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op) final;
 
@@ -56,7 +56,7 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 
 /// entropy-encode clusters to buffer with CTF
 template <typename VEC>
-void CTFCoder::encode(VEC& buff, const gsl::span<const BCData>& trigData, const gsl::span<const ChannelData>& chanData, const gsl::span<const OrbitData>& pedData)
+o2::ctf::CTFIOSize CTFCoder::encode(VEC& buff, const gsl::span<const BCData>& trigData, const gsl::span<const ChannelData>& chanData, const gsl::span<const OrbitData>& pedData)
 {
   using MD = o2::ctf::Metadata::OptStore;
   // what to do which each field: see o2::ctd::Metadata explanation
@@ -91,30 +91,34 @@ void CTFCoder::encode(VEC& buff, const gsl::span<const BCData>& trigData, const 
   ec->getANSHeader().majorVersion = 0;
   ec->getANSHeader().minorVersion = 1;
   // at every encoding the buffer might be autoexpanded, so we don't work with fixed pointer ec
+  o2::ctf::CTFIOSize iosize;
 #define ENCODEZDC(beg, end, slot, bits) CTF::get(buff.data())->encode(beg, end, int(slot), bits, optField[int(slot)], &buff, mCoders[int(slot)].get(), getMemMarginFactor());
   // clang-format off
-  ENCODEZDC(helper.begin_bcIncTrig(),    helper.end_bcIncTrig(),     CTF::BLC_bcIncTrig,    0);
-  ENCODEZDC(helper.begin_orbitIncTrig(), helper.end_orbitIncTrig(),  CTF::BLC_orbitIncTrig, 0);
-  ENCODEZDC(helper.begin_moduleTrig(),   helper.end_moduleTrig(),    CTF::BLC_moduleTrig,   0);
-  ENCODEZDC(helper.begin_channelsHL(),   helper.end_channelsHL(),    CTF::BLC_channelsHL,   0);
-  ENCODEZDC(helper.begin_triggersHL(),   helper.end_triggersHL(),    CTF::BLC_triggersHL,   0);
-  ENCODEZDC(helper.begin_extTriggers(),  helper.end_extTriggers(),   CTF::BLC_extTriggers,  0);
-  ENCODEZDC(helper.begin_nchanTrig(),    helper.end_nchanTrig(),     CTF::BLC_nchanTrig,    0);
+  iosize += ENCODEZDC(helper.begin_bcIncTrig(),    helper.end_bcIncTrig(),     CTF::BLC_bcIncTrig,    0);
+  iosize += ENCODEZDC(helper.begin_orbitIncTrig(), helper.end_orbitIncTrig(),  CTF::BLC_orbitIncTrig, 0);
+  iosize += ENCODEZDC(helper.begin_moduleTrig(),   helper.end_moduleTrig(),    CTF::BLC_moduleTrig,   0);
+  iosize += ENCODEZDC(helper.begin_channelsHL(),   helper.end_channelsHL(),    CTF::BLC_channelsHL,   0);
+  iosize += ENCODEZDC(helper.begin_triggersHL(),   helper.end_triggersHL(),    CTF::BLC_triggersHL,   0);
+  iosize += ENCODEZDC(helper.begin_extTriggers(),  helper.end_extTriggers(),   CTF::BLC_extTriggers,  0);
+  iosize += ENCODEZDC(helper.begin_nchanTrig(),    helper.end_nchanTrig(),     CTF::BLC_nchanTrig,    0);
   //
-  ENCODEZDC(helper.begin_chanID(),       helper.end_chanID(),        CTF::BLC_chanID,       0);
-  ENCODEZDC(helper.begin_chanData(),     helper.end_chanData(),      CTF::BLC_chanData,     0);
+  iosize += ENCODEZDC(helper.begin_chanID(),       helper.end_chanID(),        CTF::BLC_chanID,       0);
+  iosize += ENCODEZDC(helper.begin_chanData(),     helper.end_chanData(),      CTF::BLC_chanData,     0);
   //
-  ENCODEZDC(helper.begin_orbitIncEOD(),  helper.end_orbitIncEOD(),   CTF::BLC_orbitIncEOD,  0);
-  ENCODEZDC(helper.begin_pedData(),      helper.end_pedData(),       CTF::BLC_pedData,      0);
-  ENCODEZDC(helper.begin_sclInc(),       helper.end_sclInc(),        CTF::BLC_sclInc,       0);
+  iosize += ENCODEZDC(helper.begin_orbitIncEOD(),  helper.end_orbitIncEOD(),   CTF::BLC_orbitIncEOD,  0);
+  iosize += ENCODEZDC(helper.begin_pedData(),      helper.end_pedData(),       CTF::BLC_pedData,      0);
+  iosize += ENCODEZDC(helper.begin_sclInc(),       helper.end_sclInc(),        CTF::BLC_sclInc,       0);
 
   // clang-format on
   CTF::get(buff.data())->print(getPrefix(), mVerbosity);
+  finaliseCTFOutput<CTF>(buff);
+  iosize.rawIn = sizeof(BCData) * trigData.size() + sizeof(ChannelData) * chanData.size() + sizeof(OrbitData) * pedData.size();
+  return iosize;
 }
 
 /// decode entropy-encoded clusters to standard compact clusters
 template <typename VTRG, typename VCHAN, typename VPED>
-void CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VCHAN& chanVec, VPED& pedVec)
+o2::ctf::CTFIOSize CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VCHAN& chanVec, VPED& pedVec)
 {
   auto header = ec.getHeader();
   checkDictVersion(static_cast<const o2::ctf::CTFDictHeader&>(header));
@@ -123,22 +127,23 @@ void CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VCHAN& chanVec, VPED& 
   std::vector<uint32_t> orbitIncTrig, orbitIncEOD;
   std::vector<uint8_t> extTriggers, chanID;
 
+  o2::ctf::CTFIOSize iosize;
 #define DECODEZDC(part, slot) ec.decode(part, int(slot), mCoders[int(slot)].get())
   // clang-format off
-  DECODEZDC(bcIncTrig,      CTF::BLC_bcIncTrig);
-  DECODEZDC(orbitIncTrig,   CTF::BLC_orbitIncTrig);
-  DECODEZDC(moduleTrig,     CTF::BLC_moduleTrig);
-  DECODEZDC(channelsHL,     CTF::BLC_channelsHL);
-  DECODEZDC(triggersHL,     CTF::BLC_triggersHL);
-  DECODEZDC(extTriggers,    CTF::BLC_extTriggers);
-  DECODEZDC(nchanTrig,      CTF::BLC_nchanTrig);
+  iosize += DECODEZDC(bcIncTrig,      CTF::BLC_bcIncTrig);
+  iosize += DECODEZDC(orbitIncTrig,   CTF::BLC_orbitIncTrig);
+  iosize += DECODEZDC(moduleTrig,     CTF::BLC_moduleTrig);
+  iosize += DECODEZDC(channelsHL,     CTF::BLC_channelsHL);
+  iosize += DECODEZDC(triggersHL,     CTF::BLC_triggersHL);
+  iosize += DECODEZDC(extTriggers,    CTF::BLC_extTriggers);
+  iosize += DECODEZDC(nchanTrig,      CTF::BLC_nchanTrig);
   //
-  DECODEZDC(chanID,         CTF::BLC_chanID);
-  DECODEZDC(chanData,       CTF::BLC_chanData);
+  iosize += DECODEZDC(chanID,         CTF::BLC_chanID);
+  iosize += DECODEZDC(chanData,       CTF::BLC_chanData);
   //
-  DECODEZDC(orbitIncEOD,    CTF::BLC_orbitIncEOD);
-  DECODEZDC(pedData,        CTF::BLC_pedData);
-  DECODEZDC(scalerInc,      CTF::BLC_sclInc);
+  iosize += DECODEZDC(orbitIncEOD,    CTF::BLC_orbitIncEOD);
+  iosize += DECODEZDC(pedData,        CTF::BLC_pedData);
+  iosize += DECODEZDC(scalerInc,      CTF::BLC_sclInc);
   // clang-format on
   //
   trigVec.clear();
@@ -203,6 +208,8 @@ void CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VCHAN& chanVec, VPED& 
   assert(channelsHLIt == channelsHL.end());
   assert(triggersHLIt == triggersHL.end());
   assert(sclIncIt == scalerInc.end());
+  iosize.rawIn = sizeof(BCData) * trigVec.size() + sizeof(ChannelData) * chanVec.size() + sizeof(OrbitData) * pedVec.size();
+  return iosize;
 }
 
 } // namespace zdc

--- a/Detectors/ZDC/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/ZDC/workflow/src/EntropyEncoderSpec.cxx
@@ -56,10 +56,10 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
   auto peds = pc.inputs().get<gsl::span<o2::zdc::OrbitData>>("peds");
 
   auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"ZDC", "CTFDATA", 0, Lifetime::Timeframe});
-  mCTFCoder.encode(buffer, bcdata, chans, peds);
-  auto sz = mCTFCoder.finaliseCTFOutput<CTF>(buffer);
+  auto iosize = mCTFCoder.encode(buffer, bcdata, chans, peds);
+  pc.outputs().snapshot({"ctfrep", 0}, iosize);
   mTimer.Stop();
-  LOG(info) << "Created encoded data of size " << sz << " for ZDC in " << mTimer.CpuTime() - cput << " s";
+  LOG(info) << iosize.asString() << " in " << mTimer.CpuTime() - cput << " s";
 }
 
 void EntropyEncoderSpec::endOfStream(EndOfStreamContext& ec)
@@ -79,7 +79,8 @@ DataProcessorSpec getEntropyEncoderSpec()
   return DataProcessorSpec{
     "zdc-entropy-encoder",
     inputs,
-    Outputs{{"ZDC", "CTFDATA", 0, Lifetime::Timeframe}},
+    Outputs{{"ZDC", "CTFDATA", 0, Lifetime::Timeframe},
+            {{"ctfrep"}, "ZDC", "CTFENCREP", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<EntropyEncoderSpec>()},
     Options{{"ctf-dict", VariantType::String, "ccdb", {"CTF dictionary: empty or ccdb=CCDB, none=no external dictionary otherwise: local filename"}},
             {"mem-factor", VariantType::Float, 1.f, {"Memory allocation margin factor"}}}};


### PR DESCRIPTION
Entropy encoders and decoders of each detector sends a message <DET>/CTFENCREP/0
and <DET>/CTTDECREP/0 respectively, containing an object of o2::ctf::CTFIOSize
with the following content:
rawIn: size of input to (output from) the EntropyEncoder(Decoder)
ctfIn: size of input to (output from) the CTFCodet::encode (:decode) entropy coder method
ctfOut: size of entropy compressed output.

Note that depending on the detector rawIn and ctfIn may be the same or different, since some
detectors optimize data format for entropy compression.
Therefore, ctfOut/ctfIn provides more technical info about the compressibility of the data and
quality of the dictionary, while ctfOut/rawIn gives the real compression factor.

@tklemenz 