### PR TITLE
Use https for alice-ccdb.cern.ch

### DIFF
--- a/CCDB/test/testCcdbApi_alien.cxx
+++ b/CCDB/test/testCcdbApi_alien.cxx
@@ -39,7 +39,7 @@ struct Fixture {
   Fixture()
   {
     CcdbApi api;
-    ccdbUrl = "http://alice-ccdb.cern.ch";
+    ccdbUrl = "https://alice-ccdb.cern.ch";
     api.init(ccdbUrl);
     cout << "ccdb url: " << ccdbUrl << endl;
     hostReachable = api.isHostReachable();

--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -52,7 +52,7 @@ void SimConfig::initOptions(boost::program_options::options_description& options
     "field", bpo::value<std::string>()->default_value("-5"), "L3 field rounded to kGauss, allowed values +-2,+-5 and 0; +-<intKGaus>U for uniform field; \"ccdb\" for taking it from CCDB ")(
     "nworkers,j", bpo::value<int>()->default_value(nsimworkersdefault), "number of parallel simulation workers (only for parallel mode)")(
     "noemptyevents", "only writes events with at least one hit")(
-    "CCDBUrl", bpo::value<std::string>()->default_value("http://alice-ccdb.cern.ch"), "URL for CCDB to be used.")(
+    "CCDBUrl", bpo::value<std::string>()->default_value("https://alice-ccdb.cern.ch"), "URL for CCDB to be used.")(
     "timestamp", bpo::value<uint64_t>(), "global timestamp value in ms (for anchoring) - default is now ... or beginning of run if ALICE run number was given")(
     "run", bpo::value<int>()->default_value(-1), "ALICE run number")(
     "asservice", bpo::value<bool>()->default_value(false), "run in service/server mode")(

--- a/Common/Utils/include/CommonUtils/NameConf.h
+++ b/Common/Utils/include/CommonUtils/NameConf.h
@@ -140,7 +140,7 @@ class NameConf : public o2::conf::ConfigurableParamHelper<NameConf>
   std::string mDirMatLUT = "none";                        // directory for material LUT
   std::string mDirCollContext = "none";                   // directory for collision context
   std::string mDirTFIDINFO = "none";                      // directory for TFIDInfo vector
-  std::string mCCDBServer = "http://alice-ccdb.cern.ch/"; // default CCDB server
+  std::string mCCDBServer = "https://alice-ccdb.cern.ch/"; // default CCDB server
 
   O2ParamDef(NameConf, "NameConf");
 };

--- a/DataFormats/Parameters/src/GRPTool.cxx
+++ b/DataFormats/Parameters/src/GRPTool.cxx
@@ -57,7 +57,7 @@ struct Options {
   bool print = false; // whether to print outcome of GRP operation
   bool lhciffromccdb = false; // whether only to take GRPLHCIF from CCDB
   std::string publishto = "";
-  std::string ccdbhost = "http://alice-ccdb.cern.ch";
+  std::string ccdbhost = "https://alice-ccdb.cern.ch";
   bool isRun5 = false; // whether or not this is supposed to be a Run5 detector configuration
 };
 

--- a/Detectors/Calibration/README.md
+++ b/Detectors/Calibration/README.md
@@ -99,7 +99,7 @@ in the workflow defined as:
 <your_workflow> | o2-calibration-ccdb-populator-workflow --ccdb-path="http://localhost:8080" --name-extention loc  --sspec-min 1 --sspec-max 10 |
 o2-calibration-ccdb-populator-workflow --sspec-min 0 --sspec-max 1  -b
 ```
-then the `ObjA` will be uploaded only to the default server (`http://alice-ccdb.cern.ch`), `ObjB` will be uploaded to both default and `local` server and
+then the `ObjA` will be uploaded only to the default server (`https://alice-ccdb.cern.ch`), `ObjB` will be uploaded to both default and `local` server and
 `ObjC` will be uploaded to the `local` server only.
 
 By default the ccdb-populator-workflow will not produce `fatal` on failed upload. To require it an option `--fatal-on-failure` can be used.

--- a/Detectors/FIT/FT0/workflow/include/FT0Workflow/ReconstructionSpec.h
+++ b/Detectors/FIT/FT0/workflow/include/FT0Workflow/ReconstructionSpec.h
@@ -53,7 +53,7 @@ class ReconstructionDPL : public Task
 };
 
 /// create a processor spec
-framework::DataProcessorSpec getReconstructionSpec(bool useMC = false, const std::string ccdbpath = "http://alice-ccdb.cern.ch");
+framework::DataProcessorSpec getReconstructionSpec(bool useMC = false, const std::string ccdbpath = "https://alice-ccdb.cern.ch");
 
 } // namespace ft0
 } // namespace o2

