### PR TITLE
[MCH] add electronic noise and time response

### DIFF
--- a/Detectors/MUON/MCH/Simulation/README.md
+++ b/Detectors/MUON/MCH/Simulation/README.md
@@ -1,0 +1,41 @@
+# How to make a simulation including MCH
+
+## Only MCH
+
+Like all [O2 simulations](../../../../doc/DetectorSimulation.md), it's a two stage process : first create the hits and then digitize them.
+
+### Hit creation
+
+     o2-sim -n 10 -g fwmugen -e TGeant3 -m MCH
+
+will generate 10 events using the `fwmugen` generator (1 forward muon per event), using Geant3 as transport, and with only MCH geometry.
+
+     CAUTION: by specifying -m MCH you only get MCH geometry, no absorber, no dipole, no beam shield, etc... So that's only a relevant option for quick debug, not for any kind of physics analysis.
+
+This steps creates (among others) an `o2sim_HitsMCH.root` file with the MCH hits, as well as `o2sim_geometry.root` and `o2sim_grp.root` which are used later on by the digitizer.
+
+### Digitization
+
+In the same directory where the hits were created, use:
+
+     o2-sim-digitizer-workflow
+
+This will creates `mchdigits.root`, updates `o2sim_grp.root` and generates a `collisioncontext.root`.
+This last file can be used to redo the digitization for the very _same_ collisions, but with e.g. different digitization parameters.
+
+Various options can be specified using the `--configKeyValues`.
+For example for the MCH digitizer:
+
+     o2-sim-digitizer-workflow --configKeyValues "MCHDigitizer.noiseOnlyProba=1.e-6;MCHDigitizer.timeSigma=6."
+
+For the list of possible parameters see the [DigitizerParam](./include/MCHSimulation/DigitizerParam.h) and [ResponseParam](../Base/include/MCHBase/ResponseParam.h) structs.
+
+## More realistic simulations
+
+For anything but debug, you should include more modules at the hit creation stage:
+
+     o2-sim -m HALL MAG DIPO COMP PIPE ABSO SHIL MCH
+
+Of course, add other detectors (MID,MFT,ITS,...) if need be.
+
+Note that there is a way to simply include the geometry of a detector, just to have its material budget in the picture, without also having it participating to the hit creation, see PR: https://github.com/AliceO2Group/AliceO2/pull/8149 for the options.

--- a/Detectors/MUON/MCH/Simulation/include/MCHSimulation/DEDigitizer.h
+++ b/Detectors/MUON/MCH/Simulation/include/MCHSimulation/DEDigitizer.h
@@ -12,71 +12,118 @@
 #ifndef O2_MCH_SIMULATION_DE_DIGITIZER_H
 #define O2_MCH_SIMULATION_DE_DIGITIZER_H
 
+#include <map>
+#include <random>
+#include <utility>
+#include <vector>
+
 #include "DataFormatsMCH/Digit.h"
+#include "CommonDataFormat/InteractionRecord.h"
+#include "MathUtils/Cartesian.h"
 #include "MCHMappingInterface/Segmentation.h"
 #include "MCHSimulation/Hit.h"
 #include "MCHSimulation/Response.h"
