### PR TITLE
Fix in HBFUtilsInitializer

### DIFF
--- a/Detectors/Raw/include/DetectorsRaw/HBFUtilsInitializer.h
+++ b/Detectors/Raw/include/DetectorsRaw/HBFUtilsInitializer.h
@@ -44,9 +44,11 @@ struct HBFUtilsInitializer {
   enum HBFOpt { NONE,
                 INI,
                 JSON,
+                HBFUTILS,
                 ROOT };
   static constexpr char HBFConfOpt[] = "hbfutils-config";
-  static constexpr char HBFTFInfoOpt[] = "tf-info-file";
+  static constexpr char HBFTFInfoOpt[] = "tf-info-source";
+  static constexpr char HBFUSrc[] = "hbfutils";
 
   HBFUtilsInitializer(const o2::framework::ConfigContext& configcontext, o2::framework::WorkflowSpec& wf);
   static HBFOpt getOptType(const std::string& optString);


### PR DESCRIPTION
Modify TimingInfo only if explicitly requested, i.e. when option --hbfutils-config
is invoked with
1) ini file with HBFUtils (from digitization time): update HBFUtils from it
2) new option: with hbfutils keyword the settings from HBFUtils will be used as is
   (e.g. updated from the command line --configKeyValues"
3) TFIDInfo file from the reconstruction