### PR TITLE
Tentative fix for TPC DCS DP processor

### DIFF
--- a/Detectors/TPC/dcs/src/DCSProcessor.cxx
+++ b/Detectors/TPC/dcs/src/DCSProcessor.cxx
@@ -152,12 +152,12 @@ void DCSProcessor::fitTemperature(Side side)
 
       LOGP(debug, "sensor {}, start {}, size {}", sensor.sensorNumber, startPos[iSensor], sensor.data.size());
       while (startPos[iSensor] < sensor.data.size()) {
-        nextInterval = true;
         const auto& dataPoint = sensor.data[startPos[iSensor]];
         if ((dataPoint.time - refTime) >= mFitInterval) {
           LOGP(debug, "sensor {}, {} - {} >= {}", sensor.sensorNumber, dataPoint.time, refTime, mFitInterval);
           break;
         }
+        nextInterval = true;
         firstTime = std::min(firstTime, dataPoint.time);
         const auto temperature = dataPoint.value;
         // sanity check


### PR DESCRIPTION
@wiechula TPC DCS processor was getting stuck in an infinite loop in the fitTemperature, blocking the whole workflow.
This fix allows to avoid it, could you please check if the logic is correct.
For the record: changing `LOG(debug)` to `LOG(info)` I was getting in the log infinite loop like in 
[tpcdcs.txt](https://github.com/AliceO2Group/AliceO2/files/8791371/tpcdcs.txt)
after the fix it becomes 
[tpcdcsCorr.txt](https://github.com/AliceO2Group/AliceO2/files/8791374/tpcdcsCorr.txt)

and I see periodic updates:
```
 grep 'Storing in ccdb TPC' dcs-dps_rs_PR10.log

[1772913:ccdb-populator]: [17:08:10][INFO] Storing in ccdb TPC/Calib/Gas/o2-tpc-dcs-Gas_1653750490977.root of size 2048 Valid for 1652369592799 : 1653748798207
[1772913:ccdb-populator]: [17:08:10][INFO] Storing in ccdb TPC/Calib/HV/o2-tpc-dcs-HV_1653750490896.root of size 516096 Valid for 1653742795102 : 1653750488178
[1772913:ccdb-populator]: [17:08:10][INFO] Storing in ccdb TPC/Calib/Temperature/o2-tpc-dcs-Temperature_1653750490857.root of size 4096 Valid for 1653750143980 : 1653750484397
[1772913:ccdb-populator]: [17:13:11][INFO] Storing in ccdb TPC/Calib/Gas/o2-tpc-dcs-Gas_1653750791330.root of size 2048 Valid for 1652369592799 : 1653748798207
[1772913:ccdb-populator]: [17:13:11][INFO] Storing in ccdb TPC/Calib/HV/o2-tpc-dcs-HV_1653750791246.root of size 523264 Valid for 1653742795102 : 1653750789031
[1772913:ccdb-populator]: [17:13:11][INFO] Storing in ccdb TPC/Calib/Temperature/o2-tpc-dcs-Temperature_1653750791246.root of size 4096 Valid for 1653750433992 : 1653750784780
```

I am now running on flp199 the workflow with this patch to see if blocking the workflow is gone.
