### PR TITLE
Improve information for MID chamber efficiency calculation

### DIFF
--- a/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/Track.h
+++ b/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/Track.h
@@ -143,19 +143,26 @@ class Track
   /// Gets the word allowing to compute the chamber efficiency
   uint32_t getEfficiencyWord() const { return mEfficiencyWord; }
 
-  /// Sets the fired local board for efficiency calculation
-  /// \param locId local board ID in the range 1-234
-  void setFiredLocalBoard(int locId) { setEfficiencyWord(8, 0xFF, locId); }
+  /// Sets the fired FEE ID
+  void setFiredFEEId(int uniqueFeeId) { setEfficiencyWord(8, 0x7FFF, uniqueFeeId); }
+
+  /// Gets the fired FEE ID
+  int getFiredFEEId() const { return (mEfficiencyWord >> 8) & 0x7FFF; }
 
   /// Gets the fired local board for efficiency calculation
-  int getFiredLocalBoard() const { return (mEfficiencyWord >> 8) & 0xFF; }
+  [[deprecated]] int getFiredLocalBoard() const { return (mEfficiencyWord >> 8) & 0xFF; }
 
-  /// Sets the fired detection element ID for efficiency calculation
-  /// \param deId detection element ID in the range 1-234
-  void setFiredDeId(int deId) { setEfficiencyWord(16, 0xFF, deId); }
+  /// Gets the fired Detection Element ID
+  int getFiredDEId() const { return (mEfficiencyWord >> 16) & 0x7F; }
 
-  /// Gets the fired detection element ID for efficiency calculation
-  int getFiredDeId() const { return (mEfficiencyWord >> 16) & 0xFF; }
+  /// Gets the fired Detection Element ID
+  [[deprecated("Use getFiredDEId instead")]] int getFiredDeId() const { return getFiredDEId(); }
+
+  /// Gets the fired column ID
+  int getFiredColumnId() const { return (mEfficiencyWord >> 12) & 0x7; }
+
+  /// Gets the fired line ID
+  int getFiredLineId() const { return (mEfficiencyWord >> 8) & 0x3; }
 
   /// Sets the flag for efficiency calculation
   /// \param effFlag efficiency flag

--- a/DataFormats/Detectors/MUON/MID/src/Track.cxx
+++ b/DataFormats/Detectors/MUON/MID/src/Track.cxx
@@ -177,7 +177,7 @@ std::ostream& operator<<(std::ostream& stream, const Track& track)
     stream << ((ival == 5) ? ")" : ", ");
   }
   stream << fmt::format(" chi2/ndf: {:g}/{:d}", track.getChi2(), track.getNDF());
-  stream << fmt::format(" hitMap: 0x{:x} locId: {:d} deId: {:d} effFlag {:d}", track.getHitMap(), track.getFiredLocalBoard(), track.getFiredDeId(), track.getEfficiencyFlag());
+  stream << fmt::format(" hitMap: 0x{:x} deId: {:d} columnId: {:d} lineId: {:d} effFlag {:d}", track.getHitMap(), track.getFiredDEId(), track.getFiredColumnId(), track.getFiredLineId(), track.getEfficiencyFlag());
   return stream;
 }
 

--- a/Detectors/MUON/MID/Base/include/MIDBase/DetectorParameters.h
+++ b/Detectors/MUON/MID/Base/include/MIDBase/DetectorParameters.h
@@ -58,6 +58,29 @@ int getDEId(bool isRight, int chamber, int rpc);
 /// Gets the detection element name from its ID
 /// \param deId The detection element ID
 std::string getDEName(int deId);
+
+/// Gets the unique Front-End Electronics ID
+/// \param deId The detection element ID
+/// \param columnId Column ID
+/// \param lineId Line in column
+/// \return unique FEE ID
+inline int getUniqueFEEId(int deId, int columnId, int lineId) { return lineId | (columnId << 4) | (deId << 8); }
+
+/// Gets the detection element ID from the unique FEE ID
+/// \param uniqueFEEId Unique FEE ID
+/// \return Detection element ID
+inline int getDEIdFromFEEId(int uniqueFEEId) { return (uniqueFEEId >> 8) & 0x7F; }
+
+/// Gets the column ID from the unique FEE ID
+/// \param uniqueFEEId Unique FEE ID
+/// \return Column ID
+inline int getColumnIdFromFEEId(int uniqueFEEId) { return (uniqueFEEId >> 4) & 0x7; }
+
+/// Gets the line ID from the unique FEE ID
+/// \param uniqueFEEId Unique FEE ID
+/// \return Line ID
+inline int getLineIdFromFEEId(int uniqueFEEId) { return uniqueFEEId & 0x3; }
+
 } // namespace detparams
 } // namespace mid
 } // namespace o2

