### PR TITLE
[EMCAL-835] General error handling for invalid access in CCDB objects

### DIFF
--- a/Detectors/EMCAL/calib/CMakeLists.txt
+++ b/Detectors/EMCAL/calib/CMakeLists.txt
@@ -10,152 +10,152 @@
 # or submit itself to any jurisdiction.
 
 o2_add_library(EMCALCalib
-               SOURCES src/BadChannelMap.cxx
-                       src/TimeCalibrationParams.cxx
-                       src/TimeCalibParamL1Phase.cxx
-                       src/TempCalibrationParams.cxx
-                       src/TempCalibParamSM.cxx
-                       src/GainCalibrationFactors.cxx
-                       src/TriggerTRUDCS.cxx
-                       src/TriggerSTUDCS.cxx
-                       src/TriggerSTUErrorCounter.cxx
-                       src/TriggerDCS.cxx
-                       src/FeeDCS.cxx
-                       src/CalibDB.cxx
-                       src/ElmbMeasurement.cxx
-                       src/EMCALChannelScaleFactors.cxx
-               PUBLIC_LINK_LIBRARIES O2::CCDB O2::EMCALBase)
+        SOURCES src/CalibContainerErrors.cxx
+        src/BadChannelMap.cxx
+        src/TimeCalibrationParams.cxx
+        src/TimeCalibParamL1Phase.cxx
+        src/TempCalibrationParams.cxx
+        src/TempCalibParamSM.cxx
+        src/GainCalibrationFactors.cxx
+        src/TriggerTRUDCS.cxx
+        src/TriggerSTUDCS.cxx
+        src/TriggerSTUErrorCounter.cxx
+        src/TriggerDCS.cxx
+        src/FeeDCS.cxx
+        src/CalibDB.cxx
+        src/ElmbMeasurement.cxx
+        src/EMCALChannelScaleFactors.cxx
+        PUBLIC_LINK_LIBRARIES O2::CCDB O2::EMCALBase)
 
 o2_target_root_dictionary(EMCALCalib
-                          HEADERS include/EMCALCalib/BadChannelMap.h
-                                  include/EMCALCalib/TimeCalibrationParams.h
-                                  include/EMCALCalib/TimeCalibParamL1Phase.h
-                                  include/EMCALCalib/TempCalibrationParams.h
-                                  include/EMCALCalib/TempCalibParamSM.h
-                                  include/EMCALCalib/GainCalibrationFactors.h
-                                  include/EMCALCalib/TriggerTRUDCS.h
-                                  include/EMCALCalib/TriggerSTUDCS.h
-                                  include/EMCALCalib/TriggerSTUErrorCounter.h
-                                  include/EMCALCalib/TriggerDCS.h
-                                  include/EMCALCalib/FeeDCS.h
-                                  include/EMCALCalib/CalibDB.h
-                                  include/EMCALCalib/ElmbData.h
-                                  include/EMCALCalib/ElmbMeasurement.h
-                                  include/EMCALCalib/EMCALChannelScaleFactors.h
-                          LINKDEF src/EMCALCalibLinkDef.h)
+        HEADERS include/EMCALCalib/BadChannelMap.h
+        include/EMCALCalib/TimeCalibrationParams.h
+        include/EMCALCalib/TimeCalibParamL1Phase.h
+        include/EMCALCalib/TempCalibrationParams.h
+        include/EMCALCalib/TempCalibParamSM.h
+        include/EMCALCalib/GainCalibrationFactors.h
+        include/EMCALCalib/TriggerTRUDCS.h
+        include/EMCALCalib/TriggerSTUDCS.h
+        include/EMCALCalib/TriggerSTUErrorCounter.h
+        include/EMCALCalib/TriggerDCS.h
+        include/EMCALCalib/FeeDCS.h
+        include/EMCALCalib/CalibDB.h
+        include/EMCALCalib/ElmbData.h
+        include/EMCALCalib/ElmbMeasurement.h
+        include/EMCALCalib/EMCALChannelScaleFactors.h
+        LINKDEF src/EMCALCalibLinkDef.h)
 
 o2_add_test(BadChannelMap
-            SOURCES test/testBadChannelMap.cxx
-            PUBLIC_LINK_LIBRARIES O2::EMCALCalib
-            COMPONENT_NAME emcal
-            LABELS emcal)
+        SOURCES test/testBadChannelMap.cxx
+        PUBLIC_LINK_LIBRARIES O2::EMCALCalib
+        COMPONENT_NAME emcal
+        LABELS emcal)
 
 o2_add_test(TimeCalibrationParams
-            SOURCES test/testTimeCalibration.cxx
-            PUBLIC_LINK_LIBRARIES O2::EMCALCalib
-            COMPONENT_NAME emcal
-            LABELS emcal
-            ENVIRONMENT O2_ROOT=${CMAKE_BINARY_DIR}/stage)
+        SOURCES test/testTimeCalibration.cxx
+        PUBLIC_LINK_LIBRARIES O2::EMCALCalib
+        COMPONENT_NAME emcal
+        LABELS emcal
+        ENVIRONMENT O2_ROOT=${CMAKE_BINARY_DIR}/stage)
 
 o2_add_test(TimeCalibParamL1Phase
-            SOURCES test/testTimeL1PhaseCalib.cxx
-            PUBLIC_LINK_LIBRARIES O2::EMCALCalib
-            COMPONENT_NAME emcal
-            LABELS emcal
-            ENVIRONMENT O2_ROOT=${CMAKE_BINARY_DIR}/stage)
+        SOURCES test/testTimeL1PhaseCalib.cxx
+        PUBLIC_LINK_LIBRARIES O2::EMCALCalib
+        COMPONENT_NAME emcal
+        LABELS emcal
+        ENVIRONMENT O2_ROOT=${CMAKE_BINARY_DIR}/stage)
 
 o2_add_test(TempCalibrationParams
-            SOURCES test/testTempCalibration.cxx
-            PUBLIC_LINK_LIBRARIES O2::EMCALCalib
-            COMPONENT_NAME emcal
-            LABELS emcal
-            ENVIRONMENT O2_ROOT=${CMAKE_BINARY_DIR}/stage)
+        SOURCES test/testTempCalibration.cxx
+        PUBLIC_LINK_LIBRARIES O2::EMCALCalib
+        COMPONENT_NAME emcal
+        LABELS emcal
+        ENVIRONMENT O2_ROOT=${CMAKE_BINARY_DIR}/stage)
 
 o2_add_test(TempCalibParamSM
-            SOURCES test/testTempCalibrationSM.cxx
-            PUBLIC_LINK_LIBRARIES O2::EMCALCalib
-            COMPONENT_NAME emcal
-            LABELS emcal
-            ENVIRONMENT O2_ROOT=${CMAKE_BINARY_DIR}/stage)
+        SOURCES test/testTempCalibrationSM.cxx
+        PUBLIC_LINK_LIBRARIES O2::EMCALCalib
+        COMPONENT_NAME emcal
+        LABELS emcal
+        ENVIRONMENT O2_ROOT=${CMAKE_BINARY_DIR}/stage)
 
 o2_add_test(GainCalibrationFactors
-            SOURCES test/testGainCalibration.cxx
-            PUBLIC_LINK_LIBRARIES O2::EMCALCalib
-            COMPONENT_NAME emcal
-            LABELS emcal
-            ENVIRONMENT O2_ROOT=${CMAKE_BINARY_DIR}/stage)
+        SOURCES test/testGainCalibration.cxx
+        PUBLIC_LINK_LIBRARIES O2::EMCALCalib
+        COMPONENT_NAME emcal
+        LABELS emcal
+        ENVIRONMENT O2_ROOT=${CMAKE_BINARY_DIR}/stage)
 
 o2_add_test(TriggerTRUDCS
-            SOURCES test/testTriggerTRUDCS.cxx
-            PUBLIC_LINK_LIBRARIES O2::EMCALCalib
-            COMPONENT_NAME emcal
-            LABELS emcal)
+        SOURCES test/testTriggerTRUDCS.cxx
+        PUBLIC_LINK_LIBRARIES O2::EMCALCalib
+        COMPONENT_NAME emcal
+        LABELS emcal)
 
 o2_add_test(TriggerSTUDCS
-            SOURCES test/testTriggerSTUDCS.cxx
-            PUBLIC_LINK_LIBRARIES O2::EMCALCalib
-            COMPONENT_NAME emcal
-            LABELS emcal)
+        SOURCES test/testTriggerSTUDCS.cxx
+        PUBLIC_LINK_LIBRARIES O2::EMCALCalib
+        COMPONENT_NAME emcal
+        LABELS emcal)
 
 o2_add_test(TriggerSTUErrorCounter
-            SOURCES test/testTriggerSTUErrorCounter.cxx
-            PUBLIC_LINK_LIBRARIES O2::EMCALCalib
-            COMPONENT_NAME emcal
-            LABELS emcal)
+        SOURCES test/testTriggerSTUErrorCounter.cxx
+        PUBLIC_LINK_LIBRARIES O2::EMCALCalib
+        COMPONENT_NAME emcal
+        LABELS emcal)
 
 o2_add_test(TriggerDCS
-            SOURCES test/testTriggerDCS.cxx
-            PUBLIC_LINK_LIBRARIES O2::EMCALCalib
-            COMPONENT_NAME emcal
-            LABELS emcal)
+        SOURCES test/testTriggerDCS.cxx
+        PUBLIC_LINK_LIBRARIES O2::EMCALCalib
+        COMPONENT_NAME emcal
+        LABELS emcal)
 
 o2_add_test_root_macro(macros/BadChannelMap_CCDBApitest.C
-            PUBLIC_LINK_LIBRARIES O2::EMCALCalib
-            LABELS emcal COMPILE_ONLY)
+        PUBLIC_LINK_LIBRARIES O2::EMCALCalib
+        LABELS emcal COMPILE_ONLY)
 
 o2_add_test_root_macro(macros/BadChannelMap_CalibDBtest.C
-            PUBLIC_LINK_LIBRARIES O2::EMCALCalib
-            LABELS emcal COMPILE_ONLY)
+        PUBLIC_LINK_LIBRARIES O2::EMCALCalib
+        LABELS emcal COMPILE_ONLY)
 
 o2_add_test_root_macro(macros/TimeCalibrationParams_CCDBApiTest.C
-            PUBLIC_LINK_LIBRARIES O2::EMCALCalib
-            LABELS emcal COMPILE_ONLY)
+        PUBLIC_LINK_LIBRARIES O2::EMCALCalib
+        LABELS emcal COMPILE_ONLY)
 
 o2_add_test_root_macro(macros/TimeCalibrationParams_CalibDBTest.C
-            PUBLIC_LINK_LIBRARIES O2::EMCALCalib
-            LABELS emcal COMPILE_ONLY)
+        PUBLIC_LINK_LIBRARIES O2::EMCALCalib
+        LABELS emcal COMPILE_ONLY)
 
 o2_add_test_root_macro(macros/TimeCalibParamsL1Phase_CCDBApiTest.C
-            PUBLIC_LINK_LIBRARIES O2::EMCALCalib
-            LABELS emcal COMPILE_ONLY)
+        PUBLIC_LINK_LIBRARIES O2::EMCALCalib
+        LABELS emcal COMPILE_ONLY)
 
 o2_add_test_root_macro(macros/TimeCalibParamsL1Phase_CalibDBTest.C
-            PUBLIC_LINK_LIBRARIES O2::EMCALCalib
-            LABELS emcal COMPILE_ONLY)
+        PUBLIC_LINK_LIBRARIES O2::EMCALCalib
+        LABELS emcal COMPILE_ONLY)
 
 o2_add_test_root_macro(macros/TempCalibrationParams_CCDBApiTest.C
-            PUBLIC_LINK_LIBRARIES O2::EMCALCalib
-            LABELS emcal COMPILE_ONLY)
+        PUBLIC_LINK_LIBRARIES O2::EMCALCalib
+        LABELS emcal COMPILE_ONLY)
 
 o2_add_test_root_macro(macros/TempCalibrationParams_CalibDBTest.C
-            PUBLIC_LINK_LIBRARIES O2::EMCALCalib
-            LABELS emcal COMPILE_ONLY)
+        PUBLIC_LINK_LIBRARIES O2::EMCALCalib
+        LABELS emcal COMPILE_ONLY)
 
 o2_add_test_root_macro(macros/TempCalibParamSM_CCDBApiTest.C
-            PUBLIC_LINK_LIBRARIES O2::EMCALCalib
-            LABELS emcal COMPILE_ONLY)
+        PUBLIC_LINK_LIBRARIES O2::EMCALCalib
+        LABELS emcal COMPILE_ONLY)
 
 o2_add_test_root_macro(macros/TempCalibParamSM_CalibDBTest.C
-            PUBLIC_LINK_LIBRARIES O2::EMCALCalib
-            LABELS emcal COMPILE_ONLY)
+        PUBLIC_LINK_LIBRARIES O2::EMCALCalib
+        LABELS emcal COMPILE_ONLY)
 
 o2_add_test_root_macro(macros/GainCalibrationFactors_CCDBApiTest.C
-            PUBLIC_LINK_LIBRARIES O2::EMCALCalib
-            LABELS emcal COMPILE_ONLY)
+        PUBLIC_LINK_LIBRARIES O2::EMCALCalib
+        LABELS emcal COMPILE_ONLY)
 
 o2_add_test_root_macro(macros/GainCalibrationFactors_CalibDBTest.C
-            PUBLIC_LINK_LIBRARIES O2::EMCALCalib
-            LABELS emcal COMPILE_ONLY)
+        PUBLIC_LINK_LIBRARIES O2::EMCALCalib
+        LABELS emcal COMPILE_ONLY)
 
 o2_data_file(COPY files DESTINATION Detectors/EMC)
