### PR TITLE
TPC: Remove redundant compilation of files, TPCWorkflowGUI can just use TPCWorkflow as library

### DIFF
--- a/Detectors/TPC/workflow/CMakeLists.txt
+++ b/Detectors/TPC/workflow/CMakeLists.txt
@@ -45,40 +45,10 @@ o2_add_library(TPCWorkflow
            )
 
 o2_add_library(TPCWorkflowGUI
-               SOURCES src/RecoWorkflow.cxx
-                       src/ClustererSpec.cxx
-                       src/ClusterDecoderRawSpec.cxx
-                       src/EntropyEncoderSpec.cxx
-                       src/EntropyDecoderSpec.cxx
-                       src/RawToDigitsSpec.cxx
-                       src/LinkZSToDigitsSpec.cxx
-                       src/ZSSpec.cxx
-                       src/CalibProcessingHelper.cxx
-                       src/ClusterSharingMapSpec.cxx
-                       src/CalDetMergerPublisherSpec.cxx
-                       src/KryptonClustererSpec.cxx
-                       src/KryptonRawFilterSpec.cxx
-                       src/SACProcessorSpec.cxx
-                       src/IDCToVectorSpec.cxx
-                       src/CalibdEdxSpec.cxx
-                       src/CalibratordEdxSpec.cxx
-                       src/MIPTrackFilterSpec.cxx
-                       src/LaserTrackFilterSpec.cxx
-                       src/ApplyCCDBCalibSpec.cxx
-                       src/MonitorWorkflowSpec.cxx
-                       src/ProcessingHelpers.cxx
-                       src/TrackAndClusterFilterSpec.cxx
-                       src/FileWriterSpec.cxx
-                       src/TPCVDriftTglCalibSpec.cxx
+               SOURCES src/MonitorWorkflowSpec.cxx
                TARGETVARNAME targetName
-               PUBLIC_LINK_LIBRARIES O2::Framework O2::DataFormatsTPC
-                                     O2::DPLUtils O2::TPCReconstruction
-                                     O2::TPCCalibration O2::TPCSimulation
-                                     O2::TPCQC O2::DetectorsCalibration
-                                     O2::TPCReaderWorkflow
+               PUBLIC_LINK_LIBRARIES O2::TPCWorkflow
                                      O2::TPCMonitor
-               PRIVATE_LINK_LIBRARIES O2::GPUTracking # For the Zero Suppression includes
-                                      O2::GPUWorkflow
            )
 
 


### PR DESCRIPTION
@ktf : When adding the TPCWorkflowGUI library: was there any reason to compile all the files twice?