### PR TITLE
Release cuts in SVertexer

### DIFF
--- a/Detectors/Vertexing/include/DetectorsVertexing/SVertexer.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/SVertexer.h
@@ -122,8 +122,6 @@ class SVertexer
   std::vector<std::vector<Cascade>> mCascadesTmp;
   std::array<std::vector<TrackCand>, 2> mTracksPool{}; // pools of positive and negative seeds sorted in min VtxID
   std::array<std::vector<int>, 2> mVtxFirstTrack{};    // 1st pos. and neg. track of the pools for each vertex
-  std::array<std::vector<int>, 2> mTrackSortVtxMax{};  // pos. and neg. track indices sorted by max VtxID
-  std::array<std::vector<int>, 2> mVtxMaxLUT{};        // pos. and neg. max vtx ID track LUT for each vertex
 
   o2d::VertexBase mMeanVertex{{0., 0., 0.}, {0.1 * 0.1, 0., 0.1 * 0.1, 0., 0., 6. * 6.}};
   const SVertexerParams* mSVParams = nullptr;

--- a/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/SVertexerParams.h
@@ -47,13 +47,13 @@ struct SVertexerParams : public o2::conf::ConfigurableParamHelper<SVertexerParam
   bool usePropagator = false;                                           ///< use external propagator
   bool refitWithMatCorr = false;                                        ///< refit V0 applying material corrections
   //
-  int maxPVContributors = 2;              ///< max number PV contributors to allow in V0
-  float minDCAToPV = 0.1;                 ///< min DCA to PV of single track to accept
-  float minRToMeanVertex = 0.5;           ///< min radial distance of V0 from beam line (mean vertex)
-  float maxDCAXYToMeanVertex = 0.2;       ///< max DCA of V0 from beam line (mean vertex) for prompt V0 candidates
-  float maxDCAXYToMeanVertexV0Casc = 0.5; ///< max DCA of V0 from beam line (mean vertex) for cascade V0 candidates
-  float minPtV0 = 0.01;                   ///< v0 minimum pT
-  float maxTglV0 = 2.;                    ///< maximum tgLambda of V0
+  int maxPVContributors = 2;             ///< max number PV contributors to allow in V0
+  float minDCAToPV = 0.05;               ///< min DCA to PV of single track to accept
+  float minRToMeanVertex = 0.5;          ///< min radial distance of V0 from beam line (mean vertex)
+  float maxDCAXYToMeanVertex = 0.2;      ///< max DCA of V0 from beam line (mean vertex) for prompt V0 candidates
+  float maxDCAXYToMeanVertexV0Casc = 2.; ///< max DCA of V0 from beam line (mean vertex) for cascade V0 candidates
+  float minPtV0 = 0.01;                  ///< v0 minimum pT
+  float maxTglV0 = 2.;                   ///< maximum tgLambda of V0
 
   float causalityRTolerance = 1.; ///< V0 radius cannot exceed its contributors minR by more than this value
   float maxV0ToProngsRDiff = 50.; ///< V0 radius cannot be lower than this ammount wrt minR of contributors
@@ -68,18 +68,18 @@ struct SVertexerParams : public o2::conf::ConfigurableParamHelper<SVertexerParam
   float minRDiffV0Casc = 0.2; ///< cascade should be at least this radial distance below V0
   float maxRIniCasc = 90.;    // don't consider as a cascade seed (circles/line intersection) if its R exceeds this
 
-  float maxDCAXYCasc = 0.3; // max DCA of cascade to PV in XY // TODO RS: shall we use real chi2 to vertex?
-  float maxDCAZCasc = 0.3;  // max DCA of cascade to PV in Z
+  float maxDCAXYCasc = 0.5; // max DCA of cascade to PV in XY // TODO RS: shall we use real chi2 to vertex?
+  float maxDCAZCasc = 0.5;  // max DCA of cascade to PV in Z
   float minCosPACasc = 0.7; ///< min cos of PA to PV for cascade candidates
   float minPtCasc = 0.01;   // cascade minimum pT
   float maxTglCasc = 2.;    // maximum tgLambda of cascade
 
   // cuts on different V0 PID params
   bool checkV0Hypothesis = true;
