### PR TITLE
Use GRPGeomHelper to fetch GRP and Geometry related stuff from CCDB

### DIFF
--- a/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
+++ b/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
@@ -999,7 +999,6 @@ void RecoContainer::addMFTClusters(ProcessingContext& pc, bool mc)
   commonPool[GTrackID::MFT].registerContainer(pc.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("clusMFTROF"), CLUSREFS);
   commonPool[GTrackID::MFT].registerContainer(pc.inputs().get<gsl::span<o2::itsmft::CompClusterExt>>("clusMFT"), CLUSTERS);
   commonPool[GTrackID::MFT].registerContainer(pc.inputs().get<gsl::span<unsigned char>>("clusMFTPatt"), PATTERNS);
-  pc.inputs().get<o2::itsmft::TopologyDictionary*>("cldictMFT"); // just to trigger the finaliseCCDB
   if (mc) {
     mcITSClusters = pc.inputs().get<const dataformats::MCTruthContainer<MCCompLabel>*>("clusMFTMC");
   }

--- a/DataFormats/common/include/CommonDataFormat/BunchFilling.h
+++ b/DataFormats/common/include/CommonDataFormat/BunchFilling.h
@@ -79,7 +79,10 @@ class BunchFilling
   int getLastFilledBC(int dir = -1) const;
 
   // print pattern of bunches, dir=0,1: for C,A beams, dir=-1: for interacting BCs, otherwise: all
-  void print(int dir = -2, int bcPerLine = 100) const;
+  void print(int dir = -2, bool filledOnly = true, int bcPerLine = 20) const;
+
+  // get vector with filled BCs
+  std::vector<int> getFilledBCs(int dir = -1) const;
 
   // set BC filling a la TPC TDR, 12 50ns trains of 48 BCs
   // but instead of uniform train spacing we add 96empty BCs after each train

--- a/DataFormats/common/src/BunchFilling.cxx
+++ b/DataFormats/common/src/BunchFilling.cxx
@@ -55,6 +55,18 @@ int BunchFilling::getLastFilledBC(int dir) const
 }
 
 //_________________________________________________
+std::vector<int> BunchFilling::getFilledBCs(int dir) const
+{
+  std::vector<int> vb;
+  for (int bc = 0; bc < o2::constants::lhc::LHCMaxBunches; bc++) {
+    if (testBC(bc, dir)) {
+      vb.push_back(bc);
+    }
+  }
+  return vb;
+}
+
+//_________________________________________________
 void BunchFilling::setBC(int bcID, bool active, int dir)
 {
   // add interacting BC slot
@@ -111,7 +123,7 @@ void BunchFilling::setBCFilling(const std::string& patt, int dir)
 }
 
 //_________________________________________________
