### PR TITLE
[EMCAL-614] Adding parameter that turns off the L1 phase

### DIFF
--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/SimParam.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/SimParam.h
@@ -61,6 +61,7 @@ class SimParam : public o2::conf::ConfigurableParamHelper<SimParam>
   Bool_t doSimulateTimeResponse() const { return mSimulateTimeResponse; }
   Bool_t doRemoveDigitsBelowThreshold() const { return mRemoveDigitsBelowThreshold; }
   Bool_t doSimulateNoiseDigits() const { return mSimulateNoiseDigits; }
+  Bool_t doSimulateL1Phase() const { return mSimulateL1Phase; }
 
   Bool_t isDisablePileup() const { return mDisablePileup; }
 
@@ -100,6 +101,7 @@ class SimParam : public o2::conf::ConfigurableParamHelper<SimParam>
   Bool_t mSimulateTimeResponse{true};       ///< simulate time response
   Bool_t mRemoveDigitsBelowThreshold{true}; ///< remove digits below threshold
   Bool_t mSimulateNoiseDigits{true};        ///< simulate noise digits
+  bool mSimulateL1Phase{true};              ///< Simulate L1 phase
 
   // DigitizerSpec
   Bool_t mDisablePileup{false}; ///< disable pileup simulation

--- a/Detectors/EMCAL/simulation/src/Digitizer.cxx
+++ b/Detectors/EMCAL/simulation/src/Digitizer.cxx
@@ -209,7 +209,7 @@ void Digitizer::setEventTime(o2::InteractionTimeRecord record)
 
   mDigits.forwardMarker(record);
 
-  mPhase = mDigits.getPhase();
+  mPhase = mSimParam->doSimulateL1Phase() ? mDigits.getPhase() : 0;
 
   mEventTimeOffset = 0;
 

--- a/Detectors/EMCAL/simulation/src/SimParam.cxx
+++ b/Detectors/EMCAL/simulation/src/SimParam.cxx
@@ -52,6 +52,7 @@ void SimParam::PrintStream(std::ostream& stream) const
   stream << "\nEMCal::SimParam.mRemoveDigitsBelowThreshold = " << ((mRemoveDigitsBelowThreshold) ? "true" : "false");
   stream << "\nEMCal::SimParam.mSimulateNoiseDigits = " << ((mSimulateNoiseDigits) ? "true" : "false");
   stream << "\nEMCal::SimParam.mDisablePileup = " << ((mDisablePileup) ? "true" : "false");
+  stream << "\nEMCal::SimParam.mSimulateL1Phase = " << ((mSimulateL1Phase) ? "true" : "false");
 }
 
 Double_t SimParam::getTimeResolution(Double_t energy) const


### PR DESCRIPTION
A parameter has been added for switching off the L1 phase simulation. Since in data the L1 phase might be subtracted in the hardware.