### PR TITLE
Special treatment for shifts of ZDC triggers at BC=0,3563

### DIFF
--- a/Detectors/Base/include/DetectorsBase/CTFCoderBase.h
+++ b/Detectors/Base/include/DetectorsBase/CTFCoderBase.h
@@ -128,7 +128,7 @@ class CTFCoderBase
 
   void setBCShift(int64_t n) { mBCShift = n; }
   void setFirstTFOrbit(uint32_t n) { mFirstTFOrbit = n; }
-  auto getBCShist() const { return mBCShift; }
+  auto getBCShift() const { return mBCShift; }
   auto getFirstTFOrbit() const { return mFirstTFOrbit; }
   void setSupportBCShifts(bool v = true) { mSupportBCShifts = v; }
   bool getSupportBCShifts() const { return mSupportBCShifts; }
@@ -137,11 +137,13 @@ class CTFCoderBase
   std::string getPrefix() const { return o2::utils::Str::concat_string(mDet.getName(), "_CTF: "); }
   void checkDictVersion(const CTFDictHeader& h) const;
   bool isTreeDictionary(const void* buff) const;
-  bool canApplyBCShift(const o2::InteractionRecord& ir) const
+  bool canApplyBCShift(const o2::InteractionRecord& ir, long shift) const
   {
     auto diff = ir.differenceInBC({0, mFirstTFOrbit});
-    return diff < 0 ? true : diff >= mBCShift;
+    return diff < 0 ? true : diff >= shift;
   }
+  bool canApplyBCShift(const o2::InteractionRecord& ir) const { return canApplyBCShift(ir, mBCShift); }
+
   template <typename CTF>
   std::vector<char> loadDictionaryFromTree(TTree* tree);
   std::vector<std::shared_ptr<void>> mCoders; // encoders/decoders

--- a/Detectors/ZDC/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/ZDC/workflow/src/EntropyDecoderSpec.cxx
@@ -17,6 +17,7 @@
 #include "Framework/ConfigParamRegistry.h"
 #include "Framework/CCDBParamSpec.h"
 #include "ZDCWorkflow/EntropyDecoderSpec.h"
+#include "CommonConstants/LHCConstants.h"
 
 using namespace o2::framework;
 
@@ -36,6 +37,11 @@ EntropyDecoderSpec::EntropyDecoderSpec(int verbosity) : mCTFCoder(o2::ctf::CTFCo
 void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
 {
   if (mCTFCoder.finaliseCCDB<CTF>(matcher, obj)) {
+    if (mCTFCoder.getBCShift()) {
+      long norb = mCTFCoder.getBCShift() / o2::constants::lhc::LHCMaxBunches;
+      mCTFCoder.setBCShiftOrbits(norb * o2::constants::lhc::LHCMaxBunches);
+      LOGP(info, "BCs 0 and 3563 will be corrected only for {} BCs (= {} integer orbits)", mCTFCoder.getBCShiftOrbits(), norb);
+    }
     return;
   }
 }


### PR DESCRIPTION
These special triggers can be shifted only orbit-wise but the BC must remain unchanged