### PR TITLE
ShmManager: error & exit if memory is removed unexpectedly

### DIFF
--- a/Utilities/ShmManager/src/ShmManager.cxx
+++ b/Utilities/ShmManager/src/ShmManager.cxx
@@ -161,6 +161,21 @@ struct ShmManager {
     }
   }
 
+  bool CheckPresence()
+  {
+    for (const auto& sc : segmentCfgs) {
+      if (!(fair::mq::shmem::Monitor::SegmentIsPresent(fair::mq::shmem::ShmId{shmId}, sc.id))) {
+        return false;
+      }
+    }
+    for (const auto& rc : regionCfgs) {
+      if (!(fair::mq::shmem::Monitor::RegionIsPresent(fair::mq::shmem::ShmId{shmId}, rc.id.value()))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   void ResetContent()
   {
     fair::mq::shmem::Monitor::ResetContent(fair::mq::shmem::ShmId{shmId}, segmentCfgs, regionCfgs);
@@ -196,6 +211,7 @@ int main(int argc, char** argv)
 
   try {
     bool nozero = false;
+    bool checkPresence = true;
     uint64_t shmId = 0;
     vector<string> segments;
     vector<string> regions;
@@ -206,6 +222,7 @@ int main(int argc, char** argv)
       "segments", value<vector<string>>(&segments)->multitoken()->composing(), "Segments, as <id>,<size>,<numaid> <id>,<size>,<numaid> <id>,<size>,<numaid> ... (numaid: -2 disabled, -1 interleave, >=0 node)")(
       "regions", value<vector<string>>(&regions)->multitoken()->composing(), "Regions, as <id>,<size> <id>,<size>,<numaid> <id>,<size>,<numaid> ...")(
       "nozero", value<bool>(&nozero)->default_value(false)->implicit_value(true), "Do not zero segments after initialization")(
+      "check-presence", value<bool>(&checkPresence)->default_value(true)->implicit_value(true), "Check periodically if configured segments/regions are still present, and cleanup and leave if they are not")(
       "help,h", "Print help");
 
     variables_map vm;
@@ -234,11 +251,19 @@ int main(int argc, char** argv)
       }
     });
 
-    while (!gStopping) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    if (checkPresence) {
+      while (!gStopping) {
+        if (shmManager.CheckPresence() == false) {
+          LOG(error) << "Failed to find segments, exiting.";
+          gStopping = true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+      }
     }
 
-    resetContentThread.join();
+    if (resetContentThread.joinable()) {
+      resetContentThread.join();
+    }
 
     LOG(info) << "stopping.";
   } catch (exception& e) {


### PR DESCRIPTION
Add a option (on by default) to check periodically if all shmem segments/regions are still present, and error & exit if they are not.
To catch and report cases where a misconfigured device or anything else would remove the memory.

For https://alice.its.cern.ch/jira/browse/EPN-106.