### PR TITLE
TF rate limiting for CTF, raw-file and raw-tf readers

### DIFF
--- a/Detectors/CTF/README.md
+++ b/Detectors/CTF/README.md
@@ -172,3 +172,8 @@ by `ctrl-C`. Periodic incremental saving of so-far accumulated dictionary data d
 ``--save-dict-after <N>``.
 
 When decoding CTF containing dictionary data (i.e. encoded w/o external dictionaries), externally provided dictionaries will be ignored.
+
+To apply TF rate limiting (make sure that no more than N TFs are in processing) provide `--timeframes-rate-limit <N> --timeframes-rate-limit-ipcid <IPCID>`
+too all workflows (e.g. via ARGS_ALL).
+The IPCID is the NUMA domain ID (usually 0 on non-EPN workflow).
+Additionally, one may throttle on the free SHM by providing an option to the reader `--timeframes-shm-limit <shm-size>`.

--- a/Detectors/CTF/workflow/include/CTFWorkflow/CTFReaderSpec.h
+++ b/Detectors/CTF/workflow/include/CTFWorkflow/CTFReaderSpec.h
@@ -29,6 +29,7 @@ struct CTFReaderInp {
   std::string copyCmd{};
   std::string tffileRegex{};
   std::string remoteRegex{};
+  std::string metricChannel{};
   std::vector<int> ctfIDs{};
   bool allowMissingDetectors = false;
   bool sup0xccdb = false;
@@ -37,6 +38,8 @@ struct CTFReaderInp {
   int maxLoops = 0;
   int maxTFs = -1;
   unsigned int subspec = 0;
+  int tfRateLimit = 0;
+  size_t minSHM = 0;
 };
 
 /// create a processor spec

--- a/Detectors/CTF/workflow/src/CTFReaderSpec.cxx
+++ b/Detectors/CTF/workflow/src/CTFReaderSpec.cxx
@@ -20,6 +20,7 @@
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/InputSpec.h"
 #include "Framework/RawDeviceService.h"
+#include "Framework/RateLimiter.h"
 #include "CommonUtils/StringUtils.h"
 #include "CommonUtils/FileFetcher.h"
 #include "CTFWorkflow/CTFReaderSpec.h"
@@ -44,6 +45,7 @@
 #include "DataFormatsCTP/CTF.h"
 #include "Algorithm/RangeTokenizer.h"
 #include <TStopwatch.h>
+#include <fairmq/Device.h>
 
 using namespace o2::framework;
 
@@ -174,10 +176,9 @@ void CTFReaderSpec::openCTFFile(const std::string& flname)
 ///_______________________________________
 void CTFReaderSpec::run(ProcessingContext& pc)
 {
-
-  if (!mCTFCounter) { // RS FIXME: this is a temporary hack to avoid late-starting devices to lose the input
-    LOG(warning) << "This is a hack, sleeping 5 s at startup";
-    pc.services().get<RawDeviceService>().waitFor(1000);
+  static bool initOnceDone = false;
+  if (!initOnceDone) {
+    mInput.tfRateLimit = std::stoi(pc.services().get<RawDeviceService>().device()->fConfig->GetValue<std::string>("timeframes-rate-limit"));
   }
 
   std::string tfFileName;
@@ -226,6 +227,9 @@ void CTFReaderSpec::processTF(ProcessingContext& pc)
 {
   auto cput = mTimer.CpuTime();
   mTimer.Start(false);
+
+  static RateLimiter limiter;
+  limiter.check(pc, mInput.tfRateLimit, mInput.minSHM);
 
   CTFHeader ctfHeader;
   if (!readFromTree(*(mCTFTree.get()), "CTFHeader", ctfHeader, mCurrTreeEntry)) {
@@ -281,6 +285,7 @@ void CTFReaderSpec::processTF(ProcessingContext& pc)
   auto entryStr = fmt::format("({} of {} in {})", mCurrTreeEntry, mCTFTree->GetEntries(), mCTFFile->GetName());
   checkTreeEntries();
   mTimer.Stop();
+
   // do we need to way to respect the delay ?
   long tNow = std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::system_clock::now()).time_since_epoch().count();
   auto tDiff = tNow - mLastSendTime;
@@ -288,8 +293,6 @@ void CTFReaderSpec::processTF(ProcessingContext& pc)
     if (tDiff < mInput.delay_us) {
       pc.services().get<RawDeviceService>().waitFor((mInput.delay_us - tDiff) / 1000); // respect requested delay before sending
     }
-  } else {
-    mLastSendTime = tNow;
   }
   tNow = std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::system_clock::now()).time_since_epoch().count();
   LOGP(info, "Read CTF {} {} in {:.3f} s, {:.4f} s elapsed from previous CTF", mCTFCounter, entryStr, mTimer.CpuTime() - cput, 1e-6 * (tNow - mLastSendTime));
@@ -393,6 +396,7 @@ void CTFReaderSpec::tryToFixCTFHeader(CTFHeader& ctfHeader) const
 DataProcessorSpec getCTFReaderSpec(const CTFReaderInp& inp)
 {
   std::vector<OutputSpec> outputs;
+  std::vector<ConfigParamSpec> options;
 
   outputs.emplace_back(OutputLabel{"header"}, "CTF", "HEADER", inp.subspec, Lifetime::Timeframe);
   for (auto id = DetID::First; id <= DetID::Last; id++) {
@@ -405,14 +409,19 @@ DataProcessorSpec getCTFReaderSpec(const CTFReaderInp& inp)
     outputs.emplace_back(OutputSpec{{"TFDist"}, o2::header::gDataOriginFLP, o2::header::gDataDescriptionDISTSTF, 0xccdb});
   }
 
+  options.emplace_back(ConfigParamSpec{"select-ctf-ids", VariantType::String, "", {"comma-separated list CTF IDs to inject (from cumulative counter of CTFs seen)"}});
+  options.emplace_back(ConfigParamSpec{"impose-run-start-timstamp", VariantType::Int64, 0L, {"impose run start time stamp (ms), ignored if 0"}});
+  options.emplace_back(ConfigParamSpec{"local-tf-counter", VariantType::Bool, false, {"reassign header.tfCounter from local TF counter"}});
+  if (!inp.metricChannel.empty()) {
+    options.emplace_back(ConfigParamSpec{"channel-config", VariantType::String, inp.metricChannel, {"Out-of-band channel config for TF throttling"}});
+  }
+
   return DataProcessorSpec{
     "ctf-reader",
     Inputs{},
     outputs,
     AlgorithmSpec{adaptFromTask<CTFReaderSpec>(inp)},
-    Options{{"select-ctf-ids", VariantType::String, "", {"comma-separated list CTF IDs to inject (from cumulative counter of CTFs seen)"}},
-            {"impose-run-start-timstamp", VariantType::Int64, 0L, {"impose run start time stamp (ms), ignored if 0"}},
-            {"local-tf-counter", VariantType::Bool, false, {"reassign header.tfCounter from local TF counter"}}}};
+    options};
 }
 
 } // namespace ctf

