### PR TITLE
Add standalone CTP digit writer

### DIFF
--- a/Detectors/CTP/workflowIO/CMakeLists.txt
+++ b/Detectors/CTP/workflowIO/CMakeLists.txt
@@ -16,3 +16,8 @@ o2_add_library(CTPWorkflowIO
                                      O2::DPLUtils
                                      O2::DetectorsRaw
                                      O2::Algorithm)
+
+o2_add_executable(digit-writer
+                  COMPONENT_NAME ctp
+                  SOURCES src/digits-writer-workflow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::CTPWorkflowIO)

--- a/Detectors/CTP/workflowIO/src/digits-writer-workflow.cxx
+++ b/Detectors/CTP/workflowIO/src/digits-writer-workflow.cxx
@@ -1,0 +1,44 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
+
+using namespace o2::framework;
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  std::vector<o2::framework::ConfigParamSpec> options{
+    {"no-lumi", o2::framework::VariantType::Bool, false, {"write only digits as from MC instead of digits/lumi of raw mode"}},
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
+  std::swap(workflowOptions, options);
+}
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  // ordered policies for the writers
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:CTP|ctp).*[W,w]riter.*"));
+}
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/WorkflowSpec.h"
+#include "CTPWorkflowIO/DigitWriterSpec.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
+  WorkflowSpec specs;
+  specs.emplace_back(o2::ctp::getDigitWriterSpec(!configcontext.options().get<bool>("no-lumi")));
+  return std::move(specs);
+}

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -457,6 +457,10 @@ if [[ ! -z "$EXTRA_WORKFLOW" ]]; then
   WORKFLOW+="$EXTRA_WORKFLOW"
 fi
 
+if [[ ! -z "$ADD_EXTRA_WORKFLOW" ]]; then
+  add_W $ADD_EXTRA_WORKFLOW
+fi
+
 # ---------------------------------------------------------------------------------------------------------------------
 # DPL run binary
 WORKFLOW+="o2-dpl-run $ARGS_ALL $GLOBALDPLOPT"


### PR DESCRIPTION
It is not explicitly in the dpl-workflow via any option but can be added as a custom workflow via
`ADD_EXTRA_WORKFLOW=o2-ctp-digit-writer`

@davidrohr I see you have added already https://github.com/AliceO2Group/AliceO2/blob/e93f18dfaa27ad2e0fe57a34370da4cdc1be4789/prodtests/full-system-test/dpl-workflow.sh#L456-L458 but I don't see how this can work in general unless one guesses correctly options added via  `$ARGS_ALL`