### PR TITLE
TPC Track Model Compression: Store Bz field and max time bin with data

### DIFF
--- a/DataFormats/Detectors/TPC/include/DataFormatsTPC/CompressedClusters.h
+++ b/DataFormats/Detectors/TPC/include/DataFormatsTPC/CompressedClusters.h
@@ -30,8 +30,10 @@ struct CompressedClustersCounters {
   unsigned int nAttachedClustersReduced = 0;
   unsigned int nSliceRows = 36 * 152;
   unsigned char nComppressionModes = 0;
+  float solenoidBz = -1e6f;
+  int maxTimeBin = -1e6;
 
-  ClassDefNV(CompressedClustersCounters, 2);
+  ClassDefNV(CompressedClustersCounters, 3);
 };
 
 template <class TCHAR, class TSHORT, class TINT>
@@ -63,7 +65,7 @@ struct CompressedClustersPtrs_x {
   TSHORT nTrackClusters = 0;  //!
   TINT nSliceRowClusters = 0; //!
 
-  ClassDefNV(CompressedClustersPtrs_x, 2);
+  ClassDefNV(CompressedClustersPtrs_x, 3);
 };
 
 struct CompressedClustersPtrs : public CompressedClustersPtrs_x<unsigned char*, unsigned short*, unsigned int*> {
@@ -81,7 +83,7 @@ struct CompressedClusters : public CompressedClustersCounters, public Compressed
 
   void dump();
 
-  ClassDefNV(CompressedClusters, 2);
+  ClassDefNV(CompressedClusters, 3);
 };
 
 struct CompressedClustersROOT : public CompressedClusters {
@@ -92,7 +94,7 @@ struct CompressedClustersROOT : public CompressedClusters {
   int flatdataSize = 0;
   char* flatdata = nullptr; //[flatdataSize]
 
-  ClassDefNV(CompressedClustersROOT, 2);
+  ClassDefNV(CompressedClustersROOT, 3);
 };
 
 struct CompressedClustersFlat : private CompressedClustersCounters, private CompressedClustersOffsets {

--- a/Detectors/TPC/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/TPC/workflow/src/EntropyDecoderSpec.cxx
@@ -44,7 +44,7 @@ void EntropyDecoderSpec::run(ProcessingContext& pc)
   mTimer.Start(false);
   o2::ctf::CTFIOSize iosize;
 
-  mCTFCoder.updateTimeDependentParams(pc);
+  mCTFCoder.updateTimeDependentParams(pc, true);
   auto buff = pc.inputs().get<gsl::span<o2::ctf::BufferType>>("ctf");
 
   auto& compclusters = pc.outputs().make<std::vector<char>>(OutputRef{"output"});
@@ -68,7 +68,7 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
 {
   std::vector<InputSpec> inputs;
   inputs.emplace_back("ctf", "TPC", "CTFDATA", sspec, Lifetime::Timeframe);
-  inputs.emplace_back("ctfdict", "TPC", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("TPC/Calib/CTFDictionary"));
+  inputs.emplace_back("ctfdict", "TPC", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("TPC/Calib/CTFDictionaryTree"));
 
   return DataProcessorSpec{
     "tpc-entropy-decoder",

--- a/Detectors/TPC/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/TPC/workflow/src/EntropyEncoderSpec.cxx
@@ -135,6 +135,12 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
   CompressedClusters clustersFiltered = clusters;
   std::vector<std::pair<std::vector<unsigned int>, std::vector<unsigned short>>> tmpBuffer(std::max<int>(mNThreads, 1));
   if (mSelIR) {
+    if (clusters.nTracks && clusters.solenoidBz != -1e6f && clusters.solenoidBz != mParam->bzkG) {
+      throw std::runtime_error("Configured solenoid Bz does not match value used for track model encoding");
+    }
+    if (clusters.nTracks && clusters.maxTimeBin != -1e6 && clusters.maxTimeBin != mParam->par.continuousMaxTimeBin) {
+      throw std::runtime_error("Configured max time bin does not match value used for track model encoding");
+    }
     mCTFCoder.setSelectedIRFrames(pc.inputs().get<gsl::span<o2::dataformats::IRFrame>>("selIRFrames"));
     rejectHits.resize(clusters.nUnattachedClusters);
     rejectTracks.resize(clusters.nTracks);
@@ -272,7 +278,7 @@ DataProcessorSpec getEntropyEncoderSpec(bool inputFromFile, bool selIR)
   std::vector<InputSpec> inputs;
   header::DataDescription inputType = inputFromFile ? header::DataDescription("COMPCLUSTERS") : header::DataDescription("COMPCLUSTERSFLAT");
   inputs.emplace_back("input", "TPC", inputType, 0, Lifetime::Timeframe);
-  inputs.emplace_back("ctfdict", "TPC", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("TPC/Calib/CTFDictionary"));
+  inputs.emplace_back("ctfdict", "TPC", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("TPC/Calib/CTFDictionaryTree"));
 
   std::shared_ptr<o2::base::GRPGeomRequest> ggreq;
   if (selIR) {

--- a/GPU/GPUTracking/DataCompression/TPCClusterDecompressor.cxx
+++ b/GPU/GPUTracking/DataCompression/TPCClusterDecompressor.cxx
@@ -39,6 +39,12 @@ int TPCClusterDecompressor::decompress(const CompressedClustersFlat* clustersCom
 
 int TPCClusterDecompressor::decompress(const CompressedClusters* clustersCompressed, o2::tpc::ClusterNativeAccess& clustersNative, std::function<o2::tpc::ClusterNative*(size_t)> allocator, const GPUParam& param)
 {
+  if (clustersCompressed->nTracks && clustersCompressed->solenoidBz != -1e6f && clustersCompressed->solenoidBz != param.bzkG) {
+    throw std::runtime_error("Configured solenoid Bz does not match value used for track model encoding");
+  }
+  if (clustersCompressed->nTracks && clustersCompressed->maxTimeBin != -1e6 && clustersCompressed->maxTimeBin != param.par.continuousMaxTimeBin) {
+    throw std::runtime_error("Configured max time bin does not match value used for track model encoding");
+  }
   std::vector<ClusterNative> clusters[NSLICES][GPUCA_ROW_COUNT];
   std::atomic_flag locks[NSLICES][GPUCA_ROW_COUNT];
   for (unsigned int i = 0; i < NSLICES * GPUCA_ROW_COUNT; i++) {

--- a/GPU/GPUTracking/Global/GPUChainTrackingCompression.cxx
+++ b/GPU/GPUTracking/Global/GPUChainTrackingCompression.cxx
@@ -67,6 +67,8 @@ int GPUChainTracking::RunTPCCompression()
   O->nAttachedClustersReduced = O->nAttachedClusters - O->nTracks;
   O->nSliceRows = NSLICES * GPUCA_ROW_COUNT;
   O->nComppressionModes = param().rec.tpc.compressionTypeMask;
+  O->solenoidBz = param().bzkG;
+  O->maxTimeBin = param().par.continuousMaxTimeBin;
   size_t outputSize = AllocateRegisteredMemory(Compressor.mMemoryResOutputHost, mSubOutputControls[GPUTrackingOutputs::getIndex(&GPUTrackingOutputs::compressedClusters)]);
   Compressor.mOutputFlat->set(outputSize, *Compressor.mOutput);
   char* hostFlatPtr = (char*)Compressor.mOutput->qTotU; // First array as allocated in GPUTPCCompression::SetPointersCompressedClusters


### PR DESCRIPTION
@shahor02 : I'd like to store these 2 additional values
```
  float solenoidBz = -1e6f;
  int maxTimeBin = -1e6;
```
with the TPC CTF. Do we have some kind of schema evolution for it? Old CTFs should be read with these default values.

Reading old CTFs with this PR segfaults, so we certainly need to do something on the CTF encoder / decoder.