### PR TITLE
Make HepMC and native status available for MC gen

### DIFF
--- a/DataFormats/simulation/CMakeLists.txt
+++ b/DataFormats/simulation/CMakeLists.txt
@@ -43,6 +43,7 @@ o2_target_root_dictionary(
           include/SimulationDataFormat/MCEventStats.h
           include/SimulationDataFormat/IOMCTruthContainerView.h
           include/SimulationDataFormat/MCUtils.h
+          include/SimulationDataFormat/MCGenStatus.h
           include/SimulationDataFormat/O2DatabasePDG.h
   LINKDEF src/SimulationDataLinkDef.h)
 # note the explicit LINKDEF as the linkdef in src is

--- a/DataFormats/simulation/include/SimulationDataFormat/MCGenStatus.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCGenStatus.h
@@ -1,0 +1,62 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_SIMDATA_MCGENSTATUS_H_
+#define ALICEO2_SIMDATA_MCGENSTATUS_H_
+
+namespace o2
+{
+namespace mcgenstatus
+{
+
+// Value to check MCGenStatusEncoding::isEncoded against to decide whether or not the stored value is encoded or basically only the HepMC status code
+// as it used to be
+constexpr int isEncodedValue{5};
+
+// internal structure to allow convenient manipulation of properties as bits on an int to (dis)entangle HepMC and specific generator status codes
+union MCGenStatusEncoding {
+  MCGenStatusEncoding(int enc) : fullEncoding(enc) {}
+  // To be backward-compatible, only set transport to 1 if hepmc status is 1
+  MCGenStatusEncoding(int hepmcIn, int genIn) : isEncoded(5), hepmc(hepmcIn), gen(genIn), reserved(0) {}
+  int fullEncoding;
+  struct {
+    unsigned int isEncoded : 3; // special bits to check whether or not the fullEncoding is a combination of HepMC and gen status codes
+    int hepmc : 9;              // HepMC status code
+    int gen : 10;               // specific generator status code
+    int reserved : 10;          // reserved bits for future usage
+  };
+};
+
+inline int getHepMCStatusCode(int encoded)
+{
+  MCGenStatusEncoding enc(encoded);
+  if (enc.isEncoded != isEncodedValue) {
+    // in this case simply set hepmc code to what was given
+    return encoded;
+  }
+  return enc.hepmc;
+}
+
+inline int getGenStatusCode(int encoded)
+{
+  MCGenStatusEncoding enc(encoded);
+  if (enc.isEncoded != isEncodedValue) {
+    // in this case simply set hepmc code to what was given
+    return encoded;
+  }
+  return enc.gen;
+}
+
+} // namespace mcgenstatus
+
+} // namespace o2
+
+#endif

--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -137,6 +137,7 @@ o2_add_library(Framework
                        src/Base64.cxx
                        src/DPLWebSocket.cxx
                        test/TestClasses.cxx
+               TARGETVARNAME targetName
                PRIVATE_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_LIST_DIR}/src
                PUBLIC_LINK_LIBRARIES AliceO2::Configuration
                                      AliceO2::Monitoring
@@ -158,6 +159,9 @@ o2_add_library(Framework
                                      Gandiva::gandiva_shared
                                      LibUV::LibUV
                                      )
