### PR TITLE
TRD fix handling bad cru halfchamber headers, and errorneous data at end of buffers

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
@@ -85,6 +85,7 @@ constexpr int MAXLINKERRORHISTOGRAMS = 10;     // size of the array holding the 
 constexpr int MAXPARSEERRORHISTOGRAMS = 60;    // size of the array holding the parsing error plots from the raw reader
 constexpr int ETYPEPHYSICSTRIGGER = 0x2;       // CRU Half Chamber header eventtype definition
 constexpr int ETYPECALIBRATIONTRIGGER = 0x3;   // CRU Half Chamber header eventtype definition
+constexpr int MAXCRUERRORVALUE = 0x2;          // Max possible value for a CRU Halfchamber link error. As of may 2022, can only be 0x0, 0x1, and 0x2, at least that is all so far(may2022).
 
 } //namespace constants
 } // namespace trd

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
@@ -83,8 +83,8 @@ Word 7  |              reserved 5                       |             link 14 da
       uint64_t HeaderVersion : 8;  // TRD Header Version
       uint64_t BunchCrossing : 12; // bunch crossing of the physics trigger.
       //NB  The BC in the RDH is the BC sent together with the heartbeat trigger, while the BC in the HalfCRUHeader is the BC of the physics trigger where the data that follows the HalfCRUHeader belongs to. However, it is not forbidden for CTP to send the heartbeat trigger together with a physics trigger, in this case the two would match (accidentally).
-      uint64_t StopBit : 4;        // 8 .. 11 stop bit  0x1 if TRD packet is last data packet of trigger, else 0x0  TODO why 4 bits if only using 1?
-      uint64_t EndPoint : 4;       // bit 0..7 event type of the data. Trigger bits from TTC-PON message, distinguish physics from calibration events.
+      uint64_t StopBit : 4;        // 8 .. 11 stop bit  0x1 if TRD packet is last data packet of trigger, else 0x0
+      uint64_t EndPoint : 4;       // pci end point upper or lower 15 links of cru
       uint64_t EventType : 4;      // bit 0..7 event type of the data. Trigger bits from TTC-PON message, distinguish physics from calibration events.
       uint64_t reserveda : 32;     //
     } __attribute__((__packed__));
@@ -447,6 +447,7 @@ bool trackletHCHeaderSanityCheck(o2::trd::TrackletHCHeader& header);
 bool digitMCMHeaderSanityCheck(o2::trd::DigitMCMHeader* header);
 bool digitMCMADCMaskSanityCheck(o2::trd::DigitMCMADCMask& mask, int numberofbitsset);
 bool digitMCMWordSanityCheck(o2::trd::DigitMCMData* word, int adcchannel);
+bool halfCRUHeaderSanityCheck(o2::trd::HalfCRUHeader& header, std::array<uint32_t, 15>& lengths, std::array<uint32_t, 15>& eflags);
 void printDigitMCMHeader(o2::trd::DigitMCMHeader& header);
 int getDigitHCHeaderWordType(uint32_t word);
 void printDigitHCHeader(o2::trd::DigitHCHeader& header, uint32_t headers[3]);

--- a/DataFormats/Detectors/TRD/src/RawData.cxx
+++ b/DataFormats/Detectors/TRD/src/RawData.cxx
@@ -333,6 +333,36 @@ std::ostream& operator<<(std::ostream& stream, const HalfCRUHeader& halfcru)
   return stream;
 }
 
