### PR TITLE
I/O for CTP reconstruction results

### DIFF
--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainer.h
@@ -26,6 +26,7 @@
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
 #include "SimulationDataFormat/ConstMCTruthContainer.h"
+#include "DataFormatsCTP/LumiInfo.h"
 #include <gsl/span>
 #include <memory>
 
@@ -314,6 +315,7 @@ struct RecoContainer {
   std::unique_ptr<const o2::dataformats::MCTruthContainer<o2::mid::MCClusterLabel>> mcMIDTrackClusters;
   std::unique_ptr<const o2::dataformats::MCTruthContainer<o2::mid::MCClusterLabel>> mcMIDClusters;
   std::unique_ptr<const std::vector<o2::MCCompLabel>> mcMIDTracks;
+  o2::ctp::LumiInfo mCTPLumi;
 
   gsl::span<const unsigned char> clusterShMapTPC; ///< externally set TPC clusters sharing map
 
@@ -634,6 +636,7 @@ struct RecoContainer {
 
   // CTP
   auto getCTPDigits() const { return getSpan<const o2::ctp::CTPDigit>(GTrackID::CTP, CLUSTERS); }
+  const o2::ctp::LumiInfo& getCTPLumi() const { return mCTPLumi; }
 
   // CPV
   auto getCPVClusters() const { return getSpan<const o2::cpv::Cluster>(GTrackID::CPV, CLUSTERS); }

--- a/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
+++ b/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
@@ -403,6 +403,7 @@ void DataRequest::requestSecondaryVertertices(bool)
 void DataRequest::requestCTPDigits(bool mc)
 {
   addInput({"CTPDigits", "CTP", "DIGITS", 0, Lifetime::Timeframe});
+  addInput({"CTPLumi", "CTP", "LUMI", 0, Lifetime::Timeframe});
   if (mc) {
     LOG(warning) << "MC truth not implemented for CTP";
     // addInput({"CTPDigitsMC", "CTP", "DIGITSMCTR", 0, Lifetime::Timeframe});
@@ -1086,6 +1087,7 @@ void RecoContainer::addMIDClusters(ProcessingContext& pc, bool mc)
 void RecoContainer::addCTPDigits(ProcessingContext& pc, bool mc)
 {
   commonPool[GTrackID::CTP].registerContainer(pc.inputs().get<gsl::span<o2::ctp::CTPDigit>>("CTPDigits"), CLUSTERS);
+  mCTPLumi = pc.inputs().get<o2::ctp::LumiInfo>("CTPLumi");
   if (mc) {
     //  pc.inputs().get<const dataformats::MCTruthContainer<MCCompLabel>*>("CTPDigitsMC");
   }

--- a/Detectors/CTP/workflow/src/ctp-raw-decoder.cxx
+++ b/Detectors/CTP/workflow/src/ctp-raw-decoder.cxx
@@ -29,12 +29,14 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"ignore-dist-stf", o2::framework::VariantType::Bool, false, {"do not subscribe to FLP/DISTSUBTIMEFRAME/0 message (no lost TF recovery)"}},
     {"no-lumi", o2::framework::VariantType::Bool, false, {"do not produce luminosity output"}},
     {"no-digits", o2::framework::VariantType::Bool, false, {"do not produce digits output"}},
+    {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writer"}},
     {"configKeyValues", o2::framework::VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
   std::swap(workflowOptions, options);
 }
 
 #include "Framework/runDataProcessing.h" // the main driver
 #include "CTPWorkflow/RawDecoderSpec.h"
+#include "CTPWorkflowIO/DigitWriterSpec.h"
 
 /// The workflow executable for the stand alone CTP reconstruction workflow
 /// - digit and lumi reader
@@ -47,5 +49,8 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
   specs.emplace_back(o2::ctp::reco_workflow::getRawDecoderSpec(!cfgc.options().get<bool>("ignore-dist-stf"),
                                                                !cfgc.options().get<bool>("no-digits"),
                                                                !cfgc.options().get<bool>("no-lumi")));
+  if (!cfgc.options().get<bool>("disable-root-output")) {
+    specs.emplace_back(o2::ctp::getDigitWriterSpec(true));
+  }
   return specs;
 }

--- a/Detectors/CTP/workflowIO/include/CTPWorkflowIO/DigitReaderSpec.h
+++ b/Detectors/CTP/workflowIO/include/CTPWorkflowIO/DigitReaderSpec.h
@@ -20,7 +20,7 @@ namespace o2
 namespace ctp
 {
 
-framework::DataProcessorSpec getDigitsReaderSpec(bool propagateMC = true);
+framework::DataProcessorSpec getDigitsReaderSpec(bool propagateMC = true, const std::string& defFile = "ctpdigits.root");
 
 } // namespace ctp
 } // end namespace o2

--- a/Detectors/CTP/workflowIO/include/CTPWorkflowIO/DigitWriterSpec.h
+++ b/Detectors/CTP/workflowIO/include/CTPWorkflowIO/DigitWriterSpec.h
@@ -16,9 +16,6 @@
 #define O2_CTPDIGITWRITERSPEC_H
 
 #include "Framework/DataProcessorSpec.h"
-#include "DPLUtils/MakeRootTreeWriterSpec.h"
-#include "Framework/InputSpec.h"
-#include "DataFormatsCTP/Digits.h"
 
 using namespace o2::framework;
 namespace o2

--- a/Detectors/CTP/workflowIO/src/DigitWriterSpec.cxx
+++ b/Detectors/CTP/workflowIO/src/DigitWriterSpec.cxx
@@ -13,6 +13,10 @@
 /// \author Roman Lietava
 
 #include "CTPWorkflowIO/DigitWriterSpec.h"
+#include "DPLUtils/MakeRootTreeWriterSpec.h"
+#include "Framework/InputSpec.h"
+#include "DataFormatsCTP/Digits.h"
+#include "DataFormatsCTP/LumiInfo.h"
 
 namespace o2
 {
@@ -29,8 +33,14 @@ framework::DataProcessorSpec getDigitWriterSpec(bool raw)
   auto logger = [](std::vector<o2::ctp::CTPDigit> const& vecDigits) {
     LOG(info) << "CTPDigitWriter pulled " << vecDigits.size() << " digits";
   };
-  return MakeRootTreeWriterSpec(raw ? "ctp-digit-writer-dec" : "ctp-digit-writer",
-                                raw ? "o2_ctpdigits.root" : "ctpdigits.root",
+  if (raw) {
+    return MakeRootTreeWriterSpec("ctp-digit-writer-dec", "ctpdigits.root",
+                                  MakeRootTreeWriterSpec::TreeAttributes{"o2sim", "Tree with CTP digits/Lumi"},
+                                  BranchDefinition<std::vector<o2::ctp::CTPDigit>>{InputSpec{"digit", "CTP", "DIGITS", 0}, "CTPDigits", logger},
+                                  BranchDefinition<o2::ctp::LumiInfo>{InputSpec{"lumi", "CTP", "LUMI", 0}, "CTPLumi"})();
+  }
+  // MC digits case, no lumi available
+  return MakeRootTreeWriterSpec("ctp-digit-writer", "ctpdigits.root",
                                 MakeRootTreeWriterSpec::TreeAttributes{"o2sim", "Tree with CTP digits"},
                                 BranchDefinition<std::vector<o2::ctp::CTPDigit>>{InputSpec{"digit", "CTP", "DIGITS", 0}, "CTPDigits", logger})();
 }

--- a/Detectors/GlobalTrackingWorkflow/helpers/src/InputHelper.cxx
+++ b/Detectors/GlobalTrackingWorkflow/helpers/src/InputHelper.cxx
@@ -145,7 +145,7 @@ int InputHelper::addInputSpecs(const ConfigContext& configcontext, WorkflowSpec&
   if (maskTracks[GID::TPCTRD] || maskTracks[GID::TPCTRDTOF]) {
     specs.emplace_back(o2::trd::getTRDTPCTrackReaderSpec(maskTracksMC[GID::TPCTRD], subSpecStrict));
   }
-  if (maskTracks[GID::CTP] && maskClusters[GID::CTP]) {
+  if (maskTracks[GID::CTP] || maskClusters[GID::CTP]) {
     specs.emplace_back(o2::ctp::getDigitsReaderSpec(maskTracksMC[GID::CTP] || maskClustersMC[GID::CTP]));
   }
 

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -392,7 +392,7 @@ if [[ $CTFINPUT == 0 && $DIGITINPUT == 0 ]]; then
   has_detector TRD && add_W o2-trd-datareader "$TRD_DECODER_OPTIONS $DISABLE_ROOT_OUTPUT --pipeline $(get_N trd-datareader TRD RAW 1 TRDRAWDEC)" "" 0
   has_detector ZDC && add_W o2-zdc-raw2digits "$DISABLE_ROOT_OUTPUT --pipeline $(get_N zdc-datareader-dpl ZDC RAW 1)"
   has_detector HMP && add_W o2-hmpid-raw-to-digits-stream-workflow "--pipeline $(get_N HMP-RawStreamDecoder HMP RAW 1)"
-  has_detector CTP && add_W o2-ctp-reco-workflow "$CTP_CONFIG --ntf-to-average 1 --pipeline $(get_N ctp-raw-decoder CTP RAW 1)"
+  has_detector CTP && add_W o2-ctp-reco-workflow "$DISABLE_ROOT_OUTPUT $CTP_CONFIG --ntf-to-average 1 --pipeline $(get_N ctp-raw-decoder CTP RAW 1)"
   has_detector PHS && ! has_detector_flp_processing PHS && add_W o2-phos-reco-workflow "--input-type raw --output-type cells $DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT --pipeline $(get_N PHOSRawToCellConverterSpec PHS REST 1) $DISABLE_MC"
   has_detector CPV && add_W o2-cpv-reco-workflow "--input-type $CPV_INPUT --output-type clusters $DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT --pipeline $(get_N CPVRawToDigitConverterSpec CPV REST 1),$(get_N CPVClusterizerSpec CPV REST 1) $DISABLE_MC"
   has_detector EMC && ! has_detector_flp_processing EMC && add_W o2-emcal-reco-workflow "--input-type raw --output-type cells $EMCRAW2C_CONFIG $DISABLE_ROOT_OUTPUT $DISABLE_MC --pipeline $(get_N EMCALRawToCellConverterSpec EMC REST 1 EMCREC)"


### PR DESCRIPTION
* add LumiInfo to CTP digits writer and reader
* add LumiInfo to InputHelper and RecoContainer
* add digit writer to `ctp-reco-workflow` with usual option `--disable-root-output` and account for it in the dpl-workflow.sh