### PR TITLE
TRD tracking update

### DIFF
--- a/Detectors/TRD/calibration/src/TrackBasedCalib.cxx
+++ b/Detectors/TRD/calibration/src/TrackBasedCalib.cxx
@@ -90,6 +90,11 @@ int TrackBasedCalib::doTrdOnlyTrackFits(gsl::span<const TrackTRD>& tracks)
     trkWork.setChi2(0.f);
     trkWork.resetCovariance(20);
 
+    if (std::isnan(trkWork.getSnp())) {
+      LOG(alarm) << "Track with invalid parameters found: " << trkWork.getRefGlobalTrackId();
+      continue;
+    }
+
     // first inward propagation (TRD track fit)
     int currLayer = NLAYER;
     for (int iLayer = NLAYER - 1; iLayer >= 0; --iLayer) {

--- a/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
@@ -353,7 +353,7 @@ void TRDGlobalTracking::run(ProcessingContext& pc)
     if (trackGID.includesDet(GTrackID::Source::ITS)) {
       // this track is from an ITS-TPC seed
       tracksOutITSTPC.push_back(trdTrack);
-      if (!refitITSTPCTRDTrack(tracksOutITSTPC.back(), mChainTracking->mIOPtrs.trdTriggerTimes[trdTrack.getCollisionId()], &inputTracks)) {
+      if (!refitITSTPCTRDTrack(tracksOutITSTPC.back(), mChainTracking->mIOPtrs.trdTriggerTimes[trdTrack.getCollisionId()], &inputTracks) || std::isnan(tracksOutITSTPC.back().getSnp())) {
         tracksOutITSTPC.pop_back();
         ++nTracksFailedITSTPCTRDRefit;
         continue;
@@ -364,7 +364,7 @@ void TRDGlobalTracking::run(ProcessingContext& pc)
     } else {
       // this track is from a TPC-only seed
       tracksOutTPC.push_back(trdTrack);
-      if (!refitTPCTRDTrack(tracksOutTPC.back(), mChainTracking->mIOPtrs.trdTriggerTimes[trdTrack.getCollisionId()], &inputTracks)) {
+      if (!refitTPCTRDTrack(tracksOutTPC.back(), mChainTracking->mIOPtrs.trdTriggerTimes[trdTrack.getCollisionId()], &inputTracks) || std::isnan(tracksOutTPC.back().getSnp())) {
         tracksOutTPC.pop_back();
         ++nTracksFailedTPCTRDRefit;
         continue;

--- a/GPU/GPUTracking/Definitions/GPUSettingsList.h
+++ b/GPU/GPUTracking/Definitions/GPUSettingsList.h
@@ -89,6 +89,7 @@ AddOptionRTC(chi2SeparationCut, float, 2.5f, "", 0, "Minimum difference between 
 AddOptionRTC(nSigmaTerrITSTPC, float, 4.f, "", 0, "Number of sigmas for ITS-TPC track time error estimate")
 AddOptionRTC(extraRoadY, float, 2.f, "", 0, "Addition to search road around track prolongation along Y in cm")
 AddOptionRTC(extraRoadZ, float, 0.f, "", 0, "Addition to search road around track prolongation along Z in cm")
+AddOptionRTC(trkltResRPhiIdeal, float, 0.04f, "", 0, "Optimal tracklet rphi resolution in cm (in case phi of track = lorentz angle)")
 AddOptionRTC(applyDeflectionCut, unsigned char, 0, "", 0, "Set to 1 to enable tracklet selection based on deflection")
 AddOptionRTC(stopTrkAfterNMissLy, unsigned char, 6, "", 0, "Abandon track following after N layers without a TRD match")
 AddOptionRTC(useExternalO2DefaultPropagator, unsigned char, 0, "", 0, "Use the default instance of the o2::Propagator, instead of the GPU Reconstruciton one with GPU B field")

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
@@ -130,17 +130,18 @@ void GPUTRDTracker_t<TRDTRK, PROP>::InitializeProcessor()
   }
 
   float Bz = Param().par.bzkG;
+  float resRPhiIdeal2 = Param().rec.trd.trkltResRPhiIdeal * Param().rec.trd.trkltResRPhiIdeal;
   GPUInfo("Initializing with B-field: %f kG", Bz);
   if (CAMath::Abs(CAMath::Abs(Bz) - 2) < 0.1) {
     // magnetic field +-0.2 T
     if (Bz > 0) {
       GPUInfo("Loading error parameterization for Bz = +2 kG");
-      mRPhiA2 = 1.6e-3f, mRPhiB = -1.43e-2f, mRPhiC2 = 4.55e-2f;
+      mRPhiA2 = resRPhiIdeal2, mRPhiB = -1.43e-2f, mRPhiC2 = 4.55e-2f;
       mDyA2 = 1.225e-3f, mDyB = -9.8e-3f, mDyC2 = 3.88e-2f;
       mAngleToDyA = -0.1f, mAngleToDyB = 1.89f, mAngleToDyC = -0.4f;
     } else {
       GPUInfo("Loading error parameterization for Bz = -2 kG");
-      mRPhiA2 = 1.6e-3f, mRPhiB = 1.43e-2f, mRPhiC2 = 4.55e-2f;
+      mRPhiA2 = resRPhiIdeal2, mRPhiB = 1.43e-2f, mRPhiC2 = 4.55e-2f;
       mDyA2 = 1.225e-3f, mDyB = 9.8e-3f, mDyC2 = 3.88e-2f;
       mAngleToDyA = 0.1f, mAngleToDyB = 1.89f, mAngleToDyC = 0.4f;
     }
@@ -148,12 +149,12 @@ void GPUTRDTracker_t<TRDTRK, PROP>::InitializeProcessor()
     // magnetic field +-0.5 T
     if (Bz > 0) {
       GPUInfo("Loading error parameterization for Bz = +5 kG");
-      mRPhiA2 = 1.6e-3f, mRPhiB = 0.125f, mRPhiC2 = 0.0961f;
+      mRPhiA2 = resRPhiIdeal2, mRPhiB = 0.125f, mRPhiC2 = 0.0961f;
       mDyA2 = 1.681e-3f, mDyB = 0.15f, mDyC2 = 0.1849f;
       mAngleToDyA = 0.13f, mAngleToDyB = 2.43f, mAngleToDyC = -0.58f;
     } else {
       GPUInfo("Loading error parameterization for Bz = -5 kG");
-      mRPhiA2 = 1.6e-3f, mRPhiB = -0.14f, mRPhiC2 = 0.1156f;
+      mRPhiA2 = resRPhiIdeal2, mRPhiB = -0.14f, mRPhiC2 = 0.1156f;
       mDyA2 = 2.209e-3f, mDyB = -0.15f, mDyC2 = 0.2025f;
       mAngleToDyA = -0.15f, mAngleToDyB = 2.34f, mAngleToDyC = 0.56f;
     }


### PR DESCRIPTION
- allow to set the tracklet resolution from outside (needed until proper parameterization found)
- add protection from invalid track parameters

Found that the call in https://github.com/AliceO2Group/AliceO2/blob/943ff7c1b3d73aeec2e91292c1468909965de605/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx#L543 can leave the track parameters as NAN although the return value is valid. I tried to add additional protection directly in GPUTrackingRefit, but that unfortunately did not work for me.