### PR TITLE
DPL Analysis: Event mixing: Mixing counters

### DIFF
--- a/Framework/Core/include/Framework/ASoAHelpers.h
+++ b/Framework/Core/include/Framework/ASoAHelpers.h
@@ -505,7 +505,7 @@ struct CombinationsBlockIndexPolicyBase : public CombinationsIndexPolicyBase<Ts.
     if (this->mIsEnd) {
       return 0;
     }
-    uint64_t maxForWindow = std::get<0>(this->mBeginIndices) + this->mSlidingWindowSize;
+    uint64_t maxForWindow = std::get<0>(this->mBeginIndices) + this->mSlidingWindowSize - 1;
     uint64_t maxForTable = std::get<0>(this->mMaxOffset);
     uint64_t currentMax = maxForWindow < maxForTable ? maxForWindow : maxForTable;
     int numberOfEventsToMixWith = currentMax - std::get<0>(mCurrentIndices);
@@ -857,7 +857,7 @@ struct CombinationsBlockSameIndexPolicyBase : public CombinationsIndexPolicyBase
     if (this->mIsEnd) {
       return 0;
     }
-    uint64_t maxForWindow = std::get<0>(this->mCurrentIndices) + this->mSlidingWindowSize;
+    uint64_t maxForWindow = std::get<0>(this->mCurrentIndices) + this->mSlidingWindowSize - 1;
     uint64_t maxForTable = std::get<0>(this->mMaxOffset);
     uint64_t currentMax = maxForWindow < maxForTable ? maxForWindow : maxForTable;
     int numberOfEventsToMixWith = currentMax - std::get<0>(mCurrentIndices);

--- a/Framework/Core/include/Framework/ASoAHelpers.h
+++ b/Framework/Core/include/Framework/ASoAHelpers.h
@@ -418,14 +418,14 @@ struct CombinationsBlockIndexPolicyBase : public CombinationsIndexPolicyBase<Ts.
   using CombinationType = typename CombinationsIndexPolicyBase<Ts...>::CombinationType;
   using IndicesType = typename NTupleType<uint64_t, sizeof...(Ts)>::type;
 
-  CombinationsBlockIndexPolicyBase(const BP& binningPolicy, int categoryNeighbours, const T& outsider) : CombinationsIndexPolicyBase<Ts...>(), mSlidingWindowSize(categoryNeighbours + 1), mBP(binningPolicy), mCategoryNeighbours(categoryNeighbours), mOutsider(outsider) {}
-  CombinationsBlockIndexPolicyBase(const BP& binningPolicy, int categoryNeighbours, const T& outsider, const Ts&... tables) : CombinationsIndexPolicyBase<Ts...>(tables...), mSlidingWindowSize(categoryNeighbours + 1), mBP(binningPolicy), mCategoryNeighbours(categoryNeighbours), mOutsider(outsider)
+  CombinationsBlockIndexPolicyBase(const BP& binningPolicy, int categoryNeighbours, const T& outsider) : CombinationsIndexPolicyBase<Ts...>(), mSlidingWindowSize(categoryNeighbours + 1), mBP(binningPolicy), mCategoryNeighbours(categoryNeighbours), mOutsider(outsider), mIsFirstEvent(true) {}
+  CombinationsBlockIndexPolicyBase(const BP& binningPolicy, int categoryNeighbours, const T& outsider, const Ts&... tables) : CombinationsIndexPolicyBase<Ts...>(tables...), mSlidingWindowSize(categoryNeighbours + 1), mBP(binningPolicy), mCategoryNeighbours(categoryNeighbours), mOutsider(outsider), mIsFirstEvent(true)
   {
     if (!this->mIsEnd) {
       setRanges(tables...);
     }
   }
