### PR TITLE
Fix ITS aggregator for EoS operations at P2

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdAggregatorSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdAggregatorSpec.h
@@ -92,10 +92,10 @@ class ITSThresholdAggregator : public Task
   // confDB version
   short int mDBversion = -1;
 
-  // DataTakingContext used to get lhcperiod 
+  // DataTakingContext used to get lhcperiod
   o2::framework::DataTakingContext mDataTakingContext{};
 
-  // Timing info used to get run number 
+  // Timing info used to get run number
   o2::framework::TimingInfo mTimingInfo{};
 };
 

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdAggregatorSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdAggregatorSpec.h
@@ -33,6 +33,8 @@
 #include "CCDB/CcdbApi.h"
 #include "DataFormatsDCS/DCSConfigObject.h"
 #include "Framework/InputRecordWalker.h"
+#include "Framework/DataTakingContext.h"
+#include "Framework/TimingInfo.h"
 
 using namespace o2::framework;
 using namespace o2::itsmft;
@@ -58,8 +60,7 @@ class ITSThresholdAggregator : public Task
   //////////////////////////////////////////////////////////////////
  private:
   void finalizeOutput();
-  void updateLHCPeriod(ProcessingContext&);
-  void updateRunID(ProcessingContext&);
+  void updateLHCPeriodAndRunNumber(ProcessingContext&);
 
   std::unique_ptr<o2::ccdb::CcdbObjectInfo> mWrapper = nullptr;
   std::string mOutputStr;
@@ -90,6 +91,12 @@ class ITSThresholdAggregator : public Task
   int mRunNumber = -1;
   // confDB version
   short int mDBversion = -1;
+
+  // DataTakingContext used to get lhcperiod 
+  o2::framework::DataTakingContext mDataTakingContext{};
+
+  // Timing info used to get run number 
+  o2::framework::TimingInfo mTimingInfo{};
 };
 
 // Create a processor spec

