### PR TITLE
[EMCAL-630] Add static methods for error code names and titles for all reconstruction error classes

### DIFF
--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/ErrorTypeFEE.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/ErrorTypeFEE.h
@@ -171,6 +171,20 @@ class ErrorTypeFEE
   /// Helper function, called in the output stream operator for the ErrorTypeFEE
   void PrintStream(std::ostream& stream) const;
 
+  /// \brief Get the number of error types
+  /// \return Number of error types (including undefined)
+  static constexpr int getNumberOfErrorTypes() { return 7; }
+
+  /// \brief Get the name of the error type
+  /// \param errorTypeID ID of the error type
+  /// \return Name of the error type
+  static const char* getErrorTypeName(unsigned int errorTypeID);
+
+  /// \brief Get the title of the error type
+  /// \param errorTypeID ID of the error type
+  /// \return Title of the error type
+  static const char* getErrorTypeTitle(unsigned int errorTypeID);
+
  private:
   /// \brief Helper function getting the error code under condition that the error is of a certain type
   /// \return Error code (-1 in case the error handle by the object is not of the given type)

--- a/DataFormats/Detectors/EMCAL/src/ErrorTypeFEE.cxx
+++ b/DataFormats/Detectors/EMCAL/src/ErrorTypeFEE.cxx
@@ -53,6 +53,50 @@ void ErrorTypeFEE::PrintStream(std::ostream& stream) const
   }
 }
 
