### PR TITLE
TRD add pretrigger phase to digits

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
@@ -90,6 +90,7 @@ constexpr int MAXPARSEERRORHISTOGRAMS = 60;    // size of the array holding the 
 constexpr unsigned int ETYPEPHYSICSTRIGGER = 0x2;     // CRU Half Chamber header eventtype definition
 constexpr unsigned int ETYPECALIBRATIONTRIGGER = 0x3; // CRU Half Chamber header eventtype definition
 constexpr int MAXCRUERRORVALUE = 0x2;          // Max possible value for a CRU Halfchamber link error. As of may 2022, can only be 0x0, 0x1, and 0x2, at least that is all so far(may2022).
+constexpr int INVALIDPRETRIGGERPHASE = 0xf;    // Invalid value for phase, used to signify there is no hcheader.
 
 } // namespace constants
 } // namespace trd

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Digit.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Digit.h
@@ -38,15 +38,28 @@ using ArrayADC = std::array<ADC_t, constants::TIMEBINS>;
 //        this negates the need for need alternate indexing strategies.
 //        if you are trying to go from mcm/rob/adc to pad/row and back to mcm/rob/adc ,
 //        you may not end up in the same place, you need to remember to manually check for shared pads.
+//    Pre Trigger phase:
+//        LHC clock runs at 40.08MHz, ADC run at 1/4 or 10MHz and the trap runs at 120MHz or LHC*3.
+//        The phase then has 4 values although it has 4 bits, which is rather confusing.
+//        The trap clock can therefore be in 1 of 12 positions relative to the ADC clock.
+//        Only 4 of those positions are valid, hence there is 4 values for pre trigger, 0,3,7,11.
+//        vaguely graphically below:
+//        LHC  ___---___---___---___---___---___---___---___---___---___---___---___---___---___---___---___---___---___---___---___---___---___---___
+//        TRAP _-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_
+//        ADC  ___------------____________------------____________------------____________------------____________------------____________------------
+//             _________------------____________------------____________------------____________------------____________------------____________------
+//             ---____________------------____________------------____________------------____________------------____________------------____________
+//             ---------____________------------____________------------____________------------____________------------____________------------______
+// PreTrig     _________------________________________------________________________------________________________------________________________------
 
 class Digit
 {
  public:
   Digit() = default;
   ~Digit() = default;
-  Digit(const int det, const int row, const int pad, const ArrayADC adc);
-  Digit(const int det, const int row, const int pad); // add adc data in a seperate step
-  Digit(const int det, const int rob, const int mcm, const int channel, const ArrayADC adc);
+  Digit(const int det, const int row, const int pad, const ArrayADC adc, const uint8_t phase = 0);
+  Digit(const int det, const int row, const int pad); // add adc data, and pretrigger phase in a seperate step
+  Digit(const int det, const int rob, const int mcm, const int channel, const ArrayADC adc, const uint8_t phase = 0);
   Digit(const int det, const int rob, const int mcm, const int channel); // add adc data in a seperate step
 
   // Copy
@@ -59,17 +72,19 @@ class Digit
   void setROB(int row, int col) { mROB = HelperMethods::getROBfromPad(row, col); } // set ROB from pad row, column
   void setMCM(int row, int col) { mMCM = HelperMethods::getMCMfromPad(row, col); } // set MCM from pad row, column
   void setChannel(int channel) { mChannel = channel; }
-  void setDetector(int det) { mDetector = det; }
+  void setDetector(int det) { mDetector = ((mDetector & 0xf000) | (det & 0xfff)); }
   void setADC(ArrayADC const& adc) { mADC = adc; }
   void setADC(const gsl::span<ADC_t>& adc) { std::copy(adc.begin(), adc.end(), mADC.begin()); }
+  void setPreTrigPhase(const unsigned int phase) { mDetector = (((phase & 0xf) << 12) | (mDetector & 0xfff)); }
   // Get methods
-  int getDetector() const { return mDetector; }
-  int getHCId() const { return mDetector * 2 + (mROB % 2); }
+  int getDetector() const { return mDetector & 0xfff; }
+  int getHCId() const { return (mDetector & 0xfff) * 2 + (mROB % 2); }
   int getPadRow() const { return HelperMethods::getPadRowFromMCM(mROB, mMCM); }
   int getPadCol() const { return HelperMethods::getPadColFromADC(mROB, mMCM, mChannel); }
   int getROB() const { return mROB; }
   int getMCM() const { return mMCM; }
   int getChannel() const { return mChannel; }
+  int getPreTrigPhase() const { return ((mDetector >> 12) & 0xf); }
   bool isSharedDigit() const;
 
   ArrayADC const& getADC() const { return mADC; }
@@ -83,13 +98,13 @@ class Digit
   }
 
  private:
