### PR TITLE
Writer for PHY triggers from ITS/MFT data

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/GBTLink.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/GBTLink.h
@@ -85,7 +85,7 @@ struct GBTLink {
   CollectedDataStatus status = None;
   Format format = NewFormat;
   Verbosity verbosity = VerboseErrors;
-  std::vector<GBTTrigger>* extTrigVec = nullptr;
+  std::vector<GBTTriggerR>* extTrigVec = nullptr;
   uint8_t idInRU = 0;     // link ID within the RU
   uint8_t idInCRU = 0;    // link ID within the CRU
   uint8_t endPointID = 0; // endpoint ID of the CRU
@@ -278,7 +278,8 @@ GBTLink::CollectedDataStatus GBTLink::collectROFCableData(const Mapping& chmap)
             gbtTrg = gbtTrgTmp; // this is a trigger describing the following data
           } else {
             if (extTrigVec) { // this link collects external triggers
-              extTrigVec->push_back(*gbtTrgTmp);
+              extTrigVec->emplace_back(GBTTriggerR{uint32_t(gbtTrgTmp->orbit), uint16_t(gbtTrgTmp->bc), uint16_t(gbtTrgTmp->triggerType), gbtTrgTmp->internal != 0, gbtTrgTmp->noData != 0});
+              printTrigger(gbtTrgTmp);
             }
           }
           continue;

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/GBTWord.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/GBTWord.h
@@ -55,6 +55,16 @@ constexpr uint8_t GBTFlagStatus = 0xe0;
 constexpr int GBTWordLength = 10;       // lentgh in bytes
 constexpr int GBTPaddedWordLength = 16; // lentgh in bytes with padding
 
