### PR TITLE
Update configurables from key-value pairs

### DIFF
--- a/Detectors/TPC/workflow/src/tpc-calibrator-gainmap-tracks.cxx
+++ b/Detectors/TPC/workflow/src/tpc-calibrator-gainmap-tracks.cxx
@@ -25,6 +25,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
   std::vector<ConfigParamSpec> options{
     {"useLastExtractedMapAsReference", VariantType::Bool, false, {"enabling iterative extraction of the gain map: Multiplying the extracted gain map with the latest extracted map stored in the CCDB"}},
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}},
     {"configFile", VariantType::String, "", {"configuration file for configurable parameters"}}};
 
   std::swap(workflowOptions, options);
@@ -38,6 +39,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
 
   // set up configuration
   o2::conf::ConfigurableParam::updateFromFile(config.options().get<std::string>("configFile"));
+  o2::conf::ConfigurableParam::updateFromString(config.options().get<std::string>("configKeyValues"));
   o2::conf::ConfigurableParam::writeINI("o2tpcpadgaintrackscalibrator_configuration.ini");
   const bool useLastExtractedMapAsReference = config.options().get<bool>("useLastExtractedMapAsReference");
 

--- a/Detectors/TPC/workflow/src/tpc-integrate-idc.cxx
+++ b/Detectors/TPC/workflow/src/tpc-integrate-idc.cxx
@@ -30,6 +30,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
   const int defaultlanes = std::max(1u, std::thread::hardware_concurrency() / 2);
 
   std::vector<ConfigParamSpec> options{
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}},
     {"nOrbits", VariantType::Int, 12, {"number of orbits for which the IDCs are integrated"}},
     {"outputFormat", VariantType::String, "Sim", {"setting the output format type: 'Sim'=IDC simulation format, 'Real'=real output format of CRUs (not implemented yet)"}},
     {"debug", VariantType::Bool, false, {"create debug tree"}},
@@ -53,6 +54,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
   if (!confDig.empty() && confDig != "none") {
     o2::conf::ConfigurableParam::updateFromFile(confDig, "HBFUtils");
   }
+  o2::conf::ConfigurableParam::updateFromString(config.options().get<std::string>("configKeyValues"));
   o2::conf::ConfigurableParam::writeINI("o2tpcintegrateidc_configuration.ini");
 
   const auto& hbfu = o2::raw::HBFUtils::Instance();

--- a/prodtests/full-system-test/aggregator-workflow.sh
+++ b/prodtests/full-system-test/aggregator-workflow.sh
@@ -139,7 +139,7 @@ fi
 if [[ $AGGREGATOR_TASKS == BARREL_SPORADIC ]] || [[ $AGGREGATOR_TASKS == ALL ]]; then
   # TPC
   if [[ $CALIB_TPC_RESPADGAIN == 1 ]]; then
-    add_W o2-tpc-calibrator-gainmap-tracks "--tf-per-slot 10000" "" 0
+    add_W o2-tpc-calibrator-gainmap-tracks "--tf-per-slot 10000"
   fi
 fi
 


### PR DESCRIPTION
Workflows writing out the INI file should respect the output dir passed via key-value configurables, so they have to update the configuration from those.