### PR TITLE
[EMCAL-841] Fix for interchanged energy and time in cell calibration

### DIFF
--- a/Detectors/EMCAL/calib/include/EMCALCalib/CellRecalibrator.h
+++ b/Detectors/EMCAL/calib/include/EMCALCalib/CellRecalibrator.h
@@ -142,8 +142,8 @@ class CellRecalibrator
       }
     }
 
-    float calibratedEnergy = inputcell.getTimeStamp();
-    float calibratedTime = inputcell.getEnergy();
+    float calibratedEnergy = inputcell.getEnergy();
+    float calibratedTime = inputcell.getTimeStamp();
 
     if (hasTimeCalibration()) {
       calibratedTime -= mTimeCalibration->getTimeCalibParam(inputcell.getTower(), inputcell.getLowGain());


### PR DESCRIPTION
- Calibrated time and calibrated energy were switched which results in wrong values energy and time in the AO2D file