### PR TITLE
[EMCAL-565] Use proper calibrator in fillTFIDInfo

### DIFF
--- a/Detectors/EMCAL/calibration/testWorkflow/EMCALChannelCalibratorSpec.h
+++ b/Detectors/EMCAL/calibration/testWorkflow/EMCALChannelCalibratorSpec.h
@@ -96,7 +96,11 @@ class EMCALChannelCalibDevice : public o2::framework::Task
     }
 
     o2::base::GRPGeomHelper::instance().checkUpdates(pc);
-    o2::base::TFIDInfoHelper::fillTFIDInfo(pc, mTimeCalibrator->getCurrentTFInfo());
+    if (mTimeCalibrator) {
+      o2::base::TFIDInfoHelper::fillTFIDInfo(pc, mTimeCalibrator->getCurrentTFInfo());
+    } else if (mBadChannelCalibrator) {
+      o2::base::TFIDInfoHelper::fillTFIDInfo(pc, mBadChannelCalibrator->getCurrentTFInfo());
+    }
 
     auto tfcounter = o2::header::get<o2::framework::DataProcessingHeader*>(pc.inputs().get(getCellBinding()).header)->startTime;
 


### PR DESCRIPTION
Code was using hard-coded mTimeCalibrator in
fillTFIDInfo, which doesn't exist for the bad channel
calibration. Instead the bad channel calibrator must be
used here. Handling like the rest of the code is exclusive.