### PR TITLE
[EMCAL-835] Trigger exception based on array size

### DIFF
--- a/Detectors/EMCAL/calib/src/GainCalibrationFactors.cxx
+++ b/Detectors/EMCAL/calib/src/GainCalibrationFactors.cxx
@@ -22,7 +22,7 @@ using namespace o2::emcal;
 
 void GainCalibrationFactors::addGainCalibFactor(unsigned short iCell, float gainFactor)
 {
-  if (iCell >= 17664) {
+  if (iCell >= mGainCalibFactors.size()) {
     throw CalibContainerIndexException(iCell);
   }
   mGainCalibFactors[iCell] = gainFactor;
@@ -30,7 +30,7 @@ void GainCalibrationFactors::addGainCalibFactor(unsigned short iCell, float gain
 
 float GainCalibrationFactors::getGainCalibFactors(unsigned short iCell) const
 {
-  if (iCell >= 17664) {
+  if (iCell >= mGainCalibFactors.size()) {
     throw CalibContainerIndexException(iCell);
   }
   return mGainCalibFactors[iCell];

--- a/Detectors/EMCAL/calib/src/TimeCalibrationParams.cxx
+++ b/Detectors/EMCAL/calib/src/TimeCalibrationParams.cxx
@@ -22,7 +22,7 @@ using namespace o2::emcal;
 
 void TimeCalibrationParams::addTimeCalibParam(unsigned short cellID, short time, bool isLowGain)
 {
-  if (cellID >= 17664) {
+  if (cellID >= mTimeCalibParamsHG.size()) {
     throw CalibContainerIndexException(cellID);
   }
   if (!isLowGain) {
@@ -34,7 +34,7 @@ void TimeCalibrationParams::addTimeCalibParam(unsigned short cellID, short time,
 
 short TimeCalibrationParams::getTimeCalibParam(unsigned short cellID, bool isLowGain) const
 {
-  if (cellID >= 17664) {
+  if (cellID >= mTimeCalibParamsHG.size()) {
     throw CalibContainerIndexException(cellID);
   }
   if (isLowGain) {


### PR DESCRIPTION
Use array size instead of hard coded number of cells for triggering the exception in case if invalid cell ID.