### PR TITLE
Fix MFT tracker for B=0 

### DIFF
--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/TrackFitter.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/TrackFitter.h
@@ -50,6 +50,7 @@ class TrackFitter
   void setMFTRadLength(float MFT_x2X0) { mMFTDiskThicknessInX0 = MFT_x2X0 / 5.0; }
   void setVerbosity(bool v) { mVerbose = v; }
   void setTrackModel(Int_t m) { mTrackModel = m; }
+  auto& getTrackModel() const { return mTrackModel; }
   void setAlignResiduals(Float_t res) { mAlignResidual = res; }
 
   bool initTrack(T& track, bool outward = false);

--- a/Detectors/ITSMFT/MFT/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/Tracker.cxx
@@ -50,8 +50,12 @@ void Tracker<T>::initConfig(const MFTTrackingParam& trkParam, bool printConfig)
 
   mTrackFitter->setMFTRadLength(trkParam.MFTRadLength);
   mTrackFitter->setVerbosity(trkParam.verbose);
-  mTrackFitter->setTrackModel(trkParam.trackmodel);
   mTrackFitter->setAlignResiduals(trkParam.alignResidual);
+  if (trkParam.forceZeroField || (std::abs(mBz) < o2::constants::math::Almost0)) {
+    mTrackFitter->setTrackModel(o2::mft::MFTTrackModel::Linear);
+  } else {
+    mTrackFitter->setTrackModel(trkParam.trackmodel);
+  }
 
   mMinTrackPointsLTF = trkParam.MinTrackPointsLTF;
   mMinTrackPointsCA = trkParam.MinTrackPointsCA;
@@ -81,7 +85,7 @@ void Tracker<T>::initConfig(const MFTTrackingParam& trkParam, bool printConfig)
 
   if (printConfig) {
     LOG(info) << "Configurable tracker parameters:";
-    switch (trkParam.trackmodel) {
+    switch (mTrackFitter->getTrackModel()) {
       case o2::mft::MFTTrackModel::Helix:
         LOG(info) << "Fwd track model     = Helix";
         break;

--- a/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
@@ -313,8 +313,7 @@ void TrackerDPL::run(ProcessingContext& pc)
         int ntracksROF = 0, firstROFTrackEntry = allTracksMFT.size();
         tracksL.swap(rofData.getTracks());
         ntracksROF = tracks.size();
-        copyTracks(tracks, allTracksMFT, allClusIdx);
-
+        copyTracks(tracksL, allTracksMFT, allClusIdx);
         rof->setFirstEntry(firstROFTrackEntry);
         rof->setNEntries(ntracksROF);
         *rof++;
@@ -371,6 +370,7 @@ void TrackerDPL::updateTimeDependentParams(ProcessingContext& pc)
       mFieldOn = false;
       for (auto i = 0; i < mNThreads; i++) {
         auto& tracker = mTrackerLVec.emplace_back(std::make_unique<o2::mft::Tracker<TrackLTFL>>(mUseMC));
+        tracker->setBz(0);
         tracker->initConfig(trackingParam, !i);
         tracker->initialize(trackingParam.FullClusterScan);
       }

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -91,7 +91,7 @@ if [[ $SYNCMODE == 1 ]]; then
     [[ ! -z $CUT_RANDOM_FRACTION_ITS ]] && ITS_CONFIG_KEY+="fastMultConfig.cutRandomFraction=$CUT_RANDOM_FRACTION_ITS;"
   fi
   if has_detector_reco ITS; then
-    MFT_CONFIG_KEY+="MFTTracking.irFramesOnly=1;"
+    [[ $RUNTYPE == "COSMICS" ]] && MFT_CONFIG_KEY+="MFTTracking.irFramesOnly=1;"
   else
     MFT_CONFIG_KEY+="MFTTracking.cutMultClusLow=0;MFTTracking.cutMultClusHigh=2000;"
   fi


### PR DESCRIPTION
This PR fix a bug introduced by the multithreaded MFT tracker which produces no tracks for B=0 reconstruction. 
This commit also ensures Linear track model is used when B=0

I hijack this PR to also disable MFT Tracker IR filter for cosmic runs during sync reco