+bool halfCRUHeaderSanityCheck(o2::trd::HalfCRUHeader& header, std::array<uint32_t, 15>& lengths, std::array<uint32_t, 15>& eflags)
+{
+  // check the sizes for less than max value
+  // check the errors for either < 0x3, for now (may 2022) there is only no error, 1, or 2.
+  //
+  bool goodheader = true;
+  for (int lengthindex = 0; lengthindex < 15; ++lengthindex) {
+    if (lengths[lengthindex] > o2::trd::constants::MAXDATAPERLINK256) {
+      // something has gone insane.
+      //LOG(info) << "AAA dumping half cru as : half cru link length > max possible! : " << lengths[lengthindex] << " ?? " << o2::trd::constants::MAXDATAPERLINK256;
+      goodheader = false;
+    }
+  }
+  for (int eflagindex = 0; eflagindex < 15; ++eflagindex) {
+    if (eflags[eflagindex] > o2::trd::constants::MAXCRUERRORVALUE) {
+      // something has gone insane.
+      // LOG(info) << "AAA dumping half cru as : half cru link eflag > max possible! : " << std::hex << eflags[eflagindex] << " ?? " << o2::trd::constants::MAXCRUERRORVALUE;
+      goodheader = false;
+    }
+    if (header.EndPoint > 1) {
+      // end point can only be zero or 1, for ach of the 2 pci end points in the cru
+      goodheader = false;
+    }
+    //LOG(info) << "Header sanity check is : " << goodheader;
+    goodheader = false;
+  }
+
+  return goodheader;
+}
+
 bool trackletMCMHeaderSanityCheck(o2::trd::TrackletMCMHeader& header)
 {
   // a bit limited to what we can check.

--- a/Detectors/TRD/reconstruction/src/CruRawReader.cxx
+++ b/Detectors/TRD/reconstruction/src/CruRawReader.cxx
@@ -117,7 +117,7 @@ void CruRawReader::OutputHalfCruRawData()
 void CruRawReader::dumpRDHAndNextHeader(const o2::header::RDHAny* rdh)
 {
   LOG(info) << "######################### Dumping RDH incoming buffer ##########################";
-  o2::raw::RDHUtils::printRDH(rdh);
+  //  o2::raw::RDHUtils::printRDH(rdh);
   LOG(info) << "Now for the buffer breakdown";
   auto offsetToNext = o2::raw::RDHUtils::getOffsetToNext(rdh);
   for (int i = 0; i < offsetToNext / 4; ++i) {
@@ -140,6 +140,9 @@ bool CruRawReader::processHBFs(int datasizealreadyread, bool verbose)
   auto rdh = mDataRDH;
   auto preceedingrdh = rdh;
   uint32_t totaldataread = 0;
+  if (mHeaderVerbose) {
+    LOG(info) << " mem : " << o2::raw::RDHUtils::getMemorySize(rdh) << " headersize : " << o2::raw::RDHUtils::getHeaderSize(rdh);
+  }
   mState = CRUStateHalfCRUHeader;
   uint32_t currentsaveddatacount = 0;
   mTotalHBFPayLoad = 0;
@@ -150,7 +153,6 @@ bool CruRawReader::processHBFs(int datasizealreadyread, bool verbose)
   while (!o2::raw::RDHUtils::getStop(rdh)) { // carry on till the end of the event.
     if (mHeaderVerbose) {
       LOG(info) << "----------------------------------------------";
-      LOG(info) << "--- RDH open/continue detected loopcount :" << loopcount;
       LOG(info) << " rdh first word 0x" << std::hex << (uint32_t)*mDataPointer;
       LOG(info) << " rdh first word is sitting at 0x" << std::hex << (void*)mDataPointer;
       o2::raw::RDHUtils::printRDH(rdh);
@@ -190,7 +192,7 @@ bool CruRawReader::processHBFs(int datasizealreadyread, bool verbose)
         LOG(info) << "Next rdh is not a stop, and has a header size of " << o2::raw::RDHUtils::getHeaderSize(rdh) << " and memsize of : " << o2::raw::RDHUtils::getMemorySize(rdh);
         LOG(info) << "rdh 0x" << (void*)rdh << " bufsize:" << mDataBufferSize << " payload start: 0x" << (void*)&mHBFPayload[0] << " mHBFoffset32 " << std::dec << mHBFoffset32;
         LOGP(info, " rdh::: {0:08x} {1:08x} {2:08x}  {3:08x} {4:08x} {5:08x} {6:08x} {7:08x} ", *((uint32_t*)rdh), *((uint32_t*)rdh + 1), *((uint32_t*)rdh + 2), *((uint32_t*)rdh + 3), *((uint32_t*)rdh + 4), *((uint32_t*)rdh + 5), *((uint32_t*)rdh + 6), *((uint32_t*)rdh + 7), *((uint32_t*)rdh + 8));
-        o2::raw::RDHUtils::printRDH(rdh);
+        //      o2::raw::RDHUtils::printRDH(rdh);
       } else {
         LOG(info) << "Next rdh is a stop, and we have moved to it.";
       }
@@ -217,8 +219,7 @@ bool CruRawReader::processHBFs(int datasizealreadyread, bool verbose)
   }
 
   // at this point the entire HBF data payload is sitting in mHBFPayload and the total data count is mTotalHBFPayLoad
-
-  while ((mHBFoffset32 < ((mTotalHBFPayLoad) / 4))) { // the blank event of eeeeee at the end
+  while ((mHBFoffset32 < ((mTotalHBFPayLoad) / 4))) {
     if (mHeaderVerbose) {
       LOG(info) << "Looping over cruheaders in HBF, loop count " << counthalfcru << " current offset is" << mHBFoffset32 << " total payload is " << mTotalHBFPayLoad / 4 << "  raw :" << mTotalHBFPayLoad;
     }
@@ -233,17 +234,22 @@ bool CruRawReader::processHBFs(int datasizealreadyread, bool verbose)
           break;
         case 1:
           LOG(info) << "all good parsing half cru";
+          LOG(info) << " mHBFoffset32:" << mHBFoffset32 << " and mTotalHBFPayload/4 : " << mTotalHBFPayLoad / 4;
           break;
         case 2:
           LOG(info) << "all good parsing half cru was blank double 0xe event";
           break;
-        default:
-          return true;
+          //        default:
+          //          return true;
       }
     }
     //take care of the case where there is an "empty" rdh containing all 0xeeeeeeee as payload.
-    if (mTotalHBFPayLoad / 4 - mHBFoffset32 == 8 && mHBFPayload[mHBFoffset32 + 7] == o2::trd::constants::CRUPADDING32) {
-      mHBFoffset32 += 8;
+    //    if (mTotalHBFPayLoad / 4 - mHBFoffset32 == 8 && mHBFPayload[mHBFoffset32 + 7] == o2::trd::constants::CRUPADDING32) {
+    //      mHBFoffset32 += 8;
+    //    }
+    if (halfcruprocess == -2) {
+      //dump rest of this rdh payload, something screwed up.
+      mHBFoffset32 = mTotalHBFPayLoad / 4;
     }
     counthalfcru++;
   } // loop of halfcru's while there is still data in the heart beat frame.
@@ -446,6 +452,22 @@ int CruRawReader::processHalfCRU(int cruhbfstartoffset)
   mTotalHalfCRUDataLength = mTotalHalfCRUDataLength256 * 32; //convert to bytes.
   int mTotalHalfCRUDataLength32 = mTotalHalfCRUDataLength256 * 8; //convert to bytes.
 
+  //can this half cru length fit into the available space of the rdh accumulated payload
+  if (mTotalHalfCRUDataLength32 > mTotalHBFPayLoad - mHBFoffset32) {
+    if (mMaxErrsPrinted > 0) {
+      LOG(error) << "Next HalfCRU header says it contains more data than in the rdh payloads! " << mTotalHalfCRUDataLength32 << " < " << mTotalHBFPayLoad << "-" << mHBFoffset32;
+      checkNoErr();
+    }
+    return -2;
+  }
+  if (halfCRUHeaderSanityCheck(mCurrentHalfCRUHeader, mCurrentHalfCRULinkLengths, mCurrentHalfCRULinkErrorFlags)) {
+    if (mMaxErrsPrinted > 0) {
+      LOG(error) << "HalfCRU header failed sanity check";
+      checkNoErr();
+    }
+    return -2;
+  }
+
   //get eventrecord for event we are looking at
   mIR.bc = mCurrentHalfCRUHeader.BunchCrossing; // correct mIR to have the physics trigger bunchcrossing *NOT* the heartbeat trigger bunch crossing.
   InteractionRecord trdir(mIR);
@@ -478,7 +500,7 @@ int CruRawReader::processHalfCRU(int cruhbfstartoffset)
       LOG(info) << "******* LINK # " << currentlinkindex;
     }
     //disaster dump the rest of this hbf
-    return 42;
+    return -2;
   }
 
   // verify cru header vs rdh header
@@ -753,6 +775,13 @@ bool CruRawReader::run()
     if (!goodprocessing) {
       //processHBFs returned false, get out of here ...
       LOG(error) << "Error processing heart beat frame ... good luck";
+      break;
+    }
+    if (totaldataread == 0) {
+      if (mMaxWarnPrinted > 0) {
+        LOG(warn) << "EEE  we read zero data but bailing out of here for now.";
+        checkNoWarn();
+      }
       break;
     }
   } while (((char*)mDataPointer - mDataBuffer) < mDataBufferSize);


### PR DESCRIPTION
- check for vaguely valid cruhalfchamber headers.
- skip data at the end if rdh and cruheaders dont match up on length, only seen crh header < rdh but both are handled.
- hack around going back onto an rdh stop.
- cruhalf chamber header is checked that :
-- lengths are < link maximal data
-- errors are  < known errors of 0x0 0x1 0x2 (checks <0x4)
-- checks sum of all lengths < payload, or remaining payload.
-- checks that endpoint is < 0x2, not sure why its 4 bits.
-- next reader also checks that the orbit is increasing, but cant trivially do that here.