### PR TITLE
[EMCAL-839]  Integration CCDB objects in the digitizer

### DIFF
--- a/Detectors/EMCAL/simulation/include/EMCALSimulation/DigitsWriteoutBuffer.h
+++ b/Detectors/EMCAL/simulation/include/EMCALSimulation/DigitsWriteoutBuffer.h
@@ -102,6 +102,7 @@ class DigitsWriteoutBuffer
   unsigned long mTriggerTime = 0;                         ///< Time of the collision that fired the trigger (ns)
   unsigned long mLastEventTime = 0;                       ///< The event time of last collisions in the readout window
   unsigned int mPhase = 0;                                ///< The event L1 phase
+  unsigned int mSwapPhase = 0;                            ///< BC phase swap
   bool mFirstEvent = true;                                ///< Flag to the first event in the run
   std::deque<o2::emcal::DigitTimebin> mTimedDigitsFuture; ///< Container for time sampled digits per tower ID for future digits
   std::deque<o2::emcal::DigitTimebin> mTimedDigitsPast;   ///< Container for time sampled digits per tower ID for past digits

--- a/Detectors/EMCAL/simulation/src/DigitsWriteoutBuffer.cxx
+++ b/Detectors/EMCAL/simulation/src/DigitsWriteoutBuffer.cxx
@@ -36,7 +36,7 @@ void DigitsWriteoutBuffer::init()
   mLiveTime = simParam->getLiveTime();
   mBusyTime = simParam->getBusyTime();
   mPreTriggerTime = simParam->getPreTriggerTime();
-
+  mSwapPhase = simParam->getBCPhaseSwap();
   mDigitStream.init();
 }
 
@@ -156,7 +156,9 @@ void DigitsWriteoutBuffer::forwardMarker(o2::InteractionTimeRecord record)
   }
 
   mLastEventTime = eventTime;
-  mPhase = ((int)(std::fmod(mLastEventTime, 100) / 25));
+  // mPhase = ((int)(std::fmod(mLastEventTime, 100) / 25));
+  mPhase = (record.bc + mSwapPhase) % 4;
+
   if (mFirstEvent) {
     mFirstEvent = false;
   }

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/CellConverterSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/CellConverterSpec.h
@@ -46,7 +46,7 @@ class CellConverterSpec : public framework::Task
  public:
   /// \brief Constructor
   /// \param propagateMC If true the MCTruthContainer is propagated to the output
-  CellConverterSpec(bool propagateMC) : framework::Task(), mPropagateMC(propagateMC){};
+  CellConverterSpec(bool propagateMC, bool useccdb) : framework::Task(), mPropagateMC(propagateMC), mLoadRecoParamFromCCDB(useccdb){};
 
   /// \brief Destructor
   ~CellConverterSpec() override = default;
@@ -73,6 +73,8 @@ class CellConverterSpec : public framework::Task
   /// Output MC-truth: {"EMC", "CELLSMCTR", 0, Lifetime::Timeframe}
   void run(framework::ProcessingContext& ctx) final;
 
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
+
  protected:
   std::vector<o2::emcal::SRUBunchContainer> digitsToBunches(gsl::span<const o2::emcal::Digit> digits, std::vector<gsl::span<const o2::emcal::MCLabel>>& mcLabels);
 
@@ -84,6 +86,7 @@ class CellConverterSpec : public framework::Task
 
  private:
   bool mPropagateMC = false;                                           ///< Switch whether to process MC true labels
+  bool mLoadRecoParamFromCCDB = false;                                 ///< Flag to load the the SimParams from CCDB
   o2::emcal::Geometry* mGeometry = nullptr;                            ///!<! Geometry pointer
   std::unique_ptr<o2::emcal::CaloRawFitter> mRawFitter;                ///!<! Raw fitter
   std::vector<o2::emcal::Cell> mOutputCells;                           ///< Container with output cells
@@ -96,7 +99,7 @@ class CellConverterSpec : public framework::Task
 /// \param propagateMC If true the MC truth container is propagated to the output
 ///
 /// Refer to CellConverterSpec::run for input and output specs
-framework::DataProcessorSpec getCellConverterSpec(bool propagateMC);
+framework::DataProcessorSpec getCellConverterSpec(bool propagateMC, bool useccdb = false);
 
 } // namespace reco_workflow
 

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/EMCALDigitizerSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/EMCALDigitizerSpec.h
@@ -62,7 +62,7 @@ class DigitizerSpec final : public o2::base::BaseDPLDigitizer, public o2::framew
   /// - Open readout window when the event sets a trigger
   /// - Accumulate digits sampled via the time response from different bunch crossings
   /// - Retrieve digits when the readout window closes
