### PR TITLE
FIT: Store DCS DPs as 64 bit ints and rename bad channel map

### DIFF
--- a/DataFormats/Detectors/FIT/common/include/DataFormatsFIT/DCSDPValues.h
+++ b/DataFormats/Detectors/FIT/common/include/DataFormatsFIT/DCSDPValues.h
@@ -20,16 +20,16 @@ namespace o2
 namespace fit
 {
 struct DCSDPValues {
-  std::vector<std::pair<uint64_t, int>> values;
+  std::vector<std::pair<uint64_t, int64_t>> values;
 
   DCSDPValues()
   {
-    values = std::vector<std::pair<uint64_t, int>>();
+    values = std::vector<std::pair<uint64_t, int64_t>>();
   }
 
-  void add(uint64_t timestamp, int value)
+  void add(uint64_t timestamp, int64_t value)
   {
-    values.push_back(std::pair<uint64_t, int>(timestamp, value));
+    values.push_back(std::pair<uint64_t, int64_t>(timestamp, value));
   }
 
   bool empty()
@@ -57,7 +57,7 @@ struct DCSDPValues {
     }
   }
 
-  ClassDefNV(DCSDPValues, 2);
+  ClassDefNV(DCSDPValues, 3);
 };
 
 } // namespace fit

--- a/DataFormats/Detectors/FIT/common/include/DataFormatsFIT/DeadChannelMap.h
+++ b/DataFormats/Detectors/FIT/common/include/DataFormatsFIT/DeadChannelMap.h
@@ -9,13 +9,13 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file BadChannelMap.h
-/// \brief Bad channel map for FIT
+/// \file DeadChannelMap.h
+/// \brief Dead channel map for FIT
 ///
 /// \author Andreas Molander <andreas.molander@cern.ch>, University of Jyvaskyla, Finland
 
-#ifndef O2_FIT_BADCHANNELMAP_H
-#define O2_FIT_BADCHANNELMAP_H
+#ifndef O2_FIT_DEADCHANNELMAP_H
+#define O2_FIT_DEADCHANNELMAP_H
 
 #include <cstdint>
 #include <unordered_map>
@@ -25,16 +25,16 @@ namespace o2
 namespace fit
 {
 
-struct BadChannelMap {
-  /// Bad channel map as 'channel id - state' pairs. true = good, false = bad.
+struct DeadChannelMap {
+  /// Dead channel map as 'channel id - state' pairs. true = alive, false = dead.
   std::unordered_map<uint8_t, bool> map;
 
-  void setChannelGood(const uint8_t& chId, const bool isGood)
+  void setChannelAlive(const uint8_t& chId, const bool isAlive)
   {
-    map[chId] = isGood;
+    map[chId] = isAlive;
   }
 
-  const bool isChannelGood(const uint8_t& chId) const
+  const bool isChannelAlive(const uint8_t& chId) const
   {
     return map.at(chId);
   }
@@ -44,10 +44,10 @@ struct BadChannelMap {
     map.clear();
   }
 
-  ClassDefNV(BadChannelMap, 1);
+  ClassDefNV(DeadChannelMap, 1);
 };
 
 } // namespace fit
 } // namespace o2
 
-#endif // O2_FIT_BADCHANNELMAP_H
+#endif // O2_FIT_DEADCHANNELMAP_H

--- a/Detectors/FIT/FDD/dcsmonitoring/workflow/FDDDCSConfigProcessorSpec.h
+++ b/Detectors/FIT/FDD/dcsmonitoring/workflow/FDDDCSConfigProcessorSpec.h
@@ -33,19 +33,19 @@ namespace framework
 
 DataProcessorSpec getFDDDCSConfigProcessorSpec()
 {
-  o2::header::DataDescription ddBChM = "FDD_BCHM";
+  o2::header::DataDescription ddDChM = "FDD_DCHM";
   std::vector<OutputSpec> outputs;
-  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, ddBChM}, Lifetime::Sporadic);
-  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, ddBChM}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, ddDChM}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, ddDChM}, Lifetime::Sporadic);
 
   return DataProcessorSpec{
     "fdd-dcs-config-processor",
     Inputs{{"inputConfig", o2::header::gDataOriginFDD, "DCS_CONFIG_FILE", Lifetime::Timeframe},
            {"inputConfigFileName", o2::header::gDataOriginFDD, "DCS_CONFIG_NAME", Lifetime::Timeframe}},
     outputs,
-    AlgorithmSpec{adaptFromTask<o2::fit::FITDCSConfigProcessor>("FDD", ddBChM)},
+    AlgorithmSpec{adaptFromTask<o2::fit::FITDCSConfigProcessor>("FDD", ddDChM)},
     Options{{"use-verbose-mode", VariantType::Bool, false, {"Use verbose mode"}},
-            {"filename-bchm", VariantType::String, "FDD-badchannels.txt", {"Bad channel map file name"}}}};
+            {"filename-dchm", VariantType::String, "FDD-deadchannels.txt", {"Dead channel map file name"}}}};
 }
 
 } // namespace framework

