### PR TITLE
Fix V0-bachelor association

### DIFF
--- a/Detectors/Vertexing/include/DetectorsVertexing/SVertexer.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/SVertexer.h
@@ -107,7 +107,8 @@ class SVertexer
   std::vector<std::vector<Cascade>> mCascadesTmp;
   std::array<std::vector<TrackCand>, 2> mTracksPool{}; // pools of positive and negative seeds sorted in min VtxID
   std::array<std::vector<int>, 2> mVtxFirstTrack{};    // 1st pos. and neg. track of the pools for each vertex
-  std::array<std::vector<int>, 2> mVtxLastTrack{};    // last pos. and neg. track of the pools for each vertex
+  std::array<std::vector<int>, 2> mTrackSortVtxMax{};  // pos. and neg. track indices sorted by max VtxID
+  std::array<std::vector<int>, 2> mVtxMaxLUT{};        // pos. and neg. max vtx ID track LUT for each vertex
 
   o2d::VertexBase mMeanVertex{{0., 0., 0.}, {0.1 * 0.1, 0., 0.1 * 0.1, 0., 0., 6. * 6.}};
   const SVertexerParams* mSVParams = nullptr;

--- a/Detectors/Vertexing/include/DetectorsVertexing/SVertexer.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/SVertexer.h
@@ -107,6 +107,8 @@ class SVertexer
   std::vector<std::vector<Cascade>> mCascadesTmp;
   std::array<std::vector<TrackCand>, 2> mTracksPool{}; // pools of positive and negative seeds sorted in min VtxID
   std::array<std::vector<int>, 2> mVtxFirstTrack{};    // 1st pos. and neg. track of the pools for each vertex
+  std::array<std::vector<int>, 2> mVtxLastTrack{};    // last pos. and neg. track of the pools for each vertex
+
   o2d::VertexBase mMeanVertex{{0., 0., 0.}, {0.1 * 0.1, 0., 0.1 * 0.1, 0., 0., 6. * 6.}};
   const SVertexerParams* mSVParams = nullptr;
   std::array<SVertexHypothesis, NHypV0> mV0Hyps;

--- a/Detectors/Vertexing/include/DetectorsVertexing/SVertexer.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/SVertexer.h
@@ -89,7 +89,7 @@ class SVertexer
 
  private:
   bool checkV0(const TrackCand& seed0, const TrackCand& seed1, int iP, int iN, int ithread);
-  int checkCascades(float rv0, std::array<float, 3> pV0, float p2v0, int avoidTrackID, int posneg, int ithread);
+  int checkCascades(float rv0, std::array<float, 3> pV0, float p2V0, int avoidTrackID, int posneg, VBracket v0vlist, int ithread);
   void setupThreads();
   void buildT2V(const o2::globaltracking::RecoContainer& recoTracks);
   void updateTimeDependentParams();

--- a/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
@@ -48,13 +48,13 @@ struct SVertexerParams : public o2::conf::ConfigurableParamHelper<SVertexerParam
   bool usePropagator = false;                                           ///< use external propagator
   bool refitWithMatCorr = false;                                        ///< refit V0 applying material corrections
   //
-  int maxPVContributors = 2;             ///< max number PV contributors to allow in V0
-  float minDCAToPV = 0.1;                ///< min DCA to PV of single track to accept
-  float minRToMeanVertex = 0.5;          ///< min radial distance of V0 from beam line (mean vertex)
-  float maxDCAXYToMeanVertex = 0.2;      ///< max DCA of V0 from beam line (mean vertex) for prompt V0 candidates
+  int maxPVContributors = 2;              ///< max number PV contributors to allow in V0
+  float minDCAToPV = 0.1;                 ///< min DCA to PV of single track to accept
+  float minRToMeanVertex = 0.5;           ///< min radial distance of V0 from beam line (mean vertex)
+  float maxDCAXYToMeanVertex = 0.2;       ///< max DCA of V0 from beam line (mean vertex) for prompt V0 candidates
   float maxDCAXYToMeanVertexV0Casc = 0.5; ///< max DCA of V0 from beam line (mean vertex) for cascade V0 candidates
