### PR TITLE
MRRTF-173: cluster transformer now reads geometry from CCDB by default

### DIFF
--- a/Detectors/MUON/MCH/Geometry/Transformer/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Geometry/Transformer/CMakeLists.txt
@@ -21,3 +21,15 @@ o2_add_executable(
   PUBLIC_LINK_LIBRARIES ROOT::Geom Microsoft.GSL::GSL Boost::program_options
                         O2::MCHGeometryTransformer
   COMPONENT_NAME mch)
+
+o2_add_executable(
+        clusters-transformer-workflow
+        SOURCES src/clusters-transformer-workflow.cxx src/ClusterTransformerSpec.cxx
+        COMPONENT_NAME mch
+        PUBLIC_LINK_LIBRARIES
+           O2::DetectorsBase
+           O2::Framework
+           O2::MCHBase
+           O2::MCHGeometryTransformer
+        )
+

--- a/Detectors/MUON/MCH/Geometry/Transformer/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Geometry/Transformer/CMakeLists.txt
@@ -11,9 +11,10 @@
 
 o2_add_library(
   MCHGeometryTransformer
-  SOURCES src/Transformations.cxx src/VolumePaths.cxx
+  SOURCES src/Transformations.cxx src/VolumePaths.cxx src/ClusterTransformerSpec.cxx
   PUBLIC_LINK_LIBRARIES ROOT::Geom O2::MathUtils Microsoft.GSL::GSL
-                        RapidJSON::RapidJSON)
+                        RapidJSON::RapidJSON O2::Framework O2::DetectorsBase
+                        O2::DataFormatsMCH)
 
 o2_add_executable(
   convert-geometry
@@ -24,7 +25,7 @@ o2_add_executable(
 
 o2_add_executable(
         clusters-transformer-workflow
-        SOURCES src/clusters-transformer-workflow.cxx src/ClusterTransformerSpec.cxx
+        SOURCES src/clusters-transformer-workflow.cxx
         COMPONENT_NAME mch
         PUBLIC_LINK_LIBRARIES
            O2::DetectorsBase

--- a/Detectors/MUON/MCH/Geometry/Transformer/README.md
+++ b/Detectors/MUON/MCH/Geometry/Transformer/README.md
@@ -34,3 +34,23 @@ cat output.json | jq '.alignables|=sort_by(.deid)'
 
 That last command being the one that was used to produce the example [ideal-geometry-o2.json](../Test/ideal-geometry-o2.json) file.
 
+## Workflow
+
+The `o2-mch-clusters-transformer-workflow` takes as input the list of all clusters ([Cluster](/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Cluster.h)), in local reference frame, in the current time frame, with the data description "CLUSTERS".
+
+It sends the list of the same clusters, but converted in global reference frame, with the data description "GLOBALCLUSTERS".
+
+By default the workflow reads the (aligned) geometry from the CCDB.
+ One can instead read the geometry from a file (either JSON or Root format) using the `--geometry` option, together with the explicit `--mch-disable-geometry-from-ccdb`option.
+
+To test it one can use e.g. a `sampler-transformer-sink` pipeline as such :
+
+```
+o2-mch-clusters-sampler-workflow
+    -b --nEventsPerTF 1000 --infile someclusters.data |
+o2-mch-clusters-transformer-workflow
+    -b --mch-disable-geometry-from-ccdb --geometry Detectors/MUON/MCH/Geometry/Test/ideal-geometry-o2.json |
+o2-mch-clusters-sink-workflow
+    -b --txt --outfile global-clusters.txt --no-digits --global
+```
+

--- a/Detectors/MUON/MCH/Geometry/Transformer/include/MCHGeometryTransformer/ClusterTransformerSpec.h
+++ b/Detectors/MUON/MCH/Geometry/Transformer/include/MCHGeometryTransformer/ClusterTransformerSpec.h
@@ -9,13 +9,13 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifndef O2_MCH_WORKFLOW_CLUSTER_TRANSFORMER_SPEC_H
-#define O2_MCH_WORKFLOW_CLUSTER_TRANSFORMER_SPEC_H
+#ifndef O2_MCH_GEOMETRY_TRANSFORMER_CLUSTER_TRANSFORMER_SPEC_H
+#define O2_MCH_GEOMETRY_TRANSFORMER_CLUSTER_TRANSFORMER_SPEC_H
 #include "Framework/DataProcessorSpec.h"
 
 namespace o2::mch
 {
-o2::framework::DataProcessorSpec getClusterTransformerSpec(const char* specName = "mch-cluster-transformer");
+o2::framework::DataProcessorSpec getClusterTransformerSpec(const char* specName = "mch-cluster-transformer", bool disableCcdb = false);
 };
 
 #endif

--- a/Detectors/MUON/MCH/Geometry/Transformer/src/ClusterTransformerSpec.cxx
+++ b/Detectors/MUON/MCH/Geometry/Transformer/src/ClusterTransformerSpec.cxx
@@ -9,7 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#include "ClusterTransformerSpec.h"
+#include "MCHGeometryTransformer/ClusterTransformerSpec.h"
 
 #include "DetectorsBase/GeometryManager.h"
 #include "CommonUtils/NameConf.h"
@@ -30,6 +30,7 @@
 #include <filesystem>
 #include <fstream>
 #include <vector>
+#include "DetectorsBase/GRPGeomHelper.h"
 
 using namespace std;
 using namespace o2::framework;
@@ -61,9 +62,20 @@ void local2global(geo::TransformationCreator transformation,
 class ClusterTransformerTask
 {
  public:
-  void init(InitContext& ic)
+  ClusterTransformerTask(std::shared_ptr<base::GRPGeomRequest> req) : mCcdbRequest(req)
   {
-    auto geoFile = ic.options().get<std::string>("geometry");
+  }
+
+  void finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
+  {
+    if (mCcdbRequest) {
+      base::GRPGeomHelper::instance().finaliseCCDB(matcher, obj);
+      transformation = o2::mch::geo::transformationFromTGeoManager(*gGeoManager);
+    }
+  }
+
+  void readGeometryFromFile(std::string geoFile)
+  {
     std::string ext = fs::path(geoFile).extension();
     std::transform(ext.begin(), ext.begin(), ext.end(), [](unsigned char c) { return std::tolower(c); });
 
@@ -77,7 +89,17 @@ class ClusterTransformerTask
       o2::base::GeometryManager::loadGeometry(geoFile);
       transformation = o2::mch::geo::transformationFromTGeoManager(*gGeoManager);
     } else {
-      throw std::invalid_argument("Geometry can only be in JSON or Root format");
+      throw std::invalid_argument("Geometry from file can only be in JSON or Root format");
+    }
+  }
+
+  void init(InitContext& ic)
+  {
+    if (mCcdbRequest) {
+      base::GRPGeomHelper::instance().setRequest(mCcdbRequest);
+    } else {
+      auto geoFile = ic.options().get<std::string>("geometry");
+      readGeometryFromFile(geoFile);
     }
   }
 
@@ -85,6 +107,10 @@ class ClusterTransformerTask
   // tranform them into master reference frame.
   void run(ProcessingContext& pc)
   {
+    if (mCcdbRequest) {
+      base::GRPGeomHelper::instance().checkUpdates(pc);
+    }
+
     // get the input clusters
     auto localClusters = pc.inputs().get<gsl::span<Cluster>>("clusters");
 
@@ -96,16 +122,27 @@ class ClusterTransformerTask
 
  public:
   o2::mch::geo::TransformationCreator transformation;
+  std::shared_ptr<base::GRPGeomRequest> mCcdbRequest;
+  bool mDisableCcdb;
 };
 
-DataProcessorSpec getClusterTransformerSpec(const char* specName)
+DataProcessorSpec getClusterTransformerSpec(const char* specName, bool disableCcdb)
 {
   std::string inputConfig = fmt::format("rofs:MCH/CLUSTERROFS;clusters:MCH/CLUSTERS");
+  auto inputs = o2::framework::select(inputConfig.c_str());
+
+  auto ccdbRequest = disableCcdb ? nullptr : std::make_shared<o2::base::GRPGeomRequest>(false,                             // orbitResetTime
+                                                                                        false,                             // GRPECS=true
+                                                                                        false,                             // GRPLHCIF
+                                                                                        false,                             // GRPMagField
+                                                                                        false,                             // askMatLUT
+                                                                                        o2::base::GRPGeomRequest::Aligned, // geometry
+                                                                                        inputs);
   return DataProcessorSpec{
     specName,
-    Inputs{o2::framework::select(inputConfig.c_str())},
+    inputs,
     Outputs{OutputSpec{{"globalclusters"}, "MCH", "GLOBALCLUSTERS", 0, Lifetime::Timeframe}},
-    AlgorithmSpec{adaptFromTask<ClusterTransformerTask>()},
+    AlgorithmSpec{adaptFromTask<ClusterTransformerTask>(ccdbRequest)},
     Options{
       {"geometry", VariantType::String, o2::base::NameConf::getGeomFileName(), {"input geometry file (JSON or Root format)"}}}};
 }

--- a/Detectors/MUON/MCH/Geometry/Transformer/src/ClusterTransformerSpec.cxx
+++ b/Detectors/MUON/MCH/Geometry/Transformer/src/ClusterTransformerSpec.cxx
@@ -123,7 +123,6 @@ class ClusterTransformerTask
  public:
   o2::mch::geo::TransformationCreator transformation;
   std::shared_ptr<base::GRPGeomRequest> mCcdbRequest;
-  bool mDisableCcdb;
 };
 
 DataProcessorSpec getClusterTransformerSpec(const char* specName, bool disableCcdb)

--- a/Detectors/MUON/MCH/Geometry/Transformer/src/clusters-transformer-workflow.cxx
+++ b/Detectors/MUON/MCH/Geometry/Transformer/src/clusters-transformer-workflow.cxx
@@ -25,7 +25,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
                                o2::framework::ConfigParamSpec::HelpString{"Semicolon separated key=value strings"});
   workflowOptions.emplace_back("mch-disable-geometry-from-ccdb",
                                o2::framework::VariantType::Bool, false,
-                               o2::framework::ConfigParamSpec::HelpString{"do not reead geometry from ccdb"});
+                               o2::framework::ConfigParamSpec::HelpString{"do not read geometry from ccdb"});
 }
 
 #include "Framework/runDataProcessing.h"

