### PR TITLE
GPU: Fix compilation issue with HIP+LOG(): workaround

### DIFF
--- a/DataFormats/Reconstruction/src/TrackParametrization.cxx
+++ b/DataFormats/Reconstruction/src/TrackParametrization.cxx
@@ -216,7 +216,7 @@ GPUd() bool TrackParametrization<value_T>::propagateParamTo(value_t xk, const di
   }
   // Do not propagate tracks outside the ALICE detector
   if (math_utils::detail::abs<value_T>(dx) > 1e5 || math_utils::detail::abs<value_T>(getY()) > 1e5 || math_utils::detail::abs<value_T>(getZ()) > 1e5) {
-    LOGP(warning, "Anomalous track, target X:{:f}", xk);
+    LOG(warning) << "Anomalous track, traget X:" << xk;
     return false;
   }
   value_t crv = getCurvature(b[2]);

--- a/DataFormats/Reconstruction/src/TrackParametrizationWithError.cxx
+++ b/DataFormats/Reconstruction/src/TrackParametrizationWithError.cxx
@@ -9,22 +9,6 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// @file   TrackparametrizationWithError.cxx
-/// @author ruben.shahoyan@cern.ch, michael.lettrich@cern.ch
-/// @since  Oct 1, 2020
-/// @brief
-
-// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
-// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
-// All rights not expressly granted are reserved.
-//
-// This software is distributed under the terms of the GNU General Public
-// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
-//
-// In applying this license CERN does not waive the privileges and immunities
-// granted to it by virtue of its status as an Intergovernmental Organization
-// or submit itself to any jurisdiction.
-
 #include "ReconstructionDataFormats/TrackParametrizationWithError.h"
 #include "ReconstructionDataFormats/Vertex.h"
 #include "ReconstructionDataFormats/DCA.h"
@@ -182,7 +166,7 @@ GPUd() bool TrackParametrizationWithError<value_T>::rotate(value_t alpha)
   // RS: check if rotation does no invalidate track model (cos(local_phi)>=0, i.e. particle
   // direction in local frame is along the X axis
   if ((csp * ca + snp * sa) < 0) {
-    //LOGP(warning,"Rotation failed: local cos(phi) would become {:.2f}", csp * ca + snp * sa);
+    // LOGP(warning,"Rotation failed: local cos(phi) would become {:.2f}", csp * ca + snp * sa);
     return false;
   }
   //