-  void run(framework::ProcessingContext& ctx);
+  void run(framework::ProcessingContext& ctx) override;
 
  private:
   Bool_t mFinished = false;             ///< Flag for digitization finished

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/EMCALDigitizerSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/EMCALDigitizerSpec.h
@@ -37,11 +37,12 @@ namespace emcal
 /// \author Anders Garritt Knospe <anders.knospe@cern.ch>, University of Houston
 /// \author Markus Fasel <markus.fasel@cern.ch> Oak Ridge National laboratory
 /// \since Nov 12, 2018
-class DigitizerSpec final : public o2::base::BaseDPLDigitizer
+class DigitizerSpec final : public o2::base::BaseDPLDigitizer, public o2::framework::Task
 {
  public:
+  using o2::base::BaseDPLDigitizer::init;
   /// \brief Constructor
-  DigitizerSpec() : o2::base::BaseDPLDigitizer(o2::base::InitServices::GEOM) {}
+  DigitizerSpec(bool useccdb) : o2::base::BaseDPLDigitizer(o2::base::InitServices::GEOM), o2::framework::Task(), mLoadSimParamFromCCDB(useccdb) {}
 
   /// \brief Destructor
   ~DigitizerSpec() final = default;
@@ -49,6 +50,10 @@ class DigitizerSpec final : public o2::base::BaseDPLDigitizer
   /// \brief init digitizer
   /// \param ctx Init context
   void initDigitizerTask(framework::InitContext& ctx) final;
+
+  void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final;
+
+  void configure();
 
   /// \brief run digitizer
   /// \param ctx Processing context
@@ -60,16 +65,18 @@ class DigitizerSpec final : public o2::base::BaseDPLDigitizer
   void run(framework::ProcessingContext& ctx);
 
  private:
-  Bool_t mFinished = false;            ///< Flag for digitization finished
-  Digitizer mDigitizer;                ///< Digitizer object
-  o2::emcal::SDigitizer mSumDigitizer; ///< Summed digitizer
-  std::vector<Hit> mHits;              ///< Vector with input hits
+  Bool_t mFinished = false;             ///< Flag for digitization finished
+  Bool_t mLoadSimParamFromCCDB = false; ///< Flag to load the the SimParams from CCDB
+  bool mIsConfigured = false;           ///< Initialization status of the digitizer
+  Digitizer mDigitizer;                 ///< Digitizer object
+  o2::emcal::SDigitizer mSumDigitizer;  ///< Summed digitizer
+  std::vector<Hit> mHits;               ///< Vector with input hits
   std::vector<TChain*> mSimChains;
 };
 
 /// \brief Create new digitizer spec
 /// \return Digitizer spec
-o2::framework::DataProcessorSpec getEMCALDigitizerSpec(int channel, bool mctruth = true);
+o2::framework::DataProcessorSpec getEMCALDigitizerSpec(int channel, bool mctruth = true, bool useccdb = true);
 
 } // end namespace emcal
 } // end namespace o2

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/RecoWorkflow.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/RecoWorkflow.h
@@ -62,7 +62,8 @@ framework::WorkflowSpec getWorkflow(bool propagateMC = true,
                                     std::string const& cfgOutput = "clusters",
                                     bool disableRootInput = false,
                                     bool disableRootOutput = false,
-                                    bool disableDecodingErrors = false);
+                                    bool disableDecodingErrors = false,
+                                    bool useccdb = false);
 } // namespace reco_workflow
 
 } // namespace emcal

--- a/Detectors/EMCAL/workflow/src/CellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/CellConverterSpec.cxx
@@ -14,6 +14,7 @@
 
 #include "DataFormatsEMCAL/Digit.h"
 #include "EMCALWorkflow/CellConverterSpec.h"
+#include "Framework/CCDBParamSpec.h"
 #include "Framework/ControlService.h"
 #include "Framework/ConfigParamRegistry.h"
 #include "DataFormatsEMCAL/MCLabel.h"
@@ -46,13 +47,19 @@ void CellConverterSpec::init(framework::InitContext& ctx)
   }
   mRawFitter->setAmpCut(0.);
   mRawFitter->setL1Phase(0.);
-  LOG(info) << "Using time shift: " << RecoParam::Instance().getCellTimeShiftNanoSec() << " ns";
 }
 
 void CellConverterSpec::run(framework::ProcessingContext& ctx)
 {
   LOG(debug) << "[EMCALCellConverter - run] called";
+
+  if (mLoadRecoParamFromCCDB) {
+    // for reading the reco params from the ccdb
+    ctx.inputs().get<o2::emcal::RecoParam*>("EMC_RecoParam");
+  }
+
   double timeshift = RecoParam::Instance().getCellTimeShiftNanoSec(); // subtract offset in ns in order to center the time peak around the nominal delay
+  timeshift = int(timeshift / 100) * 100;                             // This is a cheat to make the time multiple of 100, since the digitizer takes the delay only as mutiple of 100
 
   mOutputCells.clear();
   mOutputLabels.clear();
@@ -71,6 +78,8 @@ void CellConverterSpec::run(framework::ProcessingContext& ctx)
       mOutputTriggers.emplace_back(trg.getBCData(), trg.getTriggerBits(), currentstart, ncellsTrigger);
       continue;
     }
