### PR TITLE
[EMCAL-534] Skip pages with inconsistent trailers

### DIFF
--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RawDecodingError.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RawDecodingError.h
@@ -41,7 +41,8 @@ class RawDecodingError : public std::exception
     PAYLOAD_DECODING,   ///< Payload cannot be decoded (format incorrect)
     HEADER_INVALID,     ///< Header in memory not belonging to requested superpage
     PAGE_START_INVALID, ///< Page position starting outside payload size
-    PAYLOAD_INVALID     ///< Payload in memory not belonging to requested superpage
+    PAYLOAD_INVALID,    ///< Payload in memory not belonging to requested superpage
+    TRAILER_DECODING    ///< Inconsistent trailer in memory (several trailer words missing the trailer marker)
   };
 
   /// \brief Constructor
@@ -73,6 +74,8 @@ class RawDecodingError : public std::exception
         return "Page decoding starting outside payload size";
       case ErrorType_t::PAYLOAD_INVALID:
         return "Access to payload not belonging to requested superpage";
+      case ErrorType_t::TRAILER_DECODING:
+        return "Inconsistent trailer in memory";
     };
     return "Undefined error";
   }
@@ -102,6 +105,8 @@ class RawDecodingError : public std::exception
         return 4;
       case ErrorType_t::PAYLOAD_INVALID:
         return 5;
+      case ErrorType_t::TRAILER_DECODING:
+        return 6;
     };
     // can never reach this, due to enum class
     // just to make Werror happy

--- a/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
@@ -147,7 +147,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
           mOutputDecoderErrors.emplace_back(e.getFECID(), ErrorTypeFEE::ErrorSource_t::PAGE_ERROR, RawDecodingError::ErrorTypeToInt(e.getErrorType()));
         }
         if (mNumErrorMessages < mMaxErrorMessages) {
-          LOG(alarm) << " EMCAL raw task: " << e.what() << " in FEC " << e.getFECID() << std::endl;
+          LOG(alarm) << " Page decoding: " << e.what() << " in FEE ID " << e.getFECID() << std::endl;
           mNumErrorMessages++;
           if (mNumErrorMessages == mMaxErrorMessages) {
             LOG(alarm) << "Max. amount of error messages (" << mMaxErrorMessages << " reached, further messages will be suppressed";


### PR DESCRIPTION
Pages must be skipped if the number of found trailer
words identified by the trailer marker is smaller than
the trailersize reported by the trailer itself encoded
in the last trailer word. In such cases the consistency
of the payload is also questionable.