### PR TITLE
DPL: introduce an AsyncQueue

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -14,6 +14,7 @@ o2_add_library(Framework
                        src/ArrowSupport.cxx
                        src/AnalysisDataModel.cxx
                        src/ASoA.cxx
+                       src/AsyncQueue.cxx
                        src/AnalysisHelpers.cxx
                        src/AnalysisDataModelHelpers.cxx
                        src/BoostOptionsRetriever.cxx
@@ -171,6 +172,7 @@ foreach(t
         AlgorithmSpec
         AnalysisTask
         AnalysisDataModel
+        AsyncQueue
         ASoA
         ASoAHelpers
         BoostOptionsRetriever

--- a/Framework/Core/include/Framework/AsyncQueue.h
+++ b/Framework/Core/include/Framework/AsyncQueue.h
@@ -1,0 +1,54 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef O2_FRAMEWORK_ASYNCQUUE_H_
+#define O2_FRAMEWORK_ASYNCQUUE_H_
+
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace o2::framework
+{
+
+struct AsyncTaskSpec {
+  std::string name;
+  // Its priority compared to the other tasks
+  int score = 0;
+};
+
+/// The position of the TaskSpec in the prototypes
+struct AsyncTaskId {
+  int value = -1;
+};
+
+/// An actuatual task to be executed
+struct AsyncTask {
+  // The task to be executed
+  std::function<void()> task;
+  // The associated task spec
+  AsyncTaskId id = {-1};
+  // Only the task with the highest debounce value will be executed
+  int debounce = 0;
+};
+
+struct AsyncQueue {
+  std::vector<AsyncTaskSpec> prototypes;
+  std::vector<AsyncTask> tasks;
+};
+
+struct AsyncQueueHelpers {
+  static AsyncTaskId create(AsyncQueue& queue, AsyncTaskSpec spec);
+  static void post(AsyncQueue& queue, AsyncTaskId, std::function<void()> task, int64_t debounce = 0);
+  static void run(AsyncQueue& queue);
+};
+
+} // namespace o2::framework
+#endif // O2_FRAMEWORK_ASYNCQUEUE_H_

--- a/Framework/Core/include/Framework/CommonServices.h
+++ b/Framework/Core/include/Framework/CommonServices.h
@@ -80,6 +80,7 @@ struct CommonServices {
   static ServiceSpec timingInfoSpec();
   static ServiceSpec ccdbSupportSpec();
   static ServiceSpec decongestionSpec();
+  static ServiceSpec asyncQueue();
 
   static std::vector<ServiceSpec> defaultServices(int numWorkers = 0);
   static std::vector<ServiceSpec> requiredServices();

--- a/Framework/Core/src/AsyncQueue.cxx
+++ b/Framework/Core/src/AsyncQueue.cxx
@@ -1,0 +1,62 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/AsyncQueue.h"
+#include <numeric>
+
+namespace o2::framework
+{
+auto AsyncQueueHelpers::create(AsyncQueue& queue, AsyncTaskSpec spec) -> AsyncTaskId
+{
+  AsyncTaskId id;
+  id.value = queue.prototypes.size();
+  queue.prototypes.push_back(spec);
+  return id;
+}
+
+auto AsyncQueueHelpers::post(AsyncQueue& queue, AsyncTaskId id, std::function<void()> task, int64_t debounce) -> void
+{
+  AsyncTask taskToPost;
+  taskToPost.task = task;
+  taskToPost.id = id;
+  taskToPost.debounce = debounce;
+  queue.tasks.push_back(taskToPost);
+}
+
+auto AsyncQueueHelpers::run(AsyncQueue& queue) -> void
+{
+  std::vector<int> order;
+  order.resize(queue.tasks.size());
+  std::iota(order.begin(), order.end(), 0);
+
+  // Sort by priority and debounce
+  std::sort(order.begin(), order.end(), [&queue](int a, int b) {
+    if (queue.tasks[a].id.value == -1 || queue.tasks[b].id.value == -1) {
+      return false;
+    }
+    if (queue.tasks[a].id.value == queue.tasks[b].id.value) {
+      return queue.tasks[a].debounce > queue.tasks[b].debounce;
+    }
+    return queue.prototypes[queue.tasks[a].id.value].score > queue.prototypes[queue.tasks[b].id.value].score;
+  });
+  // Keep only the tasks with the highest debounce value for a given id
+  auto newEnd = std::unique(order.begin(), order.end(), [&queue](int a, int b) {
+    return queue.tasks[a].id.value == queue.tasks[b].id.value;
+  });
+  order.erase(newEnd, order.end());
+
+  for (auto i : order) {
+    queue.tasks[i].task();
+  }
+  queue.tasks.clear();
+}
+
+} // namespace o2::framework

--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -32,6 +32,7 @@
 #include "Framework/RunningWorkflowInfo.h"
 #include "Framework/Tracing.h"
 #include "Framework/Monitoring.h"
+#include "Framework/AsyncQueue.h"
 #include "TextDriverClient.h"
 #include "WSDriverClient.h"
 #include "HTTPParser.h"
@@ -118,6 +119,16 @@ o2::framework::ServiceSpec CommonServices::monitoringSpec()
     .exit = [](ServiceRegistry& registry, void* service) {
                        Monitoring* monitoring = reinterpret_cast<Monitoring*>(service);
                        delete monitoring; },
+    .kind = ServiceKind::Serial};
+}
+
+// An asyncronous service that executes actions in at the end of the data processing
+o2::framework::ServiceSpec CommonServices::asyncQueue()
+{
+  return ServiceSpec{
+    .name = "async-queue",
+    .init = simpleServiceInit<AsyncQueue, AsyncQueue>(),
+    .configure = noConfiguration(),
     .kind = ServiceKind::Serial};
 }
 
@@ -868,6 +879,7 @@ o2::framework::ServiceSpec CommonServices::objectCache()
 std::vector<ServiceSpec> CommonServices::defaultServices(int numThreads)
 {
   std::vector<ServiceSpec> specs{
+    asyncQueue(),
     timingInfoSpec(),
     timesliceIndex(),
     driverClientSpec(),

--- a/Framework/Core/test/test_AsyncQueue.cxx
+++ b/Framework/Core/test/test_AsyncQueue.cxx
@@ -1,0 +1,47 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test Framework
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+#include "Framework/AsyncQueue.h"
+
+/// Test debouncing functionality. The same task cannot be executed more than once
+/// in a given run.
+BOOST_AUTO_TEST_CASE(TestDebouncing)
+{
+  o2::framework::AsyncQueue queue;
+  auto taskId = o2::framework::AsyncQueueHelpers::create(queue, {.name = "test", .score = 10});
+  // Push two tasks on the queue with the same id
+  auto count = 0;
+  o2::framework::AsyncQueueHelpers::post(
+    queue, taskId, [&count]() { count += 1; }, 10);
+  o2::framework::AsyncQueueHelpers::post(
+    queue, taskId, [&count]() { count += 2; }, 20);
+  o2::framework::AsyncQueueHelpers::run(queue);
+  BOOST_CHECK_EQUAL(count, 2);
+}
+
+// Test task oridering. The tasks with the highest priority should be executed first.
+BOOST_AUTO_TEST_CASE(TestPriority)
+{
+  o2::framework::AsyncQueue queue;
+  auto taskId1 = o2::framework::AsyncQueueHelpers::create(queue, {.name = "test1", .score = 10});
+  auto taskId2 = o2::framework::AsyncQueueHelpers::create(queue, {.name = "test2", .score = 20});
+  // Push two tasks on the queue with the same id
+  auto count = 0;
+  o2::framework::AsyncQueueHelpers::post(queue, taskId1, [&count]() { count += 10; });
+  o2::framework::AsyncQueueHelpers::post(queue, taskId2, [&count]() { count /= 10; });
+  o2::framework::AsyncQueueHelpers::run(queue);
+  BOOST_CHECK_EQUAL(count, 10);
+}


### PR DESCRIPTION
Useful to postpone actions which need to happen outside of the
data processing loop and that might have to be debounced, like
sending the oldest possible timeframe.