### PR TITLE
ITS: Add per-ROF OMP multithreading to seeding tracklet finding and selection

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
@@ -106,6 +106,8 @@ struct VertexingParameters {
   int maxTrackletsPerCluster = 2e3;
   int phiSpan = -1;
   int zSpan = -1;
+
+  int nThreads = 1;
 };
 
 struct VertexerHistogramsConfiguration {

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -372,14 +372,14 @@ inline gsl::span<int> TimeFrame::getIndexTable(int rofId, int layer)
           static_cast<gsl::span<int>::size_type>(mIndexTableUtils.getNphiBins() * mIndexTableUtils.getNzBins() + 1)};
 }
 
-inline std::vector<Line>& TimeFrame::getLines(int tf)
+inline std::vector<Line>& TimeFrame::getLines(int rof)
 {
-  return mLines[tf];
+  return mLines[rof];
 }
 
-inline std::vector<ClusterLines>& TimeFrame::getTrackletClusters(int tf)
+inline std::vector<ClusterLines>& TimeFrame::getTrackletClusters(int rof)
 {
-  return mTrackletClusters[tf];
+  return mTrackletClusters[rof];
 }
 
 template <typename... T>

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TimeFrame.h
@@ -157,13 +157,16 @@ class TimeFrame
   int getROfCutAllMult() const { return mCutClusterMult + mCutVertexMult; }
 
   // Vertexer
-  void computeTrackletsScans();
+  void computeTrackletsScans(const int nThreads = 1);
   int& getNTrackletsROf(int tf, int combId);
   std::vector<Line>& getLines(int tf);
   std::vector<ClusterLines>& getTrackletClusters(int tf);
   gsl::span<const Tracklet> getFoundTracklets(int rofId, int combId) const;
+  gsl::span<Tracklet> getFoundTracklets(int rofId, int combId);
   gsl::span<const MCCompLabel> getLabelsFoundTracklets(int rofId, int combId) const;
   gsl::span<int> getNTrackletsCluster(int rofId, int combId);
+  uint32_t getTotalTrackletsTF(const int iLayer) { return mTotalTracklets[iLayer]; }
+
   // \Vertexer
 
   void initialiseRoadLabels();
@@ -244,6 +247,7 @@ class TimeFrame
   std::vector<std::vector<int>> mTrackletsIndexROf;
   std::vector<std::vector<MCCompLabel>> mLinesLabels;
   std::vector<std::vector<MCCompLabel>> mVerticesLabels;
+  std::array<uint32_t, 2> mTotalTracklets = {0, 0};
   // \Vertexer
 };
 
@@ -443,9 +447,9 @@ inline gsl::span<int> TimeFrame::getNTrackletsCluster(int rofId, int combId)
   return {&mNTrackletsPerCluster[combId][startIdx], static_cast<gsl::span<int>::size_type>(mROframesClusters[1][rofId + 1] - startIdx)};
 }
 
-inline int& TimeFrame::getNTrackletsROf(int tf, int combId)
+inline int& TimeFrame::getNTrackletsROf(int rof, int combId)
 {
-  return mNTrackletsPerROf[combId][tf];
+  return mNTrackletsPerROf[combId][rof];
 }
 
 inline bool TimeFrame::isRoadFake(int i) const
@@ -476,6 +480,15 @@ inline std::vector<std::vector<std::vector<int>>>& TimeFrame::getCellsNeighbours
 }
 
 inline std::vector<Road>& TimeFrame::getRoads() { return mRoads; }
+
+inline gsl::span<Tracklet> TimeFrame::getFoundTracklets(int rofId, int combId)
+{
+  if (rofId < 0 || rofId >= mNrof) {
+    return gsl::span<Tracklet>();
+  }
+  auto startIdx{mNTrackletsPerROf[combId][rofId]};
+  return {&mTracklets[combId][startIdx], static_cast<gsl::span<Tracklet>::size_type>(mNTrackletsPerROf[combId][rofId + 1] - startIdx)};
+}
 
 inline gsl::span<const Tracklet> TimeFrame::getFoundTracklets(int rofId, int combId) const
 {

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
@@ -34,6 +34,8 @@ struct VertexerParamConfig : public o2::conf::ConfigurableParamHelper<VertexerPa
   int phiSpan = -1;
   int zSpan = -1;
 
+  int nThreads = 1;
+
   O2ParamDef(VertexerParamConfig, "ITSVertexerParam");
 };
 

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Vertexer.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Vertexer.h
@@ -53,12 +53,10 @@ class Vertexer
   Vertexer& operator=(const Vertexer&) = delete;
 
   void adoptTimeFrame(TimeFrame& tf);
