### PR TITLE
MCH: speedup elecmap by using static in some key methods

### DIFF
--- a/Detectors/MUON/MCH/Raw/ElecMap/src/ElectronicMapperImplHelper.h
+++ b/Detectors/MUON/MCH/Raw/ElecMap/src/ElectronicMapperImplHelper.h
@@ -93,9 +93,9 @@ std::map<VALUE, KEY> inverseMap(const std::map<KEY, VALUE>& src)
 template <typename T>
 std::set<uint16_t> getSolarUIDs(int deid)
 {
-  auto d2e = o2::mch::raw::createDet2ElecMapper<T>();
+  static auto d2e = o2::mch::raw::createDet2ElecMapper<T>();
   std::set<uint16_t> solarsForDE;
-  auto dslist = createDualSampaMapper();
+  static auto dslist = createDualSampaMapper();
   for (auto dsid : dslist(deid)) {
     DsDetId id{static_cast<uint16_t>(deid), static_cast<uint16_t>(dsid)};
     auto dsel = d2e(id);
@@ -124,7 +124,7 @@ template <typename T>
 std::set<uint16_t> getSolarUIDsPerFeeId(uint16_t feeid)
 {
   std::set<uint16_t> solars;
-  auto feeLink2Solar = createFeeLink2SolarMapper<T>();
+  static auto feeLink2Solar = createFeeLink2SolarMapper<T>();
   for (uint8_t link = 0; link < 12; link++) {
     auto solar = feeLink2Solar(FeeLinkId{feeid, link});
     if (solar.has_value()) {
@@ -154,7 +154,7 @@ std::vector<std::string> solar2FeeLinkConsistencyCheck()
 
   // All solars must have a FeeLinkId
   std::set<uint16_t> solarIds = getSolarUIDs<T>();
-  auto solar2feeLink = createSolar2FeeLinkMapper<T>();
+  static auto solar2feeLink = createSolar2FeeLinkMapper<T>();
   std::vector<o2::mch::raw::FeeLinkId> feeLinkIds;
   for (auto s : solarIds) {
     auto p = solar2feeLink(s);
@@ -181,8 +181,8 @@ std::set<DsElecId> getAllDs()
 {
   std::set<DsElecId> dsElecIds;
 
-  auto dslist = createDualSampaMapper();
-  auto det2ElecMapper = createDet2ElecMapper<T>();
+  static auto dslist = createDualSampaMapper();
+  static auto det2ElecMapper = createDet2ElecMapper<T>();
 
   for (auto deId : o2::mch::constants::deIdsForAllMCH) {
     for (auto dsId : dslist(deId)) {
@@ -201,7 +201,7 @@ std::set<DsDetId> getDualSampas(uint16_t solarId)
 {
   std::set<DsDetId> dualSampas;
 
-  auto elec2det = o2::mch::raw::createElec2DetMapper<T>();
+  static auto elec2det = o2::mch::raw::createElec2DetMapper<T>();
   for (uint8_t group = 0; group < 8; group++) {
     for (uint8_t index = 0; index < 5; index++) {
       DsElecId dsElecId{solarId, group, index};


### PR DESCRIPTION
The speedup on affected MCH tests is :

- ~30X for `testElectronicMapper`
- ~4X for `testClosureCoDecDigit`
- ~10X for `testNumberOfPadsPerFeeId`

Tested on a MacBook Pro M1.
On a FLP-like machine the results are comparable.

The total test time for mch (`ctest -L mch`) has been decreased by 1.5 on the MacBook, but not on the FLP-like machine where tests reading from disk (actual spinning disk vs SSD on the MacBook) dominate the total time.

@aferrero2707 FYI