### PR TITLE
Store start time of slot in ms when it is created.

### DIFF
--- a/DataFormats/Detectors/TOF/src/CalibTimeSlewingParamTOF.cxx
+++ b/DataFormats/Detectors/TOF/src/CalibTimeSlewingParamTOF.cxx
@@ -286,4 +286,6 @@ CalibTimeSlewingParamTOF::CalibTimeSlewingParamTOF(const CalibTimeSlewingParamTO
     *(mSigmaPeak[i]) = *(source.mSigmaPeak[i]);
     *(mGlobalOffset[i]) = *(source.mGlobalOffset[i]);
   }
+  mStartValidity = source.mStartValidity;
+  mEndValidity = source.mEndValidity;
 }

--- a/Detectors/Calibration/include/DetectorsCalibration/TimeSlot.h
+++ b/Detectors/Calibration/include/DetectorsCalibration/TimeSlot.h
@@ -34,10 +34,7 @@ class TimeSlot
 {
  public:
   TimeSlot() = default;
-  TimeSlot(TFType tfS, TFType tfE) : mTFStart(tfS), mTFEnd(tfE)
-  {
-    mTFStartMS = getStartTimeMS();
-  }
+  TimeSlot(TFType tfS, TFType tfE) : mTFStart(tfS), mTFEnd(tfE) {}
   TimeSlot(const TimeSlot& src) : mTFStart(src.mTFStart), mTFEnd(src.mTFEnd), mContainer(std::make_unique<Container>(*src.getContainer())) {}
   TimeSlot& operator=(const TimeSlot& src)
   {
@@ -65,6 +62,7 @@ class TimeSlot
 
   void setTFStart(TFType v) { mTFStart = v; }
   void setTFEnd(TFType v) { mTFEnd = v; }
+  void setStaticStartTimeMS(long t) { mTFStartMS = t; }
   void setRunStartOrbit(long t) { mRunStartOrbit = t; }
   auto getRunStartOrbit() const { return mRunStartOrbit; }
 
@@ -76,11 +74,12 @@ class TimeSlot
   {
     mContainer->merge(prev.mContainer.get());
     mTFStart = prev.mTFStart;
+    mTFStartMS = prev.mTFStartMS;
   }
 
   void print() const
   {
-    LOGF(info, "Calibration slot %5d <=TF<=  %5d", mTFStart, mTFEnd);
+    LOGF(info, "Calibration slot %5d <=TF<=  %5d (start in ms = %ld)", mTFStart, mTFEnd, mTFStartMS);
     mContainer->print();
   }
 

--- a/Detectors/Calibration/include/DetectorsCalibration/TimeSlot.h
+++ b/Detectors/Calibration/include/DetectorsCalibration/TimeSlot.h
@@ -34,13 +34,17 @@ class TimeSlot
 {
  public:
   TimeSlot() = default;
-  TimeSlot(TFType tfS, TFType tfE) : mTFStart(tfS), mTFEnd(tfE) {}
+  TimeSlot(TFType tfS, TFType tfE) : mTFStart(tfS), mTFEnd(tfE)
+  {
+    mTFStartMS = getStartTimeMS();
+  }
   TimeSlot(const TimeSlot& src) : mTFStart(src.mTFStart), mTFEnd(src.mTFEnd), mContainer(std::make_unique<Container>(*src.getContainer())) {}
   TimeSlot& operator=(const TimeSlot& src)
   {
     if (&src != this) {
       mTFStart = src.mTFStart;
       mTFEnd = src.mTFEnd;
+      mTFStartMS = src.mTFStartMS;
       mContainer = std::make_unique<Container>(*src.getContainer());
     }
     return *this;
@@ -51,6 +55,7 @@ class TimeSlot
   TFType getTFStart() const { return mTFStart; }
   TFType getTFEnd() const { return mTFEnd; }
 
+  long getStaticStartTimeMS() const { return mTFStartMS; }
   long getStartTimeMS() const { return o2::base::GRPGeomHelper::instance().getOrbitResetTimeMS() + (mRunStartOrbit + long(o2::base::GRPGeomHelper::getNHBFPerTF()) * mTFStart) * o2::constants::lhc::LHCOrbitMUS / 1000; }
   long getEndTimeMS() const { return o2::base::GRPGeomHelper::instance().getOrbitResetTimeMS() + (mRunStartOrbit + long(o2::base::GRPGeomHelper::getNHBFPerTF()) * (mTFEnd + 1)) * o2::constants::lhc::LHCOrbitMUS / 1000; }
 
@@ -85,8 +90,9 @@ class TimeSlot
   size_t mEntries = 0;
   long mRunStartOrbit = 0;
   std::unique_ptr<Container> mContainer; // user object to accumulate the calibration data for this slot
+  long mTFStartMS = 0;                   // start time of the slot in ms that avoids to calculate it on the fly; needed when a slot covers more runs, otherwise the OrbitReset that is read is the one of the latest run, and the validity will be wrong
 
-  ClassDefNV(TimeSlot, 1);
+  ClassDefNV(TimeSlot, 2);
 };
 
 } // namespace calibration

--- a/Detectors/Calibration/include/DetectorsCalibration/TimeSlotCalibration.h
+++ b/Detectors/Calibration/include/DetectorsCalibration/TimeSlotCalibration.h
@@ -70,7 +70,7 @@ class TimeSlotCalibration
   void checkSlotLength()
   {
     if (mSlotLengthInSeconds > 0) {
-      TFType ntf = mSlotLengthInSeconds / (long(o2::base::GRPGeomHelper::getNHBFPerTF()) * o2::constants::lhc::LHCOrbitMUS / 1000000);
+      TFType ntf = mSlotLengthInSeconds / (o2::base::GRPGeomHelper::getNHBFPerTF() * o2::constants::lhc::LHCOrbitMUS * 1e-6);
       LOGP(info, "Redefining slot duration from {} s. to {} TFs", mSlotLengthInSeconds, ntf);
       setSlotLength(ntf);
       mSlotLengthInSeconds = 0;
@@ -343,6 +343,7 @@ TimeSlot<Container>& TimeSlotCalibration<Input, Container>::getSlotForTF(TFType 
     } else if (mSlots.empty()) {
       auto& sl = emplaceNewSlot(true, mFirstTF, tf);
       sl.setRunStartOrbit(getRunStartOrbit());
+      sl.setStaticStartTimeMS(sl.getStartTimeMS());
     }
     return mSlots.back();
   }
@@ -356,6 +357,7 @@ TimeSlot<Container>& TimeSlotCalibration<Input, Container>::getSlotForTF(TFType 
       LOG(info) << "Adding new slot for " << tfmn << " <= TF <= " << tfmx;
       auto& sl = emplaceNewSlot(true, tfmn, tfmx);
       sl.setRunStartOrbit(getRunStartOrbit());
+      sl.setStaticStartTimeMS(sl.getStartTimeMS());
       if (!tfmn) {
         break;
       }
@@ -377,6 +379,7 @@ TimeSlot<Container>& TimeSlotCalibration<Input, Container>::getSlotForTF(TFType 
     LOG(info) << "Adding new slot for " << tfmn << " <= TF <= " << tfmx;
     auto& sl = emplaceNewSlot(false, tfmn, tfmx);
     sl.setRunStartOrbit(getRunStartOrbit());
+    sl.setStaticStartTimeMS(sl.getStartTimeMS());
     tfmn = tf2SlotMin(mSlots.back().getTFEnd() + 1);
   } while (tf > mSlots.back().getTFEnd());
 

--- a/Detectors/TOF/calibration/src/LHCClockCalibrator.cxx
+++ b/Detectors/TOF/calibration/src/LHCClockCalibrator.cxx
@@ -88,6 +88,10 @@ void LHCClockCalibrator::initOutput()
 void LHCClockCalibrator::finalizeSlot(Slot& slot)
 {
   // Extract results for the single slot
+
+  // marging in milliseconds for the end validity of the object to be uploaded
+  static long endValidityMarging = long((5 + getMaxSlotsDelay()) * getSlotLength() * o2::base::GRPGeomHelper::getNHBFPerTF() * o2::constants::lhc::LHCOrbitMUS * 1e-3);
+
   o2::tof::LHCClockDataHisto* c = slot.getContainer();
   LOG(info) << "Finalize slot " << slot.getTFStart() << " <= TF <= " << slot.getTFEnd() << " with "
             << c->getEntries() << " entries";
@@ -108,8 +112,8 @@ void LHCClockCalibrator::finalizeSlot(Slot& slot)
   auto clName = o2::utils::MemFileHelper::getClassName(l);
   auto flName = o2::ccdb::CcdbApi::generateFileName(clName);
 
-  auto starting = slot.getStartTimeMS();
-  auto stopping = slot.getEndTimeMS() + 5 * getSlotLength() + getMaxSlotsDelay();
+  auto starting = slot.getStartTimeMS() - o2::ccdb::CcdbObjectInfo::SECOND * 10; // adding a marging, in case some TFs were not processed
+  auto stopping = slot.getEndTimeMS() + endValidityMarging;
   LOG(info) << "starting = " << starting << " - stopping = " << stopping << " -> phase = " << fitValues[1] << " ps (added BC = " << tobeused << ")";
   l.setStartValidity(starting);
   l.setEndValidity(stopping);

--- a/Detectors/TOF/calibration/src/TOFChannelCalibrator.cxx
+++ b/Detectors/TOF/calibration/src/TOFChannelCalibrator.cxx
@@ -801,7 +801,7 @@ void TOFChannelCalibrator<T>::finalizeSlotWithTracks(Slot& slot)
   }   // end loop over sectors
   auto clName = o2::utils::MemFileHelper::getClassName(ts);
   auto flName = o2::ccdb::CcdbApi::generateFileName(clName);
-  auto startValidity = slot.getStartTimeMS();
+  auto startValidity = slot.getStaticStartTimeMS();
   auto endValidity = startValidity + o2::ccdb::CcdbObjectInfo::MONTH * 2;
   ts.setStartValidity(startValidity);
   ts.setEndValidity(endValidity);

--- a/Detectors/TOF/calibration/src/TOFChannelCalibrator.cxx
+++ b/Detectors/TOF/calibration/src/TOFChannelCalibrator.cxx
@@ -627,7 +627,7 @@ void TOFChannelCalibrator<T>::finalizeSlotWithCosmics(Slot& slot)
 
   auto clName = o2::utils::MemFileHelper::getClassName(ts);
   auto flName = o2::ccdb::CcdbApi::generateFileName(clName);
-  auto startValidity = slot.getStartTimeMS();
+  auto startValidity = slot.getStaticStartTimeMS() - o2::ccdb::CcdbObjectInfo::SECOND * 10; // adding a marging, in case some TFs were not processed
   auto endValidity = o2::ccdb::CcdbObjectInfo::MONTH * 2;
   ts.setStartValidity(startValidity);
   ts.setEndValidity(endValidity);
@@ -734,7 +734,7 @@ void TOFChannelCalibrator<T>::finalizeSlotWithTracks(Slot& slot)
 
       double fitres = fitGaus(nbinsUsed, histoValues.data(), minRange, maxRange, fitValues, nullptr, 2., false);
       LOG(info) << "channel = " << ich << " fitted by thread = " << ithread;
-      if (fitres > -3) {
+      if (fitres > -10) {
         LOG(info) << "Channel " << ich << " :: Fit result " << fitres << " Mean = " << fitValues[1] << " Sigma = " << fitValues[2];
       } else {
 #ifdef DEBUGGING
@@ -801,7 +801,7 @@ void TOFChannelCalibrator<T>::finalizeSlotWithTracks(Slot& slot)
   }   // end loop over sectors
   auto clName = o2::utils::MemFileHelper::getClassName(ts);
   auto flName = o2::ccdb::CcdbApi::generateFileName(clName);
-  auto startValidity = slot.getStaticStartTimeMS();
+  auto startValidity = slot.getStaticStartTimeMS() - o2::ccdb::CcdbObjectInfo::SECOND * 10; // adding a marging, in case some TFs were not processed
   auto endValidity = startValidity + o2::ccdb::CcdbObjectInfo::MONTH * 2;
   ts.setStartValidity(startValidity);
   ts.setEndValidity(endValidity);


### PR DESCRIPTION
Needed when you have time slots that span over more than one run: if you
don't cache this value, you risk that the OrbitReset used to
calculate the start time is different from the correct one (namely,
if the last run that is processed has a different OrbitReset from the
run when the slot started).

@noferini 