### PR TITLE
TRD final fix for pileup in digitization?

### DIFF
--- a/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Digitizer.h
@@ -56,6 +56,7 @@ class Digitizer
   void dumpLabels(const SignalContainer&, o2::dataformats::MCTruthContainer<MCLabel>&);
   void pileup();
   void clearPileupSignals() { mPileupSignals.clear(); }
+  const std::deque<std::array<SignalContainer, constants::MAXCHAMBER>>& getPileupSignals() const { return mPileupSignals; }
   void setEventTime(double timeNS) { mTime = timeNS; }
   void setTriggerTime(double t) { mCurrentTriggerTime = t; }
   void setEventID(int entryID) { mEventID = entryID; }


### PR DESCRIPTION
Another try... The previous workaround was helping, but it was still not correct, because in case there was still some pileup signal left in the container from a previous collision this would be removed even though it could theoretically still contribute to the next trigger.

I also understood the problem with the previous implementation better and will explain it here in order not to forget:
In case there is a collision potentially contributing to pileup the `Digitizer::pileup()` is called which moves the currently stored signals into the pileup container. Whenever a new collision appears which separated long enough from the trigger time `Digitizer::flush()` is called. This method checks first if the pileup container is non empty. In case it is not empty only the signal from the pileup container is taken for generating the digits. If the pileup container is empty, the currently stored signal is taken. Now consider the following collisions:

1. New trigger, hits are processed and stored in signal container
2. Pileup collision, previous signal from collision 1 is moved into pileup container, hits for collision 2 are processed
3. A collision which is far enough in the future that a call to `flush` is made.  The signal from the pileup container is taken (signal from collision 1). But it actually misses the signal from collision 2, as that has not been moved into the pileup container. Signal from collision 2 contributing to the previous collision is lost. Also the pileup container is not cleared, because collision 2 happened after 1 its signal could still contribute to future triggers. Hits for collision 3 are processed.
4. A collision which is again far enough in the future such that a new trigger is generated and a call to `flush` is made. Now we have an even bigger problem, because the pileup container will not be empty. Now the digitizer is searching in the pileup container for signal for collision 3 but it most likely finds nothing because the signal from collision 2 is too far in the past and signal from collision 3 is not even considered. We get 0 digits out.

This can be avoided by always moving the signal into the pileup container, in case it is not empty, before a call to flush. Drawback is that digits are not sorted anymore in that case. Which makes the TRAP simulation then probably a bit slower. So I added the clearing of the pileup container in case this can be safely done so that for most triggers the digits are still sorted.