### PR TITLE
Add extra info to TPC VDrift correction objects

### DIFF
--- a/DataFormats/Detectors/TPC/CMakeLists.txt
+++ b/DataFormats/Detectors/TPC/CMakeLists.txt
@@ -59,6 +59,7 @@ o2_target_root_dictionary(
           include/DataFormatsTPC/ZeroSuppressionLinkBased.h
           include/DataFormatsTPC/TrackCuts.h
           include/DataFormatsTPC/LtrCalibData.h
+          include/DataFormatsTPC/VDriftCorrFact.h
           include/DataFormatsTPC/CalibdEdxCorrection.h
           include/DataFormatsTPC/BetheBlochAleph.h)
 

--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/LtrCalibData.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/LtrCalibData.h
@@ -26,10 +26,12 @@ struct LtrCalibData {
   size_t processedTFs{};               ///< number of processed TFs with laser track candidates
   uint64_t firstTime{};                ///< first time stamp of processed TFs
   uint64_t lastTime{};                 ///< last time stamp of processed TFs
-  float dvCorrectionA{};               ///< drift velocity correction factor A-Side
-  float dvCorrectionC{};               ///< drift velocity correction factor C-Side
+  long creationTime{};                 ///< time of creation
+  float dvCorrectionA{};               ///< drift velocity correction factor A-Side (inverse multiplicative)
+  float dvCorrectionC{};               ///< drift velocity correction factor C-Side (inverse multiplicative)
   float dvOffsetA{};                   ///< drift velocity trigger offset A-Side
   float dvOffsetC{};                   ///< drift velocity trigger offset C-Side
+  float refVDrift{};                   ///< reference vdrift for which factor was extracted
   uint16_t nTracksA{};                 ///< number of tracks used for A-Side fit
   uint16_t nTracksC{};                 ///< number of tracks used for C-Side fit
   std::vector<uint16_t> matchedLtrIDs; ///< list of matched laser track IDs
@@ -41,6 +43,7 @@ struct LtrCalibData {
     processedTFs = 0;
     firstTime = 0;
     lastTime = 0;
+    creationTime = 0;
     dvCorrectionA = 0;
     dvCorrectionC = 0;
     dvOffsetA = 0;
@@ -51,7 +54,7 @@ struct LtrCalibData {
     matchedLtrIDs.clear();
   }
 
-  ClassDefNV(LtrCalibData, 1);
+  ClassDefNV(LtrCalibData, 2);
 };
 
 } // namespace o2::tpc

--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/VDriftCorrFact.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/VDriftCorrFact.h
@@ -9,12 +9,12 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file LtrCalibData.h
+/// \file VDriftCorrFact.h
 /// \brief calibration data from laser track calibration
 ///
-/// This class holds the calibration output data of CalibLaserTracks
+/// This class holds the calibration output data ITS/TPC tgl difference calibration
 ///
-/// \author Jens Wiechula, Jens.Wiechula@ikf.uni-frankfurt.de
+/// \author ruben.shahoyan@cern.ch
 
 #ifndef AliceO2_TPC_VDRIFT_CORRFACT_H
 #define AliceO2_TPC_VDRIFT_CORRFACT_H

--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/VDriftCorrFact.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/VDriftCorrFact.h
@@ -1,0 +1,36 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file LtrCalibData.h
+/// \brief calibration data from laser track calibration
+///
+/// This class holds the calibration output data of CalibLaserTracks
+///
+/// \author Jens Wiechula, Jens.Wiechula@ikf.uni-frankfurt.de
+
+#ifndef AliceO2_TPC_VDRIFT_CORRFACT_H
+#define AliceO2_TPC_VDRIFT_CORRFACT_H
+
+namespace o2::tpc
+{
+
+struct VDriftCorrFact {
+  long firstTime{};    ///< first time stamp of processed TFs
+  long lastTime{};     ///< last time stamp of processed TFs
+  long creationTime{}; ///< time of creation
+  float corrFact{};    ///< drift velocity correction factor (multiplicative)
+  float corrFactErr{}; ///< stat error of correction factor
+  float refVDrift{};   ///< reference vdrift for which factor was extracted
+  ClassDefNV(VDriftCorrFact, 1);
+};
+
+} // namespace o2::tpc
+#endif

