### PR TITLE
DPL Analysis: Rework index builder

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -81,6 +81,7 @@ o2_add_library(Framework
                        src/GraphvizHelpers.cxx
                        src/MermaidHelpers.cxx
                        src/HTTPParser.cxx
+                       src/IndexBuilderHelpers.cxx
                        src/InputRecord.cxx
                        src/InputRouteHelpers.cxx
                        src/InputSpan.cxx

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1018,7 +1018,7 @@ constexpr bool is_binding_compatible_v()
 }
 
 template <typename T, typename B>
-struct is_binding_compatible : std::conditional_t<is_binding_compatible_v<T,typename B::binding_t>(), std::true_type, std::false_type> {
+struct is_binding_compatible : std::conditional_t<is_binding_compatible_v<T, typename B::binding_t>(), std::true_type, std::false_type> {
 };
 
 //! Helper to check if a type T is an iterator
@@ -1203,11 +1203,12 @@ class Table
   }
 
   template <typename Key>
-  inline arrow::ChunkedArray* getIndexToKey() {
-    if constexpr (framework::has_type_conditional_v<is_binding_compatible,Key,external_index_columns_t>) {
-      using IC = framework::pack_element_t<framework::has_type_at_conditional<is_binding_compatible,Key>(external_index_columns_t{}),external_index_columns_t>;
+  inline arrow::ChunkedArray* getIndexToKey()
+  {
+    if constexpr (framework::has_type_conditional_v<is_binding_compatible, Key, external_index_columns_t>) {
+      using IC = framework::pack_element_t<framework::has_type_at_conditional<is_binding_compatible, Key>(external_index_columns_t{}), external_index_columns_t>;
       return mColumnChunks[framework::has_type_at<IC>(persistent_columns_t{})];
-    } else if constexpr (std::is_same_v<table_t,Key>) {
+    } else if constexpr (std::is_same_v<table_t, Key>) {
       return nullptr;
     } else {
       static_assert(framework::always_static_assert_v<Key>, "This table does not have an index to this type");

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1017,6 +1017,10 @@ constexpr bool is_binding_compatible_v()
   return are_bindings_compatible_v<T>(originals_pack_t<B>{});
 }
 
+template <typename T, typename B>
+struct is_binding_compatible : std::conditional_t<is_binding_compatible_v<T,typename B::binding_t>(), std::true_type, std::false_type> {
+};
+
 //! Helper to check if a type T is an iterator
 template <typename T>
 inline constexpr bool is_soa_iterator_v = framework::is_base_of_template_v<RowViewCore, T> || framework::is_specialization_v<T, RowViewCore>;
@@ -1196,6 +1200,18 @@ class Table
   Table(std::vector<std::shared_ptr<arrow::Table>>&& tables, uint64_t offset = 0)
     : Table(ArrowHelpers::joinTables(std::move(tables)), offset)
   {
+  }
+
+  template <typename Key>
+  inline arrow::ChunkedArray* getIndexToKey() {
+    if constexpr (framework::has_type_conditional_v<is_binding_compatible,Key,external_index_columns_t>) {
+      using IC = framework::pack_element_t<framework::has_type_at_conditional<is_binding_compatible,Key>(external_index_columns_t{}),external_index_columns_t>;
+      return mColumnChunks[framework::has_type_at<IC>(persistent_columns_t{})];
+    } else if constexpr (std::is_same_v<table_t,Key>) {
+      return nullptr;
+    } else {
+      static_assert(framework::always_static_assert_v<Key>, "This table does not have an index to this type");
+    }
   }
 
   unfiltered_iterator begin()

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -20,6 +20,9 @@
 #include "Framework/OutputObjHeader.h"
 #include "Framework/StringHelpers.h"
 #include "Framework/Output.h"
+#include "Framework/IndexBuilderHelpers.h"
+#include <arrow/table.h>
+#include <arrow/util/key_value_metadata.h>
 #include <string>
 namespace o2::framework
 {
@@ -219,154 +222,102 @@ struct Spawns : TableTransform<typename aod::MetadataTrait<framework::pack_head_
 
 /// Policy to control index building
 /// Exclusive index: each entry in a row has a valid index
-struct IndexExclusive {
-  /// Generic builder for in index table
-  template <typename... Cs, typename Key, typename T1, typename... T>
-  static auto indexBuilder(const char* label, framework::pack<Cs...>, Key const&, std::tuple<T1, T...>&& tables)
-  {
-    static_assert(sizeof...(Cs) == sizeof...(T) + 1, "Number of columns does not coincide with number of supplied tables");
-    using tables_t = framework::pack<T...>;
-    using first_t = T1;
-    auto tail = tuple_tail(tables);
-    TableBuilder builder;
-    auto cursor = framework::FFL(builder.cursor<o2::soa::Table<Cs...>>());
-
-    std::array<int32_t, sizeof...(T)> values;
-    iterator_tuple_t<std::decay_t<T>...> iterators = std::apply(
-      [](auto&&... x) {
-        return std::make_tuple(x.begin()...);
-      },
-      tail);
-
-    using rest_it_t = decltype(pack_from_tuple(iterators));
-
-    auto setValue = [&](auto& x, int idx) -> bool {
-      using type = std::decay_t<decltype(x)>;
-      constexpr auto position = framework::has_type_at_v<type>(rest_it_t{});
-
-      if constexpr (std::is_same_v<framework::pack_element_t<position, framework::pack<std::decay_t<T>...>>, Key>) {
-        values[position] = idx;
-        return true;
-      } else {
-        lowerBound<Key>(idx, x);
-        if (x == soa::RowViewSentinel{static_cast<uint64_t>(x.size())}) {
-          return false;
-        } else if (x.template getId<Key>() != idx) {
-          return false;
-        } else {
-          values[position] = x.globalIndex();
-          ++x;
-          return true;
-        }
-      }
-    };
-
-    auto first = std::get<first_t>(tables);
-    for (auto& row : first) {
-      auto idx = -1;
-      if constexpr (std::is_same_v<first_t, Key>) {
-        idx = row.globalIndex();
-      } else {
-        idx = row.template getId<Key>();
-      }
-      if (std::apply(
-            [](auto&... x) {
-              return ((x == soa::RowViewSentinel{static_cast<uint64_t>(x.size())}) && ...);
-            },
-            iterators)) {
-        break;
-      }
-
-      auto result = std::apply(
-        [&](auto&... x) {
-          std::array<bool, sizeof...(T)> results{setValue(x, idx)...};
-          return (results[framework::has_type_at_v<std::decay_t<decltype(x)>>(rest_it_t{})] && ...);
-        },
-        iterators);
-
-      if (result) {
-        cursor(0, row.globalIndex(), values[framework::has_type_at_v<T>(tables_t{})]...);
-      }
-    }
-    builder.setLabel(label);
-    return builder.finalize();
-  }
-
-  template <typename IDX, typename Key, typename T1, typename... T>
-  static auto makeIndex(Key const& key, std::tuple<T1, T...>&& tables)
-  {
-    auto t = IDX{indexBuilder(o2::aod::MetadataTrait<IDX>::metadata::tableLabel(),
-                              typename o2::aod::MetadataTrait<IDX>::metadata::index_pack_t{},
-                              key,
-                              std::make_tuple(std::decay_t<T1>{{std::get<T1>(tables).asArrowTable()}}, std::decay_t<T>{{std::get<T>(tables).asArrowTable()}}...))};
-    t.bindExternalIndices(&key, &std::get<T1>(tables), &std::get<T>(tables)...);
-    return t;
-  }
-};
 /// Sparse index: values in a row can be (-1), index table is isomorphic (joinable)
 /// to T1
-struct IndexSparse {
-  template <typename... Cs, typename Key, typename T1, typename... T>
-  static auto indexBuilder(const char* label, framework::pack<Cs...>, Key const&, std::tuple<T1, T...>&& tables)
-  {
-    static_assert(sizeof...(Cs) == sizeof...(T) + 1, "Number of columns does not coincide with number of supplied tables");
-    using tables_t = framework::pack<T...>;
-    using first_t = T1;
-    auto tail = tuple_tail(tables);
-    TableBuilder builder;
-    auto cursor = framework::FFL(builder.cursor<o2::soa::Table<Cs...>>());
+struct Exclusive {};
+struct Sparse {};
 
-    std::array<int32_t, sizeof...(T)> values;
+namespace {
+template <typename T, typename Key>
+inline arrow::ChunkedArray* getIndexToKey(arrow::Table* table) {
+//  if constexpr (framework::has_type_conditional_v<soa::is_binding_compatible,Key,typename T::external_index_columns_t>) {
+    using IC = framework::pack_element_t<framework::has_type_at_conditional<soa::is_binding_compatible,Key>(typename T::external_index_columns_t{}),typename T::external_index_columns_t>;
+    return table->column(framework::has_type_at<IC>(typename T::persistent_columns_t{})).get();
+//  } else if constexpr (std::is_same_v<typename T::table_t,Key>) {
+//    return nullptr;
+//  } else {
+//    static_assert(framework::always_static_assert_v<Key>, "This table does not have an index to this type");
+//  }
+}
 
-    iterator_tuple_t<std::decay_t<T>...> iterators = std::apply(
-      [](auto&&... x) {
-        return std::make_tuple(x.begin()...);
-      },
-      tail);
+template <typename C>
+struct ColumnTrait {
+  static_assert(framework::is_base_of_template_v<o2::soa::Column,C>, "Not a column type!");
+  using column_t = C;
 
-    using rest_it_t = decltype(pack_from_tuple(iterators));
-
-    auto setValue = [&](auto& x, int idx) -> bool {
-      using type = std::decay_t<decltype(x)>;
-      constexpr auto position = framework::has_type_at_v<type>(rest_it_t{});
-
-      if constexpr (std::is_same_v<framework::pack_element_t<position, framework::pack<std::decay_t<T>...>>, Key>) {
-        values[position] = idx;
-        return true;
+  static constexpr auto listSize(){
+      if constexpr (std::is_same_v<typename C::type, std::vector<int>>) {
+        return -1;
+      } else if constexpr (std::is_same_v<int[2],typename C::type>) {
+        return 2;
       } else {
-        lowerBound<Key>(idx, x);
-        if (x == soa::RowViewSentinel{static_cast<uint64_t>(x.size())}) {
-          values[position] = -1;
-          return false;
-        } else if (x.template getId<Key>() != idx) {
-          values[position] = -1;
-          return false;
-        } else {
-          values[position] = x.globalIndex();
-          ++x;
-          return true;
+        return 1;
+      }
+  }
+
+  template <typename T, typename Key>
+  static std::shared_ptr<SelfIndexColumnBuilder> makeColumnBuilder(arrow::Table* table, arrow::MemoryPool* pool)
+  {
+    if constexpr (!std::is_same_v<T,Key>)  {
+      return std::make_shared<IndexColumnBuilder>(getIndexToKey<T,Key>(table), C::columnLabel(), listSize(), pool);
+    } else {
+      return std::make_shared<SelfIndexColumnBuilder>(C::columnLabel(), pool);
+    }
+  }
+};
+}
+
+template <typename Key, typename C>
+struct Reduction {
+  using type = typename std::conditional<soa::is_binding_compatible_v<Key,typename C::binding_t>(),SelfIndexColumnBuilder,IndexColumnBuilder>::type;
+};
+
+template <typename Kind>
+struct IndexBuilder {
+  template <typename Key, typename C1, typename... Cs, typename T1, typename... Ts>
+  static auto indexBuilder(const char* label, std::vector<std::shared_ptr<arrow::Table>>&& tables, framework::pack<C1,Cs...>, framework::pack<T1,Ts...>)
+  {
+    auto pool = arrow::default_memory_pool();
+    SelfIndexColumnBuilder self{C1::columnLabel(),pool};
+    std::unique_ptr<ChunkedArrayIterator> keyIndex = nullptr;
+    int64_t counter = 0;
+    if constexpr (!std::is_same_v<T1,Key>) {
+      keyIndex = std::make_unique<ChunkedArrayIterator>(getIndexToKey<T1, Key>(tables[0].get()));
+    }
+
+    std::array<std::shared_ptr<framework::SelfIndexColumnBuilder>, sizeof...(Cs)> columnBuilders{ColumnTrait<Cs>::template makeColumnBuilder<framework::pack_element_t<framework::has_type_at_v<Cs>(framework::pack<Cs...>{}), framework::pack<Ts...>>, Key>(
+      tables[framework::has_type_at_v<Cs>(framework::pack<Cs...>{}) + 1].get(),
+        pool)...};
+    std::array<bool, sizeof...(Cs)> finds;
+
+    for (counter = 0; counter < tables[0]->num_rows(); ++counter) {
+      auto idx = -1;
+      if constexpr (std::is_same_v<T1,Key>) {
+        idx = counter;
+      } else {
+        idx = keyIndex->valueAt(counter);
+      }
+      finds = {std::static_pointer_cast<typename Reduction<Key,Cs>::type>(columnBuilders[framework::has_type_at_v<Cs>(framework::pack<Cs...>{})])->template find<Cs>(idx)...};
+      if constexpr (std::is_same_v<Kind,Sparse>) {
+        (std::static_pointer_cast<typename Reduction<Key,Cs>::type>(columnBuilders[framework::has_type_at_v<Cs>(framework::pack<Cs...>{})])->template fill<Cs>(idx),...);
+        self.fill<C1>(counter);
+      } else if constexpr (std::is_same_v<Kind,Exclusive>) {
+        if (std::none_of(finds.begin(),finds.end(),[](bool const x){ return x == false; })) {
+          (std::static_pointer_cast<typename Reduction<Key,Cs>::type>(columnBuilders[framework::has_type_at_v<Cs>(framework::pack<Cs...>{})])->template fill<Cs>(idx),...);
+          self.fill<C1>(counter);
         }
       }
-    };
-
-    auto first = std::get<first_t>(tables);
-    for (auto& row : first) {
-      auto idx = -1;
-      if constexpr (std::is_same_v<first_t, Key>) {
-        idx = row.globalIndex();
-      } else {
-        idx = row.template getId<Key>();
-      }
-      std::apply(
-        [&](auto&... x) {
-          (setValue(x, idx), ...);
-        },
-        iterators);
-
-      cursor(0, row.globalIndex(), values[framework::has_type_at_v<T>(tables_t{})]...);
     }
-    builder.setLabel(label);
-    return builder.finalize();
+
+    std::vector<std::shared_ptr<arrow::ChunkedArray>> columns{self.template result<C1>(), std::static_pointer_cast<typename Reduction<Key,Cs>::type>(columnBuilders[framework::has_type_at_v<Cs>(framework::pack<Cs...>{})])->template result<Cs>()...};
+    std::vector<std::shared_ptr<arrow::Field>> fields{self.field(), std::static_pointer_cast<typename Reduction<Key,Cs>::type>(columnBuilders[framework::has_type_at_v<Cs>(framework::pack<Cs...>{})])->field()...};
+    auto schema = std::make_shared<arrow::Schema>(fields);
+    schema->WithMetadata(
+      std::make_shared<arrow::KeyValueMetadata>(
+        std::vector{std::string{"label"}},
+        std::vector{std::string{label}}));
+    auto table = arrow::Table::Make(schema, columns);
+    return table;
   }
 
   template <typename IDX, typename Key, typename T1, typename... T>
@@ -384,7 +335,7 @@ struct IndexSparse {
 /// This helper struct allows you to declare index tables to be created in a task
 template <typename T>
 struct Builds : TableTransform<typename aod::MetadataTrait<T>::metadata> {
-  using IP = std::conditional_t<aod::MetadataTrait<T>::metadata::exclusive, IndexExclusive, IndexSparse>;
+  using IP = std::conditional_t<aod::MetadataTrait<T>::metadata::exclusive, IndexBuilder<Exclusive>, IndexBuilder<Sparse>>;
   using Key = typename T::indexing_t;
   using H = typename T::first_t;
   using Ts = typename T::rest_t;
@@ -410,10 +361,10 @@ struct Builds : TableTransform<typename aod::MetadataTrait<T>::metadata> {
     return index_pack_t{};
   }
 
-  template <typename... Cs, typename Key, typename T1, typename... Ts>
-  auto build(framework::pack<Cs...>, Key const& key, std::tuple<T1, Ts...>&& tables)
+  template <typename Key, typename... Cs, typename... Ts>
+  auto build(framework::pack<Cs...>, framework::pack<Ts...>, std::vector<std::shared_ptr<arrow::Table>>&& tables)
   {
-    this->table = std::make_shared<T>(IP::indexBuilder(aod::MetadataTrait<T>::metadata::tableLabel(), framework::pack<Cs...>{}, key, std::forward<std::tuple<T1, Ts...>>(tables)));
+    this->table = std::make_shared<T>(IP::template indexBuilder<Key>(aod::MetadataTrait<T>::metadata::tableLabel(), std::forward<std::vector<std::shared_ptr<arrow::Table>>>(tables), framework::pack<Cs...>{}, framework::pack<Ts...>{}));
     return (this->table != nullptr);
   }
 };

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -21,8 +21,6 @@
 #include "Framework/StringHelpers.h"
 #include "Framework/Output.h"
 #include "Framework/IndexBuilderHelpers.h"
-#include <arrow/table.h>
-#include <arrow/util/key_value_metadata.h>
 #include <string>
 namespace o2::framework
 {
@@ -264,12 +262,12 @@ struct ColumnTrait {
     }
   }
 };
-} // namespace
 
 template <typename Key, typename C>
 struct Reduction {
   using type = typename std::conditional<soa::is_binding_compatible_v<Key, typename C::binding_t>(), SelfIndexColumnBuilder, IndexColumnBuilder>::type;
 };
+} // namespace
 
 template <typename Kind>
 struct IndexBuilder {

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -306,15 +306,9 @@ struct IndexBuilder {
       }
     }
 
-    std::vector<std::shared_ptr<arrow::ChunkedArray>> columns{self.template result<C1>(), std::static_pointer_cast<typename Reduction<Key, Cs>::type>(columnBuilders[framework::has_type_at_v<Cs>(framework::pack<Cs...>{})])->template result<Cs>()...};
-    std::vector<std::shared_ptr<arrow::Field>> fields{self.field(), std::static_pointer_cast<typename Reduction<Key, Cs>::type>(columnBuilders[framework::has_type_at_v<Cs>(framework::pack<Cs...>{})])->field()...};
-    auto schema = std::make_shared<arrow::Schema>(fields);
-    schema->WithMetadata(
-      std::make_shared<arrow::KeyValueMetadata>(
-        std::vector{std::string{"label"}},
-        std::vector{std::string{label}}));
-    auto table = arrow::Table::Make(schema, columns);
-    return table;
+    return makeArrowTable(label,
+                          {self.template result<C1>(), std::static_pointer_cast<typename Reduction<Key, Cs>::type>(columnBuilders[framework::has_type_at_v<Cs>(framework::pack<Cs...>{})])->template result<Cs>()...},
+                          {self.field(), std::static_pointer_cast<typename Reduction<Key, Cs>::type>(columnBuilders[framework::has_type_at_v<Cs>(framework::pack<Cs...>{})])->field()...});
   }
 
   template <typename IDX, typename Key, typename T1, typename... T>

--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -230,14 +230,8 @@ struct Sparse {};
 namespace {
 template <typename T, typename Key>
 inline arrow::ChunkedArray* getIndexToKey(arrow::Table* table) {
-//  if constexpr (framework::has_type_conditional_v<soa::is_binding_compatible,Key,typename T::external_index_columns_t>) {
     using IC = framework::pack_element_t<framework::has_type_at_conditional<soa::is_binding_compatible,Key>(typename T::external_index_columns_t{}),typename T::external_index_columns_t>;
     return table->column(framework::has_type_at<IC>(typename T::persistent_columns_t{})).get();
-//  } else if constexpr (std::is_same_v<typename T::table_t,Key>) {
-//    return nullptr;
-//  } else {
-//    static_assert(framework::always_static_assert_v<Key>, "This table does not have an index to this type");
-//  }
 }
 
 template <typename C>

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -346,26 +346,26 @@ struct OutputManager<Spawns<T>> {
 };
 
 /// Builds specialization
-template <typename... Os>
-static inline auto extractOriginalsVector(framework::pack<Os...>, ProcessingContext& pc)
+template <typename... Ts>
+static inline auto doExtractOriginal(framework::pack<Ts...>, ProcessingContext& pc)
 {
-  return std::vector{extractOriginal<Os>(pc)...};
-}
-
-template <typename O>
-static inline auto extractTypedOriginal(ProcessingContext& pc)
-{
-  if constexpr (soa::is_type_with_originals_v<O>) {
-    return O{extractOriginalsVector(soa::originals_pack_t<O>{}, pc)};
+  if constexpr (sizeof...(Ts) == 1) {
+    return pc.inputs().get<TableConsumer>(aod::MetadataTrait<framework::pack_element_t<0, framework::pack<Ts...>>>::metadata::tableLabel())->asArrowTable();
   } else {
-    return O{pc.inputs().get<TableConsumer>(aod::MetadataTrait<O>::metadata::tableLabel())->asArrowTable()};
+    return std::vector{pc.inputs().get<TableConsumer>(aod::MetadataTrait<Ts>::metadata::tableLabel())->asArrowTable()...};
   }
 }
 
-template <typename... Os>
-static inline auto extractOriginalsTuple(framework::pack<Os...>, ProcessingContext& pc)
+template <typename O>
+static inline auto extractOriginalJoined(ProcessingContext& pc)
 {
-  return std::make_tuple(extractTypedOriginal<Os>(pc)...);
+  return o2::soa::ArrowHelpers::joinTables({doExtractOriginal(soa::make_originals_from_type<O>(), pc)});
+}
+
+template <typename... Os>
+static inline auto extractOriginalsVector(framework::pack<Os...>, ProcessingContext& pc)
+{
+  return std::vector{extractOriginalJoined<Os>(pc)...};
 }
 
 template <typename T>
@@ -378,9 +378,8 @@ struct OutputManager<Builds<T>> {
 
   static bool prepare(ProcessingContext& pc, Builds<T>& what)
   {
-    return what.build(what.pack(),
-                      extractTypedOriginal<typename Builds<T>::Key>(pc),
-                      extractOriginalsTuple(what.originals_pack(), pc));
+    return what.template build<typename T::indexing_t>(what.pack(),what.originals_pack(),
+                                            extractOriginalsVector(what.originals_pack(), pc));
   }
 
   static bool finalize(ProcessingContext& pc, Builds<T>& what)

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -378,8 +378,8 @@ struct OutputManager<Builds<T>> {
 
   static bool prepare(ProcessingContext& pc, Builds<T>& what)
   {
-    return what.template build<typename T::indexing_t>(what.pack(),what.originals_pack(),
-                                            extractOriginalsVector(what.originals_pack(), pc));
+    return what.template build<typename T::indexing_t>(what.pack(), what.originals_pack(),
+                                                       extractOriginalsVector(what.originals_pack(), pc));
   }
 
   static bool finalize(ProcessingContext& pc, Builds<T>& what)

--- a/Framework/Core/include/Framework/IndexBuilderHelpers.h
+++ b/Framework/Core/include/Framework/IndexBuilderHelpers.h
@@ -137,6 +137,8 @@ class IndexColumnBuilder : public SelfIndexColumnBuilder, public ChunkedArrayIte
   size_t mSourceSize = 0;
   size_t mResultSize = 0;
 };
+
+std::shared_ptr<arrow::Table> makeArrowTable(const char* label, std::vector<std::shared_ptr<arrow::ChunkedArray> > &&columns, std::vector<std::shared_ptr<arrow::Field> > &&fields);
 } // namespace o2::framework
 
 #endif // O2_FRAMEWORK_INDEXBUILDERHELPERS_H_

--- a/Framework/Core/include/Framework/IndexBuilderHelpers.h
+++ b/Framework/Core/include/Framework/IndexBuilderHelpers.h
@@ -138,7 +138,7 @@ class IndexColumnBuilder : public SelfIndexColumnBuilder, public ChunkedArrayIte
   size_t mResultSize = 0;
 };
 
-std::shared_ptr<arrow::Table> makeArrowTable(const char* label, std::vector<std::shared_ptr<arrow::ChunkedArray> > &&columns, std::vector<std::shared_ptr<arrow::Field> > &&fields);
+std::shared_ptr<arrow::Table> makeArrowTable(const char* label, std::vector<std::shared_ptr<arrow::ChunkedArray>>&& columns, std::vector<std::shared_ptr<arrow::Field>>&& fields);
 } // namespace o2::framework
 
 #endif // O2_FRAMEWORK_INDEXBUILDERHELPERS_H_

--- a/Framework/Core/include/Framework/IndexBuilderHelpers.h
+++ b/Framework/Core/include/Framework/IndexBuilderHelpers.h
@@ -1,0 +1,136 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_FRAMEWORK_INDEXBUILDERHELPERS_H_
+#define O2_FRAMEWORK_INDEXBUILDERHELPERS_H_
+#include "Framework/RuntimeError.h"
+#include "arrow/array.h"
+#include <arrow/chunked_array.h>
+#include <arrow/builder.h>
+#include <arrow/memory_pool.h>
+#include <string>
+#include <memory>
+#include <type_traits>
+
+namespace o2::framework {
+struct ChunkedArrayIterator {
+  ChunkedArrayIterator(arrow::ChunkedArray* source);
+  virtual ~ChunkedArrayIterator() {}
+
+  arrow::ChunkedArray* mSource;
+  size_t mPosition = 0;
+  int mChunk = 0;
+  size_t mOffset = 0;
+  std::shared_ptr<arrow::Int32Array> mCurrentArray = nullptr;
+  int const* mCurrent = nullptr;
+  int const* mLast = nullptr;
+  size_t mFirstIndex = 0;
+
+  std::shared_ptr<arrow::Int32Array> getCurrentArray();
+  void nextChunk();
+  void prevChunk();
+  int valueAt(size_t pos);
+};
+
+struct SelfIndexColumnBuilder {
+  SelfIndexColumnBuilder(const char* name, arrow::MemoryPool* pool);
+  virtual ~SelfIndexColumnBuilder() {}
+
+  template <typename C>
+  inline std::shared_ptr<arrow::ChunkedArray> result() const
+  {
+    std::shared_ptr<arrow::Array> array;
+    auto status = static_cast<arrow::Int32Builder*>(mBuilder.get())->Finish(&array);
+    if (!status.ok()) {
+      throw runtime_error("Cannot build an array");
+    }
+
+    return std::make_shared<arrow::ChunkedArray>(array);
+  }
+  std::shared_ptr<arrow::Field> field() const;
+  template <typename C>
+  inline bool find(int) {return true;}
+
+  template <typename C>
+  inline void fill(int idx)
+  {
+    (void)static_cast<arrow::Int32Builder*>(mBuilder.get())->Append(idx);
+  }
+
+
+  std::string mColumnName;
+  std::unique_ptr<arrow::ArrayBuilder> mBuilder = nullptr;
+};
+
+class IndexColumnBuilder : public SelfIndexColumnBuilder, public ChunkedArrayIterator {
+ public:
+  IndexColumnBuilder(arrow::ChunkedArray* source, const char *name, int listSize, arrow::MemoryPool* pool);
+  virtual ~IndexColumnBuilder() {}
+
+  template <typename C>
+  inline std::shared_ptr<arrow::ChunkedArray> result() const
+  {
+    if constexpr (std::is_same_v<typename C::type, std::vector<int>>) {
+      return resultMulti();
+    } else if constexpr (std::is_same_v<typename C::type, int[2]>) {
+      return resultSlice();
+    } else {
+      return resultSingle();
+    }
+  }
+
+  template <typename C>
+  inline bool find(int idx) {
+    if constexpr (std::is_same_v<typename C::type, std::vector<int>>) {
+      return findMulti(idx);
+    } else if constexpr (std::is_same_v<typename C::type, int[2]>) {
+      return findSlice(idx);
+    } else {
+      return findSingle(idx);
+    }
+  }
+
+  template <typename C>
+  inline void fill(int idx){
+    ++mResultSize;
+    if constexpr (std::is_same_v<typename C::type, std::vector<int>>) {
+      fillMulti(idx);
+    } else if constexpr (std::is_same_v<typename C::type, int[2]>) {
+      fillSlice(idx);
+    } else {
+      fillSingle(idx);
+    }
+  }
+
+ private:
+  bool findSingle(int idx);
+  bool findSlice(int idx);
+  bool findMulti(int idx);
+
+  void fillSingle(int idx);
+  void fillSlice(int idx);
+  void fillMulti(int idx);
+
+  std::shared_ptr<arrow::ChunkedArray> resultSingle() const;
+  std::shared_ptr<arrow::ChunkedArray> resultSlice() const;
+  std::shared_ptr<arrow::ChunkedArray> resultMulti() const;
+
+  int mListSize = 1;
+  std::shared_ptr<arrow::DataType> mArrowType;
+  arrow::ArrayBuilder* mValueBuilder = nullptr;
+  std::unique_ptr<arrow::ArrayBuilder> mListBuilder = nullptr;
+
+  size_t mSourceSize = 0;
+  size_t mResultSize = 0;
+};
+}
+
+#endif // O2_FRAMEWORK_INDEXBUILDERHELPERS_H_

--- a/Framework/Core/include/Framework/IndexBuilderHelpers.h
+++ b/Framework/Core/include/Framework/IndexBuilderHelpers.h
@@ -20,7 +20,8 @@
 #include <memory>
 #include <type_traits>
 
-namespace o2::framework {
+namespace o2::framework
+{
 struct ChunkedArrayIterator {
   ChunkedArrayIterator(arrow::ChunkedArray* source);
   virtual ~ChunkedArrayIterator() {}
@@ -57,7 +58,10 @@ struct SelfIndexColumnBuilder {
   }
   std::shared_ptr<arrow::Field> field() const;
   template <typename C>
-  inline bool find(int) {return true;}
+  inline bool find(int)
+  {
+    return true;
+  }
 
   template <typename C>
   inline void fill(int idx)
@@ -65,14 +69,14 @@ struct SelfIndexColumnBuilder {
     (void)static_cast<arrow::Int32Builder*>(mBuilder.get())->Append(idx);
   }
 
-
   std::string mColumnName;
   std::unique_ptr<arrow::ArrayBuilder> mBuilder = nullptr;
 };
 
-class IndexColumnBuilder : public SelfIndexColumnBuilder, public ChunkedArrayIterator {
+class IndexColumnBuilder : public SelfIndexColumnBuilder, public ChunkedArrayIterator
+{
  public:
-  IndexColumnBuilder(arrow::ChunkedArray* source, const char *name, int listSize, arrow::MemoryPool* pool);
+  IndexColumnBuilder(arrow::ChunkedArray* source, const char* name, int listSize, arrow::MemoryPool* pool);
   virtual ~IndexColumnBuilder() {}
 
   template <typename C>
@@ -88,7 +92,8 @@ class IndexColumnBuilder : public SelfIndexColumnBuilder, public ChunkedArrayIte
   }
 
   template <typename C>
-  inline bool find(int idx) {
+  inline bool find(int idx)
+  {
     if constexpr (std::is_same_v<typename C::type, std::vector<int>>) {
       return findMulti(idx);
     } else if constexpr (std::is_same_v<typename C::type, int[2]>) {
@@ -99,7 +104,8 @@ class IndexColumnBuilder : public SelfIndexColumnBuilder, public ChunkedArrayIte
   }
 
   template <typename C>
-  inline void fill(int idx){
+  inline void fill(int idx)
+  {
     ++mResultSize;
     if constexpr (std::is_same_v<typename C::type, std::vector<int>>) {
       fillMulti(idx);
@@ -131,6 +137,6 @@ class IndexColumnBuilder : public SelfIndexColumnBuilder, public ChunkedArrayIte
   size_t mSourceSize = 0;
   size_t mResultSize = 0;
 };
-}
+} // namespace o2::framework
 
 #endif // O2_FRAMEWORK_INDEXBUILDERHELPERS_H_

--- a/Framework/Core/include/Framework/IndexBuilderHelpers.h
+++ b/Framework/Core/include/Framework/IndexBuilderHelpers.h
@@ -24,7 +24,7 @@ namespace o2::framework
 {
 struct ChunkedArrayIterator {
   ChunkedArrayIterator(arrow::ChunkedArray* source);
-  virtual ~ChunkedArrayIterator() {}
+  virtual ~ChunkedArrayIterator() = default;
 
   arrow::ChunkedArray* mSource;
   size_t mPosition = 0;
@@ -43,7 +43,7 @@ struct ChunkedArrayIterator {
 
 struct SelfIndexColumnBuilder {
   SelfIndexColumnBuilder(const char* name, arrow::MemoryPool* pool);
-  virtual ~SelfIndexColumnBuilder() {}
+  virtual ~SelfIndexColumnBuilder() = default;
 
   template <typename C>
   inline std::shared_ptr<arrow::ChunkedArray> result() const
@@ -77,7 +77,7 @@ class IndexColumnBuilder : public SelfIndexColumnBuilder, public ChunkedArrayIte
 {
  public:
   IndexColumnBuilder(arrow::ChunkedArray* source, const char* name, int listSize, arrow::MemoryPool* pool);
-  virtual ~IndexColumnBuilder() {}
+  virtual ~IndexColumnBuilder() override = default;
 
   template <typename C>
   inline std::shared_ptr<arrow::ChunkedArray> result() const

--- a/Framework/Core/include/Framework/IndexBuilderHelpers.h
+++ b/Framework/Core/include/Framework/IndexBuilderHelpers.h
@@ -77,7 +77,7 @@ class IndexColumnBuilder : public SelfIndexColumnBuilder, public ChunkedArrayIte
 {
  public:
   IndexColumnBuilder(arrow::ChunkedArray* source, const char* name, int listSize, arrow::MemoryPool* pool);
-  virtual ~IndexColumnBuilder() override = default;
+  ~IndexColumnBuilder() override = default;
 
   template <typename C>
   inline std::shared_ptr<arrow::ChunkedArray> result() const

--- a/Framework/Core/src/IndexBuilderHelpers.cxx
+++ b/Framework/Core/src/IndexBuilderHelpers.cxx
@@ -12,9 +12,8 @@
 #include "Framework/IndexBuilderHelpers.h"
 #include "Framework/CompilerBuiltins.h"
 #include <arrow/status.h>
-#include <arrow/stl.h>
-#include <arrow/type_traits.h>
-#include <iostream>
+#include <arrow/table.h>
+#include <arrow/util/key_value_metadata.h>
 
 namespace o2::framework
 {
@@ -179,5 +178,15 @@ int ChunkedArrayIterator::valueAt(size_t pos)
     prevChunk();
   }
   return *(mCurrent + pos);
+}
+
+std::shared_ptr<arrow::Table> makeArrowTable(const char* label, std::vector<std::shared_ptr<arrow::ChunkedArray>>&& columns, std::vector<std::shared_ptr<arrow::Field>>&& fields)
+{
+  auto schema = std::make_shared<arrow::Schema>(fields);
+  schema->WithMetadata(
+    std::make_shared<arrow::KeyValueMetadata>(
+      std::vector{std::string{"label"}},
+      std::vector{std::string{label}}));
+  return arrow::Table::Make(schema, columns);
 }
 } // namespace o2::framework

--- a/Framework/Core/src/IndexBuilderHelpers.cxx
+++ b/Framework/Core/src/IndexBuilderHelpers.cxx
@@ -1,0 +1,183 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/IndexBuilderHelpers.h"
+#include "Framework/CompilerBuiltins.h"
+#include <arrow/status.h>
+#include <arrow/stl.h>
+#include <arrow/type_traits.h>
+#include <iostream>
+
+namespace o2::framework
+{
+ChunkedArrayIterator::ChunkedArrayIterator(arrow::ChunkedArray* source)
+  : mSource{source}
+{
+  mCurrentArray = getCurrentArray();
+  mCurrent = reinterpret_cast<int const*>(mCurrentArray->values()->data()) + mOffset;
+  mLast = mCurrent + mCurrentArray->length();
+}
+
+SelfIndexColumnBuilder::SelfIndexColumnBuilder(const char* name, arrow::MemoryPool* pool)
+  : mColumnName{name}
+{
+  auto status = arrow::MakeBuilder(pool, arrow::int32(), &mBuilder);
+  if (!status.ok()) {
+    throw runtime_error("Cannot create array builder!");
+  }
+}
+
+std::shared_ptr<arrow::Field> SelfIndexColumnBuilder::field() const
+{
+  return std::make_shared<arrow::Field>(mColumnName, arrow::int32());
+}
+
+IndexColumnBuilder::IndexColumnBuilder(arrow::ChunkedArray* source, const char* name, int listSize, arrow::MemoryPool* pool)
+  : ChunkedArrayIterator{source},
+    SelfIndexColumnBuilder{name, pool},
+    mListSize{listSize},
+    mSourceSize{(size_t)source->length()}
+{
+  switch (mListSize) {
+    case 1: {
+      mValueBuilder = mBuilder.get();
+      mArrowType = arrow::int32();
+    }; break;
+    case 2: {
+      mListBuilder = std::make_unique<arrow::FixedSizeListBuilder>(pool, std::move(mBuilder), mListSize);
+      mValueBuilder = static_cast<arrow::FixedSizeListBuilder*>(mListBuilder.get())->value_builder();
+      mArrowType = arrow::fixed_size_list(arrow::int32(), 2);
+    }; break;
+    case -1: {
+      mListBuilder = std::make_unique<arrow::ListBuilder>(pool, std::move(mBuilder));
+      mValueBuilder = static_cast<arrow::ListBuilder*>(mListBuilder.get())->value_builder();
+      mArrowType = arrow::list(arrow::int32());
+    }; break;
+    default:
+      throw runtime_error_f("Invalid list size for index column: %d", mListSize);
+  }
+}
+
+std::shared_ptr<arrow::ChunkedArray> IndexColumnBuilder::resultSingle() const
+{
+  std::shared_ptr<arrow::Array> array;
+  auto status = static_cast<arrow::Int32Builder*>(mValueBuilder)->Finish(&array);
+  if (!status.ok()) {
+    throw runtime_error("Cannot build an array");
+  }
+  return std::make_shared<arrow::ChunkedArray>(array);
+}
+
+std::shared_ptr<arrow::ChunkedArray> IndexColumnBuilder::resultSlice() const
+{
+  std::shared_ptr<arrow::Array> array;
+  std::shared_ptr<arrow::Array> varray;
+  auto status = static_cast<arrow::Int32Builder*>(mValueBuilder)->Finish(&varray);
+  if (!status.ok()) {
+    throw runtime_error("Cannot build an array");
+  }
+  array = std::make_shared<arrow::FixedSizeListArray>(mArrowType, mResultSize, varray);
+  return std::make_shared<arrow::ChunkedArray>(array);
+}
+
+std::shared_ptr<arrow::ChunkedArray> IndexColumnBuilder::resultMulti() const
+{
+  throw runtime_error("Not implemented");
+}
+
+bool IndexColumnBuilder::findSingle(int idx)
+{
+  size_t step = 0;
+  auto count = mSourceSize - mPosition;
+  while (count > 0) {
+    step = count / 2;
+    mPosition += step;
+    if (valueAt(mPosition) <= idx) {
+      count -= step + 1;
+    } else {
+      mPosition -= step;
+      count = step;
+    }
+  }
+
+  return (mPosition < mSourceSize && valueAt(mPosition) == idx);
+}
+
+bool IndexColumnBuilder::findSlice(int idx)
+{
+  throw runtime_error("Not implemented");
+}
+
+bool IndexColumnBuilder::findMulti(int idx)
+{
+  throw runtime_error("Not implemented");
+}
+
+void IndexColumnBuilder::fillSingle(int idx)
+{
+  // entry point
+  if (mPosition < mSourceSize && valueAt(mPosition) == idx) {
+    (void)static_cast<arrow::Int32Builder*>(mValueBuilder)->Append((int)mPosition);
+  } else {
+    (void)static_cast<arrow::Int32Builder*>(mValueBuilder)->Append(-1);
+  }
+}
+
+void IndexColumnBuilder::fillSlice(int idx)
+{
+  throw runtime_error("Not implemented");
+}
+
+void IndexColumnBuilder::fillMulti(int idx)
+{
+  throw runtime_error("Not implemented");
+}
+
+std::shared_ptr<arrow::Int32Array> ChunkedArrayIterator::getCurrentArray()
+{
+  auto chunk = mSource->chunk(mChunk);
+  mOffset = chunk->offset();
+  return std::static_pointer_cast<arrow::Int32Array>(chunk);
+}
+
+void ChunkedArrayIterator::nextChunk()
+{
+  auto previousArray = getCurrentArray();
+  mFirstIndex += previousArray->length();
+
+  ++mChunk;
+  auto array = getCurrentArray();
+  mCurrent = reinterpret_cast<int const*>(array->values()->data()) + mOffset - mFirstIndex;
+  mLast = mCurrent + array->length() + mFirstIndex;
+}
+
+void ChunkedArrayIterator::prevChunk()
+{
+  auto previousArray = getCurrentArray();
+  mFirstIndex -= previousArray->length();
+
+  --mChunk;
+  auto array = getCurrentArray();
+  mCurrent = reinterpret_cast<int const*>(array->values()->data()) + mOffset - mFirstIndex;
+  mLast = mCurrent + array->length() + mFirstIndex;
+}
+
+int ChunkedArrayIterator::valueAt(size_t pos)
+{
+  while (O2_BUILTIN_UNLIKELY(mCurrent + pos >= mLast)) {
+    nextChunk();
+  }
+  while (O2_BUILTIN_UNLIKELY(pos < mFirstIndex)) {
+    prevChunk();
+  }
+  return *(mCurrent + pos);
+}
+} // namespace o2::framework

--- a/Framework/Core/test/test_IndexBuilder.cxx
+++ b/Framework/Core/test/test_IndexBuilder.cxx
@@ -102,7 +102,7 @@ BOOST_AUTO_TEST_CASE(TestIndexBuilder)
   auto t4 = b4.finalize();
   Categorys st4{t4};
 
-  auto t5 = IndexExclusive::indexBuilder("test1", typename IDXs::persistent_columns_t{}, st1, std::tie(st1, st2, st3, st4));
+  auto t5 = IndexBuilder<Exclusive>::indexBuilder<Points>("test1a", {t1, t2, t3, t4}, typename IDXs::persistent_columns_t{}, o2::framework::pack<Points, Distances, Flags, Categorys>{});
   BOOST_REQUIRE_EQUAL(t5->num_rows(), 4);
   IDXs idxt{t5};
   idxt.bindExternalIndices(&st1, &st2, &st3, &st4);
@@ -112,7 +112,7 @@ BOOST_AUTO_TEST_CASE(TestIndexBuilder)
     BOOST_REQUIRE(row.category().pointId() == row.pointId());
   }
 
-  auto t6 = IndexSparse::indexBuilder("test2", typename IDX2s::persistent_columns_t{}, st1, std::tie(st2, st1, st3, st4));
+  auto t6 = IndexBuilder<Sparse>::indexBuilder<Points>("test3", {t2, t1, t3, t4}, typename IDX2s::persistent_columns_t{}, o2::framework::pack<Distances, Points, Flags, Categorys>{});
   BOOST_REQUIRE_EQUAL(t6->num_rows(), st2.size());
   IDX2s idxs{t6};
   std::array<int, 7> fs{0, 1, 2, -1, -1, 4, -1};

--- a/Framework/Foundation/include/Framework/Pack.h
+++ b/Framework/Foundation/include/Framework/Pack.h
@@ -160,14 +160,14 @@ struct has_type<T, pack<Us...>> : std::disjunction<std::is_same<T, Us>...> {
 template <typename T, typename... Us>
 inline constexpr bool has_type_v = has_type<T, Us...>::value;
 
-template <template <typename,typename> typename Condition, typename T, typename Pack>
+template <template <typename, typename> typename Condition, typename T, typename Pack>
 struct has_type_conditional;
 
-template <template <typename,typename> typename Condition, typename T, typename... Us>
-struct has_type_conditional<Condition, T, pack<Us...>> : std::disjunction<Condition<T,Us>...> {
+template <template <typename, typename> typename Condition, typename T, typename... Us>
+struct has_type_conditional<Condition, T, pack<Us...>> : std::disjunction<Condition<T, Us>...> {
 };
 
-template <template <typename,typename> typename Condition, typename T, typename... Us>
+template <template <typename, typename> typename Condition, typename T, typename... Us>
 inline constexpr bool has_type_conditional_v = has_type_conditional<Condition, T, Us...>::value;
 
 template <typename T>
@@ -187,15 +187,16 @@ constexpr size_t has_type_at(pack<T1, Ts...> const&)
   return sizeof...(Ts) + 2;
 }
 
-template <template <typename,typename> typename Condition, typename T>
+template <template <typename, typename> typename Condition, typename T>
 constexpr size_t has_type_at_conditional(pack<>&&)
 {
   return static_cast<size_t>(-1);
 }
 
-template <template <typename,typename> typename Condition, typename T, typename T1, typename... Ts>
-constexpr size_t has_type_at_conditional(pack<T1,Ts...>&&) {
-  if constexpr (Condition<T,T1>::value) {
+template <template <typename, typename> typename Condition, typename T, typename T1, typename... Ts>
+constexpr size_t has_type_at_conditional(pack<T1, Ts...>&&)
+{
+  if constexpr (Condition<T, T1>::value) {
     return 0;
   } else if constexpr (has_type_conditional_v<Condition, T, pack<Ts...>>) {
     return 1 + has_type_at_conditional<Condition, T>(pack<Ts...>{});

--- a/Framework/Foundation/include/Framework/Pack.h
+++ b/Framework/Foundation/include/Framework/Pack.h
@@ -160,6 +160,16 @@ struct has_type<T, pack<Us...>> : std::disjunction<std::is_same<T, Us>...> {
 template <typename T, typename... Us>
 inline constexpr bool has_type_v = has_type<T, Us...>::value;
 
+template <template <typename,typename> typename Condition, typename T, typename Pack>
+struct has_type_conditional;
+
+template <template <typename,typename> typename Condition, typename T, typename... Us>
+struct has_type_conditional<Condition, T, pack<Us...>> : std::disjunction<Condition<T,Us>...> {
+};
+
+template <template <typename,typename> typename Condition, typename T, typename... Us>
+inline constexpr bool has_type_conditional_v = has_type_conditional<Condition, T, Us...>::value;
+
 template <typename T>
 constexpr size_t has_type_at(pack<> const&)
 {
@@ -171,9 +181,24 @@ constexpr size_t has_type_at(pack<T1, Ts...> const&)
 {
   if constexpr (std::is_same_v<T, T1>) {
     return 0;
-  }
-  if constexpr (has_type_v<T, pack<T1, Ts...>>) {
+  } else if constexpr (has_type_v<T, pack<Ts...>>) {
     return 1 + has_type_at<T>(pack<Ts...>{});
+  }
+  return sizeof...(Ts) + 2;
+}
+
+template <template <typename,typename> typename Condition, typename T>
+constexpr size_t has_type_at_conditional(pack<>&&)
+{
+  return static_cast<size_t>(-1);
+}
+
+template <template <typename,typename> typename Condition, typename T, typename T1, typename... Ts>
+constexpr size_t has_type_at_conditional(pack<T1,Ts...>&&) {
+  if constexpr (Condition<T,T1>::value) {
+    return 0;
+  } else if constexpr (has_type_conditional_v<Condition, T, pack<Ts...>>) {
+    return 1 + has_type_at_conditional<Condition, T>(pack<Ts...>{});
   }
   return sizeof...(Ts) + 2;
 }

--- a/Framework/Foundation/test/test_FunctionalHelpers.cxx
+++ b/Framework/Foundation/test/test_FunctionalHelpers.cxx
@@ -31,12 +31,17 @@ struct TestStruct {
 };
 BOOST_AUTO_TEST_CASE(TestOverride)
 {
-  static_assert(pack_size(pack<int, float>{}) == 2, "Bad size for pack");
-  static_assert(has_type_v<int, pack<int, float>> == true, "int should be in pack");
-  static_assert(has_type_v<double, pack<int, float>> == false, "int should be in pack");
+  static_assert(pack_size(pack<int, float>{}) == 2, "Bad size for the pack");
+  static_assert(has_type_v<int, pack<int, float>> == true, "int should be in the pack");
+  static_assert(has_type_v<double, pack<int, float>> == false, "double should not be in the pack");
+  static_assert(has_type_conditional_v<std::is_same, int, pack<int, float>> == true, "int should be in the pack");
+  static_assert(has_type_conditional_v<std::is_same, double, pack<int, float>> == false, "double should not be in the pack");
+
   pack<float, char, int, bool> pck;
-  static_assert(has_type_at<int>(pck) == 2, "int should be a 2nd entry");
+  static_assert(has_type_at<int>(pck) == 2, "int should be at 2");
   static_assert(has_type_at<double>(pck) == pack_size(pck) + 1, "double is not in the pack so the function returns size + 1");
+  static_assert(has_type_at_conditional<std::is_same, bool>(pack<int, float, bool>()) == 2, "bool should be at 2");
+  static_assert(has_type_at_conditional<std::is_same, bool>(pack<int, float, double>()) == 3 + 1, "bool is not in the pack so the function returns size + 1");
 
   static_assert(std::is_same_v<selected_pack<is_int_t, int, float, char>, pack<int>>, "selector should select int");
   static_assert(std::is_same_v<selected_pack_multicondition<is_same_as_second_t, pack<int>, pack<int, float, char>>, pack<int>>, "multiselector should select int");
@@ -75,10 +80,10 @@ BOOST_AUTO_TEST_CASE(TestOverride)
   // static_assert(is_type_complete_v<ForwardDeclared> == true, "This should be complete because the struct is now fully declared.");
 
   bool flag = false;
-  call_if_defined<struct Undeclared>([&flag](auto* p) { flag = true; });
+  call_if_defined<struct Undeclared>([&flag](auto*) { flag = true; });
   BOOST_REQUIRE_EQUAL(flag, false);
 
   flag = false;
-  call_if_defined<struct Declared>([&flag](auto* p) { flag = true; });
+  call_if_defined<struct Declared>([&flag](auto*) { flag = true; });
   BOOST_REQUIRE_EQUAL(flag, true);
 }


### PR DESCRIPTION
* Does not create `soa::Table` objects anymore, reducing overhead
* Some code moved to `IndexBuilderHelpers.h/cxx`
* Groundwork done to allow slice and array index columns for index tables (requires implementing search algos)