### PR TITLE
[EMCAL-847] Provide trigger inputs to CTP simulation

### DIFF
--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Digit.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Digit.h
@@ -14,9 +14,11 @@
 
 #include <iosfwd>
 #include <cmath>
+#include <bitset>
 #include "Rtypes.h"
 #include "CommonDataFormat/TimeStamp.h"
 #include "DataFormatsEMCAL/Constants.h"
+#include "DataFormatsEMCAL/TriggerRecord.h"
 
 #include <boost/serialization/base_object.hpp> // for base_object
 
@@ -26,6 +28,45 @@ namespace o2
 namespace emcal
 {
 using DigitBase = o2::dataformats::TimeStamp<double>;
+
+enum Triggers {
+  kMB,  // Minimum bias
+  kEL0, // EMCAL L0 trigger
+  kDL0, // DCAL L0 trigger
+  kEG1, // EMCAL gamma L1 trigger
+  kDG1, // DCAL gamma L1 trigger
+  kEG2, // EMCAL gamma L1 trigger
+  kDG2, // DCAL gamma L1 trigger
+  kEJ1, // EMCAL jet L1 trigger
+  kDJ1, // DCAL jet L1 trigger
+  kEJ2, // EMCAL jet L1 trigger
+  kDJ2  // DCAL jet L1 trigger
+};
+
+struct DetTrigInput {
+  static constexpr char sChannelNameDPL[] = "TRIGGERINPUT";
+  static constexpr char sDigitName[] = "DetTrigInput";
+  static constexpr char sDigitBranchName[] = "EMCTRIGGERINPUT";
+  o2::InteractionRecord mIntRecord{}; // bc/orbit of the intpur
+  std::bitset<5> mInputs{};           // pattern of inputs.
+  DetTrigInput() = default;
+  DetTrigInput(const o2::InteractionRecord& iRec, Bool_t isMB, Bool_t isEL0, Bool_t isDL0, Bool_t isEG1, Bool_t isDG1, Bool_t isEG2, Bool_t isDG2, Bool_t isEJ1, Bool_t isDJ1, Bool_t isEJ2, Bool_t isDJ2)
+    : mIntRecord(iRec),
+      mInputs((isMB << o2::emcal::Triggers::kMB) |
+              (isEL0 << o2::emcal::Triggers::kEL0) |
+              (isDL0 << o2::emcal::Triggers::kDL0) |
+              (isEG1 << o2::emcal::Triggers::kEG1) |
+              (isDG1 << o2::emcal::Triggers::kDG1) |
+              (isEG2 << o2::emcal::Triggers::kEG2) |
+              (isDG2 << o2::emcal::Triggers::kDG2) |
+              (isEJ1 << o2::emcal::Triggers::kEJ1) |
+              (isDJ1 << o2::emcal::Triggers::kDJ1) |
+              (isEJ2 << o2::emcal::Triggers::kEJ2) |
+              (isDJ2 << o2::emcal::Triggers::kDJ2))
+  {
+  }
+  ClassDefNV(DetTrigInput, 1);
+};
 
 /// \class Digit
 /// \brief EMCAL digit implementation

--- a/Detectors/CTP/simulation/src/Digitizer.cxx
+++ b/Detectors/CTP/simulation/src/Digitizer.cxx
@@ -39,6 +39,7 @@ std::vector<CTPDigit> Digitizer::process(const gsl::span<o2::ctp::CTPInputDigit>
     data.intRecord = hits.first;
     std::bitset<CTP_NINPUTS> inpmaskcoll = 0;
     for (auto const inp : hits.second) {
+      std::cout << "EMC ID: " << o2::detectors::DetID::EMC << " Det ID: " << inp->detector << std::endl;
       switch (inp->detector) {
         case o2::detectors::DetID::FT0: {
           // see dummy database above
@@ -60,24 +61,28 @@ std::vector<CTPDigit> Digitizer::process(const gsl::span<o2::ctp::CTPInputDigit>
             uint64_t mask = (inp->inputsMask).to_ullong() & detInputName2Mask[ctpinp.name];
             inpmaskcoll |= std::bitset<CTP_NINPUTS>(ctpinp.inputMask);
           }
+          break;
         }
         case o2::detectors::DetID::EMC: {
           for (auto const& ctpinp : det2ctpinp[o2::detectors::DetID::EMC]) {
             uint64_t mask = (inp->inputsMask).to_ullong() & detInputName2Mask[ctpinp.name];
             inpmaskcoll |= std::bitset<CTP_NINPUTS>(ctpinp.inputMask);
           }
+          break;
         }
         case o2::detectors::DetID::PHS: {
           for (auto const& ctpinp : det2ctpinp[o2::detectors::DetID::PHS]) {
             uint64_t mask = (inp->inputsMask).to_ullong() & detInputName2Mask[ctpinp.name];
             inpmaskcoll |= std::bitset<CTP_NINPUTS>(ctpinp.inputMask);
           }
+          break;
         }
         case o2::detectors::DetID::ZDC: {
           for (auto const& ctpinp : det2ctpinp[o2::detectors::DetID::ZDC]) {
             uint64_t mask = (inp->inputsMask).to_ullong() & detInputName2Mask[ctpinp.name];
             inpmaskcoll |= std::bitset<CTP_NINPUTS>(ctpinp.inputMask);
           }
+          break;
         }
         default:
           // Error

--- a/Detectors/EMCAL/workflow/src/EMCALDigitizerSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/EMCALDigitizerSpec.cxx
@@ -136,6 +136,12 @@ void DigitizerSpec::run(framework::ProcessingContext& ctx)
   const o2::parameters::GRPObject::ROMode roMode = o2::parameters::GRPObject::TRIGGERING;
   LOG(info) << "EMCAL: Sending ROMode= " << roMode << " to GRPUpdater";
   ctx.outputs().snapshot(Output{"EMC", "ROMode", 0, Lifetime::Timeframe}, roMode);
+  std::vector<o2::emcal::DetTrigInput> triggerinputs;
+  for (auto& trg : mDigitizer.getTriggerRecords()) {
+    // covert TriggerRecord into CTP trigger digit
+    triggerinputs.emplace_back(trg.getBCData(), true, false, false, false, false, false, false, false, false, false, false);
+  }
+  ctx.outputs().snapshot(Output{"EMC", "TRIGGERINPUT", 0, Lifetime::Timeframe}, triggerinputs);
 
   timer.Stop();
   LOG(info) << "Digitization took " << timer.CpuTime() << "s";
@@ -171,6 +177,7 @@ o2::framework::DataProcessorSpec getEMCALDigitizerSpec(int channel, bool mctruth
     outputs.emplace_back("EMC", "DIGITSMCTR", 0, Lifetime::Timeframe);
   }
   outputs.emplace_back("EMC", "ROMode", 0, Lifetime::Timeframe);
+  outputs.emplace_back("EMC", "TRIGGERINPUT", 0, Lifetime::Timeframe);
 
   std::vector<o2::framework::InputSpec> inputs;
   inputs.emplace_back("collisioncontext", "SIM", "COLLISIONCONTEXT", static_cast<SubSpecificationType>(channel), Lifetime::Timeframe);


### PR DESCRIPTION
Allowing the EMCAL digitizer to provide MB trigger inputs to the CTP in simulation