### PR TITLE
Enable TTree support in CcdbApi and upload tool + fixes

### DIFF
--- a/CCDB/include/CCDB/BasicCCDBManager.h
+++ b/CCDB/include/CCDB/BasicCCDBManager.h
@@ -46,7 +46,6 @@ class CCDBManagerInstance
     std::string uuid;
     long startvalidity = 0;
     long endvalidity = -1;
-    bool isBlob = false; // is this raw blob or parsed object?
     bool isValid(long ts) { return ts < endvalidity && ts > startvalidity; }
     void clear()
     {
@@ -54,12 +53,10 @@ class CCDBManagerInstance
       uuid = "";
       startvalidity = 0;
       endvalidity = -1;
-      isBlob = false;
     }
   };
 
  public:
-  using BLOB = std::vector<char>;
   using MD = std::map<std::string, std::string>;
 
   CCDBManagerInstance(std::string const& path) : mCCDBAccessor{}
@@ -102,11 +99,6 @@ class CCDBManagerInstance
   {
     return getForTimeStamp<T>(path, mTimestamp);
   }
-
-  /// aliases for BLOB retrieval
-  BLOB* getBlobForTimeStamp(std::string const& path, long timestamp) { return getForTimeStamp<BLOB>(path, timestamp); }
-  BLOB* getSpecificBlob(std::string const& path, long timestamp = -1, MD metaData = MD()) { return getSpecific<BLOB>(path, timestamp, metaData); }
-  BLOB* getBlob(std::string const& path) { return get<BLOB>(path); }
 
   bool isHostReachable() const { return mCCDBAccessor.isHostReachable(); }
 
@@ -164,10 +156,6 @@ class CCDBManagerInstance
  private:
   // method to print (fatal) error
   void reportFatal(std::string_view s);
-  BLOB* createBlob(std::string const& path,
-                   MD const& metadata, long timestamp,
-                   MD* headers, std::string const& etag,
-                   const std::string& createdNotAfter, const std::string& createdNotBefore);
   // we access the CCDB via the CURL based C++ API
   o2::ccdb::CcdbApi mCCDBAccessor;
   std::unordered_map<std::string, CachedObject> mCache; //! map for {path, CachedObject} associations
