### PR TITLE
add IRFrameSelector class to validate IR or IRFrame

### DIFF
--- a/Common/Utils/CMakeLists.txt
+++ b/Common/Utils/CMakeLists.txt
@@ -22,6 +22,7 @@ o2_add_library(CommonUtils
                        src/VerbosityConfig.cxx
                        src/BoostHistogramUtils.cxx
                        src/NameConf.cxx
+                       src/IRFrameSelector.cxx
                PUBLIC_LINK_LIBRARIES ROOT::Hist ROOT::Tree Boost::iostreams O2::CommonDataFormat O2::Headers
                                      FairLogger::FairLogger)
 
@@ -43,7 +44,8 @@ o2_target_root_dictionary(CommonUtils
                                   include/CommonUtils/KeyValParam.h
                                   include/CommonUtils/VerbosityConfig.h
                                   include/CommonUtils/FileFetcher.h
-                                  include/CommonUtils/NameConf.h)
+                                  include/CommonUtils/NameConf.h
+                                  include/CommonUtils/IRFrameSelector.h)
 
 o2_add_test(TreeStream
             COMPONENT_NAME CommonUtils

--- a/Common/Utils/include/CommonUtils/IRFrameSelector.h
+++ b/Common/Utils/include/CommonUtils/IRFrameSelector.h
@@ -1,0 +1,46 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file IRFrameSelector.h
+/// \brief Class to check if give InteractionRecord or IRFrame is selected by the external IRFrame vector
+/// \author ruben.shahoyan@cern.ch
+
+#include "CommonDataFormat/IRFrame.h"
+#include <gsl/span>
+
+namespace o2::utils
+{
+class IRFrameSelector
+{
+ public:
+  bool check(const o2::dataformats::IRFrame& fr);
+  bool check(const o2::InteractionRecord& ir) { return check(o2::dataformats::IRFrame{ir, ir}); }
+
+  template <typename SPAN>
+  void setSelectedIRFrames(const SPAN& sp)
+  {
+    mFrames = gsl::span<const o2::dataformats::IRFrame>(sp.data(), sp.size());
+    mLastBoundID = -1;
+    mLastIRFrameChecked.getMin().clear(); // invalidate
+  }
+
+  size_t loadIRFrames(const std::string& fname);
+  void print(bool lst = false) const;
+
+ private:
+  gsl::span<const o2::dataformats::IRFrame> mFrames{}; // externally provided span of IRFrames, must be sorted in IRFrame.getMin()
+  o2::dataformats::IRFrame mLastIRFrameChecked{};      // last frame which was checked
+  long mLastBoundID = -1;                              // id of the last checked entry >= mLastIRFrameChecked
+  std::vector<o2::dataformats::IRFrame> mOwnList;      // list loaded from the file
+  ClassDefNV(IRFrameSelector, 1);
+};
+
+} // namespace o2::utils

--- a/Common/Utils/src/CommonUtilsLinkDef.h
+++ b/Common/Utils/src/CommonUtilsLinkDef.h
@@ -37,4 +37,6 @@
 #pragma link C++ class o2::base::NameConf + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::base::NameConf> + ;
 
+#pragma link C++ class o2::utils::IRFrameSelector + ;
+
 #endif

--- a/Common/Utils/src/IRFrameSelector.cxx
+++ b/Common/Utils/src/IRFrameSelector.cxx
@@ -1,0 +1,142 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file IRFrameSelector.cxx
+/// \brief Class to check if give InteractionRecord or IRFrame is selected by the external IRFrame vector
+/// \author ruben.shahoyan@cern.ch
+
+#include "CommonUtils/IRFrameSelector.h"
+#include "Framework/Logger.h"
+#include <TFile.h>
+#include <TTree.h>
+#include <TKey.h>
+
+using namespace o2::utils;
+
+bool IRFrameSelector::check(const o2::dataformats::IRFrame& fr)
+{
+  bool ans = false;
+
+  // find entry which overlaps or above fr
+  auto fullcheck = [&fr, this]() {
+    auto lower = std::lower_bound(this->mFrames.begin(), this->mFrames.end(), fr);
+    if (lower == this->mFrames.end()) {
+      this->mLastBoundID = this->mFrames.size();
+    } else {
+      this->mLastBoundID = std::distance(this->mFrames.begin(), lower);
+      return fr.isOutside(*lower) == o2::dataformats::IRFrame::Inside;
+    }
+    return false;
+  };
+
+  if (mLastBoundID < 0) { // 1st call, do full search
+    ans = fullcheck();
+  } else { // we assume that the new query is in the vicinity of the previous one
+    int steps = 0;
+    constexpr int MaxSteps = 3;
+    if (fr.getMin() >= mLastIRFrameChecked.getMin()) { // check entries including and following mLastBoundID
+      for (; mLastBoundID < (long)mFrames.size(); mLastBoundID++) {
+        auto res = fr.isOutside(mFrames[mLastBoundID]);
+        if (res == o2::dataformats::IRFrame::Above) {
+          break; // no point in checking further
+        } else if (res == o2::dataformats::IRFrame::Inside) {
+          ans = true;
+          break;
+        }
+        if (++steps == MaxSteps) {
+          ans = fullcheck();
+          break;
+        }
+      }
+    } else { // check entries preceding mLastBoundID
+      if (mLastBoundID >= (long)mFrames.size()) {
+        mLastBoundID = (long)mFrames.size() - 1;
+      }
+      for (; mLastBoundID >= 0; mLastBoundID--) {
+        auto res = fr.isOutside(mFrames[mLastBoundID]);
+        if (res == o2::dataformats::IRFrame::Below) {
+          mLastBoundID++; // no point in checking further
+          break;
+        } else if (res == o2::dataformats::IRFrame::Inside) {
+          ans = true;
+          break;
+        }
+        if (++steps == MaxSteps) {
+          ans = fullcheck();
+          break;
+        }
+      }
+      if (mLastBoundID < 0) {
+        mLastBoundID = 0;
+      }
+    }
+  }
+  mLastIRFrameChecked = fr;
+  return ans;
+}
+
+size_t IRFrameSelector::loadIRFrames(const std::string& fname)
+{
+  // read IRFrames to filter from the file
+  std::unique_ptr<TFile> tfl(TFile::Open(fname.c_str()));
+  if (!tfl || tfl->IsZombie()) {
+    LOGP(fatal, "Cannot open file {}", fname);
+  }
+  auto klst = gDirectory->GetListOfKeys();
+  TIter nextkey(klst);
+  TKey* key;
+  std::string clVec{TClass::GetClass("std::vector<o2::dataformats::IRFrame>")->GetName()};
+  bool done = false;
+  while ((key = (TKey*)nextkey())) {
+    std::string kcl(key->GetClassName());
+    if (kcl == clVec) {
+      auto* v = (std::vector<o2::dataformats::IRFrame>*)tfl->GetObjectUnchecked(key->GetName());
+      if (!v) {
+        LOGP(fatal, "Failed to extract vector {} from {}", key->GetName(), fname);
+      }
+      mOwnList.insert(mOwnList.end(), v->begin(), v->end());
+      LOGP(info, "Loaded {} IRFrames from vector {} of {}", mOwnList.size(), key->GetName(), fname);
+      done = true;
+      break;
+    } else if (kcl == "TTree") {
+      std::unique_ptr<TTree> tr((TTree*)tfl->Get(key->GetName()));
+      if (!tr->GetBranch("IRFrames")) {
+        LOGP(fatal, "Did not find branch IRFrames in the tree {}", key->GetName());
+      }
+      std::vector<o2::dataformats::IRFrame> tmpv, *tpmvPtr = &tmpv;
+      tr->SetBranchAddress("IRFrames", &tpmvPtr);
+      for (int i = 0; i < (int)tr->GetEntries(); i++) {
+        tr->GetEntry(i);
+        mOwnList.insert(mOwnList.end(), tmpv.begin(), tmpv.end());
+      }
+      done = true;
+      LOGP(info, "Loaded {} IRFrames from tree {} of {}", mOwnList.size(), key->GetName(), fname);
+      break;
+    }
+  }
+  if (!true) {
+    LOGP(fatal, "Did not find neither tree nor vector of IRFrames in {}", fname);
+  }
+  setSelectedIRFrames(mOwnList);
+  return mOwnList.size();
+}
+
+void IRFrameSelector::print(bool lst) const
+{
+  LOGP(info, "Last query stopped at entry {} for IRFrame {}:{}", mLastBoundID,
+       mLastIRFrameChecked.getMin().asString(), mLastIRFrameChecked.getMax().asString());
+  if (lst) {
+    size_t i = 0;
+    for (const auto& f : mFrames) {
+      LOGP(info, "Frame#{}: {}:{}", i++, f.getMin().asString(), f.getMax().asString());
+    }
+  }
+}


### PR DESCRIPTION
Allows to assign or to read from the file the list of ordered (not checked) IRFrames
and check for any InteractionRecord or IRFrame if it overlaps with any entry in the list