### PR TITLE
DPL Analysis: do not use string lookup for finding columns

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1046,7 +1046,8 @@ auto select(T const& t, framework::expressions::Filter const& f)
 }
 
 template <typename C, typename... Cs>
-arrow::ChunkedArray* getColumnByType(framework::pack<Cs...> columns, arrow::Table* table) {
+arrow::ChunkedArray* getColumnByType(framework::pack<Cs...> columns, arrow::Table* table)
+{
   return table->column(framework::has_type_at_v<C>(columns)).get();
 }
 
@@ -1348,7 +1349,7 @@ class Table
   arrow::ChunkedArray* lookupColumn()
   {
     if constexpr (T::persistent::value) {
-      return getColumnByType<T>(persistent_columns_t{},mTable.get());
+      return getColumnByType<T>(persistent_columns_t{}, mTable.get());
     } else {
       return nullptr;
     }

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1045,7 +1045,10 @@ auto select(T const& t, framework::expressions::Filter const& f)
   return Filtered<T>({t.asArrowTable()}, selectionToVector(framework::expressions::createSelection(t.asArrowTable(), f)));
 }
 
-arrow::ChunkedArray* getIndexFromLabel(arrow::Table* table, const char* label);
+template <typename C, typename... Cs>
+arrow::ChunkedArray* getColumnByType(framework::pack<Cs...> columns, arrow::Table* table) {
+  return table->column(framework::has_type_at_v<C>(columns)).get();
+}
 
 /// A Table class which observes an arrow::Table and provides
 /// It is templated on a set of Column / DynamicColumn types.
@@ -1345,8 +1348,7 @@ class Table
   arrow::ChunkedArray* lookupColumn()
   {
     if constexpr (T::persistent::value) {
-      auto label = T::columnLabel();
-      return getIndexFromLabel(mTable.get(), label);
+      return getColumnByType<T>(persistent_columns_t{},mTable.get());
     } else {
       return nullptr;
     }
@@ -1495,18 +1497,21 @@ void notBoundTable(const char* tableName);
 
 namespace row_helpers
 {
-template <typename... Cs>
-std::array<arrow::ChunkedArray*, sizeof...(Cs)> getArrowColumns(arrow::Table* table, framework::pack<Cs...>)
+template <typename T, typename... Cs>
+std::array<arrow::ChunkedArray*, sizeof...(Cs)> getArrowColumnsTyped(const T& table, framework::pack<Cs...>)
 {
   static_assert(std::conjunction_v<typename Cs::persistent...>, "Arrow columns: only persistent columns accepted (not dynamic and not index ones");
-  return std::array<arrow::ChunkedArray*, sizeof...(Cs)>{o2::soa::getIndexFromLabel(table, Cs::columnLabel())...};
+  return {o2::soa::getColumnByType<Cs>(typename T::persistent_columns_t{}, table.asArrowTable().get())...};
 }
 
-template <typename... Cs>
-std::array<std::shared_ptr<arrow::Array>, sizeof...(Cs)> getChunks(arrow::Table* table, framework::pack<Cs...>, uint64_t ci)
+template <size_t N>
+auto getChunksFromColumns(std::array<arrow::ChunkedArray*, N>& columns, uint64_t ci)
 {
-  static_assert(std::conjunction_v<typename Cs::persistent...>, "Arrow chunks: only persistent columns accepted (not dynamic and not index ones");
-  return std::array<std::shared_ptr<arrow::Array>, sizeof...(Cs)>{o2::soa::getIndexFromLabel(table, Cs::columnLabel())->chunk(ci)...};
+  std::array<std::shared_ptr<arrow::Array>, N> chunks;
+  for (size_t i = 0; i < N; ++i) {
+    chunks[i] = columns[i]->chunk(ci);
+  }
+  return chunks;
 }
 
 template <typename T, typename C>
@@ -1517,7 +1522,7 @@ typename C::type getSingleRowPersistentData(arrow::Table* table, T& rowIterator,
     ci = colIterator.mCurrentChunk;
     ai = *(colIterator.mCurrentPos) - colIterator.mFirstIndex;
   }
-  return std::static_pointer_cast<o2::soa::arrow_array_for_t<typename C::type>>(o2::soa::getIndexFromLabel(table, C::columnLabel())->chunk(ci))->raw_values()[ai];
+  return std::static_pointer_cast<o2::soa::arrow_array_for_t<typename C::type>>(o2::soa::getColumnByType<C>(typename T::parent_t::persistent_columns_t{}, table)->chunk(ci))->raw_values()[ai];
 }
 
 template <typename T, typename C>

--- a/Framework/Core/include/Framework/ASoAHelpers.h
+++ b/Framework/Core/include/Framework/ASoAHelpers.h
@@ -94,7 +94,7 @@ std::vector<BinningIndex> groupTable(const T& table, const BP<Cs...>& binningPol
 
   auto persistentColumns = typename BP<Cs...>::persistent_columns_t{};
   constexpr auto persistentColumnsCount = pack_size(persistentColumns);
-  auto arrowColumns = o2::soa::row_helpers::getArrowColumns(arrowTable, persistentColumns);
+  auto arrowColumns = o2::soa::row_helpers::getArrowColumnsTyped(table, persistentColumns);
   auto chunksCount = arrowColumns[0]->num_chunks();
   for (int i = 1; i < persistentColumnsCount; i++) {
     if (arrowColumns[i]->num_chunks() != chunksCount) {
@@ -103,7 +103,7 @@ std::vector<BinningIndex> groupTable(const T& table, const BP<Cs...>& binningPol
   }
 
   for (uint64_t ci = 0; ci < chunksCount; ++ci) {
-    auto chunks = o2::soa::row_helpers::getChunks(arrowTable, persistentColumns, ci);
+    auto chunks = o2::soa::row_helpers::getChunksFromColumns(arrowColumns, ci);
     auto chunkLength = std::get<0>(chunks)->length();
     for_<persistentColumnsCount - 1>([&chunks, &chunkLength](auto i) {
       if (std::get<i.value + 1>(chunks)->length() != chunkLength) {

--- a/Framework/Core/src/ASoA.cxx
+++ b/Framework/Core/src/ASoA.cxx
@@ -101,15 +101,6 @@ std::shared_ptr<arrow::Table> ArrowHelpers::concatTables(std::vector<std::shared
   return result;
 }
 
-arrow::ChunkedArray* getIndexFromLabel(arrow::Table* table, const char* label)
-{
-  auto index = table->schema()->GetAllFieldIndices(label);
-  if (index.empty() == true) {
-    o2::framework::throw_error(o2::framework::runtime_error_f("Unable to find column with label %s", label));
-  }
-  return table->column(index[0]).get();
-}
-
 void notBoundTable(const char* tableName)
 {
   throw o2::framework::runtime_error_f("Index pointing to %s is not bound! Did you subscribe to the table?", tableName);

--- a/Framework/Core/test/test_IndexBuilder.cxx
+++ b/Framework/Core/test/test_IndexBuilder.cxx
@@ -114,7 +114,7 @@ BOOST_AUTO_TEST_CASE(TestIndexBuilder)
 
   auto t6 = IndexSparse::indexBuilder("test2", typename IDX2s::persistent_columns_t{}, st1, std::tie(st2, st1, st3, st4));
   BOOST_REQUIRE_EQUAL(t6->num_rows(), st2.size());
-  IDXs idxs{t6};
+  IDX2s idxs{t6};
   std::array<int, 7> fs{0, 1, 2, -1, -1, 4, -1};
   std::array<int, 7> cs{0, 1, 2, -1, 5, 6, -1};
   idxs.bindExternalIndices(&st1, &st2, &st3, &st4);


### PR DESCRIPTION
@ktf this removes string column lookup reducing runtime costs of table construction significantly, but probably increases compile time. Could you take a look?