### PR TITLE
[EMCAL-830] Recalibrator workflow for EMCAL cells

### DIFF
--- a/Detectors/EMCAL/workflow/CMakeLists.txt
+++ b/Detectors/EMCAL/workflow/CMakeLists.txt
@@ -10,73 +10,81 @@
 # or submit itself to any jurisdiction.
 
 o2_add_library(EMCALWorkflow
-               SOURCES src/EMCALDigitWriterSpec.cxx
-                       src/EMCALDigitizerSpec.cxx
-                       src/RecoWorkflow.cxx
-                       src/PublisherSpec.cxx
-                       src/CellConverterSpec.cxx
-                       src/ClusterizerSpec.cxx
-                       src/DigitsPrinterSpec.cxx
-                       src/AnalysisClusterSpec.cxx
-                       src/RawToCellConverterSpec.cxx
-                       src/EntropyEncoderSpec.cxx
-                       src/OfflineCalibSpec.cxx
-                       src/EntropyDecoderSpec.cxx
-                       src/StandaloneAODProducerSpec.cxx
-               PUBLIC_LINK_LIBRARIES O2::Framework O2::DataFormatsCTP O2::DataFormatsEMCAL O2::EMCALSimulation O2::Steer
-                                     O2::DPLUtils O2::EMCALBase O2::EMCALReconstruction O2::Algorithm O2::MathUtils)
+        SOURCES src/CalibLoader.cxx
+        src/EMCALDigitWriterSpec.cxx
+        src/EMCALDigitizerSpec.cxx
+        src/RecoWorkflow.cxx
+        src/PublisherSpec.cxx
+        src/CellConverterSpec.cxx
+        src/ClusterizerSpec.cxx
+        src/DigitsPrinterSpec.cxx
+        src/AnalysisClusterSpec.cxx
+        src/RawToCellConverterSpec.cxx
+        src/EntropyEncoderSpec.cxx
+        src/OfflineCalibSpec.cxx
+        src/CellRecalibratorSpec.cxx
+        src/EntropyDecoderSpec.cxx
+        src/StandaloneAODProducerSpec.cxx
+        PUBLIC_LINK_LIBRARIES O2::Framework O2::DataFormatsCTP O2::DataFormatsEMCAL O2::EMCALSimulation O2::Steer
+        O2::DPLUtils O2::EMCALBase O2::EMCALCalib O2::EMCALReconstruction O2::Algorithm O2::MathUtils)
 
 o2_add_executable(reco-workflow
-                  COMPONENT_NAME emcal
-                  SOURCES src/emc-reco-workflow.cxx
-                  PUBLIC_LINK_LIBRARIES O2::EMCALWorkflow)
+        COMPONENT_NAME emcal
+        SOURCES src/emc-reco-workflow.cxx
+        PUBLIC_LINK_LIBRARIES O2::EMCALWorkflow)
 
 o2_add_executable(entropy-encoder-workflow
-                  COMPONENT_NAME emcal
-                  SOURCES src/entropy-encoder-workflow.cxx
-                  PUBLIC_LINK_LIBRARIES O2::EMCALWorkflow)
+        COMPONENT_NAME emcal
+        SOURCES src/entropy-encoder-workflow.cxx
+        PUBLIC_LINK_LIBRARIES O2::EMCALWorkflow)
 
 o2_add_executable(emc-dcs-workflow
-                  COMPONENT_NAME calibration
-                  SOURCES src/emc-dcs-data-workflow.cxx
-                  PUBLIC_LINK_LIBRARIES O2::Framework
-                                       O2::EMCALCalibration
-                                       O2::EMCALWorkflow
-                                       O2::DetectorsDCS)
+        COMPONENT_NAME calibration
+        SOURCES src/emc-dcs-data-workflow.cxx
+        PUBLIC_LINK_LIBRARIES O2::Framework
+        O2::EMCALCalibration
+        O2::EMCALWorkflow
+        O2::DetectorsDCS)
 
 o2_add_executable(emc-dcs-sim-workflow
-                  COMPONENT_NAME calibration
-                  SOURCES src/emc-dcs-sim-workflow.cxx
-                  PUBLIC_LINK_LIBRARIES O2::DCStestWorkflow)
+        COMPONENT_NAME calibration
+        SOURCES src/emc-dcs-sim-workflow.cxx
+        PUBLIC_LINK_LIBRARIES O2::DCStestWorkflow)
 
 o2_add_executable(cell-writer-workflow
-                  COMPONENT_NAME emcal
-                  SOURCES src/cell-writer-workflow.cxx
-                  PUBLIC_LINK_LIBRARIES O2::EMCALWorkflow)
+        COMPONENT_NAME emcal
+        SOURCES src/cell-writer-workflow.cxx
+        PUBLIC_LINK_LIBRARIES O2::EMCALWorkflow)
 
 o2_add_executable(emc-offline-calib-workflow
-                  COMPONENT_NAME emcal
-                  SOURCES src/emc-offline-calib-workflow.cxx
-                  PUBLIC_LINK_LIBRARIES O2::Framework
-                                        O2::EMCALWorkflow
-                                        O2::EMCALCalibration)
+        COMPONENT_NAME emcal
+        SOURCES src/emc-offline-calib-workflow.cxx
+        PUBLIC_LINK_LIBRARIES O2::Framework
+        O2::EMCALWorkflow
+        O2::EMCALCalibration)
+
+o2_add_executable(cell-recalibrator-workflow
+        COMPONENT_NAME emcal
+        SOURCES src/cell-recalibrator-workflow.cxx
+        PUBLIC_LINK_LIBRARIES O2::Framework
+        O2::EMCALWorkflow)
 
 o2_add_executable(cell-reader-workflow
-                  COMPONENT_NAME emcal
-                  SOURCES src/cell-reader-workflow.cxx
-                  PUBLIC_LINK_LIBRARIES O2::EMCALWorkflow)
+        COMPONENT_NAME emcal
+        SOURCES src/cell-reader-workflow.cxx
+        PUBLIC_LINK_LIBRARIES O2::EMCALWorkflow)
 
 o2_add_executable(digit-reader-workflow
-                  COMPONENT_NAME emcal
-                  SOURCES src/digit-reader-workflow.cxx
-                  PUBLIC_LINK_LIBRARIES O2::EMCALWorkflow)
+        COMPONENT_NAME emcal
+        SOURCES src/digit-reader-workflow.cxx
+        PUBLIC_LINK_LIBRARIES O2::EMCALWorkflow)
 
 o2_add_executable(standalone-aod-producer-workflow
-                  COMPONENT_NAME emcal
-                  SOURCES src/standalone-aod-producer-workflow.cxx
-                  PUBLIC_LINK_LIBRARIES O2::EMCALWorkflow)
+        COMPONENT_NAME emcal
+        SOURCES src/standalone-aod-producer-workflow.cxx
+        PUBLIC_LINK_LIBRARIES O2::EMCALWorkflow)
 
 o2_add_executable(channel-data-producer
-                  COMPONENT_NAME emcal
-                  SOURCES src/emc-channel-data-producer.cxx
-                  PUBLIC_LINK_LIBRARIES O2::EMCALWorkflow)
+        COMPONENT_NAME emcal
+        SOURCES src/emc-channel-data-producer.cxx
+        PUBLIC_LINK_LIBRARIES O2::EMCALWorkflow)

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/CalibLoader.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/CalibLoader.h
@@ -1,0 +1,202 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <string>
+#include <string_view>
+#include <vector>
+#include "Framework/ConcreteDataMatcher.h"
+#include "Framework/InputSpec.h"
+
+namespace o2
+{
+
+namespace emcal
+{
+class BadChannelMap;
+class TimeCalibrationParams;
+class GainCalibrationFactors;
+
+/// \class CalibLoader
+/// \brief Handler for EMCAL calibration objects in DPL workflows
+/// \ingroup EMCALWorkflow
+/// \author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
+/// \since Sept. 5, 2022
+///
+/// Loading the calibration object i based on the objects stored in the CCDB, which
+/// is fully delegated to the framework CCDB support. Alternativelty, particularly for
+/// testing purpose, local CCDB paths for files for the different calibration objects
+/// can be provided. In this case the CCDB is bypassed. The function `static_load`
+/// must always be called in the init function - it will take care of loading the
+/// calibration objects to be taken from file. Furthermore in finalizeCCDB the workflow
+/// must call finalizeCCDB from the CalibLoader in order to make load the calibration
+/// objects requested from CCDB.
+class CalibLoader
+{
+ public:
+  /// \brief Constructor
+  CalibLoader() = default;
+
+  /// \brief Destructor
+  ~CalibLoader() = default;
+
+  /// \brief Access to current bad channel map
+  /// \return Current bad channel map (nullptr if not loaded)
+  BadChannelMap* getBadChannelMap() const { return mBadChannelMap.getObject(); }
+
+  /// \brief Access to current time calibration params
+  /// \return Current time calibration params
+  TimeCalibrationParams* getTimeCalibration() const { return mTimeCalibParams.getObject(); }
+
+  /// \brief Access to current gain calibration factors
+  /// \return Current gain calibration factors
+  GainCalibrationFactors* getGainCalibration() const { return mGainCalibParams.getObject(); }
+
+  /// \brief Check whether the bad channel map is handled
+  /// \return True if the bad channel map is handled, false otherwise
+  bool hasBadChannelMap() const { return mEnableBadChannelMap; }
+
+  /// \brief Check whether the time calibration params are handled
+  /// \return True if the time calibration params are handled, false otherwise
+  bool hasTimeCalib() const { return mEnableTimeCalib; }
+
+  /// \brief Check whether the gain calibration factors are handled
+  /// \return True if the gain calibration factors are handled, false otherwise
+  bool hasGainCalib() const { return mEnableGainCalib; }
+
+  /// \brief Check whether the bad channel map is loaded from local file
+  /// \return True if the bad channel map is loaded from a local file
+  bool hasLocalBadChannelMap() const { return mEnableBadChannelMap && mPathBadChannelMap.length(); }
+
+  /// \brief Check whether the time calibration params are loaded from local file
+  /// \return True if the time calibration params are loaded from a local file
+  bool hasLocalTimeCalib() const { return mEnableTimeCalib && mPathTimeCalib.length(); }
+
+  /// \brief Check whether the gain calibration factors are loaded from local file
+  /// \return True if the gain calibration factors are loaded from a local file
+  bool hasLocalGainCalib() const { return mEnableGainCalib && mPathGainCalib.length(); }
+
+  /// \brief Enable loading of the bad channel map
+  /// \param doEnable If true the bad channel map is loaded (per default from CCDB)
+  void enableBadChannelMap(bool doEnable) { mEnableBadChannelMap = doEnable; }
+
+  /// \brief Enable loading of the time calibration params
+  /// \param doEnable If true the time calibration params are loaded (per default from CCDB)
+  void enableTimeCalib(bool doEnable) { mEnableTimeCalib = doEnable; }
+
+  /// \brief Enable loading of the gain calibration factors
+  /// \param doEnable If true the gain calibration factors are loaded (per default from CCDB)
+  void enableGainCalib(bool doEnable) { mEnableGainCalib = doEnable; }
+
+  /// \brief Define path of local fine for bad channel map
+  /// \param path Path of local file with bad channel map
+  ///
+  /// The bad channel map will be taken from the file instead of the CCDB.
+  /// The file is expected to contain a valid o2::emcal::BadChannelMap with
+  /// the name "ccdb_object"
+  void setLoadBadChannelMapFromFile(const std::string_view path)
+  {
+    mPathBadChannelMap = path;
+    enableBadChannelMap(true);
+  }
+
+  /// \brief Define path of local fine for time calibration params
+  /// \param path Path of local file with time calibration params
+  ///
+  /// The time calibration params will be taken from the file instead
+  /// of the CCDB. The file is expected to contain a valid
+  /// o2::emcal::TimeCalibrationParams with the name "ccdb_object"
+  void setLoadTimeCalibFromFile(const std::string_view path)
+  {
+    mPathTimeCalib = path;
+    enableBadChannelMap(true);
+  }
+
+  /// \brief Define path of local fine for gain calibration factors
+  /// \param path Path of local file with gain calibration factors
+  ///
+  /// The gain calibration factors will be taken from the file instead
+  /// of the CCDB. The file is expected to contain a valid
+  /// o2::emcal::GainCalibrationFactors with the name "ccdb_object"
+  void setLoadGainCalibFromFile(const std::string_view path)
+  {
+    mPathGainCalib = path;
+    enableGainCalib(true);
+  }
+
+  /// \brief Define input specs in workflow for calibration objects to be loaded from the CCDB
+  /// \param ccdbInputs List of inputs where the CCDB input specs will be added to
+  ///
+  /// Defining only objects which are enabled and for which no local path is specified.
+  void defineInputSpecs(std::vector<framework::InputSpec>& ccdbInputs);
+
+  /// \brief Callback for objects loaded from CCDB
+  /// \param matcher Type of the CCDB object
+  /// \param obj CCDB object loaded by the framework
+  ///
+  /// Only CCDB objects compatible with one of the types are handled. In case the object type
+  /// is requested and not loaded from local source the object accepted locally and accessible
+  /// via the corresponding getter function.
+  bool finalizeCCDB(framework::ConcreteDataMatcher& matcher, void* obj);
+
+  /// \brief Load all calibration objects for which a local path is defined
+  void static_load();
+
+ private:
+  /// \class ManagedObject
+  /// \brief Internal helper treating owned and non-owned object with the same member
+  /// \tparam T object type to be handled
+  ///
+  /// In case the object is owned the object will be deleted in case the helper goes
+  /// out-of-scope. Otherwise ownership will be assumed with someone else and the object
+  /// will not be deleted in the destructor.
+  template <typename T>
+  class ManagedObject
+  {
+   public:
+    /// \brief Dummy constructor
+    ManagedObject() = default;
+
+    /// \brief Constructor, defining the object as managed or not
+    /// \param object Object to be handled
+    /// \param managed If true the object will be automatically deleted if the helper goes out-of-scope
+    ManagedObject(T* object, bool managed) : mObject(object), mManaged(managed) {}
+
+    /// \brief Destructor, deletes only managed objects
+    ~ManagedObject()
+    {
+      if (mManaged) {
+        delete mObject;
+      }
+    }
+
+    /// \brief Access to the object
+    /// \return Object handled by the helper
+    T* getObject() const { return mObject; }
+
+   private:
+    T* mObject = nullptr;  ///< Object to be handled
+    bool mManaged = false; ///< Management status
+  };
+
+  bool mEnableBadChannelMap;                                         ///< Switch for enabling / disabling loading of the bad channel map
+  bool mEnableTimeCalib;                                             ///< Switch for enabling / disabling loading of the time calibration params
+  bool mEnableGainCalib;                                             ///< Switch for enabling / disabling loading of the gain calibration params
+  std::string mPathBadChannelMap;                                    ///< Path of local file with bad channel map (optional)
+  std::string mPathTimeCalib;                                        ///< Path of local file with time calibration params (optional)
+  std::string mPathGainCalib;                                        ///< Path of local file with gain calibration params (optional)
+  ManagedObject<o2::emcal::BadChannelMap> mBadChannelMap;            ///< Container of current bad channel map
+  ManagedObject<o2::emcal::TimeCalibrationParams> mTimeCalibParams;  ///< Container of current time calibration object
+  ManagedObject<o2::emcal::GainCalibrationFactors> mGainCalibParams; ///< Container of current gain calibration object
+};
+
+} // namespace emcal
+
+} // namespace o2

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/CellRecalibratorSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/CellRecalibratorSpec.h
@@ -1,0 +1,148 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <bitset>
+#include <cstdint>
+#include <optional>
+#include <string_view>
+#include "EMCALWorkflow/CalibLoader.h"
+#include "Framework/ConcreteDataMatcher.h"
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+
+namespace o2
+{
+
+namespace emcal
+{
+
+class Cell;
+
+/// \class CellRecalibratorSpec
+/// \brief Recalibration workflow at cell level
+/// \ingroup EMCALworkflow
+/// \author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
+/// \since Sept 5, 2022
+///
+/// # Recalibration at cell level
+///
+/// The workflow recalibrates a cell vector (with corresponding trigger records) for
+/// a given timeframe. The following calibrations are supported:
+/// - Bad channel calibration
+/// - Time calibration
+/// - Gain (energy) calibration
+/// Calibration objects are handled automatically via the CCDB. Calibrations must be
+/// enabled manually and are only applied in case the calibration objects exists in
+/// the CCDB.
+///
+/// While the energy and time calibration only change values within a cell the bad channel
+/// calibration decides whether a cell is accepted. Therefore the amount of cells can change
+/// for the given trigger. New trigger record objects are created and published to the same
+/// subspec as what is used for the output cell vector.
+class CellRecalibratorSpec : public framework::Task
+{
+ public:
+  /// \brief Constructor
+  /// \param outputspec Subspecification under which the output is posted
+  /// \param badChannelCalib If true the bad channel calibration is enabled
+  /// \param timeCalib If true the time calibration is enabled
+  /// \param gainCalib If true the fain calibration is enabled
+  /// \param calibHandler Handler for calibration object loading
+  CellRecalibratorSpec(uint32_t outputspec, bool badChannelCalib, bool timeCalib, bool gainCalib, std::shared_ptr<CalibLoader>(calibHandler));
+
+  /// \brief Destructor
+  ~CellRecalibratorSpec() final = default;
+
+  /// \brief Initialize recalibrator
+  /// \param ctx Init context
+  void init(framework::InitContext& ctx) final;
+
+  /// \brief Run recalibration of cells for a new timeframe
+  /// \param ctx Processing context
+  ///
+  /// Iterates over all triggers in the timeframe and recalibrates cells. Only
+  /// calibrations which are enabled are applied. Calibrated cells and new trigger
+  /// records are posted at the end of the timeframe to the subspecification requested
+  /// in the constructor using standard types for cells and trigger records
+  void run(framework::ProcessingContext& ctx) final;
+
+  /// \brief Fetching cell objects and assigning them to the internal handlers
+  /// \param matcher Data type matcher of the CCDB object
+  /// \param obj Pointer to CCDB object loaded
+  ///
+  /// Loading CCDB object into internal cache for the 3 supported CCDB entries (bad
+  /// channel map, time calibration params, gain calibration params). Objects are only
+  /// loaded in case the calibration type was enabled.
+  void finaliseCCDB(framework::ConcreteDataMatcher& matcher, void* obj) final;
+
+  /// \brief Switch for bad channel calibration
+  /// \param doRun If true the bad channel calibration is applied
+  void setRunBadChannelCalibration(bool doRun) { mCalibrationSettings.set(BADCHANNEL_CALIB, doRun); };
+
+  /// \brief Switch for time calibration
+  /// \param doRun If true the time calibration is applied
+  void setRunTimeCalibration(bool doRun) { mCalibrationSettings.set(TIME_CALIB, doRun); }
+
+  /// \brief Switch for the gain calibration
+  /// \param doRun If true the gain calibration is applied
+  void setRunGainCalibration(bool doRun) { mCalibrationSettings.set(GAIN_CALIB, doRun); }
+
+  /// \brief Check if the bad channel calibration is enabled
+  /// \return True if the bad channel calibration is enabled, false otherwise
+  bool isRunBadChannlCalibration() const { return mCalibrationSettings.test(BADCHANNEL_CALIB); }
+
+  /// \brief Check if the time calibration is enabled
+  /// \return True if the time calibration is enabled, false otherwise
+  bool isRunTimeCalibration() const { return mCalibrationSettings.test(TIME_CALIB); }
+
+  /// \brief Check if the gain calibration is enabled
+  /// \return True if the gain calibration is enabled, false otherwise
+  bool isRunGainCalibration() const { return mCalibrationSettings.test(GAIN_CALIB); }
+
+ private:
+  /// \brief Apply requested calibrations to the cell
+  /// \param inputcell Cell to be calibrated
+  /// \return Optional of calibrated cell (empty optional in case the cell is rejected as bad or dead)
+  ///
+  /// Recalibrating cell for energy and time, and check whether the corresponding tower is not
+  /// marked as bad or dead. Only calibrations which are enabled are applied.
+  std::optional<o2::emcal::Cell> getCalibratedCell(const o2::emcal::Cell& inputcell) const;
+
+  /// \brief Update internal cache of calibration objects
+  void updateCalibObjects();
+
+  /// \enum CalibrationType_t
+  /// \brief Calibrations handled by the recalibration workflow
+  enum CalibrationType_t {
+    BADCHANNEL_CALIB = 0, ///< Bad channel calibration
+    TIME_CALIB = 1,       ///< Time calibration
+    GAIN_CALIB = 2        ///< Gain calibration
+  };
+
+  uint32_t mOutputSubspec = 0;                              ///< output subspecification;
+  std::bitset<8> mCalibrationSettings;                      ///< Recalibration settings (which calibration to be applied)
+  std::shared_ptr<CalibLoader> mCalibrationHandler;         ///< Handler loading calibration objects
+  const BadChannelMap* mBadChannelMap = nullptr;            ///< Bad channelMap
+  const TimeCalibrationParams* mTimeCalibration = nullptr;  ///< Time calibration coefficients
+  const GainCalibrationFactors* mGainCalibration = nullptr; ///< Gain calibration factors
+};
+
+/// \brief Create CellRecalibrator processor spec
+/// \param inputSubsepc Subspecification used for the input objects (cells and trigger records)
+/// \param outputSubspec Subspecification used for the output objects (cells and trigger records)
+/// \param badChannelCalib If true the bad channel calibration is enabled
+/// \param timeCalib If true the time calibration is enabled
+/// \param gainCalib If true the gain (energy) calibration is enabled
+framework::DataProcessorSpec getCellRecalibratorSpec(uint32_t inputSubspec, uint32_t outputSubspec, bool badChannelCalib, bool timeCalib, bool gainCalib, const std::string_view pathBadChannelMap, const std::string_view pathTimeCalib, std::string_view pathGainCalib);
+
+} // namespace emcal
+
+} // namespace o2

