### PR TITLE
Rdev tofcompressor fixes

### DIFF
--- a/Detectors/TOF/compression/src/Compressor.cxx
+++ b/Detectors/TOF/compression/src/Compressor.cxx
@@ -538,6 +538,7 @@ bool Compressor<RDH, verbose, paranoid>::processLTM()
   /** process LTM **/
 
   mDecoderSummary.ltmDataHeader = mDecoderPointer;
+  uint32_t eventWords = GET_LTMDATAHEADER_EVENTWORDS(*mDecoderPointer);
   if (verbose && mDecoderVerbose) {
     auto ltmDataHeader = reinterpret_cast<const raw::LTMDataHeader_t*>(mDecoderPointer);
     auto eventWords = ltmDataHeader->eventWords;
@@ -551,7 +552,6 @@ bool Compressor<RDH, verbose, paranoid>::processLTM()
   }
 
   /** loop over LTM payload **/
-  uint32_t eventWords = GET_LTMDATAHEADER_EVENTWORDS(*mDecoderPointer);
   for (int i = 0; i < eventWords; ++i) {
     if (verbose && mDecoderVerbose) {
       printf(" %08x LTM Data \n", *mDecoderPointer);

--- a/Detectors/TOF/compression/src/Compressor.cxx
+++ b/Detectors/TOF/compression/src/Compressor.cxx
@@ -18,6 +18,8 @@
 #include "TOFBase/Geo.h"
 #include "DetectorsRaw/RDHUtils.h"
 
+#include "FairLogger.h"
+
 #include <cstring>
 #include <iostream>
 
@@ -193,7 +195,12 @@ bool Compressor<RDH, verbose, paranoid>::processHBF()
   /** process DRM data **/
   mDecoderPointer = reinterpret_cast<const uint32_t*>(mDecoderSaveBuffer);
   mDecoderPointerMax = reinterpret_cast<const uint32_t*>(mDecoderSaveBuffer + mDecoderSaveBufferDataSize);
+  int nsteps = 0;
   while (mDecoderPointer < mDecoderPointerMax) {
+    nsteps++;
+    if (nsteps > 3) {
+      LOG(error) << "processHBF: nsteps in while loop = " << nsteps << ", infity loop?";
+    }
     mEventCounter++;
     if (processDRM()) {            // if this breaks, we did not run the checker and the summary is not reset!
       mDecoderSummary = {nullptr}; // reset it like this, perhaps a better way can be found
@@ -396,7 +403,12 @@ bool Compressor<RDH, verbose, paranoid>::processDRM()
   encoderNext();
 
   /** loop over DRM payload **/
+  int nsteps = 0;
   while (true) {
+    nsteps++;
+    if (nsteps > 20) {
+      LOG(error) << "processDRM: nsteps in while loop = " << nsteps << ", infity loop?";
+    }
 
     /** LTM global header detected **/
     if (IS_LTM_GLOBAL_HEADER(*mDecoderPointer)) {
@@ -599,7 +611,12 @@ bool Compressor<RDH, verbose, paranoid>::processTRM()
   }
 
   /** loop over TRM payload **/
+  int nsteps = 0;
   while (true) {
+    nsteps++;
+    if (nsteps > 20) {
+      LOG(error) << "processTRM: nsteps in while loop = " << nsteps << ", infity loop?";
+    }
 
     /** TRM Chain-A Header detected **/
     if (IS_TRM_CHAINA_HEADER(*mDecoderPointer) && GET_TRMCHAINHEADER_SLOTID(*mDecoderPointer) == slotId) {
@@ -689,7 +706,12 @@ bool Compressor<RDH, verbose, paranoid>::processTRMchain(int itrm, int ichain)
   }
 
   /** loop over TRM Chain payload **/
+  int nsteps = 0;
   while (true) {
+    nsteps++;
+    if (nsteps > 20) {
+      LOG(error) << "processTRMchain: nsteps in while loop = " << nsteps << ", infity loop?";
+    }
     /** TDC hit detected **/
     if (IS_TDC_HIT(*mDecoderPointer)) {
       mDecoderSummary.hasHits[itrm][ichain] = true;

--- a/Detectors/TOF/compression/src/Compressor.cxx
+++ b/Detectors/TOF/compression/src/Compressor.cxx
@@ -539,7 +539,11 @@ bool Compressor<RDH, verbose, paranoid>::processLTM()
 
   mDecoderSummary.ltmDataHeader = mDecoderPointer;
   if (verbose && mDecoderVerbose) {
-    printf(" %08x LTM Global Header \n", *mDecoderPointer);
+    auto ltmDataHeader = reinterpret_cast<const raw::LTMDataHeader_t*>(mDecoderPointer);
+    auto eventWords = ltmDataHeader->eventWords;
+    auto cycloneErr = ltmDataHeader->cycloneErr;
+    auto fault = ltmDataHeader->cycloneErr;
+    printf(" %08x LTM Data Header       (eventWords=%d, cycloneErr=%d, fault=%d) \n", *mDecoderPointer, eventWords, cycloneErr, fault);
   }
   decoderNext();
   if (paranoid && decoderParanoid()) {
@@ -550,7 +554,7 @@ bool Compressor<RDH, verbose, paranoid>::processLTM()
   uint32_t eventWords = GET_LTMDATAHEADER_EVENTWORDS(*mDecoderPointer);
   for (int i = 0; i < eventWords; ++i) {
     if (verbose && mDecoderVerbose) {
-      printf(" %08x LTM Data Header \n", *mDecoderPointer);
+      printf(" %08x LTM Data \n", *mDecoderPointer);
     }
     decoderNext();
     if (paranoid && decoderParanoid()) {
@@ -568,7 +572,6 @@ bool Compressor<RDH, verbose, paranoid>::processLTM()
     if (paranoid && decoderParanoid()) {
       return true;
     }
-    break;
   }
 
   /** success **/

--- a/Detectors/TOF/compression/src/Compressor.cxx
+++ b/Detectors/TOF/compression/src/Compressor.cxx
@@ -419,19 +419,13 @@ bool Compressor<RDH, verbose, paranoid>::processDRM()
         printf(" %08x DRM Data Trailer      (locEvCnt=%d) \n", *mDecoderPointer, locEvCnt);
       }
       decoderNext();
-      if (paranoid && decoderParanoid()) {
-        return true;
-      }
 
       /** filler detected **/
-      if (IS_FILLER(*mDecoderPointer)) {
+      if ( (mDecoderPointer < mDecoderPointerMax) && IS_FILLER(*mDecoderPointer) ) {
         if (verbose && mDecoderVerbose) {
           printf(" %08x Filler \n", *mDecoderPointer);
         }
         decoderNext();
-        if (paranoid && decoderParanoid()) {
-          return true;
-        }
       }
 
       /** encode Crate Trailer **/

--- a/Detectors/TOF/compression/src/Compressor.cxx
+++ b/Detectors/TOF/compression/src/Compressor.cxx
@@ -424,7 +424,7 @@ bool Compressor<RDH, verbose, paranoid>::processDRM()
       decoderNext();
 
       /** filler detected **/
-      if ( (mDecoderPointer < mDecoderPointerMax) && IS_FILLER(*mDecoderPointer) ) {
+      if ((mDecoderPointer < mDecoderPointerMax) && IS_FILLER(*mDecoderPointer)) {
         if (verbose && mDecoderVerbose) {
           printf(" %08x Filler \n", *mDecoderPointer);
         }

--- a/Detectors/TOF/compression/src/Compressor.cxx
+++ b/Detectors/TOF/compression/src/Compressor.cxx
@@ -538,7 +538,8 @@ bool Compressor<RDH, verbose, paranoid>::processLTM()
   /** process LTM **/
 
   mDecoderSummary.ltmDataHeader = mDecoderPointer;
-  uint32_t eventWords = GET_LTMDATAHEADER_EVENTWORDS(*mDecoderPointer);
+  uint32_t eventWords = GET_LTMDATAHEADER_EVENTWORDS(*mDecoderPointer); // this is the total event size, including header/trailer
+  uint32_t payload = eventWords - 2;
   if (verbose && mDecoderVerbose) {
     auto ltmDataHeader = reinterpret_cast<const raw::LTMDataHeader_t*>(mDecoderPointer);
     auto eventWords = ltmDataHeader->eventWords;
@@ -552,7 +553,7 @@ bool Compressor<RDH, verbose, paranoid>::processLTM()
   }
 
   /** loop over LTM payload **/
-  for (int i = 0; i < eventWords; ++i) {
+  for (int i = 0; i < payload; ++i) {
     if (verbose && mDecoderVerbose) {
       printf(" %08x LTM Data \n", *mDecoderPointer);
     }

--- a/Detectors/ZDC/simulation/include/ZDCSimulation/SpatialPhotonResponse.h
+++ b/Detectors/ZDC/simulation/include/ZDCSimulation/SpatialPhotonResponse.h
@@ -37,7 +37,7 @@ class SpatialPhotonResponse
   SpatialPhotonResponse() = default;
 
   void addPhoton(double x, double y, int nphotons);
-  //Adds photon to the image (as addPhoton does) but it takes pixel coordinates as arguments.
+  // Adds photon to the image (as addPhoton does) but it takes pixel coordinates as arguments.
   void addPhotonByPixel(int xpixel, int ypixel, int nphotons);
   // void exportToPNG() const;
   void printToScreen() const;

--- a/GPU/Workflow/src/GPUWorkflowSpec.cxx
+++ b/GPU/Workflow/src/GPUWorkflowSpec.cxx
@@ -532,7 +532,8 @@ void GPURecoWorkflowSpec::run(ProcessingContext& pc)
           if (mVerbosity) {
             end = std::chrono::high_resolution_clock::now();
             std::chrono::duration<double> elapsed_seconds = end - start;
-            LOG(info) << "Allocation time for " << name << " (" << size << " bytes)" << ": " << elapsed_seconds.count() << "s";
+            LOG(info) << "Allocation time for " << name << " (" << size << " bytes)"
+                      << ": " << elapsed_seconds.count() << "s";
           }
           return (buffer.second = buffer.first->get().data()) + offset;
         };


### PR DESCRIPTION
This PR fixes a bug in the TOF compressor when running with the `decoderParanoid` option.

It also changes the decoding strategy for the LTM, removing the endless in favour of a checked-loop against the declared event size. It will result in slower but safer execution.