### PR TITLE
[EMCAL-565] Add Time information for bad channel calib

### DIFF
--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibExtractor.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibExtractor.h
@@ -26,6 +26,7 @@
 #include "EMCALCalib/TimeCalibrationParams.h"
 #include "CommonUtils/BoostHistogramUtils.h"
 #include "EMCALBase/Geometry.h"
+#include "EMCALCalibration/EMCALCalibParams.h"
 #include <boost/histogram.hpp>
 
 #include <TRobustEstimator.h>
@@ -51,6 +52,11 @@ class EMCALCalibExtractor
     std::map<slice_t, std::array<double, 17664>> nHitsMap;               // number of hits per cell per slice
     std::map<slice_t, std::pair<double, double>> goodCellWindowMap;      // for each slice, the emin and the emax of the good cell window
     std::map<slice_t, std::pair<double, double>> goodCellWindowNHitsMap; // for each slice, the nHitsMin and the mHitsMax of the good cell window
+  };
+
+  struct BadChannelCalibTimeInfo {
+    std::array<double, 17664> sigmaCell; // sigma value of time distribution for single cells
+    double goodCellWindow;               // cut value for good cells
   };
 
  public:
@@ -81,8 +87,10 @@ class EMCALCalibExtractor
   boostHisto buildHitAndEnergyMeanScaled(double emin, double emax, boostHisto mCellAmplitude);
 
   /// \brief Function to perform the calibration of bad channels
+  /// \param hist histogram cell energy vs. cell ID. Main histogram for the bad channel calibration
+  /// \param histTime histogram cell time vs. cell ID. If default argument is taken, no calibration based on the timing signal will be performed
   template <typename... axes>
-  o2::emcal::BadChannelMap calibrateBadChannels(boost::histogram::histogram<axes...>& hist)
+  o2::emcal::BadChannelMap calibrateBadChannels(boost::histogram::histogram<axes...>& hist, const boost::histogram::histogram<axes...>& histTime = boost::histogram::make_histogram(boost::histogram::axis::variable<>{0., 1.}, boost::histogram::axis::variable<>{0., 1.}))
   {
     double time1 = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
     std::map<int, std::pair<double, double>> slices = {{0, {0.1, 0.3}}, {1, {0.3, 0.5}}, {2, {0.5, 1.0}}, {3, {1.0, 4.0}}};
@@ -102,6 +110,13 @@ class EMCALCalibExtractor
 
     // get all ofthe calibration information that we need in a struct
     BadChannelCalibInfo calibrationInformation = buildHitAndEnergyMean(slices, hist);
+
+    // only initialize this if the histo is not the default one
+    const bool doIncludeTime = (histTime.axis(0).size() > 1 && EMCALCalibParams::Instance().useTimeInfoForCalib_bc) ? true : false;
+    BadChannelCalibTimeInfo calibrationTimeInfo;
+    if (doIncludeTime) {
+      calibrationTimeInfo = buildTimeMeanAndSigma(histTime);
+    }
 
     o2::emcal::BadChannelMap mOutputBCM;
     // now loop through the cells and determine the mask for a given cell
@@ -134,6 +149,14 @@ class EMCALCalibExtractor
             LOG(debug) << "********* FAILED **********";
             failed = true;
             break;
+          }
+
+          // check if the cell is bad due to timing signal.
+          if (!failed && doIncludeTime) {
+            if (calibrationTimeInfo.sigmaCell[cellID] > calibrationTimeInfo.goodCellWindow) {
+              LOG(debug) << "Cell " << cellID << " is flagged due to time distribution";
+              failed = true;
+            }
           }
         }
         if (failed) {
@@ -236,6 +259,37 @@ class EMCALCalibExtractor
 
     return outputInfo;
   }
