### PR TITLE
Implementation of ITSMFT Cage Side Panels into O2 geometry

### DIFF
--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/V3Cage.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/V3Cage.h
@@ -69,6 +69,12 @@ class V3Cage : public V11Geometry
   /// \param mgr  The GeoManager (used only to get the proper material)
   TGeoVolume* createCageSidePanel(const TGeoManager* mgr = gGeoManager);
 
+  /// Creates the shape of the Cage Side Panel core and foil
+  TGeoCompositeShape* createCageSidePanelCoreFoil(const Double_t thickness, const char* prefix);
+
+  /// Creates the shape of a Cage Side Panel rail
+  TGeoCompositeShape* createCageSidePanelRail(const Double_t length, const Int_t index);
+
   /// Creates the Cage End Cap element
   /// \param mgr  The GeoManager (used only to get the proper material)
   TGeoVolume* createCageEndCap(const TGeoManager* mgr = gGeoManager);
@@ -107,13 +113,19 @@ class V3Cage : public V11Geometry
   static const Double_t sCageSidePanelRail1Len;  ///< Side panel 1st rail length
   static const Double_t sCageSidePanelRail2Len;  ///< Side panel 2nd rail length
   static const Double_t sCageSidePanelRail3Len;  ///< Side panel 3rd rail length
-  static const Double_t sCageSidePanelRailThick; ///< Side panel rail thickness
-  static const Double_t sCageSidePanelRailWidth; ///< Side panel rail width
+  static const Double_t sCageSidePanelRailWidth; ///< Side panel rail Y width
+  static const Double_t sCageSidePanelRailSpan;  ///< Side panel rail X span
+  static const Double_t sCageSidePanelRailHThik; ///< Side panel rail horiz thickness
+  static const Double_t sCageSidePanelRailVThik; ///< Side panel rail vert thickness
   static const Double_t sCageSidePanelGuideLen;  ///< Side panel guide Z length
   static const Double_t sCageSidePanelGuideInHi; ///< Side panel guide in-height
   static const Double_t sCageSidePanelGuideWide; ///< Side panel guide X width
   static const Double_t sCageSidePanelGuidThik1; ///< Side panel guide thickness
   static const Double_t sCageSidePanelGuidThik2; ///< Side panel guide thickness
+
+  static const Double_t sCageSidePanelRail1Ypos[2]; ///< Side panel rail 1 Y pos
+  static const Double_t sCageSidePanelRail2Ypos;    ///< Side panel rail 2 Y pos
+  static const Double_t sCageSidePanelRail3Ypos[3]; ///< Side panel rail 3 Y pos
 
   static const Double_t sCageEndCapDext;        ///< End Cap ext diameter
   static const Double_t sCageEndCapDint;        ///< End Cap int diameter

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/V3Cage.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/V3Cage.h
@@ -65,6 +65,10 @@ class V3Cage : public V11Geometry
   /// \param mgr  The GeoManager (used only to get the proper material)
   TGeoVolume* createCageCoverRib(const TGeoManager* mgr = gGeoManager);
 
+  /// Creates the Cage Side Panel element
+  /// \param mgr  The GeoManager (used only to get the proper material)
+  TGeoVolume* createCageSidePanel(const TGeoManager* mgr = gGeoManager);
+
   /// Creates the Cage End Cap element
   /// \param mgr  The GeoManager (used only to get the proper material)
   TGeoVolume* createCageEndCap(const TGeoManager* mgr = gGeoManager);
@@ -94,6 +98,22 @@ class V3Cage : public V11Geometry
   static const Double_t sCageCoverRibXBaseInt; ///< Cover rib internal Base X
   static const Double_t sCageCoverRibYBaseHi;  ///< Cover rib Base Height on Y
   static const Double_t sCageCoverRibFoldHi;   ///< Cover rib Fold Height
