### PR TITLE
DCSConfigObject to noise calib workflow and extra cut for ITS IB

### DIFF
--- a/Detectors/ITSMFT/ITS/calibration/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/calibration/CMakeLists.txt
@@ -17,6 +17,7 @@ o2_add_library(ITSCalibration
                SOURCES src/NoiseSlotCalibrator.cxx
                SOURCES src/NoiseCalibratorSpec.cxx
                PUBLIC_LINK_LIBRARIES O2::DataFormatsITS
+                                     O2::DataFormatsDCS
                                      O2::ITSBase
                                      O2::ITSMFTReconstruction
                                      O2::DetectorsCalibration

--- a/Detectors/ITSMFT/ITS/calibration/include/ITSCalibration/NoiseCalibrator.h
+++ b/Detectors/ITSMFT/ITS/calibration/include/ITSCalibration/NoiseCalibrator.h
@@ -70,7 +70,6 @@ class NoiseCalibrator
   const o2::itsmft::TopologyDictionary* mDict = nullptr;
   o2::itsmft::NoiseMap mNoiseMap{24120};
   float mProbabilityThreshold = 3e-6f;
-  float mCutIB = 1e-2;     // looser cut for IB to decide which pixels to keep in the noise mask
   float mProbRelErr = 0.2; // relative error on channel noise to apply the threshold
   long mMinROFs = 0;
   unsigned int mNumberOfStrobes = 0;

--- a/Detectors/ITSMFT/ITS/calibration/include/ITSCalibration/NoiseCalibrator.h
+++ b/Detectors/ITSMFT/ITS/calibration/include/ITSCalibration/NoiseCalibrator.h
@@ -51,7 +51,7 @@ class NoiseCalibrator
   bool processTimeFrameDigits(gsl::span<const o2::itsmft::Digit> const& digits,
                               gsl::span<const o2::itsmft::ROFRecord> const& rofs);
 
-  void finalize(float cutIB);
+  void finalize(float cutIB = -1.);
 
   void setNThreads(int n) { mNThreads = n > 0 ? n : 1; }
 

--- a/Detectors/ITSMFT/ITS/calibration/include/ITSCalibration/NoiseCalibrator.h
+++ b/Detectors/ITSMFT/ITS/calibration/include/ITSCalibration/NoiseCalibrator.h
@@ -51,7 +51,7 @@ class NoiseCalibrator
   bool processTimeFrameDigits(gsl::span<const o2::itsmft::Digit> const& digits,
                               gsl::span<const o2::itsmft::ROFRecord> const& rofs);
 
-  void finalize();
+  void finalize(float cutIB);
 
   void setNThreads(int n) { mNThreads = n > 0 ? n : 1; }
 
@@ -70,6 +70,7 @@ class NoiseCalibrator
   const o2::itsmft::TopologyDictionary* mDict = nullptr;
   o2::itsmft::NoiseMap mNoiseMap{24120};
   float mProbabilityThreshold = 3e-6f;
+  float mCutIB = 1e-2;     // looser cut for IB to decide which pixels to keep in the noise mask
   float mProbRelErr = 0.2; // relative error on channel noise to apply the threshold
   long mMinROFs = 0;
   unsigned int mNumberOfStrobes = 0;

--- a/Detectors/ITSMFT/ITS/calibration/include/ITSCalibration/NoiseCalibratorSpec.h
+++ b/Detectors/ITSMFT/ITS/calibration/include/ITSCalibration/NoiseCalibratorSpec.h
@@ -19,6 +19,7 @@
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
 #include "DetectorsBase/GRPGeomHelper.h"
+#include "DataFormatsDCS/DCSConfigObject.h"
 
 //#define TIME_SLOT_CALIBRATION
 #ifdef TIME_SLOT_CALIBRATION
@@ -52,6 +53,7 @@ class NoiseCalibratorSpec : public Task
   void finaliseCCDB(ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
+  void addDatabaseEntry(int chip, int row, int col);
   void sendOutput(DataAllocator& output);
   void updateTimeDependentParams(ProcessingContext& pc);
   std::unique_ptr<CALIBRATOR> mCalibrator = nullptr;
@@ -62,6 +64,9 @@ class NoiseCalibratorSpec : public Task
   bool mUseClusters = false;
   bool mStopMeOnly = false; // send QuitRequest::Me instead of QuitRequest::All
   TStopwatch mTimer{};
+  float mNoiseCutIB = -1.;
+  o2::dcs::DCSconfigObject_t mNoiseMapDCS; // noisy pixels to be sent to DCS CCDB
+  std::vector<int>* mConfDBmap;
 };
 
 /// create a processor spec

--- a/Detectors/ITSMFT/ITS/calibration/src/NoiseCalibrator.cxx
+++ b/Detectors/ITSMFT/ITS/calibration/src/NoiseCalibrator.cxx
@@ -143,10 +143,16 @@ bool NoiseCalibrator::processTimeFrameDigits(gsl::span<const o2::itsmft::Digit> 
   return (mNumberOfStrobes > mMinROFs) ? true : false;
 }
 
-void NoiseCalibrator::finalize()
+void NoiseCalibrator::finalize(float cutIB)
 {
   LOG(info) << "Number of processed strobes is " << mNumberOfStrobes;
-  mNoiseMap.applyProbThreshold(mProbabilityThreshold, mNumberOfStrobes, mProbRelErr);
+  if (cutIB > 0) {
+    mNoiseMap.applyProbThreshold(mProbabilityThreshold, mNumberOfStrobes, mProbRelErr, 432, 24119); // to OB only
+    LOG(info) << "Applying special cut for ITS IB: " << cutIB;
+    mNoiseMap.applyProbThreshold(cutIB, mNumberOfStrobes, mProbRelErr, 0, 431); // to IB only
+  } else {
+    mNoiseMap.applyProbThreshold(mProbabilityThreshold, mNumberOfStrobes, mProbRelErr);
+  }
   mNoiseMap.print();
 }
 

--- a/Detectors/ITSMFT/MFT/calibration/include/MFTCalibration/NoiseCalibratorSpec.h
+++ b/Detectors/ITSMFT/MFT/calibration/include/MFTCalibration/NoiseCalibratorSpec.h
@@ -24,7 +24,7 @@
 using CALIBRATOR = o2::mft::NoiseCalibrator;
 
 //#include "MFTCalibration/NoiseSlotCalibrator.h" //For TimeSlot calibration
-//using CALIBRATOR = o2::mft::NoiseSlotCalibrator;
+// using CALIBRATOR = o2::mft::NoiseSlotCalibrator;
 
 #include "DataFormatsITSMFT/NoiseMap.h"
 


### PR DESCRIPTION
This PR introduces the DCSConfigObject (for DCS CCDB) for the noise calibration workflow. It's a copy of `o2::itsmft::NoiseMap` which can be read out from DCS. 

In WIP just because I need confirmation from Hartmut about the format of the object. Can be reviewed anyway (cc @shahor02 and @chiarazampolli and @iouribelikov )

New option introduced (`--cut-ib`) which allow to apply a special cut for Inner Barrel. So far, we are cutting at 10^-2 for IB and 10^-6 for OB and this is what we would like to keep (maybe 10^-5 can be considered for OB). 

Workflow tested in the following way:
```
o2-ctf-reader-workflow -b --ctf-input /data/iravasen/513464/513464_random.dat --remote-regex "^alien:///alice/data/.+" --copy-cmd no-copy --onlyDet ITS --its-digits | \
o2-its-noise-calib-workflow -b --prob-threshold 1e-4 --cut-ib 1e-2 --nthreads 2 | \
o2-calibration-ccdb-populator-workflow -b --ccdb-path "http://ccdb-test.cern.ch:8080" --sspec-min 0 --sspec-max 0 | \
o2-calibration-ccdb-populator-workflow -b --ccdb-path "http://ccdb-test.cern.ch:8080" --sspec-min 1 --sspec-max 1 --name-extention dcs
```

It has to be noted that even if `NoiseMap.h` has been changed, it is NOT needed to change MFT workflow. In real life, the first calib workflow will ship to prod CCDB while the second to DCS CCDB. 