### PR TITLE
GRP tool for simulation

### DIFF
--- a/Common/SimConfig/include/SimConfig/SimConfig.h
+++ b/Common/SimConfig/include/SimConfig/SimConfig.h
@@ -117,6 +117,9 @@ class SimConfig
   static void determineActiveModules(std::vector<std::string> const& input, std::vector<std::string> const& skipped, std::vector<std::string>& active);
   static void determineReadoutDetectors(std::vector<std::string> const& active, std::vector<std::string> const& enabledRO, std::vector<std::string> const& skippedRO, std::vector<std::string>& finalRO);
 
+  // helper to parse field option
+  static bool parseFieldString(std::string const& fieldstring, int& fieldvalue, o2::conf::SimFieldMode& mode);
+
   // get selected generator (to be used to select a genconfig)
   std::string getGenerator() const { return mConfigData.mGenerator; }
   std::string getTrigger() const { return mConfigData.mTrigger; }

--- a/Common/SimConfig/include/SimConfig/SimConfig.h
+++ b/Common/SimConfig/include/SimConfig/SimConfig.h
@@ -111,6 +111,12 @@ class SimConfig
   // get selected active detectors
   std::vector<std::string> const& getActiveModules() const { return mConfigData.mActiveModules; }
   std::vector<std::string> const& getReadoutDetectors() const { return mConfigData.mReadoutDetectors; }
+
+  // static helper functions to determine list of active / readout modules
+  // can also be used from outside
+  static void determineActiveModules(std::vector<std::string> const& input, std::vector<std::string> const& skipped, std::vector<std::string>& active);
+  static void determineReadoutDetectors(std::vector<std::string> const& active, std::vector<std::string> const& enabledRO, std::vector<std::string> const& skippedRO, std::vector<std::string>& finalRO);
+
   // get selected generator (to be used to select a genconfig)
   std::string getGenerator() const { return mConfigData.mGenerator; }
   std::string getTrigger() const { return mConfigData.mTrigger; }

--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -204,6 +204,30 @@ bool SimConfig::resetFromParsedMap(boost::program_options::variables_map const& 
   if (fieldstring != "ccdb") {
     mConfigData.mField = std::stoi((vm["field"].as<std::string>()).substr(0, (vm["field"].as<std::string>()).rfind("U")));
   }
+  if (!parseFieldString(fieldstring, mConfigData.mField, mConfigData.mFieldMode)) {
+    return false;
+  }
+
+  return true;
+}
+
+bool SimConfig::parseFieldString(std::string const& fieldstring, int& fieldvalue, SimFieldMode& mode)
+{
+  // analyse field options
+  // either: "ccdb" or +-2[U],+-5[U] and 0[U]; +-<intKGaus>U
+  std::regex re("(ccdb)|([+-]?[250]U?)");
+  if (!std::regex_match(fieldstring, re)) {
+    LOG(error) << "Invalid field option";
+    return false;
+  }
+  if (fieldstring == "ccdb") {
+    mode = SimFieldMode::kCCDB;
+  } else if (fieldstring.find("U") != std::string::npos) {
+    mode = SimFieldMode::kUniform;
+  }
+  if (fieldstring != "ccdb") {
+    fieldvalue = std::stoi(fieldstring.substr(0, fieldstring.rfind("U")));
+  }
   return true;
 }
 

