### PR TITLE
TRD charge handling in tracklets

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawDataStats.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawDataStats.h
@@ -71,7 +71,11 @@ enum ParsingErrors { TRDParsingNoError,
                      TRDParsingDigitHeaderWrong4,                              // expected header word but have no idea what we are looking at default of switch statement
                      TRDParsingDigitDataStillOnLink,                           // got to the end of digit parsing and there is still data on link, normally not advancing far enough when dumping data.
                      TRDParsingTrackletIgnoringDataTillEndMarker,              // for some reason we are bouncing to the end word by word, this counts those words
-                     TRDLastParsingError                                       // here as place holder for trivial sizing of structures.
+                     TRDParsingGarbageDataAtEndOfHalfCRU,                      // if the first word of the halfcru is wrong i.e. side, eventype, the half cru header is so wrong its not corrupt, its other garbage
+                     TRDParsingHalfCRUSumLength,                               // if the HalfCRU headers summed lengths wont fit into the buffer, implies corruption, its a faster check than the next one.
+
+                     TRDParsingHalfCRUCorrupt, // if the HalfCRU headers has values out of range, corruption is assumed.
+                     TRDLastParsingError       // here as place holder for trivial sizing of structures.
 };
 
 extern std::vector<std::string> ParsingErrorsString;

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Tracklet64.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Tracklet64.h
@@ -93,9 +93,41 @@ class Tracklet64
   GPUd() int getPosition() const { return ((mtrackletWord & posmask) >> posbs); };         // in units of 1/40 pads, 11 bit granularity
   GPUd() int getSlope() const { return ((mtrackletWord & slopemask) >> slopebs); };        // in units of 1/1000 pads/timebin, 8 bit granularity
   GPUd() int getPID() const { return ((mtrackletWord & PIDmask)); };                       // no unit, all 3 charge windows combined
-  GPUd() int getQ0() const { return ((mtrackletWord & Q0mask) >> Q0bs); };                 // no unit
-  GPUd() int getQ1() const { return ((mtrackletWord & Q1mask) >> Q1bs); };                 // no unit
-  GPUd() int getQ2() const { return ((mtrackletWord & Q2mask) >> Q2bs); };                 // no unit
+  GPUd() int getDynamicCharge(unsigned int charge) const
+  {
+    int shift = (charge >> 6) & 0x3;
+    if (shift == 0) {
+      shift = 8;
+    } else {
+      shift = shift << 1;
+    }
+    charge = charge << shift;
+    return charge;
+  }; // no unit
+  GPUd() int getQ0() const
+  {
+    if ((getFormat() & 0x1) == 0) {
+      return ((mtrackletWord & Q0mask) >> Q0bs);
+    } else {
+      return getDynamicCharge((mtrackletWord & Q0mask) >> Q0bs);
+    }
+  }; // no unit
+  GPUd() int getQ1() const
+  {
+    if ((getFormat() & 0x1) == 0) {
+      return ((mtrackletWord & Q1mask) >> Q1bs);
+    } else {
+      return getDynamicCharge((mtrackletWord & Q1mask) >> Q1bs);
+    }
+  }; // no unit
+  GPUd() int getQ2() const
+  {
+    if ((getFormat() & 0x1) == 0) {
+      return ((mtrackletWord & Q2mask) >> Q2bs);
+    } else {
+      return getDynamicCharge((mtrackletWord & Q2mask) >> Q2bs);
+    }
+  }; // no unit
 
   GPUd() void setTrackletWord(uint64_t trackletword) { mtrackletWord = trackletword; }
 
@@ -177,7 +209,7 @@ class Tracklet64
  protected:
   uint64_t mtrackletWord; // the 64 bit word holding all the tracklet information for run3.
  private:
-  ClassDefNV(Tracklet64, 1);
+  ClassDefNV(Tracklet64, 2);
 };
 
 GPUdi() int Tracklet64::getPositionBinSigned() const

