### PR TITLE
Retrieve SOR/EOR information for ITS DCS parser

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DCSParserSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/DCSParserSpec.h
@@ -85,9 +85,6 @@ class ITSDCSParser : public Task
 
   std::string mSelfName = "";
 
-  // Keep track of whether the endOfStream() or stop() has been called
-  bool mStopped = false;
-
   // Whether to use verbose output
   bool mVerboseOutput = false;
 

--- a/Detectors/ITSMFT/ITS/workflow/src/DCSParserSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/DCSParserSpec.cxx
@@ -400,7 +400,7 @@ void ITSDCSParser::pushToCCDB(ProcessingContext& pc)
   std::map<std::string, std::string> metadata;
   std::map<std::string, std::string> headers = api.retrieveHeaders(
     "RCT/Info/RunInformation", metadata, this->mRunNumber);
-  if (headers.empty()) {  // No CCDB entry is found
+  if (headers.empty()) { // No CCDB entry is found
     LOG(error) << "Failed to retrieve headers from CCDB with run number " << this->mRunNumber
                << "\nWill default to using the current time for timestamp information";
     tstart = o2::ccdb::getCurrentTimestamp();

--- a/Detectors/ITSMFT/ITS/workflow/src/DCSParserSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/DCSParserSpec.cxx
@@ -391,9 +391,17 @@ void ITSDCSParser::writeChipInfo(
 //////////////////////////////////////////////////////////////////////////////
 void ITSDCSParser::pushToCCDB(ProcessingContext& pc)
 {
-  // Timestamps for CCDB entry
-  long tstart = o2::ccdb::getCurrentTimestamp();
-  long tend = tstart + 365L * 24 * 3600 * 1000;
+  // Timestamps for CCDB entry: retireve run start/stop times from CCDB
+  //long tstart = o2::ccdb::getCurrentTimestamp();
+  //long tend = tstart + 365L * 24 * 3600 * 1000;
+  auto api = o2::ccdb::CcdbApi();
+  // Initialize empty metadata object for search
+  auto runInfoMD = std::map<std::string, std::string>();
+  TFile* ccdbObj = (TFile*) api.retrieve("RCT/Info/RunInformation", runInfoMD, this->mRunNumber);
+  // Extract metadata from retrieved object
+  runInfoMD = *(api.retrieveMetaInfo(*ccdbObj));
+  long tstart = std::stol(runInfoMD["SOR"]);
+  long tend = std::stol(runInfoMD["EOR"]);
 
   auto class_name = o2::utils::MemFileHelper::getClassName(mConfigDCS);
 

--- a/Detectors/ITSMFT/ITS/workflow/src/DCSParserSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/DCSParserSpec.cxx
@@ -76,6 +76,11 @@ void ITSDCSParser::run(ProcessingContext& pc)
     this->mConfigDCS.clear();
   }
 
+  // Reset saved information for the next EOR file
+  this->mRunNumber = UNSET_INT;
+  this->mConfigVersion = UNSET_INT;
+  this->mRunType = UNSET_SHORT;
+
   return;
 }
 
@@ -204,7 +209,7 @@ void ITSDCSParser::updateAndCheck(int& memValue, const int newValue)
     memValue = newValue;
   } else if (memValue != newValue) {
     // Different value received than the one saved in memory -- throw error
-    throw newValue;
+    throw std::runtime_error(fmt::format("New value {} differs from old value {}", newValue, memValue));
   }
 
   return;
@@ -219,7 +224,7 @@ void ITSDCSParser::updateAndCheck(short int& memValue, const short int newValue)
     memValue = newValue;
   } else if (memValue != newValue) {
     // Different value received than the one saved in memory -- throw error
-    throw newValue;
+    throw std::runtime_error(fmt::format("New value {} differs from old value {}", newValue, memValue));
   }
 
   return;


### PR DESCRIPTION
The ITS DCS parser now retrieves the SOR / EOR information for setting the validity time in the submitted CCDB entry. 