### PR TITLE
add MCH-MID tracks to VertexTrackMatcher

### DIFF
--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
@@ -522,7 +522,8 @@ struct RecoContainer {
   auto getMFTMCHMatches() const { return getSpan<o2::dataformats::MatchInfoFwd>(GTrackID::MFTMCH, MATCHES); }
   auto getGlobalFwdTracksMCLabels() const { return getSpan<o2::MCCompLabel>(GTrackID::MFTMCH, MCLABELS); }
 
-  // MCH
+  // MCH-MID
+  const o2::dataformats::TrackMCHMID& getMCHMIDMatch(GTrackID gid) const { return getObject<o2::dataformats::TrackMCHMID>(gid, MATCHES); }
   auto getMCHMIDMatches() const { return getSpan<o2::dataformats::TrackMCHMID>(GTrackID::MCHMID, MATCHES); }
 
   // ITS-TPC-TRD, since the TrackTRD track is just an alias, forward-declaring it does not work, need to keep template

--- a/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
+++ b/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
@@ -460,6 +460,9 @@ void DataRequest::requestTracks(GTrackID::mask_t src, bool useMC)
   if (src[GTrackID::MFTMCH]) {
     requestGlobalFwdTracks(useMC);
   }
+  if (src[GTrackID::MCHMID]) {
+    requestMCHMIDMatches(useMC);
+  }
   if (src[GTrackID::TPCTOF]) {
     requestTPCTOFTracks(useMC);
   }
@@ -1303,6 +1306,10 @@ RecoContainer::GlobalIDSet RecoContainer::getSingleDetectorRefs(GTrackID gidx) c
     if (parent0.getMIDTrackID() != -1) {
       table[GTrackID::MID] = parent0.getMIDTrackID();
     }
+  } else if (src == GTrackID::MCHMID) {
+    const auto& parent0 = getMCHMIDMatch(gidx);
+    table[GTrackID::MCH] = parent0.getMCHRef();
+    table[GTrackID::MID] = parent0.getMIDRef();
   }
   return std::move(table);
 }

--- a/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
+++ b/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
@@ -445,7 +445,7 @@ void DataRequest::requestTracks(GTrackID::mask_t src, bool useMC)
   if (src[GTrackID::MFT]) {
     requestMFTTracks(useMC);
   }
-  if (src[GTrackID::MCH]) {
+  if (src[GTrackID::MCH] || src[GTrackID::MCHMID]) {
     requestMCHTracks(useMC);
   }
   if (src[GTrackID::MID]) {

--- a/Detectors/GlobalTrackingWorkflow/helpers/src/InputHelper.cxx
+++ b/Detectors/GlobalTrackingWorkflow/helpers/src/InputHelper.cxx
@@ -76,8 +76,8 @@ int InputHelper::addInputSpecs(const ConfigContext& configcontext, WorkflowSpec&
   if (maskClusters[GID::MFT]) {
     specs.emplace_back(o2::itsmft::getMFTClusterReaderSpec(maskClustersMC[GID::MFT], true));
   }
-  if (maskTracks[GID::MCH]) {
-    specs.emplace_back(o2::mch::getTrackReaderSpec(maskTracksMC[GID::MCH]));
+  if (maskTracks[GID::MCH] || maskMatches[GID::MCHMID]) {
+    specs.emplace_back(o2::mch::getTrackReaderSpec(maskTracksMC[GID::MCH] || maskTracksMC[GID::MCHMID]));
   }
   if (maskTracks[GID::MID]) {
     specs.emplace_back(o2::mid::getTrackReaderSpec(maskTracksMC[GID::MID]));

--- a/Detectors/GlobalTrackingWorkflow/src/primary-vertexing-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/primary-vertexing-workflow.cxx
@@ -72,7 +72,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   WorkflowSpec specs;
 
   GID::mask_t allowedSourcesPV = GID::getSourcesMask("ITS,ITS-TPC,ITS-TPC-TRD,ITS-TPC-TOF,ITS-TPC-TRD-TOF");
-  GID::mask_t allowedSourcesVT = GID::getSourcesMask("ITS,MFT,TPC,MCH,MFT-MCH,ITS-TPC,TPC-TOF,TPC-TRD,ITS-TPC-TRD,TPC-TRD-TOF,ITS-TPC-TOF,ITS-TPC-TRD-TOF");
+  GID::mask_t allowedSourcesVT = GID::getSourcesMask("ITS,MFT,TPC,MCH,MCH-MID,MFT-MCH,ITS-TPC,TPC-TOF,TPC-TRD,ITS-TPC-TRD,TPC-TRD-TOF,ITS-TPC-TOF,ITS-TPC-TRD-TOF");
 
   // Update the (declared) parameters if changed from the command line
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));

--- a/Detectors/Vertexing/src/VertexTrackMatcher.cxx
+++ b/Detectors/Vertexing/src/VertexTrackMatcher.cxx
@@ -199,7 +199,7 @@ void VertexTrackMatcher::extractTracks(const o2::globaltracking::RecoContainer& 
     terr += mPVParams->timeMarginTrackTime;
     mTBrackets.emplace_back(TrackTBracket{{t0 - terr, t0 + terr}, _origID});
 
-    if constexpr (isMFTTrack<decltype(_tr)>() || isMCHTrack<decltype(_tr)>() || isGlobalFwdTrack<decltype(_tr)>()) {
+    if constexpr (isGlobalFwdTrack<decltype(_tr)>()) {
       return false;
     }
     return true;


### PR DESCRIPTION
MCH-MID tracks are basically MCH tracks with MID timing information. The object TrackMCHMID only contains matching information, timing and references to the corresponding MCH-standalone and MID-standalone tracks.

The MCH-MID matched tracks are treated first and the corresponding MCH-standalone tracks are discarded.

Since the timing information is stored in the TrackMCHMID object, there is not need to access the MID tracks here.