### PR TITLE
Add MC labels to ITS seeding vertices

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -65,6 +65,7 @@ class TimeFrame
   const Vertex& getPrimaryVertex(const int) const;
   gsl::span<const Vertex> getPrimaryVertices(int tf) const;
   gsl::span<const Vertex> getPrimaryVertices(int romin, int romax) const;
+  gsl::span<const std::vector<MCCompLabel>> getPrimaryVerticesLabels(const int rof) const;
   gsl::span<const std::array<float, 2>> getPrimaryVerticesXAlpha(int tf) const;
   void fillPrimaryVerticesXandAlpha();
   int getPrimaryVerticesNum(int rofID = -1) const;
@@ -128,7 +129,9 @@ class TimeFrame
   std::vector<std::vector<std::vector<int>>>& getCellsNeighbours();
   std::vector<Road>& getRoads();
   std::vector<TrackITSExt>& getTracks(int rof) { return mTracks[rof]; }
-  std::vector<MCCompLabel>& getTracksLabel(int rof) { return mTracksLabel[rof]; }
+  std::vector<MCCompLabel>& getTracksLabel(const int rof) { return mTracksLabel[rof]; }
+  std::vector<MCCompLabel>& getLinesLabel(const int rof) { return mLinesLabels[rof]; }
+  std::vector<std::vector<MCCompLabel>>& getVerticesLabels() { return mVerticesLabels; }
 
   int getNumberOfClusters() const;
   int getNumberOfCells() const;
@@ -146,6 +149,7 @@ class TimeFrame
   std::vector<Line>& getLines(int tf);
   std::vector<ClusterLines>& getTrackletClusters(int tf);
   gsl::span<const Tracklet> getFoundTracklets(int rofId, int combId) const;
+  gsl::span<const MCCompLabel> getLabelsFoundTracklets(int rofId, int combId) const;
   gsl::span<int> getNTrackletsCluster(int rofId, int combId);
   // \Vertexer
 
@@ -224,6 +228,8 @@ class TimeFrame
   std::vector<std::vector<Line>> mLines;
   std::vector<std::vector<ClusterLines>> mTrackletClusters;
   std::vector<std::vector<int>> mTrackletsIndexROf;
+  std::vector<std::vector<MCCompLabel>> mLinesLabels;
+  std::vector<std::vector<MCCompLabel>> mVerticesLabels;
   // \Vertexer
 };
 
@@ -235,6 +241,14 @@ inline gsl::span<const Vertex> TimeFrame::getPrimaryVertices(int rof) const
   const int stop_idx = rof >= mNrof - 1 ? mNrof : rof + 1;
   int delta = mMultiplicityCutMask[rof] ? mROframesPV[stop_idx] - start : 0; // return empty span if Rof is excluded
   return {&mPrimaryVertices[start], static_cast<gsl::span<const Vertex>::size_type>(delta)};
+}
+
+inline gsl::span<const std::vector<MCCompLabel>> TimeFrame::getPrimaryVerticesLabels(const int rof) const
+{
+  const int start = mROframesPV[rof];
+  const int stop_idx = rof >= mNrof - 1 ? mNrof : rof + 1;
+  int delta = mMultiplicityCutMask[rof] ? mROframesPV[stop_idx] - start : 0; // return empty span if Rof is excluded
+  return {&mVerticesLabels[start], static_cast<gsl::span<const Vertex>::size_type>(delta)};
 }
 
 inline gsl::span<const Vertex> TimeFrame::getPrimaryVertices(int romin, int romax) const
@@ -454,6 +468,15 @@ inline gsl::span<const Tracklet> TimeFrame::getFoundTracklets(int rofId, int com
   }
   auto startIdx{mNTrackletsPerROf[combId][rofId]};
   return {&mTracklets[combId][startIdx], static_cast<gsl::span<Tracklet>::size_type>(mNTrackletsPerROf[combId][rofId + 1] - startIdx)};
+}
+
+inline gsl::span<const MCCompLabel> TimeFrame::getLabelsFoundTracklets(int rofId, int combId) const
+{
+  if (rofId < 0 || rofId >= mNrof || !hasMCinformation()) {
+    return gsl::span<const MCCompLabel>();
+  }
+  auto startIdx{mNTrackletsPerROf[combId][rofId]};
+  return {&mTrackletLabels[combId][startIdx], static_cast<gsl::span<Tracklet>::size_type>(mNTrackletsPerROf[combId][rofId + 1] - startIdx)};
 }
 
 inline int TimeFrame::getNumberOfClusters() const

