### PR TITLE
TPC cluster residuals + track information are dumped by aggregator

### DIFF
--- a/Detectors/Calibration/include/DetectorsCalibration/TimeSlotCalibration.h
+++ b/Detectors/Calibration/include/DetectorsCalibration/TimeSlotCalibration.h
@@ -102,7 +102,6 @@ class TimeSlotCalibration
 
   template <typename DATA>
   bool process(const DATA& data);
-  virtual bool process(const gsl::span<const Input> data);
   virtual void checkSlotsToFinalize(TFType tf, int maxDelay = 0);
   virtual void finalizeOldestSlot();
 
@@ -202,44 +201,6 @@ bool TimeSlotCalibration<Input, Container>::process(const DATA& data)
   auto& slotTF = getSlotForTF(tf);
   using Cont_t = typename std::remove_pointer<decltype(slotTF.getContainer())>::type;
   if constexpr (has_fill_method<Cont_t, void(const o2::dataformats::TFIDInfo&, const DATA&)>::value) {
-    slotTF.getContainer()->fill(mCurrentTFInfo, data);
-  } else {
-    slotTF.getContainer()->fill(data);
-  }
-  if (tf > mMaxSeenTF) {
-    mMaxSeenTF = tf; // keep track of the most recent TF processed
-  }
-  if (!mUpdateAtTheEndOfRunOnly) { // if you update at the end of run only, you don't check at every TF which slots can be closed
-    // check if some slots are done
-    checkSlotsToFinalize(tf, maxDelay);
-  }
-
-  return true;
-}
-
-//_________________________________________________
-template <typename Input, typename Container>
-bool TimeSlotCalibration<Input, Container>::process(const gsl::span<const Input> data)
-{
-
-  // process current TF
-  TFType tf = mCurrentTFInfo.tfCounter;
-  uint64_t maxDelay64 = uint64_t(mSlotLength) * mMaxSlotsDelay;
-  TFType maxDelay = maxDelay64 > o2::calibration::INFINITE_TF ? o2::calibration::INFINITE_TF : TFType(maxDelay64);
-
-  if (!mUpdateAtTheEndOfRunOnly) {                                                                 // if you update at the end of run only, then you accept everything
-    if (tf < mLastClosedTF || (!mSlots.empty() && getLastSlot().getTFStart() > tf + maxDelay64)) { // ignore TF; note that if you have only 1 timeslot
-                                                                                                   // which is INFINITE_TF wide, then maxDelay
-                                                                                                   // does not matter: you won't accept TFs from the past,
-                                                                                                   // so the first condition will be used
-      LOG(info) << "Ignoring TF " << tf << ", mLastClosedTF = " << mLastClosedTF;
-      return false;
-    }
-  }
-
-  auto& slotTF = getSlotForTF(tf);
-  using Cont_t = typename std::remove_pointer<decltype(slotTF.getContainer())>::type;
-  if constexpr (has_fill_method<Cont_t, void(const o2::dataformats::TFIDInfo&, const gsl::span<const Input>)>::value) {
     slotTF.getContainer()->fill(mCurrentTFInfo, data);
   } else {
     slotTF.getContainer()->fill(data);

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCInterpolationSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCInterpolationSpec.h
@@ -37,7 +37,7 @@ namespace tpc
 class TPCInterpolationDPL : public Task
 {
  public:
-  TPCInterpolationDPL(std::shared_ptr<o2::globaltracking::DataRequest> dr, std::shared_ptr<o2::base::GRPGeomRequest> gr, bool useMC, bool processITSTPConly, bool writeResiduals) : mDataRequest(dr), mGGCCDBRequest(gr), mUseMC(useMC), mProcessITSTPConly(processITSTPConly), mWriteResiduals(writeResiduals) {}
+  TPCInterpolationDPL(std::shared_ptr<o2::globaltracking::DataRequest> dr, std::shared_ptr<o2::base::GRPGeomRequest> gr, bool useMC, bool processITSTPConly, bool writeResiduals, bool sendTrackData) : mDataRequest(dr), mGGCCDBRequest(gr), mUseMC(useMC), mProcessITSTPConly(processITSTPConly), mWriteResiduals(writeResiduals), mSendTrackData(sendTrackData) {}
   ~TPCInterpolationDPL() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
@@ -53,11 +53,12 @@ class TPCInterpolationDPL : public Task
   bool mUseMC{false}; ///< MC flag
   bool mProcessITSTPConly{false}; ///< should also tracks without outer point (ITS-TPC only) be processed?
   bool mWriteResiduals{false};    ///< whether or not the unbinned unfiltered residuals should be sent out
+  bool mSendTrackData{false};     ///< if true, not only the clusters but also corresponding track data will be sent
   TStopwatch mTimer;
 };
 
 /// create a processor spec
-framework::DataProcessorSpec getTPCInterpolationSpec(o2::dataformats::GlobalTrackID::mask_t src, bool useMC, bool processITSTPConly, bool writeResiduals);
+framework::DataProcessorSpec getTPCInterpolationSpec(o2::dataformats::GlobalTrackID::mask_t src, bool useMC, bool processITSTPConly, bool writeResiduals, bool sendTrackData);
 
 } // namespace tpc
 } // namespace o2

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCResidualAggregatorSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCResidualAggregatorSpec.h
@@ -38,7 +38,7 @@ namespace calibration
 class ResidualAggregatorDevice : public o2::framework::Task
 {
  public:
-  ResidualAggregatorDevice(std::shared_ptr<o2::base::GRPGeomRequest> req) : mCCDBRequest(req) {}
+  ResidualAggregatorDevice(std::shared_ptr<o2::base::GRPGeomRequest> req, bool trackInput, bool writeUnbinnedResiduals, bool writeBinnedResiduals, bool writeTrackData) : mCCDBRequest(req), mTrackInput(trackInput), mWriteUnbinnedResiduals(writeUnbinnedResiduals), mWriteBinnedResiduals(writeBinnedResiduals), mWriteTrackData(writeTrackData) {}
 
   void init(o2::framework::InitContext& ic) final
   {
@@ -67,7 +67,9 @@ class ResidualAggregatorDevice : public o2::framework::Task
     mAggregator->setSlotLength(slotLength);
     mAggregator->setMaxSlotsDelay(delay);
     mAggregator->setCheckIntervalInfiniteSlot(updateInterval);
-    mAggregator->initOutput();
+    mAggregator->setWriteBinnedResiduals(mWriteBinnedResiduals);
+    mAggregator->setWriteUnbinnedResiduals(mWriteUnbinnedResiduals);
+    mAggregator->setWriteTrackData(mWriteTrackData);
   }
 
   void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final
@@ -79,9 +81,20 @@ class ResidualAggregatorDevice : public o2::framework::Task
   {
     updateTimeDependentParams(pc);
 
-    auto data = pc.inputs().get<gsl::span<o2::tpc::TrackResiduals::UnbinnedResid>>("input");
+    auto residualsData = pc.inputs().get<gsl::span<o2::tpc::TrackResiduals::UnbinnedResid>>("unbinnedRes");
+
+    // track data input is optional
+    const gsl::span<const o2::tpc::TrackData>* trkDataPtr = nullptr;
+    using trkDataType = std::decay_t<decltype(pc.inputs().get<gsl::span<o2::tpc::TrackData>>(""))>;
+    std::optional<trkDataType> trkData;
+    if (mTrackInput) {
+      trkData.emplace(pc.inputs().get<gsl::span<o2::tpc::TrackData>>("trkData"));
+      trkDataPtr = &trkData.value();
+    }
+
+    auto data = std::make_pair<gsl::span<const o2::tpc::TrackData>, gsl::span<const o2::tpc::TrackResiduals::UnbinnedResid>>(std::move(*trkData), std::move(residualsData));
     o2::base::TFIDInfoHelper::fillTFIDInfo(pc, mAggregator->getCurrentTFInfo());
-    LOG(debug) << "Processing TF " << mAggregator->getCurrentTFInfo().tfCounter << " with " << data.size() << " unbinned residuals";
+    LOG(debug) << "Processing TF " << mAggregator->getCurrentTFInfo().tfCounter << " with " << trkData->size() << " tracks and " << residualsData.size() << " unbinned residuals associated to them";
     mAggregator->process(data);
   }
 
@@ -102,8 +115,12 @@ class ResidualAggregatorDevice : public o2::framework::Task
       mAggregator->setDataTakingContext(pc.services().get<DataTakingContext>());
     }
   }