--- a/Detectors/FIT/FDD/dcsmonitoring/workflow/FDDDCSDataProcessorSpec.h
+++ b/Detectors/FIT/FDD/dcsmonitoring/workflow/FDDDCSDataProcessorSpec.h
@@ -29,16 +29,16 @@ namespace framework
 
 DataProcessorSpec getFDDDCSDataProcessorSpec()
 {
-  o2::header::DataDescription ddBChM = "FDD_DCSDPs";
+  o2::header::DataDescription ddDCSDPs = "FDD_DCSDPs";
   std::vector<OutputSpec> outputs;
-  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, ddBChM}, Lifetime::Sporadic);
-  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, ddBChM}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, ddDCSDPs}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, ddDCSDPs}, Lifetime::Sporadic);
 
   return DataProcessorSpec{
     "fdd-dcs-data-processor",
     Inputs{{"input", "DCS", "FDDDATAPOINTS"}},
     outputs,
-    AlgorithmSpec{adaptFromTask<o2::fdd::FDDDCSDataProcessor>("FDD", ddBChM)},
+    AlgorithmSpec{adaptFromTask<o2::fdd::FDDDCSDataProcessor>("FDD", ddDCSDPs)},
     Options{{"ccdb-path", VariantType::String, "http://localhost:8080", {"Path to CCDB"}},
             {"use-ccdb-to-configure", VariantType::Bool, false, {"Use CCDB to configure"}},
             {"use-verbose-mode", VariantType::Bool, false, {"Use verbose mode"}},

--- a/Detectors/FIT/FT0/dcsmonitoring/workflow/FT0DCSConfigProcessorSpec.h
+++ b/Detectors/FIT/FT0/dcsmonitoring/workflow/FT0DCSConfigProcessorSpec.h
@@ -35,8 +35,8 @@ class FT0DCSConfigProcessor : public o2::fit::FITDCSConfigProcessor
 {
   // Example of how to use another DCS config reader (subclass of o2::fit::FITDCSConfigReader)
  public:
-  FT0DCSConfigProcessor(const std::string& detectorName, const o2::header::DataDescription& dataDescriptionBChM)
-    : o2::fit::FITDCSConfigProcessor(detectorName, dataDescriptionBChM) {}
+  FT0DCSConfigProcessor(const std::string& detectorName, const o2::header::DataDescription& dataDescriptionDChM)
+    : o2::fit::FITDCSConfigProcessor(detectorName, dataDescriptionDChM) {}
 
  protected:
   void initDCSConfigReader() override
@@ -52,19 +52,19 @@ namespace framework
 
 DataProcessorSpec getFT0DCSConfigProcessorSpec()
 {
-  o2::header::DataDescription ddBChM = "FT0_BCHM";
+  o2::header::DataDescription ddDChM = "FT0_DCHM";
   std::vector<OutputSpec> outputs;
-  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, ddBChM}, Lifetime::Sporadic);
-  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, ddBChM}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, ddDChM}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, ddDChM}, Lifetime::Sporadic);
 
   return DataProcessorSpec{
     "ft0-dcs-config-processor",
     Inputs{{"inputConfig", o2::header::gDataOriginFT0, "DCS_CONFIG_FILE", Lifetime::Timeframe},
            {"inputConfigFileName", o2::header::gDataOriginFT0, "DCS_CONFIG_NAME", Lifetime::Timeframe}},
     outputs,
-    AlgorithmSpec{adaptFromTask<o2::ft0::FT0DCSConfigProcessor>("FT0", ddBChM)},
+    AlgorithmSpec{adaptFromTask<o2::ft0::FT0DCSConfigProcessor>("FT0", ddDChM)},
     Options{{"use-verbose-mode", VariantType::Bool, false, {"Use verbose mode"}},
-            {"filename-bchm", VariantType::String, "FT0-badchannels.txt", {"Bad channel map file name"}}}};
+            {"filename-dchm", VariantType::String, "FT0-deadchannels.txt", {"Dead channel map file name"}}}};
 }
 
 } // namespace framework

