### PR TITLE
[EMCAL-630] Send mapping errors to DecoderErrorContainer

### DIFF
--- a/Detectors/EMCAL/base/include/EMCALBase/Mapper.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/Mapper.h
@@ -88,8 +88,11 @@ class Mapper
     /// \param address Hardware address raising the exception
     AddressNotFoundException(int address) : exception(),
                                             mAddress(address),
-                                            mMessage("Hardware address " + std::to_string(address) + " not found")
+                                            mMessage()
     {
+      std::stringstream msgbuilder;
+      msgbuilder << "Hardware address " << address << "(0x" << std::hex << address << std::dec << ") not found";
+      mMessage = msgbuilder.str();
     }
 
     /// \brief Destructor

--- a/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
@@ -334,6 +334,8 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
             iCol = map.getColumn(chan.getHardwareAddress());
             chantype = map.getChannelType(chan.getHardwareAddress());
           } catch (Mapper::AddressNotFoundException& ex) {
+            ErrorTypeFEE mappingError{feeID, ErrorTypeFEE::ErrorSource_t::ALTRO_ERROR, AltroDecoderError::errorTypeToInt(AltroDecoderError::ErrorType_t::ALTRO_MAPPING_ERROR), -1, chan.getHardwareAddress()};
+            mOutputDecoderErrors.push_back(mappingError);
             if (mNumErrorMessages < mMaxErrorMessages) {
               LOG(warning) << "Mapping error DDL " << feeID << ": " << ex.what();
               mNumErrorMessages++;


### PR DESCRIPTION
Mapping errors were missing in the decoder error container,
treated with existing error code for decoder error in
major ALTRO decoding error. As additional information the
hardware address raising the errror is sent, FEC ID
cannot be determined as the HW address is invalid.

In addition log hardware address as hex value in error
message of AddressNotFoundException