### PR TITLE
[EMCAL-769] Protection from crash in raw decoding if bunch ADC vector is too small

### DIFF
--- a/Detectors/EMCAL/reconstruction/src/CaloRawFitter.cxx
+++ b/Detectors/EMCAL/reconstruction/src/CaloRawFitter.cxx
@@ -281,6 +281,11 @@ std::tuple<int, int, float, short, short, float, int, int> CaloRawFitter::preFit
   mReversed.fill(0);
 
   // select the bunch with the highest amplitude unless any time constraints is set
+  for (unsigned int i = 0; i < bunchvector.size(); i++) {
+    if (bunchvector[i].getBunchLength() > bunchvector[i].getADC().size()) {
+      throw RawFitterError_t::FIT_ERROR;
+    }
+  }
   auto [bunchindex, indexMaxADC, adcMAX] = selectMaximumBunch(bunchvector);
 
   // something valid was found, and non-zero amplitude

--- a/prodtests/full_system_test.sh
+++ b/prodtests/full_system_test.sh
@@ -49,7 +49,7 @@ ENABLE_GPU_TEST=${ENABLE_GPU_TEST:-0} # Run the full system test also on the GPU
 GPUMEMSIZE=${GPUMEMSIZE:-6000000000} # Size of GPU memory to use in case ENABBLE_GPU_TEST=1
 NTIMEFRAMES=${NTIMEFRAMES:-1} # Number of time frames to process
 TFDELAY=${TFDELAY:-100} # Delay in seconds between publishing time frames
-NOMCLABELS="--disable-mc"
+[[ -z ${NOMCLABELS+x} ]] && NOMCLABELS="--disable-mc"
 O2SIMSEED=${O2SIMSEED:--1}
 SPLITTRDDIGI=${SPLITTRDDIGI:-1}
 DIGITDOWNSCALINGTRD=${DIGITDOWNSCALINGTRD:-1000}


### PR DESCRIPTION
@mfasDa @mpoghos : This fixes the segfault in the corrupt EMCAL raw data for me.
The problem is that in some bunches the size of the mADC vector is smaller than what is returned by bunch.getBunchLength, and that causes an out of bounds access in CaloRawFitter line 177 and afterwards:
```
  const std::vector<uint16_t>& sig = bunch.getADC();
  for (int i = 0; i < bunch.getBunchLength(); i++) {
    if (sig[i] > maxADC) {
```
I didn't check why the bunchLength was set incorrectly in the first place. Fixeing that would be the proper fix, but this PR at least cures the segmentation fault for me, at least on the samples of corrupted raw data I checked.