### PR TITLE
Multiple changes for DCS DP processing

### DIFF
--- a/Detectors/DCS/testWorkflow/src/DCStoDPLconverter.h
+++ b/Detectors/DCS/testWorkflow/src/DCStoDPLconverter.h
@@ -19,6 +19,7 @@
 #include "DetectorsDCS/DataPointIdentifier.h"
 #include "DetectorsDCS/DataPointValue.h"
 #include "DetectorsDCS/DataPointCompositeObject.h"
+#include "CommonUtils/StringUtils.h"
 #include <unordered_map>
 #include <functional>
 #include <string_view>
@@ -50,15 +51,36 @@ using DPCOM = o2::dcs::DataPointCompositeObject;
 /// A callback function to retrieve the FairMQChannel name to be used for sending
 /// messages of the specified OutputSpec
 
-o2f::InjectorFunction dcs2dpl(std::unordered_map<DPID, o2h::DataDescription>& dpid2group, uint64_t startTime, uint64_t step, bool verbose = false)
+o2f::InjectorFunction dcs2dpl(std::unordered_map<DPID, o2h::DataDescription>& dpid2group, bool fbiFirst, bool verbose = false)
 {
 
-  auto timesliceId = std::make_shared<size_t>(startTime);
-  return [dpid2group, timesliceId, step, verbose](TimingInfo&, FairMQDevice& device, FairMQParts& parts, o2f::ChannelRetriever channelRetriever) {
+  return [dpid2group, fbiFirst, verbose](TimingInfo& tinfo, FairMQDevice& device, FairMQParts& parts, o2f::ChannelRetriever channelRetriever) {
     static std::unordered_map<DPID, DPCOM> cache; // will keep only the latest measurement in the 1-second wide window for each DPID
     static auto timer = std::chrono::system_clock::now();
+    static auto timer0 = std::chrono::system_clock::now();
+    static bool seenFBI = false;
+    static uint32_t localTFCounter = 0;
 
     LOG(debug) << "In lambda function: ********* Size of unordered_map (--> number of defined groups) = " << dpid2group.size();
+    // check if we got FBI (Master) or delta (MasterDelta)
+    if (!parts.Size()) {
+      LOGP(warn, "Empty input recieved at timeslice {}", tinfo.timeslice);
+      return;
+    }
+    std::string firstName = std::string((char*)&(reinterpret_cast<const DPCOM*>(parts.At(0)->GetData()))->id);
+    bool isFBI = false;
+    if (o2::utils::Str::endsWith(firstName, "Master")) {
+      isFBI = true;
+      seenFBI = true;
+    } else if (o2::utils::Str::endsWith(firstName, "MasterDelta")) {
+      isFBI = false;
+    } else {
+      LOGP(error, "Cannot determine if the map is FBI or Delta, 1st DP name is {}", firstName);
+    }
+    if (verbose) {
+      LOGP(info, "New input of {} parts received, map type: {}, timeslice {}", parts.Size(), isFBI ? "FBI" : "Delta", tinfo.timeslice);
+    }
+
     // We first iterate over the parts of the received message
     for (size_t i = 0; i < parts.Size(); ++i) {             // DCS sends only 1 part, but we should be able to receive more
       auto nDPCOM = parts.At(i)->GetSize() / sizeof(DPCOM); // number of DPCOM in current part
@@ -76,9 +98,18 @@ o2f::InjectorFunction dcs2dpl(std::unordered_map<DPID, o2h::DataDescription>& dp
     }
 
     auto timerNow = std::chrono::system_clock::now();
+    if (fbiFirst && !seenFBI) {
+      static int prevDelay = 0;
+      std::chrono::duration<double, std::ratio<1>> duration = timerNow - timer0;
+      int delay = duration.count();
+      if (delay > prevDelay) {
+        LOGP(info, "Waiting for requested 1st FBI since {} s", delay);
+        prevDelay = delay;
+      }
+    }
+
     std::chrono::duration<double, std::ratio<1>> duration = timerNow - timer;
-    if (duration.count() > 1) { //did we accumulate for 1 sec?
-      *timesliceId += step;     // we increment only if we send something
+    if (duration.count() > 1 && (seenFBI || !fbiFirst)) { // did we accumulate for 1 sec and have we seen FBI if it was requested?
       std::unordered_map<o2h::DataDescription, pmr::vector<DPCOM>, std::hash<o2h::DataDescription>> outputs;
       // in the cache we have the final values of the DPs that we should put in the output
       // distribute DPs over the vectors for each requested output
@@ -89,45 +120,57 @@ o2f::InjectorFunction dcs2dpl(std::unordered_map<DPID, o2h::DataDescription>& dp
         }
       }
       std::uint64_t creation = std::chrono::time_point_cast<std::chrono::milliseconds>(timerNow).time_since_epoch().count();
+      std::unordered_map<std::string, std::unique_ptr<FairMQParts>> messagesPerRoute;
       // create and send output messages
-      for (auto& it : outputs) {
+      for (auto& it : outputs) { // distribute messages per routes
         o2h::DataHeader hdr(it.first, "DCS", 0);
         o2f::OutputSpec outsp{hdr.dataOrigin, hdr.dataDescription, hdr.subSpecification};
         if (it.second.empty()) {
           LOG(warning) << "No data for OutputSpec " << outsp;
           continue;
         }
-        auto channel = channelRetriever(outsp, *timesliceId);
+        auto channel = channelRetriever(outsp, tinfo.timeslice);
         if (channel.empty()) {
           LOG(warning) << "No output channel found for OutputSpec " << outsp << ", discarding its data";
           it.second.clear();
           continue;
         }
 
-        hdr.tfCounter = *timesliceId; // this also
+        hdr.tfCounter = localTFCounter; // this also
         hdr.payloadSerializationMethod = o2h::gSerializationMethodNone;
         hdr.splitPayloadParts = 1;
         hdr.splitPayloadIndex = 1;
         hdr.payloadSize = it.second.size() * sizeof(DPCOM);
         hdr.firstTForbit = 0; // this should be irrelevant for DCS
-        o2h::Stack headerStack{hdr, o2::framework::DataProcessingHeader{*timesliceId, 1, creation}};
+        o2h::Stack headerStack{hdr, o2::framework::DataProcessingHeader{tinfo.timeslice, 1, creation}};
         auto fmqFactory = device.GetChannel(channel).Transport();
         auto hdMessage = fmqFactory->CreateMessage(headerStack.size(), fair::mq::Alignment{64});
         auto plMessage = fmqFactory->CreateMessage(hdr.payloadSize, fair::mq::Alignment{64});
         memcpy(hdMessage->GetData(), headerStack.data(), headerStack.size());
         memcpy(plMessage->GetData(), it.second.data(), hdr.payloadSize);
+
+        FairMQParts* parts2send = messagesPerRoute[channel].get(); // FairMQParts*
+        if (!parts2send) {
+          messagesPerRoute[channel] = std::make_unique<FairMQParts>();
+          parts2send = messagesPerRoute[channel].get();
+        }
+        parts2send->AddPart(std::move(hdMessage));
+        parts2send->AddPart(std::move(plMessage));
         if (verbose) {
-          LOGP(info, "Pushing {} DPs to {} for TimeSlice {} at {}", it.second.size(), o2f::DataSpecUtils::describe(outsp), *timesliceId, creation);
+          LOGP(info, "Pushing {} DPs to {} for TimeSlice {} at {}", it.second.size(), o2f::DataSpecUtils::describe(outsp), tinfo.timeslice, creation);
         }
         it.second.clear();
-        FairMQParts outParts;
-        outParts.AddPart(std::move(hdMessage));
-        outParts.AddPart(std::move(plMessage));
-        o2f::sendOnChannel(device, outParts, channel, *timesliceId);
       }
-
+      // push output of every route
+      for (auto& msgIt : messagesPerRoute) {
+        LOG(info) << "Sending " << msgIt.second->Size() / 2 << " parts to channel " << msgIt.first;
+        o2f::sendOnChannel(device, *msgIt.second.get(), msgIt.first, tinfo.timeslice);
+      }
       timer = timerNow;
       cache.clear();
+      if (!messagesPerRoute.empty()) {
+        localTFCounter++;
+      }
     }
   };
 }

--- a/Detectors/DCS/testWorkflow/src/dcs-proxy.cxx
+++ b/Detectors/DCS/testWorkflow/src/dcs-proxy.cxx
@@ -44,6 +44,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
   workflowOptions.push_back(ConfigParamSpec{"verbose", VariantType::Bool, false, {"verbose output"}});
   workflowOptions.push_back(ConfigParamSpec{"test-mode", VariantType::Bool, false, {"test mode"}});
+  workflowOptions.push_back(ConfigParamSpec{"may-send-delta-first", VariantType::Bool, false, {"if true, do not wait for FBI before sending 1st output"}});
   workflowOptions.push_back(ConfigParamSpec{"ccdb-url", VariantType::String, "http://ccdb-test.cern.ch:8080", {"url of CCDB to get the detectors DPs configuration"}});
   workflowOptions.push_back(ConfigParamSpec{"detector-list", VariantType::String, "TOF, MCH", {"list of detectors for which to process DCS"}});
   workflowOptions.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}});
