### PR TITLE
correct and standardize the definition of MCH/MID-based track time

### DIFF
--- a/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h
+++ b/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h
@@ -19,8 +19,10 @@
 
 #include "CommonDataFormat/InteractionRecord.h"
 #include "CommonDataFormat/RangeReference.h"
+#include "CommonDataFormat/TimeStamp.h"
 
 #include <iosfwd>
+#include <utility>
 
 namespace o2
 {
@@ -33,6 +35,7 @@ class ROFRecord
 {
   using BCData = o2::InteractionRecord;
   using DataRef = o2::dataformats::RangeReference<int, int>;
+  using Time = o2::dataformats::TimeStampWithError<float, float>;
 
  public:
   ROFRecord() = default;
@@ -45,6 +48,8 @@ class ROFRecord
   BCData& getBCData() { return mBCData; }
   /// set the interaction record
   void setBCData(const BCData& bc) { mBCData = bc; }
+
+  std::pair<Time, bool> getTimeMUS(const BCData& startIR, uint32_t nOrbits = 128, bool printError = false) const;
 
   /// get the number of associated objects
   int getNEntries() const { return mDataRef.getEntries(); }

--- a/DataFormats/Detectors/MUON/MCH/src/ROFRecord.cxx
+++ b/DataFormats/Detectors/MUON/MCH/src/ROFRecord.cxx
@@ -10,9 +10,13 @@
 // or submit itself to any jurisdiction.
 
 #include "DataFormatsMCH/ROFRecord.h"
+
 #include <fmt/format.h>
 #include <iostream>
 #include <stdexcept>
+
+#include "CommonConstants/LHCConstants.h"
+#include "Framework/Logger.h"
 
 namespace o2::mch
 {
@@ -22,6 +26,23 @@ std::ostream& operator<<(std::ostream& os, const ROFRecord& rof)
                     rof.getBCData().asString(), rof.getFirstIdx(), rof.getLastIdx(),
                     rof.getBCWidth());
   return os;
+}
+
+//__________________________________________________________________________
+/// return a pair consisting of the ROF time with error (in mus) relative to the reference IR 'startIR'
+/// and a flag telling if it is inside the TF starting at 'startIR' and containing 'nOrbits' orbits.
+/// if printError = true, print an error message in case the ROF is outside the TF
+std::pair<ROFRecord::Time, bool> ROFRecord::getTimeMUS(const BCData& startIR, uint32_t nOrbits, bool printError) const
+{
+  auto bcDiff = mBCData.differenceInBC(startIR);
+  float tMean = (bcDiff + 0.5 * mBCWidth) * o2::constants::lhc::LHCBunchSpacingMUS;
+  float tErr = 0.5 * mBCWidth * o2::constants::lhc::LHCBunchSpacingMUS;
+  bool isInTF = bcDiff >= 0 && bcDiff < nOrbits * o2::constants::lhc::LHCMaxBunches;
+  if (printError && !isInTF) {
+    LOGP(alarm, "ATTENTION: wrong bunches diff. {} for current IR {} wrt 1st TF orbit {}, source:MCH",
+         bcDiff, mBCData, startIR);
+  }
+  return std::make_pair(Time(tMean, tErr), isInTF);
 }
 
 } // namespace o2::mch

--- a/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/ROFRecord.h
+++ b/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/ROFRecord.h
@@ -17,7 +17,12 @@
 #ifndef ALICEO2_MID_ROFRECORD_H
 #define ALICEO2_MID_ROFRECORD_H
 
+#include <utility>
+
+#include "CommonConstants/LHCConstants.h"
 #include "CommonDataFormat/InteractionRecord.h"
