### PR TITLE
TRD fix bad rdh headers, add numerous data integrity checks

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
@@ -142,7 +142,7 @@ struct TrackletHCHeader {
       uint32_t layer : 3;
       uint32_t stack : 3;
       uint32_t supermodule : 5;
-      uint32_t one : 1;   //always 0
+      uint32_t one : 1;   //always 1
       uint32_t MCLK : 15; // MCM clock counter 120MHz ... for simulation -- incrementing, and uniform across an event
       uint32_t format : 4;
       //  0 baseline PID 3 time slices, 7 bit each
@@ -492,7 +492,7 @@ void printHalfCRUHeader(o2::trd::HalfCRUHeader& halfcru);
 void dumpHalfCRUHeader(o2::trd::HalfCRUHeader& halfcru);
 void clearHalfCRUHeader(o2::trd::HalfCRUHeader& halfcru);
 bool sanityCheckTrackletMCMHeader(o2::trd::TrackletMCMHeader* header);
-bool sanityCheckTrackletHCHeader(o2::trd::TrackletHCHeader& header);
+bool sanityCheckTrackletHCHeader(o2::trd::TrackletHCHeader& header, bool verbose = false);
 bool sanityCheckDigitMCMHeader(o2::trd::DigitMCMHeader* header);
 bool sanityCheckDigitMCMADCMask(o2::trd::DigitMCMADCMask& mask, int numberofbitsset);
 bool sanityCheckDigitMCMWord(o2::trd::DigitMCMData* word, int adcchannel);

--- a/DataFormats/Detectors/TRD/src/RawData.cxx
+++ b/DataFormats/Detectors/TRD/src/RawData.cxx
@@ -422,22 +422,31 @@ bool sanityCheckTrackletMCMHeader(o2::trd::TrackletMCMHeader* header)
   return goodheader;
 }
 
