### PR TITLE
Implementation of the ITS OB Gamma Conversion Wire

### DIFF
--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/V3Layer.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/V3Layer.h
@@ -62,8 +62,6 @@ class V3Layer : public V11Geometry
   /// Default destructor
   ~V3Layer() override;
 
-  Bool_t hasGammaConversionRods() const { return mAddGammaConv; };
-
   Bool_t isTurbo() const { return mIsTurbo; };
 
   Double_t getChipThick() const { return mChipThickness; };
@@ -104,12 +102,6 @@ class V3Layer : public V11Geometry
 
   void setChipThick(Double_t t) { mChipThickness = t; };
 
-  /// Gets the Gamma Conversion Rod diameter
-  Double_t getGammaConversionRodDiam();
-
-  /// Gets the Gamma Conversion Rod X position
-  Double_t getGammaConversionRodXPos();
-
   /// Sets the Stave tilt angle (for turbo layers only)
   /// \param t The stave tilt angle
   void setStaveTilt(Double_t t);
@@ -137,11 +129,6 @@ class V3Layer : public V11Geometry
   void setBuildLevel(Int_t buildLevel) { mBuildLevel = buildLevel; }
 
   void setStaveModel(o2::its::Detector::Model model) { mStaveModel = model; }
-
-  /// Adds the Gamma Conversion Rods to the geometry
-  /// \param diam the diameter of each rod
-  /// \param xPos the X position of each rod
-  void addGammaConversionRods(const Double_t diam, const Double_t xPos);
 
   /// Creates the actual Layer and places inside its mother volume
   /// \param motherVolume the TGeoVolume owing the volume structure
@@ -335,10 +322,6 @@ class V3Layer : public V11Geometry
   Int_t mBuildLevel;  ///< Used for material studies
 
   Detector::Model mStaveModel; ///< The stave model
-
-  Bool_t mAddGammaConv;    ///< True to add Gamma Conversion Rods
-  Double_t mGammaConvDiam; ///< Gamma Conversion Rod Diameter
-  Double_t mGammaConvXPos; ///< Gamma Conversion Rod X Position
 
   // Dimensions computed during geometry build-up
   Double_t mIBModuleZLength; ///< IB Module Length along Z

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/V3Services.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/V3Services.h
@@ -97,6 +97,11 @@ class V3Services : public V11Geometry
   /// \param mgr  The GeoManager (used only to get the proper material)
   void createOBCYSSCylinder(TGeoVolume* mother, const TGeoManager* mgr = gGeoManager);
 
+  /// Creates the Outer Barrel Gamma Conversion Wire
+  /// \param mother the TGeoVolume owing the volume structure
+  /// \param mgr  The GeoManager (used only to get the proper material)
+  void createOBGammaConvWire(TGeoVolume* mother, const TGeoManager* mgr = gGeoManager);
+
  private:
   /// Creates a single Inner Barrel End Wheel on Side A
   /// \param iLay  the layer number
@@ -171,6 +176,11 @@ class V3Services : public V11Geometry
   /// \param mother  the volume containing the created wheel
   /// \param mgr  The GeoManager (used only to get the proper material)
   void obCYSS11(TGeoVolume* mother, const TGeoManager* mgr = gGeoManager);
+
+  /// Creates the Outer Barrel Gamma Conversion Wire
+  /// \param mother the TGeoVolume owing the volume structure
+  /// \param mgr  The GeoManager (used only to get the proper material)
+  void obConvWire(TGeoVolume* mother, const TGeoManager* mgr = gGeoManager);
 
   // Parameters
   static constexpr Int_t sNumberInnerLayers = 3; ///< Number of inner layers in ITSU

--- a/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
@@ -441,6 +441,12 @@ void Detector::createMaterials()
   Float_t wRohac[4] = {9., 13., 1., 2.};
   Float_t dRohac = 0.05;
 
+  // Brass CuZn39Pb3 (Cu Zn Pb)
+  Float_t aBrass[3] = {63.55, 65.41, 207.2};
+  Float_t zBrass[3] = {29., 30., 82.};
+  Float_t wBrass[3] = {0.58, 0.39, 0.03};
+  Float_t dBrass = 8.46;
+
   o2::base::Detector::Mixture(1, "AIR$", aAir, zAir, dAir, 4, wAir);
   o2::base::Detector::Medium(1, "AIR$", 1, 0, ifield, fieldm, tmaxfdAir, stemaxAir, deemaxAir, epsilAir, stminAir);
 
@@ -545,6 +551,14 @@ void Detector::createMaterials()
   // Tungsten (for gamma converter rods)
   o2::base::Detector::Material(28, "TUNGSTEN$", 183.84, 74, 19.25, 999, 999);
   o2::base::Detector::Medium(28, "TUNGSTEN$", 28, 0, ifield, fieldm, tmaxfdSi, stemaxSi, deemaxSi, epsilSi, stminSi);
+
+  // Brass CuZn39Pb3
+  o2::base::Detector::Mixture(34, "BRASS$", aBrass, zBrass, dBrass, 3, wBrass);
+  o2::base::Detector::Medium(34, "BRASS$", 34, 0, ifield, fieldm, tmaxfd, stemax, deemaxSi, epsilSi, stminSi);
+
+  // Titanium
+  o2::base::Detector::Material(35, "TITANIUM$", 47.867, 22, 4.506, 999, 999);
+  o2::base::Detector::Medium(35, "TITANIUM$", 35, 0, ifield, fieldm, tmaxfdSi, stemaxSi, deemaxSi, epsilSi, stminSi);
 }
 
 void Detector::EndOfEvent() { Reset(); }
@@ -892,6 +906,8 @@ void Detector::constructDetectorGeometry()
   createMiddlBarrelServices(wrapVols[1]);
   createOuterBarrelServices(wrapVols[2]);
   createOuterBarrelSupports(vITSV);
+
+  mServicesGeometry->createOBGammaConvWire(vITSV);
 
   // Finally create and place the cage
   V3Cage* cagePtr = new V3Cage();


### PR DESCRIPTION
The Tungsten wire located in the ITS Outer Barrel and used for the Gamma Conversion studies along with its metal supports have been implemented the O2 geometry following the latest blueprints. The new volumes are created inside the V3Services class. At the same time a previous, very old and experimental implementation of a similar wire has been removed from the V3Layer class.