### PR TITLE
[EMCAL-566] Added option to time-profile calibration

### DIFF
--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibParams.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibParams.h
@@ -37,6 +37,10 @@ struct EMCALCalibParams : public o2::conf::ConfigurableParamHelper<EMCALCalibPar
   bool useScaledHistoForBadChannelMap = true; ///< use the scaled histogram for the bad channel map
   bool enableTestMode = false;                ///< enable test mode for calibration
   float minCellEnergyForTimeCalib = 0.5;      ///< minimum cell energy to enter the time calibration (typical minimum seed energy for clusters), time resolution gets better with rising energy
+  unsigned int slotLength = 0;                ///< Lenght of the slot before calibration is triggered. If set to 0 calibration is triggered when hasEnoughData returns true
+  bool UpdateAtEndOfRunOnly = false;          ///< switsch to enable trigger of calibration only at end of run
+  bool enableTimeProfiling = false;           ///< enable to log how much time is spent in the run function in the calibrator spec. Needed for speed tests offline and at point 2
+  bool enableFastCalib = false;               ///< switch to enable fast calibration. Instead of filling boost histograms, mean and sigma of cells is calculated on the fly
 
   O2ParamDef(EMCALCalibParams, "EMCALCalibParams");
 };

--- a/Detectors/EMCAL/calibration/src/EMCALTimeCalibData.cxx
+++ b/Detectors/EMCAL/calibration/src/EMCALTimeCalibData.cxx
@@ -83,8 +83,8 @@ void EMCALTimeCalibData::fill(const gsl::span<const o2::emcal::Cell> data)
     double cellEnergy = cell.getEnergy();
     double cellTime = cell.getTimeStamp();
     int id = cell.getTower();
-    LOG(debug) << "inserting in cell ID " << id << ": cellTime = " << cellTime;
     if (cellEnergy > EMCALCalibParams::Instance().minCellEnergyForTimeCalib) {
+      LOG(debug) << "inserting in cell ID " << id << ": cellTime = " << cellTime;
       mTimeHisto(cellTime, id);
       mNEntriesInHisto++;
     }


### PR DESCRIPTION
- Added switch to obtain the time spend in the run function of the time
and bad channel calib. Needed because very high CPU consumption was
observed in online tests at point2 which cannot be reproduced
offline/locally. If option enabled (via EMCALCalibParams), time in ns is
printed out. Only for debug purposes
- Added options to set slot length and restriction to trigger
calibration only at end of run