### PR TITLE
FIT: add definitions for new DCS DPs

### DIFF
--- a/Detectors/FIT/FDD/dcsmonitoring/macros/makeFDDCCDBEntryForDCS.C
+++ b/Detectors/FIT/FDD/dcsmonitoring/macros/makeFDDCCDBEntryForDCS.C
@@ -15,6 +15,7 @@
 /// \author Andreas Molander <andreas.molander@cern.ch>, University of Jyvaskyla, Finland
 
 #include "CCDB/CcdbApi.h"
+#include "CCDB/CCDBTimeStampUtils.h"
 #include "DetectorsDCS/AliasExpander.h"
 #include "DetectorsDCS/DeliveryType.h"
 #include "DetectorsDCS/DataPointIdentifier.h"
@@ -43,8 +44,17 @@ int makeFDDCCDBEntryForDCS(const std::string ccdbUrl = "http://localhost:8080",
                                          "FDD/PM/SIDE_C/LAYER1/PMT_1_[0..3]/ADC[0,1]_BASELINE",
                                          "FDD/PM/SIDE_A/LAYER2/PMT_2_[0..3]/ADC[0,1]_BASELINE",
                                          "FDD/PM/SIDE_A/LAYER3/PMT_3_[0..3]/ADC[0,1]_BASELINE"};
+  std::vector<std::string> aliasesRates = {"FDD/Trigger1_Central/CNT_RATE",
+                                           "FDD/Trigger2_SemiCentral/CNT_RATE",
+                                           "FDD/Trigger3_Vertex/CNT_RATE",
+                                           "FDD/Trigger4_OrC/CNT_RATE",
+                                           "FDD/Trigger5_OrA/CNT_RATE",
+                                           "FDD/Background/[0..9]/CNT_RATE",
+                                           "FDD/Background/[A,B,C,D,E,F,G,H]/CNT_RATE"};
+
   std::vector<std::string> expAliasesHV = o2::dcs::expandAliases(aliasesHV);
   std::vector<std::string> expAliasesADC = o2::dcs::expandAliases(aliasesADC);
+  std::vector<std::string> expAliasesRates = o2::dcs::expandAliases(aliasesRates);
 
   LOG(info) << "DCS DP IDs:";
 
@@ -59,6 +69,11 @@ int makeFDDCCDBEntryForDCS(const std::string ccdbUrl = "http://localhost:8080",
     dpid2DataDesc[dpIdTmp] = "FDDDATAPOINTS";
     LOG(info) << dpIdTmp;
   }
+  for (size_t i = 0; i < expAliasesRates.size(); i++) {
+    DPID::FILL(dpIdTmp, expAliasesRates[i], o2::dcs::DeliveryType::DPVAL_DOUBLE);
+    dpid2DataDesc[dpIdTmp] = "FDDDATAPOINTS";
+    LOG(info) << dpIdTmp;
+  }
 
   LOG(info) << "Total number of DPs: " << dpid2DataDesc.size();
 
@@ -68,7 +83,7 @@ int makeFDDCCDBEntryForDCS(const std::string ccdbUrl = "http://localhost:8080",
     o2::ccdb::CcdbApi api;
     api.init(ccdbUrl);
     std::map<std::string, std::string> metadata;
-    long ts = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+    long ts = o2::ccdb::getCurrentTimestamp();
     api.storeAsTFileAny(&dpid2DataDesc, ccdbPath, metadata, ts, 99999999999999);
   }
 

--- a/Detectors/FIT/FDD/dcsmonitoring/src/FDDDCSDataProcessor.cxx
+++ b/Detectors/FIT/FDD/dcsmonitoring/src/FDDDCSDataProcessor.cxx
@@ -37,13 +37,24 @@ std::vector<o2::dcs::DataPointIdentifier> o2::fdd::FDDDCSDataProcessor::getHardC
                                          "FDD/PM/SIDE_C/LAYER1/PMT_1_[0..3]/ADC[0,1]_BASELINE",
                                          "FDD/PM/SIDE_A/LAYER2/PMT_2_[0..3]/ADC[0,1]_BASELINE",
                                          "FDD/PM/SIDE_A/LAYER3/PMT_3_[0..3]/ADC[0,1]_BASELINE"};
