### PR TITLE
MCH: added time information to Track class

### DIFF
--- a/DataFormats/Detectors/MUON/MCH/CMakeLists.txt
+++ b/DataFormats/Detectors/MUON/MCH/CMakeLists.txt
@@ -38,3 +38,9 @@ o2_add_test(digit
             COMPONENT_NAME mch
             LABELS muon;mch)
 
+o2_add_test(track
+            SOURCES src/testTrackMCH.cxx
+            PUBLIC_LINK_LIBRARIES O2::MCHBase
+            COMPONENT_NAME mch
+            LABELS muon;mch)
+

--- a/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h
+++ b/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h
@@ -110,9 +110,7 @@ class TrackMCH
   /// set the number of the clusters attached to the track and the index of the first one
   void setClusterRef(int firstClusterIdx, int nClusters) { mClusRef.set(firstClusterIdx, nClusters); }
 
-  /// get the interaction record associated to this track
-  InteractionRecord getIR(uint32_t refOrbit) const;
-
+  /// mean time associated to this track, with error
   const Time& getTimeMUS() const { return mTimeMUS; }
   Time& getTimeMUS() { return mTimeMUS; }
   void setTimeMUS(const Time& t) { mTimeMUS = t; }
@@ -121,6 +119,9 @@ class TrackMCH
     mTimeMUS.setTimeStamp(t);
     mTimeMUS.setTimeStampError(te);
   }
+
+  /// interaction record corresponding to the mean track time
+  InteractionRecord getMeanIR(uint32_t refOrbit) const;
 
  private:
   static constexpr int SNParams = 5;  ///< number of track parameters
@@ -151,7 +152,7 @@ class TrackMCH
   double mZAtMID = 0.;                 ///< z position on the MID side where the parameters are evaluated
   double mParamAtMID[SNParams] = {0.}; ///< 5 parameters: X (cm), SlopeX, Y (cm), SlopeY, q/pYZ ((GeV/c)^-1)
   double mCovAtMID[SCovSize] = {0.};   ///< reduced covariance matrix of track parameters, formated as above
-  Time mTimeMUS;                       ///< associated time in microseconds from the TF start
+  Time mTimeMUS{};                     ///< associated time in microseconds from the TF start
 
   ClassDefNV(TrackMCH, 3);
 };

--- a/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h
+++ b/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h
@@ -21,6 +21,8 @@
 #include <iosfwd>
 
 #include "CommonDataFormat/RangeReference.h"
+#include "CommonDataFormat/InteractionRecord.h"
+#include "CommonDataFormat/TimeStamp.h"
 
 namespace o2
 {
@@ -31,6 +33,7 @@ namespace mch
 class TrackMCH
 {
   using ClusRef = o2::dataformats::RangeRefComp<5>;
+  using Time = o2::dataformats::TimeStampWithError<float, float>;
 
  public:
   TrackMCH() = default;
@@ -107,6 +110,18 @@ class TrackMCH
   /// set the number of the clusters attached to the track and the index of the first one
   void setClusterRef(int firstClusterIdx, int nClusters) { mClusRef.set(firstClusterIdx, nClusters); }
 
+  /// get the interaction record associated to this track
+  InteractionRecord getIR(uint32_t refOrbit) const;
+
+  const Time& getTimeMUS() const { return mTimeMUS; }
+  Time& getTimeMUS() { return mTimeMUS; }
+  void setTimeMUS(const Time& t) { mTimeMUS = t; }
+  void setTimeMUS(float t, float te)
+  {
+    mTimeMUS.setTimeStamp(t);
+    mTimeMUS.setTimeStampError(te);
+  }
+
  private:
   static constexpr int SNParams = 5;  ///< number of track parameters
   static constexpr int SCovSize = 15; ///< number of different elements in the symmetric covariance matrix
@@ -136,8 +151,9 @@ class TrackMCH
   double mZAtMID = 0.;                 ///< z position on the MID side where the parameters are evaluated
   double mParamAtMID[SNParams] = {0.}; ///< 5 parameters: X (cm), SlopeX, Y (cm), SlopeY, q/pYZ ((GeV/c)^-1)
   double mCovAtMID[SCovSize] = {0.};   ///< reduced covariance matrix of track parameters, formated as above
+  Time mTimeMUS;                       ///< associated time in microseconds from the TF start
 
-  ClassDefNV(TrackMCH, 2);
+  ClassDefNV(TrackMCH, 3);
 };
 
 std::ostream& operator<<(std::ostream& os, const TrackMCH& t);

--- a/DataFormats/Detectors/MUON/MCH/src/TrackMCH.cxx
+++ b/DataFormats/Detectors/MUON/MCH/src/TrackMCH.cxx
@@ -17,7 +17,6 @@
 #include "DataFormatsMCH/TrackMCH.h"
 
 #include <cmath>
-#include <limits>
 #include <fmt/format.h>
 #include <string>
 #include <iostream>
@@ -88,25 +87,11 @@ void TrackMCH::setCovariances(const TMatrixD& src, double (&dest)[SCovSize])
 }
 
 //__________________________________________________________________________
