### PR TITLE
MCH: added DPL message with heart-beat packets

### DIFF
--- a/Detectors/MUON/MCH/Base/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Base/CMakeLists.txt
@@ -22,7 +22,7 @@ o2_add_library(MCHBase
          PUBLIC_LINK_LIBRARIES O2::DataFormatsMCH)
 
 o2_target_root_dictionary(MCHBase
-  HEADERS include/MCHBase/DecoderError.h include/MCHBase/ResponseParam.h include/MCHBase/TrackerParam.h)
+  HEADERS include/MCHBase/DecoderError.h include/MCHBase/HeartBeatPacket.h include/MCHBase/ResponseParam.h include/MCHBase/TrackerParam.h)
 
 o2_add_test(trackable
             SOURCES src/testTrackable.cxx

--- a/Detectors/MUON/MCH/Base/include/MCHBase/HeartBeatPacket.h
+++ b/Detectors/MUON/MCH/Base/include/MCHBase/HeartBeatPacket.h
@@ -1,0 +1,53 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/** @file HeartBeatPacket.h
+ * C++ definition of a heart-beat packet
+ * @author  Andrea Ferrero, CEE-Saclay
+ */
+
+#ifndef O2_MCH_BASE_HEARTBEATPACKET_H_
+#define O2_MCH_BASE_HEARTBEATPACKET_H_
+
+#include "Rtypes.h"
+
+namespace o2
+{
+namespace mch
+{
+
+// \class HeartBeatPacket
+/// \brief MCH heart-beat packet implementation
+class HeartBeatPacket
+{
+ public:
+  HeartBeatPacket() = default;
+
+  HeartBeatPacket(int solarid, int dsid, int chip, uint32_t bc) : mSolarID(solarid), mChipID(dsid * 2 + (chip % 2)), mBunchCrossing(bc) {}
+  ~HeartBeatPacket() = default;
+
+  uint16_t getSolarID() const { return mSolarID; }
+  uint8_t getDsID() const { return mChipID / 2; }
+  uint8_t getChip() const { return mChipID % 2; }
+
+  uint32_t getBunchCrossing() const { return mBunchCrossing; }
+
+ private:
+  uint16_t mSolarID{0};
+  uint8_t mChipID{0};
+  uint32_t mBunchCrossing{0};
+
+  ClassDefNV(HeartBeatPacket, 1);
+}; //class HeartBeatPacket
+
+} //namespace mch
+} //namespace o2
+#endif // O2_MCH_BASE_HEARTBEATPACKET_H_

--- a/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DataDecoder.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/DataDecoder.h
@@ -27,6 +27,7 @@
 #include "Headers/RDHAny.h"
 #include "DataFormatsMCH/Digit.h"
 #include "MCHBase/DecoderError.h"
+#include "MCHBase/HeartBeatPacket.h"
 #include "MCHRawDecoder/OrbitInfo.h"
 #include "MCHRawDecoder/PageDecoder.h"
 
@@ -184,6 +185,8 @@ class DataDecoder
   const std::unordered_set<OrbitInfo, OrbitInfoHash>& getOrbits() const { return mOrbits; }
   /// Get the list of decoding errors that have been found in the current TimeFrame
   const std::vector<o2::mch::DecoderError>& getErrors() const { return mErrors; }
+  /// Get the list of heart-beat packets that have been found in the current TimeFrame
+  const std::vector<o2::mch::HeartBeatPacket>& getHBPackets() const { return mHBPackets; }
   /// Initialize the digits from an external vector. To be only used for unit tests.
   void setDigits(const RawDigitVector& digits) { mDigits = digits; }
 
@@ -235,6 +238,7 @@ class DataDecoder
   RawDigitVector mDigits;                               ///< vector of decoded digits
   std::unordered_set<OrbitInfo, OrbitInfoHash> mOrbits; ///< list of orbits in the processed buffer
   std::vector<o2::mch::DecoderError> mErrors;           ///< list of decoding errors in the processed buffer
+  std::vector<o2::mch::HeartBeatPacket> mHBPackets;     ///< list of heart-beat packets in the processed buffer
 
   uint32_t mOrbitsInTF{128};    ///< number of orbits in one time frame
   uint32_t mBcInOrbit;          ///< number of bunch crossings in one orbit

--- a/Detectors/MUON/MCH/Raw/Decoder/src/DataDecoder.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/DataDecoder.cxx
@@ -562,6 +562,8 @@ void DataDecoder::decodePage(gsl::span<const std::byte> page)
       return;
     }
 
