### PR TITLE
[EMCAL-561] Port run2/3 trigger mapping to O2

### DIFF
--- a/Detectors/EMCAL/base/CMakeLists.txt
+++ b/Detectors/EMCAL/base/CMakeLists.txt
@@ -10,41 +10,43 @@
 # or submit itself to any jurisdiction.
 
 o2_add_library(EMCALBase
-               SOURCES src/Geometry.cxx src/Hit.cxx
-                       src/ShishKebabTrd1Module.cxx
-                       src/Mapper.cxx
-                       src/RCUTrailer.cxx
-                       src/ClusterFactory.cxx
-               PUBLIC_LINK_LIBRARIES O2::CommonDataFormat O2::Headers Boost::serialization
-                                     O2::MathUtils O2::DataFormatsEMCAL
-                                     O2::SimulationDataFormat ROOT::Physics)
+        SOURCES src/Geometry.cxx src/Hit.cxx
+        src/ShishKebabTrd1Module.cxx
+        src/Mapper.cxx
+        src/RCUTrailer.cxx
+        src/ClusterFactory.cxx
+        src/TriggerMappingV2.cxx
+        PUBLIC_LINK_LIBRARIES O2::CommonDataFormat O2::Headers Boost::serialization
+        O2::MathUtils O2::DataFormatsEMCAL
+        O2::SimulationDataFormat ROOT::Physics)
 
 o2_target_root_dictionary(EMCALBase
-                          HEADERS include/EMCALBase/GeometryBase.h
-                                  include/EMCALBase/Geometry.h
-                                  include/EMCALBase/Hit.h
-                                  include/EMCALBase/ShishKebabTrd1Module.h
-                                  include/EMCALBase/Mapper.h
-                                  include/EMCALBase/RCUTrailer.h
-                                  include/EMCALBase/ClusterFactory.h
-                                  )
+        HEADERS include/EMCALBase/GeometryBase.h
+        include/EMCALBase/Geometry.h
+        include/EMCALBase/Hit.h
+        include/EMCALBase/ShishKebabTrd1Module.h
+        include/EMCALBase/Mapper.h
+        include/EMCALBase/RCUTrailer.h
+        include/EMCALBase/TriggerMappingV2.h
+        include/EMCALBase/ClusterFactory.h
+)
 
 o2_data_file(COPY files DESTINATION Detectors/EMC)
 
 o2_add_test(Mapper
-            SOURCES test/testMapper.cxx
-            PUBLIC_LINK_LIBRARIES O2::EMCALBase
-            COMPONENT_NAME emcal
-            LABELS emcal
-            ENVIRONMENT O2_ROOT=${CMAKE_BINARY_DIR}/stage)
+        SOURCES test/testMapper.cxx
+        PUBLIC_LINK_LIBRARIES O2::EMCALBase
+        COMPONENT_NAME emcal
+        LABELS emcal
+        ENVIRONMENT O2_ROOT=${CMAKE_BINARY_DIR}/stage)
 
 o2_add_test(RCUTrailer
-            SOURCES test/testRCUTrailer.cxx
-            PUBLIC_LINK_LIBRARIES O2::EMCALBase
-            COMPONENT_NAME emcal
-            LABELS emcal
-            ENVIRONMENT O2_ROOT=${CMAKE_BINARY_DIR}/stage)
-            
+        SOURCES test/testRCUTrailer.cxx
+        PUBLIC_LINK_LIBRARIES O2::EMCALBase
+        COMPONENT_NAME emcal
+        LABELS emcal
+        ENVIRONMENT O2_ROOT=${CMAKE_BINARY_DIR}/stage)
+
 o2_add_test_root_macro(test/testGeometryRowColIndexing.C
-            PUBLIC_LINK_LIBRARIES O2::EMCALBase
-            LABELS emcal)
+        PUBLIC_LINK_LIBRARIES O2::EMCALBase
+        LABELS emcal)

--- a/Detectors/EMCAL/base/include/EMCALBase/GeometryBase.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/GeometryBase.h
@@ -42,10 +42,10 @@ class InvalidModuleException final : public std::exception
   /// \brief Constructor
   /// \param nModule Module number raising the exception
   /// \param nMax Maximum amount of modules in setup
-  InvalidModuleException(Int_t nModule, Int_t nMax) : std::exception(),
-                                                      mModule(nModule),
-                                                      mMax(nMax),
-                                                      mMessage("Invalid Module [ " + std::to_string(mModule) + "|" + std::to_string(mMax) + "]")
+  InvalidModuleException(int nModule, int nMax) : std::exception(),
+                                                  mModule(nModule),
+                                                  mMax(nMax),
+                                                  mMessage("Invalid Module [ " + std::to_string(mModule) + "|" + std::to_string(mMax) + "]")
   {
   }
 
@@ -65,8 +65,8 @@ class InvalidModuleException final : public std::exception
   const char* what() const noexcept final { return mMessage.c_str(); }
 
  private:
-  Int_t mModule;        ///< Module ID raising the exception
-  Int_t mMax;           ///< Max. Number of modules
+  int mModule;          ///< Module ID raising the exception
+  int mMax;             ///< Max. Number of modules
   std::string mMessage; ///< Error message
 };
 
@@ -115,9 +115,9 @@ class InvalidCellIDException final : public std::exception
  public:
   /// \brief Constructor, setting cell ID raising the exception
   /// \param cellID Cell ID raising the exception
-  InvalidCellIDException(Int_t cellID) : std::exception(),
-                                         mCellID(cellID),
-                                         mMessage("Cell ID " + std::to_string(mCellID) + " outside limits.")
+  InvalidCellIDException(int cellID) : std::exception(),
+                                       mCellID(cellID),
+                                       mMessage("Cell ID " + std::to_string(mCellID) + " outside limits.")
   {
   }
 
@@ -126,14 +126,14 @@ class InvalidCellIDException final : public std::exception
 
   /// \brief Access to cell ID raising the exception
   /// \return Cell ID
-  Int_t getCellID() const noexcept { return mCellID; }
+  int getCellID() const noexcept { return mCellID; }
 
   /// \brief Access to error message of the exception
   /// \return Error message
   const char* what() const noexcept final { return mMessage.data(); }
 
  private:
-  Int_t mCellID;        ///< Cell ID raising the exception
+  int mCellID;          ///< Cell ID raising the exception
   std::string mMessage; ///< error Message
 };
 

