### PR TITLE
 [EMCAL-790] Fix correction of the cell time for BC mod 4

### DIFF
--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RecoParam.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RecoParam.h
@@ -37,8 +37,8 @@ class RecoParam : public o2::conf::ConfigurableParamHelper<RecoParam>
 
  private:
   double mNoiseThresholdLGnoHG = 10.;  ///< Noise threshold applied to suppress LGnoHG error
-  double mCellTimeShiftNanoSec = 600.; ///< Time shift applied on the cell time to center trigger peak around 0
-  int mPhaseBCmod4 = 0;                ///< Rollback of the BC ID in the correction of the cell time for the BC mod 4
+  double mCellTimeShiftNanoSec = 475.; ///< Time shift applied on the cell time to center trigger peak around 0
+  int mPhaseBCmod4 = 2;                ///< Rollback of the BC ID in the correction of the cell time for the BC mod 4
 
   O2ParamDef(RecoParam, "EMCRecoParam");
 };

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RecoParam.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RecoParam.h
@@ -31,12 +31,14 @@ class RecoParam : public o2::conf::ConfigurableParamHelper<RecoParam>
 
   double getCellTimeShiftNanoSec() const { return mCellTimeShiftNanoSec; }
   double getNoiseThresholdLGnoHG() const { return mNoiseThresholdLGnoHG; }
+  int getPhaseBCmod4() const { return mPhaseBCmod4; }
 
   void PrintStream(std::ostream& stream) const;
 
  private:
   double mNoiseThresholdLGnoHG = 10.;  ///< Noise threshold applied to suppress LGnoHG error
   double mCellTimeShiftNanoSec = 600.; ///< Time shift applied on the cell time to center trigger peak around 0
+  int mPhaseBCmod4 = 0;                ///< Rollback of the BC ID in the correction of the cell time for the BC mod 4
 
   O2ParamDef(RecoParam, "EMCRecoParam");
 };

--- a/Detectors/EMCAL/reconstruction/src/RecoParam.cxx
+++ b/Detectors/EMCAL/reconstruction/src/RecoParam.cxx
@@ -27,5 +27,6 @@ void RecoParam::PrintStream(std::ostream& stream) const
   stream << "EMCAL Reconstruction parameters:"
          << "\n============================================="
          << "\nTime offset (ns):                 " << mCellTimeShiftNanoSec
-         << "\nNoise threshold HGLG suppression: " << mNoiseThresholdLGnoHG;
+         << "\nNoise threshold HGLG suppression: " << mNoiseThresholdLGnoHG
+         << "\nPhase in BC mod 4 correction:     " << mPhaseBCmod4;
 }


### PR DESCRIPTION
The correction method used to merged the bunches
of the 4 trigger BC into 1 assumes the permutation
(0 1 2 3), otherwise it will only merge either 2 or 3 trigger
BCs into 1. Two possible issues can spoil the correction
a) Initial permutation differs from (0 1 2 3), i.e. BC 3 comes
   first, BC 0 second ...
b) Number of BCs in L0-LM correction not a multiple of 4
In order to allow for minimal intervention we treat the two
cases separately
a) We introduce a rollback parameter (default 0) rotating
   the initial permutation
b) We add again L0-LM delay % 4 BCs to the BC used in
   the correction to obtain the default parameterization
In the default case we will get the permutation (0 1 2 3)
and stay with a rollback of 0, non-0 rollback parameters
are needed only of the BC obtained would be shifted with
respect to expectation.