### PR TITLE
[EMCAL-845] Cleanup library dependencies in EMCAL libraries

### DIFF
--- a/DataFormats/Detectors/EMCAL/CMakeLists.txt
+++ b/DataFormats/Detectors/EMCAL/CMakeLists.txt
@@ -10,38 +10,37 @@
 # or submit itself to any jurisdiction.
 
 o2_add_library(DataFormatsEMCAL
-               SOURCES src/EMCALBlockHeader.cxx 
-                       src/TriggerRecord.cxx
-                       src/Constants.cxx
-                       src/Cluster.cxx
-                       src/AnalysisCluster.cxx
-                       src/Cell.cxx 
-                       src/Digit.cxx
-                       src/EventHandler.cxx
-                       src/CTF.cxx
-                       src/ErrorTypeFEE.cxx
-               PUBLIC_LINK_LIBRARIES O2::CommonDataFormat 
-                                     O2::Headers 
-                                     O2::MathUtils 
-                                     O2::DetectorsBase 
-                                     O2::SimulationDataFormat
-                                     Boost::serialization)
+        SOURCES src/EMCALBlockHeader.cxx
+        src/TriggerRecord.cxx
+        src/Constants.cxx
+        src/Cluster.cxx
+        src/AnalysisCluster.cxx
+        src/Cell.cxx
+        src/Digit.cxx
+        src/EventHandler.cxx
+        src/CTF.cxx
+        src/ErrorTypeFEE.cxx
+        PUBLIC_LINK_LIBRARIES O2::CommonDataFormat
+        O2::Headers
+        O2::MathUtils
+        O2::SimulationDataFormat
+        Boost::serialization)
 
 o2_target_root_dictionary(DataFormatsEMCAL
-                          HEADERS include/DataFormatsEMCAL/EMCALBlockHeader.h
-                                  include/DataFormatsEMCAL/TriggerRecord.h
-                                  include/DataFormatsEMCAL/Constants.h
-                                  include/DataFormatsEMCAL/Cell.h
-                                  include/DataFormatsEMCAL/Digit.h
-                                  include/DataFormatsEMCAL/Cluster.h
-                                  include/DataFormatsEMCAL/AnalysisCluster.h
-                                  include/DataFormatsEMCAL/EventHandler.h
-                                  include/DataFormatsEMCAL/MCLabel.h
-                                  include/DataFormatsEMCAL/CTF.h
-                                  include/DataFormatsEMCAL/ErrorTypeFEE.h)
+        HEADERS include/DataFormatsEMCAL/EMCALBlockHeader.h
+        include/DataFormatsEMCAL/TriggerRecord.h
+        include/DataFormatsEMCAL/Constants.h
+        include/DataFormatsEMCAL/Cell.h
+        include/DataFormatsEMCAL/Digit.h
+        include/DataFormatsEMCAL/Cluster.h
+        include/DataFormatsEMCAL/AnalysisCluster.h
+        include/DataFormatsEMCAL/EventHandler.h
+        include/DataFormatsEMCAL/MCLabel.h
+        include/DataFormatsEMCAL/CTF.h
+        include/DataFormatsEMCAL/ErrorTypeFEE.h)
 
 o2_add_test(Cell
-            SOURCES test/testCell.cxx
-            COMPONENT_NAME DataFormats-EMCAL
-            PUBLIC_LINK_LIBRARIES O2::DataFormatsEMCAL
-            LABELS emcal dataformats)
+        SOURCES test/testCell.cxx
+        COMPONENT_NAME DataFormats-EMCAL
+        PUBLIC_LINK_LIBRARIES O2::DataFormatsEMCAL
+        LABELS emcal dataformats)

--- a/Detectors/EMCAL/base/CMakeLists.txt
+++ b/Detectors/EMCAL/base/CMakeLists.txt
@@ -18,7 +18,7 @@ o2_add_library(EMCALBase
         src/TriggerMappingV2.cxx
         PUBLIC_LINK_LIBRARIES O2::CommonDataFormat O2::Headers Boost::serialization
         O2::MathUtils O2::DataFormatsEMCAL
-        O2::SimulationDataFormat ROOT::Physics)
+        O2::SimulationDataFormat)
 
 o2_target_root_dictionary(EMCALBase
         HEADERS include/EMCALBase/GeometryBase.h

--- a/Detectors/EMCAL/reconstruction/CMakeLists.txt
+++ b/Detectors/EMCAL/reconstruction/CMakeLists.txt
@@ -30,10 +30,9 @@ o2_add_library(EMCALReconstruction
         src/DigitReader.cxx
         src/CTFCoder.cxx
         src/CTFHelper.cxx
-        PUBLIC_LINK_LIBRARIES FairRoot::Base O2::Headers
+        PUBLIC_LINK_LIBRARIES O2::Headers
         AliceO2::InfoLogger
         O2::DataFormatsEMCAL
-        O2::DetectorsBase
         O2::DetectorsRaw
         O2::EMCALBase
         O2::rANS


### PR DESCRIPTION
Remove unused dependecies:
- EMCALReconstruction:
  - FairRoot::Base
  - O2::DetectorsBase
- EMCALBase:
  - ROOT::Physics
- DataFormatsEMCAL:
  - O2::DetectorsBase