### PR TITLE
DPL Analysis: introducing SmallGroupsUnfiltered

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -2979,12 +2979,12 @@ using SmallGroupsUnfiltered = SmallGroupsBase<T, false>;
 
 template <typename T>
 struct is_smallgroups_t {
-    static constexpr bool value = false;
+  static constexpr bool value = false;
 };
 
 template <typename T, bool F>
-struct is_smallgroups_t<SmallGroupsBase<T,F>> {
-    static constexpr bool value = true;
+struct is_smallgroups_t<SmallGroupsBase<T, F>> {
+  static constexpr bool value = true;
 };
 
 template <typename T>

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -2958,17 +2958,37 @@ struct IndexTable : Table<soa::Index<>, H, Ts...> {
 template <typename T>
 inline constexpr bool is_soa_index_table_v = framework::is_base_of_template_v<soa::IndexTable, T>;
 
-template <typename T>
-struct SmallGroups : public Filtered<T> {
-  SmallGroups(std::vector<std::shared_ptr<arrow::Table>>&& tables, gandiva::Selection const& selection, uint64_t offset = 0)
+template <typename T, bool APPLY>
+struct SmallGroupsBase : public Filtered<T> {
+  static constexpr bool applyFilters = APPLY;
+  SmallGroupsBase(std::vector<std::shared_ptr<arrow::Table>>&& tables, gandiva::Selection const& selection, uint64_t offset = 0)
     : Filtered<T>(std::move(tables), selection, offset) {}
 
-  SmallGroups(std::vector<std::shared_ptr<arrow::Table>>&& tables, SelectionVector&& selection, uint64_t offset = 0)
+  SmallGroupsBase(std::vector<std::shared_ptr<arrow::Table>>&& tables, SelectionVector&& selection, uint64_t offset = 0)
     : Filtered<T>(std::move(tables), std::forward<SelectionVector>(selection), offset) {}
 
-  SmallGroups(std::vector<std::shared_ptr<arrow::Table>>&& tables, gsl::span<int64_t const> const& selection, uint64_t offset = 0)
+  SmallGroupsBase(std::vector<std::shared_ptr<arrow::Table>>&& tables, gsl::span<int64_t const> const& selection, uint64_t offset = 0)
     : Filtered<T>(std::move(tables), selection, offset) {}
 };
+
+template <typename T>
+using SmallGroups = SmallGroupsBase<T, true>;
+
+template <typename T>
+using SmallGroupsUnfiltered = SmallGroupsBase<T, false>;
+
+template <typename T>
+struct is_smallgroups_t {
+    static constexpr bool value = false;
+};
+
+template <typename T, bool F>
+struct is_smallgroups_t<SmallGroupsBase<T,F>> {
+    static constexpr bool value = true;
+};
+
+template <typename T>
+constexpr bool is_smallgroups_v = is_smallgroups_t<T>::value;
 
 } // namespace o2::soa
 

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -196,7 +196,7 @@ struct AnalysisDataProcessorBuilder {
       info.selection = framework::expressions::createSelection(table, info.filter);
       info.resetSelection = false;
     }
-    if constexpr (!is_smallgroups_v<std::decay_t<T>>) {
+    if constexpr (!o2::soa::is_smallgroups_v<std::decay_t<T>>) {
       if (info.selection == nullptr) {
         throw runtime_error_f("Null selection for %d (arg %d), missing Filter declaration?", info.processHash, info.argumentIndex);
       }

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -196,7 +196,7 @@ struct AnalysisDataProcessorBuilder {
       info.selection = framework::expressions::createSelection(table, info.filter);
       info.resetSelection = false;
     }
-    if constexpr (!framework::is_base_of_template_v<soa::SmallGroups, std::decay_t<T>>) {
+    if constexpr (!is_smallgroups_v<std::decay_t<T>>) {
       if (info.selection == nullptr) {
         throw runtime_error_f("Null selection for %d (arg %d), missing Filter declaration?", info.processHash, info.argumentIndex);
       }

--- a/Framework/Core/include/Framework/GroupSlicer.h
+++ b/Framework/Core/include/Framework/GroupSlicer.h
@@ -81,7 +81,7 @@ struct GroupSlicer {
       constexpr auto index = framework::has_type_at_v<std::decay_t<T>>(associated_pack_t{});
       if constexpr (relatedByIndex<std::decay_t<G>, std::decay_t<T>>()) {
         auto name = getLabelFromType<std::decay_t<T>>();
-        if constexpr (!framework::is_specialization_v<std::decay_t<T>, soa::SmallGroups>) {
+        if constexpr (!o2::soa::is_smallgroups_v<std::decay_t<T>>) {
           if (table.size() == 0) {
             return;
           }
@@ -236,7 +236,7 @@ struct GroupSlicer {
           pos = position;
         }
 
-        if constexpr (!framework::is_specialization_v<std::decay_t<A1>, soa::SmallGroups>) {
+        if constexpr (!o2::soa::is_smallgroups_v<std::decay_t<A1>>) {
           // optimized split
           if (originalTable.size() == 0) {
             return originalTable;
@@ -271,7 +271,7 @@ struct GroupSlicer {
             return typedTable;
           }
         } else {
-          //generic split
+          // generic split
           if constexpr (soa::is_soa_filtered_v<std::decay_t<A1>>) {
             // intersect selections
             o2::soa::SelectionVector s;
@@ -281,7 +281,11 @@ struct GroupSlicer {
               }
             } else {
               if (!filterGroups[index].empty()) {
-                std::set_intersection((filterGroups[index])[pos].begin(), (filterGroups[index])[pos].end(), selections[index]->begin(), selections[index]->end(), std::back_inserter(s));
+                if constexpr (std::decay_t<A1>::applyFilters) {
+                  std::set_intersection((filterGroups[index])[pos].begin(), (filterGroups[index])[pos].end(), selections[index]->begin(), selections[index]->end(), std::back_inserter(s));
+                } else {
+                  std::copy((filterGroups[index])[pos].begin(), (filterGroups[index])[pos].end(), std::back_inserter(s));
+                }
               }
             }
             std::decay_t<A1> typedTable{{originalTable.asArrowTable()}, std::move(s)};
@@ -292,7 +296,7 @@ struct GroupSlicer {
           }
         }
       } else {
-        static_assert(!framework::is_specialization_v<std::decay_t<A1>, soa::SmallGroups>, "SmallGroups used with a table that is not related by index to the gouping table");
+        static_assert(!o2::soa::is_smallgroups_v<std::decay_t<A1>>, "SmallGroups used with a table that is not related by index to the gouping table");
         return originalTable;
       }
     }

--- a/Framework/Core/test/test_GroupSlicer.cxx
+++ b/Framework/Core/test/test_GroupSlicer.cxx
@@ -396,10 +396,12 @@ BOOST_AUTO_TEST_CASE(GroupSlicerMismatchedUnsortedFilteredGroups)
   soa::SelectionVector rows{2, 4, 10, 9, 15};
   FilteredEvents e{{evtTable}, {2, 4, 10, 9, 15}};
   soa::SmallGroups<aod::TrksXU> t{{trkTable}, std::move(sel)};
+
   BOOST_CHECK_EQUAL(e.size(), 5);
   BOOST_CHECK_EQUAL(t.size(), 10 * (20 - 4));
 
   auto tt = std::make_tuple(t);
+
   o2::framework::GroupSlicer g(e, tt);
 
   unsigned int count = 0;
@@ -432,6 +434,24 @@ BOOST_AUTO_TEST_CASE(GroupSlicerMismatchedUnsortedFilteredGroups)
     BOOST_CHECK_EQUAL(gg.globalIndex(), rows[count]);
     auto trks = std::get<soa::SmallGroups<aod::TrksXU>>(as);
     BOOST_CHECK_EQUAL(trks.size(), 0);
+    ++count;
+  }
+
+  soa::SmallGroupsUnfiltered<aod::TrksXU> tu{{trkTable}, std::vector<int64_t>{}};
+  auto ttu = std::make_tuple(tu);
+  o2::framework::GroupSlicer gu(e, ttu);
+
+  count = 0;
+  for (auto& slice : gu) {
+    auto as = slice.associatedTables();
+    auto gg = slice.groupingElement();
+    BOOST_CHECK_EQUAL(gg.globalIndex(), rows[count]);
+    auto trks = std::get<soa::SmallGroupsUnfiltered<aod::TrksXU>>(as);
+    if (rows[count] == 3 || rows[count] == 10 || rows[count] == 12 || rows[count] == 16) {
+      BOOST_CHECK_EQUAL(trks.size(), 0);
+    } else {
+      BOOST_CHECK_EQUAL(trks.size(), 10);
+    }
     ++count;
   }
 }


### PR DESCRIPTION
@jgrosseo as discussed

* `SmallGroups` keeps current behavior: all filters are combined
* `SmallGroupsUnfiltered` _only_ uses grouping filter, ignoring the rest