-InteractionRecord TrackMCH::getIR(uint32_t refOrbit) const
+InteractionRecord TrackMCH::getMeanIR(uint32_t refOrbit) const
 {
-  // track time converted in bunch-crossing units
-  auto fbc = mTimeMUS.getTimeStamp() / o2::constants::lhc::LHCBunchSpacingMUS;
-  // wrap-up one full orbit if the track time is negative,
-  // the first TF orbit is also decreased by one to compensate
-  if (fbc < 0) {
-    fbc += o2::constants::lhc::LHCMaxBunches;
-    refOrbit -= 1;
-  }
-
-  // get the bc-in-orbit value
-  uint64_t trackBCinTF = uint64_t(std::round(fbc));
-  uint16_t trackBC = uint16_t(trackBCinTF % o2::constants::lhc::LHCMaxBunches);
-  // get the absolute track orbit by adding the first orbit of the current TF
-  uint32_t trackOrbit = uint32_t(trackBCinTF / o2::constants::lhc::LHCMaxBunches) + refOrbit;
-
-  // build the track interaction record
-  return {trackBC, trackOrbit};
+  InteractionRecord startIR(0, refOrbit);
+  auto trackBCinTF = std::llround(mTimeMUS.getTimeStamp() / constants::lhc::LHCBunchSpacingMUS);
+  return startIR + trackBCinTF;
 }
 
 std::ostream& operator<<(std::ostream& os, const o2::mch::TrackMCH& t)

--- a/DataFormats/Detectors/MUON/MCH/src/TrackMCH.cxx
+++ b/DataFormats/Detectors/MUON/MCH/src/TrackMCH.cxx
@@ -17,6 +17,7 @@
 #include "DataFormatsMCH/TrackMCH.h"
 
 #include <cmath>
+#include <limits>
 #include <fmt/format.h>
 #include <string>
 #include <iostream>

--- a/DataFormats/Detectors/MUON/MCH/src/TrackMCH.cxx
+++ b/DataFormats/Detectors/MUON/MCH/src/TrackMCH.cxx
@@ -87,6 +87,28 @@ void TrackMCH::setCovariances(const TMatrixD& src, double (&dest)[SCovSize])
   }
 }
 
+//__________________________________________________________________________
+InteractionRecord TrackMCH::getIR(uint32_t refOrbit) const
+{
+  // track time converted in bunch-crossing units
+  auto fbc = mTimeMUS.getTimeStamp() / o2::constants::lhc::LHCBunchSpacingMUS;
+  // wrap-up one full orbit if the track time is negative,
+  // the first TF orbit is also decreased by one to compensate
+  if (fbc < 0) {
+    fbc += o2::constants::lhc::LHCMaxBunches;
+    refOrbit -= 1;
+  }
+
+  // get the bc-in-orbit value
+  uint64_t trackBCinTF = uint64_t(std::round(fbc));
+  uint16_t trackBC = uint16_t(trackBCinTF % o2::constants::lhc::LHCMaxBunches);
+  // get the absolute track orbit by adding the first orbit of the current TF
+  uint32_t trackOrbit = uint32_t(trackBCinTF / o2::constants::lhc::LHCMaxBunches) + refOrbit;
+
+  // build the track interaction record
+  return {trackBC, trackOrbit};
+}
+
 std::ostream& operator<<(std::ostream& os, const o2::mch::TrackMCH& t)
 {
   os << asString(t);

--- a/DataFormats/Detectors/MUON/MCH/src/testTrackMCH.cxx
+++ b/DataFormats/Detectors/MUON/MCH/src/testTrackMCH.cxx
@@ -1,0 +1,57 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <boost/test/tools/old/interface.hpp>
+#define BOOST_TEST_MODULE MCH TrackMCH
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include <boost/test/data/test_case.hpp>
+#include <boost/test/data/monomorphic.hpp>
+
+#include "DataFormatsMCH/TrackMCH.h"
+
+BOOST_AUTO_TEST_CASE(TrackIRMatchesTrackTime)
+{
+  uint16_t bc{10};
+  uint32_t orbit{2000};
+  uint32_t orbitRef = orbit - 120;
+  o2::InteractionRecord ir{bc, orbit};
+  o2::InteractionRecord irRef{0, orbitRef};
+
+  o2::mch::TrackMCH track;
+
+  auto bcDiff = ir.differenceInBC(irRef);
+  float tMean = o2::constants::lhc::LHCBunchSpacingMUS * bcDiff;
+  float tErr = 6.0 * o2::constants::lhc::LHCBunchSpacingMUS;
+  track.setTimeMUS(tMean, tErr);
+
+  o2::InteractionRecord trackIR = track.getIR(orbitRef);
+  BOOST_CHECK_EQUAL(ir, trackIR);
+}
+
+BOOST_AUTO_TEST_CASE(TrackIRMatchesNegativeTrackTime)
+{
+  uint16_t bc{10};
+  uint32_t orbit{2000};
+  uint32_t orbitRef = orbit + 1;
+  o2::InteractionRecord ir{bc, orbit};
+  o2::InteractionRecord irRef{0, orbitRef};
+
+  o2::mch::TrackMCH track;
+
+  auto bcDiff = ir.differenceInBC(irRef);
+  float tMean = o2::constants::lhc::LHCBunchSpacingMUS * bcDiff;
+  float tErr = 6.0 * o2::constants::lhc::LHCBunchSpacingMUS;
+  track.setTimeMUS(tMean, tErr);
+
+  o2::InteractionRecord trackIR = track.getIR(orbitRef);
+  BOOST_CHECK_EQUAL(ir, trackIR);
+}

--- a/DataFormats/Detectors/MUON/MCH/src/testTrackMCH.cxx
+++ b/DataFormats/Detectors/MUON/MCH/src/testTrackMCH.cxx
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE(TrackIRMatchesTrackTime)
   float tErr = 6.0 * o2::constants::lhc::LHCBunchSpacingMUS;
   track.setTimeMUS(tMean, tErr);
 
-  o2::InteractionRecord trackIR = track.getIR(orbitRef);
+  o2::InteractionRecord trackIR = track.getMeanIR(orbitRef);
   BOOST_CHECK_EQUAL(ir, trackIR);
 }
 
