### PR TITLE
MCH: fix digit nofsamples exceeding limit

### DIFF
--- a/Detectors/MUON/MCH/Simulation/src/Response.cxx
+++ b/Detectors/MUON/MCH/Simulation/src/Response.cxx
@@ -88,5 +88,6 @@ uint16_t Response::nSamples(uint32_t adc) const
   // applied in data reconstruction (see MCH/DigitFiltering/src/DigitFilter.cxx).
   // a realistic estimate of nSamples would require a complete simulation of the electronic signal
   double signalParam[3] = {14., 13., 1.5};
-  return std::round(std::pow(double(adc) / signalParam[1], 1. / signalParam[2]) + signalParam[0]);
+  unsigned int nSamples = std::round(std::pow(double(adc) / signalParam[1], 1. / signalParam[2]) + signalParam[0]);
+  return std::min(nSamples, 0x3FFU); // the number of samples must fit within 10 bits
 }


### PR DESCRIPTION
the number of samples must fit within 10 bits