### PR TITLE
Fix in vertex-track association

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/readers/src/PrimaryVertexReaderSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/readers/src/PrimaryVertexReaderSpec.cxx
@@ -95,7 +95,7 @@ void PrimaryVertexReader::run(ProcessingContext& pc)
   if (mVerbose) {
     size_t nrec = mPV2MatchIdxRef.size();
     for (size_t cnt = 0; cnt < nrec; cnt++) {
-      if (cnt < mVertices.size() - 1) {
+      if (cnt < mVertices.size()) {
         const auto& vtx = mVertices[cnt];
         Label lb;
         if (mUseMC) {

--- a/Detectors/Vertexing/src/VertexTrackMatcher.cxx
+++ b/Detectors/Vertexing/src/VertexTrackMatcher.cxx
@@ -107,8 +107,7 @@ void VertexTrackMatcher::process(const o2::globaltracking::RecoContainer& recoDa
       auto res = tro.tBracket.isOutside(vto.tBracket);
       if (res == TBracket::Below) {                                       // vertex preceeds the track
         if (tro.tBracket.getMin() > vto.tBracket.getMin() + maxVtxSpan) { // all following vertices will be preceeding all following tracks times
-          ivStart = ++iv;
-          break;
+          ivStart = iv + 1;
         }
         continue; // following vertex with longer span might still match this track
       }
@@ -199,7 +198,7 @@ void VertexTrackMatcher::extractTracks(const o2::globaltracking::RecoContainer& 
     terr += mPVParams->timeMarginTrackTime;
     mTBrackets.emplace_back(TrackTBracket{{t0 - terr, t0 + terr}, _origID});
 
-    if constexpr (isGlobalFwdTrack<decltype(_tr)>()) {
+    if constexpr (isGlobalFwdTrack<decltype(_tr)>() || isMFTTrack<decltype(_tr)>()) {
       return false;
     }
     return true;


### PR DESCRIPTION
If checked non-contributor track time-bracket was above vertex time-bracket
by good margin, such a track could be declared as an orphan instead of comparing
with the next vertex.