-

--- a/Detectors/EMCAL/calib/include/EMCALCalib/BadChannelMap.h
+++ b/Detectors/EMCAL/calib/include/EMCALCalib/BadChannelMap.h
@@ -106,6 +106,7 @@ class BadChannelMap
   /// \brief Add bad cell to the container
   /// \param channelID Absolute ID of the bad channel
   /// \param mask type of the bad channel
+  /// \throw CalibContainerIndexException in case the cell ID exceeds the range of cells in EMCAL
   ///
   /// Adding new bad channel to the container. In case a cell
   /// with the same ID is already present in the container,
@@ -119,6 +120,7 @@ class BadChannelMap
   /// \brief Get the status of a certain cell
   /// \param channelID channel for which to obtain the channel status
   /// \return Mask status of the cell (GOOD_CELL if not registered)
+  /// \throw CalibContainerIndexException in case the cell ID exceeds the range of cells in EMCAL
   ///
   /// Provide the mask status of a cell. In case the cell is registered
   /// in the container the mask status registered is returned, otherwise

--- a/Detectors/EMCAL/calib/include/EMCALCalib/CalibContainerErrors.h
+++ b/Detectors/EMCAL/calib/include/EMCALCalib/CalibContainerErrors.h
@@ -1,0 +1,62 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef ALICEO2_EMCAL_CALIBCONTAINERERORS_H
+#define ALICEO2_EMCAL_CALIBCONTAINERERORS_H
+
+#include <iosfwd>
+#include <exception>
+#include <string>
+
+namespace o2
+{
+
+namespace emcal
+{
+
+/// \class CalibContainerIndexException
+/// \brief Error handling for invalid index in calibration request
+/// \ingroup EMCALCalib
+/// \author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
+/// \since Sept 15, 2022
+class CalibContainerIndexException : public std::exception
+{
+ public:
+  /// \brief Constructor
+  /// \param index Index in container raising the exception
+  CalibContainerIndexException(unsigned int index);
+
+  /// \brief Destructor
+  ~CalibContainerIndexException() noexcept final = default;
+
+  /// \brief Access to error message of the exception
+  /// \return Error message
+  const char* what() const noexcept final { return mErrorMessage.data(); }
+
+  /// \brief Access to index raising the exception
+  /// \return Index raising the exception
+  unsigned int getIndex() const noexcept { return mIndex; }
+
+ private:
+  unsigned int mIndex;       ///< Index raising the error message
+  std::string mErrorMessage; ///< Buffer for error message
+};
+
+/// \brief Output stream operator for CalibContainerIndexException
+/// \param stream Stream where the error message should be displayed
+/// \param obj Exception object to be streamed
+/// \return Stream after the message
+std::ostream& operator<<(std::ostream& stream, const CalibContainerIndexException& obj);
+
+} // namespace emcal
+
+} // namespace o2
+
+#endif // !ALICEO2_EMCAL_CALIBCONTAINERERORS_H

