### PR TITLE
[EMCAL-769] Skip bunches with bunch size > channel payload size

### DIFF
--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/AltroDecoder.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/AltroDecoder.h
@@ -89,7 +89,8 @@ class MinorAltroDecodingError
   enum class ErrorType_t {
     BUNCH_HEADER_NULL,            ///< Bunch header is 0
     CHANNEL_END_PAYLOAD_UNEXPECT, ///< Unexpected end of payload (channel or trailer word in bunch words)
-    CHANNEL_PAYLOAD_EXCEED        ///< Exceeding channel payload block
+    CHANNEL_PAYLOAD_EXCEED,       ///< Exceeding channel payload block
+    BUNCH_LENGTH_EXCEED           ///< Bunch length exceeding channel payload size
   };
 
   /// \brief Dummy constructor

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/Bunch.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/Bunch.h
@@ -89,6 +89,17 @@ class Bunch
   /// the samples are in reversed order.
   uint8_t getEndTime() const { return mStartTime - mBunchLength + 1; }
 
+  /// \brief Set the length of the ALTRO bunch
+  /// \param length Bunch length
+  void setBunchLength(uint8_t length) { mBunchLength = length; }
+
+  /// \brief Set the start time bin
+  /// \param start timebin
+  ///
+  /// The start timebin is the higher of the two,
+  /// the samples are in reversed order.
+  void setStartTime(uint8_t start) { mStartTime = start; }
+
  private:
   uint8_t mBunchLength = 0;   ///< Number of ADC samples in buffer
   uint8_t mStartTime = 0;     ///< Start timebin (larger time bin, samples are in reversed order)

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/Channel.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/Channel.h
@@ -95,7 +95,7 @@ class Channel
 
   /// \brief Get the size of the payload
   /// \return Size of the payload as number of 10-bit samples (1/3rd words)
-  uint8_t getPayloadSize() const { return mPayloadSize; }
+  uint16_t getPayloadSize() const { return mPayloadSize; }
 
   /// \brief Get list of bunches in the channel
   /// \return List of bunches
@@ -172,7 +172,7 @@ class Channel
 
  private:
   int32_t mHardwareAddress = -1; ///< Hardware address
-  uint8_t mPayloadSize = 0;      ///< Payload size
+  uint16_t mPayloadSize = 0;     ///< Payload size
   bool mBadChannel;              ///< Bad channel status
   std::vector<Bunch> mBunches;   ///< Bunches in channel;
 

--- a/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
@@ -150,7 +150,6 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
 
     // loop over all the DMA pages
     while (rawreader.hasNext()) {
-
       try {
         rawreader.next();
       } catch (RawDecodingError& e) {
@@ -258,7 +257,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
             default:
               break;
           };
-          LOG(warning) << " EMCAL raw task: " << errormessage << " in DDL " << feeID << std::endl;
+          LOG(warning) << " EMCAL raw task: " << errormessage << " in DDL " << feeID;
           mNumErrorMessages++;
           if (mNumErrorMessages == mMaxErrorMessages) {
             LOG(warning) << "Max. amount of error messages (" << mMaxErrorMessages << " reached, further messages will be suppressed";
@@ -276,7 +275,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
       if (mCreateRawDataErrors) {
         for (auto minorerror : decoder.getMinorDecodingErrors()) {
           if (mNumErrorMessages < mMaxErrorMessages) {
-            LOG(warning) << " EMCAL raw task - Minor error in DDL " << feeID << ": " << minorerror.what() << std::endl;
+            LOG(warning) << " EMCAL raw task - Minor error in DDL " << feeID << ": " << minorerror.what();
             mNumErrorMessages++;
             if (mNumErrorMessages == mMaxErrorMessages) {
               LOG(warning) << "Max. amount of error messages (" << mMaxErrorMessages << " reached, further messages will be suppressed";
@@ -284,7 +283,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
           } else {
             mErrorMessagesSuppressed++;
           }
-          ErrorTypeFEE errornum(feeID, ErrorTypeFEE::ErrorSource_t::ALTRO_ERROR, MinorAltroDecodingError::errorTypeToInt(minorerror.getErrorType()), -1, -1);
+          ErrorTypeFEE errornum(feeID, ErrorTypeFEE::ErrorSource_t::MINOR_ALTRO_ERROR, MinorAltroDecodingError::errorTypeToInt(minorerror.getErrorType()), -1, -1);
           mOutputDecoderErrors.push_back(errornum);
         }
       }
@@ -317,7 +316,6 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
         // Loop over all the channels
         int nBunchesNotOK = 0;
         for (auto& chan : decoder.getChannels()) {
-
           int iRow, iCol;
           ChannelType_t chantype;
           try {


### PR DESCRIPTION
- Skip bunches, they will lead to memory corruption
- Raise minor decoding error (only skipping bunch, not
  page)