@@ -52,6 +52,6 @@ BOOST_AUTO_TEST_CASE(TrackIRMatchesNegativeTrackTime)
   float tErr = 6.0 * o2::constants::lhc::LHCBunchSpacingMUS;
   track.setTimeMUS(tMean, tErr);
 
-  o2::InteractionRecord trackIR = track.getIR(orbitRef);
+  o2::InteractionRecord trackIR = track.getMeanIR(orbitRef);
   BOOST_CHECK_EQUAL(ir, trackIR);
 }

--- a/Detectors/MUON/MCH/Workflow/src/TrackFinderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackFinderSpec.cxx
@@ -22,7 +22,6 @@
 #include <stdexcept>
 #include <string>
 #include <filesystem>
-#include <limits>
 
 #include <gsl/span>
 
@@ -155,78 +154,31 @@ class TrackFinderTask
   }
 
  private:
-  std::pair<InteractionRecord, bool> trackBC2IR(double trackBCinTF, const ROFRecord& trackROF, uint32_t firstTForbit) const
+  void setTrackTime(TrackMCH& track, const ROFRecord& clusterROF, uint32_t firstTForbit, const gsl::span<const Cluster> usedClusters, const gsl::span<const Digit> usedDigits) const
   {
-    // limits of the current ROF
-    const InteractionRecord& rofStart = trackROF.getBCData();
-    const InteractionRecord& rofEnd = trackROF.getBCData() + int64_t(trackROF.getBCWidth());
-
-    // wrap-up one full orbit if the track time is negative,
-    // the first TF orbit is also decreased by one to compensate
-    if (trackBCinTF < 0) {
-      trackBCinTF += o2::constants::lhc::LHCMaxBunches;
-      firstTForbit -= 1;
-    }
-
-    // get the bc-in-orbit value
-    uint16_t trackBC = uint16_t(uint64_t(trackBCinTF) % o2::constants::lhc::LHCMaxBunches);
-    // get the absolute track orbit by adding the first orbit of the current TF
-    uint32_t trackOrbit = uint32_t(uint64_t(trackBCinTF) / o2::constants::lhc::LHCMaxBunches) + firstTForbit;
-
-    // build the track interaction record
-    InteractionRecord trackIR{trackBC, trackOrbit};
-
-    // if we are outside the cluster ROF, something must be wrong
-    // in this case we log a warning message and we return a default IR value
-    bool isOk = true;
-    if (trackIR < rofStart || trackIR > rofEnd) {
-      LOG(warning) << fmt::format("track time incompatible with track ROF. TRACK: BC={}, IR={},{}  ROF: start={},{}, end={},{}  FIRST_TF_ORBIT: {}",
-                                  trackBCinTF, trackIR.orbit, trackIR.bc, rofStart.orbit, rofStart.bc, rofEnd.orbit, rofEnd.bc, firstTForbit);
-      isOk = false;
-    }
-
-    return {trackIR, isOk};
-  }
-
-  //_________________________________________________________________________________________________
-  void setTrackTimeFromROF(TrackMCH& track, const ROFRecord& trackROF, uint32_t firstTForbit) const
-  {
-    // the track time is taken at the middle of the track ROF,
-    // in microseconds relative to the beginning of the TF
-    InteractionRecord startIR{0, firstTForbit};
-    float rofHalfWidth = 0.5 * trackROF.getBCWidth();
-    auto ir = trackROF.getBCData();
-    float bcDiff = ir.differenceInBC(startIR);
-    bcDiff += rofHalfWidth;
-    float tMean = o2::constants::lhc::LHCBunchSpacingMUS * bcDiff;
-    // the time resolution is estimated as the half-width of the track ROF
-    float tErr = o2::constants::lhc::LHCBunchSpacingMUS * rofHalfWidth;
-    track.setTimeMUS(tMean, tErr);
-  }
-
-  //_________________________________________________________________________________________________
-  void setTrackTime(TrackMCH& track, const ROFRecord& trackROF, uint32_t firstTForbit, const gsl::span<const Cluster> usedClusters, const gsl::span<const Digit> usedDigits) const
-  {
-    float trackBCinTF = 0;
+    double trackBCinTF = 0;
     int nDigits = 0;
 
     // loop over digits and compute the average track time
     for (const auto& cluster : usedClusters.subspan(track.getFirstClusterIdx(), track.getNClusters())) {
       for (const auto& digit : usedDigits.subspan(cluster.firstDigit, cluster.nDigits)) {
         nDigits += 1;
-        trackBCinTF += (float(digit.getTime()) - trackBCinTF) / nDigits;
+        trackBCinTF += (double(digit.getTime()) - trackBCinTF) / nDigits;
       }
     }
 
     // set the track IR from the computed average digits time
     if (nDigits > 0) {
-      float tMean = o2::constants::lhc::LHCBunchSpacingMUS * trackBCinTF;
+      // convert the average digit time from bunch-crossing units to microseconds
+      // add 1.5 BC to account for the fact that the actual digit time in BC units
+      // can be between t and t+3, hence t+1.5 in average
+      float tMean = o2::constants::lhc::LHCBunchSpacingMUS * (trackBCinTF + 1.5);
       float tErr = o2::constants::lhc::LHCBunchSpacingMUS * mTrackTime3Sigma;
       track.setTimeMUS(tMean, tErr);
     } else {
       // if no digits are found, compute the time directly from the track's ROF
-      LOG(warning) << "no digits found when computing the track mean time";
-      setTrackTimeFromROF(track, trackROF, firstTForbit);
+      LOG(fatal) << "MCH: no digits found when computing the track mean time";
+      track.setTimeMUS(clusterROF.getTimeMUS({0, firstTForbit}).first);
     }
   }
 
