### PR TITLE
[EMCAL-791] Adapting the SimParam to be a CCDB object

### DIFF
--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/SimParam.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/SimParam.h
@@ -45,6 +45,7 @@ class SimParam : public o2::conf::ConfigurableParamHelper<SimParam>
   Float_t getTimeResponseTau() const { return mTimeResponseTau; }
   Float_t getTimeResponsePower() const { return mTimeResponsePower; }
   Float_t getTimeResponseThreshold() const { return mTimeResponseThreshold; }
+  Int_t getBCPhaseSwap() const { return mSwapPhase; }
 
   // Parameters used in SDigitizer
   Float_t getA() const { return mA; }
@@ -67,7 +68,6 @@ class SimParam : public o2::conf::ConfigurableParamHelper<SimParam>
 
   void PrintStream(std::ostream& stream) const;
 
- private:
   // Digitizer
   Int_t mDigitThreshold{3};              ///< Threshold for storing digits in EMC
   Int_t mMeanPhotonElectron{4400};       ///< number of photon electrons per GeV deposited energy
@@ -83,6 +83,7 @@ class SimParam : public o2::conf::ConfigurableParamHelper<SimParam>
   Float_t mTimeResponseTau{2.35};        ///< Raw time response function tau parameter
   Float_t mTimeResponsePower{2};         ///< Raw time response function power parameter
   Float_t mTimeResponseThreshold{0.001}; ///< Raw time response function energy threshold
+  Int_t mSwapPhase{0};                   ///< BC phase swap similar to data
 
   // SDigitizer
   Float_t mA{0.};                 ///< Pedestal parameter
@@ -112,6 +113,16 @@ class SimParam : public o2::conf::ConfigurableParamHelper<SimParam>
 std::ostream& operator<<(std::ostream& stream, const SimParam& s);
 
 } // namespace emcal
+
+namespace framework
+{
+template <typename T>
+struct is_messageable;
+template <>
+struct is_messageable<o2::emcal::SimParam> : std::true_type {
+};
+} // namespace framework
+
 } // namespace o2
 
 #endif

--- a/Detectors/EMCAL/simulation/src/EMCALSimulationLinkDef.h
+++ b/Detectors/EMCAL/simulation/src/EMCALSimulationLinkDef.h
@@ -22,6 +22,7 @@
 #pragma link C++ class o2::emcal::DigitsWriteoutBuffer + ;
 #pragma link C++ class o2::emcal::DigitsVectorStream + ;
 #pragma link C++ class o2::emcal::SimParam + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::emcal::SimParam> + ;
 #pragma link C++ class o2::emcal::LabeledDigit + ;
 #pragma link C++ class o2::emcal::RawWriter + ;
 

--- a/Detectors/EMCAL/simulation/src/SimParam.cxx
+++ b/Detectors/EMCAL/simulation/src/SimParam.cxx
@@ -17,7 +17,7 @@ O2ParamImpl(o2::emcal::SimParam);
 
 using namespace o2::emcal;
 
-std::ostream& operator<<(std::ostream& stream, const o2::emcal::SimParam& s)
+std::ostream& o2::emcal::operator<<(std::ostream& stream, const o2::emcal::SimParam& s)
 {
   s.PrintStream(stream);
   return stream;
@@ -39,6 +39,7 @@ void SimParam::PrintStream(std::ostream& stream) const
   stream << "\nEMCal::SimParam.mTimeResponsePower = " << mTimeResponsePower;
   stream << "\nEMCal::SimParam.mTimeResponseThreshold = " << mTimeResponseThreshold;
   stream << "\nEMCal::SimParam.mNADCEC = " << mNADCEC;
+  stream << "\nEMCal::SimParam.mSwapPhase = " << mSwapPhase;
   stream << "\nEMCal::SimParam.mA = " << mA;
   stream << "\nEMCal::SimParam.mB = " << mB;
   stream << "\nEMCal::SimParam.mECPrimThreshold = " << mECPrimThreshold;


### PR DESCRIPTION
The EMCAL SimParam has been adapted to work as a CCDB object, so we can store some MC configuration in the CCDB and load them when needed.