+// root friendly version of the trigger (root does not support anonymous structs)
+struct GBTTriggerR {
+  uint32_t orbit = 0;
+  uint16_t bc = 0;
+  uint16_t triggerType = 0;
+  bool internal = false;
+  bool noData = false;
+  ClassDefNV(GBTTriggerR, 1);
+};
+
 struct GBTWord {
   /// GBT word of 80 bits, bits 72:79 are reserver for GBT Header flag, the rest depends on specifications
   union {

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelDecoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelDecoder.h
@@ -108,8 +108,8 @@ class RawPixelDecoder final : public PixelReader
   void setRawDumpDirectory(const std::string& s) { mRawDumpDirectory = s; }
   auto getRawDumpDirectory() const { return mRawDumpDirectory; }
 
-  std::vector<GBTTrigger>& getExternalTriggers() { return mExtTriggers; }
-  const std::vector<GBTTrigger>& getExternalTriggers() const { return mExtTriggers; }
+  std::vector<GBTTriggerR>& getExternalTriggers() { return mExtTriggers; }
+  const std::vector<GBTTriggerR>& getExternalTriggers() const { return mExtTriggers; }
 
   struct LinkEntry {
     int entry = -1;
@@ -129,7 +129,7 @@ class RawPixelDecoder final : public PixelReader
   std::vector<RUDecodeData> mRUDecodeVec;                   // set of active RUs
   std::array<short, Mapping::getNRUs()> mRUEntry;           // entry of the RU with given SW ID in the mRUDecodeVec
   std::vector<ChipPixelData*> mOrderedChipsPtr;             // special ordering helper used for the MFT (its chipID is not contiguous in RU)
-  std::vector<GBTTrigger> mExtTriggers;                     // external triggers
+  std::vector<GBTTriggerR> mExtTriggers;                    // external triggers
   std::string mSelfName{};                                  // self name
   std::string mRawDumpDirectory;                            // destination directory for dumps
   header::DataOrigin mUserDataOrigin = o2::header::gDataOriginInvalid; // alternative user-provided data origin to pick

--- a/Detectors/ITSMFT/common/reconstruction/src/ITSMFTReconstructionLinkDef.h
+++ b/Detectors/ITSMFT/common/reconstruction/src/ITSMFTReconstructionLinkDef.h
@@ -46,7 +46,8 @@
 #pragma link C++ class o2::itsmft::RUDecodeData + ;
 #pragma link C++ class o2::itsmft::RawDecodingStat + ;
 #pragma link C++ class o2::itsmft::ChipStat + ;
-
+#pragma link C++ class o2::itsmft::GBTTriggerR + ;
+#pragma link C++ class std::vector < o2::itsmft::GBTTrigger> + ;
 #pragma link C++ class std::map < unsigned long, std::pair < o2::itsmft::ClusterTopology, unsigned long>> + ;
 
 #pragma link C++ class o2::itsmft::ClustererParam < o2::detectors::DetID::ITS> + ;

--- a/Detectors/ITSMFT/common/workflow/CMakeLists.txt
+++ b/Detectors/ITSMFT/common/workflow/CMakeLists.txt
@@ -45,3 +45,8 @@ o2_add_executable(digit-reader-workflow
                   SOURCES src/digit-reader-workflow.cxx
                   COMPONENT_NAME itsmft
                   PUBLIC_LINK_LIBRARIES O2::ITSMFTWorkflow)
+
+o2_add_executable(trigges-writer-workflow
+                  SOURCES src/trigger-writer-workflow.cxx
+                  COMPONENT_NAME itsmft
+                  PUBLIC_LINK_LIBRARIES O2::ITSMFTWorkflow)

--- a/Detectors/ITSMFT/common/workflow/src/trigger-writer-workflow.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/trigger-writer-workflow.cxx
@@ -1,0 +1,90 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @brief  Processor spec for a ROOT file writer for ITSMFT digits
+
+#include "ITSMFTWorkflow/DigitWriterSpec.h"
+#include "DPLUtils/MakeRootTreeWriterSpec.h"
+#include "ITSMFTReconstruction/GBTWord.h"
+#include "Headers/DataHeader.h"
+#include "DetectorsCommonDataFormats/DetID.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include <vector>
+#include <string>
+#include <algorithm>
+
+using namespace o2::framework;
+using SubSpecificationType = o2::framework::DataAllocator::SubSpecificationType;
+using DetID = o2::detectors::DetID;
+
+namespace o2
+{
+namespace itsmft
+{
+
+template <typename T>
+using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
+
+/// create the processor spec
+/// describing a processor receiving physics triggers words from ITS/MFT decoder and writing them to file
+DataProcessorSpec getPhyTrigWriterSpec(DetID detId)
+{
+  std::string detStr = DetID::getName(detId);
+  std::string detStrL = "o2_";
+  detStrL += detStr;
+  std::transform(detStrL.begin(), detStrL.end(), detStrL.begin(), ::tolower);
+  auto logger = [](std::vector<o2::itsmft::GBTTriggerR> const& inp) {
+    LOG(info) << "Received " << inp.size() << " triggers";
+  };
+
+  return MakeRootTreeWriterSpec((detStr + "phytrigwriter").c_str(),
+                                (detStrL + "phy-triggers.root").c_str(),
+                                MakeRootTreeWriterSpec::TreeAttributes{"o2sim", "Physics triggers tree"},
+                                BranchDefinition<std::vector<o2::itsmft::GBTTriggerR>>{InputSpec{"trig",
+                                                                                                 detId == DetID::ITS ? "ITS" : "MFT", "PHYSTRIG", 0},
+                                                                                       (detStr + "Trig").c_str()})();
+}
+
+} // end namespace itsmft
+} // end namespace o2
+
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
+
+// ------------------------------------------------------------------
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*phytrigwriter.*"));
+}
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  std::vector<ConfigParamSpec> options{
+    ConfigParamSpec{"runmft", VariantType::Bool, false, {"expect MFT data"}},
+    ConfigParamSpec{"configKeyValues", VariantType::String, "", {"semicolon separated key=value strings"}}};
+
+  std::swap(workflowOptions, options);
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  WorkflowSpec wf;
+  o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
+  wf.emplace_back(o2::itsmft::getPhyTrigWriterSpec(cfgc.options().get<bool>("runmft") ? DetID::MFT : DetID::ITS));
+  return wf;
+}


### PR DESCRIPTION
since ROOT does not support anonymous structs used in the GBTTrigger, we store dedicated struct
with the same content