### PR TITLE
Allow to set different thresholds for MID dead and noisy channels

### DIFF
--- a/Detectors/MUON/MID/Calibration/CMakeLists.txt
+++ b/Detectors/MUON/MID/Calibration/CMakeLists.txt
@@ -11,11 +11,11 @@
 
 o2_add_library(
   MIDCalibration
-  SOURCES src/ChannelCalibrator.cxx
+  SOURCES src/ChannelCalibrator.cxx src/ChannelCalibratorFinalizer.cxx src/ChannelCalibratorParam.cxx
   PUBLIC_LINK_LIBRARIES O2::DataFormatsMID O2::MIDFiltering
                         O2::DetectorsCalibration O2::CCDB Microsoft.GSL::GSL)
 
 o2_target_root_dictionary(MIDCalibration
-                          HEADERS include/MIDCalibration/ChannelCalibrator.h)
+                          HEADERS include/MIDCalibration/ChannelCalibrator.h include/MIDCalibration/ChannelCalibratorParam.h)
 
 add_subdirectory(exe)

--- a/Detectors/MUON/MID/Calibration/include/MIDCalibration/ChannelCalibrator.h
+++ b/Detectors/MUON/MID/Calibration/include/MIDCalibration/ChannelCalibrator.h
@@ -17,6 +17,7 @@
 #ifndef O2_MID_CHANNELCALIBRATOR_H
 #define O2_MID_CHANNELCALIBRATOR_H
 
+#include <array>
 #include <string>
 #include <vector>
 #include <gsl/span>
