### PR TITLE
Fixes for TriggerOffsets application in TRD and CPV

### DIFF
--- a/Detectors/CPV/workflow/include/CPVWorkflow/RawToDigitConverterSpec.h
+++ b/Detectors/CPV/workflow/include/CPVWorkflow/RawToDigitConverterSpec.h
@@ -62,6 +62,7 @@ class RawToDigitConverterSpec : public framework::Task
   /// Output cells trigger record: {"CPV", "DIGITTRIGREC", 0, Lifetime::Timeframe}
   /// Output HW errors: {"CPV", "RAWHWERRORS", 0, Lifetime::Timeframe}
   void run(framework::ProcessingContext& ctx) final;
+  void finaliseCCDB(framework::ConcreteDataMatcher& matcher, void* obj) final;
 
  protected:
   /// \brief simple check of HW address

--- a/Detectors/CPV/workflow/src/RawToDigitConverterSpec.cxx
+++ b/Detectors/CPV/workflow/src/RawToDigitConverterSpec.cxx
@@ -59,9 +59,9 @@ void RawToDigitConverterSpec::init(framework::InitContext& ctx)
   LOG(info) << "Task configuration is done.";
 }
 
-void finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
+void RawToDigitConverterSpec::finaliseCCDB(framework::ConcreteDataMatcher& matcher, void* obj)
 {
-  if (matcher == ConcreteDataMatcher("CTP", "Trig_Offset", 0)) {
+  if (matcher == framework::ConcreteDataMatcher("CTP", "Trig_Offset", 0)) {
     LOG(info) << "RawToDigitConverterSpec::finaliseCCDB() : CTP/Config/TriggerOffsets updated.";
     const auto& par = o2::ctp::TriggerOffsetsParam::Instance();
     par.printKeyValues();

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/DataReaderTask.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/DataReaderTask.h
@@ -45,8 +45,10 @@ class DataReaderTask : public Task
   void run(ProcessingContext& pc) final;
   bool isTimeFrameEmpty(ProcessingContext& pc);
   void endOfStream(o2::framework::EndOfStreamContext& ec) override;
+  void finaliseCCDB(ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
+  void updateTimeDependentParams(framework::ProcessingContext& pc);
   CruRawReader mReader;                  // this will do the parsing, of raw data passed directly through the flp(no compression)
   CompressedRawReader mCompressedReader; //this will handle the incoming compressed data from the flp
                                          // in both cases we pull the data from the vectors build message and pass on.

--- a/Detectors/TRD/reconstruction/src/DataReader.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReader.cxx
@@ -21,6 +21,7 @@
 #include "Framework/ConcreteDataMatcher.h"
 #include "Framework/CallbacksPolicy.h"
 #include "Framework/Logger.h"
+#include "Framework/CCDBParamSpec.h"
 #include "DetectorsRaw/RDHUtils.h"
 #include "TRDWorkflowIO/TRDTrackletWriterSpec.h"
 #include "TRDWorkflowIO/TRDDigitWriterSpec.h"
@@ -52,7 +53,8 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"histogramsfile", VariantType::String, "histos.root", {"Name of the histogram file, so one can run multiple per node"}},
     {"trd-debugm1", VariantType::Bool, false, {"various output statements specific to debugging m1 problems."}},
     //{"generate-stats", VariantType::Bool, true, {"Generate the state message sent to qc"}},
-    {"trd-datareader-enablebyteswapdata", VariantType::Bool, false, {"byteswap the incoming data, raw data needs it and simulation does not."}}};
+    {"trd-datareader-enablebyteswapdata", VariantType::Bool, false, {"byteswap the incoming data, raw data needs it and simulation does not."}},
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
   std::swap(workflowOptions, options);
 }
 
@@ -64,7 +66,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
 
   //  auto config = cfgc.options().get<std::string>("trd-datareader-config");
-
+  o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
   //auto outputspec = cfgc.options().get<std::string>("trd-datareader-outputspec");
   auto verbose = cfgc.options().get<bool>("trd-datareader-verbose");
   auto byteswap = cfgc.options().get<bool>("trd-datareader-enablebyteswapdata");
@@ -120,6 +122,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   if (askSTFDist) {
     inputs.emplace_back("stdDist", "FLP", "DISTSUBTIMEFRAME", 0, Lifetime::Timeframe);
   }
+  inputs.emplace_back("trigoffset", "CTP", "Trig_Offset", 0, o2::framework::Lifetime::Condition, o2::framework::ccdbParamSpec("CTP/Config/TriggerOffsets"));
   workflow.emplace_back(DataProcessorSpec{
     std::string("trd-datareader"), // left as a string cast incase we append stuff to the string
     inputs,

--- a/Detectors/TRD/simulation/CMakeLists.txt
+++ b/Detectors/TRD/simulation/CMakeLists.txt
@@ -22,7 +22,12 @@ o2_add_library(TRDSimulation
                        src/TrapSimulator.cxx
                        src/Trap2CRU.cxx
                        src/PileupTool.cxx
-                       PUBLIC_LINK_LIBRARIES O2::DetectorsBase O2::SimulationDataFormat O2::TRDBase O2::DataFormatsTRD O2::DetectorsRaw)
+                       PUBLIC_LINK_LIBRARIES O2::DetectorsBase
+                                             O2::SimulationDataFormat
+                                             O2::TRDBase
+                                             O2::DataFormatsTRD
+                                             O2::DetectorsRaw
+                                             O2::DataFormatsCTP)
 
 o2_target_root_dictionary(TRDSimulation
                           HEADERS include/TRDSimulation/Detector.h

--- a/Detectors/TRD/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/TRD/workflow/src/EntropyDecoderSpec.cxx
@@ -18,6 +18,7 @@
 #include "Framework/CCDBParamSpec.h"
 #include "TRDWorkflow/EntropyDecoderSpec.h"
 #include "TRDReconstruction/CTFCoder.h"
+#include "DataFormatsCTP/TriggerOffsetsParam.h"
 #include <TStopwatch.h>
 
 using namespace o2::framework;
@@ -39,6 +40,7 @@ class EntropyDecoderSpec : public o2::framework::Task
 
  private:
   o2::trd::CTFCoder mCTFCoder;
+  int mIRShift = 0;
   TStopwatch mTimer;
 };
 
@@ -59,6 +61,10 @@ void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matche
 void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
 {
   mCTFCoder.init<CTF>(ic);
+  if (ic.options().get<bool>("correct-trd-trigger-offset")) {
+    mCTFCoder.setBCShift(o2::ctp::TriggerOffsetsParam::Instance().LM_L0);
+    LOGP(info, "Decoded IRs will be corrected by -{} BCs, discarded if become prior to 1st orbit", o2::ctp::TriggerOffsetsParam::Instance().LM_L0);
+  }
 }
 
 void EntropyDecoderSpec::run(ProcessingContext& pc)
@@ -77,6 +83,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   // since the buff is const, we cannot use EncodedBlocks::relocate directly, instead we wrap its data to another flat object
   if (buff.size()) {
     const auto ctfImage = o2::trd::CTF::getImage(buff.data());
+    mCTFCoder.setFirstTFOrbit(pc.services().get<o2::framework::TimingInfo>().firstTFOrbit);
     iosize = mCTFCoder.decode(ctfImage, triggers, tracklets, digits);
   }
   pc.outputs().snapshot({"ctfrep", 0}, iosize);
@@ -107,7 +114,8 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
     inputs,
     outputs,
     AlgorithmSpec{adaptFromTask<EntropyDecoderSpec>(verbosity)},
-    Options{{"ctf-dict", VariantType::String, "ccdb", {"CTF dictionary: empty or ccdb=CCDB, none=no external dictionary otherwise: local filename"}}}};
+    Options{{"ctf-dict", VariantType::String, "ccdb", {"CTF dictionary: empty or ccdb=CCDB, none=no external dictionary otherwise: local filename"}},
+            {"correct-trd-trigger-offset", VariantType::Bool, false, {"Correct decoded IR by TriggerOffsetsParam::LM_L0"}}}};
 }
 
 } // namespace trd


### PR DESCRIPTION
* CPV decoder: finaliseCCDB must be the method of the DPL task
* Apply LM_L0 shift in TRD digi2raw
* TRD decoder accepts configKeyValues + fetches CTP/Config/TriggerOffsets
*  TRD ctf decoder: with --correct-trd-trigger-offset correct for LM_L0 shift
to be used with the CTFs which were not corrected at the raw date decoding level