### PR TITLE
MRRTF-190: decrease precluster finder verbosity

### DIFF
--- a/Detectors/MUON/MCH/Base/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Base/CMakeLists.txt
@@ -11,6 +11,7 @@
 
 o2_add_library(MCHBase
          SOURCES
+           src/ErrorMap.cxx
            src/MathiesonOriginal.cxx
            src/PreCluster.cxx
            src/SanityCheck.cxx
@@ -25,6 +26,12 @@ o2_target_root_dictionary(MCHBase
 
 o2_add_test(trackable
             SOURCES src/testTrackable.cxx
+            COMPONENT_NAME mch
+            PUBLIC_LINK_LIBRARIES O2::MCHBase
+            LABELS muon;mch)
+
+o2_add_test(errormap
+            SOURCES src/testErrorMap.cxx
             COMPONENT_NAME mch
             PUBLIC_LINK_LIBRARIES O2::MCHBase
             LABELS muon;mch)

--- a/Detectors/MUON/MCH/Base/include/MCHBase/ErrorMap.h
+++ b/Detectors/MUON/MCH/Base/include/MCHBase/ErrorMap.h
@@ -1,0 +1,69 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_MCH_BASE_ERROR_MAP_H_H
+#define O2_MCH_BASE_ERROR_MAP_H_H
+
+#include <map>
+#include <set>
+#include <cstdint>
+#include <functional>
+
+namespace o2::mch
+{
+
+/** A container class to summarize errors encountered during processing.
+ *
+ * The interface is :
+ * add(errorType, id0, id1)
+ *
+ * where errorType, id0 and id1 are integers (unsigned, 32 bits wide)
+ *
+ * ErrorMap stores the number of times the add method has been
+ * called for the {errorType,id0,id1} triplet.
+ *
+ * The exact meaning of the triplet members is left to the client of ErrorMap.
+ *
+ */
+class ErrorMap
+{
+ public:
+  /* ErrorFunction is a function that receive a triplet {errorType,id0,id1)
+   * and the number of times (count) that triplet has been seen.
+   */
+  using ErrorFunction = std::function<void(uint32_t errorType,
+                                           uint32_t id0,
+                                           uint32_t id1,
+                                           uint64_t count)>;
+
+  /* increment the count of the {errorType,id0,id1} triplet by one.*/
+  void add(uint32_t errorType, uint32_t id0, uint32_t id1);
+
+  /* execute function f on all {errorType,id0,id1} triplets.
+   *
+   * The function is passed the triplet and the corresponding occurence count
+   * of that triplet.
+   */
+  void forEach(ErrorFunction f) const;
+
+ private:
+  std::map<uint32_t, std::map<uint64_t, uint64_t>> mErrorCounts;
+};
+
+/* convenience function to get the number of error types */
+uint64_t numberOfErrorTypes(const ErrorMap& em);
+
+/* convenience function to get the total number of errors */
+uint64_t totalNumberOfErrors(const ErrorMap& em);
+
+}; // namespace o2::mch
+
+#endif

--- a/Detectors/MUON/MCH/Base/src/ErrorMap.cxx
+++ b/Detectors/MUON/MCH/Base/src/ErrorMap.cxx
@@ -1,0 +1,73 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "MCHBase/ErrorMap.h"
+
+namespace o2::mch
+{
+
+uint64_t encode(uint32_t a, uint32_t b)
+{
+  uint64_t r = a;
+  r = (r << 32) & 0xFFFFFFFF00000000 | b;
+  return r;
+}
+
+std::pair<uint32_t, uint32_t> decode(uint64_t x)
+{
+  uint32_t a = static_cast<uint32_t>((x & 0xFFFFFFFF00000000) >> 32);
+  uint32_t b = static_cast<uint32_t>(x & 0xFFFFFFFF);
+  return std::make_pair(a, b);
+}
+
+void ErrorMap::add(uint32_t errorType, uint32_t id0, uint32_t id1)
+{
+  mErrorCounts[errorType][encode(id0, id1)]++;
+}
+
+void ErrorMap::forEach(ErrorFunction f) const
+{
+  for (auto errorType : mErrorCounts) {
+    for (auto errorCounts : errorType.second) {
+      uint64_t count = errorCounts.second;
+      uint64_t id = errorCounts.first;
+      auto [id0, id1] = decode(id);
+      f(errorType.first, id0, id1, count);
+    }
+  }
+}
+
+uint64_t numberOfErrorTypes(const ErrorMap& em)
+{
+  std::set<uint32_t> errorTypes;
+  auto countErrorTypes = [&errorTypes](uint32_t errorType,
+                                       uint32_t /*id0*/,
+                                       uint32_t /*id1*/,
+                                       uint64_t /*count*/) {
+    errorTypes.emplace(errorType);
+  };
+  em.forEach(countErrorTypes);
+  return errorTypes.size();
+}
+
+uint64_t totalNumberOfErrors(const ErrorMap& em)
+{
+  uint64_t n{0};
+  auto countErrors = [&n](uint32_t /*errorType*/,
+                          uint32_t /*id0*/,
+                          uint32_t /*id1*/,
+                          uint64_t count) {
+    n += count;
+  };
+  em.forEach(countErrors);
+  return n;
+}
+}; // namespace o2::mch

--- a/Detectors/MUON/MCH/Base/src/testErrorMap.cxx
+++ b/Detectors/MUON/MCH/Base/src/testErrorMap.cxx
@@ -1,0 +1,67 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE errormap test
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include "MCHBase/ErrorMap.h"
+#include <fmt/core.h>
+
+using o2::mch::ErrorMap;
+
+BOOST_AUTO_TEST_CASE(DefaultErrorMapShouldBeEmpty)
+{
+  ErrorMap em;
+  BOOST_CHECK_EQUAL(o2::mch::numberOfErrorTypes(em), 0);
+  BOOST_CHECK_EQUAL(o2::mch::totalNumberOfErrors(em), 0);
+}
+
+BOOST_AUTO_TEST_CASE(AddingErrorType)
+{
+  ErrorMap em;
+  em.add(0, 0, 0);
+  em.add(1, 0, 0);
+  em.add(2, 0, 0);
+  BOOST_CHECK_EQUAL(o2::mch::numberOfErrorTypes(em), 3);
+}
+
+BOOST_AUTO_TEST_CASE(AddingError)
+{
+  ErrorMap em;
+  em.add(0, 0, 0);
+  em.add(0, 0, 0);
+  em.add(0, 0, 0);
+  BOOST_CHECK_EQUAL(o2::mch::numberOfErrorTypes(em), 1);
+  BOOST_CHECK_EQUAL(o2::mch::totalNumberOfErrors(em), 3);
+}
+
+BOOST_AUTO_TEST_CASE(ErrorFunction)
+{
+  ErrorMap em;
+  em.add(0, 0, 0);
+  em.add(0, 0, 0);
+  em.add(0, 0, 0);
+  em.add(0, 1, 2);
+
+  std::vector<std::string> lines;
+  auto f = [&lines](uint32_t errorType, uint32_t id0, uint32_t id1,
+                    uint64_t count) {
+    lines.emplace_back(fmt::format("ET {} ID [{},{}] seen {} time(s)", errorType, id0, id1, count));
+  };
+  em.forEach(f);
+  for (auto s : lines) {
+    std::cout << s << "\n";
+  }
+  BOOST_REQUIRE_EQUAL(lines.size(), 2);
+  BOOST_CHECK_EQUAL(lines[0], "ET 0 ID [0,0] seen 3 time(s)");
+  BOOST_CHECK_EQUAL(lines[1], "ET 0 ID [1,2] seen 1 time(s)");
+}

--- a/Detectors/MUON/MCH/PreClustering/include/MCHPreClustering/PreClusterFinder.h
+++ b/Detectors/MUON/MCH/PreClustering/include/MCHPreClustering/PreClusterFinder.h
@@ -16,16 +16,17 @@
 #ifndef O2_MCH_PRECLUSTERFINDER_H_
 #define O2_MCH_PRECLUSTERFINDER_H_
 
+#include "DataFormatsMCH/Digit.h"
+#include "MCHBase/ErrorMap.h"
+#include "MCHBase/PreCluster.h"
 #include <cassert>
 #include <cstdint>
-#include <unordered_map>
-#include <vector>
-#include <memory>
-
 #include <gsl/span>
-
-#include "DataFormatsMCH/Digit.h"
-#include "MCHBase/PreCluster.h"
+#include <memory>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+#include <map>
 
 namespace o2
 {
@@ -55,6 +56,8 @@ class PreClusterFinder
   int run();
 
   void getPreClusters(std::vector<o2::mch::PreCluster>& preClusters, std::vector<Digit>& digits);
+
+  ErrorMap errorMap() const { return mErrorMap; }
 
  private:
   struct DetectionElement;
@@ -89,6 +92,10 @@ class PreClusterFinder
 
   int mNPreClusters[SNDEs][2]{};                                     ///< number of preclusters in each cathods of each DE
   std::vector<std::unique_ptr<PreCluster>> mPreClusters[SNDEs][2]{}; ///< preclusters in each cathods of each DE
+
+  enum ErrorTypes : uint32_t { kMultipleDigitInSamePad = 0 };
+
+  ErrorMap mErrorMap; ///< counting of encountered errors
 };
 
 } // namespace mch

--- a/Detectors/MUON/MCH/PreClustering/src/PreClusterFinder.cxx
+++ b/Detectors/MUON/MCH/PreClustering/src/PreClusterFinder.cxx
@@ -67,6 +67,11 @@ void PreClusterFinder::init()
 void PreClusterFinder::deinit()
 {
   /// clear the internal structure
+  auto print = [](uint32_t /*errorType*/, uint32_t deId, uint32_t padid,
+                  uint64_t count) {
+    LOGP(warning, "multiple digits on the same pad (DE {} pad {}): seen {} time{}", deId, padid, count, count > 1 ? "s" : "");
+  };
+  mErrorMap.forEach(print);
   reset();
   mDEIndices.clear();
 }
@@ -138,7 +143,7 @@ void PreClusterFinder::loadDigit(const Digit& digit)
 
   // check that the pad is not already fired
   if (de.mapping->pads[iPad].useMe) {
-    LOG(info) << "multiple digits on the same pad (DE " << digit.getDetID() << ", pad " << iPad << ")";
+    mErrorMap.add(kMultipleDigitInSamePad, digit.getDetID(), iPad);
     return;
   }
 


### PR DESCRIPTION
just store the number of times the "multiple digits on the same pad"
error is encountered and show the summary at de-initialization phase.

@pillot @aferrero2707 we might consider reusing the newly introduced ErrorMap class in other places as well. To be seen.
Note that in this PR I just changed the way the reporting is done : from "right away" to only once at the end, but we probably should actually sending the ErrorMap in the corresponding DeviceSpec instead (and quality-control it for instance), as the logs are not really that useful on the long term.