### PR TITLE
Fixes for tof-calibinfo-reader, more robust TimeSlice methods

### DIFF
--- a/Detectors/Calibration/include/DetectorsCalibration/TimeSlotCalibration.h
+++ b/Detectors/Calibration/include/DetectorsCalibration/TimeSlotCalibration.h
@@ -151,7 +151,15 @@ class TimeSlotCalibration
 
  protected:
   auto& getSlots() { return mSlots; }
-  int getRunStartOrbit() const { return mCurrentTFInfo.firstTForbit - o2::base::GRPGeomHelper::getNHBFPerTF() * mCurrentTFInfo.tfCounter; }
+  int getRunStartOrbit() const {
+    int orb = mCurrentTFInfo.firstTForbit - o2::base::GRPGeomHelper::getNHBFPerTF() * mCurrentTFInfo.tfCounter;
+    if (orb<0) {
+      LOGP(alarm, "Negative runStartOrbit = {} deduced for from tfCounter={} and firstTForbit={}, enforcing runStartOrbit to 0", orb, mCurrentTFInfo.tfCounter, mCurrentTFInfo.firstTForbit);
+      orb = 0;
+    }
+    return orb;
+  }
+
   TFType tf2SlotMin(TFType tf) const;
 
   std::deque<Slot> mSlots;

--- a/Detectors/Calibration/include/DetectorsCalibration/TimeSlotCalibration.h
+++ b/Detectors/Calibration/include/DetectorsCalibration/TimeSlotCalibration.h
@@ -151,9 +151,10 @@ class TimeSlotCalibration
 
  protected:
   auto& getSlots() { return mSlots; }
-  int getRunStartOrbit() const {
+  int getRunStartOrbit() const
+  {
     int orb = mCurrentTFInfo.firstTForbit - o2::base::GRPGeomHelper::getNHBFPerTF() * mCurrentTFInfo.tfCounter;
-    if (orb<0) {
+    if (orb < 0) {
       LOGP(alarm, "Negative runStartOrbit = {} deduced for from tfCounter={} and firstTForbit={}, enforcing runStartOrbit to 0", orb, mCurrentTFInfo.tfCounter, mCurrentTFInfo.firstTForbit);
       orb = 0;
     }

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-calibinfo-reader.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-calibinfo-reader.cxx
@@ -21,10 +21,17 @@
 #include "FairLogger.h"
 #include "CommonUtils/ConfigurableParam.h"
 #include "CommonUtils/NameConf.h"
+#include "DetectorsRaw/HBFUtilsInitializer.h"
+#include "Framework/CallbacksPolicy.h"
 
 #include <string>
 #include <stdexcept>
 #include <unordered_map>
+
+void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
+{
+  o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
 
 // add workflow options, note that customization needs to be declared before
 // including Framework/runDataProcessing
@@ -34,6 +41,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   workflowOptions.push_back(ConfigParamSpec{"ninstances", o2::framework::VariantType::Int, 1, {"Number of reader instances"}});
   workflowOptions.push_back(ConfigParamSpec{"tpc-matches", o2::framework::VariantType::Bool, false, {"Made from TOF-TPC matches"}});
   workflowOptions.push_back(ConfigParamSpec{"configKeyValues", o2::framework::VariantType::String, "", {"Semicolon separated key=value strings ..."}});
+  o2::raw::HBFUtilsInitializer::addConfigOption(workflowOptions, o2::raw::HBFUtilsInitializer::HBFUSrc);
 }
 
 #include "Framework/runDataProcessing.h" // the main driver
@@ -78,6 +86,10 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   }
 
   LOG(info) << "Number of active devices = " << specs.size();
-
+  if (ninstances == 1) {
+    o2::raw::HBFUtilsInitializer hbfIni(cfgc, specs);
+  } else {
+    LOG(warning) << "Cannot use HBFUtilsInitializer with multiple instances";
+  }
   return std::move(specs);
 }

--- a/Detectors/Raw/include/DetectorsRaw/HBFUtilsInitializer.h
+++ b/Detectors/Raw/include/DetectorsRaw/HBFUtilsInitializer.h
@@ -18,6 +18,7 @@
 #include <vector>
 #include <string>
 #include "CommonDataFormat/TFIDInfo.h"
+#include "CommonUtils/NameConf.h"
 
 namespace o2
 {
@@ -55,7 +56,7 @@ struct HBFUtilsInitializer {
   static std::vector<o2::dataformats::TFIDInfo> readTFIDInfoVector(const std::string& fname);
   static void assignDataHeader(const std::vector<o2::dataformats::TFIDInfo>& tfinfoVec, o2::header::DataHeader& dh, o2::framework::DataProcessingHeader& dph);
   static void addNewTimeSliceCallback(std::vector<o2::framework::CallbacksPolicy>& policies);
-  static void addConfigOption(std::vector<o2::framework::ConfigParamSpec>& opts);
+  static void addConfigOption(std::vector<o2::framework::ConfigParamSpec>& opts, const std::string& defOpt = std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE));
 };
 
 } // namespace raw