+const char* ErrorTypeFEE::getErrorTypeName(unsigned int errorTypeID)
+{
+  switch (errorTypeID) {
+    case ErrorSource_t::PAGE_ERROR:
+      return "Page";
+    case ErrorSource_t::ALTRO_ERROR:
+      return "MajorAltro";
+    case ErrorSource_t::MINOR_ALTRO_ERROR:
+      return "MinorAltro";
+    case ErrorSource_t::FIT_ERROR:
+      return "Fit";
+    case ErrorSource_t::GEOMETRY_ERROR:
+      return "Geometry";
+    case ErrorTypeFEE::GAIN_ERROR:
+      return "GainType";
+    case ErrorSource_t::UNDEFINED:
+      return "Undefined";
+    default:
+      return "";
+  };
+}
+
+const char* ErrorTypeFEE::getErrorTypeTitle(unsigned int errorTypeID)
+{
+  switch (errorTypeID) {
+    case ErrorSource_t::PAGE_ERROR:
+      return "Page";
+    case ErrorSource_t::ALTRO_ERROR:
+      return "Major ALTRO";
+    case ErrorSource_t::MINOR_ALTRO_ERROR:
+      return "Minor ALTRO";
+    case ErrorSource_t::FIT_ERROR:
+      return "Fit";
+    case ErrorSource_t::GEOMETRY_ERROR:
+      return "Geometry";
+    case ErrorTypeFEE::GAIN_ERROR:
+      return "Gain";
+    case ErrorSource_t::UNDEFINED:
+      return "Unknown";
+    default:
+      return "";
+  };
+}
+
 std::ostream& operator<<(std::ostream& stream, const ErrorTypeFEE& error)
 {
   error.PrintStream(stream);

--- a/Detectors/EMCAL/reconstruction/CMakeLists.txt
+++ b/Detectors/EMCAL/reconstruction/CMakeLists.txt
@@ -18,6 +18,8 @@ o2_add_library(EMCALReconstruction
         src/Bunch.cxx
         src/Channel.cxx
         src/RecoParam.cxx
+        src/RawDecodingError.cxx
+        src/ReconstructionErrors.cxx
         src/CaloFitResults.cxx
         src/CaloRawFitter.cxx
         src/CaloRawFitterStandard.cxx
@@ -60,6 +62,30 @@ o2_add_executable(rawreader-file
         COMPONENT_NAME emcal
         PUBLIC_LINK_LIBRARIES O2::EMCALReconstruction
         SOURCES run/rawReaderFile.cxx)
+
+o2_add_test(AltroDecoderError
+        SOURCES test/testAltroDecoderError.cxx
+        PUBLIC_LINK_LIBRARIES O2::EMCALReconstruction
+        COMPONENT_NAME emcal
+        LABELS emcal)
+
+o2_add_test(MinorAltroDecodingError
+        SOURCES test/testMinorAltroDecodingError.cxx
+        PUBLIC_LINK_LIBRARIES O2::EMCALReconstruction
+        COMPONENT_NAME emcal
+        LABELS emcal)
+
+o2_add_test(CaloRawFitterError
+        SOURCES test/testCaloRawFitterError.cxx
+        PUBLIC_LINK_LIBRARIES O2::EMCALReconstruction
+        COMPONENT_NAME emcal
+        LABELS emcal)
+
+o2_add_test(RawDecodingError
+        SOURCES test/testRawDecodingError.cxx
+        PUBLIC_LINK_LIBRARIES O2::EMCALReconstruction
+        COMPONENT_NAME emcal
+        LABELS emcal)
 
 o2_add_test_root_macro(macros/RawFitterTESTs.C
         PUBLIC_LINK_LIBRARIES O2::EMCALReconstruction O2::Headers

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/AltroDecoder.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/AltroDecoder.h
@@ -15,6 +15,7 @@
 #include <iosfwd>
 #include <gsl/span>
 #include <string>
+#include <string_view>
 #include "EMCALBase/RCUTrailer.h"
 #include "EMCALReconstruction/Bunch.h"
 #include "EMCALReconstruction/Channel.h"
@@ -48,7 +49,10 @@ class AltroDecoderError : public std::exception
   ///
   /// Defining error code and error message. To be called when the
   /// exception is thrown
-  AltroDecoderError(ErrorType_t errtype, const char* message) : mErrorType(errtype), mErrorMessage(message) {}
+  ///
+  /// \param errtype Type of the error
+  /// \param message Error message related to the error
+  AltroDecoderError(ErrorType_t errtype, const std::string_view message) : mErrorType(errtype), mErrorMessage(message) {}
 
   /// \brief Destructor
   ~AltroDecoderError() noexcept override = default;
@@ -72,6 +76,69 @@ class AltroDecoderError : public std::exception
   /// \brief Access to the error type connected to the erro
   /// \return Error type
   const ErrorType_t getErrorType() const noexcept { return mErrorType; }
+
+  /// \brief Get the name connected to the error type
+  ///
+  /// A single word descriptor i.e. used for object names
+  /// is produced.
+  ///
+  /// \param errortype Error type raising the exception (symbolic representation)
+  /// \return Name of the error type
+  static const char* getErrorTypeName(ErrorType_t errortype);
+
+  /// \brief Get the name connected to the error type
+  ///
+  /// A single word descriptor i.e. used for object names
+  /// is produced.
+  ///
+  /// \param errortype Error type raising the exception (numeric representation)
+  /// \return Name of the error type
+  static const char* getErrorTypeName(unsigned int errortype)
+  {
+    return getErrorTypeName(intToErrorType(errortype));
+  }
+
+  /// \brief Get the title connected to the error type
+  ///
+  /// A short description i.e. used for bin labels or histogam titles
+  /// is produced.
+  ///
+  /// \param errortype Error type raising the exception (symbolic representation)
+  /// \return Title of the error type
+  static const char* getErrorTypeTitle(ErrorType_t errortype);
+
+  /// \brief Get the title connected to the error type
+  ///
+  /// A short description i.e. used for bin labels or histogam titles
+  /// is produced.
+  ///
+  /// \param errortype Error type raising the exception (numeric representation)
+  /// \return Title of the error type
+  static const char* getErrorTypeTitle(unsigned int errortype)
+  {
+    return getErrorTypeTitle(intToErrorType(errortype));
+  }
+
+  /// \brief Get the description connected to the error type
+  ///
+  /// A detailed description i.e. used for error message on the stdout
+  /// is produced.
+  ///
+  /// \param errortype Error type raising the exception (symbolic representation)
+  /// \return Description connected to the error type
+  static const char* getErrorTypeDescription(ErrorType_t errortype);
+
+  /// \brief Get the description connected to the error type
+  ///
+  /// A detailed description i.e. used for error message on the stdout
+  /// is produced.
+  ///
+  /// \param errortype Error type raising the exception (numeric representation)
+  /// \return Description connected to the error type
+  static const char* getErrorTypeDescription(unsigned int errortype)
+  {
+    return getErrorTypeDescription(intToErrorType(errortype));
+  }
 
  private:
   ErrorType_t mErrorType;    ///< Code of the decoding error type
@@ -139,7 +206,70 @@ class MinorAltroDecodingError
 
   /// \brief Get the number of error types handled by the AltroDecoderError
   /// \return Number of error types
-  static constexpr int getNumberOfErrorTypes() noexcept { return 2; }
+  static constexpr int getNumberOfErrorTypes() noexcept { return 4; }
+
+  /// \brief Get the name connected to the error type
+  ///
+  /// A single word descriptor i.e. used for object names
+  /// is produced.
+  ///
+  /// \param errortype Error type raising the exception (symbolic representation)
+  /// \return Name of the error type
+  static const char* getErrorTypeName(ErrorType_t errortype);
+
+  /// \brief Get the name connected to the error type
+  ///
+  /// A single word descriptor i.e. used for object names
+  /// is produced.
+  ///
+  /// \param errortype Error type raising the exception (numeric representation)
+  /// \return Name of the error type
+  static const char* getErrorTypeName(unsigned int errortype)
+  {
+    return getErrorTypeName(intToErrorType(errortype));
+  }
+
+  /// \brief Get the title connected to the error type
+  ///
+  /// A short description i.e. used for bin labels or histogam titles
+  /// is produced.
+  ///
+  /// \param errortype Error type raising the exception (symbolic representation)
+  /// \return Title of the error type
+  static const char* getErrorTypeTitle(ErrorType_t errortype);
+
+  /// \brief Get the title connected to the error type
+  ///
+  /// A short description i.e. used for bin labels or histogam titles
+  /// is produced.
+  ///
+  /// \param errortype Error type raising the exception (numeric representation)
+  /// \return Title of the error type
+  static const char* getErrorTypeTitle(unsigned int errortype)
+  {
+    return getErrorTypeTitle(intToErrorType(errortype));
+  }
+
+  /// \brief Get the description connected to the error type
+  ///
+  /// A detailed description i.e. used for error message on the stdout
+  /// is produced.
+  ///
+  /// \param errortype Error type raising the exception (symbolic representation)
+  /// \return Description connected to the error type
+  static const char* getErrorTypeDescription(ErrorType_t errortype);
+
+  /// \brief Get the description connected to the error type
+  ///
+  /// A detailed description i.e. used for error message on the stdout
+  /// is produced.
+  ///
+  /// \param errortype Error type raising the exception (numeric representation)
+  /// \return Description connected to the error type
+  static const char* getErrorTypeDescription(unsigned int errortype)
+  {
+    return getErrorTypeDescription(intToErrorType(errortype));
+  }
 
  private:
   ErrorType_t mErrorType;  ///< Type of the error
@@ -219,6 +349,42 @@ class AltroDecoder
 
   ClassDefNV(AltroDecoder, 1);
 };
+
+/// \brief Stream operator of the AltroDecoderError
+///
+/// Printing error.what()
+///
+/// \param stream Stream to print on
+/// \param error Error to be displayed
+/// \return Stream after printing
+std::ostream& operator<<(std::ostream& stream, const AltroDecoderError& error);
+
+/// \brief Stream operator of AltroDecoderError's ErrorType_t
+///
+/// Prining name of the error type
+///
+/// \param stream Stream to print on
+/// \param error Error type to be displayed
+/// \return Stream after printing
+std::ostream& operator<<(std::ostream& stream, const AltroDecoderError::ErrorType_t& errortype);
+
+/// \brief Stream operator of the MinorAltroDecodingError
+///
+/// Printing error.what()
+///
+/// \param stream Stream to print on
+/// \param error Error to be displayed
+/// \return Stream after printing
+std::ostream& operator<<(std::ostream& stream, const MinorAltroDecodingError& error);
+
+/// \brief Stream operator of MinorAltroDecodingError's ErrorType_t
+///
+/// Prining name of the error type
+///
+/// \param stream Stream to print on
+/// \param error Error type to be displayed
+/// \return Stream after printing
+std::ostream& operator<<(std::ostream& stream, const MinorAltroDecodingError::ErrorType_t& errortype);
 
 } // namespace emcal
 

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CaloRawFitter.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CaloRawFitter.h
@@ -56,16 +56,87 @@ class CaloRawFitter
   /// \brief Create error message for a given error type
   /// \param fiterror Fit error type
   /// \return Error message connected to the error type
-  static std::string createErrorMessage(RawFitterError_t fiterror);
+  static std::string createErrorMessage(RawFitterError_t fiterror) { return getErrorTypeDescription(fiterror); }
 
   /// \brief Convert error type to numeric representation
   /// \param fiterror Fit error type
   /// \return Numeric representation of the raw fitter error
   static int getErrorNumber(RawFitterError_t fiterror);
 
+  /// \brief Convert numeric representation of error type to RawFitterError_t
+  ///
+  /// Expect the error code provided to be a valid error code.
+  ///
+  /// \param fiterror Numeric representation of fit error
+  /// \return Symbolic representation of the error code
+  static RawFitterError_t intToErrorType(unsigned int fiterror);
+
   /// \brief Get the number of raw fit error types supported
-  /// \return Number of error types (4)
-  static constexpr int getNumberOfErrorTypes() noexcept { return 4; }
+  /// \return Number of error types (5)
+  static constexpr int getNumberOfErrorTypes() noexcept { return 5; }
+
+  /// \brief Get the name connected to the fit error type
+  ///
+  /// A single word descriptor i.e. used for object names
+  /// is produced.
+  ///
+  /// \param errortype Error type raising the exception (symbolic representation)
+  /// \return Name of the fit error type
+  static const char* getErrorTypeName(RawFitterError_t fiterror);
+
+  /// \brief Get the name connected to the fit error type
+  ///
+  /// A single word descriptor i.e. used for object names
+  /// is produced.
+  ///
+  /// \param errortype Error type raising the exception (numeric representation)
+  /// \return Name of the fit error type
+  static const char* getErrorTypeName(unsigned int fiterror)
+  {
+    return getErrorTypeName(intToErrorType(fiterror));
+  }
+
+  /// \brief Get the title connected to the fit error type
+  ///
+  /// A short description i.e. used for bin labels or histogam titles
+  /// is produced.
+  ///
+  /// \param errortype Error type raising the exception (symbolic representation)
+  /// \return Title of the fit error type
+  static const char* getErrorTypeTitle(RawFitterError_t fiterror);
+
+  /// \brief Get the title connected to the fit error type
+  ///
+  /// A short description i.e. used for bin labels or histogam titles
+  /// is produced.
+  ///
+  /// \param errortype Error type raising the exception (numeric representation)
+  /// \return Title of the fit error type
+  static const char* getErrorTypeTitle(unsigned int fiterror)
+  {
+    return getErrorTypeTitle(intToErrorType(fiterror));
+  }
+
+  /// \brief Get the description connected to the fit error type
+  ///
+  /// A detailed description i.e. used for error message on the stdout
+  /// is produced.
+  ///
+  /// \param errortype Error type raising the exception (symbolic representation)
+  /// \return Description connected to the fit error type
+  static const char* getErrorTypeDescription(RawFitterError_t fiterror);
+
+  /// \brief Get the description connected to the fit error type
+  ///
+  /// A detailed description i.e. used for error message on the stdout
+  /// is produced.
+  ///
+  /// \param errortype Error type raising the exception (numeric representation)
+  /// \return Description connected to the fit error type
+  static const char* getErrorTypeDescription(unsigned int fiterror)
+  {
+    return getErrorTypeDescription(intToErrorType(fiterror));
+  }
 
   /// \brief Constructor
   CaloRawFitter(const char* name, const char* nameshort);
@@ -198,6 +269,12 @@ class CaloRawFitter
 
   ClassDefNV(CaloRawFitter, 1);
 }; // CaloRawFitter
