### PR TITLE
Add verbose option for ITS DCS parser

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DCSParserSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DCSParserSpec.h
@@ -87,6 +87,9 @@ class ITSDCSParser : public Task
   // Keep track of whether the endOfStream() or stop() has been called
   bool mStopped = false;
 
+  // Whether to use verbose output
+  bool mVerboseOutput = false;
+
   // DCS config object for storing output string
   o2::dcs::DCSconfigObject_t mConfigDCS;
 

--- a/Detectors/ITSMFT/ITS/workflow/src/DCSParserSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/DCSParserSpec.cxx
@@ -36,6 +36,8 @@ void ITSDCSParser::init(InitContext& ic)
 
   this->mCcdbUrl = ic.options().get<std::string>("ccdb-url");
 
+  this->mVerboseOutput = ic.options().get<bool>("verbose");
+
   return;
 }
 
@@ -70,6 +72,11 @@ void ITSDCSParser::run(ProcessingContext& pc)
 //////////////////////////////////////////////////////////////////////////////
 void ITSDCSParser::updateMemoryFromInputString(const std::string& inString)
 {
+  // Print the entire string if verbose mode is requested
+  if (this->mVerboseOutput) {
+    LOG(info) << "Parsing string: " << inString;
+  }
+
   // Parse the individual parts of the string
   const std::string delimiter = "|";
   unsigned int pos = 0;
@@ -407,6 +414,7 @@ DataProcessorSpec getITSDCSParserSpec()
     outputs,
     AlgorithmSpec{adaptFromTask<o2::its::ITSDCSParser>()},
     Options{
+      {"verbose", VariantType::Bool, false, {"Use verbose output mode"}},
       {"ccdb-url", VariantType::String, "", {"CCDB url, default is empty (i.e. send output to CCDB populator workflow)"}}}};
 }
 } // namespace its


### PR DESCRIPTION
Adding verbose option to the ITS DCS parser workflow which prints out the string being parsed by the workflow. This will be useful for debugging strings which are not properly parsed by the workflow.