### PR TITLE
TRD: Tracker: Add padrow crossing information

### DIFF
--- a/Detectors/TRD/base/include/TRDBase/PadPlane.h
+++ b/Detectors/TRD/base/include/TRDBase/PadPlane.h
@@ -12,7 +12,7 @@
 #ifndef O2_TRD_PADPLANE_H
 #define O2_TRD_PADPLANE_H
 
-//Forwards to standard header with protection for GPU compilation
+// Forwards to standard header with protection for GPU compilation
 #include "GPUCommonRtypes.h" // for ClassDef
 #include "GPUCommonDef.h"
 
@@ -85,7 +85,39 @@ class PadPlane
   void setAnodeWireOffset(float o) { mAnodeWireOffset = o; };
   void setTiltingAngle(double t);
 
-  GPUd() int getPadRowNumber(double z) const;
+  GPUd() int getPadRowNumber(double z) const
+  {
+    //
+    // Finds the pad row number for a given z-position in local supermodule system
+    //
+    int row = 0;
+    int nabove = 0;
+    int nbelow = 0;
+    int middle = 0;
+
+    if ((z > getRow0()) || (z < getRowEnd())) {
+      row = -1;
+
+    } else {
+      nabove = mNrows + 1;
+      nbelow = 0;
+      while (nabove - nbelow > 1) {
+        middle = (nabove + nbelow) / 2;
+        if (z == (mPadRow[middle - 1] + mPadRowSMOffset)) {
+          row = middle;
+        }
+        if (z > (mPadRow[middle - 1] + mPadRowSMOffset)) {
+          nabove = middle;
+        } else {
+          nbelow = middle;
+        }
+      }
+      row = nbelow - 1;
+    }
+
+    return row;
+  };
+
   GPUd() int getPadRowNumberROC(double z) const;
   GPUd() double getPadRow(double z) const;
   GPUd() int getPadColNumber(double rphi) const;

--- a/Detectors/TRD/base/src/PadPlane.cxx
+++ b/Detectors/TRD/base/src/PadPlane.cxx
@@ -42,41 +42,6 @@ void PadPlane::setTiltingAngle(double t)
 }
 
 //_____________________________________________________________________________
