### PR TITLE
Always store PV->tracks table, even if with primaries only

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/src/primary-vertexing-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/primary-vertexing-workflow.cxx
@@ -119,7 +119,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   }
 
   if (!disableRootOut) {
-    specs.emplace_back(o2::vertexing::getPrimaryVertexWriterSpec(srcVT.none(), useMC));
+    specs.emplace_back(o2::vertexing::getPrimaryVertexWriterSpec(false, useMC));
   }
 
   // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit

--- a/Detectors/Vertexing/src/VertexTrackMatcher.cxx
+++ b/Detectors/Vertexing/src/VertexTrackMatcher.cxx
@@ -122,7 +122,9 @@ void VertexTrackMatcher::process(const o2::globaltracking::RecoContainer& recoDa
       vr.setFirstEntryOfSource(oldSrc, trackIndex.size());
     }
     vr.setEnd(trackIndex.size());
-    LOG(info) << vr;
+    if (logVertices) {
+      LOG(info) << vr;
+    }
   }
   logCounter++;
   LOG(info) << "Assigned " << nAssigned << " (" << nAmbiguous << " ambiguously) out of " << mTBrackets.size() << " non-contributor tracks + " << vcont.size() << " contributors";


### PR DESCRIPTION
+ yet another fix for log prescaling

Trivial, merging