--- a/Detectors/Raw/README.md
+++ b/Detectors/Raw/README.md
@@ -537,7 +537,7 @@ The raw data will be propagated (if present) only if the detector is selected in
 
 ## TF rate limiting
 
-To apply TF rate limiting (make sure that no more than N TFs are in processing) provide `--timeframes-rate-limit <N> --timeframes-rate-limit-ipcid <IPCID>`
+To apply TF rate limiting (i.e. make sure that no more than N TFs are in processing) provide `--timeframes-rate-limit <N> --timeframes-rate-limit-ipcid <IPCID>`
 too all workflows (e.g. via ARGS_ALL).
 The IPCID is the NUMA domain ID (usually 0 on non-EPN workflow).
 Additionally, one may throttle on the free SHM by providing an option to the reader `--timeframes-shm-limit <shm-size>`.

--- a/Detectors/Raw/README.md
+++ b/Detectors/Raw/README.md
@@ -535,6 +535,13 @@ list of detectors for which raw outputs are discarded.
 
 The raw data will be propagated (if present) only if the detector is selected in `--onlyDet` and `NOT` selected in `--non-raw-only-det`. The non-raw data will be propagated (if defined for the given detector and present in the file) only if the detector is selected in `--onlyDet` and `NOT` selected in `--raw-only-det`.
 
