### PR TITLE
DPL: fix name clash with the new FairMQ

### DIFF
--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -715,12 +715,12 @@ auto sendRelayerMetrics(ServiceRegistry& registry, DataProcessingStats& stats) -
     auto device = registry.get<RawDeviceService>().device();
     long freeMemory = -1;
     try {
-      freeMemory = Monitor::GetFreeMemory(ShmId{makeShmIdStr(device->fConfig->GetProperty<uint64_t>("shmid"))}, runningWorkflow.shmSegmentId);
+      freeMemory = fair::mq::shmem::Monitor::GetFreeMemory(ShmId{makeShmIdStr(device->fConfig->GetProperty<uint64_t>("shmid"))}, runningWorkflow.shmSegmentId);
     } catch (...) {
     }
     if (freeMemory == -1) {
       try {
-        freeMemory = Monitor::GetFreeMemory(SessionId{device->fConfig->GetProperty<std::string>("session")}, runningWorkflow.shmSegmentId);
+        freeMemory = fair::mq::shmem::Monitor::GetFreeMemory(SessionId{device->fConfig->GetProperty<std::string>("session")}, runningWorkflow.shmSegmentId);
       } catch (...) {
       }
     }

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -323,7 +323,7 @@ static void handle_sigint(int)
 void cleanupSHM(std::string const& uniqueWorkflowId)
 {
   using namespace fair::mq::shmem;
-  Monitor::Cleanup(SessionId{"dpl_" + uniqueWorkflowId}, false);
+  fair::mq::shmem::Monitor::Cleanup(SessionId{"dpl_" + uniqueWorkflowId}, false);
 }
 
 static void handle_sigchld(int) { sigchld_requested = true; }


### PR DESCRIPTION
Apparently the new version of FairMQ clashes with something in monitoring.