-  CombinationsBlockIndexPolicyBase(const BP& binningPolicy, int categoryNeighbours, const T& outsider, Ts&&... tables) : CombinationsIndexPolicyBase<Ts...>(std::forward<Ts>(tables)...), mSlidingWindowSize(categoryNeighbours + 1), mBP(binningPolicy), mCategoryNeighbours(categoryNeighbours), mOutsider(outsider)
+  CombinationsBlockIndexPolicyBase(const BP& binningPolicy, int categoryNeighbours, const T& outsider, Ts&&... tables) : CombinationsIndexPolicyBase<Ts...>(std::forward<Ts>(tables)...), mSlidingWindowSize(categoryNeighbours + 1), mBP(binningPolicy), mCategoryNeighbours(categoryNeighbours), mOutsider(outsider), mIsFirstEvent(true)
   {
     if (!this->mIsEnd) {
       setRanges();
@@ -500,6 +500,23 @@ struct CombinationsBlockIndexPolicyBase : public CombinationsIndexPolicyBase<Ts.
     });
   }
 
+  int getNumberOfEventsToMixWith()
+  {
+    if (this->mIsEnd) {
+      return 0;
+    }
+    uint64_t maxForWindow = std::get<0>(this->mBeginIndices) + this->mSlidingWindowSize;
+    uint64_t maxForTable = std::get<0>(this->mMaxOffset);
+    uint64_t currentMax = maxForWindow < maxForTable ? maxForWindow : maxForTable;
+    int numberOfEventsToMixWith = currentMax - std::get<0>(mCurrentIndices);
+    return numberOfEventsToMixWith;
+  }
+
+  bool getIsFirstEvent()
+  {
+    return mIsFirstEvent;
+  }
+
   std::array<std::vector<BinningIndex>, sizeof...(Ts)> mGroupedIndices;
   IndicesType mCurrentIndices;
   IndicesType mBeginIndices;
@@ -507,6 +524,7 @@ struct CombinationsBlockIndexPolicyBase : public CombinationsIndexPolicyBase<Ts.
   const BP mBP;
   const int mCategoryNeighbours;
   const T mOutsider;
+  bool mIsFirstEvent;
 };
 
 template <typename BP, typename T, typename... Ts>
@@ -579,6 +597,8 @@ struct CombinationsBlockUpperIndexPolicy : public CombinationsBlockIndexPolicyBa
         }
       }
     });
+
+    this->mIsFirstEvent = modify;
 
     // First iterator processed separately
     if (modify) {
@@ -694,6 +714,8 @@ struct CombinationsBlockFullIndexPolicy : public CombinationsBlockIndexPolicyBas
       }
     });
 
