### PR TITLE
Avoid issue with empty tables in Preslice and sliceBy

### DIFF
--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -30,6 +30,7 @@
 #include <fmt/format.h>
 #include <typeinfo>
 #include <gsl/span>
+#include <iostream>
 
 namespace o2::framework
 {
@@ -61,13 +62,16 @@ struct Preslice {
 
   arrow::Status getSliceFor(int value, std::shared_ptr<arrow::Table> const& input, std::shared_ptr<arrow::Table>& output, uint64_t& offset) const
   {
-    arrow::Status status;
-    for (auto slice = 0; slice < mValues->length(); ++slice) {
-      if (mValues->Value(slice) == value) {
-        output = input->Slice(offset, mCounts->Value(slice));
-        return arrow::Status::OK();
+    if (input->num_rows() > 0) {
+      for (auto slice = 0; slice < mValues->length(); ++slice) {
+        if (mValues->Value(slice) == value) {
+          output = input->Slice(offset, mCounts->Value(slice));
+          return arrow::Status::OK();
+        }
+        offset += mCounts->Value(slice);
       }
-      offset += mCounts->Value(slice);
+    } else {
+      offset = 0;
     }
     output = input->Slice(offset, 0);
     return arrow::Status::OK();

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -30,7 +30,6 @@
 #include <fmt/format.h>
 #include <typeinfo>
 #include <gsl/span>
-#include <iostream>
 
 namespace o2::framework
 {

--- a/Framework/Core/src/Kernels.cxx
+++ b/Framework/Core/src/Kernels.cxx
@@ -22,7 +22,6 @@
 #include <arrow/util/config.h>
 
 #include <string>
-#include <iostream>
 
 namespace o2::framework
 {
@@ -34,7 +33,7 @@ arrow::Status getSlices(
 {
   arrow::Datum value_counts;
   auto options = arrow::compute::ScalarAggregateOptions::Defaults();
-  if (input->num_rows() > 0 ) {
+  if (input->num_rows() > 0) {
     ARROW_ASSIGN_OR_RAISE(value_counts,
                           arrow::compute::CallFunction("value_counts", {input->GetColumnByName(key)},
                                                        &options));

--- a/Framework/Core/src/Kernels.cxx
+++ b/Framework/Core/src/Kernels.cxx
@@ -22,6 +22,7 @@
 #include <arrow/util/config.h>
 
 #include <string>
+#include <iostream>
 
 namespace o2::framework
 {
@@ -33,12 +34,14 @@ arrow::Status getSlices(
 {
   arrow::Datum value_counts;
   auto options = arrow::compute::ScalarAggregateOptions::Defaults();
-  ARROW_ASSIGN_OR_RAISE(value_counts,
-                        arrow::compute::CallFunction("value_counts", {input->GetColumnByName(key)},
-                                                     &options));
-  auto pair = static_cast<arrow::StructArray>(value_counts.array());
-  values = std::make_shared<arrow::NumericArray<arrow::Int32Type>>(pair.field(0)->data());
-  counts = std::make_shared<arrow::NumericArray<arrow::Int64Type>>(pair.field(1)->data());
+  if (input->num_rows() > 0 ) {
+    ARROW_ASSIGN_OR_RAISE(value_counts,
+                          arrow::compute::CallFunction("value_counts", {input->GetColumnByName(key)},
+                                                       &options));
+    auto pair = static_cast<arrow::StructArray>(value_counts.array());
+    values = std::make_shared<arrow::NumericArray<arrow::Int32Type>>(pair.field(0)->data());
+    counts = std::make_shared<arrow::NumericArray<arrow::Int64Type>>(pair.field(1)->data());
+  }
   return arrow::Status::OK();
 }
 


### PR DESCRIPTION
When using Preslice / sliceBy with an empty table the processing crashed. This PR introduces changes to avoid the crash. 