### PR TITLE
Added possibility to set maximum size of output files

### DIFF
--- a/Framework/Core/include/Framework/DataOutputDirector.h
+++ b/Framework/Core/include/Framework/DataOutputDirector.h
@@ -90,13 +90,20 @@ struct DataOutputDirector {
   // get the matching TFile
   FileAndFolder getFileFolder(DataOutputDescriptor* dodesc, uint64_t folderNumber, std::string parentFileName);
 
+  // check file sizes
+  bool checkFileSizes();
+  // close all files
   void closeDataFiles();
 
+  // setters
+  void setResultDir(std::string resDir);
   void setFilenameBase(std::string dfn);
+  void setMaximumFileSize(float maxfs);
 
   void printOut();
 
  private:
+  std::string mresultDirectory;
   std::string mfilenameBase;
   std::string* const mfilenameBasePtr = &mfilenameBase;
   std::vector<DataOutputDescriptor*> mDataOutputDescriptors;
@@ -105,6 +112,8 @@ struct DataOutputDirector {
   std::vector<TFile*> mfilePtrs;
   std::vector<TMap*> mParentMaps;
   bool mdebugmode = false;
+  int mfileCounter = 1;
+  float mmaxfilesize = -1.;
   int mnumberTimeFramesToMerge = 1;
   std::string mfileMode = "RECREATE";
 

--- a/Framework/Core/include/Framework/DataOutputDirector.h
+++ b/Framework/Core/include/Framework/DataOutputDirector.h
@@ -103,7 +103,7 @@ struct DataOutputDirector {
   void printOut();
 
  private:
-  std::string mresultDirectory;
+  std::string mresultDirectory{"."};
   std::string mfilenameBase;
   std::string* const mfilenameBasePtr = &mfilenameBase;
   std::vector<DataOutputDescriptor*> mDataOutputDescriptors;

--- a/Framework/Core/src/CommonDataProcessors.cxx
+++ b/Framework/Core/src/CommonDataProcessors.cxx
@@ -326,6 +326,9 @@ DataProcessorSpec
         tfFilenames.insert(std::pair<uint64_t, std::string>(startTime, aodInputFile));
       }
 
+      // close all output files if one has reached size limit
+      dod->checkFileSizes();
+
       // loop over the DataRefs which are contained in pc.inputs()
       for (const auto& ref : pc.inputs()) {
         if (!ref.spec) {

--- a/Framework/Core/src/DataOutputDirector.cxx
+++ b/Framework/Core/src/DataOutputDirector.cxx
@@ -11,12 +11,16 @@
 #include "Framework/DataOutputDirector.h"
 #include "Framework/Logger.h"
 
+#include <filesystem>
+
 #include "rapidjson/document.h"
 #include "rapidjson/prettywriter.h"
 #include "rapidjson/filereadstream.h"
 
 #include "TMap.h"
 #include "TObjString.h"
+
+namespace fs = std::filesystem;
 
 namespace o2
 {
@@ -260,8 +264,10 @@ std::tuple<std::string, std::string, int> DataOutputDirector::readJsonDocument(D
   const char* itemName;
 
   // initialisations
+  std::string resdir(".");
   std::string dfn("");
   std::string fmode("");
+  float maxfs = -1.;
   int ntfm = -1;
 
   // is it a proper json document?
@@ -298,6 +304,17 @@ std::tuple<std::string, std::string, int> DataOutputDirector::readJsonDocument(D
     dodirItem.Accept(writer);
   }
 
+  itemName = "resdir";
+  if (dodirItem.HasMember(itemName)) {
+    if (dodirItem[itemName].IsString()) {
+      resdir = dodirItem[itemName].GetString();
+      setResultDir(resdir);
+    } else {
+      LOGP(error, "Check the JSON document! Item \"{}\" must be a string!", itemName);
+      return memptyanswer;
+    }
+  }
+
   itemName = "resfile";
   if (dodirItem.HasMember(itemName)) {
     if (dodirItem[itemName].IsString()) {
@@ -316,6 +333,17 @@ std::tuple<std::string, std::string, int> DataOutputDirector::readJsonDocument(D
       setFileMode(fmode);
     } else {
       LOGP(error, "Check the JSON document! Item \"{}\" must be a string!", itemName);
+      return memptyanswer;
+    }
+  }
+
+  itemName = "maxfilesize";
+  if (dodirItem.HasMember(itemName)) {
+    if (dodirItem[itemName].IsNumber()) {
+      maxfs = dodirItem[itemName].GetFloat();
+      setMaximumFileSize(maxfs);
+    } else {
+      LOGP(error, "Check the JSON document! Item \"{}\" must be a number!", itemName);
       return memptyanswer;
     }
   }
@@ -444,9 +472,30 @@ FileAndFolder DataOutputDirector::getFileFolder(DataOutputDescriptor* dodesc, ui
   auto it = std::find(mfilenameBases.begin(), mfilenameBases.end(), dodesc->getFilenameBase());
   if (it != mfilenameBases.end()) {
     int ind = std::distance(mfilenameBases.begin(), it);
+
+    // open new output file
     if (!mfilePtrs[ind]->IsOpen()) {
-      auto fn = mfilenameBases[ind] + ".root";
+      // output directory
+      auto resdirname = mresultDirectory;
+      // is the maximum-file-size check enabled?
+      if (mmaxfilesize > 0.) {
+        // subdirectory ./xxx
+        char chcnt[4];
+        std::snprintf(chcnt, sizeof(chcnt), "%03d", mfileCounter);
+        resdirname += "/" + std::string(chcnt);
+      }
+      auto resdir = fs::path{resdirname.c_str()};
+
+      if (!fs::is_directory(resdir)) {
+        if (!fs::create_directories(resdir)) {
+          LOGF(fatal, "Could not create output directory %s", resdirname.c_str());
+        }
+      }
+
+      // complete file name
+      auto fn = resdirname + "/" + mfilenameBases[ind] + ".root";
       delete mfilePtrs[ind];
+      mParentMaps[ind]->Clear();
       mfilePtrs[ind] = TFile::Open(fn.c_str(), mfileMode.c_str(), "", 501);
     }
     fileAndFolder.file = mfilePtrs[ind];
@@ -465,6 +514,44 @@ FileAndFolder DataOutputDirector::getFileFolder(DataOutputDescriptor* dodesc, ui
   }
 
   return fileAndFolder;
+}
+
+bool DataOutputDirector::checkFileSizes()
+{
+  // is the maximum-file-size check enabled?
+  if (mmaxfilesize <= 0.) {
+    return true;
+  }
+
+  // current result directory
+  char chcnt[4];
+  std::snprintf(chcnt, sizeof(chcnt), "%03d", mfileCounter);
+  std::string strcnt{chcnt};
+  auto resdirname = mresultDirectory + "/" + strcnt;
+
+  // loop over all files
+  // if one file is large, then all files need to be closed
+  for (int i = 0; i < mfilenameBases.size(); i++) {
+    if (!mfilePtrs[i]) {
+      continue;
+    }
+    // size of fn
+    auto fn = resdirname + "/" + mfilenameBases[i] + ".root";
+    auto resfile = fs::path{fn.c_str()};
+    if (!fs::exists(resfile)) {
+      continue;
+    }
+    auto fsize = (float)fs::file_size(resfile) / 1.E6; // MBytes
+    LOGF(debug, "File %s: %f MBytes", fn.c_str(), fsize);
+    if (fsize >= mmaxfilesize) {
+      closeDataFiles();
+      // increment the subdirectory counter
+      mfileCounter++;
+      return false;
+    }
+  }
+
+  return true;
 }
 
 void DataOutputDirector::closeDataFiles()
@@ -496,6 +583,11 @@ void DataOutputDirector::printOut()
   for (auto const& fb : mfilenameBases) {
     LOGP(info, fb);
   }
+}
+
+void DataOutputDirector::setResultDir(std::string resDir)
+{
+  mresultDirectory = resDir;
 }
 
 void DataOutputDirector::setFilenameBase(std::string dfn)
@@ -532,6 +624,11 @@ void DataOutputDirector::setFilenameBase(std::string dfn)
     mfilePtrs.emplace_back(new TFile());
     mParentMaps.emplace_back(new TMap());
   }
+}
+
+void DataOutputDirector::setMaximumFileSize(float maxfs)
+{
+  mmaxfilesize = maxfs;
 }
 
 } // namespace framework

--- a/Framework/Core/src/DataOutputDirector.cxx
+++ b/Framework/Core/src/DataOutputDirector.cxx
@@ -154,6 +154,7 @@ void DataOutputDirector::reset()
   closeDataFiles();
   mfilePtrs.clear();
   mfilenameBase = std::string("");
+  mfileCounter = 1;
 };
 
 void DataOutputDirector::readString(std::string const& keepString)


### PR DESCRIPTION
Two items have been added to the aod-writer json:
maxfilesize (default value: -1): the approximate maximum size an output file shall reach in MBytes.
resdir (default value: "."): is the directory into which the output files are saved.

Before a DF is saved to disk, the size of all output files is checked to be below _maxfilesize_. If one of the files is larger than _maxfilesize_ MBytes, then all output files are closed and new ones are created. The files are saved into directories _resdir_/xxx, where xxx is an increasing counter starting at 1. The test of the file size is disabled if _maxfilesize_ is <= 0. In that case all DFs are saved into one set of files in directory _resdir_. Directory _resdir_ as well as its subdirectories _resdir_/xxx  are created if they do not exist already.