### PR TITLE
TRD: calibration: Separated calibration methods

### DIFF
--- a/DataFormats/Detectors/TRD/CMakeLists.txt
+++ b/DataFormats/Detectors/TRD/CMakeLists.txt
@@ -35,6 +35,7 @@ o2_target_root_dictionary(DataFormatsTRD
                        include/DataFormatsTRD/CalibratedTracklet.h
                        include/DataFormatsTRD/DcsCcdbObjects.h
                        include/DataFormatsTRD/AngularResidHistos.h
+                       include/DataFormatsTRD/GainCalibration.h
                        include/DataFormatsTRD/HelperMethods.h
                        include/DataFormatsTRD/Hit.h
                        include/DataFormatsTRD/Digit.h
@@ -43,6 +44,7 @@ o2_target_root_dictionary(DataFormatsTRD
                        include/DataFormatsTRD/NoiseCalibration.h
                        include/DataFormatsTRD/CTF.h
                        include/DataFormatsTRD/CalVdriftExB.h
+                       include/DataFormatsTRD/CalGain.h
                        include/DataFormatsTRD/CalT0.h
                        include/DataFormatsTRD/SignalArray.h
                        include/DataFormatsTRD/CompressedDigit.h

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/CalGain.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/CalGain.h
@@ -1,0 +1,42 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file CalGain.h
+/// \brief This file holds the gain calibration object to be written into the CCDB
+/// \author Felix Schlepper
+
+#ifndef O2_TRD_CALGAIN_H
+#define O2_TRD_CALGAIN_H
+
+namespace o2
+{
+namespace trd
+{
+
+/// Defines the gain calibration object.
+/// ...
+class CalGain
+{
+ public:
+  /// Default constructor
+  CalGain() = default;
+  /// Default copy constructor
+  CalGain(const CalGain&) = default;
+  /// Default destructor
+  ~CalGain() = default;
+
+ private:
+};
+
+} // namespace trd
+} // namespace o2
+
+#endif // O2_TRD_CALGAIN_H

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/GainCalibration.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/GainCalibration.h
@@ -1,0 +1,50 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file GainCalibration.h
+/// \brief This file holds the gain calibration object
+/// \author Felix Schlepper
+
+#ifndef O2_TRD_GAINCALIBRATION_H
+#define O2_TRD_GAINCALIBRATION_H
+
+#include <gsl/span>
+
+namespace o2
+{
+namespace trd
+{
+
+/// Defines the gain calibration object.
+/// ...
+class GainCalibration
+{
+ public:
+  /// Default constructor
+  GainCalibration() = default;
+  /// Default copy constructor
+  GainCalibration(const GainCalibration&) = default;
+  /// Default destructor
+  ~GainCalibration() = default;
+
+  // TODO
+  void fill(const GainCalibration& input) {}
+  void fill(const gsl::span<const GainCalibration> input) {}
+  void merge(const GainCalibration* prev) {}
+  void print() {}
+
+ private:
+};
+
+} // namespace trd
+} // namespace o2
+
+#endif // O2_TRD_GAINCALIBRATION_H

--- a/Detectors/TRD/calibration/CMakeLists.txt
+++ b/Detectors/TRD/calibration/CMakeLists.txt
@@ -14,6 +14,7 @@ add_subdirectory(macros)
 o2_add_library(TRDCalibration
                SOURCES src/TrackBasedCalib.cxx
                        src/CalibratorVdExB.cxx
+                       src/CalibratorGain.cxx
                        src/KrClusterFinder.cxx
                        src/DCSProcessor.cxx
                PUBLIC_LINK_LIBRARIES O2::TRDBase
@@ -28,6 +29,7 @@ o2_add_library(TRDCalibration
  o2_target_root_dictionary(TRDCalibration
                            HEADERS include/TRDCalibration/TrackBasedCalib.h
                                    include/TRDCalibration/CalibratorVdExB.h
+                                   include/TRDCalibration/CalibratorGain.h
                                    include/TRDCalibration/KrClusterFinder.h
                                    include/TRDCalibration/DCSProcessor.h)
 

--- a/Detectors/TRD/calibration/README.md
+++ b/Detectors/TRD/calibration/README.md
@@ -51,7 +51,7 @@ TODO...
 If you want to run the calibration from a local file with residuals, ?.root, you can run:
 
     o2-calibration-trd -b --gain --enable-root-input-gain --gain-opts '--tf-per-slot 1 --min-entries 50000'
-    
+
 ## DCS data points
 
 To process the DCS data points for the TRD the list of aliases for example "trd_gaschromatographXe" has to be available in the CCDB.

--- a/Detectors/TRD/calibration/README.md
+++ b/Detectors/TRD/calibration/README.md
@@ -15,13 +15,13 @@ The histograms are send to aggregator nodes which calculate for each TRD chamber
 
 To run the calibration one can start the following workflow:
 
-    o2-trd-global-tracking -b --disable-root-output --enable-trackbased-calib | o2-calibration-trd-vdrift-exb -b --calib-vdexb-calibration '--tf-per-slot 5 --min-entries 50000 --max-delay 90000'
+    o2-trd-global-tracking -b --disable-root-output --enable-trackbased-calib | o2-calibration-trd -b --vdexb --vdexb-opts '--tf-per-slot 5 --min-entries 50000 --max-delay 90000'
 
-*Hint: You can get information on the meaning of the parameters by running `o2-calibration-trd-vdrift-exb -b --help full`*
+*Hint: You can get information on the meaning of the parameters by running `o2-calibration-trd --vdexb -b --help full`*
 
 If you want to run the calibration from a local file with residuals, trdangreshistos.root, you can run:
 
-    o2-calibration-trd-vdrift-exb -b --enable-root-input --calib-vdexb-calibration '--tf-per-slot 1 --min-entries 50000'
+    o2-calibration-trd -b --vdexb --enable-root-input-vdexb --vdexb-opts '--tf-per-slot 1 --min-entries 50000'
 
 Additionally it is possible to perform the calibrations fit manually per chamber if you have TPC-TRD or ITS-TPC-TRD tracks, you can run:
 
@@ -32,7 +32,7 @@ Then run the macro `Detectors/TRD/calibration/macros/manualCalibFit.C`.
 This produces a file of similar name with the fitted data and prints out the fit results.
 This is equivalent to running:
 
-    o2-calibration-trd-vdrift-exb -b --enable-root-input '--tf-per-slot 1 --min-entries 2000 --enable-root-output'
+    o2-calibration-trd --vdexb -b --enable-root-input--vdexb '--tf-per-slot 1 --min-entries 2000 --enable-root-output'
 
 You can plot the calibration values for VDrift and ExB for a given Run by using the macro at `Detectors/TRD/cailbration/macros/plotVdriftExB.C`.
 This produces a root file of similar name which holds the time-series plots (reference the macro).
@@ -44,6 +44,14 @@ For that you can use the macro at `Detectors/TRD/calibration/macros/makeDeflecti
 
 In the macro you have to point to the right Run and potentially the correct CCDB.
 
+## Gain Calibration
+
+TODO...
+
+If you want to run the calibration from a local file with residuals, ?.root, you can run:
+
+    o2-calibration-trd -b --gain --enable-root-input-gain --gain-opts '--tf-per-slot 1 --min-entries 50000'
+    
 ## DCS data points
 
 To process the DCS data points for the TRD the list of aliases for example "trd_gaschromatographXe" has to be available in the CCDB.

--- a/Detectors/TRD/calibration/include/TRDCalibration/CalibratorGain.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/CalibratorGain.h
@@ -54,10 +54,10 @@ class CalibratorGain final : public o2::calibration::TimeSlotCalibration<o2::trd
   void initProcessing();
 
  private:
-  bool mInitDone{false}; ///< flag to avoid creating the TProfiles multiple times
-  bool mEnableOutput;    ///< enable output of calibration fits and tprofiles in a root file instead of the ccdb
+  bool mInitDone{false};                             ///< flag to avoid creating the TProfiles multiple times
+  bool mEnableOutput;                                ///< enable output of calibration fits and tprofiles in a root file instead of the ccdb
   std::vector<o2::ccdb::CcdbObjectInfo> mInfoVector; ///< vector of CCDB infos; each element is filled with CCDB description of accompanying CCDB calibration object
-  std::vector<o2::trd::CalGain> mObjectVector;  ///< vector of CCDB calibration objects; the extracted ... TODO
+  std::vector<o2::trd::CalGain> mObjectVector;       ///< vector of CCDB calibration objects; the extracted ... TODO
 
   ClassDefOverride(CalibratorGain, 1);
 };

--- a/Detectors/TRD/calibration/include/TRDCalibration/CalibratorGain.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/CalibratorGain.h
@@ -1,0 +1,68 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file CalibratorVdExB.h
+/// \brief TimeSlot-based calibration of vDrift and ExB
+/// \author Ole Schmidt
+
+#ifndef O2_TRD_CALIBRATORGAIN_H
+#define O2_TRD_CALIBRATORGAIN_H
+
+#include "DetectorsCalibration/TimeSlotCalibration.h"
+#include "DetectorsCalibration/TimeSlot.h"
+#include "DataFormatsTRD/Constants.h"
+#include "DataFormatsTRD/CalGain.h"
+#include "DataFormatsTRD/GainCalibration.h"
+#include "CCDB/CcdbObjectInfo.h"
+
+#include "Rtypes.h"
+#include "TProfile.h"
+
+#include <array>
+#include <cstdlib>
+
+namespace o2
+{
+namespace trd
+{
+
+class CalibratorGain final : public o2::calibration::TimeSlotCalibration<o2::trd::GainCalibration, o2::trd::GainCalibration>
+{
+  using Slot = o2::calibration::TimeSlot<o2::trd::GainCalibration>;
+
+ public:
+  CalibratorGain(bool enableOut = false) : mEnableOutput(enableOut) {}
+  ~CalibratorGain() final = default;
+
+  bool hasEnoughData(const Slot& slot) const final { return true; }
+  void initOutput() final;
+  void finalizeSlot(Slot& slot) final;
+  Slot& emplaceNewSlot(bool front, TFType tStart, TFType tEnd) final;
+
+  // TODO
+  const std::vector<o2::trd::CalGain>& getCcdbObjectVector() const { return mObjectVector; }
+  std::vector<o2::ccdb::CcdbObjectInfo>& getCcdbObjectInfoVector() { return mInfoVector; }
+
+  void initProcessing();
+
+ private:
+  bool mInitDone{false}; ///< flag to avoid creating the TProfiles multiple times
+  bool mEnableOutput;    ///< enable output of calibration fits and tprofiles in a root file instead of the ccdb
+  std::vector<o2::ccdb::CcdbObjectInfo> mInfoVector; ///< vector of CCDB infos; each element is filled with CCDB description of accompanying CCDB calibration object
+  std::vector<o2::trd::CalGain> mObjectVector;  ///< vector of CCDB calibration objects; the extracted ... TODO
+
+  ClassDefOverride(CalibratorGain, 1);
+};
+
+} // namespace trd
+} // namespace o2
+
+#endif // O2_TRD_CALIBRATORGAIN_H

--- a/Detectors/TRD/calibration/src/CalibratorGain.cxx
+++ b/Detectors/TRD/calibration/src/CalibratorGain.cxx
@@ -28,7 +28,6 @@ using namespace o2::trd::constants;
 namespace o2::trd
 {
 
-
 using Slot = o2::calibration::TimeSlot<GainCalibration>;
 
 void CalibratorGain::initOutput()

--- a/Detectors/TRD/calibration/src/CalibratorGain.cxx
+++ b/Detectors/TRD/calibration/src/CalibratorGain.cxx
@@ -1,0 +1,79 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file CalibratorGain.cxx
+/// \brief TimeSlot-based calibration of gain
+/// \author Felix Schlepper
+
+#include "TRDCalibration/CalibratorGain.h"
+#include "TStopwatch.h"
+#include "CCDB/CcdbApi.h"
+#include "CCDB/BasicCCDBManager.h"
+#include <string>
+#include <map>
+#include <memory>
+#include "CommonUtils/NameConf.h"
+#include "CommonUtils/MemFileHelper.h"
+
+using namespace o2::trd::constants;
+
+namespace o2::trd
+{
+
+
+using Slot = o2::calibration::TimeSlot<GainCalibration>;
+
+void CalibratorGain::initOutput()
+{
+  // reset the CCDB output vectors
+  mInfoVector.clear();
+  mObjectVector.clear();
+}
+
+void CalibratorGain::initProcessing()
+{
+  if (mInitDone) {
+    return;
+  }
+}
+
+void CalibratorGain::finalizeSlot(Slot& slot)
+{
+  // do actual calibration for the data provided in the given slot
+  TStopwatch timer;
+  timer.Start();
+  // TODO processing
+  timer.Stop();
+  LOGF(info, "Done fitting angular residual histograms. CPU time: %f, real time: %f", timer.CpuTime(), timer.RealTime());
+
+  // Write results to file
+  if (mEnableOutput) {
+  }
+
+  // assemble CCDB object
+  CalGain calObject;
+  auto clName = o2::utils::MemFileHelper::getClassName(calObject);
+  auto flName = o2::ccdb::CcdbApi::generateFileName(clName);
+  std::map<std::string, std::string> metadata; // TODO: do we want to store any meta data?
+  long startValidity = slot.getStartTimeMS() - 10 * o2::ccdb::CcdbObjectInfo::SECOND;
+  mInfoVector.emplace_back("TRD/Calib/Gain", clName, flName, metadata, startValidity, startValidity + o2::ccdb::CcdbObjectInfo::HOUR);
+  mObjectVector.push_back(calObject);
+}
+
+Slot& CalibratorGain::emplaceNewSlot(bool front, TFType tStart, TFType tEnd)
+{
+  auto& container = getSlots();
+  auto& slot = front ? container.emplace_front(tStart, tEnd) : container.emplace_back(tStart, tEnd);
+  slot.setContainer(std::make_unique<GainCalibration>());
+  return slot;
+}
+
+} // namespace o2::trd

--- a/Detectors/TRD/calibration/src/TRDCalibrationLinkDef.h
+++ b/Detectors/TRD/calibration/src/TRDCalibrationLinkDef.h
@@ -18,6 +18,9 @@
 #pragma link C++ class o2::trd::CalibratorVdExB + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::trd::AngularResidHistos> + ;
 #pragma link C++ class o2::calibration::TimeSlotCalibration < o2::trd::AngularResidHistos, o2::trd::AngularResidHistos> + ;
+#pragma link C++ class o2::trd::CalibratorGain + ;
+#pragma link C++ class o2::calibration::TimeSlot < o2::trd::GainCalibration> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::trd::GainCalibration, o2::trd::GainCalibration> + ;
 #pragma link C++ class o2::trd::TrackBasedCalib + ;
 #pragma link C++ class o2::trd::KrClusterFinder + ;
 #pragma link C++ class std::unordered_map < o2::dcs::DataPointIdentifier, o2::trd::TRDDCSMinMaxMeanInfo> + ;

--- a/Detectors/TRD/workflow/CMakeLists.txt
+++ b/Detectors/TRD/workflow/CMakeLists.txt
@@ -23,6 +23,7 @@ o2_add_library(TRDWorkflow
                        src/TrackBasedCalibSpec.cxx
                        src/KrClustererSpec.cxx
                        include/TRDWorkflow/VdAndExBCalibSpec.h
+                       include/TRDWorkflow/GainCalibSpec.h
                        include/TRDWorkflow/TRDGlobalTrackingQCSpec.h
                PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::Steer O2::Algorithm O2::DataFormatsTRD O2::TRDSimulation O2::TRDReconstruction O2::TRDQC O2::DetectorsBase O2::SimulationDataFormat O2::TRDBase O2::TRDCalibration O2::GPUTracking O2::GlobalTrackingWorkflowHelpers O2::GlobalTrackingWorkflowReaders O2::GPUWorkflowHelper O2::ReconstructionDataFormats O2::ITSWorkflow O2::TPCWorkflow O2::TRDWorkflowIO)
 
@@ -51,7 +52,7 @@ o2_add_executable(event-display-feed
                   SOURCES src/TRDEventDisplayFeedWorkflow.cxx
                   PUBLIC_LINK_LIBRARIES O2::TRDWorkflow)
 
-o2_add_executable(trd-vdrift-exb
+o2_add_executable(trd
                   COMPONENT_NAME calibration
                   SOURCES src/trd-calib-workflow.cxx
                   PUBLIC_LINK_LIBRARIES O2::Framework O2::TRDCalibration O2::TRDWorkflow O2::DetectorsCalibration)

--- a/Detectors/TRD/workflow/io/CMakeLists.txt
+++ b/Detectors/TRD/workflow/io/CMakeLists.txt
@@ -12,14 +12,16 @@
 o2_add_library(TRDWorkflowIO
                SOURCES src/TRDDigitReaderSpec.cxx
                        src/TRDTrackletReaderSpec.cxx
-                       src/TRDCalibReaderSpec.cxx
+                       src/TRDCalibVdExBReaderSpec.cxx
+                       src/TRDCalibVdExBWriterSpec.cxx
+                       src/TRDCalibGainReaderSpec.cxx
+                       src/TRDCalibGainWriterSpec.cxx
                        src/TRDDigitWriterSpec.cxx
                        src/TRDTrackletWriterSpec.cxx
                        src/TRDTrapRawWriterSpec.cxx
                        src/TRDCalibratedTrackletWriterSpec.cxx
                        src/TRDTrackWriterSpec.cxx
                        src/TRDTrackReaderSpec.cxx
-                       src/TRDCalibWriterSpec.cxx
                        src/KrClusterWriterSpec.cxx
                PUBLIC_LINK_LIBRARIES O2::DataFormatsTRD O2::SimulationDataFormat O2::DPLUtils O2::GPUDataTypeHeaders O2::DataFormatsTPC)
 
@@ -28,6 +30,7 @@ o2_add_executable(track-reader
                  COMPONENT_NAME trd
                  SOURCES src/trd-track-reader-workflow.cxx
                  PUBLIC_LINK_LIBRARIES O2::TRDWorkflowIO)
+
 o2_add_executable(digittracklet-writer
                  COMPONENT_NAME trd
                  SOURCES src/trd-digittracklet-writer-workflow.cxx

--- a/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDCalibGainReaderSpec.h
+++ b/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDCalibGainReaderSpec.h
@@ -1,0 +1,53 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   TRDCalibGainReaderSpec.h
+/// \brief Calibration Reader for gain
+/// \author Felix Schlepper
+
+#ifndef O2_TRD_CALIBGAINREADER
+#define O2_TRD_CALIBGAINREADER
+
+#include "TFile.h"
+#include "TTree.h"
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+
+namespace o2
+{
+namespace trd
+{
+
+class TRDCalibGainReader : public o2::framework::Task
+{
+ public:
+  TRDCalibGainReader() = default;
+  ~TRDCalibGainReader() override = default;
+  void init(o2::framework::InitContext& ic) final;
+  void run(o2::framework::ProcessingContext& pc) final;
+
+ private:
+  void connectTree();
+  std::unique_ptr<TFile> mFile;
+  std::unique_ptr<TTree> mTree;
+  std::string mInFileName{"trdgain.root"};
+  std::string mInTreeName{"calibdata"};
+};
+
+/// create a processor spec
+/// read TRD calibration data from a root file
+framework::DataProcessorSpec getTRDCalibGainReaderSpec();
+
+} // namespace trd
+} // namespace o2
+
+#endif /* O2_TRD_CALIBGAINREADER */

--- a/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDCalibGainWriterSpec.h
+++ b/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDCalibGainWriterSpec.h
@@ -9,8 +9,8 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifndef O2_TRDCALIBWRITERSPEC_H
-#define O2_TRDCALIBWRITERSPEC_H
+#ifndef O2_TRDCALIBGAINWRITERSPEC_H
+#define O2_TRDCALIBGAINWRITERSPEC_H
 
 namespace o2
 {
@@ -25,9 +25,9 @@ namespace o2
 namespace trd
 {
 
-o2::framework::DataProcessorSpec getTRDCalibWriterSpec();
+o2::framework::DataProcessorSpec getTRDCalibGainWriterSpec();
 
 } // end namespace trd
 } // end namespace o2
 
-#endif // O2_TRDCALIBWRITERSPEC_H
+#endif // O2_TRDCALIBGAINWRITERSPEC_H

--- a/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDCalibVdExBReaderSpec.h
+++ b/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDCalibVdExBReaderSpec.h
@@ -9,10 +9,10 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// @file   TRDCalibReaderSpec.h
+/// @file   TRDCalibVdExBReaderSpec.h
 
-#ifndef O2_TRD_CALIBREADER
-#define O2_TRD_CALIBREADER
+#ifndef O2_TRD_CALIBVDEXBREADER
+#define O2_TRD_CALIBVDEXBREADER
 
 #include "TFile.h"
 #include "TTree.h"
@@ -26,11 +26,11 @@ namespace o2
 namespace trd
 {
 
-class TRDCalibReader : public o2::framework::Task
+class TRDCalibVdExBReader : public o2::framework::Task
 {
  public:
-  TRDCalibReader() = default;
-  ~TRDCalibReader() override = default;
+  TRDCalibVdExBReader() = default;
+  ~TRDCalibVdExBReader() override = default;
   void init(o2::framework::InitContext& ic) final;
   void run(o2::framework::ProcessingContext& pc) final;
 
@@ -45,9 +45,9 @@ class TRDCalibReader : public o2::framework::Task
 
 /// create a processor spec
 /// read TRD calibration data from a root file
-framework::DataProcessorSpec getTRDCalibReaderSpec();
+framework::DataProcessorSpec getTRDCalibVdExBReaderSpec();
 
 } // namespace trd
 } // namespace o2
 
-#endif /* O2_TRD_CALIBREADER */
+#endif /* O2_TRD_CALIBVDEXBREADER */

--- a/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDCalibVdExBWriterSpec.h
+++ b/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDCalibVdExBWriterSpec.h
@@ -1,0 +1,33 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TRDCALIBVDEXBWRITERSPEC_H
+#define O2_TRDCALIBVDEXBWRITERSPEC_H
+
+namespace o2
+{
+namespace framework
+{
+struct DataProcessorSpec;
+}
+} // namespace o2
+
+namespace o2
+{
+namespace trd
+{
+
+o2::framework::DataProcessorSpec getTRDCalibVdExBWriterSpec();
+
+} // end namespace trd
+} // end namespace o2
+
+#endif // O2_TRDCALIBVDEXBWRITERSPEC_H

--- a/Detectors/TRD/workflow/io/src/TRDCalibGainReaderSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDCalibGainReaderSpec.cxx
@@ -1,0 +1,83 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   TRDCalibGainReaderSpec.cxx
+
+#include "TRDWorkflowIO/TRDCalibGainReaderSpec.h"
+
+#include "Framework/ControlService.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "fairlogger/Logger.h"
+#include "CommonUtils/NameConf.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace trd
+{
+
+void TRDCalibGainReader::init(InitContext& ic)
+{
+  // get the option from the init context
+  LOG(info) << "Init TRD gain calibration reader!";
+  mInFileName = o2::utils::Str::concat_string(o2::utils::Str::rectifyDirectory(ic.options().get<std::string>("input-dir")),
+                                              ic.options().get<std::string>("trd-calib-infile"));
+  mInTreeName = o2::utils::Str::concat_string(o2::utils::Str::rectifyDirectory(ic.options().get<std::string>("input-dir")),
+                                              ic.options().get<std::string>("treename"));
+  connectTree();
+}
+
+void TRDCalibGainReader::connectTree()
+{
+  mTree.reset(nullptr); // in case it was already loaded
+  mFile.reset(TFile::Open(mInFileName.c_str()));
+  assert(mFile && !mFile->IsZombie());
+  mTree.reset((TTree*)mFile->Get(mInTreeName.c_str()));
+  assert(mTree);
+  // mTree->SetBranchAddress("AngularResids", &mAngResidPtr); TODO
+  LOG(info) << "Loaded tree from " << mInFileName << " with " << mTree->GetEntries() << " entries";
+}
+
+void TRDCalibGainReader::run(ProcessingContext& pc)
+{
+  auto currEntry = mTree->GetReadEntry() + 1;
+  assert(currEntry < mTree->GetEntries()); // this should not happen
+  mTree->GetEntry(currEntry);
+  // TODO
+  // LOG(info) << "Pushing angular residual histograms filled with " << mAngResids.getNEntries() << " entries at tree entry " << currEntry;
+  // pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "ANGRESHISTS", 0, Lifetime::Timeframe}, mAngResids);
+
+  if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
+    pc.services().get<ControlService>().endOfStream();
+    pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+  }
+}
+
+DataProcessorSpec getTRDCalibGainReaderSpec()
+{
+  std::vector<OutputSpec> outputs;
+  outputs.emplace_back(o2::header::gDataOriginTRD, "ANGRESHISTS", 0, Lifetime::Timeframe);
+
+  return DataProcessorSpec{
+    "TRDCalibGainReader",
+    Inputs{},
+    outputs,
+    AlgorithmSpec{adaptFromTask<TRDCalibGainReader>()},
+    Options{
+      {"trd-calib-infile", VariantType::String, "trdgainhistos.root", {"Name of the input file"}},
+      {"input-dir", VariantType::String, "none", {"Input directory"}},
+      {"treename", VariantType::String, "calibdata", {"Name of top-level TTree"}},
+    }};
+}
+
+} // namespace trd
+} // namespace o2

--- a/Detectors/TRD/workflow/io/src/TRDCalibGainWriterSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDCalibGainWriterSpec.cxx
@@ -1,0 +1,38 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/DataProcessorSpec.h"
+#include "DPLUtils/MakeRootTreeWriterSpec.h"
+#include "Framework/InputSpec.h"
+#include "TRDWorkflowIO/TRDCalibGainWriterSpec.h"
+#include "DataFormatsTRD/AngularResidHistos.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace trd
+{
+
+template <typename T>
+using BranchDefinition = framework::MakeRootTreeWriterSpec::BranchDefinition<T>;
+
+o2::framework::DataProcessorSpec getTRDCalibWriterSpec()
+{
+  using MakeRootTreeWriterSpec = framework::MakeRootTreeWriterSpec;
+  return MakeRootTreeWriterSpec("TRDCalibGainWriter",
+                                "trdgainhistos.root",
+                                "calibdata",
+                                BranchDefinition<o2::trd::AngularResidHistos>{InputSpec{"calibdata", "TRD", "GAINHISTS"}, "Gain"})();
+};
+
+} // end namespace trd
+} // end namespace o2

--- a/Detectors/TRD/workflow/io/src/TRDCalibVdExBReaderSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDCalibVdExBReaderSpec.cxx
@@ -9,9 +9,9 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// @file   TRDCalibReaderSpec.cxx
+/// @file   TRDCalibVdExBReaderSpec.cxx
 
-#include "TRDWorkflowIO/TRDCalibReaderSpec.h"
+#include "TRDWorkflowIO/TRDCalibVdExBReaderSpec.h"
 
 #include "Framework/ControlService.h"
 #include "Framework/ConfigParamRegistry.h"
@@ -25,10 +25,10 @@ namespace o2
 namespace trd
 {
 
-void TRDCalibReader::init(InitContext& ic)
+void TRDCalibVdExBReader::init(InitContext& ic)
 {
   // get the option from the init context
-  LOG(info) << "Init TRD tracklet reader!";
+  LOG(info) << "Init TRD VdExB calibration reader!";
   mInFileName = o2::utils::Str::concat_string(o2::utils::Str::rectifyDirectory(ic.options().get<std::string>("input-dir")),
                                               ic.options().get<std::string>("trd-calib-infile"));
   mInTreeName = o2::utils::Str::concat_string(o2::utils::Str::rectifyDirectory(ic.options().get<std::string>("input-dir")),
@@ -36,7 +36,7 @@ void TRDCalibReader::init(InitContext& ic)
   connectTree();
 }
 
-void TRDCalibReader::connectTree()
+void TRDCalibVdExBReader::connectTree()
 {
   mTree.reset(nullptr); // in case it was already loaded
   mFile.reset(TFile::Open(mInFileName.c_str()));
@@ -47,7 +47,7 @@ void TRDCalibReader::connectTree()
   LOG(info) << "Loaded tree from " << mInFileName << " with " << mTree->GetEntries() << " entries";
 }
 
-void TRDCalibReader::run(ProcessingContext& pc)
+void TRDCalibVdExBReader::run(ProcessingContext& pc)
 {
   auto currEntry = mTree->GetReadEntry() + 1;
   assert(currEntry < mTree->GetEntries()); // this should not happen
@@ -61,16 +61,16 @@ void TRDCalibReader::run(ProcessingContext& pc)
   }
 }
 
-DataProcessorSpec getTRDCalibReaderSpec()
+DataProcessorSpec getTRDCalibVdExBReaderSpec()
 {
   std::vector<OutputSpec> outputs;
   outputs.emplace_back(o2::header::gDataOriginTRD, "ANGRESHISTS", 0, Lifetime::Timeframe);
 
   return DataProcessorSpec{
-    "TRDCalibReader",
+    "TRDCalibVdExBReader",
     Inputs{},
     outputs,
-    AlgorithmSpec{adaptFromTask<TRDCalibReader>()},
+    AlgorithmSpec{adaptFromTask<TRDCalibVdExBReader>()},
     Options{
       {"trd-calib-infile", VariantType::String, "trdangreshistos.root", {"Name of the input file"}},
       {"input-dir", VariantType::String, "none", {"Input directory"}},

--- a/Detectors/TRD/workflow/io/src/TRDCalibVdExBWriterSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDCalibVdExBWriterSpec.cxx
@@ -12,7 +12,7 @@
 #include "Framework/DataProcessorSpec.h"
 #include "DPLUtils/MakeRootTreeWriterSpec.h"
 #include "Framework/InputSpec.h"
-#include "TRDWorkflowIO/TRDCalibWriterSpec.h"
+#include "TRDWorkflowIO/TRDCalibVdExBWriterSpec.h"
 #include "DataFormatsTRD/AngularResidHistos.h"
 
 using namespace o2::framework;
@@ -25,10 +25,10 @@ namespace trd
 template <typename T>
 using BranchDefinition = framework::MakeRootTreeWriterSpec::BranchDefinition<T>;
 
-o2::framework::DataProcessorSpec getTRDCalibWriterSpec()
+o2::framework::DataProcessorSpec getTRDCalibVdExBWriterSpec()
 {
   using MakeRootTreeWriterSpec = framework::MakeRootTreeWriterSpec;
-  return MakeRootTreeWriterSpec("TRDCalibWriter",
+  return MakeRootTreeWriterSpec("TRDCalibVdExBWriter",
                                 "trdangreshistos.root",
                                 "calibdata",
                                 BranchDefinition<o2::trd::AngularResidHistos>{InputSpec{"calibdata", "TRD", "ANGRESHISTS"}, "AngularResids"})();

--- a/Detectors/TRD/workflow/src/trd-calib-workflow.cxx
+++ b/Detectors/TRD/workflow/src/trd-calib-workflow.cxx
@@ -54,7 +54,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     }
     specs.emplace_back(getTRDGainCalibSpec());
   }
-  if(specs.empty()){
+  if (specs.empty()) {
     LOG(warn) << "No Calibration Mode selected, dilly-dallying...";
   }
   return specs;

--- a/Detectors/TRD/workflow/src/trd-tracking-workflow.cxx
+++ b/Detectors/TRD/workflow/src/trd-tracking-workflow.cxx
@@ -15,7 +15,7 @@
 #include "DetectorsRaw/HBFUtilsInitializer.h"
 #include "Framework/CallbacksPolicy.h"
 #include "ReconstructionDataFormats/GlobalTrackID.h"
-#include "TRDWorkflowIO/TRDCalibWriterSpec.h"
+#include "TRDWorkflowIO/TRDCalibVdExBWriterSpec.h"
 #include "TRDWorkflowIO/TRDTrackWriterSpec.h"
 #include "TRDWorkflow/TrackBasedCalibSpec.h"
 #include "TRDWorkflow/TRDGlobalTrackingSpec.h"
@@ -94,7 +94,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
       specs.emplace_back(o2::trd::getTRDTPCTrackWriterSpec(useMC, strict));
     }
     if (configcontext.options().get<bool>("enable-trackbased-calib")) {
-      specs.emplace_back(o2::trd::getTRDCalibWriterSpec());
+      specs.emplace_back(o2::trd::getTRDCalibVdExBWriterSpec());
     }
     if (configcontext.options().get<bool>("enable-qc")) {
       specs.emplace_back(o2::trd::getTRDTrackingQCWriterSpec());

--- a/prodtests/full-system-test/aggregator-workflow.sh
+++ b/prodtests/full-system-test/aggregator-workflow.sh
@@ -45,6 +45,7 @@ if [[ "0$GEN_TOPO_VERBOSE" == "01" ]]; then
   echo "CALIB_PHS_TURNONCALIB = $CALIB_PHS_TURNONCALIB" 1>&2
   echo "CALIB_PHS_RUNBYRUNCALIB = $CALIB_PHS_RUNBYRUNCALIB" 1>&2
   echo "CALIB_TRD_VDRIFTEXB = $CALIB_TRD_VDRIFTEXB" 1>&2
+  echo "CALIB_TRD_GAIN = $CALIB_TRD_GAIN" 1>&2
   echo "CALIB_TPC_TIMEGAIN = $CALIB_TPC_TIMEGAIN" 1>&2
   echo "CALIB_TPC_RESPADGAIN = $CALIB_TPC_RESPADGAIN" 1>&2
   echo "CALIB_TPC_SCDCALIB = $CALIB_TPC_SCDCALIB" 1>&2
@@ -185,7 +186,10 @@ if [[ $AGGREGATOR_TASKS == BARREL_TF ]] || [[ $AGGREGATOR_TASKS == ALL ]]; then
   fi
   # TRD
   if [[ $CALIB_TRD_VDRIFTEXB == 1 ]]; then
-    add_W o2-calibration-trd-vdrift-exb ""
+    add_W o2-calibration-trd "--vdexb"
+  fi
+  if [[ $CALIB_TRD_GAIN == 1 ]]; then
+    add_W o2-calibration-trd "--gain"
   fi
 fi
 


### PR DESCRIPTION
This patch separates the future gain from vdexb calibration clearly. As a consequence it introduces a new interface for o2-calibration-trd (renamed) as a generic binary and gives a bare bones structure for gain calibration.
The various classes introduced are subject to change in the future.

One can then select and configure different calibration methods:

1. `--vdexb` and `--enable-root-input-vdexb` for VDrift and ExB calibration, configurable with `--vdexb-opts`
2. `--gain` and `--enable-root-input-gain` for gain calibration, configurable with `--gain-opts`

This can easily be extended for other possible calibrations in the future.

Signed-off-by: Felix Schlepper <felix.schlepper@cern.ch>