### PR TITLE
[EMCAL-565]: Integrate scaling in the bad channel calibration

### DIFF
--- a/Detectors/EMCAL/calib/include/EMCALCalib/CalibDB.h
+++ b/Detectors/EMCAL/calib/include/EMCALCalib/CalibDB.h
@@ -27,6 +27,7 @@ class TempCalibParamSM;
 class TimeCalibrationParams;
 class TimeCalibParamL1Phase;
 class GainCalibrationFactors;
+class EMCALChannelScaleFactors;
 class FeeDCS;
 class ElmbData;
 
@@ -257,6 +258,13 @@ class CalibDB
   /// \throw TypeMismatchException if object is present but type is different (CCDB corrupted)
   GainCalibrationFactors* readGainCalibFactors(ULong_t timestamp, const std::map<std::string, std::string>& metadata);
 
+  /// \brief Find scale factors used for bad channel calibration in the CCDB for given timestamp
+  /// \param timestamp Timestamp used in query (there is only one entry in the CCDB)
+  /// \param metadata Additional metadata to be used in the query
+  /// \throw ObjectNotFoundException if object is not found for the given timestamp
+  /// \throw TypeMismatchException if object is present but type is different (CCDB corrupted)
+  EMCALChannelScaleFactors* readChannelScaleFactors(ULong_t timestamp, const std::map<std::string, std::string>& metadata);
+
   /// \brief Store FEE DCS data in the CCDB
   /// \param dcs FEE DCS data to be stored
   /// \param metadata Additional metadata that can be used in the query
@@ -329,6 +337,10 @@ class CalibDB
   /// \return Path of the Temperature Sensor data in the CCDB
   static const char* getCDBPathTemperatureSensor() { return "EMC/Calib/Temperature"; }
 
+  /// \brief Get CCDB path for the scale factors used in the bad channel calibration
+  /// \return Path of the scale factors used in the bad channel calibration in the CCDB
+  static const char* getCDBPathChannelScaleFactors() { return "EMC/Config/ChannelScaleFactors"; }
+
  private:
   /// \brief Initialize CCDB server (when new object is created or the server URL changes)
   void
@@ -338,7 +350,7 @@ class CalibDB
   std::string mCCDBServer = "emcccdb-test.cern.ch"; ///< Name of the CCDB server
   Bool_t mInit = false;                             ///< Init status (needed for lazy evaluation of the CcdbApi init)
 
-  ClassDefNV(CalibDB, 1);
+  ClassDefNV(CalibDB, 2);
 };
 } // namespace emcal
 

--- a/Detectors/EMCAL/calib/src/CalibDB.cxx
+++ b/Detectors/EMCAL/calib/src/CalibDB.cxx
@@ -15,6 +15,7 @@
 #include "EMCALCalib/TimeCalibParamL1Phase.h"
 #include "EMCALCalib/TempCalibParamSM.h"
 #include "EMCALCalib/GainCalibrationFactors.h"
+#include "EMCALCalib/EMCALChannelScaleFactors.h"
 #include "EMCALCalib/FeeDCS.h"
 #include "EMCALCalib/CalibDB.h"
 #include "EMCALCalib/ElmbData.h"
@@ -164,6 +165,18 @@ GainCalibrationFactors* CalibDB::readGainCalibFactors(ULong_t timestamp, const s
   GainCalibrationFactors* result = mCCDBManager.retrieveFromTFileAny<o2::emcal::GainCalibrationFactors>(getCDBPathGainCalibrationParams(), metadata, timestamp);
   if (!result) {
     throw ObjectNotFoundException(mCCDBServer, getCDBPathGainCalibrationParams(), metadata, timestamp);
+  }
+  return result;
+}
+
+EMCALChannelScaleFactors* CalibDB::readChannelScaleFactors(ULong_t timestamp, const std::map<std::string, std::string>& metadata)
+{
+  if (!mInit) {
+    init();
+  }
+  EMCALChannelScaleFactors* result = mCCDBManager.retrieveFromTFileAny<o2::emcal::EMCALChannelScaleFactors>(getCDBPathChannelScaleFactors(), metadata, timestamp);
+  if (!result) {
+    throw ObjectNotFoundException(mCCDBServer, getCDBPathChannelScaleFactors(), metadata, timestamp);
   }
   return result;
 }

--- a/Detectors/EMCAL/calibration/run/runCalibOffline.cxx
+++ b/Detectors/EMCAL/calibration/run/runCalibOffline.cxx
@@ -189,14 +189,16 @@ int main(int argc, char** argv)
   o2::emcal::CalibDB calibdb(ccdbServerPath);
 
   if (doBadChannelCalib) {
+    std::map<std::string, std::string> dummymeta;
+    CalibExtractor.setBCMScaleFactors(calibdb.readChannelScaleFactors(1546300800001, dummymeta));
     printf("perform bad channel analysis\n");
     o2::emcal::BadChannelMap BCMap;
 
     BCMap = CalibExtractor.calibrateBadChannels(hCalibInputHist);
     // store bad channel map in ccdb via emcal calibdb
     if (doLocal) {
-      std::unique_ptr<TFile> writer(TFile::Open("bcm.root", "RECREATE"));
-      writer->WriteObjectAny(&BCMap, "o2::emcal::BadChannelMap", "BadChannelMap");
+      std::unique_ptr<TFile> writer(TFile::Open(Form("bcm_%lu.root", rangestart), "RECREATE"));
+      writer->WriteObjectAny(&BCMap, "o2::emcal::BadChannelMap", "ccdb_object");
     } else {
       std::map<std::string, std::string> metadata;
       calibdb.storeBadChannelMap(&BCMap, metadata, rangestart, rangeend);
@@ -210,8 +212,8 @@ int main(int argc, char** argv)
     TCparams = CalibExtractor.calibrateTime(hCalibInputHist, timeRangeLow, timeRangeHigh);
 
     if (doLocal) {
-      std::unique_ptr<TFile> writer(TFile::Open("timecalib.root", "RECREATE"));
-      writer->WriteObjectAny(&TCparams, "o2::emcal::TimeCalibrationParams", "TimeCalibrationParams");
+      std::unique_ptr<TFile> writer(TFile::Open(Form("timecalib_%lu.root", rangestart), "RECREATE"));
+      writer->WriteObjectAny(&TCparams, "o2::emcal::TimeCalibrationParams", "ccdb_object");
     } else {
       // store parameters in ccdb via emcal calibdb
       std::map<std::string, std::string> metadata;


### PR DESCRIPTION
Scaling of the energy vs. cellID histogram is now integrated into the CalibExtractor. Reads scale factors from the CCDB. 

- Additionally change the writing of root histograms in the offline calibrator to have a more realistic name. 