### PR TITLE
Filter MID bad channels

### DIFF
--- a/Detectors/MUON/MID/Raw/include/MIDRaw/ROBoardConfigHandler.h
+++ b/Detectors/MUON/MID/Raw/include/MIDRaw/ROBoardConfigHandler.h
@@ -84,9 +84,12 @@ class ROBoardConfigHandler
 std::vector<ROBoardConfig> makeDefaultROBoardConfig(uint16_t gbtUniqueId = 0xFFFF);
 /// Creates a local board configuration where no zero suppression is required
 /// \param gbtUniqueId GBT unique ID
-/// \return Vector of Readout boards configuration with no Zero suppression
+/// \return Vector of Readout boards configuration with no zero suppression
 std::vector<ROBoardConfig> makeNoZSROBoardConfig(uint16_t gbtUniqueId = 0xFFFF);
-
+/// Creates a local board configuration with zero suppression
+/// \param gbtUniqueId GBT unique ID
+/// \return Vector of Readout boards configuration with zero suppression
+std::vector<ROBoardConfig> makeZSROBoardConfig(uint16_t gbtUniqueId = 0xFFFF);
 } // namespace mid
 } // namespace o2
 

--- a/Detectors/MUON/MID/Workflow/CMakeLists.txt
+++ b/Detectors/MUON/MID/Workflow/CMakeLists.txt
@@ -19,6 +19,7 @@ o2_add_library(
           src/EntropyDecoderSpec.cxx
           src/EntropyEncoderSpec.cxx
           src/FetToDeadSpec.cxx
+          src/FilteringSpec.cxx
           src/MaskHandlerSpec.cxx
           src/MaskMakerSpec.cxx
           src/ChannelCalibratorSpec.cxx

--- a/Detectors/MUON/MID/Workflow/include/MIDWorkflow/FilteringSpec.h
+++ b/Detectors/MUON/MID/Workflow/include/MIDWorkflow/FilteringSpec.h
@@ -9,23 +9,24 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file   MIDWorkflow/ZeroSuppressionSpec.h
-/// \brief  MID zero suppression spec
+/// \file   MIDWorkflow/FilteringSpec.h
+/// \brief  MID filtering spec
 /// \author Diego Stocco <Diego.Stocco at cern.ch>
-/// \date   23 October 2020
+/// \date   16 March 2022
 
-#ifndef O2_MID_ZEROSUPPRESSIONSPEC_H
-#define O2_MID_ZEROSUPPRESSIONSPEC_H
+#ifndef O2_MID_FILTERINGSPEC_H
+#define O2_MID_FILTERINGSPEC_H
 
 #include "Framework/DataProcessorSpec.h"
+
 #include <string_view>
 
 namespace o2
 {
 namespace mid
 {
-framework::DataProcessorSpec getZeroSuppressionSpec(bool useMC = true, std::string_view dataDesc = "DATAMC");
+framework::DataProcessorSpec getFilteringSpec(bool useMC = true, std::string_view inDesc = "DATA", std::string_view outDesc = "FDATA");
 }
 } // namespace o2
 
-#endif // O2_MID_ZEROSUPPRESSIONSPEC_H
+#endif // O2_MID_FILTERINGSPEC_H

--- a/Detectors/MUON/MID/Workflow/src/FilteringSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/FilteringSpec.cxx
@@ -1,0 +1,144 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Workflow/src/FilteringSpec.cxx
+/// \brief  MID filtering spec
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   16 March 2022
+
+#include "MIDWorkflow/FilteringSpec.h"
+
+#include <vector>
+#include <gsl/gsl>
+#include <fmt/format.h>
+#include "Framework/CCDBParamSpec.h"
+#include "Framework/Output.h"
+#include "Framework/Task.h"
+#include "Framework/WorkflowSpec.h"
+#include "DataFormatsMID/ColumnData.h"
+#include "DataFormatsMID/ROFRecord.h"
+#include "DataFormatsMID/MCLabel.h"
+#include "SimulationDataFormat/MCTruthContainer.h"
+#include "MIDFiltering/ChannelMasksHandler.h"
+#include "MIDWorkflow/ColumnDataSpecsUtils.h"
+
+namespace of = o2::framework;
+
+namespace o2
+{
+namespace mid
+{
+
+class FilteringDeviceDPL
+{
+ public:
+  FilteringDeviceDPL(bool useMC, std::vector<of::OutputSpec> outputSpecs) : mUseMC(useMC)
+  {
+    mOutputs = specs::buildOutputs(outputSpecs);
+
+    if (useMC) {
+      mFillLabels = [](size_t inIdx, size_t outIdx, const o2::dataformats::MCTruthContainer<MCLabel>* inMCContainer, o2::dataformats::MCTruthContainer<MCLabel>& outMCContainer, const ColumnData& col) {
+        auto labels = inMCContainer->getLabels(inIdx);
+        for (auto& label : labels) {
+          if (label.getDEId() == col.deId && label.getColumnId() == col.columnId) {
+            bool hasLabel = false;
+            for (int istrip = label.getFirstStrip(), last = label.getLastStrip(); istrip <= last; ++istrip) {
+              if ((label.getCathode() == 1 && col.isNBPStripFired(istrip)) || (label.getCathode() == 0 && col.isBPStripFired(label.getStripInLine(istrip), label.getLine(istrip)))) {
+                hasLabel = true;
+                break;
+              }
+            }
+            if (hasLabel) {
+              outMCContainer.addElement(outIdx, label);
+            }
+          }
+        }
+      };
+    }
+  }
+
+  void init(of::InitContext& ic)
+  {
+  }
+
+  void finaliseCCDB(of::ConcreteDataMatcher matcher, void* obj)
+  {
+    if (matcher == of::ConcreteDataMatcher(header::gDataOriginMID, "BAD_CHANNELS", 0)) {
+      LOG(info) << "Update MID_BAD_CHANNELS";
+      auto* badChannels = static_cast<std::vector<ColumnData>*>(obj);
+      mMasksHandler.switchOffChannels(*badChannels);
+    }
+  }
+
+  void run(of::ProcessingContext& pc)
+  {
+    const auto badChannels = pc.inputs().get<std::vector<ColumnData>*>("mid_bad_channels");
+
+    auto data = specs::getData(pc, "mid_filter_in", EventType::Standard);
+    auto inROFRecords = specs::getRofs(pc, "mid_filter_in", EventType::Standard);
+
+    std::unique_ptr<const o2::dataformats::MCTruthContainer<MCLabel>> inMCContainer = mUseMC ? specs::getLabels(pc, "mid_filter_in") : nullptr;
+
+    auto& maskedData = pc.outputs().make<std::vector<ColumnData>>(of::OutputRef{"mid_filter_out_0"});
+    auto& maskedRofs = pc.outputs().make<std::vector<ROFRecord>>(of::OutputRef{"mid_filter_out_rof_0"});
+
+    maskedData.reserve(data.size());
+    maskedRofs.reserve(inROFRecords.size());
+
+    o2::dataformats::MCTruthContainer<MCLabel> outMCContainer;
+
+    for (auto& rof : inROFRecords) {
+      auto firstEntry = maskedData.size();
+      for (auto dataIt = data.begin() + rof.firstEntry, end = data.begin() + rof.getEndIndex(); dataIt != end; ++dataIt) {
+        auto col = *dataIt;
+        if (mMasksHandler.applyMask(col)) {
+          // Data are not fully masked
+          maskedData.emplace_back(col);
+          auto inIdx = std::distance(data.begin(), dataIt);
+          mFillLabels(inIdx, maskedData.size() - 1, inMCContainer.get(), outMCContainer, col);
+        }
+      }
+      auto nEntries = maskedData.size() - firstEntry;
+      if (nEntries > 0) {
+        maskedRofs.emplace_back(rof);
+        maskedRofs.back().firstEntry = firstEntry;
+        maskedRofs.back().nEntries = nEntries;
+      }
+    }
+
+    if (mUseMC) {
+      pc.outputs().snapshot(mOutputs[2], outMCContainer);
+    }
+  }
+
+ private:
+  ChannelMasksHandler mMasksHandler{};
+  bool mUseMC{false};
+  std::vector<of::Output> mOutputs;
+  std::function<void(size_t, size_t, const o2::dataformats::MCTruthContainer<MCLabel>*, o2::dataformats::MCTruthContainer<MCLabel>&, const ColumnData& col)> mFillLabels{[](size_t, size_t, const o2::dataformats::MCTruthContainer<MCLabel>*, o2::dataformats::MCTruthContainer<MCLabel>&, const ColumnData&) {}};
+};
+
+of::DataProcessorSpec getFilteringSpec(bool useMC, std::string_view inDesc, std::string_view outDesc)
+{
+
+  auto inputSpecs = specs::buildInputSpecs("mid_filter_in", inDesc, useMC);
+  inputSpecs.emplace_back("mid_bad_channels", header::gDataOriginMID, "BAD_CHANNELS", 0, of::Lifetime::Condition, of::ccdbParamSpec("MID/Calib/BadChannels"));
+
+  auto outputSpecs = specs::buildStandardOutputSpecs("mid_filter_out", outDesc, useMC);
+
+  return of::DataProcessorSpec{
+    "MIDFiltering",
+    {inputSpecs},
+    {outputSpecs},
+    of::AlgorithmSpec{of::adaptFromTask<o2::mid::FilteringDeviceDPL>(useMC, outputSpecs)}};
+}
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/Workflow/src/digits-reader-workflow.cxx
+++ b/Detectors/MUON/MID/Workflow/src/digits-reader-workflow.cxx
@@ -41,7 +41,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
   std::vector<ConfigParamSpec> options{
     {"disable-mc", VariantType::Bool, false, {"Do not propagate MC info"}},
-    {"disable-zero-suppression", VariantType::Bool, false, {"Do not apply zero suppression"}},
+    {"disable-zero-suppression", VariantType::Bool, true, {"Do not apply zero suppression. Option is disabled since ZS cannot be applied right now (see ROBoradConfigHanler)"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
   std::swap(workflowOptions, options);
@@ -52,6 +52,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   bool disableZS = cfgc.options().get<bool>("disable-zero-suppression");
+  disableZS = true; // Option is disabled
   bool useMC = !cfgc.options().get<bool>("disable-mc");
 
   o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));

--- a/Detectors/MUON/MID/Workflow/src/digits-reader-workflow.cxx
+++ b/Detectors/MUON/MID/Workflow/src/digits-reader-workflow.cxx
@@ -23,6 +23,7 @@
 #include "DataFormatsMID/ROFRecord.h"
 #include "DataFormatsMID/MCLabel.h"
 #include "MIDWorkflow/DigitReaderSpec.h"
+#include "MIDWorkflow/FilteringSpec.h"
 #include "MIDWorkflow/ZeroSuppressionSpec.h"
 #include "DetectorsRaw/HBFUtilsInitializer.h"
 #include "Framework/CallbacksPolicy.h"
@@ -56,9 +57,12 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
 
   WorkflowSpec specs;
-  specs.emplace_back(o2::mid::getDigitReaderSpec(useMC, disableZS ? "DATA" : "DATAMC"));
+  std::string dataDesc = disableZS ? "DATA" : "DATAMC";
+  specs.emplace_back(o2::mid::getDigitReaderSpec(useMC, dataDesc.data()));
   if (!disableZS) {
-    specs.emplace_back(o2::mid::getZeroSuppressionSpec(useMC));
+    std::string outDesc = "MFDATA";
+    specs.emplace_back(o2::mid::getFilteringSpec(useMC, dataDesc, outDesc));
+    specs.emplace_back(o2::mid::getZeroSuppressionSpec(useMC, outDesc));
   }
 
   // configure dpl timer to inject correct firstTFOrbit: start from the 1st orbit of TF containing 1st sampled orbit


### PR DESCRIPTION
This is mainly achieved by the first commit. The presence of the filtering requires a consistent treatment of the the digits specs name (before and after filtering). Such specs change once again name in case the ZeroSuppression is there or not.
The ZS is currently not appliable, so, to simplify the calculation, we also disable the option to perform the ZeroSuppression .
The commits are meant to be done in a short time one after another, so the easiest way is to group them in one PR.

Please do not squash when merging.