### PR TITLE
 [EMCAL-566] Replacing algorithm::sum with own counter 

### DIFF
--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibParams.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibParams.h
@@ -30,12 +30,13 @@ namespace emcal
 struct EMCALCalibParams : public o2::conf::ConfigurableParamHelper<EMCALCalibParams> {
 
   unsigned int minNEvents = 1e6;              ///< minimum number of events to trigger the calibration
-  unsigned int minNEntries = 1e5;             ///< minimum number of entries to trigger the calibration
+  unsigned int minNEntries = 1e6;             ///< minimum number of entries to trigger the calibration
   bool useNEventsForCalib = true;             ///< use the minimum number of events to trigger the calibration
   std::string calibType = "time";             ///< type of calibration to run
   std::string localRootFilePath = "";         ///< path to local root file in order to store the calibration histograms (off by default, only to be used for testing)
   bool useScaledHistoForBadChannelMap = true; ///< use the scaled histogram for the bad channel map
   bool enableTestMode = false;                ///< enable test mode for calibration
+  float minCellEnergyForTimeCalib = 0.5;      ///< minimum cell energy to enter the time calibration (typical minimum seed energy for clusters), time resolution gets better with rising energy
 
   O2ParamDef(EMCALCalibParams, "EMCALCalibParams");
 };

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelData.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelData.h
@@ -107,11 +107,15 @@ class EMCALChannelData
   int getNEvents() const { return mEvents; }
   void setNEvents(int nevt) { mEvents = nevt; }
 
+  long unsigned int getNEntriesInHisto() const { return mNEntriesInHisto; }
+  void setNEntriesInHisto(long unsigned int n) { mNEntriesInHisto = n; }
+
  private:
   float mRange = 0.35; // looked at old QA plots where max was 0.35 GeV, might need to be changed
   int mNBins = 1000;
   boostHisto mHisto;
   int mEvents = 0;
+  long unsigned int mNEntriesInHisto = 0;               ///< Number of entries in the histogram
   boostHisto mEsumHisto;                                ///< contains the average energy per hit for each cell
   boostHisto mEsumHistoScaled;                          ///< contains the average energy (scaled) per hit for each cell
   boostHisto mCellAmplitude;                            ///< is the input for the calibration, hist of cell E vs. ID

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALTimeCalibData.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALTimeCalibData.h
@@ -87,6 +87,11 @@ class EMCALTimeCalibData
   /// \brief Get number of events currently available for calibration
   int getNEvents() const { return mEvents; }
 
+  /// \brief Get the number of entries in histogram
+  long unsigned int getNEntriesInHisto() const { return mNEntriesInHisto; }
+  /// \brief Set the number of entries in histogram
+  void setNEntriesInHisto(long unsigned int n) { mNEntriesInHisto = n; }
+
   /// \brief Get current histogram
   boostHisto& getHisto() { return mTimeHisto; }
   const boostHisto& getHisto() const { return mTimeHisto; }
@@ -97,10 +102,11 @@ class EMCALTimeCalibData
   o2::emcal::TimeCalibrationParams process();
 
  private:
-  boostHisto mTimeHisto;
-  TimeCalibInitParams mTimeCalibParams;
+  boostHisto mTimeHisto;                ///< histogram with cell time vs. cell ID
+  TimeCalibInitParams mTimeCalibParams; ///< initialization parameters for histogram
 
-  int mEvents = 0;
+  int mEvents = 0;                        ///< current number of events
+  long unsigned int mNEntriesInHisto = 0; ///< number of entries in histogram
 
   ClassDefNV(EMCALTimeCalibData, 1);
 };

--- a/Detectors/EMCAL/calibration/src/EMCALChannelData.cxx
+++ b/Detectors/EMCAL/calibration/src/EMCALChannelData.cxx
@@ -54,6 +54,7 @@ void EMCALChannelData::fill(const gsl::span<const o2::emcal::Cell> data)
     Int_t id = cell.getTower();
     LOG(debug) << "inserting in cell ID " << id << ": energy = " << cellEnergy;
     mHisto(cellEnergy, id);
+    mNEntriesInHisto++;
   }
 }
 //_____________________________________________