-  std::unique_ptr<o2::tpc::ResidualAggregator> mAggregator;
+  std::unique_ptr<o2::tpc::ResidualAggregator> mAggregator; ///< the TimeSlotCalibration device
   std::shared_ptr<o2::base::GRPGeomRequest> mCCDBRequest;
+  bool mTrackInput{false};             ///< flag whether to expect track data as input
+  bool mWriteBinnedResiduals{false};   ///< flag, whether to write binned residuals to output file
+  bool mWriteUnbinnedResiduals{false}; ///< flag, whether to write unbinned residuals to output file
+  bool mWriteTrackData{false};         ///< flag, whether to write track data to output file
 };
 
 } // namespace calibration
@@ -111,9 +128,13 @@ class ResidualAggregatorDevice : public o2::framework::Task
 namespace framework
 {
 
-DataProcessorSpec getTPCResidualAggregatorSpec()
+DataProcessorSpec getTPCResidualAggregatorSpec(bool trackInput, bool writeUnbinnedResiduals, bool writeBinnedResiduals, bool writeTrackData)
 {
-  std::vector<InputSpec> inputs{{"input", "GLO", "UNBINNEDRES"}};
+  std::vector<InputSpec> inputs;
+  inputs.emplace_back("unbinnedRes", "GLO", "UNBINNEDRES");
+  if (trackInput) {
+    inputs.emplace_back("trkData", "GLO", "TRKDATA");
+  }
   auto ccdbRequest = std::make_shared<o2::base::GRPGeomRequest>(true,                           // orbitResetTime
                                                                 true,                           // GRPECS=true
                                                                 false,                          // GRPLHCIF
@@ -125,7 +146,7 @@ DataProcessorSpec getTPCResidualAggregatorSpec()
     "residual-aggregator",
     inputs,
     Outputs{},
-    AlgorithmSpec{adaptFromTask<o2::calibration::ResidualAggregatorDevice>(ccdbRequest)},
+    AlgorithmSpec{adaptFromTask<o2::calibration::ResidualAggregatorDevice>(ccdbRequest, trackInput, writeUnbinnedResiduals, writeBinnedResiduals, writeTrackData)},
     Options{
       {"tf-per-slot", VariantType::UInt32, 6'000u, {"number of TFs per calibration time slot (put 0 for infinite slot length)"}},
       {"updateInterval", VariantType::UInt32, 6'000u, {"update interval in number of TFs in case slot length is infinite"}},

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
@@ -149,6 +149,9 @@ void TPCInterpolationDPL::run(ProcessingContext& pc)
     pc.outputs().snapshot(Output{"GLO", "TPCINT_RES", 0, Lifetime::Timeframe}, mInterpolation.getClusterResiduals());
   }
   pc.outputs().snapshot(Output{"GLO", "UNBINNEDRES", 0, Lifetime::Timeframe}, mResidualProcessor.getUnbinnedResiduals());
+  if (mSendTrackData) {
+    pc.outputs().snapshot(Output{"GLO", "TRKDATA", 0, Lifetime::Timeframe}, mResidualProcessor.getTrackDataOut());
+  }
 
   mInterpolation.reset();
   mResidualProcessor.resetUnbinnedResiduals();
@@ -160,7 +163,7 @@ void TPCInterpolationDPL::endOfStream(EndOfStreamContext& ec)
        mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
 }
 
-DataProcessorSpec getTPCInterpolationSpec(GTrackID::mask_t src, bool useMC, bool processITSTPConly, bool writeResiduals)
+DataProcessorSpec getTPCInterpolationSpec(GTrackID::mask_t src, bool useMC, bool processITSTPConly, bool writeResiduals, bool sendTrackData)
 {
   auto dataRequest = std::make_shared<DataRequest>();
   std::vector<OutputSpec> outputs;
@@ -185,12 +188,13 @@ DataProcessorSpec getTPCInterpolationSpec(GTrackID::mask_t src, bool useMC, bool
     outputs.emplace_back("GLO", "TPCINT_RES", 0, Lifetime::Timeframe);
   }
   outputs.emplace_back("GLO", "UNBINNEDRES", 0, Lifetime::Timeframe);
+  outputs.emplace_back("GLO", "TRKDATA", 0, Lifetime::Timeframe);
 
   return DataProcessorSpec{
     "tpc-track-interpolation",
     dataRequest->inputs,
     outputs,
-    AlgorithmSpec{adaptFromTask<TPCInterpolationDPL>(dataRequest, ggRequest, useMC, processITSTPConly, writeResiduals)},
+    AlgorithmSpec{adaptFromTask<TPCInterpolationDPL>(dataRequest, ggRequest, useMC, processITSTPConly, writeResiduals, sendTrackData)},
     Options{}};
 }
 

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/tpc-interpolation-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/tpc-interpolation-workflow.cxx
@@ -40,6 +40,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"enable-itsonly", VariantType::Bool, false, {"process tracks without outer point (ITS-TPC only)"}},
     {"tracking-sources", VariantType::String, std::string{GID::ALL}, {"comma-separated list of sources to use for tracking"}},
     {"enable-residual-writer", VariantType::Bool, false, {"write unbinned and unfiltered residuals"}},
+    {"send-track-data", VariantType::Bool, false, {"Send also the track information to the aggregator"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
   std::swap(workflowOptions, options);
@@ -74,10 +75,11 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   useMC = false; // force disabling MC as long as it is not implemented
   auto processITSTPConly = configcontext.options().get<bool>("enable-itsonly");
   auto writeResiduals = configcontext.options().get<bool>("enable-residual-writer");
+  auto sendTrackData = configcontext.options().get<bool>("send-track-data");
   GID::mask_t src = allowedSources & GID::getSourcesMask(configcontext.options().get<std::string>("tracking-sources"));
   LOG(info) << "Data sources: " << GID::getSourcesNames(src);
 
-  specs.emplace_back(o2::tpc::getTPCInterpolationSpec(src, useMC, processITSTPConly, writeResiduals));
+  specs.emplace_back(o2::tpc::getTPCInterpolationSpec(src, useMC, processITSTPConly, writeResiduals, sendTrackData));
   if (!configcontext.options().get<bool>("disable-root-output") && writeResiduals) {
     specs.emplace_back(o2::tpc::getTPCResidualWriterSpec(useMC));
   }

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/tpc-residual-aggregator.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/tpc-residual-aggregator.cxx
@@ -18,7 +18,10 @@ using namespace o2::framework;
 // we need to add workflow options before including Framework/runDataProcessing
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
-  std::vector<o2::framework::ConfigParamSpec> options{{"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
+  std::vector<o2::framework::ConfigParamSpec> options{
+    {"output-type", VariantType::String, "binnedResid", {"Comma separated list of outputs (without spaces). Valid strings: unbinnedResid, binnedResid, trackParams"}},
+    {"enable-track-input", VariantType::Bool, false, {"Whether to expect track data from interpolation workflow"}},
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
   std::swap(workflowOptions, options);
 }
 
@@ -29,8 +32,35 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 {
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
+  auto trkInput = configcontext.options().get<bool>("enable-track-input");
+
+  bool writeUnbinnedResiduals = false;
+  bool writeBinnedResiduals = false;
+  bool writeTrackData = false;
+  auto outputType = configcontext.options().get<string>("output-type");
+  std::vector<std::string> outputTypes;
+  size_t pos = 0;
+  while ((pos = outputType.find(",")) != std::string::npos) {
+    outputTypes.push_back(outputType.substr(0, pos));
+    outputType.erase(0, pos + 1);
+  }
+  outputTypes.push_back(outputType);
+  for (const auto& out : outputTypes) {
+    if (out == "unbinnedResid") {
+      writeUnbinnedResiduals = true;
+    } else if (out == "binnedResid") {
+      writeBinnedResiduals = true;
+    } else if (out == "trackParams") {
+      if (!trkInput) {
+        LOG(error) << "Track output will be empty, because it is not configured as input";
+      }
+      writeTrackData = true;
+    } else {
+      LOG(error) << "Invalid output requested: " << out;
+    }
+  }
 
   WorkflowSpec specs;
-  specs.emplace_back(getTPCResidualAggregatorSpec());
+  specs.emplace_back(getTPCResidualAggregatorSpec(trkInput, writeUnbinnedResiduals, writeBinnedResiduals, writeTrackData));
   return specs;
 }

--- a/Detectors/ITSMFT/ITS/calibration/include/ITSCalibration/NoiseSlotCalibrator.h
+++ b/Detectors/ITSMFT/ITS/calibration/include/ITSCalibration/NoiseSlotCalibrator.h
@@ -75,7 +75,7 @@ class NoiseSlotCalibrator : public o2::calibration::TimeSlotCalibration<o2::itsm
   }
 
   // Functions overloaded from the calibration framework
-  bool process(const gsl::span<const o2::itsmft::CompClusterExt> data) final;
+  bool process(const gsl::span<const o2::itsmft::CompClusterExt> data);
 
   // Functions required by the calibration framework
   void initOutput() final {}

--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/ResidualAggregator.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/ResidualAggregator.h
@@ -42,11 +42,11 @@ struct ResidualsContainer {
   ResidualsContainer& operator=(const ResidualsContainer& src) = delete;
   ~ResidualsContainer();
 
-  void init(const TrackResiduals* residualsEngine, std::string outputDir);
+  void init(const TrackResiduals* residualsEngine, std::string outputDir, bool wBinnedResid, bool wUnbinnedResid, bool wTrackData);
   void fillStatisticsBranches();
   uint64_t getNEntries() const { return nResidualsTotal; }
 
-  void fill(const o2::dataformats::TFIDInfo& ti, const gsl::span<const TrackResiduals::UnbinnedResid> data);
+  void fill(const o2::dataformats::TFIDInfo& ti, const std::pair<gsl::span<const o2::tpc::TrackData>, gsl::span<const TrackResiduals::UnbinnedResid>> data);
   void merge(ResidualsContainer* prev);
   void print();
 
@@ -58,19 +58,27 @@ struct ResidualsContainer {
   uint32_t runNumber;                                                        ///< run number (required for meta data file)
   std::vector<uint32_t> tfOrbits, *tfOrbitsPtr{&tfOrbits};                   ///< first TF orbit
   std::vector<uint32_t> sumOfResiduals, *sumOfResidualsPtr{&sumOfResiduals}; ///< sum of residuals for each TF
+  std::vector<TrackResiduals::UnbinnedResid> unbinnedRes, *unbinnedResPtr{&unbinnedRes}; // unbinned residuals
+  std::vector<TrackData> trkData, *trkDataPtr{&trkData};                                 // track data and cluster ranges
 
   std::string fileName{"o2tpc_residuals"};
   std::string treeNameResiduals{"resid"};
   std::string treeNameStats{"stats"};
   std::string treeNameRecords{"records"};
   std::unique_ptr<TFile> fileOut{nullptr};
+  std::unique_ptr<TTree> treeOutResidualsUnbinned{nullptr};
+  std::unique_ptr<TTree> treeOutTrackData{nullptr};
   std::unique_ptr<TTree> treeOutResiduals{nullptr};
   std::unique_ptr<TTree> treeOutStats{nullptr};
   std::unique_ptr<TTree> treeOutRecords{nullptr};
 
+  bool writeBinnedResid{false};
+  bool writeUnbinnedResiduals{false};
+  bool writeTrackData{false};
+
   uint64_t nResidualsTotal{0};
 
-  ClassDefNV(ResidualsContainer, 1);
+  ClassDefNV(ResidualsContainer, 2);
 };
 
 class ResidualAggregator final : public o2::calibration::TimeSlotCalibration<TrackResiduals::UnbinnedResid, ResidualsContainer>
@@ -89,6 +97,9 @@ class ResidualAggregator final : public o2::calibration::TimeSlotCalibration<Tra
     mStoreMetaData = true;
   }
   void setLHCPeriod(std::string period) { mLHCPeriod = period; }
+  void setWriteBinnedResiduals(bool f) { mWriteBinnedResiduals = f; }
+  void setWriteUnbinnedResiduals(bool f) { mWriteUnbinnedResiduals = f; }
+  void setWriteTrackData(bool f) { mWriteTrackData = f; }
 
   bool hasEnoughData(const Slot& slot) const final;
   void initOutput() final;
@@ -102,9 +113,12 @@ class ResidualAggregator final : public o2::calibration::TimeSlotCalibration<Tra
   std::string mMetaOutputDir{"none"}; ///< the directory where the meta data file is stored
   std::string mLHCPeriod{""};         ///< the LHC period to be put into the meta file
   bool mStoreMetaData{false};         ///< flag, whether meta file is supposed to be stored
+  bool mWriteBinnedResiduals{false};  ///< flag, whether to write binned residuals to output file
+  bool mWriteUnbinnedResiduals{false}; ///< flag, whether to write unbinned residuals to output file
+  bool mWriteTrackData{false};         ///< flag, whether to write track data to output file
   size_t mMinEntries;             ///< the minimum number of residuals required for the map creation (per voxel)
 
-  ClassDefOverride(ResidualAggregator, 1);
+  ClassDefOverride(ResidualAggregator, 2);
 };
 
 } // namespace tpc

--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackInterpolation.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackInterpolation.h
@@ -57,22 +57,22 @@ struct TPCClusterResiduals {
   float tgl{};          ///< dip angle of track
   unsigned char sec{};  ///< sector number 0..35
   unsigned char dRow{}; ///< distance to previous row in units of pad rows
-  short row{};          ///< TPC pad row (absolute units)
   void setDY(float val) { dy = fabs(val) < param::MaxResid ? val : std::copysign(param::MaxResid, val); }
   void setDZ(float val) { dz = fabs(val) < param::MaxResid ? val : std::copysign(param::MaxResid, val); }
   void setY(float val) { y = fabs(val) < param::MaxY ? val : std::copysign(param::MaxY, val); }
   void setZ(float val) { z = fabs(val) < param::MaxZ ? val : std::copysign(param::MaxZ, val); }
   void setPhi(float val) { phi = fabs(val) < param::MaxTgSlp ? val : std::copysign(param::MaxTgSlp, val); }
   void setTgl(float val) { tgl = fabs(val) < param::MaxTgSlp ? val : std::copysign(param::MaxTgSlp, val); }
-  ClassDefNV(TPCClusterResiduals, 1);
+  ClassDefNV(TPCClusterResiduals, 2);
 };
 
 /// Structure filled for each track with track quality information and a vector with TPCClusterResiduals
 struct TrackData {
   o2::dataformats::GlobalTrackID gid{}; ///< global track ID for seeding track
-  float eta{};                 ///< track dip angle
-  float phi{};                 ///< track azimuthal angle
-  float qPt{};                 ///< track q/pT
+  // the track parameters are taken from the ITS track
+  float x{};                                  ///< track X position
+  float alpha{};                              ///< track alpha angle
+  std::array<float, o2::track::kNParams> p{}; ///< track parameters
   float chi2TPC{};             ///< chi2 of TPC track
   float chi2ITS{};             ///< chi2 of ITS track
   unsigned short nClsTPC{};    ///< number of attached TPC clusters

--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackResiduals.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackResiduals.h
@@ -193,6 +193,9 @@ class TrackResiduals
   /// Returns the collected unbinned residuals after outlier rejection is applied
   std::vector<UnbinnedResid>& getUnbinnedResiduals() { return mUnbinnedResiduals; }
 
+  /// Returns the track parameters and cluster range reference for validated tracks (this is a subset of the input mTrackDataPtr)
+  std::vector<TrackData>& getTrackDataOut() { return mTrackDataOut; }
+
   /// Create output files for each sector with trees for local residuals
   void prepareLocalResidualTrees();
 
@@ -556,7 +559,7 @@ class TrackResiduals
   TTree* mTreeInTracks{nullptr};                        ///< tree with input track information
   std::vector<TrackData>* mTrackDataPtr{nullptr};       ///< vector with input track information
   TTree* mTreeInClRes{nullptr};                         ///< tree with TPC cluster residuals
-  std::vector<TPCClusterResiduals>* mClResPtr{nullptr}; ///< vector with TPC cluster residuals
+  std::vector<TPCClusterResiduals>* mClResPtr{nullptr}; ///< vector with unbinned TPC cluster residuals
   std::vector<LocalResid> mLocalResidualsIn;            ///< binned local residuals from aggregator
   std::vector<VoxStats> mVoxStatsIn, *mVoxStatsInPtr{&mVoxStatsIn}; ///< the statistics information for each voxel from the aggregator
   // output data
@@ -564,6 +567,7 @@ class TrackResiduals
   std::unique_ptr<TTree> mTreeOut; ///< tree holding debug output
   std::vector<UnbinnedResid> mUnbinnedResiduals; ///< large vector for the unbinned residual data which is sent to the aggregator
   std::vector<UnbinnedResid>* mUnbinnedResidualsPtr{&mUnbinnedResiduals};
+  std::vector<TrackData> mTrackDataOut; // the same as mTrackDataPtr, but the rejected tracks are removed, to be sent to the aggregator
   // status flags
   bool mIsInitialized{}; ///< initialize only once
   bool mPrintMem{};      ///< turn on to print memory usage at certain points
@@ -630,7 +634,7 @@ class TrackResiduals
   float mMaxRejFrac{.15f}; ///< if the fraction of rejected clusters of a track is higher, the full track is invalidated
   float mMaxRMSLong{.8f};  ///< maximum variance of the cluster residuals wrt moving avarage for a track to be considered
 
-  ClassDefNV(TrackResiduals, 1);
+  ClassDefNV(TrackResiduals, 2);
 };
 
 //_____________________________________________________

--- a/Detectors/TPC/calibration/SpacePoints/src/ResidualAggregator.cxx
+++ b/Detectors/TPC/calibration/SpacePoints/src/ResidualAggregator.cxx
@@ -26,6 +26,8 @@ using namespace o2::tpc;
 ResidualsContainer::~ResidualsContainer()
 {
   // trees must be deleted before the file is closed, otherwise segfaults
+  treeOutResidualsUnbinned.reset();
+  treeOutTrackData.reset();
   treeOutResiduals.reset();
   treeOutStats.reset();
   if (fileOut) {
@@ -50,6 +52,8 @@ ResidualsContainer::ResidualsContainer(ResidualsContainer&& rhs)
   trackResiduals = rhs.trackResiduals;
   fileOut = std::move(rhs.fileOut);
   fileName = std::move(rhs.fileName);
+  treeOutResidualsUnbinned = std::move(rhs.treeOutResidualsUnbinned);
+  treeOutTrackData = std::move(rhs.treeOutTrackData);
   treeOutResiduals = std::move(rhs.treeOutResiduals);
   treeOutStats = std::move(rhs.treeOutStats);
   for (int iSec = 0; iSec < SECTORSPERSIDE * SIDES; ++iSec) {
@@ -61,35 +65,48 @@ ResidualsContainer::ResidualsContainer(ResidualsContainer&& rhs)
   sumOfResiduals = std::move(rhs.sumOfResiduals);
 }
 
-void ResidualsContainer::init(const TrackResiduals* residualsEngine, std::string outputDir)
+void ResidualsContainer::init(const TrackResiduals* residualsEngine, std::string outputDir, bool wBinnedResid, bool wUnbinnedResid, bool wTrackData)
 {
   trackResiduals = residualsEngine;
+  writeBinnedResid = wBinnedResid;
+  writeUnbinnedResiduals = wUnbinnedResid;
+  writeTrackData = wTrackData;
   fileName += std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count());
   fileName += ".root";
   std::string fileNameTmp = outputDir + fileName;
   fileNameTmp += ".part"; // to prevent premature external usage of the file use temporary name
   fileOut = std::make_unique<TFile>(fileNameTmp.c_str(), "recreate");
-  treeOutResiduals = std::make_unique<TTree>(treeNameResiduals.c_str(), "TPC binned residuals");
-  treeOutStats = std::make_unique<TTree>(treeNameStats.c_str(), "Voxel statistics mean position and nEntries");
-  treeOutRecords = std::make_unique<TTree>(treeNameRecords.c_str(), "Statistics per TF slot");
-  for (int iSec = 0; iSec < SECTORSPERSIDE * SIDES; ++iSec) {
-    residualsPtr[iSec] = &residuals[iSec];
-    statsPtr[iSec] = &stats[iSec];
-    stats[iSec].resize(trackResiduals->getNVoxelsPerSector());
-    for (int ix = 0; ix < trackResiduals->getNXBins(); ++ix) {
-      for (int ip = 0; ip < trackResiduals->getNY2XBins(); ++ip) {
-        for (int iz = 0; iz < trackResiduals->getNZ2XBins(); ++iz) {
-          auto& statsVoxel = stats[iSec][trackResiduals->getGlbVoxBin(ix, ip, iz)];
-          // COG estimates are set to the bin center by default
-          trackResiduals->getVoxelCoordinates(iSec, ix, ip, iz, statsVoxel.meanPos[TrackResiduals::VoxX], statsVoxel.meanPos[TrackResiduals::VoxF], statsVoxel.meanPos[TrackResiduals::VoxZ]);
+  if (writeUnbinnedResiduals) {
+    treeOutResidualsUnbinned = std::make_unique<TTree>("unbinnedResid", "TPC unbinned residuals");
+    treeOutResidualsUnbinned->Branch("res", &unbinnedResPtr);
+  }
+  if (writeTrackData) {
+    treeOutTrackData = std::make_unique<TTree>("trackData", "Track information incl cluster range ref");
+    treeOutTrackData->Branch("trk", &trkDataPtr);
+  }
+  if (writeBinnedResid) {
+    treeOutResiduals = std::make_unique<TTree>(treeNameResiduals.c_str(), "TPC binned residuals");
+    treeOutStats = std::make_unique<TTree>(treeNameStats.c_str(), "Voxel statistics mean position and nEntries");
+    treeOutRecords = std::make_unique<TTree>(treeNameRecords.c_str(), "Statistics per TF slot");
+    for (int iSec = 0; iSec < SECTORSPERSIDE * SIDES; ++iSec) {
+      residualsPtr[iSec] = &residuals[iSec];
+      statsPtr[iSec] = &stats[iSec];
+      stats[iSec].resize(trackResiduals->getNVoxelsPerSector());
+      for (int ix = 0; ix < trackResiduals->getNXBins(); ++ix) {
+        for (int ip = 0; ip < trackResiduals->getNY2XBins(); ++ip) {
+          for (int iz = 0; iz < trackResiduals->getNZ2XBins(); ++iz) {
+            auto& statsVoxel = stats[iSec][trackResiduals->getGlbVoxBin(ix, ip, iz)];
+            // COG estimates are set to the bin center by default
+            trackResiduals->getVoxelCoordinates(iSec, ix, ip, iz, statsVoxel.meanPos[TrackResiduals::VoxX], statsVoxel.meanPos[TrackResiduals::VoxF], statsVoxel.meanPos[TrackResiduals::VoxZ]);
+          }
         }
       }
+      treeOutResiduals->Branch(Form("sec%d", iSec), &residualsPtr[iSec]);
+      treeOutStats->Branch(Form("sec%d", iSec), &statsPtr[iSec]);
     }
-    treeOutResiduals->Branch(Form("sec%d", iSec), &residualsPtr[iSec]);
-    treeOutStats->Branch(Form("sec%d", iSec), &statsPtr[iSec]);
+    treeOutRecords->Branch("firstTForbit", &tfOrbitsPtr);
+    treeOutRecords->Branch("sumOfResiduals", &sumOfResidualsPtr);
   }
-  treeOutRecords->Branch("firstTForbit", &tfOrbitsPtr);
-  treeOutRecords->Branch("sumOfResiduals", &sumOfResidualsPtr);
 }
 
 void ResidualsContainer::fillStatisticsBranches()
@@ -97,17 +114,28 @@ void ResidualsContainer::fillStatisticsBranches()
   // only called when the slot is finalized, otherwise treeOutStats
   // remains empty and we keep the statistics in memory in the vectors
   // (since their size anyway does not change)
-  treeOutStats->Fill();
-  treeOutRecords->Fill();
+  if (writeBinnedResid) {
+    treeOutStats->Fill();
+    treeOutRecords->Fill();
+  }
 }
 
-void ResidualsContainer::fill(const o2::dataformats::TFIDInfo& ti, const gsl::span<const TrackResiduals::UnbinnedResid> data)
+void ResidualsContainer::fill(const o2::dataformats::TFIDInfo& ti, const std::pair<gsl::span<const o2::tpc::TrackData>, gsl::span<const TrackResiduals::UnbinnedResid>> data)
 {
   // receives large vector of unbinned residuals and fills the sector-wise vectors
   // with binned residuals and statistics
-  LOG(debug) << "Filling ResidualsContainer with vector of size " << data.size();
+  LOG(debug) << "Filling ResidualsContainer with vector of size " << data.second.size();
   uint32_t nResidualsInTF = 0;
-  for (const auto& residIn : data) {
+  for (const auto& residIn : data.second) {
+    bool counterIncremented = false;
+    if (writeUnbinnedResiduals) {
+      unbinnedRes.push_back(residIn);
+      ++nResidualsTotal;
+      counterIncremented = true;
+    }
+    if (!writeBinnedResid) {
+      continue;
+    }
     int sec = residIn.sec;
     auto& residVecOut = residuals[sec];
     auto& statVecOut = stats[sec];
@@ -130,51 +158,85 @@ void ResidualsContainer::fill(const o2::dataformats::TFIDInfo& ti, const gsl::sp
     stat.meanPos[TrackResiduals::VoxX] = (stat.meanPos[TrackResiduals::VoxX] * oldEntries + xPos) * norm;
     stat.meanPos[TrackResiduals::VoxF] = (stat.meanPos[TrackResiduals::VoxF] * oldEntries + yPos * xPosInv) * norm;
     stat.meanPos[TrackResiduals::VoxZ] = (stat.meanPos[TrackResiduals::VoxZ] * oldEntries + zPos * xPosInv) * norm;
-    ++nResidualsTotal;
+    if (!counterIncremented) {
+      ++nResidualsTotal;
+    }
     ++nResidualsInTF;
   }
-  treeOutResiduals->Fill();
+  if (writeBinnedResid) {
+    treeOutResiduals->Fill();
+    sumOfResiduals.push_back(nResidualsInTF);
+  }
   for (auto& residVecOut : residuals) {
     residVecOut.clear();
   }
+  if (writeTrackData) {
+    for (const auto& trkIn : data.first) {
+      trkData.push_back(trkIn);
+    }
+    treeOutTrackData->Fill();
+    trkData.clear();
+  }
+  if (writeUnbinnedResiduals) {
+    treeOutResidualsUnbinned->Fill();
+    unbinnedRes.clear();
+  }
   runNumber = ti.runNumber;
   tfOrbits.push_back(ti.firstTForbit);
-  sumOfResiduals.push_back(nResidualsInTF);
 }
 
 void ResidualsContainer::merge(ResidualsContainer* prev)
 {
   // the previous slot is merged to this one and afterwards
   // the previous one will be deleted
-  for (int iSec = 0; iSec < SECTORSPERSIDE * SIDES; ++iSec) {
-    // merge statistics
-    const auto& statVecPrev = prev->stats[iSec];
-    auto& statVec = stats[iSec];
-    for (int iVox = 0; iVox < trackResiduals->getNVoxelsPerSector(); ++iVox) {
-      const auto& statPrev = statVecPrev[iVox];
-      auto& stat = statVec[iVox];
-      float norm = 1.f;
-      if (statPrev.nEntries + stat.nEntries > 0.1) {
-        // if there is at least a single entry in either of the containers we need the proper norm
-        norm /= (statPrev.nEntries + stat.nEntries);
+  if (writeBinnedResid) {
+    for (int iSec = 0; iSec < SECTORSPERSIDE * SIDES; ++iSec) {
+      // merge statistics
+      const auto& statVecPrev = prev->stats[iSec];
+      auto& statVec = stats[iSec];
+      for (int iVox = 0; iVox < trackResiduals->getNVoxelsPerSector(); ++iVox) {
+        const auto& statPrev = statVecPrev[iVox];
+        auto& stat = statVec[iVox];
+        float norm = 1.f;
+        if (statPrev.nEntries + stat.nEntries > 0.1) {
+          // if there is at least a single entry in either of the containers we need the proper norm
+          norm /= (statPrev.nEntries + stat.nEntries);
+        }
+        stat.meanPos[TrackResiduals::VoxX] = (stat.meanPos[TrackResiduals::VoxX] * stat.nEntries + statPrev.meanPos[TrackResiduals::VoxX] * statPrev.nEntries) * norm;
+        stat.meanPos[TrackResiduals::VoxF] = (stat.meanPos[TrackResiduals::VoxF] * stat.nEntries + statPrev.meanPos[TrackResiduals::VoxF] * statPrev.nEntries) * norm;
+        stat.meanPos[TrackResiduals::VoxZ] = (stat.meanPos[TrackResiduals::VoxZ] * stat.nEntries + statPrev.meanPos[TrackResiduals::VoxZ] * statPrev.nEntries) * norm;
+        stat.nEntries += statPrev.nEntries;
       }
-      stat.meanPos[TrackResiduals::VoxX] = (stat.meanPos[TrackResiduals::VoxX] * stat.nEntries + statPrev.meanPos[TrackResiduals::VoxX] * statPrev.nEntries) * norm;
-      stat.meanPos[TrackResiduals::VoxF] = (stat.meanPos[TrackResiduals::VoxF] * stat.nEntries + statPrev.meanPos[TrackResiduals::VoxF] * statPrev.nEntries) * norm;
-      stat.meanPos[TrackResiduals::VoxZ] = (stat.meanPos[TrackResiduals::VoxZ] * stat.nEntries + statPrev.meanPos[TrackResiduals::VoxZ] * statPrev.nEntries) * norm;
-      stat.nEntries += statPrev.nEntries;
+      // prepare merging of residuals
+      prev->treeOutResiduals->SetBranchAddress(Form("sec%d", iSec), &residualsPtr);
     }
-    // prepare merging of residuals
-    prev->treeOutResiduals->SetBranchAddress(Form("sec%d", iSec), &residualsPtr);
+    // We append the entries of the tree of the following slot to the
+    // previous slot and afterwards move the merged tree to this slot.
+    // This way the order of the entries is preserved
+    for (int i = 0; i < treeOutResiduals->GetEntries(); ++i) {
+      treeOutResiduals->GetEntry(i);
+      prev->treeOutResiduals->Fill();
+    }
   }
-  // We append the entries of the tree of the following slot to the
-  // previous slot and afterwards move the merged tree to this slot.
-  // This way the order of the entries is preserved
-  for (int i = 0; i < treeOutResiduals->GetEntries(); ++i) {
-    treeOutResiduals->GetEntry(i);
-    prev->treeOutResiduals->Fill();
+
+  if (writeTrackData) {
+    prev->treeOutTrackData->SetBranchAddress("trk", &trkDataPtr);
+    for (int i = 0; i < treeOutTrackData->GetEntries(); ++i) {
+      treeOutTrackData->GetEntry(i);
+      prev->treeOutTrackData->Fill();
+    }
+  }
+  if (writeUnbinnedResiduals) {
+    prev->treeOutResidualsUnbinned->SetBranchAddress("res", &unbinnedResPtr);
+    for (int i = 0; i < treeOutResidualsUnbinned->GetEntries(); ++i) {
+      treeOutResidualsUnbinned->GetEntry(i);
+      prev->treeOutResidualsUnbinned->Fill();
+    }
   }
 
   treeOutResiduals = std::move(prev->treeOutResiduals);
+  treeOutTrackData = std::move(prev->treeOutTrackData);
+  treeOutResidualsUnbinned = std::move(prev->treeOutResidualsUnbinned);
 
   nResidualsTotal += prev->nResidualsTotal;
 
@@ -213,16 +275,27 @@ void ResidualAggregator::initOutput()
 
 void ResidualAggregator::finalizeSlot(Slot& slot)
 {
+  LOG(info) << "Finalizing slot";
   auto cont = slot.getContainer();
   cont->print();
   cont->fillStatisticsBranches();
   cont->fileOut->cd();
-  cont->treeOutResiduals->Write();
-  cont->treeOutResiduals.reset();
-  cont->treeOutStats->Write();
-  cont->treeOutStats.reset();
-  cont->treeOutRecords->Write();
-  cont->treeOutRecords.reset();
+  if (mWriteBinnedResiduals) {
+    cont->treeOutResiduals->Write();
+    cont->treeOutResiduals.reset();
+    cont->treeOutStats->Write();
+    cont->treeOutStats.reset();
+    cont->treeOutRecords->Write();
+    cont->treeOutRecords.reset();
+  }
+  if (mWriteUnbinnedResiduals) {
+    cont->treeOutResidualsUnbinned->Write();
+    cont->treeOutResidualsUnbinned.reset();
+  }
+  if (mWriteTrackData) {
+    cont->treeOutTrackData->Write();
+    cont->treeOutTrackData.reset();
+  }
   cont->fileOut->Close();
   cont->fileOut.reset();
   std::filesystem::rename(o2::utils::Str::concat_string(mOutputDir, cont->fileName, ".part"), mOutputDir + cont->fileName);
@@ -255,6 +328,6 @@ Slot& ResidualAggregator::emplaceNewSlot(bool front, TFType tStart, TFType tEnd)
   auto& cont = getSlots();
   auto& slot = front ? cont.emplace_front(tStart, tEnd) : cont.emplace_back(tStart, tEnd);
   slot.setContainer(std::make_unique<ResidualsContainer>());
-  slot.getContainer()->init(&mTrackResiduals, mOutputDir);
+  slot.getContainer()->init(&mTrackResiduals, mOutputDir, mWriteBinnedResiduals, mWriteUnbinnedResiduals, mWriteTrackData);
   return slot;
 }

--- a/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
+++ b/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
@@ -257,16 +257,17 @@ void TrackInterpolation::interpolateTrack(int iSeed)
     res.setTgl(mCache[iRow].tgl[Int]);
     res.sec = mCache[iRow].clSec;
     res.dRow = deltaRow;
-    res.row = iRow;
     mClRes.push_back(std::move(res));
     ++nMeasurements;
     deltaRow = 1;
   }
 
   trackData.gid = (*mGIDs)[iSeed];
-  trackData.eta = trkTPC.getEta();
-  trackData.phi = trkTPC.getSnp();
-  trackData.qPt = trkTPC.getQ2Pt();
+  trackData.x = (*mSeeds)[iSeed].getX();
+  trackData.alpha = (*mSeeds)[iSeed].getAlpha();
+  for (int i = 0; i < o2::track::kNParams; ++i) {
+    trackData.p[i] = (*mSeeds)[iSeed].getParam(i);
+  }
   trackData.chi2TPC = trkTPC.getChi2();
   trackData.chi2ITS = trkITS.getChi2();
   trackData.nClsTPC = trkTPC.getNClusterReferences();
@@ -313,15 +314,16 @@ void TrackInterpolation::extrapolateTrack(int iSeed)
     res.setTgl(trkWork.getTgl());
     res.sec = sector;
     res.dRow = row - rowPrev;
-    res.row = row;
     rowPrev = row;
     mClRes.push_back(std::move(res));
     ++nMeasurements;
   }
   trackData.gid = (*mGIDs)[iSeed];
-  trackData.eta = trkTPC.getEta();
-  trackData.phi = trkTPC.getSnp();
-  trackData.qPt = trkTPC.getQ2Pt();
+  trackData.x = (*mSeeds)[iSeed].getX();
+  trackData.alpha = (*mSeeds)[iSeed].getAlpha();
+  for (int i = 0; i < o2::track::kNParams; ++i) {
+    trackData.p[i] = (*mSeeds)[iSeed].getParam(i);
+  }
   trackData.chi2TPC = trkTPC.getChi2();
   trackData.chi2ITS = trkITS.getChi2();
   trackData.nClsTPC = trkTPC.getNClusterReferences();

--- a/prodtests/full-system-test/aggregator-workflow.sh
+++ b/prodtests/full-system-test/aggregator-workflow.sh
@@ -48,6 +48,9 @@ if [[ $BEAMTYPE == "PbPb" ]]; then
   TOF_CHANNELOFFSETS_DELTA_UPDATE=500
 fi
 
+# special settings for aggregator workflows
+if [[ "0$CALIB_TPC_SCDCALIB_SENDTRKDATA" == "01" ]]; then ENABLE_TRACK_INPUT="--enable-track-input"; fi
+
 # Calibration workflows
 if ! workflow_has_parameter CALIB_LOCAL_INTEGRATED_AGGREGATOR; then
   WORKFLOW=
@@ -122,7 +125,7 @@ if [[ $AGGREGATOR_TASKS == BARREL_TF ]] || [[ $AGGREGATOR_TASKS == ALL ]]; then
   if [[ $CALIB_TPC_SCDCALIB == 1 ]]; then
     # TODO: the residual aggregator should have --output-dir and --meta-output-dir defined
     # without that the residuals will be stored in the local working directory (and deleted after a week)
-    add_W o2-calibration-residual-aggregator ""
+    add_W o2-calibration-residual-aggregator "$ENABLE_TRACK_INPUT --output-type trackParams,unbinnedResid,binnedResid"
   fi
   # TRD
   if [[ $CALIB_TRD_VDRIFTEXB == 1 ]]; then

--- a/prodtests/full-system-test/calib-workflow.sh
+++ b/prodtests/full-system-test/calib-workflow.sh
@@ -14,8 +14,10 @@ if workflow_has_parameters CALIB_LOCAL_INTEGRATED_AGGREGATOR CALIB_PROXIES; then
   exit 2
 fi
 
+if [[ "0$CALIB_TPC_SCDCALIB_SENDTRKDATA" == "01" ]]; then ENABLE_TRKDATA_OUTPUT="--send-track-data"; fi
+
 # specific calibration workflows
-if [[ $CALIB_TPC_SCDCALIB == 1 ]]; then add_W o2-tpc-scdcalib-interpolation-workflow "$DISABLE_ROOT_OUTPUT --disable-root-input --pipeline $(get_N tpc-track-interpolation TPC REST)" "$ITSMFT_FILES"; fi
+if [[ $CALIB_TPC_SCDCALIB == 1 ]]; then add_W o2-tpc-scdcalib-interpolation-workflow "$ENABLE_TRKDATA_OUTPUT $DISABLE_ROOT_OUTPUT --disable-root-input --pipeline $(get_N tpc-track-interpolation TPC REST)" "$ITSMFT_FILES"; fi
 if [[ $CALIB_TPC_TIMEGAIN == 1 ]]; then add_W o2-tpc-miptrack-filter "" "" 0; fi
 if [[ $CALIB_TPC_RESPADGAIN == 1 ]]; then add_W o2-tpc-calib-gainmap-tracks "--publish-after-tfs 10000"; fi
 


### PR DESCRIPTION
In order to use `TimeSlotCalibration::process()` with a custom data object which is not of type `const gsl::span<const Input>` I had to remove the redundant method and the final keyword in the ITS calibration, since templated methods cannot be virtual.

The residual aggregator is now writing binned residuals, unbinned residuals and track data to 3 different trees. For each tree I create one entry per TF.