### PR TITLE
DCS DP processors report timing, wait for 2nd FBI unless it is forbidden

### DIFF
--- a/Detectors/DCS/testWorkflow/src/DCStoDPLconverter.h
+++ b/Detectors/DCS/testWorkflow/src/DCStoDPLconverter.h
@@ -74,8 +74,8 @@ o2f::InjectorFunction dcs2dpl(std::unordered_map<DPID, o2h::DataDescription>& dp
     nInp++;
     if (o2::utils::Str::endsWith(firstName, "Master")) {
       isFBI = true;
-      seenFBI = true;
       nInpFBI++;
+      seenFBI = true;
     } else if (o2::utils::Str::endsWith(firstName, "MasterDelta")) {
       isFBI = false;
     } else {
@@ -106,7 +106,8 @@ o2f::InjectorFunction dcs2dpl(std::unordered_map<DPID, o2h::DataDescription>& dp
       }
     }
     auto timerNow = std::chrono::high_resolution_clock::now();
-    if (fbiFirst && !seenFBI) {
+    if (fbiFirst && nInpFBI < 2) { // 1st FBI might be obsolete
+      seenFBI = false;
       static int prevDelay = 0;
       std::chrono::duration<double, std::ratio<1>> duration = timerNow - timer0;
       int delay = duration.count();

--- a/Detectors/DCS/testWorkflow/src/DCStoDPLconverter.h
+++ b/Detectors/DCS/testWorkflow/src/DCStoDPLconverter.h
@@ -56,11 +56,12 @@ o2f::InjectorFunction dcs2dpl(std::unordered_map<DPID, o2h::DataDescription>& dp
 
   return [dpid2group, fbiFirst, verbose](o2::framework::TimingInfo& tinfo, fair::mq::Device& device, fair::mq::Parts& parts, o2f::ChannelRetriever channelRetriever) {
     static std::unordered_map<DPID, DPCOM> cache; // will keep only the latest measurement in the 1-second wide window for each DPID
-    static auto timer = std::chrono::system_clock::now();
-    static auto timer0 = std::chrono::system_clock::now();
+    static auto timer = std::chrono::high_resolution_clock::now();
+    static auto timer0 = std::chrono::high_resolution_clock::now();
     static bool seenFBI = false;
     static uint32_t localTFCounter = 0;
-
+    static size_t nInp = 0, nInpFBI = 0;
+    static size_t szInp = 0, szInpFBI = 0;
     LOG(debug) << "In lambda function: ********* Size of unordered_map (--> number of defined groups) = " << dpid2group.size();
     // check if we got FBI (Master) or delta (MasterDelta)
     if (!parts.Size()) {
@@ -68,10 +69,13 @@ o2f::InjectorFunction dcs2dpl(std::unordered_map<DPID, o2h::DataDescription>& dp
       return;
     }
     std::string firstName = std::string((char*)&(reinterpret_cast<const DPCOM*>(parts.At(0)->GetData()))->id);
+
     bool isFBI = false;
+    nInp++;
     if (o2::utils::Str::endsWith(firstName, "Master")) {
       isFBI = true;
       seenFBI = true;
+      nInpFBI++;
     } else if (o2::utils::Str::endsWith(firstName, "MasterDelta")) {
       isFBI = false;
     } else {
@@ -83,7 +87,12 @@ o2f::InjectorFunction dcs2dpl(std::unordered_map<DPID, o2h::DataDescription>& dp
 
     // We first iterate over the parts of the received message
     for (size_t i = 0; i < parts.Size(); ++i) {             // DCS sends only 1 part, but we should be able to receive more
-      auto nDPCOM = parts.At(i)->GetSize() / sizeof(DPCOM); // number of DPCOM in current part
+      auto sz = parts.At(i)->GetSize();
+      szInp += sz;
+      if (isFBI) {
+        szInpFBI += sz;
+      }
+      auto nDPCOM = sz / sizeof(DPCOM); // number of DPCOM in current part
       for (size_t j = 0; j < nDPCOM; j++) {
         const auto& src = *(reinterpret_cast<const DPCOM*>(parts.At(i)->GetData()) + j);
         // do we want to check if this DP was requested ?
@@ -92,12 +101,11 @@ o2f::InjectorFunction dcs2dpl(std::unordered_map<DPID, o2h::DataDescription>& dp
           LOG(info) << "Received DP " << src.id << " (data = " << src.data << "), matched to output-> " << (mapEl == dpid2group.end() ? "none " : mapEl->second.as<std::string>());
         }
         if (mapEl != dpid2group.end()) {
-          auto& dst = cache[src.id] = src; // this is needed in case in the 1s window we get a new value for the same DP
+          cache[src.id] = src; // this is needed in case in the 1s window we get a new value for the same DP
         }
       }
     }
-
-    auto timerNow = std::chrono::system_clock::now();
+    auto timerNow = std::chrono::high_resolution_clock::now();
     if (fbiFirst && !seenFBI) {
       static int prevDelay = 0;
       std::chrono::duration<double, std::ratio<1>> duration = timerNow - timer0;
@@ -171,6 +179,10 @@ o2f::InjectorFunction dcs2dpl(std::unordered_map<DPID, o2h::DataDescription>& dp
       if (!messagesPerRoute.empty()) {
         localTFCounter++;
       }
+    }
+    if (isFBI) {
+      float runtime = 1e-3 * std::chrono::duration_cast<std::chrono::milliseconds>(timerNow - timer0).count();
+      LOGP(info, "{} inputs ({} bytes) of which {} FBI ({} bytes) seen in {:.3f} s", nInp, fmt::group_digits(szInp), nInpFBI, fmt::group_digits(szInpFBI), runtime);
     }
   };
 }

--- a/Detectors/DCS/testWorkflow/src/dcs-proxy.cxx
+++ b/Detectors/DCS/testWorkflow/src/dcs-proxy.cxx
@@ -24,6 +24,7 @@
 #include "DetectorsDCS/DataPointValue.h"
 #include "DetectorsDCS/DeliveryType.h"
 #include "DCStoDPLconverter.h"
+#include "CommonUtils/StringUtils.h"
 #include "CCDB/BasicCCDBManager.h"
 #include "CCDB/CcdbApi.h"
 #include "Headers/DataHeaderHelpers.h"
@@ -84,12 +85,16 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
     std::sregex_token_iterator it(detectorList.begin(), detectorList.end(), re, -1);
     std::sregex_token_iterator reg_end;
     for (; it != reg_end; ++it) {
-      LOG(info) << "DCS DPs configured for detector " << it->str();
-      std::unordered_map<DPID, std::string>* dpid2Det = mgr.getForTimeStamp<std::unordered_map<DPID, std::string>>(it->str() + "/Config/DCSDPconfig", ts);
-      for (auto& el : *dpid2Det) {
-        o2::header::DataDescription tmpd;
-        tmpd.runtimeInit(el.second.c_str(), el.second.size());
-        dpid2DataDesc[el.first] = tmpd;
+      std::string detStr = it->str();
+      o2::utils::Str::trim(detStr);
+      if (!detStr.empty()) {
+        LOG(info) << "DCS DPs configured for detector " << detStr;
+        std::unordered_map<DPID, std::string>* dpid2Det = mgr.getForTimeStamp<std::unordered_map<DPID, std::string>>(detStr + "/Config/DCSDPconfig", ts);
+        for (auto& el : *dpid2Det) {
+          o2::header::DataDescription tmpd;
+          tmpd.runtimeInit(el.second.c_str(), el.second.size());
+          dpid2DataDesc[el.first] = tmpd;
+        }
       }
     }
   }

--- a/Detectors/GRP/workflows/include/GRPWorkflows/GRPDCSDPsSpec.h
+++ b/Detectors/GRP/workflows/include/GRPWorkflows/GRPDCSDPsSpec.h
@@ -43,6 +43,7 @@ class GRPDCSDPsDataProcessor : public Task
   std::unique_ptr<GRPDCSDPsProcessor> mProcessor;
   HighResClock::time_point mTimer;
   int64_t mDPsUpdateInterval;
+  bool mReportTiming = false;
 };
 } // namespace grp
 

--- a/Detectors/TOF/calibration/testWorkflow/TOFDCSDataProcessorSpec.h
+++ b/Detectors/TOF/calibration/testWorkflow/TOFDCSDataProcessorSpec.h
@@ -100,10 +100,12 @@ class TOFDCSDataProcessor : public o2::framework::Task
     }
     mProcessor->init(vect);
     mTimer = HighResClock::now();
+    mReportTiming = ic.options().get<bool>("report-timing") || useVerboseMode;
   }
 
   void run(o2::framework::ProcessingContext& pc) final
   {
+    TStopwatch sw;
     auto startValidity = DataRefUtils::getHeader<DataProcessingHeader*>(pc.inputs().getFirstValid(true))->creation;
     auto dps = pc.inputs().get<gsl::span<DPCOM>>("input");
     auto timeNow = HighResClock::now();
@@ -118,6 +120,10 @@ class TOFDCSDataProcessor : public o2::framework::Task
       mTimer = timeNow;
     }
     sendLVandHVoutput(pc.outputs());
+    sw.Stop();
+    if (mReportTiming) {
+      LOGP(info, "Timing CPU:{:.3e} Real:{:.3e} at slice {}", sw.CpuTime(), sw.RealTime(), pc.services().get<o2::framework::TimingInfo>().timeslice);
+    }
   }
 
   void endOfStream(o2::framework::EndOfStreamContext& ec) final
@@ -127,6 +133,7 @@ class TOFDCSDataProcessor : public o2::framework::Task
   }
 
  private:
+  bool mReportTiming = false;
   std::unique_ptr<TOFDCSProcessor> mProcessor;
   HighResClock::time_point mTimer;
   int64_t mDPsUpdateInterval;
@@ -201,6 +208,7 @@ DataProcessorSpec getTOFDCSDataProcessorSpec()
     Options{{"ccdb-path", VariantType::String, "http://localhost:8080", {"Path to CCDB"}},
             {"use-ccdb-to-configure", VariantType::Bool, false, {"Use CCDB to configure"}},
             {"use-verbose-mode", VariantType::Bool, false, {"Use verbose mode"}},
+            {"report-timing", VariantType::Bool, false, {"Report timing for every slice"}},
             {"DPs-update-interval", VariantType::Int64, 600ll, {"Interval (in s) after which to update the DPs CCDB entry"}}}};
 }
 


### PR DESCRIPTION
* All DCS DP processors optionally report timing, dcs-proxy reports at FBI the processed stat.
* Wait for 2nd FBI if unless --may-send-delta-first asked
  Since with the push/pull method the 1st FBI received might be obsolete, start using data from 1nd FBI unless it is explicitly forbidden.