--- a/Detectors/TRD/base/test/testRawData.cxx
+++ b/Detectors/TRD/base/test/testRawData.cxx
@@ -59,20 +59,20 @@ BOOST_AUTO_TEST_CASE(TRDRawDataHeaderInternals)
   BOOST_CHECK_EQUAL(halfcruheader.errorflags[1].errorflag, 0xa);
   halfcruheader.word12[1] = 0x00ed000000000000; // should link 14 error flags.
   BOOST_CHECK_EQUAL(halfcruheader.errorflags[14].errorflag, 0xed);
-  BOOST_CHECK_EQUAL(halfcruheader.errorflags[14].errorflag, o2::trd::getlinkerrorflag(halfcruheader, 14));
+  BOOST_CHECK_EQUAL(halfcruheader.errorflags[14].errorflag, o2::trd::getHalfCRULinkErrorFlag(halfcruheader, 14));
   //datasizes
   halfcruheader.word47[0] = 0xbdbd;
   BOOST_CHECK_EQUAL(halfcruheader.datasizes[0].size, 0xbdbd);
-  BOOST_CHECK_EQUAL(halfcruheader.datasizes[0].size, o2::trd::getlinkdatasize(halfcruheader, 0));
+  BOOST_CHECK_EQUAL(halfcruheader.datasizes[0].size, o2::trd::getHalfCRULinkDataSize(halfcruheader, 0));
   halfcruheader.word47[1] = 0xabcd;
   BOOST_CHECK_EQUAL(halfcruheader.datasizes[4].size, 0xabcd);
-  BOOST_CHECK_EQUAL(halfcruheader.datasizes[4].size, o2::trd::getlinkdatasize(halfcruheader, 4));
+  BOOST_CHECK_EQUAL(halfcruheader.datasizes[4].size, o2::trd::getHalfCRULinkDataSize(halfcruheader, 4));
   halfcruheader.word47[2] = 0xaaade127;
   BOOST_CHECK_EQUAL(halfcruheader.datasizes[8].size, 0xe127);
-  BOOST_CHECK_EQUAL(halfcruheader.datasizes[8].size, o2::trd::getlinkdatasize(halfcruheader, 8));
+  BOOST_CHECK_EQUAL(halfcruheader.datasizes[8].size, o2::trd::getHalfCRULinkDataSize(halfcruheader, 8));
   halfcruheader.word47[3] = 0xefaadebc0000;
   BOOST_CHECK_EQUAL(halfcruheader.datasizes[14].size, 0xefaa);
-  BOOST_CHECK_EQUAL(halfcruheader.datasizes[14].size, o2::trd::getlinkdatasize(halfcruheader, 14));
+  BOOST_CHECK_EQUAL(halfcruheader.datasizes[14].size, o2::trd::getHalfCRULinkDataSize(halfcruheader, 14));
   o2::trd::TrackletMCMHeader mcmrawdataheader;
   mcmrawdataheader.word = 0x78000000;
   BOOST_CHECK_EQUAL(mcmrawdataheader.padrow, 15);

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
@@ -162,9 +162,8 @@ class CruRawReader
 
  protected:
   bool processHBFs(int datasizealreadyread = 0, bool verbose = false);
-  bool processHBFsa(int datasizealreadyread = 0, bool verbose = false);
   bool buildCRUPayLoad();
-  int processHalfCRU(int cruhbfstartoffset);
+  int processHalfCRU(int cruhbfstartoffset, int numberOfPreviousCRU);
   bool processCRULink();
   int parseDigitHCHeader();
   int checkDigitHCHeader();
@@ -176,6 +175,9 @@ class CruRawReader
     if (mRootOutput) {
       mParsingErrors->Fill(hist);
       ((TH2F*)mParsingErrors2d->At(hist))->Fill(sectorside, stack * constants::NLAYER + layer);
+    }
+    if (mDataVerbose) {
+      LOG(info) << "Parsing error: " << hist << " sectorside:" << sectorside << " stack:" << stack << " layer:" << layer;
     }
   }
   void dumpRDHAndNextHeader(const o2::header::RDHAny* rdh);
@@ -233,6 +235,7 @@ class CruRawReader
 
   const o2::header::RDHAny* mDataRDH;
   HalfCRUHeader mCurrentHalfCRUHeader; // are we waiting for new header or currently parsing the payload of on
