### PR TITLE
Adding protection to the fwdtrack table columns

### DIFF
--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -433,7 +433,7 @@ DECLARE_SOA_EXPRESSION_COLUMN(Eta, eta, float, //!
 DECLARE_SOA_EXPRESSION_COLUMN(Pt, pt, float, //!
                               ifnode(nabs(aod::fwdtrack::signed1Pt) < o2::constants::math::Almost0, o2::constants::math::VeryBig, nabs(1.f / aod::fwdtrack::signed1Pt)));
 DECLARE_SOA_EXPRESSION_COLUMN(P, p, float, //!
-                              ifnode(nabs(aod::fwdtrack::signed1Pt) < o2::constants::math::Almost0, o2::constants::math::VeryBig, 0.5f * (ntan(PIQuarter - 0.5f * natan(aod::fwdtrack::tgl)) + 1.f / ntan(PIQuarter - 0.5f * natan(aod::fwdtrack::tgl))) / nabs(aod::fwdtrack::signed1Pt)));
+                              ifnode((nabs(aod::fwdtrack::signed1Pt) < o2::constants::math::Almost0) || (nabs(PIQuarter - 0.5f * natan(aod::fwdtrack::tgl)) < o2::constants::math::Almost0), o2::constants::math::VeryBig, 0.5f * (ntan(PIQuarter - 0.5f * natan(aod::fwdtrack::tgl)) + 1.f / ntan(PIQuarter - 0.5f * natan(aod::fwdtrack::tgl))) / nabs(aod::fwdtrack::signed1Pt)));
 DECLARE_SOA_DYNAMIC_COLUMN(Px, px, //!
                            [](float pt, float phi) -> float {
                              return pt * std::cos(phi);


### PR DESCRIPTION
The modified line of code computes the quantity `1/(pi/2 - 0.5 * atan(tan(lambda)))` which returns an error `[ERROR] Exception caught: Cannot apply projector to source table of FwdTracksExtension: ExecutionError in Gandiva: divide by zero error.` when tan(lambda) is very large.  A few AODs from LHC22m (e.g. /alice/data/2022/LHC22m/523397/apass1/0930/AOD/001) show this feature of very large tan(lambda) ( > 10^9), producing this error.
This PR introduces an additional security to prevent this error.