### PR TITLE
Correctly flag FET for MID REG boards

### DIFF
--- a/Detectors/MUON/MID/Raw/src/ELinkDataShaper.cxx
+++ b/Detectors/MUON/MID/Raw/src/ELinkDataShaper.cxx
@@ -41,10 +41,10 @@ ELinkDataShaper::ELinkDataShaper(bool isDebugMode, bool isLoc, uint8_t uniqueId,
     }
   }
   mLocalToBCSelfTrig = mElectronicsDelay.localToBC;
+  mElectronicsDelay.calibToFET += mElectronicsDelay.localToBC;
   if (!isLoc) {
     mLocalToBCSelfTrig -= electronicsDelay.localToReg;
   }
-  mElectronicsDelay.calibToFET += mLocalToBCSelfTrig;
 }
 
 void ELinkDataShaper::set(uint32_t orbit, uint32_t trigger)


### PR DESCRIPTION
In self-triggered events, the regional response is delayed compared to the local board one.
This was correctly accounted for in most cases, except when flagging the FET event.
Since the regional response is not used, the bug is harmless for physics, but it is of course better to fix it.