### PR TITLE
Always do renorming of the 1st setting of VDrift

### DIFF
--- a/Detectors/TPC/calibration/include/TPCCalibration/VDriftHelper.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/VDriftHelper.h
@@ -66,7 +66,7 @@ class VDriftHelper
   VDriftCorrFact mVD{};
   Source mSource{};       // update source
   bool mUpdated = false;  // signal update, must be reset once new value is fetched
-  bool mMayRenorm = true; // if starting VDrift correction != 1, we will renorm reference in such a way that initial correction is 1.0
+  uint32_t mMayRenormSrc = 0xffffffff; // if starting VDrift correction != 1, we will renorm reference in such a way that initial correction is 1.0, flag per source
 
   ClassDefNV(VDriftHelper, 1);
 };

--- a/Detectors/TPC/calibration/src/VDriftHelper.cxx
+++ b/Detectors/TPC/calibration/src/VDriftHelper.cxx
@@ -61,13 +61,13 @@ void VDriftHelper::accountLaserCalibration(const LtrCalibData* calib, long fallB
     mVD.corrFact = 1. / corr;
     mUpdated = true;
     mSource = Source::Laser;
-    if (mMayRenorm) {    // this was 1st setting?
+    if (mMayRenormSrc & (0x1U << Source::Laser)) { // this was 1st setting?
       if (corr != 1.f) { // this may happen if old-style (non-normalized) standalone or non-normalized run-time laset calibration is used
         LOGP(warn, "VDriftHelper: renorming initinal TPC refVDrift={}/correction={} to {}/1.0, source: {}", mVD.refVDrift, mVD.corrFact, mVD.getVDrift(), getSourceName());
         mVD.normalize(); // renorm reference to have correction = 1.
       }
-      mMayRenorm = false;
-    } else if (ref != prevRef) { // we want to keep the same reference over the run, this may happen if run-time laser calibration is supplied
+      mMayRenormSrc &= ~(0x1U << Source::Laser); // unset MayRenorm
+    } else if (ref != prevRef) {                 // we want to keep the same reference over the run, this may happen if run-time laser calibration is supplied
       LOGP(warn, "VDriftHelper: renorming updated TPC refVDrift={}/correction={} previous refVDrift {}, source: {}", mVD.refVDrift, mVD.corrFact, prevRef, getSourceName());
       mVD.normalize(prevRef);
     }
@@ -85,13 +85,13 @@ void VDriftHelper::accountDriftCorrectionITSTPCTgl(const VDriftCorrFact* calib)
   mVD = *calib;
   mUpdated = true;
   mSource = Source::ITSTPCTgl;
-  if (mMayRenorm) {            // this was 1st setting?
+  if (mMayRenormSrc & (0x1U << Source::ITSTPCTgl)) { // this was 1st setting?
     if (mVD.corrFact != 1.f) { // this may happen if calibration from prevous run is used
       LOGP(warn, "VDriftHelper: renorming initinal TPC refVDrift={}/correction={} to {}/1.0, source: {}", mVD.refVDrift, mVD.corrFact, mVD.getVDrift(), getSourceName());
       mVD.normalize(); // renorm reference to have correction = 1.
     }
-    mMayRenorm = false;
-  } else if (mVD.refVDrift != prevRef) { // we want to keep the same reference over the run, this should not happen!
+    mMayRenormSrc &= ~(0x1U << Source::ITSTPCTgl); // unset MayRenorm
+  } else if (mVD.refVDrift != prevRef) {           // we want to keep the same reference over the run, this should not happen!
     LOGP(alarm, "VDriftHelper: renorming updated TPC refVDrift={}/correction={} previous refVDrift {}, source: {}", mVD.refVDrift, mVD.corrFact, prevRef, getSourceName());
     mVD.normalize(prevRef);
   }


### PR DESCRIPTION
Every source (laser, dTgl) keeps track independent of 1st setting (where the renorming is done) so if the 1st one is discarded in favour of 2nd one, the acceptred on is still renormed