### PR TITLE
TRD: QC: Move root output

### DIFF
--- a/Detectors/TRD/calibration/include/TRDCalibration/CalibratorVdExB.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/CalibratorVdExB.h
@@ -26,9 +26,12 @@
 #include "Rtypes.h"
 #include "TProfile.h"
 #include "Fit/Fitter.h"
+#include "TFile.h"
+#include "TTree.h"
 
 #include <array>
 #include <cstdlib>
+#include <memory>
 
 namespace o2
 {
@@ -64,6 +67,14 @@ class CalibratorVdExB final : public o2::calibration::TimeSlotCalibration<o2::tr
   void finalizeSlot(Slot& slot) final;
   Slot& emplaceNewSlot(bool front, TFType tStart, TFType tEnd) final;
 
+  /// (Re-)Creates a file "trd_calibVdriftExB.root". This lets continually fill
+  /// a tree with the fit results and the residuals histograms.
+  void createOutputFile();
+
+  /// Close the output file. E.g. First write the tree to the file and let the
+  /// smart pointers take care of closing the file.
+  void closeOutputFile();
+
   const std::vector<o2::trd::CalVdriftExB>& getCcdbObjectVector() const { return mObjectVector; }
   std::vector<o2::ccdb::CcdbObjectInfo>& getCcdbObjectInfoVector() { return mInfoVector; }
 
@@ -78,12 +89,15 @@ class CalibratorVdExB final : public o2::calibration::TimeSlotCalibration<o2::tr
   size_t mMinEntriesTotal;                           ///< minimum total number of angular deviations (on average ~3 entries per bin for each TRD chamber)
   size_t mMinEntriesChamber;                         ///< minimum number of angular deviations per chamber for accepting refitted value (~3 per bin)
   bool mEnableOutput;                                ///< enable output of calibration fits and tprofiles in a root file instead of the ccdb
+  std::unique_ptr<TFile> mOutFile{nullptr};          ///< output file
+  std::unique_ptr<TTree> mOutTree{nullptr};          ///< output tree
   FitFunctor mFitFunctor;                            ///< used for minimization procedure
   std::vector<o2::ccdb::CcdbObjectInfo> mInfoVector; ///< vector of CCDB infos; each element is filled with CCDB description of accompanying CCDB calibration object
   std::vector<o2::trd::CalVdriftExB> mObjectVector;  ///< vector of CCDB calibration objects; the extracted vDrift and ExB per chamber for given slot
   ROOT::Fit::Fitter mFitter;                         ///< Fitter object will be reused across slots
   double mParamsStart[2];                            ///< Start fit parameter
-  ClassDefOverride(CalibratorVdExB, 3);
+
+  ClassDefOverride(CalibratorVdExB, 4);
 };
 
 } // namespace trd

--- a/Detectors/TRD/workflow/include/TRDWorkflow/VdAndExBCalibSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/VdAndExBCalibSpec.h
@@ -50,6 +50,7 @@ class VdAndExBCalibDevice : public o2::framework::Task
     mCalibrator = std::make_unique<o2::trd::CalibratorVdExB>(enableOutput);
     mCalibrator->setSlotLengthInSeconds(slotL);
     mCalibrator->setMaxSlotsDelay(delay);
+    mCalibrator->createOutputFile(); // internally checks if output is enabled
   }
 
   void finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj) final
@@ -75,7 +76,13 @@ class VdAndExBCalibDevice : public o2::framework::Task
   {
     LOG(info) << "Finalizing calibration";
     mCalibrator->checkSlotsToFinalize(o2::calibration::INFINITE_TF);
+    mCalibrator->closeOutputFile();
     sendOutput(ec.outputs());
+  }
+
+  void stop() final
+  {
+    mCalibrator->closeOutputFile();
   }
 
  private:

--- a/Detectors/TRD/workflow/src/trd-calib-workflow.cxx
+++ b/Detectors/TRD/workflow/src/trd-calib-workflow.cxx
@@ -14,6 +14,7 @@
 #include "TRDWorkflowIO/TRDDigitReaderSpec.h"
 #include "TRDWorkflow/VdAndExBCalibSpec.h"
 #include "TRDWorkflow/NoiseCalibSpec.h"
+#include "CommonUtils/ConfigurableParam.h"
 
 using namespace o2::framework;
 
@@ -36,6 +37,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 
 WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 {
+  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
   auto enableRootInp = configcontext.options().get<bool>("enable-root-input");
 
   WorkflowSpec specs;


### PR DESCRIPTION
This patch allows to reproduce the actual online calibration which runs every 15 minutes. Every entry in the output tree represents a slot and contains the residual profiles and fit results.

Also I added the update for the configKeyValues, which I previously forgot...

Signed-off-by: Felix Schlepper <f3sch.git@outlook.com>