### PR TITLE
[EMCAL-565]: Fix for bad channel histo range, reorganize EMCALCalibParams

### DIFF
--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibParams.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibParams.h
@@ -29,18 +29,46 @@ namespace emcal
 // class containing the parameters to trigger the calibrations
 struct EMCALCalibParams : public o2::conf::ConfigurableParamHelper<EMCALCalibParams> {
 
+  // parameters for bad channel calibration
+  unsigned int minNEvents_bc = 1e7;     ///< minimum number of events to trigger the calibration
+  unsigned int minNEntries_bc = 1e6;    ///< minimum number of entries to trigger the calibration
+  bool useNEventsForCalib_bc = true;    ///< use the minimum number of events to trigger the calibration
+  bool useScaledHisto_bc = true;        ///< use the scaled histogram for the bad channel map
+  bool enableTestMode_bc = false;       ///< enable test mode for calibration
+  int nBinsEnergyAxis_bc = 1000;        ///< number of bins for boost histogram energy axis
+  float maxValueEnergyAxis_bc = 10;     ///< maximum value for boost histogram energy axis (minimum is always 0)
+  unsigned int slotLength_bc = 0;       ///< Lenght of the slot before calibration is triggered. If set to 0 calibration is triggered when hasEnoughData returns true
+  bool UpdateAtEndOfRunOnly_bc = false; ///< switsch to enable trigger of calibration only at end of run
+
+  // parameters for time calibration
+  unsigned int minNEvents_tc = 1e7;     ///< minimum number of events to trigger the calibration
+  unsigned int minNEntries_tc = 1e6;    ///< minimum number of entries to trigger the calibration
+  bool useNEventsForCalib_tc = true;    ///< use the minimum number of events to trigger the calibration
+  float minCellEnergy_tc = 0.5;         ///< minimum cell energy to enter the time calibration (typical minimum seed energy for clusters), time resolution gets better with rising energy
+  int minTimeForFit_tc = -300;          ///< minimum cell time considered for the time calibration in ns
+  int maxTimeForFit_tc = 300;           ///< maximum cell time considered for the time calibration in ns
+  int restrictFitRangeToMax_tc = 25;    ///< window around the largest entry within the minTimeForFit in which the fit is performed in ns
+  int nBinsTimeAxis_tc = 1500;          ///< number of bins used for the time calibration
+  int minValueTimeAxis_tc = -500;       ///< minimum value of the time axis in the time calibration
+  int maxValueTimeAxis_tc = 1000;       ///< maximum value of the time axis in the time calibration
+  unsigned int slotLength_tc = 0;       ///< Lenght of the slot before calibration is triggered. If set to 0 calibration is triggered when hasEnoughData returns true
+  bool UpdateAtEndOfRunOnly_tc = false; ///< switsch to enable trigger of calibration only at end of run
+
+  // common parameters
+  std::string calibType = "time";     ///< type of calibration to run
+  std::string localRootFilePath = ""; ///< path to local root file in order to store the calibration histograms (off by default, only to be used for testing)
+  bool enableFastCalib = false;       ///< switch to enable fast calibration. Instead of filling boost histograms, mean and sigma of cells is calculated on the fly
+  bool enableTimeProfiling = false;   ///< enable to log how much time is spent in the run function in the calibrator spec. Needed for speed tests offline and at point 2
+
+  // old parameters. Keep them for a bit (can be deleted after september 5th) as otherwise ccdb and o2 version might not be in synch
   unsigned int minNEvents = 1e7;              ///< minimum number of events to trigger the calibration
   unsigned int minNEntries = 1e6;             ///< minimum number of entries to trigger the calibration
   bool useNEventsForCalib = true;             ///< use the minimum number of events to trigger the calibration
-  std::string calibType = "time";             ///< type of calibration to run
-  std::string localRootFilePath = "";         ///< path to local root file in order to store the calibration histograms (off by default, only to be used for testing)
   bool useScaledHistoForBadChannelMap = true; ///< use the scaled histogram for the bad channel map
   bool enableTestMode = false;                ///< enable test mode for calibration
   float minCellEnergyForTimeCalib = 0.5;      ///< minimum cell energy to enter the time calibration (typical minimum seed energy for clusters), time resolution gets better with rising energy
   unsigned int slotLength = 0;                ///< Lenght of the slot before calibration is triggered. If set to 0 calibration is triggered when hasEnoughData returns true
   bool UpdateAtEndOfRunOnly = false;          ///< switsch to enable trigger of calibration only at end of run
-  bool enableTimeProfiling = false;           ///< enable to log how much time is spent in the run function in the calibrator spec. Needed for speed tests offline and at point 2
-  bool enableFastCalib = false;               ///< switch to enable fast calibration. Instead of filling boost histograms, mean and sigma of cells is calculated on the fly
   int minTimeForFit = -300;                   ///< minimum cell time considered for the time calibration in ns
   int maxTimeForFit = 300;                    ///< maximum cell time considered for the time calibration in ns
   int restrictFitRangeToMax = 25;             ///< window around the largest entry within the minTimeForFit in which the fit is performed in ns

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelData.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelData.h
@@ -46,11 +46,6 @@ namespace emcal
 {
 class EMCALCalibExtractor;
 
-struct ChannelCalibInitParams {
-  unsigned int nbins = 1000;
-  std::array<float, 2> range = {0, 0.35};
-};
-
 class EMCALChannelData
 {
   //using Slot = o2::calibration::TimeSlot<o2::emcal::EMCALChannelData>;
@@ -63,7 +58,7 @@ class EMCALChannelData
   o2::emcal::Geometry* mGeometry = o2::emcal::Geometry::GetInstanceFromRunNumber(300000);
   int NCELLS = mGeometry->GetNCells();
 
-  EMCALChannelData(const ChannelCalibInitParams& hist) : mNBins(hist.nbins), mRange(1)
+  EMCALChannelData() : mNBins(EMCALCalibParams::Instance().nBinsEnergyAxis_bc), mRange(EMCALCalibParams::Instance().maxValueEnergyAxis_bc)
   {
     // boost histogram with amplitude vs. cell ID, specify the range and binning of the amplitude axis
     mHisto = boost::histogram::make_histogram(boost::histogram::axis::regular<>(mNBins, 0, mRange, "t-texp"), boost::histogram::axis::integer<>(0, NCELLS, "CELL ID"));
@@ -112,10 +107,10 @@ class EMCALChannelData
   void setNEntriesInHisto(long unsigned int n) { mNEntriesInHisto = n; }
 
  private:
-  float mRange = 0.35; // looked at old QA plots where max was 0.35 GeV, might need to be changed
-  int mNBins = 1000;
-  boostHisto mHisto;
-  int mEvents = 0;
+  float mRange = 10;                                    ///< Maximum energy range of boost histogram (will be overwritten by values in the EMCALCalibParams)
+  int mNBins = 1000;                                    ///< Number of bins in the boost histogram (will be overwritten by values in the EMCALCalibParams)
+  boostHisto mHisto;                                    ///< 2d boost histogram with cellID vs cell energy
+  int mEvents = 0;                                      ///< event counter
   long unsigned int mNEntriesInHisto = 0;               ///< Number of entries in the histogram
   boostHisto mEsumHisto;                                ///< contains the average energy per hit for each cell
   boostHisto mEsumHistoScaled;                          ///< contains the average energy (scaled) per hit for each cell

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALTimeCalibData.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALTimeCalibData.h
@@ -41,15 +41,6 @@ namespace o2
 namespace emcal
 {
 
-// class containing the initialization parameters for histograms (time bins/range etc.)
-struct TimeCalibInitParams {
- public:
-  unsigned int mTimeBins = 1500;
-  std::array<float, 2> mTimeRange = {-500., 1000.}; // time range in ns
-  unsigned int mEnergyBins = 5000;
-  std::array<float, 2> mEnergyRange = {0., 50.}; // energy range in GeV
-};
-
 class EMCALTimeCalibData
 {
  public:
@@ -59,10 +50,13 @@ class EMCALTimeCalibData
   o2::emcal::Geometry* mGeometry = o2::emcal::Geometry::GetInstanceFromRunNumber(300000);
   int NCELLS = mGeometry->GetNCells();
 
-  EMCALTimeCalibData(const TimeCalibInitParams& par)
+  EMCALTimeCalibData()
   {
     // boost histogram with amplitude vs. cell ID, specify the range and binning of the amplitude axis
-    mTimeHisto = boost::histogram::make_histogram(boost::histogram::axis::regular<>(par.mTimeBins, par.mTimeRange.at(0), par.mTimeRange.at(1), "t (ns)"), boost::histogram::axis::regular<>(NCELLS, -0.5, NCELLS - 0.5, "CELL ID"));
+    int nBins = EMCALCalibParams::Instance().nBinsTimeAxis_tc;
+    int minValTime = EMCALCalibParams::Instance().minValueTimeAxis_tc;
+    int maxValTime = EMCALCalibParams::Instance().maxValueTimeAxis_tc;
+    mTimeHisto = boost::histogram::make_histogram(boost::histogram::axis::regular<>(nBins, minValTime, maxValTime, "t (ns)"), boost::histogram::axis::regular<>(NCELLS, -0.5, NCELLS - 0.5, "CELL ID"));
     LOG(debug) << "initialize time histogram with " << NCELLS << " cells";
   }
 
@@ -102,8 +96,7 @@ class EMCALTimeCalibData
   o2::emcal::TimeCalibrationParams process();
 
  private:
-  boostHisto mTimeHisto;                ///< histogram with cell time vs. cell ID
-  TimeCalibInitParams mTimeCalibParams; ///< initialization parameters for histogram
+  boostHisto mTimeHisto; ///< histogram with cell time vs. cell ID
 
   int mEvents = 0;                        ///< current number of events
   long unsigned int mNEntriesInHisto = 0; ///< number of entries in histogram

--- a/Detectors/EMCAL/calibration/src/EMCALCalibrationLinkDef.h
+++ b/Detectors/EMCAL/calibration/src/EMCALCalibrationLinkDef.h
@@ -15,11 +15,11 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
-#pragma link C++ class o2::emcal::EMCALChannelCalibrator < o2::emcal::EMCALChannelData, o2::emcal::BadChannelMap, o2::emcal::ChannelCalibInitParams> + ;
+#pragma link C++ class o2::emcal::EMCALChannelCalibrator < o2::emcal::EMCALChannelData, o2::emcal::BadChannelMap> + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::emcal::EMCALChannelData> + ;
 #pragma link C++ class o2::calibration::TimeSlotCalibration < o2::emcal::Cell, o2::emcal::EMCALChannelData> + ;
 
-#pragma link C++ class o2::emcal::EMCALChannelCalibrator < o2::emcal::EMCALTimeCalibData, o2::emcal::TimeCalibrationParams, o2::emcal::TimeCalibInitParams> + ;
+#pragma link C++ class o2::emcal::EMCALChannelCalibrator < o2::emcal::EMCALTimeCalibData, o2::emcal::TimeCalibrationParams> + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::emcal::EMCALTimeCalibData> + ;
 #pragma link C++ class o2::calibration::TimeSlotCalibration < o2::emcal::Cell, o2::emcal::EMCALTimeCalibData> + ;
 

--- a/Detectors/EMCAL/calibration/src/EMCALChannelData.cxx
+++ b/Detectors/EMCAL/calibration/src/EMCALChannelData.cxx
@@ -75,13 +75,13 @@ bool EMCALChannelData::hasEnoughData() const
 {
   bool enough = false;
 
-  LOG(debug) << "mNEntriesInHisto: " << mNEntriesInHisto << " needed: " << EMCALCalibParams::Instance().minNEntries << "  mEvents = " << mEvents;
+  LOG(debug) << "mNEntriesInHisto: " << mNEntriesInHisto << " needed: " << EMCALCalibParams::Instance().minNEntries_bc << "  mEvents = " << mEvents;
   // use enrties in histogram for calibration
-  if (!EMCALCalibParams::Instance().useNEventsForCalib && mNEntriesInHisto > EMCALCalibParams::Instance().minNEntries) {
+  if (!EMCALCalibParams::Instance().useNEventsForCalib_bc && mNEntriesInHisto > EMCALCalibParams::Instance().minNEntries_bc) {
     enough = true;
   }
   // use number of events (from emcal trigger record) for calibration
-  if (EMCALCalibParams::Instance().useNEventsForCalib && mEvents > EMCALCalibParams::Instance().minNEvents) {
+  if (EMCALCalibParams::Instance().useNEventsForCalib_bc && mEvents > EMCALCalibParams::Instance().minNEvents_bc) {
     enough = true;
   }
 

--- a/Detectors/EMCAL/calibration/src/EMCALTimeCalibData.cxx
+++ b/Detectors/EMCAL/calibration/src/EMCALTimeCalibData.cxx
@@ -61,13 +61,13 @@ bool EMCALTimeCalibData::hasEnoughData() const
 {
   bool enough = false;
 
-  LOG(debug) << "mNEntriesInHisto: " << mNEntriesInHisto << " needed: " << EMCALCalibParams::Instance().minNEntries << "  mEvents = " << mEvents;
+  LOG(debug) << "mNEntriesInHisto: " << mNEntriesInHisto << " needed: " << EMCALCalibParams::Instance().minNEntries_tc << "  mEvents = " << mEvents;
   // use enrties in histogram for calibration
-  if (!EMCALCalibParams::Instance().useNEventsForCalib && mNEntriesInHisto > EMCALCalibParams::Instance().minNEntries) {
+  if (!EMCALCalibParams::Instance().useNEventsForCalib_tc && mNEntriesInHisto > EMCALCalibParams::Instance().minNEntries_tc) {
     enough = true;
   }
   // use number of events (from emcal trigger record) for calibration
-  if (EMCALCalibParams::Instance().useNEventsForCalib && mEvents > EMCALCalibParams::Instance().minNEvents) {
+  if (EMCALCalibParams::Instance().useNEventsForCalib_tc && mEvents > EMCALCalibParams::Instance().minNEvents_tc) {
     enough = true;
   }
 
@@ -83,7 +83,7 @@ void EMCALTimeCalibData::fill(const gsl::span<const o2::emcal::Cell> data)
     double cellEnergy = cell.getEnergy();
     double cellTime = cell.getTimeStamp();
     int id = cell.getTower();
-    if (cellEnergy > EMCALCalibParams::Instance().minCellEnergyForTimeCalib) {
+    if (cellEnergy > EMCALCalibParams::Instance().minCellEnergy_tc) {
       LOG(debug) << "inserting in cell ID " << id << ": cellTime = " << cellTime;
       mTimeHisto(cellTime, id);
       mNEntriesInHisto++;

--- a/Detectors/EMCAL/calibration/testWorkflow/EMCALChannelCalibratorSpec.h
+++ b/Detectors/EMCAL/calibration/testWorkflow/EMCALChannelCalibratorSpec.h
@@ -60,26 +60,26 @@ class EMCALChannelCalibDevice : public o2::framework::Task
     if (EMCALCalibParams::Instance().calibType.find("time") != std::string::npos) { // time calibration
       isBadChannelCalib = false;
       if (!mTimeCalibrator) {
-        mTimeCalibrator = std::make_unique<o2::emcal::EMCALChannelCalibrator<o2::emcal::EMCALTimeCalibData, o2::emcal::TimeCalibrationParams, o2::emcal::TimeCalibInitParams>>();
+        mTimeCalibrator = std::make_unique<o2::emcal::EMCALChannelCalibrator<o2::emcal::EMCALTimeCalibData, o2::emcal::TimeCalibrationParams>>();
       }
       mTimeCalibrator->SetCalibExtractor(mCalibExtractor);
-      mTimeCalibrator->setSlotLength(EMCALCalibParams::Instance().slotLength);
-      if (EMCALCalibParams::Instance().UpdateAtEndOfRunOnly) {
+      mTimeCalibrator->setSlotLength(EMCALCalibParams::Instance().slotLength_tc);
+      if (EMCALCalibParams::Instance().UpdateAtEndOfRunOnly_tc) {
         mBadChannelCalibrator->setUpdateAtTheEndOfRunOnly();
       }
 
     } else { // bad cell calibration
       isBadChannelCalib = true;
       if (!mBadChannelCalibrator) {
-        mBadChannelCalibrator = std::make_unique<o2::emcal::EMCALChannelCalibrator<o2::emcal::EMCALChannelData, o2::emcal::BadChannelMap, o2::emcal::ChannelCalibInitParams>>();
+        mBadChannelCalibrator = std::make_unique<o2::emcal::EMCALChannelCalibrator<o2::emcal::EMCALChannelData, o2::emcal::BadChannelMap>>();
       }
       mBadChannelCalibrator->SetCalibExtractor(mCalibExtractor);
-      mBadChannelCalibrator->setSlotLength(EMCALCalibParams::Instance().slotLength);
-      if (EMCALCalibParams::Instance().UpdateAtEndOfRunOnly) {
+      mBadChannelCalibrator->setSlotLength(EMCALCalibParams::Instance().slotLength_bc);
+      if (EMCALCalibParams::Instance().UpdateAtEndOfRunOnly_bc) {
         mBadChannelCalibrator->setUpdateAtTheEndOfRunOnly();
       }
-      mBadChannelCalibrator->setIsTest(EMCALCalibParams::Instance().enableTestMode);
-      if (EMCALCalibParams::Instance().useScaledHistoForBadChannelMap) {
+      mBadChannelCalibrator->setIsTest(EMCALCalibParams::Instance().enableTestMode_bc);
+      if (EMCALCalibParams::Instance().useScaledHisto_bc) {
         mBadChannelCalibrator->getCalibExtractor()->setUseScaledHistoForBadChannels(true);
       }
     }
@@ -168,8 +168,8 @@ class EMCALChannelCalibDevice : public o2::framework::Task
   static const char* getCellTriggerRecordBinding() { return "EMCCellsTrgR"; }
 
  private:
-  std::unique_ptr<o2::emcal::EMCALChannelCalibrator<o2::emcal::EMCALChannelData, o2::emcal::BadChannelMap, o2::emcal::ChannelCalibInitParams>> mBadChannelCalibrator;
-  std::unique_ptr<o2::emcal::EMCALChannelCalibrator<o2::emcal::EMCALTimeCalibData, o2::emcal::TimeCalibrationParams, o2::emcal::TimeCalibInitParams>> mTimeCalibrator;
+  std::unique_ptr<o2::emcal::EMCALChannelCalibrator<o2::emcal::EMCALChannelData, o2::emcal::BadChannelMap>> mBadChannelCalibrator;
+  std::unique_ptr<o2::emcal::EMCALChannelCalibrator<o2::emcal::EMCALTimeCalibData, o2::emcal::TimeCalibrationParams>> mTimeCalibrator;
   std::shared_ptr<o2::emcal::EMCALCalibExtractor> mCalibExtractor;
   std::shared_ptr<o2::base::GRPGeomRequest> mCCDBRequest;
   bool isBadChannelCalib = true;


### PR DESCRIPTION
- The bad channel calibration crashed due to the histogram axis beeing
initialized with a range from 0-1GeV while the analysis went up to 4GeV
which leads to undefined behavior
- Now the histogram ranges are stored in the CalibParams and could be
modified if needed. The maximum energy was increased to 10GeV
- Reorganized the EMCALCalibParams to enable setting different values
for the bad channel and the time calibration
- Delete the CalibInitParams and instead moved the values to the
EMCALCalibParams to unify all calibration parameters in one class