### PR TITLE
TRD: Trackletsparser: corrections, spacing and logic changes

### DIFF
--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/TrackletsParser.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/TrackletsParser.h
@@ -48,7 +48,6 @@ class TrackletsParser
                              StateTrackletEndMarker,
                              StateFinished };
   std::vector<Tracklet64>& getTracklets() { return mTracklets; }
-  inline void swapByteOrder(unsigned int& ui);
   bool getTrackletParsingState() { return mTrackletParsingBad; }
   void clear()
   {

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/TrackletsParser.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/TrackletsParser.h
@@ -38,18 +38,9 @@ class TrackletsParser
   int Parse(); // presupposes you have set everything up already.
   int Parse(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>* data, std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator start, std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator end, TRDFeeID feeid, int robside,
             int detector, int stack, int layer, EventRecord* eventrecord, EventStorage* eventrecords, std::bitset<16> option, bool cleardigits = false, int usetracklethcheader = 0);
-  void setVerbose(bool verbose, bool header = false, bool data = false)
-  {
-    mVerbose = verbose;
-    mHeaderVerbose = header;
-    mDataVerbose = data;
-  }
-  void setByteSwap(bool swap) { mByteOrderFix = swap; }
   int getDataWordsRead() { return mWordsRead; }
   int getDataWordsDumped() { return mWordsDumped; }
   int getTrackletsFound() { return mTrackletsFound; }
-  void setIgnoreTrackletHCHeader(bool ignore) { mIgnoreTrackletHCHeader = ignore; }
-  bool getIgnoreTrackletHCHeader() { return mIgnoreTrackletHCHeader; }
   enum TrackletParserState { StateTrackletHCHeader, // always the start of a half chamber.
                              StateTrackletMCMHeader,
                              StateTrackletMCMData,
@@ -97,24 +88,19 @@ class TrackletsParser
   TrackletMCMHeader* mTrackletMCMHeader;
   std::array<TrackletMCMData, 3> mTrackletMCMData;
 
-  int mState{0};               // state that the parser is currently in.
-  int mWordsRead{0};           // number of words read from buffer
-  uint64_t mWordsDumped{0};    // number of words ignored from buffer
-  int mTrackletsFound{0};      // tracklets found in the data block, mostly used for debugging.
-  int mPaddingWordsCounter{0}; // count of padding words encountered
-  Tracklet64 mCurrentTrack;    // the current track we are looking at, used to accumulate the possibly 3 tracks from the parsing 4 incoming data words
-  bool mVerbose{false};        // user verbose output, put debug statement in output from commandline.
-  bool mHeaderVerbose{false};
-  bool mDataVerbose{false};
-  int mTrackletHCHeaderState{0};       // what to with the tracklet half chamber header 0,1,2
-  bool mIgnoreTrackletHCHeader{false}; // Is the data with out the tracklet HC Header? defaults to having it in.
-  bool mByteOrderFix{false};           // simulated data is not byteswapped, real is, so deal with it accordingly.
+  int mState{0};            // state that the parser is currently in.
+  int mWordsRead{0};        // number of words read from buffer
+  uint64_t mWordsDumped{0}; // number of words ignored from buffer
+  int mTrackletsFound{0};   // tracklets found in the data block, mostly used for debugging.
+  int mPaddingWordsCounter{0}; // count of padding words encoutnered
+  Tracklet64 mCurrentTrack; // the current track we are looking at, used to accumulate the possibly 3 tracks from the parsing 4 incoming data words
+  int mTrackletHCHeaderState{0}; //what to with the tracklet half chamber header 0,1,2
   std::bitset<16> mOptions;
   bool mTrackletParsingBad{false}; // store weather we should dump the rest of the link buffer after working through this tracklet buffer.
   uint16_t mEventCounter{0};
   std::chrono::duration<double> mTrackletparsetime;                                        // store the time it takes to parse
   std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator mStartParse, mEndParse; // limits of parsing, effectively the link limits to parse on.
-  // uint32_t mCurrentLinkDataPosition256;                // count of data read for current link in units of 256 bits
+  //uint32_t mCurrentLinkDataPosition256;                // count of data read for current link in units of 256 bits
   EventRecord* mEventRecord;
   EventStorage* mEventRecords;
 

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/TrackletsParser.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/TrackletsParser.h
@@ -88,19 +88,19 @@ class TrackletsParser
   TrackletMCMHeader* mTrackletMCMHeader;
   std::array<TrackletMCMData, 3> mTrackletMCMData;
 
-  int mState{0};            // state that the parser is currently in.
-  int mWordsRead{0};        // number of words read from buffer
-  uint64_t mWordsDumped{0}; // number of words ignored from buffer
-  int mTrackletsFound{0};   // tracklets found in the data block, mostly used for debugging.
-  int mPaddingWordsCounter{0}; // count of padding words encoutnered
-  Tracklet64 mCurrentTrack; // the current track we are looking at, used to accumulate the possibly 3 tracks from the parsing 4 incoming data words
-  int mTrackletHCHeaderState{0}; //what to with the tracklet half chamber header 0,1,2
+  int mState{0};                 // state that the parser is currently in.
+  int mWordsRead{0};             // number of words read from buffer
+  uint64_t mWordsDumped{0};      // number of words ignored from buffer
+  int mTrackletsFound{0};        // tracklets found in the data block, mostly used for debugging.
+  int mPaddingWordsCounter{0};   // count of padding words encountered
+  Tracklet64 mCurrentTrack;      // the current track we are looking at, used to accumulate the possibly 3 tracks from the parsing 4 incoming data words
+  int mTrackletHCHeaderState{0}; // what to with the tracklet half chamber header 0,1,2
   std::bitset<16> mOptions;
   bool mTrackletParsingBad{false}; // store weather we should dump the rest of the link buffer after working through this tracklet buffer.
   uint16_t mEventCounter{0};
   std::chrono::duration<double> mTrackletparsetime;                                        // store the time it takes to parse
   std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator mStartParse, mEndParse; // limits of parsing, effectively the link limits to parse on.
-  //uint32_t mCurrentLinkDataPosition256;                // count of data read for current link in units of 256 bits
+  // uint32_t mCurrentLinkDataPosition256;                // count of data read for current link in units of 256 bits
   EventRecord* mEventRecord;
   EventStorage* mEventRecords;
 

--- a/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
+++ b/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
@@ -107,48 +107,49 @@ int TrackletsParser::Parse()
   mCurrentLink = 0;
   mWordsRead = 0;
   mTrackletsFound = 0;
+
   if (mTrackletHCHeaderState == 0) {
     // tracklet hc header is never present
     mState = StateTrackletMCMHeader;
     LOG(error) << " This option of TrackletHalfChamberHeader 0 is no longer permitted";
     return -1;
-  } else {
-    if (mTrackletHCHeaderState == 1) {
-      // we either have a tracklet half chamber header word or a digit one.
-      // digit has 01 at the end last 2 bits and the supermodule in bits 9 to 13 [0:17]
-      // tracklet has bit 11 (zero based) set to 1
-      // we have tracklet data so no TrackletHCHeader
-      mState = StateTrackletHCHeader;
-      TrackletHCHeader hcheader;
+  }
 
-      hcheader.word = *mStartParse;
-      uint32_t tmpheader = *mStartParse;
-      if (!sanityCheckTrackletHCHeader(hcheader)) {
-        // we dont have a tracklethcheader so no tracklet data.
-        if (mOptions[TRDHeaderVerboseBit]) {
-          LOG(info) << "Returning 0 from tracklet parsing " << std::hex << (tmpheader & 0x3) << " supermodule : " << ((tmpheader >> 9) & 0x1f);
-        }
+  if (mTrackletHCHeaderState == 1) {
+    // we either have a tracklet half chamber header word or a digit one.
+    // digit has 01 at the end last 2 bits and the supermodule in bits 9 to 13 [0:17]
+    // tracklet has bit 11 (zero based) set to 1
+    // we have tracklet data so no TrackletHCHeader
+    mState = StateTrackletHCHeader;
+    TrackletHCHeader hcheader;
 
-        return -1; // mWordsRead;
+    hcheader.word = *mStartParse;
+    uint32_t tmpheader = *mStartParse;
+    if (!sanityCheckTrackletHCHeader(hcheader)) {
+      // we dont have a tracklethcheader so no tracklet data.
+      if (mOptions[TRDHeaderVerboseBit]) {
+        LOG(info) << "Returning 0 from tracklet parsing " << std::hex << (tmpheader & 0x3) << " supermodule : " << ((tmpheader >> 9) & 0x1f);
       }
-      // NBNBNBNB
-      // digit half chamber header ends with 01b and has the supermodule in position (9-13).
-      // this of course can conflict with a tracklet hc header, hence should not be used!
-      // NBNBNBNB
-      if ((tmpheader & 0x3) == 0x1 && (((tmpheader >> 9) & 0x1f) == mHCID / 30)) {
-        if (mOptions[TRDHeaderVerboseBit]) {
-          LOG(info) << " we seem to be on a digit halfchamber header";
-        }
-        return 0;
-      }
-      mState = StateTrackletHCHeader;
-    } else {
-      if (mTrackletHCHeaderState != 2) {
-        LOG(warn) << "Unknown TrackletHCHeaderState of " << mTrackletHCHeaderState;
-      }
-      // tracklet hc header is always present
-      mState = StateTrackletHCHeader; // we start with a trackletMCMHeader
+
+      return -1; // mWordsRead;
     }
+    // NBNBNBNB
+    // digit half chamber header ends with 01b and has the supermodule in position (9-13).
+    // this of course can conflict with a tracklet hc header, hence should not be used!
+    // NBNBNBNB
+    if ((tmpheader & 0x3) == 0x1 && (((tmpheader >> 9) & 0x1f) == mHCID / 30)) {
+      if (mOptions[TRDHeaderVerboseBit]) {
+        LOG(info) << " we seem to be on a digit halfchamber header";
+      }
+      return 0;
+    }
+    mState = StateTrackletHCHeader;
+  } else {
+    if (mTrackletHCHeaderState != 2) {
+      LOG(warn) << "Unknown TrackletHCHeaderState of " << mTrackletHCHeaderState;
+    }
+    // tracklet hc header is always present
+    mState = StateTrackletHCHeader; // we start with a trackletMCMHeader
   }
 
   int currentLinkStart = 0;

--- a/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
+++ b/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
@@ -297,8 +297,9 @@ int TrackletsParser::Parse()
             mEventRecord->popTracklets(mcmtrackletcount); // our format is always 4
             // TODO count remove warning
           }
+
           // take the header and this data word and build the underlying 64bit tracklet.
-          int q0, q1, q2;
+          uint32_t q0, q1, q2;
           if (mcmtrackletcount > 2) {
             LOG(info) << "mcmtrackletcount is not in [0:2] count=" << mcmtrackletcount << " headertrackletcount=" << headertrackletcount << " something very wrong parsing the TrackletMCMData fields with data of : 0x" << std::hex << *word;
             incParsingError(TRDParsingTrackletInvalidTrackletCount);
@@ -310,10 +311,11 @@ int TrackletsParser::Parse()
             q0 = getChargeFromRawHeaders(mTrackletHCHeader, mTrackletMCMHeader, mTrackletMCMData, 0, mcmtrackletcount);
             q1 = getChargeFromRawHeaders(mTrackletHCHeader, mTrackletMCMHeader, mTrackletMCMData, 1, mcmtrackletcount);
             q2 = getChargeFromRawHeaders(mTrackletHCHeader, mTrackletMCMHeader, mTrackletMCMData, 2, mcmtrackletcount);
-            int padrow = mTrackletMCMHeader->padrow;
-            int col = mTrackletMCMHeader->col;
-            int pos = mTrackletMCMData[mcmtrackletcount].pos;
-            int slope = mTrackletMCMData[mcmtrackletcount].slope;
+            uint32_t padrow = mTrackletMCMHeader->padrow;
+            uint32_t col = mTrackletMCMHeader->col;
+            uint32_t pos = mTrackletMCMData[mcmtrackletcount].pos;
+            uint32_t slope = mTrackletMCMData[mcmtrackletcount].slope;
+
             // The 8-th bit of position and slope are always flipped in the FEE.
             // We flip them back while reading the raw data so that they are stored
             // without flipped bits in the CTFs

--- a/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
+++ b/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
@@ -329,14 +329,17 @@ int TrackletsParser::Parse()
                 LOG(info) << "Tracklet HCID : " << hcid << " mDetector:" << mDetector << " robside:" << mHalfChamberSide << " " << mTrackletMCMHeader->padrow << ":" << mTrackletMCMHeader->col;
               }
             }
+
             // TODO cross reference hcid to somewhere for a check. mDetector is assigned at the time of parser initialization.
             if (mOptions[TRDDataVerboseBit]) {
               LOG(info) << "TTT format : " << (int)mTrackletHCHeader.format << " hcid: " << hcid << " padrow:" << padrow << " col:" << col << " pos:" << pos << " slope:" << slope << " q::" << q0 << " " << q1 << " " << q2;
             }
+
             mEventRecord->getTracklets().emplace_back((int)mTrackletHCHeader.format, hcid, padrow, col, pos, slope, q0, q1, q2); // our format is always
             mEventRecord->incTrackletsFound(1);
             mTrackletsFound++;
             mcmtrackletcount++;
+
             if (mcmtrackletcount == headertrackletcount) { // headertrackletcount and mcmtrackletcount are not zero based counting
               // at the end of the tracklet output of this mcm
               // next to come can either be an mcmheaderword or a trackletendmarker.
@@ -353,8 +356,10 @@ int TrackletsParser::Parse()
         }
       }
     } // else
