### PR TITLE
Sign of sigma shouldn't flip with bz

### DIFF
--- a/Detectors/Vertexing/src/SVertexHypothesis.cxx
+++ b/Detectors/Vertexing/src/SVertexHypothesis.cxx
@@ -25,7 +25,8 @@ void SVertexHypothesis::set(PID v0, PID ppos, PID pneg, float sig, float nSig, f
   mPars[SigmaM] = sig;
   mPars[NSigmaM] = nSig;
   mPars[MarginM] = margin;
-  mPars[CPt] = std::abs(bz) > 1e-3 ? cpt * 5.0066791 / bz : 0.; // assume that pT dependent sigma is linear with B
+  float absBz{std::abs(bz)};
+  mPars[CPt] = absBz > 1e-3 ? cpt * 5.0066791 / absBz : 0.; // assume that pT dependent sigma is linear with B
 }
 
 void SVertexHypothesis::set(PID v0, PID ppos, PID pneg, const float pars[NPIDParams], float bz)


### PR DESCRIPTION
Hi @shahor02,

we spotted this with @wang-yuanzhe, as it is currently used in the SVertexing it suppresses the efficiency at large momenta if bz is negative. However I am not sure if there is some parameter change that we miss to make it working as intended.

Let us know,
Cheers,
Max