### PR TITLE
TRD fix tracklethcheader in mc to raw

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
@@ -133,7 +133,7 @@ struct TrackletHCHeader {
     //             |   |              |    |  |  |---  1-3  stack
     //             |   |              |    |  |------  4-6  layer
     //             |   |              |    |--------  7-11 sector
-    //             |   |              |------------- 12 always 0
+    //             |   |              |------------- 12 always 1
     //             |   ----------------------------- 13-27 MCM Clock counter
     //             --------------------------------- 28-31 tracklet data format number
     uint32_t word;
@@ -496,6 +496,7 @@ bool sanityCheckTrackletHCHeader(o2::trd::TrackletHCHeader& header, bool verbose
 bool sanityCheckDigitMCMHeader(o2::trd::DigitMCMHeader* header);
 bool sanityCheckDigitMCMADCMask(o2::trd::DigitMCMADCMask& mask, int numberofbitsset);
 bool sanityCheckDigitMCMWord(o2::trd::DigitMCMData* word, int adcchannel);
+void incrementADCMask(DigitMCMADCMask& mask, int channel);
 void printDigitMCMHeader(o2::trd::DigitMCMHeader& header);
 int getDigitHCHeaderWordType(uint32_t word);
 void printDigitHCHeaders(o2::trd::DigitHCHeader& header, uint32_t headers[3], int index, int offset, bool good);
@@ -504,7 +505,7 @@ int getNumberOfTrackletsFromHeader(o2::trd::TrackletMCMHeader* header, bool verb
 void setNumberOfTrackletsInHeader(o2::trd::TrackletMCMHeader& header, int numberoftracklets);
 int getNextMCMADCfromBP(uint32_t& bp, int channel);
 
-inline bool isTrackletHCHeader(uint32_t& header) { return (((header >> 11) & 0x1) == 0x1); }
+inline bool isTrackletHCHeader(uint32_t& header) { return (((header >> 12) & 0x1) == 0x1); }
 inline bool isTrackletMCMHeader(uint32_t& header) { return ((header & 0x80000001) == 0x80000001); }
 }
 }

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
@@ -192,7 +192,7 @@ struct TrackletMCMData {
     struct {
       uint8_t checkbit : 1; //
       uint16_t slope : 8;   // Deflection angle of tracklet
-      uint16_t pid : 12;    // Particle Identity 7 bits of Q0 and 5 bits of Q1
+      uint16_t pid : 12;    // Particle Identity 6 bits of Q0 and 6 bits of Q1
       uint16_t pos : 11;    // Position of tracklet, signed 11 bits, granularity 1/80 pad widths, -12.80 to +12.80, relative to centre of pad 10
     } __attribute__((__packed__));
   };

--- a/DataFormats/Detectors/TRD/src/RawData.cxx
+++ b/DataFormats/Detectors/TRD/src/RawData.cxx
@@ -278,20 +278,16 @@ void constructTrackletMCMData(TrackletMCMData& trackletword, const int format, c
   trackletword.word = 0;
   // create a tracklet word as it would be sent from the FEE
   // slope and position have the 8-th bit flipped each
-  trackletword.word = 0;
   trackletword.slope = slope ^ 0x80;
   trackletword.pos = pos ^ 0x80;
   trackletword.checkbit = 0;
   if (format & 0x1) {
-    //length of q1 and q2 are 6 with a 2 bit offset.
-    //What happens when q2 and q1 dont share the same offset (upper 2 bits ?) ?
-    LOG(error) << "This tracklet format has not been tested yet";
-    trackletword.pid = (q0 & 0x3f) & ((q1 & 0x1) << 6);
-    //TODO check the 2 bit offset is still valid ... ??
+    //length of q1 and q2 are 6 with a 2 bit offset sitting in the header.
+    trackletword.pid = (q0 & 0x3f) | ((q1 & 0x3f) << 6);
   } else {
-    trackletword.pid = (q0 & 0x3f) & ((q1 & 0x1) << 6);
+    //q2 sits with upper 1 bit of q1 in the header pid word, hence the 0x3f so 6 bits of q1 are used here, shifted up above the 6 bits of q0.
+    trackletword.pid = (int)(q0 & 0x3f) | ((q1 & 0x3f) << 6);
   }
-  //q2 sits with upper 2 bits of q1 in the header pid word, hence the 0x1f so 5 bits are used here.
 }
 
 void constructTrackletMCMData(TrackletMCMData& trackletword, const Tracklet64& tracklet)
@@ -319,7 +315,7 @@ void printTrackletHCHeader(o2::trd::TrackletHCHeader& halfchamber)
 
 void printTrackletMCMData(o2::trd::TrackletMCMData& tracklet)
 {
-  LOGF(info, "TrackletMCMData: Raw:0x%08x pos:%d slope:%d pid:0x%08x checkbit:0x%02x",
+  LOGF(info, "TrackletMCMData: Raw:0x%08x pos:%d slope:%d pid:0x%03x checkbit:0x%02x",
        tracklet.word, tracklet.pos, tracklet.slope, tracklet.pid, tracklet.checkbit);
 }
 void printTrackletMCMHeader(o2::trd::TrackletMCMHeader& mcmhead)

--- a/DataFormats/Detectors/TRD/src/RawData.cxx
+++ b/DataFormats/Detectors/TRD/src/RawData.cxx
@@ -33,10 +33,10 @@ namespace trd
 std::ostream& operator<<(std::ostream& stream, const TrackletHCHeader halfchamberheader)
 {
   stream << "TrackletHCHeader : Raw:0x" << std::hex << halfchamberheader.word << " "
-         << halfchamberheader.format << " ;; " << halfchamberheader.MCLK << " :: "
-         << halfchamberheader.one << " :: (" << halfchamberheader.supermodule << ","
-         << halfchamberheader.stack << "," << halfchamberheader.layer << ") on side :"
-         << halfchamberheader.side << std::endl;
+         << (int)halfchamberheader.format << " ;; " << (int)halfchamberheader.MCLK << " :: "
+         << halfchamberheader.one << " :: (" << (int)halfchamberheader.supermodule << ","
+         << (int)halfchamberheader.stack << "," << (int)halfchamberheader.layer << ") on side :"
+         << (int)halfchamberheader.side << std::endl;
   return stream;
 }
 
@@ -152,14 +152,13 @@ std::ostream& operator<<(std::ostream& stream, const HalfCRUHeader& halfcru)
 void constructTrackletHCHeader(TrackletHCHeader& header, int sector, int stack, int layer, int side, int chipclock, int format)
 {
   header.word = 0;
-
   header.format = format;
   header.supermodule = ~sector;
   header.stack = ~stack;
   header.layer = ~layer;
   header.side = ~side;
   header.MCLK = chipclock;
-  header.one = 0;
+  header.one = 1;
 }
 
 void constructTrackletHCHeaderd(TrackletHCHeader& header, int detector, int rob, int chipclock, int format)
@@ -315,7 +314,7 @@ DigitMCMADCMask constructBlankADCMask()
 void printTrackletHCHeader(o2::trd::TrackletHCHeader& halfchamber)
 {
   LOGF(info, "TrackletHCHeader: Raw:0x%08x SM : %d stack %d layer %d side : %d MCLK: 0x%0x Format: 0x%0x Always1:0x%0x",
-       halfchamber.supermodule, halfchamber.stack, halfchamber.layer, halfchamber.side, halfchamber.MCLK, halfchamber.format, halfchamber.one);
+       halfchamber.word, (int)(~halfchamber.supermodule) & 0x1f, (int)(~halfchamber.stack) & 0x7, (int)(~halfchamber.layer) & 0x7, (int)(~halfchamber.side) & 0x1, (int)halfchamber.MCLK, (int)halfchamber.format, (int)halfchamber.one);
 }
 
 void printTrackletMCMData(o2::trd::TrackletMCMData& tracklet)
@@ -496,6 +495,14 @@ bool sanityCheckDigitMCMADCMask(o2::trd::DigitMCMADCMask& mask, int numberofbits
     goodadcmask = false;
   }
   return goodadcmask;
+}
+
+void incrementADCMask(DigitMCMADCMask& mask, int channel)
+{
+  mask.adcmask |= 1UL << channel;
+  int bitcount = (~mask.c) & 0x1f;
+  bitcount++;
+  mask.c = ~((bitcount)&0x1f);
 }
 
 bool sanityCheckDigitMCMWord(o2::trd::DigitMCMData* word, int adcchannel)

