### PR TITLE
DPL: drop all messages when cleanup property increases

### DIFF
--- a/Framework/Core/include/Framework/DataProcessingDevice.h
+++ b/Framework/Core/include/Framework/DataProcessingDevice.h
@@ -119,6 +119,7 @@ class DataProcessingDevice : public fair::mq::Device
   /// Handle to wake up the main loop from other threads
   /// e.g. when FairMQ notifies some callback in an asynchronous way
   uv_async_t* mAwakeHandle = nullptr;
+  int64_t mCleanupCount = -1;
 };
 
 } // namespace o2::framework


### PR DESCRIPTION
This is an attempt at doing what we discussed. Frankly speaking
I am more and more convinced this is a hack (if it works at all)
and we should either have a proper DRAIN state, or we discard messages
based on the run number.