### PR TITLE
[EMCAL-566] Add is_messagable to calib params

### DIFF
--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibParams.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibParams.h
@@ -29,7 +29,7 @@ namespace emcal
 // class containing the parameters to trigger the calibrations
 struct EMCALCalibParams : public o2::conf::ConfigurableParamHelper<EMCALCalibParams> {
 
-  unsigned int minNEvents = 1e6;              ///< minimum number of events to trigger the calibration
+  unsigned int minNEvents = 1e7;              ///< minimum number of events to trigger the calibration
   unsigned int minNEntries = 1e6;             ///< minimum number of entries to trigger the calibration
   bool useNEventsForCalib = true;             ///< use the minimum number of events to trigger the calibration
   std::string calibType = "time";             ///< type of calibration to run
@@ -49,6 +49,16 @@ struct EMCALCalibParams : public o2::conf::ConfigurableParamHelper<EMCALCalibPar
 };
 
 } // namespace emcal
+
+namespace framework
+{
+template <typename T>
+struct is_messageable;
+template <>
+struct is_messageable<o2::emcal::EMCALCalibParams> : std::true_type {
+};
+} // namespace framework
+
 } // namespace o2
 
 #endif /*EMCAL_CALIB_INIT_PARAMS_H_ */


### PR DESCRIPTION
- is_messagable added to calib params in order to prepare to read them
from ccdb (this will need additional changes in the CalibratorSpec which
will be added as soon as the ccdb object exists)
- Changed the default value of the minimum number of events needed to
trigger the calibration. The 10 million events was tested at point 2 and
gives reasonable results