### PR TITLE
[QC-864] Mergers: publish the complete objects at End Of Stream

### DIFF
--- a/Utilities/Mergers/include/Mergers/FullHistoryMerger.h
+++ b/Utilities/Mergers/include/Mergers/FullHistoryMerger.h
@@ -46,6 +46,9 @@ class FullHistoryMerger : public framework::Task
   /// \brief FullHistoryMerger process callback.
   void run(framework::ProcessingContext& ctx) override;
 
+  /// \brief Callback for CallbackService::Id::EndOfStream
+  void endOfStream(framework::EndOfStreamContext& eosContext) override;
+
  private:
   header::DataHeader::SubSpecificationType mSubSpec;
 

--- a/Utilities/Mergers/include/Mergers/IntegratingMerger.h
+++ b/Utilities/Mergers/include/Mergers/IntegratingMerger.h
@@ -51,6 +51,9 @@ class IntegratingMerger : public framework::Task
   /// \brief IntegratingMerger process callback.
   void run(framework::ProcessingContext& ctx) override;
 
+  /// \brief Callback for CallbackService::Id::EndOfStream
+  void endOfStream(framework::EndOfStreamContext& eosContext) override;
+
  private:
   void publish(framework::DataAllocator& allocator);
   void clear();

--- a/Utilities/Mergers/src/FullHistoryMerger.cxx
+++ b/Utilities/Mergers/src/FullHistoryMerger.cxx
@@ -85,6 +85,11 @@ void FullHistoryMerger::run(framework::ProcessingContext& ctx)
   }
 }
 
+void FullHistoryMerger::endOfStream(framework::EndOfStreamContext& eosContext)
+{
+  publish(eosContext.outputs());
+}
+
 // I am not calling it reset(), because it does not have to be performed during the FairMQs reset.
 void FullHistoryMerger::clear()
 {

--- a/Utilities/Mergers/src/IntegratingMerger.cxx
+++ b/Utilities/Mergers/src/IntegratingMerger.cxx
@@ -91,6 +91,11 @@ void IntegratingMerger::run(framework::ProcessingContext& ctx)
   }
 }
 
+void IntegratingMerger::endOfStream(framework::EndOfStreamContext& eosContext)
+{
+  publish(eosContext.outputs());
+}
+
 // I am not calling it reset(), because it does not have to be performed during the FairMQs reset.
 void IntegratingMerger::clear()
 {


### PR DESCRIPTION
This should make the QC multinode test fail much rarer in CI.