### PR TITLE
Remove option to ignore bogus TRD headers

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawDataStats.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawDataStats.h
@@ -119,7 +119,6 @@ enum OptionBits {
   TRDVerboseBit,
   TRDVerboseErrorsBit,
   TRDIgnore2StageTrigger,
-  TRDIgnoreBogusTrackletHCHeaders,
   TRDGenerateStats,
   TRDOnlyCalibrationTriggerBit
 }; // this is currently 16 options, the array is 16, if you add here you need to change the 16;

--- a/Detectors/TRD/reconstruction/src/CruRawReader.cxx
+++ b/Detectors/TRD/reconstruction/src/CruRawReader.cxx
@@ -639,14 +639,6 @@ bool CruRawReader::isTrackletHCHeaderOK(const TrackletHCHeader& header, int& hci
   }
   int detHeader = HelperMethods::getDetector(((~header.supermodule) & 0x1f), ((~header.stack) & 0x7), ((~header.layer) & 0x7));
   int hcidHeader = (detHeader * 2 + ((~header.side) & 0x1));
-
-  if (mOptions[TRDIgnoreBogusTrackletHCHeaders]) {
-    // in the current synthetic data sample the tracklet HC headers are screwed up
-    // this option should be removed when we have new synthetic data samples available
-    // with fixed headers
-    return true;
-  }
-
   if (hcid != hcidHeader) {
     if (mMaxWarnPrinted > 0) {
       LOGF(alarm, "RDH HCID %i, TrackletHCHeader HCID %i. Taking the TrackletHCHedaer as authority", hcid, hcidHeader);

--- a/Detectors/TRD/reconstruction/src/DataReader.cxx
+++ b/Detectors/TRD/reconstruction/src/DataReader.cxx
@@ -36,7 +36,6 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"verbose", VariantType::Bool, false, {"Enable verbose epn data reading."}},
     {"verboseerrors", VariantType::Bool, false, {"Enable verbose error text, instead of simply updating the spectra."}},
     {"ignore-dist-stf", VariantType::Bool, false, {"do not subscribe to FLP/DISTSUBTIMEFRAME/0 message (no lost TF recovery)"}},
-    {"ignore-tracklethcheader", VariantType::Bool, false, {"temporary fix for synthetic data with bogus headers, not to be used with real raw data"}},
     {"halfchamberwords", VariantType::Int, 0, {"Fix half chamber for when it is version is 0.0 integer value of additional header words, ignored if version is not 0.0"}},
     {"halfchambermajor", VariantType::Int, 0, {"Fix half chamber for when it is version is 0.0 integer value of major version, ignored if version is not 0.0"}},
     {"fixforoldtrigger", VariantType::Bool, false, {"Fix for the old data not having a 2 stage trigger stored in the cru header."}},
@@ -75,7 +74,6 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   binaryoptions[o2::trd::TRDIgnore2StageTrigger] = cfgc.options().get<bool>("fixforoldtrigger");
   binaryoptions[o2::trd::TRDGenerateStats] = cfgc.options().get<bool>("generate-stats");
   binaryoptions[o2::trd::TRDOnlyCalibrationTriggerBit] = cfgc.options().get<bool>("onlycalibrationtrigger");
-  binaryoptions[o2::trd::TRDIgnoreBogusTrackletHCHeaders] = cfgc.options().get<bool>("ignore-tracklethcheader");
   AlgorithmSpec algoSpec;
   algoSpec = AlgorithmSpec{adaptFromTask<o2::trd::DataReaderTask>(tracklethcheader, halfchamberwords, halfchambermajor, binaryoptions)};
 


### PR DESCRIPTION
The current synthetic data samples contain more bogus data so it is not worth trying to circumvent all this in the raw reader. Instead, we need to create new synthetic data samples in order to exercise the TRD processing without beam.