### PR TITLE
Added TRDTrackQC parameters

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
@@ -22,14 +22,14 @@ namespace trd
 {
 namespace constants
 {
-constexpr int NSECTOR = 18;        // the number of sectors
-constexpr int NSTACK = 5;          // the number of stacks per sector
-constexpr int NLAYER = 6;          // the number of layers
-constexpr int NCHAMBERPERSEC = 30; // the number of chambers per sector
-constexpr int MAXCHAMBER = 540;    // the maximum number of installed chambers
+constexpr int NSECTOR = 18;          // the number of sectors
+constexpr int NSTACK = 5;            // the number of stacks per sector
+constexpr int NLAYER = 6;            // the number of layers
+constexpr int NCHAMBERPERSEC = 30;   // the number of chambers per sector
+constexpr int MAXCHAMBER = 540;      // the maximum number of installed chambers
 constexpr int MAXHALFCHAMBER = 1080; // the maximum number of installed half-chambers
-constexpr int NCHAMBER = 521;      // the number of chambers actually installed
-constexpr int NHALFCRU = 72;       // the number of half cru (link bundles)
+constexpr int NCHAMBER = 521;        // the number of chambers actually installed
+constexpr int NHALFCRU = 72;         // the number of half cru (link bundles)
 constexpr int NLINKSPERHALFCRU = 15; // the number of links per half cru or cru end point.
 constexpr int NRU = 36;              // the number of CRU we have
 constexpr int NFLP = 12;             // the number of FLP we have.
@@ -49,20 +49,20 @@ constexpr int NROBC1 = 8;       // the number of ROBs per C1 chamber
 constexpr int NADCMCM = 21;     // the number of ADC channels per MCM
 constexpr int NCOLMCM = 18;     // the number of pads per MCM
 constexpr int NCPU = 4;         // the number of CPUs inside the TRAP chip
-constexpr int NCHARGES = 3;         // the number of charges per tracklet (Q0/1/2)
+constexpr int NCHARGES = 3;     // the number of charges per tracklet (Q0/1/2)
 
 // the values below should come out of the TRAP config in the future
-constexpr int NBITSTRKLPOS = 11;                   // number of bits for position in tracklet64 word
-constexpr int NBITSTRKLSLOPE = 8;                  // number of bits for slope in tracklet64 word
-constexpr int ADDBITSHIFTSLOPE = 1 << 3;           // in the TRAP the slope is shifted by 3 additional bits compared to the position
-constexpr int PADGRANULARITYTRKLPOS = 40;          // tracklet position is stored in units of 1/40 pad
-constexpr int PADGRANULARITYTRKLSLOPE = 128;       // tracklet deflection is stored in units of 1/128 pad per time bin
+constexpr int NBITSTRKLPOS = 11;                                      // number of bits for position in tracklet64 word
+constexpr int NBITSTRKLSLOPE = 8;                                     // number of bits for slope in tracklet64 word
+constexpr int ADDBITSHIFTSLOPE = 1 << 3;                              // in the TRAP the slope is shifted by 3 additional bits compared to the position
+constexpr int PADGRANULARITYTRKLPOS = 40;                             // tracklet position is stored in units of 1/40 pad
+constexpr int PADGRANULARITYTRKLSLOPE = 128;                          // tracklet deflection is stored in units of 1/128 pad per time bin
 constexpr float GRANULARITYTRKLPOS = 1.f / PADGRANULARITYTRKLPOS;     // granularity of position in tracklet64 word in pad-widths
 constexpr float GRANULARITYTRKLSLOPE = 1.f / PADGRANULARITYTRKLSLOPE; // granularity of slope in tracklet64 word in pads/timebin
 constexpr int ADCBASELINE = 10;                                       // baseline in ADC units
 
 // OS: Should this not be flexible for example in case of Kr calib?
-constexpr int TIMEBINS = 30; // the number of time bins
+constexpr int TIMEBINS = 30;           // the number of time bins
 constexpr float MAXIMPACTANGLE = 25.f; // the maximum impact angle for tracks relative to the TRD detector plane to be considered for vDrift and ExB calibration
 constexpr int NBINSANGLEDIFF = 25;     // the number of bins for the track angle used for the vDrift and ExB calibration based on the tracking
 
@@ -72,15 +72,15 @@ constexpr double DEAD_TIME = 200;                      // trigger deadtime, 2 mi
 constexpr double BUSY_TIME = READOUT_TIME + DEAD_TIME; // the time for which no new trigger can be received in nanoseconds
 
 // array size to store incoming half cru payload.
-constexpr int HBFBUFFERMAX = 1048576;         // max buffer size for data read from a half cru, (all events)
-constexpr int CRUPADDING32 = 0xeeeeeeee;      // padding word used in the cru.
-constexpr int CHANNELNRNOTRKLT = 23;          // this marks channels in the ADC mask which don't contribute to a tracklet
-constexpr int NOTRACKLETFIT = 31;             // this value is assigned to the fit pointer in case no tracklet is available
-constexpr int TRACKLETENDMARKER = 0x10001000; // marker for the end of tracklets in raw data, 2 of these.
-constexpr int DIGITENDMARKER = 0x0;           // marker for the end of digits in raw data, 2 of these
-constexpr int MAXDATAPERLINK32 = 13824;       // max number of 32 bit words per link ((21x12+2+4)*64) 64 mcm, 21 channels, 10 words per channel 2 header words(DigitMCMHeader DigitMCMADCmask) 4 words for tracklets.
-constexpr int MAXDATAPERLINK256 = 1728;       // max number of linkwords per cru link. (256bit words)
-constexpr int MAXEVENTCOUNTERSEPERATION = 200; // how far appart can subsequent mcmheader event counters be before we flag for concern, used as a sanity check in rawreader.
+constexpr int HBFBUFFERMAX = 1048576;          // max buffer size for data read from a half cru, (all events)
+constexpr int CRUPADDING32 = 0xeeeeeeee;       // padding word used in the cru.
+constexpr int CHANNELNRNOTRKLT = 23;           // this marks channels in the ADC mask which don't contribute to a tracklet
+constexpr int NOTRACKLETFIT = 31;              // this value is assigned to the fit pointer in case no tracklet is available
+constexpr int TRACKLETENDMARKER = 0x10001000;  // marker for the end of tracklets in raw data, 2 of these.
+constexpr int DIGITENDMARKER = 0x0;            // marker for the end of digits in raw data, 2 of these
+constexpr int MAXDATAPERLINK32 = 13824;        // max number of 32 bit words per link ((21x12+2+4)*64) 64 mcm, 21 channels, 10 words per channel 2 header words(DigitMCMHeader DigitMCMADCmask) 4 words for tracklets.
+constexpr int MAXDATAPERLINK256 = 1728;        // max number of linkwords per cru link. (256bit words)
+constexpr int MAXEVENTCOUNTERSEPERATION = 200; // how far apart can subsequent mcmheader event counters be before we flag for concern, used as a sanity check in rawreader.
 constexpr int MAXMCMCOUNT = 69120;             // at most mcm count maxchamber x nrobc1 nmcmrob
 constexpr int MAXLINKERRORHISTOGRAMS = 10;     // size of the array holding the link error plots from the raw reader
 constexpr int MAXPARSEERRORHISTOGRAMS = 60;    // size of the array holding the parsing error plots from the raw reader
@@ -88,7 +88,7 @@ constexpr int ETYPEPHYSICSTRIGGER = 0x2;       // CRU Half Chamber header eventt
 constexpr int ETYPECALIBRATIONTRIGGER = 0x3;   // CRU Half Chamber header eventtype definition
 constexpr int MAXCRUERRORVALUE = 0x2;          // Max possible value for a CRU Halfchamber link error. As of may 2022, can only be 0x0, 0x1, and 0x2, at least that is all so far(may2022).
 
-} //namespace constants
+} // namespace constants
 } // namespace trd
 } // namespace o2
 

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
@@ -49,6 +49,7 @@ constexpr int NROBC1 = 8;       // the number of ROBs per C1 chamber
 constexpr int NADCMCM = 21;     // the number of ADC channels per MCM
 constexpr int NCOLMCM = 18;     // the number of pads per MCM
 constexpr int NCPU = 4;         // the number of CPUs inside the TRAP chip
