### PR TITLE
Fixes for Mean Vertex calibration

### DIFF
--- a/Detectors/Calibration/include/DetectorsCalibration/MeanVertexData.h
+++ b/Detectors/Calibration/include/DetectorsCalibration/MeanVertexData.h
@@ -30,7 +30,7 @@ struct MeanVertexData {
   std::vector<std::array<float, 3>> histoVtx{0};
   bool mVerbose = false;
 
-  MeanVertexData();
+  MeanVertexData() = default;
 
   ~MeanVertexData()
   {

--- a/Detectors/Calibration/src/MeanVertexCalibrator.cxx
+++ b/Detectors/Calibration/src/MeanVertexCalibrator.cxx
@@ -69,6 +69,9 @@ void MeanVertexCalibrator::binVector(std::vector<float>& vectOut, const std::vec
       continue;
     }
     int bin = (vectIn[i] - min) * binWidthInv;
+    if (bin >= vectOut.size()) {
+      continue;
+    }
     vectOut[bin]++;
   }
 }
@@ -142,8 +145,8 @@ void MeanVertexCalibrator::fitMeanVertex(o2::calibration::MeanVertexData* c, Mea
           printVector(binnedVect, -(mRangeX), mRangeX, mBinWidthX);
         }
         fitres = fitGaus(mNBinsX, &binnedVect[0], -(mRangeX), mRangeX, fitResSlicesX.back(), &covMatrixX.back());
-        if (fitres != 10) {
-          LOG(info) << "X, counter " << counter << ": Fit result (z slice [" << c->histoVtx[startZ][2] << ", " << c->histoVtx[ii][2] << "[) => " << fitres << ". Mean = " << fitResSlicesX[counter][1] << " Sigma = " << fitResSlicesX[counter][2] << ", covMatrix = " << covMatrixX[counter](2, 2);
+        if (fitres != -10) {
+          LOG(info) << "X, counter " << counter << ": Fit result (z slice [" << c->histoVtx[startZ][2] << ", " << c->histoVtx[ii - 1][2] << "]) => " << fitres << ". Mean = " << fitResSlicesX[counter][1] << " Sigma = " << fitResSlicesX[counter][2] << ", covMatrix = " << covMatrixX[counter](2, 2);
         } else {
           LOG(error) << "X, counter " << counter << ": Fit failed with result = " << fitres;
         }
@@ -165,8 +168,8 @@ void MeanVertexCalibrator::fitMeanVertex(o2::calibration::MeanVertexData* c, Mea
           printVector(binnedVect, -(mRangeY), mRangeY, mBinWidthY);
         }
         fitres = fitGaus(mNBinsY, &binnedVect[0], -(mRangeY), mRangeY, fitResSlicesY.back(), &covMatrixY.back());
-        if (fitres != 10) {
-          LOG(info) << "Y, counter " << counter << ": Fit result (z slice [" << c->histoVtx[startZ][2] << ", " << c->histoVtx[ii][2] << "[) => " << fitres << ". Mean = " << fitResSlicesY[counter][1] << " Sigma = " << fitResSlicesY[counter][2] << ", covMatrix = " << covMatrixY[counter](2, 2);
+        if (fitres != -10) {
+          LOG(info) << "Y, counter " << counter << ": Fit result (z slice [" << c->histoVtx[startZ][2] << ", " << c->histoVtx[ii - 1][2] << "]) => " << fitres << ". Mean = " << fitResSlicesY[counter][1] << " Sigma = " << fitResSlicesY[counter][2] << ", covMatrix = " << covMatrixY[counter](2, 2);
         } else {
           LOG(error) << "Y, counter " << counter << ": Fit failed with result = " << fitres;
         }
@@ -181,7 +184,7 @@ void MeanVertexCalibrator::fitMeanVertex(o2::calibration::MeanVertexData* c, Mea
         break;
       }
     }
-    startZ += mMinEntries * counter;
+    startZ += minEntriesPerPoint * counter;
     if (mVerbose) {
       LOG(info) << "End of while: startZ = " << startZ << " c->histoVtx.size() = " << c->histoVtx.size();
     }

--- a/Detectors/Calibration/src/MeanVertexData.cxx
+++ b/Detectors/Calibration/src/MeanVertexData.cxx
@@ -27,12 +27,6 @@ using PVertex = o2::dataformats::PrimaryVertex;
 using clbUtils = o2::calibration::Utils;
 
 //_____________________________________________
-MeanVertexData::MeanVertexData()
-{
-  LOG(info) << "Default c-tor, not to be used";
-}
-
-//_____________________________________________
 void MeanVertexData::print() const
 {
   LOG(info) << entries << " entries";


### PR DESCRIPTION
Dear @martenole , @davidrohr , @shahor02 ,

This PR fixes the issues in the mean vertex calibration - at least locally. 
@shahor02 : there was also a typo, and the fitGaus was considered as failing when the return code was 10 instead of -10. But I also see that for the tgLamdba based vdrift calib, you consider a failure if the result is `<-2` (https://github.com/AliceO2Group/AliceO2/blob/825cb83467cd666ed96dd8f1457e5cd726d9150d/Detectors/TPC/calibration/src/TPCVDriftTglCalibration.cxx#L55). Can you confirm that -10 is correct?

Thanks,

Chiara