### PR TITLE
TRD TRAP charge scaling configurable

### DIFF
--- a/Detectors/TRD/simulation/include/TRDSimulation/TrapSimulator.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/TrapSimulator.h
@@ -133,6 +133,7 @@ class TrapSimulator
   int getAdditionalBaseline() const { return mAdditionalBaseline; }
 
   void setUseFloatingPointForQ() { mUseFloatingPointForQ = true; }
+  void setChargeScalingFactor(int scale) { mScaleQ = (1UL << 32UL) / scale; }
 
   int getDetector() const { return mDetector; }; // Returns Chamber ID (0-539)
   int getRobPos() const { return mRobPos; };     // Returns ROB position (0-7)

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDTrapSimulatorSpec.h
@@ -44,6 +44,7 @@ class TRDDPLTrapSimulatorTask : public o2::framework::Task
   TrapConfig* mTrapConfig{nullptr};
   int mRunNumber{297595}; // run number to anchor simulation to.
   int mDigitDownscaling{1}; // only digits of every mDigitDownscaling-th trigger will be kept
+  int mChargeScalingFactor{-1}; // can be overwritten to set custom charge scaling factor for tracklets
   bool mUseFloatingPointForQ{false};
   bool mEnableOnlineGainCorrection{false};
   bool mUseMC{false}; // whether or not to use MC labels


### PR DESCRIPTION
Should come from TRAP config eventually, but for now to try different settings in simulations this is added as command line parameter