### PR TITLE
TRD variable timebins for digits

### DIFF
--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
@@ -76,6 +76,7 @@ class CruRawReader
     mEnableTimeInfo = options[TRDEnableTimeInfoBit];
     mEnableStats = options[TRDEnableStatsBit];
     mOptions = options;
+    mTimeBins = constants::TIMEBINS; // set to value from constants incase the DigitHCHeader1 header is not present.
   }
 
   void setMaxErrWarnPrinted(int nerr, int nwar)
@@ -235,6 +236,7 @@ class CruRawReader
   HalfCRUHeader mCurrentHalfCRUHeader; // are we waiting for new header or currently parsing the payload of on
   DigitHCHeader mDigitHCHeader;        // Digit HalfChamber header we are currently on.
   DigitHCHeader1 mDigitHCHeader1;      // this and the next 2 are option are and variable in order, hence
+  uint16_t mTimeBins;
   DigitHCHeader2 mDigitHCHeader2;      // the individual seperation instead of an array.
   DigitHCHeader3 mDigitHCHeader3;
   TrackletHCHeader mTrackletHCHeader;  // Tracklet HalfChamber header we are currently on.

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/DigitsParser.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/DigitsParser.h
@@ -46,7 +46,7 @@ class DigitsParser
   void setData(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>* data) { mData = data; }
   int Parse(bool verbose = false); // presupposes you have set everything up already.
   int Parse(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>* data, std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator start,
-            std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator end, int detector, int stack, int layer, int side, DigitHCHeader& hcheader,
+            std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator end, int detector, int stack, int layer, int side, DigitHCHeader& hcheader, uint16_t timebins,
             TRDFeeID& feeid, unsigned int linkindex, EventRecord* eventrecord, EventStorage* eventrecords, std::bitset<16> options, bool cleardigits = false);
 
   enum DigitParserState { StateDigitHCHeader, // always the start of a half chamber.
@@ -89,6 +89,7 @@ class DigitsParser
       ((TH2F*)mParsingErrors2d->At(error))->Fill(mFEEID.supermodule * 2 + mHalfChamberSide, mStack * constants::NLAYER + mLayer);
     }
   }
+  void checkNoErr();
 
  private:
   int mState;
@@ -134,11 +135,13 @@ class DigitsParser
   uint16_t mSector;
   uint16_t mHalfChamberSide;
   uint16_t mStackLayer; //store these values to prevent numerous recalculation;
+  uint16_t mTimeBins;   // timebins used defaults is constants::TIMEBINS
 
   uint16_t mEventCounter;
   TRDFeeID mFEEID;
   std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator mStartParse, mEndParse; // limits of parsing, effectively the link limits to parse on.
   std::array<uint16_t, constants::TIMEBINS> mADCValues{};
+  int mMaxErrsPrinted;
   TH1F* mParsingErrors;
   TList* mParsingErrors2d;
 };

--- a/Detectors/TRD/reconstruction/src/CruRawReader.cxx
+++ b/Detectors/TRD/reconstruction/src/CruRawReader.cxx
@@ -357,6 +357,15 @@ int CruRawReader::parseDigitHCHeader()
           //LOG(alarm) << "Digit HC Header 1 reserved : " << std::hex << mDigitHCHeader1.res << " raw: 0x" << mDigitHCHeader1.word;
           increment2dHist(TRDParsingDigitHeaderWrong1, mFEEID.supermodule * 2 + mHalfChamberSide[0], mStack[0], mLayer[0]);
         }
+        mTimeBins = mDigitHCHeader1.numtimebins;
+        if (mTimeBins < 1 && mTimeBins > o2::trd::constants::TIMEBINS) {
+          //sanity check on the hcheader settings
+          mTimeBins = o2::trd::constants::TIMEBINS;
+          if (mMaxWarnPrinted > 0) {
+            LOG(warn) << "Time bins in Digit HC Header 1 is " << mDigitHCHeader1.numtimebins << " this is absurd";
+            checkNoWarn();
+          }
+        }
         break;
       case 2: // header header2;
         mDigitHCHeader2.word = headers[headerwordcount];
@@ -641,7 +650,7 @@ int CruRawReader::processHalfCRU(int cruhbfstartoffset)
             mDigitWordsRead = 0;
             auto digitsparsingstart = std::chrono::high_resolution_clock::now();
             //linkstart and linkend already have the multiple cruheaderoffsets built in