+  std::vector<std::string> aliasesRates = {"FDD/Trigger1_Central/CNT_RATE",
+                                           "FDD/Trigger2_SemiCentral/CNT_RATE",
+                                           "FDD/Trigger3_Vertex/CNT_RATE",
+                                           "FDD/Trigger4_OrC/CNT_RATE",
+                                           "FDD/Trigger5_OrA/CNT_RATE",
+                                           "FDD/Background/[0..9]/CNT_RATE",
+                                           "FDD/Background/[A,B,C,D,E,F,G,H]/CNT_RATE"};
   std::vector<std::string> expAliasesHV = o2::dcs::expandAliases(aliasesHV);
   std::vector<std::string> expAliasesADC = o2::dcs::expandAliases(aliasesADC);
+  std::vector<std::string> expAliasesRates = o2::dcs::expandAliases(aliasesRates);
   for (const auto& i : expAliasesHV) {
     vect.emplace_back(i, o2::dcs::DPVAL_DOUBLE);
   }
   for (const auto& i : expAliasesADC) {
     vect.emplace_back(i, o2::dcs::DPVAL_UINT);
+  }
+  for (const auto& i : expAliasesRates) {
+    vect.emplace_back(i, o2::dcs::DPVAL_DOUBLE);
   }
   return vect;
 }

--- a/Detectors/FIT/FDD/dcsmonitoring/workflow/fdd-dcs-sim-workflow.cxx
+++ b/Detectors/FIT/FDD/dcsmonitoring/workflow/fdd-dcs-sim-workflow.cxx
@@ -20,22 +20,25 @@
 o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& configcontext)
 {
   std::vector<o2::dcs::test::HintType> dphints;
-  // for testing, we use less DPs than the official ones
   dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FDD/SIDE_A/HV_A9/[I,V]MON", 250, 350});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FDD/SIDE_C/HV_C[9,32]/[I,V]MON", 250, 350});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FDD/SIDE_C/LAYER0/PMT_0_[0..3]/[I,V]MON", 250, 350});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FDD/SIDE_C/LAYER1/PMT_1_[0..3]/[I,V]MON", 250, 350});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FDD/SIDE_A/LAYER2/PMT_2_[0..3]/[I,V]MON", 250, 350});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FDD/SIDE_A/LAYER3/PMT_3_[0..3]/[I,V]MON", 250, 350});
   dphints.emplace_back(o2::dcs::test::DataPointHint<uint>{"FDD/PM/SIDE_A/PMT_A_9/ADC[0,1]_BASELINE", 30, 150});