-#include "MathUtils/Cartesian.h"
-#include <vector>
-#include "SimulationDataFormat/MCTruthContainer.h"
-#include "CommonDataFormat/InteractionRecord.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
 
 namespace o2::mch
 {
 
-/** MCH Digitizer dealing with a single detection element. */
-
+/// MCH digitizer dealing with a single detection element.
 class DEDigitizer
 {
  public:
-  DEDigitizer(int deId, o2::math_utils::Transform3D transformation);
+  using DigitsAndLabels = std::pair<std::vector<Digit>, dataformats::MCLabelContainer>;
 
-  /** startCollision sets the current IR under consideration.
-   *
-   * All the digits created between a call to this one and clear()
-   * will be associated to a MCH ROFRecord == collisionTime
-  */
-  void startCollision(o2::InteractionRecord collisionTime);
+  /** Constructor.
+   * @param deId detection element ID
+   * @param transformation a transformation to convert global coordinates
+   *        (of this hits) into local (to the detection element) ones
+   * @param random random number generator
+   */
+  DEDigitizer(int deId, math_utils::Transform3D transformation, std::mt19937& random);
 
-  /** Add some noise to the current collision */
-  void addNoise(float noiseProba);
-
-  /** process one MCH Hit.
+  /** Process one MCH Hit.
    *
    * This will convert the hit eloss into a charge and spread (according
    * to a Mathieson 2D distribution) that charge among several pads,
    * that will become digits eventually
    *
-   * @param hit the input hit to be digitized
+   * @param hit the input hit to be processed
+   * @param collisionTime the IR this hit is associated to
    * @param evID the event identifier of the hit in the sim chain within srcID
    * @param srcID the origin (signal, background) of the hit
    * @see o2::steer::EventPart
    */
-  void process(const Hit& hit, int evID, int srcID);
+  void processHit(const Hit& hit, const InteractionRecord& collisionTime, int evID, int srcID);
 
-  /** extractDigitsAndLabels appends digits and labels to given containers.
+  /** Add noise-only signals.
    *
-   * This function copies our internal information into the parameter vectors
+   * Noise will be generated for all IR between `firstIR` and `lastIR`.
+   * Note that depending on the actual noise probability some IR
+   * might not get any pad with noise-only signal, and that's fine.
    *
-   * @param digits vector of digits where we append our internal digits.
-   * @param labels MCTruthContainer where we append our internal labels.
+   * @param firstIR first IR for which noise will be generated
+   * @param lastIR last IR for which noise will be generated
    */
-  void extractDigitsAndLabels(std::vector<Digit>& digits,
-                              o2::dataformats::MCTruthContainer<o2::MCCompLabel>& labels);
+  void addNoise(const InteractionRecord& firstIR, const InteractionRecord& lastIR);
 
-  /** Clear resets our internal lists of digits and labels. */
+  /** Do the digitization.
+   *
+   * The digitization accounts for charge dispersion (adding noise to physical
+   * signals) and threshold, time dispersion and pileup within readout windows.
+   * It fills the lists of digits and associated labels ordered per IR
+   * and returns the number of signal pileup in overlapping readout windows.
+   *
+   * @param irDigitsAndLabels lists of digits and associated labels ordered per IR
+   */
+  size_t digitize(std::map<InteractionRecord, DigitsAndLabels>& irDigitsAndLabels);
+
+  /// Clear the internal lists of signals.
   void clear();
 
  private:
-  int mDeId;                                         // detection element id
-  Response mResponse;                                // response function (Mathieson parameters, ...)
-  o2::math_utils::Transform3D mTransformation;       // from local to global and reverse
-  mapping::Segmentation mSegmentation;               // mapping of this detection element
-  o2::InteractionRecord mIR;                         // interaction record to associate charges and labels to
-  std::vector<float> mCharges;                       // pad charges (fixed size = number of pads in this DE)
-  std::vector<std::vector<o2::MCCompLabel>> mLabels; // mLabels.size()==mCharges.size()
+  /// internal structure to hold signal informations
+  struct Signal {
+    InteractionRecord rofIR;
+    uint8_t bcInROF;
+    float charge;
+    std::vector<MCCompLabel> labels;
+    Signal(const InteractionRecord& ir, uint8_t bc, float q, const MCCompLabel& label)
+      : rofIR{ir}, bcInROF{bc}, charge{q}, labels{label} {}
+  };
+
+  /// add a physical signal to the given pad at the given IR
+  void addSignal(int padid, const InteractionRecord& collisionTime, float charge, const MCCompLabel& label);
+  /// add a noise-only signal to the given pad at the given IR
+  void addNoise(int padid, const InteractionRecord& rofIR);
+  /// add noise to the given signal
+  void addNoise(Signal& signal, uint32_t nSamples);
+  /// add time dispersion to signal
+  void addTimeDispersion(Signal& signal);
+  /// test if the charge is above threshold
+  bool isAboveThreshold(float charge);
+  /// add a new digit and associated labels at the relevant IR and return a pointer to their container
+  DigitsAndLabels* addNewDigit(std::map<InteractionRecord, DigitsAndLabels>& irDigitsAndLabels,
+                               int padid, const Signal& signal, uint32_t nSamples) const;
+  /// add signal and associated labels to the last created digit
+  void appendLastDigit(DigitsAndLabels* digitsAndLabels, const Signal& signal, uint32_t nSamples) const;
+
+  int mDeId;                                   ///< detection element ID
+  Response mResponse;                          ///< response function (Mathieson parameters, ...)
+  o2::math_utils::Transform3D mTransformation; ///< transformation from local to global and reverse
+  mapping::Segmentation mSegmentation;         ///< mapping of this detection element
+
+  std::mt19937& mRandom;                            ///< reference to the random number generator
+  std::normal_distribution<float> mMinChargeDist;   ///< random lower charge threshold generator (gaussian distribution)
+  std::normal_distribution<float> mTimeDist;        ///< random time dispersion generator (gaussian distribution)
+  std::normal_distribution<float> mNoiseDist;       ///< random charge noise generator (gaussian distribution)
+  std::normal_distribution<float> mNoiseOnlyDist;   ///< random noise-only signal generator (gaussian distribution)
+  std::poisson_distribution<int> mNofNoisyPadsDist; ///< random number of noisy pads generator (poisson distribution)
+  std::uniform_int_distribution<int> mPadIdDist;    ///< random pad ID generator (uniform distribution)
+  std::uniform_int_distribution<int> mBCDist;       ///< random BC number inside ROF generator (uniform distribution)
+
+  std::vector<std::vector<Signal>> mSignals; ///< list of signals per pad
 };
 
 } // namespace o2::mch

