### PR TITLE
[MCH] abort tracking if it takes too long

### DIFF
--- a/Detectors/MUON/MCH/Base/include/MCHBase/TrackerParam.h
+++ b/Detectors/MUON/MCH/Base/include/MCHBase/TrackerParam.h
@@ -43,8 +43,7 @@ struct TrackerParam : public o2::conf::ConfigurableParamHelper<TrackerParam> {
   bool refineTracks = true;    ///< refine the tracks in the end using cluster resolution
 
   std::size_t maxCandidates = 100000; ///< maximum number of track candidates above which the tracking abort
-
-  std::size_t maxClusters = std::numeric_limits<std::size_t>::max(); ///< maximum allowed number of clusters per ROF (above this number the tracking is not even attempted)
+  double maxTrackingDuration = 1000.; ///< maximum tracking duration in second above which the tracking abort
 
   O2ParamDef(TrackerParam, "MCHTracking");
 };

--- a/Detectors/MUON/MCH/PreClustering/src/PreClusterFinderSpec.cxx
+++ b/Detectors/MUON/MCH/PreClustering/src/PreClusterFinderSpec.cxx
@@ -200,7 +200,7 @@ class PreClusterFinderTask
 
     LOGP(info, "Processed {} digit rofs with {} digits and output {} precluster rofs with {} preclusters and {} digits",
          digitROFs.size(),
-         digits.size(),
+         nDigitsInRofs,
          preClusterROFs.size(),
          mPreClusters.size(), mUsedDigits.size());
   }

--- a/Detectors/MUON/MCH/Tracking/include/MCHTracking/TrackFinder.h
+++ b/Detectors/MUON/MCH/Tracking/include/MCHTracking/TrackFinder.h
@@ -134,6 +134,8 @@ class TrackFinder
 
   std::list<Track> mTracks{}; ///< list of reconstructed tracks
 
+  std::chrono::time_point<std::chrono::steady_clock> mStartTime{}; ///< time when the tracking start
+
   double mChamberResolutionX2 = 0.;      ///< chamber resolution square (cm^2) in x direction
   double mChamberResolutionY2 = 0.;      ///< chamber resolution square (cm^2) in y direction
   double mBendingVertexDispersion2 = 0.; ///< vertex dispersion square (cm^2) in y direction

--- a/Detectors/MUON/MCH/Workflow/src/TrackFinderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackFinderSpec.cxx
@@ -42,7 +42,6 @@
 #include "DataFormatsMCH/TrackMCH.h"
 #include "DataFormatsMCH/Cluster.h"
 #include "DataFormatsMCH/Digit.h"
-#include "MCHBase/TrackerParam.h"
 #include "MCHTracking/TrackParam.h"
 #include "MCHTracking/Track.h"
 #include "MCHTracking/TrackFinder.h"
@@ -127,15 +126,6 @@ class TrackFinderTask
     auto timeStart = std::chrono::high_resolution_clock::now();
 
     for (const auto& clusterROF : clusterROFs) {
-
-      if (clusterROF.getNEntries() > TrackerParam::Instance().maxClusters) {
-        LOGP(warning, "Number of clusters above limit ({}>{}) : skipping tracking", clusterROF.getNEntries(), TrackerParam::Instance().maxClusters);
-        int trackOffset(mchTracks.size());
-        writeTracks({}, mchTracks, usedClusters, digitsIn, usedDigits);
-        trackROFs.emplace_back(clusterROF.getBCData(), trackOffset, mchTracks.size() - trackOffset,
-                               clusterROF.getBCWidth());
-        continue;
-      }
 
       // sort the input clusters of the current event per DE
       std::unordered_map<int, std::list<const Cluster*>> clusters{};


### PR DESCRIPTION
This is to protect the synchronous reconstruction against a few events that take too long to reconstruct (because of too large combinatorics). See [MRRTF-193](https://alice.its.cern.ch/jira/browse/MRRTF-193). It replaces the temporary protection #9567.

The maximum tracking duration is adjustable with:
--configKeyValues "MCHTracking.maxTrackingDuration=xxx"
Where xxx is the time in second.

The default value, 1000s (i.e. no limit), is set for the asynchronous reconstruction where the average time over (several) CTFs is more important than the instantaneous time per ROF and loosing real physics events is more critical.

100s seems to be a reasonable limit for synchronous reconstruction (and even for asynchronous if needed (tested in run2 central PbPb events)). Even 10s could be an acceptable limit for the synchronous reconstruction.