### PR TITLE
EMCAL-612

### DIFF
--- a/Detectors/EMCAL/workflow/src/cell-reader-workflow.cxx
+++ b/Detectors/EMCAL/workflow/src/cell-reader-workflow.cxx
@@ -31,6 +31,7 @@ void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
 void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
   std::vector<ConfigParamSpec> options{{"disable-mc", VariantType::Bool, false, {"Do not propagate MC labels"}},
+                                       {"subspec", VariantType::UInt32, 0, {"Subspecification for cell output"}},
                                        {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
   workflowOptions.insert(workflowOptions.end(), options.begin(), options.end());
@@ -41,6 +42,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   bool disableMC = cfgc.options().get<bool>("disable-mc");
+  auto subspec = cfgc.options().get<uint32_t>("subspec");
   o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
 
   WorkflowSpec specs;
@@ -51,9 +53,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
                                                                                  {"cellbranch", "EMCALCell", "Cell branch"},
                                                                                  {"celltriggerbranch", "EMCALCellTRGR", "Trigger record branch"},
                                                                                  {"mcbranch", "EMCALCellMCTruth", "MC label branch"},
-                                                                                 o2::framework::OutputSpec{"EMC", "CELLS"},
-                                                                                 o2::framework::OutputSpec{"EMC", "CELLSTRGR"},
-                                                                                 o2::framework::OutputSpec{"EMC", "CELLSMCTR"}},
+                                                                                 o2::framework::OutputSpec{"EMC", "CELLS", subspec},
+                                                                                 o2::framework::OutputSpec{"EMC", "CELLSTRGR", subspec},
+                                                                                 o2::framework::OutputSpec{"EMC", "CELLSMCTR", subspec}},
                                                                                !disableMC));
 
   // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit

--- a/Detectors/EMCAL/workflow/src/cell-writer-workflow.cxx
+++ b/Detectors/EMCAL/workflow/src/cell-writer-workflow.cxx
@@ -28,6 +28,7 @@ using namespace o2::emcal;
 void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
   std::vector<ConfigParamSpec> options{{"disable-mc", VariantType::Bool, false, {"Do not propagate MC labels"}},
+                                       {"subspec", VariantType::UInt32, 0, {"Input subspecification"}},
                                        {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
   workflowOptions.insert(workflowOptions.end(), options.begin(), options.end());
 }
@@ -43,12 +44,13 @@ void customize(std::vector<o2::framework::CompletionPolicy>& policies)
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   bool disableMC = cfgc.options().get<bool>("disable-mc");
+  auto subspec = cfgc.options().get<uint32_t>("subspec");
   o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
 
   WorkflowSpec specs;
   specs.emplace_back(MakeRootTreeWriterSpec("emcal-cells-writer", "emccells.root", "o2sim",
-                                            MakeRootTreeWriterSpec::BranchDefinition<std::vector<Cell>>{InputSpec{"data", "EMC", "CELLS", 0}, "EMCALCell", "cell-branch-name"},
-                                            MakeRootTreeWriterSpec::BranchDefinition<std::vector<TriggerRecord>>{InputSpec{"trigger", "EMC", "CELLSTRGR", 0}, "EMCALCellTRGR", "celltrigger-branch-name"},
-                                            MakeRootTreeWriterSpec::BranchDefinition<o2::dataformats::MCTruthContainer<MCLabel>>{InputSpec{"mc", "EMC", "CELLSMCTR", 0}, "EMCALCellMCTruth", "cellmc-branch-name", disableMC ? 0 : 1})());
+                                            MakeRootTreeWriterSpec::BranchDefinition<std::vector<Cell>>{InputSpec{"data", "EMC", "CELLS", subspec}, "EMCALCell", "cell-branch-name"},
+                                            MakeRootTreeWriterSpec::BranchDefinition<std::vector<TriggerRecord>>{InputSpec{"trigger", "EMC", "CELLSTRGR", subspec}, "EMCALCellTRGR", "celltrigger-branch-name"},
+                                            MakeRootTreeWriterSpec::BranchDefinition<o2::dataformats::MCTruthContainer<MCLabel>>{InputSpec{"mc", "EMC", "CELLSMCTR", subspec}, "EMCALCellMCTruth", "cellmc-branch-name", disableMC ? 0 : 1})());
   return specs;
 }


### PR DESCRIPTION
Publisher can publish cells on different subspec then 0.
Default subspec 0, settable via ConfigParamSpec. Needed
when running processor consuming cells and publishing
new cell containers (i.e. in order to apply cell-level
calibration)