### PR TITLE
ctf-writer logs per-det. data sizes every --report-data-size-interval TFs

### DIFF
--- a/Detectors/CTF/workflow/include/CTFWorkflow/CTFWriterSpec.h
+++ b/Detectors/CTF/workflow/include/CTFWorkflow/CTFWriterSpec.h
@@ -24,7 +24,7 @@ namespace ctf
 {
 
 /// create a processor spec
-framework::DataProcessorSpec getCTFWriterSpec(o2::detectors::DetID::mask_t dets, uint64_t run, const std::string& outType, int verbosity);
+framework::DataProcessorSpec getCTFWriterSpec(o2::detectors::DetID::mask_t dets, uint64_t run, const std::string& outType, int verbosity, int reportInterval);
 
 } // namespace ctf
 } // namespace o2

--- a/Detectors/CTF/workflow/src/ctf-writer-workflow.cxx
+++ b/Detectors/CTF/workflow/src/ctf-writer-workflow.cxx
@@ -36,6 +36,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   options.push_back(ConfigParamSpec{"no-grp", VariantType::Bool, false, {"do not read GRP file"}});
   options.push_back(ConfigParamSpec{"output-type", VariantType::String, "ctf", {"output types: ctf (per TF) or dict (create dictionaries) or both or none"}});
   options.push_back(ConfigParamSpec{"ctf-writer-verbosity", VariantType::Int, 0, {"verbosity level (0: summary per detector, 1: summary per block"}});
+  options.push_back(ConfigParamSpec{"report-data-size-interval", VariantType::Int, 200, {"report sizes per detector for every N-th timeframe"}});
   options.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}});
   std::swap(workflowOptions, options);
 }
@@ -80,6 +81,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     }
     outType = configcontext.options().get<std::string>("output-type");
   }
-  WorkflowSpec specs{o2::ctf::getCTFWriterSpec(dets, run, outType, configcontext.options().get<int>("ctf-writer-verbosity"))};
+  WorkflowSpec specs{o2::ctf::getCTFWriterSpec(dets, run, outType,
+                                               configcontext.options().get<int>("ctf-writer-verbosity"),
+                                               configcontext.options().get<int>("report-data-size-interval"))};
   return std::move(specs);
 }


### PR DESCRIPTION
@davidrohr e.g. for FST reports:
```
[IMPORTANT] CTF#0 size: ITS:1156776 TPC:243714102 TRD:14806105 TOF:355787 PHS:87223 CPV:479847 EMC:109134 HMP:646 MFT:390180 MCH:879173 MID:267335 ZDC:502826 FT0:35119 FV0:1476 FDD:3090 CTP:3602
```