### PR TITLE
TPC: Add standalone interface for ZS decoding

### DIFF
--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/ZeroSuppression.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/ZeroSuppression.h
@@ -51,7 +51,6 @@ struct TPCZSHDR {
 };
 struct TPCZSHDRV2 : public TPCZSHDR {
   static constexpr unsigned int TPC_ZS_NBITS_V3 = 12;
-  static constexpr unsigned int TPC_ZS_NBITS_V4 = 12;
   static constexpr bool TIGHTLY_PACKED_V3 = false;
   static constexpr unsigned int SAMPLESPER64BIT = 64 / TPC_ZS_NBITS_V3; // 5 12-bit samples with 4 bit padding per 64 bit word for non-TIGHTLY_PACKED data
 

--- a/GPU/GPUTracking/Base/GPUReconstructionConvert.h
+++ b/GPU/GPUTracking/Base/GPUReconstructionConvert.h
@@ -16,6 +16,8 @@
 #define GPURECONSTRUCTIONCONVERT_H
 
 #include <memory>
+#include <functional>
+#include <vector>
 #include "GPUDef.h"
 
 namespace o2
@@ -58,7 +60,18 @@ class GPUReconstructionConvert
   static int GetMaxTimeBin(const o2::tpc::ClusterNativeAccess& native);
   static int GetMaxTimeBin(const GPUTrackingInOutDigits& digits);
   static int GetMaxTimeBin(const GPUTrackingInOutZS& zspages);
+  static std::function<void(std::vector<o2::tpc::Digit>&, const void*, unsigned int)> GetDecoder(int version, const GPUParam& param);
 };
+
+class GPUReconstructionZSDecoder
+{
+ public:
+  void DecodePage(std::vector<o2::tpc::Digit>& outputBuffer, const void* page, unsigned int tfFirstOrbit, const GPUParam& param);
+
+ private:
+  std::vector<std::function<void(std::vector<o2::tpc::Digit>&, const void*, unsigned int)>> mDecoders;
+};
+
 } // namespace gpu
 } // namespace GPUCA_NAMESPACE
 

--- a/GPU/GPUTracking/Global/GPUChainTrackingClusterizer.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTrackingClusterizer.cxx
@@ -91,8 +91,7 @@ std::pair<unsigned int, unsigned int> GPUChainTracking::TPCClusterizerDecodeZSCo
   unsigned int nDigits = 0;
   unsigned int nPages = 0;
   bool doGPU = mRec->GetRecoStepsGPU() & GPUDataTypes::RecoStep::TPCClusterFinding;
-  int firstHBF = (mIOPtrs.settingsTF && mIOPtrs.settingsTF->hasTfStartOrbit) ? mIOPtrs.settingsTF->tfStartOrbit : (mIOPtrs.tpcZS->slice[iSlice].count[0] && mIOPtrs.tpcZS->slice[iSlice].nZSPtr[0][0]) ? o2::raw::RDHUtils::getHeartBeatOrbit(*(const o2::header::RAWDataHeader*)mIOPtrs.tpcZS->slice[iSlice].zsPtr[0][0])
-                                                                                                                                                                                                       : 0;
+  int firstHBF = (mIOPtrs.settingsTF && mIOPtrs.settingsTF->hasTfStartOrbit) ? mIOPtrs.settingsTF->tfStartOrbit : (mIOPtrs.tpcZS->slice[iSlice].count[0] && mIOPtrs.tpcZS->slice[iSlice].nZSPtr[0][0]) ? o2::raw::RDHUtils::getHeartBeatOrbit(*(const o2::header::RAWDataHeader*)mIOPtrs.tpcZS->slice[iSlice].zsPtr[0][0]) : 0;
 
   for (unsigned short j = 0; j < GPUTrackingInOutZS::NENDPOINTS; j++) {
 #ifndef GPUCA_NO_VC


### PR DESCRIPTION
@wiechula : This is a standalone interface to use the decoder I have implemented for validation.
There are basically 2 ways to use it:
- `GPUReconstructionConvert::GetDecoder(int version, const GPUParam& param)` returns a std:function, which can be called and decodes a page appending the digits to a std::vector. The parameters are:
  - version: Version of the ZS (1 / 2 = original version with 10/12 bits, 3 = ILBZS, 4 = DILBZS). This must be either provided externally, or obtained from the paga manually.
  - param: GPUParam object, to be obained as in https://github.com/AliceO2Group/AliceO2/blob/f41b813575f646e40653aca82a0dc39609e220df/Detectors/TPC/workflow/src/ZSSpec.cxx#L95
  - tfFirstOrbit : first Orbit in current TF
- `GPUReconstructionZSDecoder::DecodePage` : This is a wrapper around the above, which automatically fetches the std::function for the correct version, which it obtains from the page. It might be slightly slower, since it will always check the version, but shouldn't make any noticable difference.
In both cases I would propose to store the object (std::function or the class) and don't recreate it every time.