### PR TITLE
Changes in IRFrame filling / selecting

### DIFF
--- a/Common/Utils/include/CommonUtils/IRFrameSelector.h
+++ b/Common/Utils/include/CommonUtils/IRFrameSelector.h
@@ -21,8 +21,8 @@ namespace o2::utils
 class IRFrameSelector
 {
  public:
-  bool check(const o2::dataformats::IRFrame& fr);
-  bool check(const o2::InteractionRecord& ir) { return check(o2::dataformats::IRFrame{ir, ir}); }
+  long check(const o2::dataformats::IRFrame& fr);
+  long check(const o2::InteractionRecord& ir) { return check(o2::dataformats::IRFrame{ir, ir}); }
 
   template <typename SPAN>
   void setSelectedIRFrames(const SPAN& sp)
@@ -34,6 +34,8 @@ class IRFrameSelector
 
   size_t loadIRFrames(const std::string& fname);
   void print(bool lst = false) const;
+
+  auto getIRFrames() const { return mFrames; }
 
  private:
   gsl::span<const o2::dataformats::IRFrame> mFrames{}; // externally provided span of IRFrames, must be sorted in IRFrame.getMin()

--- a/Common/Utils/src/IRFrameSelector.cxx
+++ b/Common/Utils/src/IRFrameSelector.cxx
@@ -21,20 +21,20 @@
 
 using namespace o2::utils;
 
-bool IRFrameSelector::check(const o2::dataformats::IRFrame& fr)
+long IRFrameSelector::check(const o2::dataformats::IRFrame& fr)
 {
-  bool ans = false;
+  long ans = -1;
 
   // find entry which overlaps or above fr
-  auto fullcheck = [&fr, this]() {
+  auto fullcheck = [&fr, this]() -> long {
     auto lower = std::lower_bound(this->mFrames.begin(), this->mFrames.end(), fr);
     if (lower == this->mFrames.end()) {
       this->mLastBoundID = this->mFrames.size();
     } else {
       this->mLastBoundID = std::distance(this->mFrames.begin(), lower);
-      return fr.isOutside(*lower) == o2::dataformats::IRFrame::Inside;
+      return fr.isOutside(*lower) == o2::dataformats::IRFrame::Inside ? this->mLastBoundID : -1;
     }
-    return false;
+    return -1;
   };
 
   if (mLastBoundID < 0) { // 1st call, do full search
@@ -48,7 +48,7 @@ bool IRFrameSelector::check(const o2::dataformats::IRFrame& fr)
         if (res == o2::dataformats::IRFrame::Above) {
           break; // no point in checking further
         } else if (res == o2::dataformats::IRFrame::Inside) {
-          ans = true;
+          ans = mLastBoundID;
           break;
         }
         if (++steps == MaxSteps) {
@@ -66,7 +66,7 @@ bool IRFrameSelector::check(const o2::dataformats::IRFrame& fr)
           mLastBoundID++; // no point in checking further
           break;
         } else if (res == o2::dataformats::IRFrame::Inside) {
-          ans = true;
+          ans = mLastBoundID;
           break;
         }
         if (++steps == MaxSteps) {

--- a/DataFormats/common/include/CommonDataFormat/IRFrame.h
+++ b/DataFormats/common/include/CommonDataFormat/IRFrame.h
@@ -29,7 +29,10 @@ namespace dataformats
 // problems with fwd.declaration
 struct IRFrame : public o2::math_utils::detail::Bracket<o2::InteractionRecord> {
   using o2::math_utils::detail::Bracket<o2::InteractionRecord>::Bracket;
-  ClassDefNV(IRFrame, 1);
+
+  uint64_t info = 0;
+
+  ClassDefNV(IRFrame, 2);
 };
 
 } // namespace dataformats

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/FastMultEstConfig.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/FastMultEstConfig.h
@@ -38,6 +38,13 @@ struct FastMultEstConfig : public o2::conf::ConfigurableParamHelper<FastMultEstC
   float cutMultClusHigh = -1; /// reject ROF with estimated cluster mult. above this value (no cut if <0)
   float cutMultVtxLow = -1;   /// reject seed vertex if its multiplicity below this value (no cut if <0)
   float cutMultVtxHigh = -1;  /// reject seed vertex if its multiplicity above this value (no cut if <0)
+  float cutRandomFraction = -1.; /// apply random cut rejecting requested fraction
+
+  bool isMultCutRequested() const { return cutMultClusLow >= 0.f && cutMultClusHigh > 0.f; };
+  bool isVtxMultCutRequested() const { return cutMultVtxLow >= 0.f && cutMultVtxHigh > 0.f; };
+  bool isPassingRandomRejection() const;
+  bool isPassingMultCut(float mult) const { return mult >= cutMultClusLow && (mult <= cutMultClusHigh || cutMultClusHigh <= 0.f); }
+  bool isPassingVtxMultCut(int mult) const { return mult >= cutMultVtxLow && (mult <= cutMultVtxHigh || cutMultVtxHigh <= 0.f); }
 
   O2ParamDef(FastMultEstConfig, "fastMultConfig");
 };

--- a/Detectors/ITSMFT/ITS/reconstruction/src/FastMultEstConfig.cxx
+++ b/Detectors/ITSMFT/ITS/reconstruction/src/FastMultEstConfig.cxx
@@ -10,5 +10,13 @@
 // or submit itself to any jurisdiction.
 
 #include "ITSReconstruction/FastMultEstConfig.h"
+#include "TRandom.h"
 
 O2ParamImpl(o2::its::FastMultEstConfig);
+
+using namespace o2::its;
+
+bool FastMultEstConfig::isPassingRandomRejection() const
+{
+  return (cutRandomFraction <= 0. || gRandom->Rndm() > cutRandomFraction) ? true : false;
+}

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -148,7 +148,7 @@ class TimeFrame
   const unsigned long long& getRoadLabel(int i) const;
   bool isRoadFake(int i) const;
 
-  void setMultiplicityCutMask(std::vector<bool> cutMask) { mMultiplicityCutMask.swap(cutMask); }
+  void setMultiplicityCutMask(std::vector<bool> cutMask) { mMultiplicityCutMask = cutMask; }
 
   int hasBogusClusters() const { return std::accumulate(mBogusClusters.begin(), mBogusClusters.end(), 0); }
 

--- a/Detectors/ITSMFT/ITS/workflow/src/CookedTrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/CookedTrackerSpec.cxx
@@ -146,21 +146,23 @@ void CookedTrackerDPL::run(ProcessingContext& pc)
   mTimeFrame.loadROFrameData(rofspan, compClusters, pattIt_timeframe, mDict, labels.get());
 
   std::vector<bool> processingMask;
-  int cutClusterMult{0}, cutVertexMult{0}, cutTotalMult{0};
+  int cutRandomMult{0}, cutClusterMult{0}, cutVertexMult{0};
 
   for (size_t iRof{0}; iRof < rofspan.size(); ++iRof) {
     auto& rof = rofspan[iRof];
-    bool multCut = (multEstConf.cutMultClusLow <= 0 && multEstConf.cutMultClusHigh <= 0); // cut was requested
-    if (!multCut) {
+    bool selROF = !multEstConf.isPassingRandomRejection();
+    if (!selROF) {
+      cutRandomMult++;
+    } else if (multEstConf.isMultCutRequested()) { // cut was requested
       float mult = multEst.process(rof.getROFData(compClusters));
-      multCut = mult >= multEstConf.cutMultClusLow && mult <= multEstConf.cutMultClusHigh;
-      if (!multCut) {
+      selROF = multEstConf.isPassingMultCut(mult);
+      if (!selROF) {
         LOG(info) << "Estimated cluster mult. " << mult << " is outside of requested range "
                   << multEstConf.cutMultClusLow << " : " << multEstConf.cutMultClusHigh << " | ROF " << rof.getBCData();
       }
-      cutClusterMult += !multCut;
+      cutClusterMult += !selROF;
     }
-    processingMask.push_back(multCut);
+    processingMask.push_back(selROF);
   }
   // auto processingMask_ephemeral = processingMask;
   mTimeFrame.setMultiplicityCutMask(processingMask);
@@ -186,16 +188,21 @@ void CookedTrackerDPL::run(ProcessingContext& pc)
     for (auto& v : mTimeFrame.getPrimaryVertices(iRof)) {
       vtxVecLoc.push_back(v);
     }
-    if (multEstConf.cutMultVtxLow > 0 || multEstConf.cutMultVtxHigh > 0) { // cut was requested
+    if (multEstConf.isVtxMultCutRequested()) { // cut was requested
       std::vector<o2::dataformats::Vertex<o2::dataformats::TimeStamp<int>>> vtxVecSel;
       vtxVecSel.swap(vtxVecLoc);
+      int nv = vtxVecSel.size(), nrej = 0;
       for (const auto& vtx : vtxVecSel) {
-        if (vtx.getNContributors() < multEstConf.cutMultVtxLow || (multEstConf.cutMultVtxHigh > 0 && vtx.getNContributors() > multEstConf.cutMultVtxHigh)) {
-          LOG(info) << "Found vertex mult. " << vtx.getNContributors() << " is outside of requested range "
-                    << multEstConf.cutMultVtxLow << " : " << multEstConf.cutMultVtxHigh << " | ROF " << rof.getBCData();
+        if (!multEstConf.isPassingVtxMultCut(vtx.getNContributors())) {
+          LOG(info) << "Found vertex mult. " << vtx.getNContributors() << " is outside of requested range " << multEstConf.cutMultVtxLow << " : " << multEstConf.cutMultVtxHigh << " | ROF " << rof.getBCData();
+          nrej++;
           continue; // skip vertex of unwanted multiplicity
         }
         vtxVecLoc.push_back(vtx);
+      }
+      if (nv && (nrej == nv)) { // all vertices were rejected
+        cutVertexMult++;
+        processingMask[iRof] = false;
       }
     }
     if (vtxVecLoc.empty()) {
@@ -215,8 +222,8 @@ void CookedTrackerDPL::run(ProcessingContext& pc)
 
     mTracker.setVertices(vtxVecLoc);
     mTracker.process(compClusters, pattIt_tracker, mDict, tracks, clusIdx, rof);
-    if (tracks.size()) {
-      irFrames.emplace_back(rof.getBCData(), rof.getBCData() + nBCPerTF - 1);
+    if (processingMask[iRof]) {
+      irFrames.emplace_back(rof.getBCData(), rof.getBCData() + nBCPerTF - 1).info = tracks.size();
     }
   }
 

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -221,19 +221,21 @@ void TrackerDPL::run(ProcessingContext& pc)
   int nclUsed = 0;
 
   std::vector<bool> processingMask;
-  int cutClusterMult{0}, cutVertexMult{0}, cutTotalMult{0};
+  int cutRandomMult{0}, cutClusterMult{0}, cutVertexMult{0};
   for (size_t iRof{0}; iRof < rofspan.size(); ++iRof) {
     auto& rof = rofspan[iRof];
-    bool multCut = (multEstConf.cutMultClusLow <= 0 && multEstConf.cutMultClusHigh <= 0); // cut was requested
-    if (!multCut) {
+    bool selROF = multEstConf.isPassingRandomRejection();
+    if (!selROF) {
+      cutRandomMult++;
+    } else if (multEstConf.isMultCutRequested()) { // cut was requested
       float mult = multEst.process(rof.getROFData(compClusters));
-      multCut = mult >= multEstConf.cutMultClusLow && mult <= multEstConf.cutMultClusHigh;
-      if (!multCut) {
+      selROF = multEstConf.isPassingMultCut(mult);
+      if (!selROF) {
         LOG(debug) << fmt::format("ROF {} rejected by the cluster multiplicity selection [{},{}]", processingMask.size(), multEstConf.cutMultClusLow, multEstConf.cutMultClusHigh);
       }
-      cutClusterMult += !multCut;
+      cutClusterMult += !selROF;
     }
-    processingMask.push_back(multCut);
+    processingMask.push_back(selROF);
   }
   timeFrame->setMultiplicityCutMask(processingMask);
 
@@ -245,29 +247,30 @@ void TrackerDPL::run(ProcessingContext& pc)
   // timeFrame->setMultiplicityCutMask(std::vector<bool>(false, processingMask.size())); // <===== THIS BREAKS EVERYTHING
 
   for (auto iRof{0}; iRof < rofspan.size(); ++iRof) {
-    bool multCut;
     std::vector<Vertex> vtxVecLoc;
     auto& vtxROF = vertROFvec.emplace_back(rofspan[iRof]);
     vtxROF.setFirstEntry(vertices.size());
     if (mRunVertexer) {
       auto vtxSpan = timeFrame->getPrimaryVertices(iRof);
       vtxROF.setNEntries(vtxSpan.size());
-      multCut = vtxSpan.size() == 0;
-      for (auto& v : vtxSpan) {
-        if (v.getNContributors() < multEstConf.cutMultVtxLow || (multEstConf.cutMultVtxHigh > 0 && v.getNContributors() > multEstConf.cutMultVtxHigh)) {
-          continue; // skip vertex of unwanted multiplicity
+      if (multEstConf.isVtxMultCutRequested()) {
+        bool selROF = vtxSpan.size() == 0;
+        for (auto& v : vtxSpan) {
+          if (!multEstConf.isPassingVtxMultCut(v.getNContributors())) {
+            continue; // skip vertex of unwanted multiplicity
+          }
+          selROF = true;
+          vertices.push_back(v);
         }
-        multCut = true;
-        vertices.push_back(v);
-      }
-      if (processingMask[iRof] && !multCut) { // passed selection in clusters and not in vertex multiplicity
-        LOG(debug) << fmt::format("ROF {} rejected by the vertex multiplicity selection [{},{}]",
-                                  iRof,
-                                  multEstConf.cutMultVtxLow,
-                                  multEstConf.cutMultVtxHigh);
-        processingMask[iRof] = multCut;
-        cutVertexMult++;
-      }
+        if (processingMask[iRof] && !selROF) { // passed selection in clusters and not in vertex multiplicity
+          LOG(debug) << fmt::format("ROF {} rejected by the vertex multiplicity selection [{},{}]",
+                                    iRof,
+                                    multEstConf.cutMultVtxLow,
+                                    multEstConf.cutMultVtxHigh);
+          processingMask[iRof] = selROF;
+          cutVertexMult++;
+        }
+      }      // vertex mult cut was requested
     } else { // cosmics
       vtxVecLoc.emplace_back(Vertex());
       vtxVecLoc.back().setNContributors(1);
@@ -279,9 +282,7 @@ void TrackerDPL::run(ProcessingContext& pc)
     }
   }
 
-  LOG(info) << fmt::format(" - In total, multiplicity selection rejected {}/{} ROFs", cutTotalMult, rofspan.size());
-  LOG(info) << fmt::format("\t - Cluster multiplicity selection rejected {}/{} ROFs", cutClusterMult, rofspan.size());
-  LOG(info) << fmt::format("\t - Vertex multiplicity selection rejected {}/{} ROFs", cutVertexMult, rofspan.size());
+  LOG(info) << fmt::format(" - rejected {}/{} ROFs: random:{}, mult.sel:{}, vtx.sel:{}", cutRandomMult + cutClusterMult + cutVertexMult, rofspan.size(), cutRandomMult, cutClusterMult, cutVertexMult);
   LOG(info) << fmt::format(" - Vertex seeding total elapsed time: {} ms for {} clusters in {} ROFs", vertexerElapsedTime, nclUsed, rofspan.size());
   LOG(info) << fmt::format(" - Beam position computed for the TF: {}, {}", timeFrame->getBeamX(), timeFrame->getBeamY());
 
@@ -306,9 +307,10 @@ void TrackerDPL::run(ProcessingContext& pc)
       rof.setFirstEntry(first);
       rof.setNEntries(number);
 
-      if (tracks.size()) {
-        irFrames.emplace_back(rof.getBCData(), rof.getBCData() + nBCPerTF - 1);
+      if (processingMask[iROF]) {
+        irFrames.emplace_back(rof.getBCData(), rof.getBCData() + nBCPerTF - 1).info = tracks.size();
       }
+
       std::copy(trackLabels.begin(), trackLabels.end(), std::back_inserter(allTrackLabels));
       // Some conversions that needs to be moved in the tracker internals
       for (unsigned int iTrk{0}; iTrk < tracks.size(); ++iTrk) {

--- a/Detectors/TRD/workflow/src/TRDTrackletTransformerSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrackletTransformerSpec.cxx
@@ -52,6 +52,9 @@ void TRDTrackletTransformerSpec::run(o2::framework::ProcessingContext& pc)
     const auto irFrames = inputData.getIRFramesITS();
     size_t lastMatchedIdx = 0; // ITS IR are sorted in time and do not overlap
     for (const auto& irFrame : irFrames) {
+      if (!irFrame.info) { // skip IRFrames where ITS did not find any track
+        continue;
+      }
       for (auto j = lastMatchedIdx; j < trigRecs.size(); ++j) {
         const auto& trigRec = trigRecs[j];
         if (trigRec.getBCData() >= irFrame.getMin()) {


### PR DESCRIPTION
* IRFrame got info field, TRD will accept only frames with info>0

* ITS trackers do not reject empty IRFrames
If the IRFrame was not rejected by mult. or random selections, it is always added  to IRFrames, 
even if not tracks were found. The NTracks in ROF is assiged to IRFrame.info.  

* Allow random ITS ROF rejection on top of mult. cut
if `fastMultConfig.cutRandomFraction>0`, apply random rejection of this fraction of ROFs to processed ITS ROFs

* IRFrameSelector returns matching frame ID on success, -1 if fails to match

