### PR TITLE
[WIP][EMCAL-551] improvement of emcal cell energy compression

### DIFF
--- a/DataFormats/Detectors/EMCAL/CMakeLists.txt
+++ b/DataFormats/Detectors/EMCAL/CMakeLists.txt
@@ -16,6 +16,7 @@ o2_add_library(DataFormatsEMCAL
                        src/Cluster.cxx
                        src/AnalysisCluster.cxx
                        src/Cell.cxx 
+                       src/CellCompressed.cxx 
                        src/Digit.cxx
                        src/EventHandler.cxx
                        src/CTF.cxx
@@ -32,6 +33,7 @@ o2_target_root_dictionary(DataFormatsEMCAL
                                   include/DataFormatsEMCAL/TriggerRecord.h
                                   include/DataFormatsEMCAL/Constants.h
                                   include/DataFormatsEMCAL/Cell.h
+                                  include/DataFormatsEMCAL/CellCompressed.h
                                   include/DataFormatsEMCAL/Digit.h
                                   include/DataFormatsEMCAL/Cluster.h
                                   include/DataFormatsEMCAL/AnalysisCluster.h

--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/CTF.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/CTF.h
@@ -20,6 +20,7 @@
 #include <Rtypes.h>
 #include "DetectorsCommonDataFormats/EncodedBlocks.h"
 #include "DataFormatsEMCAL/TriggerRecord.h"
+#include "DataFormatsEMCAL/CellCompressed.h"
 #include "DataFormatsEMCAL/Cell.h"
 
 namespace o2

--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/CTF.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/CTF.h
@@ -38,7 +38,7 @@ struct CTFHeader : public o2::ctf::CTFDictHeader {
 };
 
 /// wrapper for the Entropy-encoded triggers and cells of the TF
-struct CTF : public o2::ctf::EncodedBlocks<CTFHeader, 8, uint32_t> {
+struct CTF : public o2::ctf::EncodedBlocks<CTFHeader, 9, uint32_t> {
 
   static constexpr size_t N = getNBlocks();
   enum Slots { BLC_bcIncTrig,
@@ -49,9 +49,10 @@ struct CTF : public o2::ctf::EncodedBlocks<CTFHeader, 8, uint32_t> {
                BLC_energy,
                BLC_status,
                // extra slot added, should not alter the order of previous ones
-               BLC_trigger // trigger bits
+               BLC_trigger, // trigger bits
+               BLC_chi2     // chi2 of the trigger (added later)
   };
-  ClassDefNV(CTF, 2);
+  ClassDefNV(CTF, 3);
 };
 
 } // namespace emcal

--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Cell.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Cell.h
@@ -58,6 +58,22 @@ namespace emcal
 class Cell
 {
  public:
+  // constants
+  static const float TIME_SHIFT = 600.,
+            TIME_RANGE = 1500.,
+            TIME_RESOLUTION = TIME_RANGE / 2047.,
+            ENERGY_BITS = static_cast<float>(0x3FFF),
+            HGLGTRANSITION = o2::emcal::constants::EMCAL_HGLGTRANSITION * o2::emcal::constants::EMCAL_ADCENERGY,
+            ENERGY_TRUNCATION = 250.,
+            ENERGY_BUFFER = 0.1, // 10% buffer in case calibrations shift the energy out of HG/LG range
+            ENERGY_RESOLUTION_LG = (ENERGY_TRUNCATION - (HGLGTRANSITION * (1 - ENERGY_BUFFER))) / ENERGY_BITS,
+            ENERGY_RESOLUTION_HG = HGLGTRANSITION * (1 + ENERGY_BUFFER) / ENERGY_BITS,
+            ENERGY_RESOLUTION_TRU = ENERGY_TRUNCATION / ENERGY_BITS,
+            ENERGY_RESOLUTION_LEDMON = ENERGY_TRUNCATION / ENERGY_BITS,
+            CHI2_TRUNCATION = 10.,
+            CHI_2BITS = static_cast<float>(0x3F),
+            CHI2_RESOLUTION = CHI2_TRUNCATION / CHI_2BITS,
+            ENERGY_RESOLUTION_OLD = ENERGY_TRUNCATION / 16383.;
   Cell();
   Cell(short tower, float energy, float time, ChannelType_t ctype = ChannelType_t::LOW_GAIN, float chi2 = 10.);
   ~Cell() = default; // override

--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/CellCompressed.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/CellCompressed.h
@@ -1,0 +1,224 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_EMCAL_CELLCOMPRESSED_H_
+#define ALICEO2_EMCAL_CELLCOMPRESSED_H_
+
+#include <bitset>
+#include "DataFormatsEMCAL/Constants.h"
+
+namespace o2
+{
+namespace emcal
+{
+
+/// \class CellCompressed
+/// \brief EMCAL compressed cell information
+/// \author Anders Knospe, University of Houston
+/// \author Markus Fasel <markus.fasel@cern.ch>, Oak Ridge National Laboratory
+/// \since March 6, 2019
+/// \ingroup EMCALDataFormat
+///
+/// # Base format for EMCAL cell information in the Compressed Timeframe
+///
+/// The cell class contains the relevant information for each tower per event
+/// - Tower ID
+/// - Energy of the raw fit
+/// - Time of the raw fit
+/// - Type of the cell
+/// While cell type and tower ID have a predefined range based on the hardware
+/// design, energy and time have a finite resolution influenced by the resolution
+/// of the digitizer. This is used in order to compress the information stored
+/// in the compressed timeframe by not storing the full double values but instead
+/// assigning a certain amount of bits to each information. Therefore for certain
+/// information (energy, time) precision loss has to be taken into account.
+///
+/// # Internal structure and resolution
+///
+/// The internal structure is a bit field compressing the information to
+/// 48 bits. The definition of the bit field as well as the value range and the resolution
+/// is listed in the table below:
+///
+/// | Bits  | Content       | Resolution    | Range                       |
+/// |-------|---------------|---------------|-----------------------------|
+/// | 0-14  | Tower ID      | -             | 0 to 17644                  |
+/// | 15-26 | Time (ns)     | 0.73 ns       | -600 to 900 ns              |
+/// | 27-40 | Energy (GeV)  | 0.0153 GeV    | 0 to 250 GeV                |
+/// | 41-42 | Cell type     | -             | 0=LG, 1=HG, 2=LEMon, 4=TRU  |
+/// | 42-47 | Chi2 of raw fit | 0.159        | 0 to 10                 |
+/// The remaining bits are 0
+class CellCompressed
+{
+ public:
+  // constants
+  static constexpr float TIME_SHIFT = 600.,
+            TIME_RANGE = 1500.,
+            TIME_RESOLUTION = TIME_RANGE / 2047.,
+            ENERGY_BITS = static_cast<float>(0x3FFF),
+            HGLGTRANSITION = o2::emcal::constants::EMCAL_HGLGTRANSITION * o2::emcal::constants::EMCAL_ADCENERGY,
+            ENERGY_TRUNCATION = 250.,
+            ENERGY_RESOLUTION_LG = (ENERGY_TRUNCATION - HGLGTRANSITION) / ENERGY_BITS,
+            ENERGY_RESOLUTION_HG = HGLGTRANSITION  / ENERGY_BITS,
+            ENERGY_RESOLUTION_TRU = ENERGY_TRUNCATION / ENERGY_BITS,
+            ENERGY_RESOLUTION_LEDMON = ENERGY_TRUNCATION / ENERGY_BITS,
+            CHI2_TRUNCATION = 10.,
+            CHI_2BITS = static_cast<float>(0x3F),
+            CHI2_RESOLUTION = CHI2_TRUNCATION / CHI_2BITS,
+            ENERGY_RESOLUTION_OLD = ENERGY_TRUNCATION / 16383.;
+  CellCompressed();
+  CellCompressed(short tower, float energy, float time, ChannelType_t ctype = ChannelType_t::LOW_GAIN, float chi2 = 10.);
+  ~CellCompressed() = default; // override
+
+  void setTower(short tower) { getDataRepresentation()->mTowerID = tower; }
+  short getTower() const { return getDataRepresentation()->mTowerID; }
+
+  /// \brief Set the time stamp
+  /// \param time Time in ns
+  ///
+  /// The time stamp is expressed in ns and has
+  /// a resolution of 1 ns. The time range which can
+  /// be stored is from -1023 to 1023 ns. In case the
+  /// range is exceeded the time is set to the limit
+  /// of the range.
+  void setTimeStamp(float time);
+
+  /// \brief Get the time stamp
+  /// \return Time in ns
+  ///
+  /// Time has a resolution of 1 ns and can cover
+  /// a range from -1023 to 1023 ns
+  float getTimeStamp() const;
+
+  /// \brief Set the energy of the cell
+  /// \brief Energy of the cell in GeV
+  ///
+  /// The energy range covered by the cell
+  /// is 0 - 250 GeV, with a resolution of
+  /// 0.0153 GeV. In case an energy exceeding
+  /// the limits is provided the energy is
+  /// set to the limits (0 in case of negative
+  /// energy, 250. in case of energies > 250 GeV)
+  void setEnergy(float energy);
+
+  /// \brief Get the energy of the cell
+  /// \return Energy of the cell
+  ///
+  /// The energy is truncated to a range
+  /// covering 0 to 250 GeV with a resolution
+  /// of 0.0153 GeV
+  float getEnergy() const;
+
+  /// \brief Set the amplitude of the cell
+  /// \param amplitude Cell amplitude
+  ///
+  /// See setEnergy for more information
+  void setAmplitude(float amplitude) { setEnergy(amplitude); }
+
+  /// \brief Get cell amplitude
+  /// \return cell Amplitude
+  ///
+  /// Set getEnergy for more information
+  float getAmplitude() const { return getEnergy(); }
+
+  /// \brief Set the type of the cell
+  /// \param ctype Type of the cell (HIGH_GAIN, LOW_GAIN, LEDMON, TRU)
+  void setType(ChannelType_t ctype) { getDataRepresentation()->mCellStatus = static_cast<uint16_t>(ctype); }
+
+  /// \brief Get the type of the cell
+  /// \return Type of the cell (HIGH_GAIN, LOW_GAIN, LEDMON, TRU)
+  ChannelType_t getType() const { return static_cast<ChannelType_t>(getDataRepresentation()->mCellStatus); }
+
+  /// \brief Check whether the cell is of a given type
+  /// \param ctype Type of the cell (HIGH_GAIN, LOW_GAIN, LEDMON, TRU)
+  /// \return True if the type of the cell matches the requested type, false otherwise
+  bool isChannelType(ChannelType_t ctype) const { return getType() == ctype; }
+
+  /// \brief Mark cell as low gain cell
+  void setLowGain() { setType(ChannelType_t::LOW_GAIN); }
+
+  /// \brief Check whether the cell is a low gain cell
+  /// \return True if the cell type is low gain, false otherwise
+  Bool_t getLowGain() const { return isChannelType(ChannelType_t::LOW_GAIN); }
+
+  /// \brief Mark cell as high gain cell
+  void setHighGain() { setType(ChannelType_t::HIGH_GAIN); }
+
+  /// \brief Check whether the cell is a high gain cell
+  /// \return True if the cell type is high gain, false otherwise
+  Bool_t getHighGain() const { return isChannelType(ChannelType_t::HIGH_GAIN); };
+
+  /// \brief Mark cell as LED monitor cell
+  void setLEDMon() { setType(ChannelType_t::LEDMON); }
+
+  /// \brief Check whether the cell is a LED monitor cell
+  /// \return True if the cell type is LED monitor, false otherwise
+  Bool_t getLEDMon() const { return isChannelType(ChannelType_t::LEDMON); }
+
+  /// \brief Mark cell as TRU cell
+  void setTRU() { setType(ChannelType_t::TRU); }
+
+  /// \brief Check whether the cell is a TRU cell
+  /// \return True if the cell type is TRU, false otherwise
+  Bool_t getTRU() const { return isChannelType(ChannelType_t::TRU); }
+
+  /// \brief Set the chi2 of the raw fitter
+  /// \param chi2 Chi2 of the raw fitter
+  void setChi2(float chi2);
+
+  /// \brief Get the chi2 of the raw fitter
+  /// \return Chi2 of the raw fitter
+  float getChi2() const;
+
+  void PrintStream(std::ostream& stream) const;
+
+  /// used for CTF encoding/decoding: access to packed data
+  void setPacked(uint16_t tower, uint16_t t, uint16_t en, uint16_t status, uint16_t chi2)
+  {
+    auto dt = getDataRepresentation();
+    dt->mTowerID = tower;
+    dt->mTime = t;
+    dt->mEnergy = en;
+    dt->mCellStatus = status;
+    dt->mChi2 = chi2;
+  }
+
+  auto getPackedTowerID() const { return getDataRepresentation()->mTowerID; }
+  auto getPackedTime() const { return getDataRepresentation()->mTime; }
+  auto getPackedEnergy() const { return getDataRepresentation()->mEnergy; }
+  auto getPackedCellStatus() const { return getDataRepresentation()->mCellStatus; }
+  auto getPackedChi2() const { return getDataRepresentation()->mChi2; }
+
+ private:
+  struct __attribute__((packed)) CellData {
+    uint16_t mTowerID : 15;   ///< bits 0-14   Tower ID
+    uint16_t mTime : 11;      ///< bits 15-25: Time (signed, can become negative after calibration)
+    uint16_t mEnergy : 14;    ///< bits 26-39: Energy
+    uint16_t mCellStatus : 2; ///< bits 40-41: Cell status
+    uint16_t mChi2 : 6;       ///< bits 42-47: chi2 of raw fitter
+  };
+
+  CellData* getDataRepresentation() { return reinterpret_cast<CellData*>(mCellWords); }
+  const CellData* getDataRepresentation() const { return reinterpret_cast<const CellData*>(mCellWords); }
+
+  uint16_t mCellWords[3]; ///< data word
+
+  ClassDefNV(CellCompressed, 1);
+};
+
+/// \brief Stream operator for EMCAL cell
+/// \param stream Stream where to print the EMCAL cell
+/// \param cell Cell to be printed
+/// \return Stream after printing
+std::ostream& operator<<(std::ostream& stream, const CellCompressed& cell);
+} // namespace emcal
+} // namespace o2
+
+#endif

--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Constants.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Constants.h
@@ -89,15 +89,14 @@ std::ostream& operator<<(std::ostream& stream, ChannelType_t chantype);
 
 namespace constants
 {
-
-constexpr int OVERFLOWCUT = 950;               ///< sample overflow
+constexpr int EMCAL_HGLGTRANSITION = 950;      ///< sample overflow
 constexpr int LG_SUPPRESSION_CUT = 880;        ///< LG bunch suppression ADC value
 constexpr int ORDER = 2;                       ///< Order of shaping stages of the signal conditioning unit
 constexpr double TAU = 2.35;                   ///< Approximate shaping time
 constexpr Double_t EMCAL_TIMESAMPLE = 100.;    ///< Width of a timebin in nanoseconds
 constexpr Double_t EMCAL_ADCENERGY = 0.0162;   ///< Energy of one ADC count in GeV/c^2
 constexpr Int_t EMCAL_HGLGFACTOR = 16;         ///< Conversion from High to Low Gain
-constexpr Int_t EMCAL_HGLGTRANSITION = 1024;   ///< Transition from High to Low Gain
+constexpr Int_t OVERFLOWCUT = 1024;            ///< Transition from High to Low Gain
 constexpr Int_t EMCAL_MAXTIMEBINS = 15;        ///< Maximum number of time bins for time response
 constexpr int MAX_RANGE_ADC = 0x3FF;           ///< Dynamic range of the ADCs (10 bit ADC)
 constexpr double EMCAL_TRU_ADCENERGY = 0.0786; ///< resolution of the TRU digitizer, @TODO check exact value

--- a/DataFormats/Detectors/EMCAL/src/Cell.cxx
+++ b/DataFormats/Detectors/EMCAL/src/Cell.cxx
@@ -19,96 +19,30 @@ using namespace o2::emcal;
 
 Cell::Cell()
 {
-  memset(mCellWords, 0, sizeof(uint16_t) * 3);
+  mtower = std::numeric_limits<short>::max();
+  menergy = std::numeric_limits<float>::min();
+  mtime = std::numeric_limits<float>::min();
+  mchi2 = std::numeric_limits<float>::max();
+  mtype = ChannelType_t::HIGH_GAIN;
 }
 
-Cell::Cell(short tower, float energy, float time, ChannelType_t ctype, float chi2)
+Cell::Cell(short tower, float energy, float time, ChannelType_t type, float chi2)
 {
-  memset(mCellWords, 0, sizeof(uint16_t) * 3);
-  setTower(tower);
-  setTimeStamp(time);
-  setType(ctype); // type needs to be set before energy to allow for proper conversion
-  setEnergy(energy);
-  setChi2(chi2);
+  mtower = tower;
+  menergy = energy;
+  mtime = time;
+  mtype = type;
+  mchi2 = chi2;
+  
 }
 
-void Cell::setTimeStamp(float timestamp)
+void Cell::setAll(short tower, float energy, float time, ChannelType_t type, float chi2)
 {
-  // truncate:
-  const float TIME_MIN = -1. * TIME_SHIFT,
-              TIME_MAX = TIME_RANGE - TIME_SHIFT;
-  if (timestamp < TIME_MIN) {
-    timestamp = TIME_MIN;
-  } else if (timestamp > TIME_MAX) {
-    timestamp = TIME_MAX;
-  }
-  getDataRepresentation()->mTime = static_cast<uint16_t>(std::round((timestamp + TIME_SHIFT) / TIME_RESOLUTION));
-}
-
-float Cell::getTimeStamp() const
-{
-  return (static_cast<float>(getDataRepresentation()->mTime) * TIME_RESOLUTION) - TIME_SHIFT;
-}
-
-void Cell::setEnergy(float energy)
-{
-  double truncatedEnergy = energy;
-  if (truncatedEnergy < 0.) {
-    truncatedEnergy = 0.;
-  } else if (truncatedEnergy > ENERGY_TRUNCATION) {
-    truncatedEnergy = ENERGY_TRUNCATION;
-  }
-  switch (getType()) {
-    case ChannelType_t::HIGH_GAIN: {
-      getDataRepresentation()->mEnergy = static_cast<uint16_t>(std::round(truncatedEnergy / ENERGY_RESOLUTION_HG));
-      break;
-    }
-    case ChannelType_t::LOW_GAIN: {
-      getDataRepresentation()->mEnergy = static_cast<uint16_t>(std::round(truncatedEnergy / ENERGY_RESOLUTION_LG));
-      break;
-    }
-    case ChannelType_t::TRU: {
-      getDataRepresentation()->mEnergy = static_cast<uint16_t>(std::round(truncatedEnergy / ENERGY_RESOLUTION_TRU));
-      break;
-    }
-    case ChannelType_t::LEDMON: {
-      getDataRepresentation()->mEnergy = static_cast<uint16_t>(std::round(truncatedEnergy / ENERGY_RESOLUTION_LEDMON));
-      break;
-    }
-  }
-}
-
-float Cell::getEnergy() const
-{
-  switch (getType()) {
-    case ChannelType_t::HIGH_GAIN: {
-      return static_cast<float>(getDataRepresentation()->mEnergy) * ENERGY_RESOLUTION_HG;
-    }
-    case ChannelType_t::LOW_GAIN: {
-      return static_cast<float>(getDataRepresentation()->mEnergy) * ENERGY_RESOLUTION_LG;
-    }
-    case ChannelType_t::TRU: {
-      return static_cast<float>(getDataRepresentation()->mEnergy) * ENERGY_RESOLUTION_TRU;
-    }
-    case ChannelType_t::LEDMON: {
-      return static_cast<float>(getDataRepresentation()->mEnergy) * ENERGY_RESOLUTION_LEDMON;
-    }
-  }
-}
-
-void Cell::setChi2(float chi2)
-{
-  if (chi2 < 0.) {
-    chi2 = 0.;
-  } else if (chi2 > CHI2_TRUNCATION) {
-    chi2 = CHI2_TRUNCATION;
-  }
-  getDataRepresentation()->mChi2 = static_cast<uint16_t>(std::round(chi2 / CHI2_RESOLUTION));
-}
-
-float Cell::getChi2() const
-{
-  return static_cast<float>(getDataRepresentation()->mChi2) * CHI2_RESOLUTION;
+  mtower = tower;
+  menergy = energy;
+  mtime = time;
+  mtype = type;
+  mchi2 = chi2;
 }
 
 void Cell::PrintStream(std::ostream& stream) const

--- a/DataFormats/Detectors/EMCAL/src/Cell.cxx
+++ b/DataFormats/Detectors/EMCAL/src/Cell.cxx
@@ -20,8 +20,13 @@ using namespace o2::emcal;
 const float TIME_SHIFT = 600.,
             TIME_RANGE = 1500.,
             TIME_RESOLUTION = TIME_RANGE / 2047.,
+            ENERGY_BITS = static_cast<float>(0x3FFF),
+            HGLGTRANSITION = o2::emcal::constants::EMCAL_HGLGTRANSITION * o2::emcal::constants::EMCAL_ADCENERGY,
             ENERGY_TRUNCATION = 250.,
-            ENERGY_RESOLUTION = ENERGY_TRUNCATION / 16383.;
+            ENERGY_RESOLUTION_LG = (ENERGY_TRUNCATION - HGLGTRANSITION) / ENERGY_BITS,
+            ENERGY_RESOLUTION_HG = HGLGTRANSITION / ENERGY_BITS,
+            ENERGY_RESOLUTION_TRU = ENERGY_TRUNCATION / ENERGY_BITS,
+            ENERGY_RESOLUTION_LEDMON = ENERGY_TRUNCATION / ENERGY_BITS;
 
 Cell::Cell()
 {
@@ -33,8 +38,8 @@ Cell::Cell(short tower, float energy, float time, ChannelType_t ctype)
   memset(mCellWords, 0, sizeof(uint16_t) * 3);
   setTower(tower);
   setTimeStamp(time);
+  setType(ctype); // type needs to be set before energy to allow for proper conversion
   setEnergy(energy);
-  setType(ctype);
 }
 
 void Cell::setTimeStamp(float timestamp)
@@ -63,12 +68,42 @@ void Cell::setEnergy(float energy)
   } else if (truncatedEnergy > ENERGY_TRUNCATION) {
     truncatedEnergy = ENERGY_TRUNCATION;
   }
-  getDataRepresentation()->mEnergy = static_cast<int16_t>(std::round(truncatedEnergy / ENERGY_RESOLUTION));
+  switch (getType()) {
+    case ChannelType_t::HIGH_GAIN: {
+      getDataRepresentation()->mEnergy = static_cast<uint16_t>(std::round(truncatedEnergy / ENERGY_RESOLUTION_HG));
+      break;
+    }
+    case ChannelType_t::LOW_GAIN: {
+      getDataRepresentation()->mEnergy = static_cast<uint16_t>(std::round(truncatedEnergy / ENERGY_RESOLUTION_LG));
+      break;
+    }
+    case ChannelType_t::TRU: {
+      getDataRepresentation()->mEnergy = static_cast<uint16_t>(std::round(truncatedEnergy / ENERGY_RESOLUTION_TRU));
+      break;
+    }
+    case ChannelType_t::LEDMON: {
+      getDataRepresentation()->mEnergy = static_cast<uint16_t>(std::round(truncatedEnergy / ENERGY_RESOLUTION_LEDMON));
+      break;
+    }
+  }
 }
 
 float Cell::getEnergy() const
 {
-  return static_cast<float>(getDataRepresentation()->mEnergy) * ENERGY_RESOLUTION;
+  switch (getType()) {
+    case ChannelType_t::HIGH_GAIN: {
+      return static_cast<float>(getDataRepresentation()->mEnergy) * ENERGY_RESOLUTION_HG;
+    }
+    case ChannelType_t::LOW_GAIN: {
+      return static_cast<float>(getDataRepresentation()->mEnergy) * ENERGY_RESOLUTION_LG;
+    }
+    case ChannelType_t::TRU: {
+      return static_cast<float>(getDataRepresentation()->mEnergy) * ENERGY_RESOLUTION_TRU;
+    }
+    case ChannelType_t::LEDMON: {
+      return static_cast<float>(getDataRepresentation()->mEnergy) * ENERGY_RESOLUTION_LEDMON;
+    }
+  }
 }
 
 void Cell::PrintStream(std::ostream& stream) const

--- a/DataFormats/Detectors/EMCAL/src/Cell.cxx
+++ b/DataFormats/Detectors/EMCAL/src/Cell.cxx
@@ -17,21 +17,6 @@
 
 using namespace o2::emcal;
 
-const float TIME_SHIFT = 600.,
-            TIME_RANGE = 1500.,
-            TIME_RESOLUTION = TIME_RANGE / 2047.,
-            ENERGY_BITS = static_cast<float>(0x3FFF),
-            HGLGTRANSITION = o2::emcal::constants::EMCAL_HGLGTRANSITION * o2::emcal::constants::EMCAL_ADCENERGY,
-            ENERGY_TRUNCATION = 250.,
-            ENERGY_BUFFER = 0.1, // 10% buffer in case calibrations shift the energy out of HG/LG range
-  ENERGY_RESOLUTION_LG = (ENERGY_TRUNCATION - (HGLGTRANSITION * (1 - ENERGY_BUFFER))) / ENERGY_BITS,
-            ENERGY_RESOLUTION_HG = HGLGTRANSITION * (1 + ENERGY_BUFFER) / ENERGY_BITS,
-            ENERGY_RESOLUTION_TRU = ENERGY_TRUNCATION / ENERGY_BITS,
-            ENERGY_RESOLUTION_LEDMON = ENERGY_TRUNCATION / ENERGY_BITS,
-            CHI2_TRUNCATION = 10.,
-            CHI_2BITS = static_cast<float>(0x3F),
-            CHI2_RESOLUTION = CHI2_TRUNCATION / CHI_2BITS;
-
 Cell::Cell()
 {
   memset(mCellWords, 0, sizeof(uint16_t) * 3);

--- a/DataFormats/Detectors/EMCAL/src/CellCompressed.cxx
+++ b/DataFormats/Detectors/EMCAL/src/CellCompressed.cxx
@@ -1,0 +1,123 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "DataFormatsEMCAL/Constants.h"
+#include "DataFormatsEMCAL/CellCompressed.h"
+#include <iostream>
+#include <bitset>
+#include <cmath>
+
+using namespace o2::emcal;
+
+CellCompressed::CellCompressed()
+{
+  memset(mCellWords, 0, sizeof(uint16_t) * 3);
+}
+
+CellCompressed::CellCompressed(short tower, float energy, float time, ChannelType_t ctype, float chi2)
+{
+  memset(mCellWords, 0, sizeof(uint16_t) * 3);
+  setTower(tower);
+  setTimeStamp(time);
+  setType(ctype); // type needs to be set before energy to allow for proper conversion
+  setEnergy(energy);
+  setChi2(chi2);
+}
+
+void CellCompressed::setTimeStamp(float timestamp)
+{
+  // truncate:
+  const float TIME_MIN = -1. * TIME_SHIFT,
+              TIME_MAX = TIME_RANGE - TIME_SHIFT;
+  if (timestamp < TIME_MIN) {
+    timestamp = TIME_MIN;
+  } else if (timestamp > TIME_MAX) {
+    timestamp = TIME_MAX;
+  }
+  getDataRepresentation()->mTime = static_cast<uint16_t>(std::round((timestamp + TIME_SHIFT) / TIME_RESOLUTION));
+}
+
+float CellCompressed::getTimeStamp() const
+{
+  return (static_cast<float>(getDataRepresentation()->mTime) * TIME_RESOLUTION) - TIME_SHIFT;
+}
+
+void CellCompressed::setEnergy(float energy)
+{
+  double truncatedEnergy = energy;
+  if (truncatedEnergy < 0.) {
+    truncatedEnergy = 0.;
+  } else if (truncatedEnergy > ENERGY_TRUNCATION) {
+    truncatedEnergy = ENERGY_TRUNCATION;
+  }
+  switch (getType()) {
+    case ChannelType_t::HIGH_GAIN: {
+      getDataRepresentation()->mEnergy = static_cast<uint16_t>(std::round(truncatedEnergy / ENERGY_RESOLUTION_HG));
+      break;
+    }
+    case ChannelType_t::LOW_GAIN: {
+      getDataRepresentation()->mEnergy = static_cast<uint16_t>(std::round(truncatedEnergy / ENERGY_RESOLUTION_LG));
+      break;
+    }
+    case ChannelType_t::TRU: {
+      getDataRepresentation()->mEnergy = static_cast<uint16_t>(std::round(truncatedEnergy / ENERGY_RESOLUTION_TRU));
+      break;
+    }
+    case ChannelType_t::LEDMON: {
+      getDataRepresentation()->mEnergy = static_cast<uint16_t>(std::round(truncatedEnergy / ENERGY_RESOLUTION_LEDMON));
+      break;
+    }
+  }
+}
+
+float CellCompressed::getEnergy() const
+{
+  switch (getType()) {
+    case ChannelType_t::HIGH_GAIN: {
+      return static_cast<float>(getDataRepresentation()->mEnergy) * ENERGY_RESOLUTION_HG;
+    }
+    case ChannelType_t::LOW_GAIN: {
+      return static_cast<float>(getDataRepresentation()->mEnergy) * ENERGY_RESOLUTION_LG;
+    }
+    case ChannelType_t::TRU: {
+      return static_cast<float>(getDataRepresentation()->mEnergy) * ENERGY_RESOLUTION_TRU;
+    }
+    case ChannelType_t::LEDMON: {
+      return static_cast<float>(getDataRepresentation()->mEnergy) * ENERGY_RESOLUTION_LEDMON;
+    }
+  }
+}
+
+void CellCompressed::setChi2(float chi2)
+{
+  if (chi2 < 0.) {
+    chi2 = 0.;
+  } else if (chi2 > CHI2_TRUNCATION) {
+    chi2 = CHI2_TRUNCATION;
+  }
+  getDataRepresentation()->mChi2 = static_cast<uint16_t>(std::round(chi2 / CHI2_RESOLUTION));
+}
+
+float CellCompressed::getChi2() const
+{
+  return static_cast<float>(getDataRepresentation()->mChi2) * CHI2_RESOLUTION;
+}
+
+void CellCompressed::PrintStream(std::ostream& stream) const
+{
+  stream << "EMCAL Cell: Type " << getType() << ", Energy " << getEnergy() << ", Time " << getTimeStamp() << ", Tower " << getTower() << ", Chi2 " << getChi2();
+}
+
+std::ostream& operator<<(std::ostream& stream, const CellCompressed& c)
+{
+  c.PrintStream(stream);
+  return stream;
+}

--- a/DataFormats/Detectors/EMCAL/src/DataFormatsEMCALLinkDef.h
+++ b/DataFormats/Detectors/EMCAL/src/DataFormatsEMCALLinkDef.h
@@ -18,6 +18,7 @@
 #pragma link C++ class o2::emcal::TriggerRecord + ;
 #pragma link C++ class o2::dataformats::TimeStamp < Float16_t> + ;
 #pragma link C++ class o2::emcal::Cell + ;
+#pragma link C++ class o2::emcal::CellCompressed + ;
 #pragma link C++ class o2::emcal::Digit + ;
 #pragma link C++ class o2::emcal::Cluster + ;
 #pragma link C++ class o2::emcal::AnalysisCluster + ;
@@ -26,6 +27,7 @@
 
 #pragma link C++ class std::vector < o2::emcal::TriggerRecord> + ;
 #pragma link C++ class std::vector < o2::emcal::Cell> + ;
+#pragma link C++ class std::vector < o2::emcal::CellCompressed> + ;
 #pragma link C++ class std::vector < o2::emcal::Digit> + ;
 #pragma link C++ class std::vector < o2::emcal::Cluster> + ;
 #pragma link C++ class std::vector < o2::emcal::AnalysisCluster> + ;

--- a/Detectors/CTF/test/test_ctf_io_emcal.cxx
+++ b/Detectors/CTF/test/test_ctf_io_emcal.cxx
@@ -28,7 +28,7 @@ using namespace o2::emcal;
 BOOST_AUTO_TEST_CASE(CTFTest)
 {
   std::vector<TriggerRecord> triggers;
-  std::vector<Cell> cells;
+  std::vector<CellCompressed> cells;
   //  gSystem->Load("libO2DetectorsCommonDataFormats");
   TStopwatch sw;
   sw.Start();
@@ -126,9 +126,9 @@ BOOST_AUTO_TEST_CASE(CTFTest)
   for (size_t i = 0; i < cells.size(); i++) {
     const auto& cor = cells[i];
     const auto& cdc = cellsD[i];
-    BOOST_CHECK_EQUAL(cor.getPackedTowerID(), cdc.getPackedTowerID());
-    BOOST_CHECK_EQUAL(cor.getPackedTime(), cdc.getPackedTime());
-    BOOST_CHECK_EQUAL(cor.getPackedEnergy(), cdc.getPackedEnergy());
-    BOOST_CHECK_EQUAL(cor.getPackedCellStatus(), cdc.getPackedCellStatus());
+    BOOST_CHECK_EQUAL(cor.getTower(), cdc.getTower());
+    BOOST_CHECK_EQUAL(cor.getTimeStamp(), cdc.getTimeStamp());
+    BOOST_CHECK_EQUAL(cor.getEnergy(), cdc.getEnergy());
+    BOOST_CHECK_EQUAL(cor.getType(), cdc.getType());
   }
 }

--- a/Detectors/EMCAL/base/src/ClusterFactory.cxx
+++ b/Detectors/EMCAL/base/src/ClusterFactory.cxx
@@ -84,6 +84,7 @@ o2::emcal::AnalysisCluster ClusterFactory<InputType>::buildCluster(int clusterIn
   clusterAnalysis.setNCells(inputsIndices.size());
 
   std::vector<unsigned short> cellsIdices;
+  std::vector<float> ampfractions;
 
   for (auto cellIndex : inputsIndices) {
     cellsIdices.push_back(cellIndex);
@@ -101,6 +102,21 @@ o2::emcal::AnalysisCluster ClusterFactory<InputType>::buildCluster(int clusterIn
 
   evalCoreEnergy(inputsIndices, clusterAnalysis);
   evalTime(inputsIndices, clusterAnalysis);
+
+  // set amp fractions
+  float cellenergy = 0;
+  for (auto cellIndex : inputsIndices) {
+    if (cellIndex >= mInputsContainer.size()) {
+      throw CellIndexRangeException(cellIndex, mInputsContainer.size());
+    }
+    cellenergy = mInputsContainer[cellIndex].getEnergy();
+    if (clusterAnalysis.E() > 0) {
+      ampfractions.push_back(cellenergy / clusterAnalysis.E());
+    } else {
+      LOG(fatal) << "Division by cluster energy 0! This should not happen";
+    }
+  }
+  clusterAnalysis.setCellsAmplitudeFraction(ampfractions);
 
   // TODO to be added at a later stage
   //evalPrimaries(inputsIndices, clusterAnalysis);

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelCalibrator.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelCalibrator.h
@@ -25,6 +25,7 @@
 #include "DetectorsCalibration/TimeSlotCalibration.h"
 #include "DetectorsCalibration/TimeSlot.h"
 #include "DataFormatsEMCAL/Cell.h"
+#include "DataFormatsEMCAL/CellCompressed.h"
 #include "EMCALBase/Geometry.h"
 #include "CCDB/CcdbObjectInfo.h"
 #include "EMCALCalib/CalibDB.h"
@@ -47,14 +48,17 @@ namespace o2
 {
 namespace emcal
 {
+/// \class EMCALChannelCalibrator
 /// \brief class used for managment of bad channel and time calibration
-/// template DataInput can be ChannelData or TimeData   // o2::emcal::EMCALChannelData, o2::emcal::EMCALTimeCalibData
-template <typename DataInput, typename DataOutput>
-class EMCALChannelCalibrator : public o2::calibration::TimeSlotCalibration<o2::emcal::Cell, DataInput>
+/// \tparam DataInput Timeslot object (TimeData or ChannelData)
+/// \tparam DataOutput Calibration object produced by the calibrator
+/// \tparam CellType Type of the cell (implementing the CellInterface) handled by the calibrator
+template <typename DataInput, typename DataOutput, typename CellType>
+class EMCALChannelCalibrator : public o2::calibration::TimeSlotCalibration<CellType, DataInput>
 {
   using TFType = o2::calibration::TFType;
   using Slot = o2::calibration::TimeSlot<DataInput>;
-  using Cell = o2::emcal::Cell;
+  //using Cell = o2::emcal::Cell;
   using CcdbObjectInfo = o2::ccdb::CcdbObjectInfo;
   using CcdbObjectInfoVector = std::vector<CcdbObjectInfo>;
 
@@ -96,8 +100,8 @@ class EMCALChannelCalibrator : public o2::calibration::TimeSlotCalibration<o2::e
 };
 
 //_____________________________________________
-template <typename DataInput, typename DataOutput>
-void EMCALChannelCalibrator<DataInput, DataOutput>::initOutput()
+template <typename DataInput, typename DataOutput, typename CellType>
+void EMCALChannelCalibrator<DataInput, DataOutput, CellType>::initOutput()
 {
   mInfoVector.clear();
   mCalibObjectVector.clear();
@@ -106,16 +110,16 @@ void EMCALChannelCalibrator<DataInput, DataOutput>::initOutput()
 }
 
 //_____________________________________________
-template <typename DataInput, typename DataOutput>
-bool EMCALChannelCalibrator<DataInput, DataOutput>::hasEnoughData(const o2::calibration::TimeSlot<DataInput>& slot) const
+template <typename DataInput, typename DataOutput, typename CellType>
+bool EMCALChannelCalibrator<DataInput, DataOutput, CellType>::hasEnoughData(const o2::calibration::TimeSlot<DataInput>& slot) const
 {
   const DataInput* c = slot.getContainer();
   return (mTest ? true : c->hasEnoughData());
 }
 
 //_____________________________________________
-template <typename DataInput, typename DataOutput>
-void EMCALChannelCalibrator<DataInput, DataOutput>::finalizeSlot(o2::calibration::TimeSlot<DataInput>& slot)
+template <typename DataInput, typename DataOutput, typename CellType>
+void EMCALChannelCalibrator<DataInput, DataOutput, CellType>::finalizeSlot(o2::calibration::TimeSlot<DataInput>& slot)
 {
 
   // Extract results for the single slot
@@ -184,10 +188,10 @@ void EMCALChannelCalibrator<DataInput, DataOutput>::finalizeSlot(o2::calibration
   }
 }
 
-template <typename DataInput, typename DataOutput>
-o2::calibration::TimeSlot<DataInput>& EMCALChannelCalibrator<DataInput, DataOutput>::emplaceNewSlot(bool front, TFType tstart, TFType tend)
+template <typename DataInput, typename DataOutput, typename CellType>
+o2::calibration::TimeSlot<DataInput>& EMCALChannelCalibrator<DataInput, DataOutput, CellType>::emplaceNewSlot(bool front, TFType tstart, TFType tend)
 {
-  auto& cont = o2::calibration::TimeSlotCalibration<o2::emcal::Cell, DataInput>::getSlots();
+  auto& cont = o2::calibration::TimeSlotCalibration<CellType, DataInput>::getSlots();
   auto& slot = front ? cont.emplace_front(tstart, tend) : cont.emplace_back(tstart, tend);
   slot.setContainer(std::make_unique<DataInput>());
   return slot;

--- a/Detectors/EMCAL/calibration/src/EMCALCalibrationLinkDef.h
+++ b/Detectors/EMCAL/calibration/src/EMCALCalibrationLinkDef.h
@@ -15,13 +15,17 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
-#pragma link C++ class o2::emcal::EMCALChannelCalibrator < o2::emcal::EMCALChannelData, o2::emcal::BadChannelMap> + ;
+#pragma link C++ class o2::emcal::EMCALChannelCalibrator < o2::emcal::EMCALChannelData, o2::emcal::BadChannelMap, o2::emcal::Cell> + ;
+#pragma link C++ class o2::emcal::EMCALChannelCalibrator < o2::emcal::EMCALChannelData, o2::emcal::BadChannelMap, o2::emcal::CellCompressed> + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::emcal::EMCALChannelData> + ;
 #pragma link C++ class o2::calibration::TimeSlotCalibration < o2::emcal::Cell, o2::emcal::EMCALChannelData> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::emcal::CellCompressed, o2::emcal::EMCALChannelData> + ;
 
-#pragma link C++ class o2::emcal::EMCALChannelCalibrator < o2::emcal::EMCALTimeCalibData, o2::emcal::TimeCalibrationParams> + ;
+#pragma link C++ class o2::emcal::EMCALChannelCalibrator < o2::emcal::EMCALTimeCalibData, o2::emcal::TimeCalibrationParams, o2::emcal::Cell> + ;
+#pragma link C++ class o2::emcal::EMCALChannelCalibrator < o2::emcal::EMCALTimeCalibData, o2::emcal::TimeCalibrationParams, o2::emcal::CellCompressed> + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::emcal::EMCALTimeCalibData> + ;
 #pragma link C++ class o2::calibration::TimeSlotCalibration < o2::emcal::Cell, o2::emcal::EMCALTimeCalibData> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::emcal::CellCompressed, o2::emcal::EMCALTimeCalibData> + ;
 
 #pragma link C++ class o2::emcal::EMCALCalibParams + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::emcal::EMCALCalibParams> + ;

--- a/Detectors/EMCAL/calibration/src/EMCALChannelData.cxx
+++ b/Detectors/EMCAL/calibration/src/EMCALChannelData.cxx
@@ -45,25 +45,6 @@ std::ostream& operator<<(std::ostream& stream, const EMCALChannelData& emcdata)
   return stream;
 }
 //_____________________________________________
-void EMCALChannelData::fill(const gsl::span<const o2::emcal::Cell> data)
-{
-  //the fill function is called once per event
-  mEvents++;
-  for (auto cell : data) {
-    double cellEnergy = cell.getEnergy();
-    int id = cell.getTower();
-    LOG(debug) << "inserting in cell ID " << id << ": energy = " << cellEnergy;
-    mHisto(cellEnergy, id);
-    mNEntriesInHisto++;
-
-    if (cellEnergy > o2::emcal::EMCALCalibParams::Instance().minCellEnergyTime_bc) {
-      double cellTime = cell.getTimeStamp();
-      LOG(debug) << "inserting in cell ID " << id << ": time = " << cellTime;
-      mHistoTime(cellTime, id);
-    }
-  }
-}
-//_____________________________________________
 void EMCALChannelData::print()
 {
   LOG(debug) << *this;

--- a/Detectors/EMCAL/calibration/src/EMCALTimeCalibData.cxx
+++ b/Detectors/EMCAL/calibration/src/EMCALTimeCalibData.cxx
@@ -73,23 +73,6 @@ bool EMCALTimeCalibData::hasEnoughData() const
 
   return enough;
 }
-//_____________________________________________
-void EMCALTimeCalibData::fill(const gsl::span<const o2::emcal::Cell> data)
-{
-  // the fill function is called once per event
-  mEvents++;
-
-  for (auto cell : data) {
-    double cellEnergy = cell.getEnergy();
-    double cellTime = cell.getTimeStamp();
-    int id = cell.getTower();
-    if (cellEnergy > EMCALCalibParams::Instance().minCellEnergy_tc) {
-      LOG(debug) << "inserting in cell ID " << id << ": cellTime = " << cellTime;
-      mTimeHisto(cellTime, id);
-      mNEntriesInHisto++;
-    }
-  }
-}
 
 //_____________________________________________
 o2::emcal::TimeCalibrationParams EMCALTimeCalibData::process()

--- a/Detectors/EMCAL/calibration/testWorkflow/DataLoader.h
+++ b/Detectors/EMCAL/calibration/testWorkflow/DataLoader.h
@@ -1,0 +1,214 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <bitset>
+#include <exception>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <vector>
+
+#include <gsl/span>
+
+#include <DataFormatsEMCAL/Cell.h>
+#include <DataFormatsEMCAL/CellCompressed.h>
+#include <DataFormatsEMCAL/TriggerRecord.h>
+#include <Framework/InputRecord.h>
+#include <Framework/InputSpec.h>
+#include <Framework/ProcessingContext.h>
+#include <Headers/DataHeader.h>
+
+namespace o2
+{
+namespace emcal
+{
+
+class DataLoader
+{
+ public:
+  class ObjectTypeException : public std::exception
+  {
+   public:
+    ObjectTypeException(const std::string_view request, const std::string_view expectType) : mRequest(request), mExpectType(expectType)
+    {
+      mMessage = "Invalid type for ";
+      mMessage += mRequest.data();
+      mMessage += ": expecting ";
+      mMessage += expectType.data();
+    }
+    ~ObjectTypeException() noexcept final = default;
+
+    const char* what() const noexcept final
+    {
+      return mMessage.data();
+    }
+
+    const char* getRequest() const noexcept
+    {
+      return mRequest.data();
+    }
+
+    const char* getExpectType() const noexcept
+    {
+      return mExpectType.data();
+    }
+
+   private:
+    std::string mRequest;
+    std::string mExpectType;
+    std::string mMessage;
+  };
+
+  class ObjectRequestException : public std::exception
+  {
+   public:
+    ObjectRequestException(const std::string_view request) : mRequest(request)
+    {
+      mMessage = "No load request for data type: ";
+      mMessage += mRequest.data();
+    }
+    ~ObjectRequestException() noexcept final = default;
+
+    const char* what() const noexcept final
+    {
+      return mMessage.data();
+    }
+
+    const char* getRequest() const noexcept
+    {
+      return mRequest.data();
+    }
+
+   private:
+    std::string mRequest;
+    std::string mMessage;
+  };
+
+  class UnsupportedRequestException : public std::exception
+  {
+    UnsupportedRequestException(const std::string_view request) : mRequest(request)
+    {
+      mMessage = "Request not supported by data loader: ";
+      mMessage += mRequest.data();
+    }
+    ~UnsupportedRequestException() noexcept final = default;
+
+    const char* what() const noexcept final
+    {
+      return mMessage.data();
+    }
+
+    const char* getRequest() const noexcept
+    {
+      return mRequest.data();
+    }
+
+   private:
+    std::string mRequest;
+    std::string mMessage;
+  };
+
+  enum Object_t {
+    EMCCELL,
+    EMCCELLCOMPRESSED,
+    EMCCELLTRIGGERRECORD
+  };
+
+  enum class Request_t {
+    CELL,
+    CELLTRIGGERRECORD
+  };
+
+  static const char* getCellBinding() { return "emccells"; }
+  static const char* getCellCompressedBinding() { return "emccellscompressed"; }
+  static const char* getCellTriggerRecordBinding() { return "emccellstriggerrecords"; }
+
+  DataLoader() = default;
+  ~DataLoader() = default;
+
+  void setLoadCells(bool doLoad = true) { mObjects.set(EMCCELL, doLoad); }
+  void setLoadCompressedCells(bool doLoad = true) { mObjects.set(EMCCELLCOMPRESSED, doLoad); }
+  void setLoadCellTriggerRecords(bool doLoad = true) { mObjects.set(EMCCELLTRIGGERRECORD, doLoad); }
+
+  void defineInputs(std::vector<framework::InputSpec> inputs)
+  {
+    if (mObjects.test(EMCCELL)) {
+      inputs.emplace_back(getCellBinding(), o2::header::gDataOriginEMC, "CELLS", 0, framework::Lifetime::Timeframe);
+    }
+    if (mObjects.test(EMCCELLCOMPRESSED)) {
+      inputs.emplace_back(getCellCompressedBinding(), o2::header::gDataOriginEMC, "CELLS", 0, framework::Lifetime::Timeframe);
+    }
+    if (mObjects.test(EMCCELLTRIGGERRECORD)) {
+      inputs.emplace_back(getCellTriggerRecordBinding(), o2::header::gDataOriginEMC, "CELLSTRGR", 0, framework::Lifetime::Timeframe);
+    }
+  }
+
+  void updateObjects(framework::ProcessingContext& ctx)
+  {
+    if (mObjects.test(EMCCELL)) {
+      auto cellinput = gsl::span<const o2::emcal::Cell>(*(ctx.inputs().get<gsl::span<const o2::emcal::Cell>>(getCellBinding())));
+    }
+    if (mObjects.test(EMCCELLCOMPRESSED)) {
+      mCompressedCells = gsl::span<const o2::emcal::CellCompressed>(*(ctx.inputs().get<gsl::span<const o2::emcal::CellCompressed>>(getCellCompressedBinding())));
+    }
+    if (mObjects.test(EMCCELLTRIGGERRECORD)) {
+      mCellTriggerRecords = gsl::span<const o2::emcal::TriggerRecord>(*(ctx.inputs().get<gsl::span<const o2::emcal::TriggerRecord>>(getCellTriggerRecordBinding())));
+    }
+  }
+
+  template <typename objecttype>
+  gsl::span<const objecttype> get(Request_t request)
+  {
+    switch (request) {
+      case Request_t::CELL: {
+        if (mObjects.test(EMCCELL)) {
+          if constexpr (std::is_same<objecttype, o2::emcal::Cell>::value) {
+            return mCells;
+          } else {
+            throw ObjectTypeException("Cell", "o2::emcal::Cell");
+          }
+        } else if (mObjects.test(EMCCELLCOMPRESSED)) {
+          if constexpr (std::is_same<objecttype, o2::emcal::CellCompressed>::value) {
+            return mCompressedCells;
+          } else {
+            throw ObjectTypeException("Cell", "o2::emcal::CellCompressed");
+          }
+        } else {
+          throw ObjectRequestException("Cell");
+        }
+        break;
+      }
+      case Request_t::CELLTRIGGERRECORD: {
+        if (mObjects.test(EMCCELLTRIGGERRECORD)) {
+          if constexpr (std::is_same<objecttype, o2::emcal::TriggerRecord>::value) {
+            return mCellTriggerRecords;
+          } else {
+            throw ObjectTypeException("CellTriggerRecord", "o2::emcal::TriggerRecord");
+          }
+        } else {
+          throw ObjectRequestException("CellTriggerRecord");
+        }
+      }
+    };
+    throw ObjectRequestException("Unknown");
+  }
+
+ private:
+  std::bitset<16> mObjects;
+  gsl::span<const o2::emcal::Cell> mCells;
+  gsl::span<const o2::emcal::CellCompressed> mCompressedCells;
+  gsl::span<const o2::emcal::TriggerRecord> mCellTriggerRecords;
+
+}; // namespace emcal
+
+} // namespace emcal
+
+} // namespace o2

--- a/Detectors/EMCAL/calibration/testWorkflow/EMCALChannelCalibratorSpec.h
+++ b/Detectors/EMCAL/calibration/testWorkflow/EMCALChannelCalibratorSpec.h
@@ -18,9 +18,11 @@
 #ifndef O2_CALIBRATION_EMCALCHANNEL_CALIBRATOR_H
 #define O2_CALIBRATION_EMCALCHANNEL_CALIBRATOR_H
 
+#include "DataLoader.h"
 #include "EMCALCalibration/EMCALChannelCalibrator.h"
 #include "EMCALCalibration/EMCALCalibParams.h"
 #include "DetectorsCalibration/Utils.h"
+#include "DataFormatsEMCAL/CellCompressed.h"
 #include "DataFormatsEMCAL/TriggerRecord.h"
 #include "CommonUtils/MemFileHelper.h"
 #include "CommonConstants/Triggers.h"
@@ -44,13 +46,14 @@ namespace o2
 namespace calibration
 {
 
+template <typename CellType>
 class EMCALChannelCalibDevice : public o2::framework::Task
 {
 
   using EMCALCalibParams = o2::emcal::EMCALCalibParams;
 
  public:
-  EMCALChannelCalibDevice(std::shared_ptr<o2::base::GRPGeomRequest> req, bool params, std::string calibType, bool rejCalibTrg) : mCCDBRequest(req), mLoadCalibParamsFromCCDB(params), mCalibType(calibType), mRejectCalibTriggers(rejCalibTrg) {}
+  EMCALChannelCalibDevice(std::shared_ptr<o2::base::GRPGeomRequest> req, std::shared_ptr<o2::emcal::DataLoader> dataloader, bool params, std::string_view calibType, bool rejCalibTrg) : mCCDBRequest(req), mDataLoader(dataloader), mLoadCalibParamsFromCCDB(params), mCalibType(calibType.data()), mRejectCalibTriggers(rejCalibTrg) {}
 
   void init(o2::framework::InitContext& ic) final
   {
@@ -61,14 +64,14 @@ class EMCALChannelCalibDevice : public o2::framework::Task
     if (mCalibType.find("time") != std::string::npos) { // time calibration
       isBadChannelCalib = false;
       if (!mTimeCalibrator) {
-        mTimeCalibrator = std::make_unique<o2::emcal::EMCALChannelCalibrator<o2::emcal::EMCALTimeCalibData, o2::emcal::TimeCalibrationParams>>();
+        mTimeCalibrator = std::make_unique<o2::emcal::EMCALChannelCalibrator<o2::emcal::EMCALTimeCalibData, o2::emcal::TimeCalibrationParams, CellType>>();
       }
       mTimeCalibrator->SetCalibExtractor(mCalibExtractor);
 
     } else { // bad cell calibration
       isBadChannelCalib = true;
       if (!mBadChannelCalibrator) {
-        mBadChannelCalibrator = std::make_unique<o2::emcal::EMCALChannelCalibrator<o2::emcal::EMCALChannelData, o2::emcal::BadChannelMap>>();
+        mBadChannelCalibrator = std::make_unique<o2::emcal::EMCALChannelCalibrator<o2::emcal::EMCALChannelData, o2::emcal::BadChannelMap, CellType>>();
       }
       mBadChannelCalibrator->SetCalibExtractor(mCalibExtractor);
     }
@@ -122,52 +125,59 @@ class EMCALChannelCalibDevice : public o2::framework::Task
       configureCalibrators();
       mIsConfigured = true;
     }
+    mDataLoader->updateObjects(pc);
 
-    auto tfcounter = o2::header::get<o2::framework::DataProcessingHeader*>(pc.inputs().get(getCellBinding()).header)->startTime;
+    auto tfcounter = o2::header::get<o2::framework::DataProcessingHeader*>(pc.inputs().get(o2::emcal::DataLoader::getCellTriggerRecordBinding()).header)->startTime;
 
-    auto data = pc.inputs().get<gsl::span<o2::emcal::Cell>>(getCellBinding());
+    try {
+      auto data = mDataLoader->get<CellType>(o2::emcal::DataLoader::Request_t::CELL);
 
-    auto InputTriggerRecord = pc.inputs().get<gsl::span<o2::emcal::TriggerRecord>>(getCellTriggerRecordBinding());
-    LOG(debug) << "[EMCALCalibrator - run]  Received " << InputTriggerRecord.size() << " Trigger Records, running calibration ...";
+      auto InputTriggerRecord = mDataLoader->get<o2::emcal::TriggerRecord>(o2::emcal::DataLoader::Request_t::CELLTRIGGERRECORD);
+      LOG(debug) << "[EMCALCalibrator - run]  Received " << InputTriggerRecord.size() << " Trigger Records, running calibration ...";
 
-    LOG(debug) << "Processing TF " << tfcounter << " with " << data.size() << " cells";
+      LOG(debug) << "Processing TF " << tfcounter << " with " << data.size() << " cells";
 
-    // call process for every event in the trigger record to ensure correct event counting for the calibration.
-    for (const auto& trg : InputTriggerRecord) {
-      if (!trg.getNumberOfObjects()) {
-        continue;
-      }
-      // reject calibration trigger from the calibration
-      if (mRejectCalibTriggers) {
-        LOG(debug) << "Trigger: " << trg.getTriggerBits() << "   o2::trigger::Cal " << o2::trigger::Cal;
-        if (trg.getTriggerBits() & o2::trigger::Cal) {
-          LOG(debug) << "skipping triggered events due to wrong trigger (no Physics trigger)";
+      // call process for every event in the trigger record to ensure correct event counting for the calibration.
+      for (const auto& trg : InputTriggerRecord) {
+        if (!trg.getNumberOfObjects()) {
           continue;
         }
-      }
+        // reject calibration trigger from the calibration
+        if (mRejectCalibTriggers) {
+          LOG(debug) << "Trigger: " << trg.getTriggerBits() << "   o2::trigger::Cal " << o2::trigger::Cal;
+          if (trg.getTriggerBits() & o2::trigger::Cal) {
+            LOG(debug) << "skipping triggered events due to wrong trigger (no Physics trigger)";
+            continue;
+          }
+        }
 
-      gsl::span<const o2::emcal::Cell> eventData(data.data() + trg.getFirstEntry(), trg.getNumberOfObjects());
+        auto eventData = data.subspan(trg.getFirstEntry(), trg.getNumberOfObjects());
 
-      // fast calibration
-      if (EMCALCalibParams::Instance().enableFastCalib) {
-        LOG(debug) << "fast calib not yet available!";
-        // normal calibration procedure
-      } else {
-        if (isBadChannelCalib) {
-          mBadChannelCalibrator->process(eventData);
+        // fast calibration
+        if (EMCALCalibParams::Instance().enableFastCalib) {
+          LOG(debug) << "fast calib not yet available!";
+          // normal calibration procedure
         } else {
-          mTimeCalibrator->process(eventData);
+          if (isBadChannelCalib) {
+            mBadChannelCalibrator->process(eventData);
+          } else {
+            mTimeCalibrator->process(eventData);
+          }
         }
       }
-    }
-    if (isBadChannelCalib) {
-      sendOutput<o2::emcal::BadChannelMap>(pc.outputs());
-    } else {
-      sendOutput<o2::emcal::TimeCalibrationParams>(pc.outputs());
-    }
-    if (EMCALCalibParams::Instance().enableTimeProfiling) {
-      timeMeas[1] = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
-      LOG(info) << "end of run function. Time: " << timeMeas[1] - timeMeas[0] << " [ns] for " << InputTriggerRecord.size() << " events";
+      if (isBadChannelCalib) {
+        sendOutput<o2::emcal::BadChannelMap>(pc.outputs());
+      } else {
+        sendOutput<o2::emcal::TimeCalibrationParams>(pc.outputs());
+      }
+      if (EMCALCalibParams::Instance().enableTimeProfiling) {
+        timeMeas[1] = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count();
+        LOG(info) << "end of run function. Time: " << timeMeas[1] - timeMeas[0] << " [ns] for " << InputTriggerRecord.size() << " events";
+      }
+    } catch (o2::emcal::DataLoader::ObjectTypeException& error) {
+      LOG(error) << error.what();
+    } catch (o2::emcal::DataLoader::ObjectRequestException& error) {
+      LOG(error) << error.what();
     }
   }
 
@@ -182,20 +192,18 @@ class EMCALChannelCalibDevice : public o2::framework::Task
     }
   }
 
-  static const char* getCellBinding() { return "EMCCells"; }
-  static const char* getCellTriggerRecordBinding() { return "EMCCellsTrgR"; }
-
  private:
-  std::unique_ptr<o2::emcal::EMCALChannelCalibrator<o2::emcal::EMCALChannelData, o2::emcal::BadChannelMap>> mBadChannelCalibrator;     ///< Bad channel calibrator
-  std::unique_ptr<o2::emcal::EMCALChannelCalibrator<o2::emcal::EMCALTimeCalibData, o2::emcal::TimeCalibrationParams>> mTimeCalibrator; ///< Time calibrator
-  std::shared_ptr<o2::emcal::EMCALCalibExtractor> mCalibExtractor;                                                                     ///< Calibration postprocessing
-  std::shared_ptr<o2::base::GRPGeomRequest> mCCDBRequest;                                                                              ///< CCDB request for geometry
-  std::string mCalibType;                                                                                                              ///< Name of the calibration type
-  bool mIsConfigured = false;                                                                                                          ///< Configure status of calibrators
-  bool mScaleFactorsInitialized = false;                                                                                               ///< Scale factor init status
-  bool isBadChannelCalib = true;                                                                                                       ///< Calibration mode bad channel calib (false := time calib)
-  bool mLoadCalibParamsFromCCDB = true;                                                                                                ///< Switch for loading calib params from the CCDB
-  bool mRejectCalibTriggers = true;                                                                                                    ///! reject calibration triggers in the online calibration
+  std::unique_ptr<o2::emcal::EMCALChannelCalibrator<o2::emcal::EMCALChannelData, o2::emcal::BadChannelMap, CellType>> mBadChannelCalibrator;     ///< Bad channel calibrator
+  std::unique_ptr<o2::emcal::EMCALChannelCalibrator<o2::emcal::EMCALTimeCalibData, o2::emcal::TimeCalibrationParams, CellType>> mTimeCalibrator; ///< Time calibrator
+  std::shared_ptr<o2::emcal::EMCALCalibExtractor> mCalibExtractor;                                                                               ///< Calibration postprocessing
+  std::shared_ptr<o2::base::GRPGeomRequest> mCCDBRequest;                                                                                        ///< CCDB request for geometry
+  std::shared_ptr<o2::emcal::DataLoader> mDataLoader;                                                                                            ///< Loader for input data for calibration
+  std::string mCalibType;                                                                                                                        ///< Name of the calibration type
+  bool mIsConfigured = false;                                                                                                                    ///< Configure status of calibrators
+  bool mScaleFactorsInitialized = false;                                                                                                         ///< Scale factor init status
+  bool isBadChannelCalib = true;                                                                                                                 ///< Calibration mode bad channel calib (false := time calib)
+  bool mLoadCalibParamsFromCCDB = true;                                                                                                          ///< Switch for loading calib params from the CCDB
+  bool mRejectCalibTriggers = true;                                                                                                              ///! reject calibration triggers in the online calibration
   std::array<double, 2> timeMeas;
 
   //________________________________________________________________
@@ -268,9 +276,8 @@ class EMCALChannelCalibDevice : public o2::framework::Task
 namespace framework
 {
 
-DataProcessorSpec getEMCALChannelCalibDeviceSpec(const std::string calibType, const bool loadCalibParamsFromCCDB, const bool rejectCalibTrigger)
+DataProcessorSpec getEMCALChannelCalibDeviceSpec(const std::string_view calibType, const std::string_view cellType, bool loadCalibParamsFromCCDB, bool rejectCalibTrigger)
 {
-  using device = o2::calibration::EMCALChannelCalibDevice;
   using clbUtils = o2::calibration::Utils;
   using EMCALCalibParams = o2::emcal::EMCALCalibParams;
   using CalibDB = o2::emcal::CalibDB;
@@ -288,8 +295,14 @@ DataProcessorSpec getEMCALChannelCalibDeviceSpec(const std::string calibType, co
   }
 
   std::vector<InputSpec> inputs;
-  inputs.emplace_back(device::getCellBinding(), o2::header::gDataOriginEMC, "CELLS", 0, o2::framework::Lifetime::Timeframe);
-  inputs.emplace_back(device::getCellTriggerRecordBinding(), o2::header::gDataOriginEMC, "CELLSTRGR", 0, o2::framework::Lifetime::Timeframe);
+  std::shared_ptr<o2::emcal::DataLoader> loader;
+  loader->setLoadCellTriggerRecords(true);
+  if (cellType == "Cell") {
+    loader->setLoadCells(true);
+  } else if (cellType == "CellCompressed") {
+    loader->setLoadCompressedCells(true);
+  }
+  loader->defineInputs(inputs);
   // for loading the channelCalibParams from the ccdb
   if (loadCalibParamsFromCCDB) {
     inputs.emplace_back("EMC_CalibParam", o2::header::gDataOriginEMC, "EMCALCALIBPARAM", 0, Lifetime::Condition, ccdbParamSpec("EMC/Config/CalibParam"));
@@ -304,14 +317,25 @@ DataProcessorSpec getEMCALChannelCalibDeviceSpec(const std::string calibType, co
                                                                 false,                          // askMatLUT
                                                                 o2::base::GRPGeomRequest::None, // geometry
                                                                 inputs);
-  return DataProcessorSpec{
-    processorName,
-    inputs,
-    outputs,
-    AlgorithmSpec{adaptFromTask<device>(ccdbRequest, loadCalibParamsFromCCDB, calibType, rejectCalibTrigger)},
-    Options{}};
-}
+  if (cellType == "Cell") {
+    return DataProcessorSpec{
+      processorName,
+      inputs,
+      outputs,
+      AlgorithmSpec{adaptFromTask<o2::calibration::EMCALChannelCalibDevice<o2::emcal::Cell>>(ccdbRequest, loader, loadCalibParamsFromCCDB, calibType, rejectCalibTrigger)},
+      Options{}};
+  } else if (cellType == "CellCompressed") {
+    return DataProcessorSpec{
+      processorName,
+      inputs,
+      outputs,
+      AlgorithmSpec{adaptFromTask<o2::calibration::EMCALChannelCalibDevice<o2::emcal::CellCompressed>>(ccdbRequest, loader, loadCalibParamsFromCCDB, calibType, rejectCalibTrigger)},
+      Options{}};
 
+  } else {
+    throw std::runtime_error(fmt::format("Unknown cell type: {}", cellType));
+  }
+}
 } // namespace framework
 } // namespace o2
 

--- a/Detectors/EMCAL/calibration/testWorkflow/emc-channel-calib-workflow.cxx
+++ b/Detectors/EMCAL/calibration/testWorkflow/emc-channel-calib-workflow.cxx
@@ -38,6 +38,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
   std::vector<ConfigParamSpec> options{
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}},
     {"calibType", VariantType::String, "time", {"choose which calibration should be performed: time for tiem calibration, badchannel for bad channel calibration"}},
+    {"cellType", VariantType::String, "CellCompressed", {"Specify cell input type, can be Cell or CellCompressed"}},
     {"no-loadCalibParamsFromCCDB", VariantType::Bool, false, {"disabled by default such that calib params are taken from the ccdb. If enabled, calib params are taken from EMCALCalibParams.h directly"}},
     {"no-rejectCalibTrigger", VariantType::Bool, false, {"disabled by default such that calib triggers are rejected. If enabled, calibration triggers (LED events etc.) also enter the calibration"}}};
 
@@ -53,9 +54,13 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   std::string calibType = cfgc.options().get<std::string>("calibType");
   bool loadCalibParamsFromCCDB = !cfgc.options().get<bool>("no-loadCalibParamsFromCCDB");
   bool rejectCalibTrigger = !cfgc.options().get<bool>("no-rejectCalibTrigger");
+  std::string cellType = cfgc.options().get<std::string>("cellType");
+  if (cellType != "Cell" && cellType != "CellCompressed") {
+    std::runtime_error(fmt::format("Cell type {} undefined, choose either Cell or CompressedCell", cellType.data()));
+  }
 
   WorkflowSpec specs;
-  specs.emplace_back(getEMCALChannelCalibDeviceSpec(calibType, loadCalibParamsFromCCDB, rejectCalibTrigger));
+  specs.emplace_back(getEMCALChannelCalibDeviceSpec(calibType, cellType, loadCalibParamsFromCCDB, rejectCalibTrigger));
 
   // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit
   // o2::raw::HBFUtilsInitializer hbfIni(cfgc, specs);

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CTFHelper.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CTFHelper.h
@@ -232,6 +232,14 @@ class CTFHelper
     value_type operator[](difference_type i) const { return mData[mIndex + i].getPackedCellStatus(); }
   };
 
+  //_______________________________________________
+  class Iter_chi2 : public _Iter<Iter_chi2, Cell, uint16_t>
+  {
+   public:
+    using _Iter<Iter_chi2, Cell, uint16_t>::_Iter;
+    value_type operator*() const { return mData[mIndex].getPackedChi2(); }
+  };
+
   //<<< =========================== ITERATORS ========================================
 
   Iter_bcIncTrig begin_bcIncTrig() const { return Iter_bcIncTrig(mTrigData, false); }
@@ -257,6 +265,9 @@ class CTFHelper
 
   Iter_status begin_status() const { return Iter_status(mCellData, false); }
   Iter_status end_status() const { return Iter_status(mCellData, true); }
+
+  Iter_chi2 begin_chi2() const { return Iter_chi2(mCellData, false); }
+  Iter_chi2 end_chi2() const { return Iter_chi2(mCellData, true); }
 
  private:
   const gsl::span<const o2::emcal::TriggerRecord> mTrigData;

--- a/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CTFHelper.h
+++ b/Detectors/EMCAL/reconstruction/include/EMCALReconstruction/CTFHelper.h
@@ -28,7 +28,7 @@ class CTFHelper
 {
 
  public:
-  CTFHelper(const gsl::span<const TriggerRecord>& trgData, const gsl::span<const Cell>& cellData)
+  CTFHelper(const gsl::span<const TriggerRecord>& trgData, const gsl::span<const CellCompressed>& cellData)
     : mTrigData(trgData), mCellData(cellData) {}
 
   CTFHeader createHeader()
@@ -42,7 +42,7 @@ class CTFHelper
     return h;
   }
 
-  size_t getSize() const { return mTrigData.size() * sizeof(TriggerRecord) + mCellData.size() * sizeof(Cell); }
+  size_t getSize() const { return mTrigData.size() * sizeof(TriggerRecord) + mCellData.size() * sizeof(CellCompressed); }
 
   //>>> =========================== ITERATORS ========================================
 
@@ -197,46 +197,46 @@ class CTFHelper
   };
 
   //_______________________________________________
-  class Iter_towerID : public _Iter<Iter_towerID, Cell, uint16_t>
+  class Iter_towerID : public _Iter<Iter_towerID, CellCompressed, uint16_t>
   {
    public:
-    using _Iter<Iter_towerID, Cell, uint16_t>::_Iter;
+    using _Iter<Iter_towerID, CellCompressed, uint16_t>::_Iter;
     value_type operator*() const { return mData[mIndex].getPackedTowerID(); }
     value_type operator[](difference_type i) const { return mData[mIndex + i].getPackedTowerID(); }
   };
 
   //_______________________________________________
-  class Iter_time : public _Iter<Iter_time, Cell, uint16_t>
+  class Iter_time : public _Iter<Iter_time, CellCompressed, uint16_t>
   {
    public:
-    using _Iter<Iter_time, Cell, uint16_t>::_Iter;
+    using _Iter<Iter_time, CellCompressed, uint16_t>::_Iter;
     value_type operator*() const { return mData[mIndex].getPackedTime(); }
     value_type operator[](difference_type i) const { return mData[mIndex + i].getPackedTime(); }
   };
 
   //_______________________________________________
-  class Iter_energy : public _Iter<Iter_energy, Cell, uint16_t>
+  class Iter_energy : public _Iter<Iter_energy, CellCompressed, uint16_t>
   {
    public:
-    using _Iter<Iter_energy, Cell, uint16_t>::_Iter;
+    using _Iter<Iter_energy, CellCompressed, uint16_t>::_Iter;
     value_type operator*() const { return mData[mIndex].getPackedEnergy(); }
     value_type operator[](difference_type i) const { return mData[mIndex + i].getPackedEnergy(); }
   };
 
   //_______________________________________________
-  class Iter_status : public _Iter<Iter_status, Cell, uint8_t>
+  class Iter_status : public _Iter<Iter_status, CellCompressed, uint8_t>
   {
    public:
-    using _Iter<Iter_status, Cell, uint8_t>::_Iter;
+    using _Iter<Iter_status, CellCompressed, uint8_t>::_Iter;
     value_type operator*() const { return mData[mIndex].getPackedCellStatus(); }
     value_type operator[](difference_type i) const { return mData[mIndex + i].getPackedCellStatus(); }
   };
 
   //_______________________________________________
-  class Iter_chi2 : public _Iter<Iter_chi2, Cell, uint16_t>
+  class Iter_chi2 : public _Iter<Iter_chi2, CellCompressed, uint16_t>
   {
    public:
-    using _Iter<Iter_chi2, Cell, uint16_t>::_Iter;
+    using _Iter<Iter_chi2, CellCompressed, uint16_t>::_Iter;
     value_type operator*() const { return mData[mIndex].getPackedChi2(); }
   };
 
@@ -271,7 +271,7 @@ class CTFHelper
 
  private:
   const gsl::span<const o2::emcal::TriggerRecord> mTrigData;
-  const gsl::span<const o2::emcal::Cell> mCellData;
+  const gsl::span<const o2::emcal::CellCompressed> mCellData;
 };
 
 } // namespace emcal

--- a/Detectors/EMCAL/reconstruction/src/CTFCoder.cxx
+++ b/Detectors/EMCAL/reconstruction/src/CTFCoder.cxx
@@ -41,7 +41,7 @@ void CTFCoder::createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBa
 {
   const auto ctf = CTF::getImage(bufVec.data());
   // just to get types
-  uint16_t bcInc = 0, entries = 0, cellTime = 0, energy = 0, tower = 0, trigger = 0;
+  uint16_t bcInc = 0, entries = 0, cellTime = 0, energy = 0, tower = 0, trigger = 0, chi2 = 0;
   uint32_t orbitInc = 0;
   uint8_t status = 0;
 #define MAKECODER(part, slot) createCoder<decltype(part)>(op, ctf.getFrequencyTable(slot), int(slot))
@@ -55,5 +55,6 @@ void CTFCoder::createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBa
   MAKECODER(status,     CTF::BLC_status);
   // extra slot was added in the end
   MAKECODER(trigger,    CTF::BLC_trigger);
+  MAKECODER(chi2,       CTF::BLC_chi2);
   // clang-format on
 }

--- a/Detectors/EMCAL/reconstruction/src/CaloRawFitterGamma2.cxx
+++ b/Detectors/EMCAL/reconstruction/src/CaloRawFitterGamma2.cxx
@@ -48,7 +48,7 @@ CaloFitResults CaloRawFitterGamma2::evaluate(const gsl::span<const Bunch> bunchl
     int timebinOffset = bunchlist[bunchIndex].getStartTime() - (bunchlist[bunchIndex].getBunchLength() - 1);
     amp = ampEstimate;
 
-    if (nsamples > 2 && maxADC < constants::OVERFLOWCUT) {
+    if (nsamples > 2 && maxADC < constants::EMCAL_HGLGTRANSITION) {
       std::tie(amp, time) = doParabolaFit(timeEstimate - 1);
       mNiter = 0;
       try {

--- a/Detectors/EMCAL/reconstruction/src/CaloRawFitterStandard.cxx
+++ b/Detectors/EMCAL/reconstruction/src/CaloRawFitterStandard.cxx
@@ -66,7 +66,7 @@ CaloFitResults CaloRawFitterStandard::evaluate(const gsl::span<const Bunch> bunc
     int timebinOffset = bunchlist[bunchIndex].getStartTime() - (bunchlist[bunchIndex].getBunchLength() - 1);
     amp = ampEstimate;
 
-    if (nsamples > 1 && maxADC < constants::OVERFLOWCUT) {
+    if (nsamples > 1 && maxADC < constants::EMCAL_HGLGTRANSITION) {
       try {
         std::tie(amp, time, chi2) = fitRaw(first, last);
         time += timebinOffset;

--- a/Detectors/EMCAL/workflow/src/CellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/CellConverterSpec.cxx
@@ -96,7 +96,7 @@ void CellConverterSpec::run(framework::ProcessingContext& ctx)
           fitResults = mRawFitter->evaluate(channelData.mChannelsBunchesHG);
 
           // If the high gain bunch is saturated then fit the low gain
-          if (fitResults.getAmp() > o2::emcal::constants::OVERFLOWCUT) {
+          if (fitResults.getAmp() > o2::emcal::constants::EMCAL_HGLGTRANSITION) {
             fitResults = mRawFitter->evaluate(channelData.mChannelsBunchesLG);
             fitResults.setAmp(fitResults.getAmp() * o2::emcal::constants::EMCAL_HGLGFACTOR);
             channelType = ChannelType_t::LOW_GAIN;

--- a/Detectors/EMCAL/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/EntropyEncoderSpec.cxx
@@ -50,7 +50,7 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
   mTimer.Start(false);
   mCTFCoder.updateTimeDependentParams(pc);
   auto triggers = pc.inputs().get<gsl::span<TriggerRecord>>("triggers");
-  auto cells = pc.inputs().get<gsl::span<Cell>>("cells");
+  auto cells = pc.inputs().get<gsl::span<CellCompressed>>("cells");
 
   auto& buffer = pc.outputs().make<std::vector<o2::ctf::BufferType>>(Output{"EMC", "CTFDATA", 0, Lifetime::Timeframe});
   if (mSelIR) {

--- a/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
@@ -441,7 +441,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
                   res->mHGOutOfRange = false; // LG is found so it can replace the HG if the HG is out of range
                   if (res->mCellData.getHighGain()) {
                     double ampOld = res->mCellData.getEnergy() / o2::emcal::constants::EMCAL_ADCENERGY; // cut applied on ADC and not on energy
-                    if (ampOld > o2::emcal::constants::OVERFLOWCUT) {
+                    if (ampOld > o2::emcal::constants::EMCAL_HGLGTRANSITION) {
                       // High gain digit has energy above overflow cut, use low gain instead
                       res->mCellData.setEnergy(amp * o2::emcal::constants::EMCAL_HGLGFACTOR);
                       res->mCellData.setTimeStamp(celltime);
@@ -456,7 +456,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
                   res->mIsLGnoHG = false;
                   res->mHGOutOfRange = false;
                   res->mHWAddressHG = chan.getHardwareAddress();
-                  if (amp / o2::emcal::constants::EMCAL_ADCENERGY <= o2::emcal::constants::OVERFLOWCUT) {
+                  if (amp / o2::emcal::constants::EMCAL_ADCENERGY <= o2::emcal::constants::EMCAL_HGLGTRANSITION) {
                     res->mCellData.setEnergy(amp);
                     res->mCellData.setTimeStamp(celltime);
                     res->mCellData.setHighGain();
@@ -474,7 +474,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
                   hwAddressLG = chan.getHardwareAddress();
                 } else {
                   // High gain cell: Flag as low gain if above threshold
-                  if (amp / o2::emcal::constants::EMCAL_ADCENERGY > o2::emcal::constants::OVERFLOWCUT) {
+                  if (amp / o2::emcal::constants::EMCAL_ADCENERGY > o2::emcal::constants::EMCAL_HGLGTRANSITION) {
                     hgOutOfRange = true;
                   }
                   hwAddressHG = chan.getHardwareAddress();

--- a/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
@@ -426,6 +426,8 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
             if (fitResults.getTime() < 0) {
               fitResults.setTime(0.);
             }
+
+            float chi2 = fitResults.getChi2();
             // apply correction for bc mod 4
             double celltime = fitResults.getTime() - timeshift - 25 * bcmod4;
             double amp = fitResults.getAmp() * o2::emcal::constants::EMCAL_ADCENERGY;
@@ -446,6 +448,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
                       res->mCellData.setEnergy(amp * o2::emcal::constants::EMCAL_HGLGFACTOR);
                       res->mCellData.setTimeStamp(celltime);
                       res->mCellData.setLowGain();
+                      res->mCellData.setChi2(chi2);
                     }
                     res->mIsLGnoHG = false;
                   }
@@ -460,6 +463,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
                     res->mCellData.setEnergy(amp);
                     res->mCellData.setTimeStamp(celltime);
                     res->mCellData.setHighGain();
+                    res->mCellData.setChi2(chi2);
                   }
                 }
               } else {
@@ -480,7 +484,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
                   hwAddressHG = chan.getHardwareAddress();
                 }
                 int fecID = mMapper->getFEEForChannelInDDL(feeID, chan.getFECIndex(), chan.getBranchIndex());
-                currentCellContainer->push_back({o2::emcal::Cell(CellID, amp, celltime, chantype),
+                currentCellContainer->push_back({o2::emcal::Cell(CellID, amp, celltime, chantype, chi2),
                                                  lgNoHG,
                                                  hgOutOfRange,
                                                  fecID, feeID, hwAddressLG, hwAddressHG});
@@ -495,7 +499,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
                 amp *= o2::emcal::constants::EMCAL_HGLGFACTOR;
               }
               int fecID = mMapper->getFEEForChannelInDDL(feeID, chan.getFECIndex(), chan.getBranchIndex());
-              currentCellContainer->push_back({o2::emcal::Cell(CellID, amp, celltime, chantype),
+              currentCellContainer->push_back({o2::emcal::Cell(CellID, amp, celltime, chantype, chi2),
                                                false,
                                                false,
                                                fecID, feeID, hwAddressLG, hwAddressHG});


### PR DESCRIPTION
- this PR is work-in-progress and contains multiple changes related to EMCal cells
- the class Cell.h which was used for CTF decoding and encoding was renamed to CellCompressed.h, including improvements for the energy compression, which is now performed differnetly for HG and LG cells to enhance the effective precision given the number of available bits
- the former Cell class is now replaced with a class that stores the energy etc in float precision (no compression) and is intended to be used from CTF onwards from now on (this change was needed because it was discovered that the energy calibration might cause problems with the enegry range dependent compression)
- the chi2 information was added to CTF encoding and decoding
- a check for the CTF dictionary version was implemented to allow for backward compatibility of old data