### PR TITLE
TRD: AODProducer: Fix trdPattern

### DIFF
--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -1114,7 +1114,7 @@ void AODProducerWorkflowDPL::countTPCClusters(const o2::tpc::TrackTPC& track,
 uint8_t AODProducerWorkflowDPL::getTRDPattern(const o2::trd::TrackTRD& track)
 {
   uint8_t pattern = 0;
-  for (int il = o2::trd::TrackTRD::EGPUTRDTrack::kNLayers; il >= 0; il--) {
+  for (int il = o2::trd::TrackTRD::EGPUTRDTrack::kNLayers - 1; il >= 0; il--) {
     if (track.getTrackletIndex(il) != -1) {
       pattern |= 0x1 << il;
     }


### PR DESCRIPTION
In noticed sometime that 7 tracklets were counted as contributing to the track, which is physically impossible since we only have 6 layers.

I used this function to convert from the pattern to nTracklets:

  // Count the number of contributor tracklets from the trd pattern.
  inline uint8_t nTrackletsFromPattern(uint8_t pattern) {
    return std::bitset<8>{pattern}.count();
    }

Looking at AODProducerWorkflowDPL:getTRDPattern(), we are looping over the layers _7_ times instead of 6 (kNLayers=6 and break condition is >=0).
In this function we call track.getTrackletIndex(6) on our first iteration, which indexes into mAttachedTracklets[kNLayers]. This is UB!

This patch fixes it by decrementing the loop iterations by one.