### PR TITLE
Fix for HMP data in RecoContainer

### DIFF
--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
@@ -222,7 +222,7 @@ struct DataRequest {
   void requestMCHClusters(bool mc);
   void requestMIDClusters(bool mc);
   void requestHMPClusters(bool mc);
-  void requestHMPMatches(bool mc);
+  //  void requestHMPMatches(bool mc); // no input available at the moment
 
   void requestCTPDigits(bool mc);
 
@@ -338,7 +338,7 @@ struct RecoContainer {
   void addTOFMatchesTPCTRD(o2::framework::ProcessingContext& pc, bool mc);
   void addTOFMatchesITSTPCTRD(o2::framework::ProcessingContext& pc, bool mc);
 
-  void addHMPMatches(o2::framework::ProcessingContext& pc, bool mc);
+  //  void addHMPMatches(o2::framework::ProcessingContext& pc, bool mc); // no input available for the moment
 
   void addMFTMCHMatches(o2::framework::ProcessingContext& pc, bool mc);
   void addMCHMIDMatches(o2::framework::ProcessingContext& pc, bool mc);
@@ -594,11 +594,13 @@ struct RecoContainer {
   auto getITSTPCTRDTOFMatches() const { return getSpan<o2::dataformats::MatchInfoTOF>(GTrackID::ITSTPCTRDTOF, MATCHES); }
   auto getITSTPCTRDTOFMatchesMCLabels() const { return getSpan<o2::MCCompLabel>(GTrackID::ITSTPCTRDTOF, MCLABELS); }
 
+  /* no input available for the moment
   // HMPID matches
   auto getHMPMatchTriggers() const { return getSpan<o2::hmpid::Trigger>(GTrackID::HMP, TRACKREFS); }
   auto getHMPMatches() const { return getSpan<o2::dataformats::MatchInfoHMP>(GTrackID::HMP, MATCHES); }
   auto getHMPPhotsClusterCharges() const { return getSpan<float>(GTrackID::HMP, PATTERNS); }
   auto getHMPMatchesMCLabels() const { return getSpan<o2::MCCompLabel>(GTrackID::HMP, MCLABELS); }
+  */
 
   // TOF clusters
   auto getTOFClusters() const { return getSpan<o2::tof::Cluster>(GTrackID::TOF, CLUSTERS); }

--- a/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
+++ b/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
@@ -281,8 +281,12 @@ void DataRequest::requestMCHClusters(bool mc)
 
 void DataRequest::requestHMPClusters(bool mc)
 {
+  if (mc) { // RS: remove this once labels will be available
+    LOG(warn) << "HMP clusters do not support MC lables, disabling";
+    mc = false;
+  }
   addInput({"hmpidcluster", "HMP", "CLUSTERS", 0, Lifetime::Timeframe});
-  addInput({"hmpidtriggers", "HMP", "CLUSREFS", 0, Lifetime::Timeframe});
+  addInput({"hmpidtriggers", "HMP", "INTRECORDS1", 0, Lifetime::Timeframe});
   if (mc) {
     addInput({"hmpidclusterlabel", "HMP", "CLUSTERSMCTR", 0, Lifetime::Timeframe});
   }
@@ -433,6 +437,7 @@ void DataRequest::requestEMCALCells(bool mc)
   requestMap["EMCCells"] = mc;
 }
 
+/*
 void DataRequest::requestHMPMatches(bool mc)
 {
   addInput({"matchHMP", "HMP", "MATCHES", 0, Lifetime::Timeframe});
@@ -443,6 +448,7 @@ void DataRequest::requestHMPMatches(bool mc)
   }
   requestMap["matchHMP"] = mc;
 }
+*/
 
 void DataRequest::requestTracks(GTrackID::mask_t src, bool useMC)
 {
@@ -499,9 +505,9 @@ void DataRequest::requestTracks(GTrackID::mask_t src, bool useMC)
   if (GTrackID::includesDet(DetID::CTP, src)) {
     requestCTPDigits(false); // RS FIXME: at the moment does not support MC
   }
-  if (src[GTrackID::HMP]) {
-    requestHMPMatches(useMC);
-  }
+  //  if (src[GTrackID::HMP]) {
+  //    requestHMPMatches(useMC);
+  //  }
 }
 
 void DataRequest::requestClusters(GTrackID::mask_t src, bool useMC)
@@ -730,10 +736,10 @@ void RecoContainer::collectData(ProcessingContext& pc, const DataRequest& reques
   if (req != reqMap.end()) {
     addIRFramesITS(pc);
   }
-  req = reqMap.find("matchHMP");
-  if (req != reqMap.end()) {
-    addHMPMatches(pc, req->second);
-  }
+  //  req = reqMap.find("matchHMP");
+  //  if (req != reqMap.end()) {
+  //    addHMPMatches(pc, req->second);
+  //  }
 }
 
 //____________________________________________________________
@@ -960,6 +966,7 @@ void RecoContainer::addTOFMatchesITSTPCTRD(ProcessingContext& pc, bool mc)
   }
 }
 
+/*
 //__________________________________________________________
 void RecoContainer::addHMPMatches(ProcessingContext& pc, bool mc)
 {
@@ -970,6 +977,8 @@ void RecoContainer::addHMPMatches(ProcessingContext& pc, bool mc)
     commonPool[GTrackID::HMP].registerContainer(pc.inputs().get<gsl::span<o2::MCCompLabel>>("clsHMP_GLO_MCTR"), MCLABELS);
   }
 }
+*/
+
 //__________________________________________________________
 void RecoContainer::addITSClusters(ProcessingContext& pc, bool mc)
 {


### PR DESCRIPTION
@gvolpe79 HMPID clusters were subscribed with wrong DataDescription, changing `CLUSREFS` to `INTRECORDS1` and masking MC labels request since your clustered has no MC mode.

Also, you added access to HMPIDMatches but no workflow produces the outputs you are subscribing to, so I've commented these methods until such inputs will be available.