### PR TITLE
[EMCAL-830] Adapt CalibLoader to fully rely on CCDB-backend

### DIFF
--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/CalibLoader.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/CalibLoader.h
@@ -9,9 +9,8 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#include <string>
-#include <string_view>
 #include <vector>
+#include <Framework/ProcessingContext.h>
 #include "Framework/ConcreteDataMatcher.h"
 #include "Framework/InputSpec.h"
 
@@ -49,15 +48,15 @@ class CalibLoader
 
   /// \brief Access to current bad channel map
   /// \return Current bad channel map (nullptr if not loaded)
-  BadChannelMap* getBadChannelMap() const { return mBadChannelMap.getObject(); }
+  BadChannelMap* getBadChannelMap() const { return mBadChannelMap; }
 
   /// \brief Access to current time calibration params
   /// \return Current time calibration params
-  TimeCalibrationParams* getTimeCalibration() const { return mTimeCalibParams.getObject(); }
+  TimeCalibrationParams* getTimeCalibration() const { return mTimeCalibParams; }
 
   /// \brief Access to current gain calibration factors
   /// \return Current gain calibration factors
-  GainCalibrationFactors* getGainCalibration() const { return mGainCalibParams.getObject(); }
+  GainCalibrationFactors* getGainCalibration() const { return mGainCalibParams; }
 
   /// \brief Check whether the bad channel map is handled
   /// \return True if the bad channel map is handled, false otherwise
@@ -71,18 +70,6 @@ class CalibLoader
   /// \return True if the gain calibration factors are handled, false otherwise
   bool hasGainCalib() const { return mEnableGainCalib; }
 
-  /// \brief Check whether the bad channel map is loaded from local file
-  /// \return True if the bad channel map is loaded from a local file
-  bool hasLocalBadChannelMap() const { return mEnableBadChannelMap && mPathBadChannelMap.length(); }
-
-  /// \brief Check whether the time calibration params are loaded from local file
-  /// \return True if the time calibration params are loaded from a local file
-  bool hasLocalTimeCalib() const { return mEnableTimeCalib && mPathTimeCalib.length(); }
-
-  /// \brief Check whether the gain calibration factors are loaded from local file
-  /// \return True if the gain calibration factors are loaded from a local file
-  bool hasLocalGainCalib() const { return mEnableGainCalib && mPathGainCalib.length(); }
-
   /// \brief Enable loading of the bad channel map
   /// \param doEnable If true the bad channel map is loaded (per default from CCDB)
   void enableBadChannelMap(bool doEnable) { mEnableBadChannelMap = doEnable; }
@@ -95,47 +82,17 @@ class CalibLoader
   /// \param doEnable If true the gain calibration factors are loaded (per default from CCDB)
   void enableGainCalib(bool doEnable) { mEnableGainCalib = doEnable; }
 
-  /// \brief Define path of local fine for bad channel map
-  /// \param path Path of local file with bad channel map
-  ///
-  /// The bad channel map will be taken from the file instead of the CCDB.
-  /// The file is expected to contain a valid o2::emcal::BadChannelMap with
-  /// the name "ccdb_object"
-  void setLoadBadChannelMapFromFile(const std::string_view path)
-  {
-    mPathBadChannelMap = path;
-    enableBadChannelMap(true);
-  }
-
-  /// \brief Define path of local fine for time calibration params
-  /// \param path Path of local file with time calibration params
-  ///
-  /// The time calibration params will be taken from the file instead
-  /// of the CCDB. The file is expected to contain a valid
-  /// o2::emcal::TimeCalibrationParams with the name "ccdb_object"
-  void setLoadTimeCalibFromFile(const std::string_view path)
-  {
-    mPathTimeCalib = path;
-    enableBadChannelMap(true);
-  }
-
-  /// \brief Define path of local fine for gain calibration factors
-  /// \param path Path of local file with gain calibration factors
-  ///
-  /// The gain calibration factors will be taken from the file instead
-  /// of the CCDB. The file is expected to contain a valid
-  /// o2::emcal::GainCalibrationFactors with the name "ccdb_object"
-  void setLoadGainCalibFromFile(const std::string_view path)
-  {
-    mPathGainCalib = path;
-    enableGainCalib(true);
-  }
-
   /// \brief Define input specs in workflow for calibration objects to be loaded from the CCDB
   /// \param ccdbInputs List of inputs where the CCDB input specs will be added to
   ///
   /// Defining only objects which are enabled and for which no local path is specified.
   void defineInputSpecs(std::vector<framework::InputSpec>& ccdbInputs);
