### PR TITLE
Sending to CCDB only after all DPs have been seen.

### DIFF
--- a/Detectors/TOF/calibration/include/TOFCalibration/TOFDCSProcessor.h
+++ b/Detectors/TOF/calibration/include/TOFCalibration/TOFDCSProcessor.h
@@ -115,6 +115,16 @@ class TOFDCSProcessor
     mTOFDCS.clear();
   }
 
+  bool areAllDPsFilled()
+  {
+    for (auto& it : mPids) {
+      if (!it.second) {
+        return false;
+      }
+    }
+    return true;
+  }
+
  private:
   std::unordered_map<DPID, TOFDCSinfo> mTOFDCS;                // this is the object that will go to the CCDB
   std::unordered_map<DPID, bool> mPids;                        // contains all PIDs for the processor, the bool


### PR DESCRIPTION
At end of stream, what is there is sent, even if not complete.

@noferini , @shahor02 : this follows a comment by @shahor02 concerning what happens is not all DPs are seen. 
Since the FBI is sent every 5 seconds, and TOF integrates at least over a minute (of course, via command line option one could set shorter intervals), and in real data now every 10 minutes, this situation should never happen, but here is a fix. 
At end of stream, of course, we could be in the situation that not everything is there, but here there is not much we can do. 
Another option, though, could be that we keep the previous value till the new one arrives. If this solution is better, then I will implement it that way (it came to my mind after I implemented this one).
