### PR TITLE
DPL: handle Lifetime::Condition in consumeWhenAny

### DIFF
--- a/Utilities/Mergers/src/MergerBuilder.cxx
+++ b/Utilities/Mergers/src/MergerBuilder.cxx
@@ -112,13 +112,11 @@ framework::DataProcessorSpec MergerBuilder::buildSpec()
 
 void MergerBuilder::customizeInfrastructure(std::vector<framework::CompletionPolicy>& policies)
 {
+  auto matcher = [label = mergerLabel()](framework::DeviceSpec const& device) {
+    return std::find(device.labels.begin(), device.labels.end(), label) != device.labels.end();
+  };
   // each merger's name contains the common label and should always consume
-  policies.emplace_back(
-    "MergerCompletionPolicy",
-    [label = mergerLabel()](framework::DeviceSpec const& device) {
-      return std::find(device.labels.begin(), device.labels.end(), label) != device.labels.end();
-    },
-    CompletionPolicyHelpers::consumeWhenAny().callback);
+  policies.emplace_back(CompletionPolicyHelpers::consumeWhenAny("MergerCompletionPolicy", matcher));
 }
 
 } // namespace o2::mergers


### PR DESCRIPTION
Conditions should never be consumed, unless there is data.