### PR TITLE
Populator may to adjust previous EOV to SOV of new CCDB object

### DIFF
--- a/CCDB/include/CCDB/CCDBTimeStampUtils.h
+++ b/CCDB/include/CCDB/CCDBTimeStampUtils.h
@@ -16,12 +16,14 @@
 #ifndef O2_CCDBTIMESTAMPUTILS_H
 #define O2_CCDBTIMESTAMPUTILS_H
 
-/// a couple of static helper functions to create timestamp values for CCDB queries
+/// a couple of static helper functions to create timestamp values for CCDB queries or override obsolete objects
 
 namespace o2
 {
 namespace ccdb
 {
+class CcdbApi;
+class CcdbObjectInfo;
 
 /// returns the timestamp in long corresponding to "now + secondsInFuture"
 long getFutureTimestamp(int secondsInFuture);
@@ -31,6 +33,9 @@ long getCurrentTimestamp();
 
 /// \brief Converting time into numerical time stamp representation
 long createTimestamp(int year, int month, int day, int hour, int minutes, int seconds);
+
+/// \brief set EOV of overriden objects to SOV-1 of overriding one if it is allowed
+int adjustOverriddenEOV(CcdbApi& api, const CcdbObjectInfo& infoNew);
 
 } // namespace ccdb
 } // namespace o2

--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -204,7 +204,7 @@ class CcdbApi //: public DatabaseInterface
    * @param timestamp The timestamp to select the object
    * @param id The id, if any, to select the object
    */