@@ -56,6 +57,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
 
   bool verbose = config.options().get<bool>("verbose");
   bool testMode = config.options().get<bool>("test-mode");
+  bool fbiFirst = !config.options().get<bool>("may-send-delta-first");
   std::string detectorList = config.options().get<std::string>("detector-list");
   o2::conf::ConfigurableParam::updateFromString(config.options().get<std::string>("configKeyValues"));
   std::string url = config.options().get<std::string>("ccdb-url");
@@ -110,7 +112,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
     "dcs-proxy",
     std::move(dcsOutputs),
     "type=pull,method=connect,address=tcp://aldcsadaposactor:60000,rateLogging=1,transport=zeromq",
-    dcs2dpl(dpid2DataDesc, 0, 1, verbose));
+    dcs2dpl(dpid2DataDesc, fbiFirst, verbose));
 
   WorkflowSpec workflow;
   workflow.emplace_back(dcsProxy);

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCDCSProcessor.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCDCSProcessor.h
@@ -126,7 +126,7 @@ void EMCDCSProcessor::prepareCCDBobjectInfo(const T& obj, CcdbObjectInfo& info, 
   info.setObjectType(clName);
   info.setFileName(flName);
   info.setStartValidityTimestamp(tf);
-  info.setEndValidityTimestamp(o2::ccdb::CcdbObjectInfo::INFINITE_TIMESTAMP);
+  info.setEndValidityTimestamp(tf + o2::ccdb::CcdbObjectInfo::MONTH);
   info.setMetaData(md);
 }
 

