### PR TITLE
DPL: Get stuck in some pathological cases of incorrect EoS, instead of quitting without error

### DIFF
--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -1192,6 +1192,9 @@ void DataProcessingDevice::doPrepare(DataProcessorContext& context)
     auto newEnd = std::remove_if(pollOrder.begin(), pollOrder.end(), [&infos, limitNew = currentOldest.value + ahead](int a) -> bool {
       return infos[a].oldestForChannel.value > limitNew;
     });
+    if (newEnd != pollOrder.end()) {
+      context.allDone = false;
+    }
     pollOrder.erase(newEnd, pollOrder.end());
   }
   LOGP(debug, "processing {} channels", pollOrder.size());


### PR DESCRIPTION
@ktf : This is the patch we discussed this morning.
For me the FST runs through with it.
I think in principle we don't need it, on the other hand it would be the slightly better behavior in case of this error condition.

I am slightly concerned whether we might break something with it.
I.e., in case we remove e.g. a timer channel with `info.state != InputChannelState::Pull` and then set it to false, coud we break something?