### PR TITLE
DPL: Don't fail on empty workflow when dumping the topology

### DIFF
--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -1461,7 +1461,7 @@ int runStateMachine(DataProcessorSpecs const& workflow,
       case DriverState::MATERIALISE_WORKFLOW:
         try {
           auto workflowState = WorkflowHelpers::verifyWorkflow(workflow);
-          if (driverInfo.batch == true && workflowState == WorkflowParsingState::Empty) {
+          if (driverInfo.batch == true && !varmap["dds"].as<bool>() && !varmap["dump-workflow"].as<bool>() && workflowState == WorkflowParsingState::Empty) {
             LOGP(error, "Empty workflow provided while running in batch mode.");
             return 1;
           }


### PR DESCRIPTION
@ktf : This is needed since some of the calib collections may be empty