### PR TITLE
DPL: Add option to not drop old timeSlices based on oldestPossible via env variable

### DIFF
--- a/Framework/Core/src/DataRelayer.cxx
+++ b/Framework/Core/src/DataRelayer.cxx
@@ -272,6 +272,10 @@ void DataRelayer::setOldestPossibleInput(TimesliceId proposed, ChannelIndex chan
 {
   auto newOldest = mTimesliceIndex.setOldestPossibleInput(proposed, channel);
   LOGP(debug, "DataRelayer::setOldestPossibleInput {} from channel {}", newOldest.timeslice.value, newOldest.channel.value);
+  static bool dontDrop = getenv("DPL_DONT_DROP_OLD_TIMESLICE") && atoi(getenv("DPL_DONT_DROP_OLD_TIMESLICE"));
+  if (dontDrop) {
+    return;
+  }
   for (size_t si = 0; si < mCache.size() / mInputs.size(); ++si) {
     auto& variables = mTimesliceIndex.getVariablesForSlot({si});
     auto timestamp = VariableContextHelpers::getTimeslice(variables);


### PR DESCRIPTION
kind of a hack, but we need to disable dropping based on oldestPossible in the sporadic output proxy since the calibrations are losing data. Otherwise we'd need one proxy per sporadic data type, which would be a mess IMHO.