-int PadPlane::getPadRowNumber(double z) const
-{
-  //
-  // Finds the pad row number for a given z-position in local supermodule system
-  //
-
-  int row = 0;
-  int nabove = 0;
-  int nbelow = 0;
-  int middle = 0;
-
-  if ((z > getRow0()) || (z < getRowEnd())) {
-    row = -1;
-
-  } else {
-    nabove = mNrows + 1;
-    nbelow = 0;
-    while (nabove - nbelow > 1) {
-      middle = (nabove + nbelow) / 2;
-      if (z == (mPadRow[middle - 1] + mPadRowSMOffset)) {
-        row = middle;
-      }
-      if (z > (mPadRow[middle - 1] + mPadRowSMOffset)) {
-        nabove = middle;
-      } else {
-        nbelow = middle;
-      }
-    }
-    row = nbelow - 1;
-  }
-
-  return row;
-}
-
-//_____________________________________________________________________________
 int PadPlane::getPadRowNumberROC(double z) const
 {
   //

--- a/Detectors/TRD/qc/include/TRDQC/Tracking.h
+++ b/Detectors/TRD/qc/include/TRDQC/Tracking.h
@@ -29,6 +29,7 @@
 #include "Rtypes.h"
 
 #include <gsl/span>
+#include <bitset>
 
 namespace o2
 {
@@ -42,15 +43,16 @@ namespace trd
 {
 
 struct TrackQC {
-  int type;          ///< 0 TPC-TRD track; 1 ITS-TPC-TRD track
-  int nTracklets;    ///< number of attached TRD tracklets
-  int nLayers;       //< Number of Layers of a Track in which the track extrapolation was in geometrical acceptance of the TRD
-  float chi2;        ///< total chi2 value for the track
-  float reducedChi2; ///< chi2 total divided by number of layers in which track is inside TRD geometrical acceptance
-  float p;           ///< the total momentum of the track at the point of the innermost ITS cluster (ITS-TPC-TRD) or at the inner TPC radius (TPC-TRD)
-  float pt;          ///< the transverse momentum of the track at the point of the innermost ITS cluster (ITS-TPC-TRD) or at the inner TPC radius (TPC-TRD)
-  float ptSigma2;    //< Sigma2 of pt
-  float dEdxTotTPC;  //< raw total dEdx information for seeding track in TPC
+  int type;                        ///< 0 TPC-TRD track; 1 ITS-TPC-TRD track
+  int nTracklets;                  ///< number of attached TRD tracklets
+  int nLayers;                     //< Number of Layers of a Track in which the track extrapolation was in geometrical acceptance of the TRD
+  float chi2;                      ///< total chi2 value for the track
+  float reducedChi2;               ///< chi2 total divided by number of layers in which track is inside TRD geometrical acceptance
+  float p;                         ///< the total momentum of the track at the point of the innermost ITS cluster (ITS-TPC-TRD) or at the inner TPC radius (TPC-TRD)
+  float pt;                        ///< the transverse momentum of the track at the point of the innermost ITS cluster (ITS-TPC-TRD) or at the inner TPC radius (TPC-TRD)
+  float ptSigma2;                  ///< Sigma2 of pt
+  float dEdxTotTPC;                ///< raw total dEdx information for seeding track in TPC
+  std::bitset<6> isPadrowCrossing; ///< indicate if track crossed a padrow in that layer
 
   // layer-wise information for seeding track and assigned tracklet (if available)
   std::array<bool, constants::NLAYER> findable{};  ///< flag if track was in geometrical acceptance
@@ -80,7 +82,7 @@ struct TrackQC {
   std::array<int, constants::NLAYER> trackletMcm{};                                      ///< the MCM number of the tracklet
   std::array<float, constants::NLAYER> trackletChi2{};                                   ///< estimated chi2 for the update of the track with the given tracklet
   std::array<std::array<int, constants::NCHARGES>, constants::NLAYER> trackletCharges{}; ///< charges of tracklets
-  ClassDefNV(TrackQC, 2);
+  ClassDefNV(TrackQC, 3);
 };
 
 class Tracking

--- a/Detectors/TRD/qc/include/TRDQC/Tracking.h
+++ b/Detectors/TRD/qc/include/TRDQC/Tracking.h
@@ -53,6 +53,7 @@ struct TrackQC {
   float ptSigma2;                  ///< Sigma2 of pt
   float dEdxTotTPC;                ///< raw total dEdx information for seeding track in TPC
   std::bitset<6> isPadrowCrossing; ///< indicate if track crossed a padrow in that layer
+  bool hasNeighbor;                ///< indicate if track crossed a padrow in that layer
 
   // layer-wise information for seeding track and assigned tracklet (if available)
   std::array<bool, constants::NLAYER> findable{};  ///< flag if track was in geometrical acceptance

--- a/Detectors/TRD/qc/include/TRDQC/Tracking.h
+++ b/Detectors/TRD/qc/include/TRDQC/Tracking.h
@@ -43,17 +43,18 @@ namespace trd
 {
 
 struct TrackQC {
-  int type;                        ///< 0 TPC-TRD track; 1 ITS-TPC-TRD track
-  int nTracklets;                  ///< number of attached TRD tracklets
-  int nLayers;                     //< Number of Layers of a Track in which the track extrapolation was in geometrical acceptance of the TRD
-  float chi2;                      ///< total chi2 value for the track
-  float reducedChi2;               ///< chi2 total divided by number of layers in which track is inside TRD geometrical acceptance
-  float p;                         ///< the total momentum of the track at the point of the innermost ITS cluster (ITS-TPC-TRD) or at the inner TPC radius (TPC-TRD)
-  float pt;                        ///< the transverse momentum of the track at the point of the innermost ITS cluster (ITS-TPC-TRD) or at the inner TPC radius (TPC-TRD)
-  float ptSigma2;                  ///< Sigma2 of pt
-  float dEdxTotTPC;                ///< raw total dEdx information for seeding track in TPC
-  std::bitset<6> isPadrowCrossing; ///< indicate if track crossed a padrow in that layer
-  bool hasNeighbor;                ///< indicate if track crossed a padrow in that layer
+  int type;                          ///< 0 TPC-TRD track; 1 ITS-TPC-TRD track
+  int nTracklets;                    ///< number of attached TRD tracklets
+  int nLayers;                       //< Number of Layers of a Track in which the track extrapolation was in geometrical acceptance of the TRD
+  float chi2;                        ///< total chi2 value for the track
+  float reducedChi2;                 ///< chi2 total divided by number of layers in which track is inside TRD geometrical acceptance
+  float p;                           ///< the total momentum of the track at the point of the innermost ITS cluster (ITS-TPC-TRD) or at the inner TPC radius (TPC-TRD)
+  float pt;                          ///< the transverse momentum of the track at the point of the innermost ITS cluster (ITS-TPC-TRD) or at the inner TPC radius (TPC-TRD)
+  float ptSigma2;                    ///< Sigma2 of pt
+  float dEdxTotTPC;                  ///< raw total dEdx information for seeding track in TPC
+  std::bitset<6> isCrossingNeighbor; ///< indicate if track crossed a padrow and/or had a neighboring tracklet in that layer
+  bool hasNeighbor;                  ///< indicate if a track had a tracklet with a neighboring one e.g. potentailly split tracklet
+  bool hasPadrowCrossing;            ///< indicate if track crossed a padrow
 
   // layer-wise information for seeding track and assigned tracklet (if available)
   std::array<bool, constants::NLAYER> findable{};  ///< flag if track was in geometrical acceptance

--- a/Detectors/TRD/qc/src/Tracking.cxx
+++ b/Detectors/TRD/qc/src/Tracking.cxx
@@ -67,6 +67,7 @@ void Tracking::checkTrack(const TrackTRD& trkTrd, bool isTPCTRD)
   qcStruct.dEdxTotTPC = isTPCTRD ? mTracksTPC[trkTrd.getRefGlobalTrackId()].getdEdx().dEdxTotTPC : mTracksTPC[mTracksITSTPC[trkTrd.getRefGlobalTrackId()].getRefTPC()].getdEdx().dEdxTotTPC;
   auto trk = trkSeed;
   for (int iLayer = 0; iLayer < NLAYER; ++iLayer) {
+    qcStruct.isPadrowCrossing[iLayer] = trkTrd.getIsPadrowCrossing(iLayer);
     qcStruct.findable[iLayer] = trkTrd.getIsFindable(iLayer);
     int trkltId = trkTrd.getTrackletIndex(iLayer);
     if (trkltId < 0) {

--- a/Detectors/TRD/qc/src/Tracking.cxx
+++ b/Detectors/TRD/qc/src/Tracking.cxx
@@ -61,6 +61,7 @@ void Tracking::checkTrack(const TrackTRD& trkTrd, bool isTPCTRD)
   qcStruct.p = trkTrd.getP();
   qcStruct.pt = trkTrd.getPt();
   qcStruct.ptSigma2 = trkTrd.getSigma1Pt2();
+  qcStruct.hasNeighbor = trkTrd.getHasNeighbor();
 
   LOGF(debug, "Got track with %i tracklets and ID %i", trkTrd.getNtracklets(), trkTrd.getRefGlobalTrackId());
   const auto& trkSeed = isTPCTRD ? mTracksTPC[trkTrd.getRefGlobalTrackId()].getParamOut() : mTracksITSTPC[trkTrd.getRefGlobalTrackId()].getParamOut();

--- a/Detectors/TRD/qc/src/Tracking.cxx
+++ b/Detectors/TRD/qc/src/Tracking.cxx
@@ -62,13 +62,14 @@ void Tracking::checkTrack(const TrackTRD& trkTrd, bool isTPCTRD)
   qcStruct.pt = trkTrd.getPt();
   qcStruct.ptSigma2 = trkTrd.getSigma1Pt2();
   qcStruct.hasNeighbor = trkTrd.getHasNeighbor();
+  qcStruct.hasPadrowCrossing = trkTrd.getHasPadrowCrossing();
 
   LOGF(debug, "Got track with %i tracklets and ID %i", trkTrd.getNtracklets(), trkTrd.getRefGlobalTrackId());
   const auto& trkSeed = isTPCTRD ? mTracksTPC[trkTrd.getRefGlobalTrackId()].getParamOut() : mTracksITSTPC[trkTrd.getRefGlobalTrackId()].getParamOut();
   qcStruct.dEdxTotTPC = isTPCTRD ? mTracksTPC[trkTrd.getRefGlobalTrackId()].getdEdx().dEdxTotTPC : mTracksTPC[mTracksITSTPC[trkTrd.getRefGlobalTrackId()].getRefTPC()].getdEdx().dEdxTotTPC;
   auto trk = trkSeed;
   for (int iLayer = 0; iLayer < NLAYER; ++iLayer) {
-    qcStruct.isPadrowCrossing[iLayer] = trkTrd.getIsPadrowCrossing(iLayer);
+    qcStruct.isCrossingNeighbor[iLayer] = trkTrd.getIsCrossingNeighbor(iLayer);
     qcStruct.findable[iLayer] = trkTrd.getIsFindable(iLayer);
     int trkltId = trkTrd.getTrackletIndex(iLayer);
     if (trkltId < 0) {

--- a/GPU/GPUTracking/DataTypes/GPUTRDTrack.cxx
+++ b/GPU/GPUTracking/DataTypes/GPUTRDTrack.cxx
@@ -34,6 +34,7 @@ GPUd() void GPUTRDTrack_t<T>::initialize()
   mRefGlobalTrackId = 0;
   mCollisionId = -1;
   mFlags = 0;
+  mIsPadrowCrossing = 0;
   for (int i = 0; i < kNLayers; ++i) {
     mAttachedTracklets[i] = -1;
   }
@@ -69,6 +70,7 @@ GPUd() void GPUTRDTrack_t<T>::ConvertTo(GPUTRDTrackDataRecord& t) const
   for (int i = 0; i < kNLayers; i++) {
     t.fAttachedTracklets[i] = getTrackletIndex(i);
   }
+  t.mIsPadrowCrossing = getIsPadrowCrossing();
 }
 
 template <typename T>
@@ -81,6 +83,7 @@ GPUd() void GPUTRDTrack_t<T>::ConvertFrom(const GPUTRDTrackDataRecord& t)
   setRefGlobalTrackIdRaw(t.fTPCTrackID);
   mChi2 = 0.f;
   mFlags = 0;
+  mIsPadrowCrossing = 0;
   mCollisionId = -1;
   for (int iLayer = 0; iLayer < kNLayers; iLayer++) {
     mAttachedTracklets[iLayer] = t.fAttachedTracklets[iLayer];
@@ -109,7 +112,7 @@ GPUd() GPUTRDTrack_t<T>::GPUTRDTrack_t(const o2::tpc::TrackTPC& t) : T(t)
 
 template <typename T>
 GPUd() GPUTRDTrack_t<T>::GPUTRDTrack_t(const GPUTRDTrack_t<T>& t)
-  : T(t), mChi2(t.mChi2), mRefGlobalTrackId(t.mRefGlobalTrackId), mCollisionId(t.mCollisionId), mFlags(t.mFlags)
+  : T(t), mChi2(t.mChi2), mRefGlobalTrackId(t.mRefGlobalTrackId), mCollisionId(t.mCollisionId), mFlags(t.mFlags), mIsPadrowCrossing(t.mIsPadrowCrossing)
 {
   // copy constructor
   for (int i = 0; i < kNLayers; ++i) {
@@ -136,6 +139,7 @@ GPUd() GPUTRDTrack_t<T>& GPUTRDTrack_t<T>::operator=(const GPUTRDTrack_t<T>& t)
   mRefGlobalTrackId = t.mRefGlobalTrackId;
   mCollisionId = t.mCollisionId;
   mFlags = t.mFlags;
+  mIsPadrowCrossing = t.mIsPadrowCrossing;
   for (int i = 0; i < kNLayers; ++i) {
     mAttachedTracklets[i] = t.mAttachedTracklets[i];
   }

--- a/GPU/GPUTracking/DataTypes/GPUTRDTrack.cxx
+++ b/GPU/GPUTracking/DataTypes/GPUTRDTrack.cxx
@@ -34,7 +34,7 @@ GPUd() void GPUTRDTrack_t<T>::initialize()
   mRefGlobalTrackId = 0;
   mCollisionId = -1;
   mFlags = 0;
-  mIsPadrowCrossing = 0;
+  mIsCrossingNeighbor = 0;
   for (int i = 0; i < kNLayers; ++i) {
     mAttachedTracklets[i] = -1;
   }
@@ -70,7 +70,7 @@ GPUd() void GPUTRDTrack_t<T>::ConvertTo(GPUTRDTrackDataRecord& t) const
   for (int i = 0; i < kNLayers; i++) {
     t.fAttachedTracklets[i] = getTrackletIndex(i);
   }
-  t.mIsPadrowCrossing = getIsPadrowCrossing();
+  t.mIsCrossingNeighbor = getIsCrossingNeighbor();
 }
 
 template <typename T>
@@ -83,7 +83,7 @@ GPUd() void GPUTRDTrack_t<T>::ConvertFrom(const GPUTRDTrackDataRecord& t)
   setRefGlobalTrackIdRaw(t.fTPCTrackID);
   mChi2 = 0.f;
   mFlags = 0;
-  mIsPadrowCrossing = 0;
+  mIsCrossingNeighbor = 0;
   mCollisionId = -1;
   for (int iLayer = 0; iLayer < kNLayers; iLayer++) {
     mAttachedTracklets[iLayer] = t.fAttachedTracklets[iLayer];
@@ -112,7 +112,7 @@ GPUd() GPUTRDTrack_t<T>::GPUTRDTrack_t(const o2::tpc::TrackTPC& t) : T(t)
 
 template <typename T>
 GPUd() GPUTRDTrack_t<T>::GPUTRDTrack_t(const GPUTRDTrack_t<T>& t)
-  : T(t), mChi2(t.mChi2), mRefGlobalTrackId(t.mRefGlobalTrackId), mCollisionId(t.mCollisionId), mFlags(t.mFlags), mIsPadrowCrossing(t.mIsPadrowCrossing)
+  : T(t), mChi2(t.mChi2), mRefGlobalTrackId(t.mRefGlobalTrackId), mCollisionId(t.mCollisionId), mFlags(t.mFlags), mIsCrossingNeighbor(t.mIsCrossingNeighbor)
 {
   // copy constructor
   for (int i = 0; i < kNLayers; ++i) {
@@ -139,7 +139,7 @@ GPUd() GPUTRDTrack_t<T>& GPUTRDTrack_t<T>::operator=(const GPUTRDTrack_t<T>& t)
   mRefGlobalTrackId = t.mRefGlobalTrackId;
   mCollisionId = t.mCollisionId;
   mFlags = t.mFlags;
-  mIsPadrowCrossing = t.mIsPadrowCrossing;
+  mIsCrossingNeighbor = t.mIsCrossingNeighbor;
   for (int i = 0; i < kNLayers; ++i) {
     mAttachedTracklets[i] = t.mAttachedTracklets[i];
   }

--- a/GPU/GPUTracking/DataTypes/GPUTRDTrack.h
+++ b/GPU/GPUTracking/DataTypes/GPUTRDTrack.h
@@ -86,6 +86,8 @@ class GPUTRDTrack_t : public T
   GPUd() short getCollisionId() const { return mCollisionId; }
   GPUd() int getNtracklets() const;
   GPUd() float getChi2() const { return mChi2; }
+  GPUd() unsigned char getIsPadrowCrossing() const { return mIsPadrowCrossing; }
+  GPUd() bool getIsPadrowCrossing(int iLayer) const { return mIsPadrowCrossing & (1 << iLayer); }
   GPUd() float getReducedChi2() const { return getNlayersFindable() == 0 ? mChi2 : mChi2 / getNlayersFindable(); }
   GPUd() bool getIsStopped() const { return (mFlags >> kStopFlag) & 0x1; }
   GPUd() bool getIsAmbiguous() const { return (mFlags >> kAmbiguousFlag) & 0x1; }
@@ -106,6 +108,7 @@ class GPUTRDTrack_t : public T
   GPUd() void setIsStopped() { mFlags |= (1U << kStopFlag); }
   GPUd() void setIsAmbiguous() { mFlags |= (1U << kAmbiguousFlag); }
   GPUd() void setChi2(float chi2) { mChi2 = chi2; }
+  GPUd() void setIsPadrowCrossing(int iLayer) { mIsPadrowCrossing |= (1U << iLayer); }
 
   // conversion to / from HLT track structure (only for AliRoot)
   GPUd() void ConvertTo(GPUTRDTrackDataRecord& t) const;
@@ -117,11 +120,12 @@ class GPUTRDTrack_t : public T
   int mAttachedTracklets[kNLayers]; // indices of the tracklets attached to this track; -1 means no tracklet in that layer
   short mCollisionId;               // the collision ID of the tracklets attached to this track; is used to retrieve the BC information for this track after the tracking is done
   unsigned char mFlags;             // bits 0 to 5 indicate whether track is findable in layer 0 to 5, bit 6 indicates an ambiguous track and bit 7 flags if the track is stopped in the TRD
+  unsigned char mIsPadrowCrossing;  // bits 0 to 5 indicate wheter track was in between two padrows
 
  private:
   GPUd() void initialize();
 #if !defined(GPUCA_STANDALONE) && !defined(GPUCA_ALIROOT_LIB)
-  ClassDefNV(GPUTRDTrack_t, 2);
+  ClassDefNV(GPUTRDTrack_t, 3);
 #endif
 };
 

--- a/GPU/GPUTracking/DataTypes/GPUTRDTrack.h
+++ b/GPU/GPUTracking/DataTypes/GPUTRDTrack.h
@@ -88,6 +88,7 @@ class GPUTRDTrack_t : public T
   GPUd() float getChi2() const { return mChi2; }
   GPUd() unsigned char getIsPadrowCrossing() const { return mIsPadrowCrossing; }
   GPUd() bool getIsPadrowCrossing(int iLayer) const { return mIsPadrowCrossing & (1 << iLayer); }
+  GPUd() bool getHasNeighbor() const { return mIsPadrowCrossing & (1 << 6); }
   GPUd() float getReducedChi2() const { return getNlayersFindable() == 0 ? mChi2 : mChi2 / getNlayersFindable(); }
   GPUd() bool getIsStopped() const { return (mFlags >> kStopFlag) & 0x1; }
   GPUd() bool getIsAmbiguous() const { return (mFlags >> kAmbiguousFlag) & 0x1; }
@@ -109,6 +110,7 @@ class GPUTRDTrack_t : public T
   GPUd() void setIsAmbiguous() { mFlags |= (1U << kAmbiguousFlag); }
   GPUd() void setChi2(float chi2) { mChi2 = chi2; }
   GPUd() void setIsPadrowCrossing(int iLayer) { mIsPadrowCrossing |= (1U << iLayer); }
+  GPUd() void setHasNeighbor() { mIsPadrowCrossing |= (1U << 6); }
 
   // conversion to / from HLT track structure (only for AliRoot)
   GPUd() void ConvertTo(GPUTRDTrackDataRecord& t) const;
@@ -120,7 +122,7 @@ class GPUTRDTrack_t : public T
   int mAttachedTracklets[kNLayers]; // indices of the tracklets attached to this track; -1 means no tracklet in that layer
   short mCollisionId;               // the collision ID of the tracklets attached to this track; is used to retrieve the BC information for this track after the tracking is done
   unsigned char mFlags;             // bits 0 to 5 indicate whether track is findable in layer 0 to 5, bit 6 indicates an ambiguous track and bit 7 flags if the track is stopped in the TRD
-  unsigned char mIsPadrowCrossing;  // bits 0 to 5 indicate wheter track was in between two padrows
+  unsigned char mIsPadrowCrossing;  // bits 0 to 5 indicate whether track was in between two padrows and bit 6 indicates that a neighbor in any layer has been found
 
  private:
   GPUd() void initialize();

--- a/GPU/GPUTracking/DataTypes/GPUTRDTrack.h
+++ b/GPU/GPUTracking/DataTypes/GPUTRDTrack.h
@@ -86,9 +86,10 @@ class GPUTRDTrack_t : public T
   GPUd() short getCollisionId() const { return mCollisionId; }
   GPUd() int getNtracklets() const;
   GPUd() float getChi2() const { return mChi2; }
-  GPUd() unsigned char getIsPadrowCrossing() const { return mIsPadrowCrossing; }
-  GPUd() bool getIsPadrowCrossing(int iLayer) const { return mIsPadrowCrossing & (1 << iLayer); }
-  GPUd() bool getHasNeighbor() const { return mIsPadrowCrossing & (1 << 6); }
+  GPUd() unsigned char getIsCrossingNeighbor() const { return mIsCrossingNeighbor; }
+  GPUd() bool getIsCrossingNeighbor(int iLayer) const { return mIsCrossingNeighbor & (1 << iLayer); }
+  GPUd() bool getHasNeighbor() const { return mIsCrossingNeighbor & (1 << 6); }
+  GPUd() bool getHasPadrowCrossing() const { return mIsCrossingNeighbor & (1 << 7); }
   GPUd() float getReducedChi2() const { return getNlayersFindable() == 0 ? mChi2 : mChi2 / getNlayersFindable(); }
   GPUd() bool getIsStopped() const { return (mFlags >> kStopFlag) & 0x1; }
   GPUd() bool getIsAmbiguous() const { return (mFlags >> kAmbiguousFlag) & 0x1; }
@@ -109,20 +110,21 @@ class GPUTRDTrack_t : public T
   GPUd() void setIsStopped() { mFlags |= (1U << kStopFlag); }
   GPUd() void setIsAmbiguous() { mFlags |= (1U << kAmbiguousFlag); }
   GPUd() void setChi2(float chi2) { mChi2 = chi2; }
-  GPUd() void setIsPadrowCrossing(int iLayer) { mIsPadrowCrossing |= (1U << iLayer); }
-  GPUd() void setHasNeighbor() { mIsPadrowCrossing |= (1U << 6); }
+  GPUd() void setIsCrossingNeighbor(int iLayer) { mIsCrossingNeighbor |= (1U << iLayer); }
+  GPUd() void setHasNeighbor() { mIsCrossingNeighbor |= (1U << 6); }
+  GPUd() void setHasPadrowCrossing() { mIsCrossingNeighbor |= (1U << 7); }
 
   // conversion to / from HLT track structure (only for AliRoot)
   GPUd() void ConvertTo(GPUTRDTrackDataRecord& t) const;
   GPUd() void ConvertFrom(const GPUTRDTrackDataRecord& t);
 
  protected:
-  float mChi2;                      // total chi2.
-  unsigned int mRefGlobalTrackId;   // raw GlobalTrackID of the seeding track (either ITS-TPC or TPC)
-  int mAttachedTracklets[kNLayers]; // indices of the tracklets attached to this track; -1 means no tracklet in that layer
-  short mCollisionId;               // the collision ID of the tracklets attached to this track; is used to retrieve the BC information for this track after the tracking is done
-  unsigned char mFlags;             // bits 0 to 5 indicate whether track is findable in layer 0 to 5, bit 6 indicates an ambiguous track and bit 7 flags if the track is stopped in the TRD
-  unsigned char mIsPadrowCrossing;  // bits 0 to 5 indicate whether track was in between two padrows and bit 6 indicates that a neighbor in any layer has been found
+  float mChi2;                       // total chi2.
+  unsigned int mRefGlobalTrackId;    // raw GlobalTrackID of the seeding track (either ITS-TPC or TPC)
+  int mAttachedTracklets[kNLayers];  // indices of the tracklets attached to this track; -1 means no tracklet in that layer
+  short mCollisionId;                // the collision ID of the tracklets attached to this track; is used to retrieve the BC information for this track after the tracking is done
+  unsigned char mFlags;              // bits 0 to 5 indicate whether track is findable in layer 0 to 5, bit 6 indicates an ambiguous track and bit 7 flags if the track is stopped in the TRD
+  unsigned char mIsCrossingNeighbor; // bits 0 to 5 indicate if a tracklet was either a neighboring tracklet (e.g. a potential split tracklet) or crossed a padrow, bit 6 indicates that a neighbor in any layer has been found and bit 7 if a padrow was crossed
 
  private:
   GPUd() void initialize();

--- a/GPU/GPUTracking/TRDTracking/GPUTRDGeometry.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDGeometry.h
@@ -72,6 +72,7 @@ class GPUTRDpadPlane : private o2::trd::PadPlane
   GPUd() float GetColPos(int col) const { return getColPos(col); }
   GPUd() float GetNrows() const { return getNrows(); }
   GPUd() float GetNcols() const { return getNcols(); }
+  GPUd() int GetPadRowNumber(double z) const { return getPadRowNumber(z); }
 };
 
 class GPUTRDGeometry : private o2::trd::GeometryFlat
@@ -88,6 +89,7 @@ class GPUTRDGeometry : private o2::trd::GeometryFlat
   // Base functionality of Geometry
   GPUd() float GetTime0(int layer) const { return getTime0(layer); }
   GPUd() float GetCol0(int layer) const { return getCol0(layer); }
+  GPUd() float GetCdrHght() const { return cdrHght(); }
   GPUd() int GetLayer(int det) const { return getLayer(det); }
   GPUd() bool CreateClusterMatrixArray() const { return false; }
   GPUd() float AnodePos() const { return anodePos(); }
@@ -138,6 +140,7 @@ class GPUTRDpadPlane
   GPUd() float GetColEnd() const { return 0; }
   GPUd() float GetColPos(int col) const { return 0; }
   GPUd() float GetNrows() const { return 0; }
+  GPUd() int GetPadRowNumber(double z) const { return 0; }
 };
 
 class GPUTRDGeometry
@@ -155,6 +158,7 @@ class GPUTRDGeometry
   // Base functionality of Geometry
   GPUd() float GetTime0(int layer) const { return 0; }
   GPUd() float GetCol0(int layer) const { return 0; }
+  GPUd() float GetCdrHght() const { return 0; }
   GPUd() int GetLayer(int det) const { return 0; }
   GPUd() bool CreateClusterMatrixArray() const { return false; }
   GPUd() float AnodePos() const { return 0; }

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTrackData.h
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTrackData.h
@@ -28,6 +28,7 @@ struct GPUTRDTrackDataRecord {
   float fC[15];              // covariance matrix
   int fTPCTrackID;           // id of corresponding TPC track
   int fAttachedTracklets[6]; // IDs for attached tracklets sorted by layer
+  unsigned char mIsPadrowCrossing; // bits 0 to 5 indicate whether a padrow was crossed
 
   int GetNTracklets() const
   {

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
@@ -821,6 +821,34 @@ GPUd() bool GPUTRDTracker_t<TRDTRK, PROP>::FollowProlongation(PROP* prop, TRDTRK
       if (iUpdate == 0 && mNCandidates > 1) {
         *t = mCandidates[2 * iUpdate + nextIdx];
       }
+      // check if track crosses padrows
+      float projZEntry, projYEntry;
+      // Get Z for Entry of Track
+      prop->getPropagatedYZ(trkWork->getX() - mGeo->GetCdrHght(), projYEntry, projZEntry);
+      // Get Padrow number for Exit&Entry and compare. If is not equal mark
+      // as padrow crossing. While simple, this comes with the cost of not
+      // properly handling Tracklets that hit a different Pad but still get
+      // attached to the Track. It is estimated that the probability for
+      // this is low.
+      const auto padrowEntry = pad->GetPadRowNumber(projZEntry);
+      const auto padrowExit = pad->GetPadRowNumber(trkWork->getZ());
+      if (padrowEntry != padrowExit) {
+        trkWork->setIsPadrowCrossing(iLayer);
+        continue; // we can only mark padrow crossings once, hence the next loop is pointless
+      }
+      const auto currDet = tracklets[mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId].GetDetector();
+      // Mark tracklets as Padrow crossing if they have a neighboring tracklet.
+      for (int trkltIdx = glbTrkltIdxOffset + mTrackletIndexArray[trkltIdxOffset + currDet]; trkltIdx < glbTrkltIdxOffset + mTrackletIndexArray[trkltIdxOffset + currDet + 1]; ++trkltIdx) {
+        // skip orig tracklet
+        if (mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId == trkltIdx) {
+          continue;
+        }
+        if (GPUCommonMath::Abs(tracklets[mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId].GetZbin() - tracklets[trkltIdx].GetZbin()) == 1 &&
+            GPUCommonMath::Abs(tracklets[mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId].GetY() - tracklets[trkltIdx].GetY()) < 1) {
+          trkWork->setIsPadrowCrossing(iLayer);
+          break;
+        }
+      }
     } // end update loop
 
     if (!isOK) {

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
@@ -846,6 +846,7 @@ GPUd() bool GPUTRDTracker_t<TRDTRK, PROP>::FollowProlongation(PROP* prop, TRDTRK
         if (GPUCommonMath::Abs(tracklets[mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId].GetZbin() - tracklets[trkltIdx].GetZbin()) == 1 &&
             GPUCommonMath::Abs(tracklets[mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId].GetY() - tracklets[trkltIdx].GetY()) < 1) {
           trkWork->setIsPadrowCrossing(iLayer);
+          trkWork->setHasNeighbor();
           break;
         }
       }

--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
@@ -833,8 +833,8 @@ GPUd() bool GPUTRDTracker_t<TRDTRK, PROP>::FollowProlongation(PROP* prop, TRDTRK
       const auto padrowEntry = pad->GetPadRowNumber(projZEntry);
       const auto padrowExit = pad->GetPadRowNumber(trkWork->getZ());
       if (padrowEntry != padrowExit) {
-        trkWork->setIsPadrowCrossing(iLayer);
-        continue; // we can only mark padrow crossings once, hence the next loop is pointless
+        trkWork->setIsCrossingNeighbor(iLayer);
+        trkWork->setHasPadrowCrossing();
       }
       const auto currDet = tracklets[mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId].GetDetector();
       // Mark tracklets as Padrow crossing if they have a neighboring tracklet.
@@ -845,7 +845,7 @@ GPUd() bool GPUTRDTracker_t<TRDTRK, PROP>::FollowProlongation(PROP* prop, TRDTRK
         }
         if (GPUCommonMath::Abs(tracklets[mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId].GetZbin() - tracklets[trkltIdx].GetZbin()) == 1 &&
             GPUCommonMath::Abs(tracklets[mHypothesis[iUpdate + hypothesisIdxOffset].mTrackletId].GetY() - tracklets[trkltIdx].GetY()) < 1) {
-          trkWork->setIsPadrowCrossing(iLayer);
+          trkWork->setIsCrossingNeighbor(iLayer);
           trkWork->setHasNeighbor();
           break;
         }


### PR DESCRIPTION
This patch adds to the GPUTRDTrack one new members:
     1. mIsPadrowCrossing:
        unsigned char -> bits 0 to 5 indicate if in a layer the track
        crossed a padrow and bit 6 indicate whether a neighborign was found.
        Rational: Charge information is lost in these tracklets and
        one should possibly even discard those Tracks for gain
        calibration and PID.

Additionally, this was added to TrackQC.

Signed-off-by: Felix Schlepper <f3sch.git@outlook.com>