### PR TITLE
TRD DCS calib objects use adjustable EOV

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/DcsCcdbObjects.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/DcsCcdbObjects.h
@@ -26,15 +26,17 @@ namespace trd
 {
 
 struct TRDDCSMinMaxMeanInfo {
+  uint64_t firstTS{0};  // time stamp of the first point added
+  uint64_t lastTS{0};   // time stamp of the last point added
   float minValue{0.f};  // min value seen by the TRD DCS processor
   float maxValue{0.f};  // max value seen by the TRD DCS processor
   float meanValue{0.f}; // mean value seen by the TRD DCS processor
   int nPoints{0};       // number of values seen by the TRD DCS processor
 
   void print() const;
-  void addPoint(float value);
+  void addPoint(float value, uint64_t ts);
 
-  ClassDefNV(TRDDCSMinMaxMeanInfo, 1);
+  ClassDefNV(TRDDCSMinMaxMeanInfo, 2);
 };
 
 } // namespace trd

--- a/DataFormats/Detectors/TRD/src/DcsCcdbObjects.cxx
+++ b/DataFormats/Detectors/TRD/src/DcsCcdbObjects.cxx
@@ -15,20 +15,32 @@
 
 #include "DataFormatsTRD/DcsCcdbObjects.h"
 #include <fairlogger/Logger.h>
+#include <string>
 
 using namespace o2::trd;
 
 void TRDDCSMinMaxMeanInfo::print() const
 {
+  std::time_t tStart = firstTS / 1e3;
+  std::string tStartStr = std::asctime(std::localtime(&tStart));
+  tStartStr.erase(tStartStr.length() - 1); // remove '\n', since it is added by FairLogger anyways
+  std::time_t tEnd = lastTS / 1e3;
+  std::string tEndStr = std::asctime(std::localtime(&tEnd));
+  tEndStr.erase(tEndStr.length() - 1);
+  LOG(info) << "Raw time interval from " << firstTS << " to " << lastTS << ". In local time:";
+  LOG(info) << tStartStr;
+  LOG(info) << tEndStr;
   LOG(info) << "Min value: " << minValue;
   LOG(info) << "Max value: " << maxValue;
   LOG(info) << "Mean value: " << meanValue;
   LOG(info) << "Number of points added: " << nPoints;
 }
 
-void TRDDCSMinMaxMeanInfo::addPoint(float value)
+void TRDDCSMinMaxMeanInfo::addPoint(float value, uint64_t ts)
 {
   if (nPoints == 0) {
+    firstTS = ts;
+    lastTS = ts;
     minValue = value;
     maxValue = value;
     meanValue = value;
@@ -38,6 +50,13 @@ void TRDDCSMinMaxMeanInfo::addPoint(float value)
     }
     if (value > maxValue) {
       maxValue = value;
+    }
+    // I am not sure whether the DPs arrive always ordered in time
+    if (ts > lastTS) {
+      lastTS = ts;
+    }
+    if (ts < firstTS) {
+      firstTS = ts;
     }
     meanValue += (value - meanValue) / (nPoints + 1);
   }

--- a/Detectors/TRD/calibration/README.md
+++ b/Detectors/TRD/calibration/README.md
@@ -24,3 +24,5 @@ So, in order to test the workflow independent of the actual CCDB using a local i
 
     root $O2_ROOT/share/macro/makeTRDCCDBEntryForDCS.C+
     o2-calibration-trd-dcs-sim-workflow -b --delta-fraction 0.5 --max-timeframes 10 | o2-calibration-trd-dcs-workflow -b --ccdb-path http://localhost:8080 --use-ccdb-to-configure --processor-verbosity 1 | o2-calibration-ccdb-populator-workflow -b --ccdb-path http://localhost:8080
+
+The macro `readTRDDCSentries.C` shows an example how to read one of the created CCDB objects after processing.

--- a/Detectors/TRD/calibration/macros/makeTRDCCDBEntryForDCS.C
+++ b/Detectors/TRD/calibration/macros/makeTRDCCDBEntryForDCS.C
@@ -58,7 +58,7 @@ int makeTRDCCDBEntryForDCS(const std::string url = "http://localhost:8080")
   api.init(url);
   std::map<std::string, std::string> md;
   long ts = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-  api.storeAsTFileAny(&dpid2DataDesc, "TRD/Config/DCSDPconfig", md, ts);
+  api.storeAsTFileAny(&dpid2DataDesc, "TRD/Config/DCSDPconfig", md, ts, ts + 10 * o2::ccdb::CcdbObjectInfo::YEAR);
 
   return 0;
 }