+    this->mIsFirstEvent = modify;
+
     // Currently fixed iterator processed separately
     if (modify) {
       // If we haven't finished with window starting element
@@ -758,14 +780,14 @@ struct CombinationsBlockSameIndexPolicyBase : public CombinationsIndexPolicyBase
   using CombinationType = typename CombinationsIndexPolicyBase<T, Ts...>::CombinationType;
   using IndicesType = typename NTupleType<uint64_t, sizeof...(Ts) + 1>::type;
 
-  CombinationsBlockSameIndexPolicyBase(const BP& binningPolicy, int categoryNeighbours, const T1& outsider, int minWindowSize) : CombinationsIndexPolicyBase<T, Ts...>(), mSlidingWindowSize(categoryNeighbours + 1), mBP(binningPolicy), mCategoryNeighbours(categoryNeighbours), mOutsider(outsider), mMinWindowSize(minWindowSize) {}
-  CombinationsBlockSameIndexPolicyBase(const BP& binningPolicy, int categoryNeighbours, const T1& outsider, int minWindowSize, const T& table, const Ts&... tables) : CombinationsIndexPolicyBase<T, Ts...>(table, tables...), mSlidingWindowSize(categoryNeighbours + 1), mBP(binningPolicy), mCategoryNeighbours(categoryNeighbours), mOutsider(outsider), mMinWindowSize(minWindowSize)
+  CombinationsBlockSameIndexPolicyBase(const BP& binningPolicy, int categoryNeighbours, const T1& outsider, int minWindowSize) : CombinationsIndexPolicyBase<T, Ts...>(), mSlidingWindowSize(categoryNeighbours + 1), mBP(binningPolicy), mCategoryNeighbours(categoryNeighbours), mOutsider(outsider), mMinWindowSize(minWindowSize), mIsFirstEvent(true) {}
+  CombinationsBlockSameIndexPolicyBase(const BP& binningPolicy, int categoryNeighbours, const T1& outsider, int minWindowSize, const T& table, const Ts&... tables) : CombinationsIndexPolicyBase<T, Ts...>(table, tables...), mSlidingWindowSize(categoryNeighbours + 1), mBP(binningPolicy), mCategoryNeighbours(categoryNeighbours), mOutsider(outsider), mMinWindowSize(minWindowSize), mIsFirstEvent(true)
   {
     if (!this->mIsEnd) {
       setRanges(table);
     }
   }
-  CombinationsBlockSameIndexPolicyBase(const BP& binningPolicy, int categoryNeighbours, const T1& outsider, int minWindowSize, T&& table, Ts&&... tables) : CombinationsIndexPolicyBase<T, Ts...>(std::forward<T>(table), std::forward<Ts>(tables)...), mSlidingWindowSize(categoryNeighbours + 1), mBP(binningPolicy), mCategoryNeighbours(categoryNeighbours), mOutsider(outsider), mMinWindowSize(minWindowSize)
+  CombinationsBlockSameIndexPolicyBase(const BP& binningPolicy, int categoryNeighbours, const T1& outsider, int minWindowSize, T&& table, Ts&&... tables) : CombinationsIndexPolicyBase<T, Ts...>(std::forward<T>(table), std::forward<Ts>(tables)...), mSlidingWindowSize(categoryNeighbours + 1), mBP(binningPolicy), mCategoryNeighbours(categoryNeighbours), mOutsider(outsider), mMinWindowSize(minWindowSize), mIsFirstEvent(true)
   {
     if (!this->mIsEnd) {
       setRanges();
@@ -824,6 +846,23 @@ struct CombinationsBlockSameIndexPolicyBase : public CombinationsIndexPolicyBase
     std::get<0>(this->mCurrentIndices) = 0;
   }
 
+  int getNumberOfEventsToMixWith()
+  {
+    if (this->mIsEnd) {
+      return 0;
+    }
+    uint64_t maxForWindow = std::get<0>(this->mCurrentIndices) + this->mSlidingWindowSize;
+    uint64_t maxForTable = std::get<0>(this->mMaxOffset);
+    uint64_t currentMax = maxForWindow < maxForTable ? maxForWindow : maxForTable;
+    int numberOfEventsToMixWith = currentMax - std::get<0>(mCurrentIndices);
+    return numberOfEventsToMixWith;
+  }
+
+  bool getIsFirstEvent()
+  {
+    return mIsFirstEvent;
+  }
+
   std::vector<BinningIndex> mGroupedIndices;
   IndicesType mCurrentIndices;
   const uint64_t mSlidingWindowSize;
@@ -831,6 +870,7 @@ struct CombinationsBlockSameIndexPolicyBase : public CombinationsIndexPolicyBase
   const BP mBP;
   const int mCategoryNeighbours;
   const T1 mOutsider;
+  bool mIsFirstEvent;
 };
 
 template <typename BP, typename T1, typename... Ts>
@@ -900,6 +940,8 @@ struct CombinationsBlockUpperSameIndexPolicy : public CombinationsBlockSameIndex
         }
       }
     });
+
+    this->mIsFirstEvent = modify;
 
     // First iterator processed separately
     if (modify) {
@@ -1001,6 +1043,8 @@ struct CombinationsBlockStrictlyUpperSameIndexPolicy : public CombinationsBlockS
         }
       }
     });
+
+    this->mIsFirstEvent = modify;
 
     // First iterator processed separately
     if (modify) {

--- a/Framework/Core/include/Framework/ASoAHelpers.h
+++ b/Framework/Core/include/Framework/ASoAHelpers.h
@@ -500,7 +500,7 @@ struct CombinationsBlockIndexPolicyBase : public CombinationsIndexPolicyBase<Ts.
     });
   }
 
-  int getNumberOfEventsToMixWith()
+  int numberOfEventsToMixWith()
   {
     if (this->mIsEnd) {
       return 0;
@@ -512,7 +512,7 @@ struct CombinationsBlockIndexPolicyBase : public CombinationsIndexPolicyBase<Ts.
     return numberOfEventsToMixWith;
   }
 
-  bool getIsFirstEvent()
+  bool isFirstEvent()
   {
     return mIsFirstEvent;
   }
@@ -846,7 +846,7 @@ struct CombinationsBlockSameIndexPolicyBase : public CombinationsIndexPolicyBase
     std::get<0>(this->mCurrentIndices) = 0;
   }
 
