### PR TITLE
TRD permit eventype to change between rdh stops, reduce errorneous errors, and reduce some alarms to info messages.

### DIFF
--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
@@ -156,25 +156,20 @@ class CruRawReader
   void updateLinkErrorGraphs(int currentlinkindex, int supermodule_half, int stack_layer);
   void incrementErrors(int hist, int sector = -1, int side = 0, int stack = 0, int layer = 0)
   {
-    //  LOG(info) << "increment ed parsing error with " << hist << " "<< sectorside/2 <<  " "<< sectorside%2 << " " <<stack*constants::NLAYER+layer << " stack:" << stack << " layer" << layer << " sectorside:" << sectorside;
     if (sector > 17) {
-      LOG(info) << "Parsing error: " << hist << " sector: " << sector << " side:" << side << " stack:" << stack << " layer:" << layer;
       sector = 0;
     }
     if (stack > 4) {
-      LOG(info) << "Parsing error: " << hist << " sector:" << sector << " side:" << side << " stack:" << stack << " layer:" << layer;
       stack = 0;
     }
     if (layer > 5) {
-      LOG(info) << "Parsing error: " << hist << " sector:" << sector << " side:" << side << " stack:" << stack << " layer:" << layer;
       layer = 0;
     }
     if (sector < -1) {
-      LOG(info) << "Parsing error: " << hist << " sector:" << sector << " side:" << side << " stack:" << stack << " layer:" << layer;
       sector = 0;
     }
     mEventRecords.incParsingError(hist, sector, side, stack * constants::NLAYER + layer);
-    if (mDataVerbose) {
+    if (mVerbose) {
       LOG(info) << "Parsing error: " << hist << " sector:" << sector << " side:" << side << " stack:" << stack << " layer:" << layer;
     }
   }

--- a/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
+++ b/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
@@ -302,7 +302,7 @@ int TrackletsParser::Parse()
           // take the header and this data word and build the underlying 64bit tracklet.
           int q0, q1, q2;
           if (mcmtrackletcount > 2) {
-            LOG(alarm) << "mcmtrackletcount is not in [0:2] count=" << mcmtrackletcount << " headertrackletcount=" << headertrackletcount << " something very wrong parsing the TrackletMCMData fields with data of : 0x" << std::hex << *word;
+            LOG(info) << "mcmtrackletcount is not in [0:2] count=" << mcmtrackletcount << " headertrackletcount=" << headertrackletcount << " something very wrong parsing the TrackletMCMData fields with data of : 0x" << std::hex << *word;
             incParsingError(TRDParsingTrackletInvalidTrackletCount);
             //this should have been caught above by the headertrackletcount to mcmtrackletcount
             ignoreDataTillTrackletEndMarker = true;
@@ -324,7 +324,6 @@ int TrackletsParser::Parse()
             int hcid = mDetector * 2 + mHalfChamberSide;
             if (mHeaderVerbose) {
               if (mTrackletHCHeaderState) {
-                //LOG(info) << "Tracklet HCID : " << hcid << " mDetector:" << mDetector << " robside:" << mHalfChamberSide << " " << mTrackletMCMHeader->padrow << ":" << mTrackletMCMHeader->col << " ---- " << mTrackletHCHeader->supermodule << ":" << mTrackletHCHeader->stack << ":" << mTrackletHCHeader->layer << ":" << mTrackletHCHeader->side << " rawhcheader : 0x" << std::hex << std::hex << mTrackletHCHeader->word;
                 LOG(info) << "Tracklet HCID : " << hcid << " mDetector:" << mDetector << " robside:" << mHalfChamberSide << " " << mTrackletMCMHeader->padrow << ":" << mTrackletMCMHeader->col << " ---- " << mTrackletHCHeader.supermodule << ":" << mTrackletHCHeader.stack << ":" << mTrackletHCHeader.layer << ":" << mTrackletHCHeader.side << " rawhcheader : 0x" << std::hex << std::hex << mTrackletHCHeader.word;
               } else {
                 LOG(info) << "Tracklet HCID : " << hcid << " mDetector:" << mDetector << " robside:" << mHalfChamberSide << " " << mTrackletMCMHeader->padrow << ":" << mTrackletMCMHeader->col;


### PR DESCRIPTION
- some alarms, although important to trd, are only worthy of info message, so changed.
- reduce the logging to parsing error graphs in case of padding words 0xeeeeeeee
- remove the eventype being consistent across rdh, eventype can change from 2 to 3 and back for a physics, calibration trigger respectively. The changes to make the code safe were too restrictive.