-bool sanityCheckTrackletHCHeader(o2::trd::TrackletHCHeader& header)
+bool sanityCheckTrackletHCHeader(o2::trd::TrackletHCHeader& header, bool verbose)
 {
   bool goodheader = true;
-  if (header.one != -1) {
-    goodheader = false;
-  }
   if ((~header.supermodule) > 17) {
+    if (verbose) {
+      LOG(info) << " TrackletHCHeader : 0x" << std::hex << header.word << " failure header.supermodule=" << ~header.supermodule;
+    }
     goodheader = false;
   }
   if ((~header.layer) > 6) {
+    if (verbose) {
+      LOG(info) << " TrackletHCHeader : 0x" << std::hex << header.word << " failure header.layer=" << ~header.layer;
+    }
     goodheader = false;
   }
   if ((~header.stack) > 5) {
+    if (verbose) {
+      LOG(info) << " TrackletHCHeader : 0x" << std::hex << header.word << " failure header.stack=" << ~header.stack;
+    }
     goodheader = false;
   }
-  if (header.one != 0) {
+  if (header.one != 1) {
+    if (verbose) {
+      LOG(info) << " TrackletHCHeader : 0x" << std::hex << header.word << " failure header.one=" << header.one;
+    }
     goodheader = false;
   }
   int trackletmode = (header.format >> 2) & 0x3;
@@ -453,7 +462,6 @@ bool sanityCheckTrackletHCHeader(o2::trd::TrackletHCHeader& header)
       if ((header.format & 0x1) == 0x1) {
         dynamicqrange = true;
       }
-      //LOG(info) << "Tracklet sector:layer:stack " << ((~header.supermodule)&0x1f) <<":" << ((~header.layer)&0x7) << ":" << ((~header.stack)&0x7) << " Tracklet format is : " << std::hex << header.format << " last bit : " << (header.format&0x1) << " trackletmode : " << trackletmode;
       break;
   }
   return goodheader;
@@ -535,13 +543,17 @@ void printDigitMCMData(o2::trd::DigitMCMData& digitmcmdata)
 
 int getDigitHCHeaderWordType(uint32_t word)
 {
+  //  LOG(info) << "getDigitHCHeaderwordtype : " << std::hex << word;
   if ((word & 0x3f) == 0b110001) {
+    //  LOG(info) << "getDigitHCHeaderwordtype  2 : " << std::hex << word << " returning 2 for :" << std::hex << (word&0x3f);
     return 2;
   }
   if ((word & 0x3f) == 0b110101) {
+    //  LOG(info) << "getDigitHCHeaderwordtype 3 : " << std::hex << word << " returning 3 for :" << std::hex << (word&0x3f);
     return 3;
   }
   if ((word & 0x3) == 0b01) {
+    //  LOG(info) << "getDigitHCHeaderwordtype 1 : " << std::hex << word << " returning 1 for :" << std::hex << (word&0x3f);
     return 1;
   }
   return -1;
@@ -584,6 +596,7 @@ void printDigitHCHeader(o2::trd::DigitHCHeader& header, uint32_t headers[3])
       case 1:
         DigitHCHeader1 header1;
         header1.word = headers[countheaderwords];
+        index = 0;
         if (header1.res != 0x1) {
           printDigitHCHeaders(header, headers, index, countheaderwords, false);
         } else {
@@ -593,6 +606,7 @@ void printDigitHCHeader(o2::trd::DigitHCHeader& header, uint32_t headers[3])
       case 2:
         DigitHCHeader2 header2;
         header2.word = headers[countheaderwords];
+        index = 1;
         if (header2.res != 0b110001) {
           printDigitHCHeaders(header, headers, index, countheaderwords, false);
         } else {
@@ -602,6 +616,7 @@ void printDigitHCHeader(o2::trd::DigitHCHeader& header, uint32_t headers[3])
       case 3:
         DigitHCHeader3 header3;
         header3.word = headers[countheaderwords];
+        index = 2;
         if (header3.res != 0b110101) {
           printDigitHCHeaders(header, headers, index, countheaderwords, false);
         } else {

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/DataReaderTask.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/DataReaderTask.h
@@ -46,9 +46,6 @@ class DataReaderTask : public Task
   bool isTimeFrameEmpty(ProcessingContext& pc);
   void endOfStream(o2::framework::EndOfStreamContext& ec) override;
 
-  void setParsingErrorLabels();
-  void buildHistograms();
-
  private:
   CruRawReader mReader;                  // this will do the parsing, of raw data passed directly through the flp(no compression)
   CompressedRawReader mCompressedReader; //this will handle the incoming compressed data from the flp
@@ -80,27 +77,6 @@ class DataReaderTask : public Task
   o2::trd::TRDDataCountersPerTimeFrame mTimeFrameStats;                                   // TODO for compressed data this is going to come in for each subtimeframe
                                                                                           // and we need to collate them.
 
-  TH2F* LinkError;
-  TH2F* LinkError1;
-  TH2F* LinkError2;
-  TH2F* LinkError3;
-  TH2F* LinkError4;
-  TH2F* LinkError5;
-  TH2F* LinkError6;
-  TH2F* LinkError7;
-  //std::array<TH2F*, constants::MAXLINKERRORHISTOGRAMS> mLinkErrors;
-  //std::array<TH2F*, constants::MAXPARSEERRORHISTOGRAMS> mParseErrors;
-  TList* mLinkErrors;
-  TList* mParseErrors;
-  TH1F* mTimeFrameTime;
-  TH1F* mTrackletParsingTime;
-  TH1F* mDigitParsingTime;
-  TH1F* mCruTime;
-  TH1F* mPackagingTime;
-  TH1F* mDataVersions;
-  TH1F* mDataVersionsMajor;
-  TH1F* mParsingErrors;
-  TFile* mRootFile;
 };
 
 } // namespace o2::trd

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/DigitsParser.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/DigitsParser.h
@@ -25,9 +25,6 @@
 #include "TRDReconstruction/EventRecord.h"
 #include <fstream>
 #include <bitset>
-#include "TH1F.h"
-#include "TH2F.h"
-#include "TList.h"
 
 //using namespace o2::framework;
 
@@ -72,21 +69,11 @@ class DigitsParser
   uint64_t getDumpedDataCount() { return mWordsDumped; }
   uint64_t getDataWordsParsed() { return mDataWordsParsed; }
   void OutputIncomingData();
-  void setParsingHisto(TH1F* parsingerrors, TList* parsingerrors2d)
-  {
-    mParsingErrors = parsingerrors;
-    mParsingErrors2d = parsingerrors2d;
-  }
 
   void incParsingError(int error)
   {
-
     if (mOptions[TRDGenerateStats]) {
       mEventRecords->incParsingError(error, mFEEID.supermodule, mHalfChamberSide, mStackLayer);
-    }
-    if (mOptions[TRDEnableRootOutputBit]) {
-      mParsingErrors->Fill(error);
-      ((TH2F*)mParsingErrors2d->At(error))->Fill(mFEEID.supermodule * 2 + mHalfChamberSide, mStack * constants::NLAYER + mLayer);
     }
   }
   void checkNoErr();
@@ -142,8 +129,6 @@ class DigitsParser
   std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator mStartParse, mEndParse; // limits of parsing, effectively the link limits to parse on.
   std::array<uint16_t, constants::TIMEBINS> mADCValues{};
   int mMaxErrsPrinted;
-  TH1F* mParsingErrors;
-  TList* mParsingErrors2d;
 };
 
 } // namespace o2::trd

--- a/Detectors/TRD/reconstruction/src/EventRecord.cxx
+++ b/Detectors/TRD/reconstruction/src/EventRecord.cxx
@@ -211,9 +211,6 @@ void EventStorage::sendData(o2::framework::ProcessingContext& pc, bool generates
   mEventRecords.clear();
   std::chrono::duration<double, std::micro> dataReadTime = std::chrono::high_resolution_clock::now() - dataReadStart;
   LOG(debug) << "Preparing for sending and sending data took  " << std::chrono::duration_cast<std::chrono::milliseconds>(dataReadTime).count() << "ms";
-  if (mPackagingTime != nullptr) {
-    mPackagingTime->Fill((int)std::chrono::duration_cast<std::chrono::microseconds>(dataReadTime).count());
-  }
 }
 
 void EventStorage::accumulateStats()


### PR DESCRIPTION
- fix rdh bad headers, in particular 0xfff? for the FEEID, data gets dumped.
- caused a sector of 255 instead of [0,17] and was used as an index into an array.
- ensure sequential rdh have identical relevant information
- ensure halfcru headers on a link all have same informaiton.
- add checks for various other parameters to make sure they are inrange.
- change stats to not have 2d plots associated with the 1d plot in those cases where you cant know the sector,side,stack,layer.
- add sanity checks to volume of data to attempt to parse.
- remove all the pre qc, qc where various plots were produced by the decoder. All that info is now passed to qc via a rawstats message.