### PR TITLE
Fix TOF DCS DP processing

### DIFF
--- a/Detectors/TOF/calibration/src/TOFDCSProcessor.cxx
+++ b/Detectors/TOF/calibration/src/TOFDCSProcessor.cxx
@@ -70,16 +70,18 @@ int TOFDCSProcessor::process(const gsl::span<const DPCOM> dps)
     mFirstTimeSet = true;
   }
 
-  std::unordered_map<DPID, DPVAL> mapin;
-  for (auto& it : dps) {
-    mapin[it.id] = it.data;
-  }
-  for (auto& it : mPids) {
-    const auto& el = mapin.find(it.first);
-    if (el == mapin.end()) {
-      LOG(debug) << "DP " << it.first << " not found in map";
-    } else {
-      LOG(debug) << "DP " << it.first << " found in map";
+  if (false) {
+    std::unordered_map<DPID, DPVAL> mapin;
+    for (auto& it : dps) {
+      mapin[it.id] = it.data;
+    }
+    for (auto& it : mPids) {
+      const auto& el = mapin.find(it.first);
+      if (el == mapin.end()) {
+        LOG(debug) << "DP " << it.first << " not found in map";
+      } else {
+        LOG(debug) << "DP " << it.first << " found in map";
+      }
     }
   }
 
@@ -332,11 +334,12 @@ void TOFDCSProcessor::updateDPsCCDB()
     double double_value;
   } converter0, converter1;
 
-  for (const auto& it : mPids) {
+  for (auto& it : mPids) {
     const auto& type = it.first.get_type();
     if (type == o2::dcs::DPVAL_DOUBLE) {
       auto& tofdcs = mTOFDCS[it.first];
-      if (it.second == true) { // we processed the DP at least 1x
+      if (it.second) {     // we processed the DP at least 1x
+        it.second = false; // reset for the next period
         auto& dpvect = mDpsdoublesmap[it.first];
         tofdcs.firstValue.first = dpvect[0].get_epoch_time();
         converter0.raw_data = dpvect[0].payload_pt1;


### PR DESCRIPTION
Reset DP acknowledgment bit at the start of new period

@chiarazampolli I saw your comment in https://github.com/AliceO2Group/AliceO2/pull/8992 only after merging it. 
Indeed, the same problem was in TOF processor, applying the same fix. 
It would crashe only if some DP seen in some interval, does not arrive during the following interval, apparently it does not happen with TOF.

Since the fix is trivial, merging.