### PR TITLE
TRD raw reader update

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
@@ -435,16 +435,6 @@ uint32_t getlinkerrorflag(const HalfCRUHeader& cruhead, const uint32_t link);
 uint32_t getlinkdatasize(const HalfCRUHeader& cruhead, const uint32_t link);
 uint32_t getlinkerrorflags(const HalfCRUHeader& cruheader, std::array<uint32_t, 15>& linkerrorflags);
 uint32_t getlinkdatasizes(const HalfCRUHeader& cruheader, std::array<uint32_t, 15>& linksizes);
-std::ostream& operator<<(std::ostream& stream, const TrackletHCHeader& halfchamberheader);
-std::ostream& operator<<(std::ostream& stream, const TrackletMCMHeader& mcmhead);
-std::ostream& operator<<(std::ostream& stream, const TrackletMCMData& tracklet);
-void dumpHalfChamber(o2::trd::TrackletHCHeader& halfchamber);
-std::ostream& operator<<(std::ostream& stream, const HalfCRUHeader& halfcru);
-bool trackletMCMHeaderSanityCheck(o2::trd::TrackletMCMHeader& header);
-bool trackletHCHeaderSanityCheck(o2::trd::TrackletHCHeader& header);
-bool digitMCMHeaderSanityCheck(o2::trd::DigitMCMHeader* header);
-bool digitMCMADCMaskSanityCheck(o2::trd::DigitMCMADCMask& mask, int numberofbitsset);
-bool digitMCMWordSanityCheck(o2::trd::DigitMCMData* word, int adcchannel);
 bool halfCRUHeaderSanityCheck(const o2::trd::HalfCRUHeader& header);
 void printDigitHCHeader(o2::trd::DigitHCHeader& header, uint32_t headers[3]);
 
@@ -480,6 +470,7 @@ void printDigitMCMADCMask(const o2::trd::DigitMCMADCMask& digitmcmadcmask);
 
 void printHalfCRUHeader(const o2::trd::HalfCRUHeader& halfcru);
 void clearHalfCRUHeader(o2::trd::HalfCRUHeader& halfcru);
