### PR TITLE
[EMCAL-838] Load RecoParams from the CCDB in EMCAL reconstruction workflow

### DIFF
--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/RawToCellConverterSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/RawToCellConverterSpec.h
@@ -12,6 +12,7 @@
 #include <chrono>
 #include <vector>
 
+#include "Framework/ConcreteDataMatcher.h"
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
 #include "DataFormatsEMCAL/Cell.h"
@@ -41,6 +42,7 @@ class RawToCellConverterSpec : public framework::Task
   /// \brief Constructor
   /// \param subspecification Output subspecification for parallel running on multiple nodes
   /// \param hasDecodingErrors Option to swich on/off creating raw decoding error objects for later monitoring
+  /// \param loadRecoParamsFromCCDB Option to load the RecoParams from the CCDB
   RawToCellConverterSpec(int subspecification, bool hasDecodingErrors) : framework::Task(), mSubspecification(subspecification), mCreateRawDataErrors(hasDecodingErrors){};
 
   /// \brief Destructor
@@ -59,11 +61,19 @@ class RawToCellConverterSpec : public framework::Task
   /// Output cells trigger record: {"EMC", "CELLSTR", 0, Lifetime::Timeframe}
   void run(framework::ProcessingContext& ctx) final;
 
+  /// \brief Handle objects obtained from the CCDB
+  /// \param matcher Matcher providing the CCDB path of the object
+  /// \param obj CCDB object loaded by the CCDB interface
+  void finaliseCCDB(framework::ConcreteDataMatcher& matcher, void* obj) final;
+
   /// \brief Set max number of error messages printed
   /// \param maxMessages Max. amount of messages printed
   ///
   /// Error messages will be suppressed once the maximum is reached
-  void setMaxErrorMessages(int maxMessages) { mMaxErrorMessages = maxMessages; }
+  void setMaxErrorMessages(int maxMessages)
+  {
+    mMaxErrorMessages = maxMessages;
+  }
 
   void setNoiseThreshold(int thresold) { mNoiseThreshold = thresold; }
   int getNoiseThreshold() const { return mNoiseThreshold; }
@@ -134,9 +144,12 @@ class RawToCellConverterSpec : public framework::Task
 };
 
 /// \brief Creating DataProcessorSpec for the EMCAL Cell Converter Spec
+/// \param askDISTSTF Include input spec FLP/DISTSUBTIMEFRAME
+/// \param loadRecoParamsFromCCDB Obtain reco params from the CCDB
+/// \param subspecification Subspecification used in the output spec
 ///
 /// Refer to RawToCellConverterSpec::run for input and output specs
-framework::DataProcessorSpec getRawToCellConverterSpec(bool askDISTSTF, bool disableDecodingErrors, int subspecification);
+framework::DataProcessorSpec getRawToCellConverterSpec(bool askDISTSTF, bool disableDecodingError, int subspecification);
 
 } // namespace reco_workflow
 

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/RecoWorkflow.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/RecoWorkflow.h
@@ -51,6 +51,7 @@ enum struct OutputType { Digits,          ///< EMCAL digits
 /// \param subspecification Subspecification in case of running on different FLPs
 /// \param cfgInput Input objects processed in the workflow
 /// \param cfgOutput Output objects created in the workflow
+/// \param loadRecoParamsFromCCDB Load the reco params from the CCDB
 /// \return EMCAL reconstruction workflow for the configuration provided
 /// \ingroup EMCALwokflow
 framework::WorkflowSpec getWorkflow(bool propagateMC = true,

--- a/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
@@ -17,6 +17,7 @@
 
 #include "CommonConstants/Triggers.h"
 #include "CommonDataFormat/InteractionRecord.h"
+#include "Framework/CCDBParamSpec.h"
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/ControlService.h"
 #include "Framework/InputRecordWalker.h"
@@ -92,8 +93,6 @@ void RawToCellConverterSpec::init(framework::InitContext& ctx)
   mDisablePedestalEvaluation = ctx.options().get<bool>("no-evalpedestal");
 
   LOG(info) << "Running gain merging mode: " << (mMergeLGHG ? "yes" : "no");
-  LOG(info) << "Using time shift: " << RecoParam::Instance().getCellTimeShiftNanoSec() << " ns";
-  LOG(info) << "Using BCshfit phase:" << RecoParam::Instance().getPhaseBCmod4() << " BCs";
   LOG(info) << "Using L0LM delay: " << o2::ctp::TriggerOffsetsParam::Instance().LM_L0 << " BCs";
 
   mRawFitter->setAmpCut(mNoiseThreshold);
@@ -103,6 +102,9 @@ void RawToCellConverterSpec::init(framework::InitContext& ctx)
 void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
 {
   LOG(debug) << "[EMCALRawToCellConverter - run] called";
+  // for reading the reco param object from the ccdb
+  ctx.inputs().get<o2::emcal::RecoParam*>("EMC_RecoParam");
+
   double timeshift = RecoParam::Instance().getCellTimeShiftNanoSec(); // subtract offset in ns in order to center the time peak around the nominal delay
   constexpr auto originEMC = o2::header::gDataOriginEMC;
   constexpr auto descRaw = o2::header::gDataDescriptionRawData;
@@ -591,6 +593,16 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
   sendData(ctx, mOutputCells, mOutputTriggerRecords, mOutputDecoderErrors);
 }
 
+void RawToCellConverterSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+{
+  // check if calib params need to be updated
+  if (matcher == framework::ConcreteDataMatcher("EMC", "EMCALRECOPARAM", 0)) {
+    LOG(info) << "RecoParams updated";
+    o2::emcal::RecoParam::Instance().printKeyValues(true, true);
+    return;
+  }
+}
+
 bool RawToCellConverterSpec::isLostTimeframe(framework::ProcessingContext& ctx) const
 {
   constexpr auto originEMC = header::gDataOriginEMC;
@@ -642,6 +654,8 @@ o2::framework::DataProcessorSpec o2::emcal::reco_workflow::getRawToCellConverter
   if (askDISTSTF) {
     inputs.emplace_back("stdDist", "FLP", "DISTSUBTIMEFRAME", 0, o2::framework::Lifetime::Timeframe);
   }
+  // CCDB objects
+  inputs.emplace_back("EMC_RecoParam", o2::header::gDataOriginEMC, "EMCALRECOPARAM", 0, o2::framework::Lifetime::Condition, o2::framework::ccdbParamSpec("EMC/Config/RecoParam"));
 
   return o2::framework::DataProcessorSpec{"EMCALRawToCellConverterSpec",
                                           inputs,


### PR DESCRIPTION
- RecoParams are by default loaded from the CCDB
- Option to disable loading from CCDB available in
  RawToCellConverterSpec (will take the default
  parameters in the constructor)