### PR TITLE
[QC-867] Mergers: use all 16 possible characters for the timer input

### DIFF
--- a/Utilities/Mergers/src/MergerBuilder.cxx
+++ b/Utilities/Mergers/src/MergerBuilder.cxx
@@ -96,7 +96,7 @@ framework::DataProcessorSpec MergerBuilder::buildSpec()
     merger.algorithm = framework::adaptFromTask<FullHistoryMerger>(mConfig, subSpec);
   }
 
-  merger.inputs.push_back({"timer-publish", "MRGR", mergerDataDescription("timer-" + mName), mergerSubSpec(mLayer, mId), framework::Lifetime::Timer});
+  merger.inputs.push_back({"timer-publish", "TMR", mergerDataDescription(mName), mergerSubSpec(mLayer, mId), framework::Lifetime::Timer});
   merger.options.push_back({"period-timer-publish", framework::VariantType::Int, static_cast<int>(mConfig.publicationDecision.param * 1000000), {"timer period"}});
   merger.labels.push_back(mergerLabel());
   merger.maxInputTimeslices = mTimePipeline;


### PR DESCRIPTION
This is to decrease the chance of having the same timer inputs for different Mergers, which is not well received by DPL (see O2-3210).