### PR TITLE
Add timer to TRD and TPC calibrations

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
@@ -146,7 +146,7 @@ void TPCInterpolationDPL::run(ProcessingContext& pc)
 
   mInterpolation.process(recoData, gids, gidTables, seeds, trkTimes);
   mTimer.Stop();
-  LOGF(info, "TPC insterpolation timing: Cpu: %.3e Real: %.3e s", mTimer.CpuTime(), mTimer.RealTime());
+  LOGF(info, "TPC interpolation timing: Cpu: %.3e Real: %.3e s", mTimer.CpuTime(), mTimer.RealTime());
   mTimer.Start(true);
   mResidualProcessor.setInputData(mInterpolation.getReferenceTracks(), mInterpolation.getClusterResiduals());
   // in the following step one can create one output file per TPC sector with local residuals and statistics

--- a/Detectors/TRD/workflow/include/TRDWorkflow/VdAndExBCalibSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/VdAndExBCalibSpec.h
@@ -27,6 +27,7 @@
 #include "CCDB/CcdbApi.h"
 #include "CCDB/CcdbObjectInfo.h"
 #include "DetectorsBase/GRPGeomHelper.h"
+#include <chrono>
 
 using namespace o2::framework;
 
@@ -58,12 +59,15 @@ class VdAndExBCalibDevice : public o2::framework::Task
 
   void run(o2::framework::ProcessingContext& pc) final
   {
+    auto runStartTime = std::chrono::high_resolution_clock::now();
     o2::base::GRPGeomHelper::instance().checkUpdates(pc);
     auto data = pc.inputs().get<o2::trd::AngularResidHistos>("input");
     o2::base::TFIDInfoHelper::fillTFIDInfo(pc, mCalibrator->getCurrentTFInfo());
     LOG(info) << "Processing TF " << mCalibrator->getCurrentTFInfo().tfCounter << " with " << data.getNEntries() << " AngularResidHistos entries";
     mCalibrator->process(data);
     sendOutput(pc.outputs());
+    std::chrono::duration<double, std::milli> runDuration = std::chrono::high_resolution_clock::now() - runStartTime;
+    LOGP(info, "Duration for run method: {} ms", std::chrono::duration_cast<std::chrono::milliseconds>(runDuration).count());
   }
 
   void endOfStream(o2::framework::EndOfStreamContext& ec) final


### PR DESCRIPTION
Adding this for run 526121 and processing a few TFs locally I get for TRD vDrift and ExB:
```
[65866:calib-vdexb-calibration]: [13:02:27][INFO] Duration for run method: 18 ms
[65866:calib-vdexb-calibration]: [13:02:50][INFO] Duration for run method: 0 ms
[65866:calib-vdexb-calibration]: [13:03:22][INFO] Duration for run method: 0 ms
[65866:calib-vdexb-calibration]: [13:03:56][INFO] Duration for run method: 0 ms
[65866:calib-vdexb-calibration]: [13:04:29][INFO] Duration for run method: 0 ms
[65866:calib-vdexb-calibration]: [13:05:03][INFO] Duration for run method: 0 ms
[65866:calib-vdexb-calibration]: [13:05:38][INFO] Duration for run method: 0 ms
[65866:calib-vdexb-calibration]: [13:06:13][INFO] Duration for run method: 0 ms
[65866:calib-vdexb-calibration]: [13:06:48][INFO] Duration for run method: 0 ms
[65866:calib-vdexb-calibration]: [13:07:24][INFO] Duration for run method: 0 ms
```
and for the residual aggregator:
```
[65870:residual-aggregator]: [13:02:30][INFO] Duration for run method: 111 ms
[65870:residual-aggregator]: [13:02:50][INFO] Duration for run method: 20 ms
[65870:residual-aggregator]: [13:03:22][INFO] Duration for run method: 1 ms
[65870:residual-aggregator]: [13:03:56][INFO] Duration for run method: 0 ms
[65870:residual-aggregator]: [13:04:29][INFO] Duration for run method: 0 ms
[65870:residual-aggregator]: [13:05:03][INFO] Duration for run method: 0 ms
[65870:residual-aggregator]: [13:05:38][INFO] Duration for run method: 3 ms
[65870:residual-aggregator]: [13:06:13][INFO] Duration for run method: 1 ms
[65870:residual-aggregator]: [13:06:48][INFO] Duration for run method: 1 ms
[65870:residual-aggregator]: [13:07:24][INFO] Duration for run method: 0 ms
```
So for the very first TF the processing time in both cases is too slow. Afterwards it is within the limit (should be below TF duration of about 11ms). For the residual aggregator only very few tracks per TF are processed:
```
[65870:residual-aggregator]: [13:02:30][INFO] Processing TF 2361558 with 15 tracks and 2042 unbinned residuals associated to them
[65870:residual-aggregator]: [13:02:50][INFO] Processing TF 2367348 with 16 tracks and 2117 unbinned residuals associated to them
[65870:residual-aggregator]: [13:03:22][INFO] Processing TF 2369708 with 27 tracks and 3580 unbinned residuals associated to them
[65870:residual-aggregator]: [13:03:56][INFO] Processing TF 2361778 with 13 tracks and 1735 unbinned residuals associated to them
[65870:residual-aggregator]: [13:04:29][INFO] Processing TF 2368207 with 19 tracks and 2500 unbinned residuals associated to them
[65870:residual-aggregator]: [13:05:03][INFO] Processing TF 2362150 with 13 tracks and 1737 unbinned residuals associated to them
[65870:residual-aggregator]: [13:05:38][INFO] Processing TF 2362811 with 20 tracks and 2667 unbinned residuals associated to them
[65870:residual-aggregator]: [13:06:13][INFO] Processing TF 2367573 with 17 tracks and 2255 unbinned residuals associated to them
[65870:residual-aggregator]: [13:06:48][INFO] Processing TF 2364399 with 15 tracks and 2002 unbinned residuals associated to them
[65870:residual-aggregator]: [13:07:24][INFO] Processing TF 1032806 with 27 tracks and 3496 unbinned residuals associated to them
```