### PR TITLE
multi-thread countTPCClusters in aod-producer

### DIFF
--- a/Detectors/AOD/CMakeLists.txt
+++ b/Detectors/AOD/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(internal::AODProducerWorkflow ALIAS AODProducerWorkflow)
 o2_add_executable(
   workflow
   COMPONENT_NAME aod-producer
+  TARGETVARNAME targetName
   SOURCES src/aod-producer-workflow.cxx src/AODProducerWorkflowSpec.cxx
   PUBLIC_LINK_LIBRARIES internal::AODProducerWorkflow O2::Version
 )
@@ -75,3 +76,8 @@ o2_add_executable(
         O2::Steer
         O2::ZDCBase
 )
+
+if (OpenMP_CXX_FOUND)
+  target_compile_definitions(${targetName} PRIVATE WITH_OPENMP)
+  target_link_libraries(${targetName} PRIVATE OpenMP::OpenMP_CXX)
+endif()

--- a/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
+++ b/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
@@ -226,6 +226,7 @@ class AODProducerWorkflowDPL : public Task
     return std::uint64_t(mStartIR.toLong()) + relativeTime_to_LocalBC(relativeTimeStampInNS);
   }
 
+  int mNThreads = 1;
   bool mUseMC = true;
   bool mEnableSV = true;             // enable secondary vertices
   const float cSpeed = 0.029979246f; // speed of light in TOF units
@@ -410,6 +411,14 @@ class AODProducerWorkflowDPL : public Task
     uint8_t fwdLabelMask = 0;
   };
 
+  // counters for TPC clusters
+  struct TPCCounters {
+    uint8_t shared = 0;
+    uint8_t found = 0;
+    uint8_t crossed = 0;
+  };
+  std::vector<TPCCounters> mTPCCounters;
+
   void updateTimeDependentParams(ProcessingContext& pc);
 
   void addRefGlobalBCsForTOF(const o2::dataformats::VtxTrackRef& trackRef, const gsl::span<const GIndex>& GIndices,
@@ -486,11 +495,7 @@ class AODProducerWorkflowDPL : public Task
   std::uint64_t fillBCSlice(int (&slice)[2], double tmin, double tmax, const std::map<uint64_t, int>& bcsMap) const;
 
   // helper for tpc clusters
-  void countTPCClusters(const o2::tpc::TrackTPC& track,
-                        const gsl::span<const o2::tpc::TPCClRefElem>& tpcClusRefs,
-                        const gsl::span<const unsigned char>& tpcClusShMap,
-                        const o2::tpc::ClusterNativeAccess& tpcClusAcc,
-                        uint8_t& shared, uint8_t& found, uint8_t& crossed);
+  void countTPCClusters(const o2::globaltracking::RecoContainer& data);
 
   // helper for trd pattern
   uint8_t getTRDPattern(const o2::trd::TrackTRD& track);


### PR DESCRIPTION
Testing on: 
```
WORKFLOW_DETECTORS=CPV,EMC,FDD,FT0,FV0,ITS,MCH,MFT,MID,PHS,TOF,TPC,TRD $O2_ROOT/prodtests/full-system-test/run-workflow-on-inputlist.sh CTF o2_ctf_run00523142_orbit0187895167_tf0000000004_epn069.root
```
shows ~40% decrease of the wall time:
For original code:
```
[1372263:aod-producer-workflow]: [19:03:57][INFO] aod producer dpl total timing: Cpu: 6.850e+00 Real: 6.927e+00 s in 5 slots
```
for 10 threads (by default set to `std::thread::hardware_concurrency() / 2`):
```
[1356456:aod-producer-workflow]: [18:36:46][INFO] aod producer dpl total timing: Cpu: 6.460e+00 Real: 4.125e+00 s in 5 slots
```