### PR TITLE
Update ITS DCS string parser

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DCSParserSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DCSParserSpec.h
@@ -63,7 +63,7 @@ class ITSDCSParser : public Task
   void saveToOutput();
   void resetMemory();
   void pushToCCDB(ProcessingContext&);
-  bool updatePosition(unsigned int&, unsigned int&, const std::string&, const char*, const std::string&, bool ignoreNpos=false);
+  bool updatePosition(unsigned int&, unsigned int&, const std::string&, const char*, const std::string&, bool ignoreNpos = false);
   void updateAndCheck(int&, const int);
   void updateAndCheck(short int&, const short int);
   void writeChipInfo(o2::dcs::DCSconfigObject_t&, const std::string&, const unsigned short int);

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DCSParserSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DCSParserSpec.h
@@ -63,6 +63,7 @@ class ITSDCSParser : public Task
   void saveToOutput();
   void resetMemory();
   void pushToCCDB(ProcessingContext&);
+  bool updatePosition(unsigned int&, unsigned int&, const std::string&, const char*, const std::string&, bool ignoreNpos=false);
   void updateAndCheck(int&, const int);
   void updateAndCheck(short int&, const short int);
   void writeChipInfo(o2::dcs::DCSconfigObject_t&, const std::string&, const unsigned short int);

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DCSParserSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DCSParserSpec.h
@@ -63,7 +63,7 @@ class ITSDCSParser : public Task
   void saveToOutput();
   void resetMemory();
   void pushToCCDB(ProcessingContext&);
-  bool updatePosition(unsigned int&, unsigned int&, const std::string&, const char*, const std::string&, bool ignoreNpos = false);
+  bool updatePosition(size_t&, size_t&, const std::string&, const char*, const std::string&, bool ignoreNpos = false);
   void updateAndCheck(int&, const int);
   void updateAndCheck(short int&, const short int);
   void writeChipInfo(o2::dcs::DCSconfigObject_t&, const std::string&, const unsigned short int);

--- a/Detectors/ITSMFT/ITS/workflow/src/DCSParserSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/DCSParserSpec.cxx
@@ -56,7 +56,7 @@ void ITSDCSParser::run(ProcessingContext& pc)
   // Check for DOS vs. Unix line ending
   std::string line_ending = "\n";
   size_t newline_pos = inStringConv.find(line_ending);
-  if (newline_pos && inStringConv[newline_pos-1] == '\r') {
+  if (newline_pos && inStringConv[newline_pos - 1] == '\r') {
     line_ending = "\r\n";
   }
 

--- a/Detectors/ITSMFT/ITS/workflow/src/DCSParserSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/DCSParserSpec.cxx
@@ -175,8 +175,8 @@ void ITSDCSParser::updateMemoryFromInputString(const std::string& inString)
 //////////////////////////////////////////////////////////////////////////////
 // Update pos and npos and check for validity. Return false if there is error
 bool ITSDCSParser::updatePosition(unsigned int& pos, unsigned int& npos,
-  const std::string& delimiter, const char* word,
-  const std::string& inString, bool ignoreNpos/*=false*/)
+                                  const std::string& delimiter, const char* word,
+                                  const std::string& inString, bool ignoreNpos /*=false*/)
 {
   pos += npos + delimiter.length() + std::string(word).length();
   if (!ignoreNpos) {

--- a/Detectors/ITSMFT/ITS/workflow/src/DCSParserSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/DCSParserSpec.cxx
@@ -148,7 +148,6 @@ void ITSDCSParser::updateMemoryFromInputString(const std::string& inString)
 
       // First, update map of disabled double columns at EOR
       std::vector<std::string> doubleColDisable = this->vectorizeStringList(bigVectSplit[0], ";");
-      //LOG(info) << "doubleColDisable: " << doubleColDisable;
       for (const std::string& str : doubleColDisable) {
         std::vector<unsigned short int> doubleColDisableVector = this->vectorizeStringListInt(str, ":");
         this->mDoubleColsDisableEOR[doubleColDisableVector[0]].push_back(doubleColDisableVector[1]);

--- a/Detectors/ITSMFT/ITS/workflow/src/DCSParserSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/DCSParserSpec.cxx
@@ -89,8 +89,8 @@ void ITSDCSParser::updateMemoryFromInputString(const std::string& inString)
 
   // Parse the individual parts of the string
   const std::string delimiter = "|";
-  unsigned int pos = 0;
-  unsigned int npos = inString.find(delimiter);
+  size_t pos = 0;
+  size_t npos = inString.find(delimiter);
   if (npos == std::string::npos) {
     LOG(error) << "Delimiter not found, possibly corrupted data!";
     return;
@@ -174,7 +174,7 @@ void ITSDCSParser::updateMemoryFromInputString(const std::string& inString)
 
 //////////////////////////////////////////////////////////////////////////////
 // Update pos and npos and check for validity. Return false if there is error
-bool ITSDCSParser::updatePosition(unsigned int& pos, unsigned int& npos,
+bool ITSDCSParser::updatePosition(size_t& pos, size_t& npos,
                                   const std::string& delimiter, const char* word,
                                   const std::string& inString, bool ignoreNpos /*=false*/)
 {
@@ -231,7 +231,7 @@ std::vector<std::string> ITSDCSParser::vectorizeStringList(
   const std::string& str, const std::string& delimiter)
 {
   std::vector<std::string> str_vect;
-  std::string::size_type prev_pos = 0, pos = 0;
+  size_t prev_pos = 0, pos = 0;
   while ((pos = str.find(delimiter, pos)) != std::string::npos) {
     std::string substr = str.substr(prev_pos, pos - prev_pos);
     if (substr.length()) {
@@ -252,7 +252,7 @@ std::vector<unsigned short int> ITSDCSParser::vectorizeStringListInt(
   const std::string& str, const std::string& delimiter)
 {
   std::vector<unsigned short int> int_vect;
-  std::string::size_type prev_pos = 0, pos = 0;
+  size_t prev_pos = 0, pos = 0;
   while ((pos = str.find(delimiter, pos)) != std::string::npos) {
     unsigned short int substr = std::stoi(str.substr(prev_pos, pos - prev_pos));
     int_vect.push_back(substr);


### PR DESCRIPTION
Two bug fixes for the ITS DCS string parser:
- work with both DOS and Unix file endings;
- work correctly with ampersand delineation.

Code has already been tested -- tagging @shahor02 for merging.