### PR TITLE
TRD small reco update

### DIFF
--- a/DataFormats/Detectors/TRD/src/Digit.cxx
+++ b/DataFormats/Detectors/TRD/src/Digit.cxx
@@ -70,7 +70,7 @@ ADC_t Digit::getADCmax(int& idx) const
 
 std::ostream& operator<<(std::ostream& stream, const Digit& d)
 {
-  stream << "Digit Det: " << d.getDetector() << " ROB: " << d.getROB() << " MCM: " << d.getMCM() << " Channel: " << d.getChannel() << " ADCs:";
+  stream << "Digit Det: " << HelperMethods::getSector(d.getDetector()) << "_" << HelperMethods::getStack(d.getDetector()) << "_" << HelperMethods::getLayer(d.getDetector()) << " pad row: " << d.getPadRow() << " pad column: " << d.getPadCol() << " Channel: " << d.getChannel() << " ADCs:";
   for (int i = 0; i < constants::TIMEBINS; i++) {
     stream << "[" << d.getADC()[i] << "]";
   }

--- a/DataFormats/Detectors/TRD/src/Tracklet64.cxx
+++ b/DataFormats/Detectors/TRD/src/Tracklet64.cxx
@@ -11,6 +11,7 @@
 
 #include "DataFormatsTRD/Tracklet64.h"
 #include "DataFormatsTRD/Constants.h"
+#include "DataFormatsTRD/HelperMethods.h"
 
 #include "fairlogger/Logger.h"
 #include <iostream>
@@ -25,8 +26,8 @@ using namespace constants;
 
 void Tracklet64::print() const
 {
-  LOGF(info, "trackletWord(0x%x), hcid(%i), row(%i), col(%i), position(%i), slope(%i), pid(%i), q0(%i), q1(%i), q2(%i)",
-       getTrackletWord(), getHCID(), getPadRow(), getColumn(), getPosition(), getSlope(), getPID(), getQ0(), getQ1(), getQ2());
+  LOGF(info, "%02i_%i_%i, row(%i), col(%i), position(%i), slope(%i), pid(%i), q0(%i), q1(%i), q2(%i)",
+       HelperMethods::getSector(getDetector()), HelperMethods::getStack(getDetector()), HelperMethods::getLayer(getDetector()), getPadRow(), getColumn(), getPosition(), getSlope(), getPID(), getQ0(), getQ1(), getQ2());
 }
 
 #ifndef GPUCA_GPUCODE_DEVICE

--- a/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
@@ -116,6 +116,8 @@ void TRDGlobalTracking::init(InitContext& ic)
 
   mTracker->PrintSettings();
   LOG(info) << "Strict matching mode is " << ((mStrict) ? "ON" : "OFF");
+  LOGF(info, "The search road in time for ITS-TPC tracks is set to %.1f sigma and %.2f us are added to it on top",
+       mRec->GetParam().rec.trd.nSigmaTerrITSTPC, mRec->GetParam().rec.trd.addTimeRoadITSTPC);
 
   mTimer.Stop();
   mTimer.Reset();
@@ -284,8 +286,8 @@ void TRDGlobalTracking::run(ProcessingContext& pc)
     const auto& trkITSTPC = mChainTracking->mIOPtrs.tracksTPCITSO2[iTrk];
     GPUTRDTracker::HelperTrackAttributes trkAttribs;
     trkAttribs.mTime = trkITSTPC.getTimeMUS().getTimeStamp();
-    trkAttribs.mTimeAddMax = trkITSTPC.getTimeMUS().getTimeStampError() * mRec->GetParam().rec.trd.nSigmaTerrITSTPC;
-    trkAttribs.mTimeSubMax = trkITSTPC.getTimeMUS().getTimeStampError() * mRec->GetParam().rec.trd.nSigmaTerrITSTPC;
+    trkAttribs.mTimeAddMax = trkITSTPC.getTimeMUS().getTimeStampError() * mRec->GetParam().rec.trd.nSigmaTerrITSTPC + mRec->GetParam().rec.trd.addTimeRoadITSTPC;
+    trkAttribs.mTimeSubMax = trkITSTPC.getTimeMUS().getTimeStampError() * mRec->GetParam().rec.trd.nSigmaTerrITSTPC + mRec->GetParam().rec.trd.addTimeRoadITSTPC;
     GPUTRDTrack trkLoad(trkITSTPC);
     auto trackGID = GTrackID(iTrk, GTrackID::ITSTPC);
     if (mTracker->LoadTrack(trkLoad, trackGID.getRaw(), true, &trkAttribs)) {

--- a/GPU/GPUTracking/Definitions/GPUSettingsList.h
+++ b/GPU/GPUTracking/Definitions/GPUSettingsList.h
@@ -87,6 +87,7 @@ AddOptionRTC(penaltyChi2, float, 13.f, "", 0, "Chi2 penalty for no available TRD
 AddOptionRTC(chi2StrictCut, float, 10.f, "", 0, "Chi2 cut for strict matching mode")
 AddOptionRTC(chi2SeparationCut, float, 2.5f, "", 0, "Minimum difference between chi2 of winner match and chi2 of second best match")
 AddOptionRTC(nSigmaTerrITSTPC, float, 4.f, "", 0, "Number of sigmas for ITS-TPC track time error estimate")
+AddOptionRTC(addTimeRoadITSTPC, float, 0.f, "", 0, "Increase time search road by X us for ITS-TPC tracks")
 AddOptionRTC(extraRoadY, float, 2.f, "", 0, "Addition to search road around track prolongation along Y in cm")
 AddOptionRTC(extraRoadZ, float, 0.f, "", 0, "Addition to search road around track prolongation along Z in cm")
 AddOptionRTC(trkltResRPhiIdeal, float, 0.04f, "", 0, "Optimal tracklet rphi resolution in cm (in case phi of track = lorentz angle)")


### PR DESCRIPTION
- digits and tracklets print methods updated to include sector_stack_layer
- allow to set externally additional search road in time for ITS-TPC tracks (to account for possible offset between TRD trigger time and ITS-TPC track times observed in recent pilot beam runs)