### PR TITLE
Optionally prefer ROFs with physics triggers with downscaling ITS reco

### DIFF
--- a/DataFormats/Detectors/ITSMFT/common/CMakeLists.txt
+++ b/DataFormats/Detectors/ITSMFT/common/CMakeLists.txt
@@ -34,7 +34,8 @@ o2_target_root_dictionary(DataFormatsITSMFT
                                   include/DataFormatsITSMFT/ClusterTopology.h
                                   include/DataFormatsITSMFT/TopologyDictionary.h
                                   include/DataFormatsITSMFT/CTF.h
-      include/DataFormatsITSMFT/TrkClusRef.h
+                                  include/DataFormatsITSMFT/TrkClusRef.h
+                                  include/DataFormatsITSMFT/PhysTrigger.h
                           LINKDEF src/ITSMFTDataFormatsLinkDef.h)
 
 o2_add_test(Cluster

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/PhysTrigger.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/PhysTrigger.h
@@ -1,0 +1,34 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file PhysTrigger.h
+/// \brief Definition Physics trigger record extracted from the ITS/MFT stream
+
+#ifndef ALICEO2_ITSMFT_PHYSTRIGGER_H
+#define ALICEO2_ITSMFT_PHYSTRIGGER_H
+
+#include "CommonDataFormat/InteractionRecord.h"
+
+namespace o2::itsmft
+{
+// root friendly version of the trigger (root does not support anonymous structs)
+struct PhysTrigger {
+  o2::InteractionRecord ir;
+  uint16_t triggerType = 0;
+  bool internal = false;
+  bool noData = false;
+
+  ClassDefNV(PhysTrigger, 1);
+};
+
+} // namespace o2::itsmft
+
+#endif

--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/PhysTrigger.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/PhysTrigger.h
@@ -21,10 +21,8 @@ namespace o2::itsmft
 {
 // root friendly version of the trigger (root does not support anonymous structs)
 struct PhysTrigger {
-  o2::InteractionRecord ir;
-  uint16_t triggerType = 0;
-  bool internal = false;
-  bool noData = false;
+  o2::InteractionRecord ir{};
+  uint64_t data = 0;
 
   ClassDefNV(PhysTrigger, 1);
 };

--- a/DataFormats/Detectors/ITSMFT/common/src/ITSMFTDataFormatsLinkDef.h
+++ b/DataFormats/Detectors/ITSMFT/common/src/ITSMFTDataFormatsLinkDef.h
@@ -41,6 +41,9 @@
 #pragma link C++ class o2::itsmft::TrkClusRef + ;
 #pragma link C++ class std::vector < o2::itsmft::TrkClusRef> + ;
 
+#pragma link C++ class o2::itsmft::PhysTrigger + ;
+#pragma link C++ class std::vector < o2::itsmft::PhysTrigger> + ;
+
 #pragma link C++ class o2::itsmft::CTFHeader + ;
 #pragma link C++ class o2::itsmft::CompressedClusters + ;
 #pragma link C++ class o2::itsmft::CTF + ;

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/FastMultEst.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/FastMultEst.h
@@ -17,7 +17,9 @@
 #define ALICEO2_ITS_FASTMULTEST_
 
 #include "ITSMFTReconstruction/ChipMappingITS.h"
+#include "DataFormatsITSMFT/ROFRecord.h"
 #include "DataFormatsITSMFT/CompCluster.h"
+#include <DataFormatsITSMFT/PhysTrigger.h>
 #include "ITSReconstruction/FastMultEstConfig.h"
 #include <gsl/span>
 #include <array>
@@ -37,6 +39,9 @@ struct FastMultEst {
   float chi2 = 0.;                         /// chi2
   int nLayersUsed = 0;                     /// number of layers actually used
   std::array<int, NLayers> nClPerLayer{0}; // measured N Cl per layer
+
+  int selectROFs(const gsl::span<const o2::itsmft::ROFRecord> rofs, const gsl::span<const o2::itsmft::CompClusterExt> clus,
+                 const gsl::span<const o2::itsmft::PhysTrigger> trig, std::vector<bool>& sel);
 
   void fillNClPerLayer(const gsl::span<const o2::itsmft::CompClusterExt>& clusters);
   float process(const std::array<int, NLayers> ncl)

--- a/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/FastMultEstConfig.h
+++ b/Detectors/ITSMFT/ITS/reconstruction/include/ITSReconstruction/FastMultEstConfig.h
@@ -39,6 +39,7 @@ struct FastMultEstConfig : public o2::conf::ConfigurableParamHelper<FastMultEstC
   float cutMultVtxLow = -1;   /// reject seed vertex if its multiplicity below this value (no cut if <0)
   float cutMultVtxHigh = -1;  /// reject seed vertex if its multiplicity above this value (no cut if <0)
   float cutRandomFraction = -1.; /// apply random cut rejecting requested fraction
+  bool preferTriggered = true;   /// prefer ROFs with highest number of physics triggers
 
   bool isMultCutRequested() const { return cutMultClusLow >= 0.f && cutMultClusHigh > 0.f; };
   bool isVtxMultCutRequested() const { return cutMultVtxLow >= 0.f && cutMultVtxHigh > 0.f; };

--- a/Detectors/ITSMFT/ITS/workflow/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/workflow/CMakeLists.txt
@@ -27,6 +27,7 @@ o2_add_library(ITSWorkflow
                                O2::SimConfig
                                O2::DataFormatsITS
                                O2::DataFormatsDCS
+                               O2::DataFormatsTRD
                                O2::SimulationDataFormat
                                O2::ITStracking
                                O2::ITSReconstruction

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/CookedTrackerSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/CookedTrackerSpec.h
@@ -35,7 +35,7 @@ namespace its
 class CookedTrackerDPL : public Task
 {
  public:
-  CookedTrackerDPL(std::shared_ptr<o2::base::GRPGeomRequest> gr, bool useMC, const std::string& trMode);
+  CookedTrackerDPL(std::shared_ptr<o2::base::GRPGeomRequest> gr, bool useMC, bool useTRDTriggers, const std::string& trMode);
   ~CookedTrackerDPL() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
@@ -50,6 +50,7 @@ class CookedTrackerDPL : public Task
   int mState = 0;
   bool mUseMC = true;
   bool mRunVertexer = true;
+  bool mUseTRDTriggers = false;
   std::string mMode = "async";
   const o2::itsmft::TopologyDictionary* mDict = nullptr;
   std::unique_ptr<o2::parameters::GRPObject> mGRP = nullptr;
@@ -61,7 +62,7 @@ class CookedTrackerDPL : public Task
 
 /// create a processor spec
 /// run ITS CookedMatrix tracker
-framework::DataProcessorSpec getCookedTrackerSpec(bool useMC, const std::string& trMode);
+framework::DataProcessorSpec getCookedTrackerSpec(bool useMC, bool useTRD, const std::string& trMode);
 
 } // namespace its
 } // namespace o2

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/CookedTrackerSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/CookedTrackerSpec.h
@@ -35,7 +35,7 @@ namespace its
 class CookedTrackerDPL : public Task
 {
  public:
-  CookedTrackerDPL(std::shared_ptr<o2::base::GRPGeomRequest> gr, bool useMC, bool useTRDTriggers, const std::string& trMode);
+  CookedTrackerDPL(std::shared_ptr<o2::base::GRPGeomRequest> gr, bool useMC, int trgType, const std::string& trMode);
   ~CookedTrackerDPL() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
@@ -50,7 +50,7 @@ class CookedTrackerDPL : public Task
   int mState = 0;
   bool mUseMC = true;
   bool mRunVertexer = true;
-  bool mUseTRDTriggers = false;
+  int mUseTriggers = 0;
   std::string mMode = "async";
   const o2::itsmft::TopologyDictionary* mDict = nullptr;
   std::unique_ptr<o2::parameters::GRPObject> mGRP = nullptr;
@@ -62,7 +62,7 @@ class CookedTrackerDPL : public Task
 
 /// create a processor spec
 /// run ITS CookedMatrix tracker
-framework::DataProcessorSpec getCookedTrackerSpec(bool useMC, bool useTRD, const std::string& trMode);
+framework::DataProcessorSpec getCookedTrackerSpec(bool useMC, int useTrig, const std::string& trMode);
 
 } // namespace its
 } // namespace o2

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/RecoWorkflow.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/RecoWorkflow.h
@@ -29,7 +29,7 @@ namespace reco_workflow
 {
 
 framework::WorkflowSpec getWorkflow(bool useMC, bool useCAtracker, const std::string& trmode, o2::gpu::GPUDataTypes::DeviceType dType = o2::gpu::GPUDataTypes::DeviceType::CPU,
-                                    bool upstreamDigits = false, bool upstreamClusters = false, bool disableRootOutput = false, bool eencode = false);
+                                    bool upstreamDigits = false, bool upstreamClusters = false, bool disableRootOutput = false, bool useTRD = false, bool eencode = false);
 }
 
 } // namespace its

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/RecoWorkflow.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/RecoWorkflow.h
@@ -29,7 +29,7 @@ namespace reco_workflow
 {
 
 framework::WorkflowSpec getWorkflow(bool useMC, bool useCAtracker, const std::string& trmode, o2::gpu::GPUDataTypes::DeviceType dType = o2::gpu::GPUDataTypes::DeviceType::CPU,
-                                    bool upstreamDigits = false, bool upstreamClusters = false, bool disableRootOutput = false, bool useTRD = false, bool eencode = false);
+                                    bool upstreamDigits = false, bool upstreamClusters = false, bool disableRootOutput = false, int useTrig = 0, bool eencode = false);
 }
 
 } // namespace its

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/TrackerSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/TrackerSpec.h
@@ -41,7 +41,7 @@ namespace its
 class TrackerDPL : public framework::Task
 {
  public:
-  TrackerDPL(std::shared_ptr<o2::base::GRPGeomRequest> gr, bool isMC, const std::string& trModeS, o2::gpu::GPUDataTypes::DeviceType dType = o2::gpu::GPUDataTypes::DeviceType::CPU); // : mIsMC{isMC} {}
+  TrackerDPL(std::shared_ptr<o2::base::GRPGeomRequest> gr, bool isMC, bool useTRDTriggers, const std::string& trModeS, o2::gpu::GPUDataTypes::DeviceType dType = o2::gpu::GPUDataTypes::DeviceType::CPU); // : mIsMC{isMC} {}
   ~TrackerDPL() override = default;
   void init(framework::InitContext& ic) final;
   void run(framework::ProcessingContext& pc) final;
@@ -55,6 +55,7 @@ class TrackerDPL : public framework::Task
   bool mIsMC = false;
   bool mRunVertexer = true;
   bool mCosmicsProcessing = false;
+  bool mUseTRDTriggers = false;
   std::string mMode = "sync";
   std::shared_ptr<o2::base::GRPGeomRequest> mGGCCDBRequest;
   const o2::itsmft::TopologyDictionary* mDict = nullptr;
@@ -67,7 +68,7 @@ class TrackerDPL : public framework::Task
 
 /// create a processor spec
 /// run ITS CA tracker
-framework::DataProcessorSpec getTrackerSpec(bool useMC, const std::string& trModeS, o2::gpu::GPUDataTypes::DeviceType dType);
+framework::DataProcessorSpec getTrackerSpec(bool useMC, bool useTRD, const std::string& trModeS, o2::gpu::GPUDataTypes::DeviceType dType);
 
 } // namespace its
 } // namespace o2

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/TrackerSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/TrackerSpec.h
@@ -41,7 +41,7 @@ namespace its
 class TrackerDPL : public framework::Task
 {
  public:
-  TrackerDPL(std::shared_ptr<o2::base::GRPGeomRequest> gr, bool isMC, bool useTRDTriggers, const std::string& trModeS, o2::gpu::GPUDataTypes::DeviceType dType = o2::gpu::GPUDataTypes::DeviceType::CPU); // : mIsMC{isMC} {}
+  TrackerDPL(std::shared_ptr<o2::base::GRPGeomRequest> gr, bool isMC, int trgType, const std::string& trModeS, o2::gpu::GPUDataTypes::DeviceType dType = o2::gpu::GPUDataTypes::DeviceType::CPU); // : mIsMC{isMC} {}
   ~TrackerDPL() override = default;
   void init(framework::InitContext& ic) final;
   void run(framework::ProcessingContext& pc) final;
@@ -55,7 +55,7 @@ class TrackerDPL : public framework::Task
   bool mIsMC = false;
   bool mRunVertexer = true;
   bool mCosmicsProcessing = false;
-  bool mUseTRDTriggers = false;
+  int mUseTriggers = 0;
   std::string mMode = "sync";
   std::shared_ptr<o2::base::GRPGeomRequest> mGGCCDBRequest;
   const o2::itsmft::TopologyDictionary* mDict = nullptr;
@@ -68,7 +68,7 @@ class TrackerDPL : public framework::Task
 
 /// create a processor spec
 /// run ITS CA tracker
-framework::DataProcessorSpec getTrackerSpec(bool useMC, bool useTRD, const std::string& trModeS, o2::gpu::GPUDataTypes::DeviceType dType);
+framework::DataProcessorSpec getTrackerSpec(bool useMC, int useTrig, const std::string& trModeS, o2::gpu::GPUDataTypes::DeviceType dType);
 
 } // namespace its
 } // namespace o2