+
+    int bcmod4 = (trg.getBCData().bc + RecoParam::Instance().getPhaseBCmod4()) % 4;
 
     gsl::span<const o2::emcal::Digit> digits(digitsAll.data() + trg.getFirstEntry(), trg.getNumberOfObjects());
     std::vector<gsl::span<const o2::emcal::MCLabel>> mcLabels;
@@ -110,7 +119,7 @@ void CellConverterSpec::run(framework::ProcessingContext& ctx)
           if (fitResults.getTime() < 0) {
             fitResults.setTime(0.);
           }
-          mOutputCells.emplace_back(tower, fitResults.getAmp() * o2::emcal::constants::EMCAL_ADCENERGY, fitResults.getTime() - timeshift, channelType);
+          mOutputCells.emplace_back(tower, fitResults.getAmp() * o2::emcal::constants::EMCAL_ADCENERGY, fitResults.getTime() - timeshift - 25 * bcmod4, channelType);
 
           if (mPropagateMC) {
             Int_t LabelIndex = mOutputLabels.getIndexedSize();
@@ -432,11 +441,22 @@ int CellConverterSpec::selectMaximumBunch(const gsl::span<const Bunch>& bunchvec
   return bunchindex;
 }
 
-o2::framework::DataProcessorSpec o2::emcal::reco_workflow::getCellConverterSpec(bool propagateMC)
+void CellConverterSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
+{
+  if (matcher == o2::framework::ConcreteDataMatcher("EMC", "RecoParam", 0)) {
+    LOG(info) << "EMCal RecoParam updated";
+    return;
+  }
+}
+
+o2::framework::DataProcessorSpec o2::emcal::reco_workflow::getCellConverterSpec(bool propagateMC, bool useccdb)
 {
   std::vector<o2::framework::InputSpec> inputs;
   std::vector<o2::framework::OutputSpec> outputs;
   inputs.emplace_back("digits", o2::header::gDataOriginEMC, "DIGITS", 0, o2::framework::Lifetime::Timeframe);
+  if (useccdb) {
+    inputs.emplace_back("EMC_RecoParam", o2::header::gDataOriginEMC, "RECOPARAM", 0, o2::framework::Lifetime::Condition, o2::framework::ccdbParamSpec("EMC/Config/RecoParam"));
+  }
   inputs.emplace_back("triggers", "EMC", "DIGITSTRGR", 0, o2::framework::Lifetime::Timeframe);
   outputs.emplace_back("EMC", "CELLS", 0, o2::framework::Lifetime::Timeframe);
   outputs.emplace_back("EMC", "CELLSTRGR", 0, o2::framework::Lifetime::Timeframe);
@@ -447,7 +467,7 @@ o2::framework::DataProcessorSpec o2::emcal::reco_workflow::getCellConverterSpec(
   return o2::framework::DataProcessorSpec{"EMCALCellConverterSpec",
                                           inputs,
                                           outputs,
-                                          o2::framework::adaptFromTask<o2::emcal::reco_workflow::CellConverterSpec>(propagateMC),
+                                          o2::framework::adaptFromTask<o2::emcal::reco_workflow::CellConverterSpec>(propagateMC, useccdb),
                                           o2::framework::Options{
                                             {"fitmethod", o2::framework::VariantType::String, "gamma2", {"Fit method (standard or gamma2)"}}}};
 }

--- a/Detectors/EMCAL/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/EMCAL/workflow/src/RecoWorkflow.cxx
@@ -52,7 +52,8 @@ o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
                                         std::string const& cfgOutput,
                                         bool disableRootInput,
                                         bool disableRootOutput,
-                                        bool disableDecodingErrors)
+                                        bool disableDecodingErrors,
+                                        bool useccdb)
 {
 
   const std::unordered_map<std::string, InputType> InputMap{
@@ -169,7 +170,7 @@ o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
   if (isEnabled(OutputType::Cells)) {
     // add converter for cells
     if (inputType == InputType::Digits) {
-      specs.emplace_back(o2::emcal::reco_workflow::getCellConverterSpec(propagateMC));
+      specs.emplace_back(o2::emcal::reco_workflow::getCellConverterSpec(propagateMC, useccdb));
     } else if (inputType == InputType::Raw) {
       // raw data will come from upstream
       specs.emplace_back(o2::emcal::reco_workflow::getRawToCellConverterSpec(askDISTSTF, disableDecodingErrors, subspecification));

--- a/Detectors/EMCAL/workflow/src/emc-reco-workflow.cxx
+++ b/Detectors/EMCAL/workflow/src/emc-reco-workflow.cxx
@@ -54,6 +54,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"disable-mc", o2::framework::VariantType::Bool, false, {"disable sending of MC information"}},
     {"disable-decoding-errors", o2::framework::VariantType::Bool, false, {"disable propagating decoding errors"}},
     {"ignore-dist-stf", o2::framework::VariantType::Bool, false, {"do not subscribe to FLP/DISTSUBTIMEFRAME/0 message (no lost TF recovery)"}},
+    {"use-ccdb", o2::framework::VariantType::Bool, false, {"enable access to ccdb EMCAL simulation objects"}},
     {"subspecification", o2::framework::VariantType::Int, 0, {"Subspecification in case the workflow runs in parallel on multiple nodes (i.e. different FLPs)"}}};
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
   std::swap(workflowOptions, options);
@@ -84,7 +85,8 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
                                                   cfgc.options().get<std::string>("output-type"),
                                                   cfgc.options().get<bool>("disable-root-input"),
                                                   cfgc.options().get<bool>("disable-root-output"),
-                                                  cfgc.options().get<bool>("disable-decoding-errors"));
+                                                  cfgc.options().get<bool>("disable-decoding-errors"),
+                                                  cfgc.options().get<bool>("use-ccdb"));
 
   // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit
   o2::raw::HBFUtilsInitializer hbfIni(cfgc, wf);