--- a/DataFormats/Detectors/TPC/src/DataFormatsTPCLinkDef.h
+++ b/DataFormats/Detectors/TPC/src/DataFormatsTPCLinkDef.h
@@ -55,6 +55,8 @@
 #pragma link C++ class std::vector < o2::tpc::KrCluster> + ;
 #pragma link C++ class o2::tpc::LtrCalibData + ;
 #pragma link C++ class std::vector < o2::tpc::LtrCalibData> + ;
+#pragma link C++ class o2::tpc::VDriftCorrFact + ;
+#pragma link C++ class std::vector < o2::tpc::VDriftCorrFact> + ;
 #pragma link C++ class o2::tpc::CalibdEdxCorrection + ;
 #pragma link C++ class o2::tpc::dcs::DataPoint < float> + ;
 #pragma link C++ class std::vector < o2::tpc::dcs::DataPoint < float>> + ;

--- a/Detectors/Calibration/CMakeLists.txt
+++ b/Detectors/Calibration/CMakeLists.txt
@@ -16,7 +16,6 @@ o2_add_library(DetectorsCalibration
                    src/MeanVertexData.cxx
                    src/MeanVertexCalibrator.cxx
                    src/MeanVertexParams.cxx
-                   src/TPCVDriftTglCalibration.cxx
                PUBLIC_LINK_LIBRARIES O2::Headers
                    O2::CCDB
                    O2::CommonUtils
@@ -34,8 +33,7 @@ o2_target_root_dictionary(DetectorsCalibration
                                   include/DetectorsCalibration/Utils.h
                                   include/DetectorsCalibration/MeanVertexData.h
                                   include/DetectorsCalibration/MeanVertexCalibrator.h
-                                  include/DetectorsCalibration/MeanVertexParams.h
-                                  include/DetectorsCalibration/TPCVDriftTglCalibration.h)
+                                  include/DetectorsCalibration/MeanVertexParams.h)
 
 o2_add_executable(ccdb-populator-workflow
                   COMPONENT_NAME calibration

--- a/Detectors/Calibration/src/DetectorsCalibrationLinkDef.h
+++ b/Detectors/Calibration/src/DetectorsCalibrationLinkDef.h
@@ -22,8 +22,4 @@
 #pragma link C++ class o2::calibration::MeanVertexParams + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::calibration::MeanVertexParams> + ;
 
-#pragma link C++ class o2::calibration::TimeSlot < o2::calibration::TPCVDTglContainer> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::dataformats::Pair < float, float>, o2::calibration::TPCVDTglContainer> + ;
-#pragma link C++ class o2::calibration::TPCVDriftTglCalibration + ;
-
 #endif

--- a/Detectors/Calibration/workflow/CMakeLists.txt
+++ b/Detectors/Calibration/workflow/CMakeLists.txt
@@ -11,7 +11,6 @@
 
 o2_add_library(DetectorsCalibrationWorkflow
                SOURCES src/MeanVertexCalibratorSpec.cxx
-                       src/TPCVDriftTglCalibSpec.cxx
                PUBLIC_LINK_LIBRARIES O2::Framework
                      O2::Headers
                      O2::CCDB
@@ -30,12 +29,3 @@ o2_add_executable(mean-vertex-calibration-workflow
                     O2::ReconstructionDataFormats
                     O2::DataFormatsCalibration
                     O2::CCDB)
-
-o2_add_executable(calibration-workflow
-                  COMPONENT_NAME tpc-vdrift-tgl
-                  SOURCES src/tpc-vdrift-tgl-calibration-workflow.cxx
-                  PUBLIC_LINK_LIBRARIES O2::Framework
-                                        O2::DetectorsCalibration
-                                        O2::DetectorsCalibrationWorkflow
-                                        O2::DataFormatsCalibration
-                                        O2::CCDB)

--- a/Detectors/TPC/calibration/CMakeLists.txt
+++ b/Detectors/TPC/calibration/CMakeLists.txt
@@ -43,6 +43,7 @@ o2_add_library(TPCCalibration
                        src/CalibratordEdx.cxx
                        src/TrackDump.cxx
                        src/CalibratorPadGainTracks.cxx
+                       src/TPCVDriftTglCalibration.cxx
                PUBLIC_LINK_LIBRARIES O2::DataFormatsTPC O2::TPCBase
                                      O2::TPCReconstruction ROOT::Minuit
                                      Microsoft.GSL::GSL
@@ -83,7 +84,8 @@ o2_target_root_dictionary(TPCCalibration
                                   include/TPCCalibration/CalibratordEdx.h
                                   include/TPCCalibration/TrackDump.h
                                   include/TPCCalibration/IDCDrawHelper.h
-                                  include/TPCCalibration/CalibratorPadGainTracks.h)
+                                  include/TPCCalibration/CalibratorPadGainTracks.h
+                                  include/TPCCalibration/TPCVDriftTglCalibration.h)
 
 o2_add_test_root_macro(macro/comparePedestalsAndNoise.C
                        PUBLIC_LINK_LIBRARIES O2::TPCBase

--- a/Detectors/TPC/calibration/include/TPCCalibration/TPCVDriftTglCalibration.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/TPCVDriftTglCalibration.h
@@ -19,10 +19,11 @@
 #include "DetectorsCalibration/TimeSlotCalibration.h"
 #include "DetectorsCalibration/TimeSlot.h"
 #include "CommonDataFormat/FlatHisto2D.h"
+#include "DataFormatsTPC/VDriftCorrFact.h"
 #include "CommonDataFormat/Pair.h"
 #include "CCDB/CcdbObjectInfo.h"
 
-namespace o2::calibration
+namespace o2::tpc
 {
 struct TPCVDTglContainer {
   std::unique_ptr<o2::dataformats::FlatHisto2D_f> histo;
@@ -79,9 +80,9 @@ class TPCVDriftTglCalibration : public o2::calibration::TimeSlotCalibration<o2::
   void finalizeSlot(Slot& slot) final;
   Slot& emplaceNewSlot(bool front, TFType tstart, TFType tend) final;
 
-  const std::vector<o2::dataformats::Pair<float, float>>& getVDPerSlot() const { return mVDPerSlot; }
+  const std::vector<o2::tpc::VDriftCorrFact>& getVDPerSlot() const { return mVDPerSlot; }
   const std::vector<o2::ccdb::CcdbObjectInfo>& getCCDBInfoPerSlot() const { return mCCDBInfoPerSlot; }
-  std::vector<o2::dataformats::Pair<float, float>>& getVDPerSlot() { return mVDPerSlot; }
+  std::vector<o2::tpc::VDriftCorrFact>& getVDPerSlot() { return mVDPerSlot; }
   std::vector<o2::ccdb::CcdbObjectInfo>& getCCDBInfoPerSlot() { return mCCDBInfoPerSlot; }
 
   void setSaveHistosFile(const std::string& f) { mSaveHistosFile = f; }
@@ -93,11 +94,11 @@ class TPCVDriftTglCalibration : public o2::calibration::TimeSlotCalibration<o2::
   float mMaxTgl = 1.;
   float mMaxDTgl = 0.2;
   std::string mSaveHistosFile{};
-  std::vector<o2::dataformats::Pair<float, float>> mVDPerSlot;
+  std::vector<o2::tpc::VDriftCorrFact> mVDPerSlot;
   std::vector<o2::ccdb::CcdbObjectInfo> mCCDBInfoPerSlot;
 
   ClassDefNV(TPCVDriftTglCalibration, 1);
 };
 
-} // namespace o2::calibration
+} // namespace o2::tpc
 #endif

--- a/Detectors/TPC/calibration/src/CalibLaserTracks.cxx
+++ b/Detectors/TPC/calibration/src/CalibLaserTracks.cxx
@@ -18,6 +18,7 @@
 #include "TPCBase/ParameterElectronics.h"
 #include "TPCCalibration/CalibLaserTracks.h"
 #include "TLinearFitter.h"
+#include <chrono>
 
 using namespace o2::tpc;
 void CalibLaserTracks::fill(std::vector<TrackTPC> const& tracks)
@@ -304,7 +305,8 @@ void CalibLaserTracks::fillCalibData(LtrCalibData& calibData, const std::vector<
 {
   auto dvA = fit(pairsA);
   auto dvC = fit(pairsC);
-
+  calibData.creationTime = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+  calibData.refVDrift = mDriftV;
   calibData.dvOffsetA = dvA.x1;
   calibData.dvCorrectionA = dvA.x2;
   calibData.nTracksA = uint16_t(pairsA.size());

--- a/Detectors/TPC/calibration/src/TPCCalibrationLinkDef.h
+++ b/Detectors/TPC/calibration/src/TPCCalibrationLinkDef.h
@@ -90,4 +90,8 @@
 #pragma link C++ class o2::tpc::sac::DecodedData + ;
 #pragma link C++ class o2::tpc::sac::Decoder;
 
+#pragma link C++ class o2::calibration::TimeSlot < o2::tpc::TPCVDTglContainer> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::dataformats::Pair < float, float>, o2::tpc::TPCVDTglContainer> + ;
+#pragma link C++ class o2::tpc::TPCVDriftTglCalibration + ;
+
 #endif

--- a/Detectors/TPC/workflow/CMakeLists.txt
+++ b/Detectors/TPC/workflow/CMakeLists.txt
@@ -34,6 +34,7 @@ o2_add_library(TPCWorkflow
                        src/ProcessingHelpers.cxx
                        src/TrackAndClusterFilterSpec.cxx
                        src/FileWriterSpec.cxx
+                       src/TPCVDriftTglCalibSpec.cxx
                TARGETVARNAME targetName
                PUBLIC_LINK_LIBRARIES O2::Framework O2::DataFormatsTPC
                                      O2::DPLUtils O2::TPCReconstruction
@@ -210,5 +211,15 @@ o2_add_executable(entropy-encoder-workflow
                   SOURCES src/entropy-encoder-workflow.cxx
                   COMPONENT_NAME tpc
                   PUBLIC_LINK_LIBRARIES O2::TPCWorkflow)
+
+o2_add_executable(calibration-workflow
+                  COMPONENT_NAME tpc-vdrift-tgl
+                  SOURCES src/tpc-vdrift-tgl-calibration-workflow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::Framework
+                                        O2::TPCWorkflow
+                                        O2::DetectorsCalibration
+                                        O2::DetectorsCalibrationWorkflow
+                                        O2::DataFormatsCalibration
+                                        O2::CCDB)
 
 add_subdirectory(readers)

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCVDriftTglCalibSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCVDriftTglCalibSpec.h
@@ -17,7 +17,7 @@
 
 #include "Framework/DataProcessorSpec.h"
 
-namespace o2::calibration
+namespace o2::tpc
 {
 
 o2::framework::DataProcessorSpec getTPCVDriftTglCalibSpec(int ntgl, float tglMax, int ndtgl, float dtglMax, size_t slotL, size_t minEnt);

--- a/Detectors/TPC/workflow/src/TPCVDriftTglCalibSpec.cxx
+++ b/Detectors/TPC/workflow/src/TPCVDriftTglCalibSpec.cxx
@@ -14,8 +14,8 @@
 #include "Framework/ControlService.h"
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/Logger.h"
-#include "DetectorsCalibration/TPCVDriftTglCalibration.h"
-#include "DetectorsCalibrationWorkflow/TPCVDriftTglCalibSpec.h"
+#include "TPCCalibration/TPCVDriftTglCalibration.h"
+#include "TPCWorkflow/TPCVDriftTglCalibSpec.h"
 #include "DetectorsCalibration/Utils.h"
 #include "CCDB/CcdbApi.h"
 #include "CCDB/CcdbObjectInfo.h"
@@ -25,14 +25,14 @@ using namespace o2::framework;
 
 namespace o2
 {
-namespace calibration
+namespace tpc
 {
 class TPCVDriftTglCalibSpec : public Task
 {
  public:
   TPCVDriftTglCalibSpec(int ntgl, float tglMax, int ndtgl, float dtglMax, size_t slotL, size_t minEnt, std::shared_ptr<o2::base::GRPGeomRequest> req) : mCCDBRequest(req)
   {
-    mCalibrator = std::make_unique<o2::calibration::TPCVDriftTglCalibration>(ntgl, tglMax, ndtgl, dtglMax, slotL, minEnt);
+    mCalibrator = std::make_unique<o2::tpc::TPCVDriftTglCalibration>(ntgl, tglMax, ndtgl, dtglMax, slotL, minEnt);
   }
 
   void init(InitContext& ic) final
@@ -65,7 +65,7 @@ class TPCVDriftTglCalibSpec : public Task
 
  private:
   void sendOutput(DataAllocator& output);
-  std::unique_ptr<o2::calibration::TPCVDriftTglCalibration> mCalibrator;
+  std::unique_ptr<o2::tpc::TPCVDriftTglCalibration> mCalibrator;
   std::shared_ptr<o2::base::GRPGeomRequest> mCCDBRequest;
 };
 
@@ -96,7 +96,7 @@ void TPCVDriftTglCalibSpec::sendOutput(DataAllocator& output)
 DataProcessorSpec getTPCVDriftTglCalibSpec(int ntgl, float tglMax, int ndtgl, float dtglMax, size_t slotL, size_t minEnt)
 {
 
-  using device = o2::calibration::TPCVDriftTglCalibSpec;
+  using device = o2::tpc::TPCVDriftTglCalibSpec;
   using clbUtils = o2::calibration::Utils;
 
   std::vector<InputSpec> inputs;
@@ -117,9 +117,9 @@ DataProcessorSpec getTPCVDriftTglCalibSpec(int ntgl, float tglMax, int ndtgl, fl
     "tpc-vd-tgl-calib",
     inputs,
     outputs,
-    AlgorithmSpec{adaptFromTask<o2::calibration::TPCVDriftTglCalibSpec>(ntgl, tglMax, ndtgl, dtglMax, slotL, minEnt, ccdbRequest)},
+    AlgorithmSpec{adaptFromTask<o2::tpc::TPCVDriftTglCalibSpec>(ntgl, tglMax, ndtgl, dtglMax, slotL, minEnt, ccdbRequest)},
     Options{{"vdtgl-histos-file-name", VariantType::String, "", {"file to save histos (if name provided)"}}}};
 }
 
-} // namespace calibration
+} // namespace tpc
 } // namespace o2

--- a/Detectors/TPC/workflow/src/tpc-vdrift-tgl-calibration-workflow.cxx
+++ b/Detectors/TPC/workflow/src/tpc-vdrift-tgl-calibration-workflow.cxx
@@ -10,7 +10,7 @@
 // or submit itself to any jurisdiction.
 
 #include "Framework/DataProcessorSpec.h"
-#include "DetectorsCalibrationWorkflow/TPCVDriftTglCalibSpec.h"
+#include "TPCWorkflow/TPCVDriftTglCalibSpec.h"
 #include "CommonUtils/ConfigurableParam.h"
 
 using namespace o2::framework;
@@ -38,11 +38,11 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 {
   WorkflowSpec specs;
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
-  specs.emplace_back(o2::calibration::getTPCVDriftTglCalibSpec(configcontext.options().get<int>("nbins-tgl"),
-                                                               configcontext.options().get<float>("max-tgl-its"),
-                                                               configcontext.options().get<int>("nbins-dtgl"),
-                                                               configcontext.options().get<float>("max-dtgl-itstpc"),
-                                                               configcontext.options().get<int>("time-slot-length"),
-                                                               configcontext.options().get<int>("min-entries-per-slot")));
+  specs.emplace_back(o2::tpc::getTPCVDriftTglCalibSpec(configcontext.options().get<int>("nbins-tgl"),
+                                                       configcontext.options().get<float>("max-tgl-its"),
+                                                       configcontext.options().get<int>("nbins-dtgl"),
+                                                       configcontext.options().get<float>("max-dtgl-itstpc"),
+                                                       configcontext.options().get<int>("time-slot-length"),
+                                                       configcontext.options().get<int>("min-entries-per-slot")));
   return specs;
 }


### PR DESCRIPTION
* Store in LtrCalibData reference VDrift and creation time 
* Move TPC VDtgl calibration to TPC/calibration
Use VDriftCorrFact object for CCDB, which apart from the correction/error provides reference VDrift used and stores the timestamp of the calibration

@wiechula since we are working with correction factors rather than abs. vdrift, to keep track of what was the reference vdrift used for the calibration I add it both to LtrCalibData and to the object created by the tgl-calibration.
Also adding the timestamp of creation since at run-time will need to select among different sources.

@martenole one thing we have not discussed: the residuals should be extracted wrt well-defined reference VDrift, currently it is whatever value of `GasParam.VDrift` you use to create the transform map when working with clusters. 
Eventually, we should stop playing with `GasParam.VDrift` from the command line and instead use whatever reference was stored in the LtrCalibData or VDriftCorrFact objects, I'll provide a helper for that.
