### PR TITLE
DPL Analysis: Event mixing: Fix to allow Pair and Triple on the same kind tables

### DIFF
--- a/Framework/Core/include/Framework/GroupedCombinations.h
+++ b/Framework/Core/include/Framework/GroupedCombinations.h
@@ -85,7 +85,7 @@ struct GroupedCombinationsGenerator {
       } else {
         mGrouping = std::make_shared<G>(std::vector{grouping.asArrowTable()});
       }
-      mAssociated = std::make_shared<std::tuple<As...>>(std::make_tuple(std::get<As>(associated)...));
+      mAssociated = std::make_shared<std::tuple<As...>>(std::make_tuple(std::get<has_type_at<As>(pack<T2s...>{})>(associated)...));
       setMultipleGroupingTables<sizeof...(As)>(grouping);
       if (!this->mIsEnd) {
         setCurrentGroupedCombination();

--- a/Framework/Core/include/Framework/GroupedCombinations.h
+++ b/Framework/Core/include/Framework/GroupedCombinations.h
@@ -60,7 +60,7 @@ struct GroupedCombinationsGenerator {
 
     GroupedIterator(const GroupingPolicy& groupingPolicy) : GroupingPolicy(groupingPolicy), mIndexColumns{getMatchingIndexNode<G, As>()...} {}
     template <typename... T2s>
-    GroupedIterator(const GroupingPolicy& groupingPolicy, const G& grouping, std::tuple<T2s...>& associated) : GroupingPolicy(groupingPolicy), mGrouping{std::make_shared<G>(std::vector{grouping.asArrowTable()})}, mAssociated{std::make_shared<std::tuple<As...>>(std::make_tuple(std::get<As>(associated)...))}, mIndexColumns{getMatchingIndexNode<G, As>()...}
+    GroupedIterator(const GroupingPolicy& groupingPolicy, const G& grouping, std::tuple<T2s...>& associated) : GroupingPolicy(groupingPolicy), mGrouping{std::make_shared<G>(std::vector{grouping.asArrowTable()})}, mAssociated{std::make_shared<std::tuple<As...>>(std::make_tuple(std::get<has_type_at<As>(pack<T2s...>{})>(associated)...))}, mIndexColumns{getMatchingIndexNode<G, As>()...}
     {
       if constexpr (soa::is_soa_filtered_t<std::decay_t<G>>::value) {
         mGrouping = std::make_shared<G>(std::vector{grouping.asArrowTable()}, grouping.getSelectedRows());


### PR DESCRIPTION
Hi @ktf @aalkin @jgrosseo 

this allows to repeat the same table in the definition of Pair and Triple (which originally are for different types/table, and SameKindPair and SameKindTriple are meant for the same table).

Use case: when we want to generalize code for both tracks-tracks and candidates-tracks mixing, see [here](https://github.com/saganatt-cern/O2Physics/blob/flow-hf-corr/PWGHF/HFC/Tasks/taskFlow.cxx#L396)