--- a/Detectors/ITSMFT/ITS/workflow/src/ThresholdAggregatorSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ThresholdAggregatorSpec.cxx
@@ -45,6 +45,11 @@ void ITSThresholdAggregator::init(InitContext& ic)
 // Get DCSconfigObject_t from EPNs and aggregate them in 1 object
 void ITSThresholdAggregator::run(ProcessingContext& pc)
 {
+  // Skip everything in case of garbage (potentially at EoS)
+  if (pc.services().get<o2::framework::TimingInfo>().firstTFOrbit == -1U) {
+    LOG(info) << "Skipping the processing of inputs for timeslice " << pc.services().get<o2::framework::TimingInfo>().timeslice << " (firstTFOrbit is " << pc.services().get<o2::framework::TimingInfo>().firstTFOrbit << ")";
+    return;
+  }
   // take run type, scan type, fit type, db version only at the beginning (important for EoS operations!)
   if (mRunType == -1) {
     for (auto const& inputRef : InputRecordWalker(pc.inputs(), {{"check", ConcreteDataTypeMatcher{"ITS", "RUNT"}}})) {
@@ -69,7 +74,7 @@ void ITSThresholdAggregator::run(ProcessingContext& pc)
     LOG(info) << "Run number: " << mRunNumber;
     LOG(info) << "LHC period: " << mLHCPeriod;
     LOG(info) << "Scan type : " << mScanType;
-    LOG(info) << "Fit type  : " << mFitType;
+    LOG(info) << "Fit type  : " << std::to_string(mFitType);
     LOG(info) << "DB version: " << mDBversion;
   }
   for (auto const& inputRef : InputRecordWalker(pc.inputs(), {{"check", ConcreteDataTypeMatcher{"ITS", "TSTR"}}})) {

--- a/Detectors/ITSMFT/ITS/workflow/src/ThresholdAggregatorSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ThresholdAggregatorSpec.cxx
@@ -46,7 +46,7 @@ void ITSThresholdAggregator::init(InitContext& ic)
 void ITSThresholdAggregator::run(ProcessingContext& pc)
 {
   // take run type, scan type, fit type, db version only at the beginning (important for EoS operations!)
-  if(mRunType == -1) {
+  if (mRunType == -1) {
     for (auto const& inputRef : InputRecordWalker(pc.inputs(), {{"check", ConcreteDataTypeMatcher{"ITS", "RUNT"}}})) {
       updateLHCPeriodAndRunNumber(pc);
       mRunType = pc.inputs().get<short int>(inputRef);
@@ -115,7 +115,9 @@ void ITSThresholdAggregator::finalize(EndOfStreamContext* ec)
   auto class_name = o2::utils::MemFileHelper::getClassName(tuningMerge);
 
   // Create metadata for database object
-  std::string ft = this->mFitType == 0 ? "derivative" : this->mFitType == 1 ? "fit" : this->mFitType == 2 ? "hitcounting" : "null";
+  std::string ft = this->mFitType == 0 ? "derivative" : this->mFitType == 1 ? "fit"
+                                                      : this->mFitType == 2 ? "hitcounting"
+                                                                            : "null";
   if (mScanType == 'D' || mScanType == 'A') {
     ft = "null";
   }

--- a/Detectors/ITSMFT/ITS/workflow/src/ThresholdAggregatorSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ThresholdAggregatorSpec.cxx
@@ -45,26 +45,32 @@ void ITSThresholdAggregator::init(InitContext& ic)
 // Get DCSconfigObject_t from EPNs and aggregate them in 1 object
 void ITSThresholdAggregator::run(ProcessingContext& pc)
 {
-  // take run type and scan type at the beginning
-  for (auto const& inputRef : InputRecordWalker(pc.inputs(), {{"check", ConcreteDataTypeMatcher{"ITS", "RUNT"}}})) {
-    if (mRunType == -1) {
-      updateRunID(pc);
-      updateLHCPeriod(pc);
+  // take run type, scan type, fit type, db version only at the beginning (important for EoS operations!)
+  if(mRunType == -1) {
+    for (auto const& inputRef : InputRecordWalker(pc.inputs(), {{"check", ConcreteDataTypeMatcher{"ITS", "RUNT"}}})) {
+      updateLHCPeriodAndRunNumber(pc);
+      mRunType = pc.inputs().get<short int>(inputRef);
+      break;
     }
-    mRunType = pc.inputs().get<short int>(inputRef);
-    break;
-  }
-  for (auto const& inputRef : InputRecordWalker(pc.inputs(), {{"check", ConcreteDataTypeMatcher{"ITS", "SCANT"}}})) {
-    mScanType = pc.inputs().get<char>(inputRef);
-    break;
-  }
-  for (auto const& inputRef : InputRecordWalker(pc.inputs(), {{"check", ConcreteDataTypeMatcher{"ITS", "FITT"}}})) {
-    mFitType = pc.inputs().get<char>(inputRef);
-    break;
-  }
-  for (auto const& inputRef : InputRecordWalker(pc.inputs(), {{"check", ConcreteDataTypeMatcher{"ITS", "CONFDBV"}}})) {
-    mDBversion = pc.inputs().get<short int>(inputRef);
-    break;
+    for (auto const& inputRef : InputRecordWalker(pc.inputs(), {{"check", ConcreteDataTypeMatcher{"ITS", "SCANT"}}})) {
+      mScanType = pc.inputs().get<char>(inputRef);
+      break;
+    }
+    for (auto const& inputRef : InputRecordWalker(pc.inputs(), {{"check", ConcreteDataTypeMatcher{"ITS", "FITT"}}})) {
+      mFitType = pc.inputs().get<char>(inputRef);
+      break;
+    }
+    for (auto const& inputRef : InputRecordWalker(pc.inputs(), {{"check", ConcreteDataTypeMatcher{"ITS", "CONFDBV"}}})) {
+      mDBversion = pc.inputs().get<short int>(inputRef);
+      break;
+    }
+    LOG(info) << "Aggregator received the following parameters:";
+    LOG(info) << "Run type  : " << mRunType;
+    LOG(info) << "Run number: " << mRunNumber;
+    LOG(info) << "LHC period: " << mLHCPeriod;
+    LOG(info) << "Scan type : " << mScanType;
+    LOG(info) << "Fit type  : " << mFitType;
+    LOG(info) << "DB version: " << mDBversion;
   }
   for (auto const& inputRef : InputRecordWalker(pc.inputs(), {{"check", ConcreteDataTypeMatcher{"ITS", "TSTR"}}})) {
     // Read strings with tuning info
@@ -109,8 +115,7 @@ void ITSThresholdAggregator::finalize(EndOfStreamContext* ec)
   auto class_name = o2::utils::MemFileHelper::getClassName(tuningMerge);
 
   // Create metadata for database object
-  std::string ft = this->mFitType == 0 ? "derivative" : this->mFitType == 1 ? "fit"
-                                                                            : "hitcounting";
+  std::string ft = this->mFitType == 0 ? "derivative" : this->mFitType == 1 ? "fit" : this->mFitType == 2 ? "hitcounting" : "null";
   if (mScanType == 'D' || mScanType == 'A') {
     ft = "null";
   }
@@ -131,7 +136,8 @@ void ITSThresholdAggregator::finalize(EndOfStreamContext* ec)
   std::string name_str = mScanType == 'V' ? "VCASN" : mScanType == 'I' ? "ITHR"
                                                     : mScanType == 'D' ? "DIG"
                                                     : mScanType == 'A' ? "ANA"
-                                                                       : "THR";
+                                                    : mScanType == 'T' ? "THR"
+                                                                       : "NULL";
   o2::ccdb::CcdbObjectInfo info((path + name_str), "threshold_map", "calib_scan.root", md, tstart, tend);
   o2::ccdb::CcdbObjectInfo info_pixtyp((path + name_str), "threshold_map", "calib_scan.root", md, tstart, tend);
 
@@ -172,7 +178,7 @@ void ITSThresholdAggregator::finalize(EndOfStreamContext* ec)
       ec->outputs().snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "ANA", 0}, *image_pixtyp);
       ec->outputs().snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "ANA", 0}, info_pixtyp);
     } else {
-      LOG(error) << "Nothing sent to ccdb-populator, mScanType does not match any known scan type";
+      LOG(error) << "Nothing sent to ccdb-populator, mScanType" << mScanType << "does not match any known scan type";
     }
   }
 
@@ -187,7 +193,7 @@ void ITSThresholdAggregator::finalize(EndOfStreamContext* ec)
 
   if (!mCcdbUrlProd.empty()) { // if url is specified, send object to ccdb from THIS wf
 
-    LOG(info) << "Sending Noisy, Dead and Inefficenct pixel object " << info_pixtyp.getFileName() << " to " << mCcdbUrlProd << "/browse/" << info_pixtyp.getPath() << " from the ITS calib workflow";
+    LOG(info) << "Sending Noisy, Dead and Inefficenct pixel object " << info_pixtyp.getFileName() << " (size:" << image_pixtyp->size() << ") to " << mCcdbUrlProd << "/browse/" << info_pixtyp.getPath() << " from the ITS calib workflow";
     o2::ccdb::CcdbApi mApiProd;
     mApiProd.init(mCcdbUrlProd);
     mApiProd.storeAsBinaryFile(&image_pixtyp->at(0), image_pixtyp->size(), info_pixtyp.getFileName(), info_pixtyp.getObjectType(), info_pixtyp.getPath(), info_pixtyp.getMetaData(), info_pixtyp.getStartValidityTimestamp(), info_pixtyp.getEndValidityTimestamp());
@@ -219,11 +225,11 @@ void ITSThresholdAggregator::endOfStream(EndOfStreamContext& ec)
 }
 
 /////////////////////////////////////////////////////////////////////////////
-// Search current month  or LHCperiod
-void ITSThresholdAggregator::updateLHCPeriod(ProcessingContext& pc)
+// Search current month  or LHCperiod, and read run number
+void ITSThresholdAggregator::updateLHCPeriodAndRunNumber(ProcessingContext& pc)
 {
-  auto conf = pc.services().get<RawDeviceService>().device()->fConfig;
-  const std::string LHCPeriodStr = conf->GetProperty<std::string>("LHCPeriod", "");
+  mDataTakingContext = pc.services().get<DataTakingContext>();
+  const std::string LHCPeriodStr = mDataTakingContext.lhcPeriod;
   if (!(LHCPeriodStr.empty())) {
     this->mLHCPeriod = LHCPeriodStr;
   } else {
@@ -236,18 +242,9 @@ void ITSThresholdAggregator::updateLHCPeriod(ProcessingContext& pc)
   }
   this->mLHCPeriod += "_ITS";
 
-  return;
-}
-
-//////////////////////////////////////////////////////////////////////////////
-// Retrieve Run Number
-void ITSThresholdAggregator::updateRunID(ProcessingContext& pc)
-{
-  const auto dh = DataRefUtils::getHeader<o2::header::DataHeader*>(
-    pc.inputs().getFirstValid(true));
-  if (dh->runNumber != 0) {
-    this->mRunNumber = dh->runNumber;
-  }
+  // Run number
+  mTimingInfo = pc.services().get<o2::framework::TimingInfo>();
+  this->mRunNumber = mTimingInfo.runNumber;
 
   return;
 }

--- a/Detectors/ITSMFT/ITS/workflow/src/ThresholdCalibratorSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ThresholdCalibratorSpec.cxx
@@ -723,7 +723,7 @@ void ITSThresholdCalibrator::run(ProcessingContext& pc)
           LOG(info) << "Calibrator will ship these run parameters to aggregator:";
           LOG(info) << "Run type  : " << mRunType;
           LOG(info) << "Scan type : " << mScanType;
-          LOG(info) << "Fit type  : " << mFitType;
+          LOG(info) << "Fit type  : " << std::to_string(mFitType);
           LOG(info) << "DB version: " << mConfDBv;
         }
         this->mRunTypeUp = ((short int)(calib.calibUserField >> 24)) & 0xff;

--- a/Detectors/ITSMFT/ITS/workflow/src/ThresholdCalibratorSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ThresholdCalibratorSpec.cxx
@@ -718,7 +718,7 @@ void ITSThresholdCalibrator::run(ProcessingContext& pc)
 
         if (this->mRunType == -1) {
           short int runtype = ((short int)(calib.calibUserField >> 24)) & 0xff;
-          mConfDBv = ((short int)(calib.calibUserField >> 32)) & 0xffff; // confDB version 
+          mConfDBv = ((short int)(calib.calibUserField >> 32)) & 0xffff; // confDB version
           this->setRunType(runtype);
           LOG(info) << "Calibrator will ship these run parameters to aggregator:";
           LOG(info) << "Run type  : " << mRunType;

--- a/Detectors/ITSMFT/ITS/workflow/src/ThresholdCalibratorSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ThresholdCalibratorSpec.cxx
@@ -718,9 +718,13 @@ void ITSThresholdCalibrator::run(ProcessingContext& pc)
 
         if (this->mRunType == -1) {
           short int runtype = ((short int)(calib.calibUserField >> 24)) & 0xff;
-          mConfDBv = ((short int)(calib.calibUserField >> 32)) & 0xffff; // confDB version
-          LOG(info) << "confDB version in use: " << mConfDBv;
+          mConfDBv = ((short int)(calib.calibUserField >> 32)) & 0xffff; // confDB version 
           this->setRunType(runtype);
+          LOG(info) << "Calibrator will ship these run parameters to aggregator:";
+          LOG(info) << "Run type  : " << mRunType;
+          LOG(info) << "Scan type : " << mScanType;
+          LOG(info) << "Fit type  : " << mFitType;
+          LOG(info) << "DB version: " << mConfDBv;
         }
         this->mRunTypeUp = ((short int)(calib.calibUserField >> 24)) & 0xff;
         // Divide calibration word (24-bit) by 2^16 to get the first 8 bits


### PR DESCRIPTION
@shahor02 this should apply the fixes we discuss to operate with EoS at P2. I have one question:
- this part https://github.com/AliceO2Group/AliceO2/blob/3c74bf64226e93eb5ca102a115432a44a9d29dc1/Detectors/ITSMFT/ITS/workflow/src/ThresholdAggregatorSpec.cxx#L69-L87 take pieces of strings from calibrators and merge them in 1 big string. Here I did not put any protection for the garbage arriving at EoS. Might this be an issue? In principle these are DCSConfigObject_t which are not filled at EoS time by calibrators and hence I guess the aggregator should not do anything. 

I keep it as WIP because I want to test it locally just to be sure that everything works as expected (at least locally)