### PR TITLE
fix ITS/MFT track time assingment in VertexTrackMatcherSpec

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/src/VertexTrackMatcherSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/VertexTrackMatcherSpec.cxx
@@ -92,9 +92,9 @@ void VertexTrackMatcherSpec::updateTimeDependentParams(ProcessingContext& pc)
     initOnceDone = true;
     // put here init-once stuff
     const auto& alpParamsITS = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>::Instance();
-    mMatcher.setITSROFrameLengthMUS(o2::base::GRPGeomHelper::instance().getGRPECS()->isDetContinuousReadOut(o2::detectors::DetID::ITS) ? alpParamsITS.roFrameLengthTrig * 1.e-3 : alpParamsITS.roFrameLengthInBC * o2::constants::lhc::LHCBunchSpacingMUS);
+    mMatcher.setITSROFrameLengthMUS(o2::base::GRPGeomHelper::instance().getGRPECS()->isDetContinuousReadOut(o2::detectors::DetID::ITS) ? alpParamsITS.roFrameLengthInBC * o2::constants::lhc::LHCBunchSpacingMUS : alpParamsITS.roFrameLengthTrig * 1.e-3);
     const auto& alpParamsMFT = o2::itsmft::DPLAlpideParam<o2::detectors::DetID::MFT>::Instance();
-    mMatcher.setMFTROFrameLengthMUS(o2::base::GRPGeomHelper::instance().getGRPECS()->isDetContinuousReadOut(o2::detectors::DetID::MFT) ? alpParamsMFT.roFrameLengthTrig * 1.e-3 : alpParamsMFT.roFrameLengthInBC * o2::constants::lhc::LHCBunchSpacingMUS);
+    mMatcher.setMFTROFrameLengthMUS(o2::base::GRPGeomHelper::instance().getGRPECS()->isDetContinuousReadOut(o2::detectors::DetID::MFT) ? alpParamsMFT.roFrameLengthInBC * o2::constants::lhc::LHCBunchSpacingMUS : alpParamsMFT.roFrameLengthTrig * 1.e-3);
     LOGP(info, "VertexTrackMatcher ITSROFrameLengthMUS:{} MFTROFrameLengthMUS:{}", mMatcher.getITSROFrameLengthMUS(), mMatcher.getMFTROFrameLengthMUS());
   }
   // we may have other params which need to be queried regularly


### PR DESCRIPTION
Due to the typo instead of continuous readout ROF length the dummy triggered strobe length (6 ms) was used
in for ITS/MFT standalone track time resolution assignment.

Trivial fix, merging.