### PR TITLE
[EMCAL-566] print cellID if fit in time calib fails

### DIFF
--- a/Common/Utils/src/BoostHistogramUtils.cxx
+++ b/Common/Utils/src/BoostHistogramUtils.cxx
@@ -19,6 +19,27 @@ namespace o2
 namespace utils
 {
 
+std::string createErrorMessageFitGaus(o2::utils::FitGausError_t errorcode)
+{
+  switch (errorcode) {
+    case FitGausError_t::FIT_ERROR_MIN:
+      return "Gaus fit failed! xMax < 4";
+    case FitGausError_t::FIT_ERROR_MAX:
+      return "Gaus fit failed! xMax too large";
+    case FitGausError_t::FIT_ERROR_ENTRIES:
+      return "Gaus fit failed! entries < 12";
+    case FitGausError_t::FIT_ERROR_KTOL_MEAN:
+      return "Gaus fit failed! std::abs(par[1]) < kTol";
+    case FitGausError_t::FIT_ERROR_KTOL_SIGMA:
+      return "Gaus fit failed! std::abs(par[2]) < kTol";
+    case FitGausError_t::FIT_ERROR_KTOL_RMS:
+      return "Gaus fit failed! RMS < kTol";
+    default:
+      return "Gaus fit failed! Unknown error code";
+  }
+  return "Gaus fit failed! Unknown error code";
+}
+
 boostHisto1d_VarAxis boosthistoFromRoot_1D(TH1D* inHist1D)
 {
   // first setup the proper boost histogram

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibExtractor.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibExtractor.h
@@ -140,8 +140,7 @@ class EMCALCalibExtractor
           maxElementIndex = 0;
         }
         float maxElementCenter = 0.5 * (boostHist1d.axis(0).bin(maxElementIndex).upper() + boostHist1d.axis(0).bin(maxElementIndex).lower());
-        float timeInterval = 25; // in ns
-        boostHist1d = boost::histogram::algorithm::reduce(boostHist1d, boost::histogram::algorithm::shrink(maxElementCenter - timeInterval, maxElementCenter + timeInterval));
+        boostHist1d = boost::histogram::algorithm::reduce(boostHist1d, boost::histogram::algorithm::shrink(maxElementCenter - restrictFitRangeToMax, maxElementCenter + restrictFitRangeToMax));
       }
 
       try {
@@ -149,7 +148,8 @@ class EMCALCalibExtractor
         mean = fitValues.at(1);
         // add mean to time calib params
         TCP.addTimeCalibParam(i, mean, 0);
-      } catch (o2::utils::FitGausError_t) {
+      } catch (o2::utils::FitGausError_t err) {
+        LOG(warning) << createErrorMessageFitGaus(err) << "; for cell " << i << " (Will take the parameter of the previous cell: " << mean << "ns)";
         TCP.addTimeCalibParam(i, mean, 0); // take calib value of last cell; or 400 ns shift default value
       }
     }


### PR DESCRIPTION
- cellID is now printed if the fit of the time distribution of this cell
fails.
- Can be usefull for debugging etc.
- Additionally the time calibration parameter that is assigned to this
cell is printed (per default the value of the previous cell is used)