### PR TITLE
Move MC stack to DetectorsBase

### DIFF
--- a/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/HitType.h
+++ b/DataFormats/Detectors/FIT/FT0/include/DataFormatsFT0/HitType.h
@@ -16,7 +16,6 @@
 #define ALICEO2_FIT_HITTYPE_H_
 
 #include "SimulationDataFormat/BaseHits.h"
-#include "SimulationDataFormat/Stack.h"
 #include "CommonUtils/ShmAllocator.h"
 
 namespace o2

--- a/DataFormats/Detectors/TPC/CMakeLists.txt
+++ b/DataFormats/Detectors/TPC/CMakeLists.txt
@@ -31,6 +31,7 @@ o2_add_library(
           src/DCS.cxx
   PUBLIC_LINK_LIBRARIES O2::GPUCommon
                         O2::SimulationDataFormat
+                        O2::ReconstructionDataFormats
                         O2::CommonDataFormat
                         O2::Headers
                         O2::Algorithm)

--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Hit.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Hit.h
@@ -13,7 +13,6 @@
 #define ALICEO2_TRD_HIT_H_
 
 #include <vector>
-#include "DetectorsBase/Detector.h"
 #include "SimulationDataFormat/BaseHits.h"
 #include "CommonUtils/ShmAllocator.h"
 

--- a/DataFormats/Parameters/CMakeLists.txt
+++ b/DataFormats/Parameters/CMakeLists.txt
@@ -16,7 +16,7 @@ o2_add_library(DataFormatsParameters
                        src/GRPMagField.cxx
                PUBLIC_LINK_LIBRARIES FairRoot::Base O2::CommonConstants
                                      O2::CommonTypes O2::CCDB
-                                     O2::DetectorsCommonDataFormats O2::SimConfig)
+                                     O2::DetectorsCommonDataFormats)
 
 o2_target_root_dictionary(DataFormatsParameters
                           HEADERS include/DataFormatsParameters/ECSDataAdapters.h
@@ -29,7 +29,7 @@ o2_target_root_dictionary(DataFormatsParameters
 o2_add_executable(simgrp-tool
                   COMPONENT_NAME grp
                   SOURCES src/GRPTool.cxx
-                  PUBLIC_LINK_LIBRARIES Boost::program_options O2::DataFormatsParameters)
+                  PUBLIC_LINK_LIBRARIES Boost::program_options O2::DataFormatsParameters O2::SimConfig)
 
 # note we are explicitely giving the LINKDEF parameter as the LinkDef does not
 # follow the usual naming scheme [module]LinkDef.h

--- a/DataFormats/simulation/CMakeLists.txt
+++ b/DataFormats/simulation/CMakeLists.txt
@@ -10,8 +10,7 @@
 # or submit itself to any jurisdiction.
 
 o2_add_library(SimulationDataFormat
-               SOURCES src/Stack.cxx
-                       src/MCTrack.cxx
+               SOURCES src/MCTrack.cxx
                        src/MCCompLabel.cxx
                        src/MCEventLabel.cxx
                        src/DigitizationContext.cxx
@@ -23,13 +22,13 @@ o2_add_library(SimulationDataFormat
                PUBLIC_LINK_LIBRARIES Microsoft.GSL::GSL
                                      FairRoot::Base
                                      O2::DetectorsCommonDataFormats
-                                     O2::GPUCommon O2::DetectorsBase
-                                     O2::SimConfig ROOT::TreePlayer)
+                                     O2::DataFormatsParameters
+                                     O2::GPUCommon
+                                     ROOT::TreePlayer)
 
 o2_target_root_dictionary(
   SimulationDataFormat
-  HEADERS include/SimulationDataFormat/Stack.h
-          include/SimulationDataFormat/StackParam.h
+  HEADERS include/SimulationDataFormat/StackParam.h
           include/SimulationDataFormat/MCTrack.h
           include/SimulationDataFormat/BaseHits.h
           include/SimulationDataFormat/MCTruthContainer.h

--- a/DataFormats/simulation/src/SimulationDataLinkDef.h
+++ b/DataFormats/simulation/src/SimulationDataLinkDef.h
@@ -23,7 +23,6 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
-#pragma link C++ class o2::data::Stack + ;
 #pragma link C++ class o2::sim::StackParam + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::sim::StackParam> + ;
 #pragma link C++ class o2::MCTrackT < double> + ;

--- a/DataFormats/simulation/test/MCTrack.cxx
+++ b/DataFormats/simulation/test/MCTrack.cxx
@@ -12,14 +12,9 @@
 #define BOOST_TEST_MODULE Test MCTrack class
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_DYN_LINK
-#include "SimulationDataFormat/MCTrack.h"
 #include <boost/test/unit_test.hpp>
-#include <iomanip>
-#include <ios>
-#include <iostream>
+#include "SimulationDataFormat/MCTrack.h"
 #include "DetectorsCommonDataFormats/DetID.h"
-#include "SimulationDataFormat/Stack.h"
-#include "SimulationDataFormat/PrimaryChunk.h"
 #include "TFile.h"
 #include "TParticle.h"
 #include "TMCProcess.h"
@@ -71,31 +66,5 @@ BOOST_AUTO_TEST_CASE(MCTrack_test)
     f.GetObject("MCTrack", intrack);
     BOOST_CHECK(intrack->getStore() == true);
     BOOST_CHECK(intrack->hasHits() == true);
-  }
-}
-
-// unit tests on stack
-BOOST_AUTO_TEST_CASE(Stack_test)
-{
-  o2::data::Stack st;
-  int a;
-  TMCProcess proc{kPPrimary};
-  // add a 2 primary particles
-  st.PushTrack(1, -1, 0, 0, 0., 0., 10., 5., 5., 5., 0.1, 0., 0., 0., proc, a, 1., 1);
-  st.PushTrack(1, -1, 0, 0, 0., 0., 10., 5., 5., 5., 0.1, 0., 0., 0., proc, a, 1., 1);
-  BOOST_CHECK(st.getPrimaries().size() == 2);
-
-  {
-    // serialize it
-    TFile f("StackOut.root", "RECREATE");
-    f.WriteObject(&st, "Stack");
-    f.Close();
-  }
-
-  {
-    o2::data::Stack* inst = nullptr;
-    TFile f("StackOut.root", "OPEN");
-    f.GetObject("Stack", inst);
-    BOOST_CHECK(inst->getPrimaries().size() == 2);
   }
 }

