### PR TITLE
MCH: improve raw decoder diagnostics

### DIFF
--- a/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DataDecoder.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DataDecoder.h
@@ -177,7 +177,6 @@ class DataDecoder
   /// Compute the time of all the digits that have been decoded in the current TimeFrame
   void computeDigitsTimeBCRst();
   void computeDigitsTime();
-  void checkDigitsTime();
 
   /// Get the vector of digits that have been decoded in the current TimeFrame
   const RawDigitVector& getDigits() const { return mDigits; }

--- a/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/ErrorCodes.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/ErrorCodes.h
@@ -31,11 +31,12 @@ enum ErrorCodes {
   ErrorBadClusterSize = 1 << 6,              // 64
   ErrorBadIncompleteWord = 1 << 7,           // 128
   ErrorTruncatedData = 1 << 8,               // 256
-  ErrorBadELinkID = 1 << 9,                  // 512
-  ErrorBadLinkID = 1 << 10,                  // 1024
-  ErrorUnknownLinkID = 1 << 11,              // 2048
-  ErrorBadHBTime = 1 << 12,                  // 4096
-  ErrorNonRecoverableDecodingError = 1 << 13 // 8192
+  ErrorUnexpectedSyncPacket = 1 << 9,        // 512
+  ErrorBadELinkID = 1 << 10,                 // 1024
+  ErrorBadLinkID = 1 << 11,                  // 2048
+  ErrorUnknownLinkID = 1 << 12,              // 4096
+  ErrorBadHBTime = 1 << 13,                  // 8192
+  ErrorNonRecoverableDecodingError = 1 << 14 // 16384
 };
 
 uint32_t getErrorCodesSize();

--- a/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/ErrorCodes.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/ErrorCodes.h
@@ -25,16 +25,17 @@ enum ErrorCodes {
   ErrorParity = 1,                           // 1
   ErrorHammingCorrectable = 1 << 1,          // 2
   ErrorHammingUncorrectable = 1 << 2,        // 4
-  ErrorBadClusterSize = 1 << 3,              // 8
-  ErrorBadPacketType = 1 << 4,               // 16
-  ErrorBadHeartBeatPacket = 1 << 5,          // 32
-  ErrorBadIncompleteWord = 1 << 6,           // 64
-  ErrorTruncatedData = 1 << 7,               // 128
-  ErrorBadELinkID = 1 << 8,                  // 256
-  ErrorBadLinkID = 1 << 9,                   // 512
-  ErrorUnknownLinkID = 1 << 10,              // 1024
-  ErrorInvalidDigitTime = 1 << 11,           // 2048
-  ErrorNonRecoverableDecodingError = 1 << 12 // 4096
+  ErrorBadSyncPacket = 1 << 3,               // 8
+  ErrorBadHeartBeatPacket = 1 << 4,          // 16
+  ErrorBadDataPacket = 1 << 5,               // 32
+  ErrorBadClusterSize = 1 << 6,              // 64
+  ErrorBadIncompleteWord = 1 << 7,           // 128
+  ErrorTruncatedData = 1 << 8,               // 256
+  ErrorBadELinkID = 1 << 9,                  // 512
+  ErrorBadLinkID = 1 << 10,                  // 1024
+  ErrorUnknownLinkID = 1 << 11,              // 2048
+  ErrorBadHBTime = 1 << 12,                  // 4096
+  ErrorNonRecoverableDecodingError = 1 << 13 // 8192
 };
 
 uint32_t getErrorCodesSize();

--- a/Detectors/MUON/MCH/Raw/Decoder/src/DataDecoder.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/DataDecoder.cxx
@@ -814,21 +814,6 @@ void DataDecoder::computeDigitsTimeBCRst()
 
 //_________________________________________________________________________________________________
 