--- a/Detectors/TRD/calibration/macros/readTRDDCSentries.C
+++ b/Detectors/TRD/calibration/macros/readTRDDCSentries.C
@@ -24,11 +24,11 @@
 #include <bitset>
 #endif
 
-void readTRDDCSentries(std::string ccdb = "http://ccdb-test.cern.ch:8080", long ts = -1)
+void readTRDDCSentries(std::string ccdb = "http://localhost:8080", long ts = -1)
 {
 
   auto& ccdbmgr = o2::ccdb::BasicCCDBManager::instance();
-  ccdbmgr.setURL(ccdb.c_str());
+  ccdbmgr.setURL(ccdb.c_str()); // comment out this line to read from production CCDB instead of a local one, or adapt ccdb string
   if (ts < 0) {
     ts = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
   }
@@ -44,7 +44,7 @@ void readTRDDCSentries(std::string ccdb = "http://ccdb-test.cern.ch:8080", long 
   std::cout << std::endl;
 
   // now, access the actual calibration object from CCDB
-  auto cal = ccdbmgr.get<unordered_map<o2::dcs::DataPointIdentifier, o2::trd::TRDDCSMinMaxMeanInfo>>("TRD/Calib/DCSDPs");
+  auto cal = ccdbmgr.get<unordered_map<o2::dcs::DataPointIdentifier, o2::trd::TRDDCSMinMaxMeanInfo>>("TRD/Calib/DCSDPsGas");
 
   std::cout << "Printing a single object from the map (trd_gasCO2):" << std::endl;
   o2::dcs::DataPointIdentifier dpid; // used as key to access the map

--- a/Detectors/TRD/calibration/src/DCSProcessor.cxx
+++ b/Detectors/TRD/calibration/src/DCSProcessor.cxx
@@ -108,7 +108,7 @@ int DCSProcessor::processDP(const DPCOM& dpcom)
         auto& dpInfoGas = mTRDDCSGas[dpid];
         if (dpInfoGas.nPoints == 0 || etime != mLastDPTimeStamps[dpid]) {
           // only add data point in case it was not already read before
-          dpInfoGas.addPoint(o2::dcs::getValue<double>(dpcom));
+          dpInfoGas.addPoint(o2::dcs::getValue<double>(dpcom), etime);
           mLastDPTimeStamps[dpid] = etime;
         }
       }
@@ -122,7 +122,7 @@ int DCSProcessor::processDP(const DPCOM& dpcom)
         auto& dpInfoCurrents = mTRDDCSCurrents[dpid];
         if (dpInfoCurrents.nPoints == 0 || etime != mLastDPTimeStamps[dpid]) {
           // only add data point in case it was not already read before
-          dpInfoCurrents.addPoint(o2::dcs::getValue<double>(dpcom));
+          dpInfoCurrents.addPoint(o2::dcs::getValue<double>(dpcom), etime);
           mLastDPTimeStamps[dpid] = etime;
         }
       }
@@ -159,7 +159,7 @@ int DCSProcessor::processDP(const DPCOM& dpcom)
         auto& dpInfoEnv = mTRDDCSEnv[dpid];
         if (dpInfoEnv.nPoints == 0 || etime != mLastDPTimeStamps[dpid]) {
           // only add data point in case it was not already read before
-          dpInfoEnv.addPoint(o2::dcs::getValue<double>(dpcom));
+          dpInfoEnv.addPoint(o2::dcs::getValue<double>(dpcom), etime);
           mLastDPTimeStamps[dpid] = etime;
         }
       }
@@ -301,7 +301,7 @@ bool DCSProcessor::updateGasDPsCCDB()
   }
   std::map<std::string, std::string> md;
   md["responsible"] = "Ole Schmidt";
-  o2::calibration::Utils::prepareCCDBobjectInfo(mTRDDCSGas, mCcdbGasDPsInfo, "TRD/Calib/DCSDPsGas", md, mGasStartTS, mCurrentTS);
+  o2::calibration::Utils::prepareCCDBobjectInfo(mTRDDCSGas, mCcdbGasDPsInfo, "TRD/Calib/DCSDPsGas", md, mGasStartTS, mGasStartTS + 3 * o2::ccdb::CcdbObjectInfo::DAY);
 
   return retVal;
 }
@@ -329,7 +329,7 @@ bool DCSProcessor::updateCurrentsDPsCCDB()
   }
   std::map<std::string, std::string> md;
   md["responsible"] = "Ole Schmidt";
