### PR TITLE
[EMCAL-630, EMCAL-789] EMCAL Reco Params and LGnoHG suppression 

### DIFF
--- a/Detectors/EMCAL/reconstruction/CMakeLists.txt
+++ b/Detectors/EMCAL/reconstruction/CMakeLists.txt
@@ -10,60 +10,61 @@
 # or submit itself to any jurisdiction.
 
 o2_add_library(EMCALReconstruction
-               SOURCES src/RawReaderMemory.cxx
-                       src/RawBuffer.cxx
-                       src/RawHeaderStream.cxx
-                       src/RawPayload.cxx
-                       src/AltroDecoder.cxx
-                       src/Bunch.cxx
-                       src/Channel.cxx
-                       src/CaloFitResults.cxx
-                       src/CaloRawFitter.cxx
-                       src/CaloRawFitterStandard.cxx
-                       src/CaloRawFitterGamma2.cxx
-                       src/ClusterizerParameters.cxx
-                       src/Clusterizer.cxx
-                       src/ClusterizerTask.cxx
-                       src/DigitReader.cxx
-                       src/CTFCoder.cxx
-                       src/CTFHelper.cxx
-               PUBLIC_LINK_LIBRARIES FairRoot::Base O2::Headers
-                                     AliceO2::InfoLogger
-                                     O2::DataFormatsEMCAL
-                                     O2::DetectorsBase
-                                     O2::DetectorsRaw
-                                     O2::EMCALBase
-                                     O2::rANS
-                                     Microsoft.GSL::GSL)
+        SOURCES src/RawReaderMemory.cxx
+        src/RawBuffer.cxx
+        src/RawHeaderStream.cxx
+        src/RawPayload.cxx
+        src/AltroDecoder.cxx
+        src/Bunch.cxx
+        src/Channel.cxx
+        src/RecoParam.cxx
+        src/CaloFitResults.cxx
+        src/CaloRawFitter.cxx
+        src/CaloRawFitterStandard.cxx
+        src/CaloRawFitterGamma2.cxx
+        src/ClusterizerParameters.cxx
+        src/Clusterizer.cxx
+        src/ClusterizerTask.cxx
+        src/DigitReader.cxx
+        src/CTFCoder.cxx
+        src/CTFHelper.cxx
+        PUBLIC_LINK_LIBRARIES FairRoot::Base O2::Headers
+        AliceO2::InfoLogger
+        O2::DataFormatsEMCAL
+        O2::DetectorsBase
+        O2::DetectorsRaw
+        O2::EMCALBase
+        O2::rANS
+        Microsoft.GSL::GSL)
 
 o2_target_root_dictionary(
-                          EMCALReconstruction
-                          HEADERS include/EMCALReconstruction/RawReaderMemory.h
-                                  include/EMCALReconstruction/AltroDecoder.h
-                                  include/EMCALReconstruction/AltroHelper.h
-                                  include/EMCALReconstruction/RawPayload.h
-                                  include/EMCALReconstruction/Bunch.h
-                                  include/EMCALReconstruction/Channel.h
-                                  include/EMCALReconstruction/CaloFitResults.h
-                                  include/EMCALReconstruction/CaloRawFitter.h
-                                  include/EMCALReconstruction/CaloRawFitterStandard.h
-                                  include/EMCALReconstruction/CaloRawFitterGamma2.h
-                                  include/EMCALReconstruction/ClusterizerParameters.h
-                                  include/EMCALReconstruction/Clusterizer.h
-                                  include/EMCALReconstruction/ClusterizerTask.h
-                                  include/EMCALReconstruction/DigitReader.h
+        EMCALReconstruction
+        HEADERS include/EMCALReconstruction/RawReaderMemory.h
+        include/EMCALReconstruction/AltroDecoder.h
+        include/EMCALReconstruction/AltroHelper.h
+        include/EMCALReconstruction/RawPayload.h
+        include/EMCALReconstruction/Bunch.h
+        include/EMCALReconstruction/Channel.h
+        include/EMCALReconstruction/CaloFitResults.h
+        include/EMCALReconstruction/CaloRawFitter.h
+        include/EMCALReconstruction/CaloRawFitterStandard.h
+        include/EMCALReconstruction/CaloRawFitterGamma2.h
+        include/EMCALReconstruction/ClusterizerParameters.h
+        include/EMCALReconstruction/Clusterizer.h
+        include/EMCALReconstruction/ClusterizerTask.h
+        include/EMCALReconstruction/DigitReader.h
+        include/EMCALReconstruction/RecoParam.h
 )
 
 o2_add_executable(rawreader-file
-                  COMPONENT_NAME emcal
-                  PUBLIC_LINK_LIBRARIES O2::EMCALReconstruction
-                  SOURCES run/rawReaderFile.cxx)
+        COMPONENT_NAME emcal
+        PUBLIC_LINK_LIBRARIES O2::EMCALReconstruction
+        SOURCES run/rawReaderFile.cxx)
 
 o2_add_test_root_macro(macros/RawFitterTESTs.C
-            PUBLIC_LINK_LIBRARIES O2::EMCALReconstruction O2::Headers
-            LABELS emcal COMPILE_ONLY)
+        PUBLIC_LINK_LIBRARIES O2::EMCALReconstruction O2::Headers
+        LABELS emcal COMPILE_ONLY)
 
 o2_add_test_root_macro(macros/RawFitterTESTMulti.C
-            PUBLIC_LINK_LIBRARIES O2::EMCALReconstruction O2::Headers
-            LABELS emcal COMPILE_ONLY)
-
+        PUBLIC_LINK_LIBRARIES O2::EMCALReconstruction O2::Headers
+        LABELS emcal COMPILE_ONLY)

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RecoParam.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RecoParam.h
@@ -1,0 +1,46 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+// or submit itself to any jurisdiction.
+#ifndef ALICEO2_EMCAL_RECOPARAM_H_
+#define ALICEO2_EMCAL_RECOPARAM_H_
+
+#include <iosfwd>
+#include "CommonUtils/ConfigurableParam.h"
+#include "CommonUtils/ConfigurableParamHelper.h"
+#include "Rtypes.h"
+
+namespace o2
+{
+namespace emcal
+{
+/// \class RecoParam
+/// \brief EMCal reconstruction parameters
+/// \ingroup EMCALreconstruction
+class RecoParam : public o2::conf::ConfigurableParamHelper<RecoParam>
+{
+ public:
+  ~RecoParam() override = default;
+
+  double getCellTimeShiftNanoSec() const { return mCellTimeShiftNanoSec; }
+  double getNoiseThresholdLGnoHG() const { return mNoiseThresholdLGnoHG; }
+
+  void PrintStream(std::ostream& stream) const;
+
+ private:
+  double mNoiseThresholdLGnoHG = 10.;  ///< Noise threshold applied to suppress LGnoHG error
+  double mCellTimeShiftNanoSec = 600.; ///< Time shift applied on the cell time to center trigger peak around 0
+
+  O2ParamDef(RecoParam, "EMCRecoParam");
+};
+std::ostream& operator<<(std::ostream& stream, const RecoParam& s);
+} // namespace emcal
+} // namespace o2
+#endif