+
+/// \brief Stream operator for CaloRawFitter's RawFitterError
+/// \param stream Stream to print on
+/// \param error Error code to be printed
+/// \return Stream after printing
+std::ostream& operator<<(std::ostream& stream, const CaloRawFitter::RawFitterError_t error);
 
 } // namespace emcal
 

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RawDecodingError.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/RawDecodingError.h
@@ -11,6 +11,8 @@
 #ifndef ALICEO2_EMCAL_RAWDECODINGERROR_H
 #define ALICEO2_EMCAL_RAWDECODINGERROR_H
 
+#include <array>
+#include <cassert>
 #include <exception>
 
 namespace o2
@@ -61,23 +63,7 @@ class RawDecodingError : public std::exception
   /// \return Error message of the exception
   const char* what() const noexcept override
   {
-    switch (mErrorType) {
-      case ErrorType_t::PAGE_NOTFOUND:
-        return "Page with requested index not found";
-      case ErrorType_t::HEADER_DECODING:
-        return "RDH of page cannot be decoded";
-      case ErrorType_t::PAYLOAD_DECODING:
-        return "Payload of page cannot be decoded";
-      case ErrorType_t::HEADER_INVALID:
-        return "Access to header not belonging to requested superpage";
-      case ErrorType_t::PAGE_START_INVALID:
-        return "Page decoding starting outside payload size";
-      case ErrorType_t::PAYLOAD_INVALID:
-        return "Access to payload not belonging to requested superpage";
-      case ErrorType_t::TRAILER_DECODING:
-        return "Inconsistent trailer in memory";
-    };
-    return "Undefined error";
+    return getErrorCodeDescription(mErrorType);
   }
 
   /// \brief Get the type identifier of the error handled with this exception
@@ -113,10 +99,156 @@ class RawDecodingError : public std::exception
     return -1;
   }
 
