### PR TITLE
[WIP] TRD fix XOR handling of tracklet word

### DIFF
--- a/Detectors/TRD/simulation/src/Trap2CRU.cxx
+++ b/Detectors/TRD/simulation/src/Trap2CRU.cxx
@@ -112,7 +112,7 @@ Trap2CRU::Trap2CRU(const std::string& outputDir, const std::string& inputdigitsf
 void Trap2CRU::openInputFiles()
 {
   mDigitsFile = TFile::Open(mInputDigitsFileName.data());
-  if (mDigitsFile != nullptr) {
+  if (mDigitsFile != nullptr && !mDigitsFile->IsZombie()) {
     mDigitsTree = (TTree*)mDigitsFile->Get("o2sim");
     mDigitsTree->SetBranchAddress("TRDDigit", &mDigitsPtr);                   // the branch with the actual digits
     mDigitsTree->SetBranchAddress("TriggerRecord", &mDigitTriggerRecordsPtr); // branch with trigger records for digits
@@ -120,7 +120,7 @@ void Trap2CRU::openInputFiles()
     LOG(warn) << " cant open file containing digit tree";
   }
   mTrackletsFile = TFile::Open(mInputTrackletsFileName.data());
-  if (mTrackletsFile != nullptr) {
+  if (mTrackletsFile != nullptr && !mTrackletsFile->IsZombie()) {
     mTrackletsTree = (TTree*)mTrackletsFile->Get("o2sim");
     mTrackletsTree->SetBranchAddress("Tracklet", &mTrackletsPtr);              // the branch with the actual tracklets.
     mTrackletsTree->SetBranchAddress("TrackTrg", &mTrackletTriggerRecordsPtr); // branch with trigger records for digits


### PR DESCRIPTION
With this change the Tracklet64 class is expected to always store the position and slope without any inverted bits. The XOR takes place in 2 places now:
1) When the raw reader creates the Tracklet64 which are stored in the CTFs it applies the XOR
2) Within the Sim->Raw conversion used for creating synthetic data sets the XOR is applied to the simulated Tracklet64 before the the raw data is created.

That way we don't need to worry at all inside reconstruction, calibration or QC about flipping bits.

I have added an option to the tracklet transformer to apply the XOR. This would only be needed for reprocessing the CTFs from the pilot beam in 2021. Any data taken after cb42172601cd4bc43764894cb457eec837039b28 was merged in January will have the bit flip corrected position and slope stored in the Tracklet64