-            mDigitWordsRead = mDigitsParser.Parse(&mHBFPayload, linkstart, linkend, mDetector[mWhichData], mStack[mWhichData], mLayer[mWhichData], mHalfChamberSide[mWhichData], mDigitHCHeader, mFEEID, currentlinkindex, mCurrentEvent, &mEventRecords, mOptions, cleardigits);
+            mDigitWordsRead = mDigitsParser.Parse(&mHBFPayload, linkstart, linkend, mDetector[mWhichData], mStack[mWhichData], mLayer[mWhichData], mHalfChamberSide[mWhichData], mDigitHCHeader, mTimeBins, mFEEID, currentlinkindex, mCurrentEvent, &mEventRecords, mOptions, cleardigits);
             std::chrono::duration<double, std::micro> digitsparsingtime = std::chrono::high_resolution_clock::now() - digitsparsingstart;
             if (mRootOutput) {
               mDigitTiming->Fill((int)std::chrono::duration_cast<std::chrono::microseconds>(digitsparsingtime).count());

--- a/Detectors/TRD/reconstruction/src/DigitsParser.cxx
+++ b/Detectors/TRD/reconstruction/src/DigitsParser.cxx
@@ -42,7 +42,7 @@ inline void DigitsParser::swapByteOrder(unsigned int& word)
          (word << 24);
 }
 int DigitsParser::Parse(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>* data, std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator start,
-                        std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator end, int detector, int stack, int layer, int side, DigitHCHeader& hcheader,
+                        std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator end, int detector, int stack, int layer, int side, DigitHCHeader& hcheader, uint16_t timebins,
                         TRDFeeID& feeid, unsigned int linkindex, EventRecord* eventrecord, EventStorage* eventrecords, std::bitset<16> options, bool cleardigits)
 {
   setData(data);
@@ -63,6 +63,14 @@ int DigitsParser::Parse(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>* 
   mReturnVectorPos = 0;
   mEventRecord = eventrecord;
   mEventRecords = eventrecords;
+  mTimeBins = timebins;
+  if (mTimeBins > constants::TIMEBINS) {
+    mTimeBins = constants::TIMEBINS;
+    if (mMaxErrsPrinted > 0) {
+      LOG(alarm) << "Time bins DigitHC Header is too large:" << timebins << " > " << constants::TIMEBINS;
+      checkNoErr();
+    }
+  }
   return Parse();
 };
 
@@ -277,7 +285,7 @@ int DigitsParser::Parse(bool verbose)
             if (mHeaderVerbose) {
               LOG(info) << "***DigitMCMWord : " << std::hex << *word << " channel:" << std::dec << mCurrentADCChannel << " wordcount:" << mDigitWordCount << " at offset " << std::hex << std::distance(mStartParse, word);
             }
-            if (mDigitWordCount == 0 || mDigitWordCount == constants::TIMEBINS / 3) {
+            if (mDigitWordCount == 0 || mDigitWordCount == mTimeBins / 3) {
               //new adc expected so set channel accord to bitpattern or sequential depending on zero suppressed or not.
               if (mDigitHCHeader.major & 0x20) { // zero suppressed
                 //zero suppressed, so channel must be extracted from next available bit in adcmask
@@ -305,7 +313,7 @@ int DigitsParser::Parse(bool verbose)
                 }
               }
             }
-            if (mDigitWordCount > constants::TIMEBINS / 3) {
+            if (mDigitWordCount > mTimeBins / 3) {
               incParsingError(TRDParsingDigitGT10ADCs);
             }
             mDigitMCMData = (DigitMCMData*)word;
@@ -324,7 +332,7 @@ int DigitsParser::Parse(bool verbose)
               mADCValues[digittimebinoffset++] = mDigitMCMData->y;
               mADCValues[digittimebinoffset++] = mDigitMCMData->x;
 
-              if (digittimebinoffset > constants::TIMEBINS) {
+              if (digittimebinoffset > mTimeBins) {
                 incParsingError(TRDParsingDigitSanityCheck);
                 //bale out TODO
                 mWordsDumped += std::distance(word, mEndParse) - 1;
@@ -333,7 +341,7 @@ int DigitsParser::Parse(bool verbose)
               if (mVerbose || mDataVerbose) {
                 LOG(info) << "digit word count is : " << mDigitWordCount << " digittimebinoffset = " << digittimebinoffset;
               }
-              if (mDigitWordCount == constants::TIMEBINS / 3) {
+              if (mDigitWordCount == mTimeBins / 3) {
                 //write out adc value to vector
                 //zero digittimebinoffset
                 mEventRecord->getDigits().emplace_back(mDetector, mROB, mMCM, mCurrentADCChannel, mADCValues); // outgoing parsed digits
@@ -372,5 +380,11 @@ int DigitsParser::Parse(bool verbose)
   return mDataWordsParsed;
 }
 
+void DigitsParser::checkNoErr()
+{
+  if (!mVerbose && --mMaxErrsPrinted == 0) {
+    LOG(error) << "Errors limit reached, the following ones will be suppressed";
+  }
+}
 
 } // namespace o2::trd


### PR DESCRIPTION
- Enable somewhat variable timebins for digits.
- It must be below 30, if not it will be set to 30 via o2::trd::constants::TIMEBINS, the storing structure remains the same 30 timebins.
- Any bins less than 30 are stored blank. This therefore only affects the parsing. The objects sent back still have 30 timesbins in the ADC struct.
- This is needed for possibly improving the pulseheight spectra. Some runs were taken with 24 time bins.