### PR TITLE
[ITS] Factorise description of ITS inner barrel for ITS3 geometry implementation

### DIFF
--- a/Detectors/ITSMFT/ITS/base/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/base/CMakeLists.txt
@@ -12,9 +12,11 @@
 o2_add_library(ITSBase
                SOURCES src/GeometryTGeo.cxx src/ContainerFactory.cxx
                        src/MisalignmentParameter.cxx
+                       src/DescriptorInnerBarrel.cxx
                PUBLIC_LINK_LIBRARIES O2::DetectorsBase O2::ITSMFTBase)
 
 o2_target_root_dictionary(ITSBase
                           HEADERS include/ITSBase/GeometryTGeo.h
                                   include/ITSBase/ContainerFactory.h
-                                  include/ITSBase/MisalignmentParameter.h)
+                                  include/ITSBase/MisalignmentParameter.h
+                                  include/ITSBase/DescriptorInnerBarrel.h)

--- a/Detectors/ITSMFT/ITS/base/include/ITSBase/DescriptorInnerBarrel.h
+++ b/Detectors/ITSMFT/ITS/base/include/ITSBase/DescriptorInnerBarrel.h
@@ -1,0 +1,77 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file DescriptorInnerBarrel.h
+/// \brief Definition of the DescriptorInnerBarrel class
+
+#ifndef ALICEO2_ITS_DESCRIPTORINNERBARREL_H
+#define ALICEO2_ITS_DESCRIPTORINNERBARREL_H
+
+#include <string>
+#include <vector>
+#include <TObject.h>
+#include <TGeoTube.h>
+
+namespace o2
+{
+namespace its
+{
+class DescriptorInnerBarrel : public TObject
+{
+ public:
+  /// Default constructor
+  DescriptorInnerBarrel() {}
+  /// Standard constructor
+  DescriptorInnerBarrel(int nlayers);
+
+  /// Default destructor
+  virtual ~DescriptorInnerBarrel() {}
+
+  DescriptorInnerBarrel(const DescriptorInnerBarrel& src) = delete;
+  DescriptorInnerBarrel& operator=(const DescriptorInnerBarrel& geom) = delete;
+
+  double radii2Turbo(double rMin, double rMid, double rMax, double sensW)
+  {
+    // compute turbo angle from radii and sensor width
+    return TMath::ASin((rMax * rMax - rMin * rMin) / (2 * rMid * sensW)) * TMath::RadToDeg();
+  }
+
+  int GetNumberOfLayers() const { return fNumLayers; }
+  double GetSensorThickness() const { return fSensorLayerThickness; }
+  void GetConfigurationWrapperVolume(double& minradius, double& maxradius, double& zspan);
+  TGeoTube* DefineWrapperVolume();
+
+ protected:
+  int fNumLayers{3};
+
+  // wrapper volume properties
+  double fWrapperMinRadius{2.1};
+  double fWrapperMaxRadius{16.4};
+  double fWrapperZSpan{70.};
+
+  // sensor properties
+  double fSensorLayerThickness{};
+
+  // layer properties
+  std::vector<double> fLayerRadii{};
+  std::vector<double> fLayerZLen{};
+  std::vector<double> fDetectorThickness{};
+  std::vector<int> fChipTypeID{};
+  std::vector<int> fBuildLevel{};
+
+  /// \cond CLASSIMP
+  ClassDef(DescriptorInnerBarrel, 1); /// ITS inner barrel geometry descriptor
+  /// \endcond
+};
+} // namespace its
+} // namespace o2
+
+#endif

--- a/Detectors/ITSMFT/ITS/base/include/ITSBase/DescriptorInnerBarrel.h
+++ b/Detectors/ITSMFT/ITS/base/include/ITSBase/DescriptorInnerBarrel.h
@@ -28,12 +28,12 @@ class DescriptorInnerBarrel : public TObject
 {
  public:
   /// Default constructor
-  DescriptorInnerBarrel() {}
+  DescriptorInnerBarrel();
   /// Standard constructor
   DescriptorInnerBarrel(int nlayers);
 
   /// Default destructor
-  virtual ~DescriptorInnerBarrel() {}
+  ~DescriptorInnerBarrel() = default;
 
   DescriptorInnerBarrel(const DescriptorInnerBarrel& src) = delete;
   DescriptorInnerBarrel& operator=(const DescriptorInnerBarrel& geom) = delete;

--- a/Detectors/ITSMFT/ITS/base/include/ITSBase/DescriptorInnerBarrel.h
+++ b/Detectors/ITSMFT/ITS/base/include/ITSBase/DescriptorInnerBarrel.h
@@ -33,7 +33,7 @@ class DescriptorInnerBarrel : public TObject
   DescriptorInnerBarrel(int nlayers);
 
   /// Default destructor
-  ~DescriptorInnerBarrel() = default;
+  ~DescriptorInnerBarrel() override;
 
   DescriptorInnerBarrel(const DescriptorInnerBarrel& src) = delete;
   DescriptorInnerBarrel& operator=(const DescriptorInnerBarrel& geom) = delete;

--- a/Detectors/ITSMFT/ITS/base/include/ITSBase/DescriptorInnerBarrel.h
+++ b/Detectors/ITSMFT/ITS/base/include/ITSBase/DescriptorInnerBarrel.h
@@ -32,9 +32,6 @@ class DescriptorInnerBarrel : public TObject
   /// Standard constructor
   DescriptorInnerBarrel(int nlayers);
 
-  /// Default destructor
-  ~DescriptorInnerBarrel() override;
-
   DescriptorInnerBarrel(const DescriptorInnerBarrel& src) = delete;
   DescriptorInnerBarrel& operator=(const DescriptorInnerBarrel& geom) = delete;
 

--- a/Detectors/ITSMFT/ITS/base/src/DescriptorInnerBarrel.cxx
+++ b/Detectors/ITSMFT/ITS/base/src/DescriptorInnerBarrel.cxx
@@ -47,7 +47,15 @@ DescriptorInnerBarrel::DescriptorInnerBarrel() : TObject()
 DescriptorInnerBarrel::DescriptorInnerBarrel(int nlayers) : TObject(), fNumLayers(nlayers)
 {
   //
-  // Default constructor
+  // Standard constructor
+  //
+}
+
+//________________________________________________________________
+DescriptorInnerBarrel::~DescriptorInnerBarrel()
+{
+  //
+  // Default destructor
   //
 }
 

--- a/Detectors/ITSMFT/ITS/base/src/DescriptorInnerBarrel.cxx
+++ b/Detectors/ITSMFT/ITS/base/src/DescriptorInnerBarrel.cxx
@@ -52,14 +52,6 @@ DescriptorInnerBarrel::DescriptorInnerBarrel(int nlayers) : TObject(), fNumLayer
 }
 
 //________________________________________________________________
