### PR TITLE
update on tof calibration

### DIFF
--- a/DataFormats/Detectors/TOF/include/DataFormatsTOF/CalibInfoTOF.h
+++ b/DataFormats/Detectors/TOF/include/DataFormatsTOF/CalibInfoTOF.h
@@ -43,6 +43,8 @@ class CalibInfoTOF
   void setFlags(int flags) { mFlags = flags; }
   float getFlags() const { return mFlags; }
 
+  int getMask() const { return mMask; }
+
   // for event time maker
   float tofSignal() const { return mDeltaTimePi; }
   float tofExpSignalPi() const { return 0.0; }

--- a/DataFormats/Detectors/TOF/include/DataFormatsTOF/CalibTimeSlewingParamTOF.h
+++ b/DataFormats/Detectors/TOF/include/DataFormatsTOF/CalibTimeSlewingParamTOF.h
@@ -37,6 +37,7 @@ class CalibTimeSlewingParamTOF
   CalibTimeSlewingParamTOF& operator=(const CalibTimeSlewingParamTOF& source) = default;
 
   float getChannelOffset(int channel) const;
+  void setChannelOffset(int channel, float val);
 
   float evalTimeSlewing(int channel, float tot) const;
 

--- a/DataFormats/Detectors/TOF/src/CalibTimeSlewingParamTOF.cxx
+++ b/DataFormats/Detectors/TOF/src/CalibTimeSlewingParamTOF.cxx
@@ -35,6 +35,16 @@ float CalibTimeSlewingParamTOF::getChannelOffset(int channel) const
 {
   return evalTimeSlewing(channel, 0);
 }
