### PR TITLE
FST MC->Raw files are produced by CRU end point

### DIFF
--- a/Detectors/CPV/simulation/src/RawCreator.cxx
+++ b/Detectors/CPV/simulation/src/RawCreator.cxx
@@ -48,7 +48,7 @@ int main(int argc, const char** argv)
     add_option("help,h", "Print this help message");
     add_option("verbose,v", bpo::value<uint32_t>()->default_value(0), "Select verbosity level [0 = no output]");
     add_option("input-file,i", bpo::value<std::string>()->default_value("cpvdigits.root"), "Specifies digit input file.");
-    add_option("file-for,f", bpo::value<std::string>()->default_value("all"), "single file per: all,cru,link");
+    add_option("file-for,f", bpo::value<std::string>()->default_value("all"), "single file per: all,cruendpoint,link");
     add_option("output-dir,o", bpo::value<std::string>()->default_value("./"), "output directory for raw data");
     add_option("debug,d", bpo::value<uint32_t>()->default_value(0), "Select debug output level [0 = no debug output]");
     add_option("hbfutils-config,u", bpo::value<std::string>()->default_value(std::string(o2::base::NameConf::DIGITIZATIONCONFIGFILE)), "config file for HBFUtils (or none)");
@@ -97,7 +97,7 @@ int main(int argc, const char** argv)
   TTreeReaderValue<std::vector<o2::cpv::TriggerRecord>> triggerbranch(*treereader, "CPVDigitTrigRecords");
 
   o2::cpv::RawWriter::FileFor_t granularity = o2::cpv::RawWriter::FileFor_t::kFullDet;
