### PR TITLE
[EMCAL-551][WIP] improvement of emcal cell energy compression

### DIFF
--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Constants.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Constants.h
@@ -89,15 +89,14 @@ std::ostream& operator<<(std::ostream& stream, ChannelType_t chantype);
 
 namespace constants
 {
-
-constexpr int OVERFLOWCUT = 950;               ///< sample overflow
+constexpr int EMCAL_HGLGTRANSITION = 950;      ///< sample overflow
 constexpr int LG_SUPPRESSION_CUT = 880;        ///< LG bunch suppression ADC value
 constexpr int ORDER = 2;                       ///< Order of shaping stages of the signal conditioning unit
 constexpr double TAU = 2.35;                   ///< Approximate shaping time
 constexpr Double_t EMCAL_TIMESAMPLE = 100.;    ///< Width of a timebin in nanoseconds
 constexpr Double_t EMCAL_ADCENERGY = 0.0162;   ///< Energy of one ADC count in GeV/c^2
 constexpr Int_t EMCAL_HGLGFACTOR = 16;         ///< Conversion from High to Low Gain
-constexpr Int_t EMCAL_HGLGTRANSITION = 1024;   ///< Transition from High to Low Gain
+constexpr Int_t OVERFLOWCUT = 1024;            ///< Transition from High to Low Gain
 constexpr Int_t EMCAL_MAXTIMEBINS = 15;        ///< Maximum number of time bins for time response
 constexpr int MAX_RANGE_ADC = 0x3FF;           ///< Dynamic range of the ADCs (10 bit ADC)
 constexpr double EMCAL_TRU_ADCENERGY = 0.0786; ///< resolution of the TRU digitizer, @TODO check exact value

--- a/DataFormats/Detectors/EMCAL/src/Cell.cxx
+++ b/DataFormats/Detectors/EMCAL/src/Cell.cxx
@@ -20,8 +20,13 @@ using namespace o2::emcal;
 const float TIME_SHIFT = 600.,
             TIME_RANGE = 1500.,
             TIME_RESOLUTION = TIME_RANGE / 2047.,
+            ENERGY_BITS = static_cast<float>(0x3FFF),
+            HGLGTRANSITION = o2::emcal::constants::EMCAL_HGLGTRANSITION * o2::emcal::constants::EMCAL_ADCENERGY,
             ENERGY_TRUNCATION = 250.,
-            ENERGY_RESOLUTION = ENERGY_TRUNCATION / 16383.;
+            ENERGY_RESOLUTION_LG = (ENERGY_TRUNCATION - HGLGTRANSITION) / ENERGY_BITS,
+            ENERGY_RESOLUTION_HG = HGLGTRANSITION / ENERGY_BITS,
+            ENERGY_RESOLUTION_TRU = ENERGY_TRUNCATION / ENERGY_BITS,
+            ENERGY_RESOLUTION_LEDMON = ENERGY_TRUNCATION / ENERGY_BITS;
 
 Cell::Cell()
 {
@@ -33,8 +38,8 @@ Cell::Cell(short tower, float energy, float time, ChannelType_t ctype)
   memset(mCellWords, 0, sizeof(uint16_t) * 3);
   setTower(tower);
   setTimeStamp(time);
+  setType(ctype); // type needs to be set before energy to allow for proper conversion
   setEnergy(energy);
-  setType(ctype);
 }
 
 void Cell::setTimeStamp(float timestamp)
@@ -63,12 +68,42 @@ void Cell::setEnergy(float energy)
   } else if (truncatedEnergy > ENERGY_TRUNCATION) {
     truncatedEnergy = ENERGY_TRUNCATION;
   }
-  getDataRepresentation()->mEnergy = static_cast<int16_t>(std::round(truncatedEnergy / ENERGY_RESOLUTION));
+  switch (getType()) {
+    case ChannelType_t::HIGH_GAIN: {
+      getDataRepresentation()->mEnergy = static_cast<uint16_t>(std::round(truncatedEnergy / ENERGY_RESOLUTION_HG));
+      break;
+    }
+    case ChannelType_t::LOW_GAIN: {
+      getDataRepresentation()->mEnergy = static_cast<uint16_t>(std::round(truncatedEnergy / ENERGY_RESOLUTION_LG));
+      break;
+    }
+    case ChannelType_t::TRU: {
+      getDataRepresentation()->mEnergy = static_cast<uint16_t>(std::round(truncatedEnergy / ENERGY_RESOLUTION_TRU));
+      break;
+    }
+    case ChannelType_t::LEDMON: {
+      getDataRepresentation()->mEnergy = static_cast<uint16_t>(std::round(truncatedEnergy / ENERGY_RESOLUTION_LEDMON));
+      break;
+    }
+  }
 }
 
 float Cell::getEnergy() const
 {
-  return static_cast<float>(getDataRepresentation()->mEnergy) * ENERGY_RESOLUTION;
+  switch (getType()) {
+    case ChannelType_t::HIGH_GAIN: {
+      return static_cast<float>(getDataRepresentation()->mEnergy) * ENERGY_RESOLUTION_HG;
+    }
+    case ChannelType_t::LOW_GAIN: {
+      return static_cast<float>(getDataRepresentation()->mEnergy) * ENERGY_RESOLUTION_LG;
+    }
+    case ChannelType_t::TRU: {
+      return static_cast<float>(getDataRepresentation()->mEnergy) * ENERGY_RESOLUTION_TRU;
+    }
+    case ChannelType_t::LEDMON: {
+      return static_cast<float>(getDataRepresentation()->mEnergy) * ENERGY_RESOLUTION_LEDMON;
+    }
+  }
 }
 
 void Cell::PrintStream(std::ostream& stream) const

