### PR TITLE
CTFWriter skips detector storage if an empty CTF container is passed

### DIFF
--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/EncodedBlocks.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/EncodedBlocks.h
@@ -695,6 +695,7 @@ void EncodedBlocks<H, N, W>::clear()
 template <typename H, int N, typename W>
 auto EncodedBlocks<H, N, W>::getImage(const void* newHead)
 {
+  assert(newHead);
   auto image(*get(newHead)); // 1st make a shalow copy
   // now fix its pointers
   // we don't modify newHead, but still need to remove constness for relocation interface


### PR DESCRIPTION
In case of direct ctf filtering as
```
o2-ctf-reader-workflow ... --onlyDet <dets> --allow-missing-detectors | o2-ctf-writer-workflow ...  --onlyDet <dets> the 
```
the writer would get an empty CTF pointer if the requested detector was missing in the original CTF. With this patch, the writing of new CTF for such detector will be skipped, provided this detector did not send non-empty data for previous events.
Otherwise, an exception will be thrown to avoid misalignment between different CTF branches. The same happens if non-empty CTF data is supplied after null data in the previous TF.