+
+  static const Double_t sCageSidePanelLength;    ///< Side panel length along Z
+  static const Double_t sCageSidePanelWidth;     ///< Side panel width along Y
+  static const Double_t sCageSidePanelFoilThick; ///< Side panel foil thickness
+  static const Double_t sCageSidePanelCoreThick; ///< Side panel core thickness
+  static const Double_t sCageSidePanelXDist;     ///< Side panel distance on X
+  static const Double_t sCageSidePanelRail1Len;  ///< Side panel 1st rail length
+  static const Double_t sCageSidePanelRail2Len;  ///< Side panel 2nd rail length
+  static const Double_t sCageSidePanelRail3Len;  ///< Side panel 3rd rail length
+  static const Double_t sCageSidePanelRailThick; ///< Side panel rail thickness
+  static const Double_t sCageSidePanelRailWidth; ///< Side panel rail width
+  static const Double_t sCageSidePanelGuideLen;  ///< Side panel guide Z length
+  static const Double_t sCageSidePanelGuideInHi; ///< Side panel guide in-height
+  static const Double_t sCageSidePanelGuideWide; ///< Side panel guide X width
+  static const Double_t sCageSidePanelGuidThik1; ///< Side panel guide thickness
+  static const Double_t sCageSidePanelGuidThik2; ///< Side panel guide thickness
 
   static const Double_t sCageEndCapDext;        ///< End Cap ext diameter
   static const Double_t sCageEndCapDint;        ///< End Cap int diameter

--- a/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
@@ -24,12 +24,12 @@
 #include "SimulationDataFormat/TrackReference.h"
 
 // FairRoot includes
-#include "FairDetector.h"    // for FairDetector
+#include "FairDetector.h"      // for FairDetector
 #include <fairlogger/Logger.h> // for LOG, LOG_IF
-#include "FairRootManager.h" // for FairRootManager
-#include "FairRun.h"         // for FairRun
-#include "FairRuntimeDb.h"   // for FairRuntimeDb
-#include "FairVolume.h"      // for FairVolume
+#include "FairRootManager.h"   // for FairRootManager
+#include "FairRun.h"           // for FairRun
+#include "FairRuntimeDb.h"     // for FairRuntimeDb
+#include "FairVolume.h"        // for FairVolume
 #include "FairRootManager.h"
 
 #include "TGeoManager.h"     // for TGeoManager, gGeoManager
@@ -441,6 +441,12 @@ void Detector::createMaterials()
   Float_t wRohac[4] = {9., 13., 1., 2.};
   Float_t dRohac = 0.05;
 
+  // EN AW 7075 (Al alloy with Cu Mg Zn)
+  Float_t aENAW7075[4] = {26.98, 63.55, 24.31, 65.41};
+  Float_t zENAW7075[4] = {13., 29., 12., 30.};
+  Float_t wENAW7075[4] = {0., 0.015, 0.025, 0.055}; // [0] will be computed
+  Float_t dENAW7075 = 2.85;
+
   // Brass CuZn39Pb3 (Cu Zn Pb)
   Float_t aBrass[3] = {63.55, 65.41, 207.2};
   Float_t zBrass[3] = {29., 30., 82.};
@@ -551,6 +557,11 @@ void Detector::createMaterials()
   // Tungsten (for gamma converter rods)
   o2::base::Detector::Material(28, "TUNGSTEN$", 183.84, 74, 19.25, 999, 999);
   o2::base::Detector::Medium(28, "TUNGSTEN$", 28, 0, ifield, fieldm, tmaxfdSi, stemaxSi, deemaxSi, epsilSi, stminSi);
+
+  // EN AW 7075 (Al alloy with Cu Mg Zn) (for Cage rails)
+  wENAW7075[0] = 1. - wENAW7075[1] - wENAW7075[2] - wENAW7075[3];
+  o2::base::Detector::Mixture(36, "ENAW7075$", aENAW7075, zENAW7075, dENAW7075, 4, wENAW7075);
+  o2::base::Detector::Medium(36, "ENAW7075$", 36, 0, ifield, fieldm, tmaxfd, stemax, deemaxSi, epsilSi, stminSi);
 
   // Brass CuZn39Pb3
   o2::base::Detector::Mixture(34, "BRASS$", aBrass, zBrass, dBrass, 3, wBrass);

--- a/Detectors/ITSMFT/ITS/simulation/src/V3Cage.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/V3Cage.cxx
@@ -71,13 +71,19 @@ const Double_t V3Cage::sCageSidePanelXDist = 988.0 * sMm;
 const Double_t V3Cage::sCageSidePanelRail1Len = 3320.0 * sMm;
 const Double_t V3Cage::sCageSidePanelRail2Len = 1550.0 * sMm;
 const Double_t V3Cage::sCageSidePanelRail3Len = 302.0 * sMm;