-  if ((filefor == "all") || (filefor == "cru")) { // CPV has only 1 cru so "all" is identical to "cru"
+  if ((filefor == "all") || (filefor == "cruendpoint")) { // CPV has only 1 cru so "all" is identical to "cruendpoint"
     granularity = o2::cpv::RawWriter::FileFor_t::kFullDet;
   } else if (filefor == "link") {
     granularity = o2::cpv::RawWriter::FileFor_t::kLink;

--- a/Detectors/CTP/simulation/src/digi2raw.cxx
+++ b/Detectors/CTP/simulation/src/digi2raw.cxx
@@ -44,7 +44,7 @@ int main(int argc, char** argv)
     add_option("verbosity,v", bpo::value<int>()->default_value(0), "verbosity level");
     //    add_option("input-file,i", bpo::value<std::string>()->default_value(o2::base::NameConf::getDigitsFileName(o2::detectors::DetID::CTP)),"input CTP digits file"); // why not used?
     add_option("input-file,i", bpo::value<std::string>()->default_value("ctpdigits.root"), "input CTP digits file");
-    add_option("file-for,f", bpo::value<std::string>()->default_value("all"), "single file per: all,link,cru");
+    add_option("file-for,f", bpo::value<std::string>()->default_value("all"), "single file per: all,link,cruendpoint");
     add_option("output-dir,o", bpo::value<std::string>()->default_value("./"), "output directory for raw data");
     uint32_t defRDH = o2::raw::RDHUtils::getVersion<o2::header::RAWDataHeader>();
     add_option("rdh-version,r", bpo::value<uint32_t>()->default_value(defRDH), "RDH version to use");

--- a/Detectors/FIT/FDD/simulation/src/digit2raw.cxx
+++ b/Detectors/FIT/FDD/simulation/src/digit2raw.cxx
@@ -49,7 +49,7 @@ int main(int argc, char** argv)
     //    add_option("input-file,i", bpo::value<std::string>()->default_value(o2::base::NameConf::getDigitsFileName(o2::detectors::DetID::FDD)),"input FDD digits file"); // why not used?
     add_option("input-file,i", bpo::value<std::string>()->default_value("fdddigits.root"), "input FDD digits file");
     add_option("flp-name", bpo::value<std::string>()->default_value("alio2-cr1-flp201"), "single file per: all,flp,cru,link"); // temporary, beacause FIT deployed only on one node
-    add_option("file-for,f", bpo::value<std::string>()->default_value("all"), "single file per: all,flp,cru,link");
+    add_option("file-for,f", bpo::value<std::string>()->default_value("all"), "single file per: all,flp,cruendpoint,link");
     add_option("output-dir,o", bpo::value<std::string>()->default_value("./"), "output directory for raw data");
     uint32_t defRDH = o2::raw::RDHUtils::getVersion<o2::header::RAWDataHeader>();
     add_option("rdh-version,r", bpo::value<uint32_t>()->default_value(defRDH), "RDH version to use");

--- a/Detectors/FIT/FT0/simulation/src/digit2raw.cxx
+++ b/Detectors/FIT/FT0/simulation/src/digit2raw.cxx
@@ -44,7 +44,7 @@ int main(int argc, char** argv)
     //    add_option("input-file,i", bpo::value<std::string>()->default_value(o2::base::NameConf::getDigitsFileName(o2::detectors::DetID::FT0)),"input FT0 digits file"); // why not used?
     add_option("input-file,i", bpo::value<std::string>()->default_value("ft0digits.root"), "input FT0 digits file");
     add_option("flp-name", bpo::value<std::string>()->default_value("alio2-cr1-flp200"), "single file per: all,flp,cru,link");
-    add_option("file-for,f", bpo::value<std::string>()->default_value("all"), "single file per: all,flp,cru,link");
+    add_option("file-for,f", bpo::value<std::string>()->default_value("all"), "single file per: all,flp,cruendpoint,link");
     add_option("output-dir,o", bpo::value<std::string>()->default_value("./"), "output directory for raw data");
     uint32_t defRDH = o2::raw::RDHUtils::getVersion<o2::header::RAWDataHeader>();
     add_option("rdh-version,r", bpo::value<uint32_t>()->default_value(defRDH), "RDH version to use");

--- a/Detectors/FIT/FV0/simulation/src/digit2raw.cxx
+++ b/Detectors/FIT/FV0/simulation/src/digit2raw.cxx
@@ -43,7 +43,7 @@ int main(int argc, char** argv)
     add_option("verbosity,v", bpo::value<int>()->default_value(0), "verbosity level");
     //    add_option("input-file,i", bpo::value<std::string>()->default_value(o2::base::NameConf::getDigitsFileName(o2::detectors::DetID::FV0)),"input FV0 digits file"); // why not used?
     add_option("input-file,i", bpo::value<std::string>()->default_value("fv0digits.root"), "input FV0 digits file");
-    add_option("flp-name", bpo::value<std::string>()->default_value("alio2-cr1-flp180"), "single file per: all,flp,cru,link");
+    add_option("flp-name", bpo::value<std::string>()->default_value("alio2-cr1-flp180"), "single file per: all,flp,cruendpoint,link");
     add_option("file-for,f", bpo::value<std::string>()->default_value("all"), "single file per: all,flp,cru,link");
     add_option("output-dir,o", bpo::value<std::string>()->default_value("./"), "output directory for raw data");
     uint32_t defRDH = o2::raw::RDHUtils::getVersion<o2::header::RAWDataHeader>();

--- a/Detectors/FIT/raw/include/FITRaw/RawWriterFIT.h
+++ b/Detectors/FIT/raw/include/FITRaw/RawWriterFIT.h
@@ -77,7 +77,7 @@ class RawWriterFIT
         maskName += fmt::format("_{}", mFlpName);
         if (mFileFor != "flp") {
           maskName += fmt::format("_cru{}_{}", RDHUtils::getCRUID(rdh), RDHUtils::getEndPointID(rdh));
-          if (mFileFor != "cru") {
+          if (mFileFor != "cruendpoint") {
             maskName += fmt::format("_lnk{}_feeid{}", RDHUtils::getLinkID(rdh), RDHUtils::getFEEID(rdh));
             if (mFileFor != "link") {
               throw std::runtime_error("invalid option provided for file grouping");

--- a/Detectors/HMPID/simulation/src/HmpidCoder2.cxx
+++ b/Detectors/HMPID/simulation/src/HmpidCoder2.cxx
@@ -254,7 +254,7 @@ void HmpidCoder2::openOutputStream(const std::string& outputFileName, const std:
       outfname = fmt::format("{}_{}.raw", outputFileName, ReadOut::FlpHostName(eq));
     } else if (fileFor == "all") {
       outfname = fmt::format("{}.raw", outputFileName);
-    } else if (fileFor == "cru") {
+    } else if (fileFor == "crorcendpoint") {
       outfname = fmt::format("{}_{}_crorc{}_{}.raw", outputFileName, ReadOut::FlpHostName(eq), int(rdh.cruID), int(rdh.linkID));
     } else {
       throw std::runtime_error(fmt::format("unknown raw file grouping option {}", fileFor));

--- a/Detectors/HMPID/workflow/src/DigitsToRawSpec.cxx
+++ b/Detectors/HMPID/workflow/src/DigitsToRawSpec.cxx
@@ -197,7 +197,7 @@ o2::framework::DataProcessorSpec getDigitsToRawSpec()
     outputs,
     AlgorithmSpec{adaptFromTask<DigitsToRawSpec>()},
     Options{{"outdir", VariantType::String, "./", {"base dir for output file"}},
-            {"file-for", VariantType::String, "all", {"single file per: all,flp,link,cru"}},
+            {"file-for", VariantType::String, "all", {"single file per: all,flp,link,crorcendpoint"}},
             {"outfile", VariantType::String, "HMP", {"base name for output file"}},
             {"in-file", VariantType::String, "hmpiddigits.root", {"name of the input sim root file"}},
             {"dump-digits", VariantType::Bool, false, {"out the digits file in /tmp/hmpDumpDigits.dat"}},

--- a/Detectors/ITSMFT/ITS/simulation/src/digi2raw.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/digi2raw.cxx
@@ -59,7 +59,7 @@ int main(int argc, char** argv)
     add_option("help,h", "Print this help message");
     add_option("verbosity,v", bpo::value<uint32_t>()->default_value(0), "verbosity level [0 = no output]");
     add_option("input-file,i", bpo::value<std::string>()->default_value("itsdigits.root"), "input ITS digits file");
-    add_option("file-for,f", bpo::value<std::string>()->default_value("all"), "single file per: all,flp,cru,link");
+    add_option("file-for,f", bpo::value<std::string>()->default_value("all"), "single file per: all,flp,cruendpoint,link");
     add_option("output-dir,o", bpo::value<std::string>()->default_value("./"), "output directory for raw data");
     add_option("rdh-version,r", bpo::value<uint32_t>()->default_value(DefRDHVersion), "RDH version to use");
     add_option("no-empty-hbf,e", bpo::value<bool>()->default_value(false)->implicit_value(true), "do not create empty HBF pages (except for HBF starting TF)");
@@ -446,7 +446,7 @@ void setupLinks(o2::itsmft::MC2RawEncoder<MAP>& m2r, std::string_view outDir, st
         outFileLink += fmt::format("_{}", ruhw.flp);
         if (fileFor != "flp") {
           outFileLink += fmt::format("_cru{}_{}", ruhw.cruHWID, link->endPointID);
-          if (fileFor != "cru") {
+          if (fileFor != "cruendpoint") {
             outFileLink += fmt::format("_lnk{}_feeid{}", link->idInCRU, link->feeID);
             if (fileFor != "link") {
               throw std::runtime_error("invalid option provided for file grouping");

--- a/Detectors/ITSMFT/MFT/simulation/src/digi2raw.cxx
+++ b/Detectors/ITSMFT/MFT/simulation/src/digi2raw.cxx
@@ -56,7 +56,7 @@ int main(int argc, char** argv)
     add_option("help,h", "Print this help message");
     add_option("verbosity,v", bpo::value<uint32_t>()->default_value(0), "verbosity level [0 = no output]");
     add_option("input-file,i", bpo::value<std::string>()->default_value("mftdigits.root"), "input  digits file");
-    add_option("file-for,f", bpo::value<std::string>()->default_value("layer"), "single file per: all,layer,cru,link");
+    add_option("file-for,f", bpo::value<std::string>()->default_value("layer"), "single file per: all,layer,cruendpoint,link");
     add_option("output-dir,o", bpo::value<std::string>()->default_value("./"), "output directory for raw data");
     uint32_t defRDH = o2::raw::RDHUtils::getVersion<o2::header::RAWDataHeader>();
     add_option("rdh-version,r", bpo::value<uint32_t>()->default_value(defRDH), "RDH version to use");
@@ -310,7 +310,7 @@ void setupLinks(o2::itsmft::MC2RawEncoder<MAP>& m2r, std::string_view outDir, st
       outFileLink += fmt::format("_{}", mftHWMap[ruID].flp);
       if (fileFor != "flp") {
         outFileLink += fmt::format("_cru{}_{}", mftHWMap[ruID].cruHWID, link->endPointID);
-        if (fileFor != "cru") {
+        if (fileFor != "cruendpoint") {
           outFileLink += fmt::format("_lnk{}_feeid{}", link->idInCRU, link->feeID);
           if (fileFor != "link") {
             throw std::runtime_error("invalid option provided for file grouping");

--- a/Detectors/MUON/MCH/Raw/Encoder/Digit/digits-to-raw.cxx
+++ b/Detectors/MUON/MCH/Raw/Encoder/Digit/digits-to-raw.cxx
@@ -55,7 +55,7 @@ int main(int argc, char* argv[])
       ("userLogic,u",po::bool_switch()->default_value(true),"user logic format")
       ("dummy-elecmap,d",po::bool_switch()->default_value(false),"use a dummy electronic mapping (for testing only, to be removed at some point)")
       ("output-dir,o",po::value<std::string>()->default_value("./"),"output directory for file(s)")
-      ("file-for,f", po::value<std::string>()->default_value("all"), "output one file (file-for=all), per link (file-for=link) or per cru end point (file-for=cru)")
+      ("file-for,f", po::value<std::string>()->default_value("all"), "output one file (file-for=all), per link (file-for=link) or per cru end point (file-for=cruendpoint)")
       ("input-file,i",po::value<std::string>(&input)->default_value("mchdigits.root"),"input file name")
       ("configKeyValues", po::value<std::string>()->default_value(""), "comma-separated configKeyValues")
       ("no-empty-hbf,e", po::value<bool>()->default_value(false), "do not create empty HBF pages (except for HBF starting TF)")
@@ -108,7 +108,7 @@ int main(int argc, char* argv[])
   auto fileFor = vm["file-for"].as<std::string>();
   if (fileFor == "link") {
     opts.splitMode = OutputSplit::PerLink;
-  } else if (fileFor == "cru") {
+  } else if (fileFor == "cruendpoint") {
     opts.splitMode = OutputSplit::PerCruEndpoint;
   } else if (fileFor == "all") {
     opts.splitMode = OutputSplit::None;

--- a/Detectors/MUON/MID/Raw/src/Encoder.cxx
+++ b/Detectors/MUON/MID/Raw/src/Encoder.cxx
@@ -56,7 +56,7 @@ void Encoder::init(std::string_view outDir, std::string_view fileFor, int verbos
         outFileLink += "_alio2-cr1-flp159";
         if (fileFor != "flp") {
           outFileLink += fmt::format("_cru{}_{}", cruId, epId);
-          if (fileFor != "cru") {
+          if (fileFor != "cruendpoint") {
             outFileLink += fmt::format("_lnk{}_feeid{}", raw::sUserLogicLinkID, feeId);
             if (fileFor != "link") {
               throw std::runtime_error("invalid option provided for file grouping");

--- a/Detectors/MUON/MID/Workflow/src/RawWriterSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/RawWriterSpec.cxx
@@ -97,7 +97,7 @@ framework::DataProcessorSpec getRawWriterSpec()
     of::AlgorithmSpec{of::adaptFromTask<o2::mid::RawWriterDeviceDPL>()},
     of::Options{
       {"mid-raw-outdir", of::VariantType::String, ".", {"Raw file output directory"}},
-      {"file-for", of::VariantType::String, "all", {"single file per: all,flp,cru,link"}},
+      {"file-for", of::VariantType::String, "all", {"single file per: all,flp,cruendpoint,link"}},
       {"mid-raw-header-offset", of::VariantType::Bool, false, {"Header offset in bytes"}}}};
 }
 } // namespace mid

--- a/Detectors/TOF/reconstruction/include/TOFReconstruction/Encoder.h
+++ b/Detectors/TOF/reconstruction/include/TOFReconstruction/Encoder.h
@@ -42,7 +42,7 @@ class Encoder
   Encoder();
   ~Encoder() = default;
 
-  bool open(const std::string& name, const std::string& path = ".", const std::string& fileFor = "cru");
+  bool open(const std::string& name, const std::string& path = ".", const std::string& fileFor = "cruendpoint");
   bool alloc(long size);
 
   bool encode(std::vector<std::vector<o2::tof::Digit>> digitWindow, int tofwindow = 0);

--- a/Detectors/TOF/reconstruction/src/Encoder.cxx
+++ b/Detectors/TOF/reconstruction/src/Encoder.cxx
@@ -82,7 +82,7 @@ bool Encoder::open(const std::string& name, const std::string& path, const std::
     if (mCrateOn[crateid]) {
       if (fileFor == "all") { // single file for all links
         outFileLink = o2::utils::Str::concat_string(path, "/TOF.raw");
-      } else if (fileFor == "cru") {
+      } else if (fileFor == "cruendpoint") {
         outFileLink = o2::utils::Str::concat_string(path, "/", "TOF_alio2-cr1-flp", std::to_string(Geo::getFLPid(crateid)), "_cru", std::to_string(Geo::getCRUid(crateid)), "_", std::to_string(Geo::getCRUendpoint(crateid)), ".raw");
       } else if (fileFor == "link") {
         outFileLink = o2::utils::Str::concat_string(path, "/", "TOF_alio2-cr1-flp", std::to_string(Geo::getFLPid(crateid)), "_cru", std::to_string(Geo::getCRUid(crateid)), "_", std::to_string(Geo::getCRUendpoint(crateid)), "_link", std::to_string(RDHUtils::getLinkID(rdh)), ".raw");

--- a/Detectors/TOF/workflowIO/src/TOFRawWriterSpec.cxx
+++ b/Detectors/TOF/workflowIO/src/TOFRawWriterSpec.cxx
@@ -119,7 +119,7 @@ DataProcessorSpec getTOFRawWriterSpec()
     Options{
       {"tof-raw-outfile", VariantType::String, "tof.raw", {"Name of the output file"}},
       {"tof-raw-outdir", VariantType::String, ".", {"Name of the output dir"}},
-      {"file-for", VariantType::String, "cru", {"Single file per: all,cru,link"}}}};
+      {"file-for", VariantType::String, "cruendpoint", {"Single file per: all,cruendpoint,link"}}}};
 }
 } // namespace tof
 } // namespace o2

--- a/Detectors/TPC/workflow/src/convertDigitsToRawZS.cxx
+++ b/Detectors/TPC/workflow/src/convertDigitsToRawZS.cxx
@@ -150,7 +150,7 @@ void convertDigitsToZSfinal(std::string_view digitsFile, std::string_view output
         outfname = fmt::format("{}tpc_all.raw", outDir);
       } else if (fileFor == "sector") {
         outfname = i == NSectors ? fmt::format("{}tpc_iac.raw", outDir) : fmt::format("{}tpc_sector{}.raw", outDir, i);
-      } else if (fileFor == "link" || fileFor == "cru") {
+      } else if (fileFor == "link" || fileFor == "cruendpoint") {
         outfname = fmt::format("{}TPC_{}_cru{}_{}.raw", outDir, CRU_FLPS[cruID], cruID, j & 1);
       } else {
         throw std::runtime_error("invalid option provided for file grouping");
@@ -257,7 +257,7 @@ int main(int argc, char** argv)
     add_option("output-dir,o", bpo::value<std::string>()->default_value("./"), "Specify output directory");
     add_option("no-parent-directories,n", "Do not create parent directories recursively");
     add_option("sector-by-sector,s", bpo::value<bool>()->default_value(false)->implicit_value(true), "Run one TPC sector after another");
-    add_option("file-for,f", bpo::value<std::string>()->default_value("sector"), "single file per: link,sector,cru,all");
+    add_option("file-for,f", bpo::value<std::string>()->default_value("sector"), "single file per: link,sector,cruendpoint,all");
     add_option("stop-page,p", bpo::value<bool>()->default_value(false)->implicit_value(true), "HBF stop on separate CRU page");
     add_option("padding", bpo::value<bool>()->default_value(false)->implicit_value(true), "Pad all pages to 8kb");
     uint32_t defRDH = o2::raw::RDHUtils::getVersion<o2::header::RAWDataHeader>();

--- a/Detectors/TRD/simulation/src/Trap2CRU.cxx
+++ b/Detectors/TRD/simulation/src/Trap2CRU.cxx
@@ -261,10 +261,10 @@ void Trap2CRU::readTrapData()
       ss << std::setw(2) << std::setfill('0') << sm;
       std::string supermodule = ss.str();
       outFileLink = o2::utils::Str::concat_string(mOutputDir, "/", outPrefix, "_sm_", supermodule, outSuffix);
-    } else if (mFilePer == "fullcru") {
+    } else if (mFilePer == "cru") {
       // one file per CRU (both end points combined)
       outFileLink = o2::utils::Str::concat_string(mOutputDir, "/", outPrefix, std::to_string(flpid), "_cru", std::to_string(cruhwid), outSuffix);
-    } else if (mFilePer == "cru") {
+    } else if (mFilePer == "cruendpoint") {
       // one file per CRU end point
       outFileLink = o2::utils::Str::concat_string(mOutputDir, "/", outPrefix, std::to_string(flpid), "_cru", std::to_string(cruhwid), "_", std::to_string(mEndPointID), outSuffix);
     } else {

--- a/Detectors/TRD/simulation/src/trap2raw.cxx
+++ b/Detectors/TRD/simulation/src/trap2raw.cxx
@@ -57,7 +57,7 @@ int main(int argc, char** argv)
     add_option("verbosity,v", bpo::value<int>()->default_value(0), "verbosity level");
     add_option("input-file-digits,d", bpo::value<std::string>()->default_value("trddigits.root"), "input Trapsim digits file");
     add_option("input-file-tracklets,t", bpo::value<std::string>()->default_value("trdtracklets.root"), "input Trapsim tracklets file");
-    add_option("file-per,l", bpo::value<std::string>()->default_value("halfcru"), "all : raw file(false), halfcru : cru end point, cru : one file per cru, sm: one file per supermodule");
+    add_option("file-for,l", bpo::value<std::string>()->default_value("cruendpoint"), "all : raw file(false), cruendpoint : cru end point, cru : one file per cru, sm: one file per supermodule");
     add_option("output-dir,o", bpo::value<std::string>()->default_value("./"), "output directory for raw data");
     add_option("tracklethcheader,x", bpo::value<int>()->default_value(2), "include tracklet half chamber header (for run3). 0 never, 1 if there is tracklet data, 2 always");
     add_option("no-empty-hbf,e", bpo::value<bool>()->default_value(false)->implicit_value(true), "do not create empty HBF pages (except for HBF starting TF)");
@@ -91,7 +91,7 @@ int main(int argc, char** argv)
 
   const auto& hbfu = o2::raw::HBFUtils::Instance(); // we need the creation time for the link mapping from CCDB
 
-  trap2raw(vm["input-file-digits"].as<std::string>(), vm["input-file-tracklets"].as<std::string>(), vm["output-dir"].as<std::string>(), vm["verbosity"].as<int>(), vm["file-per"].as<std::string>(), vm["rdh-version"].as<uint32_t>(), vm["no-empty-hbf"].as<bool>(), vm["tracklethcheader"].as<int>(), 1024 * 1024, hbfu.startTime);
+  trap2raw(vm["input-file-digits"].as<std::string>(), vm["input-file-tracklets"].as<std::string>(), vm["output-dir"].as<std::string>(), vm["verbosity"].as<int>(), vm["file-for"].as<std::string>(), vm["rdh-version"].as<uint32_t>(), vm["no-empty-hbf"].as<bool>(), vm["tracklethcheader"].as<int>(), 1024 * 1024, hbfu.startTime);
 
   return 0;
 }

--- a/Detectors/ZDC/simulation/src/Digits2Raw.cxx
+++ b/Detectors/ZDC/simulation/src/Digits2Raw.cxx
@@ -68,7 +68,7 @@ void Digits2Raw::processDigits(const std::string& outDir, const std::string& fil
       outFileLink += fmt::format("_{}", mFLP);
       if (mFileFor != "flp") {
         outFileLink += fmt::format("_cru{}_{}", mCruID, mEndPointID);
-        if (mFileFor != "cru") {
+        if (mFileFor != "cruendpoint") {
           outFileLink += fmt::format("_lnk{}_feeid{}", ilink, FeeID);
           if (mFileFor != "link") {
             LOG(fatal) << "Not supported output file splitting: " << mFileFor;

--- a/Detectors/ZDC/simulation/src/digi2raw.cxx
+++ b/Detectors/ZDC/simulation/src/digi2raw.cxx
@@ -56,7 +56,7 @@ int main(int argc, char** argv)
     add_option("verbosity,v", bpo::value<int>()->default_value(0), "verbosity level");
     //    add_option("input-file,i", bpo::value<std::string>()->default_value(o2::base::NameConf::getDigitsFileName(o2::detectors::DetID::ZDC)),"input ZDC digits file"); // why not used?
     add_option("input-file,i", bpo::value<std::string>()->default_value("zdcdigits.root"), "input ZDC digits file");
-    add_option("file-for,f", bpo::value<std::string>()->default_value("all"), "single file per: all,flp,cru,link");
+    add_option("file-for,f", bpo::value<std::string>()->default_value("all"), "single file per: all,flp,cruendpoint,link");
     add_option("output-dir,o", bpo::value<std::string>()->default_value("./"), "output directory for raw data");
     uint32_t defRDH = o2::raw::RDHUtils::getVersion<o2::header::RAWDataHeader>();
     add_option("rdh-version,r", bpo::value<uint32_t>()->default_value(defRDH), "RDH version to use");

--- a/prodtests/full-system-test/create_full_system_pipeline.py
+++ b/prodtests/full-system-test/create_full_system_pipeline.py
@@ -3,6 +3,9 @@
 # A script producing a consistent full-system-test workflow.
 # Python used for convenient json handling but this is completely up to the workflow writer.
 #
+# WARNING: THIS SCRIPT IS CURRENTLY OUTDATED AND SHOULD BE MADE CONSISTENT WITH full_system_test.sh BEFORE USING IT AGAIN
+#
+#
 from os import environ
 import json
 

--- a/prodtests/full_system_test.sh
+++ b/prodtests/full_system_test.sh
@@ -135,22 +135,22 @@ if [ "0$GENERATE_ITSMFT_DICTIONARIES" == "01" ]; then
 fi
 
 mkdir -p raw
-taskwrapper itsraw.log o2-its-digi2raw --file-for cru -o raw/ITS
-taskwrapper mftraw.log o2-mft-digi2raw --file-for cru -o raw/MFT
-taskwrapper ft0raw.log o2-ft0-digi2raw --file-for cru -o raw/FT0
-taskwrapper fv0raw.log o2-fv0-digi2raw --file-for cru -o raw/FV0
-taskwrapper fddraw.log o2-fdd-digit2raw --file-for cru -o raw/FDD
-taskwrapper tpcraw.log o2-tpc-digits-to-rawzs --zs-version ${FST_TPC_ZSVERSION} --file-for cru -i tpcdigits.root -o raw/TPC
-taskwrapper tofraw.log o2-tof-reco-workflow ${GLOBALDPLOPT} --file-for cru --output-type raw --tof-raw-outdir raw/TOF
-taskwrapper midraw.log o2-mid-digits-to-raw-workflow ${GLOBALDPLOPT} --mid-raw-outdir raw/MID --file-for cru
-taskwrapper mchraw.log o2-mch-digits-to-raw --input-file mchdigits.root --output-dir raw/MCH --file-for cru
+taskwrapper itsraw.log o2-its-digi2raw --file-for cruendpoint -o raw/ITS
+taskwrapper mftraw.log o2-mft-digi2raw --file-for cruendpoint -o raw/MFT
+taskwrapper ft0raw.log o2-ft0-digi2raw --file-for cruendpoint -o raw/FT0
+taskwrapper fv0raw.log o2-fv0-digi2raw --file-for cruendpoint -o raw/FV0
+taskwrapper fddraw.log o2-fdd-digit2raw --file-for cruendpoint -o raw/FDD
+taskwrapper tpcraw.log o2-tpc-digits-to-rawzs --zs-version ${FST_TPC_ZSVERSION} --file-for cruendpoint -i tpcdigits.root -o raw/TPC
+taskwrapper tofraw.log o2-tof-reco-workflow ${GLOBALDPLOPT} --file-for cruendpoint --output-type raw --tof-raw-outdir raw/TOF
+taskwrapper midraw.log o2-mid-digits-to-raw-workflow ${GLOBALDPLOPT} --mid-raw-outdir raw/MID --file-for cruendpoint
+taskwrapper mchraw.log o2-mch-digits-to-raw --input-file mchdigits.root --output-dir raw/MCH --file-for cruendpoint
 taskwrapper emcraw.log o2-emcal-rawcreator --file-for link -o raw/EMC
 taskwrapper phsraw.log o2-phos-digi2raw --file-for link -o raw/PHS
-taskwrapper cpvraw.log o2-cpv-digi2raw --file-for cru -o raw/CPV
-taskwrapper zdcraw.log o2-zdc-digi2raw --file-for cru -o raw/ZDC
-taskwrapper hmpraw.log o2-hmpid-digits-to-raw-workflow --file-for cru --outdir raw/HMP
-taskwrapper trdraw.log o2-trd-trap2raw -o raw/TRD --file-per cru
-taskwrapper ctpraw.log o2-ctp-digi2raw -o raw/CTP --file-for cru
+taskwrapper cpvraw.log o2-cpv-digi2raw --file-for cruendpoint -o raw/CPV
+taskwrapper zdcraw.log o2-zdc-digi2raw --file-for cruendpoint -o raw/ZDC
+taskwrapper hmpraw.log o2-hmpid-digits-to-raw-workflow --file-for crorcendpoint --outdir raw/HMP
+taskwrapper trdraw.log o2-trd-trap2raw -o raw/TRD --file-for cruendpoint
+taskwrapper ctpraw.log o2-ctp-digi2raw -o raw/CTP --file-for cruendpoint
 
 CHECK_DETECTORS_RAW="ITS MFT FT0 FV0 FDD TPC TOF MID MCH CPV ZDC TRD CTP"
 if [ $BEAMTYPE == "PbPb" ] && [ $NEvents -ge 5 ] ; then


### PR DESCRIPTION
When creating new synthetic data samples we noticed inconsistencies in the option naming scheme of different detectors.
By default, when creating raw data for readout at P2 we require the files per CRU end point. Thus the option `cru` used by most detectors to describe this has been changed to `cruendpoint`.
For HMPID I use `crorcendpoint` instead of `cru`. I did not use `link` as the other CROC detectors do, because that option is used by something else for HMPID.
Please let me know in case you have comments or prefer to keep the options as they are now. There was some initial discussion in https://github.com/AliceO2Group/AliceO2/pull/9822