### PR TITLE
DPL: improve async queue to support oldest possible timeframe

### DIFF
--- a/Framework/Core/src/AsyncQueue.cxx
+++ b/Framework/Core/src/AsyncQueue.cxx
@@ -10,6 +10,7 @@
 // or submit itself to any jurisdiction.
 
 #include "Framework/AsyncQueue.h"
+#include "Framework/Logger.h"
 #include <numeric>
 
 namespace o2::framework
@@ -22,41 +23,88 @@ auto AsyncQueueHelpers::create(AsyncQueue& queue, AsyncTaskSpec spec) -> AsyncTa
   return id;
 }
 
-auto AsyncQueueHelpers::post(AsyncQueue& queue, AsyncTaskId id, std::function<void()> task, int64_t debounce) -> void
+auto AsyncQueueHelpers::post(AsyncQueue& queue, AsyncTaskId id, std::function<void()> task, TimesliceId timeslice, int64_t debounce) -> void
 {
   AsyncTask taskToPost;
   taskToPost.task = task;
   taskToPost.id = id;
+  taskToPost.timeslice = timeslice;
   taskToPost.debounce = debounce;
   queue.tasks.push_back(taskToPost);
 }
 
-auto AsyncQueueHelpers::run(AsyncQueue& queue) -> void
+auto AsyncQueueHelpers::run(AsyncQueue& queue, TimesliceId oldestPossible) -> void
 {
+  if (queue.tasks.empty()) {
+    return;
+  }
+  LOGP(debug, "Attempting at running {} tasks", queue.tasks.size());
   std::vector<int> order;
   order.resize(queue.tasks.size());
   std::iota(order.begin(), order.end(), 0);
+  // Decide wether or not they can run as a first thing
+  for (auto& task : queue.tasks) {
+    if (task.timeslice.value < oldestPossible.value) {
+      task.runnable = true;
+    }
+  }
 
-  // Sort by priority and debounce
+  // Sort by runnable, timeslice, then priority and finally debounce
   std::sort(order.begin(), order.end(), [&queue](int a, int b) {
-    if (queue.tasks[a].id.value == -1 || queue.tasks[b].id.value == -1) {
+    if (queue.tasks[a].runnable && !queue.tasks[b].runnable) {
+      return true;
+    }
+    if (!queue.tasks[a].runnable && queue.tasks[b].runnable) {
       return false;
     }
-    if (queue.tasks[a].id.value == queue.tasks[b].id.value) {
-      return queue.tasks[a].debounce > queue.tasks[b].debounce;
+    if (queue.tasks[a].timeslice.value == queue.tasks[b].timeslice.value) {
+      if (queue.tasks[a].id.value == -1 || queue.tasks[b].id.value == -1) {
+        return false;
+      }
+      if (queue.tasks[a].id.value == queue.tasks[b].id.value) {
+        return queue.tasks[a].debounce > queue.tasks[b].debounce;
+      }
+      return queue.prototypes[queue.tasks[a].id.value].score > queue.prototypes[queue.tasks[b].id.value].score;
+    } else {
+      return queue.tasks[a].timeslice.value > queue.tasks[b].timeslice.value;
     }
-    return queue.prototypes[queue.tasks[a].id.value].score > queue.prototypes[queue.tasks[b].id.value].score;
   });
+  for (auto i : order) {
+    if (queue.tasks[i].timeslice.value < oldestPossible.value) {
+      LOGP(debug, "AsyncQueue: Running task {}, timeslice {}, score {}, debounce {}", queue.tasks[i].id.value, queue.tasks[i].timeslice.value, queue.prototypes[queue.tasks[i].id.value].score, queue.tasks[i].debounce);
+    } else {
+      LOGP(debug, "AsyncQueue: Skipping task {}, timeslice {}, score {}, debounce {}", queue.tasks[i].id.value, queue.tasks[i].timeslice.value, queue.prototypes[queue.tasks[i].id.value].score, queue.tasks[i].debounce);
+    }
+  }
   // Keep only the tasks with the highest debounce value for a given id
   auto newEnd = std::unique(order.begin(), order.end(), [&queue](int a, int b) {
-    return queue.tasks[a].id.value == queue.tasks[b].id.value;
+    return queue.tasks[a].runnable == queue.tasks[b].runnable && queue.tasks[a].id.value == queue.tasks[b].id.value;
   });
   order.erase(newEnd, order.end());
 
-  for (auto i : order) {
-    queue.tasks[i].task();
+  if (order.empty() && queue.tasks.size() > 0) {
+    LOGP(debug, "AsyncQueue: not running iteration {} timeslice {} pending {}.", order.size(), queue.iteration, oldestPossible.value, queue.tasks.size());
+    return;
+  } else if (order.empty()) {
+    return;
   }
-  queue.tasks.clear();
+  LOGP(debug, "AsyncQueue: Running {} tasks in iteration {} timeslice {}", order.size(), queue.iteration, oldestPossible.value);
+  bool obsolete = true;
+
+  for (auto i : order) {
+    if (queue.tasks[i].timeslice.value < oldestPossible.value) {
+      // If a timeslice is obsolete, we can run the task and remove it from the queue
+      LOGP(debug, "Running task {} ({})", queue.prototypes[queue.tasks[i].id.value].name, i);
+      queue.tasks[i].task();
+      LOGP(debug, "Done running {}", i);
+    }
+  }
+  // Remove all runnable tasks regardless  they actually
+  // ran or they were skipped due to debouncing.
+  queue.tasks.erase(std::remove_if(queue.tasks.begin(), queue.tasks.end(), [&queue](AsyncTask const& task) {
+                      return task.runnable;
+                    }),
+                    queue.tasks.end());
 }
 
 } // namespace o2::framework

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -843,7 +843,9 @@ void DataProcessingDevice::Run()
       // - we can guarantee this is the last thing we do in the loop (
       //   assuming no one else is adding to the queue before this point).
       auto& queue = mServiceRegistry.get<AsyncQueue>();
-      AsyncQueueHelpers::run(queue);
+      auto oldestPossibleTimeslice = mRelayer->getOldestPossibleOutput();
+      AsyncQueueHelpers::run(queue, {oldestPossibleTimeslice.timeslice.value + 1});
+
       uv_run(mState.loop, shouldNotWait ? UV_RUN_NOWAIT : UV_RUN_ONCE);
       if ((mState.loopReason & mState.tracingFlags) != 0) {
         mState.severityStack.push_back((int)fair::Logger::GetConsoleSeverity());

--- a/Framework/Core/test/test_AsyncQueue.cxx
+++ b/Framework/Core/test/test_AsyncQueue.cxx
@@ -20,28 +20,104 @@
 /// in a given run.
 BOOST_AUTO_TEST_CASE(TestDebouncing)
 {
-  o2::framework::AsyncQueue queue;
-  auto taskId = o2::framework::AsyncQueueHelpers::create(queue, {.name = "test", .score = 10});
+  using namespace o2::framework;
+  AsyncQueue queue;
+  auto taskId = AsyncQueueHelpers::create(queue, {.name = "test", .score = 10});
   // Push two tasks on the queue with the same id
   auto count = 0;
-  o2::framework::AsyncQueueHelpers::post(
-    queue, taskId, [&count]() { count += 1; }, 10);
-  o2::framework::AsyncQueueHelpers::post(
-    queue, taskId, [&count]() { count += 2; }, 20);
-  o2::framework::AsyncQueueHelpers::run(queue);
+  AsyncQueueHelpers::post(
+    queue, taskId, [&count]() { count += 1; }, TimesliceId{0}, 10);
+  AsyncQueueHelpers::post(
+    queue, taskId, [&count]() { count += 2; }, TimesliceId{1}, 20);
+  AsyncQueueHelpers::run(queue, TimesliceId{2});
   BOOST_CHECK_EQUAL(count, 2);
 }
 
 // Test task oridering. The tasks with the highest priority should be executed first.
 BOOST_AUTO_TEST_CASE(TestPriority)
 {
-  o2::framework::AsyncQueue queue;
-  auto taskId1 = o2::framework::AsyncQueueHelpers::create(queue, {.name = "test1", .score = 10});
-  auto taskId2 = o2::framework::AsyncQueueHelpers::create(queue, {.name = "test2", .score = 20});
+  using namespace o2::framework;
+  AsyncQueue queue;
+  auto taskId1 = AsyncQueueHelpers::create(queue, {.name = "test1", .score = 10});
+  auto taskId2 = AsyncQueueHelpers::create(queue, {.name = "test2", .score = 20});
   // Push two tasks on the queue with the same id
   auto count = 0;
-  o2::framework::AsyncQueueHelpers::post(queue, taskId1, [&count]() { count += 10; });
-  o2::framework::AsyncQueueHelpers::post(queue, taskId2, [&count]() { count /= 10; });
-  o2::framework::AsyncQueueHelpers::run(queue);
+  AsyncQueueHelpers::post(
+    queue, taskId1, [&count]() { count += 10; }, TimesliceId{0});
+  AsyncQueueHelpers::post(
+    queue, taskId2, [&count]() { count /= 10; }, TimesliceId{0});
+  AsyncQueueHelpers::run(queue, TimesliceId{2});
   BOOST_CHECK_EQUAL(count, 10);
+}
+
+// Make sure we execute tasks only up to the timeslice provided to run.
+BOOST_AUTO_TEST_CASE(TestOldestTimeslice)
+{
+  using namespace o2::framework;
+  AsyncQueue queue;
+  auto taskId1 = AsyncQueueHelpers::create(queue, {.name = "test1", .score = 10});
+  auto taskId2 = AsyncQueueHelpers::create(queue, {.name = "test2", .score = 20});
+  // Push two tasks on the queue with the same id
+  auto count = 0;
+  AsyncQueueHelpers::post(
+    queue, taskId1, [&count]() { count += 10; }, TimesliceId{1});
+  AsyncQueueHelpers::post(
+    queue, taskId2, [&count]() { count += 20; }, TimesliceId{0});
+  AsyncQueueHelpers::run(queue, TimesliceId{1});
+  BOOST_CHECK_EQUAL(count, 20);
+  AsyncQueueHelpers::run(queue, TimesliceId{1});
+  BOOST_CHECK_EQUAL(count, 20);
+  AsyncQueueHelpers::run(queue, TimesliceId{2});
+  BOOST_CHECK_EQUAL(count, 30);
+}
+
+// Make sure we execute tasks only up to the timeslice provided to run.
+BOOST_AUTO_TEST_CASE(TestOldestTimesliceWithBounce)
+{
+  using namespace o2::framework;
+  AsyncQueue queue;
+  auto taskId1 = AsyncQueueHelpers::create(queue, {.name = "test1", .score = 10});
+  auto taskId2 = AsyncQueueHelpers::create(queue, {.name = "test2", .score = 20});
+  // Push two tasks on the queue with the same id
+  auto count = 0;
+  AsyncQueueHelpers::post(
+    queue, taskId1, [&count]() { count += 10; }, TimesliceId{1});
+  AsyncQueueHelpers::post(
+    queue, taskId2, [&count]() { count += 20; }, TimesliceId{0}, 10);
+  AsyncQueueHelpers::post(
+    queue, taskId2, [&count]() { count += 30; }, TimesliceId{0}, 20);
+  AsyncQueueHelpers::run(queue, TimesliceId{0});
+  BOOST_CHECK_EQUAL(count, 0);
+  BOOST_CHECK_EQUAL(queue.tasks.size(), 3);
+  AsyncQueueHelpers::run(queue, TimesliceId{1});
+  BOOST_CHECK_EQUAL(count, 30);
+  BOOST_CHECK_EQUAL(queue.tasks.size(), 1);
+  AsyncQueueHelpers::run(queue, TimesliceId{2});
+  BOOST_CHECK_EQUAL(count, 40);
+  BOOST_CHECK_EQUAL(queue.tasks.size(), 0);
+}
+
+// Make sure we execute tasks only up to the timeslice provided to run.
+BOOST_AUTO_TEST_CASE(TestOldestTimeslicePerTimeslice)
+{
+  using namespace o2::framework;
+  AsyncQueue queue;
+  auto taskId1 = AsyncQueueHelpers::create(queue, {.name = "test1", .score = 10});
+  // Push two tasks on the queue with the same id
+  auto count = 0;
+  AsyncQueueHelpers::post(
+    queue, taskId1, [&count]() { count += 10; }, TimesliceId{0});
+  BOOST_CHECK_EQUAL(queue.tasks.size(), 1);
+  AsyncQueueHelpers::run(queue, TimesliceId{0});
+  BOOST_CHECK_EQUAL(queue.tasks.size(), 1);
+  BOOST_CHECK_EQUAL(count, 0);
+  AsyncQueueHelpers::post(
+    queue, taskId1, [&count]() { count += 20; }, TimesliceId{1});
+  BOOST_CHECK_EQUAL(queue.tasks.size(), 2);
+  AsyncQueueHelpers::run(queue, TimesliceId{1});
+  BOOST_CHECK_EQUAL(queue.tasks.size(), 1);
+  BOOST_CHECK_EQUAL(count, 10);
+  AsyncQueueHelpers::run(queue, TimesliceId{2});
+  BOOST_CHECK_EQUAL(queue.tasks.size(), 0);
+  BOOST_CHECK_EQUAL(count, 30);
 }


### PR DESCRIPTION
Do not schedule tasks before their associated oldest possible
timeframe is reached.