### PR TITLE
DPL: use production instance for CCDB test

### DIFF
--- a/Framework/TestWorkflows/src/test_CCDBFetchToTimeframe.cxx
+++ b/Framework/TestWorkflows/src/test_CCDBFetchToTimeframe.cxx
@@ -20,7 +20,7 @@
 using namespace o2::framework;
 
 // Set a start value which might correspond to a real timestamp of an object in CCDB, for example:
-// o2-testworkflows-ccdb-fetch-to-timeframe --condition-backend http://ccdb-test.cern.ch:8080 --start-value-enumeration 1575985965925000
+// o2-testworkflows-ccdb-fetch-to-timeframe --condition-backend http://alice-ccdb.cern.ch --start-value-enumeration 1575985965925000
 WorkflowSpec defineDataProcessing(ConfigContext const&)
 {
   return WorkflowSpec{


### PR DESCRIPTION
ccdb-test is the development instance, so it should not be used for the production tests.