### PR TITLE
Optionally apply BC shift to triggered detectors in CTF decoding

### DIFF
--- a/DataFormats/Detectors/CTP/include/DataFormatsCTP/TriggerOffsetsParam.h
+++ b/DataFormats/Detectors/CTP/include/DataFormatsCTP/TriggerOffsetsParam.h
@@ -22,9 +22,10 @@ namespace o2
 namespace ctp
 {
 struct TriggerOffsetsParam : public o2::conf::ConfigurableParamHelper<TriggerOffsetsParam> {
+  static constexpr int MaxNDet = 32; // take with margin to account for possible changes / upgrades
   int64_t LM_L0 = 15;
   int64_t L0_L1 = 280;
-
+  int64_t customOffset[MaxNDet] = {};
   O2ParamDef(TriggerOffsetsParam, "TriggerOffsetsParam"); // boilerplate stuff + make principal key
 };
 } // namespace ctp

--- a/Detectors/Base/CMakeLists.txt
+++ b/Detectors/Base/CMakeLists.txt
@@ -28,6 +28,7 @@ o2_add_library(DetectorsBase
                PUBLIC_LINK_LIBRARIES FairRoot::Base
                                      O2::CommonUtils
                                      O2::DetectorsCommonDataFormats
+                                     O2::DataFormatsCTP
                                      O2::GPUCommon
                                      O2::GPUUtils
                                      O2::ReconstructionDataFormats

--- a/Detectors/Base/include/DetectorsBase/CTFCoderBase.h
+++ b/Detectors/Base/include/DetectorsBase/CTFCoderBase.h
@@ -25,6 +25,7 @@
 #include "DetectorsCommonDataFormats/CTFDictHeader.h"
 #include "DetectorsCommonDataFormats/CTFHeader.h"
 #include "DetectorsCommonDataFormats/CTFIOSize.h"
+#include "DataFormatsCTP/TriggerOffsetsParam.h"
 #include "rANS/rans.h"
 #include <filesystem>
 #include "Framework/InitContext.h"
@@ -125,10 +126,22 @@ class CTFCoderBase
   size_t getIRFrameSelMarginBwd() const { return mIRFrameSelMarginBwd; }
   size_t getIRFrameSelMarginFwd() const { return mIRFrameSelMarginFwd; }
 
+  void setBCShift(int64_t n) { mBCShift = n; }
+  void setFirstTFOrbit(uint32_t n) { mFirstTFOrbit = n; }
+  auto getBCShist() const { return mBCShift; }
+  auto getFirstTFOrbit() const { return mFirstTFOrbit; }
+  void setSupportBCShifts(bool v = true) { mSupportBCShifts = v; }
+  bool getSupportBCShifts() const { return mSupportBCShifts; }
+
  protected:
   std::string getPrefix() const { return o2::utils::Str::concat_string(mDet.getName(), "_CTF: "); }
   void checkDictVersion(const CTFDictHeader& h) const;
   bool isTreeDictionary(const void* buff) const;
+  bool canApplyBCShift(const o2::InteractionRecord& ir) const
+  {
+    auto diff = ir.differenceInBC({0, mFirstTFOrbit});
+    return diff < 0 ? true : diff >= mBCShift;
+  }
   template <typename CTF>
   std::vector<char> loadDictionaryFromTree(TTree* tree);
   std::vector<std::shared_ptr<void>> mCoders; // encoders/decoders
@@ -137,7 +150,10 @@ class CTFCoderBase
   o2::utils::IRFrameSelector mIRFrameSelector; // optional IR frames selector
   float mMemMarginFactor = 1.0f; // factor for memory allocation in EncodedBlocks
   bool mLoadDictFromCCDB{true};
+  bool mSupportBCShifts{false};
   OpType mOpType; // Encoder or Decoder
+  int64_t mBCShift = 0; // shift to apply to decoded IR (i.e. CTP offset if was not corrected on raw data decoding level)
+  uint32_t mFirstTFOrbit = 0;
   size_t mIRFrameSelMarginBwd = 0; // margin in BC to add to the IRFrame lower boundary when selection is requested
   size_t mIRFrameSelMarginFwd = 0; // margin in BC to add to the IRFrame upper boundary when selection is requested
   int mVerbosity = 0;
@@ -293,6 +309,17 @@ bool CTFCoderBase::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, voi
       LOGP(info, "Loaded {} from CCDB", mExtHeader.asString());
     }
     mLoadDictFromCCDB = false; // we read the dictionary at most once!
