### PR TITLE
[EMCAL-786, EMCAL-565, EMCAL-566] Different spec names for Bad Channel Calib and Time Calib

### DIFF
--- a/Detectors/EMCAL/calibration/testWorkflow/EMCALChannelCalibratorSpec.h
+++ b/Detectors/EMCAL/calibration/testWorkflow/EMCALChannelCalibratorSpec.h
@@ -233,10 +233,13 @@ DataProcessorSpec getEMCALChannelCalibDeviceSpec(const bool loadCalibParamsFromC
   using EMCALCalibParams = o2::emcal::EMCALCalibParams;
 
   std::vector<OutputSpec> outputs;
-  if (EMCALCalibParams::Instance().calibType.find("time") != std::string::npos) {                                                        // time calibration
-    outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "EMC_TIMECALIB"}, Lifetime::Sporadic);   // This needs to match with the output!
-    outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "EMC_TIMECALIB"}, Lifetime::Sporadic);   // This needs to match with the output!
-  } else {                                                                                                                               // bad channel calibration
+  std::string processorName;
+  if (EMCALCalibParams::Instance().calibType.find("time") != std::string::npos) { // time calibration
+    processorName = "calib-emcalchannel-time";
+    outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "EMC_TIMECALIB"}, Lifetime::Sporadic); // This needs to match with the output!
+    outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "EMC_TIMECALIB"}, Lifetime::Sporadic); // This needs to match with the output!
+  } else {                                                                                                                             // bad channel calibration
+    processorName = "calib-emcalchannel-badchannel";
     outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "EMC_BADCHANNELS"}, Lifetime::Sporadic); // This needs to match with the output!
     outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "EMC_BADCHANNELS"}, Lifetime::Sporadic); // This needs to match with the output!
   }
@@ -256,7 +259,7 @@ DataProcessorSpec getEMCALChannelCalibDeviceSpec(const bool loadCalibParamsFromC
                                                                 o2::base::GRPGeomRequest::None, // geometry
                                                                 inputs);
   return DataProcessorSpec{
-    "calib-emcalchannel-calibration",
+    processorName,
     inputs,
     outputs,
     AlgorithmSpec{adaptFromTask<device>(ccdbRequest, loadCalibParamsFromCCDB)},


### PR DESCRIPTION
Define differnet names for the EMCALChannelCalibratorSpec
depending on what calibration is running.
Needed in order to run the two calibrations
in one workflow at the same time.