### PR TITLE
Option to run ITS noise calibrators as accumulators->normalizer

### DIFF
--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/NoiseMap.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/NoiseMap.h
@@ -172,6 +172,9 @@ class NoiseMap
   void merge(const NoiseMap* prev) {}
   const std::map<int, int>* getChipMap(int chip) const { return chip < (int)mNoisyPixels.size() ? &mNoisyPixels[chip] : nullptr; }
 
+  std::map<int, int>& getChip(int chip) { return mNoisyPixels[chip]; }
+  const std::map<int, int>& getChip(int chip) const { return mNoisyPixels[chip]; }
+
   void maskFullChip(int chip, bool cleanNoisyPixels = false)
   {
     if (cleanNoisyPixels) {
@@ -199,6 +202,7 @@ class NoiseMap
     return std::ceil((1. + 1. / t) / (relErr * relErr));
   }
 
+  size_t size() const { return mNoisyPixels.size(); }
   void setNumOfStrobes(long n) { mNumOfStrobes = n; }
   void addStrobes(long n) { mNumOfStrobes += n; }
   long getNumberOfStrobes() const { return mNumOfStrobes; }

--- a/Detectors/ITSMFT/ITS/calibration/include/ITSCalibration/NoiseCalibrator.h
+++ b/Detectors/ITSMFT/ITS/calibration/include/ITSCalibration/NoiseCalibrator.h
@@ -18,6 +18,7 @@
 #include "DataFormatsITSMFT/TopologyDictionary.h"
 #include "DataFormatsITSMFT/NoiseMap.h"
 #include "ITSMFTReconstruction/PixelData.h"
+#include "ITSMFTReconstruction/ChipMappingITS.h"
 #include "gsl/span"
 
 namespace o2
@@ -35,6 +36,8 @@ namespace its
 class NoiseCalibrator
 {
  public:
+  static constexpr int NChips = o2::itsmft::ChipMappingITS::getNChips();
+
   NoiseCalibrator() = default;
   NoiseCalibrator(bool one, float prob, float relErr = 0.2) : m1pix(one), mProbabilityThreshold(prob), mProbRelErr(relErr)
   {
@@ -50,34 +53,38 @@ class NoiseCalibrator
   bool processTimeFrameDigits(gsl::span<const o2::itsmft::Digit> const& digits,
                               gsl::span<const o2::itsmft::ROFRecord> const& rofs);
 
+  void addMap(const o2::itsmft::NoiseMap& extMap);
+
   void finalize(float cutIB = -1.);
 
   void setNThreads(int n) { mNThreads = n > 0 ? n : 1; }
 
   void setMinROFs(long n) { mMinROFs = n; }
+  long getMinROFs() const { return mMinROFs; }
 
   void setClusterDictionary(const o2::itsmft::TopologyDictionary* d) { mDict = d; }
 
   const o2::itsmft::NoiseMap& getNoiseMap() const { return mNoiseMap; }
 
-  void setInstanceID(size_t i) { mInstanceID = i; }
-  void setNInstances(size_t n) { mNInstances = n; }
+  void setInstanceID(int i) { mInstanceID = i; }
+  void setNInstances(int n) { mNInstances = n; }
   auto getInstanceID() const { return mInstanceID; }
   auto getNInstances() const { return mNInstances; }
+  auto getNStrobes() const { return mNumberOfStrobes; }
 
  private:
   const o2::itsmft::TopologyDictionary* mDict = nullptr;
-  o2::itsmft::NoiseMap mNoiseMap{24120};
+  o2::itsmft::NoiseMap mNoiseMap{NChips};
   float mProbabilityThreshold = 3e-6f;
   float mProbRelErr = 0.2; // relative error on channel noise to apply the threshold
   long mMinROFs = 0;
   unsigned int mNumberOfStrobes = 0;
   bool m1pix = true;
   int mNThreads = 1;
-  size_t mInstanceID = 0; // pipeline instance
-  size_t mNInstances = 1; // total number of pipelines
+  int mInstanceID = 0; // pipeline instance
+  int mNInstances = 1; // total number of pipelines
   std::vector<int> mChipIDs;
-  std::array<std::vector<int>, 24120> mChipHits;
+  std::array<std::vector<int>, NChips> mChipHits;
 };
 
 } // namespace its

--- a/Detectors/ITSMFT/ITS/calibration/include/ITSCalibration/NoiseCalibratorSpec.h
+++ b/Detectors/ITSMFT/ITS/calibration/include/ITSCalibration/NoiseCalibratorSpec.h
@@ -41,7 +41,11 @@ namespace its
 class NoiseCalibratorSpec : public Task
 {
  public:
-  NoiseCalibratorSpec(bool useClusters = false, std::shared_ptr<o2::base::GRPGeomRequest> req = {}) : mCCDBRequest(req), mUseClusters(useClusters)
+  enum ProcessingMode { Full,
+                        Accumulate,
+                        Normalize };
+
+  NoiseCalibratorSpec(ProcessingMode md = ProcessingMode::Full, bool useClusters = false, std::shared_ptr<o2::base::GRPGeomRequest> req = {}) : mMode(md), mCCDBRequest(req), mUseClusters(useClusters)
   {
     mTimer.Stop();
   }
@@ -51,27 +55,32 @@ class NoiseCalibratorSpec : public Task
   void run(ProcessingContext& pc) final;
   void endOfStream(EndOfStreamContext& ec) final;
   void finaliseCCDB(ConcreteDataMatcher& matcher, void* obj) final;
+  void setProcessingMode(ProcessingMode m) { mMode = m; }
+  ProcessingMode getProcessingMode() const { return mMode; }
 
  private:
   void addDatabaseEntry(int chip, int row, int col);
   void sendOutput(DataAllocator& output);
+  void sendAccumulatedMap(DataAllocator& output);
   void updateTimeDependentParams(ProcessingContext& pc);
   std::unique_ptr<CALIBRATOR> mCalibrator = nullptr;
   std::shared_ptr<o2::base::GRPGeomRequest> mCCDBRequest;
   size_t mDataSizeStat = 0;
   size_t mNClustersProc = 0;
   int mValidityDays = 3;
+  int mNPartsDone = 0; // number of accumalated parts in Normalization mode
   bool mUseClusters = false;
   bool mStopMeOnly = false; // send QuitRequest::Me instead of QuitRequest::All
   TStopwatch mTimer{};
   float mNoiseCutIB = -1.;
   o2::dcs::DCSconfigObject_t mNoiseMapDCS; // noisy pixels to be sent to DCS CCDB
   std::vector<int>* mConfDBmap{nullptr};
+  ProcessingMode mMode = ProcessingMode::Full;
 };
 
 /// create a processor spec
 /// run ITS noise calibration
-DataProcessorSpec getNoiseCalibratorSpec(bool useClusters);
+DataProcessorSpec getNoiseCalibratorSpec(bool useClusters, int pmode = 0);
 
 } // namespace its
 } // namespace o2

