### PR TITLE
Do not cache DataProcessingContext & TimingInfo

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdAggregatorSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdAggregatorSpec.h
@@ -91,12 +91,6 @@ class ITSThresholdAggregator : public Task
   int mRunNumber = -1;
   // confDB version
   short int mDBversion = -1;
-
-  // DataTakingContext used to get lhcperiod
-  o2::framework::DataTakingContext mDataTakingContext{};
-
-  // Timing info used to get run number
-  o2::framework::TimingInfo mTimingInfo{};
 };
 
 // Create a processor spec

--- a/Detectors/ITSMFT/ITS/workflow/src/ThresholdAggregatorSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ThresholdAggregatorSpec.cxx
@@ -235,8 +235,8 @@ void ITSThresholdAggregator::endOfStream(EndOfStreamContext& ec)
 // Search current month  or LHCperiod, and read run number
 void ITSThresholdAggregator::updateLHCPeriodAndRunNumber(ProcessingContext& pc)
 {
-  mDataTakingContext = pc.services().get<DataTakingContext>();
-  const std::string LHCPeriodStr = mDataTakingContext.lhcPeriod;
+  auto& dataTakingContext = pc.services().get<o2::framework::DataTakingContext>();
+  const std::string LHCPeriodStr = dataTakingContext.lhcPeriod;
   if (!(LHCPeriodStr.empty())) {
     this->mLHCPeriod = LHCPeriodStr;
   } else {
@@ -250,8 +250,8 @@ void ITSThresholdAggregator::updateLHCPeriodAndRunNumber(ProcessingContext& pc)
   this->mLHCPeriod += "_ITS";
 
   // Run number
-  mTimingInfo = pc.services().get<o2::framework::TimingInfo>();
-  this->mRunNumber = mTimingInfo.runNumber;
+  auto& timingInfo = pc.services().get<o2::framework::TimingInfo>();
+  this->mRunNumber = timingInfo.runNumber;
 
   return;
 }


### PR DESCRIPTION
Spotted by some syntetic run. The copy was taking 10% of the CPU utilization.