### PR TITLE
[EMCAL-798]: Prepare offline calibrator. 

### DIFF
--- a/Detectors/EMCAL/workflow/CMakeLists.txt
+++ b/Detectors/EMCAL/workflow/CMakeLists.txt
@@ -20,6 +20,7 @@ o2_add_library(EMCALWorkflow
                        src/AnalysisClusterSpec.cxx
                        src/RawToCellConverterSpec.cxx
                        src/EntropyEncoderSpec.cxx
+                       src/OfflineCalibSpec.cxx
                        src/EntropyDecoderSpec.cxx
                        src/StandaloneAODProducerSpec.cxx
                PUBLIC_LINK_LIBRARIES O2::Framework O2::DataFormatsCTP O2::DataFormatsEMCAL O2::EMCALSimulation O2::Steer
@@ -52,6 +53,13 @@ o2_add_executable(cell-writer-workflow
                   COMPONENT_NAME emcal
                   SOURCES src/cell-writer-workflow.cxx
                   PUBLIC_LINK_LIBRARIES O2::EMCALWorkflow)
+
+o2_add_executable(emc-offline-calib-workflow
+                  COMPONENT_NAME emcal
+                  SOURCES src/emc-offline-calib-workflow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::Framework
+                                        O2::EMCALWorkflow
+                                        O2::EMCALCalibration)
 
 o2_add_executable(cell-reader-workflow
                   COMPONENT_NAME emcal

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/OfflineCalibSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/OfflineCalibSpec.h
@@ -1,0 +1,73 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <string>
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+
+#include "TFile.h"
+#include "TH1.h"
+#include "TH2.h"
+#include "THnSparse.h"
+
+namespace o2
+{
+
+namespace emcal
+{
+
+/// \class OfflineCalibSpec
+/// \brief Task for producing offline calibration objects
+/// \ingroup EMCALworkflow
+/// \author Hannah Bossi <hannah.bossi@cern.ch>, Yale University
+/// \since August 16th, 2022
+///
+/// This task fills offline calibration objects for the EMCAL.
+class OfflineCalibSpec : public framework::Task
+{
+ public:
+  /// \brief Constructor
+  /// \param makeCellIDTimeEnergy If true the THnSparseF of cell ID, time, and energy is made
+  OfflineCalibSpec(bool makeCellIDTimeEnergy) : mMakeCellIDTimeEnergy(makeCellIDTimeEnergy){};
+
+  /// \brief Destructor
+  ~OfflineCalibSpec() override = default;
+
+  /// \brief Initializing the offline calib task
+  /// \param ctx Init context
+  void init(framework::InitContext& ctx) final;
+
+  /// \brief Fill histograms needed for the offline calibration
+  /// \param ctx Processing context
+  ///
+  void run(framework::ProcessingContext& ctx) final;
+
+  /// \brief Write histograms to an output root file
+  /// \param ec end of stream context
+  ///
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+
+ private:
+  std::unique_ptr<TH2> mCellAmplitude;         ///< Cell energy vs. cell ID
+  std::unique_ptr<TH2> mCellTime;              ///< Cell time vs. cell ID
+  std::unique_ptr<TH1> mNevents;               ///< Number of events
+  std::unique_ptr<THnSparseF> mCellTimeEnergy; ///< ID, time, energy
+  bool mMakeCellIDTimeEnergy = true;           ///< Switch whether or not to make a THnSparseF of cell ID, time, and energy
+};
+
+/// \brief Creating offline calib spec
+/// \ingroup EMCALworkflow
+///
+o2::framework::DataProcessorSpec getEmcalOfflineCalibSpec(bool makeCellIDTimeEnergy);
+
+} // namespace emcal
+
+} // namespace o2

--- a/Detectors/EMCAL/workflow/src/OfflineCalibSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/OfflineCalibSpec.cxx
@@ -1,0 +1,95 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <iostream>
+#include <vector>
+#include <type_traits>
+#include <gsl/span>
+
+#include "FairLogger.h"
+
+#include "Framework/ControlService.h"
+#include "Framework/DataRefUtils.h"
+#include "DataFormatsEMCAL/Cell.h"
+#include "DataFormatsEMCAL/TriggerRecord.h"
+#include "EMCALWorkflow/OfflineCalibSpec.h"
+
+using namespace o2::emcal;
+
+void OfflineCalibSpec::init(o2::framework::InitContext& ctx)
+{
+  // energy vs. cell ID
+  mCellAmplitude = std::unique_ptr<TH2>(new TH2F("mCellAmplitude", "Cell amplitude", 800, 0., 40., 17664, -0.5, 17663.5));
+  // time vs. cell ID
+  mCellTime = std::unique_ptr<TH2>(new TH2F("mCellTime", "Cell time", 800, -200, 600, 17664, -0.5, 17663.5));
+  // number of events
+  mNevents = std::unique_ptr<TH1>(new TH1F("mNevents", "Number of events", 1, 0.5, 1.5));
+  if (mMakeCellIDTimeEnergy) {
+    // cell time, cell energy, cell ID
+    std::array<int, 3> arrNBins = {17664, 100, 100}; // NCells, time, energy
+    std::array<double, 3> arrMin = {-0.5, -50, 0};
+    std::array<double, 3> arrMax = {17663.5, 50., 50};
+    mCellTimeEnergy = std::unique_ptr<THnSparseF>(new THnSparseF("CellIDvsTimevsEnergy", "CellIDvsTimevsEnergy", arrNBins.size(), arrNBins.data(), arrMin.data(), arrMax.data()));
+  }
+}
+
+void OfflineCalibSpec::run(framework::ProcessingContext& pc)
+{
+  auto cells = pc.inputs().get<gsl::span<o2::emcal::Cell>>("cells");
+  auto triggerrecords = pc.inputs().get<gsl::span<o2::emcal::TriggerRecord>>("triggerrecord");
+  LOG(debug) << "[EMCALOfflineCalib - run] received " << cells.size() << " cells from " << triggerrecords.size() << " triggers ...";
+  if (triggerrecords.size()) {
+    for (const auto& trg : triggerrecords) {
+      if (!trg.getNumberOfObjects()) {
+        LOG(debug) << "[EMCALOfflineCalib - run] Trigger does not contain cells, skipping ...";
+        continue;
+      }
+      LOG(debug) << "[EMCALOfflineCalib - run] Trigger has " << trg.getNumberOfObjects() << " cells  ..." << std::endl;
+      gsl::span<const o2::emcal::Cell> objectsTrigger(cells.data() + trg.getFirstEntry(), trg.getNumberOfObjects());
+      for (const auto& c : objectsTrigger) {
+        LOG(debug) << "[EMCALOfflineSpec - run] Channel: " << c.getTower();
+        LOG(debug) << "[EMCALOfflineSpec - run] Energy: " << c.getEnergy();
+        LOG(debug) << "[EMCALOfflineSpec - run] Time: " << c.getTimeStamp();
+        mCellAmplitude->Fill(c.getEnergy(), c.getTower());
+        if (c.getEnergy() > 0.5) {
+          mCellTime->Fill(c.getTimeStamp(), c.getTower());
+          if (mMakeCellIDTimeEnergy) {
+            mCellTimeEnergy->Fill(c.getTower(), c.getTimeStamp(), c.getEnergy());
+          }
+        }
+      }
+      mNevents->Fill(1);
+    }
+  }
+}
+
+void OfflineCalibSpec::endOfStream(o2::framework::EndOfStreamContext& ec)
+{
+  // write histograms to root file here
+  std::unique_ptr<TFile> outputFile(new TFile("emcal-offline-calib.root", "RECREATE"));
+  outputFile->cd();
+  mCellAmplitude->Write();
+  mCellTime->Write();
+  mNevents->Write();
+  if (mMakeCellIDTimeEnergy) {
+    mCellTimeEnergy->Write();
+  }
+  outputFile->Close();
+}
+
+o2::framework::DataProcessorSpec o2::emcal::getEmcalOfflineCalibSpec(bool makeCellIDTimeEnergy)
+{
+  return o2::framework::DataProcessorSpec{"EMCALOfflineCalib",
+                                          {{"cells", o2::header::gDataOriginEMC, "CELLS", 0, o2::framework::Lifetime::Timeframe},
+                                           {"triggerrecord", o2::header::gDataOriginEMC, "CELLSTRGR", 0, o2::framework::Lifetime::Timeframe}},
+                                          {},
+                                          o2::framework::adaptFromTask<o2::emcal::OfflineCalibSpec>(makeCellIDTimeEnergy)};
+}

--- a/Detectors/EMCAL/workflow/src/emc-offline-calib-workflow.cxx
+++ b/Detectors/EMCAL/workflow/src/emc-offline-calib-workflow.cxx
@@ -1,0 +1,41 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "EMCALWorkflow/OfflineCalibSpec.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "Framework/ConfigParamSpec.h"
+
+using namespace o2::framework;
+
+// ------------------------------------------------------------------
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  std::vector<ConfigParamSpec> options{{"makeCellIDTimeEnergy", VariantType::Bool, true, {"list whether or not to make the cell ID, time, energy THnSparse"}},
+                                       {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
+  workflowOptions.insert(workflowOptions.end(), options.begin(), options.end());
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  WorkflowSpec wf;
+  // Update the (declared) parameters if changed from the command line
+  bool makeCellIDTimeEnergy = cfgc.options().get<bool>("makeCellIDTimeEnergy");
+  o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
+  wf.emplace_back(o2::emcal::getEmcalOfflineCalibSpec(makeCellIDTimeEnergy));
+  return wf;
+}


### PR DESCRIPTION
Designed to produce objects used as input for the offline calibration. Linked with ctf reader workflow.