+  /// \brief Get the number of error codes
+  /// \return Number of error codes
+  static constexpr int getNumberOfErrorTypes() { return 7; }
+
+  static ErrorType_t intToErrorType(unsigned int errortype)
+  {
+    assert(errortype < getNumberOfErrorTypes());
+    static constexpr std::array<ErrorType_t, getNumberOfErrorTypes()> errortypes = {{ErrorType_t::PAGE_NOTFOUND, ErrorType_t::HEADER_DECODING,
+                                                                                     ErrorType_t::PAYLOAD_DECODING, ErrorType_t::HEADER_INVALID,
+                                                                                     ErrorType_t::PAGE_START_INVALID, ErrorType_t::PAYLOAD_INVALID,
+                                                                                     ErrorType_t::TRAILER_DECODING}};
+    return errortypes[errortype];
+  }
+
+  /// \brief Get name of error type
+  ///
+  /// A single word descriptor i.e. to be used in object names
+  /// is produced.
+  ///
+  /// \param errortype Error type raising the exception (symbolic representation)
+  /// \return Name of the error type
+  static const char* getErrorCodeNames(ErrorType_t errortype)
+  {
+    switch (errortype) {
+      case ErrorType_t::PAGE_NOTFOUND:
+        return "PageNotFound";
+      case ErrorType_t::HEADER_DECODING:
+        return "HeaderDecoding";
+      case ErrorType_t::PAYLOAD_DECODING:
+        return "PayloadDecoding";
+      case ErrorType_t::HEADER_INVALID:
+        return "HeaderCorruption";
+      case ErrorType_t::PAGE_START_INVALID:
+        return "PageStartInvalid";
+      case ErrorType_t::PAYLOAD_INVALID:
+        return "PayloadCorruption";
+      case ErrorType_t::TRAILER_DECODING:
+        return "TrailerDecoding";
+    };
+    return "Undefined error";
+  }
+
+  /// \brief Get name of error type
+  ///
+  /// A single word descriptor i.e. to be used in object names
+  /// is produced.
+  ///
+  /// \param errortype Error type raising the exception (numeric representation)
+  /// \return Name of the error type
+  static const char* getErrorCodeNames(unsigned int errortype)
+  {
+    return getErrorCodeNames(intToErrorType(errortype));
+  }
+
+  /// \brief Get title of error type
+  ///
+  /// A short description i.e. to be used in histogram titles
+  /// is produced.
+  ///
+  /// \param errortype Error type raising the exception (symbolic representation)
+  /// \return Title of the error type
+  static const char* getErrorCodeTitles(ErrorType_t errortype)
+  {
+    switch (errortype) {
+      case ErrorType_t::PAGE_NOTFOUND:
+        return "Page not found";
+      case ErrorType_t::HEADER_DECODING:
+        return "Header decoding";
+      case ErrorType_t::PAYLOAD_DECODING:
+        return "Payload decoding";
+      case ErrorType_t::HEADER_INVALID:
+        return "Header corruption";
+      case ErrorType_t::PAGE_START_INVALID:
+        return "Page start invalid";
+      case ErrorType_t::PAYLOAD_INVALID:
+        return "Payload corruption";
+      case ErrorType_t::TRAILER_DECODING:
+        return "Trailer decoding";
+    };
+    return "Undefined error";
+  }
+
+  /// \brief Get title of error type
+  ///
+  /// A short description i.e. to be used in histogram titles
+  /// is produced.
+  ///
+  /// \param errortype Error type raising the exception (numeric representation)
+  /// \return Title of the error type
+  static const char* getErrorCodeTitles(unsigned int errortype)
+  {
+    return getErrorCodeTitles(intToErrorType(errortype));
+  }
+
+  /// \brief Get description of error type
+  ///
+  /// A dedicated description is created which can be used i.e. in the
+  /// what() function of the exception.
+  ///
+  /// \param errortype Error type raising the exceptio (symbolic representation)
+  /// \return Description text for the error type
+  static const char* getErrorCodeDescription(ErrorType_t errortype)
+  {
+    switch (errortype) {
+      case ErrorType_t::PAGE_NOTFOUND:
+        return "Page with requested index not found";
+      case ErrorType_t::HEADER_DECODING:
+        return "RDH of page cannot be decoded";
+      case ErrorType_t::PAYLOAD_DECODING:
+        return "Payload of page cannot be decoded";
+      case ErrorType_t::HEADER_INVALID:
+        return "Access to header not belonging to requested superpage";
+      case ErrorType_t::PAGE_START_INVALID:
+        return "Page decoding starting outside payload size";
+      case ErrorType_t::PAYLOAD_INVALID:
+        return "Access to payload not belonging to requested superpage";
+      case ErrorType_t::TRAILER_DECODING:
+        return "Inconsistent trailer in memory";
+    };
+    return "Undefined error";
+  }
+
+  /// \brief Get description of error type
+  ///
+  /// A dedicated description is created which can be used i.e. in the
+  /// what() function of the exception.
+  ///
+  /// \param errortype Error type raising the exception (numeric representation)
+  /// \return Description text for the error type
+  static const char* getErrorCodeDescription(unsigned int errortype)
+  {
+    return getErrorCodeDescription(intToErrorType(errortype));
+  }
+
  private:
   ErrorType_t mErrorType; ///< Type of the error
   int mFecID;             ///< ID of the FEC responsible for the ERROR
 };