--- a/Detectors/MUON/MCH/Geometry/Transformer/src/clusters-transformer-workflow.cxx
+++ b/Detectors/MUON/MCH/Geometry/Transformer/src/clusters-transformer-workflow.cxx
@@ -9,7 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#include "ClusterTransformerSpec.h"
+#include "MCHGeometryTransformer/ClusterTransformerSpec.h"
 
 #include "CommonUtils/ConfigurableParam.h"
 #include "Framework/ConfigContext.h"
@@ -23,6 +23,9 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   workflowOptions.emplace_back("configKeyValues",
                                o2::framework::VariantType::String, "",
                                o2::framework::ConfigParamSpec::HelpString{"Semicolon separated key=value strings"});
+  workflowOptions.emplace_back("mch-disable-geometry-from-ccdb",
+                               o2::framework::VariantType::Bool, false,
+                               o2::framework::ConfigParamSpec::HelpString{"do not reead geometry from ccdb"});
 }
 
 #include "Framework/runDataProcessing.h"
@@ -30,5 +33,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 o2::framework::WorkflowSpec defineDataProcessing(const o2::framework::ConfigContext& configContext)
 {
   o2::conf::ConfigurableParam::updateFromString(configContext.options().get<std::string>("configKeyValues"));
-  return o2::framework::WorkflowSpec{o2::mch::getClusterTransformerSpec()};
+  bool disableCcdb = configContext.options().get<bool>("mch-disable-geometry-from-ccdb");
+
+  return o2::framework::WorkflowSpec{o2::mch::getClusterTransformerSpec("mch-cluster-transformer", disableCcdb)};
 }

