### PR TITLE
TOFbase: Avoid global static initialization of TF1

### DIFF
--- a/Detectors/TOF/base/include/TOFBase/Utils.h
+++ b/Detectors/TOF/base/include/TOFBase/Utils.h
@@ -88,7 +88,6 @@ class Utils
   static int mMaskBCchan[o2::tof::Geo::NCHANNELS][16];
   static int mMaskBCchanUsed[o2::tof::Geo::NCHANNELS][16];
 
-  static TF1* mFitFunc;
   static TChain* mTreeFit;
   static std::vector<dataformats::CalibInfoTOF> mVectC;
   static std::vector<dataformats::CalibInfoTOF>* mPvectC;


### PR DESCRIPTION
Fixing a problem observed in ROOT interactive mode, when initialing objects that link (indirectly) to TOFBase:

```
> root[0] tof::base::Digit d;
> Error in <TClingCallFunc::make_wrapper>: Failed to compile
>   ==== SOURCE BEGIN ====
> #pragma clang diagnostic push
> #pragma clang diagnostic ignored "-Wformat-security"
> __attribute__((used)) __attribute__((annotate("__cling__ptrcheck(off)")))
> extern "C" void __cf_0(void* obj, int nargs, void** args, void* ret)
> {
>    if (ret) {
>       new (ret) (double) (((double (&)(double*,
> double*))TFormula____id14894549893318956329)(*(double**)args[0],
> *(double**)args[1]));
>       return;
>    }
>    else {
>       (void)(((double (&)(double*,
> double*))TFormula____id14894549893318956329)(*(double**)args[0],
> *(double**)args[1]));
>       return;
>    }
> }
> #pragma clang diagnostic pop
>   ==== SOURCE END ====
> Error in <prepareFuncPtr>: Compiled function pointer is null
> Error in <TFormula::InputFormulaIntoCling>: Error compiling formula
> expression in Cling
> Error in <TFormula::ProcessFormula>: Formula
> "[p0]*exp(-0.5*((x-[p1])/[p2])*((x-[p1])/[p2]))" is invalid !
```

This is most likely a problem within ROOT itself. However, we could track it down to being caused by a static initialisation of a TF1 during library loading.

The present commit refactors the code to not use such a static TF1.

We should avoid static variable initialization in general, since it is a performance overhead. So the rest of the class might benefit from a rewrite, too.

Co-author: @martenole