### PR TITLE
o2-sim: Customize LOG(fatal) to not produce a core dump

### DIFF
--- a/run/O2PrimaryServerDevice.h
+++ b/run/O2PrimaryServerDevice.h
@@ -186,6 +186,9 @@ class O2PrimaryServerDevice final : public FairMQDevice
 
   void InitTask() final
   {
+    // fatal without core dump
+    fair::Logger::OnFatal([] { throw fair::FatalException("Fatal error occured. Exiting without core dump..."); });
+
     o2::simpubsub::publishMessage(fChannels["primary-notifications"].at(0), "SERVER : INITIALIZING");
 
     stateTransition(O2PrimaryServerState::Initializing, "INITTASK");

--- a/run/O2SimDeviceRunner.cxx
+++ b/run/O2SimDeviceRunner.cxx
@@ -259,6 +259,10 @@ int main(int argc, char* argv[])
     }
   }
 
+  // set the fatal callback for the logger to not do a core dump (since this might interfere with process shutdown sequence
+  // since it calls ROOT::TSystem and further child processes)
+  fair::Logger::OnFatal([] { throw fair::FatalException("Fatal error occured. Exiting without core dump..."); });
+
   // extract the path to FairMQ config
   bpo::options_description desc{"Options"};
   // clang-format off


### PR DESCRIPTION
This is both much faster and also safer for the multi-process
shutdown sequence.