### PR TITLE
[EMCAL-710] Add hardware address to FEE error type

### DIFF
--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/ErrorTypeFEE.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/ErrorTypeFEE.h
@@ -67,7 +67,8 @@ class ErrorTypeFEE
   /// \param errortype Type of the error
   /// \param errorCode Error code for the given error type
   /// \param subspec Subspecification of the error (i.e. FEC ID)
-  ErrorTypeFEE(int FEEID, ErrorSource_t errortype, int errorCode, int subspec) : mFEEID(FEEID), mErrorSource(errortype), mErrorCode(errorCode), mSubspecification(subspec) {}
+  /// \param hardwareAddress Hardware address of the channel
+  ErrorTypeFEE(int FEEID, ErrorSource_t errortype, int errorCode, int subspec, int hardwareAddress) : mFEEID(FEEID), mErrorSource(errortype), mErrorCode(errorCode), mSubspecification(subspec), mHardwareAddress(hardwareAddress) {}
 
   /// \brief Destructor
   ~ErrorTypeFEE() = default;
@@ -117,9 +118,16 @@ class ErrorTypeFEE
   /// \param subspec Subspecification of the error
   void setSubspecification(int subspec) { mSubspecification = subspec; }
 
+  /// \brief Set the hardware address of the error
+  /// \param hardwareAddress Hardware address of the error
+  void setHardwareAddress(int hardwareAddress) { mHardwareAddress = hardwareAddress; }
+
   /// \brief Get the FEE ID of the electronics responsible for the error
   /// \return ID of the FEE component
-  int getFEEID() const { return mFEEID; }
+  int getFEEID() const
+  {
+    return mFEEID;
+  }
 
   /// \brief Get the type of the error handled by the object
   /// \return Error type
@@ -153,6 +161,10 @@ class ErrorTypeFEE
   /// \return Subspecification of the error
   int getSubspecification() const { return mSubspecification; }
 
+  /// \brief Get the hardware address of the error
+  /// \return Hardware address of the error
+  int getHarwareAddress() const { return mHardwareAddress; }
+
   /// \brief Printing information of the error type
   /// \param stream Output stream where to print the error
   ///
@@ -168,6 +180,7 @@ class ErrorTypeFEE
   ErrorSource_t mErrorSource = ErrorSource_t::UNDEFINED; ///< Source of the error
   int mErrorCode = -1;                                   ///< Raw page error type
   int mSubspecification;                                 ///< Subspecification
+  int mHardwareAddress;                                  ///< Hardware address of the channel
 
   ClassDefNV(ErrorTypeFEE, 1);
 };

--- a/DataFormats/Detectors/EMCAL/src/ErrorTypeFEE.cxx
+++ b/DataFormats/Detectors/EMCAL/src/ErrorTypeFEE.cxx
@@ -10,6 +10,7 @@
 // or submit itself to any jurisdiction.
 
 #include "DataFormatsEMCAL/ErrorTypeFEE.h"
+#include <iomanip>
 #include <iostream>
 
 using namespace o2::emcal;
@@ -46,6 +47,9 @@ void ErrorTypeFEE::PrintStream(std::ostream& stream) const
   stream << "EMCAL SM: " << getFEEID() << ", " << typestring << " Type: " << getErrorCode();
   if (mSubspecification >= 0) {
     stream << ", Subspecification: " << mSubspecification;
+  }
+  if (mHardwareAddress >= 0) {
+    stream << ", hardware address 0x" << std::hex << mHardwareAddress << std::dec;
   }
 }
 

--- a/Detectors/EMCAL/base/include/EMCALBase/Geometry.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/Geometry.h
@@ -375,7 +375,7 @@ class Geometry
   /// \param col Global col ID
   /// \return Position in supermodule: [0 - supermodule ID, 1 - row in supermodule - col in supermodule]
   /// \throw RowColException
-  std::tuple<int, int, int> GetPositionInSupermoduleFromGlobalRowCol(int col, int row) const;
+  std::tuple<int, int, int> GetPositionInSupermoduleFromGlobalRowCol(int row, int col) const;
 
   /// \brief Get the cell indices from global position in the EMCAL
   /// \param row Global row ID

--- a/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
@@ -155,7 +155,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
         rawreader.next();
       } catch (RawDecodingError& e) {
         if (mCreateRawDataErrors) {
-          mOutputDecoderErrors.emplace_back(e.getFECID(), ErrorTypeFEE::ErrorSource_t::PAGE_ERROR, RawDecodingError::ErrorTypeToInt(e.getErrorType()), -1);
+          mOutputDecoderErrors.emplace_back(e.getFECID(), ErrorTypeFEE::ErrorSource_t::PAGE_ERROR, RawDecodingError::ErrorTypeToInt(e.getErrorType()), -1, -1);
         }
         if (mNumErrorMessages < mMaxErrorMessages) {
           LOG(alarm) << " Page decoding: " << e.what() << " in FEE ID " << e.getFECID() << std::endl;
@@ -268,7 +268,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
         }
         if (mCreateRawDataErrors) {
           // fill histograms  with error types
-          ErrorTypeFEE errornum(feeID, ErrorTypeFEE::ErrorSource_t::ALTRO_ERROR, AltroDecoderError::errorTypeToInt(e.getErrorType()), -1);
+          ErrorTypeFEE errornum(feeID, ErrorTypeFEE::ErrorSource_t::ALTRO_ERROR, AltroDecoderError::errorTypeToInt(e.getErrorType()), -1, -1);
           mOutputDecoderErrors.push_back(errornum);
         }
         continue;
@@ -284,7 +284,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
           } else {
             mErrorMessagesSuppressed++;
           }
