### PR TITLE
Disable RDH packet jumps check at start of TF in ITS/MFT decoder

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/GBTLink.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/GBTLink.h
@@ -212,9 +212,7 @@ GBTLink::CollectedDataStatus GBTLink::collectROFCableData(const Mapping& chmap)
       if (verbosity >= VerboseHeaders) {
         RDHUtils::printRDH(rdh);
       }
-      GBTLINK_DECODE_ERRORCHECK(errRes, checkErrorsRDH(*rdh));     // make sure we are dealing with RDH
-      GBTLINK_DECODE_ERRORCHECK(errRes, checkErrorsRDHStop(*rdh)); // if new HB starts, the lastRDH must have stop
-      //      GBTLINK_DECODE_ERRORCHECK(checkErrorsRDHStopPageEmpty(*rdh)); // end of HBF should be an empty page with stop
+      GBTLINK_DECODE_ERRORCHECK(errRes, checkErrorsRDH(*rdh)); // make sure we are dealing with RDH
       hbfEntry = hbfEntrySav; // critical check of RDH passed
       lastRDH = rdh;
       statistics.nPackets++;
@@ -222,6 +220,8 @@ GBTLink::CollectedDataStatus GBTLink::collectROFCableData(const Mapping& chmap)
         irHBF = RDHUtils::getHeartBeatIR(*rdh);
         hbfEntry = rawData.currentPieceID();
       }
+      GBTLINK_DECODE_ERRORCHECK(errRes, checkErrorsRDHStop(*rdh)); // if new HB starts, the lastRDH must have stop
+      //      GBTLINK_DECODE_ERRORCHECK(checkErrorsRDHStopPageEmpty(*rdh)); // end of HBF should be an empty page with stop
       dataOffset += sizeof(RDH);
       auto psz = RDHUtils::getMemorySize(*rdh);
       if (psz == sizeof(RDH)) {

--- a/Detectors/ITSMFT/common/reconstruction/src/GBTLink.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/GBTLink.cxx
@@ -56,6 +56,7 @@ void GBTLink::clear(bool resetStat, bool resetTFRaw)
   nTriggers = 0;
   lanes = 0;
   lanesActive = lanesStop = lanesTimeOut = lanesWithData = 0;
+  packetCounter = -1;
   errorBits = 0;
   irHBF.clear();
   if (resetTFRaw) {
@@ -159,6 +160,9 @@ uint8_t GBTLink::checkErrorsRDH(const RDH& rdh)
     return err;
   }
   if ((RDHUtils::getPacketCounter(rdh) > packetCounter + 1) && packetCounter >= 0) {
+    if (irHBF.isDummy()) {
+      irHBF = RDHUtils::getHeartBeatIR(rdh);
+    }
     statistics.errorCounts[GBTLinkDecodingStat::ErrPacketCounterJump]++;
     if (needToPrintError(statistics.errorCounts[GBTLinkDecodingStat::ErrPacketCounterJump])) {
       LOG(important) << describe() << ' ' << irHBF << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrPacketCounterJump]


### PR DESCRIPTION
As this check makes no sense if TFs are not contiguous, i.e. on EPN

@nicolovalle 