--- a/Detectors/GRP/calibration/src/GRPDCSDPsProcessor.cxx
+++ b/Detectors/GRP/calibration/src/GRPDCSDPsProcessor.cxx
@@ -58,8 +58,7 @@ int GRPDCSDPsProcessor::process(const gsl::span<const DPCOM> dps)
       LOG(debug) << "DP " << it.first << " found in list of DPs expected for GRP";
     }
   }
-
-  mUpdateMagField = false;    // by default, we do not foresee a new entry in the CCDB for the B field
+  mMagFieldHelper.updated = false;
   mUpdateEnvVars = false;     // by default, we do not foresee a new entry in the CCDB for the Env Var
   mUpdateCollimators = false; // by default, we do not foresee a new entry in the CCDB for the Collimators
   mUpdateLHCIFInfo = false;   // by default, we do not foresee a new entry in the CCDB for the LHCIF DPs
@@ -76,7 +75,7 @@ int GRPDCSDPsProcessor::process(const gsl::span<const DPCOM> dps)
     mPids[it.id] = true;
   }
 
-  if (mUpdateMagField) {
+  if (isMagFieldUpdated()) {
     updateMagFieldCCDB();
   }
   if (mUpdateEnvVars) {
@@ -89,11 +88,11 @@ int GRPDCSDPsProcessor::process(const gsl::span<const DPCOM> dps)
     updateLHCIFInfoCCDB();
   }
 
+  mCallSlice++;
   return 0;
 }
 
 //__________________________________________________________________
