### PR TITLE
Fix TPC Entropy encoder with dictionary from CCDB tree object

### DIFF
--- a/Detectors/TPC/workflow/src/EntropyEncoderSpec.cxx
+++ b/Detectors/TPC/workflow/src/EntropyEncoderSpec.cxx
@@ -109,7 +109,7 @@ void EntropyEncoderSpec::run(ProcessingContext& pc)
     }
   }
 
-  mCTFCoder.updateTimeDependentParams(pc);
+  mCTFCoder.updateTimeDependentParams(pc, true);
 
   CompressedClusters clusters;
 


### PR DESCRIPTION
@shahor02 : I assume we need this as well for the entropy encoder? (You sent it to me only for the decoder).
At least I have seen it crashing. Actually I don't understand how it passed the FullCI before...