### PR TITLE
TRD XOR cleanup

### DIFF
--- a/DataFormats/Detectors/TRD/src/RawData.cxx
+++ b/DataFormats/Detectors/TRD/src/RawData.cxx
@@ -68,9 +68,11 @@ uint16_t buildTRDFeeID(int supermodule, int side, int endpoint)
 
 void buildTrackletMCMData(TrackletMCMData& trackletword, const uint slope, const uint pos, const uint q0, const uint q1, const uint q2)
 {
+  // create a tracklet word as it would be sent from the FEE
+  // slope and position have the 8-th bit flipped each
   trackletword.word = 0;
-  trackletword.slope = slope;
-  trackletword.pos = pos;
+  trackletword.slope = slope ^ 0x80;
+  trackletword.pos = pos ^ 0x80;
   trackletword.pid = (q0 & 0x7f) & ((q1 & 0x1f) << 7); //q2 sits with upper 2 bits of q1 in the header pid word, hence the 0x1f so 5 bits are used here.
   trackletword.checkbit = 1;
 }

--- a/Detectors/TRD/base/include/TRDBase/TrackletTransformer.h
+++ b/Detectors/TRD/base/include/TRDBase/TrackletTransformer.h
@@ -41,6 +41,7 @@ class TrackletTransformer
   void setXtb0(float x) { mXtb0 = x; }
 
   void setCalVdriftExB(const CalVdriftExB* cal) { mCalVdriftExB = cal; };
+  void setApplyXOR() { mApplyXOR = true; }
 
   float calculateY(int hcid, int column, int position);
 
@@ -59,6 +60,7 @@ class TrackletTransformer
  private:
   Geometry* mGeo{nullptr};
   const PadPlane* mPadPlane{nullptr};
+  bool mApplyXOR{false};
 
   float mXCathode;
   float mXAnode;

--- a/Detectors/TRD/base/src/TrackletTransformer.cxx
+++ b/Detectors/TRD/base/src/TrackletTransformer.cxx
@@ -10,6 +10,7 @@
 // or submit itself to any jurisdiction.
 
 #include "DetectorsBase/GeometryManager.h"
+#include "DataFormatsTRD/Constants.h"
 #include "TRDBase/TrackletTransformer.h"
 #include "TMath.h"
 
@@ -98,8 +99,21 @@ CalibratedTracklet TrackletTransformer::transformTracklet(Tracklet64 tracklet)
   auto hcid = tracklet.getHCID();
   auto padrow = tracklet.getPadRow();
   auto column = tracklet.getColumn();
-  auto position = tracklet.getPositionBinSigned();
-  auto slope = tracklet.getSlopeBinSigned();
+  int position;
+  int slope;
+  if (mApplyXOR) {
+    position = tracklet.getPosition() ^ 0x80;
+    if (position & (1 << (constants::NBITSTRKLPOS - 1))) {
+      position = -((~(position - 1)) & ((1 << constants::NBITSTRKLPOS) - 1));
+    }
+    slope = tracklet.getSlope() ^ 0x80;
+    if (slope & (1 << (constants::NBITSTRKLSLOPE - 1))) {
+      slope = -((~(slope - 1)) & ((1 << constants::NBITSTRKLSLOPE) - 1));
+    }
+  } else {
+    position = tracklet.getPositionBinSigned();
+    slope = tracklet.getSlopeBinSigned();
+  }
 
   // calculate raw local chamber space point
   mPadPlane = mGeo->getPadPlane(detector);

--- a/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
+++ b/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
@@ -308,6 +308,11 @@ int TrackletsParser::Parse()
             int col = mTrackletMCMHeader->col;
             int pos = mTrackletMCMData->pos;
             int slope = mTrackletMCMData->slope;
+            // The 8-th bit of position and slope are always flipped in the FEE.
+            // We flip them back while reading the raw data so that they are stored
+            // without flipped bits in the CTFs
+            pos = pos ^ 0x80;
+            slope = slope ^ 0x80;
             int hcid = mDetector * 2 + mHalfChamberSide;
             if (mHeaderVerbose) {
               if (mTrackletHCHeaderState) {

--- a/Detectors/TRD/simulation/src/TrapSimulator.cxx
+++ b/Detectors/TRD/simulation/src/TrapSimulator.cxx
@@ -1796,7 +1796,6 @@ void TrapSimulator::fitTracklet()
           // prepare 64 bit tracklet word directly
           uint64_t trkltWord64 = mTrkltWordEmpty;
           trkltWord64 |= (static_cast<uint64_t>(position & 0x7ff) << Tracklet64::posbs) | (static_cast<uint64_t>(slope & 0xff) << Tracklet64::slopebs) | (q2 << Tracklet64::Q2bs) | (q1 << Tracklet64::Q1bs) | q0;
-          trkltWord64 ^= 0x8080000000UL; // two bits are inverted in before the tracklet is sent / stored
           mTrackletArray64.emplace_back(trkltWord64);
 
           // calculate number of hits and MC label

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrackletTransformerSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrackletTransformerSpec.h
@@ -23,7 +23,7 @@ namespace trd
 class TRDTrackletTransformerSpec : public o2::framework::Task
 {
  public:
-  TRDTrackletTransformerSpec(std::shared_ptr<o2::globaltracking::DataRequest> dataRequest, bool trigRecFilterActive) : mDataRequest(dataRequest), mTrigRecFilterActive(trigRecFilterActive){};
+  TRDTrackletTransformerSpec(std::shared_ptr<o2::globaltracking::DataRequest> dataRequest, bool trigRecFilterActive, bool applyXOR) : mDataRequest(dataRequest), mTrigRecFilterActive(trigRecFilterActive), mApplyXOR(applyXOR){};
   ~TRDTrackletTransformerSpec() override = default;
   void init(o2::framework::InitContext& ic) override;
   void run(o2::framework::ProcessingContext& pc) override;
@@ -34,10 +34,11 @@ class TRDTrackletTransformerSpec : public o2::framework::Task
 
   std::shared_ptr<o2::globaltracking::DataRequest> mDataRequest;
   bool mTrigRecFilterActive; ///< if true, transform only TRD tracklets for which ITS data is available
+  bool mApplyXOR;            ///< if true, the 8-th bit of position and slope will be inverted before transformation in chamber coordinates
   TrackletTransformer mTransformer;
 };
 
-o2::framework::DataProcessorSpec getTRDTrackletTransformerSpec(bool trigRecFilterActive);
+o2::framework::DataProcessorSpec getTRDTrackletTransformerSpec(bool trigRecFilterActive, bool applyXOR);
 
 } // end namespace trd
 } // end namespace o2