--- a/Detectors/EMCAL/calib/include/EMCALCalib/EMCALChannelScaleFactors.h
+++ b/Detectors/EMCAL/calib/include/EMCALCalib/EMCALChannelScaleFactors.h
@@ -33,10 +33,10 @@ class InvalidEnergyIntervalException final : public std::exception
  public:
   /// \brief Constructor
   /// \param E Cell energy requested
-  InvalidEnergyIntervalException(float E, int cellID) : std::exception(),
-                                                        mE(E),
-                                                        mCellID(cellID),
-                                                        mMessage("Invalid energy " + std::to_string(mE) + "for cell " + std::to_string(mCellID) + "]")
+  InvalidEnergyIntervalException(float E, unsigned int cellID) : std::exception(),
+                                                                 mE(E),
+                                                                 mCellID(cellID),
+                                                                 mMessage("Invalid energy " + std::to_string(mE) + "for cell " + std::to_string(mCellID) + "]")
   {
   }
 
@@ -49,7 +49,7 @@ class InvalidEnergyIntervalException final : public std::exception
 
  private:
   float mE;             ///< Cell energy requested
-  int mCellID;          ///< Cell ID
+  unsigned int mCellID; ///< Cell ID
   std::string mMessage; ///< Message to be printed
 };
 
@@ -136,13 +136,16 @@ class EMCALChannelScaleFactors
   /// \param E_min Minimum energy of the interval
   /// \param E_max Maximum energy of the interval
   /// \param scale Scale factor for number of hits in bad channel calibration
