### PR TITLE
[QC-485] Timepipeline parallelism in multi-layer Mergers

### DIFF
--- a/Utilities/Mergers/include/Mergers/MergerBuilder.h
+++ b/Utilities/Mergers/include/Mergers/MergerBuilder.h
@@ -50,6 +50,7 @@ class MergerBuilder
   void setInputSpecs(const framework::Inputs&);
   void setOutputSpec(const framework::OutputSpec&);
   void setTopologyPosition(size_t layer, size_t id);
+  void setTimePipeline(size_t timepipeline);
   void setConfig(MergerConfig);
 
   framework::DataProcessorSpec buildSpec();
@@ -76,6 +77,7 @@ class MergerBuilder
   std::string mName;
   size_t mId{0};
   size_t mLayer{1};
+  size_t mTimePipeline{1};
   framework::Inputs mInputSpecs;
   framework::OutputSpec mOutputSpec;
   MergerConfig mConfig;

--- a/Utilities/Mergers/src/MergerBuilder.cxx
+++ b/Utilities/Mergers/src/MergerBuilder.cxx
@@ -47,6 +47,11 @@ void MergerBuilder::setTopologyPosition(size_t layer, size_t id)
   mId = id;
 }
 
+void MergerBuilder::setTimePipeline(size_t timepipeline)
+{
+  mTimePipeline = timepipeline;
+}
+
 void MergerBuilder::setInputSpecs(const framework::Inputs& inputs)
 {
   mInputSpecs = inputs;
@@ -94,6 +99,7 @@ framework::DataProcessorSpec MergerBuilder::buildSpec()
   merger.inputs.push_back({"timer-publish", "MRGR", mergerDataDescription("timer-" + mName), mergerSubSpec(mLayer, mId), framework::Lifetime::Timer});
   merger.options.push_back({"period-timer-publish", framework::VariantType::Int, static_cast<int>(mConfig.publicationDecision.param * 1000000), {"timer period"}});
   merger.labels.push_back(mergerLabel());
+  merger.maxInputTimeslices = mTimePipeline;
 
   return std::move(merger);
 }


### PR DESCRIPTION
It is needed when the number of inputs is unknown, thus we cannot split subspecs between data processors, but we can distribute the load in round robin order.