### PR TITLE
DPL: Speed up DeviceSpecHelper::dataProcessorSpecs2DeviceSpecs

### DIFF
--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -780,7 +780,6 @@ void WorkflowHelpers::constructGraph(const WorkflowSpec& workflow,
   // This is the state. Oif is the iterator I use for the searches.
   std::vector<LogicalOutputInfo> availableOutputsInfo;
   auto const& constOutputs = outputs; // const version of the outputs
-  decltype(availableOutputsInfo.begin()) oif;
   // Forwards is a local cache to avoid adding forwards before time.
   std::vector<LogicalOutputInfo> forwards;
 
@@ -799,113 +798,6 @@ void WorkflowHelpers::constructGraph(const WorkflowSpec& workflow,
     }
   };
 
-  // Notice that if the output is actually a forward, we need to store that
-  // information so that when we add it at device level we know which output
-  // channel we need to connect it too.
-  auto hasMatchingOutputFor = [&workflow, &constOutputs,
-                               &availableOutputsInfo, &oif,
-                               &forwardedInputsInfo](size_t ci, size_t ii) {
-    assert(ci < workflow.size());
-    assert(ii < workflow[ci].inputs.size());
-    auto& input = workflow[ci].inputs[ii];
-    size_t lastIndex = -1;
-    auto matcher = [&input, &constOutputs, &lastIndex](const LogicalOutputInfo& outputInfo) -> bool {
-      if (outputInfo.enabled == false) {
-        return false;
-      }
-      if (lastIndex == outputInfo.outputGlobalIndex) {
-        // If we have already tried to match this output,
-        // we don't need to try again, since the find_if
-        // would have already stopped at the first match.
-        return false;
-      }
-      lastIndex = outputInfo.outputGlobalIndex;
-      auto& output = constOutputs[outputInfo.outputGlobalIndex];
-      return DataSpecUtils::match(input, output);
-    };
-    oif = std::find_if(availableOutputsInfo.begin(),
-                       availableOutputsInfo.end(),
-                       matcher);
-    if (oif != availableOutputsInfo.end() && oif->forward) {
-      LogicalForwardInfo forward;
-      forward.consumer = ci;
-      forward.inputLocalIndex = ii;
-      forward.outputGlobalIndex = oif->outputGlobalIndex;
-      forwardedInputsInfo.emplace_back(LogicalForwardInfo{ci, ii, oif->outputGlobalIndex});
-    }
-    return oif != availableOutputsInfo.end();
-  };
-
-  int eraseCount = 0;
-  // We have consumed the input, therefore we remove it from the list.
-  // We will insert the forwarded inputs only at the end of the iteration.
-  auto findNextOutputFor = [&availableOutputsInfo, &constOutputs, &oif, &workflow, &eraseCount](
-                             size_t ci, size_t& ii) {
-    auto& input = workflow[ci].inputs[ii];
-    size_t lastIndex = -1;
-    auto matcher = [&input, &constOutputs, &lastIndex](const LogicalOutputInfo& outputInfo) -> bool {
-      if (outputInfo.enabled == false) {
-        return false;
-      }
-      if (lastIndex == outputInfo.outputGlobalIndex) {
-        // If we have already tried to match this output,
-        // we don't need to try again, since the find_if
-        // would have already stopped at the first match.
-        return false;
-      }
-      auto& output = constOutputs[outputInfo.outputGlobalIndex];
-      return DataSpecUtils::match(input, output);
-    };
-    if (oif != availableOutputsInfo.end()) {
-      oif->enabled = false;
-      eraseCount++;
-      oif = std::find_if(oif + 1, availableOutputsInfo.end(), matcher);
-    }
-    return oif;
-  };
-
-  auto numberOfInputsFor = [&workflow](size_t ci) {
-    auto& consumer = workflow[ci];
-    return consumer.inputs.size();
-  };
-
-  auto maxInputTimeslicesFor = [&workflow](size_t pi) {
-    auto& processor = workflow[pi];
-    return processor.maxInputTimeslices;
-  };
-
-  // Trivial, but they make reading easier..
-  auto getOutputAssociatedProducer = [&oif]() {
-    return oif->specIndex;
-  };
-
-  // Trivial, but they make reading easier..
-  auto getAssociateOutput = [&oif]() {
-    return oif->outputGlobalIndex;
-  };
-
-  auto isForward = [&oif]() {
-    return oif->forward;
-  };
-
-  // Trivial but makes reasing easier in the outer loop.
-  auto createEdge = [&logicalEdges](size_t producer,
-                                    size_t consumer,
-                                    size_t tpi,
-                                    size_t ptpi,
-                                    size_t uniqueOutputId,
-                                    size_t matchingInputInConsumer,
-                                    bool doForward) {
-    logicalEdges.emplace_back(
-      DeviceConnectionEdge{producer,
-                           consumer,
-                           tpi,
-                           ptpi,
-                           uniqueOutputId,
-                           matchingInputInConsumer,
-                           doForward});
-  };
-
   auto errorDueToMissingOutputFor = [&workflow, &constOutputs](size_t ci, size_t ii) {
     auto input = workflow[ci].inputs[ii];
     std::ostringstream str;
@@ -917,31 +809,6 @@ void WorkflowHelpers::constructGraph(const WorkflowSpec& workflow,
     }
 
     throw std::runtime_error(str.str());
-  };
-
-  // Whenever we have a set of forwards, we need to append it
-  // the the global list of outputs, so that they can be matched
-  // and we need to add a ForwardRoute for the current consumer
-  // because it is the one who will actually do the forwarding.
-  auto appendForwardsToPossibleOutputs = [&availableOutputsInfo, &forwards]() {
-    for (auto& forward : forwards) {
-      availableOutputsInfo.push_back(forward);
-    }
-  };
-
-  // Given we create a forward every time we match and input and an
-  // output, having no forwards means we did not find any matching.
-  auto noMatchingOutputFound = [&forwards]() {
-    return forwards.empty();
-  };
-
-  // Forwards is basically a cache to record
-  auto newEdgeBetweenDevices = [&forwards]() {
-    forwards.clear();
-  };
-
-  auto forwardOutputFrom = [&forwards](size_t consumer, size_t uniqueOutputId) {
-    forwards.push_back(LogicalOutputInfo{consumer, uniqueOutputId, true});
   };
 
   // This is the outer loop
