### PR TITLE
ITS-tracking: use flat index tables for clusters

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TimeFrameGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/TimeFrameGPU.cu
@@ -136,18 +136,8 @@ void TimeFrameGPU<NLayers>::loadToDevice(const int maxLayers)
       mClusterExternalIndicesD[iLayer].reset(mClusterExternalIndices[iLayer].data(), static_cast<int>(mClusterExternalIndices[iLayer].size()));
     }
   } else {
-    // flatten vector of vectors into single buffer
-    std::vector<int> flatTables0, flatTables2;
-    flatTables0.reserve(mConfig.nMaxROFs * (ZBins * PhiBins + 1));
-    flatTables2.reserve(mConfig.nMaxROFs * (ZBins * PhiBins + 1));
-    for (size_t rofId{0}; rofId < mNrof; ++rofId) {
-      const auto& v0 = mIndexTables[rofId][0];
-      const auto& v2 = mIndexTables[rofId][2];
-      flatTables0.insert(flatTables0.end(), v0.begin(), v0.end());
-      flatTables2.insert(flatTables2.end(), v2.begin(), v2.end());
-    }
-    mIndexTablesLayer0D.reset(flatTables0.data(), static_cast<int>(flatTables0.size()));
-    mIndexTablesLayer2D.reset(flatTables2.data(), static_cast<int>(flatTables2.size()));
+    mIndexTablesLayer0D.reset(getIndexTableWhole(0).data(), static_cast<int>(getIndexTableWhole(0).size()));
+    mIndexTablesLayer2D.reset(getIndexTableWhole(2).data(), static_cast<int>(getIndexTableWhole(2).size()));
   }
   gpuThrowOnError();
 }

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -97,7 +97,8 @@ class TimeFrame
   gsl::span<Cluster> getClustersOnLayer(int rofId, int layerId);
   gsl::span<const Cluster> getClustersOnLayer(int rofId, int layerId) const;
   gsl::span<const Cluster> getUnsortedClustersOnLayer(int rofId, int layerId) const;
-  index_table_t& getIndexTables(int tf);
+  gsl::span<int> getIndexTable(int rofId, int layerId);
+  std::vector<int>& getIndexTableWhole(int layerId) { return mIndexTables[layerId]; }
   const std::vector<TrackingFrameInfo>& getTrackingFrameInfoOnLayer(int layerId) const;
 
   const TrackingFrameInfo& getClusterTrackingFrameInfo(int layerId, const Cluster& cl) const;
@@ -169,7 +170,7 @@ class TimeFrame
   std::vector<std::vector<TrackingFrameInfo>> mTrackingFrameInfo;
   std::vector<std::vector<int>> mClusterExternalIndices;
   std::vector<std::vector<int>> mROframesClusters;
-  std::vector<index_table_t> mIndexTables;
+  std::vector<std::vector<int>> mIndexTables;
   int mNrof = 0;
 
  private:
@@ -313,9 +314,13 @@ inline int TimeFrame::getClusterExternalIndex(int layerId, const int clId) const
   return mClusterExternalIndices[layerId][clId];
 }
 
-inline index_table_t& TimeFrame::getIndexTables(int tf)
+inline gsl::span<int> TimeFrame::getIndexTable(int rofId, int layer)
 {
-  return mIndexTables[tf];
+  if (rofId < 0 || rofId >= mNrof) {
+    return gsl::span<int>();
+  }
+  return {&mIndexTables[layer][rofId * (mIndexTableUtils.getNphiBins() * mIndexTableUtils.getNzBins() + 1)],
+          static_cast<gsl::span<int>::size_type>(mIndexTableUtils.getNphiBins() * mIndexTableUtils.getNzBins() + 1)};
 }
 
 inline std::vector<Line>& TimeFrame::getLines(int tf)

--- a/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
@@ -229,7 +229,7 @@ void TimeFrame::initialise(const int iteration, const MemoryParameters& memParam
       mUsedClusters[iLayer].resize(mUnsortedClusters[iLayer].size(), false);
       mPositionResolution[iLayer] = std::hypot(trkParam.LayerMisalignment[iLayer], trkParam.LayerResolution[iLayer]);
     }
-    mIndexTables.resize(mNrof);
+    mIndexTables.resize(mClusters.size(), std::vector<int>(mNrof * (trkParam.ZBins * trkParam.PhiBins + 1), 0));
     mLines.resize(mNrof);
     mTrackletClusters.resize(mNrof);
     mNTrackletsPerROf.resize(2, std::vector<int>(mNrof + 1, 0));
