### PR TITLE
Prevent division by 0 if no MID trace was produced at end of run

### DIFF
--- a/Detectors/MUON/MID/Workflow/src/ClusterizerSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/ClusterizerSpec.cxx
@@ -67,7 +67,7 @@ class ClusterizerDeviceDPL
     }
 
     auto stop = [this]() {
-      double scaleFactor = 1.e6 / mNROFs;
+      double scaleFactor = (mNROFs == 0) ? 0. : 1.e6 / mNROFs;
       LOG(info) << "Processing time / " << mNROFs << " ROFs: full: " << mTimer.count() * scaleFactor << " us  pre-clustering: " << mTimerPreCluster.count() * scaleFactor << " us  clustering: " << mTimerCluster.count() * scaleFactor << " us";
     };
     ic.services().get<of::CallbackService>().set(of::CallbackService::Id::Stop, stop);

--- a/Detectors/MUON/MID/Workflow/src/DecodedDataAggregatorSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/DecodedDataAggregatorSpec.cxx
@@ -38,8 +38,7 @@ class DecodedDataAggregatorDeviceDPL
   void init(of::InitContext& ic)
   {
     auto stop = [this]() {
-      LOG(info) << "Capacities: ROFRecords: " << mAggregator.getROFRecords().capacity() << "  Data: " << mAggregator.getData().capacity();
-      double scaleFactor = 1.e6 / mNROFs;
+      double scaleFactor = (mNROFs == 0) ? 0. : 1.e6 / mNROFs;
       LOG(info) << "Processing time / " << mNROFs << " ROFs: full: " << mTimer.count() * scaleFactor << "  aggregating: " << mTimerAlgo.count() * scaleFactor << " us";
     };
     ic.services().get<of::CallbackService>().set(of::CallbackService::Id::Stop, stop);

--- a/Detectors/MUON/MID/Workflow/src/RawGBTDecoderSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/RawGBTDecoderSpec.cxx
@@ -46,7 +46,7 @@ class RawGBTDecoderDeviceDPL
   void init(o2::framework::InitContext& ic)
   {
     auto stop = [this]() {
-      double scaleFactor = 1.e6 / mNROFs;
+      double scaleFactor = (mNROFs == 0) ? 0. : 1.e6 / mNROFs;
       LOG(info) << "Processing time / " << mNROFs << " ROFs: full: " << mTimer.count() * scaleFactor << " us  decoding: " << mTimerAlgo.count() * scaleFactor << " us";
     };
     ic.services().get<o2::framework::CallbackService>().set(o2::framework::CallbackService::Id::Stop, stop);

--- a/Detectors/MUON/MID/Workflow/src/TrackerSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/TrackerSpec.cxx
@@ -52,8 +52,7 @@ class TrackerDeviceDPL
     mKeepAll = !ic.options().get<bool>("mid-tracker-keep-best");
 
     auto stop = [this]() {
-      LOG(info) << "Capacities: ROFRecords: " << mTracker->getTrackROFRecords().capacity() << "  tracks: " << mTracker->getTracks().capacity() << "  clusters: " << mTracker->getClusters().capacity();
-      double scaleFactor = 1.e6 / mNROFs;
+      double scaleFactor = (mNROFs == 0) ? 0. : 1.e6 / mNROFs;
       LOG(info) << "Processing time / " << mNROFs << " ROFs: full: " << mTimer.count() * scaleFactor << " us  tracking: " << mTimerTracker.count() * scaleFactor << " us  hitMapBuilder: " << mTimerBuilder.count() << " us";
     };
     ic.services().get<of::CallbackService>().set(of::CallbackService::Id::Stop, stop);


### PR DESCRIPTION
This PR is meant to solve an issue that was most likely the cause of crashes after stopping runs with incomplete events