-  std::uint16_t mDetector{0}; // detector, the chamber [0-539]
+  std::uint16_t mDetector{0}; // detector, the chamber [0-539] ; detector value is in 0-11 [0-1023], 12-15 is the phase of the trigger from the digit hc header.
   std::uint8_t mROB{0};       // read out board within chamber [0-7] [0-5] depending on C0 or C1
   std::uint8_t mMCM{0};       // MCM chip this digit is attached [0-15]
   std::uint8_t mChannel{0};   // channel of this chip the digit is attached to, see TDP chapter ?? TODO fill in later the figure number of ROB to MCM mapping picture
 
   ArrayADC mADC{}; // ADC vector (30 time-bins)
-  ClassDefNV(Digit, 3);
+  ClassDefNV(Digit, 4);
 };
 
 std::ostream& operator<<(std::ostream& stream, const Digit& d);

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/RawData.h
@@ -258,8 +258,8 @@ struct DigitHCHeader1 {
     uint32_t word;
     struct {
       uint32_t res : 2;
-      uint32_t ptrigcount : 4;
       uint32_t ptrigphase : 4;
+      uint32_t ptrigcount : 4;
       uint32_t bunchcrossing : 16;
       uint32_t numtimebins : 6;
     } __attribute__((__packed__));

--- a/DataFormats/Detectors/TRD/src/Digit.cxx
+++ b/DataFormats/Detectors/TRD/src/Digit.cxx
@@ -18,13 +18,14 @@ namespace o2::trd
 
 using namespace constants;
 
-Digit::Digit(const int det, const int row, const int pad, const ArrayADC adc)
+Digit::Digit(const int det, const int row, const int pad, const ArrayADC adc, const uint8_t pretrigphase)
 {
   setDetector(det);
   setROB(row, pad);
   setMCM(row, pad);
   setADC(adc);
   setChannel(NADCMCM - 2 - (pad % NCOLMCM));
+  setPreTrigPhase(pretrigphase);
 }
 
 Digit::Digit(const int det, const int row, const int pad) // add adc data in a seperate step
@@ -35,13 +36,14 @@ Digit::Digit(const int det, const int row, const int pad) // add adc data in a s
   setChannel(NADCMCM - 2 - (pad % NCOLMCM));
 }
 
-Digit::Digit(const int det, const int rob, const int mcm, const int channel, const ArrayADC adc)
+Digit::Digit(const int det, const int rob, const int mcm, const int channel, const ArrayADC adc, const uint8_t pretrigphase)
 {
   setDetector(det);
   setROB(rob);
   setMCM(mcm);
   setChannel(channel);
   setADC(adc);
+  setPreTrigPhase(pretrigphase);
 }
 
 Digit::Digit(const int det, const int rob, const int mcm, const int channel) // add adc data in a seperate step

--- a/DataFormats/Detectors/TRD/test/testDigit.cxx
+++ b/DataFormats/Detectors/TRD/test/testDigit.cxx
@@ -176,6 +176,27 @@ BOOST_AUTO_TEST_CASE(TRDDigit_test)
   testDigitDetRowPad(za, 10, 12, NCOLMCM - 1);
   BOOST_CHECK(za.getADC()[14] == 56); // 14th time bin should be 56;
   BOOST_CHECK(za.getADC()[16] == 58); // 16th time bin should be 58;