+
+/// \brief Streaming operator for RawDecodingError
+/// \param stream Stream to print on
+/// \param error Error to be printed
+/// \return Stream after printing
+std::ostream& operator<<(std::ostream& stream, const RawDecodingError& error);
+
+/// \brief Streaming operator for RawDecodingError's ErrorType_t
+/// \param stream Stream to print on
+/// \param error Error to be printed
+/// \return Stream after printing
+std::ostream& operator<<(std::ostream& stream, const RawDecodingError::ErrorType_t& error);
 
 } // namespace emcal
 

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/ReconstructionErrors.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/ReconstructionErrors.h
@@ -1,0 +1,222 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef ALICEO2_EMCAL_RECONSTRUCTIONERRORS_H
+#define ALICEO2_EMCAL_RECONSTRUCTIONERRORS_H
+
+namespace o2
+{
+
+namespace emcal
+{
+
+namespace reconstructionerrors
+{
+
+/// \class GeometryError_t
+/// \brief Errors appearing in geometry access obtaining the tower ID
+/// \ingroup EMCALreconstruction
+///
+/// Errors can appear during geometry access, either because the
+/// cell number provided by the geometry is negative or because
+/// the cell number exceeds the range of allowed cell indices
+enum class GeometryError_t {
+  CELL_RANGE_EXCEED,   ///< Requested cell value exceeding allowed cell range
+  CELL_INDEX_NEGATIVE, ///< Requested cell value negative
+  UNKNOWN_ERROR        ///< Unknown error code
+};
+
+/// \brief Get the number of geometry error codes
+/// \return Number of geometry error codes
+constexpr int getNumberOfGeometryErrorCodes() { return 2; }
+
+/// \brief Convert geometry error type into numberic representation
+/// \param errortype Geometry error type
+/// \return Error code connected to error type
+constexpr int getErrorCodeFromGeometryError(GeometryError_t errortype)
+{
+  switch (errortype) {
+    case GeometryError_t::CELL_RANGE_EXCEED:
+      return 0;
+    case GeometryError_t::CELL_INDEX_NEGATIVE:
+      return 1;
+    default:
+      return -1;
+  }
+}
+
+/// \brief Convert error code to geometry error type
+///
+/// Attention: Error code must be a valid error code, handled
+/// internally via assert.
+///
+/// \param errorcode Error code to be converted
+/// \return Error type connected to error code
+GeometryError_t getGeometryErrorFromErrorCode(unsigned int errorcode);
+
+/// \brief Get name of a given geometry error type
+///
+/// Name is a short single word descriptor used i.e. in
+/// object names.
+///
+/// \param errortype Error type of the geometry error
+/// \return Name connected to geometry error type
+const char* getGeometryErrorName(GeometryError_t errortype);
+
+/// \brief Get name of a given geometry error code
+///
+/// Name is a short single word descriptor used i.e. in
+/// object names. Attention: Error code must be a valid
+/// geomentry error code.
+///
+/// \param errorcode Error code of the geometry error
+/// \return Name connected to geometry error type
+const char* getGeometryErrorName(unsigned int errorcode);
+
+/// \brief Get title of a given geometry error type
+///
+/// Title is a short descriptor used i.e. in
+/// histogram titles.
+///
+/// \param errortype Error type of the geometry error
+/// \return Title connected to geometry error type
+const char* getGeometryErrorTitle(GeometryError_t errortype);
+
+/// \brief Get title of a given geometry error type
+///
+/// Title is a short descriptor used i.e. in
+/// histogram titles. Attention: Error code must
+/// be a valid geomentry error code.
+///
+/// \param errorcode Error code of the geometry error
+/// \return Title connected to geometry error type
+const char* getGeometryErrorTitle(unsigned int errorcode);
+
+/// \brief Get detailed description of a given geometry error type
+///
+/// Provides a long description to be used i.e. in error messages.
+///
+/// \param errortype Error type of the geometry error
+/// \return Detaied description connected to geometry error type
+const char* getGeometryErrorDescription(GeometryError_t errortype);
+
+/// \brief Get detailed description of a given geometry error type
+///
+/// Provides a long description to be used i.e. in error messages.
+/// Attention: Error code must be a valid geomentry error code.
+///
+/// \param errortype Error type of the geometry error
+/// \return Detaied description connected to geometry error type
+const char* getGeometryErrorDescription(unsigned int errorcode);
+
+/// \enum GainError_t
+/// \brief Errors appearing when merging gain types
+/// \ingroup EMCALreconstruction
+///
+/// Errors can appear when an expected gain type is missing,
+/// either because the HG is saturated and the LG is missing
+/// or because the LG is found for an ADC below HG/LG transition
+/// and the HG is missing.
+enum class GainError_t {
+  LGNOHG,       ///< LG found below HG/LG transition, HG missing
+  HGNOLG,       ///< HG saturated, LG missing
+  UNKNOWN_ERROR ///< Unknown error code
+};
+
+/// \brief Get the number of gain error codes
+/// \return Number of gain error codes
+constexpr int getNumberOfGainErrorCodes() { return 2; }
+
+/// \brief Convert gain error type into numberic representation
+/// \param errortype Gain error type
+/// \return Error code connected to error type
+constexpr int getErrorCodeFromGainError(GainError_t errortype)
+{
+  switch (errortype) {
+    case GainError_t::LGNOHG:
+      return 0;
+    case GainError_t::HGNOLG:
+      return 1;
+    default:
+      return -1;
+  };
+}
+
+/// \brief Convert error code to gain error type
+///
+/// Attention: Error code must be a valid error code, handled
+/// internally via assert.
+///
+/// \param errorcode Error code to be converted
+/// \return Error type connected to error code
+GainError_t getGainErrorFromErrorCode(unsigned int errorcode);
+
+/// \brief Get name of a given gain error type
+///
+/// Name is a short single word descriptor used i.e. in
+/// object names.
+///
+/// \param errortype Error type of the gain error
+/// \return Name connected to gain error type
+const char* getGainErrorName(GainError_t errortype);
+
+/// \brief Get name of a given gain error code
+///
+/// Name is a short single word descriptor used i.e. in
+/// object names. Attention: Error code must be a valid
+/// geomentry error code.
+///
+/// \param errorcode Error code of the gain error
+/// \return Name connected to gain error type
+const char* getGainErrorName(unsigned int errorcode);
+
+/// \brief Get title of a given gain error type
+///
+/// Title is a short descriptor used i.e. in
+/// histogram titles.
+///
+/// \param errortype Error type of the gain error
+/// \return Title connected to gain error type
+const char* getGainErrorTitle(GainError_t errortype);
+
+/// \brief Get title of a given gain error type
+///
+/// Title is a short descriptor used i.e. in
+/// histogram titles. Attention: Error code must
+/// be a valid geomentry error code.
+///
+/// \param errorcode Error code of the gain error
+/// \return Title connected to gain error type
+const char* getGainErrorTitle(unsigned int errorcode);
+
+/// \brief Get detailed description of a given gain error type
+///
+/// Provides a long description to be used i.e. in error messages.
+///
+/// \param errortype Error type of the gain error
+/// \return Detaied description connected to gain error type
+const char* getGainErrorDescription(GainError_t errortype);
+
+/// \brief Get detailed description of a given gain error type
+///
+/// Provides a long description to be used i.e. in error messages.
+/// Attention: Error code must be a valid gain error code.
+///
+/// \param errortype Error type of the geometry error
+/// \return Detaied description connected to gain error type
+const char* getGainErrorDescription(unsigned int errorcode);
+
+} // namespace reconstructionerrors
+
+} // namespace emcal
+
+} // namespace o2
+
+#endif // !ALICEO2_EMCAL_RECONSTRUCTIONERRORS_H

--- a/Detectors/EMCAL/reconstruction/src/RawDecodingError.cxx
+++ b/Detectors/EMCAL/reconstruction/src/RawDecodingError.cxx
@@ -1,0 +1,25 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <iostream>
+#include <EMCALReconstruction/RawDecodingError.h>
+
+std::ostream& o2::emcal::operator<<(std::ostream& stream, const o2::emcal::RawDecodingError& error)
+{
+  stream << error.what();
+  return stream;
+}
+
+std::ostream& o2::emcal::operator<<(std::ostream& stream, const o2::emcal::RawDecodingError::ErrorType_t& error)
+{
+  stream << o2::emcal::RawDecodingError::getErrorCodeNames(error);
+  return stream;
+}

