### PR TITLE
Change path for CCDB entry for GRP/LHCIF datapoints

### DIFF
--- a/Detectors/GRP/calibration/src/GRPDCSDPsProcessor.cxx
+++ b/Detectors/GRP/calibration/src/GRPDCSDPsProcessor.cxx
@@ -381,7 +381,7 @@ void GRPDCSDPsProcessor::updateLHCIFInfoCCDB()
   }
   std::map<std::string, std::string> md;
   md["responsible"] = "Chiara Zampolli";
-  o2::calibration::Utils::prepareCCDBobjectInfo(mLHCInfo, mccdbLHCIFInfo, "GLO/Config/LHCIF", md, mStartValidity, mStartValidity + 3 * o2::ccdb::CcdbObjectInfo::DAY); // valid for 3 days
+  o2::calibration::Utils::prepareCCDBobjectInfo(mLHCInfo, mccdbLHCIFInfo, "GLO/Config/LHCIFDataPoints", md, mStartValidity, mStartValidity + 3 * o2::ccdb::CcdbObjectInfo::DAY); // valid for 3 days
   return;
 }
 


### PR DESCRIPTION
Now the GRP Data Points processing will store:
- GLO/Config/GRPMagField --> magnetic field
- GLO/Config/LHCIFDataPoints --> beam mode, BPTX, luminosity... 
- GLO/Config/EnvVars --> pressure and temperature
- GLO/Config/Collimators --> collimators

In addition, as a reminder, we have: 
- GLO/Config/GRPECS --> for ECS info (star/end run, detectors...)
- GLO/Config/GRPLHCIF --> for LHC file-push (beam type, energy, filling scheme...)

If we want to have "GRP" in front of the 3rd level path of all objects, those filled in the Pilot Beam till now will be invalidated. For LHCIFDataPoints it does not matter, as the data stored there were not meaningful (@shahor02 )
