### PR TITLE
[EMCAL-711] Add subspecification to decoding error object

### DIFF
--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/ErrorTypeFEE.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/ErrorTypeFEE.h
@@ -66,7 +66,8 @@ class ErrorTypeFEE
   /// \param FEEID ID of the FEE responsible for the error
   /// \param errortype Type of the error
   /// \param errorCode Error code for the given error type
-  ErrorTypeFEE(int FEEID, ErrorSource_t errortype, int errorCode) : mFEEID(FEEID), mErrorSource(errortype), mErrorCode(errorCode) {}
+  /// \param subspec Subspecification of the error (i.e. FEC ID)
+  ErrorTypeFEE(int FEEID, ErrorSource_t errortype, int errorCode, int subspec) : mFEEID(FEEID), mErrorSource(errortype), mErrorCode(errorCode), mSubspecification(subspec) {}
 
   /// \brief Destructor
   ~ErrorTypeFEE() = default;
@@ -112,6 +113,10 @@ class ErrorTypeFEE
     setErrorCode(errorcode);
   }
 
+  /// \brief Set the subspecification of the error
+  /// \param subspec Subspecification of the error
+  void setSubspecification(int subspec) { mSubspecification = subspec; }
+
   /// \brief Get the FEE ID of the electronics responsible for the error
   /// \return ID of the FEE component
   int getFEEID() const { return mFEEID; }
@@ -144,6 +149,10 @@ class ErrorTypeFEE
   /// \return Error code (-1 in case the object is not a gain type error)
   int getGainTypeErrorType() const { return getRawErrorForType(ErrorSource_t::GAIN_ERROR); }
 
+  /// \brief Get subspecification of the error
+  /// \return Subspecification of the error
+  int getSubspecification() const { return mSubspecification; }
+
   /// \brief Printing information of the error type
   /// \param stream Output stream where to print the error
   ///
@@ -158,6 +167,7 @@ class ErrorTypeFEE
   int mFEEID = -1;                                       ///< FEE ID of the SM responsible for the error
   ErrorSource_t mErrorSource = ErrorSource_t::UNDEFINED; ///< Source of the error
   int mErrorCode = -1;                                   ///< Raw page error type
+  int mSubspecification;                                 ///< Subspecification
 
   ClassDefNV(ErrorTypeFEE, 1);
 };

--- a/DataFormats/Detectors/EMCAL/src/ErrorTypeFEE.cxx
+++ b/DataFormats/Detectors/EMCAL/src/ErrorTypeFEE.cxx
@@ -44,6 +44,9 @@ void ErrorTypeFEE::PrintStream(std::ostream& stream) const
       break;
   };
   stream << "EMCAL SM: " << getFEEID() << ", " << typestring << " Type: " << getErrorCode();
+  if (mSubspecification >= 0) {
+    stream << ", Subspecification: " << mSubspecification;
+  }
 }
 
 std::ostream& operator<<(std::ostream& stream, const ErrorTypeFEE& error)

--- a/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
@@ -151,7 +151,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
         rawreader.next();
       } catch (RawDecodingError& e) {
         if (mCreateRawDataErrors) {
-          mOutputDecoderErrors.emplace_back(e.getFECID(), ErrorTypeFEE::ErrorSource_t::PAGE_ERROR, RawDecodingError::ErrorTypeToInt(e.getErrorType()));
+          mOutputDecoderErrors.emplace_back(e.getFECID(), ErrorTypeFEE::ErrorSource_t::PAGE_ERROR, RawDecodingError::ErrorTypeToInt(e.getErrorType()), -1);
         }
         if (mNumErrorMessages < mMaxErrorMessages) {
           LOG(alarm) << " Page decoding: " << e.what() << " in FEE ID " << e.getFECID() << std::endl;
@@ -248,7 +248,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
         }
         if (mCreateRawDataErrors) {
           // fill histograms  with error types
-          ErrorTypeFEE errornum(feeID, ErrorTypeFEE::ErrorSource_t::ALTRO_ERROR, AltroDecoderError::errorTypeToInt(e.getErrorType()));
+          ErrorTypeFEE errornum(feeID, ErrorTypeFEE::ErrorSource_t::ALTRO_ERROR, AltroDecoderError::errorTypeToInt(e.getErrorType()), -1);
           mOutputDecoderErrors.push_back(errornum);
         }
         continue;
@@ -264,7 +264,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
           } else {
             mErrorMessagesSuppressed++;
           }