-
 int GRPDCSDPsProcessor::processDP(const DPCOM& dpcom)
 {
 
@@ -116,66 +115,22 @@ int GRPDCSDPsProcessor::processDP(const DPCOM& dpcom)
   }
   auto flags = val.get_flags();
   if (processFlags(flags, dpid.get_alias()) == 0) {
-
     // now I need to access the correct element
     std::string aliasStr(dpid.get_alias());
     // LOG(info) << "alias 0 = " << aliasStr;
     //  B-field DPs
-    if (aliasStr.find("Current") != string::npos || aliasStr.find("Polarity") != string::npos) { // B-field DPs
-      mUpdateMagField = true;
-      if (aliasStr == "L3Current") {
-        mMagField.setL3Current(std::signbit(mMagField.getL3Current()) ? -static_cast<float>(o2::dcs::getValue<double>(dpcom)) : static_cast<float>(o2::dcs::getValue<double>(dpcom))); // true is negative field
-        if (mVerbose) {
-          LOG(info) << "Updating L3 current with value " << mMagField.getL3Current();
-        }
-      } else if (aliasStr == "L3Polarity") {
-        mMagField.setL3Current(o2::dcs::getValue<bool>(dpcom) ? -mMagField.getL3Current() : mMagField.getL3Current()); // true is negative field
-        if (mVerbose) {
-          LOG(info) << "Updating L3 polarity with value " << std::signbit(mMagField.getL3Current()); // poisitive is false, negative is true
-        }
-      } else if (aliasStr == "DipoleCurrent") {
-        mMagField.setDipoleCurrent(std::signbit(mMagField.getDipoleCurrent()) ? -static_cast<float>(o2::dcs::getValue<double>(dpcom)) : static_cast<float>(o2::dcs::getValue<double>(dpcom))); // true is negative field
-        if (mVerbose) {
-          LOG(info) << "Updating Dipole current with value " << mMagField.getDipoleCurrent();
-        }
-      } else if (aliasStr == "DipolePolarity") {
-        mMagField.setDipoleCurrent(o2::dcs::getValue<bool>(dpcom) ? -mMagField.getDipoleCurrent() : mMagField.getDipoleCurrent()); // true is negative field
-        if (mVerbose) {
-          LOG(info) << "Updating Dipole polarity with value " << std::signbit(mMagField.getDipoleCurrent()); // poisitive is false, negative is true
-        }
-      } else {
-        if (mVerbose) {
-          LOG(info) << "Alias " << aliasStr << " seemd from B field, but it is not recognized";
-        }
-        mUpdateMagField = false;
-      }
+    if (aliasStr == "L3Current") {
+      mMagFieldHelper.updateCurL3(static_cast<float>(o2::dcs::getValue<double>(dpcom)));
+    } else if (aliasStr == "DipoleCurrent") {
+      mMagFieldHelper.updateCurDip(static_cast<float>(o2::dcs::getValue<double>(dpcom)));
+    } else if (aliasStr == "L3Polarity") {
+      mMagFieldHelper.updateSignL3(o2::dcs::getValue<bool>(dpcom)); // true is negative
+    } else if (aliasStr == "DipolePolarity") {
+      mMagFieldHelper.updateSignDip(o2::dcs::getValue<bool>(dpcom)); // true is negative
+    } else if (processEnvVar(dpcom)) {                               // environment variables
+    } else if (processCollimators(dpcom)) {
     } else {
-      // environment variables
-      if (aliasStr.find("Cavern") != string::npos || aliasStr.find("Surface") != string::npos) {
-        if (mVerbose) {
-          LOG(info) << "Alias " << aliasStr << " seems from Env Variables";
-        }
-        processEnvVar(dpcom);
-      }
-
-      else {
-        // Collimators
-        if (aliasStr.find("Collimator") != string::npos) {
-          // this is a collimator
-          if (mVerbose) {
-            LOG(info) << "Alias " << aliasStr << " seems from Collimators";
-          }
-          processCollimators(dpcom);
-        }
-
-        else {
-          // the rest should all be LHCIF DPs
-          if (mVerbose) {
-            LOG(info) << "Alias " << aliasStr << " should be related to LHCIF";
-          }
-          processLHCIFDPs(dpcom);
-        }
-      }
+      processLHCIFDPs(dpcom);
     }
   }
   return 0;
@@ -183,43 +138,40 @@ int GRPDCSDPsProcessor::processDP(const DPCOM& dpcom)
 
 //______________________________________________________________________
 
-void GRPDCSDPsProcessor::processCollimators(const DPCOM& dpcom)
+bool GRPDCSDPsProcessor::processCollimators(const DPCOM& dpcom)
 {
 
   // function to process Data Points that are related to the collimators
-
-  processPair(dpcom, "LHC_CollimatorPos_TCLIA_4R2_lvdt_gap_downstream", mCollimators.mgap_downstream, mUpdateCollimators);
-  processPair(dpcom, "LHC_CollimatorPos_TCLIA_4R2_lvdt_gap_upstream", mCollimators.mgap_upstream, mUpdateCollimators);
-  processPair(dpcom, "LHC_CollimatorPos_TCLIA_4R2_lvdt_left_downstream", mCollimators.mleft_downstream, mUpdateCollimators);
-  processPair(dpcom, "LHC_CollimatorPos_TCLIA_4R2_lvdt_left_upstream", mCollimators.mleft_upstream, mUpdateCollimators);
-  processPair(dpcom, "LHC_CollimatorPos_TCLIA_4R2_lvdt_right_downstream", mCollimators.mright_downstream, mUpdateCollimators);
-  processPair(dpcom, "LHC_CollimatorPos_TCLIA_4R2_lvdt_right_upstream", mCollimators.mright_upstream, mUpdateCollimators);
+  bool match = processPairD(dpcom, "LHC_CollimatorPos_TCLIA_4R2_lvdt_gap_downstream", mCollimators.mgap_downstream, mUpdateCollimators) ||
+               processPairD(dpcom, "LHC_CollimatorPos_TCLIA_4R2_lvdt_gap_upstream", mCollimators.mgap_upstream, mUpdateCollimators) ||
+               processPairD(dpcom, "LHC_CollimatorPos_TCLIA_4R2_lvdt_left_downstream", mCollimators.mleft_downstream, mUpdateCollimators) ||
+               processPairD(dpcom, "LHC_CollimatorPos_TCLIA_4R2_lvdt_left_upstream", mCollimators.mleft_upstream, mUpdateCollimators) ||
+               processPairD(dpcom, "LHC_CollimatorPos_TCLIA_4R2_lvdt_right_downstream", mCollimators.mright_downstream, mUpdateCollimators) ||
+               processPairD(dpcom, "LHC_CollimatorPos_TCLIA_4R2_lvdt_right_upstream", mCollimators.mright_upstream, mUpdateCollimators);
   if (mVerbose) {
-    LOG(info) << "update collimators = " << mUpdateCollimators;
+    LOG(info) << "update collimators = " << mUpdateCollimators << " matched: " << match;
   }
-  return;
+  return match;
 }
 
 //______________________________________________________________________
 
-void GRPDCSDPsProcessor::processEnvVar(const DPCOM& dpcom)
+bool GRPDCSDPsProcessor::processEnvVar(const DPCOM& dpcom)
 {
 
   // function to process Data Points that are related to env variables
-
-  processPair(dpcom, "CavernTemperature", mEnvVars.mCavernTemperature, mUpdateEnvVars);
-  processPair(dpcom, "CavernAtmosPressure", mEnvVars.mCavernAtmosPressure, mUpdateEnvVars);
-  processPair(dpcom, "SurfaceAtmosPressure", mEnvVars.mSurfaceAtmosPressure, mUpdateEnvVars);
-  processPair(dpcom, "CavernAtmosPressure2", mEnvVars.mCavernAtmosPressure2, mUpdateEnvVars);
+  bool match = processPairD(dpcom, "CavernTemperature", mEnvVars.mCavernTemperature, mUpdateEnvVars) ||
+               processPairD(dpcom, "CavernAtmosPressure", mEnvVars.mCavernAtmosPressure, mUpdateEnvVars) ||
+               processPairD(dpcom, "SurfaceAtmosPressure", mEnvVars.mSurfaceAtmosPressure, mUpdateEnvVars) ||
+               processPairD(dpcom, "CavernAtmosPressure2", mEnvVars.mCavernAtmosPressure2, mUpdateEnvVars);
   if (mVerbose) {
-    LOG(info) << "update env vars = " << mUpdateEnvVars;
+    LOG(info) << "update env vars = " << mUpdateEnvVars << " matched: " << match;
   }
-  return;
+  return match;
 }
 
 //______________________________________________________________________
-
-void GRPDCSDPsProcessor::processPair(const DPCOM& dpcom, const std::string& alias, std::pair<uint64_t, double>& p, bool& flag)
+bool GRPDCSDPsProcessor::processPairD(const DPCOM& dpcom, const std::string& alias, std::pair<uint64_t, double>& p, bool& flag)
 {
 
   // function to process Data Points that is stored in a pair
@@ -229,7 +181,7 @@ void GRPDCSDPsProcessor::processPair(const DPCOM& dpcom, const std::string& alia
   std::string aliasStr(dpid.get_alias());
 
   if (mVerbose) {
-    LOG(info) << "Processing alias " << aliasStr;
+    LOG(info) << "comparing DP alias " << aliasStr << " to " << alias;
   }
 
   if (aliasStr == alias) {
@@ -237,8 +189,42 @@ void GRPDCSDPsProcessor::processPair(const DPCOM& dpcom, const std::string& alia
       LOG(info) << "It matches the requested string " << alias << ", let's check if the value needs to be updated";
     }
     flag = compareAndUpdate(p, dpcom);
+    return true;
   }
-  return;
+  return false;
+}
+
+//______________________________________________________________________
+bool GRPDCSDPsProcessor::processPairS(const DPCOM& dpcom, const std::string& alias, std::pair<uint64_t, std::string>& p, bool& flag)
+{
+
+  // function to process string Data Points that is stored in a pair
+
+  auto& dpcomdata = dpcom.data;
+  auto& dpid = dpcom.id;
+  std::string aliasStr(dpid.get_alias());
+
+  if (mVerbose) {
+    LOG(info) << "comparing string DP alias " << aliasStr << " to " << alias;
+  }
+
+  if (aliasStr == alias) {
+    auto val = o2::dcs::getValue<std::string>(dpcom);
+    if (mVerbose) {
+      LOG(info) << "It matches the requested string " << alias << ", let's check if the value needs to be updated";
+      LOG(info) << "old value = " << p.second << ", new value = " << val << ", call " << mCallSlice;
+    }
+    if (mCallSlice == 0 || (val != p.second)) {
+      p.first = dpcomdata.get_epoch_time();
+      p.second = val;
+      flag = true;
+      if (mVerbose) {
+        LOG(info) << "Updating value " << alias << " with timestamp " << p.first;
+      }
+    }
+    return true;
+  }
+  return false;
 }
 
 //______________________________________________________________________
@@ -251,9 +237,9 @@ bool GRPDCSDPsProcessor::compareAndUpdate(std::pair<uint64_t, double>& p, const 
   double val = o2::dcs::getValue<double>(dpcom);
   auto& dpcomdata = dpcom.data;
   if (mVerbose) {
-    LOG(info) << "old value = " << p.second << ", new value = " << val << ", absolute difference = " << std::abs(p.second - val);
+    LOG(info) << "old value = " << p.second << ", new value = " << val << ", absolute difference = " << std::abs(p.second - val) << " call " << mCallSlice;
   }
-  if (std::abs(p.second - val) > 0.5e-7 * (std::abs(p.second) + std::abs(val))) {
+  if (mCallSlice == 0 || (std::abs(p.second - val) > 0.5e-7 * (std::abs(p.second) + std::abs(val)))) {
     p.first = dpcomdata.get_epoch_time();
     p.second = val;
     if (mVerbose) {
@@ -343,46 +329,19 @@ bool GRPDCSDPsProcessor::processLHCIFDPs(const DPCOM& dpcom)
     if (aliasStr.find(fmt::format("{}{}", "ALI_Background", ibkg)) != string::npos) {
       double val = o2::dcs::getValue<double>(dpcom);
       mLHCInfo.mBackground[ibkg - 1].emplace_back(dpcomdata.get_epoch_time(), val);
-      LOG(info) << "Adding value " << val << " with timestamp " << dpcomdata.get_epoch_time() << " to mBackground[" << ibkg - 1 << "]";
       if (mVerbose) {
         LOG(info) << "Adding value " << val << " with timestamp " << dpcomdata.get_epoch_time() << " to mBackground[" << ibkg - 1 << "]";
       }
       return true;
     }
   }
-  if (aliasStr == "ALI_Lumi_Source_Name") {
-    std::string val = o2::dcs::getValue<std::string>(dpcom);
-    mLHCInfo.mLumiSource.first = dpcomdata.get_epoch_time();
-    mLHCInfo.mLumiSource.second = val;
-    LOG(info) << "Updating value " << val << " with timestamp " << dpcomdata.get_epoch_time() << " for mLumiSource";
-    if (mVerbose) {
-      LOG(info) << "Updating value " << val << " with timestamp " << dpcomdata.get_epoch_time() << " for mLumiSource";
-    }
-    mUpdateLHCIFInfo = true; // we force the update of the LHCIF if the lumi source changes
+  if (processPairS(dpcom, "ALI_Lumi_Source_Name", mLHCInfo.mLumiSource, mUpdateLHCIFInfo)) {
     return true;
   }
-
-  if (aliasStr == "MACHINE_MODE") {
-    std::string val = o2::dcs::getValue<std::string>(dpcom);
-    mLHCInfo.mMachineMode.first = dpcomdata.get_epoch_time();
-    mLHCInfo.mMachineMode.second = val;
-    LOG(info) << "Updating value " << val << " with timestamp " << dpcomdata.get_epoch_time() << " for mMachineMode";
-    if (mVerbose) {
-      LOG(info) << "Updating value " << val << " with timestamp " << dpcomdata.get_epoch_time() << " for mMachineMode";
-    }
-    mUpdateLHCIFInfo = true; // we force the update of the LHCIF if the machine mode (ION PHYSICS, PROTON PHYSICS..., see https://lhc-commissioning.web.cern.ch/systems/data-exchange/doc/LHC-OP-ES-0005-10-00.pdf) changes
+  if (processPairS(dpcom, "MACHINE_MODE", mLHCInfo.mMachineMode, mUpdateLHCIFInfo)) {
     return true;
   }
-  if (aliasStr == "BEAM_MODE") {
-    std::string val = o2::dcs::getValue<std::string>(dpcom);
-    LOG(info) << "Updating value " << val << " with timestamp " << dpcomdata.get_epoch_time() << " for mBeamMode";
-    mLHCInfo.mBeamMode.first = dpcomdata.get_epoch_time();
-    mLHCInfo.mBeamMode.second = val;
-    if (mVerbose) {
-      LOG(info) << "Updating value " << val << " with timestamp " << dpcomdata.get_epoch_time() << " for mBeamMode";
-    }
-
-    mUpdateLHCIFInfo = true; // we force the update of the LHCIF if the beam mode (SETUP, RAMP, STABLE BEAMS..., see https://lhc-commissioning.web.cern.ch/systems/data-exchange/doc/LHC-OP-ES-0005-10-00.pdf) changes
+  if (processPairS(dpcom, "BEAM_MODE", mLHCInfo.mBeamMode, mUpdateLHCIFInfo)) {
     return true;
   }
 
@@ -394,16 +353,20 @@ bool GRPDCSDPsProcessor::processLHCIFDPs(const DPCOM& dpcom)
 
 void GRPDCSDPsProcessor::updateMagFieldCCDB()
 {
-
   // we need to update a CCDB for the B field --> let's prepare the CCDBInfo
-
   if (mVerbose) {
     LOG(info) << "At least one DP related to B field changed --> we will update CCDB with startTime " << mStartValidity;
   }
+  if (mMagFieldHelper.isSet != (0x1 << 4) - 1) {
+    LOG(alarm) << "Magnetic field was updated but not all fields were set: no FBI was seen?";
+    mMagFieldHelper.updated = false;
+    return;
+  }
+  mMagField.setL3Current(mMagFieldHelper.negL3 ? -mMagFieldHelper.curL3 : mMagFieldHelper.curL3);
+  mMagField.setDipoleCurrent(mMagFieldHelper.negDip ? -mMagFieldHelper.curDip : mMagFieldHelper.curDip);
   std::map<std::string, std::string> md;
   md["responsible"] = "Chiara Zampolli";
-  o2::calibration::Utils::prepareCCDBobjectInfo(mMagField, mccdbMagFieldInfo, "GLO/Config/GRPMagField", md, mStartValidity, o2::ccdb::CcdbObjectInfo::INFINITE_TIMESTAMP);
-  return;
+  o2::calibration::Utils::prepareCCDBobjectInfo(mMagField, mccdbMagFieldInfo, "GLO/Config/GRPMagField", md, mStartValidity, mStartValidity + o2::ccdb::CcdbObjectInfo::MONTH);
 }
 
 //______________________________________________________________________
@@ -418,7 +381,7 @@ void GRPDCSDPsProcessor::updateLHCIFInfoCCDB()
   }
   std::map<std::string, std::string> md;
   md["responsible"] = "Chiara Zampolli";
-  o2::calibration::Utils::prepareCCDBobjectInfo(mLHCInfo, mccdbLHCIFInfo, "GLO/Config/LHCIF", md, mStartValidity, mStartValidity + 3 * 24L * 3600000); // valid for 3 days
+  o2::calibration::Utils::prepareCCDBobjectInfo(mLHCInfo, mccdbLHCIFInfo, "GLO/Config/LHCIF", md, mStartValidity, mStartValidity + 3 * o2::ccdb::CcdbObjectInfo::DAY); // valid for 3 days
   return;
 }
 
@@ -434,7 +397,7 @@ void GRPDCSDPsProcessor::updateEnvVarsCCDB()
   }
   std::map<std::string, std::string> md;
   md["responsible"] = "Chiara Zampolli";
-  o2::calibration::Utils::prepareCCDBobjectInfo(mEnvVars, mccdbEnvVarsInfo, "GLO/Config/EnvVars", md, mStartValidity, mStartValidity + 3 * 24L * 3600000); // valid for 3 days
+  o2::calibration::Utils::prepareCCDBobjectInfo(mEnvVars, mccdbEnvVarsInfo, "GLO/Config/EnvVars", md, mStartValidity, mStartValidity + 3 * o2::ccdb::CcdbObjectInfo::DAY); // valid for 3 days
   return;
 }
 
@@ -450,6 +413,6 @@ void GRPDCSDPsProcessor::updateCollimatorsCCDB()
   }
   std::map<std::string, std::string> md;
   md["responsible"] = "Chiara Zampolli";
-  o2::calibration::Utils::prepareCCDBobjectInfo(mEnvVars, mccdbCollimatorsInfo, "GLO/Config/Collimators", md, mStartValidity, mStartValidity + 3 * 24L * 3600000); // valid for 3 days
+  o2::calibration::Utils::prepareCCDBobjectInfo(mEnvVars, mccdbCollimatorsInfo, "GLO/Config/Collimators", md, mStartValidity, mStartValidity + 3 * o2::ccdb::CcdbObjectInfo::DAY); // valid for 3 days
   return;
 }

--- a/Detectors/ITSMFT/MFT/condition/include/MFTCondition/MFTDCSProcessor.h
+++ b/Detectors/ITSMFT/MFT/condition/include/MFTCondition/MFTDCSProcessor.h
@@ -122,7 +122,7 @@ void MFTDCSProcessor::prepareCCDBobjectInfo(T& obj, CcdbObjectInfo& info, const 
   info.setObjectType(clName);
   info.setFileName(flName);
   info.setStartValidityTimestamp(tf);
-  info.setEndValidityTimestamp(o2::ccdb::CcdbObjectInfo::INFINITE_TIMESTAMP);
+  info.setEndValidityTimestamp(tf + o2::ccdb::CcdbObjectInfo::MONTH);
   info.setMetaData(md);
 }
 

--- a/Detectors/ITSMFT/MFT/condition/testWorkflow/MFTDCSDataProcessorSpec.h
+++ b/Detectors/ITSMFT/MFT/condition/testWorkflow/MFTDCSDataProcessorSpec.h
@@ -78,8 +78,6 @@ class MFTDCSDataProcessor : public o2::framework::Task
 
       auto& mgr = CcdbManager::instance();
       mgr.setURL(o2::base::NameConf::getCCDBServer());
-      CcdbApi api;
-      api.init(mgr.getURL());
       long ts = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
       std::unordered_map<DPID, std::string>* dpid2DataDesc = mgr.getForTimeStamp<std::unordered_map<DPID, std::string>>("MFT/Config/DCSDPconfig", ts);
       for (auto& i : *dpid2DataDesc) {

--- a/Detectors/TOF/calibration/src/TOFDCSProcessor.cxx
+++ b/Detectors/TOF/calibration/src/TOFDCSProcessor.cxx
@@ -393,7 +393,7 @@ void TOFDCSProcessor::updateDPsCCDB()
   }
   std::map<std::string, std::string> md;
   md["responsible"] = "Chiara Zampolli";
-  o2::calibration::Utils::prepareCCDBobjectInfo(mTOFDCS, mccdbDPsInfo, "TOF/Calib/DCSDPs", md, mStartValidity, 3 * 24L * 3600000);
+  o2::calibration::Utils::prepareCCDBobjectInfo(mTOFDCS, mccdbDPsInfo, "TOF/Calib/DCSDPs", md, mStartValidity, mStartValidity + 3 * o2::ccdb::CcdbObjectInfo::DAY);
 
   return;
 }
@@ -410,7 +410,7 @@ void TOFDCSProcessor::updateFEACCCDB()
   }
   std::map<std::string, std::string> md;
   md["responsible"] = "Chiara Zampolli";
