### PR TITLE
ShmManager: fix race between segment reset & presence check

### DIFF
--- a/Utilities/ShmManager/src/ShmManager.cxx
+++ b/Utilities/ShmManager/src/ShmManager.cxx
@@ -25,6 +25,7 @@
 
 #include <chrono>
 #include <map>
+#include <mutex>
 #include <string>
 #include <thread>
 
@@ -163,6 +164,7 @@ struct ShmManager {
 
   bool CheckPresence()
   {
+    std::lock_guard<std::mutex> lock(localMtx);
     for (const auto& sc : segmentCfgs) {
       if (!(fair::mq::shmem::Monitor::SegmentIsPresent(fair::mq::shmem::ShmId{shmId}, sc.id))) {
         return false;
@@ -178,6 +180,7 @@ struct ShmManager {
 
   void ResetContent()
   {
+    std::lock_guard<std::mutex> lock(localMtx);
     fair::mq::shmem::Monitor::ResetContent(fair::mq::shmem::ShmId{shmId}, segmentCfgs, regionCfgs);
   }
 
@@ -195,6 +198,7 @@ struct ShmManager {
   }
 
   std::string shmId;
+  std::mutex localMtx;
   map<uint16_t, fair::mq::shmem::Segment> segments;
   map<uint16_t, unique_ptr<fair::mq::shmem::UnmanagedRegion>> regions;
   std::vector<fair::mq::shmem::SegmentConfig> segmentCfgs;


### PR DESCRIPTION
Fixes a race where a segment presence check can be called while the segments/regions are being reset.