+## TF rate limiting
+
+To apply TF rate limiting (make sure that no more than N TFs are in processing) provide `--timeframes-rate-limit <N> --timeframes-rate-limit-ipcid <IPCID>`
+too all workflows (e.g. via ARGS_ALL).
+The IPCID is the NUMA domain ID (usually 0 on non-EPN workflow).
+Additionally, one may throttle on the free SHM by providing an option to the reader `--timeframes-shm-limit <shm-size>`.
+
 ## Miscellaneous macros
 
 *   `rawStat.C`: writes into the tree the size per HBF contained in the raw data provided in the RawFileReader config file. No check for synchronization between different links is done.

--- a/Detectors/Raw/TFReaderDD/src/TFReaderSpec.cxx
+++ b/Detectors/Raw/TFReaderDD/src/TFReaderSpec.cxx
@@ -21,6 +21,7 @@
 #include "Framework/Task.h"
 #include "Framework/Logger.h"
 #include "Framework/DataProcessingHelpers.h"
+#include "Framework/RateLimiter.h"
 #include "Headers/DataHeaderHelpers.h"
 
 #include "DetectorsCommonDataFormats/DetID.h"
@@ -115,7 +116,10 @@ void TFReaderSpec::run(o2f::ProcessingContext& ctx)
   if (device != mDevice) {
     throw std::runtime_error(fmt::format("FMQDevice has changed, old={} new={}", fmt::ptr(mDevice), fmt::ptr(device)));
   }