-  o2::calibration::Utils::prepareCCDBobjectInfo(mFeac, mccdbLVInfo, "TOF/Calib/LVStatus", md, mStartValidity, o2::ccdb::CcdbObjectInfo::INFINITE_TIMESTAMP);
+  o2::calibration::Utils::prepareCCDBobjectInfo(mFeac, mccdbLVInfo, "TOF/Calib/LVStatus", md, mStartValidity, mStartValidity + o2::ccdb::CcdbObjectInfo::MONTH);
   return;
 }
 
@@ -426,7 +426,7 @@ void TOFDCSProcessor::updateHVCCDB()
   }
   std::map<std::string, std::string> md;
   md["responsible"] = "Chiara Zampolli";
-  o2::calibration::Utils::prepareCCDBobjectInfo(mHV, mccdbHVInfo, "TOF/Calib/HVStatus", md, mStartValidity, o2::ccdb::CcdbObjectInfo::INFINITE_TIMESTAMP);
+  o2::calibration::Utils::prepareCCDBobjectInfo(mHV, mccdbHVInfo, "TOF/Calib/HVStatus", md, mStartValidity, mStartValidity + o2::ccdb::CcdbObjectInfo::MONTH);
   return;
 }
 

--- a/Detectors/TOF/calibration/testWorkflow/TOFDCSDataProcessorSpec.h
+++ b/Detectors/TOF/calibration/testWorkflow/TOFDCSDataProcessorSpec.h
@@ -68,8 +68,6 @@ class TOFDCSDataProcessor : public o2::framework::Task
       std::string ccdbpath = ic.options().get<std::string>("ccdb-path");
       auto& mgr = CcdbManager::instance();
       mgr.setURL(ccdbpath);