-  float minPtV0 = 0.01;                  ///< v0 minimum pT
-  float maxTglV0 = 2.;                   ///< maximum tgLambda of V0
+  float minPtV0 = 0.01;                   ///< v0 minimum pT
+  float maxTglV0 = 2.;                    ///< maximum tgLambda of V0
 
   float causalityRTolerance = 1.; ///< V0 radius cannot exceed its contributors minR by more than this value
   float maxV0ToProngsRDiff = 50.; ///< V0 radius cannot be lower than this ammount wrt minR of contributors

--- a/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
@@ -31,6 +31,8 @@ struct SVertexerParams : public o2::conf::ConfigurableParamHelper<SVertexerParam
 
   // parameters
   bool useAbsDCA = true;        ///< use abs dca minimization
+  bool selectBestV0 = false;    ///< match only the best v0 for each cascade candidate
+  int marginBachPV = 5;         ///< margin for bach track PV to be associated with V0
   float maxChi2 = 2.;           ///< max dca from prongs to vertex
   float minParamChange = 1e-3;  ///< stop when tracks X-params being minimized change by less that this value
   float minRelChi2Change = 0.9; ///< stop when chi2 changes by less than this value
@@ -46,13 +48,13 @@ struct SVertexerParams : public o2::conf::ConfigurableParamHelper<SVertexerParam
   bool usePropagator = false;                                           ///< use external propagator
   bool refitWithMatCorr = false;                                        ///< refit V0 applying material corrections
   //
-  int maxPVContributors = 2;              ///< max number PV contributors to allow in V0
-  float minDCAToPV = 0.1;                 ///< min DCA to PV of single track to accept
-  float minRToMeanVertex = 0.5;           ///< min radial distance of V0 from beam line (mean vertex)
-  float maxDCAXYToMeanVertex = 0.2;       ///< max DCA of V0 from beam line (mean vertex) for prompt V0 candidates
+  int maxPVContributors = 2;             ///< max number PV contributors to allow in V0
+  float minDCAToPV = 0.1;                ///< min DCA to PV of single track to accept
+  float minRToMeanVertex = 0.5;          ///< min radial distance of V0 from beam line (mean vertex)
+  float maxDCAXYToMeanVertex = 0.2;      ///< max DCA of V0 from beam line (mean vertex) for prompt V0 candidates
   float maxDCAXYToMeanVertexV0Casc = 0.5; ///< max DCA of V0 from beam line (mean vertex) for cascade V0 candidates
-  float minPtV0 = 0.01;                   ///< v0 minimum pT
-  float maxTglV0 = 2.;                    ///< maximum tgLambda of V0
+  float minPtV0 = 0.01;                  ///< v0 minimum pT
+  float maxTglV0 = 2.;                   ///< maximum tgLambda of V0
 
   float causalityRTolerance = 1.; ///< V0 radius cannot exceed its contributors minR by more than this value
   float maxV0ToProngsRDiff = 50.; ///< V0 radius cannot be lower than this ammount wrt minR of contributors
@@ -62,7 +64,7 @@ struct SVertexerParams : public o2::conf::ConfigurableParamHelper<SVertexerParam
 
   float maxRToMeanVertexCascV0 = 80; // don't consider as a cascade V0 seed if above this R
   float minCosPACascV0 = 0.8;        // min cos of pointing angle to PV for cascade V0 candidates
-  float minCosPA = 0.9; ///< min cos of PA to PV for prompt V0 candidates
+  float minCosPA = 0.9;              ///< min cos of PA to PV for prompt V0 candidates
 
   float minRDiffV0Casc = 0.2; ///< cascade should be at least this radial distance below V0
   float maxRIniCasc = 90.;    // don't consider as a cascade seed (circles/line intersection) if its R exceeds this

