### PR TITLE
FST: Do not set STROBE lengths by default, will be taken from CCDB

### DIFF
--- a/prodtests/full-system-test/workflow-setup.sh
+++ b/prodtests/full-system-test/workflow-setup.sh
@@ -13,12 +13,6 @@ else
   if [[ -z "${WORKFLOW_DETECTORS_MATCHING+x}" ]]; then export WORKFLOW_DETECTORS_MATCHING="ALL"; fi # All matching / vertexing enabled in async mode
 fi
 
-if [[ $BEAMTYPE == "PbPb" ]]; then
-  [[ -z $ITS_STROBE ]] && ITS_STROBE="891"
-elif [[ $BEAMTYPE == "pp" ]]; then
-  [[ -z $ITS_STROBE ]] && ITS_STROBE="198"
-fi
-
 MID_FEEID_MAP="$FILEWORKDIR/mid-feeId_mapper.txt"
 
 ITSMFT_STROBES=""


### PR DESCRIPTION
Tested locally with FST, and with FST processing in data replay from DD with overriding creationTime in readout-proxy. All works, so this workaround is no longer needed.
Trivial, merging