### PR TITLE
Adapt eve-export to GRPGeomHelper

### DIFF
--- a/EventVisualisation/Workflow/include/EveWorkflow/DetectorData.h
+++ b/EventVisualisation/Workflow/include/EveWorkflow/DetectorData.h
@@ -47,7 +47,7 @@ class DetectorData
 
   const o2::itsmft::TopologyDictionary* mITSDict = nullptr;
   const o2::itsmft::TopologyDictionary* mMFTDict = nullptr;
-  std::unique_ptr<EveConfiguration> mConfig;
+  EveConfiguration mConfig{};
   std::unique_ptr<o2::trd::GeometryFlat> mTrdGeo;
 };
 

--- a/EventVisualisation/Workflow/include/EveWorkflow/EveWorkflowHelper.h
+++ b/EventVisualisation/Workflow/include/EveWorkflow/EveWorkflowHelper.h
@@ -195,8 +195,9 @@ class EveWorkflowHelper
   Bracket mTimeBracket;
   Bracket mEtaBracket;
   bool mPrimaryVertexMode;
-  o2::globaltracking::RecoContainer mRecoCont;
-  o2::globaltracking::RecoContainer& getRecoContainer() { return mRecoCont; }
+  const o2::globaltracking::RecoContainer* mRecoCont = nullptr;
+  const o2::globaltracking::RecoContainer* getRecoContainer() const { return mRecoCont; }
+  void setRecoContainer(const o2::globaltracking::RecoContainer* rc) { mRecoCont = rc; }
   TracksSet mTrackSet;
   o2::event_visualisation::VisualisationEvent mEvent;
   std::unordered_map<GID, std::size_t> mTotalTracks;

--- a/EventVisualisation/Workflow/include/EveWorkflow/O2DPLDisplay.h
+++ b/EventVisualisation/Workflow/include/EveWorkflow/O2DPLDisplay.h
@@ -18,6 +18,7 @@
 
 #include "ReconstructionDataFormats/GlobalTrackID.h"
 #include "DataFormatsGlobalTracking/RecoContainer.h"
+#include "DetectorsBase/GRPGeomHelper.h"
 #include "EveWorkflow/DetectorData.h"
 #include "Framework/Task.h"
 #include <memory>
@@ -51,12 +52,14 @@ class O2DPLDisplaySpec : public o2::framework::Task
 
   O2DPLDisplaySpec(bool useMC, o2::dataformats::GlobalTrackID::mask_t trkMask,
                    o2::dataformats::GlobalTrackID::mask_t clMask,
-                   std::shared_ptr<o2::globaltracking::DataRequest> dataRequest, const std::string& jsonPath, const std::string& ext,
+                   std::shared_ptr<o2::globaltracking::DataRequest> dataRequest,
+                   std::shared_ptr<o2::base::GRPGeomRequest> gr,
+                   const std::string& jsonPath, const std::string& ext,
                    std::chrono::milliseconds timeInterval, int numberOfFiles, int numberOfTracks,
                    bool eveHostNameMatch, int minITSTracks, int minTracks, bool filterITSROF, bool filterTime,
                    const EveWorkflowHelper::Bracket& timeBracket, bool removeTPCEta,
                    const EveWorkflowHelper::Bracket& etaBracket, bool trackSorting, int onlyNthEvent, bool primaryVertex, int maxPrimaryVertices)
