### PR TITLE
TRD raw reader update

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
@@ -75,7 +75,7 @@ constexpr double BUSY_TIME = READOUT_TIME + DEAD_TIME; // the time for which no 
 
 // array size to store incoming half cru payload.
 constexpr int HBFBUFFERMAX = 1048576;          // max buffer size for data read from a half cru, (all events)
-constexpr int CRUPADDING32 = 0xeeeeeeee;       // padding word used in the cru.
+constexpr unsigned int CRUPADDING32 = 0xeeeeeeee; // padding word used in the cru.
 constexpr int CHANNELNRNOTRKLT = 23;           // this marks channels in the ADC mask which don't contribute to a tracklet
 constexpr int NOTRACKLETFIT = 31;              // this value is assigned to the fit pointer in case no tracklet is available
 constexpr int TRACKLETENDMARKER = 0x10001000;  // marker for the end of tracklets in raw data, 2 of these.
@@ -87,8 +87,8 @@ constexpr int MAXEVENTCOUNTERSEPERATION = 200; // how far apart can subsequent m
 constexpr int MAXMCMCOUNT = 69120;             // at most mcm count maxchamber x nrobc1 nmcmrob
 constexpr int MAXLINKERRORHISTOGRAMS = 10;     // size of the array holding the link error plots from the raw reader
 constexpr int MAXPARSEERRORHISTOGRAMS = 60;    // size of the array holding the parsing error plots from the raw reader
-constexpr int ETYPEPHYSICSTRIGGER = 0x2;       // CRU Half Chamber header eventtype definition
-constexpr int ETYPECALIBRATIONTRIGGER = 0x3;   // CRU Half Chamber header eventtype definition
+constexpr unsigned int ETYPEPHYSICSTRIGGER = 0x2;     // CRU Half Chamber header eventtype definition
+constexpr unsigned int ETYPECALIBRATIONTRIGGER = 0x3; // CRU Half Chamber header eventtype definition
 constexpr int MAXCRUERRORVALUE = 0x2;          // Max possible value for a CRU Halfchamber link error. As of may 2022, can only be 0x0, 0x1, and 0x2, at least that is all so far(may2022).
 
 } // namespace constants

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
@@ -430,8 +430,6 @@ std::ostream& operator<<(std::ostream& stream, const TrackletHCHeader& halfchamb
 std::ostream& operator<<(std::ostream& stream, const TrackletMCMHeader& mcmhead);
 std::ostream& operator<<(std::ostream& stream, const TrackletMCMData& tracklet);
 void printTrackletMCMData(o2::trd::TrackletMCMData& tracklet);
-void printTrackletMCMHeader(o2::trd::TrackletMCMHeader& mcmhead);
-void printHalfChamber(o2::trd::TrackletHCHeader& halfchamber);
 void dumpHalfChamber(o2::trd::TrackletHCHeader& halfchamber);
 std::ostream& operator<<(std::ostream& stream, const HalfCRUHeader& halfcru);
 bool trackletMCMHeaderSanityCheck(o2::trd::TrackletMCMHeader& header);
@@ -472,8 +470,6 @@ std::ostream& operator<<(std::ostream& stream, const HalfCRUHeader& halfcru);
 void printTrackletHCHeader(o2::trd::TrackletHCHeader& tracklet);
 void printTrackletMCMData(o2::trd::TrackletMCMData& tracklet);
 void printTrackletMCMHeader(o2::trd::TrackletMCMHeader& mcmhead);
-
-void printHalfChamber(o2::trd::TrackletHCHeader& digithcheader);
 
 void printDigitHCHeader(o2::trd::DigitHCHeader& digitmcmheader);
 void printDigitMCMData(o2::trd::DigitMCMData& digitmcmdata);

--- a/DataFormats/Detectors/TRD/src/RawData.cxx
+++ b/DataFormats/Detectors/TRD/src/RawData.cxx
@@ -317,7 +317,7 @@ void printHalfCRUHeader(o2::trd::HalfCRUHeader& halfcru)
   LOGF(info, "V:%d BC:%d SB:%d EType:%d", halfcru.HeaderVersion, halfcru.BunchCrossing,
        halfcru.StopBit, halfcru.EventType);
   for (int i = 0; i < 15; i++) {
-    LOGF(info, "Link %d size: %ul eflag: 0x%02x", i, sizes[i], errorflags[i]);
+    LOGF(info, "Link %d size: %lu eflag: 0x%02x", i, sizes[i], errorflags[i]);
   }
   LOG(info) << "Raw: " << std::hex << halfcru.word0 << " " << halfcru.word12[0] << " " << halfcru.word12[1] << " " << halfcru.word3 << " " << halfcru.word47[0] << " " << halfcru.word47[1] << " " << halfcru.word47[2] << " " << halfcru.word47[3];
 }
@@ -352,25 +352,23 @@ bool halfCRUHeaderSanityCheck(o2::trd::HalfCRUHeader& header, std::array<uint32_
   // check the sizes for less than max value
   // check the errors for either < 0x3, for now (may 2022) there is only no error, 1, or 2.
   //
-  bool goodheader = true;
   for (int lengthindex = 0; lengthindex < 15; ++lengthindex) {
     if (lengths[lengthindex] > o2::trd::constants::MAXDATAPERLINK256) {
       // something has gone insane.
-      goodheader = false;
+      return false;
     }
   }
   for (int eflagindex = 0; eflagindex < 15; ++eflagindex) {
     if (eflags[eflagindex] > o2::trd::constants::MAXCRUERRORVALUE) {
       // something has gone insane.
-      goodheader = false;
+      return false;
     }
     if (header.EndPoint > 1) {
-      // end point can only be zero or 1, for ach of the 2 pci end points in the cru
-      goodheader = false;
+      // end point can only be zero or 1, for each of the 2 pci end points in the cru
+      return false;
     }
   }
-
-  return goodheader;
+  return true;
 }
 
 bool sanityCheckTrackletMCMHeader(o2::trd::TrackletMCMHeader* header)

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
@@ -35,8 +35,6 @@
 #include "CommonDataFormat/InteractionRecord.h"
 #include "TRDReconstruction/EventRecord.h"
 