+bool sanityCheckTrackletHCHeader(const o2::trd::TrackletHCHeader& header);
 bool sanityCheckTrackletMCMHeader(const o2::trd::TrackletMCMHeader& header);
 bool sanityCheckDigitMCMHeader(const o2::trd::DigitMCMHeader& header);
 bool sanityCheckDigitMCMADCMask(const o2::trd::DigitMCMADCMask& mask);

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawDataStats.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawDataStats.h
@@ -44,6 +44,9 @@ enum ParsingErrors {
   TrackletDataWrongOrdering,           // the tracklet data is not arriving in increasing MCM order
   TrackletDataDuplicateMCM,            // we see more than one TrackletMCMHeader for the same MCM
   TrackletNoTrackletEndMarker,         // got to the end of the buffer with out finding a tracklet end marker.
+  TrackletNoSecondEndMarker,           // we expected to see a second tracklet end marker, but found something else instead
+  TrackletMCMDataFailure,              // invalid word for TrackletMCMData detected
+  TrackletDataMissing,                 // we expected tracklet data but got an endmarker instead
   TrackletExitingNoTrackletEndMarker,  // got to the end of the buffer exiting tracklet parsing with no tracklet end marker
   UnparsedTrackletDataRemaining,       // the tracklet parsing has finished correctly, but there is still data left on the link (CRU puts incorrect link size or corrupt data?)
   UnparsedDigitDataRemaining,          // the digit parsing has finished correctly, but there is still data left on the link (CRU puts incorrect link size or corrupt data? RDH > 8kByte before?)
@@ -84,6 +87,9 @@ static const std::unordered_map<int, std::string> ParsingErrorsString = {
   {TrackletDataWrongOrdering, "TrackletDataWrongOrdering"},
   {TrackletDataDuplicateMCM, "TrackletDataDuplicateMCM"},
   {TrackletNoTrackletEndMarker, "TrackletNoTrackletEndMarker"},
+  {TrackletNoSecondEndMarker, "TrackletNoSecondEndMarker"},
+  {TrackletMCMDataFailure, "TrackletMCMDataFailure"},
+  {TrackletDataMissing, "TrackletDataMissing"},
   {TrackletExitingNoTrackletEndMarker, "TrackletExitingNoTrackletEndMarker"},
   {UnparsedTrackletDataRemaining, "UnparsedTrackletDataRemaining"},
   {UnparsedDigitDataRemaining, "UnparsedDigitDataRemaining"},

--- a/DataFormats/Detectors/TRD/src/RawData.cxx
+++ b/DataFormats/Detectors/TRD/src/RawData.cxx
@@ -266,6 +266,23 @@ bool halfCRUHeaderSanityCheck(const o2::trd::HalfCRUHeader& header)
   return true;
 }
 
+bool sanityCheckTrackletHCHeader(const o2::trd::TrackletHCHeader& header)
+{
+  if (header.one != 1) {
+    return false;
+  }
+  if (((~header.supermodule) & 0x1f) >= NSECTOR) {
+    return false;
+  }
+  if (((~header.stack) & 0x7) >= NSTACK) {
+    return false;
+  }
+  if (((~header.layer) & 0x7) >= NLAYER) {
+    return false;
+  }
+  return true;
+}
+
 bool sanityCheckTrackletMCMHeader(const o2::trd::TrackletMCMHeader& header)
 {
   // a bit limited to what we can check.
@@ -298,7 +315,7 @@ bool sanityCheckDigitMCMADCMask(const o2::trd::DigitMCMADCMask& mask)
   if (mask.j != 0xc) {
     return false;
   }
-  int counter = (~mask.c) & 0x1f;
+  unsigned int counter = (~mask.c) & 0x1f;
   std::bitset<NADCMCM> headerMask(mask.adcmask);
   return (counter == headerMask.count());
 }
@@ -376,7 +393,6 @@ void printDigitHCHeaders(o2::trd::DigitHCHeader& header, uint32_t headers[3], in
 void printDigitHCHeader(o2::trd::DigitHCHeader& header, uint32_t headers[3])
 {
   printDigitHCHeaders(header, headers, -1, 0, true);
-  int countheaderwords = header.numberHCW;
   int index;
   //for the currently 3 implemented other header words, they can come in any order, and are identified by their reserved portion
   for (int countheaderwords = 0; countheaderwords < header.numberHCW; ++countheaderwords) {

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
@@ -160,6 +160,7 @@ class CruRawReader
 
   HalfCRUHeader mCurrentHalfCRUHeader; // are we waiting for new header or currently parsing the payload of on
   HalfCRUHeader mPreviousHalfCRUHeader; // are we waiting for new header or currently parsing the payload of on
+  bool mPreviousHalfCRUHeaderSet;       // flag, whether we can use mPreviousHalfCRUHeader for additional sanity checks
   DigitHCHeader mDigitHCHeader;         // Digit HalfChamber header we are currently on.
   uint16_t mTimeBins{constants::TIMEBINS}; // the number of time bins to be read out (default 30, can be overwritten from digit HC header)
   bool mHaveSeenDigitHCHeader3{false};     // flag, whether we can compare an incoming DigitHCHeader3 with a header we have seen before

--- a/Detectors/TRD/reconstruction/macros/CompareDigitsAndTracklets.C
+++ b/Detectors/TRD/reconstruction/macros/CompareDigitsAndTracklets.C
@@ -78,17 +78,20 @@ void CompareDigitsAndTracklets(bool ignoreTrkltPid = false,
     trackletTreereco->GetEvent(iev);
 
     // compare trigger records
+    bool compareTriggerRecords = true;
     if (trigRecs->size() != trigRecsReco->size()) {
       LOG(warn) << "Number of trigger records does not match for entry " << iev;
-      continue;
+      compareTriggerRecords = false;
     }
-    for (size_t iTrig = 0; iTrig < trigRecs->size(); ++iTrig) {
-      const auto& trig = trigRecs->at(iTrig);
-      const auto& trigReco = trigRecsReco->at(iTrig);
-      if (!(trig == trigReco)) {
-        LOGF(error, "Trigger records don't match at trigger %lu. Reference orbit/bc (%u/%u), orbit/bc (%u/%u)",
-             iTrig, trig.getBCData().orbit, trig.getBCData().bc, trigReco.getBCData().orbit, trigReco.getBCData().bc);
-        break;
+    if (compareTriggerRecords) {
+      for (size_t iTrig = 0; iTrig < trigRecs->size(); ++iTrig) {
+        const auto& trig = trigRecs->at(iTrig);
+        const auto& trigReco = trigRecsReco->at(iTrig);
+        if (!(trig == trigReco)) {
+          LOGF(error, "Trigger records don't match at trigger %lu. Reference orbit/bc (%u/%u), orbit/bc (%u/%u)",
+               iTrig, trig.getBCData().orbit, trig.getBCData().bc, trigReco.getBCData().orbit, trigReco.getBCData().bc);
+          break;
+        }
       }
     }
 

--- a/Detectors/TRD/reconstruction/src/DataReader.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReader.cxx
@@ -81,10 +81,6 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 
   WorkflowSpec workflow;
 
-  std::string iconfig;
-  std::string inputDescription;
-  int idevice = 0;
-  auto orig = o2::header::gDataOriginTRD;
   auto inputs = o2::framework::select(std::string("x:TRD/RAWDATA").c_str());
   for (auto& inp : inputs) {
     // take care of case where our data is not in the time frame
@@ -94,7 +90,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     inputs.emplace_back("stdDist", "FLP", "DISTSUBTIMEFRAME", 0, Lifetime::Timeframe);
   }
   inputs.emplace_back("trigoffset", "CTP", "Trig_Offset", 0, o2::framework::Lifetime::Condition, o2::framework::ccdbParamSpec("CTP/Config/TriggerOffsets"));
-  // inputs.emplace_back("linkToHcid", "TRD", "LinkToHcid", 0, o2::framework::Lifetime::Condition, o2::framework::ccdbParamSpec("TRD/Config/LinkToHCIDMapping")); // FIXME: uncomment, when object available in CCDB
+  inputs.emplace_back("linkToHcid", "TRD", "LinkToHcid", 0, o2::framework::Lifetime::Condition, o2::framework::ccdbParamSpec("TRD/Config/LinkToHCIDMapping"));
   workflow.emplace_back(DataProcessorSpec{
     std::string("trd-datareader"), // left as a string cast incase we append stuff to the string
     inputs,

--- a/Detectors/TRD/reconstruction/src/DataReaderTask.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReaderTask.cxx
@@ -49,14 +49,11 @@ void DataReaderTask::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
     LOG(info) << " CTP/Config/TriggerOffsets updated.";
     o2::ctp::TriggerOffsetsParam::Instance().printKeyValues();
     return;
-  }
-  /* FIXME uncomment when CCDB object is available
-  else if (matcher == ConcreteDataMatcher("TRD", "LinkToHcid", 0)) {
+  } else if (matcher == ConcreteDataMatcher("TRD", "LinkToHcid", 0)) {
     LOG(info) << "Updated Link ID to HCID mapping";
     mReader.setLinkMap((const o2::trd::LinkToHCIDMapping*)obj);
     return;
   }
-  */
 }
 
 void DataReaderTask::updateTimeDependentParams(framework::ProcessingContext& pc)
@@ -64,7 +61,7 @@ void DataReaderTask::updateTimeDependentParams(framework::ProcessingContext& pc)
   static bool updateOnlyOnce = false;
   if (!updateOnlyOnce) {
     pc.inputs().get<o2::ctp::TriggerOffsetsParam*>("trigoffset");
-    // pc.inputs().get<o2::trd::LinkToHCIDMapping*>("linkToHcid");  FIXME uncomment when CCDB object is available
+    pc.inputs().get<o2::trd::LinkToHCIDMapping*>("linkToHcid");
     updateOnlyOnce = true;
   }
 }

--- a/Detectors/TRD/reconstruction/src/EventRecord.cxx
+++ b/Detectors/TRD/reconstruction/src/EventRecord.cxx
@@ -82,8 +82,9 @@ void EventRecordContainer::accumulateStats()
   int eventcount = mEventRecords.size();
   int sumtracklets = 0;
   int sumdigits = 0;
-  int sumdigittime = 0;
-  int sumtracklettime = 0;
+  double sumdigittime = 0;
+  double sumtracklettime = 0;
+  double sumtime = 0;
   uint64_t sumwordsrejected = 0;
   uint64_t sumwordsread = 0;
   for (auto event : mEventRecords) {
@@ -91,15 +92,14 @@ void EventRecordContainer::accumulateStats()
     sumdigits += event.getEventStats().mDigitsFound;
     sumtracklettime += event.getEventStats().mTimeTakenForTracklets;
     sumdigittime += event.getEventStats().mTimeTakenForDigits;
-    // OS: the two counters below are not even used anymore, are they needed?
-    sumwordsrejected += event.getEventStats().mWordsRejected;
-    sumwordsread += event.getEventStats().mWordsRead;
+    sumtime += event.getEventStats().mTimeTaken;
   }
   if (eventcount != 0) {
     mTFStats.mTrackletsPerEvent = sumtracklets / eventcount;
     mTFStats.mDigitsPerEvent = sumdigits / eventcount;
     mTFStats.mTimeTakenForTracklets = sumtracklettime;
     mTFStats.mTimeTakenForDigits = sumdigittime;
+    mTFStats.mTimeTaken = sumtime;
   }
 }
 
@@ -107,7 +107,7 @@ void EventRecordContainer::setCurrentEventRecord(const InteractionRecord& ir)
 {
   // check if we already have an EventRecord for given interaction
   bool foundEventRecord = false;
-  for (int idx = 0; idx < mEventRecords.size(); ++idx) {
+  for (int idx = 0; idx < (int)mEventRecords.size(); ++idx) {
     if (mEventRecords.at(idx).getBCData() == ir) {
       mCurrEventRecord = idx;
       foundEventRecord = true;

--- a/Detectors/TRD/simulation/include/TRDSimulation/Trap2CRU.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/Trap2CRU.h
@@ -55,6 +55,7 @@ class Trap2CRU
   void setOutputDir(std::string outdir) { mOutputDir = outdir; };
   void setVerbosity(int verbosity) { mVerbosity = verbosity; }
   void setTrackletHCHeader(int tracklethcheader) { mUseTrackletHCHeader = tracklethcheader; }
+  void setTimeStamp(long ts) { mTimeStamp = ts; }
 
   // make the writer available in trap2raw.cxx for configuration
   o2::raw::RawFileWriter& getWriter() { return mWriter; }
@@ -64,7 +65,7 @@ class Trap2CRU
   // write digits for single MCM into raw stream (include DigitMCMHeader and ADC mask)
   int buildDigitRawData(const int digitstartindex, const int digitendindex, const int mcm, const int rob, const uint32_t triggercount);
   // write tracklets for single MCM into raw stream (includes TrackletMCMHeader)
-  int buildTrackletRawData(int trackletIndexStart);
+  int buildTrackletRawData(unsigned int trackletIndexStart);
   // write two digit end markers
   void writeDigitEndMarkers();
   // write two tracklet end markers
@@ -100,6 +101,8 @@ class Trap2CRU
   std::vector<o2::trd::TriggerRecord> mTrackletTriggerRecords, *mTrackletTriggerRecordsPtr{&mTrackletTriggerRecords};
 
   // helpers
+  long mTimeStamp{0};                          // used to retrieve the correct link to HCID mapping from CCDB
+  const LinkToHCIDMapping* mLinkMap = nullptr; // to retrieve HCID from Link ID
   std::vector<uint32_t> mDigitsIndex; // input digits are sorted using this index array
   char* mRawDataPtr{nullptr};         // points to the current position in the raw data where we are writing
   uint64_t mCurrentTracklet{0}; //the tracklet we are currently busy adding

--- a/Detectors/TRD/simulation/src/Trap2CRU.cxx
+++ b/Detectors/TRD/simulation/src/Trap2CRU.cxx
@@ -22,6 +22,7 @@
 #include "CommonDataFormat/InteractionRecord.h"
 #include "DataFormatsCTP/TriggerOffsetsParam.h"
 #include "DetectorsRaw/HBFUtils.h"
+#include "CCDB/BasicCCDBManager.h"
 #include "DetectorsRaw/RawFileWriter.h"
 #include "TRDSimulation/Trap2CRU.h"
 #include "CommonUtils/StringUtils.h"
@@ -219,6 +220,13 @@ void Trap2CRU::readTrapData()
   // first 15 links go to cru0a, second 15 links go to cru0b, 3rd 15 links go to cru1a ... first 90 links to flp0 and then repeat for 12 flp
   // then do next event
 
+  // request the mapping from CCDB, if not yet available
+  if (!mLinkMap) {
+    LOG(info) << "Retrieving LinkToHCIDMapping for time stamp " << mTimeStamp;
+    auto& ccdbmgr = o2::ccdb::BasicCCDBManager::instance();
+    mLinkMap = ccdbmgr.getForTimeStamp<LinkToHCIDMapping>("TRD/Config/LinkToHCIDMapping", mTimeStamp);
+  }
+
   // lets register our links
   std::string prefix = mOutputDir;
   if (!prefix.empty() && prefix.back() != '/') {
@@ -279,7 +287,6 @@ void Trap2CRU::readTrapData()
     nTriggerRecordsTotal += mTrackletTriggerRecords.size();
     sortDataToLinks();
     // each entry is a timeframe
-    uint32_t linkcount = 0;
     for (auto tracklettrigger : mTrackletTriggerRecords) {
       convertTrapData(tracklettrigger, triggercount); // tracklettrigger assumed to be authoritive
       triggercount++;
@@ -297,9 +304,7 @@ uint32_t Trap2CRU::buildHalfCRUHeader(HalfCRUHeader& header, const uint32_t bc, 
   int crurdhversion = 6;
   int feeid = 0;
   int cruid = 0;
-  uint32_t crudatasize = 0; //link size in units of 256 bits.
   int endpoint = halfcru % 2 ? 1 : 0;
-  uint32_t padding = 0;
   //lets first clear it out.
   clearHalfCRUHeader(header);
   //this bunchcrossing is not the same as the bunchcrossing in the rdh, which is the bc coming in the parameter list to this function. See explanation in rawdata.h
@@ -323,8 +328,8 @@ int Trap2CRU::buildDigitRawData(const int digitstartindex, const int digitendind
   header.yearflag = 1; // >10.2007
   header.eventcount = triggerrecordcount;
   memcpy(mRawDataPtr, (char*)&header, sizeof(DigitMCMHeader)); // uint32 -- 4 bytes.
-  DigitMCMHeader* headerptr = (DigitMCMHeader*)mRawDataPtr;
-  //LOG(info) << "Digt Header word: 0x" << std::hex << headerptr->word;
+  // DigitMCMHeader* headerptr = (DigitMCMHeader*)mRawDataPtr;
+  // LOG(info) << "Digt Header word: 0x" << std::hex << headerptr->word;
   mRawDataPtr += 4;
   digitwordswritten++;
   // we are writing zero suppressed so we need adcmask
@@ -366,7 +371,7 @@ int Trap2CRU::buildDigitRawData(const int digitstartindex, const int digitendind
   return digitwordswritten;
 }
 
-int Trap2CRU::buildTrackletRawData(int trackletIndexStart)
+int Trap2CRU::buildTrackletRawData(unsigned int trackletIndexStart)
 {
   int hcid = mTracklets[trackletIndexStart].getHCID();
   TrackletMCMHeader header;                 // header with common tracklet information and upper 8 bit of PID information for each tracklet
@@ -384,7 +389,7 @@ int Trap2CRU::buildTrackletRawData(int trackletIndexStart)
   while (hcid == mTracklets[trackletIndexStart + iCurrTracklet].getHCID() &&
          header.col == mTracklets[trackletIndexStart + iCurrTracklet].getColumn() &&
          header.padrow == mTracklets[trackletIndexStart + iCurrTracklet].getPadRow()) { // we are still on the same MCM
-    int trackletIndex = trackletIndexStart + iCurrTracklet;
+    unsigned int trackletIndex = trackletIndexStart + iCurrTracklet;
     auto& trackletData = tracklets[iCurrTracklet];
     trackletData.word = 0;
     // slope and position have the 8-th bit flipped each
@@ -526,8 +531,8 @@ void Trap2CRU::convertTrapData(o2::trd::TriggerRecord const& triggerrecord, cons
     LOG(info) << "BUNCH CROSSING : " << triggerrecord.getBCData().bc << " with orbit : " << triggerrecord.getBCData().orbit;
   }
 
-  int endtrackletindex = triggerrecord.getFirstTracklet() + triggerrecord.getNumberOfTracklets();
-  int64_t enddigitindex = triggerrecord.getFirstDigit() + triggerrecord.getNumberOfDigits();
+  uint64_t endtrackletindex = triggerrecord.getFirstTracklet() + triggerrecord.getNumberOfTracklets();
+  uint64_t enddigitindex = triggerrecord.getFirstDigit() + triggerrecord.getNumberOfDigits();
   // with digit downscaling enabled there will be triggers with only tracklets
   bool isCalibTrigger = triggerrecord.getNumberOfDigits() > 0 ? true : false;
   const auto& ctpOffsets = o2::ctp::TriggerOffsetsParam::Instance();
@@ -569,7 +574,7 @@ void Trap2CRU::convertTrapData(o2::trd::TriggerRecord const& triggerrecord, cons
     for (int halfcrulink = 0; halfcrulink < constants::NLINKSPERHALFCRU; halfcrulink++) {
       //links run from 0 to 14, so linkid offset is halfcru*15;
       int linkid = halfcrulink + halfcru * constants::NLINKSPERHALFCRU;
-      int hcid = HelperMethods::getHCIDFromLinkID(linkid);
+      int hcid = mLinkMap->getHCID(linkid);
       int linkwordswritten = 0; // number of 32 bit words for this link
       int errors = 0;           // put no errors in for now.
       uint32_t crudatasize = 0; // in 256 bit words.

--- a/Detectors/TRD/simulation/src/trap2raw.cxx
+++ b/Detectors/TRD/simulation/src/trap2raw.cxx
@@ -40,7 +40,7 @@ namespace bpo = boost::program_options;
 
 void trap2raw(const std::string& inpDigitsName, const std::string& inpTrackletsName,
               const std::string& outDir, int verbosity, std::string filePerLink,
-              uint32_t rdhV = 6, bool noEmptyHBF = false, int tracklethcheader = 0, int superPageSizeInB = 1024 * 1024);
+              uint32_t rdhV = 6, bool noEmptyHBF = false, int tracklethcheader = 0, int superPageSizeInB = 1024 * 1024, long startTime = 1547590800000);
 
 int main(int argc, char** argv)
 {
@@ -89,12 +89,14 @@ int main(int argc, char** argv)
   }
   o2::conf::ConfigurableParam::updateFromString(vm["configKeyValues"].as<std::string>());
 
-  trap2raw(vm["input-file-digits"].as<std::string>(), vm["input-file-tracklets"].as<std::string>(), vm["output-dir"].as<std::string>(), vm["verbosity"].as<int>(), vm["file-per"].as<std::string>(), vm["rdh-version"].as<uint32_t>(), vm["no-empty-hbf"].as<bool>(), vm["tracklethcheader"].as<int>());
+  const auto& hbfu = o2::raw::HBFUtils::Instance(); // we need the creation time for the link mapping from CCDB
+
+  trap2raw(vm["input-file-digits"].as<std::string>(), vm["input-file-tracklets"].as<std::string>(), vm["output-dir"].as<std::string>(), vm["verbosity"].as<int>(), vm["file-per"].as<std::string>(), vm["rdh-version"].as<uint32_t>(), vm["no-empty-hbf"].as<bool>(), vm["tracklethcheader"].as<int>(), 1024 * 1024, hbfu.startTime);
 
   return 0;
 }
 
-void trap2raw(const std::string& inpDigitsName, const std::string& inpTrackletsName, const std::string& outDir, int verbosity, std::string filePer, uint32_t rdhV, bool noEmptyHBF, int trackletHCHeader, int superPageSizeInB)
+void trap2raw(const std::string& inpDigitsName, const std::string& inpTrackletsName, const std::string& outDir, int verbosity, std::string filePer, uint32_t rdhV, bool noEmptyHBF, int trackletHCHeader, int superPageSizeInB, long startTime)
 {
   TStopwatch swTot;
   swTot.Start();
@@ -104,11 +106,11 @@ void trap2raw(const std::string& inpDigitsName, const std::string& inpTrackletsN
   mc2raw.setFilePer(filePer);
   mc2raw.setVerbosity(verbosity);
   mc2raw.setTrackletHCHeader(trackletHCHeader); // run3 or run2
+  mc2raw.setTimeStamp(startTime);
   auto& wr = mc2raw.getWriter();
   std::string inputGRP = o2::base::NameConf::getGRPFileName();
   const auto grp = o2::parameters::GRPObject::loadFrom(inputGRP);
-  // wr.setContinuousReadout(grp->isDetContinuousReadOut(o2::detectors::DetID::TRD)); // must be set explicitly
-  wr.setContinuousReadout(false); // above should work, but I know this is correct, come back TODO
+  wr.setContinuousReadout(grp->isDetContinuousReadOut(o2::detectors::DetID::TRD)); // must be set explicitly
   wr.setSuperPageSize(superPageSizeInB);
   wr.useRDHVersion(rdhV);
   wr.setDontFillEmptyHBF(noEmptyHBF);
@@ -120,7 +122,6 @@ void trap2raw(const std::string& inpDigitsName, const std::string& inpTrackletsN
     outDirName += '/';
   }
 
-  mc2raw.setTrackletHCHeader(trackletHCHeader);
   mc2raw.readTrapData();
   wr.writeConfFile(wr.getOrigin().str, "RAWDATA", o2::utils::Str::concat_string(outDirName, wr.getOrigin().str, "raw.cfg"));
   //


### PR DESCRIPTION
Won't pass the CI until the CCDB object `TRD/Config/LinkToHCIDMapping` is available. But when it is we can enable link to HCID mapping from CCDB.
In addition some warnings have been replaced by sending error counters to QC. And currently the CRU sends quite often bogus link data which would always lead to warnings in the log file. Therefore the warnings are disabled for now and should be re-enabled when the CRU is updated. We still send errors counters for this to QC.
Finally, some more compiler warnings are addressed.