### PR TITLE
Add possibility to exclude ITS inner barrel from geometry

### DIFF
--- a/Detectors/ITSMFT/ITS/base/include/ITSBase/GeometryTGeo.h
+++ b/Detectors/ITSMFT/ITS/base/include/ITSBase/GeometryTGeo.h
@@ -354,6 +354,7 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
   static constexpr int MAXLAYERS = 15; ///< max number of active layers
 
   Int_t mNumberOfLayers;                        ///< number of layers
+  Int_t mInnerLayerID;                          ///< identifier of inner layer (needed in case of inner barrel turned off)
   Int_t mNumberOfHalfBarrels;                   ///< number of halfbarrels
   std::vector<int> mNumberOfStaves;             ///< number of staves/layer(layer)
   std::vector<int> mNumberOfHalfStaves;         ///< the number of substaves/stave(layer)
@@ -385,7 +386,7 @@ class GeometryTGeo : public o2::itsmft::GeometryTGeo
   static std::unique_ptr<o2::its::GeometryTGeo> sInstance; ///< singletone instance
 #endif
 
-  ClassDefOverride(GeometryTGeo, 1); // ITS geometry based on TGeo
+  ClassDefOverride(GeometryTGeo, 2); // ITS geometry based on TGeo
 };
 } // namespace its
 } // namespace o2

--- a/Detectors/ITSMFT/ITS/base/src/GeometryTGeo.cxx
+++ b/Detectors/ITSMFT/ITS/base/src/GeometryTGeo.cxx
@@ -393,16 +393,16 @@ void GeometryTGeo::Build(int loadTrans)
     return;
   }
 
-  mNumberOfStaves.resize(mNumberOfLayers + mInnerLayerID);
-  mNumberOfHalfStaves.resize(mNumberOfLayers + mInnerLayerID);
-  mNumberOfModules.resize(mNumberOfLayers + mInnerLayerID);
-  mNumberOfChipsPerModule.resize(mNumberOfLayers + mInnerLayerID);
-  mNumberOfChipRowsPerModule.resize(mNumberOfLayers + mInnerLayerID);
-  mNumberOfChipsPerHalfStave.resize(mNumberOfLayers + mInnerLayerID);
-  mNumberOfChipsPerStave.resize(mNumberOfLayers + mInnerLayerID);
-  mNumberOfChipsPerHalfBarrel.resize(mNumberOfLayers + mInnerLayerID);
-  mNumberOfChipsPerLayer.resize(mNumberOfLayers + mInnerLayerID);
-  mLastChipIndex.resize(mNumberOfLayers + mInnerLayerID);
+  mNumberOfStaves.resize(sNumberLayers);
+  mNumberOfHalfStaves.resize(sNumberLayers);
+  mNumberOfModules.resize(sNumberLayers);
+  mNumberOfChipsPerModule.resize(sNumberLayers);
+  mNumberOfChipRowsPerModule.resize(sNumberLayers);
+  mNumberOfChipsPerHalfStave.resize(sNumberLayers);
+  mNumberOfChipsPerStave.resize(sNumberLayers);
+  mNumberOfChipsPerHalfBarrel.resize(sNumberLayers);
+  mNumberOfChipsPerLayer.resize(sNumberLayers);
+  mLastChipIndex.resize(sNumberLayers);
   int numberOfChips = 0;
 
   mNumberOfHalfBarrels = extractNumberOfHalfBarrels();

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
@@ -113,7 +113,7 @@ class Detector : public o2::base::DetImpl<Detector>
     return nullptr;
   }
 
-  void ExcludeInnerBarrel() {mExcludeInnerBarrel = true;}
+  void ExcludeInnerBarrel() { mExcludeInnerBarrel = true; }
 
  public:
   /// Has to be called after each event to reset the containers
@@ -269,7 +269,7 @@ class Detector : public o2::base::DetImpl<Detector>
   Int_t mNumberOfDetectors;
 
   Bool_t mModifyGeometry;
-  Bool_t mExcludeInnerBarrel;                          //! Flag to exclude inner barrel (for ITS3 studies)
+  Bool_t mExcludeInnerBarrel; //! Flag to exclude inner barrel (for ITS3 studies)
 
   Double_t mWrapperMinRadius[sNumberOfWrapperVolumes]; //! Min radius of wrapper volume
   Double_t mWrapperMaxRadius[sNumberOfWrapperVolumes]; //! Max radius of wrapper volume
@@ -330,7 +330,7 @@ class Detector : public o2::base::DetImpl<Detector>
 
   template <typename Det>
   friend class o2::base::DetImpl;
-  ClassDefOverride(Detector, 2);
+  ClassDefOverride(Detector, 1);
 };
 
 // Input and output function for standard C++ input/output.

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
@@ -113,6 +113,8 @@ class Detector : public o2::base::DetImpl<Detector>
     return nullptr;
   }
 
+  void ExcludeInnerBarrel() {mExcludeInnerBarrel = true;}
+
  public:
   /// Has to be called after each event to reset the containers
   void Reset() override;
@@ -267,6 +269,7 @@ class Detector : public o2::base::DetImpl<Detector>
   Int_t mNumberOfDetectors;
 
   Bool_t mModifyGeometry;
+  Bool_t mExcludeInnerBarrel;                          //! Flag to exclude inner barrel (for ITS3 studies)
 
   Double_t mWrapperMinRadius[sNumberOfWrapperVolumes]; //! Min radius of wrapper volume
   Double_t mWrapperMaxRadius[sNumberOfWrapperVolumes]; //! Max radius of wrapper volume
@@ -327,7 +330,7 @@ class Detector : public o2::base::DetImpl<Detector>
 
   template <typename Det>
   friend class o2::base::DetImpl;
-  ClassDefOverride(Detector, 1);
+  ClassDefOverride(Detector, 2);
 };
 
 // Input and output function for standard C++ input/output.


### PR DESCRIPTION
@mconcas this PR allows to exclude the inner barrel of the ITS from the geometry, needed for ITS3 studies.
To do that, a data member `mExcludeInnerBarrel` is added to the `Detector.cxx` class for the ITS. If set to false (default) nothing changes with respect to the previous code.