### PR TITLE
Optionally use Logger for printKeyValues

### DIFF
--- a/Common/Utils/include/CommonUtils/ConfigurableParam.h
+++ b/Common/Utils/include/CommonUtils/ConfigurableParam.h
@@ -160,7 +160,7 @@ class ConfigurableParam
   virtual std::string getName() const = 0;
 
   // print the current keys and values to screen (optionally with provenance information)
-  virtual void printKeyValues(bool showprov = true) const = 0;
+  virtual void printKeyValues(bool showprov = true, bool useLogger = false) const = 0;
 
   // return the provenance of the member key
   virtual EParamProvenance getMemberProvenance(const std::string& key) const = 0;
@@ -168,7 +168,7 @@ class ConfigurableParam
   static EParamProvenance getProvenance(const std::string& key);
 
   static void printAllRegisteredParamNames();
-  static void printAllKeyValuePairs();
+  static void printAllKeyValuePairs(bool useLogger = false);
 
   static const std::string& getInputDir() { return sInputDir; }
   static const std::string& getOutputDir() { return sOutputDir; }

--- a/Common/Utils/include/CommonUtils/ConfigurableParamHelper.h
+++ b/Common/Utils/include/CommonUtils/ConfigurableParamHelper.h
@@ -58,8 +58,8 @@ class _ParamHelper
   static void syncCCDBandRegistry(std::string const& mainkey, TClass* cl, void* to, void* from,
                                   std::map<std::string, ConfigurableParam::EParamProvenance>* provmap);
 
-  static void outputMembersImpl(std::ostream& out, std::string const& mainkey, std::vector<ParamDataMember> const* members, bool showProv);
-  static void printMembersImpl(std::string const& mainkey, std::vector<ParamDataMember> const* members, bool showProv);
+  static void outputMembersImpl(std::ostream& out, std::string const& mainkey, std::vector<ParamDataMember> const* members, bool showProv, bool useLogger);
+  static void printMembersImpl(std::string const& mainkey, std::vector<ParamDataMember> const* members, bool showProv, bool useLogger);
 
   template <typename P>
   friend class ConfigurableParamHelper;
@@ -95,13 +95,13 @@ class ConfigurableParamHelper : virtual public ConfigurableParam
   // ----------------------------------------------------------------
 
   // one of the key methods, using introspection to print itself
-  void printKeyValues(bool showProv = true) const final
+  void printKeyValues(bool showProv = true, bool useLogger = false) const final
   {
     if (!isInitialized()) {
       initialize();
     }
     auto members = getDataMembers();
-    _ParamHelper::printMembersImpl(getName(), members, showProv);
+    _ParamHelper::printMembersImpl(getName(), members, showProv, useLogger);
   }
 
   // ----------------------------------------------------------------
@@ -109,7 +109,7 @@ class ConfigurableParamHelper : virtual public ConfigurableParam
   void output(std::ostream& out) const final
   {
     auto members = getDataMembers();
-    _ParamHelper::outputMembersImpl(out, getName(), members, true);
+    _ParamHelper::outputMembersImpl(out, getName(), members, true, false);
   }
 
   // ----------------------------------------------------------------

--- a/Common/Utils/src/ConfigurableParam.cxx
+++ b/Common/Utils/src/ConfigurableParam.cxx
@@ -284,14 +284,14 @@ void ConfigurableParam::initPropertyTree()
 
 // ------------------------------------------------------------------
 
-void ConfigurableParam::printAllKeyValuePairs()
+void ConfigurableParam::printAllKeyValuePairs(bool useLogger)
 {
   if (!sIsFullyInitialized) {
     initialize();
   }
   std::cout << "####\n";
   for (auto p : *sRegisteredParamClasses) {
-    p->printKeyValues(true);
+    p->printKeyValues(true, useLogger);
   }
   std::cout << "----\n";
 }

--- a/Common/Utils/src/ConfigurableParamHelper.cxx
+++ b/Common/Utils/src/ConfigurableParamHelper.cxx
@@ -45,14 +45,12 @@ std::string ParamDataMember::toString(std::string const& prefix, bool showProv) 
     std::string prov = (provenance.compare("") == 0 ? nil : provenance);
     out << "\t\t[ " + prov + " ]";
   }
-
-  out << "\n";
   return out.str();
 }
 
 std::ostream& operator<<(std::ostream& out, const ParamDataMember& pdm)
 {
-  out << pdm.toString("", false);
+  out << pdm.toString("", false) << "\n";
   return out;
 }
 
@@ -309,19 +307,24 @@ void _ParamHelper::fillKeyValuesImpl(std::string const& mainkey, TClass* cl, voi
 
 // ----------------------------------------------------------------------
 
-void _ParamHelper::printMembersImpl(std::string const& mainkey, std::vector<ParamDataMember> const* members, bool showProv)
+void _ParamHelper::printMembersImpl(std::string const& mainkey, std::vector<ParamDataMember> const* members, bool showProv, bool useLogger)
 {
-  _ParamHelper::outputMembersImpl(std::cout, mainkey, members, showProv);
+
+  _ParamHelper::outputMembersImpl(std::cout, mainkey, members, showProv, useLogger);
 }
 
-void _ParamHelper::outputMembersImpl(std::ostream& out, std::string const& mainkey, std::vector<ParamDataMember> const* members, bool showProv)
+void _ParamHelper::outputMembersImpl(std::ostream& out, std::string const& mainkey, std::vector<ParamDataMember> const* members, bool showProv, bool useLogger)
 {
   if (members == nullptr) {
     return;
   }
 
   for (auto& member : *members) {
-    out << member.toString(mainkey, showProv);
+    if (useLogger) {
+      LOG(info) << member.toString(mainkey, showProv);
+    } else {
+      out << member.toString(mainkey, showProv) << "\n";
+    }
   }
 }
 


### PR DESCRIPTION
The output is sent to the logger instead of the std::cout if printKeyValues is called with 2nd parameter set to true