### PR TITLE
MCTrack: change encoding for process to unsigned

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/MCTrack.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCTrack.h
@@ -239,7 +239,7 @@ class MCTrackT
     int i;
     struct {
       int storage : 1;  // encoding whether to store this track to the output
-      int process : 6;  // encoding process that created this track (enough to store TMCProcess from ROOT)
+      unsigned int process : 6; // encoding process that created this track (enough to store TMCProcess from ROOT)
       int hitmask : 21; // encoding hits per detector
       int reserved1 : 1; // bit reserved for possible future purposes
       int reserved2 : 1; // bit reserved for possible future purposes

--- a/DataFormats/simulation/test/MCTrack.cxx
+++ b/DataFormats/simulation/test/MCTrack.cxx
@@ -52,6 +52,12 @@ BOOST_AUTO_TEST_CASE(MCTrack_test)
   BOOST_CHECK(track.leftTrace(1) == true);
   BOOST_CHECK(track.getNumDet() == 1);
 
+  // check process encoding
+  track.setProcess(TMCProcess::kPPrimary);
+  BOOST_CHECK(track.getProcess() == TMCProcess::kPPrimary);
+  track.setProcess(TMCProcess::kPTransportation);
+  BOOST_CHECK(track.getProcess() == TMCProcess::kPTransportation);
+
   {
     // serialize it
     TFile f("MCTrackOut.root", "RECREATE");


### PR DESCRIPTION
We used 6bit int to be able to encode TMCProcesses inside MCTrack.
Unfortunately, when reading back as int this was interpreted in a signed
fashion and so an overflow/negative values were possible.

Now using an explicit unsigned 6 bit representation to fix the problem.
Fixes https://alice.its.cern.ch/jira/browse/O2-3030.