+  HalfCRUHeader mPreviousHalfCRUHeader; // are we waiting for new header or currently parsing the payload of on
   DigitHCHeader mDigitHCHeader;        // Digit HalfChamber header we are currently on.
   DigitHCHeader1 mDigitHCHeader1;      // this and the next 2 are option are and variable in order, hence
   DigitHCHeader2 mDigitHCHeader2;      // the individual seperation instead of an array.

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/TrackletsParser.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/TrackletsParser.h
@@ -89,9 +89,9 @@ class TrackletsParser
   std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>* mData;
   std::vector<Tracklet64> mTracklets;
   // pointers to keep track of the currently parsing headers and data.
-  TrackletHCHeader* mTrackletHCHeader;
+  TrackletHCHeader mTrackletHCHeader;
   TrackletMCMHeader* mTrackletMCMHeader;
-  TrackletMCMData* mTrackletMCMData;
+  std::array<TrackletMCMData, 3> mTrackletMCMData;
 
   int mState;               // state that the parser is currently in.
   int mWordsRead{0};        // number of words read from buffer

--- a/Detectors/TRD/reconstruction/macros/checkTrackletCharges.C
+++ b/Detectors/TRD/reconstruction/macros/checkTrackletCharges.C
@@ -1,0 +1,117 @@
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+// ROOT header
+#include <TROOT.h>
+#include <TChain.h>
+#include <TH2.h>
+#include <TF1.h>
+#include <TCanvas.h>
+#include <TStyle.h>
+#include <TProfile.h>
+#include <TFile.h>
+#include <TTree.h>
+#include <TAxis.h>
+#include <TLine.h>
+// O2 header
+#include "DataFormatsTRD/TriggerRecord.h"
+#include "DataFormatsTRD/Digit.h"
+#include "DataFormatsTRD/Tracklet64.h"
+#include "DataFormatsTRD/Constants.h"
+#endif
+
+using namespace o2::trd;
+
+std::vector<TH1F*> createTrdChargeHists()
+{
+  std::vector<TH1F*> hCharges;
+  hCharges.push_back(new TH1F("Charge0", "Charge window 0;charge;counts", 64, 0, 63));
+  hCharges.push_back(new TH1F("Charge1", "Charge window 1;charge;counts", 256, 0, 255));
+  hCharges.push_back(new TH1F("Charge2", "Charge window 2;charge;counts", 256, 0, 255));
+  return hCharges;
+}
+
+void checkTrackletCharges(int sector = -1)
+{
+  TChain chain("o2sim");
+  chain.AddFile("trdtracklets.root");
+  std::vector<TriggerRecord> trigIn, *trigInPtr{&trigIn};
+  std::vector<Tracklet64> tracklets, *trackletsInPtr{&tracklets};
+  chain.SetBranchAddress("TrackTrg", &trigInPtr);
+  chain.SetBranchAddress("Tracklet", &trackletsInPtr);
+
+  //auto fOut = new TFile("trackletsOutput.root", "recreate");
+  auto hDet = new TH1F("det", "Detector number for tracklet;detector;counts", 540, -0.5, 539.5);
+  auto hTrigger = new TH1F("trigger", "Number of TRD triggers per TF;# trigger;counts", 200, 0, 200);
+  auto hPosition = new TH1F("position", "Tracklet position uncalibrated;position;counts", 120, -60, 60);
+  auto hSlope = new TH1F("slope", "Tracklet slope uncalibrated;slope;counts", 200, -2, 2);
+
+  auto hNTracklets = new TH1F("nTracklets", "Number of tracklets for triggers with digits;nTracklets;counts", 100, 0, 1000);
+
+  auto hCharges = createTrdChargeHists();
+
+  int countEntries = 0;
+  int countTrigger = 0;
+  int nTriggerWithDigits = 0;
+
+  for (int iEntry = 0; iEntry < chain.GetEntries(); ++iEntry) {
+    chain.GetEntry(iEntry); // for each TimeFrame there is one tree entry
+    ++countEntries;
+    countTrigger += trigIn.size();
+    hTrigger->Fill(trigIn.size());
+    for (const auto& tracklet : tracklets) {
+      int det = tracklet.getHCID() / 2;
+      int side = tracklet.getHCID() % 2; // 0: A-side, 1: B-side
+      hDet->Fill(det);
+      int layer = det % 6;
+      int stack = (det % 30) / 6;
+      int sec = det / 30;
+      hSlope->Fill(tracklet.getUncalibratedDy());
+      hPosition->Fill(tracklet.getUncalibratedY());
+      if (sector > -1) {
+
+        if (sector == sec) {
+          if (tracklet.getQ0() > 0)
+            hCharges[0]->Fill(tracklet.getQ0());
+          if (tracklet.getQ1() > 0)
+            hCharges[1]->Fill(tracklet.getQ1());
+          if (tracklet.getQ2() > 0)
+            hCharges[2]->Fill(tracklet.getQ2());
+        }
+      } else {
+        if (tracklet.getQ0() > 0)
+          hCharges[0]->Fill(tracklet.getQ0());
+        if (tracklet.getQ1() > 0)
+          hCharges[1]->Fill(tracklet.getQ1());
+        if (tracklet.getQ2() > 0)
+          hCharges[2]->Fill(tracklet.getQ2());
+      }
+    }
+  }
+
+  //printf("Found in total %i collisions with digits\n", nTriggerWithDigits);
+  auto c = new TCanvas("c", "c", 1400, 1000);
+  auto line = new TLine();
+  c->Divide(3, 3);
+  c->cd(1);
+  hDet->Draw();
+  c->cd(2);
+  hTrigger->Draw();
+  c->cd(3);
+  hNTracklets->Draw();
+  auto pada = c->cd(4);
+  pada->SetLogy();
+  hPosition->Draw();
+  auto padb = c->cd(5);
+  padb->SetLogy();
+  hSlope->Draw();
+
+  for (int charge = 0; charge < 3; ++charge) {
+    auto pad = c->cd(charge + 7);
+    pad->SetRightMargin(0.15);
+    hCharges[charge]->Draw();
+    //pad->SetLogz();
+  }
+  c->Update();
+  c->SaveAs("tracklet-charges.png");
+
+  printf("Got in total %i trigger from %i TFs\n", countTrigger, countEntries);
+}

