### PR TITLE
Reimplement create-aligned-geometry to use DPL CCDB fetcher

### DIFF
--- a/Detectors/GRP/workflows/CMakeLists.txt
+++ b/Detectors/GRP/workflows/CMakeLists.txt
@@ -40,12 +40,13 @@ o2_add_executable(grp-create
                                         O2::CCDB
                                         Boost::program_options)
 
-o2_add_executable(create-aligned
-                  COMPONENT_NAME geometry
+o2_add_executable(workflow
+                  COMPONENT_NAME create-aligned-geometry
                   SOURCES src/create-aligned-geometry.cxx
                   PUBLIC_LINK_LIBRARIES O2::DetectorsBase
                                         O2::CommonUtils
                                         O2::CCDB
+                                        O2::DetectorsRaw
                                         Boost::program_options)
 
 o2_add_executable(grp-dcs-dps-sim-workflow

--- a/Detectors/GRP/workflows/src/create-aligned-geometry.cxx
+++ b/Detectors/GRP/workflows/src/create-aligned-geometry.cxx
@@ -9,7 +9,6 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#include <boost/program_options.hpp>
 #include <ctime>
 #include <chrono>
 #include "DetectorsBase/GeometryManager.h"
@@ -17,66 +16,151 @@
 #include "CCDB/CCDBTimeStampUtils.h"
 #include "CommonUtils/NameConf.h"
 #include <TGeoManager.h>
+#include "DetectorsCommonDataFormats/DetID.h"
+#include "DetectorsBase/GRPGeomHelper.h"
+#include "Framework/Task.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "Framework/CallbacksPolicy.h"
+#include "Headers/STFHeader.h"
+#include "DetectorsRaw/HBFUtils.h"
 
-using CcdbApi = o2::ccdb::CcdbApi;
-namespace bpo = boost::program_options;
+using DetID = o2::detectors::DetID;
+using namespace o2::framework;
 
-void createAlignedGeometry(long timeToPick, std::string ccdbServer = "")
+/*
+  Simple workflow to create aligned geometry file from the ideal geometry and alignment objects on the CCDB
+  One can profit from the DPL CCDB fetcher --condition-remap functionality to impose difference CCDB
+  servers for different alignment objects.
+  Also, one can use --configKeyValues "HBFUtils.startTime=... functionality to impose the timestamp for the objects to fetch.
+  E.g. to create the geometry using current timestamp and production server, use just
+  o2-create-aligned-geometry-workflow
+
+  To create the geometry using specific timestamp and ITS alignment from the test CCDB server and MFT alignment
+  from the local snapshot file in  the locCCDB directory
+  o2-create-aligned-geometry-workflow --condition-remap http://ccdb-test.cern.ch:8080=ITS/Calib/Align;file://locCCDB=MFT/Calib/Align --configKeyValues "HBFUtils.startTime=1546300800000"
+ */
+
+namespace o2::base
 {
-  if (timeToPick == 0) {
-    timeToPick = o2::ccdb::getCurrentTimestamp();
+
+class SeederTask : public Task
+{
+ public:
+  void run(ProcessingContext& pc) final
+  {
+    const auto& hbfu = o2::raw::HBFUtils::Instance();
+    auto& tinfo = pc.services().get<o2::framework::TimingInfo>();
+    if (hbfu.startTime != 0) {
+      tinfo.creation = hbfu.startTime;
+    } else {
+      tinfo.creation = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::system_clock::now()).time_since_epoch().count();
+    }
+    if (hbfu.orbitFirstSampled != 0) {
+      tinfo.firstTForbit = hbfu.orbitFirstSampled;
+    } else {
+      tinfo.firstTForbit = 0;
+    }
+    auto& stfDist = pc.outputs().make<o2::header::STFHeader>(Output{"FLP", "DISTSUBTIMEFRAME", 0});
+    pc.services().get<ControlService>().endOfStream();
+    pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
   }
-  auto& cm = o2::ccdb::BasicCCDBManager::instance();
-  if (!ccdbServer.empty()) {
-    cm.setURL(ccdbServer);
+};
+
+class AlignerTask : public Task
+{
+ public:
+  AlignerTask(DetID::mask_t dets, std::shared_ptr<o2::base::GRPGeomRequest> gr) : mDetsMask(dets), mGGCCDBRequest(gr) {}
+  ~AlignerTask() override = default;
+
+  void init(InitContext& ic) final
+  {
+    o2::base::GRPGeomHelper::instance().setRequest(mGGCCDBRequest);
   }
-  cm.setTimestamp(timeToPick);
-  cm.get<TGeoManager>("GLO/Config/Geometry");
-  if (!o2::base::GeometryManager::isGeometryLoaded()) {
-    throw std::runtime_error(fmt::format("Failed to load geometry from {} for timestamp {}", cm.getURL(), timeToPick));
+
+  void run(ProcessingContext& pc) final
+  {
+    o2::base::GRPGeomHelper::instance().checkUpdates(pc);
+    for (auto id = DetID::First; id <= DetID::Last; id++) {
+      if (mDetsMask[id]) {
+        auto alg = o2::base::GRPGeomHelper::instance().getAlignment(id);
+        if (!alg->empty()) {
+          LOGP(info, "Applying alignment for detector {}", DetID::getName(id));
+          o2::base::GeometryManager::applyAlignment(*alg);
+        } else {
+          LOGP(info, "Alignment for detector {} is empty", DetID::getName(id));
+        }
+      }
+    }
+    gGeoManager->SetName(std::string(o2::base::NameConf::CCDBOBJECT).c_str());
+    auto fnm = o2::base::NameConf::getAlignedGeomFileName();
+    gGeoManager->Export(fnm.c_str());
+    LOG(info) << "Stored to local file " << fnm;
+    pc.services().get<ControlService>().endOfStream();
+    pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
   }
-  gGeoManager->SetName(std::string(o2::base::NameConf::CCDBOBJECT).c_str());
-  o2::base::GeometryManager::applyMisalignent();
-  auto fnm = o2::base::NameConf::getAlignedGeomFileName();
-  gGeoManager->Export(fnm.c_str());
-  LOG(info) << "Stored to local file " << fnm;
+
+  void finaliseCCDB(ConcreteDataMatcher& matcher, void* obj) final
+  {
+    o2::base::GRPGeomHelper::instance().finaliseCCDB(matcher, obj);
+  }
+
+ private:
+  DetID::mask_t mDetsMask{};
+  std::shared_ptr<o2::base::GRPGeomRequest> mGGCCDBRequest;
+};
+
+} // namespace o2::base
+
+DataProcessorSpec getAlignerSpec(DetID::mask_t dets)
+{
+  std::vector<InputSpec> inputs{{"STFDist", "FLP", "DISTSUBTIMEFRAME", 0}};                         // just to have some input
+  auto ggRequest = std::make_shared<o2::base::GRPGeomRequest>(false,                                // orbitResetTime
+                                                              false,                                // GRPECS
+                                                              false,                                // GRPLHCIF
+                                                              false,                                // GRPMagField
+                                                              false,                                // askMatLUT
+                                                              o2::base::GRPGeomRequest::Alignments, // geometry
+                                                              inputs);
+
+  return DataProcessorSpec{
+    "geometry-aligned-producer",
+    inputs,
+    {},
+    AlgorithmSpec{adaptFromTask<o2::base::AlignerTask>(dets, ggRequest)},
+    Options{}};
 }
 
-int main(int argc, char** argv)
+DataProcessorSpec getSeederSpec()
 {
-  bpo::variables_map vm;
-  bpo::options_description opt_general(
-    "Create aligned geometry from CCDB ideal geometry and alignment entries\n"
-    "Usage:\n  " +
-    std::string(argv[0]) +
-    "");
-  bpo::options_description opt_hidden("");
-  bpo::options_description opt_all;
-  bpo::positional_options_description opt_pos;
+  return DataProcessorSpec{
+    "seeder",
+    Inputs{},
+    Outputs{{"FLP", "DISTSUBTIMEFRAME", 0}},
+    AlgorithmSpec{adaptFromTask<o2::base::SeederTask>()},
+    Options{}};
+}
 
-  try {
-    auto add_option = opt_general.add_options();
-    add_option("help,h", "Print this help message");
-    add_option("timestamp,t", bpo::value<long>()->default_value(0), "timestamp to use for CCDB query (0 = now)");
-    add_option("ccdb-server", bpo::value<std::string>()->default_value("http://alice-ccdb.cern.ch"), "CCDB server to query");
-    opt_all.add(opt_general).add(opt_hidden);
-    bpo::store(bpo::command_line_parser(argc, argv).options(opt_all).positional(opt_pos).run(), vm);
-    if (vm.count("help")) {
-      std::cout << opt_general << std::endl;
-      exit(0);
-    }
-    bpo::notify(vm);
-  } catch (bpo::error& e) {
-    std::cerr << "ERROR: " << e.what() << std::endl
-              << std::endl;
-    std::cerr << opt_general << std::endl;
-    exit(1);
-  } catch (std::exception& e) {
-    std::cerr << e.what() << ", application will now exit" << std::endl;
-    exit(2);
-  }
+// ------------------------------------------------------------------
 
-  createAlignedGeometry(
-    vm["timestamp"].as<long>(),
-    vm["ccdb-server"].as<std::string>());
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  std::vector<o2::framework::ConfigParamSpec> options{
+    {"onlyDet", VariantType::String, std::string{DetID::ALL}, {"comma-separated list of detectors to account"}},
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
+  std::swap(workflowOptions, options);
+}
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& configcontext)
+{
+  // Update the (declared) parameters if changed from the command line
+  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
+  DetID::mask_t dets = DetID::FullMask & DetID::getMask(configcontext.options().get<std::string>("onlyDet"));
+  o2::framework::WorkflowSpec specs{getAlignerSpec(dets), getSeederSpec()};
+
+  return std::move(specs);
 }


### PR DESCRIPTION
Old simple executable o2-geometry-create-aligned is reworked to o2-create-aligned-geometry-workflow
which uses DPL CCDB fetcher and creates an aligned geometry file from the ideal geometry and
alignment objects on the CCDB.
One can profit from the DPL CCDB fetcher `--condition-remap` functionality to impose different CCDB
servers for different alignment objects. Also, one can use
`--configKeyValues HBFUtils.startTime=... ` functionality to impose the timestamp for the objects to fetch.

E.g. to create the geometry using the current timestamp and production server, use just:
o2-create-aligned-geometry-workflow

To create the geometry using a specific timestamp and ITS alignment from the test CCDB server and MFT
alignment from the local snapshot file in the locCCDB directory:
```
o2-create-aligned-geometry-workflow --condition-remap http://ccdb-test.cern.ch:8080=ITS/Calib/Align;file://locCCDB=MFT/Calib/Align --configKeyValues HBFUtils.startTime=1546300800000
```