### PR TITLE
First working version of TPC CTF Skimming + unrelated fixes

### DIFF
--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/CompressedClusters.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/CompressedClusters.h
@@ -74,7 +74,7 @@ struct CompressedClustersOffsets : public CompressedClustersPtrs_x<size_t, size_
 
 struct CompressedClustersFlat;
 
-struct CompressedClusters : public CompressedClustersCounters, public CompressedClustersPtrs {
+struct CompressedClusters : public CompressedClustersCounters, public CompressedClustersPtrs { // TODO: Need a const version of this, currently the constructor allows to create a non-const version from const CompressedClustersFlat, which should not be allowed
   CompressedClusters() CON_DEFAULT;
   ~CompressedClusters() CON_DEFAULT;
   CompressedClusters(const CompressedClustersFlat& c);

--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/CTFCoder.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/CTFCoder.h
@@ -273,8 +273,8 @@ o2::ctf::CTFIOSize CTFCoder::encode(VEC& buff, const CompressedClusters& ccl, co
   encodeTPC(ccl.qMaxU, ccl.qMaxU + (mCombineColumns ? 0 : ccl.nUnattachedClusters), CTF::BLCqMaxU, 0, rejectHits);
 
   encodeTPC(ccl.flagsU, ccl.flagsU + ccl.nUnattachedClusters, CTF::BLCflagsU, 0, rejectHits);
-  encodeTPC(ccl.padDiffU, ccl.padDiffU + ccl.nUnattachedClusters, CTF::BLCpadDiffU, 0, rejectHits);
-  encodeTPC(ccl.timeDiffU, ccl.timeDiffU + ccl.nUnattachedClusters, CTF::BLCtimeDiffU, 0, rejectHits);
+  encodeTPC(cclFiltered.padDiffU, cclFiltered.padDiffU + cclFiltered.nUnattachedClusters, CTF::BLCpadDiffU, 0);
+  encodeTPC(cclFiltered.timeDiffU, cclFiltered.timeDiffU + cclFiltered.nUnattachedClusters, CTF::BLCtimeDiffU, 0);
 
   if (mCombineColumns) {
     const auto [begin, end] = makeInputIterators(ccl.sigmaPadU, ccl.sigmaTimeU, ccl.nUnattachedClusters,

--- a/GPU/GPUTracking/Benchmark/standalone.cxx
+++ b/GPU/GPUTracking/Benchmark/standalone.cxx
@@ -438,6 +438,9 @@ int SetupReconstruction()
     procSet.runQA = false;
     procSet.eventDisplay = eventDisplay.get();
     procSet.runCompressionStatistics = 0;
+    if (recSet.tpc.rejectionStrategy >= GPUSettings::RejectionStrategyB) {
+      procSet.tpcInputWithClusterRejection = 1;
+    }
     recSet.tpc.disableRefitAttachment = 0xFF;
     recSet.tpc.loopInterpolationInExtraPass = 0;
     recSet.maxTrackQPtB5 = CAMath::Min(recSet.maxTrackQPtB5, recSet.tpc.rejectQPtB5);

--- a/GPU/GPUTracking/CMakeLists.txt
+++ b/GPU/GPUTracking/CMakeLists.txt
@@ -159,6 +159,7 @@ set(HDRS_INSTALL
     DataTypes/GPUTRDInterfaceO2Track.h
     Base/GPUParam.inc
     DataCompression/TPCClusterDecompressor.inc
+    DataCompression/GPUTPCCompressionKernels.inc
     Merger/GPUTPCGMMergerTypes.h
     Global/GPUErrorCodes.h
     Global/GPUChainTrackingDefs.h

--- a/GPU/GPUTracking/DataCompression/GPUTPCCompressionKernels.cxx
+++ b/GPU/GPUTracking/DataCompression/GPUTPCCompressionKernels.cxx
@@ -20,6 +20,7 @@
 #include "GPUTPCCompressionTrackModel.h"
 #include "GPUTPCGeometry.h"
 #include "GPUTPCClusterRejection.h"
+#include "GPUTPCCompressionKernels.inc"
 
 using namespace GPUCA_NAMESPACE::gpu;
 using namespace o2::tpc;
@@ -272,25 +273,9 @@ GPUdii() void GPUTPCCompressionKernels::Thread<GPUTPCCompressionKernels::step1un
       for (unsigned int j = get_local_id(0); j < count; j += get_local_size(0)) {
         int outidx = idOffsetOut + totalCount + j;
         const ClusterNative& GPUrestrict() orgCl = clusters->clusters[iSlice][iRow][sortBuffer[j]];
-        unsigned int lastTime = 0;
-        unsigned int lastPad = 0;
-        if (param.rec.tpc.compressionTypeMask & GPUSettings::CompressionDifferences) {
-          if (j != 0) {
-            const ClusterNative& GPUrestrict() orgClPre = clusters->clusters[iSlice][iRow][sortBuffer[j - 1]];
-            lastPad = orgClPre.padPacked;
-            lastTime = orgClPre.getTimePacked();
-          } else if (totalCount != 0) {
-            const ClusterNative& GPUrestrict() orgClPre = clusters->clusters[iSlice][iRow][smem.lastIndex];
-            lastPad = orgClPre.padPacked;
-            lastTime = orgClPre.getTimePacked();
-          }
 
-          c.padDiffU[outidx] = orgCl.padPacked - lastPad;
-          c.timeDiffU[outidx] = (orgCl.getTimePacked() - lastTime) & 0xFFFFFF;
-        } else {
-          c.padDiffU[outidx] = orgCl.padPacked;
-          c.timeDiffU[outidx] = orgCl.getTimePacked();
-        }
+        int preId = j != 0 ? (int)sortBuffer[j - 1] : (totalCount != 0 ? (int)smem.lastIndex : -1);
+        GPUTPCCompression_EncodeUnattached(param, orgCl, c, outidx, preId == -1 ? nullptr : &clusters->clusters[iSlice][iRow][preId]);
 
         unsigned short qtot = orgCl.qTot, qmax = orgCl.qMax;
         unsigned char sigmapad = orgCl.sigmaPadPacked, sigmatime = orgCl.sigmaTimePacked;

--- a/GPU/GPUTracking/DataCompression/GPUTPCCompressionKernels.cxx
+++ b/GPU/GPUTracking/DataCompression/GPUTPCCompressionKernels.cxx
@@ -275,7 +275,7 @@ GPUdii() void GPUTPCCompressionKernels::Thread<GPUTPCCompressionKernels::step1un
         const ClusterNative& GPUrestrict() orgCl = clusters->clusters[iSlice][iRow][sortBuffer[j]];
 
         int preId = j != 0 ? (int)sortBuffer[j - 1] : (totalCount != 0 ? (int)smem.lastIndex : -1);
-        GPUTPCCompression_EncodeUnattached(param, orgCl, c, outidx, preId == -1 ? nullptr : &clusters->clusters[iSlice][iRow][preId]);
+        GPUTPCCompression_EncodeUnattached(param.rec.tpc.compressionTypeMask, orgCl, c.timeDiffU[outidx], c.padDiffU[outidx], preId == -1 ? nullptr : &clusters->clusters[iSlice][iRow][preId]);
 
         unsigned short qtot = orgCl.qTot, qmax = orgCl.qMax;
         unsigned char sigmapad = orgCl.sigmaPadPacked, sigmatime = orgCl.sigmaTimePacked;

--- a/GPU/GPUTracking/DataCompression/GPUTPCCompressionKernels.inc
+++ b/GPU/GPUTracking/DataCompression/GPUTPCCompressionKernels.inc
@@ -20,21 +20,20 @@
 namespace o2::gpu
 {
 
-template <class T>
-GPUdii() void GPUTPCCompression_EncodeUnattached(const GPUParam& param, const o2::tpc::ClusterNative& orgCl, T& c, int outidx, const o2::tpc::ClusterNative* orgClPre = nullptr)
+GPUdii() void GPUTPCCompression_EncodeUnattached(unsigned char nComppressionModes, const o2::tpc::ClusterNative& orgCl, unsigned int& outTime, unsigned short& outPad, const o2::tpc::ClusterNative* orgClPre = nullptr)
 {
-  if (param.rec.tpc.compressionTypeMask & GPUSettings::CompressionDifferences) {
+  if (nComppressionModes & GPUSettings::CompressionDifferences) {
     unsigned int lastTime = 0, lastPad = 0;
     if (orgClPre) {
       lastPad = orgClPre->padPacked;
       lastTime = orgClPre->getTimePacked();
     }
 
-    c.padDiffU[outidx] = orgCl.padPacked - lastPad;
-    c.timeDiffU[outidx] = (orgCl.getTimePacked() - lastTime) & 0xFFFFFF;
+    outPad = orgCl.padPacked - lastPad;
+    outTime = (orgCl.getTimePacked() - lastTime) & 0xFFFFFF;
   } else {
-    c.padDiffU[outidx] = orgCl.padPacked;
-    c.timeDiffU[outidx] = orgCl.getTimePacked();
+    outPad = orgCl.padPacked;
+    outTime = orgCl.getTimePacked();
   }
 }
 

--- a/GPU/GPUTracking/DataCompression/GPUTPCCompressionKernels.inc
+++ b/GPU/GPUTracking/DataCompression/GPUTPCCompressionKernels.inc
@@ -1,0 +1,41 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file GPUTPCCompressionKernels.cxx
+/// \author David Rohr
+
+#include "GPUO2DataTypes.h"
+#include "GPUParam.h"
+#include "GPUTPCGeometry.h"
+#include "GPUTPCClusterRejection.h"
+
+namespace o2::gpu
+{
+
+template <class T>
+GPUdii() void GPUTPCCompression_EncodeUnattached(const GPUParam& param, const o2::tpc::ClusterNative& orgCl, T& c, int outidx, const o2::tpc::ClusterNative* orgClPre = nullptr)
+{
+  if (param.rec.tpc.compressionTypeMask & GPUSettings::CompressionDifferences) {
+    unsigned int lastTime = 0, lastPad = 0;
+    if (orgClPre) {
+      lastPad = orgClPre->padPacked;
+      lastTime = orgClPre->getTimePacked();
+    }
+
+    c.padDiffU[outidx] = orgCl.padPacked - lastPad;
+    c.timeDiffU[outidx] = (orgCl.getTimePacked() - lastTime) & 0xFFFFFF;
+  } else {
+    c.padDiffU[outidx] = orgCl.padPacked;
+    c.timeDiffU[outidx] = orgCl.getTimePacked();
+  }
+}
+
+} // namespace o2::gpu


### PR DESCRIPTION
@shahor02 : This is working now. Two things are missing:
- unattached clusters are not checked for z / eta. That is trivial, and I'll add it with the next PR.
- There seems to be still a problem with decoding of track-model tracks created by GPU. Few tracks have some clusters with bogus time, and are thus randomly added to skimmed data of certain BCs.

But I think in principle this can already be tested together with other detectors.
One question is: What do we do with the BC shifts we see between the detectors, e.g. the 31 BCs from TPC to TOF/FIT?
Should we for now just add them as margin via command line?

The skimming part of the o2-tpc-entropy-encoder can be multithreaded with --nThreads. Default is one. Performance difference is not so much, since a lot of time goes into ANS encoding/decoding anyway.