### PR TITLE
Increase DEFAULT_PIPELINE_LENGTH to 128

### DIFF
--- a/Framework/Core/src/DataRelayer.cxx
+++ b/Framework/Core/src/DataRelayer.cxx
@@ -52,9 +52,9 @@ namespace o2::framework
 
 constexpr int INVALID_INPUT = -1;
 
-// 16 is just some reasonable numer
+// 128 is just some reasonable numer
 // The number should really be tuned at runtime for each processor.
-constexpr int DEFAULT_PIPELINE_LENGTH = 32;
+constexpr int DEFAULT_PIPELINE_LENGTH = 128;
 
 DataRelayer::DataRelayer(const CompletionPolicy& policy,
                          std::vector<InputRoute> const& routes,


### PR DESCRIPTION
@ktf : Does this make sense or do you think it is too high? Even though probably not related to the problem that we had tonight with ITS,MFT,HMP (see discussion in the PDP MM channel), I think it will be helpful in general to increase this. With even more processes being added to the global workflow, we will run in limitations otherwise.