### PR TITLE
DPL: improve websocket encoding

### DIFF
--- a/Detectors/GRP/workflows/src/create-grp-ecs.cxx
+++ b/Detectors/GRP/workflows/src/create-grp-ecs.cxx
@@ -149,7 +149,7 @@ int main(int argc, char** argv)
     add_option("start-time,s", bpo::value<long>()->default_value(0), "run start time in ms, now() if 0");
     add_option("end-time,e", bpo::value<long>()->default_value(0), "run end time in ms, start-time+3days is used if 0");
     add_option("ccdb-server", bpo::value<std::string>()->default_value("http://alice-ccdb.cern.ch"), "CCDB server for upload, local file if empty");
-    add_option("refresh", bpo::value<string>()->default_value("")->implicit_value("async"), "refresh server cache after upload: \"none\" (or \"\"), \"async\" (non-blocking) and \"sync\" (blocking)");
+    add_option("refresh", bpo::value<string>()->default_value("")->implicit_value("async"), R"(refresh server cache after upload: "none" (or ""), "async" (non-blocking) and "sync" (blocking))");
 
     opt_all.add(opt_general).add(opt_hidden);
     bpo::store(bpo::command_line_parser(argc, argv).options(opt_all).positional(opt_pos).run(), vm);
@@ -189,7 +189,7 @@ int main(int argc, char** argv)
     } else if (refreshStr == "sync") {
       refresh = CCDBRefreshMode::SYNC;
     } else {
-      LOGP(fatal, "Wrong CCDB refresh mode {}, supported are \"none\" (or \"\"), \"async\" and \"sync\"", refreshStr);
+      LOGP(fatal, R"(Wrong CCDB refresh mode {}, supported are "none" (or ""), "async" and "sync")", refreshStr);
     }
   }
 

--- a/Framework/Core/src/HTTPParser.cxx
+++ b/Framework/Core/src/HTTPParser.cxx
@@ -91,7 +91,7 @@ void encode_websocket_frames(std::vector<uv_buf_t>& outputs, char const* src, si
     memset(buffer, 0, headerSize);
     header->len = 127;
     header->len64 = htonll(size);
-    outputs.push_back(uv_buf_init(buffer, size));
+    outputs.push_back(uv_buf_init(buffer, size + maskSize + headerSize));
   }
   size_t fullHeaderSize = maskSize + headerSize;
   startPayload = buffer + fullHeaderSize;
@@ -165,7 +165,7 @@ void decode_websocket(char* start, size_t size, WebSocketHandler& handler)
       headerSize = 2 + 2 + (header->mask ? 4 : 0);
     } else if (header->len == 127) {
       WebSocketFrameHuge* headerSmall = (WebSocketFrameHuge*)cur;
-      payloadSize = ntohs(headerSmall->len64);
+      payloadSize = ntohll(headerSmall->len64);
       headerSize = 2 + 8 + (header->mask ? 4 : 0);
     }
     size_t availableSize = size - (cur - start);

