### PR TITLE
[EMCAL-687] (WIP) Added cell calibration to Event handler

### DIFF
--- a/DataFormats/Detectors/EMCAL/CMakeLists.txt
+++ b/DataFormats/Detectors/EMCAL/CMakeLists.txt
@@ -10,20 +10,20 @@
 # or submit itself to any jurisdiction.
 
 o2_add_library(DataFormatsEMCAL
-               SOURCES src/EMCALBlockHeader.cxx 
+               SOURCES src/EMCALBlockHeader.cxx
                        src/TriggerRecord.cxx
                        src/Constants.cxx
                        src/Cluster.cxx
                        src/AnalysisCluster.cxx
-                       src/Cell.cxx 
+                       src/Cell.cxx
                        src/Digit.cxx
-                       src/EventHandler.cxx
                        src/CTF.cxx
                        src/ErrorTypeFEE.cxx
-               PUBLIC_LINK_LIBRARIES O2::CommonDataFormat 
-                                     O2::Headers 
-                                     O2::MathUtils 
-                                     O2::DetectorsBase 
+                       src/EventHandler.cxx
+               PUBLIC_LINK_LIBRARIES O2::CommonDataFormat
+                                     O2::Headers
+                                     O2::MathUtils
+                                     O2::DetectorsBase
                                      O2::SimulationDataFormat
                                      Boost::serialization)
 
