### PR TITLE
TPC digit: some optimisation for PadRegion calculations

### DIFF
--- a/Detectors/TPC/base/include/TPCBase/Mapper.h
+++ b/Detectors/TPC/base/include/TPCBase/Mapper.h
@@ -681,7 +681,7 @@ inline const DigitPos Mapper::findDigitPosFromLocalPosition(const LocalPosition3
   CRU cru;
   for (const PadRegionInfo& padRegion : mMapPadRegionInfo) {
     cru = CRU(sec, padRegion.getRegion());
-    pad = padRegion.findPad(pos);
+    pad = padRegion.findPad(pos.X(), pos.Y(), (pos.Z() >= 0) ? Side::A : Side::C); // <--- to avoid calling a non-inlined library function layer for LocalPosition3D
     if (pad.isValid()) {
       break;
     }

--- a/Detectors/TPC/base/include/TPCBase/PadRegionInfo.h
+++ b/Detectors/TPC/base/include/TPCBase/PadRegionInfo.h
@@ -150,6 +150,8 @@ class PadRegionInfo
  private:
   float mPadHeight{0.f};             ///< pad height in this region
   float mPadWidth{0.f};              ///< pad width in this region
+  float mInvPadHeight{0.f};          ///< inverse pad height in this region (to avoid division in some frequent kernels)
+  float mInvPadWidth{0.f};           ///< inverse pad width in this region
   float mRadiusFirstRow{0.f};        ///< radial position of first row
   float mXhelper{0.f};               ///< helper value to calculate pads per row
   unsigned short mNumberOfPads{0};   ///< total number of pads in region

--- a/Detectors/TPC/base/src/PadRegionInfo.cxx
+++ b/Detectors/TPC/base/src/PadRegionInfo.cxx
@@ -27,7 +27,7 @@ PadRegionInfo::PadRegionInfo(const unsigned char region,
                              const unsigned char rowOffset,
                              const float xhelper,
                              const unsigned char globalRowOffset)
-  : mRegion{region}, mPartition{partition}, mNumberOfPadRows{numberOfPadRows}, mPadHeight{padHeight}, mPadWidth{padWidth}, mRadiusFirstRow{radiusFirstRow}, mRowOffset{rowOffset}, mXhelper{xhelper}, mNumberOfPads{0}, mGlobalRowOffset{globalRowOffset}, mPadsPerRow(numberOfPadRows)
+  : mRegion{region}, mPartition{partition}, mNumberOfPadRows{numberOfPadRows}, mPadHeight{padHeight}, mPadWidth{padWidth}, mInvPadHeight{1.f / padHeight}, mInvPadWidth{1.f / padWidth}, mRadiusFirstRow{radiusFirstRow}, mRowOffset{rowOffset}, mXhelper{xhelper}, mNumberOfPads{0}, mGlobalRowOffset{globalRowOffset}, mPadsPerRow(numberOfPadRows)
 {
   init();
 }
@@ -63,13 +63,13 @@ const PadPos PadRegionInfo::findPad(const float localX, const float localY, cons
   // on the A-Side one looks from the back-side, therefore
   // the localY-sign must be changed
   const float localYfactor = (side == Side::A) ? -1.f : 1.f;
-  const unsigned int row = std::floor((localX - mRadiusFirstRow) / mPadHeight);
+  const unsigned int row = std::floor((localX - mRadiusFirstRow) * mInvPadHeight);
   if (row >= mNumberOfPadRows) {
     return PadPos(255, 255);
   }
 
   const unsigned int npads = getPadsInRowRegion(row);
-  const float padfloat = (npads / 2 * mPadWidth - localYfactor * localY) / mPadWidth;
+  const float padfloat = (0.5f * npads * mPadWidth - localYfactor * localY) * mInvPadWidth;
   if (padfloat < 0) {
     return PadPos(255, 255);
   }


### PR DESCRIPTION
The "findPad" function is called billions of times in digitization
and amounts to ~10% of time according to valgrind.

It therefore makes sense to optimise this a bit:
a) avoid divisions in favour of faster multiplications
b) avoid calling a non-inlined wrapper of the findPad function