### PR TITLE
Add filtering options to MFT tracker

### DIFF
--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/IOUtils.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/IOUtils.h
@@ -61,6 +61,12 @@ int loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe<T>& events, gsl::s
                     gsl::span<const unsigned char>::iterator& pattIt, const itsmft::TopologyDictionary* dict,
                     const dataformats::MCTruthContainer<MCCompLabel>* mClsLabels = nullptr, const o2::mft::Tracker<T>* tracker = nullptr);
 
+template <typename T>
+int loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe<T>& events, gsl::span<const itsmft::CompClusterExt> clusters,
+                    gsl::span<const unsigned char>::iterator& pattIt, const itsmft::TopologyDictionary* dict,
+                    const dataformats::MCTruthContainer<MCCompLabel>* mClsLabels, const o2::mft::Tracker<T>* tracker,
+                    ROFFilter& filter);
+
 void convertCompactClusters(gsl::span<const itsmft::CompClusterExt> clusters,
                             gsl::span<const unsigned char>::iterator& pattIt,
                             std::vector<o2::BaseCluster<float>>& output,

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/MFTTrackingParam.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/MFTTrackingParam.h
@@ -67,6 +67,14 @@ struct MFTTrackingParam : public o2::conf::ConfigurableParamHelper<MFTTrackingPa
   /// road for CA algo : cylinder or cone (default)
   Bool_t CAConeRadius = kFALSE;
 
+  // cuts to reject to low or too high mult events, or externally provided IRFrames
+  float cutMultClusLow = 0;   /// reject ROF with estimated cluster mult. below this value (no cut if <0)
+  float cutMultClusHigh = -1; /// reject ROF with estimated cluster mult. above this value (no cut if <0)
+  bool irFramesOnly = false;  ///< track only ROFs that overlap one of the IRFrames (provided externally by ITS)
+
+  bool isMultCutRequested() const { return cutMultClusLow >= 0.f && cutMultClusHigh > 0.f; };
+  bool isPassingMultCut(float mult) const { return mult >= cutMultClusLow && (mult <= cutMultClusHigh || cutMultClusHigh <= 0.f); }
+
   O2ParamDef(MFTTrackingParam, "MFTTracking");
 };
 

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/Tracker.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/Tracker.h
@@ -24,6 +24,8 @@
 #include "MathUtils/Utils.h"
 #include "MathUtils/Cartesian.h"
 #include "DataFormatsMFT/TrackMFT.h"
+#include "DataFormatsITSMFT/ROFRecord.h"
+#include "CommonDataFormat/IRFrame.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
 #include "DataFormatsParameters/GRPObject.h"
