### PR TITLE
TRD add noise calibration

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/NoiseCalibration.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/NoiseCalibration.h
@@ -16,6 +16,7 @@
 #include <bitset>
 #include "DataFormatsTRD/Constants.h"
 #include "DataFormatsTRD/Tracklet64.h"
+#include "DataFormatsTRD/Digit.h"
 
 namespace o2
 {
@@ -52,11 +53,21 @@ class NoiseStatusMCM
   bool getIsNoisy(int mcmIdxGlb) const { return mNoiseFlag.test(mcmIdxGlb); }
   auto getNumberOfNoisyMCMs() const { return mNoiseFlag.count(); }
   bool isTrackletFromNoisyMCM(const Tracklet64& trklt) const { return getIsNoisy(trklt.getHCID(), trklt.getROB(), trklt.getMCM()); }
+  bool isDigitFromNoisyMCM(const Digit& d) const { return getIsNoisy(d.getHCId(), d.getROB(), d.getMCM()); }
 
  private:
   std::bitset<constants::MAXHALFCHAMBER * constants::NMCMHCMAX> mNoiseFlag{};
 
   ClassDefNV(NoiseStatusMCM, 1);
+};
+
+struct PadAdcInfo {
+  // Struct for holding the relevant ADC information
+  // This is what is send to the aggregator
+  void fill(const gsl::span<const PadAdcInfo> input) {}
+  void merge(const PadAdcInfo* prev) {}
+  void print() {}
+  ClassDefNV(PadAdcInfo, 1);
 };
 
 } // namespace trd

--- a/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
+++ b/DataFormats/Detectors/TRD/src/DataFormatsTRDLinkDef.h
@@ -31,6 +31,7 @@
 #pragma link C++ class o2::trd::KrCluster + ;
 #pragma link C++ class o2::trd::KrClusterTriggerRecord + ;
 #pragma link C++ class o2::trd::NoiseStatusMCM + ;
+#pragma link C++ class o2::trd::PadAdcInfo + ;
 #pragma link C++ class o2::trd::AngularResidHistos + ;
 #pragma link C++ class o2::trd::CalVdriftExB + ;
 #pragma link C++ class o2::trd::CalT0 + ;
@@ -45,6 +46,7 @@
 #pragma link C++ class std::vector < o2::trd::Hit > +;
 #pragma link C++ class std::vector < o2::trd::Digit> + ;
 #pragma link C++ class std::vector < o2::trd::AngularResidHistos> + ;
+#pragma link C++ class std::vector < o2::trd::PadAdcInfo> + ;
 #pragma link C++ class std::vector < o2::trd::KrCluster> + ;
 #pragma link C++ class std::vector < o2::trd::KrClusterTriggerRecord> + ;
 