+
+  //____________________________________________
+  /// \brief calculate the sigma of the time distribution for all cells and caluclate the mean of the sigmas
+  /// \param histCellTime input histogram cellID vs cell time
+  /// \return sigma value for all cells and the upper cut value
+  template <typename... axes>
+  BadChannelCalibTimeInfo buildTimeMeanAndSigma(const boost::histogram::histogram<axes...>& histCellTime)
+  {
+    std::array<double, 17664> meanSigma;
+    for (int i = 0; i < mNcells; ++i) {
+      // calculate sigma per cell
+      const int indexLow = histCellTime.axis(1).index(i);
+      const int indexHigh = histCellTime.axis(1).index(i + 1);
+      auto boostHistCellSlice = o2::utils::ProjectBoostHistoXFast(histCellTime, indexLow, indexHigh);
+      meanSigma[i] = std::sqrt(o2::utils::getVarianceBoost1D(boostHistCellSlice));
+      LOG(debug) << "meanSigma[" << i << "] " << meanSigma[i];
+    }
+
+    // get the mean sigma and the std. deviation of the sigma distribution
+    // those will be the values we cut on
+    double avMean = 0, avSigma = 0;
+    TRobustEstimator robustEstimator;
+    robustEstimator.EvaluateUni(meanSigma.size(), meanSigma.data(), avMean, avSigma, 0);
+
+    BadChannelCalibTimeInfo timeInfo;
+    timeInfo.sigmaCell = meanSigma;
+    timeInfo.goodCellWindow = avMean + (avSigma * o2::emcal::EMCALCalibParams::Instance().sigmaTime_bc); // only upper limit needed
+
+    return timeInfo;
+  }
+
   //____________________________________________
 
   /// \brief Calibrate time for all cells

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibParams.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibParams.h
@@ -36,7 +36,13 @@ struct EMCALCalibParams : public o2::conf::ConfigurableParamHelper<EMCALCalibPar
   bool useScaledHisto_bc = true;        ///< use the scaled histogram for the bad channel map
   bool enableTestMode_bc = false;       ///< enable test mode for calibration
   int nBinsEnergyAxis_bc = 1000;        ///< number of bins for boost histogram energy axis
+  bool useTimeInfoForCalib_bc = true;   ///< weather to use the timing information as a criterion in the bad channel analysis
   float maxValueEnergyAxis_bc = 10;     ///< maximum value for boost histogram energy axis (minimum is always 0)