+
+//______________________________________________
+void CalibTimeSlewingParamTOF::setChannelOffset(int channel, float val)
+{
+  int sector = channel / NCHANNELXSECTOR;
+  channel = channel % NCHANNELXSECTOR;
+
+  (*(mGlobalOffset[sector]))[channel] = val;
+}
+//______________________________________________
 void CalibTimeSlewingParamTOF::bind()
 {
   mGlobalOffset[0] = &mGlobalOffsetSec0;
@@ -55,12 +65,87 @@ void CalibTimeSlewingParamTOF::bind()
   mGlobalOffset[15] = &mGlobalOffsetSec15;
   mGlobalOffset[16] = &mGlobalOffsetSec16;
   mGlobalOffset[17] = &mGlobalOffsetSec17;
+
+  mChannelStart[0] = &mChannelStartSec0;
+  mChannelStart[1] = &mChannelStartSec1;
+  mChannelStart[2] = &mChannelStartSec2;
+  mChannelStart[3] = &mChannelStartSec3;
+  mChannelStart[4] = &mChannelStartSec4;
+  mChannelStart[5] = &mChannelStartSec5;
+  mChannelStart[6] = &mChannelStartSec6;
+  mChannelStart[7] = &mChannelStartSec7;
+  mChannelStart[8] = &mChannelStartSec8;
+  mChannelStart[9] = &mChannelStartSec9;
+  mChannelStart[10] = &mChannelStartSec10;
+  mChannelStart[11] = &mChannelStartSec11;
+  mChannelStart[12] = &mChannelStartSec12;
+  mChannelStart[13] = &mChannelStartSec13;
+  mChannelStart[14] = &mChannelStartSec14;
+  mChannelStart[15] = &mChannelStartSec15;
+  mChannelStart[16] = &mChannelStartSec16;
+  mChannelStart[17] = &mChannelStartSec17;
+
+  mTimeSlewing[0] = &mTimeSlewingSec0;
+  mTimeSlewing[1] = &mTimeSlewingSec1;
+  mTimeSlewing[2] = &mTimeSlewingSec2;
+  mTimeSlewing[3] = &mTimeSlewingSec3;
+  mTimeSlewing[4] = &mTimeSlewingSec4;
+  mTimeSlewing[5] = &mTimeSlewingSec5;
+  mTimeSlewing[6] = &mTimeSlewingSec6;
+  mTimeSlewing[7] = &mTimeSlewingSec7;
+  mTimeSlewing[8] = &mTimeSlewingSec8;
+  mTimeSlewing[9] = &mTimeSlewingSec9;
+  mTimeSlewing[10] = &mTimeSlewingSec10;
+  mTimeSlewing[11] = &mTimeSlewingSec11;
+  mTimeSlewing[12] = &mTimeSlewingSec12;
+  mTimeSlewing[13] = &mTimeSlewingSec13;
+  mTimeSlewing[14] = &mTimeSlewingSec14;
+  mTimeSlewing[15] = &mTimeSlewingSec15;
+  mTimeSlewing[16] = &mTimeSlewingSec16;
+  mTimeSlewing[17] = &mTimeSlewingSec17;
+
+  mFractionUnderPeak[0] = &mFractionUnderPeakSec0;
+  mFractionUnderPeak[1] = &mFractionUnderPeakSec1;
+  mFractionUnderPeak[2] = &mFractionUnderPeakSec2;
+  mFractionUnderPeak[3] = &mFractionUnderPeakSec3;
+  mFractionUnderPeak[4] = &mFractionUnderPeakSec4;
+  mFractionUnderPeak[5] = &mFractionUnderPeakSec5;
+  mFractionUnderPeak[6] = &mFractionUnderPeakSec6;
+  mFractionUnderPeak[7] = &mFractionUnderPeakSec7;
+  mFractionUnderPeak[8] = &mFractionUnderPeakSec8;
+  mFractionUnderPeak[9] = &mFractionUnderPeakSec9;
+  mFractionUnderPeak[10] = &mFractionUnderPeakSec10;
+  mFractionUnderPeak[11] = &mFractionUnderPeakSec11;
+  mFractionUnderPeak[12] = &mFractionUnderPeakSec12;
+  mFractionUnderPeak[13] = &mFractionUnderPeakSec13;
+  mFractionUnderPeak[14] = &mFractionUnderPeakSec14;
+  mFractionUnderPeak[15] = &mFractionUnderPeakSec15;
+  mFractionUnderPeak[16] = &mFractionUnderPeakSec16;
+  mFractionUnderPeak[17] = &mFractionUnderPeakSec17;
+
+  mSigmaPeak[0] = &mSigmaPeakSec0;
+  mSigmaPeak[1] = &mSigmaPeakSec1;
+  mSigmaPeak[2] = &mSigmaPeakSec2;
+  mSigmaPeak[3] = &mSigmaPeakSec3;
+  mSigmaPeak[4] = &mSigmaPeakSec4;
+  mSigmaPeak[5] = &mSigmaPeakSec5;
+  mSigmaPeak[6] = &mSigmaPeakSec6;
+  mSigmaPeak[7] = &mSigmaPeakSec7;
+  mSigmaPeak[8] = &mSigmaPeakSec8;
+  mSigmaPeak[9] = &mSigmaPeakSec9;
+  mSigmaPeak[10] = &mSigmaPeakSec10;
+  mSigmaPeak[11] = &mSigmaPeakSec11;
+  mSigmaPeak[12] = &mSigmaPeakSec12;
+  mSigmaPeak[13] = &mSigmaPeakSec13;
+  mSigmaPeak[14] = &mSigmaPeakSec14;
+  mSigmaPeak[15] = &mSigmaPeakSec15;
+  mSigmaPeak[16] = &mSigmaPeakSec16;
+  mSigmaPeak[17] = &mSigmaPeakSec17;
 }
 
 //______________________________________________
 float CalibTimeSlewingParamTOF::evalTimeSlewing(int channel, float totIn) const
 {
-
   // totIn is in ns
   // the correction is returned in ps
 
@@ -75,8 +160,8 @@ float CalibTimeSlewingParamTOF::evalTimeSlewing(int channel, float totIn) const
   if (n < 0) {
     return 0.;
   }
-
   int nstop = mTimeSlewing[sector]->size();
+
   if (channel < NCHANNELXSECTOR - 1) {
     nstop = (*(mChannelStart[sector]))[channel + 1];
   }

--- a/Detectors/TOF/base/include/TOFBase/CalibTOFapi.h
+++ b/Detectors/TOF/base/include/TOFBase/CalibTOFapi.h
@@ -66,6 +66,7 @@ class CalibTOFapi
   }
   void readLHCphase();
   void readTimeSlewingParam();
