### PR TITLE
DPL: improve metric processing

### DIFF
--- a/Framework/Core/include/Framework/DeviceMetricsHelper.h
+++ b/Framework/Core/include/Framework/DeviceMetricsHelper.h
@@ -56,6 +56,25 @@ struct DeviceMetricsHelper {
       return metrics.floatMetrics;
     } else if constexpr (std::is_same_v<T, uint64_t>) {
       return metrics.uint64Metrics;
+    } else if constexpr (std::is_same_v<T, int8_t>) {
+      return metrics.enumMetrics;
+    } else {
+      throw runtime_error("Unhandled metric type");
+    };
+  }
+
+  /// Typesafe way to get the actual store
+  template <typename T>
+  static auto& getTimestampsStore(DeviceMetricsInfo& metrics)
+  {
+    if constexpr (std::is_same_v<T, int>) {
+      return metrics.intTimestamps;
+    } else if constexpr (std::is_same_v<T, float>) {
+      return metrics.floatTimestamps;
+    } else if constexpr (std::is_same_v<T, uint64_t>) {
+      return metrics.uint64Timestamps;
+    } else if constexpr (std::is_same_v<T, int8_t>) {
+      return metrics.enumTimestamps;
     } else {
       throw runtime_error("Unhandled metric type");
     };
@@ -70,6 +89,8 @@ struct DeviceMetricsHelper {
       return MetricType::Float;
     } else if constexpr (std::is_same_v<T, uint64_t>) {
       return MetricType::Uint64;
+    } else if constexpr (std::is_same_v<T, int8_t>) {
+      return MetricType::Enum;
     } else {
       throw runtime_error("Unhandled metric type");
     };
@@ -87,8 +108,9 @@ struct DeviceMetricsHelper {
       metrics.min[metricIndex] = std::min(metrics.min[metricIndex], (float)value);
       metrics.changed.at(metricIndex) = true;
       auto& store = getMetricsStore<T>(metrics);
+      auto& timestamps = getTimestampsStore<T>(metrics);
       size_t pos = metric.pos++ % store[metric.storeIdx].size();
-      metrics.timestamps[metricIndex][pos] = timestamp;
+      timestamps[metric.storeIdx][pos] = timestamp;
       store[metric.storeIdx][pos] = value;
       metric.filledMetrics++;
     };

--- a/Framework/Core/include/Framework/DeviceMetricsHelper.h
+++ b/Framework/Core/include/Framework/DeviceMetricsHelper.h
@@ -145,8 +145,6 @@ struct DeviceMetricsHelper {
     size_t metricIndex = bookNumericMetric<T>(metrics, name, newMetricsCallback);
     return getNumericMetricCursor<T>(metricIndex);
   }
-
-  static void updateMetricsNames(DriverInfo& driverInfo, std::vector<DeviceMetricsInfo> const& metricsInfos);
 };
 
 } // namespace o2::framework

--- a/Framework/Core/include/Framework/DriverInfo.h
+++ b/Framework/Core/include/Framework/DriverInfo.h
@@ -135,9 +135,6 @@ struct DriverInfo {
   std::vector<DataProcessorInfo> processorInfo;
   /// The config context. We use a bare pointer because std::observer_ptr is not a thing, yet.
   ConfigContext const* configContext;
-  /// The names for all the metrics which have been collected by this driver.
-  /// Should always be sorted alphabetically to ease insertion.
-  std::vector<std::string> availableMetrics;
   /// The amount of time to process inputs coming from all the processes
   float inputProcessingCost;
   /// The time between one input processing and the other.

--- a/Framework/Core/src/ArrowSupport.cxx
+++ b/Framework/Core/src/ArrowSupport.cxx
@@ -166,9 +166,10 @@ o2::framework::ServiceSpec ArrowSupport::arrowBackendSpec()
                              changed |= deviceMetrics.changed[index];
                              MetricInfo info = deviceMetrics.metrics[index];
                              auto& data = deviceMetrics.uint64Metrics.at(info.storeIdx);
+                             auto const& timestamps = DeviceMetricsHelper::getTimestampsStore<uint64_t>(deviceMetrics).at(info.storeIdx);
                              auto value = (int64_t)data.at((info.pos - 1) % data.size());
                              totalBytesCreated += value;
-                             lastTimestamp = std::max(lastTimestamp, deviceMetrics.timestamps[index][(info.pos - 1) % data.size()]);
+                             lastTimestamp = std::max(lastTimestamp, timestamps[(info.pos - 1) % data.size()]);
                              firstTimestamp = std::min(lastTimestamp, firstTimestamp);
                            }
                          }
@@ -179,9 +180,10 @@ o2::framework::ServiceSpec ArrowSupport::arrowBackendSpec()
                              changed |= deviceMetrics.changed[index];
                              MetricInfo info = deviceMetrics.metrics[index];
                              auto& data = deviceMetrics.uint64Metrics.at(info.storeIdx);
+                             auto const& timestamps = DeviceMetricsHelper::getTimestampsStore<uint64_t>(deviceMetrics).at(info.storeIdx);
                              auto value = (int64_t)data.at((info.pos - 1) % data.size());
                              shmOfferConsumed += value;
