### PR TITLE
trace int BC used and candidates in TOF calibInfo

### DIFF
--- a/DataFormats/Detectors/TOF/include/DataFormatsTOF/CalibInfoTOF.h
+++ b/DataFormats/Detectors/TOF/include/DataFormatsTOF/CalibInfoTOF.h
@@ -24,7 +24,7 @@ namespace dataformats
 class CalibInfoTOF
 {
  public:
-  CalibInfoTOF(int indexTOFCh, int timestamp, float DeltaTimePi, float tot, int flags = 0) : mTOFChIndex(indexTOFCh), mTimestamp(timestamp), mDeltaTimePi(DeltaTimePi), mTot(tot), mFlags(flags){};
+  CalibInfoTOF(int indexTOFCh, int timestamp, float DeltaTimePi, float tot, int mask, int flags = 0) : mTOFChIndex(indexTOFCh), mTimestamp(timestamp), mDeltaTimePi(DeltaTimePi), mTot(tot), mMask(mask), mFlags(flags){};
   CalibInfoTOF() = default;
   ~CalibInfoTOF() = default;
 
@@ -58,8 +58,8 @@ class CalibInfoTOF
   float mDeltaTimePi;   // raw tof time - expected time for pi hypotesis
   float mTot;           // time-over-threshold
   unsigned char mFlags; // bit mask with quality flags (to be defined)
-
-  ClassDefNV(CalibInfoTOF, 1);
+  int mMask;            // mask for int BC used
+  ClassDefNV(CalibInfoTOF, 2);
 };
 } // namespace dataformats
 } // namespace o2

--- a/DataFormats/Detectors/TOF/include/DataFormatsTOF/CalibInfoTOFshort.h
+++ b/DataFormats/Detectors/TOF/include/DataFormatsTOF/CalibInfoTOFshort.h
@@ -24,7 +24,7 @@ namespace dataformats
 class CalibInfoTOFshort
 {
  public:
-  CalibInfoTOFshort(int timestamp, float DeltaTimePi, float tot, int flags = 0) : mTimestamp(timestamp), mDeltaTimePi(DeltaTimePi), mTot(tot), mFlags(flags){};
+  CalibInfoTOFshort(int timestamp, float DeltaTimePi, float tot, int mask, int flags = 0) : mTimestamp(timestamp), mDeltaTimePi(DeltaTimePi), mTot(tot), mMask(mask), mFlags(flags){};
   CalibInfoTOFshort() = default;
   void setTOFChIndex(int index) {}
   int getTOFChIndex() const { return 0; }
@@ -46,8 +46,9 @@ class CalibInfoTOFshort
   float mDeltaTimePi;   // raw tof time - expected time for pi hypotesis
   float mTot;           // time-over-threshold
   unsigned char mFlags; // bit mask with quality flags (to be defined)
+  int mMask;            // mask for int BC used
 
-  ClassDefNV(CalibInfoTOFshort, 1);
+  ClassDefNV(CalibInfoTOFshort, 2);
 };
 } // namespace dataformats
 } // namespace o2