--- a/Detectors/FIT/FT0/dcsmonitoring/workflow/FT0DCSDataProcessorSpec.h
+++ b/Detectors/FIT/FT0/dcsmonitoring/workflow/FT0DCSDataProcessorSpec.h
@@ -29,16 +29,16 @@ namespace framework
 
 DataProcessorSpec getFT0DCSDataProcessorSpec()
 {
-  o2::header::DataDescription ddBChM = "FT0_DCSDPs";
+  o2::header::DataDescription ddDCSDPs = "FT0_DCSDPs";
   std::vector<OutputSpec> outputs;
-  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, ddBChM}, Lifetime::Sporadic);
-  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, ddBChM}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, ddDCSDPs}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, ddDCSDPs}, Lifetime::Sporadic);
 
   return DataProcessorSpec{
     "ft0-dcs-data-processor",
     Inputs{{"input", "DCS", "FT0DATAPOINTS"}},
     outputs,
-    AlgorithmSpec{adaptFromTask<o2::ft0::FT0DCSDataProcessor>("FT0", ddBChM)},
+    AlgorithmSpec{adaptFromTask<o2::ft0::FT0DCSDataProcessor>("FT0", ddDCSDPs)},
     Options{{"ccdb-path", VariantType::String, "http://localhost:8080", {"Path to CCDB"}},
             {"use-ccdb-to-configure", VariantType::Bool, false, {"Use CCDB to configure"}},
             {"use-verbose-mode", VariantType::Bool, false, {"Use verbose mode"}},

--- a/Detectors/FIT/FV0/dcsmonitoring/workflow/FV0DCSConfigProcessorSpec.h
+++ b/Detectors/FIT/FV0/dcsmonitoring/workflow/FV0DCSConfigProcessorSpec.h
@@ -33,19 +33,19 @@ namespace framework
 
 DataProcessorSpec getFV0DCSConfigProcessorSpec()
 {
-  o2::header::DataDescription ddBChM = "FV0_BCHM";
+  o2::header::DataDescription ddDChM = "FV0_DCHM";
   std::vector<OutputSpec> outputs;
-  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, ddBChM}, Lifetime::Sporadic);
-  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, ddBChM}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, ddDChM}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, ddDChM}, Lifetime::Sporadic);
 
   return DataProcessorSpec{
     "fv0-dcs-config-processor",
     Inputs{{"inputConfig", o2::header::gDataOriginFV0, "DCS_CONFIG_FILE", Lifetime::Timeframe},
            {"inputConfigFileName", o2::header::gDataOriginFV0, "DCS_CONFIG_NAME", Lifetime::Timeframe}},
     outputs,
-    AlgorithmSpec{adaptFromTask<o2::fit::FITDCSConfigProcessor>("FV0", ddBChM)},
+    AlgorithmSpec{adaptFromTask<o2::fit::FITDCSConfigProcessor>("FV0", ddDChM)},
     Options{{"use-verbose-mode", VariantType::Bool, false, {"Use verbose mode"}},
-            {"filename-bchm", VariantType::String, "FV0-badchannels.txt", {"Bad channel map file name"}}}};
+            {"filename-dchm", VariantType::String, "FV0-deadchannels.txt", {"Dead channel map file name"}}}};
 }
 
 } // namespace framework

