### PR TITLE
[EMCAL-841, EMCAL-830] General tool for cell-level calibration

### DIFF
--- a/Detectors/EMCAL/calib/CMakeLists.txt
+++ b/Detectors/EMCAL/calib/CMakeLists.txt
@@ -25,6 +25,7 @@ o2_add_library(EMCALCalib
         src/CalibDB.cxx
         src/ElmbMeasurement.cxx
         src/EMCALChannelScaleFactors.cxx
+        src/CellRecalibrator.cxx
         PUBLIC_LINK_LIBRARIES O2::CCDB O2::EMCALBase)
 
 o2_target_root_dictionary(EMCALCalib
@@ -43,6 +44,7 @@ o2_target_root_dictionary(EMCALCalib
         include/EMCALCalib/ElmbData.h
         include/EMCALCalib/ElmbMeasurement.h
         include/EMCALCalib/EMCALChannelScaleFactors.h
+        include/EMCALCalib/CellRecalibrator.h
         LINKDEF src/EMCALCalibLinkDef.h)
 
 o2_add_test(BadChannelMap

--- a/Detectors/EMCAL/calib/include/EMCALCalib/CellRecalibrator.h
+++ b/Detectors/EMCAL/calib/include/EMCALCalib/CellRecalibrator.h
@@ -1,0 +1,205 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef ALCEO2_EMCAL_CELLRECALIBRATOR_H
+#define ALCEO2_EMCAL_CELLRECALIBRATOR_H
+
+#include <exception>
+#include <iosfwd>
+#include <optional>
+#include <vector>
+#include <gsl/span>
+
+#include "Rtypes.h"
+
+#include <DataFormatsEMCAL/Constants.h>
+#include <EMCALCalib/BadChannelMap.h>
+#include <EMCALCalib/TimeCalibrationParams.h>
+#include <EMCALCalib/GainCalibrationFactors.h>
+
+namespace o2
+{
+
+namespace emcal
+{
+
+/// \class CellRecalibrator
+/// \brief Tool for recalibration at cell level
+/// \ingroup EMCALcalib
+/// \author Markus Fasel <markus.fasel@cern.ch> Oak Ridge National Laboratory
+/// \since Oct 12, 2022
+///
+/// Applying cell-level calibrations
+/// - bad channel removal
+/// - time shift
+/// - gain calibration
+///
+/// Attention: All calibrations for which calibration objects
+/// are provided are applied. Check for active calibration is
+/// therefore related to the presence of the corresponding
+/// calibration object.
+///
+/// Input can be a single cell (getCalibratedCell) or a
+/// collection of cells (getCalibratedCells). In case of
+/// single cell the result is optional since the cell can
+/// be rejected by the bad channel mask. Only cells of type
+/// high gain or low gain can be calibrated, in case cells
+/// of other types (LEDMON/TRU) are passed to getCalibratedCell
+/// an exception will be thrown.
+///
+/// The calibrator supports all cells of the CellInterface
+/// concept.
+class CellRecalibrator
+{
+ public:
+  /// \class CellTypeException
+  /// \brief Handling of invalid cell types in calibration
+  class CellTypeException : public std::exception
+  {
+   public:
+    /// \brief Constructor
+    CellTypeException() = default;
+
+    /// \brief Destructor
+    ~CellTypeException() noexcept final = default;
+
+    /// \brief Get error message of the exception
+    /// \return Error message
+    const char* what() const noexcept final
+    {
+      return "Only possible to calibrate cells of type high gain or low gain";
+    }
+  };
+
+  /// \brief Constructor
+  CellRecalibrator() = default;
+
+  /// \brief Destructor
+  ~CellRecalibrator() = default;
+
+  /// \brief Set the bad channel map
+  /// \param bcm Bad channel map to be applied
+  void setBadChannelMap(const BadChannelMap* bcm) { mBadChannelMap = bcm; }
+
+  /// \brief Set the time calibration params
+  /// \param tcp Time calibration params to be applied
+  void setTimeCalibration(const TimeCalibrationParams* tcp) { mTimeCalibration = tcp; }
+
+  /// \brief Set the gain calibration params
+  /// \param gcf Gain calibration factors to be applied
+  void setGainCalibration(const GainCalibrationFactors* gcf) { mGainCalibration = gcf; }
+
+  /// \brief Check if the bad channel calibration is enabled
+  /// \return True if the bad channel calibration is active (object available), false otherwise
+  bool hasBadChannelMap() const { return mBadChannelMap != nullptr; }
+
+  /// \brief Check if the time calibration is enabled
+  /// \return True if the time calibration is active (object available), false otherwise
+  bool hasTimeCalibration() const { return mTimeCalibration != nullptr; }
+
+  /// \brief Check if the energy calibration is enabled
+  /// \return True if the energy calibration is active (object available), false otherwise
+  bool hasGainCalibration() const { return mGainCalibration != nullptr; }
+
+  /// \brief Get bad channel map currently used in the calibrator
+  /// \return Current bad channel map (nullptr if not set)
+  const BadChannelMap* getBadChannelMap() const { return mBadChannelMap; }
+
+  /// \brief Get time calibration parameters currently used in the calibrator
+  /// \return Current time calibration parameters (nullptr if not set)
+  const TimeCalibrationParams* getTimeCalibration() const { return mTimeCalibration; }
+
+  /// \brief Get gain calibration factors currently used in the calibrator
+  /// \return Current gain calibration factors (nullptr if not set)
+  const GainCalibrationFactors* getGainCalibration() const { return mGainCalibration; }
+
+  /// \brief Calibrate single cell
+  ///
+  /// Applying all calibrations provided based on presence of calibration objects. Only
+  /// cells of type high-gain or low-gain can be calibrated. Since the cell can be rejected
+  /// by the bad channel calibration the return type is std::optional, where an empty optional
+  /// reflects rejected cells.
+  ///
+  /// \param inputcell Cell to calibrate
+  /// \return Calibrated cell (empty optional if rejected by the bad channel map)
+  /// \throw CellTypeException in case the inputcell is neither of type high gain nor low gain
+  template <typename T>
+  std::optional<T> getCalibratedCell(const T& inputcell) const
+  {
+    if (!(inputcell.getHighGain() || inputcell.getLowGain())) {
+      throw CellTypeException();
+    }
+    if (hasBadChannelMap()) {
+      if (mBadChannelMap->getChannelStatus(inputcell.getTower()) != BadChannelMap::MaskType_t::GOOD_CELL) {
+        return std::optional<T>();
+      }
+    }
+
+    float calibratedEnergy = inputcell.getTimeStamp();
+    float calibratedTime = inputcell.getEnergy();
+
+    if (hasTimeCalibration()) {
+      calibratedTime -= mTimeCalibration->getTimeCalibParam(inputcell.getTower(), inputcell.getLowGain());
+    }
+
+    if (hasGainCalibration()) {
+      calibratedEnergy *= mGainCalibration->getGainCalibFactors(inputcell.getTower());
+    }
+    return std::make_optional<T>(inputcell.getTower(), calibratedEnergy, calibratedTime, inputcell.getHighGain() ? ChannelType_t::HIGH_GAIN : ChannelType_t::LOW_GAIN);
+  }
+
+  /// \brief Get list of calibrated cells based on a cell input collection
+  ///
+  /// Applying calibrations to all cells in the input collections and return
+  /// a vector of accepted and calibrated cells. Cells not of type high gain
+  /// or low gain are discarded. All calibrations for which calibration objects
+  /// are available are applied.
+  ///
+  /// \param inputcells Collection of input cells
+  /// \return vector of calibrated cells.
+  template <typename T>
+  std::vector<T> getCalibratedCells(const gsl::span<const T> inputcells)
+  {
+    std::vector<T> result;
+    for (const auto& cellToCalibrate : inputcells) {
+      if (!(cellToCalibrate.getHighGain() || cellToCalibrate.getLowGain())) {
+        continue;
+      }
+      auto calibrated = getCalibratedCell(cellToCalibrate);
+      if (calibrated) {
+        result.push_back(calibrated.value());
+      }
+    }
+    return result;
+  }
+
+  /// \brief Print settings to the stream
+  /// \param stream Stream to print on
+  void printStream(std::ostream& stream) const;
+
+ private:
+  const BadChannelMap* mBadChannelMap = nullptr;            ///< Bad channel map
+  const TimeCalibrationParams* mTimeCalibration = nullptr;  ///< Time calibration parameters
+  const GainCalibrationFactors* mGainCalibration = nullptr; ///< Gain calibration parameters
+
+  ClassDefNV(CellRecalibrator, 1);
+};
+
+/// \brief Output stream operator for cell-level calibrator
+/// \param in Stream to print on
+/// \param calib CellRecalibrator object to be printed
+/// \return Stream after printing
+std::ostream& operator<<(std::ostream& in, const CellRecalibrator& calib);
+
+} // namespace emcal
+
+} // namespace o2
+
+#endif // !ALCEO2_EMCAL_CELLRECALIBRATOR_H

--- a/Detectors/EMCAL/calib/src/CellRecalibrator.cxx
+++ b/Detectors/EMCAL/calib/src/CellRecalibrator.cxx
@@ -1,0 +1,30 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <iostream>
+#include <EMCALCalib/CellRecalibrator.h>
+
+using namespace o2::emcal;
+
+void CellRecalibrator::printStream(std::ostream& stream) const
+{
+  stream << "Calibrator settings: \n"
+         << "==========================================================="
+         << "  Bad channel map:              " << (hasBadChannelMap() ? "yes" : "no") << "\n"
+         << "  Time calibration params:      " << (hasTimeCalibration() ? "yes" : "no") << "\n"
+         << "  Energy calibration factors:   " << (hasGainCalibration() ? "yes" : "no") << "\n";
+}
+
+std::ostream& o2::emcal::operator<<(std::ostream& in, const o2::emcal::CellRecalibrator& calibrator)
+{
+  calibrator.printStream(in);
+  return in;
+}

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/CalibLoader.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/CalibLoader.h
@@ -9,6 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#include <bitset>
 #include <vector>
 #include <Framework/ProcessingContext.h>
 #include "Framework/ConcreteDataMatcher.h"
@@ -70,6 +71,18 @@ class CalibLoader
   /// \return True if the gain calibration factors are handled, false otherwise
   bool hasGainCalib() const { return mEnableGainCalib; }
 
+  /// \brief Check whether the bad channel map has been updated
+  /// \return True if the bad channel map has been updated, false otherwise
+  bool hasUpdateBadChannelMap() const { return mUpdateStatus.test(OBJ_BADCHANNELMAP); }
+
+  /// \brief Check whether the time calibration params have been updated
+  /// \return True if the time calibration params have been updated, false otherwise
+  bool hasUpdateTimeCalib() const { return mUpdateStatus.test(OBJ_TIMECALIB); }
+
+  /// \brief Check whether the gain calibration params have been updated
+  /// \return True if the gain calibration params have been updated, false  otherwise
+  bool hasUpdateGainCalib() const { return mUpdateStatus.test(OBJ_GAINCALIB); }
+
   /// \brief Enable loading of the bad channel map
   /// \param doEnable If true the bad channel map is loaded (per default from CCDB)
   void enableBadChannelMap(bool doEnable) { mEnableBadChannelMap = doEnable; }
@@ -81,6 +94,18 @@ class CalibLoader
   /// \brief Enable loading of the gain calibration factors
   /// \param doEnable If true the gain calibration factors are loaded (per default from CCDB)
   void enableGainCalib(bool doEnable) { mEnableGainCalib = doEnable; }
+
+  /// \brief Mark bad channel map as updated
+  void setUpdateBadChannelMap() { mUpdateStatus.set(OBJ_BADCHANNELMAP, true); }
+
+  /// \brief Mark time calibration params as updated
+  void setUpdateTimeCalib() { mUpdateStatus.set(OBJ_TIMECALIB, true); }
+
+  /// \brief Mark gain calibration params as updated
+  void setUpdateGainCalib() { mUpdateStatus.set(OBJ_GAINCALIB, true); }
+
+  /// \brief Reset the update status (all objects marked as false)
+  void resetUpdateStatus() { mUpdateStatus.reset(); }
 
   /// \brief Define input specs in workflow for calibration objects to be loaded from the CCDB
   /// \param ccdbInputs List of inputs where the CCDB input specs will be added to
@@ -104,12 +129,18 @@ class CalibLoader
   bool finalizeCCDB(framework::ConcreteDataMatcher& matcher, void* obj);
 
  private:
+  enum CalibObject_t {
+    OBJ_BADCHANNELMAP,
+    OBJ_TIMECALIB,
+    OBJ_GAINCALIB
+  };
   bool mEnableBadChannelMap;                                     ///< Switch for enabling / disabling loading of the bad channel map
   bool mEnableTimeCalib;                                         ///< Switch for enabling / disabling loading of the time calibration params
   bool mEnableGainCalib;                                         ///< Switch for enabling / disabling loading of the gain calibration params
   o2::emcal::BadChannelMap* mBadChannelMap = nullptr;            ///< Container of current bad channel map
   o2::emcal::TimeCalibrationParams* mTimeCalibParams = nullptr;  ///< Container of current time calibration object
   o2::emcal::GainCalibrationFactors* mGainCalibParams = nullptr; ///< Container of current gain calibration object
+  std::bitset<16> mUpdateStatus;                                 ///< Object update status
 };
 
 } // namespace emcal

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/CellRecalibratorSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/CellRecalibratorSpec.h
@@ -12,6 +12,7 @@
 #include <bitset>
 #include <cstdint>
 #include <optional>
