### PR TITLE
Infologger cleanup

### DIFF
--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -1336,8 +1336,9 @@ bool MatchTPCITS::refitTrackTPCITS(int iTPC, int& iITS)
     auto posStart = tracOut.getXYZGlo();
     auto tImposed = timeC * mTPCTBinMUSInv;
     if (std::abs(tImposed - mTPCTracksArray[tTPC.sourceID].getTime0()) > 550) {
-      LOGP(error, "Impossible imposed timebin {} for TPC track time0:{}, dBwd:{} dFwd:{} TB | ZShift:{}, TShift:{} | Trc: {}", tImposed, mTPCTracksArray[tTPC.sourceID].getTime0(),
-           mTPCTracksArray[tTPC.sourceID].getDeltaTBwd(), mTPCTracksArray[tTPC.sourceID].getDeltaTFwd(), trfit.getZ() - tTPC.getZ(), deltaT, mTPCTracksArray[tTPC.sourceID].asString());
+      LOGP(alarm, "Impossible imposed timebin {} for TPC track time0:{}, dBwd:{} dFwd:{} TB | ZShift:{}, TShift:{}", tImposed, mTPCTracksArray[tTPC.sourceID].getTime0(),
+           mTPCTracksArray[tTPC.sourceID].getDeltaTBwd(), mTPCTracksArray[tTPC.sourceID].getDeltaTFwd(), trfit.getZ() - tTPC.getZ(), deltaT);
+      LOGP(info, "Trc: {}", mTPCTracksArray[tTPC.sourceID].asString());
       mMatchedTracks.pop_back(); // destroy failed track
       return false;
     }

--- a/Detectors/PHOS/reconstruction/src/RawReaderMemory.cxx
+++ b/Detectors/PHOS/reconstruction/src/RawReaderMemory.cxx
@@ -96,7 +96,14 @@ void RawReaderMemory::next()
     try {
       mCurrentTrailer.constructFromPayloadWords(mRawBuffer.getDataWords());
     } catch (RCUTrailer::Error& e) {
-      LOG(error) << "Trailer decoding error: " << e.what();
+      if (e.getErrorType() == RCUTrailer::Error::ErrorType_t::DECODING_INVALID) {
+        // OS: According to expert old error of PHOS SRU firmware, not
+        //     expected to be fixed soon, hence denoted to warning to
+        //     not alarm the shifters
+        LOG(warn) << "Trailer decoding error: " << e.what();
+      } else {
+        LOG(error) << "Trailer decoding error: " << e.what();
+      }
       throw RawDecodingError::ErrorType_t::HEADER_DECODING;
     }
   }

--- a/Detectors/TRD/reconstruction/src/CruRawReader.cxx
+++ b/Detectors/TRD/reconstruction/src/CruRawReader.cxx
@@ -648,16 +648,12 @@ bool CruRawReader::isTrackletHCHeaderOK(const TrackletHCHeader& header, int& hci
   int detHeader = HelperMethods::getDetector(((~header.supermodule) & 0x1f), ((~header.stack) & 0x7), ((~header.layer) & 0x7));
   int hcidHeader = (detHeader * 2 + ((~header.side) & 0x1));
   if (hcid != hcidHeader) {
-    if (mMaxWarnPrinted > 0) {
-      LOGF(alarm, "RDH HCID %i, TrackletHCHeader HCID %i. Taking the TrackletHCHedaer as authority", hcid, hcidHeader);
-      checkNoWarn();
-    }
     mHalfChamberMismatches.insert(std::make_pair(hcid, hcidHeader));
-    hcid = hcidHeader;
+    return false;
   } else {
     mHalfChamberHeaderOK.insert(hcid);
+    return true;
   }
-  return (hcid == hcidHeader);
 }
 
 int CruRawReader::parseDigitLinkData(int maxWords32, int hcid, int& wordsRejected)


### PR DESCRIPTION
- for PHOS see https://alice-qc-shifter.docs.cern.ch/pdp/infologgerMessages/#phos
- for TPC-ITS, also since with the multi-line message due to the `asString` method of the track parameters its not possible to filter out these errors via the text message. And since the data taking can continue I believe a warning should be OK but maybe @shahor02 wants to keep it?
- for TRD @bazinski and @tdietel  I saw that the mismatches are not not coming from incorrectly connected links anymore, but from corrupted headers instead. This I conclude, because you see data from one half-chamber where the header is correct and later on from the same link you get a different half-chamber ID from the TrackletHCHeader. This does not happen for every TF, but often enough to flood the InfoLogger. Now the error `TrackletHCHeaderFailure` is incremented and sent to QC. I will not just take the HCID from the header anymore, since in the worst case one puts data in the wrong half-chamber. In case of a wrongly connected link is still there we should see a spike in the QC plots