### PR TITLE
DPL GUI: prepare ancillary classes to enable remote GUI

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -29,6 +29,7 @@ o2_add_library(Framework
                        src/CommonServices.cxx
                        src/CommonMessageBackends.cxx
                        src/CommonDriverServices.cxx
+                       src/ControlWebSocketHandler.cxx
                        src/CompletionPolicy.cxx
                        src/CompletionPolicyHelpers.cxx
                        src/ComputingQuotaEvaluator.cxx

--- a/Framework/Core/src/GuiCallbackContext.h
+++ b/Framework/Core/src/GuiCallbackContext.h
@@ -25,18 +25,18 @@ class WSDPLHandler;
 
 struct GuiRenderer {
   uv_timer_t drawTimer;
-  WSDPLHandler* handler;
-  GuiCallbackContext* gui;
+  WSDPLHandler* handler = nullptr;
+  GuiCallbackContext* gui = nullptr;
 };
 
 struct GuiCallbackContext {
   uint64_t frameLast;
-  float* frameLatency;
-  float* frameCost;
-  void* lastFrame;
-  DebugGUI* plugin;
-  void* window;
-  bool* guiQuitRequested;
+  float* frameLatency = nullptr;
+  float* frameCost = nullptr;
+  void* lastFrame = nullptr;
+  DebugGUI* plugin = nullptr;
+  void* window = nullptr;
+  bool* guiQuitRequested = nullptr;
   std::function<void(void)> callback;
   std::set<GuiRenderer*> renderers;
 };

--- a/Framework/Core/src/HTTPParser.cxx
+++ b/Framework/Core/src/HTTPParser.cxx
@@ -220,6 +220,7 @@ std::string encode_websocket_handshake_reply(char const* nonce)
     "HTTP/1.1 101 Switching Protocols\r\n"
     "Upgrade: websocket\r\n"
     "Connection: Upgrade\r\n"
+    "Access-Control-Allow-Origin: \"*\"\r\n"
     "Sec-WebSocket-Accept: {}\r\n\r\n";
   return fmt::format(res, HTTPParserHelpers::calculateAccept(nonce));
 }

--- a/Framework/Core/test/test_HTTPParser.cxx
+++ b/Framework/Core/test/test_HTTPParser.cxx
@@ -168,6 +168,7 @@ BOOST_AUTO_TEST_CASE(HTTPParser1)
       "HTTP/1.1 101 Switching Protocols\r\n"
       "Upgrade: websocket\r\n"
       "Connection: Upgrade\r\n"
+      "Access-Control-Allow-Origin: \"*\"\r\n"
       "Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r\n\r\n");
 
     DPLClientParser parser;
@@ -176,7 +177,7 @@ BOOST_AUTO_TEST_CASE(HTTPParser1)
     BOOST_REQUIRE_EQUAL(std::string(parser.mReplyCode), std::string("101"));
     BOOST_REQUIRE_EQUAL(std::string(parser.mReplyMessage), std::string("Switching Protocols"));
     BOOST_REQUIRE_EQUAL(std::string(parser.mReplyVersion), std::string("HTTP/1.1"));
-    BOOST_REQUIRE_EQUAL(parser.mHeaders.size(), 3);
+    BOOST_REQUIRE_EQUAL(parser.mHeaders.size(), 4);
     BOOST_REQUIRE_EQUAL(parser.mHeaders["Sec-WebSocket-Accept"], "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=");
     BOOST_REQUIRE_EQUAL(parser.mBody, "");
   }
@@ -329,6 +330,7 @@ BOOST_AUTO_TEST_CASE(HTTPParser1)
       "HTTP/1.1 101 Switching Protocols\r\n"
       "Upgrade: websocket\r\n"
       "Connection: Upgrade\r\n"
+      "Access-Control-Allow-Origin: \"*\"\r\n"
       "Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r\n\r\n";
     int someSeed = 123;
     std::string result = encode_websocket_handshake_request("/chat", "myprotocol", 13, "dGhlIHNhbXBsZSBub25jZQ==");


### PR DESCRIPTION
* Allow CORS connection on the websocket
* Setup the remote GUI if a non DPL connection on the websocket
  port happens.
* Invoke pollGUIPostRender and protect against empty frames in the
  beginning.