### PR TITLE
Reduce severity of dummy creation time for CCDB message from error to info

### DIFF
--- a/Framework/Core/src/CCDBHelpers.cxx
+++ b/Framework/Core/src/CCDBHelpers.cxx
@@ -309,7 +309,7 @@ AlgorithmSpec CCDBHelpers::fetchFromCCDB()
         static Long64_t orbitResetTime = -1;
         static size_t lastTimeUsed = -1;
         if (timingInfo.creation & DataProcessingHeader::DUMMY_CREATION_TIME_OFFSET) {
-          LOGP(error, "Dummy creation time is not supported for CCDB objects. Setting creation to last one used {}.", lastTimeUsed);
+          LOGP(info, "Dummy creation time is not supported for CCDB objects. Setting creation to last one used {}.", lastTimeUsed);
           timingInfo.creation = lastTimeUsed;
         }
         lastTimeUsed = timingInfo.creation;


### PR DESCRIPTION
@ktf : demoting this to reduce InfoLogger spam. We should understand where it comes from, the we can raise it again to error.