### PR TITLE
DPL GUI: display metrics for input and output channels

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -111,6 +111,7 @@ o2_add_library(Framework
                        src/ResourcePolicyHelpers.cxx
                        src/SendingPolicy.cxx
                        src/ServiceRegistry.cxx
+                       src/ServiceSpec.cxx
                        src/SimpleResourceManager.cxx
                        src/SimpleRawDeviceService.cxx
                        src/StreamOperators.cxx

--- a/Framework/Core/include/Framework/CommonServices.h
+++ b/Framework/Core/include/Framework/CommonServices.h
@@ -81,6 +81,7 @@ struct CommonServices {
   static ServiceSpec ccdbSupportSpec();
   static ServiceSpec decongestionSpec();
   static ServiceSpec asyncQueue();
+  static ServiceSpec guiMetricsSpec();
 
   static std::vector<ServiceSpec> defaultServices(int numWorkers = 0);
   static std::vector<ServiceSpec> requiredServices();

--- a/Framework/Core/include/Framework/DeviceInfo.h
+++ b/Framework/Core/include/Framework/DeviceInfo.h
@@ -72,6 +72,13 @@ struct DeviceInfo {
   Metric2DViewIndex queriesViewIndex;
   /// Index for the queries of each input route.
   Metric2DViewIndex outputsViewIndex;
+  /// Index for the metrics to be displayed associated to
+  /// each input channel of the device.
+  Metric2DViewIndex inputChannelMetricsViewIndex;
+  /// Index for the metrics to be displayed associated to
+  /// each input channel of the device.
+  Metric2DViewIndex outputChannelMetricsViewIndex;
+
   /// Current configuration for the device
   boost::property_tree::ptree currentConfig;
   /// Current provenance for the configuration keys

--- a/Framework/Core/include/Framework/DeviceMetricsInfo.h
+++ b/Framework/Core/include/Framework/DeviceMetricsInfo.h
@@ -13,6 +13,7 @@
 #define O2_FRAMEWORK_DEVICEMETRICSINFO_H_
 
 #include "Framework/RuntimeError.h"
+#include "Framework/Traits.h"
 #include <array>
 #include <cstddef>
 #include <string>
@@ -104,6 +105,24 @@ struct DeviceMetricsInfo {
   std::vector<MetricPrefixIndex> metricLabelsPrefixesSortedIdx;
   std::vector<MetricInfo> metrics;
   std::vector<bool> changed;
+};
+
+struct DeviceMetricsInfoHelpers {
+  template <typename T>
+  static std::array<T, 1024> const& get(DeviceMetricsInfo const& info, size_t metricIdx)
+  {
+    if constexpr (std::is_same_v<T, int>) {
+      return info.intMetrics[metricIdx];
+    } else if constexpr (std::is_same_v<T, uint64_t>) {
+      return info.uint64Metrics[metricIdx];
+    } else if constexpr (std::is_same_v<T, StringMetric>) {
+      return info.stringMetrics[metricIdx];
+    } else if constexpr (std::is_same_v<T, float>) {
+      return info.floatMetrics[metricIdx];
+    } else {
+      static_assert(always_static_assert_v<T>, "Unsupported type");
+    }
+  }
 };
 
 } // namespace o2::framework

--- a/Framework/Core/include/Framework/Metric2DViewIndex.h
+++ b/Framework/Core/include/Framework/Metric2DViewIndex.h
@@ -8,17 +8,15 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#ifndef o2_framework_Metric2DViewInfo_H_INCLUDED
-#define o2_framework_Metric2DViewInfo_H_INCLUDED
+#ifndef O2_FRAMEWORK_METRIC2DVIEWINDEX_H_
+#define O2_FRAMEWORK_METRIC2DVIEWINDEX_H_
 
 #include <functional>
 #include <cstddef>
 #include <string>
 #include <vector>
 
-namespace o2
-{
-namespace framework
+namespace o2::framework
 {
 
 struct MetricInfo;
@@ -42,7 +40,6 @@ struct Metric2DViewIndex {
   static Updater getUpdater(std::vector<Metric2DViewIndex*> views);
 };
 
-} // namespace framework
-} // namespace o2
+} // namespace o2::framework
 
-#endif // o2_framework_Metric2DViewInfo_H_INCLUDED
+#endif // O2_FRAMEWORK_METRIC2DVIEWINDEX_H_

--- a/Framework/Core/include/Framework/ServiceSpec.h
+++ b/Framework/Core/include/Framework/ServiceSpec.h
@@ -178,8 +178,24 @@ struct ServiceSpec {
   /// Callback invoked when we get updated about the oldest possible timeslice we can process
   ServiceDomainInfoUpdated domainInfoUpdated = nullptr;
 
+  /// Active flag. If set to false, the service will not be used by default.
+  bool active = true;
+
   /// Kind of service being specified.
   ServiceKind kind = ServiceKind::Serial;
+};
+
+struct OverrideServiceSpec {
+  std::string name;
+  bool active;
+};
+
+using OverrideServiceSpecs = std::vector<OverrideServiceSpec>;
+using ServiceSpecs = std::vector<ServiceSpec>;
+
+struct ServiceSpecHelpers {
+  static OverrideServiceSpecs parseOverrides(char const* overrideString);
+  static ServiceSpecs filterDisabled(ServiceSpecs originals, OverrideServiceSpecs const& overrides);
 };
 
 struct ServiceConfigureHandle {

--- a/Framework/Core/src/ControlWebSocketHandler.cxx
+++ b/Framework/Core/src/ControlWebSocketHandler.cxx
@@ -24,7 +24,9 @@ void ControlWebSocketHandler::frame(char const* frame, size_t s)
   auto updateMetricsViews = Metric2DViewIndex::getUpdater({&(*mContext.infos)[mIndex].dataRelayerViewIndex,
                                                            &(*mContext.infos)[mIndex].variablesViewIndex,
                                                            &(*mContext.infos)[mIndex].queriesViewIndex,
-                                                           &(*mContext.infos)[mIndex].outputsViewIndex});
+                                                           &(*mContext.infos)[mIndex].outputsViewIndex,
+                                                           &(*mContext.infos)[mIndex].inputChannelMetricsViewIndex,
+                                                           &(*mContext.infos)[mIndex].outputChannelMetricsViewIndex});
 
   auto newMetricCallback = [&updateMetricsViews, &metrics = mContext.metrics, &hasNewMetric](std::string const& name, MetricInfo const& metric, int value, size_t metricIndex) {
     updateMetricsViews(name, metric, value, metricIndex);

--- a/Framework/Core/src/DeviceSpecHelpers.h
+++ b/Framework/Core/src/DeviceSpecHelpers.h
@@ -59,7 +59,8 @@ struct DeviceSpecHelpers {
     ConfigContext const& configContext,
     bool optimizeTopology = false,
     unsigned short resourcesMonitoringInterval = 0,
-    std::string const& channelPrefix = "");
+    std::string const& channelPrefix = "",
+    OverrideServiceSpecs const& overrideServices = {});
 
   static void dataProcessorSpecs2DeviceSpecs(
     const WorkflowSpec& workflow,
@@ -72,7 +73,8 @@ struct DeviceSpecHelpers {
     ConfigContext const& configContext,
     bool optimizeTopology = false,
     unsigned short resourcesMonitoringInterval = 0,
-    std::string const& channelPrefix = "")
+    std::string const& channelPrefix = "",
+    OverrideServiceSpecs const& overrideServices = {})
   {
     std::vector<DispatchPolicy> dispatchPolicies = DispatchPolicy::createDefaultPolicies();
     std::vector<ResourcePolicy> resourcePolicies = ResourcePolicy::createDefaultPolicies();
@@ -81,7 +83,7 @@ struct DeviceSpecHelpers {
                                    dispatchPolicies, resourcePolicies, callbacksPolicies,
                                    sendingPolicies, devices,
                                    resourceManager, uniqueWorkflowId, configContext, optimizeTopology,
-                                   resourcesMonitoringInterval, channelPrefix);
+                                   resourcesMonitoringInterval, channelPrefix, overrideServices);
   }
 
   /// Helper to provide the channel configuration string for an input channel
