### PR TITLE
[EMCAL-784] Provide only EMV-EMCAL sampling factor for Geant4

### DIFF
--- a/Detectors/EMCAL/base/src/Geometry.cxx
+++ b/Detectors/EMCAL/base/src/Geometry.cxx
@@ -311,13 +311,9 @@ void Geometry::DefineSamplingFraction(const std::string_view mcname, const std::
   } else if (contains(mcname, "Fluka")) {
     samplingFactorTranportModel = 1.; // To be set
   } else if (contains(mcname, "Geant4")) {
-    if (contains(mctitle, "EMV-EMCAL")) {
-      samplingFactorTranportModel = 0.821; // EMC list but for EMCal, before 0.86
-    } else if (contains(mctitle, "EMV")) {
-      samplingFactorTranportModel = 1.096; // 0.906, 0.896 (OPT)
-    } else {
-      samplingFactorTranportModel = 0.821; // 1.15 (CHIPS), 1.149 (BERT), 1.147 (BERT_CHIPS)
-    }
+    samplingFactorTranportModel = 0.821; // EMC list but for EMCal, before 0.86
+    // @TODO here we will have dedicated samplingFactors for the different physics lists provided for O2
+    //
   }
 
   LOG(info) << "MC modeler <" << mcname << ">, Title <" << mctitle << ">: Sampling " << std::setw(2)
@@ -771,7 +767,7 @@ std::tuple<int, int, int> Geometry::GetModuleIndexesFromCellIndexesInSModule(int
       moduleID = moduleEta * nModulesInSMPhi + modulePhi;
   int etaInModule = etaInSupermodule % mNETAdiv,
       phiInModule = phiInSupermodule % mNPHIdiv;
-  //return std::make_tuple(modulePhi, moduleEta, moduleID);
+  // return std::make_tuple(modulePhi, moduleEta, moduleID);
   return std::make_tuple(phiInModule, etaInModule, moduleID);
 }
 


### PR DESCRIPTION
Geant4 tune for EMCAL identical to the one used in AliDPG,
however the tag "EMV-EMCAL" was removed from the title.
Therefore the sampling factor "EMV" was selected as the
tag is part of the physics list and it is the second in
priorty. Choosing the EMV sampling factor leads to an
overscaling. In the current stage we only provide the
EMV-EMCAL scaling factor as it is adapted to the usual
physics list, in a next iteration we will provide dedicated
sampling factors for the other two physics lists as well.