### PR TITLE
Handling of bogus TRD triggers in CTF

### DIFF
--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CTFCoder.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CTFCoder.h
@@ -25,6 +25,7 @@
 #include "DetectorsBase/CTFCoderBase.h"
 #include "rANS/rans.h"
 #include "TRDReconstruction/CTFHelper.h"
+#include "CommonConstants/LHCConstants.h"
 
 class TTree;
 
@@ -51,12 +52,14 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 
   void setBCShift(int n) { mBCShift = 0; }
   void setFirstTFOrbit(uint32_t n) { mFirstTFOrbit = n; }
+  void setCheckBogusTrig(int v) { mCheckBogusTrig = v; }
 
  private:
   void appendToTree(TTree& tree, CTF& ec);
   void readFromTree(TTree& tree, int entry, std::vector<TriggerRecord>& trigVec, std::vector<Tracklet64>& trkVec, std::vector<Digit>& digVec);
   int mBCShift = 0; // shift to apply to decoded IR (i.e. CTP offset if was not corrected on raw data decoding level)
   uint32_t mFirstTFOrbit = 0;
+  int mCheckBogusTrig = 1;
 };
 
 /// entropy-encode digits and tracklets to buffer with CTF
@@ -82,9 +85,29 @@ o2::ctf::CTFIOSize CTFCoder::encode(VEC& buff, const gsl::span<const TriggerReco
     MD::EENCODE, // BLC_chanDig
     MD::EENCODE, // BLC_ADCDig
   };
+  static size_t bogusWarnMsg = 0;
+  if (mCheckBogusTrig && bogusWarnMsg < mCheckBogusTrig) {
+    uint32_t orbitPrev = mFirstTFOrbit;
+    uint16_t bcPrev = 0;
+    int cnt = 0;
+    for (const auto& trig : trigData) {
+      LOGP(debug, "Trig#{} Old: {}/{} New: {}/{}", cnt++, bcPrev, orbitPrev, trig.getBCData().bc, trig.getBCData().orbit);
+      auto orbitPrevT = orbitPrev;
+      auto bcPrevT = bcPrev;
+      bcPrev = trig.getBCData().bc;
+      orbitPrev = trig.getBCData().orbit;
+      if (trig.getBCData().orbit < orbitPrevT || trig.getBCData().bc >= o2::constants::lhc::LHCMaxBunches || (trig.getBCData().orbit == orbitPrevT && trig.getBCData().bc < bcPrevT)) {
+        LOGP(alarm, "Bogus TRD trigger at bc:{}/orbit:{} (previous was {}/{}), with {} tracklets and {} digits",
+             trig.getBCData().bc, trig.getBCData().orbit, bcPrevT, orbitPrevT, trig.getNumberOfTracklets(), trig.getNumberOfDigits());
+        if (++bogusWarnMsg >= mCheckBogusTrig) {
+          LOGP(alarm, "Max amount of warnings ({}) was issued, will not warn anymore", size_t(mCheckBogusTrig));
+          break;
+        }
+      }
+    }
+  }
 
   CTFHelper helper(trigData, trkData, digData);
-
   // book output size with some margin
   auto szIni = sizeof(CTFHeader) + helper.getSize() * 2. / 3; // will be autoexpanded if needed
   buff.resize(szIni);
@@ -132,8 +155,10 @@ o2::ctf::CTFIOSize CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VTRK& tr
   auto header = ec.getHeader();
   checkDictVersion(static_cast<const o2::ctf::CTFDictHeader&>(header));
   ec.print(getPrefix(), mVerbosity);
-  std::vector<uint16_t> bcInc, HCIDTrk, posTrk, CIDDig, ADCDig;
-  std::vector<uint32_t> orbitInc, entriesTrk, entriesDig, pidTrk;
+  std::vector<uint16_t> HCIDTrk, posTrk, CIDDig, ADCDig;
+  std::vector<int16_t> bcInc; // RS to not crash at negative increments
+  std::vector<uint32_t> entriesTrk, entriesDig, pidTrk;
+  std::vector<int32_t> orbitInc; // RS to not crash at negative increments
   std::vector<uint8_t> padrowTrk, colTrk, slopeTrk, ROBDig, MCMDig, chanDig;
 
   o2::ctf::CTFIOSize iosize;
