### PR TITLE
Remove DEBUG_DUMP define left in accidentally

### DIFF
--- a/Detectors/Vertexing/include/DetectorsVertexing/PVertexer.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/PVertexer.h
@@ -38,7 +38,7 @@
 
 //TODO: MeanVertex and parameters input from CCDB
 
-#define _PV_DEBUG_TREE_ // if enabled, produce dbscan and vertex comparison dump
+// #define _PV_DEBUG_TREE_ // if enabled, produce dbscan and vertex comparison dump
 
 namespace o2
 {


### PR DESCRIPTION
currently broken when no data reaches the prim vtx, leads to segfault
merging