### PR TITLE
Fixes for PHOSTurnonCalibDevice

### DIFF
--- a/Detectors/PHOS/calib/include/PHOSCalibWorkflow/PHOSTurnonCalibDevice.h
+++ b/Detectors/PHOS/calib/include/PHOSCalibWorkflow/PHOSTurnonCalibDevice.h
@@ -52,7 +52,7 @@ class PHOSTurnonCalibDevice : public o2::framework::Task
 
  private:
   bool mUseCCDB = false;
-  long mRunStartTime = 0;                            /// start time of the run (sec)
+  long mRunStartTime = 0;                            /// start time of the run (ms)
   std::unique_ptr<TriggerMap> mTriggerMap;           /// Final calibration object
   std::unique_ptr<PHOSTurnonCalibrator> mCalibrator; /// Agregator of calibration TimeFrameSlots
   std::shared_ptr<o2::base::GRPGeomRequest> mCCDBRequest;


### PR DESCRIPTION
@peressounko wrong DataDescription was crashing CCDBPopulator. I've also fixed the object validity: now stored as time of 1st TF seen-1min : +1 year.