### PR TITLE
mch-reco-workflow stores cluster if root output is enabled

### DIFF
--- a/Detectors/MUON/MCH/Workflow/src/ClusterReaderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/ClusterReaderSpec.cxx
@@ -44,7 +44,11 @@ struct ClusterReader {
     auto fileName = ic.options().get<std::string>("infile");
     auto nofEntries{-1};
     auto clusterDescription = mGlobal ? header::DataDescription{"GLOBALCLUSTERS"} : header::DataDescription{"CLUSTERS"};
-
+    if (mUseMC) {
+      // not clear where the MClabels come from
+      LOG(warn) << "Disabling clusters MC labels reading";
+      mUseMC = false;
+    }
     if (mUseMC) {
       if (mDigits) {
         mTreeReader = std::make_unique<RootTreeReader>(

--- a/Detectors/MUON/MCH/Workflow/src/reco-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/reco-workflow.cxx
@@ -25,6 +25,7 @@
 #include "MCHWorkflow/ClusterFinderOriginalSpec.h"
 #include "MCHWorkflow/PreClusterFinderSpec.h"
 #include "MCHWorkflow/TrackWriterSpec.h"
+#include "MCHWorkflow/ClusterWriterSpec.h"
 #include "TrackFinderSpec.h"
 #include "TrackFitterSpec.h"
 #include "TrackMCLabelFinderSpec.h"
@@ -105,6 +106,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 
   if (!disableRootOutput) {
     specs.emplace_back(o2::mch::getTrackWriterSpec(useMC, "mch-track-writer", "mchtracks.root", digits));
+    specs.emplace_back(o2::mch::getClusterWriterSpec(false, "mch-global-cluster-writer", true, digits)); // RS cannot find who produces MCH/CLUSTERLABELS/0
   }
 
   // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit


### PR DESCRIPTION
Hi @aphecetche 
All detector reco workflows are storing their cluster trees unless `--disable-root-output` is passed. So, adding the global-cluster-writer to the mch-reco-workflow. 
But I did not find who can produce `MCH/CLUSTERLABELS/0` output, therefore at the moment disabled the writing and reading of cluster MClabels. Could you clarify how the cluster labels should be produced?