-  float pidCutsPhoton[SVertexHypothesis::NPIDParams] = {0.001, 20, 0.60, 0.0};   // Photon
-  float pidCutsK0[SVertexHypothesis::NPIDParams] = {0.003, 20, 0.07, 0.5};       // K0
-  float pidCutsLambda[SVertexHypothesis::NPIDParams] = {0.001, 20, 0.07, 0.5};   // Lambda
-  float pidCutsHTriton[SVertexHypothesis::NPIDParams] = {0.0025, 14, 0.07, 0.5}; // HyperTriton
+  float pidCutsPhoton[SVertexHypothesis::NPIDParams] = {0.001, 20, 0.60, 0.0};    // Photon
+  float pidCutsK0[SVertexHypothesis::NPIDParams] = {0.003, 20, 0.07, 0.5};        // K0
+  float pidCutsLambda[SVertexHypothesis::NPIDParams] = {0.001, 20, 0.07, 0.5};    // Lambda
+  float pidCutsHTriton[SVertexHypothesis::NPIDParams] = {0.0025, 14, 0.07, 0.5};  // HyperTriton
   float pidCutsHhydrog4[SVertexHypothesis::NPIDParams] = {0.0025, 14, 0.07, 0.5}; // Hyperhydrog4 - Need to update
   //
   // cuts on different Cascade PID params
@@ -89,7 +89,6 @@ struct SVertexerParams : public o2::conf::ConfigurableParamHelper<SVertexerParam
 
   O2ParamDef(SVertexerParams, "svertexer");
 };
-
 } // namespace vertexing
 } // end namespace o2
 

--- a/Detectors/Vertexing/src/SVertexer.cxx
+++ b/Detectors/Vertexing/src/SVertexer.cxx
@@ -488,9 +488,7 @@ int SVertexer::checkCascades(float rv0, std::array<float, 3> pV0, float p2V0, in
       cascVlist.setMin(v0.getVertexID());
       cascVlist.setMax(v0.getVertexID());
     }
-    if (bach.minR > rv0 + mSVParams->causalityRTolerance) {
-      continue;
-    }
+
     int nCandC = fitterCasc.process(v0, bach);
     if (nCandC == 0) { // discard this pair
       continue;

--- a/Detectors/Vertexing/src/SVertexer.cxx
+++ b/Detectors/Vertexing/src/SVertexer.cxx
@@ -315,8 +315,10 @@ void SVertexer::buildT2V(const o2::globaltracking::RecoContainer& recoData) // a
     const auto& tracksPool = mTracksPool[pn];
     for (unsigned i = 0; i < tracksPool.size(); i++) {
       const auto& t = tracksPool[i];
-      if (vtxFirstT[t.vBracket.getMin()] == -1) {
-        vtxFirstT[t.vBracket.getMin()] = i;
+      for (int j{t.vBracket.getMin()}; j <= t.vBracket.getMax(); ++j) {
+        if (vtxFirstT[j] == -1) {
+          vtxFirstT[j] = i;
+        }
       }
     }
   }


### PR DESCRIPTION
PR #9580 already rebased.

In this P.R. few cuts are released:
- DCAtoPV of daughter tracks from 0.1 to 0.05 (most intensive operation from computational point of view)
- DCAz and DCAXY of the cascade from 0.3 to 0.5
- maxDCAXYToMeanVertexV0Casc from 0.5 to 2
- Causality cut for bachelor removed as it is wrong since it does not take into account the geometry of the ITS. For example the 16 cm gap from L2 to L3 causes the loss of more than 50% of the bachelors, when the cut is applied.

The increase in CPU time has been evaluated in pp and Pb-Pb collisions. In pp the increase is negligible

**pp collisions at 500kHz**
- old cuts: Secondary vertexing total timing: Cpu: 1.900e+00 Real: 1.976e+00 s in 1 slots, nThreads = 1
- new cuts: Secondary vertexing total timing: Cpu: 1.920e+00 Real: 1.992e+00 s in 1 slots, nThreads = 1

**Pb-Pb collisions at 50kHz**
- old cuts: Secondary vertexing total timing: Cpu: 4.300e+00 Real: 4.376e+00 s in 1 slots, nThreads = 1
- new cuts: Secondary vertexing total timing: Cpu: 9.720e+00 Real: 9.797e+00 s in 1 slots, nThreads = 1

-----------------

The improvement in reconstruction efficiency for the Xi baryon is shown in the attached plot (more than a factor 2 increase)
![c1](https://user-images.githubusercontent.com/43742195/182401113-b517b655-a434-4977-8e39-13d777faf2e7.png)


