### PR TITLE
fix channel list and give name to proxy

### DIFF
--- a/prodtests/full-system-test/aggregator-workflow.sh
+++ b/prodtests/full-system-test/aggregator-workflow.sh
@@ -112,7 +112,7 @@ if workflow_has_parameter CALIB_PROXIES; then
           FLP_ADDRESS="tcp://alio2-cr1-flp-ib${flp}:${TPC_IDC_FLP_PORT}"
           CHANNELS_LIST+="type=pull,name=tpcidc_flp${flp},transport=zeromq,address=$FLP_ADDRESS,method=connect,rateLogging=10;"
         done
-        add_W o2-dpl-raw-proxy "--proxy-name tpc-idc-merger-proxy --dataspec \"$CALIBDATASPEC_TPCIDC_A;$CALIBDATASPEC_TPCIDC_C\" --channel-config \"$CHANNELS_LIST\" --timeframes-shm-limit $TIMEFRAME_SHM_LIMIT" "" 0
+        add_W o2-dpl-raw-proxy "--proxy-name tpcidc_flp001 --dataspec \"$CALIBDATASPEC_TPCIDC_A;$CALIBDATASPEC_TPCIDC_C\" --channel-config \"$CHANNELS_LIST\" --timeframes-shm-limit $TIMEFRAME_SHM_LIMIT" "" 0
       else
         add_W o2-dpl-raw-proxy "--dataspec \"$CALIBDATASPEC_TPCIDC_A;$CALIBDATASPEC_TPCIDC_C\" $(get_proxy_connection tpcidc_both input)" "" 0
       fi

--- a/prodtests/full-system-test/aggregator-workflow.sh
+++ b/prodtests/full-system-test/aggregator-workflow.sh
@@ -109,10 +109,10 @@ if workflow_has_parameter CALIB_PROXIES; then
         [[ -z $TPC_IDC_FLP_PORT ]] && TPC_IDC_FLP_PORT=47900
         # expand FLPs; TPC uses from 001 to 145, but 145 is reserved for SAC
         for flp in $(seq -f "%03g" 1 144); do
-          FLP_ADDRESS="tcp://alicr1-flp-ib${flp}:${TPC_IDC_FLP_PORT}"
-          CHANNELS_LIST+=" --channel-config \"type=pull,name=tpcidc_flp${flp},transport=zmq,address=$FLP_ADDRESS,method=connect,rateLogging=10\""
+          FLP_ADDRESS="tcp://alio2-cr1-flp-ib${flp}:${TPC_IDC_FLP_PORT}"
+          CHANNELS_LIST+="type=pull,name=tpcidc_flp${flp},transport=zeromq,address=$FLP_ADDRESS,method=connect,rateLogging=10;"
         done
-        add_W o2-dpl-raw-proxy "--dataspec \"$CALIBDATASPEC_TPCIDC_A;$CALIBDATASPEC_TPCIDC_C\" $CHANNELS_LIST --timeframes-shm-limit $TIMEFRAME_SHM_LIMIT" "" 0
+        add_W o2-dpl-raw-proxy "--proxy-name tpc-idc-merger-proxy --dataspec \"$CALIBDATASPEC_TPCIDC_A;$CALIBDATASPEC_TPCIDC_C\" --channel-config \"$CHANNELS_LIST\" --timeframes-shm-limit $TIMEFRAME_SHM_LIMIT" "" 0
       else
         add_W o2-dpl-raw-proxy "--dataspec \"$CALIBDATASPEC_TPCIDC_A;$CALIBDATASPEC_TPCIDC_C\" $(get_proxy_connection tpcidc_both input)" "" 0
       fi


### PR DESCRIPTION
@martenole 
For reference: the change was tested, and I get the expected errors like
```
[3243429:tpc-idc-merger-proxy]: [13:42:37][ERROR] could not resolve hostname 'alicr1-flp-ib062', reason: resolve: Host not found (non-authoritative), try again later
[3243429:tpc-idc-merger-proxy]: [13:42:37][ERROR] failed to attach channel tpcidc_flp062[0] (connect)
```

@davidrohr : when I run aggregator-workflow.sh locally, the "-b" option is not appended anymore to o2-dpl-run, do you know why? On EPNs the `DATA/tools/parse` tool will add it, but locally it would be good if one can have it. I could have added it in aggregator-workflow.sh (https://github.com/AliceO2Group/AliceO2/blob/30a86c743c10956274911326e01fab817b5a1bc6/prodtests/full-system-test/aggregator-workflow.sh#L260) and then I tried that `-b -b` would not make the workflow fail (for when running at P2), but I prefer not to touch this before discussing with you, also because it is not the best way, in my opinion. 



