### PR TITLE
[EMCAL-565] Fix condition for scalefactors in online mode

### DIFF
--- a/Detectors/EMCAL/calibration/testWorkflow/EMCALChannelCalibratorSpec.h
+++ b/Detectors/EMCAL/calibration/testWorkflow/EMCALChannelCalibratorSpec.h
@@ -256,7 +256,7 @@ DataProcessorSpec getEMCALChannelCalibDeviceSpec(const std::string calibType, co
   if (loadCalibParamsFromCCDB) {
     inputs.emplace_back("EMC_CalibParam", o2::header::gDataOriginEMC, "EMCALCALIBPARAM", 0, Lifetime::Condition, ccdbParamSpec("EMC/Config/CalibParam"));
   }
-  if (calibType.find("badchannel") == std::string::npos) {
+  if (calibType.find("badchannel") != std::string::npos) {
     inputs.emplace_back("EMC_Scalefactors", o2::header::gDataOriginEMC, "SCALEFACTORS", 0, Lifetime::Condition, ccdbParamSpec(CalibDB::getCDBPathChannelScaleFactors()));
   }
   auto ccdbRequest = std::make_shared<o2::base::GRPGeomRequest>(true,                           // orbitResetTime


### PR DESCRIPTION
Faulty comparison leading to scale factors being loaded for
the wrong calibration method (time calibration instead of
bad channel calibration)