@@ -957,32 +824,41 @@ void WorkflowHelpers::constructGraph(const WorkflowSpec& workflow,
   // parallel pipeline and add an edge for each.
   enumerateAvailableOutputs();
 
+  std::vector<bool> matches(constOutputs.size());
   for (size_t consumer = 0; consumer < workflow.size(); ++consumer) {
-    for (size_t input = 0; input < numberOfInputsFor(consumer); ++input) {
-      newEdgeBetweenDevices();
-
-      while (hasMatchingOutputFor(consumer, input)) {
-        auto producer = getOutputAssociatedProducer();
-        auto uniqueOutputId = getAssociateOutput();
-        for (size_t tpi = 0; tpi < maxInputTimeslicesFor(consumer); ++tpi) {
-          for (size_t ptpi = 0; ptpi < maxInputTimeslicesFor(producer); ++ptpi) {
-            createEdge(producer, consumer, tpi, ptpi, uniqueOutputId, input, isForward());
-          }
-          forwardOutputFrom(consumer, uniqueOutputId);
-        }
-        findNextOutputFor(consumer, input);
-        if (((eraseCount + 1) % 256) == 0) {
-          availableOutputsInfo.erase(
-            std::remove_if(availableOutputsInfo.begin(), availableOutputsInfo.end(), [](auto& info) {
-              return info.enabled == false;
-          }),
-            availableOutputsInfo.end());
-        }
+    for (size_t input = 0; input < workflow[consumer].inputs.size(); ++input) {
+      forwards.clear();
+      for (size_t i = 0; i < constOutputs.size(); i++) {
+        matches[i] = DataSpecUtils::match(workflow[consumer].inputs[input], constOutputs[i]);
       }
-      if (noMatchingOutputFound()) {
+
+      for (size_t i = 0; i < availableOutputsInfo.size(); i++) {
+        // Notice that if the output is actually a forward, we need to store that information so that when we add it at device level we know which output channel we need to connect it too.
+        if (!matches[availableOutputsInfo[i].outputGlobalIndex]) {
+          continue;
+        }
+        auto* oif = &availableOutputsInfo[i];
+        if (oif->forward) {
+          forwardedInputsInfo.emplace_back(LogicalForwardInfo{consumer, input, oif->outputGlobalIndex});
+        }
+        auto producer = oif->specIndex;
+        auto uniqueOutputId = oif->outputGlobalIndex;
+        for (size_t tpi = 0; tpi < workflow[consumer].maxInputTimeslices; ++tpi) {
+          for (size_t ptpi = 0; ptpi < workflow[producer].maxInputTimeslices; ++ptpi) {
+            logicalEdges.emplace_back(DeviceConnectionEdge{producer, consumer, tpi, ptpi, uniqueOutputId, input, oif->forward});
+          }
+        }
+        forwards.push_back(LogicalOutputInfo{consumer, uniqueOutputId, true});
+        // We have consumed the input, therefore we remove it from the list. We will insert the forwarded inputs only at the end of the iteration.
+        oif->enabled = false;
+      }
+      if (forwards.empty()) {
         errorDueToMissingOutputFor(consumer, input);
       }
-      appendForwardsToPossibleOutputs();
+      availableOutputsInfo.erase(std::remove_if(availableOutputsInfo.begin(), availableOutputsInfo.end(), [](auto& info) { return info.enabled == false; }), availableOutputsInfo.end());
+      for (auto& forward : forwards) {
+        availableOutputsInfo.push_back(forward);
+      }
     }
   }
 }


### PR DESCRIPTION
Significantly speeds up the topology generation via `DeviceSpecHelpers::dataProcessorSpecs2DeviceSpecs`.
My testcase goes down from over 1 hour to ~10 ms.
Output is identical.
Had to inline plenty of the lambda functions to understand the code and run debugger and profiler in proper way. This could be undone, but in my opinion it is clear enough as is, and could be cleaned up later if desired.
Changes are mostly:
- Fix some bugs leading to duplicate computation of the same value.
- Precompute matching of all inputs v.s. all "real" outputs, and then just check result in indexArray.
- Don't try to match the same input twice.
- Don't clean up more often than necessary.
- Be more explicit in what you do, can be optimized slightly better than all the std::.... stuff