### PR TITLE
ZDC - Better error reporting during data taking

### DIFF
--- a/DataFormats/Detectors/ZDC/include/DataFormatsZDC/ZDCTDCData.h
+++ b/DataFormats/Detectors/ZDC/include/DataFormatsZDC/ZDCTDCData.h
@@ -31,17 +31,21 @@ struct ZDCTDCDataErr {
 
   static uint32_t mErrVal[NTDCChannels]; // Errors in encoding TDC values
   static uint32_t mErrAmp[NTDCChannels]; // Errors in encoding TDC amplitudes
+  static uint32_t mErrId;                // Errors with TDC Id
 
   static void print()
   {
+    if (mErrId > 0) {
+      LOG(error) << "TDCId was out of range #times = " << mErrId;
+    }
     for (int itdc = 0; itdc < NTDCChannels; itdc++) {
       if (mErrVal[itdc] > 0) {
-        LOG(error) << " TDCVal itdc=" << itdc << " " << ChannelNames[TDCSignal[itdc]] << " was out of range #times = " << mErrVal[itdc];
+        LOG(error) << "TDCVal itdc=" << itdc << " " << ChannelNames[TDCSignal[itdc]] << " was out of range #times = " << mErrVal[itdc];
       }
     }
     for (int itdc = 0; itdc < NTDCChannels; itdc++) {
       if (mErrAmp[itdc] > 0) {
-        LOG(warning) << " TDCAmp itdc=" << itdc << " " << ChannelNames[TDCSignal[itdc]] << " was out of range #times = " << mErrAmp[itdc];
+        LOG(warning) << "TDCAmp itdc=" << itdc << " " << ChannelNames[TDCSignal[itdc]] << " was out of range #times = " << mErrAmp[itdc];
       }
     }
   }
@@ -57,27 +61,47 @@ struct ZDCTDCData {
   ZDCTDCData(uint8_t ida, int16_t vala, int16_t ampa, bool isbeg = false, bool isend = false)
   {
     // TDC value and amplitude are encoded externally
-    id = ida & 0x0f;
+    id = ida < NTDCChannels ? ida : 0xf;
     id = id | (isbeg ? 0x80 : 0x00);
     id = id | (isend ? 0x40 : 0x00);
-    val = vala;
-    amp = ampa;
+
+    if (ida < NTDCChannels) {
+      val = vala;
+      amp = ampa;
+    } else {
+      val = kMaxShort;
+      amp = kMaxShort;
+#ifdef O2_ZDC_DEBUG
+      LOG(error) << __func__ << "TDC Id = " << int(ida) << " is out of range";
+#endif
+      ZDCTDCDataErr::mErrId++;
+    }
   }
 
   ZDCTDCData(uint8_t ida, float vala, float ampa, bool isbeg = false, bool isend = false)
   {
-    // TDC value and amplitude are encoded externally
-    id = ida & 0x0f;
+    // TDC value and amplitude are encoded externally but argument is float
+    id = ida < NTDCChannels ? ida : 0xf;
     id = id | (isbeg ? 0x80 : 0x00);
     id = id | (isend ? 0x40 : 0x00);
+
+    if (ida >= NTDCChannels) {
+      val = kMaxShort;
+      amp = kMaxShort;
+#ifdef O2_ZDC_DEBUG
+      LOG(error) << __func__ << "TDC Id = " << int(ida) << " is out of range";
+#endif
+      ZDCTDCDataErr::mErrId++;
+      return;
+    }
 
     auto TDCVal = std::nearbyint(vala);
     auto TDCAmp = std::nearbyint(ampa);
 
     if (TDCVal < kMinShort) {
-      int itdc = int(ida);
+      int itdc = int(id);
 #ifdef O2_ZDC_DEBUG
-      LOG(error) << __func__ << " TDCVal itdc=" << itdc << " " << ChannelNames[TDCSignal[itdc]] << " = " << TDCVal << " is out of range";
+      LOG(error) << __func__ << "TDCVal itdc=" << itdc << " " << ChannelNames[TDCSignal[itdc]] << " = " << TDCVal << " is out of range";
 #endif
       ZDCTDCDataErr::mErrVal[itdc]++;
       TDCVal = kMinShort;
@@ -86,7 +110,7 @@ struct ZDCTDCData {
     if (TDCVal > kMaxShort) {
       int itdc = int(ida);
 #ifdef O2_ZDC_DEBUG
-      LOG(error) << __func__ << " TDCVal itdc=" << itdc << " " << ChannelNames[TDCSignal[itdc]] << " = " << TDCVal << " is out of range";
+      LOG(error) << __func__ << "TDCVal itdc=" << itdc << " " << ChannelNames[TDCSignal[itdc]] << " = " << TDCVal << " is out of range";
 #endif
       ZDCTDCDataErr::mErrVal[itdc]++;
       TDCVal = kMaxShort;
@@ -95,7 +119,7 @@ struct ZDCTDCData {
     if (TDCAmp < kMinShort) {
       int itdc = int(ida);
 #ifdef O2_ZDC_DEBUG
-      LOG(warning) << __func__ << " TDCAmp itdc=" << itdc << " " << ChannelNames[TDCSignal[itdc]] << " = " << TDCAmp << " is out of range";
+      LOG(warning) << __func__ << "TDCAmp itdc=" << itdc << " " << ChannelNames[TDCSignal[itdc]] << " = " << TDCAmp << " is out of range";
 #endif
       ZDCTDCDataErr::mErrAmp[itdc]++;
       TDCAmp = kMinShort;
@@ -104,14 +128,14 @@ struct ZDCTDCData {
     if (TDCAmp > kMaxShort) {
       int itdc = int(ida);
 #ifdef O2_ZDC_DEBUG
-      LOG(warning) << __func__ << " TDCAmp itdc=" << itdc << " " << ChannelNames[TDCSignal[itdc]] << " = " << TDCAmp << " is out of range";
+      LOG(warning) << __func__ << "TDCAmp itdc=" << itdc << " " << ChannelNames[TDCSignal[itdc]] << " = " << TDCAmp << " is out of range";
 #endif
       ZDCTDCDataErr::mErrAmp[itdc]++;
       TDCAmp = kMaxShort;
     }
 
     val = TDCVal;
-    amp = ampa;
+    amp = TDCAmp;
   }
 
   inline float amplitude() const

--- a/DataFormats/Detectors/ZDC/include/DataFormatsZDC/ZDCTDCData.h
+++ b/DataFormats/Detectors/ZDC/include/DataFormatsZDC/ZDCTDCData.h
@@ -27,6 +27,26 @@ namespace o2
 namespace zdc
 {
 
+struct ZDCTDCDataErr {
+
+  static uint32_t mErrVal[NTDCChannels]; // Errors in encoding TDC values
+  static uint32_t mErrAmp[NTDCChannels]; // Errors in encoding TDC amplitudes
+
+  static void print()
+  {
+    for (int itdc = 0; itdc < NTDCChannels; itdc++) {
+      if (mErrVal[itdc] > 0) {
+        LOG(error) << " TDCVal itdc=" << itdc << " " << ChannelNames[TDCSignal[itdc]] << " was out of range #times = " << mErrVal[itdc];
+      }
+    }
+    for (int itdc = 0; itdc < NTDCChannels; itdc++) {
+      if (mErrAmp[itdc] > 0) {
+        LOG(warning) << " TDCAmp itdc=" << itdc << " " << ChannelNames[TDCSignal[itdc]] << " was out of range #times = " << mErrAmp[itdc];
+      }
+    }
+  }
+};
+
 struct ZDCTDCData {
 
   uint8_t id = 0xff; // channel ID
@@ -55,19 +75,38 @@ struct ZDCTDCData {
     auto TDCAmp = std::nearbyint(ampa);
 
     if (TDCVal < kMinShort) {
-      LOG(error) << __func__ << " TDCVal " << int(ida) << " " << ChannelNames[ida] << " = " << TDCVal << " is out of range";
+      int itdc = int(ida);
+#ifdef O2_ZDC_DEBUG
+      LOG(error) << __func__ << " TDCVal itdc=" << itdc << " " << ChannelNames[TDCSignal[itdc]] << " = " << TDCVal << " is out of range";
+#endif
+      ZDCTDCDataErr::mErrVal[itdc]++;
       TDCVal = kMinShort;
     }
+
     if (TDCVal > kMaxShort) {
-      LOG(error) << __func__ << " TDCVal " << int(ida) << " " << ChannelNames[ida] << " = " << TDCVal << " is out of range";
+      int itdc = int(ida);
+#ifdef O2_ZDC_DEBUG
+      LOG(error) << __func__ << " TDCVal itdc=" << itdc << " " << ChannelNames[TDCSignal[itdc]] << " = " << TDCVal << " is out of range";
+#endif
+      ZDCTDCDataErr::mErrVal[itdc]++;
       TDCVal = kMaxShort;
     }
+
     if (TDCAmp < kMinShort) {
-      LOG(error) << __func__ << " TDCAmp " << int(ida) << " " << ChannelNames[ida] << " = " << TDCAmp << " is out of range";
+      int itdc = int(ida);
+#ifdef O2_ZDC_DEBUG
+      LOG(warning) << __func__ << " TDCAmp itdc=" << itdc << " " << ChannelNames[TDCSignal[itdc]] << " = " << TDCAmp << " is out of range";
+#endif
+      ZDCTDCDataErr::mErrAmp[itdc]++;
       TDCAmp = kMinShort;
     }
+
     if (TDCAmp > kMaxShort) {
-      LOG(error) << __func__ << " TDCAmp " << int(ida) << " " << ChannelNames[ida] << " = " << TDCAmp << " is out of range";
+      int itdc = int(ida);
+#ifdef O2_ZDC_DEBUG
+      LOG(warning) << __func__ << " TDCAmp itdc=" << itdc << " " << ChannelNames[TDCSignal[itdc]] << " = " << TDCAmp << " is out of range";
+#endif
+      ZDCTDCDataErr::mErrAmp[itdc]++;
       TDCAmp = kMaxShort;
     }
 

--- a/DataFormats/Detectors/ZDC/src/ZDCTDCData.cxx
+++ b/DataFormats/Detectors/ZDC/src/ZDCTDCData.cxx
@@ -15,6 +15,7 @@ using namespace o2::zdc;
 
 uint32_t ZDCTDCDataErr::mErrVal[NTDCChannels] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 uint32_t ZDCTDCDataErr::mErrAmp[NTDCChannels] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+uint32_t ZDCTDCDataErr::mErrId = 0;
 
 void o2::zdc::ZDCTDCData::print() const
 {

--- a/DataFormats/Detectors/ZDC/src/ZDCTDCData.cxx
+++ b/DataFormats/Detectors/ZDC/src/ZDCTDCData.cxx
@@ -13,6 +13,9 @@
 
 using namespace o2::zdc;
 
+uint32_t ZDCTDCDataErr::mErrVal[NTDCChannels] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+uint32_t ZDCTDCDataErr::mErrAmp[NTDCChannels] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
 void o2::zdc::ZDCTDCData::print() const
 {
   int itdc = id & 0x0f;

--- a/Detectors/ZDC/macro/CreateModuleConfig.C
+++ b/Detectors/ZDC/macro/CreateModuleConfig.C
@@ -122,8 +122,8 @@ void CreateModuleConfig(long tmin = 0, long tmax = -1, std::string ccdbHost = ""
     module.id = modID;
     module.setChannel(0, IdZPCC, 2 * modID, true, true, -5, 6, 4, 12);
     module.setChannel(1, IdZEM2, 2 * modID, true, true, -5, 6, 4, 12);
-    module.setChannel(2, IdZPC1, 2 * modID + 1, true, false, -5, 6, 4, 12);
-    module.setChannel(3, IdZPC2, 2 * modID + 1, true, false, -5, 6, 4, 12);
+    module.setChannel(2, IdZPC3, 2 * modID + 1, true, false, -5, 6, 4, 12);
+    module.setChannel(3, IdZPC4, 2 * modID + 1, true, false, -5, 6, 4, 12);
     //
   }
   //-------------------------------------------
@@ -133,8 +133,8 @@ void CreateModuleConfig(long tmin = 0, long tmax = -1, std::string ccdbHost = ""
     module.id = modID;
     module.setChannel(0, IdZPCC, 2 * modID, false, true, -5, 6, 4, 12);
     module.setChannel(1, IdZPCSum, 2 * modID, true, false, -5, 6, 4, 12);
-    module.setChannel(2, IdZPC3, 2 * modID + 1, true, false, -5, 6, 4, 12);
-    module.setChannel(3, IdZPC4, 2 * modID + 1, true, false, -5, 6, 4, 12);
+    module.setChannel(2, IdZPC1, 2 * modID + 1, true, false, -5, 6, 4, 12);
+    module.setChannel(3, IdZPC2, 2 * modID + 1, true, false, -5, 6, 4, 12);
     //
   }
   conf.check();

--- a/Detectors/ZDC/raw/src/RawReaderZDC.cxx
+++ b/Detectors/ZDC/raw/src/RawReaderZDC.cxx
@@ -10,6 +10,7 @@
 // or submit itself to any jurisdiction.
 
 #include "ZDCRaw/RawReaderZDC.h"
+#include <cstdlib>
 
 namespace o2
 {
@@ -110,6 +111,8 @@ void RawReaderZDC::process(const EventChData& ch)
 // pop digits
 int RawReaderZDC::getDigits(std::vector<BCData>& digitsBC, std::vector<ChannelData>& digitsCh, std::vector<OrbitData>& orbitData)
 {
+  const char* thefcn = "RawReaderZDC::getDigits";
+
   if (mModuleConfig == nullptr) {
     LOG(fatal) << "Missing ModuleConfig";
     return 0;
@@ -242,9 +245,11 @@ int RawReaderZDC::getDigits(std::vector<BCData>& digitsBC, std::vector<ChannelDa
             inconsistent_event = true;
             inconsistent_alice_trig = true;
             mt.f.AliceErr = true;
-            LOGF(error, "im=%d ic=%d Alice 0123 mt=%u%u%u%u ch=%u%u%u%u", im, ic,
-                 mt.f.Alice_0, mt.f.Alice_1, mt.f.Alice_2, mt.f.Alice_3,
-                 ch.f.Alice_0, ch.f.Alice_1, ch.f.Alice_2, ch.f.Alice_3);
+            LOGF(warn, "%s (m,c)=(%d,%d) Alice [0123]      %u%s%u %u%s%u %u%s%u %u%s%u", thefcn, im, ic,
+                 alice_0, alice_0 == ch.f.Alice_0 ? "==" : "!=", ch.f.Alice_0,
+                 alice_1, alice_1 == ch.f.Alice_1 ? "==" : "!=", ch.f.Alice_1,
+                 alice_2, alice_2 == ch.f.Alice_2 ? "==" : "!=", ch.f.Alice_2,
+                 alice_3, alice_3 == ch.f.Alice_3 ? "==" : "!=", ch.f.Alice_3);
           }
           if (filled_module == false) {
             mt.f.Auto_m = ch.f.Auto_m;
@@ -260,15 +265,18 @@ int RawReaderZDC::getDigits(std::vector<BCData>& digitsBC, std::vector<ChannelDa
           } else if (mt.f.Auto_m != ch.f.Auto_m || mt.f.Auto_0 != ch.f.Auto_0 || mt.f.Auto_1 != ch.f.Auto_1 || mt.f.Auto_2 != ch.f.Auto_2 || mt.f.Auto_3 != ch.f.Auto_3) {
             mt.f.AutoErr = true;
             inconsistent_auto_trig = true;
-            LOGF(error, "im=%d ic=%d Auto m0123 mt=%u%u%u%u%u ch=%u%u%u%u%u", im, ic,
-                 mt.f.Auto_m, mt.f.Auto_0, mt.f.Auto_1, mt.f.Auto_2, mt.f.Auto_3,
-                 ch.f.Auto_m, ch.f.Auto_0, ch.f.Auto_1, ch.f.Auto_2, ch.f.Auto_3);
+            LOGF(warn, "%s (m,c)=(%d,%d) Auto [m0123] %u%s%u %u%s%u %u%s%u %u%s%u %u%s%u", thefcn, im, ic,
+                 mt.f.Auto_m, mt.f.Auto_m == ch.f.Auto_m ? "==" : "!=", ch.f.Auto_m,
+                 mt.f.Auto_0, mt.f.Auto_0 == ch.f.Auto_0 ? "==" : "!=", ch.f.Auto_0,
+                 mt.f.Auto_1, mt.f.Auto_1 == ch.f.Auto_1 ? "==" : "!=", ch.f.Auto_1,
+                 mt.f.Auto_2, mt.f.Auto_2 == ch.f.Auto_2 ? "==" : "!=", ch.f.Auto_2,
+                 mt.f.Auto_3, mt.f.Auto_3 == ch.f.Auto_3 ? "==" : "!=", ch.f.Auto_3);
           }
           ncd++;
         } else if (ev.data[im][ic].f.fixed_0 == 0 && ev.data[im][ic].f.fixed_1 == 0 && ev.data[im][ic].f.fixed_2 == 0) {
           // Empty channel
         } else {
-          LOG(error) << "Data format error";
+          LOG(error) << thefcn << "RAW Data format error";
         }
       }
       bcdata.moduleTriggers[im] = mt.w;
@@ -290,7 +298,7 @@ int RawReaderZDC::getDigits(std::vector<BCData>& digitsBC, std::vector<ChannelDa
       }
     }
     if (inconsistent_event) {
-      LOG(error) << bcdata.ir.orbit << "." << bcdata.ir.bc << " Inconsistent event:" << (inconsistent_auto_trig ? " AUTOT" : "") << (inconsistent_alice_trig ? " ALICET" : "");
+      LOGF(error, "%s %u.%04u Inconsistent event:%s%s", thefcn, bcdata.ir.orbit, bcdata.ir.bc, (inconsistent_auto_trig ? " AUTOT" : ""), (inconsistent_alice_trig ? " ALICET" : ""));
     }
     if ((inconsistent_event && mVerbosity > DbgMinimal) || (mVerbosity >= DbgFull)) {
       bcdata.print(mTriggerMask);

--- a/Detectors/ZDC/raw/src/RawReaderZDC.cxx
+++ b/Detectors/ZDC/raw/src/RawReaderZDC.cxx
@@ -242,20 +242,9 @@ int RawReaderZDC::getDigits(std::vector<BCData>& digitsBC, std::vector<ChannelDa
             inconsistent_event = true;
             inconsistent_alice_trig = true;
             mt.f.AliceErr = true;
-            if (mVerbosity > DbgMinimal) {
-              if (alice_0 != ch.f.Alice_0) {
-                printf("im=%d ic=%d Alice_0 mt=%u ch=%u\n", im, ic, mt.f.Alice_0, ch.f.Alice_0);
-              }
-              if (alice_1 != ch.f.Alice_1) {
-                printf("im=%d ic=%d Alice_1 mt=%u ch=%u\n", im, ic, mt.f.Alice_1, ch.f.Alice_1);
-              }
-              if (alice_2 != ch.f.Alice_2) {
-                printf("im=%d ic=%d Alice_2 mt=%u ch=%u\n", im, ic, mt.f.Alice_2, ch.f.Alice_2);
-              }
-              if (alice_3 != ch.f.Alice_3) {
-                printf("im=%d ic=%d Alice_3 mt=%u ch=%u\n", im, ic, mt.f.Alice_3, ch.f.Alice_3);
-              }
-            }
+            LOGF(error, "im=%d ic=%d Alice 0123 mt=%u%u%u%u ch=%u%u%u%u", im, ic,
+                 mt.f.Alice_0, mt.f.Alice_1, mt.f.Alice_2, mt.f.Alice_3,
+                 ch.f.Alice_0, ch.f.Alice_1, ch.f.Alice_2, ch.f.Alice_3);
           }
           if (filled_module == false) {
             mt.f.Auto_m = ch.f.Auto_m;
@@ -271,6 +260,9 @@ int RawReaderZDC::getDigits(std::vector<BCData>& digitsBC, std::vector<ChannelDa
           } else if (mt.f.Auto_m != ch.f.Auto_m || mt.f.Auto_0 != ch.f.Auto_0 || mt.f.Auto_1 != ch.f.Auto_1 || mt.f.Auto_2 != ch.f.Auto_2 || mt.f.Auto_3 != ch.f.Auto_3) {
             mt.f.AutoErr = true;
             inconsistent_auto_trig = true;
+            LOGF(error, "im=%d ic=%d Auto m0123 mt=%u%u%u%u%u ch=%u%u%u%u%u", im, ic,
+                 mt.f.Auto_m, mt.f.Auto_0, mt.f.Auto_1, mt.f.Auto_2, mt.f.Auto_3,
+                 ch.f.Auto_m, ch.f.Auto_0, ch.f.Auto_1, ch.f.Auto_2, ch.f.Auto_3);
           }
           ncd++;
         } else if (ev.data[im][ic].f.fixed_0 == 0 && ev.data[im][ic].f.fixed_1 == 0 && ev.data[im][ic].f.fixed_2 == 0) {
@@ -298,7 +290,7 @@ int RawReaderZDC::getDigits(std::vector<BCData>& digitsBC, std::vector<ChannelDa
       }
     }
     if (inconsistent_event) {
-      LOG(error) << "Inconsistent event:" << (inconsistent_auto_trig ? " AUTOT" : "") << (inconsistent_alice_trig ? " ALICET" : "");
+      LOG(error) << bcdata.ir.orbit << "." << bcdata.ir.bc << " Inconsistent event:" << (inconsistent_auto_trig ? " AUTOT" : "") << (inconsistent_alice_trig ? " ALICET" : "");
     }
     if ((inconsistent_event && mVerbosity > DbgMinimal) || (mVerbosity >= DbgFull)) {
       bcdata.print(mTriggerMask);

--- a/Detectors/ZDC/reconstruction/src/DigiReco.cxx
+++ b/Detectors/ZDC/reconstruction/src/DigiReco.cxx
@@ -345,11 +345,14 @@ void DigiReco::eor()
     mDbg->Close();
     mDbg.reset();
   }
+
+  ZDCTDCDataErr::print();
+
   if (mNLonely > 0) {
     LOG(warn) << "Detected " << mNLonely << " lonely bunches";
     for (int ib = 0; ib < o2::constants::lhc::LHCMaxBunches; ib++) {
       if (mLonely[ib]) {
-        LOG(warn) << "lonely " << ib << " " << mLonely[ib] << " T " << mLonelyTrig[ib];
+        LOGF(warn, "lonely bunch %4d #times=%u #trig=%u", ib, mLonely[ib], mLonelyTrig[ib]);
       }
     }
   }

--- a/Detectors/ZDC/workflow/src/DigitRecoSpec.cxx
+++ b/Detectors/ZDC/workflow/src/DigitRecoSpec.cxx
@@ -255,6 +255,7 @@ void DigitRecoSpec::run(ProcessingContext& pc)
                 << "-> Reconstructed " << ntt << " signal TDCs and " << nte << " ZDC energies and "
                 << nti << " info messages in " << recEvent.mRecBC.size() << "/" << recAux.size() << " b.c. and "
                 << ntw << " waveform chunks";
+      ZDCTDCDataErr::print();
     }
   } else {
     LOG(info) << bcdata.size() << " BC " << chans.size() << " CH " << peds.size() << " OD "

--- a/Detectors/ZDC/workflow/src/DigitRecoSpec.cxx
+++ b/Detectors/ZDC/workflow/src/DigitRecoSpec.cxx
@@ -262,7 +262,6 @@ void DigitRecoSpec::run(ProcessingContext& pc)
   }
   // TODO: rate information for all channels
   // TODO: summary of reconstruction to be collected by DQM?
-  ZDCTDCDataErr::print();
   pc.outputs().snapshot(Output{"ZDC", "BCREC", 0, Lifetime::Timeframe}, recEvent.mRecBC);
   pc.outputs().snapshot(Output{"ZDC", "ENERGY", 0, Lifetime::Timeframe}, recEvent.mEnergy);
   pc.outputs().snapshot(Output{"ZDC", "TDCDATA", 0, Lifetime::Timeframe}, recEvent.mTDCData);

--- a/Detectors/ZDC/workflow/src/DigitRecoSpec.cxx
+++ b/Detectors/ZDC/workflow/src/DigitRecoSpec.cxx
@@ -255,7 +255,6 @@ void DigitRecoSpec::run(ProcessingContext& pc)
                 << "-> Reconstructed " << ntt << " signal TDCs and " << nte << " ZDC energies and "
                 << nti << " info messages in " << recEvent.mRecBC.size() << "/" << recAux.size() << " b.c. and "
                 << ntw << " waveform chunks";
-      ZDCTDCDataErr::print();
     }
   } else {
     LOG(info) << bcdata.size() << " BC " << chans.size() << " CH " << peds.size() << " OD "
@@ -263,6 +262,7 @@ void DigitRecoSpec::run(ProcessingContext& pc)
   }
   // TODO: rate information for all channels
   // TODO: summary of reconstruction to be collected by DQM?
+  ZDCTDCDataErr::print();
   pc.outputs().snapshot(Output{"ZDC", "BCREC", 0, Lifetime::Timeframe}, recEvent.mRecBC);
   pc.outputs().snapshot(Output{"ZDC", "ENERGY", 0, Lifetime::Timeframe}, recEvent.mEnergy);
   pc.outputs().snapshot(Output{"ZDC", "TDCDATA", 0, Lifetime::Timeframe}, recEvent.mTDCData);


### PR DESCRIPTION
This PR removes unnecessary error messages (overflows) that were flooding the infobrowser during p-p data taking and reports just a summary at the end of processing. The monitoring of these overflows is now also present in QC.

It also introduces more information about which module is producing misaligned data, a rare error that showed up during p-p data taking and fortunately was recovered by the firmware, but that otherwise might require to stop the run and reset the electronics.