--- a/Detectors/FIT/FV0/calibration/macros/makeChannelTimeOffsetFV0CalibObjectInCCDB.C
+++ b/Detectors/FIT/FV0/calibration/macros/makeChannelTimeOffsetFV0CalibObjectInCCDB.C
@@ -23,7 +23,7 @@
 #include "CCDB/CcdbApi.h"
 #include "FV0Base/Constants.h"
 
-int makeChannelTimeOffsetFV0CalibObjectInCCDB(const std::string url = "http://alice-ccdb.cern.ch:8080")
+int makeChannelTimeOffsetFV0CalibObjectInCCDB(const std::string url = "https://alice-ccdb.cern.ch:8080")
 {
   using CalibObjWithInfoType = std::pair<o2::ccdb::CcdbObjectInfo, std::unique_ptr<std::vector<char>>>;
   std::array<int, o2::fv0::Constants::nFv0Channels> offsets;

--- a/Detectors/FIT/FV0/calibration/macros/readChannelTimeOffsetFV0CalibObjectFromCCDB.C
+++ b/Detectors/FIT/FV0/calibration/macros/readChannelTimeOffsetFV0CalibObjectFromCCDB.C
@@ -18,7 +18,7 @@
 #endif
 
 // Macro retrieves only latest set of calibrations
-int readChannelTimeOffsetFV0CalibObjectFromCCDB(const std::string url = "http://alice-ccdb.cern.ch/")
+int readChannelTimeOffsetFV0CalibObjectFromCCDB(const std::string url = "https://alice-ccdb.cern.ch/")
 {
   o2::ccdb::CcdbApi api;
   api.init(url);

--- a/Detectors/FIT/FV0/workflow/include/FV0Workflow/ReconstructionSpec.h
+++ b/Detectors/FIT/FV0/workflow/include/FV0Workflow/ReconstructionSpec.h
@@ -53,7 +53,7 @@ class ReconstructionDPL : public Task
 };
 
 /// create a processor spec
-framework::DataProcessorSpec getReconstructionSpec(bool useMC = false, const std::string ccdbpath = "http://alice-ccdb.cern.ch");
+framework::DataProcessorSpec getReconstructionSpec(bool useMC = false, const std::string ccdbpath = "https://alice-ccdb.cern.ch");
 
 } // namespace fv0
 } // namespace o2

