### PR TITLE
MCH: CRU page reader: assemble full TFs from available links

### DIFF
--- a/Detectors/MUON/MCH/Workflow/src/cru-page-reader-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/cru-page-reader-workflow.cxx
@@ -320,7 +320,8 @@ class FileReaderTask
     }
 
     if (mPrint) {
-      std::cout << "Sending TF" << std::endl << std::endl;
+      std::cout << "Sending TF" << std::endl
+                << std::endl;
     }
     auto freefct = [](void* data, void* /*hint*/) { free(data); };
     pc.outputs().adoptChunk(Output{"RDT", "RAWDATA"}, outBuf, outSize, freefct, nullptr);


### PR DESCRIPTION
Previously the code was sending sub-TFs for each CRU link.
Now it groups together the sub-TFs from all the CRU links that are present in the input data.