### PR TITLE
[EMCAL-794] Add event counter and end of stream to data producer

### DIFF
--- a/Detectors/EMCAL/workflow/src/emc-channel-data-producer.cxx
+++ b/Detectors/EMCAL/workflow/src/emc-channel-data-producer.cxx
@@ -11,7 +11,6 @@
 
 /// \file  emc-channel-data-producer.cxx
 /// \brief This task generates an emcal event with a number of cells. It is designed to produce data for the testing of the bad channel and time calibration of the emcal
-///
 /// \author  Joshua Koenig <joshua.konig@cern.ch>
 
 #include "DataFormatsEMCAL/Cell.h"
@@ -23,6 +22,7 @@
 
 #include "Framework/DataRefUtils.h"
 #include "Framework/ControlService.h"
+#include "Framework/RawDeviceService.h"
 #include "Algorithm/RangeTokenizer.h"
 #include <random>
 
@@ -34,7 +34,7 @@
 
 using namespace o2::framework;
 
-DataProcessorSpec generateData(const std::string nameRootFile, const std::string nameInputHist, const bool isTimeCalib, const int nCellsPerEvent);
+DataProcessorSpec generateData(const std::string nameRootFile, const std::string nameInputHist, const bool isTimeCalib, const int nCellsPerEvent, const int nEventsMax);
 
 // we need to add workflow options before including Framework/runDataProcessing
 void customize(std::vector<ConfigParamSpec>& workflowOptions)
@@ -43,6 +43,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"inputRootFile", VariantType::String, "", {"input root file from which data is taken, if empty, random data will be produced"}},
     {"nameInputHist", VariantType::String, "", {"name of the 2d histogram inside the root file used for the data generation"}},
     {"isInputTimeCalib", VariantType::Bool, false, {"input is produced for time clibration or bad channel calibration. Information is needed if inputRootFiel is specified as it has ifferent content for bad channel calib and time calib"}},
+    {"nEvents", VariantType::Int, 10000, {"number of events that will be processed"}},
     {"nCellsPerEvent", VariantType::Int, 5, {"number of cells per emcal triggered event"}}};
 
   std::swap(workflowOptions, options);
@@ -56,15 +57,16 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
   const std::string nameRootFile = config.options().get<std::string>("inputRootFile");
   const std::string nameInputHist = config.options().get<std::string>("nameInputHist");
   const bool isTimeCalib = config.options().get<bool>("isInputTimeCalib");
+  int nEventsMax = config.options().get<int>("nEvents");
   const int nCellsPerEvent = config.options().get<int>("nCellsPerEvent");
 
   WorkflowSpec workflow;
-  workflow.emplace_back(generateData(nameRootFile, nameInputHist, isTimeCalib, nCellsPerEvent));
+  workflow.emplace_back(generateData(nameRootFile, nameInputHist, isTimeCalib, nCellsPerEvent, nEventsMax));
 
   return workflow;
 }
 
-DataProcessorSpec generateData(const std::string nameRootFile, const std::string nameInputHist, const bool isTimeCalib, const int nCellsPerEvent)
+DataProcessorSpec generateData(const std::string nameRootFile, const std::string nameInputHist, const bool isTimeCalib, const int nCellsPerEvent, const int nEventsMax)
 {
   std::vector<OutputSpec> outputSpecs;
   outputSpecs.emplace_back(o2::header::gDataOriginEMC, "CELLS", 0, o2::framework::Lifetime::Timeframe);
@@ -96,21 +98,32 @@ DataProcessorSpec generateData(const std::string nameRootFile, const std::string
     outputSpecs,
     AlgorithmSpec{
       [=](ProcessingContext& ctx) mutable {
+        // set up event counter. Return as soon as maximum number of events is reached
+        static int nEvent = 0;
+        if (nEvent >= nEventsMax) {
+          LOG(info) << "reached maximum amount of events requested " << nEvent << ". returning now";
+          ctx.services().get<o2::framework::ControlService>().endOfStream();
+        }
+        nEvent++;
+
+        // loop over cells
+        // ToDo: Make more realistic assumption that we dont always have the same amount of cells per event
         o2::pmr::vector<o2::emcal::Cell> CellOutput;
         for (int i = 0; i < nCellsPerEvent; ++i) {
           double cellID = 0;
           double cellE = 0;
           double cellTime = 0;
-          if (h2d) {
+          if (h2d) { // get values from histogram
             // case for time calibration
             if (isTimeCalib) {
               h2d->GetRandom2(cellTime, cellID);
               cellE = disEnergy(generator);
+              // bad channel calibration
             } else {
               h2d->GetRandom2(cellE, cellID);
               cellTime = disTime(generator);
             }
-          } else {
+          } else { // get values from random distributions
             cellID = disCellID(generator);
             cellE = disEnergy(generator);
             cellTime = disTime(generator);
@@ -118,6 +131,7 @@ DataProcessorSpec generateData(const std::string nameRootFile, const std::string
           // for now only consider low gain cells. Maybe implement high gain cells
           CellOutput.emplace_back(static_cast<int>(cellID), cellE, cellTime, o2::emcal::ChannelType_t::LOW_GAIN);
         }
+        // send output
         LOG(debug) << "sending " << CellOutput.size() << "cells";
         o2::pmr::vector<o2::emcal::TriggerRecord> TriggerOutput;
         TriggerOutput.emplace_back(0, 0, 0, CellOutput.size());


### PR DESCRIPTION
- As we wan to terminate the process after a certain amount of events is
reached (typically the number of events needed to trigger the
calibration), an event counter is introduced
- number of events added as workflow argument