### PR TITLE
TRD TRAP sim respects simulation time stamp

### DIFF
--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
@@ -46,12 +46,13 @@ class TRDDPLTrapSimulatorTask : public o2::framework::Task
   bool mEnableOnlineGainCorrection{false};
   bool mUseMC{false}; // whether or not to use MC labels
   bool mEnableTrapConfigDump{false};
+  bool mInitCcdbObjectsDone{false}; // flag whether one time download of CCDB objects has been done
   int mNumThreads{-1};              // number of threads used for parallel processing
   std::string mTrapConfigName;      // the name of the config to be used.
   std::string mOnlineGainTableName;
   std::unique_ptr<Calibrations> mCalib; // store the calibrations connection to CCDB. Used primarily for the gaintables in line above.
 
-  void initTrapConfig();
+  void initTrapConfig(long timeStamp);
   void setOnlineGainTables();
   void processTRAPchips(int& nTracklets, std::vector<Tracklet64>& trackletsAccum, std::array<TrapSimulator, constants::NMCMHCMAX>& trapSimulators, std::vector<short>& digitCounts, std::vector<int>& digitIndices);
 };

--- a/Detectors/TRD/workflow/src/TRDTrapSimulatorSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrapSimulatorSpec.cxx
@@ -24,6 +24,7 @@
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/ControlService.h"
 #include "Framework/DataProcessorSpec.h"
+#include "Framework/DataRefUtils.h"
 #include "Framework/Lifetime.h"
 #include "fairlogger/Logger.h"
 #include "CCDB/BasicCCDBManager.h"
@@ -44,13 +45,10 @@ namespace trd
 
 using namespace constants;
 
-void TRDDPLTrapSimulatorTask::initTrapConfig()
+void TRDDPLTrapSimulatorTask::initTrapConfig(long timeStamp)
 {
   auto& ccdbmgr = o2::ccdb::BasicCCDBManager::instance();
-  auto timeStamp = (mRunNumber < 0) ? std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count() : mRunNumber;
-  //ccdbmgr.setURL("http://localhost:8080");
-  ccdbmgr.setTimestamp(timeStamp);
-  mTrapConfig = ccdbmgr.get<o2::trd::TrapConfig>("TRD/TrapConfig/" + mTrapConfigName);
+  mTrapConfig = ccdbmgr.getForTimeStamp<o2::trd::TrapConfig>("TRD/TrapConfig/" + mTrapConfigName, timeStamp);
 
   if (mEnableTrapConfigDump) {
     mTrapConfig->DumpTrapConfig2File("run3trapconfig_dump");
@@ -138,12 +136,7 @@ void TRDDPLTrapSimulatorTask::init(o2::framework::InitContext& ic)
   mOnlineGainTableName = ic.options().get<std::string>("trd-onlinegaintable");
   mRunNumber = ic.options().get<int>("trd-runnum");
   mEnableTrapConfigDump = ic.options().get<bool>("trd-dumptrapconfig");
-  //Connect to CCDB for all things needing access to ccdb, trapconfig and online gains
-  auto& ccdbmgr = o2::ccdb::BasicCCDBManager::instance();
-  mCalib = std::make_unique<Calibrations>();
-  mCalib->getCCDBObjects(mRunNumber);
-  initTrapConfig();
-  setOnlineGainTables();
+
 #ifdef WITH_OPENMP
   int askedThreads = TRDSimParams::Instance().digithreads;
   int maxThreads = omp_get_max_threads();
@@ -160,6 +153,17 @@ void TRDDPLTrapSimulatorTask::run(o2::framework::ProcessingContext& pc)
 {
   // this method steeres the processing of the TRAP simulation
   LOG(info) << "TRD Trap Simulator Device running over incoming message";
+
+  if (!mInitCcdbObjectsDone) {
+    const auto ref = pc.inputs().getFirstValid(true);
+    auto creationTime = DataRefUtils::getHeader<DataProcessingHeader*>(ref)->creation;
+    auto timeStamp = (mRunNumber < 0) ? creationTime : mRunNumber;
+    mCalib = std::make_unique<Calibrations>();
+    mCalib->getCCDBObjects(timeStamp);
+    initTrapConfig(timeStamp);
+    setOnlineGainTables();
+    mInitCcdbObjectsDone = true;
+  }
 
   // input
   auto digits = pc.inputs().get<gsl::span<o2::trd::Digit>>("digitinput");                       // block of TRD digits


### PR DESCRIPTION
Moving the fetching of CCDB objects into the `run()` method to be able to retrieve the time stamp from the data header.

This fixes https://alice.its.cern.ch/jira/browse/O2-2969