+#include "CommonDataFormat/TimeStamp.h"
+#include "Framework/Logger.h"
 
 namespace o2
 {
@@ -34,6 +39,8 @@ constexpr uint32_t NEvTypes = 3;
 /// ROFRecord class encodes the trigger interaction record of given ROF and
 /// the reference on the 1st object (digit, cluster etc) of this ROF in the data tree
 struct ROFRecord {
+  using Time = o2::dataformats::TimeStampWithError<float, float>;
+
   o2::InteractionRecord interactionRecord{}; //< Interaction record
   EventType eventType{EventType::Standard};  //< Event type
   size_t firstEntry{0};                      //< First associated entry
@@ -43,6 +50,24 @@ struct ROFRecord {
   ROFRecord(const o2::InteractionRecord& intRecord, const EventType& evtType, size_t first, size_t nElements) : interactionRecord(intRecord), eventType(evtType), firstEntry(first), nEntries(nElements) {}
   ROFRecord(const ROFRecord& other, size_t first, size_t nElements) : interactionRecord(other.interactionRecord), eventType(other.eventType), firstEntry(first), nEntries(nElements) {}
   size_t getEndIndex() const { return firstEntry + nEntries; }
+
+  //__________________________________________________________________________
+  /// return a pair consisting of the ROF time with error (in mus) relative to the reference IR 'startIR'
+  /// and a flag telling if it is inside the TF starting at 'startIR' and containing 'nOrbits' orbits.
+  /// if printError = true, print an error message in case the ROF is outside the TF
+  std::pair<Time, bool> getTimeMUS(const InteractionRecord& startIR, uint32_t nOrbits = 128,
+                                   bool printError = false) const
+  {
+    auto bcDiff = interactionRecord.differenceInBC(startIR);
+    float tMean = (bcDiff + 0.5) * o2::constants::lhc::LHCBunchSpacingMUS;
+    float tErr = 0.5 * o2::constants::lhc::LHCBunchSpacingMUS;
+    bool isInTF = bcDiff >= 0 && bcDiff < nOrbits * o2::constants::lhc::LHCMaxBunches;
+    if (printError && !isInTF) {
+      LOGP(alarm, "ATTENTION: wrong bunches diff. {} for current IR {} wrt 1st TF orbit {}, source:MID",
+           bcDiff, interactionRecord, startIR);
+    }
+    return std::make_pair(Time(tMean, tErr), isInTF);
+  }
 
   ClassDefNV(ROFRecord, 1);
 };

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackMCHMID.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackMCHMID.h
@@ -17,7 +17,10 @@
 #ifndef ALICEO2_TRACKMCHMID_H
 #define ALICEO2_TRACKMCHMID_H
 
+#include <utility>
+
 #include "CommonDataFormat/InteractionRecord.h"
+#include "CommonDataFormat/TimeStamp.h"
 #include "ReconstructionDataFormats/GlobalTrackID.h"
 
 namespace o2
@@ -28,6 +31,8 @@ namespace dataformats
 /// MUON track external format
 class TrackMCHMID
 {
+  using Time = o2::dataformats::TimeStampWithError<float, float>;
+
  public:
   TrackMCHMID() = default;
   TrackMCHMID(const GlobalTrackID& mchID, const GlobalTrackID& midID, const InteractionRecord& midIR, double chi2)
@@ -59,6 +64,9 @@ class TrackMCHMID
   InteractionRecord getIR() const { return mIR; }
   /// set the interaction record associated to this track
   void setIR(const InteractionRecord& ir) { mIR = ir; }
+
+  std::pair<Time, bool> getTimeMUS(const InteractionRecord& startIR, uint32_t nOrbits = 128,
+                                   bool printError = false) const;
 
   /// get the MCH-MID matching chi2/ndf
   double getMatchChi2OverNDF() const { return mMatchNChi2; }

--- a/Detectors/GlobalTracking/src/MatchGlobalFwd.cxx
+++ b/Detectors/GlobalTracking/src/MatchGlobalFwd.cxx
@@ -152,6 +152,7 @@ bool MatchGlobalFwd::prepareMCHData()
     int nBC = rofRec.getBCData().differenceInBC(mStartIR);
     float tMin = nBC * o2::constants::lhc::LHCBunchSpacingMUS;
     float tMax = (nBC + rofRec.getBCWidth()) * o2::constants::lhc::LHCBunchSpacingMUS;
+    auto mchTime = rofRec.getTimeMUS(mStartIR).first;
 
     mMCHROFTimes.emplace_back(tMin, tMax); // MCH ROF min/max time
     LOG(debug) << "MCH ROF # " << irof << " [tMin;tMax] = [" << tMin << ";" << tMax << "]";
@@ -168,6 +169,7 @@ bool MatchGlobalFwd::prepareMCHData()
       auto convertedTrack = MCHtoFwd(tempParam);
       auto& thisMCHTrack = mMCHWork.emplace_back(TrackLocMCH{convertedTrack, {tMin, tMax}});
       thisMCHTrack.setMCHTrackID(it);
+      thisMCHTrack.setTimeMUS(mchTime);
     }
   }
   return true;
@@ -191,8 +193,9 @@ bool MatchGlobalFwd::processMCHMIDMatches()
       const auto& IR = MIDMatch.getIR();
       int nBC = IR.differenceInBC(mStartIR);
       float tMin = nBC * o2::constants::lhc::LHCBunchSpacingMUS;
-      float tMax = tMin + o2::constants::lhc::LHCBunchSpacingMUS;
+      float tMax = (nBC + 1) * o2::constants::lhc::LHCBunchSpacingMUS;
       thisMuonTrack.setMIDTrackID(MIDId);
+      thisMuonTrack.setTimeMUS(MIDMatch.getTimeMUS(mStartIR).first);
       thisMuonTrack.tBracket.set(tMin, tMax);
       thisMuonTrack.setMIDMatchingChi2(MIDMatch.getMatchChi2OverNDF());
     }
