### PR TITLE
MCH: removed "bad digit time" error code

### DIFF
--- a/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DataDecoder.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DataDecoder.h
@@ -176,7 +176,7 @@ class DataDecoder
   /// Compute the time of all the digits that have been decoded in the current TimeFrame
   void computeDigitsTimeBCRst();
   void computeDigitsTime();
-  void checkDigitsTime(int minDigitTimeAccepted, int maxDigitTimeAccepted);
+  void checkDigitsTime();
 
   /// Get the vector of digits that have been decoded in the current TimeFrame
   const RawDigitVector& getDigits() const { return mDigits; }

--- a/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/ErrorCodes.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/ErrorCodes.h
@@ -33,9 +33,8 @@ enum ErrorCodes {
   ErrorBadELinkID = 1 << 8,                  // 256
   ErrorBadLinkID = 1 << 9,                   // 512
   ErrorUnknownLinkID = 1 << 10,              // 1024
-  ErrorBadDigitTime = 1 << 11,               // 2048
-  ErrorInvalidDigitTime = 1 << 12,           // 4096
-  ErrorNonRecoverableDecodingError = 1 << 13 // 8192
+  ErrorInvalidDigitTime = 1 << 11,           // 2048
+  ErrorNonRecoverableDecodingError = 1 << 12 // 4096
 };
 
 uint32_t getErrorCodesSize();

--- a/Detectors/MUON/MCH/Raw/Decoder/src/DataDecoder.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/DataDecoder.cxx
@@ -812,12 +812,8 @@ void DataDecoder::computeDigitsTimeBCRst()
 
 //_________________________________________________________________________________________________
 
-void DataDecoder::checkDigitsTime(int minDigitOrbitAccepted, int maxDigitOrbitAccepted)
+void DataDecoder::checkDigitsTime()
 {
-  if (maxDigitOrbitAccepted < 0) {
-    maxDigitOrbitAccepted = mOrbitsInTF - 1;
-  }
-
   for (auto& digit : mDigits) {
     auto& d = digit.digit;
     auto& info = digit.info;
@@ -825,12 +821,6 @@ void DataDecoder::checkDigitsTime(int minDigitOrbitAccepted, int maxDigitOrbitAc
     if (tfTime == DataDecoder::tfTimeInvalid) {
       // add invalid digit time error
       mErrors.emplace_back(o2::mch::DecoderError(info.solar, info.ds, info.chip, ErrorInvalidDigitTime));
-    } else {
-      auto orbit = tfTime / o2::constants::lhc::LHCMaxBunches;
-      if (orbit < minDigitOrbitAccepted || orbit > maxDigitOrbitAccepted) {
-        // add bad digit time error
-        mErrors.emplace_back(o2::mch::DecoderError(info.solar, info.ds, info.chip, ErrorBadDigitTime));
-      }
     }
   }
 }

--- a/Detectors/MUON/MCH/Raw/Decoder/src/ErrorCodes.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/ErrorCodes.cxx
@@ -20,7 +20,7 @@ namespace raw
 
 uint32_t getErrorCodesSize()
 {
-  return 14;
+  return 13;
 }
 
 void append(const char* msg, std::string& to)
@@ -69,9 +69,6 @@ std::string errorCodeAsString(uint32_t ec)
   }
   if (ec & ErrorUnknownLinkID) {
     append("Unknown Link ID", msg);
-  }
-  if (ec & ErrorBadDigitTime) {
-    append("Bad Digit Time", msg);
   }
   if (ec & ErrorInvalidDigitTime) {
     append("Invalid Digit Time", msg);

--- a/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
@@ -245,9 +245,7 @@ class DataDecoderTask
       }
     }
     mDecoder->computeDigitsTime();
-    int minDigitOrbitAccepted = CoDecParam::Instance().minDigitOrbitAccepted;
-    int maxDigitOrbitAccepted = CoDecParam::Instance().maxDigitOrbitAccepted;
-    mDecoder->checkDigitsTime(minDigitOrbitAccepted, maxDigitOrbitAccepted);
+    mDecoder->checkDigitsTime();
     auto tEnd = std::chrono::high_resolution_clock::now();
     mTimeDecoding += tEnd - tStart;
 


### PR DESCRIPTION
The amount of digits with time outside the TF boundaries can be directly estimated from the QC plots, and there is no need to have a specific error code for this.