-const Double_t V3Cage::sCageSidePanelRailThick = 20.0 * sMm;
-const Double_t V3Cage::sCageSidePanelRailWidth = 16.0 * sMm;
+const Double_t V3Cage::sCageSidePanelRailWidth = 25.0 * sMm;
+const Double_t V3Cage::sCageSidePanelRailSpan = 20.0 * sMm;
+const Double_t V3Cage::sCageSidePanelRailHThik = 5.0 * sMm;
+const Double_t V3Cage::sCageSidePanelRailVThik = 2.5 * sMm;
 const Double_t V3Cage::sCageSidePanelGuideLen = 3587.0 * sMm;
 const Double_t V3Cage::sCageSidePanelGuideInHi = 204.0 * sMm;
 const Double_t V3Cage::sCageSidePanelGuideWide = 44.0 * sMm;
 const Double_t V3Cage::sCageSidePanelGuidThik1 = 6.0 * sMm;
 const Double_t V3Cage::sCageSidePanelGuidThik2 = 8.0 * sMm;
+
+const Double_t V3Cage::sCageSidePanelRail1Ypos[2] = {226.5 * sMm, 147.5 * sMm};
+const Double_t V3Cage::sCageSidePanelRail2Ypos = 74.5 * sMm;
+const Double_t V3Cage::sCageSidePanelRail3Ypos[3] = {180.0 * sMm, 107.0 * sMm, 24.0 * sMm};
 
 const Double_t V3Cage::sCageEndCapDext = 1096.0 * sMm;
 const Double_t V3Cage::sCageEndCapDint = 304.0 * sMm;
@@ -339,10 +345,6 @@ TGeoVolume* V3Cage::createCageSidePanel(const TGeoManager* mgr)
   // Created:      30 Sep 2022  Mario Sitta
   //
 
-  const Double_t sCageSidePanelRail1Ypos[2] = {226.5 * sMm, 147.5 * sMm};
-  const Double_t sCageSidePanelRail2Ypos = 74.5 * sMm;
-  const Double_t sCageSidePanelRail3Ypos[3] = {180.0 * sMm, 107.0 * sMm, 24.0 * sMm};
-
   // Local variables
   Double_t xlen, ylen, zlen;
   Double_t xpos, ypos, zpos;
@@ -350,29 +352,27 @@ TGeoVolume* V3Cage::createCageSidePanel(const TGeoManager* mgr)
   // The TGeoVolumeAssembly holding all elements
   TGeoVolumeAssembly* sidePanelVol = new TGeoVolumeAssembly("CageSidePanel");
 
-  // The inner and outer foils: a BBox (each)
+  // The inner foil: a TGeoCompositeShape
+  TGeoCompositeShape* inFoilSh = createCageSidePanelCoreFoil(sCageSidePanelFoilThick, "foil");
+
+  // The outer foil: a BBox (each)
   xlen = sCageSidePanelFoilThick / 2;
   ylen = sCageSidePanelWidth / 2;
   zlen = sCageSidePanelLength / 2;
-  TGeoBBox* foilSh = new TGeoBBox(xlen, ylen, zlen);
+  TGeoBBox* outFoilSh = new TGeoBBox(xlen, ylen, zlen);
 
-  // The intermediate core layer: a BBox
+  // The intermediate core layer: a TGeoCompositeShape
   xlen = sCageSidePanelCoreThick / 2;
-  TGeoBBox* coreSh = new TGeoBBox(xlen, ylen, zlen);
+  TGeoCompositeShape* coreSh = createCageSidePanelCoreFoil(sCageSidePanelCoreThick, "core");
 
   // The longest rails (approx): a BBox
-  xlen = sCageSidePanelRailThick / 2;
-  ylen = sCageSidePanelRailWidth / 2;
-  zlen = sCageSidePanelRail1Len / 2;
-  TGeoBBox* rail1Sh = new TGeoBBox(xlen, ylen, zlen);
+  TGeoCompositeShape* rail1Sh = createCageSidePanelRail(sCageSidePanelRail1Len, 1);
 
   // The intermediate rails (approx): a BBox
-  zlen = sCageSidePanelRail2Len / 2;
-  TGeoBBox* rail2Sh = new TGeoBBox(xlen, ylen, zlen);
+  TGeoCompositeShape* rail2Sh = createCageSidePanelRail(sCageSidePanelRail2Len, 2);
 
   // The shortest rails (approx): a BBox
-  zlen = sCageSidePanelRail3Len / 2;
-  TGeoBBox* rail3Sh = new TGeoBBox(xlen, ylen, zlen);
+  TGeoCompositeShape* rail3Sh = createCageSidePanelRail(sCageSidePanelRail3Len, 3);
 
   // The elements of the guide:
   // - the vertical part: a BBox