-void BunchFilling::print(int dir, int bcPerLine) const
+void BunchFilling::print(int dir, bool filledOnly, int bcPerLine) const
 {
   const std::string names[3] = {"Interacting", "Beam-A", "Beam-C"};
   for (int id = -1; id < 2; id++) {
@@ -119,7 +131,14 @@ void BunchFilling::print(int dir, int bcPerLine) const
       printf("%s bunches\n", names[id + 1].c_str());
       bool endlOK = false;
       for (int i = 0; i < o2::constants::lhc::LHCMaxBunches; i++) {
-        printf("%c", testBC(i, id) ? '+' : '-');
+        bool on = testBC(i, id);
+        if (!filledOnly) {
+          printf("%c", on ? '+' : '-');
+        } else if (on) {
+          printf("%4d ", i);
+        } else {
+          continue;
+        }
         if (((i + 1) % bcPerLine) == 0) {
           printf("\n");
           endlOK = true;

--- a/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
+++ b/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
@@ -27,6 +27,7 @@
 #include "DataFormatsZDC/BCRecData.h"
 #include "DataFormatsEMCAL/EventHandler.h"
 #include "DataFormatsPHOS/EventHandler.h"
+#include "DetectorsBase/GRPGeomHelper.h"
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/AnalysisHelpers.h"
 #include "Framework/DataProcessorSpec.h"
@@ -81,7 +82,7 @@ typedef boost::unordered_map<Triplet_t, int, TripletHash, TripletEqualTo> Triple
 class AODProducerWorkflowDPL : public Task
 {
  public:
-  AODProducerWorkflowDPL(GID::mask_t src, std::shared_ptr<DataRequest> dataRequest, bool enableSV, std::string resFile, bool useMC = true) : mInputSources(src), mDataRequest(dataRequest), mEnableSV(enableSV), mResFile{resFile}, mUseMC(useMC) {}
+  AODProducerWorkflowDPL(GID::mask_t src, std::shared_ptr<DataRequest> dataRequest, std::shared_ptr<o2::base::GRPGeomRequest> gr, bool enableSV, std::string resFile, bool useMC = true) : mInputSources(src), mDataRequest(dataRequest), mGGCCDBRequest(gr), mEnableSV(enableSV), mResFile{resFile}, mUseMC(useMC) {}
   ~AODProducerWorkflowDPL() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
@@ -162,6 +163,7 @@ class AODProducerWorkflowDPL : public Task
   TMap mMetaData;
 
   std::shared_ptr<DataRequest> mDataRequest;
+  std::shared_ptr<o2::base::GRPGeomRequest> mGGCCDBRequest;
 
   static constexpr int TOFTimePrecPS = 16; // required max error in ps for TOF tracks
   // truncation is enabled by default

--- a/Detectors/Base/include/DetectorsBase/GRPGeomHelper.h
+++ b/Detectors/Base/include/DetectorsBase/GRPGeomHelper.h
@@ -19,6 +19,9 @@
 #include <vector>
 #include <memory>
 #include "DetectorsCommonDataFormats/DetID.h"
+#include "DataFormatsParameters/GRPLHCIFData.h"
+#include "DataFormatsParameters/GRPECSObject.h"
+#include "DataFormatsParameters/GRPMagField.h"
 
 namespace o2::framework
 {
@@ -69,7 +72,9 @@ class MatLayerCylSet;
      ...
    }
    void finaliseCCDB(ConcreteDataMatcher& matcher, void* obj) {
-     GRPGeomHelper::instance()->finaliseCCDB(matcher, obj);
+     if (GRPGeomHelper::instance()->finaliseCCDB(matcher, obj)) {
+       return;
+     }
      ...
    }
    void run(ProcessingContext& pc) {
@@ -95,9 +100,10 @@ struct GRPGeomRequest {
   bool askGeomAlign = false;  // load aligned geometry
   bool askGeomIdeal = false;  // load ideal geometry
   bool askAlignments = false; // load detector alignments but don't apply them
+  bool askOnceAllButField = false; // for all entries but field query only once
 
   GRPGeomRequest() = delete;
-  GRPGeomRequest(bool orbitResetTime, bool GRPECS, bool GRPLHCIF, bool GRPMagField, bool askMatLUT, GeomRequest geom, std::vector<o2::framework::InputSpec>& inputs);
+  GRPGeomRequest(bool orbitResetTime, bool GRPECS, bool GRPLHCIF, bool GRPMagField, bool askMatLUT, GeomRequest geom, std::vector<o2::framework::InputSpec>& inputs, bool askOnce = false);
   void addInput(const o2::framework::InputSpec&& isp, std::vector<o2::framework::InputSpec>& inputs);
 };
 
@@ -113,7 +119,7 @@ class GRPGeomHelper
     return inst;
   }
   void setRequest(std::shared_ptr<GRPGeomRequest> req);
-  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj);
+  bool finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj);
   void checkUpdates(o2::framework::ProcessingContext& pc) const;
 
   auto getAlignment(o2::detectors::DetID det) const { return mAlignments[det]; }

--- a/Detectors/Base/src/GRPGeomHelper.cxx
+++ b/Detectors/Base/src/GRPGeomHelper.cxx
@@ -29,15 +29,14 @@
 #include "DataFormatsParameters/GRPLHCIFData.h"
 #include "DataFormatsParameters/GRPECSObject.h"
 #include "DataFormatsParameters/GRPMagField.h"
-#include "DataFormatsParameters/GRPMagField.h"
 
 using DetID = o2::detectors::DetID;
 using namespace o2::base;
 using namespace o2::framework;
 namespace o2d = o2::dataformats;
 
-GRPGeomRequest::GRPGeomRequest(bool orbitResetTime, bool GRPECS, bool GRPLHCIF, bool GRPMagField, bool askMatLUT, GeomRequest geom, std::vector<o2::framework::InputSpec>& inputs)
-  : askGRPECS(GRPECS), askGRPLHCIF(GRPLHCIF), askGRPMagField(GRPMagField), askMatLUT(askMatLUT), askTime(orbitResetTime)
+GRPGeomRequest::GRPGeomRequest(bool orbitResetTime, bool GRPECS, bool GRPLHCIF, bool GRPMagField, bool askMatLUT, GeomRequest geom, std::vector<o2::framework::InputSpec>& inputs, bool askOnce)
+  : askGRPECS(GRPECS), askGRPLHCIF(GRPLHCIF), askGRPMagField(GRPMagField), askMatLUT(askMatLUT), askTime(orbitResetTime), askOnceAllButField(askOnce)
 {
   if (geom == Aligned) {
     askGeomAlign = true;
@@ -87,7 +86,7 @@ void GRPGeomHelper::setRequest(std::shared_ptr<GRPGeomRequest> req)
   mRequest = req;
 }
 
-void GRPGeomHelper::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
+bool GRPGeomHelper::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
 {
   if (mRequest->askGRPMagField && matcher == ConcreteDataMatcher("GLO", "GRPMAGFIELD", 0)) {
     bool needInit = mGRPMagField == nullptr;
@@ -102,36 +101,36 @@ void GRPGeomHelper::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
       }
       o2::base::Propagator::Instance(false)->updateField();
     }
-    return;
+    return true;
   }
   if (mRequest->askGRPECS && matcher == ConcreteDataMatcher("GLO", "GRPECS", 0)) {
     mGRPECS = (o2::parameters::GRPECSObject*)obj;
     LOG(info) << "GRP ECS object updated";
-    return;
+    return true;
   }
   if (mRequest->askGRPLHCIF && matcher == ConcreteDataMatcher("GLO", "GRPLHCIF", 0)) {
     mGRPLHCIF = (o2::parameters::GRPLHCIFData*)obj;
     LOG(info) << "GRP LHCIF object updated";
-    return;
+    return true;
   }
   if (mRequest->askTime && matcher == ConcreteDataMatcher("CTP", "ORBITRESET", 0)) {
     mOrbitResetTimeMS = (*(std::vector<Long64_t>*)obj)[0] / 1000;
     LOG(info) << "orbit reset time updated to " << mOrbitResetTimeMS;
-    return;
+    return true;
   }
   if (mRequest->askMatLUT && matcher == ConcreteDataMatcher("GLO", "MATLUT", 0)) {
     LOG(info) << "material LUT updated";
     mMatLUT = o2::base::MatLayerCylSet::rectifyPtrFromFile((o2::base::MatLayerCylSet*)obj);
     o2::base::Propagator::Instance(false)->setMatLUT(mMatLUT);
-    return;
+    return true;
   }
   if (mRequest->askGeomAlign && matcher == ConcreteDataMatcher("GLO", "GEOMALIGN", 0)) {
     LOG(info) << "aligned geometry updated";
-    return;
+    return true;
   }
   if (mRequest->askGeomIdeal && matcher == ConcreteDataMatcher("GLO", "GEOMIDEAL", 0)) {
     LOG(info) << "ideal geometry updated";
-    return;
+    return true;
   }
   constexpr o2::header::DataDescription algDesc{"ALIGNMENT"};
   if (mRequest->askAlignments && matcher.description == algDesc) {
@@ -142,38 +141,43 @@ void GRPGeomHelper::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
         break;
       }
     }
-    return;
+    return true;
   }
+  return false;
 }
 
 void GRPGeomHelper::checkUpdates(ProcessingContext& pc) const
 {
   // request input just to trigger finaliseCCDB if there was an update
+  static bool initOnceDone = false;
   if (mRequest->askGRPMagField) {
     pc.inputs().get<o2::parameters::GRPMagField*>("grpfield");
   }
-  if (mRequest->askGRPLHCIF) {
+  if (mRequest->askGRPLHCIF && !initOnceDone) {
     pc.inputs().get<o2::parameters::GRPLHCIFData*>("grplhcif");
   }
-  if (mRequest->askGRPECS) {
+  if (mRequest->askGRPECS && !initOnceDone) {
     pc.inputs().get<o2::parameters::GRPECSObject*>("grpecs");
   }
-  if (mRequest->askTime) {
+  if (mRequest->askTime && !initOnceDone) {
     pc.inputs().get<std::vector<Long64_t>*>("orbitReset");
   }
-  if (mRequest->askMatLUT) {
+  if (mRequest->askMatLUT && !initOnceDone) {
     pc.inputs().get<o2::base::MatLayerCylSet*>("matLUT");
   }
-  if (mRequest->askGeomAlign) {
+  if (mRequest->askGeomAlign && !initOnceDone) {
     pc.inputs().get<TGeoManager*>("geomAlp");
   } else if (mRequest->askGeomIdeal) {
     pc.inputs().get<TGeoManager*>("geomIdeal");
   }
-  if (mRequest->askAlignments) {
+  if (mRequest->askAlignments && !initOnceDone) {
     for (auto id = DetID::First; id <= DetID::Last; id++) {
       std::string binding = fmt::format("align{}", DetID::getName(id));
       pc.inputs().get<std::vector<o2::detectors::AlignParam>*>(binding);
     }
+  }
+  if (!initOnceDone) {
+    initOnceDone = mRequest->askOnceAllButField;
   }
 }
 

--- a/Detectors/Calibration/src/TPCVDriftTglCalibration.cxx
+++ b/Detectors/Calibration/src/TPCVDriftTglCalibration.cxx
@@ -72,7 +72,7 @@ void TPCVDriftTglCalibration::finalizeSlot(Slot& slot)
   }
   double det = sS * sXX - sX * sX;
   if (!det || npval < 2) {
-    LOGP(alarm, "VDrift fit failed for slot {} ({}<=TF<={}) with {} entries: det={} npoints={}", slot.getTFStart(), slot.getTFEnd(), cont->entries, det, npval);
+    LOGP(alarm, "VDrift fit failed for slot {}<=TF<={} with {} entries: det={} npoints={}", slot.getTFStart(), slot.getTFEnd(), cont->entries, det, npval);
   } else {
     det = 1. / det;
     double offs = (sXX * sY - sX * sXY) * det, slope = (sS * sXY - sX * sY) * det;

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/AnalysisClusterSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/AnalysisClusterSpec.h
@@ -20,10 +20,14 @@
 #include "EMCALReconstruction/Clusterizer.h"
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
+#include "DetectorsBase/GRPGeomHelper.h"
 
 namespace o2
 {
-
+namespace framework
+{
+class ConcreteDataMatcher;
+}
 namespace emcal
 {
 
@@ -43,7 +47,7 @@ class AnalysisClusterSpec : public framework::Task
 {
  public:
   /// \brief Constructor
-  AnalysisClusterSpec() : framework::Task(){};
+  AnalysisClusterSpec(std::shared_ptr<o2::base::GRPGeomRequest> gr) : mGGCCDBRequest(gr){};
 
   /// \brief Destructor
   ~AnalysisClusterSpec() override = default;
@@ -51,7 +55,7 @@ class AnalysisClusterSpec : public framework::Task
   /// \brief Initializing the AnalysisClusterSpec
   /// \param ctx Init context
   void init(framework::InitContext& ctx) final;
-
+  void finaliseCCDB(framework::ConcreteDataMatcher& matcher, void* obj) final;
   /// \brief Run conversion of digits to cells
   /// \param ctx Processing context
   ///
@@ -62,10 +66,12 @@ class AnalysisClusterSpec : public framework::Task
   void run(framework::ProcessingContext& ctx) final;
 
  private:
+  void updateTimeDependentParams(framework::ProcessingContext& pc);
   o2::emcal::Clusterizer<InputType> mClusterizer;                        ///< Clusterizer object
   o2::emcal::Geometry* mGeometry = nullptr;                              ///< Pointer to geometry object
   o2::emcal::EventHandler<InputType>* mEventHandler = nullptr;           ///< Pointer to the event builder
   o2::emcal::ClusterFactory<InputType>* mClusterFactory = nullptr;       ///< Pointer to the cluster builder
+  std::shared_ptr<o2::base::GRPGeomRequest> mGGCCDBRequest;
   std::vector<o2::emcal::AnalysisCluster>* mOutputAnaClusters = nullptr; ///< Container with output clusters (pointer)
 };
 

--- a/Detectors/Filtering/src/FilteringSpec.cxx
+++ b/Detectors/Filtering/src/FilteringSpec.cxx
@@ -56,7 +56,6 @@
 #include "ReconstructionDataFormats/V0.h"
 #include "ReconstructionDataFormats/VtxTrackIndex.h"
 #include "ReconstructionDataFormats/VtxTrackRef.h"
-#include "SimulationDataFormat/DigitizationContext.h"
 #include "SimulationDataFormat/MCEventLabel.h"
 #include "SimulationDataFormat/MCTrack.h"
 #include "SimulationDataFormat/MCTruthContainer.h"

--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -2132,8 +2132,10 @@ void MatchTPCITS::setBunchFilling(const o2::BunchFilling& bf)
   mBunchFilling = bf;
   // find closest (from above) filled bunch
   int minBC = bf.getFirstFilledBC(), maxBC = bf.getLastFilledBC();
-  if (minBC < 0) {
-    throw std::runtime_error("Bunch filling is not set in MatchTPCITS");
+  if (minBC < 0 && mUseBCFilling) {
+    mUseBCFilling = false;
+    LOG(warning) << "Disabling match validation by BunchFilling as no interacting bunches found";
+    return;
   }
   int bcAbove = minBC;
   for (int i = o2::constants::lhc::LHCMaxBunches; i--;) {

--- a/Detectors/GlobalTrackingWorkflow/src/CosmicsMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/CosmicsMatchingSpec.cxx
@@ -45,6 +45,7 @@
 #include "Framework/Task.h"
 #include "Framework/CCDBParamSpec.h"
 #include "ITSMFTReconstruction/ClustererParam.h"
+#include "DetectorsBase/GRPGeomHelper.h"
 
 using namespace o2::framework;
 using MCLabelsTr = gsl::span<const o2::MCCompLabel>;
@@ -59,7 +60,7 @@ namespace globaltracking
 class CosmicsMatchingSpec : public Task
 {
  public:
-  CosmicsMatchingSpec(std::shared_ptr<DataRequest> dr, bool useMC) : mDataRequest(dr), mUseMC(useMC) {}
+  CosmicsMatchingSpec(std::shared_ptr<DataRequest> dr, std::shared_ptr<o2::base::GRPGeomRequest> gr, bool useMC) : mDataRequest(dr), mGGCCDBRequest(gr), mUseMC(useMC) {}
   ~CosmicsMatchingSpec() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
@@ -69,6 +70,7 @@ class CosmicsMatchingSpec : public Task
  private:
   void updateTimeDependentParams(ProcessingContext& pc);
   std::shared_ptr<DataRequest> mDataRequest;
+  std::shared_ptr<o2::base::GRPGeomRequest> mGGCCDBRequest;
   o2::globaltracking::MatchCosmics mMatching; // matching engine
   bool mUseMC = true;
   TStopwatch mTimer;
@@ -78,22 +80,7 @@ void CosmicsMatchingSpec::init(InitContext& ic)
 {
   mTimer.Stop();
   mTimer.Reset();
-  //-------- init geometry and field --------//
-  o2::base::GeometryManager::loadGeometry();
-  o2::base::Propagator::initFieldFromGRP();
-  o2::its::GeometryTGeo::Instance()->fillMatrixCache(o2::math_utils::bit2Mask(o2::math_utils::TransformType::T2GRot) | o2::math_utils::bit2Mask(o2::math_utils::TransformType::T2L));
-
-  // this is a hack to provide Mat.LUT from the local file, in general will be provided by the framework from CCDB
-  std::string matLUTPath = ic.options().get<std::string>("material-lut-path");
-  std::string matLUTFile = o2::base::NameConf::getMatLUTFileName(matLUTPath);
-  if (o2::utils::Str::pathExists(matLUTFile)) {
-    auto* lut = o2::base::MatLayerCylSet::loadFromFile(matLUTFile);
-    o2::base::Propagator::Instance()->setMatLUT(lut);
-    LOG(info) << "Loaded material LUT from " << matLUTFile;
-  } else {
-    LOG(info) << "Material LUT " << matLUTFile << " file is absent, only TGeo can be used";
-  }
-
+  o2::base::GRPGeomHelper::instance().setRequest(mGGCCDBRequest);
   mMatching.setDebugFlag(ic.options().get<int>("debug-tree-flags"));
   mMatching.setUseMC(mUseMC);
   //
@@ -116,13 +103,15 @@ void CosmicsMatchingSpec::run(ProcessingContext& pc)
 
 void CosmicsMatchingSpec::updateTimeDependentParams(ProcessingContext& pc)
 {
+  o2::base::GRPGeomHelper::instance().checkUpdates(pc);
   static bool initOnceDone = false;
   if (!initOnceDone) { // this params need to be queried only once
     initOnceDone = true;
+    o2::its::GeometryTGeo::Instance()->fillMatrixCache(o2::math_utils::bit2Mask(o2::math_utils::TransformType::T2GRot) | o2::math_utils::bit2Mask(o2::math_utils::TransformType::T2L));
 
     // pc.inputs().get<o2::itsmft::TopologyDictionary*>("cldict"); // called by the RecoContainer
     // also alpParams is called by the RecoContainer
-    std::unique_ptr<o2::parameters::GRPObject> grp{o2::parameters::GRPObject::loadFrom()};
+    auto grp = o2::base::GRPGeomHelper::instance().getGRPECS();
     const auto& alpParams = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance();
     if (!grp->isDetContinuousReadOut(DetID::ITS)) {
       mMatching.setITSROFrameLengthMUS(alpParams.roFrameLengthTrig / 1.e3); // ITS ROFrame duration in \mus
@@ -136,9 +125,13 @@ void CosmicsMatchingSpec::updateTimeDependentParams(ProcessingContext& pc)
 
 void CosmicsMatchingSpec::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
 {
+  if (o2::base::GRPGeomHelper::instance().finaliseCCDB(matcher, obj)) {
+    return;
+  }
   if (matcher == ConcreteDataMatcher("ITS", "CLUSDICT", 0)) {
     LOG(info) << "cluster dictionary updated";
     mMatching.setITSDict((const o2::itsmft::TopologyDictionary*)obj);
+    return;
   }
 }
 
@@ -162,11 +155,19 @@ DataProcessorSpec getCosmicsMatchingSpec(GTrackID::mask_t src, bool useMC)
     outputs.emplace_back("GLO", "COSMICTRC_MC", 0, Lifetime::Timeframe);
   }
 
+  auto ggRequest = std::make_shared<o2::base::GRPGeomRequest>(false,                             // orbitResetTime
+                                                              false,                             // GRPECS=true
+                                                              false,                             // GRPLHCIF
+                                                              true,                              // GRPMagField
+                                                              true,                              // askMatLUT
+                                                              o2::base::GRPGeomRequest::Aligned, // geometry
+                                                              dataRequest->inputs,
+                                                              true);
   return DataProcessorSpec{
     "cosmics-matcher",
     dataRequest->inputs,
     outputs,
-    AlgorithmSpec{adaptFromTask<CosmicsMatchingSpec>(dataRequest, useMC)},
+    AlgorithmSpec{adaptFromTask<CosmicsMatchingSpec>(dataRequest, ggRequest, useMC)},
     Options{
       {"material-lut-path", VariantType::String, "", {"Path of the material LUT file"}},
       {"debug-tree-flags", VariantType::Int, 0, {"DebugFlagTypes bit-pattern for debug tree"}}}};

--- a/Detectors/GlobalTrackingWorkflow/src/tof-eventtime-checker-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/tof-eventtime-checker-workflow.cxx
@@ -97,21 +97,6 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     }
   }
 
-  if (!o2::tof::Utils::hasFillScheme()) {
-    // check collision context
-    auto mcReader = std::make_unique<o2::steer::MCKinematicsReader>("collisioncontext.root");
-    auto context = mcReader->getDigitizationContext();
-    if (!context) {
-      auto bcf = context->getBunchFilling();
-      std::bitset<3564> isInBC = bcf.getBCPattern();
-      for (int i = 0; i < isInBC.size(); i++) {
-        if (isInBC.test(i)) {
-          o2::tof::Utils::addInteractionBC(i, true);
-        }
-      }
-    }
-  }
-
   LOG(debug) << "TOF EVENTTIME CHECKER WORKFLOW configuration";
   LOG(debug) << "TOF track inputs = " << configcontext.options().get<std::string>("track-sources");
 

--- a/Detectors/GlobalTrackingWorkflow/src/tof-matcher-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/tof-matcher-workflow.cxx
@@ -150,23 +150,6 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 
   specs.emplace_back(o2::globaltracking::getTOFMatcherSpec(src, useMC, useFIT, false, strict, extratolerancetrd)); // doTPCrefit not yet supported (need to load TPC clusters?)
 
-  // initialize collision context
-  if (gSystem->AccessPathName("collisioncontext.root")) {
-    LOG(info) << "collisioncontext.root not available, let's skip it (cosmics?) ";
-  } else {
-    auto mcReader = std::make_unique<o2::steer::MCKinematicsReader>("collisioncontext.root");
-    auto context = mcReader->getDigitizationContext();
-    if (context) {
-      auto bcf = context->getBunchFilling();
-      std::bitset<3564> isInBC = bcf.getBCPattern();
-      for (unsigned int i = 0; i < isInBC.size(); i++) {
-        if (isInBC.test(i)) {
-          o2::tof::Utils::addInteractionBC(i, true);
-        }
-      }
-    }
-  }
-
   if (!disableRootOut) {
     std::vector<DataProcessorSpec> writers;
     if (writematching) {

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCInterpolationSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCInterpolationSpec.h
@@ -21,6 +21,7 @@
 #include "Framework/Task.h"
 #include "TStopwatch.h"
 #include "ReconstructionDataFormats/GlobalTrackID.h"
+#include "DetectorsBase/GRPGeomHelper.h"
 
 using namespace o2::framework;
 
@@ -36,16 +37,19 @@ namespace tpc
 class TPCInterpolationDPL : public Task
 {
  public:
-  TPCInterpolationDPL(std::shared_ptr<o2::globaltracking::DataRequest> dr, bool useMC, bool processITSTPConly, bool writeResiduals) : mDataRequest(dr), mUseMC(useMC), mProcessITSTPConly(processITSTPConly), mWriteResiduals(writeResiduals) {}
+  TPCInterpolationDPL(std::shared_ptr<o2::globaltracking::DataRequest> dr, std::shared_ptr<o2::base::GRPGeomRequest> gr, bool useMC, bool processITSTPConly, bool writeResiduals) : mDataRequest(dr), mGGCCDBRequest(gr), mUseMC(useMC), mProcessITSTPConly(processITSTPConly), mWriteResiduals(writeResiduals) {}
   ~TPCInterpolationDPL() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
   void endOfStream(EndOfStreamContext& ec) final;
+  void finaliseCCDB(ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
+  void updateTimeDependentParams(ProcessingContext& pc);
   o2::tpc::TrackInterpolation mInterpolation;                    ///< track interpolation engine
   o2::tpc::TrackResiduals mResidualProcessor;                    ///< conversion and avg. distortion map creation engine
   std::shared_ptr<o2::globaltracking::DataRequest> mDataRequest; ///< steers the input
+  std::shared_ptr<o2::base::GRPGeomRequest> mGGCCDBRequest;
   bool mUseMC{false}; ///< MC flag
   bool mProcessITSTPConly{false}; ///< should also tracks without outer point (ITS-TPC only) be processed?
   bool mWriteResiduals{false};    ///< whether or not the unbinned unfiltered residuals should be sent out

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
@@ -41,12 +41,30 @@ namespace tpc
 void TPCInterpolationDPL::init(InitContext& ic)
 {
   //-------- init geometry and field --------//
-  o2::base::GeometryManager::loadGeometry();
-  o2::base::Propagator::initFieldFromGRP();
   mTimer.Stop();
   mTimer.Reset();
-  mInterpolation.init();
-  mResidualProcessor.init(false, o2::base::Propagator::Instance()->getNominalBz()); // initialize but skip the binning which is needed only later
+  o2::base::GRPGeomHelper::instance().setRequest(mGGCCDBRequest);
+}
+
+void TPCInterpolationDPL::updateTimeDependentParams(ProcessingContext& pc)
+{
+  o2::base::GRPGeomHelper::instance().checkUpdates(pc);
+  static bool initOnceDone = false;
+  if (!initOnceDone) { // this params need to be queried only once
+    initOnceDone = true;
+    // other init-once stuff
+
+    mInterpolation.init();
+    mResidualProcessor.init(false, o2::base::Propagator::Instance()->getNominalBz()); // initialize but skip the binning which is needed only later
+  }
+  // we may have other params which need to be queried regularly
+}
+
+void TPCInterpolationDPL::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
+{
+  if (o2::base::GRPGeomHelper::instance().finaliseCCDB(matcher, obj)) {
+    return;
+  }
 }
 
 void TPCInterpolationDPL::run(ProcessingContext& pc)
@@ -55,6 +73,7 @@ void TPCInterpolationDPL::run(ProcessingContext& pc)
   mTimer.Start(false);
   RecoContainer recoData;
   recoData.collectData(pc, *mDataRequest.get());
+  updateTimeDependentParams(pc);
 
   // load the input tracks
   std::vector<o2::globaltracking::RecoContainer::GlobalIDSet> gidTables;
@@ -153,6 +172,14 @@ DataProcessorSpec getTPCInterpolationSpec(GTrackID::mask_t src, bool useMC, bool
   dataRequest->requestTracks(src, useMC);
   dataRequest->requestClusters(src, useMC);
 
+  auto ggRequest = std::make_shared<o2::base::GRPGeomRequest>(false,                             // orbitResetTime
+                                                              true,                              // GRPECS=true
+                                                              false,                             // GRPLHCIF
+                                                              true,                              // GRPMagField
+                                                              true,                              // askMatLUT
+                                                              o2::base::GRPGeomRequest::Aligned, // geometry
+                                                              dataRequest->inputs,
+                                                              true);
   if (writeResiduals) {
     outputs.emplace_back("GLO", "TPCINT_TRK", 0, Lifetime::Timeframe);
     outputs.emplace_back("GLO", "TPCINT_RES", 0, Lifetime::Timeframe);
@@ -163,7 +190,7 @@ DataProcessorSpec getTPCInterpolationSpec(GTrackID::mask_t src, bool useMC, bool
     "tpc-track-interpolation",
     dataRequest->inputs,
     outputs,
-    AlgorithmSpec{adaptFromTask<TPCInterpolationDPL>(dataRequest, useMC, processITSTPConly, writeResiduals)},
+    AlgorithmSpec{adaptFromTask<TPCInterpolationDPL>(dataRequest, ggRequest, useMC, processITSTPConly, writeResiduals)},
     Options{}};
 }
 

--- a/Detectors/ITSMFT/ITS/QC/TestDataReaderWorkflow/src/TestDataReader.cxx
+++ b/Detectors/ITSMFT/ITS/QC/TestDataReaderWorkflow/src/TestDataReader.cxx
@@ -25,7 +25,6 @@
 #include "ITSMFTReconstruction/RawPixelReader.h"
 #include "CommonDataFormat/InteractionRecord.h"
 #include "ITSQCDataReaderWorkflow/TestDataReader.h"
-#include "DetectorsBase/GeometryManager.h"
 #include <TCanvas.h>
 #include <iostream>
 #include <dirent.h>
@@ -68,8 +67,6 @@ void TestDataReader::init(InitContext& ic)
 
   LOG(debug) << "OLD CONFIG: EventPerPush = " << mEventPerPush << "   TrackError = " << mTrackError << "  WorkDir = " << mWorkDir;
   LOG(debug) << "DONE Reset Histogram Decision";
-
-  o2::base::GeometryManager::loadGeometry();
 
   mFolderNames = GetFName(mWorkDir);
 

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/CookedTrackerSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/CookedTrackerSpec.h
@@ -23,6 +23,7 @@
 #include "DataFormatsITSMFT/TopologyDictionary.h"
 #include "Framework/Task.h"
 #include "TStopwatch.h"
+#include "DetectorsBase/GRPGeomHelper.h"
 
 using namespace o2::framework;
 
@@ -34,7 +35,7 @@ namespace its
 class CookedTrackerDPL : public Task
 {
  public:
-  CookedTrackerDPL(bool useMC, const std::string& trMode);
+  CookedTrackerDPL(std::shared_ptr<o2::base::GRPGeomRequest> gr, bool useMC, const std::string& trMode);
   ~CookedTrackerDPL() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
@@ -45,6 +46,7 @@ class CookedTrackerDPL : public Task
  private:
   void updateTimeDependentParams(ProcessingContext& pc);
 
+  std::shared_ptr<o2::base::GRPGeomRequest> mGGCCDBRequest;
   int mState = 0;
   bool mUseMC = true;
   bool mRunVertexer = true;

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/TrackerSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/TrackerSpec.h
@@ -31,6 +31,7 @@
 #include "GPUChainITS.h"
 #include "CommonUtils/StringUtils.h"
 #include "TStopwatch.h"
+#include "DetectorsBase/GRPGeomHelper.h"
 
 namespace o2
 {
@@ -40,7 +41,7 @@ namespace its
 class TrackerDPL : public framework::Task
 {
  public:
-  TrackerDPL(bool isMC, const std::string& trModeS, o2::gpu::GPUDataTypes::DeviceType dType = o2::gpu::GPUDataTypes::DeviceType::CPU); // : mIsMC{isMC} {}
+  TrackerDPL(std::shared_ptr<o2::base::GRPGeomRequest> gr, bool isMC, const std::string& trModeS, o2::gpu::GPUDataTypes::DeviceType dType = o2::gpu::GPUDataTypes::DeviceType::CPU); // : mIsMC{isMC} {}
   ~TrackerDPL() override = default;
   void init(framework::InitContext& ic) final;
   void run(framework::ProcessingContext& pc) final;
@@ -54,12 +55,11 @@ class TrackerDPL : public framework::Task
   bool mIsMC = false;
   bool mRunVertexer = true;
   bool mCosmicsProcessing = false;
-  float mBz = 0.f;
   std::string mMode = "sync";
+  std::shared_ptr<o2::base::GRPGeomRequest> mGGCCDBRequest;
   const o2::itsmft::TopologyDictionary* mDict = nullptr;
   std::unique_ptr<o2::gpu::GPUReconstruction> mRecChain = nullptr;
   std::unique_ptr<o2::gpu::GPUChainITS> mChainITS = nullptr;
-  std::unique_ptr<parameters::GRPObject> mGRP = nullptr;
   std::unique_ptr<Tracker> mTracker = nullptr;
   std::unique_ptr<Vertexer> mVertexer = nullptr;
   TStopwatch mTimer;

--- a/Detectors/ITSMFT/MFT/assessment/src/MFTAssessment.cxx
+++ b/Detectors/ITSMFT/MFT/assessment/src/MFTAssessment.cxx
@@ -11,7 +11,6 @@
 
 #include "MFTAssessment/MFTAssessment.h"
 #include "Framework/InputSpec.h"
-#include "DetectorsBase/GeometryManager.h"
 #include "MFTBase/GeometryTGeo.h"
 #include "MathUtils/Utils.h"
 #include <Framework/InputRecord.h>
@@ -29,9 +28,6 @@ void MFTAssessment::init(bool finalizeAnalysis)
 {
   mFinalizeAnalysis = finalizeAnalysis;
   createHistos();
-  // get geometry
-  o2::base::GeometryManager::loadGeometry();
-
   mUnusedChips.fill(true);
 }
 

--- a/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/MFTAssessmentSpec.h
+++ b/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/MFTAssessmentSpec.h
@@ -18,6 +18,7 @@
 #include "Framework/Task.h"
 #include "MFTAssessment/MFTAssessment.h"
 #include "TStopwatch.h"
+#include "DetectorsBase/GRPGeomHelper.h"
 
 using namespace o2::framework;
 
@@ -28,9 +29,7 @@ namespace mft
 class MFTAssessmentSpec : public Task
 {
  public:
-  MFTAssessmentSpec(bool useMC, bool processGen, bool finalizeAnalysis = false) : mUseMC(useMC),
-                                                                                  mProcessGen(processGen),
-                                                                                  mFinalizeAnalysis(finalizeAnalysis){};
+  MFTAssessmentSpec(std::shared_ptr<o2::base::GRPGeomRequest> gr, bool useMC, bool processGen, bool finalizeAnalysis = false) : mGGCCDBRequest(gr), mUseMC(useMC), mProcessGen(processGen), mFinalizeAnalysis(finalizeAnalysis){};
   void init(o2::framework::InitContext& ic) final;
   void run(o2::framework::ProcessingContext& pc) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
@@ -40,6 +39,7 @@ class MFTAssessmentSpec : public Task
   void updateTimeDependentParams(ProcessingContext& pc);
   void sendOutput(DataAllocator& output);
   std::unique_ptr<o2::mft::MFTAssessment> mMFTAssessment;
+  std::shared_ptr<o2::base::GRPGeomRequest> mGGCCDBRequest;
   bool mUseMC = true;
   bool mProcessGen = false;
   bool mFinalizeAnalysis = false;

--- a/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/TrackerSpec.h
+++ b/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/TrackerSpec.h
@@ -15,6 +15,7 @@
 #define O2_MFT_TRACKERDPL_H_
 
 #include "MFTTracking/Tracker.h"
+#include "DetectorsBase/GRPGeomHelper.h"
 
 #include "Framework/DataProcessorSpec.h"
 #include "MFTTracking/TrackCA.h"
@@ -33,7 +34,7 @@ class TrackerDPL : public o2::framework::Task
 {
 
  public:
-  TrackerDPL(bool useMC) : mUseMC(useMC) {}
+  TrackerDPL(std::shared_ptr<o2::base::GRPGeomRequest> gr, bool useMC) : mGGCCDBRequest(gr), mUseMC(useMC) {}
   ~TrackerDPL() override = default;
   void init(framework::InitContext& ic) final;
   void run(framework::ProcessingContext& pc) final;
@@ -45,6 +46,7 @@ class TrackerDPL : public o2::framework::Task
 
   bool mUseMC = false;
   bool mFieldOn = true;
+  std::shared_ptr<o2::base::GRPGeomRequest> mGGCCDBRequest;
   const o2::itsmft::TopologyDictionary* mDict = nullptr;
   std::unique_ptr<o2::parameters::GRPObject> mGRP = nullptr;
   std::unique_ptr<o2::mft::Tracker<TrackLTF>> mTracker = nullptr;

--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/STFDecoderSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/STFDecoderSpec.h
@@ -30,6 +30,10 @@ using namespace o2::framework;
 
 namespace o2
 {
+namespace base
+{
+class GRPGeomRequest;
+}
 namespace itsmft
 {
 class Clusterer;
@@ -50,7 +54,7 @@ template <class Mapping>
 class STFDecoder : public Task
 {
  public:
-  STFDecoder(const STFDecoderInp& inp);
+  STFDecoder(const STFDecoderInp& inp, std::shared_ptr<o2::base::GRPGeomRequest> gr);
   STFDecoder() = default;
   ~STFDecoder() override = default;
   void init(InitContext& ic) final;
@@ -86,6 +90,7 @@ class STFDecoder : public Task
   std::string mSelfName;
   std::unique_ptr<RawPixelDecoder<Mapping>> mDecoder;
   std::unique_ptr<Clusterer> mClusterer;
+  std::shared_ptr<o2::base::GRPGeomRequest> mGGCCDBRequest;
 };
 
 using STFDecoderITS = STFDecoder<ChipMappingITS>;

--- a/Detectors/TOF/base/src/Geo.cxx
+++ b/Detectors/TOF/base/src/Geo.cxx
@@ -45,8 +45,7 @@ void Geo::Init()
   LOG(info) << "tof::Geo: Initialization of TOF rotation parameters";
 
   if (!gGeoManager) {
-    LOG(info) << " no TGeo! Loading it";
-    o2::base::GeometryManager::loadGeometry();
+    LOG(fatal) << "geometry is not loaded";
   }
 
   int det[5];

--- a/Detectors/TRD/base/src/TrackletTransformer.cxx
+++ b/Detectors/TRD/base/src/TrackletTransformer.cxx
@@ -19,7 +19,6 @@ using namespace o2::trd::constants;
 
 void TrackletTransformer::init()
 {
-  o2::base::GeometryManager::loadGeometry();
   mGeo = Geometry::instance();
   mGeo->createPadPlaneArray();
   mGeo->createClusterMatrixArray();

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDGlobalTrackingSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDGlobalTrackingSpec.h
@@ -27,6 +27,7 @@
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/ConstMCTruthContainer.h"
 #include <memory>
+#include "DetectorsBase/GRPGeomHelper.h"
 
 #include "GPUO2InterfaceRefit.h"
 #include "TPCFastTransform.h"
@@ -44,10 +45,9 @@ namespace trd
 class TRDGlobalTracking : public o2::framework::Task
 {
  public:
-  TRDGlobalTracking(bool useMC, std::shared_ptr<o2::globaltracking::DataRequest> dataRequest, o2::dataformats::GlobalTrackID::mask_t src, bool trigRecFilterActive, bool strict) : mUseMC(useMC), mDataRequest(dataRequest), mTrkMask(src), mTrigRecFilter(trigRecFilterActive), mStrict(strict) {}
+  TRDGlobalTracking(bool useMC, std::shared_ptr<o2::globaltracking::DataRequest> dataRequest, std::shared_ptr<o2::base::GRPGeomRequest> gr, o2::dataformats::GlobalTrackID::mask_t src, bool trigRecFilterActive, bool strict) : mUseMC(useMC), mDataRequest(dataRequest), mGGCCDBRequest(gr), mTrkMask(src), mTrigRecFilter(trigRecFilterActive), mStrict(strict) {}
   ~TRDGlobalTracking() override = default;
   void init(o2::framework::InitContext& ic) final;
-  void updateTimeDependentParams(o2::framework::ProcessingContext& pc);
   void fillMCTruthInfo(const TrackTRD& trk, o2::MCCompLabel lblSeed, std::vector<o2::MCCompLabel>& lblContainerTrd, std::vector<o2::MCCompLabel>& lblContainerMatch, const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* trkltLabels) const;
   void fillTrackTriggerRecord(const std::vector<TrackTRD>& tracks, std::vector<TrackTriggerRecord>& trigRec, const gsl::span<const o2::trd::TriggerRecord>& trackletTrigRec) const;
   void run(o2::framework::ProcessingContext& pc) final;
@@ -58,6 +58,8 @@ class TRDGlobalTracking : public o2::framework::Task
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
 
  private:
+  void updateTimeDependentParams(o2::framework::ProcessingContext& pc);
+
   o2::gpu::GPUTRDTracker* mTracker{nullptr};          ///< TRD tracking engine
   o2::gpu::GPUReconstruction* mRec{nullptr};          ///< GPU reconstruction pointer, handles memory for the tracker
   o2::gpu::GPUChainTracking* mChainTracking{nullptr}; ///< TRD tracker is run in the tracking chain
@@ -67,6 +69,7 @@ class TRDGlobalTracking : public o2::framework::Task
   float mTPCTBinMUSInv{1.f / mTPCTBinMUS};            ///< inverse width of a TPC time bin in 1/us
   float mTPCVdrift{2.58f};                            ///< TPC drift velocity (for shifting TPC tracks along Z)
   std::shared_ptr<o2::globaltracking::DataRequest> mDataRequest; ///< seeding input (TPC-only, ITS-TPC or both)
+  std::shared_ptr<o2::base::GRPGeomRequest> mGGCCDBRequest;
   o2::dataformats::GlobalTrackID::mask_t mTrkMask;               ///< seeding track sources (TPC, ITS-TPC)
   bool mTrigRecFilter{false};                                    ///< if true, TRD trigger records without matching ITS IR are filtered out
   bool mStrict{false};                                           ///< preliminary matching in strict mode

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrackletTransformerSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrackletTransformerSpec.h
@@ -12,6 +12,7 @@
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
 #include "DataFormatsGlobalTracking/RecoContainer.h"
+#include "DetectorsBase/GRPGeomHelper.h"
 
 #include "TRDBase/TrackletTransformer.h"
 
@@ -23,7 +24,7 @@ namespace trd
 class TRDTrackletTransformerSpec : public o2::framework::Task
 {
  public:
-  TRDTrackletTransformerSpec(std::shared_ptr<o2::globaltracking::DataRequest> dataRequest, bool trigRecFilterActive, bool applyXOR) : mDataRequest(dataRequest), mTrigRecFilterActive(trigRecFilterActive), mApplyXOR(applyXOR){};
+  TRDTrackletTransformerSpec(std::shared_ptr<o2::globaltracking::DataRequest> dataRequest, std::shared_ptr<o2::base::GRPGeomRequest> gr, bool trigRecFilterActive, bool applyXOR) : mDataRequest(dataRequest), mGGCCDBRequest(gr), mTrigRecFilterActive(trigRecFilterActive), mApplyXOR(applyXOR){};
   ~TRDTrackletTransformerSpec() override = default;
   void init(o2::framework::InitContext& ic) override;
   void run(o2::framework::ProcessingContext& pc) override;
@@ -33,6 +34,7 @@ class TRDTrackletTransformerSpec : public o2::framework::Task
   void updateTimeDependentParams(framework::ProcessingContext& pc);
 
   std::shared_ptr<o2::globaltracking::DataRequest> mDataRequest;
+  std::shared_ptr<o2::base::GRPGeomRequest> mGGCCDBRequest;
   bool mTrigRecFilterActive; ///< if true, transform only TRD tracklets for which ITS data is available
   bool mApplyXOR;            ///< if true, the 8-th bit of position and slope will be inverted before transformation in chamber coordinates
   TrackletTransformer mTransformer;

--- a/Detectors/TRD/workflow/src/TRDGlobalTrackingQCSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDGlobalTrackingQCSpec.cxx
@@ -24,6 +24,7 @@
 #include "TRDQC/Tracking.h"
 #include <TFile.h>
 #include <TTree.h>
+#include "DetectorsBase/GRPGeomHelper.h"
 
 using namespace o2::framework;
 using namespace o2::globaltracking;
@@ -37,24 +38,23 @@ namespace trd
 class TRDGlobalTrackingQC : public Task
 {
  public:
-  TRDGlobalTrackingQC(std::shared_ptr<DataRequest> dr) : mDataRequest(dr) {}
+  TRDGlobalTrackingQC(std::shared_ptr<DataRequest> dr, std::shared_ptr<o2::base::GRPGeomRequest> gr) : mDataRequest(dr), mGGCCDBRequest(gr) {}
   ~TRDGlobalTrackingQC() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
   void endOfStream(framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(framework::ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
+  void updateTimeDependentParams(framework::ProcessingContext& pc);
   std::shared_ptr<DataRequest> mDataRequest;
+  std::shared_ptr<o2::base::GRPGeomRequest> mGGCCDBRequest;
   Tracking mQC;
 };
 
 void TRDGlobalTrackingQC::init(InitContext& ic)
 {
-  //-------- init geometry and field --------//
-  o2::base::GeometryManager::loadGeometry();
-  o2::base::Propagator::initFieldFromGRP();
-  std::unique_ptr<o2::parameters::GRPObject> grp{o2::parameters::GRPObject::loadFrom()};
-  mQC.init();
+  o2::base::GRPGeomHelper::instance().setRequest(mGGCCDBRequest);
 }
 
 void TRDGlobalTrackingQC::run(ProcessingContext& pc)
@@ -80,6 +80,24 @@ void TRDGlobalTrackingQC::endOfStream(EndOfStreamContext& ec)
   fOut->Close();
 }
 
+void TRDGlobalTrackingQC::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
+{
+  if (o2::base::GRPGeomHelper::instance().finaliseCCDB(matcher, obj)) {
+    return;
+  }
+}
+
+void TRDGlobalTrackingQC::updateTimeDependentParams(ProcessingContext& pc)
+{
+  o2::base::GRPGeomHelper::instance().checkUpdates(pc);
+  static bool initOnceDone = false;
+  if (!initOnceDone) { // this params need to be queried only once
+    initOnceDone = true;
+
+    mQC.init();
+  }
+}
+
 DataProcessorSpec getTRDGlobalTrackingQCSpec(o2::dataformats::GlobalTrackID::mask_t src)
 {
   std::vector<OutputSpec> outputs;
@@ -98,12 +116,19 @@ DataProcessorSpec getTRDGlobalTrackingQCSpec(o2::dataformats::GlobalTrackID::mas
   std::cout << src << std::endl;
   dataRequest->requestTracks(src, false);
   dataRequest->requestClusters(srcClu, false);
-
+  auto ggRequest = std::make_shared<o2::base::GRPGeomRequest>(false,                             // orbitResetTime
+                                                              false,                             // GRPECS=true
+                                                              false,                             // GRPLHCIF
+                                                              true,                              // GRPMagField
+                                                              false,                             // askMatLUT
+                                                              o2::base::GRPGeomRequest::Aligned, // geometry
+                                                              dataRequest->inputs,
+                                                              true);
   return DataProcessorSpec{
     "trd-tracking-qc",
     dataRequest->inputs,
     outputs,
-    AlgorithmSpec{adaptFromTask<TRDGlobalTrackingQC>(dataRequest)},
+    AlgorithmSpec{adaptFromTask<TRDGlobalTrackingQC>(dataRequest, ggRequest)},
     Options{}};
 }
 

--- a/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
@@ -64,78 +64,76 @@ namespace trd
 
 void TRDGlobalTracking::init(InitContext& ic)
 {
-
-  //-------- init geometry and field --------//
-  o2::base::GeometryManager::loadGeometry();
-  o2::base::Propagator::initFieldFromGRP();
-  auto geo = Geometry::instance();
-  o2::its::GeometryTGeo::Instance()->fillMatrixCache(o2::math_utils::bit2Mask(o2::math_utils::TransformType::T2GRot) | o2::math_utils::bit2Mask(o2::math_utils::TransformType::T2L));
-  geo->createPadPlaneArray();
-  geo->createClusterMatrixArray();
-  mFlatGeo = std::make_unique<GeometryFlat>(*geo);
-
-  // this is a hack to provide Mat.LUT from the local file, in general will be provided by the framework from CCDB
-  std::string matLUTPath = ic.options().get<std::string>("material-lut-path");
-  std::string matLUTFile = o2::base::NameConf::getMatLUTFileName(matLUTPath);
-  if (o2::utils::Str::pathExists(matLUTFile)) {
-    auto* lut = o2::base::MatLayerCylSet::loadFromFile(matLUTFile);
-    o2::base::Propagator::Instance()->setMatLUT(lut);
-    LOG(info) << "Loaded material LUT from " << matLUTFile;
-  } else {
-    LOG(info) << "Material LUT " << matLUTFile << " file is absent, only TGeo can be used";
-  }
-
-  //-------- init GPU reconstruction --------//
-  GPURecoStepConfiguration cfgRecoStep;
-  cfgRecoStep.steps = GPUDataTypes::RecoStep::NoRecoStep;
-  cfgRecoStep.inputs.clear();
-  cfgRecoStep.outputs.clear();
-  mRec = GPUReconstruction::CreateInstance("CPU", true);
-  mRec->SetSettings(o2::base::Propagator::Instance()->getNominalBz(), &cfgRecoStep);
-  mRec->GetNonConstParam().rec.trd.useExternalO2DefaultPropagator = true;
-
-  mChainTracking = mRec->AddChain<GPUChainTracking>();
-
-  mTracker = new GPUTRDTracker();
-  mTracker->SetNCandidates(mRec->GetProcessingSettings().trdNCandidates); // must be set before initialization
-  if (mStrict && mRec->GetProcessingSettings().trdNCandidates == 1) {
-    LOG(error) << "Strict matching mode requested, but tracks with another close hypothesis will not be rejected. Please set trdNCandidates to at least 3.";
-  }
-  mTracker->SetProcessPerTimeFrame(true);
-  mTracker->SetGenerateSpacePoints(false); // set to true to force space point calculation by the TRD tracker itself
-
-  mRec->RegisterGPUProcessor(mTracker, false);
-  mChainTracking->SetTRDGeometry(std::move(mFlatGeo));
-  if (mRec->Init()) {
-    LOG(fatal) << "GPUReconstruction could not be initialized";
-  }
-
-  std::unique_ptr<o2::gpu::TPCFastTransform> fastTransform = (o2::tpc::TPCFastTransformHelperO2::instance()->create(0));
-  mTPCTransform = std::move(fastTransform);
-  mRecoParam.setBfield(o2::base::Propagator::Instance()->getNominalBz());
-
-  mTracker->PrintSettings();
-  LOG(info) << "Strict matching mode is " << ((mStrict) ? "ON" : "OFF");
-  LOGF(info, "The search road in time for ITS-TPC tracks is set to %.1f sigma and %.2f us are added to it on top",
-       mRec->GetParam().rec.trd.nSigmaTerrITSTPC, mRec->GetParam().rec.trd.addTimeRoadITSTPC);
-
+  o2::base::GRPGeomHelper::instance().setRequest(mGGCCDBRequest);
   mTimer.Stop();
   mTimer.Reset();
 }
 
 void TRDGlobalTracking::updateTimeDependentParams(ProcessingContext& pc)
 {
-  // strictly speaking, one should do this only in case of the CCDB objects update
-  // TODO: add CCDB interface
-
+  o2::base::GRPGeomHelper::instance().checkUpdates(pc);
   // pc.inputs().get<TopologyDictionary*>("cldict"); // called by the RecoContainer to trigger finaliseCCDB
+  static bool initOnceDone = false;
+  if (!initOnceDone) { // this params need to be queried only once
+    initOnceDone = true;
+    // init-once stuff
 
+    auto geo = Geometry::instance();
+    o2::its::GeometryTGeo::Instance()->fillMatrixCache(o2::math_utils::bit2Mask(o2::math_utils::TransformType::T2GRot) | o2::math_utils::bit2Mask(o2::math_utils::TransformType::T2L));
+    geo->createPadPlaneArray();
+    geo->createClusterMatrixArray();
+    mFlatGeo = std::make_unique<GeometryFlat>(*geo);
+
+    GPURecoStepConfiguration cfgRecoStep;
+    cfgRecoStep.steps = GPUDataTypes::RecoStep::NoRecoStep;
+    cfgRecoStep.inputs.clear();
+    cfgRecoStep.outputs.clear();
+    mRec = GPUReconstruction::CreateInstance("CPU", true);
+    mRec->SetSettings(o2::base::Propagator::Instance()->getNominalBz(), &cfgRecoStep);
+    mRec->GetNonConstParam().rec.trd.useExternalO2DefaultPropagator = true;
+    mChainTracking = mRec->AddChain<GPUChainTracking>();
+
+    mTracker = new GPUTRDTracker();
+    mTracker->SetNCandidates(mRec->GetProcessingSettings().trdNCandidates); // must be set before initialization
+    if (mStrict && mRec->GetProcessingSettings().trdNCandidates == 1) {
+      LOG(error) << "Strict matching mode requested, but tracks with another close hypothesis will not be rejected. Please set trdNCandidates to at least 3.";
+    }
+    mTracker->SetProcessPerTimeFrame(true);
+    mTracker->SetGenerateSpacePoints(false); // set to true to force space point calculation by the TRD tracker itself
+
+    mRec->RegisterGPUProcessor(mTracker, false);
+    mChainTracking->SetTRDGeometry(std::move(mFlatGeo));
+    if (mRec->Init()) {
+      LOG(fatal) << "GPUReconstruction could not be initialized";
+    }
+
+    std::unique_ptr<o2::gpu::TPCFastTransform> fastTransform = (o2::tpc::TPCFastTransformHelperO2::instance()->create(0));
+    mTPCTransform = std::move(fastTransform);
+    mRecoParam.setBfield(o2::base::Propagator::Instance()->getNominalBz());
+
+    mTracker->PrintSettings();
+    LOG(info) << "Strict matching mode is " << ((mStrict) ? "ON" : "OFF");
+    LOGF(info, "The search road in time for ITS-TPC tracks is set to %.1f sigma and %.2f us are added to it on top",
+         mRec->GetParam().rec.trd.nSigmaTerrITSTPC, mRec->GetParam().rec.trd.addTimeRoadITSTPC);
+  }
   auto& elParam = o2::tpc::ParameterElectronics::Instance();
   auto& gasParam = o2::tpc::ParameterGas::Instance();
   mTPCTBinMUS = elParam.ZbinWidth;
   mTPCTBinMUSInv = 1. / mTPCTBinMUS;
   mTPCVdrift = gasParam.DriftV;
   mTracker->SetTPCVdrift(mTPCVdrift);
+}
+
+void TRDGlobalTracking::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
+{
+  if (o2::base::GRPGeomHelper::instance().finaliseCCDB(matcher, obj)) {
+    return;
+  }
+  if (matcher == ConcreteDataMatcher("ITS", "CLUSDICT", 0)) {
+    LOG(info) << "cluster dictionary updated";
+    mITSDict = (const o2::itsmft::TopologyDictionary*)obj;
+    return;
+  }
 }
 
 void TRDGlobalTracking::fillMCTruthInfo(const TrackTRD& trk, o2::MCCompLabel lblSeed, std::vector<o2::MCCompLabel>& lblContainerTrd, std::vector<o2::MCCompLabel>& lblContainerMatch, const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* trkltLabels) const
@@ -212,9 +210,11 @@ void TRDGlobalTracking::fillTrackTriggerRecord(const std::vector<TrackTRD>& trac
 void TRDGlobalTracking::run(ProcessingContext& pc)
 {
   mTimer.Start(false);
-  mChainTracking->ClearIOPointers();
   o2::globaltracking::RecoContainer inputTracks;
   inputTracks.collectData(pc, *mDataRequest);
+  updateTimeDependentParams(pc);
+  mChainTracking->ClearIOPointers();
+
   mTPCClusterIdxStruct = &inputTracks.inputsTPCclusters->clusterIndex;
   mTPCRefitter = std::make_unique<o2::gpu::GPUO2InterfaceRefit>(mTPCClusterIdxStruct, mTPCTransform.get(), o2::base::Propagator::Instance()->getNominalBz(), inputTracks.getTPCTracksClusterRefs().data(), inputTracks.clusterShMapTPC.data(), nullptr, o2::base::Propagator::Instance());
   auto tmpInputContainer = getRecoInputContainer(pc, &mChainTracking->mIOPtrs, &inputTracks, mUseMC);
@@ -253,9 +253,7 @@ void TRDGlobalTracking::run(ProcessingContext& pc)
       tpcTrackLabels = inputTracks.getTPCTracksMCLabels();
     }
   }
-
   mTracker->Reset();
-  updateTimeDependentParams(pc);
   mRec->PrepareEvent();
   mRec->SetupGPUProcessor(mTracker, true);
 
@@ -615,14 +613,6 @@ bool TRDGlobalTracking::refitTRDTrack(TrackTRD& trk, float& chi2, bool inwards)
   return true;
 }
 
-void TRDGlobalTracking::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
-{
-  if (matcher == ConcreteDataMatcher("ITS", "CLUSDICT", 0)) {
-    LOG(info) << "cluster dictionary updated";
-    mITSDict = (const o2::itsmft::TopologyDictionary*)obj;
-  }
-}
-
 void TRDGlobalTracking::endOfStream(EndOfStreamContext& ec)
 {
   LOGF(info, "TRD global tracking total timing: Cpu: %.3e Real: %.3e s in %d slots",
@@ -648,7 +638,14 @@ DataProcessorSpec getTRDGlobalTrackingSpec(bool useMC, GTrackID::mask_t src, boo
   }
   dataRequest->requestTracks(trkSrc, useMC);
   auto& inputs = dataRequest->inputs;
-
+  auto ggRequest = std::make_shared<o2::base::GRPGeomRequest>(false,                             // orbitResetTime
+                                                              false,                             // GRPECS=true
+                                                              false,                             // GRPLHCIF
+                                                              true,                              // GRPMagField
+                                                              true,                              // askMatLUT
+                                                              o2::base::GRPGeomRequest::Aligned, // geometry
+                                                              inputs,
+                                                              true);
 
   if (GTrackID::includesSource(GTrackID::Source::ITSTPC, src)) {
     outputs.emplace_back(o2::header::gDataOriginTRD, "MATCH_ITSTPC", 0, Lifetime::Timeframe);
@@ -678,7 +675,7 @@ DataProcessorSpec getTRDGlobalTrackingSpec(bool useMC, GTrackID::mask_t src, boo
     processorName,
     inputs,
     outputs,
-    AlgorithmSpec{adaptFromTask<TRDGlobalTracking>(useMC, dataRequest, src, trigRecFilterActive, strict)},
+    AlgorithmSpec{adaptFromTask<TRDGlobalTracking>(useMC, dataRequest, ggRequest, src, trigRecFilterActive, strict)},
     Options{{"material-lut-path", VariantType::String, "", {"Path of the material LUT file"}}}};
 }
 

--- a/Detectors/TRD/workflow/src/TRDTrackletTransformerSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrackletTransformerSpec.cxx
@@ -29,10 +29,7 @@ namespace trd
 
 void TRDTrackletTransformerSpec::init(o2::framework::InitContext& ic)
 {
-  mTransformer.init();
-  if (mApplyXOR) {
-    mTransformer.setApplyXOR();
-  }
+  o2::base::GRPGeomHelper::instance().setRequest(mGGCCDBRequest);
 }
 
 void TRDTrackletTransformerSpec::run(o2::framework::ProcessingContext& pc)
@@ -118,14 +115,29 @@ void TRDTrackletTransformerSpec::run(o2::framework::ProcessingContext& pc)
 
 void TRDTrackletTransformerSpec::updateTimeDependentParams(ProcessingContext& pc)
 {
+  o2::base::GRPGeomHelper::instance().checkUpdates(pc);
+  static bool initOnceDone = false;
+  if (!initOnceDone) { // this params need to be queried only once
+    initOnceDone = true;
+    // init-once stuff
+
+    mTransformer.init();
+    if (mApplyXOR) {
+      mTransformer.setApplyXOR();
+    }
+  }
   pc.inputs().get<o2::trd::CalVdriftExB*>("calvdexb"); // just to trigger the finaliseCCDB
 }
 
 void TRDTrackletTransformerSpec::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
 {
+  if (o2::base::GRPGeomHelper::instance().finaliseCCDB(matcher, obj)) {
+    return;
+  }
   if (matcher == ConcreteDataMatcher("TRD", "CALVDRIFTEXB", 0)) {
     LOG(info) << "CalVdriftExB object has been updated";
     mTransformer.setCalVdriftExB((const o2::trd::CalVdriftExB*)obj);
+    return;
   }
 }
 
@@ -139,7 +151,14 @@ o2::framework::DataProcessorSpec getTRDTrackletTransformerSpec(bool trigRecFilte
   inputs.emplace_back("trdtracklets", "TRD", "TRACKLETS", 0, Lifetime::Timeframe);
   inputs.emplace_back("trdtriggerrec", "TRD", "TRKTRGRD", 0, Lifetime::Timeframe);
   inputs.emplace_back("calvdexb", "TRD", "CALVDRIFTEXB", 0, Lifetime::Condition, ccdbParamSpec("TRD/Calib/CalVdriftExB"));
-
+  auto ggRequest = std::make_shared<o2::base::GRPGeomRequest>(false,                             // orbitResetTime
+                                                              false,                             // GRPECS=true
+                                                              false,                             // GRPLHCIF
+                                                              true,                              // GRPMagField
+                                                              false,                             // askMatLUT
+                                                              o2::base::GRPGeomRequest::Aligned, // geometry
+                                                              inputs,
+                                                              true);
   std::vector<OutputSpec> outputs;
   outputs.emplace_back("TRD", "CTRACKLETS", 0, Lifetime::Timeframe);
   outputs.emplace_back("TRD", "TRIGRECMASK", 0, Lifetime::Timeframe);
@@ -148,7 +167,7 @@ o2::framework::DataProcessorSpec getTRDTrackletTransformerSpec(bool trigRecFilte
     "TRDTRACKLETTRANSFORMER",
     inputs,
     outputs,
-    AlgorithmSpec{adaptFromTask<TRDTrackletTransformerSpec>(dataRequest, trigRecFilterActive, applyXOR)},
+    AlgorithmSpec{adaptFromTask<TRDTrackletTransformerSpec>(dataRequest, ggRequest, trigRecFilterActive, applyXOR)},
     Options{}};
 }
 

--- a/Detectors/Vertexing/include/DetectorsVertexing/VertexTrackMatcher.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/VertexTrackMatcher.h
@@ -51,21 +51,27 @@ class VertexTrackMatcher
     int origID = -1;     ///< vertex origin id
   };
 
-  void init();
   void process(const o2::globaltracking::RecoContainer& recoData,
                std::vector<VTIndex>& trackIndex, // Global ID's for associated tracks
                std::vector<VRef>& vtxRefs);      // references on these tracks
 
+  void setITSROFrameLengthMUS(float v) { mITSROFrameLengthMUS = v; }
+  void setMFTROFrameLengthMUS(float v) { mMFTROFrameLengthMUS = v; }
+  void setMaxTPCDriftTimeMUS(float v) { mMaxTPCDriftTimeMUS = v; }
+  void setTPCBin2MUS(float v) { mTPCBin2MUS = v; }
+
+  float getITSROFrameLengthMUS() const { return mITSROFrameLengthMUS; }
+  float getMFTROFrameLengthMUS() const { return mMFTROFrameLengthMUS; }
+  float getMaxTPCDriftTimeMUS() const { return mMaxTPCDriftTimeMUS; }
+  float getTPCBin2MUS() const { return mTPCBin2MUS; }
+
  private:
-  void updateTimeDependentParams();
   void extractTracks(const o2::globaltracking::RecoContainer& data, const std::unordered_map<GIndex, bool>& vcont);
   std::vector<TrackTBracket> mTBrackets;
   float mITSROFrameLengthMUS = 0;       ///< ITS RO frame in mus
   float mMFTROFrameLengthMUS = 0;       ///< MFT RO frame in mus
   float mMaxTPCDriftTimeMUS = 0;
   float mTPCBin2MUS = 0;
-  const o2::vertexing::PVertexerParams* mPVParams = nullptr;
-
 };
 
 } // namespace vertexing

--- a/Detectors/Vertexing/src/VertexTrackMatcher.cxx
+++ b/Detectors/Vertexing/src/VertexTrackMatcher.cxx
@@ -15,57 +15,19 @@
 
 #include "DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h"
 #include "DetectorsVertexing/VertexTrackMatcher.h"
-#include "DataFormatsParameters/GRPObject.h"
-#include "CommonUtils/NameConf.h"
-#include "TPCBase/ParameterElectronics.h"
-#include "TPCBase/ParameterDetector.h"
-#include "TPCBase/ParameterGas.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
 #include <unordered_map>
 #include <numeric>
 
 using namespace o2::vertexing;
 
-//___________________________________________________________________
-void VertexTrackMatcher::init()
-{
-  mPVParams = &o2::vertexing::PVertexerParams::Instance();
-  updateTimeDependentParams(); // RS FIXME eventually should be set from CCDB for every TF
-}
-
-void VertexTrackMatcher::updateTimeDependentParams()
-{
-  // tpc time bin in microseconds
-  if (mMaxTPCDriftTimeMUS == 0) {
-    auto& gasParam = o2::tpc::ParameterGas::Instance();
-    auto& elParam = o2::tpc::ParameterElectronics::Instance();
-    auto& detParam = o2::tpc::ParameterDetector::Instance();
-    mTPCBin2MUS = elParam.ZbinWidth;
-    mMaxTPCDriftTimeMUS = detParam.TPClength / gasParam.DriftV;
-  }
-  if (mITSROFrameLengthMUS == 0) {
-    std::unique_ptr<o2::parameters::GRPObject> grp{o2::parameters::GRPObject::loadFrom()};
-    const auto& alpParams = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance();
-    mITSROFrameLengthMUS = grp->isDetContinuousReadOut(o2::detectors::DetID::ITS) ? alpParams.roFrameLengthInBC * o2::constants::lhc::LHCBunchSpacingMUS : alpParams.roFrameLengthTrig * 1.e-3;
-    LOG(info) << "VertexTrackMatcher::ITSROFrameLengthMUS = " << mITSROFrameLengthMUS;
-  }
-  if (mMFTROFrameLengthMUS == 0) {
-    std::unique_ptr<o2::parameters::GRPObject> grp{o2::parameters::GRPObject::loadFrom()};
-    const auto& alpParams = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::MFT>::Instance();
-    mMFTROFrameLengthMUS = grp->isDetContinuousReadOut(o2::detectors::DetID::MFT) ? alpParams.roFrameLengthInBC * o2::constants::lhc::LHCBunchSpacingMUS : alpParams.roFrameLengthTrig * 1.e-3;
-    LOG(info) << "VertexTrackMatcher::MFTROFrameLengthMUS = " << mMFTROFrameLengthMUS;
-  }
-}
-
 void VertexTrackMatcher::process(const o2::globaltracking::RecoContainer& recoData,
                                  std::vector<VTIndex>& trackIndex,
                                  std::vector<VRef>& vtxRefs)
 {
-  updateTimeDependentParams();
-
   auto vertices = recoData.getPrimaryVertices();
   auto v2tfitIDs = recoData.getPrimaryVertexContributors();
   auto v2tfitRefs = recoData.getPrimaryVertexContributorsRefs();
+  const auto& PVParams = o2::vertexing::PVertexerParams::Instance();
 
   int nv = vertices.size(), nv1 = nv + 1;
   TmpMap tmpMap(nv1);
@@ -86,8 +48,8 @@ void VertexTrackMatcher::process(const o2::globaltracking::RecoContainer& recoDa
     }
     const auto& vtx = vertices[iv];
     const auto& vto = vtxOrdBrack.emplace_back(VtxTBracket{
-      {float((vtx.getIRMin().differenceInBC(recoData.startIR) - 0.5f) * o2::constants::lhc::LHCBunchSpacingMUS - mPVParams->timeMarginVertexTime),
-       float((vtx.getIRMax().differenceInBC(recoData.startIR) + 0.5f) * o2::constants::lhc::LHCBunchSpacingMUS + mPVParams->timeMarginVertexTime)},
+      {float((vtx.getIRMin().differenceInBC(recoData.startIR) - 0.5f) * o2::constants::lhc::LHCBunchSpacingMUS - PVParams.timeMarginVertexTime),
+       float((vtx.getIRMax().differenceInBC(recoData.startIR) + 0.5f) * o2::constants::lhc::LHCBunchSpacingMUS + PVParams.timeMarginVertexTime)},
       iv});
     if (vto.tBracket.delta() > maxVtxSpan) {
       maxVtxSpan = vto.tBracket.delta();
@@ -170,14 +132,13 @@ void VertexTrackMatcher::extractTracks(const o2::globaltracking::RecoContainer& 
   // Scan all inputs and create tracks
 
   mTBrackets.clear();
-
   auto creator = [this, &vcont](auto& _tr, GIndex _origID, float t0, float terr) {
     if constexpr (!(isMFTTrack<decltype(_tr)>() || isMCHTrack<decltype(_tr)>() || isGlobalFwdTrack<decltype(_tr)>())) { // Skip test for forward tracks; do not contribute to vertex
       if (vcont.find(_origID) != vcont.end()) {                                                                         // track is contributor to vertex, already accounted
         return true;
       }
     }
-
+    const auto& PVParams = o2::vertexing::PVertexerParams::Instance();
     if constexpr (isTPCTrack<decltype(_tr)>()) {
       // unconstrained TPC track, with t0 = TrackTPC.getTime0+0.5*(DeltaFwd-DeltaBwd) and terr = 0.5*(DeltaFwd+DeltaBwd) in TimeBins
       t0 *= this->mTPCBin2MUS;
@@ -190,10 +151,10 @@ void VertexTrackMatcher::extractTracks(const o2::globaltracking::RecoContainer& 
       terr *= this->mMFTROFrameLengthMUS;
     } else if constexpr (!(isMCHTrack<decltype(_tr)>() || isGlobalFwdTrack<decltype(_tr)>())) {
       // for all other tracks the time is in \mus with gaussian error
-      terr *= mPVParams->nSigmaTimeTrack; // gaussian errors must be scaled by requested n-sigma
+      terr *= PVParams.nSigmaTimeTrack; // gaussian errors must be scaled by requested n-sigma
     }
 
-    terr += mPVParams->timeMarginTrackTime;
+    terr += PVParams.timeMarginTrackTime;
     mTBrackets.emplace_back(TrackTBracket{{t0 - terr, t0 + terr}, _origID});
 
     if constexpr (isGlobalFwdTrack<decltype(_tr)>() || isMFTTrack<decltype(_tr)>()) {


### PR DESCRIPTION
This PP is for the not yet final transition of the workflows from local-file based geom/grp/field to fetching from CCDB using GRPGeomHelper.
I could validate only the workflows which are in the FST and sim_challenge. So I would ask authors to check their code and if possible, validate it.
Some specific comments below.


@noferini : in the workflows below you are extracting the bunchfilling from the dig.context directly in the defineDataProcessing:
```
GlobalTrackingWorkflow/src/tof-eventtime-checker-workflow.cxx:    auto context = mcReader->getDigitizationContext();
GlobalTrackingWorkflow/src/tof-matcher-workflow.cxx:    auto context = mcReader->getDigitizationContext();
```
Calib objects should be set per device, in this case I am even not sure for which device the bunch filling is set. 
Could you remove it from the defineDataProcessing and set in the relevant devices like I did in the  Detectors/TOF/workflow/src/TOFClusterizerSpec.cxx in this PR
pendentParam

TOFEventTimeChecker: I did not find why it loads geometry, GRP and inits field, so I've suppressed them.


@mfasDa :
EMCAL AnalysisClusterSpec : uses hardcoded Geometry::GetInstanceFromRunNumber(223409)

@chiarazampolli : I did not modify MatchITSTPCQC since loads geometry from file not in the DPL device, also called from QualityControl/Modules/GLO/src/ITSTPCMatchingTask.cxx which does not support GRPGeomHelper, we need to fix QC first

@mconcas in the ITS TrackerSpec the matLUT is always provided by the CCDB, so the switch for the mat. corrType depending on the presence of the file does not make sense anymore, hence eliminated. If you want, you can add a switch via configurable params.

@aphecetche : MCH ClusterTransformerTask loading geometry might be explicitly requested from the json file or from TGeo, not sure how to handle it. In any case, as far as I understand, you started the migration to CCDB initialization, so I will not touch MCH part.