+#include "EMCALCalib/CellRecalibrator.h"
 #include "EMCALWorkflow/CalibLoader.h"
 #include "Framework/ConcreteDataMatcher.h"
 #include "Framework/DataProcessorSpec.h"
@@ -107,15 +108,7 @@ class CellRecalibratorSpec : public framework::Task
   bool isRunGainCalibration() const { return mCalibrationSettings.test(GAIN_CALIB); }
 
  private:
-  /// \brief Apply requested calibrations to the cell
-  /// \param inputcell Cell to be calibrated
-  /// \return Optional of calibrated cell (empty optional in case the cell is rejected as bad or dead)
-  ///
-  /// Recalibrating cell for energy and time, and check whether the corresponding tower is not
-  /// marked as bad or dead. Only calibrations which are enabled are applied.
-  std::optional<o2::emcal::Cell> getCalibratedCell(const o2::emcal::Cell& inputcell) const;
-
-  /// \brief Update internal cache of calibration objects
+  /// \brief Update calibration objects (if changed)
   void updateCalibObjects();
 
   /// \enum CalibrationType_t
@@ -126,12 +119,10 @@ class CellRecalibratorSpec : public framework::Task
     GAIN_CALIB = 2        ///< Gain calibration
   };
 
-  uint32_t mOutputSubspec = 0;                              ///< output subspecification;
-  std::bitset<8> mCalibrationSettings;                      ///< Recalibration settings (which calibration to be applied)
-  std::shared_ptr<CalibLoader> mCalibrationHandler;         ///< Handler loading calibration objects
-  const BadChannelMap* mBadChannelMap = nullptr;            ///< Bad channelMap
-  const TimeCalibrationParams* mTimeCalibration = nullptr;  ///< Time calibration coefficients
-  const GainCalibrationFactors* mGainCalibration = nullptr; ///< Gain calibration factors
+  uint32_t mOutputSubspec = 0;                      ///< output subspecification;
+  std::bitset<8> mCalibrationSettings;              ///< Recalibration settings (which calibration to be applied)
+  std::shared_ptr<CalibLoader> mCalibrationHandler; ///< Handler loading calibration objects
+  CellRecalibrator mCellRecalibrator;               ///< Recalibrator at cell level
 };
 
 /// \brief Create CellRecalibrator processor spec

