### PR TITLE
Compile AVX512 decoder only in FLP builds

### DIFF
--- a/Detectors/FIT/FT0/workflow/CMakeLists.txt
+++ b/Detectors/FIT/FT0/workflow/CMakeLists.txt
@@ -10,7 +10,7 @@
 # or submit itself to any jurisdiction.
 
 CHECK_CXX_COMPILER_FLAG("-mavx512f -mavx512vl -mavx512bw -mavx512dq" FT0_DECODER_AVX512_GOOD_FLAGS)
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND FT0_DECODER_AVX512_GOOD_FLAGS)
+if((DEFINED $ENV{O2_BUILD_FOR_FLP}) AND (CMAKE_SYSTEM_NAME STREQUAL "Linux") AND FT0_DECODER_AVX512_GOOD_FLAGS)
 add_definitions(-DFT0_DECODER_AVX512)
 o2_add_library(FT0Workflow
                SOURCES src/RecoWorkflow.cxx


### PR DESCRIPTION
Fixes https://alice.its.cern.ch/jira/browse/O2-2975 and https://alice-talk.web.cern.ch/t/building-on-ubuntu-gets-stuck-due-to-insufficient-guards-for-avx512-code/1214/4