--- a/Detectors/TRD/reconstruction/src/DataReaderTask.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReaderTask.cxx
@@ -49,28 +49,6 @@ void DataReaderTask::setParsingErrorLabels()
   mParsingErrors->GetXaxis()->SetBinLabel(TRDParsingDigitADCMaskAdvanceToEnd, "TRDParsingDigitADCMaskAdvanceToEnd");
   mParsingErrors->GetXaxis()->SetBinLabel(TRDParsingDigitMCMHeaderBypassButStateMCMHeader, "TRDParsingDigitMCMHeaderBypassButStateMCMHeader");
   mParsingErrors->GetXaxis()->SetBinLabel(TRDParsingDigitEndMarkerStateButReadingMCMADCData, "TRDParsingDigitEndMarkerStateButReadingMCMADCData");
-  /*                       TRDParsingDigitADCChannel21,
-                           TRDParsingDigitADCChannelGT22,
-                           TRDParsingDigitGT10ADCs,
-                           TRDParsingDigitSanityCheck,
-                           TRDParsingDigitExcessTimeBins,
-                           TRDParsingDigitParsingExitInWrongState,
-                           TRDParsingDigitStackMisMatch,
-                           TRDParsingDigitLayerMisMatch,
-                           TRDParsingDigitSectorMisMatch,
-                           TRDParsingTrackletCRUPaddingWhileParsingTracklets,
-                           TRDParsingTrackletBit11NotSetInTrackletHCHeader,
-                           TRDParsingTrackletHCHeaderSanityCheckFailure,
-                           TRDParsingTrackletMCMHeaderSanityCheckFailure,
-                           TRDParsingTrackletMCMHeaderButParsingMCMData,
-                           TRDParsingTrackletStateMCMHeaderButParsingMCMData,
-                           TRDParsingTrackletTrackletCountGTThatDeclaredInMCMHeader,
-                           TRDParsingTrackletInvalidTrackletCount,
-                           TRDParsingTrackletPadRowIncreaseError,
-                           TRDParsingTrackletColIncreaseError,
-                           TRDParsingTrackletNoTrackletEndMarker,
-                           TRDParsingTrackletExitingNoTrackletEndMarker
-                           */
 }
 
 void DataReaderTask::buildHistograms()