--- a/Detectors/EMCAL/base/include/EMCALBase/TriggerMappingErrors.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/TriggerMappingErrors.h
@@ -1,0 +1,310 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_EMCAL_TRIGGERMAPPINGERRORS_H
+#define ALICEO2_EMCAL_TRIGGERMAPPINGERRORS_H
+
+#include <exception>
+#include <string>
+
+namespace o2
+{
+
+namespace emcal
+{
+
+/// \class TRUIndexException
+/// \brief Error handling of faulty TRU indices
+/// \ingroup EMCALbase
+class TRUIndexException : public std::exception
+{
+ public:
+  /// \brief Constructor
+  /// \param truindex Index of the TRU
+  TRUIndexException(unsigned int truindex) : std::exception(), mTRUIndex(truindex), mErrorMessage()
+  {
+    mErrorMessage = "Invalid TRU Index: " + std::to_string(truindex);
+  }
+
+  /// \brief Destructor
+  ~TRUIndexException() noexcept final = default;
+
+  /// \brief Get error message
+  /// \return Error message of the exception
+  const char* what() const noexcept final
+  {
+    return mErrorMessage.data();
+  }
+
+  /// \brief Get the index of the TRU raising the exception
+  /// \return Index of the TRU
+  unsigned int getTRUIndex() const noexcept { return mTRUIndex; }
+
+ private:
+  std::string mErrorMessage; ///< Buffer for the error message
+  unsigned int mTRUIndex;    ///< Index of the TRU
+};
+
+/// \class FastORIndexException
+/// \brief Error handling of faulty FastOR indices
+/// \ingroup EMCALbase
+class FastORIndexException : public std::exception
+{
+ public:
+  /// \brief Constructor
+  /// \param fastorindex Index of the FastOR
+  FastORIndexException(unsigned int fastorindex) : std::exception(), mFastORIndex(fastorindex), mErrorMessage()
+  {
+    mErrorMessage = "Invalid FastOR Index: " + std::to_string(fastorindex);
+  }
+
+  /// \brief Destructor
+  ~FastORIndexException() noexcept final = default;
+
+  /// \brief Get error message
+  /// \return Error message of the exception
+  const char* what() const noexcept final
+  {
+    return mErrorMessage.data();
+  }
+
+  /// \brief Get the index of the FastOR raising the exception
+  /// \return Index of the FastOR
+  unsigned int getFastORIndex() const noexcept { return mFastORIndex; }
+
+ private:
+  std::string mErrorMessage; ///< Buffer for the error message
+  unsigned int mFastORIndex; ///< Index of the FastOR
+};
+
+/// \class FastORPositionExceptionTRU
+/// \brief Handling of invalid positions of a FastOR within a TRU
+/// \ingroup EMCALbase
+class FastORPositionExceptionTRU : public std::exception
+{
+ public:
+  /// \brief Constructor
+  /// \param truID Index of the TRU
+  /// \param etaColumn Column of the FastOR with the faulty position in eta direction
+  /// \param phiRow Row of the FastOR with the faulty position in row direction
+  FastORPositionExceptionTRU(unsigned int truID, unsigned int etaColumn, unsigned int phiRow) : std::exception(),
+                                                                                                mErrorMessage(),
+                                                                                                mTRUID(truID),
+                                                                                                mEtaColumn(etaColumn),
+                                                                                                mPhiRow(phiRow)
+  {
+    mErrorMessage = "Invalid FastOR position in TRU " + std::to_string(truID) + ": eta = " + std::to_string(etaColumn) + ", phi = " + std::to_string(phiRow) + ")";
+  }
+
+  /// \brief Destructor
+  ~FastORPositionExceptionTRU() noexcept final = default;
+
+  /// \brief Get error message
+  /// \return Error message of the exception
+  const char* what() const noexcept final
+  {
+    return mErrorMessage.data();
+  }
+
+  /// \brief Get the TRU ID for which the position is invalid
+  /// \return TRU ID
+  unsigned int getTRUID() const noexcept { return mTRUID; }
+
+  /// \brief Get the column in eta of the FastOR with the invalid position
+  /// \return Column of the FastOR
+  unsigned int getFastOREtaColumn() const noexcept { return mEtaColumn; }
+
+  /// \brief Get the row in phi of the FastOR with the invalid position
+  /// \return Row of the FastOR
+  unsigned int getFastORPhiRow() const noexcept { return mPhiRow; }
+
+ private:
+  std::string mErrorMessage; ///< Buffer for the error message
+  unsigned int mTRUID;       ///< ID of the TRU
+  unsigned int mEtaColumn;   ///< Column of the FastOR in eta direction
+  unsigned int mPhiRow;      ///< Row of the FastOR in phi direction
+};
+
+/// \class FastORPositionExceptionSupermodule
+/// \brief Handling of invalid positions of a FastOR within a supermodule
+/// \ingroup EMCALbase
+class FastORPositionExceptionSupermodule : public std::exception
+{
+ public:
+  /// \brief Constructor
+  /// \param supermoduleID Index of the supermodule
+  /// \param etaColumn Column of the FastOR with the faulty position in eta direction
+  /// \param phiRow Row of the FastOR with the faulty position in row direction
+  FastORPositionExceptionSupermodule(unsigned int supermoduleID, unsigned int etaColumn, unsigned int phiRow) : std::exception(),
+                                                                                                                mErrorMessage(),
+                                                                                                                mSupermoduleID(supermoduleID),
+                                                                                                                mEtaColumn(etaColumn),
+                                                                                                                mPhiRow(phiRow)
+  {
+    mErrorMessage = "Invalid FastOR position in supermodule " + std::to_string(supermoduleID) + ": eta = " + std::to_string(etaColumn) + ", phi = " + std::to_string(phiRow) + ")";
+  }
+
+  /// \brief Destructor
+  ~FastORPositionExceptionSupermodule() noexcept final = default;
+
+  /// \brief Get error message
+  /// \return Error message of the exception
+  const char* what() const noexcept final
+  {
+    return mErrorMessage.data();
+  }
+
+  /// \brief Get the supermodule ID for which the position is invalid
+  /// \return Supermodule ID
+  unsigned int getSupermoduleID() const noexcept { return mSupermoduleID; }
+
+  /// \brief Get the column in eta of the FastOR with the invalid position
+  /// \return Column of the FastOR
+  unsigned int getFastOREtaColumn() const noexcept { return mEtaColumn; }
+
+  /// \brief Get the row in phi of the FastOR with the invalid position
+  /// \return Row of the FastOR
+  unsigned int getFastORPhiRow() const noexcept { return mPhiRow; }
+
+ private:
+  std::string mErrorMessage;   ///< Buffer for error message
+  unsigned int mSupermoduleID; ///< ID of the supermodule
+  unsigned int mEtaColumn;     ///< Column of the FastOR in eta direction
+  unsigned int mPhiRow;        ///< Row of the FastOR in phi direction
+};
+
+/// \class FastORPositionExceptionEMCAL
+/// \brief Handling of invalid positions of a FastOR in the detector
+/// \ingroup EMCALbase
+class FastORPositionExceptionEMCAL : public std::exception
+{
+ public:
+  /// \brief Constructor
+  /// \param etaColumn Column of the FastOR with the faulty position in eta direction
+  /// \param phiRow Row of the FastOR with the faulty position in row direction
+  FastORPositionExceptionEMCAL(unsigned int etaColumn, unsigned int phiRow) : std::exception(), mErrorMessage(), mEtaColumn(etaColumn), mPhiRow(phiRow)
+  {
+    mErrorMessage = "Invalid FastOR position: eta = " + std::to_string(etaColumn) + ", phi = " + std::to_string(phiRow) + ")";
+  }
+
+  /// \brief Destructor
+  ~FastORPositionExceptionEMCAL() noexcept final = default;
+
+  /// \brief Get error message
+  /// \return Error message of the exception
+  const char* what() const noexcept final
+  {
+    return mErrorMessage.data();
+  }
+
+  /// \brief Get the column in eta of the FastOR with the invalid position
+  /// \return Column of the FastOR
+  unsigned int getFastOREtaColumn() const noexcept { return mEtaColumn; }
+
+  /// \brief Get the row in phi of the FastOR with the invalid position
+  /// \return Row of the FastOR
+  unsigned int getFastORPhiRow() const noexcept { return mPhiRow; }
+
+ private:
+  std::string mErrorMessage; ///< Buffer for error message
+  unsigned int mEtaColumn;   ///< Column of the FastOR in eta direction
+  unsigned int mPhiRow;      ///< Row of the FastOR in phi direction
+};
+
+/// \class PHOSRegionException
+/// \brief Handling of invalid PHOS regions
+/// \ingroup EMCALbase
+class PHOSRegionException : public std::exception
+{
+ public:
+  /// \brief Constructor
+  /// \param phosregion Index of the PHOS region
+  PHOSRegionException(unsigned int phosregion) : std::exception(), mErrorMessage(), mPHOSRegion(phosregion)
+  {
+    mErrorMessage = "Invalid PHOS region: " + std::to_string(phosregion);
+  }
+
+  /// \brief Destructor
+  ~PHOSRegionException() noexcept final = default;
+
+  /// \brief Get error message
+  /// \return Error message of the exception
+  const char* what() const noexcept final
+  {
+    return mErrorMessage.data();
+  }
+
+  /// \brief Get index of the PHOS region
+  /// \return PHOS region index
+  unsigned int getPHOSRegion() const noexcept { return mPHOSRegion; }
+
+ private:
+  std::string mErrorMessage; ///< Buffer for error message
+  unsigned int mPHOSRegion;  ///< PHOS region
+};
+
+/// \class GeometryNotSetException
+/// \brief Handling cases where the geometry is required but not defined
+/// \ingroup EMCALbase
+class GeometryNotSetException : public std::exception
+{
+ public:
+  /// \brief Constructor
+  GeometryNotSetException() = default;
+
+  /// \brief Destructor
+  ~GeometryNotSetException() noexcept final = default;
+
+  /// \brief Access to error message
+  /// \return Error message
+  const char* what() const noexcept final
+  {
+    return "Geometry not available";
+  }
+};
+
+/// \class L0sizeInvalidException
+/// \brief Handlig access of L0 index mapping with invalid patch size
+/// \ingroup EMCALbase
+class L0sizeInvalidException : public std::exception
+{
+ public:
+  /// \brief Constructor
+  /// \param l0size Size of the L0 patch
+  L0sizeInvalidException(unsigned int l0size) : std::exception(), mErrorMessage(), mL0size(l0size)
+  {
+    mErrorMessage = "L0 patch size invalid: " + std::to_string(l0size);
+  }
+
+  /// \brief Destructor
+  ~L0sizeInvalidException() noexcept final = default;
+
+  /// \brief Access to error message
+  /// \return Error message
+  const char* what() const noexcept final
+  {
+    return mErrorMessage.data();
+  }
+
+  /// \brief Get the size of the L0 patch
+  /// \return Size of the L0 patch
+  unsigned int getL0size() const noexcept { return mL0size; }
+
+ private:
+  std::string mErrorMessage; ///< Buffer for error message
+  unsigned int mL0size;      ///< Size of the L0 patch
+};
+
+} // namespace emcal
+
+} // namespace o2
+
+#endif //  ALICEO2_EMCAL_TRIGGERMAPPINGERRORS_H

