### PR TITLE
TPC dE/dx: using nD piecewise polynomials for correction

### DIFF
--- a/Detectors/TPC/calibration/src/CalibPadGainTracks.cxx
+++ b/Detectors/TPC/calibration/src/CalibPadGainTracks.cxx
@@ -251,29 +251,19 @@ float CalibPadGainTracks::getTrackTopologyCorrection(const o2::tpc::TrackTPC& tr
 
 float CalibPadGainTracks::getTrackTopologyCorrectionPol(const o2::tpc::TrackTPC& track, const o2::tpc::ClusterNative& cl, const unsigned int region, const float charge) const
 {
-  const float trackSnp = track.getSnp();
-  const float maxSnp = mCalibTrackTopologyPol->getMaxSinPhi();
-  float snp = std::abs(trackSnp);
-  if (snp > maxSnp) {
-    snp = maxSnp;
-  }
-
+  const float trackSnp = std::abs(track.getSnp());
   float snp2 = trackSnp * trackSnp;
   const float sec2 = 1.f / (1.f - snp2);
   const float trackTgl = track.getTgl();
   const float tgl2 = trackTgl * trackTgl;
-  float tanTheta = std::sqrt(tgl2 * sec2);
-  const float maxTanTheta = mCalibTrackTopologyPol->getMaxTanTheta();
-  if (tanTheta > maxTanTheta) {
-    tanTheta = maxTanTheta;
-  }
+  const float tanTheta = std::sqrt(tgl2 * sec2);
 
   const float z = std::abs(track.getParam(1));
   const float padTmp = cl.getPad();
   const float absRelPad = std::abs(padTmp - int(padTmp + 0.5f));
   const float relTime = cl.getTime() - int(cl.getTime() + 0.5f);
 
-  const float effectiveLength = (mChargeType == ChargeType::Max) ? mCalibTrackTopologyPol->getCorrectionqMax(region, tanTheta, snp, z, absRelPad, relTime) : mCalibTrackTopologyPol->getCorrectionqTot(region, tanTheta, snp, z, 3.5f /*dummy threshold for now*/, std::clamp(charge, mCalibTrackTopologyPol->getMinqTot(), mCalibTrackTopologyPol->getMaxqTot()));
+  const float effectiveLength = (mChargeType == ChargeType::Max) ? mCalibTrackTopologyPol->getCorrectionqMax(region, tanTheta, trackSnp, z, absRelPad, relTime) : mCalibTrackTopologyPol->getCorrectionqTot(region, tanTheta, trackSnp, z, 3.5f /*dummy threshold for now*/, charge);
   return effectiveLength;
 }
 

--- a/GPU/GPUTracking/DataTypes/CalibdEdxContainer.h
+++ b/GPU/GPUTracking/DataTypes/CalibdEdxContainer.h
@@ -89,7 +89,7 @@ class CalibdEdxContainer : public o2::gpu::FlatObject
   /// \param region region of the TPC
   /// \param chargeT type of the charge (qMax or qTot)
   /// \param x coordinates where the correction is evaluated
-  GPUd() float getTopologyCorrection(const int region, const ChargeType chargeT, const float x[]) const
+  GPUd() float getTopologyCorrection(const int region, const ChargeType chargeT, float x[]) const
   {
     return mCalibTrackTopologyPol ? mCalibTrackTopologyPol->getCorrection(region, chargeT, x) : (mCalibTrackTopologySpline ? mCalibTrackTopologySpline->getCorrection(region, chargeT, x) : getDefaultTopologyCorrection(x[0], x[1]));
   }
@@ -97,18 +97,6 @@ class CalibdEdxContainer : public o2::gpu::FlatObject
   /// \return returns analytical default correction
   /// Correction corresponds to: "sqrt((dz/dx)^2 + (dy/dx)^2 + (dx/dx)^2) / padlength" simple track length correction (ToDo add division by pad length)
   GPUd() float getDefaultTopologyCorrection(const float tanTheta, const float sinPhi) const { return gpu::CAMath::Sqrt(tanTheta * tanTheta + 1 / (1 - sinPhi * sinPhi)); }
-
-  /// \return returns maximum tanTheta for which the topology correction is valid
-  GPUd() float getMaxTanThetaTopologyCorrection() const { return mCalibTrackTopologyPol ? mCalibTrackTopologyPol->getMaxTanTheta() : (mCalibTrackTopologySpline ? mCalibTrackTopologySpline->getMaxTanTheta() : 2); }
-
-  /// \return returns maximum sinPhi for which the topology correction is valid
-  GPUd() float getMaxSinPhiTopologyCorrection() const { return mCalibTrackTopologyPol ? mCalibTrackTopologyPol->getMaxSinPhi() : (mCalibTrackTopologySpline ? mCalibTrackTopologySpline->getMaxSinPhi() : 1); }
-
-  /// \return returns the the minimum qTot for which the polynomials are valid
-  GPUd() float getMinqTot() const { return mCalibTrackTopologyPol ? mCalibTrackTopologyPol->getMinqTot() : 0; };
-
-  /// \return returns the the maximum qTot for which the polynomials are valid
-  GPUd() float getMaxqTot() const { return mCalibTrackTopologyPol ? mCalibTrackTopologyPol->getMaxqTot() : 10000; };
 
 #if !defined(GPUCA_GPUCODE)
   /// \returns the minimum zero supression threshold for which the track topology correction is valid

--- a/GPU/GPUTracking/DataTypes/CalibdEdxTrackTopologyPol.cxx
+++ b/GPU/GPUTracking/DataTypes/CalibdEdxTrackTopologyPol.cxx
@@ -19,6 +19,20 @@
 
 using namespace o2::tpc;
 
+#if !defined(GPUCA_GPUCODE) && !defined(GPUCA_STANDALONE) // code invisible on GPU and in the standalone compilation
+void CalibdEdxTrackTopologyPol::dumpToTree(const unsigned int nSamplingPoints[/* Dim */], const char* outName) const
+{
+  for (unsigned int i = 0; i < FFits; i++) {
+    const auto treename = getPolyName(i, ChargeType::Max);
+    mCalibPolsqMax[i].dumpToTree(nSamplingPoints, outName, treename.data(), false);
+  }
+
+  for (unsigned int i = 0; i < FFits; i++) {
+    const auto treename = getPolyName(i, ChargeType::Tot);
+    mCalibPolsqTot[i].dumpToTree(nSamplingPoints, outName, treename.data(), false);
+  }
+}
+
 void CalibdEdxTrackTopologyPol::cloneFromObject(const CalibdEdxTrackTopologyPol& obj, char* newFlatBufferPtr)
 {
   const char* oldFlatBufferPtr = obj.mFlatBufferPtr;
@@ -33,13 +47,6 @@ void CalibdEdxTrackTopologyPol::cloneFromObject(const CalibdEdxTrackTopologyPol&
     char* buffer = FlatObject::relocatePointer(oldFlatBufferPtr, mFlatBufferPtr, obj.mCalibPolsqMax[i].getFlatBufferPtr());
     mCalibPolsqMax[i].cloneFromObject(obj.mCalibPolsqMax[i], buffer);
   }
-
-  mMaxTanTheta = obj.mMaxTanTheta;
-  mMaxSinPhi = obj.mMaxSinPhi;
-  mThresholdMin = obj.mThresholdMin;
-  mThresholdMax = obj.mThresholdMax;
-  mQTotMin = obj.mQTotMin;
-  mQTotMax = obj.mQTotMax;
 
   for (int i = 0; i < FFits; ++i) {
     mScalingFactorsqTot[i] = obj.mScalingFactorsqTot[i];
@@ -128,15 +135,26 @@ void CalibdEdxTrackTopologyPol::construct()
 void CalibdEdxTrackTopologyPol::setDefaultPolynomials()
 {
   for (int i = 0; i < FFits; ++i) {
-    mCalibPolsqTot[i].setParam(0, 1);
-    mCalibPolsqMax[i].setParam(0, 1);
+    const unsigned int n[FDim]{6, 5, 5, 5, 5};
+
+    //                        z tan(theta) sin(phi) |relPad| relTime
+    const float minqMax[FDim]{0, 0, 0, 0, -0.5f};
+    const float maxqMax[FDim]{250, 1.5, 0.9, 0.5f, 0.5f};
+    mCalibPolsqMax[i].init(minqMax, maxqMax, n);
+    mCalibPolsqMax[i].setDefault();
+
+    //                        z tan(theta) sin(phi) threshold <qTot>
+    const float minqTot[FDim]{0, 0, 0, 2, 30};
+    const float maxqTot[FDim]{250, 1.5, 0.9, 5, 200};
+    mCalibPolsqTot[i].init(minqTot, maxqTot, n);
+    mCalibPolsqTot[i].setDefault();
   }
   construct();
 }
 
 void CalibdEdxTrackTopologyPol::writeToFile(TFile& outf, const char* name) const
 {
-  CalibdEdxTrackTopologyPolContainer cont(mMaxTanTheta, mMaxSinPhi, mThresholdMin, mThresholdMax, mQTotMin, mQTotMax);
+  CalibdEdxTrackTopologyPolContainer cont;
   cont.mCalibPols.reserve(FFits);
 
   for (const auto& par : mCalibPolsqTot) {
@@ -178,13 +196,6 @@ void CalibdEdxTrackTopologyPol::setFromContainer(const CalibdEdxTrackTopologyPol
   for (int i = 0; i < FFits; ++i) {
     mCalibPolsqMax[i].setFromContainer(container.mCalibPols[FFits + i]);
   }
-
-  mMaxTanTheta = container.mMaxTanTheta;
-  mMaxSinPhi = container.mMaxSinPhi;
-  mThresholdMin = container.mThresholdMin;
-  mThresholdMax = container.mThresholdMax;
-  mQTotMin = container.mQTotMin;
-  mQTotMax = container.mQTotMax;
 
   for (int i = 0; i < FFits; ++i) {
     mScalingFactorsqTot[i] = container.mScalingFactorsqTot[i];

--- a/GPU/GPUTracking/dEdx/GPUdEdx.h
+++ b/GPU/GPUTracking/dEdx/GPUdEdx.h
@@ -126,20 +126,12 @@ GPUdnii() void GPUdEdx::fillCluster(float qtot, float qmax, int padRow, unsigned
   }
 
   // setting maximum for snp for which the calibration object was created
-  const float maxSnp = calibContainer->getMaxSinPhiTopologyCorrection();
-  float snp = CAMath::Abs(trackSnp);
-  if (snp > maxSnp) {
-    snp = maxSnp;
-  }
+  const float snp = CAMath::Abs(trackSnp);
 
   // tanTheta local dip angle: z angle - dz/dx (cm/cm)
   const float sec2 = 1.f / (1.f - snp2);
   const float tgl2 = trackTgl * trackTgl;
-  float tanTheta = CAMath::Sqrt(tgl2 * sec2);
-  const float maxTanTheta = calibContainer->getMaxTanThetaTopologyCorrection();
-  if (tanTheta > maxTanTheta) {
-    tanTheta = maxTanTheta;
-  }
+  const float tanTheta = CAMath::Sqrt(tgl2 * sec2);
 
   // getting the topology correction
   const int padPos = int(pad + 0.5f); // position of the pad is shifted half a pad ( pad=3 -> centre position of third pad)
@@ -148,7 +140,7 @@ GPUdnii() void GPUdEdx::fillCluster(float qtot, float qmax, int padRow, unsigned
   z = CAMath::Abs(z);
   const float threshold = calibContainer->getZeroSupressionThreshold(slice, padRow, padPos); // TODO: Use the mean zero supresion threshold of all pads in the cluster?
   const bool useFullGainMap = calibContainer->isUsageOfFullGainMap();
-  float qTotIn = CAMath::Clamp(qtot, calibContainer->getMinqTot(), calibContainer->getMaxqTot());
+  float qTotIn = qtot;
   const float fullGainMapGain = calibContainer->getGain(slice, padRow, padPos);
   if (useFullGainMap) {
     qmax /= fullGainMapGain;


### PR DESCRIPTION
This will break reconstruction for dE/dx when loading/using the old calibration object!

- Adding functionality to dump piecewise polynomials to tree