### PR TITLE
TRD: calibration: vDrift and ExB

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
@@ -67,7 +67,6 @@ constexpr int ADCBASELINE = 10;                                       ///< basel
 constexpr int TIMEBINS = 30;            ///< the number of time bins
 constexpr float MAXIMPACTANGLE = 25.f;  ///< the maximum impact angle for tracks relative to the TRD detector plane to be considered for vDrift and ExB calibration
 constexpr int NBINSANGLEDIFF = 25;      ///< the number of bins for the track angle used for the vDrift and ExB calibration based on the tracking
-constexpr double ANODEPLANE = 0.0335;   ///< distance of the TRD anode plane from the drift cathodes in [m]
 constexpr double VDRIFTDEFAULT = 1.546; ///< default value for vDrift
 constexpr double EXBDEFAULT = 0.0;      ///< default value for LorentzAngle
 

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
@@ -67,6 +67,7 @@ constexpr int ADCBASELINE = 10;                                       // baselin
 constexpr int TIMEBINS = 30;           // the number of time bins
 constexpr float MAXIMPACTANGLE = 25.f; // the maximum impact angle for tracks relative to the TRD detector plane to be considered for vDrift and ExB calibration
 constexpr int NBINSANGLEDIFF = 25;     // the number of bins for the track angle used for the vDrift and ExB calibration based on the tracking
+constexpr double ANODEPLANE = 0.0335; // distance of the TRD anode plane from the drift cathodes in [m]
 
 // Trigger parameters
 constexpr double READOUT_TIME = 3000;                  // the time the readout takes, as 30 TB = 3 micro-s.

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
@@ -64,10 +64,12 @@ constexpr float GRANULARITYTRKLSLOPE = 1.f / PADGRANULARITYTRKLSLOPE; ///< granu
 constexpr int ADCBASELINE = 10;                                       ///< baseline in ADC units
 
 // OS: Should this not be flexible for example in case of Kr calib?