@@ -35,10 +35,10 @@ o2_target_root_dictionary(DataFormatsEMCAL
                                   include/DataFormatsEMCAL/Digit.h
                                   include/DataFormatsEMCAL/Cluster.h
                                   include/DataFormatsEMCAL/AnalysisCluster.h
-                                  include/DataFormatsEMCAL/EventHandler.h
                                   include/DataFormatsEMCAL/MCLabel.h
                                   include/DataFormatsEMCAL/CTF.h
-                                  include/DataFormatsEMCAL/ErrorTypeFEE.h)
+                                  include/DataFormatsEMCAL/ErrorTypeFEE.h
+                                  include/DataFormatsEMCAL/EventHandler.h)
 
 o2_add_test(Cell
             SOURCES test/testCell.cxx

--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/EventData.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/EventData.h
@@ -12,6 +12,7 @@
 #define ALICEO2_EMCAL_EVENTDATA_H_
 #include <cstdint>
 #include <gsl/span>
+#include <vector>
 #include "CommonDataFormat/InteractionRecord.h"
 #include "DataFormatsEMCAL/Cell.h"
 #include "DataFormatsEMCAL/Cluster.h"
@@ -36,7 +37,7 @@ template <class InputType>
 struct EventData {
   InteractionRecord mInteractionRecord; ///< Interaction record for the trigger corresponding to this event
   gsl::span<const Cluster> mClusters;   ///< EMCAL clusters
-  gsl::span<const InputType> mCells;    ///< EMCAL cells / digits
+  std::vector<InputType> mCells;        ///< EMCAL cells / digits
   gsl::span<const int> mCellIndices;    ///< Cell indices in cluster
   uint64_t mTriggerBits;                ///< Trigger bits for the event
 
@@ -45,7 +46,7 @@ struct EventData {
   {
     mInteractionRecord.clear();
     mClusters = gsl::span<const Cluster>();
-    mCells = gsl::span<const InputType>();
+    mCells = std::vector<InputType>();
     mCellIndices = gsl::span<const int>();
     mTriggerBits = 0;
   }

--- a/DataFormats/Detectors/EMCAL/src/DataFormatsEMCALLinkDef.h
+++ b/DataFormats/Detectors/EMCAL/src/DataFormatsEMCALLinkDef.h
@@ -41,6 +41,7 @@
 
 #pragma link C++ class o2::emcal::EventData < o2::emcal::Cell> + ;
 #pragma link C++ class o2::emcal::EventData < o2::emcal::Digit> + ;
+
 #pragma link C++ class o2::emcal::EventHandler < o2::emcal::Cell> + ;
 #pragma link C++ class o2::emcal::EventHandler < o2::emcal::Digit> + ;
 

--- a/Detectors/AOD/CMakeLists.txt
+++ b/Detectors/AOD/CMakeLists.txt
@@ -15,6 +15,7 @@ target_link_libraries(
         AODProducerWorkflow
         INTERFACE
           O2::DetectorsVertexing
+          O2::EMCALReconstruction
           O2::FT0Workflow
           O2::FDDWorkflow
           O2::FV0Workflow

--- a/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
+++ b/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
@@ -25,7 +25,7 @@
 #include "DataFormatsTPC/TrackTPC.h"
 #include "DataFormatsTRD/TrackTRD.h"
 #include "DataFormatsZDC/BCRecData.h"
-#include "DataFormatsEMCAL/EventHandler.h"
+#include "EMCALReconstruction/EventHandler.h"
 #include "DataFormatsPHOS/EventHandler.h"
 #include "DetectorsBase/GRPGeomHelper.h"
 #include "Framework/AnalysisDataModel.h"
@@ -82,7 +82,7 @@ typedef boost::unordered_map<Triplet_t, int, TripletHash, TripletEqualTo> Triple
 class AODProducerWorkflowDPL : public Task
 {
  public:
-  AODProducerWorkflowDPL(GID::mask_t src, std::shared_ptr<DataRequest> dataRequest, std::shared_ptr<o2::base::GRPGeomRequest> gr, bool enableSV, std::string resFile, bool useMC = true) : mInputSources(src), mDataRequest(dataRequest), mGGCCDBRequest(gr), mEnableSV(enableSV), mResFile{resFile}, mUseMC(useMC) {}
+  AODProducerWorkflowDPL(GID::mask_t src, std::shared_ptr<DataRequest> dataRequest, std::shared_ptr<o2::base::GRPGeomRequest> gr, std::shared_ptr<o2::emcal::EMCALCalibRequest> emcCalibRequest, bool enableSV, std::string resFile, bool useMC = true) : mInputSources(src), mDataRequest(dataRequest), mGGCCDBRequest(gr), mEMCCalibRequest(emcCalibRequest), mEnableSV(enableSV), mResFile{resFile}, mUseMC(useMC) {}
   ~AODProducerWorkflowDPL() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
@@ -164,6 +164,9 @@ class AODProducerWorkflowDPL : public Task
 
   std::shared_ptr<DataRequest> mDataRequest;
   std::shared_ptr<o2::base::GRPGeomRequest> mGGCCDBRequest;
+
+  // EMCal calibration handler
+  std::shared_ptr<o2::emcal::EMCALCalibRequest> mEMCCalibRequest; ///< EMCal calib request handles which calibrations are applied
 
   static constexpr int TOFTimePrecPS = 16; // required max error in ps for TOF tracks
   // truncation is enabled by default

--- a/Detectors/EMCAL/calib/CMakeLists.txt
+++ b/Detectors/EMCAL/calib/CMakeLists.txt
@@ -11,6 +11,7 @@
 
 o2_add_library(EMCALCalib
                SOURCES src/BadChannelMap.cxx
+                       src/EMCALCalibCCDBHelper.cxx
                        src/TimeCalibrationParams.cxx
                        src/TimeCalibParamL1Phase.cxx
                        src/TempCalibrationParams.cxx
@@ -28,6 +29,8 @@ o2_add_library(EMCALCalib
 
 o2_target_root_dictionary(EMCALCalib
                           HEADERS include/EMCALCalib/BadChannelMap.h
+                                  include/EMCALCalib/EMCALCalibCCDBHelper.h
+                                  include/EMCALCalib/EMCALCalibrationHandler.h
                                   include/EMCALCalib/TimeCalibrationParams.h
                                   include/EMCALCalib/TimeCalibParamL1Phase.h
                                   include/EMCALCalib/TempCalibrationParams.h

--- a/Detectors/EMCAL/calib/include/EMCALCalib/CalibDB.h
+++ b/Detectors/EMCAL/calib/include/EMCALCalib/CalibDB.h
@@ -8,6 +8,10 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
+
+#ifndef EMCAL_CALIB_DB_H
+#define EMCAL_CALIB_DB_H
+
 #include <exception>
 #include <map>
 #include <string>
@@ -343,3 +347,5 @@ class CalibDB
 } // namespace emcal
 
 } // namespace o2
+
+#endif

--- a/Detectors/EMCAL/calib/include/EMCALCalib/EMCALCalibCCDBHelper.h
+++ b/Detectors/EMCAL/calib/include/EMCALCalib/EMCALCalibCCDBHelper.h
@@ -1,0 +1,135 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \class EMCALCalibCCDBHelper.h
+/// \brief Helper to load the inputs for calibration objects from the ccdb
+/// \author Joshua Konig <joshua.konig@cern.ch>
+/// \ingroup EMCALCalib
+/// \since Aug 18, 2022
+
+#ifndef EMCAL_CALIB_CCDB_HELPER_H_
+#define EMCAL_CALIB_CCDB_HELPER_H_
+
+#include <vector>
+#include <memory>
+#include "Framework/Task.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "CCDB/CcdbApi.h"
+#include "CCDB/CcdbObjectInfo.h"
+#include "CommonUtils/NameConf.h"
+#include "Framework/CCDBParamSpec.h"
+#include "EMCALCalib/CalibDB.h"
+#include "EMCALCalib/BadChannelMap.h"
+#include "EMCALCalib/TimeCalibrationParams.h"
+#include "EMCALCalib/GainCalibrationFactors.h"
+#include "EMCALCalib/TempCalibrationParams.h"
+
+namespace o2::framework
+{
+class ProcessingContext;
+class ConcreteDataMatcher;
+class InputSpec;
+} // namespace o2::framework
+
+namespace o2
+{
+
+namespace emcal
+{
+
+struct EMCALCalibRequest {
+
+  ///\brief constructor
+  EMCALCalibRequest() = delete;
+  EMCALCalibRequest(bool badChannel, bool timeCalib, bool gainCalib, bool tempCalib, std::vector<o2::framework::InputSpec>& inputs, bool askOnce = false);
+
+  ///\brief
+  void addInput(const o2::framework::InputSpec&& isp, std::vector<o2::framework::InputSpec>& inputs);
+
+  bool mAskBadChannel = false;    ///< switch to ask weather bad channel calibration should be applied
+  bool mAskTimeCalib = false;     ///< switch to ask weather time calibration should be applied
+  bool mAskTimeCalibSlew = false; ///< switch to ask weather time calibration slope should be applied
+  bool mAskGainCalib = false;     ///< switch to ask weather energy/gain calibration should be applied
+  bool mAskTempCalib = false;     ///< switch to ask weather temperature calibration should be applied
+
+  ClassDefNV(EMCALCalibRequest, 1);
+};
+
+class EMCALCalibCCDBHelper
+{
+
+ public:
+  ///\brief static constructor
+  static EMCALCalibCCDBHelper& instance()
+  {
+    static EMCALCalibCCDBHelper inst;
+    return inst;
+  }
+
+  ///\brief set EMCALCalibRequest to know which calibrations have to be applied
+  ///\param req EMCALCalibRequest
+  void setRequest(std::shared_ptr<EMCALCalibRequest> req);
+
+  ///\brief function to update calibration objects
+  bool finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj);
+
+  ///\brief function to check if calibration objects need to be updated
+  void checkUpdates(o2::framework::ProcessingContext& pc) const;
+
+  ///\brief check if bad channel calibration should be applied
+  ///\return true if calib should be applied, false otherwise
+  bool isCalibrateBadChannels() const { return mRequest->mAskBadChannel; }
+
+  ///\brief check if time calibration should be applied
+  ///\return true if calib should be applied, false otherwise
+  bool isCalibrateTime() const { return mRequest->mAskTimeCalib; }
+
+  ///\brief check if energy/gain calibration should be applied
+  ///\return true if calib should be applied, false otherwise
+  bool isCalibrateGain() const { return mRequest->mAskGainCalib; }
+
+  ///\brief check if temperature calibration should be applied
+  ///\return true if calib should be applied, false otherwise
+  bool isCalibrateTemperature() const { return mRequest->mAskTempCalib; }
+
+  ///\brief get current time calibration parameters
+  ///\return current time calibration parameters
+  auto getTimeCalibParams() const { return mTimeCalibParams; }
+
+  ///\brief get current bad channel calibration parameters
+  ///\return current bad channel calibration parameters
+  auto getBadChannelMap() const { return mBadChannelMap; }
+
+  ///\brief get current temperature calibration parameters
+  ///\return current temperature calibration parameters
+  auto getTempCalibParams() const { return mTemperatureCalibParams; }
+
+  ///\brief get current gain calibration parameters
+  ///\return current gain calibration parameters
+  auto getGainCalibParams() const { return mGainCalibParams; }
+
+ private:
+  EMCALCalibCCDBHelper() = default;
+
+  std::shared_ptr<EMCALCalibRequest> mRequest; ///< EMCALCalibRequest, which calibrations have to be applied
+
+  const o2::emcal::TimeCalibrationParams* mTimeCalibParams = nullptr;        ///< pointer to time calibration parameters
+  const o2::emcal::BadChannelMap* mBadChannelMap = nullptr;                  ///< pointer to bad channel calibration parameters
+  const o2::emcal::TempCalibrationParams* mTemperatureCalibParams = nullptr; ///< pointer to temperature calibration parameters
+  const o2::emcal::GainCalibrationFactors* mGainCalibParams = nullptr;       ///< pointer to gain calibration parameters
+};
+
+} // namespace emcal
+
+} // namespace o2
+
+#endif

--- a/Detectors/EMCAL/calib/include/EMCALCalib/EMCALCalibrationHandler.h
+++ b/Detectors/EMCAL/calib/include/EMCALCalib/EMCALCalibrationHandler.h
@@ -1,0 +1,102 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \class EMCALCalibrationHandler
+/// \brief  Apply the bad channel, time and energy calibration
+/// \author Joshua Koenig <joshua.konig@cern.ch>
+/// \ingroup EMCALCalib
+/// \since Aug 17, 2022
+
+#ifndef EMCAL_CALIBRATOR_HANDLER_H_
+#define EMCAL_CALIBRATOR_HANDLER_H_
+
+#include "DataFormatsEMCAL/Cell.h"
+#include "EMCALCalib/BadChannelMap.h"
+#include "EMCALCalib/TimeCalibrationParams.h"
+#include "EMCALCalib/EMCALCalibCCDBHelper.h"
+#include "CCDB/BasicCCDBManager.h"
+
+namespace o2
+{
+
+namespace emcal
+{
+
+template <class CellInputType>
+class EMCALCalibrationHandler
+{
+
+ public:
+  ///\brief constructor
+  EMCALCalibrationHandler() = default;
+  ///\brief destructor
+  ~EMCALCalibrationHandler() = default;
+
+  ///\brief check if cell is good cell
+  ///\param towerID cell id to be checked
+  ///\return true if cell is good or no calibration should be applied, false if cell is bad
+  bool acceptCell(const int towerID);
+
+  ///\brief calibrate cell time and energy
+  ///\param cell input cell
+  ///\return calibrated cell
+  CellInputType getCellCalibrated(CellInputType cell);
+
+  ClassDefNV(EMCALCalibrationHandler, 1);
+};
+
+template <class CellInputType>
+bool EMCALCalibrationHandler<CellInputType>::acceptCell(const int towerID)
+{
+  if (!o2::emcal::EMCALCalibCCDBHelper::instance().isCalibrateBadChannels()) {
+    LOG(debug) << "Bad Channels will not be calibrated";
+    return true;
+  }
+  if ((o2::emcal::EMCALCalibCCDBHelper::instance().getBadChannelMap())->getChannelStatus(towerID) != o2::emcal::BadChannelMap::MaskType_t::GOOD_CELL) {
+    return false;
+  }
+  return true;
+}
+
+template <class CellInputType>
+CellInputType EMCALCalibrationHandler<CellInputType>::getCellCalibrated(CellInputType cell)
+{
+  const bool isLowGain = false; // for now, treat all cells as high gain cells as low gain calibration would need a lot of statistic that is not aggregated in the onlne system
+
+  // get cell time calibration factor
+  float timeShift = 0;
+  if (o2::emcal::EMCALCalibCCDBHelper::instance().isCalibrateTime()) {
+    timeShift = o2::emcal::EMCALCalibCCDBHelper::instance().getTimeCalibParams()->getTimeCalibParam(cell.getTower(), isLowGain);
+  } else {
+    LOG(debug) << "Cell time will not be calibrated";
+  }
+
+  // TODO: apply time slope calibration (have to push this to ccdb once verified)
+
+  // get cell energy calibration factor
+  float energyShift = 1;
+  if (o2::emcal::EMCALCalibCCDBHelper::instance().isCalibrateGain()) {
+    energyShift = o2::emcal::EMCALCalibCCDBHelper::instance().getGainCalibParams()->getGainCalibFactors(cell.getTower());
+  } else {
+    LOG(debug) << "Cell energy will not be calibrated";
+  }
+
+  // create calibrated cell
+  float cellEnergyCalibrated = cell.getEnergy() * energyShift; // multiply be gain calib
+  float cellTimeCalibrated = cell.getTimeStamp() - timeShift;  // shift timing signal
+  CellInputType calibratedCell(cell.getTower(), cellEnergyCalibrated, cellTimeCalibrated, cell.getType());
+  return calibratedCell;
+}
+
+} // namespace emcal
+} // namespace o2
+
+#endif

--- a/Detectors/EMCAL/calib/src/EMCALCalibCCDBHelper.cxx
+++ b/Detectors/EMCAL/calib/src/EMCALCalibCCDBHelper.cxx
@@ -1,0 +1,98 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "EMCALCalib/EMCALCalibCCDBHelper.h"
+
+namespace o2
+{
+namespace emcal
+{
+
+EMCALCalibRequest::EMCALCalibRequest(bool badChannel, bool timeCalib, bool gainCalib, bool tempCalib, std::vector<o2::framework::InputSpec>& inputs, bool askOnce)
+  : mAskBadChannel(badChannel), mAskTimeCalib(timeCalib), mAskGainCalib(gainCalib), mAskTempCalib(tempCalib)
+{
+  if (mAskBadChannel) {
+    addInput({"EMC_BCM", "EMC", "EMC_BADCHANNELS", 0, o2::framework::Lifetime::Condition, o2::framework::ccdbParamSpec(o2::emcal::CalibDB::getCDBPathBadChannelMap())}, inputs);
+  }
+  if (mAskTimeCalib) {
+    addInput({"EMCAL_TCP", "EMC", "EMC_TIMECALIB", 0, o2::framework::Lifetime::Condition, o2::framework::ccdbParamSpec(o2::emcal::CalibDB::getCDBPathTimeCalibrationParams())}, inputs);
+  }
+  if (mAskTimeCalibSlew) {
+    LOG(warning) << "EMCAL time calibration slew not yet available!";
+    //   addInput({"EMC_TimeCalibParams", "EMC", "EMC_TIMECALIB", 0, o2::framework::Lifetime::Condition, o2::framework::ccdbParamSpec(o2::emcal::CalibDB::getCDBPathTimeCalibrationParams())}, inputs);
+  }
+  if (mAskGainCalib) {
+    addInput({"EMC_GCP", "EMC", "EMC_GAINCALIB", 0, o2::framework::Lifetime::Condition, o2::framework::ccdbParamSpec(o2::emcal::CalibDB::getCDBPathGainCalibrationParams())}, inputs);
+  }
+  if (mAskTempCalib) {
+    LOG(warning) << "EMCAL temperature calibration not yet available!";
+    //   addInput({"EMC_TimeCalibParams", "EMC", "EMC_TIMECALIB", 0, o2::framework::Lifetime::Condition, o2::framework::ccdbParamSpec(o2::emcal::CalibDB::getCDBPathTimeCalibrationParams())}, inputs);
+  }
+}
+
+void EMCALCalibRequest::addInput(const o2::framework::InputSpec&& isp, std::vector<o2::framework::InputSpec>& inputs)
+{
+  if (std::find(inputs.begin(), inputs.end(), isp) == inputs.end()) {
+    inputs.emplace_back(isp);
+  }
+}
+
+//=====================================================================================
+
+void EMCALCalibCCDBHelper::setRequest(std::shared_ptr<EMCALCalibRequest> req)
+{
+  if (mRequest) {
+    LOG(fatal) << "EMCALCalibCCDBHelper CCDB request was already set";
+  }
+  mRequest = req;
+}
+
+bool EMCALCalibCCDBHelper::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+{
+
+  if (mRequest->mAskBadChannel && matcher == o2::framework::ConcreteDataMatcher("EMC", "EMC_BADCHANNELS", 0)) {
+    mBadChannelMap = (o2::emcal::BadChannelMap*)obj;
+    LOG(info) << "EMCAL Bad Channel Map object updated";
+    return true;
+  }
+
+  if (mRequest->mAskTimeCalib && matcher == o2::framework::ConcreteDataMatcher("EMC", "EMC_TIMECALIB", 0)) {
+    mTimeCalibParams = (o2::emcal::TimeCalibrationParams*)obj;
+    LOG(info) << "EMCAL Time Calib Params object updated";
+    return true;
+  }
+
+  if (mRequest->mAskGainCalib && matcher == o2::framework::ConcreteDataMatcher("EMC", "EMC_GAINCALIB", 0)) {
+    mGainCalibParams = (o2::emcal::GainCalibrationFactors*)obj;
+    LOG(info) << "EMCAL Gain Calib Params object updated";
+    return true;
+  }
+
+  return false;
+}
+
+void EMCALCalibCCDBHelper::checkUpdates(o2::framework::ProcessingContext& pc) const
+{
+  // request input just to trigger finaliseCCDB if there was an update
+  if (mRequest->mAskBadChannel) {
+    pc.inputs().get<o2::emcal::BadChannelMap*>("EMC_BCM");
+  }
+  if (mRequest->mAskTimeCalib) {
+    pc.inputs().get<o2::emcal::TimeCalibrationParams*>("EMCAL_TCP");
+  }
+  if (mRequest->mAskGainCalib) {
+    pc.inputs().get<o2::emcal::GainCalibrationFactors*>("EMC_GCP");
+  }
+}
+
+} // namespace emcal
+
+} // namespace o2

--- a/Detectors/EMCAL/reconstruction/CMakeLists.txt
+++ b/Detectors/EMCAL/reconstruction/CMakeLists.txt
@@ -28,12 +28,15 @@ o2_add_library(EMCALReconstruction
         src/DigitReader.cxx
         src/CTFCoder.cxx
         src/CTFHelper.cxx
+        src/EventHandler.cxx
         PUBLIC_LINK_LIBRARIES FairRoot::Base O2::Headers
         AliceO2::InfoLogger
         O2::DataFormatsEMCAL
         O2::DetectorsBase
         O2::DetectorsRaw
         O2::EMCALBase
+        O2::EMCALCalib
+        O2::EMCALCalibration
         O2::rANS
         Microsoft.GSL::GSL)
 
@@ -54,6 +57,7 @@ o2_target_root_dictionary(
         include/EMCALReconstruction/ClusterizerTask.h
         include/EMCALReconstruction/DigitReader.h
         include/EMCALReconstruction/RecoParam.h
+        include/EMCALReconstruction/EventHandler.h
 )
 
 o2_add_executable(rawreader-file

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/EventHandler.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/EventHandler.h
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <exception>
 #include <iterator>
+#include <vector>
 #include <gsl/span>
 #include "Rtypes.h"
 #include "fmt/format.h"
@@ -22,7 +23,9 @@
 #include "DataFormatsEMCAL/Digit.h"
 #include "DataFormatsEMCAL/EventData.h"
 #include "DataFormatsEMCAL/TriggerRecord.h"
-
+#include "EMCALCalib/BadChannelMap.h"
+#include "EMCALCalib/TimeCalibrationParams.h"
+#include "EMCALCalib/EMCALCalibrationHandler.h"
 namespace o2
 {
 namespace emcal
@@ -396,6 +399,20 @@ class EventHandler
     mTriggerRecordsCellIndices = triggersCellIndex;
   }
 
+  /// \brief Set the bad channel map for the EMCal
+  /// \param bcm EMCal bad channel map
+  void setEMCBadChannelMap(o2::emcal::BadChannelMap bcm)
+  {
+    mEMCBadChannelMap = bcm;
+  }
+
+  /// \brief Set the time calibration parameters for the EMCal
+  /// \param tcp EMCal time calibration parameters
+  void setEMCTimeCalibParam(o2::emcal::TimeCalibrationParams tcp)
+  {
+    mEMCTimeCalibParams = tcp;
+  }
+
   /// \brief Setting the data at cell level
   /// \param cells Container for cells within the timeframe
   /// \param triggers Container with trigger records corresponding to the cell container
@@ -437,6 +454,9 @@ class EventHandler
   ClusterRange mClusters;             /// container for clusters in timeframe
   CellIndexRange mClusterCellIndices; /// container for cell indices in timeframe
   CellRange mCells;                   /// container for cells in timeframe
+
+  o2::emcal::TimeCalibrationParams mEMCTimeCalibParams;
+  o2::emcal::BadChannelMap mEMCBadChannelMap;
 
   ClassDefNV(EventHandler, 1);
 };

--- a/Detectors/EMCAL/reconstruction/src/EMCALReconstructionLinkDef.h
+++ b/Detectors/EMCAL/reconstruction/src/EMCALReconstructionLinkDef.h
@@ -35,4 +35,7 @@
 #pragma link C++ class o2::emcal::ClusterizerTask < o2::emcal::Digit> + ;
 #pragma link C++ class o2::emcal::DigitReader < o2::emcal::Cell> + ;
 #pragma link C++ class o2::emcal::DigitReader < o2::emcal::Digit> + ;
+#pragma link C++ class o2::emcal::EventHandler < o2::emcal::Cell> + ;
+#pragma link C++ class o2::emcal::EventHandler < o2::emcal::Digit> + ;
+
 #endif

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/AnalysisClusterSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/AnalysisClusterSpec.h
@@ -14,7 +14,7 @@
 #include "DataFormatsEMCAL/Cluster.h"
 #include "DataFormatsEMCAL/TriggerRecord.h"
 #include "DataFormatsEMCAL/AnalysisCluster.h"
-#include "DataFormatsEMCAL/EventHandler.h"
+#include "EMCALReconstruction/EventHandler.h"
 #include "EMCALBase/Geometry.h"
 #include "EMCALBase/ClusterFactory.h"
 #include "EMCALReconstruction/Clusterizer.h"
@@ -67,10 +67,10 @@ class AnalysisClusterSpec : public framework::Task
 
  private:
   void updateTimeDependentParams(framework::ProcessingContext& pc);
-  o2::emcal::Clusterizer<InputType> mClusterizer;                        ///< Clusterizer object
-  o2::emcal::Geometry* mGeometry = nullptr;                              ///< Pointer to geometry object
-  o2::emcal::EventHandler<InputType>* mEventHandler = nullptr;           ///< Pointer to the event builder
-  o2::emcal::ClusterFactory<InputType>* mClusterFactory = nullptr;       ///< Pointer to the cluster builder
+  o2::emcal::Clusterizer<InputType> mClusterizer;                  ///< Clusterizer object
+  o2::emcal::Geometry* mGeometry = nullptr;                        ///< Pointer to geometry object
+  o2::emcal::EventHandler<InputType>* mEventHandler = nullptr;     ///< Pointer to the event builder
+  o2::emcal::ClusterFactory<InputType>* mClusterFactory = nullptr; ///< Pointer to the cluster builder
   std::shared_ptr<o2::base::GRPGeomRequest> mGGCCDBRequest;
   std::vector<o2::emcal::AnalysisCluster>* mOutputAnaClusters = nullptr; ///< Container with output clusters (pointer)
 };

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/StandaloneAODProducerSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/StandaloneAODProducerSpec.h
@@ -19,7 +19,8 @@
 #include "Framework/AnalysisHelpers.h"
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
-#include "DataFormatsEMCAL/EventHandler.h"
+#include "EMCALReconstruction/EventHandler.h"
+#include "EMCALCalib/EMCALCalibCCDBHelper.h"
 #include <TStopwatch.h>
 
 namespace o2
@@ -30,11 +31,13 @@ namespace emcal
 class StandaloneAODProducerSpec : public o2::framework::Task
 {
  public:
-  StandaloneAODProducerSpec();
+  StandaloneAODProducerSpec(std::shared_ptr<o2::emcal::EMCALCalibRequest> cr);
   ~StandaloneAODProducerSpec() override = default;
   void run(o2::framework::ProcessingContext& pc) final;
   void init(o2::framework::InitContext& ic) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+  void updateTimeDependentParams(o2::framework::ProcessingContext& pc);
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
 
   static const char* getCellBinding() { return "EMCCells"; }
   static const char* getCellTriggerRecordBinding() { return "EMCCellsTrgR"; }
@@ -45,6 +48,7 @@ class StandaloneAODProducerSpec : public o2::framework::Task
   uint32_t mCaloAmp = 0xFFFFFF00;                                        // 15 bits
   uint32_t mCaloTime = 0xFFFFFF00;                                       // 15 bits
   o2::emcal::EventHandler<o2::emcal::Cell>* mCaloEventHandler = nullptr; ///< Pointer to the event builder for emcal cells
+  std::shared_ptr<o2::emcal::EMCALCalibRequest> mCalibRequest;           ///< calib request handles which calibrations are applied
   TStopwatch mTimer;
 
   static const char* BININGCELLS;
@@ -52,7 +56,7 @@ class StandaloneAODProducerSpec : public o2::framework::Task
 };
 
 /// create a processor spec
-framework::DataProcessorSpec getStandaloneAODProducerSpec();
+framework::DataProcessorSpec getStandaloneAODProducerSpec(std::array<bool, 4> arrEnableCalib);
 
 } // namespace emcal
 } // namespace o2

--- a/Detectors/EMCAL/workflow/src/standalone-aod-producer-workflow.cxx
+++ b/Detectors/EMCAL/workflow/src/standalone-aod-producer-workflow.cxx
@@ -26,7 +26,13 @@ using namespace o2::framework;
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   // option allowing to set parameters
-  std::vector<ConfigParamSpec> options{ConfigParamSpec{"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
+  std::vector<ConfigParamSpec> options{
+    ConfigParamSpec{"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}},
+    ConfigParamSpec{"enableCalibBadChannel", VariantType::Bool, false, {"enable bad channel calibration"}},
+    ConfigParamSpec{"enableCalibTime", VariantType::Bool, false, {"enable time calibration"}},
+    ConfigParamSpec{"enableCalibGain", VariantType::Bool, false, {"enable gain calibration"}},
+    ConfigParamSpec{"enableCalibTemp", VariantType::Bool, false, {"enable temperature calibration"}},
+  };
 
   std::swap(workflowOptions, options);
 }
@@ -40,6 +46,12 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   WorkflowSpec wf;
   // Update the (declared) parameters if changed from the command line
   o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
-  wf.emplace_back(o2::emcal::getStandaloneAODProducerSpec());
+  std::array<bool, 4> arrEnableCalib = {
+    cfgc.options().get<bool>("enableCalibBadChannel"),
+    cfgc.options().get<bool>("enableCalibTime"),
+    cfgc.options().get<bool>("enableCalibGain"),
+    cfgc.options().get<bool>("enableCalibTemp")};
+
+  wf.emplace_back(o2::emcal::getStandaloneAODProducerSpec(arrEnableCalib));
   return wf;
 }

--- a/Detectors/Filtering/CMakeLists.txt
+++ b/Detectors/Filtering/CMakeLists.txt
@@ -16,6 +16,7 @@ o2_add_executable(
   PUBLIC_LINK_LIBRARIES
           O2::DataFormatsGlobalTracking
           O2::DetectorsVertexing
+          O2::EMCALReconstruction
           O2::FT0Workflow
           O2::FDDWorkflow
           O2::FV0Workflow

--- a/Detectors/Filtering/src/FilteringSpec.h
+++ b/Detectors/Filtering/src/FilteringSpec.h
@@ -27,7 +27,7 @@
 #include "DataFormatsTPC/TrackTPC.h"
 #include "DataFormatsTRD/TrackTRD.h"
 #include "DataFormatsZDC/BCRecData.h"
-#include "DataFormatsEMCAL/EventHandler.h"
+#include "EMCALReconstruction/EventHandler.h"
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
 #include "Framework/ConcreteDataMatcher.h"


### PR DESCRIPTION
- Time, Bad channel, Energy and temperature calibration have to be
applied going from CTF -> AO2D
- The calibration objects are stored in the ccdb and are now loaded into
the dedicated component: EMCALCalibrationHandler which can be steered
via the EMCALCalibCCDBHelper where one can set which calibrations should
be applied.
- In the EventHandler, before the calibrations are stored in the
EventData object, the EMCALCalibrationHandler decides if the cell is
good or bad (the cell is only stored  if it is good), and if it is a
good cell, applies the calibrations.
- In order to only accept good cells, the cell list in the EventData had
to be changed to a vector instead of a span. The span does not own the
objects in the span and we could therefore only look at the existing
cell array of all cells in the event. To avoid filtering out cells
additionally in the AODProducer, a vector was used to store the
calibrated cells in the eventData.
- The EMCALCalibCCDBHelper is instanciated in the AODProducer directly
and can be accessed from all tasks afterwards
- The EventHandler was moved from DataFormats to reconstruction in order
to avoid circular dependencies