### PR TITLE
Misc. fixes

### DIFF
--- a/Detectors/Raw/src/RawFileReaderWorkflow.cxx
+++ b/Detectors/Raw/src/RawFileReaderWorkflow.cxx
@@ -151,6 +151,9 @@ void RawReaderSpecs::init(o2f::InitContext& ic)
     hbfU.setValue("HBFUtils.startTime", std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count()));
     LOG(warning) << "Run start time is not provided via HBFUtils.startTime, will use now() = " << hbfU.startTime << " ms.";
   }
+  if (mRunNumber == 0 && hbfU.runNumber > 0) {
+    mRunNumber = hbfU.runNumber;
+  }
 }
 
 //___________________________________________________________

--- a/Framework/Core/src/CallbacksPolicy.cxx
+++ b/Framework/Core/src/CallbacksPolicy.cxx
@@ -35,16 +35,16 @@ CallbacksPolicy epnProcessReporting()
         auto& info = registry.get<TimingInfo>();
         if ((int)info.firstTFOrbit != -1) {
           char const* what = (info.timeslice > 1652945069870351) ? "timer" : "timeslice";
-          LOGP(info, "Processing {}:{}, tfCounter:{}, firstTFOrbit:{}, creation:{}, action:{}",
-               what, info.timeslice, info.tfCounter, info.firstTFOrbit, info.creation, op);
+          LOGP(info, "Processing {}:{}, tfCounter:{}, firstTFOrbit:{}, runNumber:{}, creation:{}, action:{}",
+               what, info.timeslice, info.tfCounter, info.firstTFOrbit, info.runNumber, info.creation, op);
         }
       });
       callbacks.set(CallbackService::Id::PostProcessing, [](ServiceRegistry& registry, int op) {
         auto& info = registry.get<TimingInfo>();
         if ((int)info.firstTFOrbit != -1) {
           char const* what = (info.timeslice > 1652945069870351) ? "timer" : "timeslice";
-          LOGP(info, "Done processing {}:{}, tfCounter:{}, firstTFOrbit:{}, creation:{}, action:{}",
-               what, info.timeslice, info.tfCounter, info.firstTFOrbit, info.creation, op);
+          LOGP(info, "Done processing {}:{}, tfCounter:{}, firstTFOrbit:{}, runNumber:{}, creation:{}, action:{}",
+               what, info.timeslice, info.tfCounter, info.firstTFOrbit, info.runNumber, info.creation, op);
         }
       });
     }};


### PR DESCRIPTION
* Show run number in the TF processing report
* raw-file-reader uses HBFUtils.runNumber if allowed
* produce alarm in case of unknown response_code from curl