### PR TITLE
add protection in TOF digitization when wrong calib are passed

### DIFF
--- a/Detectors/TOF/simulation/src/Digitizer.cxx
+++ b/Detectors/TOF/simulation/src/Digitizer.cxx
@@ -289,7 +289,12 @@ void Digitizer::addDigit(Int_t channel, UInt_t istrip, Double_t time, Float_t x,
   time += TMath::Sqrt(timewalkX * timewalkX + timewalkZ * timewalkZ) - mTimeDelayCorr - mTimeWalkeSlope * 2;
 
   // Decalibrate
-  time -= mCalibApi->getTimeDecalibration(channel, tot); //TODO:  to be checked that "-" is correct, and we did not need "+" instead :-)
+  float tsCorr = mCalibApi->getTimeDecalibration(channel, tot);
+  if (TMath::Abs(tsCorr) > 200E3) { // accept correction up to 200 ns
+    LOG(error) << "Wrong de-calibration correction for ch = " << channel << ", tot = " << tot << " (Skip it)";
+    return;
+  }
+  time -= tsCorr; // TODO:  to be checked that "-" is correct, and we did not need "+" instead :-)
 
   // let's move from time to bc, tdc
 


### PR DESCRIPTION
This should fix the problem with nightlies.
@sawenzel @chiarazampolli

The problem was trigger by few channels with unrealistic decalibration values (corrupted object in ccdb will be fixed as well).
In any case I added a protection to skip such cases and printing a message in the log