### PR TITLE
ITS/MFT decoder fix for HBF triggers split over CRU pages [O2-3093]

### DIFF
--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/GBTLink.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/GBTLink.h
@@ -140,13 +140,13 @@ struct GBTLink {
  private:
   bool needToPrintError(uint32_t count) { return verbosity == Silent ? false : (verbosity > VerboseErrors || count == 1); }
   void discardData() { rawData.setDone(); }
-  void printTrigger(const GBTTrigger* gbtTrg);
-  void printHeader(const GBTDataHeader* gbtH);
-  void printHeader(const GBTDataHeaderL* gbtH);
-  void printTrailer(const GBTDataTrailer* gbtT);
-  void printDiagnostic(const GBTDiagnostic* gbtD);
+  void printTrigger(const GBTTrigger* gbtTrg, int offs);
+  void printHeader(const GBTDataHeader* gbtH, int offs);
+  void printHeader(const GBTDataHeaderL* gbtH, int offs);
+  void printTrailer(const GBTDataTrailer* gbtT, int offs);
+  void printDiagnostic(const GBTDiagnostic* gbtD, int offs);
   void printCableDiagnostic(const GBTCableDiagnostic* gbtD);
-  void printCalibrationWord(const GBTCalibration* gbtCal);
+  void printCalibrationWord(const GBTCalibration* gbtCal, int offs);
   void printCableStatus(const GBTCableStatus* gbtS);
   bool nextCRUPage();
 
@@ -200,6 +200,7 @@ GBTLink::CollectedDataStatus GBTLink::collectROFCableData(const Mapping& chmap)
   uint8_t errRes = uint8_t(GBTLink::NoError);
   bool expectPacketDone = false;
   ir.clear();
+  const GBTTrigger* gbtTrg = nullptr;
   while (currRawPiece) { // we may loop over multiple CRU page
     if (dataOffset >= currRawPiece->size) {
       dataOffset = 0;                              // start of the RDH
@@ -232,7 +233,7 @@ GBTLink::CollectedDataStatus GBTLink::collectROFCableData(const Mapping& chmap)
       if (format == NewFormat && RDHUtils::getStop(*rdh)) { // only diagnostic word can be present after the stop
         auto gbtDiag = reinterpret_cast<const GBTDiagnostic*>(&currRawPiece->data[dataOffset]);
         if (verbosity >= VerboseHeaders) {
-          printDiagnostic(gbtDiag);
+          printDiagnostic(gbtDiag, dataOffset);
         }
         GBTLINK_DECODE_ERRORCHECK(errRes, checkErrorsDiagnosticWord(gbtDiag));
         dataOffset += RDHUtils::getOffsetToNext(*rdh) - sizeof(RDH);
@@ -241,10 +242,10 @@ GBTLink::CollectedDataStatus GBTLink::collectROFCableData(const Mapping& chmap)
 
       // data must start with the GBTHeader
       auto gbtH = reinterpret_cast<const GBTDataHeader*>(&currRawPiece->data[dataOffset]); // process GBT header
-      dataOffset += GBTPaddedWordLength;
       if (verbosity >= VerboseHeaders) {
-        printHeader(gbtH);
+        printHeader(gbtH, dataOffset);
       }
+      dataOffset += GBTPaddedWordLength;
       if (format == OldFormat) {
         GBTLINK_DECODE_ERRORCHECK(errRes, checkErrorsHeaderWord(reinterpret_cast<const GBTDataHeaderL*>(gbtH)));
         lanesActive = reinterpret_cast<const GBTDataHeaderL*>(gbtH)->activeLanesL; // TODO do we need to update this for every page?
@@ -265,17 +266,16 @@ GBTLink::CollectedDataStatus GBTLink::collectROFCableData(const Mapping& chmap)
     ruPtr->nCables = ruPtr->ruInfo->nCables; // RSTODO is this needed? TOREMOVE
 
     // then we expect GBT trigger word (unless we work with old format)
-    const GBTTrigger* gbtTrg = nullptr;
     if (format == NewFormat) {
       int ntrig = 0;
       while (dataOffset < currRawPiece->size) { // we may have multiple trigger words in case there were physics triggers
         const GBTTrigger* gbtTrgTmp = reinterpret_cast<const GBTTrigger*>(&currRawPiece->data[dataOffset]);
         if (gbtTrgTmp->isTriggerWord()) {
           ntrig++;
-          dataOffset += GBTPaddedWordLength;
           if (verbosity >= VerboseHeaders) {
-            printTrigger(gbtTrgTmp);
+            printTrigger(gbtTrgTmp, dataOffset);
           }
+          dataOffset += GBTPaddedWordLength;
           if (gbtTrgTmp->noData == 0 || gbtTrgTmp->internal) {
             gbtTrg = gbtTrgTmp; // this is a trigger describing the following data
           } else {
@@ -288,7 +288,7 @@ GBTLink::CollectedDataStatus GBTLink::collectROFCableData(const Mapping& chmap)
         auto gbtC = reinterpret_cast<const o2::itsmft::GBTCalibration*>(&currRawPiece->data[dataOffset]);
         if (gbtC->isCalibrationWord()) {
           if (verbosity >= VerboseHeaders) {
-            printCalibrationWord(gbtC);
+            printCalibrationWord(gbtC, dataOffset);
           }
           dataOffset += GBTPaddedWordLength;
           LOGP(debug, "SetCalibData for RU:{} at bc:{}/orb:{} : [{}/{}]", ruPtr->ruSWID, gbtTrg ? gbtTrg->bc : -1, gbtTrg ? gbtTrg->orbit : -1, gbtC->calibCounter, gbtC->calibUserField);
@@ -297,22 +297,25 @@ GBTLink::CollectedDataStatus GBTLink::collectROFCableData(const Mapping& chmap)
         }
         break;
       }
-      if (!gbtTrg) {
-        if (!ntrig) { // no ITS trigger word was seen, produce an error, but only if no external trigger was seen either
-          gbtTrg = reinterpret_cast<const GBTTrigger*>(&currRawPiece->data[dataOffset]);
-          dataOffset += GBTPaddedWordLength;
-          GBTLINK_DECODE_ERRORCHECK(errRes, checkErrorsTriggerWord(gbtTrg)); // we know there is an error, call this just to register it
+      if (gbtTrg) {
+        statistics.nTriggers++;
+        lanesStop = 0;
+        lanesWithData = 0;
+        ir.bc = gbtTrg->bc;
+        ir.orbit = gbtTrg->orbit;
+        trigger = gbtTrg->triggerType;
+        if (gbtTrg->noData) {
+          if (verbosity >= VerboseHeaders) {
+            LOGP(info, "Offs {} Returning with status {} for {}", dataOffset, int(status), describe());
+          }
+          return status;
         }
-        return status; // in principle, this should not be reached
       }
-      statistics.nTriggers++;
-      lanesStop = 0;
-      lanesWithData = 0;
-      ir.bc = gbtTrg->bc;
-      ir.orbit = gbtTrg->orbit;
-      trigger = gbtTrg->triggerType;
-      if (gbtTrg->noData) {
-        return status;
+      if (dataOffset >= currRawPiece->size) { // end of CRU page was reached while scanning triggers
+        if (verbosity >= VerboseHeaders) {
+          LOGP(info, "Offs {} End of the CRU page reached while scanning triggers, continue to next page, {}", dataOffset, int(status), describe());
+        }
+        continue;
       }
     }
     auto gbtD = reinterpret_cast<const o2::itsmft::GBTData*>(&currRawPiece->data[dataOffset]);
@@ -338,10 +341,10 @@ GBTLink::CollectedDataStatus GBTLink::collectROFCableData(const Mapping& chmap)
     } // we are at the trailer, packet is over, check if there are more data on the next page
 
     auto gbtT = reinterpret_cast<const o2::itsmft::GBTDataTrailer*>(&currRawPiece->data[dataOffset]); // process GBT trailer
-    dataOffset += GBTPaddedWordLength;
     if (verbosity >= VerboseHeaders) {
-      printTrailer(gbtT);
+      printTrailer(gbtT, dataOffset);
     }
+    dataOffset += GBTPaddedWordLength;
 
     GBTLINK_DECODE_ERRORCHECK(errRes, checkErrorsTrailerWord(gbtT));
     // we finished the GBT page, but there might be continuation on the next CRU page
@@ -358,7 +361,9 @@ GBTLink::CollectedDataStatus GBTLink::collectROFCableData(const Mapping& chmap)
       ir = RDHUtils::getTriggerIR(*lastRDH);
       trigger = RDHUtils::getTriggerType(*lastRDH);
     }
-
+    if (verbosity >= VerboseHeaders) {
+      LOGP(info, "Offs {} Leaving collectROFCableData for {} with DataSeen", dataOffset, describe());
+    }
     return (status = DataSeen);
   }
 

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/GBTWord.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/GBTWord.h
@@ -91,7 +91,7 @@ struct GBTWord {
       uint64_t triggerType : 12; /// 0:11   12 lowest bits of trigger type received from CTP
       uint64_t internal : 1;     /// 12     Used in Continuous Mode for internally generated trigger
       uint64_t noData : 1;       /// 13     No data expected (too close to previous trigger or error)
-      uint64_t na0tr : 1;        /// 14     reserved
+      uint64_t continuation : 1; /// 14     following data is continuation of the trigger from the previous CRU page
       uint64_t na1tr : 1;        /// 15     reserved
       uint64_t bc : 12;          /// 16:27  HB or internal trigger BC count or trigger BC from CTP
       uint64_t na2tr : 4;        /// 28:31  reserved

--- a/Detectors/ITSMFT/common/reconstruction/src/GBTLink.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/GBTLink.cxx
@@ -78,7 +78,8 @@ void GBTLink::clear(bool resetStat, bool resetTFRaw)
 void GBTLink::printTrigger(const GBTTrigger* gbtTrg, int offs)
 {
   std::bitset<12> trb(gbtTrg->triggerType);
-  LOG(info) << "Offs: " << offs << " Trigger : Orbit " << gbtTrg->orbit << " BC: " << gbtTrg->bc << " Trigger: " << trb << " noData:" << gbtTrg->noData << " internal:" << gbtTrg->internal << " on " << describe();
+  LOG(info) << "Offs: " << offs << " Trigger : Orbit " << gbtTrg->orbit << " BC: " << gbtTrg->bc << " Trigger: " << trb << " noData:"
+            << gbtTrg->noData << " internal:" << gbtTrg->internal << " continuation:" << gbtTrg->continuation << " on " << describe();
   gbtTrg->printX();
 }
 

--- a/Detectors/ITSMFT/common/reconstruction/src/GBTLink.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/GBTLink.cxx
@@ -75,63 +75,63 @@ void GBTLink::clear(bool resetStat, bool resetTFRaw)
 }
 
 ///_________________________________________________________________
-void GBTLink::printTrigger(const GBTTrigger* gbtTrg)
+void GBTLink::printTrigger(const GBTTrigger* gbtTrg, int offs)
 {
-  gbtTrg->printX();
   std::bitset<12> trb(gbtTrg->triggerType);
-  LOG(info) << "Trigger : Orbit " << gbtTrg->orbit << " BC: " << gbtTrg->bc << " Trigger: " << trb << " noData:" << gbtTrg->noData << " internal:" << gbtTrg->internal;
+  LOG(info) << "Offs: " << offs << " Trigger : Orbit " << gbtTrg->orbit << " BC: " << gbtTrg->bc << " Trigger: " << trb << " noData:" << gbtTrg->noData << " internal:" << gbtTrg->internal << " on " << describe();
+  gbtTrg->printX();
 }
 
 ///_________________________________________________________________
-void GBTLink::printCalibrationWord(const GBTCalibration* gbtCal)
+void GBTLink::printCalibrationWord(const GBTCalibration* gbtCal, int offs)
 {
+  LOGP(info, "Offs: {} Calibration word {:5} | user_data {:#08x} on {}", offs, gbtCal->calibCounter, gbtCal->calibUserField, describe());
   gbtCal->printX();
-  LOGF(info, "Calibration word %5d | user_data 0x%06lx", gbtCal->calibCounter, gbtCal->calibUserField);
 }
 
 ///_________________________________________________________________
-void GBTLink::printHeader(const GBTDataHeader* gbtH)
+void GBTLink::printHeader(const GBTDataHeader* gbtH, int offs)
 {
-  gbtH->printX();
   std::bitset<28> LA(gbtH->activeLanes);
-  LOG(info) << "Header : Active Lanes " << LA;
-}
-
-///_________________________________________________________________
-void GBTLink::printHeader(const GBTDataHeaderL* gbtH)
-{
+  LOG(info) << "Offs: " << offs << " Header : Active Lanes " << LA << " on " << describe();
   gbtH->printX();
+}
+
+///_________________________________________________________________
+void GBTLink::printHeader(const GBTDataHeaderL* gbtH, int offs)
+{
   std::bitset<28> LA(gbtH->activeLanesL);
-  LOG(info) << "HeaderL : Active Lanes " << LA;
+  LOG(info) << "Offs: " << offs << " HeaderL : Active Lanes " << LA << " on " << describe();
+  gbtH->printX();
 }
 
 ///_________________________________________________________________
-void GBTLink::printTrailer(const GBTDataTrailer* gbtT)
+void GBTLink::printTrailer(const GBTDataTrailer* gbtT, int offs)
 {
-  gbtT->printX();
   std::bitset<28> LT(gbtT->lanesTimeout), LS(gbtT->lanesStops); // RSTODO
-  LOG(info) << "Trailer: Done=" << gbtT->packetDone << " Lanes TO: " << LT << " | Lanes ST: " << LS;
+  LOG(info) << "Offs: " << offs << " Trailer: Done=" << gbtT->packetDone << " Lanes TO: " << LT << " | Lanes ST: " << LS << " on " << describe();
+  gbtT->printX();
 }
 
 ///_________________________________________________________________
-void GBTLink::printDiagnostic(const GBTDiagnostic* gbtD)
+void GBTLink::printDiagnostic(const GBTDiagnostic* gbtD, int offs)
 {
+  LOG(info) << "Offs: " << offs << " Diagnostic word on " << describe();
   gbtD->printX();
-  LOG(info) << "Diagnostic word";
 }
 
 ///_________________________________________________________________
 void GBTLink::printCableDiagnostic(const GBTCableDiagnostic* gbtD)
 {
+  LOGP(info, "Diagnostic for {} Lane {} | errorID: {} data {:#018x} on {}", gbtD->isIB() ? "IB" : "OB", gbtD->getCableID(), gbtD->laneErrorID, gbtD->diagnosticData, describe());
   gbtD->printX();
-  LOGF(info, "Diagnostic for %s Lane %d | errorID: %d data 0x%016lx", gbtD->isIB() ? "IB" : "OB", gbtD->getCableID(), gbtD->laneErrorID, gbtD->diagnosticData);
 }
 
 ///_________________________________________________________________
 void GBTLink::printCableStatus(const GBTCableStatus* gbtS)
 {
+  LOGP(info, "Status data, not processed at the moment, on {}", describe());
   gbtS->printX();
-  LOGF(info, "Status data, not processed at the moment");
 }
 
 ///====================================================================

--- a/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/RawPixelDecoder.cxx
@@ -106,6 +106,7 @@ int RawPixelDecoder<Mapping>::decodeNextTrigger()
       mCurRUDecodeID = 0; // getNextChipData will start from here
       mLastReadChipID = -1;
       // set IR and trigger from the 1st non empty link
+      int cnt = 0;
       for (const auto& link : mGBTLinks) {
         if (link.status == GBTLink::DataSeen) {
           mInteractionRecord = link.ir;


### PR DESCRIPTION
This is a fix for the problem of missing trailers for multy CRU-page HBFs in the ITS/MFT data, details https://alice.its.cern.ch/jira/browse/O2-3093.

Improve verbose mode.

Don't merge yet, waiting for some feedback from ITS experts.