### PR TITLE
Suppress massive sorting in SVertexer

### DIFF
--- a/Detectors/Vertexing/include/DetectorsVertexing/SVertexer.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/SVertexer.h
@@ -122,8 +122,6 @@ class SVertexer
   std::vector<std::vector<Cascade>> mCascadesTmp;
   std::array<std::vector<TrackCand>, 2> mTracksPool{}; // pools of positive and negative seeds sorted in min VtxID
   std::array<std::vector<int>, 2> mVtxFirstTrack{};    // 1st pos. and neg. track of the pools for each vertex
-  std::array<std::vector<int>, 2> mTrackSortVtxMax{};  // pos. and neg. track indices sorted by max VtxID
-  std::array<std::vector<int>, 2> mVtxMaxLUT{};        // pos. and neg. max vtx ID track LUT for each vertex
 
   o2d::VertexBase mMeanVertex{{0., 0., 0.}, {0.1 * 0.1, 0., 0.1 * 0.1, 0., 0., 6. * 6.}};
   const SVertexerParams* mSVParams = nullptr;

--- a/Detectors/Vertexing/src/SVertexer.cxx
+++ b/Detectors/Vertexing/src/SVertexer.cxx
@@ -315,8 +315,10 @@ void SVertexer::buildT2V(const o2::globaltracking::RecoContainer& recoData) // a
     const auto& tracksPool = mTracksPool[pn];
     for (unsigned i = 0; i < tracksPool.size(); i++) {
       const auto& t = tracksPool[i];
-      if (vtxFirstT[t.vBracket.getMin()] == -1) {
-        vtxFirstT[t.vBracket.getMin()] = i;
+      for (int j{t.vBracket.getMin()}; j <= t.vBracket.getMax(); ++j) {
+        if (vtxFirstT[j] == -1) {
+          vtxFirstT[j] = i;
+        }
       }
     }
   }


### PR DESCRIPTION
Hi @fmazzasc 

Here is it, could you check if suffers in efficiency wrt your version?  Note that with unconstrained TPC tracks enabled it is still quite slow in high rate pp, but at least it can profits from the multithreding: 
```
o2-secondary-vertexing-workflow $GLO_ARG  --vertexing-sources ITS-TPC,ITS-TPC-TRD,ITS-TPC-TOF,ITS-TPC-TRD-TOF,ITS,TPC,TOF,FT0,TRD --configKeyValues "keyval.output_dir=/dev/null;$VDRIFT;" --threads 6 --hbfutils-config o2_tfidinfo.root

[2791441:secondary-vertexing]: [14:53:57][INFO] Collected 4719724 positive and 3514131 negative seeds
[2791441:secondary-vertexing]: [14:57:32][INFO] Found 87135 V0s and 56093 cascades, timing: CPU: 1289.3 Real: 217.468 s
[2791443:secondary-vertex-writer]: [14:57:32][INFO] SecondaryVertexWriter pulled 87135 v0s
[2791441:secondary-vertexing]: [14:57:32][INFO] Secondary vertexing total timing: Cpu: 1.289e+03 Real: 2.175e+02 s in 1 slots, nThreads = 6
[2791443:secondary-vertex-writer]: [14:57:32][INFO] SecondaryVertexWriter pulled 56093 cascades
```