### PR TITLE
o2-eve: fix problems with event navigation

### DIFF
--- a/EventVisualisation/Base/src/DirectoryLoader.cxx
+++ b/EventVisualisation/Base/src/DirectoryLoader.cxx
@@ -31,7 +31,7 @@ deque<string> DirectoryLoader::load(const std::string& path, const std::string& 
   // comparison with safety if marker not in the filename (-1+1 gives 0)
   std::sort(result.begin(), result.end(),
             [marker](std::string a, std::string b) {
-              return a.substr(a.find_last_of(marker) + 1) < b.substr(b.find_last_of(marker) + 1);
+              return a.substr(a.find_first_of(marker) + 1) < b.substr(b.find_first_of(marker) + 1);
             });
 
   return result;

--- a/EventVisualisation/Workflow/include/EveWorkflow/FileProducer.h
+++ b/EventVisualisation/Workflow/include/EveWorkflow/FileProducer.h
@@ -32,7 +32,7 @@ class FileProducer
 
  public:
   explicit FileProducer(const std::string& path, int filesInFolder = -1,
-                        const std::string& name = "tracks_{hostname}_{pid}_{timestamp}.json");
+                        const std::string& name = "tracks_{timestamp}_{hostname}_{pid}.json");
 
   [[nodiscard]] std::string newFileName() const;
 };


### PR DESCRIPTION
json file names pattern will change from:
tracks_{hostname}_{pid}_{timestamp}.json
to:
tracks_{timestamp}_{hostname}_{pid}.json
to enable proper sorting and comparison of files