@@ -30,9 +31,9 @@ namespace o2
 namespace mid
 {
 
-class NoiseData
+class CalibData
 {
-  using Slot = o2::calibration::TimeSlot<NoiseData>;
+  using Slot = o2::calibration::TimeSlot<CalibData>;
 
  public:
   /// Fills the data
@@ -41,7 +42,7 @@ class NoiseData
 
   /// Merges data
   /// \param prev Previous container
-  void merge(const NoiseData* prev);
+  void merge(const CalibData* prev);
 
   /// Prints scalers
   void print();
@@ -52,13 +53,13 @@ class NoiseData
  private:
   ChannelScalers mChannelScalers;
 
-  ClassDefNV(NoiseData, 1);
+  ClassDefNV(CalibData, 1);
 };
 
-class ChannelCalibrator final : public o2::calibration::TimeSlotCalibration<ColumnData, NoiseData>
+class ChannelCalibrator final : public o2::calibration::TimeSlotCalibration<ColumnData, CalibData>
 {
   using TFType = o2::calibration::TFType;
-  using Slot = o2::calibration::TimeSlot<NoiseData>;
+  using Slot = o2::calibration::TimeSlot<CalibData>;
 
  public:
   /// Initialize the output
@@ -79,25 +80,21 @@ class ChannelCalibrator final : public o2::calibration::TimeSlotCalibration<Colu
   /// \param tend End time
   Slot& emplaceNewSlot(bool front, TFType tstart, TFType tend) final;
 
-  /// Add number of calibration triggers processed
-  /// \param nEvents Number of calibration triggers in this TF
-  void addEvents(unsigned long int nEvents) { mEventsCounter += nEvents; }
+  /// Add elapsed time or number of calibration triggers processed
+  /// \param timeOrTriggers Elapsed time or number of calibration triggers processed in this TF
+  void addTimeOrTriggers(double timeOrTriggers) { mTimeOrTriggers += timeOrTriggers; }
 
   /// Returns the bad channels
   const std::vector<ColumnData>& getBadChannels() const { return mBadChannels; }
 
-  /// Returns mask as string
-  std::string getMasksAsString() { return mMasksString; }
-
-  /// Sets reference masks
-  void setReferenceMasks(const std::vector<ColumnData>& refMasks) { mRefMasks = refMasks; }
+  /// Sets the threshold
+  /// \param threshold Threshold
+  void setThreshold(double threshold) { mThreshold = threshold; }
 
  private:
   std::vector<ColumnData> mBadChannels; /// List of bad channels
-  std::vector<ColumnData> mRefMasks;    /// Reference masks
-  std::string mMasksString;             /// Masks as string
-  double mThreshold = 0.9;              /// Noise threshold
-  unsigned long int mEventsCounter = 0; /// Events counter
+  double mThreshold = 0.9;              /// dead channels threshold
+  double mTimeOrTriggers = 0;           /// Events counter
 
   ClassDefOverride(ChannelCalibrator, 1);
 };

--- a/Detectors/MUON/MID/Calibration/include/MIDCalibration/ChannelCalibratorFinalizer.h
+++ b/Detectors/MUON/MID/Calibration/include/MIDCalibration/ChannelCalibratorFinalizer.h
@@ -1,0 +1,57 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDCalibration/ChannelCalibratorFinalizer.h
+/// \brief  MID noise and dead channels calibrator finalizer
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   31 October 2022
+
+#ifndef O2_MID_CHANNELCALIBRATORFINALIZER_H
+#define O2_MID_CHANNELCALIBRATORFINALIZER_H
+
+#include <string>
+#include <vector>
+#include <gsl/span>
+#include "DataFormatsMID/ColumnData.h"
+
+namespace o2
+{
+namespace mid
+{
+
+class ChannelCalibratorFinalizer
+{
+ public:
+  /// Process the noisy and dead channels
+  /// \param noise Vector of noisy channels
+  /// \param dead Vector of dead channels
+  void process(const gsl::span<const ColumnData> noise, const gsl::span<const ColumnData> dead);
+
+  /// Returns the bad channels
+  const std::vector<ColumnData>& getBadChannels() const { return mBadChannels; }
+
+  /// Returns mask as string
+  /// \return Masks as a string
+  std::string getMasksAsString() { return mMasksString; }
+
+  /// Sets reference masks
+  /// \param refMasks Reference masks
+  void setReferenceMasks(const std::vector<ColumnData>& refMasks) { mRefMasks = refMasks; }
+
+ private:
+  std::vector<ColumnData> mBadChannels; /// List of bad channels
+  std::vector<ColumnData> mRefMasks;    /// Reference masks
+  std::string mMasksString;             /// Masks as string
+};
+} // namespace mid
+} // namespace o2
+
+#endif

--- a/Detectors/MUON/MID/Calibration/include/MIDCalibration/ChannelCalibratorParam.h
+++ b/Detectors/MUON/MID/Calibration/include/MIDCalibration/ChannelCalibratorParam.h
@@ -1,0 +1,37 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_MID_CHANNELCALIBRATORPARAM_H
+#define O2_MID_CHANNELCALIBRATORPARAM_H
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "CommonUtils/ConfigurableParamHelper.h"
+
+namespace o2
+{
+namespace mid
+{
+
+/**
+ * @class ChannelCalibratorParam
+ * @brief Configurable parameters for the Bad Channel Calibrator
+ */
+struct ChannelCalibratorParam : public o2::conf::ConfigurableParamHelper<ChannelCalibratorParam> {
+
+  float maxNoise = 10000.f; ///< maximum allowed noise value (Hz)
+  float maxDead = 0.9f;     ///< maximum fraction of time a strip was not responding to FET
+
+  O2ParamDef(ChannelCalibratorParam, "MIDChannelCalibratorParam");
+};
+} // namespace mid
+} // namespace o2
+
+#endif

--- a/Detectors/MUON/MID/Calibration/src/ChannelCalibratorFinalizer.cxx
+++ b/Detectors/MUON/MID/Calibration/src/ChannelCalibratorFinalizer.cxx
@@ -1,0 +1,61 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Calibration/src/ChannelCalibratorFinalizer.cxx
+/// \brief  MID noise and dead channels calibrator finalizer
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   31 October 2022
+
+#include "MIDCalibration/ChannelCalibratorFinalizer.h"
+
+#include <sstream>
+#include "MIDBase/ColumnDataHandler.h"
+#include "MIDFiltering/ChannelMasksHandler.h"
+#include "MIDRaw/ColumnDataToLocalBoard.h"
+#include "MIDRaw/ROBoardConfigHandler.h"
+
+namespace o2
+{
+namespace mid
+{
+
+void ChannelCalibratorFinalizer::process(const gsl::span<const ColumnData> noise, const gsl::span<const ColumnData> dead)
+{
+  ColumnDataHandler colHandler;
+  colHandler.merge(noise);
+  colHandler.merge(dead);
+
+  // Keep track of last TimeFrame, since the masks will be valid from now on
+  mBadChannels = colHandler.getMerged();
+
+  // Get the masks for the electronics
+  // First convert the dead channels into masks
+  ChannelMasksHandler masksHandler;
+  masksHandler.switchOffChannels(mBadChannels);
+
+  // Complete with the expected masks from mapping
+  masksHandler.merge(mRefMasks);
+
+  // Convert column data masks to local board masks
+  ColumnDataToLocalBoard colToBoard;
+  colToBoard.process(masksHandler.getMasks(), true);
+
+  // Update local board configuration with the masks
+  ROBoardConfigHandler roBoardCfgHandler;
+  roBoardCfgHandler.updateMasks(colToBoard.getData());
+  std::stringstream ss;
+  roBoardCfgHandler.write(ss);
+
+  mMasksString = ss.str();
+}
+
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/Calibration/src/ChannelCalibratorParam.cxx
+++ b/Detectors/MUON/MID/Calibration/src/ChannelCalibratorParam.cxx
@@ -9,16 +9,6 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifdef __CLING__
+#include "MIDCalibration/ChannelCalibratorParam.h"
 
-#pragma link off all globals;
-#pragma link off all classes;
-#pragma link off all functions;
-
-#pragma link C++ class o2::mid::ChannelCalibratorParam + ;
-#pragma link C++ class o2::mid::CalibData + ;
-#pragma link C++ class o2::mid::ChannelCalibrator + ;
-#pragma link C++ class o2::calibration::TimeSlot < o2::mid::CalibData> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::mid::ColumnData, o2::mid::CalibData> + ;
-
-#endif
+O2ParamImpl(o2::mid::ChannelCalibratorParam);

--- a/Detectors/MUON/MID/Filtering/include/MIDFiltering/MaskMaker.h
+++ b/Detectors/MUON/MID/Filtering/include/MIDFiltering/MaskMaker.h
@@ -26,8 +26,8 @@ namespace o2
 namespace mid
 {
 
-std::vector<ColumnData> makeBadChannels(const ChannelScalers& scalers, unsigned long nEvents, double threshold = 0.9);
-std::vector<ColumnData> makeMasks(const ChannelScalers& scalers, unsigned long nEvents, double threshold = 0.9, const std::vector<ColumnData>& refMasks = {});
+std::vector<ColumnData> makeBadChannels(const ChannelScalers& scalers, double timeOrTriggers, double threshold);
+std::vector<ColumnData> makeMasks(const ChannelScalers& scalers, double timeOrTriggers, double threshold, const std::vector<ColumnData>& refMasks = {});
 std::vector<ColumnData> makeDefaultMasks();
 std::vector<ColumnData> makeDefaultMasksFromCrateConfig(const FEEIdConfig& feeIdConfig = FEEIdConfig(), const CrateMasks& crateMasks = CrateMasks());
 

--- a/Detectors/MUON/MID/Filtering/src/MaskMaker.cxx
+++ b/Detectors/MUON/MID/Filtering/src/MaskMaker.cxx
@@ -27,10 +27,10 @@ namespace o2
 {
 namespace mid
 {
-std::vector<ColumnData> makeBadChannels(const ChannelScalers& scalers, unsigned long nEvents, double threshold)
+std::vector<ColumnData> makeBadChannels(const ChannelScalers& scalers, double timeOrTriggers, double threshold)
 {
   /// Makes the mask from the scalers
-  uint32_t nThresholdEvents = static_cast<uint32_t>(threshold * nEvents);
+  uint32_t nThresholdEvents = static_cast<uint32_t>(threshold * timeOrTriggers);
   ColumnDataHandler handler;
   for (const auto scaler : scalers.getScalers()) {
     if (scaler.second >= nThresholdEvents) {
@@ -40,9 +40,9 @@ std::vector<ColumnData> makeBadChannels(const ChannelScalers& scalers, unsigned 
   return handler.getMerged();
 }
 
-std::vector<ColumnData> makeMasks(const ChannelScalers& scalers, unsigned long nEvents, double threshold, const std::vector<ColumnData>& refMasks)
+std::vector<ColumnData> makeMasks(const ChannelScalers& scalers, double timeOrTriggers, double threshold, const std::vector<ColumnData>& refMasks)
 {
-  auto badChannels = makeBadChannels(scalers, nEvents, threshold);
+  auto badChannels = makeBadChannels(scalers, timeOrTriggers, threshold);
   ChannelMasksHandler maskHandler;
   maskHandler.switchOffChannels(badChannels);
   std::vector<ColumnData> masks(maskHandler.getMasks());

--- a/Detectors/MUON/MID/Workflow/CMakeLists.txt
+++ b/Detectors/MUON/MID/Workflow/CMakeLists.txt
@@ -12,14 +12,14 @@
 o2_add_library(
   MIDWorkflow
   TARGETVARNAME targetName
-  SOURCES src/ClusterizerSpec.cxx
+  SOURCES src/CalibDataProcessorSpec.cxx
+          src/ClusterizerSpec.cxx
           src/ColumnDataSpecsUtils.cxx
           src/DecodedDataAggregatorSpec.cxx
           src/DigitReaderSpec.cxx
           src/EfficiencySpec.cxx
           src/EntropyDecoderSpec.cxx
           src/EntropyEncoderSpec.cxx
-          src/FetToDeadSpec.cxx
           src/FilteringSpec.cxx
           src/MaskHandlerSpec.cxx
           src/MaskMakerSpec.cxx

--- a/Detectors/MUON/MID/Workflow/include/MIDWorkflow/CalibDataProcessorSpec.h
+++ b/Detectors/MUON/MID/Workflow/include/MIDWorkflow/CalibDataProcessorSpec.h
@@ -1,0 +1,32 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDWorkflow/CalibDataProcessorSpec.h
+/// \brief  Device to convert the calibration data into a list of bad channel candidates
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   25 October 2022
+
+#ifndef O2_MID_CALIBDATAPROCESSORSPEC_H
+#define O2_MID_CALIBDATAPROCESSORSPEC_H
+
+#include "Framework/DataProcessorSpec.h"
+#include "MIDRaw/CrateMasks.h"
+#include "MIDRaw/FEEIdConfig.h"
+
+namespace o2
+{
+namespace mid
+{
+framework::DataProcessorSpec getCalibDataProcessorSpec(const FEEIdConfig& feeIdConfig, const CrateMasks& crateMasks);
+}
+} // namespace o2
+
+#endif // O2_MID_CalibDataProcessorSPEC_H

--- a/Detectors/MUON/MID/Workflow/include/MIDWorkflow/DecodedDataDumpSpec.h
+++ b/Detectors/MUON/MID/Workflow/include/MIDWorkflow/DecodedDataDumpSpec.h
@@ -9,24 +9,22 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file   MIDWorkflow/FetToDeadSpec.h
-/// \brief  Device to convert the FEE test event into dead channels
+/// \file   MIDWorkflow/RawDumpSpec.h
+/// \brief  Device to dump decoded raw data
 /// \author Diego Stocco <Diego.Stocco at cern.ch>
-/// \date   21 February 2022
+/// \date   17 February 2022
 
-#ifndef O2_MID_FETTODEADSPEC_H
-#define O2_MID_FETTODEADSPEC_H
+#ifndef O2_MID_RAWDUMPSPEC_H
+#define O2_MID_RAWDUMPSPEC_H
 
 #include "Framework/DataProcessorSpec.h"
-#include "MIDRaw/CrateMasks.h"
-#include "MIDRaw/FEEIdConfig.h"
 
 namespace o2
 {
 namespace mid
 {
-framework::DataProcessorSpec getFetToDeadSpec(const FEEIdConfig& feeIdConfig, const CrateMasks& crateMasks);
-}
+framework::DataProcessorSpec getRawDumpSpec();
+} // namespace mid
 } // namespace o2
 
-#endif // O2_MID_FETTODEADSPEC_H
+#endif // O2_MID_RAWDUMPSPEC_H

--- a/Detectors/MUON/MID/Workflow/src/DecodedDataDumpSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/DecodedDataDumpSpec.cxx
@@ -1,0 +1,84 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Workflow/src/RawDumpSpec.cxx
+/// \brief  Device to dump decoded raw data
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   17 February 2022
+
+#include "MIDWorkflow/RawDumpSpec.h"
+
+#include <fstream>
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "Framework/Logger.h"
+#include "Framework/Task.h"
+#include "fmt/format.h"
+#include "DataFormatsMID/ROBoard.h"
+#include "DataFormatsMID/ROFRecord.h"
+
+namespace o2
+{
+namespace mid
+{
+
+class RawDumpDeviceDPL
+{
+ public:
+  void init(o2::framework::InitContext& ic)
+  {
+    auto outFilename = ic.options().get<std::string>("mid-dump-outfile");
+
+    if (!outFilename.empty()) {
+      mOutFile.open(outFilename.c_str());
+    }
+  }
+
+  void
+    run(o2::framework::ProcessingContext& pc)
+  {
+
+    auto data = pc.inputs().get<gsl::span<ROBoard>>("mid_decoded");
+    auto dataROFs = pc.inputs().get<gsl::span<ROFRecord>>("mid_decoded_rof");
+    std::stringstream ss;
+    for (auto& rof : dataROFs) {
+      ss << fmt::format("BCid: 0x{:x} Orbit: 0x{:x}  EvtType: {:d}", rof.interactionRecord.bc, rof.interactionRecord.orbit, static_cast<int>(rof.eventType)) << std::endl;
+      for (auto colIt = data.begin() + rof.firstEntry, end = data.begin() + rof.getEndIndex(); colIt != end; ++colIt) {
+        ss << *colIt << std::endl;
+      }
+    }
+    if (mOutFile.is_open()) {
+      mOutFile << ss.str();
+    } else {
+      LOG(info) << ss.str();
+    }
+  }
+
+ private:
+  std::ofstream mOutFile; /// Output file
+};
+
+framework::DataProcessorSpec getRawDumpSpec()
+{
+  std::vector<o2::framework::InputSpec> inputSpecs{
+    o2::framework::InputSpec{"mid_decoded", header::gDataOriginMID, "DECODED", 0, o2::framework::Lifetime::Timeframe},
+    o2::framework::InputSpec{"mid_decoded_rof", header::gDataOriginMID, "DECODEDROF", 0, o2::framework::Lifetime::Timeframe}};
+
+  return o2::framework::DataProcessorSpec{
+    "MIDRawDataDumper",
+    {inputSpecs},
+    {},
+    o2::framework::AlgorithmSpec{o2::framework::adaptFromTask<RawDumpDeviceDPL>()},
+    o2::framework::Options{{"mid-dump-outfile", o2::framework::VariantType::String, "", {"Dump output to file"}}}};
+}
+
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/Workflow/src/calibration-workflow.cxx
+++ b/Detectors/MUON/MID/Workflow/src/calibration-workflow.cxx
@@ -25,11 +25,13 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
   std::vector<ConfigParamSpec> options{
     {"feeId-config-file", VariantType::String, "", {"Filename with crate FEE ID correspondence"}},
-    {"crate-masks-file", VariantType::String, "", {"Filename with crate masks"}}};
+    {"crate-masks-file", VariantType::String, "", {"Filename with crate masks"}},
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
   workflowOptions.insert(workflowOptions.end(), options.begin(), options.end());
 }
 
 #include "Framework/runDataProcessing.h"
+#include "CommonUtils/ConfigurableParam.h"
 #include "MIDWorkflow/CalibDataProcessorSpec.h"
 #include "MIDWorkflow/ChannelCalibratorSpec.h"
 #include "MIDRaw/CrateMasks.h"
@@ -47,6 +49,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   if (!crateMasksFilename.empty()) {
     crateMasks = o2::mid::CrateMasks(crateMasksFilename.c_str());
   }
+  o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
   WorkflowSpec specs;
   specs.emplace_back(o2::mid::getCalibDataProcessorSpec(feeIdConfig, crateMasks));
   specs.emplace_back(o2::mid::getChannelCalibratorSpec(feeIdConfig, crateMasks));


### PR DESCRIPTION
Currently, the noisy channels were computed only when occurring in the same BC of a calibration trigger.
But the calibration run occurs without beam, so all hits (except the answer to the Front-end test) are noisy.
With this PR, the noisy channels are defined as all hits occuriring outside of a FET event.
Also, different thresholds can be applied to the define noisy channels (in Hz) and to define a dead channel (as a fraction of the number of FET events).
The PR consist of 2 commits:
- the first one merges self-triggered events with events occurring during a calibration trigger
- the second one allows to set different thresholds for noisy and dead channels, computing the masks separately for the two kind of events and then merging them.
The commits are meant to be atomic: please do not squash.