--- a/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
@@ -32,7 +32,6 @@ struct SVertexerParams : public o2::conf::ConfigurableParamHelper<SVertexerParam
   // parameters
   bool useAbsDCA = true;        ///< use abs dca minimization
   bool selectBestV0 = false;    ///< match only the best v0 for each cascade candidate
-  int marginBachPV = 5;         ///< margin for bach track PV to be associated with V0
   float maxChi2 = 2.;           ///< max dca from prongs to vertex
   float minParamChange = 1e-3;  ///< stop when tracks X-params being minimized change by less that this value
   float minRelChi2Change = 0.9; ///< stop when chi2 changes by less than this value

--- a/Detectors/Vertexing/src/SVertexer.cxx
+++ b/Detectors/Vertexing/src/SVertexer.cxx
@@ -574,7 +574,7 @@ int SVertexer::checkCascades(float rv0, std::array<float, 3> pV0, float p2V0, in
       v0clone.setCosPA(cosPA);
       v0clone.setVertexID(cascVtxID);
       mV0sTmp[ithread].push_back(v0clone);
-      casc.setV0ID(mV0sTmp[ithread].size() - 1);  // set the new V0 index in the cascade
+      casc.setV0ID(mV0sTmp[ithread].size() - 1); // set the new V0 index in the cascade
     }
   }
 

--- a/Detectors/Vertexing/src/SVertexer.cxx
+++ b/Detectors/Vertexing/src/SVertexer.cxx
@@ -471,7 +471,7 @@ int SVertexer::checkCascades(float rv0, std::array<float, 3> pV0, float p2V0, in
     v0Idx++;
     firstIdx = mVtxMaxLUT[posneg][v0Idx];
   }