+
+  // check the setting and reading of the phase for various combinations of setting the detector and phase.
+  Digit withphase(10, 6, 0, 2, data, 3);
+  BOOST_CHECK(withphase.getPreTrigPhase() == 0x3);
+  withphase.setPreTrigPhase(1);
+  BOOST_CHECK(withphase.getPreTrigPhase() == 0x1);
+  withphase.setDetector(12);
+  BOOST_CHECK(withphase.getPreTrigPhase() == 0x1);
+  BOOST_CHECK(withphase.getDetector() == 0xc);
+  withphase.setDetector(539);
+  BOOST_CHECK(withphase.getPreTrigPhase() == 0x1);
+  BOOST_CHECK(withphase.getDetector() == 539);
+  withphase.setDetector(12);
+  BOOST_CHECK(withphase.getPreTrigPhase() == 0x1);
+  BOOST_CHECK(withphase.getDetector() == 12);
+  withphase.setDetector(0);
+  BOOST_CHECK(withphase.getPreTrigPhase() == 0x1);
+  BOOST_CHECK(withphase.getDetector() == 0);
+  withphase.setPreTrigPhase(0);
+  BOOST_CHECK(withphase.getPreTrigPhase() == 0x0);
+  BOOST_CHECK(withphase.getDetector() == 0);
 }
 
 } // namespace trd

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CruRawReader.h
@@ -171,7 +171,8 @@ class CruRawReader
   bool mHaveSeenDigitHCHeader3{false};     // flag, whether we can compare an incoming DigitHCHeader3 with a header we have seen before
   uint32_t mPreviousDigitHCHeadersvnver;  // svn ver in the digithalfchamber header, used for validity checks
   uint32_t mPreviousDigitHCHeadersvnrver; // svn release ver also used for validity checks
-
+  uint8_t mPreTriggerPhase = 0;           // Pre trigger phase of the adcs producing the digits, its comes from an optional DigitHCHeader
+                                          // It is stored here to carry it around after parsing it from the DigitHCHeader1 if it exists in the data.
   uint16_t mCRUEndpoint; // the upper or lower half of the currently parsed cru 0-14 or 15-29
   uint16_t mCRUID;       // CRU ID taken from the FEEID of the RDH
   TRDFeeID mFEEID;       // current Fee ID working on

--- a/Detectors/TRD/reconstruction/src/CruRawReader.cxx
+++ b/Detectors/TRD/reconstruction/src/CruRawReader.cxx
@@ -244,6 +244,8 @@ bool CruRawReader::parseDigitHCHeaders(int hcid)
   // mHBFoffset32 is the current offset into the current buffer,
   //
   mDigitHCHeader.word = mHBFPayload[mHBFoffset32++];
+  mPreTriggerPhase = INVALIDPRETRIGGERPHASE;
+
   if (mOptions[TRDByteSwapBit]) {
     // byte swap if needed.
     o2::trd::HelperMethods::swapByteOrder(mDigitHCHeader.word);
@@ -294,6 +296,8 @@ bool CruRawReader::parseDigitHCHeaders(int hcid)
         }
         DigitHCHeader1 header1;
         header1.word = headers[headerwordcount];
+        mPreTriggerPhase = header1.ptrigphase;
+
         headersfound.set(0);
         if ((header1.numtimebins > TIMEBINS) || (header1.numtimebins < 3)) {
           if (mMaxWarnPrinted > 0) {
@@ -785,7 +789,7 @@ int CruRawReader::parseDigitLinkData(int maxWords32, int hcid, int& wordsRejecte
           if (exitChannelLoop) {
             break;
           }
-          mEventRecords.getCurrentEventRecord().addDigit(Digit(hcid / 2, (int)mcmHeader.rob, (int)mcmHeader.mcm, iChannel, adcValues));
+          mEventRecords.getCurrentEventRecord().addDigit(Digit(hcid / 2, (int)mcmHeader.rob, (int)mcmHeader.mcm, iChannel, adcValues, mPreTriggerPhase));
           mEventRecords.getCurrentEventRecord().incDigitsFound(1);
           ++mDigitsFound;
         } // end active channel


### PR DESCRIPTION
Add pretrigger phase to Digits.
The pretrigger phase is a 4 bit number that can hold 1 of 4 values. see ascii art in the digit class header file.
The phase is stored in the top 4 bits of the Detector uint16_t thus eliminating the change of class and ctf.

We will then have 4 points on the left of our current peak in the pulseheights at root histogram bin 2.