--- a/Detectors/EMCAL/base/include/EMCALBase/TriggerMappingV2.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/TriggerMappingV2.h
@@ -1,0 +1,462 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef ALICEO2_EMCAL_TRIGGERMAPPINGV2_H_
+#define ALICEO2_EMCAL_TRIGGERMAPPINGV2_H_
+
+#include <array>
+#include <bitset>
+#include <tuple>
+#include "EMCALBase/GeometryBase.h"
+
+namespace o2
+{
+namespace emcal
+{
+
+class Geometry;
+
+/// \class TriggerMappingV2
+/// \brief Trigger mapping starting from Run2
+/// \ingroup EMCALbase
+/// \author H. YOKOYAMA Tsukuba University
+/// \author R. GUERNANE LPSC Grenoble CNRS/IN2P3
+/// \author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
+class TriggerMappingV2
+{
+ public:
+  //********************************************
+  // static constant
+  //********************************************
+  static constexpr unsigned int SUPERMODULES = 20;                                                    ///< Total number of supermodules in EMCAL
+  static constexpr unsigned int ALLTRUS = 52;                                                         ///< Total number of TRUs in EMCAL
+  static constexpr unsigned int FASTORSETATRU = 8;                                                    ///< Number of FastOR/TRU in Eta
+  static constexpr unsigned int FASTORSPHITRU = 12;                                                   ///< Number of FastOR/TRU in Phi
+  static constexpr unsigned int FASTORSTRU = FASTORSETATRU * FASTORSPHITRU;                           ///< Number of FastOR/TRU
+  static constexpr unsigned int TRUSETASM = 3;                                                        ///< Number of TRUs/SM in Eta
+  static constexpr unsigned int TRUSPHISM = 1;                                                        ///< Number of TRUs/SM in Phi
+  static constexpr unsigned int TRUSSUPERMODULE = TRUSETASM * TRUSPHISM;                              ///< Number of TRUs/SM
+  static constexpr unsigned int FASTORSETASM = FASTORSETATRU * TRUSETASM;                             ///< Number of FastOR/SM in Eta
+  static constexpr unsigned int FASTORSPHISM = FASTORSPHITRU * TRUSPHISM;                             ///< Number of FastOR/SM in Phi
+  static constexpr unsigned int FASTORSETA = 2 /*Aside,Cside*/ * FASTORSETASM;                        ///< EMCAL+DCAL region eta size
+  static constexpr unsigned int FASTORSPHI = (5 * FASTORSPHISM) + (1 * FASTORSPHISM / 3)              /*EMCAL*/
+                                             + (3 * FASTORSPHISM) + (1 * FASTORSPHISM / 3) /*DCAL */; ///< Number of FastOR/EMCALs in Phi
+  static constexpr unsigned int ALLFASTORS = FASTORSETA * FASTORSPHI;                                 ///< Number of FastOR/EMCALs
+
+  //********************************************
+  // Index types
+  //********************************************
+  using IndexTRU = unsigned int;
+  using IndexSTU = unsigned int;
+  using IndexSupermodule = unsigned int;
+  using IndexFastOR = unsigned int;
+  using IndexCell = unsigned int;
+  using IndexColumnEta = unsigned int;
+  using IndexRowPhi = unsigned int;
+  using IndexOnline = unsigned int;
+
+  /// \enum DetType_t
+  /// \brief Calorimeter type
+  enum class DetType_t {
+    DET_EMCAL,
+    DET_DCAL
+  };
+
+  /// \brief Default constructor.
+  TriggerMappingV2();
+
+  /// \brief Default constructor.
+  TriggerMappingV2(Geometry* geo);
+
+  /// \brief Destructor
+  ~TriggerMappingV2() = default;
+
+  //********************************************
+  // Get FastOR index from TRU/SM/EMCAL Geometry
+  //********************************************
+
+  /// \brief Get the absolute index of the FastOr from the index in the TRU
+  /// \param truIndex Index of the TRU in the TRU numbering scheme
+  /// \param positionInTRU Channel index within the TRU
+  /// \return Absolute ID of the FastOR
+  /// \throw TRUIndexExcepiton in case of invalid TRU index
+  /// \throw FastORIndexException in case of invalid position in TRU
+  ///
+  /// Calculating the absolute ID of the FastOR which is a unique
+  /// index of a FastOR. It is calcuated as phi + eta * NPhi, added
+  /// to sum of FastORs in the TRUs with smaller TRU index.
+  IndexFastOR getAbsFastORIndexFromIndexInTRU(IndexTRU truIndex, IndexFastOR fastorIndexTRU) const;
+
+  /// \brief Get the absolute index of the FastOr from geometric position in TRU
+  /// \param truIndex Index of the TRU in the TRU numbering scheme
+  /// \param etaColumn Position of the channel in eta direction
+  /// \param phiRow Position of the channel in phi direction
+  /// \return Absolute ID of the FastOR
+  /// \throw TRUIndexException in case of invalid TRU indices
+  ///
+  /// Calculating the absolute ID of the FastOR which is a unique
+  /// index of a FastOR. It is calcuated as phi + eta * NPhi, added
+  /// to sum of FastORs in the TRUs with smaller TRU index.
+  IndexFastOR getAbsFastORIndexFromPositionInTRU(IndexTRU truIndex, IndexColumnEta etaColumn, IndexRowPhi phiRow) const;
+
+  /// \brief Get the absolute index of the FastOr from the geometric position in the supermodule
+  /// \param supermoduleID Supermodule index
+  /// \param etaColumn Position of the channel in eta direction
+  /// \param phiRow Position of the channel in phi direction
+  /// \return Absoulte ID of the FastOR
+  /// \throw SupermoduleIndexException in case the supermodule ID exceeds the number of supermodules
+  /// \throw FastORPositionExceptionSupermodule in case the position is within the supermodule
+  ///
+  /// Calculating the absolute ID of the FastOR which is a unique
+  /// index of a FastOR. It is calcuated as phi + eta * NPhi, added
+  /// to sum of FastORs in the TRUs with smaller TRU index.
+  IndexFastOR getAbsFastORIndexFromPositionInSupermodule(IndexSupermodule supermoduleID, IndexColumnEta etaColumn, IndexRowPhi phiRow) const;
+
+  /// \brief Get the absolute index of the FastOR from the geometric position in EMCAL
+  /// \param etaColumn Position of the channel in eta direction
+  /// \param phiRow Position of the channel in phi direction
+  /// \return Absoulte ID of the FastOR
+  /// \throw FastORPositionExceptionEMCAL in case the position is not a valid index within the EMCAL
+  ///
+  /// Calculating the absolute ID of the FastOR which is a linear number
+  /// scheme in eta and phi of the full EMCAL + DCAL surface defined as
+  /// column + 48 * row. TRU index and FastOR index are based on the TRU
+  /// numbering scheme.
+  IndexFastOR getAbsFastORIndexFromPositionInEMCAL(IndexColumnEta etaColumn, IndexRowPhi phiRow) const;
+
+  /// Trigger mapping method, from position in PHOS Index sub region get FastOR index
+  /// \param phosRegionID: Indes of the PHOS subregion
+  /// \return Virtual FastOR index for PHOS subregions
+  /// \throw PHOSRegionException
+  ///
+  /// Calculating the absolute ID of the PHOS subregions, which are treated in the
+  /// indexing as if they were regular DCAL TRUs and FastORs.
+  IndexFastOR getAbsFastORIndexFromPHOSSubregion(unsigned int phosRegionID) const;
+
+  //********************************************
+  // Get TRU/SM/EMCAL Geometry from FastOR index
+  //********************************************
+  /// \brief Get the TRU index and FastOR index in TRU from the absolute FastOR ID
+  /// \param fastOrAbsID Absoulte ID of the FastOR
+  /// \return tuple with 0 - TRU index in the TRU numbering scheme, 1 - FastOR index in TRU
+  /// \throw FastORIndexException in case the FastOR index is not valid
+  ///
+  /// Inverse mapping function calculating back the index of the FastOR inside a
+  /// TRU and its corresponding TRU from the absolute FastOR ID
+  std::tuple<IndexTRU, IndexFastOR> getTRUFromAbsFastORIndex(IndexFastOR fastOrAbsID) const;
+
+  /// \brief Get the position of a FastOR inside the TRU from the absolute FastOR ID
+  /// \param fastORAbsID Absolute ID of the FastOR
+  /// \return tuple with 0 - TRU index in the TRU index scheme, 1 - Position in eta within TRU, 2 - position in phi within TRU
+  /// \throw FastORIndexException in case the FastOR index is not valid
+  ///
+  /// Inverse mapping function calculating the position within a TRU of a FastOR
+  /// and its corresponding TRU from the absolute FastOR ID.
+  std::tuple<IndexTRU, IndexColumnEta, IndexRowPhi> getPositionInTRUFromAbsFastORIndex(IndexFastOR fastORAbsID) const;
+
+  /// \brief Get the position inside the supermodule from the absolute FastOR ID
+  /// \param fastORAbsID Absolute ID of the FastOR
+  /// \return tuple with 0 - Supermodule ID, 1 - position in eta, 2 - position in phi
+  /// \throw FastORIndexException in case the FastOR index is not valid
+  ///
+  /// Inverse mapping function calculating the postion within a supermodule
+  /// of a FastOR and its corresponding supermodule ID from the absolute FastOR ID
+  std::tuple<IndexSupermodule, IndexColumnEta, IndexRowPhi> getPositionInSupermoduleFromAbsFastORIndex(IndexFastOR fastORAbsID) const;
+
+  /// \brief Get the position in the Detector from the absolute FastOR ID
+  /// \param fastORAbsID Absolute ID of the FastOR
+  /// \return tuple with 0 - position in eta, 1 - position in phi
+  /// \throw FastORIndexException in case the FastOR index is not valid
+  ///
+  /// Inverse mapping frunction calculating the position of a FastOR within
+  /// the EMCAL+DCAL surface from the absolute FastOR ID.
+  std::tuple<IndexColumnEta, IndexRowPhi> getPositionInEMCALFromAbsFastORIndex(IndexFastOR fastORAbsID) const;
+
+  //********************************************
+  // TRU vs. STU
+  //********************************************
+
+  /// \brief Convert TRU and FastOR index in TRU from STU number scheme to TRU number scheme
+  /// \param truIndexSTU TRU index in the STU number scheme
+  /// \param fastOrIndexSTU FastOR index in STU number scheme
+  /// \param detector Subdetector (EMCAL or DCAL)
+  /// \return Tuple with 0 - TRU index in TRU number scheme, 1 - FastOR index in TRU number scheme
+  /// \throw TRUIndexException in case the TRU index exceeds the max.number of TRUs in the EMCAL / DCAL STU region
+  /// \throw FastORIndexException in case the FastOR index exceeds the number of FastORs in a TRU
+  ///
+  /// TRU and STU use different index schemes both for TRU indexing and FastOR indexing: For TRUs
+  /// the TRU numbering combines the TRUs in EMCAL and DCAL, including virtual TRU indices in the PHOS
+  /// retion, while the STU numbering scheme splits the TRU indicies in regions for EMCAL and DCAL
+  /// excluding the PHOS regions. For what concerns the FastOR numbering scheme the STU numbering
+  /// scheme uses a simple linerar indexing in eta and then in phi, while the TRU numbering scheme
+  /// uses a complicated indexing starting in phi direction. Consequently a FastOR can have two different
+  /// indices with the TRU depending on numbering scheme. The function converts TRU and FastOR indices
+  /// from the STU scheme to the TRU scheme.
+  std::tuple<IndexTRU, IndexFastOR> convertFastORIndexSTUtoTRU(IndexTRU truIndexSTU, IndexFastOR fastOrIndexSTU, DetType_t detector) const;
+
+  /// \brief Convert TRU and FastOR index in TRU from TRU number scheme to STU number scheme
+  /// \param truIndexTRU TRU index in the TRU number scheme
+  /// \param fastorIndexTRU FastOR index in TRU number scheme
+  /// \return Tuple with 0 - TRU index in STU number scheme, 1 - FastOR index in STU number scheme
+  /// \throw TRUIndexException in case the TRU index exceeds the max.number of TRUs
+  /// \throw FastORIndexException in case the FastOR index exceeds the number of FastORs in a TRU
+  ///
+  /// TRU and STU use different index schemes both for TRU indexing and FastOR indexing: For TRUs
+  /// the TRU numbering combines the TRUs in EMCAL and DCAL, including virtual TRU indices in the PHOS
+  /// retion, while the STU numbering scheme splits the TRU indicies in regions for EMCAL and DCAL
+  /// excluding the PHOS regions. For what concerns the FastOR numbering scheme the STU numbering
+  /// scheme uses a simple linerar indexing in eta and then in phi, while the TRU numbering scheme
+  /// uses a complicated indexing starting in phi direction. Consequently a FastOR can have two different
+  /// indices with the TRU depending on numbering scheme. The function converts TRU and FastOR indices
+  /// from the TRU scheme to the STU scheme.
+  std::tuple<IndexTRU, IndexFastOR> convertFastORIndexTRUtoSTU(IndexTRU truIndexTRU, IndexFastOR fastorIndexTRU) const;
+
+  /// \brief Convert TRU and FastOR position in TRU from STU number scheme to TRU number scheme
+  /// \param truIndexSTU TRU index in the STU number scheme
+  /// \param truEtaSTU Column of the FastOR  in STU number scheme
+  /// \param truPhiSTU Row of the FastOR in STU number scheme
+  /// \param detector Subdetector (EMCAL or DCAL)
+  /// \return Tuple with 0 - TRU index in TRU number scheme, 1 - Column of the FastOR in TRU number scheme, 2 - Row of the FastOR in TRU number scheme
+  /// \throw TRUIndexException in case the TRU index exceeds the max.number of TRUs in the EMCAL / DCAL STU region
+  /// \throw FastORPositionExceptionTRU in case the position in column and row exceeds the number of columns or rows of a TRU
+  ///
+  /// TRU and STU use different index schemes both for TRU indexing and FastOR indexing: For TRUs
+  /// the TRU numbering combines the TRUs in EMCAL and DCAL, including virtual TRU indices in the PHOS
+  /// retion, while the STU numbering scheme splits the TRU indicies in regions for EMCAL and DCAL
+  /// excluding the PHOS regions. For what concerns the FastOR numbering scheme the STU numbering
+  /// scheme uses a simple linerar indexing in eta and then in phi, while the TRU numbering scheme
+  /// uses a complicated indexing starting in phi direction. Consequently a FastOR can have two different
+  /// indices with the TRU depending on numbering scheme. The function converts TRU and FastOR position
+  /// from the STU scheme to the TRU scheme.
+  std::tuple<IndexTRU, IndexColumnEta, IndexRowPhi> convertFastORPositionSTUtoTRU(IndexTRU truIndexSTU, IndexColumnEta truEtaSTU, IndexRowPhi truPhiSTU, DetType_t detector) const;
+
+  /// \brief Convert TRU and FastOR position in TRU from TRU number scheme to STU number scheme
+  /// \param truIndexSTU TRU index in the TRU number scheme
+  /// \param truEtaSTU Column of the FastOR  in TRU number scheme
+  /// \param truPhiSTU Row of the FastOR in TRU number scheme
+  /// \return Tuple with 0 - TRU index in STU number scheme, 1 - Column of the FastOR in STU number scheme, 2 - Row of the FastOR in STU number scheme
+  /// \throw TRUIndexException in case the TRU index exceeds the max.number of TRUs
+  /// \throw FastORPositionExceptionTRU in case the position in column and row exceeds the number of columns or rows of a TRU
+  ///
+  /// TRU and STU use different index schemes both for TRU indexing and FastOR indexing: For TRUs
+  /// the TRU numbering combines the TRUs in EMCAL and DCAL, including virtual TRU indices in the PHOS
+  /// retion, while the STU numbering scheme splits the TRU indicies in regions for EMCAL and DCAL
+  /// excluding the PHOS regions. For what concerns the FastOR numbering scheme the STU numbering
+  /// scheme uses a simple linerar indexing in eta and then in phi, while the TRU numbering scheme
+  /// uses a complicated indexing starting in phi direction. Consequently a FastOR can have two different
+  /// indices with the TRU depending on numbering scheme. The function converts TRU and FastOR position
+  /// from the TRU scheme to the STU scheme.
+  std::tuple<IndexTRU, IndexColumnEta, IndexRowPhi> convertFastORPositionTRUtoSTU(IndexTRU truIndexTRU, IndexColumnEta etaTRU, IndexRowPhi phiTRU) const;
+
+  //********************************************
+  // Cell Index
+  //********************************************
+
+  /// \brief Get the absolute FastOR index of the module containing a given cell
+  /// \param cellIndex Index of the cell
+  /// \return Absolute index of the FastOR
+  /// \throw GeometryNotSetException in case the Geometry is not initialized
+  /// \throw InvalidCellIDException in case the cell ID is outside range
+  IndexFastOR getAbsFastORIndexFromCellIndex(IndexCell cellIndex) const;
+
+  /// \brief Get the indices of the cells in the module of a given FastOR
+  /// \param fastORAbsID Absolute index of the FastOR
+  /// \return Cell indices of the module (order: eta, phi)
+  /// \throw GeometryNotSetException in case the geometry is not initialized
+  /// \throw FastORIndexException in case the FastOR ID is invalid
+  std::array<IndexCell, 4> getCellIndexFromAbsFastORIndex(IndexFastOR fastORAbsID) const;
+
+  //********************************************
+  // TRU index
+  //********************************************
+
+  /// \brief Convert the TRU index from the STU numbering scheme into the TRU numbering scheme
+  /// \param truIndexSTU TRU index im STU numbering scheme
+  /// \param detector Subdetector type
+  /// \return TRU index in TRU numbering scheme
+  /// \throw TRUIndexException in case the TRU index exceeds the max. number of TRUs in the EMCAL/DCAL STU region
+  ///
+  /// The index scheme in the STU definition uses separate ranges for EMCAL and DCAL, where
+  /// the EMCAL contains 32 TRUs and the DCAL 14 TRUs. The index is converted into the TRU
+  /// index scheme adding the TRU index in DCAL + the amount of virtual TRUs in the PHOS region
+  /// (2 per sector) to the TRU index in EMCAL.
+  IndexTRU convertTRUIndexSTUtoTRU(IndexTRU truIndexSTU, DetType_t detector) const;
+
+  /// Convert the TRU index from the TRU numbering scheme into the STU numbering scheme
+  /// \param truIndexTRU TRU index im TRU numbering scheme
+  /// \return TRU index in TRU numbering scheme
+  ///
+  /// The index scheme in TRU definintion consists of a linear list of TRU indices combining EMCAL
+  /// and DCAL TRUs, togtehter with virtual TRUs in the PHOS region (2 per sector). The TRU index
+  /// is spearated for TRUs in EMCAL and DCAL, in each side starting with 0. On the EMCAL side the
+  /// TRU index is the same in both index schemes. On the DCAL side the virtual TRU index of the
+  /// the PHOS region is dropped, therefore calling the function for TRU indices in the PHOS region
+  /// leads to the TRU indices of the corresponding C-side TRUs in the same sector.
+  IndexTRU convertTRUIndexTRUtoSTU(IndexTRU truIndexTRU) const;
+
+  /// \brief Get the TRU index from the online index
+  /// \return TRU index (= online index)
+  IndexTRU getTRUIndexFromOnlineIndex(IndexOnline onlineIndex) const noexcept { return onlineIndex; };
+
+  /// \brief Get the online index from the TRU index
+  /// \return Online index (= TRU index)
+  IndexOnline getOnlineIndexFromTRUIndex(IndexTRU truIndex) const { return truIndex; };
+
+  /// \brief Get the TRU Index from the hardware address of the ALTRO channel (TRU rawdata)
+  /// \param hardwareAddress hardware address
+  /// \param ddlID ID of the DDL of the ALTRO channel
+  /// \param supermoduleID uper-module number
+  /// \return TRU global offline number from:
+  /// \throw TRUIndexException in case the TRU index is out-of-range
+  IndexTRU getTRUIndexFromOnlineHardareAddree(int hardwareAddress, unsigned int ddlID, unsigned int supermoduleID) const;
+
+  //********************************************
+  // L0 Index
+  //********************************************
+
+  /// Trigger mapping method, from L0 index get FastOR index
+  /// \param iTRU: TRU index
+  /// \param l0index:  L0? index
+  /// \param idx: indeces associated to FASTOR?
+  /// \param size: ?
+  /// \return true if found
+  std::array<unsigned int, 4> getFastORIndexFromL0Index(IndexTRU iTRU, IndexFastOR l0index, int size) const;
+
+  /// \struct FastORInformation
+  /// \brief Basic FastOR information
+  struct FastORInformation {
+    unsigned int mTRUID;                ///< Index of the TRU
+    unsigned int mFastORIDTRU;          ///< Online FastOR index in TRU
+    unsigned int mColumnEtaTRU;         ///< Column in the TRU
+    unsigned int mRowPhiTRU;            ///< Row in the TRU
+    unsigned int mSupermoduleID;        ///< Supermodule
+    unsigned int mColumnEtaSupermodule; ///< Column in the supermodule
+    unsigned int mRowPhiSupermodule;    ///< Row in the supermodule
+  };
+
+  FastORInformation getInfoFromAbsFastORIndex(IndexFastOR absFastORID) const;
+
+  //********************************************
+  // getters arrays (for debugging)
+  //********************************************
+  const std::array<unsigned int, ALLTRUS>& getArrayTRUFastOROffsetX() const { return mTRUFastOROffsetX; }
+  const std::array<unsigned int, ALLTRUS>& getTRUFastOROffsetY() const { return mTRUFastOROffsetY; }
+  const std::array<unsigned int, ALLTRUS>& getNFastORInTRUPhi() const { return mNFastORInTRUPhi; }
+  const std::array<unsigned int, ALLTRUS>& getNFastORInTRUEta() const { return mNFastORInTRUEta; }
+  const std::array<unsigned int, SUPERMODULES>& getArraySMFastOROffsetX() const { return mSMFastOROffsetX; }
+  const std::array<unsigned int, SUPERMODULES>& getArraySMFastOROffsetY() const { return mSMFastOROffsetY; }
+  const std::array<unsigned int, SUPERMODULES>& getArrayNFastORInSMPhi() const { return mNFastORInSMPhi; }
+  const std::array<unsigned int, SUPERMODULES>& getArrayNFastORInSMEta() const { return mNFastORInSMEta; }
+  const std::array<unsigned int, 5>& getArrayNModuleInEMCALPhi() const { return mNModuleInEMCALPhi; }
+
+ private:
+  //********************************************
+  // fastOR offset parameters
+  //********************************************
+  o2::emcal::Geometry* mGeometry;
+  std::array<unsigned int, ALLTRUS> mTRUFastOROffsetX; ///< FastOR offset per TRU in eta direction
+  std::array<unsigned int, ALLTRUS> mTRUFastOROffsetY; ///< FastOR offset per TRU in phi direction
+  std::array<unsigned int, ALLTRUS> mNFastORInTRUPhi;  ///< Number of FastORs per TRU in phi direction (for handling 1/3rd supermodules)
+  std::array<unsigned int, ALLTRUS> mNFastORInTRUEta;  ///< Number of FastORs per TRU in eta direction (for handling 1/3rd supermodules)
+  std::bitset<ALLTRUS> mTRUIsCside;                    ///< Marker for C-side supermodules (bit index := supermodule ID)
+
+  std::array<unsigned int, SUPERMODULES> mSMFastOROffsetX; // FastOR offset[#of SM ]
+  std::array<unsigned int, SUPERMODULES> mSMFastOROffsetY; //
+  std::array<unsigned int, SUPERMODULES> mNFastORInSMPhi;  // SM size
+  std::array<unsigned int, SUPERMODULES> mNFastORInSMEta;  //
+
+  std::array<unsigned int, 5> mNModuleInEMCALPhi; //#FastOR/EMCAL in Phi
+
+  //********************************************
+  // Initialization of FastOR index offset of each SM/TRU
+  //********************************************
+
+  /// Initialize mapping offsets for the various TRUs
+  void init_TRU_offset();
+  void init_SM_offset();
+
+  /// \brief Reset all interal arrays with 0
+  void reset_arrays();
+
+  //********************************************
+  // Rotation methods from between eta and phi orientation
+  //********************************************
+
+  /// \brief Convert absolute FastOR index into increasing order with phi
+  /// \param fastorIndexInEta Absolute FastOR index in eta orientation
+  /// \return Absolute FastOR index in phi orientation
+  ///
+  /// Input is expected to have the FastOR index oriented in eta direction, meaning
+  /// that the index increases as first dimension in eta direction and as second
+  /// dimension in phi direction. After the conversion the index increases as first
+  /// dimension with phi and as second dimension with eta. The rotation is relative
+  /// to the sector (A+C side supermodules). The FastOR index is absolute, meaning
+  /// that the offset of the sector is added to the relative position in the sector.
+  ///
+  /// The conversion is usually applied converting from the STU numbering scheme, which
+  /// first increments in eta, to the TRU numbering scheme which first increments in phi.
+  IndexFastOR rotateAbsFastOrIndexEtaToPhi(IndexFastOR fastorIndexInEta) const;
+
+  /// \brief Convert absolute FastOR index into increasing order with eta
+  /// \param fastorIndexInEta Absolute FastOR index in phi orientation
+  /// \return Absolute FastOR index in eta orientation
+  ///
+  /// Input is expected to have the FastOR index oriented in phi direction, meaning
+  /// that the index increases as first dimension in phi direction and as second
+  /// dimension in eta direction, relative to the sector (A+C side supermodules).
+  /// After the conversion the index increases as first dimension with eta and as
+  /// second dimension with phi. The rotation stays relative to the sector. The FastOR
+  /// index is absolute, meaning that the offset of the sector is added to the relative
+  /// position in the sector.
+  ///
+  /// The conversion is usually applied converting from the TRU numbering scheme, which
+  /// first increments in phi, to the STU numbering scheme which first increments in eta.
+  IndexFastOR rotateAbsFastOrIndexPhiToEta(IndexFastOR fastorIndexInPhi) const;
+
+  /// \brief Get the type of the supermodule
+  /// \param supermoduleID Index of the supermodule
+  /// \return type of the supermodule
+  /// \throw SupermoduleIndexException in case the supermoduleID exceeds the number of supermodules
+  EMCALSMType getSupermoduleType(IndexSupermodule supermoduleID) const
+  {
+    if (supermoduleID >= SUPERMODULES) {
+      throw SupermoduleIndexException(supermoduleID, SUPERMODULES);
+    }
+    if (supermoduleID < 10) {
+      return EMCAL_STANDARD;
+    }
+    if (supermoduleID < 12) {
+      return EMCAL_THIRD;
+    }
+    if (supermoduleID < 18) {
+      return DCAL_STANDARD;
+    }
+    if (supermoduleID < 20) {
+      return DCAL_EXT;
+    }
+    // silence compiler warning (check already done before in order to avoid unnecessary filter)
+    throw SupermoduleIndexException(supermoduleID, SUPERMODULES);
+  }
+
+  /// \brief Check if the supermodule is a C-side supermodule
+  /// \param supermoduleID Index of the supermodule
+  /// \return true if the supermodule is on the C-side (odd index), false if it is on the A-side (even index)
+  bool isSupermoduleOnCSide(IndexSupermodule supermoduleID) const
+  {
+    return (supermoduleID % 2 == 1) ? true : false;
+  }
+
+  ClassDefNV(TriggerMappingV2, 1);
+};
+
+} // namespace emcal
+} // namespace o2
+
+#endif // ALIEMCALTRIGGERMAPPINGV2_H

