### PR TITLE
CPV: add LM-L0 delay subtraction to RawToDigitConverterSpec

### DIFF
--- a/Detectors/CPV/calib/testWorkflow/GainCalibratorSpec.h
+++ b/Detectors/CPV/calib/testWorkflow/GainCalibratorSpec.h
@@ -189,10 +189,10 @@ DataProcessorSpec getCPVGainCalibratorSpec()
                                                                 inputs);
   std::vector<OutputSpec> outputs;
   // Length of data description ("CPV_Pedestals") must be < 16 characters.
-  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "CPV_Gains"}, Lifetime::Sporadic);
-  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "CPV_Gains"}, Lifetime::Sporadic);
-  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "CPV_GainCD"}, Lifetime::Sporadic);
-  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "CPV_GainCD"}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "CPV_Gains", 0}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "CPV_Gains", 0}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "CPV_GainCD", 0}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "CPV_GainCD", 0}, Lifetime::Sporadic);
 
   return DataProcessorSpec{
     "cpv-gain-calibration",

--- a/Detectors/CPV/calib/testWorkflow/NoiseCalibratorSpec.h
+++ b/Detectors/CPV/calib/testWorkflow/NoiseCalibratorSpec.h
@@ -183,8 +183,8 @@ DataProcessorSpec getCPVNoiseCalibratorSpec()
                                                                 inputs);
   std::vector<OutputSpec> outputs;
   // Length of data description ("CPV_Pedestals") must be < 16 characters.
-  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "CPV_BadMap"}, Lifetime::Sporadic);
-  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "CPV_BadMap"}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "CPV_BadMap", 0}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "CPV_BadMap", 0}, Lifetime::Sporadic);
 
   return DataProcessorSpec{
     "cpv-noise-calibration",

--- a/Detectors/CPV/calib/testWorkflow/PedestalCalibratorSpec.h
+++ b/Detectors/CPV/calib/testWorkflow/PedestalCalibratorSpec.h
@@ -171,16 +171,18 @@ DataProcessorSpec getCPVPedestalCalibratorSpec()
 
   std::vector<OutputSpec> outputs;
   // Length of data description ("CPV_Pedestals") must be < 16 characters.
-  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "CPV_Pedestals"}, Lifetime::Sporadic);
-  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "CPV_Pedestals"}, Lifetime::Sporadic);
-  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "CPV_FEEThrs"}, Lifetime::Sporadic);
-  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "CPV_FEEThrs"}, Lifetime::Sporadic);
-  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "CPV_PedEffs"}, Lifetime::Sporadic);
-  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "CPV_PedEffs"}, Lifetime::Sporadic);
-  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "CPV_DeadChnls"}, Lifetime::Sporadic);
-  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "CPV_DeadChnls"}, Lifetime::Sporadic);
-  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "CPV_HighThrs"}, Lifetime::Sporadic);
-  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "CPV_HighThrs"}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "CPV_Pedestals", 0}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "CPV_Pedestals", 0}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "CPV_FEEThrs", 0}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "CPV_FEEThrs", 0}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "CPV_FEEThrs", 1}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "CPV_FEEThrs", 1}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "CPV_PedEffs", 0}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "CPV_PedEffs", 0}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "CPV_DeadChnls", 0}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "CPV_DeadChnls", 0}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "CPV_HighThrs", 0}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "CPV_HighThrs", 0}, Lifetime::Sporadic);
   std::vector<InputSpec> inputs{{"digits", "CPV", "DIGITS"},
                                 {"trigrecs", "CPV", "DIGITTRIGREC"}};
   inputs.emplace_back("calibparams", "CPV", "CPV_CalibPars", 0, Lifetime::Condition, ccdbParamSpec("CPV/Config/CPVCalibParams"));

