### PR TITLE
use muon-experts for all muon dirs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -63,7 +63,7 @@
 /Detectors/GlobalTrackingWorkflow  @shahor02
 /Detectors/HMPID                   @gvolpe79
 /Detectors/ITSMFT                  @iouribelikov @bovulpes @rpezzi @mconcas
-/Detectors/MUON                    @AliceO2Group/muon-experts 
+/Detectors/MUON                    @AliceO2Group/muon-experts
 /Detectors/PHOS                    @peressounko @kharlov
 /Detectors/Passive                 @sawenzel
 /Detectors/TOF                     @noferini

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -63,7 +63,7 @@
 /Detectors/GlobalTrackingWorkflow  @shahor02
 /Detectors/HMPID                   @gvolpe79
 /Detectors/ITSMFT                  @iouribelikov @bovulpes @rpezzi @mconcas
-/Detectors/MUON                    @aphecetche @pillot
+/Detectors/MUON                    @AliceO2Group/muon-experts 
 /Detectors/PHOS                    @peressounko @kharlov
 /Detectors/Passive                 @sawenzel
 /Detectors/TOF                     @noferini


### PR DESCRIPTION
@ktf I guess this is the missing part to allow @pillot to actually merge Muon PRs ?