+  void readTimeSlewingParamFromFile(const char* filename);
   void readDiagnosticFrequencies();
   void loadDiagnosticFrequencies();
   void readActiveMap();

--- a/Detectors/TOF/base/include/TOFBase/Utils.h
+++ b/Detectors/TOF/base/include/TOFBase/Utils.h
@@ -56,6 +56,10 @@ class Utils
   static float mEtaMax;
   static float mLHCPhase;
 
+  static int addMaskBC(int mask, int channel);
+  static int getMaxUsed();
+  static int getMaxUsedChannel(int channel);
+
  private:
   static std::vector<int> mFillScheme;
   static int mBCmult[o2::constants::lhc::LHCMaxBunches];
@@ -70,6 +74,10 @@ class Utils
   static int mNsample;
   static int mIsample;
   static float mPhases[100];
+  static uint64_t mMaskBC[16];
+  static uint64_t mMaskBCUsed[16];
+  static int mMaskBCchan[o2::tof::Geo::NCHANNELS][16];
+  static int mMaskBCchanUsed[o2::tof::Geo::NCHANNELS][16];
 
   ClassDefNV(Utils, 1);
 };

--- a/Detectors/TOF/base/src/CalibTOFapi.cxx
+++ b/Detectors/TOF/base/src/CalibTOFapi.cxx
@@ -100,6 +100,17 @@ void CalibTOFapi::readTimeSlewingParam()
 }
 
 //______________________________________________________________________
