### PR TITLE
Implementing class for nD piecewise polynomials

### DIFF
--- a/GPU/TPCFastTransformation/CMakeLists.txt
+++ b/GPU/TPCFastTransformation/CMakeLists.txt
@@ -35,6 +35,7 @@ if(ALIGPU_BUILD_TYPE STREQUAL "O2")
       BandMatrixSolver.cxx
       MultivariatePolynomial.cxx
       MultivariatePolynomialHelper.cxx
+      NDPiecewisePolynomials.cxx
       devtools/IrregularSpline1D.cxx
       devtools/IrregularSpline2D3D.cxx
       devtools/SemiregularSpline2D3D.cxx
@@ -55,7 +56,7 @@ if(${ALIGPU_BUILD_TYPE} STREQUAL "O2")
                  PUBLIC_LINK_LIBRARIES O2::GPUCommon
                                        O2::GPUUtils
                                        Vc::Vc
-                                       ROOT::Core ROOT::Matrix ROOT::Tree ROOT::Gpad
+                                       ROOT::Core ROOT::Matrix ROOT::Tree ROOT::Gpad ROOT::Minuit
                              )
 
   o2_target_root_dictionary(${MODULE}

--- a/GPU/TPCFastTransformation/MultivariatePolynomial.h
+++ b/GPU/TPCFastTransformation/MultivariatePolynomial.h
@@ -38,8 +38,10 @@ namespace GPUCA_NAMESPACE::gpu
 /// Usage: see example in testMultivarPolynomials.cxx
 ///    Dim > 0 && Degree > 0 : the number of dimensions and the degree is known at compile time
 ///    Dim = 0 && Degree = 0 : the number of dimensions and the degree will be set during runtime
-template <unsigned int Dim, unsigned int Degree>
-class MultivariatePolynomial : public FlatObject, public MultivariatePolynomialHelper<Dim, Degree>
+///    InteractionOnly: consider only interaction terms: ignore x[0]*x[0]..., x[1]*x[1]*x[2]... etc. terms (same feature as 'interaction_only' in sklearn https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.PolynomialFeatures.html)
+///                     can be used for N-linear interpolation (https://en.wikipedia.org/wiki/Trilinear_interpolation#Alternative_algorithm)
+template <unsigned int Dim, unsigned int Degree, bool InteractionOnly = false>
+class MultivariatePolynomial : public FlatObject, public MultivariatePolynomialHelper<Dim, Degree, InteractionOnly>
 {
  public:
 #if !defined(GPUCA_GPUCODE)
@@ -47,14 +49,14 @@ class MultivariatePolynomial : public FlatObject, public MultivariatePolynomialH
   /// \param nDim number of dimensions
   /// \param degree degree of the polynomial
   template <bool IsEnabled = true, typename std::enable_if<(IsEnabled && (Dim == 0 && Degree == 0)), int>::type = 0>
-  MultivariatePolynomial(const unsigned int nDim, const unsigned int degree) : MultivariatePolynomialHelper<Dim, Degree>{nDim, degree}, mNParams{this->getNParameters(degree, nDim)}
+  MultivariatePolynomial(const unsigned int nDim, const unsigned int degree, const bool interactionOnly = false) : MultivariatePolynomialHelper<Dim, Degree, false>{nDim, degree, interactionOnly}, mNParams{this->getNParameters(degree, nDim, interactionOnly)}
   {
     construct();
   }
 
   /// constructor for compile time evaluation of polynomial formula
   template <bool IsEnabled = true, typename std::enable_if<(IsEnabled && (Dim != 0 && Degree != 0)), int>::type = 0>
-  MultivariatePolynomial() : mNParams{this->getNParameters(Degree, Dim)}
+  MultivariatePolynomial() : mNParams{this->getNParameters(Degree, Dim, InteractionOnly)}
   {
     construct();
   }
@@ -118,10 +120,25 @@ class MultivariatePolynomial : public FlatObject, public MultivariatePolynomialH
   /// \param outf output file
   /// \param name name of the output object
   void writeToFile(TFile& outf, const char* name);
+
+  /// performs fit of input point
+  /// \param x position of the points of length 'Dim * nPoints' (structured as in https://root.cern.ch/doc/master/classTLinearFitter.html)
+  /// \param y values which will be fitted of length 'nPoints'
+  /// \param error error of weigths of the points (if empty no weights are applied)
+  /// \param clearPoints perform the fit on new data points
+  template <bool IsEnabled = true, typename std::enable_if<(IsEnabled && (Dim == 0 && Degree == 0)), int>::type = 0>
+  void fit(std::vector<double>& x, std::vector<double>& y, std::vector<double>& error, const bool clearPoints)
+  {
+    const auto vec = MultivariatePolynomialHelper<Dim, Degree, InteractionOnly>::fit(x, y, error, clearPoints);
+    if (vec.empty()) {
+      return;
+    }
+    setParams(vec.data());
+  }
 #endif
 
   /// converts the parameters to a container which can be written to a root file
-  MultivariatePolynomialContainer getContainer() const { return MultivariatePolynomialContainer{this->getDim(), this->getDegree(), mNParams, mParams}; }
+  MultivariatePolynomialContainer getContainer() const { return MultivariatePolynomialContainer{this->getDim(), this->getDegree(), mNParams, mParams, this->isInteractionOnly()}; }
 
   /// set the parameters from MultivariatePolynomialContainer
   /// \param container container for the parameters
@@ -147,8 +164,8 @@ class MultivariatePolynomial : public FlatObject, public MultivariatePolynomialH
 //=================================================================================
 
 #if !defined(GPUCA_GPUCODE) && !defined(GPUCA_STANDALONE)
-template <unsigned int Dim, unsigned int Degree>
-void MultivariatePolynomial<Dim, Degree>::loadFromFile(TFile& inpf, const char* name)
+template <unsigned int Dim, unsigned int Degree, bool InteractionOnly>
+void MultivariatePolynomial<Dim, Degree, InteractionOnly>::loadFromFile(TFile& inpf, const char* name)
 {
   MultivariatePolynomialContainer* polTmp = nullptr;
   inpf.GetObject(name, polTmp);
@@ -162,8 +179,8 @@ void MultivariatePolynomial<Dim, Degree>::loadFromFile(TFile& inpf, const char* 
   }
 }
 
-template <unsigned int Dim, unsigned int Degree>
-void MultivariatePolynomial<Dim, Degree>::setFromContainer(const MultivariatePolynomialContainer& container)
+template <unsigned int Dim, unsigned int Degree, bool InteractionOnly>
+void MultivariatePolynomial<Dim, Degree, InteractionOnly>::setFromContainer(const MultivariatePolynomialContainer& container)
 {
   if constexpr (Dim > 0 && Degree > 0) {
     if (this->getDim() != container.mDim) {
@@ -178,6 +195,12 @@ void MultivariatePolynomial<Dim, Degree>::setFromContainer(const MultivariatePol
 #endif
       return;
     }
+    if (this->isInteractionOnly() != container.mInteractionOnly) {
+#ifndef GPUCA_ALIROOT_LIB
+      LOGP(info, fmt::format("InteractionOnly is set for this object to {}, but stored as {} in the container", this->isInteractionOnly(), container.mInteractionOnly));
+#endif
+      return;
+    }
     setParams(container.mParams.data());
   } else {
     MultivariatePolynomial polTmp(container.mDim, container.mDegree);
@@ -186,15 +209,15 @@ void MultivariatePolynomial<Dim, Degree>::setFromContainer(const MultivariatePol
   }
 }
 
-template <unsigned int Dim, unsigned int Degree>
-void MultivariatePolynomial<Dim, Degree>::writeToFile(TFile& outf, const char* name)
+template <unsigned int Dim, unsigned int Degree, bool InteractionOnly>
+void MultivariatePolynomial<Dim, Degree, InteractionOnly>::writeToFile(TFile& outf, const char* name)
 {
   const MultivariatePolynomialContainer cont = getContainer();
   outf.WriteObject(&cont, name);
 }
 
-template <unsigned int Dim, unsigned int Degree>
-void MultivariatePolynomial<Dim, Degree>::cloneFromObject(const MultivariatePolynomial<Dim, Degree>& obj, char* newFlatBufferPtr)
+template <unsigned int Dim, unsigned int Degree, bool InteractionOnly>
+void MultivariatePolynomial<Dim, Degree, InteractionOnly>::cloneFromObject(const MultivariatePolynomial<Dim, Degree, InteractionOnly>& obj, char* newFlatBufferPtr)
 {
   const char* oldFlatBufferPtr = obj.mFlatBufferPtr;
   FlatObject::cloneFromObject(obj, newFlatBufferPtr);
@@ -202,14 +225,15 @@ void MultivariatePolynomial<Dim, Degree>::cloneFromObject(const MultivariatePoly
   if constexpr (Dim == 0 && Degree == 0) {
     this->mDim = obj.mDim;
     this->mDegree = obj.mDegree;
+    this->mInteractionOnly = obj.mInteractionOnly;
   }
   if (obj.mParams) {
     mParams = FlatObject::relocatePointer(oldFlatBufferPtr, mFlatBufferPtr, obj.mParams);
   }
 }
 
-template <unsigned int Dim, unsigned int Degree>
-void MultivariatePolynomial<Dim, Degree>::moveBufferTo(char* newFlatBufferPtr)
+template <unsigned int Dim, unsigned int Degree, bool InteractionOnly>
+void MultivariatePolynomial<Dim, Degree, InteractionOnly>::moveBufferTo(char* newFlatBufferPtr)
 {
   char* oldFlatBufferPtr = mFlatBufferPtr;
   FlatObject::moveBufferTo(newFlatBufferPtr);
@@ -218,8 +242,8 @@ void MultivariatePolynomial<Dim, Degree>::moveBufferTo(char* newFlatBufferPtr)
   setActualBufferAddress(currFlatBufferPtr);
 }
 
-template <unsigned int Dim, unsigned int Degree>
-void MultivariatePolynomial<Dim, Degree>::construct()
+template <unsigned int Dim, unsigned int Degree, bool InteractionOnly>
+void MultivariatePolynomial<Dim, Degree, InteractionOnly>::construct()
 {
   FlatObject::startConstruction();
   const std::size_t flatbufferSize = sizeOfParameters();
@@ -228,22 +252,22 @@ void MultivariatePolynomial<Dim, Degree>::construct()
 }
 #endif
 
-template <unsigned int Dim, unsigned int Degree>
-void MultivariatePolynomial<Dim, Degree>::destroy()
+template <unsigned int Dim, unsigned int Degree, bool InteractionOnly>
+void MultivariatePolynomial<Dim, Degree, InteractionOnly>::destroy()
 {
   mParams = nullptr;
   FlatObject::destroy();
 }
 
-template <unsigned int Dim, unsigned int Degree>
-void MultivariatePolynomial<Dim, Degree>::setActualBufferAddress(char* actualFlatBufferPtr)
+template <unsigned int Dim, unsigned int Degree, bool InteractionOnly>
+void MultivariatePolynomial<Dim, Degree, InteractionOnly>::setActualBufferAddress(char* actualFlatBufferPtr)
 {
   FlatObject::setActualBufferAddress(actualFlatBufferPtr);
   mParams = reinterpret_cast<float*>(mFlatBufferPtr);
 }
 
-template <unsigned int Dim, unsigned int Degree>
-void MultivariatePolynomial<Dim, Degree>::setFutureBufferAddress(char* futureFlatBufferPtr)
+template <unsigned int Dim, unsigned int Degree, bool InteractionOnly>
+void MultivariatePolynomial<Dim, Degree, InteractionOnly>::setFutureBufferAddress(char* futureFlatBufferPtr)
 {
   mParams = FlatObject::relocatePointer(mFlatBufferPtr, futureFlatBufferPtr, mParams);
   FlatObject::setFutureBufferAddress(futureFlatBufferPtr);

--- a/GPU/TPCFastTransformation/MultivariatePolynomialHelper.cxx
+++ b/GPU/TPCFastTransformation/MultivariatePolynomialHelper.cxx
@@ -15,30 +15,173 @@
 #include "MultivariatePolynomialHelper.h"
 #include "GPUCommonLogger.h"
 
+#if !defined(GPUCA_GPUCODE) && !defined(GPUCA_STANDALONE)
+#include "TLinearFitter.h"
+#include <algorithm>
+#endif
+
 using namespace GPUCA_NAMESPACE::gpu;
 
 #if !defined(GPUCA_GPUCODE) && !defined(GPUCA_STANDALONE)
-void MultivariatePolynomialHelper<0, 0>::print() const
+void MultivariatePolynomialHelper<0, 0, false>::print() const
 {
 #ifndef GPUCA_NO_FMT
-  const auto terms = getTerms();
+  LOGP(info, getFormula().c_str());
+#endif
+}
+
+std::string MultivariatePolynomialHelper<0, 0, false>::getTLinearFitterFormula() const
+{
+  std::string formula = getFormula();
+  formula.replace(formula.find("p"), formula.find("]") + 1, "1");
+  size_t pos = std::string::npos;
+  while ((pos = formula.find("* p")) != std::string::npos) {
+    size_t end_pos = formula.find("]", pos) + 2;
+    formula.erase(pos, end_pos - pos);
+  }
+
+  while ((pos = formula.find(" + ")) != std::string::npos) {
+    formula.replace(pos + 1, 1, "++");
+  }
+  return formula;
+}
+
+std::string MultivariatePolynomialHelper<0, 0, false>::getFormula() const
+{
   std::string formula = "";
+#ifndef GPUCA_NO_FMT
+  const auto terms = getTerms();
   for (int i = 0; i < (int)terms.size() - 1; ++i) {
     formula += fmt::format("{} + ", terms[i]);
   }
   formula += terms.back();
-  LOGP(info, formula.c_str());
 #endif
+  return formula;
 }
 
-std::vector<std::string> MultivariatePolynomialHelper<0, 0>::getTerms() const
+std::vector<std::string> MultivariatePolynomialHelper<0, 0, false>::getTerms() const
 {
   std::vector<std::string> terms{"par[0]"};
   int indexPar = 1;
   for (unsigned int deg = 1; deg <= mDegree; ++deg) {
-    const auto strTmp = combination_with_repetiton<std::vector<std::string>>(deg, mDim, nullptr, indexPar, nullptr);
+    const auto strTmp = combination_with_repetiton<std::vector<std::string>>(deg, mDim, nullptr, indexPar, nullptr, mInteractionOnly);
     terms.insert(terms.end(), strTmp.begin(), strTmp.end());
   }
   return terms;
 }
+
+TLinearFitter MultivariatePolynomialHelper<0, 0, false>::getTLinearFitter() const
+{
+  const std::string formula = getTLinearFitterFormula();
+  TLinearFitter fitter(int(mDim), formula.data(), "");
+  return fitter;
+}
+
+std::vector<float> MultivariatePolynomialHelper<0, 0, false>::fit(TLinearFitter& fitter, std::vector<double>& x, std::vector<double>& y, std::vector<double>& error, const bool clearPoints)
+{
+  if (clearPoints) {
+    fitter.ClearPoints();
+  }
+  const int nDim = static_cast<int>(x.size() / y.size());
+  fitter.AssignData(static_cast<int>(y.size()), nDim, x.data(), y.data(), error.empty() ? nullptr : error.data());
+
+  const int status = fitter.Eval();
+  if (status != 0) {
+#ifndef GPUCA_NO_FMT
+    LOGP(info, "Fitting failed with status: {}", status);
+#endif
+    return std::vector<float>();
+  }
+
+  TVectorD params;
+  fitter.GetParameters(params);
+  std::vector<float> paramsFloat;
+  paramsFloat.reserve(static_cast<unsigned int>(params.GetNrows()));
+  std::copy(params.GetMatrixArray(), params.GetMatrixArray() + params.GetNrows(), std::back_inserter(paramsFloat));
+  return paramsFloat;
+}
+
+std::vector<float> MultivariatePolynomialHelper<0, 0, false>::fit(std::vector<double>& x, std::vector<double>& y, std::vector<double>& error, const bool clearPoints) const
+{
+  TLinearFitter fitter = getTLinearFitter();
+  return fit(fitter, x, y, error, clearPoints);
+}
+
+template <class Type>
+Type MultivariatePolynomialHelper<0, 0, false>::combination_with_repetiton(const unsigned int degree, const unsigned int dim, const float par[], int& indexPar, const float x[], const bool interactionOnly) const
+{
+  {
+    // each digit represents the currently set dimension
+    unsigned int pos[FMaxdegree + 1]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+    // return value is either the sum of all polynomials or a vector of strings containing the formula for each polynomial
+    Type val(0);
+    for (;;) {
+      // starting on the rightmost digit
+      for (unsigned int i = degree; i > 0; --i) {
+        // check if digit of current position is at is max position
+        if (pos[i] == dim) {
+          // increase digit of left position
+          ++pos[i - 1];
+          // resetting the indices of the digits to the right
+          for (unsigned int j = i; j <= degree; ++j) {
+            pos[j] = pos[i - 1];
+          }
+        }
+      }
+
+      // check if all combinations are processed
+      if (pos[0] == 1) {
+        break;
+      } else {
+
+        if (interactionOnly) {
+          bool checkInteraction = false;
+          for (size_t i = 1; i < degree; ++i) {
+            checkInteraction = pos[i] == pos[i + 1];
+            if (checkInteraction) {
+              break;
+            }
+          }
+          if (checkInteraction) {
+            ++pos[degree];
+            continue;
+          }
+        }
+
+        if constexpr (std::is_same_v<Type, float>) {
+          float term = par[indexPar++];
+          for (size_t i = 1; i <= degree; ++i) {
+            term *= x[pos[i]];
+          }
+          val += term;
+        } else {
+#if !defined(GPUCA_ALIROOT_LIB)
+          std::string term{};
+          for (size_t i = 1; i <= degree; ++i) {
+            term += fmt::format("x[{}] * ", pos[i]);
+          }
+          term += fmt::format("par[{}]", indexPar++);
+          val.emplace_back(term);
+#endif
+        }
+      }
+
+      // increase the rightmost digit
+      ++pos[degree];
+    }
+    return val;
+  }
+}
+
+float MultivariatePolynomialHelper<0, 0, false>::evalPol(const float par[], const float x[], const unsigned int degree, const unsigned int dim, const bool interactionOnly) const
+{
+  float val = par[0];
+  int indexPar = 1;
+  for (unsigned int deg = 1; deg <= degree; ++deg) {
+    val += combination_with_repetiton<float>(deg, dim, par, indexPar, x, interactionOnly);
+  }
+  return val;
+}
+
 #endif

--- a/GPU/TPCFastTransformation/MultivariatePolynomialHelper.h
+++ b/GPU/TPCFastTransformation/MultivariatePolynomialHelper.h
@@ -26,6 +26,8 @@
 #endif
 #endif
 
+class TLinearFitter;
+
 namespace GPUCA_NAMESPACE::gpu
 {
 
@@ -39,7 +41,7 @@ struct MultivariatePolynomialContainer {
   /// \param degree degree of the polynomials
   /// \param nParameters number of parameters
   /// \param params parmaeters
-  MultivariatePolynomialContainer(const unsigned int dim, const unsigned int degree, const unsigned int nParameters, const float params[/* nParameters*/]) : mDim{dim}, mDegree{degree}, mParams{params, params + nParameters} {};
+  MultivariatePolynomialContainer(const unsigned int dim, const unsigned int degree, const unsigned int nParameters, const float params[/* nParameters*/], const bool interactionOnly) : mDim{dim}, mDegree{degree}, mParams{params, params + nParameters}, mInteractionOnly{interactionOnly} {};
 
   /// for ROOT I/O
   MultivariatePolynomialContainer() = default;
@@ -47,6 +49,7 @@ struct MultivariatePolynomialContainer {
   const unsigned int mDim{};          ///< number of dimensions of the polynomial
   const unsigned int mDegree{};       ///< degree of the polynomials
   const std::vector<float> mParams{}; ///< parameters of the polynomial
+  const bool mInteractionOnly{};      ///< consider only interaction terms
 };
 #endif
 
@@ -57,7 +60,19 @@ class MultivariatePolynomialParametersHelper
   /// \returns number of parameters for given dimension and degree of polynomials
   /// calculates the number of parameters for a multivariate polynomial for given degree: nParameters = (n+d-1 d) -> binomial coefficient
   /// see: https://mathoverflow.net/questions/225953/number-of-polynomial-terms-for-certain-degree-and-certain-number-of-variables
-  GPUd() static constexpr unsigned int getNParameters(const unsigned int degree, const unsigned int dim) { return (degree == 0) ? binomialCoeff(dim - 1, 0) : binomialCoeff(dim - 1 + degree, degree) + getNParameters(degree - 1, dim); }
+  GPUd() static constexpr unsigned int getNParametersAllTerms(const unsigned int degree, const unsigned int dim) { return (degree == 0) ? binomialCoeff(dim - 1, 0) : binomialCoeff(dim - 1 + degree, degree) + getNParametersAllTerms(degree - 1, dim); }
+
+  /// \returns the number of parameters for interaction terms only (see: https://en.wikipedia.org/wiki/Combination)
+  GPUd() static constexpr unsigned int getNParametersInteractionOnly(const unsigned int degree, const unsigned int dim) { return (degree == 0) ? binomialCoeff(dim - 1, 0) : binomialCoeff(dim, degree) + getNParametersInteractionOnly(degree - 1, dim); }
+
+  GPUd() static constexpr unsigned int getNParameters(const unsigned int degree, const unsigned int dim, const bool interactionOnly)
+  {
+    if (interactionOnly) {
+      return getNParametersInteractionOnly(degree, dim);
+    } else {
+      return getNParametersAllTerms(degree, dim);
+    }
+  }
 
  private:
   /// calculate factorial of n
@@ -74,14 +89,14 @@ class MultivariatePolynomialParametersHelper
 /// by performing all loops during compile time and replacing the array to keep track of the dimensions for given term (pos[FMaxdegree + 1])
 /// to a simple unsigned int called Pos where each digit represents the dimension for a given term e.g. pos = 2234 -> x[2]*x[2]*x[3]*x[4]
 ///
-template <unsigned int Dim, unsigned int Degree>
+template <unsigned int Dim, unsigned int Degree, bool InteractionOnly>
 class MultivariatePolynomialHelper : public MultivariatePolynomialParametersHelper
 {
   static constexpr unsigned short FMaxdim = 10;   ///< maximum dimensionality of the polynomials (number of different digits: 0,1,2,3....9 )
   static constexpr unsigned short FMaxdegree = 9; ///< maximum degree of the polynomials (maximum number of digits in unsigned integer - 1)
 
 #if !defined(GPUCA_GPUCODE)
-  static_assert(Dim <= MultivariatePolynomialHelper<Dim, Degree>::FMaxdim && Degree <= MultivariatePolynomialHelper<Dim, Degree>::FMaxdegree, "Max. number of dimensions or degrees exceeded!");
+  static_assert(Dim <= MultivariatePolynomialHelper<Dim, Degree, InteractionOnly>::FMaxdim && Degree <= MultivariatePolynomialHelper<Dim, Degree, InteractionOnly>::FMaxdegree, "Max. number of dimensions or degrees exceeded!");
 #endif
 
  public:
@@ -95,6 +110,9 @@ class MultivariatePolynomialHelper : public MultivariatePolynomialParametersHelp
 
   /// \return returns the degree of the polynomials
   GPUd() static constexpr unsigned int getDegree() { return Degree; }
+
+  /// \return returns whether only interaction terms are considered
+  GPUd() static constexpr bool isInteractionOnly() { return InteractionOnly; }
 
  private:
   /// computes power of 10
@@ -114,6 +132,10 @@ class MultivariatePolynomialHelper : public MultivariatePolynomialParametersHelp
   template <unsigned int DegreePol>
   GPUd() static constexpr float prodTerm(const float x[], const unsigned int pos);
 
+  /// helper function for checking for interaction terms
+  template <unsigned int DegreePol, unsigned int posNew>
+  static constexpr bool checkInteraction();
+
   /// calculate sum of the terms for given degree -> summation of the par[]*x^4 + par[]*x^3*y + par[]*x^3*z + par[]*x^2*y^2..... terms
   /// \tparam DegreePol max degree of the polynomials
   /// \Pos decoded information about the current term e.g. 1233 -> x[1]*x[2]*x[3]*x[3] (otherwise an array could be used)
@@ -129,17 +151,16 @@ class MultivariatePolynomialHelper : public MultivariatePolynomialParametersHelp
   GPUd() static constexpr float loopDegrees(GPUgeneric() const float par[], const float x[]);
 };
 
+#if !defined(GPUCA_GPUCODE) // disable specialized class for GPU, as it should be only used for the fitting!
 /// Helper struct for evaluating a multidimensional polynomial using run time evaluated formula
 template <>
-class MultivariatePolynomialHelper<0, 0> : public MultivariatePolynomialParametersHelper
+class MultivariatePolynomialHelper<0, 0, false> : public MultivariatePolynomialParametersHelper
 {
  public:
-#if !defined(GPUCA_GPUCODE)
   /// constructor
   /// \param nDim dimensionality of the polynomials
   /// \param degree degree of the polynomials
-  MultivariatePolynomialHelper(const unsigned int nDim, const unsigned int degree) : mDim{nDim}, mDegree{degree} { assert(mDegree <= FMaxdegree); };
-#endif
+  MultivariatePolynomialHelper(const unsigned int nDim, const unsigned int degree, const bool interactionOnly) : mDim{nDim}, mDegree{degree}, mInteractionOnly{interactionOnly} { assert(mDegree <= FMaxdegree); };
 
   /// default constructor
   MultivariatePolynomialHelper() CON_DEFAULT;
@@ -147,47 +168,75 @@ class MultivariatePolynomialHelper<0, 0> : public MultivariatePolynomialParamete
   /// Destructor
   ~MultivariatePolynomialHelper() CON_DEFAULT;
 
-#if !defined(GPUCA_GPUCODE)
   /// printing the formula of the polynomial
   void print() const;
 
+  /// \return the formula as a string
+  std::string getFormula() const;
+
+  /// \return returns the formula which can be used for the TLinearFitter
+  std::string getTLinearFitterFormula() const;
+
   /// \return returns the terms which are used to evaluate the polynomial
   std::vector<std::string> getTerms() const;
-#endif
+
+  /// \return TLinearFitter for set polynomials
+  TLinearFitter getTLinearFitter() const;
+
+  /// performs fit of input points (this function can be used for mutliple fits without creating the TLinearFitter for each fit again)
+  /// \return returns parameters of the fit
+  /// \param fitter fitter which is used to fit the points ()
+  /// \param x position of the points of length 'Dim * nPoints' (structured as in https://root.cern.ch/doc/master/classTLinearFitter.html)
+  /// \param y values which will be fitted of length 'nPoints'
+  /// \param error error of weigths of the points (if empty no weights are applied)
+  /// \param clearPoints set to true if the fit is performed on new data points
+  static std::vector<float> fit(TLinearFitter& fitter, std::vector<double>& x, std::vector<double>& y, std::vector<double>& error, const bool clearPoints);
+
+  /// performs fit of input points
+  /// \return returns parameters of the fit
+  /// \param x position of the points of length 'Dim * nPoints' (structured as in https://root.cern.ch/doc/master/classTLinearFitter.html)
+  /// \param y values which will be fitted of length 'nPoints'
+  /// \param error error of weigths of the points (if empty no weights are applied)
+  /// \param clearPoints set to true if the fit is performed on new data points
+  std::vector<float> fit(std::vector<double>& x, std::vector<double>& y, std::vector<double>& error, const bool clearPoints) const;
 
   /// evaluating the polynomial
   /// \param par coefficients of the polynomial
   /// \param x input coordinates
-  GPUd() float evalPol(GPUgeneric() const float par[/*number of parameters*/], const float x[/*number of dimensions*/]) const { return evalPol(par, x, mDegree, mDim); }
+  float evalPol(const float par[/*number of parameters*/], const float x[/*number of dimensions*/]) const { return evalPol(par, x, mDegree, mDim, mInteractionOnly); }
+
+  /// evalutes the polynomial
+  float evalPol(const float par[], const float x[], const unsigned int degree, const unsigned int dim, const bool interactionOnly) const;
 
   /// \return returns number of dimensions of the polynomials
-  GPUd() unsigned int getDim() const { return mDim; }
+  unsigned int getDim() const { return mDim; }
 
   /// \return returns the degree of the polynomials
-  GPUd() unsigned int getDegree() const { return mDegree; }
+  unsigned int getDegree() const { return mDegree; }
+
+  /// \return returns whether only interaction terms are considered
+  bool isInteractionOnly() { return mInteractionOnly; }
 
  protected:
-  unsigned int mDim{};    ///< dimensionality of the polynomial
-  unsigned int mDegree{}; ///< maximum degree of the polynomial
+  unsigned int mDim{};     ///< dimensionality of the polynomial
+  unsigned int mDegree{};  ///< maximum degree of the polynomial
+  bool mInteractionOnly{}; ///< flag if only interaction terms are used
 
  private:
   static constexpr unsigned short FMaxdegree = 9; ///< maximum degree of the polynomials (can be increased if desired: size of array in combination_with_repetiton: pos[FMaxdegree + 1])
 
-  /// evalutes the polynomial
-  GPUd() static constexpr float evalPol(GPUgeneric() const float par[], const float x[], const unsigned int degree, const unsigned int dim);
-
   /// helper function to get all combinations
   template <class Type>
-  GPUd() static Type combination_with_repetiton(const unsigned int degree, const unsigned int dim, GPUgeneric() const float par[], int& indexPar, const float x[]);
-  GPUd() static constexpr float combination_with_repetiton_constexpr_float(const unsigned int degree, const unsigned int dim, GPUgeneric() const float par[], int& indexPar, const float x[]);
+  Type combination_with_repetiton(const unsigned int degree, const unsigned int dim, const float par[], int& indexPar, const float x[], const bool interactionOnly) const;
 };
+#endif
 
 //=================================================================================
 //============================ inline implementations =============================
 //=================================================================================
 
-template <unsigned int Dim, unsigned int Degree>
-GPUd() constexpr unsigned int MultivariatePolynomialHelper<Dim, Degree>::resetIndices(const unsigned int degreePol, const unsigned int pos, const unsigned int leftDigit, const unsigned int iter, const unsigned int refDigit)
+template <unsigned int Dim, unsigned int Degree, bool InteractionOnly>
+GPUd() constexpr unsigned int MultivariatePolynomialHelper<Dim, Degree, InteractionOnly>::resetIndices(const unsigned int degreePol, const unsigned int pos, const unsigned int leftDigit, const unsigned int iter, const unsigned int refDigit)
 {
   if (iter <= degreePol) {
     const int powTmp = pow10(leftDigit);
@@ -198,8 +247,8 @@ GPUd() constexpr unsigned int MultivariatePolynomialHelper<Dim, Degree>::resetIn
   return pos;
 }
 
-template <unsigned int Dim, unsigned int Degree>
-GPUd() constexpr unsigned int MultivariatePolynomialHelper<Dim, Degree>::getNewPos(const unsigned int degreePol, const unsigned int pos, const unsigned int digitPos)
+template <unsigned int Dim, unsigned int Degree, bool InteractionOnly>
+GPUd() constexpr unsigned int MultivariatePolynomialHelper<Dim, Degree, InteractionOnly>::getNewPos(const unsigned int degreePol, const unsigned int pos, const unsigned int digitPos)
 {
   if (degreePol > digitPos) {
     // check if digit of current position is at is max position
@@ -220,9 +269,9 @@ GPUd() constexpr unsigned int MultivariatePolynomialHelper<Dim, Degree>::getNewP
   return pos;
 }
 
-template <unsigned int Dim, unsigned int Degree>
+template <unsigned int Dim, unsigned int Degree, bool InteractionOnly>
 template <unsigned int DegreePol>
-GPUd() constexpr float MultivariatePolynomialHelper<Dim, Degree>::prodTerm(const float x[], const unsigned int pos)
+GPUd() constexpr float MultivariatePolynomialHelper<Dim, Degree, InteractionOnly>::prodTerm(const float x[], const unsigned int pos)
 {
   if constexpr (DegreePol > 0) {
     // extract index of the dimension which is decoded in the digit
@@ -232,138 +281,48 @@ GPUd() constexpr float MultivariatePolynomialHelper<Dim, Degree>::prodTerm(const
   return 1;
 }
 
-template <unsigned int Dim, unsigned int Degree>
+template <unsigned int Dim, unsigned int Degree, bool InteractionOnly>
+template <unsigned int DegreePol, unsigned int posNew>
+constexpr bool MultivariatePolynomialHelper<Dim, Degree, InteractionOnly>::checkInteraction()
+{
+  if constexpr (DegreePol > 1) {
+    constexpr bool isInteraction = mod10(posNew, pow10(DegreePol - 1)) == mod10(posNew, pow10(DegreePol - 2));
+    if constexpr (isInteraction) {
+      return true;
+    }
+    return checkInteraction<DegreePol - 1, posNew>();
+  }
+  return false;
+}
+
+template <unsigned int Dim, unsigned int Degree, bool InteractionOnly>
 template <unsigned int DegreePol, unsigned int Pos, unsigned int Index>
-GPUd() constexpr float MultivariatePolynomialHelper<Dim, Degree>::sumTerms(GPUgeneric() const float par[], const float x[])
+GPUd() constexpr float MultivariatePolynomialHelper<Dim, Degree, InteractionOnly>::sumTerms(GPUgeneric() const float par[], const float x[])
 {
   // checking if the current position is reasonable e.g. if the max dimension is x[4]: for Pos=15 -> x[1]*x[5] the position is set to 22 -> x[2]*x[2]
   constexpr unsigned int posNew = getNewPos(DegreePol, Pos, 0);
   if constexpr (mod10(posNew, pow10(DegreePol)) != 1) {
+
+    // check if all digits in posNew are unequal: For interaction_only terms with x[Dim]*x[Dim]... etc. can be skipped
+    if constexpr (InteractionOnly && checkInteraction<DegreePol, posNew>()) {
+      return sumTerms<DegreePol, posNew + 1, Index>(par, x);
+    }
+
     // sum up the term for corrent term and set posotion for next combination
     return par[Index] * prodTerm<DegreePol>(x, posNew) + sumTerms<DegreePol, posNew + 1, Index + 1>(par, x);
   }
   return 0;
 }
 
-template <unsigned int Dim, unsigned int Degree>
+template <unsigned int Dim, unsigned int Degree, bool InteractionOnly>
 template <unsigned int DegreePol>
-GPUd() constexpr float MultivariatePolynomialHelper<Dim, Degree>::loopDegrees(GPUgeneric() const float par[], const float x[])
+GPUd() constexpr float MultivariatePolynomialHelper<Dim, Degree, InteractionOnly>::loopDegrees(GPUgeneric() const float par[], const float x[])
 {
   if constexpr (DegreePol <= Degree) {
-    constexpr unsigned int index{getNParameters(DegreePol - 1, Dim)}; // offset of the index for accessing the parameters
+    constexpr unsigned int index{getNParameters(DegreePol - 1, Dim, InteractionOnly)}; // offset of the index for accessing the parameters
     return sumTerms<DegreePol, 0, index>(par, x) + loopDegrees<DegreePol + 1>(par, x);
   }
   return 0;
-}
-
-template <class Type>
-GPUd() Type MultivariatePolynomialHelper<0, 0>::combination_with_repetiton(const unsigned int degree, const unsigned int dim, GPUgeneric() const float par[], int& indexPar, const float x[])
-{
-  {
-    const unsigned int size = degree + 1;
-    unsigned int pos[FMaxdegree + 1]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-
-    // return value is either the sum of all polynomials or a vector of strings containing the formula for each polynomial
-    Type val(0);
-    for (;;) {
-      // starting on the rightmost digit
-      for (unsigned int i = degree; i > 0; --i) {
-        // check if digit of current position is at is max position
-        if (pos[i] == dim) {
-          // increase digit of left position
-          ++pos[i - 1];
-          // resetting the indices of the digits to the right
-          for (unsigned int j = i; j <= degree; ++j) {
-            pos[j] = pos[i - 1];
-          }
-        }
-      }
-
-      // check if all combinations are processed
-      if (pos[0] == 1) {
-        break;
-      } else {
-        if constexpr (std::is_same_v<Type, float>) {
-          float term = par[indexPar++];
-          for (size_t i = 1; i < size; ++i) {
-            term *= x[pos[i]];
-          }
-          val += term;
-        } else {
-#if !defined(GPUCA_GPUCODE) && !defined(GPUCA_NO_FMT) && !defined(GPUCA_ALIROOT_LIB)
-          std::string term{};
-          for (size_t i = 1; i < size; ++i) {
-            term += fmt::format("x[{}] * ", pos[i]);
-          }
-          term += fmt::format("par[{}]", indexPar++);
-          val.emplace_back(term);
-#endif
-        }
-      }
-      // increase the rightmost digit
-      ++pos[degree];
-    }
-    return val;
-  }
-}
-
-GPUd() constexpr float MultivariatePolynomialHelper<0, 0>::combination_with_repetiton_constexpr_float(const unsigned int degree, const unsigned int dim, GPUgeneric() const float par[], int& indexPar, const float x[])
-{
-  {
-    const unsigned int size = degree + 1;
-    unsigned int pos[FMaxdegree + 1]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-
-    // return value is either the sum of all polynomials or a vector of strings containing the formula for each polynomial
-    float val(0);
-    for (;;) {
-      // starting on the rightmost digit
-      for (unsigned int i = degree; i > 0; --i) {
-        // check if digit of current position is at is max position
-        if (pos[i] == dim) {
-          // increase digit of left position
-          ++pos[i - 1];
-          // resetting the indices of the digits to the right
-          for (unsigned int j = i; j <= degree; ++j) {
-            pos[j] = pos[i - 1];
-          }
-        }
-      }
-
-      // check if all combinations are processed
-      if (pos[0] == 1) {
-        break;
-      } else {
-        if constexpr (std::is_same_v<float, float>) {
-          float term = par[indexPar++];
-          for (size_t i = 1; i < size; ++i) {
-            term *= x[pos[i]];
-          }
-          val += term;
-        } else {
-          // Removed since it cannot work as constexpr
-          /*std::string term{};
-          for (size_t i = 1; i < size; ++i) {
-            term += fmt::format("x[{}] * ", pos[i]);
-          }
-          term += fmt::format("par[{}]", indexPar++);
-          val.emplace_back(term);*/
-        }
-      }
-      // increase the rightmost digit
-      ++pos[degree];
-    }
-    return val;
-  }
-}
-
-GPUd() constexpr float MultivariatePolynomialHelper<0, 0>::evalPol(GPUgeneric() const float par[], const float x[], const unsigned int degree, const unsigned int dim)
-{
-  float val = par[0];
-  int indexPar = 1;
-  for (unsigned int deg = 1; deg <= degree; ++deg) {
-    val += combination_with_repetiton_constexpr_float(deg, dim, par, indexPar, x);
-  }
-  return val;
 }
 
 } // namespace GPUCA_NAMESPACE::gpu

--- a/GPU/TPCFastTransformation/NDPiecewisePolynomials.cxx
+++ b/GPU/TPCFastTransformation/NDPiecewisePolynomials.cxx
@@ -1,0 +1,15 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file  NDPiecewisePolynomials.cxx
+/// \author Matthias Kleiner <mkleiner@ikf.uni-frankfurt.de>
+
+#include "NDPiecewisePolynomials.h"

--- a/GPU/TPCFastTransformation/NDPiecewisePolynomials.h
+++ b/GPU/TPCFastTransformation/NDPiecewisePolynomials.h
@@ -1,0 +1,585 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file NDPiecewisePolynomials.h
+/// \author Matthias Kleiner <mkleiner@ikf.uni-frankfurt.de>
+
+#ifndef ALICEO2_TPC_NDPIECEWISEPOLYNOMIALS
+#define ALICEO2_TPC_NDPIECEWISEPOLYNOMIALS
+
+#include "GPUCommonLogger.h"
+#include "FlatObject.h"
+#include "MultivariatePolynomialHelper.h"
+#include "GPUCommonMath.h"
+
+#if !defined(GPUCA_GPUCODE)
+#include <vector>
+#if !defined(GPUCA_STANDALONE)
+#include "TLinearFitter.h"
+#include <TFile.h>
+#endif
+#endif
+
+namespace GPUCA_NAMESPACE::gpu
+{
+
+#if !defined(GPUCA_GPUCODE)
+/// simple struct to enable writing the NDPiecewisePolynomials to file
+struct NDPiecewisePolynomialContainer {
+
+  /// constructor
+  /// \param dim number of dimensions of the polynomial
+  /// \param degree degree of the polynomials
+  /// \param nParameters number of parameters
+  /// \param params parmaeters
+  /// \param interactionOnly consider only interaction terms
+  /// \param xmin minimum coordinates of the grid
+  /// \param xmax maximum coordinates of the grid
+  /// \param nVertices number of vertices: defines number of fits per dimension
+  NDPiecewisePolynomialContainer(const unsigned int dim, const unsigned int degree, const unsigned int nParameters, const float params[/* nParameters*/], const bool interactionOnly, const float xMin[/* Dim*/], const float xMax[/* Dim*/], const unsigned int nVertices[/* Dim*/]) : mDim{dim}, mDegree{degree}, mParams{params, params + nParameters}, mInteractionOnly{interactionOnly}, mMin{xMin, xMin + dim}, mMax{xMax, xMax + dim}, mN{nVertices, nVertices + dim} {};
+
+  /// for ROOT I/O
+  NDPiecewisePolynomialContainer() = default;
+
+  const unsigned int mDim{};            ///< number of dimensions of the polynomial
+  const unsigned int mDegree{};         ///< degree of the polynomials
+  const std::vector<float> mParams{};   ///< parameters of the polynomial
+  const bool mInteractionOnly{};        ///< consider only interaction terms
+  const std::vector<float> mMin{};      ///< min vertices positions of the grid
+  const std::vector<float> mMax{};      ///< max vertices positions of the grid
+  const std::vector<unsigned int> mN{}; ///< number of vertices for each dimension
+};
+#endif
+
+/// class for piecewise polynomial fits on a regular grid
+/// This class can be used to perform independent fits of nth-degree polynomials on a regular grid.
+/// The fitting should be performed on CPUs. The evaluation can be performed on CPU or GPU.
+/// A smooth function which can be evaluated on the full grid is expected to be provided when performing the fits.
+/// The main difference to splines is that the performed polynomial fits have no restrictions on the boundaries inside of the grid (it is not guaranteed that the resulting fits will be smooth at the grid vertices)
+/// The advantage to splines is the faster evaluation of the polynomials, which are still reasonable to use in higher dimensions, when performance is critical.
+///
+/// For usage see: testMultivarPolynomials.cxx
+///
+/// TODO: add possibillity to perform the fits on scattered data points (+add weighting of points)
+///
+/// \tparam Dim number of dimensions
+/// \tparam Degree degree of the polynomials
+/// \tparam InteractionOnly: consider only interaction terms: ignore x[0]*x[0]..., x[1]*x[1]*x[2]... etc. terms (same feature as 'interaction_only' in sklearn https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.PolynomialFeatures.html)
+///                          can be used for N-linear interpolation (https://en.wikipedia.org/wiki/Trilinear_interpolation#Alternative_algorithm)
+template <unsigned int Dim, unsigned int Degree, bool InteractionOnly>
+class NDPiecewisePolynomials : public FlatObject
+{
+ public:
+#if !defined(GPUCA_GPUCODE)
+
+  /// constructor
+  /// \param min minimum coordinates of the grid
+  /// \param max maximum coordinates of the grid (note: the resulting polynomials can NOT be evaluated at the maximum coordinates: only at min <= X < max)
+  /// \param n number of vertices: defines number of fits per dimension: nFits = n - 1. n should be at least 2 to perform one fit
+  NDPiecewisePolynomials(const float min[/* Dim */], const float max[/* Dim */], const unsigned int n[/* Dim */]) { init(min, max, n); }
+
+  /// constructor construct and object by initializing it from an object stored in a Root file
+  /// \param fileName name of the file
+  /// \param name name of the object
+  NDPiecewisePolynomials(const char* fileName, const char* name)
+  {
+    TFile f(fileName, "READ");
+    loadFromFile(f, name);
+  };
+#endif
+  /// default constructor
+  NDPiecewisePolynomials() CON_DEFAULT;
+
+  /// default destructor
+  ~NDPiecewisePolynomials() CON_DEFAULT;
+
+  /// Copy constructor
+  NDPiecewisePolynomials(const NDPiecewisePolynomials& obj) { cloneFromObject(obj, nullptr); }
+
+  /// ========== FlatObject functionality, see FlatObject class for description  =================
+#if !defined(GPUCA_GPUCODE)
+  /// cloning a container object (use newFlatBufferPtr=nullptr for simple copy)
+  void cloneFromObject(const NDPiecewisePolynomials& obj, char* newFlatBufferPtr);
+
+  /// move flat buffer to new location
+  /// \param newBufferPtr new buffer location
+  void moveBufferTo(char* newBufferPtr);
+#endif
+
+  /// destroy the object (release internal flat buffer)
+  void destroy();
+
+  /// set location of external flat buffer
+  void setActualBufferAddress(char* actualFlatBufferPtr);
+
+  /// set future location of the flat buffer
+  void setFutureBufferAddress(char* futureFlatBufferPtr);
+
+  /// evalute at given coordinate with boundary check (note: input values will be changed/clamped to the grid)
+  /// \param x coordinates where to interpolate
+  GPUd() float eval(float x[/* Dim */]) const
+  {
+    int index[Dim];
+    setIndex<Dim - 1>(x, index);
+    clamp<Dim - 1>(x, index);
+    return MultivariatePolynomialHelper<Dim, Degree, InteractionOnly>::evalPol(getParameters(index), x);
+  }
+
+  /// evalute at given coordinate (note: A boundary check for the provided coordinates is not performed!)
+  /// \param x coordinates where to interpolate (note: the resulting polynomials can NOT be evaluated at the maximum coordinates: only at min <= X < max)
+  GPUd() float evalUnsafe(const float x[/* Dim */]) const
+  {
+    int index[Dim];
+    setIndex<Dim - 1>(x, index);
+    return MultivariatePolynomialHelper<Dim, Degree, InteractionOnly>::evalPol(getParameters(index), x);
+  }
+
+  /// evaluate specific polynomial at given index for given coordinate
+  /// \param x coordinates where to interpolate
+  /// \param index index of the polynomial
+  GPUd() float evalPol(const float x[/* Dim */], const int index[/* Dim */]) const { return MultivariatePolynomialHelper<Dim, Degree, InteractionOnly>::evalPol(getParameters(index), x); }
+
+  /// \return returns min range for given dimension
+  GPUd() float getXMin(const unsigned int dim) const { return mMin[dim]; }
+
+  /// \return returns max range for given dimension
+  GPUd() float getXMax(const unsigned int dim) const { return mMax[dim]; }
+
+  /// \return returns inverse spacing for given dimension
+  GPUd() float getInvSpacing(const unsigned int dim) const { return mInvSpacing[dim]; }
+
+  /// \return returns number of vertices for given dimension
+  GPUd() unsigned int getNVertices(const unsigned int dim) const { return mN[dim]; }
+
+  /// \return returns number of polynomial fits for given dimension
+  GPUd() unsigned int getNPolynomials(const unsigned int dim) const { return mN[dim] - 1; }
+
+  /// \return returns the parameters of the coefficients
+  GPUd() const float* getParams() const { return mParams; }
+
+#if !defined(GPUCA_GPUCODE)
+  /// Setting directly the parameters of the polynomials
+  void setParams(const float params[/* getNParameters() */]) { std::copy(params, params + getNParameters(), mParams); }
+
+#ifndef GPUCA_STANDALONE
+  /// perform the polynomial fits on the grid
+  /// \param func function which returns for every input x on the defined grid the true value
+  /// \param nAuxiliaryPoints number of points which will be used for the fits (should be at least 2)
+  void performFits(const std::function<double(const double x[/* Dim */])>& func, const unsigned int nAuxiliaryPoints[/* Dim */]);
+
+  /// load parameters from input file (which were written using the writeToFile method)
+  /// \param inpf input file
+  /// \param name name of the object in the file
+  void loadFromFile(TFile& inpf, const char* name);
+
+  /// write parameters to file
+  /// \param outf output file
+  /// \param name name of the output object
+  void writeToFile(TFile& outf, const char* name) const;
+
+  /// setting default polynomials which just returns 1
+  void setDefault();
+
+  /// initalize the members
+  /// \param min minimum coordinates of the grid
+  /// \param max maximum coordinates of the grid (note: the resulting polynomials can NOT be evaluated at the maximum coordinates: only at min <= X < max)
+  /// \param n number of vertices: defines number of fits per dimension: nFits = n - 1. n should be at least 2 to perform one fit
+  void init(const float min[/* Dim */], const float max[/* Dim */], const unsigned int n[/* Dim */]);
+
+  /// \return returns total number of polynomial fits
+  unsigned int getNPolynomials() const;
+#endif
+
+  /// converts the class to a container which can be written to a root file
+  NDPiecewisePolynomialContainer getContainer() const { return NDPiecewisePolynomialContainer{Dim, Degree, getNParameters(), mParams, InteractionOnly, mMin, mMax, mN}; }
+
+  /// set the parameters from NDPiecewisePolynomialContainer
+  /// \param container container for the parameters
+  void setFromContainer(const NDPiecewisePolynomialContainer& container);
+
+  /// \return returns the total number of stored parameters
+  unsigned int getNParameters() const { return getNPolynomials() * MultivariatePolynomialParametersHelper::getNParameters(Degree, Dim, InteractionOnly); }
+#endif
+
+  /// \return returns number of dimensions of the polynomials
+  GPUd() static constexpr unsigned int getDim() { return Dim; }
+
+  /// \return returns the degree of the polynomials
+  GPUd() static constexpr unsigned int getDegree() { return Degree; }
+
+  /// \return returns whether only interaction terms are considered
+  GPUd() static constexpr bool isInteractionOnly() { return InteractionOnly; }
+
+ private:
+  using DataTParams = float;     ///< data type of the parameters of the polynomials
+  float mMin[Dim]{};             ///< min vertices positions of the grid
+  float mMax[Dim]{};             ///< max vertices positions of the grid
+  float mInvSpacing[Dim]{};      ///< inverse spacings of the grid
+  unsigned int mN[Dim]{};        ///< number of vertices for each dimension
+  DataTParams* mParams{nullptr}; ///< storage for the parameters
+
+  /// \returns vertex number for given position and dimension
+  /// \param x position
+  /// \param dim dimension
+  GPUd() int getVertex(const float x, const unsigned int dim) const { return ((x - mMin[dim]) * mInvSpacing[dim]); }
+
+  /// returns terms which are needed to calculate the index for the grid for given dimension
+  /// \param dim dimension
+  GPUd() unsigned int getTerms(const unsigned int dim) const { return (dim == 0) ? 1 : (mN[dim - 1] - 1) * getTerms(dim - 1); }
+
+  /// returns index for accessing the parameter on the grid
+  /// \param ix index per dimension
+  GPUd() unsigned int getDataIndex(const int ix[/* Dim */]) const { return getDataIndex<Dim - 1>(ix) * MultivariatePolynomialParametersHelper::getNParameters(Degree, Dim, InteractionOnly); }
+
+  /// helper function to get the index
+  template <unsigned int DimTmp>
+  GPUd() unsigned int getDataIndex(const int ix[/* Dim */]) const;
+
+  /// \return returns pointer to memory where the parameters for given indices are stored
+  /// \param index indices of polynomials
+  GPUd() const float* getParameters(const int index[/* Dim */]) const { return &mParams[getDataIndex(index)]; }
+
+  /// helper function to fill array containing the indices to where the parameters are stored
+  template <unsigned int DimTmp>
+  GPUd() void setIndex(const float x[/* Dim */], int index[/* Dim */]) const;
+
+  /// clamp input coordinates to avoid extrapolation
+  template <unsigned int DimTmp>
+  GPUd() void clamp(float x[/* Dim */], int index[/* Dim */]) const;
+
+#if !defined(GPUCA_GPUCODE) && !defined(GPUCA_STANDALONE)
+  /// perform the actual fit in the grid
+  /// \param func function which returns for evey input x the true value
+  /// \param nAuxiliaryPoints number of points which will be used for the fits (should be at least 2)
+  /// \param currentIndex to keep track of where (indices on the grid) the fit is beeing performed
+  /// \param fitter TLinearFitter which is used for performing the fits
+  /// \param xCords buffer for x-coordinates
+  /// \param response buffer for y-coordinates
+  void fitInnerGrid(const std::function<double(const double x[/* Dim */])>& func, const unsigned int nAuxiliaryPoints[/* Dim */], const int currentIndex[/* Dim */], TLinearFitter& fitter, std::vector<double>& xCords, std::vector<double>& response);
+
+  /// heler function to loop over all dimensions
+  void checkPos(const unsigned int iMax[/* Dim */], int pos[/* Dim */]) const;
+
+  /// \return returns step width of the inner grid
+  /// \param dim dimension
+  /// \param nAuxiliaryPoints number of Auxiliary points for given dimension
+  double getStepWidth(const unsigned int dim, const int nAuxiliaryPoints) const { return 1 / (static_cast<double>(mInvSpacing[dim]) * (nAuxiliaryPoints - 1)); }
+
+  /// \return returns vertex position for given index and dimension
+  /// \param ix index
+  /// \param dim dimension
+  double getVertexPosition(const unsigned int ix, const int dim) const { return ix / static_cast<double>(mInvSpacing[dim]) + mMin[dim]; }
+#endif
+
+#if !defined(GPUCA_GPUCODE)
+  /// \return returns the size of the parameters
+  std::size_t sizeOfParameters() const { return getNParameters() * sizeof(DataTParams); }
+
+  // construct the object (flatbuffer)
+  void construct();
+#endif
+};
+
+//=================================================================================
+//============================ inline implementations =============================
+//=================================================================================
+
+#if !defined(GPUCA_GPUCODE) && !defined(GPUCA_STANDALONE)
+template <unsigned int Dim, unsigned int Degree, bool InteractionOnly>
+void NDPiecewisePolynomials<Dim, Degree, InteractionOnly>::loadFromFile(TFile& inpf, const char* name)
+{
+  NDPiecewisePolynomialContainer* gridTmp = nullptr;
+  inpf.GetObject(name, gridTmp);
+  if (gridTmp) {
+    setFromContainer(*gridTmp);
+    delete gridTmp;
+  } else {
+#ifndef GPUCA_ALIROOT_LIB
+    LOGP(info, fmt::format("couldnt load object {} from input file", name));
+#endif
+  }
+}
+
+template <unsigned int Dim, unsigned int Degree, bool InteractionOnly>
+void NDPiecewisePolynomials<Dim, Degree, InteractionOnly>::setFromContainer(const NDPiecewisePolynomialContainer& container)
+{
+  if (Dim != container.mDim) {
+#ifndef GPUCA_ALIROOT_LIB
+    LOGP(info, fmt::format("wrong number of dimensions! this {} container {}", Dim, container.mDim));
+#endif
+    return;
+  }
+  if (Degree != container.mDegree) {
+#ifndef GPUCA_ALIROOT_LIB
+    LOGP(info, fmt::format("wrong number of degrees! this {} container {}", Degree, container.mDegree));
+#endif
+    return;
+  }
+  if (InteractionOnly != container.mInteractionOnly) {
+#ifndef GPUCA_ALIROOT_LIB
+    LOGP(info, fmt::format("InteractionOnly is set for this object to {}, but stored as {} in the container", InteractionOnly, container.mInteractionOnly));
+#endif
+    return;
+  }
+  init(container.mMin.data(), container.mMax.data(), container.mN.data());
+  setParams(container.mParams.data());
+}
+
+template <unsigned int Dim, unsigned int Degree, bool InteractionOnly>
+void NDPiecewisePolynomials<Dim, Degree, InteractionOnly>::writeToFile(TFile& outf, const char* name) const
+{
+  const NDPiecewisePolynomialContainer cont = getContainer();
+  outf.WriteObject(&cont, name);
+}
+
+template <unsigned int Dim, unsigned int Degree, bool InteractionOnly>
+void NDPiecewisePolynomials<Dim, Degree, InteractionOnly>::setDefault()
+{
+  const auto nParamsPerPol = MultivariatePolynomialParametersHelper::getNParameters(Degree, Dim, InteractionOnly);
+  const auto nPols = getNPolynomials();
+  std::vector<float> params(nParamsPerPol);
+  params.front() = 1;
+  for (auto i = 0; i < nPols; ++i) {
+    std::copy(params.begin(), params.end(), &mParams[i * nParamsPerPol]);
+  }
+}
+
+template <unsigned int Dim, unsigned int Degree, bool InteractionOnly>
+void NDPiecewisePolynomials<Dim, Degree, InteractionOnly>::cloneFromObject(const NDPiecewisePolynomials<Dim, Degree, InteractionOnly>& obj, char* newFlatBufferPtr)
+{
+  const char* oldFlatBufferPtr = obj.mFlatBufferPtr;
+  FlatObject::cloneFromObject(obj, newFlatBufferPtr);
+  for (unsigned int i = 0; i < Dim; ++i) {
+    mMin[i] = obj.mMin[i];
+    mMax[i] = obj.mMax[i];
+    mInvSpacing[i] = obj.mInvSpacing[i];
+    mN[i] = obj.mN[i];
+  }
+  if (obj.mParams) {
+    mParams = FlatObject::relocatePointer(oldFlatBufferPtr, mFlatBufferPtr, obj.mParams);
+  }
+}
+
+template <unsigned int Dim, unsigned int Degree, bool InteractionOnly>
+void NDPiecewisePolynomials<Dim, Degree, InteractionOnly>::moveBufferTo(char* newFlatBufferPtr)
+{
+  char* oldFlatBufferPtr = mFlatBufferPtr;
+  FlatObject::moveBufferTo(newFlatBufferPtr);
+  char* currFlatBufferPtr = mFlatBufferPtr;
+  mFlatBufferPtr = oldFlatBufferPtr;
+  setActualBufferAddress(currFlatBufferPtr);
+}
+
+template <unsigned int Dim, unsigned int Degree, bool InteractionOnly>
+void NDPiecewisePolynomials<Dim, Degree, InteractionOnly>::construct()
+{
+  FlatObject::startConstruction();
+  const std::size_t flatbufferSize = sizeOfParameters();
+  FlatObject::finishConstruction(flatbufferSize);
+  mParams = reinterpret_cast<DataTParams*>(mFlatBufferPtr);
+}
+#endif
+
+template <unsigned int Dim, unsigned int Degree, bool InteractionOnly>
+void NDPiecewisePolynomials<Dim, Degree, InteractionOnly>::destroy()
+{
+  mParams = nullptr;
+  FlatObject::destroy();
+}
+
+template <unsigned int Dim, unsigned int Degree, bool InteractionOnly>
+void NDPiecewisePolynomials<Dim, Degree, InteractionOnly>::setActualBufferAddress(char* actualFlatBufferPtr)
+{
+  FlatObject::setActualBufferAddress(actualFlatBufferPtr);
+  mParams = reinterpret_cast<DataTParams*>(mFlatBufferPtr);
+}
+
+template <unsigned int Dim, unsigned int Degree, bool InteractionOnly>
+void NDPiecewisePolynomials<Dim, Degree, InteractionOnly>::setFutureBufferAddress(char* futureFlatBufferPtr)
+{
+  mParams = FlatObject::relocatePointer(mFlatBufferPtr, futureFlatBufferPtr, mParams);
+  FlatObject::setFutureBufferAddress(futureFlatBufferPtr);
+}
+
+template <unsigned int Dim, unsigned int Degree, bool InteractionOnly>
+template <unsigned int DimTmp>
+unsigned int NDPiecewisePolynomials<Dim, Degree, InteractionOnly>::getDataIndex(const int ix[/* Dim */]) const
+{
+  if constexpr (DimTmp > 0) {
+    return ix[DimTmp] * getTerms(DimTmp) + getDataIndex<DimTmp - 1>(ix);
+  }
+  return ix[DimTmp];
+}
+
+template <unsigned int Dim, unsigned int Degree, bool InteractionOnly>
+template <unsigned int DimTmp>
+void NDPiecewisePolynomials<Dim, Degree, InteractionOnly>::setIndex(const float x[/* Dim */], int index[/* Dim */]) const
+{
+  index[DimTmp] = getVertex(x[DimTmp], DimTmp);
+  if constexpr (DimTmp > 0) {
+    return setIndex<DimTmp - 1>(x, index);
+  }
+  return;
+}
+
+template <unsigned int Dim, unsigned int Degree, bool InteractionOnly>
+template <unsigned int DimTmp>
+void NDPiecewisePolynomials<Dim, Degree, InteractionOnly>::clamp(float x[/* Dim */], int index[/* Dim */]) const
+{
+  if (index[DimTmp] <= 0) {
+    index[DimTmp] = 0;
+
+    if (x[DimTmp] < mMin[DimTmp]) {
+      x[DimTmp] = mMin[DimTmp];
+    }
+
+  } else {
+    if (index[DimTmp] >= int(mN[DimTmp] - 1)) {
+      index[DimTmp] = mN[DimTmp] - 2;
+      x[DimTmp] = mMax[DimTmp];
+    }
+  }
+
+  if constexpr (DimTmp > 0) {
+    return clamp<DimTmp - 1>(x, index);
+  }
+}
+
+#if !defined(GPUCA_GPUCODE) && !defined(GPUCA_STANDALONE)
+template <unsigned int Dim, unsigned int Degree, bool InteractionOnly>
+void NDPiecewisePolynomials<Dim, Degree, InteractionOnly>::init(const float min[], const float max[], const unsigned int n[])
+{
+#ifndef GPUCA_ALIROOT_LIB
+  LOGP(info, "--- Initalizing regular grid ---");
+#endif
+  for (unsigned int i = 0; i < Dim; ++i) {
+    mMin[i] = min[i];
+    mMax[i] = max[i];
+    mN[i] = n[i];
+    mInvSpacing[i] = (mN[i] - 1) / (mMax[i] - mMin[i]);
+#ifndef GPUCA_ALIROOT_LIB
+    LOGP(info, "Setting {} fits for x[{}]", getNPolynomials(i), i);
+#endif
+  }
+  construct();
+}
+
+template <unsigned int Dim, unsigned int Degree, bool InteractionOnly>
+unsigned int NDPiecewisePolynomials<Dim, Degree, InteractionOnly>::getNPolynomials() const
+{
+  unsigned int nP = getNPolynomials(0);
+  for (unsigned int i = 1; i < Dim; ++i) {
+    nP *= getNPolynomials(i);
+  }
+  return nP;
+}
+
+template <unsigned int Dim, unsigned int Degree, bool InteractionOnly>
+void NDPiecewisePolynomials<Dim, Degree, InteractionOnly>::checkPos(const unsigned int iMax[/* Dim */], int pos[/* Dim */]) const
+{
+  for (unsigned int i = 0; i < Dim; ++i) {
+    if (pos[i] == int(iMax[i])) {
+      ++pos[i + 1];
+      std::fill_n(pos, i + 1, 0);
+    }
+  }
+}
+
+template <unsigned int Dim, unsigned int Degree, bool InteractionOnly>
+void NDPiecewisePolynomials<Dim, Degree, InteractionOnly>::performFits(const std::function<double(const double x[/* Dim */])>& func, const unsigned int nAuxiliaryPoints[/* Dim */])
+{
+  const int nTotalFits = getNPolynomials();
+#ifndef GPUCA_ALIROOT_LIB
+  LOGP(info, "Perform fitting of {}D-Polynomials of degree {} for a total of {} fits.", Dim, Degree, nTotalFits);
+#endif
+
+  MultivariatePolynomialHelper<0, 0, false> pol(Dim, Degree, InteractionOnly);
+  TLinearFitter fitter = pol.getTLinearFitter();
+
+  unsigned int nPoints = 1;
+  for (unsigned int i = 0; i < Dim; ++i) {
+    nPoints *= nAuxiliaryPoints[i];
+  }
+
+  std::vector<double> xCords;
+  std::vector<double> response;
+  xCords.reserve(Dim * nPoints);
+  response.reserve(nPoints);
+
+  unsigned int nPolynomials[Dim]{0};
+  for (unsigned int i = 0; i < Dim; ++i) {
+    nPolynomials[i] = getNPolynomials(i);
+  }
+
+  int pos[Dim + 1]{0};
+  unsigned int counter = 0;
+  const int printDebugForNFits = int(nTotalFits / 20) + 1;
+
+  for (;;) {
+    const bool debug = !(++counter % printDebugForNFits);
+    if (debug) {
+#ifndef GPUCA_ALIROOT_LIB
+      LOGP(info, "Peforming fit {} out of {}", counter, nTotalFits);
+#endif
+    }
+
+    checkPos(nPolynomials, pos);
+
+    if (pos[Dim] == 1) {
+      break;
+    }
+
+    xCords.clear();
+    response.clear();
+    fitInnerGrid(func, nAuxiliaryPoints, pos, fitter, xCords, response);
+    ++pos[0];
+  }
+}
+
+template <unsigned int Dim, unsigned int Degree, bool InteractionOnly>
+void NDPiecewisePolynomials<Dim, Degree, InteractionOnly>::fitInnerGrid(const std::function<double(const double x[/* Dim */])>& func, const unsigned int nAuxiliaryPoints[/* Dim */], const int currentIndex[/* Dim */], TLinearFitter& fitter, std::vector<double>& xCords, std::vector<double>& response)
+{
+  int pos[Dim + 1]{0};
+
+  // add points which will be used for the fit
+  for (;;) {
+    checkPos(nAuxiliaryPoints, pos);
+
+    if (pos[Dim] == 1) {
+      break;
+    }
+
+    for (unsigned int iDim = 0; iDim < Dim; ++iDim) {
+      const double stepWidth = getStepWidth(iDim, nAuxiliaryPoints[iDim]);
+      const double vertexPos = getVertexPosition(currentIndex[iDim], iDim);
+      const double realPosTmp = vertexPos + pos[iDim] * stepWidth;
+      xCords.emplace_back(realPosTmp);
+    }
+
+    // get response for last added points
+    const double responseTmp = func(&xCords[xCords.size() - Dim]);
+    response.emplace_back(responseTmp);
+    ++pos[0];
+  }
+
+  // perform the fit on the points TODO make errors configurable
+  std::vector<double> error;
+  const auto params = MultivariatePolynomialHelper<0, 0, false>::fit(fitter, xCords, response, error, true);
+
+  // store parameters
+  const unsigned int index = getDataIndex(currentIndex);
+  std::copy(params.begin(), params.end(), &mParams[index]);
+}
+#endif
+
+} // namespace GPUCA_NAMESPACE::gpu
+
+#endif

--- a/GPU/TPCFastTransformation/TPCFastTransformationLinkDef_O2.h
+++ b/GPU/TPCFastTransformation/TPCFastTransformationLinkDef_O2.h
@@ -66,5 +66,6 @@
 #pragma link C++ class o2::gpu::TPCFastSpaceChargeCorrection::SliceInfo + ;
 #pragma link C++ class o2::gpu::TPCFastSpaceChargeCorrection + ;
 #pragma link C++ struct o2::gpu::MultivariatePolynomialContainer + ;
+#pragma link C++ struct o2::gpu::NDPiecewisePolynomialContainer + ;
 
 #endif

--- a/GPU/TPCFastTransformation/test/testMultivarPolynomials.cxx
+++ b/GPU/TPCFastTransformation/test/testMultivarPolynomials.cxx
@@ -18,6 +18,8 @@
 
 #include <boost/test/unit_test.hpp>
 #include "MultivariatePolynomial.h"
+#include "NDPiecewisePolynomials.h"
+#include <vector>
 
 namespace o2::gpu
 {
@@ -26,6 +28,11 @@ namespace o2::gpu
 float evalPol4_5D(const float* x, const float* par)
 {
   return par[0] + par[1] * x[0] + par[2] * x[1] + par[3] * x[2] + par[4] * x[3] + par[5] * x[4] + par[6] * x[0] * x[0] + par[7] * x[0] * x[1] + par[8] * x[0] * x[2] + par[9] * x[0] * x[3] + par[10] * x[0] * x[4] + par[11] * x[1] * x[1] + par[12] * x[1] * x[2] + par[13] * x[1] * x[3] + par[14] * x[1] * x[4] + par[15] * x[2] * x[2] + par[16] * x[2] * x[3] + par[17] * x[2] * x[4] + par[18] * x[3] * x[3] + par[19] * x[3] * x[4] + par[20] * x[4] * x[4] + par[21] * x[0] * x[0] * x[0] + par[22] * x[0] * x[0] * x[1] + par[23] * x[0] * x[0] * x[2] + par[24] * x[0] * x[0] * x[3] + par[25] * x[0] * x[0] * x[4] + par[26] * x[0] * x[1] * x[1] + par[27] * x[0] * x[1] * x[2] + par[28] * x[0] * x[1] * x[3] + par[29] * x[0] * x[1] * x[4] + par[30] * x[0] * x[2] * x[2] + par[31] * x[0] * x[2] * x[3] + par[32] * x[0] * x[2] * x[4] + par[33] * x[0] * x[3] * x[3] + par[34] * x[0] * x[3] * x[4] + par[35] * x[0] * x[4] * x[4] + par[36] * x[1] * x[1] * x[1] + par[37] * x[1] * x[1] * x[2] + par[38] * x[1] * x[1] * x[3] + par[39] * x[1] * x[1] * x[4] + par[40] * x[1] * x[2] * x[2] + par[41] * x[1] * x[2] * x[3] + par[42] * x[1] * x[2] * x[4] + par[43] * x[1] * x[3] * x[3] + par[44] * x[1] * x[3] * x[4] + par[45] * x[1] * x[4] * x[4] + par[46] * x[2] * x[2] * x[2] + par[47] * x[2] * x[2] * x[3] + par[48] * x[2] * x[2] * x[4] + par[49] * x[2] * x[3] * x[3] + par[50] * x[2] * x[3] * x[4] + par[51] * x[2] * x[4] * x[4] + par[52] * x[3] * x[3] * x[3] + par[53] * x[3] * x[3] * x[4] + par[54] * x[3] * x[4] * x[4] + par[55] * x[4] * x[4] * x[4] + par[56] * x[0] * x[0] * x[0] * x[0] + par[57] * x[0] * x[0] * x[0] * x[1] + par[58] * x[0] * x[0] * x[0] * x[2] + par[59] * x[0] * x[0] * x[0] * x[3] + par[60] * x[0] * x[0] * x[0] * x[4] + par[61] * x[0] * x[0] * x[1] * x[1] + par[62] * x[0] * x[0] * x[1] * x[2] + par[63] * x[0] * x[0] * x[1] * x[3] + par[64] * x[0] * x[0] * x[1] * x[4] + par[65] * x[0] * x[0] * x[2] * x[2] + par[66] * x[0] * x[0] * x[2] * x[3] + par[67] * x[0] * x[0] * x[2] * x[4] + par[68] * x[0] * x[0] * x[3] * x[3] + par[69] * x[0] * x[0] * x[3] * x[4] + par[70] * x[0] * x[0] * x[4] * x[4] + par[71] * x[0] * x[1] * x[1] * x[1] + par[72] * x[0] * x[1] * x[1] * x[2] + par[73] * x[0] * x[1] * x[1] * x[3] + par[74] * x[0] * x[1] * x[1] * x[4] + par[75] * x[0] * x[1] * x[2] * x[2] + par[76] * x[0] * x[1] * x[2] * x[3] + par[77] * x[0] * x[1] * x[2] * x[4] + par[78] * x[0] * x[1] * x[3] * x[3] + par[79] * x[0] * x[1] * x[3] * x[4] + par[80] * x[0] * x[1] * x[4] * x[4] + par[81] * x[0] * x[2] * x[2] * x[2] + par[82] * x[0] * x[2] * x[2] * x[3] + par[83] * x[0] * x[2] * x[2] * x[4] + par[84] * x[0] * x[2] * x[3] * x[3] + par[85] * x[0] * x[2] * x[3] * x[4] + par[86] * x[0] * x[2] * x[4] * x[4] + par[87] * x[0] * x[3] * x[3] * x[3] + par[88] * x[0] * x[3] * x[3] * x[4] + par[89] * x[0] * x[3] * x[4] * x[4] + par[90] * x[0] * x[4] * x[4] * x[4] + par[91] * x[1] * x[1] * x[1] * x[1] + par[92] * x[1] * x[1] * x[1] * x[2] + par[93] * x[1] * x[1] * x[1] * x[3] + par[94] * x[1] * x[1] * x[1] * x[4] + par[95] * x[1] * x[1] * x[2] * x[2] + par[96] * x[1] * x[1] * x[2] * x[3] + par[97] * x[1] * x[1] * x[2] * x[4] + par[98] * x[1] * x[1] * x[3] * x[3] + par[99] * x[1] * x[1] * x[3] * x[4] + par[100] * x[1] * x[1] * x[4] * x[4] + par[101] * x[1] * x[2] * x[2] * x[2] + par[102] * x[1] * x[2] * x[2] * x[3] + par[103] * x[1] * x[2] * x[2] * x[4] + par[104] * x[1] * x[2] * x[3] * x[3] + par[105] * x[1] * x[2] * x[3] * x[4] + par[106] * x[1] * x[2] * x[4] * x[4] + par[107] * x[1] * x[3] * x[3] * x[3] + par[108] * x[1] * x[3] * x[3] * x[4] + par[109] * x[1] * x[3] * x[4] * x[4] + par[110] * x[1] * x[4] * x[4] * x[4] + par[111] * x[2] * x[2] * x[2] * x[2] + par[112] * x[2] * x[2] * x[2] * x[3] + par[113] * x[2] * x[2] * x[2] * x[4] + par[114] * x[2] * x[2] * x[3] * x[3] + par[115] * x[2] * x[2] * x[3] * x[4] + par[116] * x[2] * x[2] * x[4] * x[4] + par[117] * x[2] * x[3] * x[3] * x[3] + par[118] * x[2] * x[3] * x[3] * x[4] + par[119] * x[2] * x[3] * x[4] * x[4] + par[120] * x[2] * x[4] * x[4] * x[4] + par[121] * x[3] * x[3] * x[3] * x[3] + par[122] * x[3] * x[3] * x[3] * x[4] + par[123] * x[3] * x[3] * x[4] * x[4] + par[124] * x[3] * x[4] * x[4] * x[4] + par[125] * x[4] * x[4] * x[4] * x[4];
+}
+
+float evalPol5_5D_interactionOnly(const float* x, const float* par)
+{
+  return par[0] + x[0] * par[1] + x[1] * par[2] + x[2] * par[3] + x[3] * par[4] + x[4] * par[5] + x[0] * x[1] * par[6] + x[0] * x[2] * par[7] + x[0] * x[3] * par[8] + x[0] * x[4] * par[9] + x[1] * x[2] * par[10] + x[1] * x[3] * par[11] + x[1] * x[4] * par[12] + x[2] * x[3] * par[13] + x[2] * x[4] * par[14] + x[3] * x[4] * par[15] + x[0] * x[1] * x[2] * par[16] + x[0] * x[1] * x[3] * par[17] + x[0] * x[1] * x[4] * par[18] + x[0] * x[2] * x[3] * par[19] + x[0] * x[2] * x[4] * par[20] + x[0] * x[3] * x[4] * par[21] + x[1] * x[2] * x[3] * par[22] + x[1] * x[2] * x[4] * par[23] + x[1] * x[3] * x[4] * par[24] + x[2] * x[3] * x[4] * par[25] + x[0] * x[1] * x[2] * x[3] * par[26] + x[0] * x[1] * x[2] * x[4] * par[27] + x[0] * x[1] * x[3] * x[4] * par[28] + x[0] * x[2] * x[3] * x[4] * par[29] + x[1] * x[2] * x[3] * x[4] * par[30] + x[0] * x[1] * x[2] * x[3] * x[4] * par[31];
 }
 
 float genRand()
@@ -74,6 +81,157 @@ BOOST_AUTO_TEST_CASE(Polynomials5D)
               const float valRef = evalPol4_5D(arr, par);
               BOOST_CHECK_SMALL(valCT - valRef, abstolerance);
               BOOST_CHECK_SMALL(valRT - valRef, abstolerance);
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+BOOST_AUTO_TEST_CASE(Polynomials5D_InteractionOnly)
+{
+  std::srand(std::time(nullptr));
+  const int nPar5D5DegInteraction = 32; // number of parameters
+  const int nDim = 5;                   // dimensions
+  const int nDegree = 5;                // degree
+  const float abstolerance = 0.0001f;   // abosulte difference between refernce to polynomial class
+  const bool interactionOnly = true;
+
+  MultivariatePolynomial<nDim, nDegree, interactionOnly> polCT;       // compile time polynomial
+  MultivariatePolynomial<0, 0> polRT(nDim, nDegree, interactionOnly); // run time polynomial
+
+  // compare number of parameters
+  BOOST_CHECK(nPar5D5DegInteraction == polCT.getNParams());
+  BOOST_CHECK(nPar5D5DegInteraction == polRT.getNParams());
+
+  float par[nPar5D5DegInteraction]{20};
+  for (int iter = 0; iter < 10; ++iter) {
+
+    // draw random parameters
+    for (int i = 1; i < nPar5D5DegInteraction; ++i) {
+      par[i] = genRand();
+    }
+
+    polCT.setParams(par);
+    polRT.setParams(par);
+
+    // compare evaluated polynomials
+    for (float a = 0; a < 1; a += 0.2f) {
+      for (float b = 0; b < 1; b += 0.2f) {
+        for (float c = 0; c < 1; c += 0.2f) {
+          for (float d = 0; d < 1; d += 0.2f) {
+            for (float e = 0; e < 1; e += 0.2f) {
+              const float arr[nDim]{a, b, c, d, e};
+              const float valCT = polCT.eval(arr);
+              const float valRT = polRT.eval(arr);
+              const float valRef = evalPol5_5D_interactionOnly(arr, par);
+              BOOST_CHECK_SMALL(valCT - valRef, abstolerance);
+              BOOST_CHECK_SMALL(valRT - valRef, abstolerance);
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+BOOST_AUTO_TEST_CASE(Piecewise_polynomials)
+{
+  std::srand(std::time(nullptr));
+  const int nPar5D5DegInteraction = 32; // number of parameters
+  const int nDim = 5;                   // dimensions
+  const int nDegree = 5;                // degree
+  const bool interactionOnly = true;    // consider only interaction terms
+
+  // reference polynomial which will be approximated by the NDPiecewisePolynomials
+  MultivariatePolynomial<nDim, nDegree, interactionOnly> polCT;
+
+  // define picewise polynomials with a lower degree than the original reference function
+  std::vector<float> xMin(nDim, 0);
+  std::vector<float> xMax(nDim, 1);
+  const std::vector<unsigned int> nVert(nDim, 4);
+  NDPiecewisePolynomials<nDim, nDegree - 2, interactionOnly> piecewisePol(xMin.data(), xMax.data(), nVert.data());
+
+  // define function which will be used to approximate the picewise polynomials
+  std::function<float(const double x[/* Xdim */])> refFunc = [&polCT, nDim](const double x[/* Xdim */]) {
+    float val[nDim]{};
+    std::copy(x, x + nDim, val);
+    return polCT.eval(val);
+  };
+
+  float par[nPar5D5DegInteraction]{20};
+  for (int iter = 0; iter < 5; ++iter) {
+
+    // draw random parameters
+    for (int i = 1; i < nPar5D5DegInteraction; ++i) {
+      par[i] = genRand();
+    }
+
+    polCT.setParams(par);
+
+    // define number of axiliary points which will be used for the fitting
+    const unsigned int nAux = 4;
+    const std::vector<unsigned int> nAxiliaryPoints(nDim, nAux);
+
+    // perform the fitting of the picewise polynomials
+    piecewisePol.performFits(refFunc, nAxiliaryPoints.data());
+
+    // compare evaluated polynomials
+    for (float a = 0; a < 1; a += 0.2f) {
+      for (float b = 0; b < 1; b += 0.2f) {
+        for (float c = 0; c < 1; c += 0.2f) {
+          for (float d = 0; d < 1; d += 0.2f) {
+            for (float e = 0; e < 1; e += 0.2f) {
+              const float arr[nDim]{a, b, c, d, e};
+              const float valCT = polCT.eval(arr);
+              const float valpiecewisePol = piecewisePol.evalUnsafe(arr);
+              if (std::abs(valCT) < 0.1) {
+                BOOST_CHECK_SMALL(valCT - valpiecewisePol, 0.01f);
+              } else {
+                BOOST_CHECK_CLOSE(valpiecewisePol, valCT, 0.5);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // check for safe evaluation outside of the grid at lower boundary
+    for (float a = xMin[0] - 10; a <= xMin[0]; a += 2.f) {
+      for (float b = xMin[1] - 10; b <= xMin[1]; b += 2.f) {
+        for (float c = xMin[2] - 10; c <= xMin[2]; c += 2.f) {
+          for (float d = xMin[3] - 10; d <= xMin[3]; d += 2.f) {
+            for (float e = xMin[4] - 10; e <= xMin[4]; e += 2.f) {
+              float arr[nDim]{a, b, c, d, e};
+              const float valUnsafeLow = piecewisePol.evalUnsafe(xMin.data());
+              const float valSafeLow = piecewisePol.eval(arr);
+              if (std::abs(valUnsafeLow) < 0.1) {
+                BOOST_CHECK_SMALL(valSafeLow - valUnsafeLow, 0.0001f);
+              } else {
+                BOOST_CHECK_CLOSE(valSafeLow, valUnsafeLow, 0.001);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // check for safe evaluation outside of the grid at upper boundary
+    const std::vector<int> indexHigh(nDim, nAux - 2);
+    for (float a = xMax[0]; a <= xMax[0] + 10; a += 2.f) {
+      for (float b = xMax[1]; b <= xMax[1] + 10; b += 2.f) {
+        for (float c = xMax[2]; c <= xMax[2] + 10; c += 2.f) {
+          for (float d = xMax[3]; d <= xMax[3] + 10; d += 2.f) {
+            for (float e = xMax[4]; e <= xMax[4] + 10; e += 2.f) {
+              float arr[nDim]{a, b, c, d, e};
+              const float valUnsafeHigh = piecewisePol.evalPol(xMax.data(), indexHigh.data());
+              const float valSafeHigh = piecewisePol.eval(arr);
+              if (std::abs(valUnsafeHigh) < 0.1) {
+                BOOST_CHECK_SMALL(valSafeHigh - valUnsafeHigh, 0.0001f);
+              } else {
+                BOOST_CHECK_CLOSE(valSafeHigh, valUnsafeHigh, 0.001);
+              }
             }
           }
         }


### PR DESCRIPTION
nD piecewise polynomials can be used in a similar way to nD splines, except that the polynomials are not guaranteed to be smooth at the edges.
The main advantage compared to splines is that there is not such a large drop in performance when higher dimensions are used.

- Adding test for picewise polynomials

other changes
MultivariatePolynomial:
- adding fit functionality for runtime polynomials
- adding interaction_only feature (see:
https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.PolynomialFeatures.html)
- adding test case for interaction only
- make runtime polynomials CPU only (for GPU use compile time version)