### PR TITLE
FST: Fix TPC IDC aggregator task

### DIFF
--- a/prodtests/full-system-test/aggregator-workflow.sh
+++ b/prodtests/full-system-test/aggregator-workflow.sh
@@ -173,15 +173,15 @@ lanes=1
 lanesDistribute=1
 lanesFactorize=6
 nTFs=500
-if [[ $AGGREGATOR_TASKS == TPCIDC_A ]] || [[ $AGGREGATOR_TASKS == TPCIDC_C ]] || [[ $AGGREGATOR_TASKS == ALL ]]; then
-  add_W o2-tpc-idc-distribute "--crus ${crus} --timeframes ${nTFs} --firstTF -100 --configKeyValues 'keyval.output_dir=/dev/null' --check-for-missing-data true --lanes ${lanesDistribute} --output-lanes ${lanesFactorize} --nFactorTFs 100"
-  add_W o2-tpc-idc-factorize "--lanesDistribute ${lanesDistribute} --input-lanes ${lanesFactorize} --crus ${crus} --timeframes ${nTFs} --configFile "" --compression 2 --configKeyValues 'TPCIDCGroupParam.groupPadsSectorEdges=32211;keyval.output_dir=/dev/null'  --groupIDCs true --nthreads-grouping 8 --nthreads-IDC-factorization 8 --groupPads \"5,6,7,8,4,5,6,8,10,13\" --groupRows \"2,2,2,3,3,3,2,2,2,2\" --sendOutputFFT true --nTFsMessage 500 --enable-CCDB-output true --enablePadStatusMap --check-for-missing-data"
-  add_W o2-tpc-idc-ft-aggregator "#  --rangeIDC 200 --inputLanes ${lanesFactorize} --nFourierCoeff 40 --timeframes ${nTFs} --configKeyValues 'keyval.output_dir=/dev/null' --nthreads 8"
+if ! workflow_has_parameter CALIB_LOCAL_INTEGRATED_AGGREGATOR && [[ $AGGREGATOR_TASKS == TPCIDC_A || $AGGREGATOR_TASKS == TPCIDC_C || $AGGREGATOR_TASKS == ALL ]]; then
+  add_W o2-tpc-idc-distribute "--crus ${crus} --timeframes ${nTFs} --firstTF -100 --check-for-missing-data true --lanes ${lanesDistribute} --output-lanes ${lanesFactorize} --nFactorTFs 100"
+  add_W o2-tpc-idc-factorize "--lanesDistribute ${lanesDistribute} --input-lanes ${lanesFactorize} --crus ${crus} --timeframes ${nTFs} --configFile '' --compression 2 --groupIDCs true --nthreads-grouping 8 --nthreads-IDC-factorization 8 --groupPads \"5,6,7,8,4,5,6,8,10,13\" --groupRows \"2,2,2,3,3,3,2,2,2,2\" --sendOutputFFT true --nTFsMessage 500 --enable-CCDB-output true --enablePadStatusMap --check-for-missing-data" "TPCIDCGroupParam.groupPadsSectorEdges=32211"
+  add_W o2-tpc-idc-ft-aggregator "--rangeIDC 200 --inputLanes ${lanesFactorize} --nFourierCoeff 40 --timeframes ${nTFs} --nthreads 8"
 fi
 
 # Calo cal
 # calibrations for AGGREGATOR_TASKS == CALO_TF
-if [[ $AGGREGATOR_TASKS == CALO_TF ]] || [[ $AGGREGATOR_TASKS == ALL ]]; then
+if [[ $AGGREGATOR_TASKS == CALO_TF || $AGGREGATOR_TASKS == ALL ]]; then
   # EMC
   if [[ $CALIB_EMC_CHANNELCALIB == 1 ]]; then
     add_W o2-calibration-emcal-channel-calib-workflow "" "EMCALCalibParams.calibType=\"time\""


### PR DESCRIPTION
Fixes TPC IDC aggregator task which set --configKeyValues twice, and disable it in FST since there is no producer for the data. Not clear why it passed the initial test.
Currently broken, merging.