### PR TITLE
Fix ITS/MFT digitizer initializtions

### DIFF
--- a/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Digitizer.h
+++ b/Detectors/ITSMFT/common/simulation/include/ITSMFTSimulation/Digitizer.h
@@ -58,8 +58,8 @@ class Digitizer : public TObject
   void setROFRecords(std::vector<o2::itsmft::ROFRecord>* rec) { mROFRecords = rec; }
   o2::itsmft::DigiParams& getParams() { return (o2::itsmft::DigiParams&)mParams; }
   const o2::itsmft::DigiParams& getParams() const { return mParams; }
-  void setNoiseMap(const o2::itsmft::NoiseMap* mp);
-  void setDeadChannelsMap(const o2::itsmft::NoiseMap* mp);
+  void setNoiseMap(const o2::itsmft::NoiseMap* mp) { mNoiseMap = mp; }
+  void setDeadChannelsMap(const o2::itsmft::NoiseMap* mp) { mDeadChanMap = mp; }
 
   void init();
 
@@ -122,7 +122,7 @@ class Digitizer : public TObject
   uint32_t mEventROFrameMin = 0xffffffff; ///< lowest RO frame for processed events (w/o automatic noise ROFs)
   uint32_t mEventROFrameMax = 0;          ///< highest RO frame forfor processed events (w/o automatic noise ROFs)
 
-  int mNumberOfChips;
+  int mNumberOfChips = 0;
   o2::itsmft::AlpideSimResponse* mAlpSimRespMFT = nullptr;
   o2::itsmft::AlpideSimResponse* mAlpSimRespIB = nullptr;
   o2::itsmft::AlpideSimResponse* mAlpSimRespOB = nullptr;

--- a/Detectors/ITSMFT/common/simulation/src/DigiParams.cxx
+++ b/Detectors/ITSMFT/common/simulation/src/DigiParams.cxx
@@ -65,7 +65,7 @@ void DigiParams::print() const
   printf("Strobe delay (ns)              : %f\n", mStrobeDelay);
   printf("Strobe length (ns)             : %f\n", mStrobeLength);
   printf("Threshold (N electrons)        : %d\n", mChargeThreshold);
-  printf("Min N electrons to accoint     : %d\n", mMinChargeToAccount);
+  printf("Min N electrons to account     : %d\n", mMinChargeToAccount);
   printf("Number of charge sharing steps : %d\n", mNSimSteps);
   printf("ELoss to N electrons factor    : %e\n", mEnergyToNElectrons);
   printf("Noise level per pixel          : %e\n", mNoisePerPixel);

--- a/Detectors/ITSMFT/common/simulation/src/Digitizer.cxx
+++ b/Detectors/ITSMFT/common/simulation/src/Digitizer.cxx
@@ -40,6 +40,13 @@ void Digitizer::init()
   mChips.resize(mNumberOfChips);
   for (int i = mNumberOfChips; i--;) {
     mChips[i].setChipIndex(i);
+    if (mNoiseMap) {
+      mChips[i].setNoiseMap(mNoiseMap);
+    }
+    if (mDeadChanMap) {
+      mChips[i].disable(mDeadChanMap->isFullChipMasked(i));
+      mChips[i].setDeadChanMap(mDeadChanMap);
+    }
   }
   // initializing for both collection tables
   for (int i = 0; i < 2; i++) {
@@ -454,23 +461,4 @@ void Digitizer::registerDigits(ChipDigitsContainer& chip, uint32_t roFrame, floa
       extra->emplace_back(lbl);
     }
   }
-}
-
-//________________________________________________________________________________
-void Digitizer::setNoiseMap(const o2::itsmft::NoiseMap* mp)
-{
-  for (int i = 0; i < mNumberOfChips; i++) {
-    mChips[i].setNoiseMap(mp);
-  }
-  mNoiseMap = mp;
-}
-
-//________________________________________________________________________________
-void Digitizer::setDeadChannelsMap(const o2::itsmft::NoiseMap* mp)
-{
-  for (int i = 0; i < mNumberOfChips; i++) {
-    mChips[i].disable(mp->isFullChipMasked(i));
-    mChips[i].setDeadChanMap(mp);
-  }
-  mDeadChanMap = mp;
 }

--- a/Steer/DigitizerWorkflow/src/ITSMFTDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/ITSMFTDigitizerSpec.cxx
@@ -51,31 +51,8 @@ class ITSMFTDPLDigitizerTask : BaseDPLDigitizer
   using BaseDPLDigitizer::init;
   void initDigitizerTask(framework::InitContext& ic) override
   {
-    setDigitizationOptions(); // set options provided via configKeyValues mechanism
-    auto& digipar = mDigitizer.getParams();
-
-    mROMode = digipar.isContinuous() ? o2::parameters::GRPObject::CONTINUOUS : o2::parameters::GRPObject::PRESENT;
-    LOG(info) << mID.getName() << " simulated in "
-              << ((mROMode == o2::parameters::GRPObject::CONTINUOUS) ? "CONTINUOUS" : "TRIGGERED")
-              << " RO mode";
-
-    // configure digitizer
-    o2::itsmft::GeometryTGeo* geom = nullptr;
-    if (mID == o2::detectors::DetID::ITS) {
-      geom = o2::its::GeometryTGeo::Instance();
-    } else {
-      geom = o2::mft::GeometryTGeo::Instance();
-    }
-    geom->fillMatrixCache(o2::math_utils::bit2Mask(o2::math_utils::TransformType::L2G)); // make sure L2G matrices are loaded
-    mDigitizer.setGeometry(geom);
-
     mDisableQED = ic.options().get<bool>("disable-qed");
-
-    // init digitizer
-    mDigitizer.init();
   }
