### PR TITLE
DPL Analysis: Cached slicing pre-declaration, API

### DIFF
--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -642,7 +642,6 @@ struct Partition {
     return mFiltered->size();
   }
 };
-
 } // namespace o2::framework
 
 namespace o2::soa

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -566,6 +566,37 @@ struct IndexManager<Builds<IDX>> {
   }
 };
 
+/// Manager template to handle slice caching
+template <typename T>
+struct PresliceManager {
+  template <typename T1>
+  static bool processTable(T&, T1&)
+  {
+    return false;
+  }
+
+  static bool setNewDF(T&) { return false; };
+};
+
+template <typename T>
+struct PresliceManager<Preslice<T>> {
+  template <typename T1>
+  static bool processTable(Preslice<T>& container, T1& table)
+  {
+    if constexpr (o2::soa::is_binding_compatible_v<T, T1>()) {
+      auto status = o2::framework::getSlices(container.index.name, table.asArrowTable(), container.mValues, container.mCounts);
+      return status.ok();
+    } else {
+      return false;
+    }
+  }
+
+  static bool setNewDF(Preslice<T>& container)
+  {
+    container.setNewDF();
+    return true;
+  }
+};
 } // namespace o2::framework
 
 #endif // ANALYSISMANAGERS_H

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -361,7 +361,7 @@ struct AnalysisDataProcessorBuilder {
       } else {
         // non-grouping case
         // pre-slice associated tables
-        std::apply([](auto&... x) {
+        std::apply([&presliceTable](auto&... x) {
           (presliceTable(x), ...);
         },
                    associatedTables);

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -260,6 +260,15 @@ struct AnalysisDataProcessorBuilder {
     using G = std::decay_t<Grouping>;
     auto groupingTable = AnalysisDataProcessorBuilder::bindGroupingTable(inputs, processingFunction, infos);
 
+    auto presliceTable = [&task](auto& table) {
+      homogeneous_apply_refs([&table](auto& x) {
+        return PresliceManager<std::decay_t<decltype(x)>>::processTable(x, table);
+      },
+                             task);
+    };
+    // pre-slice grouping table if required
+    presliceTable(groupingTable);
+
     // set filtered tables for partitions with grouping
     homogeneous_apply_refs([&groupingTable](auto& x) {
       PartitionManager<std::decay_t<decltype(x)>>::setPartition(x, groupingTable);
@@ -351,6 +360,12 @@ struct AnalysisDataProcessorBuilder {
         }
       } else {
         // non-grouping case
+        // pre-slice associated tables
+        std::apply([](auto&... x) {
+          (presliceTable(x), ...);
+        },
+                   associatedTables);
+
         overwriteInternalIndices(associatedTables, associatedTables);
         // bind partitions and grouping table
         homogeneous_apply_refs([&groupingTable](auto& x) {
@@ -615,13 +630,19 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
       for (auto& info : expressionInfos) {
         info.resetSelection = true;
       }
+      // reset pre-slice for the next dataframe
+      homogeneous_apply_refs([](auto& x) { return PresliceManager<std::decay_t<decltype(x)>>::setNewDF(x); }, *(task.get()));
+      // prepare outputs
       homogeneous_apply_refs([&pc](auto&& x) { return OutputManager<std::decay_t<decltype(x)>>::prepare(pc, x); }, *task.get());
+      // execute run()
       if constexpr (has_run_v<T>) {
         task->run(pc);
       }
+      // execture process()
       if constexpr (has_process_v<T>) {
         AnalysisDataProcessorBuilder::invokeProcess(*(task.get()), pc.inputs(), &T::process, expressionInfos);
       }
+      // execute optional process()
       homogeneous_apply_refs(
         [&pc, &expressionInfos, &task](auto& x) mutable {
           if constexpr (is_base_of_template<ProcessConfigurable, std::decay_t<decltype(x)>>::value) {
@@ -633,7 +654,7 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
           return false;
         },
         *task.get());
-
+      // finalize outputs
       homogeneous_apply_refs([&pc](auto&& x) { return OutputManager<std::decay_t<decltype(x)>>::finalize(pc, x); }, *task.get());
     };
   }};

--- a/Framework/Core/test/test_ASoA.cxx
+++ b/Framework/Core/test/test_ASoA.cxx
@@ -912,6 +912,8 @@ BOOST_AUTO_TEST_CASE(TestListColumns)
 
 BOOST_AUTO_TEST_CASE(TestSliceBy)
 {
+  o2::framework::Preslice<References> slices = test::originId;
+  slices.setNewDF();
   TableBuilder b;
   auto writer = b.cursor<Origins>();
   for (auto i = 0; i < 20; ++i) {
@@ -931,11 +933,17 @@ BOOST_AUTO_TEST_CASE(TestSliceBy)
   }
   auto refs = w.finalize();
   References r{refs};
+  auto status = slices.processTable(refs);
 
   for (auto& oi : o) {
     auto slice = r.sliceBy(test::originId, oi.globalIndex());
+    auto cachedSlice = r.sliceBy(slices, oi.globalIndex());
     BOOST_CHECK_EQUAL(slice.size(), 5);
+    BOOST_CHECK_EQUAL(cachedSlice.size(), 5);
     for (auto& ri : slice) {
+      BOOST_CHECK_EQUAL(ri.originId(), oi.globalIndex());
+    }
+    for (auto& ri : cachedSlice) {
       BOOST_CHECK_EQUAL(ri.originId(), oi.globalIndex());
     }
   }


### PR DESCRIPTION
* Introduce `Preslice<Table> = column;` declaration to create a managed slice cache in the analysis task
* Introduce new `sliceBy()` method, using `Preslice<>` as an argument

The deprecated non-cached slicing method will be removed after updating O2Physics to use cached version.