### PR TITLE
Interface for integrating run-wide timeslots over many runs

### DIFF
--- a/Detectors/Calibration/CMakeLists.txt
+++ b/Detectors/Calibration/CMakeLists.txt
@@ -30,6 +30,7 @@ o2_add_library(DetectorsCalibration
 o2_target_root_dictionary(DetectorsCalibration
                           HEADERS include/DetectorsCalibration/TimeSlotCalibration.h
                                   include/DetectorsCalibration/TimeSlot.h
+                                  include/DetectorsCalibration/TimeSlotMetaData.h
                                   include/DetectorsCalibration/Utils.h
                                   include/DetectorsCalibration/MeanVertexData.h
                                   include/DetectorsCalibration/MeanVertexCalibrator.h

--- a/Detectors/Calibration/include/DetectorsCalibration/TimeSlotMetaData.h
+++ b/Detectors/Calibration/include/DetectorsCalibration/TimeSlotMetaData.h
@@ -1,0 +1,35 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef DETECTOR_CALIB_TIMESLOTMETADATA_H_
+#define DETECTOR_CALIB_TIMESLOTMETADATA_H_
+
+/// @brief meta-data for the saved content of the timeslot
+
+namespace o2
+{
+namespace calibration
+{
+struct TimeSlotMetaData {
+  using TFType = uint32_t;
+
+  int startRun = -1;
+  int endRun = -1;
+  long startTime = -1;
+  long endTime = -1;
+
+  ClassDefNV(TimeSlotMetaData, 1);
+};
+
+} // namespace calibration
+} // namespace o2
+
+#endif

--- a/Detectors/Calibration/src/DetectorsCalibrationLinkDef.h
+++ b/Detectors/Calibration/src/DetectorsCalibrationLinkDef.h
@@ -16,6 +16,7 @@
 #pragma link off all functions;
 
 #pragma link C++ class o2::calibration::MeanVertexData + ;
+#pragma link C++ class o2::calibration::TimeSlotMetaData + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::calibration::MeanVertexData> + ;
 #pragma link C++ class o2::calibration::TimeSlotCalibration < o2::dataformats::PrimaryVertex, o2::calibration::MeanVertexData> + ;
 #pragma link C++ class o2::calibration::MeanVertexCalibrator + ;


### PR DESCRIPTION
Some statistics-hungry calibrations define single time-slot which integrates data of the whole run. If there is a possibility that for the short run the slot will not accumulate enough statistics,
one can save the user-defined content of the slot to a file in the dedicated partition on the calibrator node
and adopt data from this file in the next run. In order to do that the calibrator class derived from the TimeSlotCalibration must:

* set fixed file name to write via `setSaveFileName(const std::string& n)` method. Also, the corresponding workflow should provide/parse an option to set the output directory.

* implement virtual method `bool saveLastSlotData(TFile& fl)` which writes content of the (last and only) slot into the provided file handler. It is up to detector to define the format of the stored data. The framework will write to the same file a
TimeSlotMetaData struct describing the start/end timestamps and start/end runs for the data written.

* implement virtual method `bool adoptSavedData(const TimeSlotMetaData& metadata, TFile& fl)` which reads and adds saved data to the slot in the new run. Provided metadata should be used to judge if the saved data are useful.

* decide e.g. in the finalizeSlot method if the slot content must be saved to be accounted in the following run and call `saveLastSlot()` in that case.

* in the beginning of the processing, e.g. after the 1st call of the `process(..)` method (where the time-slot will be created) call `loadSavedSlot()` method, i.e.
  ```
  auto data = pc.inputs().get<...>; // get input data
  o2::base::TFIDInfoHelper::fillTFIDInfo(pc, mCalibrator->getCurrentTFInfo());
  mCalibrator->process(data);
  static bool firstCall = true;
  if (firstCall && getNSlots()) {
    firstCall = false;
    loadSavedSlot();
  }
  ```
  Make sure the static method `o2::base::TFIDInfoHelper::fillTFIDInfo(pc, mCalibrator->getCurrentTFInfo());` was called from the `run()` method before the `process(...)` call.

The slot saving and loading will be done only if `setSavedSlotAllowed(true)` was called explicitly from the calibrator device before the processing starts (e.g. in the `init()` method).
Since one can have multiple instances of the calibrator device
running at the same time (in staging and produnction partitions, synthetic and real runs) it is important to make sure that this method is called only for the physics run calibration.

In order to not pollute calibration node disk, the file will be removed in the end of `loadSavedSlot()` call.
