### PR TITLE
Fix MFT DCS DP processor

### DIFF
--- a/Detectors/ITSMFT/MFT/condition/src/MFTDCSProcessor.cxx
+++ b/Detectors/ITSMFT/MFT/condition/src/MFTDCSProcessor.cxx
@@ -63,19 +63,20 @@ int MFTDCSProcessor::process(const gsl::span<const DPCOM> dps)
     mStartTFset = true;
   }
 
-  std::unordered_map<DPID, DPVAL> mapin;
-  for (auto& it : dps) {
-    mapin[it.id] = it.data;
-  }
-  for (auto& it : mPids) {
-    const auto& el = mapin.find(it.first);
-    if (el == mapin.end()) {
-      LOG(debug) << "DP " << it.first << " not found in map";
-    } else {
-      LOG(debug) << "DP " << it.first << " found in map";
+  if (false) { // RS: why do we need to lose CPU on this dummy check?
+    std::unordered_map<DPID, DPVAL> mapin;
+    for (auto& it : dps) {
+      mapin[it.id] = it.data;
+    }
+    for (auto& it : mPids) {
+      const auto& el = mapin.find(it.first);
+      if (el == mapin.end()) {
+        LOG(debug) << "DP " << it.first << " not found in map";
+      } else {
+        LOG(debug) << "DP " << it.first << " found in map";
+      }
     }
   }
-
   // now we process all DPs, one by one
   for (const auto& it : dps) {
     // we process only the DPs defined in the configuration
@@ -91,7 +92,6 @@ int MFTDCSProcessor::process(const gsl::span<const DPCOM> dps)
     processDP(new_it);
     */
     processDP(it);
-
     mPids[it.id] = true;
   }
 
@@ -156,11 +156,12 @@ void MFTDCSProcessor::updateDPsCCDB()
     double double_value;
   } converter0, converter1;
 
-  for (const auto& it : mPids) {
+  for (auto& it : mPids) {
     const auto& type = it.first.get_type();
     if (type == o2::dcs::DPVAL_DOUBLE) {
       auto& mftdcs = mMFTDCS[it.first];
-      if (it.second == true) { // we processed the DP at least 1x
+      if (it.second) {     // we processed the DP at least 1x
+        it.second = false; // once the point was used, reset it
         auto& dpvect = mDpsdoublesmap[it.first];
         mftdcs.firstValue.first = dpvect[0].get_epoch_time();
         converter0.raw_data = dpvect[0].payload_pt1;

--- a/Detectors/ITSMFT/MFT/condition/testWorkflow/MFTDCSDataProcessorSpec.h
+++ b/Detectors/ITSMFT/MFT/condition/testWorkflow/MFTDCSDataProcessorSpec.h
@@ -146,7 +146,6 @@ class MFTDCSDataProcessor : public o2::framework::Task
 
     auto timeNow = HighResClock::now();
     Duration elapsedTime = timeNow - mTimer; // in seconds
-
     if (elapsedTime.count() >= mDPsUpdateInterval) {
       sendDPsoutput(pc.outputs());
       mTimer = timeNow;
@@ -183,8 +182,7 @@ class MFTDCSDataProcessor : public o2::framework::Task
     }
 
     if (tend == -1) {
-      constexpr long SECONDSPERYEAR = 365 * 24 * 60 * 60;
-      tend = o2::ccdb::getFutureTimestamp(SECONDSPERYEAR);
+      tend = tstart + o2::ccdb::CcdbObjectInfo::MONTH;
     }
 
     info.setStartValidityTimestamp(tstart);


### PR DESCRIPTION
@syano0822 There was actually a bug crashing the workflow even in the test generator mode, e.g.:
```
o2-condition-mft-dcs-sim-workflow --max-timeframes 1000000 --delta-fraction 0.5  | o2-condition-mft-dcs-workflow --use-ccdb-to-configure --DPs-update-interval=20  | o2-calibration-ccdb-populator-workflow --ccdb-path="http://ccdb-test.cern.ch:8080" --shm-segment-size 12000000000
```
The reason is that after filling the CCDB object the mDpsdoublesmap and mMFTDCS were cleared but the flag of `mPids` telling that the DP was seen was not reset. As a result, if during the next interval you don't get this DP, it will fail on next object preparation. Now the flag is set to false  once the DP alias is accounted : https://github.com/AliceO2Group/AliceO2/compare/dev...shahor02:fix_mftdcsdp?expand=1#diff-ae208f14efe032410b5bdfc9a843e22d033e176e970fb746d156e6a0cede2a79R164.

I have some doubts in the logic of such periodic update with missing data: you query the CCDB object for certain timestamp and some DP value is not there. What do you in this case?

BTW, indeed there was a problem with the object validity duration: before I've fixed it in `MFTDCSProcessor::prepareCCDBobjectInfo`, but, for some reason you set it also in sendDPsoutput, now fixed: https://github.com/AliceO2Group/AliceO2/compare/dev...shahor02:fix_mftdcsdp?expand=1#diff-8190c5398bb5a1765f602cab34ed4f4ebd3f9345a34e33f67c103fab1548c7feR185