-constexpr int TIMEBINS = 30;           ///< the number of time bins
-constexpr float MAXIMPACTANGLE = 25.f; ///< the maximum impact angle for tracks relative to the TRD detector plane to be considered for vDrift and ExB calibration
-constexpr int NBINSANGLEDIFF = 25;     ///< the number of bins for the track angle used for the vDrift and ExB calibration based on the tracking
-constexpr double ANODEPLANE = 0.0335;  ///< distance of the TRD anode plane from the drift cathodes in [m]
+constexpr int TIMEBINS = 30;            ///< the number of time bins
+constexpr float MAXIMPACTANGLE = 25.f;  ///< the maximum impact angle for tracks relative to the TRD detector plane to be considered for vDrift and ExB calibration
+constexpr int NBINSANGLEDIFF = 25;      ///< the number of bins for the track angle used for the vDrift and ExB calibration based on the tracking
+constexpr double ANODEPLANE = 0.0335;   ///< distance of the TRD anode plane from the drift cathodes in [m]
+constexpr double VDRIFTDEFAULT = 1.546; ///< default value for vDrift
+constexpr double EXBDEFAULT = 0.0;      ///< default value for LorentzAngle
 
 // Trigger parameters
 constexpr double READOUT_TIME = 3000;                  ///< the time the readout takes, as 30 TB = 3 micro-s.

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
@@ -22,76 +22,76 @@ namespace trd
 {
 namespace constants
 {
-constexpr int NSECTOR = 18;          // the number of sectors
-constexpr int NSTACK = 5;            // the number of stacks per sector
-constexpr int NLAYER = 6;            // the number of layers
-constexpr int NCHAMBERPERSEC = 30;   // the number of chambers per sector
-constexpr int NHCPERSEC = 60;        // the number of half-chambers per sector
-constexpr int MAXCHAMBER = 540;      // the maximum number of installed chambers
-constexpr int MAXHALFCHAMBER = 1080; // the maximum number of installed half-chambers
-constexpr int NCHAMBER = 521;        // the number of chambers actually installed
-constexpr int NHALFCRU = 72;         // the number of half cru (link bundles)
-constexpr int NLINKSPERHALFCRU = 15; // the number of links per half cru or cru end point.
-constexpr int NLINKSPERCRU = 30;     // the number of links per CRU (two CRUs serve one supermodule)
-constexpr int NCRU = 36;             // the number of CRU we have
-constexpr int NFLP = 12;             // the number of FLP we have.
-constexpr int NCRUPERFLP = 3;        // the number of CRU per FLP
-constexpr int TRDLINKID = 15;        // hard coded link id, specific to TRD
+constexpr int NSECTOR = 18;          ///< the number of sectors
+constexpr int NSTACK = 5;            ///< the number of stacks per sector
+constexpr int NLAYER = 6;            ///< the number of layers
+constexpr int NCHAMBERPERSEC = 30;   ///< the number of chambers per sector
+constexpr int NHCPERSEC = 60;        ///< the number of half-chambers per sector
+constexpr int MAXCHAMBER = 540;      ///< the maximum number of installed chambers
+constexpr int MAXHALFCHAMBER = 1080; ///< the maximum number of installed half-chambers
+constexpr int NCHAMBER = 521;        ///< the number of chambers actually installed
+constexpr int NHALFCRU = 72;         ///< the number of half cru (link bundles)
+constexpr int NLINKSPERHALFCRU = 15; ///< the number of links per half cru or cru end point.
+constexpr int NLINKSPERCRU = 30;     ///< the number of links per CRU (two CRUs serve one supermodule)
+constexpr int NCRU = 36;             ///< the number of CRU we have
+constexpr int NFLP = 12;             ///< the number of FLP we have.
+constexpr int NCRUPERFLP = 3;        ///< the number of CRU per FLP
+constexpr int TRDLINKID = 15;        ///< hard coded link id, specific to TRD
 
-constexpr int NCOLUMN = 144; // the number of pad columns for each chamber
-constexpr int NROWC0 = 12;   // the number of pad rows for chambers of type C0 (installed in stack 2)
-constexpr int NROWC1 = 16;   // the number of pad rows for chambers of type C1 (installed in stacks 0, 1, 3 and 4)
+constexpr int NCOLUMN = 144; ///< the number of pad columns for each chamber
+constexpr int NROWC0 = 12;   ///< the number of pad rows for chambers of type C0 (installed in stack 2)
+constexpr int NROWC1 = 16;   ///< the number of pad rows for chambers of type C1 (installed in stacks 0, 1, 3 and 4)
 
-constexpr int NMCMROB = 16;     // the number of MCMs per ROB
-constexpr int NMCMHCMAX = 64;   // the maximum number of MCMs for one half chamber (C1 type)
-constexpr int NMCMROBINROW = 4; // the number of MCMs per ROB in row direction
-constexpr int NMCMROBINCOL = 4; // the number of MCMs per ROB in column direction
-constexpr int NROBC0 = 6;       // the number of ROBs per C0 chamber
-constexpr int NROBC1 = 8;       // the number of ROBs per C1 chamber
-constexpr int NADCMCM = 21;     // the number of ADC channels per MCM
-constexpr int NCOLMCM = 18;     // the number of pads per MCM
-constexpr int NCPU = 4;         // the number of CPUs inside the TRAP chip
-constexpr int NCHARGES = 3;     // the number of charges per tracklet (Q0/1/2)
+constexpr int NMCMROB = 16;     ///< the number of MCMs per ROB
+constexpr int NMCMHCMAX = 64;   ///< the maximum number of MCMs for one half chamber (C1 type)
+constexpr int NMCMROBINROW = 4; ///< the number of MCMs per ROB in row direction
+constexpr int NMCMROBINCOL = 4; ///< the number of MCMs per ROB in column direction
+constexpr int NROBC0 = 6;       ///< the number of ROBs per C0 chamber
+constexpr int NROBC1 = 8;       ///< the number of ROBs per C1 chamber
+constexpr int NADCMCM = 21;     ///< the number of ADC channels per MCM
+constexpr int NCOLMCM = 18;     ///< the number of pads per MCM
+constexpr int NCPU = 4;         ///< the number of CPUs inside the TRAP chip
+constexpr int NCHARGES = 3;     ///< the number of charges per tracklet (Q0/1/2)
 
 // the values below should come out of the TRAP config in the future
-constexpr int NBITSTRKLPOS = 11;                                      // number of bits for position in tracklet64 word
-constexpr int NBITSTRKLSLOPE = 8;                                     // number of bits for slope in tracklet64 word
-constexpr int ADDBITSHIFTSLOPE = 1 << 3;                              // in the TRAP the slope is shifted by 3 additional bits compared to the position
-constexpr int PADGRANULARITYTRKLPOS = 40;                             // tracklet position is stored in units of 1/40 pad
-constexpr int PADGRANULARITYTRKLSLOPE = 128;                          // tracklet deflection is stored in units of 1/128 pad per time bin
-constexpr float GRANULARITYTRKLPOS = 1.f / PADGRANULARITYTRKLPOS;     // granularity of position in tracklet64 word in pad-widths
-constexpr float GRANULARITYTRKLSLOPE = 1.f / PADGRANULARITYTRKLSLOPE; // granularity of slope in tracklet64 word in pads/timebin
-constexpr int ADCBASELINE = 10;                                       // baseline in ADC units
+constexpr int NBITSTRKLPOS = 11;                                      ///< number of bits for position in tracklet64 word
+constexpr int NBITSTRKLSLOPE = 8;                                     ///< number of bits for slope in tracklet64 word
+constexpr int ADDBITSHIFTSLOPE = 1 << 3;                              ///< in the TRAP the slope is shifted by 3 additional bits compared to the position
+constexpr int PADGRANULARITYTRKLPOS = 40;                             ///< tracklet position is stored in units of 1/40 pad
+constexpr int PADGRANULARITYTRKLSLOPE = 128;                          ///< tracklet deflection is stored in units of 1/128 pad per time bin
+constexpr float GRANULARITYTRKLPOS = 1.f / PADGRANULARITYTRKLPOS;     ///< granularity of position in tracklet64 word in pad-widths
+constexpr float GRANULARITYTRKLSLOPE = 1.f / PADGRANULARITYTRKLSLOPE; ///< granularity of slope in tracklet64 word in pads/timebin
+constexpr int ADCBASELINE = 10;                                       ///< baseline in ADC units
 
 // OS: Should this not be flexible for example in case of Kr calib?
-constexpr int TIMEBINS = 30;           // the number of time bins
-constexpr float MAXIMPACTANGLE = 25.f; // the maximum impact angle for tracks relative to the TRD detector plane to be considered for vDrift and ExB calibration
-constexpr int NBINSANGLEDIFF = 25;     // the number of bins for the track angle used for the vDrift and ExB calibration based on the tracking
-constexpr double ANODEPLANE = 0.0335; // distance of the TRD anode plane from the drift cathodes in [m]
+constexpr int TIMEBINS = 30;           ///< the number of time bins
+constexpr float MAXIMPACTANGLE = 25.f; ///< the maximum impact angle for tracks relative to the TRD detector plane to be considered for vDrift and ExB calibration
+constexpr int NBINSANGLEDIFF = 25;     ///< the number of bins for the track angle used for the vDrift and ExB calibration based on the tracking
+constexpr double ANODEPLANE = 0.0335;  ///< distance of the TRD anode plane from the drift cathodes in [m]
 
 // Trigger parameters
-constexpr double READOUT_TIME = 3000;                  // the time the readout takes, as 30 TB = 3 micro-s.
-constexpr double DEAD_TIME = 200;                      // trigger deadtime, 2 micro-s
-constexpr double BUSY_TIME = READOUT_TIME + DEAD_TIME; // the time for which no new trigger can be received in nanoseconds
+constexpr double READOUT_TIME = 3000;                  ///< the time the readout takes, as 30 TB = 3 micro-s.
+constexpr double DEAD_TIME = 200;                      ///< trigger deadtime, 2 micro-s
+constexpr double BUSY_TIME = READOUT_TIME + DEAD_TIME; ///< the time for which no new trigger can be received in nanoseconds
 
 // array size to store incoming half cru payload.
-constexpr int HBFBUFFERMAX = 1048576;          // max buffer size for data read from a half cru, (all events)
-constexpr unsigned int CRUPADDING32 = 0xeeeeeeee; // padding word used in the cru.
-constexpr int CHANNELNRNOTRKLT = 23;           // this marks channels in the ADC mask which don't contribute to a tracklet
-constexpr int NOTRACKLETFIT = 31;              // this value is assigned to the fit pointer in case no tracklet is available
-constexpr int TRACKLETENDMARKER = 0x10001000;  // marker for the end of tracklets in raw data, 2 of these.
-constexpr int PADDINGWORD = 0xeeeeeeee;        // half-CRU links will be padded with this words to get an even number of 256bit words
-constexpr int DIGITENDMARKER = 0x0;            // marker for the end of digits in raw data, 2 of these
-constexpr int MAXDATAPERLINK32 = 13824;        // max number of 32 bit words per link ((21x12+2+4)*64) 64 mcm, 21 channels, 10 words per channel 2 header words(DigitMCMHeader DigitMCMADCmask) 4 words for tracklets.
-constexpr int MAXDATAPERLINK256 = 1728;        // max number of linkwords per cru link. (256bit words)
-constexpr int MAXEVENTCOUNTERSEPERATION = 200; // how far apart can subsequent mcmheader event counters be before we flag for concern, used as a sanity check in rawreader.
-constexpr int MAXMCMCOUNT = 69120;             // at most mcm count maxchamber x nrobc1 nmcmrob
-constexpr int MAXLINKERRORHISTOGRAMS = 10;     // size of the array holding the link error plots from the raw reader
-constexpr int MAXPARSEERRORHISTOGRAMS = 60;    // size of the array holding the parsing error plots from the raw reader
-constexpr unsigned int ETYPEPHYSICSTRIGGER = 0x2;     // CRU Half Chamber header eventtype definition
-constexpr unsigned int ETYPECALIBRATIONTRIGGER = 0x3; // CRU Half Chamber header eventtype definition
-constexpr int MAXCRUERRORVALUE = 0x2;          // Max possible value for a CRU Halfchamber link error. As of may 2022, can only be 0x0, 0x1, and 0x2, at least that is all so far(may2022).
-constexpr int INVALIDPRETRIGGERPHASE = 0xf;    // Invalid value for phase, used to signify there is no hcheader.
+constexpr int HBFBUFFERMAX = 1048576;                 ///< max buffer size for data read from a half cru, (all events)
+constexpr unsigned int CRUPADDING32 = 0xeeeeeeee;     ///< padding word used in the cru.
+constexpr int CHANNELNRNOTRKLT = 23;                  ///< this marks channels in the ADC mask which don't contribute to a tracklet
+constexpr int NOTRACKLETFIT = 31;                     ///< this value is assigned to the fit pointer in case no tracklet is available
+constexpr int TRACKLETENDMARKER = 0x10001000;         ///< marker for the end of tracklets in raw data, 2 of these.
+constexpr int PADDINGWORD = 0xeeeeeeee;               ///< half-CRU links will be padded with this words to get an even number of 256bit words
+constexpr int DIGITENDMARKER = 0x0;                   ///< marker for the end of digits in raw data, 2 of these
+constexpr int MAXDATAPERLINK32 = 13824;               ///< max number of 32 bit words per link ((21x12+2+4)*64) 64 mcm, 21 channels, 10 words per channel 2 header words(DigitMCMHeader DigitMCMADCmask) 4 words for tracklets.
+constexpr int MAXDATAPERLINK256 = 1728;               ///< max number of linkwords per cru link. (256bit words)
+constexpr int MAXEVENTCOUNTERSEPERATION = 200;        ///< how far apart can subsequent mcmheader event counters be before we flag for concern, used as a sanity check in rawreader.
+constexpr int MAXMCMCOUNT = 69120;                    ///< at most mcm count maxchamber x nrobc1 nmcmrob
+constexpr int MAXLINKERRORHISTOGRAMS = 10;            ///< size of the array holding the link error plots from the raw reader
+constexpr int MAXPARSEERRORHISTOGRAMS = 60;           ///< size of the array holding the parsing error plots from the raw reader
+constexpr unsigned int ETYPEPHYSICSTRIGGER = 0x2;     ///< CRU Half Chamber header eventtype definition
+constexpr unsigned int ETYPECALIBRATIONTRIGGER = 0x3; ///< CRU Half Chamber header eventtype definition
+constexpr int MAXCRUERRORVALUE = 0x2;                 ///< Max possible value for a CRU Halfchamber link error. As of may 2022, can only be 0x0, 0x1, and 0x2, at least that is all so far(may2022).
+constexpr int INVALIDPRETRIGGERPHASE = 0xf;           ///< Invalid value for phase, used to signify there is no hcheader.
 
 } // namespace constants
 } // namespace trd

