### PR TITLE
Revert "DPL Analysis: do not use string lookup for finding columns (#9710)"

### DIFF
--- a/Framework/Core/include/Framework/ASoAHelpers.h
+++ b/Framework/Core/include/Framework/ASoAHelpers.h
@@ -94,7 +94,7 @@ std::vector<BinningIndex> groupTable(const T& table, const BP<Cs...>& binningPol
 
   auto persistentColumns = typename BP<Cs...>::persistent_columns_t{};
   constexpr auto persistentColumnsCount = pack_size(persistentColumns);
-  auto arrowColumns = o2::soa::row_helpers::getArrowColumnsTyped(table, persistentColumns);
+  auto arrowColumns = o2::soa::row_helpers::getArrowColumns(arrowTable, persistentColumns);
   auto chunksCount = arrowColumns[0]->num_chunks();
   for (int i = 1; i < persistentColumnsCount; i++) {
     if (arrowColumns[i]->num_chunks() != chunksCount) {
@@ -103,7 +103,7 @@ std::vector<BinningIndex> groupTable(const T& table, const BP<Cs...>& binningPol
   }
 
   for (uint64_t ci = 0; ci < chunksCount; ++ci) {
-    auto chunks = o2::soa::row_helpers::getChunksFromColumns(arrowColumns, ci);
+    auto chunks = o2::soa::row_helpers::getChunks(arrowTable, persistentColumns, ci);
     auto chunkLength = std::get<0>(chunks)->length();
     for_<persistentColumnsCount - 1>([&chunks, &chunkLength](auto i) {
       if (std::get<i.value + 1>(chunks)->length() != chunkLength) {

--- a/Framework/Core/src/ASoA.cxx
+++ b/Framework/Core/src/ASoA.cxx
@@ -101,6 +101,15 @@ std::shared_ptr<arrow::Table> ArrowHelpers::concatTables(std::vector<std::shared
   return result;
 }
 
+arrow::ChunkedArray* getIndexFromLabel(arrow::Table* table, const char* label)
+{
+  auto index = table->schema()->GetAllFieldIndices(label);
+  if (index.empty() == true) {
+    o2::framework::throw_error(o2::framework::runtime_error_f("Unable to find column with label %s", label));
+  }
+  return table->column(index[0]).get();
+}
+
 void notBoundTable(const char* tableName)
 {
   throw o2::framework::runtime_error_f("Index pointing to %s is not bound! Did you subscribe to the table?", tableName);

--- a/Framework/Core/test/test_IndexBuilder.cxx
+++ b/Framework/Core/test/test_IndexBuilder.cxx
@@ -114,7 +114,7 @@ BOOST_AUTO_TEST_CASE(TestIndexBuilder)
 
   auto t6 = IndexBuilder<Sparse>::indexBuilder<Points>("test3", {t2, t1, t3, t4}, typename IDX2s::persistent_columns_t{}, o2::framework::pack<Distances, Points, Flags, Categorys>{});
   BOOST_REQUIRE_EQUAL(t6->num_rows(), st2.size());
-  IDX2s idxs{t6};
+  IDXs idxs{t6};
   std::array<int, 7> fs{0, 1, 2, -1, -1, 4, -1};
   std::array<int, 7> cs{0, 1, 2, -1, 5, 6, -1};
   idxs.bindExternalIndices(&st1, &st2, &st3, &st4);


### PR DESCRIPTION
This reverts commit f5c0177a583f317619011e60429b5c0111868907.

It was found that some Run 2 converted data has order of branches in some trees that is different from the corresponding order of columns in the data model. This restores string lookup to prevent incorrect data access in similar cases. 