@@ -237,7 +237,6 @@ void TimeFrame::initialise(const int iteration, const MemoryParameters& memParam
     std::vector<ClusterHelper> cHelper;
     std::vector<int> clsPerBin(trkParam.PhiBins * trkParam.ZBins, 0);
     for (int rof{0}; rof < mNrof; ++rof) {
-      mIndexTables[rof].resize(mClusters.size(), std::vector<int>(trkParam.ZBins * trkParam.PhiBins + 1, 0));
       if ((int)mMultiplicityCutMask.size() == mNrof && !mMultiplicityCutMask[rof]) {
         continue;
       }
@@ -290,10 +289,10 @@ void TimeFrame::initialise(const int iteration, const MemoryParameters& memParam
         }
 
         for (unsigned int iB{0}; iB < clsPerBin.size(); ++iB) {
-          mIndexTables[rof][iLayer][iB] = lutPerBin[iB];
+          mIndexTables[iLayer][rof * (trkParam.ZBins * trkParam.PhiBins + 1) + iB] = lutPerBin[iB];
         }
-        for (auto iB{clsPerBin.size()}; iB < mIndexTables[rof][iLayer].size(); iB++) {
-          mIndexTables[rof][iLayer][iB] = clustersNum;
+        for (auto iB{clsPerBin.size()}; iB < (trkParam.ZBins * trkParam.PhiBins + 1); iB++) {
+          mIndexTables[iLayer][rof * (trkParam.ZBins * trkParam.PhiBins + 1) + iB] = clustersNum;
         }
       }
     }

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackerTraits.cxx
@@ -113,8 +113,8 @@ void TrackerTraits::computeLayerTracklets()
               const int firstBinIndex{tf->mIndexTableUtils.getBinIndex(selectedBinsRect.x, iPhiBin)};
               const int maxBinIndex{firstBinIndex + selectedBinsRect.z - selectedBinsRect.x + 1};
               if constexpr (debugLevel) {
-                if (firstBinIndex < 0 || firstBinIndex > tf->getIndexTables(rof1)[iLayer + 1].size() ||
-                    maxBinIndex < 0 || maxBinIndex > tf->getIndexTables(rof1)[iLayer + 1].size()) {
+                if (firstBinIndex < 0 || firstBinIndex > tf->getIndexTable(rof1, iLayer + 1).size() ||
+                    maxBinIndex < 0 || maxBinIndex > tf->getIndexTable(rof1, iLayer + 1).size()) {
                   std::cout << iLayer << "\t" << iCluster << "\t" << zAtRmin << "\t" << zAtRmax << "\t" << sigmaZ * mTrkParams.NSigmaCut << "\t" << tf->getPhiCut(iLayer) << std::endl;
                   std::cout << currentCluster.zCoordinate << "\t" << primaryVertex.getZ() << "\t" << currentCluster.radius << std::endl;
                   std::cout << tf->getMinR(iLayer + 1) << "\t" << currentCluster.radius << "\t" << currentCluster.zCoordinate << std::endl;
@@ -122,8 +122,8 @@ void TrackerTraits::computeLayerTracklets()
                   exit(1);
                 }
               }
-              const int firstRowClusterIndex = tf->getIndexTables(rof1)[iLayer + 1][firstBinIndex];
-              const int maxRowClusterIndex = tf->getIndexTables(rof1)[iLayer + 1][maxBinIndex];
+              const int firstRowClusterIndex = tf->getIndexTable(rof1, iLayer + 1)[firstBinIndex];
+              const int maxRowClusterIndex = tf->getIndexTable(rof1, iLayer + 1)[maxBinIndex];
 
               for (int iNextCluster{firstRowClusterIndex}; iNextCluster < maxRowClusterIndex; ++iNextCluster) {
                 if (iNextCluster >= (int)layer1.size()) {
@@ -402,8 +402,8 @@ bool TrackerTraits::trackFollowing(TrackITSExt* track, int rof, bool outward)
         int iPhiBin = (selectedBinsRect.y + iPhiCount) % mTrkParams.PhiBins;
         const int firstBinIndex{mTimeFrame->mIndexTableUtils.getBinIndex(selectedBinsRect.x, iPhiBin)};
         const int maxBinIndex{firstBinIndex + selectedBinsRect.z - selectedBinsRect.x + 1};
-        const int firstRowClusterIndex = mTimeFrame->getIndexTables(rof)[iLayer][firstBinIndex];
-        const int maxRowClusterIndex = mTimeFrame->getIndexTables(rof)[iLayer][maxBinIndex];
+        const int firstRowClusterIndex = mTimeFrame->getIndexTable(rof, iLayer)[firstBinIndex];
+        const int maxRowClusterIndex = mTimeFrame->getIndexTable(rof, iLayer)[maxBinIndex];
 
         for (int iNextCluster{firstRowClusterIndex}; iNextCluster < maxRowClusterIndex; ++iNextCluster) {
           if (iNextCluster >= (int)layer1.size()) {

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -139,7 +139,7 @@ void VertexerTraits::computeTracklets()
     trackleterKernelSerial<TrackletMode::Layer0Layer1>(
       mTimeFrame->getClustersOnLayer(rofId, 0),
       mTimeFrame->getClustersOnLayer(rofId, 1),
-      mTimeFrame->getIndexTables(rofId)[0].data(),
+      mTimeFrame->getIndexTable(rofId, 0).data(),
       mVrtParams.phiCut,
       mTimeFrame->getTracklets()[0],
       mTimeFrame->getNTrackletsCluster(rofId, 0),
@@ -147,7 +147,7 @@ void VertexerTraits::computeTracklets()
     trackleterKernelSerial<TrackletMode::Layer1Layer2>(
       mTimeFrame->getClustersOnLayer(rofId, 2),
       mTimeFrame->getClustersOnLayer(rofId, 1),
-      mTimeFrame->getIndexTables(rofId)[2].data(),
+      mTimeFrame->getIndexTable(rofId, 2).data(),
       mVrtParams.phiCut,
       mTimeFrame->getTracklets()[1],
       mTimeFrame->getNTrackletsCluster(rofId, 1),


### PR DESCRIPTION
Index tables for clusters are now stored on a per-layer basis rather than ROF-based.

@mpuccio