@@ -406,9 +406,13 @@ TGeoVolume* V3Cage::createCageSidePanel(const TGeoManager* mgr)
   TGeoMedium* medFoam = mgr->GetMedium("ITS_ROHACELL$");
   TGeoMedium* medAlAlloy = mgr->GetMedium("ITS_ENAW7075$");
 
-  TGeoVolume* foilVol = new TGeoVolume("CageSidePanelFoil", foilSh, medFabric);
-  foilVol->SetFillColor(kBlue);
-  foilVol->SetLineColor(kBlue);
+  TGeoVolume* inFoilVol = new TGeoVolume("CageSidePanelInFoil", inFoilSh, medFabric);
+  inFoilVol->SetFillColor(kBlue);
+  inFoilVol->SetLineColor(kBlue);
+
+  TGeoVolume* outFoilVol = new TGeoVolume("CageSidePanelOutFoil", outFoilSh, medFabric);
+  outFoilVol->SetFillColor(kBlue);
+  outFoilVol->SetLineColor(kBlue);
 
   TGeoVolume* coreVol = new TGeoVolume("CageSidePanelCore", coreSh, medFoam);
   coreVol->SetFillColor(kYellow);
@@ -434,27 +438,27 @@ TGeoVolume* V3Cage::createCageSidePanel(const TGeoManager* mgr)
   sidePanelVol->AddNode(coreVol, 1, nullptr);
 
   xpos = (sCageSidePanelCoreThick + sCageSidePanelFoilThick) / 2;
-  sidePanelVol->AddNode(foilVol, 1, new TGeoTranslation(xpos, 0, 0));
-  sidePanelVol->AddNode(foilVol, 2, new TGeoTranslation(-xpos, 0, 0));
+  sidePanelVol->AddNode(inFoilVol, 1, new TGeoTranslation(-xpos, 0, 0));
+  sidePanelVol->AddNode(outFoilVol, 1, new TGeoTranslation(xpos, 0, 0));
 
-  xpos += (sCageSidePanelFoilThick + sCageSidePanelRailThick) / 2;
+  xpos = (sCageSidePanelCoreThick - sCageSidePanelRailVThik) / 2;
   zpos = (sCageSidePanelLength - sCageSidePanelRail1Len) / 2;
   for (Int_t j = 0; j < 2; j++) {
     ypos = sCageSidePanelRail1Ypos[j];
-    sidePanelVol->AddNode(rail1Vol, j + 1, new TGeoTranslation(-xpos, ypos, zpos));
-    sidePanelVol->AddNode(rail1Vol, j + 3, new TGeoTranslation(-xpos, -ypos, zpos));
+    sidePanelVol->AddNode(rail1Vol, j + 1, new TGeoTranslation(xpos, ypos, zpos));
+    sidePanelVol->AddNode(rail1Vol, j + 3, new TGeoTranslation(xpos, -ypos, zpos));
   }
 
   zpos = (sCageSidePanelLength - sCageSidePanelRail2Len) / 2;
   ypos = sCageSidePanelRail2Ypos;
-  sidePanelVol->AddNode(rail2Vol, 1, new TGeoTranslation(-xpos, ypos, zpos));
-  sidePanelVol->AddNode(rail2Vol, 2, new TGeoTranslation(-xpos, -ypos, zpos));
+  sidePanelVol->AddNode(rail2Vol, 1, new TGeoTranslation(xpos, ypos, zpos));
+  sidePanelVol->AddNode(rail2Vol, 2, new TGeoTranslation(xpos, -ypos, zpos));
 
   zpos = (sCageSidePanelLength - sCageSidePanelRail3Len) / 2;
   for (Int_t j = 0; j < 3; j++) {
     ypos = sCageSidePanelRail3Ypos[j];
-    sidePanelVol->AddNode(rail3Vol, j + 1, new TGeoTranslation(-xpos, ypos, zpos));
-    sidePanelVol->AddNode(rail3Vol, j + 4, new TGeoTranslation(-xpos, -ypos, zpos));
+    sidePanelVol->AddNode(rail3Vol, j + 1, new TGeoTranslation(xpos, ypos, zpos));
+    sidePanelVol->AddNode(rail3Vol, j + 4, new TGeoTranslation(xpos, -ypos, zpos));
   }
 
   xpos = sCageSidePanelCoreThick / 2 + sCageSidePanelFoilThick + sCageSidePanelGuidThik2 / 2;