+
     trackletloopcount++;
   } // end of for loop
+
   // sanity check
   incParsingError(TRDParsingTrackletExitingNoTrackletEndMarker);
 

--- a/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
+++ b/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
@@ -253,9 +253,11 @@ int TrackletsParser::Parse()
             a.word = *word;
             printTrackletMCMHeader(a);
           }
+
           if (!sanityCheckTrackletMCMHeader(mTrackletMCMHeader)) {
             incParsingError(TRDParsingTrackletMCMHeaderSanityCheckFailure);
           }
+
           headertrackletcount = getNumberOfTrackletsFromHeader(mTrackletMCMHeader);
           if (headertrackletcount > 0) {
             mState = StateTrackletMCMData; // after reading a header we should then have data for next round through the loop
@@ -276,14 +278,15 @@ int TrackletsParser::Parse()
             word = mEndParse;
             continue;
           }
+
           mState = StateTrackletMCMData;
-          // tracklet data;
-          mTrackletMCMData[mcmtrackletcount].word = *word;
+          mTrackletMCMData[mcmtrackletcount].word = *word; // tracklet data
           mWordsRead++;
           if (mOptions[TRDHeaderVerboseBit]) {
             LOG(info) << "*** TrackletMCMData : 0x" << std::hex << *word << " at offset :0x" << std::distance(mStartParse, word);
             printTrackletMCMData(mTrackletMCMData[mcmtrackletcount]);
           }
