### PR TITLE
[EMCAL-534] Skip pages which throw exceptions in page decoding

### DIFF
--- a/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
@@ -155,6 +155,10 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
         } else {
           mErrorMessagesSuppressed++;
         }
+        // We must skip the page as payload is not consistent
+        // otherwise the next functions will rethrow the exceptions as
+        // the page format does not follow the expected format
+        continue;
       }
 
       auto& header = rawreader.getRawHeader();


### PR DESCRIPTION
In case the next function throws an exception the
payload must be skipped for the link, as the payload
extraction and separation failed. The relevant continue statement was missing and is added in this commit.
The consequence is that subsequent functions will
rethrow the error, as they depend on uninitialized data,
which are unprotected.