### PR TITLE
Possibility to enable root output for particular workflows only

### DIFF
--- a/prodtests/full-system-test/README.md
+++ b/prodtests/full-system-test/README.md
@@ -79,10 +79,9 @@ The environment variables are documented here: https://github.com/AliceO2Group/O
 
 ## Files produced / required by the full system test
 
-The full system test can use the following input files:
-* Material budget: `matbud.root` with the material budget (used if available by the workflows to speed up material queries).
-* CTF ANS dictionaries: `ctf_dictionary.root` (if `CREATECTFDICT=0` is set).
-* ITS and MFT pattern dictionaries are normally loaded from the CCDB. (Alternatively, `ITSdictionary.bin` and `MFTdictionary.bin` can be provided externally, or they can be produced automatically if `GENERATE_ITSMFT_DICTIONARIES=1` is set.)
+The local files like geometry, material LUT etc. are not anymore needed for reconstruction and calibration workflows, but some QC workflows still need
+* geometry file o2sim_geometry-aligned.root
+* old-style (dummy) monolitic GRP file o2sim_grp.root
 
 The full system test produces the following output:
 * QED simulation output in the folder `qed`.
@@ -90,3 +89,8 @@ The full system test produces the following output:
 * Digits from `o2-sim-digitizer-workflow` and TRD tracklets.
 * Depending on the options mentioned above, `ctf_dictionary.root` and `ITSdictionary.bin` / `MFTdictionary.bin`.
 * RAW files in `raw/[DETECTOR_NAME]`
+
+By default the `dpl-workflow.sh` adds sub-workflows with the option `--disable-root-output`, preventing initialization of writer devices (therefore the intermediate reconstruction files are not produced).
+This behaviour can be overridden by passing `DISABLE_ROOT_OUTPUT=0` which will trigger storing all intermediate reconstruction files as well as the creation of the `o2_tfidinfo.root` file containing timing information of every processed TF (produced by `o2-tfidinfo-writer-workflow`).
+In case intermediate files of only a few workflows are needed, instead of enabling all writers via `DISABLE_ROOT_OUTPUT=0` one can enable those of particular devices only by passing `ENABLE_ROOT_OUTPUT_<workflow_name_with_underscores>=`.
+I.e. to enable storing the output of the `o2-its-reco-workflow` it is enough to prepend the script by `ENABLE_ROOT_OUTPUT_o2_its_reco_workflow=`. The `o2-tfidinfo-writer-workflow` will be invoked if there is at least one workflow with root outputs enabled.

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -141,11 +141,9 @@ if workflow_has_parameter QC && has_detector_qc TPC; then
   [[ $GPUTYPE != "CPU" && $HOSTMEMSIZE == "0" && $TPC_TRACKING_QC_RUN_FRACTION == "100" ]] && HOSTMEMSIZE=$(( 5 << 30 ))
 fi
 
-if [[ -z $DISABLE_ROOT_OUTPUT ]]; then
-  # enable only if root output is written, because it slows down the processing
-  GPU_OUTPUT+=",send-clusters-per-sector"
-  ENABLE_ROOT_OUTPUT="--enable-root-output"
-fi
+# enable only if root output is written, because it slows down the processing
+[[ -z $DISABLE_ROOT_OUTPUT ]] && ENABLE_ROOT_OUTPUT="--enable-root-output"
+[[ -z $DISABLE_ROOT_OUTPUT ]] || needs_root_output o2-gpu-reco-workflow && GPU_OUTPUT+=",send-clusters-per-sector"
 
 has_detector_flp_processing CPV && CPV_INPUT=digits
 ! has_detector_flp_processing TOF && TOF_CONFIG+=" --ignore-dist-stf"
@@ -364,7 +362,8 @@ else
 fi
 
 # if root output is requested, record info of processed TFs DataHeader for replay of root files
-[[ -z "$DISABLE_ROOT_OUTPUT" ]] && add_W o2-tfidinfo-writer-workflow
+ROOT_OUTPUT_ASKED=`declare -p | cut -d' ' -f3 | cut -d'=' -f1 | grep ENABLE_ROOT_OUTPUT_`
+[[ -z "$DISABLE_ROOT_OUTPUT" ]] || [[ ! -z $ROOT_OUTPUT_ASKED ]] && add_W o2-tfidinfo-writer-workflow
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Raw decoder workflows - disabled in async mode
@@ -373,7 +372,7 @@ if [[ $CTFINPUT == 0 && $DIGITINPUT == 0 ]]; then
     GPU_INPUT=zsonthefly
     add_W o2-tpc-raw-to-digits-workflow "--input-spec \"\" --remove-duplicates --pipeline $(get_N tpc-raw-to-digits-0 TPC RAW 1 TPCRAWDEC)"
     add_W o2-tpc-reco-workflow "--input-type digitizer --output-type zsraw,disable-writer --pipeline $(get_N tpc-zsEncoder TPC RAW 1 TPCRAWDEC)"