-  // Official list
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FDD/SIDE_A/HV_A9/[I,V]MON", 250, 350});
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FDD/SIDE_C/HV_C[9,32]/[I,V]MON", 250, 350});
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FDD/SIDE_C/LAYER0/PMT_0_[0..3]/[I,V]MON", 250, 350});
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FDD/SIDE_C/LAYER1/PMT_1_[0..3]/[I,V]MON", 250, 350});
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FDD/SIDE_A/LAYER2/PMT_2_[0..3]/[I,V]MON", 250, 350});
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FDD/SIDE_A/LAYER3/PMT_3_[0..3]/[I,V]MON", 250, 350});
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<uint>{"FDD/PM/SIDE_A/PMT_A_9/ADC[0,1]_BASELINE", 30, 150});
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<uint>{"FDD/PM/SIDE_C/PMT_C_[9,32]/ADC[0,1]_BASELINE", 30, 150});
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<uint>{"FDD/PM/SIDE_C/LAYER0/PMT_0_[0..3]/ADC[0,1]_BASELINE", 30, 150});
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<uint>{"FDD/PM/SIDE_C/LAYER1/PMT_1_[0..3]/ADC[0,1]_BASELINE", 30, 150});
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<uint>{"FDD/PM/SIDE_A/LAYER2/PMT_2_[0..3]/ADC[0,1]_BASELINE", 30, 150});
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<uint>{"FDD/PM/SIDE_A/LAYER3/PMT_3_[0..3]/ADC[0,1]_BASELINE", 30, 150});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<uint>{"FDD/PM/SIDE_C/PMT_C_[9,32]/ADC[0,1]_BASELINE", 30, 150});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<uint>{"FDD/PM/SIDE_C/LAYER0/PMT_0_[0..3]/ADC[0,1]_BASELINE", 30, 150});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<uint>{"FDD/PM/SIDE_C/LAYER1/PMT_1_[0..3]/ADC[0,1]_BASELINE", 30, 150});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<uint>{"FDD/PM/SIDE_A/LAYER2/PMT_2_[0..3]/ADC[0,1]_BASELINE", 30, 150});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<uint>{"FDD/PM/SIDE_A/LAYER3/PMT_3_[0..3]/ADC[0,1]_BASELINE", 30, 150});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FDD/Trigger1_Central/CNT_RATE", 0, 5000000});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FDD/Trigger2_SemiCentral/CNT_RATE", 0, 5000000});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FDD/Trigger3_Vertex/CNT_RATE", 0, 5000000});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FDD/Trigger4_OrC/CNT_RATE", 0, 5000000});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FDD/Trigger5_OrA/CNT_RATE", 0, 5000000});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FDD/Background/[0..9]/CNT_RATE", 0, 50000});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FDD/Background/[A,B,C,D,E,F,G,H]/CNT_RATE", 0, 50000});
 
   o2::framework::WorkflowSpec specs;
   specs.emplace_back(o2::dcs::test::getDCSRandomDataGeneratorSpec(dphints, "FDD"));

--- a/Detectors/FIT/FT0/dcsmonitoring/src/FT0DCSDataProcessor.cxx
+++ b/Detectors/FIT/FT0/dcsmonitoring/src/FT0DCSDataProcessor.cxx
@@ -41,13 +41,24 @@ std::vector<o2::dcs::DataPointIdentifier> o2::ft0::FT0DCSDataProcessor::getHardC
                                         "FT0/HV/FT0_C/MCP_F[2..5]/actual/iMon",
                                         "FT0/HV/MCP_LC/actual/iMon"};
   std::string aliasesADC = "FT0/PM/channel[000..211]/actual/ADC[0..1]_BASELINE";
+  std::vector<std::string> aliasesRates = {"FT0/Trigger1_Central/CNT_RATE",
+                                           "FT0/Trigger2_SemiCentral/CNT_RATE",
+                                           "FT0/Trigger3_Vertex/CNT_RATE",
+                                           "FT0/Trigger4_OrC/CNT_RATE",
+                                           "FT0/Trigger5_OrA/CNT_RATE",
+                                           "FT0/Background/[0..9]/CNT_RATE",
+                                           "FT0/Background/[A,B,C,D,E,F,G,H]/CNT_RATE"};
   std::vector<std::string> expAliasesHV = o2::dcs::expandAliases(aliasesHV);
   std::vector<std::string> expAliasesADC = o2::dcs::expandAlias(aliasesADC);
+  std::vector<std::string> expAliasesRates = o2::dcs::expandAliases(aliasesRates);
   for (const auto& i : expAliasesHV) {
     vect.emplace_back(i, o2::dcs::DPVAL_DOUBLE);
   }
   for (const auto& i : expAliasesADC) {
     vect.emplace_back(i, o2::dcs::DPVAL_UINT);
+  }
+  for (const auto& i : expAliasesRates) {
+    vect.emplace_back(i, o2::dcs::DPVAL_DOUBLE);
   }
   return vect;
 }