-      CcdbApi api;
-      api.init(mgr.getURL());
       long ts = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
       std::unordered_map<DPID, std::string>* dpid2DataDesc = mgr.getForTimeStamp<std::unordered_map<DPID, std::string>>("TOF/Config/DCSDPconfig", ts);
       for (auto& i : *dpid2DataDesc) {

--- a/Detectors/TRD/calibration/workflow/TRDDCSDataProcessorSpec.h
+++ b/Detectors/TRD/calibration/workflow/TRDDCSDataProcessorSpec.h
@@ -79,8 +79,6 @@ class TRDDCSDataProcessor : public o2::framework::Task
       std::string ccdbpath = ic.options().get<std::string>("ccdb-path");
       auto& mgr = o2::ccdb::BasicCCDBManager::instance();
       mgr.setURL(ccdbpath);
-      o2::ccdb::CcdbApi api;
-      api.init(mgr.getURL());
       long ts = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
       std::unordered_map<DPID, std::string>* dpid2DataDesc = mgr.getForTimeStamp<std::unordered_map<DPID, std::string>>("TRD/Config/DCSDPconfig", ts);
       for (auto& i : *dpid2DataDesc) {


### PR DESCRIPTION
* dcs-proxy: group outputs per channel, option to send IBF first.    
The output from the proxy will be grouped per channel. Unless `--may-send-delta-first` option is explicitly requested, the dcs-proxy will delay its 1st output until the FBI is seen
* Make sure GRPMagField data is complete before uploading to CCDB
* Suppress unused instances of CcdbApi
* Change INFINITE_TIMESTAMP to MONTH in TOF, EMC and MFT processors 

@chiarazampolli @noferini @mpoghos @syano0822 Note that I've changed in your processors the validity time from INFINITE to 1 month. If needed, the objects validity may be extended later. I have some ideas on how to limit the number of overlaps w/o the risk of creating holes in the coverage.
