### PR TITLE
Add add function to work with strings

### DIFF
--- a/Framework/Core/include/Framework/HistogramRegistry.h
+++ b/Framework/Core/include/Framework/HistogramRegistry.h
@@ -93,7 +93,7 @@ class HistogramRegistry
   HistPtr add(const HistogramSpec& histSpec);
   HistPtr add(char const* const name, char const* const title, const HistogramConfigSpec& histConfigSpec, bool callSumw2 = false);
   HistPtr add(char const* const name, char const* const title, HistType histType, const std::vector<AxisSpec>& axes, bool callSumw2 = false);
-  HistPtr add(std::string_view name, char const* const title, HistType histType, const std::vector<AxisSpec>& axes, bool callSumw2 = false);
+  HistPtr add(const std::string& name, char const* const title, HistType histType, const std::vector<AxisSpec>& axes, bool callSumw2 = false);
 
   template <typename T>
   std::shared_ptr<T> add(char const* const name, char const* const title, const HistogramConfigSpec& histConfigSpec, bool callSumw2 = false);

--- a/Framework/Core/include/Framework/HistogramRegistry.h
+++ b/Framework/Core/include/Framework/HistogramRegistry.h
@@ -93,7 +93,7 @@ class HistogramRegistry
   HistPtr add(const HistogramSpec& histSpec);
   HistPtr add(char const* const name, char const* const title, const HistogramConfigSpec& histConfigSpec, bool callSumw2 = false);
   HistPtr add(char const* const name, char const* const title, HistType histType, const std::vector<AxisSpec>& axes, bool callSumw2 = false);
-  HistPtr add(const std::string_view& name, char const* const title, HistType histType, const std::vector<AxisSpec>& axes, bool callSumw2 = false);
+  HistPtr add(std::string_view name, char const* const title, HistType histType, const std::vector<AxisSpec>& axes, bool callSumw2 = false);
 
   template <typename T>
   std::shared_ptr<T> add(char const* const name, char const* const title, const HistogramConfigSpec& histConfigSpec, bool callSumw2 = false);

--- a/Framework/Core/include/Framework/HistogramRegistry.h
+++ b/Framework/Core/include/Framework/HistogramRegistry.h
@@ -93,6 +93,7 @@ class HistogramRegistry
   HistPtr add(const HistogramSpec& histSpec);
   HistPtr add(char const* const name, char const* const title, const HistogramConfigSpec& histConfigSpec, bool callSumw2 = false);
   HistPtr add(char const* const name, char const* const title, HistType histType, const std::vector<AxisSpec>& axes, bool callSumw2 = false);
+  HistPtr add(const std::string_view& name, char const* const title, HistType histType, const std::vector<AxisSpec>& axes, bool callSumw2 = false);
 
   template <typename T>
   std::shared_ptr<T> add(char const* const name, char const* const title, const HistogramConfigSpec& histConfigSpec, bool callSumw2 = false);

--- a/Framework/Core/src/HistogramRegistry.cxx
+++ b/Framework/Core/src/HistogramRegistry.cxx
@@ -114,7 +114,7 @@ HistPtr HistogramRegistry::add(char const* const name, char const* const title, 
   return insert({name, title, {histType, axes}, callSumw2});
 }
 
-HistPtr HistogramRegistry::add(std::string_view name, char const* const title, HistType histType, const std::vector<AxisSpec>& axes, bool callSumw2)
+HistPtr HistogramRegistry::add(const std::string& name, char const* const title, HistType histType, const std::vector<AxisSpec>& axes, bool callSumw2)
 {
   return insert({name.data(), title, {histType, axes}, callSumw2});
 }

--- a/Framework/Core/src/HistogramRegistry.cxx
+++ b/Framework/Core/src/HistogramRegistry.cxx
@@ -114,7 +114,7 @@ HistPtr HistogramRegistry::add(char const* const name, char const* const title, 
   return insert({name, title, {histType, axes}, callSumw2});
 }
 
-HistPtr HistogramRegistry::add(const std::string_view& name, char const* const title, HistType histType, const std::vector<AxisSpec>& axes, bool callSumw2)
+HistPtr HistogramRegistry::add(std::string_view name, char const* const title, HistType histType, const std::vector<AxisSpec>& axes, bool callSumw2)
 {
   return insert({name.data(), title, {histType, axes}, callSumw2});
 }

--- a/Framework/Core/src/HistogramRegistry.cxx
+++ b/Framework/Core/src/HistogramRegistry.cxx
@@ -114,6 +114,11 @@ HistPtr HistogramRegistry::add(char const* const name, char const* const title, 
   return insert({name, title, {histType, axes}, callSumw2});
 }
 
+HistPtr HistogramRegistry::add(const std::string_view& name, char const* const title, HistType histType, const std::vector<AxisSpec>& axes, bool callSumw2)
+{
+  return insert({name.data(), title, {histType, axes}, callSumw2});
+}
+
 // store a copy of an existing histogram (or group of histograms) under a different name
 void HistogramRegistry::addClone(const std::string& source, const std::string& target)
 {

--- a/Framework/Core/src/HistogramRegistry.cxx
+++ b/Framework/Core/src/HistogramRegistry.cxx
@@ -116,7 +116,7 @@ HistPtr HistogramRegistry::add(char const* const name, char const* const title, 
 
 HistPtr HistogramRegistry::add(const std::string& name, char const* const title, HistType histType, const std::vector<AxisSpec>& axes, bool callSumw2)
 {
-  return insert({name.data(), title, {histType, axes}, callSumw2});
+  return insert({name.c_str(), title, {histType, axes}, callSumw2});
 }
 
 // store a copy of an existing histogram (or group of histograms) under a different name


### PR DESCRIPTION
This allows to switch from e.g. 
`histos.add(hnsigma[id].data(), axisTitle, kTH2F, {pAxis, nSigmaAxis});`
to 
`histos.add(hnsigma[id], axisTitle, kTH2F, {pAxis, nSigmaAxis});`
when using arrays to initialize histograms.
This can also be done locally with helper functions but probably it's best to have it in the parent class