### PR TITLE
[EMCAL-566] Add shift for low gain time calibration

### DIFF
--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibExtractor.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibExtractor.h
@@ -24,6 +24,7 @@
 #include "EMCALCalib/BadChannelMap.h"
 #include "EMCALCalib/EMCALChannelScaleFactors.h"
 #include "EMCALCalib/TimeCalibrationParams.h"
+#include "EMCALCalibration/EMCALCalibParams.h"
 #include "CommonUtils/BoostHistogramUtils.h"
 #include "EMCALBase/Geometry.h"
 #include <boost/histogram.hpp>
@@ -285,10 +286,12 @@ class EMCALCalibExtractor
         auto fitValues = o2::utils::fitBoostHistoWithGaus<double>(boostHist1d);
         mean = fitValues.at(1);
         // add mean to time calib params
-        TCP.addTimeCalibParam(i, mean, 0);
+        TCP.addTimeCalibParam(i, mean, false);                                                // highGain calib factor
+        TCP.addTimeCalibParam(i, mean + EMCALCalibParams::Instance().lowGainOffset_tc, true); // lowGain calib factor
       } catch (o2::utils::FitGausError_t err) {
         LOG(warning) << createErrorMessageFitGaus(err) << "; for cell " << i << " (Will take the parameter of the previous cell: " << mean << "ns)";
-        TCP.addTimeCalibParam(i, mean, 0); // take calib value of last cell; or 400 ns shift default value
+        TCP.addTimeCalibParam(i, mean, false);                                                // take calib value of last cell; or 400 ns shift default value
+        TCP.addTimeCalibParam(i, mean + EMCALCalibParams::Instance().lowGainOffset_tc, true); // take calib value of last cell; or 400 ns shift default value
       }
     }
     return TCP;

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibParams.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibParams.h
@@ -51,6 +51,7 @@ struct EMCALCalibParams : public o2::conf::ConfigurableParamHelper<EMCALCalibPar
   int nBinsTimeAxis_tc = 1500;          ///< number of bins used for the time calibration
   int minValueTimeAxis_tc = -500;       ///< minimum value of the time axis in the time calibration
   int maxValueTimeAxis_tc = 1000;       ///< maximum value of the time axis in the time calibration
+  float lowGainOffset_tc = 8.8;         ///< Offset between high gain and low gain in ns. This is needed since the low gain calib will not be possible due to insuficient statistics
   unsigned int slotLength_tc = 0;       ///< Lenght of the slot before calibration is triggered. If set to 0 calibration is triggered when hasEnoughData returns true
   bool UpdateAtEndOfRunOnly_tc = false; ///< switsch to enable trigger of calibration only at end of run
 

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelCalibrator.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelCalibrator.h
@@ -163,9 +163,13 @@ void EMCALChannelCalibrator<DataInput, DataOutput>::finalizeSlot(o2::calibration
 
       TFile fLocalStorage((EMCALCalibParams::Instance().localRootFilePath).c_str(), ffile.good() == true ? "update" : "recreate");
       fLocalStorage.cd();
-      TH1F* histTCparams = (TH1F*)tcd.getHistogramRepresentation(false);
-      std::string nameTCHist = "TCParams_" + std::to_string(slot.getStartTimeMS());
+      TH1F* histTCparams = (TH1F*)tcd.getHistogramRepresentation(false); // high gain calibration
+      std::string nameTCHist = "TCParams_HG_" + std::to_string(slot.getStartTimeMS());
       histTCparams->Write(nameTCHist.c_str(), TObject::kOverwrite);
+
+      TH1F* histTCparams_LG = (TH1F*)tcd.getHistogramRepresentation(true); // low gain calibration
+      std::string nameTCHist_LG = "TCParams_LG_" + std::to_string(slot.getStartTimeMS());
+      histTCparams_LG->Write(nameTCHist_LG.c_str(), TObject::kOverwrite);
 
       TH2F hCalibHist = o2::utils::TH2FFromBoost(c->getHisto());
       std::string nameTCInputHist = "TimeVsCellID_" + std::to_string(slot.getStartTimeMS());


### PR DESCRIPTION
- In run3, the statistics accumulated before the asynchornus reconstruction is (most likely) not sufficient to calibrate the low gain cells (> ~16GeV)
- From previous run2 studies and new data from LHC22m, we know that the low gain calibration factors should be nearly the same as the high gain calib factors, however they are shifted by a few nanoseconds
- Implemented that the low gain calib factors are taken from the high gain factors and added a constant shift for all cells
- Shift is settable via the EMCALCalibParams