--- a/Detectors/MUON/MCH/Workflow/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Workflow/CMakeLists.txt
@@ -153,17 +153,6 @@ o2_add_executable(
         PUBLIC_LINK_LIBRARIES O2::DataFormatsParameters O2::Framework O2::DataFormatsMCH O2::MCHTracking O2::DataFormatsParameters)
 
 o2_add_executable(
-        clusters-transformer-workflow
-        SOURCES src/clusters-transformer-workflow.cxx src/ClusterTransformerSpec.cxx
-        COMPONENT_NAME mch
-        PUBLIC_LINK_LIBRARIES
-           O2::DetectorsBase
-           O2::Framework
-           O2::MCHBase
-           O2::MCHGeometryTransformer
-        )
-
-o2_add_executable(
         vertex-sampler-workflow
         SOURCES src/VertexSamplerSpec.cxx src/vertex-sampler-workflow.cxx
         COMPONENT_NAME mch
@@ -214,7 +203,6 @@ o2_add_executable(
 o2_add_executable(
         reco-workflow
         SOURCES
-            src/ClusterTransformerSpec.cxx
             src/DigitReaderSpec.cxx
             src/EventFinderSpec.cxx
             src/TrackFinderSpec.cxx

--- a/Detectors/MUON/MCH/Workflow/README.md
+++ b/Detectors/MUON/MCH/Workflow/README.md
@@ -186,20 +186,7 @@ The decoding is done automatically by the `o2-ctf-reader-workflow`.
 
 ## Local to global cluster transformation
 
-The `o2-mch-clusters-transformer-workflow` takes as input the list of all clusters ([Cluster](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Cluster.h)), in local reference frame, in the current time frame, with the data description "CLUSTERS".
-
-It sends the list of the same clusters, but converted in global reference frame, with the data description "GLOBALCLUSTERS".
-
-To test it one can use e.g. a sampler-transformer-sink pipeline as such :
-
-```
-o2-mch-clusters-sampler-workflow
-    -b --nEventsPerTF 1000 --infile someclusters.data |
-o2-mch-clusters-transformer-workflow
-    -b --geometry Detectors/MUON/MCH/Geometry/Test/ideal-geometry-o2.json |
-o2-mch-clusters-sink-workflow
-    -b --txt --outfile global-clusters.txt --no-digits --global
-```
+Converts the clusters coordinates from local (2D within detection element plane) to global (3D within Alice reference frame) [more...](/Detectors/MUON/MCH/Geometry/Transformer/src/clusters-transformer.cxx)
 
 ## Tracking
 

--- a/Detectors/MUON/MCH/Workflow/README.md
+++ b/Detectors/MUON/MCH/Workflow/README.md
@@ -186,7 +186,7 @@ The decoding is done automatically by the `o2-ctf-reader-workflow`.
 
 ## Local to global cluster transformation
 
-Converts the clusters coordinates from local (2D within detection element plane) to global (3D within Alice reference frame) [more...](/Detectors/MUON/MCH/Geometry/Transformer/src/clusters-transformer.cxx)
+Converts the clusters coordinates from local (2D within detection element plane) to global (3D within Alice reference frame) [more...](/Detectors/MUON/MCH/Geometry/Transformer/README.md)
 
 ## Tracking
 

--- a/Detectors/MUON/MCH/Workflow/src/reco-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/reco-workflow.cxx
@@ -9,7 +9,6 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#include "ClusterTransformerSpec.h"
 #include "CommonUtils/ConfigurableParam.h"
 #include "DetectorsRaw/HBFUtilsInitializer.h"
 #include "DigitReaderSpec.h"
@@ -21,6 +20,7 @@
 #include "Framework/Variant.h"
 #include "Framework/WorkflowSpec.h"
 #include "MCHDigitFiltering/DigitFilteringSpec.h"
+#include "MCHGeometryTransformer/ClusterTransformerSpec.h"
 #include "MCHTimeClustering/TimeClusterFinderSpec.h"
 #include "MCHWorkflow/ClusterFinderOriginalSpec.h"
 #include "MCHWorkflow/PreClusterFinderSpec.h"
@@ -95,7 +95,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
                                                       triggered ? "E-F-DIGITROFS" : (useMC ? "F-DIGITROFS" : "TC-F-DIGITROFS")));
 
   specs.emplace_back(o2::mch::getClusterFinderOriginalSpec("mch-cluster-finder"));
-  specs.emplace_back(o2::mch::getClusterTransformerSpec());
+  specs.emplace_back(o2::mch::getClusterTransformerSpec("mch-cluster-transformer", false));
   specs.emplace_back(o2::mch::getTrackFinderSpec("mch-track-finder", digits));
   if (useMC) {
     specs.emplace_back(o2::mch::getTrackMCLabelFinderSpec("mch-track-mc-label-finder",


### PR DESCRIPTION

The old behavior of reading from file (using the `--geometry` option) is retained
 in the `o2-mch-clusters-transformer-workflow` executable, but must then
 be used together with the `--mch-disable-geometry-from-ccdb` option.

Note this PR also moves the cluster-transformer out of the Workflow directory (one more step into making this directory leaner)

