### PR TITLE
DPL: Pass routes by reference, since they remain in memory anyway

### DIFF
--- a/Framework/Core/src/DeviceSpecHelpers.cxx
+++ b/Framework/Core/src/DeviceSpecHelpers.cxx
@@ -323,7 +323,7 @@ struct ExpirationHandlerHelpers {
   /// This will always exipire an optional record when no data is received.
   static RouteConfigurator::DanglingConfigurator danglingOptionalConfigurator(std::vector<InputRoute> const& routes)
   {
-    return [routes](DeviceState&, ConfigParamRegistry const&) { return LifetimeHelpers::expireIfPresent(routes, ConcreteDataMatcher{"FLP", "DISTSUBTIMEFRAME", 0}); };
+    return [&routes](DeviceState&, ConfigParamRegistry const&) { return LifetimeHelpers::expireIfPresent(routes, ConcreteDataMatcher{"FLP", "DISTSUBTIMEFRAME", 0}); };
   }
 
   /// When the record expires, simply create a dummy entry.


### PR DESCRIPTION
@ktf : Not 100% if this is safe, but if I understand correctly the routes are are coming from the device specs, so they will remain in memory.
Passes a long full system test for me. Currently breaks TOF workflows at P2, since topology generation needs > 30 seconds.