+constexpr int NCHARGES = 3;         // the number of charges per tracklet (Q0/1/2)
 
 // the values below should come out of the TRAP config in the future
 constexpr int NBITSTRKLPOS = 11;                   // number of bits for position in tracklet64 word

--- a/Detectors/TRD/qc/include/TRDQC/Tracking.h
+++ b/Detectors/TRD/qc/include/TRDQC/Tracking.h
@@ -44,13 +44,13 @@ namespace trd
 struct TrackQC {
   int type;          ///< 0 TPC-TRD track; 1 ITS-TPC-TRD track
   int nTracklets;    ///< number of attached TRD tracklets
-  int nLayers; //< Number of associated Layers of a Track
+  int nLayers;       //< Number of associated Layers of a Track
   float chi2;        ///< total chi2 value for the track
   float reducedChi2; ///< chi2 total divided by number of layers in which track is inside TRD geometrical acceptance
   float pt;          ///< the transverse momentum of the track at the point of the innermost ITS cluster (ITS-TPC-TRD) or at the inner TPC radius (TPC-TRD)
   float ptSigma2;    //< Sigma2 of pt
   track::PID pid;    //< assigned particle id from TPC
-  float phi; //< Phi 0:2Pi value of Track
+  float phi;         //< Phi 0:2Pi value of Track
 
   // layer-wise information for seeding track and assigned tracklet (if available)
   std::array<float, constants::NLAYER> findable{}; ///< flag if track was in geometrical acceptance

--- a/Detectors/TRD/qc/include/TRDQC/Tracking.h
+++ b/Detectors/TRD/qc/include/TRDQC/Tracking.h
@@ -58,18 +58,18 @@ struct TrackQC {
   std::array<float, constants::NLAYER> trackQpt{}; ///< q/pt of seeding track
 
   // tracklet position is also given in sector coordinates
-  std::array<float, constants::NLAYER> trackletYraw{};  ///< y-position of tracklet without tilt correction
-  std::array<float, constants::NLAYER> trackletZraw{};  ///< z-position of tracklet without tilt correction
-  std::array<float, constants::NLAYER> trackletY{};     ///< y-position of tracklet used for track update (including correction)
-  std::array<float, constants::NLAYER> trackletZ{};     ///< z-position of tracklet used for track update (including correction)
-  std::array<float, constants::NLAYER> trackletDy{};    ///< tracklet deflection over drift length obtained from CalibratedTracklet
-  std::array<int, constants::NLAYER> trackletSlope{};   ///< the raw slope from Tracklet64 (signed integer)
-  std::array<int, constants::NLAYER> trackletDet{};     ///< the chamber of the tracklet
+  std::array<float, constants::NLAYER> trackletYraw{}; ///< y-position of tracklet without tilt correction
+  std::array<float, constants::NLAYER> trackletZraw{}; ///< z-position of tracklet without tilt correction
+  std::array<float, constants::NLAYER> trackletY{};    ///< y-position of tracklet used for track update (including correction)
+  std::array<float, constants::NLAYER> trackletZ{};    ///< z-position of tracklet used for track update (including correction)
+  std::array<float, constants::NLAYER> trackletDy{};   ///< tracklet deflection over drift length obtained from CalibratedTracklet
+  std::array<int, constants::NLAYER> trackletSlope{};  ///< the raw slope from Tracklet64 (signed integer)
+  std::array<int, constants::NLAYER> trackletDet{};    ///< the chamber of the tracklet
   // some tracklet details to identify its global MCM number to check if it is from noisy MCM
-  std::array<int, constants::NLAYER> trackletHCId{};    ///< the half-chamber ID of the tracklet
-  std::array<int, constants::NLAYER> trackletRob{};     ///< the ROB number of the tracklet
-  std::array<int, constants::NLAYER> trackletMcm{};     ///< the MCM number of the tracklet
-  std::array<float, constants::NLAYER> trackletChi2{};  ///< estimated chi2 for the update of the track with the given tracklet
+  std::array<int, constants::NLAYER> trackletHCId{};   ///< the half-chamber ID of the tracklet
+  std::array<int, constants::NLAYER> trackletRob{};    ///< the ROB number of the tracklet
+  std::array<int, constants::NLAYER> trackletMcm{};    ///< the MCM number of the tracklet
+  std::array<float, constants::NLAYER> trackletChi2{}; ///< estimated chi2 for the update of the track with the given tracklet
   ClassDefNV(TrackQC, 1);
 };
 

--- a/Detectors/TRD/qc/include/TRDQC/Tracking.h
+++ b/Detectors/TRD/qc/include/TRDQC/Tracking.h
@@ -50,7 +50,6 @@ struct TrackQC {
   float pt;          ///< the transverse momentum of the track at the point of the innermost ITS cluster (ITS-TPC-TRD) or at the inner TPC radius (TPC-TRD)
   float ptSigma2;    //< Sigma2 of pt
   track::PID pid;    //< assigned particle id from TPC
-  float phi;         //< Phi 0:2Pi value of Track
 
   // layer-wise information for seeding track and assigned tracklet (if available)
   std::array<float, constants::NLAYER> findable{}; ///< flag if track was in geometrical acceptance
@@ -75,6 +74,8 @@ struct TrackQC {
   std::array<int, constants::NLAYER> trackletMcm{};                                      ///< the MCM number of the tracklet
   std::array<float, constants::NLAYER> trackletChi2{};                                   ///< estimated chi2 for the update of the track with the given tracklet
   std::array<std::array<int, constants::NCHARGES>, constants::NLAYER> trackletCharges{}; ///< charges of tracklets
+  std::array<float, constants::NLAYER> trackletPhi{};                                    //< Phi 0:2Pi value of Tracklet
+  std::array<float, constants::NLAYER> trackletEta{};                                    //< Eta value of Tracklet
   ClassDefNV(TrackQC, 1);
 };
 

--- a/Detectors/TRD/qc/include/TRDQC/Tracking.h
+++ b/Detectors/TRD/qc/include/TRDQC/Tracking.h
@@ -44,9 +44,13 @@ namespace trd
 struct TrackQC {
   int type;          ///< 0 TPC-TRD track; 1 ITS-TPC-TRD track
   int nTracklets;    ///< number of attached TRD tracklets
+  int nLayers; //< Number of associated Layers of a Track
   float chi2;        ///< total chi2 value for the track
   float reducedChi2; ///< chi2 total divided by number of layers in which track is inside TRD geometrical acceptance
   float pt;          ///< the transverse momentum of the track at the point of the innermost ITS cluster (ITS-TPC-TRD) or at the inner TPC radius (TPC-TRD)
+  float ptSigma2;    //< Sigma2 of pt
+  track::PID pid;    //< assigned particle id from TPC
+  float phi; //< Phi 0:2Pi value of Track
 
   // layer-wise information for seeding track and assigned tracklet (if available)
   std::array<float, constants::NLAYER> findable{}; ///< flag if track was in geometrical acceptance
@@ -66,10 +70,11 @@ struct TrackQC {
   std::array<int, constants::NLAYER> trackletSlope{};  ///< the raw slope from Tracklet64 (signed integer)
   std::array<int, constants::NLAYER> trackletDet{};    ///< the chamber of the tracklet
   // some tracklet details to identify its global MCM number to check if it is from noisy MCM
-  std::array<int, constants::NLAYER> trackletHCId{};   ///< the half-chamber ID of the tracklet
-  std::array<int, constants::NLAYER> trackletRob{};    ///< the ROB number of the tracklet
-  std::array<int, constants::NLAYER> trackletMcm{};    ///< the MCM number of the tracklet
-  std::array<float, constants::NLAYER> trackletChi2{}; ///< estimated chi2 for the update of the track with the given tracklet
+  std::array<int, constants::NLAYER> trackletHCId{};                                     ///< the half-chamber ID of the tracklet
+  std::array<int, constants::NLAYER> trackletRob{};                                      ///< the ROB number of the tracklet
+  std::array<int, constants::NLAYER> trackletMcm{};                                      ///< the MCM number of the tracklet
+  std::array<float, constants::NLAYER> trackletChi2{};                                   ///< estimated chi2 for the update of the track with the given tracklet
+  std::array<std::array<int, constants::NCHARGES>, constants::NLAYER> trackletCharges{}; ///< charges of tracklets
   ClassDefNV(TrackQC, 1);
 };
 

--- a/Detectors/TRD/qc/include/TRDQC/Tracking.h
+++ b/Detectors/TRD/qc/include/TRDQC/Tracking.h
@@ -59,6 +59,8 @@ struct TrackQC {
   std::array<float, constants::NLAYER> trackSnp{}; ///< sin(phi) of seeding track (sector coordinates -> local inclination in r-phi)
   std::array<float, constants::NLAYER> trackTgl{}; ///< tan(lambda) of seeding track (inclination in s_xy-z plane)
   std::array<float, constants::NLAYER> trackQpt{}; ///< q/pt of seeding track
+  std::array<float, constants::NLAYER> trackPhi{}; //< Phi 0:2Pi value of Track
+  std::array<float, constants::NLAYER> trackEta{}; //< Eta value of Track
 
   // tracklet position is also given in sector coordinates
   std::array<float, constants::NLAYER> trackletYraw{}; ///< y-position of tracklet without tilt correction
@@ -74,8 +76,6 @@ struct TrackQC {
   std::array<int, constants::NLAYER> trackletMcm{};                                      ///< the MCM number of the tracklet
   std::array<float, constants::NLAYER> trackletChi2{};                                   ///< estimated chi2 for the update of the track with the given tracklet
   std::array<std::array<int, constants::NCHARGES>, constants::NLAYER> trackletCharges{}; ///< charges of tracklets
-  std::array<float, constants::NLAYER> trackletPhi{};                                    //< Phi 0:2Pi value of Tracklet
-  std::array<float, constants::NLAYER> trackletEta{};                                    //< Eta value of Tracklet
   ClassDefNV(TrackQC, 1);
 };
 

--- a/Detectors/TRD/qc/include/TRDQC/Tracking.h
+++ b/Detectors/TRD/qc/include/TRDQC/Tracking.h
@@ -44,7 +44,7 @@ namespace trd
 struct TrackQC {
   int type;          ///< 0 TPC-TRD track; 1 ITS-TPC-TRD track
   int nTracklets;    ///< number of attached TRD tracklets
-  int nLayers;       //< Number of associated Layers of a Track
+  int nLayers;       //< Number of Layers of a Track in which the track extrapolation was in geometrical acceptance of the TRD
   float chi2;        ///< total chi2 value for the track
   float reducedChi2; ///< chi2 total divided by number of layers in which track is inside TRD geometrical acceptance
   float pt;          ///< the transverse momentum of the track at the point of the innermost ITS cluster (ITS-TPC-TRD) or at the inner TPC radius (TPC-TRD)

--- a/Detectors/TRD/qc/src/Tracking.cxx
+++ b/Detectors/TRD/qc/src/Tracking.cxx
@@ -60,7 +60,7 @@ void Tracking::checkTrack(const TrackTRD& trkTrd, bool isTPCTRD)
   qcStruct.reducedChi2 = trkTrd.getReducedChi2();
   qcStruct.pt = trkTrd.getPt();
   qcStruct.ptSigma2 = trkTrd.getSigma1Pt2();
-  qcStruct.phi = trkTrd.getPhi();
+  qcStruct.pid = trkTrd.getPID();
 
   LOGF(debug, "Got track with %i tracklets and ID %i", trkTrd.getNtracklets(), trkTrd.getRefGlobalTrackId());
   const auto& trkSeed = isTPCTRD ? mTracksTPC[trkTrd.getRefGlobalTrackId()].getParamOut() : mTracksITSTPC[trkTrd.getRefGlobalTrackId()].getParamOut();
@@ -120,7 +120,8 @@ void Tracking::checkTrack(const TrackTRD& trkTrd, bool isTPCTRD)
       mTrackletsRaw[trkltId].getQ1(),
       mTrackletsRaw[trkltId].getQ2(),
     };
-    qcStruct.pid = trk.getPID();
+    qcStruct.trackletPhi[iLayer] = trk.getPhi();
+    qcStruct.trackletEta[iLayer] = trk.getEta();
   }
   mTrackQC.push_back(qcStruct);
 }

--- a/Detectors/TRD/qc/src/Tracking.cxx
+++ b/Detectors/TRD/qc/src/Tracking.cxx
@@ -55,9 +55,12 @@ void Tracking::checkTrack(const TrackTRD& trkTrd, bool isTPCTRD)
   TrackQC qcStruct;
   qcStruct.type = isTPCTRD ? 0 : 1;
   qcStruct.nTracklets = trkTrd.getNtracklets();
+  qcStruct.nLayers = trkTrd.getNlayersFindable();
   qcStruct.chi2 = trkTrd.getChi2();
   qcStruct.reducedChi2 = trkTrd.getReducedChi2();
   qcStruct.pt = trkTrd.getPt();
+  qcStruct.ptSigma2 = trkTrd.getSigma1Pt2();
+  qcStruct.phi = trkTrd.getPhi();
 
   LOGF(debug, "Got track with %i tracklets and ID %i", trkTrd.getNtracklets(), trkTrd.getRefGlobalTrackId());
   const auto& trkSeed = isTPCTRD ? mTracksTPC[trkTrd.getRefGlobalTrackId()].getParamOut() : mTracksITSTPC[trkTrd.getRefGlobalTrackId()].getParamOut();
@@ -112,6 +115,12 @@ void Tracking::checkTrack(const TrackTRD& trkTrd, bool isTPCTRD)
     qcStruct.trackletRob[iLayer] = mTrackletsRaw[trkltId].getROB();
     qcStruct.trackletMcm[iLayer] = mTrackletsRaw[trkltId].getMCM();
     qcStruct.trackletChi2[iLayer] = chi2trklt;
+    qcStruct.trackletCharges[iLayer] = {
+      mTrackletsRaw[trkltId].getQ0(),
+      mTrackletsRaw[trkltId].getQ1(),
+      mTrackletsRaw[trkltId].getQ2(),
+    };
+    qcStruct.pid = trk.getPID();
   }
   mTrackQC.push_back(qcStruct);
 }

