### PR TITLE
[rANS] Fix Frequency Table Overflow

### DIFF
--- a/Detectors/CTF/workflow/src/CTFWriterSpec.cxx
+++ b/Detectors/CTF/workflow/src/CTFWriterSpec.cxx
@@ -43,6 +43,7 @@
 #include "DataFormatsCTP/CTF.h"
 #include "rANS/rans.h"
 #include <vector>
+#include <stdexcept>
 #include <array>
 #include <TStopwatch.h>
 #include <vector>
@@ -118,8 +119,8 @@ class CTFWriterSpec : public o2::framework::Task
   bool mCreateRunEnvDir = true;
   bool mStoreMetaFile = false;
   int mVerbosity = 0;
-  int mSaveDictAfter = 0; // if positive and mWriteCTF==true, save dictionary after each mSaveDictAfter TFs processed
-  int mFlagMinDet = 1;    // append list of detectors to LHC period if their number is <= mFlagMinDet
+  int mSaveDictAfter = 0;          // if positive and mWriteCTF==true, save dictionary after each mSaveDictAfter TFs processed
+  int mFlagMinDet = 1;             // append list of detectors to LHC period if their number is <= mFlagMinDet
   uint32_t mPrevDictTimeStamp = 0; // timestamp of the previously stored dictionary
   uint32_t mDictTimeStamp = 0;     // timestamp of the currently stored dictionary
   uint64_t mRun = 0;
@@ -160,6 +161,7 @@ class CTFWriterSpec : public o2::framework::Task
   // The metadata of the block (min,max) will be used for the consistency check at the decoding
   std::array<std::vector<FTrans>, DetID::nDetectors> mFreqsAccumulation;
   std::array<std::vector<o2::ctf::Metadata>, DetID::nDetectors> mFreqsMetaData;
+  std::array<std::bitset<64>, DetID::nDetectors> mIsSaturatedFrequencyTable;
   std::array<std::shared_ptr<void>, DetID::nDetectors> mHeaders;
   TStopwatch mTimer;
 
@@ -172,6 +174,7 @@ const std::string CTFWriterSpec::TMPFileEnding{".part"};
 CTFWriterSpec::CTFWriterSpec(DetID::mask_t dm, uint64_t r, const std::string& outType, int verbosity)
   : mDets(dm), mRun(r), mOutputType(outType), mVerbosity(verbosity)
 {
+  std::for_each(mIsSaturatedFrequencyTable.begin(), mIsSaturatedFrequencyTable.end(), [](auto& bitset) { bitset.reset(); });
   mTimer.Stop();
   mTimer.Reset();
 }
@@ -262,14 +265,27 @@ size_t CTFWriterSpec::processDet(o2::framework::ProcessingContext& pc, DetID det
       hb.det = det;
     }
     for (int ib = 0; ib < C::getNBlocks(); ib++) {
-      const auto& bl = ctfImage.getBlock(ib);
-      if (bl.getNDict()) {
-        auto& freq = mFreqsAccumulation[det][ib];
-        auto& mdSave = mFreqsMetaData[det][ib];
-        const auto& md = ctfImage.getMetadata(ib);
-        freq.addFrequencies(bl.getDict(), bl.getDict() + bl.getNDict(), md.min);
-        auto newProbBits = uint8_t(o2::rans::computeRenormingPrecision(freq));
-        mdSave = o2::ctf::Metadata{0, 0, md.messageWordSize, md.coderType, md.streamSize, newProbBits, md.opt, freq.getMinSymbol(), freq.getMaxSymbol(), (int)freq.size(), 0, 0};
+      if (!mIsSaturatedFrequencyTable[det][ib]) {
+        const auto& bl = ctfImage.getBlock(ib);
+        if (bl.getNDict()) {
+          auto freq = mFreqsAccumulation[det][ib];
+          auto& mdSave = mFreqsMetaData[det][ib];
+          const auto& md = ctfImage.getMetadata(ib);
+          if ([&, this]() {
+                try {
+                  freq.addFrequencies(bl.getDict(), bl.getDict() + bl.getNDict(), md.min);
+                } catch (const std::overflow_error& e) {
+                  LOGP(warning, "unable to frequency table for {}, block {} due to overflow", det.getName(), ib);
+                  mIsSaturatedFrequencyTable[det][ib] = true;
+                  return false;
+                }
+                return true;
+              }()) {
+            auto newProbBits = static_cast<uint8_t>(o2::rans::computeRenormingPrecision(freq));
+            mdSave = o2::ctf::Metadata{0, 0, md.messageWordSize, md.coderType, md.streamSize, newProbBits, md.opt, freq.getMinSymbol(), freq.getMaxSymbol(), static_cast<int32_t>(freq.size()), 0, 0};
+            mFreqsAccumulation[det][ib] = std::move(freq);
+          }
+        }
       }
     }
   }