-  int getNumberOfEventsToMixWith()
+  int numberOfEventsToMixWith()
   {
     if (this->mIsEnd) {
       return 0;
@@ -858,7 +858,7 @@ struct CombinationsBlockSameIndexPolicyBase : public CombinationsIndexPolicyBase
     return numberOfEventsToMixWith;
   }
 
-  bool getIsFirstEvent()
+  bool isFirstEvent()
   {
     return mIsFirstEvent;
   }

--- a/Framework/Core/include/Framework/ASoAHelpers.h
+++ b/Framework/Core/include/Framework/ASoAHelpers.h
@@ -509,7 +509,6 @@ struct CombinationsBlockIndexPolicyBase : public CombinationsIndexPolicyBase<Ts.
     uint64_t maxForTable = std::get<0>(this->mMaxOffset);
     uint64_t currentMax = maxForWindow < maxForTable ? maxForWindow : maxForTable;
     int numberOfEventsToMixWith = currentMax - std::get<0>(mCurrentIndices);
-    LOG(info) << "maxForWindow: " << maxForWindow << " window size: " << this->mSlidingWindowSize << " maxForTable: " << maxForTable << " current max: " << currentMax << " number of events: " << numberOfEventsToMixWith;
     return numberOfEventsToMixWith;
   }
 
@@ -821,11 +820,6 @@ struct CombinationsBlockSameIndexPolicyBase : public CombinationsIndexPolicyBase
 
     this->mGroupedIndices = groupTable(table, mBP, mMinWindowSize, mOutsider);
 
-    LOG(info) << "Grouped indices:";
-    for (auto& binInd : this->mGroupedIndices) {
-      LOG(info) << binInd.index << " bin: " << binInd.bin;
-    }
-
     if (this->mGroupedIndices.size() == 0) {
       this->mIsEnd = true;
       return;
@@ -861,7 +855,6 @@ struct CombinationsBlockSameIndexPolicyBase : public CombinationsIndexPolicyBase
     uint64_t maxForTable = std::get<0>(this->mMaxOffset);
     uint64_t currentMax = maxForWindow < maxForTable ? maxForWindow : maxForTable;
     int numberOfEventsToMixWith = currentMax - std::get<0>(mCurrentIndices);
-    LOG(info) << "maxForWindow: " << maxForWindow << " window size: " << this->mSlidingWindowSize << " maxForTable: " << maxForTable << " current max: " << currentMax << " number of events: " << numberOfEventsToMixWith;
     return numberOfEventsToMixWith;
   }
 

--- a/Framework/Core/include/Framework/ASoAHelpers.h
+++ b/Framework/Core/include/Framework/ASoAHelpers.h
@@ -509,6 +509,7 @@ struct CombinationsBlockIndexPolicyBase : public CombinationsIndexPolicyBase<Ts.
     uint64_t maxForTable = std::get<0>(this->mMaxOffset);
     uint64_t currentMax = maxForWindow < maxForTable ? maxForWindow : maxForTable;
     int numberOfEventsToMixWith = currentMax - std::get<0>(mCurrentIndices);
+    LOG(info) << "maxForWindow: " << maxForWindow << " window size: " << this->mSlidingWindowSize << " maxForTable: " << maxForTable << " current max: " << currentMax << " number of events: " << numberOfEventsToMixWith;
     return numberOfEventsToMixWith;
   }
 
@@ -820,6 +821,11 @@ struct CombinationsBlockSameIndexPolicyBase : public CombinationsIndexPolicyBase
 
     this->mGroupedIndices = groupTable(table, mBP, mMinWindowSize, mOutsider);
 
