### PR TITLE
[EMCAL-566] Read calibration params from ccdb

### DIFF
--- a/Detectors/EMCAL/calibration/testWorkflow/EMCALChannelCalibratorSpec.h
+++ b/Detectors/EMCAL/calibration/testWorkflow/EMCALChannelCalibratorSpec.h
@@ -31,6 +31,8 @@
 #include "CCDB/CcdbObjectInfo.h"
 #include "CommonUtils/NameConf.h"
 #include "DetectorsBase/GRPGeomHelper.h"
+#include "Framework/CCDBParamSpec.h"
+
 // for time measurements
 #include <chrono>
 
@@ -47,7 +49,7 @@ class EMCALChannelCalibDevice : public o2::framework::Task
   using EMCALCalibParams = o2::emcal::EMCALCalibParams;
 
  public:
-  EMCALChannelCalibDevice(std::shared_ptr<o2::base::GRPGeomRequest> req) : mCCDBRequest(req) {}
+  EMCALChannelCalibDevice(std::shared_ptr<o2::base::GRPGeomRequest> req, bool params) : mCCDBRequest(req), mLoadCalibParamsFromCCDB(params) {}
 
   void init(o2::framework::InitContext& ic) final
   {
@@ -87,6 +89,10 @@ class EMCALChannelCalibDevice : public o2::framework::Task
   void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final
   {
     o2::base::GRPGeomHelper::instance().finaliseCCDB(matcher, obj);
+    // check if calib params need to be updated
+    if (matcher == ConcreteDataMatcher("EMC", "EMCALCALIBPARAM", 0)) {
+      LOG(info) << "EMCal CalibParams updated";
+    }
   }
 
   void run(o2::framework::ProcessingContext& pc) final
@@ -97,6 +103,11 @@ class EMCALChannelCalibDevice : public o2::framework::Task
 
     o2::base::GRPGeomHelper::instance().checkUpdates(pc);
     o2::base::TFIDInfoHelper::fillTFIDInfo(pc, mTimeCalibrator->getCurrentTFInfo());
+
+    if (mLoadCalibParamsFromCCDB) {
+      // for reading the calib objects from the ccdb
+      pc.inputs().get<o2::emcal::EMCALCalibParams*>("EMC_CalibParam");
+    }
 
     auto tfcounter = o2::header::get<o2::framework::DataProcessingHeader*>(pc.inputs().get(getCellBinding()).header)->startTime;
 
@@ -157,6 +168,7 @@ class EMCALChannelCalibDevice : public o2::framework::Task
   std::shared_ptr<o2::emcal::EMCALCalibExtractor> mCalibExtractor;
   std::shared_ptr<o2::base::GRPGeomRequest> mCCDBRequest;
   bool isBadChannelCalib = true;
+  bool mLoadCalibParamsFromCCDB = true;
   std::array<double, 2> timeMeas;
 
   //________________________________________________________________
@@ -209,7 +221,7 @@ class EMCALChannelCalibDevice : public o2::framework::Task
 namespace framework
 {
 
-DataProcessorSpec getEMCALChannelCalibDeviceSpec()
+DataProcessorSpec getEMCALChannelCalibDeviceSpec(const bool loadCalibParamsFromCCDB)
 {
   using device = o2::calibration::EMCALChannelCalibDevice;
   using clbUtils = o2::calibration::Utils;
@@ -227,6 +239,10 @@ DataProcessorSpec getEMCALChannelCalibDeviceSpec()
   std::vector<InputSpec> inputs;
   inputs.emplace_back(device::getCellBinding(), o2::header::gDataOriginEMC, "CELLS", 0, o2::framework::Lifetime::Timeframe);
   inputs.emplace_back(device::getCellTriggerRecordBinding(), o2::header::gDataOriginEMC, "CELLSTRGR", 0, o2::framework::Lifetime::Timeframe);
+  // for loading the channelCalibParams from the ccdb
+  if (loadCalibParamsFromCCDB) {
+    inputs.emplace_back("EMC_CalibParam", o2::header::gDataOriginEMC, "EMCALCALIBPARAM", 0, Lifetime::Condition, ccdbParamSpec("EMC/Config/CalibParam"));
+  }
   auto ccdbRequest = std::make_shared<o2::base::GRPGeomRequest>(true,                           // orbitResetTime
                                                                 true,                           // GRPECS=true
                                                                 false,                          // GRPLHCIF
@@ -238,7 +254,7 @@ DataProcessorSpec getEMCALChannelCalibDeviceSpec()
     "calib-emcalchannel-calibration",
     inputs,
     outputs,
-    AlgorithmSpec{adaptFromTask<device>(ccdbRequest)},
+    AlgorithmSpec{adaptFromTask<device>(ccdbRequest, loadCalibParamsFromCCDB)},
     Options{}};
 }
 

--- a/Detectors/EMCAL/calibration/testWorkflow/emc-channel-calib-workflow.cxx
+++ b/Detectors/EMCAL/calibration/testWorkflow/emc-channel-calib-workflow.cxx
@@ -36,7 +36,8 @@ using namespace o2::emcal;
 void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
   std::vector<ConfigParamSpec> options{
-    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}},
+    {"no-loadCalibParamsFromCCDB", VariantType::Bool, false, {"if true, load the EMCalCalibParams from the ccdb. If false, use the default values given in the struct"}}};
 
   std::swap(workflowOptions, options);
 }
@@ -45,12 +46,15 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  WorkflowSpec specs;
-  specs.emplace_back(getEMCALChannelCalibDeviceSpec());
 
   o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
+  bool loadCalibParamsFromCCDB = !cfgc.options().get<bool>("no-loadCalibParamsFromCCDB");
+
+  WorkflowSpec specs;
+  specs.emplace_back(getEMCALChannelCalibDeviceSpec(loadCalibParamsFromCCDB));
 
   // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit
   // o2::raw::HBFUtilsInitializer hbfIni(cfgc, specs);
+
   return specs;
 }


### PR DESCRIPTION
- Added functionality to read calib params from ccdb in he calibratorSpec
- Object is already uploaded to ccdb (O2-3116)
- This will overwrite the default values in the CalibParams but can be
overwritten if secified via the configurableParams
- By default, the object is taken from the ccdb, one can switch it of by
adding the workflow argument --no-loadCalibParamsFromCCDB

addition