### PR TITLE
Optional explicit PV-tracks matching sources

### DIFF
--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -432,7 +432,7 @@ workflow_has_parameter AOD && has_detector EMC && add_W o2-emcal-cell-recalibrat
 
 # always run vertexing if requested and if there are some sources, but in cosmic mode we work in pass-trough mode (create record for non-associated tracks)
 ( [[ $BEAMTYPE == "cosmic" ]] || ! has_detector_reco ITS) && PVERTEX_CONFIG+=" --skip"
-has_detector_matching PRIMVTX && [[ ! -z "$VERTEXING_SOURCES" ]] && add_W o2-primary-vertexing-workflow "$PVTXSKIP $DISABLE_MC $DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $PVERTEX_CONFIG --pipeline $(get_N primary-vertexing MATCH REST 1),$(get_N pvertex-track-matching MATCH REST 1)" "${PVERTEXING_CONFIG_KEY}"
+has_detector_matching PRIMVTX && [[ ! -z "$VERTEXING_SOURCES" ]] && add_W o2-primary-vertexing-workflow "$DISABLE_MC $DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $PVERTEX_CONFIG --pipeline $(get_N primary-vertexing MATCH REST 1),$(get_N pvertex-track-matching MATCH REST 1)" "${PVERTEXING_CONFIG_KEY}"
 
 if [[ $BEAMTYPE != "cosmic" ]]; then
   has_detectors_reco ITS && has_detector_matching SECVTX && [[ ! -z "$SVERTEXING_SOURCES" ]] && add_W o2-secondary-vertexing-workflow "$DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT --vertexing-sources $SVERTEXING_SOURCES --threads $SVERTEX_THREADS --pipeline $(get_N secondary-vertexing MATCH REST $SVERTEX_THREADS)"

--- a/prodtests/full-system-test/workflow-setup.sh
+++ b/prodtests/full-system-test/workflow-setup.sh
@@ -66,8 +66,12 @@ for det in `echo $LIST_OF_DETECTORS | sed "s/,/ /g"`; do
     has_detector_reco $det && add_comma_separated TRACK_SOURCES "$det"
   fi
 done
+
 [[ -z $VERTEXING_SOURCES ]] && VERTEXING_SOURCES="$TRACK_SOURCES"
-PVERTEX_CONFIG="--vertexing-sources $VERTEXING_SOURCES --vertex-track-matching-sources $VERTEXING_SOURCES"
+[[ -z $VERTEX_TRACK_MATCHING_SOURCES ]] && VERTEX_TRACK_MATCHING_SOURCES="$TRACK_SOURCES"
+[[ ! -z $VERTEXING_SOURCES ]] && PVERTEX_CONFIG+=" --vertexing-sources $VERTEXING_SOURCES"
+[[ ! -z $VERTEX_TRACK_MATCHING_SOURCES ]] && PVERTEX_CONFIG+=" --vertex-track-matching-sources $VERTEX_TRACK_MATCHING_SOURCES"
+
 [[ -z $SVERTEXING_SOURCES ]] && SVERTEXING_SOURCES=$(echo $VERTEXING_SOURCES | sed -E -e "s/(^|,)TPC(-TRD|-TOF)+//g" -e "s/,TPC,/,/")
 
 # this option requires well calibrated timing beween different detectors, at the moment suppress it


### PR DESCRIPTION
With optional VERTEX_TRACK_MATCHING_SOURCES variable one can request PV-tracks matching sources different from VERTEXING_SOURCES (default behaviour). With `VERTEX_TRACK_MATCHING_SOURCES=none` only direct contributor indices will be stored in the association container (more compact output but not good for SVertexing and AOD creation).