### PR TITLE
FST: start_tmux.sh and shm-tool.sh should use same memory defaults

### DIFF
--- a/prodtests/full-system-test/shm-tool.sh
+++ b/prodtests/full-system-test/shm-tool.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+[[ -z $SHMSIZE ]] && export SHMSIZE=$(( 112 << 30 )) # Please keep these defaults in sync with those in start_tmux.sh
+[[ -z $DDSHMSIZE ]] && export DDSHMSIZE=$(( 112 << 10 ))
+
 MYDIR="$(dirname $(realpath $0))"
 source $MYDIR/setenv.sh
 

--- a/prodtests/full-system-test/start_tmux.sh
+++ b/prodtests/full-system-test/start_tmux.sh
@@ -26,7 +26,7 @@ if [[ "0$FST_TMUX_NO_EPN" != "01" ]]; then
   # This sets up the hardcoded configuration to run the full system workflow on the EPN
   export NGPUS=4
   export GPUTYPE=HIP
-  export SHMSIZE=$(( 112 << 30 ))
+  export SHMSIZE=$(( 112 << 30 )) # Please keep these defaults in sync with those in shm-tool.sh
   export DDSHMSIZE=$(( 112 << 10 ))
   export GPUMEMSIZE=$(( 24 << 30 ))
   export NUMAGPUIDS=1


### PR DESCRIPTION
only scripts changed, not tested anyway, merging