### PR TITLE
fix in TOF matching (time) to account for integrated times

### DIFF
--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTOF.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTOF.h
@@ -197,8 +197,8 @@ class MatchTOF
   bool prepareFITData();
   int prepareInteractionTimes();
   bool prepareTPCData();
-  void addTPCSeed(const o2::tpc::TrackTPC& _tr, o2::dataformats::GlobalTrackID srcGID);
-  void addITSTPCSeed(const o2::dataformats::TrackTPCITS& _tr, o2::dataformats::GlobalTrackID srcGID);
+  void addTPCSeed(const o2::tpc::TrackTPC& _tr, o2::dataformats::GlobalTrackID srcGID, float time0, float terr);
+  void addITSTPCSeed(const o2::dataformats::TrackTPCITS& _tr, o2::dataformats::GlobalTrackID srcGID, float time0, float terr);
   void addTRDSeed(const o2::trd::TrackTRD& _tr, o2::dataformats::GlobalTrackID srcGID, float time0, float terr);
   void addConstrainedSeed(o2::track::TrackParCov& trc, o2::dataformats::GlobalTrackID srcGID, o2::track::TrackLTIntegral intLT0, timeEst timeMUS);
   //  void addTPCTRDSeed(const o2::track::TrackParCov& _tr, o2::dataformats::GlobalTrackID srcGID, int tpcID);

--- a/Detectors/GlobalTrackingWorkflow/src/TOFEventTimeChecker.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TOFEventTimeChecker.cxx
@@ -65,6 +65,7 @@ struct MyTrack : o2::tof::eventTimeTrackTest {
   float tofExpSignalDe() const { return mExpDe; }
   double mSignalDouble = 0.0;
   float mEta = 0.0;
+  float mPTPC = 0.0;
   float mPhi = 0.0;
   float mExpDe = 0;
   int mIsProb = 0;
@@ -156,6 +157,7 @@ class TOFEventTimeChecker : public Task
   int mCh;
   float mP = 0;
   float mPt = 0;
+  float mPTPC = 0;
   float mEta = 0;
   float mPhi = 0;
   float mChi2 = 0;
@@ -230,6 +232,7 @@ void TOFEventTimeChecker::processEvent(std::vector<MyTrack>& tracks)
     mCh = track.mCh;
     mP = track.mP;
     mPt = track.mPt;
+    mPTPC = track.mPTPC;
     mEta = track.mEta;
     mSource = track.mSource;
     mPhi = track.mPhi;
@@ -319,7 +322,8 @@ void TOFEventTimeChecker::fillMatching(GID gid, float time0, float time0res)
     const auto& array = mRecoData.getTPCTracks();
     GID gTrackId = match.getTrackRef();
     const auto& srctrk = array[gTrackId.getIndex()];
-    trk.mPt = srctrk.getPt();
+    trk.mPt = srctrk.getPt() * srctrk.getCharge();
+    trk.mPTPC = srctrk.getP();
     trk.mP = srctrk.getP();
     trk.mEta = srctrk.getEta();
     trk.mPhi = srctrk.getPhi();
@@ -331,7 +335,8 @@ void TOFEventTimeChecker::fillMatching(GID gid, float time0, float time0res)
     const auto& array = mRecoData.getTPCTracks();
     GID gTrackId = gid;
     const auto& srctrk = array[gTrackId.getIndex()];
-    trk.mPt = srctrk.getPt();
+    trk.mPt = srctrk.getPt() * srctrk.getCharge();
+    trk.mPTPC = srctrk.getP();
     trk.mP = srctrk.getP();
     trk.mEta = srctrk.getEta();
     trk.mPhi = srctrk.getPhi();
@@ -341,7 +346,8 @@ void TOFEventTimeChecker::fillMatching(GID gid, float time0, float time0res)
     const auto& array = mRecoData.getTPCITSTracks();
     GID gTrackId = match.getTrackRef();
     const auto& srctrk = array[gTrackId.getIndex()];
-    trk.mPt = srctrk.getPt();
+    trk.mPt = srctrk.getPt() * srctrk.getCharge();
+    trk.mPTPC = srctrk.getP();
     trk.mP = srctrk.getP();
     trk.mEta = srctrk.getEta();
     trk.mPhi = srctrk.getPhi();
@@ -354,7 +360,8 @@ void TOFEventTimeChecker::fillMatching(GID gid, float time0, float time0res)
     const auto& array = mRecoData.getTPCITSTracks();
     GID gTrackId = gid; //match.getTrackRef();
     const auto& srctrk = array[gTrackId.getIndex()];
-    trk.mPt = srctrk.getPt();
+    trk.mPt = srctrk.getPt() * srctrk.getCharge();
+    trk.mPTPC = srctrk.getP();
     trk.mP = srctrk.getP();
     trk.mEta = srctrk.getEta();
     trk.mPhi = srctrk.getPhi();
@@ -366,25 +373,47 @@ void TOFEventTimeChecker::fillMatching(GID gid, float time0, float time0res)
     const auto& array = mRecoData.getTPCTRDTracks<o2::trd::TrackTRD>();
     GID gTrackId = match.getTrackRef();
     const auto& srctrk = array[gTrackId.getIndex()];
-    trk.mPt = srctrk.getPt();
+    trk.mPt = srctrk.getPt() * srctrk.getCharge();
+    trk.mPTPC = srctrk.getP();
     trk.mP = srctrk.getP();
     trk.mEta = srctrk.getEta();
     trk.mPhi = srctrk.getPhi();
     trksource = 2;
     trk.mDx = match.getDXatTOF();
     trk.mDz = match.getDZatTOF();
+  } else if (gid.getSource() == GID::TPCTRD && 0) {
+    const auto& array = mRecoData.getTPCTRDTracks<o2::trd::TrackTRD>();
+    GID gTrackId = gid; // match.getTrackRef();
+    const auto& srctrk = array[gTrackId.getIndex()];
+    trk.mPt = srctrk.getPt() * srctrk.getCharge();
+    trk.mPTPC = srctrk.getP();
+    trk.mP = srctrk.getP();
+    trk.mEta = srctrk.getEta();
+    trk.mPhi = srctrk.getPhi();
+    trksource = 2;
   } else if (gid.getSource() == GID::ITSTPCTRDTOF) {
     const o2::dataformats::MatchInfoTOF& match = mRecoData.getTOFMatch(gid);
     const auto& array = mRecoData.getITSTPCTRDTracks<o2::trd::TrackTRD>();
     GID gTrackId = match.getTrackRef();
     const auto& srctrk = array[gTrackId.getIndex()];
-    trk.mPt = srctrk.getPt();
+    trk.mPt = srctrk.getPt() * srctrk.getCharge();
+    trk.mPTPC = srctrk.getP();
     trk.mP = srctrk.getP();
     trk.mEta = srctrk.getEta();
     trk.mPhi = srctrk.getPhi();
     trksource = 3;
     trk.mDx = match.getDXatTOF();
     trk.mDz = match.getDZatTOF();
+  } else if (gid.getSource() == GID::ITSTPCTRD && 0) {
+    const auto& array = mRecoData.getTPCTRDTracks<o2::trd::TrackTRD>();
+    GID gTrackId = gid; // match.getTrackRef();
+    const auto& srctrk = array[gTrackId.getIndex()];
+    trk.mPt = srctrk.getPt() * srctrk.getCharge();
+    trk.mPTPC = srctrk.getP();
+    trk.mP = srctrk.getP();
+    trk.mEta = srctrk.getEta();
+    trk.mPhi = srctrk.getPhi();
+    trksource = 3;
   }
 
   trk.mSource = trksource;