--- a/Detectors/TRD/calibration/CMakeLists.txt
+++ b/Detectors/TRD/calibration/CMakeLists.txt
@@ -14,6 +14,7 @@ add_subdirectory(macros)
 o2_add_library(TRDCalibration
                SOURCES src/TrackBasedCalib.cxx
                        src/CalibratorVdExB.cxx
+                       src/CalibratorNoise.cxx
                        src/KrClusterFinder.cxx
                        src/DCSProcessor.cxx
                PUBLIC_LINK_LIBRARIES O2::TRDBase
@@ -28,6 +29,7 @@ o2_add_library(TRDCalibration
  o2_target_root_dictionary(TRDCalibration
                            HEADERS include/TRDCalibration/TrackBasedCalib.h
                                    include/TRDCalibration/CalibratorVdExB.h
+                                   include/TRDCalibration/CalibratorNoise.h
                                    include/TRDCalibration/KrClusterFinder.h
                                    include/TRDCalibration/DCSProcessor.h)
 

--- a/Detectors/TRD/calibration/README.md
+++ b/Detectors/TRD/calibration/README.md
@@ -15,13 +15,13 @@ The histograms are send to aggregator nodes which calculate for each TRD chamber
 
 To run the calibration one can start the following workflow:
 
-    o2-trd-global-tracking -b --disable-root-output --enable-trackbased-calib | o2-calibration-trd-vdrift-exb -b --calib-vdexb-calibration '--tf-per-slot 5 --min-entries 50000 --max-delay 90000'
+    o2-trd-global-tracking -b --disable-root-output --enable-trackbased-calib | o2-calibration-trd-workflow --vDriftAndExB -b --calib-vdexb-calibration '--tf-per-slot 5 --min-entries 50000 --max-delay 90000'
 
-*Hint: You can get information on the meaning of the parameters by running `o2-calibration-trd-vdrift-exb -b --help full`*
+*Hint: You can get information on the meaning of the parameters by running `o2-calibration-trd-workflow --vDriftAndExB -b --help full`*
 
 If you want to run the calibration from a local file with residuals, trdangreshistos.root, you can run:
 
-    o2-calibration-trd-vdrift-exb -b --enable-root-input --calib-vdexb-calibration '--tf-per-slot 1 --min-entries 50000'
+    o2-calibration-trd-workflow --vDriftAndExB -b --enable-root-input --calib-vdexb-calibration '--tf-per-slot 1 --min-entries 50000'
 
 Additionally it is possible to perform the calibrations fit manually per chamber if you have TPC-TRD or ITS-TPC-TRD tracks, you can run:
 
@@ -32,7 +32,7 @@ Then run the macro `Detectors/TRD/calibration/macros/manualCalibFit.C`.
 This produces a file of similar name with the fitted data and prints out the fit results.
 This is equivalent to running:
 
-    o2-calibration-trd-vdrift-exb -b --enable-root-input '--tf-per-slot 1 --min-entries 2000 --enable-root-output'
+    o2-calibration-trd-workflow --vDriftAndExB -b --enable-root-input '--tf-per-slot 1 --min-entries 2000 --enable-root-output'
 
 You can plot the calibration values for VDrift and ExB for a given Run by using the macro at `Detectors/TRD/cailbration/macros/plotVdriftExB.C`.
 This produces a root file of similar name which holds the time-series plots (reference the macro).

--- a/Detectors/TRD/calibration/include/TRDCalibration/CalibratorNoise.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/CalibratorNoise.h
@@ -1,0 +1,56 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file CalibratorNoise.h
+/// \brief TRD pad calibration
+
+#ifndef O2_TRD_CALIBRATORNOISE_H
+#define O2_TRD_CALIBRATORNOISE_H
+
+#include "DetectorsCalibration/TimeSlotCalibration.h"
+#include "DetectorsCalibration/TimeSlot.h"
+#include "TRDBase/PadCalibrationsAliases.h"
+#include "DataFormatsTRD/NoiseCalibration.h"
+#include "CCDB/CcdbObjectInfo.h"
+#include "Rtypes.h"
+
+namespace o2
+{
+namespace trd
+{
+
+class CalibratorNoise final : public o2::calibration::TimeSlotCalibration<PadAdcInfo, PadAdcInfo>
+{
+  using Slot = o2::calibration::TimeSlot<PadAdcInfo>;
+
+ public:
+  CalibratorNoise() = default;
+  ~CalibratorNoise() final = default;
+
+  // TODO implement these methods
+  bool hasEnoughData(const Slot& slot) const final { return false; }
+  void initOutput() final {}
+  void finalizeSlot(Slot& slot) final {}
+  Slot& emplaceNewSlot(bool front, TFType tStart, TFType tEnd) final;
+
+  const std::vector<PadNoise>& getCcdbObjectVector() const { return mObjectVector; }
+  std::vector<o2::ccdb::CcdbObjectInfo>& getCcdbObjectInfoVector() { return mInfoVector; }
+
+ private:
+  std::vector<o2::ccdb::CcdbObjectInfo> mInfoVector; ///< vector of CCDB infos; each element is filled with CCDB description of accompanying CCDB calibration object
+  std::vector<PadNoise> mObjectVector;               ///< vector of CCDB calibration objects; the extracted pad noise value for given slot
+  ClassDefOverride(CalibratorNoise, 1);
+};
+
+} // namespace trd
+} // namespace o2
+
+#endif // O2_TRD_CALIBRATORNOISE_H

--- a/Detectors/TRD/calibration/macros/checkNoisyMCMs.C
+++ b/Detectors/TRD/calibration/macros/checkNoisyMCMs.C
@@ -106,11 +106,12 @@ void checkNoisyMCMs(std::string inpFile = "trdtracklets.root", bool useMean = tr
   auto n = nTrkltsPerActiveMcm.size() / 2;
   auto median = nTrkltsPerActiveMcm[n]; // the distinction between odd/even number of entries in the vector is irrelevant
   mean90 /= nActiveMcms90;
-  auto noiseThreshold = (useMean) ? 100.f * mean90 : (float)totalTriggerCounter / 10.f;
+  auto noiseThreshold = (useMean) ? 30.f * mean90 : (float)totalTriggerCounter / 5.f;
 
   setlocale(LC_NUMERIC, "en_US.utf-8");
   printf("Info: Found in total %'lu MCMs which sent tracklets with a median of %i tracklets per MCM\n", nTrkltsPerActiveMcm.size(), median);
   printf("Info: Excluding the 10%% of MCMs which sent the highest number of tracklets %'i MCMs remain with on average %.2f tracklets per MCM\n", nActiveMcms90, mean90);
+  printf("Info: Checked %lu triggers in total\n", totalTriggerCounter);
   printf("Important: Masking MCMs which sent more than %.2f tracklets for given period\n", noiseThreshold);
 
   std::vector<int> nTrackletsFromNoisyMcm;

--- a/Detectors/TRD/calibration/src/CalibratorNoise.cxx
+++ b/Detectors/TRD/calibration/src/CalibratorNoise.cxx
@@ -9,12 +9,22 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifdef __CLING__
+/// \file CalibratorNoise.cxx
+/// \brief TRD pad calibration
 
-#pragma link off all globals;
-#pragma link off all classes;
-#pragma link off all functions;
+#include "TRDCalibration/CalibratorNoise.h"
 
-//#pragma link C++ class o2::trd::TRDDPLDigitizerTask + ;
-#pragma link C++ class gsl::span < uint32_t > +;
-#endif
+namespace o2::trd
+{
+
+using Slot = o2::calibration::TimeSlot<PadAdcInfo>;
+
+Slot& CalibratorNoise::emplaceNewSlot(bool front, TFType tStart, TFType tEnd)
+{
+  auto& container = getSlots();
+  auto& slot = front ? container.emplace_front(tStart, tEnd) : container.emplace_back(tStart, tEnd);
+  slot.setContainer(std::make_unique<PadAdcInfo>());
+  return slot;
+}
+
+} // namespace o2::trd

--- a/Detectors/TRD/calibration/src/TRDCalibrationLinkDef.h
+++ b/Detectors/TRD/calibration/src/TRDCalibrationLinkDef.h
@@ -18,6 +18,9 @@
 #pragma link C++ class o2::trd::CalibratorVdExB + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::trd::AngularResidHistos> + ;
 #pragma link C++ class o2::calibration::TimeSlotCalibration < o2::trd::AngularResidHistos, o2::trd::AngularResidHistos> + ;
+#pragma link C++ class o2::trd::CalibratorNoise + ;
+#pragma link C++ class o2::calibration::TimeSlot < o2::trd::PadAdcInfo> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::trd::PadAdcInfo, o2::trd::PadAdcInfo> + ;
 #pragma link C++ class o2::trd::TrackBasedCalib + ;
 #pragma link C++ class o2::trd::KrClusterFinder + ;
 #pragma link C++ class std::unordered_map < o2::dcs::DataPointIdentifier, o2::trd::TRDDCSMinMaxMeanInfo> + ;

--- a/Detectors/TRD/workflow/CMakeLists.txt
+++ b/Detectors/TRD/workflow/CMakeLists.txt
@@ -24,6 +24,8 @@ o2_add_library(TRDWorkflow
                        src/KrClustererSpec.cxx
                        include/TRDWorkflow/VdAndExBCalibSpec.h
                        include/TRDWorkflow/TRDGlobalTrackingQCSpec.h
+                       include/TRDWorkflow/NoiseCalibSpec.h
+                       include/TRDWorkflow/NoiseCalibAggregatorSpec.h
                PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::Steer O2::Algorithm O2::DataFormatsTRD O2::TRDSimulation O2::TRDReconstruction O2::TRDQC O2::DetectorsBase O2::SimulationDataFormat O2::TRDBase O2::TRDCalibration O2::GPUTracking O2::GlobalTrackingWorkflowHelpers O2::GlobalTrackingWorkflowReaders O2::GPUWorkflowHelper O2::ReconstructionDataFormats O2::ITSWorkflow O2::TPCWorkflow O2::TRDWorkflowIO)
 
 o2_add_executable(trap-sim
@@ -51,7 +53,7 @@ o2_add_executable(event-display-feed
                   SOURCES src/TRDEventDisplayFeedWorkflow.cxx
                   PUBLIC_LINK_LIBRARIES O2::TRDWorkflow)
 
-o2_add_executable(trd-vdrift-exb
+o2_add_executable(trd-workflow
                   COMPONENT_NAME calibration
                   SOURCES src/trd-calib-workflow.cxx
                   PUBLIC_LINK_LIBRARIES O2::Framework O2::TRDCalibration O2::TRDWorkflow O2::DetectorsCalibration)

--- a/Detectors/TRD/workflow/include/TRDWorkflow/NoiseCalibAggregatorSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/NoiseCalibAggregatorSpec.h
@@ -1,0 +1,102 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TRD_NOISECALIBAGGREGATORSPEC_H
+#define O2_TRD_NOISECALIBAGGREGATORSPEC_H
+
+/// \file   NoiseCalibAggregatorSpec.h
+/// \brief Create TRD noise map for CCDB from mean ADC values per pad
+
+#include "Framework/Task.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "Framework/WorkflowSpec.h"
+#include "TRDWorkflow/NoiseCalibSpec.h"
+#include "TRDCalibration/CalibratorNoise.h"
+#include "DataFormatsTRD/NoiseCalibration.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace trd
+{
+
+class TRDNoiseCalibAggregatorSpec : public o2::framework::Task
+{
+ public:
+  TRDNoiseCalibAggregatorSpec() = default;
+  void init(o2::framework::InitContext& ic) final
+  {
+    mCalibrator = std::make_unique<o2::trd::CalibratorNoise>();
+  }
+
+  void run(o2::framework::ProcessingContext& pc) final
+  {
+    auto data = pc.inputs().get<PadAdcInfo>("padadcs");
+    o2::base::TFIDInfoHelper::fillTFIDInfo(pc, mCalibrator->getCurrentTFInfo());
+    mCalibrator->process(data);
+    sendOutput(pc.outputs());
+  }
+
+  void endOfStream(o2::framework::EndOfStreamContext& ec) final
+  {
+    LOG(info) << "Finalizing calibration";
+    mCalibrator->checkSlotsToFinalize(o2::calibration::INFINITE_TF);
+    sendOutput(ec.outputs());
+  }
+
+ private:
+  std::unique_ptr<o2::trd::CalibratorNoise> mCalibrator;
+  //
+  void sendOutput(DataAllocator& output)
+  {
+    // extract CCDB infos and calibration objects, convert it to TMemFile and send them to the output
+    // TODO in principle, this routine is generic, can be moved to Utils.h
+
+    using clbUtils = o2::calibration::Utils;
+    const auto& payloadVec = mCalibrator->getCcdbObjectVector();
+    auto& infoVec = mCalibrator->getCcdbObjectInfoVector(); // use non-const version as we update it
+    assert(payloadVec.size() == infoVec.size());
+
+    for (uint32_t i = 0; i < payloadVec.size(); i++) {
+      auto& w = infoVec[i];
+      auto image = o2::ccdb::CcdbApi::createObjectImage(&payloadVec[i], &w);
+      LOG(info) << "Sending object " << w.getPath() << "/" << w.getFileName() << " of size " << image->size()
+                << " bytes, valid for " << w.getStartValidityTimestamp() << " : " << w.getEndValidityTimestamp();
+
+      output.snapshot(Output{clbUtils::gDataOriginCDBPayload, "PADSTATUS", i}, *image.get()); // vector<char>
+      output.snapshot(Output{clbUtils::gDataOriginCDBWrapper, "PADSTATUS", i}, w);            // root-serialized
+    }
+    if (payloadVec.size()) {
+      mCalibrator->initOutput(); // reset the outputs once they are already sent
+    }
+  }
+};
+
+o2::framework::DataProcessorSpec getTRDNoiseCalibAggregatorSpec()
+{
+  std::vector<OutputSpec> outputs;
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "PADSTATUS"}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "PADSTATUS"}, Lifetime::Sporadic);
+
+  return DataProcessorSpec{
+    "trd-noise-calib-aggregator",
+    Inputs{{"padadcs", o2::header::gDataOriginTRD, "PADADCS", 0, Lifetime::Timeframe}},
+    outputs,
+    AlgorithmSpec{adaptFromTask<TRDNoiseCalibAggregatorSpec>()},
+    Options{}};
+}
+
+} // namespace trd
+} // namespace o2
+
+#endif // O2_TRD_NOISECALIBAGGREGATORSPEC_H

--- a/Detectors/TRD/workflow/include/TRDWorkflow/NoiseCalibSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/NoiseCalibSpec.h
@@ -1,0 +1,77 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TRD_NOISECALIBSPEC_H
+#define O2_TRD_NOISECALIBSPEC_H
+
+/// \file   NoiseCalibSpec.h
+/// \brief Extract mean ADC values per pad from digits and send them to the aggregator
+
+#include "Framework/Task.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "Framework/WorkflowSpec.h"
+#include "DataFormatsTRD/NoiseCalibration.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace trd
+{
+
+class TRDNoiseCalibSpec : public o2::framework::Task
+{
+ public:
+  TRDNoiseCalibSpec() = default;
+  void init(o2::framework::InitContext& ic) final
+  {
+    // Do we need to initialize something?
+  }
+
+  void run(o2::framework::ProcessingContext& pc) final
+  {
+    auto digits = pc.inputs().get<gsl::span<Digit>>("trddigits");
+    auto trigRecs = pc.inputs().get<gsl::span<TriggerRecord>>("trdtriggerrec");
+
+    // TODO:
+    // Here we have the digits and trigger records available for a given time frame.
+    // We should extract the relevant information (ADC sum per pad and number of ADC values added for each pad)
+    // and store that in padAdcInfo which is then send to the aggregator were another device needs to be prepared
+    // which combines the information from all different EPNs and creates the CCDB object
+
+    PadAdcInfo padAdcInfo;
+
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "PADADCS", 0, Lifetime::Timeframe}, padAdcInfo);
+  }
+
+ private:
+  // Do we need any private members here, some settings for example?
+};
+
+o2::framework::DataProcessorSpec getTRDNoiseCalibSpec()
+{
+  std::vector<InputSpec> inputs;
+  inputs.emplace_back("trddigits", o2::header::gDataOriginTRD, "DIGITS", 0, Lifetime::Timeframe);
+  inputs.emplace_back("trdtriggerrec", o2::header::gDataOriginTRD, "TRKTRGRD", 0, Lifetime::Timeframe);
+
+  return DataProcessorSpec{
+    "trd-noise-calib",
+    inputs,
+    Outputs{{o2::header::gDataOriginTRD, "PADADCS", 0, Lifetime::Timeframe}},
+    AlgorithmSpec{adaptFromTask<TRDNoiseCalibSpec>()},
+    Options{}};
+}
+
+} // namespace trd
+} // namespace o2
+
+#endif // O2_TRD_NOISECALIBSPEC_H

--- a/prodtests/full-system-test/aggregator-workflow.sh
+++ b/prodtests/full-system-test/aggregator-workflow.sh
@@ -185,7 +185,7 @@ if [[ $AGGREGATOR_TASKS == BARREL_TF ]] || [[ $AGGREGATOR_TASKS == ALL ]]; then
   fi
   # TRD
   if [[ $CALIB_TRD_VDRIFTEXB == 1 ]]; then
-    add_W o2-calibration-trd-vdrift-exb ""
+    add_W o2-calibration-trd-workflow "--vDriftAndExB"
   fi
 fi
 


### PR DESCRIPTION
Barebone implementation for TRD pad noise and status information.
Added one device `NoiseCalibSpec` which should run on the EPNs and extract the relevant information per pad from the digits and one device `NoiseCalibAggregatorSpec` which should run on the aggregator (EPN calibration node) and create from the pad information the relevant CCDB objects.
 @Archita-Dash