-  void insertVal(const int cellID, float E_min, float E_max, float scale);
+  /// \throw CalibContainerIndexException in case the cell ID exceeds the range of cells in EMCAL
+  void insertVal(unsigned int cellID, float E_min, float E_max, float scale);
 
   /// Get the scale factor for a given cell and energy
   /// \param cell The cell number
   /// \param E The energy
   /// \return The scale factor
-  float getScaleVal(const int cellID, float E) const;
+  /// \throw CalibContainerIndexException in case the cell ID exceeds the range of cells in EMCAL
+  /// \throw InvalidEnergyIntervalException in case no energy interval is found for the requested energy value and cell ID
+  float getScaleVal(unsigned int cellID, float E) const;
 
  private:
   static constexpr int NCells = 17664;                               ///< Number of cells in the EMCal

--- a/Detectors/EMCAL/calib/include/EMCALCalib/GainCalibrationFactors.h
+++ b/Detectors/EMCAL/calib/include/EMCALCalib/GainCalibrationFactors.h
@@ -9,6 +9,21 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#ifndef GAINCALIBRATIONFACTORS_H_
+#define GAINCALIBRATIONFACTORS_H_
+
+#include <iosfwd>
+#include <array>
+#include <Rtypes.h>
+
+class TH1;
+
+namespace o2
+{
+
+namespace emcal
+{
+
 /// \class GainCalibrationFactors
 /// \brief CCDB container for the gain calibration factors
 /// \ingroup EMCALcalib
@@ -27,22 +42,6 @@
 /// This will return the gain calibration factor for a certain channel.
 /// ~~~
 ///
-
-#ifndef GAINCALIBRATIONFACTORS_H_
-#define GAINCALIBRATIONFACTORS_H_
-
-#include <iosfwd>
-#include <array>
-#include <Rtypes.h>
-
-class TH1;
-
-namespace o2
-{
-
-namespace emcal
-{
-
 class GainCalibrationFactors
 {
  public:
@@ -54,11 +53,13 @@ class GainCalibrationFactors
 
   /// \brief Comparison of two gain calibration factors containers
   /// \return true if the two list of gain calibration factors are the same, false otherwise
+  /// \throw CalibContainerIndexException in case the cell ID exceeds the range of cells in EMCAL
   bool operator==(const GainCalibrationFactors& other) const;
 
   /// \brief Add gain calibration factors to the container
   /// \param iCell is the cell index
   /// \param gainFactor is the gain calibration factor
+  /// \throw CalibContainerIndexException in case the cell ID exceeds the range of cells in EMCAL
   void addGainCalibFactor(unsigned short iCell, float gainFactor);
 
   /// \brief Get the gain calibration factor for a certain cell

--- a/Detectors/EMCAL/calib/include/EMCALCalib/TimeCalibrationParams.h
+++ b/Detectors/EMCAL/calib/include/EMCALCalib/TimeCalibrationParams.h
@@ -63,12 +63,14 @@ class TimeCalibrationParams
   /// \param cellID Absolute ID of cell
   /// \param time is the calibration coefficient
   /// \param isLowGain is flag whether this cell is LG or HG
+  /// \throw CalibContainerIndexException in case the cell ID exceeds the range of cells in EMCAL
   void addTimeCalibParam(unsigned short cellID, short time, bool isLowGain);
 
   /// \brief Get the time calibration coefficient for a certain cell
   /// \param cellID Absolute ID of cell
   /// \param isLowGain is flag whether this cell is LG or HG
   /// \return time calibration coefficient of the cell
+  /// \throw CalibContainerIndexException in case the cell ID exceeds the range of cells in EMCAL
   short getTimeCalibParam(unsigned short cellID, bool isLowGain) const;
 
   /// \brief Convert the time calibration coefficient array to a histogram

--- a/Detectors/EMCAL/calib/src/BadChannelMap.cxx
+++ b/Detectors/EMCAL/calib/src/BadChannelMap.cxx
@@ -11,6 +11,7 @@
 
 #include "EMCALBase/Geometry.h"
 #include "EMCALCalib/BadChannelMap.h"
+#include "EMCALCalib/CalibContainerErrors.h"
 
 #include "FairLogger.h"
 
@@ -22,6 +23,9 @@ using namespace o2::emcal;
 
 void BadChannelMap::addBadChannel(unsigned short channelID, MaskType_t mask)
 {
+  if (channelID >= 17664) {
+    throw CalibContainerIndexException(channelID);
+  }
   switch (mask) {
     case MaskType_t::GOOD_CELL:
       mBadCells.reset(channelID);
@@ -48,6 +52,9 @@ void BadChannelMap::addBadChannel(unsigned short channelID, MaskType_t mask)
 
 BadChannelMap::MaskType_t BadChannelMap::getChannelStatus(unsigned short channelID) const
 {
+  if (channelID >= 17664) {
+    throw CalibContainerIndexException(channelID);
+  }
   auto status = MaskType_t::GOOD_CELL;
   if (mDeadCells.test(channelID)) {
     status = MaskType_t::DEAD_CELL;

--- a/Detectors/EMCAL/calib/src/CalibContainerErrors.cxx
+++ b/Detectors/EMCAL/calib/src/CalibContainerErrors.cxx
@@ -1,0 +1,26 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <iostream>
+#include "EMCALCalib/CalibContainerErrors.h"
+
+using namespace o2::emcal;
+
+CalibContainerIndexException::CalibContainerIndexException(unsigned int index) : std::exception(), mIndex(index), mErrorMessage()
+{
+  mErrorMessage = "Invalid index: " + std::to_string(mIndex);
+}
+
+std::ostream& o2::emcal::operator<<(std::ostream& stream, const o2::emcal::CalibContainerIndexException& obj)
+{
+  stream << obj.what();
+  return stream;
+}

--- a/Detectors/EMCAL/calib/src/EMCALChannelScaleFactors.cxx
+++ b/Detectors/EMCAL/calib/src/EMCALChannelScaleFactors.cxx
@@ -9,6 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#include "EMCALCalib/CalibContainerErrors.h"
 #include "EMCALCalib/EMCALChannelScaleFactors.h"
 
 namespace o2
@@ -16,19 +17,19 @@ namespace o2
 namespace emcal
 {
 
-void EMCALChannelScaleFactors::insertVal(const int cellID, float E_min, float E_max, float scale)
+void EMCALChannelScaleFactors::insertVal(unsigned int cellID, float E_min, float E_max, float scale)
 {
   if (cellID >= NCells || cellID < 0) {
-    throw InvalidCellIDException(cellID);
+    throw CalibContainerIndexException(cellID);
   } else {
     ScaleFactors.at(cellID)[EnergyIntervals(E_min, E_max)] = scale;
   }
 }
 
-float EMCALChannelScaleFactors::getScaleVal(const int cellID, float E) const
+float EMCALChannelScaleFactors::getScaleVal(unsigned int cellID, float E) const
 {
   if (cellID >= NCells || cellID < 0) {
-    throw InvalidCellIDException(cellID);
+    throw CalibContainerIndexException(cellID);
   } else {
     for (const auto& [energy, scale] : ScaleFactors[cellID]) {
       if (energy.isInInterval(E)) {

--- a/Detectors/EMCAL/calib/src/GainCalibrationFactors.cxx
+++ b/Detectors/EMCAL/calib/src/GainCalibrationFactors.cxx
@@ -9,6 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#include "EMCALCalib/CalibContainerErrors.h"
 #include "EMCALCalib/GainCalibrationFactors.h"
 
 #include "FairLogger.h"
@@ -21,11 +22,17 @@ using namespace o2::emcal;
 
 void GainCalibrationFactors::addGainCalibFactor(unsigned short iCell, float gainFactor)
 {
+  if (iCell >= 17664) {
+    throw CalibContainerIndexException(iCell);
+  }
   mGainCalibFactors[iCell] = gainFactor;
 }
 
 float GainCalibrationFactors::getGainCalibFactors(unsigned short iCell) const
 {
+  if (iCell >= 17664) {
+    throw CalibContainerIndexException(iCell);
+  }
   return mGainCalibFactors[iCell];
 }
 

--- a/Detectors/EMCAL/calib/src/TimeCalibrationParams.cxx
+++ b/Detectors/EMCAL/calib/src/TimeCalibrationParams.cxx
@@ -9,6 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#include "EMCALCalib/CalibContainerErrors.h"
 #include "EMCALCalib/TimeCalibrationParams.h"
 
 #include "FairLogger.h"
@@ -21,6 +22,9 @@ using namespace o2::emcal;
 
 void TimeCalibrationParams::addTimeCalibParam(unsigned short cellID, short time, bool isLowGain)
 {
+  if (cellID >= 17664) {
+    throw CalibContainerIndexException(cellID);
+  }
   if (!isLowGain) {
     mTimeCalibParamsHG[cellID] = time;
   } else {
@@ -30,6 +34,9 @@ void TimeCalibrationParams::addTimeCalibParam(unsigned short cellID, short time,
 
 short TimeCalibrationParams::getTimeCalibParam(unsigned short cellID, bool isLowGain) const
 {
+  if (cellID >= 17664) {
+    throw CalibContainerIndexException(cellID);
+  }
   if (isLowGain) {
     return mTimeCalibParamsLG[cellID];
   } else {


### PR DESCRIPTION
Error souces very similar for all objects so they can be
implemented in the same file. Currently only invalid indices
are handled.