+  int nBinsTimeAxis_bc = 1000;          ///< number of bins for boost histogram time axis
+  float rangeTimeAxisLow_bc = -500;     ///< minimum value of time for histogram range
+  float rangeTimeAxisHigh_bc = 500;     ///< maximum value of time for histogram range
+  float minCellEnergyTime_bc = 0.1;     ///< minimum energy needed to fill the time histogram
+  float sigmaTime_bc = 5;               ///< sigma value for the upper cut on the time-variance distribution
   unsigned int slotLength_bc = 0;       ///< Lenght of the slot before calibration is triggered. If set to 0 calibration is triggered when hasEnoughData returns true
   bool UpdateAtEndOfRunOnly_bc = false; ///< switsch to enable trigger of calibration only at end of run
 

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelCalibrator.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelCalibrator.h
@@ -125,7 +125,7 @@ void EMCALChannelCalibrator<DataInput, DataOutput>::finalizeSlot(o2::calibration
   std::map<std::string, std::string> md;
   if constexpr (std::is_same<DataInput, o2::emcal::EMCALChannelData>::value) {
     LOG(debug) << "Launching the calibration.";
-    auto bcm = mCalibrator->calibrateBadChannels(c->getHisto());
+    auto bcm = mCalibrator->calibrateBadChannels(c->getHisto(), c->getHistoTime());
     LOG(debug) << "Done with the calibraiton";
     // for the CCDB entry
     auto clName = o2::utils::MemFileHelper::getClassName(bcm);
@@ -145,6 +145,11 @@ void EMCALChannelCalibrator<DataInput, DataOutput>::finalizeSlot(o2::calibration
       TH2F hCalibHist = o2::utils::TH2FFromBoost(c->getHisto());
       std::string nameBCInputHist = "EnergyVsCellID_" + std::to_string(slot.getStartTimeMS());
       hCalibHist.Write(nameBCInputHist.c_str(), TObject::kOverwrite);
+
+      TH2F hCalibHistTime = o2::utils::TH2FFromBoost(c->getHistoTime());
+      std::string nameBCInputHistTime = "TimeVsCellID_" + std::to_string(slot.getStartTimeMS());
+      hCalibHistTime.Write(nameBCInputHistTime.c_str(), TObject::kOverwrite);
+
       fLocalStorage.Close();
     }
   } else if constexpr (std::is_same<DataInput, o2::emcal::EMCALTimeCalibData>::value) {

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelData.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelData.h
@@ -58,10 +58,11 @@ class EMCALChannelData
   o2::emcal::Geometry* mGeometry = o2::emcal::Geometry::GetInstanceFromRunNumber(300000);
   int NCELLS = mGeometry->GetNCells();
 
-  EMCALChannelData() : mNBins(EMCALCalibParams::Instance().nBinsEnergyAxis_bc), mRange(EMCALCalibParams::Instance().maxValueEnergyAxis_bc)
+  EMCALChannelData() : mNBins(EMCALCalibParams::Instance().nBinsEnergyAxis_bc), mRange(EMCALCalibParams::Instance().maxValueEnergyAxis_bc), mNBinsTime(EMCALCalibParams::Instance().nBinsTimeAxis_bc), mRangeTimeLow(EMCALCalibParams::Instance().rangeTimeAxisLow_bc), mRangeTimeHigh(EMCALCalibParams::Instance().rangeTimeAxisHigh_bc)
   {
     // boost histogram with amplitude vs. cell ID, specify the range and binning of the amplitude axis
     mHisto = boost::histogram::make_histogram(boost::histogram::axis::regular<>(mNBins, 0, mRange, "t-texp"), boost::histogram::axis::integer<>(0, NCELLS, "CELL ID"));
+    mHistoTime = boost::histogram::make_histogram(boost::histogram::axis::regular<>(mNBinsTime, mRangeTimeLow, mRangeTimeHigh, "t-texp"), boost::histogram::axis::integer<>(0, NCELLS, "CELL ID"));
     // NCELLS includes DCal, treat as one calibration
     o2::emcal::Geometry* mGeometry = o2::emcal::Geometry::GetInstanceFromRunNumber(300000);
     int NCELLS = mGeometry->GetNCells();
@@ -88,6 +89,10 @@ class EMCALChannelData
   boostHisto& getHisto() { return mHisto; }
   const boostHisto& getHisto() const { return mHisto; }
 
+  /// \brief Get current calibration histogram with timing information
+  boostHisto& getHistoTime() { return mHistoTime; }
+  const boostHisto& getHistoTime() const { return mHistoTime; }
+
   /// \brief Peform the calibration and flag the bad channel map
   /// Average energy per hit histogram is fitted with a gaussian
   /// good area is +-mSigma
@@ -110,6 +115,10 @@ class EMCALChannelData
   float mRange = 10;                                    ///< Maximum energy range of boost histogram (will be overwritten by values in the EMCALCalibParams)
   int mNBins = 1000;                                    ///< Number of bins in the boost histogram (will be overwritten by values in the EMCALCalibParams)
   boostHisto mHisto;                                    ///< 2d boost histogram with cellID vs cell energy
+  int mNBinsTime = 1000;                                ///< Number of time bins in boost histogram (cell time vs. cell ID)
+  float mRangeTimeLow = -500;                           ///< lower bound of time axis of mHistoTime
+  float mRangeTimeHigh = 500;                           ///< upper bound of time axis of mHistoTime
+  boostHisto mHistoTime;                                ///< 2d boost histogram with cellID vs cell time
   int mEvents = 0;                                      ///< event counter
   long unsigned int mNEntriesInHisto = 0;               ///< Number of entries in the histogram
   boostHisto mEsumHisto;                                ///< contains the average energy per hit for each cell


### PR DESCRIPTION
- In Run2, the time information for the identification of bad channels could only be used in a second step (analysis-level QA) because the time calibration, including the BC%4 correction, was not done at the stage of the bad channel calibration
- In Run3, the BC%4 correction is already performed before the bad channel calibration. Due to that, we can use the width of the cell time distribution to identify bad channels.
- The width (std. deviation) is calculated for each cell. The values for all cells are stored and a mean and sigma of this new distribution is calculated using the TRobustEstimator. Cells above mean + nSigmas*sigma are then flagged as bad (the nSigmas can be modified in the EMCalCalibParams)
- The calibration can be switched on/off using the EMCALCalibParams
- In the offline calibrator and channel-data-producer, the time information can be added via an additional input histogram