--- a/Detectors/Base/CMakeLists.txt
+++ b/Detectors/Base/CMakeLists.txt
@@ -24,6 +24,7 @@ o2_add_library(DetectorsBase
                        src/SimFieldUtils.cxx
                        src/TFIDInfoHelper.cxx
                        src/GRPGeomHelper.cxx
+                       src/Stack.cxx
                PUBLIC_LINK_LIBRARIES FairRoot::Base
                                      O2::CommonUtils
                                      O2::DetectorsCommonDataFormats
@@ -34,6 +35,7 @@ o2_add_library(DetectorsBase
                                      O2::Framework
                                      FairMQ::FairMQ
                                      O2::DataFormatsParameters
+                                     O2::SimulationDataFormat
                                      O2::SimConfig
                                      O2::CCDB
                                      MC::VMC
@@ -52,6 +54,7 @@ o2_target_root_dictionary(DetectorsBase
                                   include/DetectorsBase/MatLayerCyl.h
                                   include/DetectorsBase/MatLayerCylSet.h
                                   include/DetectorsBase/Aligner.h
+                                  include/DetectorsBase/Stack.h
                                   include/DetectorsBase/SimFieldUtils.h)
 
 if(BUILD_SIMULATION)
@@ -60,6 +63,15 @@ if(BUILD_SIMULATION)
     SOURCES test/testMatBudLUT.cxx
     COMPONENT_NAME DetectorsBase
     PUBLIC_LINK_LIBRARIES O2::DetectorsBase O2::ITSMFTReconstruction
+    LABELS detectorsbase
+    ENVIRONMENT O2_ROOT=${CMAKE_BINARY_DIR}/stage
+                VMCWORKDIR=${CMAKE_BINARY_DIR}/stage/${CMAKE_INSTALL_DATADIR})
+
+  o2_add_test(
+    MCStack
+    SOURCES test/testStack.cxx
+    COMPONENT_NAME DetectorsBase
+    PUBLIC_LINK_LIBRARIES O2::DetectorsBase
     LABELS detectorsbase
     ENVIRONMENT O2_ROOT=${CMAKE_BINARY_DIR}/stage
                 VMCWORKDIR=${CMAKE_BINARY_DIR}/stage/${CMAKE_INSTALL_DATADIR})

--- a/Detectors/Base/include/DetectorsBase/Stack.h
+++ b/Detectors/Base/include/DetectorsBase/Stack.h
@@ -234,6 +234,9 @@ class Stack : public FairGenericStack
   /// returns if current track left a TrackReference
   bool currentTrackLeftTrackRef() const { return mCurrentParticle.TestBit(ParticleStatus::kHasTrackRefs); }
 
+  /// set track seeding mode (tracks are seeded individually for increased reproducability)
+  void setTrackSeedingMode(bool m) { mDoTrackSeeding = m; }
+
   typedef std::function<bool(const TParticle& p, const std::vector<TParticle>& particles)> TransportFcn;
 
  private:
@@ -291,6 +294,7 @@ class Stack : public FairGenericStack
   bool mIsG4Like = false; //! flag indicating if the stack is used in a manner done by Geant4
 
   bool mIsExternalMode = false; // is stack an external factory or directly used inside simulation?
+  bool mDoTrackSeeding = false; // whether to do track based seeding
 
   TransportFcn mTransportPrimary = [](const TParticle& p, const std::vector<TParticle>& particles) { return false; }; //! a function to inhibit the tracking of a particle
 

--- a/Detectors/Base/src/DetectorsBaseLinkDef.h
+++ b/Detectors/Base/src/DetectorsBaseLinkDef.h
@@ -36,4 +36,6 @@
 #pragma link C++ class o2::base::Aligner + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::base::Aligner> + ;
 
+#pragma link C++ class o2::data::Stack + ;
+
 #endif

--- a/Detectors/Base/src/Stack.cxx
+++ b/Detectors/Base/src/Stack.cxx
@@ -13,13 +13,12 @@
 /// \brief Implementation of the Stack class
 /// \author M. Al-Turany, S. Wenzel - June 2014
 
-#include "SimulationDataFormat/Stack.h"
+#include "DetectorsBase/Stack.h"
 #include "DetectorsBase/Detector.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 #include "SimulationDataFormat/MCTrack.h"
-#include "SimConfig/SimParams.h"
 
-#include "FairDetector.h" // for FairDetector
+#include "FairDetector.h"      // for FairDetector
 #include <fairlogger/Logger.h> // for FairLogger
 #include "FairRootManager.h"
 #include "SimulationDataFormat/BaseHits.h"
@@ -216,7 +215,7 @@ void Stack::PushTrack(Int_t toBeDone, Int_t parentId, Int_t pdgCode, Double_t px
   TParticle p(pdgCode, iStatus, parentId, secondparentId, daughter1Id, daughter2Id, px, py, pz, e, vx, vy, vz, time);
   p.SetPolarisation(polx, poly, polz);
   p.SetWeight(weight);
-  p.SetUniqueID(proc); // using the unique ID to transfer process ID
+  p.SetUniqueID(proc);                                           // using the unique ID to transfer process ID
   p.SetBit(ParticleStatus::kPrimary, proc == kPPrimary ? 1 : 0); // set primary bit
   p.SetBit(ParticleStatus::kToBeDone, toBeDone == 1 ? 1 : 0);    // set to be done bit
   mNumberOfEntriesInParticles++;
@@ -358,7 +357,7 @@ TParticle* Stack::PopNextTrack(Int_t& iTrack)
         mIndexOfCurrentTrack = mCurrentParticle.GetStatusCode();
       }
       iTrack = mIndexOfCurrentTrack;
-      if (o2::conf::SimCutParams::Instance().trackSeed) {
+      if (mDoTrackSeeding) {
         auto hash = getHash(mCurrentParticle);
         // LOG(info) << "SEEDING NEW TRACK USING HASH" << hash;
         // init seed per track
@@ -760,7 +759,7 @@ bool Stack::isPrimary(const MCTrack& part)
 
 bool Stack::isFromPrimaryDecayChain(const MCTrack& part)
 {
-  /** check if the particle is from the 
+  /** check if the particle is from the
       decay chain of a primary particle **/
 
   /** check if from decay **/
@@ -779,7 +778,7 @@ bool Stack::isFromPrimaryDecayChain(const MCTrack& part)
 
 bool Stack::isFromPrimaryPairProduction(const MCTrack& part)
 {
-  /** check if the particle is from 
+  /** check if the particle is from
       pair production from a particle
       belonging to the primary decay chain **/
 

--- a/Detectors/Base/test/testStack.cxx
+++ b/Detectors/Base/test/testStack.cxx
@@ -1,0 +1,46 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MODULE Test MCStack class
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include "DetectorsBase/Stack.h"
+#include "TFile.h"
+#include "TMCProcess.h"
+
+using namespace o2;
+
+// unit tests on MC stack
+BOOST_AUTO_TEST_CASE(Stack_test)
+{
+  o2::data::Stack st;
+  int a;
+  TMCProcess proc{kPPrimary};
+  // add a 2 primary particles
+  st.PushTrack(1, -1, 0, 0, 0., 0., 10., 5., 5., 5., 0.1, 0., 0., 0., proc, a, 1., 1);
+  st.PushTrack(1, -1, 0, 0, 0., 0., 10., 5., 5., 5., 0.1, 0., 0., 0., proc, a, 1., 1);
+  BOOST_CHECK(st.getPrimaries().size() == 2);
+
+  {
+    // serialize it
+    TFile f("StackOut.root", "RECREATE");
+    f.WriteObject(&st, "Stack");
+    f.Close();
+  }
+
+  {
+    o2::data::Stack* inst = nullptr;
+    TFile f("StackOut.root", "OPEN");
+    f.GetObject("Stack", inst);
+    BOOST_CHECK(inst->getPrimaries().size() == 2);
+  }
+}

--- a/Detectors/CPV/simulation/src/Detector.cxx
+++ b/Detectors/CPV/simulation/src/Detector.cxx
@@ -29,7 +29,7 @@
 #include "CPVSimulation/GeometryParams.h"
 
 #include "DetectorsBase/GeometryManager.h"
-#include "SimulationDataFormat/Stack.h"
+#include "DetectorsBase/Stack.h"
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/range/irange.hpp>

--- a/Detectors/EMCAL/reconstruction/CMakeLists.txt
+++ b/Detectors/EMCAL/reconstruction/CMakeLists.txt
@@ -34,6 +34,7 @@ o2_add_library(EMCALReconstruction
         AliceO2::InfoLogger
         O2::DataFormatsEMCAL
         O2::DetectorsRaw
+        O2::DetectorsBase
         O2::EMCALBase
         O2::rANS
         Microsoft.GSL::GSL)

--- a/Detectors/EMCAL/simulation/src/Detector.cxx
+++ b/Detectors/EMCAL/simulation/src/Detector.cxx
@@ -30,7 +30,7 @@
 #include "EMCALSimulation/Detector.h"
 #include "EMCALSimulation/SpaceFrame.h"
 
-#include "SimulationDataFormat/Stack.h"
+#include "DetectorsBase/Stack.h"
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/range/irange.hpp>

--- a/Detectors/FIT/FDD/reconstruction/CMakeLists.txt
+++ b/Detectors/FIT/FDD/reconstruction/CMakeLists.txt
@@ -14,6 +14,7 @@ o2_add_library(FDDReconstruction
                        src/CTFCoder.cxx
                PUBLIC_LINK_LIBRARIES O2::FDDBase
                                      O2::DataFormatsFDD
+                                     O2::DetectorsBase
                                      O2::DetectorsRaw)
 
 o2_target_root_dictionary(FDDReconstruction

--- a/Detectors/FIT/FDD/simulation/CMakeLists.txt
+++ b/Detectors/FIT/FDD/simulation/CMakeLists.txt
@@ -17,6 +17,7 @@ o2_add_library(FDDSimulation
         O2::FDDBase
         O2::DataFormatsFDD
         O2::DetectorsRaw
+        O2::DetectorsBase
         ROOT::Physics)
 
 o2_target_root_dictionary(FDDSimulation

--- a/Detectors/FIT/FDD/simulation/src/Detector.cxx
+++ b/Detectors/FIT/FDD/simulation/src/Detector.cxx
@@ -20,7 +20,7 @@
 
 #include "FDDSimulation/Detector.h"
 
-#include "SimulationDataFormat/Stack.h"
+#include "DetectorsBase/Stack.h"
 #include "Field/MagneticField.h"
 
 #include "TVirtualMC.h"

--- a/Detectors/FIT/FT0/simulation/src/Detector.cxx
+++ b/Detectors/FIT/FT0/simulation/src/Detector.cxx
@@ -36,7 +36,7 @@
 #include <string>
 #include "FT0Base/Geometry.h"
 #include "FT0Simulation/Detector.h"
-#include "SimulationDataFormat/Stack.h"
+#include "DetectorsBase/Stack.h"
 
 using namespace o2::ft0;
 using o2::ft0::Geometry;

--- a/Detectors/FIT/FV0/simulation/src/Detector.cxx
+++ b/Detectors/FIT/FV0/simulation/src/Detector.cxx
@@ -23,7 +23,7 @@
 #include <FairVolume.h>
 #include "FV0Simulation/Detector.h"
 #include "Framework/Logger.h"
-#include "SimulationDataFormat/Stack.h"
+#include "DetectorsBase/Stack.h"
 #include "FV0Base/Geometry.h"
 
 using namespace o2::fv0;

--- a/Detectors/HMPID/base/CMakeLists.txt
+++ b/Detectors/HMPID/base/CMakeLists.txt
@@ -13,6 +13,7 @@ o2_add_library(HMPIDBase
                SOURCES src/Param.cxx src/Geo.cxx
                PUBLIC_LINK_LIBRARIES O2::CommonDataFormat
                                      O2::SimulationDataFormat
+                                     O2::DetectorsBase
                                      ROOT::Physics)
 
 o2_target_root_dictionary(HMPIDBase

--- a/Detectors/HMPID/simulation/src/Detector.cxx
+++ b/Detectors/HMPID/simulation/src/Detector.cxx
@@ -28,7 +28,7 @@
 #include <TLorentzVector.h>   //IsLostByFresnel()
 #include <TString.h>          //StepManager()
 #include <TTree.h>
-#include "SimulationDataFormat/Stack.h"
+#include "DetectorsBase/Stack.h"
 #include "SimulationDataFormat/TrackReference.h"
 #include "DetectorsBase/MaterialManager.h"
 

--- a/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
@@ -20,7 +20,7 @@
 #include "ITSSimulation/V3Services.h"
 #include "ITSSimulation/V3Cage.h"
 
-#include "SimulationDataFormat/Stack.h"
+#include "DetectorsBase/Stack.h"
 #include "SimulationDataFormat/TrackReference.h"
 
 // FairRoot includes

--- a/Detectors/ITSMFT/MFT/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/MFT/simulation/src/Detector.cxx
@@ -23,7 +23,7 @@
 #include "MFTSimulation/Detector.h"
 
 #include "Field/MagneticField.h"
-#include "SimulationDataFormat/Stack.h"
+#include "DetectorsBase/Stack.h"
 
 #include <fairlogger/Logger.h>
 #include "FairRootManager.h"

--- a/Detectors/ITSMFT/common/reconstruction/CMakeLists.txt
+++ b/Detectors/ITSMFT/common/reconstruction/CMakeLists.txt
@@ -32,6 +32,7 @@ o2_add_library(ITSMFTReconstruction
                PUBLIC_LINK_LIBRARIES O2::ITSMFTBase
                                      O2::CommonDataFormat
                                      O2::DetectorsRaw
+                                     O2::DetectorsBase
                                      O2::SimulationDataFormat 
                                      O2::DataFormatsITSMFT
                                      O2::DPLUtils

--- a/Detectors/MUON/MCH/Simulation/src/Detector.cxx
+++ b/Detectors/MUON/MCH/Simulation/src/Detector.cxx
@@ -11,7 +11,7 @@
 
 #include "MCHSimulation/Detector.h"
 #include "MCHGeometryCreator/Geometry.h"
-#include "SimulationDataFormat/Stack.h"
+#include "DetectorsBase/Stack.h"
 #include "Stepper.h"
 #include "TGeoManager.h"
 #include <sstream>

--- a/Detectors/MUON/MCH/Simulation/src/Stepper.cxx
+++ b/Detectors/MUON/MCH/Simulation/src/Stepper.cxx
@@ -12,7 +12,7 @@
 #include "Stepper.h"
 
 #include "DetectorsCommonDataFormats/DetID.h"
-#include "SimulationDataFormat/Stack.h"
+#include "DetectorsBase/Stack.h"
 #include "SimulationDataFormat/TrackReference.h"
 #include "TGeoManager.h"
 #include "TVirtualMC.h"

--- a/Detectors/MUON/MID/Simulation/src/Detector.cxx
+++ b/Detectors/MUON/MID/Simulation/src/Detector.cxx
@@ -11,7 +11,7 @@
 
 #include "MIDSimulation/Detector.h"
 #include "MIDSimulation/Geometry.h"
-#include "SimulationDataFormat/Stack.h"
+#include "DetectorsBase/Stack.h"
 #include <TGeoManager.h>
 #include <TGeoVolume.h>
 #include "FairVolume.h"

--- a/Detectors/MUON/MID/Simulation/src/Stepper.cxx
+++ b/Detectors/MUON/MID/Simulation/src/Stepper.cxx
@@ -13,7 +13,7 @@
 
 #include "CommonUtils/ShmAllocator.h"
 #include "DetectorsCommonDataFormats/DetID.h"
-#include "SimulationDataFormat/Stack.h"
+#include "DetectorsBase/Stack.h"
 #include "SimulationDataFormat/TrackReference.h"
 #include "TVirtualMC.h"
 #include "FairRootManager.h"

--- a/Detectors/PHOS/simulation/src/Detector.cxx
+++ b/Detectors/PHOS/simulation/src/Detector.cxx
@@ -29,7 +29,7 @@
 #include "PHOSBase/PHOSSimParams.h"
 
 #include "DetectorsBase/GeometryManager.h"
-#include "SimulationDataFormat/Stack.h"
+#include "DetectorsBase/Stack.h"
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/range/irange.hpp>

--- a/Detectors/TOF/simulation/src/Detector.cxx
+++ b/Detectors/TOF/simulation/src/Detector.cxx
@@ -21,7 +21,7 @@
 
 #include <TVirtualMC.h> // for TVirtualMC, gMC
 #include "DetectorsBase/GeometryManager.h"
-#include "SimulationDataFormat/Stack.h"
+#include "DetectorsBase/Stack.h"
 
 using namespace o2::tof;
 

--- a/Detectors/TPC/base/test/testTPCParameters.cxx
+++ b/Detectors/TPC/base/test/testTPCParameters.cxx
@@ -23,7 +23,6 @@
 #include "TPCBase/ParameterGas.h"
 #include <CommonUtils/ConfigurableParam.h>
 #include <CommonUtils/ConfigurableParamHelper.h>
-#include <SimConfig/SimConfig.h>
 namespace o2
 {
 namespace tpc

--- a/Detectors/TPC/reconstruction/CMakeLists.txt
+++ b/Detectors/TPC/reconstruction/CMakeLists.txt
@@ -36,7 +36,8 @@ o2_add_library(TPCReconstruction
                                      O2::TPCBase
                                      O2::GPUO2Interface
                                      O2::TPCFastTransformation
-                                     O2::DetectorsRaw)
+                                     O2::DetectorsRaw 
+                                     O2::DetectorsBase)
 
 o2_target_root_dictionary(
   TPCReconstruction

--- a/Detectors/TPC/simulation/src/Detector.cxx
+++ b/Detectors/TPC/simulation/src/Detector.cxx
@@ -14,7 +14,7 @@
 #include "TPCSimulation/Point.h"
 #include "TPCBase/ParameterGas.h"
 
-#include "SimulationDataFormat/Stack.h"
+#include "DetectorsBase/Stack.h"
 #include "SimulationDataFormat/TrackReference.h"
 
 #include "FairVolume.h" // for FairVolume

--- a/Detectors/TPC/spacecharge/CMakeLists.txt
+++ b/Detectors/TPC/spacecharge/CMakeLists.txt
@@ -16,6 +16,7 @@ o2_add_library(TPCSpaceCharge
                        src/SpaceChargeParameter.cxx
                        src/TriCubic.cxx
                PUBLIC_LINK_LIBRARIES O2::TPCBase
+                                     O2::Field
                                      Vc::Vc
                                      ROOT::Core)
 

--- a/Detectors/TRD/simulation/src/Detector.cxx
+++ b/Detectors/TRD/simulation/src/Detector.cxx
@@ -18,7 +18,7 @@
 #include "DataFormatsTRD/Hit.h"
 
 #include "CommonUtils/ShmAllocator.h"
-#include "SimulationDataFormat/Stack.h"
+#include "DetectorsBase/Stack.h"
 #include "FairVolume.h"
 #include "FairRootManager.h"
 

--- a/Detectors/Upgrades/ALICE3/FCT/simulation/src/Detector.cxx
+++ b/Detectors/Upgrades/ALICE3/FCT/simulation/src/Detector.cxx
@@ -18,7 +18,7 @@
 #include "FCTSimulation/FCTLayer.h"
 #include "FCTBase/FCTBaseParam.h"
 
-#include "SimulationDataFormat/Stack.h"
+#include "DetectorsBase/Stack.h"
 #include "SimulationDataFormat/TrackReference.h"
 
 // FairRoot includes

--- a/Detectors/Upgrades/ALICE3/FT3/simulation/src/Detector.cxx
+++ b/Detectors/Upgrades/ALICE3/FT3/simulation/src/Detector.cxx
@@ -18,7 +18,7 @@
 #include "FT3Simulation/FT3Layer.h"
 #include "FT3Base/FT3BaseParam.h"
 
-#include "SimulationDataFormat/Stack.h"
+#include "DetectorsBase/Stack.h"
 #include "SimulationDataFormat/TrackReference.h"
 
 // FairRoot includes

--- a/Detectors/Upgrades/ALICE3/TRK/simulation/src/Detector.cxx
+++ b/Detectors/Upgrades/ALICE3/TRK/simulation/src/Detector.cxx
@@ -19,7 +19,7 @@
 #include "TRKSimulation/V3Layer.h"
 #include "TRKSimulation/V3Services.h"
 
-#include "SimulationDataFormat/Stack.h"
+#include "DetectorsBase/Stack.h"
 #include "SimulationDataFormat/TrackReference.h"
 
 // FairRoot includes

--- a/Detectors/Upgrades/IT3/simulation/src/Detector.cxx
+++ b/Detectors/Upgrades/IT3/simulation/src/Detector.cxx
@@ -19,7 +19,7 @@
 #include "ITS3Simulation/V3Layer.h"
 #include "ITS3Simulation/V3Services.h"
 
-#include "SimulationDataFormat/Stack.h"
+#include "DetectorsBase/Stack.h"
 #include "SimulationDataFormat/TrackReference.h"
 
 // FairRoot includes

--- a/Detectors/ZDC/simulation/src/Detector.cxx
+++ b/Detectors/ZDC/simulation/src/Detector.cxx
@@ -14,7 +14,7 @@
 #include "FairRootManager.h" // for FairRootManager
 #include "FairVolume.h"      // for FairVolume
 #include "DetectorsBase/MaterialManager.h"
-#include "SimulationDataFormat/Stack.h"
+#include "DetectorsBase/Stack.h"
 #include "ZDCSimulation/Detector.h"
 #include "DataFormatsZDC/Hit.h"
 

--- a/Detectors/gconfig/CMakeLists.txt
+++ b/Detectors/gconfig/CMakeLists.txt
@@ -11,12 +11,12 @@
 
 o2_add_library(G3Setup
                SOURCES src/G3Config.cxx
-               PUBLIC_LINK_LIBRARIES MC::Geant3 FairRoot::Base O2::SimulationDataFormat O2::Generators
+               PUBLIC_LINK_LIBRARIES MC::Geant3 FairRoot::Base O2::SimulationDataFormat O2::Generators O2::SimSetup
 )
 
 o2_add_library(G4Setup
                SOURCES src/G4Config.cxx
-               PUBLIC_LINK_LIBRARIES MC::Geant4VMC MC::Geant4 FairRoot::Base O2::SimulationDataFormat O2::Generators ROOT::EGPythia6
+               PUBLIC_LINK_LIBRARIES MC::Geant4VMC MC::Geant4 FairRoot::Base O2::SimulationDataFormat O2::Generators O2::SimSetup  ROOT::EGPythia6
 )
 
 o2_add_library(FLUKASetup
@@ -29,7 +29,7 @@ o2_add_library(MCReplaySetup
 )
 o2_add_library(SimSetup
                SOURCES  src/GlobalProcessCutSimParam.cxx src/SimSetup.cxx src/SetCuts.cxx src/FlukaParam.cxx src/MCReplayParam.cxx
-	       PUBLIC_LINK_LIBRARIES O2::CommonUtils O2::DetectorsBase
+	       PUBLIC_LINK_LIBRARIES O2::CommonUtils O2::DetectorsBase O2::SimConfig
               )
 
 o2_target_root_dictionary(SimSetup

--- a/Detectors/gconfig/commonConfig.C
+++ b/Detectors/gconfig/commonConfig.C
@@ -2,8 +2,9 @@
 // with VMC instances
 
 #if !defined(__CLING__) || defined(__ROOTCLING__)
-#include "SimulationDataFormat/Stack.h"
+#include "DetectorsBase/Stack.h"
 #include "SimulationDataFormat/StackParam.h"
+#include "SimConfig/SimParams.h"
 #include "TVirtualMC.h"
 #include "Generators/DecayerPythia8.h"
 #endif
@@ -17,6 +18,7 @@ void stackSetup(T* vmc, R* run)
   auto& stackparam = o2::sim::StackParam::Instance();
   st->StoreSecondaries(stackparam.storeSecondaries);
   st->pruneKinematics(stackparam.pruneKine);
+  st->setTrackSeedingMode(o2::conf::SimCutParams::Instance().trackSeed);
   vmc->SetStack(st);
 
   /*

--- a/Detectors/gconfig/src/FlukaConfig.cxx
+++ b/Detectors/gconfig/src/FlukaConfig.cxx
@@ -10,7 +10,7 @@
 // or submit itself to any jurisdiction.
 
 #include "FairRunSim.h"
-#include "SimulationDataFormat/Stack.h"
+#include "DetectorsBase/Stack.h"
 #include "SimulationDataFormat/StackParam.h"
 #include <iostream>
 #include <fairlogger/Logger.h>

--- a/Detectors/gconfig/src/G3Config.cxx
+++ b/Detectors/gconfig/src/G3Config.cxx
@@ -12,11 +12,12 @@
 #include "FairRunSim.h"
 #include "TGeant3.h"
 #include "TGeant3TGeo.h"
-#include "SimulationDataFormat/Stack.h"
+#include "DetectorsBase/Stack.h"
 #include "SimulationDataFormat/StackParam.h"
 #include <fairlogger/Logger.h>
 #include "FairModule.h"
 #include "Generators/DecayerPythia8.h"
+#include "SimConfig/SimParams.h"
 
 // these are used in commonConfig.C
 using o2::eventgen::DecayerPythia8;

--- a/Detectors/gconfig/src/G4Config.cxx
+++ b/Detectors/gconfig/src/G4Config.cxx
@@ -10,7 +10,7 @@
 // or submit itself to any jurisdiction.
 
 #include "FairRunSim.h"
-#include "SimulationDataFormat/Stack.h"
+#include "DetectorsBase/Stack.h"
 #include "SimulationDataFormat/StackParam.h"
 #include <iostream>
 #include <fairlogger/Logger.h>
@@ -19,6 +19,7 @@
 #include "TPythia6Decayer.h"
 #include "FairModule.h"
 #include "SimConfig/G4Params.h"
+#include "SimConfig/SimParams.h"
 #include "Generators/DecayerPythia8.h"
 
 //using declarations here since SetCuts.C and g4Config.C are included within namespace

--- a/Detectors/gconfig/src/MCReplayConfig.cxx
+++ b/Detectors/gconfig/src/MCReplayConfig.cxx
@@ -12,7 +12,7 @@
 #include "FairRunSim.h"
 #include "MCReplay/MCReplayEngine.h"
 #include "SimSetup/MCReplayParam.h"
-#include "SimulationDataFormat/Stack.h"
+#include "DetectorsBase/Stack.h"
 #include "SimulationDataFormat/StackParam.h"
 #include <fairlogger/Logger.h>
 #include "FairModule.h"

--- a/Generators/CMakeLists.txt
+++ b/Generators/CMakeLists.txt
@@ -46,7 +46,7 @@ o2_add_library(Generators
                        $<$<BOOL:${pythia_FOUND}>:src/DecayerPythia8Param.cxx>
                        $<$<BOOL:${HepMC3_FOUND}>:src/GeneratorHepMC.cxx>
                        $<$<BOOL:${HepMC3_FOUND}>:src/GeneratorHepMCParam.cxx>
-               PUBLIC_LINK_LIBRARIES FairRoot::Base O2::SimConfig O2::CommonUtils
+               PUBLIC_LINK_LIBRARIES FairRoot::Base O2::SimConfig O2::CommonUtils O2::DetectorsBase
                                      O2::SimulationDataFormat ${pythia6Target} ${pythiaTarget} ${hepmcTarget}
                                      FairRoot::Gen
                TARGETVARNAME targetName)

--- a/Generators/src/PrimaryGenerator.cxx
+++ b/Generators/src/PrimaryGenerator.cxx
@@ -15,7 +15,7 @@
 #include "Generators/Generator.h"
 #include "Generators/InteractionDiamondParam.h"
 #include "SimulationDataFormat/MCEventHeader.h"
-#include "SimulationDataFormat/Stack.h"
+#include "DetectorsBase/Stack.h"
 #include <fairlogger/Logger.h>
 
 #include "FairGenericStack.h"

--- a/Steer/include/Steer/O2MCApplication.h
+++ b/Steer/include/Steer/O2MCApplication.h
@@ -18,7 +18,7 @@
 #include <iostream>
 #include <TParticle.h>
 #include <vector>
-#include <SimulationDataFormat/Stack.h>
+#include <DetectorsBase/Stack.h>
 #include <SimulationDataFormat/PrimaryChunk.h>
 #include <FairRootManager.h>
 #include <FairDetector.h>

--- a/macro/duplicateHits.C
+++ b/macro/duplicateHits.C
@@ -17,12 +17,13 @@
 #include "DataFormatsCPV/Hit.h"
 #include "DataFormatsZDC/Hit.h"
 #include "SimulationDataFormat/MCEventHeader.h"
+#include "SimulationDataFormat/MCTrack.h"
+#include "SimulationDataFormat/TrackReference.h"
 #include "DataFormatsParameters/GRPObject.h"
 #include "DetectorsCommonDataFormats/DetectorNameConf.h"
 #include "DetectorsCommonDataFormats/SimTraits.h"
-
 #ifdef ENABLE_UPGRADES
-#include "EndCapsSimulation/Hit.h"
+// todo: put upgrade detectors?
 #endif
 
 #endif

--- a/run/O2HitMerger.h
+++ b/run/O2HitMerger.h
@@ -21,7 +21,7 @@
 #include <fairmq/Device.h>
 #include <fairlogger/Logger.h>
 #include <SimulationDataFormat/MCEventHeader.h>
-#include <SimulationDataFormat/Stack.h>
+#include <DetectorsBase/Stack.h>
 #include <SimulationDataFormat/PrimaryChunk.h>
 #include <DetectorsCommonDataFormats/DetID.h>
 #include <DetectorsCommonDataFormats/DetectorNameConf.h>

--- a/run/O2PrimaryServerDevice.h
+++ b/run/O2PrimaryServerDevice.h
@@ -19,7 +19,7 @@
 #include <FairPrimaryGenerator.h>
 #include <Generators/GeneratorFactory.h>
 #include <fairmq/Message.h>
-#include <SimulationDataFormat/Stack.h>
+#include <DetectorsBase/Stack.h>
 #include <SimulationDataFormat/MCEventHeader.h>
 #include <TMessage.h>
 #include <TClass.h>

--- a/run/O2SimDevice.h
+++ b/run/O2SimDevice.h
@@ -22,7 +22,7 @@
 #include "../macro/o2sim.C"
 #include "TVirtualMC.h"
 #include "TMessage.h"
-#include <SimulationDataFormat/Stack.h>
+#include <DetectorsBase/Stack.h>
 #include <SimulationDataFormat/PrimaryChunk.h>
 #include <TRandom.h>
 #include <SimConfig/SimConfig.h>

--- a/run/checkStack.cxx
+++ b/run/checkStack.cxx
@@ -15,7 +15,7 @@
 #include "SimulationDataFormat/MCTrack.h"
 #include "SimulationDataFormat/MCUtils.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
-#include "SimulationDataFormat/Stack.h"
+#include "DetectorsBase/Stack.h"
 #include "SimulationDataFormat/TrackReference.h"
 #include "Steer/MCKinematicsReader.h"
 #include "TFile.h"


### PR DESCRIPTION
This is a restructuring commit to
reduce library coupling and to avoid cycling dependencies for future developments:

a) The VMC stack implementation belongs more logically
   to Detectors/Base as an implementation of a Virtual Monte
   Carlo functionality and less as a fundamental O2 simulation data layout

b) remove some uneccessary includes