### PR TITLE
DPL: improve forward handling

### DIFF
--- a/Framework/Core/include/Framework/ChannelInfo.h
+++ b/Framework/Core/include/Framework/ChannelInfo.h
@@ -54,6 +54,15 @@ struct InputChannelInfo {
   TimesliceId oldestForChannel;
 };
 
+/// Forward channel information
+struct ForwardChannelInfo {
+  /// The name of the channel
+  std::string name = "invalid";
+  /// Wether or not it's a DPL internal channel.
+  bool dplChannel = true;
+  fair::mq::Channel& channel;
+};
+
 } // namespace o2::framework
 
 #endif // O2_FRAMEWORK_CHANNELINFO_H_

--- a/Framework/Core/include/Framework/FairMQDeviceProxy.h
+++ b/Framework/Core/include/Framework/FairMQDeviceProxy.h
@@ -13,12 +13,19 @@
 
 #include <memory>
 
+#include "Framework/ChannelInfo.h"
 #include "Framework/RoutingIndices.h"
 #include "Framework/RouteState.h"
 #include "Framework/OutputRoute.h"
 #include "Framework/InputRoute.h"
+#include "Framework/ForwardRoute.h"
 #include <fairmq/FwdDecls.h>
 #include <vector>
+
+namespace o2::header
+{
+struct DataHeader;
+};
 
 namespace o2::framework
 {
@@ -30,32 +37,49 @@ class FairMQDeviceProxy
  public:
   FairMQDeviceProxy() = default;
   FairMQDeviceProxy(FairMQDeviceProxy const&) = delete;
-  void bind(std::vector<OutputRoute> const& outputs, std::vector<InputRoute> const& inputs, fair::mq::Device& device);
+  void bind(std::vector<OutputRoute> const& outputs, std::vector<InputRoute> const& inputs,
+            std::vector<ForwardRoute> const& forwards, fair::mq::Device& device);
 
   /// Retrieve the transport associated to a given route.
   fair::mq::TransportFactory* getOutputTransport(RouteIndex routeIndex) const;
   /// Retrieve the transport associated to a given route.
   fair::mq::TransportFactory* getInputTransport(RouteIndex routeIndex) const;
+  /// Retrieve the transport associated to a given route.
+  fair::mq::TransportFactory* getForwardTransport(RouteIndex routeIndex) const;
   /// ChannelIndex from a given channel name
   ChannelIndex getOutputChannelIndexByName(std::string const& channelName) const;
   /// ChannelIndex from a given channel name
   ChannelIndex getInputChannelIndexByName(std::string const& channelName) const;
+  /// ChannelIndex from a given channel name
+  ChannelIndex getForwardChannelIndexByName(std::string const& channelName) const;
   /// Retrieve the channel index from a given OutputSpec and the associated timeslice
   ChannelIndex getOutputChannelIndex(OutputSpec const& spec, size_t timeslice) const;
+  /// Retrieve the channel index from a given OutputSpec and the associated timeslice
+  ChannelIndex getForwardChannelIndex(header::DataHeader const& header, size_t timeslice) const;
   /// ChannelIndex from a RouteIndex
   ChannelIndex getOutputChannelIndex(RouteIndex routeIndex) const;
   ChannelIndex getInputChannelIndex(RouteIndex routeIndex) const;
+  ChannelIndex getForwardChannelIndex(RouteIndex routeIndex) const;
   /// Retrieve the channel associated to a given output route.
   fair::mq::Channel* getInputChannel(ChannelIndex channelIndex) const;
   fair::mq::Channel* getOutputChannel(ChannelIndex channelIndex) const;
+  fair::mq::Channel* getForwardChannel(ChannelIndex channelIndex) const;
+
+  /// Retrieve information associated to a given forward by ChannelIndex
+  ForwardChannelInfo const& getForwardChannelInfo(ChannelIndex channelIndex) const;
 
   std::unique_ptr<fair::mq::Message> createOutputMessage(RouteIndex routeIndex) const;
   std::unique_ptr<fair::mq::Message> createOutputMessage(RouteIndex routeIndex, const size_t size) const;
 
   std::unique_ptr<fair::mq::Message> createInputMessage(RouteIndex routeIndex) const;
   std::unique_ptr<fair::mq::Message> createInputMessage(RouteIndex routeIndex, const size_t size) const;
+
+  std::unique_ptr<fair::mq::Message> createForwardMessage(RouteIndex routeIndex) const;
+
   size_t getNumOutputChannels() const { return mOutputChannels.size(); }
   size_t getNumInputChannels() const { return mInputChannels.size(); }
+  size_t getNumForwardChannels() const { return mForwardChannelInfos.size(); }
+  size_t getNumForwards() const { return mForwards.size(); }
 
   bool newStateRequested() const { return mStateChangeCallback(); }
 
@@ -69,6 +93,11 @@ class FairMQDeviceProxy
   std::vector<RouteState> mInputRoutes;
   std::vector<fair::mq::Channel*> mInputChannels;
   std::vector<std::string> mInputChannelNames;
+
+  std::vector<ForwardRoute> mForwards;
+  std::vector<RouteState> mForwardRoutes;
+  std::vector<ForwardChannelInfo> mForwardChannelInfos;
+
   std::function<bool()> mStateChangeCallback;
 };
 

