### PR TITLE
DPL Analysis: add int8 and int16 to Variant/Configurable

### DIFF
--- a/Framework/Core/include/Framework/ConfigParamRegistry.h
+++ b/Framework/Core/include/Framework/ConfigParamRegistry.h
@@ -27,6 +27,8 @@ template <typename T>
 constexpr auto isSimpleType()
 {
   return std::is_same_v<T, int> ||
+         std::is_same_v<T, int8_t> ||
+         std::is_same_v<T, int16_t> ||
          std::is_same_v<T, uint8_t> ||
          std::is_same_v<T, uint16_t> ||
          std::is_same_v<T, uint32_t> ||

--- a/Framework/Core/include/Framework/Variant.h
+++ b/Framework/Core/include/Framework/Variant.h
@@ -28,8 +28,6 @@ namespace o2::framework
 
 // Do NOT insert entries in this enum, only append at the end (before "Empty"). Hyperloop depends on the order.
 enum class VariantType : int { Int = 0,
-                               Int8,
-                               Int16,
                                Int64,
                                Float,
                                Double,
@@ -52,6 +50,8 @@ enum class VariantType : int { Int = 0,
                                UInt64,
                                Empty,
                                Dict,
+                               Int8,
+                               Int16,
                                Unknown };
 
 template <VariantType V>

--- a/Framework/Core/include/Framework/Variant.h
+++ b/Framework/Core/include/Framework/Variant.h
@@ -48,10 +48,10 @@ enum class VariantType : int { Int = 0,
                                UInt16,
                                UInt32,
                                UInt64,
-                               Empty,
-                               Dict,
                                Int8,
                                Int16,
+                               Empty,
+                               Dict,
                                Unknown };
 
 template <VariantType V>

--- a/Framework/Core/include/Framework/Variant.h
+++ b/Framework/Core/include/Framework/Variant.h
@@ -28,6 +28,8 @@ namespace o2::framework
 
 // Do NOT insert entries in this enum, only append at the end (before "Empty"). Hyperloop depends on the order.
 enum class VariantType : int { Int = 0,
+                               Int8,
+                               Int16,
                                Int64,
                                Float,
                                Double,
@@ -82,6 +84,8 @@ template <VariantType V>
 constexpr auto isSimpleVariant()
 {
   return (V == VariantType::Int) ||
+         (V == VariantType::Int8) ||
+         (V == VariantType::Int16) ||
          (V == VariantType::Int64) ||
          (V == VariantType::UInt8) ||
          (V == VariantType::UInt16) ||
@@ -102,6 +106,8 @@ struct variant_trait : std::integral_constant<VariantType, VariantType::Unknown>
   };
 
 DECLARE_VARIANT_TRAIT(int, Int);
+DECLARE_VARIANT_TRAIT(int8_t, Int8);
+DECLARE_VARIANT_TRAIT(int16_t, Int16);
 DECLARE_VARIANT_TRAIT(long int, Int64);
 DECLARE_VARIANT_TRAIT(long long int, Int64);
 DECLARE_VARIANT_TRAIT(uint8_t, UInt8);
@@ -184,6 +190,8 @@ struct variant_type {
   };
 
 DECLARE_VARIANT_TYPE(int, Int);
+DECLARE_VARIANT_TYPE(int8_t, Int8);
+DECLARE_VARIANT_TYPE(int16_t, Int16);
 DECLARE_VARIANT_TYPE(int64_t, Int64);
 DECLARE_VARIANT_TYPE(uint8_t, UInt8);
 DECLARE_VARIANT_TYPE(uint16_t, UInt16);
@@ -273,7 +281,8 @@ struct variant_helper<S, std::string> {
 /// Variant for configuration parameter storage. Owns stored data.
 class Variant
 {
-  using storage_t = std::aligned_union<8, int, int64_t, uint8_t, uint16_t, uint32_t, uint64_t,
+  using storage_t = std::aligned_union<8, int, int8_t, int16_t, int64_t,
+                                       uint8_t, uint16_t, uint32_t, uint64_t,
                                        const char*, float, double, bool,
                                        int*, float*, double*, bool*,
                                        Array2D<int>, Array2D<float>, Array2D<double>,

--- a/Framework/Core/src/BoostOptionsRetriever.cxx
+++ b/Framework/Core/src/BoostOptionsRetriever.cxx
@@ -50,17 +50,23 @@ void BoostOptionsRetriever::update(std::vector<ConfigParamSpec> const& specs,
       case VariantType::Int:
         options = options(name, bpo::value<int>()->default_value(spec.defaultValue.get<int>()), help);
         break;
+      case VariantType::Int8:
+        options = options(name, bpo::value<int8_t>()->default_value(spec.defaultValue.get<int8_t>()), help);
+        break;
+      case VariantType::Int16:
+        options = options(name, bpo::value<int16_t>()->default_value(spec.defaultValue.get<int16_t>()), help);
+        break;
       case VariantType::UInt8:
-        options = options(name, bpo::value<int>()->default_value(spec.defaultValue.get<uint8_t>()), help);
+        options = options(name, bpo::value<uint8_t>()->default_value(spec.defaultValue.get<uint8_t>()), help);
         break;
       case VariantType::UInt16:
-        options = options(name, bpo::value<int>()->default_value(spec.defaultValue.get<uint16_t>()), help);
+        options = options(name, bpo::value<uint16_t>()->default_value(spec.defaultValue.get<uint16_t>()), help);
         break;
       case VariantType::UInt32:
-        options = options(name, bpo::value<int>()->default_value(spec.defaultValue.get<uint32_t>()), help);
+        options = options(name, bpo::value<uint32_t>()->default_value(spec.defaultValue.get<uint32_t>()), help);
         break;
       case VariantType::UInt64:
-        options = options(name, bpo::value<int>()->default_value(spec.defaultValue.get<uint64_t>()), help);
+        options = options(name, bpo::value<uint64_t>()->default_value(spec.defaultValue.get<uint64_t>()), help);
         break;
       case VariantType::Int64:
         options = options(name, bpo::value<int64_t>()->default_value(spec.defaultValue.get<int64_t>()), help);

--- a/Framework/Core/src/ConfigParamsHelper.cxx
+++ b/Framework/Core/src/ConfigParamsHelper.cxx
@@ -41,6 +41,12 @@ void ConfigParamsHelper::populateBoostProgramOptions(
       case VariantType::Int:
         addConfigSpecOption<VariantType::Int>(spec, options);
         break;
+      case VariantType::Int8:
+        addConfigSpecOption<VariantType::Int8>(spec, options);
+        break;
+      case VariantType::Int16:
+        addConfigSpecOption<VariantType::Int16>(spec, options);
+        break;
       case VariantType::Int64:
         addConfigSpecOption<VariantType::Int64>(spec, options);
         break;

--- a/Framework/Core/src/PropertyTreeHelpers.cxx
+++ b/Framework/Core/src/PropertyTreeHelpers.cxx
@@ -37,6 +37,12 @@ void PropertyTreeHelpers::populateDefaults(std::vector<ConfigParamSpec> const& s
         case VariantType::Int:
           pt.put(key, spec.defaultValue.get<int>());
           break;
+        case VariantType::Int8:
+          pt.put(key, spec.defaultValue.get<int8_t>());
+          break;
+        case VariantType::Int16:
+          pt.put(key, spec.defaultValue.get<int16_t>());
+          break;
         case VariantType::UInt8:
           pt.put(key, spec.defaultValue.get<uint8_t>());
           break;
@@ -131,6 +137,12 @@ void PropertyTreeHelpers::populate(std::vector<ConfigParamSpec> const& schema,
       switch (spec.type) {
         case VariantType::Int:
           pt.put(key, vmap[key].as<int>());
+          break;
+        case VariantType::Int8:
+          pt.put(key, vmap[key].as<int8_t>());
+          break;
+        case VariantType::Int16:
+          pt.put(key, vmap[key].as<int16_t>());
           break;
         case VariantType::UInt8:
           pt.put(key, vmap[key].as<uint8_t>());
@@ -239,6 +251,12 @@ void PropertyTreeHelpers::populate(std::vector<ConfigParamSpec> const& schema,
       switch (spec.type) {
         case VariantType::Int:
           pt.put(key, (*it).get_value<int>());
+          break;
+        case VariantType::Int8:
+          pt.put(key, (*it).get_value<int8_t>());
+          break;
+        case VariantType::Int16:
+          pt.put(key, (*it).get_value<int16_t>());
           break;
         case VariantType::UInt8:
           pt.put(key, (*it).get_value<uint8_t>());

--- a/Framework/Core/src/RootConfigParamHelpers.cxx
+++ b/Framework/Core/src/RootConfigParamHelpers.cxx
@@ -230,28 +230,28 @@ ConfigParamSpec memberToConfigParamSpec(const char* tname, TDataMember* dm, void
   if (dt != nullptr) {
     switch (dt->GetType()) {
       case kChar_t: {
-        return ConfigParamSpec{tname, VariantType::Int, *(char*)ptr, {"No help"}};
+        return ConfigParamSpec{tname, VariantType::Int8, *(char*)ptr, {"No help"}};
       }
       case kUChar_t: {
-        return ConfigParamSpec{tname, VariantType::Int, *(unsigned char*)ptr, {"No help"}};
+        return ConfigParamSpec{tname, VariantType::UInt8, *(unsigned char*)ptr, {"No help"}};
       }
       case kShort_t: {
-        return ConfigParamSpec{tname, VariantType::Int, *(short*)ptr, {"No help"}};
+        return ConfigParamSpec{tname, VariantType::Int16, *(short*)ptr, {"No help"}};
       }
       case kUShort_t: {
-        return ConfigParamSpec{tname, VariantType::Int, *(unsigned short*)ptr, {"No help"}};
+        return ConfigParamSpec{tname, VariantType::UInt16, *(unsigned short*)ptr, {"No help"}};
       }
       case kInt_t: {
         return ConfigParamSpec{tname, VariantType::Int, *(int*)ptr, {"No help"}};
       }
       case kUInt_t: {
-        return ConfigParamSpec{tname, VariantType::Int, *(unsigned int*)ptr, {"No help"}};
+        return ConfigParamSpec{tname, VariantType::UInt32, *(unsigned int*)ptr, {"No help"}};
       }
       case kLong_t: {
-        return ConfigParamSpec{tname, VariantType::Int, *(long*)ptr, {"No help"}};
+        return ConfigParamSpec{tname, VariantType::Int64, *(long*)ptr, {"No help"}};
       }
       case kULong_t: {
-        return ConfigParamSpec{tname, VariantType::Int, *(unsigned long*)ptr, {"No help"}};
+        return ConfigParamSpec{tname, VariantType::UInt64, *(unsigned long*)ptr, {"No help"}};
       }
       case kFloat_t: {
         return ConfigParamSpec{tname, VariantType::Float, *(float*)ptr, {"No help"}};
@@ -267,7 +267,7 @@ ConfigParamSpec memberToConfigParamSpec(const char* tname, TDataMember* dm, void
         return ConfigParamSpec{tname, VariantType::Int64, *(int64_t*)ptr, {"No help"}};
       }
       case kULong64_t: {
-        return ConfigParamSpec{tname, VariantType::Int64, *(uint64_t*)ptr, {"No help"}};
+        return ConfigParamSpec{tname, VariantType::UInt64, *(uint64_t*)ptr, {"No help"}};
       }
       default: {
         break;

--- a/Framework/Core/src/Variant.cxx
+++ b/Framework/Core/src/Variant.cxx
@@ -56,11 +56,17 @@ std::ostream& operator<<(std::ostream& oss, Variant const& val)
     case VariantType::Int:
       oss << val.get<int>();
       break;
+    case VariantType::Int8:
+      oss << (int)val.get<int8_t>();
+      break;
+    case VariantType::Int16:
+      oss << (int)val.get<int16_t>();
+      break;
     case VariantType::UInt8:
-      oss << val.get<uint8_t>();
+      oss << (int)val.get<uint8_t>();
       break;
     case VariantType::UInt16:
-      oss << val.get<uint16_t>();
+      oss << (int)val.get<uint16_t>();
       break;
     case VariantType::UInt32:
       oss << val.get<uint32_t>();

--- a/Framework/Core/src/WorkflowSerializationHelpers.cxx
+++ b/Framework/Core/src/WorkflowSerializationHelpers.cxx
@@ -424,11 +424,17 @@ struct WorkflowImporter : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
         case VariantType::Int:
           opt = std::make_unique<ConfigParamSpec>(optionName, optionType, std::stoi(optionDefault, nullptr), HelpString{optionHelp}, optionKind);
           break;
+        case VariantType::Int8:
+          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, static_cast<int8_t>(std::stoi(optionDefault, nullptr)), HelpString{optionHelp}, optionKind);
+          break;
+        case VariantType::Int16:
+          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, static_cast<int16_t>(std::stoi(optionDefault, nullptr)), HelpString{optionHelp}, optionKind);
+          break;
         case VariantType::UInt8:
-          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, static_cast<uint8_t>(std::stoul(optionDefault, nullptr)), HelpString{optionHelp}, optionKind);
+          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, static_cast<uint8_t>(std::stoi(optionDefault, nullptr)), HelpString{optionHelp}, optionKind);
           break;
         case VariantType::UInt16:
-          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, static_cast<uint16_t>(std::stoul(optionDefault, nullptr)), HelpString{optionHelp}, optionKind);
+          opt = std::make_unique<ConfigParamSpec>(optionName, optionType, static_cast<uint16_t>(std::stoi(optionDefault, nullptr)), HelpString{optionHelp}, optionKind);
           break;
         case VariantType::UInt32:
           opt = std::make_unique<ConfigParamSpec>(optionName, optionType, static_cast<uint32_t>(std::stoul(optionDefault, nullptr)), HelpString{optionHelp}, optionKind);

--- a/Framework/Core/test/test_BoostOptionsRetriever.cxx
+++ b/Framework/Core/test/test_BoostOptionsRetriever.cxx
@@ -29,6 +29,8 @@ BOOST_AUTO_TEST_CASE(TrivialBoostOptionsRetrieverTest)
 
   auto specs = std::vector<ConfigParamSpec>{
     {"someInt", VariantType::Int, 2, {"some int option"}},
+    {"someInt8", VariantType::Int8, static_cast<int8_t>(2), {"some int8 option"}},
+    {"someInt16", VariantType::Int16, static_cast<int16_t>(2), {"some int16 option"}},
     {"someUInt8", VariantType::UInt8, static_cast<uint8_t>(2u), {"some uint8 option"}},
     {"someUInt16", VariantType::UInt16, static_cast<uint16_t>(2u), {"some uint16 option"}},
     {"someUInt32", VariantType::UInt32, 2u, {"some uint32 option"}},
@@ -42,6 +44,8 @@ BOOST_AUTO_TEST_CASE(TrivialBoostOptionsRetrieverTest)
     "test",
     "--someBool",
     "--someInt", "1",
+    "--someInt8", "1",
+    "--someInt16", "1",
     "--someUInt8", "1",
     "--someUInt16", "1",
     "--someUInt32", "1",
@@ -58,6 +62,8 @@ BOOST_AUTO_TEST_CASE(TrivialBoostOptionsRetrieverTest)
   bpo::store(parse_command_line(sizeof(args) / sizeof(char*), args, opts), vm);
   bpo::notify(vm);
   BOOST_CHECK(vm["someInt"].as<int>() == 1);
+  BOOST_CHECK(vm["someInt8"].as<int8_t>() == '1');
+  BOOST_CHECK(vm["someInt16"].as<int16_t>() == 1);
   BOOST_CHECK(vm["someUInt8"].as<uint8_t>() == '1');
   BOOST_CHECK(vm["someUInt16"].as<uint16_t>() == 1);
   BOOST_CHECK(vm["someUInt32"].as<uint32_t>() == 1);

--- a/Framework/Core/test/test_ConfigParamRegistry.cxx
+++ b/Framework/Core/test/test_ConfigParamRegistry.cxx
@@ -41,6 +41,8 @@ BOOST_AUTO_TEST_CASE(TestConfigParamRegistry)
     ("aFloat", bpo::value<float>()->default_value(10.f))                  //
     ("aDouble", bpo::value<double>()->default_value(20.))                 //
     ("anInt", bpo::value<int>()->default_value(1))                        //
+    ("anInt8", bpo::value<int8_t>()->default_value(1))                    //
+    ("anInt16", bpo::value<int16_t>()->default_value(1))                  //
     ("anUInt8", bpo::value<uint8_t>()->default_value(1))                  //
     ("anUInt16", bpo::value<uint16_t>()->default_value(1))                //
     ("anUInt32", bpo::value<uint32_t>()->default_value(1))                //
@@ -56,6 +58,8 @@ BOOST_AUTO_TEST_CASE(TestConfigParamRegistry)
   options->ParseAll({"cmd", "--aFloat", "1.0",
                      "--aDouble", "2.0",
                      "--anInt", "10",
+                     "--anInt8", "2",
+                     "--anInt16", "10",
                      "--anUInt8", "2",
                      "--anUInt16", "10",
                      "--anUInt32", "10",
@@ -68,6 +72,8 @@ BOOST_AUTO_TEST_CASE(TestConfigParamRegistry)
                     true);
   std::vector<ConfigParamSpec> specs{
     ConfigParamSpec{"anInt", VariantType::Int, 1, {"an int option"}},
+    ConfigParamSpec{"anInt8", VariantType::Int8, static_cast<int8_t>(1), {"an int8 option"}},
+    ConfigParamSpec{"anInt16", VariantType::Int16, static_cast<int16_t>(1), {"an int16 option"}},
     ConfigParamSpec{"anUInt8", VariantType::UInt8, static_cast<uint8_t>(1u), {"an uint8 option"}},
     ConfigParamSpec{"anUInt16", VariantType::UInt16, static_cast<uint16_t>(1u), {"an uint16 option"}},
     ConfigParamSpec{"anUInt32", VariantType::UInt32, 1u, {"an uint32 option"}},
@@ -94,6 +100,8 @@ BOOST_AUTO_TEST_CASE(TestConfigParamRegistry)
   BOOST_CHECK_EQUAL(registry.get<float>("aFloat"), 1.0);
   BOOST_CHECK_EQUAL(registry.get<double>("aDouble"), 2.0);
   BOOST_CHECK_EQUAL(registry.get<int>("anInt"), 10);
+  BOOST_CHECK_EQUAL(registry.get<int8_t>("anInt8"), '2');
+  BOOST_CHECK_EQUAL(registry.get<int16_t>("anInt16"), 10);
   BOOST_CHECK_EQUAL(registry.get<uint8_t>("anUInt8"), '2');
   BOOST_CHECK_EQUAL(registry.get<uint16_t>("anUInt16"), 10);
   BOOST_CHECK_EQUAL(registry.get<uint32_t>("anUInt32"), 10);

--- a/Framework/Core/test/test_ConfigParamStore.cxx
+++ b/Framework/Core/test/test_ConfigParamStore.cxx
@@ -31,6 +31,8 @@ BOOST_AUTO_TEST_CASE(TestConfigParamStore)
     ("aFloat", bpo::value<float>()->default_value(10.f))                  //
     ("aDouble", bpo::value<double>()->default_value(20.))                 //
     ("anInt", bpo::value<int>()->default_value(1))                        //
+    ("anInt8", bpo::value<int8_t>()->default_value(1))                    //
+    ("anInt16", bpo::value<int16_t>()->default_value(1))                  //
     ("anUInt8", bpo::value<uint8_t>()->default_value(1))                  //
     ("anUInt16", bpo::value<uint16_t>()->default_value(1))                //
     ("anUInt32", bpo::value<uint32_t>()->default_value(1))                //
@@ -46,6 +48,8 @@ BOOST_AUTO_TEST_CASE(TestConfigParamStore)
   options->ParseAll({"cmd", "--aFloat", "1.0",
                      "--aDouble", "2.0",
                      "--anInt", "10",
+                     "--anInt8", "2",
+                     "--anInt16", "10",
                      "--anUInt8", "2",
                      "--anUInt16", "10",
                      "--anUInt32", "10",
@@ -58,6 +62,8 @@ BOOST_AUTO_TEST_CASE(TestConfigParamStore)
                     true);
   std::vector<ConfigParamSpec> specs{
     ConfigParamSpec{"anInt", VariantType::Int, 1, {"an int option"}},
+    ConfigParamSpec{"anInt8", VariantType::Int8, static_cast<int8_t>(1), {"an int8 option"}},
+    ConfigParamSpec{"anInt16", VariantType::Int16, static_cast<int16_t>(1), {"an int16 option"}},
     ConfigParamSpec{"anUInt8", VariantType::UInt8, static_cast<uint8_t>(1u), {"an int option"}},
     ConfigParamSpec{"anUInt16", VariantType::UInt16, static_cast<uint16_t>(1u), {"an int option"}},
     ConfigParamSpec{"anUInt32", VariantType::UInt32, 1u, {"an int option"}},
@@ -83,6 +89,8 @@ BOOST_AUTO_TEST_CASE(TestConfigParamStore)
   BOOST_CHECK_EQUAL(store.store().get<float>("aFloat"), 1.0);
   BOOST_CHECK_EQUAL(store.store().get<double>("aDouble"), 2.0);
   BOOST_CHECK_EQUAL(store.store().get<int>("anInt"), 10);
+  BOOST_CHECK_EQUAL(store.store().get<int8_t>("anInt8"), '2');
+  BOOST_CHECK_EQUAL(store.store().get<int16_t>("anInt16"), 10);
   BOOST_CHECK_EQUAL(store.store().get<uint8_t>("anUInt8"), '2');
   BOOST_CHECK_EQUAL(store.store().get<uint16_t>("anUInt16"), 10);
   BOOST_CHECK_EQUAL(store.store().get<uint32_t>("anUInt32"), 10);
@@ -103,6 +111,8 @@ BOOST_AUTO_TEST_CASE(TestConfigParamStore)
   BOOST_CHECK_EQUAL(store.provenance("aFloat"), "fairmq");
   BOOST_CHECK_EQUAL(store.provenance("aDouble"), "fairmq");
   BOOST_CHECK_EQUAL(store.provenance("anInt"), "fairmq");
+  BOOST_CHECK_EQUAL(store.provenance("anInt8"), "fairmq");
+  BOOST_CHECK_EQUAL(store.provenance("anInt16"), "fairmq");
   BOOST_CHECK_EQUAL(store.provenance("anUInt8"), "fairmq");
   BOOST_CHECK_EQUAL(store.provenance("anUInt16"), "fairmq");
   BOOST_CHECK_EQUAL(store.provenance("anUInt32"), "fairmq");

--- a/Framework/GUISupport/src/FrameworkGUIDeviceInspector.cxx
+++ b/Framework/GUISupport/src/FrameworkGUIDeviceInspector.cxx
@@ -123,6 +123,12 @@ void optionsTable(const char* label, std::vector<ConfigParamSpec> const& options
           case VariantType::Int:
             ImGui::Text("%d (default)", option.defaultValue.get<int>());
             break;
+          case VariantType::Int8:
+            ImGui::Text("%d (default)", option.defaultValue.get<int8_t>());
+            break;
+          case VariantType::Int16:
+            ImGui::Text("%d (default)", option.defaultValue.get<int16_t>());
+            break;
           case VariantType::Int64:
             ImGui::Text("%" PRId64 " (default)", option.defaultValue.get<int64_t>());
             break;


### PR DESCRIPTION
* add `int8` and `int16` to Variant
* update tests
* update parsing of small ints in config/workflow serialization and deserialization