--- a/Detectors/TRD/calibration/CMakeLists.txt
+++ b/Detectors/TRD/calibration/CMakeLists.txt
@@ -17,6 +17,7 @@ o2_add_library(TRDCalibration
                        src/CalibratorNoise.cxx
                        src/KrClusterFinder.cxx
                        src/DCSProcessor.cxx
+                       src/CalibrationParams.cxx
                PUBLIC_LINK_LIBRARIES O2::TRDBase
                                      O2::DataFormatsTRD
                                      O2::DataFormatsGlobalTracking
@@ -30,6 +31,7 @@ o2_add_library(TRDCalibration
                            HEADERS include/TRDCalibration/TrackBasedCalib.h
                                    include/TRDCalibration/CalibratorVdExB.h
                                    include/TRDCalibration/CalibratorNoise.h
+                                   include/TRDCalibration/CalibrationParams.h
                                    include/TRDCalibration/KrClusterFinder.h
                                    include/TRDCalibration/DCSProcessor.h)
 

--- a/Detectors/TRD/calibration/README.md
+++ b/Detectors/TRD/calibration/README.md
@@ -15,13 +15,13 @@ The histograms are send to aggregator nodes which calculate for each TRD chamber
 
 To run the calibration one can start the following workflow:
 
-    o2-trd-global-tracking -b --disable-root-output --enable-trackbased-calib | o2-calibration-trd-workflow --vDriftAndExB -b --calib-vdexb-calibration '--tf-per-slot 5 --min-entries 50000 --max-delay 90000'
+    o2-trd-global-tracking -b --disable-root-output --enable-trackbased-calib | o2-calibration-trd-workflow --vDriftAndExB -b --calib-vdexb-calibration '--tf-per-slot 5 --min-entries-total 50000 --min-entries-chamber 100 --max-delay 90000'
 
 *Hint: You can get information on the meaning of the parameters by running `o2-calibration-trd-workflow --vDriftAndExB -b --help full`*
 
 If you want to run the calibration from a local file with residuals, trdangreshistos.root, you can run:
 
-    o2-calibration-trd-workflow --vDriftAndExB -b --enable-root-input --calib-vdexb-calibration '--tf-per-slot 1 --min-entries 50000'
+    o2-calibration-trd-workflow --vDriftAndExB -b --enable-root-input --calib-vdexb-calibration '--tf-per-slot 1 --min-entries-total 50000 --min-entries-chamber 100'
 
 Additionally it is possible to perform the calibrations fit manually per chamber if you have TPC-TRD or ITS-TPC-TRD tracks, you can run:
 
@@ -32,7 +32,7 @@ Then run the macro `Detectors/TRD/calibration/macros/manualCalibFit.C`.
 This produces a file of similar name with the fitted data and prints out the fit results.
 This is equivalent to running:
 
-    o2-calibration-trd-workflow --vDriftAndExB -b --enable-root-input '--tf-per-slot 1 --min-entries 2000 --enable-root-output'
+    o2-calibration-trd-workflow --vDriftAndExB -b --enable-root-input '--tf-per-slot 1 --min-entries-total 2000 --min-entries-chamber 75 --enable-root-output'
 
 You can plot the calibration values for VDrift and ExB for a given Run by using the macro at `Detectors/TRD/cailbration/macros/plotVdriftExB.C`.
 This produces a root file of similar name which holds the time-series plots (reference the macro).

--- a/Detectors/TRD/calibration/README.md
+++ b/Detectors/TRD/calibration/README.md
@@ -15,13 +15,21 @@ The histograms are send to aggregator nodes which calculate for each TRD chamber
 
 To run the calibration one can start the following workflow:
 
-    o2-trd-global-tracking -b --disable-root-output --enable-trackbased-calib | o2-calibration-trd-workflow --vDriftAndExB -b --calib-vdexb-calibration '--tf-per-slot 5 --min-entries-total 50000 --min-entries-chamber 100 --max-delay 90000'
+    o2-trd-global-tracking -b --disable-root-output --enable-trackbased-calib | o2-calibration-trd-workflow --vDriftAndExB -b --calib-vdexb-calibration '--tf-per-slot 5 --max-delay 90000'
+
+For 'o2-calibration-trd-workflow --vDriftAndExB' there are also the following keyConfig values available:
+
+    TRDCalibParams.
+    - nTrackletsMin; minimum amount of tracklets in tracks
+    - chi2RedMax; maximum reduced chi2 acceptable for tracks quality
+    - minEntriesChamber; minimum number of entries per chamber to fit in a single time slot
+    - minEntriesTotal; minimum total required for meaningful fits
 
 *Hint: You can get information on the meaning of the parameters by running `o2-calibration-trd-workflow --vDriftAndExB -b --help full`*
 
 If you want to run the calibration from a local file with residuals, trdangreshistos.root, you can run:
 
-    o2-calibration-trd-workflow --vDriftAndExB -b --enable-root-input --calib-vdexb-calibration '--tf-per-slot 1 --min-entries-total 50000 --min-entries-chamber 100'
+    o2-calibration-trd-workflow --vDriftAndExB -b --enable-root-input --calib-vdexb-calibration '--tf-per-slot 1' --configKeyValues "TRDCalibParams.minEntriesChamber=100;TRDCalibParams.minEntriesTotal=50000"
 
 Additionally it is possible to perform the calibrations fit manually per chamber if you have TPC-TRD or ITS-TPC-TRD tracks, you can run:
 
@@ -32,7 +40,7 @@ Then run the macro `Detectors/TRD/calibration/macros/manualCalibFit.C`.
 This produces a file of similar name with the fitted data and prints out the fit results.
 This is equivalent to running:
 
-    o2-calibration-trd-workflow --vDriftAndExB -b --enable-root-input '--tf-per-slot 1 --min-entries-total 2000 --min-entries-chamber 75 --enable-root-output'
+    o2-calibration-trd-workflow --vDriftAndExB -b --enable-root-input '--tf-per-slot 1 --enable-root-output'
 
 You can plot the calibration values for VDrift and ExB for a given Run by using the macro at `Detectors/TRD/cailbration/macros/plotVdriftExB.C`.
 This produces a root file of similar name which holds the time-series plots (reference the macro).

--- a/Detectors/TRD/calibration/include/TRDCalibration/CalibrationParams.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/CalibrationParams.h
@@ -1,0 +1,37 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+// \brief Collect all possible configurable parameters for any QC task
+
+#ifndef O2_CALIBRATION_PARAMS_H
+#define O2_CALIBRATION_PARAMS_H
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "CommonUtils/ConfigurableParamHelper.h"
+
+namespace o2
+{
+namespace trd
+{
+
+/// VDrift and ExB calibration parameters.
+struct TRDCalibParams : public o2::conf::ConfigurableParamHelper<TRDCalibParams> {
+  unsigned int nTrackletsMin = 5; // minimum amount of tracklets
+  unsigned int chi2RedMax = 6;    // maximum reduced chi2 acceptable for track quality
+
+  // boilerplate
+  O2ParamDef(TRDCalibParams, "TRDCalibParams");
+};
+
+} // namespace trd
+} // namespace o2
+
+#endif

--- a/Detectors/TRD/calibration/include/TRDCalibration/CalibrationParams.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/CalibrationParams.h
@@ -24,8 +24,10 @@ namespace trd
 
 /// VDrift and ExB calibration parameters.
 struct TRDCalibParams : public o2::conf::ConfigurableParamHelper<TRDCalibParams> {
-  unsigned int nTrackletsMin = 5; // minimum amount of tracklets
-  unsigned int chi2RedMax = 6;    // maximum reduced chi2 acceptable for track quality
+  unsigned int nTrackletsMin = 5;  ///< minimum amount of tracklets
+  unsigned int chi2RedMax = 6;     ///< maximum reduced chi2 acceptable for track quality
+  size_t minEntriesChamber = 75;   ///< minimum number of entries per chamber to fit single time slot
+  size_t minEntriesTotal = 40'500; ///< minimum total required for meaningful fits
 
   // boilerplate
   O2ParamDef(TRDCalibParams, "TRDCalibParams");

--- a/Detectors/TRD/calibration/include/TRDCalibration/CalibratorVdExB.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/CalibratorVdExB.h
@@ -38,8 +38,8 @@ struct FitFunctor {
   double operator()(const double* par) const;
   double calculateDeltaAlphaSim(double vdFit, double laFit, double impactAng) const;
   std::array<std::unique_ptr<TProfile>, constants::MAXCHAMBER> profiles; ///< profile histograms for each TRD chamber
-  double vdPreCorr;                                                      // TODO: these values should eventually be taken from CCDB
-  double laPreCorr;                                                      // TODO: these values should eventually be taken from CCDB
+  std::array<double,constants::MAXCHAMBER> vdPreCorr;                                                      // TODO: these values should eventually be taken from CCDB
+  std::array<double,constants::MAXCHAMBER> laPreCorr;                                                      // TODO: these values should eventually be taken from CCDB
   int currDet;                                                           ///< the current TRD chamber number
   float lowerBoundAngleFit;
   float upperBoundAngleFit;

--- a/Detectors/TRD/calibration/include/TRDCalibration/CalibratorVdExB.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/CalibratorVdExB.h
@@ -25,6 +25,7 @@
 
 #include "Rtypes.h"
 #include "TProfile.h"
+#include "Fit/Fitter.h"
 
 #include <array>
 #include <cstdlib>
@@ -72,13 +73,15 @@ class CalibratorVdExB final : public o2::calibration::TimeSlotCalibration<o2::tr
   void retrievePrev(o2::framework::ProcessingContext& pc);
 
  private:
-  bool mInitDone{false};                             ///< flag to avoid creating the TProfiles multiple times
-  size_t mMinEntriesTotal;                           ///< minimum total number of angular deviations (on average ~3 entries per bin for each TRD chamber)
-  size_t mMinEntriesChamber;                         ///< minimum number of angular deviations per chamber for accepting refitted value (~3 per bin)
+  bool mInitDone{false};                             //< flag to avoid creating the TProfiles multiple times
+  size_t mMinEntriesTotal;                           //< minimum total number of angular deviations (on average ~3 entries per bin for each TRD chamber)
+  size_t mMinEntriesChamber;                         //< minimum number of angular deviations per chamber for accepting refitted value (~3 per bin)
   bool mEnableOutput;                                //< enable output of calibration fits and tprofiles in a root file instead of the ccdb
-  FitFunctor mFitFunctor;                            ///< used for minimization procedure
-  std::vector<o2::ccdb::CcdbObjectInfo> mInfoVector; ///< vector of CCDB infos; each element is filled with CCDB description of accompanying CCDB calibration object
-  std::vector<o2::trd::CalVdriftExB> mObjectVector;  ///< vector of CCDB calibration objects; the extracted vDrift and ExB per chamber for given slot
+  FitFunctor mFitFunctor;                            //< used for minimization procedure
+  std::vector<o2::ccdb::CcdbObjectInfo> mInfoVector; //< vector of CCDB infos; each element is filled with CCDB description of accompanying CCDB calibration object
+  std::vector<o2::trd::CalVdriftExB> mObjectVector;  //< vector of CCDB calibration objects; the extracted vDrift and ExB per chamber for given slot
+  ROOT::Fit::Fitter mFitter;                         //< Fitter object will be reused across slots
+  double mParamsStart[2];                            //< Start fit parameter
   ClassDefOverride(CalibratorVdExB, 3);
 };
 

--- a/Detectors/TRD/calibration/include/TRDCalibration/CalibratorVdExB.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/CalibratorVdExB.h
@@ -54,10 +54,10 @@ class CalibratorVdExB final : public o2::calibration::TimeSlotCalibration<o2::tr
     LA,
     VD
   };
-  CalibratorVdExB(size_t nMin = 40'000, bool enableOut = false) : mMinEntries(nMin), mEnableOutput(enableOut) {}
+  CalibratorVdExB(size_t nMinTotal = 40'500, size_t nMinChamber = 75, bool enableOut = false) : mMinEntriesTotal(nMinTotal), mMinEntriesChamber(nMinChamber), mEnableOutput(enableOut) {}
   ~CalibratorVdExB() final = default;
 
-  bool hasEnoughData(const Slot& slot) const final { return slot.getContainer()->getNEntries() >= mMinEntries; }
+  bool hasEnoughData(const Slot& slot) const final { return slot.getContainer()->getNEntries() >= mMinEntriesTotal; }
   void initOutput() final;
   void finalizeSlot(Slot& slot) final;
   Slot& emplaceNewSlot(bool front, TFType tStart, TFType tEnd) final;
@@ -69,12 +69,13 @@ class CalibratorVdExB final : public o2::calibration::TimeSlotCalibration<o2::tr
 
  private:
   bool mInitDone{false}; ///< flag to avoid creating the TProfiles multiple times
-  size_t mMinEntries; ///< minimum total number of angular deviations (on average ~3 entries per bin for each TRD chamber)
+  size_t mMinEntriesTotal; ///< minimum total number of angular deviations (on average ~3 entries per bin for each TRD chamber)
+  size_t mMinEntriesChamber; ///< minimum number of angular deviations per chamber for accepting refitted value (~3 per bin)
   bool mEnableOutput; //< enable output of calibration fits and tprofiles in a root file instead of the ccdb
   FitFunctor mFitFunctor; ///< used for minimization procedure
   std::vector<o2::ccdb::CcdbObjectInfo> mInfoVector; ///< vector of CCDB infos; each element is filled with CCDB description of accompanying CCDB calibration object
   std::vector<o2::trd::CalVdriftExB> mObjectVector;  ///< vector of CCDB calibration objects; the extracted vDrift and ExB per chamber for given slot
-  ClassDefOverride(CalibratorVdExB, 2);
+  ClassDefOverride(CalibratorVdExB, 3);
 };
 
 } // namespace trd

--- a/Detectors/TRD/calibration/include/TRDCalibration/CalibratorVdExB.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/CalibratorVdExB.h
@@ -38,8 +38,8 @@ struct FitFunctor {
   double operator()(const double* par) const;
   double calculateDeltaAlphaSim(double vdFit, double laFit, double impactAng) const;
   std::array<std::unique_ptr<TProfile>, constants::MAXCHAMBER> profiles; ///< profile histograms for each TRD chamber
-  std::array<double,constants::MAXCHAMBER> vdPreCorr;                                                      // TODO: these values should eventually be taken from CCDB
-  std::array<double,constants::MAXCHAMBER> laPreCorr;                                                      // TODO: these values should eventually be taken from CCDB
+  std::array<double,constants::MAXCHAMBER> vdPreCorr;                                                      ///< vDrift from previous Run
+  std::array<double,constants::MAXCHAMBER> laPreCorr;                                                      ///< LorentzAngle from previous Run
   int currDet;                                                           ///< the current TRD chamber number
   float lowerBoundAngleFit;
   float upperBoundAngleFit;
@@ -66,6 +66,10 @@ class CalibratorVdExB final : public o2::calibration::TimeSlotCalibration<o2::tr
   std::vector<o2::ccdb::CcdbObjectInfo>& getCcdbObjectInfoVector() { return mInfoVector; }
 
   void initProcessing();
+
+  /// Initialize the fit values once with the previous valid ones if they are
+  /// available.
+  void retrievePrev(o2::framework::ProcessingContext& pc);
 
  private:
   bool mInitDone{false}; ///< flag to avoid creating the TProfiles multiple times

--- a/Detectors/TRD/calibration/include/TRDCalibration/CalibratorVdExB.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/CalibratorVdExB.h
@@ -38,8 +38,8 @@ struct FitFunctor {
   double operator()(const double* par) const;
   double calculateDeltaAlphaSim(double vdFit, double laFit, double impactAng) const;
   std::array<std::unique_ptr<TProfile>, constants::MAXCHAMBER> profiles; ///< profile histograms for each TRD chamber
-  std::array<double,constants::MAXCHAMBER> vdPreCorr;                                                      ///< vDrift from previous Run
-  std::array<double,constants::MAXCHAMBER> laPreCorr;                                                      ///< LorentzAngle from previous Run
+  std::array<double, constants::MAXCHAMBER> vdPreCorr;                   ///< vDrift from previous Run
+  std::array<double, constants::MAXCHAMBER> laPreCorr;                   ///< LorentzAngle from previous Run
   int currDet;                                                           ///< the current TRD chamber number
   float lowerBoundAngleFit;
   float upperBoundAngleFit;
@@ -72,11 +72,11 @@ class CalibratorVdExB final : public o2::calibration::TimeSlotCalibration<o2::tr
   void retrievePrev(o2::framework::ProcessingContext& pc);
 
  private:
-  bool mInitDone{false}; ///< flag to avoid creating the TProfiles multiple times
-  size_t mMinEntriesTotal; ///< minimum total number of angular deviations (on average ~3 entries per bin for each TRD chamber)
-  size_t mMinEntriesChamber; ///< minimum number of angular deviations per chamber for accepting refitted value (~3 per bin)
-  bool mEnableOutput; //< enable output of calibration fits and tprofiles in a root file instead of the ccdb
-  FitFunctor mFitFunctor; ///< used for minimization procedure
+  bool mInitDone{false};                             ///< flag to avoid creating the TProfiles multiple times
+  size_t mMinEntriesTotal;                           ///< minimum total number of angular deviations (on average ~3 entries per bin for each TRD chamber)
+  size_t mMinEntriesChamber;                         ///< minimum number of angular deviations per chamber for accepting refitted value (~3 per bin)
+  bool mEnableOutput;                                //< enable output of calibration fits and tprofiles in a root file instead of the ccdb
+  FitFunctor mFitFunctor;                            ///< used for minimization procedure
   std::vector<o2::ccdb::CcdbObjectInfo> mInfoVector; ///< vector of CCDB infos; each element is filled with CCDB description of accompanying CCDB calibration object
   std::vector<o2::trd::CalVdriftExB> mObjectVector;  ///< vector of CCDB calibration objects; the extracted vDrift and ExB per chamber for given slot
   ClassDefOverride(CalibratorVdExB, 3);

--- a/Detectors/TRD/calibration/include/TRDCalibration/CalibratorVdExB.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/CalibratorVdExB.h
@@ -42,8 +42,9 @@ struct FitFunctor {
   std::array<double, constants::MAXCHAMBER> vdPreCorr;                   ///< vDrift from previous Run
   std::array<double, constants::MAXCHAMBER> laPreCorr;                   ///< LorentzAngle from previous Run
   int currDet;                                                           ///< the current TRD chamber number
-  float lowerBoundAngleFit;
-  float upperBoundAngleFit;
+  float lowerBoundAngleFit;                                              ///< lower bound for fit angle
+  float upperBoundAngleFit;                                              ///< upper bound for fit angle
+  double mAnodePlane;                                                    ///< distance of the TRD anode plane from the drift cathodes in m
 };
 
 class CalibratorVdExB final : public o2::calibration::TimeSlotCalibration<o2::trd::AngularResidHistos>
@@ -73,15 +74,15 @@ class CalibratorVdExB final : public o2::calibration::TimeSlotCalibration<o2::tr
   void retrievePrev(o2::framework::ProcessingContext& pc);
 
  private:
-  bool mInitDone{false};                             //< flag to avoid creating the TProfiles multiple times
-  size_t mMinEntriesTotal;                           //< minimum total number of angular deviations (on average ~3 entries per bin for each TRD chamber)
-  size_t mMinEntriesChamber;                         //< minimum number of angular deviations per chamber for accepting refitted value (~3 per bin)
-  bool mEnableOutput;                                //< enable output of calibration fits and tprofiles in a root file instead of the ccdb
-  FitFunctor mFitFunctor;                            //< used for minimization procedure
-  std::vector<o2::ccdb::CcdbObjectInfo> mInfoVector; //< vector of CCDB infos; each element is filled with CCDB description of accompanying CCDB calibration object
-  std::vector<o2::trd::CalVdriftExB> mObjectVector;  //< vector of CCDB calibration objects; the extracted vDrift and ExB per chamber for given slot
-  ROOT::Fit::Fitter mFitter;                         //< Fitter object will be reused across slots
-  double mParamsStart[2];                            //< Start fit parameter
+  bool mInitDone{false};                             ///< flag to avoid creating the TProfiles multiple times
+  size_t mMinEntriesTotal;                           ///< minimum total number of angular deviations (on average ~3 entries per bin for each TRD chamber)
+  size_t mMinEntriesChamber;                         ///< minimum number of angular deviations per chamber for accepting refitted value (~3 per bin)
+  bool mEnableOutput;                                ///< enable output of calibration fits and tprofiles in a root file instead of the ccdb
+  FitFunctor mFitFunctor;                            ///< used for minimization procedure
+  std::vector<o2::ccdb::CcdbObjectInfo> mInfoVector; ///< vector of CCDB infos; each element is filled with CCDB description of accompanying CCDB calibration object
+  std::vector<o2::trd::CalVdriftExB> mObjectVector;  ///< vector of CCDB calibration objects; the extracted vDrift and ExB per chamber for given slot
+  ROOT::Fit::Fitter mFitter;                         ///< Fitter object will be reused across slots
+  double mParamsStart[2];                            ///< Start fit parameter
   ClassDefOverride(CalibratorVdExB, 3);
 };
 

--- a/Detectors/TRD/calibration/include/TRDCalibration/CalibratorVdExB.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/CalibratorVdExB.h
@@ -56,7 +56,7 @@ class CalibratorVdExB final : public o2::calibration::TimeSlotCalibration<o2::tr
     LA,
     VD
   };
-  CalibratorVdExB(size_t nMinTotal = 40'500, size_t nMinChamber = 75, bool enableOut = false) : mMinEntriesTotal(nMinTotal), mMinEntriesChamber(nMinChamber), mEnableOutput(enableOut) {}
+  CalibratorVdExB(bool enableOut = false) : mEnableOutput(enableOut) {}
   ~CalibratorVdExB() final = default;
 
   bool hasEnoughData(const Slot& slot) const final { return slot.getContainer()->getNEntries() >= mMinEntriesTotal; }

--- a/Detectors/TRD/calibration/macros/manualCalibFit.C
+++ b/Detectors/TRD/calibration/macros/manualCalibFit.C
@@ -70,8 +70,8 @@ void manualCalibFit()
   }
   mFitFunctor.lowerBoundAngleFit = 80 * TMath::DegToRad();
   mFitFunctor.upperBoundAngleFit = 100 * TMath::DegToRad();
-  mFitFunctor.vdPreCorr = 1.546;
-  mFitFunctor.laPreCorr = 0.;
+  mFitFunctor.vdPreCorr.fill(1.546);
+  mFitFunctor.laPreCorr.fill(0.0);
 
   //----------------------------------------------------
   // Loop

--- a/Detectors/TRD/calibration/src/CalibrationParams.cxx
+++ b/Detectors/TRD/calibration/src/CalibrationParams.cxx
@@ -1,0 +1,13 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "TRDCalibration/CalibrationParams.h"
+O2ParamImpl(o2::trd::TRDCalibParams);

--- a/Detectors/TRD/calibration/src/CalibratorVdExB.cxx
+++ b/Detectors/TRD/calibration/src/CalibratorVdExB.cxx
@@ -18,6 +18,7 @@
 #include "Framework/TimingInfo.h"
 #include "Framework/InputRecord.h"
 #include "DataFormatsTRD/Constants.h"
+#include "TRDBase/GeometryBase.h"
 #include "TStopwatch.h"
 #include "CCDB/CcdbApi.h"
 #include "CCDB/BasicCCDBManager.h"
@@ -45,20 +46,20 @@ double FitFunctor::calculateDeltaAlphaSim(double vdFit, double laFit, double imp
   double lorentzSlope = (TMath::Abs(laTan) < 1e-7) ? 1e7 : 1. / laTan;
 
   // hit point of incoming track with anode plane
-  double xAnodeHit = ANODEPLANE / slope;
-  double yAnodeHit = ANODEPLANE;
+  double xAnodeHit = mAnodePlane / slope;
+  double yAnodeHit = mAnodePlane;
 
   // hit point at anode plane of Lorentz angle shifted cluster from the entrance -> independent of true drift velocity
-  double xLorentzAnodeHit = ANODEPLANE / lorentzSlope;
-  double yLorentzAnodeHit = ANODEPLANE;
+  double xLorentzAnodeHit = mAnodePlane / lorentzSlope;
+  double yLorentzAnodeHit = mAnodePlane;
 
   // cluster location within drift cell of cluster from entrance after drift velocity ratio is applied
   double xLorentzDriftHit = xLorentzAnodeHit;
-  double yLorentzDriftHit = ANODEPLANE - ANODEPLANE * (vdPreCorr[currDet] / vdFit);
+  double yLorentzDriftHit = mAnodePlane - mAnodePlane * (vdPreCorr[currDet] / vdFit);
 
   // reconstructed hit of first cluster at chamber entrance after pre Lorentz angle correction
-  double xLorentzDriftHitPreCorr = xLorentzAnodeHit - (ANODEPLANE - yLorentzDriftHit) * TMath::Tan(laPreCorr[currDet]);
-  double yLorentzDriftHitPreCorr = ANODEPLANE - ANODEPLANE * (vdPreCorr[currDet] / vdFit);
+  double xLorentzDriftHitPreCorr = xLorentzAnodeHit - (mAnodePlane - yLorentzDriftHit) * TMath::Tan(laPreCorr[currDet]);
+  double yLorentzDriftHitPreCorr = mAnodePlane - mAnodePlane * (vdPreCorr[currDet] / vdFit);
 
   double impactAngleSim = TMath::ATan2(yAnodeHit, xAnodeHit);
 
@@ -106,6 +107,7 @@ void CalibratorVdExB::initProcessing()
 
   mFitFunctor.lowerBoundAngleFit = 80 * TMath::DegToRad();
   mFitFunctor.upperBoundAngleFit = 100 * TMath::DegToRad();
+  mFitFunctor.mAnodePlane = GeometryBase::camHght() / (2.f * 100.f);
   for (int iDet = 0; iDet < MAXCHAMBER; ++iDet) {
     mFitFunctor.profiles[iDet] = std::make_unique<TProfile>(Form("profAngleDiff_%i", iDet), Form("profAngleDiff_%i", iDet), NBINSANGLEDIFF, -MAXIMPACTANGLE, MAXIMPACTANGLE);
   }

--- a/Detectors/TRD/calibration/src/CalibratorVdExB.cxx
+++ b/Detectors/TRD/calibration/src/CalibratorVdExB.cxx
@@ -17,6 +17,7 @@
 #include "Framework/ProcessingContext.h"
 #include "Framework/TimingInfo.h"
 #include "Framework/InputRecord.h"
+#include "DataFormatsTRD/Constants.h"
 #include "Fit/Fitter.h"
 #include "TStopwatch.h"
 #include "CCDB/CcdbApi.h"
@@ -38,9 +39,6 @@ namespace o2::trd
 
 double FitFunctor::calculateDeltaAlphaSim(double vdFit, double laFit, double impactAng) const
 {
-
-  double trdAnodePlane = .0335; // distance of the TRD anode plane from the drift cathodes in [m]
-
   auto xDir = TMath::Cos(impactAng);
   auto yDir = TMath::Sin(impactAng);
   double slope = (TMath::Abs(xDir) < 1e-7) ? 1e7 : yDir / xDir;
@@ -48,20 +46,20 @@ double FitFunctor::calculateDeltaAlphaSim(double vdFit, double laFit, double imp
   double lorentzSlope = (TMath::Abs(laTan) < 1e-7) ? 1e7 : 1. / laTan;
 
   // hit point of incoming track with anode plane
-  double xAnodeHit = trdAnodePlane / slope;
-  double yAnodeHit = trdAnodePlane;
+  double xAnodeHit = ANODEPLANE / slope;
+  double yAnodeHit = ANODEPLANE;
 
   // hit point at anode plane of Lorentz angle shifted cluster from the entrance -> independent of true drift velocity
-  double xLorentzAnodeHit = trdAnodePlane / lorentzSlope;
-  double yLorentzAnodeHit = trdAnodePlane;
+  double xLorentzAnodeHit = ANODEPLANE / lorentzSlope;
+  double yLorentzAnodeHit = ANODEPLANE;
 
   // cluster location within drift cell of cluster from entrance after drift velocity ratio is applied
   double xLorentzDriftHit = xLorentzAnodeHit;
-  double yLorentzDriftHit = trdAnodePlane - trdAnodePlane * (vdPreCorr[currDet] / vdFit);
+  double yLorentzDriftHit = ANODEPLANE - ANODEPLANE * (vdPreCorr[currDet] / vdFit);
 
   // reconstructed hit of first cluster at chamber entrance after pre Lorentz angle correction
-  double xLorentzDriftHitPreCorr = xLorentzAnodeHit - (trdAnodePlane - yLorentzDriftHit) * TMath::Tan(laPreCorr[currDet]);
-  double yLorentzDriftHitPreCorr = trdAnodePlane - trdAnodePlane * (vdPreCorr[currDet] / vdFit);
+  double xLorentzDriftHitPreCorr = xLorentzAnodeHit - (ANODEPLANE - yLorentzDriftHit) * TMath::Tan(laPreCorr[currDet]);
+  double yLorentzDriftHitPreCorr = ANODEPLANE - ANODEPLANE * (vdPreCorr[currDet] / vdFit);
 
   double impactAngleSim = TMath::ATan2(yAnodeHit, xAnodeHit);
 

--- a/Detectors/TRD/calibration/src/CalibratorVdExB.cxx
+++ b/Detectors/TRD/calibration/src/CalibratorVdExB.cxx
@@ -161,7 +161,7 @@ void CalibratorVdExB::finalizeSlot(Slot& slot)
       }
     }
     // Check if we have the minimum amount of entries
-    if(sumEntries < mMinEntriesChamber){
+    if (sumEntries < mMinEntriesChamber) {
       LOGF(debug, "Chamber %d did not reach minimum amount of entries for refit", iDet);
       continue;
     }

--- a/Detectors/TRD/calibration/src/CalibratorVdExB.cxx
+++ b/Detectors/TRD/calibration/src/CalibratorVdExB.cxx
@@ -14,6 +14,7 @@
 /// \author Ole Schmidt
 
 #include "TRDCalibration/CalibratorVdExB.h"
+#include "TRDCalibration/CalibrationParams.h"
 #include "Framework/ProcessingContext.h"
 #include "Framework/TimingInfo.h"
 #include "Framework/InputRecord.h"
@@ -154,6 +155,10 @@ void CalibratorVdExB::retrievePrev(o2::framework::ProcessingContext& pc)
       mFitFunctor.laPreCorr[iDet] = dataCalVdriftExB->getExB(iDet);
       mFitFunctor.vdPreCorr[iDet] = dataCalVdriftExB->getVdrift(iDet);
     }
+
+    auto& params = TRDCalibParams::Instance();
+    mMinEntriesChamber = params.minEntriesChamber;
+    mMinEntriesTotal = params.minEntriesTotal;
   }
 }
 