--- a/Detectors/FIT/FT0/dcsmonitoring/workflow/ft0-dcs-sim-workflow.cxx
+++ b/Detectors/FIT/FT0/dcsmonitoring/workflow/ft0-dcs-sim-workflow.cxx
@@ -20,26 +20,29 @@
 o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& configcontext)
 {
   std::vector<o2::dcs::test::HintType> dphints;
-  // for testing, we use less DPs than the official ones
-  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/HV/FT0_A/MCP_A[1..2]/actual/iMon", 250, 350});
-  dphints.emplace_back(o2::dcs::test::DataPointHint<uint>{"FT0/PM/channel[000..001]/actual/ADC[0..1]_BASELINE", 30, 150});
-  // Official list
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/HV/FT0_A/MCP_A[1..5]/actual/iMon", 250, 350});
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/HV/FT0_A/MCP_B[1..5]/actual/iMon", 250, 350});
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/HV/FT0_A/MCP_C[1..2]/actual/iMon", 250, 350});
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/HV/FT0_A/MCP_C[4..5]/actual/iMon", 250, 350});
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/HV/FT0_A/MCP_D[1..5]/actual/iMon", 250, 350});
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/HV/FT0_A/MCP_E[1..5]/actual/iMon", 250, 350});
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/HV/FT0_C/MCP_A[2..5]/actual/iMon", 250, 350});
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/HV/FT0_C/MCP_B[1..6]/actual/iMon", 250, 350});
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/HV/FT0_C/MCP_C[1..2]/actual/iMon", 250, 350});
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/HV/FT0_C/MCP_C[5..6]/actual/iMon", 250, 350});
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/HV/FT0_C/MCP_D[1..2]/actual/iMon", 250, 350});
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/HV/FT0_C/MCP_D[5..6]/actual/iMon", 250, 350});
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/HV/FT0_C/MCP_E[1..6]/actual/iMon", 250, 350});
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/HV/FT0_C/MCP_F[2..5]/actual/iMon", 250, 350});
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/HV/MCP_LC/actual/iMon", 250, 350});
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<uint>{"FT0/PM/channel[000..211]/actual/ADC[0..1]_BASELINE", 30, 150});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/HV/FT0_A/MCP_A[1..5]/actual/iMon", 250, 350});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/HV/FT0_A/MCP_B[1..5]/actual/iMon", 250, 350});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/HV/FT0_A/MCP_C[1..2]/actual/iMon", 250, 350});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/HV/FT0_A/MCP_C[4..5]/actual/iMon", 250, 350});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/HV/FT0_A/MCP_D[1..5]/actual/iMon", 250, 350});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/HV/FT0_A/MCP_E[1..5]/actual/iMon", 250, 350});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/HV/FT0_C/MCP_A[2..5]/actual/iMon", 250, 350});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/HV/FT0_C/MCP_B[1..6]/actual/iMon", 250, 350});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/HV/FT0_C/MCP_C[1..2]/actual/iMon", 250, 350});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/HV/FT0_C/MCP_C[5..6]/actual/iMon", 250, 350});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/HV/FT0_C/MCP_D[1..2]/actual/iMon", 250, 350});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/HV/FT0_C/MCP_D[5..6]/actual/iMon", 250, 350});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/HV/FT0_C/MCP_E[1..6]/actual/iMon", 250, 350});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/HV/FT0_C/MCP_F[2..5]/actual/iMon", 250, 350});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/HV/MCP_LC/actual/iMon", 250, 350});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<uint>{"FT0/PM/channel[000..211]/actual/ADC[0..1]_BASELINE", 30, 150});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/Trigger1_Central/CNT_RATE", 0, 5000000});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/Trigger2_SemiCentral/CNT_RATE", 0, 5000000});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/Trigger3_Vertex/CNT_RATE", 0, 5000000});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/Trigger4_OrC/CNT_RATE", 0, 5000000});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/Trigger5_OrA/CNT_RATE", 0, 5000000});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/Background/[0..9]/CNT_RATE", 0, 50000});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FT0/Background/[A,B,C,D,E,F,G,H]/CNT_RATE", 0, 50000});
 
   o2::framework::WorkflowSpec specs;
   specs.emplace_back(o2::dcs::test::getDCSRandomDataGeneratorSpec(dphints, "FT0"));

--- a/Detectors/FIT/FV0/dcsmonitoring/macros/makeFV0CCDBEntryForDCS.C
+++ b/Detectors/FIT/FV0/dcsmonitoring/macros/makeFV0CCDBEntryForDCS.C
@@ -15,6 +15,7 @@
 /// \author Andreas Molander <andreas.molander@cern.ch>, University of Jyvaskyla, Finland
 
 #include "CCDB/CcdbApi.h"
