### PR TITLE
[EMCAL-769, EMCAL-795] Handle cases where bunch size would be 0

### DIFF
--- a/Detectors/EMCAL/reconstruction/src/AltroDecoder.cxx
+++ b/Detectors/EMCAL/reconstruction/src/AltroDecoder.cxx
@@ -122,6 +122,14 @@ void AltroDecoder::readChannels()
         // we must break here as well, the bunch is cut and the pointer would be set to invalid memory
         break;
       }
+      if (bunchlength == 0) {
+        // skip bunches with bunch size 0, they don't contain any payload
+        // Map error type to NULL header since header word is null
+        mMinorDecodingErrors.emplace_back(MinorAltroDecodingError::ErrorType_t::BUNCH_HEADER_NULL, channelheader, 0);
+        // Forward position by bunch header size
+        currentsample += bunchlength + 2;
+        continue;
+      }
       auto& currentbunch = currentchannel.createBunch(bunchlength, starttime);
       currentbunch.initFromRange(gsl::span<uint16_t>(&bunchwords[currentsample + 2], std::min((unsigned long)bunchlength, bunchwords.size() - currentsample - 2)));
       currentsample += bunchlength + 2;


### PR DESCRIPTION
In this case the bunch header is present (bunch word 0
check passed) but no payload is reported.