+    LOG(info) << "Grouped indices:";
+    for (auto& binInd : this->mGroupedIndices) {
+      LOG(info) << binInd.index << " bin: " << binInd.bin;
+    }
+
     if (this->mGroupedIndices.size() == 0) {
       this->mIsEnd = true;
       return;
@@ -855,6 +861,7 @@ struct CombinationsBlockSameIndexPolicyBase : public CombinationsIndexPolicyBase
     uint64_t maxForTable = std::get<0>(this->mMaxOffset);
     uint64_t currentMax = maxForWindow < maxForTable ? maxForWindow : maxForTable;
     int numberOfEventsToMixWith = currentMax - std::get<0>(mCurrentIndices);
+    LOG(info) << "maxForWindow: " << maxForWindow << " window size: " << this->mSlidingWindowSize << " maxForTable: " << maxForTable << " current max: " << currentMax << " number of events: " << numberOfEventsToMixWith;
     return numberOfEventsToMixWith;
   }
 

--- a/Framework/Core/include/Framework/ASoAHelpers.h
+++ b/Framework/Core/include/Framework/ASoAHelpers.h
@@ -502,6 +502,11 @@ struct CombinationsBlockIndexPolicyBase : public CombinationsIndexPolicyBase<Ts.
 
   int currentWindowNeighbours()
   {
+    // NOTE: The same number of currentWindowNeighbours is returned for all kinds of block combinations.
+    // Strictly upper: the first element will is paired with exactly currentWindowNeighbours other elements.
+    // Upper: the first element is paired with (currentWindowNeighbours + 1) elements, including itself.
+    // Full: (currentWindowNeighbours + 1) pairs with the first element in the first position (c1)
+    //       + there are other combinations with the first element at other positions.
     if (this->mIsEnd) {
       return 0;
     }
@@ -847,6 +852,11 @@ struct CombinationsBlockSameIndexPolicyBase : public CombinationsIndexPolicyBase
 
   int currentWindowNeighbours()
   {
+    // NOTE: The same number of currentWindowNeighbours is returned for all kinds of block combinations.
+    // Strictly upper: the first element will is paired with exactly currentWindowNeighbours other elements.
+    // Upper: the first element is paired with (currentWindowNeighbours + 1) elements, including itself.
+    // Full: (currentWindowNeighbours + 1) pairs with the first element in the first position (c1)
+    //       + there are other combinations with the first element at other positions.
     if (this->mIsEnd) {
       return 0;
     }

--- a/Framework/Core/include/Framework/ASoAHelpers.h
+++ b/Framework/Core/include/Framework/ASoAHelpers.h
@@ -500,7 +500,7 @@ struct CombinationsBlockIndexPolicyBase : public CombinationsIndexPolicyBase<Ts.
     });
   }
 
