### PR TITLE
Restore default MFT linear track finder radius

### DIFF
--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/MFTTrackingParam.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/MFTTrackingParam.h
@@ -49,7 +49,7 @@ struct MFTTrackingParam : public o2::conf::ConfigurableParamHelper<MFTTrackingPa
   /// minimum number of detector stations for a CA track
   Int_t MinTrackStationsCA = 4;
   /// maximum distance for a cluster to be attached to a seed line (LTF)
-  Float_t LTFclsRCut = 0.200; // Temporary for misaligned detector. Default 0.0100
+  Float_t LTFclsRCut = 0.0100;
   /// maximum distance for a cluster to be attached to a seed line (CA road)
   Float_t ROADclsRCut = 0.0400;
   /// number of bins in r-direction


### PR DESCRIPTION
At high IR the relaxed track-finding conditions leads to substantial increase in fake track-vertex associations