### PR TITLE
Fix in the LtrCalibData renormalization

### DIFF
--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/LtrCalibData.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/LtrCalibData.h
@@ -56,6 +56,7 @@ struct LtrCalibData {
       newVRef = refVDrift / getDriftVCorrection();
     }
     float fact = newVRef / refVDrift;
+    refVDrift = newVRef;
     dvCorrectionA *= fact;
     dvCorrectionC *= fact;
   }


### PR DESCRIPTION
refVdrift was not updated

Trivial, merging 