### PR TITLE
Fix indentation, and typo

### DIFF
--- a/prodtests/full-system-test/aggregator-workflow.sh
+++ b/prodtests/full-system-test/aggregator-workflow.sh
@@ -110,7 +110,7 @@ if workflow_has_parameter CALIB_PROXIES; then
   # expand FLPs; TPC uses from 001 to 145, but 145 is reserved for SAC
   for flp in $(seq -f "%03g" 1 144)
   do
-    FLP_ADDRESS+="tcp://alicr1-flp-ib${flp}:${TPC_IDC_FLP_PORT}"
+    FLP_ADDRESS="tcp://alicr1-flp-ib${flp}:${TPC_IDC_FLP_PORT}"
     CHANNELS_LIST+=" --channel-config \"type=pull,name=tpcidc_flp${flp},transport=zmq,address=$FLP_ADDRESS,method=connect,rateLogging=10\""
   done
   add_W o2-dpl-raw-proxy "--dataspec \"$CALIBDATASPEC_TPCIDC_A;CALIBDATASPEC_TPCIDC_C\" $CHANNELS_LIST --timeframes-shm-limit $TIMEFRAME_SHM_LIMIT" "" 0


### PR DESCRIPTION
@davidrohr , @martenole , @shahor02 : I fixed the indentation, but there was also a typo:
```
FLP_ADDRESS**+**="tcp://alicr1-flp-ib${flp}:${TPC_IDC_FLP_PORT}"
```
should have been:
```
FLP_ADDRESS="tcp://alicr1-flp-ib${flp}:${TPC_IDC_FLP_PORT}"
```