--- a/Detectors/ITSMFT/ITS/calibration/src/NoiseCalibrator.cxx
+++ b/Detectors/ITSMFT/ITS/calibration/src/NoiseCalibrator.cxx
@@ -133,6 +133,21 @@ bool NoiseCalibrator::processTimeFrameDigits(gsl::span<const o2::itsmft::Digit> 
   return (mNumberOfStrobes > mMinROFs) ? true : false;
 }
 
+void NoiseCalibrator::addMap(const o2::itsmft::NoiseMap& extMap)
+{
+  // add preproprecessed map to total
+#ifdef WITH_OPENMP
+#pragma omp parallel for schedule(dynamic) num_threads(mNThreads)
+#endif
+  for (int ic = 0; ic < NChips; ic++) {
+    const auto& chExt = extMap.getChip(ic);
+    auto& chCurr = mNoiseMap.getChip(ic);
+    for (auto it : chExt) {
+      chCurr[it.first] += it.second;
+    }
+  }
+}
+
 void NoiseCalibrator::finalize(float cutIB)
 {
   LOG(info) << "Number of processed strobes is " << mNumberOfStrobes;

--- a/Detectors/ITSMFT/ITS/calibration/testWorkflow/its-noise-calib-workflow.cxx
+++ b/Detectors/ITSMFT/ITS/calibration/testWorkflow/its-noise-calib-workflow.cxx
@@ -19,6 +19,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
   // option allowing to set parameters
   workflowOptions.push_back(ConfigParamSpec{"use-clusters", VariantType::Bool, false, {"Use clusters instead of digits"}});
+  workflowOptions.push_back(ConfigParamSpec{"processing-mode", VariantType::Int, 0, {"processing mode: 0 - accumulate & normalize, 1 - accumulated and send w/o normalization, 2 - receive maps from mode 1 accumulators and normalized"}});
   workflowOptions.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}});
 }
 
@@ -32,6 +33,6 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 {
   WorkflowSpec specs;
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
-  specs.emplace_back(o2::its::getNoiseCalibratorSpec(configcontext.options().get<bool>("use-clusters")));
+  specs.emplace_back(o2::its::getNoiseCalibratorSpec(configcontext.options().get<bool>("use-clusters"), configcontext.options().get<int>("processing-mode")));
   return specs;
 }


### PR DESCRIPTION
@iravasen Here is what I meant, though I had no time to test it as e.g.

```
WORKFLOW+="o2-its-noise-calib-workflow $ARGS_ALL --configKeyValues \"$ARGS_ALL_CONFIG\" --prob-threshold 1e-5 --nthreads 4 ${INPTYPE}  processing-mode 1 --pipeline its-noise-calibrator:16 | "
WORKFLOW+="o2-its-noise-calib-workflow $ARGS_ALL --configKeyValues \"$ARGS_ALL_CONFIG\" --prob-threshold 1e-5 --nthreads 16 ${INPTYPE}  processing-mode 2 | "
```
instead of the current https://github.com/AliceO2Group/O2DPG/blob/9e25586f8594d1cad8bfe8d372c455e3d2eb6802/DATA/production/calib/its-noise-aggregator.sh#L20