--- a/DataFormats/Parameters/CMakeLists.txt
+++ b/DataFormats/Parameters/CMakeLists.txt
@@ -16,7 +16,7 @@ o2_add_library(DataFormatsParameters
                        src/GRPMagField.cxx
                PUBLIC_LINK_LIBRARIES FairRoot::Base O2::CommonConstants
                                      O2::CommonTypes
-                                     O2::DetectorsCommonDataFormats)
+                                     O2::DetectorsCommonDataFormats O2::SimConfig)
 
 o2_target_root_dictionary(DataFormatsParameters
                           HEADERS include/DataFormatsParameters/GRPObject.h
@@ -25,6 +25,10 @@ o2_target_root_dictionary(DataFormatsParameters
                                   include/DataFormatsParameters/GRPMagField.h
                           LINKDEF src/ParametersDataLinkDef.h)
 
+o2_add_executable(simGRP-tool
+                  COMPONENT_NAME grp
+                  SOURCES src/GRPTool.cxx
+                  PUBLIC_LINK_LIBRARIES Boost::program_options O2::DataFormatsParameters)
 
 # note we are explicitely giving the LINKDEF parameter as the LinkDef does not
 # follow the usual naming scheme [module]LinkDef.h

--- a/DataFormats/Parameters/CMakeLists.txt
+++ b/DataFormats/Parameters/CMakeLists.txt
@@ -25,7 +25,7 @@ o2_target_root_dictionary(DataFormatsParameters
                                   include/DataFormatsParameters/GRPMagField.h
                           LINKDEF src/ParametersDataLinkDef.h)
 
-o2_add_executable(simGRP-tool
+o2_add_executable(simgrp-tool
                   COMPONENT_NAME grp
                   SOURCES src/GRPTool.cxx
                   PUBLIC_LINK_LIBRARIES Boost::program_options O2::DataFormatsParameters)

--- a/DataFormats/Parameters/src/GRPTool.cxx
+++ b/DataFormats/Parameters/src/GRPTool.cxx
@@ -1,0 +1,517 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <boost/program_options.hpp>
+#include <string>
+#include "DataFormatsParameters/GRPECSObject.h"
+#include "DataFormatsParameters/GRPMagField.h"
+#include "DataFormatsParameters/GRPLHCIFData.h"
+#include "CommonUtils/FileSystemUtils.h"
+#include <FairLogger.h>
+#include <TFile.h>
+#include <CommonUtils/NameConf.h>
+#include <DetectorsCommonDataFormats/DetID.h>
+#include <CCDB/BasicCCDBManager.h>
+#include <SimConfig/SimConfig.h>
+#include <unordered_map>
+#include <filesystem>
+
+//
+// Created by Sandro Wenzel on 20.06.22.
+//
+
+// A utility to create/edit GRP objects for MC
+
+enum class GRPCommand {
+  kNONE,
+  kCREATE,
+  kANCHOR,
+  kSETROMODE,
+  kPRINTECS,
+  kPRINTLHC,
+  kPRINTMAG
+};
+
+// options struct filled from command line
+struct Options {
+  std::vector<std::string> readout;
+  std::vector<std::string> skipreadout;
+  int run;               // run number
+  int orbitsPerTF = 128; // number of orbits per timeframe --> used to calculate start orbit for collisions
+  GRPCommand command = GRPCommand::kNONE;
+  std::string grpfilename = ""; // generic filename placeholder used by various commands
+  std::vector<std::string> continuous = {};
+  std::vector<std::string> triggered = {};
+  bool clearRO = false;
+  std::string outprefix = "";
+  std::string fieldstring = "";
+  std::string bcPatternFile = "";
+  bool print = false; // whether to print outcome of GRP operation
+  std::string publishto = "";
+  std::string ccdbhost = "http://alice-ccdb.cern.ch";
+};
+
+void print_globalHelp(int argc, char* argv[])
+{
+  std::cout << "** A GRP utility **\n\n";
+  std::cout << "Usage: " << argv[0] << " subcommand [sub-command-options]\n";
+  std::cout << "\n";
+  std::cout << "The following subcommands are available:\n";
+  std::cout << "\t createGRPs : Create baseline GRP objects/file\n";
+  std::cout << "\t anchorGRPs : Fetch GRP objects from CCDB based on run number\n";
+  std::cout << "\t print_GRPECS : print a GRPECS object/file\n";
+  std::cout << "\t print_GRPMAG : print a GRPMagField object/file\n";
+  std::cout << "\t print_GRPLHC : print a GRPLHCIF object/file\n";
+  std::cout << "\t setROMode : modify/set readoutMode in a GRPECS file\n";
+  std::cout << "\n";
+  std::cout << "Sub-command options can be seen with subcommand --help\n";
+}
+
+namespace
+{
+template <typename T>
+void printGRP(std::string const& filename, std::string const& objtype)
+{
+  std::cout << "\nPrinting " << objtype << " from file " << filename << "\n\n";
+  auto grp = T::loadFrom(filename);
+  if (grp) {
+    grp->print();
+    delete grp;
+  } else {
+    std::cerr << "Error loading " << objtype << " objects from file " << filename << "\n";
+  }
+}
+} // namespace
+
+void printGRPECS(std::string const& filename)
+{
+  printGRP<o2::parameters::GRPECSObject>(filename, "GRPECS");
+}
+
+void printGRPMAG(std::string const& filename)
+{
+  printGRP<o2::parameters::GRPMagField>(filename, "GRPMAG");
+}
+
+void printGRPLHC(std::string const& filename)
+{
+  printGRP<o2::parameters::GRPLHCIFData>(filename, "GRPLHCIF");
+}
+
+void setROMode(std::string const& filename, std::vector<std::string> const& continuous,
+               std::vector<std::string> const& triggered, bool clear = false)
+{
+  using o2::detectors::DetID;
+
+  if (filename.size() == 0) {
+    std::cout << "no filename given\n";
+    return;
+  }
+  using GRPECSObject = o2::parameters::GRPECSObject;
+  const std::string grpName{o2::base::NameConf::CCDBOBJECT};
+  TFile flGRP(filename.c_str(), "update");
+  if (flGRP.IsZombie()) {
+    LOG(error) << "Failed to open GRPECS file " << filename << " in update mode ";
+    return;
+  }
+  std::unique_ptr<GRPECSObject> grp(static_cast<GRPECSObject*>(flGRP.GetObjectChecked(grpName.c_str(), GRPECSObject::Class())));
+  if (grp.get()) {
+    // clear complete state (continuous state) first of all when asked
+    if (clear) {
+      for (auto id = DetID::First; id <= DetID::Last; ++id) {
+        if (grp->isDetReadOut(id)) {
+          grp->remDetContinuousReadOut(id);
+        }
+      }
+    }
+
+    //
+    for (auto& detstr : continuous) {
+      // convert to detID
+      o2::detectors::DetID id(detstr.c_str());
+      if (grp->isDetReadOut(id)) {
+        grp->addDetContinuousReadOut(id);
+        LOG(info) << "Setting det " << detstr << " to continuous RO mode";
+      }
+    }
+    //
+    for (auto& detstr : triggered) {
+      // convert to detID
+      o2::detectors::DetID id(detstr.c_str());
+      if (grp->isDetReadOut(id)) {
+        grp->addDetTrigger(id);
+        LOG(info) << "Setting det " << detstr << " to trigger CTP";
+      }
+    }
+    grp->print();
+    flGRP.WriteObjectAny(grp.get(), grp->Class(), grpName.c_str());
+  }
+  flGRP.Close();
+}
+
+// copies a file idendified by filename to a CCDB snapshot starting under path
+// and with the CCDBpath hierarchy
+bool publish(std::string const& filename, std::string const& path, std::string CCDBpath)
+{
+  if (!std::filesystem::exists(filename)) {
+    LOG(error) << "Input file " << filename << "does not exist\n";
+    return false;
+  }
+
+  std::string targetdir = path + CCDBpath;
+  try {
+    o2::utils::createDirectoriesIfAbsent(targetdir);
+  } catch (std::exception e) {
+    LOGP(error, fmt::format("Could not create local snapshot cache directory {}, reason: {}", targetdir, e.what()));
+    return false;
+  }
+
+  auto targetfile = std::filesystem::path(targetdir + "/snapshot.root");
+  auto opts = std::filesystem::copy_options::overwrite_existing;
+  std::filesystem::copy_file(filename, targetfile, opts);
+  if (std::filesystem::exists(targetfile)) {
+    LOG(info) << "file " << filename << " copied/published to " << targetfile;
+  }
+  return true;
+}
+
+// download a set of basic GRP files based on run number/time
+bool anchor_GRPs(Options const& opts)
+{
+  std::cout << "Fetching GRP from CCDB\n";
+  auto& ccdbmgr = o2::ccdb::BasicCCDBManager::instance();
+  auto soreor = ccdbmgr.getRunDuration(opts.run);
+  // fix the timestamp early
+  uint64_t runStart = soreor.first;
+
+  o2::ccdb::CcdbApi api;
+  api.init(opts.ccdbhost);
+
+  const bool preserve_path = true;
+  const std::string filename("snapshot.root");
+  std::map<std::string, std::string> filter;
+  bool success = true;
+  for (auto& p : std::vector<std::string>{"GLO/Config/GRPECS", "GLO/Config/GRPMagField", "GLO/Config/GRPLHCIF"}) {
+    std::cout << "path " << p << "\n";
+    success &= api.retrieveBlob(p, opts.publishto, filter, runStart, preserve_path, filename);
+  }
+  return success;
+}
+
+// creates a set of basic GRP files (for simulation)
+bool create_GRPs(Options const& opts)
+{
+  // some code duplication from o2-sim --> remove it
+
+  uint64_t runStart = -1; // used in multiple GRPs
+
+  // GRPECS
+  {
+    LOG(info) << " --- creating GRP ECS -----";
+    o2::parameters::GRPECSObject grp;
+    grp.setRun(opts.run);
+    // if
+    auto& ccdbmgr = o2::ccdb::BasicCCDBManager::instance();
+    auto soreor = ccdbmgr.getRunDuration(opts.run);
+    runStart = soreor.first;
+    grp.setTimeStart(runStart);
+    grp.setTimeEnd(runStart + 3600000);
+    grp.setNHBFPerTF(opts.orbitsPerTF);
+    std::vector<std::string> modules{};
+    o2::conf::SimConfig::determineActiveModules(opts.readout, std::vector<std::string>(), modules);
+    std::vector<std::string> readout{};
+    o2::conf::SimConfig::determineReadoutDetectors(modules, std::vector<std::string>(), opts.skipreadout, readout);
+    for (auto& detstr : readout) {
+      o2::detectors::DetID id(detstr.c_str());
+      grp.addDetReadOut(id);
+      // set default RO modes
+      if (!o2::parameters::GRPECSObject::alwaysTriggeredRO(id)) {
+        grp.addDetContinuousReadOut(id);
+      }
+    }
+    grp.setIsMC(true);
+    grp.setRunType(o2::parameters::GRPECSObject::PHYSICS);
+    // grp.setDataPeriod("mc"); // decide what to put here
+    std::string grpfilename = o2::base::NameConf::getGRPECSFileName(opts.outprefix);
+    TFile grpF(grpfilename.c_str(), "recreate");
+    grpF.WriteObjectAny(&grp, grp.Class(), o2::base::NameConf::CCDBOBJECT.data());
+    grpF.Close();
+    if (opts.print) {
+      grp.print();
+    }
+    if (opts.publishto.size() > 0) {
+      publish(grpfilename, opts.publishto, "/GLO/Config/GRPECS");
+    }
+  }
+
+  // GRPMagField
+  {
+    LOG(info) << " --- creating magfield GRP -----";
+    o2::parameters::GRPMagField grp;
+    // parse the wanted field value
+    int fieldvalue = 0;
+    o2::conf::SimFieldMode fieldmode;
+    auto ok = o2::conf::SimConfig::parseFieldString(opts.fieldstring, fieldvalue, fieldmode);
+    if (!ok) {
+      LOG(error) << "Error parsing field string " << opts.fieldstring;
+      return false;
+    }
+
+    // let's not create an actual mag field object for this
+    // we only need to lookup the currents from the possible
+    // values of mag field
+    // +-2,+-5,0 and uniform
+
+    const std::unordered_map<int, std::pair<int, int>> field_to_current = {{2, {12000, 6000}},
+                                                                           {5, {30000, 6000}},
+                                                                           {-2, {-12000, -6000}},
+                                                                           {-5, {-30000, -6000}},
+                                                                           {0, {0, 0}}};
+
+    auto currents_iter = field_to_current.find(fieldvalue);
+    if (currents_iter == field_to_current.end()) {
+      LOG(error) << " Could not lookup currents for fieldvalue " << fieldvalue;
+      return false;
+    }
+
+    o2::units::Current_t currDip = (*currents_iter).second.first;
+    o2::units::Current_t currL3 = (*currents_iter).second.second;
+    grp.setL3Current(currL3);
+    grp.setDipoleCurrent(currDip);
+    grp.setFieldUniformity(fieldmode == o2::conf::SimFieldMode::kUniform);
+    if (opts.print) {
+      grp.print();
+    }
+    std::string grpfilename = o2::base::NameConf::getGRPMagFieldFileName(opts.outprefix);
+    TFile grpF(grpfilename.c_str(), "recreate");
+    grpF.WriteObjectAny(&grp, grp.Class(), o2::base::NameConf::CCDBOBJECT.data());
+    grpF.Close();
+    if (opts.publishto.size() > 0) {
+      publish(grpfilename, opts.publishto, "/GLO/Config/GRPMagField");
+    }
+  }
+
+  // GRPLHCIF --> complete it later
+  {
+    LOG(info) << " --- creating GRP LHCIF -----";
+    o2::parameters::GRPLHCIFData grp;
+    // eventually we need to set the beam info from the generator, at the moment put some plausible values
+    grp.setFillNumberWithTime(runStart, 0);         // RS FIXME
+    grp.setInjectionSchemeWithTime(runStart, "");   // RS FIXME
+    grp.setBeamEnergyPerZWithTime(runStart, 6.8e3); // RS FIXME
+    grp.setAtomicNumberB1WithTime(runStart, 1.);    // RS FIXME
+    grp.setAtomicNumberB2WithTime(runStart, 1.);    // RS FIXME
+    grp.setCrossingAngleWithTime(runStart, 0.);     // RS FIXME
+    grp.setBeamAZ();
+
+    // set the BC pattern if necessary
+    if (opts.bcPatternFile.size() > 0) {
+      // load bunch filling from the file
+      auto* bc = o2::BunchFilling::loadFrom(opts.bcPatternFile);
+      if (!bc) {
+        LOG(fatal) << "Failed to load bunch filling from " << opts.bcPatternFile;
+      }
+      grp.setBunchFillingWithTime(grp.getBeamEnergyPerZTime(), *bc); // borrow the time from the existing entry
+      delete bc;
+    }
+    std::string grpfilename = o2::base::NameConf::getGRPLHCIFFileName(opts.outprefix);
+    if (opts.print) {
+      grp.print();
+    }
+    TFile grpF(grpfilename.c_str(), "recreate");
+    grpF.WriteObjectAny(&grp, grp.Class(), o2::base::NameConf::CCDBOBJECT.data());
+    grpF.Close();
+    if (opts.publishto.size() > 0) {
+      publish(grpfilename, opts.publishto, "/GLO/Config/GRPLHCIF");
+    }
+  }
+
+  return true;
+}
+
+void perform_Command(Options const& opts)
+{
+  switch (opts.command) {
+    case GRPCommand::kCREATE: {
+      create_GRPs(opts);
+      break;
+    }
+    case GRPCommand::kANCHOR: {
+      anchor_GRPs(opts);
+      break;
+    }
+    case GRPCommand::kPRINTECS: {
+      printGRPECS(opts.grpfilename);
+      break;
+    }
+    case GRPCommand::kPRINTMAG: {
+      printGRPMAG(opts.grpfilename);
+      break;
+    }
+    case GRPCommand::kPRINTLHC: {
+      printGRPLHC(opts.grpfilename);
+      break;
+    }
+    case GRPCommand::kSETROMODE: {
+      setROMode(opts.grpfilename, opts.continuous, opts.triggered, opts.clearRO);
+      break;
+    }
+    default: {
+    }
+  }
+}
+
+bool parseOptions(int argc, char* argv[], Options& optvalues)
+{
+  namespace bpo = boost::program_options;
+  bpo::options_description global("Global options");
+  global.add_options()("command", bpo::value<std::string>(), "command to execute")("subargs", bpo::value<std::vector<std::string>>(), "Arguments for command");
+  global.add_options()("help,h", "Produce help message.");
+
+  bpo::positional_options_description pos;
+  pos.add("command", 1).add("subargs", -1);
+
+  bpo::variables_map vm;
+  bpo::parsed_options parsed{nullptr};
+  try {
+    parsed = bpo::command_line_parser(argc, argv).options(global).positional(pos).allow_unregistered().run();
+
+    bpo::store(parsed, vm);
+
+    // help
+    if (vm.count("help") > 0 && vm.count("command") == 0) {
+      print_globalHelp(argc, argv);
+      return false;
+    }
+  } catch (const bpo::error& e) {
+    std::cerr << e.what() << "\n\n";
+    std::cerr << "Error parsing global options; Available options:\n";
+    std::cerr << global << std::endl;
+    return false;
+  }
+
+  auto subparse = [&parsed](auto& desc, auto& vm, std::string const& command_name) {
+    try {
+      // Collect all the unrecognized options from the first pass. This will include the
+      // (positional) command name, so we need to erase that.
+      std::vector<std::string> opts = bpo::collect_unrecognized(parsed.options, bpo::include_positional);
+      // opts.erase(opts.begin());
+
+      // Parse again... and store to vm
+      bpo::store(bpo::command_line_parser(opts).options(desc).run(), vm);
+      bpo::notify(vm);
+
+      if (vm.count("help")) {
+        std::cout << desc << std::endl;
+        return false;
+      }
+    } catch (const bpo::error& e) {
+      std::cerr << e.what() << "\n\n";
+      std::cerr << "Error parsing options for " << command_name << " Available options:\n";
+      std::cerr << desc << std::endl;
+      return false;
+    }
+    return true;
+  };
+
+  std::string cmd = vm["command"].as<std::string>();
+
+  if (cmd == "anchorGRPs") {
+    optvalues.command = GRPCommand::kANCHOR;
+    // ls command has the following options:
+    bpo::options_description desc("anchor GRP options");
+
+    // ls command has the following options:
+    desc.add_options()("run", bpo::value<int>(&optvalues.run)->default_value(-1), "Run number");
+    desc.add_options()("print", "print resulting GRPs");
+    desc.add_options()("publishto", bpo::value<std::string>(&optvalues.publishto)->default_value("GRP"), "Base path under which GRP objects should be published on disc. This path can serve as lookup for CCDB queries of the GRP objects.");
+    if (!subparse(desc, vm, "anchorGRPs")) {
+      return false;
+    }
+    if (vm.count("print") > 0) {
+      optvalues.print = true;
+    }
+  } else if (cmd == "createGRPs") {
+    optvalues.command = GRPCommand::kCREATE;
+
+    // ls command has the following options:
+    bpo::options_description desc("create options");
+    desc.add_options()("readoutDets", bpo::value<std::vector<std::string>>(&optvalues.readout)->multitoken()->default_value(std::vector<std::string>({"all"}), "all Run3 detectors"), "Detector list to be readout/active");
+    desc.add_options()("skipReadout", bpo::value<std::vector<std::string>>(&optvalues.skipreadout)->multitoken()->default_value(std::vector<std::string>(), "nothing skipped"), "list of inactive detectors (precendence over --readout)");
+    desc.add_options()("run", bpo::value<int>(&optvalues.run)->default_value(-1), "Run number");
+    desc.add_options()("field", bpo::value<std::string>(&optvalues.fieldstring)->default_value("-5"), "L3 field rounded to kGauss, allowed values +-2,+-5 and 0; +-<intKGaus>U for uniform field");
+    desc.add_options()("outprefix,o", bpo::value<std::string>(&optvalues.outprefix)->default_value("o2sim"), "Prefix for GRP output files");
+    desc.add_options()("bcPatternFile", bpo::value<std::string>(&optvalues.bcPatternFile)->default_value(""), "Interacting BC pattern file (e.g. from CreateBCPattern.C)");
+    desc.add_options()("print", "print resulting GRPs");
+    desc.add_options()("publishto", bpo::value<std::string>(&optvalues.publishto)->default_value(""), "Base path under which GRP objects should be published on disc. This path can serve as lookup for CCDB queries of the GRP objects.");
+    if (!subparse(desc, vm, "createGRPs")) {
+      return false;
+    }
+    if (vm.count("print") > 0) {
+      optvalues.print = true;
+    }
+  } else if (cmd == "setROMode") {
+    // set/modify the ROMode
+    optvalues.command = GRPCommand::kSETROMODE;
+    bpo::options_description desc("setting detector readout modes");
+    desc.add_options()("file,f", bpo::value<std::string>(&optvalues.grpfilename)->default_value("o2sim_grpecs.root"), "Path to GRPECS file");
+    desc.add_options()("continuousRO", bpo::value<std::vector<std::string>>(&optvalues.continuous)->multitoken()->default_value(std::vector<std::string>({"all"}), "all active detectors"), "List of detectors to set to continuous mode");
+    desc.add_options()("triggerCTP", bpo::value<std::vector<std::string>>(&optvalues.triggered)->multitoken()->default_value(std::vector<std::string>({""}), "none"), "List of detectors to trigger CTP");
+    desc.add_options()("clear", "clears all RO modes (prio to applying other options)");
+    if (!subparse(desc, vm, "setROMode")) {
+      return false;
+    }
+    if (vm.count("clear") > 0) {
+      optvalues.clearRO = true;
+    }
+  } else if (cmd == "print_GRPECS") {
+    optvalues.command = GRPCommand::kPRINTECS;
+    // print the GRP
+    bpo::options_description desc("print options");
+    desc.add_options()("file,f", bpo::value<std::string>(&optvalues.grpfilename), "Path to GRP file");
+    if (!subparse(desc, vm, "print_GRPECS")) {
+      return false;
+    }
+  } else if (cmd == "print_GRPLHC") {
+    optvalues.command = GRPCommand::kPRINTLHC;
+    // print the GRP
+    bpo::options_description desc("print options");
+    desc.add_options()("file,f", bpo::value<std::string>(&optvalues.grpfilename), "Path to GRP file");
+    if (!subparse(desc, vm, "print_GRPECS")) {
+      return false;
+    }
+  } else if (cmd == "print_GRPMAG") {
+    optvalues.command = GRPCommand::kPRINTMAG;
+    // print the GRP
+    bpo::options_description desc("print options");
+    desc.add_options()("file,f", bpo::value<std::string>(&optvalues.grpfilename), "Path to GRP file");
+    if (!subparse(desc, vm, "print_GRPECS")) {
+      return false;
+    }
+  } else {
+    std::cerr << "Error: Unknown command " << cmd << std::endl;
+    return false;
+  }
+
+  return true;
+}
+
+int main(int argc, char* argv[])
+{
+  Options options;
+  if (parseOptions(argc, argv, options)) {
+    perform_Command(options);
+  } else {
+    std::cout << "Parse options failed\n";
+    return 1;
+  }
+  return 0;
+}

--- a/prodtests/sim_challenge.sh
+++ b/prodtests/sim_challenge.sh
@@ -111,6 +111,10 @@ fi
 
 
 if [ "$dosim" == "1" ]; then
+  #---- GRP creation ------
+  echo "Creating GRPs ... and publishing in local CCDB overwrite"
+  taskwrapper grp.log o2-grp-simGRP-tool createGRPs --run ${runNumber} --publishto GRP -o mcGRP
+
   #---------------------------------------------------
   echo "Running simulation for $nev $collSyst events with $gener generator and engine $engine and run number $runNumber"
   taskwrapper sim.log o2-sim -n"$nev" --configKeyValues "Diamond.width[2]=6." -g "$gener" -e "$engine" $simWorker --run ${runNumber}
@@ -219,7 +223,7 @@ if [ "$doreco" == "1" ]; then
 
   echo "Running primary vertex finding flow"
   #needs results of TPC-ITS matching and FIT workflows
-  taskwrapper pvfinder.log o2-primary-vertexing-workflow $gloOpt
+  taskwrapper pvfinder.log o2-primary-vertexing-workflow $gloOpt --condition-remap file://./GRP=GLO/Config/GRPECS
   echo "Return status of primary vertexing: $?"
 
   echo "Running secondary vertex finding flow"

--- a/prodtests/sim_challenge.sh
+++ b/prodtests/sim_challenge.sh
@@ -113,7 +113,7 @@ fi
 if [ "$dosim" == "1" ]; then
   #---- GRP creation ------
   echo "Creating GRPs ... and publishing in local CCDB overwrite"
-  taskwrapper grp.log o2-grp-simGRP-tool createGRPs --run ${runNumber} --publishto GRP -o mcGRP
+  taskwrapper grp.log o2-grp-simgrp-tool createGRPs --run ${runNumber} --publishto GRP -o mcGRP
 
   #---------------------------------------------------
   echo "Running simulation for $nev $collSyst events with $gener generator and engine $engine and run number $runNumber"


### PR DESCRIPTION
Introduce a GRP tool for simulation
    
    Introducing a GRP command line tool for MC, which can
    
    - create the set of ECS,MagField,LHCIF objects locally
      **or** download them from CCDB, for the use in MC simulations.
    
      (creation is fast and does not need firing up the simulation executable
       as the case up until now)
    
    - publish or put these objects into directories where they can be picked
      up through CCDB queries (during reco)
    
    - edit these files to change settings (prior to digitization)
      * for now only RO mode for GRPECS is supported
    
    - print GRPs to screen
    
    The tool offers command and sub-command options.
    
    The final goal is to allow MC processing to proceed the same way
    irrespective of whether the mode is anchored, unachored, ad-hoc, etc.
    
    The tool achieves this by enabling a common workflow for all these cases.
    
    Note that the present version has some basic functionality implemented to give
    the idea. Extensions are to follow.
    
    The sim_challenge.sh script is modified to show usage of the new tool.