### PR TITLE
TPC  GainMap using tracks small optimizations

### DIFF
--- a/Detectors/TPC/calibration/include/TPCCalibration/CalibPadGainTracksBase.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/CalibPadGainTracksBase.h
@@ -57,6 +57,9 @@ class CalibPadGainTracksBase
   /// initializing CalPad object for std dev map
   void initCalPadStdDevMemory() { mSigmaMap = std::make_unique<CalPad>("SigmaMap"); }
 
+  /// initializing CalPad object for std dev map
+  void initCalPadStat() { mNClMap = std::make_unique<CalPad>("NClustersMap"); }
+
   /// copy constructor
   CalibPadGainTracksBase(const CalibPadGainTracksBase& other) : mPadHistosDet(std::make_unique<DataTHistos>(*other.mPadHistosDet)), mGainMap(std::make_unique<CalPad>(*other.mGainMap)) {}
 
@@ -84,7 +87,8 @@ class CalibPadGainTracksBase
   /// \param maxRelgain maximum accpeted relative gain (if the gain is above this value it will be set to 1)
   /// \param low lower truncation range for calculating the rel gain
   /// \param high upper truncation range
-  void finalize(const int minEntries = 10, const float minRelgain = 0.1f, const float maxRelgain = 2.f, const float low = 0.05f, const float high = 0.6f);
+  /// \param minStDev to exlude outliers (histograms with a very narrow distributions) a min std dev cut is used
+  void finalize(const int minEntries = 10, const float minRelgain = 0.1f, const float maxRelgain = 2.f, const float low = 0.05f, const float high = 0.6f, const float minStDev = 0.01);
 
   /// returns calpad containing pad-by-pad histograms
   const auto& getHistos() const { return mPadHistosDet; }
@@ -97,6 +101,9 @@ class CalibPadGainTracksBase
 
   /// \return returns the gainmap object
   const CalPad& getSigmaMap() const { return *mSigmaMap; }
+
+  /// \return returns the number of tracks per pad map
+  const CalPad& getNTracksMap() const { return *mNClMap; }
 
   /// \return return histogram which is used to extract the gain
   /// \param sector sector of the TPC
@@ -125,6 +132,13 @@ class CalibPadGainTracksBase
   /// \param maxZ max z value for drawing (if minZ > maxZ automatic z axis)
   void drawExtractedGainMapSide(const o2::tpc::Side side, const std::string filename = "GainMapSide.pdf", const float minZ = 0, const float maxZ = -1) const { drawExtractedGainMapHelper(true, 0, side == Side::A ? Sector(0) : Sector(Sector::MAXSECTOR - 1), filename, minZ, maxZ); }
 
+  /// draw number of clusters side
+  /// \param side side of the TPC which will be drawn
+  /// \param filename name of the output file. If empty the canvas is drawn
+  /// \param minZ min z value for drawing (if minZ > maxZ automatic z axis)
+  /// \param maxZ max z value for drawing (if minZ > maxZ automatic z axis)
+  void drawNClustersMapSide(const o2::tpc::Side side, const std::string filename = "NClustersMapSide.pdf", const float minZ = 0, const float maxZ = -1) const { drawExtractedGainMapHelper(true, 2, side == Side::A ? Sector(0) : Sector(Sector::MAXSECTOR - 1), filename, minZ, maxZ); }
+
   /// draw sigma map sector
   /// \param sector sector which will be drawn
   /// \param norm normalizing the sigma to the extracted gain map
@@ -140,6 +154,13 @@ class CalibPadGainTracksBase
   /// \param minZ min z value for drawing (if minZ > maxZ automatic z axis)
   /// \param maxZ max z value for drawing (if minZ > maxZ automatic z axis)
   void drawExtractedSigmaMapSide(const o2::tpc::Side side, const bool norm = false, const std::string filename = "StdDevMapSide.pdf", const float minZ = 0, const float maxZ = -1) const { drawExtractedGainMapHelper(true, 1, side == Side::A ? Sector(0) : Sector(Sector::MAXSECTOR - 1), filename, minZ, maxZ, norm); }
+
+  /// draw number of clusters sector
+  /// \param sector sector which will be drawn
+  /// \param filename name of the output file. If empty the canvas is drawn
+  /// \param minZ min z value for drawing (if minZ > maxZ automatic z axis)
+  /// \param maxZ max z value for drawing (if minZ > maxZ automatic z axis)
+  void drawNClustersMapSector(const int sector, const std::string filename = "NClustersMapSector.pdf", const float minZ = 0, const float maxZ = -1) const { drawExtractedGainMapHelper(false, 2, sector, filename, minZ, maxZ, false); }
 
   /// draw gain map using painter functionality
   TCanvas* drawExtractedGainMapPainter() const;
