### PR TITLE
[EMCAL-798] Reject calib. events in offline calib

### DIFF
--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/OfflineCalibSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/OfflineCalibSpec.h
@@ -36,7 +36,8 @@ class OfflineCalibSpec : public framework::Task
  public:
   /// \brief Constructor
   /// \param makeCellIDTimeEnergy If true the THnSparseF of cell ID, time, and energy is made
-  OfflineCalibSpec(bool makeCellIDTimeEnergy) : mMakeCellIDTimeEnergy(makeCellIDTimeEnergy){};
+  /// \param rejectCalibTriggers if true, only events which have the o2::trigger::PhT flag will be taken into account
+  OfflineCalibSpec(bool makeCellIDTimeEnergy, bool rejectCalibTriggers) : mMakeCellIDTimeEnergy(makeCellIDTimeEnergy), mRejectCalibTriggers(rejectCalibTriggers){};
 
   /// \brief Destructor
   ~OfflineCalibSpec() override = default;
@@ -61,12 +62,13 @@ class OfflineCalibSpec : public framework::Task
   std::unique_ptr<TH1> mNevents;               ///< Number of events
   std::unique_ptr<THnSparseF> mCellTimeEnergy; ///< ID, time, energy
   bool mMakeCellIDTimeEnergy = true;           ///< Switch whether or not to make a THnSparseF of cell ID, time, and energy
+  bool mRejectCalibTriggers = true;            ///< Switch to select if calib triggerred events should be rejected
 };
 
 /// \brief Creating offline calib spec
 /// \ingroup EMCALworkflow
 ///
-o2::framework::DataProcessorSpec getEmcalOfflineCalibSpec(bool makeCellIDTimeEnergy);
+o2::framework::DataProcessorSpec getEmcalOfflineCalibSpec(bool makeCellIDTimeEnergy, bool rejectCalibTriggers);
 
 } // namespace emcal
 

--- a/Detectors/EMCAL/workflow/src/emc-offline-calib-workflow.cxx
+++ b/Detectors/EMCAL/workflow/src/emc-offline-calib-workflow.cxx
@@ -22,6 +22,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   // option allowing to set parameters
   std::vector<ConfigParamSpec> options{{"makeCellIDTimeEnergy", VariantType::Bool, true, {"list whether or not to make the cell ID, time, energy THnSparse"}},
+                                       {"no-rejectCalibTrigg", VariantType::Bool, false, {"if set to true, all events, including calibration triggered events, will be accepted"}},
                                        {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
   workflowOptions.insert(workflowOptions.end(), options.begin(), options.end());
 }
@@ -35,7 +36,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   WorkflowSpec wf;
   // Update the (declared) parameters if changed from the command line
   bool makeCellIDTimeEnergy = cfgc.options().get<bool>("makeCellIDTimeEnergy");
+  bool rejectCalibTrigg = !cfgc.options().get<bool>("no-rejectCalibTrigg");
   o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
-  wf.emplace_back(o2::emcal::getEmcalOfflineCalibSpec(makeCellIDTimeEnergy));
+  wf.emplace_back(o2::emcal::getEmcalOfflineCalibSpec(makeCellIDTimeEnergy, rejectCalibTrigg));
   return wf;
 }


### PR DESCRIPTION
- calibration events are currently mixed with physics events in the emcal offline calibrator
- implemented switch to reject these calibration events
- rejection is on by default (cases where one wants the calib events are rare)