### PR TITLE
MCH: add some missing include guards

### DIFF
--- a/Detectors/MUON/MCH/Base/include/MCHBase/SanityCheck.h
+++ b/Detectors/MUON/MCH/Base/include/MCHBase/SanityCheck.h
@@ -9,6 +9,9 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#ifndef O2_MCH_BASE_SANITY_CHECK_H
+#define O2_MCH_BASE_SANITY_CHECK_H
+
 #include "DataFormatsMCH/ROFRecord.h"
 #include "Framework/Logger.h"
 #include <gsl/span>
@@ -81,3 +84,5 @@ SanityError sanityCheck(gsl::span<const ROFRecord> rofs, gsl::span<const T> item
   return error;
 }
 } // namespace o2::mch
+
+#endif

--- a/Detectors/MUON/MCH/Constants/include/MCHConstants/DetectionElements.h
+++ b/Detectors/MUON/MCH/Constants/include/MCHConstants/DetectionElements.h
@@ -9,6 +9,9 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#ifndef O2_MCH_CONSTANTS_DETECTION_ELEMENTS_H
+#define O2_MCH_CONSTANTS_DETECTION_ELEMENTS_H
+
 #include <array>
 #include <algorithm>
 
@@ -32,3 +35,5 @@ inline bool isValidDetElemId(int deId)
   return std::find(begin(deIdsForAllMCH), end(deIdsForAllMCH), deId) != deIdsForAllMCH.end();
 }
 } // namespace o2::mch::constants
+
+#endif

--- a/Detectors/MUON/MCH/Mapping/test/src/InputDocument.h
+++ b/Detectors/MUON/MCH/Mapping/test/src/InputDocument.h
@@ -9,6 +9,9 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#ifndef O2_MCH_MAPPING_TEST_INPUT_DOCUMENT_H
+#define O2_MCH_MAPPING_TEST_INPUT_DOCUMENT_H
+
 #include <rapidjson/document.h>
 #include <cstdio>
 #include <rapidjson/filereadstream.h>
@@ -42,3 +45,5 @@ class InputDocument
 };
 
 using InputWrapper = InputDocument<rapidjson::FileReadStream>;
+
+#endif

--- a/Detectors/MUON/MCH/Raw/Decoder/src/Debug.h
+++ b/Detectors/MUON/MCH/Raw/Decoder/src/Debug.h
@@ -9,4 +9,9 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#ifndef O2_MCH_RAW_DECODER_DEBUG_H
+#define O2_MCH_RAW_DECODER_DEBUG_H
+
 //#define ULDEBUG
+
+#endif


### PR DESCRIPTION
Spotted one by chance and the others using : 

```
find Detectors/MUON/MCH -name '*.h' -exec grep -L "#ifndef O2_" {} \; | grep -v LinkDef
```