--- a/Detectors/EMCAL/base/src/EMCALBaseLinkDef.h
+++ b/Detectors/EMCAL/base/src/EMCALBaseLinkDef.h
@@ -19,10 +19,11 @@
 #pragma link C++ class o2::emcal::Geometry + ;
 #pragma link C++ class o2::emcal::Mapper + ;
 #pragma link C++ class o2::emcal::MappingHandler + ;
+#pragma link C++ class o2::emcal::TriggerMappingV2 + ;
 #pragma link C++ class o2::emcal::RCUTrailer + ;
 
 #pragma link C++ class o2::emcal::ClusterFactory < o2::emcal::Cell> + ;
 #pragma link C++ class o2::emcal::ClusterFactory < o2::emcal::Digit> + ;
 
-#pragma link C++ class std::vector < o2::emcal::Hit > + ;
+#pragma link C++ class std::vector < o2::emcal::Hit> + ;
 #endif

--- a/Detectors/EMCAL/base/src/TriggerMappingV2.cxx
+++ b/Detectors/EMCAL/base/src/TriggerMappingV2.cxx
@@ -1,0 +1,599 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "EMCALBase/Geometry.h"
+#include "EMCALBase/TriggerMappingV2.h"
+#include "EMCALBase/TriggerMappingErrors.h"
+
+ClassImp(o2::emcal::TriggerMappingV2);
+
+using namespace o2::emcal;
+
+TriggerMappingV2::TriggerMappingV2()
+{
+  reset_arrays();
+  init_TRU_offset();
+  init_SM_offset();
+}
+
+TriggerMappingV2::TriggerMappingV2(o2::emcal::Geometry* geo) : mGeometry(geo)
+{
+  reset_arrays();
+  init_TRU_offset();
+  init_SM_offset();
+}
+
+void TriggerMappingV2::reset_arrays()
+{
+  std::fill(mTRUFastOROffsetX.begin(), mTRUFastOROffsetX.end(), 0);
+  std::fill(mTRUFastOROffsetY.begin(), mTRUFastOROffsetY.end(), 0);
+  std::fill(mNFastORInTRUPhi.begin(), mNFastORInTRUPhi.end(), 0);
+  std::fill(mNFastORInTRUEta.begin(), mNFastORInTRUEta.end(), 0);
+
+  std::fill(mSMFastOROffsetX.begin(), mSMFastOROffsetX.end(), 0);
+  std::fill(mSMFastOROffsetY.begin(), mSMFastOROffsetY.end(), 0);
+  std::fill(mNFastORInSMPhi.begin(), mNFastORInSMPhi.end(), 0);
+  std::fill(mNFastORInSMEta.begin(), mNFastORInSMEta.end(), 0);
+
+  std::fill(mNModuleInEMCALPhi.begin(), mNModuleInEMCALPhi.end(), 0);
+}
+
+void TriggerMappingV2::init_TRU_offset()
+{
+  mTRUFastOROffsetX[0] = 0;
+  mTRUFastOROffsetY[0] = 0;
+  IndexTRU currentTRU = 0;
+
+  enum class TRUType_t {
+    STANDARD_TRU,
+    EXT_TRU
+  };
+
+  for (IndexSupermodule supermoduleID = 0; supermoduleID < SUPERMODULES; supermoduleID++) {
+    auto smtype = getSupermoduleType(supermoduleID);
+    auto isCside = isSupermoduleOnCSide(supermoduleID);
+    TRUType_t trutype = TRUType_t::STANDARD_TRU;
+
+    //===================
+    // TRU ieta/iphi size
+    auto nTRU_inSM = TRUSSUPERMODULE;
+    auto nTRU_inSM_phi = TRUSPHISM;
+    auto nTRU_inSM_eta = TRUSETASM;
+    auto nModule_inTRU_phi = FASTORSPHITRU;
+    auto nModule_inTRU_eta = FASTORSETATRU;
+    if (smtype == EMCAL_THIRD || smtype == DCAL_EXT) {
+      nTRU_inSM = static_cast<unsigned int>(static_cast<float>(nTRU_inSM) / 3.);
+      nTRU_inSM_eta = static_cast<unsigned int>(static_cast<float>(nTRU_inSM_eta) / 3.);
+      nModule_inTRU_phi = static_cast<unsigned int>(static_cast<float>(nModule_inTRU_phi) / 3.);
+      nModule_inTRU_eta = nModule_inTRU_eta * 3;
+    }
+
+    //===================
+    // TRU ieta/iphi offset calculation
+    for (IndexTRU truInSupermodule = 0; truInSupermodule < nTRU_inSM; truInSupermodule++) {
+      mNFastORInTRUPhi[currentTRU] = nModule_inTRU_phi;
+      mNFastORInTRUEta[currentTRU] = nModule_inTRU_eta;
+      if (isCside) {
+        mTRUIsCside.set(currentTRU, true);
+      } else {
+        mTRUIsCside.set(currentTRU, false);
+      }
+
+      if ((currentTRU + 1) >= ALLTRUS) {
+        break;
+      }
+
+      trutype = TRUType_t::STANDARD_TRU;
+      if (truInSupermodule == nTRU_inSM - 1 && isCside) { // last TRU in SM
+        trutype = TRUType_t::EXT_TRU;                     // right
+      }
+
+      // calculate offset for the next TRU in supermodule (if any)
+      switch (trutype) {
+        case TRUType_t::STANDARD_TRU:
+          mTRUFastOROffsetX[currentTRU + 1] = mTRUFastOROffsetX[currentTRU] + nModule_inTRU_eta;
+          mTRUFastOROffsetY[currentTRU + 1] = mTRUFastOROffsetY[currentTRU];
+          break;
+        case TRUType_t::EXT_TRU:
+          mTRUFastOROffsetX[currentTRU + 1] = 0;
+          mTRUFastOROffsetY[currentTRU + 1] = mTRUFastOROffsetY[currentTRU] + nModule_inTRU_phi;
+          break;
+      };
+      currentTRU++;
+    } // TRU loop
+  }   // SM loop
+}
+
+/// Initialize mapping offsets of SM (add more description)
+void TriggerMappingV2::init_SM_offset()
+{
+  mSMFastOROffsetX[0] = 0;
+  mSMFastOROffsetY[0] = 0;
+  mNModuleInEMCALPhi[0] = 0;
+  int iB = 0;
+
+  EMCALSMType currentSMtype = NOT_EXISTENT;
+  for (IndexSupermodule supermoduleID = 0; supermoduleID < SUPERMODULES; supermoduleID++) {
+    auto smtype = getSupermoduleType(supermoduleID);
+    auto isCside = isSupermoduleOnCSide(supermoduleID);
+
+    IndexRowPhi nModule_inSM_phi = FASTORSPHISM;
+    IndexColumnEta nModule_inSM_eta = FASTORSETASM;
+
+    if (smtype == EMCAL_THIRD || smtype == DCAL_EXT) {
+      nModule_inSM_phi = static_cast<IndexRowPhi>(static_cast<float>(nModule_inSM_phi) / 3.);
+    }
+
+    mNFastORInSMPhi[supermoduleID] = nModule_inSM_phi;
+    mNFastORInSMEta[supermoduleID] = nModule_inSM_eta;
+
+    if (!isCside) {
+      if (currentSMtype == smtype) {
+        mNModuleInEMCALPhi[iB] += nModule_inSM_phi;
+      } else {
+        mNModuleInEMCALPhi[iB + 1] = mNModuleInEMCALPhi[iB] + nModule_inSM_phi;
+        iB++;
+      }
+      currentSMtype = smtype;
+    }
+
+    if ((supermoduleID + 1) >= SUPERMODULES) {
+      break;
+    }
+
+    // initialize offsets for next supermodule (if any)
+    if (isCside) { // right SM
+      mSMFastOROffsetX[supermoduleID + 1] = 0;
+      mSMFastOROffsetY[supermoduleID + 1] = mSMFastOROffsetY[supermoduleID] + nModule_inSM_phi;
+    } else { // left SM
+      mSMFastOROffsetX[supermoduleID + 1] = mSMFastOROffsetX[supermoduleID] + nModule_inSM_eta;
+      mSMFastOROffsetY[supermoduleID + 1] = mSMFastOROffsetY[supermoduleID];
+    }
+  } // SM loop
+}
+
+TriggerMappingV2::IndexFastOR TriggerMappingV2::getAbsFastORIndexFromIndexInTRU(IndexTRU truIndex, unsigned int positionInTRU) const
+{
+  if (truIndex >= ALLTRUS) {
+    throw TRUIndexException(truIndex);
+  }
+  if (positionInTRU >= FASTORSTRU) {
+    throw FastORIndexException(positionInTRU);
+  }
+
+  // invert index on C-side
+  IndexFastOR fastorIndexInverted = (mTRUIsCside.test(truIndex)) ? (FASTORSTRU - positionInTRU - 1) : positionInTRU;
+  IndexColumnEta columnInTRU = mTRUFastOROffsetX[truIndex] + IndexFastOR(fastorIndexInverted / mNFastORInTRUPhi[truIndex]);
+  IndexRowPhi rowInTRU = mTRUFastOROffsetY[truIndex] + mNFastORInTRUPhi[truIndex] - 1 - IndexFastOR(fastorIndexInverted % mNFastORInTRUPhi[truIndex]);
+
+  IndexFastOR id = rowInTRU * FASTORSETA + columnInTRU;
+  id = rotateAbsFastOrIndexEtaToPhi(id);
+
+  return id;
+}
+
+TriggerMappingV2::IndexFastOR TriggerMappingV2::getAbsFastORIndexFromPositionInTRU(IndexTRU truIndex, IndexColumnEta etaColumn, IndexRowPhi phiRow) const
+{
+  if (truIndex >= ALLTRUS) {
+    throw TRUIndexException(truIndex);
+  }
+  if (etaColumn > mNFastORInTRUEta[truIndex] - 1 ||
+      phiRow > mNFastORInTRUPhi[truIndex] - 1) {
+    throw FastORPositionExceptionTRU(truIndex, etaColumn, phiRow);
+  }
+
+  IndexColumnEta etatmp = etaColumn; // XXX
+  IndexRowPhi phitmp = phiRow;       // XXX
+
+  // unsigned int etatmp = ( mTRUIsCside[ iTRU])? (fnFastORInTRUEta[truIndex] - 1 - etaColumn) : etaColumn  ;
+  // unsigned int phitmp = (!mTRUIsCside.test(truIndex))? (fnFastORInTRUPhi[truIndex] - 1 - phiRow) : phiRow  ;
+
+  IndexColumnEta x = mTRUFastOROffsetX[truIndex] + etatmp;
+  IndexRowPhi y = mTRUFastOROffsetY[truIndex] + phitmp;
+
+  IndexFastOR id = y * FASTORSETA + x;
+  id = rotateAbsFastOrIndexEtaToPhi(id);
+  return id;
+}
+
+TriggerMappingV2::IndexFastOR TriggerMappingV2::getAbsFastORIndexFromPositionInSupermodule(IndexSupermodule supermoduleID, IndexColumnEta etaColumn, IndexRowPhi phiRow) const
+{
+  if (supermoduleID >= SUPERMODULES) {
+    throw SupermoduleIndexException(supermoduleID, SUPERMODULES);
+  }
+  if (
+    etaColumn >= mNFastORInSMEta[supermoduleID] ||
+    phiRow >= mNFastORInSMPhi[supermoduleID]) {
+    throw FastORPositionExceptionSupermodule(supermoduleID, etaColumn, phiRow);
+  }
+
+  // Int_t iEtatmp = (GetSMIsCside(iSM) && GetSMType(iSM) == kDCAL_Standard)?(iEta + 8):iEta ;
+  // Int_t x = fSMFastOROffsetX[iSM] + iEtatmp ;
+
+  IndexColumnEta x = mSMFastOROffsetX[supermoduleID] + etaColumn;
+  IndexRowPhi y = mSMFastOROffsetY[supermoduleID] + phiRow;
+
+  IndexFastOR id = y * FASTORSETA + x;
+  id = rotateAbsFastOrIndexEtaToPhi(id);
+  return id;
+}
+
+TriggerMappingV2::IndexFastOR TriggerMappingV2::getAbsFastORIndexFromPositionInEMCAL(IndexColumnEta etaColumn, IndexRowPhi phiRow) const
+{
+  if (
+    etaColumn >= FASTORSETA ||
+    phiRow >= FASTORSPHI) {
+    throw FastORPositionExceptionEMCAL(etaColumn, phiRow);
+  }
+
+  IndexFastOR id = phiRow * FASTORSETA + etaColumn;
+  id = rotateAbsFastOrIndexEtaToPhi(id);
+  return id;
+}
+
+TriggerMappingV2::IndexFastOR TriggerMappingV2::getAbsFastORIndexFromPHOSSubregion(unsigned int phosRegionID) const
+{
+  if (phosRegionID > 35) {
+    throw PHOSRegionException(phosRegionID);
+  }
+
+  IndexColumnEta absColumnEta = 16 + 4 * IndexColumnEta(phosRegionID % 4);
+  IndexRowPhi absRowPhi = 64 + 4 * IndexRowPhi(phosRegionID / 4);
+
+  return getAbsFastORIndexFromPositionInEMCAL(absColumnEta, absRowPhi);
+}
+
+std::tuple<TriggerMappingV2::IndexTRU, TriggerMappingV2::IndexFastOR> TriggerMappingV2::getTRUFromAbsFastORIndex(IndexFastOR fastOrAbsID) const
+{
+  IndexFastOR convertedFastorIndex = rotateAbsFastOrIndexPhiToEta(fastOrAbsID);
+
+  auto fastorInfo = getInfoFromAbsFastORIndex(convertedFastorIndex);
+  return std::make_tuple(fastorInfo.mTRUID, fastorInfo.mFastORIDTRU);
+}
+
+std::tuple<TriggerMappingV2::IndexTRU, TriggerMappingV2::IndexColumnEta, TriggerMappingV2::IndexRowPhi> TriggerMappingV2::getPositionInTRUFromAbsFastORIndex(IndexFastOR fastOrAbsID) const
+{
+
+  IndexFastOR convertedFastorIndex = rotateAbsFastOrIndexPhiToEta(fastOrAbsID);
+
+  auto fastorInfo = getInfoFromAbsFastORIndex(convertedFastorIndex);
+  return std::make_tuple(fastorInfo.mTRUID, fastorInfo.mColumnEtaTRU, fastorInfo.mRowPhiTRU);
+}
+
+std::tuple<TriggerMappingV2::IndexSupermodule, TriggerMappingV2::IndexColumnEta, TriggerMappingV2::IndexRowPhi> TriggerMappingV2::getPositionInSupermoduleFromAbsFastORIndex(IndexFastOR fastOrAbsID) const
+{
+  IndexFastOR convertedFastorIndex = rotateAbsFastOrIndexPhiToEta(fastOrAbsID);
+
+  auto fastorInfo = getInfoFromAbsFastORIndex(convertedFastorIndex);
+  return std::make_tuple(fastorInfo.mSupermoduleID, fastorInfo.mColumnEtaSupermodule, fastorInfo.mRowPhiSupermodule);
+}
+
+std::tuple<TriggerMappingV2::IndexColumnEta, TriggerMappingV2::IndexRowPhi> TriggerMappingV2::getPositionInEMCALFromAbsFastORIndex(IndexFastOR fastorAbsID) const
+{
+  if (fastorAbsID >= ALLFASTORS) {
+    throw FastORIndexException(fastorAbsID);
+  }
+
+  IndexFastOR convertedFastorIndex = rotateAbsFastOrIndexPhiToEta(fastorAbsID);
+  TriggerMappingV2::IndexColumnEta column = convertedFastorIndex % FASTORSETA;
+  TriggerMappingV2::IndexRowPhi row = convertedFastorIndex / FASTORSETA;
+  return std::make_tuple(column, row);
+}
+
+TriggerMappingV2::IndexFastOR TriggerMappingV2::getAbsFastORIndexFromCellIndex(IndexCell cellindex) const
+{
+  if (!mGeometry) {
+    throw GeometryNotSetException();
+  }
+  auto [supermoduleID, moduleId, cellPhiModule, cellEtaModule] = mGeometry->GetCellIndex(cellindex);
+
+  auto [cellPhiSupermodule, cellEtaSupermodule] = mGeometry->GetCellPhiEtaIndexInSModule(supermoduleID, moduleId, cellPhiModule, cellEtaModule);
+
+  // ietam:0-31  for DCAL Cside
+  auto cellEta = cellEtaSupermodule, cellPhi = cellPhiSupermodule;
+  if (getSupermoduleType(supermoduleID) == DCAL_STANDARD && (supermoduleID % 2) == 1) {
+    auto [cellPhiShifted, cellEtaShifted] = mGeometry->ShiftOfflineToOnlineCellIndexes(supermoduleID, cellPhiSupermodule, cellEtaSupermodule);
+    cellEta = cellEtaShifted;
+    cellPhi = cellPhiShifted;
+  }
+
+  // ietam:16-47 for DCAL Cside
+  IndexRowPhi moduleRow = static_cast<IndexRowPhi>(cellPhi / 2);
+  IndexColumnEta moduleColumn = static_cast<IndexColumnEta>(cellEta / 2);
+  return getAbsFastORIndexFromPositionInSupermodule(supermoduleID, moduleColumn, moduleRow);
+}
+
+std::array<TriggerMappingV2::IndexCell, 4> TriggerMappingV2::getCellIndexFromAbsFastORIndex(IndexFastOR fastORAbsID) const
+{
+  if (!mGeometry) {
+    throw GeometryNotSetException();
+  }
+  auto [supermoduleID, etaColumnSM, phiRowSM] = getPositionInSupermoduleFromAbsFastORIndex(fastORAbsID);
+  IndexColumnEta cellEtaColumnSupermodule = 2 * etaColumnSM;
+  IndexRowPhi cellPhiRowSupermodule = 2 * phiRowSM;
+
+  // Shift index in case the module is a DCAL standard C-side module
+  if (getSupermoduleType(supermoduleID) == DCAL_STANDARD) {
+    if (supermoduleID % 2 == 1) {
+      auto [cellPhiRowShifted, cellEtaColumnShifted] = mGeometry->ShiftOnlineToOfflineCellIndexes(supermoduleID, cellPhiRowSupermodule, cellEtaColumnSupermodule);
+      cellEtaColumnSupermodule = cellEtaColumnShifted;
+      cellPhiRowSupermodule = cellPhiRowShifted;
+    }
+  }
+  std::array<IndexCell, 4> cells = {{static_cast<IndexCell>(mGeometry->GetAbsCellIdFromCellIndexes(supermoduleID, cellPhiRowSupermodule, cellEtaColumnSupermodule)),
+                                     static_cast<IndexCell>(mGeometry->GetAbsCellIdFromCellIndexes(supermoduleID, cellPhiRowSupermodule, cellEtaColumnSupermodule + 1)),
+                                     static_cast<IndexCell>(mGeometry->GetAbsCellIdFromCellIndexes(supermoduleID, cellPhiRowSupermodule + 1, cellEtaColumnSupermodule)),
+                                     static_cast<IndexCell>(mGeometry->GetAbsCellIdFromCellIndexes(supermoduleID, cellPhiRowSupermodule + 1, cellEtaColumnSupermodule + 1))}};
+  return cells;
+}
+
+TriggerMappingV2::IndexTRU TriggerMappingV2::convertTRUIndexSTUtoTRU(IndexTRU truIndexSTU, DetType_t detector) const
+{
+  if ((truIndexSTU > 31 && detector == DetType_t::DET_EMCAL) || (truIndexSTU > 13 && detector == DetType_t::DET_DCAL)) {
+    throw TRUIndexException(truIndexSTU);
+  }
+
+  if (detector == DetType_t::DET_EMCAL) {
+    return truIndexSTU;
+  } else {
+    return 32 + ((int)(truIndexSTU / 4) * 6) + ((truIndexSTU % 4 < 2) ? (truIndexSTU % 4) : (truIndexSTU % 4 + 2));
+  }
+}
+
+TriggerMappingV2::IndexTRU TriggerMappingV2::convertTRUIndexTRUtoSTU(IndexTRU truIndexTRU) const
+{
+  if (truIndexTRU < 32) {
+    return truIndexTRU;
+  } else {
+    IndexTRU truIndexSTU = truIndexTRU;
+    if (truIndexSTU >= 48) {
+      truIndexSTU -= 2;
+    }
+    if (truIndexSTU >= 42) {
+      truIndexSTU -= 2;
+    }
+    if (truIndexSTU >= 36) {
+      truIndexSTU -= 2;
+    }
+    truIndexSTU -= 32;
+
+    return truIndexSTU;
+  }
+}
+
+TriggerMappingV2::IndexTRU TriggerMappingV2::getTRUIndexFromOnlineHardareAddree(int hardwareAddress, unsigned int ddlID, unsigned int supermoduleID) const
+{
+  // 1/3 SMs
+
+  if (supermoduleID == 10) {
+    return 30;
+  }
+  if (supermoduleID == 11) {
+    return 31;
+  }
+  if (supermoduleID == 18) {
+    return 50;
+  }
+  if (supermoduleID == 19) {
+    return 51;
+  }
+
+  // Standard EMCal/DCal SMs
+
+  unsigned short branch = (hardwareAddress >> 11) & 0x1; // 0/1
+
+  IndexTRU truIndex = ((ddlID << 1) | branch) - 1; // 0..2
+
+  truIndex = (supermoduleID % 2) ? 2 - truIndex : truIndex;
+
+  if (supermoduleID < 10) {
+    truIndex += 3 * supermoduleID; // EMCal
+  } else {
+    truIndex += (3 * supermoduleID - 4); // DCal
+  }
+
+  if (truIndex >= ALLTRUS) {
+    throw TRUIndexException(truIndex);
+  }
+
+  return truIndex;
+}
+
+std::array<unsigned int, 4> TriggerMappingV2::getFastORIndexFromL0Index(IndexTRU truIndex, IndexFastOR l0index, int l0size) const
+{
+  if (l0size <= 0 || l0size > 4) {
+    throw L0sizeInvalidException(l0size);
+  }
+
+  int motif[4];
+  motif[0] = 0;
+  motif[2] = 1;
+  motif[1] = mNFastORInTRUPhi[truIndex];
+  motif[3] = mNFastORInTRUPhi[truIndex] + 1;
+
+  std::array<unsigned int, 4> fastorIndex;
+  std::fill(fastorIndex.begin(), fastorIndex.end(), 0);
+  switch (l0size) {
+    case 1: // Cosmic trigger
+      fastorIndex[0] = getAbsFastORIndexFromIndexInTRU(truIndex, l0index);
+      break;
+    case 4: // Standard L0 patch
+      for (int index = 0; index < 4; index++) {
+        IndexFastOR fastorInTRU = mNFastORInTRUPhi[truIndex] * int(l0index / (mNFastORInTRUPhi[truIndex] - 1)) + (l0index % (mNFastORInTRUPhi[truIndex] - 1)) + motif[index];
+        fastorIndex[index] = getAbsFastORIndexFromIndexInTRU(truIndex, fastorInTRU);
+      }
+      break;
+    default:
+      break;
+  }
+
+  return fastorIndex;
+}
+TriggerMappingV2::FastORInformation TriggerMappingV2::getInfoFromAbsFastORIndex( // conv from A
+  IndexFastOR fastOrAbsID) const
+{
+  if (fastOrAbsID >= ALLFASTORS) {
+    throw FastORIndexException(fastOrAbsID);
+  }
+  unsigned int fastorIndexTRU;
+
+  IndexFastOR convertedFastorIndex = rotateAbsFastOrIndexEtaToPhi(fastOrAbsID);
+
+  IndexTRU truIndex = convertedFastorIndex / FASTORSTRU;
+  fastorIndexTRU = convertedFastorIndex % FASTORSTRU;
+  if (truIndex >= ALLTRUS) {
+    throw TRUIndexException(truIndex);
+  }
+
+  IndexColumnEta etaColumnTRU = fastorIndexTRU / mNFastORInTRUPhi[truIndex];
+  IndexRowPhi phiRowTRU = fastorIndexTRU % mNFastORInTRUPhi[truIndex];
+  fastorIndexTRU = mNFastORInTRUPhi[truIndex] * ((mTRUIsCside[truIndex]) ? (mNFastORInTRUEta[truIndex] - 1 - etaColumnTRU) : etaColumnTRU) + ((!mTRUIsCside[truIndex]) ? (mNFastORInTRUPhi[truIndex] - 1 - phiRowTRU) : phiRowTRU);
+
+  IndexColumnEta etaColumnGlobal = fastOrAbsID % FASTORSETA;
+  IndexRowPhi rowPhiGlobal = fastOrAbsID / FASTORSETA;
+
+  Int_t idtmp = (rowPhiGlobal < mNModuleInEMCALPhi[2]) ? fastOrAbsID : (fastOrAbsID + FASTORSTRU * 4);
+
+  IndexSupermodule supermoduleID = 2 * (int)(idtmp / (2 * FASTORSETASM * FASTORSPHISM)) + (int)(mTRUIsCside[truIndex]);
+  if (supermoduleID >= SUPERMODULES) {
+    throw SupermoduleIndexException(supermoduleID, SUPERMODULES);
+  }
+
+  IndexColumnEta etaColumnSupermodule = etaColumnGlobal % mNFastORInSMEta[supermoduleID];
+  IndexRowPhi phiRowSupermodule = convertedFastorIndex % mNFastORInSMPhi[supermoduleID];
+  return {
+    truIndex,
+    fastorIndexTRU,
+    etaColumnTRU,
+    phiRowTRU,
+    supermoduleID,
+    etaColumnSupermodule,
+    phiRowSupermodule};
+}
+
+TriggerMappingV2::IndexFastOR TriggerMappingV2::rotateAbsFastOrIndexEtaToPhi(IndexFastOR fastorIndexInEta) const
+{
+  Int_t det_phi = int(fastorIndexInEta / FASTORSETA);
+  Int_t nModule_inSM_phi = FASTORSPHISM; // number of modules in current supermodule
+  Int_t fastOrIndexInPhi = 0;
+  // Calculate FastOR offset relative to previous SM type
+  for (int i = 1; i < 5; i++) {
+    if (det_phi < mNModuleInEMCALPhi[i]) {
+      fastOrIndexInPhi = FASTORSETA * mNModuleInEMCALPhi[i - 1];
+      if (i == 2 || i == 4) {
+        nModule_inSM_phi /= 3;
+      }
+      break;
+    }
+  }
+  // fastOrIndexInPhi := Number of FastORs of the previous range with same SM type
+
+  Int_t fastorInSMType = fastorIndexInEta - fastOrIndexInPhi;
+  Int_t sectorInSMType = (int)(fastorInSMType / (FASTORSETA * nModule_inSM_phi));
+  Int_t fastOrInSector = (int)(fastorInSMType % (FASTORSETA * nModule_inSM_phi));
+
+  fastOrIndexInPhi += sectorInSMType * (FASTORSETA * nModule_inSM_phi); // Add back number of FastORs in previous tracking sectors of the same type
+  // rotate arrangement from eta to phi
+  fastOrIndexInPhi += (int)(fastOrInSector % FASTORSETA) * nModule_inSM_phi; // Add full colums in sector
+  fastOrIndexInPhi += (int)(fastOrInSector / FASTORSETA);                    // Add FastORs in the last column
+
+  return fastOrIndexInPhi;
+}
+
+TriggerMappingV2::IndexFastOR TriggerMappingV2::rotateAbsFastOrIndexPhiToEta(IndexFastOR fastOrIndexInPhi) const
+{
+  Int_t det_phi = int(fastOrIndexInPhi / FASTORSETA);
+  Int_t fastorIndexInEta = 0;
+  Int_t nModule_inSM_phi = FASTORSPHISM;
+  // Calculate FastOR offset relative to previous SM type
+  for (int i = 1; i < 5; i++) {
+    if (det_phi < mNModuleInEMCALPhi[i]) {
+      fastorIndexInEta = FASTORSETA * mNModuleInEMCALPhi[i - 1];
+      if (i == 2 || i == 4) {
+        nModule_inSM_phi /= 3;
+      }
+      break;
+    }
+  }
+  // fastorIndexInEta := Number of FastORs of the previous range with same SM type
+
+  Int_t fastorInSMType = fastOrIndexInPhi - fastorIndexInEta;
+  Int_t sectorInSMType = (int)(fastorInSMType / (FASTORSETA * nModule_inSM_phi));
+  Int_t fastOrInSector = (int)(fastorInSMType % (FASTORSETA * nModule_inSM_phi));
+
+  Int_t columnInSector = fastOrInSector / nModule_inSM_phi;
+  Int_t rowInSector = fastOrInSector % nModule_inSM_phi;
+
+  fastorIndexInEta += sectorInSMType * (FASTORSETA * nModule_inSM_phi); // Add back number of FastORs in previous tracking sectors of the same type
+  // rotate arrangement from phi to eta
+  fastorIndexInEta += rowInSector * FASTORSETA + columnInSector;
+
+  return fastorIndexInEta;
+}
+
+std::tuple<TriggerMappingV2::IndexTRU, TriggerMappingV2::IndexFastOR> TriggerMappingV2::convertFastORIndexSTUtoTRU(IndexTRU truIndexSTU, IndexFastOR fastOrIndexSTU, DetType_t detector) const
+{
+  if (fastOrIndexSTU >= FASTORSTRU) {
+    throw FastORIndexException(fastOrIndexSTU);
+  }
+  IndexTRU truIndexTRU = convertTRUIndexSTUtoTRU(truIndexSTU, detector);
+  IndexColumnEta etaSTU = fastOrIndexSTU % mNFastORInTRUEta[truIndexTRU];
+  IndexRowPhi phiSTU = fastOrIndexSTU / mNFastORInTRUEta[truIndexTRU];
+
+  // Rotate position on C-side as indices in TRU scheme are rotated on C-side with respect to A-side
+  IndexColumnEta etaTRU = (mTRUIsCside[truIndexTRU]) ? (mNFastORInTRUEta[truIndexTRU] - etaSTU - 1) : etaSTU;
+  IndexRowPhi phiTRU = (mTRUIsCside[truIndexTRU]) ? phiSTU : (mNFastORInTRUPhi[truIndexTRU] - phiSTU - 1);
+  IndexFastOR fastorIndexTRU = etaTRU * mNFastORInTRUPhi[truIndexTRU] + phiTRU;
+
+  return std::make_tuple(truIndexTRU, fastorIndexTRU);
+}
+
+std::tuple<TriggerMappingV2::IndexTRU, TriggerMappingV2::IndexColumnEta, TriggerMappingV2::IndexRowPhi> TriggerMappingV2::convertFastORPositionSTUtoTRU(IndexTRU truIndexSTU, IndexColumnEta truEtaSTU, IndexRowPhi truPhiSTU, DetType_t detector) const
+{
+  auto truIndexTRU = convertTRUIndexSTUtoTRU(truIndexSTU, detector);
+  if (truEtaSTU >= mNFastORInTRUEta[truIndexTRU] || truPhiSTU >= mNFastORInTRUPhi[truIndexTRU]) {
+    throw FastORPositionExceptionTRU(truIndexTRU, truEtaSTU, truPhiSTU);
+  }
+  // Rotate position on C-side as indices in TRU scheme are rotated on C-side with respect to A-side
+  IndexColumnEta truEtaTRU = (mTRUIsCside[truIndexTRU]) ? (mNFastORInTRUEta[truIndexTRU] - truEtaSTU - 1) : truEtaSTU;
+  IndexRowPhi truPhiTRU = (mTRUIsCside[truIndexTRU]) ? truPhiSTU : (mNFastORInTRUPhi[truIndexTRU] - truPhiSTU - 1);
+
+  return std::make_tuple(truIndexTRU, truEtaTRU, truPhiTRU);
+}
+
+std::tuple<TriggerMappingV2::IndexTRU, TriggerMappingV2::IndexFastOR> TriggerMappingV2::convertFastORIndexTRUtoSTU(IndexTRU truIndexTRU, IndexFastOR fastorIndexTRU) const
+{
+  if (truIndexTRU >= FASTORSTRU) {
+    throw FastORIndexException(truIndexTRU);
+  }
+  IndexColumnEta etaTRU = fastorIndexTRU / mNFastORInTRUPhi[truIndexTRU];
+  IndexRowPhi phiTRU = fastorIndexTRU % mNFastORInTRUPhi[truIndexTRU];
+  // Rotate position on C-side as indices in TRU scheme are rotated on C-side with respect to A-side
+  IndexColumnEta etaSTU = (mTRUIsCside[truIndexTRU]) ? (mNFastORInTRUEta[truIndexTRU] - etaTRU - 1) : etaTRU;
+  IndexRowPhi phiSTU = (mTRUIsCside[truIndexTRU]) ? phiTRU : (mNFastORInTRUPhi[truIndexTRU] - phiTRU - 1);
+
+  IndexTRU truIndexSTU = convertTRUIndexTRUtoSTU(truIndexTRU);
+  IndexFastOR fastorIndexSTU = phiSTU * mNFastORInTRUEta[truIndexTRU] + etaSTU;
+
+  return std::tuple(truIndexSTU, fastorIndexSTU);
+}
+
+std::tuple<TriggerMappingV2::IndexTRU, TriggerMappingV2::IndexColumnEta, TriggerMappingV2::IndexRowPhi> TriggerMappingV2::convertFastORPositionTRUtoSTU(IndexTRU truIndexTRU, IndexColumnEta truEtaTRU, IndexRowPhi truPhiTRU) const
+{
+  IndexTRU truIndexSTU = convertTRUIndexTRUtoSTU(truIndexTRU);
+  if (truEtaTRU >= mNFastORInTRUEta[truIndexTRU] || truPhiTRU >= mNFastORInTRUPhi[truIndexTRU]) {
+    throw FastORPositionExceptionTRU(truIndexTRU, truEtaTRU, truPhiTRU);
+  }
+  // Rotate position on C-side as indices in TRU scheme are rotated on C-side with respect to A-side
+  IndexColumnEta truEtaSTU = (mTRUIsCside[truIndexTRU]) ? (mNFastORInTRUEta[truIndexTRU] - truEtaTRU - 1) : truEtaTRU;
+  IndexRowPhi truPhiSTU = (mTRUIsCside[truIndexTRU]) ? truPhiTRU : (mNFastORInTRUPhi[truIndexTRU] - truPhiTRU - 1);
+  return std::make_tuple(truIndexSTU, truEtaSTU, truPhiSTU);
+}


### PR DESCRIPTION
Port functionality of the trigger mapping
from AliEMCALTriggerMappingV2 to
o2::emcal::TriggerMappingV2. Renaming
of functions, arguments and variables
wherever possible with meaningful names.
Error handling via boolean return values
replaced with exception-based error
handling defining meaningful error cases.
Return values are now handled by the
function return (either by value or by tuple)
instead of return via reference arguments.
All internal calculations use unsigned int
as indices are strictly positive or 0, in order
to avoid unnecessary handling of invalid
negative arguments. Doxygen documentation
added to functions whenever possible.