### PR TITLE
TPC SCD calib update

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
@@ -155,6 +155,7 @@ void TPCInterpolationDPL::run(ProcessingContext& pc)
 
   mInterpolation.reset();
   mResidualProcessor.resetUnbinnedResiduals();
+  mResidualProcessor.resetTrackData();
 }
 
 void TPCInterpolationDPL::endOfStream(EndOfStreamContext& ec)

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/tpc-residual-aggregator.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/tpc-residual-aggregator.cxx
@@ -21,6 +21,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   std::vector<o2::framework::ConfigParamSpec> options{
     {"output-type", VariantType::String, "binnedResid", {"Comma separated list of outputs (without spaces). Valid strings: unbinnedResid, binnedResid, trackParams"}},
     {"enable-track-input", VariantType::Bool, false, {"Whether to expect track data from interpolation workflow"}},
+    {"disable-root-output", VariantType::Bool, false, {"Disables ROOT file writing"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
   std::swap(workflowOptions, options);
 }
@@ -60,7 +61,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     }
   }
 
+  auto fileOutput = !configcontext.options().get<bool>("disable-root-output");
+
   WorkflowSpec specs;
-  specs.emplace_back(getTPCResidualAggregatorSpec(trkInput, writeUnbinnedResiduals, writeBinnedResiduals, writeTrackData));
+  specs.emplace_back(getTPCResidualAggregatorSpec(trkInput, fileOutput, writeUnbinnedResiduals, writeBinnedResiduals, writeTrackData));
   return specs;
 }

--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/ResidualAggregator.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/ResidualAggregator.h
@@ -42,7 +42,7 @@ struct ResidualsContainer {
   ResidualsContainer& operator=(const ResidualsContainer& src) = delete;
   ~ResidualsContainer();
 
-  void init(const TrackResiduals* residualsEngine, std::string outputDir, bool wBinnedResid, bool wUnbinnedResid, bool wTrackData, int autosave);
+  void init(const TrackResiduals* residualsEngine, std::string outputDir, bool wFile, bool wBinnedResid, bool wUnbinnedResid, bool wTrackData, int autosave);
   void fillStatisticsBranches();
   uint64_t getNEntries() const { return nResidualsTotal; }
 
@@ -73,6 +73,7 @@ struct ResidualsContainer {
   std::unique_ptr<TTree> treeOutStats{nullptr};
   std::unique_ptr<TTree> treeOutRecords{nullptr};
 
+  bool writeToRootFile{true};
   bool writeBinnedResid{false};
   bool writeUnbinnedResiduals{false};
   bool writeTrackData{false};
@@ -80,7 +81,7 @@ struct ResidualsContainer {
 
   uint64_t nResidualsTotal{0};
 
-  ClassDefNV(ResidualsContainer, 2);
+  ClassDefNV(ResidualsContainer, 3);
 };
 
 class ResidualAggregator final : public o2::calibration::TimeSlotCalibration<TrackResiduals::UnbinnedResid, ResidualsContainer>
@@ -103,6 +104,7 @@ class ResidualAggregator final : public o2::calibration::TimeSlotCalibration<Tra
   void setWriteUnbinnedResiduals(bool f) { mWriteUnbinnedResiduals = f; }
   void setWriteTrackData(bool f) { mWriteTrackData = f; }
   void setAutosaveInterval(int n) { mAutosaveInterval = n; }
+  void disableFileWriting() { mWriteOutput = false; }
 
   bool hasEnoughData(const Slot& slot) const final;
   void initOutput() final;
@@ -116,13 +118,14 @@ class ResidualAggregator final : public o2::calibration::TimeSlotCalibration<Tra
   std::string mMetaOutputDir{"none"}; ///< the directory where the meta data file is stored
   std::string mLHCPeriod{""};         ///< the LHC period to be put into the meta file
   bool mStoreMetaData{false};         ///< flag, whether meta file is supposed to be stored
+  bool mWriteOutput{true};            ///< if false, no output files will be written
   bool mWriteBinnedResiduals{false};  ///< flag, whether to write binned residuals to output file
   bool mWriteUnbinnedResiduals{false}; ///< flag, whether to write unbinned residuals to output file
   bool mWriteTrackData{false};         ///< flag, whether to write track data to output file
   int mAutosaveInterval{0};            ///< if >0 then the output is written to a file for every n-th TF
   size_t mMinEntries;             ///< the minimum number of residuals required for the map creation (per voxel)
 
-  ClassDefOverride(ResidualAggregator, 2);
+  ClassDefOverride(ResidualAggregator, 3);
 };
 
 } // namespace tpc

--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackResiduals.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackResiduals.h
@@ -205,6 +205,9 @@ class TrackResiduals
   /// Clear the vector of unbinned residuals
   void resetUnbinnedResiduals();
 
+  /// Clear the vector with track data belonging to residuals
+  void resetTrackData() { mTrackDataOut.clear(); }
+
   // -------------------------------------- steering functions --------------------------------------------------
 
   /// Loads residual data from track interpolation and fills vector of unbinned residuals


### PR DESCRIPTION
- residual aggregator gets `--disable-root-output` option
- bugfix: track data is reset after every TF