### PR TITLE
[EMCAL-566] Added parameters for constraining fit range

### DIFF
--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibParams.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibParams.h
@@ -41,6 +41,9 @@ struct EMCALCalibParams : public o2::conf::ConfigurableParamHelper<EMCALCalibPar
   bool UpdateAtEndOfRunOnly = false;          ///< switsch to enable trigger of calibration only at end of run
   bool enableTimeProfiling = false;           ///< enable to log how much time is spent in the run function in the calibrator spec. Needed for speed tests offline and at point 2
   bool enableFastCalib = false;               ///< switch to enable fast calibration. Instead of filling boost histograms, mean and sigma of cells is calculated on the fly
+  int minTimeForFit = -300;                   ///< minimum cell time considered for the time calibration in ns
+  int maxTimeForFit = 300;                    ///< maximum cell time considered for the time calibration in ns
+  int restrictFitRangeToMax = 25;             ///< window around the largest entry within the minTimeForFit in which the fit is performed in ns
 
   O2ParamDef(EMCALCalibParams, "EMCALCalibParams");
 };

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelCalibrator.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelCalibrator.h
@@ -131,7 +131,7 @@ void EMCALChannelCalibrator<DataInput, DataOutput, HistContainer>::finalizeSlot(
     mInfoVector.emplace_back(CalibDB::getCDBPathBadChannelMap(), clName, flName, md, slot.getStartTimeMS(), o2::ccdb::CcdbObjectInfo::INFINITE_TIMESTAMP);
     mCalibObjectVector.push_back(bcm);
   } else if constexpr (std::is_same<DataInput, o2::emcal::EMCALTimeCalibData>::value) {
-    auto tcd = mCalibrator->calibrateTime(c->getHisto());
+    auto tcd = mCalibrator->calibrateTime(c->getHisto(), EMCALCalibParams::Instance().minTimeForFit, EMCALCalibParams::Instance().maxTimeForFit, EMCALCalibParams::Instance().restrictFitRangeToMax);
 
     // for the CCDB entry
     auto clName = o2::utils::MemFileHelper::getClassName(slot);


### PR DESCRIPTION
- Configurable parameters in EMCALCalibParams for constraining the time
window for the fit performed on the cell time distributions
- Needed as previously the time window was hardcoded and the main time
peak was partly outside the window
- Also added parameter to constrain fit range to a window around the
maximum entry in the histogram