-void DataDecoder::checkDigitsTime()
-{
-  for (auto& digit : mDigits) {
-    auto& d = digit.digit;
-    auto& info = digit.info;
-    auto tfTime = d.getTime();
-    if (tfTime == DataDecoder::tfTimeInvalid) {
-      // add invalid digit time error
-      mErrors.emplace_back(o2::mch::DecoderError(info.solar, info.ds, info.chip, ErrorInvalidDigitTime));
-    }
-  }
-}
-
-//_________________________________________________________________________________________________
-
 void DataDecoder::computeDigitsTime()
 {
   switch (mTimeRecoMode) {

--- a/Detectors/MUON/MCH/Raw/Decoder/src/DataDecoder.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/DataDecoder.cxx
@@ -548,6 +548,10 @@ void DataDecoder::decodePage(gsl::span<const std::byte> page)
   uint32_t linkId;
 
   auto heartBeatHandler = [&](DsElecId dsElecId, uint8_t chip, uint32_t bunchCrossing) {
+    if (mTimeRecoMode != TimeRecoMode::HBPackets) {
+      return;
+    }
+
     auto ds = dsElecId.elinkId();
     auto solar = dsElecId.solarId();
     uint64_t chipId = getChipId(solar, ds, chip);

--- a/Detectors/MUON/MCH/Raw/Decoder/src/ErrorCodes.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/ErrorCodes.cxx
@@ -20,7 +20,7 @@ namespace raw
 
 uint32_t getErrorCodesSize()
 {
-  return 14;
+  return 15;
 }
 
 void append(const char* msg, std::string& to)
@@ -51,6 +51,9 @@ std::string errorCodeAsString(uint32_t ec)
   }
   if (ec & ErrorBadSyncPacket) {
     append("Bad Sync Packet", msg);
+  }
+  if (ec & ErrorUnexpectedSyncPacket) {
+    append("Unexpected Sync", msg);
   }
   if (ec & ErrorBadHeartBeatPacket) {
     append("Bad HB Packet", msg);

--- a/Detectors/MUON/MCH/Raw/Decoder/src/ErrorCodes.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/ErrorCodes.cxx
@@ -20,7 +20,7 @@ namespace raw
 
 uint32_t getErrorCodesSize()
 {
-  return 13;
+  return 14;
 }
 
 void append(const char* msg, std::string& to)
@@ -49,11 +49,14 @@ std::string errorCodeAsString(uint32_t ec)
   if (ec & ErrorBadClusterSize) {
     append("Cluster Size", msg);
   }
-  if (ec & ErrorBadPacketType) {
-    append("Bad Packet Type", msg);
+  if (ec & ErrorBadSyncPacket) {
+    append("Bad Sync Packet", msg);
   }
   if (ec & ErrorBadHeartBeatPacket) {
     append("Bad HB Packet", msg);
+  }
+  if (ec & ErrorBadDataPacket) {
+    append("Bad Data Packet", msg);
   }
   if (ec & ErrorBadIncompleteWord) {
     append("Bad Incomplete Word", msg);
@@ -70,8 +73,8 @@ std::string errorCodeAsString(uint32_t ec)
   if (ec & ErrorUnknownLinkID) {
     append("Unknown Link ID", msg);
   }
-  if (ec & ErrorInvalidDigitTime) {
-    append("Invalid Digit Time", msg);
+  if (ec & ErrorBadHBTime) {
+    append("Bad HB Time", msg);
   }
   if (ec & ErrorNonRecoverableDecodingError) {
     append("Non Recoverable", msg);

--- a/Detectors/MUON/MCH/Raw/Decoder/src/UserLogicElinkDecoder.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/UserLogicElinkDecoder.cxx
@@ -38,4 +38,42 @@ void UserLogicElinkDecoder<ChargeSumMode>::prepareAndSendCluster()
   mSamples.clear();
 }
 
+template <>
+bool UserLogicElinkDecoder<SampleMode>::checkDataHeader()
+{
+  int chipAddMin = mDsId.elinkIndexInGroup() * 2;
+  int chipAddMax = chipAddMin + 1;
+
+  // the chip address from the SAMPA header must be consistent with
+  // the e-Link index
+  int chipAdd = mSampaHeader.chipAddress();
+  if (chipAdd < chipAddMin || chipAdd > chipAddMax) {
+    return false;
+  }
+
+  return true;
+}
+
+template <>
+bool UserLogicElinkDecoder<ChargeSumMode>::checkDataHeader()
+{
+  int chipAddMin = mDsId.elinkIndexInGroup() * 2;
+  int chipAddMax = chipAddMin + 1;
+
+  // the chip address from the SAMPA header must be consistent with
+  // the e-Link index
+  int chipAdd = mSampaHeader.chipAddress();
+  if (chipAdd < chipAddMin || chipAdd > chipAddMax) {
+    return false;
+  }
+
+  // in cluster sum mode the number of 10-bit words must be a multiple of 4
+  int nof10BitWords = mSampaHeader.nof10BitWords();
+  if ((nof10BitWords % 4) != 0) {
+    return false;
+  }
+
+  return true;
+}
+
 } // namespace o2::mch::raw

--- a/Detectors/MUON/MCH/Raw/Decoder/src/UserLogicElinkDecoder.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/UserLogicElinkDecoder.cxx
@@ -51,6 +51,12 @@ bool UserLogicElinkDecoder<SampleMode>::checkDataHeader()
     return false;
   }
 
+  // we expect at least 3 10-bit words
+  int nof10BitWords = mSampaHeader.nof10BitWords();
+  if (nof10BitWords <= 2) {
+    return false;
+  }
+
   return true;
 }
 
@@ -67,8 +73,12 @@ bool UserLogicElinkDecoder<ChargeSumMode>::checkDataHeader()
     return false;
   }
 
-  // in cluster sum mode the number of 10-bit words must be a multiple of 4
+  // we expect at least 3 10-bit words
   int nof10BitWords = mSampaHeader.nof10BitWords();
+  if (nof10BitWords <= 2) {
+    return false;
+  }
+  // in cluster sum mode the number of 10-bit words must be a multiple of 4
   if ((nof10BitWords % 4) != 0) {
     return false;
   }

--- a/Detectors/MUON/MCH/Raw/Decoder/src/UserLogicElinkDecoder.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/UserLogicElinkDecoder.h
@@ -123,7 +123,7 @@ void UserLogicElinkDecoder<CHARGESUM>::append(uint64_t data50, uint8_t error, bo
 #endif
     if (mState != State::WaitingHeader && mState != State::WaitingSync) {
 #ifdef ULDEBUG
-      debugHeader() << (*this) << " SYNC word found while decoding payload --> resetting\n"
+      debugHeader() << (*this) << " SYNC word found while decoding payload --> resetting\n";
 #endif
       sendError(static_cast<int8_t>(mSampaHeader.chipAddress()), static_cast<uint32_t>(ErrorUnexpectedSyncPacket));
       reset();

--- a/Detectors/MUON/MCH/Raw/Decoder/src/testUserLogicEndpointDecoder.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/testUserLogicEndpointDecoder.cxx
@@ -367,9 +367,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(SyncInTheMiddleChargeSumModeTwoChannels, V, testTy
     DsElecId{361, 6, 2}, 63, {cl1, cl2},
     DsElecId{361, 6, 2}, 47, {cl3, cl4},
     5);
-  BOOST_CHECK_EQUAL(r,
-                    "S361-J6-DS2-ch-63-ts-345-q-123456-cs-789\n"
-                    "S361-J6-DS2-ch-63-ts-346-q-789012-cs-345\n");
+  std::string r2 = "S361-J6-DS2-ch-63-ts-345-q-123456-cs-789\n";
+  r2 += "S361-J6-DS2-ch-63-ts-346-q-789012-cs-345\n";
+  r2 += fmt::format("S361-J6-DS2-chip-5-error-{}\n", ErrorUnexpectedSyncPacket);
+  BOOST_CHECK_EQUAL(r, r2);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(TestCruPageOK, V, testTypes)

--- a/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
@@ -243,7 +243,6 @@ class DataDecoderTask
       }
     }
     mDecoder->computeDigitsTime();
-    mDecoder->checkDigitsTime();
     auto tEnd = std::chrono::high_resolution_clock::now();
     mTimeDecoding += tEnd - tStart;
 

--- a/Detectors/MUON/MCH/Workflow/src/cru-page-reader-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/cru-page-reader-workflow.cxx
@@ -320,7 +320,7 @@ class FileReaderTask
     }
 
     if (mPrint) {
-      std::cout << "Sending TF " << orbitMin << " (previous " << mLastTForbit << "  delta " << orbitMin-mLastTForbit << ")" << std::endl
+      std::cout << "Sending TF " << orbitMin << " (previous " << mLastTForbit << "  delta " << (orbitMin - mLastTForbit) << ")" << std::endl
                 << std::endl;
     }
     mLastTForbit = orbitMin;
@@ -616,7 +616,7 @@ class FileReaderTask
   bool mFullTF;               ///< send full time frames
   bool mSaveTF;               ///< save individual time frames to file
   int mOverlap;               ///< overlap between contiguous TimeFrames
-  int mLastTForbit{ 0 };
+  int mLastTForbit{0};        ///< first orbit number of last transmitted TimeFrame
   bool mPrint = false;        ///< print debug messages
   o2::dataformats::TFIDInfo mTFIDInfo{}; // struct to modify output headers
 

--- a/Detectors/MUON/MCH/Workflow/src/cru-page-reader-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/cru-page-reader-workflow.cxx
@@ -320,9 +320,10 @@ class FileReaderTask
     }
 
     if (mPrint) {
-      std::cout << "Sending TF" << std::endl
+      std::cout << "Sending TF " << orbitMin << " (previous " << mLastTForbit << "  delta " << orbitMin-mLastTForbit << ")" << std::endl
                 << std::endl;
     }
