### PR TITLE
[EMCAL-565,EMCAL-566] Remove symbol duplication

### DIFF
--- a/Detectors/EMCAL/calibration/src/EMCALCalibrationLinkDef.h
+++ b/Detectors/EMCAL/calibration/src/EMCALCalibrationLinkDef.h
@@ -24,7 +24,6 @@
 #pragma link C++ class o2::calibration::TimeSlotCalibration < o2::emcal::Cell, o2::emcal::EMCALTimeCalibData> + ;
 
 #pragma link C++ class o2::emcal::EMCALCalibParams + ;
-#pragma link C++ class o2::emcal::EMCALChannelScaleFactors + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::emcal::EMCALCalibParams> + ;
 #pragma link C++ class o2::emcal::EMCDCSProcessor + ;
 


### PR DESCRIPTION
Defining the EMCALChannelScaleFactors in
both LinkDefs of EMCALCalib and EMCALCalibration
leading to symbol duplication in due to dictionries
of the class in both libraries.