+
           // do we have more tracklets than the header allows?
           if (headertrackletcount < mcmtrackletcount) {
             ignoreDataTillTrackletEndMarker = true;

--- a/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
+++ b/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
@@ -269,7 +269,7 @@ int TrackletsParser::Parse()
           std::fill(mTrackletMCMData.begin(), mTrackletMCMData.end(), TrackletMCMData{0});
           mWordsRead++;
         } else {
-          if (mState == StateTrackletMCMHeader || (mState == StateTrackletHCHeader && !mOptions[mIgnoreTrackletHCHeader])) {
+          if (mState == StateTrackletMCMHeader || (mState == StateTrackletHCHeader && !mOptions[TRDIgnoreTrackletHCHeaderBit])) {
             // if we are here something is wrong, dump the data. The else of line 227 should imply we are in StateTrackletMCMData;
             ignoreDataTillTrackletEndMarker = true;
             incParsingError(TRDParsingTrackletStateMCMHeaderButParsingMCMData);

--- a/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
+++ b/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
@@ -183,8 +183,8 @@ int TrackletsParser::Parse()
     }
 
     if (*word == 0x10001000 && nextwordcopy == 0x10001000) {
-      if (!StateTrackletEndMarker && !StateTrackletHCHeader) {
-        LOG(warn) << "State should be TrackletEndMarker, current ?= end marker  ?? " << mState << " ?=" << StateTrackletEndMarker;
+      if (mState != StateTrackletEndMarker) {
+        LOG(warn) << "State should be TrackletEndMarker (=" << StateTrackletEndMarker << "), but is currently: " << mState;
       }
 
       mWordsRead += 2;

--- a/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
+++ b/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
@@ -196,6 +196,7 @@ int TrackletsParser::Parse()
       mState = StateFinished;
       return mWordsRead;
     }
+
     if (*word == o2::trd::constants::CRUPADDING32) {
       // padding word first as it clashes with the hcheader.
       mState = StatePadding;
@@ -211,6 +212,7 @@ int TrackletsParser::Parse()
         incParsingError(TRDParsingTrackletBit11NotSetInTrackletHCHeader);
         continue; // go back to the start of loop, walk the data till the above code of the tracklet end marker is hit, padding is hit or we get to the end of the data.
       }
+
       // fix to missing bit on supermodule 16 and 17, to set the uniquely identifying bit.
       if (mState == StateTrackletHCHeader) {
         if (mOptions[TRDVerboseBit]) {
@@ -221,6 +223,7 @@ int TrackletsParser::Parse()
         }
         // LOG(info) << "mFEEID : 0x"<< std::hex << mFEEID.word << " supermodule : 0x" << (int)mFEEID.supermodule << " tracklethcheader : 0x" << *word;
       }
+
       // now for Tracklet hc header
       if ((isTrackletHCHeader(*word)) && !mOptions[TRDIgnoreTrackletHCHeaderBit] && mState == StateTrackletHCHeader) { // TrackletHCHeader has bit 11 set to 1 always. Check for state because raw data can have bit 11 set!
         if (mState != StateTrackletHCHeader) {

--- a/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
+++ b/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
@@ -226,9 +226,6 @@ int TrackletsParser::Parse()
 
       // now for Tracklet hc header
       if ((isTrackletHCHeader(*word)) && !mOptions[TRDIgnoreTrackletHCHeaderBit] && mState == StateTrackletHCHeader) { // TrackletHCHeader has bit 11 set to 1 always. Check for state because raw data can have bit 11 set!
-        if (mState != StateTrackletHCHeader) {
-          incParsingError(TRDParsingTrackletBit11NotSetInTrackletHCHeader);
-        }
         // read the header
         if (mOptions[TRDHeaderVerboseBit]) {
           LOG(info) << "*** TrackletHCHeader : 0x" << std::hex << *word << " at offset :0x" << std::distance(mStartParse, word);

--- a/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
+++ b/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
@@ -99,9 +99,10 @@ int TrackletsParser::Parse()
   // producing a vector of digits.
 
   mTrackletParsingBad = false;
-  if (mOptions[TRDHeaderVerboseBit]) {
+  if (mOptions[TRDHeaderVerboseBit]) { // prints the incoming data, for debugging.
     OutputIncomingData();
   }
+
   // mData holds a buffer containing tracklets parse placing tracklets in the output vector.
   mCurrentLink = 0;
   mWordsRead = 0;

--- a/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
+++ b/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
@@ -151,7 +151,7 @@ int TrackletsParser::Parse()
       mState = StateTrackletHCHeader;
     } else {
       if (mTrackletHCHeaderState != 2) {
-        LOG(warn) << "unknwon TrackletHCHeaderState of " << mIgnoreTrackletHCHeader;
+        LOG(warn) << "Unknown TrackletHCHeaderState of " << mTrackletHCHeaderState;
       }
       // tracklet hc header is always present
       mState = StateTrackletHCHeader; // we start with a trackletMCMHeader

--- a/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
+++ b/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
@@ -32,14 +32,6 @@
 namespace o2::trd
 {
 
-inline void TrackletsParser::swapByteOrder(unsigned int& ui)
-{
-  ui = (ui >> 24) |
-       ((ui << 8) & 0x00FF0000) |
-       ((ui >> 8) & 0x0000FF00) |
-       (ui << 24);
-}
-
 int TrackletsParser::Parse(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>* data,
                            std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator start,
                            std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator end,
@@ -182,8 +174,8 @@ int TrackletsParser::Parse()
     uint32_t nextwordcopy = *nextword;
 
     if (mOptions[TRDByteSwapBit]) {
-      swapByteOrder(*word);
-      swapByteOrder(nextwordcopy);
+      HelperMethods::swapByteOrder(*word);
+      HelperMethods::swapByteOrder(nextwordcopy);
     }
 
     if (*word == 0x10001000 && nextwordcopy == 0x10001000) {

--- a/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
+++ b/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
@@ -159,15 +159,16 @@ int TrackletsParser::Parse()
   int headertrackletcount = 0;
   bool ignoreDataTillTrackletEndMarker = false;                                       // used for when we need to dump the rest of the tracklet data.
   if (std::distance(mStartParse, mEndParse) > o2::trd::constants::MAXDATAPERLINK32) { // full event is all digits and 3 tracklets per mcm,
-    LOG(warn) << "Attempt to parse a block of data for tracklets that is longer than a link can poossibly be : " << std::distance(mStartParse, mEndParse) << " should be less than : " << o2::trd::constants::MAXDATAPERLINK32 << " dumping this data.";
+    LOG(warn) << "Attempt to parse a block of data for tracklets that is longer than a link can possibly be : " << std::distance(mStartParse, mEndParse) << " should be less than : " << o2::trd::constants::MAXDATAPERLINK32 << " dumping this data.";
     // sanity check that the length of data to scan is less the possible maximum for a link
     return -1;
   }
-  for (auto word = mStartParse; word < mEndParse; ++word) { // loop over the entire data buffer (a complete link of tracklets and digits)
 
+  for (auto word = mStartParse; word < mEndParse; ++word) { // loop over the entire data buffer (a complete link of tracklets and digits)
     if (mState == StateFinished) {
       return mWordsRead;
     }
+
     // loop over all the words ...
     // check for tracklet end marker 0x1000 0x1000
     int index = std::distance(mStartParse, word);

--- a/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
+++ b/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
@@ -230,15 +230,16 @@ int TrackletsParser::Parse()
         if (mOptions[TRDHeaderVerboseBit]) {
           LOG(info) << "*** TrackletHCHeader : 0x" << std::hex << *word << " at offset :0x" << std::distance(mStartParse, word);
         }
+
         // we actually have a header word.
         mTrackletHCHeader.word = *word;
+
         // sanity check of trackletheader ??
         if (!sanityCheckTrackletHCHeader(mTrackletHCHeader)) {
           incParsingError(TRDParsingTrackletHCHeaderSanityCheckFailure);
-          LOG(warn) << " sanity check failure on TracklHCHeader of 0x" << std::hex << mTrackletHCHeader.word;
-          // sanityCheckTrackletHCHeader(mTrackletHCHeader,true);
-          // now dump and run
+          LOG(warn) << " sanity check failure on TrackletHCHeader of 0x" << std::hex << mTrackletHCHeader.word;
         }
+
         mWordsRead++;
         mState = StateTrackletMCMHeader;                                      // now we should read a MCMHeader next time through loop
       } else {                                                                // not TrackletHCHeader

--- a/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
+++ b/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
@@ -245,7 +245,8 @@ int TrackletsParser::Parse()
       } else {                                                                // not TrackletHCHeader
         if (isTrackletMCMHeader(*word) && mState == StateTrackletMCMHeader) { // TrackletMCMHeader has the bits on either end always 1
           // mcmheader
-          mTrackletMCMHeader = (TrackletMCMHeader*)&(*word);
+          mTrackletMCMHeader->word = *word;
+
           if (mOptions[TRDHeaderVerboseBit]) {
             LOG(info) << "***TrackletMCMHeader : 0x" << std::hex << *word << " at offset: 0x" << std::distance(mStartParse, word);
             TrackletMCMHeader a;

--- a/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
+++ b/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
@@ -123,29 +123,32 @@ int TrackletsParser::Parse()
     mState = StateTrackletHCHeader;
     TrackletHCHeader hcheader;
     hcheader.word = *mStartParse;
+
+    // we dont have a tracklethcheader so no tracklet data.
     if (!sanityCheckTrackletHCHeader(hcheader)) {
-      // we dont have a tracklethcheader so no tracklet data.
       if (mOptions[TRDHeaderVerboseBit]) {
         LOG(info) << "Returning 0 from tracklet parsing " << std::hex << (hcheader.format & 0x3) << " supermodule : " << hcheader.supermodule;
       }
 
       return -1; // mWordsRead;
     }
-    // NBNBNBNB
+
     // digit half chamber header ends with 01b and has the supermodule in position (9-13).
     // this of course can conflict with a tracklet hc header, hence should not be used!
-    // NBNBNBNB
     if ((hcheader.format & 0x3) == 0x1 && hcheader.supermodule == mHCID / 30) {
       if (mOptions[TRDHeaderVerboseBit]) {
         LOG(info) << " we seem to be on a digit halfchamber header";
       }
+
       return 0;
     }
+
     mState = StateTrackletHCHeader;
   } else {
     if (mTrackletHCHeaderState != 2) {
       LOG(warn) << "Unknown TrackletHCHeaderState of " << mTrackletHCHeaderState;
     }
+
     // tracklet hc header is always present
     mState = StateTrackletHCHeader; // we start with a trackletMCMHeader
   }

--- a/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
+++ b/Detectors/TRD/reconstruction/src/TrackletsParser.cxx
@@ -122,13 +122,11 @@ int TrackletsParser::Parse()
     // we have tracklet data so no TrackletHCHeader
     mState = StateTrackletHCHeader;
     TrackletHCHeader hcheader;
-
     hcheader.word = *mStartParse;
-    uint32_t tmpheader = *mStartParse;
     if (!sanityCheckTrackletHCHeader(hcheader)) {
       // we dont have a tracklethcheader so no tracklet data.
       if (mOptions[TRDHeaderVerboseBit]) {
-        LOG(info) << "Returning 0 from tracklet parsing " << std::hex << (tmpheader & 0x3) << " supermodule : " << ((tmpheader >> 9) & 0x1f);
+        LOG(info) << "Returning 0 from tracklet parsing " << std::hex << (hcheader.format & 0x3) << " supermodule : " << hcheader.supermodule;
       }
 
       return -1; // mWordsRead;
@@ -137,7 +135,7 @@ int TrackletsParser::Parse()
     // digit half chamber header ends with 01b and has the supermodule in position (9-13).
     // this of course can conflict with a tracklet hc header, hence should not be used!
     // NBNBNBNB
-    if ((tmpheader & 0x3) == 0x1 && (((tmpheader >> 9) & 0x1f) == mHCID / 30)) {
+    if ((hcheader.format & 0x3) == 0x1 && hcheader.supermodule == mHCID / 30) {
       if (mOptions[TRDHeaderVerboseBit]) {
         LOG(info) << " we seem to be on a digit halfchamber header";
       }


### PR DESCRIPTION
I was trying to understand the Trackletsparser and made some readability changes/logic errors I found.
Most commits here just remove code or add spacing for readability, however there some commits, where special attention should be payed.
Some of them make changes inferred from the comments, others from my _limited_ unterstanding of what the authors intention is.
1. 7f05c0: Was that really the intention?
2. 1ae0be: The TDP differs from the struct implementation of TrackletHCHeader, thus the shifts are wrong.
                  However, I am unsure about the logic e.g. mHCID / 30 and comparing that to supermodule.

I do not really expect this to get merged, just letting this be draft for now. After discussions of the commits above, may move to real PR.