@@ -32,6 +34,10 @@ namespace o2
 {
 namespace mft
 {
+
+using o2::dataformats::IRFrame;
+using o2::itsmft::ROFRecord;
+typedef std::function<bool(const ROFRecord&)> ROFFilter;
 
 class T;
 
@@ -59,7 +65,6 @@ class Tracker : public TrackerConfig
   void findLTFTracks(ROframe<T>&);
   void findCATracks(ROframe<T>&);
   bool fitTracks(ROframe<T>&);
-
   void computeTracksMClabels(const std::vector<T>&);
 
   void initialize(bool fullClusterScan = false);

--- a/Detectors/ITSMFT/MFT/tracking/src/IOUtils.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/IOUtils.cxx
@@ -29,6 +29,7 @@
 #include "MathUtils/Cartesian.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
+#include "MFTTracking/MFTTrackingParam.h"
 
 namespace o2
 {
@@ -37,7 +38,7 @@ namespace mft
 
 //_________________________________________________________
 template <typename T>
-int ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe<T>& event, gsl::span<const itsmft::CompClusterExt> clusters, gsl::span<const unsigned char>::iterator& pattIt, const itsmft::TopologyDictionary* dict, const dataformats::MCTruthContainer<MCCompLabel>* mcLabels, const o2::mft::Tracker<T>* tracker)
+int ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe<T>& event, gsl::span<const itsmft::CompClusterExt> clusters, gsl::span<const unsigned char>::iterator& pattIt, const itsmft::TopologyDictionary* dict, const dataformats::MCTruthContainer<MCCompLabel>* mcLabels, const o2::mft::Tracker<T>* tracker, ROFFilter& filter)
 {
   event.clear();
   GeometryTGeo* geom = GeometryTGeo::Instance();
@@ -45,13 +46,24 @@ int ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe<T>& event
   int clusterId{0};
   auto first = rof.getFirstEntry();
   auto clusters_in_frame = rof.getROFData(clusters);
-  event.Reserve(clusters_in_frame.size());
+  auto nClusters = clusters_in_frame.size();
+
+  bool skip_ROF = true;
+  auto& trackingParam = MFTTrackingParam::Instance();
+  if (filter(rof) && trackingParam.isPassingMultCut(nClusters)) {
+    LOG(debug) << " ROF selected! ; nClusters = " << nClusters << " ;   orbit = " << rof.getBCData().orbit << " ; bc = " << rof.getBCData().bc;
+    skip_ROF = false;
+    event.Reserve(nClusters);
+  } else {
+    nClusters = 0;
+  }
+
   for (auto& c : clusters_in_frame) {
     auto sensorID = c.getSensorID();
     int layer = geom->getLayer(sensorID);
     auto pattID = c.getPatternID();
     o2::math_utils::Point3D<float> locXYZ;
-    float sigmaX2 = ioutils::DefClusError2Row, sigmaY2 = ioutils::DefClusError2Col; //Dummy COG errors (about half pixel size)
+    float sigmaX2 = ioutils::DefClusError2Row, sigmaY2 = ioutils::DefClusError2Col; // Dummy COG errors (about half pixel size)
     if (pattID != itsmft::CompCluster::InvalidPatternID) {
       sigmaX2 = dict->getErr2X(pattID); // ALPIDE local X coordinate => MFT global X coordinate (ALPIDE rows)
       sigmaY2 = dict->getErr2Z(pattID); // ALPIDE local Z coordinate => MFT global Y coordinate (ALPIDE columns)
@@ -64,6 +76,10 @@ int ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe<T>& event
     } else {
       o2::itsmft::ClusterPattern patt(pattIt);
       locXYZ = dict->getClusterCoordinates(c, patt, false);
+    }
+    if (skip_ROF) { // Skip filtered-out ROFs after processing pattIt
+      clusterId++;
+      continue;
     }
     // Transformation to the local --> global
     auto gloXYZ = geom->getMatrixL2G(sensorID) * locXYZ;
@@ -82,7 +98,7 @@ int ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe<T>& event
     event.addClusterExternalIndexToLayer(layer, first + clusterId);
     clusterId++;
   }
-  return clusters_in_frame.size();
+  return nClusters;
 }
 
 //_________________________________________________________
@@ -121,6 +137,16 @@ void ioutils::convertCompactClusters(gsl::span<const itsmft::CompClusterExt> clu
     cl3d.setErrors(sigmaX2, sigmaY2, 0);
   }
 }
+
+//_________________________________________________________
+template <typename T>
+int ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe<T>& event, gsl::span<const itsmft::CompClusterExt> clusters, gsl::span<const unsigned char>::iterator& pattIt, const itsmft::TopologyDictionary* dict, const dataformats::MCTruthContainer<MCCompLabel>* mcLabels, const o2::mft::Tracker<T>* tracker)
+{
+  ROFFilter noFilter = [](const o2::itsmft::ROFRecord r) { return true; };
+  return ioutils::loadROFrameData(rof, event, clusters, pattIt, dict, mcLabels, tracker, noFilter);
+}
+
+//_________________________________________________________
 template int o2::mft::ioutils::loadROFrameData<o2::mft::TrackLTF>(const o2::itsmft::ROFRecord&, ROframe<o2::mft::TrackLTF>&, gsl::span<const itsmft::CompClusterExt>,
                                                                   gsl::span<const unsigned char>::iterator&, const itsmft::TopologyDictionary*,
                                                                   const dataformats::MCTruthContainer<MCCompLabel>*, const o2::mft::Tracker<o2::mft::TrackLTF>*);