-          ErrorTypeFEE errornum(feeID, ErrorTypeFEE::ErrorSource_t::ALTRO_ERROR, MinorAltroDecodingError::errorTypeToInt(minorerror.getErrorType()), -1);
+          ErrorTypeFEE errornum(feeID, ErrorTypeFEE::ErrorSource_t::ALTRO_ERROR, MinorAltroDecodingError::errorTypeToInt(minorerror.getErrorType()), -1, -1);
           mOutputDecoderErrors.push_back(errornum);
         }
       }
@@ -369,7 +369,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
               mErrorMessagesSuppressed++;
             }
             if (mCreateRawDataErrors) {
-              mOutputDecoderErrors.emplace_back(feeID, ErrorTypeFEE::ErrorSource_t::GEOMETRY_ERROR, 0, CellID); // 0 -> Cell ID out of range
+              mOutputDecoderErrors.emplace_back(feeID, ErrorTypeFEE::ErrorSource_t::GEOMETRY_ERROR, 0, CellID, chan.getHardwareAddress()); // 0 -> Cell ID out of range
             }
             continue;
           }
@@ -399,7 +399,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
               mErrorMessagesSuppressed++;
             }
             if (mCreateRawDataErrors) {
-              mOutputDecoderErrors.emplace_back(feeID, ErrorTypeFEE::ErrorSource_t::GEOMETRY_ERROR, 2, CellID); // Geometry error codes will start from 100
+              mOutputDecoderErrors.emplace_back(feeID, ErrorTypeFEE::ErrorSource_t::GEOMETRY_ERROR, 2, CellID, chan.getHardwareAddress()); // Geometry error codes will start from 100
             }
             continue;
           }
@@ -503,7 +503,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
               }
               // Exclude BUNCH_NOT_OK also from raw error objects
               if (mCreateRawDataErrors) {
-                mOutputDecoderErrors.emplace_back(feeID, ErrorTypeFEE::ErrorSource_t::FIT_ERROR, CaloRawFitter::getErrorNumber(fiterror), CellID);
+                mOutputDecoderErrors.emplace_back(feeID, ErrorTypeFEE::ErrorSource_t::FIT_ERROR, CaloRawFitter::getErrorNumber(fiterror), CellID, chan.getHardwareAddress());
               }
             } else {
               LOG(debug2) << "Failure in raw fitting: " << CaloRawFitter::createErrorMessage(fiterror);
@@ -521,7 +521,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
           }
         }
         if (mCreateRawDataErrors) {
-          mOutputDecoderErrors.emplace_back(feeID, ErrorTypeFEE::ErrorSource_t::ALTRO_ERROR, AltroDecoderError::errorTypeToInt(AltroDecoderError::ErrorType_t::ALTRO_MAPPING_ERROR), -1);
+          mOutputDecoderErrors.emplace_back(feeID, ErrorTypeFEE::ErrorSource_t::ALTRO_ERROR, AltroDecoderError::errorTypeToInt(AltroDecoderError::ErrorType_t::ALTRO_MAPPING_ERROR), -1, -1);
         }
       }
     }
@@ -552,7 +552,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
               mErrorMessagesSuppressed++;
             }
             if (mCreateRawDataErrors) {
-              mOutputDecoderErrors.emplace_back(cell.mFecID, ErrorTypeFEE::GAIN_ERROR, 0, cell.mFecID);
+              mOutputDecoderErrors.emplace_back(cell.mDDLID, ErrorTypeFEE::GAIN_ERROR, 0, cell.mFecID, cell.mHWAddressLG);
             }
           }
           continue;
@@ -568,7 +568,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
             mErrorMessagesSuppressed++;
           }
           if (mCreateRawDataErrors) {
-            mOutputDecoderErrors.emplace_back(cell.mFecID, ErrorTypeFEE::GAIN_ERROR, 1, cell.mFecID);
+            mOutputDecoderErrors.emplace_back(cell.mDDLID, ErrorTypeFEE::GAIN_ERROR, 1, cell.mFecID, cell.mHWAddressHG);
           }
           continue;
         }


### PR DESCRIPTION
- Use hardware address for raw data errors which are
  per channel to monitor later the channel position in
  dedicated histograms in the QC
- Use -1 for raw data errors which are per page - in such
  cases the hardware address must not be used
- Fix DDL for the gain error type
- Fix argument nams in one geometry function in order to
  avoid confusing naming