-
+  static bool initOnceDone = false;
+  if (!initOnceDone) {
+    mInput.tfRateLimit = std::stoi(device->fConfig->GetValue<std::string>("timeframes-rate-limit"));
+  }
   auto acknowledgeOutput = [this](fair::mq::Parts& parts) {
     int np = parts.Size();
     for (int ip = 0; ip < np; ip += 2) {
@@ -209,6 +213,9 @@ void TFReaderSpec::run(o2f::ProcessingContext& ctx)
       break;
     }
     if (mTFQueue.size()) {
+      static o2f::RateLimiter limiter;
+      limiter.check(ctx, mInput.tfRateLimit, mInput.minSHM);
+
       auto tfPtr = std::move(mTFQueue.front());
       mTFQueue.pop();
       if (!tfPtr) {
@@ -411,6 +418,9 @@ o2f::DataProcessorSpec o2::rawdd::getTFReaderSpec(o2::rawdd::TFReaderInp& rinp)
     if (!rinp.sup0xccdb) {
       spec.outputs.emplace_back(o2f::OutputSpec{{"stfDistCCDB"}, o2h::gDataOriginFLP, o2h::gDataDescriptionDISTSTF, 0xccdb});
     }
+    if (!rinp.metricChannel.empty()) {
+      spec.options.emplace_back(o2f::ConfigParamSpec{"channel-config", o2f::VariantType::String, rinp.metricChannel, {"Out-of-band channel config for TF throttling"}});
+    }
   } else {
     auto nameStart = rinp.rawChannelConfig.find("name=");
     if (nameStart == std::string::npos) {
@@ -423,6 +433,10 @@ o2f::DataProcessorSpec o2::rawdd::getTFReaderSpec(o2::rawdd::TFReaderInp& rinp)
     }
     spec.options = {o2f::ConfigParamSpec{"channel-config", o2f::VariantType::String, rinp.rawChannelConfig, {"Out-of-band channel config"}}};
     rinp.rawChannelConfig = rinp.rawChannelConfig.substr(nameStart, nameEnd - nameStart);
+    if (!rinp.metricChannel.empty()) {
+      LOGP(alarm, "Cannot apply TF rate limiting when publishing to raw channel, limiting must be applied on the level of the input raw proxy");
+      LOGP(alarm, R"(To avoid reader filling shm buffer use "--shm-throw-bad-alloc 0 --shm-segment-id 2")");
+    }
   }
 
   spec.algorithm = o2f::adaptFromTask<TFReaderSpec>(rinp);

--- a/Detectors/Raw/TFReaderDD/src/TFReaderSpec.h
+++ b/Detectors/Raw/TFReaderDD/src/TFReaderSpec.h
@@ -31,9 +31,12 @@ struct TFReaderInp {
   std::string copyCmd{};
   std::string tffileRegex{};
   std::string remoteRegex{};
+  std::string metricChannel{};
   o2::detectors::DetID::mask_t detMask{};
   o2::detectors::DetID::mask_t detMaskRawOnly{};
   o2::detectors::DetID::mask_t detMaskNonRawOnly{};
+  size_t minSHM = 0;
+  int tfRateLimit = 0;
   int maxTFCache = 1;
   int maxFileCache = 1;
   int verbosity = 0;

--- a/Detectors/Raw/include/DetectorsRaw/RawFileReader.h
+++ b/Detectors/Raw/include/DetectorsRaw/RawFileReader.h
@@ -39,8 +39,10 @@ struct ReaderInp {
   std::string inifile{};
   std::string rawChannelConfig{};
   std::string dropTF{};
+  std::string metricChannel{};
   size_t spSize = 1024L * 1024L;
   size_t bufferSize = 1024L * 1024L;
+  size_t minSHM = 0;
   int loop = 1;
   int runNumber = 0;
   uint32_t delay_us = 0;

--- a/Detectors/Raw/src/RawFileReaderWorkflow.cxx
+++ b/Detectors/Raw/src/RawFileReaderWorkflow.cxx
@@ -22,6 +22,7 @@
 #include "Framework/Task.h"
 #include "Framework/Logger.h"
 #include "Framework/DomainInfoHeader.h"
+#include "Framework/RateLimiter.h"
 
 #include "DetectorsRaw/RawFileReader.h"
 #include "DetectorsRaw/RDHUtils.h"
@@ -76,7 +77,9 @@ class RawReaderSpecs : public o2f::Task
   uint32_t mMaxTFID = 0xffffffff; // last TF to extrct
   int mRunNumber = 0;             // run number to pass
   int mVerbosity = 0;
+  int mTFRateLimit = 0;
   bool mPreferCalcTF = false;
+  size_t mMinSHM = 0;
   size_t mLoopsDone = 0;
   size_t mSentSize = 0;
   size_t mSentMessages = 0;
@@ -90,7 +93,7 @@ class RawReaderSpecs : public o2f::Task
 
 //___________________________________________________________
 RawReaderSpecs::RawReaderSpecs(const ReaderInp& rinp)
-  : mLoop(rinp.loop < 0 ? INT_MAX : (rinp.loop < 1 ? 1 : rinp.loop)), mDelayUSec(rinp.delay_us), mMinTFID(rinp.minTF), mMaxTFID(rinp.maxTF), mRunNumber(rinp.runNumber), mPartPerSP(rinp.partPerSP), mSup0xccdb(rinp.sup0xccdb), mReader(std::make_unique<o2::raw::RawFileReader>(rinp.inifile, rinp.verbosity, rinp.bufferSize)), mRawChannelName(rinp.rawChannelConfig), mVerbosity(rinp.verbosity), mPreferCalcTF(rinp.preferCalcTF)
+  : mLoop(rinp.loop < 0 ? INT_MAX : (rinp.loop < 1 ? 1 : rinp.loop)), mDelayUSec(rinp.delay_us), mMinTFID(rinp.minTF), mMaxTFID(rinp.maxTF), mRunNumber(rinp.runNumber), mPartPerSP(rinp.partPerSP), mSup0xccdb(rinp.sup0xccdb), mReader(std::make_unique<o2::raw::RawFileReader>(rinp.inifile, rinp.verbosity, rinp.bufferSize)), mRawChannelName(rinp.rawChannelConfig), mVerbosity(rinp.verbosity), mPreferCalcTF(rinp.preferCalcTF), mMinSHM(rinp.minSHM)
 {
   mReader->setCheckErrors(rinp.errMap);
   mReader->setMaxTFToRead(rinp.maxTF);
@@ -164,7 +167,10 @@ void RawReaderSpecs::run(o2f::ProcessingContext& ctx)
   mTimer.Start(false);
   auto device = ctx.services().get<o2f::RawDeviceService>().device();
   assert(device);
-
+  static bool initOnceDone = false;
+  if (!initOnceDone) {
+    mTFRateLimit = std::stoi(device->fConfig->GetValue<std::string>("timeframes-rate-limit"));
+  }
   auto findOutputChannel = [&ctx, this](o2h::DataHeader& h) {
     if (!this->mRawChannelName.empty()) {
       return std::string{this->mRawChannelName};
@@ -214,7 +220,7 @@ void RawReaderSpecs::run(o2f::ProcessingContext& ctx)
     } else {
       if (!mRawChannelName.empty()) { // send endOfStream message to raw channel
         o2f::SourceInfoHeader exitHdr;
-        exitHdr.state = o2::framework::InputChannelState::Completed;
+        exitHdr.state = o2f::InputChannelState::Completed;
         const auto exitStack = o2::header::Stack(o2h::DataHeader(o2h::gDataDescriptionInfo, o2h::gDataOriginAny, 0, 0), o2f::DataProcessingHeader(), exitHdr);
         auto fmqFactory = device->GetChannel(mRawChannelName, 0).Transport();
         auto hdEOSMessage = fmqFactory->CreateMessage(exitStack.size(), fair::mq::Alignment{64});
@@ -241,9 +247,12 @@ void RawReaderSpecs::run(o2f::ProcessingContext& ctx)
   mReader->setNextTFToRead(tfID);
   std::vector<RawFileReader::PartStat> partsSP;
 
+  static o2f::RateLimiter limiter;
+  limiter.check(ctx, mTFRateLimit, mMinSHM);
+
   // read next time frame
   LOG(info) << "Reading TF#" << mTFCounter << " (" << tfID << " at iteration " << mLoopsDone << ')';
-  o2::header::Stack dummyStack{o2h::DataHeader{}, o2::framework::DataProcessingHeader{0}}; // dummy stack to just to get stack size
+  o2::header::Stack dummyStack{o2h::DataHeader{}, o2f::DataProcessingHeader{0}}; // dummy stack to just to get stack size
   auto hstackSize = dummyStack.size();
 
   uint32_t firstOrbit = 0;
@@ -295,7 +304,7 @@ void RawReaderSpecs::run(o2f::ProcessingContext& ctx)
         firstOrbit = hdrTmpl.firstTForbit = (mPreferCalcTF || !link.cruDetector) ? hbfU.getIRTF(tfid).orbit : ir.orbit; // will be picked for the following parts
         creationTime = hbfU.getTFTimeStamp({0, firstOrbit});
       }
-      o2::header::Stack headerStack{hdrTmpl, o2::framework::DataProcessingHeader{mTFCounter, 1, creationTime}};
+      o2::header::Stack headerStack{hdrTmpl, o2f::DataProcessingHeader{mTFCounter, 1, creationTime}};
       memcpy(hdMessage->GetData(), headerStack.data(), headerStack.size());
       hdrTmpl.splitPayloadIndex++; // prepare for next
 
@@ -305,7 +314,7 @@ void RawReaderSpecs::run(o2f::ProcessingContext& ctx)
          mLoopsDone, link.origin.as<std::string>(), link.description.as<std::string>(), link.subspec);
   }
 
-  auto& timingInfo = ctx.services().get<o2::framework::TimingInfo>();
+  auto& timingInfo = ctx.services().get<o2f::TimingInfo>();
   timingInfo.firstTFOrbit = firstOrbit;
   timingInfo.creation = creationTime;
   timingInfo.tfCounter = mTFCounter;
@@ -323,7 +332,7 @@ void RawReaderSpecs::run(o2f::ProcessingContext& ctx)
     const auto fmqChannel = findOutputChannel(stfDistDataHeader);
     if (!fmqChannel.empty()) { // no output channel
       auto fmqFactory = device->GetChannel(fmqChannel, 0).Transport();
-      o2::header::Stack headerStackSTF{stfDistDataHeader, o2::framework::DataProcessingHeader{mTFCounter, 1, creationTime}};
+      o2::header::Stack headerStackSTF{stfDistDataHeader, o2f::DataProcessingHeader{mTFCounter, 1, creationTime}};
       auto hdMessageSTF = fmqFactory->CreateMessage(hstackSize, fair::mq::Alignment{64});
       auto plMessageSTF = fmqFactory->CreateMessage(stfDistDataHeader.payloadSize, fair::mq::Alignment{64});
       memcpy(hdMessageSTF->GetData(), headerStackSTF.data(), headerStackSTF.size());
@@ -372,6 +381,9 @@ o2f::DataProcessorSpec getReaderSpec(ReaderInp rinp)
     if (!rinp.sup0xccdb) {
       spec.outputs.emplace_back(o2f::OutputSpec{{"stfDistCCDB"}, o2::header::gDataOriginFLP, o2::header::gDataDescriptionDISTSTF, 0xccdb}); // will be added automatically
     }
+    if (!rinp.metricChannel.empty()) {
+      spec.options.emplace_back(o2f::ConfigParamSpec{"channel-config", o2f::VariantType::String, rinp.metricChannel, {"Out-of-band channel config for TF throttling"}});
+    }
   } else {
     auto nameStart = rinp.rawChannelConfig.find("name=");
     if (nameStart == std::string::npos) {
@@ -382,8 +394,12 @@ o2f::DataProcessorSpec getReaderSpec(ReaderInp rinp)
     if (nameEnd == std::string::npos) {
       nameEnd = rinp.rawChannelConfig.size();
     }
-    spec.options = {o2f::ConfigParamSpec{"channel-config", o2f::VariantType::String, rinp.rawChannelConfig, {"Out-of-band channel config"}}};
+    spec.options.emplace_back(o2f::ConfigParamSpec{"channel-config", o2f::VariantType::String, rinp.rawChannelConfig, {"Out-of-band channel config"}});
     rinp.rawChannelConfig = rinp.rawChannelConfig.substr(nameStart, nameEnd - nameStart);
+    if (!rinp.metricChannel.empty()) {
+      LOGP(alarm, "Cannot apply TF rate limiting when publishing to raw channel, limiting must be applied on the level of the input raw proxy");
+      LOGP(alarm, R"(To avoid reader filling shm buffer use "--shm-throw-bad-alloc 0 --shm-segment-id 2")");
+    }
     LOG(info) << "Will send output to non-DPL channel " << rinp.rawChannelConfig;
   }
 

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -44,7 +44,7 @@ source $MYDIR/workflow-setup.sh
 if [[ $EPNSYNCMODE == 1 ]] || type numactl >/dev/null 2>&1 && [[ `numactl -H | grep "node . size" | wc -l` -ge 2 ]]; then
   [[ $NUMAGPUIDS != 0 ]] && ARGS_ALL+=" --child-driver 'numactl --membind $NUMAID --cpunodebind $NUMAID'"
 fi
-if [[ -z $TIMEFRAME_RATE_LIMIT ]] && [[ $EXTINPUT == 1 ]]; then
+if [[ -z $TIMEFRAME_RATE_LIMIT ]] && [[ $DIGITINPUT != 1 ]]; then
   TIMEFRAME_RATE_LIMIT=$((12 * 230 / $RECO_NUM_NODES_WORKFLOW * ($NUMAGPUIDS != 0 ? 1 : 2)))
   [[ $BEAMTYPE != "PbPb" ]] && TIMEFRAME_RATE_LIMIT=$(($TIMEFRAME_RATE_LIMIT * 3))
   ! has_detector TPC && TIMEFRAME_RATE_LIMIT=$(($TIMEFRAME_RATE_LIMIT * 4))


### PR DESCRIPTION
The reader will throttle injection of the TF to not more than N TFs in processing if
--timeframes-rate-limit <N> --timeframes-rate-limit-ipcid <IPCID>
options are provided too all workflows (e.g. via ARGS_ALL)
The IPCID is the NUMA domain ID (usually 0 on non-EPN workflow).

Additionally, one may throttle on the free SHM by providing an option to the reader
--timeframes-shm-limit <shm-size>