@@ -128,6 +154,15 @@ template int o2::mft::ioutils::loadROFrameData<o2::mft::TrackLTF>(const o2::itsm
 template int o2::mft::ioutils::loadROFrameData<o2::mft::TrackLTFL>(const o2::itsmft::ROFRecord&, ROframe<o2::mft::TrackLTFL>&, gsl::span<const itsmft::CompClusterExt>,
                                                                    gsl::span<const unsigned char>::iterator&, const itsmft::TopologyDictionary*,
                                                                    const dataformats::MCTruthContainer<MCCompLabel>*, const o2::mft::Tracker<o2::mft::TrackLTFL>*);
+template int o2::mft::ioutils::loadROFrameData<o2::mft::TrackLTF>(const o2::itsmft::ROFRecord&, ROframe<o2::mft::TrackLTF>&, gsl::span<const itsmft::CompClusterExt>,
+                                                                  gsl::span<const unsigned char>::iterator&, const itsmft::TopologyDictionary*,
+                                                                  const dataformats::MCTruthContainer<MCCompLabel>*, const o2::mft::Tracker<o2::mft::TrackLTF>*,
+                                                                  ROFFilter& filter);
+
+template int o2::mft::ioutils::loadROFrameData<o2::mft::TrackLTFL>(const o2::itsmft::ROFRecord&, ROframe<o2::mft::TrackLTFL>&, gsl::span<const itsmft::CompClusterExt>,
+                                                                   gsl::span<const unsigned char>::iterator&, const itsmft::TopologyDictionary*,
+                                                                   const dataformats::MCTruthContainer<MCCompLabel>*, const o2::mft::Tracker<o2::mft::TrackLTFL>*,
+                                                                   ROFFilter& filter);
 
 } // namespace mft
 } // namespace o2

--- a/Detectors/ITSMFT/MFT/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/Tracker.cxx
@@ -81,10 +81,27 @@ void Tracker<T>::initConfig(const MFTTrackingParam& trkParam, bool printConfig)
 
   if (printConfig) {
     LOG(info) << "Configurable tracker parameters:";
+    switch (trkParam.trackmodel) {
+      case o2::mft::MFTTrackModel::Helix:
+        LOG(info) << "Fwd track model     = Helix";
+        break;
+      case o2::mft::MFTTrackModel::Quadratic:
+        LOG(info) << "Fwd track model     = Quadratic";
+        break;
+      case o2::mft::MFTTrackModel::Linear:
+        LOG(info) << "Fwd track model     = Linear";
+        break;
+      case o2::mft::MFTTrackModel::Optimized:
+        LOG(info) << "Fwd track model     = Optimized";
+        break;
+    }
+    LOG(info) << "alignResidual       = " << trkParam.alignResidual;
     LOG(info) << "MinTrackPointsLTF   = " << mMinTrackPointsLTF;
     LOG(info) << "MinTrackPointsCA    = " << mMinTrackPointsCA;
     LOG(info) << "MinTrackStationsLTF = " << mMinTrackStationsLTF;
     LOG(info) << "MinTrackStationsCA  = " << mMinTrackStationsCA;
+    LOG(info) << "LTFConeRadius       = " << (trkParam.LTFConeRadius ? "true" : "false");
+    LOG(info) << "CAConeRadius        = " << (trkParam.CAConeRadius ? "true" : "false");
     LOG(info) << "LTFclsRCut          = " << mLTFclsRCut;
     LOG(info) << "ROADclsRCut         = " << mROADclsRCut;
     LOG(info) << "RBins               = " << mRBins;
@@ -93,6 +110,13 @@ void Tracker<T>::initConfig(const MFTTrackingParam& trkParam, bool printConfig)
     LOG(info) << "LTFinterBinWin      = " << mLTFinterBinWin;
     LOG(info) << "FullClusterScan     = " << (trkParam.FullClusterScan ? "true" : "false");
     LOG(info) << "forceZeroField      = " << (trkParam.forceZeroField ? "true" : "false");
+    LOG(info) << "MFTRadLength        = " << trkParam.MFTRadLength;
+    LOG(info) << "irFramesOnly        = " << (trkParam.irFramesOnly ? "true" : "false");
+    LOG(info) << "isMultCutRequested  = " << (trkParam.isMultCutRequested() ? "true" : "false");
+    if (trkParam.isMultCutRequested()) {
+      LOG(info) << "cutMultClusLow      = " << trkParam.cutMultClusLow;
+      LOG(info) << "cutMultClusHigh     = " << trkParam.cutMultClusHigh;
+    }
   }
 }
 