--- a/Detectors/TRD/calibration/src/CalibratorVdExB.cxx
+++ b/Detectors/TRD/calibration/src/CalibratorVdExB.cxx
@@ -133,8 +133,8 @@ void CalibratorVdExB::retrievePrev(o2::framework::ProcessingContext& pc)
   static bool doneOnce = false;
   if (!doneOnce) {
     doneOnce = true;
-    mFitFunctor.vdPreCorr.fill(1.546);
-    mFitFunctor.laPreCorr.fill(0.);
+    mFitFunctor.vdPreCorr.fill(constants::VDRIFTDEFAULT);
+    mFitFunctor.laPreCorr.fill(constants::EXBDEFAULT);
     // We either get a pointer to a valid object from the last ~hour or to the default object
     // which is always present. The first has precedence over the latter.
     auto dataCalVdriftExB = pc.inputs().get<o2::trd::CalVdriftExB*>("calvdexb");

--- a/Detectors/TRD/calibration/src/CalibratorVdExB.cxx
+++ b/Detectors/TRD/calibration/src/CalibratorVdExB.cxx
@@ -113,7 +113,7 @@ void CalibratorVdExB::initProcessing()
   mFitter.SetFCN<FitFunctor>(2, mFitFunctor, mParamsStart);
   mFitter.Config().ParSettings(ParamIndex::LA).SetLimits(-0.7, 0.7);
   mFitter.Config().ParSettings(ParamIndex::LA).SetStepSize(.01);
-  mFitter.Config().ParSettings(ParamIndex::VD).SetLimits(0., 3.);
+  mFitter.Config().ParSettings(ParamIndex::VD).SetLimits(0.01, 3.);
   mFitter.Config().ParSettings(ParamIndex::VD).SetStepSize(.01);
   ROOT::Math::MinimizerOptions opt;
   opt.SetMinimizerType("Minuit2");

--- a/Detectors/TRD/calibration/src/TRDCalibrationLinkDef.h
+++ b/Detectors/TRD/calibration/src/TRDCalibrationLinkDef.h
@@ -26,5 +26,7 @@
 #pragma link C++ class std::unordered_map < o2::dcs::DataPointIdentifier, o2::trd::TRDDCSMinMaxMeanInfo> + ;
 #pragma link C++ class std::unordered_map < o2::dcs::DataPointIdentifier, float> + ;
 #pragma link C++ class std::unordered_map < o2::dcs::DataPointIdentifier, int> + ;
+#pragma link C++ class o2::trd::TRDCalibParams + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::trd::TRDCalibParams> + ;
 
 #endif

--- a/Detectors/TRD/workflow/include/TRDWorkflow/VdAndExBCalibSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/VdAndExBCalibSpec.h
@@ -43,11 +43,12 @@ class VdAndExBCalibDevice : public o2::framework::Task
   void init(o2::framework::InitContext& ic) final
   {
     o2::base::GRPGeomHelper::instance().setRequest(mCCDBRequest);
-    int minEnt = ic.options().get<int>("min-entries");
+    int minEntTotal = ic.options().get<int>("min-entries-total");
+    int minEntChamber = ic.options().get<int>("min-entries-chamber");
     auto enableOutput = ic.options().get<bool>("enable-root-output");
     auto slotL = ic.options().get<uint32_t>("sec-per-slot");
     auto delay = ic.options().get<uint32_t>("max-delay");
-    mCalibrator = std::make_unique<o2::trd::CalibratorVdExB>(minEnt, enableOutput);
+    mCalibrator = std::make_unique<o2::trd::CalibratorVdExB>(minEntTotal, minEntChamber, enableOutput);
     mCalibrator->setSlotLengthInSeconds(slotL);
     mCalibrator->setMaxSlotsDelay(delay);
   }
@@ -136,7 +137,9 @@ DataProcessorSpec getTRDVdAndExBCalibSpec()
       {"sec-per-slot", VariantType::UInt32, 900u, {"number of seconds per calibration time slot"}},
       {"max-delay", VariantType::UInt32, 2u, {"number of slots in past to consider"}},
       {"enable-root-output", VariantType::Bool, false, {"output tprofiles and fits to root file"}},
-      {"min-entries", VariantType::Int, 40'000, {"minimum number of entries to fit single time slot"}}}}; // around 3 entries per bin per chamber
+      {"min-entries-chamber", VariantType::Int, 75, {"minimum number of entries per chamber to fit single time slot"}},
+      {"min-entries-total", VariantType::Int, 40'500, {"total minimum number of entries to fit single time slot"}}}}; // around 3 entries per bin per chamber
+
 }
 
 } // namespace framework

--- a/Detectors/TRD/workflow/include/TRDWorkflow/VdAndExBCalibSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/VdAndExBCalibSpec.h
@@ -44,12 +44,10 @@ class VdAndExBCalibDevice : public o2::framework::Task
   void init(o2::framework::InitContext& ic) final
   {
     o2::base::GRPGeomHelper::instance().setRequest(mCCDBRequest);
-    int minEntTotal = ic.options().get<int>("min-entries-total");
-    int minEntChamber = ic.options().get<int>("min-entries-chamber");
     auto enableOutput = ic.options().get<bool>("enable-root-output");
     auto slotL = ic.options().get<uint32_t>("sec-per-slot");
     auto delay = ic.options().get<uint32_t>("max-delay");
-    mCalibrator = std::make_unique<o2::trd::CalibratorVdExB>(minEntTotal, minEntChamber, enableOutput);
+    mCalibrator = std::make_unique<o2::trd::CalibratorVdExB>(enableOutput);
     mCalibrator->setSlotLengthInSeconds(slotL);
     mCalibrator->setMaxSlotsDelay(delay);
   }
@@ -141,10 +139,8 @@ DataProcessorSpec getTRDVdAndExBCalibSpec()
       {"sec-per-slot", VariantType::UInt32, 900u, {"number of seconds per calibration time slot"}},
       {"max-delay", VariantType::UInt32, 2u, {"number of slots in past to consider"}},
       {"enable-root-output", VariantType::Bool, false, {"output tprofiles and fits to root file"}},
-      {"min-entries-chamber", VariantType::Int, 75, {"minimum number of entries per chamber to fit single time slot"}},
-      {"min-entries-total", VariantType::Int, 40'500, {"total minimum number of entries to fit single time slot"}}}}; // around 3 entries per bin per chamber
+    }};
 }
