### PR TITLE
Fix fake overlap between ITS wrapper volume and MFT patch panel

### DIFF
--- a/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
@@ -117,7 +117,7 @@ static void configITS(Detector* its)
   const int kNWrapVol = 3;
   const double wrpRMin[kNWrapVol] = {2.1, 19.2, 33.32};
   const double wrpRMax[kNWrapVol] = {15.4, 29.14, 44.9};
-  const double wrpZSpan[kNWrapVol] = {70., 93., 163.6};
+  const double wrpZSpan[kNWrapVol] = {70., 93., 163.0};
 
   for (int iw = 0; iw < kNWrapVol; iw++) {
     its->defineWrapperVolume(iw, wrpRMin[iw], wrpRMax[iw], wrpZSpan[iw]);


### PR DESCRIPTION
An overlap between the ITS wrapper volume 2 and the MFT patch panel has been fixed by slightly reducing the wrapper Z dimension. The overlap is fake, because it was not between two real volumes: the ITS wrapper volume is simply an air-filled container holding the two Outer Barrel staves.