--- a/Detectors/MUON/MID/Tracking/include/MIDTracking/HitMapBuilder.h
+++ b/Detectors/MUON/MID/Tracking/include/MIDTracking/HitMapBuilder.h
@@ -18,9 +18,10 @@
 #define O2_MID_HITMAPBUILDER_H
 
 #include <vector>
-#include <unordered_set>
+#include <unordered_map>
 #include <gsl/gsl>
 #include "DataFormatsMID/Cluster.h"
+#include "DataFormatsMID/ColumnData.h"
 #include "DataFormatsMID/ROFRecord.h"
 #include "DataFormatsMID/Track.h"
 #include "MIDBase/GeometryTransformer.h"
@@ -52,6 +53,10 @@ class HitMapBuilder
   /// \param clusters gsl::span of associated clusters (in local coordinates)
   void process(std::vector<Track>& tracks, gsl::span<const Cluster> clusters) const;
 
+  /// Sets the masked channels
+  /// \param maskedChannels vector of masked channels
+  void setMaskedChannels(const std::vector<ColumnData>& maskedChannels);
+
  private:
   /// Checks if the track crossed the same element
   /// \param fired Vector of fired elements
@@ -74,8 +79,14 @@ class HitMapBuilder
   /// \return The FEE ID in MT11
   int getFEEIdMT11(double xp, double yp, uint8_t deId) const;
 
-  Mapping mMapping;     ///< Mapping
-  HitFinder mHitFinder; ///< Hit finder
+  /// Cluster matches masked channel
+  /// \param cl Cluster
+  /// \return true if the cluster matches the masked channel
+  bool matchesMaskedChannel(const Cluster& cl) const;
+
+  Mapping mMapping;                                             ///< Mapping
+  HitFinder mHitFinder;                                         ///< Hit finder
+  std::unordered_map<int, std::vector<MpArea>> mMaskedChannels; ///< Masked channels
 };
 } // namespace mid
 } // namespace o2

--- a/Detectors/MUON/MID/Tracking/include/MIDTracking/HitMapBuilder.h
+++ b/Detectors/MUON/MID/Tracking/include/MIDTracking/HitMapBuilder.h
@@ -65,14 +65,14 @@ class HitMapBuilder
   /// \param firedLocIds Vector of fired Local board Ids
   /// \param nonFiredLocIds Vector of non-fired Local board Ids
   /// \return the efficiency flag
-  int getEffFlag(const std::vector<int>& firedRPCLines, const std::vector<int>& nonFiredRPCLines, const std::vector<int>& firedLocIds, const std::vector<int>& nonFiredLocIds) const;
+  int getEffFlag(const std::vector<int>& firedFEEIdMT11, const std::vector<int>& nonFiredFEEIdMT11) const;
 
-  /// Function to extract the local board ID of the cluster
-  /// \param xp cluster x coordinate
-  /// \param yp cluster y coordinate
-  /// \param deId cluster Detection Element ID
-  /// \return the Local board ID
-  int getLocId(double xp, double yp, uint8_t deId) const;
+  /// Returns the FEE ID in MT11
+  /// \param xp x position
+  /// \param yp y position
+  /// \param deId Detector element ID
+  /// \return The FEE ID in MT11
+  int getFEEIdMT11(double xp, double yp, uint8_t deId) const;
 
   Mapping mMapping;     ///< Mapping
   HitFinder mHitFinder; ///< Hit finder

--- a/Detectors/MUON/MID/Workflow/include/MIDWorkflow/TrackerSpec.h
+++ b/Detectors/MUON/MID/Workflow/include/MIDWorkflow/TrackerSpec.h
@@ -23,7 +23,7 @@ namespace o2
 {
 namespace mid
 {
-framework::DataProcessorSpec getTrackerSpec(bool isMC);
+framework::DataProcessorSpec getTrackerSpec(bool isMC, bool checkMasked);
 }
 } // namespace o2
 

--- a/Detectors/MUON/MID/Workflow/src/reco-workflow.cxx
+++ b/Detectors/MUON/MID/Workflow/src/reco-workflow.cxx
@@ -84,7 +84,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   }
   specs.emplace_back(o2::mid::getClusterizerSpec(!disableMC, dataDesc, rofDesc, labelsDesc));
   if (!disableTracking) {
-    specs.emplace_back(o2::mid::getTrackerSpec(!disableMC));
+    specs.emplace_back(o2::mid::getTrackerSpec(!disableMC, !disableFiltering));
   }
   if (!disableFile) {
     if (disableTracking) {


### PR DESCRIPTION
This PR consists of two commits:
- the first one changes the information stored in the MID track that is used to identify a local board. The legacy ID is replaced by something that it is more easily usable in the Run 3 code.
- the second one declares as bad for efficiency calculations those tracks that would have matched a masked strip. This avoids a double counting of the masked channel effect, since they would also lower the efficiency otherwise.
The commits are meant to be atomic: please do not squash.