### PR TITLE
TPC SCD calib: store correct angle in residuals

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCResidualReaderSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCResidualReaderSpec.cxx
@@ -24,7 +24,6 @@
 #include "DetectorsBase/Propagator.h"
 #include "CommonUtils/StringUtils.h"
 #include "TPCInterpolationWorkflow/TPCResidualReaderSpec.h"
-#include "DetectorsBase/GRPGeomHelper.h"
 
 using namespace o2::framework;
 
@@ -36,16 +35,13 @@ namespace tpc
 class TPCResidualReader : public Task
 {
  public:
-  TPCResidualReader(std::shared_ptr<o2::base::GRPGeomRequest> gr) : mGGCCDBRequest(gr) {}
+  TPCResidualReader() = default;
   ~TPCResidualReader() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
-  void finaliseCCDB(ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
-  void updateTimeDependentParams(ProcessingContext& pc);
   void connectTree(const std::string& filename);
-  std::shared_ptr<o2::base::GRPGeomRequest> mGGCCDBRequest;
   std::unique_ptr<TFile> mFile;
   std::unique_ptr<TTree> mTreeResiduals;
   std::unique_ptr<TTree> mTreeStats;
@@ -59,32 +55,11 @@ void TPCResidualReader::init(InitContext& ic)
   mFileName = o2::utils::Str::concat_string(o2::utils::Str::rectifyDirectory(ic.options().get<std::string>("input-dir")),
                                             ic.options().get<std::string>("residuals-infile"));
   connectTree(mFileName);
-  o2::base::GRPGeomHelper::instance().setRequest(mGGCCDBRequest);
-}
-
-void TPCResidualReader::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
-{
-  if (o2::base::GRPGeomHelper::instance().finaliseCCDB(matcher, obj)) {
-    return;
-  }
-}
-
-void TPCResidualReader::updateTimeDependentParams(ProcessingContext& pc)
-{
-  o2::base::GRPGeomHelper::instance().checkUpdates(pc);
-  static bool initOnceDone = false;
-  if (!initOnceDone) { // this params need to be queried only once
-    initOnceDone = true;
-    // other init-once stuff
-
-    mTrackResiduals.init(true, o2::base::Propagator::Instance()->getNominalBz());
-  }
-  // we may have other params which need to be queried regularly
+  mTrackResiduals.init();
 }
 
 void TPCResidualReader::run(ProcessingContext& pc)
 {
-  updateTimeDependentParams(pc);
   mTrackResiduals.createOutputFile(); // FIXME remove when map output is handled properly
   for (int iSec = 0; iSec < SECTORSPERSIDE * SIDES; ++iSec) {
     auto brStats = mTreeStats->GetBranch(Form("sec%d", iSec));
@@ -135,19 +110,11 @@ DataProcessorSpec getTPCResidualReaderSpec()
   std::vector<InputSpec> inputs;
   std::vector<OutputSpec> outputs;
   // outputs.emplace_back("GLO", "VOXELRESULTS", 0, Lifetime::Timeframe);
-  auto ggRequest = std::make_shared<o2::base::GRPGeomRequest>(false,                             // orbitResetTime
-                                                              true,                              // GRPECS=true
-                                                              false,                             // GRPLHCIF
-                                                              true,                              // GRPMagField
-                                                              true,                              // askMatLUT
-                                                              o2::base::GRPGeomRequest::Aligned, // geometry
-                                                              inputs,
-                                                              true);
   return DataProcessorSpec{
     "tpc-residual-reader",
     inputs,
     outputs,
-    AlgorithmSpec{adaptFromTask<TPCResidualReader>(ggRequest)},
+    AlgorithmSpec{adaptFromTask<TPCResidualReader>()},
     Options{
       {"residuals-infile", VariantType::String, "o2tpc_residuals.root", {"Name of the input file"}},
       {"input-dir", VariantType::String, "none", {"Input directory"}}}};

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCResidualReaderSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCResidualReaderSpec.cxx
@@ -64,7 +64,8 @@ void TPCResidualReader::run(ProcessingContext& pc)
   for (int iSec = 0; iSec < SECTORSPERSIDE * SIDES; ++iSec) {
     auto brStats = mTreeStats->GetBranch(Form("sec%d", iSec));
     brStats->SetAddress(mTrackResiduals.getVoxStatPtr());
-    brStats->GetEntry(0); // there is only one entry for the statistics tree
+    // in case autosave was enabled, we have multiple entries in the statistics tree
+    brStats->GetEntry(mTreeStats->GetEntries() - 1); // only the last entry is of interest
     auto brResid = mTreeResiduals->GetBranch(Form("sec%d", iSec));
     brResid->SetAddress(&mResidualsPtr);
     for (int iEntry = 0; iEntry < brResid->GetEntries(); ++iEntry) {
@@ -100,7 +101,6 @@ void TPCResidualReader::connectTree(const std::string& filename)
   assert(mTreeResiduals);
   mTreeStats.reset((TTree*)mFile->Get("stats"));
   assert(mTreeStats);
-  assert(mTreeStats->GetEntries() == 1); // expect exactly one entry for statistics
 
   LOG(info) << "Loaded tree from " << filename << " with " << mTreeResiduals->GetEntries() << " entries";
 }

--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackInterpolation.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackInterpolation.h
@@ -54,7 +54,7 @@ struct TPCClusterResiduals {
   float dz{};           ///< residual in Z
   float y{};            ///< Y position of track
   float z{};            ///< Z position of track
-  float phi{};          ///< phi angle of track
+  float snp{};          ///< sin of the phi angle between padrow and track
   float tgl{};          ///< dip angle of track
   unsigned char sec{};  ///< sector number 0..35
   unsigned char dRow{}; ///< distance to previous row in units of pad rows
@@ -62,9 +62,9 @@ struct TPCClusterResiduals {
   void setDZ(float val) { dz = fabs(val) < param::MaxResid ? val : std::copysign(param::MaxResid, val); }
   void setY(float val) { y = fabs(val) < param::MaxY ? val : std::copysign(param::MaxY, val); }
   void setZ(float val) { z = fabs(val) < param::MaxZ ? val : std::copysign(param::MaxZ, val); }
-  void setPhi(float val) { phi = fabs(val) < param::MaxTgSlp ? val : std::copysign(param::MaxTgSlp, val); }
+  void setSnp(float val) { snp = fabs(val) < param::MaxTgSlp ? val : std::copysign(param::MaxTgSlp, val); }
   void setTgl(float val) { tgl = fabs(val) < param::MaxTgSlp ? val : std::copysign(param::MaxTgSlp, val); }
-  ClassDefNV(TPCClusterResiduals, 2);
+  ClassDefNV(TPCClusterResiduals, 3);
 };
 
 /// Structure filled for each track with track quality information and a vector with TPCClusterResiduals
@@ -116,7 +116,7 @@ class TrackInterpolation
     std::array<float, NIndices> sy2{};
     std::array<float, NIndices> szy{};
     std::array<float, NIndices> sz2{};
-    std::array<float, NIndices> phi{};
+    std::array<float, NIndices> snp{};
     std::array<float, NIndices> tgl{};
     float clY{0.f};
     float clZ{0.f};

--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackInterpolation.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackInterpolation.h
@@ -76,12 +76,13 @@ struct TrackData {
   std::array<float, o2::track::kNParams> p{}; ///< track parameters
   float chi2TPC{};             ///< chi2 of TPC track
   float chi2ITS{};             ///< chi2 of ITS track
+  float chi2TRD{};             ///< chi2 of TRD track
   unsigned short nClsTPC{};    ///< number of attached TPC clusters
   unsigned short nClsITS{};    ///< number of attached ITS clusters
   unsigned short nTrkltsTRD{}; ///< number of attached TRD tracklets
   unsigned short clAvailTOF{}; ///< whether or not track seed has a matched TOF cluster
   o2::dataformats::RangeReference<> clIdx{}; ///< index of first cluster residual and total number of cluster residuals of this track
-  ClassDefNV(TrackData, 2);
+  ClassDefNV(TrackData, 3);
 };
 
 /// \class TrackInterpolation

--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackResiduals.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackResiduals.h
@@ -99,7 +99,7 @@ class TrackResiduals
     LocalResid(short dyIn, short dzIn, short tgSlpIn, std::array<unsigned char, VoxDim> bvoxIn) : dy(dyIn), dz(dzIn), tgSlp(tgSlpIn), bvox(bvoxIn) {}
     short dy{0};                              ///< residual in y, ranges from -param::sMaxResid to +param::sMaxResid
     short dz{0};                              ///< residual in z, ranges from -param::sMaxResid to +param::sMaxResid
-    short tgSlp{0};                           ///< track dip angle, ranges from -param::sMaxAngle to +param::sMaxAngle
+    short tgSlp{0};                           ///< tangens of the phi angle between padrow and track, ranges from -param::sMaxAngle to +param::sMaxAngle
     std::array<unsigned char, VoxDim> bvox{}; ///< voxel identifier: VoxZ, VoxF, VoxX
     ClassDefNV(LocalResid, 1);
   };

--- a/Detectors/TPC/calibration/SpacePoints/src/ResidualAggregator.cxx
+++ b/Detectors/TPC/calibration/SpacePoints/src/ResidualAggregator.cxx
@@ -198,7 +198,7 @@ void ResidualsContainer::fill(const o2::dataformats::TFIDInfo& ti, const std::pa
 void ResidualsContainer::writeToFile(bool closeFileAfterwards)
 {
   LOG(info) << "Writing results to file. Closing afterwards? " << closeFileAfterwards;
-  fillStatisticsBranches(); // TODO these would need to be filled only once, so only the last entry is important
+  fillStatisticsBranches(); // these would need to be filled only once, so only the last entry is important
   fileOut->cd();
   if (writeBinnedResid) {
     treeOutResiduals->Write();

--- a/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
+++ b/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
@@ -267,6 +267,7 @@ void TrackInterpolation::interpolateTrack(int iSeed)
   for (int i = 0; i < o2::track::kNParams; ++i) {
     trackData.p[i] = (*mSeeds)[iSeed].getParam(i);
   }
+  trackData.chi2TRD = gidTable[GTrackID::TRD].isIndexSet() ? mRecoCont->getITSTPCTRDTrack<o2::trd::TrackTRD>(gidTable[GTrackID::ITSTPCTRD]).getChi2() : 0;
   trackData.chi2TPC = trkTPC.getChi2();
   trackData.chi2ITS = trkITS.getChi2();
   trackData.nClsTPC = trkTPC.getNClusterReferences();

--- a/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
+++ b/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
@@ -136,7 +136,7 @@ void TrackInterpolation::interpolateTrack(int iSeed)
     mCache[iRow].sy2[ExtOut] = trkWork.getSigmaY2();
     mCache[iRow].szy[ExtOut] = trkWork.getSigmaZY();
     mCache[iRow].sz2[ExtOut] = trkWork.getSigmaZ2();
-    mCache[iRow].phi[ExtOut] = trkWork.getSnp();
+    mCache[iRow].snp[ExtOut] = trkWork.getSnp();
     mCache[iRow].tgl[ExtOut] = trkWork.getTgl();
     //printf("Track alpha at row %i: %.2f, Y(%.2f), Z(%.2f)\n", iRow, trkWork.getAlpha(), trkWork.getY(), trkWork.getZ());
   }
@@ -226,7 +226,7 @@ void TrackInterpolation::interpolateTrack(int iSeed)
     mCache[iRow].sy2[ExtIn] = trkWork.getSigmaY2();
     mCache[iRow].szy[ExtIn] = trkWork.getSigmaZY();
     mCache[iRow].sz2[ExtIn] = trkWork.getSigmaZ2();
-    mCache[iRow].phi[ExtIn] = trkWork.getSnp();
+    mCache[iRow].snp[ExtIn] = trkWork.getSnp();
     mCache[iRow].tgl[ExtIn] = trkWork.getTgl();
   }
 
@@ -244,7 +244,7 @@ void TrackInterpolation::interpolateTrack(int iSeed)
     mCache[iRow].z[Int] = (mCache[iRow].z[ExtOut] / mCache[iRow].sz2[ExtOut] + mCache[iRow].z[ExtIn] / mCache[iRow].sz2[ExtIn]) / wTotZ;
 
     // simple average w/o weighting for angles
-    mCache[iRow].phi[Int] = (mCache[iRow].phi[ExtOut] + mCache[iRow].phi[ExtIn]) / 2.f;
+    mCache[iRow].snp[Int] = (mCache[iRow].snp[ExtOut] + mCache[iRow].snp[ExtIn]) / 2.f;
     mCache[iRow].tgl[Int] = (mCache[iRow].tgl[ExtOut] + mCache[iRow].tgl[ExtIn]) / 2.f;
 
     TPCClusterResiduals res;
@@ -252,7 +252,7 @@ void TrackInterpolation::interpolateTrack(int iSeed)
     res.setDZ(mCache[iRow].clZ - mCache[iRow].z[Int]);
     res.setY(mCache[iRow].y[Int]);
     res.setZ(mCache[iRow].z[Int]);
-    res.setPhi(mCache[iRow].phi[Int]);
+    res.setSnp(mCache[iRow].snp[Int]);
     res.setTgl(mCache[iRow].tgl[Int]);
     res.sec = mCache[iRow].clSec;
     res.dRow = deltaRow;
@@ -310,7 +310,7 @@ void TrackInterpolation::extrapolateTrack(int iSeed)
     res.setDY(z - trkWork.getZ());
     res.setY(trkWork.getY());
     res.setZ(trkWork.getZ());
-    res.setPhi(trkWork.getSnp());
+    res.setSnp(trkWork.getSnp());
     res.setTgl(trkWork.getTgl());
     res.sec = sector;
     res.dRow = row - rowPrev;

--- a/Detectors/TPC/calibration/SpacePoints/src/TrackResiduals.cxx
+++ b/Detectors/TPC/calibration/SpacePoints/src/TrackResiduals.cxx
@@ -393,7 +393,8 @@ void TrackResiduals::doOutlierRejection(bool writeToFile)
         continue;
       }
       ++nClValidated;
-      mUnbinnedResiduals.emplace_back(clRes[clIdx].dy, clRes[clIdx].dz, clRes[clIdx].tgl, clRes[clIdx].y, clRes[clIdx].z, iRow, clRes[clIdx].sec);
+      float tgPhi = std::tan(std::asin(clRes[clIdx].phi));
+      mUnbinnedResiduals.emplace_back(clRes[clIdx].dy, clRes[clIdx].dz, tgPhi, clRes[clIdx].y, clRes[clIdx].z, iRow, clRes[clIdx].sec);
     }
     trkDataOut.clIdx.setEntries(nClValidated);
     mTrackDataOut.push_back(trkDataOut);
@@ -841,6 +842,9 @@ void TrackResiduals::processVoxelResiduals(std::vector<float>& dy, std::vector<f
   resVox.EXYCorr = corrErr;
   resVox.D[ResD] = resVox.dYSigMAD = sigMAD; // later will be overwritten by real dispersion
   resVox.dZSigLTM = zResults[2];
+
+  LOGF(debug, "D[0]=%.2f, D[1]=%.2f, D[2]=%.2f, E[0]=%.2f, E[1]=%.2f, E[2]=%.2f, EXYCorr=%.4f",
+       resVox.D[0], resVox.D[1], resVox.D[2], resVox.E[0], resVox.E[1], resVox.E[2], resVox.EXYCorr);
 
   resVox.flags |= DistDone;
 

--- a/Detectors/TPC/calibration/SpacePoints/src/TrackResiduals.cxx
+++ b/Detectors/TPC/calibration/SpacePoints/src/TrackResiduals.cxx
@@ -393,7 +393,7 @@ void TrackResiduals::doOutlierRejection(bool writeToFile)
         continue;
       }
       ++nClValidated;
-      float tgPhi = std::tan(std::asin(clRes[clIdx].phi));
+      float tgPhi = clRes[clIdx].snp / std::sqrt((1.f - clRes[clIdx].snp) * (1.f + clRes[clIdx].snp));
       mUnbinnedResiduals.emplace_back(clRes[clIdx].dy, clRes[clIdx].dz, tgPhi, clRes[clIdx].y, clRes[clIdx].z, iRow, clRes[clIdx].sec);
     }
     trkDataOut.clIdx.setEntries(nClValidated);


### PR DESCRIPTION
- Add TRD chi2 to the track data
- Geometry is not needed by the static map creator and can thus be removed from the workflow