### PR TITLE
IDCs: add option to buffer/process IDCs for TF intervals

### DIFF
--- a/Detectors/TPC/workflow/test/test_ft_EPN_Aggregator.cxx
+++ b/Detectors/TPC/workflow/test/test_ft_EPN_Aggregator.cxx
@@ -237,7 +237,7 @@ DataProcessorSpec generateIDCsCRU(int lane, const unsigned int maxTFs, const std
             const int offset = intervalsRand[interval] * nPads;
             for (int iPad = 0; iPad < nPads; ++iPad) {
               if (generateIDCs) {
-                idcs.emplace_back(irVar * gRandom->Gaus(1000, 20) / normFac[interval]);
+                idcs.emplace_back(irVar * gRandom->Gaus(10, 20) / normFac[interval]);
               } else {
                 idcs.emplace_back(irVar * mIDCs[cru][offset + iPad] / normFac[interval]);
               }

--- a/prodtests/full-system-test/aggregator-workflow.sh
+++ b/prodtests/full-system-test/aggregator-workflow.sh
@@ -223,7 +223,7 @@ nTFs_SAC=1000
 if ! workflow_has_parameter CALIB_LOCAL_INTEGRATED_AGGREGATOR; then
   if [[ $CALIB_TPC_IDC == 1 ]] && [[ $AGGREGATOR_TASKS == TPCIDC_A || $AGGREGATOR_TASKS == TPCIDC_C || $AGGREGATOR_TASKS == TPC_IDCBOTH_SAC || $AGGREGATOR_TASKS == ALL ]]; then
     add_W o2-tpc-idc-distribute "--crus ${crus} --timeframes ${nTFs} --output-lanes ${lanesFactorize} --send-precise-timestamp true --condition-tf-per-query ${nTFs}"
-    add_W o2-tpc-idc-factorize "--input-lanes ${lanesFactorize} --crus ${crus} --timeframes ${nTFs} --nthreads-grouping 8 --nthreads-IDC-factorization 8 --sendOutputFFT true --nTFsMessage 500 --enable-CCDB-output true --enablePadStatusMap true --use-precise-timestamp true --add-offset-for-CCDB-timestamp true" "TPCIDCGroupParam.groupPadsSectorEdges=32211"
+    add_W o2-tpc-idc-factorize "--input-lanes ${lanesFactorize} --crus ${crus} --timeframes ${nTFs} --nthreads-grouping 8 --nthreads-IDC-factorization 8 --sendOutputFFT true --enable-CCDB-output true --enablePadStatusMap true --use-precise-timestamp true --add-offset-for-CCDB-timestamp true" "TPCIDCGroupParam.groupPadsSectorEdges=32211"
     add_W o2-tpc-idc-ft-aggregator "--rangeIDC 200 --inputLanes ${lanesFactorize} --nFourierCoeff 40 --nthreads 8"
   fi
   if [[ $CALIB_TPC_SAC == 1 ]] && [[ $AGGREGATOR_TASKS == TPC_IDCBOTH_SAC || $AGGREGATOR_TASKS == ALL ]]; then


### PR DESCRIPTION
- to avoid sending too many messages to the input proxy

The buffering should be used in the following way: 
`o2-tpc-idc-flp --n-TFs-buffer ${nBuffer}... | o2-tpc-idc-distribute --n-TFs-buffer ${nBuffer} ... | o2-tpc-idc-factorize --n-TFs-buffer ${nBuffer} ...`