--- a/Detectors/TRD/reconstruction/src/DigitsParser.cxx
+++ b/Detectors/TRD/reconstruction/src/DigitsParser.cxx
@@ -157,7 +157,7 @@ int DigitsParser::Parse(bool verbose)
         if (mHeaderVerbose) {
           printDigitMCMHeader(*mDigitMCMHeader);
         }
-        if (!digitMCMHeaderSanityCheck(mDigitMCMHeader)) {
+        if (!sanityCheckDigitMCMHeader(mDigitMCMHeader)) {
           incParsingError(TRDParsingDigitMCMHeaderSanityCheckFailure);
           // we dump the remainig data pending better options.
           // we can try a 16 bit bitshift...
@@ -203,7 +203,7 @@ int DigitsParser::Parse(bool verbose)
           std::bitset<21> adcmask(mADCMask);
           bitsinmask = adcmask.count();
           //check ADCMask:
-          if (!digitMCMADCMaskSanityCheck(*mDigitMCMADCMask, bitsinmask)) {
+          if (!sanityCheckDigitMCMADCMask(*mDigitMCMADCMask, bitsinmask)) {
             incParsingError(TRDParsingDigitADCMaskMismatch);
             mWordsDumped += std::distance(word, mEndParse) - 1;
             word = mEndParse;
@@ -281,7 +281,8 @@ int DigitsParser::Parse(bool verbose)
               //new adc expected so set channel accord to bitpattern or sequential depending on zero suppressed or not.
               if (mDigitHCHeader.major & 0x20) { // zero suppressed
                 //zero suppressed, so channel must be extracted from next available bit in adcmask
-                mCurrentADCChannel = nextmcmadc(mADCMask, mCurrentADCChannel);
+                mCurrentADCChannel = getNextMCMADCfromBP(mADCMask, mCurrentADCChannel);
+
                 if (mCurrentADCChannel == 21) {
                   incParsingError(TRDParsingDigitADCChannel21);
                 }
@@ -313,7 +314,7 @@ int DigitsParser::Parse(bool verbose)
             mDataWordsParsed++;
             mcmdatacount++;
             // digit sanity check
-            if (!digitMCMWordSanityCheck(mDigitMCMData, mCurrentADCChannel)) {
+            if (!sanityCheckDigitMCMWord(mDigitMCMData, mCurrentADCChannel)) {
               incParsingError(TRDParsingDigitSanityCheck);
               mWordsDumped++;
               mDataWordsParsed--; // we incremented it above the if loop so now transfer the count to dumped instead of parsed;

--- a/cmake/O2RootMacroExclusionList.cmake
+++ b/cmake/O2RootMacroExclusionList.cmake
@@ -31,6 +31,7 @@ list(APPEND O2_ROOT_MACRO_EXCLUSION_LIST
             Detectors/TRD/base/macros/TestTrapSim.C
             Detectors/TRD/macros/convertRun2ToRun3Digits.C
             Detectors/TRD/simulation/macros/CheckTRDFST.C
+            Detectors/TRD/reconstruction/macros/checkTrackletCharges.C
             Detectors/gconfig/g4Config.C
             Detectors/TRD/macros/ParseTrapRawOutput.C
             Detectors/EMCAL/calib/macros/ReadTestBadChannelMap_CCDBApi.C


### PR DESCRIPTION
- fix charge handling for all charge formats in the tracklets.
- this include the dynamic range one that seems to be present in current data.
- better identification of garbage at end of link data as opposed to simply assuming its default halfcruheader.
- macro toviw charge windows per sector.
- macro to view tracklets (option to view only 1 sector)
- merged some code from new raw reader, as it evident by the rather large changes to rawdata.cxx.

This was tested on 517134, the old krypton data, the noise data 514419, will check some more runs tomorrow.