--- a/DataFormats/Detectors/TRD/src/RawData.cxx
+++ b/DataFormats/Detectors/TRD/src/RawData.cxx
@@ -486,7 +486,7 @@ bool sanityCheckDigitMCMADCMask(o2::trd::DigitMCMADCMask& mask, int numberofbits
   count = (~count) & 0x1f;
   if (count != numberofbitsset) {
     goodadcmask=false;
-    LOG(warn) << "***DigitMCMADCMask bad bit count maskcount:" << ~mask.c << "::" << mask.c << " bitscounting:" << numberofbitsset << " bp: 0x" << std::hex << mask.adcmask;
+    LOG(info) << "***DigitMCMADCMask bad bit count maskcount:" << ((~mask.c) & 0x1f) << " bitscounting:" << numberofbitsset << " bp: 0x" << std::hex << mask.adcmask;
   }
   if (mask.n != 0x1) {
     goodadcmask = false;

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/DataReaderTask.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/DataReaderTask.h
@@ -76,9 +76,9 @@ class DataReaderTask : public Task
   std::string mHistogramsFilename; // filename to use for histograms.
   o2::header::DataDescription mUserDataDescription = o2::header::gDataDescriptionInvalid; // alternative user-provided description to pick
   bool mFixDigitEndCorruption{false};                                                     // fix the parsing of corrupt end of digit data. bounce over it.
-  o2::trd::TRDDataCountersPerTimeFrame mTimeFrameStats;                                   // TODO for compressed data this is going to come in for each subtimeframe
-                                                                                          // and we need to collate them.
-
+  o2::trd::TRDDataCountersPerTimeFrame mTimeFrameStats;                                   // TODO for compressed data this is going to come in for each subtimeframe and we need to collate them.
+  uint64_t mDigitPreviousTotal;                                                           // store the previous timeframes totals for tracklets and digits, to be able to get a diferential total
+  uint64_t mTrackletsPreviousTotal;
 };
 
 } // namespace o2::trd

