### PR TITLE
DPL Analysis: prevent nullptr access on empty filter groups

### DIFF
--- a/Framework/Core/include/Framework/GroupSlicer.h
+++ b/Framework/Core/include/Framework/GroupSlicer.h
@@ -276,9 +276,13 @@ struct GroupSlicer {
             // intersect selections
             o2::soa::SelectionVector s;
             if (selections[index]->empty()) {
-              std::copy((filterGroups[index])[pos].begin(), (filterGroups[index])[pos].end(), std::back_inserter(s));
+              if (!filterGroups[index].empty()) {
+                std::copy((filterGroups[index])[pos].begin(), (filterGroups[index])[pos].end(), std::back_inserter(s));
+              }
             } else {
-              std::set_intersection((filterGroups[index])[pos].begin(), (filterGroups[index])[pos].end(), selections[index]->begin(), selections[index]->end(), std::back_inserter(s));
+              if (!filterGroups[index].empty()) {
+                std::set_intersection((filterGroups[index])[pos].begin(), (filterGroups[index])[pos].end(), selections[index]->begin(), selections[index]->end(), std::back_inserter(s));
+              }
             }
             std::decay_t<A1> typedTable{{originalTable.asArrowTable()}, std::move(s)};
             typedTable.bindInternalIndicesTo(&originalTable);

--- a/Framework/Core/test/test_GroupSlicer.cxx
+++ b/Framework/Core/test/test_GroupSlicer.cxx
@@ -387,6 +387,11 @@ BOOST_AUTO_TEST_CASE(GroupSlicerMismatchedUnsortedFilteredGroups)
     }
   }
   auto trkTable = builderT.finalize();
+
+  TableBuilder builderTE;
+  auto trksWriterE = builderTE.cursor<aod::TrksXU>();
+  auto trkTableE = builderTE.finalize();
+
   using FilteredEvents = soa::Filtered<aod::Events>;
   soa::SelectionVector rows{2, 4, 10, 9, 15};
   FilteredEvents e{{evtTable}, {2, 4, 10, 9, 15}};
@@ -412,6 +417,21 @@ BOOST_AUTO_TEST_CASE(GroupSlicerMismatchedUnsortedFilteredGroups)
     for (auto& trk : trks) {
       BOOST_CHECK_EQUAL(trk.eventId(), rows[count]);
     }
+    ++count;
+  }
+
+  std::vector<int64_t> sele;
+  soa::SmallGroups<aod::TrksXU> te{{trkTableE}, std::move(sele)};
+  auto tte = std::make_tuple(te);
+  o2::framework::GroupSlicer ge(e, tte);
+
+  count = 0;
+  for (auto& slice : ge) {
+    auto as = slice.associatedTables();
+    auto gg = slice.groupingElement();
+    BOOST_CHECK_EQUAL(gg.globalIndex(), rows[count]);
+    auto trks = std::get<soa::SmallGroups<aod::TrksXU>>(as);
+    BOOST_CHECK_EQUAL(trks.size(), 0);
     ++count;
   }
 }


### PR DESCRIPTION
@jgrosseo this fixes the crash on empty table when using `SmallGroups`