@@ -463,6 +467,159 @@ TGeoVolume* V3Cage::createCageSidePanel(const TGeoManager* mgr)
 
   // Finally return the side panel volume
   return sidePanelVol;
+}
+
+TGeoCompositeShape* V3Cage::createCageSidePanelCoreFoil(const Double_t xthick, const char* shpref)
+{
+  //
+  // Creates the shape of the core and the internal foil of the
+  // Cage Side Panel, which contain proper cuts to host the rails
+  //
+  // Input:
+  //         xthick : the shape thickness along X
+  //         shpref : prefix of the shape name
+  //
+  // Output:
+  //
+  // Return:
+  //         The side panel core or foil as a TGeoCompositeShape
+  //
+  // Created:      07 Oct 2022  Mario Sitta
+  //
+
+  // Local variables
+  Double_t xlen, ylen, zlen;
+  Double_t ypos, zpos;
+
+  // The main body: a BBox
+  xlen = xthick / 2;
+  ylen = sCageSidePanelWidth / 2;
+  zlen = sCageSidePanelLength / 2;
+  TGeoBBox* bodySh = new TGeoBBox(xlen, ylen, zlen);
+  bodySh->SetName(Form("%sbodyshape", shpref));
+
+  // The hole for the longest rails (approx): a BBox
+  xlen = 1.1 * xthick / 2;
+  ylen = sCageSidePanelRailWidth / 2;
+  zlen = sCageSidePanelRail1Len;
+  TGeoBBox* rail1Sh = new TGeoBBox(xlen, ylen, zlen);
+  rail1Sh->SetName(Form("%slongrail", shpref));
+
+  zpos = sCageSidePanelLength / 2;
+  TGeoTranslation* rail1Mat[4];
+  for (Int_t j = 0; j < 2; j++) {
+    ypos = sCageSidePanelRail1Ypos[j];
+    rail1Mat[j] = new TGeoTranslation(0, ypos, zpos);
+    rail1Mat[j]->SetName(Form("longrailmat%d", j));
+    rail1Mat[j]->RegisterYourself();
+    rail1Mat[j + 2] = new TGeoTranslation(0, -ypos, zpos);
+    rail1Mat[j + 2]->SetName(Form("longrailmat%d", j + 2));
+    rail1Mat[j + 2]->RegisterYourself();
+  }
+
+  // The hole for the intermediate rails (approx): a BBox
+  zlen = sCageSidePanelRail2Len;
+  TGeoBBox* rail2Sh = new TGeoBBox(xlen, ylen, zlen);
+  rail2Sh->SetName(Form("%smedrail", shpref));
+
+  ypos = sCageSidePanelRail2Ypos;
+  TGeoTranslation* rail2Mat[2];
+  rail2Mat[0] = new TGeoTranslation(0, ypos, zpos);
+  rail2Mat[0]->SetName("medrailmat0");
+  rail2Mat[0]->RegisterYourself();
+  rail2Mat[1] = new TGeoTranslation(0, -ypos, zpos);
+  rail2Mat[1]->SetName("medrailmat1");
+  rail2Mat[1]->RegisterYourself();
+
+  // The hole for the shortest rails (approx): a BBox
+  zlen = sCageSidePanelRail3Len;
+  TGeoBBox* rail3Sh = new TGeoBBox(xlen, ylen, zlen);
+  rail3Sh->SetName(Form("%sshortrail", shpref));
+
+  TGeoTranslation* rail3Mat[6];
+  for (Int_t j = 0; j < 3; j++) {
+    ypos = sCageSidePanelRail3Ypos[j];
+    rail3Mat[j] = new TGeoTranslation(0, ypos, zpos);
+    rail3Mat[j]->SetName(Form("shortrailmat%d", j));
+    rail3Mat[j]->RegisterYourself();
+    rail3Mat[j + 3] = new TGeoTranslation(0, -ypos, zpos);
+    rail3Mat[j + 3]->SetName(Form("shortrailmat%d", j + 3));
+    rail3Mat[j + 3]->RegisterYourself();
+  }
+
+  // The actual shape: a CompositeShape
+  TString compoShape = Form("%sbodyshape", shpref);
+  for (Int_t j = 0; j < 4; j++) {
+    compoShape += Form("-%slongrail:longrailmat%d", shpref, j);
+  }
+  for (Int_t j = 0; j < 2; j++) {
+    compoShape += Form("-%smedrail:medrailmat%d", shpref, j);
+  }
+  for (Int_t j = 0; j < 6; j++) {
+    compoShape += Form("-%sshortrail:shortrailmat%d", shpref, j);
+  }
+
+  TGeoCompositeShape* corefoilSh = new TGeoCompositeShape(compoShape);
+
+  // Now return the shape
+  return corefoilSh;
+}
+
+TGeoCompositeShape* V3Cage::createCageSidePanelRail(const Double_t zlength, const Int_t index)
+{
+  //
+  // Creates the shape of a Cage Side Panel rail
+  // (slightly approximated as a linear structure)
+  //
+  // Input:
+  //         zlength : the rail length along Z
+  //         index : an integer to distinguish subvolume names
+  //
+  // Output:
+  //
+  // Return:
+  //         The side panel rail as a TGeoCompositeShape
+  //
+  // Created:      08 Oct 2022  Mario Sitta
+  //
+
+  // Local variables
+  Double_t xlen, ylen;
+  Double_t xpos, ypos;
+
+  // The elements of the rail:
+  // - the vertical part: a BBox
+  xlen = sCageSidePanelRailVThik / 2;
+  ylen = (sCageSidePanelRailWidth - 2 * sCageSidePanelRailHThik) / 2;
+  TGeoBBox* railVert = new TGeoBBox(xlen, ylen, zlength / 2);
+  railVert->SetName(Form("railvert%d", index));
+
+  // - the horizontal part: a BBox
+  xlen = sCageSidePanelRailSpan / 2;
+  ylen = sCageSidePanelRailHThik / 2;
+  TGeoBBox* railHor = new TGeoBBox(xlen, ylen, zlength / 2);
+  railHor->SetName(Form("railhor%d", index));
+
+  // The relative matrices
+  xpos = (sCageSidePanelRailVThik - sCageSidePanelRailSpan) / 2;
+  ypos = (sCageSidePanelRailWidth - sCageSidePanelRailHThik) / 2;
+  TGeoTranslation* railHorMat1 = new TGeoTranslation(xpos, ypos, 0);
+  railHorMat1->SetName("railhormat1");
+  railHorMat1->RegisterYourself();
+
+  TGeoTranslation* railHorMat2 = new TGeoTranslation(xpos, -ypos, 0);
+  railHorMat2->SetName("railhormat2");
+  railHorMat2->RegisterYourself();
+
+  // The actual guide: a CompositeShape
+  TString compoShape = Form("railvert%d", index);
+  compoShape += Form("+railhor%d:railhormat1", index);
+  compoShape += Form("+railhor%d:railhormat2", index);
+
+  TGeoCompositeShape* railSh = new TGeoCompositeShape(compoShape);
+
+  // Now return the shape
+  return railSh;
 }
 
 TGeoVolume* V3Cage::createCageEndCap(const TGeoManager* mgr)

