### PR TITLE
Fix CPV errors in InfoLogger

### DIFF
--- a/Detectors/CPV/calib/src/GainCalibrator.cxx
+++ b/Detectors/CPV/calib/src/GainCalibrator.cxx
@@ -256,7 +256,7 @@ void GainCalibrator::finalizeSlot(GainTimeSlot& slot)
   mGainsVec.push_back(*newGains);
   // metadata for o2::cpv::CalibParams
   std::map<std::string, std::string> metaData;
-  auto className = o2::utils::MemFileHelper::getClassName(newGains);
+  auto className = o2::utils::MemFileHelper::getClassName(*newGains);
   auto fileName = o2::ccdb::CcdbApi::generateFileName(className);
   auto timeStamp = o2::ccdb::getCurrentTimestamp();
   mCcdbInfoGainsVec.emplace_back("CPV/Calib/Gains", className, fileName, metaData, timeStamp, timeStamp + 31536000000); // one year validity time (in milliseconds!)

--- a/Detectors/CPV/calib/src/NoiseCalibrator.cxx
+++ b/Detectors/CPV/calib/src/NoiseCalibrator.cxx
@@ -159,7 +159,7 @@ void NoiseCalibrator::finalizeSlot(NoiseTimeSlot& slot)
   mBadChannelMapVec.push_back(*badMap);
   // metadata for o2::cpv::BadChannelMap
   std::map<std::string, std::string> metaData;
-  auto className = o2::utils::MemFileHelper::getClassName(badMap);
+  auto className = o2::utils::MemFileHelper::getClassName(*badMap);
   auto fileName = o2::ccdb::CcdbApi::generateFileName(className);
   auto timeStamp = o2::ccdb::getCurrentTimestamp();
   mCcdbInfoBadChannelMapVec.emplace_back("CPV/Calib/BadChannelMap", className, fileName, metaData, timeStamp, timeStamp + 31536000000); // one year validity time (in milliseconds!)

--- a/Detectors/CPV/calib/src/PedestalCalibrator.cxx
+++ b/Detectors/CPV/calib/src/PedestalCalibrator.cxx
@@ -317,7 +317,7 @@ void PedestalCalibrator::finalizeSlot(PedestalTimeSlot& slot)
 
   // metadata for o2::cpv::Pedestals
   std::map<std::string, std::string> metaData;
-  auto className = o2::utils::MemFileHelper::getClassName(peds);
+  auto className = o2::utils::MemFileHelper::getClassName(*peds);
   auto fileName = o2::ccdb::CcdbApi::generateFileName(className);
   auto timeStamp = o2::ccdb::getCurrentTimestamp();
   mCcdbInfoPedestalsVec.emplace_back("CPV/Calib/Pedestals", className, fileName, metaData, timeStamp, timeStamp + 31536000000); // one year validity time (in milliseconds!)


### PR DESCRIPTION
In order to reproduce with current O2:
```
root [0] o2::cpv::CalibParams* foo = new o2::cpv::CalibParams(1)
(o2::cpv::CalibParams *) 0x80c12d0
root [1] o2::utils::MemFileHelper::getClassName(foo)
[ERROR] Could not retrieve ROOT dictionary for type PN2o23cpv11CalibParamsE
(std::string) ""
root [2] o2::utils::MemFileHelper::getClassName(*foo)
(std::string) "o2::cpv::CalibParams"
root [3] 
```
pinging just for information also to @chiarazampolli 