### PR TITLE
TRD small fixes

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
@@ -39,8 +39,8 @@ constexpr int NCRUPERFLP = 3;        // the number of CRU per FLP
 constexpr int TRDLINKID = 15;        // hard coded link id, specific to TRD
 
 constexpr int NCOLUMN = 144; // the number of pad columns for each chamber
-constexpr int NROWC0 = 12;   // the number of pad rows for chambers of type C0 (installed stack 0,1,3 and 4)
-constexpr int NROWC1 = 16;   // the number of pad rows for chambers of type C1 (installed in stack 2)
+constexpr int NROWC0 = 12;   // the number of pad rows for chambers of type C0 (installed in stack 2)
+constexpr int NROWC1 = 16;   // the number of pad rows for chambers of type C1 (installed in stacks 0, 1, 3 and 4)
 
 constexpr int NMCMROB = 16;     // the number of MCMs per ROB
 constexpr int NMCMHCMAX = 64;   // the maximum number of MCMs for one half chamber (C1 type)

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
@@ -69,7 +69,7 @@ class CruRawReader
     mMaxErrsPrinted = nerr < 0 ? std::numeric_limits<int>::max() : nerr;
     mMaxWarnPrinted = nwar < 0 ? std::numeric_limits<int>::max() : nwar;
   }
-  void checkNoWarn();
+  void checkNoWarn(bool silently = true);
   void checkNoErr();
 
   // set the input data buffer


### PR DESCRIPTION
- Fix comment in TRD constants header
- TRD raw reader should warn about throttling of warning messages in InfoLogger only if a warning message itself appears in the InfoLogger as well. We rely on QC in order to spot issues in the raw reader... That means in QC we should fix the raw data task asap