@@ -165,20 +190,39 @@ o2::ctf::CTFIOSize CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VTRK& tr
   trkVec.reserve(header.nTracklets);
   digVec.reserve(header.nDigits);
   uint32_t trkCount = 0, digCount = 0, adcCount = 0;
-  o2::InteractionRecord ir(header.firstBC, header.firstOrbit);
+  uint32_t orbit = header.firstOrbit, orbitPrev = 0, orbitPrevGood = mFirstTFOrbit;
+  uint16_t bc = header.firstBC;
   bool checkIROK = (mBCShift == 0); // need to check if CTP offset correction does not make the local time negative ?
+  static size_t countDiscardMsg = 0;
 
   for (uint32_t itrig = 0; itrig < header.nTriggers; itrig++) {
     // restore TrigRecord
     if (orbitInc[itrig]) {  // non-0 increment => new orbit
-      ir.bc = bcInc[itrig]; // bcInc has absolute meaning
-      ir.orbit += orbitInc[itrig];
+      bc = bcInc[itrig];    // bcInc has absolute meaning
+      orbit += orbitInc[itrig];
     } else {
-      ir.bc += bcInc[itrig];
+      bc += bcInc[itrig];
     }
-    LOGP(debug, "trig{} check={} shift {} differenceInBC:{} 1stOrb {}, ir:{}", itrig, checkIROK, mBCShift, ir.differenceInBC({0, mFirstTFOrbit}), mFirstTFOrbit, ir.asString());
-    if (checkIROK || ir.differenceInBC({0, mFirstTFOrbit}) >= mBCShift) { // correction will be ok
+    bool triggerOK = true;
+    if (mCheckBogusTrig && (bc >= o2::constants::lhc::LHCMaxBunches || orbitInc[itrig] < 0 || bcInc[itrig] < 0 || orbit < orbitPrevGood || (entriesTrk[itrig] == 0 && entriesDig[itrig] == 0))) {
+      if (countDiscardMsg < size_t(mCheckBogusTrig) || mCheckBogusTrig < 0) {
+        LOGP(alarm, "Bogus TRD trigger at bc:{}/orbit:{} (increments: {}/{}, 1st TF orbit: {}) with {} tracklets and {} digits{}: {}",
+             bc, orbit, bcInc[itrig], orbitInc[itrig], mFirstTFOrbit, entriesTrk[itrig], entriesDig[itrig],
+             orbitInc[itrig] < 0 ? " (decreasing orbit!) " : "",
+             mCheckBogusTrig > 0 ? "discarding" : "discarding disabled");
+        if (++countDiscardMsg == size_t(mCheckBogusTrig) && mCheckBogusTrig > 0) {
+          LOGP(alarm, "Max amount of warnings ({}) was issued, will not warn anymore", size_t(mCheckBogusTrig));
+        }
+      }
+      if (mCheckBogusTrig > 0) {
+        triggerOK = false;
+      }
+    }
+    orbitPrev = orbit;
+    o2::InteractionRecord ir{bc, orbit};
+    if (triggerOK && (checkIROK || ir.differenceInBC({0, mFirstTFOrbit}) >= mBCShift)) { // correction will be ok
       checkIROK = true;                                                   // don't check anymore since the following checks will yield same
+      orbitPrevGood = orbit;
       uint32_t firstEntryTrk = trkVec.size();
       uint16_t hcid = 0;
       for (uint32_t it = 0; it < entriesTrk[itrig]; it++) {
@@ -195,7 +239,12 @@ o2::ctf::CTFIOSize CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VTRK& tr
         digCount++;
         adcCount += constants::TIMEBINS;
       }
-      trigVec.emplace_back(ir - mBCShift, firstEntryDig, entriesDig[itrig], firstEntryTrk, entriesTrk[itrig]);
+      if (mBCShift && bc < o2::constants::lhc::LHCMaxBunches) { // we don't want corrupted orbit to look as good one after correction
+        ir -= mBCShift;
+      }
+
+      LOGP(debug, "Storing TRD trigger at {} (increments: {}/{}) with {} tracklets and {} digits", ir.asString(), bcInc[itrig], orbitInc[itrig], entriesTrk[itrig], entriesDig[itrig]);
+      trigVec.emplace_back(ir, firstEntryDig, entriesDig[itrig], firstEntryTrk, entriesTrk[itrig]);
     } else { // skip the trigger with negative local time
       trkCount += entriesTrk[itrig];
       digCount += entriesDig[itrig];

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CTFHelper.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CTFHelper.h
@@ -131,10 +131,10 @@ class CTFHelper
 
   //_______________________________________________
   // Orbit difference wrt previous. For the very 1st entry return 0 (diff wrt 1st BC in the CTF header)
-  class Iter_orbitIncTrig : public _Iter<Iter_orbitIncTrig, TriggerRecord, uint32_t>
+  class Iter_orbitIncTrig : public _Iter<Iter_orbitIncTrig, TriggerRecord, int32_t>
   {
    public:
-    using _Iter<Iter_orbitIncTrig, TriggerRecord, uint32_t>::_Iter;
+    using _Iter<Iter_orbitIncTrig, TriggerRecord, int32_t>::_Iter;
     value_type operator*() const { return mIndex ? mData[mIndex].getBCData().orbit - mData[mIndex - 1].getBCData().orbit : 0; }
   };
 

--- a/Detectors/TRD/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/TRD/workflow/src/EntropyDecoderSpec.cxx
@@ -65,6 +65,9 @@ void EntropyDecoderSpec::init(o2::framework::InitContext& ic)
     mCTFCoder.setBCShift(o2::ctp::TriggerOffsetsParam::Instance().LM_L0);
     LOGP(info, "Decoded IRs will be corrected by -{} BCs, discarded if become prior to 1st orbit", o2::ctp::TriggerOffsetsParam::Instance().LM_L0);
   }
+  int checkBogus = ic.options().get<int>("bogus-trigger-rejection");
+  mCTFCoder.setCheckBogusTrig(checkBogus);
+  LOGP(info, "Bogus triggers rejection flag: {}", checkBogus);
 }
 
 void EntropyDecoderSpec::run(ProcessingContext& pc)
@@ -115,7 +118,8 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
     outputs,
     AlgorithmSpec{adaptFromTask<EntropyDecoderSpec>(verbosity)},
     Options{{"ctf-dict", VariantType::String, "ccdb", {"CTF dictionary: empty or ccdb=CCDB, none=no external dictionary otherwise: local filename"}},
-            {"correct-trd-trigger-offset", VariantType::Bool, false, {"Correct decoded IR by TriggerOffsetsParam::LM_L0"}}}};
+            {"correct-trd-trigger-offset", VariantType::Bool, false, {"Correct decoded IR by TriggerOffsetsParam::LM_L0"}},
+            {"bogus-trigger-rejection", VariantType::Int, 10, {">0 : discard, warn N times, <0 : warn only, =0: no check for triggers with no tracklets or bogus IR"}}}};
 }
 
 } // namespace trd


### PR DESCRIPTION
option `--bogus-trigger-check N` of o2-trd-entropy-encoder-workflow will warn at most N times if TRD trigger has
1) orbit smaller than previous one
2) bc >= 3564
3) bc smaller than previous one in the same orbit as in previous trigger
Negative N mean unlimited warnings

option `--bogus-trigger-rejection N` of TRD entropy-decoder will reject at decoding level those triggers which have
1) orbit smaller than previous one
2) bc >= 3564
3) no tracklets or digits.
With positive N the warning only for first N rejections, with negative N
every rejection will print warning.