--- a/Detectors/CPV/simulation/CMakeLists.txt
+++ b/Detectors/CPV/simulation/CMakeLists.txt
@@ -16,6 +16,7 @@ o2_add_library(CPVSimulation
                        src/RawWriter.cxx
                PUBLIC_LINK_LIBRARIES O2::DetectorsBase
                                      O2::DataFormatsCPV
+                                     O2::DataFormatsCTP
                                      O2::CPVBase
                                      O2::CCDB
                                      O2::SimConfig

--- a/Detectors/CPV/simulation/include/CPVSimulation/RawWriter.h
+++ b/Detectors/CPV/simulation/include/CPVSimulation/RawWriter.h
@@ -64,7 +64,7 @@ struct padCharge {
   padCharge(short a, short b) : charge(a),
                                 pad(b)
   {
-  } //for std::vector::emplace_back functionality
+  } // for std::vector::emplace_back functionality
 };
 
 class RawWriter
@@ -100,7 +100,7 @@ class RawWriter
   CalibParams* mCalibParams = nullptr;                            ///< CPV calibration
   Pedestals* mPedestals = nullptr;                                ///< CPV pedestals
   BadChannelMap* mBadMap = nullptr;                               ///< CPV bad channel map
-
+  int64_t mLM_L0_delay = 15;                                      ///< LM-L0 delay
   std::vector<char> mPayload[kNGBTLinks];                         ///< Preformatted payload for every link to be written
   gsl::span<o2::cpv::Digit> mDigits;                              ///< Digits input vector - must be in digitized format
   std::unique_ptr<o2::raw::RawFileWriter> mRawWriter;             ///< Raw writer

--- a/Detectors/CPV/simulation/src/RawWriter.cxx
+++ b/Detectors/CPV/simulation/src/RawWriter.cxx
@@ -21,6 +21,8 @@
 #include "CPVBase/Geometry.h"
 #include "CCDB/CCDBTimeStampUtils.h"
 #include "CCDB/BasicCCDBManager.h"
+#include "DataFormatsCTP/TriggerOffsetsParam.h"
+#include "DetectorsRaw/HBFUtils.h"
 
 using namespace o2::cpv;
 
@@ -40,7 +42,11 @@ void RawWriter::init()
     mRawWriter->registerLink(link.feeId, link.cruId, link.linkId, link.endPointId, rawFileName.data());
   }
 
+  // Lm-L0 delay
+  mLM_L0_delay = o2::ctp::TriggerOffsetsParam::Instance().LM_L0;
+
   // CCDB setup
+  const auto& hbfutils = o2::raw::HBFUtils::Instance();
   LOG(info) << "CCDB Url: " << mCcdbUrl;
   auto& ccdbMgr = o2::ccdb::BasicCCDBManager::instance();
   ccdbMgr.setURL(mCcdbUrl);
@@ -59,8 +65,9 @@ void RawWriter::init()
     LOG(info) << "Successfully initializated BasicCCDBManager with caching option";
 
     // read calibration from ccdb (for now do it only at the beginning of dataprocessing)
-    // TODO: setup timestam according to anchors
-    ccdbMgr.setTimestamp(o2::ccdb::getCurrentTimestamp());
+    // setup timestam according to anchors
+    ccdbMgr.setTimestamp(hbfutils.startTime);
+    LOG(info) << "Using time stamp " << ccdbMgr.getTimestamp();
 
     LOG(info) << "CCDB: Reading o2::cpv::CalibParams from CPV/Calib/Gains";
     mCalibParams = ccdbMgr.get<o2::cpv::CalibParams>("CPV/Calib/Gains");
@@ -94,16 +101,16 @@ void RawWriter::digitsToRaw(gsl::span<o2::cpv::Digit> digitsbranch, gsl::span<o2
     return;
   }
 
-  // process digits which belong to same orbit
+  // process digits which belong to same orbit (taking into account )
   int iFirstTrgInCurrentOrbit = 0;
