### PR TITLE
add TOF method to move pos from global to local

### DIFF
--- a/Detectors/TOF/base/include/TOFBase/Geo.h
+++ b/Detectors/TOF/base/include/TOFBase/Geo.h
@@ -356,11 +356,11 @@ class Geo
   static void Init();
   static void InitIndices();
   static void getPosInSectorCoord(int ch, float* pos);
-  static int getPosInStripCoord(int ch, float* pos);
-  static int getPosInPadCoord(int ch, float* pos);
+  static void getPosInStripCoord(int ch, float* pos);
+  static void getPosInPadCoord(int ch, float* pos);
   static void getPosInSectorCoord(const Int_t* detId, float* pos);
-  static int getPosInStripCoord(const Int_t* detId, float* pos);
-  static int getPosInPadCoord(const Int_t* detId, float* pos);
+  static void getPosInStripCoord(const Int_t* detId, float* pos);
+  static void getPosInPadCoord(const Int_t* detId, float* pos);
 
  private:
   static Int_t getSector(const Float_t* pos);

--- a/Detectors/TOF/base/include/TOFBase/Geo.h
+++ b/Detectors/TOF/base/include/TOFBase/Geo.h
@@ -67,6 +67,7 @@ class Geo
   static void rotateToSector(Float_t* xyz, Int_t isector);
   static void rotateToStrip(Float_t* xyz, Int_t iplate, Int_t istrip, Int_t isector);
   static void antiRotateToSector(Float_t* xyz, Int_t isector);
+  static void antiRotateToStrip(Float_t* xyz, Int_t iplate, Int_t istrip, Int_t isector);
 
   static void antiRotate(Float_t* xyz, Double_t rotationAngles[6]);
   static void getDetID(Float_t* pos, Int_t* det);
@@ -354,6 +355,7 @@ class Geo
   static Int_t getCHFromECH(int echan) { return ELCHAN_TO_CHAN[echan]; }
 
   static void Init();
+  static void InitIdeal();
   static void InitIndices();
   static void getPosInSectorCoord(int ch, float* pos);
   static void getPosInStripCoord(int ch, float* pos);

--- a/Detectors/TOF/base/include/TOFBase/Geo.h
+++ b/Detectors/TOF/base/include/TOFBase/Geo.h
@@ -139,6 +139,7 @@ class Geo
   static constexpr Float_t RMAX2 = RMAX * RMAX;
 
   static constexpr Float_t XPAD = 2.5;
+  static constexpr Float_t XHALFSTRIP = XPAD * NPADX * 0.5;
   static constexpr Float_t ZPAD = 3.5;
   static constexpr Float_t STRIPLENGTH = 122;
 
@@ -354,6 +355,12 @@ class Geo
 
   static void Init();
   static void InitIndices();
+  static void getPosInSectorCoord(int ch, float* pos);
+  static int getPosInStripCoord(int ch, float* pos);
+  static int getPosInPadCoord(int ch, float* pos);
+  static void getPosInSectorCoord(const Int_t* detId, float* pos);
+  static int getPosInStripCoord(const Int_t* detId, float* pos);
+  static int getPosInPadCoord(const Int_t* detId, float* pos);
 
  private:
   static Int_t getSector(const Float_t* pos);

--- a/Detectors/TOF/base/src/Geo.cxx
+++ b/Detectors/TOF/base/src/Geo.cxx
@@ -544,30 +544,33 @@ void Geo::getPosInSectorCoord(const Int_t* detId, float* pos)
   pos[2] = -pos[2];
 }
 
-int Geo::getPosInStripCoord(const Int_t* detId, float* pos)
+void Geo::getPosInStripCoord(const Int_t* detId, float* pos)
 {
   Init();
   fromGlobalToSector(pos, detId[0]);
 
-  if (fromPlateToStrip(pos, detId[1], detId[0]) == -1) {
-    return -1;
-  }
-  pos[0] -= XHALFSTRIP;
-  pos[2] -= ZPAD;
-  return 0;
+  float step[3];
+  step[0] = getGeoX(detId[0], detId[1], detId[2]);
+  step[1] = getGeoHeights(detId[0], detId[1], detId[2]);
+  step[2] = -getGeoDistances(detId[0], detId[1], detId[2]);
+  translate(pos[0], pos[1], pos[2], step);
+  rotateToStrip(pos, detId[1], detId[2], detId[0]);
 }
 
