### PR TITLE
Collect and send ITS/MFT raw data decoding errors

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/DecodingStat.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/DecodingStat.h
@@ -173,6 +173,17 @@ struct ChipStat {
   ClassDefNV(ChipStat, 1);
 };
 
+struct ChipError {
+  uint32_t id = -1;
+  uint32_t nerrors = 0;
+  uint32_t errors = 0;
+
+  int16_t getChipID() const { return int16_t(id & 0xffff); }
+  uint16_t getFEEID() const { return uint16_t(id >> 16); }
+  static uint32_t composeID(uint16_t feeID, int16_t chipID) { return uint32_t(feeID) << 16 | uint16_t(chipID); }
+  ClassDefNV(ChipError, 1);
+};
+
 /// Statistics for per-link decoding
 struct GBTLinkDecodingStat {
   /// counters for format checks
@@ -202,7 +213,7 @@ struct GBTLinkDecodingStat {
   };
   static constexpr std::array<std::string_view, NErrorsDefined> ErrNames = {
     "Page data not start with expected RDH",                             // ErrNoRDHAtStart
-    "RDH is stopped, but the time is not matching the ~stop packet",     // ErrPageNotStopped
+    "RDH is stopped, but the time is not matching the stop packet",      // ErrPageNotStopped
     "Page with RDH.stop does not contain diagnostic word only",          // ErrStopPageNotEmpty
     "RDH page counters for the same RU/trigger are not continuous",      // ErrPageCounterDiscontinuity
     "RDH and GBT header page counters are not consistent",               // ErrRDHvsGBTHPageCnt
@@ -223,8 +234,7 @@ struct GBTLinkDecodingStat {
     "Wrong cable ID"                                                     // ErrWrongeCableID
   };
 
-  uint32_t ruLinkID = 0; // Link ID within RU
-
+  uint16_t feeID = 0; // FeeID
   // Note: packet here is meant as a group of CRU pages belonging to the same trigger
   uint32_t nPackets = 0;                                                        // total number of packets (RDH pages)
   uint32_t nTriggers = 0;                                                       // total number of triggers (ROFs)
@@ -241,7 +251,7 @@ struct GBTLinkDecodingStat {
 
   void print(bool skipNoErr = true) const;
 
-  ClassDefNV(GBTLinkDecodingStat, 2);
+  ClassDefNV(GBTLinkDecodingStat, 3);
 };
 
 } // namespace itsmft

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/GBTLink.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/GBTLink.h
@@ -90,6 +90,7 @@ struct GBTLink {
   uint8_t idInRU = 0;     // link ID within the RU
   uint8_t idInCRU = 0;    // link ID within the CRU
   uint8_t endPointID = 0; // endpoint ID of the CRU
+  bool gbtErrStatUpadated = false;
   uint16_t cruID = 0;     // CRU ID
   uint16_t feeID = 0;     // FEE ID
   uint16_t channelID = 0; // channel ID in the reader input

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RUDecodeData.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RUDecodeData.h
@@ -47,7 +47,7 @@ struct RUDecodeData {
   int lastChipChecked = 0; // last chips checked among nChipsFired
   int verbosity = 0;       // verbosity level, for -1,0 print only summary data, for 1: print once every error
   GBTCalibData calibData{}; // calibration info from GBT calibration word
-
+  std::unordered_map<uint32_t, std::pair<uint32_t, uint32_t>> chipErrorsTF; // vector of chip decoding errors seen in the given TF
   const RUInfo* ruInfo = nullptr;
 
   RUDecodeData()

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelReader.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/RawPixelReader.h
@@ -556,10 +556,10 @@ class RawPixelReader : public PixelReader
           newTrigger = false;
         }
       } else { // a new link was added
-        LOG(info) << "Adding new GBT LINK FEEId:" << OUTHEX(RDHUtils::getFEEID(rdh), 4);
         ruDecode.links[linkIDinRU] = addGBTLink();
         link = getGBTLink(ruDecode.links[linkIDinRU]);
-        link->statistics.ruLinkID = linkIDinRU;
+        link->statistics.feeID = RDHUtils::getFEEID(rdh);
+        LOG(info) << "Adding new GBT LINK FEEId:" << OUTHEX(link->statistics.feeID, 4);
         mNLinks++;
       }
       if (linkFlags[ruIDSW][linkIDinRU] == NotUpdated) {
@@ -1018,7 +1018,7 @@ class RawPixelReader : public PixelReader
 
     if (ruDecode.links[linkIDinRU] < 0) {
       ruDecode.links[linkIDinRU] = addGBTLink();
-      getGBTLink(ruDecode.links[linkIDinRU])->statistics.ruLinkID = linkIDinRU;
+      getGBTLink(ruDecode.links[linkIDinRU])->statistics.feeID = RDHUtils::getFEEID(rdh);
       mNLinks++;
     }
 

--- a/Detectors/ITSMFT/common/reconstruction/src/DecodingStat.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/DecodingStat.cxx
@@ -100,7 +100,7 @@ void GBTLinkDecodingStat::print(bool skipNoErr) const
     nErr += errorCounts[i];
   }
   if (!skipNoErr || nErr) {
-    std::string rep = fmt::format("FEEID#{:#04x} Packet States Statistics (total packets: {}, triggers: {})", ruLinkID, nPackets, nTriggers);
+    std::string rep = fmt::format("FEEID#{:#04x} Packet States Statistics (total packets: {}, triggers: {})", feeID, nPackets, nTriggers);
     bool countsSeen = false;
     for (int i = 0; i < GBTDataTrailer::MaxStateCombinations; i++) {
       if (packetStates[i]) {

--- a/Detectors/ITSMFT/common/reconstruction/src/GBTLink.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/GBTLink.cxx
@@ -34,6 +34,7 @@ using RDH = o2::header::RAWDataHeader;
 GBTLink::GBTLink(uint16_t _cru, uint16_t _fee, uint8_t _ep, uint8_t _idInCru, uint16_t _chan) : idInCRU(_idInCru), cruID(_cru), feeID(_fee), endPointID(_ep), channelID(_chan)
 {
   chipStat.feeID = _fee;
+  statistics.feeID = _fee;
 }
 
 ///_________________________________________________________________
@@ -62,6 +63,7 @@ void GBTLink::clear(bool resetStat, bool resetTFRaw)
   if (resetTFRaw) {
     rawData.clear();
     dataOffset = 0;
+    gbtErrStatUpadated = false;
   }
   //  lastRDH = nullptr;
   if (resetStat) {
@@ -143,6 +145,7 @@ uint8_t GBTLink::checkErrorsRDH(const RDH& rdh)
   uint8_t err = uint8_t(NoError);
   if (!RDHUtils::checkRDH(rdh, true)) {
     statistics.errorCounts[GBTLinkDecodingStat::ErrNoRDHAtStart]++;
+    gbtErrStatUpadated = true;
     if (needToPrintError(statistics.errorCounts[GBTLinkDecodingStat::ErrNoRDHAtStart])) {
       err |= uint8_t(ErrorPrinted);
       LOG(info) << describe() << ' ' << irHBF << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrNoRDHAtStart];
@@ -165,6 +168,7 @@ uint8_t GBTLink::checkErrorsRDH(const RDH& rdh)
       irHBF = RDHUtils::getHeartBeatIR(rdh);
     }
     statistics.errorCounts[GBTLinkDecodingStat::ErrPacketCounterJump]++;
+    gbtErrStatUpadated = true;
     if (needToPrintError(statistics.errorCounts[GBTLinkDecodingStat::ErrPacketCounterJump])) {
       LOG(info) << describe() << ' ' << irHBF << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrPacketCounterJump]
                 << " : jump from " << int(packetCounter) << " to " << int(RDHUtils::getPacketCounter(rdh));
@@ -185,6 +189,7 @@ uint8_t GBTLink::checkErrorsRDHStop(const RDH& rdh)
   if (format == NewFormat && lastRDH && RDHUtils::getHeartBeatOrbit(*lastRDH) != RDHUtils::getHeartBeatOrbit(rdh) // new HB starts
       && !RDHUtils::getStop(*lastRDH)) {
     statistics.errorCounts[GBTLinkDecodingStat::ErrPageNotStopped]++;
+    gbtErrStatUpadated = true;
     if (needToPrintError(statistics.errorCounts[GBTLinkDecodingStat::ErrPageNotStopped])) {
       LOG(info) << describe() << ' ' << irHBF << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrPageNotStopped];
       RDHUtils::printRDH(*lastRDH);
@@ -204,6 +209,7 @@ uint8_t GBTLink::checkErrorsRDHStopPageEmpty(const RDH& rdh)
   uint8_t err = uint8_t(NoError);
   if (format == NewFormat && RDHUtils::getStop(rdh) && RDHUtils::getMemorySize(rdh) != sizeof(RDH) + sizeof(GBTDiagnostic)) {
     statistics.errorCounts[GBTLinkDecodingStat::ErrStopPageNotEmpty]++;
+    gbtErrStatUpadated = true;
     if (needToPrintError(statistics.errorCounts[GBTLinkDecodingStat::ErrStopPageNotEmpty])) {
       LOG(info) << describe() << ' ' << irHBF << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrStopPageNotEmpty];
       RDHUtils::printRDH(rdh);
@@ -222,6 +228,7 @@ uint8_t GBTLink::checkErrorsTriggerWord(const GBTTrigger* gbtTrg)
   uint8_t err = uint8_t(NoError);
   if (!gbtTrg->isTriggerWord()) { // check trigger word
     statistics.errorCounts[GBTLinkDecodingStat::ErrMissingGBTTrigger]++;
+    gbtErrStatUpadated = true;
     if (needToPrintError(statistics.errorCounts[GBTLinkDecodingStat::ErrMissingGBTTrigger])) {
       gbtTrg->printX();
       LOG(info) << describe() << ' ' << irHBF << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrMissingGBTTrigger];
@@ -248,6 +255,7 @@ uint8_t GBTLink::checkErrorsHeaderWord(const GBTDataHeader* gbtH)
   uint8_t err = uint8_t(NoError);
   if (!gbtH->isDataHeader()) { // check header word
     statistics.errorCounts[GBTLinkDecodingStat::ErrMissingGBTHeader]++;
+    gbtErrStatUpadated = true;
     if (needToPrintError(statistics.errorCounts[GBTLinkDecodingStat::ErrMissingGBTHeader])) {
       gbtH->printX();
       LOG(info) << describe() << ' ' << irHBF << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrMissingGBTHeader];
@@ -266,6 +274,7 @@ uint8_t GBTLink::checkErrorsHeaderWord(const GBTDataHeaderL* gbtH)
   uint8_t err = uint8_t(NoError);
   if (!gbtH->isDataHeader()) { // check header word
     statistics.errorCounts[GBTLinkDecodingStat::ErrMissingGBTHeader]++;
+    gbtErrStatUpadated = true;
     if (verbosity >= VerboseErrors) {
       gbtH->printX();
       LOG(info) << describe() << ' ' << irHBF << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrMissingGBTHeader];
@@ -279,6 +288,7 @@ uint8_t GBTLink::checkErrorsHeaderWord(const GBTDataHeaderL* gbtH)
   // RSTODO: this makes sense only for old format, where every trigger has its RDH
   if (gbtH->packetIdx != cnt) {
     statistics.errorCounts[GBTLinkDecodingStat::ErrRDHvsGBTHPageCnt]++;
+    gbtErrStatUpadated = true;
     if (needToPrintError(statistics.errorCounts[GBTLinkDecodingStat::ErrRDHvsGBTHPageCnt])) {
       LOG(info) << describe() << ' ' << irHBF << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrRDHvsGBTHPageCnt] << ": diff in GBT header "
                 << gbtH->packetIdx << " and RDH page " << cnt << " counters";
@@ -293,6 +303,7 @@ uint8_t GBTLink::checkErrorsHeaderWord(const GBTDataHeaderL* gbtH)
     //if (cnt) { // makes sens for old format only
     if (gbtH->packetIdx) {
       statistics.errorCounts[GBTLinkDecodingStat::ErrNonZeroPageAfterStop]++;
+      gbtErrStatUpadated = true;
       if (needToPrintError(statistics.errorCounts[GBTLinkDecodingStat::ErrNonZeroPageAfterStop])) {
         LOG(info) << describe() << ' ' << irHBF << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrNonZeroPageAfterStop]
                   << ": Non-0 page counter (" << cnt << ") while all lanes were stopped";
@@ -312,6 +323,7 @@ uint8_t GBTLink::checkErrorsActiveLanes(int cbl)
   uint8_t err = uint8_t(NoError);
   if (~cbl & lanesActive) { // are there wrong lanes?
     statistics.errorCounts[GBTLinkDecodingStat::ErrInvalidActiveLanes]++;
+    gbtErrStatUpadated = true;
     if (needToPrintError(statistics.errorCounts[GBTLinkDecodingStat::ErrInvalidActiveLanes])) {
       std::bitset<32> expectL(cbl), gotL(lanesActive);
       LOG(info) << describe() << ' ' << irHBF << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrInvalidActiveLanes] << ' '
@@ -332,6 +344,7 @@ uint8_t GBTLink::checkErrorsGBTData(int cablePos)
   lanesWithData |= 0x1 << cablePos;    // flag that the data was seen on this lane
   if (lanesStop & (0x1 << cablePos)) { // make sure stopped lanes do not transmit the data
     statistics.errorCounts[GBTLinkDecodingStat::ErrDataForStoppedLane]++;
+    gbtErrStatUpadated = true;
     if (needToPrintError(statistics.errorCounts[GBTLinkDecodingStat::ErrDataForStoppedLane])) {
       LOG(info) << describe() << ' ' << irHBF << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrDataForStoppedLane] << cablePos;
       err |= uint8_t(ErrorPrinted);
@@ -352,6 +365,7 @@ uint8_t GBTLink::checkErrorsGBTDataID(const GBTData* gbtD)
   }
   uint8_t err = uint8_t(NoError);
   statistics.errorCounts[GBTLinkDecodingStat::ErrGBTWordNotRecognized]++;
+  gbtErrStatUpadated = true;
   if (needToPrintError(statistics.errorCounts[GBTLinkDecodingStat::ErrGBTWordNotRecognized])) {
     if (gbtD->isCableDiagnostic()) {
       printCableDiagnostic((GBTCableDiagnostic*)gbtD);
@@ -374,6 +388,7 @@ uint8_t GBTLink::checkErrorsTrailerWord(const GBTDataTrailer* gbtT)
   if (!gbtT->isDataTrailer()) {
     gbtT->printX();
     statistics.errorCounts[GBTLinkDecodingStat::ErrMissingGBTTrailer]++;
+    gbtErrStatUpadated = true;
     if (needToPrintError(statistics.errorCounts[GBTLinkDecodingStat::ErrMissingGBTTrailer])) {
       LOG(info) << describe() << ' ' << irHBF << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrMissingGBTTrailer];
       err |= uint8_t(ErrorPrinted);
@@ -394,6 +409,7 @@ uint8_t GBTLink::checkErrorsPacketDoneMissing(const GBTDataTrailer* gbtT, bool n
   uint8_t err = uint8_t(NoError);
   if (!gbtT || (!gbtT->packetDone && notEnd)) { // Done may be missing only in case of carry-over to new CRU page
     statistics.errorCounts[GBTLinkDecodingStat::ErrPacketDoneMissing]++;
+    gbtErrStatUpadated = true;
     if (needToPrintError(statistics.errorCounts[GBTLinkDecodingStat::ErrPacketDoneMissing])) {
       LOG(info) << describe() << ' ' << irHBF << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrPacketDoneMissing];
       err |= uint8_t(ErrorPrinted);
@@ -413,6 +429,7 @@ uint8_t GBTLink::checkErrorsLanesStops()
   if ((lanesActive & ~lanesStop)) {
     if (RDHUtils::getTriggerType(*lastRDH) != o2::trigger::SOT) { // only SOT trigger allows unstopped lanes?
       statistics.errorCounts[GBTLinkDecodingStat::ErrUnstoppedLanes]++;
+      gbtErrStatUpadated = true;
       if (needToPrintError(statistics.errorCounts[GBTLinkDecodingStat::ErrUnstoppedLanes])) {
         std::bitset<32> active(lanesActive), stopped(lanesStop);
         LOG(info) << describe() << ' ' << irHBF << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrUnstoppedLanes]
@@ -426,6 +443,7 @@ uint8_t GBTLink::checkErrorsLanesStops()
   // make sure all active lanes (except those in time-out) have sent some data
   if ((~lanesWithData & lanesActive) != lanesTimeOut) {
     statistics.errorCounts[GBTLinkDecodingStat::ErrNoDataForActiveLane]++;
+    gbtErrStatUpadated = true;
     if (needToPrintError(statistics.errorCounts[GBTLinkDecodingStat::ErrNoDataForActiveLane])) {
       std::bitset<32> withData(lanesWithData), active(lanesActive), timeOut(lanesTimeOut);
       LOG(info) << describe() << ' ' << irHBF << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrNoDataForActiveLane]
@@ -445,6 +463,7 @@ uint8_t GBTLink::checkErrorsDiagnosticWord(const GBTDiagnostic* gbtD)
   uint8_t err = uint8_t(NoError);
   if (RDHUtils::getMemorySize(lastRDH) != sizeof(RDH) + sizeof(GBTDiagnostic) || !gbtD->isDiagnosticWord()) { //
     statistics.errorCounts[GBTLinkDecodingStat::ErrMissingDiagnosticWord]++;
+    gbtErrStatUpadated = true;
     if (needToPrintError(statistics.errorCounts[GBTLinkDecodingStat::ErrMissingDiagnosticWord])) {
       gbtD->printX();
       LOG(info) << describe() << ' ' << irHBF << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrMissingDiagnosticWord];
@@ -463,6 +482,7 @@ uint8_t GBTLink::checkErrorsCableID(const GBTData* gbtD, uint8_t cableSW)
   uint8_t err = uint8_t(NoError);
   if (cableSW == 0xff) {
     statistics.errorCounts[GBTLinkDecodingStat::ErrWrongeCableID]++;
+    gbtErrStatUpadated = true;
     if (needToPrintError(statistics.errorCounts[GBTLinkDecodingStat::ErrWrongeCableID])) {
       gbtD->printX();
       LOG(info) << describe() << ' ' << irHBF << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrWrongeCableID] << ' ' << gbtD->getCableID();

--- a/Detectors/ITSMFT/common/reconstruction/src/RUDecodeData.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/RUDecodeData.cxx
@@ -54,8 +54,14 @@ void RUDecodeData::setROFInfo(ChipPixelData* chipData, const GBTLink* lnk)
 void RUDecodeData::fillChipStatistics(int icab, const ChipPixelData* chipData)
 {
   cableLinkPtr[icab]->chipStat.nHits += chipData->getData().size();
-  //cableLinkPtr[icab]->chipStat.addErrors(chipData->getErrorFlags(), chipData->getChipID(), verbosity);
-  auto action = cableLinkPtr[icab]->chipStat.addErrors(*chipData, verbosity);
+  uint32_t action = 0;
+  if (chipData->getErrorFlags()) {
+    cableLinkPtr[icab]->chipStat.addErrors(*chipData, verbosity);
+    auto compid = ChipError::composeID(cableLinkPtr[icab]->feeID, chipData->getChipID());
+    auto& chErr = chipErrorsTF[compid];
+    chErr.first++;
+    chErr.second |= chipData->getErrorFlags();
+  }
   if (action & ChipStat::ErrActDump) {
     linkHBFToDump[(uint64_t(cableLinkPtr[icab]->subSpec) << 32) + cableLinkPtr[icab]->hbfEntry] = cableLinkPtr[icab]->irHBF.orbit;
   }

--- a/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
@@ -136,6 +136,7 @@ void RawPixelDecoder<Mapping>::startNewTF(InputRecord& inputs)
   }
   for (auto& ru : mRUDecodeVec) {
     ru.clear();
+    // ru.chipErrorsTF.clear(); // will be cleared in the collectDecodingErrors
     ru.linkHBFToDump.clear();
   }
   setupLinks(inputs);

--- a/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/STFDecoderSpec.cxx
@@ -179,6 +179,10 @@ void STFDecoder<Mapping>::run(ProcessingContext& pc)
     mEstNROF = std::max(mEstNROF, size_t(clusROFVec.size() * 1.2));
   }
 
+  auto& linkErrors = pc.outputs().make<std::vector<GBTLinkDecodingStat>>(Output{orig, "LinkErrors", 0, Lifetime::Timeframe});
+  auto& decErrors = pc.outputs().make<std::vector<ChipError>>(Output{orig, "ChipErrors", 0, Lifetime::Timeframe});
+  mDecoder->collectDecodingErrors(linkErrors, decErrors);
+
   pc.outputs().snapshot(Output{orig, "PHYSTRIG", 0, Lifetime::Timeframe}, mDecoder->getExternalTriggers());
 
   if (mDumpOnError != int(GBTLink::RawDataDumps::DUMP_NONE)) {
@@ -293,6 +297,9 @@ DataProcessorSpec getSTFDecoderSpec(const STFDecoderInp& inp)
     outputs.emplace_back(inp.origin, "PATTERNS", 0, Lifetime::Timeframe);
   }
   outputs.emplace_back(inp.origin, "PHYSTRIG", 0, Lifetime::Timeframe);
+
+  outputs.emplace_back(inp.origin, "LinkErrors", 0, Lifetime::Timeframe);
+  outputs.emplace_back(inp.origin, "ChipErrors", 0, Lifetime::Timeframe);
 
   if (inp.askSTFDist) {
     for (auto& ins : inputs) { // mark input as optional in order not to block the workflow if our raw data happen to be missing in some TFs


### PR DESCRIPTION
@JianLIUhep (pinging also to @rpezzi for MFT)

o2-itsmft-stf-decoder-workflow will send 2 extra messages (example for ITS, same for MFT):

1) `{"ITS", "LinkErrors", 0} of the type `std::vector<o2::itsmft::GBTLinkDecodingStat>`
with GBT link decoding statistics. The `GBTLinkDecodingStat` is cumulated through the run but will be added to
the output of the given TF only if `GBTLinkDecodingStat::DecErrors` type error was detected for the given link in the given TF.

2) `{"ITS", "ChipErrors", 0}` of the type `std::vector<o2::itsmft::ChipError>` with Alpide decoding errors seen
in the given TF. ChipError for given chip (or feeID if the chip is not resolved, i.e. = -1) is cumulated over single
TF, providing the bit pattern of `ChipStat::DecErrors` and how many times this chip was in error in this TF.

To access the data in the QC:
```
auto linkErrors = pc.inputs().get<gsl::span<o2::itsmft::GBTLinkDecodingStat>>("linkerrors");
auto detErrors = pc.inputs().get<gsl::span<o2::itsmft::ChipError>>("decerrors");
for (const auto& le : linkErrors) {
  le.print();
}
for (const auto& de : decErrors) {
  LOGP(info, "err in FeeID:{:#x} Chip:{} ErrorBits {:#b}, {} errors in TF", de.getFEEID(), de.getChipID(), de.errors, de.nerrors);
}
```

For some real data (the GBT level errors are provoked for test reasons) it gives:
```
o2-raw-tf-reader-workflow --input-data raw519908/o2_rawtf_run00519908_tf00000001_epn174.tf --onlyDet ITS | o2-itsmft-stf-decoder-workflow --run 
...
[1379111:its-stf-decoder]: [00:05:35][INFO] Processing timeslice:0, tfCounter:1, firstTForbit:1856478654, runNumber:519908, creation:1656670621227, action:0
[1379111:its-stf-decoder]: [00:05:35][INFO] FEEID#0x612e Packet States Statistics (total packets: 384, triggers: 2432) | counts for triggers: b00001: 2304 | Decoding errors: 384 [RDH is stopped, but the time is not matching the stop packet: 384]
[1379111:its-stf-decoder]: [00:05:35][INFO] FEEID#0x612f Packet States Statistics (total packets: 384, triggers: 2432) | counts for triggers: b00001: 2304 | Decoding errors: 384 [RDH is stopped, but the time is not matching the stop packet: 384]
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x3106 Chip:1168 ErrorBits 0b1000000000000, 1 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x3013 Chip:-1 ErrorBits 0b100000000000000000, 1 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x410b Chip:4427 ErrorBits 0b1, 2304 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x410b Chip:4426 ErrorBits 0b1, 2304 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x410b Chip:4425 ErrorBits 0b1, 2304 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x410b Chip:4424 ErrorBits 0b1, 2304 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x410b Chip:4423 ErrorBits 0b1001, 2304 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x410b Chip:4422 ErrorBits 0b1, 2304 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x411b Chip:6219 ErrorBits 0b1, 2304 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x411b Chip:6218 ErrorBits 0b1, 2304 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x411b Chip:6217 ErrorBits 0b1, 2304 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x411b Chip:6216 ErrorBits 0b1, 2304 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x411b Chip:6215 ErrorBits 0b1001, 2304 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x411b Chip:6214 ErrorBits 0b1, 2304 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x5104 Chip:-1 ErrorBits 0b1000000000000000000000, 1 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x5005 Chip:7553 ErrorBits 0b1000000000000, 1 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x5005 Chip:7505 ErrorBits 0b1000000000000, 1 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x500e Chip:-1 ErrorBits 0b1000000000000000000000, 1 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x501e Chip:12384 ErrorBits 0b1, 2304 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x5120 Chip:12852 ErrorBits 0b1000000000000, 1 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x6016 Chip:19085 ErrorBits 0b1000000000000, 1 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x601a Chip:19877 ErrorBits 0b1, 33 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x601a Chip:19876 ErrorBits 0b10000000001, 34 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x601a Chip:19875 ErrorBits 0b1, 34 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x601a Chip:19874 ErrorBits 0b1001, 34 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x601a Chip:19873 ErrorBits 0b1, 34 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x601a Chip:19871 ErrorBits 0b10000000001, 35 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x601a Chip:-1 ErrorBits 0b10000, 7 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x601a Chip:19872 ErrorBits 0b1000000000000000010000000001, 94 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x6023 Chip:-1 ErrorBits 0b1000000000000000000000, 1 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] Done processing timeslice:0, tfCounter:1, firstTForbit:1856478654, runNumber:519908, creation:1656670621227, action:0

[1379111:its-stf-decoder]: [00:05:35][INFO] Processing timeslice:1, tfCounter:1201, firstTForbit:1856632254, runNumber:519908, creation:1656670634840, action:0
[1379111:its-stf-decoder]: [00:05:35][INFO] FEEID#0x612e Packet States Statistics (total packets: 768, triggers: 4864) | counts for triggers: b00001: 4608 | Decoding errors: 768 [RDH is stopped, but the time is not matching the stop packet: 768]
[1379111:its-stf-decoder]: [00:05:35][INFO] FEEID#0x612f Packet States Statistics (total packets: 768, triggers: 4864) | counts for triggers: b00001: 4608 | Decoding errors: 768 [RDH is stopped, but the time is not matching the stop packet: 768]
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x410b Chip:4427 ErrorBits 0b1, 2304 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x410b Chip:4426 ErrorBits 0b1, 2304 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x410b Chip:4425 ErrorBits 0b1, 2304 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x410b Chip:4424 ErrorBits 0b1, 2304 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x410b Chip:4423 ErrorBits 0b1, 2304 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x410b Chip:4422 ErrorBits 0b1, 2304 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x411b Chip:6219 ErrorBits 0b1, 2304 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x411b Chip:6218 ErrorBits 0b1, 2304 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x411b Chip:6217 ErrorBits 0b1, 2304 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x411b Chip:6216 ErrorBits 0b1, 2304 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x411b Chip:6215 ErrorBits 0b1, 2304 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x411b Chip:6214 ErrorBits 0b1, 2304 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] err in FeeID:0x501e Chip:12384 ErrorBits 0b1, 2304 errors in TF
[1379111:its-stf-decoder]: [00:05:35][INFO] Done processing timeslice:1, tfCounter:1201, firstTForbit:1856632254, runNumber:519908, creation:1656670634840, action:0
```