--- a/Detectors/EMCAL/reconstruction/src/EMCALReconstructionLinkDef.h
+++ b/Detectors/EMCAL/reconstruction/src/EMCALReconstructionLinkDef.h
@@ -25,6 +25,8 @@
 #pragma link C++ class o2::emcal::CaloRawFitterStandard + ;
 #pragma link C++ class o2::emcal::CaloRawFitterGamma2 + ;
 
+#pragma link C++ class o2::emcal::RecoParam + ;
+
 //#pragma link C++ namespace o2::emcal+;
 #pragma link C++ class o2::emcal::ClusterizerParameters + ;
 #pragma link C++ class o2::emcal::Clusterizer < o2::emcal::Cell> + ;

--- a/Detectors/EMCAL/reconstruction/src/RecoParam.cxx
+++ b/Detectors/EMCAL/reconstruction/src/RecoParam.cxx
@@ -1,0 +1,31 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <iostream>
+#include "EMCALReconstruction/RecoParam.h"
+
+O2ParamImpl(o2::emcal::RecoParam);
+
+using namespace o2::emcal;
+
+std::ostream& operator<<(std::ostream& stream, const o2::emcal::RecoParam& s)
+{
+  s.PrintStream(stream);
+  return stream;
+}
+
+void RecoParam::PrintStream(std::ostream& stream) const
+{
+  stream << "EMCAL Reconstruction parameters:"
+         << "\n============================================="
+         << "\nTime offset (ns):                 " << mCellTimeShiftNanoSec
+         << "\nNoise threshold HGLG suppression: " << mNoiseThresholdLGnoHG;
+}


### PR DESCRIPTION
Use 3 sigma noise threshold with a sigma of 0.4 for
the LG digitizer to separate faulty cells from simple
noise: If the LG cell ADC is < 3 sigma the cell is
considered as pure noise cell where the error handling
is discarded, otherwise it is treated as a data corruption.

In addition moving converion from energy to ADC
from internal conversion constant to common constant. This has
a slightly better precision and will result in ~2% increase of
the energy.

[EMCAL-789] Create parameter handler for reconstruction params

Currently implemented:
- Time shift at cell level
- Noise cut LGnoHG