-                             lastTimestamp = std::max(lastTimestamp, deviceMetrics.timestamps[index][(info.pos - 1) % data.size()]);
+                             lastTimestamp = std::max(lastTimestamp, timestamps[(info.pos - 1) % data.size()]);
                              firstTimestamp = std::min(lastTimestamp, firstTimestamp);
                            }
                          }

--- a/Framework/Core/src/ControlWebSocketHandler.cxx
+++ b/Framework/Core/src/ControlWebSocketHandler.cxx
@@ -32,9 +32,7 @@ void ControlWebSocketHandler::frame(char const* frame, size_t s)
     updateMetricsViews(name, metric, value, metricIndex);
     hasNewMetric = true;
   };
-  std::string token(frame, s);
-  std::smatch match;
-  ParsedConfigMatch configMatch;
+  std::string_view tokenSV(frame, s);
   ParsedMetricMatch metricMatch;
 
   auto doParseConfig = [](std::string const& token, ParsedConfigMatch& configMatch, DeviceInfo& info) -> bool {
@@ -46,14 +44,21 @@ void ControlWebSocketHandler::frame(char const* frame, size_t s)
     return false;
   };
   LOG(debug3) << "Data received: " << std::string_view(frame, s);
-  if (DeviceMetricsHelper::parseMetric(token, metricMatch)) {
+  if (DeviceMetricsHelper::parseMetric(tokenSV, metricMatch)) {
     // We use this callback to cache which metrics are needed to provide a
     // the DataRelayer view.
     assert(mContext.metrics);
     DeviceMetricsHelper::processMetric(metricMatch, (*mContext.metrics)[mIndex], newMetricCallback);
     didProcessMetric = true;
     didHaveNewMetric |= hasNewMetric;
-  } else if (ControlServiceHelpers::parseControl(token, match) && mContext.infos) {
+    return;
+  }
+
+  ParsedConfigMatch configMatch;
+  std::string token(frame, s);
+  std::smatch match;
+
+  if (ControlServiceHelpers::parseControl(token, match) && mContext.infos) {
     ControlServiceHelpers::processCommand(*mContext.infos, mPid, match[1].str(), match[2].str());
   } else if (doParseConfig(token, configMatch, (*mContext.infos)[mIndex]) && mContext.infos) {
     LOG(debug2) << "Found configuration information for pid " << mPid;

--- a/Framework/Core/src/ControlWebSocketHandler.cxx
+++ b/Framework/Core/src/ControlWebSocketHandler.cxx
@@ -83,9 +83,6 @@ void ControlWebSocketHandler::endChunk()
   for (auto& metricsInfo : *mContext.metrics) {
     std::fill(metricsInfo.changed.begin(), metricsInfo.changed.end(), false);
   }
-  if (didHaveNewMetric) {
-    DeviceMetricsHelper::updateMetricsNames(*mContext.driver, *mContext.metrics);
-  }
 }
 
 void ControlWebSocketHandler::headers(std::map<std::string, std::string> const& headers)

--- a/Framework/Core/src/DeviceMetricsHelper.cxx
+++ b/Framework/Core/src/DeviceMetricsHelper.cxx
@@ -12,6 +12,7 @@
 #include "Framework/DeviceMetricsHelper.h"
 #include "Framework/DriverInfo.h"
 #include "Framework/RuntimeError.h"
+#include "Framework/Logger.h"
 #include <cassert>
 #include <cinttypes>
 #include <cstdlib>
@@ -70,7 +71,11 @@ bool DeviceMetricsHelper::parseMetric(std::string_view const s, ParsedMetricMatc
     return false;
   }
   char* ep = nullptr;
+  // Some metrics are special
   match.type = static_cast<MetricType>(strtol(comma + 1, &ep, 10));
+  if (strncmp(match.beginKey, "data_relayer/", 13) == 0 && match.beginKey[13] != 'w' && match.beginKey[13] != 'h') {
+    match.type = MetricType::Enum;
+  }
   if (ep != spaces[1]) {
     return false;
   }
@@ -100,6 +105,13 @@ bool DeviceMetricsHelper::parseMetric(std::string_view const s, ParsedMetricMatc
       break;
     case MetricType::Uint64:
       match.uint64Value = strtoul(spaces[1] + 1, &ep, 10);
+      if (ep != *(space - 2)) {
+        return false;
+      }
+      match.floatValue = (float)match.uint64Value;
+      break;
+    case MetricType::Enum:
+      match.intValue = strtoul(spaces[1] + 1, &ep, 10);
       if (ep != *(space - 2)) {
         return false;
       }
@@ -156,7 +168,6 @@ static constexpr int DPL_MAX_METRICS_PER_DEVICE = 1024*128;
 
 static auto initMetric = [](DeviceMetricsInfo& info) -> void {
   // Add the timestamp buffer for it
-  info.timestamps.emplace_back(std::array<size_t, 1024>{});
   info.max.push_back(std::numeric_limits<float>::lowest());
   info.min.push_back(std::numeric_limits<float>::max());
   info.average.push_back(0);
@@ -181,6 +192,8 @@ auto storeIdx = [](DeviceMetricsInfo& info, MetricType type) -> size_t {
       return info.floatMetrics.size();
     case MetricType::Uint64:
       return info.uint64Metrics.size();
+    case MetricType::Enum:
+      return info.enumMetrics.size();
     default:
       return -1;
   }
@@ -197,16 +210,24 @@ auto createMetricInfo = [](DeviceMetricsInfo& info, MetricType type) -> MetricIn
   // Add a new empty buffer for it of the correct kind
   switch (type) {
     case MetricType::Int:
-      info.intMetrics.emplace_back(std::array<int, 1024>{});
+      info.intMetrics.emplace_back(MetricsStorage<int>{});
+      info.intTimestamps.emplace_back(TimestampsStorage<int>{});
       break;
     case MetricType::String:
-      info.stringMetrics.emplace_back(std::array<StringMetric, 32>{});
+      info.stringMetrics.emplace_back(MetricsStorage<StringMetric>{});
+      info.stringTimestamps.emplace_back(TimestampsStorage<StringMetric>{});
       break;
     case MetricType::Float:
-      info.floatMetrics.emplace_back(std::array<float, 1024>{});
+      info.floatMetrics.emplace_back(MetricsStorage<float>{});
+      info.floatTimestamps.emplace_back(TimestampsStorage<float>{});
       break;
     case MetricType::Uint64:
-      info.uint64Metrics.emplace_back(std::array<uint64_t, 1024>{});
+      info.uint64Metrics.emplace_back(MetricsStorage<uint64_t>{});
+      info.uint64Timestamps.emplace_back(TimestampsStorage<uint64_t>{});
+      break;
+    case MetricType::Enum:
+      info.enumMetrics.emplace_back(MetricsStorage<int8_t>{});
+      info.enumTimestamps.emplace_back(TimestampsStorage<int8_t>{});
       break;
     default:
       throw std::runtime_error("Unknown metric type");
@@ -291,6 +312,7 @@ bool DeviceMetricsHelper::processMetric(ParsedMetricMatch& match,
     case MetricType::Float:
     case MetricType::Int:
     case MetricType::Uint64:
+    case MetricType::Enum:
       break;
     case MetricType::String: {
       auto lastChar = std::min(match.endStringValue - match.beginStringValue, StringMetric::MAX_SIZE - 1);
@@ -376,18 +398,27 @@ bool DeviceMetricsHelper::processMetric(ParsedMetricMatch& match,
     case MetricType::Int: {
       info.intMetrics[metricInfo.storeIdx][metricInfo.pos] = match.intValue;
       sizeOfCollection = info.intMetrics[metricInfo.storeIdx].size();
+      info.intTimestamps[metricInfo.storeIdx][metricInfo.pos] = match.timestamp;
     } break;
     case MetricType::String: {
       info.stringMetrics[metricInfo.storeIdx][metricInfo.pos] = stringValue;
       sizeOfCollection = info.stringMetrics[metricInfo.storeIdx].size();
+      info.stringTimestamps[metricInfo.storeIdx][metricInfo.pos] = match.timestamp;
     } break;
     case MetricType::Float: {
       info.floatMetrics[metricInfo.storeIdx][metricInfo.pos] = match.floatValue;
       sizeOfCollection = info.floatMetrics[metricInfo.storeIdx].size();
+      info.floatTimestamps[metricInfo.storeIdx][metricInfo.pos] = match.timestamp;
     } break;
     case MetricType::Uint64: {
       info.uint64Metrics[metricInfo.storeIdx][metricInfo.pos] = match.uint64Value;
       sizeOfCollection = info.uint64Metrics[metricInfo.storeIdx].size();
+      info.uint64Timestamps[metricInfo.storeIdx][metricInfo.pos] = match.timestamp;
+    } break;
+    case MetricType::Enum: {
+      info.enumMetrics[metricInfo.storeIdx][metricInfo.pos] = match.intValue;
+      sizeOfCollection = info.enumMetrics[metricInfo.storeIdx].size();
+      info.enumTimestamps[metricInfo.storeIdx][metricInfo.pos] = match.timestamp;
     } break;
     default:
       return false;
@@ -404,7 +435,6 @@ bool DeviceMetricsHelper::processMetric(ParsedMetricMatch& match,
     return previousAverage + (nextValue - previousAverage) / (previousCount + 1);
   };
   info.average[metricIndex] = onlineAverage(match.floatValue, info.average[metricIndex], metricInfo.filledMetrics);
-  info.timestamps[metricIndex][metricInfo.pos] = match.timestamp;
   // We point to the next metric
   metricInfo.pos = (metricInfo.pos + 1) % sizeOfCollection;
   ++metricInfo.filledMetrics;

--- a/Framework/Core/src/DeviceMetricsHelper.cxx
+++ b/Framework/Core/src/DeviceMetricsHelper.cxx
@@ -52,7 +52,7 @@ bool DeviceMetricsHelper::parseMetric(std::string_view const s, ParsedMetricMatc
   // Find all spaces
   char const* nextSpace = s.data();
   while (space - spaces < 256) {
-    *space = strchr(nextSpace, ' ');
+    *space = (const char*)memchr(nextSpace, ' ', s.size() - (nextSpace - s.data()));
     if (*space == nullptr) {
       break;
     }

--- a/Framework/Core/src/DeviceMetricsHelper.cxx
+++ b/Framework/Core/src/DeviceMetricsHelper.cxx
@@ -458,21 +458,4 @@ size_t DeviceMetricsHelper::metricIdxByName(const std::string& name, const Devic
   return i;
 }
 
-void DeviceMetricsHelper::updateMetricsNames(DriverInfo& driverInfo, std::vector<DeviceMetricsInfo> const& metricsInfos)
-{
-  // Calculate the unique set of metrics, as available in the metrics service
-  static std::unordered_set<std::string> allMetricsNames;
-  for (const auto& metricsInfo : metricsInfos) {
-    for (const auto& labelsPairs : metricsInfo.metricLabels) {
-      allMetricsNames.insert(std::string(labelsPairs.label));
-    }
-  }
-  for (const auto& labelsPairs : driverInfo.metrics.metricLabels) {
-    allMetricsNames.insert(std::string(labelsPairs.label));
-  }
-  std::vector<std::string> result(allMetricsNames.begin(), allMetricsNames.end());
-  std::sort(result.begin(), result.end());
-  driverInfo.availableMetrics.swap(result);
-}
-
 } // namespace o2::framework

--- a/Framework/Core/src/DeviceMetricsInfo.cxx
+++ b/Framework/Core/src/DeviceMetricsInfo.cxx
@@ -34,8 +34,13 @@ std::ostream& operator<<(std::ostream& oss, MetricType const& val)
       oss << "string";
       break;
     case MetricType::Int:
+      oss << "int";
+      break;
     case MetricType::Uint64:
-      oss << "float";
+      oss << "uint64";
+      break;
+    case MetricType::Enum:
+      oss << "enum";
       break;
     case MetricType::Unknown:
     default:

--- a/Framework/Core/src/Metric2DViewIndex.cxx
+++ b/Framework/Core/src/Metric2DViewIndex.cxx
@@ -41,11 +41,11 @@ Metric2DViewIndex::Updater Metric2DViewIndex::getUpdater(std::vector<Metric2DVie
       extra.erase(0, view.prefix.size() + 1);
       if (extra == "w") {
         view.w = value;
-        view.indexes.resize(view.w * view.h);
+        view.indexes.resize(view.w * view.h, -1);
         return;
       } else if (extra == "h") {
         view.h = value;
-        view.indexes.resize(view.w * view.h);
+        view.indexes.resize(view.w * view.h, -1);
         return;
       }
       int idx = -1;
@@ -59,7 +59,7 @@ Metric2DViewIndex::Updater Metric2DViewIndex::getUpdater(std::vector<Metric2DVie
         return;
       }
       if (view.indexes.size() <= idx) {
-        view.indexes.resize(std::max(idx + 1, view.w * view.h));
+        view.indexes.resize(std::max(idx + 1, view.w * view.h), -1);
       }
       view.indexes[idx] = metricsIndex;
     }

--- a/Framework/Core/src/ResourcesMonitoringHelper.cxx
+++ b/Framework/Core/src/ResourcesMonitoringHelper.cxx
@@ -31,16 +31,16 @@ inline static std::string retriveValue(const std::reference_wrapper<const String
   return std::string(val.get().data);
 }
 
-template <typename T>
+template <typename T, typename TIMESTAMPS>
 boost::property_tree::ptree fillNodeWithValue(const DeviceMetricsInfo& deviceMetrics,
-                                              const T& metricsStorage, size_t labelIndex, size_t storeIndex)
+                                              const T& metricsStorage, const TIMESTAMPS& timestampsStorage, size_t labelIndex, size_t storeIndex)
 {
   unsigned int loopRange = std::min(deviceMetrics.metrics[labelIndex].filledMetrics, metricsStorage[storeIndex].size());
   boost::property_tree::ptree metricNode;
 
   for (unsigned int idx = 0; idx < loopRange; ++idx) {
     boost::property_tree::ptree values;
-    values.add("timestamp", deviceMetrics.timestamps[labelIndex][idx]);
+    values.add("timestamp", timestampsStorage[storeIndex][idx]);
     if constexpr (std::is_arithmetic_v<T>) {
       values.add("value", std::to_string(retriveValue(std::cref(metricsStorage[storeIndex][idx]))));
     } else {
@@ -91,19 +91,19 @@ bool ResourcesMonitoringHelper::dumpMetricsToJSON(const std::vector<DeviceMetric
 
       switch (deviceMetrics.metrics[mi].type) {
         case MetricType::Int:
-          metricNode = fillNodeWithValue(deviceMetrics, deviceMetrics.intMetrics, mi, storeIdx);
+          metricNode = fillNodeWithValue(deviceMetrics, deviceMetrics.intMetrics, deviceMetrics.intTimestamps, mi, storeIdx);
           break;
 
         case MetricType::Float:
-          metricNode = fillNodeWithValue(deviceMetrics, deviceMetrics.floatMetrics, mi, storeIdx);
+          metricNode = fillNodeWithValue(deviceMetrics, deviceMetrics.floatMetrics, deviceMetrics.floatTimestamps, mi, storeIdx);
           break;
 
         case MetricType::String:
-          metricNode = fillNodeWithValue(deviceMetrics, deviceMetrics.stringMetrics, mi, storeIdx);
+          metricNode = fillNodeWithValue(deviceMetrics, deviceMetrics.stringMetrics, deviceMetrics.stringTimestamps, mi, storeIdx);
           break;
 
         case MetricType::Uint64:
-          metricNode = fillNodeWithValue(deviceMetrics, deviceMetrics.uint64Metrics, mi, storeIdx);
+          metricNode = fillNodeWithValue(deviceMetrics, deviceMetrics.uint64Metrics, deviceMetrics.uint64Timestamps, mi, storeIdx);
           break;
 
         default:
@@ -139,19 +139,19 @@ bool ResourcesMonitoringHelper::dumpMetricsToJSON(const std::vector<DeviceMetric
 
     switch (driverMetrics.metrics[mi].type) {
       case MetricType::Int:
-        metricNode = fillNodeWithValue(driverMetrics, driverMetrics.intMetrics, mi, storeIdx);
+        metricNode = fillNodeWithValue(driverMetrics, driverMetrics.intMetrics, driverMetrics.intTimestamps, mi, storeIdx);
         break;
 
       case MetricType::Float:
-        metricNode = fillNodeWithValue(driverMetrics, driverMetrics.floatMetrics, mi, storeIdx);
+        metricNode = fillNodeWithValue(driverMetrics, driverMetrics.floatMetrics, driverMetrics.floatTimestamps, mi, storeIdx);
         break;
 
       case MetricType::String:
-        metricNode = fillNodeWithValue(driverMetrics, driverMetrics.stringMetrics, mi, storeIdx);
+        metricNode = fillNodeWithValue(driverMetrics, driverMetrics.stringMetrics, driverMetrics.stringTimestamps, mi, storeIdx);
         break;
 
       case MetricType::Uint64:
-        metricNode = fillNodeWithValue(driverMetrics, driverMetrics.uint64Metrics, mi, storeIdx);
+        metricNode = fillNodeWithValue(driverMetrics, driverMetrics.uint64Metrics, driverMetrics.uint64Timestamps, mi, storeIdx);
         break;
 
       default:

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -532,9 +532,6 @@ struct ControlWebSocketHandler : public WebSocketHandler {
     for (auto& metricsInfo : *mContext.metrics) {
       std::fill(metricsInfo.changed.begin(), metricsInfo.changed.end(), false);
     }
-    if (didHaveNewMetric) {
-      DeviceMetricsHelper::updateMetricsNames(*mContext.driver, *mContext.metrics);
-    }
   }
 
   /// The driver context were we want to accumulate changes
@@ -953,7 +950,6 @@ LogProcessingState processChildrenOutput(DriverInfo& driverInfo,
   result.hasNewMetric = hasNewMetric;
   if (hasNewMetric) {
     hasNewMetric = false;
-    DeviceMetricsHelper::updateMetricsNames(driverInfo, metricsInfos);
   }
   return result;
 }

--- a/Framework/Core/test/test_DeviceMetricsInfo.cxx
+++ b/Framework/Core/test/test_DeviceMetricsInfo.cxx
@@ -50,13 +50,13 @@ BOOST_AUTO_TEST_CASE(TestDeviceMetricsInfo)
   BOOST_CHECK_EQUAL(info.metricLabelsPrefixesSortedIdx[0].index, 0);
   BOOST_CHECK_EQUAL(info.intMetrics.size(), 1);
   BOOST_CHECK_EQUAL(info.floatMetrics.size(), 0);
-  BOOST_CHECK_EQUAL(info.timestamps.size(), 1);
+  BOOST_CHECK_EQUAL(info.intTimestamps.size(), 1);
   BOOST_CHECK_EQUAL(info.metrics.size(), 1);
   BOOST_CHECK_EQUAL(info.metrics[0].type, MetricType::Int);
   BOOST_CHECK_EQUAL(info.metrics[0].storeIdx, 0);
   BOOST_CHECK_EQUAL(info.metrics[0].pos, 1);
 
-  BOOST_CHECK_EQUAL(info.timestamps[0][0], 1789372894);
+  BOOST_CHECK_EQUAL(info.intTimestamps[0][0], 1789372894);
   BOOST_CHECK_EQUAL(info.intMetrics[0][0], 12);
   BOOST_CHECK_EQUAL(info.intMetrics[0][1], 0);
 
@@ -343,6 +343,24 @@ BOOST_AUTO_TEST_CASE(TestDeviceMetricsInfo)
   BOOST_CHECK_EQUAL(info.metricPrefixes[2].end, 11);
   BOOST_CHECK_EQUAL(info.metricPrefixes[3].begin, 2);
   BOOST_CHECK_EQUAL(info.metricPrefixes[3].end, 8);
+
+  memset(&match, 0, sizeof(match));
+  metric = "[METRIC] data_relayer/w,0 1 1789372895 hostname=test.cern.ch";
+  result = DeviceMetricsHelper::parseMetric(metric, match);
+  BOOST_CHECK(result);
+  BOOST_CHECK_EQUAL(match.type, MetricType::Int);
+
+  memset(&match, 0, sizeof(match));
+  metric = "[METRIC] data_relayer/h,0 1 1789372895 hostname=test.cern.ch";
+  result = DeviceMetricsHelper::parseMetric(metric, match);
+  BOOST_CHECK(result);
+  BOOST_CHECK_EQUAL(match.type, MetricType::Int);
+
+  memset(&match, 0, sizeof(match));
+  metric = "[METRIC] data_relayer/1,0 8 1789372895 hostname=test.cern.ch";
+  result = DeviceMetricsHelper::parseMetric(metric, match);
+  BOOST_CHECK(result);
+  BOOST_CHECK_EQUAL(match.type, MetricType::Enum);
 }
 
 BOOST_AUTO_TEST_CASE(TestDeviceMetricsInfo2)
@@ -400,17 +418,19 @@ BOOST_AUTO_TEST_CASE(TestDeviceMetricsInfo2)
   BOOST_CHECK_EQUAL(info.floatMetrics[0][1], 2.);
   BOOST_CHECK_EQUAL(info.floatMetrics[0][2], 3.);
   BOOST_CHECK_EQUAL(info.floatMetrics[0][3], 4.);
-  BOOST_CHECK_EQUAL(info.timestamps.size(), 3);
-  BOOST_CHECK_EQUAL(info.timestamps[0][0], 1000);
-  BOOST_CHECK_EQUAL(info.timestamps[0][1], 1001);
-  BOOST_CHECK_EQUAL(info.timestamps[0][2], 1002);
-  BOOST_CHECK_EQUAL(info.timestamps[0][3], 1003);
-  BOOST_CHECK_EQUAL(info.timestamps[0][4], 1004);
-  BOOST_CHECK_EQUAL(info.timestamps[0][5], 1005);
-  BOOST_CHECK_EQUAL(info.timestamps[1][0], 1007);
-  BOOST_CHECK_EQUAL(info.timestamps[1][1], 1008);
-  BOOST_CHECK_EQUAL(info.timestamps[1][2], 1009);
-  BOOST_CHECK_EQUAL(info.timestamps[1][3], 1010);
+  BOOST_CHECK_EQUAL(info.intTimestamps.size(), 1);
+  BOOST_CHECK_EQUAL(info.floatTimestamps.size(), 1);
+  BOOST_CHECK_EQUAL(info.uint64Timestamps.size(), 1);
+  BOOST_CHECK_EQUAL(info.intTimestamps[0][0], 1000);
+  BOOST_CHECK_EQUAL(info.intTimestamps[0][1], 1001);
+  BOOST_CHECK_EQUAL(info.intTimestamps[0][2], 1002);
+  BOOST_CHECK_EQUAL(info.intTimestamps[0][3], 1003);
+  BOOST_CHECK_EQUAL(info.intTimestamps[0][4], 1004);
+  BOOST_CHECK_EQUAL(info.intTimestamps[0][5], 1005);
+  BOOST_CHECK_EQUAL(info.floatTimestamps[0][0], 1007);
+  BOOST_CHECK_EQUAL(info.floatTimestamps[0][1], 1008);
+  BOOST_CHECK_EQUAL(info.floatTimestamps[0][2], 1009);
+  BOOST_CHECK_EQUAL(info.floatTimestamps[0][3], 1010);
   BOOST_CHECK_EQUAL(info.changed.size(), 3);
   for (int i = 0; i < 1026; ++i) {
     ckey(info, i, t++);

--- a/Framework/GUISupport/src/FrameworkGUIDebugger.cxx
+++ b/Framework/GUISupport/src/FrameworkGUIDebugger.cxx
@@ -17,6 +17,7 @@
 #include "Framework/DriverControl.h"
 #include "Framework/DriverInfo.h"
 #include "Framework/DeviceMetricsHelper.h"
+#include "Framework/DeviceMetricsInfo.h"
 #include "FrameworkGUIDeviceInspector.h"
 #include "FrameworkGUIDevicesGraph.h"
 #include "FrameworkGUIDataRelayerUsage.h"
@@ -242,10 +243,9 @@ void displaySparks(
     static ImPlotAxisFlags rty_axis = ImPlotAxisFlags_NoTickLabels | ImPlotAxisFlags_NoLabel | ImPlotAxisFlags_NoTickMarks;
     ImGui::PushID(index.stateIndex);
     HistoData data;
-    data.mod = std::min(metric.filledMetrics, metricsInfo.timestamps[index.metricIndex].size());
+    data.mod = std::min(metric.filledMetrics, metricStorageSize(metric.type));
     data.first = metric.pos - data.mod;
     data.size = metric.filledMetrics;
-    data.time = metricsInfo.timestamps[index.metricIndex].data();
     data.legend = state.legend.c_str();
 
     if (!locked) {
@@ -256,35 +256,50 @@ void displaySparks(
     if (ImPlot::BeginPlot("##sparks", "time", "value", ImVec2(700, 100), 0, rtx_axis, rty_axis)) {
       ImPlot::SetPlotYAxis(state.axis);
       switch (metric.type) {
-        case MetricType::Int: {
-          data.points = (void*)metricsInfo.intMetrics[metric.storeIdx].data();
+        case MetricType::Enum: {
+          data.points = (void*)metricsInfo.enumMetrics[metric.storeIdx].data();
+          data.time = metricsInfo.enumTimestamps[metric.storeIdx].data();
 
           auto getter = [](void* hData, int idx) -> ImPlotPoint {
             auto histoData = reinterpret_cast<HistoData*>(hData);
             size_t pos = (histoData->first + static_cast<size_t>(idx)) % histoData->mod;
-            assert(pos >= 0 && pos < 1024);
+            assert(pos >= 0 && pos < metricStorageSize(MetricType::Enum));
+            return ImPlotPoint(histoData->time[pos], ((int8_t*)(histoData->points))[pos]);
+          };
+          ImPlot::PlotLineG("##plot", getter, &data, data.mod);
+        } break;
+        case MetricType::Int: {
+          data.points = (void*)metricsInfo.intMetrics[metric.storeIdx].data();
+          data.time = metricsInfo.intTimestamps[metric.storeIdx].data();
+
+          auto getter = [](void* hData, int idx) -> ImPlotPoint {
+            auto histoData = reinterpret_cast<HistoData*>(hData);
+            size_t pos = (histoData->first + static_cast<size_t>(idx)) % histoData->mod;
+            assert(pos >= 0 && pos < metricStorageSize(MetricType::Int));
             return ImPlotPoint(histoData->time[pos], ((int*)(histoData->points))[pos]);
           };
           ImPlot::PlotLineG("##plot", getter, &data, data.mod);
         } break;
         case MetricType::Uint64: {
           data.points = (void*)metricsInfo.uint64Metrics[metric.storeIdx].data();
+          data.time = metricsInfo.uint64Timestamps[metric.storeIdx].data();
 
           auto getter = [](void* hData, int idx) -> ImPlotPoint {
             auto histoData = reinterpret_cast<HistoData*>(hData);
             size_t pos = (histoData->first + static_cast<size_t>(idx)) % histoData->mod;
-            assert(pos >= 0 && pos < 1024);
+            assert(pos >= 0 && pos < metricStorageSize(MetricType::Uint64));
             return ImPlotPoint(histoData->time[pos], ((uint64_t*)histoData->points)[pos]);
           };
           ImPlot::PlotLineG("##plot", getter, &data, data.mod, 0);
         } break;
         case MetricType::Float: {
           data.points = (void*)metricsInfo.floatMetrics[metric.storeIdx].data();
+          data.time = metricsInfo.floatTimestamps[metric.storeIdx].data();
 
           auto getter = [](void* hData, int idx) -> ImPlotPoint {
             auto histoData = reinterpret_cast<HistoData*>(hData);
             size_t pos = (histoData->first + static_cast<size_t>(idx)) % histoData->mod;
-            assert(pos >= 0 && pos < 1024);
+            assert(pos >= 0 && pos < metricStorageSize(MetricType::Float));
             return ImPlotPoint(histoData->time[pos], ((float*)histoData->points)[pos]);
           };
           ImPlot::PlotLineG("##plot", getter, &data, data.mod, 0);
@@ -334,9 +349,6 @@ void displayDeviceMetrics(const char* label,
         deviceNames.push_back(specs[di].label.c_str());
         MultiplotData data;
         data.size = metric.filledMetrics;
-        data.mod = std::min(metric.filledMetrics, metricsInfos[di].timestamps[mi].size());
-        data.first = metric.pos - data.mod;
-        data.X = metricsInfos[di].timestamps[mi].data();
         data.legend = state[gmi].legend.c_str();
         data.type = metric.type;
         data.axis = state[gmi].axis;
@@ -349,12 +361,31 @@ void displayDeviceMetrics(const char* label,
         switch (metric.type) {
           case MetricType::Int: {
             data.Y = metricsInfos[di].intMetrics[metric.storeIdx].data();
+            auto timestamps = metricsInfos[di].intTimestamps[metric.storeIdx];
+            data.mod = std::min(metric.filledMetrics, timestamps.size());
+            data.first = metric.pos - data.mod;
+            data.X = timestamps.data();
+          } break;
+          case MetricType::Enum: {
+            data.Y = metricsInfos[di].enumMetrics[metric.storeIdx].data();
+            auto timestamps = metricsInfos[di].enumTimestamps[metric.storeIdx];
+            data.mod = std::min(metric.filledMetrics, timestamps.size());
+            data.first = metric.pos - data.mod;
+            data.X = timestamps.data();
           } break;
           case MetricType::Uint64: {
             data.Y = metricsInfos[di].uint64Metrics[metric.storeIdx].data();
+            auto timestamps = metricsInfos[di].uint64Timestamps[metric.storeIdx];
+            data.mod = std::min(metric.filledMetrics, timestamps.size());
+            data.first = metric.pos - data.mod;
+            data.X = timestamps.data();
           } break;
           case MetricType::Float: {
             data.Y = metricsInfos[di].floatMetrics[metric.storeIdx].data();
+            auto timestamps = metricsInfos[di].floatTimestamps[metric.storeIdx];
+            data.mod = std::min(metric.filledMetrics, timestamps.size());
+            data.first = metric.pos - data.mod;
+            data.X = timestamps.data();
           } break;
           case MetricType::Unknown:
           case MetricType::String: {
@@ -393,6 +424,8 @@ void displayDeviceMetrics(const char* label,
       y = static_cast<const uint64_t*>(histoData->Y)[pos];
     } else if (histoData->type == MetricType::Float) {
       y = static_cast<const float*>(histoData->Y)[pos];
+    } else if (histoData->type == MetricType::Enum) {
+      y = static_cast<const int8_t*>(histoData->Y)[pos];
     }
     auto point = ImPlotPoint{x, y};
     return point;
@@ -478,18 +511,25 @@ void metricsTableRow(std::vector<MetricIndex> metricIndex,
     auto& info = metricsInfos[index.deviceIndex].metrics[index.metricIndex];
 
     ImGui::TableNextColumn();
-    auto time = metricsInfo.timestamps[index.metricIndex][row];
     switch (info.type) {
       case MetricType::Int: {
+        auto time = metricsInfo.intTimestamps[info.storeIdx][row];
         ImGui::Text("%i, %" PRIu64, metricsInfo.intMetrics[info.storeIdx][row], (uint64_t)time);
       } break;
       case MetricType::Uint64: {
+        auto time = metricsInfo.uint64Timestamps[info.storeIdx][row];
         ImGui::Text("%" PRIu64 ", %" PRIu64, metricsInfo.uint64Metrics[info.storeIdx][row], (uint64_t)time);
       } break;
       case MetricType::Float: {
+        auto time = metricsInfo.floatTimestamps[info.storeIdx][row];
         ImGui::Text("%f, %" PRIu64, metricsInfo.floatMetrics[info.storeIdx][row], (uint64_t)time);
       } break;
+      case MetricType::Enum: {
+        auto time = metricsInfo.enumTimestamps[info.storeIdx][row];
+        ImGui::Text("%i, %" PRIu64, metricsInfo.enumMetrics[info.storeIdx][row], (uint64_t)time);
+      } break;
       case MetricType::String: {
+        auto time = metricsInfo.stringTimestamps[info.storeIdx][row];
         ImGui::Text("%s, %" PRIu64, metricsInfo.stringMetrics[info.storeIdx][row].data, (uint64_t)time);
       } break;
       default:
@@ -735,10 +775,29 @@ void displayMetrics(gui::WorkspaceGUIState& state,
           deviceVisible = true;
           visibleMetrics++;
           auto& metric = metricInfo.metrics[mi];
-          auto& timestamps = metricInfo.timestamps[mi];
+          size_t const* timestamps = nullptr;
+          switch (metric.type) {
+            case MetricType::Int:
+              timestamps = metricInfo.intTimestamps[metric.storeIdx].data();
+              break;
+            case MetricType::Float:
+              timestamps = metricInfo.floatTimestamps[metric.storeIdx].data();
+              break;
+            case MetricType::String:
+              timestamps = metricInfo.stringTimestamps[metric.storeIdx].data();
+              break;
+            case MetricType::Uint64:
+              timestamps = metricInfo.uint64Timestamps[metric.storeIdx].data();
+              break;
+            case MetricType::Enum:
+              timestamps = metricInfo.enumTimestamps[metric.storeIdx].data();
+              break;
+            default:
+              throw std::runtime_error("Unknown metric type");
+          }
 
-          for (size_t ti = 0; ti != metricInfo.timestamps.size(); ++ti) {
-            size_t minRangePos = (metric.pos + ti) % metricInfo.timestamps.size();
+          for (size_t ti = 0; ti != metricStorageSize(metric.type); ++ti) {
+            size_t minRangePos = (metric.pos + ti) % metricStorageSize(metric.type);
             size_t curMinTime = timestamps[minRangePos];
             if (curMinTime == 0) {
               continue;
@@ -748,7 +807,7 @@ void displayMetrics(gui::WorkspaceGUIState& state,
               break;
             }
           }
-          size_t maxRangePos = (size_t)(metric.pos) - 1 % metricInfo.timestamps.size();
+          size_t maxRangePos = (size_t)(metric.pos) - 1 % metricStorageSize(metric.type);
           size_t curMaxTime = timestamps[maxRangePos];
           maxTime = std::max(maxTime, curMaxTime);
           visibleMetricsIndex.push_back(MetricIndex{si, di, mi, gmi});

--- a/Framework/GUISupport/src/FrameworkGUIDevicesGraph.cxx
+++ b/Framework/GUISupport/src/FrameworkGUIDevicesGraph.cxx
@@ -312,7 +312,7 @@ struct MetricsPainter {
       auto idx = record * viewIndex.h + i;
       assert(viewIndex.indexes.size() > idx);
       MetricInfo const& metricInfo = metrics.metrics[viewIndex.indexes[idx]];
-      auto& data = DeviceMetricsInfoHelpers::get<T>(metrics, metricInfo.storeIdx);
+      auto& data = DeviceMetricsInfoHelpers::get<T, metricStorageSize<T>()>(metrics, metricInfo.storeIdx);
       return data[(metricInfo.pos - 1) % data.size()];
     };
   }


### PR DESCRIPTION
This should drastically reduce the memory needed for metrics, in
particular those which are associated to the GUI, by keeping
only a fraction of the history for things where we do not care /
it does not make sense to show it.

Moreover it speeds up metric processing by removing obsolete code and avoiding a memory allocation when parsing.