--- a/Detectors/EMCAL/workflow/src/CalibLoader.cxx
+++ b/Detectors/EMCAL/workflow/src/CalibLoader.cxx
@@ -1,0 +1,90 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <filesystem>
+#include <memory>
+#include <fairlogger/Logger.h>
+#include "EMCALCalib/CalibDB.h"
+#include "EMCALCalib/BadChannelMap.h"
+#include "EMCALCalib/TimeCalibrationParams.h"
+#include "EMCALCalib/GainCalibrationFactors.h"
+#include "EMCALWorkflow/CalibLoader.h"
+#include "Framework/CCDBParamSpec.h"
+#include "TFile.h"
+
+using namespace o2::emcal;
+
+void CalibLoader::defineInputSpecs(std::vector<o2::framework::InputSpec>& inputs)
+{
+  if (hasBadChannelMap() && !hasLocalBadChannelMap()) {
+    inputs.push_back({"badChannelMap", o2::header::gDataOriginEMC, "BADCHANNELMAP", 0, o2::framework::Lifetime::Condition, o2::framework::ccdbParamSpec(CalibDB::getCDBPathBadChannelMap())});
+  }
+  if (hasTimeCalib() && !hasLocalTimeCalib()) {
+    inputs.push_back({"timeCalibParams", o2::header::gDataOriginEMC, "TIMECALIBPARAMS", 0, o2::framework::Lifetime::Condition, o2::framework::ccdbParamSpec(CalibDB::getCDBPathTimeCalibrationParams())});
+  }
+  if (hasGainCalib() && !hasLocalGainCalib()) {
+    inputs.push_back({"gainCalibParams", o2::header::gDataOriginEMC, "GAINCALIBPARAMS", 0, o2::framework::Lifetime::Condition, o2::framework::ccdbParamSpec(CalibDB::getCDBPathGainCalibrationParams())});
+  }
+}
+
+bool CalibLoader::finalizeCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+{
+  if (matcher == o2::framework::ConcreteDataMatcher("EMC", "BADCHANNELMAP", 0)) {
+    if (hasBadChannelMap() && !hasLocalBadChannelMap()) {
+      LOG(info) << "New bad channel map loaded";
+      mBadChannelMap = ManagedObject<o2::emcal::BadChannelMap>(reinterpret_cast<o2::emcal::BadChannelMap*>(obj), false);
+    } else {
+      LOG(error) << "New bad channel map available even though bad channel calibration was not enabled, not loading";
+    }
+    return true;
+  }
+  if (matcher == o2::framework::ConcreteDataMatcher("EMC", "TIMECALIBPARAMS", 0)) {
+    if (hasTimeCalib() && !hasLocalTimeCalib()) {
+      LOG(info) << "New time calibration paramset loaded";
+      mTimeCalibParams = ManagedObject<o2::emcal::TimeCalibrationParams>(reinterpret_cast<o2::emcal::TimeCalibrationParams*>(obj), false);
+    } else {
+      LOG(error) << "New time calibration paramset available even though time calibration was not enabled, not loading";
+    }
+    return true;
+  }
+  if (matcher == o2::framework::ConcreteDataMatcher("EMC", "GAINCALIBPARAMS", 0)) {
+    if (hasGainCalib() && !hasLocalGainCalib()) {
+      LOG(info) << "New gain calibration paramset loaded";
+      mGainCalibParams = ManagedObject<o2::emcal::GainCalibrationFactors>(reinterpret_cast<o2::emcal::GainCalibrationFactors*>(obj), false);
+    } else {
+      LOG(error) << "New gain calibration paramset available even though the gain calibration was not enabled, not loading";
+    }
+    return true;
+  }
+  return false;
+}
+
+void CalibLoader::static_load()
+{
+  if (hasLocalBadChannelMap()) {
+    if (std::filesystem::exists(std::filesystem::path(mPathBadChannelMap))) {
+      std::unique_ptr<TFile> reader(TFile::Open(mPathBadChannelMap.data(), "READ"));
+      mBadChannelMap = ManagedObject<o2::emcal::BadChannelMap>(new o2::emcal::BadChannelMap(*(reader->Get<o2::emcal::BadChannelMap>("ccdb_object"))), true);
+    }
+  }
+  if (hasLocalTimeCalib()) {
+    if (std::filesystem::exists(std::filesystem::path(mPathTimeCalib))) {
+      std::unique_ptr<TFile> reader(TFile::Open(mPathTimeCalib.data(), "READ"));
+      mTimeCalibParams = ManagedObject<o2::emcal::TimeCalibrationParams>(new o2::emcal::TimeCalibrationParams(*(reader->Get<o2::emcal::TimeCalibrationParams>("ccdb_object"))), true);
+    }
+  }
+  if (hasLocalGainCalib()) {
+    if (std::filesystem::exists(std::filesystem::path(mPathGainCalib))) {
+      std::unique_ptr<TFile> reader(TFile::Open(mPathGainCalib.data(), "READ"));
+      mGainCalibParams = ManagedObject<o2::emcal::GainCalibrationFactors>(new o2::emcal::GainCalibrationFactors(*(reader->Get<o2::emcal::GainCalibrationFactors>("ccdb_object"))), true);
+    }
+  }
+}

