### PR TITLE
[EMCAL-778] Implementation of LM-L0 delay in BC

### DIFF
--- a/Detectors/EMCAL/simulation/CMakeLists.txt
+++ b/Detectors/EMCAL/simulation/CMakeLists.txt
@@ -13,7 +13,7 @@ o2_add_library(EMCALSimulation
                SOURCES src/Detector.cxx src/Digitizer.cxx src/SDigitizer.cxx
                        src/DigitsWriteoutBuffer.cxx src/DigitsVectorStream.cxx src/SpaceFrame.cxx src/SimParam.cxx
                        src/LabeledDigit.cxx src/RawWriter.cxx
-               PUBLIC_LINK_LIBRARIES O2::EMCALBase O2::DetectorsBase O2::SimConfig O2::SimulationDataFormat O2::Headers O2::DetectorsRaw O2::EMCALReconstruction)
+               PUBLIC_LINK_LIBRARIES O2::EMCALBase O2::DetectorsBase O2::SimConfig O2::SimulationDataFormat O2::Headers O2::DetectorsRaw O2::EMCALReconstruction O2::DataFormatsCTP)
 
 o2_target_root_dictionary(EMCALSimulation
                           HEADERS include/EMCALSimulation/Detector.h

--- a/Detectors/EMCAL/simulation/src/RawWriter.cxx
+++ b/Detectors/EMCAL/simulation/src/RawWriter.cxx
@@ -14,6 +14,7 @@
 #include <fmt/core.h>
 #include <gsl/span>
 #include <TSystem.h>
+#include "DataFormatsCTP/TriggerOffsetsParam.h"
 #include "DataFormatsEMCAL/Constants.h"
 #include "EMCALBase/Geometry.h"
 #include "EMCALBase/RCUTrailer.h"
@@ -152,7 +153,7 @@ bool RawWriter::processTrigger(const o2::emcal::TriggerRecord& trg)
     auto ddlid = srucont.mSRUid;
     auto [crorc, link] = mGeometry->getLinkAssignment(ddlid);
     LOG(debug1) << "Adding payload with size " << payload.size() << " (" << payload.size() / 4 << " ALTRO words)";
-    mRawWriter->addData(ddlid, crorc, link, 0, trg.getBCData(), payload, false, trg.getTriggerBits());
+    mRawWriter->addData(ddlid, crorc, link, 0, trg.getBCData() + o2::ctp::TriggerOffsetsParam::Instance().LM_L0, payload, false, trg.getTriggerBits());
   }
   LOG(debug) << "Done";
   return true;


### PR DESCRIPTION
The delay of the L0 (observed BC by FEE) with respect to LM (true BC of the collision) needs to be implemented in the raw creator. For more information see https://alice.its.cern.ch/jira/browse/CTP-133.