--- a/Detectors/EMCAL/reconstruction/src/CaloRawFitterGamma2.cxx
+++ b/Detectors/EMCAL/reconstruction/src/CaloRawFitterGamma2.cxx
@@ -48,7 +48,7 @@ CaloFitResults CaloRawFitterGamma2::evaluate(const gsl::span<const Bunch> bunchl
     int timebinOffset = bunchlist[bunchIndex].getStartTime() - (bunchlist[bunchIndex].getBunchLength() - 1);
     amp = ampEstimate;
 
-    if (nsamples > 2 && maxADC < constants::OVERFLOWCUT) {
+    if (nsamples > 2 && maxADC < constants::EMCAL_HGLGTRANSITION) {
       std::tie(amp, time) = doParabolaFit(timeEstimate - 1);
       mNiter = 0;
       try {

--- a/Detectors/EMCAL/reconstruction/src/CaloRawFitterStandard.cxx
+++ b/Detectors/EMCAL/reconstruction/src/CaloRawFitterStandard.cxx
@@ -66,7 +66,7 @@ CaloFitResults CaloRawFitterStandard::evaluate(const gsl::span<const Bunch> bunc
     int timebinOffset = bunchlist[bunchIndex].getStartTime() - (bunchlist[bunchIndex].getBunchLength() - 1);
     amp = ampEstimate;
 
-    if (nsamples > 1 && maxADC < constants::OVERFLOWCUT) {
+    if (nsamples > 1 && maxADC < constants::EMCAL_HGLGTRANSITION) {
       try {
         std::tie(amp, time, chi2) = fitRaw(first, last);
         time += timebinOffset;

--- a/Detectors/EMCAL/workflow/src/CellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/CellConverterSpec.cxx
@@ -93,7 +93,7 @@ void CellConverterSpec::run(framework::ProcessingContext& ctx)
           fitResults = mRawFitter->evaluate(channelData.mChannelsBunchesHG);
 
           // If the high gain bunch is saturated then fit the low gain
-          if (fitResults.getAmp() > o2::emcal::constants::OVERFLOWCUT) {
+          if (fitResults.getAmp() > o2::emcal::constants::EMCAL_HGLGTRANSITION) {
             fitResults = mRawFitter->evaluate(channelData.mChannelsBunchesLG);
             fitResults.setAmp(fitResults.getAmp() * o2::emcal::constants::EMCAL_HGLGFACTOR);
             channelType = ChannelType_t::LOW_GAIN;

--- a/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
@@ -430,7 +430,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
                   res->mHGOutOfRange = false; // LG is found so it can replace the HG if the HG is out of range
                   if (res->mCellData.getHighGain()) {
                     double ampOld = res->mCellData.getEnergy() / o2::emcal::constants::EMCAL_ADCENERGY; // cut applied on ADC and not on energy
-                    if (ampOld > o2::emcal::constants::OVERFLOWCUT) {
+                    if (ampOld > o2::emcal::constants::EMCAL_HGLGTRANSITION) {
                       // High gain digit has energy above overflow cut, use low gain instead
                       res->mCellData.setEnergy(amp * o2::emcal::constants::EMCAL_HGLGFACTOR);
                       res->mCellData.setTimeStamp(celltime);
@@ -445,7 +445,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
                   res->mIsLGnoHG = false;
                   res->mHGOutOfRange = false;
                   res->mHWAddressHG = chan.getHardwareAddress();
-                  if (amp / o2::emcal::constants::EMCAL_ADCENERGY <= o2::emcal::constants::OVERFLOWCUT) {
+                  if (amp / o2::emcal::constants::EMCAL_ADCENERGY <= o2::emcal::constants::EMCAL_HGLGTRANSITION) {
                     res->mCellData.setEnergy(amp);
                     res->mCellData.setTimeStamp(celltime);
                     res->mCellData.setHighGain();
@@ -463,7 +463,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
                   hwAddressLG = chan.getHardwareAddress();
                 } else {
                   // High gain cell: Flag as low gain if above threshold
-                  if (amp / o2::emcal::constants::EMCAL_ADCENERGY > o2::emcal::constants::OVERFLOWCUT) {
+                  if (amp / o2::emcal::constants::EMCAL_ADCENERGY > o2::emcal::constants::EMCAL_HGLGTRANSITION) {
                     hgOutOfRange = true;
                   }
                   hwAddressHG = chan.getHardwareAddress();


### PR DESCRIPTION
- this commit changes the compression for the emcal cell energy. Studies reported here [EMCAL-558](https://alice.its.cern.ch/jira/browse/EMCAL-558) found that using 14bit over an energy range of 0 to 250GeV for cell energy does not give sufficient precision on emcal cluster level. In order to not change the number of bits stored in the CTF (14bit) a separate treatment of high gain and low gain cells in the conversion was implemented, increasing the effective precision achievable with 14bit significantly (e.g. for HG cells 14bit can be used to store only energies of 0 to 15.39GeV)
- fix in the emcal constants, where the constants EMCAL_HGLGTRANSITION and OVERFLOWCUT were swapped. I restored the proper meaning and fixed occurences accordingly
- **this fix is marked WIP!** While the number of bits stored in the CTF does not change, the new conversion does **break backwards compatibility**. We have to discuss how we move forward and if e.g. reproduction of the CTFs is an option. However, this change is necessary in any case to achieve suitable performance on emc cluster level