+
+# To get the necessary include for the MC status codes. Needs to be public, for instance O2Physics heavily depends on Framework
+target_include_directories(${targetName} PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/DataFormats/simulation/include>)
 
 o2_target_root_dictionary(Framework
                           HEADERS test/TestClasses.h

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -17,6 +17,7 @@
 #include "CommonConstants/MathConstants.h"
 #include "CommonConstants/PhysicsConstants.h"
 #include "CommonConstants/GeomConstants.h"
+#include "SimulationDataFormat/MCGenStatus.h"
 
 using namespace o2::constants::math;
 
@@ -924,8 +925,10 @@ DECLARE_SOA_DYNAMIC_COLUMN(FromBackgroundEvent, fromBackgroundEvent, //! Particl
                            [](uint8_t flags) -> bool { return (flags & o2::aod::mcparticle::enums::FromBackgroundEvent) == o2::aod::mcparticle::enums::FromBackgroundEvent; });
 DECLARE_SOA_DYNAMIC_COLUMN(GetProcess, getProcess, //! The VMC physics code (as int) that generated this particle (see header TMCProcess.h in ROOT)
                            [](uint8_t flags, int statusCode) -> int { if ((flags & o2::aod::mcparticle::enums::ProducedByTransport) == 0x0) { return 0 /*TMCProcess::kPrimary*/; } else { return statusCode; } });
-DECLARE_SOA_DYNAMIC_COLUMN(GetGenStatusCode, getGenStatusCode, //! The status code put by the generator, or -1 if a particle produced during transport
-                           [](uint8_t flags, int statusCode) -> int { if ((flags & o2::aod::mcparticle::enums::ProducedByTransport) == 0x0) { return statusCode; } else { return -1; } });
+DECLARE_SOA_DYNAMIC_COLUMN(GetGenStatusCode, getGenStatusCode, //! The native status code put by the generator, or -1 if a particle produced during transport
+                           [](uint8_t flags, int statusCode) -> int { if ((flags & o2::aod::mcparticle::enums::ProducedByTransport) == 0x0) { return o2::mcgenstatus::getGenStatusCode(statusCode); } else { return -1; } });
+DECLARE_SOA_DYNAMIC_COLUMN(GetHepMCStatusCode, getHepMCStatusCode, //! The HepMC status code put by the generator, or -1 if a particle produced during transport
+                           [](uint8_t flags, int statusCode) -> int { if ((flags & o2::aod::mcparticle::enums::ProducedByTransport) == 0x0) { return o2::mcgenstatus::getHepMCStatusCode(statusCode); } else { return -1; } });
 DECLARE_SOA_DYNAMIC_COLUMN(IsPhysicalPrimary, isPhysicalPrimary, //! True if particle is considered a physical primary according to the ALICE definition
                            [](uint8_t flags) -> bool { return (flags & o2::aod::mcparticle::enums::PhysicalPrimary) == o2::aod::mcparticle::enums::PhysicalPrimary; });
 
@@ -969,6 +972,7 @@ DECLARE_SOA_TABLE_FULL(StoredMcParticles_000, "McParticles", "AOD", "MCPARTICLE"
                        mcparticle::ProducedByGenerator<mcparticle::Flags>,
                        mcparticle::FromBackgroundEvent<mcparticle::Flags>,
                        mcparticle::GetGenStatusCode<mcparticle::Flags, mcparticle::StatusCode>,
+                       mcparticle::GetHepMCStatusCode<mcparticle::Flags, mcparticle::StatusCode>,
                        mcparticle::GetProcess<mcparticle::Flags, mcparticle::StatusCode>,
                        mcparticle::IsPhysicalPrimary<mcparticle::Flags>);
 
@@ -981,6 +985,7 @@ DECLARE_SOA_TABLE_FULL_VERSIONED(StoredMcParticles_001, "McParticles", "AOD", "M
                                  mcparticle::ProducedByGenerator<mcparticle::Flags>,
                                  mcparticle::FromBackgroundEvent<mcparticle::Flags>,
                                  mcparticle::GetGenStatusCode<mcparticle::Flags, mcparticle::StatusCode>,
+                                 mcparticle::GetHepMCStatusCode<mcparticle::Flags, mcparticle::StatusCode>,
                                  mcparticle::GetProcess<mcparticle::Flags, mcparticle::StatusCode>,
                                  mcparticle::IsPhysicalPrimary<mcparticle::Flags>);
 

--- a/Generators/src/Generator.cxx
+++ b/Generators/src/Generator.cxx
@@ -15,6 +15,8 @@
 #include "Generators/Trigger.h"
 #include "Generators/PrimaryGenerator.h"
 #include "SimulationDataFormat/MCEventHeader.h"
+#include "SimulationDataFormat/ParticleStatus.h"
+#include "SimulationDataFormat/MCGenStatus.h"
 #include "FairPrimaryGenerator.h"
 #include <fairlogger/Logger.h>
 #include <cmath>
@@ -131,7 +133,7 @@ Bool_t
                         particle.GetMother(1),
                         particle.GetDaughter(0),
                         particle.GetDaughter(1),
-                        particle.GetStatusCode() == 1,
+                        particle.TestBit(ParticleStatus::kToBeDone),
                         particle.Energy() * mEnergyUnit,
                         particle.T() * mTimeUnit,
                         particle.GetWeight(),

--- a/Generators/src/GeneratorFromFile.cxx
+++ b/Generators/src/GeneratorFromFile.cxx
@@ -13,6 +13,7 @@
 #include "Generators/GeneratorFromO2KineParam.h"
 #include "SimulationDataFormat/MCTrack.h"
 #include "SimulationDataFormat/MCEventHeader.h"
+#include "SimulationDataFormat/MCGenStatus.h"
 #include <fairlogger/Logger.h>
 #include <FairPrimaryGenerator.h>
 #include <TBranch.h>
@@ -245,8 +246,9 @@ bool GeneratorFromO2Kine::importParticles()
 
       LOG(debug) << "Putting primary " << pdg;
 
-      mParticles.push_back(TParticle(pdg, wanttracking, m1, m2, d1, d2, px, py, pz, e, vx, vy, vz, vt));
+      mParticles.push_back(TParticle(pdg, t.getStatusCode(), m1, m2, d1, d2, px, py, pz, e, vx, vy, vz, vt));
       mParticles.back().SetUniqueID((unsigned int)t.getProcess()); // we should propagate the process ID
+      mParticles.back().SetBit(ParticleStatus::kToBeDone, wanttracking);
 
       particlecounter++;
     }