--- a/Detectors/TRD/qc/src/Tracking.cxx
+++ b/Detectors/TRD/qc/src/Tracking.cxx
@@ -104,6 +104,8 @@ void Tracking::checkTrack(const TrackTRD& trkTrd, bool isTPCTRD)
     qcStruct.trackSnp[iLayer] = trk.getSnp();
     qcStruct.trackTgl[iLayer] = trk.getTgl();
     qcStruct.trackQpt[iLayer] = trk.getQ2Pt();
+    qcStruct.trackPhi[iLayer] = trk.getPhi();
+    qcStruct.trackEta[iLayer] = trk.getEta();
     qcStruct.trackletYraw[iLayer] = mTrackletsCalib[trkltId].getY();
     qcStruct.trackletZraw[iLayer] = mTrackletsCalib[trkltId].getZ();
     qcStruct.trackletY[iLayer] = trkltPosUp[0];
@@ -120,8 +122,6 @@ void Tracking::checkTrack(const TrackTRD& trkTrd, bool isTPCTRD)
       mTrackletsRaw[trkltId].getQ1(),
       mTrackletsRaw[trkltId].getQ2(),
     };
-    qcStruct.trackletPhi[iLayer] = trk.getPhi();
-    qcStruct.trackletEta[iLayer] = trk.getEta();
   }
   mTrackQC.push_back(qcStruct);
 }


### PR DESCRIPTION
As preliminary parameters for my thesis, I added some Track parameters to the QC workflow.
I need the charges for each layer, the momentum, the number of layers in which matching tracklets have been found.
Additionally I will start my analysis using the TPC PID, but will later look at specific decays.

Also I ran clang-format on the relevant files