-          ErrorTypeFEE errornum(feeID, ErrorTypeFEE::ErrorSource_t::ALTRO_ERROR, MinorAltroDecodingError::errorTypeToInt(minorerror.getErrorType()));
+          ErrorTypeFEE errornum(feeID, ErrorTypeFEE::ErrorSource_t::ALTRO_ERROR, MinorAltroDecodingError::errorTypeToInt(minorerror.getErrorType()), -1);
           mOutputDecoderErrors.push_back(errornum);
         }
       }
@@ -349,7 +349,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
               mErrorMessagesSuppressed++;
             }
             if (mCreateRawDataErrors) {
-              mOutputDecoderErrors.emplace_back(feeID, ErrorTypeFEE::ErrorSource_t::GEOMETRY_ERROR, 0); // 0 -> Cell ID out of range
+              mOutputDecoderErrors.emplace_back(feeID, ErrorTypeFEE::ErrorSource_t::GEOMETRY_ERROR, 0, CellID); // 0 -> Cell ID out of range
             }
             continue;
           }
@@ -379,7 +379,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
               mErrorMessagesSuppressed++;
             }
             if (mCreateRawDataErrors) {
-              mOutputDecoderErrors.emplace_back(feeID, ErrorTypeFEE::ErrorSource_t::GEOMETRY_ERROR, -1); // Geometry error codes will start from 100
+              mOutputDecoderErrors.emplace_back(feeID, ErrorTypeFEE::ErrorSource_t::GEOMETRY_ERROR, 2, CellID); // Geometry error codes will start from 100
             }
             continue;
           }
@@ -484,7 +484,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
               nBunchesNotOK++;
             }
             if (mCreateRawDataErrors) {
-              mOutputDecoderErrors.emplace_back(feeID, ErrorTypeFEE::ErrorSource_t::FIT_ERROR, CaloRawFitter::getErrorNumber(fiterror));
+              mOutputDecoderErrors.emplace_back(feeID, ErrorTypeFEE::ErrorSource_t::FIT_ERROR, CaloRawFitter::getErrorNumber(fiterror), CellID);
             }
           }
         }
@@ -498,7 +498,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
           }
         }
         if (mCreateRawDataErrors) {
-          mOutputDecoderErrors.emplace_back(feeID, ErrorTypeFEE::ErrorSource_t::ALTRO_ERROR, AltroDecoderError::errorTypeToInt(AltroDecoderError::ErrorType_t::ALTRO_MAPPING_ERROR));
+          mOutputDecoderErrors.emplace_back(feeID, ErrorTypeFEE::ErrorSource_t::ALTRO_ERROR, AltroDecoderError::errorTypeToInt(AltroDecoderError::ErrorType_t::ALTRO_MAPPING_ERROR), -1);
         }
       }
     }
@@ -524,7 +524,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
             mErrorMessagesSuppressed++;
           }
           if (mCreateRawDataErrors) {
-            mOutputDecoderErrors.emplace_back(cell.mFecID, ErrorTypeFEE::GAIN_ERROR, 0);
+            mOutputDecoderErrors.emplace_back(cell.mFecID, ErrorTypeFEE::GAIN_ERROR, 0, cell.mFecID);
           }
           continue;
         }
@@ -539,7 +539,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
             mErrorMessagesSuppressed++;
           }
           if (mCreateRawDataErrors) {
-            mOutputDecoderErrors.emplace_back(cell.mFecID, ErrorTypeFEE::GAIN_ERROR, 1);
+            mOutputDecoderErrors.emplace_back(cell.mFecID, ErrorTypeFEE::GAIN_ERROR, 1, cell.mFecID);
           }
           continue;
         }


### PR DESCRIPTION
To be used for i.e. cell ID or FEC ID