--- a/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
@@ -207,8 +207,11 @@ void TimeFrame::initialise(const int iteration, const TrackingParameters& trkPar
   if (iteration == 0) {
     mTracks.clear();
     mTracksLabel.clear();
+    mLinesLabels.clear();
+    mVerticesLabels.clear();
     mTracks.resize(mNrof);
     mTracksLabel.resize(mNrof);
+    mLinesLabels.resize(mNrof);
     mCells.resize(trkParam.CellsPerRoad());
     mCellsLookupTable.resize(trkParam.CellsPerRoad() - 1);
     mCellsNeighbours.resize(trkParam.CellsPerRoad() - 1);

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -42,6 +42,7 @@ void trackleterKernelSerial(
   std::vector<Tracklet>& Tracklets,
   gsl::span<int> foundTracklets,
   const IndexTableUtils& utils,
+  const int rof,
   const int maxTrackletsPerCluster = static_cast<int>(2e3))
 {
   const int PhiBins{utils.getNphiBins()};
@@ -67,9 +68,9 @@ void trackleterKernelSerial(
           if (o2::gpu::GPUCommonMath::Abs(currentCluster.phi - nextCluster.phi) < phiCut) {
             if (storedTracklets < maxTrackletsPerCluster) {
               if constexpr (Mode == TrackletMode::Layer0Layer1) {
-                Tracklets.emplace_back(iNextLayerClusterIndex, iCurrentLayerClusterIndex, nextCluster, currentCluster);
+                Tracklets.emplace_back(iNextLayerClusterIndex, iCurrentLayerClusterIndex, nextCluster, currentCluster, rof, rof);
               } else {
-                Tracklets.emplace_back(iCurrentLayerClusterIndex, iNextLayerClusterIndex, currentCluster, nextCluster);
+                Tracklets.emplace_back(iCurrentLayerClusterIndex, iNextLayerClusterIndex, currentCluster, nextCluster, rof, rof);
               }
               ++storedTracklets;
             }
@@ -89,6 +90,8 @@ void trackletSelectionKernelSerial(
   const gsl::span<int> foundTracklets01,
   const gsl::span<int> foundTracklets12,
   std::vector<Line>& destTracklets,
+  const gsl::span<const MCCompLabel>& trackletLabels,
+  std::vector<MCCompLabel>& linesLabels,
   const float tanLambdaCut = 0.025f,
   const float phiCut = 0.005f,
   const int maxTracklets = static_cast<int>(1e2))
@@ -104,6 +107,9 @@ void trackletSelectionKernelSerial(
         if (!usedTracklets[iTracklet01] && deltaTanLambda < tanLambdaCut && deltaPhi < phiCut && validTracklets != maxTracklets) {
           usedTracklets[iTracklet01] = true;
           destTracklets.emplace_back(tracklets01[iTracklet01], clusters0.data(), clusters1.data());
+          if (trackletLabels.size()) {
+            linesLabels.emplace_back(trackletLabels[iTracklet01]);
+          }
           ++validTracklets;
         }
       }
@@ -144,6 +150,7 @@ void VertexerTraits::computeTracklets()
       mTimeFrame->getTracklets()[0],
       mTimeFrame->getNTrackletsCluster(rofId, 0),
       mIndexTableUtils,
+      rofId,
       mVrtParams.maxTrackletsPerCluster);
     trackleterKernelSerial<TrackletMode::Layer1Layer2>(
       mTimeFrame->getClustersOnLayer(rofId, 2),
@@ -153,11 +160,33 @@ void VertexerTraits::computeTracklets()
       mTimeFrame->getTracklets()[1],
       mTimeFrame->getNTrackletsCluster(rofId, 1),
       mIndexTableUtils,
+      rofId,
       mVrtParams.maxTrackletsPerCluster);
     mTimeFrame->getNTrackletsROf(rofId, 0) = std::accumulate(mTimeFrame->getNTrackletsCluster(rofId, 0).begin(), mTimeFrame->getNTrackletsCluster(rofId, 0).end(), 0);
     mTimeFrame->getNTrackletsROf(rofId, 1) = std::accumulate(mTimeFrame->getNTrackletsCluster(rofId, 1).begin(), mTimeFrame->getNTrackletsCluster(rofId, 1).end(), 0);
   }
   mTimeFrame->computeTrackletsScans();
+
+  /// Create tracklets labels for L0-L1, information is as flat as in tracklets vector (no rofId)
+  if (mTimeFrame->hasMCinformation()) {
+    for (auto& trk : mTimeFrame->getTracklets()[0]) {
+      MCCompLabel label;
+      int sortedId0{mTimeFrame->getSortedIndex(trk.rof[0], 0, trk.firstClusterIndex)};
+      int sortedId1{mTimeFrame->getSortedIndex(trk.rof[0], 1, trk.secondClusterIndex)};
+      for (auto& lab0 : mTimeFrame->getClusterLabels(0, mTimeFrame->getClusters()[0][sortedId0].clusterId)) {
+        for (auto& lab1 : mTimeFrame->getClusterLabels(1, mTimeFrame->getClusters()[1][sortedId1].clusterId)) {
+          if (lab0 == lab1 && lab0.isValid()) {
+            label = lab0;
+            break;
+          }
+        }
+        if (label.isValid()) {
+          break;
+        }
+      }
+      mTimeFrame->getTrackletsLabel(0).emplace_back(label);
+    }
+  }
 
 #ifdef VTX_DEBUG
   // Dump on file
@@ -208,6 +237,8 @@ void VertexerTraits::computeTrackletMatching()
       mTimeFrame->getNTrackletsCluster(rofId, 0),
       mTimeFrame->getNTrackletsCluster(rofId, 1),
       mTimeFrame->getLines(rofId),
+      mTimeFrame->getLabelsFoundTracklets(rofId, 0),
+      mTimeFrame->getLinesLabel(rofId),
       mVrtParams.tanLambdaCut,
       mVrtParams.phiCut);
   }
@@ -252,23 +283,23 @@ void VertexerTraits::computeVertices()
   for (int rofId{0}; rofId < mTimeFrame->getNrof(); ++rofId) {
     const int numTracklets{static_cast<int>(mTimeFrame->getLines(rofId).size())};
     std::vector<bool> usedTracklets(numTracklets, false);
-    for (int tracklet1{0}; tracklet1 < numTracklets; ++tracklet1) {
-      if (usedTracklets[tracklet1]) {
+    for (int line1{0}; line1 < numTracklets; ++line1) {
+      if (usedTracklets[line1]) {
         continue;
       }
-      for (int tracklet2{tracklet1 + 1}; tracklet2 < numTracklets; ++tracklet2) {
-        if (usedTracklets[tracklet2]) {
+      for (int line2{line1 + 1}; line2 < numTracklets; ++line2) {
+        if (usedTracklets[line2]) {
           continue;
         }
-        if (Line::getDCA(mTimeFrame->getLines(rofId)[tracklet1], mTimeFrame->getLines(rofId)[tracklet2]) < mVrtParams.pairCut) {
-          mTimeFrame->getTrackletClusters(rofId).emplace_back(tracklet1, mTimeFrame->getLines(rofId)[tracklet1], tracklet2, mTimeFrame->getLines(rofId)[tracklet2]);
+        if (Line::getDCA(mTimeFrame->getLines(rofId)[line1], mTimeFrame->getLines(rofId)[line2]) < mVrtParams.pairCut) {
+          mTimeFrame->getTrackletClusters(rofId).emplace_back(line1, mTimeFrame->getLines(rofId)[line1], line2, mTimeFrame->getLines(rofId)[line2]);
           std::array<float, 3> tmpVertex{mTimeFrame->getTrackletClusters(rofId).back().getVertex()};
           if (tmpVertex[0] * tmpVertex[0] + tmpVertex[1] * tmpVertex[1] > 4.f) {
             mTimeFrame->getTrackletClusters(rofId).pop_back();
             break;
           }
-          usedTracklets[tracklet1] = true;
-          usedTracklets[tracklet2] = true;
+          usedTracklets[line1] = true;
+          usedTracklets[line2] = true;
           for (int tracklet3{0}; tracklet3 < numTracklets; ++tracklet3) {
             if (usedTracklets[tracklet3]) {
               continue;
@@ -332,6 +363,12 @@ void VertexerTraits::computeVertices()
                                mTimeFrame->getTrackletClusters(rofId)[iCluster].getSize(),         // Contributors
                                mTimeFrame->getTrackletClusters(rofId)[iCluster].getAvgDistance2(), // In place of chi2
                                rofId);
+        if (mTimeFrame->hasMCinformation()) {
+          mTimeFrame->getVerticesLabels().emplace_back();
+          for (auto& index : mTimeFrame->getTrackletClusters(rofId)[iCluster].getLabels()) {
+            mTimeFrame->getVerticesLabels().back().push_back(mTimeFrame->getLinesLabel(rofId)[index]); // then we can use nContributors from vertices to get the labels
+          }
+        }
       }
     }
     std::vector<Vertex> vertices;

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/TrackReaderSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/TrackReaderSpec.h
@@ -50,6 +50,7 @@ class TrackReader : public o2::framework::Task
   std::vector<Vertex> mVertices, *mVerticesInp = &mVertices;
   std::vector<int> mClusInd, *mClusIndInp = &mClusInd;
   std::vector<o2::MCCompLabel> mMCTruth, *mMCTruthInp = &mMCTruth;
+  std::vector<o2::MCCompLabel> mMCVertTruth, *mMCVTruthInp = &mMCTruth;
 
   o2::header::DataOrigin mOrigin = o2::header::gDataOriginITS;
 
@@ -65,6 +66,7 @@ class TrackReader : public o2::framework::Task
   std::string mVertexBranchName = "Vertices";
   std::string mVertexROFBranchName = "VerticesROF";
   std::string mTrackMCTruthBranchName = "ITSTrackMCTruth";
+  std::string mTrackMCVertTruthBranchName = "ITSVertexMCTruth";
 };
 
 /// create a processor spec

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackReaderSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackReaderSpec.cxx
@@ -51,6 +51,7 @@ void TrackReader::run(ProcessingContext& pc)
   pc.outputs().snapshot(Output{"ITS", "VERTICESROF", 0, Lifetime::Timeframe}, mVerticesROFRec);
   if (mUseMC) {
     pc.outputs().snapshot(Output{mOrigin, "TRACKSMCTR", 0, Lifetime::Timeframe}, mMCTruth);
+    pc.outputs().snapshot(Output{mOrigin, "VERTICESMCTR", 0, Lifetime::Timeframe}, mMCVertTruth);
   }
 
   if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
@@ -102,6 +103,7 @@ DataProcessorSpec getITSTrackReaderSpec(bool useMC)
   outputSpec.emplace_back("ITS", "VERTICESROF", 0, Lifetime::Timeframe);
   if (useMC) {
     outputSpec.emplace_back("ITS", "TRACKSMCTR", 0, Lifetime::Timeframe);
+    outputSpec.emplace_back("ITS", "VERTICESMCTR", 0, Lifetime::Timeframe);
   }
 
   return DataProcessorSpec{

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackWriterSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackWriterSpec.cxx
@@ -65,6 +65,10 @@ DataProcessorSpec getTrackWriterSpec(bool useMC)
                                                              "ITSTrackMCTruth",
                                                              (useMC ? 1 : 0), // one branch if mc labels enabled
                                                              ""},
+                                BranchDefinition<LabelsType>{InputSpec{"labelsVertices", "ITS", "VERTICESMCTR", 0},
+                                                             "ITSVertexMCTruth",
+                                                             (useMC ? 1 : 0), // one branch if mc labels enabled
+                                                             ""},
                                 BranchDefinition<ROFRecLblT>{InputSpec{"MC2ROframes", "ITS", "ITSTrackMC2ROF", 0},
                                                              "ITSTracksMC2ROF",
                                                              (useMC ? 1 : 0), // one branch if mc labels enabled

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -181,8 +181,10 @@ void TrackerDPL::run(ProcessingContext& pc)
   std::vector<o2::its::TrackITSExt> tracks;
   auto& allClusIdx = pc.outputs().make<std::vector<int>>(Output{"ITS", "TRACKCLSID", 0, Lifetime::Timeframe});
   std::vector<o2::MCCompLabel> trackLabels;
+  std::vector<MCCompLabel> verticesLabels;
   auto& allTracks = pc.outputs().make<std::vector<o2::its::TrackITS>>(Output{"ITS", "TRACKS", 0, Lifetime::Timeframe});
   std::vector<o2::MCCompLabel> allTrackLabels;
+  std::vector<o2::MCCompLabel> allVerticesLabels;
 
   auto& vertROFvec = pc.outputs().make<std::vector<o2::itsmft::ROFRecord>>(Output{"ITS", "VERTICESROF", 0, Lifetime::Timeframe});
   auto& vertices = pc.outputs().make<std::vector<Vertex>>(Output{"ITS", "VERTICES", 0, Lifetime::Timeframe});
@@ -224,12 +226,17 @@ void TrackerDPL::run(ProcessingContext& pc)
       auto vtxSpan = timeFrame->getPrimaryVertices(iRof);
       vtxROF.setNEntries(vtxSpan.size());
       bool selROF = vtxSpan.size() == 0;
-      for (auto& v : vtxSpan) {
+      for (auto iV{0}; iV < vtxSpan.size(); ++iV) {
+        auto& v = vtxSpan[iV];
         if (multEstConf.isVtxMultCutRequested() && !multEstConf.isPassingVtxMultCut(v.getNContributors())) {
           continue; // skip vertex of unwanted multiplicity
         }
         selROF = true;
         vertices.push_back(v);
+        if (mIsMC) {
+          auto vLabels = timeFrame->getPrimaryVerticesLabels(iRof)[iV];
+          std::copy(vLabels.begin(), vLabels.end(), std::back_inserter(allVerticesLabels));
+        }
       }
       if (processingMask[iRof] && !selROF) { // passed selection in clusters and not in vertex multiplicity
         LOG(debug) << fmt::format("ROF {} rejected by the vertex multiplicity selection [{},{}]",
@@ -298,7 +305,10 @@ void TrackerDPL::run(ProcessingContext& pc)
     LOGP(info, "ITSTracker pushed {} tracks and {} vertices", allTracks.size(), vertices.size());
     if (mIsMC) {
       LOGP(info, "ITSTracker pushed {} track labels", allTrackLabels.size());
+      LOGP(info, "ITSTracker pushed {} vertex labels", allVerticesLabels.size());
+
       pc.outputs().snapshot(Output{"ITS", "TRACKSMCTR", 0, Lifetime::Timeframe}, allTrackLabels);
+      pc.outputs().snapshot(Output{"ITS", "VERTICESMCTR", 0, Lifetime::Timeframe}, allVerticesLabels);
       pc.outputs().snapshot(Output{"ITS", "ITSTrackMC2ROF", 0, Lifetime::Timeframe}, mc2rofs);
     }
   }
@@ -379,6 +389,7 @@ DataProcessorSpec getTrackerSpec(bool useMC, int trgType, const std::string& trM
   if (useMC) {
     inputs.emplace_back("labels", "ITS", "CLUSTERSMCTR", 0, Lifetime::Timeframe);
     inputs.emplace_back("MC2ROframes", "ITS", "CLUSTERSMC2ROF", 0, Lifetime::Timeframe);
+    outputs.emplace_back("ITS", "VERTICESMCTR", 0, Lifetime::Timeframe);
     outputs.emplace_back("ITS", "TRACKSMCTR", 0, Lifetime::Timeframe);
     outputs.emplace_back("ITS", "ITSTrackMC2ROF", 0, Lifetime::Timeframe);
     outputs.emplace_back("ITS", "VERTICES", 0, Lifetime::Timeframe);


### PR DESCRIPTION
@shahor02 : I restored a mechanism to associate MC labels to seeding vertices. For the time being my goal is to keep all the labels associated to tracklets contributing to a vertex.
In this way it should be easy to track merged vertices too.

~~This still has to be tested (compiling locally), I firstly wanted to ask if the syntax to store them into file is correct and safe.~~

~~**edit**: I tested locally, I see no labels in output file. I am definitely missing something on how to store data with DPL. Investigating.~~