### PR TITLE
Fix: use raw string instead of escaping

### DIFF
--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -289,7 +289,7 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
     AlgorithmSpec::dummyAlgorithm(),
     {ConfigParamSpec{"aod-file", VariantType::String, {"Input AOD file"}},
      ConfigParamSpec{"aod-reader-json", VariantType::String, {"json configuration file"}},
-     ConfigParamSpec{"aod-parent-base-path-replacement", VariantType::String, {"Replace base path of parent files. Syntax: FROM;TO. E.g. \"alien:///path/in/alien;/local/path\". Enclose in \"\" on the command line."}},
+     ConfigParamSpec{"aod-parent-base-path-replacement", VariantType::String, {R"(Replace base path of parent files. Syntax: FROM;TO. E.g. "alien:///path/in/alien;/local/path". Enclose in "" on the command line.)"}},
      ConfigParamSpec{"time-limit", VariantType::Int64, 0ll, {"Maximum run time limit in seconds"}},
      ConfigParamSpec{"orbit-offset-enumeration", VariantType::Int64, 0ll, {"initial value for the orbit"}},
      ConfigParamSpec{"orbit-multiplier-enumeration", VariantType::Int64, 0ll, {"multiplier to get the orbit from the counter"}},


### PR DESCRIPTION
@ktf fullCI was failing with `/sw/SOURCES/O2/9802-slc8_x86-64/0/Framework/Core/src/WorkflowHelpers.cxx:292:80: error: escaped string literal can be written as a raw string literal [modernize-raw-string-literal]`