### PR TITLE
Prevent compiler warning

### DIFF
--- a/Detectors/MUON/MID/Workflow/src/FilteringSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/FilteringSpec.cxx
@@ -80,7 +80,8 @@ class FilteringDeviceDPL
 
   void run(of::ProcessingContext& pc)
   {
-    const auto badChannels = pc.inputs().get<std::vector<ColumnData>*>("mid_bad_channels");
+    // Triggers finalizeCCDB
+    pc.inputs().get<std::vector<ColumnData>*>("mid_bad_channels");
 
     auto data = specs::getData(pc, "mid_filter_in", EventType::Standard);
     auto inROFRecords = specs::getRofs(pc, "mid_filter_in", EventType::Standard);


### PR DESCRIPTION
The call to the function is necessary to trigger the object retrieval from CCDB.
On the other hand, there is no need to store the result in a variable since the variable is not used later on.
In principle this should result in a compiler warning. In practice I never noticed a warning. But this PR should be more correct compiler-wise.