--- a/Generators/src/GeneratorHepMC.cxx
+++ b/Generators/src/GeneratorHepMC.cxx
@@ -11,6 +11,8 @@
 
 /// \author R+Preghenella - August 2017
 
+#include "SimulationDataFormat/MCGenStatus.h"
+#include "SimulationDataFormat/ParticleStatus.h"
 #include "Generators/GeneratorHepMC.h"
 #include "Generators/GeneratorHepMCParam.h"
 #include "HepMC3/ReaderAscii.h"
@@ -106,7 +108,7 @@ Bool_t GeneratorHepMC::importParticles()
     /** get particle information **/
     auto particle = particles.at(i);
     auto pdg = particle->pid();
-    auto st = particle->status();
+    auto st = o2::mcgenstatus::MCGenStatusEncoding(particle->status(), -1).fullEncoding;
     auto momentum = particle->momentum();
     auto vertex = particle->production_vertex()->position();
     auto parents = particle->parents();   // less efficient than via vertex
@@ -134,6 +136,7 @@ Bool_t GeneratorHepMC::importParticles()
 
     /** add to particle vector **/
     mParticles.push_back(TParticle(pdg, st, m1, m2, d1, d2, px, py, pz, et, vx, vy, vz, vt));
+    mParticles.back().SetBit(ParticleStatus::kToBeDone, particle->status() == 1);
 
   } /** end of loop over particles **/
 

--- a/Generators/src/GeneratorPythia8.cxx
+++ b/Generators/src/GeneratorPythia8.cxx
@@ -17,6 +17,8 @@
 #include <fairlogger/Logger.h>
 #include "TParticle.h"
 #include "SimulationDataFormat/MCEventHeader.h"
+#include "SimulationDataFormat/MCGenStatus.h"
+#include "SimulationDataFormat/ParticleStatus.h"
 #include "Pythia8/HIUserHooks.h"
 #include "TSystem.h"
 
@@ -171,7 +173,7 @@ Bool_t
   for (Int_t iparticle = 1; iparticle < nParticles; iparticle++) { // first particle is system
     auto particle = event[iparticle];
     auto pdg = particle.id();
-    auto st = particle.statusHepMC();
+    auto st = o2::mcgenstatus::MCGenStatusEncoding(particle.statusHepMC(), particle.status()).fullEncoding;
     auto px = particle.px();
     auto py = particle.py();
     auto pz = particle.pz();
@@ -185,6 +187,7 @@ Bool_t
     auto d1 = particle.daughter1() - 1;
     auto d2 = particle.daughter2() - 1;
     mParticles.push_back(TParticle(pdg, st, m1, m2, d1, d2, px, py, pz, et, vx, vy, vz, vt));
+    mParticles.back().SetBit(ParticleStatus::kToBeDone, particle.statusHepMC() == 1);
   }
 
   /** success **/

--- a/Generators/src/GeneratorTGenerator.cxx
+++ b/Generators/src/GeneratorTGenerator.cxx
@@ -9,6 +9,8 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+#include "SimulationDataFormat/MCGenStatus.h"
+#include "SimulationDataFormat/ParticleStatus.h"
 #include "Generators/GeneratorTGenerator.h"
 #include <fairlogger/Logger.h>
 #include "FairPrimaryGenerator.h"
@@ -84,6 +86,7 @@ Bool_t
   for (Int_t iparticle = 0; iparticle < nparticles; iparticle++) {
     auto particle = (TParticle*)mCloneParticles->At(iparticle);
     mParticles.push_back(*particle);
+    mParticles.back().SetBit(ParticleStatus::kToBeDone, ((o2::mcgenstatus::MCGenStatusEncoding)particle->GetStatusCode()).hepmc == 1);
   }
 
   /** success **/


### PR DESCRIPTION
* HepMC and Gen status codes handled/entangled via Union as one single integer

* common functionality to entangle/disentangle full encoding

* be backwards-compatible wrt to HepMC status code which previously was used to decide whether or not primaries should be transported

* set status code correctly for generator form kinematics