### PR TITLE
TPC CTF Skimming: Implement eta-cut on unassigned clusters

### DIFF
--- a/Detectors/TPC/workflow/include/TPCWorkflow/EntropyEncoderSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/EntropyEncoderSpec.h
@@ -66,6 +66,7 @@ class EntropyEncoderSpec : public o2::framework::Task
   bool mSelIR = false;
   unsigned int mNThreads = 1;
   float mMaxZ = 25.f, mMaxEta = 1.5f;
+  float mEtaFactor = 0.f;
   TStopwatch mTimer;
 };
 

--- a/Detectors/TPC/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/TPC/workflow/src/EntropyEncoderSpec.cxx
@@ -87,6 +87,8 @@ void EntropyEncoderSpec::init(o2::framework::InitContext& ic)
   mNThreads = ic.options().get<unsigned int>("nThreads-tpc-encoder");
   mMaxZ = ic.options().get<float>("irframe-clusters-maxz");
   mMaxEta = ic.options().get<float>("irframe-clusters-maxeta");
+
+  mEtaFactor = 1.f / (tanf(2 * atanf(expf(-mMaxEta))));
 }
 
 void EntropyEncoderSpec::run(ProcessingContext& pc)
@@ -212,9 +214,14 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
       int myThread = 0;
 #endif
       unsigned int count = 0;
-      auto checker = [i, j, firstIR, totalT, this, &preCl, &count, &outBuffer = tmpBuffer[myThread], &rejectHits, &clustersFiltered](const o2::tpc::ClusterNative& cl, unsigned int k) {
-        const auto chkVal = firstIR + (cl.getTime() * constants::LHCBCPERTIMEBIN);
-        const auto chkExt = totalT * constants::LHCBCPERTIMEBIN;
+      const float x = mParam->tpcGeometry.Row2X(j);
+      auto checker = [i, j, firstIR, totalT, x, this, &preCl, &count, &outBuffer = tmpBuffer[myThread], &rejectHits, &clustersFiltered](const o2::tpc::ClusterNative& cl, unsigned int k) {
+        const float y = mParam->tpcGeometry.LinearPad2Y(i, j, cl.getPad());
+        const float r = sqrtf(x * x + y * y);
+        const float maxz = r * mEtaFactor + mMaxZ;
+        const unsigned int deltaBC = std::max<float>(0.f, totalT - mFastTransform->convDeltaZtoDeltaTimeInTimeFrameAbs(maxz)) * constants::LHCBCPERTIMEBIN;
+        const auto chkVal = firstIR + (cl.getTime() * constants::LHCBCPERTIMEBIN) - deltaBC;
+        const auto chkExt = totalT * constants::LHCBCPERTIMEBIN - deltaBC;
         const bool reject = mCTFCoder.getIRFramesSelector().check(o2::dataformats::IRFrame(chkVal, chkVal + 1), chkExt, 0) < 0;
         if (reject) {
           rejectHits[k] = true;


### PR DESCRIPTION
@shahor02 : Finalizes the eta / z cut for unattached clusters. Fully tested and working.

What is still missing:
- track DCA cut for attached clusters (though I am still not sure how we want to do it and how strict. I think we'll at least need to refit the track for that.)
- distortion correction: either we do a vertex estimate like during the tracking, and then correct the track for the respective z, but will of course not be fully precise without matching to other detectors. Or we just add enough BC margin for the IRFrameSelector to compensate for the distortion in z.