### PR TITLE
Set DPL CCDB fetcher default validation rate to 0

### DIFF
--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -221,7 +221,7 @@ std::string defaultConditionBackend()
 // get the default value for condition query rate
 int64_t defaultConditionQueryRate()
 {
-  return getenv("DPL_CONDITION_QUERY_RATE") ? std::stoll(getenv("DPL_CONDITION_QUERY_RATE")) : 1;
+  return getenv("DPL_CONDITION_QUERY_RATE") ? std::stoll(getenv("DPL_CONDITION_QUERY_RATE")) : 0;
 }
 
 void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext const& ctx)


### PR DESCRIPTION
This means that the objects will be cached at the beginning of the run and their validity will
not be checked afterwards (except for the objects which explicitly require frequent checks via
their ccdbParamSpec).
Behaviour can be overridden by either passing `--condition-tf-per-query <N> option` or by setting
`DPL_CONDITION_QUERY_RATE=<N>` env. var.

trivial, merging.