### PR TITLE
DCS random data generator: use system_clock to get wall time

### DIFF
--- a/Detectors/DCS/testWorkflow/src/DCSRandomDataGeneratorSpec.cxx
+++ b/Detectors/DCS/testWorkflow/src/DCSRandomDataGeneratorSpec.cxx
@@ -28,13 +28,13 @@ using namespace o2::framework;
 namespace
 {
 /** generate random integers uniformly distributed within a range.
-  *
-  * @param size the number of integers to generate
-  * @param min the minimum value to be generated
-  * @param max the maximum value to be generated
-  *
-  * @returns a vector of integers
-  */
+ *
+ * @param size the number of integers to generate
+ * @param min the minimum value to be generated
+ * @param max the maximum value to be generated
+ *
+ * @returns a vector of integers
+ */
 std::vector<int> generateIntegers(size_t size, int min, int max)
 {
   std::uniform_int_distribution<int> distribution(min, max);
@@ -54,12 +54,12 @@ std::vector<int> generateIntegers(size_t size, int min, int max)
 }
 
 /** generate DCS data points.
-  *
-  * @param hints vector of HintType describing what to generate
-  * @param fraction fraction of the generated aliases that are returned (1.0 by default)
-  *
-  * @returns a vector of DataPointCompositeObjects
-  */
+ *
+ * @param hints vector of HintType describing what to generate
+ * @param fraction fraction of the generated aliases that are returned (1.0 by default)
+ *
+ * @returns a vector of DataPointCompositeObjects
+ */
 std::vector<o2::dcs::DataPointCompositeObject> generate(const std::vector<o2::dcs::test::HintType> hints,
                                                         float fraction = 1.0,
                                                         uint64_t tfid = 0)
@@ -96,12 +96,12 @@ std::vector<o2::dcs::DataPointCompositeObject> generate(const std::vector<o2::dc
 }
 
 /**
-  * DCSRandomDataGenerator is an example device that generates random
-  * DCS Data Points.
-  *
-  * The actual description of what is generated is hard-coded in
-  * the init() method.
-  */
+ * DCSRandomDataGenerator is an example device that generates random
+ * DCS Data Points.
+ *
+ * The actual description of what is generated is hard-coded in
+ * the init() method.
+ */
 class DCSRandomDataGenerator : public o2::framework::Task
 {
  public:
@@ -150,7 +150,7 @@ void DCSRandomDataGenerator::run(o2::framework::ProcessingContext& pc)
 
   LOG(info) << "***************** TF " << tfid << " has generated " << dpcoms.size() << " DPs";
   auto& timingInfo = pc.services().get<o2::framework::TimingInfo>();
-  auto timeNow = std::chrono::high_resolution_clock::now();
+  auto timeNow = std::chrono::system_clock::now();
   timingInfo.creation = std::chrono::duration_cast<std::chrono::milliseconds>(timeNow.time_since_epoch()).count(); // in ms
 
   pc.outputs().snapshot(Output{"DCS", mDataDescription, 0, Lifetime::Timeframe}, dpcoms);


### PR DESCRIPTION
using `std::chrono::high_resolution_clock::now()` is not a valid way to get current date on all systems  (e.g. not correct on Apple M1), which can be checked using : 

```
#include <chrono>
#include <iostream>

using namespace std::chrono;

int main()
{

        auto a = duration_cast<milliseconds>(high_resolution_clock::now().time_since_epoch()).count();
        auto b = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();

        std::cout << "a=" << a << "\n";
        std::cout << "b=" << b << "\n";
        return 0;
}
```

On a Linux (centos8s) box there's no difference : 
```
> g++ timing.cxx && ./a.out
a=1655996271992
b=1655996271992
```

but on a Apple M1 : 

```
clang++ -std=c++17 timing.cxx && ./a.out
a=2098554178
b=1655996660398
```