+  } else if ((match = (matcher == o2::framework::ConcreteDataMatcher("CTP", "Trig_Offset", 0)))) {
+    const auto& trigOffsParam = o2::ctp::TriggerOffsetsParam::Instance();
+    auto bcshift = trigOffsParam.customOffset[mDet.getID()];
+    if (bcshift) {
+      if (mSupportBCShifts) {
+        LOGP(info, "Decoded IRs will be augmented by {} BCs, discarded if become prior to 1st orbit", bcshift);
+        setBCShift(-bcshift); // offset is subtracted
+      } else {
+        LOGP(alarm, "Decoding with {} BCs shift is requested, but the {} does not support this operation, ignoring request", bcshift, mDet.getName());
+      }
+    }
   }
   return match;
 }

--- a/Detectors/Base/src/CTFCoderBase.cxx
+++ b/Detectors/Base/src/CTFCoderBase.cxx
@@ -17,6 +17,7 @@
 #include "Framework/ControlService.h"
 #include "Framework/ProcessingContext.h"
 #include "Framework/InputRecord.h"
+#include "Framework/TimingInfo.h"
 
 using namespace o2::ctf;
 using namespace o2::framework;
@@ -47,6 +48,10 @@ void CTFCoderBase::assignDictVersion(CTFDictHeader& h) const
 
 void CTFCoderBase::updateTimeDependentParams(ProcessingContext& pc, bool askTree)
 {
+  setFirstTFOrbit(pc.services().get<o2::framework::TimingInfo>().firstTForbit);
+  if (mOpType == OpType::Decoder) {
+    pc.inputs().get<o2::ctp::TriggerOffsetsParam*>("trigoffset"); // this is a configurable param
+  }
   if (mLoadDictFromCCDB) {
     if (askTree) {
       pc.inputs().get<TTree*>("ctfdict"); // just to trigger the finaliseCCDB

--- a/Detectors/CPV/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/CPV/workflow/src/EntropyDecoderSpec.cxx
@@ -30,6 +30,7 @@ EntropyDecoderSpec::EntropyDecoderSpec(int verbosity) : mCTFCoder(o2::ctf::CTFCo
   mTimer.Stop();
   mTimer.Reset();
   mCTFCoder.setVerbosity(verbosity);
+  mCTFCoder.setSupportBCShifts(true);
 }
 
 void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
@@ -82,6 +83,7 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
   std::vector<InputSpec> inputs;
   inputs.emplace_back("ctf", "CPV", "CTFDATA", sspec, Lifetime::Timeframe);
   inputs.emplace_back("ctfdict", "CPV", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("CPV/Calib/CTFDictionary"));
+  inputs.emplace_back("trigoffset", "CTP", "Trig_Offset", 0, Lifetime::Condition, ccdbParamSpec("CTP/Config/TriggerOffsets"));
 
   return DataProcessorSpec{
     "cpv-entropy-decoder",

--- a/Detectors/CTP/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/CTP/workflow/src/EntropyDecoderSpec.cxx
@@ -29,6 +29,7 @@ EntropyDecoderSpec::EntropyDecoderSpec(int verbosity) : mCTFCoder(o2::ctf::CTFCo
 {
   mTimer.Stop();
   mTimer.Reset();
+  mCTFCoder.setVerbosity(verbosity);
 }
 
 void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
@@ -81,6 +82,7 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
   std::vector<InputSpec> inputs;
   inputs.emplace_back("ctf", "CTP", "CTFDATA", sspec, Lifetime::Timeframe);
   inputs.emplace_back("ctfdict", "CTP", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("CTP/Calib/CTFDictionaryTree"));
+  inputs.emplace_back("trigoffset", "CTP", "Trig_Offset", 0, Lifetime::Condition, ccdbParamSpec("CTP/Config/TriggerOffsets"));
 
   return DataProcessorSpec{
     "ctp-entropy-decoder",

--- a/Detectors/EMCAL/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/EntropyDecoderSpec.cxx
@@ -30,6 +30,7 @@ EntropyDecoderSpec::EntropyDecoderSpec(int verbosity, unsigned int sspecOut) : m
   mTimer.Stop();
   mTimer.Reset();
   mCTFCoder.setVerbosity(verbosity);
+  mCTFCoder.setSupportBCShifts(true);
 }
 
 void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
@@ -82,6 +83,7 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspecInp, un
   std::vector<InputSpec> inputs;
   inputs.emplace_back("ctf", "EMC", "CTFDATA", sspecInp, Lifetime::Timeframe);
   inputs.emplace_back("ctfdict", "EMC", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("EMC/Calib/CTFDictionary"));
+  inputs.emplace_back("trigoffset", "CTP", "Trig_Offset", 0, Lifetime::Condition, ccdbParamSpec("CTP/Config/TriggerOffsets"));
 
   return DataProcessorSpec{
     "emcal-entropy-decoder",

--- a/Detectors/FIT/FDD/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/FIT/FDD/workflow/src/EntropyDecoderSpec.cxx
@@ -82,6 +82,7 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
   std::vector<InputSpec> inputs;
   inputs.emplace_back("ctf", "FDD", "CTFDATA", sspec, Lifetime::Timeframe);
   inputs.emplace_back("ctfdict", "FDD", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("FDD/Calib/CTFDictionary"));
+  inputs.emplace_back("trigoffset", "CTP", "Trig_Offset", 0, Lifetime::Condition, ccdbParamSpec("CTP/Config/TriggerOffsets"));
 
   return DataProcessorSpec{
     "fdd-entropy-decoder",

--- a/Detectors/FIT/FT0/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/FIT/FT0/workflow/src/EntropyDecoderSpec.cxx
@@ -82,6 +82,7 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
   std::vector<InputSpec> inputs;
   inputs.emplace_back("ctf", "FT0", "CTFDATA", sspec, Lifetime::Timeframe);
   inputs.emplace_back("ctfdict", "FT0", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("FT0/Calib/CTFDictionary"));
+  inputs.emplace_back("trigoffset", "CTP", "Trig_Offset", 0, Lifetime::Condition, ccdbParamSpec("CTP/Config/TriggerOffsets"));
 
   return DataProcessorSpec{
     "ft0-entropy-decoder",

--- a/Detectors/FIT/FV0/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/FIT/FV0/workflow/src/EntropyDecoderSpec.cxx
@@ -82,6 +82,7 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
   std::vector<InputSpec> inputs;
   inputs.emplace_back("ctf", "FV0", "CTFDATA", sspec, Lifetime::Timeframe);
   inputs.emplace_back("ctfdict", "FV0", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("FV0/Calib/CTFDictionary"));
+  inputs.emplace_back("trigoffset", "CTP", "Trig_Offset", 0, Lifetime::Condition, ccdbParamSpec("CTP/Config/TriggerOffsets"));
 
   return DataProcessorSpec{
     "fv0-entropy-decoder",

--- a/Detectors/HMPID/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/HMPID/workflow/src/EntropyDecoderSpec.cxx
@@ -47,6 +47,7 @@ EntropyDecoderSpec::EntropyDecoderSpec(int verbosity) : mCTFCoder(o2::ctf::CTFCo
   mTimer.Stop();
   mTimer.Reset();
   mCTFCoder.setVerbosity(verbosity);
+  mCTFCoder.setSupportBCShifts(true);
 }
 
 void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
@@ -99,6 +100,7 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
   std::vector<InputSpec> inputs;
   inputs.emplace_back("ctf", "HMP", "CTFDATA", sspec, Lifetime::Timeframe);
   inputs.emplace_back("ctfdict", "HMP", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("HMP/Calib/CTFDictionary"));
+  inputs.emplace_back("trigoffset", "CTP", "Trig_Offset", 0, Lifetime::Condition, ccdbParamSpec("CTP/Config/TriggerOffsets"));
 
   return DataProcessorSpec{
     "hmpid-entropy-decoder",

--- a/Detectors/ITSMFT/common/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/ITSMFT/common/workflow/src/EntropyDecoderSpec.cxx
@@ -136,6 +136,7 @@ DataProcessorSpec getEntropyDecoderSpec(o2::header::DataOrigin orig, int verbosi
   inputs.emplace_back("noise", orig, "NOISEMAP", 0, Lifetime::Condition, ccdbParamSpec(fmt::format("{}/Calib/NoiseMap", orig.as<std::string>())));
   inputs.emplace_back("cldict", orig, "CLUSDICT", 0, Lifetime::Condition, ccdbParamSpec(fmt::format("{}/Calib/ClusterDictionary", orig.as<std::string>())));
   inputs.emplace_back("ctfdict", orig, "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec(fmt::format("{}/Calib/CTFDictionary", orig.as<std::string>())));
+  inputs.emplace_back("trigoffset", "CTP", "Trig_Offset", 0, Lifetime::Condition, ccdbParamSpec("CTP/Config/TriggerOffsets"));
 
   return DataProcessorSpec{
     EntropyDecoderSpec::getName(orig),

--- a/Detectors/MUON/MCH/CTF/src/EntropyDecoderSpec.cxx
+++ b/Detectors/MUON/MCH/CTF/src/EntropyDecoderSpec.cxx
@@ -101,6 +101,7 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, const char* specName, uns
   std::vector<InputSpec> inputs;
   inputs.emplace_back("ctf", "MCH", "CTFDATA", sspec, Lifetime::Timeframe);
   inputs.emplace_back("ctfdict", "MCH", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("MCH/Calib/CTFDictionary"));
+  inputs.emplace_back("trigoffset", "CTP", "Trig_Offset", 0, Lifetime::Condition, ccdbParamSpec("CTP/Config/TriggerOffsets"));
 
   return DataProcessorSpec{
     specName,

--- a/Detectors/MUON/MID/Workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/EntropyDecoderSpec.cxx
@@ -93,6 +93,7 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
   std::vector<InputSpec> inputs;
   inputs.emplace_back("ctf", "MID", "CTFDATA", sspec, Lifetime::Timeframe);
   inputs.emplace_back("ctfdict", "MID", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("MID/Calib/CTFDictionary"));
+  inputs.emplace_back("trigoffset", "CTP", "Trig_Offset", 0, Lifetime::Condition, ccdbParamSpec("CTP/Config/TriggerOffsets"));
 
   return DataProcessorSpec{
     "mid-entropy-decoder",

--- a/Detectors/PHOS/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/PHOS/workflow/src/EntropyDecoderSpec.cxx
@@ -30,6 +30,7 @@ EntropyDecoderSpec::EntropyDecoderSpec(int verbosity) : mCTFCoder(o2::ctf::CTFCo
   mTimer.Stop();
   mTimer.Reset();
   mCTFCoder.setVerbosity(verbosity);
+  mCTFCoder.setSupportBCShifts(true);
 }
 
 void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
@@ -82,6 +83,7 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
   std::vector<InputSpec> inputs;
   inputs.emplace_back("ctf", "PHS", "CTFDATA", sspec, Lifetime::Timeframe);
   inputs.emplace_back("ctfdict", "PHS", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("PHS/Calib/CTFDictionary"));
+  inputs.emplace_back("trigoffset", "CTP", "Trig_Offset", 0, Lifetime::Condition, ccdbParamSpec("CTP/Config/TriggerOffsets"));
 
   return DataProcessorSpec{
     "phos-entropy-decoder",

--- a/Detectors/TOF/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/TOF/workflow/src/EntropyDecoderSpec.cxx
@@ -105,6 +105,7 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
   std::vector<InputSpec> inputs;
   inputs.emplace_back("ctf", "TOF", "CTFDATA", sspec, Lifetime::Timeframe);
   inputs.emplace_back("ctfdict", "TOF", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("TOF/Calib/CTFDictionary"));
+  inputs.emplace_back("trigoffset", "CTP", "Trig_Offset", 0, Lifetime::Condition, ccdbParamSpec("CTP/Config/TriggerOffsets"));
 
   return DataProcessorSpec{
     "tof-entropy-decoder",

--- a/Detectors/TPC/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/TPC/workflow/src/EntropyDecoderSpec.cxx
@@ -69,6 +69,7 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
   std::vector<InputSpec> inputs;
   inputs.emplace_back("ctf", "TPC", "CTFDATA", sspec, Lifetime::Timeframe);
   inputs.emplace_back("ctfdict", "TPC", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("TPC/Calib/CTFDictionaryTree"));
+  inputs.emplace_back("trigoffset", "CTP", "Trig_Offset", 0, Lifetime::Condition, ccdbParamSpec("CTP/Config/TriggerOffsets"));
 
   return DataProcessorSpec{
     "tpc-entropy-decoder",

--- a/Detectors/TRD/reconstruction/include/TRDReconstruction/CTFCoder.h
+++ b/Detectors/TRD/reconstruction/include/TRDReconstruction/CTFCoder.h
@@ -50,8 +50,6 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 
   void createCoders(const std::vector<char>& bufVec, o2::ctf::CTFCoderBase::OpType op) final;
 
-  void setBCShift(int n) { mBCShift = n; }
-  void setFirstTFOrbit(uint32_t n) { mFirstTFOrbit = n; }
   void setCheckBogusTrig(int v) { mCheckBogusTrig = v; }
 
  private:
@@ -60,8 +58,6 @@ class CTFCoder : public o2::ctf::CTFCoderBase
 
   void appendToTree(TTree& tree, CTF& ec);
   void readFromTree(TTree& tree, int entry, std::vector<TriggerRecord>& trigVec, std::vector<Tracklet64>& trkVec, std::vector<Digit>& digVec);
-  int mBCShift = 0; // shift to apply to decoded IR (i.e. CTP offset if was not corrected on raw data decoding level)
-  uint32_t mFirstTFOrbit = 0;
   int mCheckBogusTrig = 1;
   // containers for locally filtered data
   std::vector<TriggerRecord> mTrgRecFilt;
@@ -252,7 +248,7 @@ o2::ctf::CTFIOSize CTFCoder::decode(const CTF::base& ec, VTRG& trigVec, VTRK& tr
     }
     orbitPrev = orbit;
     o2::InteractionRecord ir{bc, orbit};
-    if (triggerOK && (checkIROK || ir.differenceInBC({0, mFirstTFOrbit}) >= mBCShift)) { // correction will be ok
+    if (triggerOK && (checkIROK || canApplyBCShift(ir))) {                // correction will be ok
       checkIROK = true;                                                   // don't check anymore since the following checks will yield same
       orbitPrevGood = orbit;
       uint32_t firstEntryTrk = trkVec.size();

--- a/Detectors/ZDC/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/ZDC/workflow/src/EntropyDecoderSpec.cxx
@@ -30,6 +30,7 @@ EntropyDecoderSpec::EntropyDecoderSpec(int verbosity) : mCTFCoder(o2::ctf::CTFCo
   mTimer.Stop();
   mTimer.Reset();
   mCTFCoder.setVerbosity(verbosity);
+  mCTFCoder.setSupportBCShifts(true);
 }
 
 void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
@@ -84,6 +85,7 @@ DataProcessorSpec getEntropyDecoderSpec(int verbosity, unsigned int sspec)
   std::vector<InputSpec> inputs;
   inputs.emplace_back("ctf", "ZDC", "CTFDATA", sspec, Lifetime::Timeframe);
   inputs.emplace_back("ctfdict", "ZDC", "CTFDICT", 0, Lifetime::Condition, ccdbParamSpec("ZDC/Calib/CTFDictionary"));
+  inputs.emplace_back("trigoffset", "CTP", "Trig_Offset", 0, Lifetime::Condition, ccdbParamSpec("CTP/Config/TriggerOffsets"));
 
   return DataProcessorSpec{
     "zdc-entropy-decoder",


### PR DESCRIPTION
The `TriggerOffsetsParam` `configurableParam` got an array of custom corrections per detector (0 by default) which can be applied to triggered detectors IR as an *additive* correction during CTF decoding. Note that this convention is opposite to that for the `LM_L0` correction which is subtracted from the encoded IR (at the moment only for the TRD if an option `--correct-trd-trigger-offset` was provided to the `ctf-reader`). Therefore, for the TRD, if this option is ON, the effect of the correction is 
```
ir_corrected = ir_decoded - TriggerOffsetsParam::LM_L0 + TriggerOffsetsParam::customOffset[TRD]; 
```
while for other EMC,PHS,CPV and HMP (and TRD in absence of `--correct-trd-trigger-offset`) it is simply 
```
ir_corrected = ir_decoded + TriggerOffsetsParam::customOffset[<det>];
```
In case the correction moves the IR before the TF 1st orbit, the trigger is discarded.

Update: ZDC in pbpb2022 was resetting the orbit internally to 1 at the SOR and had BC shifted by -1 like for RORC detectors: implemented the shift also for it.