--- a/Utilities/rANS/include/rANS/FrequencyTable.h
+++ b/Utilities/rANS/include/rANS/FrequencyTable.h
@@ -239,7 +239,7 @@ FrequencyTable& FrequencyTable::addFrequencies(Freq_IT begin, Freq_IT end, symbo
         histogramOverlap = utils::intersection(newHistogram, addedHistogram);
         assert(!histogramOverlap.empty());
         assert(histogramOverlap.size() == addedHistogram.size());
-        std::transform(addedHistogram.begin(), addedHistogram.end(), histogramOverlap.begin(), histogramOverlap.begin(), [this](const count_t& a, const count_t& b) { return this->frequencyCountingDecorator(a) + b; });
+        std::transform(addedHistogram.begin(), addedHistogram.end(), histogramOverlap.begin(), histogramOverlap.begin(), [this](const count_t& a, const count_t& b) { return internal::safeadd(this->frequencyCountingDecorator(a), b); });
 
         this->mFrequencyTable = std::move(newFreequencyTable);
         this->mOffset = newHistogram.getOffset();
@@ -259,7 +259,7 @@ FrequencyTable& FrequencyTable::addFrequencies(Freq_IT begin, Freq_IT end, symbo
       if (!overlapAdded.empty()) {
         assert(overlapAdded.getMin() == overlapThis.getMin());
         assert(overlapAdded.size() == overlapThis.size());
-        std::transform(overlapAdded.begin(), overlapAdded.end(), overlapThis.begin(), overlapThis.begin(), [this](const count_t& a, const count_t& b) { return this->frequencyCountingDecorator(a) + b; });
+        std::transform(overlapAdded.begin(), overlapAdded.end(), overlapThis.begin(), overlapThis.begin(), [this](const count_t& a, const count_t& b) { return internal::safeadd(this->frequencyCountingDecorator(a), b); });
       }
 
       // right incompressible tail

--- a/Utilities/rANS/include/rANS/internal/helper.h
+++ b/Utilities/rANS/include/rANS/internal/helper.h
@@ -25,6 +25,9 @@
 #include <sstream>
 #include <vector>
 
+#define rans_likely(x) __builtin_expect((x), 1)
+#define rans_unlikely(x) __builtin_expect((x), 0)
+
 namespace o2
 {
 namespace rans
@@ -141,6 +144,15 @@ class JSONArrayLogger
   std::vector<T> mElems{};
   bool mReverse{false};
 };
+
+inline uint32_t safeadd(uint32_t a, uint32_t b)
+{
+  uint32_t result;
+  if (rans_unlikely(__builtin_uadd_overflow(a, b, &result))) {
+    throw std::overflow_error("arithmetic overflow during addition");
+  }
+  return result;
+}
 
 template <typename T, typename IT>
 inline constexpr bool isCompatibleIter_v = std::is_convertible_v<typename std::iterator_traits<IT>::value_type, T>;


### PR DESCRIPTION
Solves an overflow issue  that is encountered when building a dictionary from many timeframes. In certain cases the `uint32_t` data type used to count the frequencies of symbols can overflow. The result is skewed distributions resulting in bad compression (usual case) or unrecoverable data loss due to wrong encoding (unlikely but possible).

Changes:
* Use `uint64_t` when building cumulative frequencies during renorming process.
* Introduce overflow checks when adding two frequency tables.
* Fault tolerance in `CTFWriterSpec`, in case addition of frequency tables fails.