@@ -65,6 +66,7 @@ void EMCALChannelData::print()
 void EMCALChannelData::merge(const EMCALChannelData* prev)
 {
   mEvents += prev->getNEvents();
+  mNEntriesInHisto += prev->getNEntriesInHisto();
   mHisto += prev->getHisto();
 }
 
@@ -72,10 +74,10 @@ void EMCALChannelData::merge(const EMCALChannelData* prev)
 bool EMCALChannelData::hasEnoughData() const
 {
   bool enough = false;
-  double entries = boost::histogram::algorithm::sum(mEsumHisto);
-  LOG(debug) << "entries: " << entries << " needed: " << EMCALCalibParams::Instance().minNEntries << "  mEvents = " << mEvents;
+
+  LOG(debug) << "mNEntriesInHisto: " << mNEntriesInHisto << " needed: " << EMCALCalibParams::Instance().minNEntries << "  mEvents = " << mEvents;
   // use enrties in histogram for calibration
-  if (!EMCALCalibParams::Instance().useNEventsForCalib && entries > EMCALCalibParams::Instance().minNEntries) {
+  if (!EMCALCalibParams::Instance().useNEventsForCalib && mNEntriesInHisto > EMCALCalibParams::Instance().minNEntries) {
     enough = true;
   }
   // use number of events (from emcal trigger record) for calibration

--- a/Detectors/EMCAL/calibration/src/EMCALTimeCalibData.cxx
+++ b/Detectors/EMCAL/calibration/src/EMCALTimeCalibData.cxx
@@ -83,7 +83,7 @@ void EMCALTimeCalibData::fill(const gsl::span<const o2::emcal::Cell> data)
     double cellTime = cell.getTimeStamp();
     int id = cell.getTower();
     LOG(debug) << "inserting in cell ID " << id << ": cellTime = " << cellTime;
-    if (cellEnergy > 0.3) {
+    if (cellEnergy > EMCALCalibParams::Instance().minCellEnergyForTimeCalib) {
       mTimeHisto(cellTime, id);
     }
   }

--- a/Detectors/EMCAL/calibration/src/EMCALTimeCalibData.cxx
+++ b/Detectors/EMCAL/calibration/src/EMCALTimeCalibData.cxx
@@ -53,16 +53,17 @@ std::ostream& operator<<(std::ostream& stream, const EMCALTimeCalibData& emcdata
 void EMCALTimeCalibData::merge(const EMCALTimeCalibData* prev)
 {
   mEvents += prev->getNEvents();
+  mNEntriesInHisto += prev->getNEntriesInHisto();
   mTimeHisto += prev->getHisto();
 }
 //_____________________________________________
 bool EMCALTimeCalibData::hasEnoughData() const
 {
   bool enough = false;
-  double entries = boost::histogram::algorithm::sum(mTimeHisto);
-  LOG(debug) << "entries: " << entries << " needed: " << EMCALCalibParams::Instance().minNEntries << "  mEvents = " << mEvents;
+
+  LOG(debug) << "mNEntriesInHisto: " << mNEntriesInHisto << " needed: " << EMCALCalibParams::Instance().minNEntries << "  mEvents = " << mEvents;
   // use enrties in histogram for calibration
-  if (!EMCALCalibParams::Instance().useNEventsForCalib && entries > EMCALCalibParams::Instance().minNEntries) {
+  if (!EMCALCalibParams::Instance().useNEventsForCalib && mNEntriesInHisto > EMCALCalibParams::Instance().minNEntries) {
     enough = true;
   }
   // use number of events (from emcal trigger record) for calibration
@@ -85,6 +86,7 @@ void EMCALTimeCalibData::fill(const gsl::span<const o2::emcal::Cell> data)
     LOG(debug) << "inserting in cell ID " << id << ": cellTime = " << cellTime;
     if (cellEnergy > EMCALCalibParams::Instance().minCellEnergyForTimeCalib) {
       mTimeHisto(cellTime, id);
+      mNEntriesInHisto++;
     }
   }
 }


### PR DESCRIPTION
- To obtain the number of entries in the boost calibration histograms the sum function was used. This is however very slow for large 2d histograms
- For speedup, a simple counter is added to the time and bad channel
calib data class