--- a/Detectors/EMCAL/workflow/src/CellRecalibratorSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/CellRecalibratorSpec.cxx
@@ -1,0 +1,146 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <filesystem>
+#include <gsl/span>
+#include "DataFormatsEMCAL/Cell.h"
+#include "DataFormatsEMCAL/TriggerRecord.h"
+#include "EMCALCalib/BadChannelMap.h"
+#include "EMCALCalib/TimeCalibrationParams.h"
+#include "EMCALCalib/GainCalibrationFactors.h"
+#include "EMCALWorkflow/CellRecalibratorSpec.h"
+#include "Framework/CCDBParamSpec.h"
+#include <TFile.h>
+
+using namespace o2::emcal;
+
+CellRecalibratorSpec::CellRecalibratorSpec(uint32_t outputspec, bool badChannelCalib, bool timeCalib, bool gainCalib, std::shared_ptr<o2::emcal::CalibLoader> calibHandler) : mOutputSubspec(outputspec), mCalibrationHandler(calibHandler)
+{
+  setRunBadChannelCalibration(badChannelCalib);
+  setRunTimeCalibration(timeCalib);
+  setRunGainCalibration(gainCalib);
+}
+
+void CellRecalibratorSpec::init(framework::InitContext& ctx)
+{
+  // Display calibrations which are enabled:
+  LOG(info) << "Bad channel calibration: " << (isRunBadChannlCalibration() ? "enabled" : "disabled");
+  LOG(info) << "Time calibration:        " << (isRunTimeCalibration() ? "enabled" : "disabled");
+  LOG(info) << "Gain calibration:        " << (isRunGainCalibration() ? "enabled" : "disabled");
+
+  mCalibrationHandler->static_load();
+}
+
+void CellRecalibratorSpec::run(framework::ProcessingContext& ctx)
+{
+  auto inputcells = ctx.inputs().get<gsl::span<o2::emcal::Cell>>("cells");
+  auto intputtriggers = ctx.inputs().get<gsl::span<o2::emcal::TriggerRecord>>("triggerrecords");
+
+  updateCalibObjects();
+
+  std::vector<o2::emcal::Cell> outputcells;
+  std::vector<o2::emcal::TriggerRecord> outputtriggers;
+
+  uint32_t currentfirst = outputcells.size();
+  for (const auto& trg : intputtriggers) {
+    if (!trg.getNumberOfObjects()) {
+      o2::emcal::TriggerRecord nexttrigger(trg.getBCData(), currentfirst, trg.getNumberOfObjects());
+      nexttrigger.setTriggerBits(trg.getTriggerBits());
+      outputtriggers.push_back(nexttrigger);
+      continue;
+    }
+    uint32_t cellsEvent = 0;
+    for (const auto& cell : gsl::span<const o2::emcal::Cell>(inputcells.data() + trg.getFirstEntry(), trg.getNumberOfObjects())) {
+      auto calibrated = getCalibratedCell(cell);
+      if (calibrated) {
+        outputcells.push_back(calibrated.value());
+        cellsEvent++;
+      }
+    }
+    o2::emcal::TriggerRecord nexttrigger(trg.getBCData(), currentfirst, cellsEvent);
+    nexttrigger.setTriggerBits(trg.getTriggerBits());
+    outputtriggers.push_back(nexttrigger);
+    currentfirst = outputcells.size();
+  }
+
+  // send recalibrated objects
+  ctx.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginEMC, "CELLS", mOutputSubspec, o2::framework::Lifetime::Timeframe}, outputcells);
+  ctx.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginEMC, "CELLSTRGR", mOutputSubspec, o2::framework::Lifetime::Timeframe}, outputtriggers);
+}
+
+void CellRecalibratorSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+{
+  if (mCalibrationHandler->finalizeCCDB(matcher, obj)) {
+    return;
+  }
+}
+
+std::optional<o2::emcal::Cell> CellRecalibratorSpec::getCalibratedCell(const o2::emcal::Cell& input) const
+{
+  if (isRunBadChannlCalibration() && mBadChannelMap) {
+    auto cellstatus = mBadChannelMap->getChannelStatus(input.getTower());
+    // reject bad and dead cells
+    if (cellstatus == BadChannelMap::MaskType_t::BAD_CELL || cellstatus == BadChannelMap::MaskType_t::DEAD_CELL) {
+      return std::optional<o2::emcal::Cell>();
+    }
+  }
+  auto celltime = input.getTimeStamp();
+  auto cellenergy = input.getEnergy();
+  if (isRunTimeCalibration() && mTimeCalibration) {
+    celltime -= mTimeCalibration->getTimeCalibParam(input.getTower(), input.getLowGain());
+  }
+  if (isRunGainCalibration() && mGainCalibration) {
+    cellenergy *= mGainCalibration->getGainCalibFactors(input.getTower());
+  }
+  o2::emcal::Cell outputcell(input.getTower(), cellenergy, celltime, input.getType());
+  return std::optional<o2::emcal::Cell>(outputcell);
+}
+
+void CellRecalibratorSpec::updateCalibObjects()
+{
+  if (isRunBadChannlCalibration()) {
+    mBadChannelMap = mCalibrationHandler->getBadChannelMap();
+  }
+  if (isRunTimeCalibration()) {
+    mTimeCalibration = mCalibrationHandler->getTimeCalibration();
+  }
+  if (isRunGainCalibration()) {
+    mGainCalibration = mCalibrationHandler->getGainCalibration();
+  }
+}
+
+o2::framework::DataProcessorSpec o2::emcal::getCellRecalibratorSpec(uint32_t inputSubspec, uint32_t outputSubspec, bool badChannelCalib, bool timeCalib, bool gainCalib, const std::string_view pathBadChannelMap, const std::string_view pathTimeCalib, const std::string_view pathGainCalib)
+{
+  auto calibhandler = std::make_shared<o2::emcal::CalibLoader>();
+  calibhandler->enableBadChannelMap(badChannelCalib);
+  calibhandler->enableTimeCalib(timeCalib);
+  calibhandler->enableGainCalib(gainCalib);
+  if (pathBadChannelMap.length()) {
+    calibhandler->setLoadBadChannelMapFromFile(pathBadChannelMap);
+  }
+  if (pathTimeCalib.length()) {
+    calibhandler->setLoadTimeCalibFromFile(pathTimeCalib);
+  }
+  if (pathGainCalib.length()) {
+    calibhandler->setLoadGainCalibFromFile(pathGainCalib);
+  }
+  std::vector<o2::framework::InputSpec>
+    inputs = {{"cells", o2::header::gDataOriginEMC, "CELLS", inputSubspec, o2::framework::Lifetime::Timeframe},
+              {"triggerrecords", o2::header::gDataOriginEMC, "CELLSTRGR", inputSubspec, o2::framework::Lifetime::Timeframe}};
+  std::vector<o2::framework::OutputSpec> outputs = {{o2::header::gDataOriginEMC, "CELLS", outputSubspec, o2::framework::Lifetime::Timeframe},
+                                                    {o2::header::gDataOriginEMC, "CELLSTRGR", inputSubspec, o2::framework::Lifetime::Timeframe}};
+  calibhandler->defineInputSpecs(inputs);
+
+  return o2::framework::DataProcessorSpec{"EMCALCellRecalibrator",
+                                          inputs,
+                                          outputs,
+                                          o2::framework::adaptFromTask<o2::emcal::CellRecalibratorSpec>(outputSubspec, badChannelCalib, timeCalib, gainCalib, calibhandler)};
+}

