### PR TITLE
Account for the physics triggers embedded into the ITS/MFT raw data

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/GBTLink.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/GBTLink.h
@@ -85,6 +85,7 @@ struct GBTLink {
   CollectedDataStatus status = None;
   Format format = NewFormat;
   Verbosity verbosity = VerboseErrors;
+  std::vector<GBTTrigger>* extTrigVec = nullptr;
   uint8_t idInRU = 0;     // link ID within the RU
   uint8_t idInCRU = 0;    // link ID within the CRU
   uint8_t endPointID = 0; // endpoint ID of the CRU
@@ -192,7 +193,6 @@ struct GBTLink {
 template <class Mapping>
 GBTLink::CollectedDataStatus GBTLink::collectROFCableData(const Mapping& chmap)
 {
-  int nw = 0;
   status = None;
   auto* currRawPiece = rawData.currentPiece();
   uint8_t errRes = uint8_t(GBTLink::NoError);
@@ -265,37 +265,57 @@ GBTLink::CollectedDataStatus GBTLink::collectROFCableData(const Mapping& chmap)
     // then we expect GBT trigger word (unless we work with old format)
     const GBTTrigger* gbtTrg = nullptr;
     if (format == NewFormat) {
-      gbtTrg = reinterpret_cast<const GBTTrigger*>(&currRawPiece->data[dataOffset]); // process GBT trigger
-      dataOffset += GBTPaddedWordLength;
-      if (verbosity >= VerboseHeaders) {
-        printTrigger(gbtTrg);
+      int ntrig = 0;
+      while (dataOffset < currRawPiece->size) { // we may have multiple trigger words in case there were physics triggers
+        const GBTTrigger* gbtTrgTmp = reinterpret_cast<const GBTTrigger*>(&currRawPiece->data[dataOffset]);
+        if (gbtTrgTmp->isTriggerWord()) {
+          ntrig++;
+          dataOffset += GBTPaddedWordLength;
+          if (verbosity >= VerboseHeaders) {
+            printTrigger(gbtTrgTmp);
+          }
+          if (gbtTrgTmp->noData == 0 || gbtTrgTmp->internal) {
+            gbtTrg = gbtTrgTmp; // this is a trigger describing the following data
+          } else {
+            if (extTrigVec) { // this link collects external triggers
+              extTrigVec->push_back(*gbtTrgTmp);
+            }
+          }
+          continue;
+        }
+        auto gbtC = reinterpret_cast<const o2::itsmft::GBTCalibration*>(&currRawPiece->data[dataOffset]);
+        if (gbtC->isCalibrationWord()) {
+          if (verbosity >= VerboseHeaders) {
+            printCalibrationWord(gbtC);
+          }
+          dataOffset += GBTPaddedWordLength;
+          LOGP(debug, "SetCalibData for RU:{} at bc:{}/orb:{} : [{}/{}]", ruPtr->ruSWID, gbtTrg ? gbtTrg->bc : -1, gbtTrg ? gbtTrg->orbit : -1, gbtC->calibCounter, gbtC->calibUserField);
+          ruPtr->calibData = {gbtC->calibCounter, gbtC->calibUserField};
+          continue;
+        }
+        break;
       }
-      GBTLINK_DECODE_ERRORCHECK(errRes, checkErrorsTriggerWord(gbtTrg));
+      if (!gbtTrg) {
+        if (!ntrig) { // no ITS trigger word was seen, produce an error, but only if no external trigger was seen either
+          gbtTrg = reinterpret_cast<const GBTTrigger*>(&currRawPiece->data[dataOffset]);
+          dataOffset += GBTPaddedWordLength;
+          GBTLINK_DECODE_ERRORCHECK(errRes, checkErrorsTriggerWord(gbtTrg)); // we know there is an error, call this just to register it
+        }
+        return status; // in principle, this should not be reached
+      }
       statistics.nTriggers++;
-      if (gbtTrg->noData) { // emtpy trigger
-        return status;
-      }
       lanesStop = 0;
       lanesWithData = 0;
       ir.bc = gbtTrg->bc;
       ir.orbit = gbtTrg->orbit;
       trigger = gbtTrg->triggerType;
-    }
-    if (format == NewFormat) { // at the moment just check if calibration word is there
-      auto gbtC = reinterpret_cast<const o2::itsmft::GBTCalibration*>(&currRawPiece->data[dataOffset]);
-      if (gbtC->isCalibrationWord()) {
-        if (verbosity >= VerboseHeaders) {
-          printCalibrationWord(gbtC);
-        }
-        dataOffset += GBTPaddedWordLength;
-        LOGP(debug, "SetCalibData for RU:{} at bc:{}/orb:{} : [{}/{}]", ruPtr->ruSWID, gbtTrg->bc, gbtTrg->orbit, gbtC->calibCounter, gbtC->calibUserField);
-        ruPtr->calibData = {gbtC->calibCounter, gbtC->calibUserField};
+      if (gbtTrg->noData) {
+        return status;
       }
     }
     auto gbtD = reinterpret_cast<const o2::itsmft::GBTData*>(&currRawPiece->data[dataOffset]);
     expectPacketDone = true;
     while (!gbtD->isDataTrailer()) { // start reading real payload
-      nw++;
       if (verbosity >= VerboseData) {
         gbtD->printX();
       }
@@ -320,6 +340,7 @@ GBTLink::CollectedDataStatus GBTLink::collectROFCableData(const Mapping& chmap)
     if (verbosity >= VerboseHeaders) {
       printTrailer(gbtT);
     }
+
     GBTLINK_DECODE_ERRORCHECK(errRes, checkErrorsTrailerWord(gbtT));
     // we finished the GBT page, but there might be continuation on the next CRU page
     if (!gbtT->packetDone) {

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelDecoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelDecoder.h
@@ -28,6 +28,7 @@
 #include "ITSMFTReconstruction/PixelReader.h"
 #include "DataFormatsITSMFT/ROFRecord.h"
 #include "ITSMFTReconstruction/PixelData.h"
+#include "ITSMFTReconstruction/GBTWord.h"
 
 namespace o2
 {
@@ -107,6 +108,9 @@ class RawPixelDecoder final : public PixelReader
   void setRawDumpDirectory(const std::string& s) { mRawDumpDirectory = s; }
   auto getRawDumpDirectory() const { return mRawDumpDirectory; }
 
+  std::vector<GBTTrigger>& getExternalTriggers() { return mExtTriggers; }
+  const std::vector<GBTTrigger>& getExternalTriggers() const { return mExtTriggers; }
+
   struct LinkEntry {
     int entry = -1;
   };
@@ -125,6 +129,7 @@ class RawPixelDecoder final : public PixelReader
   std::vector<RUDecodeData> mRUDecodeVec;                   // set of active RUs
   std::array<short, Mapping::getNRUs()> mRUEntry;           // entry of the RU with given SW ID in the mRUDecodeVec
   std::vector<ChipPixelData*> mOrderedChipsPtr;             // special ordering helper used for the MFT (its chipID is not contiguous in RU)
+  std::vector<GBTTrigger> mExtTriggers;                     // external triggers
   std::string mSelfName{};                                  // self name
   std::string mRawDumpDirectory;                            // destination directory for dumps
   header::DataOrigin mUserDataOrigin = o2::header::gDataOriginInvalid; // alternative user-provided data origin to pick
@@ -143,6 +148,7 @@ class RawPixelDecoder final : public PixelReader
   uint32_t mNLinksDone = 0;                       // number of links reached end of data
   size_t mNChipsFired = 0;                        // global counter
   size_t mNPixelsFired = 0;                       // global counter
+  size_t mNExtTriggers = 0;                       // global counter
   size_t mInstanceID = 0;                         // pipeline instance
   size_t mNInstances = 1;                         // total number of pipelines
   TStopwatch mTimerTFStart;

--- a/Detectors/ITSMFT/common/reconstruction/src/GBTLink.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/GBTLink.cxx
@@ -68,6 +68,7 @@ void GBTLink::clear(bool resetStat, bool resetTFRaw)
     statistics.clear();
   }
   hbfEntry = 0;
+  extTrigVec = nullptr;
   status = None;
 }
 

--- a/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
@@ -202,6 +202,8 @@ void STFDecoder<Mapping>::run(ProcessingContext& pc)
     mEstNROF = std::max(mEstNROF, size_t(clusROFVec.size() * 1.2));
   }
 
+  pc.outputs().snapshot(Output{orig, "PHYSTRIG", 0, Lifetime::Timeframe}, mDecoder->getExternalTriggers());
+
   if (mDumpOnError != int(GBTLink::RawDataDumps::DUMP_NONE)) {
     mDecoder->produceRawDataDumps(mDumpOnError, DataRefUtils::getHeader<o2::header::DataHeader*>(pc.inputs().getFirstValid(true)));
   }
@@ -286,6 +288,7 @@ DataProcessorSpec getSTFDecoderSpec(const STFDecoderInp& inp)
     // if (doClusters && doPatterns)
     outputs.emplace_back(inp.origin, "PATTERNS", 0, Lifetime::Timeframe);
   }
+  outputs.emplace_back(inp.origin, "PHYSTRIG", 0, Lifetime::Timeframe);
 
   if (inp.askSTFDist) {
     for (auto& ins : inputs) { // mark input as optional in order not to block the workflow if our raw data happen to be missing in some TFs
@@ -300,6 +303,7 @@ DataProcessorSpec getSTFDecoderSpec(const STFDecoderInp& inp)
     inputs.emplace_back("cldict", inp.origin, "CLUSDICT", 0, Lifetime::Condition,
                         o2::framework::ccdbParamSpec(fmt::format("{}/Calib/ClusterDictionary", inp.origin.as<std::string>())));
   }
+
   return DataProcessorSpec{
     inp.deviceName,
     inputs,


### PR DESCRIPTION
The trigger headers with noData=1 and internal=0 are interpreted as external physics triggers,
there could be multiple such triggers anywhere on the RDH page except interleaved with payload
words. They will be extracted to separate vector<GBTTrigger> and sent as <DET>/PHYSTRIG/0 output.
At the moment it is not used and is not written into the digit or cluster tree.