### PR TITLE
Possibility to set query rate per ccdbParamSpec

### DIFF
--- a/Detectors/Base/src/GRPGeomHelper.cxx
+++ b/Detectors/Base/src/GRPGeomHelper.cxx
@@ -65,7 +65,7 @@ GRPGeomRequest::GRPGeomRequest(bool orbitResetTime, bool GRPECS, bool GRPLHCIF, 
     addInput({"grplhcif", "GLO", "GRPLHCIF", 0, Lifetime::Condition, ccdbParamSpec("GLO/Config/GRPLHCIF")}, inputs);
   }
   if (askGRPMagField) {
-    addInput({"grpfield", "GLO", "GRPMAGFIELD", 0, Lifetime::Condition, ccdbParamSpec("GLO/Config/GRPMagField")}, inputs);
+    addInput({"grpfield", "GLO", "GRPMAGFIELD", 0, Lifetime::Condition, ccdbParamSpec("GLO/Config/GRPMagField", {}, 1)}, inputs); // query every TF
   }
 }
 

--- a/Framework/Core/include/Framework/CCDBParamSpec.h
+++ b/Framework/Core/include/Framework/CCDBParamSpec.h
@@ -25,14 +25,14 @@ struct CCDBMetadata {
 ConfigParamSpec ccdbPathSpec(std::string const& path);
 ConfigParamSpec ccdbRunDependent(bool defaultValue = true);
 
-std::vector<ConfigParamSpec> ccdbParamSpec(std::string const& path, bool runDependent, std::vector<CCDBMetadata> metadata = {});
+std::vector<ConfigParamSpec> ccdbParamSpec(std::string const& path, bool runDependent, std::vector<CCDBMetadata> metadata = {}, int64_t qrate = 0);
 /// Helper to create an InputSpec which will read from a CCDB
 /// Notice that those input specs have some convetions for their metadata:
 ///
 /// `ccdb-path`: is the path in CCDB for the entry
 /// `ccdb-run-dependent`: is a boolean flag to indicate if the entry is run dependent
 /// `ccdb-metadata-<key>`: is a list of metadata to be added to the query, where key is the metadata key
-std::vector<ConfigParamSpec> ccdbParamSpec(std::string const& path, std::vector<CCDBMetadata> metadata = {});
+std::vector<ConfigParamSpec> ccdbParamSpec(std::string const& path, std::vector<CCDBMetadata> metadata = {}, int64_t qrate = 0);
 ConfigParamSpec startTimeParamSpec(int64_t t);
 
 } // namespace o2::framework


### PR DESCRIPTION
`ccdbParamSpec` helper is extended to take an extra parameter for the validity check rate:
```
ccdbParamSpec(std::string const& path, bool runDependent, std::vector<CCDBMetadata> metadata = {}, int64_t rate=0);
```
or
```
ccdbParamSpec(std::string const& path, std::vector<CCDBMetadata> metadata = {},int64_t rate=0);
```
with the following meaning:

- `rate>0`: the validity of cached object will be checked for given TF timeslice if `(tfSlice%rate)==0`.

- `rate=0` (default): validity check of the cached object follows the global policy of the DPL fetcher set by the option
`--condition-tf-per-query <N>` (or env.var. `DPL_CONDITION_QUERY_RATE=<N>`) with same meaning that the check is done
for `tfSlice%N==0`. I.e. if you want your object validity check to be done every (or every 3d) TF seen by the workflow, use the `rate = 1 (or 3)`.

- `rate<0`: disable validity checks after caching the object, can be used for objects which are guaranteed to not change during workflow lifetime.

Note: in the online processing on the EPN the tfSlice is a dynamic counter depending on the number of EPNs and workflows per EPN, hence the result of `tfSlice%rate` has nothing to do with the check of `tfCounter%rate` except for the `rate=1`.
Effectively, the values which make sense are 0: follow global policy, 1: check every TF and –1 (or any negative value): don’t check after caching.