### PR TITLE
Add drawing of SACs per stack

### DIFF
--- a/Detectors/TPC/base/include/TPCBase/Painter.h
+++ b/Detectors/TPC/base/include/TPCBase/Painter.h
@@ -49,10 +49,15 @@ class CalArray;
 namespace painter
 {
 
+enum class Type : int {
+  Pad,   ///< drawing pads
+  Stack, ///< drawing stacks
+};
+
 /// pad corner coordinates
 struct PadCoordinates {
-  std::array<double, 4> xVals;
-  std::array<double, 4> yVals;
+  std::vector<double> xVals = std::vector<double>(4);
+  std::vector<double> yVals = std::vector<double>(4);
 
   void rotate(float angDeg)
   {
@@ -70,6 +75,12 @@ struct PadCoordinates {
 
 /// create a vector of pad corner coordinate for one full sector
 std::vector<PadCoordinates> getPadCoordinatesSector();
+
+/// create a vector of stack corner coordinate for one full sector
+std::vector<PadCoordinates> getStackCoordinatesSector();
+
+/// \return returns coordinates for given type
+std::vector<o2::tpc::painter::PadCoordinates> getCoordinates(const Type type);
 
 /// binning vector with radial pad-row positions (in cm)
 /// \param roc roc number (0-35 IROC, 36-71 OROC, >=72 full sector)
@@ -123,10 +134,12 @@ TH2* getHistogram2D(const CalArray<T>& calArray);
 /// \param xMax maximum x coordinate of the histogram
 /// \param yMin minimum y coordinate of the histogram
 /// \param yMax maximum y coordinate of the histogram
-TH2Poly* makeSectorHist(const std::string_view name = "hSector", const std::string_view title = "Sector;local #it{x} (cm);local #it{y} (cm)", const float xMin = 83.65f, const float xMax = 247.7f, const float yMin = -43.7f, const float yMax = 43.7f);
+/// \param type granularity of the histogram (per pad or per stack)
+TH2Poly* makeSectorHist(const std::string_view name = "hSector", const std::string_view title = "Sector;local #it{x} (cm);local #it{y} (cm)", const float xMin = 83.65f, const float xMax = 247.7f, const float yMin = -43.7f, const float yMax = 43.7f, const Type type = Type::Pad);
 
 /// make a side-wise histogram with correct pad corners
-TH2Poly* makeSideHist(Side side);
+/// \param type granularity of the histogram (per pad or per stack)
+TH2Poly* makeSideHist(Side side, const Type type = Type::Pad);
 
 /// fill existing TH2Poly histogram for CalDet object
 /// \param h2D histogram to fill

--- a/Detectors/TPC/calibration/CMakeLists.txt
+++ b/Detectors/TPC/calibration/CMakeLists.txt
@@ -46,6 +46,7 @@ o2_add_library(TPCCalibration
                        src/TPCVDriftTglCalibration.cxx
                        src/SACFactorization.cxx
                        src/SACParameter.cxx
+                       src/SACDrawHelper.cxx
                PUBLIC_LINK_LIBRARIES O2::DataFormatsTPC O2::TPCBase
                                      O2::TPCReconstruction ROOT::Minuit
                                      Microsoft.GSL::GSL
@@ -89,7 +90,8 @@ o2_target_root_dictionary(TPCCalibration
                                   include/TPCCalibration/CalibratorPadGainTracks.h
                                   include/TPCCalibration/TPCVDriftTglCalibration.h
                                   include/TPCCalibration/SACFactorization.h
-                                  include/TPCCalibration/SACParameter.h)
+                                  include/TPCCalibration/SACParameter.h
+                                  include/TPCCalibration/SACDrawHelper.h)
 
 o2_add_test_root_macro(macro/comparePedestalsAndNoise.C
                        PUBLIC_LINK_LIBRARIES O2::TPCBase

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCContainer.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCContainer.h
@@ -37,6 +37,9 @@ enum class IDCType { IDC = 0,     ///< integrated and grouped IDCs
                      IDCDelta = 3 ///< IDCDelta: \Delta I(r,\phi,t) = I(r,\phi,t) / ( I_0(r,\phi) * I_1(t) )
 };
 
+/// define alias for SACs
+using SACType = IDCType;
+
 /// IDC Delta IDC Compression types
 enum class IDCDeltaCompression { NO = 0,     ///< no compression using floats
                                  MEDIUM = 1, ///< medium compression using short (data compression ratio 2 when stored in CCDB)

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCDrawHelper.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCDrawHelper.h
@@ -66,8 +66,7 @@ class IDCDrawHelper
   /// \return returns z axis title
   /// \param type IDC type
   /// \param compression compression of the IDCs if used (only for IDCDelta)
-  /// \param dtype switch between IDCs and SACs (IDCs=0, SACs=1)
-  static std::string getZAxisTitle(const IDCType type, const IDCDeltaCompression compression = IDCDeltaCompression::NO, const unsigned short dtype = 0);
+  static std::string getZAxisTitle(const IDCType type, const IDCDeltaCompression compression = IDCDeltaCompression::NO);
 
  private:
   static unsigned int getPad(const unsigned int pad, const unsigned int region, const unsigned int row, const Side side);

--- a/Detectors/TPC/calibration/include/TPCCalibration/SACDrawHelper.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/SACDrawHelper.h
@@ -1,0 +1,67 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file SACDrawHelper.h
+/// \brief helper class for drawing SACs per sector/side
+/// \author Matthias Kleiner <mkleiner@ikf.uni-frankfurt.de>
+
+#ifndef ALICEO2_TPC_SACDRAWHELPER_H_
+#define ALICEO2_TPC_SACDRAWHELPER_H_
+
+#include "DataFormatsTPC/Defs.h"
+#include "functional"
+#include "TPCCalibration/IDCContainer.h"
+#include "TH2Poly.h"
+#include "TCanvas.h"
+
+namespace o2::tpc
+{
+
+class SACDrawHelper
+{
+
+ public:
+  /// helper struct containing a function to give access to the SACs which will be drawn
+  /// \param sector sector of the TPC
+  /// \param stack gem stack
+  struct SACDraw {
+    float getSAC(const unsigned int sector, const unsigned int stack) const { return mSACFunc(sector, stack); }
+    std::function<float(const unsigned int, const unsigned int)> mSACFunc; ///< function returning the value which will be drawn for sector, stack
+  };
+
+  /// draw sector
+  /// \param SAC SACDraw struct containing function to get the values which will be drawn
+  /// \param sector sector which will be drawn
+  /// \param zAxisTitle axis title of the z axis
+  /// \param fileName name of the output file (if empty the canvas is drawn instead of writte to a file)
+  /// \param minZ min z value for drawing (if minZ > maxZ automatic z axis)
+  /// \param maxZ max z value for drawing (if minZ > maxZ automatic z axis)
+  static void drawSector(const SACDraw& SAC, const unsigned int sector, const std::string zAxisTitle, const std::string filename, const float minZ = 0, const float maxZ = -1);
+
+  /// draw side
+  /// \param SAC SACDraw struct containing function to get the values which will be drawn
+  /// \param side side which will be drawn
+  /// \param zAxisTitle axis title of the z axis
+  /// \param fileName name of the output file (if empty the canvas is drawn instead of writte to a file)
+  /// \param minZ min z value for drawing (if minZ > maxZ automatic z axis)
+  /// \param maxZ max z value for drawing (if minZ > maxZ automatic z axis)
+  static void drawSide(const SACDraw& SAC, const o2::tpc::Side side, const std::string zAxisTitle, const std::string filename, const float minZ = 0, const float maxZ = -1);
+
+  static TH2Poly* drawSide(const SACDraw& SAC, const o2::tpc::Side side, const std::string zAxisTitle);
+
+  /// \return returns z axis title
+  /// \param type SAC type
+  static std::string getZAxisTitle(const SACType type);
+};
+
+} // namespace o2::tpc
+
+#endif

--- a/Detectors/TPC/calibration/include/TPCCalibration/SACFactorization.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/SACFactorization.h
@@ -215,8 +215,8 @@ class SACFactorization
   /// \return returns side for given GEM stack
   Side getSide(const unsigned int gemStack) const { return (gemStack < GEMSTACKSPERSIDE) ? Side::A : Side::C; }
 
-  /// \return returns stack for given sector and region
-  unsigned int getStack(const unsigned int sector, const unsigned int region) const { return static_cast<unsigned int>(CRU(Sector(sector), region).gemStack()) + sector * GEMSTACKSPERSECTOR; }
+  /// \return returns stack for given sector and stack
+  unsigned int getStack(const unsigned int sector, const unsigned int stack) const { return static_cast<unsigned int>(stack + sector * GEMSTACKSPERSECTOR); }
 
   /// helper function for drawing SACDelta
   void drawSACDeltaHelper(const bool type, const Sector sector, const unsigned int interval, const SACDeltaCompression compression, const std::string filename, const float minZ, const float maxZ) const;

--- a/Detectors/TPC/calibration/src/IDCDrawHelper.cxx
+++ b/Detectors/TPC/calibration/src/IDCDrawHelper.cxx
@@ -234,15 +234,9 @@ void o2::tpc::IDCDrawHelper::drawIDCZeroStackCanvas(const IDCDraw& idc, const o2
   }
 }
 
-std::string o2::tpc::IDCDrawHelper::getZAxisTitle(const IDCType type, const IDCDeltaCompression compression, const unsigned short dtype)
+std::string o2::tpc::IDCDrawHelper::getZAxisTitle(const IDCType type, const IDCDeltaCompression compression)
 {
-  std::string stype = "";
-  if (dtype == 0) {
-    stype = "IDC";
-  } else if (dtype == 1) {
-    stype = "SAC";
-  }
-
+  std::string stype = "IDC";
   switch (type) {
     case IDCType::IDC:
     default: {

--- a/Detectors/TPC/calibration/src/SACDrawHelper.cxx
+++ b/Detectors/TPC/calibration/src/SACDrawHelper.cxx
@@ -1,0 +1,133 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "TPCCalibration/SACDrawHelper.h"
+#include "TPCBase/Painter.h"
+#include "TPCBase/Mapper.h"
+#include "TH2Poly.h"
+#include "TCanvas.h"
+#include "TLatex.h"
+#include <fmt/format.h>
+
+void o2::tpc::SACDrawHelper::drawSector(const SACDraw& SAC, const unsigned int sector, const std::string zAxisTitle, const std::string filename, const float minZ, const float maxZ)
+{
+  const auto coords = o2::tpc::painter::getStackCoordinatesSector();
+  TH2Poly* poly = o2::tpc::painter::makeSectorHist("hSector", "Sector;local #it{x} (cm);local #it{y} (cm); #it{SAC}", 83.65f, 247.7f, -43.7f, 43.7f, painter::Type::Stack);
+
+  poly->SetContour(255);
+  poly->SetTitle(nullptr);
+  poly->GetYaxis()->SetTickSize(0.002f);
+  poly->GetYaxis()->SetTitleOffset(0.7f);
+  poly->GetZaxis()->SetTitleOffset(1.3f);
+  poly->SetStats(0);
+  poly->GetZaxis()->SetTitle(zAxisTitle.data());
+  if (minZ < maxZ) {
+    poly->SetMinimum(minZ);
+    poly->SetMaximum(maxZ);
+  }
+
+  TCanvas* can = new TCanvas("can", "can", 2000, 1400);
+  can->SetRightMargin(0.14f);
+  can->SetLeftMargin(0.06f);
+  can->SetTopMargin(0.04f);
+  poly->Draw("colz");
+
+  for (unsigned int stack = 0; stack < GEMSTACKSPERSECTOR; ++stack) {
+    const auto coordinate = coords[stack];
+    const float yPos = -static_cast<float>(coordinate.yVals[0] + coordinate.yVals[2]) / 2; // local coordinate system is mirrored
+    const float xPos = static_cast<float>(coordinate.xVals[0] + coordinate.xVals[2]) / 2;
+    poly->Fill(xPos, yPos, SAC.getSAC(sector, stack));
+  }
+
+  TLatex latex;
+  latex.DrawLatexNDC(.07, .9, fmt::format("Sector {}", sector).data());
+  if (!filename.empty()) {
+    can->SaveAs(filename.data());
+    delete poly;
+    delete can;
+  }
+}
+
+void o2::tpc::SACDrawHelper::drawSide(const SACDraw& SAC, const o2::tpc::Side side, const std::string zAxisTitle, const std::string filename, const float minZ, const float maxZ)
+{
+  TH2Poly* poly = o2::tpc::SACDrawHelper::drawSide(SAC, side, zAxisTitle);
+  if (minZ < maxZ) {
+    poly->SetMinimum(minZ);
+    poly->SetMaximum(maxZ);
+  }
+
+  TCanvas* can = new TCanvas("can", "can", 650, 600);
+  can->SetTopMargin(0.04f);
+  can->SetRightMargin(0.14f);
+  can->SetLeftMargin(0.1f);
+  poly->Draw("colz");
+
+  std::string sideName = (side == Side::A) ? "A-Side" : "C-Side";
+  TLatex latex;
+  latex.DrawLatexNDC(.13, .9, sideName.data());
+
+  if (!filename.empty()) {
+    can->SaveAs(filename.data());
+    delete poly;
+    delete can;
+  }
+}
+
+TH2Poly* o2::tpc::SACDrawHelper::drawSide(const SACDraw& SAC, const o2::tpc::Side side, const std::string zAxisTitle)
+{
+  const auto coords = o2::tpc::painter::getStackCoordinatesSector();
+  TH2Poly* poly = o2::tpc::painter::makeSideHist(side, painter::Type::Stack);
+  poly->SetContour(255);
+  poly->SetTitle(nullptr);
+  poly->GetXaxis()->SetTitleOffset(1.2f);
+  poly->GetYaxis()->SetTitleOffset(1.3f);
+  poly->GetZaxis()->SetTitleOffset(1.3f);
+  poly->GetZaxis()->SetTitle(zAxisTitle.data());
+  poly->GetZaxis()->SetMaxDigits(3); // force exponential axis
+  poly->SetStats(0);
+
+  unsigned int sectorStart = (side == Side::A) ? 0 : o2::tpc::SECTORSPERSIDE;
+  unsigned int sectorEnd = (side == Side::A) ? o2::tpc::SECTORSPERSIDE : Mapper::NSECTORS;
+  for (unsigned int sector = sectorStart; sector < sectorEnd; ++sector) {
+    for (unsigned int stack = 0; stack < GEMSTACKSPERSECTOR; ++stack) {
+      const float angDeg = 10.f + sector * 20;
+      auto coordinate = coords[stack];
+      coordinate.rotate(angDeg);
+      const float yPos = static_cast<float>(coordinate.yVals[0] + coordinate.yVals[1] + coordinate.yVals[2] + coordinate.yVals[3]) / 4;
+      const float xPos = static_cast<float>(coordinate.xVals[0] + coordinate.xVals[1] + coordinate.xVals[2] + coordinate.xVals[3]) / 4;
+      poly->Fill(xPos, yPos, SAC.getSAC(sector, stack));
+    }
+  }
+  return poly;
+}
+
+std::string o2::tpc::SACDrawHelper::getZAxisTitle(const SACType type)
+{
+  std::string stype = "SAC";
+  switch (type) {
+    case SACType::IDC:
+    default: {
+      return fmt::format("#it{{{}}} (ADC)", stype);
+      break;
+    }
+    case SACType::IDCZero: {
+      return fmt::format("#it{{{}_{{0}}}} (ADC)", stype);
+      break;
+    }
+    case SACType::IDCDelta:
+      return fmt::format("#Delta#it{{{}}}", stype);
+      break;
+    case SACType::IDCOne: {
+      return fmt::format("#Delta#it{{{}}}_{{1}}", stype);
+      break;
+    }
+  }
+}

--- a/Detectors/TPC/calibration/src/SACFactorization.cxx
+++ b/Detectors/TPC/calibration/src/SACFactorization.cxx
@@ -11,7 +11,7 @@
 
 #include "TPCCalibration/SACFactorization.h"
 #include "CommonUtils/TreeStreamRedirector.h"
-#include "TPCCalibration/IDCDrawHelper.h"
+#include "TPCCalibration/SACDrawHelper.h"
 #include "TPCCalibration/RobustAverage.h"
 #include "TPCCalibration/SACParameter.h"
 #include "Framework/Logger.h"
@@ -165,37 +165,37 @@ void o2::tpc::SACFactorization::reset()
 
 void o2::tpc::SACFactorization::drawSACDeltaHelper(const bool type, const Sector sector, const unsigned int integrationInterval, const SACDeltaCompression compression, const std::string filename, const float minZ, const float maxZ) const
 {
-  std::function<float(const unsigned int, const unsigned int, const unsigned int, const unsigned int)> SACFunc;
+  std::function<float(const unsigned int, const unsigned int)> SACFunc;
 
-  const std::string zAxisTitle = IDCDrawHelper::getZAxisTitle(IDCType::IDCDelta, compression, 1);
+  const std::string zAxisTitle = SACDrawHelper::getZAxisTitle(SACType::IDCDelta);
 
-  IDCDrawHelper::IDCDraw drawFun;
+  SACDrawHelper::SACDraw drawFun;
   switch (compression) {
     case SACDeltaCompression::NO:
     default: {
-      SACFunc = [this, integrationInterval](const unsigned int sector, const unsigned int region, const unsigned int, const unsigned int) {
-        return this->getSACDeltaVal(getStack(sector, region), integrationInterval);
+      SACFunc = [this, integrationInterval](const unsigned int sector, const unsigned int stack) {
+        return this->getSACDeltaVal(getStack(sector, stack), integrationInterval);
       };
-      drawFun.mIDCFunc = SACFunc;
-      type ? IDCDrawHelper::drawSide(drawFun, sector.side(), zAxisTitle, filename, minZ, maxZ) : IDCDrawHelper::drawSector(drawFun, 0, Mapper::NREGIONS, sector, zAxisTitle, filename, minZ, maxZ);
+      drawFun.mSACFunc = SACFunc;
+      type ? SACDrawHelper::drawSide(drawFun, sector.side(), zAxisTitle, filename, minZ, maxZ) : SACDrawHelper::drawSector(drawFun, sector, zAxisTitle, filename, minZ, maxZ);
       break;
     }
     case SACDeltaCompression::MEDIUM: {
       const auto SACDeltaMedium = this->getSACDeltaMediumCompressed();
-      SACFunc = [this, &SACDeltaMedium, integrationInterval = integrationInterval](const unsigned int sector, const unsigned int region, const unsigned int, const unsigned int) {
-        return SACDeltaMedium.getValue(Sector(sector).side(), getSACDeltaIndex(getStack(sector, region), integrationInterval));
+      SACFunc = [this, &SACDeltaMedium, integrationInterval = integrationInterval](const unsigned int sector, const unsigned int stack) {
+        return SACDeltaMedium.getValue(Sector(sector).side(), getSACDeltaIndex(getStack(sector, stack), integrationInterval));
       };
-      drawFun.mIDCFunc = SACFunc;
-      type ? IDCDrawHelper::drawSide(drawFun, sector.side(), zAxisTitle, filename, minZ, maxZ) : IDCDrawHelper::drawSector(drawFun, 0, Mapper::NREGIONS, sector, zAxisTitle, filename, minZ, maxZ);
+      drawFun.mSACFunc = SACFunc;
+      type ? SACDrawHelper::drawSide(drawFun, sector.side(), zAxisTitle, filename, minZ, maxZ) : SACDrawHelper::drawSector(drawFun, sector, zAxisTitle, filename, minZ, maxZ);
       break;
     }
     case SACDeltaCompression::HIGH: {
       const auto SACDeltaHigh = this->getSACDeltaHighCompressed();
-      SACFunc = [this, &SACDeltaHigh, integrationInterval](const unsigned int sector, const unsigned int region, const unsigned int, const unsigned int) {
-        return SACDeltaHigh.getValue(Sector(sector).side(), getSACDeltaIndex(getStack(sector, region), integrationInterval));
+      SACFunc = [this, &SACDeltaHigh, integrationInterval](const unsigned int sector, const unsigned int stack) {
+        return SACDeltaHigh.getValue(Sector(sector).side(), getSACDeltaIndex(getStack(sector, stack), integrationInterval));
       };
-      drawFun.mIDCFunc = SACFunc;
-      type ? IDCDrawHelper::drawSide(drawFun, sector.side(), zAxisTitle, filename, minZ, maxZ) : IDCDrawHelper::drawSector(drawFun, 0, Mapper::NREGIONS, sector, zAxisTitle, filename, minZ, maxZ);
+      drawFun.mSACFunc = SACFunc;
+      type ? SACDrawHelper::drawSide(drawFun, sector.side(), zAxisTitle, filename, minZ, maxZ) : SACDrawHelper::drawSector(drawFun, sector, zAxisTitle, filename, minZ, maxZ);
       break;
     }
   }
@@ -203,39 +203,39 @@ void o2::tpc::SACFactorization::drawSACDeltaHelper(const bool type, const Sector
 
 void o2::tpc::SACFactorization::drawSACZeroHelper(const bool type, const Sector sector, const std::string filename, const float minZ, const float maxZ) const
 {
-  std::function<float(const unsigned int, const unsigned int, const unsigned int, const unsigned int)> SACFunc = [this](const unsigned int sector, const unsigned int region, const unsigned int, const unsigned int) {
-    return this->getSACZeroVal(getStack(sector, region));
+  std::function<float(const unsigned int, const unsigned int)> SACFunc = [this](const unsigned int sector, const unsigned int stack) {
+    return this->getSACZeroVal(getStack(sector, stack));
   };
 
-  IDCDrawHelper::IDCDraw drawFun;
-  drawFun.mIDCFunc = SACFunc;
-  const std::string zAxisTitle = IDCDrawHelper::getZAxisTitle(IDCType::IDCZero, SACDeltaCompression::NO, 1);
-  type ? IDCDrawHelper::drawSide(drawFun, sector.side(), zAxisTitle, filename, minZ, maxZ) : IDCDrawHelper::drawSector(drawFun, 0, Mapper::NREGIONS, sector, zAxisTitle, filename, minZ, maxZ);
+  SACDrawHelper::SACDraw drawFun;
+  drawFun.mSACFunc = SACFunc;
+  const std::string zAxisTitle = SACDrawHelper::getZAxisTitle(SACType::IDCZero);
+  type ? SACDrawHelper::drawSide(drawFun, sector.side(), zAxisTitle, filename, minZ, maxZ) : SACDrawHelper::drawSector(drawFun, sector, zAxisTitle, filename, minZ, maxZ);
 }
 
 void o2::tpc::SACFactorization::drawSACZeroOutlierHelper(const bool type, const Sector sector, const std::string filename, const float minZ, const float maxZ) const
 {
-  std::function<float(const unsigned int, const unsigned int, const unsigned int, const unsigned int)> SACFunc = [this](const unsigned int sector, const unsigned int region, const unsigned int, const unsigned int) {
-    return this->mOutlierMap[getStack(sector, region)];
+  std::function<float(const unsigned int, const unsigned int)> SACFunc = [this](const unsigned int sector, const unsigned int stack) {
+    return this->mOutlierMap[getStack(sector, stack)];
   };
 
-  IDCDrawHelper::IDCDraw drawFun;
-  drawFun.mIDCFunc = SACFunc;
-  const std::string zAxisTitle = IDCDrawHelper::getZAxisTitle(IDCType::IDCZero, SACDeltaCompression::NO, 1) + " outlier";
-  type ? IDCDrawHelper::drawSide(drawFun, sector.side(), zAxisTitle, filename, minZ, maxZ) : IDCDrawHelper::drawSector(drawFun, 0, Mapper::NREGIONS, sector, zAxisTitle, filename, minZ, maxZ);
+  SACDrawHelper::SACDraw drawFun;
+  drawFun.mSACFunc = SACFunc;
+  const std::string zAxisTitle = SACDrawHelper::getZAxisTitle(SACType::IDCZero) + " outlier";
+  type ? SACDrawHelper::drawSide(drawFun, sector.side(), zAxisTitle, filename, minZ, maxZ) : SACDrawHelper::drawSector(drawFun, sector, zAxisTitle, filename, minZ, maxZ);
 }
 
 void o2::tpc::SACFactorization::drawSACHelper(const bool type, const Sector sector, const unsigned int integrationInterval, const std::string filename, const float minZ, const float maxZ) const
 {
-  std::function<float(const unsigned int, const unsigned int, const unsigned int, const unsigned int)> SACFunc = [this, integrationInterval](const unsigned int sector, const unsigned int region, const unsigned int irow, const unsigned int pad) {
-    return this->getSACValue(getStack(sector, region), integrationInterval);
+  std::function<float(const unsigned int, const unsigned int)> SACFunc = [this, integrationInterval](const unsigned int sector, const unsigned int stack) {
+    return this->getSACValue(getStack(sector, stack), integrationInterval);
   };
 
-  IDCDrawHelper::IDCDraw drawFun;
-  drawFun.mIDCFunc = SACFunc;
+  SACDrawHelper::SACDraw drawFun;
+  drawFun.mSACFunc = SACFunc;
 
-  const std::string zAxisTitle = IDCDrawHelper::getZAxisTitle(IDCType::IDC, SACDeltaCompression::NO, 1);
-  type ? IDCDrawHelper::drawSide(drawFun, sector.side(), zAxisTitle, filename, minZ, maxZ) : IDCDrawHelper::drawSector(drawFun, 0, Mapper::NREGIONS, sector, zAxisTitle, filename, minZ, maxZ);
+  const std::string zAxisTitle = SACDrawHelper::getZAxisTitle(SACType::IDC);
+  type ? SACDrawHelper::drawSide(drawFun, sector.side(), zAxisTitle, filename, minZ, maxZ) : SACDrawHelper::drawSector(drawFun, sector, zAxisTitle, filename, minZ, maxZ);
 }
 
 void o2::tpc::SACFactorization::createStatusMap()


### PR DESCRIPTION
Draw the SACs per stack instead of for each pad to speed up the drawing and save memory [example](https://github.com/AliceO2Group/AliceO2/files/9141992/SACsSide.pdf)