-int Geo::getPosInPadCoord(const Int_t* detId, float* pos)
+void Geo::getPosInPadCoord(const Int_t* detId, float* pos)
 {
   Init();
   fromGlobalToSector(pos, detId[0]);
 
-  if (fromPlateToStrip(pos, detId[1], detId[0]) == -1) {
-    return -1;
-  }
-  pos[0] -= (detId[4] + 0.5) * XPAD;
-  pos[2] -= (detId[3] + 0.5) * ZPAD;
-  return 0;
+  float step[3];
+  step[0] = getGeoX(detId[0], detId[1], detId[2]);
+  step[1] = getGeoHeights(detId[0], detId[1], detId[2]);
+  step[2] = -getGeoDistances(detId[0], detId[1], detId[2]);
+  translate(pos[0], pos[1], pos[2], step);
+  rotateToStrip(pos, detId[1], detId[2], detId[0]);
+
+  pos[0] -= (detId[4] + 0.5) * XPAD - XHALFSTRIP;
+  pos[2] -= (detId[3] - 0.5) * ZPAD;
 }
 
 void Geo::getPosInSectorCoord(int ch, float* pos)
@@ -577,18 +580,18 @@ void Geo::getPosInSectorCoord(int ch, float* pos)
   getPosInSectorCoord(det, pos);
 }
 
-int Geo::getPosInStripCoord(int ch, float* pos)
+void Geo::getPosInStripCoord(int ch, float* pos)
 {
   int det[5];
   getVolumeIndices(ch, det);
-  return getPosInStripCoord(det, pos);
+  getPosInStripCoord(det, pos);
 }
 
-int Geo::getPosInPadCoord(int ch, float* pos)
+void Geo::getPosInPadCoord(int ch, float* pos)
 {
   int det[5];
   getVolumeIndices(ch, det);
-  return getPosInPadCoord(det, pos);
+  getPosInPadCoord(det, pos);
 }
 
 void Geo::fromGlobalToSector(Float_t* pos, Int_t isector)

--- a/Detectors/TOF/base/src/Geo.cxx
+++ b/Detectors/TOF/base/src/Geo.cxx
@@ -533,6 +533,64 @@ Int_t Geo::getStripNumberPerSM(Int_t iplate, Int_t istrip)
   return index;
 }
 
+void Geo::getPosInSectorCoord(const Int_t* detId, float* pos)
+{
+  Init();
+  fromGlobalToSector(pos, detId[0]);
+
+  float swap = pos[0];
+  pos[0] = pos[1];
+  pos[1] = swap;
+  pos[2] = -pos[2];
+}
+
+int Geo::getPosInStripCoord(const Int_t* detId, float* pos)
+{
+  Init();
+  fromGlobalToSector(pos, detId[0]);
+
+  if (fromPlateToStrip(pos, detId[1], detId[0]) == -1) {
+    return -1;
+  }
+  pos[0] -= XHALFSTRIP;
+  pos[2] -= ZPAD;
+  return 0;
+}
+
+int Geo::getPosInPadCoord(const Int_t* detId, float* pos)
+{
+  Init();
+  fromGlobalToSector(pos, detId[0]);
+
+  if (fromPlateToStrip(pos, detId[1], detId[0]) == -1) {
+    return -1;
+  }
+  pos[0] -= (detId[4] + 0.5) * XPAD;
+  pos[2] -= (detId[3] + 0.5) * ZPAD;
+  return 0;
+}
+
+void Geo::getPosInSectorCoord(int ch, float* pos)
+{
+  int det[5];
+  getVolumeIndices(ch, det);
+  getPosInSectorCoord(det, pos);
+}
+
+int Geo::getPosInStripCoord(int ch, float* pos)
+{
+  int det[5];
+  getVolumeIndices(ch, det);
+  return getPosInStripCoord(det, pos);
+}
+
+int Geo::getPosInPadCoord(int ch, float* pos)
+{
+  int det[5];
+  getVolumeIndices(ch, det);
+  return getPosInPadCoord(det, pos);
+}
+
 void Geo::fromGlobalToSector(Float_t* pos, Int_t isector)
 {
   if (isector == -1) {


### PR DESCRIPTION
@shahor02 
Adding 3 methods to convert fro global to local coordinates

- wrt to sector
- wrt to strip
- wrt to pad/channel

Note that:
1) TOF internal ref system is still not aligned to the common one -> a conversion is applied in the 3 methods
2) for strip and pad/channel the methods return a status code (0 if the conversion is done)

For (1): I preferred not to touch TOF ref system (I'll do in a next PR since it requires many checks for the validation, I cannot risk to add bug to the geometry now)

For (2): conversion is not performed if the position is outsde the strip: X tolerance 1 cm, Z tolerance 2.5 cm. Such a tolerance depends on the current method used (to be fixed in a next PR)
 