-    : mUseMC(useMC), mTrkMask(trkMask), mClMask(clMask), mDataRequest(dataRequest), mJsonPath(jsonPath), mExt(ext), mTimeInterval(timeInterval), mNumberOfFiles(numberOfFiles), mNumberOfTracks(numberOfTracks), mEveHostNameMatch(eveHostNameMatch), mMinITSTracks(minITSTracks), mMinTracks(minTracks), mFilterITSROF(filterITSROF), mFilterTime(filterTime), mTimeBracket(timeBracket), mRemoveTPCEta(removeTPCEta), mEtaBracket(etaBracket), mTrackSorting(trackSorting), mOnlyNthEvent(onlyNthEvent), mPrimaryVertexMode(primaryVertex), mMaxPrimaryVertices(maxPrimaryVertices)
+    : mUseMC(useMC), mTrkMask(trkMask), mClMask(clMask), mDataRequest(dataRequest), mGGCCDBRequest(gr), mJsonPath(jsonPath), mExt(ext), mTimeInterval(timeInterval), mNumberOfFiles(numberOfFiles), mNumberOfTracks(numberOfTracks), mEveHostNameMatch(eveHostNameMatch), mMinITSTracks(minITSTracks), mMinTracks(minTracks), mFilterITSROF(filterITSROF), mFilterTime(filterTime), mTimeBracket(timeBracket), mRemoveTPCEta(removeTPCEta), mEtaBracket(etaBracket), mTrackSorting(trackSorting), mOnlyNthEvent(onlyNthEvent), mPrimaryVertexMode(primaryVertex), mMaxPrimaryVertices(maxPrimaryVertices)
 
   {
     this->mTimeStamp = std::chrono::high_resolution_clock::now() - timeInterval; // first run meets condition
@@ -95,6 +98,7 @@ class O2DPLDisplaySpec : public o2::framework::Task
   o2::dataformats::GlobalTrackID::mask_t mClMask;
   DetectorData mData;
   std::shared_ptr<o2::globaltracking::DataRequest> mDataRequest;
+  std::shared_ptr<o2::base::GRPGeomRequest> mGGCCDBRequest;
 };
 
 } // namespace o2::event_visualisation

--- a/EventVisualisation/Workflow/src/DetectorData.cxx
+++ b/EventVisualisation/Workflow/src/DetectorData.cxx
@@ -26,6 +26,7 @@
 #include "MCHTracking/TrackExtrap.h"
 #include "ReconstructionDataFormats/GlobalTrackID.h"
 #include "DetectorsCommonDataFormats/DetectorNameConf.h"
+#include "DetectorsBase/GRPGeomHelper.h"
 
 using namespace o2::event_visualisation;
 using namespace o2::framework;
@@ -36,19 +37,16 @@ using namespace o2::trd;
 
 void DetectorData::init()
 {
-  const auto grp = o2::parameters::GRPObject::loadFrom();
-  o2::base::GeometryManager::loadGeometry();
-  o2::base::Propagator::initFieldFromGRP();
-  mConfig.reset(new EveConfiguration);
-  mConfig->configGRP.solenoidBz = o2::base::Propagator::Instance()->getNominalBz();
-  mConfig->configGRP.continuousMaxTimeBin = grp->isDetContinuousReadOut(o2::detectors::DetID::TPC) ? -1 : 0; // Number of timebins in timeframe if continuous, 0 otherwise
-  mConfig->ReadConfigurableParam();
+  const auto grp = o2::base::GRPGeomHelper::instance().getGRPECS();
+  mConfig.configGRP.solenoidBz = o2::base::Propagator::Instance()->getNominalBz();
+  mConfig.configGRP.continuousMaxTimeBin = grp->isDetContinuousReadOut(o2::detectors::DetID::TPC) ? -1 : 0; // Number of timebins in timeframe if continuous, 0 otherwise
+  mConfig.ReadConfigurableParam();
 
   auto gm = o2::trd::Geometry::instance();
   gm->createPadPlaneArray();
   gm->createClusterMatrixArray();
   mTrdGeo.reset(new o2::trd::GeometryFlat(*gm));
-  mConfig->configCalib.trdGeometry = mTrdGeo.get();
+  mConfig.configCalib.trdGeometry = mTrdGeo.get();
 
   o2::tof::Geo::Init();
 
@@ -64,11 +62,11 @@ void DetectorData::init()
 void DetectorData::setITSDict(const o2::itsmft::TopologyDictionary* d)
 {
   mITSDict = d;
-  mConfig->configCalib.itsPatternDict = d;
+  mConfig.configCalib.itsPatternDict = d;
 }
 
 void DetectorData::setMFTDict(const o2::itsmft::TopologyDictionary* d)
 {
   mMFTDict = d;
-  mConfig->configCalib.mftPatternDict = d;
+  mConfig.configCalib.mftPatternDict = d;
 }


### PR DESCRIPTION
Somehow eve was left out of the GRPGeomHelper upgrade...

@pnwkw concerning eve not producing output files if only calorimeters are requested: this is because of these explicit cuts:
https://github.com/AliceO2Group/AliceO2/blob/29dbed29783bbf091d3540a1c340967b1aa7a19f/EventVisualisation/Workflow/src/O2DPLDisplay.cxx#L142-L148