### PR TITLE
Declaring as inline header defined function

### DIFF
--- a/Framework/Core/include/Framework/BinningPolicy.h
+++ b/Framework/Core/include/Framework/BinningPolicy.h
@@ -22,7 +22,7 @@ namespace o2::framework
 
 namespace binning_helpers
 {
-void expandConstantBinning(std::vector<double> const& bins, std::vector<double>& expanded)
+inline void expandConstantBinning(std::vector<double> const& bins, std::vector<double>& expanded)
 {
   if (bins[0] != VARIABLE_WIDTH) {
     int nBins = static_cast<int>(bins[0]);


### PR DESCRIPTION
If the header file is include by several compiled units which happen to go to the same library the linker complains about multiple defined functions.