+
+  /// \brief Check for updates of the calibration objects in the processing context
+  /// \param ctx ProcessingContext with InputSpecs
+  ///
+  /// Triggers finalizeCCDB in case of updates.
+  void checkUpdates(o2::framework::ProcessingContext& ctx);
 
   /// \brief Callback for objects loaded from CCDB
   /// \param matcher Type of the CCDB object
@@ -146,55 +103,13 @@ class CalibLoader
   /// via the corresponding getter function.
   bool finalizeCCDB(framework::ConcreteDataMatcher& matcher, void* obj);
 
-  /// \brief Load all calibration objects for which a local path is defined
-  void static_load();
-
  private:
-  /// \class ManagedObject
-  /// \brief Internal helper treating owned and non-owned object with the same member
-  /// \tparam T object type to be handled
-  ///
-  /// In case the object is owned the object will be deleted in case the helper goes
-  /// out-of-scope. Otherwise ownership will be assumed with someone else and the object
-  /// will not be deleted in the destructor.
-  template <typename T>
-  class ManagedObject
-  {
-   public:
-    /// \brief Dummy constructor
-    ManagedObject() = default;
-
-    /// \brief Constructor, defining the object as managed or not
-    /// \param object Object to be handled
-    /// \param managed If true the object will be automatically deleted if the helper goes out-of-scope
-    ManagedObject(T* object, bool managed) : mObject(object), mManaged(managed) {}
-
-    /// \brief Destructor, deletes only managed objects
-    ~ManagedObject()
-    {
-      if (mManaged) {
-        delete mObject;
-      }
-    }
-
-    /// \brief Access to the object
-    /// \return Object handled by the helper
-    T* getObject() const { return mObject; }
-
-   private:
-    T* mObject = nullptr;  ///< Object to be handled
-    bool mManaged = false; ///< Management status
-  };
-
-  bool mEnableBadChannelMap;                                         ///< Switch for enabling / disabling loading of the bad channel map
-  bool mEnableTimeCalib;                                             ///< Switch for enabling / disabling loading of the time calibration params
-  bool mEnableGainCalib;                                             ///< Switch for enabling / disabling loading of the gain calibration params
-  std::string mPathBadChannelMap;                                    ///< Path of local file with bad channel map (optional)
-  std::string mPathTimeCalib;                                        ///< Path of local file with time calibration params (optional)
-  std::string mPathGainCalib;                                        ///< Path of local file with gain calibration params (optional)
-  ManagedObject<o2::emcal::BadChannelMap> mBadChannelMap;            ///< Container of current bad channel map
-  ManagedObject<o2::emcal::TimeCalibrationParams> mTimeCalibParams;  ///< Container of current time calibration object
-  ManagedObject<o2::emcal::GainCalibrationFactors> mGainCalibParams; ///< Container of current gain calibration object
+  bool mEnableBadChannelMap;                                     ///< Switch for enabling / disabling loading of the bad channel map
+  bool mEnableTimeCalib;                                         ///< Switch for enabling / disabling loading of the time calibration params
+  bool mEnableGainCalib;                                         ///< Switch for enabling / disabling loading of the gain calibration params
+  o2::emcal::BadChannelMap* mBadChannelMap = nullptr;            ///< Container of current bad channel map
+  o2::emcal::TimeCalibrationParams* mTimeCalibParams = nullptr;  ///< Container of current time calibration object
+  o2::emcal::GainCalibrationFactors* mGainCalibParams = nullptr; ///< Container of current gain calibration object
 };
 
 } // namespace emcal

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/CellRecalibratorSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/CellRecalibratorSpec.h
@@ -12,7 +12,6 @@
 #include <bitset>
 #include <cstdint>
 #include <optional>
-#include <string_view>
 #include "EMCALWorkflow/CalibLoader.h"
 #include "Framework/ConcreteDataMatcher.h"
 #include "Framework/DataProcessorSpec.h"
@@ -141,7 +140,7 @@ class CellRecalibratorSpec : public framework::Task
 /// \param badChannelCalib If true the bad channel calibration is enabled
 /// \param timeCalib If true the time calibration is enabled
 /// \param gainCalib If true the gain (energy) calibration is enabled
-framework::DataProcessorSpec getCellRecalibratorSpec(uint32_t inputSubspec, uint32_t outputSubspec, bool badChannelCalib, bool timeCalib, bool gainCalib, const std::string_view pathBadChannelMap, const std::string_view pathTimeCalib, std::string_view pathGainCalib);
+framework::DataProcessorSpec getCellRecalibratorSpec(uint32_t inputSubspec, uint32_t outputSubspec, bool badChannelCalib, bool timeCalib, bool gainCalib);
 
 } // namespace emcal
 

