### PR TITLE
DPL: make sure we send the oldest possible timeframe only after forwarding everything

### DIFF
--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -1678,7 +1678,9 @@ bool DataProcessingDevice::tryDispatchComputation(DataProcessorContext& context,
         // in DPL we are using subchannel 0 only
         channel.Send(forwardedParts[fi]);
       }
-
+    }
+    for (size_t fi = 0; fi < spec->forwards.size(); fi++) {
+      auto& channel = device->GetChannel(spec->forwards[fi].channel, 0);
       // The oldest possible timeslice for a forwarded message
       // is conservatively the one of the device doing the forwarding.
       if (spec->forwards[fi].channel.rfind("from_", 0) == 0) {


### PR DESCRIPTION
This is similar to the issue spotted in analysis the other day. If
for some reason the channels for the forwarding are interleaved, it
might not actually work because the oldest possible timeframe arrives
too early.