### PR TITLE
ZDC FastSim: Generate Hits as final output of fast simulation

### DIFF
--- a/Detectors/ZDC/simulation/include/ZDCSimulation/Detector.h
+++ b/Detectors/ZDC/simulation/include/ZDCSimulation/Detector.h
@@ -22,6 +22,7 @@
 #include "ZDCSimulation/SpatialPhotonResponse.h"
 #include "TParticle.h"
 #include <utility>
+#include "ZDCBase/Constants.h"
 #ifdef ZDC_FASTSIM_ONNX
 #include "FastSimulations.h" // for fastsim module
 #include "Processors.h"      // for fastsim module
@@ -237,6 +238,20 @@ class Detector : public o2::base::DetImpl<Detector>
   // container for fastsim model responses
   using FastSimResults = std::vector<std::array<long, 5>>; //!
   FastSimResults mFastSimResults;                          //!
+
+  // converts FastSim model results to Hit
+  bool FastSimToHits(const Ort::Value& response, const TParticle& particle, int detector);
+  // determines detector geometry
+  constexpr std::pair<const int, const int> determineDetectorGeometry(int detector)
+  {
+    if (detector == ZNA || detector == ZNC) {
+      return {Geometry::ZNDIVISION[0] * Geometry::ZNSECTORS[0] * 2, Geometry::ZNDIVISION[1] * Geometry::ZNSECTORS[1] * 2};
+    } else if (detector == ZPA || detector == ZPC) {
+      return {Geometry::ZPDIVISION[0] * Geometry::ZPSECTORS[0] * 2, Geometry::ZPDIVISION[1] * Geometry::ZPSECTORS[1] * 2};
+    } else {
+      return {-1, -1};
+    }
+  }
 #endif
 
   template <typename Det>

--- a/Detectors/ZDC/simulation/include/ZDCSimulation/SpatialPhotonResponse.h
+++ b/Detectors/ZDC/simulation/include/ZDCSimulation/SpatialPhotonResponse.h
@@ -37,6 +37,8 @@ class SpatialPhotonResponse
   SpatialPhotonResponse() = default;
 
   void addPhoton(double x, double y, int nphotons);
+  //Adds photon to the image (as addPhoton does) but it takes pixel coordinates as arguments.
+  void addPhotonByPixel(int xpixel, int ypixel, int nphotons);
   // void exportToPNG() const;
   void printToScreen() const;
   void reset();

--- a/Detectors/ZDC/simulation/src/SpatialPhotonResponse.cxx
+++ b/Detectors/ZDC/simulation/src/SpatialPhotonResponse.cxx
@@ -54,6 +54,12 @@ void SpatialPhotonResponse::addPhoton(double x, double y, int nphotons)
   mPhotonSum += nphotons;
 }
 
+void SpatialPhotonResponse::addPhotonByPixel(int xpixel, int ypixel, int nphotons)
+{
+  mImageData[xpixel][ypixel] += nphotons;
+  mPhotonSum += nphotons;
+}
+
 // will print pixel 0 == (0,0) at the lower left corner
 void SpatialPhotonResponse::printToScreen() const
 {


### PR DESCRIPTION
SpatialPhotonResponse as return type from fast simulation will provide easy conversion to hits.
Since zdc::Detector already is using it, it will be relatively easy to use it for fast simulation. 
I propose function to easly convert fast simulation output to SpatialPhotonResponse - pixel by pixel.