### PR TITLE
Fixes for CcdbApi and manager

### DIFF
--- a/CCDB/include/CCDB/BasicCCDBManager.h
+++ b/CCDB/include/CCDB/BasicCCDBManager.h
@@ -49,6 +49,7 @@ class CCDBManagerInstance
     bool isValid(long ts) { return ts < endvalidity && ts > startvalidity; }
     void clear()
     {
+      noCleanupPtr = nullptr;
       objPtr.reset();
       uuid = "";
       startvalidity = 0;
@@ -193,7 +194,8 @@ T* CCDBManagerInstance::getForTimeStamp(std::string const& path, long timestamp)
                                               mCreatedNotAfter ? std::to_string(mCreatedNotAfter) : "",
                                               mCreatedNotBefore ? std::to_string(mCreatedNotBefore) : "");
   if (ptr) { // new object was shipped, old one (if any) is not valid anymore
-    if constexpr (std::is_same<TGeoManager, T>::value) { // some special objects cannot be cached to shared_ptr since root may delete their raw global pointer
+    if constexpr (std::is_same<TGeoManager, T>::value || std::is_base_of<o2::conf::ConfigurableParam, T>::value) {
+      // some special objects cannot be cached to shared_ptr since root may delete their raw global pointer
       cached.noCleanupPtr = ptr;
     } else {
       cached.objPtr.reset(ptr);

--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -286,7 +286,7 @@ class CcdbApi //: public DatabaseInterface
    * @param cl The TClass object describing the serialized type
    * @return raw pointer to created object
    */
-  static void* extractFromTFile(TFile& file, TClass const* cl);
+  static void* extractFromTFile(TFile& file, TClass const* cl, const char* what = CCDBOBJECT_ENTRY);
 
   /** Get headers associated to a given CCDBEntry on the server.
    * @param url the url which refers to the objects
@@ -362,7 +362,7 @@ class CcdbApi //: public DatabaseInterface
 
  private:
   // report what file is read and for which purpose
-  void logReading(const std::string& fname, const std::string& comment) const;
+  void logReading(const std::string& path, const std::map<std::string, std::string>* headers, const std::string& comment) const;
 
   /**
    * Initialize in local mode; Objects will be retrieved from snapshot
@@ -546,9 +546,12 @@ typename std::enable_if<std::is_base_of<o2::conf::ConfigurableParam, T>::value, 
                                 const std::string& createdNotAfter, const std::string& createdNotBefore) const
 {
   auto obj = retrieveFromTFile(typeid(T), path, metadata, timestamp, headers, etag, createdNotAfter, createdNotBefore);
-  auto& param = const_cast<typename std::remove_const<T&>::type>(T::Instance());
-  param.syncCCDBandRegistry(obj);
-  return &param;
+  if (obj) {
+    auto& param = const_cast<typename std::remove_const<T&>::type>(T::Instance());
+    param.syncCCDBandRegistry(obj);
+    return &param;
+  }
+  return static_cast<T*>(obj);
 }
 
 } // namespace ccdb

--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -660,19 +660,19 @@ void CcdbApi::snapshot(std::string const& ccdbrootpath, std::string const& local
   }
 }
 
-void* CcdbApi::extractFromTFile(TFile& file, TClass const* cl)
+void* CcdbApi::extractFromTFile(TFile& file, TClass const* cl, const char* what)
 {
   if (!cl) {
     return nullptr;
   }
-  auto object = file.GetObjectChecked(CCDBOBJECT_ENTRY, cl);
+  auto object = file.GetObjectChecked(what, cl);
   if (!object) {
     // it could be that object was stored with previous convention
     // where the classname was taken as key
     std::string objectName(cl->GetName());
     o2::utils::Str::trim(objectName);
     object = file.GetObjectChecked(objectName.c_str(), cl);
-    LOG(warn) << "Did not find object under expected name " << CCDBOBJECT_ENTRY;
+    LOG(warn) << "Did not find object under expected name " << what;
     if (!object) {
       return nullptr;
     }
@@ -702,7 +702,6 @@ void* CcdbApi::extractFromTFile(TFile& file, TClass const* cl)
 
 void* CcdbApi::extractFromLocalFile(std::string const& filename, std::type_info const& tinfo, std::map<std::string, std::string>* headers) const
 {
-  logReading(filename, "retrieve");
   if (!std::filesystem::exists(filename)) {
     LOG(error) << "Local snapshot " << filename << " not found \n";
     return nullptr;
@@ -716,7 +715,7 @@ void* CcdbApi::extractFromLocalFile(std::string const& filename, std::type_info 
       *headers = *storedmeta; // do a simple deep copy
       delete storedmeta;
     }
-    if (isSnapshotMode() || mPreferSnapshotCache) { // generate dummy ETag to profit from the caching
+    if ((isSnapshotMode() || mPreferSnapshotCache) && headers->find("ETag") == headers->end()) { // generate dummy ETag to profit from the caching
       (*headers)["ETag"] = filename;
     }
   }
@@ -765,7 +764,6 @@ bool CcdbApi::initTGrid() const
 
 void* CcdbApi::downloadAlienContent(std::string const& url, std::type_info const& tinfo) const
 {
-  logReading(url, "retrieve");
   if (!initTGrid()) {
     return nullptr;
   }
@@ -932,7 +930,9 @@ void* CcdbApi::retrieveFromTFile(std::type_info const& tinfo, std::string const&
       out << "CCDB-access[" << getpid() << "] to " << path << " timestamp " << timestamp << "\n";
     }
     auto snapshotfile = getSnapshotFile(mSnapshotCachePath, path);
+    bool snapshoting = false;
     if (!std::filesystem::exists(snapshotfile)) {
+      snapshoting = true;
       out << "CCDB-access[" << getpid() << "]  ... downloading to snapshot " << snapshotfile << "\n";
       // if file not already here and valid --> snapshot it
       if (!retrieveBlob(path, mSnapshotCachePath, metadata, timestamp)) {
@@ -949,7 +949,11 @@ void* CcdbApi::retrieveFromTFile(std::type_info const& tinfo, std::string const&
         boost::interprocess::named_semaphore::remove(semhashedstring.c_str());
       }
     }
-    return extractFromLocalFile(snapshotfile, tinfo, headers);
+    auto res = extractFromLocalFile(snapshotfile, tinfo, headers);
+    if (!snapshoting) { // if snapshot was created at this call, the log was already done
+      logReading(path, headers, "retrieve from snapshot");
+    }
+    return res;
   }
 
   // normal mode follows
@@ -959,6 +963,7 @@ void* CcdbApi::retrieveFromTFile(std::type_info const& tinfo, std::string const&
   // if we are in snapshot mode we can simply open the file; extract the object and return
   if (mInSnapshotMode) {
     return extractFromLocalFile(fullUrl, tinfo, headers);
+    logReading(path, headers, "retrieve from snapshot");
   }
 
   initHeadersForRetrieve(curl_handle, timestamp, headers, etag, createdNotAfter, createdNotBefore);
@@ -968,7 +973,9 @@ void* CcdbApi::retrieveFromTFile(std::type_info const& tinfo, std::string const&
     fullUrl = getFullUrlForRetrieval(curl_handle, path, metadata, timestamp, hostIndex);
     content = navigateURLsAndRetrieveContent(curl_handle, fullUrl, tinfo, headers);
   }
-
+  if (content) {
+    logReading(path, headers, "retrieve");
+  }
   curl_easy_cleanup(curl_handle);
   return content;
 }
@@ -1373,14 +1380,16 @@ void CcdbApi::loadFileToMemory(o2::pmr::vector<char>& dest, std::string const& p
   // if we are in snapshot mode we can simply open the file, unless the etag is non-empty:
   // this would mean that the object was is already fetched and in this mode we don't to validity checks!
   std::string snapshotpath{};
+  int fromSnapshot = 0;
   if (mInSnapshotMode) { // file must be there, otherwise a fatal will be produced
     loadFileToMemory(dest, getSnapshotFile(mSnapshotTopPath, path), headers);
+    fromSnapshot = 1;
   } else if (mPreferSnapshotCache && std::filesystem::exists(snapshotpath = getSnapshotFile(mSnapshotCachePath, path))) {
     // if file is available, use it, otherwise cache it below from the server. Do this only when etag is empty since otherwise the object was already fetched and cached
     if (etag.empty()) {
       loadFileToMemory(dest, snapshotpath, headers);
     }
-    return;
+    fromSnapshot = 2;
   } else { // look on the server
     CURL* curl_handle = curl_easy_init();
     string fullUrl = getFullUrlForRetrieval(curl_handle, path, metadata, timestamp);
@@ -1391,7 +1400,7 @@ void CcdbApi::loadFileToMemory(o2::pmr::vector<char>& dest, std::string const& p
 
     for (size_t hostIndex = 1; hostIndex < hostsPool.size() && isMemoryFileInvalid(dest); hostIndex++) {
       fullUrl = getFullUrlForRetrieval(curl_handle, path, metadata, timestamp, hostIndex);
-      loadFileToMemory(dest, fullUrl, headers);
+      loadFileToMemory(dest, fullUrl, nullptr); // headers loaded from the file in case of the snapshot reading only
     }
     curl_easy_cleanup(curl_handle);
   }
@@ -1399,9 +1408,11 @@ void CcdbApi::loadFileToMemory(o2::pmr::vector<char>& dest, std::string const& p
   if (dest.empty()) {
     return; // nothing was fetched: either cached value is good or error was produced
   }
+  // !considerSnapshot means that the call was made by retrieve for snapshoting reasons
+  logReading(path, headers, fmt::format("{}{}", considerSnapshot ? "load to memory" : "retrieve", fromSnapshot ? " from snapshot" : ""));
 
   // are we asked to create a snapshot ?
-  if (considerSnapshot && !mSnapshotCachePath.empty()) {
+  if (considerSnapshot && !mSnapshotCachePath.empty() && fromSnapshot != 1) { // store in the snapshot only if the object was not read from the snapshot
     if (mInSnapshotMode && mSnapshotTopPath == mSnapshotCachePath) { // do not save to itself
       return;
     }
@@ -1471,7 +1482,7 @@ void CcdbApi::navigateURLsAndLoadFileToMemory(o2::pmr::vector<char>& dest, CURL*
 
   // let's see first of all if the url is something specific that curl cannot handle
   if (url.find("alien:/", 0) != std::string::npos) {
-    return loadFileToMemory(dest, url);
+    return loadFileToMemory(dest, url, nullptr); // headers loaded from the file in case of the snapshot reading only
   }
   // otherwise make an HTTP/CURL request
   bool errorflag = false;
@@ -1573,7 +1584,6 @@ void CcdbApi::navigateURLsAndLoadFileToMemory(o2::pmr::vector<char>& dest, CURL*
 void CcdbApi::loadFileToMemory(o2::pmr::vector<char>& dest, const std::string& path, std::map<std::string, std::string>* localHeaders) const
 {
   // Read file to memory as vector. For special case of the locally cached file retriev metadata stored directly in the file
-  logReading(path, "load to memory");
   constexpr size_t MaxCopySize = 0x1L << 25;
   auto signalError = [&dest, localHeaders]() {
     dest.clear();
@@ -1618,14 +1628,15 @@ void CcdbApi::loadFileToMemory(o2::pmr::vector<char>& dest, const std::string& p
     dptr += nread;
     totalread += nread;
   } while (nread == (long)MaxCopySize);
+
   if (localHeaders) {
-    sfile->Seek(0);
-    auto storedmeta = retrieveMetaInfo(*sfile);
+    TMemFile memFile("name", const_cast<char*>(dest.data()), dest.size(), "READ");
+    auto storedmeta = (std::map<std::string, std::string>*)extractFromTFile(memFile, TClass::GetClass("std::map<std::string, std::string>"), CCDBMETA_ENTRY);
     if (storedmeta) {
       *localHeaders = *storedmeta; // do a simple deep copy
       delete storedmeta;
     }
-    if (isSnapshotMode() || mPreferSnapshotCache) { // generate dummy ETag to profit from the caching
+    if ((isSnapshotMode() || mPreferSnapshotCache) && localHeaders->find("ETag") == localHeaders->end()) { // generate dummy ETag to profit from the caching
       (*localHeaders)["ETag"] = path;
     }
   }
@@ -1657,9 +1668,21 @@ void CcdbApi::checkMetadataKeys(std::map<std::string, std::string> const& metada
   return;
 }
 
-void CcdbApi::logReading(const std::string& fname, const std::string& comment) const
+void CcdbApi::logReading(const std::string& path, const std::map<std::string, std::string>* headers, const std::string& comment) const
 {
-  LOGP(info, "ccdb reads {} ({}, agent_id: {}), ", fname, comment, mUniqueAgentID);
+  std::string upath{path};
+  if (headers) {
+    auto ent = headers->find("Valid-From");
+    if (ent != headers->end()) {
+      upath += "/" + ent->second;
+    }
+    ent = headers->find("ETag");
+    if (ent != headers->end()) {
+      upath += "/" + ent->second;
+    }
+  }
+  upath.erase(remove(upath.begin(), upath.end(), '\"'), upath.end());
+  LOGP(info, "ccdb reads {}{}{} ({}, agent_id: {}), ", mUrl, mUrl.back() == '/' ? "" : "/", upath, comment, mUniqueAgentID);
 }
 
 } // namespace o2


### PR DESCRIPTION
* Cache ConfigurableParams using no-delete pointer to avoid deleting singletons at cache update
* Report host/path/SOV/ETag of loaded object
This will provide a unique path of the object, which can be browsed directly (by adding browse
between the host and path. On epn, where http://localhost:8083 or http://o2-ccdb.internal
is used, the host can be substituted by http://alice-ccdb.cern.ch