--- a/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
+++ b/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
@@ -79,7 +79,7 @@
 #include "TRDWorkflow/TRDTrapSimulatorSpec.h"
 #include "TRDWorkflowIO/TRDTrackletWriterSpec.h"
 
-//for MUON MCH
+// for MUON MCH
 #include "MCHDigitizerSpec.h"
 #include "MCHDigitWriterSpec.h"
 
@@ -191,6 +191,9 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 
   // option to use/not use CCDB for FT0
   workflowOptions.push_back(ConfigParamSpec{"use-ccdb-ft0", o2::framework::VariantType::Bool, true, {"enable access to ccdb ft0 calibration objects"}});
+
+  // option to use/not use CCDB for EMCAL
+  workflowOptions.push_back(ConfigParamSpec{"use-ccdb-emc", o2::framework::VariantType::Bool, false, {"enable access to ccdb EMCAL simulation objects"}});
 
   // option to use or not use the Trap Simulator after digitisation (debate of digitization or reconstruction is for others)
   workflowOptions.push_back(ConfigParamSpec{"disable-trd-trapsim", VariantType::Bool, false, {"disable the trap simulation of the TRD"}});
@@ -645,9 +648,10 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 
   // the EMCal part
   if (isEnabled(o2::detectors::DetID::EMC)) {
+    auto useCCDB = configcontext.options().get<bool>("use-ccdb-emc");
     detList.emplace_back(o2::detectors::DetID::EMC);
     // connect the EMCal digitization
-    digitizerSpecs.emplace_back(o2::emcal::getEMCALDigitizerSpec(fanoutsize++, mctruth));
+    digitizerSpecs.emplace_back(o2::emcal::getEMCALDigitizerSpec(fanoutsize++, mctruth, useCCDB));
     // connect the EMCal digit writer
     writerSpecs.emplace_back(o2::emcal::getEMCALDigitWriterSpec(mctruth));
   }
@@ -690,12 +694,12 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     }
   }
 
-  //add MUON MCH
+  // add MUON MCH
   if (isEnabled(o2::detectors::DetID::MCH)) {
     detList.emplace_back(o2::detectors::DetID::MCH);
-    //connect the MUON MCH digitization
+    // connect the MUON MCH digitization
     digitizerSpecs.emplace_back(o2::mch::getMCHDigitizerSpec(fanoutsize++, mctruth));
-    //connect the MUON MCH digit writer
+    // connect the MUON MCH digit writer
     writerSpecs.emplace_back(o2::mch::getMCHDigitWriterSpec(mctruth));
   }
 


### PR DESCRIPTION
Many things were implemented here:
1. The BC phase is now calculated from the trigger record bc instead of the event time.
2. Added the BC phase swap as in data.
3. The DigitizerSpec has been adapted to load CCDB objects (SimParam)
4. The CellConverterSpec has also been adapted to load the RecoParam as a CCDB objects
5. Added a function in run() that loads only once in order to initialize the digitizer after the SimParam are loaded from the CCDB.