### PR TITLE
Make FV0 reco use DPL CCDB fetcher, fix Calib path

### DIFF
--- a/Detectors/FIT/FV0/calibration/macros/makeChannelTimeOffsetFV0CalibObjectInCCDB.C
+++ b/Detectors/FIT/FV0/calibration/macros/makeChannelTimeOffsetFV0CalibObjectInCCDB.C
@@ -26,6 +26,6 @@ int makeChannelTimeOffsetFV0CalibObjectInCCDB(const std::string url = "http://al
   for (auto& dummyCalCoeff : obj.mTimeOffsets) {
     dummyCalCoeff = 0;
   }
-  api.storeAsTFileAny(&obj, "FV0/Calibration/ChannelTimeOffset", md, 0);
+  api.storeAsTFileAny(&obj, "FV0/Calib/ChannelTimeOffset", md, 0);
   return 0;
 }

--- a/Detectors/FIT/FV0/calibration/macros/readChannelTimeOffsetFV0CalibObjectFromCCDB.C
+++ b/Detectors/FIT/FV0/calibration/macros/readChannelTimeOffsetFV0CalibObjectFromCCDB.C
@@ -24,7 +24,7 @@ int readChannelTimeOffsetFV0CalibObjectFromCCDB(const std::string url = "http://
   api.init(url);
   map<string, string> metadata;
   map<string, string> headers;
-  auto retrieved = api.retrieveFromTFileAny<o2::fv0::FV0ChannelTimeCalibrationObject>("FV0/Calibration/ChannelTimeOffset", metadata, -1, &headers);
+  auto retrieved = api.retrieveFromTFileAny<o2::fv0::FV0ChannelTimeCalibrationObject>("FV0/Calib/ChannelTimeOffset", metadata, -1, &headers);
 
   std::cout << "--- HEADERS ---" << std::endl;
   for (const auto& [key, value] : headers) {

--- a/Detectors/FIT/FV0/reconstruction/include/FV0Reconstruction/BaseRecoTask.h
+++ b/Detectors/FIT/FV0/reconstruction/include/FV0Reconstruction/BaseRecoTask.h
@@ -39,7 +39,7 @@ class BaseRecoTask
   int getChannelOffset(int channel);
 
  private:
-  o2::fv0::FV0ChannelTimeCalibrationObject* mCalibOffset;
+  o2::fv0::FV0ChannelTimeCalibrationObject* mCalibOffset = nullptr;
 
   ClassDefNV(BaseRecoTask, 3);
 };

--- a/Detectors/FIT/FV0/workflow/include/FV0Workflow/RecoWorkflow.h
+++ b/Detectors/FIT/FV0/workflow/include/FV0Workflow/RecoWorkflow.h
@@ -20,7 +20,7 @@ namespace o2
 {
 namespace fv0
 {
-framework::WorkflowSpec getRecoWorkflow(bool useMC, std::string ccdbpath, bool disableRootInp, bool disableRootOut);
+framework::WorkflowSpec getRecoWorkflow(bool useMC, bool disableRootInp, bool disableRootOut);
 } // namespace fv0
 } // namespace o2
 #endif

--- a/Detectors/FIT/FV0/workflow/include/FV0Workflow/ReconstructionSpec.h
+++ b/Detectors/FIT/FV0/workflow/include/FV0Workflow/ReconstructionSpec.h
@@ -18,7 +18,6 @@
 #include "Framework/Task.h"
 #include "FV0Reconstruction/BaseRecoTask.h"
 #include "DataFormatsFV0/RecPoints.h"
-#include "CCDB/BasicCCDBManager.h"
 #include "FV0Base/Constants.h"
 #include "TStopwatch.h"
 
@@ -34,15 +33,16 @@ class ReconstructionDPL : public Task
   static constexpr int NCHANNELS = o2::fv0::Constants::nFv0Channels;
 
  public:
-  ReconstructionDPL(bool useMC, const std::string ccdbpath) : mUseMC(useMC), mCCDBpath(ccdbpath) {}
+  ReconstructionDPL(bool useMC) : mUseMC(useMC) {}
   ~ReconstructionDPL() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
   void endOfStream(framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
+  void updateTimeDependentParams(o2::framework::ProcessingContext& pc);
   bool mUseMC = false;
-  const std::string mCCDBpath = o2::base::NameConf::getCCDBServer();
   std::vector<o2::fv0::RecPoints> mRecPoints;
   std::vector<o2::fv0::ChannelDataFloat> mRecChData;
   o2::fv0::BaseRecoTask mReco;
@@ -51,7 +51,7 @@ class ReconstructionDPL : public Task
 };
 
 /// create a processor spec
-framework::DataProcessorSpec getReconstructionSpec(bool useMC = false, const std::string ccdbpath = "http://alice-ccdb.cern.ch");
+framework::DataProcessorSpec getReconstructionSpec(bool useMC = false);
 
 } // namespace fv0
 } // namespace o2

