### PR TITLE
DPL Analysis: 1-to-many index for BCs and Collisions

### DIFF
--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -1109,13 +1109,14 @@ using HepMCHeavyIon = HepMCHeavyIons::iterator;
 
 namespace indices
 {
-DECLARE_SOA_INDEX_COLUMN(Collision, collision); //!
-DECLARE_SOA_INDEX_COLUMN(BC, bc);               //!
-DECLARE_SOA_INDEX_COLUMN(Zdc, zdc);             //!
-DECLARE_SOA_INDEX_COLUMN(FV0A, fv0a);           //!
-DECLARE_SOA_INDEX_COLUMN(FV0C, fv0c);           //!
-DECLARE_SOA_INDEX_COLUMN(FT0, ft0);             //!
-DECLARE_SOA_INDEX_COLUMN(FDD, fdd);             //!
+DECLARE_SOA_INDEX_COLUMN(Collision, collision);        //!
+DECLARE_SOA_ARRAY_INDEX_COLUMN(Collision, collisions); //!
+DECLARE_SOA_INDEX_COLUMN(BC, bc);                      //!
+DECLARE_SOA_INDEX_COLUMN(Zdc, zdc);                    //!
+DECLARE_SOA_INDEX_COLUMN(FV0A, fv0a);                  //!
+DECLARE_SOA_INDEX_COLUMN(FV0C, fv0c);                  //!
+DECLARE_SOA_INDEX_COLUMN(FT0, ft0);                    //!
+DECLARE_SOA_INDEX_COLUMN(FDD, fdd);                    //!
 } // namespace indices
 
 // First entry: Collision
@@ -1132,6 +1133,11 @@ DECLARE_SOA_INDEX_TABLE_EXCLUSIVE(MatchedBCCollisionsExclusive, BCs, "MA_BCCOL_E
                                   indices::BCId, indices::CollisionId);
 DECLARE_SOA_INDEX_TABLE(MatchedBCCollisionsSparse, BCs, "MA_BCCOL_SP", //!
                         indices::BCId, indices::CollisionId);
+
+DECLARE_SOA_INDEX_TABLE_EXCLUSIVE(MatchedBCCollisionsExclusiveMulti, BCs, "MA_BCCOLS_EX", //!
+                                  indices::BCId, indices::CollisionIds);
+DECLARE_SOA_INDEX_TABLE(MatchedBCCollisionsSparseMulti, BCs, "MA_BCCOLS_SP", //!
+                        indices::BCId, indices::CollisionIds);
 
 DECLARE_SOA_INDEX_TABLE_EXCLUSIVE(Run3MatchedToBCExclusive, BCs, "MA_RN3_BC_EX", //!
                                   indices::BCId, indices::ZdcId, indices::FT0Id, indices::FV0AId, indices::FDDId);

--- a/Framework/Core/include/Framework/IndexBuilderHelpers.h
+++ b/Framework/Core/include/Framework/IndexBuilderHelpers.h
@@ -70,6 +70,7 @@ struct SelfIndexColumnBuilder {
   }
 
   std::string mColumnName;
+  std::shared_ptr<arrow::DataType> mArrowType;
   std::unique_ptr<arrow::ArrayBuilder> mBuilder = nullptr;
 };
 
@@ -133,7 +134,6 @@ class IndexColumnBuilder : public SelfIndexColumnBuilder, public ChunkedArrayIte
   std::shared_ptr<arrow::ChunkedArray> resultMulti() const;
 
   int mListSize = 1;
-  std::shared_ptr<arrow::DataType> mArrowType;
   arrow::ArrayBuilder* mValueBuilder = nullptr;
   std::unique_ptr<arrow::ArrayBuilder> mListBuilder = nullptr;
 

--- a/Framework/Core/src/AODReaderHelpers.cxx
+++ b/Framework/Core/src/AODReaderHelpers.cxx
@@ -127,6 +127,10 @@ AlgorithmSpec AODReaderHelpers::indexBuilderCallback(std::vector<InputSpec>& req
           outputs.adopt(Output{origin, description, version}, maker(o2::aod::MatchedBCCollisionsExclusiveMetadata{}));
         } else if (description == header::DataDescription{"MA_BCCOL_SP"}) {
           outputs.adopt(Output{origin, description, version}, maker(o2::aod::MatchedBCCollisionsSparseMetadata{}));
+        } else if (description == header::DataDescription{"MA_BCCOLS_EX"}) {
+          outputs.adopt(Output{origin, description, version}, maker(o2::aod::MatchedBCCollisionsExclusiveMultiMetadata{}));
+        } else if (description == header::DataDescription{"MA_BCCOLS_SP"}) {
+          outputs.adopt(Output{origin, description, version}, maker(o2::aod::MatchedBCCollisionsSparseMultiMetadata{}));
         } else if (description == header::DataDescription{"MA_RN3_BC_SP"}) {
           outputs.adopt(Output{origin, description, version}, maker(o2::aod::Run3MatchedToBCSparseMetadata{}));
         } else if (description == header::DataDescription{"MA_RN3_BC_EX"}) {


### PR DESCRIPTION
Adds 1-to-many BC-collision association index tables to data model. This would be a multistage change, in order not to break O2Physics compilation.

* Fixes incorrect field type returned by index builder
* Fixes potential segfault when filling array column in index builder