+void CalibTOFapi::readTimeSlewingParamFromFile(const char* filename)
+{
+  TFile* f = TFile::Open(filename);
+  if (f) {
+    mSlewParam = (SlewParam*)f->Get("ccdb_object");
+  } else {
+    LOG(info) << "File " << filename << " not found";
+  }
+}
+
+//______________________________________________________________________
 
 void CalibTOFapi::readDiagnosticFrequencies()
 {
@@ -278,8 +289,8 @@ float CalibTOFapi::getTimeCalibration(int ich, float tot, float phase) const
   // time calibration to correct measured TOF times
 
   float corr = 0;
-  if (!mLHCphase || !mSlewParam) {
-    LOG(warning) << "Either LHC phase or slewing object null: mLHCphase = " << mLHCphase << ", mSlewParam = " << mSlewParam;
+  if (!mSlewParam) {
+    LOG(warning) << "slewing object null: mSlewParam = " << mSlewParam;
     return corr;
   }
   //  printf("LHC phase apply\n");

--- a/Detectors/TOF/base/src/Utils.cxx
+++ b/Detectors/TOF/base/src/Utils.cxx
@@ -38,6 +38,10 @@ o2::dataformats::CalibInfoTOF Utils::mCalibTracks[NTRACKS_REQUESTED];
 int Utils::mNsample = 0;
 int Utils::mIsample = 0;
 float Utils::mPhases[100];
+uint64_t Utils::mMaskBC[16] = {};
+uint64_t Utils::mMaskBCUsed[16] = {};
+int Utils::mMaskBCchan[o2::tof::Geo::NCHANNELS][16] = {};
+int Utils::mMaskBCchanUsed[o2::tof::Geo::NCHANNELS][16] = {};
 
 void Utils::addInteractionBC(int bc, bool fromCollisonCotext)
 {
@@ -255,4 +259,50 @@ bool Utils::hasFillScheme()
   }
 
   return false;
+}
+
+int Utils::addMaskBC(int mask, int channel)
+{
+  int mask2 = (mask >> 16);
+  int cmask = 1;
+  int used = 0;
+  for (int ibit = 0; ibit < 16; ibit++) {
+    if (mask & cmask) {
+      mMaskBCchan[channel][ibit]++;
+      mMaskBC[ibit]++;
+    }
+    if (mask2 & cmask) {
+      mMaskBCchanUsed[channel][ibit]++;
+      mMaskBCUsed[ibit]++;
+      used = ibit - 8;
+    }
+    cmask *= 2;
+  }
+  return used;
+}
+
+int Utils::getMaxUsed()
+{
+  int cmask = 0;
+  uint64_t val = 10; // at least 10 entry required
+  for (int ibit = 0; ibit < 16; ibit++) {
+    if (mMaskBC[ibit] > val) {
+      val = mMaskBC[ibit];
+      cmask = ibit - 8;
+    }
+  }
+  return cmask;
+}
+
+int Utils::getMaxUsedChannel(int channel)
+{
+  int cmask = 0;
+  int val = 10; // at least 10 entry required
+  for (int ibit = 0; ibit < 16; ibit++) {
+    if (mMaskBCchan[channel][ibit] > val) {
+      val = mMaskBCchan[channel][ibit];
+      cmask = ibit - 8;
+    }
+  }
+  return cmask;
 }

--- a/Detectors/TOF/calibration/src/LHCClockCalibrator.cxx
+++ b/Detectors/TOF/calibration/src/LHCClockCalibrator.cxx
@@ -16,6 +16,7 @@
 #include "CCDB/CcdbApi.h"
 #include "DetectorsCalibration/Utils.h"
 #include "DetectorsRaw/HBFUtils.h"
+#include "TOFBase/Utils.h"
 
 namespace o2
 {
@@ -41,7 +42,9 @@ void LHCClockDataHisto::fill(const gsl::span<const o2::dataformats::CalibInfoTOF
     auto ch = data[i].getTOFChIndex();
     auto dt = data[i].getDeltaTimePi();
     auto tot = data[i].getTot();
-    auto corr = calibApi->getTimeCalibration(ch, tot, 0.); // we take into offsets and time slewing but not lhc phase
+    int used = o2::tof::Utils::addMaskBC(data[i].getMask(), data[i].getTOFChIndex()); // fill the current BC candidate mask and return the one used
+    dt -= used * o2::tof::Geo::BC_TIME_INPS;                                          // report the time using the current 0 deltaBC as reference (the right one will be added later)
+    auto corr = calibApi->getTimeCalibration(ch, tot, 0.);                            // we take into offsets and time slewing but not lhc phase
     dt -= corr;
 
     //    printf("ch=%d - tot=%f - corr=%f -> dtcorr = %f (range=%f, bin=%d)\n",ch,tot,corr,dt,range,int((dt+range)*v2Bin));
@@ -98,6 +101,8 @@ void LHCClockCalibrator::finalizeSlot(Slot& slot)
 
   std::map<std::string, std::string> md;
   LHCphase l;
+  int tobeused = o2::tof::Utils::getMaxUsed();
+  fitValues[1] += tobeused * o2::tof::Geo::BC_TIME_INPS; // adjust by adding the right BC
   l.addLHCphase(0, fitValues[1]);
   l.addLHCphase(o2::ccdb::CcdbObjectInfo::INFINITE_TIMESTAMP_SECONDS, fitValues[1]);
   auto clName = o2::utils::MemFileHelper::getClassName(l);
@@ -105,7 +110,7 @@ void LHCClockCalibrator::finalizeSlot(Slot& slot)
 
   auto starting = slot.getStartTimeMS();
   auto stopping = slot.getEndTimeMS() + 5 * getSlotLength() + getMaxSlotsDelay();
-  LOG(info) << "starting = " << starting << " - stopping = " << stopping << " -> phase = " << fitValues[1] << " ps";
+  LOG(info) << "starting = " << starting << " - stopping = " << stopping << " -> phase = " << fitValues[1] << " ps (added BC = " << tobeused << ")";
   l.setStartValidity(starting);
   l.setEndValidity(stopping);
 


### PR DESCRIPTION
@chiarazampolli 
This is an updated version of TOF calibration able to manage 25 ns bunch spacing
Tested on a LHC22m run (both LHCphase and channel offset calib)
+ some fixes