### PR TITLE
ZDC Fastsim: Fix array iteration

### DIFF
--- a/Detectors/ZDC/simulation/src/Detector.cxx
+++ b/Detectors/ZDC/simulation/src/Detector.cxx
@@ -2630,7 +2630,7 @@ bool Detector::FastSimToHits(const Ort::Value& response, const TParticle& partic
       int currentMediumid = determineMediumID(detector, x, y);
       // LOG(info) << " x " << x << " y " << y << " sec " << sector << " medium " << currentMediumid;
       // Model output needs to be converted with exp(x)-1 function to be valid
-      int nphe = (int)std::expm1(pixels[Nx * x + y]);
+      int nphe = (int)std::expm1(pixels[Nx * y + x]);
 
       if (nphe > 0) {
         float trackenergy = 0; // energy of the primary (need to fill good value)


### PR DESCRIPTION
The iteration in FastSimToHits is firstly over y (column order) but data read was in row order. This commit fixes typo made in data read of that method.