--- a/Detectors/EMCAL/workflow/src/CalibLoader.cxx
+++ b/Detectors/EMCAL/workflow/src/CalibLoader.cxx
@@ -37,6 +37,7 @@ void CalibLoader::defineInputSpecs(std::vector<o2::framework::InputSpec>& inputs
 
 void CalibLoader::checkUpdates(o2::framework::ProcessingContext& ctx)
 {
+  resetUpdateStatus();
   if (hasBadChannelMap()) {
     ctx.inputs().get<o2::emcal::BadChannelMap*>("badChannelMap");
   }
@@ -54,6 +55,7 @@ bool CalibLoader::finalizeCCDB(o2::framework::ConcreteDataMatcher& matcher, void
     if (hasBadChannelMap()) {
       LOG(info) << "New bad channel map loaded";
       mBadChannelMap = reinterpret_cast<o2::emcal::BadChannelMap*>(obj);
+      setUpdateBadChannelMap();
     } else {
       LOG(error) << "New bad channel map available even though bad channel calibration was not enabled, not loading";
     }
@@ -63,6 +65,7 @@ bool CalibLoader::finalizeCCDB(o2::framework::ConcreteDataMatcher& matcher, void
     if (hasTimeCalib()) {
       LOG(info) << "New time calibration paramset loaded";
       mTimeCalibParams = reinterpret_cast<o2::emcal::TimeCalibrationParams*>(obj);
+      setUpdateTimeCalib();
     } else {
       LOG(error) << "New time calibration paramset available even though time calibration was not enabled, not loading";
     }
@@ -72,6 +75,7 @@ bool CalibLoader::finalizeCCDB(o2::framework::ConcreteDataMatcher& matcher, void
     if (hasGainCalib()) {
       LOG(info) << "New gain calibration paramset loaded";
       mGainCalibParams = reinterpret_cast<o2::emcal::GainCalibrationFactors*>(obj);
+      setUpdateGainCalib();
     } else {
       LOG(error) << "New gain calibration paramset available even though the gain calibration was not enabled, not loading";
     }


### PR DESCRIPTION
Outsource all calibrations applied in the cell-recalibrator-
workflow into a stand-alone tool that can be used on-the-
fly. CCDB objects must be set from outside. Two methods
applying calibrations are provided, one for a single cell
and one for a collection of cells (both templated in order
to support different objects inplemeting the CellInterface)