@@ -141,7 +143,8 @@ struct DeviceSpecHelpers {
     const std::vector<OutputSpec>& outputs,
     std::vector<ChannelConfigurationPolicy> const& channelPolicies,
     std::string const& channelPrefix,
-    ComputingOffer const& defaultOffer);
+    ComputingOffer const& defaultOffer,
+    OverrideServiceSpecs const& overrideServices = {});
 
   /// This takes the list of preprocessed edges of a graph
   /// and creates Devices and Channels which are related
@@ -159,7 +162,8 @@ struct DeviceSpecHelpers {
     const std::vector<LogicalForwardInfo>& availableForwardsInfo,
     std::vector<ChannelConfigurationPolicy> const& channelPolicies,
     std::string const& channelPrefix,
-    ComputingOffer const& defaultOffer);
+    ComputingOffer const& defaultOffer,
+    OverrideServiceSpecs const& overrideServices = {});
 
   /// return a description of all options to be forwarded to the device
   /// by default

--- a/Framework/Core/src/ServiceSpec.cxx
+++ b/Framework/Core/src/ServiceSpec.cxx
@@ -1,0 +1,104 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/ServiceSpec.h"
+#include "Framework/RuntimeError.h"
+#include "Framework/Logger.h"
+#include <sstream>
+#include <unordered_set>
+
+namespace o2::framework
+{
+
+auto findOverrideByName = [](std::string_view name) {
+  return [name](const OverrideServiceSpec& spec) { return spec.name == name; };
+};
+
+OverrideServiceSpecs ServiceSpecHelpers::parseOverrides(char const* overrideString)
+{
+  if (overrideString == nullptr || *overrideString == '\0') {
+    return {};
+  }
+  // Helper to split a string into a vector of string_views
+  auto split = [](std::string_view str, char delim) {
+    std::vector<std::string_view> result;
+    std::string_view::size_type start = 0;
+    auto end = str.find(delim);
+    while (end != std::string_view::npos) {
+      result.push_back(str.substr(start, end - start));
+      start = end + 1;
+      end = str.find(delim, start);
+    }
+    result.push_back(str.substr(start, end));
+    return result;
+  };
+
+  // if it is set, it will be a comma separated list of service names and their
+  // enabled/disabled status.
+  // if the service is enabled, it will be added to the list of services to be forced to be enabled.
+  // if the service is disabled, it will be added to the list of services to be forced to be disabled.
+
+  // Keep it simple. This is only a few elements, so we can use a vector.
+  std::vector<OverrideServiceSpec> overrides;
+  auto msg =
+    "DPL(_DRIVER)_OVERRIDE_SERVICES must be a comma separated list of service names and their enabled/disabled status. "
+    "The format is <service name>:<enable/disable/1/0>"
+    "Error while parsing: " +
+    std::string(overrideString);
+  auto overrideList = split(overrideString, ',');
+  for (auto& overrideStr : overrideList) {
+    auto overrideParts = split(overrideStr, ':');
+    if (overrideParts.size() != 2) {
+      throw std::runtime_error(msg.data());
+    }
+    bool active;
+    std::string serviceName{overrideParts[0]};
+    if (overrideParts[1] == "1") {
+      active = true;
+    } else if (overrideParts[1] == "0") {
+      active = false;
+    } else if (overrideParts[1] == "enable") {
+      active = true;
+    } else if (overrideParts[1] == "disable") {
+      active = false;
+    } else {
+      throw std::runtime_error(msg.data());
+    }
+    if (std::find_if(overrides.begin(), overrides.end(), findOverrideByName(serviceName)) != overrides.end()) {
+      throw std::runtime_error("Duplicate service name in DPL(_DRIVER)_OVERRIDE_SERVICES: " + serviceName);
+    }
+    overrides.push_back(OverrideServiceSpec{serviceName, active});
+  }
+  // Print the configuration
+  LOG(detail) << "The following services will be overridden by the DPL_OVERRIDE_SERVICES environment variable:";
+  for (auto& override : overrides) {
+    LOG(detail) << override.name << ": " << override.active;
+  }
+  return overrides;
+};
+
+ServiceSpecs ServiceSpecHelpers::filterDisabled(ServiceSpecs originals, OverrideServiceSpecs const& overrides)
+{
+
+  std::vector<ServiceSpec> result;
+  for (auto& original : originals) {
+    auto override = std::find_if(overrides.begin(), overrides.end(), findOverrideByName(original.name));
+    if (override != overrides.end()) {
+      LOGP(detail, "Overriding service {} to {}", original.name, override->active ? "enabled" : "disabled");
+      original.active = override->active;
+    }
+    if (original.active) {
+      result.push_back(original);
+    }
+  }
+  return result;
+}
+} // namespace o2::framework

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -346,6 +346,8 @@ void spawnRemoteDevice(std::string const&,
   info.variablesViewIndex = Metric2DViewIndex{"matcher_variables", 0, 0, {}};
   info.queriesViewIndex = Metric2DViewIndex{"data_queries", 0, 0, {}};
   info.outputsViewIndex = Metric2DViewIndex{"output_matchers", 0, 0, {}};
+  info.inputChannelMetricsViewIndex = Metric2DViewIndex{"oldest_possible_timeslice", 0, 0, {}};
+  info.outputChannelMetricsViewIndex = Metric2DViewIndex{"oldest_possible_output", 0, 0, {}};
   // FIXME: use uv_now.
   info.lastSignal = uv_hrtime() - 10000000;
 
@@ -464,7 +466,8 @@ struct ControlWebSocketHandler : public WebSocketHandler {
     auto updateMetricsViews = Metric2DViewIndex::getUpdater({&(*mContext.infos)[mIndex].dataRelayerViewIndex,
                                                              &(*mContext.infos)[mIndex].variablesViewIndex,
                                                              &(*mContext.infos)[mIndex].queriesViewIndex,
-                                                             &(*mContext.infos)[mIndex].outputsViewIndex});
+                                                             &(*mContext.infos)[mIndex].outputsViewIndex,
+                                                             &(*mContext.infos)[mIndex].inputChannelMetricsViewIndex});
 
     auto newMetricCallback = [&updateMetricsViews, &hasNewMetric](std::string const& name, MetricInfo const& metric, int value, size_t metricIndex) {
       updateMetricsViews(name, metric, value, metricIndex);
@@ -826,6 +829,8 @@ void spawnDevice(DeviceRef ref,
   info.variablesViewIndex = Metric2DViewIndex{"matcher_variables", 0, 0, {}};
   info.queriesViewIndex = Metric2DViewIndex{"data_queries", 0, 0, {}};
   info.outputsViewIndex = Metric2DViewIndex{"output_matchers", 0, 0, {}};
+  info.inputChannelMetricsViewIndex = Metric2DViewIndex{"oldest_possible_timeslice", 0, 0, {}};
+  info.outputChannelMetricsViewIndex = Metric2DViewIndex{"oldest_possible_output", 0, 0, {}};
   info.tracyPort = driverInfo.tracyPort;
   info.lastSignal = uv_hrtime() - 10000000;
 

--- a/Framework/GUISupport/src/FrameworkGUIDevicesGraph.cxx
+++ b/Framework/GUISupport/src/FrameworkGUIDevicesGraph.cxx
@@ -754,7 +754,7 @@ void showTopologyNodeGraph(WorkspaceGUIState& state,
         }
         draw_list->AddRectFilled(offset + slotPos - ImVec2{node->oldestPossibleInput[item].textSize + 5.f * NODE_SLOT_RADIUS, 2 * NODE_SLOT_RADIUS},
                                  offset + slotPos + ImVec2{-4.5f * NODE_SLOT_RADIUS, 2 * NODE_SLOT_RADIUS}, NODE_LABEL_BACKGROUND_COLOR, 2., ImDrawFlags_RoundCornersAll);
-        draw_list->AddText(0, 12,
+        draw_list->AddText(nullptr, 12,
                            offset + slotPos - ImVec2{node->oldestPossibleInput[item].textSize + 4.5f * NODE_SLOT_RADIUS, 2 * NODE_SLOT_RADIUS},
                            NODE_LABEL_TEXT_COLOR,
                            node->oldestPossibleInput[item].buffer);
@@ -791,7 +791,7 @@ void showTopologyNodeGraph(WorkspaceGUIState& state,
         auto rectBR = ImVec2{node->oldestPossibleOutput[item].textSize + 5.f * NODE_SLOT_RADIUS, 2 * NODE_SLOT_RADIUS};
         draw_list->AddRectFilled(offset + slotPos + rectTL,
                                  offset + slotPos + rectBR, NODE_LABEL_BACKGROUND_COLOR, 2., ImDrawFlags_RoundCornersAll);
-        draw_list->AddText(0, 12,
+        draw_list->AddText(nullptr, 12,
                            offset + slotPos + rectTL,
                            NODE_LABEL_TEXT_COLOR,
                            node->oldestPossibleOutput[item].buffer);

--- a/Framework/GUISupport/src/FrameworkGUIDevicesGraph.cxx
+++ b/Framework/GUISupport/src/FrameworkGUIDevicesGraph.cxx
@@ -74,6 +74,8 @@ NodeColor decideColorForNode(const DeviceInfo& info)
 /// Color choices
 const static ImColor INPUT_SLOT_COLOR = {150, 150, 150, 150};
 const static ImColor OUTPUT_SLOT_COLOR = {150, 150, 150, 150};
+const static ImColor NODE_LABEL_BACKGROUND_COLOR = {45, 45, 45, 255};
+const static ImColor NODE_LABEL_TEXT_COLOR = {244, 244, 244, 255};
 const static ImVec4& ERROR_MESSAGE_COLOR = PaletteHelpers::RED;
 const static ImVec4& WARNING_MESSAGE_COLOR = PaletteHelpers::YELLOW;
 const static ImColor ARROW_COLOR = {200, 200, 100};
@@ -92,6 +94,10 @@ const static ImVec4 SLOT_EMPTY_COLOR = {0.275, 0.275, 0.275, 1.};
 const static ImVec4& SLOT_PENDING_COLOR = PaletteHelpers::RED;
 const static ImVec4& SLOT_DISPATCHED_COLOR = PaletteHelpers::YELLOW;
 const static ImVec4& SLOT_DONE_COLOR = PaletteHelpers::GREEN;
+
+/// Node size
+const float NODE_SLOT_RADIUS = 4.0f;
+const ImVec2 NODE_WINDOW_PADDING(8.0f, 8.0f);
 
 /// Displays a grid
 void displayGrid(bool show_grid, ImVec2 offset, ImDrawList* draw_list)
@@ -159,6 +165,21 @@ struct Group {
   }
 };
 
+constexpr int MAX_SLOTS = 512;
+constexpr int MAX_INPUT_VALUE_SIZE = 24;
+
+struct OldestPossibleInput {
+  size_t value;
+  char buffer[MAX_INPUT_VALUE_SIZE] = "unknown";
+  float textSize = ImGui::CalcTextSize("unknown").x;
+};
+
+struct OldestPossibleOutput {
+  size_t value;
+  char buffer[MAX_INPUT_VALUE_SIZE] = "unknown";
+  float textSize = ImGui::CalcTextSize("unknown").x;
+};
+
 // Private helper struct for the graph model
 struct Node {
   int ID;
@@ -168,6 +189,8 @@ struct Node {
   float Value;
   ImVec4 Color;
   int InputsCount, OutputsCount;
+  OldestPossibleInput oldestPossibleInput[MAX_SLOTS];
+  OldestPossibleOutput oldestPossibleOutput[MAX_SLOTS];
 
   Node(int id, int groupID, char const* name, float value, const ImVec4& color, int inputs_count, int outputs_count)
   {
@@ -214,6 +237,124 @@ struct NodeLink {
   }
 };
 
+/// Helper to draw metrics
+template <typename RECORD, typename ITEM, typename CONTEXT>
+struct MetricsPainter {
+  using NumRecordsCallback = std::function<size_t(void)>;
+  using RecordCallback = std::function<RECORD(size_t)>;
+  using NumItemsCallback = std::function<size_t(RECORD const&)>;
+  using ItemCallback = std::function<ITEM const&(RECORD const&, size_t)>;
+  using ValueCallback = std::function<int(ITEM const&)>;
+  using ColorCallback = std::function<ImU32(int value)>;
+  using ContextCallback = std::function<CONTEXT&()>;
+  using PaintCallback = std::function<void(int row, int column, int value, ImU32 color, CONTEXT const& context)>;
+
+  static void draw(const char* name,
+                   ImVec2 const& offset,
+                   ImVec2 const& sizeHint,
+                   CONTEXT const& context,
+                   NumRecordsCallback const& getNumRecords,
+                   RecordCallback const& getRecord,
+                   NumItemsCallback const& getNumItems,
+                   ItemCallback const& getItem,
+                   ValueCallback const& getValue,
+                   ColorCallback const& getColor,
+                   PaintCallback const& describeCell)
+  {
+    for (size_t ri = 0; ri < getNumRecords(); ++ri) {
+      auto record = getRecord(ri);
+      for (size_t ii = 0; ii < getNumItems(record); ++ii) {
+        auto item = getItem(record, ii);
+        int value = getValue(item);
+        ImU32 color = getColor(value);
+        ImVec2 pos = ImGui::GetCursorScreenPos();
+        describeCell(ri, ii, value, color, context);
+      }
+    }
+  }
+
+  static NumRecordsCallback metric1D()
+  {
+    return []() -> size_t { return 1UL; };
+  }
+
+  static NumRecordsCallback metric2D(Metric2DViewIndex& viewIndex)
+  {
+    return [&viewIndex]() -> size_t {
+      if (viewIndex.isComplete()) {
+        return viewIndex.w;
+      }
+      return 0;
+    };
+  }
+
+  static NumItemsCallback items1D()
+  {
+    return [](RECORD const& record) -> size_t { return 1UL; };
+  }
+
+  static NumItemsCallback items2D(Metric2DViewIndex const& viewIndex)
+  {
+    return [&viewIndex](int record) -> int {
+      if (viewIndex.isComplete()) {
+        return viewIndex.h;
+      }
+      return 0;
+    };
+  }
+
+  template <typename T>
+  static ItemCallback latestMetric(DeviceMetricsInfo const& metrics,
+                                   Metric2DViewIndex const& viewIndex)
+  {
+    return [&metrics, &viewIndex](RECORD const& record, size_t i) -> ITEM const& {
+      // Calculate the index in the viewIndex.
+      auto idx = record * viewIndex.h + i;
+      assert(viewIndex.indexes.size() > idx);
+      MetricInfo const& metricInfo = metrics.metrics[viewIndex.indexes[idx]];
+      auto& data = DeviceMetricsInfoHelpers::get<T>(metrics, metricInfo.storeIdx);
+      return data[(metricInfo.pos - 1) % data.size()];
+    };
+  }
+
+  template <typename T>
+  static RecordCallback simpleRecord()
+  {
+    return [](size_t i) -> int {
+      return i;
+    };
+  }
+
+  template <typename T>
+  static ValueCallback simpleValue()
+  {
+    return [](ITEM const& item) -> T { return item; };
+  }
+
+  static ColorCallback colorPalette(std::vector<ImU32> const& colors, int minValue, int maxValue)
+  {
+    return [colors, minValue, maxValue](int const& value) -> ImU32 {
+      if (value < minValue) {
+        return colors[0];
+      } else if (value > maxValue) {
+        return colors[colors.size() - 1];
+      } else {
+        int idx = (value - minValue) * (colors.size() - 1) / (maxValue - minValue);
+        return colors[idx];
+      }
+    };
+  }
+};
+
+/// Context to draw the labels with the metrics
+struct MetricLabelsContext {
+  ImVector<Node>* nodes;
+  int nodeIdx;
+  ImVector<NodePos>* positions;
+  ImDrawList* draw_list;
+  ImVec2 offset;
+};
+
 void showTopologyNodeGraph(WorkspaceGUIState& state,
                            std::vector<DeviceInfo> const& infos,
                            std::vector<DeviceSpec> const& specs,
@@ -241,7 +382,7 @@ void showTopologyNodeGraph(WorkspaceGUIState& state,
   static bool show_legend = true;
   static int node_selected = -1;
 
-  auto prepareChannelView = [&specs, &metadata](ImVector<Node>& nodeList, ImVector<Group>& groupList) {
+  auto prepareChannelView = [&specs, &metricsInfos, &metadata](ImVector<Node>& nodeList, ImVector<Group>& groupList) {
     struct LinkInfo {
       int specId;
       int outputId;
@@ -429,9 +570,6 @@ void showTopologyNodeGraph(WorkspaceGUIState& state,
 
   ImGui::BeginGroup();
 
-  const float NODE_SLOT_RADIUS = 4.0f;
-  const ImVec2 NODE_WINDOW_PADDING(8.0f, 8.0f);
-
   ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(1, 1));
   ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0, 0));
 #if defined(ImGuiCol_ChildWindowBg)
@@ -476,6 +614,7 @@ void showTopologyNodeGraph(WorkspaceGUIState& state,
     draw_list->AddBezierCurve(p1, p1 + ImVec2(+50, 0), p2 + ImVec2(-50, 0), p2, color, thickness);
   }
 
+  auto fgDrawList = ImGui::GetForegroundDrawList();
   // Display nodes
   for (int node_idx = 0; node_idx < nodes.Size; node_idx++) {
     auto backgroundLayer = (node_idx + 1) * 2;
@@ -571,7 +710,9 @@ void showTopologyNodeGraph(WorkspaceGUIState& state,
     draw_list->AddRectFilled(node_rect_min, node_rect_max, node_bg_color, 4.0f);
     draw_list->AddRectFilled(node_rect_min, node_rect_title, node_title_color, 4.0f);
     draw_list->AddRect(node_rect_min, node_rect_max, NODE_BORDER_COLOR, NODE_BORDER_THICKNESS);
+
     for (int slot_idx = 0; slot_idx < node->InputsCount; slot_idx++) {
+      draw_list->ChannelsSetCurrent(backgroundLayer); // Background
       ImVec2 p1(-3 * NODE_SLOT_RADIUS, NODE_SLOT_RADIUS), p2(-3 * NODE_SLOT_RADIUS, -NODE_SLOT_RADIUS), p3(0, 0);
       auto pp1 = p1 + offset + NodePos::GetInputSlotPos(nodes, positions, node_idx, slot_idx);
       auto pp2 = p2 + offset + NodePos::GetInputSlotPos(nodes, positions, node_idx, slot_idx);
@@ -581,11 +722,80 @@ void showTopologyNodeGraph(WorkspaceGUIState& state,
         color = ARROW_SELECTED_COLOR;
       }
       draw_list->AddTriangleFilled(pp1, pp2, pp3, color);
-      draw_list->AddCircleFilled(offset + NodePos::GetInputSlotPos(nodes, positions, node_idx, slot_idx), NODE_SLOT_RADIUS, INPUT_SLOT_COLOR);
+      auto slotPos = NodePos::GetInputSlotPos(nodes, positions, node_idx, slot_idx);
+      draw_list->AddCircleFilled(offset + slotPos, NODE_SLOT_RADIUS, INPUT_SLOT_COLOR);
     }
+
+    draw_list->ChannelsSetCurrent(foregroundLayer);
+    MetricLabelsContext context{&nodes, node_idx, &positions, draw_list, offset};
+    /// Paint the input labels
+    MetricsPainter<int, uint64_t, MetricLabelsContext>::draw(
+      "input_labels",
+      offset,
+      ImVec2{node->Size.x, node->Size.y},
+      context,
+      MetricsPainter<int, uint64_t, MetricLabelsContext>::metric1D(),
+      MetricsPainter<int, uint64_t, MetricLabelsContext>::simpleRecord<int>(),
+      MetricsPainter<int, uint64_t, MetricLabelsContext>::items2D(info.inputChannelMetricsViewIndex),
+      MetricsPainter<int, uint64_t, MetricLabelsContext>::latestMetric<uint64_t>(metricsInfos[node->ID], info.inputChannelMetricsViewIndex),
+      MetricsPainter<int, uint64_t, MetricLabelsContext>::simpleValue<uint64_t>(),
+      MetricsPainter<int, uint64_t, MetricLabelsContext>::colorPalette(std::vector<ImU32>{{ImColor(0, 100, 0, 255), ImColor(0, 0, 100, 255), ImColor(100, 0, 0, 255)}}, 0, 3),
+      [](int, int item, int value, ImU32 color, MetricLabelsContext const& context) {
+        auto draw_list = context.draw_list;
+        auto offset = context.offset;
+        auto slotPos = NodePos::GetInputSlotPos(nodes, positions, context.nodeIdx, item);
+        Node* node = &nodes[context.nodeIdx];
+        auto& label = node->oldestPossibleInput[item];
+        // Avoid recomputing if the value is the same.
+        if (label.value != value) {
+          label.value = value;
+          snprintf(label.buffer, sizeof(label.buffer), "%d", value);
+          label.textSize = ImGui::CalcTextSize(label.buffer).x;
+        }
+        draw_list->AddRectFilled(offset + slotPos - ImVec2{node->oldestPossibleInput[item].textSize + 5.f * NODE_SLOT_RADIUS, 2 * NODE_SLOT_RADIUS},
+                                 offset + slotPos + ImVec2{-4.5f * NODE_SLOT_RADIUS, 2 * NODE_SLOT_RADIUS}, NODE_LABEL_BACKGROUND_COLOR, 2., ImDrawFlags_RoundCornersAll);
+        draw_list->AddText(0, 12,
+                           offset + slotPos - ImVec2{node->oldestPossibleInput[item].textSize + 4.5f * NODE_SLOT_RADIUS, 2 * NODE_SLOT_RADIUS},
+                           NODE_LABEL_TEXT_COLOR,
+                           node->oldestPossibleInput[item].buffer);
+      });
+
     for (int slot_idx = 0; slot_idx < node->OutputsCount; slot_idx++) {
       draw_list->AddCircleFilled(offset + NodePos::GetOutputSlotPos(nodes, positions, node_idx, slot_idx), NODE_SLOT_RADIUS, OUTPUT_SLOT_COLOR);
     }
+
+    MetricsPainter<int, uint64_t, MetricLabelsContext>::draw(
+      "output_labels",
+      offset,
+      ImVec2{node->Size.x, node->Size.y},
+      context,
+      MetricsPainter<int, uint64_t, MetricLabelsContext>::metric1D(),
+      MetricsPainter<int, uint64_t, MetricLabelsContext>::simpleRecord<int>(),
+      MetricsPainter<int, uint64_t, MetricLabelsContext>::items2D(info.outputChannelMetricsViewIndex),
+      MetricsPainter<int, uint64_t, MetricLabelsContext>::latestMetric<uint64_t>(metricsInfos[node->ID], info.outputChannelMetricsViewIndex),
+      MetricsPainter<int, uint64_t, MetricLabelsContext>::simpleValue<uint64_t>(),
+      MetricsPainter<int, uint64_t, MetricLabelsContext>::colorPalette(std::vector<ImU32>{{ImColor(0, 100, 0, 255), ImColor(0, 0, 100, 255), ImColor(100, 0, 0, 255)}}, 0, 3),
+      [](int, int item, int value, ImU32 color, MetricLabelsContext const& context) {
+        auto draw_list = context.draw_list;
+        auto offset = context.offset;
+        auto slotPos = NodePos::GetOutputSlotPos(nodes, positions, context.nodeIdx, item);
+        Node* node = &nodes[context.nodeIdx];
+        auto& label = node->oldestPossibleOutput[item];
+        // Avoid recomputing if the value is the same.
+        if (label.value != value) {
+          label.value = value;
+          snprintf(label.buffer, sizeof(label.buffer), "%d", value);
+          label.textSize = ImGui::CalcTextSize(label.buffer).x;
+        }
+        auto rectTL = ImVec2{4.5f * NODE_SLOT_RADIUS, -2 * NODE_SLOT_RADIUS};
+        auto rectBR = ImVec2{node->oldestPossibleOutput[item].textSize + 5.f * NODE_SLOT_RADIUS, 2 * NODE_SLOT_RADIUS};
+        draw_list->AddRectFilled(offset + slotPos + rectTL,
+                                 offset + slotPos + rectBR, NODE_LABEL_BACKGROUND_COLOR, 2., ImDrawFlags_RoundCornersAll);
+        draw_list->AddText(0, 12,
+                           offset + slotPos + rectTL,
+                           NODE_LABEL_TEXT_COLOR,
+                           node->oldestPossibleOutput[item].buffer);
+      });
 
     ImGui::PopID();
   }
@@ -608,7 +818,7 @@ void showTopologyNodeGraph(WorkspaceGUIState& state,
   }
 
   // Scrolling
-  //if (ImGui::IsWindowHovered() && !ImGui::IsAnyItemActive() && ImGui::IsMouseDragging(2, 0.0f))
+  // if (ImGui::IsWindowHovered() && !ImGui::IsAnyItemActive() && ImGui::IsMouseDragging(2, 0.0f))
   //    scrolling = scrolling - ImGui::GetIO().MouseDelta;
 
   ImGui::PopItemWidth();


### PR DESCRIPTION
This adds labels to each of the channels in input and in output.

In particular the current implementation allows to display the
oldest possible timeslice as seen by the inputs and the one notified
on the output.

Notice that due to the way sending works, the metric on the output
channel might be somewhat delayed wrt its real value.