--- a/Detectors/EMCAL/workflow/src/cell-recalibrator-workflow.cxx
+++ b/Detectors/EMCAL/workflow/src/cell-recalibrator-workflow.cxx
@@ -1,0 +1,70 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <string>
+#include <vector>
+#include "Framework/Variant.h"
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/CallbacksPolicy.h"
+#include "DetectorsRaw/HBFUtilsInitializer.h"
+#include "EMCALWorkflow/CellRecalibratorSpec.h"
+#include "CommonUtils/ConfigurableParam.h"
+
+using namespace o2::framework;
+using namespace o2::emcal;
+
+void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
+{
+  o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  std::vector<ConfigParamSpec> options{{"input-subspec", VariantType::UInt32, 1, {"Subspecification for input objects"}},
+                                       {"output-subspec", VariantType::UInt32, 0, {"Subspecification for output objects"}},
+                                       {"no-badchannelcalib", VariantType::Bool, false, {"Disable bad channel calibration"}},
+                                       {"no-timecalib", VariantType::Bool, false, {"Disable time calibration"}},
+                                       {"no-gaincalib", VariantType::Bool, false, {"Disable gain calibration"}},
+                                       {"local-badchannelmap", VariantType::String, "", {"path to local file with bad channel map"}},
+                                       {"local-timecalib", VariantType::String, "", {"path to local file with time calibration params"}},
+                                       {"local-gaincalib", VariantType::String, "", {"path to local file with gain calibration params"}},
+                                       {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
+  o2::raw::HBFUtilsInitializer::addConfigOption(options);
+  workflowOptions.insert(workflowOptions.end(), options.begin(), options.end());
+}
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  // Calibration types
+  auto disableBadchannels = cfgc.options().get<bool>("no-badchannelcalib"),
+       disableTime = cfgc.options().get<bool>("no-timecalib"),
+       disableEnergy = cfgc.options().get<bool>("no-gaincalib");
+
+  // subpsecs for input and output
+  auto inputsubspec = cfgc.options().get<uint32_t>("input-subspec"),
+       outputsubspec = cfgc.options().get<uint32_t>("output-subspec");
+
+  std::string pathBadChannelMap = cfgc.options().get<std::string>("local-badchannelmap"),
+              pathTimeCalib = cfgc.options().get<std::string>("local-timecalib"),
+              pathGainCalib = cfgc.options().get<std::string>("local-gaincalib");
+
+  o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
+
+  WorkflowSpec specs;
+  specs.emplace_back(o2::emcal::getCellRecalibratorSpec(inputsubspec, outputsubspec, !disableBadchannels, !disableTime, !disableEnergy, pathBadChannelMap, pathTimeCalib, pathGainCalib));
+
+  // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit
+  o2::raw::HBFUtilsInitializer hbfIni(cfgc, specs);
+  return specs;
+}


### PR DESCRIPTION
Applying cell level calibrations
- Bad channel masking
- Cell time
- Absolute energy
Calibrations can be enabled and disabled one-by-one
(default: all enabled). Input and output specs mut be
specified by the user. Calibration objects are taken from
teh CCDB.