### PR TITLE
o2-sim: Promote random seed to 64bit int (or ULong_t)

### DIFF
--- a/Common/SimConfig/include/SimConfig/SimConfig.h
+++ b/Common/SimConfig/include/SimConfig/SimConfig.h
@@ -56,7 +56,7 @@ struct SimConfigData {
                                               // but will themselves be overridden by any values given in mKeyValueTokens.
   int mPrimaryChunkSize;                      // defining max granularity for input primaries of a sim job
   int mInternalChunkSize;                     //
-  int mStartSeed;                             // base for random number seeds
+  ULong_t mStartSeed;                         // base for random number seeds
   int mSimWorkers = 1;                        // number of parallel sim workers (when it applies)
   bool mFilterNoHitEvents = false;            // whether to filter out events not leaving any response
   std::string mCCDBUrl;                       // the URL where to find CCDB
@@ -137,7 +137,7 @@ class SimConfig
   std::string getConfigFile() const { return mConfigData.mConfigFile; }
   int getPrimChunkSize() const { return mConfigData.mPrimaryChunkSize; }
   int getInternalChunkSize() const { return mConfigData.mInternalChunkSize; }
-  int getStartSeed() const { return mConfigData.mStartSeed; }
+  ULong_t getStartSeed() const { return mConfigData.mStartSeed; }
   int getNSimWorkers() const { return mConfigData.mSimWorkers; }
   bool isFilterOutNoHitEvents() const { return mConfigData.mFilterNoHitEvents; }
   bool asService() const { return mConfigData.mAsService; }
@@ -173,7 +173,7 @@ struct SimReconfigData {
   // values within the config file will override values set in code by the param classes
   // but will themselves be overridden by any values given in mKeyValueTokens.
   unsigned int primaryChunkSize; // defining max granularity for input primaries of a sim job
-  int startSeed;                 // base for random number seeds
+  ULong_t startSeed;             // base for random number seeds
   bool stop;                     // to shut down the service
 
   ClassDefNV(SimReconfigData, 1);

--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -48,7 +48,7 @@ void SimConfig::initOptions(boost::program_options::options_description& options
     "configFile", bpo::value<std::string>()->default_value(""), "Path to an INI or JSON configuration file")(
     "chunkSize", bpo::value<unsigned int>()->default_value(500), "max size of primary chunk (subevent) distributed by server")(
     "chunkSizeI", bpo::value<int>()->default_value(-1), "internalChunkSize")(
-    "seed", bpo::value<int>()->default_value(-1), "initial seed (default: -1 random)")(
+    "seed", bpo::value<ULong_t>()->default_value(0), "initial seed as ULong_t (default: 0 == random)")(
     "field", bpo::value<std::string>()->default_value("-5"), "L3 field rounded to kGauss, allowed values +-2,+-5 and 0; +-<intKGaus>U for uniform field; \"ccdb\" for taking it from CCDB ")(
     "nworkers,j", bpo::value<int>()->default_value(nsimworkersdefault), "number of parallel simulation workers (only for parallel mode)")(
     "noemptyevents", "only writes events with at least one hit")(
@@ -171,7 +171,7 @@ bool SimConfig::resetFromParsedMap(boost::program_options::variables_map const& 
   mConfigData.mConfigFile = vm["configFile"].as<std::string>();
   mConfigData.mPrimaryChunkSize = vm["chunkSize"].as<unsigned int>();
   mConfigData.mInternalChunkSize = vm["chunkSizeI"].as<int>();
-  mConfigData.mStartSeed = vm["seed"].as<int>();
+  mConfigData.mStartSeed = vm["seed"].as<ULong_t>();
   mConfigData.mSimWorkers = vm["nworkers"].as<int>();
   if (vm.count("timestamp")) {
     mConfigData.mTimestamp = vm["timestamp"].as<uint64_t>();
@@ -286,7 +286,7 @@ bool parseSimReconfigFromString(std::string const& argumentstring, SimReconfigDa
     "configKeyValues", bpo::value<std::string>(&data.keyValueTokens)->default_value(""), "semicolon separated key=value strings (e.g.: 'TPC.gasDensity=1;...")(
     "configFile", bpo::value<std::string>(&data.configFile)->default_value(""), "Path to an INI or JSON configuration file")(
     "chunkSize", bpo::value<unsigned int>(&data.primaryChunkSize)->default_value(500), "max size of primary chunk (subevent) distributed by server")(
-    "seed", bpo::value<int>(&data.startSeed)->default_value(-1), "initial seed (default: -1 random)")(
+    "seed", bpo::value<ULong_t>(&data.startSeed)->default_value(0L), "initial seed as ULong_t (default: 0 == random)")(
     "stop", bpo::value<bool>(&data.stop)->default_value(false), "control command to shut down daemon");
 
   bpo::variables_map vm;

--- a/Common/Utils/include/CommonUtils/RngHelper.h
+++ b/Common/Utils/include/CommonUtils/RngHelper.h
@@ -32,11 +32,11 @@ class RngHelper
 {
  public:
   // sets the state of the currently active ROOT gRandom Instance
-  // if -1 (or negative) is given ... we will init with a random seed
+  // if 0 is given ... we will init with a random seed
   // returns seed set to TRandom
-  static unsigned int setGRandomSeed(int seed = -1)
+  static ULong_t setGRandomSeed(ULong_t seed = 0)
   {
-    unsigned int s = seed < 0 ? readURandom<unsigned int>() : seed;
+    const auto s = seed == 0 ? readURandom<ULong_t>() : seed;
     gRandom->SetSeed(s);
     return s;
   }

--- a/DataFormats/simulation/include/SimulationDataFormat/PrimaryChunk.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/PrimaryChunk.h
@@ -29,7 +29,7 @@ struct SubEventInfo {
   int32_t runID = 0;      // the runID of this run
   uint16_t part = 0;      // which part of the eventID
   uint16_t nparts = 0;    // out of how many parts
-  uint32_t seed = 0;      // seed for RNG
+  uint64_t seed = 0;      // seed for RNG
   uint32_t index = 0;
   int32_t npersistenttracks = -1; // the number of persistent tracks for this SubEvent (might be set to cache it)
   int32_t nprimarytracks = -1;    // the number of primary tracks for this SubEvent
@@ -37,7 +37,7 @@ struct SubEventInfo {
 
   o2::dataformats::MCEventHeader mMCEventHeader; // associated FairMC header for vertex information
 
-  ClassDefNV(SubEventInfo, 1);
+  ClassDefNV(SubEventInfo, 2);
 };
 
 inline bool operator<(SubEventInfo const& a, SubEventInfo const& b)

--- a/run/O2PrimaryServerDevice.h
+++ b/run/O2PrimaryServerDevice.h
@@ -221,7 +221,7 @@ class O2PrimaryServerDevice final : public fair::mq::Device
     LOG(info) << "CHUNK SIZE SET TO " << mChunkGranularity;
 
     // initial initial seed --> we should store this somewhere
-    mInitialSeed = vm["seed"].as<int>();
+    mInitialSeed = vm["seed"].as<ULong_t>();
     mInitialSeed = o2::utils::RngHelper::setGRandomSeed(mInitialSeed);
     LOG(info) << "RNG INITIAL SEED " << mInitialSeed;
 
@@ -556,7 +556,7 @@ class O2PrimaryServerDevice final : public fair::mq::Device
   int mPartCounter = 0;
   bool mNeedNewEvent = true;
   int mMaxEvents = 2;
-  int mInitialSeed = -1;
+  ULong_t mInitialSeed = 0;
   int mPipeToDriver = -1; // handle for direct piper to driver (to communicate meta info)
   int mEventCounter = 0;
 


### PR DESCRIPTION
more naturally since type of TRandom::SetSeed takes ULong_t
in any case