### PR TITLE
[EMCAL-798] Add low and high gain histograms

### DIFF
--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/OfflineCalibSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/OfflineCalibSpec.h
@@ -59,6 +59,8 @@ class OfflineCalibSpec : public framework::Task
  private:
   std::unique_ptr<TH2> mCellAmplitude;         ///< Cell energy vs. cell ID
   std::unique_ptr<TH2> mCellTime;              ///< Cell time vs. cell ID
+  std::unique_ptr<TH2> mCellTimeLG;            ///< Cell time vs. cell ID for low gain cells
+  std::unique_ptr<TH2> mCellTimeHG;            ///< Cell time vs. cell ID for high gain cells
   std::unique_ptr<TH1> mNevents;               ///< Number of events
   std::unique_ptr<THnSparseF> mCellTimeEnergy; ///< ID, time, energy
   bool mMakeCellIDTimeEnergy = true;           ///< Switch whether or not to make a THnSparseF of cell ID, time, and energy

--- a/Detectors/EMCAL/workflow/src/OfflineCalibSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/OfflineCalibSpec.cxx
@@ -31,6 +31,10 @@ void OfflineCalibSpec::init(o2::framework::InitContext& ctx)
   mCellAmplitude = std::unique_ptr<TH2>(new TH2F("mCellAmplitude", "Cell amplitude", 800, 0., 40., 17664, -0.5, 17663.5));
   // time vs. cell ID
   mCellTime = std::unique_ptr<TH2>(new TH2F("mCellTime", "Cell time", 800, -200, 600, 17664, -0.5, 17663.5));
+  // time vs. cell ID
+  mCellTimeLG = std::unique_ptr<TH2>(new TH2F("mCellTimeLG", "Cell time (low gain)", 800, -200, 600, 17664, -0.5, 17663.5));
+  // time vs. cell ID
+  mCellTimeHG = std::unique_ptr<TH2>(new TH2F("mCellTimeHG", "Cell time (high gain)", 800, -200, 600, 17664, -0.5, 17663.5));
   // number of events
   mNevents = std::unique_ptr<TH1>(new TH1F("mNevents", "Number of events", 1, 0.5, 1.5));
   if (mMakeCellIDTimeEnergy) {
@@ -69,9 +73,15 @@ void OfflineCalibSpec::run(framework::ProcessingContext& pc)
         LOG(debug) << "[EMCALOfflineSpec - run] Channel: " << c.getTower();
         LOG(debug) << "[EMCALOfflineSpec - run] Energy: " << c.getEnergy();
         LOG(debug) << "[EMCALOfflineSpec - run] Time: " << c.getTimeStamp();
+        LOG(debug) << "[EMCALOfflineSpec - run] IsLowGain: " << c.getLowGain();
         mCellAmplitude->Fill(c.getEnergy(), c.getTower());
         if (c.getEnergy() > 0.5) {
           mCellTime->Fill(c.getTimeStamp(), c.getTower());
+          if (c.getLowGain()) {
+            mCellTimeLG->Fill(c.getTimeStamp(), c.getTower());
+          } else { // high gain cells
+            mCellTimeHG->Fill(c.getTimeStamp(), c.getTower());
+          }
           if (mMakeCellIDTimeEnergy) {
             mCellTimeEnergy->Fill(c.getTower(), c.getTimeStamp(), c.getEnergy());
           }
@@ -89,6 +99,8 @@ void OfflineCalibSpec::endOfStream(o2::framework::EndOfStreamContext& ec)
   outputFile->cd();
   mCellAmplitude->Write();
   mCellTime->Write();
+  mCellTimeLG->Write();
+  mCellTimeHG->Write();
   mNevents->Write();
   if (mMakeCellIDTimeEnergy) {
     mCellTimeEnergy->Write();


### PR DESCRIPTION
- Low gain and high gain cell time has to be calibrated differently
- In order to estimate the difference between the two, two new histograms for low gain and high gain cells (cell time vs. cell ID) have been added to the offline calibrator