-DescriptorInnerBarrel::~DescriptorInnerBarrel()
-{
-  //
-  // Default destructor
-  //
-}
-
-//________________________________________________________________
 void DescriptorInnerBarrel::GetConfigurationWrapperVolume(double& minradius, double& maxradius, double& zspan)
 {
   minradius = fWrapperMinRadius;

--- a/Detectors/ITSMFT/ITS/base/src/DescriptorInnerBarrel.cxx
+++ b/Detectors/ITSMFT/ITS/base/src/DescriptorInnerBarrel.cxx
@@ -36,6 +36,14 @@ ClassImp(DescriptorInnerBarrel);
 /// \endcond
 
 //________________________________________________________________
+DescriptorInnerBarrel::DescriptorInnerBarrel() : TObject()
+{
+  //
+  // Default constructor
+  //
+}
+
+//________________________________________________________________
 DescriptorInnerBarrel::DescriptorInnerBarrel(int nlayers) : TObject(), fNumLayers(nlayers)
 {
   //

--- a/Detectors/ITSMFT/ITS/base/src/DescriptorInnerBarrel.cxx
+++ b/Detectors/ITSMFT/ITS/base/src/DescriptorInnerBarrel.cxx
@@ -1,0 +1,59 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "FairDetector.h"      // for FairDetector
+#include <fairlogger/Logger.h> // for LOG, LOG_IF
+#include "FairRootManager.h"   // for FairRootManager
+#include "FairRun.h"           // for FairRun
+#include "FairRuntimeDb.h"     // for FairRuntimeDb
+#include "FairVolume.h"        // for FairVolume
+#include "FairRootManager.h"
+
+#include "TGeoManager.h"     // for TGeoManager, gGeoManager
+#include "TGeoTube.h"        // for TGeoTube
+#include "TGeoPcon.h"        // for TGeoPcon
+#include "TGeoVolume.h"      // for TGeoVolume, TGeoVolumeAssembly
+#include "TString.h"         // for TString, operator+
+#include "TVirtualMC.h"      // for gMC, TVirtualMC
+#include "TVirtualMCStack.h" // for TVirtualMCStack
+
+#include "ITSBase/DescriptorInnerBarrel.h"
+
+#include <cstdio> // for NULL, snprintf
+
+using namespace o2::its;
+
+/// \cond CLASSIMP
+ClassImp(DescriptorInnerBarrel);
+/// \endcond
+
+//________________________________________________________________
+DescriptorInnerBarrel::DescriptorInnerBarrel(int nlayers) : TObject(), fNumLayers(nlayers)
+{
+  //
+  // Default constructor
+  //
+}
+
+//________________________________________________________________
+void DescriptorInnerBarrel::GetConfigurationWrapperVolume(double& minradius, double& maxradius, double& zspan)
+{
+  minradius = fWrapperMinRadius;
+  maxradius = fWrapperMaxRadius;
+  zspan = fWrapperZSpan;
+}
+
+//________________________________________________________________
+TGeoTube* DescriptorInnerBarrel::DefineWrapperVolume()
+{
+  TGeoTube* wrap = new TGeoTube(fWrapperMinRadius, fWrapperMaxRadius, fWrapperZSpan / 2.);
+  return wrap;
+}

--- a/Detectors/ITSMFT/ITS/base/src/ITSBaseLinkDef.h
+++ b/Detectors/ITSMFT/ITS/base/src/ITSBaseLinkDef.h
@@ -18,5 +18,6 @@
 #pragma link C++ class o2::its::GeometryTGeo;
 #pragma link C++ class o2::its::ContainerFactory;
 #pragma link C++ class o2::its::MisalignmentParameter + ;
+#pragma link C++ class o2::its::DescriptorInnerBarrel + ;
 
 #endif

--- a/Detectors/ITSMFT/ITS/simulation/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/simulation/CMakeLists.txt
@@ -12,6 +12,7 @@
 o2_add_library(ITSSimulation
                SOURCES src/V11Geometry.cxx src/V1Layer.cxx src/V3Layer.cxx
                        src/Detector.cxx src/V3Services.cxx src/V3Cage.cxx
+                       src/DescriptorInnerBarrelITS2.cxx
                PUBLIC_LINK_LIBRARIES O2::ITSBase O2::ITSMFTSimulation
                                      ROOT::Physics)
 
@@ -21,13 +22,14 @@ o2_target_root_dictionary(ITSSimulation
                                   include/ITSSimulation/V3Layer.h
                                   include/ITSSimulation/V3Cage.h
                                   include/ITSSimulation/V11Geometry.h
-                                  include/ITSSimulation/V3Services.h)
+                                  include/ITSSimulation/V3Services.h
+                                  include/ITSSimulation/DescriptorInnerBarrelITS2.h)
 
 o2_data_file(COPY data  DESTINATION Detectors/ITS/simulation)
 
 o2_add_executable(digi2raw
                   COMPONENT_NAME its
-		  TARGETVARNAME itsdigi2raw_exe
+                  TARGETVARNAME itsdigi2raw_exe
                   SOURCES src/digi2raw.cxx
                   PUBLIC_LINK_LIBRARIES O2::ITSMFTReconstruction
                                         O2::DataFormatsITSMFT

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/DescriptorInnerBarrelITS2.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/DescriptorInnerBarrelITS2.h
@@ -30,13 +30,13 @@ namespace its
 class DescriptorInnerBarrelITS2 : public o2::its::DescriptorInnerBarrel
 {
  public:
-  // default constructor
-  DescriptorInnerBarrelITS2() {}
   // standard constructor
   DescriptorInnerBarrelITS2(int nlayers);
+  // default constructor
+  DescriptorInnerBarrelITS2();
 
   /// Default destructor
-  ~DescriptorInnerBarrelITS2() {}
+  ~DescriptorInnerBarrelITS2() = default;
 
   DescriptorInnerBarrelITS2(const DescriptorInnerBarrelITS2& src) = delete;
   DescriptorInnerBarrelITS2& operator=(const DescriptorInnerBarrelITS2& geom) = delete;
@@ -64,7 +64,7 @@ class DescriptorInnerBarrelITS2 : public o2::its::DescriptorInnerBarrel
   std::vector<double> fStaveWidth{};                             //! Vector of stave width (only used for turbo)
   std::vector<double> fStaveTilt{};                              //! Vector of stave tilt (only used for turbo)
   std::vector<o2::its::V3Layer::Model> fStaveModelInnerBarrel{}; //! Stave model
-  std::vector<V3Layer*> fLayer;                                  //! Vector of layers
+  std::vector<V3Layer*> fLayer{};                                //! Vector of layers
 
   /// \cond CLASSIMP
   ClassDef(DescriptorInnerBarrelITS2, 1); /// ITS inner barrel geometry descriptor

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/DescriptorInnerBarrelITS2.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/DescriptorInnerBarrelITS2.h
@@ -27,6 +27,9 @@ namespace o2
 {
 namespace its
 {
+class V3Layer;
+class V3Services;
+
 class DescriptorInnerBarrelITS2 : public o2::its::DescriptorInnerBarrel
 {
  public:
@@ -36,7 +39,7 @@ class DescriptorInnerBarrelITS2 : public o2::its::DescriptorInnerBarrel
   DescriptorInnerBarrelITS2();
 
   /// Default destructor
-  ~DescriptorInnerBarrelITS2() = default;
+  ~DescriptorInnerBarrelITS2() override;
 
   DescriptorInnerBarrelITS2(const DescriptorInnerBarrelITS2& src) = delete;
   DescriptorInnerBarrelITS2& operator=(const DescriptorInnerBarrelITS2& geom) = delete;

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/DescriptorInnerBarrelITS2.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/DescriptorInnerBarrelITS2.h
@@ -63,7 +63,7 @@ class DescriptorInnerBarrelITS2 : public o2::its::DescriptorInnerBarrel
   std::vector<double> fChipThickness{};                          //! Vector of chip thicknesses
   std::vector<double> fStaveWidth{};                             //! Vector of stave width (only used for turbo)
   std::vector<double> fStaveTilt{};                              //! Vector of stave tilt (only used for turbo)
-  std::vector<o2::its::V3Layer::Model> fStaveModelInnerBarrel{}; //! Stave model
+  std::vector<V3Layer::Model> fStaveModelInnerBarrel{}; //! Stave model
   std::vector<V3Layer*> fLayer{};                                //! Vector of layers
 
   /// \cond CLASSIMP

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/DescriptorInnerBarrelITS2.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/DescriptorInnerBarrelITS2.h
@@ -21,7 +21,6 @@
 #include <TGeoVolume.h>
 
 #include "ITSBase/DescriptorInnerBarrel.h"
-#include "ITSSimulation/V3Layer.h"
 
 namespace o2
 {
@@ -37,9 +36,6 @@ class DescriptorInnerBarrelITS2 : public o2::its::DescriptorInnerBarrel
   DescriptorInnerBarrelITS2(int nlayers);
   // default constructor
   DescriptorInnerBarrelITS2();
-
-  /// Default destructor
-  ~DescriptorInnerBarrelITS2() override;
 
   DescriptorInnerBarrelITS2(const DescriptorInnerBarrelITS2& src) = delete;
   DescriptorInnerBarrelITS2& operator=(const DescriptorInnerBarrelITS2& geom) = delete;
@@ -59,15 +55,14 @@ class DescriptorInnerBarrelITS2 : public o2::its::DescriptorInnerBarrel
   void AddAlignableVolumesChip(int idLayer, int iHalfBarrel, int iStave, int iHalfStave, int iModule, int iChip, TString& parentPath, int& lastUID) const;
 
   // layer properties
-  std::vector<bool> fTurboLayer{};                      //! True for "turbo" layers
-  std::vector<double> fLayerPhi0{};                     //! Vector of layer's 1st stave phi in lab
-  std::vector<int> fStavePerLayer{};                    //! Vector of number of staves per layer
-  std::vector<int> fUnitPerStave{};                     //! Vector of number of "units" per stave
-  std::vector<double> fChipThickness{};                 //! Vector of chip thicknesses
-  std::vector<double> fStaveWidth{};                    //! Vector of stave width (only used for turbo)
-  std::vector<double> fStaveTilt{};                     //! Vector of stave tilt (only used for turbo)
-  std::vector<V3Layer::Model> fStaveModelInnerBarrel{}; //! Stave model
-  std::vector<V3Layer*> fLayer{};                       //! Vector of layers
+  std::vector<bool> fTurboLayer{};      //! True for "turbo" layers
+  std::vector<double> fLayerPhi0{};     //! Vector of layer's 1st stave phi in lab
+  std::vector<int> fStavePerLayer{};    //! Vector of number of staves per layer
+  std::vector<int> fUnitPerStave{};     //! Vector of number of "units" per stave
+  std::vector<double> fChipThickness{}; //! Vector of chip thicknesses
+  std::vector<double> fStaveWidth{};    //! Vector of stave width (only used for turbo)
+  std::vector<double> fStaveTilt{};     //! Vector of stave tilt (only used for turbo)
+  std::vector<V3Layer*> fLayer{};       //! Vector of layers
 
   /// \cond CLASSIMP
   ClassDef(DescriptorInnerBarrelITS2, 1); /// ITS inner barrel geometry descriptor

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/DescriptorInnerBarrelITS2.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/DescriptorInnerBarrelITS2.h
@@ -56,15 +56,15 @@ class DescriptorInnerBarrelITS2 : public o2::its::DescriptorInnerBarrel
   void AddAlignableVolumesChip(int idLayer, int iHalfBarrel, int iStave, int iHalfStave, int iModule, int iChip, TString& parentPath, int& lastUID) const;
 
   // layer properties
-  std::vector<bool> fTurboLayer{};                               //! True for "turbo" layers
-  std::vector<double> fLayerPhi0{};                              //! Vector of layer's 1st stave phi in lab
-  std::vector<int> fStavePerLayer{};                             //! Vector of number of staves per layer
-  std::vector<int> fUnitPerStave{};                              //! Vector of number of "units" per stave
-  std::vector<double> fChipThickness{};                          //! Vector of chip thicknesses
-  std::vector<double> fStaveWidth{};                             //! Vector of stave width (only used for turbo)
-  std::vector<double> fStaveTilt{};                              //! Vector of stave tilt (only used for turbo)
+  std::vector<bool> fTurboLayer{};                      //! True for "turbo" layers
+  std::vector<double> fLayerPhi0{};                     //! Vector of layer's 1st stave phi in lab
+  std::vector<int> fStavePerLayer{};                    //! Vector of number of staves per layer
+  std::vector<int> fUnitPerStave{};                     //! Vector of number of "units" per stave
+  std::vector<double> fChipThickness{};                 //! Vector of chip thicknesses
+  std::vector<double> fStaveWidth{};                    //! Vector of stave width (only used for turbo)
+  std::vector<double> fStaveTilt{};                     //! Vector of stave tilt (only used for turbo)
   std::vector<V3Layer::Model> fStaveModelInnerBarrel{}; //! Stave model
-  std::vector<V3Layer*> fLayer{};                                //! Vector of layers
+  std::vector<V3Layer*> fLayer{};                       //! Vector of layers
 
   /// \cond CLASSIMP
   ClassDef(DescriptorInnerBarrelITS2, 1); /// ITS inner barrel geometry descriptor

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/DescriptorInnerBarrelITS2.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/DescriptorInnerBarrelITS2.h
@@ -1,0 +1,76 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file DescriptorInnerBarrelITS2.h
+/// \brief Definition of the DescriptorInnerBarrelITS2 class
+
+#ifndef ALICEO2_ITS3_DESCRIPTORINNERBARRELITS2_H
+#define ALICEO2_ITS3_DESCRIPTORINNERBARRELITS2_H
+
+#include <string>
+#include <vector>
+#include <TObject.h>
+#include <TGeoVolume.h>
+
+#include "ITSBase/DescriptorInnerBarrel.h"
+#include "ITSSimulation/V3Layer.h"
+
+namespace o2
+{
+namespace its
+{
+class DescriptorInnerBarrelITS2 : public o2::its::DescriptorInnerBarrel
+{
+ public:
+  // default constructor
+  DescriptorInnerBarrelITS2() {}
+  // standard constructor
+  DescriptorInnerBarrelITS2(int nlayers);
+
+  /// Default destructor
+  ~DescriptorInnerBarrelITS2() {}
+
+  DescriptorInnerBarrelITS2(const DescriptorInnerBarrelITS2& src) = delete;
+  DescriptorInnerBarrelITS2& operator=(const DescriptorInnerBarrelITS2& geom) = delete;
+
+  void Configure();
+
+  V3Layer* CreateLayer(int idLayer, TGeoVolume* dest);
+  void CreateServices(TGeoVolume* dest);
+
+  void AddAlignableVolumesLayer(int idLayer, int wrapperLayerId, TString& parentPath, int& lastUID);
+
+ private:
+  void AddAlignableVolumesHalfBarrel(int idLayer, int iHalfBarrel, TString& parentPath, int& lastUID) const;
+  void AddAlignableVolumesStave(int idLayer, int iHalfBarrel, int iStave, TString& parentPath, int& lastUID) const;
+  void AddAlignableVolumesHalfStave(int idLayer, int iHalfBarrel, int iStave, int iHalfStave, TString& parentPath, int& lastUID) const;
+  void AddAlignableVolumesModule(int idLayer, int iHalfBarrel, int iStave, int iHalfStave, int iModule, TString& parentPath, int& lastUID) const;
+  void AddAlignableVolumesChip(int idLayer, int iHalfBarrel, int iStave, int iHalfStave, int iModule, int iChip, TString& parentPath, int& lastUID) const;
+
+  // layer properties
+  std::vector<bool> fTurboLayer{};                               //! True for "turbo" layers
+  std::vector<double> fLayerPhi0{};                              //! Vector of layer's 1st stave phi in lab
+  std::vector<int> fStavePerLayer{};                             //! Vector of number of staves per layer
+  std::vector<int> fUnitPerStave{};                              //! Vector of number of "units" per stave
+  std::vector<double> fChipThickness{};                          //! Vector of chip thicknesses
+  std::vector<double> fStaveWidth{};                             //! Vector of stave width (only used for turbo)
+  std::vector<double> fStaveTilt{};                              //! Vector of stave tilt (only used for turbo)
+  std::vector<o2::its::V3Layer::Model> fStaveModelInnerBarrel{}; //! Stave model
+  std::vector<V3Layer*> fLayer;                                  //! Vector of layers
+
+  /// \cond CLASSIMP
+  ClassDef(DescriptorInnerBarrelITS2, 1); /// ITS inner barrel geometry descriptor
+  /// \endcond
+};
+} // namespace its
+} // namespace o2
+
+#endif

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
@@ -15,16 +15,17 @@
 #ifndef ALICEO2_ITS_DETECTOR_H_
 #define ALICEO2_ITS_DETECTOR_H_
 
-#include <vector>                             // for vector
-#include "DetectorsBase/GeometryManager.h"    // for getSensID
-#include "DetectorsBase/Detector.h"           // for Detector
-#include "DetectorsCommonDataFormats/DetID.h" // for Detector
-#include "ITSMFTSimulation/Hit.h"             // for Hit
-#include "Rtypes.h"                           // for Int_t, Double_t, Float_t, Bool_t, etc
-#include "TArrayD.h"                          // for TArrayD
-#include "TGeoManager.h"                      // for gGeoManager, TGeoManager (ptr only)
-#include "TLorentzVector.h"                   // for TLorentzVector
-#include "TVector3.h"                         // for TVector3
+#include <vector>                                    // for vector
+#include "DetectorsBase/GeometryManager.h"           // for getSensID
+#include "DetectorsBase/Detector.h"                  // for Detector
+#include "DetectorsCommonDataFormats/DetID.h"        // for Detector
+#include "ITSMFTSimulation/Hit.h"                    // for Hit
+#include "ITSSimulation/DescriptorInnerBarrelITS2.h" // for Description of Inner Barrel
+#include "Rtypes.h"                                  // for Int_t, Double_t, Float_t, Bool_t, etc
+#include "TArrayD.h"                                 // for TArrayD
+#include "TGeoManager.h"                             // for gGeoManager, TGeoManager (ptr only)
+#include "TLorentzVector.h"                          // for TLorentzVector
+#include "TVector3.h"                                // for TVector3
 
 class FairVolume;
 class TGeoVolume;
@@ -66,28 +67,13 @@ class V3Services;
 class Detector : public o2::base::DetImpl<Detector>
 {
  public:
-  enum Model {
-    kIBModelDummy = 0,
-    kIBModel0 = 1,
-    kIBModel1 = 2,
-    kIBModel21 = 3,
-    kIBModel22 = 4,
-    kIBModel3 = 5,
-    kIBModel4 = 10,
-    kOBModelDummy = 6,
-    kOBModel0 = 7,
-    kOBModel1 = 8,
-    kOBModel2 = 9
-  };
-
-  static constexpr Int_t sNumberLayers = 7;           ///< Number of layers in ITSU
-  static constexpr Int_t sNumberInnerLayers = 3;      ///< Number of inner layers in ITSU
+  static constexpr Int_t sNumberOuterLayers = 4;      ///< Number of outer layers in ITSU (fixed)
   static constexpr Int_t sNumberOfWrapperVolumes = 3; ///< Number of wrapper volumes
 
   /// Name : Detector Name
   /// Active: kTRUE for active detectors (ProcessHits() will be called)
   ///         kFALSE for inactive detectors
-  Detector(Bool_t active);
+  Detector(Bool_t active, TString name = "ITS");
 
   /// Default constructor
   Detector();
@@ -103,6 +89,9 @@ class Detector : public o2::base::DetImpl<Detector>
 
   /// Registers the produced collections in FAIRRootManager
   void Register() override;
+
+  /// We need this as a method to access members
+  void configOuterBarrelITS(int nInnerBarrelLayers);
 
   /// Gets the produced collections
   std::vector<o2::itsmft::Hit>* getHits(Int_t iColl) const
@@ -133,23 +122,6 @@ class Detector : public o2::base::DetImpl<Detector>
   /// \param buildLevel (if 0, all geometry is build, used for material budget studies)
   void defineLayer(Int_t nlay, Double_t phi0, Double_t r, Int_t nladd, Int_t nmod, Double_t lthick = 0.,
                    Double_t dthick = 0., UInt_t detType = 0, Int_t buildFlag = 0) override;
-
-  /// Sets the layer parameters for a "turbo" layer
-  /// (i.e. a layer whose staves overlap in phi)
-  /// \param nlay layer number
-  /// \param phi0 phi of 1st stave
-  /// \param r layer radius
-  /// \param nstav number of staves
-  /// \param nunit IB: number of chips per stave
-  /// \param OB: number of modules per half stave
-  /// \param width stave width
-  /// \param tilt layer tilt angle (degrees)
-  /// \param lthick stave thickness (if omitted, defaults to 0)
-  /// \param dthick detector thickness (if omitted, defaults to 0)
-  /// \param dettypeID ??
-  /// \param buildLevel (if 0, all geometry is build, used for material budget studies)
-  void defineLayerTurbo(Int_t nlay, Double_t phi0, Double_t r, Int_t nladd, Int_t nmod, Double_t width, Double_t tilt,
-                        Double_t lthick = 0., Double_t dthick = 0., UInt_t detType = 0, Int_t buildFlag = 0) override;
 
   /// Gets the layer parameters
   /// \param nlay layer number
@@ -242,19 +214,13 @@ class Detector : public o2::base::DetImpl<Detector>
   void PreTrack() override { ; }
 
   /// Returns the number of layers
-  Int_t getNumberOfLayers() const { return sNumberLayers; }
-  virtual void setStaveModelIB(Model model) { mStaveModelInnerBarrel = model; }
-  virtual void setStaveModelOB(Model model) { mStaveModelOuterBarrel = model; }
-  virtual Model getStaveModelIB() const { return mStaveModelInnerBarrel; }
-  virtual Model getStaveModelOB() const { return mStaveModelOuterBarrel; }
+  Int_t getNumberOfLayers() const { return mNumberLayers; }
+  virtual void setStaveModelOB(o2::its::V3Layer::Model model) { mStaveModelOuterBarrel = model; }
+  virtual o2::its::V3Layer::Model getStaveModelOB() const { return mStaveModelOuterBarrel; }
 
   GeometryTGeo* mGeometryTGeo; //! access to geometry details
 
  protected:
-  Int_t mLayerID[sNumberLayers];     //! [sNumberLayers] layer identifier
-  TString mLayerName[sNumberLayers]; //! [sNumberLayers] layer identifier
-
- private:
   /// this is transient data about track passing the sensor
   struct TrackData {               // this is transient
     bool mHitStarted;              //! hit creation started
@@ -264,6 +230,12 @@ class Detector : public o2::base::DetImpl<Detector>
     double mEnergyLoss;            //! energy loss
   } mTrackData;                    //!
 
+  int mNumberInnerLayers; //! Number of inner layers (depends on ITS version)
+  int mNumberLayers;      //! Number of layers (depends on inner layer version)
+
+  std::vector<int> mLayerID;       //! layer identifiers
+  std::vector<TString> mLayerName; //! layer names
+
   Int_t mNumberOfDetectors;
 
   Bool_t mModifyGeometry;
@@ -271,19 +243,19 @@ class Detector : public o2::base::DetImpl<Detector>
   Double_t mWrapperMinRadius[sNumberOfWrapperVolumes]; //! Min radius of wrapper volume
   Double_t mWrapperMaxRadius[sNumberOfWrapperVolumes]; //! Max radius of wrapper volume
   Double_t mWrapperZSpan[sNumberOfWrapperVolumes];     //! Z span of wrapper volume
-  Int_t mWrapperLayerId[sNumberLayers];                //! Id of wrapper layer to which layer belongs (-1 if not wrapped)
+  std::vector<int> mWrapperLayerId;                    //! Id of wrapper layer to which layer belongs (-1 if not wrapped)
 
-  Bool_t mTurboLayer[sNumberLayers];          //! True for "turbo" layers
-  Double_t mLayerPhi0[sNumberLayers];         //! Vector of layer's 1st stave phi in lab
-  Double_t mLayerRadii[sNumberLayers];        //! Vector of layer radii
-  Int_t mStavePerLayer[sNumberLayers];        //! Vector of number of staves per layer
-  Int_t mUnitPerStave[sNumberLayers];         //! Vector of number of "units" per stave
-  Double_t mChipThickness[sNumberLayers];     //! Vector of chip thicknesses
-  Double_t mStaveWidth[sNumberLayers];        //! Vector of stave width (only used for turbo)
-  Double_t mStaveTilt[sNumberLayers];         //! Vector of stave tilt (only used for turbo)
-  Double_t mDetectorThickness[sNumberLayers]; //! Vector of detector thicknesses
-  UInt_t mChipTypeID[sNumberLayers];          //! Vector of detector type id
-  Int_t mBuildLevel[sNumberLayers];           //! Vector of Material Budget Studies
+  std::vector<bool> mTurboLayer;          //! True for "turbo" layers
+  std::vector<double> mLayerPhi0;         //! Vector of layer's 1st stave phi in lab
+  std::vector<double> mLayerRadii;        //! Vector of layer radii
+  std::vector<int> mStavePerLayer;        //! Vector of number of staves per layer
+  std::vector<int> mUnitPerStave;         //! Vector of number of "units" per stave
+  std::vector<double> mChipThickness;     //! Vector of chip thicknesses
+  std::vector<double> mStaveWidth;        //! Vector of stave width (only used for turbo)
+  std::vector<double> mStaveTilt;         //! Vector of stave tilt (only used for turbo)
+  std::vector<double> mDetectorThickness; //! Vector of detector thicknesses
+  std::vector<uint> mChipTypeID;          //! Vector of detector type id
+  std::vector<int> mBuildLevel;           //! Vector of Material Budget Studies
 
   /// Container for hit data
   std::vector<o2::itsmft::Hit>* mHits;
@@ -299,10 +271,6 @@ class Detector : public o2::base::DetImpl<Detector>
 
   /// Define the sensitive volumes of the geometry
   void defineSensitiveVolumes();
-
-  /// Creates the Inner Barrel Services
-  /// \param motherVolume the TGeoVolume owing the volume structure
-  void createInnerBarrelServices(TGeoVolume* motherVolume);
 
   /// Creates the Middle Barrel Services
   /// \param motherVolume the TGeoVolume owing the volume structure
@@ -320,10 +288,11 @@ class Detector : public o2::base::DetImpl<Detector>
 
   Detector& operator=(const Detector&);
 
-  Model mStaveModelInnerBarrel;      //! The stave model for the Inner Barrel
-  Model mStaveModelOuterBarrel;      //! The stave model for the Outer Barrel
-  V3Layer* mGeometry[sNumberLayers]; //! Geometry
-  V3Services* mServicesGeometry;     //! Services Geometry
+  o2::its::V3Layer::Model mStaveModelOuterBarrel; //! The stave model for the Outer Barrel
+  std::vector<V3Layer*> mGeometry;                //! Geometry
+  V3Services* mServicesGeometry;                  //! Services Geometry
+
+  std::shared_ptr<DescriptorInnerBarrel> mDescriptorIB; //! Descriptor of Inner Barrel geometry
 
   template <typename Det>
   friend class o2::base::DetImpl;

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
@@ -215,8 +215,8 @@ class Detector : public o2::base::DetImpl<Detector>
 
   /// Returns the number of layers
   Int_t getNumberOfLayers() const { return mNumberLayers; }
-  virtual void setStaveModelOB(o2::its::V3Layer::Model model) { mStaveModelOuterBarrel = model; }
-  virtual o2::its::V3Layer::Model getStaveModelOB() const { return mStaveModelOuterBarrel; }
+  void setStaveModelOB(V3Layer::Model model) { mStaveModelOuterBarrel = model; }
+  V3Layer::Model getStaveModelOB() const { return mStaveModelOuterBarrel; }
 
   GeometryTGeo* mGeometryTGeo; //! access to geometry details
 

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
@@ -215,8 +215,6 @@ class Detector : public o2::base::DetImpl<Detector>
 
   /// Returns the number of layers
   Int_t getNumberOfLayers() const { return mNumberLayers; }
-  void setStaveModelOB(V3Layer::Model model) { mStaveModelOuterBarrel = model; }
-  V3Layer::Model getStaveModelOB() const { return mStaveModelOuterBarrel; }
 
   GeometryTGeo* mGeometryTGeo; //! access to geometry details
 
@@ -288,9 +286,8 @@ class Detector : public o2::base::DetImpl<Detector>
 
   Detector& operator=(const Detector&);
 
-  o2::its::V3Layer::Model mStaveModelOuterBarrel; //! The stave model for the Outer Barrel
-  std::vector<V3Layer*> mGeometry;                //! Geometry
-  V3Services* mServicesGeometry;                  //! Services Geometry
+  std::vector<V3Layer*> mGeometry; //! Geometry
+  V3Services* mServicesGeometry;   //! Services Geometry
 
   std::shared_ptr<DescriptorInnerBarrel> mDescriptorIB; //! Descriptor of Inner Barrel geometry
 

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/V11Geometry.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/V11Geometry.h
@@ -41,12 +41,24 @@ class V11Geometry : public TObject
 {
 
  public:
-  V11Geometry() : mDebug(){};
+  V11Geometry() : mDebug(), mDetName("ITS"){};
 
-  V11Geometry(Int_t debug) : mDebug(debug){};
+  V11Geometry(Int_t debug, const char* name = "ITS") : mDebug(debug), mDetName(name){};
 
   ~V11Geometry()
     override = default;
+
+  /// Set detector name
+  void SetDetName(const char* name)
+  {
+    mDetName = name;
+  }
+
+  /// Get detector name
+  const char* GetDetName() const
+  {
+    return mDetName;
+  }
 
   /// Sets the debug flag for debugging output
   void setDebug(Int_t level = 5)
@@ -451,6 +463,7 @@ class V11Geometry : public TObject
   Double_t angleForRoundedCorners1(Double_t dx, Double_t dy, Double_t sdr) const;
 
   Int_t mDebug;                     //! Debug flag/level
+  const char* mDetName;             //! Detector name
   ClassDefOverride(V11Geometry, 1); // Base class for ITS v11 geometry
 };
 } // namespace its

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/V1Layer.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/V1Layer.h
@@ -20,7 +20,6 @@
 #include <TGeoManager.h>               // for gGeoManager
 #include "Rtypes.h"                    // for Double_t, Int_t, Bool_t, etc
 #include "ITSSimulation/V11Geometry.h" // for V11Geometry
-#include "ITSSimulation/Detector.h"    // for Detector, Detector::Model
 
 class TGeoArb8;
 
@@ -47,18 +46,32 @@ class V1Layer : public V11Geometry
     kNHLevels
   };
 
+  enum Model {
+    kIBModelDummy = 0,
+    kIBModel0 = 1,
+    kIBModel1 = 2,
+    kIBModel21 = 3,
+    kIBModel22 = 4,
+    kIBModel3 = 5,
+    kIBModel4 = 10,
+    kOBModelDummy = 6,
+    kOBModel0 = 7,
+    kOBModel1 = 8,
+    kOBModel2 = 9
+  };
+
   // Default constructor
   V1Layer();
 
   // Constructor setting debugging level
-  V1Layer(Int_t debug);
+  V1Layer(Int_t debug, const char* name = "ITS");
 
   // Constructor setting layer number and debugging level
-  V1Layer(Int_t lay, Int_t debug);
+  V1Layer(Int_t lay, Int_t debug, const char* name = "ITS");
 
   /// Constructor setting layer number and debugging level
   /// for a "turbo" layer (i.e. where staves overlap in phi)
-  V1Layer(Int_t lay, Bool_t turbo, Int_t debug);
+  V1Layer(Int_t lay, Bool_t turbo, Int_t debug, const char* name = "ITS");
 
   /// Copy constructor
   V1Layer(const V1Layer& source);
@@ -144,7 +157,7 @@ class V1Layer : public V11Geometry
     return mHierarchy[kChip];
   }
 
-  Detector::Model getStaveModel() const
+  Model getStaveModel() const
   {
     return mStaveModel;
   }
@@ -203,7 +216,7 @@ class V1Layer : public V11Geometry
     mBuildLevel = buildLevel;
   }
 
-  void setStaveModel(o2::its::Detector::Model model)
+  void setStaveModel(Model model)
   {
     mStaveModel = model;
   }
@@ -364,7 +377,7 @@ class V1Layer : public V11Geometry
   Bool_t mIsTurbo;    ///< True if this layer is a "turbo" layer
   Int_t mBuildLevel;  ///< Used for material studies
 
-  Detector::Model mStaveModel; ///< The stave model
+  Model mStaveModel; ///< The stave model
 
   // Parameters for the  geometry
 

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/V3Cage.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/V3Cage.h
@@ -19,7 +19,6 @@
 #include <TGeoManager.h>               // for gGeoManager
 #include "Rtypes.h"                    // for Double_t, Int_t, Bool_t, etc
 #include "ITSSimulation/V11Geometry.h" // for V11Geometry
-#include "ITSSimulation/Detector.h"    // for Detector, Detector::Model
 
 class TGeoXtru;
 
@@ -41,6 +40,9 @@ class V3Cage : public V11Geometry
  public:
   // Default constructor
   V3Cage();
+
+  // Standard constructor
+  V3Cage(const char* name);
 
   /// Copy constructor
   V3Cage(const V3Cage&) = default;

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/V3Layer.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/V3Layer.h
@@ -20,7 +20,6 @@
 #include <TGeoManager.h>               // for gGeoManager
 #include "Rtypes.h"                    // for Double_t, Int_t, Bool_t, etc
 #include "ITSSimulation/V11Geometry.h" // for V11Geometry
-#include "ITSSimulation/Detector.h"    // for Detector, Detector::Model
 
 class TGeoXtru;
 
@@ -46,12 +45,26 @@ class V3Layer : public V11Geometry
          kChip,
          kNHLevels };
 
+  enum Model {
+    kIBModelDummy = 0,
+    kIBModel0 = 1,
+    kIBModel1 = 2,
+    kIBModel21 = 3,
+    kIBModel22 = 4,
+    kIBModel3 = 5,
+    kIBModel4 = 10,
+    kOBModelDummy = 6,
+    kOBModel0 = 7,
+    kOBModel1 = 8,
+    kOBModel2 = 9
+  };
+
   // Default constructor
   V3Layer();
 
   /// Constructor setting layer number and debugging level
   /// for a "turbo" layer (i.e. where staves overlap in phi)
-  V3Layer(Int_t lay, Bool_t turbo = kFALSE, Int_t debug = 0);
+  V3Layer(Int_t lay, Bool_t turbo = kFALSE, Int_t debug = 0, const char* name = "ITS");
 
   /// Copy constructor
   V3Layer(const V3Layer&) = default;
@@ -98,7 +111,7 @@ class V3Layer : public V11Geometry
 
   Int_t getBuildLevel() const { return mBuildLevel; }
 
-  Detector::Model getStaveModel() const { return mStaveModel; }
+  Model getStaveModel() const { return mStaveModel; }
 
   void setChipThick(Double_t t) { mChipThickness = t; };
 
@@ -128,7 +141,7 @@ class V3Layer : public V11Geometry
 
   void setBuildLevel(Int_t buildLevel) { mBuildLevel = buildLevel; }
 
-  void setStaveModel(o2::its::Detector::Model model) { mStaveModel = model; }
+  void setStaveModel(Model model) { mStaveModel = model; }
 
   /// Creates the actual Layer and places inside its mother volume
   /// \param motherVolume the TGeoVolume owing the volume structure
@@ -321,7 +334,7 @@ class V3Layer : public V11Geometry
   Bool_t mIsTurbo;    ///< True if this layer is a "turbo" layer
   Int_t mBuildLevel;  ///< Used for material studies
 
-  Detector::Model mStaveModel; ///< The stave model
+  Model mStaveModel; ///< The stave model
 
   // Dimensions computed during geometry build-up
   Double_t mIBModuleZLength; ///< IB Module Length along Z

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/V3Services.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/V3Services.h
@@ -20,7 +20,6 @@
 #include <TGeoManager.h>               // for gGeoManager
 #include "Rtypes.h"                    // for Double_t, Int_t, Bool_t, etc
 #include "ITSSimulation/V11Geometry.h" // for V11Geometry
-#include "ITSSimulation/Detector.h"    // for Detector, Detector::Model
 
 class TGeoXtru;
 
@@ -42,6 +41,9 @@ class V3Services : public V11Geometry
  public:
   // Default constructor
   V3Services();
+
+  // Standard constructor
+  V3Services(const char* name);
 
   /// Copy constructor
   V3Services(const V3Services&) = default;

--- a/Detectors/ITSMFT/ITS/simulation/src/DescriptorInnerBarrelITS2.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/DescriptorInnerBarrelITS2.cxx
@@ -40,7 +40,7 @@ ClassImp(DescriptorInnerBarrelITS2);
 DescriptorInnerBarrelITS2::DescriptorInnerBarrelITS2() : DescriptorInnerBarrel()
 {
   //
-  // Standard constructor
+  // Default constructor
   //
 
   fSensorLayerThickness = o2::itsmft::SegmentationAlpide::SensorLayerThickness;
@@ -54,6 +54,14 @@ DescriptorInnerBarrelITS2::DescriptorInnerBarrelITS2(int nlayers) : DescriptorIn
   //
 
   fSensorLayerThickness = o2::itsmft::SegmentationAlpide::SensorLayerThickness;
+}
+
+//________________________________________________________________
+DescriptorInnerBarrelITS2::~DescriptorInnerBarrelITS2()
+{
+  //
+  // Default destructor
+  //
 }
 
 //________________________________________________________________

--- a/Detectors/ITSMFT/ITS/simulation/src/DescriptorInnerBarrelITS2.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/DescriptorInnerBarrelITS2.cxx
@@ -29,6 +29,7 @@
 #include "ITSBase/GeometryTGeo.h"
 #include "ITSSimulation/DescriptorInnerBarrelITS2.h"
 #include "ITSSimulation/V3Services.h"
+#include "ITSSimulation/V3Layer.h"
 
 using namespace o2::its;
 
@@ -57,14 +58,6 @@ DescriptorInnerBarrelITS2::DescriptorInnerBarrelITS2(int nlayers) : DescriptorIn
 }
 
 //________________________________________________________________
-DescriptorInnerBarrelITS2::~DescriptorInnerBarrelITS2()
-{
-  //
-  // Default destructor
-  //
-}
-
-//________________________________________________________________
 void DescriptorInnerBarrelITS2::Configure()
 {
   // build ITS2 upgrade detector
@@ -80,7 +73,6 @@ void DescriptorInnerBarrelITS2::Configure()
   fStaveWidth.resize(fNumLayers);
   fChipTypeID.resize(fNumLayers);
   fBuildLevel.resize(fNumLayers);
-  fStaveModelInnerBarrel.resize(fNumLayers);
   fLayer.resize(fNumLayers);
 
   // Radii are from last TDR (ALICE-TDR-017.pdf Tab. 1.1)
@@ -90,7 +82,6 @@ void DescriptorInnerBarrelITS2::Configure()
   IBdat.emplace_back(std::array<double, 6>{3.78, 3.93, 4.21, 9., 9.55, 20});
 
   for (auto idLayer{0u}; idLayer < fNumLayers; ++idLayer) {
-    fStaveModelInnerBarrel[idLayer] = V3Layer::kIBModel4;
     fTurboLayer[idLayer] = true;
     fLayerPhi0[idLayer] = IBdat[idLayer][4];
     fLayerRadii[idLayer] = IBdat[idLayer][1];
@@ -136,7 +127,7 @@ V3Layer* DescriptorInnerBarrelITS2::CreateLayer(int idLayer, TGeoVolume* dest)
   fLayer[idLayer]->setChipType(fChipTypeID[idLayer]);
   fLayer[idLayer]->setBuildLevel(fBuildLevel[idLayer]);
 
-  fLayer[idLayer]->setStaveModel(fStaveModelInnerBarrel[idLayer]);
+  fLayer[idLayer]->setStaveModel(V3Layer::kIBModel4);
 
   if (fChipThickness[idLayer] != 0) {
     fLayer[idLayer]->setChipThick(fChipThickness[idLayer]);

--- a/Detectors/ITSMFT/ITS/simulation/src/DescriptorInnerBarrelITS2.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/DescriptorInnerBarrelITS2.cxx
@@ -82,7 +82,7 @@ void DescriptorInnerBarrelITS2::Configure()
   IBdat.emplace_back(std::array<double, 6>{3.78, 3.93, 4.21, 9., 9.55, 20});
 
   for (auto idLayer{0u}; idLayer < fNumLayers; ++idLayer) {
-    fStaveModelInnerBarrel[idLayer] = o2::its::V3Layer::kIBModel4;
+    fStaveModelInnerBarrel[idLayer] = V3Layer::kIBModel4;
     fTurboLayer[idLayer] = true;
     fLayerPhi0[idLayer] = IBdat[idLayer][4];
     fLayerRadii[idLayer] = IBdat[idLayer][1];

--- a/Detectors/ITSMFT/ITS/simulation/src/DescriptorInnerBarrelITS2.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/DescriptorInnerBarrelITS2.cxx
@@ -1,0 +1,318 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "FairDetector.h"      // for FairDetector
+#include <fairlogger/Logger.h> // for LOG, LOG_IF
+#include "FairRootManager.h"   // for FairRootManager
+#include "FairRun.h"           // for FairRun
+#include "FairRuntimeDb.h"     // for FairRuntimeDb
+#include "FairVolume.h"        // for FairVolume
+#include "FairRootManager.h"
+
+#include "TGeoManager.h"     // for TGeoManager, gGeoManager
+#include "TGeoTube.h"        // for TGeoTube
+#include "TGeoPcon.h"        // for TGeoPcon
+#include "TGeoVolume.h"      // for TGeoVolume, TGeoVolumeAssembly
+#include "TString.h"         // for TString, operator+
+#include "TVirtualMC.h"      // for gMC, TVirtualMC
+#include "TVirtualMCStack.h" // for TVirtualMCStack
+
+#include "ITSMFTBase/SegmentationAlpide.h"
+#include "ITSBase/GeometryTGeo.h"
+#include "ITSSimulation/DescriptorInnerBarrelITS2.h"
+#include "ITSSimulation/V3Services.h"
+
+using namespace o2::its;
+
+/// \cond CLASSIMP
+ClassImp(DescriptorInnerBarrelITS2);
+/// \endcond
+
+//________________________________________________________________
+DescriptorInnerBarrelITS2::DescriptorInnerBarrelITS2(int nlayers) : DescriptorInnerBarrel(nlayers)
+{
+  //
+  // Standard constructor
+  //
+
+  fSensorLayerThickness = o2::itsmft::SegmentationAlpide::SensorLayerThickness;
+}
+
+//________________________________________________________________
+void DescriptorInnerBarrelITS2::Configure()
+{
+  // build ITS2 upgrade detector
+  fTurboLayer.resize(fNumLayers);
+  fLayerPhi0.resize(fNumLayers);
+  fLayerRadii.resize(fNumLayers);
+  fLayerZLen.resize(fNumLayers);
+  fStavePerLayer.resize(fNumLayers);
+  fUnitPerStave.resize(fNumLayers);
+  fChipThickness.resize(fNumLayers);
+  fDetectorThickness.resize(fNumLayers);
+  fStaveTilt.resize(fNumLayers);
+  fStaveWidth.resize(fNumLayers);
+  fChipTypeID.resize(fNumLayers);
+  fBuildLevel.resize(fNumLayers);
+  fStaveModelInnerBarrel.resize(fNumLayers);
+  fLayer.resize(fNumLayers);
+
+  // Radii are from last TDR (ALICE-TDR-017.pdf Tab. 1.1)
+  std::vector<std::array<double, 6>> IBdat;
+  IBdat.emplace_back(std::array<double, 6>{2.24, 2.34, 2.67, 9., 16.42, 12});
+  IBdat.emplace_back(std::array<double, 6>{3.01, 3.15, 3.46, 9., 12.18, 16});
+  IBdat.emplace_back(std::array<double, 6>{3.78, 3.93, 4.21, 9., 9.55, 20});
+
+  for (auto idLayer{0u}; idLayer < fNumLayers; ++idLayer) {
+    fStaveModelInnerBarrel[idLayer] = o2::its::V3Layer::kIBModel4;
+    fTurboLayer[idLayer] = true;
+    fLayerPhi0[idLayer] = IBdat[idLayer][4];
+    fLayerRadii[idLayer] = IBdat[idLayer][1];
+    fStavePerLayer[idLayer] = IBdat[idLayer][5];
+    fUnitPerStave[idLayer] = IBdat[idLayer][3];
+    fChipThickness[idLayer] = 50.e-4;
+    fStaveWidth[idLayer] = o2::itsmft::SegmentationAlpide::SensorSizeRows;
+    fStaveTilt[idLayer] = radii2Turbo(IBdat[idLayer][0], IBdat[idLayer][1], IBdat[idLayer][2], o2::itsmft::SegmentationAlpide::SensorSizeRows);
+    fDetectorThickness[idLayer] = fSensorLayerThickness;
+    fChipTypeID[idLayer] = 0;
+    fBuildLevel[idLayer] = 0;
+
+    LOG(info) << "L# " << idLayer << " Phi:" << fLayerPhi0[idLayer] << " R:" << fLayerRadii[idLayer] << " Nst:" << fStavePerLayer[idLayer] << " Nunit:" << fUnitPerStave[idLayer]
+              << " W:" << fStaveWidth[idLayer] << " Tilt:" << fStaveTilt[idLayer] << " Lthick:" << fChipThickness[idLayer] << " Dthick:" << fDetectorThickness[idLayer]
+              << " DetID:" << fChipTypeID[idLayer] << " B:" << fBuildLevel[idLayer];
+  }
+
+  fWrapperMinRadius = 2.1;
+  fWrapperMaxRadius = 16.4;
+  fWrapperZSpan = 70.;
+}
+
+//________________________________________________________________
+V3Layer* DescriptorInnerBarrelITS2::CreateLayer(int idLayer, TGeoVolume* dest)
+{
+  if (idLayer >= fNumLayers) {
+    LOG(fatal) << "Trying to define layer " << idLayer << " of inner barrel, but only " << fNumLayers << " layers expected!";
+    return nullptr;
+  }
+
+  if (fTurboLayer[idLayer]) {
+    fLayer[idLayer] = new V3Layer(idLayer, true, false);
+    fLayer[idLayer]->setStaveWidth(fStaveWidth[idLayer]);
+    fLayer[idLayer]->setStaveTilt(fStaveTilt[idLayer]);
+  } else {
+    fLayer[idLayer] = new V3Layer(idLayer, false);
+  }
+
+  fLayer[idLayer]->setPhi0(fLayerPhi0[idLayer]);
+  fLayer[idLayer]->setRadius(fLayerRadii[idLayer]);
+  fLayer[idLayer]->setNumberOfStaves(fStavePerLayer[idLayer]);
+  fLayer[idLayer]->setNumberOfUnits(fUnitPerStave[idLayer]);
+  fLayer[idLayer]->setChipType(fChipTypeID[idLayer]);
+  fLayer[idLayer]->setBuildLevel(fBuildLevel[idLayer]);
+
+  fLayer[idLayer]->setStaveModel(fStaveModelInnerBarrel[idLayer]);
+
+  if (fChipThickness[idLayer] != 0) {
+    fLayer[idLayer]->setChipThick(fChipThickness[idLayer]);
+  }
+  if (fDetectorThickness[idLayer] != 0) {
+    fLayer[idLayer]->setSensorThick(fDetectorThickness[idLayer]);
+  }
+
+  fLayer[idLayer]->createLayer(dest);
+
+  return fLayer[idLayer]; // is this needed?
+}
+
+//________________________________________________________________
+void DescriptorInnerBarrelITS2::CreateServices(TGeoVolume* dest)
+{
+  //
+  // Creates the Inner Barrel Service structures
+  //
+  // Input:
+  //         motherVolume : the volume hosting the services
+  //
+  // Output:
+  //
+  // Return:
+  //
+  // Created:      15 May 2019  Mario Sitta
+  //               (partially based on P.Namwongsa implementation in AliRoot)
+  // Updated:      19 Jun 2019  Mario Sitta  IB Side A added
+  // Updated:      21 Oct 2019  Mario Sitta  CYSS added
+  //
+
+  std::unique_ptr<V3Services> mServicesGeometry(new V3Services());
+
+  // Create the End Wheels on Side A
+  TGeoVolume* endWheelsA = mServicesGeometry.get()->createIBEndWheelsSideA();
+  dest->AddNode(endWheelsA, 1, nullptr);
+
+  // Create the End Wheels on Side C
+  TGeoVolume* endWheelsC = mServicesGeometry.get()->createIBEndWheelsSideC();
+  dest->AddNode(endWheelsC, 1, nullptr);
+
+  // Create the CYSS Assembly (i.e. the supporting half cylinder and cone)
+  TGeoVolume* cyss = mServicesGeometry.get()->createCYSSAssembly();
+  dest->AddNode(cyss, 1, nullptr);
+
+  mServicesGeometry.get()->createIBGammaConvWire(dest);
+}
+
+//________________________________________________________________
+void DescriptorInnerBarrelITS2::AddAlignableVolumesLayer(int idLayer, int wrapperLayerId, TString& parentPath, int& lastUID)
+{
+  //
+  // Add alignable volumes for a Layer and its daughters
+  //
+  // Created:      06 Mar 2018  Mario Sitta First version (mainly ported from AliRoot)
+  // Updated:      06 Jul 2021  Mario Sitta Do not set Layer as alignable volume
+  //
+
+  TString wrpV = wrapperLayerId != -1 ? Form("%s%d_1", GeometryTGeo::getITSWrapVolPattern(), wrapperLayerId) : "";
+  TString path = Form("%s/%s/%s%d_1", parentPath.Data(), wrpV.Data(), GeometryTGeo::getITSLayerPattern(), idLayer);
+  TString sname = GeometryTGeo::composeSymNameLayer(idLayer);
+
+  int nHalfBarrel = fLayer[idLayer]->getNumberOfHalfBarrelsPerParent();
+  int start = nHalfBarrel > 0 ? 0 : -1;
+  for (int iHalfBarrel{start}; iHalfBarrel < nHalfBarrel; ++iHalfBarrel) {
+    AddAlignableVolumesHalfBarrel(idLayer, iHalfBarrel, path, lastUID);
+  }
+}
+
+void DescriptorInnerBarrelITS2::AddAlignableVolumesHalfBarrel(int idLayer, int iHalfBarrel, TString& parentPath, int& lastUID) const
+{
+  //
+  // Add alignable volumes for a Half barrel and its daughters
+  //
+  // Created:      28 Jun 2021  Mario Sitta First version (based on similar methods)
+  //
+
+  TString path = parentPath;
+  if (iHalfBarrel >= 0) {
+    path = Form("%s/%s%d_%d", parentPath.Data(), GeometryTGeo::getITSHalfBarrelPattern(), idLayer, iHalfBarrel);
+    TString sname = GeometryTGeo::composeSymNameHalfBarrel(idLayer, iHalfBarrel);
+
+    LOG(debug) << "Add " << sname << " <-> " << path;
+
+    if (!gGeoManager->SetAlignableEntry(sname.Data(), path.Data())) {
+      LOG(fatal) << "Unable to set alignable entry ! " << sname << " : " << path;
+    }
+  }
+
+  int nStaves = fLayer[idLayer]->getNumberOfStavesPerParent();
+  for (int iStave{0}; iStave < nStaves; ++iStave) {
+    AddAlignableVolumesStave(idLayer, iHalfBarrel, iStave, path, lastUID);
+  }
+}
+
+void DescriptorInnerBarrelITS2::AddAlignableVolumesStave(int idLayer, int iHalfBarrel, int iStave, TString& parentPath, int& lastUID) const
+{
+  //
+  // Add alignable volumes for a Stave and its daughters
+  //
+  // Created:      06 Mar 2018  Mario Sitta First version (mainly ported from AliRoot)
+  // Updated:      29 Jun 2021  Mario Sitta Hal Barrel index added
+  //
+
+  TString path = Form("%s/%s%d_%d", parentPath.Data(), GeometryTGeo::getITSStavePattern(), idLayer, iStave);
+  TString sname = GeometryTGeo::composeSymNameStave(idLayer, iHalfBarrel, iStave);
+
+  LOG(debug) << "Add " << sname << " <-> " << path;
+
+  if (!gGeoManager->SetAlignableEntry(sname.Data(), path.Data())) {
+    LOG(fatal) << "Unable to set alignable entry ! " << sname << " : " << path;
+  }
+
+  int nHalfStave = fLayer[idLayer]->getNumberOfHalfStavesPerParent();
+  int start = nHalfStave > 0 ? 0 : -1;
+  for (int iHalfStave{start}; iHalfStave < nHalfStave; ++iHalfStave) {
+    AddAlignableVolumesHalfStave(idLayer, iHalfBarrel, iStave, iHalfStave, path, lastUID);
+  }
+}
+
+void DescriptorInnerBarrelITS2::AddAlignableVolumesHalfStave(int idLayer, int iHalfBarrel, int iStave, int iHalfStave, TString& parentPath, int& lastUID) const
+{
+  //
+  // Add alignable volumes for a HalfStave (if any) and its daughters
+  //
+  // Created:      06 Mar 2018  Mario Sitta First version (mainly ported from AliRoot)
+  // Updated:      29 Jun 2021  Mario Sitta Hal Barrel index added
+  //
+
+  TString path = parentPath;
+  if (iHalfStave >= 0) {
+    path = Form("%s/%s%d_%d", parentPath.Data(), GeometryTGeo::getITSHalfStavePattern(), idLayer, iHalfStave);
+    TString sname = GeometryTGeo::composeSymNameHalfStave(idLayer, iHalfBarrel, iStave, iHalfStave);
+
+    LOG(debug) << "Add " << sname << " <-> " << path;
+
+    if (!gGeoManager->SetAlignableEntry(sname.Data(), path.Data())) {
+      LOG(fatal) << "Unable to set alignable entry ! " << sname << " : " << path;
+    }
+  }
+
+  int nModules = fLayer[idLayer]->getNumberOfModulesPerParent();
+  int start = nModules > 0 ? 0 : -1;
+  for (int iModule{start}; iModule < nModules; iModule++) {
+    AddAlignableVolumesModule(idLayer, iHalfBarrel, iStave, iHalfStave, iModule, path, lastUID);
+  }
+}
+
+void DescriptorInnerBarrelITS2::AddAlignableVolumesModule(int idLayer, int iHalfBarrel, int iStave, int iHalfStave, int iModule, TString& parentPath, int& lastUID) const
+{
+  //
+  // Add alignable volumes for a Module (if any) and its daughters
+  //
+  // Created:      06 Mar 2018  Mario Sitta First version (mainly ported from AliRoot)
+  // Updated:      29 Jun 2021  Mario Sitta Hal Barrel index added
+  //
+
+  TString path = parentPath;
+  if (iModule >= 0) {
+    path = Form("%s/%s%d_%d", parentPath.Data(), GeometryTGeo::getITSModulePattern(), idLayer, iModule);
+    TString sname = GeometryTGeo::composeSymNameModule(idLayer, iHalfBarrel, iStave, iHalfStave, iModule);
+
+    LOG(debug) << "Add " << sname << " <-> " << path;
+
+    if (!gGeoManager->SetAlignableEntry(sname.Data(), path.Data())) {
+      LOG(fatal) << "Unable to set alignable entry ! " << sname << " : " << path;
+    }
+  }
+
+  int nChips = fLayer[idLayer]->getNumberOfChipsPerParent();
+  for (int iChip{0}; iChip < nChips; ++iChip) {
+    AddAlignableVolumesChip(idLayer, iHalfBarrel, iStave, iHalfStave, iModule, iChip, path, lastUID);
+  }
+}
+
+void DescriptorInnerBarrelITS2::AddAlignableVolumesChip(int idLayer, int iHalfBarrel, int iStave, int iHalfStave, int iModule, int iChip, TString& parentPath, int& lastUID) const
+{
+  //
+  // Add alignable volumes for a Chip
+  //
+  // Created:      06 Mar 2018  Mario Sitta First version (mainly ported from AliRoot)
+  // Updated:      29 Jun 2021  Mario Sitta Hal Barrel index added
+  //
+
+  TString path = Form("%s/%s%d_%d", parentPath.Data(), GeometryTGeo::getITSChipPattern(), idLayer, iChip);
+  TString sname = GeometryTGeo::composeSymNameChip(idLayer, iHalfBarrel, iStave, iHalfStave, iModule, iChip);
+  int modUID = o2::base::GeometryManager::getSensID(o2::detectors::DetID::ITS, lastUID++);
+
+  LOG(debug) << "Add " << sname << " <-> " << path;
+
+  if (!gGeoManager->SetAlignableEntry(sname, path.Data(), modUID)) {
+    LOG(fatal) << "Unable to set alignable entry ! " << sname << " : " << path;
+  }
+
+  return;
+}

--- a/Detectors/ITSMFT/ITS/simulation/src/DescriptorInnerBarrelITS2.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/DescriptorInnerBarrelITS2.cxx
@@ -37,6 +37,16 @@ ClassImp(DescriptorInnerBarrelITS2);
 /// \endcond
 
 //________________________________________________________________
+DescriptorInnerBarrelITS2::DescriptorInnerBarrelITS2() : DescriptorInnerBarrel()
+{
+  //
+  // Standard constructor
+  //
+
+  fSensorLayerThickness = o2::itsmft::SegmentationAlpide::SensorLayerThickness;
+}
+
+//________________________________________________________________
 DescriptorInnerBarrelITS2::DescriptorInnerBarrelITS2(int nlayers) : DescriptorInnerBarrel(nlayers)
 {
   //

--- a/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
@@ -68,8 +68,7 @@ Detector::Detector()
     mNumberOfDetectors(-1),
     mModifyGeometry(kFALSE),
     mNumberInnerLayers(3),
-    mHits(o2::utils::createSimVector<o2::itsmft::Hit>()),
-    mStaveModelOuterBarrel(V3Layer::kOBModel0)
+    mHits(o2::utils::createSimVector<o2::itsmft::Hit>())
 {
   mDescriptorIB = nullptr;
   mNumberLayers = mNumberInnerLayers + sNumberOuterLayers;
@@ -101,8 +100,6 @@ void Detector::configOuterBarrelITS(int nInnerBarrelLayers)
 
   double rLr, phi0, turbo;
   int nStaveLr, nModPerStaveLr;
-
-  setStaveModelOB(V3Layer::kOBModel2);
 
   const int kNWrapVol = 2;
   const double wrpRMin[kNWrapVol] = {19.2, 33.32};
@@ -137,8 +134,7 @@ Detector::Detector(Bool_t active, TString name)
     mNumberOfDetectors(-1),
     mModifyGeometry(kFALSE),
     mNumberLayers(sNumberOuterLayers),
-    mHits(o2::utils::createSimVector<o2::itsmft::Hit>()),
-    mStaveModelOuterBarrel(V3Layer::kOBModel0)
+    mHits(o2::utils::createSimVector<o2::itsmft::Hit>())
 {
   mDescriptorIB.reset(new DescriptorInnerBarrelITS2(3));
   mNumberInnerLayers = mDescriptorIB.get()->GetNumberOfLayers();
@@ -202,8 +198,7 @@ Detector::Detector(const Detector& rhs)
     mModifyGeometry(rhs.mModifyGeometry),
 
     /// Container for data points
-    mHits(o2::utils::createSimVector<o2::itsmft::Hit>()),
-    mStaveModelOuterBarrel(rhs.mStaveModelOuterBarrel)
+    mHits(o2::utils::createSimVector<o2::itsmft::Hit>())
 {
   mDescriptorIB = rhs.mDescriptorIB;
   for (int j{0}; j < mNumberLayers; j++) {
@@ -243,8 +238,6 @@ Detector& Detector::operator=(const Detector& rhs)
 
   /// Container for data points
   mHits = nullptr;
-
-  mStaveModelOuterBarrel = rhs.mStaveModelOuterBarrel;
 
   mDescriptorIB = rhs.mDescriptorIB;
 
@@ -850,7 +843,7 @@ void Detector::constructDetectorGeometry()
       mGeometry[j]->setChipType(mChipTypeID[j]);
       mGeometry[j]->setBuildLevel(mBuildLevel[j]);
 
-      mGeometry[j]->setStaveModel(mStaveModelOuterBarrel);
+      mGeometry[j]->setStaveModel(V3Layer::kOBModel2);
 
       LOG(debug1) << "mBuildLevel: " << mBuildLevel[j];
 

--- a/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
@@ -67,41 +67,32 @@ Detector::Detector()
     */
     mNumberOfDetectors(-1),
     mModifyGeometry(kFALSE),
+    mNumberInnerLayers(3),
     mHits(o2::utils::createSimVector<o2::itsmft::Hit>()),
-    mStaveModelInnerBarrel(kIBModel0),
-    mStaveModelOuterBarrel(kOBModel0)
+    mStaveModelOuterBarrel(o2::its::V3Layer::kOBModel0)
 {
+  mDescriptorIB = nullptr;
+  mNumberLayers = mNumberInnerLayers + sNumberOuterLayers;
 }
 
-static double radii2Turbo(double rMin, double rMid, double rMax, double sensW)
+void Detector::configOuterBarrelITS(int nInnerBarrelLayers)
 {
-  // compute turbo angle from radii and sensor width
-  return TMath::ASin((rMax * rMax - rMin * rMin) / (2 * rMid * sensW)) * TMath::RadToDeg();
-}
-
-static void configITS(Detector* its)
-{
-  // build ITS upgrade detector
-  const int kNLr = 7;
-  const int kNLrInner = 3;
+  // build ITS outer barrel detector
+  const int kNLr = 4;
   const int kBuildLevel = 0;
   const int kSensTypeID = 0; // dummy id for Alpide sensor
 
-  const double ChipThicknessIB = 50.e-4;
   const double ChipThicknessOB = 100.e-4;
 
-  enum { kRmn,
-         kRmd,
-         kRmx,
-         kNModPerStave,
-         kPhi0,
-         kNStave,
-         kNPar };
+  const int kRmd = 1;
+  const int kNModPerStave = 3;
+  const int kPhi0 = 4;
+  const int kNStave = 5;
+  const int kNPar = 6;
+
   // Radii are from last TDR (ALICE-TDR-017.pdf Tab. 1.1, rMid is mean value)
+
   const double tdr5dat[kNLr][kNPar] = {
-    {2.24, 2.34, 2.67, 9., 16.42, 12}, // for each inner layer: rMin,rMid,rMax,NChip/Stave, phi0, nStaves
-    {3.01, 3.15, 3.46, 9., 12.18, 16},
-    {3.78, 3.93, 4.21, 9., 9.55, 20},
     {-1, 19.45, -1, 4., 7.5, 24},  // for others: -, rMid, -, NMod/HStave, phi0, nStaves // 24 was 49
     {-1, 24.40, -1, 4., 6., 30},   // 30 was 61
     {-1, 34.24, -1, 7., 4.29, 42}, // 42 was 88
@@ -111,16 +102,15 @@ static void configITS(Detector* its)
   double rLr, phi0, turbo;
   int nStaveLr, nModPerStaveLr;
 
-  its->setStaveModelIB(o2::its::Detector::kIBModel4);
-  its->setStaveModelOB(o2::its::Detector::kOBModel2);
+  setStaveModelOB(o2::its::V3Layer::kOBModel2);
 
-  const int kNWrapVol = 3;
-  const double wrpRMin[kNWrapVol] = {2.1, 19.2, 33.32};
-  const double wrpRMax[kNWrapVol] = {16.4, 29.14, 44.9};
-  const double wrpZSpan[kNWrapVol] = {70., 93., 163.0};
+  const int kNWrapVol = 2;
+  const double wrpRMin[kNWrapVol] = {19.2, 33.32};
+  const double wrpRMax[kNWrapVol] = {29.14, 44.9};
+  const double wrpZSpan[kNWrapVol] = {93., 163.0};
 
   for (int iw = 0; iw < kNWrapVol; iw++) {
-    its->defineWrapperVolume(iw, wrpRMin[iw], wrpRMax[iw], wrpZSpan[iw]);
+    defineWrapperVolume(iw + 1, wrpRMin[iw], wrpRMax[iw], wrpZSpan[iw]); // first wrapper volume managed by DescriptorInnerBarrel
   }
 
   for (int idLr = 0; idLr < kNLr; idLr++) {
@@ -129,20 +119,13 @@ static void configITS(Detector* its)
 
     nStaveLr = TMath::Nint(tdr5dat[idLr][kNStave]);
     nModPerStaveLr = TMath::Nint(tdr5dat[idLr][kNModPerStave]);
-    int nChipsPerStaveLr = nModPerStaveLr;
-    if (idLr >= kNLrInner) {
-      its->defineLayer(idLr, phi0, rLr, nStaveLr, nModPerStaveLr, ChipThicknessOB, Segmentation::SensorLayerThickness,
-                       kSensTypeID, kBuildLevel);
-    } else {
-      turbo = radii2Turbo(tdr5dat[idLr][kRmn], rLr, tdr5dat[idLr][kRmx], Segmentation::SensorSizeRows);
-      its->defineLayerTurbo(idLr, phi0, rLr, nStaveLr, nChipsPerStaveLr, Segmentation::SensorSizeRows, turbo,
-                            ChipThicknessIB, Segmentation::SensorLayerThickness, kSensTypeID, kBuildLevel);
-    }
+    defineLayer(idLr + nInnerBarrelLayers, phi0, rLr, nStaveLr, nModPerStaveLr, ChipThicknessOB, Segmentation::SensorLayerThickness,
+                kSensTypeID, kBuildLevel);
   }
 }
 
-Detector::Detector(Bool_t active)
-  : o2::base::DetImpl<Detector>("ITS", active),
+Detector::Detector(Bool_t active, TString name)
+  : o2::base::DetImpl<Detector>(name, active),
     mTrackData(),
     /*
     mHitStarted(false),
@@ -153,17 +136,35 @@ Detector::Detector(Bool_t active)
     */
     mNumberOfDetectors(-1),
     mModifyGeometry(kFALSE),
+    mNumberLayers(sNumberOuterLayers),
     mHits(o2::utils::createSimVector<o2::itsmft::Hit>()),
-    mStaveModelInnerBarrel(kIBModel0),
-    mStaveModelOuterBarrel(kOBModel0)
+    mStaveModelOuterBarrel(o2::its::V3Layer::kOBModel0)
 {
+  mDescriptorIB.reset(new DescriptorInnerBarrelITS2(3));
+  mNumberInnerLayers = mDescriptorIB.get()->GetNumberOfLayers();
+  mNumberLayers = mNumberInnerLayers + sNumberOuterLayers;
 
-  for (Int_t j = 0; j < sNumberLayers; j++) {
+  mLayerName.resize(mNumberLayers);
+  mTurboLayer.resize(mNumberLayers);
+  mLayerPhi0.resize(mNumberLayers);
+  mLayerRadii.resize(mNumberLayers);
+  mStavePerLayer.resize(mNumberLayers);
+  mUnitPerStave.resize(mNumberLayers);
+  mChipThickness.resize(mNumberLayers);
+  mStaveWidth.resize(mNumberLayers);
+  mStaveTilt.resize(mNumberLayers);
+  mDetectorThickness.resize(mNumberLayers);
+  mChipTypeID.resize(mNumberLayers);
+  mBuildLevel.resize(mNumberLayers);
+  mGeometry.resize(mNumberLayers);
+  mWrapperLayerId.resize(mNumberLayers);
+
+  for (int j{0}; j < mNumberLayers; j++) {
     mLayerName[j].Form("%s%d", GeometryTGeo::getITSSensorPattern(), j); // See V3Layer
   }
 
-  if (sNumberLayers > 0) { // if not, we'll Fatal-ize in CreateGeometry
-    for (Int_t j = 0; j < sNumberLayers; j++) {
+  if (mNumberLayers > 0) { // if not, we'll Fatal-ize in CreateGeometry
+    for (Int_t j = 0; j < mNumberLayers; j++) {
       mLayerPhi0[j] = 0;
       mLayerRadii[j] = 0.;
       mStavePerLayer[j] = 0;
@@ -183,7 +184,8 @@ Detector::Detector(Bool_t active)
     mWrapperMinRadius[i] = mWrapperMaxRadius[i] = mWrapperZSpan[i] = -1;
   }
 
-  configITS(this);
+  dynamic_cast<DescriptorInnerBarrelITS2*>(mDescriptorIB.get())->Configure();
+  configOuterBarrelITS(mNumberInnerLayers);
 }
 
 Detector::Detector(const Detector& rhs)
@@ -201,11 +203,10 @@ Detector::Detector(const Detector& rhs)
 
     /// Container for data points
     mHits(o2::utils::createSimVector<o2::itsmft::Hit>()),
-    mStaveModelInnerBarrel(rhs.mStaveModelInnerBarrel),
     mStaveModelOuterBarrel(rhs.mStaveModelOuterBarrel)
 {
-
-  for (Int_t j = 0; j < sNumberLayers; j++) {
+  mDescriptorIB = rhs.mDescriptorIB;
+  for (int j{0}; j < mNumberLayers; j++) {
     mLayerName[j].Form("%s%d", GeometryTGeo::getITSSensorPattern(), j); // See V3Layer
   }
 }
@@ -243,10 +244,15 @@ Detector& Detector::operator=(const Detector& rhs)
   /// Container for data points
   mHits = nullptr;
 
-  mStaveModelInnerBarrel = rhs.mStaveModelInnerBarrel;
   mStaveModelOuterBarrel = rhs.mStaveModelOuterBarrel;
 
-  for (Int_t j = 0; j < sNumberLayers; j++) {
+  mDescriptorIB = rhs.mDescriptorIB;
+
+  mNumberInnerLayers = rhs.mNumberInnerLayers;
+  mNumberLayers = rhs.mNumberLayers;
+  mLayerName.resize(mNumberLayers);
+
+  for (Int_t j = 0; j < mNumberLayers; j++) {
     mLayerName[j].Form("%s%d", GeometryTGeo::getITSSensorPattern(), j); // See V3Layer
   }
 
@@ -258,7 +264,8 @@ void Detector::InitializeO2Detector()
   // Define the list of sensitive volumes
   defineSensitiveVolumes();
 
-  for (int i = 0; i < sNumberLayers; i++) {
+  mLayerID.resize(mNumberLayers);
+  for (int i = 0; i < mNumberLayers; i++) {
     mLayerID[i] = gMC ? TVirtualMC::GetMC()->VolId(mLayerName[i]) : 0;
   }
 
@@ -278,7 +285,7 @@ Bool_t Detector::ProcessHits(FairVolume* vol)
 
   // FIXME: Determine the layer number. Is this information available directly from the FairVolume?
   bool notSens = false;
-  while ((lay < sNumberLayers) && (notSens = (volID != mLayerID[lay]))) {
+  while ((lay < mNumberLayers) && (notSens = (volID != mLayerID[lay]))) {
     ++lay;
   }
   if (notSens) {
@@ -287,7 +294,7 @@ Bool_t Detector::ProcessHits(FairVolume* vol)
 
   // Is it needed to keep a track reference when the outer ITS volume is encountered?
   auto stack = (o2::data::Stack*)fMC->GetStack();
-  if (fMC->IsTrackExiting() && (lay == 0 || lay == 6)) {
+  if (fMC->IsTrackExiting() && (lay == 0 || lay == mNumberLayers - 1)) {
     // Keep the track refs for the innermost and outermost layers only
     o2::TrackReference tr(*fMC, GetDetId());
     tr.setTrackID(stack->GetCurrentTrackNumber());
@@ -604,7 +611,7 @@ void Detector::defineWrapperVolume(Int_t id, Double_t rmin, Double_t rmax, Doubl
   mWrapperZSpan[id] = zspan;
 }
 
-void Detector::defineLayer(Int_t nlay, double phi0, Double_t r, Int_t nstav, Int_t nunit, Double_t lthick,
+void Detector::defineLayer(Int_t nlay, Double_t phi0, Double_t r, Int_t nstav, Int_t nunit, Double_t lthick,
                            Double_t dthick, UInt_t dettypeID, Int_t buildLevel)
 {
   //     Sets the layer parameters
@@ -627,7 +634,7 @@ void Detector::defineLayer(Int_t nlay, double phi0, Double_t r, Int_t nstav, Int
   LOG(info) << "L# " << nlay << " Phi:" << phi0 << " R:" << r << " Nst:" << nstav << " Nunit:" << nunit
             << " Lthick:" << lthick << " Dthick:" << dthick << " DetID:" << dettypeID << " B:" << buildLevel;
 
-  if (nlay >= sNumberLayers || nlay < 0) {
+  if (nlay >= mNumberLayers || nlay < 0) {
     LOG(error) << "Wrong layer number " << nlay;
     return;
   }
@@ -638,51 +645,6 @@ void Detector::defineLayer(Int_t nlay, double phi0, Double_t r, Int_t nstav, Int
   mStavePerLayer[nlay] = nstav;
   mUnitPerStave[nlay] = nunit;
   mChipThickness[nlay] = lthick;
-  mDetectorThickness[nlay] = dthick;
-  mChipTypeID[nlay] = dettypeID;
-  mBuildLevel[nlay] = buildLevel;
-}
-
-void Detector::defineLayerTurbo(Int_t nlay, Double_t phi0, Double_t r, Int_t nstav, Int_t nunit, Double_t width,
-                                Double_t tilt, Double_t lthick, Double_t dthick, UInt_t dettypeID, Int_t buildLevel)
-{
-  //     Sets the layer parameters for a "turbo" layer
-  //     (i.e. a layer whose staves overlap in phi)
-  // Inputs:
-  //          nlay    layer number
-  //          phi0    phi of 1st stave
-  //          r       layer radius
-  //          nstav   number of staves
-  //          nunit   IB: number of chips per stave
-  //                  OB: number of modules per half stave
-  //          width   stave width
-  //          tilt    layer tilt angle (degrees)
-  //          lthick  stave thickness (if omitted, defaults to 0)
-  //          dthick  detector thickness (if omitted, defaults to 0)
-  //          dettypeID  ??
-  //          buildLevel (if 0, all geometry is build, used for material budget studies)
-  // Outputs:
-  //   none.
-  // Return:
-  //   none.
-
-  LOG(info) << "L# " << nlay << " Phi:" << phi0 << " R:" << r << " Nst:" << nstav << " Nunit:" << nunit
-            << " W:" << width << " Tilt:" << tilt << " Lthick:" << lthick << " Dthick:" << dthick
-            << " DetID:" << dettypeID << " B:" << buildLevel;
-
-  if (nlay >= sNumberLayers || nlay < 0) {
-    LOG(error) << "Wrong layer number " << nlay;
-    return;
-  }
-
-  mTurboLayer[nlay] = kTRUE;
-  mLayerPhi0[nlay] = phi0;
-  mLayerRadii[nlay] = r;
-  mStavePerLayer[nlay] = nstav;
-  mUnitPerStave[nlay] = nunit;
-  mChipThickness[nlay] = lthick;
-  mStaveWidth[nlay] = width;
-  mStaveTilt[nlay] = tilt;
   mDetectorThickness[nlay] = dthick;
   mChipTypeID[nlay] = dettypeID;
   mBuildLevel[nlay] = buildLevel;
@@ -708,7 +670,7 @@ void Detector::getLayerParameters(Int_t nlay, Double_t& phi0, Double_t& r, Int_t
   // Return:
   //   none.
 
-  if (nlay >= sNumberLayers || nlay < 0) {
+  if (nlay >= mNumberLayers || nlay < 0) {
     LOG(error) << "Wrong layer number " << nlay;
     return;
   }
@@ -736,7 +698,7 @@ TGeoVolume* Detector::createWrapperVolume(Int_t id)
   const Double_t suppRingCZlen[3] = {4.8, 4.0, 2.1};
   const Double_t suppRingsRmin[3] = {23.35, 20.05, 35.4};
 
-  if (mWrapperMinRadius[id] < 0 || mWrapperMaxRadius[id] < 0 || mWrapperZSpan[id] < 0) {
+  if (id > 0 && (mWrapperMinRadius[id] < 0 || mWrapperMaxRadius[id] < 0 || mWrapperZSpan[id] < 0)) { // check only for OB, IB managed in DescriptorInnerBarrel
     LOG(fatal) << "Wrapper volume " << id << " was requested but not defined";
   }
 
@@ -746,8 +708,7 @@ TGeoVolume* Detector::createWrapperVolume(Int_t id)
   switch (id) {
     case 0: // IB Layer 0,1,2: simple cylinder
     {
-      TGeoTube* wrap = new TGeoTube(mWrapperMinRadius[id], mWrapperMaxRadius[id], mWrapperZSpan[id] / 2.);
-      tube = (TGeoShape*)wrap;
+      tube = (TGeoShape*)mDescriptorIB.get()->DefineWrapperVolume();
     } break;
     case 1: // MB Layer 3,4: complex Pcon to avoid MFT overlaps
     {
@@ -820,8 +781,8 @@ void Detector::constructDetectorGeometry()
   Char_t vstrng[kLength] = "xxxRS"; //?
   vITSV->SetTitle(vstrng);
 
-  // Check that we have all needed parameters
-  for (Int_t j = 0; j < sNumberLayers; j++) {
+  // Check that we have all needed parameters for OB (no need IB, which is managed by the DescriptorInnerBarrel)
+  for (Int_t j = mNumberInnerLayers; j < mNumberLayers; j++) {
     if (mLayerRadii[j] <= 0) {
       LOG(fatal) << "Wrong layer radius for layer " << j << "(" << mLayerRadii[j] << ")";
     }
@@ -865,102 +826,69 @@ void Detector::constructDetectorGeometry()
   }
 
   // Now create the actual geometry
-  for (Int_t j = 0; j < sNumberLayers; j++) {
-    TGeoVolume* dest = vITSV;
-    mWrapperLayerId[j] = -1;
+  for (Int_t j = 0; j < mNumberLayers; j++) {
 
-    if (mTurboLayer[j]) {
-      mGeometry[j] = new V3Layer(j, kTRUE, kFALSE);
-      mGeometry[j]->setStaveWidth(mStaveWidth[j]);
-      mGeometry[j]->setStaveTilt(mStaveTilt[j]);
+    if (j < mNumberInnerLayers) {
+      mGeometry[j] = dynamic_cast<DescriptorInnerBarrelITS2*>(mDescriptorIB.get())->CreateLayer(j, wrapVols[0]); // define IB layers on first wrapper volume always
+      mWrapperLayerId[j] = 0;
     } else {
-      mGeometry[j] = new V3Layer(j, kFALSE);
-    }
+      TGeoVolume* dest = vITSV;
+      mWrapperLayerId[j] = -1;
 
-    mGeometry[j]->setPhi0(mLayerPhi0[j]);
-    mGeometry[j]->setRadius(mLayerRadii[j]);
-    mGeometry[j]->setNumberOfStaves(mStavePerLayer[j]);
-    mGeometry[j]->setNumberOfUnits(mUnitPerStave[j]);
-    mGeometry[j]->setChipType(mChipTypeID[j]);
-    mGeometry[j]->setBuildLevel(mBuildLevel[j]);
-
-    if (j < sNumberInnerLayers) {
-      mGeometry[j]->setStaveModel(mStaveModelInnerBarrel);
-    } else {
-      mGeometry[j]->setStaveModel(mStaveModelOuterBarrel);
-    }
-
-    LOG(debug1) << "mBuildLevel: " << mBuildLevel[j];
-
-    if (mChipThickness[j] != 0) {
-      mGeometry[j]->setChipThick(mChipThickness[j]);
-    }
-    if (mDetectorThickness[j] != 0) {
-      mGeometry[j]->setSensorThick(mDetectorThickness[j]);
-    }
-
-    for (int iw = 0; iw < sNumberOfWrapperVolumes; iw++) {
-      if (mLayerRadii[j] > mWrapperMinRadius[iw] && mLayerRadii[j] < mWrapperMaxRadius[iw]) {
-        LOG(debug) << "Will embed layer " << j << " in wrapper volume " << iw;
-
-        dest = wrapVols[iw];
-        mWrapperLayerId[j] = iw;
-        break;
+      if (mTurboLayer[j]) {
+        mGeometry[j] = new V3Layer(j, kTRUE, kFALSE, GetName());
+        mGeometry[j]->setStaveWidth(mStaveWidth[j]);
+        mGeometry[j]->setStaveTilt(mStaveTilt[j]);
+      } else {
+        mGeometry[j] = new V3Layer(j, kFALSE, kFALSE, GetName());
       }
+
+      mGeometry[j]->setPhi0(mLayerPhi0[j]);
+      mGeometry[j]->setRadius(mLayerRadii[j]);
+      mGeometry[j]->setNumberOfStaves(mStavePerLayer[j]);
+      mGeometry[j]->setNumberOfUnits(mUnitPerStave[j]);
+      mGeometry[j]->setChipType(mChipTypeID[j]);
+      mGeometry[j]->setBuildLevel(mBuildLevel[j]);
+
+      mGeometry[j]->setStaveModel(mStaveModelOuterBarrel);
+
+      LOG(debug1) << "mBuildLevel: " << mBuildLevel[j];
+
+      if (mChipThickness[j] != 0) {
+        mGeometry[j]->setChipThick(mChipThickness[j]);
+      }
+      if (mDetectorThickness[j] != 0) {
+        mGeometry[j]->setSensorThick(mDetectorThickness[j]);
+      }
+
+      for (int iw = 0; iw < sNumberOfWrapperVolumes; iw++) {
+        if (mLayerRadii[j] > mWrapperMinRadius[iw] && mLayerRadii[j] < mWrapperMaxRadius[iw]) {
+          LOG(debug) << "Will embed layer " << j << " in wrapper volume " << iw;
+
+          dest = wrapVols[iw];
+          mWrapperLayerId[j] = iw;
+          break;
+        }
+      }
+      mGeometry[j]->createLayer(dest);
     }
-    mGeometry[j]->createLayer(dest);
   }
 
   // Now create the services
-  mServicesGeometry = new V3Services();
+  mServicesGeometry = new V3Services(GetName());
 
-  createInnerBarrelServices(wrapVols[0]);
+  dynamic_cast<DescriptorInnerBarrelITS2*>(mDescriptorIB.get())->CreateServices(wrapVols[0]);
   createMiddlBarrelServices(wrapVols[1]);
   createOuterBarrelServices(wrapVols[2]);
   createOuterBarrelSupports(vITSV);
 
-  mServicesGeometry->createIBGammaConvWire(wrapVols[0]);
   mServicesGeometry->createOBGammaConvWire(vITSV);
 
   // Finally create and place the cage
-  V3Cage* cagePtr = new V3Cage();
+  V3Cage* cagePtr = new V3Cage(GetName());
   cagePtr->createAndPlaceCage(vALIC); // vALIC = barrel
 
   delete[] wrapVols; // delete pointer only, not the volumes
-}
-
-void Detector::createInnerBarrelServices(TGeoVolume* motherVolume)
-{
-  //
-  // Creates the Inner Barrel Service structures
-  //
-  // Input:
-  //         motherVolume : the volume hosting the services
-  //
-  // Output:
-  //
-  // Return:
-  //
-  // Created:      15 May 2019  Mario Sitta
-  //               (partially based on P.Namwongsa implementation in AliRoot)
-  // Updated:      19 Jun 2019  Mario Sitta  IB Side A added
-  // Updated:      21 Oct 2019  Mario Sitta  CYSS added
-  //
-
-  // Create the End Wheels on Side A
-  TGeoVolume* endWheelsA = mServicesGeometry->createIBEndWheelsSideA();
-
-  motherVolume->AddNode(endWheelsA, 1, nullptr);
-
-  // Create the End Wheels on Side C
-  TGeoVolume* endWheelsC = mServicesGeometry->createIBEndWheelsSideC();
-
-  motherVolume->AddNode(endWheelsC, 1, nullptr);
-
-  // Create the CYSS Assembly (i.e. the supporting half cylinder and cone)
-  TGeoVolume* cyss = mServicesGeometry->createCYSSAssembly();
-
-  motherVolume->AddNode(cyss, 1, nullptr);
 }
 
 void Detector::createMiddlBarrelServices(TGeoVolume* motherVolume)
@@ -1059,8 +987,12 @@ void Detector::addAlignableVolumes() const
   }
 
   Int_t lastUID = 0;
-  for (Int_t lr = 0; lr < sNumberLayers; lr++) {
-    addAlignableVolumesLayer(lr, path, lastUID);
+  for (Int_t lr = 0; lr < mNumberLayers; lr++) {
+    if (lr < mNumberInnerLayers) {
+      dynamic_cast<DescriptorInnerBarrelITS2*>(mDescriptorIB.get())->AddAlignableVolumesLayer(lr, mWrapperLayerId[lr], path, lastUID);
+    } else {
+      addAlignableVolumesLayer(lr, path, lastUID);
+    }
   }
 
   return;
@@ -1238,8 +1170,8 @@ void Detector::defineSensitiveVolumes()
 
   TString volumeName;
 
-  // The names of the ITS sensitive volumes have the format: ITSUSensor(0...sNumberLayers-1)
-  for (Int_t j = 0; j < sNumberLayers; j++) {
+  // The names of the ITS sensitive volumes have the format: ITSUSensor(0...mNumberLayers-1)
+  for (Int_t j = 0; j < mNumberLayers; j++) {
     volumeName = GeometryTGeo::getITSSensorPattern() + TString::Itoa(j, 10);
     v = geoManager->GetVolume(volumeName.Data());
     AddSensitiveVolume(v);

--- a/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
@@ -69,7 +69,7 @@ Detector::Detector()
     mModifyGeometry(kFALSE),
     mNumberInnerLayers(3),
     mHits(o2::utils::createSimVector<o2::itsmft::Hit>()),
-    mStaveModelOuterBarrel(o2::its::V3Layer::kOBModel0)
+    mStaveModelOuterBarrel(V3Layer::kOBModel0)
 {
   mDescriptorIB = nullptr;
   mNumberLayers = mNumberInnerLayers + sNumberOuterLayers;
@@ -102,7 +102,7 @@ void Detector::configOuterBarrelITS(int nInnerBarrelLayers)
   double rLr, phi0, turbo;
   int nStaveLr, nModPerStaveLr;
 
-  setStaveModelOB(o2::its::V3Layer::kOBModel2);
+  setStaveModelOB(V3Layer::kOBModel2);
 
   const int kNWrapVol = 2;
   const double wrpRMin[kNWrapVol] = {19.2, 33.32};
@@ -138,7 +138,7 @@ Detector::Detector(Bool_t active, TString name)
     mModifyGeometry(kFALSE),
     mNumberLayers(sNumberOuterLayers),
     mHits(o2::utils::createSimVector<o2::itsmft::Hit>()),
-    mStaveModelOuterBarrel(o2::its::V3Layer::kOBModel0)
+    mStaveModelOuterBarrel(V3Layer::kOBModel0)
 {
   mDescriptorIB.reset(new DescriptorInnerBarrelITS2(3));
   mNumberInnerLayers = mDescriptorIB.get()->GetNumberOfLayers();

--- a/Detectors/ITSMFT/ITS/simulation/src/ITSSimulationLinkDef.h
+++ b/Detectors/ITSMFT/ITS/simulation/src/ITSSimulationLinkDef.h
@@ -21,6 +21,7 @@
 #pragma link C++ class o2::its::V3Cage + ;
 #pragma link C++ class o2::its::V3Services + ;
 #pragma link C++ class o2::its::Detector + ;
+#pragma link C++ class o2::its::DescriptorInnerBarrelITS2 + ;
 #pragma link C++ class o2::base::DetImpl < o2::its::Detector> + ;
 
 #endif

--- a/Detectors/ITSMFT/ITS/simulation/src/V11Geometry.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/V11Geometry.cxx
@@ -393,30 +393,30 @@ void V11Geometry::createDefaultMaterials()
   Double_t w;
 
   // Define some elements
-  auto* itsH = new TGeoElement("ITS_H", "Hydrogen", 1, 1.00794);
-  auto* itsHe = new TGeoElement("ITS_He", "Helium", 2, 4.002602);
-  auto* itsC = new TGeoElement("ITS_C", "Carbon", 6, 12.0107);
-  auto* itsN = new TGeoElement("ITS_N", "Nitrogen", 7, 14.0067);
-  auto* itsO = new TGeoElement("ITS_O", "Oxygen", 8, 15.994);
-  auto* itsF = new TGeoElement("ITS_F", "Florine", 9, 18.9984032);
-  auto* itsNe = new TGeoElement("ITS_Ne", "Neon", 10, 20.1797);
-  auto* itsMg = new TGeoElement("ITS_Mg", "Magnesium", 12, 24.3050);
-  auto* itsAl = new TGeoElement("ITS_Al", "Aluminum", 13, 26981538);
-  auto* itsSi = new TGeoElement("ITS_Si", "Silicon", 14, 28.0855);
-  auto* itsP = new TGeoElement("ITS_P", "Phosphorous", 15, 30.973761);
-  auto* itsS = new TGeoElement("ITS_S", "Sulfur", 16, 32.065);
-  auto* itsAr = new TGeoElement("ITS_Ar", "Argon", 18, 39.948);
-  auto* itsTi = new TGeoElement("ITS_Ti", "Titanium", 22, 47.867);
-  auto* itsCr = new TGeoElement("ITS_Cr", "Chromium", 24, 51.9961);
-  auto* itsMn = new TGeoElement("ITS_Mn", "Manganese", 25, 54.938049);
-  auto* itsFe = new TGeoElement("ITS_Fe", "Iron", 26, 55.845);
-  auto* itsCo = new TGeoElement("ITS_Co", "Cobalt", 27, 58.933200);
-  auto* itsNi = new TGeoElement("ITS_Ni", "Nickrl", 28, 56.6930);
-  auto* itsCu = new TGeoElement("ITS_Cu", "Copper", 29, 63.546);
-  auto* itsZn = new TGeoElement("ITS_Zn", "Zinc", 30, 65.39);
-  auto* itsKr = new TGeoElement("ITS_Kr", "Krypton", 36, 83.80);
-  auto* itsMo = new TGeoElement("ITS_Mo", "Molylibdium", 42, 95.94);
-  auto* itsXe = new TGeoElement("ITS_Xe", "Zeon", 54, 131.293);
+  auto* itsH = new TGeoElement(Form("%s_H", mDetName), "Hydrogen", 1, 1.00794);
+  auto* itsHe = new TGeoElement(Form("%s_He", mDetName), "Helium", 2, 4.002602);
+  auto* itsC = new TGeoElement(Form("%s_C", mDetName), "Carbon", 6, 12.0107);
+  auto* itsN = new TGeoElement(Form("%s_N", mDetName), "Nitrogen", 7, 14.0067);
+  auto* itsO = new TGeoElement(Form("%s_O", mDetName), "Oxygen", 8, 15.994);
+  auto* itsF = new TGeoElement(Form("%s_F", mDetName), "Florine", 9, 18.9984032);
+  auto* itsNe = new TGeoElement(Form("%s_Ne", mDetName), "Neon", 10, 20.1797);
+  auto* itsMg = new TGeoElement(Form("%s_Mg", mDetName), "Magnesium", 12, 24.3050);
+  auto* itsAl = new TGeoElement(Form("%s_Al", mDetName), "Aluminum", 13, 26981538);
+  auto* itsSi = new TGeoElement(Form("%s_Si", mDetName), "Silicon", 14, 28.0855);
+  auto* itsP = new TGeoElement(Form("%s_P", mDetName), "Phosphorous", 15, 30.973761);
+  auto* itsS = new TGeoElement(Form("%s_S", mDetName), "Sulfur", 16, 32.065);
+  auto* itsAr = new TGeoElement(Form("%s_Ar", mDetName), "Argon", 18, 39.948);
+  auto* itsTi = new TGeoElement(Form("%s_Ti", mDetName), "Titanium", 22, 47.867);
+  auto* itsCr = new TGeoElement(Form("%s_Cr", mDetName), "Chromium", 24, 51.9961);
+  auto* itsMn = new TGeoElement(Form("%s_Mn", mDetName), "Manganese", 25, 54.938049);
+  auto* itsFe = new TGeoElement(Form("%s_Fe", mDetName), "Iron", 26, 55.845);
+  auto* itsCo = new TGeoElement(Form("%s_Co", mDetName), "Cobalt", 27, 58.933200);
+  auto* itsNi = new TGeoElement(Form("%s_Ni", mDetName), "Nickrl", 28, 56.6930);
+  auto* itsCu = new TGeoElement(Form("%s_Cu", mDetName), "Copper", 29, 63.546);
+  auto* itsZn = new TGeoElement(Form("%s_Zn", mDetName), "Zinc", 30, 65.39);
+  auto* itsKr = new TGeoElement(Form("%s_Kr", mDetName), "Krypton", 36, 83.80);
+  auto* itsMo = new TGeoElement(Form("%s_Mo", mDetName), "Molylibdium", 42, 95.94);
+  auto* itsXe = new TGeoElement(Form("%s_Xe", mDetName), "Zeon", 54, 131.293);
 
   // Start with the Materials since for any one material there
   // can be defined more than one Medium.
@@ -427,7 +427,7 @@ void V11Geometry::createDefaultMaterials()
   // He 0.000524% (0.00007%), Kr 0.000114% (0.0003%), H2 0.00005% (3.5E-6%),
   // Xe 0.0000087% (0.00004 %), H2O 0.0% (dry) + trace amounts at the ppm
   // levels.
-  auto* itsAir = new TGeoMixture("ITS_Air", 9);
+  auto* itsAir = new TGeoMixture(Form("%s_Air", mDetName), 9);
   w = 75.47E-2;
   itsAir->AddElement(itsN, w);                         // Nitorgen, atomic
   w = 23.29E-2 +                                       // O2
@@ -454,12 +454,12 @@ void V11Geometry::createDefaultMaterials()
   itsAir->SetState(TGeoMaterial::kMatStateGas);
 
   // Silicone
-  auto* itsSiDet = new TGeoMaterial("ITS_Si", itsSi, 2.33 * sGCm3);
+  auto* itsSiDet = new TGeoMaterial(Form("%s_Si", mDetName), itsSi, 2.33 * sGCm3);
   itsSiDet->SetTemperature(15.0 * sCelsius);
   itsSiDet->SetState(TGeoMaterial::kMatStateSolid);
 
   // Epoxy C18 H19 O3
-  auto* itsEpoxy = new TGeoMixture("ITS_Epoxy", 3);
+  auto* itsEpoxy = new TGeoMixture(Form("%s_Epoxy", mDetName), 3);
   itsEpoxy->AddElement(itsC, 18);
   itsEpoxy->AddElement(itsH, 19);
   itsEpoxy->AddElement(itsO, 3);
@@ -475,7 +475,7 @@ void V11Geometry::createDefaultMaterials()
      </A>
   */
   // End_Html
-  auto* itsCarbonFiber = new TGeoMixture("ITS_CarbonFiber-M55J", 4);
+  auto* itsCarbonFiber = new TGeoMixture(Form("%s_CarbonFiber-M55J", mDetName), 4);
   // Assume that the epoxy fill in the space between the fibers and so
   // no change in the total volume. To compute w, assume 1cm^3 total
   // volume.
@@ -502,7 +502,7 @@ void V11Geometry::createDefaultMaterials()
      </A>
    */
   // End_Html
-  auto* itsFoam = new TGeoMixture("ITS_Foam", 4);
+  auto* itsFoam = new TGeoMixture(Form("%s_Foam", mDetName), 4);
   itsFoam->AddElement(itsC, 9);
   itsFoam->AddElement(itsH, 13);
   itsFoam->AddElement(itsN, 1);
@@ -522,7 +522,7 @@ void V11Geometry::createDefaultMaterials()
       </A>
    */
   // End_Html
-  auto* itsKapton = new TGeoMixture("ITS_Kapton", 4);
+  auto* itsKapton = new TGeoMixture(Form("%s_Kapton", mDetName), 4);
   itsKapton->AddElement(itsH, 0.026362);
   itsKapton->AddElement(itsC, 0.691133);
   itsKapton->AddElement(itsN, 0.073270);
@@ -542,7 +542,7 @@ void V11Geometry::createDefaultMaterials()
       </A>
    */
   // End_Html
-  auto* itsUpilex = new TGeoMixture("ITS_Upilex", 4);
+  auto* itsUpilex = new TGeoMixture(Form("%s_Upilex", mDetName), 4);
   itsUpilex->AddElement(itsC, 16);
   itsUpilex->AddElement(itsH, 6);
   itsUpilex->AddElement(itsN, 2);
@@ -564,7 +564,7 @@ void V11Geometry::createDefaultMaterials()
     </A>
    */
   // End_Html
-  auto* itsAl6061 = new TGeoMixture("ITS_Al6061", 9);
+  auto* itsAl6061 = new TGeoMixture(Form("%s_Al6061", mDetName), 9);
   itsAl6061->AddElement(itsCr, 0.000375);
   itsAl6061->AddElement(itsCu, 0.00275);
   itsAl6061->AddElement(itsFe, 0.0035);
@@ -591,7 +591,7 @@ void V11Geometry::createDefaultMaterials()
     </A>
    */
   // End_Html
-  auto* itsAl7075 = new TGeoMixture("ITS_Al7075", 9);
+  auto* itsAl7075 = new TGeoMixture(Form("%s_Al7075", mDetName), 9);
   itsAl7075->AddElement(itsCr, 0.0023);
   itsAl7075->AddElement(itsCu, 0.016);
   itsAl7075->AddElement(itsFe, 0.0025);
@@ -615,7 +615,7 @@ void V11Geometry::createDefaultMaterials()
     </A>
    */
   // End_Html
-  auto* itsRuby = new TGeoMixture("ITS_RubySphere", 2);
+  auto* itsRuby = new TGeoMixture(Form("%s_RubySphere", mDetName), 2);
   itsRuby->AddElement(itsAl, 2);
   itsRuby->AddElement(itsO, 3);
   itsRuby->SetTitle("Ruby reference sphere");
@@ -634,7 +634,7 @@ void V11Geometry::createDefaultMaterials()
     </A>
    */
   // End_Html
-  auto* itsInox304L = new TGeoMixture("ITS_Inox304L", 9);
+  auto* itsInox304L = new TGeoMixture(Form("%s_Inox304L", mDetName), 9);
   itsInox304L->AddElement(itsC, 0.00015);
   itsInox304L->AddElement(itsMn, 0.010);
   itsInox304L->AddElement(itsSi, 0.005);
@@ -660,7 +660,7 @@ void V11Geometry::createDefaultMaterials()
     </A>
    */
   // End_Html
-  auto* itsInox316L = new TGeoMixture("ITS_Inox316L", 9);
+  auto* itsInox316L = new TGeoMixture(Form("%s_Inox316L", mDetName), 9);
   itsInox316L->AddElement(itsC, 0.00015);
   itsInox316L->AddElement(itsMn, 0.010);
   itsInox316L->AddElement(itsSi, 0.005);
@@ -689,7 +689,7 @@ void V11Geometry::createDefaultMaterials()
     </A>
    */
   // End_Html
-  auto* itsPhynox = new TGeoMixture("ITS_Phynox", 7);
+  auto* itsPhynox = new TGeoMixture(Form("%s_Phynox", mDetName), 7);
   itsPhynox->AddElement(itsC, 0.0015);
   itsPhynox->AddElement(itsMn, 0.020);
   itsPhynox->AddElement(itsNi, 0.18);
@@ -705,7 +705,7 @@ void V11Geometry::createDefaultMaterials()
   // G10FR4
 
   // Demineralized Water H2O SDD & SSD Cooling liquid
-  auto* itsWater = new TGeoMixture("ITS_Water", 2);
+  auto* itsWater = new TGeoMixture(Form("%s_Water", mDetName), 2);
   itsWater->AddElement(itsH, 2);
   itsWater->AddElement(itsO, 1);
   itsWater->SetTitle("ITS Cooling Water");
@@ -722,7 +722,7 @@ void V11Geometry::createDefaultMaterials()
     </A>
    */
   // End_Html
-  auto* itsFreon = new TGeoMixture("ITS_SPD_Freon", 2);
+  auto* itsFreon = new TGeoMixture(Form("%s_SPD_Freon", mDetName), 2);
   itsFreon->AddElement(itsC, 4);
   itsFreon->AddElement(itsF, 10);
   itsFreon->SetTitle("ITS SPD 2 phase Cooling freon");

--- a/Detectors/ITSMFT/ITS/simulation/src/V1Layer.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/V1Layer.cxx
@@ -16,7 +16,6 @@
 
 #include "ITSSimulation/V1Layer.h"
 #include "ITSBase/GeometryTGeo.h"
-#include "ITSSimulation/Detector.h"
 
 #include <fairlogger/Logger.h> // for LOG
 
@@ -89,7 +88,7 @@ ClassImp(V1Layer);
 #define SQ(A) (A) * (A)
 
 V1Layer::V1Layer()
-  : V11Geometry(),
+  : V11Geometry(0, "ITS"),
     mLayerNumber(0),
     mPhi0(0),
     mLayerRadius(0),
@@ -104,15 +103,15 @@ V1Layer::V1Layer()
     mChipTypeID(0),
     mIsTurbo(false),
     mBuildLevel(0),
-    mStaveModel(Detector::kIBModelDummy)
+    mStaveModel(kIBModelDummy)
 {
   for (int i = kNHLevels; i--;) {
     mHierarchy[i] = 0;
   }
 }
 
-V1Layer::V1Layer(Int_t debug)
-  : V11Geometry(debug),
+V1Layer::V1Layer(Int_t debug, const char* name)
+  : V11Geometry(debug, name),
     mLayerNumber(0),
     mPhi0(0),
     mLayerRadius(0),
@@ -127,15 +126,15 @@ V1Layer::V1Layer(Int_t debug)
     mChipTypeID(0),
     mIsTurbo(false),
     mBuildLevel(0),
-    mStaveModel(Detector::kIBModelDummy)
+    mStaveModel(kIBModelDummy)
 {
   for (int i = kNHLevels; i--;) {
     mHierarchy[i] = 0;
   }
 }
 
-V1Layer::V1Layer(Int_t lay, Int_t debug)
-  : V11Geometry(debug),
+V1Layer::V1Layer(Int_t lay, Int_t debug, const char* name)
+  : V11Geometry(debug, name),
     mLayerNumber(lay),
     mPhi0(0),
     mLayerRadius(0),
@@ -150,15 +149,15 @@ V1Layer::V1Layer(Int_t lay, Int_t debug)
     mChipTypeID(0),
     mIsTurbo(false),
     mBuildLevel(0),
-    mStaveModel(Detector::kIBModelDummy)
+    mStaveModel(kIBModelDummy)
 {
   for (int i = kNHLevels; i--;) {
     mHierarchy[i] = 0;
   }
 }
 
-V1Layer::V1Layer(Int_t lay, Bool_t turbo, Int_t debug)
-  : V11Geometry(debug),
+V1Layer::V1Layer(Int_t lay, Bool_t turbo, Int_t debug, const char* name)
+  : V11Geometry(debug, name),
     mLayerNumber(lay),
     mPhi0(0),
     mLayerRadius(0),
@@ -173,7 +172,7 @@ V1Layer::V1Layer(Int_t lay, Bool_t turbo, Int_t debug)
     mChipTypeID(0),
     mIsTurbo(turbo),
     mBuildLevel(0),
-    mStaveModel(Detector::kIBModelDummy)
+    mStaveModel(kIBModelDummy)
 {
   for (int i = kNHLevels; i--;) {
     mHierarchy[i] = 0;
@@ -415,7 +414,7 @@ TGeoVolume* V1Layer::createStave(const TGeoManager* /*mgr*/)
     }
   } else {
     TGeoVolume* hstaveVol = createStaveOuterB();
-    if (mStaveModel == Detector::kOBModel0) { // Create simplified stave struct as in v0
+    if (mStaveModel == kOBModel0) { // Create simplified stave struct as in v0
       staveVol->AddNode(hstaveVol, 0);
       mHierarchy[kHalfStave] = 1;
     } else { // (if mStaveModel) Create new stave struct as in TDR
@@ -453,7 +452,7 @@ TGeoVolume* V1Layer::createStaveInnerB(const Double_t xsta, const Double_t ysta,
 
   auto* hstave = new TGeoBBox(xmod, ymod, zmod);
 
-  TGeoMedium* medAir = mgr->GetMedium("ITS_AIR$");
+  TGeoMedium* medAir = mgr->GetMedium(Form("%s_AIR$", GetDetName()));
 
   snprintf(volumeName, 30, "%s%d", GeometryTGeo::getITSHalfStavePattern(), mLayerNumber);
   auto* hstaveVol = new TGeoVolume(volumeName, hstave, medAir);
@@ -480,7 +479,7 @@ TGeoVolume* V1Layer::createModuleInnerB(Double_t xmod, Double_t ymod, Double_t z
   // Then create the module and populate it with the chips
   auto* module = new TGeoBBox(xmod, ymod, zmod);
 
-  TGeoMedium* medAir = mgr->GetMedium("ITS_AIR$");
+  TGeoMedium* medAir = mgr->GetMedium(Form("%s_AIR$", GetDetName()));
 
   snprintf(volumeName, 30, "%s%d", GeometryTGeo::getITSModulePattern(), mLayerNumber);
   auto* modVol = new TGeoVolume(volumeName, module, medAir);
@@ -501,22 +500,22 @@ TGeoVolume* V1Layer::createStaveStructInnerB(const Double_t xsta, const Double_t
   TGeoVolume* mechStavVol = nullptr;
 
   switch (mStaveModel) {
-    case Detector::kIBModelDummy:
+    case kIBModelDummy:
       mechStavVol = createStaveModelInnerBDummy(xsta, zsta, mgr);
       break;
-    case Detector::kIBModel0:
+    case kIBModel0:
       mechStavVol = createStaveModelInnerB0(xsta, zsta, mgr);
       break;
-    case Detector::kIBModel1:
+    case kIBModel1:
       mechStavVol = createStaveModelInnerB1(xsta, zsta, mgr);
       break;
-    case Detector::kIBModel21:
+    case kIBModel21:
       mechStavVol = createStaveModelInnerB21(xsta, zsta, mgr);
       break;
-    case Detector::kIBModel22:
+    case kIBModel22:
       mechStavVol = createStaveModelInnerB22(xsta, zsta, mgr);
       break;
-    case Detector::kIBModel3:
+    case kIBModel3:
       mechStavVol = createStaveModelInnerB3(xsta, zsta, mgr);
       break;
     default:
@@ -537,13 +536,13 @@ TGeoVolume* V1Layer::createStaveModelInnerB0(const Double_t xsta, const Double_t
                                              const TGeoManager* mgr)
 {
   // Materials defined in Detector
-  TGeoMedium* medAir = mgr->GetMedium("ITS_AIR$");
-  TGeoMedium* medWater = mgr->GetMedium("ITS_WATER$");
+  TGeoMedium* medAir = mgr->GetMedium(Form("%s_AIR$", GetDetName()));
+  TGeoMedium* medWater = mgr->GetMedium(Form("%s_WATER$", GetDetName()));
 
-  TGeoMedium* medM60J3K = mgr->GetMedium("ITS_M60J3K$");
-  TGeoMedium* medKapton = mgr->GetMedium("ITS_KAPTON(POLYCH2)$");
-  TGeoMedium* medGlue = mgr->GetMedium("ITS_GLUE$");
-  TGeoMedium* medFlexCable = mgr->GetMedium("ITS_FLEXCABLE$");
+  TGeoMedium* medM60J3K = mgr->GetMedium(Form("%s_M60J3K$", GetDetName()));
+  TGeoMedium* medKapton = mgr->GetMedium(Form("%s_KAPTON(POLYCH2)$", GetDetName()));
+  TGeoMedium* medGlue = mgr->GetMedium(Form("%s_GLUE$", GetDetName()));
+  TGeoMedium* medFlexCable = mgr->GetMedium(Form("%s_FLEXCABLE$", GetDetName()));
 
   // Local parameters
   Double_t kConeOutRadius = 0.15 / 2;
@@ -575,7 +574,6 @@ TGeoVolume* V1Layer::createStaveModelInnerB0(const Double_t xsta, const Double_t
   TGeoVolume* mechStavVol = nullptr;
 
   if (mBuildLevel < 5) {
-
     // world (trapezoid)
     auto* mechStruct = new TGeoXtru(2); // z sections
     Double_t xv[5] = {
@@ -728,13 +726,13 @@ TGeoVolume* V1Layer::createStaveModelInnerB1(const Double_t xsta, const Double_t
                                              const TGeoManager* mgr)
 {
   // Materials defined in Detector
-  TGeoMedium* medAir = mgr->GetMedium("ITS_AIR$");
-  TGeoMedium* medWater = mgr->GetMedium("ITS_WATER$");
+  TGeoMedium* medAir = mgr->GetMedium(Form("%s_AIR$", GetDetName()));
+  TGeoMedium* medWater = mgr->GetMedium(Form("%s_WATER$", GetDetName()));
 
-  TGeoMedium* medM60J3K = mgr->GetMedium("ITS_M60J3K$");
-  TGeoMedium* medKapton = mgr->GetMedium("ITS_KAPTON(POLYCH2)$");
-  TGeoMedium* medGlue = mgr->GetMedium("ITS_GLUE$");
-  TGeoMedium* medFlexCable = mgr->GetMedium("ITS_FLEXCABLE$");
+  TGeoMedium* medM60J3K = mgr->GetMedium(Form("%s_M60J3K$", GetDetName()));
+  TGeoMedium* medKapton = mgr->GetMedium(Form("%s_KAPTON(POLYCH2)$", GetDetName()));
+  TGeoMedium* medGlue = mgr->GetMedium(Form("%s_GLUE$", GetDetName()));
+  TGeoMedium* medFlexCable = mgr->GetMedium(Form("%s_FLEXCABLE$", GetDetName()));
 
   // Local parameters
   Double_t kConeOutRadius = 0.15 / 2;
@@ -932,16 +930,16 @@ TGeoVolume* V1Layer::createStaveModelInnerB21(const Double_t xsta, const Double_
                                               const TGeoManager* mgr)
 {
   // Materials defined in Detector
-  TGeoMedium* medAir = mgr->GetMedium("ITS_AIR$");
-  TGeoMedium* medWater = mgr->GetMedium("ITS_WATER$");
+  TGeoMedium* medAir = mgr->GetMedium(Form("%s_AIR$", GetDetName()));
+  TGeoMedium* medWater = mgr->GetMedium(Form("%s_WATER$", GetDetName()));
 
-  TGeoMedium* medM60J3K = mgr->GetMedium("ITS_M60J3K$");
-  TGeoMedium* medKapton = mgr->GetMedium("ITS_KAPTON(POLYCH2)$");
-  TGeoMedium* medGlue = mgr->GetMedium("ITS_GLUE$");
-  TGeoMedium* medFlexCable = mgr->GetMedium("ITS_FLEXCABLE$");
-  TGeoMedium* medK13D2U2k = mgr->GetMedium("ITS_K13D2U2k$");
-  TGeoMedium* medFGS003 = mgr->GetMedium("ITS_FGS003$");
-  TGeoMedium* medCarbonFleece = mgr->GetMedium("ITS_CarbonFleece$");
+  TGeoMedium* medM60J3K = mgr->GetMedium(Form("%s_M60J3K$", GetDetName()));
+  TGeoMedium* medKapton = mgr->GetMedium(Form("%s_KAPTON(POLYCH2)$", GetDetName()));
+  TGeoMedium* medGlue = mgr->GetMedium(Form("%s_GLUE$", GetDetName()));
+  TGeoMedium* medFlexCable = mgr->GetMedium(Form("%s_FLEXCABLE$", GetDetName()));
+  TGeoMedium* medK13D2U2k = mgr->GetMedium(Form("%s_K13D2U2k$", GetDetName()));
+  TGeoMedium* medFGS003 = mgr->GetMedium(Form("%s_FGS003$", GetDetName()));
+  TGeoMedium* medCarbonFleece = mgr->GetMedium(Form("%s_CarbonFleece$", GetDetName()));
 
   // Local parameters
   Double_t kConeOutRadius = 0.151384 / 2;
@@ -1212,16 +1210,16 @@ TGeoVolume* V1Layer::createStaveModelInnerB22(const Double_t xsta, const Double_
                                               const TGeoManager* mgr)
 {
   // Materials defined in Detector
-  TGeoMedium* medAir = mgr->GetMedium("ITS_AIR$");
-  TGeoMedium* medWater = mgr->GetMedium("ITS_WATER$");
+  TGeoMedium* medAir = mgr->GetMedium(Form("%s_AIR$", GetDetName()));
+  TGeoMedium* medWater = mgr->GetMedium(Form("%s_WATER$", GetDetName()));
 
-  TGeoMedium* medM60J3K = mgr->GetMedium("ITS_M60J3K$");
-  TGeoMedium* medKapton = mgr->GetMedium("ITS_KAPTON(POLYCH2)$");
-  TGeoMedium* medGlue = mgr->GetMedium("ITS_GLUE$");
-  TGeoMedium* medFlexCable = mgr->GetMedium("ITS_FLEXCABLE$");
-  TGeoMedium* medK13D2U2k = mgr->GetMedium("ITS_K13D2U2k$");
-  TGeoMedium* medFGS003 = mgr->GetMedium("ITS_FGS003$");
-  TGeoMedium* medCarbonFleece = mgr->GetMedium("ITS_CarbonFleece$");
+  TGeoMedium* medM60J3K = mgr->GetMedium(Form("%s_M60J3K$", GetDetName()));
+  TGeoMedium* medKapton = mgr->GetMedium(Form("%s_KAPTON(POLYCH2)$", GetDetName()));
+  TGeoMedium* medGlue = mgr->GetMedium(Form("%s_GLUE$", GetDetName()));
+  TGeoMedium* medFlexCable = mgr->GetMedium(Form("%s_FLEXCABLE$", GetDetName()));
+  TGeoMedium* medK13D2U2k = mgr->GetMedium(Form("%s_K13D2U2k$", GetDetName()));
+  TGeoMedium* medFGS003 = mgr->GetMedium(Form("%s_FGS003$", GetDetName()));
+  TGeoMedium* medCarbonFleece = mgr->GetMedium(Form("%s_CarbonFleece$", GetDetName()));
 
   // Local parameters
   Double_t kConeOutRadius = (0.1024 + 0.0025) / 2; // 0.107/2;
@@ -1518,16 +1516,16 @@ TGeoVolume* V1Layer::createStaveModelInnerB3(const Double_t xsta, const Double_t
                                              const TGeoManager* mgr)
 {
   // Materials defined in Detector
-  TGeoMedium* medAir = mgr->GetMedium("ITS_AIR$");
-  TGeoMedium* medWater = mgr->GetMedium("ITS_WATER$");
+  TGeoMedium* medAir = mgr->GetMedium(Form("%s_AIR$", GetDetName()));
+  TGeoMedium* medWater = mgr->GetMedium(Form("%s_WATER$", GetDetName()));
 
-  TGeoMedium* medM60J3K = mgr->GetMedium("ITS_M60J3K$");
-  TGeoMedium* medKapton = mgr->GetMedium("ITS_KAPTON(POLYCH2)$");
-  TGeoMedium* medGlue = mgr->GetMedium("ITS_GLUE$");
-  TGeoMedium* medFlexCable = mgr->GetMedium("ITS_FLEXCABLE$");
-  // TGeoMedium *medK13D2U2k  = mgr->GetMedium("ITS_K13D2U2k$");
-  // TGeoMedium *medFGS003    = mgr->GetMedium("ITS_FGS003$");
-  // TGeoMedium *medCarbonFleece = mgr->GetMedium("ITS_CarbonFleece$");
+  TGeoMedium* medM60J3K = mgr->GetMedium(Form("%s_M60J3K$", GetDetName()));
+  TGeoMedium* medKapton = mgr->GetMedium(Form("%s_KAPTON(POLYCH2)$", GetDetName()));
+  TGeoMedium* medGlue = mgr->GetMedium(Form("%s_GLUE$", GetDetName()));
+  TGeoMedium* medFlexCable = mgr->GetMedium(Form("%s_FLEXCABLE$", GetDetName()));
+  // TGeoMedium *medK13D2U2k  = mgr->GetMedium(Form("%s_K13D2U2k$", GetDetName()));
+  // TGeoMedium *medFGS003    = mgr->GetMedium(Form("%s_FGS003$", GetDetName()));
+  // TGeoMedium *medCarbonFleece = mgr->GetMedium(Form("%s_CarbonFleece$", GetDetName()));
 
   // Local parameters
   Double_t kConeOutRadius = 0.15 / 2;
@@ -1943,13 +1941,13 @@ TGeoVolume* V1Layer::createStaveOuterB(const TGeoManager* mgr)
   TGeoVolume* mechStavVol = nullptr;
 
   switch (mStaveModel) {
-    case Detector::kOBModelDummy:
+    case kOBModelDummy:
       mechStavVol = createStaveModelOuterBDummy(mgr);
       break;
-    case Detector::kOBModel0:
+    case kOBModel0:
       mechStavVol = createStaveModelOuterB0(mgr);
       break;
-    case Detector::kOBModel1:
+    case kOBModel1:
       mechStavVol = createStaveModelOuterB1(mgr);
       break;
     default:
@@ -1990,7 +1988,7 @@ TGeoVolume* V1Layer::createStaveModelOuterB0(const TGeoManager* mgr)
   auto* hstave = new TGeoBBox(xlen, ylen, zlen / 2);
 
   // We have all shapes: now create the real volumes
-  TGeoMedium* medAir = mgr->GetMedium("ITS_AIR$");
+  TGeoMedium* medAir = mgr->GetMedium(Form("%s_AIR$", GetDetName()));
 
   snprintf(volumeName, 30, "%s%d", GeometryTGeo::getITSModulePattern(), mLayerNumber);
   auto* modVol = new TGeoVolume(volumeName, module, medAir);
@@ -2100,13 +2098,13 @@ TGeoVolume* V1Layer::createStaveModelOuterB1(const TGeoManager* mgr)
 
   // We have all shapes: now create the real volumes
 
-  TGeoMedium* medAluminum = mgr->GetMedium("ITS_ALUMINUM$");
-  TGeoMedium* medCarbon = mgr->GetMedium("ITS_CARBON$");
-  TGeoMedium* medKapton = mgr->GetMedium("ITS_KAPTON(POLYCH2)$");
-  TGeoMedium* medWater = mgr->GetMedium("ITS_WATER$");
-  TGeoMedium* medCarbonFleece = mgr->GetMedium("ITS_CarbonFleece$");
-  TGeoMedium* medFGS003 = mgr->GetMedium("ITS_FGS003$"); // amec thermasol
-  TGeoMedium* medAir = mgr->GetMedium("ITS_AIR$");
+  TGeoMedium* medAluminum = mgr->GetMedium(Form("%s_ALUMINUM$", GetDetName()));
+  TGeoMedium* medCarbon = mgr->GetMedium(Form("%s_CARBON$", GetDetName()));
+  TGeoMedium* medKapton = mgr->GetMedium(Form("%s_KAPTON(POLYCH2)$", GetDetName()));
+  TGeoMedium* medWater = mgr->GetMedium(Form("%s_WATER$", GetDetName()));
+  TGeoMedium* medCarbonFleece = mgr->GetMedium(Form("%s_CarbonFleece$", GetDetName()));
+  TGeoMedium* medFGS003 = mgr->GetMedium(Form("%s_FGS003$", GetDetName())); // amec thermasol
+  TGeoMedium* medAir = mgr->GetMedium(Form("%s_AIR$", GetDetName()));
 
   auto* busAlVol = new TGeoVolume("BusAlVol", busAl, medAluminum);
   busAlVol->SetLineColor(kCyan);
@@ -2295,11 +2293,11 @@ TGeoVolume* V1Layer::createSpaceFrameOuterB(const TGeoManager* mgr)
   TGeoVolume* mechStavVol = nullptr;
 
   switch (mStaveModel) {
-    case Detector::kOBModelDummy:
-    case Detector::kOBModel0:
+    case kOBModelDummy:
+    case kOBModel0:
       mechStavVol = createSpaceFrameOuterBDummy(mgr);
       break;
-    case Detector::kOBModel1:
+    case kOBModel1:
       mechStavVol = createSpaceFrameOuterB1(mgr);
       break;
     default:
@@ -2319,8 +2317,8 @@ TGeoVolume* V1Layer::createSpaceFrameOuterBDummy(const TGeoManager*) const
 TGeoVolume* V1Layer::createSpaceFrameOuterB1(const TGeoManager* mgr)
 {
   // Materials defined in Detector
-  TGeoMedium* medCarbon = mgr->GetMedium("ITS_CARBON$");
-  TGeoMedium* medAir = mgr->GetMedium("ITS_AIR$");
+  TGeoMedium* medCarbon = mgr->GetMedium(Form("%s_CARBON$", GetDetName()));
+  TGeoMedium* medAir = mgr->GetMedium(Form("%s_AIR$", GetDetName()));
 
   // Local parameters
   Double_t sframeWidth = sOBSpaceFrameWidth;
@@ -2523,7 +2521,7 @@ TGeoVolume* V1Layer::createChipInnerB(const Double_t xchip, const Double_t ychip
   auto* sensor = new TGeoBBox(xlen, ylen, zlen);
 
   // We have all shapes: now create the real volumes
-  TGeoMedium* medSi = mgr->GetMedium("ITS_SI$");
+  TGeoMedium* medSi = mgr->GetMedium(Form("%s_SI$", GetDetName()));
 
   snprintf(volumeName, 30, "%s%d", GeometryTGeo::getITSChipPattern(), mLayerNumber);
   auto* chipVol = new TGeoVolume(volumeName, chip, medSi);
@@ -2598,11 +2596,11 @@ TGeoVolume* V1Layer::createModuleOuterB(const TGeoManager* mgr)
 
   // We have all shapes: now create the real volumes
 
-  TGeoMedium* medAir = mgr->GetMedium("ITS_AIR$");
-  TGeoMedium* medCarbon = mgr->GetMedium("ITS_CARBON$");
-  TGeoMedium* medGlue = mgr->GetMedium("ITS_GLUE$");
-  TGeoMedium* medAluminum = mgr->GetMedium("ITS_ALUMINUM$");
-  TGeoMedium* medKapton = mgr->GetMedium("ITS_KAPTON(POLYCH2)$");
+  TGeoMedium* medAir = mgr->GetMedium(Form("%s_AIR$", GetDetName()));
+  TGeoMedium* medCarbon = mgr->GetMedium(Form("%s_CARBON$", GetDetName()));
+  TGeoMedium* medGlue = mgr->GetMedium(Form("%s_GLUE$", GetDetName()));
+  TGeoMedium* medAluminum = mgr->GetMedium(Form("%s_ALUMINUM$", GetDetName()));
+  TGeoMedium* medKapton = mgr->GetMedium(Form("%s_KAPTON(POLYCH2)$", GetDetName()));
 
   auto* modPlateVol = new TGeoVolume("CarbonPlateVol", modPlate, medCarbon);
   modPlateVol->SetLineColor(kMagenta - 8);

--- a/Detectors/ITSMFT/ITS/simulation/src/V3Cage.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/V3Cage.cxx
@@ -16,7 +16,6 @@
 #include "ITSSimulation/V3Cage.h"
 #include "ITSSimulation/V11Geometry.h"
 #include "ITSBase/GeometryTGeo.h"
-#include "ITSSimulation/Detector.h"
 
 #include <fairlogger/Logger.h> // for LOG
 
@@ -111,6 +110,11 @@ ClassImp(V3Cage);
 
 V3Cage::V3Cage()
   : V11Geometry()
+{
+}
+
+V3Cage::V3Cage(const char* name)
+  : V11Geometry(0, name)
 {
 }
 
@@ -250,8 +254,8 @@ TGeoVolume* V3Cage::createCageCover(const TGeoManager* mgr)
   TGeoCompositeShape* coverSh = new TGeoCompositeShape("coverSheet-cutFold:cutBox1-cutFold:cutBox2+coverFold+coverFold:rotFold");
 
   // We have all shapes: now create the real volumes
-  TGeoMedium* medRohacell = mgr->GetMedium("ITS_ROHACELL$");
-  TGeoMedium* medPrepreg = mgr->GetMedium("ITS_M46J6K$");
+  TGeoMedium* medRohacell = mgr->GetMedium(Form("%s_ROHACELL$", GetDetName()));
+  TGeoMedium* medPrepreg = mgr->GetMedium(Form("%s_M46J6K$", GetDetName()));
 
   TGeoVolume* coverVol = new TGeoVolume("CageCover", coverSh, medPrepreg);
   coverVol->SetFillColor(kBlue);
@@ -318,7 +322,7 @@ TGeoVolume* V3Cage::createCageCoverRib(const TGeoManager* mgr)
   TGeoCompositeShape* ribSh = new TGeoCompositeShape("coverRibMain+coverRibFold+coverRibFold:rotRibFold");
 
   // We have all shapes: now create the real volume
-  TGeoMedium* medAl = mgr->GetMedium("ITS_ALUMINUM$");
+  TGeoMedium* medAl = mgr->GetMedium(Form("%s_ALUMINUM$", GetDetName()));
 
   TGeoVolume* ribVol = new TGeoVolume("CageCoverRib", ribSh, medAl);
   ribVol->SetFillColor(kGray);
@@ -401,9 +405,9 @@ TGeoVolume* V3Cage::createCageSidePanel(const TGeoManager* mgr)
   TGeoCompositeShape* guideSh = new TGeoCompositeShape("guidevert+guidehor:guidehormat1+guidehor:guidehormat2");
 
   // We have all shapes: now create the real volume
-  TGeoMedium* medFabric = mgr->GetMedium("ITS_M46J6K$");
-  TGeoMedium* medFoam = mgr->GetMedium("ITS_ROHACELL$");
-  TGeoMedium* medAlAlloy = mgr->GetMedium("ITS_ENAW7075$");
+  TGeoMedium* medFabric = mgr->GetMedium(Form("%s_M46J6K$", GetDetName()));
+  TGeoMedium* medFoam = mgr->GetMedium(Form("%s_ROHACELL$", GetDetName()));
+  TGeoMedium* medAlAlloy = mgr->GetMedium(Form("%s_ENAW7075$", GetDetName()));
 
   TGeoVolume* inFoilVol = new TGeoVolume("CageSidePanelInFoil", inFoilSh, medFabric);
   inFoilVol->SetFillColor(kBlue);
@@ -738,9 +742,9 @@ TGeoVolume* V3Cage::createCageEndCap(const TGeoManager* mgr)
   TGeoCompositeShape* cblCrosSh = createCageEndCapCableCross(mgr);
 
   // We have all shapes: now create the real volume
-  TGeoMedium* medFabric = mgr->GetMedium("ITS_M46J6K$");
-  TGeoMedium* medFoam = mgr->GetMedium("ITS_ROHACELL$");
-  TGeoMedium* medAl = mgr->GetMedium("ITS_ALUMINUM$");
+  TGeoMedium* medFabric = mgr->GetMedium(Form("%s_M46J6K$", GetDetName()));
+  TGeoMedium* medFoam = mgr->GetMedium(Form("%s_ROHACELL$", GetDetName()));
+  TGeoMedium* medAl = mgr->GetMedium(Form("%s_ALUMINUM$", GetDetName()));
 
   TGeoVolume* fabVol = new TGeoVolume("CageEndCapFabric", fabricSh, medFabric);
   fabVol->SetFillColor(kBlue);

--- a/Detectors/ITSMFT/ITS/simulation/src/V3Services.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/V3Services.cxx
@@ -17,7 +17,6 @@
 #include "ITSSimulation/V3Services.h"
 #include "ITSSimulation/V11Geometry.h"
 #include "ITSBase/GeometryTGeo.h"
-#include "ITSSimulation/Detector.h"
 #include "ITSMFTSimulation/AlpideChip.h"
 
 #include <fairlogger/Logger.h> // for LOG
@@ -57,6 +56,11 @@ ClassImp(V3Services);
 
 V3Services::V3Services()
   : V11Geometry()
+{
+}
+
+V3Services::V3Services(const char* name)
+  : V11Geometry(0, name)
 {
 }
 
@@ -555,8 +559,8 @@ void V3Services::ibEndWheelSideA(const Int_t iLay, TGeoVolume* endWheel, const T
   TGeoCompositeShape* stepASh = new TGeoCompositeShape(Form("stepBoxASh%d:stepBoxATr%d-stepPconASh%d", iLay, iLay, iLay));
 
   // We have all shapes: now create the real volumes
-  TGeoMedium* medCarbon = mgr->GetMedium("ITS_M55J6K$"); // TO BE CHECKED
-  TGeoMedium* medPEEK = mgr->GetMedium("ITS_PEEKCF30$");
+  TGeoMedium* medCarbon = mgr->GetMedium(Form("%s_M55J6K$", GetDetName())); // TO BE CHECKED
+  TGeoMedium* medPEEK = mgr->GetMedium(Form("%s_PEEKCF30$", GetDetName()));
 
   TGeoVolume* coneABasisVol = new TGeoVolume(Form("ConeABasis%d", iLay), coneABasisSh, medCarbon);
   coneABasisVol->SetFillColor(kBlue);
@@ -785,8 +789,8 @@ void V3Services::ibEndWheelSideC(const Int_t iLay, TGeoVolume* endWheel, const T
   TGeoCompositeShape* stepCSh = new TGeoCompositeShape(Form("stepBoxCSh%d:stepBoxCTr%d-stepPconCSh%d", iLay, iLay, iLay));
 
   // We have all shapes: now create the real volumes
-  TGeoMedium* medCarbon = mgr->GetMedium("ITS_M55J6K$"); // TO BE CHECKED
-  TGeoMedium* medPEEK = mgr->GetMedium("ITS_PEEKCF30$");
+  TGeoMedium* medCarbon = mgr->GetMedium(Form("%s_M55J6K$", GetDetName())); // TO BE CHECKED
+  TGeoMedium* medPEEK = mgr->GetMedium(Form("%s_PEEKCF30$", GetDetName()));
 
   TGeoVolume* endWheelCVol = new TGeoVolume(Form("EndWheelCBasis%d", iLay), endWheelCSh, medCarbon);
   endWheelCVol->SetFillColor(kBlue);
@@ -925,8 +929,8 @@ TGeoVolume* V3Services::ibCyssCylinder(const TGeoManager* mgr)
   TGeoTubeSeg* cyssInnerCylSh = new TGeoTubeSeg(rmin, rmax, zlen, phimin, phimax);
 
   // We have all shapes: now create the real volumes
-  TGeoMedium* medPrepreg = mgr->GetMedium("ITS_F6151B05M$");
-  TGeoMedium* medRohacell = mgr->GetMedium("ITS_ROHACELL$");
+  TGeoMedium* medPrepreg = mgr->GetMedium(Form("%s_F6151B05M$", GetDetName()));
+  TGeoMedium* medRohacell = mgr->GetMedium(Form("%s_ROHACELL$", GetDetName()));
 
   TGeoVolume* cyssOuterCylVol = new TGeoVolume("IBCYSSCylinder", cyssOuterCylSh, medPrepreg);
   cyssOuterCylVol->SetLineColor(35);
@@ -1047,8 +1051,8 @@ TGeoVolume* V3Services::ibCyssCone(const TGeoManager* mgr)
   cyssConeFoamSh->DefineSection(4, zlen1, rmin, rmax);
 
   // We have all shapes: now create the real volumes
-  TGeoMedium* medPrepreg = mgr->GetMedium("ITS_F6151B05M$");
-  TGeoMedium* medRohacell = mgr->GetMedium("ITS_ROHACELL$");
+  TGeoMedium* medPrepreg = mgr->GetMedium(Form("%s_F6151B05M$", GetDetName()));
+  TGeoMedium* medRohacell = mgr->GetMedium(Form("%s_ROHACELL$", GetDetName()));
 
   TGeoVolume* cyssConeVol = new TGeoVolume("IBCYSSCone", cyssConeSh, medPrepreg);
   cyssConeVol->SetLineColor(35);
@@ -1262,7 +1266,7 @@ TGeoVolume* V3Services::ibCyssFlangeSideA(const TGeoManager* mgr)
   TGeoCompositeShape* cyssFlangeASh = new TGeoCompositeShape(cyssFlangeAComposite.Data());
 
   // We have all shapes: now create the real volumes
-  TGeoMedium* medAlu = mgr->GetMedium("ITS_ALUMINUM$");
+  TGeoMedium* medAlu = mgr->GetMedium(Form("%s_ALUMINUM$", GetDetName()));
 
   TGeoVolume* cyssFlangeAVol = new TGeoVolume("IBCYSSFlangeA", cyssFlangeASh, medAlu);
   cyssFlangeAVol->SetLineColor(kCyan);
@@ -1579,7 +1583,7 @@ TGeoVolume* V3Services::ibCyssFlangeSideC(const TGeoManager* mgr)
   TGeoCompositeShape* cyssFlangeCSh = new TGeoCompositeShape(cyssFlangeCComposite.Data());
 
   // We have all shapes: now create the real volumes
-  TGeoMedium* medAlu = mgr->GetMedium("ITS_ALUMINUM$");
+  TGeoMedium* medAlu = mgr->GetMedium(Form("%s_ALUMINUM$", GetDetName()));
 
   TGeoVolume* cyssFlangeCVol = new TGeoVolume("IBCYSSFlangeC", cyssFlangeCSh, medAlu);
   cyssFlangeCVol->SetLineColor(kCyan);
@@ -1657,7 +1661,7 @@ void V3Services::obEndWheelSideA(const Int_t iLay, TGeoVolume* mother, const TGe
   TGeoBBox* shelfSh = new TGeoBBox(xlen / 2, ylen / 2, zlen / 2);
 
   // We have all shapes: now create the real volumes
-  TGeoMedium* medCarbon = mgr->GetMedium("ITS_M55J6K$"); // TO BE CHECKED
+  TGeoMedium* medCarbon = mgr->GetMedium(Form("%s_M55J6K$", GetDetName())); // TO BE CHECKED
 
   Int_t nLay = iLay + sNumberInnerLayers;
 
@@ -1821,7 +1825,7 @@ void V3Services::mbEndWheelSideC(const Int_t iLay, TGeoVolume* mother, const TGe
   TGeoBBox* shelfSh = new TGeoBBox(xlen / 2, ylen / 2, zlen / 2);
 
   // We have all shapes: now create the real volumes
-  TGeoMedium* medCarbon = mgr->GetMedium("ITS_M55J6K$"); // TO BE CHECKED
+  TGeoMedium* medCarbon = mgr->GetMedium(Form("%s_M55J6K$", GetDetName())); // TO BE CHECKED
 
   Int_t nLay = iLay + sNumberInnerLayers;
 
@@ -1988,7 +1992,7 @@ void V3Services::obEndWheelSideC(const Int_t iLay, TGeoVolume* mother, const TGe
   }
 
   // We have all shapes: now create the real volumes
-  TGeoMedium* medCarbon = mgr->GetMedium("ITS_M55J6K$"); // TO BE CHECKED
+  TGeoMedium* medCarbon = mgr->GetMedium(Form("%s_M55J6K$", GetDetName())); // TO BE CHECKED
 
   Int_t nLay = iLay + sNumberInnerLayers + sNumberMiddlLayers;
 
@@ -2128,7 +2132,7 @@ void V3Services::obConeSideA(TGeoVolume* mother, const TGeoManager* mgr)
   obConeRibSh->DefineSection(1, sOBConeAThickAll);
 
   // We have all shapes: now create the real volumes
-  TGeoMedium* medCarbon = mgr->GetMedium("ITS_M55J6K$"); // TO BE CHECKED
+  TGeoMedium* medCarbon = mgr->GetMedium(Form("%s_M55J6K$", GetDetName())); // TO BE CHECKED
 
   TGeoVolume* obConeVol = new TGeoVolume("OBConeSideA", obConeSh, medCarbon);
   obConeVol->SetFillColor(kBlue);
@@ -2226,7 +2230,7 @@ void V3Services::obConeTraysSideA(TGeoVolume* mother, const TGeoManager* mgr)
   } // for (j = 0,1)
 
   // We have all shapes: now create the real volumes
-  TGeoMedium* medCarbon = mgr->GetMedium("ITS_M55J6K$"); // TO BE CHECKED
+  TGeoMedium* medCarbon = mgr->GetMedium(Form("%s_M55J6K$", GetDetName())); // TO BE CHECKED
 
   TGeoVolume *obTrayVol[2], *obTrayRibVol[2];
 
@@ -2380,7 +2384,7 @@ void V3Services::obConeSideC(TGeoVolume* mother, const TGeoManager* mgr)
   obConeRibSh->DefineSection(1, sOBConeCThickAll);
 
   // We have all shapes: now create the real volumes
-  TGeoMedium* medCarbon = mgr->GetMedium("ITS_M55J6K$"); // TO BE CHECKED
+  TGeoMedium* medCarbon = mgr->GetMedium(Form("%s_M55J6K$", GetDetName())); // TO BE CHECKED
 
   TGeoVolume* obConeVol = new TGeoVolume("OBConeSideC", obConeSh, medCarbon);
   obConeVol->SetFillColor(kBlue);
@@ -2495,7 +2499,7 @@ void V3Services::obCYSS11(TGeoVolume* mother, const TGeoManager* mgr)
   TGeoBBox* obCyss20Sh = new TGeoBBox(sOBCYSS20Width / 2, sOBCYSS20Height / 2, sOBCYSS20Zlen / 2);
 
   // We have all shapes: now create the real volumes
-  TGeoMedium* medCarbon = mgr->GetMedium("ITS_M55J6K$"); // TO BE CHECKED
+  TGeoMedium* medCarbon = mgr->GetMedium(Form("%s_M55J6K$", GetDetName())); // TO BE CHECKED
 
   TGeoVolume* obCyss14Vol = new TGeoVolume("OBCYSS14", obCyss14Sh, medCarbon);
   obCyss14Vol->SetFillColor(kBlue);
@@ -2592,8 +2596,8 @@ void V3Services::ibConvWire(TGeoVolume* mother, const TGeoManager* mgr)
   TGeoCompositeShape* ibWireOutSuppSh = ibConvWireOutSupport();
 
   // We have all shapes: now create the real volumes
-  TGeoMedium* medAl = mgr->GetMedium("ITS_ALUMINUM$");
-  TGeoMedium* medTungsten = mgr->GetMedium("ITS_TUNGSTEN$");
+  TGeoMedium* medAl = mgr->GetMedium(Form("%s_ALUMINUM$", GetDetName()));
+  TGeoMedium* medTungsten = mgr->GetMedium(Form("%s_TUNGSTEN$", GetDetName()));
 
   TGeoVolume* ibWireVol = new TGeoVolume("IBGammaConvWire", ibWireSh, medTungsten);
   ibWireVol->SetFillColor(kGray);
@@ -3021,9 +3025,9 @@ void V3Services::obConvWire(TGeoVolume* mother, const TGeoManager* mgr)
   TGeoTube* obWireScrewSh = new TGeoTube(0, sOBGWireScrewDout / 2, sOBGWireScrewLen / 2);
 
   // We have all shapes: now create the real volumes
-  TGeoMedium* medTungsten = mgr->GetMedium("ITS_TUNGSTEN$");
-  TGeoMedium* medTitanium = mgr->GetMedium("ITS_TITANIUM$");
-  TGeoMedium* medBrass = mgr->GetMedium("ITS_BRASS$");
+  TGeoMedium* medTungsten = mgr->GetMedium(Form("%s_TUNGSTEN$", GetDetName()));
+  TGeoMedium* medTitanium = mgr->GetMedium(Form("%s_TITANIUM$", GetDetName()));
+  TGeoMedium* medBrass = mgr->GetMedium(Form("%s_BRASS$", GetDetName()));
 
   TGeoVolume* obWireVol = new TGeoVolume("OBGammaConvWire", obWireSh, medTungsten);
   obWireVol->SetFillColor(kGray);

--- a/Detectors/Upgrades/IT3/simulation/include/ITS3Simulation/DescriptorInnerBarrelITS3.h
+++ b/Detectors/Upgrades/IT3/simulation/include/ITS3Simulation/DescriptorInnerBarrelITS3.h
@@ -1,0 +1,59 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file DescriptorInnerBarrelITS3.h
+/// \brief Definition of the DescriptorInnerBarrelITS3 class
+
+#ifndef ALICEO2_ITS3_DESCRIPTORINNERBARRELITS3_H
+#define ALICEO2_ITS3_DESCRIPTORINNERBARRELITS3_H
+
+#include <string>
+#include <vector>
+#include <TObject.h>
+
+#include "ITSBase/DescriptorInnerBarrel.h"
+
+namespace o2
+{
+namespace its3 // to be decided
+{
+class DescriptorInnerBarrelITS3 : public o2::its::DescriptorInnerBarrel // could inherit from DescriptorInnerBarrel in the future
+{
+ public:
+  // default constructor
+  DescriptorInnerBarrelITS3() {}
+  // standard constructor
+  DescriptorInnerBarrelITS3(int nlayers);
+
+  /// Default destructor
+  ~DescriptorInnerBarrelITS3() {}
+
+  DescriptorInnerBarrelITS3(const DescriptorInnerBarrelITS3& src) = delete;
+  DescriptorInnerBarrelITS3& operator=(const DescriptorInnerBarrelITS3& geom) = delete;
+
+  void ConfigureITS3();
+  void GetConfigurationLayers(std::vector<double>& radii,
+                              std::vector<double>& zlen,
+                              std::vector<double>& thickness,
+                              std::vector<int>& chipID,
+                              std::vector<int>& buildlev);
+
+  //  private:
+  //   // sensor properties
+
+  /// \cond CLASSIMP
+  ClassDef(DescriptorInnerBarrelITS3, 1); /// ITS inner barrel geometry descriptor
+  /// \endcond
+};
+} // namespace its3
+} // namespace o2
+
+#endif

--- a/Detectors/Upgrades/IT3/simulation/src/DescriptorInnerBarrelITS3.cxx
+++ b/Detectors/Upgrades/IT3/simulation/src/DescriptorInnerBarrelITS3.cxx
@@ -1,0 +1,86 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "FairDetector.h"      // for FairDetector
+#include <fairlogger/Logger.h> // for LOG, LOG_IF
+#include "FairRootManager.h"   // for FairRootManager
+#include "FairRun.h"           // for FairRun
+#include "FairRuntimeDb.h"     // for FairRuntimeDb
+#include "FairVolume.h"        // for FairVolume
+#include "FairRootManager.h"
+
+#include "TGeoManager.h"     // for TGeoManager, gGeoManager
+#include "TGeoTube.h"        // for TGeoTube
+#include "TGeoPcon.h"        // for TGeoPcon
+#include "TGeoVolume.h"      // for TGeoVolume, TGeoVolumeAssembly
+#include "TString.h"         // for TString, operator+
+#include "TVirtualMC.h"      // for gMC, TVirtualMC
+#include "TVirtualMCStack.h" // for TVirtualMCStack
+
+#include "ITS3Simulation/DescriptorInnerBarrelITS3.h"
+
+using namespace o2::its;
+using namespace o2::its3;
+
+/// \cond CLASSIMP
+ClassImp(DescriptorInnerBarrelITS3);
+/// \endcond
+
+//________________________________________________________________
+DescriptorInnerBarrelITS3::DescriptorInnerBarrelITS3(int nlayers) : DescriptorInnerBarrel(nlayers)
+{
+  //
+  // Standard constructor
+  //
+
+  fSensorLayerThickness = 30.e-4;
+}
+
+//________________________________________________________________
+void DescriptorInnerBarrelITS3::ConfigureITS3()
+{
+  // build ITS3 upgrade detector
+  fLayerRadii.resize(fNumLayers);
+  fLayerZLen.resize(fNumLayers);
+  fDetectorThickness.resize(fNumLayers);
+  fChipTypeID.resize(fNumLayers);
+  fBuildLevel.resize(fNumLayers);
+
+  std::vector<std::array<double, 2>> IBtdr5dat; // 18 24
+  IBtdr5dat.emplace_back(std::array<double, 2>{1.8f, 27.15});
+  IBtdr5dat.emplace_back(std::array<double, 2>{2.4f, 27.15});
+  IBtdr5dat.emplace_back(std::array<double, 2>{3.0f, 27.15});
+  if (fNumLayers == 4)
+    IBtdr5dat.emplace_back(std::array<double, 2>{7.0f, 27.15});
+
+  const double safety = 0.5;
+  fWrapperMinRadius = IBtdr5dat[0][0] - safety;
+  fWrapperMaxRadius = IBtdr5dat[fNumLayers - 1][0] + safety;
+  fWrapperZSpan = 70.;
+
+  for (auto idLayer{0u}; idLayer < IBtdr5dat.size(); ++idLayer) {
+    fLayerRadii[idLayer] = IBtdr5dat[idLayer][0];
+    fLayerZLen[idLayer] = IBtdr5dat[idLayer][1];
+    fDetectorThickness[idLayer] = fSensorLayerThickness;
+    fChipTypeID[idLayer] = 0;
+    fBuildLevel[idLayer] = 0;
+  }
+}
+
+//________________________________________________________________
+void DescriptorInnerBarrelITS3::GetConfigurationLayers(std::vector<double>& radii, std::vector<double>& zlen, std::vector<double>& thickness, std::vector<int>& chipID, std::vector<int>& buildlev)
+{
+  radii = fLayerRadii;
+  zlen = fLayerZLen;
+  thickness = fDetectorThickness;
+  chipID = fChipTypeID;
+  buildlev = fBuildLevel;
+}


### PR DESCRIPTION
@mconcas this PR factorizes the inner barrel description from the geometry, in order to enable different versions needed for ITS3 studies. I still have to move part of the code from `Detector.cxx` to `DescriptorInnerBarrel.cxx` (such as services, alignment objects), but you can start to have a look and let me know if this makes sense to you. 
I already tested the current version and it gives exactly the same result as the old implementation.