--- a/Detectors/EMCAL/reconstruction/src/ReconstructionErrors.cxx
+++ b/Detectors/EMCAL/reconstruction/src/ReconstructionErrors.cxx
@@ -1,0 +1,154 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include <cassert>
+#include "EMCALReconstruction/ReconstructionErrors.h"
+
+namespace o2
+{
+namespace emcal
+{
+
+namespace reconstructionerrors
+{
+
+GeometryError_t getGeometryErrorFromErrorCode(unsigned int errorcode)
+{
+  assert(errorcode < getNumberOfGeometryErrorCodes());
+  switch (errorcode) {
+    case 0:
+      return GeometryError_t::CELL_RANGE_EXCEED;
+    case 1:
+      return GeometryError_t::CELL_INDEX_NEGATIVE;
+    default:
+      return GeometryError_t::UNKNOWN_ERROR;
+  }
+}
+
+const char* getGeometryErrorName(GeometryError_t errortype)
+{
+  switch (errortype) {
+    case GeometryError_t::CELL_RANGE_EXCEED:
+      return "CellRangeExceed";
+    case GeometryError_t::CELL_INDEX_NEGATIVE:
+      return "CellIndexNegative";
+    default:
+      return "UnknownError";
+  }
+}
+
+const char* getGeometryErrorName(unsigned int errorcode)
+{
+  return getGeometryErrorName(getGeometryErrorFromErrorCode(errorcode));
+}
+
+const char* getGeometryErrorTitle(GeometryError_t errortype)
+{
+  switch (errortype) {
+    case GeometryError_t::CELL_RANGE_EXCEED:
+      return "Cell ID outside range";
+    case GeometryError_t::CELL_INDEX_NEGATIVE:
+      return "Cell ID corrupted";
+    default:
+      return "UnknownError";
+  };
+}
+
+const char* getGeometryErrorTitle(unsigned int errorcode)
+{
+  return getGeometryErrorTitle(getGeometryErrorFromErrorCode(errorcode));
+}
+
+const char* getGeometryErrorDescription(GeometryError_t errortype)
+{
+  switch (errortype) {
+    case GeometryError_t::CELL_RANGE_EXCEED:
+      return "Cell index exceeding valid rage";
+    case GeometryError_t::CELL_INDEX_NEGATIVE:
+      return "Cell index corrupted (i.e. negative)";
+    default:
+      return "UnknownError";
+  };
+}
+
+const char* getGeometryErrorDescription(unsigned int errorcode)
+{
+  return getGeometryErrorDescription(getGeometryErrorFromErrorCode(errorcode));
+}
+
+GainError_t getGainErrorFromErrorCode(unsigned int errorcode)
+{
+  assert(errorcode < getNumberOfGainErrorCodes());
+  switch (errorcode) {
+    case 0:
+      return GainError_t::LGNOHG;
+    case 1:
+      return GainError_t::HGNOLG;
+    default:
+      return GainError_t::UNKNOWN_ERROR;
+  };
+}
+
+const char* getGainErrorName(GainError_t errortype)
+{
+  switch (errortype) {
+    case GainError_t::LGNOHG:
+      return "HGnoLG";
+    case GainError_t::HGNOLG:
+      return "LGnoHG";
+    default:
+      return "UnknownError";
+  };
+}
+
+const char* getGainErrorName(unsigned int errorcode)
+{
+  return getGainErrorName(getGainErrorFromErrorCode(errorcode));
+}
+
+const char* getGainErrorTitle(GainError_t errortype)
+{
+  switch (errortype) {
+    case GainError_t::LGNOHG:
+      return "High Gain missing";
+    case GainError_t::HGNOLG:
+      return "Low Gain missing";
+    default:
+      return "UnknownError";
+  };
+}
+
+const char* getGainErrorTitle(unsigned int errorcode)
+{
+  return getGainErrorTitle(getGainErrorFromErrorCode(errorcode));
+}
+
+const char* getGainErrorDescription(GainError_t errortype)
+{
+  switch (errortype) {
+    case GainError_t::LGNOHG:
+      return "HG missing for LG below HGLG transition";
+    case GainError_t::HGNOLG:
+      return "LG not found for saturated HG";
+    default:
+      return "UnknownError";
+  };
+}
+
+const char* getGainErrorDescription(unsigned int errorcode)
+{
+  return getGainErrorDescription(getGainErrorFromErrorCode(errorcode));
+}
+
+} // namespace reconstructionerrors
+
+} // namespace emcal
+
+} // namespace o2

--- a/Detectors/EMCAL/reconstruction/test/testAltroDecoderError.cxx
+++ b/Detectors/EMCAL/reconstruction/test/testAltroDecoderError.cxx
@@ -1,0 +1,79 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test EMCAL Calib
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include <array>
+#include <EMCALReconstruction/AltroDecoder.h>
+
+namespace o2
+{
+namespace emcal
+{
+
+void testThrow(AltroDecoderError::ErrorType_t errortype)
+{
+  throw AltroDecoderError(errortype, AltroDecoderError::getErrorTypeDescription(errortype));
+}
+
+BOOST_AUTO_TEST_CASE(AltroDecoderError_test)
+{
+  BOOST_CHECK_EQUAL(AltroDecoderError::getNumberOfErrorTypes(), 8);
+  std::array<std::string, 8> errornames = {{"RCUTrailerError",
+                                            "RCUTrailerVersionError",
+                                            "RCUTrailerSizeError",
+                                            "BunchHeaderError",
+                                            "BunchLengthError",
+                                            "ALTROPayloadError",
+                                            "ALTROMappingError",
+                                            "ChannelError"}},
+                             errortitles = {{"RCU Trailer",
+                                             "RCU Version",
+                                             "RCU Trailer Size",
+                                             "ALTRO Bunch Header",
+                                             "ALTRO Bunch Length",
+                                             "ALTRO Payload",
+                                             "ALTRO Mapping",
+                                             "Channel"}},
+                             errordescriptions = {{"RCU trailer decoding error",
+                                                   "Inconsistent RCU trailer version",
+                                                   "Invalid RCU trailer size",
+                                                   "Inconsistent bunch header",
+                                                   "Bunch length exceeding payload size",
+                                                   "Payload could not be decoded",
+                                                   "Invalid hardware address in ALTRO mapping",
+                                                   "Channels not initizalized"}};
+  std::array<AltroDecoderError::ErrorType_t, 8> errortypes = {{AltroDecoderError::ErrorType_t::RCU_TRAILER_ERROR,
+                                                               AltroDecoderError::ErrorType_t::RCU_VERSION_ERROR,
+                                                               AltroDecoderError::ErrorType_t::RCU_TRAILER_SIZE_ERROR,
+                                                               AltroDecoderError::ErrorType_t::ALTRO_BUNCH_HEADER_ERROR,
+                                                               AltroDecoderError::ErrorType_t::ALTRO_BUNCH_LENGTH_ERROR,
+                                                               AltroDecoderError::ErrorType_t::ALTRO_PAYLOAD_ERROR,
+                                                               AltroDecoderError::ErrorType_t::ALTRO_MAPPING_ERROR,
+                                                               AltroDecoderError::ErrorType_t::CHANNEL_ERROR}};
+  for (int errortype = 0; errortype < AltroDecoderError::getNumberOfErrorTypes(); errortype++) {
+    BOOST_CHECK_EQUAL(AltroDecoderError::errorTypeToInt(errortypes[errortype]), errortype);
+    BOOST_CHECK_EQUAL(AltroDecoderError::intToErrorType(errortype), errortypes[errortype]);
+    BOOST_CHECK_EQUAL(std::string(AltroDecoderError::getErrorTypeName(errortype)), errornames[errortype]);
+    BOOST_CHECK_EQUAL(std::string(AltroDecoderError::getErrorTypeName(errortypes[errortype])), errornames[errortype]);
+    BOOST_CHECK_EQUAL(std::string(AltroDecoderError::getErrorTypeTitle(errortype)), errortitles[errortype]);
+    BOOST_CHECK_EQUAL(std::string(AltroDecoderError::getErrorTypeTitle(errortypes[errortype])), errortitles[errortype]);
+    BOOST_CHECK_EQUAL(std::string(AltroDecoderError::getErrorTypeDescription(errortype)), errordescriptions[errortype]);
+    BOOST_CHECK_EQUAL(std::string(AltroDecoderError::getErrorTypeDescription(errortypes[errortype])), errordescriptions[errortype]);
+    auto expecttype = errortypes[errortype];
+    BOOST_CHECK_EXCEPTION(testThrow(errortypes[errortype]), AltroDecoderError, [expecttype](const AltroDecoderError& ex) { return ex.getErrorType() == expecttype; });
+  }
+}
+
+} // namespace emcal
+} // namespace o2