@@ -277,16 +229,16 @@ class TrackFinderTask
       }
 
       // compute the track time
-      if (mDigits && usedDigits) {
+      if (mDigits) {
         setTrackTime(mchTracks.back(), clusterROF, firstTForbit, usedClusters, *usedDigits);
       } else {
-        setTrackTimeFromROF(mchTracks.back(), clusterROF, firstTForbit);
+        mchTracks.back().setTimeMUS(clusterROF.getTimeMUS({0, firstTForbit}).first);
       }
     }
   }
 
   bool mDigits = false;                         ///< send to associated digits
-  float mTrackTime3Sigma{6.0};                  ///< three times the track time resolution, in BC units
+  float mTrackTime3Sigma{6.0};                  ///< three times the digit time resolution, in BC units
   TrackFinder mTrackFinder{};                   ///< track finder
   std::chrono::duration<double> mElapsedTime{}; ///< timer
 };

--- a/Detectors/MUON/MCH/Workflow/src/TrackFinderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackFinderSpec.cxx
@@ -198,7 +198,7 @@ class TrackFinderTask
     auto ir = trackROF.getBCData();
     float bcDiff = ir.differenceInBC(startIR);
     bcDiff += rofHalfWidth;
-    float tMean =  o2::constants::lhc::LHCBunchSpacingMUS * bcDiff;
+    float tMean = o2::constants::lhc::LHCBunchSpacingMUS * bcDiff;
     // the time resolution is estimated as the half-width of the track ROF
     float tErr = o2::constants::lhc::LHCBunchSpacingMUS * rofHalfWidth;
     track.setTimeMUS(tMean, tErr);


### PR DESCRIPTION
The track time is computed as the average of the time of the associated digits.
If digits are not forwarded to the track finder, the track time is set as the start of the corresponding ROF.