--- a/Detectors/FIT/macros/readFITBadChannelMap.C
+++ b/Detectors/FIT/macros/readFITBadChannelMap.C
@@ -33,7 +33,7 @@
 
 void readFITBadChannelMap(std::string detectorName,
                           long timestamp = -1,
-                          const std::string& ccdbUrl = "http://alice-ccdb.cern.ch",
+                          const std::string& ccdbUrl = "https://alice-ccdb.cern.ch",
                           const bool verbose = false)
 {
   // Parse and check detector name

--- a/Detectors/FIT/macros/readFITDCSdata.C
+++ b/Detectors/FIT/macros/readFITDCSdata.C
@@ -79,7 +79,7 @@ void readFITDCSdata(std::string detectorName = "FT0",
                     const std::string& dataPointAliases = "",
                     long timeStart = -1,
                     long timeEnd = -1,
-                    const std::string& ccdbUrl = "http://alice-ccdb.cern.ch",
+                    const std::string& ccdbUrl = "https://alice-ccdb.cern.ch",
                     const bool plot = true,
                     const std::string& rootOutput = "",
                     const bool print = false,
@@ -315,7 +315,7 @@ void plotFITDCSdataFromFile(const std::string& fileName)
 /// ROOT macro for printing the contents of one CCDB object. Used for debugging.
 void printCCDBObject(const std::string detectorName = "FT0",
                      long timestamp = -1,
-                     const std::string ccdbUrl = "http://alice-ccdb.cern.ch")
+                     const std::string ccdbUrl = "https://alice-ccdb.cern.ch")
 {
   // // Parse and check detector name
   // boost::to_upper(detectorName);

--- a/Detectors/GRP/macros/readGRPCCDB.C
+++ b/Detectors/GRP/macros/readGRPCCDB.C
@@ -26,7 +26,7 @@
 // ccdb can be
 // http://localhost:8080 (as by default)
 // http://ccdb-test.cern.ch:8080 (test CCDB)
-// http://alice-ccdb.cern.ch (production CCDB)
+// https://alice-ccdb.cern.ch (production CCDB)
 // http://o2-ccdb.internal (production CCDB, only from FLPs and EPNs)
 
 void readGRPCCDB(long ts = 9999999999000, const char* ccdb = "http://localhost:8080")

--- a/Detectors/GRP/workflows/src/create-grp-ecs.cxx
+++ b/Detectors/GRP/workflows/src/create-grp-ecs.cxx
@@ -178,7 +178,7 @@ int main(int argc, char** argv)
     add_option("flps,f", bpo::value<string>()->default_value(""), "comma separated list of FLPs in the data taking");
     add_option("start-time,s", bpo::value<long>()->default_value(0), "run start time in ms, now() if 0");
     add_option("end-time,e", bpo::value<long>()->default_value(0), "run end time in ms, start-time+3days is used if 0");
-    add_option("ccdb-server", bpo::value<std::string>()->default_value("http://alice-ccdb.cern.ch"), "CCDB server for upload, local file if empty");
+    add_option("ccdb-server", bpo::value<std::string>()->default_value("https://alice-ccdb.cern.ch"), "CCDB server for upload, local file if empty");
     add_option("meta-data,m", bpo::value<std::string>()->default_value("")->implicit_value(""), "metadata as key1=value1;key2=value2;..");
     add_option("refresh", bpo::value<string>()->default_value("")->implicit_value("async"), R"(refresh server cache after upload: "none" (or ""), "async" (non-blocking) and "sync" (blocking))");
     add_option("marginSOR", bpo::value<long>()->default_value(4 * o2::ccdb::CcdbObjectInfo::DAY), "validity at SOR");

--- a/Detectors/ITSMFT/ITS/calibration/macros/MakeNoiseMapFromClusters.C
+++ b/Detectors/ITSMFT/ITS/calibration/macros/MakeNoiseMapFromClusters.C
@@ -53,7 +53,7 @@ void MakeNoiseMapFromClusters(std::string input = "o2clus_its.root", bool only1p
 
   o2::its::NoiseCalibrator calib(only1pix, probT);
   auto& mgr = o2::ccdb::BasicCCDBManager::instance();
-  mgr.setURL("http://alice-ccdb.cern.ch");
+  mgr.setURL("https://alice-ccdb.cern.ch");
   mgr.setTimestamp(timestamp ? timestamp : o2::ccdb::getCurrentTimestamp());
 
   calib.setClusterDictionary(mgr.get<o2::itsmft::TopologyDictionary>("ITS/Calib/ClusterDictionary"));

--- a/Detectors/ITSMFT/ITS/macros/test/CheckClusters.C
+++ b/Detectors/ITSMFT/ITS/macros/test/CheckClusters.C
@@ -54,7 +54,7 @@ void CheckClusters(std::string clusfile = "o2clus_its.root", std::string hitfile
                                                  o2::math_utils::TransformType::L2G)); // request cached transforms
 
   auto& mgr = o2::ccdb::BasicCCDBManager::instance();
-  mgr.setURL("http://alice-ccdb.cern.ch");
+  mgr.setURL("https://alice-ccdb.cern.ch");
   mgr.setTimestamp(timestamp ? timestamp : o2::ccdb::getCurrentTimestamp());
   const o2::itsmft::TopologyDictionary* dict = mgr.get<o2::itsmft::TopologyDictionary>("ITS/Calib/ClusterDictionary");
 

--- a/Detectors/ITSMFT/ITS/macros/test/CheckLUtime.C
+++ b/Detectors/ITSMFT/ITS/macros/test/CheckLUtime.C
@@ -36,7 +36,7 @@ void CheckLUtime(std::string clusfile = "o2clus_its.root", long timestamp = 0)
   using ROFRec = o2::itsmft::ROFRecord;
 
   auto& mgr = o2::ccdb::BasicCCDBManager::instance();
-  mgr.setURL("http://alice-ccdb.cern.ch");
+  mgr.setURL("https://alice-ccdb.cern.ch");
   mgr.setTimestamp(timestamp ? timestamp : o2::ccdb::getCurrentTimestamp());
   const o2::itsmft::TopologyDictionary* dict = mgr.get<o2::itsmft::TopologyDictionary>("ITS/Calib/ClusterDictionary");
 

--- a/Detectors/PHOS/calib/include/PHOSCalibWorkflow/PHOSRunbyrunCalibrator.h
+++ b/Detectors/PHOS/calib/include/PHOSCalibWorkflow/PHOSRunbyrunCalibrator.h
@@ -60,7 +60,7 @@ class PHOSRunbyrunSlot
   bool mUseCCDB = false;
   long mRunStartTime = 0;                             /// start time of the run (sec)
   float mPtCut = 1.5;                                 /// ptmin of a pair cut (GeV/c)
-  std::string mCCDBPath{"http://alice-ccdb.cern.ch"}; /// CCDB path to retrieve current CCDB objects for comparison
+  std::string mCCDBPath{"https://alice-ccdb.cern.ch"}; /// CCDB path to retrieve current CCDB objects for comparison
   std::array<boostHisto, 8> mReMi;                    /// Real and Mixed inv mass distributions per module
   std::unique_ptr<RingBuffer> mBuffer;                /// Buffer for current and previous events
   std::unique_ptr<BadChannelsMap> mBadMap;            /// Latest bad channels map
@@ -98,7 +98,7 @@ class PHOSRunbyrunCalibrator final : public o2::calibration::TimeSlotCalibration
  private:
   bool mUseCCDB = false;
   long mRunStartTime = 0;                             /// start time of the run (sec)
-  std::string mCCDBPath{"http://alice-ccdb.cern.ch"}; /// CCDB path to retrieve current CCDB objects for comparison
+  std::string mCCDBPath{"https://alice-ccdb.cern.ch"}; /// CCDB path to retrieve current CCDB objects for comparison
   std::array<float, 8> mRunByRun;                     /// Final calibration object
   std::array<TH1F*, 8> mReMi;                         /// Real and Mixed inv mass distributions per module
 

--- a/Detectors/TOF/calibration/include/TOFCalibration/CalibTOF.h
+++ b/Detectors/TOF/calibration/include/TOFCalibration/CalibTOF.h
@@ -138,7 +138,7 @@ class CalibTOF
 
   bool mInitDone = false;                                  ///< flag init already done
   bool mFillCCDB = false;                                  ///< flag init already doneto decide whether to fill or not the CCDB
-  std::string mCCDBpath = "http://alice-ccdb.cern.ch";     ///< path to CCDB
+  std::string mCCDBpath = "https://alice-ccdb.cern.ch";    ///< path to CCDB
 
   ///========== Parameters to be set externally, e.g. from CCDB ====================
 

--- a/Detectors/TPC/calibration/macro/drawNoiseAndPedestal.C
+++ b/Detectors/TPC/calibration/macro/drawNoiseAndPedestal.C
@@ -55,7 +55,7 @@ TObjArray* drawNoiseAndPedestal(std::string_view pedestalFile, int mode = 0, std
     if (pedestalFile.find("cdb-test") == 0) {
       cdb.setURL("http://ccdb-test.cern.ch:8080");
     } else if (pedestalFile.find("cdb-prod") == 0) {
-      cdb.setURL("http://alice-ccdb.cern.ch");
+      cdb.setURL("https://alice-ccdb.cern.ch");
     }
     const auto timePos = pedestalFile.find("@");
     if (timePos != std::string_view::npos) {

--- a/Detectors/TPC/calibration/macro/prepareCMFiles.C
+++ b/Detectors/TPC/calibration/macro/prepareCMFiles.C
@@ -46,7 +46,7 @@ void prepareCMFiles(const std::string_view pulserFile, std::string outputDir = "
     if (pulserFile.find("cdb-test") == 0) {
       cdb.setURL("http://ccdb-test.cern.ch:8080");
     } else if (pulserFile.find("cdb-prod") == 0) {
-      cdb.setURL("http://alice-ccdb.cern.ch");
+      cdb.setURL("https://alice-ccdb.cern.ch");
     }
     const auto timePos = pulserFile.find("@");
     if (timePos != std::string_view::npos) {

--- a/Detectors/TPC/calibration/macro/prepareITFiles.C
+++ b/Detectors/TPC/calibration/macro/prepareITFiles.C
@@ -45,7 +45,7 @@ void prepareCMFiles(const std::string_view itDataFile, std::string outputDir = "
     if (itDataFile.find("cdb-test") == 0) {
       cdb.setURL("http://ccdb-test.cern.ch:8080");
     } else if (itDataFile.find("cdb-prod") == 0) {
-      cdb.setURL("http://alice-ccdb.cern.ch");
+      cdb.setURL("https://alice-ccdb.cern.ch");
     }
     const auto timePos = itDataFile.find("@");
     if (timePos != std::string_view::npos) {

--- a/Detectors/TPC/calibration/macro/preparePedestalFiles.C
+++ b/Detectors/TPC/calibration/macro/preparePedestalFiles.C
@@ -41,7 +41,7 @@ void preparePedestalFiles(const std::string_view pedestalFile, std::string outpu
     if (pedestalFile.find("cdb-test") == 0) {
       cdb.setURL("http://ccdb-test.cern.ch:8080");
     } else if (pedestalFile.find("cdb-prod") == 0) {
-      cdb.setURL("http://alice-ccdb.cern.ch");
+      cdb.setURL("https://alice-ccdb.cern.ch");
     }
     const auto timePos = pedestalFile.find("@");
     if (timePos != std::string_view::npos) {

--- a/Detectors/TRD/calibration/macros/makeDeflectionCorrelation.C
+++ b/Detectors/TRD/calibration/macros/makeDeflectionCorrelation.C
@@ -71,7 +71,7 @@ static o2::trd::NoiseStatusMCM* noiseMapPtr;
 static void ccdbDownload(unsigned int runNumber, std::string ccdb, timePoint queryInterval)
 {
   auto& ccdbMgr = o2::ccdb::BasicCCDBManager::instance();
-  ccdbMgr.setURL("http://alice-ccdb.cern.ch/");
+  ccdbMgr.setURL("https://alice-ccdb.cern.ch/");
   auto runDuration = ccdbMgr.getRunDuration(runNumber);
   std::map<std::string, std::string> md;
   md["runNumber"] = std::to_string(runNumber);

--- a/Detectors/TRD/calibration/macros/plotVdriftExB.C
+++ b/Detectors/TRD/calibration/macros/plotVdriftExB.C
@@ -39,7 +39,7 @@ static std::array<bool, 540> good;                                              
 void ccdbDownload(unsigned int runNumber, std::string ccdb, timePoint queryInterval)
 {
   auto& ccdbMgr = o2::ccdb::BasicCCDBManager::instance();
-  ccdbMgr.setURL("http://alice-ccdb.cern.ch/");
+  ccdbMgr.setURL("https://alice-ccdb.cern.ch/");
   auto runDuration = ccdbMgr.getRunDuration(runNumber);
   std::map<std::string, std::string> md;
   md["runNumber"] = std::to_string(runNumber);

--- a/Detectors/TRD/reconstruction/macros/createLinkToHCIDMapping.C
+++ b/Detectors/TRD/reconstruction/macros/createLinkToHCIDMapping.C
@@ -60,7 +60,7 @@ void createLinkToHCIDMapping(bool isDefault = true)
   }
 
   o2::ccdb::CcdbApi ccdb;
-  ccdb.init("http://alice-ccdb.cern.ch");
+  ccdb.init("https://alice-ccdb.cern.ch");
   // ccdb.init("http://ccdb-test.cern.ch:8080");
 
   std::map<std::string, std::string> metadata;

--- a/Detectors/ZDC/base/include/ZDCBase/Helpers.h
+++ b/Detectors/ZDC/base/include/ZDCBase/Helpers.h
@@ -49,7 +49,7 @@ std::string ccdbShortcuts(std::string ccdbHost, std::string cln, std::string pat
 {
   // Commonly used shortcuts for ccdbHost
   if (ccdbHost.size() == 0 || ccdbHost == "external") {
-    ccdbHost = "http://alice-ccdb.cern.ch:8080";
+    ccdbHost = "https://alice-ccdb.cern.ch:8080";
   } else if (ccdbHost == "internal") {
     ccdbHost = "http://o2-ccdb.internal/";
   } else if (ccdbHost == "test") {

--- a/Detectors/ZDC/macro/CreateSimCondition_pp.C
+++ b/Detectors/ZDC/macro/CreateSimCondition_pp.C
@@ -103,7 +103,7 @@ void CreateSimCondition_pp(long tmin = 0, long tmax = -1, std::string ccdbHost =
   o2::ccdb::CcdbApi api;
   map<string, string> metadata; // can be empty
   if (ccdbHost.size() == 0 || ccdbHost == "external") {
-    ccdbHost = "http://alice-ccdb.cern.ch:8080";
+    ccdbHost = "https://alice-ccdb.cern.ch:8080";
   } else if (ccdbHost == "internal") {
     ccdbHost = "http://o2-ccdb.internal/";
   } else if (ccdbHost == "test") {

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -215,7 +215,7 @@ std::string defaultConditionBackend()
   if (getenv("DDS_SESSION_ID") != nullptr || getenv("OCC_CONTROL_PORT") != nullptr) {
     return getenv("DPL_CONDITION_BACKEND") ? getenv("DPL_CONDITION_BACKEND") : "http://o2-ccdb.internal";
   }
-  return getenv("DPL_CONDITION_BACKEND") ? getenv("DPL_CONDITION_BACKEND") : "http://alice-ccdb.cern.ch";
+  return getenv("DPL_CONDITION_BACKEND") ? getenv("DPL_CONDITION_BACKEND") : "https://alice-ccdb.cern.ch";
 }
 
 // get the default value for condition query rate

--- a/Framework/TestWorkflows/src/test_CCDBFetchToTimeframe.cxx
+++ b/Framework/TestWorkflows/src/test_CCDBFetchToTimeframe.cxx
@@ -20,7 +20,7 @@
 using namespace o2::framework;
 
 // Set a start value which might correspond to a real timestamp of an object in CCDB, for example:
-// o2-testworkflows-ccdb-fetch-to-timeframe --condition-backend http://alice-ccdb.cern.ch --start-value-enumeration 1575985965925000
+// o2-testworkflows-ccdb-fetch-to-timeframe --condition-backend https://alice-ccdb.cern.ch --start-value-enumeration 1575985965925000
 WorkflowSpec defineDataProcessing(ConfigContext const&)
 {
   return WorkflowSpec{

--- a/macro/getTimeStamp.C
+++ b/macro/getTimeStamp.C
@@ -18,7 +18,7 @@
 
 // Snippet to get ms-timestamp for given run / orbit
 
-long getTimeStamp(int runNumber, uint32_t orbit, const std::string& ccdbHost = "http://alice-ccdb.cern.ch")
+long getTimeStamp(int runNumber, uint32_t orbit, const std::string& ccdbHost = "https://alice-ccdb.cern.ch")
 {
   static int prevRunNumber = -1;
   static int64_t orbitResetMUS = 0;

--- a/macro/run_clus_itsSA.C
+++ b/macro/run_clus_itsSA.C
@@ -37,7 +37,7 @@ void run_clus_itsSA(std::string inputfile = "rawits.bin", // input file name
   logger->SetLogScreenLevel("INFO");
 
   auto& mgr = o2::ccdb::BasicCCDBManager::instance();
-  mgr.setURL("http://alice-ccdb.cern.ch");
+  mgr.setURL("https://alice-ccdb.cern.ch");
   mgr.setTimestamp(timestamp ? timestamp : o2::ccdb::getCurrentTimestamp());
   const o2::itsmft::TopologyDictionary* dict = mgr.get<o2::itsmft::TopologyDictionary>("ITS/Calib/ClusterDictionary");
 

--- a/macro/run_trac_ca_its.C
+++ b/macro/run_trac_ca_its.C
@@ -104,7 +104,7 @@ void run_trac_ca_its(bool cosmics = false,
                                                  o2::math_utils::TransformType::L2G)); // request cached transforms
 
   auto& mgr = o2::ccdb::BasicCCDBManager::instance();
-  mgr.setURL("http://alice-ccdb.cern.ch");
+  mgr.setURL("https://alice-ccdb.cern.ch");
   mgr.setTimestamp(timestamp ? timestamp : o2::ccdb::getCurrentTimestamp());
   const o2::itsmft::TopologyDictionary* dict = mgr.get<o2::itsmft::TopologyDictionary>("ITS/Calib/ClusterDictionary");
 

--- a/macro/run_trac_its.C
+++ b/macro/run_trac_its.C
@@ -80,7 +80,7 @@ void run_trac_its(std::string path = "./", std::string outputfile = "o2trac_its.
   }
 
   auto& mgr = o2::ccdb::BasicCCDBManager::instance();
-  mgr.setURL("http://alice-ccdb.cern.ch");
+  mgr.setURL("https://alice-ccdb.cern.ch");
   mgr.setTimestamp(timestamp ? timestamp : o2::ccdb::getCurrentTimestamp());
   const o2::itsmft::TopologyDictionary* dict = mgr.get<o2::itsmft::TopologyDictionary>("ITS/Calib/ClusterDictionary");
 

--- a/scripts/datamodel-doc/ALICEO2dataModelTools.py
+++ b/scripts/datamodel-doc/ALICEO2dataModelTools.py
@@ -288,7 +288,7 @@ def getArgumentValues(words):
 def pickContent(lines_in_file):
 
   # 1. remove the comments // but not the //!
-  #   ATTENTION: '//' can be part of a string, e.g. http://alice-ccdb.cern.ch
+  #   ATTENTION: '//' can be part of a string, e.g. https://alice-ccdb.cern.ch
   # 2. consider extensions \
   # 3. remove comment blocks /* ... */
   linesWithoutComments = list()


### PR DESCRIPTION
@shahor02 @costing @sawenzel : we discussed some time ago to disable the http instance of alice-ccdb.cern.ch, since it is quite confusing that sometimes it returns objects from the cache, and sometimes not.
Should we finally proceed with this?
As preparateion, we should move everything to https.