--- a/Detectors/EMCAL/reconstruction/test/testCaloRawFitterError.cxx
+++ b/Detectors/EMCAL/reconstruction/test/testCaloRawFitterError.cxx
@@ -1,0 +1,60 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test EMCAL Calib
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include <array>
+#include <EMCALReconstruction/CaloRawFitter.h>
+
+namespace o2
+{
+namespace emcal
+{
+
+BOOST_AUTO_TEST_CASE(CaloRawFitterError_test)
+{
+  BOOST_CHECK_EQUAL(CaloRawFitter::getNumberOfErrorTypes(), 5);
+  std::array<std::string, 5> errornames = {{"SampleUninitalized",
+                                            "NoConvergence",
+                                            "Chi2Error",
+                                            "BunchRejected",
+                                            "LowSignal"}},
+                             errortitles = {{"sample uninitalized",
+                                             "No convergence",
+                                             "Chi2 error",
+                                             "Bunch rejected",
+                                             "Low signal"}},
+                             errordescriptions = {{"Sample for fit not initialzied or bunch length is 0",
+                                                   "Fit of the raw bunch was not successful",
+                                                   "Chi2 of the fit could not be determined",
+                                                   "Calo bunch could not be selected",
+                                                   "No ADC value above threshold found"}};
+  std::array<CaloRawFitter::RawFitterError_t, 5> errortypes = {{CaloRawFitter::RawFitterError_t::SAMPLE_UNINITIALIZED,
+                                                                CaloRawFitter::RawFitterError_t::FIT_ERROR,
+                                                                CaloRawFitter::RawFitterError_t::CHI2_ERROR,
+                                                                CaloRawFitter::RawFitterError_t::BUNCH_NOT_OK,
+                                                                CaloRawFitter::RawFitterError_t::LOW_SIGNAL}};
+  for (int errortype = 0; errortype < CaloRawFitter::getNumberOfErrorTypes(); errortype++) {
+    BOOST_CHECK_EQUAL(CaloRawFitter::getErrorNumber(errortypes[errortype]), errortype);
+    BOOST_CHECK_EQUAL(CaloRawFitter::intToErrorType(errortype), errortypes[errortype]);
+    BOOST_CHECK_EQUAL(std::string(CaloRawFitter::getErrorTypeName(errortype)), errornames[errortype]);
+    BOOST_CHECK_EQUAL(std::string(CaloRawFitter::getErrorTypeName(errortypes[errortype])), errornames[errortype]);
+    BOOST_CHECK_EQUAL(std::string(CaloRawFitter::getErrorTypeTitle(errortype)), errortitles[errortype]);
+    BOOST_CHECK_EQUAL(std::string(CaloRawFitter::getErrorTypeTitle(errortypes[errortype])), errortitles[errortype]);
+    BOOST_CHECK_EQUAL(std::string(CaloRawFitter::getErrorTypeDescription(errortype)), errordescriptions[errortype]);
+    BOOST_CHECK_EQUAL(std::string(CaloRawFitter::getErrorTypeDescription(errortypes[errortype])), errordescriptions[errortype]);
+  }
+}
+
+} // namespace emcal
+} // namespace o2

--- a/Detectors/EMCAL/reconstruction/test/testMinorAltroDecodingError.cxx
+++ b/Detectors/EMCAL/reconstruction/test/testMinorAltroDecodingError.cxx
@@ -1,0 +1,56 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test EMCAL Calib
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include <array>
+#include <EMCALReconstruction/AltroDecoder.h>
+
+namespace o2
+{
+namespace emcal
+{
+
+BOOST_AUTO_TEST_CASE(MinorAltroDecodingError_test)
+{
+  BOOST_CHECK_EQUAL(MinorAltroDecodingError::getNumberOfErrorTypes(), 4);
+  std::array<std::string, 4> errornames = {{"ChannelEndPayloadUnexpected",
+                                            "ChannelPayloadExceed",
+                                            "BunchHeaderNull",
+                                            "BunchLengthExceed"}},
+                             errortitles = {{"Channel end unexpected",
+                                             "Channel exceed",
+                                             "Bunch header null",
+                                             "Bunch length exceed"}},
+                             errordescriptions = {{"Unexpected end of payload in altro channel payload!",
+                                                   "Trying to access out-of-bound payload!",
+                                                   "Bunch header 0 or not configured!",
+                                                   "Bunch length exceeding channel payload size!"}};
+  std::array<MinorAltroDecodingError::ErrorType_t, 4> errortypes = {{MinorAltroDecodingError::ErrorType_t::CHANNEL_END_PAYLOAD_UNEXPECT,
+                                                                     MinorAltroDecodingError::ErrorType_t::CHANNEL_PAYLOAD_EXCEED,
+                                                                     MinorAltroDecodingError::ErrorType_t::BUNCH_HEADER_NULL,
+                                                                     MinorAltroDecodingError::ErrorType_t::BUNCH_LENGTH_EXCEED}};
+  for (int errortype = 0; errortype < MinorAltroDecodingError::getNumberOfErrorTypes(); errortype++) {
+    BOOST_CHECK_EQUAL(MinorAltroDecodingError::errorTypeToInt(errortypes[errortype]), errortype);
+    BOOST_CHECK_EQUAL(MinorAltroDecodingError::intToErrorType(errortype), errortypes[errortype]);
+    BOOST_CHECK_EQUAL(std::string(MinorAltroDecodingError::getErrorTypeName(errortype)), errornames[errortype]);
+    BOOST_CHECK_EQUAL(std::string(MinorAltroDecodingError::getErrorTypeName(errortypes[errortype])), errornames[errortype]);
+    BOOST_CHECK_EQUAL(std::string(MinorAltroDecodingError::getErrorTypeTitle(errortype)), errortitles[errortype]);
+    BOOST_CHECK_EQUAL(std::string(MinorAltroDecodingError::getErrorTypeTitle(errortypes[errortype])), errortitles[errortype]);
+    BOOST_CHECK_EQUAL(std::string(MinorAltroDecodingError::getErrorTypeDescription(errortype)), errordescriptions[errortype]);
+    BOOST_CHECK_EQUAL(std::string(MinorAltroDecodingError::getErrorTypeDescription(errortypes[errortype])), errordescriptions[errortype]);
+  }
+}
+
+} // namespace emcal
+} // namespace o2