--- a/Detectors/FIT/FV0/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/FIT/FV0/workflow/src/RecoWorkflow.cxx
@@ -22,14 +22,14 @@ namespace o2
 namespace fv0
 {
 
-framework::WorkflowSpec getRecoWorkflow(bool useMC, std::string ccdbpath, bool disableRootInp, bool disableRootOut)
+framework::WorkflowSpec getRecoWorkflow(bool useMC, bool disableRootInp, bool disableRootOut)
 {
   framework::WorkflowSpec specs;
   if (!disableRootInp) {
     specs.emplace_back(o2::fv0::getDigitReaderSpec(useMC));
   }
 
-  specs.emplace_back(o2::fv0::getReconstructionSpec(useMC, ccdbpath));
+  specs.emplace_back(o2::fv0::getReconstructionSpec(useMC));
   if (!disableRootOut) {
     specs.emplace_back(o2::fv0::getRecPointWriterSpec(useMC));
   }

--- a/Detectors/FIT/FV0/workflow/src/fv0-reco-workflow.cxx
+++ b/Detectors/FIT/FV0/workflow/src/fv0-reco-workflow.cxx
@@ -57,12 +57,11 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   o2::conf::ConfigurableParam::writeINI("o2-fv0-recoflow_configuration.ini");
 
   auto useMC = !configcontext.options().get<bool>("disable-mc");
-  auto ccdbpath = o2::base::NameConf::getCCDBServer();
   auto disableRootInp = configcontext.options().get<bool>("disable-root-input");
   auto disableRootOut = configcontext.options().get<bool>("disable-root-output");
 
-  LOG(info) << "WorkflowSpec getRecoWorkflow useMC " << useMC << " CCDB  " << ccdbpath;
-  auto wf = o2::fv0::getRecoWorkflow(useMC, ccdbpath, disableRootInp, disableRootOut);
+  LOG(info) << "WorkflowSpec getRecoWorkflow useMC " << useMC;
+  auto wf = o2::fv0::getRecoWorkflow(useMC, disableRootInp, disableRootOut);
 
   // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit
   o2::raw::HBFUtilsInitializer hbfIni(configcontext, wf);

--- a/Detectors/FIT/common/calibration/include/FITCalibration/FITCalibrationApi.h
+++ b/Detectors/FIT/common/calibration/include/FITCalibration/FITCalibrationApi.h
@@ -171,7 +171,7 @@ inline std::vector<FITCalibrationApi::CalibObjWithInfoType> FITCalibrationApi::p
 template <>
 inline const char* FITCalibrationApi::getObjectPath<o2::fv0::FV0ChannelTimeCalibrationObject>()
 {
-  return "FV0/Calibration/ChannelTimeOffset";
+  return "FV0/Calib/ChannelTimeOffset";
 }
 
 template <>


### PR DESCRIPTION
FV0 reconstruction is changed to use the DPL CCDB fetcher, all old paths FV0/Calibration/...
are changed to FV0/Calib/...

@AllaMaevskaya @mslupeck @mbroz84 @jotwinow could you please check if there are other instances (e.q. in QC) of access to <FIT>/Calibration, if so, should be changed to /Calib and the objects should be relocated. Please also change from CCDBManager to DPL fetcher, like this PR does.
Also, see the question about old objects in FV0/Calibration: https://alice.its.cern.ch/jira/browse/O2-2917?focusedCommentId=285348&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-285348