--- a/Detectors/ITSMFT/ITS/workflow/src/CookedTrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/CookedTrackerSpec.cxx
@@ -52,7 +52,7 @@ namespace its
 
 using Vertex = o2::dataformats::Vertex<o2::dataformats::TimeStamp<int>>;
 
-CookedTrackerDPL::CookedTrackerDPL(std::shared_ptr<o2::base::GRPGeomRequest> gr, bool useMC, bool useTRDTriggers, const std::string& trMode) : mGGCCDBRequest(gr), mUseMC(useMC), mUseTRDTriggers{useTRDTriggers}, mMode(trMode)
+CookedTrackerDPL::CookedTrackerDPL(std::shared_ptr<o2::base::GRPGeomRequest> gr, bool useMC, int trgType, const std::string& trMode) : mGGCCDBRequest(gr), mUseMC(useMC), mUseTriggers{trgType}, mMode(trMode)
 {
   mVertexerTraitsPtr = std::make_unique<VertexerTraits>();
   mVertexerPtr = std::make_unique<Vertexer>(mVertexerTraitsPtr.get());
@@ -81,17 +81,17 @@ void CookedTrackerDPL::run(ProcessingContext& pc)
   auto rofsinput = pc.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("ROframes");
   gsl::span<const o2::itsmft::PhysTrigger> physTriggers;
   std::vector<o2::itsmft::PhysTrigger> fromTRD;
-  if (mUseTRDTriggers) {
+  if (mUseTriggers == 2) { // use TRD triggers
     o2::InteractionRecord ir{0, pc.services().get<o2::framework::TimingInfo>().firstTForbit};
     auto trdTriggers = pc.inputs().get<gsl::span<o2::trd::TriggerRecord>>("phystrig");
     for (const auto& trig : trdTriggers) {
       if (trig.getBCData() >= ir && trig.getNumberOfTracklets()) {
         ir = trig.getBCData();
-        fromTRD.emplace_back(o2::itsmft::PhysTrigger{ir, 0, false, false});
+        fromTRD.emplace_back(o2::itsmft::PhysTrigger{ir, 0});
       }
     }
     physTriggers = gsl::span<const o2::itsmft::PhysTrigger>(fromTRD.data(), fromTRD.size());
-  } else {
+  } else if (mUseTriggers == 1) { // use Phys triggers from ITS stream
     physTriggers = pc.inputs().get<gsl::span<o2::itsmft::PhysTrigger>>("phystrig");
   }
 
@@ -262,7 +262,7 @@ void CookedTrackerDPL::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
   }
 }
 