-  void setROframe(const uint32_t ROframe) { mROframe = ROframe; }
   void setParameters(const VertexingParameters& verPar);
   void getGlobalConfiguration();
   VertexingParameters getVertParameters() const;
 
-  uint32_t getROFrame() const { return mROframe; }
   std::vector<Vertex> exportVertices();
   VertexerTraits* getTraits() const { return mTraits; };
 
@@ -82,9 +80,10 @@ class Vertexer
   void dumpTraits();
   template <typename... T>
   float evaluateTask(void (Vertexer::*)(T...), const char*, std::function<void(std::string s)> logger, T&&... args);
+  void printEpilog(std::function<void(std::string s)> logger, const float total);
 
  private:
-  std::uint32_t mROframe = 0;
+  std::uint32_t mTimeFrameCounter = 0;
 
   VertexerTraits* mTraits = nullptr; /// Observer pointer, not owned by this class
   TimeFrame* mTimeFrame = nullptr;   /// Observer pointer, not owned by this class

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
@@ -81,9 +81,12 @@ class VertexerTraits
   void setIsGPU(const unsigned char isgpu) { mIsGPU = isgpu; };
   unsigned char getIsGPU() const { return mIsGPU; };
   void dumpVertexerTraits();
+  void setNThreads(int n);
+  int getNThreads() const { return mNThreads; }
 
  protected:
   unsigned char mIsGPU;
+  int mNThreads = 1;
 
   VertexingParameters mVrtParams;
   IndexTableUtils mIndexTableUtils;

--- a/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
@@ -24,6 +24,10 @@
 
 #include <iostream>
 
+#ifdef WITH_OPENMP
+#include <omp.h>
+#endif
+
 namespace
 {
 struct ClusterHelper {
@@ -476,10 +480,13 @@ void TimeFrame::printROFoffsets()
   }
 }
 
-void TimeFrame::computeTrackletsScans()
+void TimeFrame::computeTrackletsScans(const int nThreads)
 {
-  std::exclusive_scan(mNTrackletsPerROf[0].begin(), mNTrackletsPerROf[0].end(), mNTrackletsPerROf[0].begin(), 0);
-  std::exclusive_scan(mNTrackletsPerROf[1].begin(), mNTrackletsPerROf[1].end(), mNTrackletsPerROf[1].begin(), 0);
+#pragma omp parallel for num_threads(nThreads > 1 ? 2 : nThreads)
+  for (ushort iLayer = 0; iLayer < 2; ++iLayer) {
+    mTotalTracklets[iLayer] = std::accumulate(mNTrackletsPerROf[iLayer].begin(), mNTrackletsPerROf[iLayer].end(), 0);
+    std::exclusive_scan(mNTrackletsPerROf[iLayer].begin(), mNTrackletsPerROf[iLayer].end(), mNTrackletsPerROf[iLayer].begin(), 0);
+  }
 }
 
 } // namespace its