--- a/Detectors/EMCAL/reconstruction/test/testRawDecodingError.cxx
+++ b/Detectors/EMCAL/reconstruction/test/testRawDecodingError.cxx
@@ -1,0 +1,85 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test EMCAL Calib
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include <array>
+#include <EMCALReconstruction/RawDecodingError.h>
+
+namespace o2
+{
+namespace emcal
+{
+
+void testThrow(RawDecodingError::ErrorType_t errtype, unsigned int feeID)
+{
+  throw RawDecodingError(errtype, feeID);
+}
+
+BOOST_AUTO_TEST_CASE(RawDecodingError_test)
+{
+  BOOST_CHECK_EQUAL(RawDecodingError::getNumberOfErrorTypes(), 7);
+  std::array<std::string, 7> errornames = {{"PageNotFound",
+                                            "HeaderDecoding",
+                                            "PayloadDecoding",
+                                            "HeaderCorruption",
+                                            "PageStartInvalid",
+                                            "PayloadCorruption",
+                                            "TrailerDecoding"}},
+                             errortitles = {{"Page not found",
+                                             "Header decoding",
+                                             "Payload decoding",
+                                             "Header corruption",
+                                             "Page start invalid",
+                                             "Payload corruption",
+                                             "Trailer decoding"}},
+                             errordescriptions = {{"Page with requested index not found",
+                                                   "RDH of page cannot be decoded",
+                                                   "Payload of page cannot be decoded",
+                                                   "Access to header not belonging to requested superpage",
+                                                   "Page decoding starting outside payload size",
+                                                   "Access to payload not belonging to requested superpage",
+                                                   "Inconsistent trailer in memory"}};
+  std::array<RawDecodingError::ErrorType_t, 7> errortypes = {{
+    RawDecodingError::ErrorType_t::PAGE_NOTFOUND,
+    RawDecodingError::ErrorType_t::HEADER_DECODING,
+    RawDecodingError::ErrorType_t::PAYLOAD_DECODING,
+    RawDecodingError::ErrorType_t::HEADER_INVALID,
+    RawDecodingError::ErrorType_t::PAGE_START_INVALID,
+    RawDecodingError::ErrorType_t::PAYLOAD_INVALID,
+    RawDecodingError::ErrorType_t::TRAILER_DECODING,
+  }};
+  for (int errortype = 0; errortype < RawDecodingError::getNumberOfErrorTypes(); errortype++) {
+    BOOST_CHECK_EQUAL(RawDecodingError::ErrorTypeToInt(errortypes[errortype]), errortype);
+    BOOST_CHECK_EQUAL(RawDecodingError::intToErrorType(errortype), errortypes[errortype]);
+    BOOST_CHECK_EQUAL(std::string(RawDecodingError::getErrorCodeNames(errortype)), errornames[errortype]);
+    BOOST_CHECK_EQUAL(std::string(RawDecodingError::getErrorCodeNames(errortypes[errortype])), errornames[errortype]);
+    BOOST_CHECK_EQUAL(std::string(RawDecodingError::getErrorCodeTitles(errortype)), errortitles[errortype]);
+    BOOST_CHECK_EQUAL(std::string(RawDecodingError::getErrorCodeTitles(errortypes[errortype])), errortitles[errortype]);
+    BOOST_CHECK_EQUAL(std::string(RawDecodingError::getErrorCodeDescription(errortype)), errordescriptions[errortype]);
+    BOOST_CHECK_EQUAL(std::string(RawDecodingError::getErrorCodeDescription(errortypes[errortype])), errordescriptions[errortype]);
+    for (unsigned int errtype = 0; errtype < 7; errtype++) {
+      auto errtypeval = RawDecodingError::intToErrorType(errtype);
+      for (unsigned int feeID = 0; feeID < 40; feeID++) {
+        auto checker = [errtypeval, feeID](const RawDecodingError& test) {
+          return test.getErrorType() == errtypeval && test.getFECID() == feeID;
+        };
+        BOOST_CHECK_EXCEPTION(testThrow(errtypeval, feeID),
+                              RawDecodingError, checker);
+      }
+    }
+  }
+}
+
+} // namespace emcal
+} // namespace o2

--- a/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
@@ -38,6 +38,7 @@
 #include "EMCALReconstruction/AltroDecoder.h"
 #include "EMCALReconstruction/RawDecodingError.h"
 #include "EMCALReconstruction/RecoParam.h"
+#include "EMCALReconstruction/ReconstructionErrors.h"
 #include "EMCALWorkflow/RawToCellConverterSpec.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
@@ -380,7 +381,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
               mErrorMessagesSuppressed++;
             }
             if (mCreateRawDataErrors) {
-              mOutputDecoderErrors.emplace_back(feeID, ErrorTypeFEE::ErrorSource_t::GEOMETRY_ERROR, 0, CellID, chan.getHardwareAddress()); // 0 -> Cell ID out of range
+              mOutputDecoderErrors.emplace_back(feeID, ErrorTypeFEE::ErrorSource_t::GEOMETRY_ERROR, reconstructionerrors::getErrorCodeFromGeometryError(reconstructionerrors::GeometryError_t::CELL_RANGE_EXCEED), CellID, chan.getHardwareAddress()); // 0 -> Cell ID out of range
             }
             continue;
           }
@@ -410,7 +411,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
               mErrorMessagesSuppressed++;
             }
             if (mCreateRawDataErrors) {
-              mOutputDecoderErrors.emplace_back(feeID, ErrorTypeFEE::ErrorSource_t::GEOMETRY_ERROR, 2, CellID, chan.getHardwareAddress()); // Geometry error codes will start from 100
+              mOutputDecoderErrors.emplace_back(feeID, ErrorTypeFEE::ErrorSource_t::GEOMETRY_ERROR, reconstructionerrors::getErrorCodeFromGeometryError(reconstructionerrors::GeometryError_t::CELL_INDEX_NEGATIVE), CellID, chan.getHardwareAddress()); // Geometry error codes will start from 100
             }
             continue;
           }
@@ -563,7 +564,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
               mErrorMessagesSuppressed++;
             }
             if (mCreateRawDataErrors) {
-              mOutputDecoderErrors.emplace_back(cell.mDDLID, ErrorTypeFEE::GAIN_ERROR, 0, cell.mFecID, cell.mHWAddressLG);
+              mOutputDecoderErrors.emplace_back(cell.mDDLID, ErrorTypeFEE::GAIN_ERROR, reconstructionerrors::getErrorCodeFromGainError(reconstructionerrors::GainError_t::LGNOHG), cell.mFecID, cell.mHWAddressLG);
             }
           }
           continue;
@@ -579,7 +580,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
             mErrorMessagesSuppressed++;
           }
           if (mCreateRawDataErrors) {
-            mOutputDecoderErrors.emplace_back(cell.mDDLID, ErrorTypeFEE::GAIN_ERROR, 1, cell.mFecID, cell.mHWAddressHG);
+            mOutputDecoderErrors.emplace_back(cell.mDDLID, ErrorTypeFEE::GAIN_ERROR, reconstructionerrors::getErrorCodeFromGainError(reconstructionerrors::GainError_t::HGNOLG), cell.mFecID, cell.mHWAddressHG);
           }
           continue;
         }


### PR DESCRIPTION
Provide methods for creating error names, titles and
descriptions for all error classes used in the reconstruction.
Monitoring information is nowin one place, together with
the exception it relates to. Other tickets affected:
- EMCAL-534: ALTRO decoding error
- EMCAL-686: Raw fitter error
- EMCAL-629: Page decoding errors