-DataProcessorSpec getCookedTrackerSpec(bool useMC, bool useTRD, const std::string& trMode)
+DataProcessorSpec getCookedTrackerSpec(bool useMC, int trgType, const std::string& trMode)
 {
   std::vector<InputSpec> inputs;
   inputs.emplace_back("compClusters", "ITS", "COMPCLUSTERS", 0, Lifetime::Timeframe);
@@ -270,10 +270,10 @@ DataProcessorSpec getCookedTrackerSpec(bool useMC, bool useTRD, const std::strin
   inputs.emplace_back("ROframes", "ITS", "CLUSTERSROF", 0, Lifetime::Timeframe);
   inputs.emplace_back("cldict", "ITS", "CLUSDICT", 0, Lifetime::Condition, ccdbParamSpec("ITS/Calib/ClusterDictionary"));
   inputs.emplace_back("alppar", "ITS", "ALPIDEPARAM", 0, Lifetime::Condition, ccdbParamSpec("ITS/Config/AlpideParam"));
-  if (useTRD) {
-    inputs.emplace_back("phystrig", "TRD", "TRKTRGRD", 0, Lifetime::Timeframe);
-  } else {
+  if (trgType == 1) {
     inputs.emplace_back("phystrig", "ITS", "PHYSTRIG", 0, Lifetime::Timeframe);
+  } else if (trgType == 2) {
+    inputs.emplace_back("phystrig", "TRD", "TRKTRGRD", 0, Lifetime::Timeframe);
   }
 
   std::vector<OutputSpec> outputs;
@@ -302,7 +302,7 @@ DataProcessorSpec getCookedTrackerSpec(bool useMC, bool useTRD, const std::strin
     "its-cooked-tracker",
     inputs,
     outputs,
-    AlgorithmSpec{adaptFromTask<CookedTrackerDPL>(ggRequest, useMC, useTRD, trMode)},
+    AlgorithmSpec{adaptFromTask<CookedTrackerDPL>(ggRequest, useMC, trgType, trMode)},
     Options{{"nthreads", VariantType::Int, 1, {"Number of threads"}}}};
 }
 

--- a/Detectors/ITSMFT/ITS/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/RecoWorkflow.cxx
@@ -30,11 +30,10 @@ namespace reco_workflow
 {
 
 framework::WorkflowSpec getWorkflow(bool useMC, bool useCAtracker, const std::string& trmode, o2::gpu::GPUDataTypes::DeviceType dtype,
-                                    bool upstreamDigits, bool upstreamClusters, bool disableRootOutput, bool useTRD,
+                                    bool upstreamDigits, bool upstreamClusters, bool disableRootOutput, int useTrig,
                                     bool eencode)
 {
   framework::WorkflowSpec specs;
-
   if (!(upstreamDigits || upstreamClusters)) {
     specs.emplace_back(o2::itsmft::getITSDigitReaderSpec(useMC, false, true, "itsdigits.root"));
   }
@@ -47,9 +46,9 @@ framework::WorkflowSpec getWorkflow(bool useMC, bool useCAtracker, const std::st
   }
   if (!trmode.empty()) {
     if (useCAtracker) {
-      specs.emplace_back(o2::its::getTrackerSpec(useMC, useTRD, trmode, dtype));
+      specs.emplace_back(o2::its::getTrackerSpec(useMC, useTrig, trmode, dtype));
     } else {
-      specs.emplace_back(o2::its::getCookedTrackerSpec(useMC, useTRD, trmode));
+      specs.emplace_back(o2::its::getCookedTrackerSpec(useMC, useTrig, trmode));
     }
     if (!disableRootOutput) {
       specs.emplace_back(o2::its::getTrackWriterSpec(useMC));

--- a/Detectors/ITSMFT/ITS/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/RecoWorkflow.cxx
@@ -30,7 +30,7 @@ namespace reco_workflow
 {
 
 framework::WorkflowSpec getWorkflow(bool useMC, bool useCAtracker, const std::string& trmode, o2::gpu::GPUDataTypes::DeviceType dtype,
-                                    bool upstreamDigits, bool upstreamClusters, bool disableRootOutput,
+                                    bool upstreamDigits, bool upstreamClusters, bool disableRootOutput, bool useTRD,
                                     bool eencode)
 {
   framework::WorkflowSpec specs;
@@ -47,9 +47,9 @@ framework::WorkflowSpec getWorkflow(bool useMC, bool useCAtracker, const std::st
   }
   if (!trmode.empty()) {
     if (useCAtracker) {
-      specs.emplace_back(o2::its::getTrackerSpec(useMC, trmode, dtype));
+      specs.emplace_back(o2::its::getTrackerSpec(useMC, useTRD, trmode, dtype));
     } else {
-      specs.emplace_back(o2::its::getCookedTrackerSpec(useMC, trmode));
+      specs.emplace_back(o2::its::getCookedTrackerSpec(useMC, useTRD, trmode));
     }
     if (!disableRootOutput) {
       specs.emplace_back(o2::its::getTrackWriterSpec(useMC));

--- a/Detectors/ITSMFT/ITS/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/RecoWorkflow.cxx
@@ -36,7 +36,7 @@ framework::WorkflowSpec getWorkflow(bool useMC, bool useCAtracker, const std::st
   framework::WorkflowSpec specs;
 
   if (!(upstreamDigits || upstreamClusters)) {
-    specs.emplace_back(o2::itsmft::getITSDigitReaderSpec(useMC, false, "itsdigits.root"));
+    specs.emplace_back(o2::itsmft::getITSDigitReaderSpec(useMC, false, true, "itsdigits.root"));
   }
 
   if (!upstreamClusters) {

--- a/Detectors/ITSMFT/ITS/workflow/src/its-cluster-reader-workflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/its-cluster-reader-workflow.cxx
@@ -25,6 +25,12 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   workflowOptions.push_back(
     ConfigParamSpec{
+      "suppress-triggers-output",
+      o2::framework::VariantType::Bool,
+      false,
+      {"suppress dummy triggers output"}});
+  workflowOptions.push_back(
+    ConfigParamSpec{
       "with-mc",
       o2::framework::VariantType::Bool,
       false,
@@ -51,10 +57,11 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cc)
 {
   WorkflowSpec specs;
   o2::conf::ConfigurableParam::updateFromString(cc.options().get<std::string>("configKeyValues"));
+  auto withTriggers = !cc.options().get<bool>("suppress-triggers-output");
   auto withMC = cc.options().get<bool>("with-mc");
   auto withPatterns = !cc.options().get<bool>("without-patterns");
 
-  specs.emplace_back(o2::itsmft::getITSClusterReaderSpec(withMC, withPatterns));
+  specs.emplace_back(o2::itsmft::getITSClusterReaderSpec(withMC, withPatterns, withTriggers));
 
   // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit
   o2::raw::HBFUtilsInitializer hbfIni(cc, specs);

--- a/Detectors/ITSMFT/ITS/workflow/src/its-reco-workflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/its-reco-workflow.cxx
@@ -74,7 +74,6 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   if (configcontext.options().get<bool>("disable-tracking")) {
     trmode = "";
   }
-
   std::transform(trmode.begin(), trmode.end(), trmode.begin(), [](unsigned char c) { return std::tolower(c); });
 
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));

--- a/Detectors/ITSMFT/ITS/workflow/src/its-reco-workflow.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/its-reco-workflow.cxx
@@ -46,6 +46,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"disable-root-output", o2::framework::VariantType::Bool, false, {"do not write output root files"}},
     {"disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation even if available"}},
     {"trackerCA", o2::framework::VariantType::Bool, false, {"use trackerCA (default: trackerCM)"}},
+    {"select-with-trd", o2::framework::VariantType::Bool, false, {"use TRD triggers to prescale processed ROFs"}},
     {"tracking-mode", o2::framework::VariantType::String, "sync", {"sync,async,cosmics"}},
     {"disable-tracking", o2::framework::VariantType::Bool, false, {"disable tracking step"}},
     {"entropy-encoding", o2::framework::VariantType::Bool, false, {"produce entropy encoded data"}},
@@ -66,6 +67,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   auto useMC = !configcontext.options().get<bool>("disable-mc");
   auto useCAtracker = configcontext.options().get<bool>("trackerCA");
   auto trmode = configcontext.options().get<std::string>("tracking-mode");
+  auto selTRD = configcontext.options().get<bool>("select-with-trd");
   auto gpuDevice = static_cast<o2::gpu::GPUDataTypes::DeviceType>(configcontext.options().get<int>("gpuDevice"));
   auto extDigits = configcontext.options().get<bool>("digits-from-upstream");
   auto extClusters = configcontext.options().get<bool>("clusters-from-upstream");
@@ -78,7 +80,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
 
-  auto wf = o2::its::reco_workflow::getWorkflow(useMC, useCAtracker, trmode, gpuDevice, extDigits, extClusters, disableRootOutput, eencode);
+  auto wf = o2::its::reco_workflow::getWorkflow(useMC, useCAtracker, trmode, gpuDevice, extDigits, extClusters, disableRootOutput, selTRD, eencode);
 
   // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit
   o2::raw::HBFUtilsInitializer hbfIni(configcontext, wf);

--- a/Detectors/ITSMFT/MFT/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/RecoWorkflow.cxx
@@ -33,7 +33,7 @@ framework::WorkflowSpec getWorkflow(bool useMC, bool upstreamDigits, bool upstre
   framework::WorkflowSpec specs;
 
   if (!(upstreamDigits || upstreamClusters)) {
-    specs.emplace_back(o2::itsmft::getMFTDigitReaderSpec(useMC, false, "mftdigits.root"));
+    specs.emplace_back(o2::itsmft::getMFTDigitReaderSpec(useMC, false, true, "mftdigits.root"));
   }
   if (!upstreamClusters) {
     specs.emplace_back(o2::mft::getClustererSpec(useMC));

--- a/Detectors/ITSMFT/MFT/workflow/src/mft-cluster-reader-workflow.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/mft-cluster-reader-workflow.cxx
@@ -24,6 +24,12 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   workflowOptions.push_back(
     ConfigParamSpec{
+      "suppress-triggers-output",
+      o2::framework::VariantType::Bool,
+      false,
+      {"suppress dummy triggers output"}});
+  workflowOptions.push_back(
+    ConfigParamSpec{
       "with-mc",
       o2::framework::VariantType::Bool,
       false,
@@ -44,10 +50,10 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 WorkflowSpec defineDataProcessing(ConfigContext const& cc)
 {
   WorkflowSpec specs;
+  auto withTriggers = !cc.options().get<bool>("suppress-triggers-output");
   auto withMC = cc.options().get<bool>("with-mc");
   auto withPatterns = !cc.options().get<bool>("without-patterns");
-
-  specs.emplace_back(o2::itsmft::getMFTClusterReaderSpec(withMC, withPatterns));
+  specs.emplace_back(o2::itsmft::getMFTClusterReaderSpec(withMC, withPatterns, withTriggers));
 
   // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit
   o2::raw::HBFUtilsInitializer hbfIni(cc, specs);

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/GBTLink.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/GBTLink.h
@@ -26,6 +26,7 @@
 #include "ITSMFTReconstruction/RUDecodeData.h"
 #include "ITSMFTReconstruction/DecodingStat.h"
 #include "ITSMFTReconstruction/RUInfo.h"
+#include "DataFormatsITSMFT/PhysTrigger.h"
 #include "Headers/RAWDataHeader.h"
 #include "DetectorsRaw/RDHUtils.h"
 #include "CommonDataFormat/InteractionRecord.h"
@@ -85,7 +86,7 @@ struct GBTLink {
   CollectedDataStatus status = None;
   Format format = NewFormat;
   Verbosity verbosity = VerboseErrors;
-  std::vector<GBTTriggerR>* extTrigVec = nullptr;
+  std::vector<PhysTrigger>* extTrigVec = nullptr;
   uint8_t idInRU = 0;     // link ID within the RU
   uint8_t idInCRU = 0;    // link ID within the CRU
   uint8_t endPointID = 0; // endpoint ID of the CRU
@@ -278,8 +279,8 @@ GBTLink::CollectedDataStatus GBTLink::collectROFCableData(const Mapping& chmap)
             gbtTrg = gbtTrgTmp; // this is a trigger describing the following data
           } else {
             if (extTrigVec) { // this link collects external triggers
-              extTrigVec->emplace_back(GBTTriggerR{uint32_t(gbtTrgTmp->orbit), uint16_t(gbtTrgTmp->bc), uint16_t(gbtTrgTmp->triggerType), gbtTrgTmp->internal != 0, gbtTrgTmp->noData != 0});
-              printTrigger(gbtTrgTmp);
+              extTrigVec->emplace_back(PhysTrigger{o2::InteractionRecord(uint16_t(gbtTrgTmp->bc), uint32_t(gbtTrgTmp->orbit)),
+                                                   uint16_t(gbtTrgTmp->triggerType), gbtTrgTmp->internal != 0, gbtTrgTmp->noData != 0});
             }
           }
           continue;

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/GBTLink.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/GBTLink.h
@@ -279,8 +279,7 @@ GBTLink::CollectedDataStatus GBTLink::collectROFCableData(const Mapping& chmap)
             gbtTrg = gbtTrgTmp; // this is a trigger describing the following data
           } else {
             if (extTrigVec) { // this link collects external triggers
-              extTrigVec->emplace_back(PhysTrigger{o2::InteractionRecord(uint16_t(gbtTrgTmp->bc), uint32_t(gbtTrgTmp->orbit)),
-                                                   uint16_t(gbtTrgTmp->triggerType), gbtTrgTmp->internal != 0, gbtTrgTmp->noData != 0});
+              extTrigVec->emplace_back(PhysTrigger{o2::InteractionRecord(uint16_t(gbtTrgTmp->bc), uint32_t(gbtTrgTmp->orbit)), uint64_t(gbtTrgTmp->triggerType)});
             }
           }
           continue;

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/GBTWord.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/GBTWord.h
@@ -55,16 +55,6 @@ constexpr uint8_t GBTFlagStatus = 0xe0;
 constexpr int GBTWordLength = 10;       // lentgh in bytes
 constexpr int GBTPaddedWordLength = 16; // lentgh in bytes with padding
 
-// root friendly version of the trigger (root does not support anonymous structs)
-struct GBTTriggerR {
-  uint32_t orbit = 0;
-  uint16_t bc = 0;
-  uint16_t triggerType = 0;
-  bool internal = false;
-  bool noData = false;
-  ClassDefNV(GBTTriggerR, 1);
-};
-
 struct GBTWord {
   /// GBT word of 80 bits, bits 72:79 are reserver for GBT Header flag, the rest depends on specifications
   union {

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelDecoder.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelDecoder.h
@@ -109,8 +109,8 @@ class RawPixelDecoder final : public PixelReader
   void setRawDumpDirectory(const std::string& s) { mRawDumpDirectory = s; }
   auto getRawDumpDirectory() const { return mRawDumpDirectory; }
 
-  std::vector<GBTTriggerR>& getExternalTriggers() { return mExtTriggers; }
-  const std::vector<GBTTriggerR>& getExternalTriggers() const { return mExtTriggers; }
+  std::vector<PhysTrigger>& getExternalTriggers() { return mExtTriggers; }
+  const std::vector<PhysTrigger>& getExternalTriggers() const { return mExtTriggers; }
 
   struct LinkEntry {
     int entry = -1;
@@ -130,7 +130,7 @@ class RawPixelDecoder final : public PixelReader
   std::vector<RUDecodeData> mRUDecodeVec;                   // set of active RUs
   std::array<short, Mapping::getNRUs()> mRUEntry;           // entry of the RU with given SW ID in the mRUDecodeVec
   std::vector<ChipPixelData*> mOrderedChipsPtr;             // special ordering helper used for the MFT (its chipID is not contiguous in RU)
-  std::vector<GBTTriggerR> mExtTriggers;                    // external triggers
+  std::vector<PhysTrigger> mExtTriggers;                    // external triggers
   std::string mSelfName{};                                  // self name
   std::string mRawDumpDirectory;                            // destination directory for dumps
   header::DataOrigin mUserDataOrigin = o2::header::gDataOriginInvalid; // alternative user-provided data origin to pick

--- a/Detectors/ITSMFT/common/reconstruction/src/ITSMFTReconstructionLinkDef.h
+++ b/Detectors/ITSMFT/common/reconstruction/src/ITSMFTReconstructionLinkDef.h
@@ -46,8 +46,6 @@
 #pragma link C++ class o2::itsmft::RUDecodeData + ;
 #pragma link C++ class o2::itsmft::RawDecodingStat + ;
 #pragma link C++ class o2::itsmft::ChipStat + ;
-#pragma link C++ class o2::itsmft::GBTTriggerR + ;
-#pragma link C++ class std::vector < o2::itsmft::GBTTrigger> + ;
 #pragma link C++ class std::map < unsigned long, std::pair < o2::itsmft::ClusterTopology, unsigned long>> + ;
 
 #pragma link C++ class o2::itsmft::ClustererParam < o2::detectors::DetID::ITS> + ;

--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/ClusterReaderSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/ClusterReaderSpec.h
@@ -37,7 +37,7 @@ class ClusterReader : public Task
 {
  public:
   ClusterReader() = delete;
-  ClusterReader(o2::detectors::DetID id, bool useMC, bool usePatterns = true);
+  ClusterReader(o2::detectors::DetID id, bool useMC, bool usePatterns = true, bool triggers = true);
   ~ClusterReader() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
@@ -58,6 +58,7 @@ class ClusterReader : public Task
 
   bool mUseMC = true;     // use MC truth
   bool mUsePatterns = true; // send patterns
+  bool mTriggerOut = true;  // send dummy triggers vector
 
   std::string mDetName = "";
   std::string mDetNameLC = "";
@@ -73,8 +74,8 @@ class ClusterReader : public Task
 class ITSClusterReader : public ClusterReader
 {
  public:
-  ITSClusterReader(bool useMC = true, bool usePatterns = true)
-    : ClusterReader(o2::detectors::DetID::ITS, useMC, usePatterns)
+  ITSClusterReader(bool useMC = true, bool usePatterns = true, bool triggerOut = true)
+    : ClusterReader(o2::detectors::DetID::ITS, useMC, usePatterns, triggerOut)
   {
     mOrigin = o2::header::gDataOriginITS;
   }
@@ -83,8 +84,8 @@ class ITSClusterReader : public ClusterReader
 class MFTClusterReader : public ClusterReader
 {
  public:
-  MFTClusterReader(bool useMC = true, bool usePatterns = true)
-    : ClusterReader(o2::detectors::DetID::MFT, useMC, usePatterns)
+  MFTClusterReader(bool useMC = true, bool usePatterns = true, bool triggerOut = true)
+    : ClusterReader(o2::detectors::DetID::MFT, useMC, usePatterns, triggerOut)
   {
     mOrigin = o2::header::gDataOriginMFT;
   }
@@ -92,8 +93,8 @@ class MFTClusterReader : public ClusterReader
 
 /// create a processor spec
 /// read ITS/MFT cluster data from a root file
-framework::DataProcessorSpec getITSClusterReaderSpec(bool useMC = true, bool usePatterns = true);
-framework::DataProcessorSpec getMFTClusterReaderSpec(bool useMC = true, bool usePatterns = true);
+framework::DataProcessorSpec getITSClusterReaderSpec(bool useMC = true, bool usePatterns = true, bool useTriggers = true);
+framework::DataProcessorSpec getMFTClusterReaderSpec(bool useMC = true, bool usePatterns = true, bool useTriggers = true);
 
 } // namespace itsmft
 } // namespace o2

--- a/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/DigitReaderSpec.h
+++ b/Detectors/ITSMFT/common/workflow/include/ITSMFTWorkflow/DigitReaderSpec.h
@@ -36,7 +36,7 @@ class DigitReader : public Task
 {
  public:
   DigitReader() = delete;
-  DigitReader(o2::detectors::DetID id, bool useMC, bool useCalib);
+  DigitReader(o2::detectors::DetID id, bool useMC, bool useCalib, bool triggerOut);
   ~DigitReader() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
@@ -53,10 +53,9 @@ class DigitReader : public Task
 
   std::unique_ptr<TFile> mFile;
   std::unique_ptr<TTree> mTree;
-
   bool mUseMC = true;    // use MC truth
   bool mUseCalib = true; // send calib data
-
+  bool mTriggerOut = true; // send dummy triggers vector
   std::string mDetName = "";
   std::string mDetNameLC = "";
   std::string mFileName = "";
@@ -72,8 +71,8 @@ class DigitReader : public Task
 class ITSDigitReader : public DigitReader
 {
  public:
-  ITSDigitReader(bool useMC = true, bool useCalib = false)
-    : DigitReader(o2::detectors::DetID::ITS, useMC, useCalib)
+  ITSDigitReader(bool useMC = true, bool useCalib = false, bool useTriggers = true)
+    : DigitReader(o2::detectors::DetID::ITS, useMC, useCalib, useTriggers)
   {
     mOrigin = o2::header::gDataOriginITS;
   }
@@ -82,8 +81,8 @@ class ITSDigitReader : public DigitReader
 class MFTDigitReader : public DigitReader
 {
  public:
-  MFTDigitReader(bool useMC = true, bool useCalib = false)
-    : DigitReader(o2::detectors::DetID::MFT, useMC, useCalib)
+  MFTDigitReader(bool useMC = true, bool useCalib = false, bool useTriggers = true)
+    : DigitReader(o2::detectors::DetID::MFT, useMC, useCalib, useTriggers)
   {
     mOrigin = o2::header::gDataOriginMFT;
   }
@@ -91,8 +90,8 @@ class MFTDigitReader : public DigitReader
 
 /// create a processor spec
 /// read ITS/MFT Digit data from a root file
-framework::DataProcessorSpec getITSDigitReaderSpec(bool useMC = true, bool useCalib = false, std::string defname = "o2_itsdigits.root");
-framework::DataProcessorSpec getMFTDigitReaderSpec(bool useMC = true, bool useCalib = false, std::string defname = "o2_mftdigits.root");
+framework::DataProcessorSpec getITSDigitReaderSpec(bool useMC = true, bool useCalib = false, bool useTriggers = true, std::string defname = "o2_itsdigits.root");
+framework::DataProcessorSpec getMFTDigitReaderSpec(bool useMC = true, bool useCalib = false, bool useTriggers = true, std::string defname = "o2_mftdigits.root");
 
 } // namespace itsmft
 } // namespace o2

--- a/Detectors/ITSMFT/common/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/EntropyDecoderSpec.cxx
@@ -20,6 +20,7 @@
 #include "ITSMFTWorkflow/EntropyDecoderSpec.h"
 #include "ITSMFTReconstruction/ClustererParam.h"
 #include "DetectorsCommonDataFormats/DetectorNameConf.h"
+#include "DataFormatsITSMFT/PhysTrigger.h"
 
 using namespace o2::framework;
 
@@ -72,6 +73,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
     mTimer.Stop();
     LOG(info) << "Decoded " << compcl.size() << " clusters in " << rofs.size() << " RO frames, (" << iosize.asString() << ") in " << mTimer.CpuTime() - cput << " s";
   }
+  pc.outputs().make<std::vector<o2::itsmft::PhysTrigger>>(OutputRef{"phystrig"}); // dummy output
   pc.outputs().snapshot({"ctfrep", 0}, iosize);
 }
 
@@ -121,6 +123,9 @@ DataProcessorSpec getEntropyDecoderSpec(o2::header::DataOrigin orig, int verbosi
     outputs.emplace_back(OutputSpec{{"patterns"}, orig, "PATTERNS", 0, Lifetime::Timeframe});
   }
   outputs.emplace_back(OutputSpec{{"ctfrep"}, orig, "CTFDECREP", 0, Lifetime::Timeframe});
+
+  // this is a special dummy input which makes sense only in sync workflows
+  outputs.emplace_back(OutputSpec{{"phystrig"}, orig, "PHYSTRIG", 0, Lifetime::Timeframe});
 
   std::vector<InputSpec> inputs;
   inputs.emplace_back("ctf", orig, "CTFDATA", sspec, Lifetime::Timeframe);

--- a/Detectors/ITSMFT/common/workflow/src/digit-reader-workflow.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/digit-reader-workflow.cxx
@@ -25,6 +25,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     ConfigParamSpec{"disable-mc", VariantType::Bool, false, {"disable mc truth"}},
     ConfigParamSpec{"enable-calib-data", VariantType::Bool, false, {"enable writing GBT calibration data"}},
     ConfigParamSpec{"runmft", VariantType::Bool, false, {"expect MFT data"}},
+    ConfigParamSpec{"suppress-triggers-output", VariantType::Bool, false, {"suppress dummy triggers output"}},
     ConfigParamSpec{"configKeyValues", VariantType::String, "", {"semicolon separated key=value strings"}}};
 
   std::swap(workflowOptions, options);
@@ -39,13 +40,14 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   WorkflowSpec wf;
   bool useMC = !cfgc.options().get<bool>("disable-mc");
   bool calib = cfgc.options().get<bool>("enable-calib-data");
+  bool withTriggers = !cfgc.options().get<bool>("suppress-triggers-output");
   // Update the (declared) parameters if changed from the command line
   o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
 
   if (cfgc.options().get<bool>("runmft")) {
-    wf.emplace_back(o2::itsmft::getMFTDigitReaderSpec(useMC, calib));
+    wf.emplace_back(o2::itsmft::getMFTDigitReaderSpec(useMC, calib, withTriggers));
   } else {
-    wf.emplace_back(o2::itsmft::getITSDigitReaderSpec(useMC, calib));
+    wf.emplace_back(o2::itsmft::getITSDigitReaderSpec(useMC, calib, withTriggers));
   }
   return wf;
 }

--- a/Detectors/ITSMFT/common/workflow/src/trigger-writer-workflow.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/trigger-writer-workflow.cxx
@@ -13,7 +13,7 @@
 
 #include "ITSMFTWorkflow/DigitWriterSpec.h"
 #include "DPLUtils/MakeRootTreeWriterSpec.h"
-#include "ITSMFTReconstruction/GBTWord.h"
+#include <DataFormatsITSMFT/PhysTrigger.h>
 #include "Headers/DataHeader.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 #include "CommonUtils/ConfigurableParam.h"
@@ -41,16 +41,14 @@ DataProcessorSpec getPhyTrigWriterSpec(DetID detId)
   std::string detStrL = "o2_";
   detStrL += detStr;
   std::transform(detStrL.begin(), detStrL.end(), detStrL.begin(), ::tolower);
-  auto logger = [](std::vector<o2::itsmft::GBTTriggerR> const& inp) {
+  auto logger = [](std::vector<o2::itsmft::PhysTrigger> const& inp) {
     LOG(info) << "Received " << inp.size() << " triggers";
   };
 
   return MakeRootTreeWriterSpec((detStr + "phytrigwriter").c_str(),
                                 (detStrL + "phy-triggers.root").c_str(),
                                 MakeRootTreeWriterSpec::TreeAttributes{"o2sim", "Physics triggers tree"},
-                                BranchDefinition<std::vector<o2::itsmft::GBTTriggerR>>{InputSpec{"trig",
-                                                                                                 detId == DetID::ITS ? "ITS" : "MFT", "PHYSTRIG", 0},
-                                                                                       (detStr + "Trig").c_str()})();
+                                BranchDefinition<std::vector<o2::itsmft::PhysTrigger>>{InputSpec{"trig", detId == DetID::ITS ? "ITS" : "MFT", "PHYSTRIG", 0}, (detStr + "Trig").c_str()})();
 }
 
 } // end namespace itsmft

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -108,6 +108,10 @@ else
   [[ -z ${ITS_CONFIG+x} ]] && ITS_CONFIG=" --tracking-mode async"
 fi
 
+if has_detector TRD && [[ ! -z ${PRESCALE_ITS_WITH_TRD} ]]; then
+  ITS_CONFIG+=" --select-with-trd "
+fi
+
 if [[ $BEAMTYPE == "PbPb" || $BEAMTYPE == "pp" ]]; then
   workflow_has_parameter CALIB && TRD_CONFIG+=" --enable-trackbased-calib"
 fi

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -108,9 +108,14 @@ else
   [[ -z ${ITS_CONFIG+x} ]] && ITS_CONFIG=" --tracking-mode async"
 fi
 
-if has_detector TRD && [[ ! -z ${PRESCALE_ITS_WITH_TRD} ]]; then
-  ITS_CONFIG+=" --select-with-trd "
+if [[ $SYNCMODE == 1 ]]; then
+  if has_detector TRD && [[ ! -z ${PRESCALE_ITS_WITH_TRD} ]]; then
+    ITS_CONFIG+=" --select-with-triggers trd "
+  else
+    ITS_CONFIG+=" --select-with-triggers phys "
+  fi
 fi
+
 
 if [[ $BEAMTYPE == "PbPb" || $BEAMTYPE == "pp" ]]; then
   workflow_has_parameter CALIB && TRD_CONFIG+=" --enable-trackbased-calib"


### PR DESCRIPTION
With fastMultConfig.preferTriggered=true (default) the random preselection of ITS ROFs to process will
prefer ROFs with most of physics triggers. In the raw-data workflow these triggers are provided by the
its-stf-decoder. In cluster / digits based workflows we don't have physicsl triggers, therefore cluster-reader and
digit-readers are pushing empty triggers vector to the output (can be suppressed by --suppress-triggers-output).