### PR TITLE
Mem improvement for TPC digitization

### DIFF
--- a/Detectors/TPC/simulation/src/DigitContainer.cxx
+++ b/Detectors/TPC/simulation/src/DigitContainer.cxx
@@ -36,27 +36,28 @@ void DigitContainer::fillOutputContainer(std::vector<Digit>& output,
         continue;
       }
       ++nProcessedTimeBins;
-
-      switch (digitizationMode) {
-        case DigitzationMode::FullMode: {
-          time.fillOutputContainer<DigitzationMode::FullMode>(output, mcTruth, commonModeOutput, sector, timeBin);
-          break;
-        }
-        case DigitzationMode::ZeroSuppression: {
-          time.fillOutputContainer<DigitzationMode::ZeroSuppression>(output, mcTruth, commonModeOutput, sector, timeBin);
-          break;
-        }
-        case DigitzationMode::SubtractPedestal: {
-          time.fillOutputContainer<DigitzationMode::SubtractPedestal>(output, mcTruth, commonModeOutput, sector, timeBin);
-          break;
-        }
-        case DigitzationMode::NoSaturation: {
-          time.fillOutputContainer<DigitzationMode::NoSaturation>(output, mcTruth, commonModeOutput, sector, timeBin);
-          break;
-        }
-        case DigitzationMode::PropagateADC: {
-          time.fillOutputContainer<DigitzationMode::PropagateADC>(output, mcTruth, commonModeOutput, sector, timeBin);
-          break;
+      if (time) {
+        switch (digitizationMode) {
+          case DigitzationMode::FullMode: {
+            time->fillOutputContainer<DigitzationMode::FullMode>(output, mcTruth, commonModeOutput, sector, timeBin);
+            break;
+          }
+          case DigitzationMode::ZeroSuppression: {
+            time->fillOutputContainer<DigitzationMode::ZeroSuppression>(output, mcTruth, commonModeOutput, sector, timeBin);
+            break;
+          }
+          case DigitzationMode::SubtractPedestal: {
+            time->fillOutputContainer<DigitzationMode::SubtractPedestal>(output, mcTruth, commonModeOutput, sector, timeBin);
+            break;
+          }
+          case DigitzationMode::NoSaturation: {
+            time->fillOutputContainer<DigitzationMode::NoSaturation>(output, mcTruth, commonModeOutput, sector, timeBin);
+            break;
+          }
+          case DigitzationMode::PropagateADC: {
+            time->fillOutputContainer<DigitzationMode::PropagateADC>(output, mcTruth, commonModeOutput, sector, timeBin);
+            break;
+          }
         }
       }
     } else {
@@ -67,7 +68,11 @@ void DigitContainer::fillOutputContainer(std::vector<Digit>& output,
   if (nProcessedTimeBins > 0) {
     mFirstTimeBin += nProcessedTimeBins;
     while (nProcessedTimeBins--) {
+      auto popped = mTimeBins.front();
       mTimeBins.pop_front();
+      if (popped) {
+        delete popped;
+      }
     }
   }
 }


### PR DESCRIPTION
For simulations with low interaction rate,
we saw high mem spikes (up to 24GB) coming from TPC digitization.

This is due to some preallocation of a std::deque<DigitTime>
container.

This commit preserves the logic but changes
the container to std::deque<DigitTime*> and to a just-in-time
creation of the actual DigitTime objects.

This will lead to huge mem benefits in case of sparse
occupancies and should be equivalent to the old solution
for higher occupancies.

Fixes https://alice.its.cern.ch/jira/browse/O2-3051