-
-  virtual void setDigitizationOptions() = 0;
 
   void run(framework::ProcessingContext& pc)
   {
@@ -222,6 +199,7 @@ class ITSMFTDPLDigitizerTask : BaseDPLDigitizer
     pc.inputs().get<o2::itsmft::NoiseMap*>("noise");
     pc.inputs().get<o2::itsmft::NoiseMap*>("dead");
     pc.inputs().get<o2::itsmft::DPLAlpideParam<DETID>*>("alppar");
+
     auto& dopt = o2::itsmft::DPLDigitizerParam<DETID>::Instance();
     auto& aopt = o2::itsmft::DPLAlpideParam<DETID>::Instance();
     auto& digipar = mDigitizer.getParams();
@@ -245,6 +223,22 @@ class ITSMFTDPLDigitizerTask : BaseDPLDigitizer
     digipar.setNSimSteps(dopt.nSimSteps);
     digipar.setIBVbb(dopt.IBVbb);
     digipar.setOBVbb(dopt.OBVbb);
+
+    mROMode = digipar.isContinuous() ? o2::parameters::GRPObject::CONTINUOUS : o2::parameters::GRPObject::PRESENT;
+    LOG(info) << mID.getName() << " simulated in "
+              << ((mROMode == o2::parameters::GRPObject::CONTINUOUS) ? "CONTINUOUS" : "TRIGGERED")
+              << " RO mode";
+
+    // configure digitizer
+    o2::itsmft::GeometryTGeo* geom = nullptr;
+    if (mID == o2::detectors::DetID::ITS) {
+      geom = o2::its::GeometryTGeo::Instance();
+    } else {
+      geom = o2::mft::GeometryTGeo::Instance();
+    }
+    geom->fillMatrixCache(o2::math_utils::bit2Mask(o2::math_utils::TransformType::L2G)); // make sure L2G matrices are loaded
+    mDigitizer.setGeometry(geom);
+    mDigitizer.init();
   }
 
   bool mWithMCTruth = true;
@@ -279,9 +273,6 @@ class ITSDPLDigitizerTask : public ITSMFTDPLDigitizerTask
     mID = DETID;
     mOrigin = DETOR;
   }
-  void setDigitizationOptions() override
-  {
-  }
 };
 
 constexpr o2::detectors::DetID::ID ITSDPLDigitizerTask::DETID;
@@ -298,33 +289,6 @@ class MFTDPLDigitizerTask : public ITSMFTDPLDigitizerTask
   {
     mID = DETID;
     mOrigin = DETOR;
-  }
-
-  void setDigitizationOptions() override
-  {
-    auto& dopt = o2::itsmft::DPLDigitizerParam<DETID>::Instance();
-    auto& aopt = o2::itsmft::DPLAlpideParam<DETID>::Instance();
-    auto& digipar = mDigitizer.getParams();
-    digipar.setContinuous(dopt.continuous);
-    digipar.setContinuous(dopt.continuous);
-    if (dopt.continuous) {
-      auto frameNS = aopt.roFrameLengthInBC * o2::constants::lhc::LHCBunchSpacingNS;
-      digipar.setROFrameLengthInBC(aopt.roFrameLengthInBC);
-      digipar.setROFrameLength(frameNS);                                                                       // RO frame in ns
-      digipar.setStrobeDelay(aopt.strobeDelay);                                                                // Strobe delay wrt beginning of the RO frame, in ns
-      digipar.setStrobeLength(aopt.strobeLengthCont > 0 ? aopt.strobeLengthCont : frameNS - aopt.strobeDelay); // Strobe length in ns
-    } else {
-      digipar.setROFrameLength(aopt.roFrameLengthTrig); // RO frame in ns
-      digipar.setStrobeDelay(aopt.strobeDelay);         // Strobe delay wrt beginning of the RO frame, in ns
-      digipar.setStrobeLength(aopt.strobeLengthTrig);   // Strobe length in ns
-    }
-    // parameters of signal time response: flat-top duration, max rise time and q @ which rise time is 0
-    digipar.getSignalShape().setParameters(dopt.strobeFlatTop, dopt.strobeMaxRiseTime, dopt.strobeQRiseTime0);
-    digipar.setChargeThreshold(dopt.chargeThreshold); // charge threshold in electrons
-    digipar.setNoisePerPixel(dopt.noisePerPixel);     // noise level
-    digipar.setTimeOffset(dopt.timeOffset);
-    digipar.setNSimSteps(dopt.nSimSteps);
-    digipar.setVbb(dopt.Vbb);
   }
 };
 


### PR DESCRIPTION
All initializations of the DigitizerSpec and Digitizer are moved to updateTimeDependentParams
and are made after all info from the CCDB and ConfigurableParams is accounted.