+#include "CCDB/CCDBTimeStampUtils.h"
 #include "DetectorsDCS/AliasExpander.h"
 #include "DetectorsDCS/DeliveryType.h"
 #include "DetectorsDCS/DataPointIdentifier.h"
@@ -43,8 +44,17 @@ int makeFV0CCDBEntryForDCS(const std::string ccdbUrl = "http://localhost:8080",
   std::vector<std::string> aliasesADC = {"FV0/PM/S[A,B,C,D,E,F,G,H][1..4]/actual/ADC[0,1]_BASELINE",
                                          "FV0/PM/S[A,B,C,D,E,F,G,H][51,52]/actual/ADC[0,1]_BASELINE",
                                          "FV0/PM/SREF/actual/ADC[0,1]_BASELINE"};
+
+  std::vector<std::string> aliasesRates = {"FV0/Trigger1_Charge/CNT_RATE",
+                                           "FV0/Trigger2_Nchannels/CNT_RATE",
+                                           "FV0/Trigger3_InnerRings/CNT_RATE",
+                                           "FV0/Trigger4_OuterRings/CNT_RATE",
+                                           "FV0/Trigger5_OrA/CNT_RATE",
+                                           "FV0/Background/[0..9]/CNT_RATE",
+                                           "FV0/Background/[A,B,C,D,E,F,G,H]/CNT_RATE"};
   std::vector<std::string> expAliasesHV = o2::dcs::expandAliases(aliasesHV);
   std::vector<std::string> expAliasesADC = o2::dcs::expandAliases(aliasesADC);
+  std::vector<std::string> expAliasesRates = o2::dcs::expandAliases(aliasesRates);
 
   LOG(info) << "DCS DP IDs:";
 
@@ -59,6 +69,11 @@ int makeFV0CCDBEntryForDCS(const std::string ccdbUrl = "http://localhost:8080",
     dpid2DataDesc[dpIdTmp] = "FV0DATAPOINTS";
     LOG(info) << dpIdTmp;
   }
+  for (size_t i = 0; i < expAliasesRates.size(); i++) {
+    DPID::FILL(dpIdTmp, expAliasesRates[i], o2::dcs::DeliveryType::DPVAL_DOUBLE);
+    dpid2DataDesc[dpIdTmp] = "FV0DATAPOINTS";
+    LOG(info) << dpIdTmp;
+  }
 
   LOG(info) << "Total number of DPs: " << dpid2DataDesc.size();
 
@@ -68,7 +83,7 @@ int makeFV0CCDBEntryForDCS(const std::string ccdbUrl = "http://localhost:8080",
     o2::ccdb::CcdbApi api;
     api.init(ccdbUrl);
     std::map<std::string, std::string> metadata;
-    long ts = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+    long ts = o2::ccdb::getCurrentTimestamp();
     api.storeAsTFileAny(&dpid2DataDesc, ccdbPath, metadata, ts, 99999999999999);
   }
 

--- a/Detectors/FIT/FV0/dcsmonitoring/src/FV0DCSDataProcessor.cxx
+++ b/Detectors/FIT/FV0/dcsmonitoring/src/FV0DCSDataProcessor.cxx
@@ -31,13 +31,24 @@ std::vector<o2::dcs::DataPointIdentifier> o2::fv0::FV0DCSDataProcessor::getHardC
   std::vector<std::string> aliasesADC = {"FV0/PM/S[A,B,C,D,E,F,G,H][1..4]/actual/ADC[0,1]_BASELINE",
                                          "FV0/PM/S[A,B,C,D,E,F,G,H][51,52]/actual/ADC[0,1]_BASELINE",
                                          "FV0/PM/SREF/actual/ADC[0,1]_BASELINE"};
+  std::vector<std::string> aliasesRates = {"FV0/Trigger1_Charge/CNT_RATE",
+                                           "FV0/Trigger2_Nchannels/CNT_RATE",
+                                           "FV0/Trigger3_InnerRings/CNT_RATE",
+                                           "FV0/Trigger4_OuterRings/CNT_RATE",
+                                           "FV0/Trigger5_OrA/CNT_RATE",
+                                           "FV0/Background/[0..9]/CNT_RATE",
+                                           "FV0/Background/[A,B,C,D,E,F,G,H]/CNT_RATE"};
   std::vector<std::string> expAliasesHV = o2::dcs::expandAliases(aliasesHV);
   std::vector<std::string> expAliasesADC = o2::dcs::expandAliases(aliasesADC);
+  std::vector<std::string> expAliasesRates = o2::dcs::expandAliases(aliasesRates);
   for (const auto& i : expAliasesHV) {
     vect.emplace_back(i, o2::dcs::DPVAL_DOUBLE);
   }
   for (const auto& i : expAliasesADC) {
     vect.emplace_back(i, o2::dcs::DPVAL_UINT);
+  }
+  for (const auto& i : expAliasesRates) {
+    vect.emplace_back(i, o2::dcs::DPVAL_DOUBLE);
   }
   return vect;
 }