--- a/Detectors/MUON/MCH/Simulation/include/MCHSimulation/Digitizer.h
+++ b/Detectors/MUON/MCH/Simulation/include/MCHSimulation/Digitizer.h
@@ -12,63 +12,54 @@
 #ifndef O2_MCH_SIMULATION_DIGITIZER_H
 #define O2_MCH_SIMULATION_DIGITIZER_H
 
-#include "MCHSimulation/Hit.h"
-#include "MCHGeometryTransformer/Transformations.h"
-#include "MCHSimulation/DEDigitizer.h"
 #include <map>
+#include <memory>
+#include <random>
+
 #include <gsl/span>
+
+#include "DataFormatsMCH/Digit.h"
+#include "DataFormatsMCH/ROFRecord.h"
+#include "CommonDataFormat/InteractionRecord.h"
+#include "MCHGeometryTransformer/Transformations.h"
+#include "MCHSimulation/Hit.h"
+#include "MCHSimulation/DEDigitizer.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
 
 namespace o2::mch
 {
 /** MCH Digitizer.
- *
  * This class is just steering the usage of o2::mch::DEDigitizer
- *
  */
 class Digitizer
 {
  public:
   /** Constructor.
-   * @param transformationCreator is a function that is able to create
-   * a geo::TransformationCreator
+   * @param transformationCreator is a function that is able to create a o2::math_utils::Transform3D
    */
   Digitizer(geo::TransformationCreator transformationCreator);
 
-  // @see DEDigitizer::addNoise
-  void addNoise(float noiseProba);
+  /// @see DEDigitizer::processHit
+  void processHits(gsl::span<const Hit> hits, const InteractionRecord& collisionTime, int evID, int srcID);
 
-  // @see DEDigitizer::startCollision
-  void startCollision(o2::InteractionRecord collisionTime);
+  /// @see DEDigitizer::addNoise
+  void addNoise(const InteractionRecord& firstIR, const InteractionRecord& lastIR);
 
-  // @see DEDigitizer::processHit
-  void processHits(gsl::span<Hit> hits, int evID, int srcID);
+  /** @see DEDigitizer::digitize
+   * Fill the given containers with the result of the digitization.
+   * Return the number of signal pileup in overlapping readout windows.
+   */
+  size_t digitize(std::vector<ROFRecord>& rofs, std::vector<Digit>& digits, dataformats::MCLabelContainer& labels);
 
-  // @see DEDigitizer::extractDigitsAndLabels
-  void extractDigitsAndLabels(std::vector<Digit>& digits,
-                              o2::dataformats::MCTruthContainer<o2::MCCompLabel>& labels);
-
-  // @see DEDigitizer:clear
+  /// @see DEDigitizer::clear
   void clear();
 
  private:
-  std::map<int, std::unique_ptr<DEDigitizer>> mDEDigitizers; // list of workers
+  std::mt19937 mRandom; ///< random number generator
+
+  std::map<int, std::unique_ptr<DEDigitizer>> mDEDigitizers; ///< list of digitizers per DE
 };
-
-/** Group Interaction Record that are "too close" in time (BC).
- *
- * @param records : a list of input IR to group
- * @param width (in BC unit) : all IRs within this distance will be considered
- * to be a single group
- *
- * @returns a map of IRs->{index} where index is relative to input records
- *
- */
-std::map<o2::InteractionRecord, std::vector<int>> groupIR(gsl::span<const o2::InteractionRecord> records, uint32_t width = 4);
-
-/** Same as above for InteractionTimeRecord. */
-std::map<o2::InteractionRecord, std::vector<int>> groupIR(gsl::span<const o2::InteractionTimeRecord> records, uint32_t width = 4);
 
 } // namespace o2::mch
 #endif

