### PR TITLE
MCH: handle data truncation in User Logic

### DIFF
--- a/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/ErrorCodes.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/include/MCHRawDecoder/ErrorCodes.h
@@ -31,12 +31,13 @@ enum ErrorCodes {
   ErrorBadClusterSize = 1 << 6,              // 64
   ErrorBadIncompleteWord = 1 << 7,           // 128
   ErrorTruncatedData = 1 << 8,               // 256
-  ErrorUnexpectedSyncPacket = 1 << 9,        // 512
-  ErrorBadELinkID = 1 << 10,                 // 1024
-  ErrorBadLinkID = 1 << 11,                  // 2048
-  ErrorUnknownLinkID = 1 << 12,              // 4096
-  ErrorBadHBTime = 1 << 13,                  // 8192
-  ErrorNonRecoverableDecodingError = 1 << 14 // 16384
+  ErrorTruncatedDataUL = 1 << 9,             // 512
+  ErrorUnexpectedSyncPacket = 1 << 10,       // 1024
+  ErrorBadELinkID = 1 << 11,                 // 2048
+  ErrorBadLinkID = 1 << 12,                  // 4096
+  ErrorUnknownLinkID = 1 << 13,              // 8192
+  ErrorBadHBTime = 1 << 14,                  // 16384
+  ErrorNonRecoverableDecodingError = 1 << 15 // 32768
 };
 
 uint32_t getErrorCodesSize();

--- a/Detectors/MUON/MCH/Raw/Decoder/src/ErrorCodes.cxx
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/ErrorCodes.cxx
@@ -20,7 +20,7 @@ namespace raw
 
 uint32_t getErrorCodesSize()
 {
-  return 15;
+  return 16;
 }
 
 void append(const char* msg, std::string& to)
@@ -66,6 +66,9 @@ std::string errorCodeAsString(uint32_t ec)
   }
   if (ec & ErrorTruncatedData) {
     append("Truncated Data", msg);
+  }
+  if (ec & ErrorTruncatedDataUL) {
+    append("UL Truncated Data", msg);
   }
   if (ec & ErrorBadELinkID) {
     append("Bad E-Link ID", msg);

--- a/Detectors/MUON/MCH/Raw/Decoder/src/UserLogicElinkDecoder.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/UserLogicElinkDecoder.h
@@ -117,6 +117,15 @@ void UserLogicElinkDecoder<CHARGESUM>::append(uint64_t data50, uint8_t error, bo
   debugHeader() << (*this) << fmt::format(" --> append50 {:013x} error {} incomplete {} data10={:d} {:d} {:d} {:d} {:d}\n", data50, error, incomplete, static_cast<uint10_t>(data50 & 0x3FF), static_cast<uint10_t>((data50 & 0xFFC00) >> 10), static_cast<uint10_t>((data50 & 0x3FF00000) >> 20), static_cast<uint10_t>((data50 & 0xFFC0000000) >> 30), static_cast<uint10_t>((data50 & 0x3FF0000000000) >> 40));
 #endif
 
+  if (error & 0x1) {
+#ifdef ULDEBUG
+    debugHeader() << (*this) << " data truncated by User Logic --> resetting\n";
+#endif
+    sendError(static_cast<int8_t>(mSampaHeader.chipAddress()), static_cast<uint32_t>(ErrorTruncatedDataUL));
+    reset();
+    return;
+  }
+
   if (isSync(data50)) {
 #ifdef ULDEBUG
     debugHeader() << (*this) << fmt::format(" --> SYNC word found {:013x}   state={}\n", data50, asString(mState));


### PR DESCRIPTION
Added correct handling of the "truncated data" UserLogic error flag.
This error is set by the UserLogic when it receives too many consecutive data packets from one e-Link, without intermediate SYNC words.