--- a/Detectors/TRD/workflow/src/TRDTrackletTransformerSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrackletTransformerSpec.cxx
@@ -30,6 +30,9 @@ namespace trd
 void TRDTrackletTransformerSpec::init(o2::framework::InitContext& ic)
 {
   mTransformer.init();
+  if (mApplyXOR) {
+    mTransformer.setApplyXOR();
+  }
 }
 
 void TRDTrackletTransformerSpec::run(o2::framework::ProcessingContext& pc)
@@ -126,7 +129,7 @@ void TRDTrackletTransformerSpec::finaliseCCDB(ConcreteDataMatcher& matcher, void
   }
 }
 
-o2::framework::DataProcessorSpec getTRDTrackletTransformerSpec(bool trigRecFilterActive)
+o2::framework::DataProcessorSpec getTRDTrackletTransformerSpec(bool trigRecFilterActive, bool applyXOR)
 {
   std::shared_ptr<DataRequest> dataRequest = std::make_shared<DataRequest>();
   if (trigRecFilterActive) {
@@ -145,7 +148,7 @@ o2::framework::DataProcessorSpec getTRDTrackletTransformerSpec(bool trigRecFilte
     "TRDTRACKLETTRANSFORMER",
     inputs,
     outputs,
-    AlgorithmSpec{adaptFromTask<TRDTrackletTransformerSpec>(dataRequest, trigRecFilterActive)},
+    AlgorithmSpec{adaptFromTask<TRDTrackletTransformerSpec>(dataRequest, trigRecFilterActive, applyXOR)},
     Options{}};
 }
 

--- a/Detectors/TRD/workflow/src/TRDTrackletTransformerWorkflow.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrackletTransformerWorkflow.cxx
@@ -38,6 +38,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input reader"}},
     {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writer"}},
     {"filter-trigrec", o2::framework::VariantType::Bool, false, {"ignore interaction records without ITS data"}},
+    {"apply-xor", o2::framework::VariantType::Bool, false, {"flip the 8-th bit of slope and position (for processing CTFs from 2021 pilot beam)"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
   o2::raw::HBFUtilsInitializer::addConfigOption(workflowOptions);
   std::swap(workflowOptions, options);
@@ -54,6 +55,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   // in case ROOT output is requested the tracklet labels are duplicated
   bool useMC = !configcontext.options().get<bool>("disable-mc");
 
+  auto applyXOR = configcontext.options().get<bool>("apply-xor");
+
   WorkflowSpec spec;
 
   if (!configcontext.options().get<bool>("disable-root-input")) {
@@ -65,7 +68,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     o2::globaltracking::InputHelper::addInputSpecsIRFramesITS(configcontext, spec);
   }
 
-  spec.emplace_back(o2::trd::getTRDTrackletTransformerSpec(trigRecFilterActive));
+  spec.emplace_back(o2::trd::getTRDTrackletTransformerSpec(trigRecFilterActive, applyXOR));
 
   if (!configcontext.options().get<bool>("disable-root-output")) {
     spec.emplace_back(o2::trd::getTRDCalibratedTrackletWriterSpec(useMC));


### PR DESCRIPTION
By adding the bit flipping to the constructor of Tracklet64 and the getters for position and slope in January I created a big mess. This way the two bits were flipped multiple times: in the raw reader, in the CTF encoder and in the CTF decoder.
This PR fixes this mess by applying the bit shifts explicitly in the only two places where it is needed: when we read the raw data and when we convert simulated data into raw data for synthetic running. This way the position and slope stored in the Tracklet64 class can always be used without any additional bit manipulation.

Since now the bits are actually inverted in all CTFs taken so far I have added one commit which adds an option to the tracklet transformer to apply the bit flipping again. I tested this with the last data taken with beam and it works for me.

Just to explain a bit the mess with the current state of the code before this PR: the raw reader flips the bits so they are actually OK. Our QC plots show `Tracklet64::getPosition()` and `Tracklet64::getSlope` which flip the bits again resulting in funny looking plots although the data is actually OK. Then the CTF encoder flips the bits again storing the data XORed in the CTFs. The CTF decoder does another XOR, now position and slope are OK again, but since we apply the XOR in the getters we see again wrong data for slope and position. Clearly I hadn't thought #7898 through completely

