### PR TITLE
TRD fix digit handling in trap2raw with downsampling before trap2raw

### DIFF
--- a/Detectors/TRD/simulation/include/TRDSimulation/Trap2CRU.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Trap2CRU.h
@@ -63,7 +63,7 @@ class Trap2CRU
   int writeDigitEndMarker();                                           // write the digit end marker 0x0 0x0
   int writeTrackletEndMarker();                                        // write the tracklet end maker 0x10001000 0x10001000
   int writeDigitHCHeader(const int eventcount, uint32_t linkid);       // write the Digit HalfChamberHeader into the stream, after the tracklet endmarker and before the digits.
-  int writeTrackletHCHeader(const int eventcount, uint32_t linkid);    // write the Tracklet HalfChamberHeader into the stream, at the beginning of data iff there is tracklet data.
+  int writeTrackletHCHeader(const int eventcount);                     // write the Tracklet HalfChamberHeader into the stream, at the beginning of data iff there is tracklet data.
 
   bool digitindexcompare(const o2::trd::Digit& A, const o2::trd::Digit& B);
   //boohhl digitindexcompare(const unsigned int A, const unsigned int B);


### PR DESCRIPTION
The code always assumed there were digits and then sometimes tracklets, hopefully rather often.
Now that the downsampling is before this, the assumption is invalid.

This fixes jira ticket O2-3015