### PR TITLE
[MFT] initial release of mft standalone alignment

### DIFF
--- a/Detectors/ITSMFT/MFT/CMakeLists.txt
+++ b/Detectors/ITSMFT/MFT/CMakeLists.txt
@@ -17,5 +17,6 @@ add_subdirectory(workflow)
 add_subdirectory(calibration)
 add_subdirectory(condition)
 add_subdirectory(assessment)
+add_subdirectory(alignment)
 
 o2_data_file(COPY data DESTINATION Detectors/Geometry/MFT/)

--- a/Detectors/ITSMFT/MFT/alignment/CMakeLists.txt
+++ b/Detectors/ITSMFT/MFT/alignment/CMakeLists.txt
@@ -1,0 +1,56 @@
+# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# All rights not expressly granted are reserved.
+#
+# This software is distributed under the terms of the GNU General Public
+# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+o2_add_library(MFTAlignment
+        SOURCES src/AlignConfig.cxx
+                src/Aligner.cxx
+                src/AlignPointControl.cxx
+                src/AlignPointHelper.cxx
+                src/AlignSensorHelper.cxx
+                src/MatrixSparse.cxx
+                src/MatrixSq.cxx
+                src/MillePede2.cxx
+                src/MillePedeRecord.cxx
+                src/MilleRecordReader.cxx
+                src/MilleRecordWriter.cxx
+                src/MinResSolve.cxx
+                src/RecordsToAlignParams.cxx
+                src/RectMatrix.cxx
+                src/SymBDMatrix.cxx
+                src/SymMatrix.cxx
+                src/TracksToRecords.cxx
+                src/VectorSparse.cxx
+        PUBLIC_LINK_LIBRARIES O2::MFTBase
+                O2::DataFormatsMFT
+                O2::MFTTracking
+                O2::CCDB
+                O2::Steer)
+
+o2_target_root_dictionary(MFTAlignment
+        HEADERS include/MFTAlignment/AlignConfig.h
+                include/MFTAlignment/Aligner.h
+                include/MFTAlignment/AlignPointControl.h
+                include/MFTAlignment/AlignPointHelper.h
+                include/MFTAlignment/AlignSensorHelper.h
+                include/MFTAlignment/MatrixSparse.h
+                include/MFTAlignment/MatrixSq.h
+                include/MFTAlignment/MillePede2.h
+                include/MFTAlignment/MillePedeRecord.h
+                include/MFTAlignment/MilleRecordReader.h
+                include/MFTAlignment/MilleRecordWriter.h
+                include/MFTAlignment/MinResSolve.h
+                include/MFTAlignment/RecordsToAlignParams.h
+                include/MFTAlignment/RectMatrix.h
+                include/MFTAlignment/SymBDMatrix.h
+                include/MFTAlignment/SymMatrix.h
+                include/MFTAlignment/TracksToRecords.h
+                include/MFTAlignment/VectorSparse.h
+        LINKDEF src/MFTAlignmentLinkDef.h)

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/AlignConfig.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/AlignConfig.h
@@ -1,0 +1,44 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file AlignConfig.h
+/// \author arakotoz@cern.ch
+/// \brief Configuration file for MFT standalone alignment
+
+#ifndef ALICEO2_MFT_ALIGN_CONFIG_H
+#define ALICEO2_MFT_ALIGN_CONFIG_H
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "CommonUtils/ConfigurableParamHelper.h"
+
+namespace o2
+{
+namespace mft
+{
+
+struct AlignConfig : public o2::conf::ConfigurableParamHelper<AlignConfig> {
+  int minPoints = 6;                  ///< mininum number of clusters in a track used for alignment
+  Int_t chi2CutNStdDev = 3;           ///< Number of standard deviations for chi2 cut
+  Double_t residualCutInitial = 100.; ///< Cut on residual on first iteration
+  Double_t residualCut = 100.;        ///< Cut on residual for other iterations
+  Double_t allowedVarDeltaX = 0.5;    ///< allowed max delta in x-translation (cm)
+  Double_t allowedVarDeltaY = 0.5;    ///< allowed max delta in y-translation (cm)
+  Double_t allowedVarDeltaZ = 0.5;    ///< allowed max delta in z-translation (cm)
+  Double_t allowedVarDeltaRz = 0.01;  ///< allowed max delta in rotation around z-axis (rad)
+  Double_t chi2CutFactor = 256.;      ///< used to reject outliers i.e. bad tracks with sum(chi2) > Chi2DoFLim(fNStdDev, nDoF) * fChi2CutFactor
+
+  O2ParamDef(AlignConfig, "MFTAlignment");
+};
+
+} // namespace mft
+} // namespace o2
+
+#endif

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/AlignPointControl.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/AlignPointControl.h
@@ -1,0 +1,100 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file MilleRecordStore.h
+/// \author arakotoz@cern.ch
+/// \brief Class dedicated to write AlignPointInfo to output file for MFT
+
+#ifndef ALICEO2_MFT_ALIGN_POINT_CONTROL_H
+#define ALICEO2_MFT_ALIGN_POINT_CONTROL_H
+
+#include <Rtypes.h>
+#include <TString.h>
+#include "MFTAlignment/AlignPointHelper.h"
+
+class TFile;
+class TTree;
+
+namespace o2
+{
+namespace mft
+{
+
+class AlignPointControl
+{
+ public:
+  struct AlignPointInfo {
+    UShort_t sensor;          // sensor id
+    UShort_t layer;           // layer id
+    UShort_t disk;            // disk id
+    UShort_t half;            // half id
+    Double_t measuredGlobalX; // cluster x, global frame (cm)
+    Double_t measuredGlobalY; // cluster y, global frame (cm)
+    Double_t measuredGlobalZ; // cluster z, global frame (cm)
+    Double_t measuredLocalX;  // cluster x, local frame (cm)
+    Double_t measuredLocalY;  // cluster y, local frame (cm)
+    Double_t measuredLocalZ;  // cluster z, local frame (cm)
+    Double_t residualX;       // track global x - cluster global x (cm)
+    Double_t residualY;       // track global y - cluster global y (cm)
+    Double_t residualZ;       // track global z - cluster global z (cm)
+    Double_t residualLocalX;  // track local x - cluster local x (cm)
+    Double_t residualLocalY;  // track local y - cluster local y (cm)
+    Double_t residualLocalZ;  // track local z - cluster local z (cm)
+    Double_t recoGlobalX;     // track x, global frame (cm)
+    Double_t recoGlobalY;     // track y, global frame (cm)
+    Double_t recoGlobalZ;     // track z, global frame (cm)
+    Double_t recoLocalX;      // track x, local frame (cm)
+    Double_t recoLocalY;      // track y, local frame (cm)
+    Double_t recoLocalZ;      // track z, local frame (cm)
+  };
+  /// \brief constructor
+  AlignPointControl();
+
+  /// \brief destructor
+  virtual ~AlignPointControl();
+
+  /// \brief Set the number of entries to be used by TTree::AutoSave()
+  void setCyclicAutoSave(const long nEntries);
+
+  /// \brief choose filename
+  void setOutFileName(TString fname) { mOutFileName = fname; }
+
+  /// \brief init output file and tree
+  void init();
+
+  /// \brief check if init went well
+  bool isInitOk() const { return mIsSuccessfulInit; }
+
+  /// \brief fill the tree from an align point
+  void fill(o2::mft::AlignPointHelper* aPoint,
+            const int iTrack = 0,
+            const bool doPrint = false);
+
+  /// \brief write tree and close output file
+  void terminate();
+
+ protected:
+  TTree* mControlTree;       ///< the ROOT TTree container
+  TFile* mControlFile;       ///< the output file
+  bool mIsSuccessfulInit;    ///< boolean to monitor the success of the initialization
+  long mNEntriesAutoSave;    ///< max entries in the buffer after which TTree::AutoSave() is automatically used
+  TString mOutFileName;      ///< name of the output file that will store the TTree
+  TString mTreeTitle;        ///< title of the TTree
+  AlignPointInfo mPointInfo; ///< information to be written to the output TTree
+
+  bool setControlPoint(o2::mft::AlignPointHelper* aPoint);
+
+  ClassDef(AlignPointControl, 0);
+};
+} // namespace mft
+} // namespace o2
+
+#endif

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/AlignPointHelper.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/AlignPointHelper.h
@@ -1,0 +1,285 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file AlignPointHelper.h
+/// \author arakotoz@cern.ch
+/// \brief Compute the local and global derivatives at an alignment point (track position, cluster position)
+
+#ifndef ALICEO2_MFT_ALIGN_POINT_HELPER_H
+#define ALICEO2_MFT_ALIGN_POINT_HELPER_H
+
+#include <gsl/gsl>
+
+#include "Framework/ProcessingContext.h"
+#include "MathUtils/Cartesian.h"
+#include "MFTBase/Geometry.h"
+#include "MFTBase/GeometryTGeo.h"
+#include "ReconstructionDataFormats/BaseCluster.h"
+#include "DataFormatsITSMFT/CompCluster.h"
+#include "DataFormatsITSMFT/TopologyDictionary.h"
+#include "MFTAlignment/AlignSensorHelper.h"
+#include "MFTBase/GeometryTGeo.h"
+
+namespace o2
+{
+namespace mft
+{
+
+class TrackMFT;
+
+/// \class GlobalDerivative
+/// \brief Simple container of global derivatives
+class GlobalDerivative
+{
+  friend class AlignPointHelper;
+
+ public:
+  /// \brief constructor
+  GlobalDerivative() = default;
+
+  /// \brief destructor
+  virtual ~GlobalDerivative() = default;
+
+  /// \brief reset all data members to default value (zero)
+  void reset()
+  {
+    mdDeltaX = 0.;
+    mdDeltaY = 0.;
+    mdDeltaZ = 0.;
+    mdDeltaRz = 0.;
+  }
+
+  // simple getters
+
+  double dDeltaX() const { return mdDeltaX; }
+  double dDeltaY() const { return mdDeltaY; }
+  double dDeltaZ() const { return mdDeltaZ; }
+  double dDeltaRz() const { return mdDeltaRz; }
+
+ protected:
+  double mdDeltaX = 0.;  ///< derivative w.r.t. delta translation along global x-axis
+  double mdDeltaY = 0.;  ///< derivative w.r.t. delta translation along global y-axis
+  double mdDeltaZ = 0.;  ///< derivative w.r.t. delta translation along global z-axis
+  double mdDeltaRz = 0.; ///< derivative w.r.t. delta rotation angle around global z-axis
+};
+
+/// \class LocalDerivative
+/// \brief Simple container of local derivatives
+class LocalDerivative
+{
+  friend class AlignPointHelper;
+
+ public:
+  /// \brief constructor
+  LocalDerivative() = default;
+
+  /// \brief destructor
+  virtual ~LocalDerivative() = default;
+
+  // simple getters
+
+  double dX0() const { return mdX0; }
+  double dTx() const { return mdTx; }
+  double dY0() const { return mdY0; }
+  double dTy() const { return mdTy; }
+
+  /// \brief reset all data members to default value (zero)
+  void reset()
+  {
+    mdX0 = 0.;
+    mdTx = 0.;
+    mdY0 = 0.;
+    mdTy = 0.;
+  }
+
+ protected:
+  double mdX0 = 0.; ///< derivative w.r.t. track param. x0
+  double mdTx = 0.; ///< derivative w.r.t. track param. tx
+  double mdY0 = 0.; ///< derivative w.r.t. track param. y0
+  double mdTy = 0.; ///< derivative w.r.t. track param. ty
+};
+
+/*! \class AlignPointHelper
+    \brief Container of a single alignment point and methods to fill it
+    \details An alignment point is defined by the track crossing point coordinates at the z
+    of this plane, the cluster coordinates, the value of the local derivarives and the global
+    derivatives at that point, the sensor id of this cluster. This class also offers to
+    compute the track-cluster residual at this point.
+*/
+class AlignPointHelper
+{
+ public:
+  /// \brief constructor
+  AlignPointHelper();
+
+  /// \brief destructor
+  virtual ~AlignPointHelper() = default;
+
+  /// \brief simple structure to organise the storage of track parameters at inital z0 plane
+  struct TrackParam {
+    Double_t X0, Y0, Z0, Tx, Ty;
+  };
+
+  /// \brief method to call the computation of all three compnonents of the local derivative
+  void computeLocalDerivatives();
+
+  /// \brief method to call the computation of all three components of the global derivative
+  void computeGlobalDerivatives();
+
+  // simple getters
+
+  UShort_t getSensorId() const;
+  UShort_t half() const;
+  UShort_t disk() const;
+  UShort_t layer() const;
+
+  // simple getters
+
+  bool isAlignPointSet() const { return mIsAlignPointSet; }
+  bool isGlobalDerivativeDone() const { return mIsGlobalDerivativeDone; }
+  bool isLocalDerivativeDone() const { return mIsLocalDerivativeDone; }
+  bool isClusterOk() const { return mIsClusterOk; }
+
+  // simple getters
+
+  GlobalDerivative globalDerivativeX() const { return mGlobalDerivativeX; }
+  GlobalDerivative globalDerivativeY() const { return mGlobalDerivativeY; }
+  GlobalDerivative globalDerivativeZ() const { return mGlobalDerivativeZ; }
+  LocalDerivative localDerivativeX() const { return mLocalDerivativeX; }
+  LocalDerivative localDerivativeY() const { return mLocalDerivativeY; }
+  LocalDerivative localDerivativeZ() const { return mLocalDerivativeZ; }
+
+  // simple getters
+
+  o2::math_utils::Point3D<double> getLocalMeasuredPosition() const
+  {
+    return mLocalMeasuredPosition;
+  }
+  o2::math_utils::Point3D<double> getLocalMeasuredPositionSigma() const
+  {
+    return mLocalMeasuredPositionSigma;
+  }
+  o2::math_utils::Point3D<double> getLocalResidual() const
+  {
+    return mLocalResidual;
+  }
+  o2::math_utils::Point3D<double> getGlobalResidual() const
+  {
+    return mGlobalResidual;
+  }
+  o2::math_utils::Point3D<double> getGlobalMeasuredPosition() const
+  {
+    return mGlobalMeasuredPosition;
+  }
+  o2::math_utils::Point3D<double> getGlobalRecoPosition() const
+  {
+    return mGlobalRecoPosition;
+  }
+  o2::math_utils::Point3D<double> getLocalRecoPosition() const
+  {
+    return mLocalRecoPosition;
+  }
+  TrackParam getTrackInitialParam() const { return mTrackInitialParam; }
+
+  /// \brief reset all quantities that define an alignment point to their default value
+  void resetAlignPoint();
+
+  /// \brief reset all track parameters to their default value (zero)
+  void resetTrackInitialParam();
+
+  /// \brief convert compact clusters (pixel coordinates in row, col) from workflow to base clusters with 3D position (local, global coordinates)
+  void convertCompactClusters(gsl::span<const itsmft::CompClusterExt> clusters,
+                              gsl::span<const unsigned char>::iterator& pattIt,
+                              std::vector<o2::BaseCluster<double>>& outputLocalClusters,
+                              std::vector<o2::BaseCluster<double>>& outputGlobalClusters);
+
+  /// \brief convert compact clusters (pixel coordinates in row, col) from ROOT file to base clusters with 3D position (local, global coordinates)
+  void convertCompactClusters(const std::vector<o2::itsmft::CompClusterExt>& clusters,
+                              std::vector<unsigned char>::iterator& pattIt,
+                              std::vector<o2::BaseCluster<double>>& outputLocalClusters,
+                              std::vector<o2::BaseCluster<double>>& outputGlobalClusters);
+
+  /// \brief store the track parameters at the initial z0 plane
+  void recordTrackInitialParam(o2::mft::TrackMFT& mftTrack);
+
+  /// \brief set cluster pattern dictionary (needed to compute cluster coordinates)
+  void setClusterDictionary(const o2::itsmft::TopologyDictionary* d) { mDictionary = d; }
+
+  // setters
+
+  void setGlobalRecoPosition(o2::mft::TrackMFT& mftTrack);
+  void setMeasuredPosition(const o2::BaseCluster<double>& localCluster,
+                           const o2::BaseCluster<double>& globalCluster);
+  void setLocalResidual();
+  void setGlobalResidual();
+
+ protected:
+  bool mIsAlignPointSet;        ///< boolean to indicate if mGlobalRecoPosition and mLocalMeasuredPosition are set
+  bool mIsGlobalDerivativeDone; ///< boolean to indicate if the global derivatives computaion is done
+  bool mIsLocalDerivativeDone;  ///< boolean to indicate if the local derivatives computation is done
+  bool mIsTrackInitialParamSet; ///< boolean to indicate if the initial track parameters are recorded
+  bool mIsClusterOk;            ///< boolean to check if cluster was exploitable to get coordinates
+
+  o2::mft::GeometryTGeo* mGeometry;                        ///< MFT geometry
+  const o2::itsmft::TopologyDictionary* mDictionary;       ///< cluster patterns dictionary
+  std::unique_ptr<o2::mft::AlignSensorHelper> mChipHelper; ///< utility to access the sensor transform used in the computation of the derivatives
+
+  LocalDerivative mLocalDerivativeX; ///< first (X) component of the local derivatives
+  LocalDerivative mLocalDerivativeY; ///< second (Y) component of the local derivatives
+  LocalDerivative mLocalDerivativeZ; ///< last (Z) component of the local derivatives
+
+  GlobalDerivative mGlobalDerivativeX; ///< first (X) component of the global derivatives
+  GlobalDerivative mGlobalDerivativeY; ///< second (Y) component of the global derivatives
+  GlobalDerivative mGlobalDerivativeZ; ///< last (Z) component of the global derivatives
+
+  TrackParam mTrackInitialParam; ///< Track parameters at the initial reference plane z = z0
+
+  o2::math_utils::Point3D<double> mGlobalRecoPosition; ///< Current cartesian position (cm, in Global ref. system) of the reconstructed track analytically propagated to the z position of the cluster
+  o2::math_utils::Point3D<double> mLocalRecoPosition;  ///< Current cartesian position (cm, in Local ref. system) of the reconstructed track analytically propagated to the z position of the cluster
+
+  o2::math_utils::Point3D<double> mLocalMeasuredPosition;      ///< Current cartesian position (cm, in Local ref. system) of the cluster
+  o2::math_utils::Point3D<double> mLocalMeasuredPositionSigma; ///< Estimated error on local position measurement
+  o2::math_utils::Point3D<double> mGlobalMeasuredPosition;     ///< Current cartesian position (cm, in Global ref. system) of the cluster
+
+  o2::math_utils::Point3D<double> mLocalResidual;  ///< residual between track x-ing point and cluster in local ref. system
+  o2::math_utils::Point3D<double> mGlobalResidual; ///< residual between track x-ing point and cluster in global ref. system
+
+ protected:
+  ///\brief reset all elements to zero for the local derivatives
+  void resetLocalDerivatives();
+
+  ///\brief reset all elements to zero for the global derivatives
+  void resetGlobalDerivatives();
+
+  /// \brief compute first (X) component of the local derivatives
+  bool computeLocalDerivativeX();
+
+  /// \brief compute second (Y) component of the local derivatives
+  bool computeLocalDerivativeY();
+
+  /// \brief compute last (Z) component of the local derivatives
+  bool computeLocalDerivativeZ();
+
+  /// \brief compute first (X) component of the global derivatives
+  bool computeGlobalDerivativeX();
+
+  /// \brief compute second (Y) component of the global derivatives
+  bool computeGlobalDerivativeY();
+
+  /// \brief compute last (Z) component of the global derivatives
+  bool computeGlobalDerivativeZ();
+
+  ClassDef(AlignPointHelper, 0);
+};
+
+} // namespace mft
+} // namespace o2
+#endif

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/AlignSensorHelper.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/AlignSensorHelper.h
@@ -1,0 +1,175 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file AlignSensorHelper.h
+/// \author arakotoz@cern.ch
+/// \brief Helper class to access to the global coordinates of the center each MFT sensor
+
+#ifndef ALICEO2_MFT_ALIGN_SENSOR_HELPER_H
+#define ALICEO2_MFT_ALIGN_SENSOR_HELPER_H
+
+#include <sstream>
+
+#include <TGeoMatrix.h>
+#include <TString.h>
+#include <Rtypes.h>
+
+#include "ITSMFTReconstruction/ChipMappingMFT.h"
+#include "MathUtils/Cartesian.h"
+#include "MFTBase/Geometry.h"
+#include "MFTBase/GeometryTGeo.h"
+
+namespace o2
+{
+namespace mft
+{
+
+/// \class AlignSensorHelper
+class AlignSensorHelper
+{
+ public:
+  /// \brief constructor with a pointer to the geometry
+  AlignSensorHelper();
+
+  /// \brief default destructor
+  virtual ~AlignSensorHelper() = default;
+
+  /// \brief set pointer to geometry that should already have done fillMatrixCache()
+  void setGeometry();
+
+  /// \brief set the studied sensor
+  bool setSensor(const int chipIndex);
+
+  /// \brief set the studied sensor
+  void setSensorOnlyInfo(const int chipIndex);
+
+  /// \brief return sensor index within the ladder [0, 4]
+  UShort_t chipIndexOnLadder() const { return mChipIndexOnLadder; }
+
+  /// \brief return sensor sw index within the MFT [0, 935]
+  UShort_t chipIndexInMft() const { return mChipIndexInMft; }
+
+  /// \brief return ladder geo index in this half MFT disk [0, 33]
+  UShort_t ladderInHalfDisk() const { return mLadderInHalfDisk; }
+
+  /// \brief return the half number to which belongs the sensor
+  UShort_t half() const { return mHalf; }
+
+  /// \brief return the disk number to which belongs the sensor
+  UShort_t disk() const { return mDisk; }
+
+  /// \brief return the layer number to which belongs the sensor
+  UShort_t layer() const { return mLayer; }
+
+  /// \brief return the zone to which belongs the sensor
+  UShort_t zone() const { return mZone; }
+
+  /// \brief return the connector to which the ladder is plugged
+  UShort_t connector() const { return mConnector; }
+
+  /// \brief return the transceiver on the RU for this sensor
+  UShort_t transceiver() const { return mTransceiver; }
+
+  /// \brief return the ALICE global unique id of the sensor
+  Int_t sensorUid() const { return mChipUniqueId; }
+
+  /// \brief return the geo symbolic name for this sensor
+  TString geoSymbolicName() { return mGeoSymbolicName; }
+
+  /// \brief return the x component of the translation in the sensor transform
+  double translateX() const { return mTranslation.X(); }
+
+  /// \brief return the y component of the translation in the sensor transform
+  double translateY() const { return mTranslation.Y(); }
+
+  /// \brief return the z component of the translation in the sensor transform
+  double translateZ() const { return mTranslation.Z(); }
+
+  /// \brief return the rotation angle w.r.t. global x-axis in the sensor transform
+  double angleRx() const { return mRx; }
+
+  /// \brief return the rotation angle w.r.t. global y-axis in the sensor transform
+  double angleRy() const { return mRy; }
+
+  /// \brief return the rotation angle w.r.t. global z-axis in the sensor transform
+  double angleRz() const { return mRz; }
+
+  /// \brief return the sin, cos of the rotation angle w.r.t. x-axis
+  double sinRx() const { return mSinRx; }
+  double cosRx() const { return mCosRx; }
+
+  /// \brief return the sin, cos of the rotation angle w.r.t. y-axis
+  double sinRy() const { return mSinRy; }
+  double cosRy() const { return mCosRy; }
+
+  /// \brief return the sin, cos of the rotation angle w.r.t. z-axis
+  double sinRz() const { return mSinRz; }
+  double cosRz() const { return mCosRz; }
+
+  /// \brief return the status of the sensor transform extraction
+  bool isTransformExtracted() const { return mIsTransformExtracted; }
+
+  /// \brief return a stringstream filled with the sensor info
+  std::stringstream getSensorFullName(bool wSymName = true);
+
+ protected:
+  o2::itsmft::ChipMappingMFT mChipMapping;         ///< MFT chip <-> ladder, layer, disk, half mapping
+  o2::mft::GeometryTGeo* mGeometry = nullptr;      ///< MFT geometry
+  int mNumberOfSensors = mChipMapping.getNChips(); ///< Total number of sensors (detection elements) in the MFT
+  UShort_t mChipIndexOnLadder = 0;                 ///< sensor index within the ladder [0, 4]
+  UShort_t mChipIndexInMft = 0;                    ///< sensor sw index within the MFT [0, 935]
+  UShort_t mLadderInHalfDisk = 0;                  ///< ladder geo index in this half MFT disk [0, 33]
+  UShort_t mConnector = 0;                         ///< connector index to which the ladder is plugged in the zone [0, 4]
+  UShort_t mTransceiver = 0;                       ///< transceiver id to which the sensor is connected in the zone [0, 24]
+  UShort_t mLayer = 0;                             ///< layer id [0, 9]
+  UShort_t mZone = 0;                              ///< zone id [0,3]
+  UShort_t mDisk = 0;                              ///< disk id [0, 4]
+  UShort_t mHalf = 0;                              ///< half id [0, 1]
+  Int_t mChipUniqueId = 0;                         ///< ALICE global unique id of the sensor
+  TGeoHMatrix mTransform;                          ///< sensor transformation matrix L2G
+  o2::math_utils::Point3D<double> mTranslation;    ///< coordinates of the translation between the local system origin (the center of the sensor) and the global origin
+
+  // Euler angles extracted from the sensor transform
+  double mRx = 0; ///< rotation angle aroung global x-axis (radian)
+  double mRy = 0; ///< rotation angle aroung global y-axis (radian)
+  double mRz = 0; ///< rotation angle aroung global z-axis (radian)
+
+  // Cosinus and sinus of the Euler angles
+  double mSinRx = 0;
+  double mCosRx = 0;
+  double mSinRy = 0;
+  double mCosRy = 0;
+  double mSinRz = 0;
+  double mCosRz = 0;
+
+  TString mGeoSymbolicName; ///< symbolic name of this sensor in the geometry
+
+  bool mIsTransformExtracted = false; ///< boolean used to check if the sensor transform was successfully extracted from geometry
+
+ protected:
+  /// \brief set the ALICE global unique id of the sensor
+  void setSensorUid(const int chipIndex);
+
+  /// \brief set the symbolic name of this sensor in the geometry
+  void setSymName();
+
+  /// \brief init the matrix that stores the sensor transform L2G and extract its components
+  void extractSensorTransform();
+
+  /// \brief reset all sensor transform related variables
+  void resetSensorTransformInfo();
+
+  ClassDef(AlignSensorHelper, 0);
+};
+
+} // namespace mft
+} // namespace o2
+#endif

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/Aligner.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/Aligner.h
@@ -1,0 +1,84 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file Aligner.h
+/// \author arakotoz@cern.ch
+/// \brief Abstract base class for the standalone alignment of MFT
+
+#ifndef ALICEO2_MFT_ALIGNER_H
+#define ALICEO2_MFT_ALIGNER_H
+
+#include <array>
+#include <vector>
+
+#include <Rtypes.h>
+#include <TString.h>
+#include <TFile.h>
+
+#include "ITSMFTReconstruction/ChipMappingMFT.h"
+#include "MFTAlignment/MillePede2.h"
+
+namespace o2
+{
+namespace mft
+{
+
+class Aligner
+{
+ public:
+  /// \brief construtor
+  Aligner();
+
+  /// \brief destructor
+  virtual ~Aligner();
+
+  /// \brief init Millipede (will be overriden in derived classes)
+  virtual void init() = 0;
+
+  // simple setters
+
+  void setChi2CutNStdDev(const Int_t value) { mChi2CutNStdDev = value; }
+  void setResidualCutInitial(const Double_t value) { mResCutInitial = value; }
+  void setResidualCut(const Double_t value) { mResCut = value; }
+  void setAllowedVariationDeltaX(const double value) { mAllowVar[0] = value; }
+  void setAllowedVariationDeltaY(const double value) { mAllowVar[1] = value; }
+  void setAllowedVariationDeltaZ(const double value) { mAllowVar[3] = value; }
+  void setAllowedVariationDeltaRz(const double value) { mAllowVar[2] = value; }
+  void setChi2CutFactor(const double value) { mStartFac = value; }
+
+ protected:
+  static constexpr int mNumberOfTrackParam = 4;                                  ///< Number of track (= local) parameters (X0, Tx, Y0, Ty)
+  static constexpr int mNDofPerSensor = 4;                                       ///< translation in global x, y, z, and rotation Rz around global z-axis
+  static o2::itsmft::ChipMappingMFT mChipMapping;                                ///< MFT chip <-> ladder, layer, disk, half mapping
+  static constexpr int mNumberOfSensors = mChipMapping.getNChips();              ///< Total number of sensors (detection elements) in the MFT
+  static constexpr int mNumberOfGlobalParam = mNDofPerSensor * mNumberOfSensors; ///< Number of alignment (= global) parameters
+  std::array<double, mNDofPerSensor> mAllowVar;                                  ///< "Encouraged" variation for degrees of freedom {dx, dy, dRz, dz}
+  double mStartFac;                                                              ///< Initial value for chi2 cut, used to reject outliers i.e. bad tracks with sum(chi2) > Chi2DoFLim(fNStdDev, nDoF) * chi2CutFactor (if > 1, iterations in Millepede are turned on)
+  int mChi2CutNStdDev;                                                           ///< Number of standard deviations for chi2 cut
+  double mResCutInitial;                                                         ///< Cut on residual on first iteration
+  double mResCut;                                                                ///< Cut on residual for other iterations
+  TString mMilleRecordsFileName;                                                 ///< output file name when saving the Mille records
+  TString mMilleConstraintsRecFileName;                                          ///< output file name when saving the records of the constraints
+  bool mIsInitDone = false;                                                      ///< boolean to follow the initialisation status
+  std::vector<int> mGlobalParameterStatus;                                       ///< vector of effective degrees of freedom, used to fix detectors, parameters, etc.
+
+  // used to fix some degrees of freedom
+
+  static constexpr int mFixedParId = -1;
+  static constexpr int mFreeParId = mFixedParId - 1;
+
+  ClassDef(Aligner, 0);
+};
+
+} // namespace mft
+} // namespace o2
+
+#endif

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/MatrixSparse.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/MatrixSparse.h
@@ -1,0 +1,152 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file MatrixSparse.h
+/// \brief Sparse matrix class (from AliROOT), used as a global matrix for MillePede2
+/// \author ruben.shahoyan@cern.ch
+
+#ifndef ALICEO2_MFT_MATRIXSPARSE_H
+#define ALICEO2_MFT_MATRIXSPARSE_H
+
+#include "MFTAlignment/MatrixSq.h"
+#include "MFTAlignment/VectorSparse.h"
+
+namespace o2
+{
+namespace mft
+{
+
+/// \class MatrixSparse
+class MatrixSparse : public MatrixSq
+{
+ public:
+  MatrixSparse() : fVecs(0) {}
+
+  /// \brief constructor
+  MatrixSparse(Int_t size);
+
+  /// \brief copy c-tor
+  MatrixSparse(const MatrixSparse& mat);
+
+  virtual ~MatrixSparse() { Clear(); }
+
+  VectorSparse* GetRow(Int_t ir) const { return (ir < fNcols) ? fVecs[ir] : 0; }
+  VectorSparse* GetRowAdd(Int_t ir);
+
+  virtual Int_t GetSize() const { return fNrows; }
+  virtual Int_t GetNRows() const { return fNrows; }
+  virtual Int_t GetNCols() const { return fNcols; }
+
+  void Clear(Option_t* option = "");
+  void Reset()
+  {
+    for (int i = fNcols; i--;)
+      GetRow(i)->Reset();
+  }
+  void Print(Option_t* option = "") const;
+  MatrixSparse& operator=(const MatrixSparse& src);
+  Double_t& operator()(Int_t row, Int_t col);
+  Double_t operator()(Int_t row, Int_t col) const;
+  void SetToZero(Int_t row, Int_t col);
+
+  /// \brief get fraction of non-zero elements
+  Float_t GetDensity() const;
+
+  Double_t DiagElem(Int_t r) const;
+  Double_t& DiagElem(Int_t r);
+
+  /// \brief sort columns in increasing order. Used to fix the matrix after ILUk decompostion
+  void SortIndices(Bool_t valuesToo = kFALSE);
+
+  /// \brief fill vecOut by matrix * vecIn (vector should be of the same size as the matrix)
+  void MultiplyByVec(const TVectorD& vecIn, TVectorD& vecOut) const;
+
+  void MultiplyByVec(const Double_t* vecIn, Double_t* vecOut) const;
+
+  void AddToRow(Int_t r, Double_t* valc, Int_t* indc, Int_t n);
+
+ protected:
+  VectorSparse** fVecs;
+
+  ClassDef(MatrixSparse, 0);
+};
+
+//___________________________________________________
+/// \brief multiplication
+inline void MatrixSparse::MultiplyByVec(const TVectorD& vecIn, TVectorD& vecOut) const
+{
+  MultiplyByVec((Double_t*)vecIn.GetMatrixArray(), (Double_t*)vecOut.GetMatrixArray());
+}
+
+//___________________________________________________
+/// \brief set existing element to 0
+inline void MatrixSparse::SetToZero(Int_t row, Int_t col)
+{
+  if (IsSymmetric() && col > row)
+    Swap(row, col);
+  VectorSparse* rowv = GetRow(row);
+  if (rowv)
+    rowv->SetToZero(col);
+}
+
+//___________________________________________________
+inline Double_t MatrixSparse::operator()(Int_t row, Int_t col) const
+{
+  if (IsSymmetric() && col > row)
+    Swap(row, col);
+  VectorSparse* rowv = GetRow(row);
+  if (!rowv)
+    return 0;
+  return rowv->FindIndex(col);
+}
+
+//___________________________________________________
+inline Double_t& MatrixSparse::operator()(Int_t row, Int_t col)
+{
+  //  printf("M: findindexAdd\n");
+  if (IsSymmetric() && col > row)
+    Swap(row, col);
+  VectorSparse* rowv = GetRowAdd(row);
+  if (col >= fNcols)
+    fNcols = col + 1;
+  return rowv->FindIndexAdd(col);
+}
+
+//___________________________________________________
+/// \brief get diag elem
+inline Double_t MatrixSparse::DiagElem(Int_t row) const
+{
+  VectorSparse* rowv = GetRow(row);
+  if (!rowv)
+    return 0;
+  if (IsSymmetric()) {
+    return (rowv->GetNElems() > 0 && rowv->GetLastIndex() == row) ? rowv->GetLastElem() : 0.;
+  } else
+    return rowv->FindIndex(row);
+}
+
+//___________________________________________________
+/// \brief get diag elem
+inline Double_t& MatrixSparse::DiagElem(Int_t row)
+{
+  VectorSparse* rowv = GetRowAdd(row);
+  if (row >= fNcols)
+    fNcols = row + 1;
+  if (IsSymmetric()) {
+    return (rowv->GetNElems() > 0 && rowv->GetLastIndex() == row) ? rowv->GetLastElem() : rowv->FindIndexAdd(row);
+  } else
+    return rowv->FindIndexAdd(row);
+}
+
+} // namespace mft
+} // namespace o2
+
+#endif

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/MatrixSparse.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/MatrixSparse.h
@@ -28,7 +28,7 @@ namespace mft
 class MatrixSparse : public MatrixSq
 {
  public:
-  MatrixSparse() : fVecs(0) {}
+  MatrixSparse() = default;
 
   /// \brief constructor
   MatrixSparse(Int_t size);
@@ -36,45 +36,46 @@ class MatrixSparse : public MatrixSq
   /// \brief copy c-tor
   MatrixSparse(const MatrixSparse& mat);
 
-  virtual ~MatrixSparse() { Clear(); }
+  ~MatrixSparse() override { Clear(); }
 
-  VectorSparse* GetRow(Int_t ir) const { return (ir < fNcols) ? fVecs[ir] : 0; }
+  VectorSparse* GetRow(Int_t ir) const { return (ir < fNcols) ? fVecs[ir] : nullptr; }
   VectorSparse* GetRowAdd(Int_t ir);
 
-  virtual Int_t GetSize() const { return fNrows; }
+  Int_t GetSize() const override { return fNrows; }
   virtual Int_t GetNRows() const { return fNrows; }
   virtual Int_t GetNCols() const { return fNcols; }
 
-  void Clear(Option_t* option = "");
-  void Reset()
+  void Clear(Option_t* option = "") override;
+  void Reset() override
   {
-    for (int i = fNcols; i--;)
+    for (int i = fNcols; i--;) {
       GetRow(i)->Reset();
+    }
   }
-  void Print(Option_t* option = "") const;
+  void Print(Option_t* option = "") const override;
   MatrixSparse& operator=(const MatrixSparse& src);
-  Double_t& operator()(Int_t row, Int_t col);
-  Double_t operator()(Int_t row, Int_t col) const;
+  Double_t& operator()(Int_t row, Int_t col) override;
+  Double_t operator()(Int_t row, Int_t col) const override;
   void SetToZero(Int_t row, Int_t col);
 
   /// \brief get fraction of non-zero elements
-  Float_t GetDensity() const;
+  Float_t GetDensity() const override;
 
-  Double_t DiagElem(Int_t r) const;
-  Double_t& DiagElem(Int_t r);
+  Double_t DiagElem(Int_t r) const override;
+  Double_t& DiagElem(Int_t r) override;
 
   /// \brief sort columns in increasing order. Used to fix the matrix after ILUk decompostion
   void SortIndices(Bool_t valuesToo = kFALSE);
 
   /// \brief fill vecOut by matrix * vecIn (vector should be of the same size as the matrix)
-  void MultiplyByVec(const TVectorD& vecIn, TVectorD& vecOut) const;
+  void MultiplyByVec(const TVectorD& vecIn, TVectorD& vecOut) const override;
 
-  void MultiplyByVec(const Double_t* vecIn, Double_t* vecOut) const;
+  void MultiplyByVec(const Double_t* vecIn, Double_t* vecOut) const override;
 
-  void AddToRow(Int_t r, Double_t* valc, Int_t* indc, Int_t n);
+  void AddToRow(Int_t r, Double_t* valc, Int_t* indc, Int_t n) override;
 
  protected:
-  VectorSparse** fVecs;
+  VectorSparse** fVecs = nullptr;
 
   ClassDef(MatrixSparse, 0);
 };
@@ -90,21 +91,25 @@ inline void MatrixSparse::MultiplyByVec(const TVectorD& vecIn, TVectorD& vecOut)
 /// \brief set existing element to 0
 inline void MatrixSparse::SetToZero(Int_t row, Int_t col)
 {
-  if (IsSymmetric() && col > row)
+  if (IsSymmetric() && col > row) {
     Swap(row, col);
+  }
   VectorSparse* rowv = GetRow(row);
-  if (rowv)
+  if (rowv) {
     rowv->SetToZero(col);
+  }
 }
 
 //___________________________________________________
 inline Double_t MatrixSparse::operator()(Int_t row, Int_t col) const
 {
-  if (IsSymmetric() && col > row)
+  if (IsSymmetric() && col > row) {
     Swap(row, col);
+  }
   VectorSparse* rowv = GetRow(row);
-  if (!rowv)
+  if (!rowv) {
     return 0;
+  }
   return rowv->FindIndex(col);
 }
 
@@ -112,11 +117,13 @@ inline Double_t MatrixSparse::operator()(Int_t row, Int_t col) const
 inline Double_t& MatrixSparse::operator()(Int_t row, Int_t col)
 {
   //  printf("M: findindexAdd\n");
-  if (IsSymmetric() && col > row)
+  if (IsSymmetric() && col > row) {
     Swap(row, col);
+  }
   VectorSparse* rowv = GetRowAdd(row);
-  if (col >= fNcols)
+  if (col >= fNcols) {
     fNcols = col + 1;
+  }
   return rowv->FindIndexAdd(col);
 }
 
@@ -125,12 +132,14 @@ inline Double_t& MatrixSparse::operator()(Int_t row, Int_t col)
 inline Double_t MatrixSparse::DiagElem(Int_t row) const
 {
   VectorSparse* rowv = GetRow(row);
-  if (!rowv)
+  if (!rowv) {
     return 0;
+  }
   if (IsSymmetric()) {
     return (rowv->GetNElems() > 0 && rowv->GetLastIndex() == row) ? rowv->GetLastElem() : 0.;
-  } else
+  } else {
     return rowv->FindIndex(row);
+  }
 }
 
 //___________________________________________________
@@ -138,12 +147,14 @@ inline Double_t MatrixSparse::DiagElem(Int_t row) const
 inline Double_t& MatrixSparse::DiagElem(Int_t row)
 {
   VectorSparse* rowv = GetRowAdd(row);
-  if (row >= fNcols)
+  if (row >= fNcols) {
     fNcols = row + 1;
+  }
   if (IsSymmetric()) {
     return (rowv->GetNElems() > 0 && rowv->GetLastIndex() == row) ? rowv->GetLastElem() : rowv->FindIndexAdd(row);
-  } else
+  } else {
     return rowv->FindIndexAdd(row);
+  }
 }
 
 } // namespace mft

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/MatrixSq.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/MatrixSq.h
@@ -30,8 +30,8 @@ class MatrixSq : public TMatrixDBase
 
  public:
   MatrixSq() : fSymmetric(kFALSE) {}
-  MatrixSq(const MatrixSq& src) : TMatrixDBase(src), fSymmetric(src.fSymmetric) {}
-  virtual ~MatrixSq() {}
+  MatrixSq(const MatrixSq& src);
+  ~MatrixSq() override = default;
 
   /// \brief = operator
   MatrixSq& operator=(const MatrixSq& src);
@@ -39,18 +39,18 @@ class MatrixSq : public TMatrixDBase
   virtual Int_t GetSize() const { return fNcols; }
   virtual Float_t GetDensity() const = 0;
 
-  virtual void Clear(Option_t* option = "") = 0;
+  void Clear(Option_t* option = "") override = 0;
 
   virtual Double_t Query(Int_t rown, Int_t coln) const { return operator()(rown, coln); }
-  virtual Double_t operator()(Int_t rown, Int_t coln) const = 0;
-  virtual Double_t& operator()(Int_t rown, Int_t coln) = 0;
+  Double_t operator()(Int_t rown, Int_t coln) const override = 0;
+  Double_t& operator()(Int_t rown, Int_t coln) override = 0;
 
   virtual Double_t QueryDiag(Int_t rc) const { return DiagElem(rc); }
   virtual Double_t DiagElem(Int_t r) const = 0;
   virtual Double_t& DiagElem(Int_t r) = 0;
   virtual void AddToRow(Int_t r, Double_t* valc, Int_t* indc, Int_t n) = 0;
 
-  virtual void Print(Option_t* option = "") const = 0;
+  void Print(Option_t* option = "") const override = 0;
   virtual void Reset() = 0;
 
   /// \brief print matrix in COO sparse format
@@ -61,66 +61,66 @@ class MatrixSq : public TMatrixDBase
 
   virtual void MultiplyByVec(const TVectorD& vecIn, TVectorD& vecOut) const;
 
-  Bool_t IsSymmetric() const { return fSymmetric; }
+  Bool_t IsSymmetric() const override { return fSymmetric; }
   void SetSymmetric(Bool_t v = kTRUE) { fSymmetric = v; }
 
   // ---------------------------------- Dummy methods of MatrixBase
-  virtual const Double_t* GetMatrixArray() const
+  const Double_t* GetMatrixArray() const override
   {
     Error("GetMatrixArray", "Dummy");
-    return 0;
+    return nullptr;
   };
-  virtual Double_t* GetMatrixArray()
+  Double_t* GetMatrixArray() override
   {
     Error("GetMatrixArray", "Dummy");
-    return 0;
+    return nullptr;
   };
-  virtual const Int_t* GetRowIndexArray() const
+  const Int_t* GetRowIndexArray() const override
   {
     Error("GetRowIndexArray", "Dummy");
-    return 0;
+    return nullptr;
   };
-  virtual Int_t* GetRowIndexArray()
+  Int_t* GetRowIndexArray() override
   {
     Error("GetRowIndexArray", "Dummy");
-    return 0;
+    return nullptr;
   };
-  virtual const Int_t* GetColIndexArray() const
+  const Int_t* GetColIndexArray() const override
   {
     Error("GetColIndexArray", "Dummy");
-    return 0;
+    return nullptr;
   };
-  virtual Int_t* GetColIndexArray()
+  Int_t* GetColIndexArray() override
   {
     Error("GetColIndexArray", "Dummy");
-    return 0;
+    return nullptr;
   };
-  virtual TMatrixDBase& SetRowIndexArray(Int_t*)
+  TMatrixDBase& SetRowIndexArray(Int_t*) override
   {
     Error("SetRowIndexArray", "Dummy");
     return *this;
   }
-  virtual TMatrixDBase& SetColIndexArray(Int_t*)
+  TMatrixDBase& SetColIndexArray(Int_t*) override
   {
     Error("SetColIndexArray", "Dummy");
     return *this;
   }
-  virtual TMatrixDBase& GetSub(Int_t, Int_t, Int_t, Int_t, TMatrixDBase&, Option_t*) const
+  TMatrixDBase& GetSub(Int_t, Int_t, Int_t, Int_t, TMatrixDBase&, Option_t*) const override
   {
     Error("GetSub", "Dummy");
     return *((TMatrixDBase*)this);
   }
-  virtual TMatrixDBase& SetSub(Int_t, Int_t, const TMatrixDBase&)
+  TMatrixDBase& SetSub(Int_t, Int_t, const TMatrixDBase&) override
   {
     Error("GetSub", "Dummy");
     return *this;
   }
-  virtual TMatrixDBase& ResizeTo(Int_t, Int_t, Int_t)
+  TMatrixDBase& ResizeTo(Int_t, Int_t, Int_t) override
   {
     Error("ResizeTo", "Dummy");
     return *this;
   }
-  virtual TMatrixDBase& ResizeTo(Int_t, Int_t, Int_t, Int_t, Int_t)
+  TMatrixDBase& ResizeTo(Int_t, Int_t, Int_t, Int_t, Int_t) override
   {
     Error("ResizeTo", "Dummy");
     return *this;

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/MatrixSq.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/MatrixSq.h
@@ -1,0 +1,159 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file MatrixSq.h
+/// \brief Abstract class (from AliROOT) for square matrix used for millepede2 operation
+/// \author ruben.shahoyan@cern.ch
+
+#ifndef ALICEO2_MFT_MATRIXSQ_H
+#define ALICEO2_MFT_MATRIXSQ_H
+
+#include <TMatrixDBase.h>
+#include <TVectorD.h>
+
+namespace o2
+{
+namespace mft
+{
+
+/// \class MatrixSq
+class MatrixSq : public TMatrixDBase
+{
+
+ public:
+  MatrixSq() : fSymmetric(kFALSE) {}
+  MatrixSq(const MatrixSq& src) : TMatrixDBase(src), fSymmetric(src.fSymmetric) {}
+  virtual ~MatrixSq() {}
+
+  /// \brief = operator
+  MatrixSq& operator=(const MatrixSq& src);
+
+  virtual Int_t GetSize() const { return fNcols; }
+  virtual Float_t GetDensity() const = 0;
+
+  virtual void Clear(Option_t* option = "") = 0;
+
+  virtual Double_t Query(Int_t rown, Int_t coln) const { return operator()(rown, coln); }
+  virtual Double_t operator()(Int_t rown, Int_t coln) const = 0;
+  virtual Double_t& operator()(Int_t rown, Int_t coln) = 0;
+
+  virtual Double_t QueryDiag(Int_t rc) const { return DiagElem(rc); }
+  virtual Double_t DiagElem(Int_t r) const = 0;
+  virtual Double_t& DiagElem(Int_t r) = 0;
+  virtual void AddToRow(Int_t r, Double_t* valc, Int_t* indc, Int_t n) = 0;
+
+  virtual void Print(Option_t* option = "") const = 0;
+  virtual void Reset() = 0;
+
+  /// \brief print matrix in COO sparse format
+  virtual void PrintCOO() const;
+
+  /// \brief fill vecOut by matrix * vecIn (vector should be of the same size as the matrix)
+  virtual void MultiplyByVec(const Double_t* vecIn, Double_t* vecOut) const;
+
+  virtual void MultiplyByVec(const TVectorD& vecIn, TVectorD& vecOut) const;
+
+  Bool_t IsSymmetric() const { return fSymmetric; }
+  void SetSymmetric(Bool_t v = kTRUE) { fSymmetric = v; }
+
+  // ---------------------------------- Dummy methods of MatrixBase
+  virtual const Double_t* GetMatrixArray() const
+  {
+    Error("GetMatrixArray", "Dummy");
+    return 0;
+  };
+  virtual Double_t* GetMatrixArray()
+  {
+    Error("GetMatrixArray", "Dummy");
+    return 0;
+  };
+  virtual const Int_t* GetRowIndexArray() const
+  {
+    Error("GetRowIndexArray", "Dummy");
+    return 0;
+  };
+  virtual Int_t* GetRowIndexArray()
+  {
+    Error("GetRowIndexArray", "Dummy");
+    return 0;
+  };
+  virtual const Int_t* GetColIndexArray() const
+  {
+    Error("GetColIndexArray", "Dummy");
+    return 0;
+  };
+  virtual Int_t* GetColIndexArray()
+  {
+    Error("GetColIndexArray", "Dummy");
+    return 0;
+  };
+  virtual TMatrixDBase& SetRowIndexArray(Int_t*)
+  {
+    Error("SetRowIndexArray", "Dummy");
+    return *this;
+  }
+  virtual TMatrixDBase& SetColIndexArray(Int_t*)
+  {
+    Error("SetColIndexArray", "Dummy");
+    return *this;
+  }
+  virtual TMatrixDBase& GetSub(Int_t, Int_t, Int_t, Int_t, TMatrixDBase&, Option_t*) const
+  {
+    Error("GetSub", "Dummy");
+    return *((TMatrixDBase*)this);
+  }
+  virtual TMatrixDBase& SetSub(Int_t, Int_t, const TMatrixDBase&)
+  {
+    Error("GetSub", "Dummy");
+    return *this;
+  }
+  virtual TMatrixDBase& ResizeTo(Int_t, Int_t, Int_t)
+  {
+    Error("ResizeTo", "Dummy");
+    return *this;
+  }
+  virtual TMatrixDBase& ResizeTo(Int_t, Int_t, Int_t, Int_t, Int_t)
+  {
+    Error("ResizeTo", "Dummy");
+    return *this;
+  }
+  virtual void Allocate(Int_t, Int_t, Int_t, Int_t, Int_t, Int_t)
+  {
+    Error("Allocate", "Dummy");
+    return;
+  }
+
+  static Bool_t IsZero(Double_t x, Double_t thresh = 1e-64) { return x > 0 ? (x < thresh) : (x > -thresh); }
+
+ protected:
+  void Swap(int& r, int& c) const
+  {
+    int t = r;
+    r = c;
+    c = t;
+  }
+
+ protected:
+  Bool_t fSymmetric; ///< is the matrix symmetric? Only lower triangle is filled
+
+  ClassDef(MatrixSq, 1);
+};
+
+//___________________________________________________________
+inline void MatrixSq::MultiplyByVec(const TVectorD& vecIn, TVectorD& vecOut) const
+{
+  MultiplyByVec(vecIn.GetMatrixArray(), vecOut.GetMatrixArray());
+}
+
+} // namespace mft
+} // namespace o2
+
+#endif

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/MillePede2.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/MillePede2.h
@@ -148,11 +148,13 @@ class MillePede2
   void SetParamGrID(const int grID, int i)
   {
     int ir = GetRGId(i);
-    if (ir < 0)
+    if (ir < 0) {
       return;
+    }
     fParamGrID[ir] = grID;
-    if (fNGroupsSet < grID)
+    if (fNGroupsSet < grID) {
       fNGroupsSet = grID;
+    }
   }
   void SetNGloPar(const int n) { fNGloPar = n; }
   void SetNLocPar(const int n) { fNLocPar = n; }
@@ -179,7 +181,7 @@ class MillePede2
   void SetSigmaPar(int i, double par);
 
   /// \brief performs a requested number of global iterations
-  int GlobalFit(double* par = 0, double* error = 0, double* pull = 0);
+  int GlobalFit(double* par = nullptr, double* error = nullptr, double* pull = nullptr);
 
   /// \brief perform global parameters fit once all the local equations have been fitted
   int GlobalFitIteration();
@@ -211,7 +213,7 @@ class MillePede2
   void SetRejRunList(const int* runs, const int nruns);
 
   /// \brief set the list of runs to be selected
-  void SetAccRunList(const int* runs, const int nruns, const float* wghList = 0);
+  void SetAccRunList(const int* runs, const int nruns, const float* wghList = nullptr);
 
   /// \brief validate record according run lists set by the user
   bool IsRecordAcceptable();
@@ -275,8 +277,9 @@ class MillePede2
   void SetNonLinear(int index, bool v = true)
   {
     int id = GetRGId(index);
-    if (id < 0)
+    if (id < 0) {
       return;
+    }
     fIsLinear[id] = !v;
   }
 

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/MillePede2.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/MillePede2.h
@@ -1,0 +1,389 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file MillePede2.h
+/// \authors ruben.shahoyan@cern.ch, arakotoz@cern.ch
+/// \brief General class for alignment with large number of degrees of freedom, adapted from AliROOT
+///
+/// Based on the original milliped2 by Volker Blobel
+/// http://www.desy.de/~blobel/mptalks.html
+
+#ifndef ALICEO2_MFT_MILLEPEDE2_H
+#define ALICEO2_MFT_MILLEPEDE2_H
+
+#include <vector>
+#include <TString.h>
+#include <TTree.h>
+#include "MFTAlignment/MinResSolve.h"
+#include "MFTAlignment/MillePedeRecord.h"
+#include "MFTAlignment/SymMatrix.h"
+#include "MFTAlignment/RectMatrix.h"
+#include "MFTAlignment/MatrixSparse.h"
+#include "MFTAlignment/MatrixSq.h"
+#include "MFTAlignment/MilleRecordWriter.h"
+#include "MFTAlignment/MilleRecordReader.h"
+
+class TFile;
+class TStopwatch;
+class TArrayL;
+class TArrayF;
+
+namespace o2
+{
+namespace mft
+{
+
+class MillePede2
+{
+ public:
+  //
+  enum { kFailed,
+         kInvert,
+         kNoInversion };   // used global matrix solution methods
+  enum { kFixParID = -1 }; // dummy id for fixed param
+
+  MillePede2();
+  MillePede2(const MillePede2& src);
+  virtual ~MillePede2();
+  MillePede2& operator=(const MillePede2&)
+  {
+    printf("Dummy\n");
+    return *this;
+  }
+
+  /// \brief init all
+  int InitMille(int nGlo, const int nLoc,
+                const int lNStdDev = -1, const double lResCut = -1.,
+                const double lResCutInit = -1., const std::vector<int>& regroup = {});
+
+  int GetNGloPar() const { return fNGloPar; }
+  int GetNGloParIni() const { return fNGloParIni; }
+  std::vector<int> GetRegrouping() const { return fkReGroup; }
+  int GetNLocPar() const { return fNLocPar; }
+  long GetNLocalEquations() const { return fNLocEquations; }
+  int GetCurrentIteration() const { return fIter; }
+  int GetNMaxIterations() const { return fMaxIter; }
+  int GetNStdDev() const { return fNStdDev; }
+  int GetNGlobalConstraints() const { return fNGloConstraints; }
+  int GetNLagrangeConstraints() const { return fNLagrangeConstraints; }
+  int GetNLocalFits() const { return fNLocFits; }
+  long GetNLocalFitsRejected() const { return fNLocFitsRejected; }
+  int GetNGlobalsFixed() const { return fNGloFix; }
+  int GetGlobalSolveStatus() const { return fGloSolveStatus; }
+  float GetChi2CutFactor() const { return fChi2CutFactor; }
+  float GetChi2CutRef() const { return fChi2CutRef; }
+  float GetResCurInit() const { return fResCutInit; }
+  float GetResCut() const { return fResCut; }
+  int GetMinPntValid() const { return fMinPntValid; }
+  int GetRGId(int i) const { return fkReGroup.size() ? (fkReGroup[i] < 0 ? -1 : fkReGroup[i]) : i; }
+  int GetProcessedPoints(int i) const
+  {
+    int ir = GetRGId(i);
+    return ir <= 0 ? 0 : fProcPnt[ir];
+  }
+  std::vector<int> GetProcessedPoints() const { return fProcPnt; }
+  int GetParamGrID(int i) const
+  {
+    int ir = GetRGId(i);
+    return ir <= 0 ? 0 : fParamGrID[ir];
+  }
+
+  MatrixSq* GetGlobalMatrix() const { return fMatCGlo; }
+  SymMatrix* GetLocalMatrix() const { return fMatCLoc; }
+  std::vector<double> GetGlobals() const { return fVecBGlo; }
+  std::vector<double> GetDeltaPars() const { return fDeltaPar; }
+  std::vector<double> GetInitPars() const { return fInitPar; }
+  std::vector<double> GetSigmaPars() const { return fSigmaPar; }
+  std::vector<bool> GetIsLinear() const { return fIsLinear; }
+  double GetFinalParam(int i) const
+  {
+    int ir = GetRGId(i);
+    return ir < 0 ? 0 : fDeltaPar[ir] + fInitPar[ir];
+  }
+  double GetFinalError(int i) const { return GetParError(i); }
+
+  /// \brief return pull for parameter iPar
+  double GetPull(int i) const;
+
+  double GetGlobal(int i) const
+  {
+    int ir = GetRGId(i);
+    return ir < 0 ? 0 : fVecBGlo[ir];
+  }
+  double GetInitPar(int i) const
+  {
+    int ir = GetRGId(i);
+    return ir < 0 ? 0 : fInitPar[ir];
+  }
+  double GetSigmaPar(int i) const
+  {
+    int ir = GetRGId(i);
+    return ir < 0 ? 0 : fSigmaPar[ir];
+  }
+  bool GetIsLinear(int i) const
+  {
+    int ir = GetRGId(i);
+    return ir < 0 ? 0 : fIsLinear[ir];
+  }
+  static bool IsGlobalMatSparse() { return fgIsMatGloSparse; }
+  static bool IsWeightSigma() { return fgWeightSigma; }
+  void SetWghScale(const double wOdd = 1, const double wEven = 1)
+  {
+    fWghScl[0] = wOdd;
+    fWghScl[1] = wEven;
+  }
+  void SetUseRecordWeight(const bool v = true) { fUseRecordWeight = v; }
+  bool GetUseRecordWeight() const { return fUseRecordWeight; }
+  void SetMinRecordLength(const int v = 1) { fMinRecordLength = v; }
+  int GetMinRecordLength() const { return fMinRecordLength; }
+
+  void SetParamGrID(const int grID, int i)
+  {
+    int ir = GetRGId(i);
+    if (ir < 0)
+      return;
+    fParamGrID[ir] = grID;
+    if (fNGroupsSet < grID)
+      fNGroupsSet = grID;
+  }
+  void SetNGloPar(const int n) { fNGloPar = n; }
+  void SetNLocPar(const int n) { fNLocPar = n; }
+  void SetNMaxIterations(const int n = 10) { fMaxIter = n; }
+  void SetNStdDev(const int n) { fNStdDev = n; }
+  void SetChi2CutFactor(const float v) { fChi2CutFactor = v; }
+  void SetChi2CutRef(const float v) { fChi2CutRef = v; }
+  void SetResCurInit(const float v) { fResCutInit = v; }
+  void SetResCut(const float v) { fResCut = v; }
+  void SetMinPntValid(const int n) { fMinPntValid = n > 0 ? n : 1; }
+  static void SetGlobalMatSparse(const bool v = true) { fgIsMatGloSparse = v; }
+  static void SetWeightSigma(const bool v = true) { fgWeightSigma = v; }
+
+  /// \brief initialize parameters, account for eventual grouping
+  void SetInitPars(const double* par);
+
+  /// \brief initialize sigmas, account for eventual grouping
+  void SetSigmaPars(const double* par);
+
+  /// \brief initialize param, account for eventual grouping
+  void SetInitPar(int i, double par);
+
+  /// \brief initialize sigma, account for eventual grouping
+  void SetSigmaPar(int i, double par);
+
+  /// \brief performs a requested number of global iterations
+  int GlobalFit(double* par = 0, double* error = 0, double* pull = 0);
+
+  /// \brief perform global parameters fit once all the local equations have been fitted
+  int GlobalFitIteration();
+
+  /// \brief solve global matrix equation MatCGlob*X=VecBGlo and store the result in the VecBGlo
+  int SolveGlobalMatEq();
+
+  static void SetInvChol(const bool v = true) { fgInvChol = v; }
+  static void SetMinResPrecondType(const int tp = 0) { fgMinResCondType = tp; }
+  static void SetMinResTol(double val = 1e-12) { fgMinResTol = val; }
+  static void SetMinResMaxIter(const int val = 2000) { fgMinResMaxIter = val; }
+  static void SetIterSolverType(const int val = MinResSolve::kSolMinRes) { fgIterSol = val; }
+  static void SetNKrylovV(const int val = 60) { fgNKrylovV = val; }
+
+  static bool GetInvChol() { return fgInvChol; }
+  static int GetMinResPrecondType() { return fgMinResCondType; }
+  static double GetMinResTol() { return fgMinResTol; }
+  static int GetMinResMaxIter() { return fgMinResMaxIter; }
+  static int GetIterSolverType() { return fgIterSol; }
+  static int GetNKrylovV() { return fgNKrylovV; }
+
+  /// \brief return error for parameter iPar
+  double GetParError(int iPar) const;
+
+  /// \brief print the final results into the logfile
+  int PrintGlobalParameters() const;
+
+  /// \brief set the list of runs to be rejected
+  void SetRejRunList(const int* runs, const int nruns);
+
+  /// \brief set the list of runs to be selected
+  void SetAccRunList(const int* runs, const int nruns, const float* wghList = 0);
+
+  /// \brief validate record according run lists set by the user
+  bool IsRecordAcceptable();
+
+  /// \brief Number of iterations is calculated from lChi2CutFac
+  int SetIterations(const double lChi2CutFac);
+
+  // constraints
+
+  /// \brief define a constraint equation
+  void SetGlobalConstraint(const std::vector<double>& dergb,
+                           const double val, const double sigma = 0,
+                           const bool doPrint = false);
+
+  /// \brief define a constraint equation
+  void SetGlobalConstraint(const std::vector<int>& indgb,
+                           const std::vector<double>& dergb,
+                           const int ngb, const double val,
+                           double sigma = 0, const bool doPrint = false);
+
+  /// \brief assing derivs of loc.eq.
+  void SetLocalEquation(std::vector<double>& dergb, std::vector<double>& derlc,
+                        const double lMeas, const double lSigma);
+
+  /// \brief write data of single measurement.
+  ///        Note: the records ignore regrouping, store direct parameters
+  void SetLocalEquation(std::vector<int>& indgb, std::vector<double>& dergb,
+                        int ngb, std::vector<int>& indlc,
+                        std::vector<double>& derlc, const int nlc,
+                        const double lMeas, const double lSigma);
+
+  /// \brief return file name where is stored chi2 from LocalFit()
+  const char* GetRecChi2FName() const { return fRecChi2FName.Data(); }
+
+  /// \brief initialize the file and tree to store chi2 from LocalFit()
+  bool InitChi2Storage(const int nEntriesAutoSave = 10000);
+
+  /// \brief write tree and close file where are stored chi2 from LocalFit()
+  void EndChi2Storage();
+
+  o2::mft::MillePedeRecord* GetRecord() const { return fRecord; }
+  long GetSelFirst() const { return fSelFirst; }
+  long GetSelLast() const { return fSelLast; }
+  void SetSelFirst(long v) { fSelFirst = v; }
+  void SetSelLast(long v) { fSelLast = v; }
+
+  void SetRecord(o2::mft::MillePedeRecord* aRecord) { fRecord = aRecord; }
+  void SetRecordWriter(o2::mft::MilleRecordWriter* myP) { fRecordWriter = myP; }
+  void SetConstraintsRecWriter(o2::mft::MilleRecordWriter* myP) { fConstraintsRecWriter = myP; }
+  void SetRecordReader(o2::mft::MilleRecordReader* myP) { fRecordReader = myP; }
+  void SetConstraintsRecReader(o2::mft::MilleRecordReader* myP) { fConstraintsRecReader = myP; }
+
+  /// \brief return the limit in chi^2/nd for n sigmas stdev authorized
+  ///
+  /// Only n=1, 2, and 3 are expected in input
+  float Chi2DoFLim(int nSig, int nDoF) const;
+
+  // aliases for compatibility with millipede1
+  void SetParSigma(int i, double par) { SetSigmaPar(i, par); }
+  void SetGlobalParameters(double* par) { SetInitPars(par); }
+  void SetNonLinear(int index, bool v = true)
+  {
+    int id = GetRGId(index);
+    if (id < 0)
+      return;
+    fIsLinear[id] = !v;
+  }
+
+ protected:
+  /// \brief read data record (if any) at entry recID
+  void ReadRecordData(const long recID, const bool doPrint = false);
+
+  /// \brief read constraint record (if any) at entry id recID
+  void ReadRecordConstraint(const long recID, const bool doPrint = false);
+
+  /// \brief Perform local parameters fit once all the local equations have been set
+  ///
+  /// localParams = (if !=0) will contain the fitted track parameters and related errors
+  int LocalFit(std::vector<double>& localParams);
+
+  bool IsZero(const double v, const double eps = 1e-16) const { return TMath::Abs(v) < eps; }
+
+ protected:
+  int fNLocPar;    ///< number of local parameters
+  int fNGloPar;    ///< number of global parameters
+  int fNGloParIni; ///< number of global parameters before grouping
+  int fNGloSize;   ///< final size of the global matrix (NGloPar+NConstraints)
+
+  long fNLocEquations;       ///< Number of local equations
+  int fIter;                 ///< Current iteration
+  int fMaxIter;              ///< Maximum number of iterations
+  int fNStdDev;              ///< Number of standard deviations for chi2 cut
+  int fNGloConstraints;      ///< Number of constraint equations
+  int fNLagrangeConstraints; ///< Number of constraint equations requiring Lagrange multiplier
+  long fNLocFits;            ///< Number of local fits
+  long fNLocFitsRejected;    ///< Number of local fits rejected
+  int fNGloFix;              ///< Number of globals fixed by user
+  int fGloSolveStatus;       ///< Status of global solver at current step
+
+  float fChi2CutFactor; ///< Cut factor for chi2 cut to accept local fit
+  float fChi2CutRef;    ///< Reference cut for chi2 cut to accept local fit
+  float fResCutInit;    ///< Cut in residual for first iterartion
+  float fResCut;        ///< Cut in residual for other iterartiona
+  int fMinPntValid;     ///< min number of points for global to vary
+
+  int fNGroupsSet;               ///< number of groups set
+  std::vector<int> fParamGrID;   ///< [fNGloPar] group id for the every parameter
+  std::vector<int> fProcPnt;     ///< [fNGloPar] N of processed points per global variable
+  std::vector<double> fVecBLoc;  ///< [fNLocPar] Vector B local (parameters)
+  std::vector<double> fDiagCGlo; ///< [fNGloPar] Initial diagonal elements of C global matrix
+  std::vector<double> fVecBGlo;  //! Vector B global (parameters)
+
+  std::vector<double> fInitPar;  ///< [fNGloPar] Initial global parameters
+  std::vector<double> fDeltaPar; ///< [fNGloPar] Variation of global parameters
+  std::vector<double> fSigmaPar; ///< [fNGloPar] Sigma of allowed variation of global parameter
+
+  std::vector<bool> fIsLinear;   ///< [fNGloPar] Flag for linear parameters
+  std::vector<bool> fConstrUsed; //! Flag for used constraints
+
+  std::vector<int> fGlo2CGlo; ///< [fNGloPar] global ID to compressed ID buffer
+  std::vector<int> fCGlo2Glo; ///< [fNGloPar] compressed ID to global ID buffer
+
+  // Matrices
+  o2::mft::SymMatrix* fMatCLoc;     ///< Matrix C local
+  o2::mft::MatrixSq* fMatCGlo;      ///< Matrix C global
+  o2::mft::RectMatrix* fMatCGloLoc; ///< Rectangular matrix C g*l
+  std::vector<int> fFillIndex;      ///< [fNGloPar] auxilary index array for fast matrix fill
+  std::vector<double> fFillValue;   ///< [fNGloPar] auxilary value array for fast matrix fill
+
+  TFile* fRecChi2File;
+  TString fRecChi2FName;
+  TString fRecChi2TreeName; ///< Name of chi2 per record tree
+  TTree* fTreeChi2;
+  float fSumChi2;
+  bool fIsChi2BelowLimit;
+  int fRecNDoF;
+
+  o2::mft::MillePedeRecord* fRecord; ///< Buffer of measurements records
+
+  long fCurrRecDataID;        ///< ID of the current data record
+  long fCurrRecConstrID;      ///< ID of the current constraint record
+  bool fLocFitAdd;            ///< Add contribution of carrent track (and not eliminate it)
+  bool fUseRecordWeight;      ///< force or ignore the record weight
+  int fMinRecordLength;       ///< ignore shorter records
+  int fSelFirst;              ///< event selection start
+  int fSelLast;               ///< event selection end
+  TArrayL* fRejRunList;       ///< list of runs to reject (if any)
+  TArrayL* fAccRunList;       ///< list of runs to select (if any)
+  TArrayF* fAccRunListWgh;    ///< optional weights for data of accepted runs (if any)
+  double fRunWgh;             ///< run weight
+  double fWghScl[2];          ///< optional rescaling for odd/even residual weights (see its usage in LocalFit)
+  std::vector<int> fkReGroup; ///< optional regrouping of parameters wrt ID's from the records
+
+  static bool fgInvChol;        ///< Invert global matrix in Cholesky solver
+  static bool fgWeightSigma;    ///< weight parameter constraint by statistics
+  static bool fgIsMatGloSparse; ///< Type of the global matrix (sparse ...)
+  static int fgMinResCondType;  ///< Type of the preconditioner for MinRes method
+  static double fgMinResTol;    ///< Tolerance for MinRes solution
+  static int fgMinResMaxIter;   ///< Max number of iterations for the MinRes method
+  static int fgIterSol;         ///< type of iterative solution: MinRes or FGMRES
+  static int fgNKrylovV;        ///< size of Krylov vectors buffer in FGMRES
+
+  // processed data record bufferization
+  o2::mft::MilleRecordWriter* fRecordWriter;         ///< data record writer
+  o2::mft::MilleRecordWriter* fConstraintsRecWriter; ///< constraints record writer
+  o2::mft::MilleRecordReader* fRecordReader;         ///< data record reader
+  o2::mft::MilleRecordReader* fConstraintsRecReader; ///< constraints record reader
+
+  ClassDef(MillePede2, 0);
+};
+
+} // namespace mft
+} // namespace o2
+
+#endif

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/MillePedeRecord.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/MillePedeRecord.h
@@ -1,0 +1,155 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file MillePedeRecord.h
+/// \author ruben.shahoyan@cern.ch
+/// \brief Class to store the data of single track processing
+///
+/// The records for all processed tracks are stored in the temporary tree in orgder to be
+/// reused for multiple iterations of MillePede
+
+#ifndef ALICEO2_MFT_MILLEPEDERECORD_H
+#define ALICEO2_MFT_MILLEPEDERECORD_H
+
+#include <TObject.h>
+
+namespace o2
+{
+namespace mft
+{
+/// \brief Store residuals and local/global deriavtives from a single track processing
+///
+/// Format: for each measured point the data is stored consecutively
+///
+/// INDEX                                VALUE
+/// -1                                   residual
+/// Local_param_id                       dResidual/dLocal_param
+/// ...                                  ...
+/// -2                                   weight of the measurement
+/// Global_param_od                      dResidual/dGlobal_param
+/// ...                                  ...
+class MillePedeRecord : public TObject
+{
+ public:
+  /// \brief default c-tor
+  MillePedeRecord();
+
+  /// \brief copy c-tor
+  MillePedeRecord(const MillePedeRecord& src);
+
+  /// \brief assignment op-r
+  MillePedeRecord& operator=(const MillePedeRecord& rhs);
+
+  /// \brief destuctor
+  virtual ~MillePedeRecord();
+
+  /// \brief reset all
+  void Reset();
+
+  /// \brief print itself
+  void Print(const Option_t* opt = "") const;
+
+  Int_t GetSize() const { return fSize; }
+  Int_t* GetIndex() const { return fIndex; }
+  Int_t GetIndex(int i) const { return fIndex[i]; }
+
+  void GetIndexValue(Int_t i, Int_t& ind, Double_t& val) const
+  {
+    ind = fIndex[i];
+    val = fValue[i];
+  }
+
+  /// \brief add new pair of index/value
+  void AddIndexValue(Int_t ind, Double_t val);
+
+  void AddResidual(Double_t val) { AddIndexValue(-1, val); }
+  void AddWeight(Double_t val) { AddIndexValue(-2, val); }
+  void SetWeight(Double_t w = 1) { fWeight = w; }
+  Bool_t IsResidual(Int_t i) const { return fIndex[i] == -1; }
+  Bool_t IsWeight(Int_t i) const { return fIndex[i] == -2; }
+
+  Double_t* GetValue() const { return fValue; }
+  Double_t GetValue(Int_t i) const { return fValue[i]; }
+  Double_t GetWeight() const { return fWeight; }
+
+  /// \brief mark the presence of the detector group
+  void MarkGroup(Int_t id);
+  Int_t GetNGroups() const { return fNGroups; }
+  Int_t GetGroupID(Int_t i) const { return fGroupID[i] - 1; }
+
+  /// \brief check if group is defined
+  Bool_t IsGroupPresent(Int_t id) const;
+
+  UInt_t GetRunID() const { return fRunID; }
+  void SetRunID(UInt_t run) { fRunID = run; }
+
+  /// \brief get derivative over global variable indx at point pnt
+  Double_t GetGlobalDeriv(Int_t pnt, Int_t indx) const;
+
+  /// \brief get derivative over local variable indx at point pnt
+  Double_t GetLocalDeriv(Int_t pnt, Int_t indx) const;
+
+  /// \brief get residual at point pnt
+  Double_t GetResidual(Int_t pnt) const;
+
+  /// \brief get sum of derivative over global variable indx * res. at point * weight
+  Double_t GetGloResWProd(Int_t indx) const;
+
+  /// \brief get weight of point pnt
+  Double_t GetWeight(Int_t indx) const;
+
+ protected:
+  Int_t GetDtBufferSize() const { return GetUniqueID() & 0x0000ffff; }
+  Int_t GetGrBufferSize() const { return GetUniqueID() >> 16; }
+  void SetDtBufferSize(Int_t sz) { SetUniqueID((GetGrBufferSize() << 16) + sz); }
+  void SetGrBufferSize(Int_t sz) { SetUniqueID(GetDtBufferSize() + (sz << 16)); }
+
+  /// \brief add extra space for derivatives data
+  void ExpandDtBuffer(Int_t bfsize);
+
+  /// \brief add extra space for groupID data
+  void ExpandGrBuffer(Int_t bfsize);
+
+ protected:
+  Int_t fSize;        ///< size of the record
+  Int_t fNGroups;     ///< number of groups (e.g. detectors) contributing
+  UInt_t fRunID;      ///< run ID
+  UShort_t* fGroupID; ///< [fNGroups] groups id's+1 (in increasing order)
+  Int_t* fIndex;      ///< [fSize] index of variables
+  Double32_t* fValue; ///< [fSize] array of values: derivs,residuals
+  Double32_t fWeight; ///< global weight for the record
+
+  ClassDef(MillePedeRecord, 3);
+};
+
+//_____________________________________________________________________________
+inline void MillePedeRecord::AddIndexValue(Int_t ind, Double_t val)
+{
+  if (fSize >= GetDtBufferSize())
+    ExpandDtBuffer(2 * (fSize + 1));
+  fIndex[fSize] = ind;
+  fValue[fSize++] = val;
+}
+
+//_____________________________________________________________________________
+inline Bool_t MillePedeRecord::IsGroupPresent(Int_t id) const
+{
+  id++;
+  for (int i = fNGroups; i--;)
+    if (fGroupID[i] == id)
+      return kTRUE;
+  return kFALSE;
+}
+
+} // namespace mft
+} // namespace o2
+
+#endif

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/MillePedeRecord.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/MillePedeRecord.h
@@ -49,13 +49,13 @@ class MillePedeRecord : public TObject
   MillePedeRecord& operator=(const MillePedeRecord& rhs);
 
   /// \brief destuctor
-  virtual ~MillePedeRecord();
+  ~MillePedeRecord() override;
 
   /// \brief reset all
   void Reset();
 
   /// \brief print itself
-  void Print(const Option_t* opt = "") const;
+  void Print(const Option_t* opt = "") const override;
 
   Int_t GetSize() const { return fSize; }
   Int_t* GetIndex() const { return fIndex; }
@@ -133,8 +133,9 @@ class MillePedeRecord : public TObject
 //_____________________________________________________________________________
 inline void MillePedeRecord::AddIndexValue(Int_t ind, Double_t val)
 {
-  if (fSize >= GetDtBufferSize())
+  if (fSize >= GetDtBufferSize()) {
     ExpandDtBuffer(2 * (fSize + 1));
+  }
   fIndex[fSize] = ind;
   fValue[fSize++] = val;
 }
@@ -143,9 +144,11 @@ inline void MillePedeRecord::AddIndexValue(Int_t ind, Double_t val)
 inline Bool_t MillePedeRecord::IsGroupPresent(Int_t id) const
 {
   id++;
-  for (int i = fNGroups; i--;)
-    if (fGroupID[i] == id)
+  for (int i = fNGroups; i--;) {
+    if (fGroupID[i] == id) {
       return kTRUE;
+    }
+  }
   return kFALSE;
 }
 

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/MilleRecordReader.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/MilleRecordReader.h
@@ -1,0 +1,84 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file MilleRecordReader.h
+/// \author arakotoz@cern.ch
+/// \brief Class dedicated to read MillePedeRecords from ROOT files
+
+#ifndef ALICEO2_MFT_MILLERECORD_READER_H
+#define ALICEO2_MFT_MILLERECORD_READER_H
+
+#include <Rtypes.h>
+#include <TString.h>
+#include <TChain.h>
+#include <TFile.h>
+#include <TTree.h>
+
+#include "MFTAlignment/MillePedeRecord.h"
+
+namespace o2
+{
+namespace mft
+{
+
+class MilleRecordReader
+{
+ public:
+  /// \brief constructor
+  MilleRecordReader();
+
+  /// \brief destructor
+  virtual ~MilleRecordReader();
+
+  /// \brief choose data records filename
+  void changeDataBranchName(const bool isConstraintsRec = true);
+
+  /// \brief connect to input TChain
+  void connectToChain(TChain* ch);
+
+  /// \brief check if connect to input TChain went well
+  bool isReaderOk() const { return mIsSuccessfulInit; }
+
+  /// \brief check if the last operation readNextEntry() was ok
+  bool isReadEntryOk() const { return mIsReadEntryOk; }
+
+  /// \brief return the record
+  o2::mft::MillePedeRecord* getRecord() { return mRecord; };
+
+  /// \brief return the ID of the current record in the TTree
+  long getCurrentDataID() const { return mCurrentDataID; }
+
+  /// \brief read the next entry in the tree
+  void readNextEntry(const bool doPrint = false);
+
+  /// \brief read the entry # id in the tree
+  void readEntry(const Long_t id, const bool doPrint = false);
+
+  /// \brief return the number of entries
+  Long64_t getNEntries() const { return mNEntries; }
+
+ protected:
+  TChain* mDataTree;                 ///< TChain container that stores the records
+  bool mIsSuccessfulInit;            ///< boolean to monitor the success of the initialization
+  bool mIsConstraintsRec;            ///< boolean to know if these are data records or constraints records
+  bool mIsReadEntryOk;               ///< boolean to know if the last operation readNextEntry() was ok
+  TString mDataTreeName;             ///< name of the record TTree/TChain
+  TString mDataBranchName;           ///< name of the branch where records will be stored
+  o2::mft::MillePedeRecord* mRecord; ///< the running record
+  Long64_t mCurrentDataID;           ///< counter indicating the ID of the current record in the tree
+  Long64_t mNEntries;                ///< number of entries in the read TChain
+
+  ClassDef(MilleRecordReader, 0);
+};
+} // namespace mft
+} // namespace o2
+
+#endif

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/MilleRecordWriter.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/MilleRecordWriter.h
@@ -1,0 +1,90 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file MilleRecordWriter.h
+/// \author arakotoz@cern.ch
+/// \brief Class dedicated to write MillePedeRecords to output file for MFT
+
+#ifndef ALICEO2_MFT_MILLERECORD_WRITER_H
+#define ALICEO2_MFT_MILLERECORD_WRITER_H
+
+#include <Rtypes.h>
+#include <TString.h>
+
+#include "MFTAlignment/MillePedeRecord.h"
+
+class TFile;
+class TTree;
+namespace o2
+{
+namespace mft
+{
+
+class MilleRecordWriter
+{
+ public:
+  /// \brief constructor
+  MilleRecordWriter();
+
+  /// \brief destructor
+  virtual ~MilleRecordWriter();
+
+  /// \brief Set the number of entries to be used by TTree::AutoSave()
+  void setCyclicAutoSave(const long nEntries);
+
+  /// \brief choose data records filename
+  void setDataFileName(TString fname) { mDataFileName = fname; }
+
+  /// \brief choose data records filename
+  void changeDataBranchName(const bool isConstraintsRec = true);
+
+  /// \brief init output file and tree
+  void init();
+
+  /// \brief check if init went well
+  bool isInitOk() const { return mIsSuccessfulInit; }
+
+  /// \brief return the record
+  o2::mft::MillePedeRecord* getRecord() { return mRecord; };
+
+  /// \brief return the ID of the current record in the TTree
+  Long64_t getCurrentDataID() const { return mCurrentDataID; }
+
+  /// \brief fill tree
+  void fillRecordTree(const bool doPrint = false);
+
+  /// \brief write tree and close output file
+  void terminate();
+
+  /// \brief assign run
+  void setRecordRun(int run);
+
+  /// \brief assign weight
+  void setRecordWeight(double wgh);
+
+ protected:
+  TTree* mDataTree;                  ///< TTree container that stores the records
+  TFile* mDataFile;                  ///< output file where the records are written
+  bool mIsSuccessfulInit;            ///< boolean to monitor the success of the initialization
+  bool mIsConstraintsRec;            ///< boolean to know if these are data records or constraints records
+  long mNEntriesAutoSave;            ///< max entries in the buffer after which TTree::AutoSave() is automatically used
+  TString mDataFileName;             ///< name of the output file that will store the record TTree
+  TString mDataTreeName;             ///< name of the record TTree
+  TString mDataBranchName;           ///< name of the branch where records will be stored
+  o2::mft::MillePedeRecord* mRecord; ///< the running record
+  Long64_t mCurrentDataID;           ///< counter increasing when adding a record to the tree
+
+  ClassDef(MilleRecordWriter, 0);
+};
+} // namespace mft
+} // namespace o2
+
+#endif

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/MinResSolve.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/MinResSolve.h
@@ -59,7 +59,7 @@ class MinResSolve : public TObject
   MinResSolve(const MinResSolve& src);
 
   /// \brief destructor
-  ~MinResSolve();
+  ~MinResSolve() override;
 
   /// \brief assignment op.
   MinResSolve& operator=(const MinResSolve& rhs);

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/MinResSolve.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/MinResSolve.h
@@ -1,0 +1,141 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file MinResSolve.h
+/// \brief General class (from AliROOT) for solving large system of linear equations
+/// \author ruben.shahoyan@cern.ch
+
+#ifndef ALICEO2_MFT_MINRESSOLVE_H
+#define ALICEO2_MFT_MINRESSOLVE_H
+
+#include <TObject.h>
+#include <TVectorD.h>
+#include <TString.h>
+
+namespace o2
+{
+namespace mft
+{
+
+class MatrixSq;
+class MatrixSparse;
+class SymBDMatrix;
+
+/// \class MinResSolve
+/// \brief for solving large system of linear equations
+///
+/// Includes MINRES, FGMRES methods as well as a few precondiotiong methods
+class MinResSolve : public TObject
+{
+
+ public:
+  enum { kPreconBD = 1,
+         kPreconILU0 = 100,
+         kPreconILU10 = kPreconILU0 + 10,
+         kPreconsTot };
+  enum { kSolMinRes,
+         kSolFGMRes,
+         kNSolvers };
+
+ public:
+  /// \brief default constructor
+  MinResSolve();
+
+  /// \brief copy accepting equation
+  MinResSolve(const MatrixSq* mat, const TVectorD* rhs);
+
+  /// \brief copy accepting equation
+  MinResSolve(const MatrixSq* mat, const double* rhs);
+
+  /// \brief copy constructor
+  MinResSolve(const MinResSolve& src);
+
+  /// \brief destructor
+  ~MinResSolve();
+
+  /// \brief assignment op.
+  MinResSolve& operator=(const MinResSolve& rhs);
+
+  /// \brief MINRES method (for symmetric matrices)
+  Bool_t SolveMinRes(Double_t* VecSol, Int_t precon = 0, int itnlim = 2000, double rtol = 1e-12);
+
+  /// \brief MINRES method (for symmetric matrices)
+  Bool_t SolveMinRes(TVectorD& VecSol, Int_t precon = 0, int itnlim = 2000, double rtol = 1e-12);
+
+  /// \brief FGMRES method (for general symmetric matrices)
+  Bool_t SolveFGMRES(Double_t* VecSol, Int_t precon = 0, int itnlim = 2000, double rtol = 1e-12, int nkrylov = 60);
+
+  /// \brief FGMRES method (for general symmetric matrices)
+  Bool_t SolveFGMRES(TVectorD& VecSol, Int_t precon = 0, int itnlim = 2000, double rtol = 1e-12, int nkrylov = 60);
+
+  /// \brief init auxiliary space for MinRes
+  Bool_t InitAuxMinRes();
+
+  /// \brief init auxiliary space for fgmres
+  Bool_t InitAuxFGMRES(int nkrylov);
+
+  /// \brief apply precond.
+  void ApplyPrecon(const TVectorD& vecRHS, TVectorD& vecOut) const;
+
+  /// \brief Application of preconditioner matrix: implicitly defines the matrix solving the M*VecOut = VecRHS
+  void ApplyPrecon(const double* vecRHS, double* vecOut) const;
+
+  /// \brief preconditioner building
+  Int_t BuildPrecon(Int_t val = 0);
+
+  Int_t GetPrecon() const { return fPrecon; }
+
+  /// \brief clear aux. space
+  void ClearAux();
+
+  /// \brief build Band-Diagonal preconditioner
+  Int_t BuildPreconBD(Int_t hwidth);
+
+  /// \brief ILUK preconditioner
+  Int_t BuildPreconILUK(Int_t lofM);
+
+  /// \brief ILUK preconditioner
+  Int_t BuildPreconILUKDense(Int_t lofM);
+
+  /// \brief ILUK preconditioner
+  Int_t PreconILUKsymb(Int_t lofM);
+
+  /// \brief ILUK preconditioner
+  Int_t PreconILUKsymbDense(Int_t lofM);
+
+ protected:
+  Int_t fSize;       ///< dimension of the input matrix
+  Int_t fPrecon;     ///< preconditioner type
+  MatrixSq* fMatrix; ///< matrix defining the equations
+  Double_t* fRHS;    ///< right hand side
+
+  Double_t* fPVecY;    ///< aux. space
+  Double_t* fPVecR1;   // aux. space
+  Double_t* fPVecR2;   // aux. space
+  Double_t* fPVecV;    // aux. space
+  Double_t* fPVecW;    // aux. space
+  Double_t* fPVecW1;   // aux. space
+  Double_t* fPVecW2;   // aux. space
+  Double_t** fPvv;     // aux. space
+  Double_t** fPvz;     // aux. space
+  Double_t** fPhh;     // aux. space
+  Double_t* fDiagLU;   // aux space
+  MatrixSparse* fMatL; // aux. space
+  MatrixSparse* fMatU; // aux. space
+  SymBDMatrix* fMatBD; // aux. space
+
+  ClassDef(MinResSolve, 0);
+};
+
+} // namespace mft
+} // namespace o2
+
+#endif

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/RecordsToAlignParams.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/RecordsToAlignParams.h
@@ -36,10 +36,10 @@ class RecordsToAlignParams : public Aligner
   RecordsToAlignParams();
 
   /// \brief destructor
-  ~RecordsToAlignParams();
+  ~RecordsToAlignParams() override;
 
   /// \brief init MilliPede
-  void init();
+  void init() override;
 
   // simple setters
 

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/RecordsToAlignParams.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/RecordsToAlignParams.h
@@ -1,0 +1,77 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file RecordsToAlignParams.h
+/// \author arakotoz@cern.ch
+/// \brief Class using records to run MillePede global fit and extract align params
+
+#ifndef ALICEO2_MFT_RECORDS_TO_ALIGN_PARAMS_H
+#define ALICEO2_MFT_RECORDS_TO_ALIGN_PARAMS_H
+
+#include <TChain.h>
+
+#include "MFTAlignment/MillePede2.h"
+#include "MFTAlignment/MilleRecordReader.h"
+#include "DetectorsCommonDataFormats/AlignParam.h"
+
+#include "MFTAlignment/Aligner.h"
+
+namespace o2
+{
+namespace mft
+{
+
+class RecordsToAlignParams : public Aligner
+{
+ public:
+  /// \brief construtor
+  RecordsToAlignParams();
+
+  /// \brief destructor
+  ~RecordsToAlignParams();
+
+  /// \brief init MilliPede
+  void init();
+
+  // simple setters
+
+  void setWithControl(const bool choice) { mWithControl = choice; }
+  void setNEntriesAutoSave(const int value) { mNEntriesAutoSave = value; }
+  void setWithConstraintsRecReader(const bool choice) { mWithConstraintsRecReader = choice; }
+
+  /// \brief perform the simultaneous fit of track (local) and alignement (global) parameters
+  void globalFit();
+
+  /// \brief provide access to the AlignParam vector
+  void getAlignParams(std::vector<o2::detectors::AlignParam>& alignParams) { alignParams = mAlignParams; }
+
+  /// \brief connect data record reader to input TChain of records
+  void connectRecordReaderToChain(TChain* ch);
+
+  /// \brief conect constraints record reader to input TChain of constraints record
+  void connectConstraintsRecReaderToChain(TChain* ch);
+
+ protected:
+  bool mWithControl;                                   ///< boolean to set the use of the control tree = chi2 per track filled by MillePede LocalFit()
+  long mNEntriesAutoSave = 10000;                      ///< number of entries needed to cyclically call AutoSave for the output control tree
+  std::vector<o2::detectors::AlignParam> mAlignParams; ///< vector of alignment parameters computed by MillePede simultaneous fit
+  o2::mft::MilleRecordReader* mRecordReader;           ///< utility that handles the reading of the data records used to feed MillePede solver
+  bool mWithConstraintsRecReader;                      ///< boolean to set to true if one wants to also read constraints records
+  o2::mft::MilleRecordReader* mConstraintsRecReader;   ///< utility that handles the reading of the constraints records
+  o2::mft::MillePede2* mMillepede;                     ///< Millepede2 implementation copied from AliROOT
+
+  ClassDef(RecordsToAlignParams, 0);
+};
+
+} // namespace mft
+} // namespace o2
+
+#endif

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/RectMatrix.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/RectMatrix.h
@@ -1,0 +1,88 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file RectMatrix.h
+/// \brief Class for rectangular matrix used for millepede2 operation
+/// \author ruben.shahoyan@cern.ch
+
+#ifndef ALICEO2_MFT_RECTMATRIX_H
+#define ALICEO2_MFT_RECTMATRIX_H
+
+#include "TObject.h"
+class TString;
+
+namespace o2
+{
+namespace mft
+{
+
+/// \brief Class for rectangular matrix used for millepede2 operation
+///
+/// Matrix may be sparse or dense
+class RectMatrix : public TObject
+{
+
+ public:
+  /// \brief default c-tor
+  RectMatrix();
+
+  /// \brief c-tor
+  RectMatrix(Int_t nrow, Int_t ncol);
+
+  /// \brief copy c-tor
+  RectMatrix(const RectMatrix& src);
+
+  /// \brief dest-tor
+  virtual ~RectMatrix();
+
+  Int_t GetNRows() const { return fNRows; }
+  Int_t GetNCols() const { return fNCols; }
+
+  Double_t Query(Int_t rown, Int_t coln) const { return operator()(rown, coln); }
+
+  /// \brief assignment op-r
+  RectMatrix& operator=(const RectMatrix& src);
+
+  Double_t operator()(Int_t rown, Int_t coln) const;
+  Double_t& operator()(Int_t rown, Int_t coln);
+  Double_t* operator()(Int_t row) const { return GetRow(row); }
+  Double_t* GetRow(Int_t row) const { return fRows[row]; }
+
+  /// \brief reset all
+  void Reset() const;
+
+  /// \brief print itself
+  virtual void Print(Option_t* option = "") const;
+
+ protected:
+  Int_t fNRows;     ///< Number of rows
+  Int_t fNCols;     ///< Number of columns
+  Double_t** fRows; ///< pointers on rows
+
+  ClassDef(RectMatrix, 0);
+};
+
+//___________________________________________________________
+inline Double_t RectMatrix::operator()(Int_t row, Int_t col) const
+{
+  return (const Double_t&)GetRow(row)[col];
+}
+
+//___________________________________________________________
+inline Double_t& RectMatrix::operator()(Int_t row, Int_t col)
+{
+  return (Double_t&)fRows[row][col];
+}
+
+} // namespace mft
+} // namespace o2
+
+#endif

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/RectMatrix.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/RectMatrix.h
@@ -41,7 +41,7 @@ class RectMatrix : public TObject
   RectMatrix(const RectMatrix& src);
 
   /// \brief dest-tor
-  virtual ~RectMatrix();
+  ~RectMatrix() override;
 
   Int_t GetNRows() const { return fNRows; }
   Int_t GetNCols() const { return fNCols; }
@@ -60,7 +60,7 @@ class RectMatrix : public TObject
   void Reset() const;
 
   /// \brief print itself
-  virtual void Print(Option_t* option = "") const;
+  void Print(Option_t* option = "") const override;
 
  protected:
   Int_t fNRows;     ///< Number of rows

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/SymBDMatrix.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/SymBDMatrix.h
@@ -45,30 +45,30 @@ class SymBDMatrix : public MatrixSq
   SymBDMatrix(const SymBDMatrix& mat);
 
   /// \brief d-tor
-  virtual ~SymBDMatrix();
+  ~SymBDMatrix() override;
 
   Int_t GetBandHWidth() const { return fNrows; }
   Int_t GetNElemsStored() const { return fNelems; }
 
   /// \brief clear dynamic part
-  void Clear(Option_t* option = "");
+  void Clear(Option_t* option = "") override;
 
   /// \brief set all elems to 0
-  void Reset();
+  void Reset() override;
 
   /// \brief get fraction of non-zero elements
-  Float_t GetDensity() const;
+  Float_t GetDensity() const override;
 
   /// \brief assignment operator
   SymBDMatrix& operator=(const SymBDMatrix& src);
 
-  Double_t operator()(Int_t rown, Int_t coln) const;
-  Double_t& operator()(Int_t rown, Int_t coln);
+  Double_t operator()(Int_t rown, Int_t coln) const override;
+  Double_t& operator()(Int_t rown, Int_t coln) override;
   Double_t operator()(Int_t rown) const;
   Double_t& operator()(Int_t rown);
 
-  Double_t DiagElem(Int_t r) const { return (*(const SymBDMatrix*)this)(r, r); }
-  Double_t& DiagElem(Int_t r) { return (*this)(r, r); }
+  Double_t DiagElem(Int_t r) const override { return (*(const SymBDMatrix*)this)(r, r); }
+  Double_t& DiagElem(Int_t r) override { return (*this)(r, r); }
 
   /// \brief decomposition to L Diag L^T
   void DecomposeLDLT();
@@ -83,7 +83,7 @@ class SymBDMatrix : public MatrixSq
   void Solve(const TVectorD& rhs, TVectorD& sol) { Solve(rhs.GetMatrixArray(), sol.GetMatrixArray()); }
 
   /// \brief print data
-  void Print(Option_t* option = "") const;
+  void Print(Option_t* option = "") const override;
 
   void SetDecomposed(Bool_t v = kTRUE) { SetBit(kDecomposedBit, v); }
   Bool_t IsDecomposed() const { return TestBit(kDecomposedBit); }
@@ -91,12 +91,12 @@ class SymBDMatrix : public MatrixSq
   /// \brief fill vecOut by matrix*vecIn
   ///
   /// vector should be of the same size as the matrix
-  void MultiplyByVec(const Double_t* vecIn, Double_t* vecOut) const;
+  void MultiplyByVec(const Double_t* vecIn, Double_t* vecOut) const override;
 
-  void MultiplyByVec(const TVectorD& vecIn, TVectorD& vecOut) const;
+  void MultiplyByVec(const TVectorD& vecIn, TVectorD& vecOut) const override;
 
   /// \brief add list of elements to row r
-  void AddToRow(Int_t r, Double_t* valc, Int_t* indc, Int_t n);
+  void AddToRow(Int_t r, Double_t* valc, Int_t* indc, Int_t n) override;
 
   virtual Int_t GetIndex(Int_t row, Int_t col) const;
   virtual Int_t GetIndex(Int_t diagID) const;
@@ -113,11 +113,13 @@ class SymBDMatrix : public MatrixSq
 inline Int_t SymBDMatrix::GetIndex(Int_t row, Int_t col) const
 {
   // lower triangle band is actually filled
-  if (row < col)
+  if (row < col) {
     Swap(row, col);
+  }
   col -= row;
-  if (col < -GetBandHWidth())
+  if (col < -GetBandHWidth()) {
     return -1;
+  }
   return GetIndex(row) + col;
 }
 
@@ -141,8 +143,9 @@ inline Double_t& SymBDMatrix::operator()(Int_t row, Int_t col)
 {
   // get element for assingment; assignment outside of the stored range has no effect
   int idx = GetIndex(row, col);
-  if (idx >= 0)
+  if (idx >= 0) {
     return fElems[idx];
+  }
   fTol = 0;
   return fTol;
 }

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/SymBDMatrix.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/SymBDMatrix.h
@@ -1,0 +1,173 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file SymBDMatrix.h
+/// \brief Symmetric Band Diagonal matrix (from AliROOT) with half band width W (+1 for diagonal)
+/// \author ruben.shahoyan@cern.ch
+
+#ifndef ALICEO2_MFT_SYMBDMATRIX_H
+#define ALICEO2_MFT_SYMBDMATRIX_H
+
+#include <TObject.h>
+#include <TVectorD.h>
+#include "MFTAlignment/MatrixSq.h"
+
+namespace o2
+{
+namespace mft
+{
+
+/// \class SymBDMatrix
+/// \brief Symmetric Matrix Class
+///
+/// Only lower triangle is stored in the "profile" format
+class SymBDMatrix : public MatrixSq
+{
+
+ public:
+  enum { kDecomposedBit = 0x1 };
+
+  /// \brief def. c-tor
+  SymBDMatrix();
+
+  /// \brief c-tor for given size
+  SymBDMatrix(Int_t size, Int_t w = 0);
+
+  /// \brief copy c-tor
+  SymBDMatrix(const SymBDMatrix& mat);
+
+  /// \brief d-tor
+  virtual ~SymBDMatrix();
+
+  Int_t GetBandHWidth() const { return fNrows; }
+  Int_t GetNElemsStored() const { return fNelems; }
+
+  /// \brief clear dynamic part
+  void Clear(Option_t* option = "");
+
+  /// \brief set all elems to 0
+  void Reset();
+
+  /// \brief get fraction of non-zero elements
+  Float_t GetDensity() const;
+
+  /// \brief assignment operator
+  SymBDMatrix& operator=(const SymBDMatrix& src);
+
+  Double_t operator()(Int_t rown, Int_t coln) const;
+  Double_t& operator()(Int_t rown, Int_t coln);
+  Double_t operator()(Int_t rown) const;
+  Double_t& operator()(Int_t rown);
+
+  Double_t DiagElem(Int_t r) const { return (*(const SymBDMatrix*)this)(r, r); }
+  Double_t& DiagElem(Int_t r) { return (*this)(r, r); }
+
+  /// \brief decomposition to L Diag L^T
+  void DecomposeLDLT();
+
+  /// \brief solve matrix equation
+  void Solve(Double_t* rhs);
+
+  /// \brief solve matrix equation
+  void Solve(const Double_t* rhs, Double_t* sol);
+
+  void Solve(TVectorD& rhs) { Solve(rhs.GetMatrixArray()); }
+  void Solve(const TVectorD& rhs, TVectorD& sol) { Solve(rhs.GetMatrixArray(), sol.GetMatrixArray()); }
+
+  /// \brief print data
+  void Print(Option_t* option = "") const;
+
+  void SetDecomposed(Bool_t v = kTRUE) { SetBit(kDecomposedBit, v); }
+  Bool_t IsDecomposed() const { return TestBit(kDecomposedBit); }
+
+  /// \brief fill vecOut by matrix*vecIn
+  ///
+  /// vector should be of the same size as the matrix
+  void MultiplyByVec(const Double_t* vecIn, Double_t* vecOut) const;
+
+  void MultiplyByVec(const TVectorD& vecIn, TVectorD& vecOut) const;
+
+  /// \brief add list of elements to row r
+  void AddToRow(Int_t r, Double_t* valc, Int_t* indc, Int_t n);
+
+  virtual Int_t GetIndex(Int_t row, Int_t col) const;
+  virtual Int_t GetIndex(Int_t diagID) const;
+  Double_t GetEl(Int_t row, Int_t col) const { return operator()(row, col); }
+  void SetEl(Int_t row, Int_t col, Double_t val) { operator()(row, col) = val; }
+
+ protected:
+  Double_t* fElems; ///< Elements booked by constructor
+
+  ClassDef(SymBDMatrix, 0);
+};
+
+//___________________________________________________________
+inline Int_t SymBDMatrix::GetIndex(Int_t row, Int_t col) const
+{
+  // lower triangle band is actually filled
+  if (row < col)
+    Swap(row, col);
+  col -= row;
+  if (col < -GetBandHWidth())
+    return -1;
+  return GetIndex(row) + col;
+}
+
+//___________________________________________________________
+/// \brief Get index of the diagonal element on row diagID
+inline Int_t SymBDMatrix::GetIndex(Int_t diagID) const
+{
+  return (diagID + 1) * fRowLwb - 1;
+}
+
+//___________________________________________________________
+inline Double_t SymBDMatrix::operator()(Int_t row, Int_t col) const
+{
+  // query element
+  int idx = GetIndex(row, col);
+  return (const Double_t&)idx < 0 ? 0.0 : fElems[idx];
+}
+
+//___________________________________________________________
+inline Double_t& SymBDMatrix::operator()(Int_t row, Int_t col)
+{
+  // get element for assingment; assignment outside of the stored range has no effect
+  int idx = GetIndex(row, col);
+  if (idx >= 0)
+    return fElems[idx];
+  fTol = 0;
+  return fTol;
+}
+
+//___________________________________________________________
+inline Double_t SymBDMatrix::operator()(Int_t row) const
+{
+  // query diagonal
+  return (const Double_t&)fElems[GetIndex(row)];
+}
+
+//___________________________________________________________
+inline Double_t& SymBDMatrix::operator()(Int_t row)
+{
+  // get diagonal for assingment; assignment outside of the stored range has no effect
+  return fElems[GetIndex(row)];
+}
+
+//___________________________________________________________
+inline void SymBDMatrix::MultiplyByVec(const TVectorD& vecIn, TVectorD& vecOut) const
+{
+  MultiplyByVec(vecIn.GetMatrixArray(), vecOut.GetMatrixArray());
+}
+
+} // namespace mft
+} // namespace o2
+
+#endif

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/SymMatrix.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/SymMatrix.h
@@ -1,0 +1,276 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file SymMatrix.h
+/// \brief Fast symmetric matrix (from AliROOT) with dynamically expandable size
+/// \author ruben.shahoyan@cern.ch
+
+#ifndef ALICEO2_MFT_SYMMATRIX_H
+#define ALICEO2_MFT_SYMMATRIX_H
+
+#include <TVectorD.h>
+#include <TString.h>
+
+#include "MFTAlignment/MatrixSq.h"
+
+namespace o2
+{
+namespace mft
+{
+
+/// \class SymMatrix
+/// \brief Fast symmetric matrix with dynamically expandable size.
+///
+/// Only part can be used for matrix operations. It is defined as:
+/// \param fNCols: rows built by constructor (GetSizeBooked)
+/// \param fNRows: number of rows added dynamically (automatically added on assignment to row), GetNRowAdded
+/// \param fNRowIndex: total size (fNCols+fNRows), GetSize
+/// \param fRowLwb: actual size to used for given operation, by default = total size, GetSizeUsed
+class SymMatrix : public MatrixSq
+{
+
+ public:
+  /// \brief default constructor
+  SymMatrix();
+
+  /// \brief constructor for matrix with defined size
+  SymMatrix(Int_t size);
+
+  /// \brief copy constructor
+  SymMatrix(const SymMatrix& mat);
+
+  /// \brief destructor
+  virtual ~SymMatrix();
+
+  /// \brief clear dynamic part
+  void Clear(Option_t* option = "");
+  void Reset();
+
+  Int_t GetSize() const { return fNrowIndex; }
+  Int_t GetSizeUsed() const { return fRowLwb; }
+  Int_t GetSizeBooked() const { return fNcols; }
+  Int_t GetSizeAdded() const { return fNrows; }
+
+  /// \brief get fraction of non-zero elements
+  Float_t GetDensity() const;
+
+  /// \brief assignment operator
+  SymMatrix& operator=(const SymMatrix& src);
+
+  /// \brief add operator
+  SymMatrix& operator+=(const SymMatrix& src);
+
+  /// \brief minus operator
+  SymMatrix& operator-=(const SymMatrix& src);
+
+  Double_t operator()(Int_t rown, Int_t coln) const;
+  Double_t& operator()(Int_t rown, Int_t coln);
+
+  Double_t DiagElem(Int_t r) const { return (*(const SymMatrix*)this)(r, r); }
+  Double_t& DiagElem(Int_t r) { return (*this)(r, r); }
+
+  /// \brief get pointer on the row
+  Double_t* GetRow(Int_t r);
+
+  /// \brief print itself
+  void Print(const Option_t* option = "") const;
+
+  /// \brief add empty rows
+  void AddRows(int nrows = 1);
+
+  void SetSizeUsed(Int_t sz) { fRowLwb = sz; }
+
+  void Scale(Double_t coeff);
+
+  /// \brief multiply from the right
+  Bool_t Multiply(const SymMatrix& right);
+
+  /// \brief fill vecOut by matrix*vecIn
+  ///
+  /// vector should be of the same size as the matrix
+  void MultiplyByVec(const Double_t* vecIn, Double_t* vecOut) const;
+
+  void MultiplyByVec(const TVectorD& vecIn, TVectorD& vecOut) const;
+  void AddToRow(Int_t r, Double_t* valc, Int_t* indc, Int_t n);
+
+  // ---------------------------------- Dummy methods of MatrixBase
+  virtual const Double_t* GetMatrixArray() const { return fElems; };
+  virtual Double_t* GetMatrixArray() { return (Double_t*)fElems; }
+  virtual const Int_t* GetRowIndexArray() const
+  {
+    Error("GetRowIndexArray", "Dummy");
+    return 0;
+  };
+  virtual Int_t* GetRowIndexArray()
+  {
+    Error("GetRowIndexArray", "Dummy");
+    return 0;
+  };
+  virtual const Int_t* GetColIndexArray() const
+  {
+    Error("GetColIndexArray", "Dummy");
+    return 0;
+  };
+  virtual Int_t* GetColIndexArray()
+  {
+    Error("GetColIndexArray", "Dummy");
+    return 0;
+  };
+  virtual TMatrixDBase& SetRowIndexArray(Int_t*)
+  {
+    Error("SetRowIndexArray", "Dummy");
+    return *this;
+  }
+  virtual TMatrixDBase& SetColIndexArray(Int_t*)
+  {
+    Error("SetColIndexArray", "Dummy");
+    return *this;
+  }
+  virtual TMatrixDBase& GetSub(Int_t, Int_t, Int_t, Int_t, TMatrixDBase&, Option_t*) const
+  {
+    Error("GetSub", "Dummy");
+    return *((TMatrixDBase*)this);
+  }
+  virtual TMatrixDBase& SetSub(Int_t, Int_t, const TMatrixDBase&)
+  {
+    Error("GetSub", "Dummy");
+    return *this;
+  }
+  virtual TMatrixDBase& ResizeTo(Int_t, Int_t, Int_t)
+  {
+    Error("ResizeTo", "Dummy");
+    return *this;
+  }
+  virtual TMatrixDBase& ResizeTo(Int_t, Int_t, Int_t, Int_t, Int_t)
+  {
+    Error("ResizeTo", "Dummy");
+    return *this;
+  }
+
+  // ----------------------------- Choleski methods ----------------------------------------
+  /// \brief Return a matrix with Choleski decomposition
+  ///
+  /// Adopted from Numerical Recipes in C, ch.2-9, http://www.nr.com
+  /// consturcts Cholesky decomposition of SYMMETRIC and
+  /// POSITIVELY-DEFINED matrix a (a=L*Lt)
+  /// Only upper triangle of the matrix has to be filled.
+  /// In opposite to function from the book, the matrix is modified:
+  /// lower triangle and diagonal are refilled.
+  SymMatrix* DecomposeChol();
+
+  /// \brief Invert using provided Choleski decomposition, provided the Cholseki's L matrix
+  void InvertChol(SymMatrix* mchol);
+
+  /// \brief Invert matrix using Choleski decomposition
+  Bool_t InvertChol();
+
+  /// \brief Solves the set of n linear equations A x = b
+  ///
+  /// Adopted from Numerical Recipes in C, ch.2-9, http://www.nr.com
+  /// Solves the set of n linear equations A x = b,
+  /// where a is a positive-definite symmetric matrix.
+  /// a[1..n][1..n] is the output of the routine CholDecomposw.
+  /// Only the lower triangle of a is accessed. b[1..n] is input as the
+  /// right-hand side vector. The solution vector is returned in b[1..n].
+  Bool_t SolveChol(Double_t* brhs, Bool_t invert = kFALSE);
+
+  Bool_t SolveChol(Double_t* brhs, Double_t* bsol, Bool_t invert = kFALSE);
+  Bool_t SolveChol(TVectorD& brhs, Bool_t invert = kFALSE);
+  Bool_t SolveChol(const TVectorD& brhs, TVectorD& bsol, Bool_t invert = kFALSE);
+
+  /// \brief Solves the set of n linear equations A x = b; this version solve multiple RHSs at once
+  ///
+  /// Adopted from Numerical Recipes in C, ch.2-9, http://www.nr.com
+  /// Solves the set of n linear equations A x = b,
+  /// where a is a positive-definite symmetric matrix.
+  /// a[1..n][1..n] is the output of the routine CholDecomposw.
+  /// Only the lower triangle of a is accessed. b[1..n] is input as the
+  /// right-hand side vector. The solution vector is returned in b[1..n].
+  /// This version solve multiple RHSs at once
+  Bool_t SolveCholN(Double_t* bn, int nRHS, Bool_t invert = kFALSE);
+
+  /// \brief Obtain solution of a system of linear equations with symmetric matrix
+  ///        and the inverse (using 'singular-value friendly' GAUSS pivot)
+  ///
+  /// Solution a la MP1: gaussian eliminations
+  int SolveSpmInv(double* vecB, Bool_t stabilize = kTRUE);
+
+ protected:
+  virtual Int_t GetIndex(Int_t row, Int_t col) const;
+  Double_t GetEl(Int_t row, Int_t col) const { return operator()(row, col); }
+  void SetEl(Int_t row, Int_t col, Double_t val) { operator()(row, col) = val; }
+
+ protected:
+  Double_t* fElems;     ///<   Elements booked by constructor
+  Double_t** fElemsAdd; ///<   Elements (rows) added dynamicaly
+
+  static SymMatrix* fgBuffer; ///< buffer for fast solution
+  static Int_t fgCopyCnt;     ///< matrix copy counter
+
+  ClassDef(SymMatrix, 0);
+};
+
+//___________________________________________________________
+inline Int_t SymMatrix::GetIndex(Int_t row, Int_t col) const
+{
+  // lower triangle is actually filled
+  return ((row * (row + 1)) >> 1) + col;
+}
+
+//___________________________________________________________
+inline Double_t SymMatrix::operator()(Int_t row, Int_t col) const
+{
+  //
+  if (row < col)
+    Swap(row, col);
+  if (row >= fNrowIndex)
+    return 0;
+  return (const Double_t&)(row < fNcols ? fElems[GetIndex(row, col)] : (fElemsAdd[row - fNcols])[col]);
+}
+
+//___________________________________________________________
+inline Double_t& SymMatrix::operator()(Int_t row, Int_t col)
+{
+  if (row < col)
+    Swap(row, col);
+  if (row >= fNrowIndex)
+    AddRows(row - fNrowIndex + 1);
+  return (row < fNcols ? fElems[GetIndex(row, col)] : (fElemsAdd[row - fNcols])[col]);
+}
+
+//___________________________________________________________
+inline void SymMatrix::MultiplyByVec(const TVectorD& vecIn, TVectorD& vecOut) const
+{
+  MultiplyByVec(vecIn.GetMatrixArray(), vecOut.GetMatrixArray());
+}
+
+//___________________________________________________________
+inline void SymMatrix::Scale(Double_t coeff)
+{
+  for (int i = fNrowIndex; i--;)
+    for (int j = i; j--;) {
+      double& el = operator()(i, j);
+      if (el)
+        el *= coeff;
+    }
+}
+
+//___________________________________________________________
+inline void SymMatrix::AddToRow(Int_t r, Double_t* valc, Int_t* indc, Int_t n)
+{
+  for (int i = n; i--;)
+    (*this)(indc[i], r) += valc[i];
+}
+
+} // namespace mft
+} // namespace o2
+
+#endif

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/SymMatrix.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/SymMatrix.h
@@ -48,19 +48,19 @@ class SymMatrix : public MatrixSq
   SymMatrix(const SymMatrix& mat);
 
   /// \brief destructor
-  virtual ~SymMatrix();
+  ~SymMatrix() override;
 
   /// \brief clear dynamic part
-  void Clear(Option_t* option = "");
-  void Reset();
+  void Clear(Option_t* option = "") override;
+  void Reset() override;
 
-  Int_t GetSize() const { return fNrowIndex; }
+  Int_t GetSize() const override { return fNrowIndex; }
   Int_t GetSizeUsed() const { return fRowLwb; }
   Int_t GetSizeBooked() const { return fNcols; }
   Int_t GetSizeAdded() const { return fNrows; }
 
   /// \brief get fraction of non-zero elements
-  Float_t GetDensity() const;
+  Float_t GetDensity() const override;
 
   /// \brief assignment operator
   SymMatrix& operator=(const SymMatrix& src);
@@ -71,17 +71,17 @@ class SymMatrix : public MatrixSq
   /// \brief minus operator
   SymMatrix& operator-=(const SymMatrix& src);
 
-  Double_t operator()(Int_t rown, Int_t coln) const;
-  Double_t& operator()(Int_t rown, Int_t coln);
+  Double_t operator()(Int_t rown, Int_t coln) const override;
+  Double_t& operator()(Int_t rown, Int_t coln) override;
 
-  Double_t DiagElem(Int_t r) const { return (*(const SymMatrix*)this)(r, r); }
-  Double_t& DiagElem(Int_t r) { return (*this)(r, r); }
+  Double_t DiagElem(Int_t r) const override { return (*(const SymMatrix*)this)(r, r); }
+  Double_t& DiagElem(Int_t r) override { return (*this)(r, r); }
 
   /// \brief get pointer on the row
   Double_t* GetRow(Int_t r);
 
   /// \brief print itself
-  void Print(const Option_t* option = "") const;
+  void Print(const Option_t* option = "") const override;
 
   /// \brief add empty rows
   void AddRows(int nrows = 1);
@@ -96,60 +96,60 @@ class SymMatrix : public MatrixSq
   /// \brief fill vecOut by matrix*vecIn
   ///
   /// vector should be of the same size as the matrix
-  void MultiplyByVec(const Double_t* vecIn, Double_t* vecOut) const;
+  void MultiplyByVec(const Double_t* vecIn, Double_t* vecOut) const override;
 
-  void MultiplyByVec(const TVectorD& vecIn, TVectorD& vecOut) const;
-  void AddToRow(Int_t r, Double_t* valc, Int_t* indc, Int_t n);
+  void MultiplyByVec(const TVectorD& vecIn, TVectorD& vecOut) const override;
+  void AddToRow(Int_t r, Double_t* valc, Int_t* indc, Int_t n) override;
 
   // ---------------------------------- Dummy methods of MatrixBase
-  virtual const Double_t* GetMatrixArray() const { return fElems; };
-  virtual Double_t* GetMatrixArray() { return (Double_t*)fElems; }
-  virtual const Int_t* GetRowIndexArray() const
+  const Double_t* GetMatrixArray() const override { return fElems; };
+  Double_t* GetMatrixArray() override { return (Double_t*)fElems; }
+  const Int_t* GetRowIndexArray() const override
   {
     Error("GetRowIndexArray", "Dummy");
-    return 0;
+    return nullptr;
   };
-  virtual Int_t* GetRowIndexArray()
+  Int_t* GetRowIndexArray() override
   {
     Error("GetRowIndexArray", "Dummy");
-    return 0;
+    return nullptr;
   };
-  virtual const Int_t* GetColIndexArray() const
+  const Int_t* GetColIndexArray() const override
   {
     Error("GetColIndexArray", "Dummy");
-    return 0;
+    return nullptr;
   };
-  virtual Int_t* GetColIndexArray()
+  Int_t* GetColIndexArray() override
   {
     Error("GetColIndexArray", "Dummy");
-    return 0;
+    return nullptr;
   };
-  virtual TMatrixDBase& SetRowIndexArray(Int_t*)
+  TMatrixDBase& SetRowIndexArray(Int_t*) override
   {
     Error("SetRowIndexArray", "Dummy");
     return *this;
   }
-  virtual TMatrixDBase& SetColIndexArray(Int_t*)
+  TMatrixDBase& SetColIndexArray(Int_t*) override
   {
     Error("SetColIndexArray", "Dummy");
     return *this;
   }
-  virtual TMatrixDBase& GetSub(Int_t, Int_t, Int_t, Int_t, TMatrixDBase&, Option_t*) const
+  TMatrixDBase& GetSub(Int_t, Int_t, Int_t, Int_t, TMatrixDBase&, Option_t*) const override
   {
     Error("GetSub", "Dummy");
     return *((TMatrixDBase*)this);
   }
-  virtual TMatrixDBase& SetSub(Int_t, Int_t, const TMatrixDBase&)
+  TMatrixDBase& SetSub(Int_t, Int_t, const TMatrixDBase&) override
   {
     Error("GetSub", "Dummy");
     return *this;
   }
-  virtual TMatrixDBase& ResizeTo(Int_t, Int_t, Int_t)
+  TMatrixDBase& ResizeTo(Int_t, Int_t, Int_t) override
   {
     Error("ResizeTo", "Dummy");
     return *this;
   }
-  virtual TMatrixDBase& ResizeTo(Int_t, Int_t, Int_t, Int_t, Int_t)
+  TMatrixDBase& ResizeTo(Int_t, Int_t, Int_t, Int_t, Int_t) override
   {
     Error("ResizeTo", "Dummy");
     return *this;
@@ -229,20 +229,24 @@ inline Int_t SymMatrix::GetIndex(Int_t row, Int_t col) const
 inline Double_t SymMatrix::operator()(Int_t row, Int_t col) const
 {
   //
-  if (row < col)
+  if (row < col) {
     Swap(row, col);
-  if (row >= fNrowIndex)
+  }
+  if (row >= fNrowIndex) {
     return 0;
+  }
   return (const Double_t&)(row < fNcols ? fElems[GetIndex(row, col)] : (fElemsAdd[row - fNcols])[col]);
 }
 
 //___________________________________________________________
 inline Double_t& SymMatrix::operator()(Int_t row, Int_t col)
 {
-  if (row < col)
+  if (row < col) {
     Swap(row, col);
-  if (row >= fNrowIndex)
+  }
+  if (row >= fNrowIndex) {
     AddRows(row - fNrowIndex + 1);
+  }
   return (row < fNcols ? fElems[GetIndex(row, col)] : (fElemsAdd[row - fNcols])[col]);
 }
 
@@ -255,19 +259,22 @@ inline void SymMatrix::MultiplyByVec(const TVectorD& vecIn, TVectorD& vecOut) co
 //___________________________________________________________
 inline void SymMatrix::Scale(Double_t coeff)
 {
-  for (int i = fNrowIndex; i--;)
+  for (int i = fNrowIndex; i--;) {
     for (int j = i; j--;) {
       double& el = operator()(i, j);
-      if (el)
+      if (el) {
         el *= coeff;
+      }
     }
+  }
 }
 
 //___________________________________________________________
 inline void SymMatrix::AddToRow(Int_t r, Double_t* valc, Int_t* indc, Int_t n)
 {
-  for (int i = n; i--;)
+  for (int i = n; i--;) {
     (*this)(indc[i], r) += valc[i];
+  }
 }
 
 } // namespace mft

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/TracksToRecords.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/TracksToRecords.h
@@ -1,0 +1,153 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TracksToRecords.h
+/// \author arakotoz@cern.ch
+/// \brief Class responsible to create records from tracks (and attached clusters) to feed alignment
+
+#ifndef ALICEO2_MFT_TRACKS_TO_RECORDS_H
+#define ALICEO2_MFT_TRACKS_TO_RECORDS_H
+
+#include <vector>
+#include <gsl/gsl>
+
+#include <TTree.h>
+#include <TChain.h>
+
+#include "Framework/ProcessingContext.h"
+#include "DataFormatsITSMFT/TopologyDictionary.h"
+#include "DataFormatsMFT/TrackMFT.h"
+#include "DataFormatsITSMFT/ROFRecord.h"
+#include "DataFormatsITSMFT/CompCluster.h"
+#include "ReconstructionDataFormats/BaseCluster.h"
+#include "MFTAlignment/MillePedeRecord.h"
+#include "MFTAlignment/MilleRecordWriter.h"
+#include "MFTAlignment/AlignPointHelper.h"
+#include "MFTAlignment/AlignPointControl.h"
+#include "MFTBase/GeometryTGeo.h"
+
+#include "MFTAlignment/Aligner.h"
+
+namespace o2
+{
+namespace mft
+{
+
+class TracksToRecords : public Aligner
+{
+ public:
+  /// \brief construtor
+  TracksToRecords();
+
+  /// \brief destructor
+  ~TracksToRecords();
+
+  /// \brief init Millipede and AlignPointHelper
+  void init();
+
+  // simple setters
+
+  void setClusterDictionary(const o2::itsmft::TopologyDictionary* d) { mDictionary = d; }
+  void setRunNumber(const int value) { mRunNumber = value; }
+  void setBz(const float bz) { mBz = bz; }
+  void setMinNumberClusterCut(const int value) { mMinNumberClusterCut = value; }
+  void setWithControl(const bool choice) { mWithControl = choice; }
+  void setNEntriesAutoSave(const int value) { mNEntriesAutoSave = value; }
+  void setWithConstraintsRecWriter(const bool choice) { mWithConstraintsRecWriter = choice; }
+
+  /// \brief access mft tracks and clusters in the timeframe provided by the workflow
+  void processTimeFrame(o2::framework::ProcessingContext& ctx);
+
+  /// \brief use valid tracks (and associated clusters) from the workflow to build Mille records
+  void processRecoTracks();
+
+  /// \brief use mft tracks and clusters provided by ROOT files accessed via TChain to build Mille records
+  void processROFs(TChain* mfttrackChain, TChain* mftclusterChain);
+
+  /// \brief print a summary status of what happened in processRecoTracks() or processROFs()
+  void printProcessTrackSummary();
+
+  /// \brief init the utility needed to write data records and its control tree
+  void startRecordWriter();
+
+  /// \brief end the utility used to write data records and its control tree
+  void endRecordWriter();
+
+  /// \brief init the utility needed to write constraints records
+  void startConstraintsRecWriter();
+
+  /// \brief end the utility used to write constraints records
+  void endConstraintsRecWriter();
+
+ protected:
+  int mRunNumber;                                          ///< run number
+  float mBz;                                               ///< magnetic field status
+  int mNumberTFs;                                          ///< number of timeframes processed
+  int mNumberOfClusterChainROFs;                           ///< number of ROFs in the cluster chain
+  int mNumberOfTrackChainROFs;                             ///< number of ROFs in the track chain
+  int mCounterLocalEquationFailed;                         ///< count how many times we failed to set a local equation
+  int mCounterSkippedTracks;                               ///< count how many tracks did not met the cut on the min. nb of clusters
+  int mCounterUsedTracks;                                  ///< count how many tracks were used to make Mille records
+  std::vector<double> mGlobalDerivatives;                  ///< vector of global derivatives {dDeltaX, dDeltaY, dDeltaRz, dDeltaZ}
+  std::vector<double> mLocalDerivatives;                   ///< vector of local derivatives {dX0, dTx, dY0, dTz}
+  int mMinNumberClusterCut;                                ///< Minimum number of clusters in the track to be used for alignment
+  double mWeightRecord;                                    ///< the weight given to a single Mille record in Millepede algorithm
+  const o2::itsmft::TopologyDictionary* mDictionary;       ///< cluster patterns dictionary
+  o2::mft::AlignPointHelper* mAlignPoint;                  ///< Alignment point helper
+  bool mWithControl;                                       ///< boolean to set the use of the control tree
+  long mNEntriesAutoSave = 10000;                          ///< number of entries needed to call AutoSave for the output TTrees
+  o2::mft::AlignPointControl mPointControl;                ///< AlignPointControl handles the control tree
+  o2::mft::MilleRecordWriter* mRecordWriter;               ///< utility that handles the writing of the data records to a ROOT file
+  bool mWithConstraintsRecWriter;                          ///< boolean to be set to true if one wants to also write constaints records
+  o2::mft::MilleRecordWriter* mConstraintsRecWriter;       ///< utility that handles the writing of the constraints records
+  std::vector<o2::BaseCluster<double>> mMFTClustersLocal;  ///< MFT clusters in local coordinate system
+  std::vector<o2::BaseCluster<double>> mMFTClustersGlobal; ///< MFT clusters in global coordinate system
+  o2::mft::MillePede2* mMillepede;                         ///< Millepede2 implementation copied from AliROOT
+
+  // access these data from CTFs provided uptream by the workflow
+
+  gsl::span<const o2::mft::TrackMFT> mMFTTracks;
+  gsl::span<const o2::itsmft::ROFRecord> mMFTTracksROF;
+  gsl::span<const int> mMFTTrackClusIdx;
+  gsl::span<const o2::itsmft::CompClusterExt> mMFTClusters;
+  gsl::span<const o2::itsmft::ROFRecord> mMFTClustersROF;
+  gsl::span<const unsigned char> mMFTClusterPatterns;
+  gsl::span<const unsigned char>::iterator mPattIt;
+
+ protected:
+  /// \brief set array of local derivatives
+  bool setLocalDerivative(Int_t index, Double_t value);
+
+  /// \brief set array of global derivatives
+  bool setGlobalDerivative(Int_t index, Double_t value);
+
+  /// \brief reset the array of the Local derivative
+  bool resetLocalDerivative();
+
+  /// \brief reset the array of the Global derivative
+  bool resetGlocalDerivative();
+
+  /// \brief set the first component of the local equation vector for a given alignment point
+  bool setLocalEquationX();
+
+  /// \brief set the 2nd component of the local equation vector for a given alignment point
+  bool setLocalEquationY();
+
+  /// \brief set the last component of the local equation vector for a given alignment point
+  bool setLocalEquationZ();
+
+  ClassDef(TracksToRecords, 0);
+};
+
+} // namespace mft
+} // namespace o2
+
+#endif

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/TracksToRecords.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/TracksToRecords.h
@@ -48,10 +48,10 @@ class TracksToRecords : public Aligner
   TracksToRecords();
 
   /// \brief destructor
-  ~TracksToRecords();
+  ~TracksToRecords() override;
 
   /// \brief init Millipede and AlignPointHelper
-  void init();
+  void init() override;
 
   // simple setters
 

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/VectorSparse.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/VectorSparse.h
@@ -33,10 +33,10 @@ class VectorSparse : public TObject
   /// \brief copy c-tor
   VectorSparse(const VectorSparse& src);
 
-  virtual ~VectorSparse() { Clear(); }
+  ~VectorSparse() override { Clear(); }
 
   /// \brief print itself
-  virtual void Print(Option_t* option = "") const;
+  void Print(Option_t* option = "") const override;
 
   Int_t GetNElems() const { return fNElems; }
   UShort_t* GetIndices() const { return fIndex; }
@@ -45,7 +45,7 @@ class VectorSparse : public TObject
   Double_t& GetElem(Int_t i) const { return fElems[i]; }
 
   /// \brief clear all
-  void Clear(Option_t* option = "");
+  void Clear(Option_t* option = "") override;
 
   void Reset() { memset(fElems, 0, fNElems * sizeof(Double_t)); }
 

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/VectorSparse.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/VectorSparse.h
@@ -1,0 +1,103 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file VectorSparse.h
+/// \brief Sparse vector class (from AliROOT), used as row of the MatrixSparse class
+/// \author ruben.shahoyan@cern.ch
+
+#ifndef ALICEO2_MFT_VECTORSPARSE_H
+#define ALICEO2_MFT_VECTORSPARSE_H
+
+#include <TObject.h>
+#include <TMath.h>
+
+namespace o2
+{
+namespace mft
+{
+
+/// \class VectorSparse
+class VectorSparse : public TObject
+{
+ public:
+  VectorSparse();
+
+  /// \brief copy c-tor
+  VectorSparse(const VectorSparse& src);
+
+  virtual ~VectorSparse() { Clear(); }
+
+  /// \brief print itself
+  virtual void Print(Option_t* option = "") const;
+
+  Int_t GetNElems() const { return fNElems; }
+  UShort_t* GetIndices() const { return fIndex; }
+  Double_t* GetElems() const { return fElems; }
+  UShort_t& GetIndex(Int_t i) { return fIndex[i]; }
+  Double_t& GetElem(Int_t i) const { return fElems[i]; }
+
+  /// \brief clear all
+  void Clear(Option_t* option = "");
+
+  void Reset() { memset(fElems, 0, fNElems * sizeof(Double_t)); }
+
+  /// \brief change the size
+  void ReSize(Int_t sz, Bool_t copy = kFALSE);
+
+  /// \brief sort indices in increasing order. Used to fix the row after ILUk decomposition
+  void SortIndices(Bool_t valuesToo = kFALSE);
+
+  /// \brief add indiced array to row. Indices must be in increasing order
+  void Add(Double_t* valc, Int_t* indc, Int_t n);
+
+  /// \brief assignment op-tor
+  VectorSparse& operator=(const VectorSparse& src);
+
+  virtual Double_t operator()(Int_t ind) const;
+  virtual Double_t& operator()(Int_t ind);
+
+  /// \brief set element to 0 if it was already defined
+  virtual void SetToZero(Int_t ind);
+
+  /// \brief return an element with given index
+  Double_t FindIndex(Int_t ind) const;
+
+  /// \brief increment an element with given index
+  Double_t& FindIndexAdd(Int_t ind);
+
+  Int_t GetLastIndex() const { return fIndex[fNElems - 1]; }
+  Double_t GetLastElem() const { return fElems[fNElems - 1]; }
+  Double_t& GetLastElem() { return fElems[fNElems - 1]; }
+
+ protected:
+  Int_t fNElems;    ///< Number of elements
+  UShort_t* fIndex; ///< Index of stored elems
+  Double_t* fElems; ///< pointer on elements
+
+  ClassDef(VectorSparse, 0);
+};
+
+//___________________________________________________
+inline Double_t VectorSparse::operator()(Int_t ind) const
+{
+  return FindIndex(ind);
+}
+
+//___________________________________________________
+inline Double_t& VectorSparse::operator()(Int_t ind)
+{
+  return FindIndexAdd(ind);
+}
+
+} // namespace mft
+} // namespace o2
+
+#endif

--- a/Detectors/ITSMFT/MFT/alignment/src/AlignConfig.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/AlignConfig.cxx
@@ -9,31 +9,8 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifndef O2_MFT_RECOWORKFLOW_H_
-#define O2_MFT_RECOWORKFLOW_H_
+/// @file AlignConfig.cxx
+/// @brief Configuration file for MFT standalone alignment
 
-/// @file   RecoWorkflow.h
-
-#include "Framework/WorkflowSpec.h"
-
-namespace o2
-{
-namespace mft
-{
-
-namespace reco_workflow
-{
-framework::WorkflowSpec getWorkflow(
-  bool useMC,
-  bool upstreamDigits,
-  bool upstreamClusters,
-  bool disableRootOutput,
-  bool runAssessment,
-  bool processGen,
-  bool runTracking,
-  bool runTracks2Records);
-}
-
-} // namespace mft
-} // namespace o2
-#endif
+#include "MFTAlignment/AlignConfig.h"
+O2ParamImpl(o2::mft::AlignConfig);

--- a/Detectors/ITSMFT/MFT/alignment/src/AlignPointControl.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/AlignPointControl.cxx
@@ -1,0 +1,191 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file AlignPointControl.cxx
+
+#include <TFile.h>
+#include <TTree.h>
+
+#include "Framework/Logger.h"
+
+#include "MFTAlignment/AlignPointHelper.h"
+#include "MFTAlignment/AlignPointControl.h"
+
+using namespace o2::mft;
+
+ClassImp(o2::mft::AlignPointControl);
+
+//__________________________________________________________________________
+AlignPointControl::AlignPointControl()
+  : mControlTree(nullptr),
+    mControlFile(nullptr),
+    mIsSuccessfulInit(false),
+    mNEntriesAutoSave(10000),
+    mOutFileName("mft_align_point.root"),
+    mTreeTitle("align point info tree")
+{
+  mPointInfo.sensor = 0;
+  mPointInfo.layer = 0;
+  mPointInfo.disk = 0;
+  mPointInfo.half = 0;
+  mPointInfo.measuredGlobalX = 0;
+  mPointInfo.measuredGlobalY = 0;
+  mPointInfo.measuredGlobalZ = 0;
+  mPointInfo.measuredLocalX = 0;
+  mPointInfo.measuredLocalY = 0;
+  mPointInfo.measuredLocalZ = 0;
+  mPointInfo.residualX = 0;
+  mPointInfo.residualY = 0;
+  mPointInfo.residualZ = 0;
+  mPointInfo.residualLocalX = 0;
+  mPointInfo.residualLocalY = 0;
+  mPointInfo.residualLocalZ = 0;
+  mPointInfo.recoGlobalX = 0;
+  mPointInfo.recoGlobalY = 0;
+  mPointInfo.recoGlobalZ = 0;
+  mPointInfo.recoLocalX = 0;
+  mPointInfo.recoLocalY = 0;
+  mPointInfo.recoLocalZ = 0;
+}
+
+//__________________________________________________________________________
+AlignPointControl::~AlignPointControl()
+{
+  if (mControlFile) {
+    mControlFile->Close();
+    LOG(info) << "AlignPointControl - closed file "
+              << mOutFileName.Data();
+    delete mControlFile;
+  }
+}
+
+//__________________________________________________________________________
+void AlignPointControl::setCyclicAutoSave(const long nEntries)
+{
+  if (nEntries <= 0)
+    return;
+  mNEntriesAutoSave = nEntries;
+}
+
+//__________________________________________________________________________
+void AlignPointControl::init()
+{
+  mIsSuccessfulInit = true;
+
+  if (mControlFile == nullptr)
+    mControlFile = new TFile(mOutFileName.Data(), "recreate", "", 505);
+
+  if (mControlTree == nullptr) {
+    mControlFile->cd();
+    mControlTree = new TTree("point", mTreeTitle.Data());
+    mControlTree->SetAutoSave(mNEntriesAutoSave); // flush the TTree to disk every N entries
+    mControlTree->Branch("sensor", &mPointInfo.sensor, "sensor/s");
+    mControlTree->Branch("layer", &mPointInfo.layer, "layer/s");
+    mControlTree->Branch("disk", &mPointInfo.disk, "disk/s");
+    mControlTree->Branch("half", &mPointInfo.half, "half/s");
+    mControlTree->Branch("measuredGlobalX", &mPointInfo.measuredGlobalX, "measuredGlobalX/D");
+    mControlTree->Branch("measuredGlobalY", &mPointInfo.measuredGlobalY, "measuredGlobalY/D");
+    mControlTree->Branch("measuredGlobalZ", &mPointInfo.measuredGlobalZ, "measuredGlobalZ/D");
+    mControlTree->Branch("measuredLocalX", &mPointInfo.measuredLocalX, "measuredLocalX/D");
+    mControlTree->Branch("measuredLocalY", &mPointInfo.measuredLocalY, "measuredLocalY/D");
+    mControlTree->Branch("measuredLocalZ", &mPointInfo.measuredLocalZ, "measuredLocalZ/D");
+    mControlTree->Branch("residualX", &mPointInfo.residualX, "residualX/D");
+    mControlTree->Branch("residualY", &mPointInfo.residualY, "residualY/D");
+    mControlTree->Branch("residualZ", &mPointInfo.residualZ, "residualZ/D");
+    mControlTree->Branch("residualLocalX", &mPointInfo.residualLocalX, "residualLocalX/D");
+    mControlTree->Branch("residualLocalY", &mPointInfo.residualLocalY, "residualLocalY/D");
+    mControlTree->Branch("residualLocalZ", &mPointInfo.residualLocalZ, "residualLocalZ/D");
+    mControlTree->Branch("recoGlobalX", &mPointInfo.recoGlobalX, "recoGlobalX/D");
+    mControlTree->Branch("recoGlobalY", &mPointInfo.recoGlobalY, "recoGlobalY/D");
+    mControlTree->Branch("recoGlobalZ", &mPointInfo.recoGlobalZ, "recoGlobalZ/D");
+    mControlTree->Branch("recoLocalX", &mPointInfo.recoLocalX, "recoLocalX/D");
+    mControlTree->Branch("recoLocalY", &mPointInfo.recoLocalY, "recoLocalY/D");
+    mControlTree->Branch("recoLocalZ", &mPointInfo.recoLocalZ, "recoLocalZ/D");
+  }
+  if ((!mControlFile) || (mControlFile->IsZombie())) {
+    mIsSuccessfulInit = false;
+    LOG(error) << "AlignPointControl::init() - failed, no viable output file !";
+  }
+  if (!mControlTree) {
+    mIsSuccessfulInit = false;
+    LOG(error) << "AlignPointControl::init() - failed, no TTree !";
+  }
+}
+
+//__________________________________________________________________________
+void AlignPointControl::terminate()
+{
+  if (mControlFile && mControlFile->IsWritable() && mControlTree) {
+    mControlFile->cd();
+    mControlTree->Write();
+    LOG(info) << "AlignPointControl::terminate() - wrote "
+              << mTreeTitle.Data();
+  }
+}
+
+//__________________________________________________________________________
+void AlignPointControl::fill(o2::mft::AlignPointHelper* aPoint,
+                             const int iTrack,
+                             const bool doPrint)
+{
+  if (!isInitOk()) {
+    LOG(warning) << "AlignPointControl::fill() - aborted, init was not ok !";
+    return;
+  }
+
+  bool isPointok = setControlPoint(aPoint);
+
+  if (isPointok) {
+    mControlTree->Fill();
+    if (doPrint) {
+      LOGF(info, "AlignPointControl::fillControlTree() - track %i h %d d %d l %d s %4d lMpos x %.2e y %.2e z %.2e gMpos x %.2e y %.2e z %.2e gRpos x %.2e y %.2e z %.2e",
+           iTrack, mPointInfo.half, mPointInfo.disk, mPointInfo.layer, mPointInfo.sensor,
+           mPointInfo.measuredLocalX, mPointInfo.measuredLocalY, mPointInfo.measuredLocalZ,
+           mPointInfo.measuredGlobalX, mPointInfo.measuredGlobalY, mPointInfo.measuredGlobalZ,
+           mPointInfo.recoGlobalX, mPointInfo.recoGlobalY, mPointInfo.recoGlobalZ);
+    }
+  }
+}
+
+//__________________________________________________________________________
+bool AlignPointControl::setControlPoint(
+  o2::mft::AlignPointHelper* aPoint)
+{
+  if (!aPoint) {
+    LOG(warning) << "AlignPointControl::setControlPoint() - aborted, can not use a null pointer";
+    return false;
+  }
+
+  mPointInfo.sensor = aPoint->getSensorId();
+  mPointInfo.layer = aPoint->layer();
+  mPointInfo.disk = aPoint->disk();
+  mPointInfo.half = aPoint->half();
+  mPointInfo.measuredGlobalX = aPoint->getGlobalMeasuredPosition().X();
+  mPointInfo.measuredGlobalY = aPoint->getGlobalMeasuredPosition().Y();
+  mPointInfo.measuredGlobalZ = aPoint->getGlobalMeasuredPosition().Z();
+  mPointInfo.measuredLocalX = aPoint->getLocalMeasuredPosition().X();
+  mPointInfo.measuredLocalY = aPoint->getLocalMeasuredPosition().Y();
+  mPointInfo.measuredLocalZ = aPoint->getLocalMeasuredPosition().Z();
+  mPointInfo.residualX = aPoint->getGlobalResidual().X();
+  mPointInfo.residualY = aPoint->getGlobalResidual().Y();
+  mPointInfo.residualZ = aPoint->getGlobalResidual().Z();
+  mPointInfo.residualLocalX = aPoint->getLocalResidual().X();
+  mPointInfo.residualLocalY = aPoint->getLocalResidual().Y();
+  mPointInfo.residualLocalZ = aPoint->getLocalResidual().Z();
+  mPointInfo.recoGlobalX = aPoint->getGlobalRecoPosition().X();
+  mPointInfo.recoGlobalY = aPoint->getGlobalRecoPosition().Y();
+  mPointInfo.recoGlobalZ = aPoint->getGlobalRecoPosition().Z();
+  mPointInfo.recoLocalX = aPoint->getLocalRecoPosition().X();
+  mPointInfo.recoLocalY = aPoint->getLocalRecoPosition().Y();
+  mPointInfo.recoLocalZ = aPoint->getLocalRecoPosition().Z();
+
+  return true;
+}

--- a/Detectors/ITSMFT/MFT/alignment/src/AlignPointControl.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/AlignPointControl.cxx
@@ -70,8 +70,9 @@ AlignPointControl::~AlignPointControl()
 //__________________________________________________________________________
 void AlignPointControl::setCyclicAutoSave(const long nEntries)
 {
-  if (nEntries <= 0)
+  if (nEntries <= 0) {
     return;
+  }
   mNEntriesAutoSave = nEntries;
 }
 
@@ -80,8 +81,9 @@ void AlignPointControl::init()
 {
   mIsSuccessfulInit = true;
 
-  if (mControlFile == nullptr)
+  if (mControlFile == nullptr) {
     mControlFile = new TFile(mOutFileName.Data(), "recreate", "", 505);
+  }
 
   if (mControlTree == nullptr) {
     mControlFile->cd();

--- a/Detectors/ITSMFT/MFT/alignment/src/AlignPointHelper.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/AlignPointHelper.cxx
@@ -11,7 +11,8 @@
 
 /// @file AlignPointHelper.cxx
 
-#include <math.h>
+#include <cmath>
+
 #include <Rtypes.h>
 #include "Framework/Logger.h"
 #include "DataFormatsMFT/TrackMFT.h"

--- a/Detectors/ITSMFT/MFT/alignment/src/AlignPointHelper.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/AlignPointHelper.cxx
@@ -1,0 +1,619 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file AlignPointHelper.cxx
+
+#include <math.h>
+#include <Rtypes.h>
+#include "Framework/Logger.h"
+#include "DataFormatsMFT/TrackMFT.h"
+#include "MFTAlignment/AlignSensorHelper.h"
+#include "MFTAlignment/AlignPointHelper.h"
+#include "MFTTracking/IOUtils.h"
+#include "ITSMFTBase/SegmentationAlpide.h"
+
+using namespace o2::mft;
+
+ClassImp(o2::mft::AlignPointHelper);
+
+//__________________________________________________________________________
+AlignPointHelper::AlignPointHelper()
+  : mIsAlignPointSet(false),
+    mIsGlobalDerivativeDone(false),
+    mIsLocalDerivativeDone(false),
+    mIsTrackInitialParamSet(false),
+    mIsClusterOk(false),
+    mGeometry(nullptr),
+    mDictionary(nullptr),
+    mChipHelper(nullptr),
+    mGlobalRecoPosition(0., 0., 0.),
+    mLocalRecoPosition(0., 0., 0.),
+    mLocalMeasuredPosition(0., 0., 0.),
+    mLocalMeasuredPositionSigma(0., 0., 0),
+    mGlobalMeasuredPosition(0., 0., 0.),
+    mLocalResidual(0., 0., 0.)
+{
+
+  mGeometry = o2::mft::GeometryTGeo::Instance();
+  mGeometry->fillMatrixCache(
+    o2::math_utils::bit2Mask(o2::math_utils::TransformType::T2L,
+                             o2::math_utils::TransformType::L2G));
+
+  resetLocalDerivatives();
+  resetGlobalDerivatives();
+  resetTrackInitialParam();
+  resetAlignPoint();
+
+  mChipHelper = std::make_unique<AlignSensorHelper>();
+  LOGF(debug, "AlignPointHelper instantiated");
+}
+
+//__________________________________________________________________________
+void AlignPointHelper::computeLocalDerivatives()
+{
+  resetLocalDerivatives();
+  if (mChipHelper == nullptr) {
+    LOGF(error,
+         "AlignPointHelper::computeLocalDerivatives() - no AlignSensorHelper found !");
+    return;
+  }
+  if (!mIsTrackInitialParamSet) {
+    LOGF(error,
+         "AlignPointHelper::computeLocalDerivatives() - no initial track param found !");
+    return;
+  }
+  if (!mIsAlignPointSet) {
+    LOGF(error,
+         "AlignPointHelper::computeLocalDerivatives() - no align point coordinates set !");
+    return;
+  }
+  bool success = true;
+  success &= computeLocalDerivativeX();
+  success &= computeLocalDerivativeY();
+  success &= computeLocalDerivativeZ();
+  mIsLocalDerivativeDone = success;
+}
+
+//__________________________________________________________________________
+void AlignPointHelper::computeGlobalDerivatives()
+{
+  resetGlobalDerivatives();
+  if (mChipHelper == nullptr) {
+    LOGF(error,
+         "AlignPointHelper::computeGlobalDerivatives() - no AlignSensorHelper found !");
+    return;
+  }
+  if (!mIsTrackInitialParamSet) {
+    LOGF(error,
+         "AlignPointHelper::computeGlobalDerivatives() - no initial track param found !");
+    return;
+  }
+  if (!mIsAlignPointSet) {
+    LOGF(error, "AlignPointHelper::computeGlobalDerivatives() - no align point coordinates set !");
+    return;
+  }
+  bool success = true;
+  success &= computeGlobalDerivativeX();
+  success &= computeGlobalDerivativeY();
+  success &= computeGlobalDerivativeZ();
+  mIsGlobalDerivativeDone = success;
+}
+
+//__________________________________________________________________________
+UShort_t AlignPointHelper::getSensorId() const
+{
+  if (mChipHelper == nullptr) {
+    LOGF(error,
+         "AlignPointHelper::getSensorId() - no AlignSensorHelper found !");
+    return 0;
+  }
+  if (!mIsAlignPointSet) {
+    LOGF(error,
+         "AlignPointHelper::getSensorId() - no align point coordinates set !");
+    return 0;
+  }
+  return mChipHelper->chipIndexInMft();
+}
+
+//__________________________________________________________________________
+UShort_t AlignPointHelper::half() const
+{
+  if (mChipHelper == nullptr) {
+    LOGF(error,
+         "AlignPointHelper::half() - no AlignSensorHelper found !");
+    return 0;
+  }
+  if (!mIsAlignPointSet) {
+    LOGF(error,
+         "AlignPointHelper::half() - no align point coordinates set !");
+    return 0;
+  }
+  return mChipHelper->half();
+}
+
+//__________________________________________________________________________
+UShort_t AlignPointHelper::disk() const
+{
+  if (mChipHelper == nullptr) {
+    LOGF(error,
+         "AlignPointHelper::disk() - no AlignSensorHelper found !");
+    return 0;
+  }
+  if (!mIsAlignPointSet) {
+    LOGF(error,
+         "AlignPointHelper::disk() - no align point coordinates set !");
+    return 0;
+  }
+  return mChipHelper->disk();
+}
+
+//__________________________________________________________________________
+UShort_t AlignPointHelper::layer() const
+{
+  if (mChipHelper == nullptr) {
+    LOGF(error,
+         "AlignPointHelper::layer() - no AlignSensorHelper found !");
+    return 0;
+  }
+  if (!mIsAlignPointSet) {
+    LOGF(error,
+         "AlignPointHelper::layer() - no align point coordinates set !");
+    return 0;
+  }
+  return mChipHelper->layer();
+}
+
+//__________________________________________________________________________
+void AlignPointHelper::resetAlignPoint()
+{
+  mGlobalRecoPosition.SetXYZ(0., 0., 0.);
+  mLocalRecoPosition.SetXYZ(0., 0., 0.);
+
+  mLocalMeasuredPosition.SetXYZ(0., 0., 0.);
+  mLocalMeasuredPositionSigma.SetXYZ(
+    o2::mft::ioutils::DefClusErrorRow,
+    o2::itsmft::SegmentationAlpide::SensorLayerThicknessEff * 0.5,
+    o2::mft::ioutils::DefClusErrorCol);
+  mGlobalMeasuredPosition.SetXYZ(0., 0., 0.);
+
+  mLocalResidual.SetXYZ(0., 0., 0.);
+
+  mIsAlignPointSet = false;
+}
+
+//__________________________________________________________________________
+void AlignPointHelper::resetTrackInitialParam()
+{
+  mTrackInitialParam.X0 = 0.;
+  mTrackInitialParam.Y0 = 0.;
+  mTrackInitialParam.Z0 = 0.;
+  mTrackInitialParam.Tx = 0.;
+  mTrackInitialParam.Ty = 0.;
+
+  mIsTrackInitialParamSet = false;
+}
+
+//__________________________________________________________________________
+void AlignPointHelper::convertCompactClusters(gsl::span<const itsmft::CompClusterExt> clusters,
+                                              gsl::span<const unsigned char>::iterator& pattIt,
+                                              std::vector<o2::BaseCluster<double>>& outputLocalClusters,
+                                              std::vector<o2::BaseCluster<double>>& outputGlobalClusters)
+{
+  // use this version of convertCompactClusters() in a workflow
+
+  if (mDictionary == nullptr) {
+    LOGF(error,
+         "AlignPointHelper::convertCompactClusters() - no dictionary found !");
+    return;
+  }
+  if (mGeometry == nullptr) {
+    mGeometry = o2::mft::GeometryTGeo::Instance();
+  }
+  mGeometry->fillMatrixCache(
+    o2::math_utils::bit2Mask(o2::math_utils::TransformType::T2L,
+                             o2::math_utils::TransformType::L2G));
+  outputLocalClusters.clear();
+  outputGlobalClusters.clear();
+  // inspired from Detectors/ITSMFT/MFT/tracking/src/IOUtils.cxx
+  for (auto& mftCluster : clusters) {
+    auto chipID = mftCluster.getChipID();
+    auto pattID = mftCluster.getPatternID();
+    // Dummy COG errors (about half pixel size)
+    double sigmaX = o2::mft::ioutils::DefClusErrorRow;
+    double sigmaZ = o2::mft::ioutils::DefClusErrorCol;
+
+    o2::math_utils::Point3D<double> locXYZ;
+    if (pattID != o2::itsmft::CompCluster::InvalidPatternID) {
+      // ALPIDE local Y coordinate => MFT global X coordinate (ALPIDE rows)
+      sigmaX = mDictionary->getErrX(pattID);
+      // ALPIDE local Z coordinate => MFT global Y coordinate (ALPIDE columns)
+      sigmaZ = mDictionary->getErrZ(pattID);
+
+      if (!mDictionary->isGroup(pattID)) {
+        locXYZ = mDictionary->getClusterCoordinates(mftCluster);
+      } else {
+        o2::itsmft::ClusterPattern cPattern(pattIt);
+        locXYZ = mDictionary->getClusterCoordinates(mftCluster, cPattern);
+      }
+    } else {
+      o2::itsmft::ClusterPattern cPattern(pattIt);
+      locXYZ = mDictionary->getClusterCoordinates(mftCluster, cPattern, false);
+    }
+    auto gloXYZ = mGeometry->getMatrixL2G(chipID) * locXYZ;
+
+    auto& locCl3d = outputLocalClusters.emplace_back(chipID, locXYZ); // local
+    locCl3d.setErrors(sigmaX, o2::itsmft::SegmentationAlpide::SensorLayerThicknessEff * 0.5, sigmaZ);
+
+    auto& gloCl3d = outputGlobalClusters.emplace_back(chipID, gloXYZ); // global
+    gloCl3d.setErrors(sigmaX, sigmaZ, o2::itsmft::SegmentationAlpide::SensorLayerThicknessEff * 0.5);
+  }
+  LOGF(debug,
+       "AlignPointHelper::convertCompactClusters() - output vector size %d",
+       outputLocalClusters.size());
+}
+
+//__________________________________________________________________________
+void AlignPointHelper::convertCompactClusters(const std::vector<o2::itsmft::CompClusterExt>& clusters,
+                                              std::vector<unsigned char>::iterator& pattIt,
+                                              std::vector<o2::BaseCluster<double>>& outputLocalClusters,
+                                              std::vector<o2::BaseCluster<double>>& outputGlobalClusters)
+{
+  // use this version of convertCompactClusters() in a macro
+
+  if (mDictionary == nullptr) {
+    LOGF(error,
+         "AlignPointHelper::convertCompactClusters() - no dictionary found !");
+    return;
+  }
+  if (mGeometry == nullptr) {
+    mGeometry = o2::mft::GeometryTGeo::Instance();
+  }
+  mGeometry->fillMatrixCache(
+    o2::math_utils::bit2Mask(o2::math_utils::TransformType::T2L,
+                             o2::math_utils::TransformType::L2G));
+  outputLocalClusters.clear();
+  outputGlobalClusters.clear();
+  // inspired from Detectors/ITSMFT/MFT/tracking/src/IOUtils.cxx
+  for (auto& mftCluster : clusters) {
+    auto chipID = mftCluster.getChipID();
+    auto pattID = mftCluster.getPatternID();
+    // Dummy COG errors (about half pixel size)
+    double sigmaX = o2::mft::ioutils::DefClusErrorRow;
+    double sigmaZ = o2::mft::ioutils::DefClusErrorCol;
+
+    o2::math_utils::Point3D<double> locXYZ;
+    if (pattID != o2::itsmft::CompCluster::InvalidPatternID) {
+      // ALPIDE local Y coordinate => MFT global X coordinate (ALPIDE rows)
+      sigmaX = mDictionary->getErrX(pattID);
+      // ALPIDE local Z coordinate => MFT global Y coordinate (ALPIDE columns)
+      sigmaZ = mDictionary->getErrZ(pattID);
+
+      if (!mDictionary->isGroup(pattID)) {
+        locXYZ = mDictionary->getClusterCoordinates(mftCluster);
+      } else {
+        o2::itsmft::ClusterPattern cPattern(pattIt);
+        locXYZ = mDictionary->getClusterCoordinates(mftCluster, cPattern);
+      }
+    } else {
+      o2::itsmft::ClusterPattern cPattern(pattIt);
+      locXYZ = mDictionary->getClusterCoordinates(mftCluster, cPattern, false);
+    }
+    auto gloXYZ = mGeometry->getMatrixL2G(chipID) * locXYZ;
+
+    auto& locCl3d = outputLocalClusters.emplace_back(chipID, locXYZ); // local
+    locCl3d.setErrors(sigmaX, o2::itsmft::SegmentationAlpide::SensorLayerThicknessEff * 0.5, sigmaZ);
+
+    auto& gloCl3d = outputGlobalClusters.emplace_back(chipID, gloXYZ); // global
+    gloCl3d.setErrors(sigmaX, sigmaZ, o2::itsmft::SegmentationAlpide::SensorLayerThicknessEff * 0.5);
+  }
+  LOGF(debug,
+       "AlignPointHelper::convertCompactClusters() - output vector size %d",
+       outputLocalClusters.size());
+}
+
+//__________________________________________________________________________
+void AlignPointHelper::recordTrackInitialParam(o2::mft::TrackMFT& mftTrack)
+{
+  mIsTrackInitialParamSet = false;
+  mTrackInitialParam.X0 = mftTrack.getX();
+  mTrackInitialParam.Y0 = mftTrack.getY();
+  mTrackInitialParam.Z0 = mftTrack.getZ();
+  double phi = mftTrack.getPhi();
+  double tanLambda = mftTrack.getTanl();
+  mTrackInitialParam.Tx = std::cos(phi) / tanLambda;
+  mTrackInitialParam.Ty = std::sin(phi) / tanLambda;
+  LOGF(debug,
+       "AlignPointHelper::recordTrackInitialParam - x0 = %.3e, y0 = %.3e, z0 = %.3e, Tx = %.3e, Ty = %.3e",
+       mTrackInitialParam.X0, mTrackInitialParam.Y0, mTrackInitialParam.Z0,
+       mTrackInitialParam.Tx, mTrackInitialParam.Ty);
+
+  mIsTrackInitialParamSet = true;
+}
+
+//__________________________________________________________________________
+void AlignPointHelper::setGlobalRecoPosition(o2::mft::TrackMFT& mftTrack)
+{
+  mIsAlignPointSet = false;
+  LOGF(debug,
+       "AlignPointHelper::setGlobalRecoPosition() - track x = %.3e, y = %.3e, z = %.3e",
+       mftTrack.getX(), mftTrack.getY(), mftTrack.getZ());
+  mGlobalRecoPosition.SetXYZ(mftTrack.getX(), mftTrack.getY(), mftTrack.getZ());
+  mIsAlignPointSet = true;
+  if (isnan(mGlobalRecoPosition.X()) || isnan(mGlobalRecoPosition.Y()) || isnan(mGlobalRecoPosition.Z())) {
+    LOGF(error,
+         "AlignPointHelper::setGlobalRecoPosition() - track x = %.3e, y = %.3e, z = %.3e, point x = %.3e, y = %.3e, z = %.3e",
+         mftTrack.getX(), mftTrack.getY(), mftTrack.getZ(),
+         mGlobalRecoPosition.X(), mGlobalRecoPosition.Y(), mGlobalRecoPosition.Z());
+    mIsAlignPointSet = false;
+  }
+}
+
+//__________________________________________________________________________
+void AlignPointHelper::setMeasuredPosition(const o2::BaseCluster<double>& localCluster,
+                                           const o2::BaseCluster<double>& globalCluster)
+{
+  auto chipID = localCluster.getSensorID();
+
+  mIsClusterOk = true;
+
+  mLocalMeasuredPosition.SetXYZ(
+    localCluster.getX(), localCluster.getY(), localCluster.getZ());
+  if (isnan(mLocalMeasuredPosition.X()) || isnan(mLocalMeasuredPosition.Y()) || isnan(mLocalMeasuredPosition.Z())) {
+    LOGF(error,
+         "AlignPointHelper::setMeasuredPosition() - sr %4d local x = %.3e, y = %.3e, z = %.3e",
+         chipID,
+         mLocalMeasuredPosition.X(), mLocalMeasuredPosition.Y(), mLocalMeasuredPosition.Z());
+    mIsClusterOk = false;
+    return;
+  }
+
+  mGlobalMeasuredPosition.SetXYZ(
+    globalCluster.getX(), globalCluster.getY(), globalCluster.getZ());
+  if (isnan(mGlobalMeasuredPosition.X()) || isnan(mGlobalMeasuredPosition.Y()) || isnan(mGlobalMeasuredPosition.Z())) {
+    LOGF(error,
+         "AlignPointHelper::setMeasuredPosition() - sr %4d global x = %.3e, y = %.3e, z = %.3e",
+         chipID,
+         mGlobalMeasuredPosition.X(), mGlobalMeasuredPosition.Y(), mGlobalMeasuredPosition.Z());
+    mIsClusterOk = false;
+    return;
+  }
+
+  mIsAlignPointSet &= mChipHelper->setSensor(chipID);
+}
+
+//__________________________________________________________________________
+void AlignPointHelper::setLocalResidual()
+{
+  if (mGeometry == nullptr) {
+    mGeometry = o2::mft::GeometryTGeo::Instance();
+  }
+
+  if (mIsAlignPointSet) {
+    mGeometry->fillMatrixCache(
+      o2::math_utils::bit2Mask(o2::math_utils::TransformType::T2L,
+                               o2::math_utils::TransformType::L2G));
+    mLocalRecoPosition = mGeometry->getMatrixL2G(getSensorId()).ApplyInverse(mGlobalRecoPosition);
+    mLocalResidual.SetXYZ(
+      mLocalMeasuredPosition.X() - mLocalRecoPosition.X(),
+      mLocalMeasuredPosition.Y() - mLocalRecoPosition.Y(),
+      mLocalMeasuredPosition.Z() - mLocalRecoPosition.Z());
+  } else {
+    LOGF(error,
+         "AlignPointHelper::setLocalResidual() - no align point coordinates set !");
+  }
+}
+
+//__________________________________________________________________________
+void AlignPointHelper::setGlobalResidual()
+{
+  if (mIsAlignPointSet) {
+    mGlobalResidual.SetXYZ(
+      mGlobalMeasuredPosition.X() - mGlobalRecoPosition.X(),
+      mGlobalMeasuredPosition.Y() - mGlobalRecoPosition.Y(),
+      mGlobalMeasuredPosition.Z() - mGlobalRecoPosition.Z());
+  } else {
+    LOGF(error,
+         "AlignPointHelper::setGlobalResidual() - no align point coordinates set !");
+  }
+}
+
+//__________________________________________________________________________
+void AlignPointHelper::resetLocalDerivatives()
+{
+  mLocalDerivativeX.reset();
+  mLocalDerivativeY.reset();
+  mLocalDerivativeZ.reset();
+
+  mIsLocalDerivativeDone = false;
+}
+
+//__________________________________________________________________________
+void AlignPointHelper::resetGlobalDerivatives()
+{
+  mGlobalDerivativeX.reset();
+  mGlobalDerivativeY.reset();
+  mGlobalDerivativeZ.reset();
+
+  mIsGlobalDerivativeDone = false;
+}
+
+//__________________________________________________________________________
+bool AlignPointHelper::computeLocalDerivativeX()
+{
+  if (mChipHelper->isTransformExtracted()) {
+    mLocalDerivativeX.mdX0 = mChipHelper->cosRy() * mChipHelper->cosRz();
+
+    mLocalDerivativeX.mdTx = (mGlobalRecoPosition.Z() - mTrackInitialParam.Z0) *
+                             mChipHelper->cosRy() * mChipHelper->cosRz();
+
+    mLocalDerivativeX.mdY0 = (mChipHelper->sinRx() * mChipHelper->sinRy() * mChipHelper->cosRz()) +
+                             (mChipHelper->cosRx() * mChipHelper->sinRz());
+
+    mLocalDerivativeX.mdTy = (mGlobalRecoPosition.Z() - mTrackInitialParam.Z0) *
+                             ((mChipHelper->sinRx() * mChipHelper->sinRy() * mChipHelper->cosRz()) +
+                              (mChipHelper->cosRx() * mChipHelper->sinRz()));
+    LOGF(debug,
+         "computeLocalDerivativeX(): dX0 = %.3e, dTx = %.3e, dY0 = %.3e, dTy = %.3e",
+         mLocalDerivativeX.mdX0,
+         mLocalDerivativeX.mdTx,
+         mLocalDerivativeX.mdY0,
+         mLocalDerivativeX.mdTy);
+    return true;
+  } else {
+    LOGF(error,
+         "AlignPointHelper::computeLocalDerivativeX() - no sensor transform found !");
+    return false;
+  }
+}
+
+//__________________________________________________________________________
+bool AlignPointHelper::computeLocalDerivativeY()
+{
+  if (mChipHelper->isTransformExtracted()) {
+    mLocalDerivativeY.mdX0 = (-1.) * mChipHelper->cosRy() * mChipHelper->sinRz();
+
+    mLocalDerivativeY.mdTx = (-1.) * (mGlobalRecoPosition.Z() - mTrackInitialParam.Z0) *
+                             mChipHelper->cosRy() * mChipHelper->sinRz();
+
+    mLocalDerivativeY.mdY0 = (mChipHelper->cosRx() * mChipHelper->cosRz()) -
+                             (mChipHelper->sinRx() * mChipHelper->sinRy() * mChipHelper->sinRz());
+
+    mLocalDerivativeY.mdTy = (mGlobalRecoPosition.Z() - mTrackInitialParam.Z0) *
+                             ((mChipHelper->cosRx() * mChipHelper->cosRz()) -
+                              (mChipHelper->sinRx() * mChipHelper->sinRy() * mChipHelper->sinRz()));
+    LOGF(debug,
+         "computeLocalDerivativeY(): dX0 = %.3e, dTx = %.3e, dY0 = %.3e, dTy = %.3e",
+         mLocalDerivativeY.mdX0,
+         mLocalDerivativeY.mdTx,
+         mLocalDerivativeY.mdY0,
+         mLocalDerivativeY.mdTy);
+    return true;
+  } else {
+    LOGF(error,
+         "AlignPointHelper::computeLocalDerivativeY() - no sensor transform found !");
+    return false;
+  }
+}
+
+//__________________________________________________________________________
+bool AlignPointHelper::computeLocalDerivativeZ()
+{
+  if (mChipHelper->isTransformExtracted()) {
+    mLocalDerivativeZ.mdX0 = mChipHelper->sinRy();
+
+    mLocalDerivativeZ.mdTx = (mGlobalRecoPosition.Z() - mTrackInitialParam.Z0) * mChipHelper->sinRy();
+
+    mLocalDerivativeZ.mdY0 = (-1.) * mChipHelper->sinRx() * mChipHelper->cosRy();
+
+    mLocalDerivativeZ.mdTy = (-1.) * (mGlobalRecoPosition.Z() - mTrackInitialParam.Z0) * mChipHelper->sinRx() * mChipHelper->cosRy();
+    LOGF(debug,
+         "computeLocalDerivativeZ(): dX0 = %.3e, dTx = %.3e, dY0 = %.3e, dTy = %.3e",
+         mLocalDerivativeZ.mdX0,
+         mLocalDerivativeZ.mdTx,
+         mLocalDerivativeZ.mdY0,
+         mLocalDerivativeZ.mdTy);
+    return true;
+  } else {
+    LOGF(error,
+         "AlignPointHelper::computeLocalDerivativeZ() - no sensor transform found !");
+    return false;
+  }
+}
+
+//__________________________________________________________________________
+bool AlignPointHelper::computeGlobalDerivativeX()
+{
+  if (mChipHelper->isTransformExtracted()) {
+    mGlobalDerivativeX.mdDeltaX = (-1.) * mChipHelper->cosRy() * mChipHelper->cosRz();
+
+    mGlobalDerivativeX.mdDeltaY = (-1) * ((mChipHelper->sinRx() * mChipHelper->sinRy() * mChipHelper->cosRz()) +
+                                          (mChipHelper->cosRx() * mChipHelper->sinRz()));
+
+    mGlobalDerivativeX.mdDeltaZ = (mTrackInitialParam.Tx * mChipHelper->cosRy() * mChipHelper->cosRz()) +
+                                  (mTrackInitialParam.Ty * ((mChipHelper->sinRx() * mChipHelper->sinRy() * mChipHelper->cosRz()) +
+                                                            (mChipHelper->cosRx() * mChipHelper->sinRz())));
+
+    mGlobalDerivativeX.mdDeltaRz = ((-1.) * mChipHelper->cosRy() * mChipHelper->sinRz() *
+                                    (mGlobalRecoPosition.X() - mChipHelper->translateX())) +
+                                   ((mGlobalRecoPosition.Y() - mChipHelper->translateY()) *
+                                    ((mChipHelper->cosRx() * mChipHelper->cosRz()) -
+                                     (mChipHelper->sinRx() * mChipHelper->sinRy() * mChipHelper->sinRz())));
+    LOGF(debug,
+         "computeGlobalDerivativeX(): dx = %.3e, dy = %.3e, dz = %.3e, dRz = %.3e",
+         mGlobalDerivativeX.mdDeltaX,
+         mGlobalDerivativeX.mdDeltaY,
+         mGlobalDerivativeX.mdDeltaZ,
+         mGlobalDerivativeX.mdDeltaRz);
+    return true;
+  } else {
+    LOGF(error,
+         "AlignPointHelper::computeGlobalDerivativeX() - no sensor transform found !");
+    return false;
+  }
+}
+
+//__________________________________________________________________________
+bool AlignPointHelper::computeGlobalDerivativeY()
+{
+  if (mChipHelper->isTransformExtracted()) {
+    mGlobalDerivativeY.mdDeltaX = mChipHelper->cosRy() * mChipHelper->sinRz();
+
+    mGlobalDerivativeY.mdDeltaY = (mChipHelper->sinRx() * mChipHelper->sinRy() * mChipHelper->sinRz()) -
+                                  (mChipHelper->cosRx() * mChipHelper->cosRz());
+
+    mGlobalDerivativeY.mdDeltaZ = ((-1.) * mTrackInitialParam.Tx * mChipHelper->cosRy() * mChipHelper->sinRz()) +
+                                  (mTrackInitialParam.Ty *
+                                   ((mChipHelper->cosRx() * mChipHelper->cosRz()) -
+                                    (mChipHelper->sinRx() * mChipHelper->sinRy() * mChipHelper->sinRz())));
+
+    mGlobalDerivativeY.mdDeltaRz = ((-1.) * (mGlobalRecoPosition.X() - mChipHelper->translateX()) * mChipHelper->cosRy() * mChipHelper->cosRz()) -
+                                   ((mGlobalRecoPosition.Y() - mChipHelper->translateY()) *
+                                    ((mChipHelper->cosRx() * mChipHelper->sinRz()) +
+                                     (mChipHelper->sinRx() * mChipHelper->sinRy() + mChipHelper->cosRz())));
+    LOGF(debug,
+         "computeGlobalDerivativeY(): dx = %.3e, dy = %.3e, dz = %.3e, dRz = %.3e",
+         mGlobalDerivativeY.mdDeltaX,
+         mGlobalDerivativeY.mdDeltaY,
+         mGlobalDerivativeY.mdDeltaZ,
+         mGlobalDerivativeY.mdDeltaRz);
+    return true;
+  } else {
+    LOGF(error,
+         "AlignPointHelper::computeGlobalDerivativeY() - no sensor transform found !");
+    return false;
+  }
+}
+
+//__________________________________________________________________________
+bool AlignPointHelper::computeGlobalDerivativeZ()
+{
+  if (mChipHelper->isTransformExtracted()) {
+    mGlobalDerivativeZ.mdDeltaX = (-1.) * mChipHelper->sinRy();
+
+    mGlobalDerivativeZ.mdDeltaY = mChipHelper->sinRx() * mChipHelper->cosRy();
+
+    mGlobalDerivativeZ.mdDeltaZ = (mTrackInitialParam.Tx * mChipHelper->sinRy()) -
+                                  (mTrackInitialParam.Ty * mChipHelper->sinRx() * mChipHelper->cosRy());
+
+    mGlobalDerivativeZ.mdDeltaRz = 0;
+    LOGF(debug,
+         "computeGlobalDerivativeZ(): dx = %.3e, dy = %.3e, dz = %.3e, dRz = %.3e",
+         mGlobalDerivativeZ.mdDeltaX,
+         mGlobalDerivativeZ.mdDeltaY,
+         mGlobalDerivativeZ.mdDeltaZ,
+         mGlobalDerivativeZ.mdDeltaRz);
+    return true;
+  } else {
+    LOGF(error,
+         "AlignPointHelper::computeGlobalDerivativeZ() - no sensor transform found !");
+    return false;
+  }
+}

--- a/Detectors/ITSMFT/MFT/alignment/src/AlignSensorHelper.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/AlignSensorHelper.cxx
@@ -159,8 +159,9 @@ void AlignSensorHelper::setSymName()
 //__________________________________________________________________________
 void AlignSensorHelper::extractSensorTransform()
 {
-  if (mIsTransformExtracted)
+  if (mIsTransformExtracted) {
     return;
+  }
   if (mGeometry == nullptr) {
     mGeometry = o2::mft::GeometryTGeo::Instance();
   }

--- a/Detectors/ITSMFT/MFT/alignment/src/AlignSensorHelper.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/AlignSensorHelper.cxx
@@ -1,0 +1,229 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file AlignSensorHelper.cxx
+
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include <Rtypes.h>
+#include "Framework/Logger.h"
+#include "MFTAlignment/AlignSensorHelper.h"
+
+using namespace o2::mft;
+
+ClassImp(o2::mft::AlignSensorHelper);
+
+//__________________________________________________________________________
+AlignSensorHelper::AlignSensorHelper()
+  : mNumberOfSensors(0),
+    mChipIndexOnLadder(0),
+    mChipIndexInMft(0),
+    mLadderInHalfDisk(0),
+    mConnector(0),
+    mTransceiver(0),
+    mLayer(0),
+    mZone(0),
+    mDisk(0),
+    mHalf(0),
+    mChipUniqueId(0),
+    mTranslation(0, 0, 0),
+    mRx(0),
+    mRy(0),
+    mRz(0),
+    mSinRx(0),
+    mCosRx(0),
+    mSinRy(0),
+    mCosRy(0),
+    mSinRz(0),
+    mCosRz(0),
+    mIsTransformExtracted(false)
+{
+  mNumberOfSensors = mChipMapping.getNChips();
+  setGeometry();
+  LOGF(debug, "AlignSensorHelper instantiated");
+}
+
+//__________________________________________________________________________
+void AlignSensorHelper::setGeometry()
+{
+  if (mGeometry == nullptr) {
+    mGeometry = o2::mft::GeometryTGeo::Instance();
+    mGeometry->fillMatrixCache(
+      o2::math_utils::bit2Mask(o2::math_utils::TransformType::T2L,
+                               o2::math_utils::TransformType::L2G));
+    mGeoSymbolicName = mGeometry->composeSymNameMFT();
+  }
+}
+
+//__________________________________________________________________________
+void AlignSensorHelper::setSensorOnlyInfo(const int chipIndex)
+{
+  if (chipIndex < mNumberOfSensors) {
+    o2::itsmft::MFTChipMappingData chipMappingData = (mChipMapping.getChipMappingData())[chipIndex];
+    mChipIndexOnLadder = (UShort_t)chipMappingData.chipOnModule;
+    mChipIndexInMft = chipMappingData.globalChipSWID;
+    mConnector = (UShort_t)chipMappingData.connector;
+    mTransceiver = (UShort_t)chipMappingData.cable;
+    mZone = (UShort_t)chipMappingData.zone;
+    mLayer = (UShort_t)chipMappingData.layer;
+    mDisk = (UShort_t)chipMappingData.disk;
+    mHalf = (UShort_t)chipMappingData.half;
+  } else {
+    LOGF(error, "AlignSensorHelper::setSensorOnlyInfo() - chip index %d >= %d",
+         chipIndex, mNumberOfSensors);
+  }
+
+  setSensorUid(chipIndex);
+  setSymName();
+}
+
+//__________________________________________________________________________
+std::stringstream AlignSensorHelper::getSensorFullName(bool wSymName)
+{
+  std::stringstream name;
+  if (mGeometry == nullptr) {
+    wSymName = false;
+  }
+  name << "h " << mHalf << " d " << mDisk << " layer " << mLayer
+       << " z " << mZone << " lr " << std::setw(3) << mLadderInHalfDisk
+       << " con " << std::setw(1) << mConnector
+       << " tr " << std::setw(2) << mTransceiver
+       << " sr " << std::setw(1) << mChipIndexOnLadder
+       << " iChip " << std::setw(3) << mChipIndexInMft
+       << " uid " << mChipUniqueId;
+  if (wSymName) {
+    name << " " << mGeoSymbolicName;
+  }
+  return name;
+}
+
+//__________________________________________________________________________
+bool AlignSensorHelper::setSensor(const int chipIndex)
+{
+  resetSensorTransformInfo();
+  setSensorOnlyInfo(chipIndex);
+  extractSensorTransform();
+  return mIsTransformExtracted;
+}
+
+//__________________________________________________________________________
+void AlignSensorHelper::setSensorUid(const int chipIndex)
+{
+  if (chipIndex < mNumberOfSensors) {
+    mChipUniqueId = o2::base::GeometryManager::getSensID(o2::detectors::DetID::MFT,
+                                                         chipIndex);
+  } else {
+    LOGF(error, "AlignSensorHelper::setSensorUid() - chip index %d >= %d",
+         chipIndex, mNumberOfSensors);
+    mChipUniqueId = o2::base::GeometryManager::getSensID(o2::detectors::DetID::MFT, 0);
+  }
+}
+
+//__________________________________________________________________________
+void AlignSensorHelper::setSymName()
+{
+  int hf = 0, dk = 0, lr = 0, sr = 0;
+  if (mGeometry == nullptr) {
+    mGeometry = o2::mft::GeometryTGeo::Instance();
+  }
+  mGeometry->fillMatrixCache(
+    o2::math_utils::bit2Mask(o2::math_utils::TransformType::T2L,
+                             o2::math_utils::TransformType::L2G));
+  mGeometry->getSensorID(mChipIndexInMft, hf, dk, lr, sr);
+  mLadderInHalfDisk = lr;
+  bool isIdVerified = true;
+  isIdVerified &= (hf == (int)mHalf);
+  isIdVerified &= (dk == (int)mDisk);
+  isIdVerified &= (sr == (int)mChipIndexOnLadder);
+  if (isIdVerified) {
+    mGeoSymbolicName = mGeometry->composeSymNameChip(mHalf,
+                                                     mDisk,
+                                                     mLadderInHalfDisk,
+                                                     mChipIndexOnLadder);
+  } else {
+    LOGF(error, "AlignSensorHelper::setSymName() - mismatch in some index");
+  }
+}
+
+//__________________________________________________________________________
+void AlignSensorHelper::extractSensorTransform()
+{
+  if (mIsTransformExtracted)
+    return;
+  if (mGeometry == nullptr) {
+    mGeometry = o2::mft::GeometryTGeo::Instance();
+  }
+  mGeometry->fillMatrixCache(
+    o2::math_utils::bit2Mask(o2::math_utils::TransformType::T2L,
+                             o2::math_utils::TransformType::L2G));
+  mTransform = mGeometry->getMatrixL2G(mChipIndexInMft);
+
+  Double_t* tra = mTransform.GetTranslation();
+  mTranslation.SetX(tra[0]);
+  mTranslation.SetY(tra[1]);
+  mTranslation.SetZ(tra[2]);
+
+  Double_t* rot = mTransform.GetRotationMatrix();
+  mRx = std::atan2(-rot[5], rot[8]);
+  mRy = std::asin(rot[2]);
+  mRz = std::atan2(-rot[1], rot[0]);
+
+  // force the value of some calculations of sin, cos to avoid numerical errors
+
+  // for MFT sensors, Rx = - Pi/2, or + Pi/2
+  if (mRx > 0)
+    mSinRx = 1.0; // std::sin(mRx)
+  else
+    mSinRx = -1.0; // std::sin(mRx)
+  mCosRx = 0.0;    // std::cos(mRx)
+
+  // for MFT sensors, Ry = 0
+  mSinRy = 0.0; // std::sin(mRy);
+  mCosRy = 1.0; // std::cos(mRy);
+
+  // for MFT sensors, Rz = 0 or Pi
+  mSinRz = 0.0; // std::sin(mRz);
+  mCosRz = std::cos(mRz);
+
+  mIsTransformExtracted = true;
+}
+
+//__________________________________________________________________________
+void AlignSensorHelper::resetSensorTransformInfo()
+{
+  mIsTransformExtracted = false;
+
+  double rot[9] = {
+    0., 0., 0.,
+    0., 0., 0.,
+    0., 0., 0.};
+  double tra[3] = {0., 0., 0.};
+  mTransform.SetRotation(rot);
+  mTransform.SetTranslation(tra);
+
+  mTranslation.SetX(0.0);
+  mTranslation.SetY(0.0);
+  mTranslation.SetZ(0.0);
+
+  mRx = 0;
+  mRy = 0;
+  mRz = 0;
+
+  mSinRx = 0;
+  mCosRx = 0;
+  mSinRy = 0;
+  mCosRy = 0;
+  mSinRz = 0;
+  mCosRz = 0;
+}

--- a/Detectors/ITSMFT/MFT/alignment/src/AlignSensorHelper.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/AlignSensorHelper.cxx
@@ -182,11 +182,12 @@ void AlignSensorHelper::extractSensorTransform()
   // force the value of some calculations of sin, cos to avoid numerical errors
 
   // for MFT sensors, Rx = - Pi/2, or + Pi/2
-  if (mRx > 0)
+  if (mRx > 0) {
     mSinRx = 1.0; // std::sin(mRx)
-  else
+  } else {
     mSinRx = -1.0; // std::sin(mRx)
-  mCosRx = 0.0;    // std::cos(mRx)
+  }
+  mCosRx = 0.0; // std::cos(mRx)
 
   // for MFT sensors, Ry = 0
   mSinRy = 0.0; // std::sin(mRy);

--- a/Detectors/ITSMFT/MFT/alignment/src/Aligner.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/Aligner.cxx
@@ -1,0 +1,54 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file Aligner.cxx
+
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include <TString.h>
+
+#include "Framework/Logger.h"
+#include "MFTAlignment/Aligner.h"
+#include "MFTAlignment/MillePede2.h"
+
+using namespace o2::mft;
+
+ClassImp(o2::mft::Aligner);
+
+//__________________________________________________________________________
+Aligner::Aligner()
+  : mStartFac(256),
+    mChi2CutNStdDev(3),
+    mResCutInitial(100.),
+    mResCut(100.),
+    mMilleRecordsFileName("mft_mille_records.root"),
+    mMilleConstraintsRecFileName("mft_mille_constraints.root"),
+    mIsInitDone(false),
+    mGlobalParameterStatus(std::vector<int>(mNumberOfGlobalParam))
+{
+  // default allowed variations w.r.t. global system coordinates
+  mAllowVar[0] = 0.5;  // delta translation in x (cm)
+  mAllowVar[1] = 0.5;  // delta translation in y (cm)
+  mAllowVar[2] = 0.01; // rotation angle Rz around z-axis (rad)
+  mAllowVar[3] = 0.5;  // delta translation in z (cm)
+
+  std::fill(mGlobalParameterStatus.begin(), mGlobalParameterStatus.end(), mFreeParId);
+
+  LOGF(debug, "Aligner instantiated");
+}
+
+//__________________________________________________________________________
+Aligner::~Aligner()
+{
+  LOGF(debug, "Aligner destroyed");
+}

--- a/Detectors/ITSMFT/MFT/alignment/src/MFTAlignmentLinkDef.h
+++ b/Detectors/ITSMFT/MFT/alignment/src/MFTAlignmentLinkDef.h
@@ -1,0 +1,37 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifdef __CLING__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class o2::mft::AlignConfig + ;
+#pragma link C++ class o2::mft::Aligner + ;
+#pragma link C++ class o2::mft::AlignPointControl + ;
+#pragma link C++ class o2::mft::AlignPointHelper + ;
+#pragma link C++ class o2::mft::AlignSensorHelper + ;
+#pragma link C++ class o2::mft::MatrixSparse + ;
+#pragma link C++ class o2::mft::MatrixSq + ;
+#pragma link C++ class o2::mft::MillePede2 + ;
+#pragma link C++ class o2::mft::MillePedeRecord + ;
+#pragma link C++ class o2::mft::MilleRecordReader + ;
+#pragma link C++ class o2::mft::MilleRecordWriter + ;
+#pragma link C++ class o2::mft::MinResSolve + ;
+#pragma link C++ class o2::mft::RecordsToAlignParams + ;
+#pragma link C++ class o2::mft::RectMatrix + ;
+#pragma link C++ class o2::mft::SymBDMatrix + ;
+#pragma link C++ class o2::mft::SymMatrix + ;
+#pragma link C++ class o2::mft::TracksToRecords + ;
+#pragma link C++ class o2::mft::VectorSparse + ;
+
+#endif

--- a/Detectors/ITSMFT/MFT/alignment/src/MatrixSparse.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/MatrixSparse.cxx
@@ -24,7 +24,7 @@ ClassImp(MatrixSparse);
 //___________________________________________________________
 MatrixSparse::MatrixSparse(Int_t sz)
   : MatrixSq(),
-    fVecs(0)
+    fVecs(nullptr)
 {
   fNcols = fNrows = sz;
 
@@ -37,7 +37,7 @@ MatrixSparse::MatrixSparse(Int_t sz)
 //___________________________________________________________
 MatrixSparse::MatrixSparse(const MatrixSparse& src)
   : MatrixSq(src),
-    fVecs(0)
+    fVecs(nullptr)
 {
   fVecs = new VectorSparse*[src.GetSize()];
   for (int i = GetSize(); i--;) {
@@ -70,8 +70,9 @@ VectorSparse* MatrixSparse::GetRowAdd(Int_t ir)
 //___________________________________________________________
 MatrixSparse& MatrixSparse::operator=(const MatrixSparse& src)
 {
-  if (this == &src)
+  if (this == &src) {
     return *this;
+  }
   MatrixSq::operator=(src);
 
   Clear();

--- a/Detectors/ITSMFT/MFT/alignment/src/MatrixSparse.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/MatrixSparse.cxx
@@ -29,8 +29,9 @@ MatrixSparse::MatrixSparse(Int_t sz)
   fNcols = fNrows = sz;
 
   fVecs = new VectorSparse*[sz];
-  for (int i = GetSize(); i--;)
+  for (int i = GetSize(); i--;) {
     fVecs[i] = new VectorSparse();
+  }
 }
 
 //___________________________________________________________
@@ -39,8 +40,9 @@ MatrixSparse::MatrixSparse(const MatrixSparse& src)
     fVecs(0)
 {
   fVecs = new VectorSparse*[src.GetSize()];
-  for (int i = GetSize(); i--;)
+  for (int i = GetSize(); i--;) {
     fVecs[i] = new VectorSparse(*src.GetRow(i));
+  }
 }
 
 //___________________________________________________________
@@ -49,15 +51,18 @@ VectorSparse* MatrixSparse::GetRowAdd(Int_t ir)
   // get row, add if needed
   if (ir >= fNrows) {
     VectorSparse** arrv = new VectorSparse*[ir + 1];
-    for (int i = GetSize(); i--;)
+    for (int i = GetSize(); i--;) {
       arrv[i] = fVecs[i];
+    }
     delete[] fVecs;
     fVecs = arrv;
-    for (int i = GetSize(); i <= ir; i++)
+    for (int i = GetSize(); i <= ir; i++) {
       fVecs[i] = new VectorSparse();
+    }
     fNrows = ir + 1;
-    if (IsSymmetric() && fNcols < fNrows)
+    if (IsSymmetric() && fNcols < fNrows) {
       fNcols = fNrows;
+    }
   }
   return fVecs[ir];
 }
@@ -74,16 +79,18 @@ MatrixSparse& MatrixSparse::operator=(const MatrixSparse& src)
   fNrows = src.GetNRows();
   SetSymmetric(src.IsSymmetric());
   fVecs = new VectorSparse*[fNrows];
-  for (int i = fNrows; i--;)
+  for (int i = fNrows; i--;) {
     fVecs[i] = new VectorSparse(*src.GetRow(i));
+  }
   return *this;
 }
 
 //___________________________________________________________
 void MatrixSparse::Clear(Option_t*)
 {
-  for (int i = fNrows; i--;)
+  for (int i = fNrows; i--;) {
     delete GetRow(i);
+  }
   delete[] fVecs;
   fNcols = fNrows = 0;
 }
@@ -97,8 +104,9 @@ void MatrixSparse::Print(Option_t* opt) const
   }
   for (int i = 0; i < fNrows; i++) {
     VectorSparse* row = GetRow(i);
-    if (!row->GetNElems())
+    if (!row->GetNElems()) {
       continue;
+    }
     printf("%3d: ", i);
     row->Print(opt);
   }
@@ -112,30 +120,33 @@ void MatrixSparse::MultiplyByVec(const Double_t* vecIn, Double_t* vecOut) const
   for (int rw = GetSize(); rw--;) { // loop over rows >>>
     const VectorSparse* rowV = GetRow(rw);
     Int_t nel = rowV->GetNElems();
-    if (!nel)
+    if (!nel) {
       continue;
+    }
 
     UShort_t* indV = rowV->GetIndices();
     Double_t* elmV = rowV->GetElems();
 
     if (IsSymmetric()) {
       // treat diagonal term separately. If filled, it should be the last one
-      if (indV[--nel] == rw)
+      if (indV[--nel] == rw) {
         vecOut[rw] += vecIn[rw] * elmV[nel];
-      else
+      } else {
         nel = rowV->GetNElems(); // diag elem was not filled
-
+      }
       for (int iel = nel; iel--;) { // less element retrieval for symmetric case
         if (elmV[iel]) {
           vecOut[rw] += vecIn[indV[iel]] * elmV[iel];
           vecOut[indV[iel]] += vecIn[rw] * elmV[iel];
         }
       }
-    } else
-      for (int iel = nel; iel--;)
-        if (elmV[iel])
+    } else {
+      for (int iel = nel; iel--;) {
+        if (elmV[iel]) {
           vecOut[rw] += vecIn[indV[iel]] * elmV[iel];
-
+        }
+      }
+    }
   } // loop over rows <<<
 }
 
@@ -145,8 +156,9 @@ void MatrixSparse::SortIndices(Bool_t valuesToo)
   TStopwatch sw;
   sw.Start();
   LOG(info) << "MatrixSparse:SortIndices >>";
-  for (int i = GetSize(); i--;)
+  for (int i = GetSize(); i--;) {
     GetRow(i)->SortIndices(valuesToo);
+  }
   sw.Stop();
   sw.Print();
   LOG(info) << "MatrixSparse:SortIndices <<";
@@ -175,15 +187,17 @@ void MatrixSparse::AddToRow(Int_t r, Double_t* valc, Int_t* indc, Int_t n)
   int ni = n;
   if (IsSymmetric()) {
     while (ni--) {
-      if (indc[ni] > r)
+      if (indc[ni] > r) {
         (*this)(indc[ni], r) += valc[ni];
-      else
+      } else {
         break; // use the fact that the indices are ranged in increasing order
+      }
     }
   }
 
-  if (ni < 0)
+  if (ni < 0) {
     return;
+  }
   VectorSparse* row = GetRowAdd(r);
   row->Add(valc, indc, ni + 1);
 }
@@ -193,8 +207,9 @@ Float_t MatrixSparse::GetDensity() const
 {
 
   Int_t nel = 0;
-  for (int i = GetSize(); i--;)
+  for (int i = GetSize(); i--;) {
     nel += GetRow(i)->GetNElems();
+  }
   int den = IsSymmetric() ? (GetSize() + 1) * GetSize() / 2 : GetSize() * GetSize();
   return float(nel) / den;
 }

--- a/Detectors/ITSMFT/MFT/alignment/src/MatrixSparse.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/MatrixSparse.cxx
@@ -1,0 +1,200 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file MatrixSparse.cxx
+
+#include <iomanip>
+#include <TStopwatch.h>
+
+#include "Framework/Logger.h"
+#include "MFTAlignment/MatrixSparse.h"
+
+using namespace o2::mft;
+
+ClassImp(MatrixSparse);
+
+//___________________________________________________________
+MatrixSparse::MatrixSparse(Int_t sz)
+  : MatrixSq(),
+    fVecs(0)
+{
+  fNcols = fNrows = sz;
+
+  fVecs = new VectorSparse*[sz];
+  for (int i = GetSize(); i--;)
+    fVecs[i] = new VectorSparse();
+}
+
+//___________________________________________________________
+MatrixSparse::MatrixSparse(const MatrixSparse& src)
+  : MatrixSq(src),
+    fVecs(0)
+{
+  fVecs = new VectorSparse*[src.GetSize()];
+  for (int i = GetSize(); i--;)
+    fVecs[i] = new VectorSparse(*src.GetRow(i));
+}
+
+//___________________________________________________________
+VectorSparse* MatrixSparse::GetRowAdd(Int_t ir)
+{
+  // get row, add if needed
+  if (ir >= fNrows) {
+    VectorSparse** arrv = new VectorSparse*[ir + 1];
+    for (int i = GetSize(); i--;)
+      arrv[i] = fVecs[i];
+    delete[] fVecs;
+    fVecs = arrv;
+    for (int i = GetSize(); i <= ir; i++)
+      fVecs[i] = new VectorSparse();
+    fNrows = ir + 1;
+    if (IsSymmetric() && fNcols < fNrows)
+      fNcols = fNrows;
+  }
+  return fVecs[ir];
+}
+
+//___________________________________________________________
+MatrixSparse& MatrixSparse::operator=(const MatrixSparse& src)
+{
+  if (this == &src)
+    return *this;
+  MatrixSq::operator=(src);
+
+  Clear();
+  fNcols = src.GetNCols();
+  fNrows = src.GetNRows();
+  SetSymmetric(src.IsSymmetric());
+  fVecs = new VectorSparse*[fNrows];
+  for (int i = fNrows; i--;)
+    fVecs[i] = new VectorSparse(*src.GetRow(i));
+  return *this;
+}
+
+//___________________________________________________________
+void MatrixSparse::Clear(Option_t*)
+{
+  for (int i = fNrows; i--;)
+    delete GetRow(i);
+  delete[] fVecs;
+  fNcols = fNrows = 0;
+}
+
+//___________________________________________________________
+void MatrixSparse::Print(Option_t* opt) const
+{
+  LOG(info) << "Sparse Matrix of size " << fNrows << " x " << fNcols;
+  if (IsSymmetric()) {
+    LOG(info) << " (Symmetric)\n";
+  }
+  for (int i = 0; i < fNrows; i++) {
+    VectorSparse* row = GetRow(i);
+    if (!row->GetNElems())
+      continue;
+    printf("%3d: ", i);
+    row->Print(opt);
+  }
+}
+
+//___________________________________________________________
+void MatrixSparse::MultiplyByVec(const Double_t* vecIn, Double_t* vecOut) const
+{
+  memset(vecOut, 0, GetSize() * sizeof(Double_t));
+
+  for (int rw = GetSize(); rw--;) { // loop over rows >>>
+    const VectorSparse* rowV = GetRow(rw);
+    Int_t nel = rowV->GetNElems();
+    if (!nel)
+      continue;
+
+    UShort_t* indV = rowV->GetIndices();
+    Double_t* elmV = rowV->GetElems();
+
+    if (IsSymmetric()) {
+      // treat diagonal term separately. If filled, it should be the last one
+      if (indV[--nel] == rw)
+        vecOut[rw] += vecIn[rw] * elmV[nel];
+      else
+        nel = rowV->GetNElems(); // diag elem was not filled
+
+      for (int iel = nel; iel--;) { // less element retrieval for symmetric case
+        if (elmV[iel]) {
+          vecOut[rw] += vecIn[indV[iel]] * elmV[iel];
+          vecOut[indV[iel]] += vecIn[rw] * elmV[iel];
+        }
+      }
+    } else
+      for (int iel = nel; iel--;)
+        if (elmV[iel])
+          vecOut[rw] += vecIn[indV[iel]] * elmV[iel];
+
+  } // loop over rows <<<
+}
+
+//___________________________________________________________
+void MatrixSparse::SortIndices(Bool_t valuesToo)
+{
+  TStopwatch sw;
+  sw.Start();
+  LOG(info) << "MatrixSparse:SortIndices >>";
+  for (int i = GetSize(); i--;)
+    GetRow(i)->SortIndices(valuesToo);
+  sw.Stop();
+  sw.Print();
+  LOG(info) << "MatrixSparse:SortIndices <<";
+}
+
+//___________________________________________________________
+void MatrixSparse::AddToRow(Int_t r, Double_t* valc, Int_t* indc, Int_t n)
+{
+  // for sym. matrix count how many elems to add have row >= col and assign excplicitly
+  // those which have row < col
+
+  // range in increasing order of indices
+  for (int i = n; i--;) {
+    for (int j = i; j >= 0; j--) {
+      if (indc[j] > indc[i]) { // swap
+        int ti = indc[i];
+        indc[i] = indc[j];
+        indc[j] = ti;
+        double tv = valc[i];
+        valc[i] = valc[j];
+        valc[j] = tv;
+      }
+    }
+  }
+
+  int ni = n;
+  if (IsSymmetric()) {
+    while (ni--) {
+      if (indc[ni] > r)
+        (*this)(indc[ni], r) += valc[ni];
+      else
+        break; // use the fact that the indices are ranged in increasing order
+    }
+  }
+
+  if (ni < 0)
+    return;
+  VectorSparse* row = GetRowAdd(r);
+  row->Add(valc, indc, ni + 1);
+}
+
+//___________________________________________________________
+Float_t MatrixSparse::GetDensity() const
+{
+
+  Int_t nel = 0;
+  for (int i = GetSize(); i--;)
+    nel += GetRow(i)->GetNElems();
+  int den = IsSymmetric() ? (GetSize() + 1) * GetSize() / 2 : GetSize() * GetSize();
+  return float(nel) / den;
+}

--- a/Detectors/ITSMFT/MFT/alignment/src/MatrixSq.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/MatrixSq.cxx
@@ -11,17 +11,25 @@
 
 /// @file MatrixSq.cxx
 
-#include <stdlib.h>
-#include <stdio.h>
 #include <iostream>
 
 #include "TClass.h"
 #include "TMath.h"
+
+#include "Framework/Logger.h"
 #include "MFTAlignment/MatrixSq.h"
 
 using namespace o2::mft;
 
 ClassImp(MatrixSq);
+
+//___________________________________________________________
+MatrixSq::MatrixSq(const MatrixSq& src)
+  : TMatrixDBase(src),
+    fSymmetric(src.fSymmetric)
+{
+  LOG(debug) << "copy ctor";
+}
 
 //___________________________________________________________
 MatrixSq& MatrixSq::operator=(const MatrixSq& src)

--- a/Detectors/ITSMFT/MFT/alignment/src/MatrixSq.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/MatrixSq.cxx
@@ -1,4 +1,3 @@
-
 // Copyright 2019-2020 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.

--- a/Detectors/ITSMFT/MFT/alignment/src/MatrixSq.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/MatrixSq.cxx
@@ -26,8 +26,9 @@ ClassImp(MatrixSq);
 //___________________________________________________________
 MatrixSq& MatrixSq::operator=(const MatrixSq& src)
 {
-  if (this == &src)
+  if (this == &src) {
     return *this;
+  }
   TMatrixDBase::operator=(src);
   fSymmetric = src.fSymmetric;
   return *this;
@@ -38,8 +39,9 @@ void MatrixSq::MultiplyByVec(const Double_t* vecIn, Double_t* vecOut) const
 {
   for (int i = GetSize(); i--;) {
     vecOut[i] = 0.0;
-    for (int j = GetSize(); j--;)
+    for (int j = GetSize(); j--;) {
       vecOut[i] += vecIn[j] * (*this)(i, j);
+    }
   }
 }
 
@@ -49,15 +51,21 @@ void MatrixSq::PrintCOO() const
   // get number of non-zero elements
   int nnz = 0;
   int sz = GetSize();
-  for (int ir = 0; ir < sz; ir++)
-    for (int ic = 0; ic < sz; ic++)
-      if (Query(ir, ic) != 0)
+  for (int ir = 0; ir < sz; ir++) {
+    for (int ic = 0; ic < sz; ic++) {
+      if (Query(ir, ic) != 0) {
         nnz++;
+      }
+    }
+  }
 
   printf("%d %d %d\n", sz, sz, nnz);
   double vl;
-  for (int ir = 0; ir < sz; ir++)
-    for (int ic = 0; ic < sz; ic++)
-      if ((vl = Query(ir, ic)) != 0)
+  for (int ir = 0; ir < sz; ir++) {
+    for (int ic = 0; ic < sz; ic++) {
+      if ((vl = Query(ir, ic)) != 0) {
         printf("%d %d %f\n", ir, ic, vl);
+      }
+    }
+  }
 }

--- a/Detectors/ITSMFT/MFT/alignment/src/MatrixSq.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/MatrixSq.cxx
@@ -1,0 +1,64 @@
+
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file MatrixSq.cxx
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <iostream>
+
+#include "TClass.h"
+#include "TMath.h"
+#include "MFTAlignment/MatrixSq.h"
+
+using namespace o2::mft;
+
+ClassImp(MatrixSq);
+
+//___________________________________________________________
+MatrixSq& MatrixSq::operator=(const MatrixSq& src)
+{
+  if (this == &src)
+    return *this;
+  TMatrixDBase::operator=(src);
+  fSymmetric = src.fSymmetric;
+  return *this;
+}
+
+//___________________________________________________________
+void MatrixSq::MultiplyByVec(const Double_t* vecIn, Double_t* vecOut) const
+{
+  for (int i = GetSize(); i--;) {
+    vecOut[i] = 0.0;
+    for (int j = GetSize(); j--;)
+      vecOut[i] += vecIn[j] * (*this)(i, j);
+  }
+}
+
+//___________________________________________________________
+void MatrixSq::PrintCOO() const
+{
+  // get number of non-zero elements
+  int nnz = 0;
+  int sz = GetSize();
+  for (int ir = 0; ir < sz; ir++)
+    for (int ic = 0; ic < sz; ic++)
+      if (Query(ir, ic) != 0)
+        nnz++;
+
+  printf("%d %d %d\n", sz, sz, nnz);
+  double vl;
+  for (int ir = 0; ir < sz; ir++)
+    for (int ic = 0; ic < sz; ic++)
+      if ((vl = Query(ir, ic)) != 0)
+        printf("%d %d %f\n", ir, ic, vl);
+}

--- a/Detectors/ITSMFT/MFT/alignment/src/MillePede2.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/MillePede2.cxx
@@ -843,7 +843,7 @@ int MillePede2::GlobalFit(double* par, double* error, double* pull)
       fChi2CutFactor = TMath::Sqrt(fChi2CutFactor);
       if (fChi2CutFactor < 1.2 * fChi2CutRef) {
         fChi2CutFactor = fChi2CutRef;
-        // RRR	fIter = fMaxIter - 1;  // Last iteration
+        // fIter = fMaxIter - 1; // RRR // Last iteration
       }
     }
     fIter++;

--- a/Detectors/ITSMFT/MFT/alignment/src/MillePede2.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/MillePede2.cxx
@@ -197,28 +197,35 @@ int MillePede2::InitMille(int nGlo, const int nLoc,
     fkReGroup = regroup;
     int ng = 0; // recalculate N globals
     int maxPID = -1;
-    for (int i = 0; i < nGlo; i++)
+    for (int i = 0; i < nGlo; i++) {
       if (regroup[i] >= 0) {
         ng++;
-        if (regroup[i] > maxPID)
+        if (regroup[i] > maxPID) {
           maxPID = regroup[i];
+        }
       }
+    }
     maxPID++;
     LOGF(info,
          "MillePede2 - Regrouping is requested: from %d raw to %d formal globals grouped to %d real globals",
          nGlo, ng, maxPID);
     nGlo = maxPID;
   }
-  if (nLoc > 0)
+  if (nLoc > 0) {
     fNLocPar = nLoc;
-  if (nGlo > 0)
+  }
+  if (nGlo > 0) {
     fNGloPar = nGlo;
-  if (lResCutInit > 0)
+  }
+  if (lResCutInit > 0) {
     fResCutInit = lResCutInit;
-  if (lResCut > 0)
+  }
+  if (lResCut > 0) {
     fResCut = lResCut;
-  if (lNStdDev > 0)
+  }
+  if (lNStdDev > 0) {
     fNStdDev = lNStdDev;
+  }
   LOGF(info, "MillePede2 - NLoc: %d NGlo: %d", fNLocPar, fNGloPar);
 
   fNGloSize = fNGloPar;
@@ -226,8 +233,9 @@ int MillePede2::InitMille(int nGlo, const int nLoc,
   if (fgIsMatGloSparse) {
     fMatCGlo = new MatrixSparse(fNGloPar);
     fMatCGlo->SetSymmetric(true);
-  } else
+  } else {
     fMatCGlo = new SymMatrix(fNGloPar);
+  }
 
   fFillIndex = std::vector<int>(fNGloPar);
   fFillValue = std::vector<double>(fNGloPar);
@@ -266,8 +274,9 @@ bool MillePede2::InitChi2Storage(const int nEntriesAutoSave)
     LOG(warning) << "MillePede2::InitChi2Storage() - output tree already initialized";
     return false;
   }
-  if (fRecChi2File == nullptr)
+  if (fRecChi2File == nullptr) {
     fRecChi2File = new TFile(GetRecChi2FName(), "recreate", "", 505);
+  }
   if ((!fRecChi2File) || (fRecChi2File->IsZombie())) {
     LOGF(error,
          "MillePede2::InitChi2Storage() - failed to initialise chi2 storage file %s!",
@@ -319,32 +328,36 @@ void MillePede2::SetLocalEquation(std::vector<double>& dergb, std::vector<double
 
   // write data of single measurement
   if (lSigma <= 0.0) { // If parameter is fixed, then no equation
-    for (int i = fNLocPar; i--;)
+    for (int i = fNLocPar; i--;) {
       derlc[i] = 0.0;
-    for (int i = fNGloParIni; i--;)
+    }
+    for (int i = fNGloParIni; i--;) {
       dergb[i] = 0.0;
+    }
     return;
   }
 
   fRecord->AddResidual(lMeas);
 
   // Retrieve local param interesting indices
-  for (int i = 0; i < fNLocPar; i++)
+  for (int i = 0; i < fNLocPar; i++) {
     if (!IsZero(derlc[i])) {
       fRecord->AddIndexValue(i, derlc[i]);
       derlc[i] = 0.0;
     }
+  }
 
   fRecord->AddWeight(1.0 / lSigma / lSigma);
 
   // Idem for global parameters
-  for (int i = 0; i < fNGloParIni; i++)
+  for (int i = 0; i < fNGloParIni; i++) {
     if (!IsZero(dergb[i])) {
       fRecord->AddIndexValue(i, dergb[i]);
       dergb[i] = 0.0;
       int idrg = GetRGId(i);
       fRecord->MarkGroup(idrg < 0 ? -1 : fParamGrID[i]);
     }
+  }
 }
 
 //_____________________________________________________________________________
@@ -364,32 +377,36 @@ void MillePede2::SetLocalEquation(std::vector<int>& indgb, std::vector<double>& 
   SetRecord(fRecordWriter->getRecord());
 
   if (lSigma <= 0.0) { // If parameter is fixed, then no equation
-    for (int i = nlc; i--;)
+    for (int i = nlc; i--;) {
       derlc[i] = 0.0;
-    for (int i = ngb; i--;)
+    }
+    for (int i = ngb; i--;) {
       dergb[i] = 0.0;
+    }
     return;
   }
 
   fRecord->AddResidual(lMeas);
 
   // Retrieve local param interesting indices
-  for (int i = 0; i < nlc; i++)
+  for (int i = 0; i < nlc; i++) {
     if (!IsZero(derlc[i])) {
       fRecord->AddIndexValue(indlc[i], derlc[i]);
       derlc[i] = 0.;
       indlc[i] = 0;
     }
+  }
 
   fRecord->AddWeight(1. / lSigma / lSigma);
 
   // Idem for global parameters
-  for (int i = 0; i < ngb; i++)
+  for (int i = 0; i < ngb; i++) {
     if (!IsZero(dergb[i])) {
       fRecord->AddIndexValue(indgb[i], dergb[i]);
       dergb[i] = 0.;
       indgb[i] = 0;
     }
+  }
 }
 
 //_____________________________________________________________________________
@@ -410,12 +427,15 @@ void MillePede2::SetGlobalConstraint(const std::vector<double>& dergb,
   fRecord->Reset();
   fRecord->AddResidual(val);
   fRecord->AddWeight(sigma);
-  for (int i = 0; i < fNGloParIni; i++)
-    if (!IsZero(dergb[i]))
+  for (int i = 0; i < fNGloParIni; i++) {
+    if (!IsZero(dergb[i])) {
       fRecord->AddIndexValue(i, dergb[i]);
+    }
+  }
   fNGloConstraints++;
-  if (IsZero(sigma))
+  if (IsZero(sigma)) {
     fNLagrangeConstraints++;
+  }
   if (doPrint) {
     LOG(info) << "MillePede2::SetGlobalConstraint() - new constraints added";
   }
@@ -441,12 +461,15 @@ void MillePede2::SetGlobalConstraint(const std::vector<int>& indgb,
   fRecord->Reset();
   fRecord->AddResidual(val);
   fRecord->AddWeight(sigma); // dummy
-  for (int i = 0; i < ngb; i++)
-    if (!IsZero(dergb[i]))
+  for (int i = 0; i < ngb; i++) {
+    if (!IsZero(dergb[i])) {
       fRecord->AddIndexValue(indgb[i], dergb[i]);
+    }
+  }
   fNGloConstraints++;
-  if (IsZero(sigma))
+  if (IsZero(sigma)) {
     fNLagrangeConstraints++;
+  }
   if (doPrint) {
     LOG(info) << "MillePede2::SetGlobalConstraint() - new constraints added";
   }
@@ -503,20 +526,24 @@ int MillePede2::LocalFit(std::vector<double>& localParams)
       nrefSize = 2 * (nPoints + 1);
       tmpA = refLoc;
       refLoc = new int[nrefSize];
-      if (tmpA)
+      if (tmpA) {
         memcpy(refLoc, tmpA, nPoints * sizeof(int));
+      }
       tmpA = refGlo;
       refGlo = new int[nrefSize];
-      if (tmpA)
+      if (tmpA) {
         memcpy(refGlo, tmpA, nPoints * sizeof(int));
+      }
       tmpA = nrefLoc;
       nrefLoc = new int[nrefSize];
-      if (tmpA)
+      if (tmpA) {
         memcpy(nrefLoc, tmpA, nPoints * sizeof(int));
+      }
       tmpA = nrefGlo;
       nrefGlo = new int[nrefSize];
-      if (tmpA)
+      if (tmpA) {
         memcpy(nrefGlo, tmpA, nPoints * sizeof(int));
+      }
     }
 
     refLoc[nPoints] = ++cnt;
@@ -537,22 +564,25 @@ int MillePede2::LocalFit(std::vector<double>& localParams)
 
     nPoints++;
   }
-  if (fMinRecordLength > 0 && nPoints < fMinRecordLength)
+  if (fMinRecordLength > 0 && nPoints < fMinRecordLength) {
     return 0; // ignore
+  }
 
   double vl;
 
   double gloWgh = fRunWgh;
-  if (fUseRecordWeight)
+  if (fUseRecordWeight) {
     gloWgh *= fRecord->GetWeight(); // global weight for this set
+  }
   int maxLocUsed = 0;
 
   for (int ip = nPoints; ip--;) { // Transfer the measurement records to matrices
     double resid = fRecord->GetValue(refLoc[ip] - 1);
     double weight = fRecord->GetValue(refGlo[ip] - 1) * gloWgh;
     int odd = (ip & 0x1);
-    if (fWghScl[odd] > 0)
+    if (fWghScl[odd] > 0) {
       weight *= fWghScl[odd];
+    }
     double* derLoc = fRecord->GetValue() + refLoc[ip];
     double* derGlo = fRecord->GetValue() + refGlo[ip];
     int* indLoc = fRecord->GetIndex() + refLoc[ip];
@@ -563,28 +593,33 @@ int MillePede2::LocalFit(std::vector<double>& localParams)
       // if regrouping was requested, do it here
       if (fkReGroup.size()) {
         int idtmp = fkReGroup[indGlo[i]];
-        if (idtmp == kFixParID)
+        if (idtmp == kFixParID) {
           indGlo[i] = kFixParID; // fixed param in regrouping
-        else
+        } else {
           indGlo[i] = idtmp;
+        }
       }
 
       int iID = indGlo[i]; // Global param indice
-      if (iID < 0 || fSigmaPar[iID] <= 0.)
+      if (iID < 0 || fSigmaPar[iID] <= 0.) {
         continue; // fixed parameter RRRCheck
-      if (fIsLinear[iID])
+      }
+      if (fIsLinear[iID]) {
         resid -= derGlo[i] * (fInitPar[iID] + fDeltaPar[iID]); // linear parameter
-      else
+      } else {
         resid -= derGlo[i] * fDeltaPar[iID]; // nonlinear parameter
+      }
     }
 
     // Symmetric matrix, don't bother j>i coeffs
     for (int i = nrefLoc[ip]; i--;) { // Fill local matrix and vector
       fVecBLoc[indLoc[i]] += weight * resid * derLoc[i];
-      if (indLoc[i] > maxLocUsed)
+      if (indLoc[i] > maxLocUsed) {
         maxLocUsed = indLoc[i];
-      for (int j = i + 1; j--;)
+      }
+      for (int j = i + 1; j--;) {
         matCLoc(indLoc[i], indLoc[j]) += weight * derLoc[i] * derLoc[j];
+      }
     }
 
   } // end of the transfer of the measurement record to matrices
@@ -623,32 +658,37 @@ int MillePede2::LocalFit(std::vector<double>& localParams)
     double resid = fRecord->GetValue(refLoc[ip] - 1);
     double weight = fRecord->GetValue(refGlo[ip] - 1) * gloWgh;
     int odd = (ip & 0x1);
-    if (fWghScl[odd] > 0)
+    if (fWghScl[odd] > 0) {
       weight *= fWghScl[odd];
+    }
     double* derLoc = fRecord->GetValue() + refLoc[ip];
     double* derGlo = fRecord->GetValue() + refGlo[ip];
     int* indLoc = fRecord->GetIndex() + refLoc[ip];
     int* indGlo = fRecord->GetIndex() + refGlo[ip];
 
     // Suppress local and global contribution in residuals;
-    for (int i = nrefLoc[ip]; i--;)
-      resid -= derLoc[i] * fVecBLoc[indLoc[i]]; // local part
+    for (int i = nrefLoc[ip]; i--;) {
+      resid -= derLoc[i] * fVecBLoc[indLoc[i]];
+    } // local part
 
     for (int i = nrefGlo[ip]; i--;) { // global part
       int iID = indGlo[i];
-      if (iID < 0 || fSigmaPar[iID] <= 0.)
-        continue; // fixed parameter RRRCheck
-      if (fIsLinear[iID])
+      if (iID < 0 || fSigmaPar[iID] <= 0.) {
+        continue;
+      } // fixed parameter RRRCheck
+      if (fIsLinear[iID]) {
         resid -= derGlo[i] * (fInitPar[iID] + fDeltaPar[iID]); // linear parameter
-      else
+      } else {
         resid -= derGlo[i] * fDeltaPar[iID]; // nonlinear parameter
+      }
     }
 
     // reject the track if the residual is too large (outlier)
     double absres = TMath::Abs(resid);
     if ((absres >= fResCutInit && fIter == 1) || (absres >= fResCut && fIter > 1)) {
-      if (fLocFitAdd)
+      if (fLocFitAdd) {
         fNLocFitsRejected++;
+      }
       LOGF(info, "MillePede2 - reject res %+e in record %5ld ", resid, fCurrRecDataID); // A.R. comment
       return 0;
     }
@@ -665,10 +705,12 @@ int MillePede2::LocalFit(std::vector<double>& localParams)
 
   if (fNStdDev != 0 && nDoF > 0 && lChi2 > Chi2DoFLim(fNStdDev, nDoF) * fChi2CutFactor) { // check final chi2
     fIsChi2BelowLimit = false;
-    if (GetCurrentIteration() == 1 && fTreeChi2)
+    if (GetCurrentIteration() == 1 && fTreeChi2) {
       fTreeChi2->Fill();
-    if (fLocFitAdd)
+    }
+    if (fLocFitAdd) {
       fNLocFitsRejected++;
+    }
     LOGF(debug, "MillePede2 - reject chi2 %+e record %5ld: (nDOF %d)", lChi2, fCurrRecDataID, nDoF); // A.R. comment
     // fRecord->Print();                                                                                // A.R. comment
     return 0;
@@ -691,8 +733,9 @@ int MillePede2::LocalFit(std::vector<double>& localParams)
     double resid = fRecord->GetValue(refLoc[ip] - 1);
     double weight = fRecord->GetValue(refGlo[ip] - 1) * gloWgh;
     int odd = (ip & 0x1);
-    if (fWghScl[odd] > 0)
+    if (fWghScl[odd] > 0) {
       weight *= fWghScl[odd];
+    }
     double* derLoc = fRecord->GetValue() + refLoc[ip];
     double* derGlo = fRecord->GetValue() + refGlo[ip];
     int* indLoc = fRecord->GetIndex() + refLoc[ip];
@@ -700,29 +743,34 @@ int MillePede2::LocalFit(std::vector<double>& localParams)
 
     for (int i = nrefGlo[ip]; i--;) { // suppress the global part
       int iID = indGlo[i];            // Global param indice
-      if (iID < 0 || fSigmaPar[iID] <= 0.)
-        continue; // fixed parameter RRRCheck
-      if (fIsLinear[iID])
+      if (iID < 0 || fSigmaPar[iID] <= 0.) {
+        continue;
+      } // fixed parameter RRRCheck
+      if (fIsLinear[iID]) {
         resid -= derGlo[i] * (fInitPar[iID] + fDeltaPar[iID]); // linear parameter
-      else
+      } else {
         resid -= derGlo[i] * fDeltaPar[iID]; // nonlinear parameter
+      }
     }
 
     for (int ig = nrefGlo[ip]; ig--;) {
       int iIDg = indGlo[ig]; // Global param indice (the matrix line)
-      if (iIDg < 0 || fSigmaPar[iIDg] <= 0.)
-        continue; // fixed parameter RRRCheck
-      if (fLocFitAdd)
-        fVecBGlo[iIDg] += weight * resid * derGlo[ig]; //!!!
-      else
-        fVecBGlo[iIDg] -= weight * resid * derGlo[ig]; //!!!
+      if (iIDg < 0 || fSigmaPar[iIDg] <= 0.) {
+        continue;
+      } // fixed parameter RRRCheck
+      if (fLocFitAdd) {
+        fVecBGlo[iIDg] += weight * resid * derGlo[ig];
+      } else {
+        fVecBGlo[iIDg] -= weight * resid * derGlo[ig];
+      }
 
       // First of all, the global/global terms (exactly like local matrix)
       int nfill = 0;
       for (int jg = ig + 1; jg--;) { // matCGlo is symmetric by construction
         int jIDg = indGlo[jg];
-        if (jIDg < 0 || fSigmaPar[jIDg] <= 0.)
-          continue; // fixed parameter RRRCheck
+        if (jIDg < 0 || fSigmaPar[jIDg] <= 0.) {
+          continue;
+        } // fixed parameter RRRCheck
         if (!IsZero(vl = weight * derGlo[ig] * derGlo[jg])) {
           fFillIndex[nfill] = jIDg;
           fFillValue[nfill++] = fLocFitAdd ? vl : -vl;
@@ -736,15 +784,17 @@ int MillePede2::LocalFit(std::vector<double>& localParams)
       int iCIDg = fGlo2CGlo[iIDg]; // compressed Index of index
       if (iCIDg == -1) {
         double* rowGL = matCGloLoc(nGloInFit);
-        for (int k = maxLocUsed; k--;)
-          rowGL[k] = 0.0; // reset the row
+        for (int k = maxLocUsed; k--;) {
+          rowGL[k] = 0.0;
+        } // reset the row
         iCIDg = fGlo2CGlo[iIDg] = nGloInFit;
         fCGlo2Glo[nGloInFit++] = iIDg;
       }
 
       double* rowGLIDg = matCGloLoc(iCIDg);
-      for (int il = nrefLoc[ip]; il--;)
+      for (int il = nrefLoc[ip]; il--;) {
         rowGLIDg[indLoc[il]] += weight * derGlo[ig] * derLoc[il];
+      }
       fProcPnt[iIDg] += fLocFitAdd ? 1 : -1; // update counter
     }
   } // end of Update matrices
@@ -767,10 +817,12 @@ int MillePede2::LocalFit(std::vector<double>& localParams)
     vl = 0;
     double* rowGLIDg = matCGloLoc(iCIDg);
     for (int kl = 0; kl < maxLocUsed; kl++)
-      if (rowGLIDg[kl])
+      if (rowGLIDg[kl]) {
         vl += rowGLIDg[kl] * fVecBLoc[kl];
-    if (!IsZero(vl))
+      }
+    if (!IsZero(vl)) {
       fVecBGlo[iIDg] -= fLocFitAdd ? vl : -vl;
+    }
 
     int nfill = 0;
     for (int jCIDg = 0; jCIDg <= iCIDg; jCIDg++) {
@@ -780,15 +832,18 @@ int MillePede2::LocalFit(std::vector<double>& localParams)
       double* rowGLJDg = matCGloLoc(jCIDg);
       for (int kl = 0; kl < maxLocUsed; kl++) {
         // diag terms
-        if ((!IsZero(vll = rowGLIDg[kl] * rowGLJDg[kl])))
+        if ((!IsZero(vll = rowGLIDg[kl] * rowGLJDg[kl]))) {
           vl += matCLoc.QueryDiag(kl) * vll;
+        }
         //
         // off-diag terms
         for (int ll = 0; ll < kl; ll++) {
-          if (!IsZero(vll = rowGLIDg[kl] * rowGLJDg[ll]))
+          if (!IsZero(vll = rowGLIDg[kl] * rowGLJDg[ll])) {
             vl += matCLoc(kl, ll) * vll;
-          if (!IsZero(vll = rowGLIDg[ll] * rowGLJDg[kl]))
+          }
+          if (!IsZero(vll = rowGLIDg[ll] * rowGLJDg[kl])) {
             vl += matCLoc(kl, ll) * vll;
+          }
         }
       }
       if (!IsZero(vl)) {
@@ -814,8 +869,9 @@ int MillePede2::LocalFit(std::vector<double>& localParams)
   }
   //
   //---------------------------------------------------- <<<
-  if (GetCurrentIteration() == 1 && fTreeChi2)
+  if (GetCurrentIteration() == 1 && fTreeChi2) {
     fTreeChi2->Fill();
+  }
   return 1;
 }
 
@@ -836,8 +892,9 @@ int MillePede2::GlobalFit(double* par, double* error, double* pull)
   while (fIter <= fMaxIter) {
     //
     res = GlobalFitIteration();
-    if (!res)
+    if (!res) {
       break;
+    }
     //
     if (!IsZero(fChi2CutFactor - fChi2CutRef)) {
       fChi2CutFactor = TMath::Sqrt(fChi2CutFactor);
@@ -851,20 +908,27 @@ int MillePede2::GlobalFit(double* par, double* error, double* pull)
 
   sw.Stop();
   LOGF(info, "MillePede2 - Global fit %s, CPU time: %.1f", res ? "Converged" : "Failed", sw.CpuTime());
-  if (!res)
+  if (!res) {
     return 0;
+  }
 
-  if (par)
-    for (int i = fNGloParIni; i--;)
+  if (par) {
+    for (int i = fNGloParIni; i--;) {
       par[i] = GetFinalParam(i);
+    }
+  }
 
   if (fGloSolveStatus == kInvert) { // errors on params are available
-    if (error)
-      for (int i = fNGloParIni; i--;)
+    if (error) {
+      for (int i = fNGloParIni; i--;) {
         error[i] = GetFinalError(i);
-    if (pull)
-      for (int i = fNGloParIni; i--;)
+      }
+    }
+    if (pull) {
+      for (int i = fNGloParIni; i--;) {
         pull[i] = GetPull(i);
+      }
+    }
   }
 
   return 1;
@@ -902,10 +966,12 @@ int MillePede2::GlobalFitIteration()
   fNLagrangeConstraints = 0;
   for (int i = 0; i < fNGloConstraints; i++) {
     ReadRecordConstraint(i);
-    if (!fConstraintsRecReader->isReadEntryOk())
+    if (!fConstraintsRecReader->isReadEntryOk()) {
       continue;
-    if (IsZero(fRecord->GetValue(1)))
+    }
+    if (IsZero(fRecord->GetValue(1))) {
       fNLagrangeConstraints++; // exact constraint (no error) -> Lagrange multiplier
+    }
   }
 
   // if needed, readjust the size of the global vector (for matrices this is done automatically)
@@ -926,8 +992,9 @@ int MillePede2::GlobalFitIteration()
   ndr = last - first;
 
   LOGF(info, "MillePede2 - Building the Global matrix from data records %ld : %ld", first, last);
-  if (ndr < 1)
+  if (ndr < 1) {
     return 0;
+  }
 
   TStopwatch swt;
   swt.Start();
@@ -935,12 +1002,14 @@ int MillePede2::GlobalFitIteration()
   for (long i = 0; i < ndr; i++) {
     long iev = i + first;
     ReadRecordData(iev);
-    if (!IsRecordAcceptable() || !fRecordReader->isReadEntryOk())
+    if (!IsRecordAcceptable() || !fRecordReader->isReadEntryOk()) {
       continue;
+    }
     std::vector<double> emptyLocalParams = {};
     LocalFit(emptyLocalParams);
-    if ((i % int(0.2 * ndr)) == 0)
+    if ((i % int(0.2 * ndr)) == 0) {
       printf("%.1f%% of local fits done\n", double(100. * i) / ndr);
+    }
   }
   swt.Stop();
   LOGF(info, "MillePede2 - %ld local fits done: ", ndr);
@@ -970,14 +1039,16 @@ int MillePede2::GlobalFitIteration()
 
     for (int i = fNGloPar; i--;) { // Reset row and column of fixed params and add 1/sig^2 to free ones
       int grID = fParamGrID[i];
-      if (grID < 0)
+      if (grID < 0) {
         continue; // not in the group
+      }
 
       if (grID != grIDold) {                                        // starting new group
         if (grIDold >= 0) {                                         // decide if the group has enough statistics
           if (oldMin < fMinPntValid && oldMax < 2 * fMinPntValid) { // suppress group
-            for (int iold = oldStart; iold > i; iold--)
+            for (int iold = oldStart; iold > i; iold--) {
               fProcPnt[iold] = 0;
+            }
             bool fnd = false; // check if the group is already accounted
             for (int j = nFixedGroups; j--;)
               if (fixGroups[j] == grIDold) {
@@ -998,21 +1069,25 @@ int MillePede2::GlobalFitIteration()
         oldMin = 1.e20;
         oldMax = -1.e20;
       }
-      if (oldMin > fProcPnt[i])
+      if (oldMin > fProcPnt[i]) {
         oldMin = fProcPnt[i];
-      if (oldMax < fProcPnt[i])
+      }
+      if (oldMax < fProcPnt[i]) {
         oldMax = fProcPnt[i];
+      }
     }
     // extra check for the last group
     if (grIDold >= 0 && oldMin < fMinPntValid && oldMax < 2 * fMinPntValid) { // suppress group
-      for (int iold = oldStart; iold--;)
+      for (int iold = oldStart; iold--;) {
         fProcPnt[iold] = 0;
+      }
       bool fnd = false; // check if the group is already accounted
-      for (int j = nFixedGroups; j--;)
+      for (int j = nFixedGroups; j--;) {
         if (fixGroups[j] == grIDold) {
           fnd = true;
           break;
         }
+      }
       if (!fnd) {
         if (nFixedGroups >= fixArrSize) {
           fixArrSize *= 2;
@@ -1028,12 +1103,15 @@ int MillePede2::GlobalFitIteration()
     for (long i = 0; i < ndr; i++) {
       long iev = i + first;
       ReadRecordData(iev);
-      if (!IsRecordAcceptable() || !fRecordReader->isReadEntryOk())
+      if (!IsRecordAcceptable() || !fRecordReader->isReadEntryOk()) {
         continue;
+      }
       bool suppr = false;
-      for (int ifx = nFixedGroups; ifx--;)
-        if (fRecord->IsGroupPresent(fixGroups[ifx]))
+      for (int ifx = nFixedGroups; ifx--;) {
+        if (fRecord->IsGroupPresent(fixGroups[ifx])) {
           suppr = true;
+        }
+      }
       if (suppr) {
         std::vector<double> emptyLocalParams = {};
         LocalFit(emptyLocalParams);
@@ -1062,19 +1140,22 @@ int MillePede2::GlobalFitIteration()
       matCGlo.DiagElem(i) = 1.;
       // float(fNLocEquations*fNLocEquations);
       // matCGlo.DiagElem(i) = float(fNLocEquations*fNLocEquations);
-    } else
+    } else {
       matCGlo.DiagElem(i) += (fgWeightSigma ? fProcPnt[i] : 1.) / (fSigmaPar[i] * fSigmaPar[i]);
+    }
   }
 
-  for (int i = fNGloPar; i--;)
+  for (int i = fNGloPar; i--;) {
     fDiagCGlo[i] = matCGlo.QueryDiag(i); // save the diagonal elements
+  }
 
   // add constraint equations
   int nVar = fNGloPar; // Current size of global matrix
   for (int i = 0; i < fNGloConstraints; i++) {
     ReadRecordConstraint(i);
-    if (!fConstraintsRecReader->isReadEntryOk())
+    if (!fConstraintsRecReader->isReadEntryOk()) {
       continue;
+    }
     double val = fRecord->GetValue(0);
     double sig = fRecord->GetValue(1);
     int* indV = fRecord->GetIndex() + 2;
@@ -1084,8 +1165,9 @@ int MillePede2::GlobalFitIteration()
     if (fkReGroup.size()) {
       for (int jp = csize; jp--;) {
         int idp = indV[jp];
-        if (fkReGroup[idp] < 0)
+        if (fkReGroup[idp] < 0) {
           LOGF(fatal, "MillePede2 - Constain is requested for suppressed parameter #%d", indV[jp]);
+        }
         indV[jp] = idp;
       }
     }
@@ -1094,9 +1176,9 @@ int MillePede2::GlobalFitIteration()
     int nSuppressed = 0;
     int maxStat = 1;
     for (int j = csize; j--;) {
-      if (fProcPnt[indV[j]] < 1)
+      if (fProcPnt[indV[j]] < 1) {
         nSuppressed++;
-      else {
+      } else {
         maxStat = TMath::Max(maxStat, fProcPnt[indV[j]]);
       }
     }
@@ -1114,8 +1196,9 @@ int MillePede2::GlobalFitIteration()
     }
 
     // account for already accumulated corrections
-    for (int j = csize; j--;)
+    for (int j = csize; j--;) {
       val -= der[j] * (fInitPar[indV[j]] + fDeltaPar[indV[j]]);
+    }
 
     if (sig > 0) { // this is a gaussian constriant: no Lagrange multipliers are added
 
@@ -1125,21 +1208,24 @@ int MillePede2::GlobalFitIteration()
         for (int ic = 0; ic <= ir; ic++) { // matrix is symmetric
           int jID = indV[ic];
           double vl = der[ir] * der[ic] * sig2i;
-          if (!IsZero(vl))
+          if (!IsZero(vl)) {
             matCGlo(iID, jID) += vl;
+          }
         }
         fVecBGlo[iID] += val * der[ir] * sig2i;
       }
     } else { // this is exact constriant:  Lagrange multipliers must be added
       for (int j = csize; j--;) {
         int jID = indV[j];
-        if (fProcPnt[jID] < 1)
-          continue;                                          // this parameter was fixed, don't put it into constraint
+        if (fProcPnt[jID] < 1) { // this parameter was fixed, don't put it into constraint
+          continue;
+        }
         matCGlo(nVar, jID) = float(fNLocEquations) * der[j]; // fMatCGlo is symmetric, only lower triangle is filled
       }
 
-      if (matCGlo.QueryDiag(nVar))
+      if (matCGlo.QueryDiag(nVar)) {
         matCGlo.DiagElem(nVar) = 0.0;
+      }
       fVecBGlo[nVar++] = float(fNLocEquations) * val; // RS ? should we use here fNLocFits ?
       fConstrUsed[i] = true;
     }
@@ -1184,8 +1270,9 @@ int MillePede2::GlobalFitIteration()
   printf("#Equation before step %d\n", fIter);
   fMatCGlo->Print("10");
   printf("#RHS/STAT : NGlo:%d NGloSize:%d\n", fNGloPar, fNGloSize);
-  for (int i = 0; i < fNGloSize; i++)
+  for (int i = 0; i < fNGloSize; i++) {
     printf("%d %+.10f %d\n", i, fVecBGlo[i], fProcPnt[i]);
+  }
   //
   dup2(defoutB, 1);
   close(slvDumpB);
@@ -1202,8 +1289,9 @@ int MillePede2::GlobalFitIteration()
   printf("#Matrix after step %d\n", fIter);
   fMatCGlo->Print("10");
   printf("#RHS/STAT : NGlo:%d NGloSize:%d\n", fNGloPar, fNGloSize);
-  for (int i = 0; i < fNGloSize; i++)
+  for (int i = 0; i < fNGloSize; i++) {
     printf("%d %+.10f %d\n", i, fVecBGlo[i], fProcPnt[i]);
+  }
   //
   dup2(defoutA, 1);
   close(slvDumpA);
@@ -1219,8 +1307,9 @@ int MillePede2::GlobalFitIteration()
   if (fGloSolveStatus == kFailed)
     return 0;
   //
-  for (int i = fNGloPar; i--;)
-    fDeltaPar[i] += fVecBGlo[i]; // Update global parameters values (for iterations)
+  for (int i = fNGloPar; i--;) { // Update global parameters values (for iterations)
+    fDeltaPar[i] += fVecBGlo[i];
+  }
 
 #ifdef _DUMP_EQ_AFTER_
   const char* faildumpA = Form("mp2eq_after%d.dat", fIter);
@@ -1234,8 +1323,9 @@ int MillePede2::GlobalFitIteration()
     dup2(slvDumpA, 1);
     printf("Solving%d for %d params\n", fIter, fNGloSize);
     matCGlo.Print("10");
-    for (int i = 0; i < fNGloSize; i++)
+    for (int i = 0; i < fNGloSize; i++) {
       printf("b%2d : %+.10f\n", i, fVecBGlo[i]);
+    }
   }
   dup2(defoutA, 1);
   close(slvDumpA);
@@ -1264,15 +1354,17 @@ int MillePede2::SolveGlobalMatEq()
 
   if (!fgIsMatGloSparse) {
     if (fNLagrangeConstraints == 0) { // pos-def systems are faster to solve by Cholesky
-      if (((SymMatrix*)fMatCGlo)->SolveChol(fVecBGlo.data(), fgInvChol))
+      if (((SymMatrix*)fMatCGlo)->SolveChol(fVecBGlo.data(), fgInvChol)) {
         return fgInvChol ? kInvert : kNoInversion;
-      else
+      } else {
         LOG(warning) << "MillePede2 - Solution of Global Dense System by Cholesky failed, trying Gaussian Elimiation";
+      }
     }
-    if (((SymMatrix*)fMatCGlo)->SolveSpmInv(fVecBGlo.data(), true))
+    if (((SymMatrix*)fMatCGlo)->SolveSpmInv(fVecBGlo.data(), true)) {
       return kInvert;
-    else
+    } else {
       LOG(warning) << "MillePede2 - Solution of Global Dense System by Gaussian Elimination failed, trying iterative methods";
+    }
   }
   // try to solve by minres
   TVectorD sol(fNGloSize);
@@ -1282,12 +1374,15 @@ int MillePede2::SolveGlobalMatEq()
     return kFailed;
 
   bool res = false;
-  if (fgIterSol == MinResSolve::kSolMinRes)
+  if (fgIterSol == MinResSolve::kSolMinRes) {
     res = slv->SolveMinRes(sol, fgMinResCondType, fgMinResMaxIter, fgMinResTol);
-  else if (fgIterSol == MinResSolve::kSolFGMRes)
-    res = slv->SolveFGMRES(sol, fgMinResCondType, fgMinResMaxIter, fgMinResTol, fgNKrylovV);
-  else
-    LOGF(warning, "MillePede2 - Undefined Iteritive Solver ID=%d, only %d are defined", fgIterSol, MinResSolve::kNSolvers);
+  } else {
+    if (fgIterSol == MinResSolve::kSolFGMRes) {
+      res = slv->SolveFGMRES(sol, fgMinResCondType, fgMinResMaxIter, fgMinResTol, fgNKrylovV);
+    } else {
+      LOGF(warning, "MillePede2 - Undefined Iteritive Solver ID=%d, only %d are defined", fgIterSol, MinResSolve::kNSolvers);
+    }
+  }
 
   if (!res) {
     const char* faildump = "fgmr_failed.dat";
@@ -1304,19 +1399,22 @@ int MillePede2::SolveGlobalMatEq()
       printf("#Dump of matrix:\n");
       fMatCGlo->Print("10");
       printf("#Dump of RHS:\n");
-      for (int i = 0; i < fNGloSize; i++)
+      for (int i = 0; i < fNGloSize; i++) {
         printf("%d %+.10f\n", i, fVecBGlo[i]);
+      }
       dup2(defout, 1);
       close(slvDump);
       close(defout);
       printf("#Dumped failed matrix and RHS to %s\n", faildump);
-    } else
+    } else {
       LOG(warning) << "MillePede2 - Failed on file open for matrix dumping";
+    }
     close(defout);
     return kFailed;
   }
-  for (int i = fNGloSize; i--;)
+  for (int i = fNGloSize; i--;) {
     fVecBGlo[i] = sol[i];
+  }
 
   return kNoInversion;
 }
@@ -1367,15 +1465,17 @@ int MillePede2::SetIterations(const double lChi2CutFac)
 double MillePede2::GetParError(int iPar) const
 {
   if (fGloSolveStatus == kInvert) {
-    if (fkReGroup.size())
+    if (fkReGroup.size()) {
       iPar = fkReGroup[iPar];
+    }
     if (iPar < 0) {
       // LOG(debug) << Form("Parameter %d was suppressed in the regrouping",iPar));
       return 0;
     }
     double res = fMatCGlo->QueryDiag(iPar);
-    if (res >= 0)
+    if (res >= 0) {
       return TMath::Sqrt(res);
+    }
   }
   return 0.;
 }
@@ -1384,8 +1484,9 @@ double MillePede2::GetParError(int iPar) const
 double MillePede2::GetPull(int iPar) const
 {
   if (fGloSolveStatus == kInvert) {
-    if (fkReGroup.size())
+    if (fkReGroup.size()) {
       iPar = fkReGroup[iPar];
+    }
     if (iPar < 0) {
       // LOG(debug) << Form("Parameter %d was suppressed in the regrouping",iPar));
       return 0;
@@ -1412,10 +1513,12 @@ int MillePede2::PrintGlobalParameters() const
   int lastPrintedId = -1;
   for (int i0 = 0; i0 < fNGloParIni; i0++) {
     int i = GetRGId(i0);
-    if (i < 0)
+    if (i < 0) {
       continue;
-    if (i != i0 && lastPrintedId >= 0 && i <= lastPrintedId)
-      continue; // grouped param
+    }
+    if (i != i0 && lastPrintedId >= 0 && i <= lastPrintedId) { // grouped param
+      continue;
+    }
     lastPrintedId = i;
     lError = GetParError(i0);
     lGlobalCor = 0.0;
@@ -1445,22 +1548,25 @@ bool MillePede2::IsRecordAcceptable()
     // is run to be rejected?
     if (fRejRunList && (n = fRejRunList->GetSize())) {
       prevAns = true;
-      for (int i = n; i--;)
+      for (int i = n; i--;) {
         if (runID == (*fRejRunList)[i]) {
           prevAns = false;
           LOGF(info, "MillePede2 - New Run to reject: %ld", runID);
           break;
         }
+      }
     } else if (fAccRunList && (n = fAccRunList->GetSize())) { // is run specifically selected
       prevAns = false;
-      for (int i = n; i--;)
+      for (int i = n; i--;) {
         if (runID == (*fAccRunList)[i]) {
           prevAns = true;
-          if (fAccRunListWgh)
+          if (fAccRunListWgh) {
             fRunWgh = (*fAccRunListWgh)[i];
+          }
           LOGF(info, "MillePede2 - New Run to accept explicitly: %ld, weight=%f", runID, fRunWgh);
           break;
         }
+      }
       if (!prevAns)
         LOGF(info, "New Run is not in the list to accept: %ld", runID);
     }
@@ -1472,26 +1578,32 @@ bool MillePede2::IsRecordAcceptable()
 //_____________________________________________________________________________
 void MillePede2::SetRejRunList(const int* runs, const int nruns)
 {
-  if (fRejRunList)
+  if (fRejRunList) {
     delete fRejRunList;
+  }
   fRejRunList = 0;
-  if (nruns < 1 || !runs)
+  if (nruns < 1 || !runs) {
     return;
+  }
   fRejRunList = new TArrayL(nruns);
-  for (int i = 0; i < nruns; i++)
+  for (int i = 0; i < nruns; i++) {
     (*fRejRunList)[i] = runs[i];
+  }
 }
 
 //_____________________________________________________________________________
 void MillePede2::SetAccRunList(const int* runs, const int nruns, const float* wghList)
 {
-  if (fAccRunList)
+  if (fAccRunList) {
     delete fAccRunList;
-  if (fAccRunListWgh)
+  }
+  if (fAccRunListWgh) {
     delete fAccRunListWgh;
+  }
   fAccRunList = 0;
-  if (nruns < 1 || !runs)
+  if (nruns < 1 || !runs) {
     return;
+  }
   fAccRunList = new TArrayL(nruns);
   fAccRunListWgh = new TArrayF(nruns);
   for (int i = 0; i < nruns; i++) {
@@ -1505,8 +1617,9 @@ void MillePede2::SetInitPars(const double* par)
 {
   for (int i = 0; i < fNGloParIni; i++) {
     int id = GetRGId(i);
-    if (id < 0)
+    if (id < 0) {
       continue;
+    }
     fInitPar[id] = par[i];
   }
 }
@@ -1516,8 +1629,9 @@ void MillePede2::SetSigmaPars(const double* par)
 {
   for (int i = 0; i < fNGloParIni; i++) {
     int id = GetRGId(i);
-    if (id < 0)
+    if (id < 0) {
       continue;
+    }
     fSigmaPar[id] = par[i];
   }
 }
@@ -1526,8 +1640,9 @@ void MillePede2::SetSigmaPars(const double* par)
 void MillePede2::SetInitPar(int i, double par)
 {
   int id = GetRGId(i);
-  if (id < 0)
+  if (id < 0) {
     return;
+  }
   fInitPar[id] = par;
 }
 
@@ -1535,7 +1650,8 @@ void MillePede2::SetInitPar(int i, double par)
 void MillePede2::SetSigmaPar(int i, double par)
 {
   int id = GetRGId(i);
-  if (id < 0)
+  if (id < 0) {
     return;
+  }
   fSigmaPar[id] = par;
 }

--- a/Detectors/ITSMFT/MFT/alignment/src/MillePede2.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/MillePede2.cxx
@@ -1,4 +1,3 @@
-
 // Copyright 2019-2020 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.

--- a/Detectors/ITSMFT/MFT/alignment/src/MillePede2.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/MillePede2.cxx
@@ -21,8 +21,6 @@
 #include <TArrayL.h>
 #include <TArrayF.h>
 #include <TSystem.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -505,7 +503,7 @@ int MillePede2::LocalFit(std::vector<double>& localParams)
 {
   static int nrefSize = 0;
   //  static TArrayI refLoc,refGlo,nrefLoc,nrefGlo;
-  static int *refLoc = 0, *refGlo = 0, *nrefLoc = 0, *nrefGlo = 0;
+  static int *refLoc = nullptr, *refGlo = nullptr, *nrefLoc = nullptr, *nrefGlo = nullptr;
   int nPoints = 0;
   fIsChi2BelowLimit = true;
 
@@ -522,7 +520,7 @@ int MillePede2::LocalFit(std::vector<double>& localParams)
   while (cnt < recSz) { // Transfer the measurement records to matrices
     // extract addresses of residual, weight and pointers on local and global derivatives for each point
     if (nrefSize <= nPoints) {
-      int* tmpA = 0;
+      int* tmpA = nullptr;
       nrefSize = 2 * (nPoints + 1);
       tmpA = refLoc;
       refLoc = new int[nrefSize];
@@ -1581,7 +1579,7 @@ void MillePede2::SetRejRunList(const int* runs, const int nruns)
   if (fRejRunList) {
     delete fRejRunList;
   }
-  fRejRunList = 0;
+  fRejRunList = nullptr;
   if (nruns < 1 || !runs) {
     return;
   }
@@ -1600,7 +1598,7 @@ void MillePede2::SetAccRunList(const int* runs, const int nruns, const float* wg
   if (fAccRunListWgh) {
     delete fAccRunListWgh;
   }
-  fAccRunList = 0;
+  fAccRunList = nullptr;
   if (nruns < 1 || !runs) {
     return;
   }

--- a/Detectors/ITSMFT/MFT/alignment/src/MillePede2.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/MillePede2.cxx
@@ -843,7 +843,7 @@ int MillePede2::GlobalFit(double* par, double* error, double* pull)
       fChi2CutFactor = TMath::Sqrt(fChi2CutFactor);
       if (fChi2CutFactor < 1.2 * fChi2CutRef) {
         fChi2CutFactor = fChi2CutRef;
-        // RRR	fIter = fMaxIter - 1;     // Last iteration
+        // RRR	fIter = fMaxIter - 1;  // Last iteration
       }
     }
     fIter++;
@@ -968,7 +968,7 @@ int MillePede2::GlobalFitIteration()
     double oldMin = 1.e20;
     double oldMax = -1.e20;
 
-    for (int i = fNGloPar; i--;) { // // Reset row and column of fixed params and add 1/sig^2 to free ones
+    for (int i = fNGloPar; i--;) { // Reset row and column of fixed params and add 1/sig^2 to free ones
       int grID = fParamGrID[i];
       if (grID < 0)
         continue; // not in the group
@@ -1054,13 +1054,14 @@ int MillePede2::GlobalFitIteration()
 
   // add large number to diagonal of fixed params
 
-  for (int i = fNGloPar; i--;) { // // Reset row and column of fixed params and add 1/sig^2 to free ones
-    //    printf("#%3d : Nproc : %5d   grp: %d\n",i,fProcPnt[i],fParamGrID[i]);
+  for (int i = fNGloPar; i--;) { // Reset row and column of fixed params and add 1/sig^2 to free ones
+                                 // printf("#%3d : Nproc : %5d grp: %d\n",i,fProcPnt[i],fParamGrID[i]);
     if (fProcPnt[i] < 1) {
       fNGloFix++;
       fVecBGlo[i] = 0.;
-      matCGlo.DiagElem(i) = 1.; // float(fNLocEquations*fNLocEquations);
-      //      matCGlo.DiagElem(i) = float(fNLocEquations*fNLocEquations);
+      matCGlo.DiagElem(i) = 1.;
+      // float(fNLocEquations*fNLocEquations);
+      // matCGlo.DiagElem(i) = float(fNLocEquations*fNLocEquations);
     } else
       matCGlo.DiagElem(i) += (fgWeightSigma ? fProcPnt[i] : 1.) / (fSigmaPar[i] * fSigmaPar[i]);
   }
@@ -1101,7 +1102,7 @@ int MillePede2::GlobalFitIteration()
     }
 
     if (nSuppressed == csize) {
-      //      AliInfo(Form("Neglecting constraint %d of %d derivatives since no free parameters left",i,csize));
+      // LOG(info << Form("Neglecting constraint %d of %d derivatives since no free parameters left",i,csize));
 
       // was this constraint ever created ?
       if (sig == 0 && fConstrUsed[i]) { // this is needed only for constraints with Lagrange multiplier
@@ -1369,7 +1370,7 @@ double MillePede2::GetParError(int iPar) const
     if (fkReGroup.size())
       iPar = fkReGroup[iPar];
     if (iPar < 0) {
-      //  AliDebug(2,Form("Parameter %d was suppressed in the regrouping",iPar));
+      // LOG(debug) << Form("Parameter %d was suppressed in the regrouping",iPar));
       return 0;
     }
     double res = fMatCGlo->QueryDiag(iPar);
@@ -1386,7 +1387,7 @@ double MillePede2::GetPull(int iPar) const
     if (fkReGroup.size())
       iPar = fkReGroup[iPar];
     if (iPar < 0) {
-      //  AliDebug(2,Form("Parameter %d was suppressed in the regrouping",iPar));
+      // LOG(debug) << Form("Parameter %d was suppressed in the regrouping",iPar));
       return 0;
     }
     return fProcPnt[iPar] > 0 && (fSigmaPar[iPar] * fSigmaPar[iPar] - fMatCGlo->QueryDiag(iPar)) > 0. && fSigmaPar[iPar] > 0

--- a/Detectors/ITSMFT/MFT/alignment/src/MillePede2.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/MillePede2.cxx
@@ -1,0 +1,1541 @@
+
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file MillePede2.cxx
+
+#include "MFTAlignment/MillePede2.h"
+#include "Framework/Logger.h"
+#include <TStopwatch.h>
+#include <TFile.h>
+#include <TChain.h>
+#include <TMath.h>
+#include <TVectorD.h>
+#include <TArrayL.h>
+#include <TArrayF.h>
+#include <TSystem.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <fstream>
+
+//#define _DUMP_EQ_BEFORE_
+//#define _DUMP_EQ_AFTER_
+
+//#define _DUMPEQ_BEFORE_
+//#define _DUMPEQ_AFTER_
+
+using std::ifstream;
+using namespace o2::mft;
+
+ClassImp(MillePede2);
+
+bool MillePede2::fgInvChol = true;                   // Invert global matrix with Cholesky solver
+bool MillePede2::fgWeightSigma = true;               // weight local constraint by module statistics
+bool MillePede2::fgIsMatGloSparse = false;           // use faster dense matrix by default
+int MillePede2::fgMinResCondType = 1;                // Jacoby preconditioner by default
+double MillePede2::fgMinResTol = 1.e-11;             // default tolerance
+int MillePede2::fgMinResMaxIter = 10000;             // default max number of iterations
+int MillePede2::fgIterSol = MinResSolve::kSolMinRes; // default iterative solver
+int MillePede2::fgNKrylovV = 240;                    // default number of Krylov vectors to keep
+
+//_____________________________________________________________________________
+MillePede2::MillePede2()
+  : fNLocPar(0),
+    fNGloPar(0),
+    fNGloParIni(0),
+    fNGloSize(0),
+    fNLocEquations(0),
+    fIter(0),
+    fMaxIter(10),
+    fNStdDev(3),
+    fNGloConstraints(0),
+    fNLagrangeConstraints(0),
+    fNLocFits(0),
+    fNLocFitsRejected(0),
+    fNGloFix(0),
+    fGloSolveStatus(kFailed),
+    fChi2CutFactor(1.),
+    fChi2CutRef(1.),
+    fResCutInit(100.),
+    fResCut(100.),
+    fMinPntValid(1),
+    fNGroupsSet(0),
+    fMatCLoc(nullptr),
+    fMatCGlo(nullptr),
+    fMatCGloLoc(nullptr),
+    fRecChi2File(nullptr),
+    fRecChi2FName("chi2_records.root"),
+    fRecChi2TreeName("chi2Records"),
+    fTreeChi2(nullptr),
+    fSumChi2(0.),
+    fIsChi2BelowLimit(true),
+    fRecNDoF(0),
+    fRecord(nullptr),
+    fCurrRecDataID(0),
+    fCurrRecConstrID(0),
+    fLocFitAdd(true),
+    fUseRecordWeight(true),
+    fMinRecordLength(1),
+    fSelFirst(1),
+    fSelLast(-1),
+    fRejRunList(nullptr),
+    fAccRunList(nullptr),
+    fAccRunListWgh(nullptr),
+    fRunWgh(1),
+    fRecordWriter(nullptr),
+    fConstraintsRecWriter(nullptr),
+    fRecordReader(nullptr),
+    fConstraintsRecReader(nullptr)
+{
+  fWghScl[0] = fWghScl[1] = -1;
+  LOGF(info, "MillePede2 instantiated");
+}
+
+//_____________________________________________________________________________
+MillePede2::MillePede2(const MillePede2& src)
+  : fNLocPar(0),
+    fNGloPar(0),
+    fNGloParIni(0),
+    fNGloSize(0),
+    fNLocEquations(0),
+    fIter(0),
+    fMaxIter(10),
+    fNStdDev(3),
+    fNGloConstraints(0),
+    fNLagrangeConstraints(0),
+    fNLocFits(0),
+    fNLocFitsRejected(0),
+    fNGloFix(0),
+    fGloSolveStatus(kFailed),
+    fChi2CutFactor(1.),
+    fChi2CutRef(1.),
+    fResCutInit(100.),
+    fResCut(100.),
+    fMinPntValid(1),
+    fNGroupsSet(0),
+    fMatCLoc(nullptr),
+    fMatCGlo(nullptr),
+    fMatCGloLoc(nullptr),
+    fRecChi2File(nullptr),
+    fRecChi2FName("chi2_records.root"),
+    fRecChi2TreeName("chi2Records"),
+    fTreeChi2(nullptr),
+    fSumChi2(0.),
+    fIsChi2BelowLimit(true),
+    fRecNDoF(0),
+    fRecord(nullptr),
+    fCurrRecDataID(0),
+    fCurrRecConstrID(0),
+    fLocFitAdd(true),
+    fUseRecordWeight(true),
+    fMinRecordLength(1),
+    fSelFirst(1),
+    fSelLast(-1),
+    fRejRunList(nullptr),
+    fAccRunList(nullptr),
+    fAccRunListWgh(nullptr),
+    fRunWgh(1),
+    fRecordWriter(nullptr),
+    fConstraintsRecWriter(nullptr),
+    fRecordReader(nullptr),
+    fConstraintsRecReader(nullptr)
+{
+  fWghScl[0] = src.fWghScl[0];
+  fWghScl[1] = src.fWghScl[1];
+  printf("Dummy\n");
+}
+
+//_____________________________________________________________________________
+MillePede2::~MillePede2()
+{
+  if (fMatCLoc) {
+    delete fMatCLoc;
+  }
+  if (fMatCGlo) {
+    delete fMatCGlo;
+  }
+  if (fMatCGloLoc) {
+    delete fMatCGloLoc;
+  }
+
+  if (fRejRunList) {
+    delete fRejRunList;
+  }
+  if (fAccRunList) {
+    delete fAccRunList;
+  }
+  if (fAccRunListWgh) {
+    delete fAccRunListWgh;
+  }
+  if (fRecChi2File) {
+    fRecChi2File->Close();
+    LOG(info) << "MillePede2 - Closed file "
+              << GetRecChi2FName();
+    delete fRecChi2File; // this should automatically delete the TTree that belongs to the file
+  }
+  LOGF(debug, "MillePede2 destroyed");
+}
+
+//_____________________________________________________________________________
+int MillePede2::InitMille(int nGlo, const int nLoc,
+                          const int lNStdDev, const double lResCut,
+                          const double lResCutInit, const std::vector<int>& regroup)
+{
+  fNGloParIni = nGlo;
+  if (regroup.size()) { // regrouping is requested
+    fkReGroup = regroup;
+    int ng = 0; // recalculate N globals
+    int maxPID = -1;
+    for (int i = 0; i < nGlo; i++)
+      if (regroup[i] >= 0) {
+        ng++;
+        if (regroup[i] > maxPID)
+          maxPID = regroup[i];
+      }
+    maxPID++;
+    LOGF(info,
+         "MillePede2 - Regrouping is requested: from %d raw to %d formal globals grouped to %d real globals",
+         nGlo, ng, maxPID);
+    nGlo = maxPID;
+  }
+  if (nLoc > 0)
+    fNLocPar = nLoc;
+  if (nGlo > 0)
+    fNGloPar = nGlo;
+  if (lResCutInit > 0)
+    fResCutInit = lResCutInit;
+  if (lResCut > 0)
+    fResCut = lResCut;
+  if (lNStdDev > 0)
+    fNStdDev = lNStdDev;
+  LOGF(info, "MillePede2 - NLoc: %d NGlo: %d", fNLocPar, fNGloPar);
+
+  fNGloSize = fNGloPar;
+
+  if (fgIsMatGloSparse) {
+    fMatCGlo = new MatrixSparse(fNGloPar);
+    fMatCGlo->SetSymmetric(true);
+  } else
+    fMatCGlo = new SymMatrix(fNGloPar);
+
+  fFillIndex = std::vector<int>(fNGloPar);
+  fFillValue = std::vector<double>(fNGloPar);
+
+  fMatCLoc = new SymMatrix(fNLocPar);
+  fMatCGloLoc = new RectMatrix(fNGloPar, fNLocPar);
+
+  fParamGrID = std::vector<int>(fNGloPar);
+  fProcPnt = std::vector<int>(fNGloPar);
+  fVecBLoc = std::vector<double>(fNGloPar);
+  fDiagCGlo = std::vector<double>(fNGloPar);
+
+  fInitPar = std::vector<double>(fNGloPar);
+  fDeltaPar = std::vector<double>(fNGloPar);
+  fSigmaPar = std::vector<double>(fNGloPar);
+  fIsLinear = std::vector<bool>(fNGloPar);
+
+  fGlo2CGlo = std::vector<int>(fNGloPar);
+  fCGlo2Glo = std::vector<int>(fNGloPar);
+
+  for (int i = fNGloPar; i--;) {
+    fGlo2CGlo[i] = fCGlo2Glo[i] = -1;
+    fIsLinear[i] = true;
+    fParamGrID[i] = -1;
+  }
+
+  fWghScl[0] = -1;
+  fWghScl[1] = -1;
+  return 1;
+}
+
+//_____________________________________________________________________________
+bool MillePede2::InitChi2Storage(const int nEntriesAutoSave)
+{
+  if (fTreeChi2) {
+    LOG(warning) << "MillePede2::InitChi2Storage() - output tree already initialized";
+    return false;
+  }
+  if (fRecChi2File == nullptr)
+    fRecChi2File = new TFile(GetRecChi2FName(), "recreate", "", 505);
+  if ((!fRecChi2File) || (fRecChi2File->IsZombie())) {
+    LOGF(error,
+         "MillePede2::InitChi2Storage() - failed to initialise chi2 storage file %s!",
+         GetRecChi2FName());
+    return false;
+  }
+  if (fTreeChi2 == nullptr) {
+    fRecChi2File->cd();
+    fTreeChi2 = new TTree(fRecChi2TreeName.Data(), "Sum of chi2 per records");
+    fTreeChi2->SetAutoSave(nEntriesAutoSave); // flush the TTree to disk every N entries
+    fTreeChi2->SetImplicitMT(true);
+    fTreeChi2->Branch("sumChi2", &fSumChi2, "fSumChi2/F");
+    fTreeChi2->Branch("accepted", &fIsChi2BelowLimit, "fIsChi2BelowLimit/O");
+    fTreeChi2->Branch("nDoF", &fRecNDoF, "fRecNDoF/I");
+  }
+  if (!fTreeChi2) {
+    LOG(error) << "MillePede2::InitChi2Storage() - failed to initialise TTree !";
+    return false;
+  }
+  LOGF(info, "MillePede2::InitChi2Storage() - chi2 storage file %s",
+       GetRecChi2FName());
+  return true;
+}
+
+//_____________________________________________________________________________
+void MillePede2::EndChi2Storage()
+{
+  if (fRecChi2File && fRecChi2File->IsWritable() && fTreeChi2) {
+    fRecChi2File->cd();
+    fTreeChi2->Write();
+    LOG(info) << "MillePede2::EndChi2Storage() - wrote tree "
+              << fRecChi2TreeName.Data();
+  }
+}
+
+//_____________________________________________________________________________
+void MillePede2::SetLocalEquation(std::vector<double>& dergb, std::vector<double>& derlc,
+                                  const double lMeas, const double lSigma)
+{
+  if (!fRecordWriter) {
+    LOG(fatal) << "MillePede2::SetLocalEquation() - aborted: null pointer to record writer";
+    return;
+  }
+  if (!fRecordWriter->isInitOk()) {
+    LOG(fatal) << "MillePede2::SetLocalEquation() - aborted: unintialised record writer";
+    return;
+  }
+  SetRecord(fRecordWriter->getRecord());
+
+  // write data of single measurement
+  if (lSigma <= 0.0) { // If parameter is fixed, then no equation
+    for (int i = fNLocPar; i--;)
+      derlc[i] = 0.0;
+    for (int i = fNGloParIni; i--;)
+      dergb[i] = 0.0;
+    return;
+  }
+
+  fRecord->AddResidual(lMeas);
+
+  // Retrieve local param interesting indices
+  for (int i = 0; i < fNLocPar; i++)
+    if (!IsZero(derlc[i])) {
+      fRecord->AddIndexValue(i, derlc[i]);
+      derlc[i] = 0.0;
+    }
+
+  fRecord->AddWeight(1.0 / lSigma / lSigma);
+
+  // Idem for global parameters
+  for (int i = 0; i < fNGloParIni; i++)
+    if (!IsZero(dergb[i])) {
+      fRecord->AddIndexValue(i, dergb[i]);
+      dergb[i] = 0.0;
+      int idrg = GetRGId(i);
+      fRecord->MarkGroup(idrg < 0 ? -1 : fParamGrID[i]);
+    }
+}
+
+//_____________________________________________________________________________
+void MillePede2::SetLocalEquation(std::vector<int>& indgb, std::vector<double>& dergb,
+                                  int ngb, std::vector<int>& indlc,
+                                  std::vector<double>& derlc, const int nlc,
+                                  const double lMeas, const double lSigma)
+{
+  if (!fRecordWriter) {
+    LOG(fatal) << "MillePede2::SetLocalEquation() - aborted: null pointer to record writer";
+    return;
+  }
+  if (!fRecordWriter->isInitOk()) {
+    LOG(fatal) << "MillePede2::SetLocalEquation() - aborted: unintialised record writer";
+    return;
+  }
+  SetRecord(fRecordWriter->getRecord());
+
+  if (lSigma <= 0.0) { // If parameter is fixed, then no equation
+    for (int i = nlc; i--;)
+      derlc[i] = 0.0;
+    for (int i = ngb; i--;)
+      dergb[i] = 0.0;
+    return;
+  }
+
+  fRecord->AddResidual(lMeas);
+
+  // Retrieve local param interesting indices
+  for (int i = 0; i < nlc; i++)
+    if (!IsZero(derlc[i])) {
+      fRecord->AddIndexValue(indlc[i], derlc[i]);
+      derlc[i] = 0.;
+      indlc[i] = 0;
+    }
+
+  fRecord->AddWeight(1. / lSigma / lSigma);
+
+  // Idem for global parameters
+  for (int i = 0; i < ngb; i++)
+    if (!IsZero(dergb[i])) {
+      fRecord->AddIndexValue(indgb[i], dergb[i]);
+      dergb[i] = 0.;
+      indgb[i] = 0;
+    }
+}
+
+//_____________________________________________________________________________
+void MillePede2::SetGlobalConstraint(const std::vector<double>& dergb,
+                                     const double val, const double sigma,
+                                     const bool doPrint)
+{
+  if (!fConstraintsRecWriter) {
+    LOG(fatal) << "MillePede2::SetGlobalConstraint() - aborted: null pointer to record writer";
+    return;
+  }
+  if (!fConstraintsRecWriter->isInitOk()) {
+    LOG(fatal) << "MillePede2::SetGlobalConstraint() - aborted: unintialised record writer";
+    return;
+  }
+  SetRecord(fConstraintsRecWriter->getRecord());
+
+  fRecord->Reset();
+  fRecord->AddResidual(val);
+  fRecord->AddWeight(sigma);
+  for (int i = 0; i < fNGloParIni; i++)
+    if (!IsZero(dergb[i]))
+      fRecord->AddIndexValue(i, dergb[i]);
+  fNGloConstraints++;
+  if (IsZero(sigma))
+    fNLagrangeConstraints++;
+  if (doPrint) {
+    LOG(info) << "MillePede2::SetGlobalConstraint() - new constraints added";
+  }
+  fConstraintsRecWriter->fillRecordTree(doPrint);
+}
+
+//_____________________________________________________________________________
+void MillePede2::SetGlobalConstraint(const std::vector<int>& indgb,
+                                     const std::vector<double>& dergb,
+                                     const int ngb, const double val,
+                                     const double sigma, const bool doPrint)
+{
+  if (!fConstraintsRecWriter) {
+    LOG(fatal) << "MillePede2::SetGlobalConstraint() - aborted: null pointer to record writer";
+    return;
+  }
+  if (!fConstraintsRecWriter->isInitOk()) {
+    LOG(fatal) << "MillePede2::SetGlobalConstraint() - aborted: unintialised record writer";
+    return;
+  }
+  SetRecord(fConstraintsRecWriter->getRecord());
+
+  fRecord->Reset();
+  fRecord->AddResidual(val);
+  fRecord->AddWeight(sigma); // dummy
+  for (int i = 0; i < ngb; i++)
+    if (!IsZero(dergb[i]))
+      fRecord->AddIndexValue(indgb[i], dergb[i]);
+  fNGloConstraints++;
+  if (IsZero(sigma))
+    fNLagrangeConstraints++;
+  if (doPrint) {
+    LOG(info) << "MillePede2::SetGlobalConstraint() - new constraints added";
+  }
+  fConstraintsRecWriter->fillRecordTree(doPrint);
+}
+
+//_____________________________________________________________________________
+void MillePede2::ReadRecordData(const long recID, bool doPrint)
+{
+  if (fRecordReader == nullptr) {
+    LOG(error) << "MillePede2::ReadRecordData() - aborted, input record reader is a null pointer";
+    return;
+  }
+  SetRecord(fRecordReader->getRecord());
+  fRecordReader->readEntry(recID, doPrint);
+  fCurrRecDataID = recID;
+}
+
+//_____________________________________________________________________________
+void MillePede2::ReadRecordConstraint(const long recID, bool doPrint)
+{
+  if (fConstraintsRecReader == nullptr) {
+    LOG(error) << "MillePede2::ReadRecordConstraint() - aborted, input record reader is a null pointer";
+    return;
+  }
+  SetRecord(fConstraintsRecReader->getRecord());
+  fConstraintsRecReader->readEntry(recID, doPrint);
+  fCurrRecConstrID = recID;
+}
+
+//_____________________________________________________________________________
+int MillePede2::LocalFit(std::vector<double>& localParams)
+{
+  static int nrefSize = 0;
+  //  static TArrayI refLoc,refGlo,nrefLoc,nrefGlo;
+  static int *refLoc = 0, *refGlo = 0, *nrefLoc = 0, *nrefGlo = 0;
+  int nPoints = 0;
+  fIsChi2BelowLimit = true;
+
+  SymMatrix& matCLoc = *fMatCLoc;
+  MatrixSq& matCGlo = *fMatCGlo;
+  RectMatrix& matCGloLoc = *fMatCGloLoc;
+
+  std::fill(fVecBLoc.begin(), fVecBLoc.end(), 0.);
+  matCLoc.Reset();
+
+  int cnt = 0;
+  int recSz = fRecord->GetSize();
+
+  while (cnt < recSz) { // Transfer the measurement records to matrices
+    // extract addresses of residual, weight and pointers on local and global derivatives for each point
+    if (nrefSize <= nPoints) {
+      int* tmpA = 0;
+      nrefSize = 2 * (nPoints + 1);
+      tmpA = refLoc;
+      refLoc = new int[nrefSize];
+      if (tmpA)
+        memcpy(refLoc, tmpA, nPoints * sizeof(int));
+      tmpA = refGlo;
+      refGlo = new int[nrefSize];
+      if (tmpA)
+        memcpy(refGlo, tmpA, nPoints * sizeof(int));
+      tmpA = nrefLoc;
+      nrefLoc = new int[nrefSize];
+      if (tmpA)
+        memcpy(nrefLoc, tmpA, nPoints * sizeof(int));
+      tmpA = nrefGlo;
+      nrefGlo = new int[nrefSize];
+      if (tmpA)
+        memcpy(nrefGlo, tmpA, nPoints * sizeof(int));
+    }
+
+    refLoc[nPoints] = ++cnt;
+    int nLoc = 0;
+    while (!fRecord->IsWeight(cnt)) {
+      nLoc++;
+      cnt++;
+    }
+    nrefLoc[nPoints] = nLoc;
+
+    refGlo[nPoints] = ++cnt;
+    int nGlo = 0;
+    while (!fRecord->IsResidual(cnt) && cnt < recSz) {
+      nGlo++;
+      cnt++;
+    }
+    nrefGlo[nPoints] = nGlo;
+
+    nPoints++;
+  }
+  if (fMinRecordLength > 0 && nPoints < fMinRecordLength)
+    return 0; // ignore
+
+  double vl;
+
+  double gloWgh = fRunWgh;
+  if (fUseRecordWeight)
+    gloWgh *= fRecord->GetWeight(); // global weight for this set
+  int maxLocUsed = 0;
+
+  for (int ip = nPoints; ip--;) { // Transfer the measurement records to matrices
+    double resid = fRecord->GetValue(refLoc[ip] - 1);
+    double weight = fRecord->GetValue(refGlo[ip] - 1) * gloWgh;
+    int odd = (ip & 0x1);
+    if (fWghScl[odd] > 0)
+      weight *= fWghScl[odd];
+    double* derLoc = fRecord->GetValue() + refLoc[ip];
+    double* derGlo = fRecord->GetValue() + refGlo[ip];
+    int* indLoc = fRecord->GetIndex() + refLoc[ip];
+    int* indGlo = fRecord->GetIndex() + refGlo[ip];
+
+    for (int i = nrefGlo[ip]; i--;) { // suppress the global part (only relevant with iterations)
+
+      // if regrouping was requested, do it here
+      if (fkReGroup.size()) {
+        int idtmp = fkReGroup[indGlo[i]];
+        if (idtmp == kFixParID)
+          indGlo[i] = kFixParID; // fixed param in regrouping
+        else
+          indGlo[i] = idtmp;
+      }
+
+      int iID = indGlo[i]; // Global param indice
+      if (iID < 0 || fSigmaPar[iID] <= 0.)
+        continue; // fixed parameter RRRCheck
+      if (fIsLinear[iID])
+        resid -= derGlo[i] * (fInitPar[iID] + fDeltaPar[iID]); // linear parameter
+      else
+        resid -= derGlo[i] * fDeltaPar[iID]; // nonlinear parameter
+    }
+
+    // Symmetric matrix, don't bother j>i coeffs
+    for (int i = nrefLoc[ip]; i--;) { // Fill local matrix and vector
+      fVecBLoc[indLoc[i]] += weight * resid * derLoc[i];
+      if (indLoc[i] > maxLocUsed)
+        maxLocUsed = indLoc[i];
+      for (int j = i + 1; j--;)
+        matCLoc(indLoc[i], indLoc[j]) += weight * derLoc[i] * derLoc[j];
+    }
+
+  } // end of the transfer of the measurement record to matrices
+
+  matCLoc.SetSizeUsed(++maxLocUsed); // data with B=0 may use less than declared nLocals
+
+  /* //RRR
+  fRecord->Print("l");
+  printf("\nBefore\nLocalMatrix: "); matCLoc.Print("l");
+  printf("RHSLoc: "); for (int i=0;i<fNLocPar;i++) printf("%+e |",fVecBLoc[i]); printf("\n");
+  */
+  // first try to solve by faster Cholesky decomposition, then by Gaussian elimination
+  double* pVecBLoc = &fVecBLoc[0];
+  if (!matCLoc.SolveChol(pVecBLoc, true)) {
+    LOG(warning) << "MillePede2 - Failed to solve locals by Cholesky, trying Gaussian Elimination";
+    if (!matCLoc.SolveSpmInv(pVecBLoc, true)) {
+      LOG(warning) << "MillePede2 - Failed to solve locals by Gaussian Elimination, skip...";
+      matCLoc.Print("d");
+      return 0; // failed to solve
+    }
+  }
+
+  // If requested, store the track params and errors
+  // RRR  printf("locfit: "); for (int i=0;i<fNLocPar;i++) printf("%+e |",fVecBLoc[i]); printf("\n");
+
+  if (localParams.size())
+    for (int i = maxLocUsed; i--;) {
+      localParams[2 * i] = fVecBLoc[i];
+      localParams[2 * i + 1] = TMath::Sqrt(TMath::Abs(matCLoc.QueryDiag(i)));
+    }
+
+  float lChi2 = 0;
+  int nEq = 0;
+
+  for (int ip = nPoints; ip--;) { // Calculate residuals
+    double resid = fRecord->GetValue(refLoc[ip] - 1);
+    double weight = fRecord->GetValue(refGlo[ip] - 1) * gloWgh;
+    int odd = (ip & 0x1);
+    if (fWghScl[odd] > 0)
+      weight *= fWghScl[odd];
+    double* derLoc = fRecord->GetValue() + refLoc[ip];
+    double* derGlo = fRecord->GetValue() + refGlo[ip];
+    int* indLoc = fRecord->GetIndex() + refLoc[ip];
+    int* indGlo = fRecord->GetIndex() + refGlo[ip];
+
+    // Suppress local and global contribution in residuals;
+    for (int i = nrefLoc[ip]; i--;)
+      resid -= derLoc[i] * fVecBLoc[indLoc[i]]; // local part
+
+    for (int i = nrefGlo[ip]; i--;) { // global part
+      int iID = indGlo[i];
+      if (iID < 0 || fSigmaPar[iID] <= 0.)
+        continue; // fixed parameter RRRCheck
+      if (fIsLinear[iID])
+        resid -= derGlo[i] * (fInitPar[iID] + fDeltaPar[iID]); // linear parameter
+      else
+        resid -= derGlo[i] * fDeltaPar[iID]; // nonlinear parameter
+    }
+
+    // reject the track if the residual is too large (outlier)
+    double absres = TMath::Abs(resid);
+    if ((absres >= fResCutInit && fIter == 1) || (absres >= fResCut && fIter > 1)) {
+      if (fLocFitAdd)
+        fNLocFitsRejected++;
+      LOGF(info, "MillePede2 - reject res %+e in record %5ld ", resid, fCurrRecDataID); // A.R. comment
+      return 0;
+    }
+
+    lChi2 += weight * resid * resid; // total chi^2
+    nEq++;                           // number of equations
+  }                                  // end of Calculate residuals
+
+  lChi2 /= gloWgh;
+  int nDoF = nEq - maxLocUsed;
+  lChi2 = (nDoF > 0) ? lChi2 / nDoF : 0; // Chi^2/dof
+  fSumChi2 = lChi2;
+  fRecNDoF = nDoF;
+
+  if (fNStdDev != 0 && nDoF > 0 && lChi2 > Chi2DoFLim(fNStdDev, nDoF) * fChi2CutFactor) { // check final chi2
+    fIsChi2BelowLimit = false;
+    if (GetCurrentIteration() == 1 && fTreeChi2)
+      fTreeChi2->Fill();
+    if (fLocFitAdd)
+      fNLocFitsRejected++;
+    LOGF(debug, "MillePede2 - reject chi2 %+e record %5ld: (nDOF %d)", lChi2, fCurrRecDataID, nDoF); // A.R. comment
+    // fRecord->Print();                                                                                // A.R. comment
+    return 0;
+  }
+
+  if (fLocFitAdd) {
+    fNLocFits++;
+    fNLocEquations += nEq;
+  } else {
+    fNLocFits--;
+    fNLocEquations -= nEq;
+  }
+
+  //  local operations are finished, track is accepted
+  //  We now update the global parameters (other matrices)
+
+  int nGloInFit = 0;
+
+  for (int ip = nPoints; ip--;) { // Update matrices
+    double resid = fRecord->GetValue(refLoc[ip] - 1);
+    double weight = fRecord->GetValue(refGlo[ip] - 1) * gloWgh;
+    int odd = (ip & 0x1);
+    if (fWghScl[odd] > 0)
+      weight *= fWghScl[odd];
+    double* derLoc = fRecord->GetValue() + refLoc[ip];
+    double* derGlo = fRecord->GetValue() + refGlo[ip];
+    int* indLoc = fRecord->GetIndex() + refLoc[ip];
+    int* indGlo = fRecord->GetIndex() + refGlo[ip];
+
+    for (int i = nrefGlo[ip]; i--;) { // suppress the global part
+      int iID = indGlo[i];            // Global param indice
+      if (iID < 0 || fSigmaPar[iID] <= 0.)
+        continue; // fixed parameter RRRCheck
+      if (fIsLinear[iID])
+        resid -= derGlo[i] * (fInitPar[iID] + fDeltaPar[iID]); // linear parameter
+      else
+        resid -= derGlo[i] * fDeltaPar[iID]; // nonlinear parameter
+    }
+
+    for (int ig = nrefGlo[ip]; ig--;) {
+      int iIDg = indGlo[ig]; // Global param indice (the matrix line)
+      if (iIDg < 0 || fSigmaPar[iIDg] <= 0.)
+        continue; // fixed parameter RRRCheck
+      if (fLocFitAdd)
+        fVecBGlo[iIDg] += weight * resid * derGlo[ig]; //!!!
+      else
+        fVecBGlo[iIDg] -= weight * resid * derGlo[ig]; //!!!
+
+      // First of all, the global/global terms (exactly like local matrix)
+      int nfill = 0;
+      for (int jg = ig + 1; jg--;) { // matCGlo is symmetric by construction
+        int jIDg = indGlo[jg];
+        if (jIDg < 0 || fSigmaPar[jIDg] <= 0.)
+          continue; // fixed parameter RRRCheck
+        if (!IsZero(vl = weight * derGlo[ig] * derGlo[jg])) {
+          fFillIndex[nfill] = jIDg;
+          fFillValue[nfill++] = fLocFitAdd ? vl : -vl;
+        }
+      }
+      if (nfill) {
+        matCGlo.AddToRow(iIDg, fFillValue.data(), fFillIndex.data(), nfill);
+      }
+
+      // Now we have also rectangular matrices containing global/local terms.
+      int iCIDg = fGlo2CGlo[iIDg]; // compressed Index of index
+      if (iCIDg == -1) {
+        double* rowGL = matCGloLoc(nGloInFit);
+        for (int k = maxLocUsed; k--;)
+          rowGL[k] = 0.0; // reset the row
+        iCIDg = fGlo2CGlo[iIDg] = nGloInFit;
+        fCGlo2Glo[nGloInFit++] = iIDg;
+      }
+
+      double* rowGLIDg = matCGloLoc(iCIDg);
+      for (int il = nrefLoc[ip]; il--;)
+        rowGLIDg[indLoc[il]] += weight * derGlo[ig] * derLoc[il];
+      fProcPnt[iIDg] += fLocFitAdd ? 1 : -1; // update counter
+    }
+  } // end of Update matrices
+  //
+  /*//RRR
+  LOG(info) << "MillePede2 - After GLO";
+  printf("MatCLoc: "); fMatCLoc->Print("l");
+  printf("MatCGlo: "); fMatCGlo->Print("l");
+  printf("MatCGlLc:"); fMatCGloLoc->Print("l");
+  printf("BGlo: "); for (int i=0; i<fNGloPar; i++) printf("%+e |",fVecBGlo[i]); printf("\n");
+  */
+  // calculate fMatCGlo -= fMatCGloLoc * fMatCLoc * fMatCGloLoc^T
+  // and       fVecBGlo -= fMatCGloLoc * fVecBLoc
+  //
+  //-------------------------------------------------------------- >>>
+  double vll;
+  for (int iCIDg = 0; iCIDg < nGloInFit; iCIDg++) {
+    int iIDg = fCGlo2Glo[iCIDg];
+
+    vl = 0;
+    double* rowGLIDg = matCGloLoc(iCIDg);
+    for (int kl = 0; kl < maxLocUsed; kl++)
+      if (rowGLIDg[kl])
+        vl += rowGLIDg[kl] * fVecBLoc[kl];
+    if (!IsZero(vl))
+      fVecBGlo[iIDg] -= fLocFitAdd ? vl : -vl;
+
+    int nfill = 0;
+    for (int jCIDg = 0; jCIDg <= iCIDg; jCIDg++) {
+      int jIDg = fCGlo2Glo[jCIDg];
+
+      vl = 0;
+      double* rowGLJDg = matCGloLoc(jCIDg);
+      for (int kl = 0; kl < maxLocUsed; kl++) {
+        // diag terms
+        if ((!IsZero(vll = rowGLIDg[kl] * rowGLJDg[kl])))
+          vl += matCLoc.QueryDiag(kl) * vll;
+        //
+        // off-diag terms
+        for (int ll = 0; ll < kl; ll++) {
+          if (!IsZero(vll = rowGLIDg[kl] * rowGLJDg[ll]))
+            vl += matCLoc(kl, ll) * vll;
+          if (!IsZero(vll = rowGLIDg[ll] * rowGLJDg[kl]))
+            vl += matCLoc(kl, ll) * vll;
+        }
+      }
+      if (!IsZero(vl)) {
+        fFillIndex[nfill] = jIDg;
+        fFillValue[nfill++] = fLocFitAdd ? -vl : vl;
+      }
+    }
+    if (nfill) {
+      matCGlo.AddToRow(iIDg, fFillValue.data(), fFillIndex.data(), nfill);
+    }
+  }
+
+  // reset compressed index array
+
+  /*//RRR
+  LOG(info) << "MillePede2 - After GLOLoc";
+  printf("MatCGlo: "); fMatCGlo->Print("");
+  printf("BGlo: "); for (int i=0; i<fNGloPar; i++) printf("%+e |",fVecBGlo[i]); printf("\n");
+  */
+  for (int i = nGloInFit; i--;) {
+    fGlo2CGlo[fCGlo2Glo[i]] = -1;
+    fCGlo2Glo[i] = -1;
+  }
+  //
+  //---------------------------------------------------- <<<
+  if (GetCurrentIteration() == 1 && fTreeChi2)
+    fTreeChi2->Fill();
+  return 1;
+}
+
+//_____________________________________________________________________________
+int MillePede2::GlobalFit(double* par, double* error, double* pull)
+{
+  if (fRecordReader == nullptr) {
+    LOG(fatal) << "MillePede2::GlobalFit() - aborted, input record reader is a null pointer";
+    return 1;
+  }
+  fIter = 1;
+
+  TStopwatch sw;
+  sw.Start();
+
+  int res = 0;
+  LOG(info) << "MillePede2 - Starting Global fit.";
+  while (fIter <= fMaxIter) {
+    //
+    res = GlobalFitIteration();
+    if (!res)
+      break;
+    //
+    if (!IsZero(fChi2CutFactor - fChi2CutRef)) {
+      fChi2CutFactor = TMath::Sqrt(fChi2CutFactor);
+      if (fChi2CutFactor < 1.2 * fChi2CutRef) {
+        fChi2CutFactor = fChi2CutRef;
+        // RRR	fIter = fMaxIter - 1;     // Last iteration
+      }
+    }
+    fIter++;
+  }
+
+  sw.Stop();
+  LOGF(info, "MillePede2 - Global fit %s, CPU time: %.1f", res ? "Converged" : "Failed", sw.CpuTime());
+  if (!res)
+    return 0;
+
+  if (par)
+    for (int i = fNGloParIni; i--;)
+      par[i] = GetFinalParam(i);
+
+  if (fGloSolveStatus == kInvert) { // errors on params are available
+    if (error)
+      for (int i = fNGloParIni; i--;)
+        error[i] = GetFinalError(i);
+    if (pull)
+      for (int i = fNGloParIni; i--;)
+        pull[i] = GetPull(i);
+  }
+
+  return 1;
+}
+
+//_____________________________________________________________________________
+int MillePede2::GlobalFitIteration()
+{
+  LOGF(info, "MillePede2 - Global Fit Iteration#%2d (Local Fit Chi^2 cut factor: %.2f)", fIter, fChi2CutFactor);
+
+  if (!fRecordReader) {
+    LOG(info) << "MillePede2::GlobalFitIteration() - no record is accessible, stopping iteration";
+    return 0;
+  }
+  if (!fNGloPar) {
+    LOG(info) << "MillePede2::GlobalFitIteration() - zero global parameter, stopping iteration";
+    return 0;
+  }
+  TStopwatch sw, sws;
+  sw.Start();
+  sws.Stop();
+
+  if (!fConstrUsed.size()) {
+    fConstrUsed = std::vector<bool>(fNGloConstraints);
+    std::fill(fConstrUsed.begin(), fConstrUsed.end(), 0);
+  }
+  // Reset all info specific for this step
+  MatrixSq& matCGlo = *fMatCGlo;
+  matCGlo.Reset();
+  std::fill(fProcPnt.begin(), fProcPnt.end(), 0);
+
+  fNGloConstraints = fConstraintsRecReader ? fConstraintsRecReader->getNEntries() : 0;
+
+  // count number of Lagrange constraints: they need new row/cols to be added
+  fNLagrangeConstraints = 0;
+  for (int i = 0; i < fNGloConstraints; i++) {
+    ReadRecordConstraint(i);
+    if (!fConstraintsRecReader->isReadEntryOk())
+      continue;
+    if (IsZero(fRecord->GetValue(1)))
+      fNLagrangeConstraints++; // exact constraint (no error) -> Lagrange multiplier
+  }
+
+  // if needed, readjust the size of the global vector (for matrices this is done automatically)
+  if (!fVecBGlo.size() || fNGloSize != fNGloPar + fNLagrangeConstraints) {
+    fVecBGlo.clear(); // in case some constraint was added between the two manual iterations
+    fNGloSize = fNGloPar + fNLagrangeConstraints;
+    fVecBGlo = std::vector<double>(fNGloSize);
+  }
+
+  fNLocFits = 0;
+  fNLocFitsRejected = 0;
+  fNLocEquations = 0;
+
+  //  Process data records and build the matrices
+  long ndr = fRecordReader->getNEntries();
+  long first = fSelFirst > 0 ? fSelFirst : 0;
+  long last = fSelLast < 1 ? ndr : (fSelLast >= ndr ? ndr : fSelLast + long(1));
+  ndr = last - first;
+
+  LOGF(info, "MillePede2 - Building the Global matrix from data records %ld : %ld", first, last);
+  if (ndr < 1)
+    return 0;
+
+  TStopwatch swt;
+  swt.Start();
+  fLocFitAdd = true; // add contributions of matching tracks
+  for (long i = 0; i < ndr; i++) {
+    long iev = i + first;
+    ReadRecordData(iev);
+    if (!IsRecordAcceptable() || !fRecordReader->isReadEntryOk())
+      continue;
+    std::vector<double> emptyLocalParams = {};
+    LocalFit(emptyLocalParams);
+    if ((i % int(0.2 * ndr)) == 0)
+      printf("%.1f%% of local fits done\n", double(100. * i) / ndr);
+  }
+  swt.Stop();
+  LOGF(info, "MillePede2 - %ld local fits done: ", ndr);
+  /*
+  printf("MatCGlo: "); fMatCGlo->Print("l");
+  printf("BGlo: "); for (int i=0; i<fNGloPar; i++) printf("%+e |",fVecBGlo[i]); printf("\n");
+  swt.Print();
+  */
+  sw.Start(false);
+
+  // ---------------------- Reject parameters with low statistics ------------>>
+  fNGloFix = 0;
+  if (fMinPntValid > 1 && fNGroupsSet) {
+    //
+    LOGF(info, "MillePede2 - Checking parameters with statistics < %d", fMinPntValid);
+    TStopwatch swsup;
+    swsup.Start();
+    // 1) build the list of parameters to fix
+    int fixArrSize = 10;
+    int nFixedGroups = 0;
+    TArrayI fixGroups(fixArrSize);
+    //
+    int grIDold = -2;
+    int oldStart = -1;
+    double oldMin = 1.e20;
+    double oldMax = -1.e20;
+
+    for (int i = fNGloPar; i--;) { // // Reset row and column of fixed params and add 1/sig^2 to free ones
+      int grID = fParamGrID[i];
+      if (grID < 0)
+        continue; // not in the group
+
+      if (grID != grIDold) {                                        // starting new group
+        if (grIDold >= 0) {                                         // decide if the group has enough statistics
+          if (oldMin < fMinPntValid && oldMax < 2 * fMinPntValid) { // suppress group
+            for (int iold = oldStart; iold > i; iold--)
+              fProcPnt[iold] = 0;
+            bool fnd = false; // check if the group is already accounted
+            for (int j = nFixedGroups; j--;)
+              if (fixGroups[j] == grIDold) {
+                fnd = true;
+                break;
+              }
+            if (!fnd) {
+              if (nFixedGroups >= fixArrSize) {
+                fixArrSize *= 2;
+                fixGroups.Set(fixArrSize);
+              }
+              fixGroups[nFixedGroups++] = grIDold; // add group to fix
+            }
+          }
+        }
+        grIDold = grID; // mark the start of the new group
+        oldStart = i;
+        oldMin = 1.e20;
+        oldMax = -1.e20;
+      }
+      if (oldMin > fProcPnt[i])
+        oldMin = fProcPnt[i];
+      if (oldMax < fProcPnt[i])
+        oldMax = fProcPnt[i];
+    }
+    // extra check for the last group
+    if (grIDold >= 0 && oldMin < fMinPntValid && oldMax < 2 * fMinPntValid) { // suppress group
+      for (int iold = oldStart; iold--;)
+        fProcPnt[iold] = 0;
+      bool fnd = false; // check if the group is already accounted
+      for (int j = nFixedGroups; j--;)
+        if (fixGroups[j] == grIDold) {
+          fnd = true;
+          break;
+        }
+      if (!fnd) {
+        if (nFixedGroups >= fixArrSize) {
+          fixArrSize *= 2;
+          fixGroups.Set(fixArrSize);
+        }
+        fixGroups[nFixedGroups++] = grIDold; // add group to fix
+      }
+    }
+
+    // 2) loop over records and add contributions of fixed groups with negative sign
+    fLocFitAdd = false;
+
+    for (long i = 0; i < ndr; i++) {
+      long iev = i + first;
+      ReadRecordData(iev);
+      if (!IsRecordAcceptable() || !fRecordReader->isReadEntryOk())
+        continue;
+      bool suppr = false;
+      for (int ifx = nFixedGroups; ifx--;)
+        if (fRecord->IsGroupPresent(fixGroups[ifx]))
+          suppr = true;
+      if (suppr) {
+        std::vector<double> emptyLocalParams = {};
+        LocalFit(emptyLocalParams);
+      }
+    }
+    fLocFitAdd = true;
+
+    if (nFixedGroups) {
+      LOGF(info, "MillePede2 - Suppressed contributions of groups with NPoints < %d :", fMinPntValid);
+      for (int i = 0; i < nFixedGroups; i++)
+        printf("%d ", fixGroups[i]);
+      printf("\n");
+    }
+    swsup.Stop();
+    swsup.Print();
+  }
+  // ---------------------- Reject parameters with low statistics ------------<<
+
+  // add large number to diagonal of fixed params
+
+  for (int i = fNGloPar; i--;) { // // Reset row and column of fixed params and add 1/sig^2 to free ones
+    //    printf("#%3d : Nproc : %5d   grp: %d\n",i,fProcPnt[i],fParamGrID[i]);
+    if (fProcPnt[i] < 1) {
+      fNGloFix++;
+      fVecBGlo[i] = 0.;
+      matCGlo.DiagElem(i) = 1.; // float(fNLocEquations*fNLocEquations);
+      //      matCGlo.DiagElem(i) = float(fNLocEquations*fNLocEquations);
+    } else
+      matCGlo.DiagElem(i) += (fgWeightSigma ? fProcPnt[i] : 1.) / (fSigmaPar[i] * fSigmaPar[i]);
+  }
+
+  for (int i = fNGloPar; i--;)
+    fDiagCGlo[i] = matCGlo.QueryDiag(i); // save the diagonal elements
+
+  // add constraint equations
+  int nVar = fNGloPar; // Current size of global matrix
+  for (int i = 0; i < fNGloConstraints; i++) {
+    ReadRecordConstraint(i);
+    if (!fConstraintsRecReader->isReadEntryOk())
+      continue;
+    double val = fRecord->GetValue(0);
+    double sig = fRecord->GetValue(1);
+    int* indV = fRecord->GetIndex() + 2;
+    double* der = fRecord->GetValue() + 2;
+    int csize = fRecord->GetSize() - 2;
+    //
+    if (fkReGroup.size()) {
+      for (int jp = csize; jp--;) {
+        int idp = indV[jp];
+        if (fkReGroup[idp] < 0)
+          LOGF(fatal, "MillePede2 - Constain is requested for suppressed parameter #%d", indV[jp]);
+        indV[jp] = idp;
+      }
+    }
+    // check if after suppression of fixed variables there are non-0 derivatives
+    // and determine the max statistics of involved params
+    int nSuppressed = 0;
+    int maxStat = 1;
+    for (int j = csize; j--;) {
+      if (fProcPnt[indV[j]] < 1)
+        nSuppressed++;
+      else {
+        maxStat = TMath::Max(maxStat, fProcPnt[indV[j]]);
+      }
+    }
+
+    if (nSuppressed == csize) {
+      //      AliInfo(Form("Neglecting constraint %d of %d derivatives since no free parameters left",i,csize));
+
+      // was this constraint ever created ?
+      if (sig == 0 && fConstrUsed[i]) { // this is needed only for constraints with Lagrange multiplier
+        // to avoid empty row impose dummy constraint on "Lagrange multiplier"
+        matCGlo.DiagElem(nVar) = 1.;
+        fVecBGlo[nVar++] = 0;
+      }
+      continue;
+    }
+
+    // account for already accumulated corrections
+    for (int j = csize; j--;)
+      val -= der[j] * (fInitPar[indV[j]] + fDeltaPar[indV[j]]);
+
+    if (sig > 0) { // this is a gaussian constriant: no Lagrange multipliers are added
+
+      double sig2i = (fgWeightSigma ? TMath::Sqrt(maxStat) : 1.) / sig / sig;
+      for (int ir = 0; ir < csize; ir++) {
+        int iID = indV[ir];
+        for (int ic = 0; ic <= ir; ic++) { // matrix is symmetric
+          int jID = indV[ic];
+          double vl = der[ir] * der[ic] * sig2i;
+          if (!IsZero(vl))
+            matCGlo(iID, jID) += vl;
+        }
+        fVecBGlo[iID] += val * der[ir] * sig2i;
+      }
+    } else { // this is exact constriant:  Lagrange multipliers must be added
+      for (int j = csize; j--;) {
+        int jID = indV[j];
+        if (fProcPnt[jID] < 1)
+          continue;                                          // this parameter was fixed, don't put it into constraint
+        matCGlo(nVar, jID) = float(fNLocEquations) * der[j]; // fMatCGlo is symmetric, only lower triangle is filled
+      }
+
+      if (matCGlo.QueryDiag(nVar))
+        matCGlo.DiagElem(nVar) = 0.0;
+      fVecBGlo[nVar++] = float(fNLocEquations) * val; // RS ? should we use here fNLocFits ?
+      fConstrUsed[i] = true;
+    }
+  }
+
+  LOGF(info, "MillePede2 - Obtained %-7ld equations from %-7ld records (%-7ld rejected). Fixed %-4d globals",
+       fNLocEquations, fNLocFits, fNLocFitsRejected, fNGloFix);
+
+  sws.Start();
+
+#ifdef _DUMP_EQ_BEFORE_
+  const char* faildumpB = Form("mp2eq_before%d.dat", fIter);
+  int defoutB = dup(1);
+  if (defoutB < 0) {
+    LOG(fatal) << "Failed on dup";
+    exit(1);
+  }
+  int slvDumpB = open(faildumpB, O_RDWR | O_CREAT, 0666);
+  if (slvDumpB >= 0) {
+    dup2(slvDumpB, 1);
+    printf("Solving%d for %d params\n", fIter, fNGloSize);
+    matCGlo.Print("10");
+    for (int i = 0; i < fNGloSize; i++)
+      printf("b%2d : %+.10f\n", i, fVecBGlo[i]);
+  }
+  dup2(defoutB, 1);
+  close(slvDumpB);
+  close(defoutB);
+
+#endif
+  /*
+  printf("Solving:\n");
+  matCGlo.Print("l");
+  for (int i=0;i<fNGloSize;i++) printf("b%2d : %+e\n",i,fVecBGlo[i]);
+  */
+#ifdef _DUMPEQ_BEFORE_
+  const char* faildumpB = Form("mp2eq_before%d.dat", fIter);
+  int defoutB = dup(1);
+  int slvDumpB = open(faildumpB, O_RDWR | O_CREAT, 0666);
+  dup2(slvDumpB, 1);
+  //
+  printf("#Equation before step %d\n", fIter);
+  fMatCGlo->Print("10");
+  printf("#RHS/STAT : NGlo:%d NGloSize:%d\n", fNGloPar, fNGloSize);
+  for (int i = 0; i < fNGloSize; i++)
+    printf("%d %+.10f %d\n", i, fVecBGlo[i], fProcPnt[i]);
+  //
+  dup2(defoutB, 1);
+  close(slvDumpB);
+  close(defoutB);
+#endif
+  //
+  fGloSolveStatus = SolveGlobalMatEq(); // obtain solution for this step
+#ifdef _DUMPEQ_AFTER_
+  const char* faildumpA = Form("mp2eq_after%d.dat", fIter);
+  int defoutA = dup(1);
+  int slvDumpA = open(faildumpA, O_RDWR | O_CREAT, 0666);
+  dup2(slvDumpA, 1);
+  //
+  printf("#Matrix after step %d\n", fIter);
+  fMatCGlo->Print("10");
+  printf("#RHS/STAT : NGlo:%d NGloSize:%d\n", fNGloPar, fNGloSize);
+  for (int i = 0; i < fNGloSize; i++)
+    printf("%d %+.10f %d\n", i, fVecBGlo[i], fProcPnt[i]);
+  //
+  dup2(defoutA, 1);
+  close(slvDumpA);
+  close(defoutA);
+#endif
+  //
+  sws.Stop();
+  printf("Solve %d |", fIter);
+  sws.Print();
+  //
+  sw.Stop();
+  LOGF(info, "MillePede2 - Iteration#%2d %s. CPU time: %.1f", fIter, fGloSolveStatus == kFailed ? "Failed" : "Converged", sw.CpuTime());
+  if (fGloSolveStatus == kFailed)
+    return 0;
+  //
+  for (int i = fNGloPar; i--;)
+    fDeltaPar[i] += fVecBGlo[i]; // Update global parameters values (for iterations)
+
+#ifdef _DUMP_EQ_AFTER_
+  const char* faildumpA = Form("mp2eq_after%d.dat", fIter);
+  int defoutA = dup(1);
+  if (defoutA < 0) {
+    LOG(fatal) << "Failed on dup";
+    exit(1);
+  }
+  int slvDumpA = open(faildumpA, O_RDWR | O_CREAT, 0666);
+  if (slvDumpA >= 0) {
+    dup2(slvDumpA, 1);
+    printf("Solving%d for %d params\n", fIter, fNGloSize);
+    matCGlo.Print("10");
+    for (int i = 0; i < fNGloSize; i++)
+      printf("b%2d : %+.10f\n", i, fVecBGlo[i]);
+  }
+  dup2(defoutA, 1);
+  close(slvDumpA);
+  close(defoutA);
+#endif
+  //
+  /*
+  printf("Solved:\n");
+  matCGlo.Print("l");
+  for (int i=0;i<fNGloSize;i++) printf("b%2d : %+e (->%+e)\n",i,fVecBGlo[i], fDeltaPar[i]);
+  */
+
+  PrintGlobalParameters();
+  return 1;
+}
+
+//_____________________________________________________________________________
+int MillePede2::SolveGlobalMatEq()
+{
+  /*
+  printf("GlobalMatrix\n");
+  fMatCGlo->Print("l");
+  printf("RHS\n");
+  for (int i=0;i<fNGloPar;i++) printf("%d %+e\n",i,fVecBGlo[i]);
+  */
+
+  if (!fgIsMatGloSparse) {
+    if (fNLagrangeConstraints == 0) { // pos-def systems are faster to solve by Cholesky
+      if (((SymMatrix*)fMatCGlo)->SolveChol(fVecBGlo.data(), fgInvChol))
+        return fgInvChol ? kInvert : kNoInversion;
+      else
+        LOG(warning) << "MillePede2 - Solution of Global Dense System by Cholesky failed, trying Gaussian Elimiation";
+    }
+    if (((SymMatrix*)fMatCGlo)->SolveSpmInv(fVecBGlo.data(), true))
+      return kInvert;
+    else
+      LOG(warning) << "MillePede2 - Solution of Global Dense System by Gaussian Elimination failed, trying iterative methods";
+  }
+  // try to solve by minres
+  TVectorD sol(fNGloSize);
+
+  MinResSolve* slv = new MinResSolve(fMatCGlo, fVecBGlo.data());
+  if (!slv)
+    return kFailed;
+
+  bool res = false;
+  if (fgIterSol == MinResSolve::kSolMinRes)
+    res = slv->SolveMinRes(sol, fgMinResCondType, fgMinResMaxIter, fgMinResTol);
+  else if (fgIterSol == MinResSolve::kSolFGMRes)
+    res = slv->SolveFGMRES(sol, fgMinResCondType, fgMinResMaxIter, fgMinResTol, fgNKrylovV);
+  else
+    LOGF(warning, "MillePede2 - Undefined Iteritive Solver ID=%d, only %d are defined", fgIterSol, MinResSolve::kNSolvers);
+
+  if (!res) {
+    const char* faildump = "fgmr_failed.dat";
+    int defout = dup(1);
+    if (defout < 0) {
+      LOG(warning) << "Failed on dup";
+      return kFailed;
+    }
+    int slvDump = open(faildump, O_RDWR | O_CREAT, 0666);
+    if (slvDump >= 0) {
+      dup2(slvDump, 1);
+      printf("#Failed to solve using solver %d with PreCond: %d MaxIter: %d Tol: %e NKrylov: %d\n",
+             fgIterSol, fgMinResCondType, fgMinResMaxIter, fgMinResTol, fgNKrylovV);
+      printf("#Dump of matrix:\n");
+      fMatCGlo->Print("10");
+      printf("#Dump of RHS:\n");
+      for (int i = 0; i < fNGloSize; i++)
+        printf("%d %+.10f\n", i, fVecBGlo[i]);
+      dup2(defout, 1);
+      close(slvDump);
+      close(defout);
+      printf("#Dumped failed matrix and RHS to %s\n", faildump);
+    } else
+      LOG(warning) << "MillePede2 - Failed on file open for matrix dumping";
+    close(defout);
+    return kFailed;
+  }
+  for (int i = fNGloSize; i--;)
+    fVecBGlo[i] = sol[i];
+
+  return kNoInversion;
+}
+
+//_____________________________________________________________________________
+Float_t MillePede2::Chi2DoFLim(int nSig, int nDoF) const
+{
+  int lNSig;
+  float sn[3] = {0.47523, 1.690140, 2.782170};
+  float table[3][30] = {{1.0000, 1.1479, 1.1753, 1.1798, 1.1775, 1.1730, 1.1680, 1.1630,
+                         1.1581, 1.1536, 1.1493, 1.1454, 1.1417, 1.1383, 1.1351, 1.1321,
+                         1.1293, 1.1266, 1.1242, 1.1218, 1.1196, 1.1175, 1.1155, 1.1136,
+                         1.1119, 1.1101, 1.1085, 1.1070, 1.1055, 1.1040},
+                        {4.0000, 3.0900, 2.6750, 2.4290, 2.2628, 2.1415, 2.0481, 1.9736,
+                         1.9124, 1.8610, 1.8171, 1.7791, 1.7457, 1.7161, 1.6897, 1.6658,
+                         1.6442, 1.6246, 1.6065, 1.5899, 1.5745, 1.5603, 1.5470, 1.5346,
+                         1.5230, 1.5120, 1.5017, 1.4920, 1.4829, 1.4742},
+                        {9.0000, 5.9146, 4.7184, 4.0628, 3.6410, 3.3436, 3.1209, 2.9468,
+                         2.8063, 2.6902, 2.5922, 2.5082, 2.4352, 2.3711, 2.3143, 2.2635,
+                         2.2178, 2.1764, 2.1386, 2.1040, 2.0722, 2.0428, 2.0155, 1.9901,
+                         1.9665, 1.9443, 1.9235, 1.9040, 1.8855, 1.8681}};
+
+  if (nDoF < 1) {
+    return 0.0;
+  } else {
+    lNSig = TMath::Max(1, TMath::Min(nSig, 3));
+
+    if (nDoF <= 30) {
+      return table[lNSig - 1][nDoF - 1];
+    } else { // approximation
+      return ((sn[lNSig - 1] + TMath::Sqrt(float(2 * nDoF - 3))) *
+              (sn[lNSig - 1] + TMath::Sqrt(float(2 * nDoF - 3)))) /
+             float(2 * nDoF - 2);
+    }
+  }
+}
+
+//_____________________________________________________________________________
+int MillePede2::SetIterations(const double lChi2CutFac)
+{
+  fChi2CutFactor = TMath::Max(1.0, lChi2CutFac);
+  LOGF(info, "MillePede2 - Initial cut factor is %f", fChi2CutFactor);
+  fIter = 1; // Initializes the iteration process
+  return 1;
+}
+
+//_____________________________________________________________________________
+double MillePede2::GetParError(int iPar) const
+{
+  if (fGloSolveStatus == kInvert) {
+    if (fkReGroup.size())
+      iPar = fkReGroup[iPar];
+    if (iPar < 0) {
+      //  AliDebug(2,Form("Parameter %d was suppressed in the regrouping",iPar));
+      return 0;
+    }
+    double res = fMatCGlo->QueryDiag(iPar);
+    if (res >= 0)
+      return TMath::Sqrt(res);
+  }
+  return 0.;
+}
+
+//_____________________________________________________________________________
+double MillePede2::GetPull(int iPar) const
+{
+  if (fGloSolveStatus == kInvert) {
+    if (fkReGroup.size())
+      iPar = fkReGroup[iPar];
+    if (iPar < 0) {
+      //  AliDebug(2,Form("Parameter %d was suppressed in the regrouping",iPar));
+      return 0;
+    }
+    return fProcPnt[iPar] > 0 && (fSigmaPar[iPar] * fSigmaPar[iPar] - fMatCGlo->QueryDiag(iPar)) > 0. && fSigmaPar[iPar] > 0
+             ? fDeltaPar[iPar] / TMath::Sqrt(fSigmaPar[iPar] * fSigmaPar[iPar] - fMatCGlo->QueryDiag(iPar))
+             : 0;
+  }
+  return 0.;
+}
+
+//_____________________________________________________________________________
+int MillePede2::PrintGlobalParameters() const
+{
+  double lError = 0.;
+  double lGlobalCor = 0.;
+
+  printf("\nMillePede2 output\n");
+  printf("   Result of fit for global parameters\n");
+  printf("   ===================================\n");
+  printf("    I       initial       final       differ        lastcor        error       gcor       Npnt\n");
+  printf("----------------------------------------------------------------------------------------------\n");
+  //
+  int lastPrintedId = -1;
+  for (int i0 = 0; i0 < fNGloParIni; i0++) {
+    int i = GetRGId(i0);
+    if (i < 0)
+      continue;
+    if (i != i0 && lastPrintedId >= 0 && i <= lastPrintedId)
+      continue; // grouped param
+    lastPrintedId = i;
+    lError = GetParError(i0);
+    lGlobalCor = 0.0;
+    double dg;
+    if (fGloSolveStatus == kInvert && TMath::Abs((dg = fMatCGlo->QueryDiag(i)) * fDiagCGlo[i]) > 0) {
+      lGlobalCor = TMath::Sqrt(TMath::Abs(1.0 - 1.0 / (dg * fDiagCGlo[i])));
+      printf("%4d(%4d)\t %+.6f\t %+.6f\t %+.6f\t %.6f\t %.6f\t %.6f\t %6d\n",
+             i, i0, fInitPar[i], fInitPar[i] + fDeltaPar[i], fDeltaPar[i], fVecBGlo[i], lError, lGlobalCor, fProcPnt[i]);
+    } else {
+      printf("%4d (%4d)\t %+.6f\t %+.6f\t %+.6f\t %.6f\t OFF\t OFF\t %6d\n", i, i0, fInitPar[i], fInitPar[i] + fDeltaPar[i],
+             fDeltaPar[i], fVecBGlo[i], fProcPnt[i]);
+    }
+  }
+  return 1;
+}
+
+//_____________________________________________________________________________
+bool MillePede2::IsRecordAcceptable()
+{
+  static long prevRunID = kMaxInt;
+  static bool prevAns = true;
+  long runID = fRecord->GetRunID();
+  if (runID != prevRunID) {
+    int n = 0;
+    fRunWgh = 1.;
+    prevRunID = runID;
+    // is run to be rejected?
+    if (fRejRunList && (n = fRejRunList->GetSize())) {
+      prevAns = true;
+      for (int i = n; i--;)
+        if (runID == (*fRejRunList)[i]) {
+          prevAns = false;
+          LOGF(info, "MillePede2 - New Run to reject: %ld", runID);
+          break;
+        }
+    } else if (fAccRunList && (n = fAccRunList->GetSize())) { // is run specifically selected
+      prevAns = false;
+      for (int i = n; i--;)
+        if (runID == (*fAccRunList)[i]) {
+          prevAns = true;
+          if (fAccRunListWgh)
+            fRunWgh = (*fAccRunListWgh)[i];
+          LOGF(info, "MillePede2 - New Run to accept explicitly: %ld, weight=%f", runID, fRunWgh);
+          break;
+        }
+      if (!prevAns)
+        LOGF(info, "New Run is not in the list to accept: %ld", runID);
+    }
+  }
+
+  return prevAns;
+}
+
+//_____________________________________________________________________________
+void MillePede2::SetRejRunList(const int* runs, const int nruns)
+{
+  if (fRejRunList)
+    delete fRejRunList;
+  fRejRunList = 0;
+  if (nruns < 1 || !runs)
+    return;
+  fRejRunList = new TArrayL(nruns);
+  for (int i = 0; i < nruns; i++)
+    (*fRejRunList)[i] = runs[i];
+}
+
+//_____________________________________________________________________________
+void MillePede2::SetAccRunList(const int* runs, const int nruns, const float* wghList)
+{
+  if (fAccRunList)
+    delete fAccRunList;
+  if (fAccRunListWgh)
+    delete fAccRunListWgh;
+  fAccRunList = 0;
+  if (nruns < 1 || !runs)
+    return;
+  fAccRunList = new TArrayL(nruns);
+  fAccRunListWgh = new TArrayF(nruns);
+  for (int i = 0; i < nruns; i++) {
+    (*fAccRunList)[i] = runs[i];
+    (*fAccRunListWgh)[i] = wghList ? wghList[i] : 1.0;
+  }
+}
+
+//_____________________________________________________________________________
+void MillePede2::SetInitPars(const double* par)
+{
+  for (int i = 0; i < fNGloParIni; i++) {
+    int id = GetRGId(i);
+    if (id < 0)
+      continue;
+    fInitPar[id] = par[i];
+  }
+}
+
+//_____________________________________________________________________________
+void MillePede2::SetSigmaPars(const double* par)
+{
+  for (int i = 0; i < fNGloParIni; i++) {
+    int id = GetRGId(i);
+    if (id < 0)
+      continue;
+    fSigmaPar[id] = par[i];
+  }
+}
+
+//_____________________________________________________________________________
+void MillePede2::SetInitPar(int i, double par)
+{
+  int id = GetRGId(i);
+  if (id < 0)
+    return;
+  fInitPar[id] = par;
+}
+
+//_____________________________________________________________________________
+void MillePede2::SetSigmaPar(int i, double par)
+{
+  int id = GetRGId(i);
+  if (id < 0)
+    return;
+  fSigmaPar[id] = par;
+}

--- a/Detectors/ITSMFT/MFT/alignment/src/MillePedeRecord.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/MillePedeRecord.cxx
@@ -64,8 +64,9 @@ MillePedeRecord& MillePedeRecord::operator=(const MillePedeRecord& rhs)
     }
     fWeight = rhs.fWeight;
     fRunID = rhs.fRunID;
-    for (int i = 0; i < rhs.GetNGroups(); i++)
+    for (int i = 0; i < rhs.GetNGroups(); i++) {
       MarkGroup(rhs.GetGroupID(i));
+    }
   }
   return *this;
 }
@@ -82,8 +83,9 @@ MillePedeRecord::~MillePedeRecord()
 void MillePedeRecord::Reset()
 {
   fSize = 0;
-  for (int i = fNGroups; i--;)
+  for (int i = fNGroups; i--;) {
     fGroupID[i] = 0;
+  }
   fNGroups = 0;
   fRunID = 0;
   fWeight = 1.;
@@ -98,10 +100,12 @@ void MillePedeRecord::Print(const Option_t*) const
   }
   int cnt = 0, point = 0;
 
-  if (fNGroups)
+  if (fNGroups) {
     printf("Groups: ");
-  for (int i = 0; i < fNGroups; i++)
+  }
+  for (int i = 0; i < fNGroups; i++) {
     printf("%4d |", GetGroupID(i));
+  }
   printf("Run: %9d Weight: %+.2e\n", fRunID, fWeight);
   while (cnt < fSize) {
     Double_t resid = fValue[cnt++];
@@ -123,12 +127,14 @@ void MillePedeRecord::Print(const Option_t*) const
 
     printf("\n*** Point#%2d | Residual = %+.4e | Weight = %+.4e\n", point++, resid, weight);
     printf("Locals : ");
-    for (int i = 0; i < nLoc; i++)
+    for (int i = 0; i < nLoc; i++) {
       printf("[%5d] %+.4e|", indLoc[i], derLoc[i]);
+    }
     printf("\n");
     printf("Globals: ");
-    for (int i = 0; i < nGlo; i++)
+    for (int i = 0; i < nGlo; i++) {
       printf("[%5d] %+.4e|", indGlo[i], derGlo[i]);
+    }
     printf("\n");
   }
 }
@@ -145,8 +151,9 @@ Double_t MillePedeRecord::GetGloResWProd(Int_t indx) const
 
   while (cnt < fSize) {
     Double_t resid = fValue[cnt++];
-    while (!IsWeight(cnt))
+    while (!IsWeight(cnt)) {
       cnt++;
+    }
     Double_t weight = GetValue(cnt++);
     Double_t* derGlo = GetValue() + cnt;
     int* indGlo = GetIndex() + cnt;
@@ -155,9 +162,11 @@ Double_t MillePedeRecord::GetGloResWProd(Int_t indx) const
       nGlo++;
       cnt++;
     }
-    for (int i = nGlo; i--;)
-      if (indGlo[i] == indx)
+    for (int i = nGlo; i--;) {
+      if (indGlo[i] == indx) {
         prodsum += resid * weight * derGlo[i];
+      }
+    }
   }
   return prodsum;
 }
@@ -172,8 +181,9 @@ Double_t MillePedeRecord::GetGlobalDeriv(Int_t pnt, Int_t indx) const
   int cnt = 0, point = 0;
   while (cnt < fSize) {
     cnt++;
-    while (!IsWeight(cnt))
+    while (!IsWeight(cnt)) {
       cnt++;
+    }
     cnt++;
     Double_t* derGlo = GetValue() + cnt;
     int* indGlo = GetIndex() + cnt;
@@ -182,11 +192,14 @@ Double_t MillePedeRecord::GetGlobalDeriv(Int_t pnt, Int_t indx) const
       nGlo++;
       cnt++;
     }
-    if (pnt != point++)
+    if (pnt != point++) {
       continue;
-    for (int i = nGlo; i--;)
-      if (indGlo[i] == indx)
+    }
+    for (int i = nGlo; i--;) {
+      if (indGlo[i] == indx) {
         return derGlo[i];
+      }
+    }
     break;
   }
   return 0;
@@ -210,13 +223,16 @@ Double_t MillePedeRecord::GetLocalDeriv(Int_t pnt, Int_t indx) const
       cnt++;
     }
     cnt++;
-    while (!IsResidual(cnt) && cnt < fSize)
+    while (!IsResidual(cnt) && cnt < fSize) {
       cnt++;
-    if (pnt != point++)
+    }
+    if (pnt != point++) {
       continue;
-    for (int i = nLoc; i--;)
+    }
+    for (int i = nLoc; i--;) {
       if (indLoc[i] == indx)
         return derLoc[i];
+    }
     break;
   }
   return 0;
@@ -232,13 +248,16 @@ Double_t MillePedeRecord::GetResidual(Int_t pnt) const
   int cnt = 0, point = 0;
   while (cnt < fSize) {
     Double_t resid = fValue[cnt++];
-    while (!IsWeight(cnt))
+    while (!IsWeight(cnt)) {
       cnt++;
+    }
     cnt++;
-    while (!IsResidual(cnt) && cnt < fSize)
+    while (!IsResidual(cnt) && cnt < fSize) {
       cnt++;
-    if (pnt != point++)
+    }
+    if (pnt != point++) {
       continue;
+    }
     return resid;
   }
   return 0;
@@ -254,14 +273,16 @@ Double_t MillePedeRecord::GetWeight(Int_t pnt) const
   int cnt = 0, point = 0;
   while (cnt < fSize) {
     cnt++;
-    while (!IsWeight(cnt))
+    while (!IsWeight(cnt)) {
       cnt++;
-    if (point == pnt)
+    }
+    if (point == pnt) {
       return GetValue(cnt);
-    ;
+    }
     cnt++;
-    while (!IsResidual(cnt) && cnt < fSize)
+    while (!IsResidual(cnt) && cnt < fSize) {
       cnt++;
+    }
     point++;
   }
   return -1;
@@ -292,8 +313,9 @@ void MillePedeRecord::ExpandGrBuffer(Int_t bfsize)
   memcpy(tmpI, fGroupID, fNGroups * sizeof(UShort_t));
   delete[] fGroupID;
   fGroupID = tmpI;
-  for (int i = fNGroups; i < bfsize; i++)
+  for (int i = fNGroups; i < bfsize; i++) {
     fGroupID[i] = 0;
+  }
 
   SetGrBufferSize(bfsize);
 }
@@ -302,9 +324,11 @@ void MillePedeRecord::ExpandGrBuffer(Int_t bfsize)
 void MillePedeRecord::MarkGroup(Int_t id)
 {
   id++; // groupID is stored as realID+1
-  if (fNGroups > 0 && fGroupID[fNGroups - 1] == id)
+  if (fNGroups > 0 && fGroupID[fNGroups - 1] == id) {
     return; // already there
-  if (fNGroups >= GetGrBufferSize())
+  }
+  if (fNGroups >= GetGrBufferSize()) {
     ExpandGrBuffer(2 * (fNGroups + 1));
+  }
   fGroupID[fNGroups++] = id;
 }

--- a/Detectors/ITSMFT/MFT/alignment/src/MillePedeRecord.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/MillePedeRecord.cxx
@@ -1,0 +1,310 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file MillePedeRecord.cxx
+
+#include "MFTAlignment/MillePedeRecord.h"
+#include <TMath.h>
+#include "Framework/Logger.h"
+
+using namespace o2::mft;
+
+ClassImp(MillePedeRecord);
+
+//_____________________________________________________________________________
+MillePedeRecord::MillePedeRecord()
+  : fSize(0),
+    fNGroups(0),
+    fRunID(0),
+    fGroupID(nullptr),
+    fIndex(nullptr),
+    fValue(nullptr),
+    fWeight(1)
+{
+  SetUniqueID(0);
+}
+
+//_____________________________________________________________________________
+MillePedeRecord::MillePedeRecord(const MillePedeRecord& src)
+  : TObject(src),
+    fSize(src.fSize),
+    fNGroups(src.fNGroups),
+    fRunID(src.fRunID),
+    fGroupID(nullptr),
+    fIndex(nullptr),
+    fValue(nullptr),
+    fWeight(src.fWeight)
+{
+  fIndex = new Int_t[GetDtBufferSize()];
+  memcpy(fIndex, src.fIndex, fSize * sizeof(Int_t));
+  fValue = new Double_t[GetDtBufferSize()];
+  memcpy(fValue, src.fValue, fSize * sizeof(Double_t));
+  fGroupID = new UShort_t[GetGrBufferSize()];
+  memcpy(fGroupID, src.fGroupID, GetGrBufferSize() * sizeof(UShort_t));
+}
+
+//_____________________________________________________________________________
+MillePedeRecord& MillePedeRecord::operator=(const MillePedeRecord& rhs)
+{
+  if (this != &rhs) {
+    Reset();
+    for (int i = 0; i < rhs.GetSize(); i++) {
+      Double_t val;
+      Int_t ind;
+      rhs.GetIndexValue(i, ind, val);
+      AddIndexValue(ind, val);
+    }
+    fWeight = rhs.fWeight;
+    fRunID = rhs.fRunID;
+    for (int i = 0; i < rhs.GetNGroups(); i++)
+      MarkGroup(rhs.GetGroupID(i));
+  }
+  return *this;
+}
+
+//_____________________________________________________________________________
+MillePedeRecord::~MillePedeRecord()
+{
+  delete[] fIndex;
+  delete[] fValue;
+  delete[] fGroupID;
+}
+
+//_____________________________________________________________________________
+void MillePedeRecord::Reset()
+{
+  fSize = 0;
+  for (int i = fNGroups; i--;)
+    fGroupID[i] = 0;
+  fNGroups = 0;
+  fRunID = 0;
+  fWeight = 1.;
+}
+
+//_____________________________________________________________________________
+void MillePedeRecord::Print(const Option_t*) const
+{
+  if (!fSize) {
+    LOG(info) << "No data";
+    return;
+  }
+  int cnt = 0, point = 0;
+
+  if (fNGroups)
+    printf("Groups: ");
+  for (int i = 0; i < fNGroups; i++)
+    printf("%4d |", GetGroupID(i));
+  printf("Run: %9d Weight: %+.2e\n", fRunID, fWeight);
+  while (cnt < fSize) {
+    Double_t resid = fValue[cnt++];
+    Double_t* derLoc = GetValue() + cnt;
+    int* indLoc = GetIndex() + cnt;
+    int nLoc = 0;
+    while (!IsWeight(cnt)) {
+      nLoc++;
+      cnt++;
+    }
+    Double_t weight = GetValue(cnt++);
+    Double_t* derGlo = GetValue() + cnt;
+    int* indGlo = GetIndex() + cnt;
+    int nGlo = 0;
+    while (!IsResidual(cnt) && cnt < fSize) {
+      nGlo++;
+      cnt++;
+    }
+
+    printf("\n*** Point#%2d | Residual = %+.4e | Weight = %+.4e\n", point++, resid, weight);
+    printf("Locals : ");
+    for (int i = 0; i < nLoc; i++)
+      printf("[%5d] %+.4e|", indLoc[i], derLoc[i]);
+    printf("\n");
+    printf("Globals: ");
+    for (int i = 0; i < nGlo; i++)
+      printf("[%5d] %+.4e|", indGlo[i], derGlo[i]);
+    printf("\n");
+  }
+}
+
+//_____________________________________________________________________________
+Double_t MillePedeRecord::GetGloResWProd(Int_t indx) const
+{
+  if (!fSize) {
+    LOG(info) << "No data";
+    return 0;
+  }
+  int cnt = 0;
+  double prodsum = 0.0;
+
+  while (cnt < fSize) {
+    Double_t resid = fValue[cnt++];
+    while (!IsWeight(cnt))
+      cnt++;
+    Double_t weight = GetValue(cnt++);
+    Double_t* derGlo = GetValue() + cnt;
+    int* indGlo = GetIndex() + cnt;
+    int nGlo = 0;
+    while (!IsResidual(cnt) && cnt < fSize) {
+      nGlo++;
+      cnt++;
+    }
+    for (int i = nGlo; i--;)
+      if (indGlo[i] == indx)
+        prodsum += resid * weight * derGlo[i];
+  }
+  return prodsum;
+}
+
+//_____________________________________________________________________________
+Double_t MillePedeRecord::GetGlobalDeriv(Int_t pnt, Int_t indx) const
+{
+  if (!fSize) {
+    LOG(error) << "No data";
+    return 0;
+  }
+  int cnt = 0, point = 0;
+  while (cnt < fSize) {
+    cnt++;
+    while (!IsWeight(cnt))
+      cnt++;
+    cnt++;
+    Double_t* derGlo = GetValue() + cnt;
+    int* indGlo = GetIndex() + cnt;
+    int nGlo = 0;
+    while (!IsResidual(cnt) && cnt < fSize) {
+      nGlo++;
+      cnt++;
+    }
+    if (pnt != point++)
+      continue;
+    for (int i = nGlo; i--;)
+      if (indGlo[i] == indx)
+        return derGlo[i];
+    break;
+  }
+  return 0;
+}
+
+//_____________________________________________________________________________
+Double_t MillePedeRecord::GetLocalDeriv(Int_t pnt, Int_t indx) const
+{
+  if (!fSize) {
+    LOG(error) << "No data";
+    return 0;
+  }
+  int cnt = 0, point = 0;
+  while (cnt < fSize) {
+    cnt++;
+    Double_t* derLoc = GetValue() + cnt;
+    int* indLoc = GetIndex() + cnt;
+    int nLoc = 0;
+    while (!IsWeight(cnt)) {
+      nLoc++;
+      cnt++;
+    }
+    cnt++;
+    while (!IsResidual(cnt) && cnt < fSize)
+      cnt++;
+    if (pnt != point++)
+      continue;
+    for (int i = nLoc; i--;)
+      if (indLoc[i] == indx)
+        return derLoc[i];
+    break;
+  }
+  return 0;
+}
+
+//_____________________________________________________________________________
+Double_t MillePedeRecord::GetResidual(Int_t pnt) const
+{
+  if (!fSize) {
+    LOG(error) << "No data";
+    return 0;
+  }
+  int cnt = 0, point = 0;
+  while (cnt < fSize) {
+    Double_t resid = fValue[cnt++];
+    while (!IsWeight(cnt))
+      cnt++;
+    cnt++;
+    while (!IsResidual(cnt) && cnt < fSize)
+      cnt++;
+    if (pnt != point++)
+      continue;
+    return resid;
+  }
+  return 0;
+}
+
+//_____________________________________________________________________________
+Double_t MillePedeRecord::GetWeight(Int_t pnt) const
+{
+  if (!fSize) {
+    LOG(error) << "No data";
+    return 0;
+  }
+  int cnt = 0, point = 0;
+  while (cnt < fSize) {
+    cnt++;
+    while (!IsWeight(cnt))
+      cnt++;
+    if (point == pnt)
+      return GetValue(cnt);
+    ;
+    cnt++;
+    while (!IsResidual(cnt) && cnt < fSize)
+      cnt++;
+    point++;
+  }
+  return -1;
+}
+
+//_____________________________________________________________________________
+void MillePedeRecord::ExpandDtBuffer(Int_t bfsize)
+{
+  bfsize = TMath::Max(bfsize, GetDtBufferSize());
+  Int_t* tmpI = new Int_t[bfsize];
+  memcpy(tmpI, fIndex, fSize * sizeof(Int_t));
+  delete[] fIndex;
+  fIndex = tmpI;
+
+  Double_t* tmpD = new Double_t[bfsize];
+  memcpy(tmpD, fValue, fSize * sizeof(Double_t));
+  delete[] fValue;
+  fValue = tmpD;
+
+  SetDtBufferSize(bfsize);
+}
+
+//_____________________________________________________________________________
+void MillePedeRecord::ExpandGrBuffer(Int_t bfsize)
+{
+  bfsize = TMath::Max(bfsize, GetGrBufferSize());
+  UShort_t* tmpI = new UShort_t[bfsize];
+  memcpy(tmpI, fGroupID, fNGroups * sizeof(UShort_t));
+  delete[] fGroupID;
+  fGroupID = tmpI;
+  for (int i = fNGroups; i < bfsize; i++)
+    fGroupID[i] = 0;
+
+  SetGrBufferSize(bfsize);
+}
+
+//_____________________________________________________________________________
+void MillePedeRecord::MarkGroup(Int_t id)
+{
+  id++; // groupID is stored as realID+1
+  if (fNGroups > 0 && fGroupID[fNGroups - 1] == id)
+    return; // already there
+  if (fNGroups >= GetGrBufferSize())
+    ExpandGrBuffer(2 * (fNGroups + 1));
+  fGroupID[fNGroups++] = id;
+}

--- a/Detectors/ITSMFT/MFT/alignment/src/MilleRecordReader.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/MilleRecordReader.cxx
@@ -37,10 +37,12 @@ MilleRecordReader::MilleRecordReader()
 //__________________________________________________________________________
 MilleRecordReader::~MilleRecordReader()
 {
-  if (mDataTree)
+  if (mDataTree) {
     mDataTree->Reset();
-  if (mRecord)
+  }
+  if (mRecord) {
     delete mRecord;
+  }
 }
 
 //__________________________________________________________________________

--- a/Detectors/ITSMFT/MFT/alignment/src/MilleRecordReader.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/MilleRecordReader.cxx
@@ -1,0 +1,131 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file MilleRecordReader.cxx
+
+#include "Framework/Logger.h"
+
+#include "MFTAlignment/MilleRecordReader.h"
+
+using namespace o2::mft;
+
+ClassImp(o2::mft::MilleRecordReader);
+
+//__________________________________________________________________________
+MilleRecordReader::MilleRecordReader()
+  : mDataTree(nullptr),
+    mIsSuccessfulInit(false),
+    mIsConstraintsRec(false),
+    mIsReadEntryOk(false),
+    mDataTreeName("milleRecords"),
+    mDataBranchName("data"),
+    mRecord(nullptr),
+    mCurrentDataID(-1),
+    mNEntries(0)
+{
+  mRecord = new MillePedeRecord();
+}
+
+//__________________________________________________________________________
+MilleRecordReader::~MilleRecordReader()
+{
+  if (mDataTree)
+    mDataTree->Reset();
+  if (mRecord)
+    delete mRecord;
+}
+
+//__________________________________________________________________________
+void MilleRecordReader::changeDataBranchName(const bool isConstraintsRec)
+{
+  mIsConstraintsRec = isConstraintsRec;
+  if (!mIsConstraintsRec) {
+    mDataBranchName = TString("data");
+  } else {
+    mDataBranchName = TString("constraints");
+  }
+}
+
+//__________________________________________________________________________
+void MilleRecordReader::connectToChain(TChain* ch)
+{
+  mIsSuccessfulInit = false;
+
+  if (mDataTree) {
+    LOG(warning) << "MilleRecordReader::connectToChain() - input chain already initialized";
+    mIsSuccessfulInit = true;
+    return;
+  }
+  if (!ch) {
+    LOG(fatal) << "MilleRecordReader::connectToChain() - input chain is a null pointer";
+    return;
+  }
+  Long64_t nEntries = ch->GetEntries();
+  if (nEntries < 1) {
+    LOG(fatal) << "MilleRecordReader::connectToChain() - input chain is empty";
+    return;
+  }
+  mDataTree = ch;
+  mNEntries = mDataTree->GetEntries();
+  mDataTree->SetBranchAddress(mDataBranchName.Data(), &mRecord);
+  if (!mIsConstraintsRec) {
+    LOGF(info,
+         "MilleRecordReader::connectToChain() - found %lld derivatives records",
+         mNEntries);
+  } else {
+    LOGF(info,
+         "MilleRecordReader::connectToChain() - found %lld constraints records",
+         mNEntries);
+  }
+  mIsSuccessfulInit = true;
+  mCurrentDataID = -1;
+}
+
+//__________________________________________________________________________
+void MilleRecordReader::readNextEntry(const bool doPrint)
+{
+  mIsReadEntryOk = false;
+  if (!isReaderOk()) {
+    LOG(error) << "MilleRecordReader::readNextEntry() - aborted, connectToChain() was not ok !";
+    return;
+  }
+  mCurrentDataID++;
+  if (!mDataTree || mCurrentDataID >= mNEntries) {
+    mCurrentDataID--;
+    return;
+  }
+  mDataTree->GetEntry(mCurrentDataID);
+  if (doPrint) {
+    LOGF(info, "MilleRecordReader::readNextEntry() - read entry %i", mCurrentDataID);
+    mRecord->Print();
+  }
+  mIsReadEntryOk = true;
+}
+
+//__________________________________________________________________________
+void MilleRecordReader::readEntry(const Long_t id, const bool doPrint)
+{
+  mIsReadEntryOk = false;
+  if (!isReaderOk()) {
+    LOG(error) << "MilleRecordReader::readEntry() - aborted, connectToChain() was not ok !";
+    return;
+  }
+  mCurrentDataID = id;
+  if (!mDataTree || mCurrentDataID >= mNEntries) {
+    return;
+  }
+  mDataTree->GetEntry(mCurrentDataID);
+  if (doPrint) {
+    LOGF(info, "MilleRecordReader::readEntry() - read entry %i", mCurrentDataID);
+    mRecord->Print();
+  }
+  mIsReadEntryOk = true;
+}

--- a/Detectors/ITSMFT/MFT/alignment/src/MilleRecordWriter.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/MilleRecordWriter.cxx
@@ -46,15 +46,17 @@ MilleRecordWriter::~MilleRecordWriter()
     LOG(info) << "MilleRecordWriter - closed file "
               << mDataFileName.Data();
   }
-  if (mRecord)
+  if (mRecord) {
     delete mRecord;
+  }
 }
 
 //__________________________________________________________________________
 void MilleRecordWriter::setCyclicAutoSave(const long nEntries)
 {
-  if (nEntries <= 0)
+  if (nEntries <= 0) {
     return;
+  }
   mNEntriesAutoSave = nEntries;
 }
 
@@ -74,8 +76,9 @@ void MilleRecordWriter::init()
 {
   mIsSuccessfulInit = false;
 
-  if (mDataFile == nullptr)
+  if (mDataFile == nullptr) {
     mDataFile = new TFile(mDataFileName.Data(), "recreate", "", 505);
+  }
 
   if ((!mDataFile) || (mDataFile->IsZombie())) {
     LOGF(fatal,

--- a/Detectors/ITSMFT/MFT/alignment/src/MilleRecordWriter.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/MilleRecordWriter.cxx
@@ -1,0 +1,148 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file MilleRecordWriter.cxx
+
+#include <TFile.h>
+#include <TTree.h>
+
+#include "Framework/Logger.h"
+
+#include "MFTAlignment/MilleRecordWriter.h"
+
+using namespace o2::mft;
+
+ClassImp(o2::mft::MilleRecordWriter);
+
+//__________________________________________________________________________
+MilleRecordWriter::MilleRecordWriter()
+  : mDataTree(nullptr),
+    mDataFile(nullptr),
+    mIsSuccessfulInit(false),
+    mIsConstraintsRec(false),
+    mNEntriesAutoSave(10000),
+    mDataFileName("mft_mille_records.root"),
+    mDataTreeName("milleRecords"),
+    mDataBranchName("data"),
+    mRecord(nullptr),
+    mCurrentDataID(-1)
+{
+  mRecord = new MillePedeRecord();
+}
+
+//__________________________________________________________________________
+MilleRecordWriter::~MilleRecordWriter()
+{
+  if (mDataFile) {
+    mDataFile->Close();
+    LOG(info) << "MilleRecordWriter - closed file "
+              << mDataFileName.Data();
+  }
+  if (mRecord)
+    delete mRecord;
+}
+
+//__________________________________________________________________________
+void MilleRecordWriter::setCyclicAutoSave(const long nEntries)
+{
+  if (nEntries <= 0)
+    return;
+  mNEntriesAutoSave = nEntries;
+}
+
+//__________________________________________________________________________
+void MilleRecordWriter::changeDataBranchName(const bool isConstraintsRec)
+{
+  mIsConstraintsRec = isConstraintsRec;
+  if (!mIsConstraintsRec) {
+    mDataBranchName = TString("data");
+  } else {
+    mDataBranchName = TString("constraints");
+  }
+}
+
+//__________________________________________________________________________
+void MilleRecordWriter::init()
+{
+  mIsSuccessfulInit = false;
+
+  if (mDataFile == nullptr)
+    mDataFile = new TFile(mDataFileName.Data(), "recreate", "", 505);
+
+  if ((!mDataFile) || (mDataFile->IsZombie())) {
+    LOGF(fatal,
+         "MilleRecordWriter::init() - failed to initialise records file %s!",
+         mDataFileName.Data());
+    return;
+  }
+  if (mDataTree == nullptr) {
+    mDataFile->cd();
+    mDataTree = new TTree(mDataTreeName.Data(), "records for MillePede2");
+    mDataTree->SetAutoSave(mNEntriesAutoSave); // flush the TTree to disk every N entries
+    const int bufsize = 32000;
+    const int splitLevel = 99; // "all the way"
+    mDataTree->Branch(mDataBranchName.Data(), "MillePedeRecord", mRecord, bufsize, splitLevel);
+  }
+  if (!mDataTree) {
+    LOG(fatal) << "MilleRecordWriter::init() - failed to initialise TTree !";
+    return;
+  }
+
+  if (!mIsConstraintsRec) {
+    LOGF(info,
+         "MilleRecordWriter::init() - file %s used for derivatives records",
+         mDataFileName.Data());
+  } else {
+    LOGF(info,
+         "MilleRecordWriter::init() - file %s used for constraints records",
+         mDataFileName.Data());
+  }
+  mIsSuccessfulInit = true;
+}
+
+//__________________________________________________________________________
+void MilleRecordWriter::fillRecordTree(const bool doPrint)
+{
+  if (!isInitOk()) {
+    LOG(warning) << "MilleRecordWriter::fillRecordTree() - aborted, init was not ok !";
+    return;
+  }
+  mDataTree->Fill();
+  mCurrentDataID++;
+  if (doPrint) {
+    LOGF(info, "MilleRecordWriter::fillRecordTree() - added entry %i", mCurrentDataID);
+    mRecord->Print();
+  }
+  mRecord->Reset();
+}
+
+//__________________________________________________________________________
+void MilleRecordWriter::terminate()
+{
+  if (mDataFile && mDataFile->IsWritable() && mDataTree) {
+    mDataFile->cd();
+    mDataTree->Write();
+    LOG(info) << "MilleRecordWriter::terminate() - wrote tree "
+              << mDataTreeName.Data();
+  }
+}
+
+//_____________________________________________________________________________
+void MilleRecordWriter::setRecordWeight(double wgh)
+{
+  mRecord->SetWeight(wgh);
+}
+
+//_____________________________________________________________________________
+void MilleRecordWriter::setRecordRun(int run)
+{
+  mRecord->SetRunID(run);
+}

--- a/Detectors/ITSMFT/MFT/alignment/src/MinResSolve.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/MinResSolve.cxx
@@ -12,7 +12,6 @@
 /// @file MinResSolve.cxx
 
 #include <iomanip>
-#include <float.h>
 #include <TMath.h>
 #include <TStopwatch.h>
 
@@ -30,22 +29,22 @@ ClassImp(MinResSolve);
 MinResSolve::MinResSolve()
   : fSize(0),
     fPrecon(0),
-    fMatrix(0),
-    fRHS(0),
-    fPVecY(0),
-    fPVecR1(0),
-    fPVecR2(0),
-    fPVecV(0),
-    fPVecW(0),
-    fPVecW1(0),
-    fPVecW2(0),
-    fPvv(0),
-    fPvz(0),
-    fPhh(0),
-    fDiagLU(0),
-    fMatL(0),
-    fMatU(0),
-    fMatBD(0)
+    fMatrix(nullptr),
+    fRHS(nullptr),
+    fPVecY(nullptr),
+    fPVecR1(nullptr),
+    fPVecR2(nullptr),
+    fPVecV(nullptr),
+    fPVecW(nullptr),
+    fPVecW1(nullptr),
+    fPVecW2(nullptr),
+    fPvv(nullptr),
+    fPvz(nullptr),
+    fPhh(nullptr),
+    fDiagLU(nullptr),
+    fMatL(nullptr),
+    fMatU(nullptr),
+    fMatBD(nullptr)
 {
 }
 
@@ -56,20 +55,20 @@ MinResSolve::MinResSolve(const MinResSolve& src)
     fPrecon(src.fPrecon),
     fMatrix(src.fMatrix),
     fRHS(src.fRHS),
-    fPVecY(0),
-    fPVecR1(0),
-    fPVecR2(0),
-    fPVecV(0),
-    fPVecW(0),
-    fPVecW1(0),
-    fPVecW2(0),
-    fPvv(0),
-    fPvz(0),
-    fPhh(0),
-    fDiagLU(0),
-    fMatL(0),
-    fMatU(0),
-    fMatBD(0)
+    fPVecY(nullptr),
+    fPVecR1(nullptr),
+    fPVecR2(nullptr),
+    fPVecV(nullptr),
+    fPVecW(nullptr),
+    fPVecW1(nullptr),
+    fPVecW2(nullptr),
+    fPvv(nullptr),
+    fPvz(nullptr),
+    fPhh(nullptr),
+    fDiagLU(nullptr),
+    fMatL(nullptr),
+    fMatU(nullptr),
+    fMatBD(nullptr)
 {
 }
 
@@ -79,20 +78,20 @@ MinResSolve::MinResSolve(const MatrixSq* mat, const TVectorD* rhs)
     fPrecon(0),
     fMatrix((MatrixSq*)mat),
     fRHS((double*)rhs->GetMatrixArray()),
-    fPVecY(0),
-    fPVecR1(0),
-    fPVecR2(0),
-    fPVecV(0),
-    fPVecW(0),
-    fPVecW1(0),
-    fPVecW2(0),
-    fPvv(0),
-    fPvz(0),
-    fPhh(0),
-    fDiagLU(0),
-    fMatL(0),
-    fMatU(0),
-    fMatBD(0)
+    fPVecY(nullptr),
+    fPVecR1(nullptr),
+    fPVecR2(nullptr),
+    fPVecV(nullptr),
+    fPVecW(nullptr),
+    fPVecW1(nullptr),
+    fPVecW2(nullptr),
+    fPvv(nullptr),
+    fPvz(nullptr),
+    fPhh(nullptr),
+    fDiagLU(nullptr),
+    fMatL(nullptr),
+    fMatU(nullptr),
+    fMatBD(nullptr)
 {
 }
 
@@ -729,47 +728,47 @@ void MinResSolve::ClearAux()
   if (fPVecY) {
     delete[] fPVecY;
   }
-  fPVecY = 0;
+  fPVecY = nullptr;
   if (fPVecR1) {
     delete[] fPVecR1;
   }
-  fPVecR1 = 0;
+  fPVecR1 = nullptr;
   if (fPVecR2) {
     delete[] fPVecR2;
   }
-  fPVecR2 = 0;
+  fPVecR2 = nullptr;
   if (fPVecV) {
     delete[] fPVecV;
   }
-  fPVecV = 0;
+  fPVecV = nullptr;
   if (fPVecW) {
     delete[] fPVecW;
   }
-  fPVecW = 0;
+  fPVecW = nullptr;
   if (fPVecW1) {
     delete[] fPVecW1;
   }
-  fPVecW1 = 0;
+  fPVecW1 = nullptr;
   if (fPVecW2) {
     delete[] fPVecW2;
   }
-  fPVecW2 = 0;
+  fPVecW2 = nullptr;
   if (fDiagLU) {
     delete[] fDiagLU;
   }
-  fDiagLU = 0;
+  fDiagLU = nullptr;
   if (fMatL) {
     delete fMatL;
   }
-  fMatL = 0;
+  fMatL = nullptr;
   if (fMatU) {
     delete fMatU;
   }
-  fMatU = 0;
+  fMatU = nullptr;
   if (fMatBD) {
     delete fMatBD;
   }
-  fMatBD = 0;
+  fMatBD = nullptr;
 }
 
 //___________________________________________________________
@@ -1075,9 +1074,9 @@ Int_t MinResSolve::PreconILUKsymb(Int_t lofM)
   MatrixSparse* matrix = (MatrixSparse*)fMatrix;
   sw.Start();
 
-  UChar_t **ulvl = 0, *levls = 0;
-  UShort_t* jbuf = 0;
-  Int_t* iw = 0;
+  UChar_t **ulvl = nullptr, *levls = nullptr;
+  UShort_t* jbuf = nullptr;
+  Int_t* iw = nullptr;
   ulvl = new UChar_t*[fSize]; // stores lev-fils for U part of ILU factorization
   levls = new UChar_t[fSize];
   jbuf = new UShort_t[fSize];
@@ -1219,9 +1218,9 @@ Int_t MinResSolve::PreconILUKsymbDense(Int_t lofM)
    * Adapted from iluk.c: lofC of ITSOL_1 package by Y.Saad: http://www-users.cs.umn.edu/~saad/software/
    *----------------------------------------------------------------------------*/
   //
-  UChar_t **ulvl = 0, *levls = 0;
-  UShort_t* jbuf = 0;
-  Int_t* iw = 0;
+  UChar_t **ulvl = nullptr, *levls = nullptr;
+  UShort_t* jbuf = nullptr;
+  Int_t* iw = nullptr;
   ulvl = new UChar_t*[fSize]; // stores lev-fils for U part of ILU factorization
   levls = new UChar_t[fSize];
   jbuf = new UShort_t[fSize];

--- a/Detectors/ITSMFT/MFT/alignment/src/MinResSolve.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/MinResSolve.cxx
@@ -1,0 +1,1258 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file MinResSolve.cxx
+
+#include <iomanip>
+#include <float.h>
+#include <TMath.h>
+#include <TStopwatch.h>
+
+#include "Framework/Logger.h"
+#include "MFTAlignment/MinResSolve.h"
+#include "MFTAlignment/MatrixSq.h"
+#include "MFTAlignment/MatrixSparse.h"
+#include "MFTAlignment/SymBDMatrix.h"
+
+using namespace o2::mft;
+
+ClassImp(MinResSolve);
+
+//______________________________________________________
+MinResSolve::MinResSolve()
+  : fSize(0),
+    fPrecon(0),
+    fMatrix(0),
+    fRHS(0),
+    fPVecY(0),
+    fPVecR1(0),
+    fPVecR2(0),
+    fPVecV(0),
+    fPVecW(0),
+    fPVecW1(0),
+    fPVecW2(0),
+    fPvv(0),
+    fPvz(0),
+    fPhh(0),
+    fDiagLU(0),
+    fMatL(0),
+    fMatU(0),
+    fMatBD(0)
+{
+}
+
+//______________________________________________________
+MinResSolve::MinResSolve(const MinResSolve& src)
+  : TObject(src),
+    fSize(src.fSize),
+    fPrecon(src.fPrecon),
+    fMatrix(src.fMatrix),
+    fRHS(src.fRHS),
+    fPVecY(0),
+    fPVecR1(0),
+    fPVecR2(0),
+    fPVecV(0),
+    fPVecW(0),
+    fPVecW1(0),
+    fPVecW2(0),
+    fPvv(0),
+    fPvz(0),
+    fPhh(0),
+    fDiagLU(0),
+    fMatL(0),
+    fMatU(0),
+    fMatBD(0)
+{
+}
+
+//______________________________________________________
+MinResSolve::MinResSolve(const MatrixSq* mat, const TVectorD* rhs)
+  : fSize(mat->GetSize()),
+    fPrecon(0),
+    fMatrix((MatrixSq*)mat),
+    fRHS((double*)rhs->GetMatrixArray()),
+    fPVecY(0),
+    fPVecR1(0),
+    fPVecR2(0),
+    fPVecV(0),
+    fPVecW(0),
+    fPVecW1(0),
+    fPVecW2(0),
+    fPvv(0),
+    fPvz(0),
+    fPhh(0),
+    fDiagLU(0),
+    fMatL(0),
+    fMatU(0),
+    fMatBD(0)
+{
+}
+
+//______________________________________________________
+MinResSolve::MinResSolve(const MatrixSq* mat, const double* rhs)
+  : fSize(mat->GetSize()),
+    fPrecon(0),
+    fMatrix((MatrixSq*)mat),
+    fRHS((double*)rhs),
+    fPVecY(0),
+    fPVecR1(0),
+    fPVecR2(0),
+    fPVecV(0),
+    fPVecW(0),
+    fPVecW1(0),
+    fPVecW2(0),
+    fPvv(0),
+    fPvz(0),
+    fPhh(0),
+    fDiagLU(0),
+    fMatL(0),
+    fMatU(0),
+    fMatBD(0)
+{
+}
+
+//______________________________________________________
+MinResSolve::~MinResSolve()
+{
+  ClearAux();
+}
+
+//______________________________________________________
+MinResSolve& MinResSolve::operator=(const MinResSolve& src)
+{
+  if (this != &src) {
+    fSize = src.fSize;
+    fPrecon = src.fPrecon;
+    fMatrix = src.fMatrix;
+    fRHS = src.fRHS;
+  }
+  return *this;
+}
+
+//_______________________________________________________________
+Int_t MinResSolve::BuildPrecon(Int_t prec)
+{
+  fPrecon = prec;
+
+  if (fPrecon >= kPreconBD && fPrecon < kPreconILU0) { // band diagonal decomposition
+    return BuildPreconBD(fPrecon - kPreconBD);         // with halfbandwidth + diagonal = fPrecon
+  }
+
+  if (fPrecon >= kPreconILU0 && fPrecon <= kPreconILU10) {
+    if (fMatrix->InheritsFrom("MatrixSparse"))
+      return BuildPreconILUK(fPrecon - kPreconILU0);
+    else
+      return BuildPreconILUKDense(fPrecon - kPreconILU0);
+  }
+
+  return -1;
+}
+
+//________________________________ FGMRES METHODS ________________________________
+Bool_t MinResSolve::SolveFGMRES(TVectorD& VecSol, Int_t precon, int itnlim, double rtol, int nkrylov)
+{
+  // solve by fgmres
+  return SolveFGMRES(VecSol.GetMatrixArray(), precon, itnlim, rtol, nkrylov);
+}
+
+//________________________________________________________________________________
+Bool_t MinResSolve::SolveFGMRES(double* VecSol, Int_t precon, int itnlim, double rtol, int nkrylov)
+{
+  // Adapted from Y.Saad fgmrs.c of ITSOL_1 package by Y.Saad: http://www-users.cs.umn.edu/~saad/software/
+  /*----------------------------------------------------------------------
+    |                 *** Preconditioned FGMRES ***
+    +-----------------------------------------------------------------------
+    | This is a simple version of the ARMS preconditioned FGMRES algorithm.
+    +-----------------------------------------------------------------------
+    | Y. S. Dec. 2000. -- Apr. 2008
+    +-----------------------------------------------------------------------
+    | VecSol  = real vector of length n containing an initial guess to the
+    | precon  = precondtioner id (0 = no precon)
+    | itnlim  = max n of iterations
+    | rtol     = tolerance for stopping iteration
+    | nkrylov = N of Krylov vectors to store
+    +---------------------------------------------------------------------*/
+  int l;
+  double status = kTRUE;
+  double t, beta, eps1 = 0;
+  const double epsmac = 2.22E-16;
+
+  LOG(info) << "Solution by FGMRes: Preconditioner #" << precon
+            << " Max.iter.: " << itnlim
+            << std::scientific << std::setprecision(3) << " Tol.: " << rtol
+            << "NKrylov: " << nkrylov;
+
+  int its = 0;
+  if (nkrylov < 10) {
+    LOG(info) << "Changing N Krylov vectors from " << nkrylov << " 10";
+    nkrylov = 10;
+  }
+
+  if (precon > 0) {
+    if (precon >= kPreconsTot) {
+      LOG(warning) << "Unknown preconditioner identifier " << precon << ", ignore";
+    } else {
+      if (BuildPrecon(precon) < 0) {
+        ClearAux();
+        LOG(error) << "FGMRES failed to build the preconditioner";
+        return kFALSE;
+      }
+    }
+  }
+
+  if (!InitAuxFGMRES(nkrylov))
+    return kFALSE;
+
+  for (l = fSize; l--;)
+    VecSol[l] = 0;
+
+  //-------------------- outer loop starts here
+  TStopwatch timer;
+  timer.Start();
+  while (1) {
+
+    //-------------------- compute initial residual vector
+    fMatrix->MultiplyByVec(VecSol, fPvv[0]);
+    for (l = fSize; l--;)
+      fPvv[0][l] = fRHS[l] - fPvv[0][l]; //  fPvv[0]= initial residual
+    beta = 0;
+    for (l = fSize; l--;)
+      beta += fPvv[0][l] * fPvv[0][l];
+    beta = TMath::Sqrt(beta);
+
+    if (beta < epsmac)
+      break; // success?
+    t = 1.0 / beta;
+    //--------------------   normalize:  fPvv[0] = fPvv[0] / beta
+    for (l = fSize; l--;)
+      fPvv[0][l] *= t;
+    if (its == 0)
+      eps1 = rtol * beta;
+
+    //    ** initialize 1-st term  of rhs of hessenberg system
+    fPVecV[0] = beta;
+    int i = -1;
+    do {
+      i++;
+      its++;
+      int i1 = i + 1;
+
+      //  (Right) Preconditioning Operation   z_{j} = M^{-1} v_{j}
+
+      if (precon > 0)
+        ApplyPrecon(fPvv[i], fPvz[i]);
+      else
+        for (l = fSize; l--;)
+          fPvz[i][l] = fPvv[i][l];
+
+      //-------------------- matvec operation w = A z_{j} = A M^{-1} v_{j}
+      fMatrix->MultiplyByVec(fPvz[i], fPvv[i1]);
+
+      // modified gram - schmidt...
+      // h_{i,j} = (w,v_{i})
+      // w  = w - h_{i,j} v_{i}
+
+      for (int j = 0; j <= i; j++) {
+        for (t = 0, l = fSize; l--;)
+          t += fPvv[j][l] * fPvv[i1][l];
+        fPhh[i][j] = t;
+        for (l = fSize; l--;)
+          fPvv[i1][l] -= t * fPvv[j][l];
+      }
+      // -------------------- h_{j+1,j} = ||w||_{2}
+      for (t = 0, l = fSize; l--;)
+        t += fPvv[i1][l] * fPvv[i1][l];
+      t = TMath::Sqrt(t);
+      fPhh[i][i1] = t;
+      if (t > 0)
+        for (t = 1. / t, l = 0; l < fSize; l++)
+          fPvv[i1][l] *= t; //  v_{j+1} = w / h_{j+1,j}
+
+      // done with modified gram schimdt and arnoldi step
+      // now  update factorization of fPhh
+      //
+      // perform previous transformations  on i-th column of h
+
+      for (l = 1; l <= i; l++) {
+        int l1 = l - 1;
+        t = fPhh[i][l1];
+        fPhh[i][l1] = fPVecR1[l1] * t + fPVecR2[l1] * fPhh[i][l];
+        fPhh[i][l] = -fPVecR2[l1] * t + fPVecR1[l1] * fPhh[i][l];
+      }
+      double gam = TMath::Sqrt(fPhh[i][i] * fPhh[i][i] + fPhh[i][i1] * fPhh[i][i1]);
+
+      // if gamma is zero then any small value will do...
+      // will affect only residual estimate
+      if (gam < epsmac)
+        gam = epsmac;
+      //  get  next plane rotation
+      fPVecR1[i] = fPhh[i][i] / gam;
+      fPVecR2[i] = fPhh[i][i1] / gam;
+      fPVecV[i1] = -fPVecR2[i] * fPVecV[i];
+      fPVecV[i] *= fPVecR1[i];
+
+      //  determine residual norm and test for convergence
+      fPhh[i][i] = fPVecR1[i] * fPhh[i][i] + fPVecR2[i] * fPhh[i][i1];
+      beta = TMath::Abs(fPVecV[i1]);
+      //
+    } while ((i < nkrylov - 1) && (beta > eps1) && (its < itnlim));
+    //
+    // now compute solution. 1st, solve upper triangular system
+    fPVecV[i] = fPVecV[i] / fPhh[i][i];
+    for (int j = 1; j <= i; j++) {
+      int k = i - j;
+      for (t = fPVecV[k], l = k + 1; l <= i; l++)
+        t -= fPhh[l][k] * fPVecV[l];
+      fPVecV[k] = t / fPhh[k][k];
+    }
+    // --------------------  linear combination of v[i]'s to get sol.
+    for (int j = 0; j <= i; j++)
+      for (t = fPVecV[j], l = 0; l < fSize; l++)
+        VecSol[l] += t * fPvz[j][l];
+
+    // --------------------  restart outer loop if needed
+
+    if (beta <= eps1) {
+      timer.Stop();
+      LOG(info) << "FGMRES converged in " << its
+                << " iterations, CPU time: "
+                << std::setprecision(1) << timer.CpuTime() << " sec";
+      break; // success
+    }
+
+    if (its >= itnlim) {
+      timer.Stop();
+      LOG(error) << itnlim << " iterations limit exceeded, CPU time: "
+                 << std::setprecision(1) << timer.CpuTime() << " sec";
+      status = kFALSE;
+      break;
+    }
+  }
+
+  ClearAux();
+  return status;
+}
+
+//________________________________ MINRES METHODS ________________________________
+Bool_t MinResSolve::SolveMinRes(TVectorD& VecSol, Int_t precon, int itnlim, double rtol)
+{
+  // solve by minres
+  return SolveMinRes(VecSol.GetMatrixArray(), precon, itnlim, rtol);
+}
+
+//________________________________________________________________________________
+Bool_t MinResSolve::SolveMinRes(double* VecSol, Int_t precon, int itnlim, double rtol)
+{
+  /*
+    Adapted from author's Fortran code:
+    Michael A. Saunders           na.msaunders@na-net.ornl.gov
+
+    MINRES is an implementation of the algorithm described in the following reference:
+    C. C. Paige and M. A. Saunders (1975),
+    Solution of sparse indefinite systems of linear equations,
+    SIAM J. Numer. Anal. 12(4), pp. 617-629.
+
+  */
+  if (!fMatrix->IsSymmetric()) {
+    LOG(error) << "MinRes cannot solve asymmetric matrices, use FGMRes instead";
+    return kFALSE;
+  }
+
+  ClearAux();
+  const double eps = 2.22E-16;
+  double beta1;
+
+  if (precon > 0) {
+    if (precon >= kPreconsTot) {
+      LOG(warning) << "Unknown preconditioner identifier "
+                   << precon << ", ignore";
+    } else {
+      if (BuildPrecon(precon) < 0) {
+        ClearAux();
+        LOG(error) << "MinRes failed to build the preconditioner";
+        return kFALSE;
+      }
+    }
+  }
+  LOG(info) << "Solution by MinRes: Preconditioner #" << precon
+            << " Max.iter.: " << itnlim << " Tol.: "
+            << std::scientific << std::setprecision(3) << rtol;
+
+  // ------------------------ initialization  ---------------------->>>>
+  memset(VecSol, 0, fSize * sizeof(double));
+  int status = 0, itn = 0;
+  double normA = 0;
+  double condA = 0;
+  double ynorm = 0;
+  double rnorm = 0;
+  double gam, gmax = 1, gmin = 1, gbar, oldeps, epsa, epsx, epsr, diag, delta, phi, denom, z;
+
+  if (!InitAuxMinRes())
+    return kFALSE;
+
+  memset(VecSol, 0, fSize * sizeof(double));
+
+  // ------------ init aux -------------------------<<<<
+  //   Set up y and v for the first Lanczos vector v1.
+  //   y  =  beta1 P' v1,  where  P = C**(-1). v is really P' v1.
+
+  for (int i = fSize; i--;)
+    fPVecY[i] = fPVecR1[i] = fRHS[i];
+
+  if (precon > 0)
+    ApplyPrecon(fRHS, fPVecY);
+  beta1 = 0;
+  for (int i = fSize; i--;)
+    beta1 += fRHS[i] * fPVecY[i];
+
+  if (beta1 < 0) {
+    LOG(error) << "Preconditioner is indefinite (init) ("
+               << std::scientific << std::setprecision(3) << beta1 << ").";
+    ClearAux();
+    status = 7;
+    return kFALSE;
+  }
+
+  if (beta1 < eps) {
+    LOG(warning) << "RHS is zero or is the nullspace of the Preconditioner: Solution is {0}";
+    ClearAux();
+    return kTRUE;
+  }
+
+  beta1 = TMath::Sqrt(beta1); // Normalize y to get v1 later.
+
+  //      See if Msolve is symmetric. //RS: Skept
+  //      See if Aprod  is symmetric. //RS: Skept
+
+  double oldb = 0;
+  double beta = beta1;
+  double dbar = 0;
+  double epsln = 0;
+  double qrnorm = beta1;
+  double phibar = beta1;
+  double rhs1 = beta1;
+  double rhs2 = 0;
+  double tnorm2 = 0;
+  double ynorm2 = 0;
+  double cs = -1;
+  double sn = 0;
+  for (int i = fSize; i--;)
+    fPVecR2[i] = fPVecR1[i];
+
+  TStopwatch timer;
+  timer.Start();
+  while (status == 0) { //-----------------  Main iteration loop ---------------------->>>>
+
+    itn++;
+    /*-----------------------------------------------------------------
+      Obtain quantities for the next Lanczos vector vk+1, k = 1, 2,...
+      The general iteration is similar to the case k = 1 with v0 = 0:
+      p1      = Operator * v1  -  beta1 * v0,
+      alpha1  = v1'p1,
+      q2      = p2  -  alpha1 * v1,
+      beta2^2 = q2'q2,
+      v2      = (1/beta2) q2.
+      Again, y = betak P vk,  where  P = C**(-1).
+      .... more description needed.
+      -----------------------------------------------------------------*/
+
+    double s = 1. / beta; // Normalize previous vector (in y).
+    for (int i = fSize; i--;)
+      fPVecV[i] = s * fPVecY[i]; // v = vk if P = I
+
+    fMatrix->MultiplyByVec(fPVecV, fPVecY); //      APROD (VecV, VecY);
+
+    if (itn >= 2) {
+      double btrat = beta / oldb;
+      for (int i = fSize; i--;)
+        fPVecY[i] -= btrat * fPVecR1[i];
+    }
+    double alfa = 0;
+    for (int i = fSize; i--;)
+      alfa += fPVecV[i] * fPVecY[i]; //      alphak
+
+    double alf2bt = alfa / beta;
+    for (int i = fSize; i--;) {
+      fPVecY[i] -= alf2bt * fPVecR2[i];
+      fPVecR1[i] = fPVecR2[i];
+      fPVecR2[i] = fPVecY[i];
+    }
+
+    if (precon > 0)
+      ApplyPrecon(fPVecR2, fPVecY);
+
+    oldb = beta; //      oldb = betak
+    beta = 0;
+    for (int i = fSize; i--;)
+      beta += fPVecR2[i] * fPVecY[i]; // beta = betak+1^2
+
+    if (beta < 0) {
+      LOG(error) << "Preconditioner is indefinite ("
+                 << std::scientific << std::setprecision(3) << beta << ").";
+      status = 7;
+      break;
+    }
+
+    beta = TMath::Sqrt(beta); //            beta = betak+1
+    tnorm2 += alfa * alfa + oldb * oldb + beta * beta;
+
+    if (itn == 1) { //     Initialize a few things.
+      if (beta / beta1 <= 10.0 * eps) {
+        status = 0; //-1   //?????  beta2 = 0 or ~ 0,  terminate later.
+        LOG(info) << "RHS is eigenvector";
+      }
+      //        !tnorm2 = alfa**2
+      gmax = TMath::Abs(alfa); //              alpha1
+      gmin = gmax;             //              alpha1
+    }
+
+    /*
+      Apply previous rotation Qk-1 to get
+      [deltak epslnk+1] = [cs  sn][dbark    0   ]
+      [gbar k dbar k+1]   [sn -cs][alfak betak+1].
+    */
+
+    oldeps = epsln;
+    delta = cs * dbar + sn * alfa; //  delta1 = 0         deltak
+    gbar = sn * dbar - cs * alfa;  //  gbar 1 = alfa1     gbar k
+    epsln = sn * beta;             //  epsln2 = 0         epslnk+1
+    dbar = -cs * beta;             //  dbar 2 = beta2     dbar k+1
+
+    // Compute the next plane rotation Qk
+
+    gam = TMath::Sqrt(gbar * gbar + beta * beta); // gammak
+    cs = gbar / gam;                              // ck
+    sn = beta / gam;                              // sk
+    phi = cs * phibar;                            // phik
+    phibar = sn * phibar;                         // phibark+1
+
+    // Update  x.
+    denom = 1. / gam;
+
+    for (int i = fSize; i--;) {
+      fPVecW1[i] = fPVecW2[i];
+      fPVecW2[i] = fPVecW[i];
+      fPVecW[i] = denom * (fPVecV[i] - oldeps * fPVecW1[i] - delta * fPVecW2[i]);
+      VecSol[i] += phi * fPVecW[i];
+    }
+
+    //  Go round again.
+
+    gmax = TMath::Max(gmax, gam);
+    gmin = TMath::Min(gmin, gam);
+    z = rhs1 / gam;
+    ynorm2 += z * z;
+    rhs1 = rhs2 - delta * z;
+    rhs2 = -epsln * z;
+
+    //   Estimate various norms and test for convergence.
+    normA = TMath::Sqrt(tnorm2);
+    ynorm = TMath::Sqrt(ynorm2);
+    epsa = normA * eps;
+    epsx = normA * ynorm * eps;
+    epsr = normA * ynorm * rtol;
+    diag = gbar;
+    if (diag == 0)
+      diag = epsa;
+    //
+    qrnorm = phibar;
+    rnorm = qrnorm;
+    /*
+      Estimate  cond(A).
+      In this version we look at the diagonals of  R  in the
+      factorization of the lower Hessenberg matrix,  Q * H = R,
+      where H is the tridiagonal matrix from Lanczos with one
+      extra row, beta(k+1) e_k^T.
+    */
+    condA = gmax / gmin;
+
+    // See if any of the stopping criteria are satisfied.
+    // In rare cases, istop is already -1 from above (Abar = const*I).
+
+    LOG(debug) << Form("#%5d |qnrm: %+.2e Anrm:%+.2e Cnd:%+.2e Rnrm:%+.2e Ynrm:%+.2e EpsR:%+.2e EpsX:%+.2e Beta1:%+.2e",
+                       itn, qrnorm, normA, condA, rnorm, ynorm, epsr, epsx, beta1);
+
+    if (status == 0) {
+      if (itn >= itnlim) {
+        status = 5;
+        LOG(error) << itnlim << " iterations limit exceeded";
+      }
+      if (condA >= 0.1 / eps) {
+        status = 4;
+        LOG(error) << "Matrix condition number "
+                   << std::scientific << std::setprecision(3) << condA
+                   << " exceeds limit "
+                   << std::scientific << std::setprecision(3) << 0.1 / eps;
+      }
+      if (epsx >= beta1) {
+        status = 3;
+        LOG(warning) << "Approximate convergence";
+      }
+      if (qrnorm <= epsx) {
+        status = 2;
+        LOG(info) << "Converged within machine precision";
+      }
+      if (qrnorm <= epsr) {
+        status = 1;
+        LOG(info) << "Converged";
+      }
+    }
+
+  } //-----------------  Main iteration loop ----------------------<<<
+
+  ClearAux();
+
+  timer.Stop();
+  LOG(info) << Form(
+    "Exit from MinRes: CPU time: %.2f sec\n"
+    "Status    :  %2d\n"
+    "Iterations:  %4d\n"
+    "Norm      :  %+e\n"
+    "Condition :  %+e\n"
+    "Res.Norm  :  %+e\n"
+    "Sol.Norm  :  %+e",
+    timer.CpuTime(), status, itn, normA, condA, rnorm, ynorm);
+
+  return status >= 0 && status <= 3;
+}
+
+//______________________________________________________________
+void MinResSolve::ApplyPrecon(const TVectorD& vecRHS, TVectorD& vecOut) const
+{
+  // apply precond.
+  ApplyPrecon(vecRHS.GetMatrixArray(), vecOut.GetMatrixArray());
+}
+
+//______________________________________________________________
+void MinResSolve::ApplyPrecon(const double* vecRHS, double* vecOut) const
+{
+  if (fPrecon >= kPreconBD && fPrecon < kPreconILU0) { // band diagonal decomposition
+    fMatBD->Solve(vecRHS, vecOut);
+    //    return;
+  }
+
+  else if (fPrecon >= kPreconILU0 && fPrecon <= kPreconILU10) {
+
+    for (int i = 0; i < fSize; i++) { // Block L solve
+      vecOut[i] = vecRHS[i];
+      VectorSparse& rowLi = *fMatL->GetRow(i);
+      int n = rowLi.GetNElems();
+      for (int j = 0; j < n; j++)
+        vecOut[i] -= vecOut[rowLi.GetIndex(j)] * rowLi.GetElem(j);
+    }
+
+    for (int i = fSize; i--;) { // Block -- U solve
+      VectorSparse& rowUi = *fMatU->GetRow(i);
+      int n = rowUi.GetNElems();
+      for (int j = 0; j < n; j++)
+        vecOut[i] -= vecOut[rowUi.GetIndex(j)] * rowUi.GetElem(j);
+      vecOut[i] *= fDiagLU[i];
+    }
+  }
+}
+
+//___________________________________________________________
+Bool_t MinResSolve::InitAuxMinRes()
+{
+  fPVecY = new double[fSize];
+  fPVecR1 = new double[fSize];
+  fPVecR2 = new double[fSize];
+  fPVecV = new double[fSize];
+  fPVecW = new double[fSize];
+  fPVecW1 = new double[fSize];
+  fPVecW2 = new double[fSize];
+
+  for (int i = fSize; i--;)
+    fPVecY[i] = fPVecR1[i] = fPVecR2[i] = fPVecV[i] = fPVecW[i] = fPVecW1[i] = fPVecW2[i] = 0.0;
+
+  return kTRUE;
+}
+
+//___________________________________________________________
+Bool_t MinResSolve::InitAuxFGMRES(int nkrylov)
+{
+  fPvv = new double*[nkrylov + 1];
+  fPvz = new double*[nkrylov];
+  for (int i = 0; i <= nkrylov; i++)
+    fPvv[i] = new double[fSize];
+  fPhh = new double*[nkrylov];
+  for (int i = 0; i < nkrylov; i++) {
+    fPhh[i] = new double[i + 2];
+    fPvz[i] = new double[fSize];
+  }
+
+  fPVecR1 = new double[nkrylov];
+  fPVecR2 = new double[nkrylov];
+  fPVecV = new double[nkrylov + 1];
+
+  return kTRUE;
+}
+
+//___________________________________________________________
+void MinResSolve::ClearAux()
+{
+  if (fPVecY)
+    delete[] fPVecY;
+  fPVecY = 0;
+  if (fPVecR1)
+    delete[] fPVecR1;
+  fPVecR1 = 0;
+  if (fPVecR2)
+    delete[] fPVecR2;
+  fPVecR2 = 0;
+  if (fPVecV)
+    delete[] fPVecV;
+  fPVecV = 0;
+  if (fPVecW)
+    delete[] fPVecW;
+  fPVecW = 0;
+  if (fPVecW1)
+    delete[] fPVecW1;
+  fPVecW1 = 0;
+  if (fPVecW2)
+    delete[] fPVecW2;
+  fPVecW2 = 0;
+  if (fDiagLU)
+    delete[] fDiagLU;
+  fDiagLU = 0;
+  if (fMatL)
+    delete fMatL;
+  fMatL = 0;
+  if (fMatU)
+    delete fMatU;
+  fMatU = 0;
+  if (fMatBD)
+    delete fMatBD;
+  fMatBD = 0;
+}
+
+//___________________________________________________________
+Int_t MinResSolve::BuildPreconBD(Int_t hwidth)
+{
+  LOG(info) << "Building Band-Diagonal preconditioner of half-width = "
+            << hwidth;
+  fMatBD = new SymBDMatrix(fMatrix->GetSize(), hwidth);
+
+  // fill the band-diagonal part of the matrix
+  if (fMatrix->InheritsFrom("MatrixSparse")) {
+    for (int ir = fMatrix->GetSize(); ir--;) {
+      int jmin = TMath::Max(0, ir - hwidth);
+      VectorSparse& irow = *((MatrixSparse*)fMatrix)->GetRow(ir);
+      for (int j = irow.GetNElems(); j--;) {
+        int jind = irow.GetIndex(j);
+        if (jind < jmin)
+          break;
+        (*fMatBD)(ir, jind) = irow.GetElem(j);
+      }
+    }
+  } else {
+    for (int ir = fMatrix->GetSize(); ir--;) {
+      int jmin = TMath::Max(0, ir - hwidth);
+      for (int jr = jmin; jr <= ir; jr++)
+        (*fMatBD)(ir, jr) = fMatrix->Query(ir, jr);
+    }
+  }
+
+  fMatBD->DecomposeLDLT();
+
+  return 0;
+}
+
+//___________________________________________________________
+Int_t MinResSolve::BuildPreconILUK(Int_t lofM)
+{
+  /*----------------------------------------------------------------------------
+   * ILUK preconditioner
+   * incomplete LU factorization with level of fill dropping
+   * Adapted from iluk.c of ITSOL_1 package by Y.Saad: http://www-users.cs.umn.edu/~saad/software/
+   *----------------------------------------------------------------------------*/
+
+  LOG(info) << "Building ILU" << lofM << " preconditioner";
+
+  TStopwatch sw;
+  sw.Start();
+  fMatL = new MatrixSparse(fSize);
+  fMatU = new MatrixSparse(fSize);
+  fMatL->SetSymmetric(kFALSE);
+  fMatU->SetSymmetric(kFALSE);
+  fDiagLU = new Double_t[fSize];
+  MatrixSparse* matrix = (MatrixSparse*)fMatrix;
+
+  // symbolic factorization to calculate level of fill index arrays
+  if (PreconILUKsymb(lofM) < 0) {
+    ClearAux();
+    return -1;
+  }
+
+  Int_t* jw = new Int_t[fSize];
+  for (int j = fSize; j--;)
+    jw[j] = -1; // set indicator array jw to -1
+
+  for (int i = 0; i < fSize; i++) { // beginning of main loop
+    if ((i % int(0.1 * fSize)) == 0) {
+      LOG(info) << "BuildPrecon: row " << i << " of " << fSize;
+      sw.Stop();
+      sw.Print();
+      sw.Start(kFALSE);
+    }
+    /* setup array jw[], and initial i-th row */
+    VectorSparse& rowLi = *fMatL->GetRow(i);
+    VectorSparse& rowUi = *fMatU->GetRow(i);
+    VectorSparse& rowM = *matrix->GetRow(i);
+    //
+    for (int j = rowLi.GetNElems(); j--;) { // initialize L part
+      int col = rowLi.GetIndex(j);
+      jw[col] = j;
+      rowLi.GetElem(j) = 0.; // do we need this ?
+    }
+    jw[i] = i;
+    fDiagLU[i] = 0; // initialize diagonal
+    //
+    for (int j = rowUi.GetNElems(); j--;) { // initialize U part
+      int col = rowUi.GetIndex(j);
+      jw[col] = j;
+      rowUi.GetElem(j) = 0;
+    }
+    // copy row from csmat into L,U D
+    for (int j = rowM.GetNElems(); j--;) { // L and D part
+      if (MatrixSq::IsZero(rowM.GetElem(j)))
+        continue;
+      int col = rowM.GetIndex(j); // (the original matrix stores only lower triangle)
+      if (col < i)
+        rowLi.GetElem(jw[col]) = rowM.GetElem(j);
+      else if (col == i)
+        fDiagLU[i] = rowM.GetElem(j);
+      else
+        rowUi.GetElem(jw[col]) = rowM.GetElem(j);
+    }
+    if (matrix->IsSymmetric())
+      for (int col = i + 1; col < fSize; col++) { // part of the row I on the right of diagonal is stored as
+        double vl = matrix->Query(col, i);        // the lower part of the column I
+        if (MatrixSq::IsZero(vl))
+          continue;
+        rowUi.GetElem(jw[col]) = vl;
+      }
+
+    // eliminate previous rows
+    for (int j = 0; j < rowLi.GetNElems(); j++) {
+      int jrow = rowLi.GetIndex(j);
+      // get the multiplier for row to be eliminated (jrow)
+      rowLi.GetElem(j) *= fDiagLU[jrow];
+      //
+      // combine current row and row jrow
+      VectorSparse& rowUj = *fMatU->GetRow(jrow);
+      for (int k = 0; k < rowUj.GetNElems(); k++) {
+        int col = rowUj.GetIndex(k);
+        int jpos = jw[col];
+        if (jpos == -1)
+          continue;
+        if (col < i)
+          rowLi.GetElem(jpos) -= rowLi.GetElem(j) * rowUj.GetElem(k);
+        else if (col == i)
+          fDiagLU[i] -= rowLi.GetElem(j) * rowUj.GetElem(k);
+        else
+          rowUi.GetElem(jpos) -= rowLi.GetElem(j) * rowUj.GetElem(k);
+      }
+    }
+    // reset double-pointer to -1 ( U-part)
+    for (int j = rowLi.GetNElems(); j--;)
+      jw[rowLi.GetIndex(j)] = -1;
+    jw[i] = -1;
+    for (int j = rowUi.GetNElems(); j--;)
+      jw[rowUi.GetIndex(j)] = -1;
+
+    if (MatrixSq::IsZero(fDiagLU[i])) {
+      LOG(fatal) << "Fatal error in ILIk: Zero diagonal found...";
+      delete[] jw;
+      return -1;
+    }
+    fDiagLU[i] = 1.0 / fDiagLU[i];
+  }
+
+  delete[] jw;
+
+  sw.Stop();
+  LOG(info) << "ILU" << lofM << "preconditioner OK, CPU time: "
+            << std::setprecision(1) << sw.CpuTime() << " sec";
+  LOG(info) << "Densities: M " << matrix->GetDensity()
+            << " L " << fMatL->GetDensity()
+            << " U " << fMatU->GetDensity();
+
+  return 0;
+}
+
+//___________________________________________________________
+Int_t MinResSolve::BuildPreconILUKDense(Int_t lofM)
+{
+  /*----------------------------------------------------------------------------
+   * ILUK preconditioner
+   * incomplete LU factorization with level of fill dropping
+   * Adapted from iluk.c of ITSOL_1 package by Y.Saad: http://www-users.cs.umn.edu/~saad/software/
+   *----------------------------------------------------------------------------*/
+
+  TStopwatch sw;
+  sw.Start();
+  LOG(info) << "Building ILU" << lofM
+            << " preconditioner for dense matrix";
+
+  fMatL = new MatrixSparse(fSize);
+  fMatU = new MatrixSparse(fSize);
+  fMatL->SetSymmetric(kFALSE);
+  fMatU->SetSymmetric(kFALSE);
+  fDiagLU = new Double_t[fSize];
+
+  // symbolic factorization to calculate level of fill index arrays
+  if (PreconILUKsymbDense(lofM) < 0) {
+    ClearAux();
+    return -1;
+  }
+
+  Int_t* jw = new Int_t[fSize];
+  for (int j = fSize; j--;)
+    jw[j] = -1; // set indicator array jw to -1
+
+  for (int i = 0; i < fSize; i++) { // beginning of main loop
+    /* setup array jw[], and initial i-th row */
+    VectorSparse& rowLi = *fMatL->GetRow(i);
+    VectorSparse& rowUi = *fMatU->GetRow(i);
+
+    for (int j = rowLi.GetNElems(); j--;) { // initialize L part
+      int col = rowLi.GetIndex(j);
+      jw[col] = j;
+      rowLi.GetElem(j) = 0.; // do we need this ?
+    }
+    jw[i] = i;
+    fDiagLU[i] = 0; // initialize diagonal
+
+    for (int j = rowUi.GetNElems(); j--;) { // initialize U part
+      int col = rowUi.GetIndex(j);
+      jw[col] = j;
+      rowUi.GetElem(j) = 0;
+    }
+    // copy row from csmat into L,U D
+    for (int j = fSize; j--;) { // L and D part
+      double vl = fMatrix->Query(i, j);
+      if (MatrixSq::IsZero(vl))
+        continue;
+      if (j < i)
+        rowLi.GetElem(jw[j]) = vl;
+      else if (j == i)
+        fDiagLU[i] = vl;
+      else
+        rowUi.GetElem(jw[j]) = vl;
+    }
+    // eliminate previous rows
+    for (int j = 0; j < rowLi.GetNElems(); j++) {
+      int jrow = rowLi.GetIndex(j);
+      // get the multiplier for row to be eliminated (jrow)
+      rowLi.GetElem(j) *= fDiagLU[jrow];
+
+      // combine current row and row jrow
+      VectorSparse& rowUj = *fMatU->GetRow(jrow);
+      for (int k = 0; k < rowUj.GetNElems(); k++) {
+        int col = rowUj.GetIndex(k);
+        int jpos = jw[col];
+        if (jpos == -1)
+          continue;
+        if (col < i)
+          rowLi.GetElem(jpos) -= rowLi.GetElem(j) * rowUj.GetElem(k);
+        else if (col == i)
+          fDiagLU[i] -= rowLi.GetElem(j) * rowUj.GetElem(k);
+        else
+          rowUi.GetElem(jpos) -= rowLi.GetElem(j) * rowUj.GetElem(k);
+      }
+    }
+    // reset double-pointer to -1 ( U-part)
+    for (int j = rowLi.GetNElems(); j--;)
+      jw[rowLi.GetIndex(j)] = -1;
+    jw[i] = -1;
+    for (int j = rowUi.GetNElems(); j--;)
+      jw[rowUi.GetIndex(j)] = -1;
+
+    if (MatrixSq::IsZero(fDiagLU[i])) {
+      LOG(fatal) << "Fatal error in ILIk: Zero diagonal found...";
+      delete[] jw;
+      return -1;
+    }
+    fDiagLU[i] = 1.0 / fDiagLU[i];
+  }
+
+  delete[] jw;
+
+  sw.Stop();
+  LOG(info) << "ILU" << lofM << " dense preconditioner OK, CPU time: "
+            << std::setprecision(1) << sw.CpuTime()
+            << " sec";
+  /*
+  LOG(info) << "Densities: M " << matrix->GetDensity()
+  << " L " << fMatL->GetDensity()
+  << " U " << fMatU->GetDensity();
+  */
+  return 0;
+}
+
+//___________________________________________________________
+Int_t MinResSolve::PreconILUKsymb(Int_t lofM)
+{
+  /*----------------------------------------------------------------------------
+   * ILUK preconditioner
+   * incomplete LU factorization with level of fill dropping
+   * Adapted from iluk.c: lofC of ITSOL_1 package by Y.Saad: http://www-users.cs.umn.edu/~saad/software/
+   *----------------------------------------------------------------------------*/
+
+  TStopwatch sw;
+  LOG(info) << "PreconILUKsymb >>";
+  MatrixSparse* matrix = (MatrixSparse*)fMatrix;
+  sw.Start();
+
+  UChar_t **ulvl = 0, *levls = 0;
+  UShort_t* jbuf = 0;
+  Int_t* iw = 0;
+  ulvl = new UChar_t*[fSize]; // stores lev-fils for U part of ILU factorization
+  levls = new UChar_t[fSize];
+  jbuf = new UShort_t[fSize];
+  iw = new Int_t[fSize];
+
+  for (int j = fSize; j--;)
+    iw[j] = -1; // initialize iw
+  for (int i = 0; i < fSize; i++) {
+    int incl = 0;
+    int incu = i;
+    VectorSparse& row = *matrix->GetRow(i);
+
+    // assign lof = 0 for matrix elements
+    for (int j = 0; j < row.GetNElems(); j++) {
+      int col = row.GetIndex(j);
+      if (MatrixSq::IsZero(row.GetElem(j)))
+        continue;    // !!!! matrix is sparse but sometimes 0 appears
+      if (col < i) { // L-part
+        jbuf[incl] = col;
+        levls[incl] = 0;
+        iw[col] = incl++;
+      } else if (col > i) { // This works only for general matrix
+        jbuf[incu] = col;
+        levls[incu] = 0;
+        iw[col] = incu++;
+      }
+    }
+    if (matrix->IsSymmetric())
+      for (int col = i + 1; col < fSize; col++) { // U-part of symmetric matrix
+        if (MatrixSq::IsZero(matrix->Query(col, i)))
+          continue; // Due to the symmetry  == matrix(i,col)
+        jbuf[incu] = col;
+        levls[incu] = 0;
+        iw[col] = incu++;
+      }
+
+    // symbolic k,i,j Gaussian elimination
+    int jpiv = -1;
+    while (++jpiv < incl) {
+      int k = jbuf[jpiv]; // select leftmost pivot
+      int kmin = k;
+      int jmin = jpiv;
+      for (int j = jpiv + 1; j < incl; j++)
+        if (jbuf[j] < kmin) {
+          kmin = jbuf[j];
+          jmin = j;
+        }
+
+      // ------------------------------------  swap
+      if (jmin != jpiv) {
+        jbuf[jpiv] = kmin;
+        jbuf[jmin] = k;
+        iw[kmin] = jpiv;
+        iw[k] = jmin;
+        int tj = levls[jpiv];
+        levls[jpiv] = levls[jmin];
+        levls[jmin] = tj;
+        k = kmin;
+      }
+      // ------------------------------------ symbolic linear combinaiton of rows
+      VectorSparse& rowU = *fMatU->GetRow(k);
+      for (int j = 0; j < rowU.GetNElems(); j++) {
+        int col = rowU.GetIndex(j);
+        int it = ulvl[k][j] + levls[jpiv] + 1;
+        if (it > lofM)
+          continue;
+        int ip = iw[col];
+        if (ip == -1) {
+          if (col < i) {
+            jbuf[incl] = col;
+            levls[incl] = it;
+            iw[col] = incl++;
+          } else if (col > i) {
+            jbuf[incu] = col;
+            levls[incu] = it;
+            iw[col] = incu++;
+          }
+        } else
+          levls[ip] = TMath::Min(levls[ip], it);
+      }
+    } // end - while loop
+
+    // reset iw
+    for (int j = 0; j < incl; j++)
+      iw[jbuf[j]] = -1;
+    for (int j = i; j < incu; j++)
+      iw[jbuf[j]] = -1;
+
+    // copy L-part
+    VectorSparse& rowLi = *fMatL->GetRow(i);
+    rowLi.ReSize(incl);
+    if (incl > 0)
+      memcpy(rowLi.GetIndices(), jbuf, sizeof(UShort_t) * incl);
+    // copy U-part
+    int k = incu - i;
+    VectorSparse& rowUi = *fMatU->GetRow(i);
+    rowUi.ReSize(k);
+    if (k > 0) {
+      memcpy(rowUi.GetIndices(), jbuf + i, sizeof(UShort_t) * k);
+      ulvl[i] = new UChar_t[k]; // update matrix of levels
+      memcpy(ulvl[i], levls + i, k * sizeof(UChar_t));
+    }
+  }
+
+  // free temp space and leave
+  delete[] levls;
+  delete[] jbuf;
+  for (int i = fSize; i--;)
+    if (fMatU->GetRow(i)->GetNElems())
+      delete[] ulvl[i];
+  delete[] ulvl;
+  delete[] iw;
+
+  fMatL->SortIndices();
+  fMatU->SortIndices();
+  sw.Stop();
+  sw.Print();
+  LOG(info) << "PreconILUKsymb <<";
+  return 0;
+}
+
+//___________________________________________________________
+Int_t MinResSolve::PreconILUKsymbDense(Int_t lofM)
+{
+  /*----------------------------------------------------------------------------
+   * ILUK preconditioner
+   * incomplete LU factorization with level of fill dropping
+   * Adapted from iluk.c: lofC of ITSOL_1 package by Y.Saad: http://www-users.cs.umn.edu/~saad/software/
+   *----------------------------------------------------------------------------*/
+  //
+  UChar_t **ulvl = 0, *levls = 0;
+  UShort_t* jbuf = 0;
+  Int_t* iw = 0;
+  ulvl = new UChar_t*[fSize]; // stores lev-fils for U part of ILU factorization
+  levls = new UChar_t[fSize];
+  jbuf = new UShort_t[fSize];
+  iw = new Int_t[fSize];
+
+  for (int j = fSize; j--;)
+    iw[j] = -1; // initialize iw
+  for (int i = 0; i < fSize; i++) {
+    int incl = 0;
+    int incu = i;
+
+    // assign lof = 0 for matrix elements
+    for (int j = 0; j < fSize; j++) {
+      if (MatrixSq::IsZero(fMatrix->Query(i, j)))
+        continue;
+      if (j < i) { // L-part
+        jbuf[incl] = j;
+        levls[incl] = 0;
+        iw[j] = incl++;
+      } else if (j > i) { // This works only for general matrix
+        jbuf[incu] = j;
+        levls[incu] = 0;
+        iw[j] = incu++;
+      }
+    }
+
+    // symbolic k,i,j Gaussian elimination
+    int jpiv = -1;
+    while (++jpiv < incl) {
+      int k = jbuf[jpiv]; // select leftmost pivot
+      int kmin = k;
+      int jmin = jpiv;
+      for (int j = jpiv + 1; j < incl; j++)
+        if (jbuf[j] < kmin) {
+          kmin = jbuf[j];
+          jmin = j;
+        }
+
+      // ------------------------------------  swap
+      if (jmin != jpiv) {
+        jbuf[jpiv] = kmin;
+        jbuf[jmin] = k;
+        iw[kmin] = jpiv;
+        iw[k] = jmin;
+        int tj = levls[jpiv];
+        levls[jpiv] = levls[jmin];
+        levls[jmin] = tj;
+        k = kmin;
+      }
+      // ------------------------------------ symbolic linear combinaiton of rows
+      VectorSparse& rowU = *fMatU->GetRow(k);
+      for (int j = 0; j < rowU.GetNElems(); j++) {
+        int col = rowU.GetIndex(j);
+        int it = ulvl[k][j] + levls[jpiv] + 1;
+        if (it > lofM)
+          continue;
+        int ip = iw[col];
+        if (ip == -1) {
+          if (col < i) {
+            jbuf[incl] = col;
+            levls[incl] = it;
+            iw[col] = incl++;
+          } else if (col > i) {
+            jbuf[incu] = col;
+            levls[incu] = it;
+            iw[col] = incu++;
+          }
+        } else
+          levls[ip] = TMath::Min(levls[ip], it);
+      }
+    } // end - while loop
+
+    // reset iw
+    for (int j = 0; j < incl; j++)
+      iw[jbuf[j]] = -1;
+    for (int j = i; j < incu; j++)
+      iw[jbuf[j]] = -1;
+
+    // copy L-part
+    VectorSparse& rowLi = *fMatL->GetRow(i);
+    rowLi.ReSize(incl);
+    if (incl > 0)
+      memcpy(rowLi.GetIndices(), jbuf, sizeof(UShort_t) * incl);
+    // copy U-part
+    int k = incu - i;
+    VectorSparse& rowUi = *fMatU->GetRow(i);
+    rowUi.ReSize(k);
+    if (k > 0) {
+      memcpy(rowUi.GetIndices(), jbuf + i, sizeof(UShort_t) * k);
+      ulvl[i] = new UChar_t[k]; // update matrix of levels
+      memcpy(ulvl[i], levls + i, k * sizeof(UChar_t));
+    }
+  }
+
+  // free temp space and leave
+  delete[] levls;
+  delete[] jbuf;
+  for (int i = fSize; i--;)
+    if (fMatU->GetRow(i)->GetNElems())
+      delete[] ulvl[i];
+  delete[] ulvl;
+  delete[] iw;
+
+  fMatL->SortIndices();
+  fMatU->SortIndices();
+  return 0;
+}

--- a/Detectors/ITSMFT/MFT/alignment/src/RecordsToAlignParams.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/RecordsToAlignParams.cxx
@@ -57,8 +57,9 @@ RecordsToAlignParams::~RecordsToAlignParams()
 //__________________________________________________________________________
 void RecordsToAlignParams::init()
 {
-  if (mIsInitDone)
+  if (mIsInitDone) {
     return;
+  }
 
   mMillepede->SetRecordReader(mRecordReader);
 
@@ -112,8 +113,9 @@ void RecordsToAlignParams::globalFit()
 
   // initialize the file and tree to store chi2 from Millepede LocalFit()
 
-  if (mWithControl)
+  if (mWithControl) {
     mMillepede->InitChi2Storage(mNEntriesAutoSave);
+  }
 
   // allocate memory in arrays to temporarily store the results of the global fit
 
@@ -133,8 +135,9 @@ void RecordsToAlignParams::globalFit()
 
   mMillepede->GlobalFit(params, paramsErrors, paramsPulls);
 
-  if (mWithControl)
+  if (mWithControl) {
     mMillepede->EndChi2Storage();
+  }
 
   // post-treatment:
   // debug output + save Millepede global fit result in AlignParam vector

--- a/Detectors/ITSMFT/MFT/alignment/src/RecordsToAlignParams.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/RecordsToAlignParams.cxx
@@ -1,0 +1,191 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file RecordsToAlignParams.cxx
+
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include "Framework/Logger.h"
+#include "MFTAlignment/AlignSensorHelper.h"
+#include "MFTAlignment/RecordsToAlignParams.h"
+
+using namespace o2::mft;
+
+ClassImp(o2::mft::RecordsToAlignParams);
+
+//__________________________________________________________________________
+RecordsToAlignParams::RecordsToAlignParams()
+  : Aligner(),
+    mWithControl(false),
+    mNEntriesAutoSave(10000),
+    mRecordReader(new MilleRecordReader()),
+    mWithConstraintsRecReader(false),
+    mConstraintsRecReader(nullptr),
+    mMillepede(new MillePede2())
+{
+  if (mWithConstraintsRecReader) {
+    mConstraintsRecReader = new MilleRecordReader();
+  }
+  LOGF(debug, "RecordsToAlignParams instantiated");
+}
+
+//__________________________________________________________________________
+RecordsToAlignParams::~RecordsToAlignParams()
+{
+  if (mConstraintsRecReader) {
+    delete mConstraintsRecReader;
+  }
+  if (mMillepede) {
+    delete mMillepede;
+  }
+  if (mRecordReader) {
+    delete mRecordReader;
+  }
+  LOGF(debug, "RecordsToAlignParams destroyed");
+}
+
+//__________________________________________________________________________
+void RecordsToAlignParams::init()
+{
+  if (mIsInitDone)
+    return;
+
+  mMillepede->SetRecordReader(mRecordReader);
+
+  if (mWithConstraintsRecReader) {
+    mMillepede->SetConstraintsRecReader(mConstraintsRecReader);
+  }
+
+  mMillepede->InitMille(mNumberOfGlobalParam,
+                        mNumberOfTrackParam,
+                        mChi2CutNStdDev,
+                        mResCut,
+                        mResCutInitial);
+
+  LOG(info) << "-------------- RecordsToAlignParams configured with -----------------";
+  LOGF(info, "Chi2CutNStdDev = %d", mChi2CutNStdDev);
+  LOGF(info, "ResidualCutInitial = %.3f", mResCutInitial);
+  LOGF(info, "ResidualCut = %.3f", mResCut);
+  LOGF(info, "mStartFac = %.3f", mStartFac);
+  LOGF(info,
+       "Allowed variation: dx = %.3f, dy = %.3f, dz = %.3f, dRz = %.4f",
+       mAllowVar[0], mAllowVar[1], mAllowVar[3], mAllowVar[2]);
+  LOG(info) << "-----------------------------------------------------------";
+
+  // set allowed variations for all parameters
+  for (int chipId = 0; chipId < mNumberOfSensors; ++chipId) {
+    for (Int_t iPar = 0; iPar < mNDofPerSensor; ++iPar) {
+      mMillepede->SetParSigma(chipId * mNDofPerSensor + iPar, mAllowVar[iPar]);
+    }
+  }
+
+  // set iterations
+  if (mStartFac > 1) {
+    mMillepede->SetIterations(mStartFac);
+  }
+
+  LOGF(info, "RecordsToAlignParams init done");
+  mIsInitDone = true;
+}
+
+//__________________________________________________________________________
+void RecordsToAlignParams::globalFit()
+{
+  if (!mIsInitDone) {
+    LOGF(fatal, "RecordsToAlignParams::globalFit() aborted because init was not done !");
+    return;
+  }
+  if (!mRecordReader || !mRecordReader->isReaderOk() || !mRecordReader->getNEntries()) {
+    LOGF(fatal, "RecordsToAlignParams::globalFit() aborted because no data record can be read !");
+    return;
+  }
+
+  // initialize the file and tree to store chi2 from Millepede LocalFit()
+
+  if (mWithControl)
+    mMillepede->InitChi2Storage(mNEntriesAutoSave);
+
+  // allocate memory in arrays to temporarily store the results of the global fit
+
+  double* params = (double*)malloc(sizeof(double) * mNumberOfGlobalParam);
+  double* paramsErrors = (double*)malloc(sizeof(double) * mNumberOfGlobalParam);
+  double* paramsPulls = (double*)malloc(sizeof(double) * mNumberOfGlobalParam);
+
+  // initialise the content of each array
+
+  for (int ii = 0; ii < mNumberOfGlobalParam; ii++) {
+    params[ii] = 0.;
+    paramsErrors[ii] = 0.;
+    paramsPulls[ii] = 0.;
+  }
+
+  // perform the simultaneous fit of track and alignement parameters
+
+  mMillepede->GlobalFit(params, paramsErrors, paramsPulls);
+
+  if (mWithControl)
+    mMillepede->EndChi2Storage();
+
+  // post-treatment:
+  // debug output + save Millepede global fit result in AlignParam vector
+
+  LOGF(info, "RecordsToAlignParams::globalFit() - done, results below");
+  LOGF(info, "sensor info, dx (cm), dy (cm), dz (cm), dRz (rad)");
+
+  AlignSensorHelper chipHelper;
+  double dRx = 0., dRy = 0., dRz = 0.; // delta rotations
+  double dx = 0., dy = 0., dz = 0.;    // delta translations
+  bool global = true;                  // delta in global ref. system
+  bool withSymName = false;
+
+  for (int chipId = 0; chipId < mNumberOfSensors; chipId++) {
+    chipHelper.setSensorOnlyInfo(chipId);
+    std::stringstream name = chipHelper.getSensorFullName(withSymName);
+    dx = params[chipId * mNDofPerSensor + 0];
+    dy = params[chipId * mNDofPerSensor + 1];
+    dz = params[chipId * mNDofPerSensor + 3];
+    dRz = params[chipId * mNDofPerSensor + 2];
+    LOGF(info,
+         "%s, %.3e, %.3e, %.3e, %.3e",
+         name.str().c_str(), dx, dy, dz, dRz);
+    mAlignParams.emplace_back(
+      chipHelper.geoSymbolicName(),
+      chipHelper.sensorUid(),
+      dx, dy, dz,
+      dRx, dRy, dRz,
+      global);
+  }
+
+  // free allocated memory
+
+  free(params);
+  free(paramsErrors);
+  free(paramsPulls);
+}
+
+//__________________________________________________________________________
+void RecordsToAlignParams::connectRecordReaderToChain(TChain* ch)
+{
+  if (mRecordReader) {
+    mRecordReader->connectToChain(ch);
+  }
+}
+
+//__________________________________________________________________________
+void RecordsToAlignParams::connectConstraintsRecReaderToChain(TChain* ch)
+{
+  if (mConstraintsRecReader) {
+    mConstraintsRecReader->changeDataBranchName();
+    mConstraintsRecReader->connectToChain(ch);
+  }
+}

--- a/Detectors/ITSMFT/MFT/alignment/src/RectMatrix.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/RectMatrix.cxx
@@ -22,7 +22,7 @@ ClassImp(RectMatrix);
 RectMatrix::RectMatrix()
   : fNRows(0),
     fNCols(0),
-    fRows(0)
+    fRows(nullptr)
 {
 }
 
@@ -30,7 +30,7 @@ RectMatrix::RectMatrix()
 RectMatrix::RectMatrix(Int_t nrow, Int_t ncol)
   : fNRows(nrow),
     fNCols(ncol),
-    fRows(0)
+    fRows(nullptr)
 {
   fRows = new Double_t*[fNRows];
   for (int i = fNRows; i--;) {
@@ -44,7 +44,7 @@ RectMatrix::RectMatrix(const RectMatrix& src)
   : TObject(src),
     fNRows(src.fNRows),
     fNCols(src.fNCols),
-    fRows(0)
+    fRows(nullptr)
 {
   fRows = new Double_t*[fNRows];
   for (int i = fNRows; i--;) {

--- a/Detectors/ITSMFT/MFT/alignment/src/RectMatrix.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/RectMatrix.cxx
@@ -1,0 +1,108 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file RectMatrix.cxx
+
+#include <TString.h>
+#include "MFTAlignment/RectMatrix.h"
+
+using namespace o2::mft;
+
+ClassImp(RectMatrix);
+
+//___________________________________________________________
+RectMatrix::RectMatrix()
+  : fNRows(0),
+    fNCols(0),
+    fRows(0)
+{
+}
+
+//___________________________________________________________
+RectMatrix::RectMatrix(Int_t nrow, Int_t ncol)
+  : fNRows(nrow),
+    fNCols(ncol),
+    fRows(0)
+{
+  fRows = new Double_t*[fNRows];
+  for (int i = fNRows; i--;) {
+    fRows[i] = new Double_t[fNCols];
+    memset(fRows[i], 0, fNCols * sizeof(Double_t));
+  }
+}
+
+//___________________________________________________________
+RectMatrix::RectMatrix(const RectMatrix& src)
+  : TObject(src),
+    fNRows(src.fNRows),
+    fNCols(src.fNCols),
+    fRows(0)
+{
+  fRows = new Double_t*[fNRows];
+  for (int i = fNRows; i--;) {
+    fRows[i] = new Double_t[fNCols];
+    memcpy(fRows[i], src.fRows[i], fNCols * sizeof(Double_t));
+  }
+}
+
+//___________________________________________________________
+RectMatrix::~RectMatrix()
+{
+  if (fNRows)
+    for (int i = fNRows; i--;)
+      delete[] fRows[i];
+  delete[] fRows;
+}
+
+//___________________________________________________________
+RectMatrix& RectMatrix::operator=(const RectMatrix& src)
+{
+  if (&src == this)
+    return *this;
+  if (fNRows)
+    for (int i = fNRows; i--;)
+      delete[] fRows[i];
+  delete[] fRows;
+  fNRows = src.fNRows;
+  fNCols = src.fNCols;
+  fRows = new Double_t*[fNRows];
+  for (int i = fNRows; i--;) {
+    fRows[i] = new Double_t[fNCols];
+    memcpy(fRows[i], src.fRows[i], fNCols * sizeof(Double_t));
+  }
+
+  return *this;
+}
+
+//___________________________________________________________
+void RectMatrix::Print(Option_t* option) const
+{
+  printf("Rectangular Matrix:  %d rows %d columns\n", fNRows, fNCols);
+  TString opt = option;
+  opt.ToLower();
+  if (opt.IsNull())
+    return;
+  for (int i = 0; i < fNRows; i++) {
+    for (Int_t j = 0; j <= fNCols; j++)
+      printf("%+.3e|", Query(i, j));
+    printf("\n");
+  }
+}
+
+//___________________________________________________________
+void RectMatrix::Reset() const
+{
+  for (int i = fNRows; i--;) {
+    double* row = GetRow(i);
+    for (int j = fNCols; j--;)
+      row[j] = 0.;
+  }
+}

--- a/Detectors/ITSMFT/MFT/alignment/src/RectMatrix.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/RectMatrix.cxx
@@ -56,20 +56,25 @@ RectMatrix::RectMatrix(const RectMatrix& src)
 //___________________________________________________________
 RectMatrix::~RectMatrix()
 {
-  if (fNRows)
-    for (int i = fNRows; i--;)
+  if (fNRows) {
+    for (int i = fNRows; i--;) {
       delete[] fRows[i];
+    }
+  }
   delete[] fRows;
 }
 
 //___________________________________________________________
 RectMatrix& RectMatrix::operator=(const RectMatrix& src)
 {
-  if (&src == this)
+  if (&src == this) {
     return *this;
-  if (fNRows)
-    for (int i = fNRows; i--;)
+  }
+  if (fNRows) {
+    for (int i = fNRows; i--;) {
       delete[] fRows[i];
+    }
+  }
   delete[] fRows;
   fNRows = src.fNRows;
   fNCols = src.fNCols;
@@ -88,11 +93,13 @@ void RectMatrix::Print(Option_t* option) const
   printf("Rectangular Matrix:  %d rows %d columns\n", fNRows, fNCols);
   TString opt = option;
   opt.ToLower();
-  if (opt.IsNull())
+  if (opt.IsNull()) {
     return;
+  }
   for (int i = 0; i < fNRows; i++) {
-    for (Int_t j = 0; j <= fNCols; j++)
+    for (Int_t j = 0; j <= fNCols; j++) {
       printf("%+.3e|", Query(i, j));
+    }
     printf("\n");
   }
 }
@@ -102,7 +109,8 @@ void RectMatrix::Reset() const
 {
   for (int i = fNRows; i--;) {
     double* row = GetRow(i);
-    for (int j = fNCols; j--;)
+    for (int j = fNCols; j--;) {
       row[j] = 0.;
+    }
   }
 }

--- a/Detectors/ITSMFT/MFT/alignment/src/SymBDMatrix.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/SymBDMatrix.cxx
@@ -1,0 +1,276 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file SymBDMatrix.cxx
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <iostream>
+#include <float.h>
+
+#include "TClass.h"
+#include "TMath.h"
+#include "MFTAlignment/SymBDMatrix.h"
+
+using namespace o2::mft;
+
+ClassImp(SymBDMatrix);
+
+//___________________________________________________________
+SymBDMatrix::SymBDMatrix()
+  : fElems(0)
+{
+  fSymmetric = kTRUE;
+}
+
+//___________________________________________________________
+SymBDMatrix::SymBDMatrix(Int_t size, Int_t w)
+  : MatrixSq(), fElems(0)
+{
+  fNcols = size; // number of rows
+  if (w < 0)
+    w = 0;
+  if (w >= size)
+    w = size - 1;
+  fNrows = w;
+  fRowLwb = w + 1;
+  fSymmetric = kTRUE;
+
+  // total number of stored elements
+  fNelems = size * (w + 1) - w * (w + 1) / 2;
+
+  fElems = new Double_t[fNcols * fRowLwb];
+  memset(fElems, 0, fNcols * fRowLwb * sizeof(Double_t));
+}
+
+//___________________________________________________________
+SymBDMatrix::SymBDMatrix(const SymBDMatrix& src)
+  : MatrixSq(src), fElems(0)
+{
+  if (src.GetSize() < 1)
+    return;
+  fNcols = src.GetSize();
+  fNrows = src.GetBandHWidth();
+  fRowLwb = fNrows + 1;
+  fNelems = src.GetNElemsStored();
+  fElems = new Double_t[fNcols * fRowLwb];
+  memcpy(fElems, src.fElems, fNcols * fRowLwb * sizeof(Double_t));
+}
+
+//___________________________________________________________
+SymBDMatrix::~SymBDMatrix()
+{
+  Clear();
+}
+
+//___________________________________________________________
+SymBDMatrix& SymBDMatrix::operator=(const SymBDMatrix& src)
+{
+  if (this != &src) {
+    TObject::operator=(src);
+    if (fNcols != src.fNcols) {
+      // recreate the matrix
+      if (fElems)
+        delete[] fElems;
+      fNcols = src.GetSize();
+      fNrows = src.GetBandHWidth();
+      fNelems = src.GetNElemsStored();
+      fRowLwb = src.fRowLwb;
+      fElems = new Double_t[fNcols * fRowLwb];
+    }
+    memcpy(fElems, src.fElems, fNcols * fRowLwb * sizeof(Double_t));
+    fSymmetric = kTRUE;
+  }
+  return *this;
+}
+
+//___________________________________________________________
+void SymBDMatrix::Clear(Option_t*)
+{
+  if (fElems) {
+    delete[] fElems;
+    fElems = 0;
+  }
+  fNelems = fNcols = fNrows = fRowLwb = 0;
+}
+
+//___________________________________________________________
+Float_t SymBDMatrix::GetDensity() const
+{
+  if (!fNelems)
+    return 0;
+  Int_t nel = 0;
+  for (int i = fNelems; i--;)
+    if (!IsZero(fElems[i]))
+      nel++;
+  return nel / fNelems;
+}
+
+//___________________________________________________________
+void SymBDMatrix::Print(Option_t* option) const
+{
+  printf("Symmetric Band-Diagonal Matrix : Size = %d, half bandwidth = %d\n",
+         GetSize(), GetBandHWidth());
+  TString opt = option;
+  opt.ToLower();
+  if (opt.IsNull())
+    return;
+  opt = "%";
+  opt += 1 + int(TMath::Log10(double(GetSize())));
+  opt += "d|";
+  for (Int_t i = 0; i < GetSize(); i++) {
+    printf(opt, i);
+    for (Int_t j = TMath::Max(0, i - GetBandHWidth()); j <= i; j++)
+      printf("%+.3e|", GetEl(i, j));
+    printf("\n");
+  }
+}
+
+//___________________________________________________________
+void SymBDMatrix::MultiplyByVec(const Double_t* vecIn, Double_t* vecOut) const
+{
+  if (IsDecomposed()) {
+    for (int i = 0; i < GetSize(); i++) {
+      double sm = 0;
+      int jmax = TMath::Min(GetSize(), i + fRowLwb);
+      for (int j = i + 1; j < jmax; j++)
+        sm += vecIn[j] * Query(j, i);
+      vecOut[i] = QueryDiag(i) * (vecIn[i] + sm);
+    }
+    for (int i = GetSize(); i--;) {
+      double sm = 0;
+      int jmin = TMath::Max(0, i - GetBandHWidth());
+      int jmax = i - 1;
+      for (int j = jmin; j < jmax; j++)
+        sm += vecOut[j] * Query(i, j);
+      vecOut[i] += sm;
+    }
+  } else { // not decomposed
+    for (int i = GetSize(); i--;) {
+      vecOut[i] = 0.0;
+      int jmin = TMath::Max(0, i - GetBandHWidth());
+      int jmax = TMath::Min(GetSize(), i + fRowLwb);
+      for (int j = jmin; j < jmax; j++)
+        vecOut[i] += vecIn[j] * Query(i, j);
+    }
+  }
+}
+
+//___________________________________________________________
+void SymBDMatrix::Reset()
+{
+  if (fElems)
+    memset(fElems, 0, fNcols * fRowLwb * sizeof(Double_t));
+  SetDecomposed(kFALSE);
+}
+
+//___________________________________________________________
+void SymBDMatrix::AddToRow(Int_t r, Double_t* valc, Int_t* indc, Int_t n)
+{
+  for (int i = 0; i < n; i++)
+    (*this)(r, indc[i]) = valc[i];
+}
+
+//___________________________________________________________
+void SymBDMatrix::DecomposeLDLT()
+{
+  if (IsDecomposed())
+    return;
+
+  Double_t eps = std::numeric_limits<double>::epsilon() * std::numeric_limits<double>::epsilon();
+
+  Double_t dtmp, gamma = 0.0, xi = 0.0;
+  int iDiag;
+
+  // find max diag and number of non-0 diag.elements
+  for (dtmp = 0.0, iDiag = 0; iDiag < GetSize(); iDiag++) {
+    if ((dtmp = QueryDiag(iDiag)) <= 0.0)
+      break;
+    if (gamma < dtmp)
+      gamma = dtmp;
+  }
+
+  // find max. off-diag element
+  for (int ir = 1; ir < iDiag; ir++) {
+    for (int ic = ir - GetBandHWidth(); ic < ir; ic++) {
+      if (ic < 0)
+        continue;
+      dtmp = TMath::Abs(Query(ir, ic));
+      if (xi < dtmp)
+        xi = dtmp;
+    }
+  }
+  double delta = eps * TMath::Max(1.0, xi + gamma);
+
+  double sn = GetSize() > 1 ? 1.0 / TMath::Sqrt(GetSize() * GetSize() - 1.0) : 1.0;
+  double beta = TMath::Sqrt(TMath::Max(eps, TMath::Max(gamma, xi * sn)));
+
+  for (int kr = 1; kr < GetSize(); kr++) {
+    int colKmin = TMath::Max(0, kr - GetBandHWidth());
+    double theta = 0.0;
+
+    for (int jr = colKmin; jr <= kr; jr++) {
+      int colJmin = TMath::Max(0, jr - GetBandHWidth());
+
+      dtmp = 0.0;
+      for (int i = TMath::Max(colKmin, colJmin); i < jr; i++)
+        dtmp += Query(kr, i) * QueryDiag(i) * Query(jr, i);
+      dtmp = (*this)(kr, jr) -= dtmp;
+
+      theta = TMath::Max(theta, TMath::Abs(dtmp));
+
+      if (jr != kr) {
+        if (!IsZero(QueryDiag(jr)))
+          (*this)(kr, jr) /= QueryDiag(jr);
+        else
+          (*this)(kr, jr) = 0.0;
+      } else if (kr < iDiag) {
+        dtmp = theta / beta;
+        dtmp *= dtmp;
+        dtmp = TMath::Max(dtmp, delta);
+        (*this)(kr, jr) = TMath::Max(TMath::Abs(Query(kr, jr)), dtmp);
+      }
+    } // jr
+  }   // kr
+
+  for (int i = 0; i < GetSize(); i++) {
+    dtmp = QueryDiag(i);
+    if (!IsZero(dtmp))
+      DiagElem(i) = 1. / dtmp;
+  }
+
+  SetDecomposed();
+}
+
+//___________________________________________________________
+void SymBDMatrix::Solve(Double_t* rhs)
+{
+  if (!IsDecomposed())
+    DecomposeLDLT();
+
+  for (int kr = 0; kr < GetSize(); kr++)
+    for (int jr = TMath::Max(0, kr - GetBandHWidth()); jr < kr; jr++)
+      rhs[kr] -= Query(kr, jr) * rhs[jr];
+
+  for (int kr = GetSize(); kr--;)
+    rhs[kr] *= QueryDiag(kr);
+
+  for (int kr = GetSize(); kr--;)
+    for (int jr = TMath::Max(0, kr - GetBandHWidth()); jr < kr; jr++)
+      rhs[jr] -= Query(kr, jr) * rhs[kr];
+}
+
+//___________________________________________________________
+void SymBDMatrix::Solve(const Double_t* rhs, Double_t* sol)
+{
+  memcpy(sol, rhs, GetSize() * sizeof(Double_t));
+  Solve(sol);
+}

--- a/Detectors/ITSMFT/MFT/alignment/src/SymBDMatrix.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/SymBDMatrix.cxx
@@ -11,10 +11,7 @@
 
 /// @file SymBDMatrix.cxx
 
-#include <stdlib.h>
-#include <stdio.h>
 #include <iostream>
-#include <float.h>
 
 #include "TClass.h"
 #include "TMath.h"
@@ -26,14 +23,14 @@ ClassImp(SymBDMatrix);
 
 //___________________________________________________________
 SymBDMatrix::SymBDMatrix()
-  : fElems(0)
+  : fElems(nullptr)
 {
   fSymmetric = kTRUE;
 }
 
 //___________________________________________________________
 SymBDMatrix::SymBDMatrix(Int_t size, Int_t w)
-  : MatrixSq(), fElems(0)
+  : MatrixSq(), fElems(nullptr)
 {
   fNcols = size; // number of rows
   if (w < 0) {
@@ -55,7 +52,7 @@ SymBDMatrix::SymBDMatrix(Int_t size, Int_t w)
 
 //___________________________________________________________
 SymBDMatrix::SymBDMatrix(const SymBDMatrix& src)
-  : MatrixSq(src), fElems(0)
+  : MatrixSq(src), fElems(nullptr)
 {
   if (src.GetSize() < 1) {
     return;
@@ -101,7 +98,7 @@ void SymBDMatrix::Clear(Option_t*)
 {
   if (fElems) {
     delete[] fElems;
-    fElems = 0;
+    fElems = nullptr;
   }
   fNelems = fNcols = fNrows = fRowLwb = 0;
 }

--- a/Detectors/ITSMFT/MFT/alignment/src/SymMatrix.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/SymMatrix.cxx
@@ -11,11 +11,7 @@
 
 /// @file SymMatrix.cxx
 
-#include <stdlib.h>
-#include <stdio.h>
 #include <iostream>
-#include <float.h>
-#include <string.h>
 
 #include <TClass.h>
 #include <TMath.h>
@@ -26,13 +22,13 @@ using namespace o2::mft;
 
 ClassImp(SymMatrix);
 
-SymMatrix* SymMatrix::fgBuffer = 0;
+SymMatrix* SymMatrix::fgBuffer = nullptr;
 Int_t SymMatrix::fgCopyCnt = 0;
 
 //___________________________________________________________
 SymMatrix::SymMatrix()
-  : fElems(0),
-    fElemsAdd(0)
+  : fElems(nullptr),
+    fElemsAdd(nullptr)
 {
   fSymmetric = kTRUE;
   fgCopyCnt++;
@@ -41,8 +37,8 @@ SymMatrix::SymMatrix()
 //___________________________________________________________
 SymMatrix::SymMatrix(Int_t size)
   : MatrixSq(),
-    fElems(0),
-    fElemsAdd(0)
+    fElems(nullptr),
+    fElemsAdd(nullptr)
 {
   fNrows = 0;
   fNrowIndex = fNcols = fRowLwb = size;
@@ -55,8 +51,8 @@ SymMatrix::SymMatrix(Int_t size)
 //___________________________________________________________
 SymMatrix::SymMatrix(const SymMatrix& src)
   : MatrixSq(src),
-    fElems(0),
-    fElemsAdd(0)
+    fElems(nullptr),
+    fElemsAdd(nullptr)
 {
   fNrowIndex = fNcols = src.GetSize();
   fNrows = 0;
@@ -76,9 +72,9 @@ SymMatrix::SymMatrix(const SymMatrix& src)
       }
     }
   } else {
-    fElems = 0;
+    fElems = nullptr;
   }
-  fElemsAdd = 0;
+  fElemsAdd = nullptr;
   fgCopyCnt++;
 }
 
@@ -88,7 +84,7 @@ SymMatrix::~SymMatrix()
   Clear();
   if (--fgCopyCnt < 1 && fgBuffer) {
     delete fgBuffer;
-    fgBuffer = 0;
+    fgBuffer = nullptr;
   }
 }
 
@@ -171,7 +167,7 @@ void SymMatrix::Clear(Option_t*)
 {
   if (fElems) {
     delete[] fElems;
-    fElems = 0;
+    fElems = nullptr;
   }
 
   if (fElemsAdd) {
@@ -179,7 +175,7 @@ void SymMatrix::Clear(Option_t*)
       delete[] fElemsAdd[i];
     }
     delete[] fElemsAdd;
-    fElemsAdd = 0;
+    fElemsAdd = nullptr;
   }
   fNrowIndex = fNcols = fNrows = fRowLwb = 0;
 }
@@ -204,8 +200,9 @@ void SymMatrix::Print(Option_t* option) const
   printf("Symmetric Matrix: Size = %d (%d rows added dynamically), %d used\n", GetSize(), GetSizeAdded(), GetSizeUsed());
   TString opt = option;
   opt.ToLower();
-  if (opt.IsNull())
+  if (opt.IsNull()) {
     return;
+  }
   opt = "%";
   opt += 1 + int(TMath::Log10(double(GetSize())));
   opt += "d|";
@@ -483,7 +480,7 @@ void SymMatrix::Reset()
       delete[] fElemsAdd[i];
     }
     delete[] fElemsAdd;
-    fElemsAdd = 0;
+    fElemsAdd = nullptr;
     fNcols = fRowLwb = fNrowIndex;
     fElems = new Double_t[GetSize() * (GetSize() + 1) / 2];
     fNrows = 0;
@@ -552,7 +549,7 @@ int SymMatrix::SolveSpmInv(double* vecB, Bool_t stabilize)
   double eps = 1e-14;
   int nGlo = GetSizeUsed();
   bool* bUnUsed = new bool[nGlo];
-  double *rowMax, *colMax = 0;
+  double *rowMax, *colMax = nullptr;
   rowMax = new double[nGlo];
 
   if (stabilize) {

--- a/Detectors/ITSMFT/MFT/alignment/src/SymMatrix.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/SymMatrix.cxx
@@ -1,0 +1,658 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file SymMatrix.cxx
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <iostream>
+#include <float.h>
+#include <string.h>
+
+#include <TClass.h>
+#include <TMath.h>
+#include "MFTAlignment/SymMatrix.h"
+#include "Framework/Logger.h"
+
+using namespace o2::mft;
+
+ClassImp(SymMatrix);
+
+SymMatrix* SymMatrix::fgBuffer = 0;
+Int_t SymMatrix::fgCopyCnt = 0;
+
+//___________________________________________________________
+SymMatrix::SymMatrix()
+  : fElems(0),
+    fElemsAdd(0)
+{
+  fSymmetric = kTRUE;
+  fgCopyCnt++;
+}
+
+//___________________________________________________________
+SymMatrix::SymMatrix(Int_t size)
+  : MatrixSq(),
+    fElems(0),
+    fElemsAdd(0)
+{
+  fNrows = 0;
+  fNrowIndex = fNcols = fRowLwb = size;
+  fElems = new Double_t[fNcols * (fNcols + 1) / 2];
+  fSymmetric = kTRUE;
+  Reset();
+  fgCopyCnt++;
+}
+
+//___________________________________________________________
+SymMatrix::SymMatrix(const SymMatrix& src)
+  : MatrixSq(src),
+    fElems(0),
+    fElemsAdd(0)
+{
+  fNrowIndex = fNcols = src.GetSize();
+  fNrows = 0;
+  fRowLwb = src.GetSizeUsed();
+  if (fNcols) {
+    int nmainel = fNcols * (fNcols + 1) / 2;
+    fElems = new Double_t[nmainel];
+    nmainel = src.fNcols * (src.fNcols + 1) / 2;
+    memcpy(fElems, src.fElems, nmainel * sizeof(Double_t));
+    if (src.GetSizeAdded()) { // transfer extra rows to main matrix
+      Double_t* pnt = fElems + nmainel;
+      int ncl = src.GetSizeBooked() + 1;
+      for (int ir = 0; ir < src.GetSizeAdded(); ir++) {
+        memcpy(pnt, src.fElemsAdd[ir], ncl * sizeof(Double_t));
+        pnt += ncl;
+        ncl++;
+      }
+    }
+  } else
+    fElems = 0;
+  fElemsAdd = 0;
+  fgCopyCnt++;
+}
+
+//___________________________________________________________
+SymMatrix::~SymMatrix()
+{
+  Clear();
+  if (--fgCopyCnt < 1 && fgBuffer) {
+    delete fgBuffer;
+    fgBuffer = 0;
+  }
+}
+
+//___________________________________________________________
+SymMatrix& SymMatrix::operator=(const SymMatrix& src)
+{
+  if (this != &src) {
+    TObject::operator=(src);
+    if (GetSizeBooked() != src.GetSizeBooked() && GetSizeAdded() != src.GetSizeAdded()) {
+      // recreate the matrix
+      if (fElems)
+        delete[] fElems;
+      for (int i = 0; i < GetSizeAdded(); i++)
+        delete[] fElemsAdd[i];
+      delete[] fElemsAdd;
+
+      fNrowIndex = src.GetSize();
+      fNcols = src.GetSize();
+      fNrows = 0;
+      fRowLwb = src.GetSizeUsed();
+      fElems = new Double_t[GetSize() * (GetSize() + 1) / 2];
+      int nmainel = src.GetSizeBooked() * (src.GetSizeBooked() + 1);
+      memcpy(fElems, src.fElems, nmainel * sizeof(Double_t));
+      if (src.GetSizeAdded()) {           // transfer extra rows to main matrix
+        Double_t* pnt = fElems + nmainel; //*sizeof(Double_t);
+        int ncl = src.GetSizeBooked() + 1;
+        for (int ir = 0; ir < src.GetSizeAdded(); ir++) {
+          ncl += ir;
+          memcpy(pnt, src.fElemsAdd[ir], ncl * sizeof(Double_t));
+          pnt += ncl; //*sizeof(Double_t);
+        }
+      }
+
+    } else {
+      memcpy(fElems, src.fElems, GetSizeBooked() * (GetSizeBooked() + 1) / 2 * sizeof(Double_t));
+      int ncl = GetSizeBooked() + 1;
+      for (int ir = 0; ir < GetSizeAdded(); ir++) { // dynamic rows
+        ncl += ir;
+        memcpy(fElemsAdd[ir], src.fElemsAdd[ir], ncl * sizeof(Double_t));
+      }
+    }
+  }
+  return *this;
+}
+
+//___________________________________________________________
+SymMatrix& SymMatrix::operator+=(const SymMatrix& src)
+{
+  if (GetSizeUsed() != src.GetSizeUsed()) {
+    LOG(error) << "Matrix sizes are different";
+    return *this;
+  }
+  for (int i = 0; i < GetSizeUsed(); i++)
+    for (int j = i; j < GetSizeUsed(); j++)
+      (*this)(j, i) += src(j, i);
+  return *this;
+}
+
+//___________________________________________________________
+SymMatrix& SymMatrix::operator-=(const SymMatrix& src)
+{
+  if (GetSizeUsed() != src.GetSizeUsed()) {
+    LOG(error) << "Matrix sizes are different";
+    return *this;
+  }
+  for (int i = 0; i < GetSizeUsed(); i++)
+    for (int j = i; j < GetSizeUsed(); j++)
+      (*this)(j, i) -= src(j, i);
+  return *this;
+}
+
+//___________________________________________________________
+void SymMatrix::Clear(Option_t*)
+{
+  if (fElems) {
+    delete[] fElems;
+    fElems = 0;
+  }
+
+  if (fElemsAdd) {
+    for (int i = 0; i < GetSizeAdded(); i++)
+      delete[] fElemsAdd[i];
+    delete[] fElemsAdd;
+    fElemsAdd = 0;
+  }
+  fNrowIndex = fNcols = fNrows = fRowLwb = 0;
+}
+
+//___________________________________________________________
+Float_t SymMatrix::GetDensity() const
+{
+  Int_t nel = 0;
+  for (int i = GetSizeUsed(); i--;)
+    for (int j = i + 1; j--;)
+      if (!IsZero(GetEl(i, j)))
+        nel++;
+  return 2. * nel / ((GetSizeUsed() + 1) * GetSizeUsed());
+}
+
+//___________________________________________________________
+void SymMatrix::Print(Option_t* option) const
+{
+  printf("Symmetric Matrix: Size = %d (%d rows added dynamically), %d used\n", GetSize(), GetSizeAdded(), GetSizeUsed());
+  TString opt = option;
+  opt.ToLower();
+  if (opt.IsNull())
+    return;
+  opt = "%";
+  opt += 1 + int(TMath::Log10(double(GetSize())));
+  opt += "d|";
+  for (Int_t i = 0; i < GetSizeUsed(); i++) {
+    printf(opt, i);
+    for (Int_t j = 0; j <= i; j++)
+      printf("%+.3e|", GetEl(i, j));
+    printf("\n");
+  }
+}
+
+//___________________________________________________________
+void SymMatrix::MultiplyByVec(const Double_t* vecIn, Double_t* vecOut) const
+{
+  for (int i = GetSizeUsed(); i--;) {
+    vecOut[i] = 0.0;
+    for (int j = GetSizeUsed(); j--;)
+      vecOut[i] += vecIn[j] * GetEl(i, j);
+  }
+}
+
+//___________________________________________________________
+Bool_t SymMatrix::Multiply(const SymMatrix& right)
+{
+  int sz = GetSizeUsed();
+  if (sz != right.GetSizeUsed()) {
+    LOG(error) << "Matrix sizes are different";
+    return kFALSE;
+  }
+  if (!fgBuffer || fgBuffer->GetSizeUsed() != sz) {
+    delete fgBuffer;
+    fgBuffer = new SymMatrix(*this);
+  } else
+    (*fgBuffer) = *this;
+
+  for (int i = sz; i--;) {
+    for (int j = i + 1; j--;) {
+      double val = 0.;
+      for (int k = sz; k--;)
+        val += fgBuffer->GetEl(i, k) * right.GetEl(k, j);
+      SetEl(i, j, val);
+    }
+  }
+
+  return kTRUE;
+}
+
+//___________________________________________________________
+SymMatrix* SymMatrix::DecomposeChol()
+{
+  if (!fgBuffer || fgBuffer->GetSizeUsed() != GetSizeUsed()) {
+    delete fgBuffer;
+    fgBuffer = new SymMatrix(*this);
+  } else
+    (*fgBuffer) = *this;
+
+  SymMatrix& mchol = *fgBuffer;
+
+  for (int i = 0; i < GetSizeUsed(); i++) {
+    Double_t* rowi = mchol.GetRow(i);
+    for (int j = i; j < GetSizeUsed(); j++) {
+      Double_t* rowj = mchol.GetRow(j);
+      double sum = rowj[i];
+      for (int k = i - 1; k >= 0; k--)
+        if (rowi[k] && rowj[k])
+          sum -= rowi[k] * rowj[k];
+      if (i == j) {
+        if (sum <= 0.0) { // not positive-definite
+          LOG(debug) << "The matrix is not positive definite [" << sum
+                     << "]: Choleski decomposition is not possible";
+          // Print("l");
+          return 0;
+        }
+        rowi[i] = TMath::Sqrt(sum);
+      } else
+        rowj[i] = sum / rowi[i];
+    }
+  }
+  return fgBuffer;
+}
+
+//___________________________________________________________
+Bool_t SymMatrix::InvertChol()
+{
+  SymMatrix* mchol = DecomposeChol();
+  if (!mchol) {
+    LOG(error) << "Failed to invert the matrix";
+    return kFALSE;
+  }
+
+  InvertChol(mchol);
+  return kTRUE;
+}
+
+//___________________________________________________________
+void SymMatrix::InvertChol(SymMatrix* pmchol)
+{
+  Double_t sum;
+  SymMatrix& mchol = *pmchol;
+
+  // Invert decomposed triangular L matrix (Lower triangle is filled)
+  for (int i = 0; i < GetSizeUsed(); i++) {
+    mchol(i, i) = 1.0 / mchol(i, i);
+    for (int j = i + 1; j < GetSizeUsed(); j++) {
+      Double_t* rowj = mchol.GetRow(j);
+      sum = 0.0;
+      for (int k = i; k < j; k++)
+        if (rowj[k]) {
+          double& mki = mchol(k, i);
+          if (mki)
+            sum -= rowj[k] * mki;
+        }
+      rowj[i] = sum / rowj[j];
+    }
+  }
+
+  // take product of the inverted Choleski L matrix with its transposed
+  for (int i = GetSizeUsed(); i--;) {
+    for (int j = i + 1; j--;) {
+      sum = 0;
+      for (int k = i; k < GetSizeUsed(); k++) {
+        double& mik = mchol(i, k);
+        if (mik) {
+          double& mjk = mchol(j, k);
+          if (mjk)
+            sum += mik * mjk;
+        }
+      }
+      (*this)(j, i) = sum;
+    }
+  }
+}
+
+//___________________________________________________________
+Bool_t SymMatrix::SolveChol(Double_t* b, Bool_t invert)
+{
+  Int_t i, k;
+  Double_t sum;
+
+  SymMatrix* pmchol = DecomposeChol();
+  if (!pmchol) {
+    LOG(debug) << "SolveChol failed";
+    //    Print("l");
+    return kFALSE;
+  }
+  SymMatrix& mchol = *pmchol;
+
+  for (i = 0; i < GetSizeUsed(); i++) {
+    Double_t* rowi = mchol.GetRow(i);
+    for (sum = b[i], k = i - 1; k >= 0; k--)
+      if (rowi[k] && b[k])
+        sum -= rowi[k] * b[k];
+    b[i] = sum / rowi[i];
+  }
+
+  for (i = GetSizeUsed() - 1; i >= 0; i--) {
+    for (sum = b[i], k = i + 1; k < GetSizeUsed(); k++)
+      if (b[k]) {
+        double& mki = mchol(k, i);
+        if (mki)
+          sum -= mki * b[k];
+      }
+    b[i] = sum / mchol(i, i);
+  }
+
+  if (invert)
+    InvertChol(pmchol);
+  return kTRUE;
+}
+
+//___________________________________________________________
+Bool_t SymMatrix::SolveCholN(Double_t* bn, int nRHS, Bool_t invert)
+{
+  int sz = GetSizeUsed();
+  Int_t i, k;
+  Double_t sum;
+
+  SymMatrix* pmchol = DecomposeChol();
+  if (!pmchol) {
+    LOG(debug) << "SolveChol failed";
+    //    Print("l");
+    return kFALSE;
+  }
+  SymMatrix& mchol = *pmchol;
+
+  for (int ir = 0; ir < nRHS; ir++) {
+    double* b = bn + ir * sz;
+
+    for (i = 0; i < sz; i++) {
+      Double_t* rowi = mchol.GetRow(i);
+      for (sum = b[i], k = i - 1; k >= 0; k--)
+        if (rowi[k] && b[k])
+          sum -= rowi[k] * b[k];
+      b[i] = sum / rowi[i];
+    }
+
+    for (i = sz - 1; i >= 0; i--) {
+      for (sum = b[i], k = i + 1; k < sz; k++)
+        if (b[k]) {
+          double& mki = mchol(k, i);
+          if (mki)
+            sum -= mki * b[k];
+        }
+      b[i] = sum / mchol(i, i);
+    }
+  }
+
+  if (invert)
+    InvertChol(pmchol);
+  return kTRUE;
+}
+
+//___________________________________________________________
+Bool_t SymMatrix::SolveChol(TVectorD& b, Bool_t invert)
+{
+  return SolveChol((Double_t*)b.GetMatrixArray(), invert);
+}
+
+//___________________________________________________________
+Bool_t SymMatrix::SolveChol(Double_t* brhs, Double_t* bsol, Bool_t invert)
+{
+  memcpy(bsol, brhs, GetSizeUsed() * sizeof(Double_t));
+  return SolveChol(bsol, invert);
+}
+
+//___________________________________________________________
+Bool_t SymMatrix::SolveChol(const TVectorD& brhs, TVectorD& bsol, Bool_t invert)
+{
+  bsol = brhs;
+  return SolveChol(bsol, invert);
+}
+
+//___________________________________________________________
+void SymMatrix::AddRows(int nrows)
+{
+  if (nrows < 1)
+    return;
+  Double_t** pnew = new Double_t*[nrows + fNrows];
+  for (int ir = 0; ir < fNrows; ir++)
+    pnew[ir] = fElemsAdd[ir]; // copy old extra rows
+  for (int ir = 0; ir < nrows; ir++) {
+    int ncl = GetSize() + 1;
+    pnew[fNrows] = new Double_t[ncl];
+    memset(pnew[fNrows], 0, ncl * sizeof(Double_t));
+    fNrows++;
+    fNrowIndex++;
+    fRowLwb++;
+  }
+  delete[] fElemsAdd;
+  fElemsAdd = pnew;
+}
+
+//___________________________________________________________
+void SymMatrix::Reset()
+{
+  // if additional rows exist, regularize it
+  if (fElemsAdd) {
+    delete[] fElems;
+    for (int i = 0; i < fNrows; i++)
+      delete[] fElemsAdd[i];
+    delete[] fElemsAdd;
+    fElemsAdd = 0;
+    fNcols = fRowLwb = fNrowIndex;
+    fElems = new Double_t[GetSize() * (GetSize() + 1) / 2];
+    fNrows = 0;
+  }
+  if (fElems)
+    memset(fElems, 0, GetSize() * (GetSize() + 1) / 2 * sizeof(Double_t));
+}
+
+//___________________________________________________________
+/*
+void SymMatrix::AddToRow(Int_t r, Double_t *valc,Int_t *indc,Int_t n)
+{
+  //   for (int i=n;i--;) {
+  //     (*this)(indc[i],r) += valc[i];
+  //   }
+  //   return;
+
+  double *row;
+  if (r>=fNrowIndex) {
+    AddRows(r-fNrowIndex+1);
+    row = &((fElemsAdd[r-fNcols])[0]);
+  }
+  else row = &fElems[GetIndex(r,0)];
+
+  int nadd = 0;
+  for (int i=n;i--;) {
+    if (indc[i]>r) continue;
+    row[indc[i]] += valc[i];
+    nadd++;
+  }
+  if (nadd == n) return;
+
+  // add to col>row
+  for (int i=n;i--;) {
+    if (indc[i]>r) (*this)(indc[i],r) += valc[i];
+  }
+}
+*/
+
+//___________________________________________________________
+Double_t* SymMatrix::GetRow(Int_t r)
+{
+  if (r >= GetSize()) {
+    int nn = GetSize();
+    AddRows(r - GetSize() + 1);
+    LOG(debug) << Form("create %d of %d\n", r, nn);
+    return &((fElemsAdd[r - GetSizeBooked()])[0]);
+  } else
+    return &fElems[GetIndex(r, 0)];
+}
+
+//___________________________________________________________
+int SymMatrix::SolveSpmInv(double* vecB, Bool_t stabilize)
+{
+  Int_t nRank = 0;
+  int iPivot;
+  double vPivot = 0.;
+  double eps = 1e-14;
+  int nGlo = GetSizeUsed();
+  bool* bUnUsed = new bool[nGlo];
+  double *rowMax, *colMax = 0;
+  rowMax = new double[nGlo];
+
+  if (stabilize) {
+    colMax = new double[nGlo];
+    for (Int_t i = nGlo; i--;)
+      rowMax[i] = colMax[i] = 0.0;
+    for (Int_t i = nGlo; i--;)
+      for (Int_t j = i + 1; j--;) {
+        double vl = TMath::Abs(Query(i, j));
+        if (IsZero(vl))
+          continue;
+        if (vl > rowMax[i])
+          rowMax[i] = vl; // Max elemt of row i
+        if (vl > colMax[j])
+          colMax[j] = vl; // Max elemt of column j
+        if (i == j)
+          continue;
+        if (vl > rowMax[j])
+          rowMax[j] = vl; // Max elemt of row j
+        if (vl > colMax[i])
+          colMax[i] = vl; // Max elemt of column i
+      }
+
+    for (Int_t i = nGlo; i--;) {
+      if (!IsZero(rowMax[i]))
+        rowMax[i] = 1. / rowMax[i]; // Max elemt of row i
+      if (!IsZero(colMax[i]))
+        colMax[i] = 1. / colMax[i]; // Max elemt of column i
+    }
+  }
+
+  for (Int_t i = nGlo; i--;)
+    bUnUsed[i] = true;
+
+  if (!fgBuffer || fgBuffer->GetSizeUsed() != GetSizeUsed()) {
+    delete fgBuffer;
+    fgBuffer = new SymMatrix(*this);
+  } else
+    (*fgBuffer) = *this;
+
+  if (stabilize)
+    for (int i = 0; i < nGlo; i++) { // Small loop for matrix equilibration (gives a better conditioning)
+      for (int j = 0; j <= i; j++) {
+        double vl = Query(i, j);
+        if (!IsZero(vl))
+          SetEl(i, j, TMath::Sqrt(rowMax[i]) * vl * TMath::Sqrt(colMax[j])); // Equilibrate the V matrix
+      }
+      for (int j = i + 1; j < nGlo; j++) {
+        double vl = Query(j, i);
+        if (!IsZero(vl))
+          fgBuffer->SetEl(j, i, TMath::Sqrt(rowMax[i]) * vl * TMath::Sqrt(colMax[j])); // Equilibrate the V matrix
+      }
+    }
+
+  for (Int_t j = nGlo; j--;)
+    fgBuffer->DiagElem(j) = TMath::Abs(QueryDiag(j)); // save diagonal elem absolute values
+
+  for (Int_t i = 0; i < nGlo; i++) {
+    vPivot = 0.0;
+    iPivot = -1;
+
+    for (Int_t j = 0; j < nGlo; j++) { // First look for the pivot, ie max unused diagonal element
+      double vl;
+      if (bUnUsed[j] && (TMath::Abs(vl = QueryDiag(j)) > TMath::Max(TMath::Abs(vPivot), eps * fgBuffer->QueryDiag(j)))) {
+        vPivot = vl;
+        iPivot = j;
+      }
+    }
+
+    if (iPivot >= 0) { // pivot found
+      nRank++;
+      bUnUsed[iPivot] = false; // This value is used
+      vPivot = 1.0 / vPivot;
+      DiagElem(iPivot) = -vPivot; // Replace pivot by its inverse
+      //
+      for (Int_t j = 0; j < nGlo; j++) {
+        for (Int_t jj = 0; jj < nGlo; jj++) {
+          if (j != iPivot && jj != iPivot) { // Other elements (!!! do them first as you use old matV[k][j]'s !!!)
+            double& r = j >= jj ? (*this)(j, jj) : (*fgBuffer)(jj, j);
+            r -= vPivot * (j > iPivot ? Query(j, iPivot) : fgBuffer->Query(iPivot, j)) * (iPivot > jj ? Query(iPivot, jj) : fgBuffer->Query(jj, iPivot));
+          }
+        }
+      }
+
+      for (Int_t j = 0; j < nGlo; j++)
+        if (j != iPivot) { // Pivot row or column elements
+          (*this)(j, iPivot) *= vPivot;
+          (*fgBuffer)(iPivot, j) *= vPivot;
+        }
+
+    } else { // No more pivot value (clear those elements)
+      for (Int_t j = 0; j < nGlo; j++) {
+        if (bUnUsed[j]) {
+          vecB[j] = 0.0;
+          for (Int_t k = 0; k < nGlo; k++) {
+            (*this)(j, k) = 0.;
+            if (j != k)
+              (*fgBuffer)(j, k) = 0;
+          }
+        }
+      }
+      break; // No more pivots anyway, stop here
+    }
+  }
+
+  if (stabilize)
+    for (Int_t i = 0; i < nGlo; i++)
+      for (Int_t j = 0; j < nGlo; j++) {
+        double vl = TMath::Sqrt(colMax[i]) * TMath::Sqrt(rowMax[j]); // Correct matrix V
+        if (i >= j)
+          (*this)(i, j) *= vl;
+        else
+          (*fgBuffer)(j, i) *= vl;
+      }
+
+  for (Int_t j = 0; j < nGlo; j++) {
+    rowMax[j] = 0.0;
+    for (Int_t jj = 0; jj < nGlo; jj++) { // Reverse matrix elements
+      double vl;
+      if (j >= jj)
+        vl = (*this)(j, jj) = -Query(j, jj);
+      else
+        vl = (*fgBuffer)(j, jj) = -fgBuffer->Query(j, jj);
+      rowMax[j] += vl * vecB[jj];
+    }
+  }
+
+  for (Int_t j = 0; j < nGlo; j++) {
+    vecB[j] = rowMax[j]; // The final result
+  }
+
+  delete[] bUnUsed;
+  delete[] rowMax;
+  if (stabilize)
+    delete[] colMax;
+
+  return nRank;
+}

--- a/Detectors/ITSMFT/MFT/alignment/src/SymMatrix.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/SymMatrix.cxx
@@ -75,8 +75,9 @@ SymMatrix::SymMatrix(const SymMatrix& src)
         ncl++;
       }
     }
-  } else
+  } else {
     fElems = 0;
+  }
   fElemsAdd = 0;
   fgCopyCnt++;
 }
@@ -98,10 +99,12 @@ SymMatrix& SymMatrix::operator=(const SymMatrix& src)
     TObject::operator=(src);
     if (GetSizeBooked() != src.GetSizeBooked() && GetSizeAdded() != src.GetSizeAdded()) {
       // recreate the matrix
-      if (fElems)
+      if (fElems) {
         delete[] fElems;
-      for (int i = 0; i < GetSizeAdded(); i++)
+      }
+      for (int i = 0; i < GetSizeAdded(); i++) {
         delete[] fElemsAdd[i];
+      }
       delete[] fElemsAdd;
 
       fNrowIndex = src.GetSize();
@@ -140,9 +143,11 @@ SymMatrix& SymMatrix::operator+=(const SymMatrix& src)
     LOG(error) << "Matrix sizes are different";
     return *this;
   }
-  for (int i = 0; i < GetSizeUsed(); i++)
-    for (int j = i; j < GetSizeUsed(); j++)
+  for (int i = 0; i < GetSizeUsed(); i++) {
+    for (int j = i; j < GetSizeUsed(); j++) {
       (*this)(j, i) += src(j, i);
+    }
+  }
   return *this;
 }
 
@@ -153,9 +158,11 @@ SymMatrix& SymMatrix::operator-=(const SymMatrix& src)
     LOG(error) << "Matrix sizes are different";
     return *this;
   }
-  for (int i = 0; i < GetSizeUsed(); i++)
-    for (int j = i; j < GetSizeUsed(); j++)
+  for (int i = 0; i < GetSizeUsed(); i++) {
+    for (int j = i; j < GetSizeUsed(); j++) {
       (*this)(j, i) -= src(j, i);
+    }
+  }
   return *this;
 }
 
@@ -168,8 +175,9 @@ void SymMatrix::Clear(Option_t*)
   }
 
   if (fElemsAdd) {
-    for (int i = 0; i < GetSizeAdded(); i++)
+    for (int i = 0; i < GetSizeAdded(); i++) {
       delete[] fElemsAdd[i];
+    }
     delete[] fElemsAdd;
     fElemsAdd = 0;
   }
@@ -180,10 +188,13 @@ void SymMatrix::Clear(Option_t*)
 Float_t SymMatrix::GetDensity() const
 {
   Int_t nel = 0;
-  for (int i = GetSizeUsed(); i--;)
-    for (int j = i + 1; j--;)
-      if (!IsZero(GetEl(i, j)))
+  for (int i = GetSizeUsed(); i--;) {
+    for (int j = i + 1; j--;) {
+      if (!IsZero(GetEl(i, j))) {
         nel++;
+      }
+    }
+  }
   return 2. * nel / ((GetSizeUsed() + 1) * GetSizeUsed());
 }
 
@@ -200,8 +211,9 @@ void SymMatrix::Print(Option_t* option) const
   opt += "d|";
   for (Int_t i = 0; i < GetSizeUsed(); i++) {
     printf(opt, i);
-    for (Int_t j = 0; j <= i; j++)
+    for (Int_t j = 0; j <= i; j++) {
       printf("%+.3e|", GetEl(i, j));
+    }
     printf("\n");
   }
 }
@@ -211,8 +223,9 @@ void SymMatrix::MultiplyByVec(const Double_t* vecIn, Double_t* vecOut) const
 {
   for (int i = GetSizeUsed(); i--;) {
     vecOut[i] = 0.0;
-    for (int j = GetSizeUsed(); j--;)
+    for (int j = GetSizeUsed(); j--;) {
       vecOut[i] += vecIn[j] * GetEl(i, j);
+    }
   }
 }
 
@@ -227,14 +240,16 @@ Bool_t SymMatrix::Multiply(const SymMatrix& right)
   if (!fgBuffer || fgBuffer->GetSizeUsed() != sz) {
     delete fgBuffer;
     fgBuffer = new SymMatrix(*this);
-  } else
+  } else {
     (*fgBuffer) = *this;
+  }
 
   for (int i = sz; i--;) {
     for (int j = i + 1; j--;) {
       double val = 0.;
-      for (int k = sz; k--;)
+      for (int k = sz; k--;) {
         val += fgBuffer->GetEl(i, k) * right.GetEl(k, j);
+      }
       SetEl(i, j, val);
     }
   }
@@ -248,8 +263,9 @@ SymMatrix* SymMatrix::DecomposeChol()
   if (!fgBuffer || fgBuffer->GetSizeUsed() != GetSizeUsed()) {
     delete fgBuffer;
     fgBuffer = new SymMatrix(*this);
-  } else
+  } else {
     (*fgBuffer) = *this;
+  }
 
   SymMatrix& mchol = *fgBuffer;
 
@@ -258,9 +274,10 @@ SymMatrix* SymMatrix::DecomposeChol()
     for (int j = i; j < GetSizeUsed(); j++) {
       Double_t* rowj = mchol.GetRow(j);
       double sum = rowj[i];
-      for (int k = i - 1; k >= 0; k--)
+      for (int k = i - 1; k >= 0; k--) {
         if (rowi[k] && rowj[k])
           sum -= rowi[k] * rowj[k];
+      }
       if (i == j) {
         if (sum <= 0.0) { // not positive-definite
           LOG(debug) << "The matrix is not positive definite [" << sum
@@ -269,8 +286,9 @@ SymMatrix* SymMatrix::DecomposeChol()
           return 0;
         }
         rowi[i] = TMath::Sqrt(sum);
-      } else
+      } else {
         rowj[i] = sum / rowi[i];
+      }
     }
   }
   return fgBuffer;
@@ -301,12 +319,14 @@ void SymMatrix::InvertChol(SymMatrix* pmchol)
     for (int j = i + 1; j < GetSizeUsed(); j++) {
       Double_t* rowj = mchol.GetRow(j);
       sum = 0.0;
-      for (int k = i; k < j; k++)
+      for (int k = i; k < j; k++) {
         if (rowj[k]) {
           double& mki = mchol(k, i);
-          if (mki)
+          if (mki) {
             sum -= rowj[k] * mki;
+          }
         }
+      }
       rowj[i] = sum / rowj[j];
     }
   }
@@ -319,8 +339,9 @@ void SymMatrix::InvertChol(SymMatrix* pmchol)
         double& mik = mchol(i, k);
         if (mik) {
           double& mjk = mchol(j, k);
-          if (mjk)
+          if (mjk) {
             sum += mik * mjk;
+          }
         }
       }
       (*this)(j, i) = sum;
@@ -345,8 +366,9 @@ Bool_t SymMatrix::SolveChol(Double_t* b, Bool_t invert)
   for (i = 0; i < GetSizeUsed(); i++) {
     Double_t* rowi = mchol.GetRow(i);
     for (sum = b[i], k = i - 1; k >= 0; k--)
-      if (rowi[k] && b[k])
+      if (rowi[k] && b[k]) {
         sum -= rowi[k] * b[k];
+      }
     b[i] = sum / rowi[i];
   }
 
@@ -354,8 +376,9 @@ Bool_t SymMatrix::SolveChol(Double_t* b, Bool_t invert)
     for (sum = b[i], k = i + 1; k < GetSizeUsed(); k++)
       if (b[k]) {
         double& mki = mchol(k, i);
-        if (mki)
+        if (mki) {
           sum -= mki * b[k];
+        }
       }
     b[i] = sum / mchol(i, i);
   }
@@ -386,8 +409,9 @@ Bool_t SymMatrix::SolveCholN(Double_t* bn, int nRHS, Bool_t invert)
     for (i = 0; i < sz; i++) {
       Double_t* rowi = mchol.GetRow(i);
       for (sum = b[i], k = i - 1; k >= 0; k--)
-        if (rowi[k] && b[k])
+        if (rowi[k] && b[k]) {
           sum -= rowi[k] * b[k];
+        }
       b[i] = sum / rowi[i];
     }
 
@@ -395,8 +419,9 @@ Bool_t SymMatrix::SolveCholN(Double_t* bn, int nRHS, Bool_t invert)
       for (sum = b[i], k = i + 1; k < sz; k++)
         if (b[k]) {
           double& mki = mchol(k, i);
-          if (mki)
+          if (mki) {
             sum -= mki * b[k];
+          }
         }
       b[i] = sum / mchol(i, i);
     }
@@ -433,8 +458,9 @@ void SymMatrix::AddRows(int nrows)
   if (nrows < 1)
     return;
   Double_t** pnew = new Double_t*[nrows + fNrows];
-  for (int ir = 0; ir < fNrows; ir++)
+  for (int ir = 0; ir < fNrows; ir++) {
     pnew[ir] = fElemsAdd[ir]; // copy old extra rows
+  }
   for (int ir = 0; ir < nrows; ir++) {
     int ncl = GetSize() + 1;
     pnew[fNrows] = new Double_t[ncl];
@@ -453,45 +479,53 @@ void SymMatrix::Reset()
   // if additional rows exist, regularize it
   if (fElemsAdd) {
     delete[] fElems;
-    for (int i = 0; i < fNrows; i++)
+    for (int i = 0; i < fNrows; i++) {
       delete[] fElemsAdd[i];
+    }
     delete[] fElemsAdd;
     fElemsAdd = 0;
     fNcols = fRowLwb = fNrowIndex;
     fElems = new Double_t[GetSize() * (GetSize() + 1) / 2];
     fNrows = 0;
   }
-  if (fElems)
+  if (fElems) {
     memset(fElems, 0, GetSize() * (GetSize() + 1) / 2 * sizeof(Double_t));
+  }
 }
 
 //___________________________________________________________
 /*
-void SymMatrix::AddToRow(Int_t r, Double_t *valc,Int_t *indc,Int_t n)
+void SymMatrix::AddToRow(Int_t r, Double_t* valc, Int_t* indc, Int_t n)
 {
   //   for (int i=n;i--;) {
   //     (*this)(indc[i],r) += valc[i];
   //   }
   //   return;
 
-  double *row;
-  if (r>=fNrowIndex) {
-    AddRows(r-fNrowIndex+1);
-    row = &((fElemsAdd[r-fNcols])[0]);
+  double* row;
+  if (r >= fNrowIndex) {
+    AddRows(r - fNrowIndex + 1);
+    row = &((fElemsAdd[r - fNcols])[0]);
+  } else {
+    row = &fElems[GetIndex(r, 0)];
   }
-  else row = &fElems[GetIndex(r,0)];
 
   int nadd = 0;
-  for (int i=n;i--;) {
-    if (indc[i]>r) continue;
+  for (int i = n; i--;) {
+    if (indc[i] > r) {
+      continue;
+    }
     row[indc[i]] += valc[i];
     nadd++;
   }
-  if (nadd == n) return;
+  if (nadd == n) {
+    return;
+  }
 
   // add to col>row
-  for (int i=n;i--;) {
-    if (indc[i]>r) (*this)(indc[i],r) += valc[i];
+  for (int i = n; i--;) {
+    if (indc[i] > r)
+      (*this)(indc[i], r) += valc[i];
   }
 }
 */
@@ -504,8 +538,9 @@ Double_t* SymMatrix::GetRow(Int_t r)
     AddRows(r - GetSize() + 1);
     LOG(debug) << Form("create %d of %d\n", r, nn);
     return &((fElemsAdd[r - GetSizeBooked()])[0]);
-  } else
+  } else {
     return &fElems[GetIndex(r, 0)];
+  }
 }
 
 //___________________________________________________________
@@ -522,59 +557,73 @@ int SymMatrix::SolveSpmInv(double* vecB, Bool_t stabilize)
 
   if (stabilize) {
     colMax = new double[nGlo];
-    for (Int_t i = nGlo; i--;)
+    for (Int_t i = nGlo; i--;) {
       rowMax[i] = colMax[i] = 0.0;
-    for (Int_t i = nGlo; i--;)
+    }
+    for (Int_t i = nGlo; i--;) {
       for (Int_t j = i + 1; j--;) {
         double vl = TMath::Abs(Query(i, j));
-        if (IsZero(vl))
+        if (IsZero(vl)) {
           continue;
-        if (vl > rowMax[i])
+        }
+        if (vl > rowMax[i]) {
           rowMax[i] = vl; // Max elemt of row i
-        if (vl > colMax[j])
+        }
+        if (vl > colMax[j]) {
           colMax[j] = vl; // Max elemt of column j
-        if (i == j)
+        }
+        if (i == j) {
           continue;
-        if (vl > rowMax[j])
+        }
+        if (vl > rowMax[j]) {
           rowMax[j] = vl; // Max elemt of row j
-        if (vl > colMax[i])
+        }
+        if (vl > colMax[i]) {
           colMax[i] = vl; // Max elemt of column i
+        }
       }
+    }
 
     for (Int_t i = nGlo; i--;) {
-      if (!IsZero(rowMax[i]))
+      if (!IsZero(rowMax[i])) {
         rowMax[i] = 1. / rowMax[i]; // Max elemt of row i
-      if (!IsZero(colMax[i]))
+      }
+      if (!IsZero(colMax[i])) {
         colMax[i] = 1. / colMax[i]; // Max elemt of column i
+      }
     }
   }
 
-  for (Int_t i = nGlo; i--;)
+  for (Int_t i = nGlo; i--;) {
     bUnUsed[i] = true;
+  }
 
   if (!fgBuffer || fgBuffer->GetSizeUsed() != GetSizeUsed()) {
     delete fgBuffer;
     fgBuffer = new SymMatrix(*this);
-  } else
+  } else {
     (*fgBuffer) = *this;
+  }
 
-  if (stabilize)
+  if (stabilize) {
     for (int i = 0; i < nGlo; i++) { // Small loop for matrix equilibration (gives a better conditioning)
       for (int j = 0; j <= i; j++) {
         double vl = Query(i, j);
-        if (!IsZero(vl))
+        if (!IsZero(vl)) {
           SetEl(i, j, TMath::Sqrt(rowMax[i]) * vl * TMath::Sqrt(colMax[j])); // Equilibrate the V matrix
+        }
       }
       for (int j = i + 1; j < nGlo; j++) {
         double vl = Query(j, i);
-        if (!IsZero(vl))
+        if (!IsZero(vl)) {
           fgBuffer->SetEl(j, i, TMath::Sqrt(rowMax[i]) * vl * TMath::Sqrt(colMax[j])); // Equilibrate the V matrix
+        }
       }
     }
-
-  for (Int_t j = nGlo; j--;)
+  }
+  for (Int_t j = nGlo; j--;) {
     fgBuffer->DiagElem(j) = TMath::Abs(QueryDiag(j)); // save diagonal elem absolute values
-
+  }
   for (Int_t i = 0; i < nGlo; i++) {
     vPivot = 0.0;
     iPivot = -1;
@@ -614,8 +663,9 @@ int SymMatrix::SolveSpmInv(double* vecB, Bool_t stabilize)
           vecB[j] = 0.0;
           for (Int_t k = 0; k < nGlo; k++) {
             (*this)(j, k) = 0.;
-            if (j != k)
+            if (j != k) {
               (*fgBuffer)(j, k) = 0;
+            }
           }
         }
       }
@@ -623,24 +673,27 @@ int SymMatrix::SolveSpmInv(double* vecB, Bool_t stabilize)
     }
   }
 
-  if (stabilize)
-    for (Int_t i = 0; i < nGlo; i++)
+  if (stabilize) {
+    for (Int_t i = 0; i < nGlo; i++) {
       for (Int_t j = 0; j < nGlo; j++) {
         double vl = TMath::Sqrt(colMax[i]) * TMath::Sqrt(rowMax[j]); // Correct matrix V
-        if (i >= j)
+        if (i >= j) {
           (*this)(i, j) *= vl;
-        else
+        } else {
           (*fgBuffer)(j, i) *= vl;
+        }
       }
-
+    }
+  }
   for (Int_t j = 0; j < nGlo; j++) {
     rowMax[j] = 0.0;
     for (Int_t jj = 0; jj < nGlo; jj++) { // Reverse matrix elements
       double vl;
-      if (j >= jj)
+      if (j >= jj) {
         vl = (*this)(j, jj) = -Query(j, jj);
-      else
+      } else {
         vl = (*fgBuffer)(j, jj) = -fgBuffer->Query(j, jj);
+      }
       rowMax[j] += vl * vecB[jj];
     }
   }
@@ -651,8 +704,9 @@ int SymMatrix::SolveSpmInv(double* vecB, Bool_t stabilize)
 
   delete[] bUnUsed;
   delete[] rowMax;
-  if (stabilize)
+  if (stabilize) {
     delete[] colMax;
+  }
 
   return nRank;
 }

--- a/Detectors/ITSMFT/MFT/alignment/src/TracksToRecords.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/TracksToRecords.cxx
@@ -11,10 +11,6 @@
 
 /// @file TracksToRecords.cxx
 
-#include <iostream>
-#include <sstream>
-#include <string>
-
 #include <TTreeReader.h>
 #include <TTreeReaderValue.h>
 

--- a/Detectors/ITSMFT/MFT/alignment/src/TracksToRecords.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/TracksToRecords.cxx
@@ -78,16 +78,18 @@ TracksToRecords::~TracksToRecords()
   if (mAlignPoint) {
     delete mAlignPoint;
   }
-  if (mDictionary)
+  if (mDictionary) {
     mDictionary = nullptr;
+  }
   LOGF(debug, "TracksToRecords destroyed");
 }
 
 //__________________________________________________________________________
 void TracksToRecords::init()
 {
-  if (mIsInitDone)
+  if (mIsInitDone) {
     return;
+  }
   if (mDictionary == nullptr) {
     LOGF(fatal, "TracksToRecords::init() failed because no cluster dictionary is defined");
     mIsInitDone = false;
@@ -240,8 +242,9 @@ void TracksToRecords::processRecoTracks()
       success &= setLocalEquationY();
       success &= setLocalEquationZ();
       isTrackUsed &= success;
-      if (mWithControl && success)
+      if (mWithControl && success) {
         mPointControl.fill(mAlignPoint, mCounterUsedTracks);
+      }
       if (!success) {
         LOGF(error, "TracksToRecords::processRecoTracks() - track %i h %d d %d l %d s %4d lMpos x %.2e y %.2e z %.2e gMpos x %.2e y %.2e z %.2e gRpos x %.2e y %.2e z %.2e",
              mCounterUsedTracks, mAlignPoint->half(), mAlignPoint->disk(), mAlignPoint->layer(), mAlignPoint->getSensorId(),
@@ -375,8 +378,9 @@ void TracksToRecords::processROFs(TChain* mfttrackChain, TChain* mftclusterChain
         success &= setLocalEquationY();
         success &= setLocalEquationZ();
         isTrackUsed &= success;
-        if (mWithControl && success)
+        if (mWithControl && success) {
           mPointControl.fill(mAlignPoint, mCounterUsedTracks);
+        }
         if (!success) {
           LOGF(error, "TracksToRecords::processROFs() - track %i h %d d %d l %d s %4d lMpos x %.2e y %.2e z %.2e gMpos x %.2e y %.2e z %.2e gRpos x %.2e y %.2e z %.2e",
                mCounterUsedTracks, mAlignPoint->half(), mAlignPoint->disk(), mAlignPoint->layer(), mAlignPoint->getSensorId(),
@@ -423,8 +427,9 @@ void TracksToRecords::printProcessTrackSummary()
 //__________________________________________________________________________
 void TracksToRecords::startRecordWriter()
 {
-  if (mRecordWriter)
+  if (mRecordWriter) {
     mRecordWriter->init();
+  }
   if (mWithControl) {
     mPointControl.setCyclicAutoSave(mNEntriesAutoSave);
     mPointControl.init();
@@ -444,9 +449,9 @@ void TracksToRecords::endRecordWriter()
 //__________________________________________________________________________
 void TracksToRecords::startConstraintsRecWriter()
 {
-  if (!mWithConstraintsRecWriter)
+  if (!mWithConstraintsRecWriter) {
     return;
-
+  }
   if (mConstraintsRecWriter) {
     mConstraintsRecWriter->changeDataBranchName();
     mConstraintsRecWriter->init();
@@ -456,9 +461,9 @@ void TracksToRecords::startConstraintsRecWriter()
 //__________________________________________________________________________
 void TracksToRecords::endConstraintsRecWriter()
 {
-  if (!mWithConstraintsRecWriter)
+  if (!mWithConstraintsRecWriter) {
     return;
-
+  }
   if (mConstraintsRecWriter) {
     mConstraintsRecWriter->terminate();
   }
@@ -525,10 +530,12 @@ bool TracksToRecords::setLocalEquationX()
          "TracksToRecords::setLocalEquationX() - no align point coordinates set !");
     return false;
   }
-  if (!mAlignPoint->isGlobalDerivativeDone())
+  if (!mAlignPoint->isGlobalDerivativeDone()) {
     return false;
-  if (!mAlignPoint->isLocalDerivativeDone())
+  }
+  if (!mAlignPoint->isLocalDerivativeDone()) {
     return false;
+  }
 
   bool success = true;
 
@@ -587,10 +594,12 @@ bool TracksToRecords::setLocalEquationY()
          "TracksToRecords::setLocalEquationY() - no align point coordinates set !");
     return false;
   }
-  if (!mAlignPoint->isGlobalDerivativeDone())
+  if (!mAlignPoint->isGlobalDerivativeDone()) {
     return false;
-  if (!mAlignPoint->isLocalDerivativeDone())
+  }
+  if (!mAlignPoint->isLocalDerivativeDone()) {
     return false;
+  }
 
   bool success = true;
 
@@ -649,10 +658,12 @@ bool TracksToRecords::setLocalEquationZ()
          "TracksToRecords::setLocalEquationZ() - no align point coordinates set !");
     return false;
   }
-  if (!mAlignPoint->isGlobalDerivativeDone())
+  if (!mAlignPoint->isGlobalDerivativeDone()) {
     return false;
-  if (!mAlignPoint->isLocalDerivativeDone())
+  }
+  if (!mAlignPoint->isLocalDerivativeDone()) {
     return false;
+  }
 
   bool success = true;
 

--- a/Detectors/ITSMFT/MFT/alignment/src/TracksToRecords.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/TracksToRecords.cxx
@@ -1,0 +1,704 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file TracksToRecords.cxx
+
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include <TTreeReader.h>
+#include <TTreeReaderValue.h>
+
+#include "Framework/InputSpec.h"
+#include "Framework/Logger.h"
+#include <Framework/InputRecord.h>
+#include "MFTBase/Geometry.h"
+#include "MFTAlignment/MillePedeRecord.h"
+
+#include "MFTAlignment/TracksToRecords.h"
+
+using namespace o2::mft;
+
+ClassImp(o2::mft::TracksToRecords);
+
+//__________________________________________________________________________
+TracksToRecords::TracksToRecords()
+  : Aligner(),
+    mRunNumber(0),
+    mBz(0),
+    mNumberTFs(0),
+    mNumberOfClusterChainROFs(0),
+    mNumberOfTrackChainROFs(0),
+    mCounterLocalEquationFailed(0),
+    mCounterSkippedTracks(0),
+    mCounterUsedTracks(0),
+    mGlobalDerivatives(std::vector<double>(mNumberOfGlobalParam)),
+    mLocalDerivatives(std::vector<double>(mNumberOfTrackParam)),
+    mMinNumberClusterCut(6),
+    mWeightRecord(1.),
+    mDictionary(nullptr),
+    mAlignPoint(new AlignPointHelper()),
+    mWithControl(false),
+    mNEntriesAutoSave(10000),
+    mRecordWriter(new MilleRecordWriter()),
+    mWithConstraintsRecWriter(false),
+    mConstraintsRecWriter(nullptr),
+    mMillepede(new MillePede2())
+{
+  if (mWithConstraintsRecWriter) {
+    mConstraintsRecWriter = new MilleRecordWriter();
+  }
+  // initialise the content of each array
+  resetGlocalDerivative();
+  resetLocalDerivative();
+  LOGF(debug, "TracksToRecords instantiated");
+}
+
+//__________________________________________________________________________
+TracksToRecords::~TracksToRecords()
+{
+  if (mConstraintsRecWriter) {
+    delete mConstraintsRecWriter;
+  }
+  if (mMillepede) {
+    delete mMillepede;
+  }
+  if (mRecordWriter) {
+    delete mRecordWriter;
+  }
+  if (mAlignPoint) {
+    delete mAlignPoint;
+  }
+  if (mDictionary)
+    mDictionary = nullptr;
+  LOGF(debug, "TracksToRecords destroyed");
+}
+
+//__________________________________________________________________________
+void TracksToRecords::init()
+{
+  if (mIsInitDone)
+    return;
+  if (mDictionary == nullptr) {
+    LOGF(fatal, "TracksToRecords::init() failed because no cluster dictionary is defined");
+    mIsInitDone = false;
+    return;
+  }
+
+  mRecordWriter->setCyclicAutoSave(mNEntriesAutoSave);
+  mRecordWriter->setDataFileName(mMilleRecordsFileName);
+  mMillepede->SetRecordWriter(mRecordWriter);
+
+  if (mWithConstraintsRecWriter) {
+    mConstraintsRecWriter->setCyclicAutoSave(mNEntriesAutoSave);
+    mConstraintsRecWriter->setDataFileName(mMilleConstraintsRecFileName);
+    mMillepede->SetConstraintsRecWriter(mConstraintsRecWriter);
+  }
+
+  mAlignPoint->setClusterDictionary(mDictionary);
+
+  mMillepede->InitMille(mNumberOfGlobalParam,
+                        mNumberOfTrackParam,
+                        mChi2CutNStdDev,
+                        mResCut,
+                        mResCutInitial);
+
+  LOG(info) << "-------------- TracksToRecords configured with -----------------";
+  LOGF(info, "Chi2CutNStdDev = %d", mChi2CutNStdDev);
+  LOGF(info, "ResidualCutInitial = %.3f", mResCutInitial);
+  LOGF(info, "ResidualCut = %.3f", mResCut);
+  LOGF(info, "MinNumberClusterCut = %d", mMinNumberClusterCut);
+  LOGF(info, "mStartFac = %.3f", mStartFac);
+  LOGF(info,
+       "Allowed variation: dx = %.3f, dy = %.3f, dz = %.3f, dRz = %.4f",
+       mAllowVar[0], mAllowVar[1], mAllowVar[3], mAllowVar[2]);
+  LOG(info) << "-----------------------------------------------------------";
+
+  // set allowed variations for all parameters
+  for (int chipId = 0; chipId < mNumberOfSensors; ++chipId) {
+    for (Int_t iPar = 0; iPar < mNDofPerSensor; ++iPar) {
+      mMillepede->SetParSigma(chipId * mNDofPerSensor + iPar, mAllowVar[iPar]);
+    }
+  }
+
+  // set iterations
+  if (mStartFac > 1) {
+    mMillepede->SetIterations(mStartFac);
+  }
+
+  mIsInitDone = true;
+  LOGF(info, "TracksToRecords init done");
+}
+
+//__________________________________________________________________________
+void TracksToRecords::processTimeFrame(o2::framework::ProcessingContext& ctx)
+{
+  mNumberTFs++; // TF Counter
+
+  // get tracks
+  mMFTTracks = ctx.inputs().get<gsl::span<o2::mft::TrackMFT>>("tracks");
+  mMFTTracksROF = ctx.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("tracksrofs");
+  mMFTTrackClusIdx = ctx.inputs().get<gsl::span<int>>("trackClIdx");
+
+  // get clusters
+  mMFTClusters = ctx.inputs().get<gsl::span<o2::itsmft::CompClusterExt>>("compClusters");
+  mMFTClustersROF = ctx.inputs().get<gsl::span<o2::itsmft::ROFRecord>>("clustersrofs");
+  mMFTClusterPatterns = ctx.inputs().get<gsl::span<unsigned char>>("patterns");
+  mPattIt = mMFTClusterPatterns.begin();
+  mAlignPoint->convertCompactClusters(
+    mMFTClusters, mPattIt, mMFTClustersLocal, mMFTClustersGlobal);
+}
+
+//__________________________________________________________________________
+void TracksToRecords::processRecoTracks()
+{
+  if (!mIsInitDone) {
+    LOGF(fatal, "TracksToRecords::processRecoTracks() aborted because init was not done !");
+    return;
+  }
+  if (!mRecordWriter || !mRecordWriter->isInitOk()) {
+    LOGF(fatal, "TracksToRecords::processRecoTracks() aborted because uninitialised mRecordWriter !");
+    return;
+  }
+
+  LOG(info) << "TracksToRecords::processRecoTracks() - start";
+
+  int nCounterAllTracks = 0;
+
+  for (auto& oneTrack : mMFTTracks) { // track loop
+
+    LOGF(debug, "Processing track # %5d", nCounterAllTracks);
+
+    // Skip the track if not enough clusters
+    auto ncls = oneTrack.getNumberOfPoints();
+    if (ncls < mMinNumberClusterCut) {
+      nCounterAllTracks++;
+      mCounterSkippedTracks++;
+      continue;
+    }
+
+    // Skip presumably quite low momentum track
+    if (!oneTrack.isLTF()) {
+      nCounterAllTracks++;
+      mCounterSkippedTracks++;
+      continue;
+    }
+
+    auto offset = oneTrack.getExternalClusterIndexOffset();
+
+    mRecordWriter->getRecord()->Reset();
+
+    // Store the initial track parameters
+    auto track = oneTrack;
+    mAlignPoint->resetTrackInitialParam();
+    mAlignPoint->recordTrackInitialParam(track);
+
+    bool isTrackUsed = true;
+
+    for (int icls = 0; icls < ncls; ++icls) { // cluster loop
+
+      mAlignPoint->resetAlignPoint();
+
+      // Store measured positions
+      auto clsEntry = mMFTTrackClusIdx[offset + icls];
+      auto localCluster = mMFTClustersLocal[clsEntry];
+      auto globalCluster = mMFTClustersGlobal[clsEntry];
+      mAlignPoint->setMeasuredPosition(localCluster, globalCluster);
+      if (!mAlignPoint->isClusterOk()) {
+        LOGF(warning, "TracksToRecords::processRecoTracks() - will not use track # %5d with at least a bad cluster", nCounterAllTracks);
+        mCounterSkippedTracks++;
+        isTrackUsed = false;
+        break;
+      }
+
+      // Propagate track to the current z plane of this cluster
+      track.propagateParamToZlinear(mAlignPoint->getGlobalMeasuredPosition().Z());
+
+      // Store reco positions
+      mAlignPoint->setGlobalRecoPosition(track);
+
+      // compute residuals
+      mAlignPoint->setLocalResidual();
+      mAlignPoint->setGlobalResidual();
+
+      // Compute derivatives
+      mAlignPoint->computeLocalDerivatives();
+      mAlignPoint->computeGlobalDerivatives();
+
+      // Set local equations
+      bool success = true;
+      success &= setLocalEquationX();
+      success &= setLocalEquationY();
+      success &= setLocalEquationZ();
+      isTrackUsed &= success;
+      if (mWithControl && success)
+        mPointControl.fill(mAlignPoint, mCounterUsedTracks);
+      if (!success) {
+        LOGF(error, "TracksToRecords::processRecoTracks() - track %i h %d d %d l %d s %4d lMpos x %.2e y %.2e z %.2e gMpos x %.2e y %.2e z %.2e gRpos x %.2e y %.2e z %.2e",
+             mCounterUsedTracks, mAlignPoint->half(), mAlignPoint->disk(), mAlignPoint->layer(), mAlignPoint->getSensorId(),
+             mAlignPoint->getLocalMeasuredPosition().X(), mAlignPoint->getLocalMeasuredPosition().Y(), mAlignPoint->getLocalMeasuredPosition().Z(),
+             mAlignPoint->getGlobalMeasuredPosition().X(), mAlignPoint->getGlobalMeasuredPosition().Y(), mAlignPoint->getGlobalMeasuredPosition().Z(),
+             mAlignPoint->getGlobalRecoPosition().X(), mAlignPoint->getGlobalRecoPosition().Y(), mAlignPoint->getGlobalRecoPosition().Z());
+      }
+
+    } // end of loop on clusters
+
+    if (isTrackUsed) {
+      mRecordWriter->setRecordRun(mRunNumber);
+      mRecordWriter->setRecordWeight(mWeightRecord);
+      const bool doPrint = false;
+      mRecordWriter->fillRecordTree(doPrint); // save record data
+      mCounterUsedTracks++;
+    }
+    nCounterAllTracks++;
+  } // end of loop on tracks
+  LOG(info) << "TracksToRecords::processRecoTracks() - end";
+}
+
+//__________________________________________________________________________
+void TracksToRecords::processROFs(TChain* mfttrackChain, TChain* mftclusterChain)
+{
+  if (!mIsInitDone) {
+    LOGF(fatal, "TracksToRecords::processROFs() aborted because init was not done !");
+    return;
+  }
+
+  if (!mRecordWriter || !mRecordWriter->isInitOk()) {
+    LOGF(fatal, "TracksToRecords::processROFs() aborted because uninitialised mRecordWriter !");
+    return;
+  }
+
+  LOG(info) << "TracksToRecords::processROFs() - start";
+
+  TTreeReader mftTrackChainReader(mfttrackChain);
+  TTreeReader mftClusterChainReader(mftclusterChain);
+  std::vector<unsigned char>::iterator pattIterator;
+
+  TTreeReaderValue<std::vector<o2::mft::TrackMFT>> mftTracks =
+    {mftTrackChainReader, "MFTTrack"};
+  TTreeReaderValue<std::vector<o2::itsmft::ROFRecord>> mftTracksROF =
+    {mftTrackChainReader, "MFTTracksROF"};
+  TTreeReaderValue<std::vector<int>> mftTrackClusIdx =
+    {mftTrackChainReader, "MFTTrackClusIdx"};
+
+  TTreeReaderValue<std::vector<o2::itsmft::CompClusterExt>> mftClusters =
+    {mftClusterChainReader, "MFTClusterComp"};
+  TTreeReaderValue<std::vector<o2::itsmft::ROFRecord>> mftClustersROF =
+    {mftClusterChainReader, "MFTClustersROF"};
+  TTreeReaderValue<std::vector<unsigned char>> mftClusterPatterns =
+    {mftClusterChainReader, "MFTClusterPatt"};
+
+  int nCounterAllTracks = 0;
+
+  while (mftTrackChainReader.Next() && mftClusterChainReader.Next()) {
+
+    mNumberOfTrackChainROFs += (*mftTracksROF).size();
+    mNumberOfClusterChainROFs += (*mftClustersROF).size();
+    assert(mNumberOfTrackChainROFs == mNumberOfClusterChainROFs);
+
+    pattIterator = (*mftClusterPatterns).begin();
+    mAlignPoint->convertCompactClusters(
+      *mftClusters, pattIterator, mMFTClustersLocal, mMFTClustersGlobal);
+
+    //______________________________________________________
+    for (auto& oneTrack : *mftTracks) { // track loop
+
+      LOGF(debug, "Processing track # %5d", nCounterAllTracks);
+
+      // Skip the track if not enough clusters
+      auto ncls = oneTrack.getNumberOfPoints();
+      if (ncls < mMinNumberClusterCut) {
+        nCounterAllTracks++;
+        mCounterSkippedTracks++;
+        continue;
+      }
+
+      // Skip presumably quite low momentum track
+      if (!oneTrack.isLTF()) {
+        nCounterAllTracks++;
+        mCounterSkippedTracks++;
+        continue;
+      }
+
+      auto offset = oneTrack.getExternalClusterIndexOffset();
+
+      mRecordWriter->getRecord()->Reset();
+
+      // Store the initial track parameters
+      mAlignPoint->resetTrackInitialParam();
+      mAlignPoint->recordTrackInitialParam(oneTrack);
+
+      bool isTrackUsed = true;
+
+      for (int icls = 0; icls < ncls; ++icls) { // cluster loop
+
+        mAlignPoint->resetAlignPoint();
+
+        // Store measured positions
+        auto clsEntry = (*mftTrackClusIdx)[offset + icls];
+        auto localCluster = mMFTClustersLocal[clsEntry];
+        auto globalCluster = mMFTClustersGlobal[clsEntry];
+        mAlignPoint->setMeasuredPosition(localCluster, globalCluster);
+        if (!mAlignPoint->isClusterOk()) {
+          LOGF(warning, "TracksToRecords::processROFs() - will not use track # %5d with at least a bad cluster", nCounterAllTracks);
+          mCounterSkippedTracks++;
+          isTrackUsed = false;
+          break;
+        }
+
+        // Propagate track to the current z plane of this cluster
+        oneTrack.propagateParamToZlinear(mAlignPoint->getGlobalMeasuredPosition().Z());
+
+        // Store reco positions
+        mAlignPoint->setGlobalRecoPosition(oneTrack);
+
+        // compute residuals
+        mAlignPoint->setLocalResidual();
+        mAlignPoint->setGlobalResidual();
+
+        // Compute derivatives
+        mAlignPoint->computeLocalDerivatives();
+        mAlignPoint->computeGlobalDerivatives();
+
+        // Set local equations
+        bool success = true;
+        success &= setLocalEquationX();
+        success &= setLocalEquationY();
+        success &= setLocalEquationZ();
+        isTrackUsed &= success;
+        if (mWithControl && success)
+          mPointControl.fill(mAlignPoint, mCounterUsedTracks);
+        if (!success) {
+          LOGF(error, "TracksToRecords::processROFs() - track %i h %d d %d l %d s %4d lMpos x %.2e y %.2e z %.2e gMpos x %.2e y %.2e z %.2e gRpos x %.2e y %.2e z %.2e",
+               mCounterUsedTracks, mAlignPoint->half(), mAlignPoint->disk(), mAlignPoint->layer(), mAlignPoint->getSensorId(),
+               mAlignPoint->getLocalMeasuredPosition().X(), mAlignPoint->getLocalMeasuredPosition().Y(), mAlignPoint->getLocalMeasuredPosition().Z(),
+               mAlignPoint->getGlobalMeasuredPosition().X(), mAlignPoint->getGlobalMeasuredPosition().Y(), mAlignPoint->getGlobalMeasuredPosition().Z(),
+               mAlignPoint->getGlobalRecoPosition().X(), mAlignPoint->getGlobalRecoPosition().Y(), mAlignPoint->getGlobalRecoPosition().Z());
+        }
+
+      } // end of loop on clusters
+
+      if (isTrackUsed) {
+        // copy track record
+        mRecordWriter->setRecordRun(mRunNumber);
+        mRecordWriter->setRecordWeight(mWeightRecord);
+        const bool doPrint = false;
+        mRecordWriter->fillRecordTree(doPrint); // save record data
+        mCounterUsedTracks++;
+      }
+      nCounterAllTracks++;
+    } // end of loop on tracks
+
+  } // end of loop on TChain reader
+
+  LOG(info) << "TracksToRecords::processROFs() - end";
+}
+
+//__________________________________________________________________________
+void TracksToRecords::printProcessTrackSummary()
+{
+  LOGF(info, "TracksToRecords processRecoTracks() summary: ");
+  if (mNumberOfTrackChainROFs) {
+    LOGF(info,
+         "n ROFs = %d, used tracks = %d, skipped tracks = %d, local equations failed = %d",
+         mNumberOfTrackChainROFs, mCounterUsedTracks,
+         mCounterSkippedTracks, mCounterLocalEquationFailed);
+  } else {
+    LOGF(info,
+         "n TFs = %d, used tracks = %d, skipped tracks = %d, local equations failed = %d",
+         mNumberTFs, mCounterUsedTracks,
+         mCounterSkippedTracks, mCounterLocalEquationFailed);
+  }
+}
+
+//__________________________________________________________________________
+void TracksToRecords::startRecordWriter()
+{
+  if (mRecordWriter)
+    mRecordWriter->init();
+  if (mWithControl) {
+    mPointControl.setCyclicAutoSave(mNEntriesAutoSave);
+    mPointControl.init();
+  }
+}
+
+//__________________________________________________________________________
+void TracksToRecords::endRecordWriter()
+{
+  if (mRecordWriter) {
+    mRecordWriter->terminate(); // write record tree and close output file
+  }
+  if (mWithControl)
+    mPointControl.terminate();
+}
+
+//__________________________________________________________________________
+void TracksToRecords::startConstraintsRecWriter()
+{
+  if (!mWithConstraintsRecWriter)
+    return;
+
+  if (mConstraintsRecWriter) {
+    mConstraintsRecWriter->changeDataBranchName();
+    mConstraintsRecWriter->init();
+  }
+}
+
+//__________________________________________________________________________
+void TracksToRecords::endConstraintsRecWriter()
+{
+  if (!mWithConstraintsRecWriter)
+    return;
+
+  if (mConstraintsRecWriter) {
+    mConstraintsRecWriter->terminate();
+  }
+}
+
+//__________________________________________________________________________
+bool TracksToRecords::setLocalDerivative(Int_t index, Double_t value)
+{
+  // index [0 .. 3] for {dX0, dTx, dY0, dTz}
+
+  bool success = false;
+  if (index < mNumberOfTrackParam) {
+    mLocalDerivatives[index] = value;
+    success = true;
+  } else {
+    LOGF(error,
+         "AlignHelper::setLocalDerivative() - index %d >= %d",
+         index, mNumberOfTrackParam);
+  }
+  return success;
+}
+
+//__________________________________________________________________________
+bool TracksToRecords::setGlobalDerivative(Int_t index, Double_t value)
+{
+  // index [0 .. 3] for {dDeltaX, dDeltaY, dDeltaRz, dDeltaZ}
+
+  bool success = false;
+  if (index < mNumberOfGlobalParam) {
+    mGlobalDerivatives[index] = value;
+    success = true;
+  } else {
+    LOGF(error,
+         "AlignHelper::setGlobalDerivative() - index %d >= %d",
+         index, mNumberOfGlobalParam);
+  }
+  return success;
+}
+
+//__________________________________________________________________________
+bool TracksToRecords::resetLocalDerivative()
+{
+  bool success = false;
+  std::fill(mLocalDerivatives.begin(), mLocalDerivatives.end(), 0.);
+  success = true;
+  return success;
+}
+
+//__________________________________________________________________________
+bool TracksToRecords::resetGlocalDerivative()
+{
+  bool success = false;
+  std::fill(mGlobalDerivatives.begin(), mGlobalDerivatives.end(), 0.);
+  success = true;
+  return success;
+}
+
+//__________________________________________________________________________
+bool TracksToRecords::setLocalEquationX()
+{
+
+  if (!mAlignPoint->isAlignPointSet()) {
+    LOGF(error,
+         "TracksToRecords::setLocalEquationX() - no align point coordinates set !");
+    return false;
+  }
+  if (!mAlignPoint->isGlobalDerivativeDone())
+    return false;
+  if (!mAlignPoint->isLocalDerivativeDone())
+    return false;
+
+  bool success = true;
+
+  // clean slate for the local equation for this measurement
+
+  success &= resetGlocalDerivative();
+  success &= resetLocalDerivative();
+
+  // local derivatives
+  // index [0 .. 3] for {dX0, dTx, dY0, dTz}
+
+  success &= setLocalDerivative(0, mAlignPoint->localDerivativeX().dX0());
+  success &= setLocalDerivative(1, mAlignPoint->localDerivativeX().dTx());
+  success &= setLocalDerivative(2, mAlignPoint->localDerivativeX().dY0());
+  success &= setLocalDerivative(3, mAlignPoint->localDerivativeX().dTy());
+
+  // global derivatives
+  // index [0 .. 3] for {dDeltaX, dDeltaY, dDeltaRz, dDeltaZ}
+
+  Int_t chipId = mAlignPoint->getSensorId();
+  success &= setGlobalDerivative(chipId * mNDofPerSensor + 0, mAlignPoint->globalDerivativeX().dDeltaX());
+  success &= setGlobalDerivative(chipId * mNDofPerSensor + 1, mAlignPoint->globalDerivativeX().dDeltaY());
+  success &= setGlobalDerivative(chipId * mNDofPerSensor + 2, mAlignPoint->globalDerivativeX().dDeltaRz());
+  success &= setGlobalDerivative(chipId * mNDofPerSensor + 3, mAlignPoint->globalDerivativeX().dDeltaZ());
+
+  if (success) {
+    if (mCounterUsedTracks < 5) {
+      LOGF(debug,
+           "TracksToRecords::setLocalEquationX(): track %i sr %4d local %.3e %.3e %.3e %.3e, global %.3e %.3e %.3e %.3e X %.3e sigma %.3e",
+           mCounterUsedTracks, chipId,
+           mLocalDerivatives[0], mLocalDerivatives[1], mLocalDerivatives[2], mLocalDerivatives[3],
+           mGlobalDerivatives[chipId * mNDofPerSensor + 0],
+           mGlobalDerivatives[chipId * mNDofPerSensor + 1],
+           mGlobalDerivatives[chipId * mNDofPerSensor + 2],
+           mGlobalDerivatives[chipId * mNDofPerSensor + 3],
+           mAlignPoint->getLocalMeasuredPosition().X(),
+           mAlignPoint->getLocalMeasuredPositionSigma().X());
+    }
+    mMillepede->SetLocalEquation(
+      mGlobalDerivatives,
+      mLocalDerivatives,
+      mAlignPoint->getLocalMeasuredPosition().X(),
+      mAlignPoint->getLocalMeasuredPositionSigma().X());
+  } else {
+    mCounterLocalEquationFailed++;
+  }
+
+  return success;
+}
+
+//__________________________________________________________________________
+bool TracksToRecords::setLocalEquationY()
+{
+  if (!mAlignPoint->isAlignPointSet()) {
+    LOGF(error,
+         "TracksToRecords::setLocalEquationY() - no align point coordinates set !");
+    return false;
+  }
+  if (!mAlignPoint->isGlobalDerivativeDone())
+    return false;
+  if (!mAlignPoint->isLocalDerivativeDone())
+    return false;
+
+  bool success = true;
+
+  // clean slate for the local equation for this measurement
+
+  success &= resetGlocalDerivative();
+  success &= resetLocalDerivative();
+
+  // local derivatives
+  // index [0 .. 3] for {dX0, dTx, dY0, dTz}
+
+  success &= setLocalDerivative(0, mAlignPoint->localDerivativeY().dX0());
+  success &= setLocalDerivative(1, mAlignPoint->localDerivativeY().dTx());
+  success &= setLocalDerivative(2, mAlignPoint->localDerivativeY().dY0());
+  success &= setLocalDerivative(3, mAlignPoint->localDerivativeY().dTy());
+
+  // global derivatives
+  // index [0 .. 3] for {dDeltaX, dDeltaY, dDeltaRz, dDeltaZ}
+
+  Int_t chipId = mAlignPoint->getSensorId();
+  success &= setGlobalDerivative(chipId * mNDofPerSensor + 0, mAlignPoint->globalDerivativeY().dDeltaX());
+  success &= setGlobalDerivative(chipId * mNDofPerSensor + 1, mAlignPoint->globalDerivativeY().dDeltaY());
+  success &= setGlobalDerivative(chipId * mNDofPerSensor + 2, mAlignPoint->globalDerivativeY().dDeltaRz());
+  success &= setGlobalDerivative(chipId * mNDofPerSensor + 3, mAlignPoint->globalDerivativeY().dDeltaZ());
+
+  if (success) {
+    if (mCounterUsedTracks < 5) {
+      LOGF(debug,
+           "TracksToRecords::setLocalEquationY(): track %i sr %4d local %.3e %.3e %.3e %.3e, global %.3e %.3e %.3e %.3e Y %.3e sigma %.3e",
+           mCounterUsedTracks, chipId,
+           mLocalDerivatives[0], mLocalDerivatives[1], mLocalDerivatives[2], mLocalDerivatives[3],
+           mGlobalDerivatives[chipId * mNDofPerSensor + 0],
+           mGlobalDerivatives[chipId * mNDofPerSensor + 1],
+           mGlobalDerivatives[chipId * mNDofPerSensor + 2],
+           mGlobalDerivatives[chipId * mNDofPerSensor + 3],
+           mAlignPoint->getLocalMeasuredPosition().Y(),
+           mAlignPoint->getLocalMeasuredPositionSigma().Y());
+    }
+    mMillepede->SetLocalEquation(
+      mGlobalDerivatives,
+      mLocalDerivatives,
+      mAlignPoint->getLocalMeasuredPosition().Y(),
+      mAlignPoint->getLocalMeasuredPositionSigma().Y());
+  } else {
+    mCounterLocalEquationFailed++;
+  }
+
+  return success;
+}
+
+//__________________________________________________________________________
+bool TracksToRecords::setLocalEquationZ()
+{
+  if (!mAlignPoint->isAlignPointSet()) {
+    LOGF(error,
+         "TracksToRecords::setLocalEquationZ() - no align point coordinates set !");
+    return false;
+  }
+  if (!mAlignPoint->isGlobalDerivativeDone())
+    return false;
+  if (!mAlignPoint->isLocalDerivativeDone())
+    return false;
+
+  bool success = true;
+
+  // clean slate for the local equation for this measurement
+
+  success &= resetGlocalDerivative();
+  success &= resetLocalDerivative();
+
+  // local derivatives
+  // index [0 .. 3] for {dX0, dTx, dY0, dTz}
+
+  success &= setLocalDerivative(0, mAlignPoint->localDerivativeZ().dX0());
+  success &= setLocalDerivative(1, mAlignPoint->localDerivativeZ().dTx());
+  success &= setLocalDerivative(2, mAlignPoint->localDerivativeZ().dY0());
+  success &= setLocalDerivative(3, mAlignPoint->localDerivativeZ().dTy());
+
+  // global derivatives
+  // index [0 .. 3] for {dDeltaX, dDeltaY, dDeltaRz, dDeltaZ}
+
+  Int_t chipId = mAlignPoint->getSensorId();
+  success &= setGlobalDerivative(chipId * mNDofPerSensor + 0, mAlignPoint->globalDerivativeZ().dDeltaX());
+  success &= setGlobalDerivative(chipId * mNDofPerSensor + 1, mAlignPoint->globalDerivativeZ().dDeltaY());
+  success &= setGlobalDerivative(chipId * mNDofPerSensor + 2, mAlignPoint->globalDerivativeZ().dDeltaRz());
+  success &= setGlobalDerivative(chipId * mNDofPerSensor + 3, mAlignPoint->globalDerivativeZ().dDeltaZ());
+
+  if (success) {
+    if (mCounterUsedTracks < 5) {
+      LOGF(debug,
+           "TracksToRecords::setLocalEquationZ(): track %i sr %4d local %.3e %.3e %.3e %.3e, global %.3e %.3e %.3e %.3e Z %.3e sigma %.3e",
+           mCounterUsedTracks, chipId,
+           mLocalDerivatives[0], mLocalDerivatives[1], mLocalDerivatives[2], mLocalDerivatives[3],
+           mGlobalDerivatives[chipId * mNDofPerSensor + 0],
+           mGlobalDerivatives[chipId * mNDofPerSensor + 1],
+           mGlobalDerivatives[chipId * mNDofPerSensor + 2],
+           mGlobalDerivatives[chipId * mNDofPerSensor + 3],
+           mAlignPoint->getLocalMeasuredPosition().Z(),
+           mAlignPoint->getLocalMeasuredPositionSigma().Z());
+    }
+    mMillepede->SetLocalEquation(
+      mGlobalDerivatives,
+      mLocalDerivatives,
+      mAlignPoint->getLocalMeasuredPosition().Z(),
+      mAlignPoint->getLocalMeasuredPositionSigma().Z());
+  } else {
+    mCounterLocalEquationFailed++;
+  }
+
+  return success;
+}

--- a/Detectors/ITSMFT/MFT/alignment/src/VectorSparse.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/VectorSparse.cxx
@@ -1,0 +1,260 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file VectorSparse.cxx
+
+#include <string.h>
+#include <TString.h>
+
+#include "MFTAlignment/VectorSparse.h"
+
+using namespace o2::mft;
+
+ClassImp(VectorSparse);
+
+//___________________________________________________________
+VectorSparse::VectorSparse()
+  : fNElems(0),
+    fIndex(0),
+    fElems(0)
+{
+}
+
+//___________________________________________________________
+VectorSparse::VectorSparse(const VectorSparse& src)
+  : TObject(src),
+    fNElems(src.fNElems),
+    fIndex(0),
+    fElems(0)
+{
+  fIndex = new UShort_t[fNElems];
+  fElems = new Double_t[fNElems];
+  memcpy(fIndex, src.fIndex, fNElems * sizeof(UShort_t));
+  memcpy(fElems, src.fElems, fNElems * sizeof(Double_t));
+}
+
+//___________________________________________________________
+void VectorSparse::Clear(Option_t*)
+{
+  delete[] fIndex;
+  fIndex = 0;
+  delete[] fElems;
+  fElems = 0;
+  fNElems = 0;
+}
+
+//___________________________________________________________
+VectorSparse& VectorSparse::operator=(const VectorSparse& src)
+{
+  if (&src == this)
+    return *this;
+  Clear();
+  TObject::operator=(src);
+  fNElems = src.fNElems;
+  fIndex = new UShort_t[fNElems];
+  fElems = new Double_t[fNElems];
+  memcpy(fIndex, src.fIndex, fNElems * sizeof(UShort_t));
+  memcpy(fElems, src.fElems, fNElems * sizeof(Double_t));
+  //
+  return *this;
+}
+
+//___________________________________________________________
+Double_t VectorSparse::FindIndex(Int_t ind) const
+{
+  // printf("V: findindex\n");
+  int first = 0;
+  int last = fNElems - 1;
+  while (first <= last) {
+    int mid = (first + last) >> 1;
+    if (ind > fIndex[mid])
+      first = mid + 1;
+    else if (ind < fIndex[mid])
+      last = mid - 1;
+    else
+      return fElems[mid];
+  }
+  return 0.0;
+}
+
+//___________________________________________________________
+void VectorSparse::SetToZero(Int_t ind)
+{
+  int first = 0;
+  int last = fNElems - 1;
+  while (first <= last) {
+    int mid = (first + last) >> 1;
+    if (ind > fIndex[mid])
+      first = mid + 1;
+    else if (ind < fIndex[mid])
+      last = mid - 1;
+    else {
+      fElems[mid] = 0.;
+      return;
+    }
+  }
+}
+
+//___________________________________________________________
+Double_t& VectorSparse::FindIndexAdd(Int_t ind)
+{
+  // printf("V: findindexAdd\n");
+  int first = 0;
+  int last = fNElems - 1;
+  while (first <= last) {
+    int mid = (first + last) >> 1;
+    if (ind > fIndex[mid])
+      first = mid + 1;
+    else if (ind < fIndex[mid])
+      last = mid - 1;
+    else
+      return fElems[mid];
+  }
+  // need to insert a new element
+  UShort_t* arrI = new UShort_t[fNElems + 1];
+  memcpy(arrI, fIndex, first * sizeof(UShort_t));
+  arrI[first] = ind;
+  memcpy(arrI + first + 1, fIndex + first, (fNElems - first) * sizeof(UShort_t));
+  delete[] fIndex;
+  fIndex = arrI;
+
+  Double_t* arrE = new Double_t[fNElems + 1];
+  memcpy(arrE, fElems, first * sizeof(Double_t));
+  arrE[first] = 0;
+  memcpy(arrE + first + 1, fElems + first, (fNElems - first) * sizeof(Double_t));
+  delete[] fElems;
+  fElems = arrE;
+
+  fNElems++;
+  return fElems[first];
+}
+
+//__________________________________________________________
+void VectorSparse::ReSize(Int_t sz, Bool_t copy)
+{
+  if (sz < 1) {
+    Clear();
+    return;
+  }
+  // need to insert a new element
+  UShort_t* arrI = new UShort_t[sz];
+  Double_t* arrE = new Double_t[sz];
+  memset(arrI, 0, sz * sizeof(UShort_t));
+  memset(arrE, 0, sz * sizeof(Double_t));
+  //
+  if (copy && fIndex) {
+    int cpsz = TMath::Min(fNElems, sz);
+    memcpy(arrI, fIndex, cpsz * sizeof(UShort_t));
+    memcpy(arrE, fElems, cpsz * sizeof(Double_t));
+  }
+  delete[] fIndex;
+  delete[] fElems;
+  fIndex = arrI;
+  fElems = arrE;
+  fNElems = sz;
+}
+
+//__________________________________________________________
+void VectorSparse::SortIndices(Bool_t valuesToo)
+{
+  for (int i = fNElems; i--;)
+    for (int j = i; j--;)
+      if (fIndex[i] < fIndex[j]) { // swap
+        UShort_t tmpI = fIndex[i];
+        fIndex[i] = fIndex[j];
+        fIndex[j] = tmpI;
+        if (valuesToo) {
+          Double_t tmpV = fElems[i];
+          fElems[i] = fElems[j];
+          fElems[j] = tmpV;
+        }
+      }
+}
+
+//__________________________________________________________
+void VectorSparse::Print(Option_t* opt) const
+{
+  TString sopt = opt;
+  sopt.ToLower();
+  int ndig = sopt.Atoi();
+  if (ndig <= 1)
+    ndig = 2;
+  sopt = "%2d:%+.";
+  sopt += ndig;
+  sopt += "e |";
+  printf("|");
+  for (int i = 0; i < fNElems; i++)
+    printf(sopt.Data(), fIndex[i], fElems[i]);
+  printf("\n");
+}
+
+//___________________________________________________________
+void VectorSparse::Add(Double_t* valc, Int_t* indc, Int_t n)
+{
+  int indx;
+  int nadd = 0;
+
+  int last = fNElems - 1;
+  int mid = 0;
+  for (int i = n; i--;) {
+    // if the element with this index is already defined, just add the value
+    int first = 0;
+    Bool_t toAdd = kTRUE;
+    indx = indc[i];
+    while (first <= last) {
+      mid = (first + last) >> 1;
+      if (indx > fIndex[mid])
+        first = mid + 1;
+      else if (indx < fIndex[mid])
+        last = mid - 1;
+      else {
+        fElems[mid] += valc[i];
+        indc[i] = -1;
+        toAdd = kFALSE;
+        last = mid - 1; // profit from the indices being ordered
+        break;
+      }
+    }
+    if (toAdd)
+      nadd++;
+  }
+
+  if (nadd < 1)
+    return; // nothing to do anymore
+
+  // need to expand the row
+  UShort_t* arrI = new UShort_t[fNElems + nadd];
+  Double_t* arrE = new Double_t[fNElems + nadd];
+  // copy old elems embedding the new ones
+  int inew = 0, iold = 0;
+  for (int i = 0; i < n; i++) {
+    if ((indx = indc[i]) < 0)
+      continue;
+    while (iold < fNElems && fIndex[iold] < indx) {
+      arrI[inew] = fIndex[iold];
+      arrE[inew++] = fElems[iold++];
+    }
+    arrI[inew] = indx;
+    arrE[inew++] = valc[i];
+  }
+  // copy the rest
+  while (iold < fNElems) {
+    arrI[inew] = fIndex[iold];
+    arrE[inew++] = fElems[iold++];
+  }
+
+  delete[] fIndex;
+  delete[] fElems;
+  fIndex = arrI;
+  fElems = arrE;
+
+  fNElems += nadd;
+}

--- a/Detectors/ITSMFT/MFT/alignment/src/VectorSparse.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/VectorSparse.cxx
@@ -11,7 +11,6 @@
 
 /// @file VectorSparse.cxx
 
-#include <string.h>
 #include <TString.h>
 
 #include "MFTAlignment/VectorSparse.h"
@@ -23,8 +22,8 @@ ClassImp(VectorSparse);
 //___________________________________________________________
 VectorSparse::VectorSparse()
   : fNElems(0),
-    fIndex(0),
-    fElems(0)
+    fIndex(nullptr),
+    fElems(nullptr)
 {
 }
 
@@ -32,8 +31,8 @@ VectorSparse::VectorSparse()
 VectorSparse::VectorSparse(const VectorSparse& src)
   : TObject(src),
     fNElems(src.fNElems),
-    fIndex(0),
-    fElems(0)
+    fIndex(nullptr),
+    fElems(nullptr)
 {
   fIndex = new UShort_t[fNElems];
   fElems = new Double_t[fNElems];
@@ -45,17 +44,18 @@ VectorSparse::VectorSparse(const VectorSparse& src)
 void VectorSparse::Clear(Option_t*)
 {
   delete[] fIndex;
-  fIndex = 0;
+  fIndex = nullptr;
   delete[] fElems;
-  fElems = 0;
+  fElems = nullptr;
   fNElems = 0;
 }
 
 //___________________________________________________________
 VectorSparse& VectorSparse::operator=(const VectorSparse& src)
 {
-  if (&src == this)
+  if (&src == this) {
     return *this;
+  }
   Clear();
   TObject::operator=(src);
   fNElems = src.fNElems;
@@ -75,12 +75,15 @@ Double_t VectorSparse::FindIndex(Int_t ind) const
   int last = fNElems - 1;
   while (first <= last) {
     int mid = (first + last) >> 1;
-    if (ind > fIndex[mid])
+    if (ind > fIndex[mid]) {
       first = mid + 1;
-    else if (ind < fIndex[mid])
-      last = mid - 1;
-    else
-      return fElems[mid];
+    } else {
+      if (ind < fIndex[mid]) {
+        last = mid - 1;
+      } else {
+        return fElems[mid];
+      }
+    }
   }
   return 0.0;
 }
@@ -92,13 +95,15 @@ void VectorSparse::SetToZero(Int_t ind)
   int last = fNElems - 1;
   while (first <= last) {
     int mid = (first + last) >> 1;
-    if (ind > fIndex[mid])
+    if (ind > fIndex[mid]) {
       first = mid + 1;
-    else if (ind < fIndex[mid])
-      last = mid - 1;
-    else {
-      fElems[mid] = 0.;
-      return;
+    } else {
+      if (ind < fIndex[mid]) {
+        last = mid - 1;
+      } else {
+        fElems[mid] = 0.;
+        return;
+      }
     }
   }
 }
@@ -111,12 +116,15 @@ Double_t& VectorSparse::FindIndexAdd(Int_t ind)
   int last = fNElems - 1;
   while (first <= last) {
     int mid = (first + last) >> 1;
-    if (ind > fIndex[mid])
+    if (ind > fIndex[mid]) {
       first = mid + 1;
-    else if (ind < fIndex[mid])
-      last = mid - 1;
-    else
-      return fElems[mid];
+    } else {
+      if (ind < fIndex[mid]) {
+        last = mid - 1;
+      } else {
+        return fElems[mid];
+      }
+    }
   }
   // need to insert a new element
   UShort_t* arrI = new UShort_t[fNElems + 1];
@@ -185,14 +193,16 @@ void VectorSparse::Print(Option_t* opt) const
   TString sopt = opt;
   sopt.ToLower();
   int ndig = sopt.Atoi();
-  if (ndig <= 1)
+  if (ndig <= 1) {
     ndig = 2;
+  }
   sopt = "%2d:%+.";
   sopt += ndig;
   sopt += "e |";
   printf("|");
-  for (int i = 0; i < fNElems; i++)
+  for (int i = 0; i < fNElems; i++) {
     printf(sopt.Data(), fIndex[i], fElems[i]);
+  }
   printf("\n");
 }
 
@@ -211,33 +221,36 @@ void VectorSparse::Add(Double_t* valc, Int_t* indc, Int_t n)
     indx = indc[i];
     while (first <= last) {
       mid = (first + last) >> 1;
-      if (indx > fIndex[mid])
+      if (indx > fIndex[mid]) {
         first = mid + 1;
-      else if (indx < fIndex[mid])
-        last = mid - 1;
-      else {
-        fElems[mid] += valc[i];
-        indc[i] = -1;
-        toAdd = kFALSE;
-        last = mid - 1; // profit from the indices being ordered
-        break;
+      } else {
+        if (indx < fIndex[mid]) {
+          last = mid - 1;
+        } else {
+          fElems[mid] += valc[i];
+          indc[i] = -1;
+          toAdd = kFALSE;
+          last = mid - 1; // profit from the indices being ordered
+          break;
+        }
       }
     }
     if (toAdd)
       nadd++;
   }
 
-  if (nadd < 1)
+  if (nadd < 1) {
     return; // nothing to do anymore
-
+  }
   // need to expand the row
   UShort_t* arrI = new UShort_t[fNElems + nadd];
   Double_t* arrE = new Double_t[fNElems + nadd];
   // copy old elems embedding the new ones
   int inew = 0, iold = 0;
   for (int i = 0; i < n; i++) {
-    if ((indx = indc[i]) < 0)
+    if ((indx = indc[i]) < 0) {
       continue;
+    }
     while (iold < fNElems && fIndex[iold] < indx) {
       arrI[inew] = fIndex[iold];
       arrE[inew++] = fElems[iold++];

--- a/Detectors/ITSMFT/MFT/base/src/GeometryTGeo.cxx
+++ b/Detectors/ITSMFT/MFT/base/src/GeometryTGeo.cxx
@@ -483,7 +483,7 @@ void GeometryTGeo::updateL2GMatrixCache(std::vector<int> chipIDs)
 //__________________________________________________________________________
 TGeoHMatrix& GeometryTGeo::createT2LMatrix(Int_t index)
 {
-  // create for sensor isn the TGeo matrix for Tracking to Local frame transformations
+  // create for sensor at index the TGeo matrix for Tracking to Local frame transformations
 
   static TGeoHMatrix t2l;
   Float_t x = 0.f, alpha = 0.f;
@@ -491,8 +491,9 @@ TGeoHMatrix& GeometryTGeo::createT2LMatrix(Int_t index)
   t2l.Clear();
   /*
   t2l.RotateZ(alpha * RadToDeg()); // rotate in direction of normal to the sensor plane
-  const TGeoHMatrix* matL2G = extractMatrixSensor(isn);
-  t2l.MultiplyLeft(&matL2G->Inverse());
+  const TGeoHMatrix* matL2G = extractMatrixSensor(index);
+  const TGeoHMatrix& matL2Gi = matL2G->Inverse();
+  t2l.MultiplyLeft(&matL2Gi);
   */
   return t2l;
 }

--- a/Detectors/ITSMFT/MFT/calibration/CMakeLists.txt
+++ b/Detectors/ITSMFT/MFT/calibration/CMakeLists.txt
@@ -10,19 +10,20 @@
 # or submit itself to any jurisdiction.
 
 o2_add_library(MFTCalibration
-               SOURCES src/NoiseCalibrator.cxx
-         SOURCES src/NoiseCalibratorSpec.cxx
-         PUBLIC_LINK_LIBRARIES O2::DataFormatsMFT O2::MFTBase
-                                     O2::DetectorsCalibration
-                                     O2::CCDB)
+        SOURCES src/NoiseCalibrator.cxx
+                src/NoiseCalibratorSpec.cxx
+        PUBLIC_LINK_LIBRARIES O2::MFTBase
+                O2::DataFormatsMFT
+                O2::MFTTracking
+                O2::DetectorsCalibration
+                O2::CCDB)
 
 o2_target_root_dictionary(MFTCalibration
         HEADERS include/MFTCalibration/NoiseCalibrator.h
         LINKDEF src/MFTCalibrationLinkDef.h)
 
 o2_add_executable(mft-calib-workflow
-                  COMPONENT_NAME calibration
-                  SOURCES testWorkflow/mft-calib-workflow.cxx
-                  PUBLIC_LINK_LIBRARIES O2::Framework
-      O2::MFTCalibration)
-
+        COMPONENT_NAME calibration
+        SOURCES testWorkflow/mft-calib-workflow.cxx
+        PUBLIC_LINK_LIBRARIES O2::Framework
+                              O2::MFTCalibration)

--- a/Detectors/ITSMFT/MFT/calibration/src/MchAlignment.cxx
+++ b/Detectors/ITSMFT/MFT/calibration/src/MchAlignment.cxx
@@ -1,0 +1,1660 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+//-----------------------------------------------------------------------------
+/// \file Alignment
+/// Alignment class for the ALICE DiMuon spectrometer
+///
+/// MUON specific alignment class which interface to AliMillepede.
+/// For each track ProcessTrack calculates the local and global derivatives
+/// at each cluster and fill the corresponding local equations. Provide methods
+/// for fixing or constraining detection elements for best results.
+///
+/// \author Javier Castillo Castellanos
+//-----------------------------------------------------------------------------
+
+#include "MCHAlign/Alignment.h"
+#include "MCHAlign/MillePede2.h"
+#include "MCHAlign/MillePedeRecord.h"
+#include <iostream>
+
+#include "MCHTracking/Track.h"
+#include "MCHTracking/TrackParam.h"
+#include "MCHTracking/Cluster.h"
+#include "TGeoManager.h"
+
+// #include "DataFormatsMCH/ROFRecord.h"
+// #include "DataFormatsMCH/TrackMCH.h"
+// #include "DataFormatsMCH/Cluster.h"
+// #include "DataFormatsMCH/Digit.h"
+
+// #include "AliMUONGeometryTransformer.h"
+// #include "AliMUONGeometryModuleTransformer.h"
+// #include "MCHAlign/AliMUONGeometryDetElement.h"
+// #include "AliMUONGeometryBuilder.h"
+#include "MCHGeometryCreator/Geometry.h"
+#include "MCHGeometryTest/Helpers.h"
+#include "MCHGeometryTransformer/Transformations.h"
+#include "TGeoManager.h"
+
+// #include "Align/Millepede2Record.h" //to be replaced
+// #include "AliMpExMap.h"
+// #include "AliMpExMapIterator.h"
+
+#include "DetectorsCommonDataFormats/AlignParam.h"
+#include "Framework/Logger.h"
+
+#include <TMath.h>
+#include <TMatrixDSym.h>
+#include <TMatrixD.h>
+#include <TClonesArray.h>
+#include <TGraphErrors.h>
+#include <TObject.h>
+
+namespace o2
+{
+namespace mch
+{
+
+using namespace std;
+
+//_____________________________________________________________________
+// static variables
+const Int_t Alignment::fgNDetElemCh[Alignment::fgNCh] = {4, 4, 4, 4, 18, 18, 26, 26, 26, 26};
+const Int_t Alignment::fgSNDetElemCh[Alignment::fgNCh + 1] = {0, 4, 8, 12, 16, 34, 52, 78, 104, 130, 156};
+
+// number of detector elements in each half-chamber
+const Int_t Alignment::fgNDetElemHalfCh[Alignment::fgNHalfCh] = {2, 2, 2, 2, 2, 2, 2, 2, 9, 9, 9, 9, 13, 13, 13, 13, 13, 13, 13, 13};
+
+// list of detector elements for each half chamber
+const Int_t Alignment::fgDetElemHalfCh[Alignment::fgNHalfCh][Alignment::fgNDetHalfChMax] =
+  {
+    {100, 103, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+    {101, 102, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+
+    {200, 203, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+    {201, 202, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+
+    {300, 303, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+    {301, 302, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+
+    {400, 403, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+    {401, 402, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+
+    {500, 501, 502, 503, 504, 514, 515, 516, 517, 0, 0, 0, 0},
+    {505, 506, 507, 508, 509, 510, 511, 512, 513, 0, 0, 0, 0},
+
+    {600, 601, 602, 603, 604, 614, 615, 616, 617, 0, 0, 0, 0},
+    {605, 606, 607, 608, 609, 610, 611, 612, 613, 0, 0, 0, 0},
+
+    {700, 701, 702, 703, 704, 705, 706, 720, 721, 722, 723, 724, 725},
+    {707, 708, 709, 710, 711, 712, 713, 714, 715, 716, 717, 718, 719},
+
+    {800, 801, 802, 803, 804, 805, 806, 820, 821, 822, 823, 824, 825},
+    {807, 808, 809, 810, 811, 812, 813, 814, 815, 816, 817, 818, 819},
+
+    {900, 901, 902, 903, 904, 905, 906, 920, 921, 922, 923, 924, 925},
+    {907, 908, 909, 910, 911, 912, 913, 914, 915, 916, 917, 918, 919},
+
+    {1000, 1001, 1002, 1003, 1004, 1005, 1006, 1020, 1021, 1022, 1023, 1024, 1025},
+    {1007, 1008, 1009, 1010, 1011, 1012, 1013, 1014, 1015, 1016, 1017, 1018, 1019}
+
+};
+
+//_____________________________________________________________________
+/// self initialized array, used for adding constraints
+class Array
+{
+
+ public:
+  /// contructor
+  Array(void)
+  {
+    for (Int_t i = 0; i < Alignment::fNGlobal; ++i) {
+      values[i] = 0;
+    }
+  }
+
+  /// array
+  Double_t values[Alignment::fNGlobal];
+
+ private:
+  /// Not implemented
+  Array(const Array&);
+
+  /// Not implemented
+  Array& operator=(const Array&);
+};
+
+//________________________________________________________________________
+Double_t Square(Double_t x) { return x * x; }
+
+//_____________________________________________________________________
+Alignment::Alignment()
+  : TObject(),
+    fInitialized(kFALSE),
+    fRunNumber(0),
+    fBFieldOn(kFALSE),
+    fRefitStraightTracks(kFALSE),
+    fStartFac(256),
+    fResCutInitial(100),
+    fResCut(100),
+    fMillepede(0L), // to be modified
+    fCluster(0L),
+    fNStdDev(3),
+    fDetElemNumber(0),
+    fTrackRecord(),
+    fTransformCreator(),
+    fGeoCombiTransInverse(),
+    fDoEvaluation(kFALSE),
+    fTrackParamOrig(0),
+    fTrackParamNew(0),
+    fTFile(0),
+    fTTree(0)
+{
+  /// constructor
+  fSigma[0] = 1.5e-1;
+  fSigma[1] = 1.0e-2;
+
+  // default allowed variations
+  fAllowVar[0] = 0.5;  // x
+  fAllowVar[1] = 0.5;  // y
+  fAllowVar[2] = 0.01; // phi_z
+  fAllowVar[3] = 5;    // z
+
+  // initialize millepede
+  fMillepede = new MillePede2();
+  // fMillepede = new o2::align::Mille("theMilleFile.txt"); // To be replaced by MillePede2
+
+  // initialize degrees of freedom
+  // by default all parameters are free
+  for (Int_t iPar = 0; iPar < fNGlobal; ++iPar) {
+    fGlobalParameterStatus[iPar] = kFreeParId;
+  }
+
+  // initialize local equations
+  for (int i = 0; i < fNLocal; ++i) {
+    fLocalDerivatives[i] = 0.0;
+  }
+
+  for (int i = 0; i < fNGlobal; ++i) {
+    fGlobalDerivatives[i] = 0.0;
+  }
+}
+
+//_____________________________________________________________________
+// Alignment::~Alignment()
+//{
+//  /// destructor
+//}
+// Alignment::~Alignment() = default;
+//_____________________________________________________________________
+void Alignment::init(void)
+{
+
+  /// initialize
+  /**
+  initialize millipede
+  must be called after necessary detectors have been fixed,
+  but before constrains are added and before global parameters initial value are set
+  */
+  if (fInitialized) {
+    LOG(fatal) << "Millepede already initialized";
+  }
+
+  // assign proper groupID to free parameters
+  Int_t nGlobal = 0;
+  for (Int_t iPar = 0; iPar < fNGlobal; ++iPar) {
+
+    if (fGlobalParameterStatus[iPar] == kFixedParId) {
+      // fixed parameters are left unchanged
+      continue;
+
+    } else if (fGlobalParameterStatus[iPar] == kFreeParId || fGlobalParameterStatus[iPar] == kGroupBaseId) {
+
+      // free parameters or first element of group are assigned a new group id
+      fGlobalParameterStatus[iPar] = nGlobal++;
+      continue;
+
+    } else if (fGlobalParameterStatus[iPar] < kGroupBaseId) {
+
+      // get detector element id from status, get chamber parameter id
+      const Int_t iDeBase(kGroupBaseId - 1 - fGlobalParameterStatus[iPar]);
+      const Int_t iParBase = iPar % fgNParCh;
+
+      // check
+      if (iDeBase < 0 || iDeBase >= iPar / fgNParCh) {
+        LOG(fatal) << "Group for parameter index " << iPar << " has wrong base detector element: " << iDeBase;
+      }
+
+      // assign identical group id to current
+      fGlobalParameterStatus[iPar] = fGlobalParameterStatus[iDeBase * fgNParCh + iParBase];
+      LOG(info) << "Parameter " << iPar << " grouped to detector " << iDeBase << " (" << GetParameterMaskString(1 << iParBase).Data() << ")";
+
+    } else
+      LOG(fatal) << "Unrecognized parameter status for index " << iPar << ": " << fGlobalParameterStatus[iPar];
+  }
+
+  LOG(info) << "Free Parameters: " << nGlobal << " out of " << fNGlobal;
+
+  // initialize millepede
+  // fMillepede->InitMille(fNGlobal, fNLocal, fNStdDev, fResCut, fResCutInitial, fGlobalParameterStatus);
+  fMillepede->InitMille(fNGlobal, fNLocal, fNStdDev, fResCut, fResCutInitial); // MillePede2 implementation
+
+  fInitialized = kTRUE;
+
+  // some debug output
+  for (Int_t iPar = 0; iPar < fgNParCh; ++iPar) {
+    LOG(info) << "fAllowVar[" << iPar << "]= " << fAllowVar[iPar];
+  }
+
+  // set allowed variations for all parameters
+  for (Int_t iDet = 0; iDet < fgNDetElem; ++iDet) {
+    for (Int_t iPar = 0; iPar < fgNParCh; ++iPar) {
+      fMillepede->SetParSigma(iDet * fgNParCh + iPar, fAllowVar[iPar]);
+    }
+  }
+
+  // Set iterations
+  if (fStartFac > 1) {
+    fMillepede->SetIterations(fStartFac);
+  }
+  // setup monitoring TFile
+  if (fDoEvaluation && fRefitStraightTracks) {
+    fTFile = new TFile("Alignment.root", "RECREATE");
+    fTTree = new TTree("TreeE", "Evaluation");
+
+    const Int_t kSplitlevel = 98;
+    const Int_t kBufsize = 32000;
+
+    fTrackParamOrig = new LocalTrackParam();
+    fTTree->Branch("fTrackParamOrig", "LocalTrackParam", &fTrackParamOrig, kBufsize, kSplitlevel);
+
+    fTrackParamNew = new LocalTrackParam();
+    fTTree->Branch("fTrackParamNew", "LocalTrackParam", &fTrackParamNew, kBufsize, kSplitlevel);
+  }
+}
+
+//_____________________________________________________
+void Alignment::terminate(void)
+{
+  LOG(info) << "Closing Evaluation TFile";
+  if (fTFile && fTTree) {
+    fTFile->cd();
+    fTTree->Write();
+    fTFile->Close();
+  }
+}
+
+//_____________________________________________________
+MillePedeRecord* Alignment::ProcessTrack(Track& track, Bool_t doAlignment, Double_t weight)
+{
+  /// process track for alignment minimization
+  /**
+  returns the alignment records for this track.
+  They can be stored in some output for later reprocessing.
+  */
+
+  // reset track records
+  fTrackRecord.Reset();
+  if (fMillepede->GetRecord()) {
+    fMillepede->GetRecord()->Reset();
+  }
+
+  // loop over clusters to get starting values
+  Bool_t first(kTRUE);
+  // if (!trackParam)
+  // continue;
+  for (auto itTrackParam(track.begin()); itTrackParam != track.end(); ++itTrackParam) {
+
+    // get cluster
+    const Cluster* Cluster = itTrackParam->getClusterPtr();
+    if (!cluster)
+      continue;
+
+    // for first valid cluster, save track position as "starting" values
+    if (first) {
+
+      first = kFALSE;
+      FillTrackParamData(&*itTrackParam);
+      fTrackPos0[0] = fTrackPos[0];
+      fTrackPos0[1] = fTrackPos[1];
+      fTrackPos0[2] = fTrackPos[2];
+      fTrackSlope0[0] = fTrackSlope[0];
+      fTrackSlope0[1] = fTrackSlope[1];
+
+      break;
+    }
+  }
+
+  // redo straight track fit
+  if (fRefitStraightTracks) {
+
+    // refit straight track
+    const LocalTrackParam trackParam(RefitStraightTrack(track, fTrackPos0[2]));
+
+    // fill evaluation tree
+    if (fTrackParamOrig) {
+      fTrackParamOrig->fTrackX = fTrackPos0[0];
+      fTrackParamOrig->fTrackY = fTrackPos0[1];
+      fTrackParamOrig->fTrackZ = fTrackPos0[2];
+      fTrackParamOrig->fTrackSlopeX = fTrackSlope[0];
+      fTrackParamOrig->fTrackSlopeY = fTrackSlope[1];
+    }
+
+    // new ones
+    if (fTrackParamNew) {
+      fTrackParamNew->fTrackX = trackParam.fTrackX;
+      fTrackParamNew->fTrackY = trackParam.fTrackY;
+      fTrackParamNew->fTrackZ = trackParam.fTrackZ;
+      fTrackParamNew->fTrackSlopeX = trackParam.fTrackSlopeX;
+      fTrackParamNew->fTrackSlopeY = trackParam.fTrackSlopeY;
+    }
+
+    if (fTTree)
+      fTTree->Fill();
+
+    /*
+    copy new parameters to stored ones for derivatives calculation
+    this is done only if BFieldOn is false, for which these parameters are used
+    */
+    if (!fBFieldOn) {
+      fTrackPos0[0] = trackParam.fTrackX;
+      fTrackPos0[1] = trackParam.fTrackY;
+      fTrackPos0[2] = trackParam.fTrackZ;
+      fTrackSlope[0] = trackParam.fTrackSlopeX;
+      fTrackSlope[1] = trackParam.fTrackSlopeY;
+    }
+  }
+
+  // second loop to perform alignment
+  for (auto itTrackParam(track.begin()); itTrackParam != track.end(); ++itTrackParam) {
+
+    // get track parameters
+    if (!&*itTrackParam)
+      continue;
+
+    // get cluster
+    const Cluster* cluster = itTrackParam->getClusterPtr();
+    if (!cluster)
+      continue;
+
+    // fill local variables for this position --> one measurement
+    FillDetElemData(cluster);
+    FillRecPointData(cluster);
+    FillTrackParamData(&*itTrackParam);
+
+    // 'inverse' (GlobalToLocal) rotation matrix
+    const Double_t* r(fGeoCombiTransInverse.GetRotationMatrix());
+
+    // calculate measurements
+    if (fBFieldOn) {
+
+      // use residuals (cluster - track) for measurement
+      fMeas[0] = r[0] * (fClustPos[0] - fTrackPos[0]) + r[1] * (fClustPos[1] - fTrackPos[1]);
+      fMeas[1] = r[3] * (fClustPos[0] - fTrackPos[0]) + r[4] * (fClustPos[1] - fTrackPos[1]);
+
+    } else {
+
+      // use cluster position for measurement
+      fMeas[0] = (r[0] * fClustPos[0] + r[1] * fClustPos[1]);
+      fMeas[1] = (r[3] * fClustPos[0] + r[4] * fClustPos[1]);
+    }
+
+    // Set local equations
+    LocalEquationX();
+    LocalEquationY();
+  }
+
+  // copy track record
+  fMillepede->SetRecordRun(fRunNumber);
+  fMillepede->SetRecordWeight(weight);
+  fTrackRecord = *fMillepede->GetRecord();
+
+  // save record data
+  if (doAlignment) {
+    fMillepede->SaveRecordData();
+    fMillepede->CloseDataRecStorage();
+  }
+
+  // return record
+  return &fTrackRecord;
+}
+
+//______________________________________________________________________________
+void Alignment::ProcessTrack(MillePedeRecord* trackRecord)
+{
+  LOG(fatal) << __PRETTY_FUNCTION__ << " is disabled";
+
+  /// process track record
+  if (!trackRecord)
+    return;
+
+  // // make sure record storage is initialized
+  if (!fMillepede->GetRecord()) {
+    fMillepede->InitDataRecStorage(kFalse);
+  }
+  // // copy content
+  *fMillepede->GetRecord() = *trackRecord;
+
+  // save record
+  fMillepede->SaveRecordData();
+  // write to local file
+  fMillepede->CloseDataRecStorage();
+
+  return;
+}
+
+//_____________________________________________________________________
+void Alignment::FixAll(UInt_t mask)
+{
+  /// fix parameters matching mask, for all chambers
+  LOG(info) << "Fixing " << GetParameterMaskString(mask).Data() << " for all detector elements";
+
+  // fix all stations
+  for (Int_t i = 0; i < fgNDetElem; ++i) {
+    if (mask & ParX)
+      FixParameter(i, 0);
+    if (mask & ParY)
+      FixParameter(i, 1);
+    if (mask & ParTZ)
+      FixParameter(i, 2);
+    if (mask & ParZ)
+      FixParameter(i, 3);
+  }
+}
+
+//_____________________________________________________________________
+void Alignment::FixChamber(Int_t iCh, UInt_t mask)
+{
+  /// fix parameters matching mask, for all detector elements in a given chamber, counting from 1
+
+  // check boundaries
+  if (iCh < 1 || iCh > 10) {
+    LOG(fatal) << "Invalid chamber index " << iCh;
+  }
+
+  // get first and last element
+  const Int_t iDetElemFirst = fgSNDetElemCh[iCh - 1];
+  const Int_t iDetElemLast = fgSNDetElemCh[iCh];
+  for (Int_t i = iDetElemFirst; i < iDetElemLast; ++i) {
+
+    LOG(info) << "Fixing " << GetParameterMaskString(mask).Data() << " for detector element " << i;
+
+    if (mask & ParX)
+      FixParameter(i, 0);
+    if (mask & ParY)
+      FixParameter(i, 1);
+    if (mask & ParTZ)
+      FixParameter(i, 2);
+    if (mask & ParZ)
+      FixParameter(i, 3);
+  }
+}
+
+//_____________________________________________________________________
+void Alignment::FixDetElem(Int_t iDetElemId, UInt_t mask)
+{
+  /// fix parameters matching mask, for a given detector element, counting from 0
+  const Int_t iDet(GetDetElemNumber(iDetElemId));
+  if (mask & ParX)
+    FixParameter(iDet, 0);
+  if (mask & ParY)
+    FixParameter(iDet, 1);
+  if (mask & ParTZ)
+    FixParameter(iDet, 2);
+  if (mask & ParZ)
+    FixParameter(iDet, 3);
+}
+
+//_____________________________________________________________________
+void Alignment::FixHalfSpectrometer(const Bool_t* lChOnOff, UInt_t sidesMask, UInt_t mask)
+{
+
+  /// Fix parameters matching mask for all detectors in selected chambers and selected sides of the spectrometer
+  for (Int_t i = 0; i < fgNDetElem; ++i) {
+
+    // get chamber matching detector
+    const Int_t iCh(GetChamberId(i));
+    if (!lChOnOff[iCh - 1])
+      continue;
+
+    // get detector element in chamber
+    Int_t lDetElemNumber = i - fgSNDetElemCh[iCh - 1];
+
+    // skip detector if its side is off
+    // stations 1 and 2
+    if (iCh >= 1 && iCh <= 4) {
+      if (lDetElemNumber == 0 && !(sidesMask & SideTopRight))
+        continue;
+      if (lDetElemNumber == 1 && !(sidesMask & SideTopLeft))
+        continue;
+      if (lDetElemNumber == 2 && !(sidesMask & SideBottomLeft))
+        continue;
+      if (lDetElemNumber == 3 && !(sidesMask & SideBottomRight))
+        continue;
+    }
+
+    // station 3
+    if (iCh >= 5 && iCh <= 6) {
+      if (lDetElemNumber >= 0 && lDetElemNumber <= 4 && !(sidesMask & SideTopRight))
+        continue;
+      if (lDetElemNumber >= 5 && lDetElemNumber <= 10 && !(sidesMask & SideTopLeft))
+        continue;
+      if (lDetElemNumber >= 11 && lDetElemNumber <= 13 && !(sidesMask & SideBottomLeft))
+        continue;
+      if (lDetElemNumber >= 14 && lDetElemNumber <= 17 && !(sidesMask & SideBottomRight))
+        continue;
+    }
+
+    // stations 4 and 5
+    if (iCh >= 7 && iCh <= 10) {
+      if (lDetElemNumber >= 0 && lDetElemNumber <= 6 && !(sidesMask & SideTopRight))
+        continue;
+      if (lDetElemNumber >= 7 && lDetElemNumber <= 13 && !(sidesMask & SideTopLeft))
+        continue;
+      if (lDetElemNumber >= 14 && lDetElemNumber <= 19 && !(sidesMask & SideBottomLeft))
+        continue;
+      if (lDetElemNumber >= 20 && lDetElemNumber <= 25 && !(sidesMask & SideBottomRight))
+        continue;
+    }
+
+    // detector is accepted, fix it
+    FixDetElem(i, mask);
+  }
+}
+
+//______________________________________________________________________
+void Alignment::FixParameter(Int_t iPar)
+{
+
+  /// fix a given parameter, counting from 0
+  if (fInitialized) {
+    LOG(fatal) << "Millepede already initialized";
+  }
+
+  fGlobalParameterStatus[iPar] = kFixedParId;
+}
+
+//_____________________________________________________________________
+void Alignment::ReleaseChamber(Int_t iCh, UInt_t mask)
+{
+  /// release parameters matching mask, for all detector elements in a given chamber, counting from 1
+
+  // check boundaries
+  if (iCh < 1 || iCh > 10) {
+    LOG(fatal) << "Invalid chamber index " << iCh;
+  }
+
+  // get first and last element
+  const Int_t iDetElemFirst = fgSNDetElemCh[iCh - 1];
+  const Int_t iDetElemLast = fgSNDetElemCh[iCh];
+  for (Int_t i = iDetElemFirst; i < iDetElemLast; ++i) {
+
+    LOG(info) << "Releasing " << GetParameterMaskString(mask).Data() << " for detector element " << i;
+
+    if (mask & ParX)
+      ReleaseParameter(i, 0);
+    if (mask & ParY)
+      ReleaseParameter(i, 1);
+    if (mask & ParTZ)
+      ReleaseParameter(i, 2);
+    if (mask & ParZ)
+      ReleaseParameter(i, 3);
+  }
+}
+
+//_____________________________________________________________________
+void Alignment::ReleaseDetElem(Int_t iDetElemId, UInt_t mask)
+{
+  /// release parameters matching mask, for a given detector element, counting from 0
+  const Int_t iDet(GetDetElemNumber(iDetElemId));
+  if (mask & ParX)
+    ReleaseParameter(iDet, 0);
+  if (mask & ParY)
+    ReleaseParameter(iDet, 1);
+  if (mask & ParTZ)
+    ReleaseParameter(iDet, 2);
+  if (mask & ParZ)
+    ReleaseParameter(iDet, 3);
+}
+
+//______________________________________________________________________
+void Alignment::ReleaseParameter(Int_t iPar)
+{
+
+  /// release a given parameter, counting from 0
+  if (fInitialized) {
+    LOG(fatal) << "Millepede already initialized";
+  }
+
+  fGlobalParameterStatus[iPar] = kFreeParId;
+}
+
+//_____________________________________________________________________
+void Alignment::GroupChamber(Int_t iCh, UInt_t mask)
+{
+  /// group parameters matching mask for all detector elements in a given chamber, counting from 1
+  if (iCh < 1 || iCh > fgNCh) {
+    LOG(fatal) << "Invalid chamber index " << iCh;
+  }
+
+  const Int_t detElemMin = 100 * iCh;
+  const Int_t detElemMax = 100 * iCh + fgNDetElemCh[iCh] - 1;
+  GroupDetElems(detElemMin, detElemMax, mask);
+}
+
+//_____________________________________________________________________
+void Alignment::GroupHalfChamber(Int_t iCh, Int_t iHalf, UInt_t mask)
+{
+  /// group parameters matching mask for all detector elements in a given tracking module (= half chamber), counting from 0
+  if (iCh < 1 || iCh > fgNCh) {
+    LOG(fatal) << "Invalid chamber index " << iCh;
+  }
+
+  if (iHalf < 0 || iHalf > 1) {
+    LOG(fatal) << "Invalid half chamber index " << iHalf;
+  }
+
+  const Int_t iHalfCh = 2 * (iCh - 1) + iHalf;
+  GroupDetElems(&fgDetElemHalfCh[iHalfCh][0], fgNDetElemHalfCh[iHalfCh], mask);
+}
+
+//_____________________________________________________________________
+void Alignment::GroupDetElems(Int_t detElemMin, Int_t detElemMax, UInt_t mask)
+{
+  /// group parameters matching mask for all detector elements between min and max
+  // check number of detector elements
+  const Int_t nDetElem = detElemMax - detElemMin + 1;
+  if (nDetElem < 2) {
+    LOG(fatal) << "Requested group of DEs " << detElemMin << "-" << detElemMax << " contains less than 2 DE's";
+  }
+
+  // create list
+  Int_t* detElemList = new int[nDetElem];
+  for (Int_t i = 0; i < nDetElem; ++i) {
+    detElemList[i] = detElemMin + i;
+  }
+
+  // group
+  GroupDetElems(detElemList, nDetElem, mask);
+  delete[] detElemList;
+}
+
+//_____________________________________________________________________
+void Alignment::GroupDetElems(const Int_t* detElemList, Int_t nDetElem, UInt_t mask)
+{
+  /// group parameters matching mask for all detector elements in list
+  if (fInitialized) {
+    LOG(fatal) << "Millepede already initialized";
+  }
+
+  const Int_t iDeBase(GetDetElemNumber(detElemList[0]));
+  for (Int_t i = 0; i < nDetElem; ++i) {
+    const Int_t iDeCurrent(GetDetElemNumber(detElemList[i]));
+    if (mask & ParX)
+      fGlobalParameterStatus[iDeCurrent * fgNParCh + 0] = (i == 0) ? kGroupBaseId : (kGroupBaseId - iDeBase - 1);
+    if (mask & ParY)
+      fGlobalParameterStatus[iDeCurrent * fgNParCh + 1] = (i == 0) ? kGroupBaseId : (kGroupBaseId - iDeBase - 1);
+    if (mask & ParTZ)
+      fGlobalParameterStatus[iDeCurrent * fgNParCh + 2] = (i == 0) ? kGroupBaseId : (kGroupBaseId - iDeBase - 1);
+    if (mask & ParZ)
+      fGlobalParameterStatus[iDeCurrent * fgNParCh + 3] = (i == 0) ? kGroupBaseId : (kGroupBaseId - iDeBase - 1);
+
+    if (i == 0)
+      LOG(info) << "Creating new group for detector " << detElemList[i] << " and variable " << GetParameterMaskString(mask).Data();
+    else
+      LOG(info) << "Adding detector element " << detElemList[i] << " to current group";
+  }
+}
+
+//______________________________________________________________________
+void Alignment::SetChamberNonLinear(Int_t iCh, UInt_t mask)
+{
+  /// Set parameters matching mask as non linear, for all detector elements in a given chamber, counting from 1
+  const Int_t iDetElemFirst = fgSNDetElemCh[iCh - 1];
+  const Int_t iDetElemLast = fgSNDetElemCh[iCh];
+  for (Int_t i = iDetElemFirst; i < iDetElemLast; ++i) {
+
+    if (mask & ParX)
+      SetParameterNonLinear(i, 0);
+    if (mask & ParY)
+      SetParameterNonLinear(i, 1);
+    if (mask & ParTZ)
+      SetParameterNonLinear(i, 2);
+    if (mask & ParZ)
+      SetParameterNonLinear(i, 3);
+  }
+}
+
+//_____________________________________________________________________
+void Alignment::SetDetElemNonLinear(Int_t iDetElemId, UInt_t mask)
+{
+  /// Set parameters matching mask as non linear, for a given detector element, counting from 0
+  const Int_t iDet(GetDetElemNumber(iDetElemId));
+  if (mask & ParX)
+    SetParameterNonLinear(iDet, 0);
+  if (mask & ParY)
+    SetParameterNonLinear(iDet, 1);
+  if (mask & ParTZ)
+    SetParameterNonLinear(iDet, 2);
+  if (mask & ParZ)
+    SetParameterNonLinear(iDet, 3);
+}
+
+//______________________________________________________________________
+void Alignment::SetParameterNonLinear(Int_t iPar)
+{
+  /// Set nonlinear flag for parameter iPar
+  if (!fInitialized) {
+    LOG(fatal) << "Millepede not initialized";
+  }
+
+  fMillepede->SetNonLinear(iPar);
+  LOG(info) << "Parameter " << iPar << " set to non linear ";
+}
+
+//______________________________________________________________________
+void Alignment::AddConstraints(const Bool_t* lChOnOff, UInt_t mask)
+{
+  /// Add constraint equations for selected chambers and degrees of freedom
+
+  Array fConstraintX;
+  Array fConstraintY;
+  Array fConstraintTZ;
+  Array fConstraintZ;
+
+  for (Int_t i = 0; i < fgNDetElem; ++i) {
+
+    // get chamber matching detector
+    const Int_t iCh(GetChamberId(i));
+    if (lChOnOff[iCh - 1]) {
+
+      if (mask & ParX)
+        fConstraintX.values[i * fgNParCh + 0] = 1.0;
+      if (mask & ParY)
+        fConstraintY.values[i * fgNParCh + 1] = 1.0;
+      if (mask & ParTZ)
+        fConstraintTZ.values[i * fgNParCh + 2] = 1.0;
+      if (mask & ParZ)
+        fConstraintTZ.values[i * fgNParCh + 3] = 1.0;
+    }
+  }
+
+  if (mask & ParX)
+    AddConstraint(fConstraintX.values, 0.0);
+  if (mask & ParY)
+    AddConstraint(fConstraintY.values, 0.0);
+  if (mask & ParTZ)
+    AddConstraint(fConstraintTZ.values, 0.0);
+  if (mask & ParZ)
+    AddConstraint(fConstraintZ.values, 0.0);
+}
+
+//______________________________________________________________________
+void Alignment::AddConstraints(const Bool_t* lChOnOff, const Bool_t* lVarXYT, UInt_t sidesMask)
+{
+  /*
+  questions:
+  - is there not redundancy/inconsistency between lDetTLBR and lSpecLROnOff ? shouldn't we use only lDetTLBR ?
+  - why is weight ignored for ConstrainT and ConstrainB
+  - why is there no constrain on z
+  */
+
+  /// Add constraint equations for selected chambers, degrees of freedom and detector half
+  Double_t lMeanY = 0.;
+  Double_t lSigmaY = 0.;
+  Double_t lMeanZ = 0.;
+  Double_t lSigmaZ = 0.;
+  Int_t lNDetElem = 0;
+
+  for (Int_t i = 0; i < fgNDetElem; ++i) {
+
+    // get chamber matching detector
+    const Int_t iCh(GetChamberId(i));
+
+    // skip detector if chamber is off
+    if (lChOnOff[iCh - 1])
+      continue;
+
+    // get detector element id from detector element number
+    const Int_t lDetElemNumber = i - fgSNDetElemCh[iCh - 1];
+    const Int_t lDetElemId = iCh * 100 + lDetElemNumber;
+
+    // skip detector if its side is off
+    // stations 1 and 2
+    if (iCh >= 1 && iCh <= 4) {
+      if (lDetElemNumber == 0 && !(sidesMask & SideTopRight))
+        continue;
+      if (lDetElemNumber == 1 && !(sidesMask & SideTopLeft))
+        continue;
+      if (lDetElemNumber == 2 && !(sidesMask & SideBottomLeft))
+        continue;
+      if (lDetElemNumber == 3 && !(sidesMask & SideBottomRight))
+        continue;
+    }
+
+    // station 3
+    if (iCh >= 5 && iCh <= 6) {
+      if (lDetElemNumber >= 0 && lDetElemNumber <= 4 && !(sidesMask & SideTopRight))
+        continue;
+      if (lDetElemNumber >= 5 && lDetElemNumber <= 10 && !(sidesMask & SideTopLeft))
+        continue;
+      if (lDetElemNumber >= 11 && lDetElemNumber <= 13 && !(sidesMask & SideBottomLeft))
+        continue;
+      if (lDetElemNumber >= 14 && lDetElemNumber <= 17 && !(sidesMask & SideBottomRight))
+        continue;
+    }
+
+    // stations 4 and 5
+    if (iCh >= 7 && iCh <= 10) {
+      if (lDetElemNumber >= 0 && lDetElemNumber <= 6 && !(sidesMask & SideTopRight))
+        continue;
+      if (lDetElemNumber >= 7 && lDetElemNumber <= 13 && !(sidesMask & SideTopLeft))
+        continue;
+      if (lDetElemNumber >= 14 && lDetElemNumber <= 19 && !(sidesMask & SideBottomLeft))
+        continue;
+      if (lDetElemNumber >= 20 && lDetElemNumber <= 25 && !(sidesMask & SideBottomRight))
+        continue;
+    }
+
+    // get global x, y and z position
+    Double_t lDetElemGloX = 0.;
+    Double_t lDetElemGloY = 0.;
+    Double_t lDetElemGloZ = 0.;
+
+    auto fTransform = fTransformCreator(lDetElemId);
+    o2::math_utils::Point3D<double> SlatPos{0.0, 0.0, 0.0};
+    o2::math_utils::Point3D<double> GlobalPos;
+
+    fTransform.LocalToMaster(SlatPos, GlobalPos);
+    lDetElemGloX = GlobalPos.x();
+    lDetElemGloY = GlobalPos.y();
+    lDetElemGloZ = GlobalPos.z();
+    // fTransform->Local2Global(lDetElemId, 0, 0, 0, lDetElemGloX, lDetElemGloY, lDetElemGloZ);
+
+    // increment mean Y, mean Z, sigmas and number of accepted detectors
+    lMeanY += lDetElemGloY;
+    lSigmaY += lDetElemGloY * lDetElemGloY;
+    lMeanZ += lDetElemGloZ;
+    lSigmaZ += lDetElemGloZ * lDetElemGloZ;
+    lNDetElem++;
+  }
+
+  // calculate mean values
+  lMeanY /= lNDetElem;
+  lSigmaY /= lNDetElem;
+  lSigmaY = TMath::Sqrt(lSigmaY - lMeanY * lMeanY);
+  lMeanZ /= lNDetElem;
+  lSigmaZ /= lNDetElem;
+  lSigmaZ = TMath::Sqrt(lSigmaZ - lMeanZ * lMeanZ);
+  LOG(info) << "Used " << lNDetElem << " DetElem, MeanZ= " << lMeanZ << ", SigmaZ= " << lSigmaZ;
+
+  // create all possible arrays
+  Array fConstraintX[4];  // Array for constraint equation X
+  Array fConstraintY[4];  // Array for constraint equation Y
+  Array fConstraintP[4];  // Array for constraint equation P
+  Array fConstraintXZ[4]; // Array for constraint equation X vs Z
+  Array fConstraintYZ[4]; // Array for constraint equation Y vs Z
+  Array fConstraintPZ[4]; // Array for constraint equation P vs Z
+
+  // do we really need these ?
+  Array fConstraintXY[4]; // Array for constraint equation X vs Y
+  Array fConstraintYY[4]; // Array for constraint equation Y vs Y
+  Array fConstraintPY[4]; // Array for constraint equation P vs Y
+
+  // fill Bool_t sides array based on masks, for convenience
+  Bool_t lDetTLBR[4];
+  lDetTLBR[0] = sidesMask & SideTop;
+  lDetTLBR[1] = sidesMask & SideLeft;
+  lDetTLBR[2] = sidesMask & SideBottom;
+  lDetTLBR[3] = sidesMask & SideRight;
+
+  for (Int_t i = 0; i < fgNDetElem; ++i) {
+
+    // get chamber matching detector
+    const Int_t iCh(GetChamberId(i));
+
+    // skip detector if chamber is off
+    if (!lChOnOff[iCh - 1])
+      continue;
+
+    // get detector element id from detector element number
+    const Int_t lDetElemNumber = i - fgSNDetElemCh[iCh - 1];
+    const Int_t lDetElemId = iCh * 100 + lDetElemNumber;
+
+    // get global x, y and z position
+    Double_t lDetElemGloX = 0.;
+    Double_t lDetElemGloY = 0.;
+    Double_t lDetElemGloZ = 0.;
+
+    auto fTransform = fTransformCreator(lDetElemId);
+    o2::math_utils::Point3D<double> SlatPos{0.0, 0.0, 0.0};
+    o2::math_utils::Point3D<double> GlobalPos;
+
+    fTransform.LocalToMaster(SlatPos, GlobalPos);
+    lDetElemGloX = GlobalPos.x();
+    lDetElemGloY = GlobalPos.y();
+    lDetElemGloZ = GlobalPos.z();
+    // fTransform->Local2Global(lDetElemId, 0, 0, 0, lDetElemGloX, lDetElemGloY, lDetElemGloZ);
+
+    // loop over sides
+    for (Int_t iSide = 0; iSide < 4; iSide++) {
+
+      // skip if side is not selected
+      if (!lDetTLBR[iSide])
+        continue;
+
+      // skip detector if it is not in the selected side
+      // stations 1 and 2
+      if (iCh >= 1 && iCh <= 4) {
+        if (lDetElemNumber == 0 && !(iSide == 0 || iSide == 3))
+          continue; // top-right
+        if (lDetElemNumber == 1 && !(iSide == 0 || iSide == 1))
+          continue; // top-left
+        if (lDetElemNumber == 2 && !(iSide == 2 || iSide == 1))
+          continue; // bottom-left
+        if (lDetElemNumber == 3 && !(iSide == 2 || iSide == 3))
+          continue; // bottom-right
+      }
+
+      // station 3
+      if (iCh >= 5 && iCh <= 6) {
+        if (lDetElemNumber >= 0 && lDetElemNumber <= 4 && !(iSide == 0 || iSide == 3))
+          continue; // top-right
+        if (lDetElemNumber >= 5 && lDetElemNumber <= 9 && !(iSide == 0 || iSide == 1))
+          continue; // top-left
+        if (lDetElemNumber >= 10 && lDetElemNumber <= 13 && !(iSide == 2 || iSide == 1))
+          continue; // bottom-left
+        if (lDetElemNumber >= 14 && lDetElemNumber <= 17 && !(iSide == 2 || iSide == 3))
+          continue; // bottom-right
+      }
+
+      // stations 4 and 5
+      if (iCh >= 7 && iCh <= 10) {
+        if (lDetElemNumber >= 0 && lDetElemNumber <= 6 && !(iSide == 0 || iSide == 3))
+          continue; // top-right
+        if (lDetElemNumber >= 7 && lDetElemNumber <= 13 && !(iSide == 0 || iSide == 1))
+          continue; // top-left
+        if (lDetElemNumber >= 14 && lDetElemNumber <= 19 && !(iSide == 2 || iSide == 1))
+          continue; // bottom-left
+        if (lDetElemNumber >= 20 && lDetElemNumber <= 25 && !(iSide == 2 || iSide == 3))
+          continue; // bottom-right
+      }
+
+      // constrain x
+      if (lVarXYT[0])
+        fConstraintX[iSide].values[i * fgNParCh + 0] = 1;
+
+      // constrain y
+      if (lVarXYT[1])
+        fConstraintY[iSide].values[i * fgNParCh + 1] = 1;
+
+      // constrain phi (rotation around z)
+      if (lVarXYT[2])
+        fConstraintP[iSide].values[i * fgNParCh + 2] = 1;
+
+      // x-z shearing
+      if (lVarXYT[3])
+        fConstraintXZ[iSide].values[i * fgNParCh + 0] = (lDetElemGloZ - lMeanZ) / lSigmaZ;
+
+      // y-z shearing
+      if (lVarXYT[4])
+        fConstraintYZ[iSide].values[i * fgNParCh + 1] = (lDetElemGloZ - lMeanZ) / lSigmaZ;
+
+      // phi-z shearing
+      if (lVarXYT[5])
+        fConstraintPZ[iSide].values[i * fgNParCh + 2] = (lDetElemGloZ - lMeanZ) / lSigmaZ;
+
+      // x-y shearing
+      if (lVarXYT[6])
+        fConstraintXY[iSide].values[i * fgNParCh + 0] = (lDetElemGloY - lMeanY) / lSigmaY;
+
+      // y-y shearing
+      if (lVarXYT[7])
+        fConstraintYY[iSide].values[i * fgNParCh + 1] = (lDetElemGloY - lMeanY) / lSigmaY;
+
+      // phi-y shearing
+      if (lVarXYT[8])
+        fConstraintPY[iSide].values[i * fgNParCh + 2] = (lDetElemGloY - lMeanY) / lSigmaY;
+    }
+  }
+
+  // pass constraints to millepede
+  for (Int_t iSide = 0; iSide < 4; iSide++) {
+    // skip if side is not selected
+    if (!lDetTLBR[iSide])
+      continue;
+
+    if (lVarXYT[0])
+      AddConstraint(fConstraintX[iSide].values, 0.0);
+    if (lVarXYT[1])
+      AddConstraint(fConstraintY[iSide].values, 0.0);
+    if (lVarXYT[2])
+      AddConstraint(fConstraintP[iSide].values, 0.0);
+    if (lVarXYT[3])
+      AddConstraint(fConstraintXZ[iSide].values, 0.0);
+    if (lVarXYT[4])
+      AddConstraint(fConstraintYZ[iSide].values, 0.0);
+    if (lVarXYT[5])
+      AddConstraint(fConstraintPZ[iSide].values, 0.0);
+    if (lVarXYT[6])
+      AddConstraint(fConstraintXY[iSide].values, 0.0);
+    if (lVarXYT[7])
+      AddConstraint(fConstraintYY[iSide].values, 0.0);
+    if (lVarXYT[8])
+      AddConstraint(fConstraintPY[iSide].values, 0.0);
+  }
+}
+
+//______________________________________________________________________
+void Alignment::InitGlobalParameters(Double_t* par)
+{
+  /// Initialize global parameters with par array
+  if (!fInitialized) {
+    LOG(fatal) << "Millepede is not initialized";
+  }
+
+  fMillepede->SetGlobalParameters(par);
+}
+
+//______________________________________________________________________
+void Alignment::SetAllowedVariation(Int_t iPar, Double_t value)
+{
+  /// "Encouraged" variation for degrees of freedom
+  // check initialization
+  if (fInitialized) {
+    LOG(fatal) << "Millepede already initialized";
+  }
+
+  // check initialization
+  if (!(iPar >= 0 && iPar < fgNParCh)) {
+    LOG(fatal) << "Invalid index: " << iPar;
+  }
+
+  fAllowVar[iPar] = value;
+}
+
+//______________________________________________________________________
+void Alignment::SetSigmaXY(Double_t sigmaX, Double_t sigmaY)
+{
+
+  /// Set expected measurement resolution
+  fSigma[0] = sigmaX;
+  fSigma[1] = sigmaY;
+
+  // print
+  for (Int_t i = 0; i < 2; ++i) {
+    LOG(info) << "fSigma[" << i << "] =" << fSigma[i];
+  }
+}
+
+//_____________________________________________________
+void Alignment::GlobalFit(Double_t* parameters, Double_t* errors, Double_t* pulls)
+{
+
+  /// Call global fit; Global parameters are stored in parameters
+  fMillepede->GlobalFit(parameters, errors, pulls);
+
+  LOG(info) << "Done fitting global parameters";
+  for (int iDet = 0; iDet < fgNDetElem; ++iDet) {
+    LOG(info) << iDet << " " << parameters[iDet * fgNParCh + 0] << " " << parameters[iDet * fgNParCh + 1] << " " << parameters[iDet * fgNParCh + 3] << " " << parameters[iDet * fgNParCh + 2];
+  }
+}
+
+//_____________________________________________________
+void Alignment::PrintGlobalParameters() const
+{
+  fMillepede->PrintGlobalParameters();
+}
+
+//_____________________________________________________
+Double_t Alignment::GetParError(Int_t iPar) const
+{
+  return fMillepede->GetParError(iPar);
+}
+
+// //______________________________________________________________________
+// AliMUONGeometryTransformer* Alignment::ReAlign(
+//   const AliMUONGeometryTransformer* transformer,
+//   const double* misAlignments, Bool_t)
+// {
+
+//   /// Returns a new AliMUONGeometryTransformer with the found misalignments
+//   /// applied.
+
+//   // Takes the internal geometry module transformers, copies them
+//   // and gets the Detection Elements from them.
+//   // Takes misalignment parameters and applies these
+//   // to the local transform of the Detection Element
+//   // Obtains the global transform by multiplying the module transformer
+//   // transformation with the local transformation
+//   // Applies the global transform to a new detection element
+//   // Adds the new detection element to a new module transformer
+//   // Adds the new module transformer to a new geometry transformer
+//   // Returns the new geometry transformer
+
+//   Double_t lModuleMisAlignment[fgNParCh] = {0};
+//   Double_t lDetElemMisAlignment[fgNParCh] = {0};
+//   const TClonesArray* oldMisAlignArray(transformer->GetMisAlignmentData());
+
+//   AliMUONGeometryTransformer* newGeometryTransformer = new AliMUONGeometryTransformer();
+//   for (Int_t iMt = 0; iMt < transformer->GetNofModuleTransformers(); ++iMt) {
+
+//     // module transformers
+//     const AliMUONGeometryModuleTransformer* kModuleTransformer = transformer->GetModuleTransformer(iMt, kTRUE);
+
+//     AliMUONGeometryModuleTransformer* newModuleTransformer = new AliMUONGeometryModuleTransformer(iMt);
+//     newGeometryTransformer->AddModuleTransformer(newModuleTransformer);
+
+//     // get transformation
+//     TGeoHMatrix deltaModuleTransform(DeltaTransform(lModuleMisAlignment));
+
+//     // update module
+//     TGeoHMatrix moduleTransform(*kModuleTransformer->GetTransformation());
+//     TGeoHMatrix newModuleTransform(AliMUONGeometryBuilder::Multiply(deltaModuleTransform, moduleTransform));
+//     newModuleTransformer->SetTransformation(newModuleTransform);
+
+//     // Get matching old alignment and update current matrix accordingly
+//     if (oldMisAlignArray) {
+
+//       const AliAlignObjMatrix* oldAlignObj(0);
+//       const Int_t moduleId(kModuleTransformer->GetModuleId());
+//       const Int_t volId = AliGeomManager::LayerToVolUID(AliGeomManager::kMUON, moduleId);
+//       for (Int_t pos = 0; pos < oldMisAlignArray->GetEntriesFast(); ++pos) {
+
+//         const AliAlignObjMatrix* localAlignObj(dynamic_cast<const AliAlignObjMatrix*>(oldMisAlignArray->At(pos)));
+//         if (localAlignObj && localAlignObj->GetVolUID() == volId) {
+//           oldAlignObj = localAlignObj;
+//           break;
+//         }
+//       }
+
+//       // multiply
+//       if (oldAlignObj) {
+
+//         TGeoHMatrix oldMatrix;
+//         oldAlignObj->GetMatrix(oldMatrix);
+//         deltaModuleTransform.Multiply(&oldMatrix);
+//       }
+//     }
+
+//     // Create module mis alignment matrix
+//     newGeometryTransformer->AddMisAlignModule(kModuleTransformer->GetModuleId(), deltaModuleTransform);
+
+//     AliMpExMap* detElements = kModuleTransformer->GetDetElementStore();
+
+//     TIter next(detElements->CreateIterator());
+//     AliMUONGeometryDetElement* detElement;
+//     Int_t iDe(-1);
+//     while ((detElement = static_cast<AliMUONGeometryDetElement*>(next()))) {
+//       ++iDe;
+//       // make a new detection element
+//       AliMUONGeometryDetElement* newDetElement = new AliMUONGeometryDetElement(detElement->GetId(), detElement->GetVolumePath());
+//       TString lDetElemName(detElement->GetDEName());
+//       lDetElemName.ReplaceAll("DE", "");
+
+//       // store detector element id and number
+//       const Int_t iDetElemId = lDetElemName.Atoi();
+//       if (DetElemIsValid(iDetElemId)) {
+
+//         const Int_t iDetElemNumber(GetDetElemNumber(iDetElemId));
+
+//         for (int i = 0; i < fgNParCh; ++i) {
+//           lDetElemMisAlignment[i] = 0.0;
+//           if (iMt < fgNTrkMod) {
+//             lDetElemMisAlignment[i] = misAlignments[iDetElemNumber * fgNParCh + i];
+//           }
+//         }
+
+//         // get transformation
+//         TGeoHMatrix deltaGlobalTransform(DeltaTransform(lDetElemMisAlignment));
+
+//         // update module
+//         TGeoHMatrix globalTransform(*detElement->GetGlobalTransformation());
+//         TGeoHMatrix newGlobalTransform(AliMUONGeometryBuilder::Multiply(deltaGlobalTransform, globalTransform));
+//         newDetElement->SetGlobalTransformation(newGlobalTransform);
+//         newModuleTransformer->GetDetElementStore()->Add(newDetElement->GetId(), newDetElement);
+
+//         // Get matching old alignment and update current matrix accordingly
+//         if (oldMisAlignArray) {
+
+//           const AliAlignObjMatrix* oldAlignObj(0);
+//           const int detElemId(detElement->GetId());
+//           const Int_t volId = AliGeomManager::LayerToVolUID(AliGeomManager::kMUON, detElemId);
+//           for (Int_t pos = 0; pos < oldMisAlignArray->GetEntriesFast(); ++pos) {
+
+//             const AliAlignObjMatrix* localAlignObj(dynamic_cast<const AliAlignObjMatrix*>(oldMisAlignArray->At(pos)));
+//             if (localAlignObj && localAlignObj->GetVolUID() == volId) {
+//               oldAlignObj = localAlignObj;
+//               break;
+//             }
+//           }
+
+//           // multiply
+//           if (oldAlignObj) {
+
+//             TGeoHMatrix oldMatrix;
+//             oldAlignObj->GetMatrix(oldMatrix);
+//             deltaGlobalTransform.Multiply(&oldMatrix);
+//           }
+//         }
+
+//         // Create misalignment matrix
+//         newGeometryTransformer->AddMisAlignDetElement(detElement->GetId(), deltaGlobalTransform);
+
+//       } else {
+
+//         // "invalid" detector elements come from MTR and are left unchanged
+//         Aliinfo(Form("Keeping detElement %i unchanged", iDetElemId));
+
+//         // update module
+//         TGeoHMatrix globalTransform(*detElement->GetGlobalTransformation());
+//         newDetElement->SetGlobalTransformation(globalTransform);
+//         newModuleTransformer->GetDetElementStore()->Add(newDetElement->GetId(), newDetElement);
+
+//         // Get matching old alignment and update current matrix accordingly
+//         if (oldMisAlignArray) {
+
+//           const AliAlignObjMatrix* oldAlignObj(0);
+//           const int detElemId(detElement->GetId());
+//           const Int_t volId = AliGeomManager::LayerToVolUID(AliGeomManager::kMUON, detElemId);
+//           for (Int_t pos = 0; pos < oldMisAlignArray->GetEntriesFast(); ++pos) {
+
+//             const AliAlignObjMatrix* localAlignObj(dynamic_cast<const AliAlignObjMatrix*>(oldMisAlignArray->At(pos)));
+//             if (localAlignObj && localAlignObj->GetVolUID() == volId) {
+//               oldAlignObj = localAlignObj;
+//               break;
+//             }
+//           }
+
+//           // multiply
+//           if (oldAlignObj) {
+
+//             TGeoHMatrix oldMatrix;
+//             oldAlignObj->GetMatrix(oldMatrix);
+//             newGeometryTransformer->AddMisAlignDetElement(detElement->GetId(), oldMatrix);
+//           }
+//         }
+//       }
+//     }
+
+//     newGeometryTransformer->AddModuleTransformer(newModuleTransformer);
+//   }
+
+//   return newGeometryTransformer;
+// }
+
+//______________________________________________________________________
+void Alignment::SetAlignmentResolution(const TClonesArray* misAlignArray, Int_t rChId, Double_t chResX, Double_t chResY, Double_t deResX, Double_t deResY)
+{
+
+  /// Set alignment resolution to misalign objects to be stored in CDB
+  /// if rChId is > 0 set parameters for this chamber only, counting from 1
+  TMatrixDSym mChCorrMatrix(6);
+  mChCorrMatrix[0][0] = chResX * chResX;
+  mChCorrMatrix[1][1] = chResY * chResY;
+
+  TMatrixDSym mDECorrMatrix(6);
+  mDECorrMatrix[0][0] = deResX * deResX;
+  mDECorrMatrix[1][1] = deResY * deResY;
+
+  o2::detectors::AlignParam* alignMat = 0x0;
+
+  for (Int_t chId = 0; chId <= 9; ++chId) {
+
+    // skip chamber if selection is valid, and does not match
+    if (rChId > 0 && chId + 1 != rChId)
+      continue;
+
+    TString chName1;
+    TString chName2;
+    if (chId < 4) {
+
+      chName1 = Form("GM%d", chId);
+      chName2 = Form("GM%d", chId);
+
+    } else {
+
+      chName1 = Form("GM%d", 4 + (chId - 4) * 2);
+      chName2 = Form("GM%d", 4 + (chId - 4) * 2 + 1);
+    }
+
+    for (int i = 0; i < misAlignArray->GetEntries(); ++i) {
+
+      alignMat = (o2::detectors::AlignParam*)misAlignArray->At(i);
+      TString volName(alignMat->getSymName());
+      if ((volName.Contains(chName1) &&
+           ((volName.Last('/') == volName.Index(chName1) + chName1.Length()) ||
+            (volName.Length() == volName.Index(chName1) + chName1.Length()))) ||
+          (volName.Contains(chName2) &&
+           ((volName.Last('/') == volName.Index(chName2) + chName2.Length()) ||
+            (volName.Length() == volName.Index(chName2) + chName2.Length())))) {
+
+        volName.Remove(0, volName.Last('/') + 1);
+        // if (volName.Contains("GM")){
+        //   alignMat->SetCorrMatrix(mChCorrMatrix);
+        // }else if (volName.Contains("DE")){
+        //   alignMat->SetCorrMatrix(mDECorrMatrix);
+        // }
+      }
+    }
+  }
+}
+
+//_____________________________________________________
+LocalTrackParam Alignment::RefitStraightTrack(Track& track, Double_t z0) const
+{
+
+  // initialize matrices
+  TMatrixD AtGASum(4, 4);
+  AtGASum.Zero();
+
+  TMatrixD AtGMSum(4, 1);
+  AtGMSum.Zero();
+
+  // loop over clusters
+  for (auto itTrackParam(track.begin()); itTrackParam != track.end(); ++itTrackParam) {
+
+    // get track parameters
+    if (!&*itTrackParam)
+      continue;
+
+    // get cluster
+    const Cluster* cluster = itTrackParam->getClusterPtr();
+    if (!cluster)
+      continue;
+
+    // projection matrix
+    TMatrixD A(2, 4);
+    A.Zero();
+    A(0, 0) = 1;
+    A(0, 2) = (cluster->getZ() - z0);
+    A(1, 1) = 1;
+    A(1, 3) = (cluster->getZ() - z0);
+
+    TMatrixD At(TMatrixD::kTransposed, A);
+
+    // gain matrix
+    TMatrixD G(2, 2);
+    G.Zero();
+    G(0, 0) = 1.0 / Square(cluster->getEx());
+    G(1, 1) = 1.0 / Square(cluster->getEy());
+
+    const TMatrixD AtG(At, TMatrixD::kMult, G);
+    const TMatrixD AtGA(AtG, TMatrixD::kMult, A);
+    AtGASum += AtGA;
+
+    // measurement
+    TMatrixD M(2, 1);
+    M(0, 0) = cluster->getX();
+    M(1, 0) = cluster->getY();
+    const TMatrixD AtGM(AtG, TMatrixD::kMult, M);
+    AtGMSum += AtGM;
+  }
+
+  // perform inversion
+  TMatrixD AtGASumInv(TMatrixD::kInverted, AtGASum);
+  TMatrixD X(AtGASumInv, TMatrixD::kMult, AtGMSum);
+
+  //   // TODO: compare with initial track parameters
+  //   Aliinfo( Form( "x: %.3f vs %.3f", fTrackPos0[0], X(0,0) ) );
+  //   Aliinfo( Form( "y: %.3f vs %.3f", fTrackPos0[1], X(1,0) ) );
+  //   Aliinfo( Form( "dxdz: %.6g vs %.6g", fTrackSlope0[0], X(2,0) ) );
+  //   Aliinfo( Form( "dydz: %.6g vs %.6g\n", fTrackSlope0[1], X(3,0) ) );
+
+  // fill output parameters
+  LocalTrackParam out;
+  out.fTrackX = X(0, 0);
+  out.fTrackY = X(1, 0);
+  out.fTrackZ = z0;
+  out.fTrackSlopeX = X(2, 0);
+  out.fTrackSlopeY = X(3, 0);
+
+  return out;
+}
+
+//_____________________________________________________
+void Alignment::FillDetElemData(const Cluster* cluster)
+{
+  // LOG(fatal) << __PRETTY_FUNCTION__ << " is disabled";
+  LOG(info) << __PRETTY_FUNCTION__ << " is enabled";
+
+  /// Get information of current detection element
+  // get detector element number from Alice ID
+  const Int_t detElemId = cluster->getDEId();
+  fDetElemNumber = GetDetElemNumber(detElemId);
+
+  // get detector element
+  // const AliMUONGeometryDetElement detElement(detElemId);
+  auto fTransform = fTransformCreator(detElemId);
+  /*
+  get the global transformation matrix and store its inverse, in order to manually perform
+  the global to Local transformations needed to calculate the derivatives
+  */
+  // fTransform = fTransform.Inverse();
+  // fTransform.GetTransformMatrix(fGeoCombiTransInverse);
+}
+
+//______________________________________________________________________
+void Alignment::FillRecPointData(const Cluster* cluster)
+{
+
+  /// Get information of current cluster
+  fClustPos[0] = cluster->getX();
+  fClustPos[1] = cluster->getY();
+  fClustPos[2] = cluster->getZ();
+}
+
+//______________________________________________________________________
+void Alignment::FillTrackParamData(const TrackParam* trackParam)
+{
+
+  /// Get information of current track at current cluster
+  fTrackPos[0] = trackParam->getNonBendingCoor();
+  fTrackPos[1] = trackParam->getBendingCoor();
+  fTrackPos[2] = trackParam->getZ();
+  fTrackSlope[0] = trackParam->getNonBendingSlope();
+  fTrackSlope[1] = trackParam->getBendingSlope();
+}
+
+//______________________________________________________________________
+void Alignment::LocalEquationX(void)
+{
+  /// local equation along X
+
+  // 'inverse' (GlobalToLocal) rotation matrix
+  const Double_t* r(fGeoCombiTransInverse.GetRotationMatrix());
+
+  // local derivatives
+  SetLocalDerivative(0, r[0]);
+  SetLocalDerivative(1, r[0] * (fTrackPos[2] - fTrackPos0[2]));
+  SetLocalDerivative(2, r[1]);
+  SetLocalDerivative(3, r[1] * (fTrackPos[2] - fTrackPos0[2]));
+
+  // global derivatives
+  /*
+  alignment parameters are
+  0: delta_x
+  1: delta_y
+  2: delta_phiz
+  3: delta_z
+  */
+
+  SetGlobalDerivative(fDetElemNumber * fgNParCh + 0, -r[0]);
+  SetGlobalDerivative(fDetElemNumber * fgNParCh + 1, -r[1]);
+
+  if (fBFieldOn) {
+
+    // use local position for derivatives vs 'delta_phi_z'
+    SetGlobalDerivative(fDetElemNumber * fgNParCh + 2, -r[1] * fTrackPos[0] + r[0] * fTrackPos[1]);
+
+    // use local slopes for derivatives vs 'delta_z'
+    SetGlobalDerivative(fDetElemNumber * fgNParCh + 3, r[0] * fTrackSlope[0] + r[1] * fTrackSlope[1]);
+
+  } else {
+
+    // local copy of extrapolated track positions
+    const Double_t trackPosX = fTrackPos0[0] + fTrackSlope0[0] * (fTrackPos[2] - fTrackPos0[2]);
+    const Double_t trackPosY = fTrackPos0[1] + fTrackSlope0[1] * (fTrackPos[2] - fTrackPos0[2]);
+
+    // use properly extrapolated position for derivatives vs 'delta_phi_z'
+    SetGlobalDerivative(fDetElemNumber * fgNParCh + 2, -r[1] * trackPosX + r[0] * trackPosY);
+
+    // use slopes at origin for derivatives vs 'delta_z'
+    SetGlobalDerivative(fDetElemNumber * fgNParCh + 3, r[0] * fTrackSlope0[0] + r[1] * fTrackSlope0[1]);
+  }
+
+  // store local equation
+  fMillepede->SetLocalEquation(fGlobalDerivatives, fLocalDerivatives, fMeas[0], fSigma[0]);
+}
+
+//______________________________________________________________________
+void Alignment::LocalEquationY(void)
+{
+  /// local equation along Y
+
+  // 'inverse' (GlobalToLocal) rotation matrix
+  const Double_t* r(fGeoCombiTransInverse.GetRotationMatrix());
+
+  // store local derivatives
+  SetLocalDerivative(0, r[3]);
+  SetLocalDerivative(1, r[3] * (fTrackPos[2] - fTrackPos0[2]));
+  SetLocalDerivative(2, r[4]);
+  SetLocalDerivative(3, r[4] * (fTrackPos[2] - fTrackPos0[2]));
+
+  // set global derivatives
+  SetGlobalDerivative(fDetElemNumber * fgNParCh + 0, -r[3]);
+  SetGlobalDerivative(fDetElemNumber * fgNParCh + 1, -r[4]);
+
+  if (fBFieldOn) {
+
+    // use local position for derivatives vs 'delta_phi'
+    SetGlobalDerivative(fDetElemNumber * fgNParCh + 2, -r[4] * fTrackPos[0] + r[3] * fTrackPos[1]);
+
+    // use local slopes for derivatives vs 'delta_z'
+    SetGlobalDerivative(fDetElemNumber * fgNParCh + 3, r[3] * fTrackSlope[0] + r[4] * fTrackSlope[1]);
+
+  } else {
+
+    // local copy of extrapolated track positions
+    const Double_t trackPosX = fTrackPos0[0] + fTrackSlope0[0] * (fTrackPos[2] - fTrackPos0[2]);
+    const Double_t trackPosY = fTrackPos0[1] + fTrackSlope0[1] * (fTrackPos[2] - fTrackPos0[2]);
+
+    // use properly extrapolated position for derivatives vs 'delta_phi'
+    SetGlobalDerivative(fDetElemNumber * fgNParCh + 2, -r[4] * trackPosX + r[3] * trackPosY);
+
+    // use slopes at origin for derivatives vs 'delta_z'
+    SetGlobalDerivative(fDetElemNumber * fgNParCh + 3, r[3] * fTrackSlope0[0] + r[4] * fTrackSlope0[1]);
+  }
+
+  // store local equation
+  fMillepede->SetLocalEquation(fGlobalDerivatives, fLocalDerivatives, fMeas[1], fSigma[1]);
+}
+
+//_________________________________________________________________________
+TGeoCombiTrans Alignment::DeltaTransform(const double* lMisAlignment) const
+{
+  /// Get Delta Transformation, based on alignment parameters
+
+  // translation
+  const TGeoTranslation deltaTrans(lMisAlignment[0], lMisAlignment[1], lMisAlignment[3]);
+
+  // rotation
+  TGeoRotation deltaRot;
+  deltaRot.RotateZ(lMisAlignment[2] * 180. / TMath::Pi());
+
+  // combined rotation and translation.
+  return TGeoCombiTrans(deltaTrans, deltaRot);
+}
+
+//______________________________________________________________________
+void Alignment::AddConstraint(Double_t* par, Double_t value)
+{
+  /// Constrain equation defined by par to value
+  if (!fInitialized) {
+    LOG(fatal) << "Millepede is not initialized";
+  }
+
+  fMillepede->SetGlobalConstraint(par, value);
+}
+
+//______________________________________________________________________
+Bool_t Alignment::DetElemIsValid(Int_t iDetElemId) const
+{
+  /// return true if given detector element is valid (and belongs to muon tracker)
+  const Int_t iCh = iDetElemId / 100;
+  const Int_t iDet = iDetElemId % 100;
+  return (iCh > 0 && iCh <= fgNCh && iDet < fgNDetElemCh[iCh - 1]);
+}
+
+//______________________________________________________________________
+Int_t Alignment::GetDetElemNumber(Int_t iDetElemId) const
+{
+  /// get det element number from ID
+  // get chamber and element number in chamber
+  const Int_t iCh = iDetElemId / 100;
+  const Int_t iDet = iDetElemId % 100;
+
+  // make sure detector index is valid
+  if (!(iCh > 0 && iCh <= fgNCh && iDet < fgNDetElemCh[iCh - 1])) {
+    LOG(fatal) << "Invalid detector element id: " << iDetElemId;
+  }
+
+  // add number of detectors up to this chamber
+  return iDet + fgSNDetElemCh[iCh - 1];
+}
+
+//______________________________________________________________________
+Int_t Alignment::GetChamberId(Int_t iDetElemNumber) const
+{
+  /// get chamber (counting from 1) matching a given detector element id
+  Int_t iCh(0);
+  for (iCh = 0; iCh < fgNCh; iCh++) {
+    if (iDetElemNumber < fgSNDetElemCh[iCh])
+      break;
+  }
+
+  return iCh;
+}
+
+//______________________________________________________________________
+TString Alignment::GetParameterMaskString(UInt_t mask) const
+{
+  TString out;
+  if (mask & ParX)
+    out += "X";
+  if (mask & ParY)
+    out += "Y";
+  if (mask & ParZ)
+    out += "Z";
+  if (mask & ParTZ)
+    out += "T";
+  return out;
+}
+
+//______________________________________________________________________
+TString Alignment::GetSidesMaskString(UInt_t mask) const
+{
+  TString out;
+  if (mask & SideTop)
+    out += "T";
+  if (mask & SideLeft)
+    out += "L";
+  if (mask & SideBottom)
+    out += "B";
+  if (mask & SideRight)
+    out += "R";
+  return out;
+}
+
+} // namespace mch
+} // namespace o2

--- a/Detectors/ITSMFT/MFT/workflow/CMakeLists.txt
+++ b/Detectors/ITSMFT/MFT/workflow/CMakeLists.txt
@@ -18,6 +18,7 @@ o2_add_library(MFTWorkflow
                        src/TrackReaderSpec.cxx
                        src/TrackWriterSpec.cxx
                        src/MFTAssessmentSpec.cxx
+                       src/TracksToRecordsSpec.cxx
                PUBLIC_LINK_LIBRARIES O2::Framework
                                      O2::SimConfig
                                      O2::SimulationDataFormat
@@ -25,7 +26,8 @@ o2_add_library(MFTWorkflow
                                      O2::MFTTracking
                                      O2::MFTAssessment
                                      O2::DataFormatsMFT
-                                     O2::ITSMFTWorkflow)
+                                     O2::ITSMFTWorkflow
+                                     O2::MFTAlignment)
 o2_add_executable(reco-workflow
                   SOURCES src/mft-reco-workflow.cxx
                   COMPONENT_NAME mft
@@ -43,5 +45,10 @@ o2_add_executable(assessment-workflow
 
 o2_add_executable(cluster-writer-workflow
                   SOURCES src/mft-cluster-writer-workflow.cxx
+                  COMPONENT_NAME mft
+                  PUBLIC_LINK_LIBRARIES O2::MFTWorkflow)
+
+o2_add_executable(tracks2records-workflow
+                  SOURCES src/mft-tracks2records-workflow.cxx
                   COMPONENT_NAME mft
                   PUBLIC_LINK_LIBRARIES O2::MFTWorkflow)

--- a/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/TracksToRecordsSpec.h
+++ b/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/TracksToRecordsSpec.h
@@ -1,0 +1,61 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TracksToRecordsSpec.h
+/// \author arakotoz@cern.ch
+/// \brief Class to run tracks to records needed to feed standalone alignment for MFT
+
+#ifndef ALICEO2_MFT_ALIGNMENT_DEVICE_H
+#define ALICEO2_MFT_ALIGNMENT_DEVICE_H
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+#include "MFTAlignment/TracksToRecords.h"
+#include "TStopwatch.h"
+#include "DetectorsBase/GRPGeomHelper.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace mft
+{
+class TracksToRecordsSpec : public Task
+{
+ public:
+  TracksToRecordsSpec(std::shared_ptr<o2::base::GRPGeomRequest> gr)
+    : mGGCCDBRequest(gr){};
+  void init(o2::framework::InitContext& ic) final;
+  void run(o2::framework::ProcessingContext& pc) final;
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
+
+ private:
+  void updateTimeDependentParams(o2::framework::ProcessingContext& pc);
+  void sendOutput(o2::framework::DataAllocator& output);
+  std::unique_ptr<o2::mft::TracksToRecords> mAlignment;
+  std::shared_ptr<o2::base::GRPGeomRequest> mGGCCDBRequest;
+  enum TimerIDs { SWTot,
+                  SWProcessTimeFrame,
+                  SWProcessRecoTracks,
+                  NStopWatches };
+  static constexpr std::string_view TimerName[] = {"Total",
+                                                   "processTimeFrame",
+                                                   "processRecoTracks"};
+  TStopwatch mTimer[NStopWatches];
+};
+
+DataProcessorSpec getTracksToRecordsSpec();
+
+} // namespace mft
+} // namespace o2
+
+#endif

--- a/Detectors/ITSMFT/MFT/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/RecoWorkflow.cxx
@@ -19,6 +19,7 @@
 #include "MFTWorkflow/TrackWriterSpec.h"
 #include "ITSMFTWorkflow/DigitReaderSpec.h"
 #include "MFTWorkflow/MFTAssessmentSpec.h"
+#include "MFTWorkflow/TracksToRecordsSpec.h"
 
 namespace o2
 {
@@ -28,7 +29,15 @@ namespace mft
 namespace reco_workflow
 {
 
-framework::WorkflowSpec getWorkflow(bool useMC, bool upstreamDigits, bool upstreamClusters, bool disableRootOutput, bool runAssessment, bool processGen, bool runTracking)
+framework::WorkflowSpec getWorkflow(
+  bool useMC,
+  bool upstreamDigits,
+  bool upstreamClusters,
+  bool disableRootOutput,
+  bool runAssessment,
+  bool processGen,
+  bool runTracking,
+  bool runTracks2Records)
 {
   framework::WorkflowSpec specs;
 
@@ -48,6 +57,9 @@ framework::WorkflowSpec getWorkflow(bool useMC, bool upstreamDigits, bool upstre
     }
     if (runAssessment) {
       specs.emplace_back(o2::mft::getMFTAssessmentSpec(useMC, processGen));
+    }
+    if (runTracks2Records) {
+      specs.emplace_back(o2::mft::getTracksToRecordsSpec());
     }
   }
   return specs;

--- a/Detectors/ITSMFT/MFT/workflow/src/TracksToRecordsSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/TracksToRecordsSpec.cxx
@@ -1,0 +1,164 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file TracksToRecordsSpec.cxx
+
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/CCDBParamSpec.h"
+#include "Framework/Logger.h"
+#include "Framework/TimingInfo.h"
+#include "Field/MagneticField.h"
+#include "TGeoGlobalMagField.h"
+#include "MFTBase/GeometryTGeo.h"
+#include "MFTAlignment/AlignConfig.h"
+
+#include "MFTWorkflow/TracksToRecordsSpec.h"
+#include "CommonUtils/NameConf.h"
+#include "DetectorsCommonDataFormats/AlignParam.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace mft
+{
+
+//_____________________________________________________________
+void TracksToRecordsSpec::init(InitContext& ic)
+{
+  o2::base::GRPGeomHelper::instance().setRequest(mGGCCDBRequest);
+
+  auto& alignConfigParam = o2::mft::AlignConfig::Instance();
+  mAlignment = std::make_unique<o2::mft::TracksToRecords>();
+  mAlignment->setChi2CutNStdDev(alignConfigParam.chi2CutNStdDev);
+  mAlignment->setResidualCutInitial(alignConfigParam.residualCutInitial);
+  mAlignment->setResidualCut(alignConfigParam.residualCut);
+  mAlignment->setAllowedVariationDeltaX(alignConfigParam.allowedVarDeltaX);
+  mAlignment->setAllowedVariationDeltaY(alignConfigParam.allowedVarDeltaY);
+  mAlignment->setAllowedVariationDeltaZ(alignConfigParam.allowedVarDeltaZ);
+  mAlignment->setAllowedVariationDeltaRz(alignConfigParam.allowedVarDeltaRz);
+  mAlignment->setChi2CutFactor(alignConfigParam.chi2CutFactor);
+  for (int sw = 0; sw < NStopWatches; sw++) {
+    mTimer[sw].Stop();
+    mTimer[sw].Reset();
+  }
+  mTimer[SWTot].Start(false);
+}
+
+//_____________________________________________________________
+void TracksToRecordsSpec::run(o2::framework::ProcessingContext& pc)
+{
+  updateTimeDependentParams(pc);
+  mTimer[SWProcessTimeFrame].Start(false);
+  mAlignment->startRecordWriter();
+  mAlignment->processTimeFrame(pc);
+  mTimer[SWProcessTimeFrame].Stop();
+
+  mTimer[SWProcessRecoTracks].Start(false);
+  mAlignment->processRecoTracks();
+  mTimer[SWProcessRecoTracks].Stop();
+}
+
+//_____________________________________________________________
+void TracksToRecordsSpec::endOfStream(o2::framework::EndOfStreamContext& ec)
+{
+  mAlignment->printProcessTrackSummary();
+  mAlignment->endRecordWriter();
+
+  sendOutput(ec.outputs());
+  mTimer[SWTot].Stop();
+
+  for (int i = 0; i < NStopWatches; i++) {
+    LOGF(info, "Timing %18s: Cpu: %.3e s; Real: %.3e s in %d slots", TimerName[i], mTimer[i].CpuTime(), mTimer[i].RealTime(), mTimer[i].Counter() - 1);
+  }
+}
+
+//_____________________________________________________________
+void TracksToRecordsSpec::sendOutput(DataAllocator& output)
+{
+  // TODO: figure out how to have record tree output redirected here and saved
+}
+
+///_______________________________________
+void TracksToRecordsSpec::updateTimeDependentParams(ProcessingContext& pc)
+{
+  o2::base::GRPGeomHelper::instance().checkUpdates(pc);
+  static bool initOnceDone = false;
+  if (!initOnceDone) { // this params need to be queried only once
+    initOnceDone = true;
+    pc.inputs().get<o2::itsmft::TopologyDictionary*>("cldict"); // just to trigger the finaliseCCDB
+
+    o2::mft::GeometryTGeo* geom = o2::mft::GeometryTGeo::Instance();
+    geom->fillMatrixCache(o2::math_utils::bit2Mask(o2::math_utils::TransformType::T2L,
+                                                   o2::math_utils::TransformType::T2GRot,
+                                                   o2::math_utils::TransformType::T2G));
+    auto& alignConfigParam = o2::mft::AlignConfig::Instance();
+    auto field = static_cast<o2::field::MagneticField*>(TGeoGlobalMagField::Instance()->GetField());
+    double centerMFT[3] = {0, 0, -61.4}; // Field at center of MFT
+    auto Bz = field->getBz(centerMFT);
+    LOG(info) << "Setting MFT TracksToRecords Bz = " << Bz;
+    mAlignment->setBz(Bz);
+    const auto& timingInfo = pc.services().get<o2::framework::TimingInfo>();
+    auto runNumber = timingInfo.runNumber;
+    mAlignment->setRunNumber(runNumber);
+    LOG(info) << "Setting MFT TracksToRecords run numner = " << runNumber;
+    mAlignment->setMinNumberClusterCut(alignConfigParam.minPoints);
+    mAlignment->init();
+  }
+}
+
+///_______________________________________
+void TracksToRecordsSpec::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
+{
+  if (o2::base::GRPGeomHelper::instance().finaliseCCDB(matcher, obj)) {
+    return;
+  }
+  if (matcher == ConcreteDataMatcher("MFT", "CLUSDICT", 0)) {
+    LOG(info) << "cluster dictionary updated";
+    mAlignment->setClusterDictionary((const o2::itsmft::TopologyDictionary*)obj);
+  }
+}
+
+//_____________________________________________________________
+DataProcessorSpec getTracksToRecordsSpec()
+{
+  std::vector<InputSpec> inputs;
+  std::vector<OutputSpec> outputs;
+
+  inputs.emplace_back("compClusters", "MFT", "COMPCLUSTERS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("patterns", "MFT", "PATTERNS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("clustersrofs", "MFT", "CLUSTERSROF", 0, Lifetime::Timeframe);
+  inputs.emplace_back("tracksrofs", "MFT", "MFTTrackROF", 0, Lifetime::Timeframe);
+  inputs.emplace_back("tracks", "MFT", "TRACKS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("trackClIdx", "MFT", "TRACKCLSID", 0, Lifetime::Timeframe);
+  inputs.emplace_back("cldict", "MFT", "CLUSDICT", 0, Lifetime::Condition, ccdbParamSpec("MFT/Calib/ClusterDictionary"));
+  auto ggRequest = std::make_shared<o2::base::GRPGeomRequest>(false,                             // orbitResetTime
+                                                              true,                              // GRPECS=true
+                                                              false,                             // GRPLHCIF
+                                                              true,                              // GRPMagField
+                                                              false,                             // askMatLUT
+                                                              o2::base::GRPGeomRequest::Aligned, // geometry
+                                                              inputs,
+                                                              true);
+
+  outputs.emplace_back("MFT", "TRACKS2RECORDS", 0, Lifetime::Sporadic);
+
+  return DataProcessorSpec{
+    "mft-tracks2records",
+    inputs,
+    outputs,
+    AlgorithmSpec{adaptFromTask<o2::mft::TracksToRecordsSpec>(ggRequest)},
+    Options{{}}};
+}
+
+} // namespace mft
+} // namespace o2

--- a/Detectors/ITSMFT/MFT/workflow/src/mft-reco-workflow.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/mft-reco-workflow.cxx
@@ -40,7 +40,8 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"disable-tracking", o2::framework::VariantType::Bool, false, {"disable tracking step"}},
     {"run-assessment", o2::framework::VariantType::Bool, false, {"run MFT assessment workflow"}},
     {"disable-process-gen", o2::framework::VariantType::Bool, false, {"disable processing of all generated tracks (depends on --run-assessment)"}},
-    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}},
+    {"run-tracks2records", o2::framework::VariantType::Bool, false, {"run MFT alignment tracks to records workflow"}}};
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
   std::swap(workflowOptions, options);
 }
@@ -61,8 +62,17 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   auto runAssessment = configcontext.options().get<bool>("run-assessment");
   auto processGen = !configcontext.options().get<bool>("disable-process-gen");
   auto runTracking = !configcontext.options().get<bool>("disable-tracking");
+  auto runTracks2Records = configcontext.options().get<bool>("run-tracks2records");
 
-  auto wf = o2::mft::reco_workflow::getWorkflow(useMC, extDigits, extClusters, disableRootOutput, runAssessment, processGen, runTracking);
+  auto wf = o2::mft::reco_workflow::getWorkflow(
+    useMC,
+    extDigits,
+    extClusters,
+    disableRootOutput,
+    runAssessment,
+    processGen,
+    runTracking,
+    runTracks2Records);
 
   // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit
   o2::raw::HBFUtilsInitializer hbfIni(configcontext, wf);

--- a/Detectors/ITSMFT/MFT/workflow/src/mft-tracks2records-workflow.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/mft-tracks2records-workflow.cxx
@@ -1,0 +1,42 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/DataProcessorSpec.h"
+#include "MFTWorkflow/TracksToRecordsSpec.h"
+#include "CommonUtils/ConfigurableParam.h"
+
+using namespace o2::framework;
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  std::vector<o2::framework::ConfigParamSpec> options{
+    {"run-tracks2records", o2::framework::VariantType::Bool, false, {"run MFT alignment tracks to records workflow"}}};
+  std::swap(workflowOptions, options);
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  // Update the (declared) parameters if changed from the command line
+  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
+  // write the configuration used for the workflow
+  o2::conf::ConfigurableParam::writeINI("o2-mft-tracks2records.ini");
+  auto runTracks2Records = configcontext.options().get<bool>("run-tracks2records");
+
+  WorkflowSpec specs;
+  specs.emplace_back(o2::mft::getTracksToRecordsSpec());
+  return specs;
+}


### PR DESCRIPTION
First release of the design architecture and main mechanisms in the MFT standalone alignment:
- compute Mille records from {tracks} and their attached clusters
- feed MillePede2 solver with Mille records, run it and extract alignment parameters
The matrix algebra behind MillePede2 solver and the solver itself are taken from AliROOT. However, the interface of MillePede2 solver that deals with Mille records has been modified to work seamlessly with the MFT code that fill/read the records.

The code has been tested on a local computer with macros running with mfttracks.root and mftclusters.root from 2021 pilot beam at zero B stored locally on disk. It was not tested via a workflow (this is postponed for the next round of commits).