--- a/Detectors/ITSMFT/ITS/simulation/src/V3Cage.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/V3Cage.cxx
@@ -362,16 +362,15 @@ TGeoVolume* V3Cage::createCageSidePanel(const TGeoManager* mgr)
   TGeoBBox* outFoilSh = new TGeoBBox(xlen, ylen, zlen);
 
   // The intermediate core layer: a TGeoCompositeShape
-  xlen = sCageSidePanelCoreThick / 2;
   TGeoCompositeShape* coreSh = createCageSidePanelCoreFoil(sCageSidePanelCoreThick, "core");
 
-  // The longest rails (approx): a BBox
+  // The longest rails
   TGeoCompositeShape* rail1Sh = createCageSidePanelRail(sCageSidePanelRail1Len, 1);
 
-  // The intermediate rails (approx): a BBox
+  // The intermediate rails
   TGeoCompositeShape* rail2Sh = createCageSidePanelRail(sCageSidePanelRail2Len, 2);
 
-  // The shortest rails (approx): a BBox
+  // The shortest rails
   TGeoCompositeShape* rail3Sh = createCageSidePanelRail(sCageSidePanelRail3Len, 3);
 
   // The elements of the guide:


### PR DESCRIPTION
The Side Panels of the ITSMFT Cage were implemented in the O2 geometry. They were the last missing main elements of the Cage, which is now complete in its most relevant parts. A full description can be found here
https://indico.cern.ch/event/1206725/contributions/5075224/attachments/2521836/4336441/sitta_WP2_221004.pdf