--- a/Framework/Core/src/CommonMessageBackends.cxx
+++ b/Framework/Core/src/CommonMessageBackends.cxx
@@ -56,8 +56,9 @@ o2::framework::ServiceSpec CommonMessageBackends::fairMQDeviceProxy()
       auto* proxy = static_cast<FairMQDeviceProxy*>(instance);
       auto& outputs = services.get<DeviceSpec const>().outputs;
       auto& inputs = services.get<DeviceSpec const>().inputs;
+      auto& forwards = services.get<DeviceSpec const>().forwards;
       auto* device = services.get<RawDeviceService>().device();
-      proxy->bind(outputs, inputs, *device); },
+      proxy->bind(outputs, inputs, forwards, *device); },
   };
 }
 

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -1463,6 +1463,150 @@ void update_maximum(std::atomic<T>& maximum_value, T const& value) noexcept
 }
 } // namespace
 
+static auto toBeForwardedDataRef = [](DataRef const& input) {
+  // If is now possible that the record is not complete when
+  // we forward it, because of a custom completion policy.
+  // this means that we need to skip the empty entries in the
+  // record for being forwarded.
+  if (input.header == nullptr) {
+    return false;
+  }
+  auto sih = o2::header::get<SourceInfoHeader*>(input.header);
+  if (sih) {
+    return false;
+  }
+
+  auto dih = o2::header::get<DomainInfoHeader*>(input.header);
+  if (dih) {
+    return false;
+  }
+
+  auto dh = o2::header::get<DataHeader*>(input.header);
+  if (!dh) {
+    return false;
+  }
+  auto dph = o2::header::get<DataProcessingHeader*>(input.header);
+  if (!dph) {
+    return false;
+  }
+  return true;
+};
+
+static auto toBeforwardedMessageSet = [](ChannelIndex& cachedForwardingChoice,
+                                         FairMQDeviceProxy& proxy,
+                                         std::unique_ptr<fair::mq::Message>& header,
+                                         std::unique_ptr<fair::mq::Message>& payload,
+                                         size_t total,
+                                         bool consume) {
+  if (header.get() == nullptr) {
+    // Missing an header is not an error anymore.
+    // it simply means that we did not receive the
+    // given input, but we were asked to
+    // consume existing, so we skip it.
+    return false;
+  }
+  if (payload.get() == nullptr && consume == true) {
+    // If the payload is not there, it means we already
+    // processed it with ConsumeExisiting. Therefore we
+    // need to do something only if this is the last consume.
+    header.reset(nullptr);
+    return false;
+  }
+
+  auto fdph = o2::header::get<DataProcessingHeader*>(header->GetData());
+  if (fdph == nullptr) {
+    LOG(error) << "Data is missing DataProcessingHeader";
+    return false;
+  }
+  auto fdh = o2::header::get<DataHeader*>(header->GetData());
+  if (fdh == nullptr) {
+    LOG(error) << "Data is missing DataHeader";
+    return false;
+  }
+
+  // We need to find the forward route only for the first
+  // part of a split payload. All the others will use the same.
+  // but always check if we have a sequence of multiple payloads
+  if (fdh->splitPayloadIndex == 0 || fdh->splitPayloadParts <= 1 || total > 1) {
+    cachedForwardingChoice = proxy.getForwardChannelIndex(*fdh, fdph->startTime);
+  }
+  /// We did not find a match. Skip it.
+  if (cachedForwardingChoice.value == ChannelIndex::INVALID) {
+    return false;
+  }
+  return true;
+};
+
+// This is how we do the forwarding, i.e. we push
+// the inputs which are shared between this device and others
+// to the next one in the daisy chain.
+// FIXME: do it in a smarter way than O(N^2)
+static auto forwardInputs = [](ServiceRegistry& registry, TimesliceSlot slot, InputRecord& record, std::vector<MessageSet>& currentSetOfInputs, bool copy, bool consume = true) {
+  ZoneScopedN("forward inputs");
+  LOGP(debug, "DataProcessingDevice::tryDispatchComputation::forwardInputs");
+  auto& proxy = registry.get<FairMQDeviceProxy>();
+  assert(record.size() == currentSetOfInputs.size());
+  // we collect all messages per forward in a map and send them together
+  std::vector<fair::mq::Parts> forwardedParts;
+  forwardedParts.resize(proxy.getNumForwards());
+
+  for (size_t ii = 0, ie = record.size(); ii < ie; ++ii) {
+    DataRef input = record.getByPos(ii);
+    if (!toBeForwardedDataRef(input)) {
+      continue;
+    }
+    ChannelIndex cachedForwardingChoice{ChannelIndex::INVALID};
+
+    for (size_t pi = 0; pi < currentSetOfInputs[ii].size(); ++pi) {
+      auto& messageSet = currentSetOfInputs[ii];
+      auto& header = messageSet.header(pi);
+      auto& payload = messageSet.payload(pi);
+      auto total = messageSet.getNumberOfPayloads(pi);
+
+      if (!toBeforwardedMessageSet(cachedForwardingChoice, proxy, header, payload, total, consume)) {
+        continue;
+      }
+
+      if (copy) {
+        auto&& newHeader = header->GetTransport()->CreateMessage();
+        newHeader->Copy(*header);
+        forwardedParts[cachedForwardingChoice.value].AddPart(std::move(newHeader));
+
+        for (size_t payloadIndex = 0; payloadIndex < messageSet.getNumberOfPayloads(pi); ++payloadIndex) {
+          auto&& newPayload = header->GetTransport()->CreateMessage();
+          newPayload->Copy(*messageSet.payload(pi, payloadIndex));
+          forwardedParts[cachedForwardingChoice.value].AddPart(std::move(newPayload));
+        }
+      } else {
+        forwardedParts[cachedForwardingChoice.value].AddPart(std::move(messageSet.header(pi)));
+        for (size_t payloadIndex = 0; payloadIndex < messageSet.getNumberOfPayloads(pi); ++payloadIndex) {
+          forwardedParts[cachedForwardingChoice.value].AddPart(std::move(messageSet.payload(pi, payloadIndex)));
+        }
+      }
+    }
+  }
+  for (int fi = 0; fi < proxy.getNumForwardChannels(); fi++) {
+    if (forwardedParts[fi].Size() == 0) {
+      continue;
+    }
+    auto channel = proxy.getForwardChannel(ChannelIndex{fi});
+    // in DPL we are using subchannel 0 only
+    channel->Send(forwardedParts[fi]);
+  }
+  for (int fi = 0; fi < proxy.getNumForwardChannels(); fi++) {
+    auto& info = proxy.getForwardChannelInfo(ChannelIndex{fi});
+    // The oldest possible timeslice for a forwarded message
+    // is conservatively the one of the device doing the forwarding.
+    // TODO: this we could cache in the proxy at the bind moment.
+    if (!info.dplChannel) {
+      continue;
+    }
+    auto oldestTimeslice = registry.get<TimesliceIndex>().getOldestPossibleOutput();
+    DataProcessingHelpers::sendOldestPossibleTimeframe(info.channel, oldestTimeslice.timeslice.value);
+    LOGP(debug, "Forwarding to channel {} oldest possible timeslice {}", info.name, oldestTimeslice.timeslice.value);
+  }
+};
+
 bool DataProcessingDevice::tryDispatchComputation(DataProcessorContext& context, std::vector<DataRelayer::RecordAction>& completed)
 {
   ZoneScopedN("DataProcessingDevice::tryDispatchComputation");
@@ -1597,147 +1741,6 @@ bool DataProcessingDevice::tryDispatchComputation(DataProcessorContext& context,
   };
 #endif
 
-  // This is how we do the forwarding, i.e. we push
-  // the inputs which are shared between this device and others
-  // to the next one in the daisy chain.
-  // FIXME: do it in a smarter way than O(N^2)
-  auto forwardInputs = [&reportError,
-                        &spec = context.deviceContext->spec,
-                        &timesliceIndex = context.registry->get<TimesliceIndex>(),
-                        &device = context.deviceContext->device, &currentSetOfInputs](TimesliceSlot slot, InputRecord& record, bool copy, bool consume = true) {
-    ZoneScopedN("forward inputs");
-    LOGP(debug, "DataProcessingDevice::tryDispatchComputation::forwardInputs");
-    assert(record.size() == currentSetOfInputs.size());
-    // we collect all messages per forward in a map and send them together
-    std::vector<fair::mq::Parts> forwardedParts;
-    forwardedParts.resize(spec->forwards.size());
-
-    std::vector<size_t> forwardMap;
-    forwardMap.resize(spec->forwards.size());
-    std::unordered_map<std::string, size_t> tmpMap;
-    for (size_t fi = 0; fi < spec->forwards.size(); fi++) {
-      forwardMap[fi] = tmpMap.try_emplace(spec->forwards[fi].channel, fi).first->second;
-    }
-
-    for (size_t ii = 0, ie = record.size(); ii < ie; ++ii) {
-      DataRef input = record.getByPos(ii);
-
-      // If is now possible that the record is not complete when
-      // we forward it, because of a custom completion policy.
-      // this means that we need to skip the empty entries in the
-      // record for being forwarded.
-      if (input.header == nullptr) {
-        continue;
-      }
-      auto sih = o2::header::get<SourceInfoHeader*>(input.header);
-      if (sih) {
-        continue;
-      }
-
-      auto dih = o2::header::get<DomainInfoHeader*>(input.header);
-      if (dih) {
-        continue;
-      }
-
-      auto dh = o2::header::get<DataHeader*>(input.header);
-      if (!dh) {
-        reportError("Forwarding a non-DataHeader?");
-        continue;
-      }
-      auto dph = o2::header::get<DataProcessingHeader*>(input.header);
-      if (!dph) {
-        reportError("Header stack does not contain DataProcessingHeader");
-        continue;
-      }
-
-      int cachedForwardingChoice = -1;
-
-      for (size_t pi = 0; pi < currentSetOfInputs[ii].size(); ++pi) {
-        auto& messageSet = currentSetOfInputs[ii];
-        auto& header = messageSet.header(pi);
-        auto& payload = messageSet.payload(pi);
-
-        if (header.get() == nullptr) {
-          // Missing an header is not an error anymore.
-          // it simply means that we did not receive the
-          // given input, but we were asked to
-          // consume existing, so we skip it.
-          continue;
-        }
-        if (payload.get() == nullptr && consume == true) {
-          // If the payload is not there, it means we already
-          // processed it with ConsumeExisiting. Therefore we
-          // need to do something only if this is the last consume.
-          header.reset(nullptr);
-          continue;
-        }
-
-        auto fdph = o2::header::get<DataProcessingHeader*>(header->GetData());
-        if (fdph == nullptr) {
-          LOG(error) << "Data is missing DataProcessingHeader";
-          continue;
-        }
-        auto fdh = o2::header::get<DataHeader*>(header->GetData());
-        if (fdh == nullptr) {
-          LOG(error) << "Data is missing DataHeader";
-          continue;
-        }
-        // We need to find the forward route only for the first
-        // part of a split payload. All the others will use the same.
-        // but always check if we have a sequence of multiple payloads
-        if (fdh->splitPayloadIndex == 0 || fdh->splitPayloadParts <= 1 || messageSet.getNumberOfPayloads(pi) > 1) {
-          cachedForwardingChoice = -1;
-          for (size_t fi = 0; fi < spec->forwards.size(); fi++) {
-            auto& forward = spec->forwards[fi];
-            if (DataSpecUtils::match(forward.matcher, fdh->dataOrigin, fdh->dataDescription, fdh->subSpecification) == false || (fdph->startTime % forward.maxTimeslices) != forward.timeslice) {
-              continue;
-            }
-            cachedForwardingChoice = forwardMap[fi];
-            break;
-          }
-        }
-        /// We did not find a match. Skip it.
-        if (cachedForwardingChoice == -1) {
-          continue;
-        }
-
-        if (copy) {
-          auto&& newHeader = header->GetTransport()->CreateMessage();
-          newHeader->Copy(*header);
-          forwardedParts[cachedForwardingChoice].AddPart(std::move(newHeader));
-
-          for (size_t payloadIndex = 0; payloadIndex < messageSet.getNumberOfPayloads(pi); ++payloadIndex) {
-            auto&& newPayload = header->GetTransport()->CreateMessage();
-            newPayload->Copy(*messageSet.payload(pi, payloadIndex));
-            forwardedParts[cachedForwardingChoice].AddPart(std::move(newPayload));
-          }
-        } else {
-          forwardedParts[cachedForwardingChoice].AddPart(std::move(messageSet.header(pi)));
-          for (size_t payloadIndex = 0; payloadIndex < messageSet.getNumberOfPayloads(pi); ++payloadIndex) {
-            forwardedParts[cachedForwardingChoice].AddPart(std::move(messageSet.payload(pi, payloadIndex)));
-          }
-        }
-      }
-    }
-    for (size_t fi = 0; fi < spec->forwards.size(); fi++) {
-      auto& channel = device->GetChannel(spec->forwards[fi].channel, 0);
-      if (forwardedParts[fi].Size() != 0) {
-        // in DPL we are using subchannel 0 only
-        channel.Send(forwardedParts[fi]);
-      }
-    }
-    for (size_t fi = 0; fi < spec->forwards.size(); fi++) {
-      auto& channel = device->GetChannel(spec->forwards[fi].channel, 0);
-      // The oldest possible timeslice for a forwarded message
-      // is conservatively the one of the device doing the forwarding.
-      if (spec->forwards[fi].channel.rfind("from_", 0) == 0) {
-        auto oldestTimeslice = timesliceIndex.getOldestPossibleOutput();
-        DataProcessingHelpers::sendOldestPossibleTimeframe(channel, oldestTimeslice.timeslice.value);
-        LOGP(debug, "Forwarding to channel {} oldest possible timeslice {}", spec->forwards[fi].channel, oldestTimeslice.timeslice.value);
-      }
-    }
-  };
-
   auto switchState = [&control = context.registry->get<ControlService>(),
                       &state = context.deviceContext->state](StreamingState newState) {
     state->streaming = newState;
@@ -1810,7 +1813,7 @@ bool DataProcessingDevice::tryDispatchComputation(DataProcessorContext& context,
       LOGP(debug, "  - Action is to Discard");
       context.registry->postDispatchingCallbacks(processContext);
       if (context.deviceContext->spec->forwards.empty() == false) {
-        forwardInputs(action.slot, record, false);
+        forwardInputs(*context.registry, action.slot, record, currentSetOfInputs, false);
         continue;
       }
     }
@@ -1823,7 +1826,7 @@ bool DataProcessingDevice::tryDispatchComputation(DataProcessorContext& context,
 
     if (context.canForwardEarly && hasForwards && consumeSomething) {
       LOGP(debug, "  - Early forwarding");
-      forwardInputs(action.slot, record, true, action.op == CompletionPolicy::CompletionOp::Consume);
+      forwardInputs(*context.registry, action.slot, record, currentSetOfInputs, true, action.op == CompletionPolicy::CompletionOp::Consume);
     }
     markInputsAsDone(action.slot);
 
@@ -1899,7 +1902,7 @@ bool DataProcessingDevice::tryDispatchComputation(DataProcessorContext& context,
     }
     if ((context.canForwardEarly == false) && hasForwards && consumeSomething) {
       LOGP(debug, "Late forwarding");
-      forwardInputs(action.slot, record, false, action.op == CompletionPolicy::CompletionOp::Consume);
+      forwardInputs(*context.registry, action.slot, record, currentSetOfInputs, false, action.op == CompletionPolicy::CompletionOp::Consume);
     }
     context.registry->postForwardingCallbacks(processContext);
     if (action.op == CompletionPolicy::CompletionOp::Consume) {

--- a/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
+++ b/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
@@ -490,7 +490,7 @@ DataProcessorSpec specifyFairMQDeviceOutputProxy(char const* name,
   spec.name = name;
   spec.inputs = inputSpecs;
   spec.outputs = {};
-  spec.algorithm = adaptStateful([inputSpecs](CallbackService& callbacks, RawDeviceService& rds, DeviceSpec const& deviceSpec, ConfigParamRegistry const& options) {
+  spec.algorithm = adaptStateful([inputSpecs](FairMQDeviceProxy& proxy, CallbackService& callbacks, RawDeviceService& rds, DeviceSpec const& deviceSpec, ConfigParamRegistry const& options) {
     // we can retrieve the channel name from the channel configuration string
     // FIXME: even if a --channel-config option is specified on the command line, always the default string
     // is retrieved from the config registry. The channel name thus needs to be configured in the default
@@ -523,12 +523,15 @@ DataProcessorSpec specifyFairMQDeviceOutputProxy(char const* name,
       // are no internal forwards
       throw std::runtime_error("can not add forward targets outside DPL if internal forwards are existing, the proxy must be at the end of the workflow");
     }
+    auto& spec = const_cast<DeviceSpec&>(deviceSpec);
     for (auto const& inputSpec : inputSpecs) {
       // this is a prototype, in principle we want to have all spec objects const
       // and so only the const object can be retrieved from service registry
       ForwardRoute route{0, 1, inputSpec, outputChannelName};
-      const_cast<DeviceSpec&>(deviceSpec).forwards.emplace_back(route);
+      spec.forwards.emplace_back(route);
     }
+
+    proxy.bind(spec.outputs, spec.inputs, spec.forwards, *device);
 
     auto forwardEos = [device, lastDataProcessingHeader, outputChannelName](EndOfStreamContext&) {
       // DPL implements an internal end of stream signal, which is propagated through
@@ -595,20 +598,21 @@ DataProcessorSpec specifyFairMQDeviceMultiOutputProxy(char const* name,
   spec.name = name;
   spec.inputs = inputSpecs;
   spec.outputs = {};
-  spec.algorithm = adaptStateful([inputSpecs, channelSelector](CallbackService& callbacks, RawDeviceService& rds, const DeviceSpec& deviceSpec) {
+  spec.algorithm = adaptStateful([inputSpecs, channelSelector](FairMQDeviceProxy& proxy, CallbackService& callbacks, RawDeviceService& rds, const DeviceSpec& deviceSpec) {
     auto device = rds.device();
     // check that the input spec bindings have corresponding output channels
     // fair::mq::Device calls the custom init before the channels have been configured
     // so we do the check before starting in a dedicated callback
     // also we set forwards for all input specs and keep a list of all channels so we can send EOS on them
     auto channelNames = std::make_shared<std::vector<std::string>>();
-    auto channelConfigurationInitializer = [inputSpecs = std::move(inputSpecs), device, channelSelector, &deviceSpec, channelNames]() {
+    auto channelConfigurationInitializer = [&proxy, inputSpecs = std::move(inputSpecs), device, channelSelector, &deviceSpec, channelNames]() {
       if (deviceSpec.forwards.size() > 0) {
         // check that no internal forwards are existing, i.e. that proxy is at the end of the workflow
         // in principle we can be less strict here if we check only for the defined input specs that there
         // are no internal forwards
         throw std::runtime_error("can not add forward targets outside DPL if internal forwards are existing, the proxy must be at the end of the workflow");
       }
+      auto& mutableDeviceSpec = const_cast<DeviceSpec&>(deviceSpec);
       for (auto const& spec : inputSpecs) {
         auto channel = channelSelector(spec, device->fChannels);
         if (device->fChannels.count(channel) == 0) {
@@ -619,10 +623,11 @@ DataProcessorSpec specifyFairMQDeviceMultiOutputProxy(char const* name,
         // set external routes. Basically, this has to be added while setting up the
         // workflow. After that, the actual spec provided by the service is supposed
         // to be const by design
-        const_cast<DeviceSpec&>(deviceSpec).forwards.emplace_back(route);
+        mutableDeviceSpec.forwards.emplace_back(route);
 
         channelNames->emplace_back(std::move(channel));
       }
+      proxy.bind(mutableDeviceSpec.outputs, mutableDeviceSpec.inputs, mutableDeviceSpec.forwards, *device);
     };
     callbacks.set(CallbackService::Id::Start, channelConfigurationInitializer);
 

--- a/Framework/Core/test/test_ExternalFairMQDeviceWorkflow.cxx
+++ b/Framework/Core/test/test_ExternalFairMQDeviceWorkflow.cxx
@@ -86,6 +86,11 @@ using Stack = o2::header::Stack;
     LOG(fatal) << R"(Test condition ")" #condition R"(" failed)"; \
   }
 
+#define ASSERT_EQUAL(left, right)                                                            \
+  if ((left == right) == false) {                                                            \
+    LOGP(fatal, R"(Test condition {} ({}) == {} ({}) failed")", #left, left, #right, right); \
+  }
+
 template <typename T>
 T readConfig(ConfigContext const& config, const char* key)
 {
@@ -308,7 +313,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const& config)
     ++(*counter);
   };
   auto checkCounter = [counter, nRolls](EndOfStreamContext&) {
-    ASSERT_ERROR(*counter == nRolls);
+    ASSERT_EQUAL(*counter, nRolls);
     if (*counter == nRolls) {
       LOG(info) << "checker has received " << nRolls << " successful event(s)";
     }


### PR DESCRIPTION
* handle forwarding in FairMQDeviceProxy
* refactor forwardign itself so that it can be done via a free
  function.

Should simplify the forwarding code and allow it to be done
already at the level of DataRelayer, so that we can handle
the issue with forwarding of obsolete timeframes.