### PR TITLE
MRRTF-174: fix counting of input digits in pre-clustering

### DIFF
--- a/Detectors/MUON/MCH/Workflow/src/PreClusterFinderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/PreClusterFinderSpec.cxx
@@ -122,6 +122,13 @@ class PreClusterFinderTask
     // create the output message for precluster ROFs
     auto& preClusterROFs = pc.outputs().make<std::vector<ROFRecord>>(OutputRef{"preclusterrofs"});
 
+    // count the number of digits associated with the input ROFs. This can be smaller than the
+    // total number of digits if we are processing filtered ROFs.
+    int nDigitsInRofs = 0;
+    for (const auto& digitROF : digitROFs) {
+      nDigitsInRofs += digitROF.getNEntries();
+    }
+
     // prepare to receive new data
     mPreClusters.clear();
     mUsedDigits.clear();
@@ -167,7 +174,7 @@ class PreClusterFinderTask
       }
 
       // check sizes of input and output digits vectors
-      bool digitsSizesDiffer = (nRemovedDigits + mUsedDigits.size() != digits.size());
+      bool digitsSizesDiffer = (nRemovedDigits + mUsedDigits.size() != nDigitsInRofs);
       switch (mCheckNoLeftoverDigits) {
         case CHECK_NO_LEFTOVER_DIGITS_OFF:
           break;


### PR DESCRIPTION
When ROF filtering is enabled the pre-clustering considers only a sub-set of the available digits, and therefore the check on the digits number consistency must be modified accordingly, by comparing with the number of digits in the input ROFs instead of the total number of digits.