### PR TITLE
Reduce verbosity, throttle warnings

### DIFF
--- a/Detectors/FIT/raw/include/FITRaw/DigitBlockFIT.h
+++ b/Detectors/FIT/raw/include/FITRaw/DigitBlockFIT.h
@@ -110,7 +110,10 @@ auto ConvertEventData2ChData(std::vector<ChannelDataType>& vecChData, const PMDa
   if (isValid) {
     vecChData.emplace_back(static_cast<uint8_t>(globalChID), static_cast<int>(pmData.time), static_cast<int>(pmData.charge), static_cast<uint8_t>(pmData.getFlagWord()));
   } else {
-    LOG(warning) << "Incorrect global channel! linkID: " << linkID << " | EndPoint: " << ep << " | LocalChID: " << pmData.channelID;
+    static int warningCount = 0;
+    if (warningCount++ < 100) {
+      LOG(warning) << "Incorrect global channel! linkID: " << linkID << " | EndPoint: " << ep << " | LocalChID: " << pmData.channelID;
+    }
   }
 }
 // FDD
@@ -122,7 +125,10 @@ auto ConvertEventData2ChData(std::vector<ChannelDataType>& vecChData, const PMDa
   if (isValid) {
     vecChData.emplace_back(static_cast<uint8_t>(globalChID), static_cast<int>(pmData.time), static_cast<int>(pmData.charge), static_cast<uint8_t>(pmData.getFlagWord()));
   } else {
-    LOG(warning) << "Incorrect global channel! linkID: " << linkID << " | EndPoint: " << ep << " | LocalChID: " << pmData.channelID;
+    static int warningCount = 0;
+    if (warningCount++ < 100) {
+      LOG(warning) << "Incorrect global channel! linkID: " << linkID << " | EndPoint: " << ep << " | LocalChID: " << pmData.channelID;
+    }
   }
 }
 //Interface for extracting interaction record from Digit

--- a/Detectors/HMPID/workflow/src/DataDecoderSpec2.cxx
+++ b/Detectors/HMPID/workflow/src/DataDecoderSpec2.cxx
@@ -211,7 +211,7 @@ void DataDecoderTask2::decodeTF(framework::ProcessingContext& pc)
       }
     } catch (int e) {
       // The stream end !
-      LOG(info) << "End Page decoding !";
+      LOG(debug) << "End Page decoding !";
     }
     //   std::cout << ">>>>" << pointerToTheFirst << "," << mDeco->mDigits.size() << std::endl;
     mTriggers.push_back(o2::hmpid::Trigger(mDeco->mIntReco, pointerToTheFirst, mDeco->mDigits.size() - pointerToTheFirst));


### PR DESCRIPTION
@afurs : This disables the warning after 100 messages to reduce log file spam.
If you want, you can add a better soluition, e.g. to silence for few minutes and then restart.