### PR TITLE
CCDB: Better test isolation

### DIFF
--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -126,7 +126,7 @@ void CcdbApi::init(std::string const& host)
 }
 
 /**
- * Keep only the alphanumeric characters plus '_' plus '/' from the string passed in argument.
+ * Keep only the alphanumeric characters plus '_' plus '/' plus '.' from the string passed in argument.
  * @param objectName
  * @return a new string following the rule enounced above.
  */
@@ -134,7 +134,7 @@ std::string sanitizeObjectName(const std::string& objectName)
 {
   string tmpObjectName = objectName;
   tmpObjectName.erase(std::remove_if(tmpObjectName.begin(), tmpObjectName.end(),
-                                     [](auto const& c) -> bool { return (!std::isalnum(c) && c != '_' && c != '/'); }),
+                                     [](auto const& c) -> bool { return (!std::isalnum(c) && c != '_' && c != '/' && c != '.'); }),
                       tmpObjectName.end());
   return tmpObjectName;
 }

--- a/CCDB/test/testCcdbApi.cxx
+++ b/CCDB/test/testCcdbApi.cxx
@@ -60,7 +60,9 @@ struct Fixture {
     cout << "ccdb url: " << ccdbUrl << endl;
     hostReachable = api.isHostReachable();
     cout << "Is host reachable ? --> " << hostReachable << endl;
-    basePath = string("Test/pid") + getpid() + "/";
+    char hostname[_POSIX_HOST_NAME_MAX];
+    gethostname(hostname, _POSIX_HOST_NAME_MAX);
+    basePath = string("Test/TestCcdbApi/") + hostname + "/pid" + getpid() + "/";
     cout << "Path we will use in this test suite : " + basePath << endl;
   }
   ~Fixture()
@@ -377,8 +379,6 @@ BOOST_AUTO_TEST_CASE(list_test, *utf::precondition(if_reachable()))
 
   // more complex tree
   TH1F h1("object1", "object1", 100, 0, 99);
-  cout << "storing object 1 in Test" << endl;
-  f.api.storeAsTFile(&h1, "Test", f.metadata);
   cout << "storing object 2 in Test/Detector" << endl;
   f.api.storeAsTFile(&h1, basePath + "Detector", f.metadata);
   cout << "storing object 3 in Test/Detector" << endl;

--- a/CCDB/test/testCcdbApi_ConfigParam.cxx
+++ b/CCDB/test/testCcdbApi_ConfigParam.cxx
@@ -61,8 +61,9 @@ struct Fixture {
     api.init(ccdbUrl);
     cout << "ccdb url: " << ccdbUrl << endl;
     hostReachable = api.isHostReachable();
-    cout << "Is host reachable ? --> " << hostReachable << endl;
-    basePath = string("Test/pid") + getpid() + "/";
+    char hostname[_POSIX_HOST_NAME_MAX];
+    gethostname(hostname, _POSIX_HOST_NAME_MAX);
+    basePath = string("Test/") + hostname + "/pid" + getpid() + "/";
     cout << "Path we will use in this test suite : " + basePath << endl;
   }
   ~Fixture()


### PR DESCRIPTION
This is a commit hoping to fix
CCDB problems in the CI, which could be related
to race conditions between multiple parallel tests.

Concretely:
a) equip test CCDB paths with hostname identifier for better isolation 
b) promote some tests (like testBasicCCDBManager) to use isolated
   paths (including hostname + pid)
c) do not write objects to global folder "Test" anymore 
d) truncate more aggressively in each test, not leaving behind
   objects on the CCDB server