### PR TITLE
TRD: QC: Add global track id to TrackQC

### DIFF
--- a/Detectors/TRD/qc/include/TRDQC/Tracking.h
+++ b/Detectors/TRD/qc/include/TRDQC/Tracking.h
@@ -21,6 +21,7 @@
 #include "DataFormatsTRD/CalibratedTracklet.h"
 #include "DataFormatsTRD/Constants.h"
 #include "ReconstructionDataFormats/TrackTPCITS.h"
+#include "ReconstructionDataFormats/GlobalTrackID.h"
 #include "DataFormatsTPC/TrackTPC.h"
 #include "DetectorsBase/Propagator.h"
 #include "TRDBase/RecoParam.h"
@@ -30,6 +31,8 @@
 
 #include <gsl/span>
 #include <bitset>
+
+using GTrackID = o2::dataformats::GlobalTrackID;
 
 namespace o2
 {
@@ -44,6 +47,7 @@ namespace trd
 
 struct TrackQC {
   int type;                          ///< 0 TPC-TRD track; 1 ITS-TPC-TRD track
+  GTrackID refGlobalTrackId;         ///< GlobalTrackID of the seeding track (either ITS-TPC or TPC)
   int nTracklets;                    ///< number of attached TRD tracklets
   int nLayers;                       //< Number of Layers of a Track in which the track extrapolation was in geometrical acceptance of the TRD
   float chi2;                        ///< total chi2 value for the track
@@ -84,7 +88,7 @@ struct TrackQC {
   std::array<int, constants::NLAYER> trackletMcm{};                                      ///< the MCM number of the tracklet
   std::array<float, constants::NLAYER> trackletChi2{};                                   ///< estimated chi2 for the update of the track with the given tracklet
   std::array<std::array<int, constants::NCHARGES>, constants::NLAYER> trackletCharges{}; ///< charges of tracklets
-  ClassDefNV(TrackQC, 3);
+  ClassDefNV(TrackQC, 4);
 };
 
 class Tracking

--- a/Detectors/TRD/qc/src/Tracking.cxx
+++ b/Detectors/TRD/qc/src/Tracking.cxx
@@ -52,8 +52,10 @@ void Tracking::run()
 void Tracking::checkTrack(const TrackTRD& trkTrd, bool isTPCTRD)
 {
   auto propagator = o2::base::Propagator::Instance();
+  auto id = trkTrd.getRefGlobalTrackId();
   TrackQC qcStruct;
   qcStruct.type = isTPCTRD ? 0 : 1;
+  qcStruct.refGlobalTrackId = id;
   qcStruct.nTracklets = trkTrd.getNtracklets();
   qcStruct.nLayers = trkTrd.getNlayersFindable();
   qcStruct.chi2 = trkTrd.getChi2();
@@ -64,9 +66,9 @@ void Tracking::checkTrack(const TrackTRD& trkTrd, bool isTPCTRD)
   qcStruct.hasNeighbor = trkTrd.getHasNeighbor();
   qcStruct.hasPadrowCrossing = trkTrd.getHasPadrowCrossing();
 
-  LOGF(debug, "Got track with %i tracklets and ID %i", trkTrd.getNtracklets(), trkTrd.getRefGlobalTrackId());
-  const auto& trkSeed = isTPCTRD ? mTracksTPC[trkTrd.getRefGlobalTrackId()].getParamOut() : mTracksITSTPC[trkTrd.getRefGlobalTrackId()].getParamOut();
-  qcStruct.dEdxTotTPC = isTPCTRD ? mTracksTPC[trkTrd.getRefGlobalTrackId()].getdEdx().dEdxTotTPC : mTracksTPC[mTracksITSTPC[trkTrd.getRefGlobalTrackId()].getRefTPC()].getdEdx().dEdxTotTPC;
+  LOGF(debug, "Got track with %i tracklets and ID %i", trkTrd.getNtracklets(), id);
+  const auto& trkSeed = isTPCTRD ? mTracksTPC[id].getParamOut() : mTracksITSTPC[id].getParamOut();
+  qcStruct.dEdxTotTPC = isTPCTRD ? mTracksTPC[id].getdEdx().dEdxTotTPC : mTracksTPC[mTracksITSTPC[id].getRefTPC()].getdEdx().dEdxTotTPC;
   auto trk = trkSeed;
   for (int iLayer = 0; iLayer < NLAYER; ++iLayer) {
     qcStruct.isCrossingNeighbor[iLayer] = trkTrd.getIsCrossingNeighbor(iLayer);


### PR DESCRIPTION
This patch allows for offline extraction of additional TOF PID. And will allow a cleaner cuts for the TRD PID model building.

As @martenole already mentioned in #10229:
> Well it would be just adding one more integer to the QC struct but as you wish ;)

It turned out that adding GlobalTrackId suffices for matching to TOF tracks...


Signed-off-by: Felix Schlepper <f3sch.git@outlook.com>