--- a/Detectors/Raw/src/HBFUtilsInitializer.cxx
+++ b/Detectors/Raw/src/HBFUtilsInitializer.cxx
@@ -17,7 +17,6 @@
 #include "DetectorsRaw/HBFUtils.h"
 #include "CommonUtils/ConfigurableParam.h"
 #include "CommonUtils/StringUtils.h"
-#include "CommonUtils/NameConf.h"
 #include "Framework/ConfigContext.h"
 #include "Framework/WorkflowSpec.h"
 #include "Framework/ConfigParamSpec.h"
@@ -157,7 +156,7 @@ void HBFUtilsInitializer::addNewTimeSliceCallback(std::vector<o2::framework::Cal
     }});
 }
 
-void HBFUtilsInitializer::addConfigOption(std::vector<o2f::ConfigParamSpec>& opts)
+void HBFUtilsInitializer::addConfigOption(std::vector<o2f::ConfigParamSpec>& opts, const std::string& defOpt)
 {
-  o2f::ConfigParamsHelper::addOptionIfMissing(opts, o2f::ConfigParamSpec{HBFConfOpt, o2f::VariantType::String, std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE), {R"(ConfigurableParam ini file or "hbfutils" for HBFUtils, root file with per-TF info or "none")"}});
+  o2f::ConfigParamsHelper::addOptionIfMissing(opts, o2f::ConfigParamSpec{HBFConfOpt, o2f::VariantType::String, defOpt, {R"(ConfigurableParam ini file or "hbfutils" for HBFUtils, root file with per-TF info or "none")"}});
 }

--- a/Detectors/TOF/workflowIO/src/CalibInfoReaderSpec.cxx
+++ b/Detectors/TOF/workflowIO/src/CalibInfoReaderSpec.cxx
@@ -22,7 +22,6 @@
 #include "Framework/Logger.h"
 #include "TOFWorkflowIO/CalibInfoReaderSpec.h"
 #include "CommonUtils/NameConf.h"
-#include "DetectorsRaw/HBFUtils.h"
 
 using namespace o2::framework;
 using namespace o2::tof;
@@ -53,18 +52,7 @@ void CalibInfoReader::run(ProcessingContext& pc)
   if (mState != 1) {
     return;
   }
-
-  static int tf = 0;
-  static uint64_t timestamp = 1;
-  const auto& hbfu = o2::raw::HBFUtils::Instance();
   auto& timingInfo = pc.services().get<o2::framework::TimingInfo>();
-  timingInfo.firstTForbit = hbfu.orbitFirst;
-  timingInfo.creation = timestamp; // set after reading tree
-  timingInfo.tfCounter = tf;
-  timingInfo.runNumber = hbfu.runNumber;
-
-  tf++;
-
   char filename[100];
 
   if ((mTree && mCurrentEntry < mTree->GetEntries()) || fscanf(mFile, "%s", filename) == 1) {
@@ -85,10 +73,8 @@ void CalibInfoReader::run(ProcessingContext& pc)
 
       if (mVect.size()) {
         timingInfo.creation = uint64_t(mVect[0].getTimestamp()) * 1000;
-        timestamp = timingInfo.creation;
       } else if (mDiagnostic) {
         timingInfo.creation = uint64_t(mDia.getTimeStamp()) * 1000;
-        timestamp = timingInfo.creation;
       }
 
       LOG(debug) << "Current entry " << mCurrentEntry;


### PR DESCRIPTION


@noferini your reader was not using HBFUtilsInitializer and on top of this, was setting all orbits to constant (0).
This was making the `getRunStartOrbit() const { return mCurrentTFInfo.firstTForbit - o2::base::GRPGeomHelper::getNHBFPerTF() * mCurrentTFInfo.tfCounter; }` negative and TF dependent, hence the result were wrong.

This is fixed, but I've put the protection against negative `getRunStartOrbit()` if orbit is not set for some reason.

Now with your workflow I get
```
 grep -E 'closing slot|Sending object' xx.log
[1986551:tof-diagnostic-calibration]: [02:49:44][INFO] closing slot 0 <= TF <= 26399
[1986551:tof-diagnostic-calibration]: [02:49:44][INFO] Sending object TOF/Calib/Diagnostic/o2-tof-Diagnostic_1657932584879.root of size 1024 bytes, valid for 1654239385946 : 1654239706440
[1986551:tof-diagnostic-calibration]: [02:49:51][INFO] closing slot 26400 <= TF <= 52799
[1986551:tof-diagnostic-calibration]: [02:49:51][INFO] Sending object TOF/Calib/Diagnostic/o2-tof-Diagnostic_1657932591353.root of size 1024 bytes, valid for 1654239686440 : 1654240006934
[1986551:tof-diagnostic-calibration]: [02:49:57][INFO] closing slot 52800 <= TF <= 79199
[1986551:tof-diagnostic-calibration]: [02:49:57][INFO] Sending object TOF/Calib/Diagnostic/o2-tof-Diagnostic_1657932597169.root of size 1024 bytes, valid for 1654239986934 : 1654240307428
```