--- a/Detectors/FIT/FV0/dcsmonitoring/workflow/FV0DCSDataProcessorSpec.h
+++ b/Detectors/FIT/FV0/dcsmonitoring/workflow/FV0DCSDataProcessorSpec.h
@@ -29,16 +29,16 @@ namespace framework
 
 DataProcessorSpec getFV0DCSDataProcessorSpec()
 {
-  o2::header::DataDescription ddBChM = "FV0_DCSDPs";
+  o2::header::DataDescription ddDCSDPs = "FV0_DCSDPs";
   std::vector<OutputSpec> outputs;
-  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, ddBChM}, Lifetime::Sporadic);
-  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, ddBChM}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, ddDCSDPs}, Lifetime::Sporadic);
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, ddDCSDPs}, Lifetime::Sporadic);
 
   return DataProcessorSpec{
     "fv0-dcs-data-processor",
     Inputs{{"input", "DCS", "FV0DATAPOINTS"}},
     outputs,
-    AlgorithmSpec{adaptFromTask<o2::fv0::FV0DCSDataProcessor>("FV0", ddBChM)},
+    AlgorithmSpec{adaptFromTask<o2::fv0::FV0DCSDataProcessor>("FV0", ddDCSDPs)},
     Options{{"ccdb-path", VariantType::String, "http://localhost:8080", {"Path to CCDB"}},
             {"use-ccdb-to-configure", VariantType::Bool, false, {"Use CCDB to configure"}},
             {"use-verbose-mode", VariantType::Bool, false, {"Use verbose mode"}},

--- a/Detectors/FIT/common/dcsmonitoring/include/FITDCSMonitoring/FITDCSConfigReader.h
+++ b/Detectors/FIT/common/dcsmonitoring/include/FITDCSMonitoring/FITDCSConfigReader.h
@@ -18,7 +18,7 @@
 #define O2_FIT_DCSCONFIGREADER_H
 
 #include "CCDB/CcdbObjectInfo.h"
-#include "DataFormatsFIT/BadChannelMap.h"
+#include "DataFormatsFIT/DeadChannelMap.h"
 
 #include <gsl/span>
 #include <string>
@@ -34,36 +34,36 @@ class FITDCSConfigReader
   FITDCSConfigReader() = default;
   ~FITDCSConfigReader() = default;
 
-  virtual void processBChM(gsl::span<const char> configBuf);
-  void updateBChMCcdbObjectInfo();
+  virtual void processDChM(gsl::span<const char> configBuf);
+  void updateDChMCcdbObjectInfo();
 
-  const o2::fit::BadChannelMap& getBChM() const;
-  void resetBChM();
-  const std::string& getCcdbPathBChm() const;
-  void setCcdbPathBChM(const std::string& ccdbPath);
-  const long getStartValidityBChM() const;
-  const long getEndValidityBChM() const;
-  void setStartValidityBChM(const long startValidity);
-  const bool isStartValidityBChMSet() const;
-  void resetStartValidityBChM();
-  const o2::ccdb::CcdbObjectInfo& getObjectInfoBChM() const;
-  o2::ccdb::CcdbObjectInfo& getObjectInfoBChM();
+  const o2::fit::DeadChannelMap& getDChM() const;
+  void resetDChM();
+  const std::string& getCcdbPathDChm() const;
+  void setCcdbPathDChM(const std::string& ccdbPath);
+  const long getStartValidityDChM() const;
+  const long getEndValidityDChM() const;
+  void setStartValidityDChM(const long startValidity);
+  const bool isStartValidityDChMSet() const;
+  void resetStartValidityDChM();
+  const o2::ccdb::CcdbObjectInfo& getObjectInfoDChM() const;
+  o2::ccdb::CcdbObjectInfo& getObjectInfoDChM();
 
-  const std::string& getFileNameBChM() const;
-  void setFileNameBChM(const std::string& fileName);
+  const std::string& getFileNameDChM() const;
+  void setFileNameDChM(const std::string& fileName);
 
   const bool getVerboseMode() const;
   void setVerboseMode(const bool verboseMode);
 
  protected:
-  o2::fit::BadChannelMap mBChM; ///< The bad channel map CCDB object
-  bool mVerbose = false;        ///< Verbose mode
+  o2::fit::DeadChannelMap mDChM; ///< The dead channel map CCDB object
+  bool mVerbose = false;         ///< Verbose mode
 
  private:
-  std::string mFileNameBChM;                                              ///< The expected file name of the bad channel map
-  std::string mCcdbPathBChM;                                              ///< The bad channel map CCDB path
-  long mStartValidityBChM = o2::ccdb::CcdbObjectInfo::INFINITE_TIMESTAMP; ///< Start validity of the bad channel map CCDB object
-  o2::ccdb::CcdbObjectInfo mCcdbObjectInfoBChM;                           ///< CCDB object info for the bad channel map
+  std::string mFileNameDChM;                                              ///< The expected file name of the dead channel map
+  std::string mCcdbPathDChM;                                              ///< The dead channel map CCDB path
+  long mStartValidityDChM = o2::ccdb::CcdbObjectInfo::INFINITE_TIMESTAMP; ///< Start validity of the dead channel map CCDB object
+  o2::ccdb::CcdbObjectInfo mCcdbObjectInfoDChM;                           ///< CCDB object info for the dead channel map
 
   ClassDefNV(FITDCSConfigReader, 1);
 };

--- a/Detectors/FIT/common/dcsmonitoring/macros/CMakeLists.txt
+++ b/Detectors/FIT/common/dcsmonitoring/macros/CMakeLists.txt
@@ -9,7 +9,7 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-o2_add_test_root_macro(makeDefaultBadChannelMap.C
+o2_add_test_root_macro(makeDefaultDeadChannelMap.C
                        PUBLIC_LINK_LIBRARIES O2::CCDB
                                              O2::DataFormatsFIT
                                              O2::Framework

--- a/Detectors/FIT/common/dcsmonitoring/macros/makeDefaultDeadChannelMap.C
+++ b/Detectors/FIT/common/dcsmonitoring/macros/makeDefaultDeadChannelMap.C
@@ -9,15 +9,15 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file makeDefaultBadChannelMap.C
-/// \brief Macro for uploading default bad channel maps to CCDB
+/// \file makeDefaultDeadChannelMap.C
+/// \brief Macro for uploading default dead channel maps to CCDB
 ///
 /// \author Andreas Molander <andreas.molander@cern.ch>, University of Jyvaskyla, Finland
 
 #if !defined(__CLING__) || defined(__ROOTCLING__)
 
 #include "CCDB/CcdbApi.h"
-#include "DataFormatsFIT/BadChannelMap.h"
+#include "DataFormatsFIT/DeadChannelMap.h"
 #include "TFile.h"
 
 #include <chrono>
@@ -30,9 +30,9 @@
 
 #include <boost/algorithm/string.hpp>
 
-void makeDefaultBadChannelMap(std::string detectorName,
-                              const std::string ccdbUrl = "http://localhost:8080",
-                              const std::string fileName = "")
+void makeDefaultDeadChannelMap(std::string detectorName,
+                               const std::string ccdbUrl = "http://localhost:8080",
+                               const std::string fileName = "")
 {
   boost::to_upper(detectorName);
 
@@ -49,29 +49,29 @@ void makeDefaultBadChannelMap(std::string detectorName,
     return;
   }
 
-  LOGP(info, "Creating default bad channel map for {}.", detectorName);
+  LOGP(info, "Creating default dead channel map for {}.", detectorName);
 
-  o2::fit::BadChannelMap badChannelMap;
+  o2::fit::DeadChannelMap deadChannelMap;
 
   for (int iChannel = 0; iChannel < nChannels; iChannel++) {
-    badChannelMap.setChannelGood(iChannel, true);
+    deadChannelMap.setChannelAlive(iChannel, true);
   }
 
   if (!ccdbUrl.empty()) {
-    const std::string ccdbPath = detectorName + "/Calib/BadChannelMap";
+    const std::string ccdbPath = detectorName + "/Calib/DeadChannelMap";
     std::map<std::string, std::string> metadata;
     metadata["default"] = "true";
-    metadata["comment"] = "Default bad channel map, all channels are good.";
-    LOGP(info, "Storing default bad channel map on {}/{}.", ccdbUrl, ccdbPath);
+    metadata["comment"] = "Default dead channel map, all channels are alive.";
+    LOGP(info, "Storing default dead channel map on {}/{}.", ccdbUrl, ccdbPath);
     o2::ccdb::CcdbApi api;
     api.init(ccdbUrl);
-    api.storeAsTFileAny(&badChannelMap, ccdbPath, metadata, 1, 99999999999999);
+    api.storeAsTFileAny(&deadChannelMap, ccdbPath, metadata, 1, 99999999999999);
   }
 
   if (!fileName.empty()) {
-    LOGP(info, "Storing default bad channel map locally in {}.", fileName);
+    LOGP(info, "Storing default dead channel map locally in {}.", fileName);
     std::unique_ptr<TFile> file(TFile::Open(fileName.c_str(), "RECREATE"));
-    file->WriteObject(&badChannelMap, "badChannelMap");
+    file->WriteObject(&deadChannelMap, "deadChannelMap");
   }
   return;
 }

--- a/Detectors/FIT/common/dcsmonitoring/src/FITDCSConfigReader.cxx
+++ b/Detectors/FIT/common/dcsmonitoring/src/FITDCSConfigReader.cxx
@@ -23,9 +23,9 @@
 
 using namespace o2::fit;
 
-void FITDCSConfigReader::processBChM(gsl::span<const char> configBuf)
+void FITDCSConfigReader::processDChM(gsl::span<const char> configBuf)
 {
-  LOG(info) << "Processing bad channel map";
+  LOG(info) << "Processing dead channel map";
 
   // AM: need to specify the size,
   // otherwise the configBuf.data() pointer might point to an array that is too long,
@@ -34,7 +34,7 @@ void FITDCSConfigReader::processBChM(gsl::span<const char> configBuf)
   uint8_t iLine = 0; // line 0 corresponds to cahnnel id 0 and so on
 
   for (std::string line; std::getline(iss, line);) {
-    mBChM.setChannelGood(iLine, std::stoi(line) == 1);
+    mDChM.setChannelAlive(iLine, std::stoi(line) == 1);
     iLine++;
   }
 
@@ -43,26 +43,26 @@ void FITDCSConfigReader::processBChM(gsl::span<const char> configBuf)
   }
 }
 
-void FITDCSConfigReader::updateBChMCcdbObjectInfo()
+void FITDCSConfigReader::updateDChMCcdbObjectInfo()
 {
   std::map<std::string, std::string> metadata;
-  o2::calibration::Utils::prepareCCDBobjectInfo(mBChM, mCcdbObjectInfoBChM, mCcdbPathBChM, metadata, getStartValidityBChM(), getEndValidityBChM());
+  o2::calibration::Utils::prepareCCDBobjectInfo(mDChM, mCcdbObjectInfoDChM, mCcdbPathDChM, metadata, getStartValidityDChM(), getEndValidityDChM());
 }
 
-const o2::fit::BadChannelMap& FITDCSConfigReader::getBChM() const { return mBChM; }
-void FITDCSConfigReader::resetBChM() { mBChM.clear(); }
-const std::string& FITDCSConfigReader::getCcdbPathBChm() const { return mCcdbPathBChM; }
-void FITDCSConfigReader::setCcdbPathBChM(const std::string& ccdbPath) { mCcdbPathBChM = ccdbPath; }
-const long FITDCSConfigReader::getStartValidityBChM() const { return mStartValidityBChM; }
-const long FITDCSConfigReader::getEndValidityBChM() const { return mStartValidityBChM + o2::ccdb::CcdbObjectInfo::MONTH; }
-void FITDCSConfigReader::setStartValidityBChM(const long startValidity) { mStartValidityBChM = startValidity; }
-const bool FITDCSConfigReader::isStartValidityBChMSet() const { return mStartValidityBChM != o2::ccdb::CcdbObjectInfo::INFINITE_TIMESTAMP; }
-void FITDCSConfigReader::resetStartValidityBChM() { mStartValidityBChM = o2::ccdb::CcdbObjectInfo::INFINITE_TIMESTAMP; }
-const o2::ccdb::CcdbObjectInfo& FITDCSConfigReader::getObjectInfoBChM() const { return mCcdbObjectInfoBChM; }
-o2::ccdb::CcdbObjectInfo& FITDCSConfigReader::getObjectInfoBChM() { return mCcdbObjectInfoBChM; }
+const o2::fit::DeadChannelMap& FITDCSConfigReader::getDChM() const { return mDChM; }
+void FITDCSConfigReader::resetDChM() { mDChM.clear(); }
+const std::string& FITDCSConfigReader::getCcdbPathDChm() const { return mCcdbPathDChM; }
+void FITDCSConfigReader::setCcdbPathDChM(const std::string& ccdbPath) { mCcdbPathDChM = ccdbPath; }
+const long FITDCSConfigReader::getStartValidityDChM() const { return mStartValidityDChM; }
+const long FITDCSConfigReader::getEndValidityDChM() const { return mStartValidityDChM + o2::ccdb::CcdbObjectInfo::MONTH; }
+void FITDCSConfigReader::setStartValidityDChM(const long startValidity) { mStartValidityDChM = startValidity; }
+const bool FITDCSConfigReader::isStartValidityDChMSet() const { return mStartValidityDChM != o2::ccdb::CcdbObjectInfo::INFINITE_TIMESTAMP; }
+void FITDCSConfigReader::resetStartValidityDChM() { mStartValidityDChM = o2::ccdb::CcdbObjectInfo::INFINITE_TIMESTAMP; }
+const o2::ccdb::CcdbObjectInfo& FITDCSConfigReader::getObjectInfoDChM() const { return mCcdbObjectInfoDChM; }
+o2::ccdb::CcdbObjectInfo& FITDCSConfigReader::getObjectInfoDChM() { return mCcdbObjectInfoDChM; }
 
-const std::string& FITDCSConfigReader::getFileNameBChM() const { return mFileNameBChM; }
-void FITDCSConfigReader::setFileNameBChM(const std::string& fileName) { mFileNameBChM = fileName; }
+const std::string& FITDCSConfigReader::getFileNameDChM() const { return mFileNameDChM; }
+void FITDCSConfigReader::setFileNameDChM(const std::string& fileName) { mFileNameDChM = fileName; }
 
 const bool FITDCSConfigReader::getVerboseMode() const { return mVerbose; }
 void FITDCSConfigReader::setVerboseMode(const bool verboseMode) { mVerbose = verboseMode; }

--- a/Detectors/FIT/common/dcsmonitoring/src/FITDCSDataReader.cxx
+++ b/Detectors/FIT/common/dcsmonitoring/src/FITDCSDataReader.cxx
@@ -102,7 +102,7 @@ int FITDCSDataReader::processDP(const DPCOM& dpcom)
     if (mDpData[dpid].values.empty() || val.get_epoch_time() > mDpData[dpid].values.back().first) {
       dpValueConverter.raw_data = val.payload_pt1;
       if (type == DPVAL_DOUBLE) {
-        mDpData[dpid].add(val.get_epoch_time(), lround(dpValueConverter.double_value * 1000)); // store as nA
+        mDpData[dpid].add(val.get_epoch_time(), llround(dpValueConverter.double_value * 1000)); // store as nA
       } else if (type == DPVAL_UINT) {
         mDpData[dpid].add(val.get_epoch_time(), dpValueConverter.uint_value);
       }

--- a/Detectors/FIT/common/dcsmonitoring/src/FITDCSMonitoringLinkDef.h
+++ b/Detectors/FIT/common/dcsmonitoring/src/FITDCSMonitoringLinkDef.h
@@ -16,7 +16,7 @@
 #pragma link off all functions;
 
 #pragma link C++ std::unordered_map < uint8_t, bool> + ;
-#pragma link C++ struct o2::fit::BadChannelMap + ;
+#pragma link C++ struct o2::fit::DeadChannelMap + ;
 
 // TODO AM: Move this to DataFormatsFIT when unused class warning is solved.
 #pragma link C++ class std::unordered_map < o2::dcs::DataPointIdentifier, o2::fit::DCSDPValues> + ;

--- a/Detectors/FIT/macros/CMakeLists.txt
+++ b/Detectors/FIT/macros/CMakeLists.txt
@@ -29,7 +29,7 @@ o2_add_test_root_macro(readFV0digits.C
                        PUBLIC_LINK_LIBRARIES O2::FV0Simulation
                        LABELS fit)
 
-o2_add_test_root_macro(readFITBadChannelMap.C
+o2_add_test_root_macro(readFITDeadChannelMap.C
                        PUBLIC_LINK_LIBRARIES O2::CCDB
                                              O2::DataFormatsFIT
                                              O2::Framework


### PR DESCRIPTION
- Store DCS DP values as 64 bit integers in CCDB instead of 32 bit integers. Double values are multplied by 1000 and stored as integers, trigger rates would therefore overflow with 32 bits.
- Rename bad channel map to dead channel map.