### PR TITLE
[EMCAL-565]: Bug fix to cut on the mean energy per hit.

### DIFF
--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibExtractor.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALCalibExtractor.h
@@ -224,7 +224,7 @@ class EMCALCalibExtractor
         double sumVal = boost::histogram::algorithm::sum(slicedHist);
         if (sumVal > 0.) {
           // fill the output map with the desired slicing etc.
-          outputMapEnergyPerHit[sliceIndex][cellID] = (meanVal / (sumVal));
+          outputMapEnergyPerHit[sliceIndex][cellID] = meanVal;
           outputMapNHits[sliceIndex][cellID] = sumVal;
         }
 


### PR DESCRIPTION
- Before we were dividing the mean energy per hit by the number of hits. 
- Switching this to actually be the mean energy per hit as intended. 