### PR TITLE
Add CTP lumi information to TPC SCD calibration

### DIFF
--- a/Detectors/Calibration/include/DetectorsCalibration/TimeSlotCalibration.h
+++ b/Detectors/Calibration/include/DetectorsCalibration/TimeSlotCalibration.h
@@ -36,7 +36,7 @@ class ProcessingContext;
 namespace calibration
 {
 
-template <typename Input, typename Container>
+template <typename Input, typename Container = Input>
 class TimeSlotCalibration
 {
  public:
@@ -104,8 +104,8 @@ class TimeSlotCalibration
   const Slot& getLastSlot() const { return (Slot&)mSlots.back(); }
   const Slot& getFirstSlot() const { return (Slot&)mSlots.front(); }
 
-  template <typename DATA>
-  bool process(const DATA& data);
+  template <typename... DATA>
+  bool process(const DATA&... data);
   virtual void checkSlotsToFinalize(TFType tf, int maxDelay = 0);
   virtual void finalizeOldestSlot();
 
@@ -227,8 +227,8 @@ class TimeSlotCalibration
 
 //_________________________________________________
 template <typename Input, typename Container>
-template <typename DATA>
-bool TimeSlotCalibration<Input, Container>::process(const DATA& data)
+template <typename... DATA>
+bool TimeSlotCalibration<Input, Container>::process(const DATA&... data)
 {
   static bool firstCall = true;
   if (firstCall) {
@@ -251,10 +251,10 @@ bool TimeSlotCalibration<Input, Container>::process(const DATA& data)
   }
   auto& slotTF = getSlotForTF(tf);
   using Cont_t = typename std::remove_pointer<decltype(slotTF.getContainer())>::type;
-  if constexpr (has_fill_method<Cont_t, void(const o2::dataformats::TFIDInfo&, const DATA&)>::value) {
-    slotTF.getContainer()->fill(mCurrentTFInfo, data);
+  if constexpr (has_fill_method<Cont_t, void(const o2::dataformats::TFIDInfo&, const DATA&...)>::value) {
+    slotTF.getContainer()->fill(mCurrentTFInfo, data...);
   } else {
-    slotTF.getContainer()->fill(data);
+    slotTF.getContainer()->fill(data...);
   }
   if (tf > mMaxSeenTF) {
     mMaxSeenTF = tf; // keep track of the most recent TF processed

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCResidualAggregatorSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCResidualAggregatorSpec.h
@@ -30,6 +30,7 @@
 #include <chrono>
 
 using namespace o2::framework;
+using GID = o2::dataformats::GlobalTrackID;
 
 namespace o2
 {
@@ -39,7 +40,7 @@ namespace calibration
 class ResidualAggregatorDevice : public o2::framework::Task
 {
  public:
-  ResidualAggregatorDevice(std::shared_ptr<o2::base::GRPGeomRequest> req, bool trackInput, bool writeOutput, bool writeUnbinnedResiduals, bool writeBinnedResiduals, bool writeTrackData) : mCCDBRequest(req), mTrackInput(trackInput), mWriteOutput(writeOutput), mWriteUnbinnedResiduals(writeUnbinnedResiduals), mWriteBinnedResiduals(writeBinnedResiduals), mWriteTrackData(writeTrackData) {}
+  ResidualAggregatorDevice(std::shared_ptr<o2::base::GRPGeomRequest> req, bool trackInput, bool ctpInput, bool writeOutput, bool writeUnbinnedResiduals, bool writeBinnedResiduals, bool writeTrackData, std::shared_ptr<o2::globaltracking::DataRequest> dataRequest) : mCCDBRequest(req), mTrackInput(trackInput), mCTPInput(ctpInput), mWriteOutput(writeOutput), mWriteUnbinnedResiduals(writeUnbinnedResiduals), mWriteBinnedResiduals(writeBinnedResiduals), mWriteTrackData(writeTrackData), mDataRequest(dataRequest) {}
 
   void init(o2::framework::InitContext& ic) final
   {
@@ -92,11 +93,12 @@ class ResidualAggregatorDevice : public o2::framework::Task
   void run(o2::framework::ProcessingContext& pc) final
   {
     auto runStartTime = std::chrono::high_resolution_clock::now();
+    o2::globaltracking::RecoContainer recoCont;
+    recoCont.collectData(pc, *mDataRequest);
     updateTimeDependentParams(pc);
     std::chrono::duration<double, std::milli> ccdbUpdateTime = std::chrono::high_resolution_clock::now() - runStartTime;
 
     auto residualsData = pc.inputs().get<gsl::span<o2::tpc::UnbinnedResid>>("unbinnedRes");
-
     // track data input is optional
     const gsl::span<const o2::tpc::TrackData>* trkDataPtr = nullptr;
     using trkDataType = std::decay_t<decltype(pc.inputs().get<gsl::span<o2::tpc::TrackData>>(""))>;
@@ -105,11 +107,20 @@ class ResidualAggregatorDevice : public o2::framework::Task
       trkData.emplace(pc.inputs().get<gsl::span<o2::tpc::TrackData>>("trkData"));
       trkDataPtr = &trkData.value();
     }
+    // CTP lumi input (optional)
+    const o2::ctp::LumiInfo* lumi = nullptr;
+    using lumiDataType = std::decay_t<decltype(pc.inputs().get<o2::ctp::LumiInfo>(""))>;
+    std::optional<lumiDataType> lumiInput;
+    if (mCTPInput) {
+      recoCont.getCTPLumi();
+      lumiInput = recoCont.getCTPLumi();
+      lumi = &lumiInput.value();
+    }
 
     auto data = std::make_pair<gsl::span<const o2::tpc::TrackData>, gsl::span<const o2::tpc::UnbinnedResid>>(std::move(*trkData), std::move(residualsData));
     o2::base::TFIDInfoHelper::fillTFIDInfo(pc, mAggregator->getCurrentTFInfo());
     LOG(info) << "Processing TF " << mAggregator->getCurrentTFInfo().tfCounter << " with " << trkData->size() << " tracks and " << residualsData.size() << " unbinned residuals associated to them";
-    mAggregator->process(data);
+    mAggregator->process(data, lumi);
     std::chrono::duration<double, std::milli> runDuration = std::chrono::high_resolution_clock::now() - runStartTime;
     LOGP(info, "Duration for run method: {} ms. From this taken for time dependent param update: {} ms",
          std::chrono::duration_cast<std::chrono::milliseconds>(runDuration).count(),
@@ -135,7 +146,9 @@ class ResidualAggregatorDevice : public o2::framework::Task
   }
   std::unique_ptr<o2::tpc::ResidualAggregator> mAggregator; ///< the TimeSlotCalibration device
   std::shared_ptr<o2::base::GRPGeomRequest> mCCDBRequest;
+  std::shared_ptr<o2::globaltracking::DataRequest> mDataRequest; ///< optional CTP input
   bool mTrackInput{false};             ///< flag whether to expect track data as input
+  bool mCTPInput{false};               ///< flag whether to expect luminosity input from CTP
   bool mWriteOutput{true};             ///< if false, no output file will be written
   bool mWriteBinnedResiduals{false};   ///< flag, whether to write binned residuals to output file
   bool mWriteUnbinnedResiduals{false}; ///< flag, whether to write unbinned residuals to output file
@@ -147,9 +160,13 @@ class ResidualAggregatorDevice : public o2::framework::Task
 namespace framework
 {
 
-DataProcessorSpec getTPCResidualAggregatorSpec(bool trackInput, bool writeOutput, bool writeUnbinnedResiduals, bool writeBinnedResiduals, bool writeTrackData)
+DataProcessorSpec getTPCResidualAggregatorSpec(bool trackInput, bool ctpInput, bool writeOutput, bool writeUnbinnedResiduals, bool writeBinnedResiduals, bool writeTrackData)
 {
-  std::vector<InputSpec> inputs;
+  std::shared_ptr<o2::globaltracking::DataRequest> dataRequest = std::make_shared<o2::globaltracking::DataRequest>();
+  if (ctpInput) {
+    dataRequest->requestClusters(GID::getSourcesMask("CTP"), false);
+  }
+  auto& inputs = dataRequest->inputs;
   inputs.emplace_back("unbinnedRes", "GLO", "UNBINNEDRES");
   if (trackInput) {
     inputs.emplace_back("trkData", "GLO", "TRKDATA");
@@ -165,7 +182,7 @@ DataProcessorSpec getTPCResidualAggregatorSpec(bool trackInput, bool writeOutput
     "residual-aggregator",
     inputs,
     Outputs{},
-    AlgorithmSpec{adaptFromTask<o2::calibration::ResidualAggregatorDevice>(ccdbRequest, trackInput, writeOutput, writeUnbinnedResiduals, writeBinnedResiduals, writeTrackData)},
+    AlgorithmSpec{adaptFromTask<o2::calibration::ResidualAggregatorDevice>(ccdbRequest, trackInput, ctpInput, writeOutput, writeUnbinnedResiduals, writeBinnedResiduals, writeTrackData, dataRequest)},
     Options{
       {"tf-per-slot", VariantType::UInt32, 6'000u, {"number of TFs per calibration time slot (put 0 for infinite slot length)"}},
       {"updateInterval", VariantType::UInt32, 6'000u, {"update interval in number of TFs in case slot length is infinite"}},

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCResidualWriterSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCResidualWriterSpec.cxx
@@ -16,6 +16,7 @@
 #include "SpacePoints/TrackInterpolation.h"
 #include "SpacePoints/TrackResiduals.h"
 #include "TPCInterpolationWorkflow/TPCResidualWriterSpec.h"
+#include "DataFormatsCTP/LumiInfo.h"
 #include "DPLUtils/MakeRootTreeWriterSpec.h"
 
 using namespace o2::framework;

--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/ResidualAggregator.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/ResidualAggregator.h
@@ -18,6 +18,7 @@
 
 #include "DetectorsCalibration/TimeSlotCalibration.h"
 #include "DetectorsCalibration/TimeSlot.h"
+#include "DataFormatsCTP/LumiInfo.h"
 #include "DataFormatsTPC/Defs.h"
 #include "SpacePoints/TrackResiduals.h"
 #include "CommonUtils/StringUtils.h"
@@ -46,7 +47,7 @@ struct ResidualsContainer {
   void fillStatisticsBranches();
   uint64_t getNEntries() const { return nResidualsTotal; }
 
-  void fill(const o2::dataformats::TFIDInfo& ti, const std::pair<gsl::span<const o2::tpc::TrackData>, gsl::span<const UnbinnedResid>> data);
+  void fill(const o2::dataformats::TFIDInfo& ti, const std::pair<gsl::span<const o2::tpc::TrackData>, gsl::span<const UnbinnedResid>> data, const o2::ctp::LumiInfo* lumiInput);
   void merge(ResidualsContainer* prev);
   void print();
   void writeToFile(bool closeFileAfterwards);
@@ -59,6 +60,7 @@ struct ResidualsContainer {
   uint32_t runNumber;                                                        ///< run number (required for meta data file)
   std::vector<uint32_t> tfOrbits, *tfOrbitsPtr{&tfOrbits};                   ///< first TF orbit
   std::vector<uint32_t> sumOfResiduals, *sumOfResidualsPtr{&sumOfResiduals}; ///< sum of residuals for each TF
+  std::vector<o2::ctp::LumiInfo> lumi, *lumiPtr{&lumi};                      ///< luminosity information from CTP per TF
   std::vector<UnbinnedResid> unbinnedRes, *unbinnedResPtr{&unbinnedRes};     // unbinned residuals
   std::vector<TrackData> trkData, *trkDataPtr{&trkData};                                 // track data and cluster ranges
 

--- a/Detectors/TRD/calibration/include/TRDCalibration/CalibratorNoise.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/CalibratorNoise.h
@@ -27,7 +27,7 @@ namespace o2
 namespace trd
 {
 
-class CalibratorNoise final : public o2::calibration::TimeSlotCalibration<PadAdcInfo, PadAdcInfo>
+class CalibratorNoise final : public o2::calibration::TimeSlotCalibration<PadAdcInfo>
 {
   using Slot = o2::calibration::TimeSlot<PadAdcInfo>;
 

--- a/Detectors/TRD/calibration/include/TRDCalibration/CalibratorVdExB.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/CalibratorVdExB.h
@@ -45,7 +45,7 @@ struct FitFunctor {
   float upperBoundAngleFit;
 };
 
-class CalibratorVdExB final : public o2::calibration::TimeSlotCalibration<o2::trd::AngularResidHistos, o2::trd::AngularResidHistos>
+class CalibratorVdExB final : public o2::calibration::TimeSlotCalibration<o2::trd::AngularResidHistos>
 {
   using Slot = o2::calibration::TimeSlot<o2::trd::AngularResidHistos>;
 

--- a/Detectors/TRD/calibration/src/TRDCalibrationLinkDef.h
+++ b/Detectors/TRD/calibration/src/TRDCalibrationLinkDef.h
@@ -17,10 +17,10 @@
 
 #pragma link C++ class o2::trd::CalibratorVdExB + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::trd::AngularResidHistos> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::trd::AngularResidHistos, o2::trd::AngularResidHistos> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::trd::AngularResidHistos> + ;
 #pragma link C++ class o2::trd::CalibratorNoise + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::trd::PadAdcInfo> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::trd::PadAdcInfo, o2::trd::PadAdcInfo> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::trd::PadAdcInfo> + ;
 #pragma link C++ class o2::trd::TrackBasedCalib + ;
 #pragma link C++ class o2::trd::KrClusterFinder + ;
 #pragma link C++ class std::unordered_map < o2::dcs::DataPointIdentifier, o2::trd::TRDDCSMinMaxMeanInfo> + ;

--- a/prodtests/full-system-test/aggregator-workflow.sh
+++ b/prodtests/full-system-test/aggregator-workflow.sh
@@ -191,7 +191,7 @@ if [[ $AGGREGATOR_TASKS == BARREL_TF ]] || [[ $AGGREGATOR_TASKS == ALL ]]; then
   if [[ $CALIB_TPC_SCDCALIB == 1 ]]; then
     # TODO: the residual aggregator should have --output-dir and --meta-output-dir defined
     # without that the residuals will be stored in the local working directory (and deleted after a week)
-    add_W o2-calibration-residual-aggregator "--disable-root-input $ENABLE_TRACK_INPUT --output-type trackParams,unbinnedResid,binnedResid --autosave-interval $RESIDUAL_AGGREGATOR_AUTOSAVE"
+    add_W o2-calibration-residual-aggregator "--disable-root-input $ENABLE_TRACK_INPUT $CALIB_TPC_SCDCALIB_CTP_INPUT --output-type trackParams,unbinnedResid,binnedResid --autosave-interval $RESIDUAL_AGGREGATOR_AUTOSAVE"
   fi
   if [[ $CALIB_TPC_VDRIFTTGL == 1 ]]; then
     # options available via ARGS_EXTRA_PROCESS_o2_tpc_vdrift_tgl_calibration_workflow="--nbins-tgl 20 --nbins-dtgl 50 --max-tgl-its 2. --max-dtgl-itstpc 0.15 --min-entries-per-slot 1000 --time-slot-seconds 600 <--vdtgl-histos-file-name name> "


### PR DESCRIPTION
Hi @chiarazampolli with https://github.com/AliceO2Group/AliceO2/commit/a33a3b55ccc874e92a62890e451db15e1b8679fd I am changing a bit the interface of the TimeSlotCalibration. The change is fully backwards compatible and allows the user to define a `fill()` method for their container with as many inputs as wanted. I am using this for the residual aggregator to also process the lumi information, if it is available. Also I am making the `Container` type the same as the `Input` type by default, because in some cases they are identical (see https://github.com/AliceO2Group/AliceO2/commit/f4ecaa65b94844b3afca1cc73a1e54f254e1e364)
@shahor02 in order to be able to forward the lumi information I am using different subspecs on the processing EPNs, because otherwise the `o2-tpc-scdcalib-interpolation-workflow` would depend on itself.

The averaging for a given calibration interval I still need to add. Will be done in a follow-up PR. Also this needs a change to O2DPG to become effective.