--- a/Detectors/ITSMFT/MFT/workflow/CMakeLists.txt
+++ b/Detectors/ITSMFT/MFT/workflow/CMakeLists.txt
@@ -27,7 +27,8 @@ o2_add_library(MFTWorkflow
                                      O2::MFTAssessment
                                      O2::DataFormatsMFT
                                      O2::ITSMFTWorkflow
-                                     O2::MFTAlignment)
+                                     O2::MFTAlignment
+                                     O2::GlobalTrackingWorkflowReaders)
 o2_add_executable(reco-workflow
                   SOURCES src/mft-reco-workflow.cxx
                   COMPONENT_NAME mft

--- a/Detectors/ITSMFT/MFT/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/RecoWorkflow.cxx
@@ -20,6 +20,7 @@
 #include "ITSMFTWorkflow/DigitReaderSpec.h"
 #include "MFTWorkflow/MFTAssessmentSpec.h"
 #include "MFTWorkflow/TracksToRecordsSpec.h"
+#include "GlobalTrackingWorkflowReaders/IRFrameReaderSpec.h"
 
 namespace o2
 {
@@ -51,6 +52,11 @@ framework::WorkflowSpec getWorkflow(
   if (!disableRootOutput) {
     specs.emplace_back(o2::mft::getClusterWriterSpec(useMC));
   }
+  auto& trackingParam = MFTTrackingParam::Instance();
+  if (trackingParam.irFramesOnly) {
+    specs.emplace_back(o2::globaltracking::getIRFrameReaderSpec("ITS", 0, "its-irframe-reader", "o2_its_irframe.root"));
+  }
+
   if (runTracking) {
     specs.emplace_back(o2::mft::getTrackerSpec(useMC, nThreads));
     if (!disableRootOutput) {

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -64,6 +64,7 @@ TOF_CONFIG=
 TOF_INPUT=raw
 TOF_OUTPUT=clusters
 ITS_CONFIG_KEY=
+MFT_CONFIG_KEY=
 TRD_CONFIG=
 TRD_CONFIG_KEY=
 TRD_FILTER_CONFIG=
@@ -86,6 +87,11 @@ if [[ $SYNCMODE == 1 ]]; then
     ITS_CONFIG_KEY+="fastMultConfig.cutMultClusLow=30;fastMultConfig.cutMultClusHigh=2000;fastMultConfig.cutMultVtxHigh=500;"
   elif [[ $BEAMTYPE == "pp" ]]; then
     ITS_CONFIG_KEY+="fastMultConfig.cutMultClusLow=-1;fastMultConfig.cutMultClusHigh=-1;fastMultConfig.cutMultVtxHigh=-1;ITSVertexerParam.phiCut=0.5;ITSVertexerParam.clusterContributorsCut=3;ITSVertexerParam.tanLambdaCut=0.2;fastMultConfig.cutRandomFraction=0.9;"
+  fi
+  if has_detector_reco ITS; then
+    MFT_CONFIG_KEY+="MFTTracking.irFramesOnly=1;"
+  else
+    MFT_CONFIG_KEY+="MFTTracking.cutMultClusLow=0;MFTTracking.cutMultClusHigh=2000;"
   fi
 
   PVERTEXING_CONFIG_KEY+="pvertexer.meanVertexExtraErrConstraint=0.3;" # for calibration relax the constraint
@@ -286,7 +292,7 @@ if has_processing_step MUON_SYNC_RECO; then
     fi
     has_detector_reco ITS && [[ $RUNTYPE != "COSMICS" ]] && CONFIG_EXTRA_PROCESS_o2_mch_reco_workflow+="MCHTimeClusterizer.irFramesOnly=true;"
   fi
-  [[ $RUNTYPE == "COSMICS" ]] && [[ -z $CONFIG_EXTRA_PROCESS_o2_mft_reco_workflow ]] && CONFIG_EXTRA_PROCESS_o2_mft_reco_workflow="MFTTracking.LTFclsRCut=0.2;MFTTracking.forceZeroField=true;MFTTracking.FullClusterScan=true"
+  [[ $RUNTYPE == "COSMICS" ]] && [[ -z $CONFIG_EXTRA_PROCESS_o2_mft_reco_workflow ]] && CONFIG_EXTRA_PROCESS_o2_mft_reco_workflow="MFTTracking.FullClusterScan=true"
 fi
 [[ "0$ED_VERTEX_MODE" == "01" ]] && has_detectors_reco ITS && has_detector_matching PRIMVTX && [[ ! -z "$VERTEXING_SOURCES" ]] && EVE_CONFIG+=" --primary-vertex-mode"
 [[ $EPNSYNCMODE == 1 ]] && [[ -z $CONFIG_EXTRA_PROCESS_o2_trd_global_tracking ]] && CONFIG_EXTRA_PROCESS_o2_trd_global_tracking='GPU_rec_trd.maxChi2=25;GPU_rec_trd.penaltyChi2=20;GPU_rec_trd.extraRoadY=4;GPU_rec_trd.extraRoadZ=10;GPU_rec_trd.applyDeflectionCut=0;GPU_rec_trd.trkltResRPhiIdeal=1'
@@ -413,7 +419,7 @@ has_detectors TPC && [ -z "$DISABLE_ROOT_OUTPUT" ] && add_W o2-tpc-reco-workflow
 # Reconstruction workflows normally active only in async mode in async mode ($LIST_OF_ASYNC_RECO_STEPS), but can be forced via $WORKFLOW_EXTRA_PROCESSING_STEPS
 has_detector MID && has_processing_step MID_RECO && add_W o2-mid-reco-workflow "$DISABLE_ROOT_OUTPUT $DISABLE_MC --pipeline $(get_N MIDClusterizer MID REST 1),$(get_N MIDTracker MID REST 1)"
 has_detector MCH && has_processing_step MCH_RECO && add_W o2-mch-reco-workflow "$DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $DISABLE_MC --pipeline $(get_N mch-track-finder MCH REST 1 MCHTRK),$(get_N mch-cluster-finder MCH REST 1 MCHCL),$(get_N mch-cluster-transformer MCH REST 1)" "$MCH_CONFIG_KEY"
-has_detector MFT && has_processing_step MFT_RECO && add_W o2-mft-reco-workflow "$DISABLE_DIGIT_CLUSTER_INPUT $DISABLE_MC $DISABLE_ROOT_OUTPUT --pipeline $(get_N mft-tracker MFT REST 1 MFTTRK)" "$ITSMFT_STROBES"
+has_detector MFT && has_processing_step MFT_RECO && add_W o2-mft-reco-workflow "$DISABLE_DIGIT_CLUSTER_INPUT $DISABLE_MC $DISABLE_ROOT_OUTPUT --pipeline $(get_N mft-tracker MFT REST 1 MFTTRK)" "$MFT_CONFIG_KEY;$ITSMFT_STROBES"
 has_detector FDD && has_processing_step FDD_RECO && add_W o2-fdd-reco-workflow "$DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $DISABLE_MC"
 has_detector FV0 && has_processing_step FV0_RECO && add_W o2-fv0-reco-workflow "$DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $DISABLE_MC"
 has_detector ZDC && has_processing_step ZDC_RECO && add_W o2-zdc-digits-reco "$DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $DISABLE_MC"


### PR DESCRIPTION
This PR add two filtering options to reduce EPN load during sync reconstruction: 

- irFramesOnly: Reconstruct only IRFrames selected by ITS
- Multiplicity filter: selects ROFs matching a range of cluster multiplicity