-  auto firstTr = mTrackSortVtxMax[posneg][firstIdx];
+
   for (int it = firstIdx; it < tracks.size(); it++) {
     auto& trackInd = mTrackSortVtxMax[posneg][it];
     auto& bach = tracks[trackInd];

--- a/Detectors/Vertexing/src/SVertexer.cxx
+++ b/Detectors/Vertexing/src/SVertexer.cxx
@@ -567,13 +567,13 @@ int SVertexer::checkCascades(float rv0, std::array<float, 3> pV0, float p2V0, in
 
     // clone the V0, set new cosPA and VerteXID, add it to the list of V0s
     if (cascVtxID != v0.getVertexID()) {
-      auto v0clone = v0;
+      mV0sTmp[ithread].push_back(v0);
+      auto& v0clone = mV0sTmp[ithread].back();
       const auto& pv = mPVertices[cascVtxID];
       float dx = v0.getX() - pv.getX(), dy = v0.getY() - pv.getY(), dz = v0.getZ() - pv.getZ(), prodXYZ = dx * pV0[0] + dy * pV0[1] + dz * pV0[2];
       float cosPA = prodXYZ / std::sqrt((dx * dx + dy * dy + dz * dz) * p2V0);
       v0clone.setCosPA(cosPA);
       v0clone.setVertexID(cascVtxID);
-      mV0sTmp[ithread].push_back(v0clone);
       casc.setV0ID(mV0sTmp[ithread].size() - 1); // set the new V0 index in the cascade
     }
   }
@@ -600,7 +600,7 @@ bool SVertexer::processTPCTrack(const o2::tpc::TrackTPC& trTPC, GIndex gid, int 
   }
   const auto& vtx = mPVertices[vtxid];
   auto twe = vtx.getTimeStamp();
-  int posneg = trTPC.getSign() < 0 ? 1 : 0;
+  int posneg = trTPC.getSign() < 0 ? 1 : 0;^^^
   auto trLoc = mTracksPool[posneg].emplace_back(TrackCand{trTPC, gid, {vtxid, vtxid}, 0.});
   auto err = correctTPCTrack(trLoc, trTPC, twe.getTimeStamp(), twe.getTimeStampError());
   if (err < 0) {

--- a/Detectors/Vertexing/src/SVertexer.cxx
+++ b/Detectors/Vertexing/src/SVertexer.cxx
@@ -421,10 +421,10 @@ bool SVertexer::checkV0(const TrackCand& seedP, const TrackCand& seedN, int iP, 
   if (checkForCascade) {
     int nCascAdded = 0;
     if (hypCheckStatus[HypV0::Lambda] || !mSVParams->checkCascadeHypothesis) {
-      nCascAdded += checkCascades(rv0, pV0, p2V0, iN, NEG, ithread);
+      nCascAdded += checkCascades(rv0, pV0, p2V0, iN, NEG, vlist, ithread);
     }
     if (hypCheckStatus[HypV0::AntiLambda] || !mSVParams->checkCascadeHypothesis) {
-      nCascAdded += checkCascades(rv0, pV0, p2V0, iP, POS, ithread);
+      nCascAdded += checkCascades(rv0, pV0, p2V0, iP, POS, vlist, ithread);
     }
     if (!nCascAdded && rejectIfNotCascade) { // v0 would be accepted only if it creates a cascade
       mV0sTmp[ithread].pop_back();
@@ -436,29 +436,38 @@ bool SVertexer::checkV0(const TrackCand& seedP, const TrackCand& seedN, int iP, 
 }
 
 //__________________________________________________________________
-int SVertexer::checkCascades(float rv0, std::array<float, 3> pV0, float p2V0, int avoidTrackID, int posneg, int ithread)
+int SVertexer::checkCascades(float rv0, std::array<float, 3> pV0, float p2V0, int avoidTrackID, int posneg, VBracket v0vlist, int ithread)
 {
+
   // check last added V0 for belonging to cascade
   auto& fitterCasc = mFitterCasc[ithread];
   const auto& v0 = mV0sTmp[ithread].back();
   auto& tracks = mTracksPool[posneg];
-  const auto& pv = mPVertices[v0.getVertexID()];
+
   int nCascIni = mCascadesTmp[ithread].size();
   // start from the 1st track compatible with V0's primary vertex
-  int firstTr = mVtxFirstTrack[posneg][v0.getVertexID()], nTr = tracks.size();
+  int firstIdx = v0vlist.getMin() - mSVParams->marginBachPV > 0 ? v0vlist.getMin() - mSVParams->marginBachPV : 0;
+  int firstTr = mVtxFirstTrack[posneg][firstIdx], nTr = tracks.size();
   if (firstTr < 0) {
     firstTr = nTr;
   }
   for (int it = firstTr; it < nTr; it++) {
+    auto& bach = tracks[it];
+
     if (it == avoidTrackID) {
       continue; // skip the track used by V0
     }
-    auto& bach = tracks[it];
-    if (bach.vBracket > v0.getVertexID()) {
+    if (bach.vBracket.getMin() > v0vlist.getMax()) {
       break; // all other bachelor candidates will be also not compatible with this PV
     }
-    if (bach.vBracket.isOutside(v0.getVertexID())) {
-      LOG(error) << "Incompatible bachelor: PV " << bach.vBracket.asString() << " vs V0 " << v0.getVertexID();
+    auto cascVlist = v0vlist.getOverlap(bach.vBracket); // indices of vertices shared by V0 and bachelor
+    if (mSVParams->selectBestV0) {
+      // select only the best V0 candidate among the compatible ones
+      if (v0.getVertexID() < cascVlist.getMin() || v0.getVertexID() > cascVlist.getMax()) {
+        continue;
+      }
+      cascVlist.setMin(v0.getVertexID());
+      cascVlist.setMax(v0.getVertexID());
     }
     if (bach.minR > rv0 + mSVParams->causalityRTolerance) {
       continue;
@@ -469,8 +478,9 @@ int SVertexer::checkCascades(float rv0, std::array<float, 3> pV0, float p2V0, in
     }
     int candC = 0;
     const auto& cascXYZ = fitterCasc.getPCACandidatePos(candC);
-    // make sure the cascade radius is smaller than that of the vertex
-    float dxc = cascXYZ[0] - pv.getX(), dyc = cascXYZ[1] - pv.getY(), dzc = cascXYZ[2] - pv.getZ(), r2casc = dxc * dxc + dyc * dyc;
+
+    // make sure the cascade radius is smaller than that of the mean vertex
+    float dxc = cascXYZ[0] - mMeanVertex.getX(), dyc = cascXYZ[1] - mMeanVertex.getY(), dzc = cascXYZ[2] - mMeanVertex.getZ(), r2casc = dxc * dxc + dyc * dyc;
     if (rv0 * rv0 - r2casc < mMinR2DiffV0Casc || r2casc < mMinR2ToMeanVertex) {
       continue;
     }
@@ -479,6 +489,7 @@ int SVertexer::checkCascades(float rv0, std::array<float, 3> pV0, float p2V0, in
     if (!fitterCasc.isPropagateTracksToVertexDone() && !fitterCasc.propagateTracksToVertex()) {
       continue;
     }
+
     auto& trNeut = fitterCasc.getTrack(0, candC);
     auto& trBach = fitterCasc.getTrack(1, candC);
     trNeut.setPID(o2::track::PID::Lambda);
@@ -489,20 +500,42 @@ int SVertexer::checkCascades(float rv0, std::array<float, 3> pV0, float p2V0, in
     std::array<float, 3> pCasc = {pNeut[0] + pBach[0], pNeut[1] + pBach[1], pNeut[2] + pBach[2]};
     auto prodPPos = pV0[0] * dxc + pV0[1] * dyc + pV0[2] * dzc;
     if (prodPPos < 0.) { // causality cut
+      LOG(debug) << "Casc not causally compatible";
       continue;
     }
     float pt2Casc = pCasc[0] * pCasc[0] + pCasc[1] * pCasc[1], p2Casc = pt2Casc + pCasc[2] * pCasc[2];
     if (pt2Casc < mMinPt2Casc) { // pt cut
+      LOG(debug) << "Casc pt too low";
       continue;
     }
     if (pCasc[2] * pCasc[2] / pt2Casc > mMaxTgl2Casc) { // tgLambda cut
+      LOG(debug) << "Casc tgLambda too high";
       continue;
     }
-    //    LOG(info) << "ptcasc2 " << pt2Casc << " tglcasc2 " << pCasc[2]*pCasc[2] / pt2Casc << " cut " << mMaxTgl2Casc;
-    float cosPA = (pCasc[0] * dxc + pCasc[1] * dyc + pCasc[2] * dzc) / std::sqrt(p2Casc * (r2casc + dzc * dzc));
-    if (cosPA < mSVParams->minCosPACasc) {
+
+    // compute primary vertex and cosPA of the cascade
+    auto bestCosPA = mSVParams->minCosPACasc;
+    auto cascVtxID = -1;
+
+    for (int iv = cascVlist.getMin(); iv <= cascVlist.getMax(); iv++) {
+      const auto& pv = mPVertices[iv];
+      // check cos of pointing angle
+      float dx = cascXYZ[0] - pv.getX(), dy = cascXYZ[1] - pv.getY(), dz = cascXYZ[2] - pv.getZ(), prodXYZcasc = dx * pCasc[0] + dy * pCasc[1] + dz * pCasc[2];
+      float cosPA = prodXYZcasc / std::sqrt((dx * dx + dy * dy + dz * dz) * p2Casc);
+      if (cosPA < bestCosPA) {
+        LOG(debug) << "Rej. cosPA: " << cosPA;
+        continue;
+      }
+      cascVtxID = iv;
+      bestCosPA = cosPA;
+    }
+    if (cascVtxID == -1) {
+      LOG(debug) << "Casc not compatible with any vertex";
       continue;
     }
+
+    const auto& cascPv = mPVertices[cascVtxID];
+
     float p2Bach = pBach[0] * pBach[0] + pBach[1] * pBach[1] + pBach[2] * pBach[2];
     float ptCasc = std::sqrt(pt2Casc);
     bool goodHyp = false;
@@ -513,20 +546,38 @@ int SVertexer::checkCascades(float rv0, std::array<float, 3> pV0, float p2V0, in
       }
     }
     if (!goodHyp) {
+      LOG(debug) << "Casc not compatible with any hypothesis";
       continue;
     }
     auto& casc = mCascadesTmp[ithread].emplace_back(cascXYZ, pCasc, fitterCasc.calcPCACovMatrixFlat(candC), trNeut, trBach, mV0sTmp[ithread].size() - 1, bach.gid);
     o2::track::TrackParCov trc = casc;
     o2::dataformats::DCA dca;
-    if (!trc.propagateToDCA(pv, fitterCasc.getBz(), &dca, 5.) ||
+    if (!trc.propagateToDCA(cascPv, fitterCasc.getBz(), &dca, 5.) ||
         std::abs(dca.getY()) > mSVParams->maxDCAXYCasc || std::abs(dca.getZ()) > mSVParams->maxDCAZCasc) {
+      LOG(debug) << "Casc not compatible with PV";
+      LOG(debug) << "DCA: " << dca.getY() << " " << dca.getZ();
       mCascadesTmp[ithread].pop_back();
       continue;
     }
-    casc.setCosPA(cosPA);
-    casc.setVertexID(v0.getVertexID());
+
+    LOG(debug) << "Casc successfully added";
+    casc.setCosPA(bestCosPA);
+    casc.setVertexID(cascVtxID);
     casc.setDCA(fitterCasc.getChi2AtPCACandidate());
+
+    // clone the V0, set new cosPA and VerteXID, add it to the list of V0s
+    if (cascVtxID != v0.getVertexID()) {
+      auto v0clone = v0;
+      const auto& pv = mPVertices[cascVtxID];
+      float dx = v0.getX() - pv.getX(), dy = v0.getY() - pv.getY(), dz = v0.getZ() - pv.getZ(), prodXYZ = dx * pV0[0] + dy * pV0[1] + dz * pV0[2];
+      float cosPA = prodXYZ / std::sqrt((dx * dx + dy * dy + dz * dz) * p2V0);
+      v0clone.setCosPA(cosPA);
+      v0clone.setVertexID(cascVtxID);
+      mV0sTmp[ithread].push_back(v0clone);
+      casc.setV0ID(mV0sTmp[ithread].size() - 1);  // set the new V0 index in the cascade
+    }
   }
+
   return mCascadesTmp[ithread].size() - nCascIni;
 }
 


### PR DESCRIPTION
Follow up of P.R. #9461

I implemented strategy 1) --> if the v0 and the bachelor match with a different vertexID, a new v0 clone is created, the cosPA is recomputed and the new PV is set. Then the new v0 is pushed into the v0 vector. I have also added a couple of flags in the SVertexerParams file:

- `marginBachPV` : it's the lower margin from where the bachelor loop starts: since bachelors are sorted in bracket.GetMin() order, the loops should not start here `mVtxFirstTrack[posneg][v0.getVertexID()]` as this excludes all the bachelors w/ bachelor.bracket.GetMin() < than the v0.getVertexID() one. So I added a margin that is subtracted to the minimum vertex index of the V0. The value of the margin is chosen by looking at the maximum number of vertices in which a bachelor is present 

- `selectBestV0` : if the bachelor bracket does not include the v0 best vertex, the cascade candidate is rejected. If the v0 best vertex is in the bachelor bracket, this vertex is the one used. With this flag `True` no clones should be generated
 