-  void updateMetadata(std::string const& path, std::map<std::string, std::string> const& metadata, long timestamp, std::string const& id = "");
+  void updateMetadata(std::string const& path, std::map<std::string, std::string> const& metadata, long timestamp, std::string const& id = "", long newEOV = 0);
 
   /**
    * Return the listing of objects, and in some cases subfolders, matching this path.

--- a/CCDB/include/CCDB/CcdbObjectInfo.h
+++ b/CCDB/include/CCDB/CcdbObjectInfo.h
@@ -33,12 +33,19 @@ class CcdbObjectInfo
   static constexpr long YEAR = 364 * DAY;
   static constexpr long INFINITE_TIMESTAMP = 9999999999999;
   static constexpr long INFINITE_TIMESTAMP_SECONDS = 2000000000; // not really inifinity, but close to std::numeric_limits<int>::max() till 18.05.2033
+  static constexpr const char* AdjustableEOV = "adjustableEOV";
+  static constexpr const char* DefaultObj = "default";
 
   CcdbObjectInfo() = default;
   CcdbObjectInfo(std::string path, std::string objType, std::string flName,
                  std::map<std::string, std::string> metadata,
-                 long startValidityTimestamp, long endValidityTimestamp)
-    : mObjType(std::move(objType)), mFileName(std::move(flName)), mPath(std::move(path)), mMD(std::move(metadata)), mStart(startValidityTimestamp), mEnd(endValidityTimestamp) {}
+                 long startValidityTimestamp, long endValidityTimestamp, bool adjustableEOV = true)
+    : mObjType(std::move(objType)), mFileName(std::move(flName)), mPath(std::move(path)), mMD(std::move(metadata)), mStart(startValidityTimestamp), mEnd(endValidityTimestamp)
+  {
+    if (adjustableEOV) {
+      setAdjustableEOV();
+    }
+  }
   ~CcdbObjectInfo() = default;
 
   [[nodiscard]] const std::string& getObjectType() const { return mObjType; }
@@ -51,7 +58,26 @@ class CcdbObjectInfo
   void setPath(const std::string& path) { mPath = path; }
 
   [[nodiscard]] const std::map<std::string, std::string>& getMetaData() const { return mMD; }
-  void setMetaData(const std::map<std::string, std::string>& md) { mMD = md; }
+  void setMetaData(const std::map<std::string, std::string>& md)
+  {
+    mMD = md;
+    if (mAdjustableEOV) {
+      setAdjustableEOV();
+    }
+  }
+
+  void setAdjustableEOV()
+  {
+    mAdjustableEOV = true;
+    if (mMD.find(DefaultObj) != mMD.end()) {
+      LOGP(fatal, "default object cannot have adjustable EOV, {}", mPath);
+    }
+    if (mMD.find(AdjustableEOV) == mMD.end()) {
+      mMD[AdjustableEOV] = "true";
+    }
+  }
+
+  bool isAdjustableEOV() const { return mAdjustableEOV; }
 
   [[nodiscard]] long getStartValidityTimestamp() const { return mStart; }
   void setStartValidityTimestamp(long start) { mStart = start; }
@@ -66,8 +92,8 @@ class CcdbObjectInfo
   std::map<std::string, std::string> mMD; // metadata
   long mStart = 0;                        // start of the validity of the object
   long mEnd = 0;                          // end of the validity of the object
-
-  ClassDefNV(CcdbObjectInfo, 1);
+  bool mAdjustableEOV = false;            // each new object may override EOV of object it overrides to its own SOV
+  ClassDefNV(CcdbObjectInfo, 2);
 };
 
 } // namespace o2::ccdb

--- a/CCDB/src/CCDBTimeStampUtils.cxx
+++ b/CCDB/src/CCDBTimeStampUtils.cxx
@@ -12,7 +12,9 @@
 //
 // Created by Sandro Wenzel on 2019-08-20.
 //
-#include <CCDB/CCDBTimeStampUtils.h>
+#include "CCDB/CCDBTimeStampUtils.h"
+#include "CCDB/CcdbApi.h"
+#include "CCDB/CcdbObjectInfo.h"
 #include <chrono>
 #include <ctime>
 
@@ -52,6 +54,27 @@ long createTimestamp(int year, int month, int day, int hour, int minutes, int se
 
   time_t timeformat = mktime(&timeinfo);
   return static_cast<long>(timeformat);
+}
+
+int adjustOverriddenEOV(CcdbApi& api, const CcdbObjectInfo& infoNew)
+{
+  int res = 0;
+  if (infoNew.getStartValidityTimestamp() > 0) {
+    std::map<std::string, std::string> dummyMD, prevHeader;
+    dummyMD[o2::ccdb::CcdbObjectInfo::AdjustableEOV] = "true";
+    prevHeader = api.retrieveHeaders(infoNew.getPath(), dummyMD, infoNew.getStartValidityTimestamp() - 1); // is there an adjustable object to override?
+    const auto itETag = prevHeader.find("ETag");
+    if (itETag != prevHeader.end() &&
+        prevHeader.find(o2::ccdb::CcdbObjectInfo::AdjustableEOV) != prevHeader.end() &&
+        prevHeader.find(o2::ccdb::CcdbObjectInfo::DefaultObj) == prevHeader.end()) {
+      std::string etag = itETag->second;
+      etag.erase(remove(etag.begin(), etag.end(), '\"'), etag.end());
+      LOGP(info, "Adjusting EOV of previous {}/{}/{} to {} (id:{})", infoNew.getPath(), prevHeader["Valid-From"], prevHeader["Valid-Until"], infoNew.getStartValidityTimestamp() - 1, etag);
+      // equivalent of std::string cmd = fmt::format("sh -c \"curl -X PUT {}{}{}/{}/{}\"", api.getURL(), api.getURL().back() == '/' ? "" : "/", infoNew.getPath(), infoNew.getStartValidityTimestamp() - 1, infoNew.getStartValidityTimestamp());
+      api.updateMetadata(infoNew.getPath(), {}, infoNew.getStartValidityTimestamp() - 1, etag, infoNew.getStartValidityTimestamp());
+    }
+  }
+  return res;
 }
 
 } // namespace o2::ccdb

--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -1280,7 +1280,7 @@ TClass* CcdbApi::tinfo2TClass(std::type_info const& tinfo)
   return cl;
 }
 
-void CcdbApi::updateMetadata(std::string const& path, std::map<std::string, std::string> const& metadata, long timestamp, std::string const& id)
+void CcdbApi::updateMetadata(std::string const& path, std::map<std::string, std::string> const& metadata, long timestamp, std::string const& id, long newEOV)
 {
   CURL* curl = curl_easy_init();
   if (curl != nullptr) {
@@ -1288,6 +1288,9 @@ void CcdbApi::updateMetadata(std::string const& path, std::map<std::string, std:
     stringstream fullUrl;
     for (size_t hostIndex = 0; hostIndex < hostsPool.size(); hostIndex++) {
       fullUrl << getHostUrl(hostIndex) << "/" << path << "/" << timestamp;
+      if (newEOV > 0) {
+        fullUrl << "/" << newEOV;
+      }
       if (!id.empty()) {
         fullUrl << "/" << id;
       }
@@ -1305,9 +1308,11 @@ void CcdbApi::updateMetadata(std::string const& path, std::map<std::string, std:
       }
 
       if (curl != nullptr) {
+        LOG(debug) << "passing to curl: " << fullUrl.str();
         curl_easy_setopt(curl, CURLOPT_URL, fullUrl.str().c_str());
         curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PUT"); // make sure we use PUT
         curl_easy_setopt(curl, CURLOPT_USERAGENT, mUniqueAgentID.c_str());
+        curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
         curlSetSSLOptions(curl);
 
         // Perform the request, res will get the return code


### PR DESCRIPTION
If the CcdbObjectInfo of the object sent to the populator was created with
adjustableEOV flag (default), then, after uploading the new object populator will
override the EOV of the previous overlapping object (if any) to the SOV of
the new object. This is done only provided the object to override has metadata
key \"adjustableEOV\" defined (value is irrelevant) and has no \"default\" key.
The newly uploaded object will have this \"adjustableEOV\" assigned in its metadata.

@costing did in a somewhat different way, could you check. Tested on the http://ccdb-test.cern.ch:8080/browse/TST/Override?report=true, I guess on the http://alice-ccdb.cern.ch it should not work since credentials will be requested.
What would be the curl API call equivalent to `curl -X PUT http://ccdb-test.cern.ch:8080/TST/Override/1499/1500`