--- a/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
@@ -482,7 +482,7 @@ void TimeFrame::printROFoffsets()
 
 void TimeFrame::computeTrackletsScans(const int nThreads)
 {
-#pragma omp parallel for num_threads(nThreads > 1 ? 2 : nThreads)
+  // #pragma omp parallel for num_threads(nThreads > 1 ? 2 : nThreads)
   for (ushort iLayer = 0; iLayer < 2; ++iLayer) {
     mTotalTracklets[iLayer] = std::accumulate(mNTrackletsPerROf[iLayer].begin(), mNTrackletsPerROf[iLayer].end(), 0);
     std::exclusive_scan(mNTrackletsPerROf[iLayer].begin(), mNTrackletsPerROf[iLayer].end(), mNTrackletsPerROf[iLayer].begin(), 0);

--- a/Detectors/ITSMFT/ITS/tracking/src/TrackerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TrackerTraits.cxx
@@ -998,6 +998,7 @@ void TrackerTraits::setNThreads(int n)
   mNThreads = 1;
 #endif
 }
+
 int TrackerTraits::getTFNumberOfClusters() const
 {
   return mTimeFrame->getNumberOfClusters();

--- a/Detectors/ITSMFT/ITS/tracking/src/Vertexer.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Vertexer.cxx
@@ -41,10 +41,10 @@ float Vertexer::clustersToVertices(std::function<void(std::string s)> logger)
   float total{0.f};
   TrackingParameters trkPars;
   total += evaluateTask(&Vertexer::initialiseVertexer, "Vertexer initialisation", logger, trkPars);
-  total += evaluateTask(&Vertexer::findTracklets, "Tracklet finding", logger);
-  total += evaluateTask(&Vertexer::validateTracklets, "Adjacent tracklets validation", logger);
-  total += evaluateTask(&Vertexer::findVertices, "Vertex finding", logger);
-
+  total += evaluateTask(&Vertexer::findTracklets, "Vertexer tracklet finding", logger);
+  total += evaluateTask(&Vertexer::validateTracklets, "Vertexer adjacent tracklets validation", logger);
+  total += evaluateTask(&Vertexer::findVertices, "Vertexer vertex finding", logger);
+  printEpilog(logger, total);
   return total;
 }
 
@@ -67,6 +67,7 @@ void Vertexer::getGlobalConfiguration()
   verPar.clusterContributorsCut = vc.clusterContributorsCut;
   verPar.maxTrackletsPerCluster = vc.maxTrackletsPerCluster;
   verPar.phiSpan = vc.phiSpan;
+  verPar.nThreads = vc.nThreads;
 
   mTraits->updateVertexingParameters(verPar);
 }
@@ -76,5 +77,11 @@ void Vertexer::adoptTimeFrame(TimeFrame& tf)
   mTimeFrame = &tf;
   mTraits->adoptTimeFrame(&tf);
 }
+
+void Vertexer::printEpilog(std::function<void(std::string s)> logger, const float total)
+{
+  logger(fmt::format(" - Timeframe {} vertexing completed in: {}ms, using {} thread(s).", mTimeFrameCounter++, total, mTraits->getNThreads()));
+}
+
 } // namespace its
 } // namespace o2

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -24,6 +24,10 @@
 #include <ostream>
 #endif
 
