### PR TITLE
Revert "Temporarily disable consumeWhenAllOrdered Policy for ctf-writer"

### DIFF
--- a/Detectors/CTF/workflow/src/ctf-writer-workflow.cxx
+++ b/Detectors/CTF/workflow/src/ctf-writer-workflow.cxx
@@ -40,11 +40,11 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   std::swap(workflowOptions, options);
 }
 
-/*void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
 {
   // ordered policies for the writers
   policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:CTF|ctf).*[W,w]riter.*"));
-}*/
+}
 
 // ------------------------------------------------------------------
 #include "Framework/runDataProcessing.h"


### PR DESCRIPTION
Reverts AliceO2Group/AliceO2#8928

Should be fixed properly now