+    mHBPackets.emplace_back(solar, ds, chip, bunchCrossing);
+
     if (!mTimeFrameStartRecords[chipId].update(mFirstOrbitInTF, bunchCrossing)) {
       if (mErrorCount < MCH_DECODER_MAX_ERROR_COUNT) {
         auto s = asString(dsElecId);
@@ -928,6 +930,7 @@ void DataDecoder::reset()
   mDigits.clear();
   mOrbits.clear();
   mErrors.clear();
+  mHBPackets.clear();
   memset(mMergerRecordsReady.data(), 0, sizeof(uint64_t) * mMergerRecordsReady.size());
 }
 

--- a/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/DataDecoderSpec.cxx
@@ -250,6 +250,7 @@ class DataDecoderTask
     auto& digits = mDecoder->getDigits();
     auto& orbits = mDecoder->getOrbits();
     auto& errors = mDecoder->getErrors();
+    auto& hbpackets = mDecoder->getHBPackets();
 
 #ifdef MCH_RAW_DATADECODER_DEBUG_DIGIT_TIME
     constexpr int BCINORBIT = o2::constants::lhc::LHCMaxBunches;
@@ -283,11 +284,12 @@ class DataDecoderTask
     }
 
     // send the output buffer via DPL
-    size_t digitsSize, rofsSize, orbitsSize, errorsSize;
+    size_t digitsSize, rofsSize, orbitsSize, errorsSize, hbSize;
     char* digitsBuffer = rofFinder.saveDigitsToBuffer(digitsSize);
     char* rofsBuffer = rofFinder.saveROFRsToBuffer(rofsSize);
     char* orbitsBuffer = createBuffer(orbits, orbitsSize);
     char* errorsBuffer = createBuffer(errors, errorsSize);
+    char* hbBuffer = createBuffer(hbpackets, hbSize);
 
     if (mDebug) {
       LOGP(info, "digitsSize {}  rofsSize {}  orbitsSize {}  errorsSize {}", digitsSize, rofsSize, orbitsSize, errorsSize);
@@ -299,6 +301,7 @@ class DataDecoderTask
     pc.outputs().adoptChunk(Output{header::gDataOriginMCH, "DIGITROFS", 0}, rofsBuffer, rofsSize, freefct, nullptr);
     pc.outputs().adoptChunk(Output{header::gDataOriginMCH, "ORBITS", 0}, orbitsBuffer, orbitsSize, freefct, nullptr);
     pc.outputs().adoptChunk(Output{header::gDataOriginMCH, "ERRORS", 0}, errorsBuffer, errorsSize, freefct, nullptr);
+    pc.outputs().adoptChunk(Output{header::gDataOriginMCH, "HBPACKETS", 0}, hbBuffer, hbSize, freefct, nullptr);
 
     mTFcount += 1;
     if (mErrorLogFrequency) {
@@ -345,6 +348,7 @@ o2::framework::DataProcessorSpec getDecodingSpec(const char* specName, std::stri
     Outputs{OutputSpec{header::gDataOriginMCH, "DIGITS", 0, Lifetime::Timeframe},
             OutputSpec{header::gDataOriginMCH, "DIGITROFS", 0, Lifetime::Timeframe},
             OutputSpec{header::gDataOriginMCH, "ORBITS", 0, Lifetime::Timeframe},
+            OutputSpec{header::gDataOriginMCH, "HBPACKETS", 0, Lifetime::Timeframe},
             OutputSpec{header::gDataOriginMCH, "ERRORS", 0, Lifetime::Timeframe}},
     AlgorithmSpec{adaptFromTask<DataDecoderTask>(std::move(task))},
     Options{{"mch-debug", VariantType::Bool, false, {"enable verbose output"}},


### PR DESCRIPTION
The HB packets can be used for diagnostic purpose, for example to check the synchronization between the SAMPA chips.