@@ -230,7 +214,7 @@ GPUd() bool TrackParametrizationWithError<value_T>::propagateToDCA(const o2::dat
   value_t xv = vtx.getX() * cs + vtx.getY() * sn, yv = -vtx.getX() * sn + vtx.getY() * cs, zv = vtx.getZ();
   x -= xv;
   y -= yv;
-  //Estimate the impact parameter neglecting the track curvature
+  // Estimate the impact parameter neglecting the track curvature
   value_t d = gpu::CAMath::Abs(x * snp - y * csp);
   if (d > maxD) {
     return false;
@@ -455,7 +439,7 @@ GPUd() bool TrackParametrizationWithError<value_T>::propagateTo(value_t xk, cons
   }
   // Do not propagate tracks outside the ALICE detector
   if (gpu::CAMath::Abs(dx) > 1e5 || gpu::CAMath::Abs(this->getY()) > 1e5 || gpu::CAMath::Abs(this->getZ()) > 1e5) {
-    LOGP(warning, "Anomalous track, target X:{:f}", xk);
+    LOG(warning) << "Anomalous track, target X:" << xk;
     //    print();
     return false;
   }

--- a/Detectors/Base/src/Propagator.cxx
+++ b/Detectors/Base/src/Propagator.cxx
@@ -427,7 +427,7 @@ GPUd() bool PropagatorImpl<value_T>::propagateToDCA(const o2::dataformats::Verte
   value_type xv = vtx.getX() * cs + vtx.getY() * sn, yv = -vtx.getX() * sn + vtx.getY() * cs, zv = vtx.getZ();
   x -= xv;
   y -= yv;
-  //Estimate the impact parameter neglecting the track curvature
+  // Estimate the impact parameter neglecting the track curvature
   value_type d = math_utils::detail::abs<value_type>(x * snp - y * csp);
   if (d > maxD) {
     return false;
@@ -476,7 +476,7 @@ GPUd() bool PropagatorImpl<value_T>::propagateToDCABxByBz(const o2::dataformats:
   value_type xv = vtx.getX() * cs + vtx.getY() * sn, yv = -vtx.getX() * sn + vtx.getY() * cs, zv = vtx.getZ();
   x -= xv;
   y -= yv;
-  //Estimate the impact parameter neglecting the track curvature
+  // Estimate the impact parameter neglecting the track curvature
   value_type d = math_utils::detail::abs<value_type>(x * snp - y * csp);
   if (d > maxD) {
     return false;
@@ -525,7 +525,7 @@ GPUd() bool PropagatorImpl<value_T>::propagateToDCA(const math_utils::Point3D<va
   value_type xv = vtx.X() * cs + vtx.Y() * sn, yv = -vtx.X() * sn + vtx.Y() * cs, zv = vtx.Z();
   x -= xv;
   y -= yv;
-  //Estimate the impact parameter neglecting the track curvature
+  // Estimate the impact parameter neglecting the track curvature
   value_type d = math_utils::detail::abs<value_type>(x * snp - y * csp);
   if (d > maxD) {
     return false;
@@ -573,7 +573,7 @@ GPUd() bool PropagatorImpl<value_T>::propagateToDCABxByBz(const math_utils::Poin
   value_type xv = vtx.X() * cs + vtx.Y() * sn, yv = -vtx.X() * sn + vtx.Y() * cs, zv = vtx.Z();
   x -= xv;
   y -= yv;
-  //Estimate the impact parameter neglecting the track curvature
+  // Estimate the impact parameter neglecting the track curvature
   value_type d = math_utils::detail::abs<value_type>(x * snp - y * csp);
   if (d > maxD) {
     return false;
@@ -611,7 +611,7 @@ GPUd() bool PropagatorImpl<value_T>::propagateToDCABxByBz(const math_utils::Poin
 template <typename value_T>
 GPUd() void PropagatorImpl<value_T>::estimateLTFast(o2::track::TrackLTIntegral& lt, const o2::track::TrackParametrization<value_type>& trc) const
 {
-  value_T xdca = 0., ydca = 0., length = 0.;          // , zdca = 0. // zdca might be used in future
+  value_T xdca = 0., ydca = 0., length = 0.; // , zdca = 0. // zdca might be used in future
   o2::math_utils::CircleXY<value_T> c;
   constexpr float TinyF = 1e-9;
   auto straigh_line_approx = [&]() {
@@ -691,7 +691,7 @@ GPUd() void PropagatorImpl<value_T>::getFieldXYZImpl(const math_utils::Point3D<T
 #endif
     float bxyzF[3];
     f->GetField(xyz.X(), xyz.Y(), xyz.Z(), bxyzF);
-    //copy and convert
+    // copy and convert
     constexpr value_type kCLight1 = 1. / o2::gpu::gpu_common_constants::kCLight;
     for (uint i = 0; i < 3; ++i) {
       bxyz[i] = static_cast<value_type>(bxyzF[i]) * kCLight1;

--- a/GPU/Common/GPUCommonLogger.h
+++ b/GPU/Common/GPUCommonLogger.h
@@ -47,10 +47,9 @@ struct DummyLogger {
     printf(string "\n");        \
   }
 
-#elif defined(GPUCA_STANDALONE) ||                    \
-  defined(GPUCA_ALIROOT_LIB) ||                       \
-  (!defined(__cplusplus) || __cplusplus < 201703L) || \
-  (defined(__HIPCC__) && (!defined(_GLIBCXX_USE_CXX11_ABI) || _GLIBCXX_USE_CXX11_ABI == 0))
+#elif defined(GPUCA_STANDALONE) || \
+  defined(GPUCA_ALIROOT_LIB) ||    \
+  (!defined(__cplusplus) || __cplusplus < 201703L)
 #include <iostream>
 #include <cstdio>
 #define LOG(type) std::cout

--- a/GPU/Common/GPUCommonLogger.h
+++ b/GPU/Common/GPUCommonLogger.h
@@ -17,12 +17,12 @@
 
 #include "GPUCommonDef.h"
 
-#if defined(GPUCA_GPUCODE_DEVICE) || defined(__HIPCC__)
+#if defined(GPUCA_GPUCODE_DEVICE)
 namespace o2::gpu::detail
 {
 struct DummyLogger {
   template <typename... Args>
-  GPUhd() DummyLogger& operator<<(Args... args)
+  GPUd() DummyLogger& operator<<(Args... args)
   {
     return *this;
   }
@@ -35,7 +35,7 @@ struct DummyLogger {
 #define LOGF(...)
 #define LOGP(...)
 
-#elif defined(GPUCA_GPUCODE_DEVICE) || defined(__HIPCC__)
+#elif defined(GPUCA_GPUCODE_DEVICE)
 #define LOG(...) o2::gpu::detail::DummyLogger()
 //#define LOG(...) static_assert(false, "LOG(...) << ... unsupported in GPU code");
 #define LOGF(type, string, ...)         \


### PR DESCRIPTION
@davidrohr 
I restricted the issue down to two similar offending lines `LOGP(warning, "Anomalous track, target X:{:f}", xk);`. 
Using `LOG(...)` works that around. Probably the underlying format causes this odd behaviour with compiler.
I did not investigate very much the details, my guess is that only the methods that have the lines are used on GPU, and that's why it fails at linking stage.
Otherwise I would not explain why all the other calls across the `TrackParametrization*.*` files don't raise this issue.

There are some leftover formatting that my editor spotted and fixed, hope it does not bother.

NB: I just checked that it compiles and my printouts worked, but this might have some impact on GPU tracking. Worth to check, maybe.