### PR TITLE
Full rapidjson dev

### DIFF
--- a/CCDB/CMakeLists.txt
+++ b/CCDB/CMakeLists.txt
@@ -13,13 +13,16 @@ o2_add_library(CCDB
                SOURCES  src/CcdbApi.cxx
                         src/BasicCCDBManager.cxx
                         src/CCDBTimeStampUtils.cxx
-        src/IdPath.cxx src/CCDBQuery.cxx
+                        src/IdPath.cxx
+                        src/CCDBQuery.cxx
+                        src/CCDBResponse.cxx
         PUBLIC_LINK_LIBRARIES CURL::libcurl
-                                    FairRoot::ParMQ
-                                    ROOT::Hist
-                                    O2::CommonUtils
-                                    FairMQ::FairMQ
-                                    libjalien::libjalienO2
+                                FairRoot::ParMQ
+                                ROOT::Hist
+                                O2::CommonUtils
+                                FairMQ::FairMQ
+                                libjalien::libjalienO2
+                                RapidJSON::RapidJSON
                TARGETVARNAME targetName)
 
 o2_target_root_dictionary(CCDB
@@ -30,7 +33,8 @@ o2_target_root_dictionary(CCDB
                                   include/CCDB/IdPath.h
                                   include/CCDB/BasicCCDBManager.h
                                   include/CCDB/CCDBTimeStampUtils.h
-                                  include/CCDB/CCDBQuery.h)
+                                  include/CCDB/CCDBQuery.h
+                                  include/CCDB/CCDBResponse.h)
 
 o2_add_executable(inspectccdbfile
             COMPONENT_NAME ccdb
@@ -74,6 +78,12 @@ o2_add_test(BasicCCDBManager
 
 o2_add_test(CcdbApiMultipleUrls
             SOURCES test/testCcdbApiMultipleUrls.cxx
+            COMPONENT_NAME ccdb
+            PUBLIC_LINK_LIBRARIES O2::CCDB
+            LABELS ccdb)
+
+o2_add_test(CCDBResponse
+            SOURCES test/testCCDBResponse.cxx
             COMPONENT_NAME ccdb
             PUBLIC_LINK_LIBRARIES O2::CCDB
             LABELS ccdb)

--- a/CCDB/include/CCDB/CCDBResponse.h
+++ b/CCDB/include/CCDB/CCDBResponse.h
@@ -1,0 +1,148 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef CCDB_RESPONSE_H_
+#define CCDB_RESPONSE_H_
+
+#include <Rtypes.h>
+#include <map>
+#include <vector>
+#include <string>
+#include <unordered_map>
+#include "rapidjson/document.h"
+
+namespace o2
+{
+namespace ccdb
+{
+
+class CCDBResponse
+{
+ public:
+  CCDBResponse(const std::string& jsonString);
+  ~CCDBResponse() = default;
+
+  /**
+   * Parses the response contained in the object to string.
+   * @returns - string formatted as JSON
+   */
+  std::string toString();
+
+  /**
+   * The number of objects inside the document.
+   */
+  int objectNum;
+
+  /**
+   * Return attribute in string type.
+   *
+   * @param ind - index of object inside document
+   * @param attributeName - name of attribute to be retrieved
+   * @return - string value of the attribute
+   */
+  std::string getStringAttribute(int ind, std::string attributeName);
+
+  /**
+   * Merges objects with unique IDs and paths from another document into this one.
+   *
+   * @param other - Other CCDBResponse to be merged into this one.
+   */
+  void latestAndMerge(CCDBResponse* other);
+
+  /**
+   * Merges objects with unique IDs from another document into this one.
+   *
+   * @param other - Other CCDBResponse to be merged into this one.
+   */
+  void browseAndMerge(CCDBResponse* other);
+
+  /**
+   * Debug method. Print all attributes of all objects inside the document.
+   */
+  void printObjectAttributes(rapidjson::Document* document);
+
+ private:
+  /**
+   * Rapidjson document used to store the server response.
+   */
+  rapidjson::Document document;
+
+  /**
+   * Debug method. Print all attributes of all objects inside the document.
+   * @return - pointer to the document
+   */
+  rapidjson::Document* getDocument();
+
+  /**
+   * Parses a given rapidjson document into string.
+   * @param document - document to be parsed into string
+   * @return - string formatted as JSON
+   */
+  std::string JsonToString(rapidjson::Document* document);
+
+  /**
+   * Concatenates other response object into this object excluding duplicate ids.
+   */
+  void browse(CCDBResponse* other);
+
+  /**
+   * Updates the number of objects described by the document.
+   */
+  void refreshObjectNum();
+
+  /**
+   * Counts the number of objects described by the document.
+   * @return - number of objectsinside the document.
+   */
+  size_t countObjects();
+
+  /**
+   * Removes as objects from given document using a vector of boolean values.
+   * @param document - document which objects will be removed
+   * @param toBeRemoved - Vector of the length of number of objects in document. Objects at indexes containing true will be removed from the document.
+   */
+  void removeObjects(rapidjson::Document* document, std::vector<bool> toBeRemoved);
+
+  /**
+   * Merges two rapidjson documents into one.
+   * @param dstObject - destination object for the merge
+   * @param srcObject - source object for the merge
+   * @param allocator - allocator of the destination object
+   */
+  bool mergeObjects(rapidjson::Value& dstObject, rapidjson::Value& srcObject, rapidjson::Document::AllocatorType& allocator);
+
+  /**
+   * Unordered_map of <id, id> used to store the ids of all objects inside the document.
+   */
+  std::unordered_map<std::string, std::string> idHashmap;
+
+  /**
+   * Unordered_map of <path, path> used to store the path attribute of all objects in the document.
+   */
+  std::unordered_map<std::string, std::string> pathHashmap;
+
+  /**
+   * Refreshes the unordered_map of ids.
+   */
+  void refreshIdMap();
+
+  /**
+   * Refreshes the unordered_map of paths.
+   */
+  void refreshPathMap();
+
+  ClassDefNV(CCDBResponse, 1);
+};
+
+} // namespace ccdb
+} // namespace o2
+
+#endif

--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -439,6 +439,18 @@ class CcdbApi //: public DatabaseInterface
                           long timestamp = -1, std::map<std::string, std::string>* headers = nullptr, std::string const& etag = "",
                           const std::string& createdNotAfter = "", const std::string& createdNotBefore = "") const;
 
+  /**
+   * Concatenates /browse/ responses from all servers in hostsPool.
+   * @return Summary /browse/ string. Empty string if no response received.
+   */
+  std::string browse();
+
+  /**
+   * Concatenates /latest/ responses from all servers in hostsPool.
+   * @return Summary /latest/ string. Empty string if no response received.
+   */
+  std::string latest();
+
  private:
   /**
    * A helper function to extract object from a local ROOT file

--- a/CCDB/src/CCDBResponse.cxx
+++ b/CCDB/src/CCDBResponse.cxx
@@ -1,0 +1,212 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <CCDB/CCDBResponse.h>
+#include <string>
+#include <vector>
+#include <cstdio>
+#include "rapidjson/document.h"
+#include "rapidjson/writer.h"
+#include "rapidjson/stringbuffer.h"
+#include <algorithm>
+#include <iostream>
+
+using namespace rapidjson;
+
+namespace o2
+{
+namespace ccdb
+{
+
+std::string CCDBResponse::toString()
+{
+  return JsonToString(&document);
+}
+
+std::string CCDBResponse::JsonToString(rapidjson::Document* document)
+{
+  rapidjson::StringBuffer buffer;
+  buffer.Clear();
+  rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+  (*document).Accept(writer);
+  return buffer.GetString();
+}
+
+CCDBResponse::CCDBResponse(const std::string& jsonString)
+{
+  document.Parse(jsonString.c_str());
+  refreshObjectNum();
+  refreshIdMap();
+}
+
+void CCDBResponse::refreshObjectNum()
+{
+  objectNum = countObjects();
+}
+
+void CCDBResponse::refreshPathMap()
+{
+  for (size_t i = 0; i < objectNum; i++) {
+    std::string path = getStringAttribute(i, "path");
+    pathHashmap[path] = path;
+  }
+}
+
+void CCDBResponse::refreshIdMap()
+{
+  for (size_t i = 0; i < objectNum; i++) {
+    std::string id = getStringAttribute(i, "id");
+    idHashmap[id] = id;
+  }
+}
+
+size_t CCDBResponse::countObjects()
+{
+  auto objectsArray = document["objects"].GetArray();
+  return objectsArray.Size();
+}
+
+bool CCDBResponse::mergeObjects(rapidjson::Value& dstObject, rapidjson::Value& srcObject, rapidjson::Document::AllocatorType& allocator)
+{
+  for (auto srcIt = srcObject.MemberBegin(); srcIt != srcObject.MemberEnd(); ++srcIt) {
+    auto dstIt = dstObject.FindMember(srcIt->name);
+    if (dstIt == dstObject.MemberEnd()) {
+      rapidjson::Value dstName;
+      dstName.CopyFrom(srcIt->name, allocator);
+      rapidjson::Value dstVal;
+      dstVal.CopyFrom(srcIt->value, allocator);
+
+      dstObject.AddMember(dstName, dstVal, allocator);
+
+      dstName.CopyFrom(srcIt->name, allocator);
+      dstIt = dstObject.FindMember(dstName);
+      if (dstIt == dstObject.MemberEnd()) {
+        return false;
+      }
+    } else {
+      auto srcT = srcIt->value.GetType();
+      auto dstT = dstIt->value.GetType();
+      if (srcT != dstT) {
+        return false;
+      }
+
+      if (srcIt->value.IsArray()) {
+        for (auto arrayIt = srcIt->value.Begin(); arrayIt != srcIt->value.End(); ++arrayIt) {
+          rapidjson::Value dstVal;
+          dstVal.CopyFrom(*arrayIt, allocator);
+          dstIt->value.PushBack(dstVal, allocator);
+        }
+      } else if (srcIt->value.IsObject()) {
+        if (!mergeObjects(dstIt->value, srcIt->value, allocator)) {
+          return false;
+        }
+      } else {
+        dstIt->value.CopyFrom(srcIt->value, allocator);
+      }
+    }
+  }
+  return true;
+}
+
+void CCDBResponse::removeObjects(rapidjson::Document* document, std::vector<bool> toBeRemoved)
+{
+  rapidjson::Value& objects = (*document)["objects"];
+  if (objects.Size() > 1) {
+    size_t i = 1;
+    rapidjson::Value::ConstValueIterator pastObject = objects.Begin();
+    rapidjson::Value::ConstValueIterator nextObject = pastObject + 1;
+    while (pastObject != objects.End() && nextObject != objects.End()) {
+      if (toBeRemoved[i]) {
+        objects.Erase(nextObject);
+      } else {
+        pastObject++;
+      }
+      nextObject = pastObject + 1;
+      i++;
+    }
+  }
+  if (toBeRemoved[0]) {
+    objects.Erase(objects.Begin());
+  }
+}
+
+std::string CCDBResponse::getStringAttribute(int ind, std::string attributeName)
+{
+  if (ind < objectNum) {
+    const char* attrNameChar = attributeName.c_str();
+    return document["objects"][ind][attrNameChar].GetString();
+  }
+  return "";
+}
+
+void CCDBResponse::browse(CCDBResponse* other)
+{
+  std::vector<bool> toBeRemoved(other->objectNum, false);
+  for (size_t i = 0; i < other->objectNum; i++) {
+    std::string id = other->getStringAttribute(i, "id");
+    if (idHashmap.find(id) != idHashmap.end() && idHashmap[id].compare(id) == 0) {
+      toBeRemoved[i] = true;
+    }
+  }
+  removeObjects(other->getDocument(), toBeRemoved);
+  refreshObjectNum();
+}
+
+void CCDBResponse::browseAndMerge(CCDBResponse* other)
+{
+  browse(other);
+  mergeObjects(document, *(other->getDocument()), document.GetAllocator());
+  refreshObjectNum();
+}
+
+void CCDBResponse::latestAndMerge(CCDBResponse* other)
+{
+  browse(other);
+  other->refreshObjectNum();
+  refreshPathMap();
+  other->refreshPathMap();
+
+  std::vector<bool> toBeRemoved(other->objectNum, false);
+  for (size_t i = 0; i < other->objectNum; i++) {
+    std::string path = other->getStringAttribute(i, "path");
+    if (pathHashmap.find(path) != pathHashmap.end() && pathHashmap[path].compare(other->pathHashmap[path]) == 0) {
+      toBeRemoved[i] = true;
+    }
+  }
+  removeObjects(other->getDocument(), toBeRemoved);
+  mergeObjects(document, *(other->getDocument()), document.GetAllocator());
+  refreshObjectNum();
+}
+
+rapidjson::Document* CCDBResponse::getDocument()
+{
+  return &document;
+}
+
+void CCDBResponse::printObjectAttributes(rapidjson::Document* document)
+{
+  auto objectsArray = (*document)["objects"].GetArray();
+  if (objectsArray.Size() > 0) {
+    for (rapidjson::Value::ConstValueIterator object = objectsArray.begin(); object != objectsArray.end(); object++) {
+      for (rapidjson::Value::ConstMemberIterator entry = object->MemberBegin(); entry != object->MemberEnd(); entry++) {
+        auto& value = entry->value;
+        auto name = entry->name.GetString();
+        if (value.IsString()) {
+          std::cout << name << " " << value.GetString() << std::endl;
+        }
+      }
+      std::cout << "\n";
+    }
+  }
+}
+
+} // namespace ccdb
+} // namespace o2

--- a/CCDB/test/testCCDBResponse.cxx
+++ b/CCDB/test/testCCDBResponse.cxx
@@ -1,0 +1,61 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE CCDB
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include "testCCDBResponseResources.h"
+#include <CCDB/CCDBResponse.h>
+#include <boost/test/unit_test.hpp>
+#include <string>
+
+using namespace o2::ccdb;
+
+BOOST_AUTO_TEST_CASE(TestCCDBResponseParse)
+{
+  std::string* responseString = new std::string(secondFullResponse);
+  CCDBResponse ccdbResponse(*responseString);
+  BOOST_CHECK(ccdbResponse.objectNum == 4);
+  BOOST_CHECK("407f3a65-4c7b-11ec-8cf8-200114580202" == ccdbResponse.getStringAttribute(0, "id"));
+  BOOST_CHECK("e5183d1a-4c7a-11ec-9d71-7f000001aa8b" == ccdbResponse.getStringAttribute(1, "id"));
+  BOOST_CHECK("52d3f61a-4c6b-11ec-a98e-7f000001aa8b" == ccdbResponse.getStringAttribute(2, "id"));
+  BOOST_CHECK("99d3f61a-4c6b-11ec-a98e-7f000001aa8b" == ccdbResponse.getStringAttribute(3, "id"));
+}
+
+BOOST_AUTO_TEST_CASE(TestCCDBResponseBrowse)
+{
+  std::string* firstResponseString = new std::string(firstFullResponse);
+  std::string* secondResponseString = new std::string(secondFullResponse);
+  CCDBResponse firstCcdbResponse(*firstResponseString);
+  CCDBResponse secondCcdbResponse(*secondResponseString);
+
+  firstCcdbResponse.browseAndMerge(&secondCcdbResponse);
+  BOOST_CHECK(firstCcdbResponse.objectNum == 4);
+  BOOST_CHECK("407f3a65-4c7b-11ec-8cf8-200114580202" == firstCcdbResponse.getStringAttribute(0, "id"));
+  BOOST_CHECK("52d3f61a-4c6b-11ec-a98e-7f000001aa8b" == firstCcdbResponse.getStringAttribute(1, "id"));
+  BOOST_CHECK("e5183d1a-4c7a-11ec-9d71-7f000001aa8b" == firstCcdbResponse.getStringAttribute(2, "id"));
+  BOOST_CHECK("99d3f61a-4c6b-11ec-a98e-7f000001aa8b" == firstCcdbResponse.getStringAttribute(3, "id"));
+}
+
+BOOST_AUTO_TEST_CASE(TestCCDBResponseLatest)
+{
+  std::string* firstResponseString = new std::string(firstFullResponse);
+  std::string* secondResponseString = new std::string(secondFullResponse);
+  CCDBResponse firstCcdbResponse(*firstResponseString);
+  CCDBResponse secondCcdbResponse(*secondResponseString);
+
+  firstCcdbResponse.latestAndMerge(&secondCcdbResponse);
+  BOOST_CHECK(firstCcdbResponse.objectNum == 3);
+  BOOST_CHECK("407f3a65-4c7b-11ec-8cf8-200114580202" == firstCcdbResponse.getStringAttribute(0, "id"));
+  BOOST_CHECK("52d3f61a-4c6b-11ec-a98e-7f000001aa8b" == firstCcdbResponse.getStringAttribute(1, "id"));
+  BOOST_CHECK("99d3f61a-4c6b-11ec-a98e-7f000001aa8b" == firstCcdbResponse.getStringAttribute(2, "id"));
+}

--- a/CCDB/test/testCCDBResponseResources.h
+++ b/CCDB/test/testCCDBResponseResources.h
@@ -1,0 +1,247 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_CCDB_RESPONSE_TEST_RESOURCES_H
+#define O2_CCDB_RESPONSE_TEST_RESOURCES_H
+
+namespace o2
+{
+namespace ccdb
+{
+
+const char* firstFullResponse = R"({
+    "objects": [
+        {
+            "path": "Users/g/grigoras/testing/grid/a",
+            "createTime": 1637685278841,
+            "lastModified": 1637685278841,
+            "Created": 1637685278841,
+            "Last-Modified": 1637685278841,
+            "id": "407f3a65-4c7b-11ec-8cf8-200114580202",
+            "validFrom": 1604175160884,
+            "validUntil": 1919535160884,
+            "initialValidity": 1919535160884,
+            "MD5": "c1ffddcd4db30e3e684180165acd63ca",
+            "fileName": "TObject_1595938437506.root",
+            "contentType": "application/octet-stream",
+            "size": 4096,
+            "ETag": "\"407f3a65-4c7b-11ec-8cf8-200114580202\"",
+            "Valid-From": 1604175160884,
+            "Valid-Until": 1919535160884,
+            "InitialValidityLimit": 1919535160884,
+            "Content-MD5": "c1ffddcd4db30e3e684180165acd63ca",
+            "Content-Disposition": "inline;filename=\"TObject_1595938437506.root\"",
+            "Content-Type": "application/octet-stream",
+            "Content-Length": 4096,
+            "UploadedFrom": "2001:1458:202:56::101:bc25",
+            "ObjectType": "TH1F",
+            "qc_detector_name": "HMP",
+            "custom": "34",
+            "UpdatedFrom": "2001:1458:202:56:0:0:101:bc25",
+            "qc_task_name": "daqTask",
+            "qc_version": "1.1.0",
+            "partName": "send",
+            "replicas": [
+                "/download/407f3a65-4c7b-11ec-8cf8-200114580202"
+            ]
+        },
+        {
+            "path": "Users/g/grigoras/testing/grid/b",
+            "createTime": 1637678437647,
+            "lastModified": 1637678437647,
+            "Created": 1637678437647,
+            "Last-Modified": 1637678437647,
+            "id": "52d3f61a-4c6b-11ec-a98e-7f000001aa8b",
+            "validFrom": 1604175160884,
+            "validUntil": 1919535160884,
+            "initialValidity": 1919535160884,
+            "MD5": "c1ffddcd4db30e3e684180165acd63ca",
+            "fileName": "TObject_1595938437506.root",
+            "contentType": "application/octet-stream",
+            "size": 4096,
+            "ETag": "\"52d3f61a-4c6b-11ec-a98e-7f000001aa8b\"",
+            "Valid-From": 1604175160884,
+            "Valid-Until": 1919535160884,
+            "InitialValidityLimit": 1919535160884,
+            "Content-MD5": "c1ffddcd4db30e3e684180165acd63ca",
+            "Content-Disposition": "inline;filename=\"TObject_1595938437506.root\"",
+            "Content-Type": "application/octet-stream",
+            "Content-Length": 4096,
+            "UploadedFrom": "127.0.0.1",
+            "preservation": "false",
+            "ObjectType": "TH1F",
+            "qc_detector_name": "HMP",
+            "custom": "34",
+            "UpdatedFrom": "127.0.0.1",
+            "qc_task_name": "daqTask",
+            "qc_version": "1.1.0",
+            "partName": "send",
+            "replicas": [
+                "/download/52d3f61a-4c6b-11ec-a98e-7f000001aa8b"
+            ]
+        }
+    ]
+}
+)";
+
+const char* secondFullResponse = R"({
+    "objects": [
+        {
+            "path": "Users/g/grigoras/testing/grid/a",
+            "createTime": 1637685278841,
+            "lastModified": 1637685278841,
+            "Created": 1637685278841,
+            "Last-Modified": 1637685278841,
+            "id": "407f3a65-4c7b-11ec-8cf8-200114580202",
+            "validFrom": 1604175160884,
+            "validUntil": 1919535160884,
+            "initialValidity": 1919535160884,
+            "MD5": "c1ffddcd4db30e3e684180165acd63ca",
+            "fileName": "TObject_1595938437506.root",
+            "contentType": "application/octet-stream",
+            "size": 4096,
+            "ETag": "\"407f3a65-4c7b-11ec-8cf8-200114580202\"",
+            "Valid-From": 1604175160884,
+            "Valid-Until": 1919535160884,
+            "InitialValidityLimit": 1919535160884,
+            "Content-MD5": "c1ffddcd4db30e3e684180165acd63ca",
+            "Content-Disposition": "inline;filename=\"TObject_1595938437506.root\"",
+            "Content-Type": "application/octet-stream",
+            "Content-Length": 4096,
+            "UploadedFrom": "2001:1458:202:56::101:bc25",
+            "ObjectType": "TH1F",
+            "qc_detector_name": "HMP",
+            "custom": "34",
+            "UpdatedFrom": "2001:1458:202:56:0:0:101:bc25",
+            "qc_task_name": "daqTask",
+            "qc_version": "1.1.0",
+            "partName": "send",
+            "replicas": [
+                "/download/407f3a65-4c7b-11ec-8cf8-200114580202"
+            ]
+        },
+        {
+            "path": "Users/g/grigoras/testing/grid/a",
+            "createTime": 1637685125493,
+            "lastModified": 1637685125493,
+            "Created": 1637685125493,
+            "Last-Modified": 1637685125493,
+            "id": "e5183d1a-4c7a-11ec-9d71-7f000001aa8b",
+            "validFrom": 1604175160884,
+            "validUntil": 1919535160884,
+            "initialValidity": 1919535160884,
+            "MD5": "c1ffddcd4db30e3e684180165acd63ca",
+            "fileName": "TObject_1595938437506.root",
+            "contentType": "application/octet-stream",
+            "size": 4096,
+            "ETag": "\"e5183d1a-4c7a-11ec-9d71-7f000001aa8b\"",
+            "Valid-From": 1604175160884,
+            "Valid-Until": 1919535160884,
+            "InitialValidityLimit": 1919535160884,
+            "Content-MD5": "c1ffddcd4db30e3e684180165acd63ca",
+            "Content-Disposition": "inline;filename=\"TObject_1595938437506.root\"",
+            "Content-Type": "application/octet-stream",
+            "Content-Length": 4096,
+            "UploadedFrom": "127.0.0.1",
+            "ObjectType": "TH1F",
+            "qc_detector_name": "HMP",
+            "custom": "34",
+            "UpdatedFrom": "127.0.0.1",
+            "qc_task_name": "daqTask",
+            "qc_version": "1.1.0",
+            "partName": "send",
+            "replicas": [
+                "alien:///alice/data/CCDB/Users/g/grigoras/testing/grid/00/18200/e5183d1a-4c7a-11ec-9d71-7f000001aa8b",
+                "/download/e5183d1a-4c7a-11ec-9d71-7f000001aa8b"
+            ]
+        },
+        {
+            "path": "Users/g/grigoras/testing/grid/a",
+            "createTime": 1637678437647,
+            "lastModified": 1637678437647,
+            "Created": 1637678437647,
+            "Last-Modified": 1637678437647,
+            "id": "52d3f61a-4c6b-11ec-a98e-7f000001aa8b",
+            "validFrom": 1604175160884,
+            "validUntil": 1919535160884,
+            "initialValidity": 1919535160884,
+            "MD5": "c1ffddcd4db30e3e684180165acd63ca",
+            "fileName": "TObject_1595938437506.root",
+            "contentType": "application/octet-stream",
+            "size": 4096,
+            "ETag": "\"52d3f61a-4c6b-11ec-a98e-7f000001aa8b\"",
+            "Valid-From": 1604175160884,
+            "Valid-Until": 1919535160884,
+            "InitialValidityLimit": 1919535160884,
+            "Content-MD5": "c1ffddcd4db30e3e684180165acd63ca",
+            "Content-Disposition": "inline;filename=\"TObject_1595938437506.root\"",
+            "Content-Type": "application/octet-stream",
+            "Content-Length": 4096,
+            "UploadedFrom": "127.0.0.1",
+            "preservation": "false",
+            "ObjectType": "TH1F",
+            "qc_detector_name": "HMP",
+            "custom": "34",
+            "UpdatedFrom": "127.0.0.1",
+            "qc_task_name": "daqTask",
+            "qc_version": "1.1.0",
+            "partName": "send",
+            "replicas": [
+                "/download/52d3f61a-4c6b-11ec-a98e-7f000001aa8b"
+            ]
+        },
+        {
+            "path": "Users/g/grigoras/testing/grid/c",
+            "createTime": 1637678437647,
+            "lastModified": 1637678437647,
+            "Created": 1637678437647,
+            "Last-Modified": 1637678437647,
+            "id": "99d3f61a-4c6b-11ec-a98e-7f000001aa8b",
+            "validFrom": 1604175160884,
+            "validUntil": 1919535160884,
+            "initialValidity": 1919535160884,
+            "MD5": "c1ffddcd4db30e3e684180165acd63ca",
+            "fileName": "TObject_1595938437506.root",
+            "contentType": "application/octet-stream",
+            "size": 4096,
+            "ETag": "\"52d3f61a-4c6b-11ec-a98e-7f000001aa8b\"",
+            "Valid-From": 1604175160884,
+            "Valid-Until": 1919535160884,
+            "InitialValidityLimit": 1919535160884,
+            "Content-MD5": "c1ffddcd4db30e3e684180165acd63ca",
+            "Content-Disposition": "inline;filename=\"TObject_1595938437506.root\"",
+            "Content-Type": "application/octet-stream",
+            "Content-Length": 4096,
+            "UploadedFrom": "127.0.0.1",
+            "preservation": "false",
+            "ObjectType": "TH1F",
+            "qc_detector_name": "HMP",
+            "custom": "34",
+            "UpdatedFrom": "127.0.0.1",
+            "qc_task_name": "daqTask",
+            "qc_version": "1.1.0",
+            "partName": "send",
+            "replicas": [
+                "/download/52d3f61a-4c6b-11ec-a98e-7f000001aa8b"
+            ]
+        }
+    ]
+}
+)";
+
+const char* emptyResponse = R"({
+    "objects": [],
+})";
+
+} // namespace ccdb
+} // namespace o2
+
+#endif

--- a/CCDB/test/testCcdbApi.cxx
+++ b/CCDB/test/testCcdbApi.cxx
@@ -19,7 +19,7 @@
 #define BOOST_TEST_DYN_LINK
 
 #include "CCDB/CcdbApi.h"
-#include "CCDB/IdPath.h"    // just as test object
+#include "CCDB/IdPath.h"           // just as test object
 #include "CommonUtils/RootChain.h" // just as test object
 #include "CCDB/CCDBTimeStampUtils.h"
 #include <boost/test/unit_test.hpp>
@@ -101,6 +101,24 @@ struct test_fixture {
   CcdbApi api;
   map<string, string> metadata;
 };
+
+BOOST_AUTO_TEST_CASE(CCDBResponseLatest)
+{
+  CcdbApi api;
+  string url = "http://ccdb-test.cern.ch:8080,http://alice-ccdb.cern.ch";
+  api.init(url);
+  std::string response = api.latest();
+  BOOST_CHECK(response != "");
+}
+
+BOOST_AUTO_TEST_CASE(CCDBResponseBrowse)
+{
+  CcdbApi api;
+  string url = "http://ccdb-test.cern.ch:8080,http://alice-ccdb.cern.ch";
+  api.init(url);
+  std::string response = api.browse();
+  BOOST_CHECK(response != "");
+}
 
 BOOST_AUTO_TEST_CASE(storeTMemFile_test, *utf::precondition(if_reachable()))
 {


### PR DESCRIPTION
Added two functions to CCDBApi:

browse() - retrieves the /browse/ result from all servers in hostsPool and concatenates them into one string in JSON format. In case of duplicate ids the function takes the object from the server that comes earlier in the hostsPool, in order to mimick a /browse/ response from all servers.

latest() - same as browse() but for the /latest/ call. Removes duplicate ids and paths, prioritizing objects coming from servers earlier in the hostsPool.

If needed, contact me at michal.dominik.trzebuniak@cern.ch