### PR TITLE
adjust TOF calib collector (speed up)

### DIFF
--- a/Detectors/TOF/calibration/include/TOFCalibration/TOFCalibCollector.h
+++ b/Detectors/TOF/calibration/include/TOFCalibration/TOFCalibCollector.h
@@ -14,9 +14,9 @@
 
 #include "DetectorsCalibration/TimeSlotCalibration.h"
 #include "DetectorsCalibration/TimeSlot.h"
+#include "TOFBase/Geo.h"
 #include "DataFormatsTOF/CalibInfoTOF.h"
 #include "DataFormatsTOF/CalibInfoCluster.h"
-#include "TOFBase/Geo.h"
 #include "DataFormatsTOF/CalibInfoTOFshort.h"
 
 #include <array>
@@ -57,7 +57,7 @@ class TOFCalibInfoSlot
 
  private:
   std::array<int, Geo::NCHANNELS> mEntriesSlot;                               // vector containing number of entries per channel
-  std::vector<o2::dataformats::CalibInfoTOFshort> mTOFCollectedCalibInfoSlot; ///< output TOF calibration info
+  std::vector<o2::dataformats::CalibInfoTOF> mTOFCollectedCalibInfoSlot;      ///< output TOF calibration info
 
   ClassDefNV(TOFCalibInfoSlot, 1);
 };
@@ -87,9 +87,9 @@ class TOFCalibCollector final : public o2::calibration::TimeSlotCalibration<o2::
   bool mTest = false;                                                     // flag to say whether we are in test mode or not
   bool mAbsMaxNumOfHits = true;                                           // to decide if the mMaxNumOfHits should be multiplied by the number of TOF channels
   std::array<int, Geo::NCHANNELS> mEntries;                               // vector containing number of entries per channel
-  std::vector<o2::dataformats::CalibInfoTOFshort> mTOFCollectedCalibInfo; ///< output TOF calibration info
+  std::vector<o2::dataformats::CalibInfoTOF> mTOFCollectedCalibInfo;      ///< output TOF calibration info
 
-  ClassDefOverride(TOFCalibCollector, 1);
+  ClassDefOverride(TOFCalibCollector, 2);
 };
 
 } // end namespace tof

--- a/Detectors/TOF/calibration/testWorkflow/TOFCalibCollectorWriterSpec.h
+++ b/Detectors/TOF/calibration/testWorkflow/TOFCalibCollectorWriterSpec.h
@@ -16,7 +16,7 @@
 /// @brief  Device to write to tree the information for TOF time slewing calibration.
 
 #include "TOFCalibration/TOFCalibCollector.h"
-#include "DataFormatsTOF/CalibInfoTOFshort.h"
+#include "DataFormatsTOF/CalibInfoTOF.h"
 #include <TTree.h>
 #include <gsl/span>
 
@@ -51,7 +51,7 @@ class TOFCalibCollectorWriter : public o2::framework::Task
 
   void run(o2::framework::ProcessingContext& pc) final
   {
-    auto collectedInfo = pc.inputs().get<gsl::span<o2::dataformats::CalibInfoTOFshort>>("collectedInfo");
+    auto collectedInfo = pc.inputs().get<gsl::span<o2::dataformats::CalibInfoTOF>>("collectedInfo");
     auto entriesPerChannel = pc.inputs().get<gsl::span<int>>("entriesCh");
     int offsetStart = 0;
     for (int ich = 0; ich < o2::tof::Geo::NCHANNELS; ich++) {
@@ -59,8 +59,8 @@ class TOFCalibCollectorWriter : public o2::framework::Task
       if (entriesPerChannel[ich] > 0) {
         mTOFCalibInfoOut.resize(entriesPerChannel[ich]);
         auto subSpanVect = collectedInfo.subspan(offsetStart, entriesPerChannel[ich]);
-        memcpy(&mTOFCalibInfoOut[0], subSpanVect.data(), sizeof(o2::dataformats::CalibInfoTOFshort) * subSpanVect.size());
-        const o2::dataformats::CalibInfoTOFshort* tmp = subSpanVect.data();
+        memcpy(&mTOFCalibInfoOut[0], subSpanVect.data(), sizeof(o2::dataformats::CalibInfoTOF) * subSpanVect.size());
+        const o2::dataformats::CalibInfoTOF* tmp = subSpanVect.data();
       }
       mOutputTree->Fill();
       offsetStart += entriesPerChannel[ich];
@@ -77,7 +77,7 @@ class TOFCalibCollectorWriter : public o2::framework::Task
  private:
   int mCount = 0; // how many times we filled the tree
   bool mIsEndOfStream = false;
-  std::vector<o2::dataformats::CalibInfoTOFshort> mTOFCalibInfoOut, *mPTOFCalibInfoOut = &mTOFCalibInfoOut; ///< these are the object and pointer to the CalibInfo of a specific channel that we need to fill the output tree
+  std::vector<o2::dataformats::CalibInfoTOF> mTOFCalibInfoOut, *mPTOFCalibInfoOut = &mTOFCalibInfoOut;      ///< these are the object and pointer to the CalibInfo of a specific channel that we need to fill the output tree
   std::unique_ptr<TTree> mOutputTree;                                                                       ///< tree for the collected calib tof info
   std::string mTOFCalibInfoBranchName = "TOFCalibInfo";                                                     ///< name of branch containing input TOF calib infos
   std::string mOutputBranchName = "TOFCollectedCalibInfo";                                                  ///< name of branch containing output


### PR DESCRIPTION
@chiarazampolli 
This apply a fix (validated on LHC22m run) to speed up the calib collector.
I removed emplace in random position and I added a sorting on the channel number when finalizing.
This is very much faster, I just needed to replace CalibInfoShort with CalibInfo since the channel number is needed for the sorting.