### PR TITLE
Fix invalid digit index (overflow) in HMPID

### DIFF
--- a/Detectors/HMPID/simulation/include/HMPIDSimulation/HMPIDDigitizer.h
+++ b/Detectors/HMPID/simulation/include/HMPIDSimulation/HMPIDDigitizer.h
@@ -101,7 +101,7 @@ class HMPIDDigitizer
   constexpr static double TRACKHOLDTIME = 1200; // defines the window for pile-up after a trigger received in nanoseconds
   constexpr static double BUSYTIME = 22000;     // the time for which no new trigger can be received in nanoseconds
 
-  std::map<int, short> mIndexForPad; //! logarithmic mapping of pad to digit index
+  std::map<int, int> mIndexForPad; //! logarithmic mapping of pad to digit index
 
   std::vector<int> mInvolvedPads; //! list of pads where digits created
 

--- a/Detectors/HMPID/simulation/src/HMPIDDigitizer.cxx
+++ b/Detectors/HMPID/simulation/src/HMPIDDigitizer.cxx
@@ -63,7 +63,7 @@ void HMPIDDigitizer::reset()
 // this will process hits and fill the digit vector with digits which are finalized
 void HMPIDDigitizer::process(std::vector<o2::hmpid::HitType> const& hits, std::vector<o2::hmpid::Digit>& digits)
 {
-  printf("*******************In digitizer process**********************************");
+  LOG(info) << "Starting HMPPID digitizer process function";
 
   for (auto& hit : hits) {
     int chamber, pc, px, py;
@@ -81,7 +81,7 @@ void HMPIDDigitizer::process(std::vector<o2::hmpid::HitType> const& hits, std::v
     for (int nx = -1; nx <= 1; ++nx) {
       for (int ny = -1; ny <= 1; ++ny) {
         if ((px + nx) < 0 || (px + nx) > 79 || (py + ny) < 0 || (py + ny) > 47) {
-          LOG(info) << ">> Pad out the PhotoCathod boundary. Excluded :" << px << " " << py << " :" << nx << "," << ny;
+          // LOG(info) << ">> Pad out the PhotoCathod boundary. Excluded :" << px << " " << py << " :" << nx << "," << ny;
           continue;
         }
         allpads[counter] = o2::hmpid::Digit::abs(chamber, pc, px + nx, py + ny);


### PR DESCRIPTION
There was an overflow in a 2-byte short
index when many HMP digits were created.

This led to a crash in MCTruthContainer access.

Problem is fixed by going from short --> int.

Fixes https://alice.its.cern.ch/jira/browse/O2-2978

Also taking out/adjusting some printouts as a minor
change.