@@ -196,6 +217,7 @@ class CalibPadGainTracksBase
   std::unique_ptr<DataTHistos> mPadHistosDet; ///< Calibration object containing for each pad a histogram with normalized charge
   std::unique_ptr<CalPad> mGainMap;           ///< Extracted gain map from tracks
   std::unique_ptr<CalPad> mSigmaMap;          ///< standard deviation map
+  std::unique_ptr<CalPad> mNClMap;            ///< statistics (number of entries per pad)
   NormType mNormType = region;                ///< Normalization type for the extracted gain map
 
   /// Helper function for drawing the extracted gain map

--- a/Detectors/TPC/calibration/src/CalibratorPadGainTracks.cxx
+++ b/Detectors/TPC/calibration/src/CalibratorPadGainTracks.cxx
@@ -57,7 +57,7 @@ void CalibratorPadGainTracks::finalizeSlot(Slot& slot)
     }
   }
 
-  std::unordered_map<std::string, CalPad> cal({{"GainMap", extractedGainMap}, {"SigmaMap", calibPadGainTracks.getSigmaMap()}});
+  std::unordered_map<std::string, CalPad> cal({{"GainMap", extractedGainMap}, {"SigmaMap", calibPadGainTracks.getSigmaMap()}, {"NTracks", calibPadGainTracks.getNTracksMap()}});
   mCalibs.emplace_back(cal);
 
   if (mUseLastExtractedMapAsReference) {

--- a/Detectors/TPC/workflow/include/TPCWorkflow/CalibratorPadGainTracksSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/CalibratorPadGainTracksSpec.h
@@ -141,13 +141,13 @@ o2::framework::DataProcessorSpec getTPCCalibPadGainTracksSpec(const bool useLast
     Options{
       {"tf-per-slot", VariantType::UInt32, 100u, {"number of TFs per calibration time slot"}},
       {"max-delay", VariantType::UInt32, 0u, {"number of slots in past to consider"}},
-      {"min-entries", VariantType::Int, 0, {"minimum entries per pad-by-pad histogram which are required"}},
+      {"min-entries", VariantType::Int, 40, {"minimum entries per pad-by-pad histogram which are required"}},
       {"lowTrunc", VariantType::Float, 0.05f, {"lower truncation range for calculating the rel gain"}},
       {"upTrunc", VariantType::Float, 0.6f, {"upper truncation range for calculating the rel gain"}},
       {"minAcceptedRelgain", VariantType::Float, 0.1f, {"minimum accpeted relative gain (if the gain is below this value it will be set to 1)"}},
       {"maxAcceptedRelgain", VariantType::Float, 2.f, {"maximum accpeted relative gain (if the gain is above this value it will be set to 1)"}},
-      {"gainNorm", VariantType::Int, 2, {"normalization method for the extracted gain map: 0=no normalization, 1=median per stack, 2=median per region"}},
-      {"minEntriesMean", VariantType::Int, 10, {"minEntries minimum number of entries in pad-by-pad histogram to calculate the mean"}},
+      {"gainNorm", VariantType::Int, 1, {"normalization method for the extracted gain map: 0=no normalization, 1=median per stack, 2=median per region"}},
+      {"minEntriesMean", VariantType::Int, 40, {"minEntries minimum number of entries in pad-by-pad histogram to calculate the mean"}},
       {"file-dump", VariantType::Bool, false, {"directly write calibration to a file"}}}};
 }
 

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCCalibPadGainTracksSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCCalibPadGainTracksSpec.h
@@ -267,7 +267,7 @@ DataProcessorSpec getTPCCalibPadGainTracksSpec(const uint32_t publishAfterTFs, c
       {"reldEdxMin", VariantType::Int, 0, {"Minimum x coordinate of the histogram for Q/(dE/dx)"}},
       {"reldEdxMax", VariantType::Int, 3, {"Maximum x coordinate of the histogram for Q/(dE/dx)"}},
       {"underflowBin", VariantType::Bool, false, {"Using under flow bin"}},
-      {"overflowBin", VariantType::Bool, true, {"Using under flow bin"}},
+      {"overflowBin", VariantType::Bool, true, {"Using overflow flow bin"}},
       {"momMin", VariantType::Float, 0.3f, {"minimum momentum of the tracks which are used for the pad-by-pad gain map"}},
       {"momMax", VariantType::Float, 1.f, {"maximum momentum of the tracks which are used for the pad-by-pad gain map"}},
       {"etaMax", VariantType::Float, 1.f, {"maximum eta of the tracks which are used for the pad-by-pad gain map"}},


### PR DESCRIPTION
- storing number of clusters per pad
- adding sigma cut for outlier filtering
- optimising has enough data: Using the mean number of clusters per pad as reference
- changing default settings: normalize gain per stack, increase minimum number of clusters to avoid creation of empty objects