@@ -502,6 +531,7 @@ void TOFEventTimeChecker::init(InitContext& ic)
   mTree->Branch("isProb", &mIsProb, "isProb/I");
   mTree->Branch("p", &mP, "p/F");
   mTree->Branch("pt", &mPt, "pt/F");
+  mTree->Branch("pTPC", &mPTPC, "pTPC/F");
   mTree->Branch("source", &mSource, "source/I");
   mTree->Branch("eta", &mEta, "eta/F");
   mTree->Branch("phi", &mPhi, "phi/F");

--- a/Detectors/TOF/base/src/EventTimeMaker.cxx
+++ b/Detectors/TOF/base/src/EventTimeMaker.cxx
@@ -27,7 +27,7 @@ namespace o2
 namespace tof
 {
 
-constexpr int MAXNTRACKINSET = 10;
+constexpr int MAXNTRACKINSET = 20;
 // usefull constants
 constexpr unsigned long combinatorial[MAXNTRACKINSET + 1] = {1, 3, 9, 27, 81, 243, 729, 2187, 6561, 19683, 59049};
 //---------------
@@ -47,7 +47,9 @@ void computeEvTime(const std::vector<eventTimeTrack>& tracks, const std::vector<
 
   int hypo[MAXNTRACKINSET];
 
-  int nmaxtracksinset = ntracks > 22 ? 6 : MAXNTRACKINSET; // max number of tracks in a set for event time computation
+  //  int nmaxtracksinset = ntracks > 22 ? 6 : MAXNTRACKINSET; // max number of tracks in a set for event time computation
+  int nmaxtracksinset = MAXNTRACKINSET;
+
   LOG(debug) << "nmaxtracksinset " << nmaxtracksinset;
   int ntracksinset = std::min(ntracks, nmaxtracksinset);
   LOG(debug) << "ntracksinset " << ntracksinset;


### PR DESCRIPTION
This is a fix for the time window used to match tracks.
- track time errors are now get from createTracksVariadic for all kinds of tracks
- track length are used (beta=1) to shift track time to TOF radius (more efficient than do the opposite)
- 100 ns tolerance added on the maxTrkTime to avoid to cut on slow tracks (relevant for *-TRD tracks)
I would expect to recover almost 50% efficiency in LHC22m/... for ITS-TPC-* tracks because we should recover all ITS-TPC-TRD tracks (now almost complety cut)
Tested on Pb-Pb data (full reco output) by re-running TOF matching

@chiarazampolli , @njacazio , @ercolessi
