### PR TITLE
MCH: temporary workaround to limit tracking duration

### DIFF
--- a/Detectors/MUON/MCH/Base/include/MCHBase/TrackerParam.h
+++ b/Detectors/MUON/MCH/Base/include/MCHBase/TrackerParam.h
@@ -44,6 +44,8 @@ struct TrackerParam : public o2::conf::ConfigurableParamHelper<TrackerParam> {
 
   std::size_t maxCandidates = 100000; ///< maximum number of track candidates above which the tracking abort
 
+  std::size_t maxClusters = std::numeric_limits<std::size_t>::max(); ///< maximum allowed number of clusters per ROF (above this number the tracking is not even attempted)
+
   O2ParamDef(TrackerParam, "MCHTracking");
 };
 


### PR DESCRIPTION
@shahor02 @aferrero2707

This PR introduces a MCH tracker parameter to allow to mitigate the very long tracking time observed in sync reco for some ROFs. By tuning the `MCHTracking.maxClusters` parameter, one can simply discard "high" occupancy ROFs. Setting a limit at 300 clusters seems to avoid cases that have been observed so far.

This is only a _stopgap_ measure as we will of course have to investigate further whether the ROFs that are thus rejected by this abrupt cut are legit physical ROFs (in which case we should not discard them in the first place) or "noise" related ones (in which case rejection would be the right thing to do).

Note that the long tracking times might just be due to the very loose roads we currently have as we're not aligned. And thus with a proper alignment the issue might either disappear or lead to completely acceptable tracking times). To be confirmed later on when we'll get an alignment. 