### PR TITLE
DPL: move responsibility to get services

### DIFF
--- a/Framework/Core/include/Framework/CommonServices.h
+++ b/Framework/Core/include/Framework/CommonServices.h
@@ -12,6 +12,7 @@
 #define O2_FRAMEWORK_COMMONSERVICES_H_
 
 #include "Framework/ServiceSpec.h"
+#include "Framework/ServiceRegistryRef.h"
 #include "Framework/TypeIdHelpers.h"
 
 class TDatabasePDG;

--- a/Framework/Core/include/Framework/DataProcessingDevice.h
+++ b/Framework/Core/include/Framework/DataProcessingDevice.h
@@ -122,7 +122,7 @@ struct DeviceConfigurationHelpers {
 class DataProcessingDevice : public fair::mq::Device
 {
  public:
-  DataProcessingDevice(RunningDeviceRef ref, ServiceRegistryRef, ProcessingPolicies& policies);
+  DataProcessingDevice(RunningDeviceRef ref, ServiceRegistry&, ProcessingPolicies& policies);
   void Init() final;
   void InitTask() final;
   void PreRun() final;
@@ -159,7 +159,7 @@ class DataProcessingDevice : public fair::mq::Device
   AlgorithmSpec::ErrorCallback mError;
   std::function<void(RuntimeErrorRef e, InputRecord& record)> mErrorHandling;
   std::unique_ptr<ConfigParamRegistry> mConfigRegistry;
-  ServiceRegistryRef mServiceRegistry;
+  ServiceRegistry& mServiceRegistry;
   DataAllocator mAllocator;
   DataRelayer* mRelayer = nullptr;
   /// Expiration handler

--- a/Framework/Core/include/Framework/DataSender.h
+++ b/Framework/Core/include/Framework/DataSender.h
@@ -40,6 +40,8 @@ class DataSender
 
  private:
   FairMQDeviceProxy& mProxy;
+  // We need the ServiceRegistry and not a ref, to be able
+  // to call the callbacks after sending.
   ServiceRegistryRef mRegistry;
   DeviceSpec const& mSpec;
   std::vector<OutputSpec> mOutputs;

--- a/Framework/Core/include/Framework/DebugGUI.h
+++ b/Framework/Core/include/Framework/DebugGUI.h
@@ -24,6 +24,7 @@
 
 namespace o2::framework
 {
+struct ServiceRegistry;
 /// Plugin interface for DPL GUIs.
 struct DebugGUI {
   virtual std::function<void(void)> getGUIDebugger(std::vector<o2::framework::DeviceInfo> const& infos,
@@ -41,7 +42,7 @@ struct DebugGUI {
   virtual void keyUp(char key) = 0;
   virtual void charIn(char key) = 0;
 
-  virtual void* initGUI(char const* windowTitle, ServiceRegistryRef registry) = 0;
+  virtual void* initGUI(char const* windowTitle, ServiceRegistry& registry) = 0;
   virtual void getFrameJSON(void* data, std::ostream& json_data) = 0;
   virtual void getFrameRaw(void* data, void** raw_data, int* size) = 0;
   virtual bool pollGUIPreRender(void* context, float delta) = 0;

--- a/Framework/Core/include/Framework/ErrorContext.h
+++ b/Framework/Core/include/Framework/ErrorContext.h
@@ -12,7 +12,7 @@
 #define O2_FRAMEWORK_ERROR_CONTEXT_H_
 
 #include "Framework/InputRecord.h"
-#include "Framework/ServiceRegistry.h"
+#include "Framework/ServiceRegistryRef.h"
 #include "Framework/RuntimeError.h"
 
 namespace o2::framework
@@ -31,7 +31,7 @@ class ErrorContext
   }
 
   InputRecord const& inputs() { return mInputs; }
-  ServiceRegistry const& services() { return mServices; }
+  ServiceRegistryRef services() { return mServices; }
   RuntimeErrorRef exception() { return mExceptionRef; }
 
  private:

--- a/Framework/Core/include/Framework/ServiceRegistry.h
+++ b/Framework/Core/include/Framework/ServiceRegistry.h
@@ -370,10 +370,6 @@ struct ServiceRegistry {
   }
 };
 
-// This is to migrate the code in QC.
-// FIXME: move this to the proper smart reference class once done
-using ServiceRegistryRef = o2::framework::ServiceRegistry &;
-
 } // namespace o2::framework
 
 #endif // O2_FRAMEWORK_SERVICEREGISTRY_H_

--- a/Framework/Core/include/Framework/ServiceSpec.h
+++ b/Framework/Core/include/Framework/ServiceSpec.h
@@ -30,7 +30,7 @@ namespace o2::framework
 struct InitContext;
 struct DeviceSpec;
 struct ServiceRegistry;
-using ServiceRegistryRef = ServiceRegistry&;
+struct ServiceRegistryRef;
 struct DeviceState;
 struct ProcessingContext;
 class EndOfStreamContext;
@@ -96,10 +96,10 @@ using ServicePostDispatching = void (*)(ProcessingContext&, void*);
 using ServicePostForwarding = void (*)(ProcessingContext&, void*);
 
 /// Callback invoked when the driver enters the init phase.
-using ServiceDriverInit = void (*)(ServiceRegistryRef, boost::program_options::variables_map const&);
+using ServiceDriverInit = void (*)(ServiceRegistry&, boost::program_options::variables_map const&);
 
 /// Callback invoked when the driver enters the init phase.
-using ServiceDriverStartup = void (*)(ServiceRegistryRef, boost::program_options::variables_map const&);
+using ServiceDriverStartup = void (*)(ServiceRegistry&, boost::program_options::variables_map const&);
 
 /// Callback invoked when we inject internal devices in the topology
 using ServiceTopologyInject = void (*)(WorkflowSpecNode&, ConfigContext&);

--- a/Framework/Core/src/ArrowSupport.cxx
+++ b/Framework/Core/src/ArrowSupport.cxx
@@ -364,7 +364,7 @@ o2::framework::ServiceSpec ArrowSupport::arrowBackendSpec()
                        monitoring.send(Metric{(uint64_t)arrow->bytesDestroyed(), "arrow-bytes-destroyed"}.addTag(Key::Subsystem, monitoring::tags::Value::DPL));
                        monitoring.send(Metric{(uint64_t)arrow->messagesDestroyed(), "arrow-messages-destroyed"}.addTag(Key::Subsystem, monitoring::tags::Value::DPL));
                        monitoring.flushBuffer(); },
-    .driverInit = [](ServiceRegistryRef registry, boost::program_options::variables_map const& vm) {
+    .driverInit = [](ServiceRegistry& registry, boost::program_options::variables_map const& vm) {
                        auto config = new RateLimitConfig{};
                        int readers = std::stoll(vm["readers"].as<std::string>());
                        if (vm.count("aod-memory-rate-limit") && vm["aod-memory-rate-limit"].defaulted() == false) {

--- a/Framework/Core/src/CallbacksPolicy.cxx
+++ b/Framework/Core/src/CallbacksPolicy.cxx
@@ -11,6 +11,7 @@
 #include "Framework/CallbacksPolicy.h"
 #include "Framework/CallbackService.h"
 #include "Framework/CompletionPolicy.h"
+#include "Framework/ServiceRegistryRef.h"
 #include "Framework/TimingInfo.h"
 #include "Framework/Logger.h"
 #include <cstdlib>

--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -18,7 +18,7 @@
 #include "Framework/TimesliceIndex.h"
 #include "Framework/DataTakingContext.h"
 #include "Framework/DataSender.h"
-#include "Framework/ServiceRegistry.h"
+#include "Framework/ServiceRegistryRef.h"
 #include "Framework/DeviceSpec.h"
 #include "Framework/LocalRootFileService.h"
 #include "Framework/DataRelayer.h"
@@ -207,7 +207,7 @@ o2::framework::ServiceSpec CommonServices::configurationSpec()
                            ConfigurationFactory::getConfiguration(backend).release()};
     },
     .configure = noConfiguration(),
-    .driverStartup = [](ServiceRegistryRef registry, boost::program_options::variables_map const& vmap) {
+    .driverStartup = [](ServiceRegistry& registry, boost::program_options::variables_map const& vmap) {
       if (vmap.count("configuration") == 0) {
         registry.registerService(ServiceHandle{0, nullptr});
         return;

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -108,7 +108,7 @@ void on_communication_requested(uv_async_t* s)
   state->loopReason |= DeviceState::METRICS_MUST_FLUSH;
 }
 
-DataProcessingDevice::DataProcessingDevice(RunningDeviceRef ref, ServiceRegistryRef registry, ProcessingPolicies& policies)
+DataProcessingDevice::DataProcessingDevice(RunningDeviceRef ref, ServiceRegistry& registry, ProcessingPolicies& policies)
   : mSpec{registry.get<RunningWorkflowInfo const>().devices[ref.index]},
     mState{registry.get<DeviceState>()},
     mInit{mSpec.algorithm.onInit},

--- a/Framework/Core/src/DataSender.cxx
+++ b/Framework/Core/src/DataSender.cxx
@@ -79,7 +79,7 @@ std::unique_ptr<fair::mq::Message> DataSender::create(RouteIndex routeIndex)
 
 void DataSender::send(fair::mq::Parts& parts, ChannelIndex channelIndex)
 {
-  mRegistry.preSendingMessagesCallbacks(mRegistry, parts, channelIndex);
+  mRegistry.preSendingMessagesCallbacks(parts, channelIndex);
   mPolicy.send(mProxy, parts, channelIndex, mRegistry);
 }
 

--- a/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
+++ b/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
@@ -435,7 +435,7 @@ DataProcessorSpec specifyExternalFairMQDeviceProxy(char const* name,
     // will be multiple channels. At least we throw a more informative exception.
     // fair::mq::Device calls the custom init before the channels have been configured
     // so we do the check before starting in a dedicated callback
-    auto channelConfigurationChecker = [device, deviceName, &services = ctx.services()]() {
+    auto channelConfigurationChecker = [device, deviceName, services = ctx.services()]() {
       auto& deviceState = services.get<DeviceState>();
       channels.clear();
       numberOfEoS.clear();

--- a/Framework/Core/src/ServiceRegistry.cxx
+++ b/Framework/Core/src/ServiceRegistry.cxx
@@ -9,6 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 #include "Framework/ServiceRegistry.h"
+#include "Framework/ServiceRegistryRef.h"
 #include "Framework/Tracing.h"
 #include "Framework/Logger.h"
 #include <iostream>
@@ -28,7 +29,7 @@ ServiceRegistry::ServiceRegistry(ServiceRegistry const& other)
   }
 }
 
-ServiceRegistryRef ServiceRegistry::operator=(ServiceRegistry const& other)
+ServiceRegistry& ServiceRegistry::operator=(ServiceRegistry const& other)
 {
   for (size_t i = 0; i < MAX_SERVICES; ++i) {
     mServicesKey[i].store(other.mServicesKey[i].load());
@@ -234,18 +235,18 @@ void ServiceRegistry::preExitCallbacks()
   // FIXME: we need to call the callback only once for the global services
   /// I guess...
   for (auto exitHandle = mPreExitHandles.rbegin(); exitHandle != mPreExitHandles.rend(); ++exitHandle) {
-    exitHandle->callback(*this, exitHandle->service);
+    exitHandle->callback(ServiceRegistryRef{*this}, exitHandle->service);
   }
 }
 
-void ServiceRegistry::domainInfoUpdatedCallback(ServiceRegistryRef registry, size_t oldestPossibleTimeslice, ChannelIndex channelIndex)
+void ServiceRegistry::domainInfoUpdatedCallback(ServiceRegistry& registry, size_t oldestPossibleTimeslice, ChannelIndex channelIndex)
 {
   for (auto& handle : mDomainInfoHandles) {
     handle.callback(*this, oldestPossibleTimeslice, channelIndex);
   }
 }
 
-void ServiceRegistry::preSendingMessagesCallbacks(ServiceRegistryRef registry, fair::mq::Parts& parts, ChannelIndex channelIndex)
+void ServiceRegistry::preSendingMessagesCallbacks(ServiceRegistry& registry, fair::mq::Parts& parts, ChannelIndex channelIndex)
 {
   for (auto& handle : mPreSendingMessagesHandles) {
     handle.callback(*this, parts, channelIndex);

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -1042,7 +1042,7 @@ void doDefaultWorkflowTerminationHook()
   // LOG(info) << "Process " << getpid() << " is exiting.";
 }
 
-int doChild(int argc, char** argv, ServiceRegistryRef serviceRegistry,
+int doChild(int argc, char** argv, ServiceRegistry& serviceRegistry,
             RunningWorkflowInfo const& runningWorkflow,
             RunningDeviceRef ref,
             ProcessingPolicies processingPolicies,

--- a/Framework/Foundation/include/Framework/Features.h
+++ b/Framework/Foundation/include/Framework/Features.h
@@ -1,0 +1,17 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_FRAMEWORK_FEATURES_H_
+#define O2_FRAMEWORK_FEATURES_H_
+
+#define DPL_HAS_SERVICEREGISTRY_REF 1
+
+#endif

--- a/Framework/GUISupport/src/Plugin.cxx
+++ b/Framework/GUISupport/src/Plugin.cxx
@@ -68,7 +68,7 @@ struct ImGUIDebugGUI : o2::framework::DebugGUI {
     o2::framework::gui::charIn(key);
   }
 
-  void* initGUI(char const* windowTitle, ServiceRegistryRef registry_) override
+  void* initGUI(char const* windowTitle, ServiceRegistry& registry_) override
   {
     registry = &registry_;
     return o2::framework::initGUI(windowTitle);

--- a/Framework/GUISupport/src/SpyService.h
+++ b/Framework/GUISupport/src/SpyService.h
@@ -14,6 +14,7 @@
 
 #include "Framework/ServiceHandle.h"
 #include "Framework/ServiceSpec.h"
+#include "Framework/ServiceRegistryRef.h"
 #include <mutex>
 #include <vector>
 #include <fairmq/FwdDecls.h>


### PR DESCRIPTION
Responsibility to access services is now moved to
the newly introduced ServiceRegistryRef. This will cache the information about the current stream / thread (and in the future the multiplexed DataProcessor) and it will eventually avoid concurrent access to the shared services.