-  unsigned int currentOrbit = triggerbranch[0].getBCData().orbit;
+  unsigned int currentOrbit = triggerbranch[iFirstTrgInCurrentOrbit].getBCData().orbit;
   int nTrgsInCurrentOrbit = 1;
   for (unsigned int iTrg = 1; iTrg < triggerbranch.size(); iTrg++) {
-    if (triggerbranch[iTrg].getBCData().orbit != currentOrbit) { // if orbit changed, write previous orbit to file
+    if ((triggerbranch[iTrg].getBCData() + mLM_L0_delay).orbit != currentOrbit) { // if orbit changed, write previous orbit to file
       processOrbit(digitsbranch, triggerbranch.subspan(iFirstTrgInCurrentOrbit, nTrgsInCurrentOrbit));
       iFirstTrgInCurrentOrbit = iTrg; // orbit changed
       nTrgsInCurrentOrbit = 1;
-      currentOrbit = triggerbranch[iTrg].getBCData().orbit;
+      currentOrbit = (triggerbranch[iTrg].getBCData() + mLM_L0_delay).orbit;
     } else {
       nTrgsInCurrentOrbit++;
     }
@@ -129,9 +136,11 @@ bool RawWriter::processOrbit(const gsl::span<o2::cpv::Digit> digitsbranch, const
   int gbtWordCounterBeforeCPVTrailer[kNGBTLinks] = {0, 0, 0};
   bool isHeaderClosedWithTrailer[kNGBTLinks] = {false, false, false};
   for (auto& trg : trgs) {
+    o2::InteractionRecord currentIR = trg.getBCData();
+    currentIR += mLM_L0_delay;
     LOG(debug) << "RawWriter::processOrbit() : "
-               << "I start to process trigger record (orbit = " << trg.getBCData().orbit
-               << ", BC = " << trg.getBCData().bc << ")";
+               << "I start to process trigger record (orbit = " << currentIR.orbit
+               << ", BC = " << currentIR.bc << ")";
     LOG(debug) << "First entry = " << trg.getFirstEntry() << ", Number of objects = " << trg.getNumberOfObjects();
 
     // Clear array which is used to store digits
@@ -166,7 +175,7 @@ bool RawWriter::processOrbit(const gsl::span<o2::cpv::Digit> digitsbranch, const
       gbtWordCounterBeforeCPVTrailer[iLink] = 0;
       if (nMaxGbtWordsPerPage - gbtWordCounter[iLink] < 3) { // otherwise flush already prepared data to file
         LOG(debug) << "RawWriter::processOrbit() : before header: adding preformatted dma page of size " << mPayload[iLink].size();
-        mRawWriter->addData(links[iLink].feeId, links[iLink].cruId, links[iLink].linkId, links[iLink].endPointId, trg.getBCData(),
+        mRawWriter->addData(links[iLink].feeId, links[iLink].cruId, links[iLink].linkId, links[iLink].endPointId, currentIR,
                             gsl::span<char>(mPayload[iLink].data(), mPayload[iLink].size()), preformatted);
         mPayload[iLink].clear();
         gbtWordCounter[iLink] = 0;
@@ -174,14 +183,14 @@ bool RawWriter::processOrbit(const gsl::span<o2::cpv::Digit> digitsbranch, const
       }
 
       // first, header goes
-      CpvHeader header(trg.getBCData(), false, false);
+      CpvHeader header(currentIR, false, false);
       for (int i = 0; i < 16; i++) {
         mPayload[iLink].push_back(header.mBytes[i]);
       }
       isHeaderClosedWithTrailer[iLink] = false;
       LOG(debug) << "RawWriter::processOrbit() : "
-                 << "I wrote cpv header for orbit = " << trg.getBCData().orbit
-                 << " and BC = " << trg.getBCData().bc;
+                 << "I wrote cpv header for orbit = " << currentIR.orbit
+                 << " and BC = " << currentIR.bc;
 
       gbtWordCounter[iLink]++;
       gbtWordCounterBeforeCPVTrailer[iLink]++;
@@ -211,21 +220,21 @@ bool RawWriter::processOrbit(const gsl::span<o2::cpv::Digit> digitsbranch, const
                 }
                 gbtWordCounter[iLink]++;
                 gbtWordCounterBeforeCPVTrailer[iLink]++;
-                if (nMaxGbtWordsPerPage - gbtWordCounter[iLink] == 1) {                                            // the only space for trailer left on current page
-                  CpvTrailer tr(gbtWordCounterBeforeCPVTrailer[iLink], trg.getBCData().bc, nDigsToWriteLeft == 0); // add trailer and flush page to file
+                if (nMaxGbtWordsPerPage - gbtWordCounter[iLink] == 1) {                                      // the only space for trailer left on current page
+                  CpvTrailer tr(gbtWordCounterBeforeCPVTrailer[iLink], currentIR.bc, nDigsToWriteLeft == 0); // add trailer and flush page to file
                   for (int i = 0; i < 16; i++) {
                     mPayload[iLink].push_back(tr.mBytes[i]);
                   }
                   isHeaderClosedWithTrailer[iLink] = true;
                   LOG(debug) << "RawWriter::processOrbit() : middle of payload: adding preformatted dma page of size " << mPayload[iLink].size();
-                  mRawWriter->addData(links[iLink].feeId, links[iLink].cruId, links[iLink].linkId, links[iLink].endPointId, trg.getBCData(),
+                  mRawWriter->addData(links[iLink].feeId, links[iLink].cruId, links[iLink].linkId, links[iLink].endPointId, currentIR,
                                       gsl::span<char>(mPayload[iLink].data(), mPayload[iLink].size()), preformatted);
 
                   mPayload[iLink].clear();
                   gbtWordCounter[iLink] = 0;
                   gbtWordCounterBeforeCPVTrailer[iLink] = 0;
                   if (nDigsToWriteLeft) { // some digits left for writing
-                    CpvHeader newHeader(trg.getBCData(), false, true);
+                    CpvHeader newHeader(currentIR, false, true);
                     for (int i = 0; i < 16; i++) { // so put a new header and continue
                       mPayload[iLink].push_back(newHeader.mBytes[i]);
                     }
@@ -251,14 +260,14 @@ bool RawWriter::processOrbit(const gsl::span<o2::cpv::Digit> digitsbranch, const
           }
           gbtWordCounter[iLink]++;
           gbtWordCounterBeforeCPVTrailer[iLink]++;
-          if (nMaxGbtWordsPerPage - gbtWordCounter[iLink] == 1) {                                            // the only space for trailer left on current page
-            CpvTrailer tr(gbtWordCounterBeforeCPVTrailer[iLink], trg.getBCData().bc, nDigsToWriteLeft == 0); // add trailer and flush page to file
+          if (nMaxGbtWordsPerPage - gbtWordCounter[iLink] == 1) {                                      // the only space for trailer left on current page
+            CpvTrailer tr(gbtWordCounterBeforeCPVTrailer[iLink], currentIR.bc, nDigsToWriteLeft == 0); // add trailer and flush page to file
             for (int i = 0; i < 16; i++) {
               mPayload[iLink].push_back(tr.mBytes[i]);
             }
             isHeaderClosedWithTrailer[iLink] = true;
             LOG(debug) << "RawWriter::processOrbit() : middle of payload (after filling empty words): adding preformatted dma page of size " << mPayload[iLink].size();
-            mRawWriter->addData(links[iLink].feeId, links[iLink].cruId, links[iLink].linkId, links[iLink].endPointId, trg.getBCData(),
+            mRawWriter->addData(links[iLink].feeId, links[iLink].cruId, links[iLink].linkId, links[iLink].endPointId, currentIR,
                                 gsl::span<char>(mPayload[iLink].data(), mPayload[iLink].size()), preformatted);
             mPayload[iLink].clear();
             gbtWordCounter[iLink] = 0;
@@ -275,7 +284,7 @@ bool RawWriter::processOrbit(const gsl::span<o2::cpv::Digit> digitsbranch, const
         }
       } // end of ccId cycle
       if (!isHeaderClosedWithTrailer[iLink]) {
-        CpvTrailer tr(gbtWordCounterBeforeCPVTrailer[iLink], trg.getBCData().bc, true);
+        CpvTrailer tr(gbtWordCounterBeforeCPVTrailer[iLink], currentIR.bc, true);
         for (int i = 0; i < 16; i++) {
           mPayload[iLink].push_back(tr.mBytes[i]);
         }

--- a/Detectors/CPV/workflow/CMakeLists.txt
+++ b/Detectors/CPV/workflow/CMakeLists.txt
@@ -20,6 +20,7 @@ o2_add_library(CPVWorkflow
                        src/EntropyDecoderSpec.cxx
                PUBLIC_LINK_LIBRARIES O2::Framework
                                      O2::DataFormatsCPV
+                                     O2::DataFormatsCTP
                                      O2::DPLUtils
                                      O2::CPVBase
                                      O2::CPVSimulation

--- a/Detectors/CPV/workflow/include/CPVWorkflow/RawToDigitConverterSpec.h
+++ b/Detectors/CPV/workflow/include/CPVWorkflow/RawToDigitConverterSpec.h
@@ -68,9 +68,15 @@ class RawToDigitConverterSpec : public framework::Task
   char CheckHWAddress(short ddl, short hwAddress, short& fee);
 
  private:
+  void updateTimeDependentParams(framework::ProcessingContext& ctx);
+
+ private:
   bool mIsUsingGainCalibration;                                      ///< Use gain calibration from CCDB
   bool mIsUsingBadMap;                                               ///< Use BadChannelMap to mask bad channels
   bool mIsPedestalData;                                              ///< Do not subtract pedestals if true
+  const o2::cpv::Pedestals* mPedestals = nullptr;                    ///< Pedestals from the CCDB
+  const o2::cpv::BadChannelMap* mBadMap = nullptr;                   ///< Bad Channel Map from the CCDB
+  const o2::cpv::CalibParams* mGains = nullptr;                      ///< Gains from the CCDB
   std::vector<Digit> mOutputDigits;                                  ///< Container with output cells
   std::vector<TriggerRecord> mOutputTriggerRecords;                  ///< Container with output cells
   std::vector<RawDecoderError> mOutputHWErrors;                      ///< Errors occured in reading data

--- a/Detectors/CPV/workflow/src/RawToDigitConverterSpec.cxx
+++ b/Detectors/CPV/workflow/src/RawToDigitConverterSpec.cxx
@@ -20,6 +20,7 @@
 #include "Framework/ConcreteDataMatcher.h"
 #include "DataFormatsCPV/CPVBlockHeader.h"
 #include "DataFormatsCPV/TriggerRecord.h"
+#include "DataFormatsCTP/TriggerOffsetsParam.h"
 #include "DetectorsRaw/RDHUtils.h"
 #include "CPVReconstruction/RawDecoder.h"
 #include "CPVWorkflow/RawToDigitConverterSpec.h"
@@ -58,8 +59,47 @@ void RawToDigitConverterSpec::init(framework::InitContext& ctx)
   LOG(info) << "Task configuration is done.";
 }
 
+void finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
+{
+  if (matcher == ConcreteDataMatcher("CTP", "Trig_Offset", 0)) {
+    LOG(info) << "RawToDigitConverterSpec::finaliseCCDB() : CTP/Config/TriggerOffsets updated.";
+    const auto& par = o2::ctp::TriggerOffsetsParam::Instance();
+    par.printKeyValues();
+    return;
+  }
+}
+
+void RawToDigitConverterSpec::updateTimeDependentParams(framework::ProcessingContext& ctx)
+{
+  static bool updateOnlyOnce = false;
+  if (!updateOnlyOnce) {
+    ctx.inputs().get<o2::ctp::TriggerOffsetsParam*>("trigoffset");
+
+    std::decay_t<decltype(ctx.inputs().get<o2::cpv::Pedestals*>("peds"))> pedPtr{};
+    std::decay_t<decltype(ctx.inputs().get<o2::cpv::BadChannelMap*>("badmap"))> badMapPtr{};
+    std::decay_t<decltype(ctx.inputs().get<o2::cpv::CalibParams*>("gains"))> gainsPtr{};
+
+    if (!mIsPedestalData) {
+      pedPtr = ctx.inputs().get<o2::cpv::Pedestals*>("peds");
+      mPedestals = pedPtr.get();
+    }
+
+    if (mIsUsingBadMap) {
+      badMapPtr = ctx.inputs().get<o2::cpv::BadChannelMap*>("badmap");
+      mBadMap = badMapPtr.get();
+    }
+
+    if (mIsUsingGainCalibration) {
+      gainsPtr = ctx.inputs().get<o2::cpv::CalibParams*>("gains");
+      mGains = gainsPtr.get();
+    }
+    updateOnlyOnce = true;
+  }
+}
+
 void RawToDigitConverterSpec::run(framework::ProcessingContext& ctx)
 {
+  updateTimeDependentParams(ctx);
   // check timers if we need mute/unmute error reporting
   auto now = std::chrono::system_clock::now();
   if (mIsMuteDecoderErrors) { // check if 10-minutes muting period passed
@@ -105,28 +145,6 @@ void RawToDigitConverterSpec::run(framework::ProcessingContext& ctx)
     }
   }
   contDeadBeef = 0; // if good data, reset the counter
-
-  const o2::cpv::Pedestals* pedestals = nullptr;
-  const o2::cpv::BadChannelMap* badMap = nullptr;
-  const o2::cpv::CalibParams* gains = nullptr;
-  std::decay_t<decltype(ctx.inputs().get<o2::cpv::Pedestals*>("peds"))> pedPtr{};
-  std::decay_t<decltype(ctx.inputs().get<o2::cpv::BadChannelMap*>("badmap"))> badMapPtr{};
-  std::decay_t<decltype(ctx.inputs().get<o2::cpv::CalibParams*>("gains"))> gainsPtr{};
-
-  if (!mIsPedestalData) {
-    pedPtr = ctx.inputs().get<o2::cpv::Pedestals*>("peds");
-    pedestals = pedPtr.get();
-  }
-
-  if (mIsUsingBadMap) {
-    badMapPtr = ctx.inputs().get<o2::cpv::BadChannelMap*>("badmap");
-    badMap = badMapPtr.get();
-  }
-
-  if (mIsUsingGainCalibration) {
-    gainsPtr = ctx.inputs().get<o2::cpv::CalibParams*>("gains");
-    gains = gainsPtr.get();
-  }
 
   bool skipTF = false; // skip TF due to fatal error?
 
@@ -227,15 +245,15 @@ void RawToDigitConverterSpec::run(framework::ProcessingContext& ctx)
           if (!mIsPedestalData) { // not a pedestal data
             // test bad map
             if (mIsUsingBadMap) {
-              if (!badMap->isChannelGood(absId)) {
+              if (!mBadMap->isChannelGood(absId)) {
                 continue; // skip bad channel
               }
             }
             float amp = 0;
             if (mIsUsingGainCalibration) { // calibrate amplitude
-              amp = gains->getGain(absId) * (ac.Charge - pedestals->getPedestal(absId));
+              amp = mGains->getGain(absId) * (ac.Charge - mPedestals->getPedestal(absId));
             } else { // no gain calibration needed
-              amp = ac.Charge - pedestals->getPedestal(absId);
+              amp = ac.Charge - mPedestals->getPedestal(absId);
             }
             if (amp > 0) { // emplace new digit
               currentDigitContainer->emplace_back(absId, amp, -1);
@@ -266,7 +284,12 @@ void RawToDigitConverterSpec::run(framework::ProcessingContext& ctx)
   // Loop over BCs, sort digits with increasing digit ID and write to output containers
   mOutputDigits.clear();
   mOutputTriggerRecords.clear();
+  const auto tfOrbitFirst = o2::framework::DataRefUtils::getHeader<o2::header::DataHeader*>(ctx.inputs().getFirstValid(true))->firstTForbit;
+  const auto& ctpOffsets = o2::ctp::TriggerOffsetsParam::Instance();
   for (auto [bc, digits] : digitBuffer) {
+    if (bc.differenceInBC({0, tfOrbitFirst}) < ctpOffsets.LM_L0) {
+      continue; // discard this BC as it is actually out of
+    }
     int prevDigitSize = mOutputDigits.size();
     if (digits->size()) {
       // Sort digits according to digit ID
@@ -276,8 +299,8 @@ void RawToDigitConverterSpec::run(framework::ProcessingContext& ctx)
         mOutputDigits.push_back(digit);
       }
     }
-
-    mOutputTriggerRecords.emplace_back(bc, prevDigitSize, mOutputDigits.size() - prevDigitSize);
+    // subtract ctp L0-LM offset here
+    mOutputTriggerRecords.emplace_back(bc - ctpOffsets.LM_L0, prevDigitSize, mOutputDigits.size() - prevDigitSize);
   }
   digitBuffer.clear();
 
@@ -303,6 +326,8 @@ o2::framework::DataProcessorSpec o2::cpv::reco_workflow::getRawToDigitConverterS
     if (useGainCalibration) {
       inputs.emplace_back("gains", "CPV", "CPV_Gains", 0, o2::framework::Lifetime::Condition, o2::framework::ccdbParamSpec("CPV/Calib/Gains"));
     }
+    // use BC correction for non-pedestal runs
+    inputs.emplace_back("trigoffset", "CTP", "Trig_Offset", 0, o2::framework::Lifetime::Condition, o2::framework::ccdbParamSpec("CTP/Config/TriggerOffsets"));
   }
 
   std::vector<o2::framework::OutputSpec> outputs;

--- a/Detectors/CPV/workflow/src/RawToDigitConverterSpec.cxx
+++ b/Detectors/CPV/workflow/src/RawToDigitConverterSpec.cxx
@@ -75,22 +75,22 @@ void RawToDigitConverterSpec::updateTimeDependentParams(framework::ProcessingCon
   if (!updateOnlyOnce) {
     ctx.inputs().get<o2::ctp::TriggerOffsetsParam*>("trigoffset");
 
-    std::decay_t<decltype(ctx.inputs().get<o2::cpv::Pedestals*>("peds"))> pedPtr{};
-    std::decay_t<decltype(ctx.inputs().get<o2::cpv::BadChannelMap*>("badmap"))> badMapPtr{};
-    std::decay_t<decltype(ctx.inputs().get<o2::cpv::CalibParams*>("gains"))> gainsPtr{};
+    // std::decay_t<decltype(ctx.inputs().get<o2::cpv::Pedestals*>("peds"))> pedPtr{};
+    // std::decay_t<decltype(ctx.inputs().get<o2::cpv::BadChannelMap*>("badmap"))> badMapPtr{};
+    // std::decay_t<decltype(ctx.inputs().get<o2::cpv::CalibParams*>("gains"))> gainsPtr{};
 
     if (!mIsPedestalData) {
-      pedPtr = ctx.inputs().get<o2::cpv::Pedestals*>("peds");
+      auto pedPtr = ctx.inputs().get<o2::cpv::Pedestals*>("peds");
       mPedestals = pedPtr.get();
     }
 
     if (mIsUsingBadMap) {
-      badMapPtr = ctx.inputs().get<o2::cpv::BadChannelMap*>("badmap");
+      auto badMapPtr = ctx.inputs().get<o2::cpv::BadChannelMap*>("badmap");
       mBadMap = badMapPtr.get();
     }
 
     if (mIsUsingGainCalibration) {
-      gainsPtr = ctx.inputs().get<o2::cpv::CalibParams*>("gains");
+      auto gainsPtr = ctx.inputs().get<o2::cpv::CalibParams*>("gains");
       mGains = gainsPtr.get();
     }
     updateOnlyOnce = true;


### PR DESCRIPTION
Hello! LM-L0 delay subtraction is added to RawToDigitConverterSpec. Also it is taken into account in simulation/RawWriter.cxx.
Also ccdb timestamp is fetched  from hbfutils (was 'now' previously) in there.