--- a/Detectors/GlobalTracking/src/MatchTOF.cxx
+++ b/Detectors/GlobalTracking/src/MatchTOF.cxx
@@ -1106,12 +1106,13 @@ void MatchTOF::selectBestMatches()
 
     // add also calibration infos
     if (sourceID == o2::dataformats::GlobalTrackID::ITSTPC) {
-      float deltat = o2::tof::Utils::subtractInteractionBC(mTOFClusWork[matchingPair.getTOFClIndex()].getTimeRaw() - t0info - intLT.getTOF(o2::track::PID::Pion), true);
+      int mask = 0;
+      float deltat = o2::tof::Utils::subtractInteractionBC(mTOFClusWork[matchingPair.getTOFClIndex()].getTimeRaw() - t0info - intLT.getTOF(o2::track::PID::Pion), mask, true);
 
       mCalibInfoTOF.emplace_back(mTOFClusWork[matchingPair.getTOFClIndex()].getMainContributingChannel(),
                                  mTimestamp / 1000 + int(mTOFClusWork[matchingPair.getTOFClIndex()].getTimeRaw() * 1E-12), // add time stamp
                                  deltat,
-                                 mTOFClusWork[matchingPair.getTOFClIndex()].getTot());
+                                 mTOFClusWork[matchingPair.getTOFClIndex()].getTot(), mask);
     }
 
     if (mMCTruthON) {
@@ -1220,7 +1221,7 @@ void MatchTOF::selectBestMatchesHP()
       mCalibInfoTOF.emplace_back(mTOFClusWork[matchingPair.getTOFClIndex()].getMainContributingChannel(),
                                  mTimestamp / 1000 + int(mTOFClusWork[matchingPair.getTOFClIndex()].getTimeRaw() * 1E-12), // add time stamp
                                  mTOFClusWork[matchingPair.getTOFClIndex()].getTimeRaw() - t0info - intLT.getTOF(o2::track::PID::Pion),
-                                 mTOFClusWork[matchingPair.getTOFClIndex()].getTot());
+                                 mTOFClusWork[matchingPair.getTOFClIndex()].getTot(), 0);
     }
 
     if (mMCTruthON) {

--- a/Detectors/GlobalTrackingWorkflow/src/TOFEventTimeChecker.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TOFEventTimeChecker.cxx
@@ -194,12 +194,14 @@ void TOFEventTimeChecker::processEvent(std::vector<MyTrack>& tracks)
       int bcStarOrbit = int(localTime * o2::tof::Geo::BC_TIME_INPS_INV);
       bcStarOrbit = (bcStarOrbit / o2::constants::lhc::LHCMaxBunches) * o2::constants::lhc::LHCMaxBunches; // truncation
       localTime -= bcStarOrbit * o2::tof::Geo::BC_TIME_INPS;
-      track.mSignal = o2::tof::Utils::subtractInteractionBC(localTime);
+      int mask = 0;
+      track.mSignal = o2::tof::Utils::subtractInteractionBC(localTime, mask);
       localTime = track.mTrktime;
       bcStarOrbit = int(localTime * o2::tof::Geo::BC_TIME_INPS_INV);
       bcStarOrbit = (bcStarOrbit / o2::constants::lhc::LHCMaxBunches) * o2::constants::lhc::LHCMaxBunches; // truncation
       localTime -= bcStarOrbit * o2::tof::Geo::BC_TIME_INPS;
-      track.mTrktime = o2::tof::Utils::subtractInteractionBC(localTime);
+      mask = 0;
+      track.mTrktime = o2::tof::Utils::subtractInteractionBC(localTime, mask);
     }
   }
 

--- a/Detectors/TOF/base/include/TOFBase/Utils.h
+++ b/Detectors/TOF/base/include/TOFBase/Utils.h
@@ -43,8 +43,8 @@ class Utils
   static void addBC(double toftime, bool subLatency = false) { addBC(float(toftime), subLatency); }
   static void addInteractionBC(int bc, bool fromCollisonCotext = false);
   static int getInteractionBC(int ibc) { return mFillScheme[ibc]; }
-  static double subtractInteractionBC(double time, bool subLatency = false);
-  static float subtractInteractionBC(float time, bool subLatency = false);
+  static double subtractInteractionBC(double time, int& mask, bool subLatency = false);
+  static float subtractInteractionBC(float time, int& mask, bool subLatency = false);
   static void init();
   static void printFillScheme();
   static void addCalibTrack(float time);

--- a/Detectors/TOF/base/src/Utils.cxx
+++ b/Detectors/TOF/base/src/Utils.cxx
@@ -109,7 +109,7 @@ int Utils::getNinteractionBC()
   return mFillScheme.size();
 }
 