@@ -355,7 +358,6 @@ void MatchGlobalFwd::doMatching()
         }
 
         thisMCHTrack.setMFTTrackID(bestMFTMatchID);
-        thisMCHTrack.setTimeMUS(thisMCHTrack.tBracket.getMin(), thisMCHTrack.tBracket.delta());
         LOG(debug) << "    thisMCHTrack.getMFTTrackID() = " << thisMCHTrack.getMFTTrackID()
                    << "; thisMCHTrack.getMFTMCHMatchingChi2() = " << thisMCHTrack.getMFTMCHMatchingChi2();
 
@@ -418,7 +420,6 @@ void MatchGlobalFwd::ROFMatch(int MFTROFId, int firstMCHROFId, int lastMCHROFId)
         }
         if constexpr (saveAllMode == SaveMode::kSaveAll) { // In saveAllmode save all pairs to output container
           thisMCHTrack.setMFTTrackID(MFTId);
-          thisMCHTrack.setTimeMUS(thisMCHTrack.tBracket.getMin(), thisMCHTrack.tBracket.delta());
           mMatchedTracks.emplace_back(thisMCHTrack);
           mMatchingInfo.emplace_back(thisMCHTrack);
           if (mMCTruthON) {
@@ -429,7 +430,6 @@ void MatchGlobalFwd::ROFMatch(int MFTROFId, int firstMCHROFId, int lastMCHROFId)
 
         if constexpr (saveAllMode == SaveMode::kSaveTrainingData) { // In save training data mode store track parameters at matching plane
           thisMCHTrack.setMFTTrackID(MFTId);
-          thisMCHTrack.setTimeMUS(thisMCHTrack.tBracket.getMin(), thisMCHTrack.tBracket.delta());
           mMatchingInfo.emplace_back(thisMCHTrack);
           mMCHMatchPlaneParams.emplace_back(thisMCHTrack);
           mMFTMatchPlaneParams.emplace_back(static_cast<o2::mft::TrackMFT>(thisMFTTrack));
@@ -490,7 +490,6 @@ void MatchGlobalFwd::doMCMatching()
         auto chi2 = mMatchFunc(thisMCHTrack, thisMFTTrack);
         thisMCHTrack.setMFTTrackID(MFTId);
         thisMCHTrack.setMFTMCHMatchingChi2(chi2);
-        thisMCHTrack.setTimeMUS(thisMCHTrack.tBracket.getMin(), thisMCHTrack.tBracket.delta());
         mMatchedTracks.emplace_back(thisMCHTrack);
         mMatchingInfo.emplace_back(thisMCHTrack);
         mMatchLabels.push_back(matchLabel);

--- a/Detectors/Vertexing/src/VertexTrackMatcher.cxx
+++ b/Detectors/Vertexing/src/VertexTrackMatcher.cxx
@@ -188,13 +188,11 @@ void VertexTrackMatcher::extractTracks(const o2::globaltracking::RecoContainer& 
     } else if constexpr (isMFTTrack<decltype(_tr)>()) { // Same for MFT
       t0 += 0.5 * this->mMFTROFrameLengthMUS;
       terr *= this->mMFTROFrameLengthMUS;
-    } else if constexpr (isGlobalFwdTrack<decltype(_tr)>()) {
-      t0 = _tr.getTimeMUS().getTimeStamp();
-      terr = _tr.getTimeMUS().getTimeStampError() * mPVParams->nSigmaTimeTrack; // gaussian errors must be scaled by requested n-sigma
-    } else {
+    } else if constexpr (!(isMCHTrack<decltype(_tr)>() || isGlobalFwdTrack<decltype(_tr)>())) {
+      // for all other tracks the time is in \mus with gaussian error
       terr *= mPVParams->nSigmaTimeTrack; // gaussian errors must be scaled by requested n-sigma
     }
-    // for all other tracks the time is in \mus with gaussian error
+
     terr += mPVParams->timeMarginTrackTime;
     mTBrackets.emplace_back(TrackTBracket{{t0 - terr, t0 + terr}, _origID});
 

--- a/EventVisualisation/Workflow/src/EveWorkflowHelper.cxx
+++ b/EventVisualisation/Workflow/src/EveWorkflowHelper.cxx
@@ -88,13 +88,11 @@ void EveWorkflowHelper::selectTracks(const CalibObjectsConst* calib,
     } else if constexpr (isMFTTrack<decltype(_tr)>()) { // Same for MFT
       t0 += 0.5f * this->mMFTROFrameLengthMUS;
       terr *= this->mMFTROFrameLengthMUS;
-    } else if constexpr (isGlobalFwdTrack<decltype(_tr)>()) {
-      t0 = _tr.getTimeMUS().getTimeStamp();
-      terr = _tr.getTimeMUS().getTimeStampError() * mPVParams->nSigmaTimeTrack; // gaussian errors must be scaled by requested n-sigma
-    } else {
+    } else if constexpr (!(isMCHTrack<decltype(_tr)>() || isMIDTrack<decltype(_tr)>() || isGlobalFwdTrack<decltype(_tr)>())) {
+      // for all other tracks the time is in \mus with gaussian error
       terr *= mPVParams->nSigmaTimeTrack; // gaussian errors must be scaled by requested n-sigma
     }
-    // for all other tracks the time is in \mus with gaussian error
+
     terr += mPVParams->timeMarginTrackTime;
 
     return Bracket{t0 - terr, t0 + terr};


### PR DESCRIPTION
This corrects the calculation of the MCH/MID-based track time. Also it is now done in one single place for each type of track (MCH-standalone, MID-standalone and MCH-MID), thus avoiding having different definitions in different places.

The fonctions return the track time with error, in µs, wrt to the TF start given as a parameter. They also return a flag to assess its validity, i.e. if the first BC of the time bracket is inside the TF, whose number of orbits is also a parameter of the functions. Finally they have a third parameter to optionally print an error message if it is not valid.

I also profit from this PR to fix the calculations of muon track parameter covariances and pDCA as well as a harmless bug in MFT and fwd track index recording in the AOD producer.