### PR TITLE
Cleanup ASoA

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1015,20 +1015,15 @@ constexpr bool is_binding_compatible_v()
   return are_bindings_compatible_v<T>(originals_pack_t<B>{});
 }
 
+//! Helper to check if a type T is an iterator
 template <typename T>
-using is_soa_iterator_t = typename framework::is_base_of_template<RowViewCore, T>;
-
-template <typename T>
-constexpr bool is_soa_iterator_v()
-{
-  return is_soa_iterator_t<T>::value || framework::is_specialization_v<T, RowViewCore>;
-}
+inline constexpr bool is_soa_iterator_v = framework::is_base_of_template_v<RowViewCore, T> || framework::is_specialization_v<T, RowViewCore>;
 
 template <typename T>
 using is_soa_table_t = typename framework::is_specialization<T, soa::Table>;
 
 template <typename T>
-using is_soa_table_like_t = typename framework::is_base_of_template<soa::Table, T>;
+inline constexpr bool is_soa_table_like_v = framework::is_base_of_template_v<soa::Table, T>;
 
 /// Helper function to extract bound indices
 template <typename... Is>
@@ -2921,7 +2916,7 @@ class Filtered<Filtered<T>> : public FilteredBase<typename T::table_t>
 };
 
 template <typename T>
-using is_soa_filtered_t = typename framework::is_base_of_template<soa::FilteredBase, T>;
+inline constexpr bool is_soa_filtered_v = framework::is_base_of_template_v<soa::FilteredBase, T>;
 
 /// Template for building an index table to access matching rows from non-
 /// joinable, but compatible tables, e.g. Collisions and ZDCs.
@@ -2953,7 +2948,7 @@ struct IndexTable : Table<soa::Index<>, H, Ts...> {
 };
 
 template <typename T>
-using is_soa_index_table_t = typename framework::is_base_of_template<soa::IndexTable, T>;
+inline constexpr bool is_soa_index_table_v = framework::is_base_of_template_v<soa::IndexTable, T>;
 
 template <typename T>
 struct SmallGroups : public Filtered<T> {

--- a/Framework/Core/include/Framework/ASoAHelpers.h
+++ b/Framework/Core/include/Framework/ASoAHelpers.h
@@ -88,7 +88,7 @@ std::vector<BinningIndex> groupTable(const T& table, const BP<Cs...>& binningPol
     return groupedIndices;
   }
 
-  if constexpr (soa::is_soa_filtered_t<T>::value) {
+  if constexpr (soa::is_soa_filtered_v<T>) {
     selectedRows = table.getSelectedRows(); // vector<int64_t>
   }
 
@@ -111,7 +111,7 @@ std::vector<BinningIndex> groupTable(const T& table, const BP<Cs...>& binningPol
       }
     });
 