-#include "TH2F.h"
-
 namespace o2::trd
 {
 class Tracklet64;
@@ -45,41 +43,18 @@ class Digit;
 
 class CruRawReader
 {
-
-  static constexpr bool debugparsing = true;
-  enum CRUSate { CRUStateHalfCRUHeader = 0,
-                 CRUStateHalfCRU };
-  enum Dataformats { TrackletsDataFormat = 0,
-                     DigitsDataFormat,
-                     TestPatternDataFormat,
-                     ConfigEventDataFormat };
-
  public:
   CruRawReader() = default;
   ~CruRawReader() = default;
 
-  bool run();
+  // top-level method, takes the full payload data of the DPL raw data message and delegates to processHBFs()
+  // probably this method can be removed and we can directly go to processHBFs()
+  void run();
 
-  void checkSummary();
-  void resetCounters();
-  void configure(int tracklethcheader, int halfchamberwords, int halfchambermajor, std::bitset<16> options)
-  {
-    mVerbose = options[TRDVerboseBit];
-    mHeaderVerbose = options[TRDHeaderVerboseBit];
-    mDataVerbose = options[TRDDataVerboseBit];
-    mFixDigitEndCorruption = options[TRDFixDigitCorruptionBit];
-    mTrackletHCHeaderState = tracklethcheader;
-    mHalfChamberWords = halfchamberwords;
-    mHalfChamberMajor = halfchambermajor;
-    mRootOutput = options[TRDEnableRootOutputBit];
-    mEnableTimeInfo = options[TRDEnableTimeInfoBit];
-    mEnableStats = options[TRDEnableStatsBit];
-    mOptions = options;
-    mTimeBins = constants::TIMEBINS; // set to value from constants incase the DigitHCHeader1 header is not present.
-    mPreviousDigitHCHeadersvnver = 0xffffffff;
-    mPreviousDigitHCHeadersvnrver = 0xffffffff;
-  }
+  // configure the raw reader, currently done for each TF and should be done only once (change DataReaderTask::run() method)
+  void configure(int tracklethcheader, int halfchamberwords, int halfchambermajor, std::bitset<16> options);
 
+  // settings in order to avoid InfoLogger flooding
   void setMaxErrWarnPrinted(int nerr, int nwar)
   {
     mMaxErrsPrinted = nerr < 0 ? std::numeric_limits<int>::max() : nerr;
@@ -88,37 +63,18 @@ class CruRawReader
   void checkNoWarn();
   void checkNoErr();
 
-  void setBlob(bool returnblob) { mReturnBlob = returnblob; }; //set class to produce blobs and not vectors. (compress vs pass through)`
-  void setDataBuffer(const char* val)
-  {
-    mDataBuffer = val;
-    if (mVerbose) {
-      if (val == nullptr) {
-        LOG(error) << "Data buffer is being assigned to a null ptr";
-      }
-    }
-  };
-  void setDataBufferSize(long val)
-  {
-    if (mVerbose) {
-      LOG(info) << " Setting buffer size to : " << val;
-    }
-    mDataBufferSize = val;
-  };
+  // set the input data buffer
+  void setDataBuffer(const char* val) { mDataBufferPtr = val; }
+
+  // set the input data buffer size in bytes
+  void setDataBufferSize(long val) { mDataBufferSize = val; }
+
+  // verbosity settings
   void setVerbose(bool verbose) { mVerbose = verbose; }
   void setDataVerbose(bool verbose) { mDataVerbose = verbose; }
   void setHeaderVerbose(bool verbose) { mHeaderVerbose = verbose; }
-  inline uint32_t getDecoderByteCounter() const { return reinterpret_cast<const char*>(mDataPointer) - mDataBuffer; };
-  bool buildBlobOutput(char* outputbuffer); // should probably go into a writer object.
-  // benchmarks
-  double mIntegratedBytes = 0.;
-  double mIntegratedTime = 0.;
 
-  std::vector<Tracklet64>& getTracklets(InteractionRecord& ir) { return mEventRecords.getTracklets(ir); };
-  std::vector<Digit>& getDigits(InteractionRecord& ir) { return mEventRecords.getDigits(ir); };
-  //  std::vector<o2::trd::TriggerRecord> getIR() { return mEventTriggers; }
-  void getParsedObjects(std::vector<Tracklet64>& tracklets, std::vector<Digit>& cdigits, std::vector<TriggerRecord>& triggers);
-  void getParsedObjectsandClear(std::vector<Tracklet64>& tracklets, std::vector<Digit>& digits, std::vector<TriggerRecord>& triggers);
+  // probably better to make mEventRecords available to the outside and then use that directly, can clean up this header a lot more
   void buildDPLOutputs(o2::framework::ProcessingContext& outputs);
   int getDigitsFound() { return mTotalDigitsFound; }
   int getTrackletsFound() { return mTotalTrackletsFound; }
@@ -127,68 +83,47 @@ class CruRawReader
   int getWordsRead() { return mWordsAccepted + mTotalDigitWordsRead + mTotalTrackletWordsRead; }
   int getWordsRejected() { return mWordsRejected + mTotalDigitWordsRejected + mTotalTrackletWordsRejected; }
 
-  std::shared_ptr<EventStorage*> getEventStorage() { return std::make_shared<EventStorage*>(&mEventRecords); }
   void clearall()
   {
     mEventRecords.clear();
-    clear();
-  }
-  void clear()
-  {
     mTrackletsParser.clear();
     mDigitsParser.clear();
   }
-  void OutputHalfCruRawData();
-  // void setStats(o2::trd::TRDDataCountersPerTimeFrame* trdstats){mTimeFrameStats=trdstats;}
-  //void setHistos(std::array<TH2F*, 10> hist, std::array<TH2F*, constants::MAXPARSEERRORHISTOGRAMS> parsingerrors2d)
 
- protected:
-  bool processHBFs(int datasizealreadyread = 0, bool verbose = false);
-  bool buildCRUPayLoad();
-  int processHalfCRU(int cruhbfstartoffset, int numberOfPreviousCRU, unsigned int maxdatawrittentobuffer);
-  bool processCRULink();
-  int parseDigitHCHeader();
-  int checkDigitHCHeader();
-  int checkTrackletHCHeader();
-  bool compareRDH(const o2::header::RDHAny* firstrdh, const o2::header::RDHAny* rdh);
+ private:
+  // the parsing starts here, payload from all available RDHs is copied into mHBFPayload and afterwards processHalfCRU() is called
+  // returns the total number of bytes read, including RDH header
+  int processHBFs();
+
+  // process the data which is stored inside the mHBFPayload for the current half-CRU. The iteration corresponds to the trigger index inside the HBF
+  int processHalfCRU(int iteration);
+
+  // parse the digit HC headers, possibly update settings as the number of time bins from the header word
+  int parseDigitHCHeader(int hcid);
+
+  // if configured, compare the link ID information from the digit HC headers with what we know from RDH header
+  void checkDigitHCHeader(int hcidRef);
+
+  // helper function to compare two consecutive RDHs
+  bool compareRDH(const o2::header::RDHAny* rdhPrev, const o2::header::RDHAny* rdhCurr);
+
+  // sanity check on individual RDH (can find unconfigured FLP or invalid data)
   bool checkRDH(const o2::header::RDHAny* rdh);
-  bool skipRDH();
-  void updateLinkErrorGraphs(int currentlinkindex, int supermodule_half, int stack_layer);
 
-  void incrementErrors(int hist, int sector = -1, int side = 0, int stack = 0, int layer = 0)
-  {
-    if (sector > 17 || sector < -1) {
-      sector = 0;
-    }
-    if (stack > 4 || stack < 0) {
-      stack = 0;
-    }
-    if (layer > 5 || layer < 0) {
-      layer = 0;
-    }
-    if (sector == -1) {
-      sector = (unsigned int)mFEEID.supermodule;
-      side = (unsigned int)mFEEID.side;
-      layer = 0;
-      stack = (unsigned int)mFEEID.endpoint;
-      // encode the endpoint into the stack for the 2d plots. This is for those situations where you can not know stack/layer at the time of the error.
-    }
-    mEventRecords.incParsingError(hist, sector, side, stack * constants::NLAYER + layer);
-    if (mVerbose) {
-      LOG(info) << "Parsing error: " << hist << " sector:" << sector << " side:" << side << " stack:" << stack << " layer:" << layer;
-    }
-  }
-  void dumpRDHAndNextHeader(const o2::header::RDHAny* rdh);
+  // important function to keep track of all errors, if possible accounted to a certain link / half-chamber ID
+  // FIXME:
+  // - whenever we don't know the half-chamber, fill it for HCID == 1080 so that we can still disentangle errors from half-chamber 0?
+  // - probably enough to only pass the half-chamber ID, if we know it
+  // - or what about being more granular? dump ROB or MCM, if we know it?
+  void incrementErrors(int hist, int sector = -1, int side = 0, int stack = 0, int layer = 0);
 
-  inline void rewind()
-  {
-    if (mVerbose) {
-      LOG(info) << "rewinding crurawreader incoming data buffer";
-    }
-    mDataPointer = reinterpret_cast<const uint32_t*>(mDataBuffer);
-  };
+  // helper function to dump the whole input payload including RDH headers
+  void dumpInputPayload() const;
 
-  int mJumpRDH = 0;
+  // ###############################################################
+  // ## class member variables
+  // ###############################################################
+
   bool mVerbose{false};
   bool mHeaderVerbose{false};
   bool mDataVerbose{false};
@@ -196,46 +131,29 @@ class CruRawReader
   int mTrackletHCHeaderState{0};
   int mHalfChamberWords{0};
   int mHalfChamberMajor{0};
-  bool mRootOutput{0};
-  bool mEnableTimeInfo{0};
-  bool mEnableStats{0};
   std::bitset<16> mOptions;
-  const char* mDataBuffer = nullptr;
-  static const uint32_t mMaxHBFBufferSize = o2::trd::constants::HBFBUFFERMAX;
-  std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX> mHBFPayload; //this holds the O2 payload held with in the HBFs to pass to parsing.
-  uint32_t mHalfCRUPayLoadRead{0};                                    // the words current read in for the currnt cru payload.
-  uint32_t mO2PayLoadRead{0};                                         // the words current read in for the currnt cru payload.
-  std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator mStartParse, mEndParse; // limits of parsing, start and end points for parsing.
-  std::array<uint16_t, constants::TIMEBINS> mADCValues{};
-  int mCurrentHalfCRULinkHeaderPoisition = 0;
-  // no need to waste time doing the copy  std::array<uint32_t,8> mCurrentCRUWord; // data for a cru comes in words of 256 bits.
-  uint32_t mCurrentLinkDataPosition256;    // count of data read for current link in units of 256 bits
-  uint32_t mCurrentLinkDataPosition;       // count of data read for current link in units of 256 bits
-  uint32_t mCurrentHalfCRUDataPosition256; //count of data read for this half cru.
-  uint32_t mTotalHalfCRUDataLength;
-  uint32_t mTotalHalfCRUDataLength256;
 
-  uint32_t mTotalTrackletsFound{0};
-  uint32_t mTotalDigitsFound{0};
+  std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX> mHBFPayload; // this holds the O2 payload held with in the HBFs to pass to parsing.
 
+  uint32_t mTotalTrackletsFound{0}; // accumulated number of tracklets found
+  uint32_t mTotalDigitsFound{0};    // accumulated number of digits found
+
+  // InfoLogger flood protection settings
   int mMaxErrsPrinted = 20;
   int mMaxWarnPrinted = 20;
 
-  long mDataBufferSize;
-  uint32_t mDataReadIn = 0;
-  const uint32_t* mDataPointer = nullptr; // pointer to the current position in the rdh
-  const uint32_t* mDataPointerMax = nullptr;
-  const uint32_t* mDataEndPointer = nullptr;
-  const uint32_t* mDataPointerNext = nullptr;
-  uint8_t mDataNextWord = 1;
-  uint8_t mDataNextWordStep = 2;
+  // helper pointers, counters for the input buffer
+  const char* mDataBufferPtr = nullptr; // pointer to the beginning of the whole payload data
+  long mDataBufferSize;                 // the total payload size of the raw data message from the FLP (typically a single HBF from one half-CRU)
+  const char* mCurrRdhPtr = nullptr;    // points inside the payload data at the current RDH position
+  uint32_t mTotalHBFPayLoad = 0;        // total data payload of the heart beat frame in question (up to wich array index mHBFPayload is filled with data)
+  uint32_t mHBFoffset32 = 0;            // points to the current position inside mHBFPayload we are currently reading
 
-  const o2::header::RDHAny* mDataRDH;
   HalfCRUHeader mCurrentHalfCRUHeader; // are we waiting for new header or currently parsing the payload of on
   HalfCRUHeader mPreviousHalfCRUHeader; // are we waiting for new header or currently parsing the payload of on
   DigitHCHeader mDigitHCHeader;        // Digit HalfChamber header we are currently on.
   DigitHCHeader1 mDigitHCHeader1;      // this and the next 2 are option are and variable in order, hence
-  uint16_t mTimeBins;
+  uint16_t mTimeBins;                  // the number of time bins to be read out (default 30, can be overwritten from digit HC header)
   DigitHCHeader2 mDigitHCHeader2;      // the individual seperation instead of an array.
   DigitHCHeader3 mDigitHCHeader3;
   uint32_t mPreviousDigitHCHeadersvnver;  // svn ver in the digithalfchamber header, used for validity checks
@@ -243,64 +161,29 @@ class CruRawReader
   TrackletHCHeader mTrackletHCHeader;  // Tracklet HalfChamber header we are currently on.
   uint16_t mCurrentLink;               // current link within the halfcru we are parsing 0-14
   uint16_t mCRUEndpoint;               // the upper or lower half of the currently parsed cru 0-14 or 15-29
-  uint16_t mCRUID;
-  uint16_t mHCID;
+  uint16_t mCRUID;                     // CRU ID taken from the FEEID of the RDH
   TRDFeeID mFEEID; // current Fee ID working on
-  // the store of the 3 ways we can determine this information, link,rdh,halfchamber
-  std::array<int, 3> mDetector;
-  std::array<int, 3> mSector;
-  std::array<int, 3> mStack;
-  std::array<int, 3> mLayer;
-  std::array<int, 3> mSide;
-  std::array<int, 3> mEndPoint;
-  std::array<int, 3> mHalfChamberSide;
-  int mWhichData; // index used into the above arrays once decided on which source is "correct"
+
   o2::InteractionRecord mIR;
   std::array<uint32_t, 15> mCurrentHalfCRULinkLengths;
   std::array<uint32_t, 15> mCurrentHalfCRULinkErrorFlags;
-  uint32_t mCRUState; // the state of what we are expecting to read currently from the data stream, *not* what we have just read.
-  bool mError = false;
-  bool mFatal = false;
-  uint32_t mSaveBufferDataSize = 0;
-  uint32_t mSaveBufferDataLeft = 0;
-  uint32_t mcruFeeID = 0;
-  uint32_t mDatareadfromhbf;
-  uint32_t mTotalHBFPayLoad = 0; // total data payload of the heart beat frame in question.
-  uint32_t mHBFoffset32 = 0;     // total data payload of the heart beat frame in question.
-  uint32_t mDigitWordsRead = 0;
-  uint32_t mDigitWordsRejected = 0;
+
+  // FIXME for all counters need to check which one is really needed
   uint32_t mTotalDigitWordsRead = 0;
   uint32_t mTotalDigitWordsRejected = 0;
-  uint32_t mTrackletWordsRead = 0;
-  uint32_t mTrackletWordsRejected = 0;
   uint32_t mTotalTrackletWordsRejected = 0;
   uint32_t mTotalTrackletWordsRead = 0;
   uint32_t mWordsRejected = 0; // those words rejected before tracklet and digit parsing together with the digit and tracklet rejected words;
   uint32_t mWordsAccepted = 0; // those words before before tracklet and digit parsing together with the digit and tracklet rejected words;
-  //pointers to the data as we read them in, again no point in copying.
-  HalfCRUHeader* mhalfcruheader;
 
-  bool checkerCheck();
-  void checkerCheckRDH();
-  int mState; // basic state machine for where we are in the parsing.
   // we parse rdh to rdh but data is cru to cru.
   //the relevant parsers. Not elegant but we need both so pointers to base classes and sending them in with templates or some other such mechanism seems impossible, or its just late and I cant think.
   //TODO think of a more elegant way of incorporating the parsers.
   TrackletsParser mTrackletsParser;
   DigitsParser mDigitsParser;
-  //used to surround the outgoing data with a coherent rdh coming from the incoming stream.
-  const o2::header::RDHAny* mOpenRDH;
-  const o2::header::RDHAny* mCloseRDH;
-
-  uint32_t mEventCounter;
-  uint32_t mFatalCounter;
-  uint32_t mErrorCounter;
 
   EventStorage mEventRecords; // store data range indexes into the above vectors.
   EventRecord* mCurrentEvent; // the current event we are looking at, info extracted from cru half chamber header.
-
-  bool mReturnBlob{0};        // whether to return blobs or vectors;
-  o2::trd::TRDDataCountersRunning mStatCountersRunning;
 };
 
 } // namespace o2::trd

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/DataReaderTask.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/DataReaderTask.h
@@ -26,10 +26,6 @@
 #include "DataFormatsTRD/RawDataStats.h"
 #include <fstream>
 
-#include "TGraph2D.h"
-#include "TH3F.h"
-#include <TH2F.h>
-
 using namespace o2::framework;
 
 namespace o2::trd
@@ -38,7 +34,7 @@ namespace o2::trd
 class DataReaderTask : public Task
 {
  public:
-  DataReaderTask(int tracklethcheader, int halfchamberwords, int halfchambermajor, std::string histofilename, std::bitset<16> option) : mCompressedData(option[TRDCompressedDataBit]), mByteSwap(option[TRDByteSwapBit]), mFixDigitEndCorruption(option[TRDFixDigitCorruptionBit]), mTrackletHCHeaderState(tracklethcheader), mHalfChamberWords(halfchamberwords), mHalfChamberMajor(halfchambermajor), mHistogramsFilename(histofilename), mVerbose(option[TRDVerboseBit]), mHeaderVerbose(option[TRDHeaderVerboseBit]), mDataVerbose(option[TRDDataVerboseBit]), mEnableTimeInfo(option[TRDEnableTimeInfoBit]), mEnableStats(option[TRDEnableStatsBit]), mRootOutput(option[TRDEnableRootOutputBit]), mIgnoreTrackletHCHeader(option[TRDIgnoreTrackletHCHeaderBit]), mIgnoreDigitHCHeader(option[TRDIgnoreDigitHCHeaderBit]), mOptions(option) {}
+  DataReaderTask(int tracklethcheader, int halfchamberwords, int halfchambermajor, std::string histofilename, std::bitset<16> option) : mCompressedData(option[TRDCompressedDataBit]), mByteSwap(option[TRDByteSwapBit]), mFixDigitEndCorruption(option[TRDFixDigitCorruptionBit]), mTrackletHCHeaderState(tracklethcheader), mHalfChamberWords(halfchamberwords), mHalfChamberMajor(halfchambermajor), mVerbose(option[TRDVerboseBit]), mHeaderVerbose(option[TRDHeaderVerboseBit]), mDataVerbose(option[TRDDataVerboseBit]), mIgnoreTrackletHCHeader(option[TRDIgnoreTrackletHCHeaderBit]), mIgnoreDigitHCHeader(option[TRDIgnoreDigitHCHeaderBit]), mOptions(option) {}
   ~DataReaderTask() override = default;
   void init(InitContext& ic) final;
   void sendData(ProcessingContext& pc, bool blankframe = false);
@@ -60,9 +56,6 @@ class DataReaderTask : public Task
   bool mHeaderVerbose{false};    // verbose output of headers
   bool mCompressedData{false};   // are we dealing with the compressed data from the flp (send via option)
   bool mByteSwap{true};          // whether we are to byteswap the incoming data, mc is not byteswapped, raw data is (too be changed in cru at some point)
-  bool mEnableTimeInfo{false};   // enable the timing of timeframe,cru,digit,tracklet processing.
-  bool mEnableStats{false};      // enable the taking of stats in the rawdatastats class
-  bool mRootOutput{false};       // enable the writing of histos.root, a poor mans qc, mostly for debugging.
   bool mIgnoreDigitHCHeader{false};    // ignore this header for the purposes of data cross checking use the rdh/cru as authoritative
   bool mIgnoreTrackletHCHeader{false}; // ignore this header for data validity checks, this and the above are use to parse corrupted data.
   std::bitset<16> mOptions;            // stores the incoming of the above bools, useful to be able to send this on instead of the individual ones above
@@ -73,10 +66,8 @@ class DataReaderTask : public Task
   int mTrackletHCHeaderState{0}; // what to do about tracklethcheader, 0 never there, 2 always there, 1 there iff tracklet data, i.e. only there if next word is *not* endmarker 10001000.
   int mHalfChamberWords{0};      // if the halfchamber header is effectively blanked major.minor = 0.0 and halfchamberwords=0 then this value is used as the number of additional words to try recover the data
   int mHalfChamberMajor{0};      // if the halfchamber header is effectively blanked major.minor = 0.0 and halfchamberwords=0 then this value is used as the major version to try recover the data
-  std::string mHistogramsFilename; // filename to use for histograms.
   o2::header::DataDescription mUserDataDescription = o2::header::gDataDescriptionInvalid; // alternative user-provided description to pick
   bool mFixDigitEndCorruption{false};                                                     // fix the parsing of corrupt end of digit data. bounce over it.
-  o2::trd::TRDDataCountersPerTimeFrame mTimeFrameStats;                                   // TODO for compressed data this is going to come in for each subtimeframe and we need to collate them.
   uint64_t mDigitPreviousTotal;                                                           // store the previous timeframes totals for tracklets and digits, to be able to get a diferential total
   uint64_t mTrackletsPreviousTotal;
 };

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/EventRecord.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/EventRecord.h
@@ -70,6 +70,7 @@ class EventRecord
 
   //statistics stuff these get passed to the per tf data at the end of the timeframe,
   //but as we read in per link, events are seperated hence these counters
+  const TRDDataCountersPerEvent& getEventStats() const { return mEventStats; }
   void clearStats();
   void incTrackletTime(double timeadd) { mEventStats.mTimeTakenForTracklets += timeadd; }
 
@@ -79,9 +80,7 @@ class EventRecord
   void incWordsRejected(int count) { mEventStats.mWordsRejected += count; } // words read in
   void incTrackletsFound(int count) { mEventStats.mTrackletsFound += count; }
   void incDigitsFound(int count) { mEventStats.mDigitsFound += count; }
-  void setDataPerLink(int link, int length)
-  { /* mEventStats.mLinkLength[link] = length;*/
-  }
+
   //std::array<uint8_t, 1080> mLinkErrorFlag{}; //status of the error flags for this event, 8bit values from cru halfchamber header.
   bool operator==(const EventRecord& o) const
   {
@@ -94,12 +93,12 @@ class EventRecord
   }
 
   void incStats(int tracklets, int digits, int wordsread, int wordsrejected);
-  o2::trd::TRDDataCountersPerEvent mEventStats;
 
  private:
   BCData mBCData;                       /// orbit and Bunch crossing data of the physics trigger
   std::vector<Digit> mDigits{};         /// digit data, for this event
   std::vector<Tracklet64> mTracklets{}; /// tracklet data, for this event
+  TRDDataCountersPerEvent mEventStats{};
   //statistics stuff these get passed to the per tf data at the end of the timeframe,
   //but as we read in per link, events are seperated hence these counters
 };

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/TrackletsParser.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/TrackletsParser.h
@@ -37,7 +37,7 @@ class TrackletsParser
   void setData(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>* data) { mData = data; }
   int Parse(); // presupposes you have set everything up already.
   int Parse(std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>* data, std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator start, std::array<uint32_t, o2::trd::constants::HBFBUFFERMAX>::iterator end, TRDFeeID feeid, int robside,
-            int detector, int stack, int layer, EventRecord* eventrecord, EventStorage* eventrecords, std::bitset<16> option, bool cleardigits = false, int usetracklethcheader = 0);
+            int detector, int stack, int layer, EventRecord* eventrecord, EventStorage* eventrecords, std::bitset<16> option, int usetracklethcheader = 0);
   void setVerbose(bool verbose, bool header = false, bool data = false)
   {
     mVerbose = verbose;
@@ -74,13 +74,13 @@ class TrackletsParser
     if (side > 1 || side < 0) {
       side = 0;
     }
-    if (mFEEID.supermodule > 17 || mFEEID.supermodule < 0) {
+    if (mFEEID.supermodule > 17) {
       sector = 0;
     }
-    if (mStack > 4 || mStack < 0) {
+    if (mStack > 4) {
       stack = 0;
     }
-    if (layer > 5 || mLayer < 0) {
+    if (layer > 5) {
       layer = 0;
     }
     // error is too big ?

--- a/Detectors/TRD/reconstruction/src/CruCompressorTask.cxx
+++ b/Detectors/TRD/reconstruction/src/CruCompressorTask.cxx
@@ -40,12 +40,6 @@ namespace trd
 void CruCompressorTask::init(InitContext& ic)
 {
   LOG(info) << "FLP Compressore Task init";
-
-  auto finishFunction = [this]() {
-    mReader.checkSummary();
-  };
-
-  ic.services().get<CallbackService>().set(CallbackService::Id::Stop, finishFunction);
 }
 
 uint64_t CruCompressorTask::buildEventOutput()
@@ -65,15 +59,16 @@ uint64_t CruCompressorTask::buildEventOutput()
   std::vector<o2::trd::TriggerRecord> ir;
   std::vector<o2::trd::Tracklet64> tracklets;
   std::vector<o2::trd::Digit> digits;
-  mReader.getParsedObjects(tracklets, digits, ir);
   trackletheader->bc = ir[0].getBCData().bc;
   trackletheader->orbit = ir[0].getBCData().orbit;
   trackletheader->padding = 0xeeee;
   trackletheader->size = mReader.sumTrackletsFound() * 8; // to get to bytes. TODO compare to getTrackletsFound
+  /*
   for (auto tracklet : mReader.getTracklets(ir[0].getBCData())) {
     //convert tracklet to 64 bit and add to blob
     mOutBuffer[currentpos++] = tracklet.getTrackletWord();
   }
+  */
   CompressedRawTrackletDigitSeperator* tracklettrailer = (CompressedRawTrackletDigitSeperator*)&mOutBuffer[currentpos];
   tracklettrailer->word = trailer;
   currentpos++;
@@ -82,6 +77,7 @@ uint64_t CruCompressorTask::buildEventOutput()
   digitheader->format = 2;
   digitheader->eventtime = 99;
 
+  /*
   for (auto digit : mReader.getDigits(ir[0].getBCData())) {
     uint64_t* word;
     word = &mOutBuffer[currentpos];
@@ -96,6 +92,7 @@ uint64_t CruCompressorTask::buildEventOutput()
     mcmheader.word = (*word) >> 32;
     currentpos++;
   }
+  */
   CompressedRawTrackletDigitSeperator* digittrailer = (CompressedRawTrackletDigitSeperator*)&mOutBuffer[currentpos];
   digittrailer->word = trailer;
   currentpos++;

--- a/Detectors/TRD/reconstruction/src/CruRawReader.cxx
+++ b/Detectors/TRD/reconstruction/src/CruRawReader.cxx
@@ -39,94 +39,48 @@
 #include <array>
 #include <numeric>
 
+using namespace o2::trd::constants;
+
 namespace o2::trd
 {
 
-bool CruRawReader::skipRDH()
+void CruRawReader::configure(int tracklethcheader, int halfchamberwords, int halfchambermajor, std::bitset<16> options)
 {
-  // check rdh for being empty or only padding words.
-  if (o2::raw::RDHUtils::getMemorySize(mOpenRDH) == o2::raw::RDHUtils::getHeaderSize(mOpenRDH)) {
-    //empty rdh so we want to avoid parsing it for cru data.
-    if (mVerbose) {
-      LOG(info) << " skipping rdh (empty) packetcount of: " << std::hex << o2::raw::RDHUtils::getPacketCounter(mOpenRDH);
-    }
-    return true;
-  } else {
-
-    if (mHBFPayload[0] == o2::trd::constants::CRUPADDING32 && mHBFPayload[0] == o2::trd::constants::CRUPADDING32) {
-      //event only contains paddings words.
-      if (mVerbose) {
-        LOG(info) << " skipping rdh (padding) with packetcounter of: " << std::hex << o2::raw::RDHUtils::getPacketCounter(mOpenRDH);
-      }
-      // mDataPointer+= o2::raw::RDHUtils::getOffsetToNext()/4;
-      auto rdh = reinterpret_cast<const o2::header::RDHAny*>(mDataPointer);
-      mDataPointer += o2::raw::RDHUtils::getOffsetToNext(rdh) / 4;
-      //mDataPointer=reinterpret_cast<const uint32_t*>(reinterpret_cast<const char*>(rdh) + o2::raw::RDHUtils::getOffsetToNext(rdh));
-      return true;
-      return true;
-    } else {
-      return false;
-    }
-  }
+  mVerbose = options[TRDVerboseBit];
+  mHeaderVerbose = options[TRDHeaderVerboseBit];
+  mDataVerbose = options[TRDDataVerboseBit];
+  mFixDigitEndCorruption = options[TRDFixDigitCorruptionBit];
+  mTrackletHCHeaderState = tracklethcheader;
+  mHalfChamberWords = halfchamberwords;
+  mHalfChamberMajor = halfchambermajor;
+  mOptions = options;
+  mTimeBins = TIMEBINS; // set to value from constants incase the DigitHCHeader1 header is not present.
+  mPreviousDigitHCHeadersvnver = 0xffffffff;
+  mPreviousDigitHCHeadersvnrver = 0xffffffff;
 }
 
-void CruRawReader::OutputHalfCruRawData()
+void CruRawReader::incrementErrors(int hist, int sector, int side, int stack, int layer)
 {
-  LOG(info) << "Full 1/2 CRU dump begin  **************************  FEEID:0x" << std::hex << mFEEID.word;
-  for (int z = 0; z < 15; ++z) {
-    LOG(info) << "link " << z << " length : " << mCurrentHalfCRULinkLengths[z] << " (256bit rows)";
+  if (sector > 17 || sector < -1) {
+    sector = 0;
   }
-  int linkcount = 0;
-  uint32_t linkzsum = 0;
-  int bufferoffset = 0;
-  uint32_t totalhalfcrulength = std::accumulate(mCurrentHalfCRULinkLengths.begin(),
-                                                mCurrentHalfCRULinkLengths.end(),
-                                                decltype(mCurrentHalfCRULinkLengths)::value_type(0));
-  totalhalfcrulength *= 8; //convert from 256 bits to 32 bits.
-  LOGP(info, "CRH bufferoffset:{0:06d} :: {1:08x} {2:08x}  {3:08x} {4:08x} {5:08x} {6:08x} {7:08x} {8:08x} ", bufferoffset, HelperMethods::swapByteOrderreturn(mHBFPayload[bufferoffset]), HelperMethods::swapByteOrderreturn(mHBFPayload[bufferoffset + 1]), HelperMethods::swapByteOrderreturn(mHBFPayload[bufferoffset + 2]), HelperMethods::swapByteOrderreturn(mHBFPayload[bufferoffset + 3]), HelperMethods::swapByteOrderreturn(mHBFPayload[bufferoffset + 4]), HelperMethods::swapByteOrderreturn(mHBFPayload[bufferoffset + 5]), HelperMethods::swapByteOrderreturn(mHBFPayload[bufferoffset + 6]), HelperMethods::swapByteOrderreturn(mHBFPayload[bufferoffset + 7]));
-  bufferoffset += 8;
-  LOGP(info, "CRH bufferoffset:{0:06d} :: {1:08x} {2:08x}  {3:08x} {4:08x} {5:08x} {6:08x} {7:08x} {8:08x} ", bufferoffset, HelperMethods::swapByteOrderreturn(mHBFPayload[bufferoffset]), HelperMethods::swapByteOrderreturn(mHBFPayload[bufferoffset + 1]), HelperMethods::swapByteOrderreturn(mHBFPayload[bufferoffset + 2]), HelperMethods::swapByteOrderreturn(mHBFPayload[bufferoffset + 3]), HelperMethods::swapByteOrderreturn(mHBFPayload[bufferoffset + 4]), HelperMethods::swapByteOrderreturn(mHBFPayload[bufferoffset + 5]), HelperMethods::swapByteOrderreturn(mHBFPayload[bufferoffset + 6]), HelperMethods::swapByteOrderreturn(mHBFPayload[bufferoffset + 7]));
-  int outputoffset = 2;
-  bufferoffset += 8;
-  int olengthoffset0 = 0;
-  while (olengthoffset0 < totalhalfcrulength) {
-    bufferoffset = olengthoffset0 + 16;
-    if (mCurrentHalfCRULinkLengths[linkcount] == 0) {
-      //output nothing, but state link empty
-      LOG(info) << "empty link link:" << linkcount;
-      linkcount++;
-    } else {
-      LOGP(info, "0x{0:06x} :: {1:08x} {2:08x}  {3:08x} {4:08x} {5:08x} {6:08x} {7:08x} {8:08x} ", olengthoffset0, HelperMethods::swapByteOrderreturn(mHBFPayload[bufferoffset]), HelperMethods::swapByteOrderreturn(mHBFPayload[bufferoffset + 1]), HelperMethods::swapByteOrderreturn(mHBFPayload[bufferoffset + 2]), HelperMethods::swapByteOrderreturn(mHBFPayload[bufferoffset + 3]), HelperMethods::swapByteOrderreturn(mHBFPayload[bufferoffset + 4]), HelperMethods::swapByteOrderreturn(mHBFPayload[bufferoffset + 5]), HelperMethods::swapByteOrderreturn(mHBFPayload[bufferoffset + 6]), HelperMethods::swapByteOrderreturn(mHBFPayload[bufferoffset + 7]));
-      olengthoffset0 += 8; // advance a whole cru word of 256 bits or 8 32 bit words
-      bufferoffset += 8;   // advance a whole cru word of 256 bits or 8 32 bit words
-      if (olengthoffset0 == mCurrentHalfCRULinkLengths[linkcount] * 8 + linkzsum * 8) {
-        LOG(info) << "end of link :" << linkcount;
-        linkzsum += mCurrentHalfCRULinkLengths[linkcount];
-        linkcount++;
-      }
-    }
+  if (stack > 4 || stack < 0) {
+    stack = 0;
   }
-  LOG(info) << "CRU Next 16 words just for info";
-  for (int bufferoffset = totalhalfcrulength; bufferoffset < totalhalfcrulength + 16; bufferoffset += 8) {
-    LOGP(info, "0x{0:06x} :: {1:08x} {2:08x}  {3:08x} {4:08x} {5:08x} {6:08x} {7:08x} {8:08x} ", bufferoffset, mHBFPayload[bufferoffset], mHBFPayload[bufferoffset + 1], mHBFPayload[bufferoffset + 2], mHBFPayload[bufferoffset + 3], mHBFPayload[bufferoffset + 4], mHBFPayload[bufferoffset + 5], mHBFPayload[bufferoffset + 6], mHBFPayload[bufferoffset + 7]);
+  if (layer > 5 || layer < 0) {
+    layer = 0;
   }
-  LOG(info) << "Full 1/2 CRU dump end ***************";
-}
-
-void CruRawReader::dumpRDHAndNextHeader(const o2::header::RDHAny* rdh)
-{
-  LOG(info) << "######################### Dumping RDH incoming buffer ##########################";
-  //  o2::raw::RDHUtils::printRDH(rdh);
-  LOG(info) << "Now for the buffer breakdown";
-  auto offsetToNext = o2::raw::RDHUtils::getOffsetToNext(rdh);
-  for (int i = 0; i < offsetToNext / 4; ++i) {
-    LOG(info) << "ii:" << i << " 0x" << std::hex << *((uint32_t*)rdh + i); //*(uint32_t*)(reinterpret_cast<const uint32_t*>(rdh) + i);
+  if (sector == -1) {
+    sector = (unsigned int)mFEEID.supermodule;
+    side = (unsigned int)mFEEID.side;
+    layer = 0;
+    stack = (unsigned int)mFEEID.endpoint;
+    // encode the endpoint into the stack for the 2d plots. This is for those situations where you can not know stack/layer at the time of the error.
   }
-  LOG(info) << "Next 8....";
-  for (int i = 0; i < 8; ++i) {
-    LOG(info) << "iii:" << i << " 0x" << std::hex << *((uint32_t*)rdh + i + offsetToNext); //*(uint32_t*)(reinterpret_cast<const uint32_t*>(rdh) + i+offsetToNext);
+  mEventRecords.incParsingError(hist, sector, side, stack * NLAYER + layer);
+  if (mVerbose) {
+    LOG(info) << "Parsing error: " << hist << " sector:" << sector << " side:" << side << " stack:" << stack << " layer:" << layer;
   }
-  LOG(info) << "######################### Finished RDH incoming buffer ##########################";
 }
 
 bool CruRawReader::checkRDH(const o2::header::RDHAny* rdh)
@@ -135,27 +89,35 @@ bool CruRawReader::checkRDH(const o2::header::RDHAny* rdh)
   TRDFeeID feeid;
   feeid.word = o2::raw::RDHUtils::getFEEID(rdh);
   if (((feeid.word) >> 4) == 0xfff) { // error condition is 0xfff? as the end point is known to the cru, but the rest is configured.
-    if (mMaxWarnPrinted > 0) {
-      LOG(warn) << "failed due to 0xfff? : " << std::hex << feeid.word << " whole feeid : " << std::hex << (unsigned int)feeid.word;
-      checkNoWarn();
+    if (mMaxErrsPrinted > 0) {
+      LOG(error) << "RDH check failed due to 0xfff. FLP not configured, call TRD on call. Whole feeid = " << std::hex << (unsigned int)feeid.word;
+      checkNoErr();
     }
     incrementErrors(TRDFEEIDIsFFFF, 0, 0, 0, 0);
     return false;
   }
   if (feeid.supermodule > 17) {
     if (mMaxWarnPrinted > 0) {
-      LOG(warn) << "failed due to supermodule :  " << std::dec << (int)feeid.supermodule << " whole feeid : " << std::hex << (unsigned int)feeid.word;
+      LOG(warn) << "Wrong supermodule number " << std::dec << (int)feeid.supermodule << " detected in RDH. Whole feeid : " << std::hex << (unsigned int)feeid.word;
       checkNoWarn();
     }
     incrementErrors(TRDFEEIDBadSector, 0, 0, 0, 0);
     return false;
   }
+  if (o2::raw::RDHUtils::getMemorySize(rdh) <= 0) {
+    if (mMaxWarnPrinted > 0) {
+      LOG(warn) << "Received RDH header with invalid memory size (<= 0) ";
+      checkNoWarn();
+    }
+    incrementErrors(TRDParsingBadRDHMemSize, 0, 0, 0, 0);
+    return false;
+  }
   return true;
 }
 
-bool CruRawReader::compareRDH(const o2::header::RDHAny* firstrdh, const o2::header::RDHAny* rdh)
+bool CruRawReader::compareRDH(const o2::header::RDHAny* rdhPrev, const o2::header::RDHAny* rdhCurr)
 {
-  if (o2::raw::RDHUtils::getFEEID(firstrdh) != o2::raw::RDHUtils::getFEEID(rdh)) {
+  if (o2::raw::RDHUtils::getFEEID(rdhPrev) != o2::raw::RDHUtils::getFEEID(rdhCurr)) {
     if (mMaxWarnPrinted > 0) {
       LOG(warn) << "ERDH FEEID are not identical in rdh.";
       checkNoWarn();
@@ -163,7 +125,7 @@ bool CruRawReader::compareRDH(const o2::header::RDHAny* firstrdh, const o2::head
     incrementErrors(TRDParsingBadRDHFEEID, 0, 0, 0, 0);
     return false;
   }
-  if (o2::raw::RDHUtils::getEndPointID(firstrdh) != o2::raw::RDHUtils::getEndPointID(rdh)) {
+  if (o2::raw::RDHUtils::getEndPointID(rdhPrev) != o2::raw::RDHUtils::getEndPointID(rdhCurr)) {
     if (mMaxWarnPrinted > 0) {
       LOG(warn) << "ERDH  EndPointID are not identical in rdh.";
       checkNoWarn();
@@ -171,7 +133,7 @@ bool CruRawReader::compareRDH(const o2::header::RDHAny* firstrdh, const o2::head
     incrementErrors(TRDParsingBadRDHEndPoint, 0, 0, 0, 0);
     return false;
   }
-  if (o2::raw::RDHUtils::getTriggerOrbit(firstrdh) != o2::raw::RDHUtils::getTriggerOrbit(rdh)) {
+  if (o2::raw::RDHUtils::getTriggerOrbit(rdhPrev) != o2::raw::RDHUtils::getTriggerOrbit(rdhCurr)) {
     if (mMaxWarnPrinted > 0) {
       LOG(warn) << "ERDH  Orbit are not identical in rdh.";
       checkNoWarn();
@@ -179,7 +141,7 @@ bool CruRawReader::compareRDH(const o2::header::RDHAny* firstrdh, const o2::head
     incrementErrors(TRDParsingBadRDHOrbit, 0, 0, 0, 0);
     return false;
   }
-  if (o2::raw::RDHUtils::getCRUID(firstrdh) != o2::raw::RDHUtils::getCRUID(rdh)) {
+  if (o2::raw::RDHUtils::getCRUID(rdhPrev) != o2::raw::RDHUtils::getCRUID(rdhCurr)) {
     if (mMaxWarnPrinted > 0) {
       LOG(warn) << "ERDH  CRUID are not identical in rdh.";
       checkNoWarn();
@@ -187,7 +149,7 @@ bool CruRawReader::compareRDH(const o2::header::RDHAny* firstrdh, const o2::head
     incrementErrors(TRDParsingBadRDHCRUID, 0, 0, 0, 0);
     return false;
   }
-  if (o2::raw::RDHUtils::getPacketCounter(firstrdh) == o2::raw::RDHUtils::getPacketCounter(rdh) + 1) {
+  if (o2::raw::RDHUtils::getPacketCounter(rdhPrev) == o2::raw::RDHUtils::getPacketCounter(rdhCurr)) {
     if (mMaxWarnPrinted > 0) {
       LOG(warn) << "ERDH  PacketCounters are not sequential in rdh.";
       checkNoWarn();
@@ -198,214 +160,113 @@ bool CruRawReader::compareRDH(const o2::header::RDHAny* firstrdh, const o2::head
   return true;
 }
 
-bool CruRawReader::processHBFs(int datasizealreadyread, bool verbose)
+int CruRawReader::processHBFs()
 {
-  if (mHeaderVerbose) {
-    LOG(info) << "PROCESS HBF starting at " << std::hex << (void*)mDataPointer << " already read in : " << datasizealreadyread;
-  }
-  mDataRDH = reinterpret_cast<const o2::header::RDHAny*>(mDataPointer);
-  mOpenRDH = reinterpret_cast<const o2::header::RDHAny*>((const char*)mDataPointer);
-  auto rdh = mDataRDH;
-  uint32_t totaldataread = 0;
-  if (mHeaderVerbose) {
-    LOG(info) << " mem : " << o2::raw::RDHUtils::getMemorySize(rdh) << " headersize : " << o2::raw::RDHUtils::getHeaderSize(rdh);
-  }
-  mState = CRUStateHalfCRUHeader;
-  uint32_t currentsaveddatacount = 0;
+
+  const o2::header::RDHAny* rdh = reinterpret_cast<const o2::header::RDHAny*>(mCurrRdhPtr);
+  auto rdhPrevious = rdh;
+  bool firstRdh = true;
+  uint32_t totalDataInputSize = 0;
   mTotalHBFPayLoad = 0;
-  int loopcount = 0;
-  int counthalfcru = 0;
-  // store the endpoint and cruid for later checking of subsequent rdh for integrity
-  const o2::header::RDHAny* firstRDH;
-  firstRDH = reinterpret_cast<const o2::header::RDHAny*>(reinterpret_cast<const char*>(rdh));
-  mHBFoffset32 = 0;
+
   // loop until RDH stop header
   while (!o2::raw::RDHUtils::getStop(rdh)) { // carry on till the end of the event.
     if (mHeaderVerbose) {
-      LOG(info) << "----------------------------------------------";
-      LOG(info) << " rdh first word 0x" << std::hex << (uint32_t)*mDataPointer;
-      LOG(info) << " rdh first word is sitting at 0x" << std::hex << (void*)mDataPointer;
+      LOG(info) << "Current RDH is as follows:";
       o2::raw::RDHUtils::printRDH(rdh);
-      dumpRDHAndNextHeader(rdh);
     }
     if (!checkRDH(rdh)) {
-      if (mMaxErrsPrinted > 0) {
-        LOG(error) << "RDH validity failure : Call on call, an flp is not configured. Check the tracklets per halfchamber id for gaps of 30 or larger to figure out which one, feeid:" << std::hex << o2::raw::RDHUtils::getFEEID(rdh) << " cruid:" << o2::raw::RDHUtils::getCRUID(rdh) << " packetcounter:" << o2::raw::RDHUtils::getPacketCounter(rdh);
-        checkNoErr();
-      }
-      return false; // dump and run.
+      return -1;
     }
-    if (!compareRDH(firstRDH, rdh)) { // compare previous rdh detector info to the current rdh, they must be the same.
-      return false;                   // dump and run.
+    if (!firstRdh && !compareRDH(rdhPrevious, rdh)) {
+      // previous and current RDHs are inconsistent, this should not happen
+      return -1;
     }
-    firstRDH = rdh;
+    rdhPrevious = rdh;
+    firstRdh = false;
     auto headerSize = o2::raw::RDHUtils::getHeaderSize(rdh);
     auto memorySize = o2::raw::RDHUtils::getMemorySize(rdh);
-    if (memorySize == 0) {
-      LOG(warn) << "rdh memory size is zero";
-      return false; // get out of here if the rdh says it has nothing.
-    }
     auto offsetToNext = o2::raw::RDHUtils::getOffsetToNext(rdh);
     auto rdhpayload = memorySize - headerSize;
     mFEEID.word = o2::raw::RDHUtils::getFEEID(rdh);       //TODO change this and just carry around the curreht RDH
     mCRUEndpoint = o2::raw::RDHUtils::getEndPointID(rdh); // the upper or lower half of the currently parsed cru 0-14 or 15-29
     mCRUID = o2::raw::RDHUtils::getCRUID(rdh);
     mIR = o2::raw::RDHUtils::getTriggerIR(rdh);
-    int packetCount = o2::raw::RDHUtils::getPacketCounter(rdh);
-    //mDataEndPointer = (uint32_t*)((char*)rdh + offsetToNext);
-    if (mOptions[TRDM1Debug]) {
-      LOG(info) << "mFEEID:" << mFEEID.word << " mCRUEndpoint:" << mCRUEndpoint << " mCRUID:" << mCRUID << " packetCount:" << packetCount << "rdhpayload:" << rdhpayload << " offsettonext:" << offsetToNext << " dmDataEndPointer(after move to rdh+offsetToNext): 0x" << std::hex << (void*)mDataEndPointer << " rdh is currently at 0x" << std::hex << (void*)rdh;
-    }
-    // copy the contents of the current rdh into the buffer to be parsed
-    std::memcpy((char*)&mHBFPayload[0] + currentsaveddatacount, ((char*)rdh) + headerSize, rdhpayload);
+
+    // copy the contents of the current RDH into the buffer to be parsed, RDH payload is memory size minus header size
+    std::memcpy((char*)&mHBFPayload[0] + mTotalHBFPayLoad, ((char*)rdh) + headerSize, rdhpayload);
     mTotalHBFPayLoad += rdhpayload;
-    currentsaveddatacount += rdhpayload;
-    totaldataread += offsetToNext;
+    totalDataInputSize += offsetToNext;
     // move to next rdh
-    auto oldRDH = rdh;
     rdh = reinterpret_cast<const o2::header::RDHAny*>(reinterpret_cast<const char*>(rdh) + offsetToNext);
-    //increment the data pointer by the size of the stop rdh.
-    mDataPointer = reinterpret_cast<const uint32_t*>(reinterpret_cast<const char*>(rdh) + o2::raw::RDHUtils::getOffsetToNext(rdh));
+    // increment the data pointer by the size of the next RDH.
+    mCurrRdhPtr = reinterpret_cast<const char*>(rdh) + offsetToNext;
 
     if (mHeaderVerbose) {
-      if (!o2::raw::RDHUtils::getStop(rdh)) {
-        LOG(info) << "Next rdh is not a stop, and has a header size of " << o2::raw::RDHUtils::getHeaderSize(rdh) << " and memsize of : " << o2::raw::RDHUtils::getMemorySize(rdh);
-        LOG(info) << "rdh 0x" << (void*)rdh << " bufsize:" << mDataBufferSize << " payload start: 0x" << (void*)&mHBFPayload[0] << " mHBFoffset32 " << std::dec << mHBFoffset32;
-        LOGP(info, " rdh::: {0:08x} {1:08x} {2:08x}  {3:08x} {4:08x} {5:08x} {6:08x} {7:08x} ", *((uint32_t*)rdh), *((uint32_t*)rdh + 1), *((uint32_t*)rdh + 2), *((uint32_t*)rdh + 3), *((uint32_t*)rdh + 4), *((uint32_t*)rdh + 5), *((uint32_t*)rdh + 6), *((uint32_t*)rdh + 7), *((uint32_t*)rdh + 8));
-      } else {
-        LOG(info) << "Next rdh is a stop, and we have moved to it.";
-      }
+      LOG(info) << "Next RDH is as follows:";
+      o2::raw::RDHUtils::printRDH(rdh);
     }
 
-    if (o2::raw::RDHUtils::getStop(rdh) || o2::raw::RDHUtils::getOffsetToNext(rdh) < mDataBufferSize - mHBFoffset32) {
-      // we can still copy into this buffer.
-    } else {
+    if (!o2::raw::RDHUtils::getStop(rdh) && offsetToNext >= mCurrRdhPtr - mDataBufferPtr) {
       if (mMaxWarnPrinted > 0) {
-        LOG(warn) << "rdh bounds fail offsetToNext:" << offsetToNext << " rdh 0x" << (void*)rdh << " bufsize:" << mDataBufferSize << " payload start: 0x" << (void*)&mHBFPayload[0] << " mHBFoffset32 " << std::dec << mHBFoffset32;
+        LOGP(warn, "RDH offsetToNext = {} is larger than it can possibly be. Remaining data in the buffer = {}", offsetToNext, mCurrRdhPtr - mDataBufferPtr);
         checkNoWarn();
       }
-        if (mVerbose) {
-          LOG(info) << "rdh bounds fail offsetToNext:" << offsetToNext << " rdh 0x" << (void*)rdh << " bufsize:" << mDataBufferSize << " payload start: 0x" << (void*)&mHBFPayload[0] << " mHBFoffset32 " << std::dec << mHBFoffset32;
-        }
-        return false;
+      return -1;
     }
   }
 
   // at this point the entire HBF data payload is sitting in mHBFPayload and the total data count is mTotalHBFPayLoad
+  int iteration = 0;
+  mHBFoffset32 = 0;
   while ((mHBFoffset32 < ((mTotalHBFPayLoad) / 4))) {
     if (mHeaderVerbose) {
-      LOG(info) << "Looping over cruheaders in HBF, loop count " << counthalfcru << " current offset is" << mHBFoffset32 << " total payload is " << mTotalHBFPayLoad / 4 << "  raw :" << mTotalHBFPayLoad;
+      LOGP(info, "Current half-CRU iteration {}, current offset in the HBF payload {}, total payload in number of 32-bit words {}", iteration, mHBFoffset32, mTotalHBFPayLoad / 4);
     }
-    int halfcruprocess = processHalfCRU(mHBFoffset32, counthalfcru, currentsaveddatacount);
-    if (mVerbose) {
-      switch (halfcruprocess) {
-        case -1:
-          LOG(info) << "ignored rdh event ";
-          break;
-        case 0:
-          LOG(warn) << "figure out what now";
-          break;
-        case 1:
-          LOG(info) << "all good parsing half cru";
-          LOG(info) << " mHBFoffset32:" << mHBFoffset32 << " and mTotalHBFPayload/4 : " << mTotalHBFPayLoad / 4;
-          break;
-        case 2:
-          LOG(info) << "all good parsing half cru was blank double 0xe event";
-          break;
-        default:
-          LOG(info) << "unhandled return from processhalfcru of : " << halfcruprocess;
-          break;
-      }
-    }
+    int halfcruprocess = processHalfCRU(iteration);
+
     if (halfcruprocess == -2) {
       //dump rest of this rdh payload, something screwed up.
-      mHBFoffset32 = mTotalHBFPayLoad / 4;
+      break;
     }
-    counthalfcru++;
+    iteration++;
   } // loop of halfcru's while there is still data in the heart beat frame.
-  if (totaldataread > 0) {
-    mDatareadfromhbf = totaldataread;
-  }
-  return true; //totaldataread;
+
+  return totalDataInputSize;
 }
 
-int CruRawReader::checkTrackletHCHeader()
+void CruRawReader::checkDigitHCHeader(int halfChamberIdRef)
 {
-  // index 0 is rdh data, index 1 is ori calculated data
-  auto currentsector = mTrackletHCHeader.supermodule;
-  auto currentlayer = mTrackletHCHeader.layer;
-  auto currentstack = mTrackletHCHeader.stack;
-  auto currentside = mTrackletHCHeader.side;
-  if (!mOptions[TRDIgnoreTrackletHCHeaderBit]) { // we take half chamber header as authoritive
-    return 0;
-  }
-  return 0; // for now always ignore, something is wrong with it, yet to be determined, tdp and header dont match.  FIXME!
-}
+  // compare the half chamber ID from the digit HC header with the reference one obtained from the link ID
+  int halfChamberIdHeader = mDigitHCHeader.supermodule * NHCPERSEC + mDigitHCHeader.stack * NLAYER * 2 + mDigitHCHeader.layer * 2 + mDigitHCHeader.side;
 
-int CruRawReader::checkDigitHCHeader()
-{
-  // index 0 is rdh data, index 1 is ori calculated data
-  auto currentsector = mDigitHCHeader.supermodule;
-  auto currentlayer = mDigitHCHeader.layer;
-  auto currentstack = mDigitHCHeader.stack;
-  auto currentside = mDigitHCHeader.side;
-  //check rdh info vs half chamber header
-  if (!mOptions[TRDIgnoreDigitHCHeaderBit]) { // we take half chamber header as authoritive
-    // can use digithcheader for cross checking the sector/stack/layer
-    /*if (currentstack != mStack[0]) { // || currentstack != mStack[1]) {
-      //stack mismatch
-      //count these
-      incrementErrors(TRDParsingDigitStackMismatch, mFEEID.supermodule, mHalfChamberSide[0], mStack[0], mLayer[0]);
+  if (!mOptions[TRDIgnoreDigitHCHeaderBit]) {
+    if (halfChamberIdHeader != halfChamberIdRef) {
+      incrementErrors(TRDParsingDigitHCHeaderMismatch, mFEEID.supermodule, halfChamberIdRef % 2, HelperMethods::getStack(halfChamberIdRef / 2), HelperMethods::getLayer(halfChamberIdRef / 2));
     }
-    if (currentlayer != mLayer[0]) { //|| currentlayer != mLayer[1]) {
-      //layer mismatch
-      //count these
-      incrementErrors(TRDParsingDigitLayerMismatch, mFEEID.supermodule, mHalfChamberSide[0], mStack[0], mLayer[0]);
-    }*/
-    // taken out as stack and layer changes with in a cru endoint, or halfcruheder of 15 links.
-    // need to rather check that the subsequent ones are correct relative to the previous ones, but that can come in other rawreader.
-    // sector does not change.
-    if (currentsector != mSector[0]) { //} || currentsector != mSector[1]) {
-      //sector mismatch, mDetector comes in from a construction via the feeid and ori.
-      //count these
-      incrementErrors(TRDParsingDigitSectorMismatch, mFEEID.supermodule, mHalfChamberSide[0], mStack[0], mLayer[0]);
-    }
-    mSector[2] = currentsector; //from hc header treating it as authoritative
-    mLayer[2] = currentlayer;
-    mStack[2] = currentstack;
-    mDetector[2] = mLayer[2] + mStack[2] * constants::NLAYER + mSector[2] * constants::NLAYER * constants::NSTACK;
-    return 2;
-  } else { // ignore the halfcahmber headers contents so use the rdh
-    //take mDetector, layer and stack from the rdh/cru, we have those already assigned on entry to here
-    return 0; // the index in mSector/mStack etc.
   }
 }
 
-int CruRawReader::parseDigitHCHeader()
+int CruRawReader::parseDigitHCHeader(int hcid)
 {
-  //mHBFoffset is the current offset into the current buffer,
+  // mHBFoffset32 is the current offset into the current buffer,
   //
-  uint32_t dhcheader = mHBFPayload[mHBFoffset32++];
+  mDigitHCHeader.word = mHBFPayload[mHBFoffset32++];
   std::array<uint32_t, 4> headers{0};
   if (mOptions[TRDByteSwapBit]) {
     // byte swap if needed.
-    o2::trd::HelperMethods::swapByteOrder(dhcheader);
+    o2::trd::HelperMethods::swapByteOrder(mDigitHCHeader.word);
   }
-  mDigitHCHeader.word = dhcheader;
   if (mDigitHCHeader.major == 0 && mDigitHCHeader.minor == 0 && mDigitHCHeader.numberHCW == 0) {
     //hack this data into something resembling usable.
     mDigitHCHeader.major = mHalfChamberMajor;
     mDigitHCHeader.minor = 42; // to keep me entertained
     mDigitHCHeader.numberHCW = mHalfChamberWords;
-    if (mHalfChamberWords == 0 || mHalfChamberMajor == 0) {
-      LOG(warn) << "we have a messed up halfchamber header and you have only set the halfchamber command line option to zero, hex dump of data and revisit what it should be.";
-      // already in histograms
-    }
   }
 
   int additionalHeaderWords = mDigitHCHeader.numberHCW;
   if (additionalHeaderWords >= 3) {
-    incrementErrors(TRDParsingDigitHeaderCountGT3, mFEEID.supermodule, mHalfChamberSide[0], mStack[0], mLayer[0]);
+    incrementErrors(TRDParsingDigitHeaderCountGT3, mFEEID.supermodule, hcid % 2, HelperMethods::getStack(hcid / 2), HelperMethods::getLayer(hcid / 2));
     //TODO graph this and stats it
     if (mMaxWarnPrinted > 0) {
       LOG(warn) << "Error parsing DigitHCHeader, too many additional words count=" << additionalHeaderWords << " header:" << std::hex << mDigitHCHeader.word;
@@ -441,19 +302,14 @@ int CruRawReader::parseDigitHCHeader()
           }
           incrementErrors(TRDParsingDigitHeaderWrong1);
         }
-        if ((mDigitHCHeader1.numtimebins > o2::trd::constants::TIMEBINS) || (mDigitHCHeader1.numtimebins < 3)) {
-          // numtimebins is unsigned so no need to check for <1
-          return -1;
-        }
-        mTimeBins = mDigitHCHeader1.numtimebins;
-        if (mTimeBins < 1 && mTimeBins > o2::trd::constants::TIMEBINS) {
-          //sanity check on the hcheader settings
-          mTimeBins = o2::trd::constants::TIMEBINS;
+        if ((mDigitHCHeader1.numtimebins > TIMEBINS) || (mDigitHCHeader1.numtimebins < 3)) {
           if (mMaxWarnPrinted > 0) {
             LOG(warn) << "Time bins in Digit HC Header 1 is " << mDigitHCHeader1.numtimebins << " this is absurd";
             checkNoWarn();
           }
+          return -1;
         }
+        mTimeBins = mDigitHCHeader1.numtimebins;
         break;
       case 2: // header header2;
         if (headersfound.test(1)) {
@@ -514,105 +370,63 @@ int CruRawReader::parseDigitHCHeader()
   return 1;
 }
 
-void CruRawReader::updateLinkErrorGraphs(int currentlinkindex, int supermodule_half, int stack_layer)
+int CruRawReader::processHalfCRU(int iteration)
 {
-  mEventRecords.incLinkErrorFlags(mDetector[0], mHalfChamberSide[0], stack_layer, mCurrentHalfCRULinkErrorFlags[currentlinkindex]);
-  if (mCurrentHalfCRULinkLengths[currentlinkindex] == 0) {
-    mEventRecords.incLinkNoData(mDetector[0], mHalfChamberSide[0], stack_layer);
-  }
-}
-
-int CruRawReader::processHalfCRU(int cruhbfstartoffset, int numberOfPreviousCRU, unsigned int maxdatawrittentobuffer)
-{
-  //It will clean this code up *alot*
   // process a halfcru
-  uint32_t currentlinkindex = 0;
-  uint32_t currentlinkoffset = 0;
-  uint32_t currentlinksize = 0;
-  uint32_t currentlinksize32 = 0;
-  uint32_t linksizeAccum32 = 0;
-  uint32_t sumtrackletwords = 0;
-  uint32_t sumdigitwords = 0;
-  uint32_t sumlinklengths = 0;
-  mDigitWordsRead = 0;
-  mDigitWordsRejected = 0;
-  mTrackletWordsRead = 0;
-  mTrackletWordsRejected = 0;
-  uint32_t cruwordsread = 9;
-  //reject halfcru if it starts with padding words.
-  //TODO put maxdatawrittentobuffer in a qc plot
-  if (mHBFPayload.size() < cruhbfstartoffset || cruhbfstartoffset > maxdatawrittentobuffer) {
-    if (mMaxErrsPrinted > 0) {
-      LOG(warn) << "Error parsing HalfCRUHeader, HBFPayload size = " << mHBFPayload.size() << " payload offset:" << cruhbfstartoffset << " max data written to buffer : " << maxdatawrittentobuffer;
-      checkNoErr();
-    }
-    mHBFoffset32++;
-    incrementErrors(TRDProcessingBadPayloadOrOffset);
-    return -2;
-  }
-  //this should only hit that instance where the cru payload is a "blank event" of o2::trd::constants::CRUPADDING32
-  if (mHBFPayload[cruhbfstartoffset] == o2::trd::constants::CRUPADDING32) { //} && mHBFPayload[cruhbfstartoffset + 1] == o2::trd::constants::CRUPADDING32) {
+
+  // this should only hit that instance where the cru payload is a "blank event" of CRUPADDING32
+  if (mHBFPayload[mHBFoffset32] == CRUPADDING32) {
     if (mVerbose) {
-      LOG(info) << "blank rdh payload data at " << cruhbfstartoffset << ": 0x " << std::hex << mHBFPayload[cruhbfstartoffset] << " and 0x" << mHBFPayload[cruhbfstartoffset + 1];
+      LOG(info) << "blank rdh payload data at " << mHBFoffset32 << ": 0x " << std::hex << mHBFPayload[mHBFoffset32] << " and 0x" << mHBFPayload[mHBFoffset32 + 1];
     }
-    mHBFoffset32++; // increment past the word of the if statement and then any others that might be here.
     int loopcount = 0;
-    while (mHBFPayload[mHBFoffset32] == o2::trd::constants::CRUPADDING32 && loopcount < 8) { // can only ever be an entire 256 bit word hence a limit of 8 here.
+    while (mHBFPayload[mHBFoffset32] == CRUPADDING32 && loopcount < 8) { // can only ever be an entire 256 bit word hence a limit of 8 here.
+      // TODO: check with Guido if it could not actually be more padding words
       mHBFoffset32++;
       mWordsAccepted++;
       loopcount++;
     }
     return 2;
   }
-  if (mTotalHBFPayLoad == 0) {
-    //empty payload
-    return -1;
-  }
+
   auto crustart = std::chrono::high_resolution_clock::now();
   // well then read the halfcruheader.
-  memcpy((char*)&mCurrentHalfCRUHeader, (void*)(&mHBFPayload[cruhbfstartoffset]), sizeof(mCurrentHalfCRUHeader));
-  mHBFoffset32 += sizeof(mCurrentHalfCRUHeader) / 4; // advance past the header.
+  memcpy(&mCurrentHalfCRUHeader, &(mHBFPayload[mHBFoffset32]), sizeof(HalfCRUHeader));
+  mHBFoffset32 += sizeof(HalfCRUHeader) / 4; // advance past the header.
 
   o2::trd::getHalfCRULinkDataSizes(mCurrentHalfCRUHeader, mCurrentHalfCRULinkLengths);
   o2::trd::getHalfCRULinkErrorFlags(mCurrentHalfCRUHeader, mCurrentHalfCRULinkErrorFlags);
-  mTotalHalfCRUDataLength256 = std::accumulate(mCurrentHalfCRULinkLengths.begin(),
-                                               mCurrentHalfCRULinkLengths.end(),
-                                               decltype(mCurrentHalfCRULinkLengths)::value_type(0));
-  mTotalHalfCRUDataLength = mTotalHalfCRUDataLength256 * 32; //convert to bytes.
-  int mTotalHalfCRUDataLength32 = mTotalHalfCRUDataLength256 * 8; //convert to bytes.
+  uint32_t totalHalfCRUDataLength256 = std::accumulate(mCurrentHalfCRULinkLengths.begin(),
+                                                       mCurrentHalfCRULinkLengths.end(),
+                                                       0U);
+  uint32_t totalHalfCRUDataLength32 = totalHalfCRUDataLength256 * 8; // convert to 32-bit words
 
   // in the interests of descerning real corrupt halfcruheaders from the sometimes garbage at the end of a half cru
   // if the first word is clearly garbage assume garbage and not a corrupt halfcruheader.
-  if (numberOfPreviousCRU > 0) {
+  if (iteration > 0) {
     if (mCurrentHalfCRUHeader.EndPoint != mPreviousHalfCRUHeader.EndPoint) {
       incrementErrors(TRDParsingHalfCRUCorrupt);
-      LOG(info) << numberOfPreviousCRU << " current endpont : " << mCurrentHalfCRUHeader.EndPoint << " previous end point : " << mPreviousHalfCRUHeader.EndPoint;
+      LOGF(info, "For current half-CRU index %i we have end point %i, while the previous end point was %i", iteration, mCurrentHalfCRUHeader.EndPoint, mPreviousHalfCRUHeader.EndPoint);
+      mWordsRejected += totalHalfCRUDataLength32;
       return -2;
     }
-    /*if (mCurrentHalfCRUHeader.EventType != mPreviousHalfCRUHeader.EventType) {
-      incrementErrors(TRDParsingHalfCRUCorrupt, mFEEID.supermodule, mHalfChamberSide[0], mStack[0], mLayer[0]);
-      LOG(info) <<numberOfPreviousCRU <<  " current eventtype : " << mCurrentHalfCRUHeader.EventType << " previous eventtype: " <<  mPreviousHalfCRUHeader.EventType << " raw : 0x" << std::hex << mHBFPayload[cruhbfstartoffset];
-    //  return -2;
-    }*/
-    // event type can change wit in a
     if (mCurrentHalfCRUHeader.StopBit != mPreviousHalfCRUHeader.StopBit) {
       incrementErrors(TRDParsingHalfCRUCorrupt);
-      LOG(info) << numberOfPreviousCRU << " current stopbit: " << mCurrentHalfCRUHeader.StopBit << " previous stopbit: " << mPreviousHalfCRUHeader.StopBit;
-      mWordsRejected += mTotalHalfCRUDataLength32;
+      LOGF(info, "For current half-CRU index %i we have stop bit %i, while the previous stop bit was %i", iteration, mCurrentHalfCRUHeader.StopBit, mPreviousHalfCRUHeader.StopBit);
+      mWordsRejected += totalHalfCRUDataLength32;
       return -2;
     }
   }
-  memcpy((char*)&mPreviousHalfCRUHeader, (void*)(&mHBFPayload[cruhbfstartoffset]), sizeof(mCurrentHalfCRUHeader));
+  mPreviousHalfCRUHeader = mCurrentHalfCRUHeader;
+
   //can this half cru length fit into the available space of the rdh accumulated payload
-  if (mTotalHalfCRUDataLength32 > mTotalHBFPayLoad - mHBFoffset32) {
+  if (totalHalfCRUDataLength32 > (mTotalHBFPayLoad / 4) - mHBFoffset32) {
     if (mMaxWarnPrinted > 0) {
-      LOG(warn) << "Next HalfCRU header says it contains more data than in the rdh payloads! " << mTotalHalfCRUDataLength32 << " < " << mTotalHBFPayLoad << "-" << mHBFoffset32 << " sector:side:endpoint: " << (unsigned int)mFEEID.supermodule << ":" << (unsigned int)mFEEID.side << ":" << (unsigned int)mFEEID.endpoint;
+      LOGP(warn, "HalfCRU header says it contains more data ({} 32-bit words) than is remaining in the payload ({} 32-bit words)", totalHalfCRUDataLength32, ((mTotalHBFPayLoad / 4) - mHBFoffset32));
       checkNoWarn();
     }
     incrementErrors(TRDParsingHalfCRUSumLength);
-    mWordsRejected += mTotalHalfCRUDataLength32;
-    mHBFoffset32 += mTotalHalfCRUDataLength32; // go to the end of this halfcruheader and payload.
-
+    mWordsRejected += (mTotalHBFPayLoad / 4) - mHBFoffset32;
     return -2;
   }
   if (!halfCRUHeaderSanityCheck(mCurrentHalfCRUHeader, mCurrentHalfCRULinkLengths, mCurrentHalfCRULinkErrorFlags)) {
@@ -623,27 +437,31 @@ int CruRawReader::processHalfCRU(int cruhbfstartoffset, int numberOfPreviousCRU,
     // let incrementErrors catch the undefined values of sector side stack and layer as if not set it will go so zero in the method, however if set, it means this is the second half cru header, and we have the values from the last one we read which
     // *SHOULD* be the same as this halfcruheader.
     incrementErrors(TRDParsingHalfCRUCorrupt);
-    mWordsRejected += mTotalHalfCRUDataLength32;
-    mHBFoffset32 += mTotalHalfCRUDataLength32; // go to the end of this halfcruheader and payload.
+    mWordsRejected += (mTotalHBFPayLoad / 4) - mHBFoffset32;
     return -2;
   }
 
   //get eventrecord for event we are looking at
   mIR.bc = mCurrentHalfCRUHeader.BunchCrossing; // correct mIR to have the physics trigger bunchcrossing *NOT* the heartbeat trigger bunch crossing.
-  //shift accordingly
-  mIR.bc = mCurrentHalfCRUHeader.BunchCrossing - o2::ctp::TriggerOffsetsParam::Instance().LM_L0;
-  if (mIR.bc < 0) {
+
+  if (o2::ctp::TriggerOffsetsParam::Instance().LM_L0 > (int)mIR.bc) {
+    // applying the configured BC shift would lead to negative BC, hence we reject this trigger
     // dump to the end of this cruhalfchamberheader
-    // data to dump is mTotalHalfCruDataLength32
-    mHBFoffset32 += mTotalHalfCRUDataLength32;   // go to the end of this halfcruheader and payload.
-    mWordsRejected += mTotalHalfCRUDataLength32; // add the rejected data to the accounting;
+    // data to dump is totalHalfCRUDataLength32
+    mHBFoffset32 += totalHalfCRUDataLength32;   // go to the end of this halfcruheader and payload.
+    mWordsRejected += totalHalfCRUDataLength32; // add the rejected data to the accounting;
     incrementErrors(TRDParsingHalfCRUBadBC);
-    return 1; // nothing particularly wrong with the data, we just dont want it, as a trigger problem
+    return 0; // nothing particularly wrong with the data, we just dont want it, as a trigger problem
+  } else {
+    // apply CTP offset shift
+    mIR.bc -= o2::ctp::TriggerOffsetsParam::Instance().LM_L0;
   }
 
   InteractionRecord trdir(mIR);
   mCurrentEvent = &mEventRecords.getEventRecord(trdir);
-  //check for cru errors :
+
+  // check for cru errors :
+  //  TODO make this check configurable? Or do something in case of error flags set?
   int linkerrorcounter = 0;
   for (auto& linkerror : mCurrentHalfCRULinkErrorFlags) {
     if (linkerror != 0) {
@@ -654,14 +472,10 @@ int CruRawReader::processHalfCRU(int cruhbfstartoffset, int numberOfPreviousCRU,
     }
   }
 
-  std::array<uint32_t, 1024>::iterator currentlinkstart = mHBFPayload.begin() + cruhbfstartoffset;
-
   if (mHeaderVerbose) {
     printHalfCRUHeader(mCurrentHalfCRUHeader);
-    OutputHalfCruRawData();
   }
-  std::array<uint32_t, 1024>::iterator linkstart, linkend;
-  int dataoffsetstart32 = sizeof(mCurrentHalfCRUHeader) / 4 + cruhbfstartoffset; // in uint32
+
   //CHECK 1 does rdh endpoint match cru header end point.
   if (mCRUEndpoint != mCurrentHalfCRUHeader.EndPoint) {
     if (mMaxWarnPrinted > 0) {
@@ -672,137 +486,106 @@ int CruRawReader::processHalfCRU(int cruhbfstartoffset, int numberOfPreviousCRU,
     return -2;
   }
 
-  // verify cru header vs rdh header
-  //FEEID has supermodule/layer/stack/side in it.
-  //CRU has
-
-  linkstart = mHBFPayload.begin() + dataoffsetstart32;
-  linkend = mHBFPayload.begin() + dataoffsetstart32;
   //loop over links
-  for (currentlinkindex = 0; currentlinkindex < constants::NLINKSPERHALFCRU; currentlinkindex++) {
-    auto linktimerstart = std::chrono::high_resolution_clock::now(); // measure total processing time
-    mSector[0] = mFEEID.supermodule;
-    mEndPoint[0] = mFEEID.endpoint;
-    mSide[0] = mFEEID.side; // side of detector A/C
-    int hbfoffsetatstartoflink = mHBFoffset32;
-    //stack layer and side map to ori
-    int oriindex = currentlinkindex + constants::NLINKSPERHALFCRU * mEndPoint[0]; // endpoint denotes the pci side, upper or lower for the pair of 15 fibres.
-    FeeParam::unpackORI(oriindex, mSide[0], mStack[1], mLayer[1], mHalfChamberSide[1]);
-    //sadly not all the data is redundant, probably a good thing, so stack and layer and halfchamber side is derived from the ori.
-    mLayer[0] = mLayer[1];
-    mStack[0] = mStack[1];
-    mHalfChamberSide[0] = mHalfChamberSide[1];
-    mSector[1] = oriindex / 30;
-    mSide[1] = mSide[0];
-    mDetector[0] = mStack[0] * constants::NLAYER + mLayer[0] + mSector[0] * constants::NLAYER * constants::NSTACK;
-    mDetector[1] = mStack[1] * constants::NLAYER + mLayer[1] + mSector[1] * constants::NLAYER * constants::NSTACK;
-    int supermodule_half = mSector[0] * 2 + mHalfChamberSide[0]; // will just go with the rdh one here its only for the hack graphing purposes.
-    float stack_layer;
-    stack_layer = mStack[0] * constants::NLAYER + mLayer[0]; // similarly this is also only for graphing so just use the rdh ones for now.
-    updateLinkErrorGraphs(currentlinkindex, supermodule_half, stack_layer);
+  uint32_t linksizeAccum32 = 0;     // accumulated size of all links in 32-bit words
+  auto hbfOffsetTmp = mHBFoffset32; // store current position at the beginning of the half-CRU payload data
+  for (int currentlinkindex = 0; currentlinkindex < NLINKSPERHALFCRU; currentlinkindex++) {
+    int cruIdx = mFEEID.supermodule * 2 + mFEEID.side;                    // 2 CRUs per SM, side defining A/C-side CRU
+    int halfCruIdx = cruIdx * 2 + mFEEID.endpoint;                        // endpoint (0 or 1) defines half-CRU
+    int linkIdxGlobal = halfCruIdx * NLINKSPERHALFCRU + currentlinkindex; // global link ID [0..1079]
+    int halfChamberId = HelperMethods::getHCIDFromLinkID(linkIdxGlobal);
+    // TODO we keep detector, stack, layer, sector, side for now to be compatible to the current code state,
+    // but halfChamberId contains everything we need to know... More cleanup to be done in second step
+    int detectorId = halfChamberId / 2;
+    int stack = HelperMethods::getStack(detectorId);
+    int layer = HelperMethods::getLayer(detectorId);
+    int sector = HelperMethods::getSector(detectorId);
+    int side = halfChamberId % 2;
 
-    mEventRecords.incLinkErrorFlags(mFEEID.supermodule, mHalfChamberSide[0], stack_layer, mCurrentHalfCRULinkErrorFlags[currentlinkindex]);
-    currentlinksize = mCurrentHalfCRULinkLengths[currentlinkindex];
-    // first parameter is the base of the link in the, so either the first or second part of the cru hence the *15
-    mCurrentEvent->setDataPerLink((mFEEID.supermodule * 2 + mHalfChamberSide[0]) * 30 + currentlinkindex, currentlinksize);
-    currentlinksize32 = currentlinksize * 8; //x8 to go from 256 bits to 32 bit;
-    linkstart = mHBFPayload.begin() + dataoffsetstart32 + linksizeAccum32;
-    linkend = linkstart + currentlinksize32;
-    if (currentlinksize == 0) {
-      mEventRecords.incLinkNoData(mDetector[0], mHalfChamberSide[0], stack_layer);
-    }
-    uint32_t linkzsum = 0;
-    int dioffset = dataoffsetstart32 + linksizeAccum32;
-    if (dioffset % 8 != 0) {
-      if (mMaxErrsPrinted > 0) {
-        LOG(warn) << " we are not 256 bit aligned ... this should never happen";
-        checkNoErr();
-      }
-    }
-    if (mHBFoffset32 != std::distance(mHBFPayload.begin(), linkstart)) {
-      mHBFoffset32 = std::distance(mHBFPayload.begin(), linkstart);
-    }
-    if (mHeaderVerbose) {
-      LOG(info) << "Cru link :" << currentlinkindex << " raw dump before processing begin linkstart:" << std::hex << linkstart << " to " << linkend << " mHBFoffset32=" << std::dec << mHBFoffset32 << " and distance from start is : " << std::distance(mHBFPayload.begin(), linkstart);
-      for (int dumpoffset = dataoffsetstart32 + linksizeAccum32; dumpoffset < dataoffsetstart32 + linksizeAccum32 + currentlinksize32; dumpoffset += 8) {
-        LOGP(info, "0x{0:06x} :: {1:08x} {2:08x}  {3:08x} {4:08x} {5:08x} {6:08x} {7:08x} {8:08x} ", dumpoffset, HelperMethods::swapByteOrderreturn(mHBFPayload[dumpoffset]), HelperMethods::swapByteOrderreturn(mHBFPayload[dumpoffset + 1]), HelperMethods::swapByteOrderreturn(mHBFPayload[dumpoffset + 2]), HelperMethods::swapByteOrderreturn(mHBFPayload[dumpoffset + 3]), HelperMethods::swapByteOrderreturn(mHBFPayload[dumpoffset + 4]), HelperMethods::swapByteOrderreturn(mHBFPayload[dumpoffset + 5]), HelperMethods::swapByteOrderreturn(mHBFPayload[dumpoffset + 6]), HelperMethods::swapByteOrderreturn(mHBFPayload[dumpoffset + 7]));
-      }
-    }
+    int stack_layer = stack * NLAYER + layer; // similarly this is also only for graphing so just use the rdh ones for now.
+
+    mEventRecords.incLinkErrorFlags(mFEEID.supermodule, side, stack_layer, mCurrentHalfCRULinkErrorFlags[currentlinkindex]);
+    uint32_t currentlinksize32 = mCurrentHalfCRULinkLengths[currentlinkindex] * 8; // x8 to go from 256 bits to 32 bit;
+    std::array<uint32_t, 1024>::iterator linkstart = mHBFPayload.begin() + mHBFoffset32;
+    std::array<uint32_t, 1024>::iterator linkend = linkstart + currentlinksize32;
     linksizeAccum32 += currentlinksize32;
-    if (mDataVerbose) {
-      LOG(info) << "******* LINK # " << currentlinkindex << " and  starting at " << mHBFoffset32 << " unpackORI(" << oriindex << "," << mSide[1] << "," << mStack[1] << "," << mLayer[1] << "," << mHalfChamberSide[1] << ") and an FEEID:" << std::hex << mFEEID.word << " det:" << std::dec << mDetector[1];
-      LOG(info) << "******* LINK # " << currentlinkindex << " an FEEID:" << std::hex << mFEEID.word << " det:" << std::dec << mDetector[1] << " Error Flags : " << mCurrentHalfCRULinkErrorFlags[currentlinkindex];
+    if (currentlinksize32 == 0) {
+      mEventRecords.incLinkNoData(detectorId, side, stack_layer);
     }
+
+    if (mHeaderVerbose) {
+      if (currentlinksize32 > 0) {
+        LOGF(info, "Half-CRU link %i raw dump before parsing starts:", currentlinkindex);
+        for (uint32_t dumpoffset = mHBFoffset32; dumpoffset < mHBFoffset32 + currentlinksize32; dumpoffset += 8) {
+          LOGF(info, "0x%08x 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x", mHBFPayload[dumpoffset], mHBFPayload[dumpoffset + 1], mHBFPayload[dumpoffset + 2], mHBFPayload[dumpoffset + 3], mHBFPayload[dumpoffset + 4], mHBFPayload[dumpoffset + 5], mHBFPayload[dumpoffset + 6], mHBFPayload[dumpoffset + 7]);
+        }
+      } else {
+        LOGF(info, "Half-CRU link %i has zero link size", currentlinkindex);
+      }
+    }
+
     if (linkstart != linkend) { // if link is not empty
-      bool cleardigits = false; //linkstart and linkend already have the multiple cruheaderoffsets built in
       auto trackletparsingstart = std::chrono::high_resolution_clock::now();
       if (mHeaderVerbose) {
-        LOG(info) << "*** Tracklet Parser : starting at " << std::hex << linkstart << " at hbfoffset: " << std::dec << mHBFoffset32 << " linkhbf start pos:" << hbfoffsetatstartoflink;
+        LOGF(info, "Tracklet parser starting at offset %u and processing up to %u words", mHBFoffset32, currentlinksize32);
       }
-      if (std::distance(linkstart, linkend) > mCurrentHalfCRULinkLengths[currentlinkindex] * 8) { //*8 for lengths are stored in units of cru words(256bit) and iterators are 32bit.
-        if (mMaxErrsPrinted > 0) {
-          LOG(warning) << "linkstart - linkend for  LINK # " << currentlinkindex << " an FEEID:" << std::hex << mFEEID.word << " det:" << std::dec << mDetector[1] << " is > the lenght stored in the cruhalfchamber header : " << mCurrentHalfCRULinkLengths[currentlinkindex];
-          checkNoErr();
-        }
-        incrementErrors(TRDParsingBadLinkstartend, mFEEID.supermodule, mFEEID.side, mStack[0], mLayer[0]);
-        // in the immortal words of ... run away ... run away ... run away
-        return -2; // dump this buffer.
-      }
+
       // for now we are using 0 i.e. from rdh FIXME figure out which is authoritative between rdh and ori tracklethcheader if we have it enabled.
-      mTrackletWordsRead = mTrackletsParser.Parse(&mHBFPayload, linkstart, linkend, mFEEID, mHalfChamberSide[0], mDetector[0], mStack[0], mLayer[0], mCurrentEvent, &mEventRecords, mOptions, cleardigits, mTrackletHCHeaderState); // this will read up to the tracklet end marker.
-      if (mTrackletWordsRead == -1) {
+      int trackletWordsRead = mTrackletsParser.Parse(&mHBFPayload, linkstart, linkend, mFEEID, side, detectorId, stack, layer, mCurrentEvent, &mEventRecords, mOptions, mTrackletHCHeaderState); // this will read up to the tracklet end marker.
+      if (trackletWordsRead == -1) {
         //something went wrong bailout of here.
         if (mMaxErrsPrinted > 0) {
-          LOG(warn) << "TrackletParser returned -1 for  LINK # " << currentlinkindex << " an FEEID:" << std::hex << mFEEID.word << " det:" << std::dec << mDetector[1] << " is > the lenght stored in the cruhalfchamber header : " << mCurrentHalfCRULinkLengths[currentlinkindex];
+          LOG(warn) << "TrackletParser returned -1 for  LINK # " << currentlinkindex << " an FEEID:" << std::hex << mFEEID.word << " det:" << std::dec << detectorId << " is > the lenght stored in the cruhalfchamber header : " << mCurrentHalfCRULinkLengths[currentlinkindex];
           checkNoErr();
         }
-        incrementErrors(TRDParsingTrackletsReturnedMinusOne, mFEEID.supermodule, mFEEID.side, mStack[0], mLayer[0]);
+        incrementErrors(TRDParsingTrackletsReturnedMinusOne, mFEEID.supermodule, mFEEID.side, stack, layer);
         return -2;
       }
-      mTrackletWordsRejected = mTrackletsParser.getDataWordsDumped();
+      int trackletWordsDumped = mTrackletsParser.getDataWordsDumped();
       std::chrono::duration<double, std::micro> trackletparsingtime = std::chrono::high_resolution_clock::now() - trackletparsingstart;
       mCurrentEvent->incTrackletTime((double)std::chrono::duration_cast<std::chrono::microseconds>(trackletparsingtime).count());
       if (mHeaderVerbose) {
-        LOG(info) << "trackletwordsread:" << mTrackletWordsRead << " trackletwordsrejected:" << mTrackletWordsRejected << "  mem copy with offset of : " << cruhbfstartoffset << " parsing with linkstart: " << linkstart << " ending at : " << linkend;
+        LOGF(info, "Read %i tracklet words and rejected %i words", trackletWordsRead, trackletWordsDumped);
       }
-      linkstart += mTrackletWordsRead + mTrackletWordsRejected;
+      linkstart += trackletWordsRead + trackletWordsDumped;
       //now we have a tracklethcheader and a digithcheader.
 
-      mHBFoffset32 += mTrackletWordsRead + mTrackletWordsRejected;
+      mHBFoffset32 += trackletWordsRead + trackletWordsDumped;
       mTotalTrackletsFound += mTrackletsParser.getTrackletsFound();
-      mTotalTrackletWordsRejected += mTrackletWordsRejected;
-      mTotalTrackletWordsRead += mTrackletWordsRead;
-      mCurrentEvent->incWordsRead(mTrackletWordsRead);
-      mCurrentEvent->incWordsRejected(mTrackletWordsRejected);
-      mEventRecords.incLinkWordsRead(mFEEID.supermodule, mHalfChamberSide[0], stack_layer, mTrackletWordsRead);
-      mEventRecords.incLinkWordsRejected(mFEEID.supermodule, mHalfChamberSide[0], stack_layer, mTrackletWordsRejected);
+      mTotalTrackletWordsRejected += trackletWordsDumped;
+      mTotalTrackletWordsRead += trackletWordsRead;
+      mCurrentEvent->incWordsRead(trackletWordsRead);
+      mCurrentEvent->incWordsRejected(trackletWordsDumped);
+      mEventRecords.incLinkWordsRead(mFEEID.supermodule, side, stack_layer, trackletWordsRead);
+      mEventRecords.incLinkWordsRejected(mFEEID.supermodule, side, stack_layer, trackletWordsRead);
       if (mTrackletsParser.getTrackletParsingState()) {
-        mHBFoffset32 += std::distance(linkstart, linkend);
-        linkstart = linkend; // bail out as tracklet parsing bombed out. We are essentially lost.
-      }
-      if (mHeaderVerbose) {
-        LOG(info) << "*** Tracklet Parser : trackletwordsread:" << mTrackletWordsRead << " ending " << std::hex << linkstart << " at hbfoffset: " << std::dec << mHBFoffset32;
+        LOGF(info, "Tracklet parser is in a bad state");
+        mHBFoffset32 = hbfOffsetTmp + linksizeAccum32;
+        continue; // move to next link of this half-CRU
       }
 
       /****************
       ** DIGITS NOW ***
       *****************/
       // Check if we have a calibration trigger ergo we do actually have digits data. check if we are now at the end of the data due to bugs, i.e. if trackletparsing read padding words.
-      if (linkstart != linkend && (mCurrentHalfCRUHeader.EventType == o2::trd::constants::ETYPECALIBRATIONTRIGGER || mOptions[TRDIgnore2StageTrigger]) && (mHBFPayload[cruhbfstartoffset] != o2::trd::constants::CRUPADDING32)) { // calibration trigger and insure we dont come in here if we are on a padding word.
+      if (linkstart != linkend &&
+          (mCurrentHalfCRUHeader.EventType == ETYPECALIBRATIONTRIGGER || mOptions[TRDIgnore2StageTrigger]) &&
+          (mHBFPayload[mHBFoffset32] != CRUPADDING32)) {
+        // calibration trigger and insure we dont come in here if we are on a padding word.
         if (mHeaderVerbose) {
-          LOG(info) << "*** Digit Parsing : starting at " << std::hex << linkstart << " at hbfoffset: " << std::dec << mHBFoffset32 << " linkhbf start pos:" << hbfoffsetatstartoflink;
+          LOG(info) << "*** Digit Parsing : starting with " << std::hex << mHBFPayload[mHBFoffset32] << " at hbfoffset: " << std::dec << mHBFoffset32;
         }
-        // linkstart advanced all the way to the end due to trackletparser parsing crupadding words (known bug or feature )
-        auto hfboffsetbeforehcparse = mHBFoffset32;
+
+        uint32_t hfboffsetbeforehcparse = mHBFoffset32;
         //now read the digit half chamber header
-        auto hcparse = parseDigitHCHeader();
+        auto hcparse = parseDigitHCHeader(halfChamberId);
         if (hcparse != 1) {
           //disaster dump the rest of this hbf
           return -2;
         }
-        mWhichData = checkDigitHCHeader();
+        checkDigitHCHeader(halfChamberId);
         //move over the DigitHCHeader mHBFoffset32 has already been moved in the reading.
-        if (mHBFoffset32 - hfboffsetbeforehcparse != 1 + mDigitHCHeader.numberHCW) {
+        if (mHBFoffset32 - hfboffsetbeforehcparse != 1U + mDigitHCHeader.numberHCW) {
           if (mMaxErrsPrinted > 0) {
             LOG(warn) << "Seems data offset is out of sync with number of HC Headers words " << mHBFoffset32 << "-" << hfboffsetbeforehcparse << "!=" << 1 << "+" << mDigitHCHeader.numberHCW;
             checkNoErr();
@@ -821,70 +604,59 @@ int CruRawReader::processHalfCRU(int cruhbfstartoffset, int numberOfPreviousCRU,
         if (mDigitHCHeader.major == 0x47) {
           // config event so ignore for now and bail out of parsing.
           //advance data pointers to the end;
-          linkstart = linkend;
-          mHBFoffset32 = std::distance(mHBFPayload.begin(), linkend); //currentlinksize-mTrackletWordsRead-sizeof(digitHCHeader)/4; // advance to the end of the link
-          mTotalDigitWordsRejected += std::distance(linkstart + mTrackletWordsRead + sizeof(DigitHCHeader) / 4, linkend);
+          mHBFoffset32 = hbfOffsetTmp + currentlinksize32;
+          // linkstart points to beginning of digits data, need to add the HC header words to it
+          mTotalDigitWordsRejected += std::distance(linkstart + 1U + mDigitHCHeader.numberHCW, linkend);
           LOG(info) << "Configuration event  ";
         } else {
-            mDigitWordsRead = 0;
-            auto digitsparsingstart = std::chrono::high_resolution_clock::now();
-            //linkstart and linkend already have the multiple cruheaderoffsets built in
-            mDigitWordsRead = mDigitsParser.Parse(&mHBFPayload, linkstart, linkend, mDetector[mWhichData], mStack[mWhichData], mLayer[mWhichData], mHalfChamberSide[mWhichData], mDigitHCHeader, mTimeBins, mFEEID, currentlinkindex, mCurrentEvent, &mEventRecords, mOptions, cleardigits);
-            std::chrono::duration<double, std::micro> digitsparsingtime = std::chrono::high_resolution_clock::now() - digitsparsingstart;
-            mCurrentEvent->incDigitTime((double)std::chrono::duration_cast<std::chrono::microseconds>(digitsparsingtime).count());
-            mDigitWordsRejected = mDigitsParser.getDumpedDataCount();
-            mCurrentEvent->incWordsRead(mDigitWordsRead);
-            mCurrentEvent->incWordsRejected(mDigitWordsRejected);
-            mEventRecords.incLinkWordsRead(mFEEID.supermodule, mHalfChamberSide[0], stack_layer, mDigitWordsRead);
-            mEventRecords.incLinkWordsRejected(mFEEID.supermodule, mHalfChamberSide[0], stack_layer, mDigitWordsRejected);
-            if (mHeaderVerbose) {
-              if (mDigitsParser.getDumpedDataCount() != 0) {
-                LOG(info) << "FEEID: " << mFEEID.word << " LINK #" << oriindex << " bad datacount:" << mDigitsParser.getDataWordsParsed() << "::" << mDigitsParser.getDumpedDataCount();
-              } else {
-                LOG(info) << "FEEID: " << mFEEID.word << " LINK #" << oriindex << " good datacount:" << mDigitsParser.getDataWordsParsed() << "::" << mDigitsParser.getDumpedDataCount();
-              }
+          auto digitsparsingstart = std::chrono::high_resolution_clock::now();
+          // linkstart and linkend already have the multiple cruheaderoffsets built in
+          int digitWordsRead = mDigitsParser.Parse(&mHBFPayload, linkstart, linkend, detectorId, stack, layer, side, mDigitHCHeader, mTimeBins, mFEEID, currentlinkindex, mCurrentEvent, &mEventRecords, mOptions, false);
+          std::chrono::duration<double, std::micro> digitsparsingtime = std::chrono::high_resolution_clock::now() - digitsparsingstart;
+          mCurrentEvent->incDigitTime((double)std::chrono::duration_cast<std::chrono::microseconds>(digitsparsingtime).count());
+          int digitWordsRejected = mDigitsParser.getDumpedDataCount();
+          mCurrentEvent->incWordsRead(digitWordsRead);
+          mCurrentEvent->incWordsRejected(digitWordsRejected);
+          mEventRecords.incLinkWordsRead(mFEEID.supermodule, side, stack_layer, digitWordsRead);
+          mEventRecords.incLinkWordsRejected(mFEEID.supermodule, side, stack_layer, digitWordsRejected);
+
+          if (mHeaderVerbose) {
+            LOGF(info, "FEEID: 0x%8x, LINK # %i, digit words parsed %i, digit words dumped %i", mFEEID.word, linkIdxGlobal, digitWordsRead, digitWordsRejected);
+          }
+          if (digitWordsRead + digitWordsRejected != std::distance(linkstart, linkend)) {
+            // we have the data corruption problem of a pile of stuff at the end of a link, jump over it.
+            if (mFixDigitEndCorruption) {
+              digitWordsRead = std::distance(linkstart, linkend);
+            } else {
+              incrementErrors(TRDParsingDigitDataStillOnLink, mFEEID.supermodule, side, stack, layer);
             }
-            mDigitWordsRejected = mDigitsParser.getDumpedDataCount();
-            if (mHeaderVerbose) {
-              if (mDigitsParser.getDumpedDataCount() != 0) {
-                LOG(info) << "FEEID: " << mFEEID.word << " LINK #" << oriindex << " bad datacount:" << mDigitsParser.getDataWordsParsed() << "::" << mDigitsParser.getDumpedDataCount();
-              } else {
-                LOG(info) << "FEEID: " << mFEEID.word << " LINK #" << oriindex << " good datacount:" << mDigitsParser.getDataWordsParsed() << "::" << mDigitsParser.getDumpedDataCount();
-              }
-              incrementErrors(TRDParsingDigitStackMismatch, mFEEID.supermodule, mHalfChamberSide[0], mStack[0], mLayer[0]);
-            }
-            if (mDigitWordsRead + mDigitWordsRejected != std::distance(linkstart, linkend)) {
-              //we have the data corruption problem of a pile of stuff at the end of a link, jump over it.
-              if (mFixDigitEndCorruption) {
-                mDigitWordsRead = std::distance(linkstart, linkend);
-              } else {
-                incrementErrors(TRDParsingDigitDataStillOnLink, mFEEID.supermodule, mHalfChamberSide[0], mStack[0], mLayer[0]);
-              }
-            }
-            mTotalDigitsFound += mDigitsParser.getDigitsFound();
-            if (mDataVerbose) {
-              LOG(info) << "mDigitWordsRead : " << mDigitWordsRead << " mem copy with offset of : " << cruhbfstartoffset << " parsing digits with linkstart: " << linkstart << " ending at : " << linkend << " linkhbf start pos:" << hbfoffsetatstartoflink;
-            }
-            mHBFoffset32 += mDigitWordsRead + mDigitWordsRejected; // all 3 in 32bit units
-            mTotalDigitWordsRead += mDigitWordsRead;
-            mTotalDigitWordsRejected += mDigitWordsRejected;
-          sumlinklengths += mCurrentHalfCRULinkLengths[currentlinkindex];
-          sumtrackletwords += mTrackletWordsRead;
-          sumdigitwords += mDigitWordsRead;
+          }
+          mTotalDigitsFound += mDigitsParser.getDigitsFound();
+          mHBFoffset32 += digitWordsRead + digitWordsRejected; // all 3 in 32bit units
+          mTotalDigitWordsRead += digitWordsRead;
+          mTotalDigitWordsRejected += digitWordsRejected;
         }
       }
     } else {
-      if (mCurrentHalfCRUHeader.EventType == o2::trd::constants::ETYPEPHYSICSTRIGGER) {
+      if (mCurrentHalfCRUHeader.EventType == ETYPEPHYSICSTRIGGER) {
         mEventRecords.incMajorVersion(128); // 127 is max histogram goes to 256
       }
     }
-  } //for loop over link index.
+    if (mHBFoffset32 != hbfOffsetTmp + linksizeAccum32) {
+      // if only tracklet data is available the tracklet parser advances to the tracklet end marker, but there can still be padding words on the link
+      LOGF(debug, "After processing link %i the payload offset of %u is not the expected %u + %u", currentlinkindex, mHBFoffset32, hbfOffsetTmp, linksizeAccum32);
+      mHBFoffset32 = hbfOffsetTmp + linksizeAccum32;
+    }
+  } // for loop over link index.
+  if (mHBFoffset32 != hbfOffsetTmp + totalHalfCRUDataLength32) {
+    LOGF(debug, "After processing half-CRU data the offset (%u) is not pointing to the expected position (%u + %u = %u)", mHBFoffset32, hbfOffsetTmp, totalHalfCRUDataLength32, totalHalfCRUDataLength32 + hbfOffsetTmp);
+    mHBFoffset32 = hbfOffsetTmp + totalHalfCRUDataLength32;
+  }
   // we have read in all the digits and tracklets for this event.
   //digits and tracklets are sitting inside the parsing classes.
   //extract the vectors and copy them to tracklets and digits here, building the indexing(triggerrecords)
   //as this is for a single cru half chamber header all the tracklets and digits are for the same trigger defined by the bc and orbit in the rdh which we hold in mIR
 
-  int lasttrigger = 0, lastdigit = 0, lasttracklet = 0;
   std::chrono::duration<double, std::milli> cruparsingtime = std::chrono::high_resolution_clock::now() - crustart;
   mCurrentEvent->incTime(cruparsingtime.count());
 
@@ -892,91 +664,47 @@ int CruRawReader::processHalfCRU(int cruhbfstartoffset, int numberOfPreviousCRU,
   return 1;
 }
 
-bool CruRawReader::buildCRUPayLoad()
+void CruRawReader::dumpInputPayload() const
 {
-  // copy data for the current half cru, and when we eventually get to the end of the payload return 1
-  // to say we are done.
-  int cruid = 0;
-  int additionalBytes = -1;
-  int crudatasize = -1;
-  return true;
+  // we print 8 32-bit words per line
+  LOG(info) << "Dumping full input payload ----->";
+  for (int iWord = 0; iWord < (mDataBufferSize / 4); iWord += 8) {
+    LOGF(info, "Word %4i/%4i: 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x",
+         iWord, mDataBufferSize / 4,
+         *((uint32_t*)mDataBufferPtr + iWord), *((uint32_t*)mDataBufferPtr + iWord + 1), *((uint32_t*)mDataBufferPtr + iWord + 2), *((uint32_t*)mDataBufferPtr + iWord + 3),
+         *((uint32_t*)mDataBufferPtr + iWord + 4), *((uint32_t*)mDataBufferPtr + iWord + 5), *((uint32_t*)mDataBufferPtr + iWord + 6), *((uint32_t*)mDataBufferPtr + iWord + 7));
+  }
+  LOG(info) << "<------ Done dumping full input payload";
 }
 
-bool CruRawReader::processCRULink()
+void CruRawReader::run()
 {
-  /* process a CRU Link 15 per half cru */
-  //  checkFeeID(); // check the link we are working with corresponds with the FeeID we have in the current rdh.
-  //  uint32_t slotId = GET_TRMDATAHEADER_SLOTID(*mDataPointer);
-  return false;
-}
+  if (mDataVerbose) {
+    dumpInputPayload();
+  }
 
-void CruRawReader::resetCounters()
-{
-  //mStatCountersPerEvent.mLinkErrorFlag.fill(0);
-  mEventCounter = 0;
-  mFatalCounter = 0;
-  mErrorCounter = 0;
-}
+  mCurrRdhPtr = mDataBufferPtr; // set the pointer to the current RDH to the beginning of the payload
+  while ((mCurrRdhPtr - mDataBufferPtr) < mDataBufferSize) {
 
-void CruRawReader::checkSummary()
-{
-  char chname[2] = {'a', 'b'};
+    int dataRead = processHBFs();
 
-  LOG(info) << "--- SUMMARY COUNTERS: " << mEventCounter << " events "
-            << " | " << mFatalCounter << " decode fatals "
-            << " | " << mErrorCounter << " decode errors ";
-}
-
-bool CruRawReader::run()
-{
-  uint32_t dowhilecount = 0;
-  uint32_t totaldataread = 0;
-  rewind();
-  mTotalDigitWordsRead = 0;
-  mTotalDigitWordsRejected = 0;
-  mTotalTrackletWordsRead = 0;
-  mTotalTrackletWordsRejected = 0;
-  uint32_t* bufferptr;
-  bufferptr = (uint32_t*)mDataBuffer;
-  do {
-    if (mDataVerbose) {
-      LOG(info) << " mDataBuffer :" << (void*)mDataBuffer << " and offset to start on is :" << totaldataread;
-    }
-    mDatareadfromhbf = 0;
-    auto goodprocessing = processHBFs(totaldataread, mVerbose);
-    totaldataread += mDatareadfromhbf;
-    if (!goodprocessing) {
-      //processHBFs returned false, get out of here ...
+    if (dataRead < 0) {
       if (mMaxWarnPrinted > 0) {
         LOG(warn) << "Error processing heart beat frame ... dumping data, heart beat frame rejected";
         checkNoWarn();
       }
       break;
-    }
-    if (totaldataread == 0) {
+    } else if (dataRead == 0) {
       if (mMaxWarnPrinted > 0) {
         LOG(warn) << "EEE  we read zero data but bailing out of here for now.";
         checkNoWarn();
       }
       break;
+    } else {
+      LOG(debug) << "Done processing HBFs. Total input size was " << dataRead << " bytes (including all headers and padding words)";
     }
-  } while (((char*)mDataPointer - mDataBuffer) < mDataBufferSize);
-
-  return false;
+  }
 };
-
-void CruRawReader::getParsedObjects(std::vector<Tracklet64>& tracklets, std::vector<Digit>& digits, std::vector<TriggerRecord>& triggers)
-{
-  int digitcountsum = 0;
-  int trackletcountsum = 0;
-  mEventRecords.unpackData(triggers, tracklets, digits);
-}
-
-void CruRawReader::getParsedObjectsandClear(std::vector<Tracklet64>& tracklets, std::vector<Digit>& digits, std::vector<TriggerRecord>& triggers)
-{
-  getParsedObjects(tracklets, digits, triggers);
-  clearall();
-}
 
 //write the output data directly to the given DataAllocator from the datareader task.
 void CruRawReader::buildDPLOutputs(o2::framework::ProcessingContext& pc)

--- a/Detectors/TRD/reconstruction/src/DataReader.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReader.cxx
@@ -42,7 +42,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"trd-datareader-fixdigitcorruptdata", VariantType::Bool, false, {"Fix the erroneous data at the end of digits"}},
     {"enable-timing", VariantType::Bool, false, {"enable the timing of tracklet, digit, timeframe, cru processing"}},
     {"enable-stats", VariantType::Bool, false, {"enable the reader stats"}},
-    {"enable-root-output", VariantType::Bool, false, {"Write the data to file"}},
+    {"enable-root-output", VariantType::Bool, false, {"Write the digits and tracklets to file"}},
     {"ignore-tracklethcheader", VariantType::Bool, false, {"Ignore the tracklethalf chamber header for cross referencing"}},
     {"halfchamberwords", VariantType::Int, 0, {"Fix half chamber for when it is version is 0.0 integer value of additional header words, ignored if version is not 0.0"}},
     {"halfchambermajor", VariantType::Int, 0, {"Fix half chamber for when it is version is 0.0 integer value of major version, ignored if version is not 0.0"}},
@@ -50,8 +50,6 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"fixforoldtrigger", VariantType::Bool, false, {"Fix for the old data not having a 2 stage trigger stored in the cru header."}},
     {"tracklethcheader", VariantType::Int, 2, {"Status of TrackletHalfChamberHeader 0 off always, 1 iff tracklet data, 2 on always"}},
     {"histogramsfile", VariantType::String, "histos.root", {"Name of the histogram file, so one can run multiple per node"}},
-    {"trd-debugm1", VariantType::Bool, false, {"various output statements specific to debugging m1 problems."}},
-    //{"generate-stats", VariantType::Bool, true, {"Generate the state message sent to qc"}},
     {"trd-datareader-enablebyteswapdata", VariantType::Bool, false, {"byteswap the incoming data, raw data needs it and simulation does not."}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
   std::swap(workflowOptions, options);
@@ -93,16 +91,11 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   binaryoptions[o2::trd::TRDDataVerboseBit] = cfgc.options().get<bool>("trd-datareader-dataverbose");
   binaryoptions[o2::trd::TRDCompressedDataBit] = cfgc.options().get<bool>("trd-datareader-compresseddata");
   binaryoptions[o2::trd::TRDFixDigitCorruptionBit] = cfgc.options().get<bool>("trd-datareader-fixdigitcorruptdata");
-  binaryoptions[o2::trd::TRDEnableTimeInfoBit] = cfgc.options().get<bool>("enable-timing");
-  binaryoptions[o2::trd::TRDEnableStatsBit] = cfgc.options().get<bool>("enable-stats");
   binaryoptions[o2::trd::TRDIgnoreDigitHCHeaderBit] = cfgc.options().get<bool>("ignore-digithcheader");
   binaryoptions[o2::trd::TRDIgnoreTrackletHCHeaderBit] = cfgc.options().get<bool>("ignore-tracklethcheader");
-  binaryoptions[o2::trd::TRDEnableRootOutputBit] = cfgc.options().get<bool>("enable-root-output");
   binaryoptions[o2::trd::TRDByteSwapBit] = cfgc.options().get<bool>("trd-datareader-enablebyteswapdata");
   binaryoptions[o2::trd::TRDIgnore2StageTrigger] = cfgc.options().get<bool>("fixforoldtrigger");
-  //binaryoptions[o2::trd::TRDGenerateStats] = cfgc.options().get<bool>("generate-stats");
-  binaryoptions[o2::trd::TRDGenerateStats] = true; //cfgc.options().get<bool>("generate-stats");
-  binaryoptions[o2::trd::TRDM1Debug] = cfgc.options().get<bool>("trd-debugm1");
+  binaryoptions[o2::trd::TRDGenerateStats] = true; // always generate stats for QC
   AlgorithmSpec algoSpec;
   algoSpec = AlgorithmSpec{adaptFromTask<o2::trd::DataReaderTask>(tracklethcheader, halfchamberwords, halfchambermajor, cfgc.options().get<std::string>("histogramsfile"), binaryoptions)};
 

--- a/Detectors/TRD/reconstruction/src/EventRecord.cxx
+++ b/Detectors/TRD/reconstruction/src/EventRecord.cxx
@@ -226,12 +226,12 @@ void EventStorage::accumulateStats()
   uint64_t sumwordsrejected = 0;
   uint64_t sumwordsread = 0;
   for (auto event : mEventRecords) {
-    sumtracklets += event.mEventStats.mTrackletsFound;
-    sumdigits += event.mEventStats.mDigitsFound;
-    sumtracklettime += event.mEventStats.mTimeTakenForTracklets;
-    sumdigittime += event.mEventStats.mTimeTakenForDigits;
-    sumwordsrejected += event.mEventStats.mWordsRejected;
-    sumwordsread += event.mEventStats.mWordsRead;
+    sumtracklets += event.getEventStats().mTrackletsFound;
+    sumdigits += event.getEventStats().mDigitsFound;
+    sumtracklettime += event.getEventStats().mTimeTakenForTracklets;
+    sumdigittime += event.getEventStats().mTimeTakenForDigits;
+    sumwordsrejected += event.getEventStats().mWordsRejected;
+    sumwordsread += event.getEventStats().mWordsRead;
   }
   if (eventcount != 0) {
     mTFStats.mTrackletsPerEvent = sumtracklets / eventcount;

--- a/Detectors/TRD/simulation/src/TrapSimulator.cxx
+++ b/Detectors/TRD/simulation/src/TrapSimulator.cxx
@@ -1209,7 +1209,7 @@ void TrapSimulator::addHitToFitreg(int adc, unsigned short timebin, unsigned sho
     mFitReg[adc].q1 += qtot;
   }
 
-  if ((timebin >= 5) &&
+  if ((timebin >= 1) &&
       (timebin < 24)) {
     mFitReg[adc].sumX += timebin;
     mFitReg[adc].sumX2 += timebin * timebin;


### PR DESCRIPTION
This leaves the logic and functionality of the raw reader as it was before. It contains lots of cleanup, fixing of compiler warnings (unused variables, signed/unsigned comparisons) and adds more comments to the raw reader header to all its methods. The parsing of tracklets and digits data is left untouched as much as possible.
Still WIP, since I find 1.8% less tracklets with these changes and that should actually be constant, unless one check was not fully working before and is now dumping input data as it should. This I am checking now together with @bazinski 