### PR TITLE
TRD fix error message to only have information that is certain to be there.

### DIFF
--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
@@ -154,19 +154,24 @@ class CruRawReader
   bool checkRDH(const o2::header::RDHAny* rdh);
   bool skipRDH();
   void updateLinkErrorGraphs(int currentlinkindex, int supermodule_half, int stack_layer);
+
   void incrementErrors(int hist, int sector = -1, int side = 0, int stack = 0, int layer = 0)
   {
-    if (sector > 17) {
+    if (sector > 17 || sector < -1) {
       sector = 0;
     }
-    if (stack > 4) {
+    if (stack > 4 || stack < 0) {
       stack = 0;
     }
-    if (layer > 5) {
+    if (layer > 5 || layer < 0) {
       layer = 0;
     }
-    if (sector < -1) {
-      sector = 0;
+    if (sector == -1) {
+      sector = (unsigned int)mFEEID.supermodule;
+      side = (unsigned int)mFEEID.side;
+      layer = 0;
+      stack = (unsigned int)mFEEID.endpoint;
+      // encode the endpoint into the stack for the 2d plots. This is for those situations where you can not know stack/layer at the time of the error.
     }
     mEventRecords.incParsingError(hist, sector, side, stack * constants::NLAYER + layer);
     if (mVerbose) {

--- a/Detectors/TRD/reconstruction/src/CruRawReader.cxx
+++ b/Detectors/TRD/reconstruction/src/CruRawReader.cxx
@@ -135,15 +135,17 @@ bool CruRawReader::checkRDH(const o2::header::RDHAny* rdh)
   TRDFeeID feeid;
   feeid.word = o2::raw::RDHUtils::getFEEID(rdh);
   if (((feeid.word) >> 4) == 0xfff) { // error condition is 0xfff? as the end point is known to the cru, but the rest is configured.
-    if (mVerbose) {
-      LOG(error) << "failed due to 0xfff? : " << std::hex << feeid.word << " whole feeid : " << std::hex << (unsigned int)feeid.word;
+    if (mMaxWarnPrinted > 0) {
+      LOG(warn) << "failed due to 0xfff? : " << std::hex << feeid.word << " whole feeid : " << std::hex << (unsigned int)feeid.word;
+      checkNoWarn();
     }
     incrementErrors(TRDFEEIDIsFFFF, 0, 0, 0, 0);
     return false;
   }
   if (feeid.supermodule > 17) {
-    if (mVerbose) {
-      LOG(info) << "failed due to supermodule :  " << std::dec << (int)feeid.supermodule << " whole feeid : " << std::hex << (unsigned int)feeid.word;
+    if (mMaxWarnPrinted > 0) {
+      LOG(warn) << "failed due to supermodule :  " << std::dec << (int)feeid.supermodule << " whole feeid : " << std::hex << (unsigned int)feeid.word;
+      checkNoWarn();
     }
     incrementErrors(TRDFEEIDBadSector, 0, 0, 0, 0);
     return false;
@@ -154,58 +156,43 @@ bool CruRawReader::checkRDH(const o2::header::RDHAny* rdh)
 bool CruRawReader::compareRDH(const o2::header::RDHAny* firstrdh, const o2::header::RDHAny* rdh)
 {
   if (o2::raw::RDHUtils::getFEEID(firstrdh) != o2::raw::RDHUtils::getFEEID(rdh)) {
-    if (mMaxErrsPrinted > 0) {
-      LOG(error) << "ERDH FEEID are not identical in rdh.";
-      checkNoErr();
+    if (mMaxWarnPrinted > 0) {
+      LOG(warn) << "ERDH FEEID are not identical in rdh.";
+      checkNoWarn();
     }
     incrementErrors(TRDParsingBadRDHFEEID, 0, 0, 0, 0);
-    if (mVerbose) {
-      LOG(error) << "ERDH FEEID are not identical in rdh.";
-    }
     return false;
   }
   if (o2::raw::RDHUtils::getEndPointID(firstrdh) != o2::raw::RDHUtils::getEndPointID(rdh)) {
-    if (mMaxErrsPrinted > 0) {
-      LOG(error) << "ERDH  EndPointID are not identical in rdh.";
-      checkNoErr();
+    if (mMaxWarnPrinted > 0) {
+      LOG(warn) << "ERDH  EndPointID are not identical in rdh.";
+      checkNoWarn();
     }
     incrementErrors(TRDParsingBadRDHEndPoint, 0, 0, 0, 0);
-    if (mVerbose) {
-      LOG(error) << "ERDH  EndPointID are not identical in rdh.";
-    }
     return false;
   }
   if (o2::raw::RDHUtils::getTriggerOrbit(firstrdh) != o2::raw::RDHUtils::getTriggerOrbit(rdh)) {
-    if (mMaxErrsPrinted > 0) {
-      LOG(error) << "ERDH  Orbit are not identical in rdh.";
-      checkNoErr();
+    if (mMaxWarnPrinted > 0) {
+      LOG(warn) << "ERDH  Orbit are not identical in rdh.";
+      checkNoWarn();
     }
     incrementErrors(TRDParsingBadRDHOrbit, 0, 0, 0, 0);
-    if (mVerbose) {
-      LOG(error) << "ERDH  Orbit are not identical in rdh.";
-    }
     return false;
   }
   if (o2::raw::RDHUtils::getCRUID(firstrdh) != o2::raw::RDHUtils::getCRUID(rdh)) {
-    if (mMaxErrsPrinted > 0) {
-      LOG(error) << "ERDH  CRUID are not identical in rdh.";
-      checkNoErr();
+    if (mMaxWarnPrinted > 0) {
+      LOG(warn) << "ERDH  CRUID are not identical in rdh.";
+      checkNoWarn();
     }
     incrementErrors(TRDParsingBadRDHCRUID, 0, 0, 0, 0);
-    if (mVerbose) {
-      LOG(error) << "ERDH  CRUID are not identical in rdh.";
-    }
     return false;
   }
   if (o2::raw::RDHUtils::getPacketCounter(firstrdh) == o2::raw::RDHUtils::getPacketCounter(rdh) + 1) {
-    if (mMaxErrsPrinted > 0) {
-      LOG(error) << "ERDH  PacketCounters are not sequential in rdh.";
-      checkNoErr();
+    if (mMaxWarnPrinted > 0) {
+      LOG(warn) << "ERDH  PacketCounters are not sequential in rdh.";
+      checkNoWarn();
     }
     incrementErrors(TRDParsingBadRDHPacketCounter, 0, 0, 0, 0);
-    if (mVerbose) {
-      LOG(error) << "ERDH  PacketCounters are not sequential in rdh.";
-    }
     return false;
   }
   return true;
@@ -316,7 +303,7 @@ bool CruRawReader::processHBFs(int datasizealreadyread, bool verbose)
           LOG(info) << "ignored rdh event ";
           break;
         case 0:
-          LOG(error) << "figure out what now";
+          LOG(warn) << "figure out what now";
           break;
         case 1:
           LOG(info) << "all good parsing half cru";
@@ -411,7 +398,7 @@ int CruRawReader::parseDigitHCHeader()
     mDigitHCHeader.minor = 42; // to keep me entertained
     mDigitHCHeader.numberHCW = mHalfChamberWords;
     if (mHalfChamberWords == 0 || mHalfChamberMajor == 0) {
-      //LOG(warn) << "we have a messed up halfchamber header and you have only set the halfchamber command line option to zero, hex dump of data and revisit what it should be.";
+      LOG(warn) << "we have a messed up halfchamber header and you have only set the halfchamber command line option to zero, hex dump of data and revisit what it should be.";
       // already in histograms
     }
   }
@@ -420,10 +407,10 @@ int CruRawReader::parseDigitHCHeader()
   if (additionalHeaderWords >= 3) {
     incrementErrors(TRDParsingDigitHeaderCountGT3, mFEEID.supermodule, mHalfChamberSide[0], mStack[0], mLayer[0]);
     //TODO graph this and stats it
-    if (mMaxErrsPrinted > 0) {
-      LOG(alarm) << "Error parsing DigitHCHeader, too many additional words count=" << additionalHeaderWords << " header:" << std::hex << mDigitHCHeader.word;
+    if (mMaxWarnPrinted > 0) {
+      LOG(warn) << "Error parsing DigitHCHeader, too many additional words count=" << additionalHeaderWords << " header:" << std::hex << mDigitHCHeader.word;
       //printDigitHCHeader(mDigitHCHeader, &headers[0]);
-      checkNoErr();
+      checkNoWarn();
     }
     return -1;
   }
@@ -439,16 +426,19 @@ int CruRawReader::parseDigitHCHeader()
       case 1: // header header1;
         if (headersfound.test(0)) {
           // we have a problem, we already have a Digit HC Header1, we are hereby lost, so as Monty Python said, .... run away , run away, run away.
-          if (mMaxErrsPrinted > 0) {
-            LOG(alarm) << "We have a >1 Digit HC Header 1  : " << std::hex << " raw: 0x" << headers[headerwordcount];
-            checkNoErr();
+          if (mMaxWarnPrinted > 0) {
+            LOG(warn) << "We have a >1 Digit HC Header 1  : " << std::hex << " raw: 0x" << headers[headerwordcount];
+            checkNoWarn();
           }
           incrementErrors(TRDParsingDigitHCHeader1);
         }
         mDigitHCHeader1.word = headers[headerwordcount];
         headersfound.set(0);
         if (mDigitHCHeader1.res != 0x1) {
-          LOG(alarm) << "Digit HC Header 1 reserved : 0x" << std::hex << mDigitHCHeader1.res << " raw: 0x" << mDigitHCHeader1.word;
+          if (mMaxWarnPrinted > 0) {
+            LOG(warn) << "Digit HC Header 1 reserved : 0x" << std::hex << mDigitHCHeader1.res << " raw: 0x" << mDigitHCHeader1.word;
+            checkNoWarn();
+          }
           incrementErrors(TRDParsingDigitHeaderWrong1);
         }
         if ((mDigitHCHeader1.numtimebins > o2::trd::constants::TIMEBINS) || (mDigitHCHeader1.numtimebins < 3)) {
@@ -468,9 +458,9 @@ int CruRawReader::parseDigitHCHeader()
       case 2: // header header2;
         if (headersfound.test(1)) {
           // we have a problem, we already have a Digit HC Header2, we are hereby lost, so as Monty Python said, .... run away , run away, run away.
-          if (mMaxErrsPrinted > 0) {
-            LOG(alarm) << "We have a >1 Digit HC Header 2  : " << std::hex << " raw: 0x" << headers[headerwordcount];
-            checkNoErr();
+          if (mMaxWarnPrinted > 0) {
+            LOG(warn) << "We have a >1 Digit HC Header 2  : " << std::hex << " raw: 0x" << headers[headerwordcount];
+            checkNoWarn();
           }
           incrementErrors(TRDParsingDigitHCHeader2);
           LOG(info) << "We have a >1 Digit HC Header 2 reserved : " << std::hex << headers[headerwordcount];
@@ -478,30 +468,30 @@ int CruRawReader::parseDigitHCHeader()
         mDigitHCHeader2.word = headers[headerwordcount];
         headersfound.set(1);
         if (mDigitHCHeader2.res != 0b110001) {
-          // LOG(alarm) << "Digit HC Header 2 reserved : " << std::hex << mDigitHCHeader2.res << " raw: 0x" << mDigitHCHeader2.word;
+          // LOG(warn) << "Digit HC Header 2 reserved : " << std::hex << mDigitHCHeader2.res << " raw: 0x" << mDigitHCHeader2.word;
           incrementErrors(TRDParsingDigitHeaderWrong2);
         }
         break;
       case 3: // header header3;
         if (headersfound.test(2)) {
           // we have a problem, we already have a Digit HC Header2, we are hereby lost, so as Monty Python said, .... run away , run away, run away.
-          if (mMaxErrsPrinted > 0) {
-            LOG(alarm) << "We have a >1 Digit HC Header 2  : " << std::hex << " raw: 0x" << headers[headerwordcount];
-            checkNoErr();
+          if (mMaxWarnPrinted > 0) {
+            LOG(warn) << "We have a >1 Digit HC Header 2  : " << std::hex << " raw: 0x" << headers[headerwordcount];
+            checkNoWarn();
           }
           incrementErrors(TRDParsingDigitHCHeader3);
         }
         mDigitHCHeader3.word = headers[headerwordcount];
         headersfound.set(2);
         if (mDigitHCHeader3.res != 0b110101) {
-          // LOG(alarm) << "Digit HC Header 3 reserved : " << std::hex << mDigitHCHeader3.res << " raw: 0x" << mDigitHCHeader3.word;
+          // LOG(warn) << "Digit HC Header 3 reserved : " << std::hex << mDigitHCHeader3.res << " raw: 0x" << mDigitHCHeader3.word;
           incrementErrors(TRDParsingDigitHeaderWrong3);
         }
         if (mPreviousDigitHCHeadersvnver != 0xffffffff && mPreviousDigitHCHeadersvnrver != 0xffffffff) {
           if ((mDigitHCHeader3.svnver != mPreviousDigitHCHeadersvnver) && (mDigitHCHeader3.svnrver != mPreviousDigitHCHeadersvnrver)) {
-            if (mMaxErrsPrinted > 0) {
-              LOG(alarm) << "Digit HC Header 3 svn ver : " << std::hex << mDigitHCHeader3.svnver << " svn release ver : 0x" << mDigitHCHeader3.svnrver;
-              checkNoErr();
+            if (mMaxWarnPrinted > 0) {
+              LOG(warn) << "Digit HC Header 3 svn ver : " << std::hex << mDigitHCHeader3.svnver << " svn release ver : 0x" << mDigitHCHeader3.svnrver;
+              checkNoWarn();
             }
             incrementErrors(TRDParsingDigitHCHeaderSVNMismatch);
             return -1;
@@ -513,7 +503,7 @@ int CruRawReader::parseDigitHCHeader()
         }
         break;
       default:
-        //LOG(alarm) << "Error parsing DigitHCHeader at word:" << headerwordcount << " looking at 0x:" << std::hex << mHBFPayload[mHBFoffset32 - 1];
+        //LOG(warn) << "Error parsing DigitHCHeader at word:" << headerwordcount << " looking at 0x:" << std::hex << mHBFPayload[mHBFoffset32 - 1];
         incrementErrors(TRDParsingDigitHeaderWrong4);
     }
   }
@@ -553,7 +543,7 @@ int CruRawReader::processHalfCRU(int cruhbfstartoffset, int numberOfPreviousCRU,
   //TODO put maxdatawrittentobuffer in a qc plot
   if (mHBFPayload.size() < cruhbfstartoffset || cruhbfstartoffset > maxdatawrittentobuffer) {
     if (mMaxErrsPrinted > 0) {
-      LOG(alarm) << "Error parsing HalfCRUHeader, HBFPayload size = " << mHBFPayload.size() << " payload offset:" << cruhbfstartoffset << " max data written to buffer : " << maxdatawrittentobuffer;
+      LOG(warn) << "Error parsing HalfCRUHeader, HBFPayload size = " << mHBFPayload.size() << " payload offset:" << cruhbfstartoffset << " max data written to buffer : " << maxdatawrittentobuffer;
       checkNoErr();
     }
     mHBFoffset32++;
@@ -615,19 +605,20 @@ int CruRawReader::processHalfCRU(int cruhbfstartoffset, int numberOfPreviousCRU,
   memcpy((char*)&mPreviousHalfCRUHeader, (void*)(&mHBFPayload[cruhbfstartoffset]), sizeof(mCurrentHalfCRUHeader));
   //can this half cru length fit into the available space of the rdh accumulated payload
   if (mTotalHalfCRUDataLength32 > mTotalHBFPayLoad - mHBFoffset32) {
-    if (mMaxErrsPrinted > 0) {
-      LOG(alarm) << "Next HalfCRU header says it contains more data than in the rdh payloads! " << mTotalHalfCRUDataLength32 << " < " << mTotalHBFPayLoad << "-" << mHBFoffset32 << " sector:side:endpoint: " << (unsigned int)mFEEID.supermodule << ":" << (unsigned int)mFEEID.side << ":" << (unsigned int)mFEEID.endpoint;
-      checkNoErr();
+    if (mMaxWarnPrinted > 0) {
+      LOG(warn) << "Next HalfCRU header says it contains more data than in the rdh payloads! " << mTotalHalfCRUDataLength32 << " < " << mTotalHBFPayLoad << "-" << mHBFoffset32 << " sector:side:endpoint: " << (unsigned int)mFEEID.supermodule << ":" << (unsigned int)mFEEID.side << ":" << (unsigned int)mFEEID.endpoint;
+      checkNoWarn();
     }
     incrementErrors(TRDParsingHalfCRUSumLength);
     mWordsRejected += mTotalHalfCRUDataLength32;
+    mHBFoffset32 += mTotalHalfCRUDataLength32; // go to the end of this halfcruheader and payload.
 
     return -2;
   }
   if (!halfCRUHeaderSanityCheck(mCurrentHalfCRUHeader, mCurrentHalfCRULinkLengths, mCurrentHalfCRULinkErrorFlags)) {
-    if (mMaxErrsPrinted > 0) {
-      LOG(alarm) << "HalfCRU header failed sanity check for FEEID with  sector:side:endpoint: " << (unsigned int)mFEEID.supermodule << ":" << (unsigned int)mFEEID.side << ":" << (unsigned int)mFEEID.endpoint;
-      checkNoErr();
+    if (mMaxWarnPrinted > 0) {
+      LOG(warn) << "HalfCRU header failed sanity check for FEEID with  sector:side:endpoint: " << (unsigned int)mFEEID.supermodule << ":" << (unsigned int)mFEEID.side << ":" << (unsigned int)mFEEID.endpoint;
+      checkNoWarn();
     }
     // let incrementErrors catch the undefined values of sector side stack and layer as if not set it will go so zero in the method, however if set, it means this is the second half cru header, and we have the values from the last one we read which
     // *SHOULD* be the same as this halfcruheader.
@@ -724,7 +715,7 @@ int CruRawReader::processHalfCRU(int cruhbfstartoffset, int numberOfPreviousCRU,
     int dioffset = dataoffsetstart32 + linksizeAccum32;
     if (dioffset % 8 != 0) {
       if (mMaxErrsPrinted > 0) {
-        LOG(alarm) << " we are not 256 bit aligned ... this should never happen";
+        LOG(warn) << " we are not 256 bit aligned ... this should never happen";
         checkNoErr();
       }
     }
@@ -762,7 +753,7 @@ int CruRawReader::processHalfCRU(int cruhbfstartoffset, int numberOfPreviousCRU,
       if (mTrackletWordsRead == -1) {
         //something went wrong bailout of here.
         if (mMaxErrsPrinted > 0) {
-          LOG(alarm) << "TrackletParser returned -1 for  LINK # " << currentlinkindex << " an FEEID:" << std::hex << mFEEID.word << " det:" << std::dec << mDetector[1] << " is > the lenght stored in the cruhalfchamber header : " << mCurrentHalfCRULinkLengths[currentlinkindex];
+          LOG(warn) << "TrackletParser returned -1 for  LINK # " << currentlinkindex << " an FEEID:" << std::hex << mFEEID.word << " det:" << std::dec << mDetector[1] << " is > the lenght stored in the cruhalfchamber header : " << mCurrentHalfCRULinkLengths[currentlinkindex];
           checkNoErr();
         }
         incrementErrors(TRDParsingTrackletsReturnedMinusOne, mFEEID.supermodule, mFEEID.side, mStack[0], mLayer[0]);
@@ -813,13 +804,13 @@ int CruRawReader::processHalfCRU(int cruhbfstartoffset, int numberOfPreviousCRU,
         //move over the DigitHCHeader mHBFoffset32 has already been moved in the reading.
         if (mHBFoffset32 - hfboffsetbeforehcparse != 1 + mDigitHCHeader.numberHCW) {
           if (mMaxErrsPrinted > 0) {
-            LOG(alarm) << "Seems data offset is out of sync with number of HC Headers words " << mHBFoffset32 << "-" << hfboffsetbeforehcparse << "!=" << 1 << "+" << mDigitHCHeader.numberHCW;
+            LOG(warn) << "Seems data offset is out of sync with number of HC Headers words " << mHBFoffset32 << "-" << hfboffsetbeforehcparse << "!=" << 1 << "+" << mDigitHCHeader.numberHCW;
             checkNoErr();
           }
         }
         if (hcparse == -1) {
           if (mMaxWarnPrinted > 0) {
-            LOG(alarm) << "Parsing Digit HCHeader returned a -1";
+            LOG(warn) << "Parsing Digit HCHeader returned a -1";
             checkNoWarn();
           }
         } else {
@@ -997,7 +988,7 @@ void CruRawReader::buildDPLOutputs(o2::framework::ProcessingContext& pc)
 void CruRawReader::checkNoWarn()
 {
   if (!mVerbose && --mMaxWarnPrinted == 0) {
-    LOG(alarm) << "Warnings limit reached, the following ones will be suppressed";
+    LOG(warn) << "Warnings limit reached, the following ones will be suppressed";
   }
 }
 

--- a/Detectors/TRD/reconstruction/src/DataReaderTask.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReaderTask.cxx
@@ -45,6 +45,8 @@ void DataReaderTask::init(InitContext& ic)
   ic.services().get<CallbackService>().set(CallbackService::Id::Stop, finishFunction);
   mDigitPreviousTotal = mReader.getDigitsFound();
   mTrackletsPreviousTotal = mReader.getTrackletsFound();
+  mWordsRead = 0;
+  mWordsRejected = 0;
 }
 
 void DataReaderTask::endOfStream(o2::framework::EndOfStreamContext& ec)
@@ -140,17 +142,13 @@ void DataReaderTask::run(ProcessingContext& pc)
       if (mVerbose) {
         LOG(info) << " parsing non compressed data in the data reader task with a payload of " << payloadInSize << " payload size";
       }
-      //          LOG(info) << "start of data is at ref.payload=0x"<< std::hex << " payloadSize:0x" << payloadInSize <<" dh->headerSize:0x" <<dh->headerSize;
       total1 += payloadInSize;
       total2 += dh->headerSize;
-      //          LOG(info) << "start of data is at ref.payload=0x"<< std::hex << " total1:0x" << total1 <<" total2:0x" <<total2;
       mReader.setDataBuffer(payloadIn);
       mReader.setDataBufferSize(payloadInSize);
       mReader.configure(mTrackletHCHeaderState, mHalfChamberWords, mHalfChamberMajor, mOptions);
       //mReader.setStats(&mTimeFrameStats);
       mReader.run();
-      mWordsRead += mReader.getWordsRead();
-      mWordsRejected += mReader.getWordsRejected();
       if (mVerbose) {
         LOG(info) << "relevant vectors to read : " << mReader.sumTrackletsFound() << " tracklets and " << mReader.sumDigitsFound() << " compressed digits";
       }
@@ -161,6 +159,8 @@ void DataReaderTask::run(ProcessingContext& pc)
       mCompressedReader.run();
     }
   }
+  mWordsRead += mReader.getWordsRead();
+  mWordsRejected += mReader.getWordsRejected();
 
   sendData(pc, false);
   std::chrono::duration<double, std::milli> dataReadTime = std::chrono::high_resolution_clock::now() - dataReadStart;

--- a/Detectors/TRD/reconstruction/src/DigitsParser.cxx
+++ b/Detectors/TRD/reconstruction/src/DigitsParser.cxx
@@ -295,7 +295,7 @@ int DigitsParser::Parse(bool verbose)
                   incParsingError(TRDParsingDigitADCChannel21);
                 }
                 if (mCurrentADCChannel > 22) {
-                  LOG(error) << "invalid bitpattern (read a zero) for this mcm 0x" << std::hex << mADCMask << " at offset " << std::distance(mStartParse, word);
+                  LOG(warn) << "invalid bitpattern (read a zero) for this mcm 0x" << std::hex << mADCMask << " at offset " << std::distance(mStartParse, word);
                   incParsingError(TRDParsingDigitADCChannelGT22);
                   mCurrentADCChannel = 100 * bitsinmask + overchannelcount++;
                   if (mHeaderVerbose) {

--- a/Detectors/TRD/reconstruction/src/EventRecord.cxx
+++ b/Detectors/TRD/reconstruction/src/EventRecord.cxx
@@ -320,7 +320,7 @@ EventRecord& EventStorage::getEventRecord(InteractionRecord& ir)
 void EventRecord::popTracklets(int popcount)
 {
   if (popcount > 3 || popcount < 0) {
-    LOG(error) << " been asked to pop more than 3 tracklets:" << popcount;
+    LOG(warn) << " been asked to pop more than 3 tracklets:" << popcount;
   } else {
     while (popcount > 0) {
       mTracklets.pop_back();

--- a/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
+++ b/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
@@ -67,7 +67,7 @@ int TrackletsParser::Parse(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX
   mEventRecords = eventrecords;
   if (std::distance(start, end) > o2::trd::constants::MAXDATAPERLINK32) { // full event is all digits and 3 tracklets per mcm,
     //sanity check that the length of data to scan is less the possible maximum for a link
-    LOG(error) << "Attempt to parse a block of data for tracklets that is longer than a link can poossibly be : " << std::distance(start, end) << " should be less than : " << o2::trd::constants::MAXDATAPERLINK32 << " dumping this block of data.";
+    LOG(warn) << "Attempt to parse a block of data for tracklets that is longer than a link can poossibly be : " << std::distance(start, end) << " should be less than : " << o2::trd::constants::MAXDATAPERLINK32 << " dumping this block of data.";
     return -1;
   }
   if (eventrecord == nullptr) {
@@ -167,7 +167,7 @@ int TrackletsParser::Parse()
   int headertrackletcount = 0;
   bool ignoreDataTillTrackletEndMarker = false;             // used for when we need to dump the rest of the tracklet data.
   if (std::distance(mStartParse, mEndParse) > o2::trd::constants::MAXDATAPERLINK32) { // full event is all digits and 3 tracklets per mcm,
-    LOG(error) << "Attempt to parse a block of data for tracklets that is longer than a link can poossibly be : " << std::distance(mStartParse, mEndParse) << " should be less than : " << o2::trd::constants::MAXDATAPERLINK32 << " dumping this data.";
+    LOG(warn) << "Attempt to parse a block of data for tracklets that is longer than a link can poossibly be : " << std::distance(mStartParse, mEndParse) << " should be less than : " << o2::trd::constants::MAXDATAPERLINK32 << " dumping this data.";
     //sanity check that the length of data to scan is less the possible maximum for a link
     return -1;
   }


### PR DESCRIPTION
- weird text seen in error messages.
- change the information to be sector:side:layer so the link cru in question and not the actual link, which we sometimes cant know definitively.
- removed 2 checks on stack and layer in the digit hcheader as they are not constant for a given half cru of 15 links, did not produce an error merely updated the graphs which was somewhat confusing, assuming trd qc is actually running.
- fix the datarates that appear in the logs, rejected and accepted.