### PR TITLE
[EMCAL-566] Added StatAccumulator for fast time calib

### DIFF
--- a/Detectors/EMCAL/calib/include/EMCALCalib/CalibDB.h
+++ b/Detectors/EMCAL/calib/include/EMCALCalib/CalibDB.h
@@ -15,6 +15,9 @@
 #include "RStringView.h"
 #include "CCDB/CcdbApi.h"
 
+#ifndef EMCALCALIBDB_H_
+#define EMCALCALIBDB_H_
+
 namespace o2
 {
 
@@ -343,3 +346,5 @@ class CalibDB
 } // namespace emcal
 
 } // namespace o2
+
+#endif


### PR DESCRIPTION
- Standard calibration is based on boost histograms and fitting the time
distribution for each EMCal cell
- New, fast, procedure, calculates mean and sigma on the fly and
therefore, no fitting is needed.
- StatAccumulators could be stored in ccdb for each run to later
calibrate based on multiple runs if needed (for example for the low gain
cells above ~16GeV)