-
 } // namespace framework
 } // namespace o2
 

--- a/Detectors/TRD/workflow/include/TRDWorkflow/VdAndExBCalibSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/VdAndExBCalibSpec.h
@@ -143,7 +143,6 @@ DataProcessorSpec getTRDVdAndExBCalibSpec()
       {"enable-root-output", VariantType::Bool, false, {"output tprofiles and fits to root file"}},
       {"min-entries-chamber", VariantType::Int, 75, {"minimum number of entries per chamber to fit single time slot"}},
       {"min-entries-total", VariantType::Int, 40'500, {"total minimum number of entries to fit single time slot"}}}}; // around 3 entries per bin per chamber
-
 }
 
 } // namespace framework


### PR DESCRIPTION
This patch series does the following:

1. reusing fit values from the previous slot
2. pulling the initial fit values from the ccdb if there was any which is still valid e.g. ~in the last hour
3. introduced a keyConfig values for more granular control for track selection
4. introduced a new constant for trd
5. some minor touch-ups and doxygen compliant comments

more info in commits.

There were some concerns about the TrackletTransformer however looking through the code vDrift and ExB are only used for calculating the calibrated Dy (where it is a good thing to use updated values anyways) and for caluclation of the Timebin [here](https://github.com/AliceO2Group/AliceO2/blob/3d9ad243b0cff6cfb3112b5d950ca01e69bd7266/Detectors/TRD/base/src/TrackletTransformer.cxx#L139-L155), where an updated vDrift would also be good? How do I test this?

I `tested` it by comparing the fit values before and after for a Run 523677.
I did not have a chance to test if the actual pull for the initial fit values works as I expect, this is somewhat hard for me to test.