--- a/Framework/Core/src/HTTPParser.cxx
+++ b/Framework/Core/src/HTTPParser.cxx
@@ -55,24 +55,43 @@ void encode_websocket_frames(std::vector<uv_buf_t>& outputs, char const* src, si
 
   if (size < 126) {
     headerSize = sizeof(WebSocketFrameTiny);
-    buffer = (char*)malloc(headerSize + maskSize + size);
+    // Allocate a new page if we do not fit in the current one
+    if (outputs.empty() || outputs.back().len > WebSocketConstants::MaxChunkSize || (size + maskSize + headerSize) > (WebSocketConstants::MaxChunkSize - outputs.back().len)) {
+      char* chunk = (char*)malloc(WebSocketConstants::MaxChunkSize);
+      outputs.push_back(uv_buf_init(chunk, 0));
+    }
+    auto& buf = outputs.back();
+    // Reposition the buffer to the end of the current page
+    buffer = buf.base + buf.len;
+    buf.len += headerSize + size + maskSize;
     WebSocketFrameTiny* header = (WebSocketFrameTiny*)buffer;
     memset(buffer, 0, headerSize);
     header->len = size;
   } else if (size < 1 << 16) {
     headerSize = sizeof(WebSocketFrameShort);
-    buffer = (char*)malloc(headerSize + maskSize + size);
+    // Allocate a new page if we do not fit in the current one
+    if (outputs.empty() || outputs.back().len > WebSocketConstants::MaxChunkSize || (size + maskSize + headerSize) > (WebSocketConstants::MaxChunkSize - outputs.back().len)) {
+      char* chunk = (char*)malloc(WebSocketConstants::MaxChunkSize);
+      outputs.push_back(uv_buf_init(chunk, 0));
+    }
+    auto& buf = outputs.back();
+    // Reposition the buffer to the end of the current page
+    buffer = buf.base + buf.len;
+    buf.len += headerSize + size + maskSize;
     WebSocketFrameShort* header = (WebSocketFrameShort*)buffer;
     memset(buffer, 0, headerSize);
     header->len = 126;
     header->len16 = htons(size);
   } else {
+    // For larger messages we do standalone allocation
+    // so that the message does not need to be sent in multiple chunks
     headerSize = sizeof(WebSocketFrameHuge);
     buffer = (char*)malloc(headerSize + maskSize + size);
     WebSocketFrameHuge* header = (WebSocketFrameHuge*)buffer;
     memset(buffer, 0, headerSize);
     header->len = 127;
     header->len64 = htonll(size);
+    outputs.push_back(uv_buf_init(buffer, size));
   }
   size_t fullHeaderSize = maskSize + headerSize;
   startPayload = buffer + fullHeaderSize;
@@ -85,7 +104,6 @@ void encode_websocket_frames(std::vector<uv_buf_t>& outputs, char const* src, si
   }
   header->mask = mask ? 1 : 0;
   memmask(startPayload, src, size, mask);
-  outputs.push_back(uv_buf_init(buffer, size + fullHeaderSize));
 }
 
 void decode_websocket(char* start, size_t size, WebSocketHandler& handler)

--- a/Framework/Core/src/HTTPParser.cxx
+++ b/Framework/Core/src/HTTPParser.cxx
@@ -51,30 +51,30 @@ void encode_websocket_frames(std::vector<uv_buf_t>& outputs, char const* src, si
   size_t headerSize;
   char* buffer = nullptr;
   char* startPayload = nullptr;
-  std::vector<uv_buf_t> result;
+  int maskSize = mask ? 4 : 0;
 
   if (size < 126) {
     headerSize = sizeof(WebSocketFrameTiny);
-    buffer = (char*)malloc(headerSize + size);
+    buffer = (char*)malloc(headerSize + maskSize + size);
     WebSocketFrameTiny* header = (WebSocketFrameTiny*)buffer;
     memset(buffer, 0, headerSize);
     header->len = size;
   } else if (size < 1 << 16) {
     headerSize = sizeof(WebSocketFrameShort);
-    buffer = (char*)malloc(headerSize + size);
+    buffer = (char*)malloc(headerSize + maskSize + size);
     WebSocketFrameShort* header = (WebSocketFrameShort*)buffer;
     memset(buffer, 0, headerSize);
     header->len = 126;
     header->len16 = htons(size);
   } else {
     headerSize = sizeof(WebSocketFrameHuge);
-    buffer = (char*)malloc(headerSize + size);
+    buffer = (char*)malloc(headerSize + maskSize + size);
     WebSocketFrameHuge* header = (WebSocketFrameHuge*)buffer;
     memset(buffer, 0, headerSize);
     header->len = 127;
     header->len64 = htonll(size);
   }
-  size_t fullHeaderSize = (mask ? 4 : 0) + headerSize;
+  size_t fullHeaderSize = maskSize + headerSize;
   startPayload = buffer + fullHeaderSize;
   WebSocketFrameTiny* header = (WebSocketFrameTiny*)buffer;
   header->fin = 1;

--- a/Framework/Core/src/HTTPParser.h
+++ b/Framework/Core/src/HTTPParser.h
@@ -105,6 +105,15 @@ enum struct WebSocketOpCode : uint8_t {
   Pong = 10
 };
 
+struct WebSocketConstants {
+  /// The maximum size of a WebSocket chunk.
+  /// We always allocate new buffers of this size and then we use
+  /// len to decide how much data was used. This way
+  /// we can simply multiplex multiple messages in the same buffer.
+  /// For larger messages, we can then create the right size buffer.
+  constexpr static size_t MaxChunkSize = 0x10000;
+};
+
 /// Encodes the request handshake for a given path / protocol / version.
 /// @a path is the path of the websocket endpoint
 /// @a protocol is the protocol required for the websocket connection


### PR DESCRIPTION
Apparently the "leak" which is observed comes from some weird allocation pattern from the metrics. If I pool allocations like done in this PR it seems to behave correctly also at low rates. Not sure what is going on, but this fixes the issue in my case.