--- a/Detectors/FIT/FV0/dcsmonitoring/workflow/fv0-dcs-sim-workflow.cxx
+++ b/Detectors/FIT/FV0/dcsmonitoring/workflow/fv0-dcs-sim-workflow.cxx
@@ -20,16 +20,19 @@
 o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& configcontext)
 {
   std::vector<o2::dcs::test::HintType> dphints;
-  // for testing, we use less DPs than the official ones
-  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FV0/HV/SA[1..2]/actual/iMon", 250, 350});
-  dphints.emplace_back(o2::dcs::test::DataPointHint<uint>{"FV0/PM/SA[1..2]/actual/ADC0_BASELINE", 30, 150});
-  // Official list
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FV0/HV/S[A,B,C,D,E,F,G,H][1..4]/actual/iMon", 250, 350});
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FV0/HV/S[A,B,C,D,E,F,G,H][51,52]/actual/iMon", 250, 350});
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FV0/HV/SREF/actual/iMon", 250, 350});
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<uint>{"FV0/PM/S[A,B,C,D,E,F,G,H][1..4]/actual/ADC[0,1]_BASELINE", 30, 150});
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<uint>{"FV0/PM/S[A,B,C,D,E,F,G,H][51,52]/actual/ADC[0,1]_BASELINE", 30, 150});
-  // dphints.emplace_back(o2::dcs::test::DataPointHint<uint>{"FV0/PM/SREF/actual/ADC[0,1]_BASELINE", 30, 150});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FV0/HV/S[A,B,C,D,E,F,G,H][1..4]/actual/iMon", 250, 350});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FV0/HV/S[A,B,C,D,E,F,G,H][51,52]/actual/iMon", 250, 350});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FV0/HV/SREF/actual/iMon", 250, 350});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<uint>{"FV0/PM/S[A,B,C,D,E,F,G,H][1..4]/actual/ADC[0,1]_BASELINE", 30, 150});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<uint>{"FV0/PM/S[A,B,C,D,E,F,G,H][51,52]/actual/ADC[0,1]_BASELINE", 30, 150});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<uint>{"FV0/PM/SREF/actual/ADC[0,1]_BASELINE", 30, 150});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FV0/Trigger1_Charge/CNT_RATE", 0, 5000000});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FV0/Trigger2_Nchannels/CNT_RATE", 0, 5000000});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FV0/Trigger3_InnerRings/CNT_RATE", 0, 5000000});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FV0/Trigger4_OuterRings/CNT_RATE", 0, 5000000});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FV0/Trigger5_OrA/CNT_RATE", 0, 5000000});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FV0/Background/[0..9]/CNT_RATE", 0, 50000});
+  dphints.emplace_back(o2::dcs::test::DataPointHint<double>{"FV0/Background/[A,B,C,D,E,F,G,H]/CNT_RATE", 0, 50000});
 
   o2::framework::WorkflowSpec specs;
   specs.emplace_back(o2::dcs::test::getDCSRandomDataGeneratorSpec(dphints, "FV0"));


### PR DESCRIPTION
Trigger and background rates in DCS are configured for ADAPOS. Include these in CCDB upload workflows and related macros.