@@ -189,52 +177,26 @@ T* CCDBManagerInstance::getForTimeStamp(std::string const& path, long timestamp)
 {
   T* ptr = nullptr;
   if (!isCachingEnabled()) {
-    if constexpr (std::is_same<T, BLOB>::value) {
-      ptr = createBlob(path, mMetaData, timestamp, nullptr, "",
-                       mCreatedNotAfter ? std::to_string(mCreatedNotAfter) : "",
-                       mCreatedNotBefore ? std::to_string(mCreatedNotBefore) : "");
-    } else {
-      ptr = mCCDBAccessor.retrieveFromTFileAny<T>(path, mMetaData, timestamp, nullptr, "",
-                                                  mCreatedNotAfter ? std::to_string(mCreatedNotAfter) : "",
-                                                  mCreatedNotBefore ? std::to_string(mCreatedNotBefore) : "");
-    }
+    ptr = mCCDBAccessor.retrieveFromTFileAny<T>(path, mMetaData, timestamp, nullptr, "",
+                                                mCreatedNotAfter ? std::to_string(mCreatedNotAfter) : "",
+                                                mCreatedNotBefore ? std::to_string(mCreatedNotBefore) : "");
     if (!ptr && mFatalWhenNull) {
       reportFatal(std::string("Got nullptr from CCDB for path ") + path + std::string(" and timestamp ") + std::to_string(timestamp));
     }
     return ptr;
   }
   auto& cached = mCache[path];
-  if constexpr (std::is_same<T, BLOB>::value) { // check if cached object type is consistent with requested one
-    if (!cached.isBlob) {
-      cached.clear();
-    }
-  } else {
-    if (cached.isBlob) {
-      cached.clear();
-    }
-  }
   if (mCheckObjValidityEnabled && cached.isValid(timestamp)) {
     return reinterpret_cast<T*>(cached.noCleanupPtr ? cached.noCleanupPtr : cached.objPtr.get());
   }
-  if constexpr (std::is_same<T, BLOB>::value) {
-    ptr = createBlob(path, mMetaData, timestamp, &mHeaders, cached.uuid,
-                     mCreatedNotAfter ? std::to_string(mCreatedNotAfter) : "",
-                     mCreatedNotBefore ? std::to_string(mCreatedNotBefore) : "");
-  } else {
-    ptr = mCCDBAccessor.retrieveFromTFileAny<T>(path, mMetaData, timestamp, &mHeaders, cached.uuid,
-                                                mCreatedNotAfter ? std::to_string(mCreatedNotAfter) : "",
-                                                mCreatedNotBefore ? std::to_string(mCreatedNotBefore) : "");
-  }
+  ptr = mCCDBAccessor.retrieveFromTFileAny<T>(path, mMetaData, timestamp, &mHeaders, cached.uuid,
+                                              mCreatedNotAfter ? std::to_string(mCreatedNotAfter) : "",
+                                              mCreatedNotBefore ? std::to_string(mCreatedNotBefore) : "");
   if (ptr) { // new object was shipped, old one (if any) is not valid anymore
     if constexpr (std::is_same<TGeoManager, T>::value) { // some special objects cannot be cached to shared_ptr since root may delete their raw global pointer
       cached.noCleanupPtr = ptr;
     } else {
       cached.objPtr.reset(ptr);
-    }
-    if constexpr (std::is_same<T, BLOB>::value) {
-      cached.isBlob = true;
-    } else {
-      cached.isBlob = false;
     }
     cached.uuid = mHeaders["ETag"];
     cached.startvalidity = std::stol(mHeaders["Valid-From"]);

--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -342,7 +342,7 @@ class CcdbApi //: public DatabaseInterface
   void loadFileToMemory(o2::pmr::vector<char>& dest, std::string const& path,
                         std::map<std::string, std::string> const& metadata, long timestamp,
                         std::map<std::string, std::string>* headers, std::string const& etag,
-                        const std::string& createdNotAfter, const std::string& createdNotBefore) const;
+                        const std::string& createdNotAfter, const std::string& createdNotBefore, bool considerSnapshot = true) const;
   void navigateURLsAndLoadFileToMemory(o2::pmr::vector<char>& dest, CURL* curl_handle, std::string const& url, std::map<string, string>* headers) const;
 
   // the failure to load the file to memory is signaled by 0 size and non-0 capacity

--- a/CCDB/src/BasicCCDBManager.cxx
+++ b/CCDB/src/BasicCCDBManager.cxx
@@ -22,22 +22,6 @@ namespace o2
 namespace ccdb
 {
 
-// Create blob pointer from the vector<char> containing the CCDB file
-CCDBManagerInstance::BLOB* CCDBManagerInstance::createBlob(std::string const& path, MD const& metadata, long timestamp, MD* headers, std::string const& etag,
-                                                           const std::string& createdNotAfter, const std::string& createdNotBefore)
-{
-  o2::pmr::vector<char> v;
-  mCCDBAccessor.loadFileToMemory(v, path, metadata, timestamp, headers, etag, createdNotAfter, createdNotBefore);
-  if ((headers && headers->count("Error")) || !v.size()) {
-    return nullptr;
-  }
-  // Do a copy to avoid changing the API of createBlob, at least for now.
-  BLOB* b = new BLOB();
-  b->reserve(v.size());
-  std::copy(v.begin(), v.end(), b->end());
-  return b;
-}
-
 void CCDBManagerInstance::setURL(std::string const& url)
 {
   mCCDBAccessor.init(url);

--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -681,12 +681,12 @@ void* CcdbApi::extractFromTFile(TFile& file, TClass const* cl)
   auto result = object;
   // We need to handle some specific cases as ROOT ties them deeply
   // to the file they are contained in
-  if (cl->InheritsFrom("TObject")) { // RS not sure why cloning is needed, certainly for the histos it it enough to SetDirectory(nullptr)
+  if (cl->InheritsFrom("TObject")) {
     // make a clone
     // detach from the file
     auto tree = dynamic_cast<TTree*>((TObject*)object);
-    if (tree) { // RS At the moment leaving the cloning for TTree
-      tree = (TTree*)tree->Clone();
+    if (tree) {
+      tree->LoadBaskets(0x1L << 32); // make tree memory based
       tree->SetDirectory(nullptr);
       result = tree;
     } else {

--- a/CCDB/src/UploadTool.cxx
+++ b/CCDB/src/UploadTool.cxx
@@ -14,6 +14,7 @@
 #include "CCDB/CCDBTimeStampUtils.h"
 #include <map>
 #include "TFile.h"
+#include "TTree.h"
 #include "TClass.h"
 #include "TKey.h"
 #include <iostream>
@@ -150,9 +151,14 @@ int main(int argc, char* argv[])
   if (key) {
     // get type of key
     auto classname = key->GetClassName();
-    auto object = f.Get<void>(keyname.c_str());
-    // convert classname to typeinfo
     auto tcl = TClass::GetClass(classname);
+    auto object = f.Get<void>(keyname.c_str());
+    if (tcl->InheritsFrom("TTree")) {
+      auto tree = static_cast<TTree*>(object);
+      tree->LoadBaskets(0x1L << 32); // make tree memory based
+      tree->SetDirectory(nullptr);
+    }
+    // convert classname to typeinfo
     // typeinfo
     auto ti = tcl->GetTypeInfo();
 


### PR DESCRIPTION
@Barthelemy : I've kept your compression settings but override them in case of uploading a TTree to avoid too large files.

@sawenzel I had to modify the retrieveBlob since the previous version with `string fullUrl = getHostUrl(i) + "/download/" + ETag;` was failing on local CCDB server (with localhost:8080)