### PR TITLE
DPL: Reduce DPL_MAX_CHANNEL_AHEAD default to 8

### DIFF
--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -966,7 +966,7 @@ void DataProcessingDevice::doPrepare(DataProcessorContext& context)
   auto& infos = context.deviceContext->state->inputChannelInfos;
 
   if (context.balancingInputs) {
-    static uint64_t ahead = getenv("DPL_MAX_CHANNEL_AHEAD") ? std::atoll(getenv("DPL_MAX_CHANNEL_AHEAD")) : 16;
+    static uint64_t ahead = getenv("DPL_MAX_CHANNEL_AHEAD") ? std::atoll(getenv("DPL_MAX_CHANNEL_AHEAD")) : 8;
     auto newEnd = std::remove_if(pollOrder.begin(), pollOrder.end(), [&infos, limitNew = currentOldest.value + ahead](int a) -> bool {
       return infos[a].oldestForChannel.value > limitNew;
     });


### PR DESCRIPTION
@ktf : Are you fine with this for now? This is how we run on the EPN. On the EPN we have several places where we have more than 16 input channels.
I think in principle, we should increase the default DPL PIPELINE LENGTH from 32 to 128 to have more margin, and then the MAX_CHANNEL_AHEAD default should be computed from the number of input channels.