### PR TITLE
DPL: avoid race condition when resetting output proxy

### DIFF
--- a/Framework/Core/src/CompletionPolicyHelpers.cxx
+++ b/Framework/Core/src/CompletionPolicyHelpers.cxx
@@ -125,7 +125,12 @@ CompletionPolicy CompletionPolicyHelpers::consumeWhenAllOrdered(const char* name
       if (input.header == nullptr) {
         return CompletionPolicy::CompletionOp::Wait;
       }
-      if (framework::DataRefUtils::isValid(input) && framework::DataRefUtils::getHeader<o2::framework::DataProcessingHeader*>(input)->startTime != *nextTimeSlice) {
+      long int startTime = framework::DataRefUtils::getHeader<o2::framework::DataProcessingHeader*>(input)->startTime;
+      if (startTime == 0) {
+        LOGP(info, "startTime is 0, which means we have the first message, so we can process it.");
+        *nextTimeSlice = 0;
+      }
+      if (framework::DataRefUtils::isValid(input) && startTime != *nextTimeSlice) {
         return CompletionPolicy::CompletionOp::Retry;
       }
     }

--- a/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
+++ b/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
@@ -258,6 +258,12 @@ InjectorFunction dplModelAdaptor(std::vector<OutputSpec> const& filterSpecs, DPL
         LOG(error) << "data on input " << msgidx << " does not follow the O2 data model, DataProcessingHeader missing";
         continue;
       }
+      static size_t currentRunNumber = -1;
+      if (dh->runNumber != currentRunNumber) {
+        LOGP(detail, "Run number changed from {} to {}. Resetting DPL timeslice counter", currentRunNumber, dh->runNumber);
+        currentRunNumber = dh->runNumber;
+        dplCounter = 0;
+      }
       const_cast<DataProcessingHeader*>(dph)->startTime = dplCounter;
       if (override_creation) {
         const_cast<DataProcessingHeader*>(dph)->creation = creationVal + (dh->firstTForbit * o2::constants::lhc::LHCOrbitNS * 0.000001f);


### PR DESCRIPTION
Due to the consumeWhenAllOrdered policy of the output proxy, if the startTime on the input proxy and the counter in the policy go out of sync, it will result in no messages being processed.

To obviate this, we reset the dplCounter whenever we have a new run and we reset the policy counter when we see a 0 for the startTime.