### PR TITLE
Put 10M basket size

### DIFF
--- a/Framework/Core/src/TableTreeHelpers.cxx
+++ b/Framework/Core/src/TableTreeHelpers.cxx
@@ -441,6 +441,8 @@ void TableToTree::addBranch(std::shared_ptr<arrow::ChunkedArray> const& column, 
 
 std::shared_ptr<TTree> TableToTree::process()
 {
+  mTree->SetBasketSize("*", 10000000);
+  
   int64_t row = 0;
   if (mTree->GetNbranches() == 0 || mRows == 0) {
     mTree->Write("", TObject::kOverwrite);

--- a/Framework/Core/src/TableTreeHelpers.cxx
+++ b/Framework/Core/src/TableTreeHelpers.cxx
@@ -442,7 +442,7 @@ void TableToTree::addBranch(std::shared_ptr<arrow::ChunkedArray> const& column, 
 std::shared_ptr<TTree> TableToTree::process()
 {
   mTree->SetBasketSize("*", 10000000);
-  
+
   int64_t row = 0;
   if (mTree->GetNbranches() == 0 || mRows == 0) {
     mTree->Write("", TObject::kOverwrite);


### PR DESCRIPTION
This reduces the AOD size dramatically because the compression for large tables goes up a factor 10. 

Ideally this basket size is tuned based on the known size of the table * column type at writing.