-    [ -z "$DISABLE_ROOT_OUTPUT" ] && add_W o2-tpc-reco-workflow "--input-type digitizer --output-type digits $DISABLE_MC"
+    [[ -z "$DISABLE_ROOT_OUTPUT" ]] || needs_root_output o2-gpu-reco-workflow && add_W o2-tpc-reco-workflow "--input-type digitizer --output-type digits $DISABLE_MC"
   fi
   has_detector ITS && add_W o2-itsmft-stf-decoder-workflow "--nthreads ${NITSDECTHREADS} --raw-data-dumps $ALPIDE_ERR_DUMPS --pipeline $(get_N its-stf-decoder ITS RAW 1 ITSRAWDEC)" "$ITSMFT_STROBES;VerbosityConfig.rawParserSeverity=warn;"
   has_detector MFT && add_W o2-itsmft-stf-decoder-workflow "--nthreads ${NMFTDECTHREADS} --raw-data-dumps $ALPIDE_ERR_DUMPS --pipeline $(get_N mft-stf-decoder MFT RAW 1 MFTRAWDEC) --runmft true" "$ITSMFT_STROBES;VerbosityConfig.rawParserSeverity=warn;"

--- a/prodtests/full-system-test/workflow-setup.sh
+++ b/prodtests/full-system-test/workflow-setup.sh
@@ -97,6 +97,15 @@ math_max()
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
+# Helper to check if root ouput is requested for certain process
+
+needs_root_output()
+{
+  local NAME_PROC_ENABLE_ROOT_OUTPUT="ENABLE_ROOT_OUTPUT_${1//-/_}"
+  [[ ! -z ${!NAME_PROC_ENABLE_ROOT_OUTPUT+x} ]]
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
 # Helper to add binaries to workflow adding automatic and custom arguments
 
 add_W() # Add binarry to workflow command USAGE: add_W [BINARY] [COMMAND_LINE_OPTIONS] [CONFIG_KEY_VALUES] [Add ARGS_ALL_CONFIG, optional, default = 1]
@@ -108,7 +117,12 @@ add_W() # Add binarry to workflow command USAGE: add_W [BINARY] [COMMAND_LINE_OP
   [[ ! -z "$3" ]] && KEY_VALUES+="$3;"
   [[ ! -z ${!NAME_PROC_CONFIG} ]] && KEY_VALUES+="${!NAME_PROC_CONFIG};"
   [[ ! -z "$KEY_VALUES" ]] && KEY_VALUES="--configKeyValues \"$KEY_VALUES\""
-  WORKFLOW+="$1 $ARGS_ALL $2 ${!NAME_PROC_ARGS} $KEY_VALUES | "
+  local WFADD="$1 $ARGS_ALL $2 ${!NAME_PROC_ARGS} $KEY_VALUES | "
+  local NAME_PROC_ENABLE_ROOT_OUTPUT="ENABLE_ROOT_OUTPUT_${1//-/_}"
+  if [[ ! -z $DISABLE_ROOT_OUTPUT ]] && needs_root_output $1 ; then
+      WFADD=${WFADD//$DISABLE_ROOT_OUTPUT/}
+  fi
+  WORKFLOW+=$WFADD
 }
 
 fi # workflow-setup.sh sourced


### PR DESCRIPTION
By default the `dpl-workflow.sh` adds sub-workflows with the option `--disable-root-output`, preventing initialization of writer devices (therefore the intermediate reconstruction files are not produced). 
This behaviour can be overridden by passing `DISABLE_ROOT_OUTPUT=0` which will trigger storing all intermediate reconstruction files as well as the creation of the `o2_tfidinfo.root` file containing timing information of every processed TF (produced by `o2-tfidinfo-writer-workflow`). 
In case intermediate files of only a few workflows are needed, instead of enabling all writers via `DISABLE_ROOT_OUTPUT=0` one can enable those of particular devices only by passing `ENABLE_ROOT_OUTPUT_<workflow_name_with_underscores>=`.
I.e. to enable storing the output of the `o2-its-reco-workflow` it is enough to prepend the script by `ENABLE_ROOT_OUTPUT_o2_its_reco_workflow=`. The `o2-tfidinfo-writer-workflow` will be invoked if there is at least one workflow with root outputs enabled.