--- a/Detectors/MUON/MCH/Simulation/include/MCHSimulation/DigitizerParam.h
+++ b/Detectors/MUON/MCH/Simulation/include/MCHSimulation/DigitizerParam.h
@@ -20,11 +20,26 @@ namespace o2::mch
 
 struct DigitizerParam : public o2::conf::ConfigurableParamHelper<DigitizerParam> {
 
-  bool continuous = true;           ///< whether we assume continuous mode or not
-  float noiseProba = 3.1671242e-05; ///< by default = proba to be above 4*sigma of a gaussian noise
-  uint32_t minADC = 12;             ///< minimum ADC value for a pad to respond
+  bool continuous = true; ///< whether we assume continuous mode or not
 
-  O2ParamDef(DigitizerParam, "MCHDigitizerParam")
+  int seed = 0; ///< seed for random number generators used for time, noise and threshold (0 means no seed given)
+
+  float timeSigma = 0.f; ///< time dispersion added to digit times (in bc unit)
+
+  float noiseSigma = 0.5f; ///< dispersion of noise added to physical signal per ADC sample (in ADC counts)
+
+  float noiseOnlyProba = 1.e-7f; ///< probability of noise-only signal (per pad per ROF=4BC)
+  float noiseOnlyMean = 23.f;    ///< mean value of noise-only signal (in ADC counts)
+  float noiseOnlySigma = 3.f;    ///< dispersion of noise-only signal (in ADC counts)
+
+  bool onlyNoise = false; ///< for debug only: disable treatment of physical signals (i.e. keep only noise)
+
+  float minChargeMean = 22.2f; ///< mean value of lower charge threshold for a signal to be digitized (in ADC counts)
+  float minChargeSigma = 2.8f; ///< dispersion of lower charge threshold for a signal to be digitized (in ADC counts)
+
+  bool handlePileup = true; ///< merge digits in overlapping readout windows (defined by the number of samples + 2)
+
+  O2ParamDef(DigitizerParam, "MCHDigitizer")
 };
 
 } // namespace o2::mch

--- a/Detectors/MUON/MCH/Simulation/include/MCHSimulation/Response.h
+++ b/Detectors/MUON/MCH/Simulation/include/MCHSimulation/Response.h
@@ -40,7 +40,7 @@ class Response
   /** Converts energy deposition into a charge.
    *
    * @param edepos deposited energy from Geant (in GeV)
-   * @returns an equivalent charge (roughyl in ADC units)
+   * @returns an equivalent charge (roughly in ADC units)
    *
    */
   float etocharge(float edepos) const;
@@ -61,8 +61,8 @@ class Response
   /// return a randomized charge correlation between cathodes
   float chargeCorr() const;
 
-  /// compute the number of samples corresponding to the ADC value
-  uint32_t nSamples(uint32_t adc) const;
+  /// compute the number of samples corresponding to the charge in ADC units
+  uint32_t nSamples(float charge) const;
 
  private:
   MathiesonOriginal mMathieson{}; ///< Mathieson function

--- a/Detectors/MUON/MCH/Simulation/src/Response.cxx
+++ b/Detectors/MUON/MCH/Simulation/src/Response.cxx
@@ -81,11 +81,11 @@ float Response::chargeCorr() const
 }
 
 //_____________________________________________________________________
-uint32_t Response::nSamples(uint32_t adc) const
+uint32_t Response::nSamples(float charge) const
 {
   // the main purpose is to the pass the background rejection and signal selection
   // applied in data reconstruction (see MCH/DigitFiltering/src/DigitFilter.cxx).
   // a realistic estimate of nSamples would require a complete simulation of the electronic signal
   double signalParam[3] = {14., 13., 1.5};
-  return std::round(std::pow(double(adc) / signalParam[1], 1. / signalParam[2]) + signalParam[0]);
+  return std::round(std::pow(charge / signalParam[1], 1. / signalParam[2]) + signalParam[0]);
 }


### PR DESCRIPTION
Improve the realism of the electronic response by:
- adding electronic noise to physical signals
- generating noise-only signals
- adding dispersion of the effective ADC threshold
- adding time dispersion of the response
- handling signal pileup within the readout window

The last point is more a protection against the little probability of generating multiple digits on the same pad in nearby ROFs than a precise handling of overlapping signals. The latter, if needed, would require a complete simulation of the electronic response.

All this is parametrizable through configurable parameters in DigitizerParam.
