### PR TITLE
fix in TOF CalibApi initialization

### DIFF
--- a/Detectors/TOF/base/include/TOFBase/CalibTOFapi.h
+++ b/Detectors/TOF/base/include/TOFBase/CalibTOFapi.h
@@ -39,9 +39,9 @@ class CalibTOFapi
 
  public:
   void resetDia();
-  CalibTOFapi();
+  CalibTOFapi() = default;
   CalibTOFapi(const std::string url);
-  CalibTOFapi(long timestamp, o2::dataformats::CalibLHCphaseTOF* phase, o2::dataformats::CalibTimeSlewingParamTOF* slew, Diagnostic* dia = nullptr) : mTimeStamp(timestamp), mLHCphase(phase), mSlewParam(slew), mDiaFreq(dia) { CalibTOFapi(); }
+  CalibTOFapi(long timestamp, o2::dataformats::CalibLHCphaseTOF* phase, o2::dataformats::CalibTimeSlewingParamTOF* slew, Diagnostic* dia = nullptr) : mTimeStamp(timestamp), mLHCphase(phase), mSlewParam(slew), mDiaFreq(dia) {}
   ~CalibTOFapi()
   {
     if (mLHCphase) {
@@ -109,15 +109,15 @@ class CalibTOFapi
   // info from diagnostic
   int mNoisyThreshold = 1;                          ///< threshold to be noisy
   float mEmptyTOF = 0;                              ///< probability to have TOF fully empty
-  float mEmptyCrateProb[Geo::kNCrate];              ///< probability to have an empty crate in the current readout window
+  float mEmptyCrateProb[Geo::kNCrate] = {};         ///< probability to have an empty crate in the current readout window
   std::vector<std::pair<int, float>> mNoisy;        ///< probTRMerror
   std::vector<std::pair<int, float>> mTRMerrorProb; ///< probTRMerror
   std::vector<int> mTRMmask;                        ///< mask error for TRM
 
-  bool mIsErrorCh[Geo::NCHANNELS];  ///< channels in error (TRM)
-  std::vector<int> mFillErrChannel; ///< last error channels filled
-  bool mIsOffCh[Geo::NCHANNELS];    ///< channels in error (TRM)
-  bool mIsNoisy[Geo::NCHANNELS];    ///< noisy channels
+  bool mIsErrorCh[Geo::NCHANNELS] = {}; ///< channels in error (TRM)
+  std::vector<int> mFillErrChannel;     ///< last error channels filled
+  bool mIsOffCh[Geo::NCHANNELS] = {};   ///< channels in error (TRM)
+  bool mIsNoisy[Geo::NCHANNELS] = {};   ///< noisy channels
 
   ClassDefNV(CalibTOFapi, 1);
 };

--- a/Detectors/TOF/base/src/CalibTOFapi.cxx
+++ b/Detectors/TOF/base/src/CalibTOFapi.cxx
@@ -24,19 +24,10 @@ void CalibTOFapi::resetDia()
   mNoisy.clear();
 }
 
-CalibTOFapi::CalibTOFapi()
-{
-  resetDia();
-  memset(mIsErrorCh, false, Geo::NCHANNELS);
-  memset(mIsOffCh, false, Geo::NCHANNELS);
-  memset(mIsNoisy, false, Geo::NCHANNELS);
-}
-
 //______________________________________________________________________
 
 CalibTOFapi::CalibTOFapi(const std::string url)
 {
-  CalibTOFapi();
   // setting the URL to the CCDB manager
 
   setURL(url);


### PR DESCRIPTION
Array initialization is no longer working (really not clear for me).
I couldn't find any way to attribute a value to all array elements within the constructor implementation.
I implemented initialization for all arrays in the header.
Now it works.

NB: the TOF clusterization was "broken" for this reason in the last tags (it seems a recent problem) since the majority of the channels were flagged as trmError or noisy leading to a very low TOF ME.

This fix is required to resume LHC21k6 production
@chiarazampolli

