### PR TITLE
Fixed DCS ITS parser output to CCDB

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DCSParserSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DCSParserSpec.h
@@ -54,10 +54,6 @@ class ITSDCSParser : public Task
 
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
-  void endOfStream(EndOfStreamContext& ec) final;
-
-  void finalize(EndOfStreamContext* ec);
-  void stop() final;
 
   //////////////////////////////////////////////////////////////////
  private:
@@ -66,7 +62,7 @@ class ITSDCSParser : public Task
   void updateMemoryFromInputString(const std::string&);
   void saveToOutput();
   void resetMemory();
-  void pushToCCDB(EndOfStreamContext*);
+  void pushToCCDB(ProcessingContext&);
   void updateAndCheck(int&, const int);
   void updateAndCheck(short int&, const short int);
   void writeChipInfo(o2::dcs::DCSconfigObject_t&, const std::string&, const unsigned short int);

--- a/Detectors/ITSMFT/ITS/workflow/src/DCSParserSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/DCSParserSpec.cxx
@@ -60,7 +60,7 @@ void ITSDCSParser::run(ProcessingContext& pc)
   }
 
   if (this->mConfigDCS.size()) {
-    this->pushToCCDB(nullptr);
+    this->pushToCCDB(pc);
     this->mConfigDCS.clear();
   }
 
@@ -343,7 +343,7 @@ void ITSDCSParser::writeChipInfo(
 }
 
 //////////////////////////////////////////////////////////////////////////////
-void ITSDCSParser::pushToCCDB(EndOfStreamContext* ec)
+void ITSDCSParser::pushToCCDB(ProcessingContext& pc)
 {
   // Timestamps for CCDB entry
   long tstart = o2::ccdb::getCurrentTimestamp();
@@ -363,16 +363,15 @@ void ITSDCSParser::pushToCCDB(EndOfStreamContext* ec)
   auto image = o2::ccdb::CcdbApi::createObjectImage(&mConfigDCS, &info);
   info.setFileName(filename);
 
-  if (ec) { // send to ccdb-populator wf only if there is an EndOfStreamContext
-    LOG(info) << "Class Name: " << class_name << " | File Name: " << filename
-              << "\nSending to ccdb-populator the object " << info.getPath() << "/" << info.getFileName()
-              << " of size " << image->size() << " bytes, valid for "
-              << info.getStartValidityTimestamp() << " : "
-              << info.getEndValidityTimestamp();
+  // Send to ccdb-populator wf
+  LOG(info) << "Class Name: " << class_name << " | File Name: " << filename
+            << "\nSending to ccdb-populator the object " << info.getPath() << "/" << info.getFileName()
+            << " of size " << image->size() << " bytes, valid for "
+            << info.getStartValidityTimestamp() << " : "
+            << info.getEndValidityTimestamp();
 
-    ec->outputs().snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "DCS_CONFIG", 0}, *image);
-    ec->outputs().snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "DCS_CONFIG", 0}, info);
-  }
+  pc.outputs().snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "DCS_CONFIG", 0}, *image);
+  pc.outputs().snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "DCS_CONFIG", 0}, info);
 
   if (!mCcdbUrl.empty()) { // if url is specified, send object to ccdb from THIS wf
 
@@ -385,43 +384,6 @@ void ITSDCSParser::pushToCCDB(EndOfStreamContext* ec)
       info.getMetaData(), info.getStartValidityTimestamp(), info.getEndValidityTimestamp());
   }
 
-  return;
-}
-
-//////////////////////////////////////////////////////////////////////////////
-void ITSDCSParser::finalize(EndOfStreamContext* ec)
-{
-  if (ec) {
-    LOGF(info, "endOfStream report:", mSelfName);
-  }
-
-  if (this->mConfigDCS.size()) {
-    this->pushToCCDB(ec);
-  }
-
-  return;
-}
-
-//////////////////////////////////////////////////////////////////////////////
-// fairMQ functionality; called automatically when the DDS stops processing
-void ITSDCSParser::stop()
-{
-  if (!mStopped) {
-    this->finalize(nullptr);
-    this->mStopped = true;
-  }
-  return;
-}
-
-//////////////////////////////////////////////////////////////////////////////
-// O2 functionality allowing to do post-processing when the upstream device
-// tells that there will be no more input data
-void ITSDCSParser::endOfStream(EndOfStreamContext& ec)
-{
-  if (!mStopped) {
-    this->finalize(&ec);
-    this->mStopped = true;
-  }
   return;
 }
 

--- a/Detectors/ITSMFT/ITS/workflow/src/DCSParserSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/DCSParserSpec.cxx
@@ -370,10 +370,12 @@ void ITSDCSParser::pushToCCDB(ProcessingContext& pc)
             << info.getStartValidityTimestamp() << " : "
             << info.getEndValidityTimestamp();
 
-  pc.outputs().snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "DCS_CONFIG", 0}, *image);
-  pc.outputs().snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "DCS_CONFIG", 0}, info);
+  if (mCcdbUrl.empty()) {
 
-  if (!mCcdbUrl.empty()) { // if url is specified, send object to ccdb from THIS wf
+    pc.outputs().snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "DCS_CONFIG", 0}, *image);
+    pc.outputs().snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "DCS_CONFIG", 0}, info);
+
+  } else { // if url is specified, send object to ccdb from THIS wf
 
     LOG(info) << "Sending object " << info.getFileName() << " to " << mCcdbUrl << "/browse/"
               << info.getPath() << " from the ITS string parser workflow";
@@ -396,8 +398,8 @@ DataProcessorSpec getITSDCSParserSpec()
   inputs.emplace_back("nameString", detOrig, "DCS_CONFIG_NAME", 0, Lifetime::Timeframe);
 
   std::vector<OutputSpec> outputs;
-  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "DCS_CONFIG"});
-  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "DCS_CONFIG"});
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "DCS_CONFIG"}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "DCS_CONFIG"}, Lifetime::Sporadic);
 
   return DataProcessorSpec{
     "its-parser",
@@ -405,7 +407,7 @@ DataProcessorSpec getITSDCSParserSpec()
     outputs,
     AlgorithmSpec{adaptFromTask<o2::its::ITSDCSParser>()},
     Options{
-      {"ccdb-url", VariantType::String, "", {"CCDB url, default is empty (i.e. no upload to CCDB)"}}}};
+      {"ccdb-url", VariantType::String, "", {"CCDB url, default is empty (i.e. send output to CCDB populator workflow)"}}}};
 }
 } // namespace its
 } // namespace o2


### PR DESCRIPTION
Changing output of DCS ITS parser workflow so that it sends output to CCDB populator workflow. Workflow can now be run as:

```
CHANFROM="type=sub,method=connect,address=tcp://127.0.0.1:5556,rateLogging=1,transport=zeromq"
CHANACK="type=push,method=connect,address=tcp://127.0.0.1:5557,Logging=1,transport=zeromq"

o2-dcs-config-proxy --subscribe-to "$CHANFROM" --acknowlege-to "$CHANACK" | \
o2-its-dcs-parser-workflow -b | \
o2-calibration-ccdb-populator-workflow --ccdb-path="http://ccdb-test.cern.ch:8080" -b
```