-  int combinationsWithFirst()
+  int currentWindowNeighbours()
   {
     if (this->mIsEnd) {
       return 0;
@@ -845,7 +845,7 @@ struct CombinationsBlockSameIndexPolicyBase : public CombinationsIndexPolicyBase
     std::get<0>(this->mCurrentIndices) = 0;
   }
 
-  int combinationsWithFirst()
+  int currentWindowNeighbours()
   {
     if (this->mIsEnd) {
       return 0;

--- a/Framework/Core/include/Framework/GroupedCombinations.h
+++ b/Framework/Core/include/Framework/GroupedCombinations.h
@@ -165,9 +165,6 @@ struct GroupedCombinationsGenerator {
       }
     }
 
-    //using GroupingPolicy::getIsFirstEvent;
-    //using GroupingPolicy::getNumberOfEventsToMixWith;
-
     std::array<expressions::BindingNode, sizeof...(As)> mIndexColumns;
     std::shared_ptr<G> mGrouping;
     std::shared_ptr<std::tuple<As...>> mAssociated;

--- a/Framework/Core/include/Framework/GroupedCombinations.h
+++ b/Framework/Core/include/Framework/GroupedCombinations.h
@@ -165,6 +165,9 @@ struct GroupedCombinationsGenerator {
       }
     }
 
+    //using GroupingPolicy::getIsFirstEvent;
+    //using GroupingPolicy::getNumberOfEventsToMixWith;
+
     std::array<expressions::BindingNode, sizeof...(As)> mIndexColumns;
     std::shared_ptr<G> mGrouping;
     std::shared_ptr<std::tuple<As...>> mAssociated;

--- a/Framework/Core/test/test_ASoAHelpers.cxx
+++ b/Framework/Core/test/test_ASoAHelpers.cxx
@@ -1359,15 +1359,46 @@ BOOST_AUTO_TEST_CASE(BlockCombinationsCounters)
 
   ColumnBinningPolicy<test::Y, test::FloatZ> pairBinning{{yBins, zBins}, false};
 
-  std::vector<int> expectedEventsInBin{3, 3, 2, 1, 3, 3, 2, 1};
+  // Window size < category size
+  std::vector<int> expectedEventsInBinSmallWindow{3, 3, 2, 1, 3, 3, 2, 1};
   int countFirst = 0;
   int previousEvent = -1;
-  auto combGen = combinations(CombinationsBlockStrictlyUpperSameIndexPolicy(pairBinning, 3, -1, testA, testA));
-  for (auto it = combGen.begin(); it != combGen.end(); it++) {
+  auto combGenSmallWindow = combinations(CombinationsBlockStrictlyUpperSameIndexPolicy(pairBinning, 3, -1, testA, testA));
+  for (auto it = combGenSmallWindow.begin(); it != combGenSmallWindow.end(); it++) {
     auto& [c0, c1] = *it;
     BOOST_CHECK_EQUAL(it.isFirstEvent(), previousEvent != c0.x());
     if (it.isFirstEvent()) {
-      BOOST_CHECK_EQUAL(it.numberOfEventsToMixWith(), expectedEventsInBin[countFirst]);
+      BOOST_CHECK_EQUAL(it.numberOfEventsToMixWith(), expectedEventsInBinSmallWindow[countFirst]);
+      countFirst++;
+    }
+    previousEvent = c0.index();
+  }
+
+  // Window size = category size
+  std::vector<int> expectedEventsInBinEqualWindow{4, 3, 2, 1, 4, 3, 2, 1};
+  countFirst = 0;
+  previousEvent = -1;
+  auto combGenEqualWindow = combinations(CombinationsBlockStrictlyUpperSameIndexPolicy(pairBinning, 4, -1, testA, testA));
+  for (auto it = combGenEqualWindow.begin(); it != combGenEqualWindow.end(); it++) {
+    auto& [c0, c1] = *it;
+    BOOST_CHECK_EQUAL(it.isFirstEvent(), previousEvent != c0.x());
+    if (it.isFirstEvent()) {
+      BOOST_CHECK_EQUAL(it.numberOfEventsToMixWith(), expectedEventsInBinEqualWindow[countFirst]);
+      countFirst++;
+    }
+    previousEvent = c0.index();
+  }
+
+  // Window size = category size
+  std::vector<int> expectedEventsInBinBigWindow{4, 3, 2, 1, 4, 3, 2, 1};
+  countFirst = 0;
+  previousEvent = -1;
+  auto combGenBigWindow = combinations(CombinationsBlockStrictlyUpperSameIndexPolicy(pairBinning, 5, -1, testA, testA));
+  for (auto it = combGenBigWindow.begin(); it != combGenBigWindow.end(); it++) {
+    auto& [c0, c1] = *it;
+    BOOST_CHECK_EQUAL(it.isFirstEvent(), previousEvent != c0.x());
+    if (it.isFirstEvent()) {
+      BOOST_CHECK_EQUAL(it.numberOfEventsToMixWith(), expectedEventsInBinBigWindow[countFirst]);
       countFirst++;
     }
     previousEvent = c0.index();

--- a/Framework/Core/test/test_ASoAHelpers.cxx
+++ b/Framework/Core/test/test_ASoAHelpers.cxx
@@ -1367,9 +1367,9 @@ BOOST_AUTO_TEST_CASE(BlockCombinationsCounters)
   auto combGen = combinations(CombinationsBlockStrictlyUpperSameIndexPolicy(pairBinning, 4, -1, testA, testA));
   for (auto it = combGen.begin(); it != combGen.end(); it++) {
     auto& [c0, c1] = *it;
-    BOOST_CHECK_EQUAL(it.getIsFirstEvent(), previousEvent != c0.x());
-    if (it.getIsFirstEvent()) {
-      BOOST_CHECK_EQUAL(it.getNumberOfEventsToMixWith(), expectedEventsInBin[countFirst]);
+    BOOST_CHECK_EQUAL(it.isFirstEvent(), previousEvent != c0.x());
+    if (it.isFirstEvent()) {
+      BOOST_CHECK_EQUAL(it.numberOfEventsToMixWith(), expectedEventsInBin[countFirst]);
       countFirst++;
     }
     previousEvent = c0.index();

--- a/Framework/Core/test/test_ASoAHelpers.cxx
+++ b/Framework/Core/test/test_ASoAHelpers.cxx
@@ -1360,45 +1360,45 @@ BOOST_AUTO_TEST_CASE(BlockCombinationsCounters)
   ColumnBinningPolicy<test::Y, test::FloatZ> pairBinning{{yBins, zBins}, false};
 
   // Window size < category size
-  std::vector<int> expectedEventsInBinSmallWindow{3, 3, 2, 1, 3, 3, 2, 1};
+  std::vector<int> expectedCollisionsInBinSmallWindow{3, 3, 2, 1, 3, 3, 2, 1};
   int countFirst = 0;
   int previousEvent = -1;
   auto combGenSmallWindow = combinations(CombinationsBlockStrictlyUpperSameIndexPolicy(pairBinning, 3, -1, testA, testA));
   for (auto it = combGenSmallWindow.begin(); it != combGenSmallWindow.end(); it++) {
     auto& [c0, c1] = *it;
-    BOOST_CHECK_EQUAL(it.isFirstEvent(), previousEvent != c0.x());
-    if (it.isFirstEvent()) {
-      BOOST_CHECK_EQUAL(it.numberOfEventsToMixWith(), expectedEventsInBinSmallWindow[countFirst]);
+    BOOST_CHECK_EQUAL(it.isNewWindow(), previousEvent != c0.x());
+    if (it.isNewWindow()) {
+      BOOST_CHECK_EQUAL(it.combinationsWithFirst(), expectedCollisionsInBinSmallWindow[countFirst]);
       countFirst++;
     }
     previousEvent = c0.index();
   }
 
   // Window size = category size
-  std::vector<int> expectedEventsInBinEqualWindow{4, 3, 2, 1, 4, 3, 2, 1};
+  std::vector<int> expectedCollisionsInBinEqualWindow{4, 3, 2, 1, 4, 3, 2, 1};
   countFirst = 0;
   previousEvent = -1;
   auto combGenEqualWindow = combinations(CombinationsBlockStrictlyUpperSameIndexPolicy(pairBinning, 4, -1, testA, testA));
   for (auto it = combGenEqualWindow.begin(); it != combGenEqualWindow.end(); it++) {
     auto& [c0, c1] = *it;
-    BOOST_CHECK_EQUAL(it.isFirstEvent(), previousEvent != c0.x());
-    if (it.isFirstEvent()) {
-      BOOST_CHECK_EQUAL(it.numberOfEventsToMixWith(), expectedEventsInBinEqualWindow[countFirst]);
+    BOOST_CHECK_EQUAL(it.isNewWindow(), previousEvent != c0.x());
+    if (it.isNewWindow()) {
+      BOOST_CHECK_EQUAL(it.combinationsWithFirst(), expectedCollisionsInBinEqualWindow[countFirst]);
       countFirst++;
     }
     previousEvent = c0.index();
   }
 
   // Window size = category size
-  std::vector<int> expectedEventsInBinBigWindow{4, 3, 2, 1, 4, 3, 2, 1};
+  std::vector<int> expectedCollisionsInBinBigWindow{4, 3, 2, 1, 4, 3, 2, 1};
   countFirst = 0;
   previousEvent = -1;
   auto combGenBigWindow = combinations(CombinationsBlockStrictlyUpperSameIndexPolicy(pairBinning, 5, -1, testA, testA));
   for (auto it = combGenBigWindow.begin(); it != combGenBigWindow.end(); it++) {
     auto& [c0, c1] = *it;
-    BOOST_CHECK_EQUAL(it.isFirstEvent(), previousEvent != c0.x());
-    if (it.isFirstEvent()) {
-      BOOST_CHECK_EQUAL(it.numberOfEventsToMixWith(), expectedEventsInBinBigWindow[countFirst]);
+    BOOST_CHECK_EQUAL(it.isNewWindow(), previousEvent != c0.x());
+    if (it.isNewWindow()) {
+      BOOST_CHECK_EQUAL(it.combinationsWithFirst(), expectedCollisionsInBinBigWindow[countFirst]);
       countFirst++;
     }
     previousEvent = c0.index();

--- a/Framework/Core/test/test_ASoAHelpers.cxx
+++ b/Framework/Core/test/test_ASoAHelpers.cxx
@@ -1368,7 +1368,7 @@ BOOST_AUTO_TEST_CASE(BlockCombinationsCounters)
     auto& [c0, c1] = *it;
     BOOST_CHECK_EQUAL(it.isNewWindow(), previousEvent != c0.x());
     if (it.isNewWindow()) {
-      BOOST_CHECK_EQUAL(it.combinationsWithFirst(), expectedCollisionsInBinSmallWindow[countFirst]);
+      BOOST_CHECK_EQUAL(it.currentWindowNeighbours(), expectedCollisionsInBinSmallWindow[countFirst]);
       countFirst++;
     }
     previousEvent = c0.index();
@@ -1383,7 +1383,7 @@ BOOST_AUTO_TEST_CASE(BlockCombinationsCounters)
     auto& [c0, c1] = *it;
     BOOST_CHECK_EQUAL(it.isNewWindow(), previousEvent != c0.x());
     if (it.isNewWindow()) {
-      BOOST_CHECK_EQUAL(it.combinationsWithFirst(), expectedCollisionsInBinEqualWindow[countFirst]);
+      BOOST_CHECK_EQUAL(it.currentWindowNeighbours(), expectedCollisionsInBinEqualWindow[countFirst]);
       countFirst++;
     }
     previousEvent = c0.index();
@@ -1398,7 +1398,7 @@ BOOST_AUTO_TEST_CASE(BlockCombinationsCounters)
     auto& [c0, c1] = *it;
     BOOST_CHECK_EQUAL(it.isNewWindow(), previousEvent != c0.x());
     if (it.isNewWindow()) {
-      BOOST_CHECK_EQUAL(it.combinationsWithFirst(), expectedCollisionsInBinBigWindow[countFirst]);
+      BOOST_CHECK_EQUAL(it.currentWindowNeighbours(), expectedCollisionsInBinBigWindow[countFirst]);
       countFirst++;
     }
     previousEvent = c0.index();

--- a/Framework/Core/test/test_ASoAHelpers.cxx
+++ b/Framework/Core/test/test_ASoAHelpers.cxx
@@ -1359,12 +1359,10 @@ BOOST_AUTO_TEST_CASE(BlockCombinationsCounters)
 
   ColumnBinningPolicy<test::Y, test::FloatZ> pairBinning{{yBins, zBins}, false};
 
-  std::vector<std::tuple<int32_t, int32_t>> expectedStrictlyUpperPairs{
-    {0, 4}, {0, 7}, {4, 7}, {1, 6}, {3, 5}, {2, 8}, {2, 9}, {8, 9}};
-  std::vector<int> expectedEventsInBin{4, 3, 2, 1, 4, 3, 2, 1};
+  std::vector<int> expectedEventsInBin{3, 3, 2, 1, 3, 3, 2, 1};
   int countFirst = 0;
   int previousEvent = -1;
-  auto combGen = combinations(CombinationsBlockStrictlyUpperSameIndexPolicy(pairBinning, 4, -1, testA, testA));
+  auto combGen = combinations(CombinationsBlockStrictlyUpperSameIndexPolicy(pairBinning, 3, -1, testA, testA));
   for (auto it = combGen.begin(); it != combGen.end(); it++) {
     auto& [c0, c1] = *it;
     BOOST_CHECK_EQUAL(it.isFirstEvent(), previousEvent != c0.x());


### PR DESCRIPTION
Ciao @ktf @jgrosseo 

here come mixing variables needed by @jgrosseo for weighted correlations.

I return the same number for strictly upper / upper / full combinations, so I delegate the responsibility to the user to interpret it correctly. For example, in upper combinations the 1st event will be mixed with `currentWindowNeighbors() + 1` events, including itself. In strictly upper combinations, the number is simply `currentWindowNeighbors()` and that's the most common use case. Let me know if you prefer some differentiation here.

Analysis task example in the PR mentioned below.