### PR TITLE
Optionaly write CcdbApi.storeAsBinaryFile output to local file

### DIFF
--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -371,7 +371,7 @@ class CcdbApi //: public DatabaseInterface
    */
   void initInSnapshotMode(std::string const& snapshotpath)
   {
-    mSnapshotTopPath = snapshotpath;
+    mSnapshotTopPath = snapshotpath.empty() ? "." : snapshotpath;
     mInSnapshotMode = true;
   }
 
@@ -510,8 +510,11 @@ class CcdbApi //: public DatabaseInterface
    */
   void checkMetadataKeys(std::map<std::string, std::string> const& metadata) const;
 
-  std::string getSnapshotDir(const std::string& topdir, const string& path) const { return topdir + "/" + path; }
-  std::string getSnapshotFile(const std::string& topdir, const string& path) const { return getSnapshotDir(topdir, path) + "/snapshot.root"; }
+  std::string getSnapshotDir(const std::string& topdir, const std::string& path) const { return topdir + "/" + path; }
+  std::string getSnapshotFile(const std::string& topdir, const std::string& path, const std::string& sfile = "snapshot.root") const
+  {
+    return getSnapshotDir(topdir, path) + '/' + sfile;
+  }
 
   /// Base URL of the CCDB (with port)
   std::string mUniqueAgentID{}; // Unique User-Agent ID communicated to server for logging

--- a/CCDB/src/UploadTool.cxx
+++ b/CCDB/src/UploadTool.cxx
@@ -12,6 +12,7 @@
 #include "CCDB/CcdbApi.h"
 #include "CCDB/CCDBQuery.h"
 #include "CCDB/CCDBTimeStampUtils.h"
+#include "CCDB/CcdbObjectInfo.h"
 #include <map>
 #include "TFile.h"
 #include "TTree.h"
@@ -163,10 +164,14 @@ int main(int argc, char* argv[])
     auto ti = tcl->GetTypeInfo();
 
     std::cout << " Uploading an object of type " << key->GetClassName()
-              << " to path " << path << " with timestamp validy from " << starttimestamp
+              << " to path " << path << " with timestamp validity from " << starttimestamp
               << " to " << endtimestamp << "\n";
 
     api.storeAsTFile_impl(object, *ti, path, meta, starttimestamp, endtimestamp);
+    if (!api.isSnapshotMode() && meta.find("adjustableEOV") != meta.end() && meta.find("default") == meta.end()) {
+      o2::ccdb::CcdbObjectInfo oi(path, classname, filename, meta, starttimestamp, endtimestamp);
+      o2::ccdb::adjustOverriddenEOV(api, oi);
+    }
   } else {
     std::cerr << "Key " << keyname << " does not exist\n";
   }

--- a/Detectors/Calibration/workflow/CCDBPopulatorSpec.h
+++ b/Detectors/Calibration/workflow/CCDBPopulatorSpec.h
@@ -106,7 +106,7 @@ class CCDBPopulator : public o2::framework::Task
       }
 
       // do we need to override previous object?
-      if (wrp->isAdjustableEOV()) {
+      if (wrp->isAdjustableEOV() && !mAPI.isSnapshotMode()) {
         o2::ccdb::adjustOverriddenEOV(mAPI, *wrp.get());
       }
     }


### PR DESCRIPTION
If ccdb server provided to CcdbApi is "file://<dir>" then CcdbApi::storeAsBinaryFile will create a local file
at requested path, inserting _startValidityTimestamp_endValidityTimestamp to the file name and logging the
string which can used for the manual uploading.

Particularly, this method can be used for the CCDB object upload preparation: run your calibration task providing
`--ccdb-path file://something` to `o2-calibration-ccdb-populator-workflow`, then create a tarball from something
directory and use the results of grep "Upload with" of the job log to create upload requests script.

E.g.
```
~/Downloads$ o2-ccdb-upload --host file://tmp -p XX/YY/ZZ -f o2sim_grpecs.root -k ccdb_object --starttimestamp 123450 --endtimestamp 123460 -m "comment=test"
[INFO] Init CcdApi with UserAgentID: alicrs02-1658833311-6qUlcs, Host: file://tmp(snapshot readonly mode)
 Uploading an object of type o2::parameters::GRPECSObject to path XX/YY/ZZ with timestamp validity from 123450 to 123460
[INFO] Created local snapshot tmp/XX/YY/ZZ/o2-parameters-GRPECSObject_1658833311851_123450_123460.root
[INFO] Upload with: o2-ccdb-upload --host $ccdbhost -p XX/YY/ZZ -f tmp/XX/YY/ZZ/o2-parameters-GRPECSObject_1658833311851_123450_123460.root -k ccdb_query --starttimestamp 123450 --endtimestamp 123460 -m comment=test;$USER_META;
```