+#ifdef WITH_OPENMP
+#include <omp.h>
+#endif
+
 namespace o2
 {
 namespace its
@@ -31,22 +35,24 @@ namespace its
 using boost::histogram::indexed;
 using constants::math::TwoPi;
 
-template <TrackletMode Mode>
-void trackleterKernelSerial(
+template <TrackletMode Mode, bool DryRun>
+void trackleterKernelHost(
   const gsl::span<const Cluster>& clustersNextLayer,    // 0 2
   const gsl::span<const Cluster>& clustersCurrentLayer, // 1 1
   int* indexTableNext,
   const float phiCut,
-  std::vector<Tracklet>& Tracklets,
+  std::vector<Tracklet>& tracklets,
   gsl::span<int> foundTracklets,
   const IndexTableUtils& utils,
   const int rof,
+  const int rofFoundTrackletsOffset,
   const int maxTrackletsPerCluster = static_cast<int>(2e3))
 {
   const int PhiBins{utils.getNphiBins()};
   const int ZBins{utils.getNzBins()};
   // loop on layer1 clusters
-  for (unsigned int iCurrentLayerClusterIndex{0}; iCurrentLayerClusterIndex < clustersCurrentLayer.size(); ++iCurrentLayerClusterIndex) {
+  int cumulativeStoredTracklets{0};
+  for (int iCurrentLayerClusterIndex = 0; iCurrentLayerClusterIndex < clustersCurrentLayer.size(); ++iCurrentLayerClusterIndex) {
     int storedTracklets{0};
     const Cluster& currentCluster{clustersCurrentLayer[iCurrentLayerClusterIndex]};
     const int4 selectedBinsRect{VertexerTraits::getBinsRect(currentCluster, (int)Mode, 0.f, 50.f, phiCut / 2, utils)};
@@ -65,10 +71,12 @@ void trackleterKernelSerial(
           const Cluster& nextCluster{clustersNextLayer[iNextLayerClusterIndex]};
           if (o2::gpu::GPUCommonMath::Abs(currentCluster.phi - nextCluster.phi) < phiCut) {
             if (storedTracklets < maxTrackletsPerCluster) {
-              if constexpr (Mode == TrackletMode::Layer0Layer1) {
-                Tracklets.emplace_back(iNextLayerClusterIndex, iCurrentLayerClusterIndex, nextCluster, currentCluster, rof, rof);
-              } else {
-                Tracklets.emplace_back(iCurrentLayerClusterIndex, iNextLayerClusterIndex, currentCluster, nextCluster, rof, rof);
+              if constexpr (!DryRun) {
+                if constexpr (Mode == TrackletMode::Layer0Layer1) {
+                  tracklets[rofFoundTrackletsOffset + cumulativeStoredTracklets + storedTracklets] = Tracklet{iNextLayerClusterIndex, iCurrentLayerClusterIndex, nextCluster, currentCluster, rof, rof};
+                } else {
+                  tracklets[rofFoundTrackletsOffset + cumulativeStoredTracklets + storedTracklets] = Tracklet{iCurrentLayerClusterIndex, iNextLayerClusterIndex, currentCluster, nextCluster, rof, rof};
+                }
               }
               ++storedTracklets;
             }
@@ -76,11 +84,15 @@ void trackleterKernelSerial(
         }
       }
     }
-    foundTracklets[iCurrentLayerClusterIndex] = storedTracklets;
+    if constexpr (DryRun) {
+      foundTracklets[iCurrentLayerClusterIndex] = storedTracklets;
+    } else {
+      cumulativeStoredTracklets += storedTracklets;
+    }
   }
 }
 
-void trackletSelectionKernelSerial(
+void trackletSelectionKernelHost(
   const gsl::span<const Cluster> clusters0, // 0
   const gsl::span<const Cluster> clusters1, // 1
   const gsl::span<const Tracklet>& tracklets01,
@@ -144,12 +156,14 @@ void VertexerTraits::updateVertexingParameters(const VertexingParameters& vrtPar
   mVrtParams.phiSpan = static_cast<int>(std::ceil(mIndexTableUtils.getNphiBins() * mVrtParams.phiCut /
                                                   constants::math::TwoPi));
   mVrtParams.zSpan = static_cast<int>(std::ceil(mVrtParams.zCut * mIndexTableUtils.getInverseZCoordinate(0)));
+  setNThreads(mVrtParams.nThreads);
 }
 
 void VertexerTraits::computeTracklets()
 {
-  for (int rofId{0}; rofId < mTimeFrame->getNrof(); ++rofId) {
-    trackleterKernelSerial<TrackletMode::Layer0Layer1>(
+#pragma omp parallel for num_threads(mNThreads)
+  for (int rofId = 0; rofId < mTimeFrame->getNrof(); ++rofId) {
+    trackleterKernelHost<TrackletMode::Layer0Layer1, true>(
       mTimeFrame->getClustersOnLayer(rofId, 0),
       mTimeFrame->getClustersOnLayer(rofId, 1),
       mTimeFrame->getIndexTable(rofId, 0).data(),
@@ -158,8 +172,9 @@ void VertexerTraits::computeTracklets()
       mTimeFrame->getNTrackletsCluster(rofId, 0),
       mIndexTableUtils,
       rofId,
+      0,
       mVrtParams.maxTrackletsPerCluster);
-    trackleterKernelSerial<TrackletMode::Layer1Layer2>(
+    trackleterKernelHost<TrackletMode::Layer1Layer2, true>(
       mTimeFrame->getClustersOnLayer(rofId, 2),
       mTimeFrame->getClustersOnLayer(rofId, 1),
       mTimeFrame->getIndexTable(rofId, 2).data(),
@@ -168,11 +183,41 @@ void VertexerTraits::computeTracklets()
       mTimeFrame->getNTrackletsCluster(rofId, 1),
       mIndexTableUtils,
       rofId,
+      0,
       mVrtParams.maxTrackletsPerCluster);
     mTimeFrame->getNTrackletsROf(rofId, 0) = std::accumulate(mTimeFrame->getNTrackletsCluster(rofId, 0).begin(), mTimeFrame->getNTrackletsCluster(rofId, 0).end(), 0);
     mTimeFrame->getNTrackletsROf(rofId, 1) = std::accumulate(mTimeFrame->getNTrackletsCluster(rofId, 1).begin(), mTimeFrame->getNTrackletsCluster(rofId, 1).end(), 0);
   }
-  mTimeFrame->computeTrackletsScans();
+
+  mTimeFrame->computeTrackletsScans(mNThreads);
+  mTimeFrame->getTracklets()[0].reserve(mTimeFrame->getTotalTrackletsTF(0));
+  mTimeFrame->getTracklets()[1].reserve(mTimeFrame->getTotalTrackletsTF(1));
+
+#pragma omp parallel for num_threads(mNThreads)
+  for (int rofId = 0; rofId < mTimeFrame->getNrof(); ++rofId) {
+    trackleterKernelHost<TrackletMode::Layer0Layer1, false>(
+      mTimeFrame->getClustersOnLayer(rofId, 0),
+      mTimeFrame->getClustersOnLayer(rofId, 1),
+      mTimeFrame->getIndexTable(rofId, 0).data(),
+      mVrtParams.phiCut,
+      mTimeFrame->getTracklets()[0],
+      mTimeFrame->getNTrackletsCluster(rofId, 0),
+      mIndexTableUtils,
+      rofId,
+      mTimeFrame->getNTrackletsROf(rofId, 0),
+      mVrtParams.maxTrackletsPerCluster);
+    trackleterKernelHost<TrackletMode::Layer1Layer2, false>(
+      mTimeFrame->getClustersOnLayer(rofId, 2),
+      mTimeFrame->getClustersOnLayer(rofId, 1),
+      mTimeFrame->getIndexTable(rofId, 2).data(),
+      mVrtParams.phiCut,
+      mTimeFrame->getTracklets()[1],
+      mTimeFrame->getNTrackletsCluster(rofId, 1),
+      mIndexTableUtils,
+      rofId,
+      mTimeFrame->getNTrackletsROf(rofId, 1),
+      mVrtParams.maxTrackletsPerCluster);
+  }
 
   /// Create tracklets labels for L0-L1, information is as flat as in tracklets vector (no rofId)
   if (mTimeFrame->hasMCinformation()) {
@@ -236,7 +281,7 @@ void VertexerTraits::computeTracklets()
 void VertexerTraits::computeTrackletMatching()
 {
   for (int rofId{0}; rofId < mTimeFrame->getNrof(); ++rofId) {
-    trackletSelectionKernelSerial(
+    trackletSelectionKernelHost(
       mTimeFrame->getClustersOnLayer(rofId, 0),
       mTimeFrame->getClustersOnLayer(rofId, 1),
       mTimeFrame->getFoundTracklets(rofId, 0),
@@ -408,6 +453,16 @@ void VertexerTraits::computeVertices()
   ln_clus_lines_tree->Write();
   dbg_file->Close();
 #endif
+}
+
+void VertexerTraits::setNThreads(int n)
+{
+#ifdef WITH_OPENMP
+  mNThreads = n > 0 ? n : 1;
+#else
+  mNThreads = 1;
+#endif
+  LOGP(info, "Setting seeding vertexer with {} threads.", mNThreads);
 }
 
 // void VertexerTraits::computeHistVertices()

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -190,8 +190,8 @@ void VertexerTraits::computeTracklets()
   }
 
   mTimeFrame->computeTrackletsScans(mNThreads);
-  mTimeFrame->getTracklets()[0].reserve(mTimeFrame->getTotalTrackletsTF(0));
-  mTimeFrame->getTracklets()[1].reserve(mTimeFrame->getTotalTrackletsTF(1));
+  mTimeFrame->getTracklets()[0].resize(mTimeFrame->getTotalTrackletsTF(0));
+  mTimeFrame->getTracklets()[1].resize(mTimeFrame->getTotalTrackletsTF(1));
 
 #pragma omp parallel for num_threads(mNThreads)
   for (int rofId = 0; rofId < mTimeFrame->getNrof(); ++rofId) {


### PR DESCRIPTION
Hi @shahor02: this PR add the parallelisation of the "tracklet finding" part of the seeding vertexer.
Next will be the tracklet validation.

Hereafter the elapsed time for the `computeTracklets()` call as a function of #threads. This i got from a quick test on my M2 Mac (4 physical cores).

To test it: `--configKeyValues='ITSVertexerParam.nThreads=<n>'`

| # threads | trackleting elapsed time (ms) |
|-----------|-------------------------------|
| 1         | 222.4                         |
| 2         | 137.3                         |
| 3         | 91.6                          |
| 4         | 76.0                          |

As embarrassing parallelism is applied at ROF level, I expect the single TF processing time should theoretically scale better over more threads, on a more capable machine. I am also aware we will not allocate 32 threads for this.

I'll do a more extended test on the other workstation once I'll add the tracklet selection parallelisation.