--- a/Detectors/TRD/reconstruction/src/CruRawReader.cxx
+++ b/Detectors/TRD/reconstruction/src/CruRawReader.cxx
@@ -462,9 +462,15 @@ int CruRawReader::parseDigitHCHeader()
           return -1;
         }
         if (mDigitHCHeader1.ptrigphase > 11) {
-          LOG(alarm) << "Digit HC Header 1 Pretrigger phase is out of bounds : 0x" << std::hex << mDigitHCHeader1.ptrigphase << " raw: 0x" << mDigitHCHeader1.word;
+          //TODO figure out why 0xe happens more than it should. If I leave this in the shifters will be panicing.
+          //This does not appear to be true, its false positive too many times
+          //  LOG(alarm) << "Digit HC Header 1 Pretrigger phase is out of bounds : 0x" << std::hex << mDigitHCHeader1.ptrigphase << " raw: 0x" << mDigitHCHeader1.word;
+          if (mVerbose) {
+            // leave the error in for not running online.
+            LOG(alarm) << "Digit HC Header 1 Pretrigger phase is out of bounds : 0x" << std::hex << mDigitHCHeader1.ptrigphase << " raw: 0x" << mDigitHCHeader1.word;
+          }
           incrementErrors(TRDParsingDigitHCHeaderPreTriggerPhaseOOB);
-          return -1;
+          //  return -1;
         }
         mTimeBins = mDigitHCHeader1.numtimebins;
         if (mTimeBins < 1 && mTimeBins > o2::trd::constants::TIMEBINS) {

--- a/Detectors/TRD/reconstruction/src/DataReader.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReader.cxx
@@ -100,7 +100,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   binaryoptions[o2::trd::TRDIgnoreTrackletHCHeaderBit] = cfgc.options().get<bool>("ignore-tracklethcheader");
   binaryoptions[o2::trd::TRDEnableRootOutputBit] = cfgc.options().get<bool>("enable-root-output");
   binaryoptions[o2::trd::TRDByteSwapBit] = cfgc.options().get<bool>("trd-datareader-enablebyteswapdata");
-  binaryoptions[o2::trd::TRDFixSM1617Bit] = cfgc.options().get<bool>("fixsm1617");
+  //binaryoptions[o2::trd::TRDFixSM1617Bit] = cfgc.options().get<bool>("fixsm1617");
   binaryoptions[o2::trd::TRDIgnore2StageTrigger] = cfgc.options().get<bool>("fixforoldtrigger");
   //binaryoptions[o2::trd::TRDGenerateStats] = cfgc.options().get<bool>("generate-stats");
   binaryoptions[o2::trd::TRDGenerateStats] = true; //cfgc.options().get<bool>("generate-stats");

--- a/Detectors/TRD/simulation/src/Trap2CRU.cxx
+++ b/Detectors/TRD/simulation/src/Trap2CRU.cxx
@@ -495,7 +495,7 @@ int Trap2CRU::buildTrackletRawData(const int trackletindex, const int linkid)
   while (linkid == HelperMethods::getLinkIDfromHCID(mTracklets[trackletindex + trackletcounter].getHCID()) && header.col == mTracklets[trackletindex + trackletcounter].getColumn() && header.padrow == mTracklets[trackletindex + trackletcounter].getPadRow()) {
     int trackletoffset = trackletindex + trackletcounter;
     constructTrackletMCMData(trackletdata[trackletcounter], mTracklets[trackletoffset]);
-    unsigned int headerqpart = ((mTracklets[trackletoffset].getQ2() & 0x2f) << 2) + ((mTracklets[trackletoffset].getQ1() >> 6) & 0x3);
+    unsigned int headerqpart = ((mTracklets[trackletoffset].getQ2() & 0x7f) << 1) + ((mTracklets[trackletoffset].getQ1() >> 6) & 0x3);
     //all 6 bits of Q1 and 2 upper bits of 7bit Q1
     if (mVerbosity) {
       if (mTracklets[trackletoffset].getQ2() > 0x3f) {
@@ -539,13 +539,15 @@ int Trap2CRU::buildTrackletRawData(const int trackletindex, const int linkid)
     setNumberOfTrackletsInHeader(header, trackletcounter);
     if (trackletcounter > 0) { // dont write header if there are no tracklets.
       if (mVerbosity) {
-        LOG(info) << " TTT TrackletMCMHeader : 0x" << std::hex << header;
+        LOG(info) << " TTT TrackletMCMHeader : 0x" << std::hex << header << " pid : " << header.pid0 << " pid1: " << header.pid1;
+        printTrackletMCMHeader(header);
       }
       memcpy((char*)mRawDataPtr, (char*)&header, sizeof(TrackletMCMHeader));
       mRawDataPtr += sizeof(TrackletMCMHeader);
       for (int i = 0; i < trackletcounter; ++i) {
         if (mVerbosity) {
           LOG(info) << " TTTx TrackletMCMData : 0x" << std::hex << trackletdata[i];
+          printTrackletMCMData(trackletdata[i]);
         }
         memcpy((char*)mRawDataPtr, (char*)&trackletdata[i], sizeof(TrackletMCMData));
         mRawDataPtr += sizeof(TrackletMCMData);


### PR DESCRIPTION
- the parser is now very strict on the tracklethcheader causing a lot of the tracklets to be rejected.
- mc to raw now uses the methods in rawdata.cxx to construct the tracklethcheader correctly.

- remove option for fixsm1617
- fix pid in mc to raw to reconstruction
- change level of some error messages, bad adc mask seems to appear rather often, now info message.
- fix the construction of adcmasks in the mc to raw.
- remove the strict limit on pretrigger phase, it is above 11 far too often, code is still there and the parsing error graph updated for now.