-double Utils::subtractInteractionBC(double time, bool subLatency)
+double Utils::subtractInteractionBC(double time, int& mask, bool subLatency)
 {
   static const int deltalat = o2::tof::Geo::BC_IN_ORBIT - o2::tof::Geo::LATENCYWINDOW_IN_BC;
   int bc = int(time * o2::tof::Geo::BC_TIME_INPS_INV + 0.2);
@@ -127,26 +127,38 @@ double Utils::subtractInteractionBC(double time, bool subLatency)
   int bcOrbit = bc % o2::constants::lhc::LHCMaxBunches;
 
   int dbc = o2::constants::lhc::LHCMaxBunches, bcc = bc;
+  int dbcSigned = 1000;
   for (int k = 0; k < getNinteractionBC(); k++) { // get bc from fill scheme closest
-    if (abs(bcOrbit - getInteractionBC(k)) < dbc) {
-      bcc = bc - bcOrbit + getInteractionBC(k);
-      dbc = abs(bcOrbit - getInteractionBC(k));
+    int deltaCBC = bcOrbit - getInteractionBC(k);
+    if (deltaCBC >= -8 && deltaCBC < 8) {
+      mask += (1 << (deltaCBC + 8)); // fill bc candidates
     }
-    if (abs(bcOrbit - getInteractionBC(k) + o2::constants::lhc::LHCMaxBunches) < dbc) { // in case k is close to the right border (last BC of the orbit)
-      bcc = bc - bcOrbit + getInteractionBC(k) - o2::constants::lhc::LHCMaxBunches;
-      dbc = abs(bcOrbit - getInteractionBC(k) + o2::constants::lhc::LHCMaxBunches);
+    if (abs(deltaCBC) < dbc) {
+      bcc = bc - deltaCBC;
+      dbcSigned = deltaCBC;
+      dbc = abs(dbcSigned);
     }
-    if (abs(bcOrbit - getInteractionBC(k) - o2::constants::lhc::LHCMaxBunches) < dbc) { // in case k is close to the left border (BC=0)
-      bcc = bc - bcOrbit + getInteractionBC(k) + o2::constants::lhc::LHCMaxBunches;
-      dbc = abs(bcOrbit - getInteractionBC(k) - o2::constants::lhc::LHCMaxBunches);
+    if (abs(deltaCBC + o2::constants::lhc::LHCMaxBunches) < dbc) { // in case k is close to the right border (last BC of the orbit)
+      bcc = bc - deltaCBC - o2::constants::lhc::LHCMaxBunches;
+      dbcSigned = deltaCBC + o2::constants::lhc::LHCMaxBunches;
+      dbc = abs(dbcSigned);
+    }
+    if (abs(deltaCBC - o2::constants::lhc::LHCMaxBunches) < dbc) { // in case k is close to the left border (BC=0)
+      bcc = bc - deltaCBC + o2::constants::lhc::LHCMaxBunches;
+      dbcSigned = deltaCBC - o2::constants::lhc::LHCMaxBunches;
+      dbc = abs(dbcSigned);
     }
   }
+  if (dbcSigned >= -8 && dbcSigned < 8) {
+    mask += (1 << (dbcSigned + 24)); // fill bc used
+  }
+
   time -= o2::tof::Geo::BC_TIME_INPS * bcc;
 
   return time;
 }
 
-float Utils::subtractInteractionBC(float time, bool subLatency)
+float Utils::subtractInteractionBC(float time, int& mask, bool subLatency)
 {
   static const int deltalat = o2::tof::Geo::BC_IN_ORBIT - o2::tof::Geo::LATENCYWINDOW_IN_BC;
   int bc = int(time * o2::tof::Geo::BC_TIME_INPS_INV + 0.2);
@@ -164,20 +176,32 @@ float Utils::subtractInteractionBC(float time, bool subLatency)
   int bcOrbit = bc % o2::constants::lhc::LHCMaxBunches;
 
   int dbc = o2::constants::lhc::LHCMaxBunches, bcc = bc;
+  int dbcSigned = 1000;
   for (int k = 0; k < getNinteractionBC(); k++) { // get bc from fill scheme closest
-    if (abs(bcOrbit - getInteractionBC(k)) < dbc) {
-      bcc = bc - bcOrbit + getInteractionBC(k);
-      dbc = abs(bcOrbit - getInteractionBC(k));
+    int deltaCBC = bcOrbit - getInteractionBC(k);
+    if (deltaCBC >= -8 && deltaCBC < 8) {
+      mask += (1 << (deltaCBC + 8)); // fill bc candidates
     }
-    if (abs(bcOrbit - getInteractionBC(k) + o2::constants::lhc::LHCMaxBunches) < dbc) { // in case k is close to the right border (last BC of the orbit)
-      bcc = bc - bcOrbit + getInteractionBC(k) - o2::constants::lhc::LHCMaxBunches;
-      dbc = abs(bcOrbit - getInteractionBC(k) + o2::constants::lhc::LHCMaxBunches);
+    if (abs(deltaCBC) < dbc) {
+      bcc = bc - deltaCBC;
+      dbcSigned = deltaCBC;
+      dbc = abs(dbcSigned);
     }
-    if (abs(bcOrbit - getInteractionBC(k) - o2::constants::lhc::LHCMaxBunches) < dbc) { // in case k is close to the left border (BC=0)
-      bcc = bc - bcOrbit + getInteractionBC(k) + o2::constants::lhc::LHCMaxBunches;
-      dbc = abs(bcOrbit - getInteractionBC(k) - o2::constants::lhc::LHCMaxBunches);
+    if (abs(deltaCBC + o2::constants::lhc::LHCMaxBunches) < dbc) { // in case k is close to the right border (last BC of the orbit)
+      bcc = bc - deltaCBC - o2::constants::lhc::LHCMaxBunches;
+      dbcSigned = deltaCBC + o2::constants::lhc::LHCMaxBunches;
+      dbc = abs(dbcSigned);
+    }
+    if (abs(deltaCBC - o2::constants::lhc::LHCMaxBunches) < dbc) { // in case k is close to the left border (BC=0)
+      bcc = bc - deltaCBC + o2::constants::lhc::LHCMaxBunches;
+      dbcSigned = deltaCBC - o2::constants::lhc::LHCMaxBunches;
+      dbc = abs(dbcSigned);
     }
   }
+  if (dbcSigned >= -8 && dbcSigned < 8) {
+    mask += (1 << (dbcSigned + 24)); // fill bc used
+  }
+
   time -= o2::tof::Geo::BC_TIME_INPS * bcc;
 
   return time;

--- a/Detectors/TOF/calibration/include/TOFCalibration/LHCClockCalibrator.h
+++ b/Detectors/TOF/calibration/include/TOFCalibration/LHCClockCalibrator.h
@@ -65,7 +65,7 @@ class LHCClockCalibrator final : public o2::calibration::TimeSlotCalibration<o2:
   using LHCphaseVector = std::vector<LHCphase>;
 
  public:
-  LHCClockCalibrator(int minEnt = 500, int nb = 1000, float r = 24400, const std::string path = o2::base::NameConf::getCCDBServer()) : mMinEntries(minEnt), mNBins(nb), mRange(r) { mCalibTOFapi->setURL(path); }
+  LHCClockCalibrator(int minEnt = 500, int nb = 10000, float r = 244000, const std::string path = o2::base::NameConf::getCCDBServer()) : mMinEntries(minEnt), mNBins(nb), mRange(r) { mCalibTOFapi->setURL(path); }
   ~LHCClockCalibrator() final = default;
   bool hasEnoughData(const Slot& slot) const final { return slot.getContainer()->entries >= mMinEntries; }
   void initOutput() final;

--- a/Detectors/TOF/prototyping/convertTreeTo02object.C
+++ b/Detectors/TOF/prototyping/convertTreeTo02object.C
@@ -24,7 +24,7 @@ void convertTreeTo02object()
     //for (int ientry = 1; ientry <= 3; ientry++){
     t->GetEntry(ientry);
     for (int i = 0; i < t->GetLeaf("nhits")->GetValue(); i++) {
-      mCalibInfoTOF.emplace_back(t->GetLeaf("index")->GetValue(i), t->GetLeaf("timestamp")->GetValue(), t->GetLeaf("time")->GetValue(i) - t->GetLeaf("texp")->GetValue(i), t->GetLeaf("tot")->GetValue(i));
+      mCalibInfoTOF.emplace_back(t->GetLeaf("index")->GetValue(i), t->GetLeaf("timestamp")->GetValue(), t->GetLeaf("time")->GetValue(i) - t->GetLeaf("texp")->GetValue(i), t->GetLeaf("tot")->GetValue(i), 0);
     }
     tout->Fill();
     mCalibInfoTOF.clear();


### PR DESCRIPTION
This is needed to trace the interaction BC assumed/used to store calib info and possible candidates (int mask).
This will allow to identify shift larger than 1 BC and correct for in calibration workflows also for small (25 ns) bunch spacing 