+    mLastTForbit = orbitMin;
     auto freefct = [](void* data, void* /*hint*/) { free(data); };
     pc.outputs().adoptChunk(Output{"RDT", "RAWDATA"}, outBuf, outSize, freefct, nullptr);
 
@@ -448,7 +449,7 @@ class FileReaderTask
       // increment the total buffer size
       mTimeFrameSizes[feeID][linkID] += pageSize;
 
-      if ((triggerType & 0x800) != 0 && stopBit == 0 && pageCounter == 0 && bc == 0) {
+      if ((triggerType & 0x800) != 0 && /*stopBit == 0 && pageCounter == 0 &&*/ bc == 0) {
         // This is the start of a new TimeFrame, so we need to push a new empty TimeFrame in the queue
         if (mPrint) {
           std::cout << "tfQueue.size(): " << tfQueue.size() << std::endl;
@@ -615,6 +616,7 @@ class FileReaderTask
   bool mFullTF;               ///< send full time frames
   bool mSaveTF;               ///< save individual time frames to file
   int mOverlap;               ///< overlap between contiguous TimeFrames
+  int mLastTForbit{ 0 };
   bool mPrint = false;        ///< print debug messages
   o2::dataformats::TFIDInfo mTFIDInfo{}; // struct to modify output headers
 


### PR DESCRIPTION
The following decoding errors can now be detected and reported:
- badly formatted SYNC words
- SAMPA packet headers consistency
    - chip address and e-link index compatibility
    - num of 10-bit words multiple of 4 in cluster sum mode

The check of the digits time in DataDecoder has also been removed, because the corresponding "Bad digit time" error type has been removed as well. The digit time can be checked offline with `digit.getTime() != DataDecoder::tfTimeInvalid`.