-    if constexpr (soa::is_soa_filtered_t<T>::value) {
+    if constexpr (soa::is_soa_filtered_v<T>) {
       if (selectedRows[ind] >= selInd + chunkLength) {
         selInd += chunkLength;
         continue; // Go to the next chunk, no value selected in this chunk
@@ -120,7 +120,7 @@ std::vector<BinningIndex> groupTable(const T& table, const BP<Cs...>& binningPol
 
     uint64_t ai = 0;
     while (ai < chunkLength) {
-      if constexpr (soa::is_soa_filtered_t<T>::value) {
+      if constexpr (soa::is_soa_filtered_v<T>) {
         ai += selectedRows[ind] - selInd;
         selInd = selectedRows[ind];
       }
@@ -132,7 +132,7 @@ std::vector<BinningIndex> groupTable(const T& table, const BP<Cs...>& binningPol
       }
       ind++;
 
-      if constexpr (soa::is_soa_filtered_t<T>::value) {
+      if constexpr (soa::is_soa_filtered_v<T>) {
         if (ind >= selectedRows.size()) {
           break;
         }
@@ -141,7 +141,7 @@ std::vector<BinningIndex> groupTable(const T& table, const BP<Cs...>& binningPol
       }
     }
 
-    if constexpr (soa::is_soa_filtered_t<T>::value) {
+    if constexpr (soa::is_soa_filtered_v<T>) {
       if (ind == selectedRows.size()) {
         break;
       }

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -77,7 +77,7 @@ struct WritingCursor<soa::Table<PC...>> {
   template <typename T>
   static decltype(auto) extract(T const& arg)
   {
-    if constexpr (soa::is_soa_iterator_t<T>::value) {
+    if constexpr (soa::is_soa_iterator_v<T>) {
       return arg.globalIndex();
     } else {
       static_assert(!framework::has_type_v<T, framework::pack<PC...>>, "Argument type mismatch");
@@ -529,7 +529,7 @@ struct Service {
 template <typename T>
 auto getTableFromFilter(const T& table, soa::SelectionVector&& selection)
 {
-  if constexpr (soa::is_soa_filtered_t<std::decay_t<T>>::value) {
+  if constexpr (soa::is_soa_filtered_v<std::decay_t<T>>) {
     return std::make_unique<o2::soa::Filtered<T>>(std::vector{table}, std::forward<soa::SelectionVector>(selection));
   } else {
     return std::make_unique<o2::soa::Filtered<T>>(std::vector{table.asArrowTable()}, std::forward<soa::SelectionVector>(selection));
@@ -660,7 +660,7 @@ auto Extend(T const& table)
 template <typename T, typename... Cs>
 auto Attach(T const& table)
 {
-  static_assert((framework::is_base_of_template<o2::soa::DynamicColumn, Cs>::value && ...), "You can only attach dynamic columns");
+  static_assert((framework::is_base_of_template_v<o2::soa::DynamicColumn, Cs> && ...), "You can only attach dynamic columns");
   using output_t = Join<T, o2::soa::Table<Cs...>>;
   return output_t{{table.asArrowTable()}, table.offset()};
 }

--- a/Framework/Core/include/Framework/ConfigParamRegistry.h
+++ b/Framework/Core/include/Framework/ConfigParamRegistry.h
@@ -85,11 +85,11 @@ class ConfigParamRegistry
         return mStore->store().get<std::string>(key);
       } else if constexpr (std::is_same_v<T, std::string_view>) {
         return std::string_view{mStore->store().get<std::string>(key)};
-      } else if constexpr (is_base_of_template<std::vector, T>::value) {
+      } else if constexpr (is_base_of_template_v<std::vector, T>) {
         return vectorFromBranch<typename T::value_type>(mStore->store().get_child(key));
-      } else if constexpr (is_base_of_template<o2::framework::Array2D, T>::value) {
+      } else if constexpr (is_base_of_template_v<o2::framework::Array2D, T>) {
         return array2DFromBranch<typename T::element_t>(mStore->store().get_child(key));
-      } else if constexpr (is_base_of_template<o2::framework::LabeledArray, T>::value) {
+      } else if constexpr (is_base_of_template_v<o2::framework::LabeledArray, T>) {
         return labeledArrayFromBranch<typename T::element_t>(mStore->store().get_child(key));
       } else if constexpr (std::is_same_v<T, boost::property_tree::ptree>) {
         return mStore->store().get_child(key);

--- a/Framework/Core/include/Framework/GroupSlicer.h
+++ b/Framework/Core/include/Framework/GroupSlicer.h
@@ -55,7 +55,7 @@ struct GroupSlicer {
         return str;
       };
 
-      if constexpr (soa::is_soa_index_table_t<std::decay_t<Z>>::value) {
+      if constexpr (soa::is_soa_index_table_v<std::decay_t<Z>>) {
         using T = typename std::decay_t<Z>::first_t;
         if constexpr (soa::is_type_with_originals_v<std::decay_t<T>>) {
           using O = typename framework::pack_element_t<0, typename std::decay_t<Z>::originals>;
@@ -116,7 +116,7 @@ struct GroupSlicer {
     template <typename T>
     auto extractingFunction(T&& table)
     {
-      if constexpr (soa::is_soa_filtered_t<std::decay_t<T>>::value) {
+      if constexpr (soa::is_soa_filtered_v<std::decay_t<T>>) {
         constexpr auto index = framework::has_type_at_v<std::decay_t<T>>(associated_pack_t{});
         selections[index] = &table.getSelectedRows();
         starts[index] = selections[index]->begin();
@@ -131,7 +131,7 @@ struct GroupSlicer {
         mGroupingElement{gt.begin()},
         position{0}
     {
-      if constexpr (soa::is_soa_filtered_t<std::decay_t<G>>::value) {
+      if constexpr (soa::is_soa_filtered_v<std::decay_t<G>>) {
         groupSelection = mGt->getSelectedRows();
       }
 
@@ -230,7 +230,7 @@ struct GroupSlicer {
 
       if constexpr (relatedByIndex<std::decay_t<G>, std::decay_t<A1>>()) {
         uint64_t pos;
-        if constexpr (soa::is_soa_filtered_t<std::decay_t<G>>::value) {
+        if constexpr (soa::is_soa_filtered_v<std::decay_t<G>>) {
           pos = groupSelection[position];
         } else {
           pos = position;
@@ -241,7 +241,7 @@ struct GroupSlicer {
           if (originalTable.size() == 0) {
             return originalTable;
           }
-          if constexpr (soa::is_soa_filtered_t<std::decay_t<A1>>::value) {
+          if constexpr (soa::is_soa_filtered_v<std::decay_t<A1>>) {
             if (groups[index].empty()) {
               return std::decay_t<A1>{{makeEmptyTable<A1>("empty")}, soa::SelectionVector{}};
             }
@@ -272,7 +272,7 @@ struct GroupSlicer {
           }
         } else {
           //generic split
-          if constexpr (soa::is_soa_filtered_t<std::decay_t<A1>>::value) {
+          if constexpr (soa::is_soa_filtered_v<std::decay_t<A1>>) {
             // intersect selections
             o2::soa::SelectionVector s;
             if (selections[index]->empty()) {

--- a/Framework/Core/include/Framework/GroupedCombinations.h
+++ b/Framework/Core/include/Framework/GroupedCombinations.h
@@ -62,7 +62,7 @@ struct GroupedCombinationsGenerator {
     template <typename... T2s>
     GroupedIterator(const GroupingPolicy& groupingPolicy, const G& grouping, std::tuple<T2s...>& associated) : GroupingPolicy(groupingPolicy), mGrouping{std::make_shared<G>(std::vector{grouping.asArrowTable()})}, mAssociated{std::make_shared<std::tuple<As...>>(std::make_tuple(std::get<As>(associated)...))}, mIndexColumns{getMatchingIndexNode<G, As>()...}
     {
-      if constexpr (soa::is_soa_filtered_t<std::decay_t<G>>::value) {
+      if constexpr (soa::is_soa_filtered_v<std::decay_t<G>>) {
         mGrouping = std::make_shared<G>(std::vector{grouping.asArrowTable()}, grouping.getSelectedRows());
       } else {
         mGrouping = std::make_shared<G>(std::vector{grouping.asArrowTable()});
@@ -80,7 +80,7 @@ struct GroupedCombinationsGenerator {
     template <typename... T2s>
     void setTables(const G& grouping, std::tuple<T2s...>& associated)
     {
-      if constexpr (soa::is_soa_filtered_t<std::decay_t<G>>::value) {
+      if constexpr (soa::is_soa_filtered_v<std::decay_t<G>>) {
         mGrouping = std::make_shared<G>(std::vector{grouping.asArrowTable()}, grouping.getSelectedRows());
       } else {
         mGrouping = std::make_shared<G>(std::vector{grouping.asArrowTable()});

--- a/Framework/Core/include/Framework/RootTableBuilderHelpers.h
+++ b/Framework/Core/include/Framework/RootTableBuilderHelpers.h
@@ -205,7 +205,7 @@ struct RootTableBuilderHelpers {
                            TTreeReader& reader,
                            ReaderHolder<T>... holders)
   {
-    std::vector<std::string> branchNames = {holders.reader->GetBranchName()...};
+    std::array<char const*, sizeof...(T)> branchNames = {holders.reader->GetBranchName()...};
     TTree* tree = reader.GetTree();
     size_t maxExtries = reader.GetEntries(true);
     tree->SetCacheSize(maxExtries * (holders.itemSize + ...));

--- a/Framework/Core/include/Framework/TableBuilder.h
+++ b/Framework/Core/include/Framework/TableBuilder.h
@@ -692,7 +692,7 @@ class TableBuilder
     if constexpr (sizeof...(ARGS) == 1 &&
                   is_bounded_array<pack_element_t<0, args_pack_t>>::value == false &&
                   std::is_arithmetic_v<pack_element_t<0, args_pack_t>> == false &&
-                  framework::is_base_of_template<std::vector, pack_element_t<0, args_pack_t>>::value == false) {
+                  framework::is_base_of_template_v<std::vector, pack_element_t<0, args_pack_t>> == false) {
       using objType_t = pack_element_t<0, framework::pack<ARGS...>>;
       using argsPack_t = decltype(tuple_to_pack(framework::to_tuple(std::declval<objType_t>())));
       auto persister = persistTuple(argsPack_t{}, columnNames);
@@ -702,7 +702,7 @@ class TableBuilder
       };
     } else if constexpr (sizeof...(ARGS) == 1 &&
                          (is_bounded_array<pack_element_t<0, args_pack_t>>::value == true ||
-                          framework::is_base_of_template<std::vector, pack_element_t<0, args_pack_t>>::value == true)) {
+                          framework::is_base_of_template_v<std::vector, pack_element_t<0, args_pack_t>> == true)) {
       using objType_t = pack_element_t<0, framework::pack<ARGS...>>;
       auto persister = persistTuple(framework::pack<objType_t>{}, columnNames);
       // Callback used to fill the builders
@@ -920,7 +920,7 @@ constexpr auto pack_from_tuple(std::tuple<T...> const&)
 template <typename Key, typename T>
 void lowerBound(int32_t value, T& start)
 {
-  static_assert(soa::is_soa_iterator_t<T>::value, "Argument needs to be a Table::iterator");
+  static_assert(soa::is_soa_iterator_v<T>, "Argument needs to be a Table::iterator");
   int step;
   auto count = start.size() - start.globalIndex();
 

--- a/Framework/Core/src/TableBuilder.cxx
+++ b/Framework/Core/src/TableBuilder.cxx
@@ -72,11 +72,8 @@ void TableBuilder::throwError(RuntimeErrorRef const& ref)
   throw ref;
 }
 
-void TableBuilder::validate(const int nColumns, std::vector<std::string> const& columnNames) const
+void TableBuilder::validate() const
 {
-  if (nColumns != columnNames.size()) {
-    throwError(runtime_error("Mismatching number of column types and names"));
-  }
   if (mHolders != nullptr) {
     throwError(runtime_error("TableBuilder::persist can only be invoked once per instance"));
   }

--- a/Framework/Core/test/test_TableBuilder.cxx
+++ b/Framework/Core/test/test_TableBuilder.cxx
@@ -402,3 +402,12 @@ BOOST_AUTO_TEST_CASE(TestColumnCount)
   int count2 = TableBuilder::countColumns<float, int, char[3]>();
   BOOST_REQUIRE_EQUAL(count2, 3);
 }
+
+BOOST_AUTO_TEST_CASE(TestMakeFields) {
+  auto fields = TableBuilderHelpers::makeFields<int, float>({ "i", "f" });
+  BOOST_REQUIRE_EQUAL(fields.size(), 2);
+  BOOST_REQUIRE_EQUAL(fields[0]->name(), "i");
+  BOOST_REQUIRE_EQUAL(fields[1]->name(), "f");
+  BOOST_REQUIRE_EQUAL(fields[0]->type()->name(), "int32");
+  BOOST_REQUIRE_EQUAL(fields[1]->type()->name(), "float");
+}

--- a/Framework/Core/test/test_TableBuilder.cxx
+++ b/Framework/Core/test/test_TableBuilder.cxx
@@ -377,3 +377,28 @@ BOOST_AUTO_TEST_CASE(TestPodInjestion)
     ++i;
   }
 }
+
+BOOST_AUTO_TEST_CASE(TestColumnCount)
+{
+  struct Foo {
+    int x;
+    int y;
+  };
+  struct Bar {
+    int x;
+    int y;
+    std::string s;
+  };
+  struct FooBar {
+    int x;
+    int y;
+    float f;
+  };
+  BOOST_REQUIRE_EQUAL(TableBuilder::countColumns<Foo>(), 2);
+  BOOST_REQUIRE_EQUAL(TableBuilder::countColumns<Bar>(), 3);
+  BOOST_REQUIRE_EQUAL(TableBuilder::countColumns<FooBar>(), 3);
+  int count = TableBuilder::countColumns<float, int>();
+  BOOST_REQUIRE_EQUAL(count, 2);
+  int count2 = TableBuilder::countColumns<float, int, char[3]>();
+  BOOST_REQUIRE_EQUAL(count2, 3);
+}

--- a/Framework/Core/test/test_TypeTraits.cxx
+++ b/Framework/Core/test/test_TypeTraits.cxx
@@ -142,3 +142,35 @@ BOOST_AUTO_TEST_CASE(TestIsSpan)
   BOOST_REQUIRE_EQUAL(is_span<decltype(b)>::value, false);
   BOOST_REQUIRE_EQUAL(is_span<decltype(c)>::value, false);
 }
+
+template <typename A>
+struct FooFoo {
+};
+
+template <typename A>
+struct NoFooFoo {
+};
+
+struct Bar : FooFoo<int> {
+};
+
+struct NoBar : NoFooFoo<int> {
+};
+
+BOOST_AUTO_TEST_CASE(BaseOfTemplate)
+{
+  constexpr bool t = is_base_of_template_v<std::vector, std::vector<int>>;
+  static_assert(t == true, "This should be true");
+
+  constexpr bool t2 = is_base_of_template_v<std::vector, int>;
+  static_assert(t2 == false, "This should be true");
+
+  constexpr bool t3 = is_base_of_template_v<FooFoo, Bar>;
+  static_assert(t3 == true, "This should be true");
+
+  constexpr bool t4 = is_base_of_template_v<FooFoo, NoBar>;
+  static_assert(t4 == false, "This should be false");
+
+  constexpr bool t5 = is_base_of_template_v<NoFooFoo, NoBar>;
+  static_assert(t5 == true, "This should be true");
+}

--- a/Framework/Foundation/include/Framework/Traits.h
+++ b/Framework/Foundation/include/Framework/Traits.h
@@ -52,6 +52,9 @@ struct is_base_of_template_impl {
 template <template <typename...> class base, typename derived>
 using is_base_of_template = typename is_base_of_template_impl<base, derived>::type;
 
+template <template <typename...> class base, typename derived>
+inline constexpr bool is_base_of_template_v = is_base_of_template<base, derived>::value;
+
 } // namespace o2::framework
 
 #endif // O2_FRAMEWORK_TRAITS_H_


### PR DESCRIPTION
* Use _v suffix in place of ::value, as in C++14 and subsequent.
* Use std::array rather than std::vector when the number of columns is known.
* Avoid gymnastic between  columns and tables and back to columns. 