### PR TITLE
cmake: improve pythia8 data detection

### DIFF
--- a/dependencies/Findpythia.cmake
+++ b/dependencies/Findpythia.cmake
@@ -24,7 +24,8 @@ find_library(${PKGNAME}_LIBRARY_SHARED
 find_path(${PKGNAME}_DATA
           NAMES MainProgramSettings.xml
           PATHS ${${PKGNAME}_ROOT}/share/Pythia8/xmldoc
-                $ENV{${PKGENVNAME}_ROOT}/share/Pythia8/xmldoc)
+                $ENV{${PKGENVNAME}_ROOT}/share/Pythia8/xmldoc
+                $ENV{PYTHIA8DATA})
 
 if(${PKGNAME}_INCLUDE_DIR AND ${PKGNAME}_LIBRARY_SHARED AND ${PKGNAME}_DATA)
   add_library(pythia SHARED IMPORTED)


### PR DESCRIPTION
We are actually using `PKGNAME`=pythia while what is defined upon installation is `PYTHIA8XXX` env variables. We could also change the target/package name from `pythia` to `pythia8` but that would require more changes.

Without this change a (spack) installation of QualityControl was failing to find Pythia8 (data). 