### PR TITLE
DPL Analysis: Add slice/array index builder

### DIFF
--- a/Framework/Core/include/Framework/AnalysisHelpers.h
+++ b/Framework/Core/include/Framework/AnalysisHelpers.h
@@ -230,10 +230,10 @@ struct Sparse {
 namespace
 {
 template <typename T, typename Key>
-inline arrow::ChunkedArray* getIndexToKey(arrow::Table* table)
+inline std::shared_ptr<arrow::ChunkedArray> getIndexToKey(arrow::Table* table)
 {
   using IC = framework::pack_element_t<framework::has_type_at_conditional<soa::is_binding_compatible, Key>(typename T::external_index_columns_t{}), typename T::external_index_columns_t>;
-  return table->column(framework::has_type_at<IC>(typename T::persistent_columns_t{})).get();
+  return table->column(framework::has_type_at<IC>(typename T::persistent_columns_t{}));
 }
 
 template <typename C>

--- a/Framework/Core/include/Framework/IndexBuilderHelpers.h
+++ b/Framework/Core/include/Framework/IndexBuilderHelpers.h
@@ -118,7 +118,7 @@ class IndexColumnBuilder : public SelfIndexColumnBuilder, public ChunkedArrayIte
 
  private:
   arrow::Status preSlice();
-  void preFind();
+  arrow::Status preFind();
 
   bool findSingle(int idx);
   bool findSlice(int idx);

--- a/Framework/Core/src/IndexBuilderHelpers.cxx
+++ b/Framework/Core/src/IndexBuilderHelpers.cxx
@@ -103,13 +103,10 @@ std::shared_ptr<arrow::ChunkedArray> IndexColumnBuilder::resultSingle() const
 std::shared_ptr<arrow::ChunkedArray> IndexColumnBuilder::resultSlice() const
 {
   std::shared_ptr<arrow::Array> array;
-  //  std::shared_ptr<arrow::Array> varray;
   auto status = static_cast<arrow::FixedSizeListBuilder*>(mListBuilder.get())->Finish(&array);
-  //  auto status = static_cast<arrow::Int32Builder*>(mValueBuilder)->Finish(&varray);
   if (!status.ok()) {
     throw runtime_error("Cannot build an array");
   }
-  //  array = std::make_shared<arrow::FixedSizeListArray>(mArrowType, mResultSize, varray);
   return std::make_shared<arrow::ChunkedArray>(array);
 }
 

--- a/Framework/Core/test/test_IndexBuilder.cxx
+++ b/Framework/Core/test/test_IndexBuilder.cxx
@@ -137,17 +137,19 @@ BOOST_AUTO_TEST_CASE(TestIndexBuilder)
 namespace extra_4
 {
 DECLARE_SOA_COLUMN_FULL(Bin, bin, int, "bin");
-}
+DECLARE_SOA_COLUMN_FULL(Color, color, int, "color");
+} // namespace extra_4
 
 DECLARE_SOA_TABLE(BinnedPoints, "TST", "BinnedPoints", Index<>, extra_4::Bin, indices::PointId);
+DECLARE_SOA_TABLE(ColoredPoints, "TST", "ColoredPoints", Index<>, extra_4::Color, indices::PointId);
 
 namespace indices
 {
 DECLARE_SOA_SLICE_INDEX_COLUMN(BinnedPoint, binsSlice);
-DECLARE_SOA_ARRAY_INDEX_COLUMN(BinnedPoint, binsList);
+DECLARE_SOA_ARRAY_INDEX_COLUMN(ColoredPoint, colorsList);
 } // namespace indices
 
-DECLARE_SOA_TABLE(IDX3s, "TST", "Index3", Index<>, indices::PointId, indices::BinnedPointIdSlice);
+DECLARE_SOA_TABLE(IDX3s, "TST", "Index3", Index<>, indices::PointId, indices::BinnedPointIdSlice, indices::ColoredPointIds);
 
 BOOST_AUTO_TEST_CASE(AdvancedIndexTables)
 {
@@ -176,10 +178,39 @@ BOOST_AUTO_TEST_CASE(AdvancedIndexTables)
   auto t2 = b2.finalize();
   BinnedPoints st2{t2};
 
-  auto t3 = IndexBuilder<Sparse>::indexBuilder<Points>("test4", {t1, t2}, typename IDX3s::persistent_columns_t{}, o2::framework::pack<Points, BinnedPoints>{});
+  TableBuilder b3;
+  auto w3 = b3.cursor<ColoredPoints>();
+  std::array<int, 20> pointIds1 = {19, 2, 10, 5, 7, 17, 1, 3, 9, 12, 17, 6, 4, 13, 8, 5, 16, 15, 18, 0};
+  std::array<int, 20> pointIds2 = {3, 19, 2, 6, 4, 13, 11, 5, 7, 11, 1, 9, 12, 17, 8, 14, 16, 2, 18, 0};
+  std::array<int, 20> pointIds3 = {19, 2, 9, 15, 1, 3, 9, 12, 17, 18, 0, 10, 5, 7, 11, 6, 4, 13, 9, 14};
+  for (int i = 0; i < 20; ++i) {
+    w3(0, i, pointIds1[i]);
+  }
+  for (int i = 0; i < 20; ++i) {
+    w3(0, i + 20, pointIds2[i]);
+  }
+  for (int i = 0; i < 20; ++i) {
+    w3(0, i + 40, pointIds3[i]);
+  }
+  auto tc = b3.finalize();
+  ColoredPoints st3{tc};
+
+  std::array<int, 10> colorsizes = {3, 3, 4, 3, 3, 4, 3, 3, 2, 5};
+  std::array<std::vector<int>, 10> colorvalues = {{{19, 39, 50},
+                                                   {6, 30, 44},
+                                                   {1, 22, 37, 41},
+                                                   {7, 20, 45},
+                                                   {12, 24, 56},
+                                                   {3, 15, 27, 52},
+                                                   {11, 23, 55},
+                                                   {4, 28, 53},
+                                                   {14, 34},
+                                                   {8, 31, 42, 46, 58}}};
+
+  auto t3 = IndexBuilder<Sparse>::indexBuilder<Points>("test4", {t1, t2, tc}, typename IDX3s::persistent_columns_t{}, o2::framework::pack<Points, BinnedPoints, ColoredPoints>{});
   BOOST_REQUIRE_EQUAL(t3->num_rows(), st1.size());
   IDX3s idxs{t3};
-  idxs.bindExternalIndices(&st1, &st2);
+  idxs.bindExternalIndices(&st1, &st2, &st3);
   count = 0;
   for (auto const& row : idxs) {
     BOOST_REQUIRE(row.has_point());
@@ -189,6 +220,11 @@ BOOST_AUTO_TEST_CASE(AdvancedIndexTables)
       for (auto const& bin : slice) {
         BOOST_REQUIRE_EQUAL(bin.pointId(), row.pointId());
       }
+    }
+    auto colors = row.colorsList();
+    BOOST_REQUIRE_EQUAL(colors.size(), colorsizes[count]);
+    for (auto j = 0; j < colors.size(); ++j) {
+      BOOST_REQUIRE_EQUAL(colors[j].color(), colorvalues[count][j]);
     }
     ++count;
   }


### PR DESCRIPTION
* Adds ability to automatically create index tables with 1-to-many relations using slice and array index columns
* IndexBuilder test is updated to include these advanced cases