--- a/Detectors/EMCAL/workflow/src/CalibLoader.cxx
+++ b/Detectors/EMCAL/workflow/src/CalibLoader.cxx
@@ -10,7 +10,6 @@
 // or submit itself to any jurisdiction.
 
 #include <filesystem>
-#include <memory>
 #include <fairlogger/Logger.h>
 #include "EMCALCalib/CalibDB.h"
 #include "EMCALCalib/BadChannelMap.h"
@@ -18,82 +17,65 @@
 #include "EMCALCalib/GainCalibrationFactors.h"
 #include "EMCALWorkflow/CalibLoader.h"
 #include "Framework/CCDBParamSpec.h"
+#include "Framework/InputRecord.h"
 #include "TFile.h"
 
 using namespace o2::emcal;
 
 void CalibLoader::defineInputSpecs(std::vector<o2::framework::InputSpec>& inputs)
 {
-  if (hasBadChannelMap() && !hasLocalBadChannelMap()) {
+  if (hasBadChannelMap()) {
     inputs.push_back({"badChannelMap", o2::header::gDataOriginEMC, "BADCHANNELMAP", 0, o2::framework::Lifetime::Condition, o2::framework::ccdbParamSpec(CalibDB::getCDBPathBadChannelMap())});
   }
-  if (hasTimeCalib() && !hasLocalTimeCalib()) {
+  if (hasTimeCalib()) {
     inputs.push_back({"timeCalibParams", o2::header::gDataOriginEMC, "TIMECALIBPARAMS", 0, o2::framework::Lifetime::Condition, o2::framework::ccdbParamSpec(CalibDB::getCDBPathTimeCalibrationParams())});
   }
-  if (hasGainCalib() && !hasLocalGainCalib()) {
+  if (hasGainCalib()) {
     inputs.push_back({"gainCalibParams", o2::header::gDataOriginEMC, "GAINCALIBPARAMS", 0, o2::framework::Lifetime::Condition, o2::framework::ccdbParamSpec(CalibDB::getCDBPathGainCalibrationParams())});
+  }
+}
+
+void CalibLoader::checkUpdates(o2::framework::ProcessingContext& ctx)
+{
+  if (hasBadChannelMap()) {
+    ctx.inputs().get<o2::emcal::BadChannelMap*>("badChannelMap");
+  }
+  if (hasTimeCalib()) {
+    ctx.inputs().get<o2::emcal::TimeCalibrationParams*>("timeCalibParams");
+  }
+  if (hasGainCalib()) {
+    ctx.inputs().get<o2::emcal::GainCalibrationFactors*>("gainCalibParams");
   }
 }
 
 bool CalibLoader::finalizeCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
 {
   if (matcher == o2::framework::ConcreteDataMatcher("EMC", "BADCHANNELMAP", 0)) {
-    if (hasBadChannelMap() && !hasLocalBadChannelMap()) {
+    if (hasBadChannelMap()) {
       LOG(info) << "New bad channel map loaded";
-      mBadChannelMap = ManagedObject<o2::emcal::BadChannelMap>(reinterpret_cast<o2::emcal::BadChannelMap*>(obj), false);
+      mBadChannelMap = reinterpret_cast<o2::emcal::BadChannelMap*>(obj);
     } else {
       LOG(error) << "New bad channel map available even though bad channel calibration was not enabled, not loading";
     }
     return true;
   }
   if (matcher == o2::framework::ConcreteDataMatcher("EMC", "TIMECALIBPARAMS", 0)) {
-    if (hasTimeCalib() && !hasLocalTimeCalib()) {
+    if (hasTimeCalib()) {
       LOG(info) << "New time calibration paramset loaded";
-      mTimeCalibParams = ManagedObject<o2::emcal::TimeCalibrationParams>(reinterpret_cast<o2::emcal::TimeCalibrationParams*>(obj), false);
+      mTimeCalibParams = reinterpret_cast<o2::emcal::TimeCalibrationParams*>(obj);
     } else {
       LOG(error) << "New time calibration paramset available even though time calibration was not enabled, not loading";
     }
     return true;
   }
   if (matcher == o2::framework::ConcreteDataMatcher("EMC", "GAINCALIBPARAMS", 0)) {
-    if (hasGainCalib() && !hasLocalGainCalib()) {
+    if (hasGainCalib()) {
       LOG(info) << "New gain calibration paramset loaded";
-      mGainCalibParams = ManagedObject<o2::emcal::GainCalibrationFactors>(reinterpret_cast<o2::emcal::GainCalibrationFactors*>(obj), false);
+      mGainCalibParams = reinterpret_cast<o2::emcal::GainCalibrationFactors*>(obj);
     } else {
       LOG(error) << "New gain calibration paramset available even though the gain calibration was not enabled, not loading";
     }
     return true;
   }
   return false;
-}
-
-void CalibLoader::static_load()
-{
-  if (hasLocalBadChannelMap()) {
-    if (std::filesystem::exists(std::filesystem::path(mPathBadChannelMap))) {
-      LOG(info) << "Static load: Bad channel map taken from file " << mPathBadChannelMap;
-      std::unique_ptr<TFile> reader(TFile::Open(mPathBadChannelMap.data(), "READ"));
-      mBadChannelMap = ManagedObject<o2::emcal::BadChannelMap>(new o2::emcal::BadChannelMap(*(reader->Get<o2::emcal::BadChannelMap>("ccdb_object"))), true);
-    } else {
-      LOG(error) << "Static load: Path to bad channel map (" << mPathBadChannelMap << ") not existing";
-    }
-  }
-  if (hasLocalTimeCalib()) {
-    if (std::filesystem::exists(std::filesystem::path(mPathTimeCalib))) {
-      LOG(info) << "Static load: Time calibration coefficients taken from file " << mPathTimeCalib;
-      std::unique_ptr<TFile> reader(TFile::Open(mPathTimeCalib.data(), "READ"));
-      mTimeCalibParams = ManagedObject<o2::emcal::TimeCalibrationParams>(new o2::emcal::TimeCalibrationParams(*(reader->Get<o2::emcal::TimeCalibrationParams>("ccdb_object"))), true);
-    } else {
-      LOG(error) << "Static load: Path to time calibration params (" << mPathTimeCalib << ") not existing";
-    }
-  }
-  if (hasLocalGainCalib()) {
-    if (std::filesystem::exists(std::filesystem::path(mPathGainCalib))) {
-      LOG(info) << "Static load: Gain calibration coefficients taken from file " << mPathGainCalib;
-      std::unique_ptr<TFile> reader(TFile::Open(mPathGainCalib.data(), "READ"));
-      mGainCalibParams = ManagedObject<o2::emcal::GainCalibrationFactors>(new o2::emcal::GainCalibrationFactors(*(reader->Get<o2::emcal::GainCalibrationFactors>("ccdb_object"))), true);
-    } else {
-      LOG(error) << "Static load: Path to gain calibration params (" << mPathGainCalib << ") not existing";
-    }
-  }
 }

--- a/Detectors/EMCAL/workflow/src/CellRecalibratorSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/CellRecalibratorSpec.cxx
@@ -35,8 +35,6 @@ void CellRecalibratorSpec::init(framework::InitContext& ctx)
   LOG(info) << "Bad channel calibration: " << (isRunBadChannlCalibration() ? "enabled" : "disabled");
   LOG(info) << "Time calibration:        " << (isRunTimeCalibration() ? "enabled" : "disabled");
   LOG(info) << "Gain calibration:        " << (isRunGainCalibration() ? "enabled" : "disabled");
-
-  mCalibrationHandler->static_load();
 }
 
 void CellRecalibratorSpec::run(framework::ProcessingContext& ctx)
@@ -45,6 +43,7 @@ void CellRecalibratorSpec::run(framework::ProcessingContext& ctx)
   auto intputtriggers = ctx.inputs().get<gsl::span<o2::emcal::TriggerRecord>>("triggerrecords");
   LOG(info) << "Received " << inputcells.size() << " cells from " << intputtriggers.size() << " triggers";
 
+  mCalibrationHandler->checkUpdates(ctx);
   updateCalibObjects();
 
   std::vector<o2::emcal::Cell> outputcells;
@@ -81,6 +80,7 @@ void CellRecalibratorSpec::run(framework::ProcessingContext& ctx)
 
 void CellRecalibratorSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
 {
+  LOG(info) << "Handling new Calibration objects";
   if (mCalibrationHandler->finalizeCCDB(matcher, obj)) {
     return;
   }
@@ -109,32 +109,31 @@ std::optional<o2::emcal::Cell> CellRecalibratorSpec::getCalibratedCell(const o2:
 
 void CellRecalibratorSpec::updateCalibObjects()
 {
+  auto badmapOld = mBadChannelMap;
+  auto timeCalibOld = mTimeCalibration;
   if (isRunBadChannlCalibration()) {
     mBadChannelMap = mCalibrationHandler->getBadChannelMap();
+    if (badmapOld != mBadChannelMap) {
+      LOG(info) << "updateCalibObjects: Bad channel map changed";
+    }
   }
   if (isRunTimeCalibration()) {
     mTimeCalibration = mCalibrationHandler->getTimeCalibration();
+    if (timeCalibOld != mTimeCalibration) {
+      LOG(info) << "updateCalibObjects: Time calib params changed";
+    }
   }
   if (isRunGainCalibration()) {
     mGainCalibration = mCalibrationHandler->getGainCalibration();
   }
 }
 
-o2::framework::DataProcessorSpec o2::emcal::getCellRecalibratorSpec(uint32_t inputSubspec, uint32_t outputSubspec, bool badChannelCalib, bool timeCalib, bool gainCalib, const std::string_view pathBadChannelMap, const std::string_view pathTimeCalib, const std::string_view pathGainCalib)
+o2::framework::DataProcessorSpec o2::emcal::getCellRecalibratorSpec(uint32_t inputSubspec, uint32_t outputSubspec, bool badChannelCalib, bool timeCalib, bool gainCalib)
 {
   auto calibhandler = std::make_shared<o2::emcal::CalibLoader>();
   calibhandler->enableBadChannelMap(badChannelCalib);
   calibhandler->enableTimeCalib(timeCalib);
   calibhandler->enableGainCalib(gainCalib);
-  if (pathBadChannelMap.length()) {
-    calibhandler->setLoadBadChannelMapFromFile(pathBadChannelMap);
-  }
-  if (pathTimeCalib.length()) {
-    calibhandler->setLoadTimeCalibFromFile(pathTimeCalib);
-  }
-  if (pathGainCalib.length()) {
-    calibhandler->setLoadGainCalibFromFile(pathGainCalib);
-  }
   std::vector<o2::framework::InputSpec>
     inputs = {{"cells", o2::header::gDataOriginEMC, "CELLS", inputSubspec, o2::framework::Lifetime::Timeframe},
               {"triggerrecords", o2::header::gDataOriginEMC, "CELLSTRGR", inputSubspec, o2::framework::Lifetime::Timeframe}};

--- a/Detectors/EMCAL/workflow/src/cell-recalibrator-workflow.cxx
+++ b/Detectors/EMCAL/workflow/src/cell-recalibrator-workflow.cxx
@@ -34,9 +34,6 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
                                        {"no-badchannelcalib", VariantType::Bool, false, {"Disable bad channel calibration"}},
                                        {"no-timecalib", VariantType::Bool, false, {"Disable time calibration"}},
                                        {"no-gaincalib", VariantType::Bool, false, {"Disable gain calibration"}},
-                                       {"local-badchannelmap", VariantType::String, "", {"path to local file with bad channel map"}},
-                                       {"local-timecalib", VariantType::String, "", {"path to local file with time calibration params"}},
-                                       {"local-gaincalib", VariantType::String, "", {"path to local file with gain calibration params"}},
                                        {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
   workflowOptions.insert(workflowOptions.end(), options.begin(), options.end());
@@ -55,14 +52,10 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   auto inputsubspec = cfgc.options().get<uint32_t>("input-subspec"),
        outputsubspec = cfgc.options().get<uint32_t>("output-subspec");
 
-  std::string pathBadChannelMap = cfgc.options().get<std::string>("local-badchannelmap"),
-              pathTimeCalib = cfgc.options().get<std::string>("local-timecalib"),
-              pathGainCalib = cfgc.options().get<std::string>("local-gaincalib");
-
   o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
 
   WorkflowSpec specs;
-  specs.emplace_back(o2::emcal::getCellRecalibratorSpec(inputsubspec, outputsubspec, !disableBadchannels, !disableTime, !disableEnergy, pathBadChannelMap, pathTimeCalib, pathGainCalib));
+  specs.emplace_back(o2::emcal::getCellRecalibratorSpec(inputsubspec, outputsubspec, !disableBadchannels, !disableTime, !disableEnergy));
 
   // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit
   o2::raw::HBFUtilsInitializer hbfIni(cfgc, specs);


### PR DESCRIPTION
- Remove static loading of calibration objects from file in
  favour of condition-remap from the framework
- Remove ManagedObject as it is no longer needed due to
  ownership handling in the CCDB backend
- Add checkUpdate function triggering the request of the
  calibration objects from the ProcessingContext