### PR TITLE
[EMCAL-612] Make workflow name optional for cell writer

### DIFF
--- a/Detectors/EMCAL/workflow/src/cell-writer-workflow.cxx
+++ b/Detectors/EMCAL/workflow/src/cell-writer-workflow.cxx
@@ -27,7 +27,8 @@ using namespace o2::emcal;
 // we need to add workflow options before including Framework/runDataProcessing
 void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
-  std::vector<ConfigParamSpec> options{{"disable-mc", VariantType::Bool, false, {"Do not propagate MC labels"}},
+  std::vector<ConfigParamSpec> options{{"cell-writer-name", VariantType::String, "emcal-cells-writer", {"Workflow name"}},
+                                       {"disable-mc", VariantType::Bool, false, {"Do not propagate MC labels"}},
                                        {"subspec", VariantType::UInt32, 0U, {"Input subspecification"}},
                                        {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
   workflowOptions.insert(workflowOptions.end(), options.begin(), options.end());
@@ -45,10 +46,11 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   bool disableMC = cfgc.options().get<bool>("disable-mc");
   auto subspec = cfgc.options().get<uint32_t>("subspec");
+  auto workflowname = cfgc.options().get<std::string>("cell-writer-name");
   o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
 
   WorkflowSpec specs;
-  specs.emplace_back(MakeRootTreeWriterSpec("emcal-cells-writer", "emccells.root", "o2sim",
+  specs.emplace_back(MakeRootTreeWriterSpec(workflowname.data(), "emccells.root", "o2sim",
                                             MakeRootTreeWriterSpec::BranchDefinition<std::vector<Cell>>{InputSpec{"data", "EMC", "CELLS", subspec}, "EMCALCell", "cell-branch-name"},
                                             MakeRootTreeWriterSpec::BranchDefinition<std::vector<TriggerRecord>>{InputSpec{"trigger", "EMC", "CELLSTRGR", subspec}, "EMCALCellTRGR", "celltrigger-branch-name"},
                                             MakeRootTreeWriterSpec::BranchDefinition<o2::dataformats::MCTruthContainer<MCLabel>>{InputSpec{"mc", "EMC", "CELLSMCTR", subspec}, "EMCALCellMCTruth", "cellmc-branch-name", disableMC ? 0 : 1})());


### PR DESCRIPTION
Needed in order to run different cell writers in parallel. As
default the current workflow name is used so the standard
behaviour is unchanged.