-  o2::calibration::Utils::prepareCCDBobjectInfo(mTRDDCSCurrents, mCcdbCurrentsDPsInfo, "TRD/Calib/DCSDPsI", md, mCurrentsStartTS, mCurrentTS);
+  o2::calibration::Utils::prepareCCDBobjectInfo(mTRDDCSCurrents, mCcdbCurrentsDPsInfo, "TRD/Calib/DCSDPsI", md, mCurrentsStartTS, mCurrentsStartTS + 3 * o2::ccdb::CcdbObjectInfo::DAY);
 
   return retVal;
 }
@@ -356,7 +356,7 @@ bool DCSProcessor::updateVoltagesDPsCCDB()
   }
   std::map<std::string, std::string> md;
   md["responsible"] = "Ole Schmidt";
-  o2::calibration::Utils::prepareCCDBobjectInfo(mTRDDCSVoltages, mCcdbVoltagesDPsInfo, "TRD/Calib/DCSDPsU", md, mVoltagesStartTS, mCurrentTS);
+  o2::calibration::Utils::prepareCCDBobjectInfo(mTRDDCSVoltages, mCcdbVoltagesDPsInfo, "TRD/Calib/DCSDPsU", md, mVoltagesStartTS, mVoltagesStartTS + 7 * o2::ccdb::CcdbObjectInfo::DAY);
 
   return retVal;
 }
@@ -384,7 +384,7 @@ bool DCSProcessor::updateEnvDPsCCDB()
   }
   std::map<std::string, std::string> md;
   md["responsible"] = "Ole Schmidt";
-  o2::calibration::Utils::prepareCCDBobjectInfo(mTRDDCSEnv, mCcdbEnvDPsInfo, "TRD/Calib/DCSDPsEnv", md, mEnvStartTS, mCurrentTS);
+  o2::calibration::Utils::prepareCCDBobjectInfo(mTRDDCSEnv, mCcdbEnvDPsInfo, "TRD/Calib/DCSDPsEnv", md, mEnvStartTS, mEnvStartTS + 3 * o2::ccdb::CcdbObjectInfo::DAY);
 
   return retVal;
 }

--- a/Detectors/TRD/calibration/workflow/TRDDCSDataProcessorSpec.h
+++ b/Detectors/TRD/calibration/workflow/TRDDCSDataProcessorSpec.h
@@ -134,11 +134,10 @@ class TRDDCSDataProcessor : public o2::framework::Task
     auto dps = pc.inputs().get<gsl::span<DPCOM>>("input");
     auto timeNow = std::chrono::high_resolution_clock::now();
     if (currentTimeStamp < 1577833200000UL || currentTimeStamp > 2208985200000UL) {
-      LOG(error) << "The creation time of this TF is set to " << currentTimeStamp << ". Overwriting this with current time";
+      LOG(warning) << "The creation time of this TF is set to " << currentTimeStamp << ". Overwriting this with current time";
       // in case it is not set
       currentTimeStamp = std::chrono::duration_cast<std::chrono::milliseconds>(timeNow.time_since_epoch()).count(); // in ms
     }
-    LOG(warning) << "Setting current time stamp: " << currentTimeStamp; // TODO REMOVE BEFORE MERGING
     mProcessor->setCurrentTS(currentTimeStamp);
     mProcessor->process(dps);
 

--- a/Detectors/TRD/calibration/workflow/trd-dcs-sim-workflow.cxx
+++ b/Detectors/TRD/calibration/workflow/trd-dcs-sim-workflow.cxx
@@ -27,9 +27,9 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
 
   // HV parameters
   dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"trd_hvAnodeImon[00..539]", 0, 50.});
-  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"trd_hvAnodeUmon[00..539]", 49., 50.});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"trd_hvAnodeUmon[00..539]", 1549., 1550.});
   dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"trd_hvDriftImon[00..539]", 0, 50.});
-  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"trd_hvDriftUmon[00..539]", 49., 50.});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"trd_hvDriftUmon[00..539]", 2249., 2250.});
 
   // temperatures, pressures, config and other
   // dphints.emplace_back(o2::dcs::test::DataPointHint<std::string>{"trd_fedCFGtag[00..539]", "foo", "bar"});


### PR DESCRIPTION
Values which are constantly monitored are put into CCDB objects. These objects now contain also the time stamp for the first and the last DP seen. That way the CCDB object validity can profit from the update mechanism of the CCDB populator and we should not have any holes in the CCDB even if the DCS processor is stopped for some time. We simply set the end validity to a few days in the future.