### PR TITLE
Add TPC residual aggregator CALIB workflow

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/tpc-residual-aggregator.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/tpc-residual-aggregator.cxx
@@ -18,6 +18,8 @@ using namespace o2::framework;
 // we need to add workflow options before including Framework/runDataProcessing
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
+  std::vector<o2::framework::ConfigParamSpec> options{{"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
+  std::swap(workflowOptions, options);
 }
 
 // ------------------------------------------------------------------
@@ -26,6 +28,8 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 
 WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 {
+  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
+
   WorkflowSpec specs;
   specs.emplace_back(getTPCResidualAggregatorSpec());
   return specs;

--- a/prodtests/full-system-test/aggregator-workflow.sh
+++ b/prodtests/full-system-test/aggregator-workflow.sh
@@ -34,6 +34,7 @@ if [[ "0$GEN_TOPO_VERBOSE" == "01" ]]; then
   echo "CALIB_TRD_VDRIFTEXB = $CALIB_TRD_VDRIFTEXB" 1>&2
   echo "CALIB_TPC_TIMEGAIN = $CALIB_TPC_TIMEGAIN" 1>&2
   echo "CALIB_TPC_RESPADGAIN = $CALIB_TPC_RESPADGAIN" 1>&2
+  echo "CALIB_TPC_SCDCALIB = $CALIB_TPC_SCDCALIB" 1>&2
 fi
 
 # beamtype dependent settings
@@ -117,6 +118,11 @@ if [[ $AGGREGATOR_TASKS == BARREL_TF ]] || [[ $AGGREGATOR_TASKS == ALL ]]; then
   # TPC
   if [[ $CALIB_TPC_TIMEGAIN == 1 ]]; then
     add_W o2-tpc-calibrator-dedx "--min-entries-sector 3000 --min-entries-1d 200 --min-entries-2d 10000"
+  fi
+  if [[ $CALIB_TPC_SCDCALIB == 1 ]]; then
+    # TODO: the residual aggregator should have --output-dir and --meta-output-dir defined
+    # without that the residuals will be stored in the local working directory (and deleted after a week)
+    add_W o2-calibration-residual-aggregator ""
   fi
   # TRD
   if [[ $CALIB_TRD_VDRIFTEXB == 1 ]]; then


### PR DESCRIPTION
Add aggregator workflow for TPC residuals. Currently without defining `--meta-output-dir` which means that the output is not shipped to alien. But one could nevertheless check with the created local files if they are reasonable.
Goes together with https://github.com/AliceO2Group/O2DPG/pull/496