### PR TITLE
Use DataProcessorContext and StreamContext to handle callbacks

### DIFF
--- a/Detectors/TOF/compression/src/CompressorTask.cxx
+++ b/Detectors/TOF/compression/src/CompressorTask.cxx
@@ -63,6 +63,10 @@ void CompressorTask<RDH, verbose, paranoid>::run(ProcessingContext& pc)
 
   auto device = pc.services().get<o2::framework::RawDeviceService>().device();
   auto outputRoutes = pc.services().get<o2::framework::RawDeviceService>().spec().outputs;
+  if (outputRoutes.size() != 1) {
+    LOG(error) << "Compressor output routes size != 1";
+    return;
+  }
   auto fairMQChannel = outputRoutes.at(0).channel;
   fair::mq::Parts partsOut;
 

--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -53,6 +53,7 @@ o2_add_library(Framework
                        src/DataProcessingHelpers.cxx
                        src/DataProcessorSpecHelpers.cxx
                        src/DataProcessorMatchers.cxx
+                       src/DataProcessingContext.cxx
                        src/DataRefUtils.cxx
                        src/SourceInfoHeader.cxx
                        src/DataProcessor.cxx
@@ -114,6 +115,7 @@ o2_add_library(Framework
                        src/SimpleResourceManager.cxx
                        src/SimpleRawDeviceService.cxx
                        src/StreamOperators.cxx
+                       src/StreamContext.cxx
                        src/TMessageSerializer.cxx
                        src/TableBuilder.cxx
                        src/TableConsumer.cxx

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -647,6 +647,7 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
                              *task.get());
       eosContext.services().get<ControlService>().readyToQuit(QuitRequest::Me);
     };
+
     callbacks.set(CallbackService::Id::EndOfStream, endofdatacb);
 
     /// update configurables in filters

--- a/Framework/Core/include/Framework/ArrowContext.h
+++ b/Framework/Core/include/Framework/ArrowContext.h
@@ -32,6 +32,8 @@ class FairMQResizableBuffer;
 class ArrowContext
 {
  public:
+  constexpr static ServiceKind service_kind = ServiceKind::Stream;
+
   ArrowContext(FairMQDeviceProxy& proxy)
     : mProxy{proxy}
   {

--- a/Framework/Core/include/Framework/CommonServices.h
+++ b/Framework/Core/include/Framework/CommonServices.h
@@ -81,6 +81,7 @@ struct CommonServices {
   static ServiceSpec asyncQueue();
   static ServiceSpec guiMetricsSpec();
   static ServiceSpec dataAllocatorSpec();
+  static ServiceSpec streamContextSpec();
 
   static std::vector<ServiceSpec> defaultServices(int numWorkers = 0);
   static std::vector<ServiceSpec> requiredServices();

--- a/Framework/Core/include/Framework/DataSender.h
+++ b/Framework/Core/include/Framework/DataSender.h
@@ -37,6 +37,16 @@ class DataSender
              SendingPolicy const& policy);
   void send(fair::mq::Parts&, ChannelIndex index);
   std::unique_ptr<fair::mq::Message> create(RouteIndex index);
+  /// Reset the datasender to a clean state
+  /// so that we can track what whill be sent in the next
+  /// iteration and eventually complain if one of the
+  /// Lifetime::Timeframe is not create / sent.
+  void reset();
+  /// Actually verify if all the selected outputs have been sent.
+  /// Notice how I think there are a few cases in which we might
+  /// have a false positive, since I one could have a completion policy
+  /// which creates two required messages in two different iterations.
+  void verifyMissingSporadic() const;
 
  private:
   FairMQDeviceProxy& mProxy;
@@ -51,6 +61,8 @@ class DataSender
   std::vector<std::string> mMetricsNames;
   std::vector<std::string> mVariablesMetricsNames;
   std::vector<std::string> mQueriesMetricsNames;
+  std::vector<bool> mPresent;
+  std::vector<bool> mPresentDefaults;
 
   TracyLockableN(std::recursive_mutex, mMutex, "data relayer mutex");
 };

--- a/Framework/Core/include/Framework/DataTakingContext.h
+++ b/Framework/Core/include/Framework/DataTakingContext.h
@@ -11,6 +11,7 @@
 #ifndef O2_FRAMEWORK_DATATAKINGCONTEXT_H_
 #define O2_FRAMEWORK_DATATAKINGCONTEXT_H_
 
+#include "Framework/ServiceHandle.h"
 #include <string>
 #include <cstdint>
 
@@ -18,6 +19,7 @@ namespace o2::framework
 {
 
 struct DataTakingContext {
+  constexpr static ServiceKind service_kind = ServiceKind::Stream;
   static constexpr const char* UNKNOWN = "unknown";
   /// The current run number
   std::string runNumber{UNKNOWN};

--- a/Framework/Core/include/Framework/MessageContext.h
+++ b/Framework/Core/include/Framework/MessageContext.h
@@ -53,6 +53,8 @@ struct Output;
 class MessageContext
 {
  public:
+  constexpr static ServiceKind service_kind = ServiceKind::Stream;
+
   // so far we are only using one instance per named channel
   static constexpr int DefaultChannelIndex = 0;
 
@@ -110,12 +112,12 @@ class MessageContext
     }
 
     /// @brief return the channel name
-    RouteIndex route() const
+    [[nodiscard]] RouteIndex route() const
     {
       return mRouteIndex;
     }
 
-    bool empty() const
+    [[nodiscard]] bool empty() const
     {
       return mParts.Size() == 0;
     }
@@ -212,7 +214,7 @@ class MessageContext
       return mUpstream->getTransportFactory();
     }
 
-    size_t getNumberOfMessages() const noexcept override
+    [[nodiscard]] size_t getNumberOfMessages() const noexcept override
     {
       return mUpstream->getNumberOfMessages();
     }
@@ -228,7 +230,7 @@ class MessageContext
       return mUpstream->deallocate(p, bytes, alignment < 64 ? 64 : alignment);
     }
 
-    bool do_is_equal(const pmr::memory_resource& other) const noexcept override
+    [[nodiscard]] bool do_is_equal(const pmr::memory_resource& other) const noexcept override
     {
       return this == &other;
     }
@@ -511,7 +513,7 @@ class MessageContext
   // such cached message.
   int64_t addToCache(std::unique_ptr<fair::mq::Message>& message);
   // Clone a message from cache so that it can be added to the context
-  std::unique_ptr<fair::mq::Message> cloneFromCache(int64_t id) const;
+  [[nodiscard]] std::unique_ptr<fair::mq::Message> cloneFromCache(int64_t id) const;
   // Prune a message from cache
   void pruneFromCache(int64_t id);
 

--- a/Framework/Core/include/Framework/O2DataModelHelpers.h
+++ b/Framework/Core/include/Framework/O2DataModelHelpers.h
@@ -70,7 +70,16 @@ struct O2DataModelHelpers {
     }
     return true;
   }
-  static bool checkForMissingSporadic(fair::mq::Parts& parts, std::vector<OutputSpec> const& specs, std::vector<bool>& present);
+  static void updateMissingSporadic(fair::mq::Parts& parts, std::vector<OutputSpec> const& specs, std::vector<bool>& present);
+  static bool validateOutputs(std::vector<bool>& present)
+  {
+    for (auto p : present) {
+      if (!p) {
+        return false;
+      }
+    }
+    return true;
+  }
   static std::string describeMissingOutputs(std::vector<OutputSpec> const& specs, std::vector<bool> const& present);
 };
 } // namespace o2::framework

--- a/Framework/Core/include/Framework/RawBufferContext.h
+++ b/Framework/Core/include/Framework/RawBufferContext.h
@@ -28,6 +28,8 @@ namespace o2::framework
 class RawBufferContext
 {
  public:
+  constexpr static ServiceKind service_kind = ServiceKind::Stream;
+
   RawBufferContext(FairMQDeviceProxy& proxy)
     : mProxy{proxy}
   {

--- a/Framework/Core/include/Framework/ServiceRegistry.h
+++ b/Framework/Core/include/Framework/ServiceRegistry.h
@@ -178,32 +178,6 @@ struct ServiceRegistry {
     return Index{static_cast<int32_t>(id.id & MAX_SERVICES_MASK)};
   }
 
-  /// Callbacks for services to be executed before every process method invokation
-  mutable std::vector<ServiceProcessingHandle> mPreProcessingHandles;
-  /// Callbacks for services to be executed after every process method invokation
-  mutable std::vector<ServiceProcessingHandle> mPostProcessingHandles;
-  /// Callbacks for services to be executed before every dangling check
-  mutable std::vector<ServiceDanglingHandle> mPreDanglingHandles;
-  /// Callbacks for services to be executed after every dangling check
-  mutable std::vector<ServiceDanglingHandle> mPostDanglingHandles;
-  /// Callbacks for services to be executed before every EOS user callback invokation
-  mutable std::vector<ServiceEOSHandle> mPreEOSHandles;
-  /// Callbacks for services to be executed after every EOS user callback invokation
-  mutable std::vector<ServiceEOSHandle> mPostEOSHandles;
-  /// Callbacks for services to be executed after every dispatching
-  mutable std::vector<ServiceDispatchingHandle> mPostDispatchingHandles;
-  /// Callbacks for services to be executed after every dispatching
-  mutable std::vector<ServiceForwardingHandle> mPostForwardingHandles;
-  /// Callbacks for services to be executed before Start
-  mutable std::vector<ServiceStartHandle> mPreStartHandles;
-  /// Callbacks for services to be executed on the Stop transition
-  mutable std::vector<ServiceStopHandle> mPostStopHandles;
-  /// Callbacks for services to be executed on exit
-  mutable std::vector<ServiceExitHandle> mPreExitHandles;
-  /// Callbacks for services to be executed on exit
-  mutable std::vector<ServiceDomainInfoHandle> mDomainInfoHandles;
-  /// Callbacks for services to be executed before sending messages
-  mutable std::vector<ServicePreSendingMessagesHandle> mPreSendingMessagesHandles;
   /// Callbacks to be executed after the main GUI has been drawn
   mutable std::vector<ServicePostRenderGUIHandle> mPostRenderGUIHandles;
 
@@ -217,36 +191,8 @@ struct ServiceRegistry {
   ServiceRegistry(ServiceRegistry const& other);
   ServiceRegistry& operator=(ServiceRegistry const& other);
 
-  /// Invoke callbacks to be executed in PreRun(), before the User Start callbacks
-  void preStartCallbacks();
-  /// Invoke callbacks to be executed before every process method invokation
-  void preProcessingCallbacks(ProcessingContext&);
-  /// Invoke callbacks to be executed after every process method invokation
-  void postProcessingCallbacks(ProcessingContext&);
-  /// Invoke callbacks to be executed before every dangling check
-  void preDanglingCallbacks(DanglingContext&);
-  /// Invoke callbacks to be executed after every dangling check
-  void postDanglingCallbacks(DanglingContext&);
-  /// Invoke callbacks to be executed before every EOS user callback invokation
-  void preEOSCallbacks(EndOfStreamContext&);
-  /// Invoke callbacks to be executed after every EOS user callback invokation
-  void postEOSCallbacks(EndOfStreamContext&);
-  /// Invoke callbacks to monitor inputs after dispatching, regardless of them
-  /// being discarded, consumed or processed.
-  void postDispatchingCallbacks(ProcessingContext&);
-  /// Callback invoked after the late forwarding has been done
-  void postForwardingCallbacks(ProcessingContext&);
-
-  /// Invoke callbacks on stop.
-  void postStopCallbacks();
   /// Invoke callbacks on exit.
   void preExitCallbacks();
-
-  /// Invoke whenever we get a new DomainInfo message
-  void domainInfoUpdatedCallback(ServiceRegistry& registry, size_t oldestPossibleTimeslice, ChannelIndex channelIndex);
-
-  /// Invoke before sending messages @a parts on a channel @a channelindex
-  void preSendingMessagesCallbacks(ServiceRegistry& registry, fair::mq::Parts& parts, ChannelIndex channelindex);
 
   /// Invoke after rendering the GUI. Can be used to
   /// add custom GUI elements associated to a given service.
@@ -262,9 +208,9 @@ struct ServiceRegistry {
   /// FIXME: for now we create everything in the global context
   void declareService(ServiceSpec const& spec, DeviceState& state, fair::mq::ProgOptions& options, ServiceRegistry::Salt salt = ServiceRegistry::globalDeviceSalt());
 
-  /// Bind the callbacks of a service spec to a given service.
-  /// Notice that
-  void bindService(ServiceSpec const& spec, void* service) const;
+  void bindService(ServiceRegistry::Salt salt, ServiceSpec const& spec, void* service) const;
+
+  void lateBindStreamServices(DeviceState& state, fair::mq::ProgOptions& options, ServiceRegistry::Salt salt);
 
   /// Type erased service registration. @a typeHash is the
   /// hash used to identify the service, @a service is
@@ -360,6 +306,11 @@ struct ServiceRegistry {
     throwError(runtime_error_f("Unable to find service of kind %s (%d) in stream %d and dataprocessor %d. Make sure you use const / non-const correctly.", typeid(T).name(), typeHash.hash, salt.streamId, salt.dataProcessorId));
     O2_BUILTIN_UNREACHABLE();
   }
+
+  /// Callback invoked by the driver after rendering.
+  /// FIXME: Needs to stay here for the moment as it is used by
+  /// the driver and not by one of the data processors.
+  void postRenderGUICallbacks(ServiceRegistryRef ref);
 };
 
 } // namespace o2::framework

--- a/Framework/Core/include/Framework/ServiceRegistryRef.h
+++ b/Framework/Core/include/Framework/ServiceRegistryRef.h
@@ -58,12 +58,6 @@ class ServiceRegistryRef
     return mRegistry.get<T>(mSalt);
   }
 
-  /// Invoke before sending messages @a parts on a channel @a channelindex
-  void preSendingMessagesCallbacks(fair::mq::Parts& parts, ChannelIndex channelindex)
-  {
-    mRegistry.preSendingMessagesCallbacks(mRegistry, parts, channelindex);
-  }
-
   void registerService(ServiceTypeHash typeHash, void* service, ServiceKind kind, char const* name = nullptr) const
   {
     mRegistry.registerService(typeHash, service, kind, mSalt, name);

--- a/Framework/Core/include/Framework/ServiceSpec.h
+++ b/Framework/Core/include/Framework/ServiceSpec.h
@@ -259,6 +259,12 @@ struct ServiceStartHandle {
   void* service;
 };
 
+struct ServiceStartStreamHandle {
+  ServiceSpec const& spec;
+  ServiceStartCallback callback;
+  void* service;
+};
+
 struct ServiceStopHandle {
   ServiceSpec const& spec;
   ServiceStopCallback callback;

--- a/Framework/Core/include/Framework/StreamContext.h
+++ b/Framework/Core/include/Framework/StreamContext.h
@@ -1,0 +1,66 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef O2_FRAMEWORK_STREAMCONTEXT_H_
+#define O2_FRAMEWORK_STREAMCONTEXT_H_
+
+#include "Framework/ServiceHandle.h"
+#include "ProcessingContext.h"
+#include "ServiceSpec.h"
+#include <functional>
+
+namespace o2::framework
+{
+
+struct ProcessingContext;
+
+/// This context exists only for a given stream,
+/// it can therefore be used for e.g. callbacks
+/// which need to happen on a per stream basis
+/// or for caching information which is specific
+/// to a given stream (like wether or not we processed
+/// something in the current iteration).
+struct StreamContext {
+  constexpr static ServiceKind service_kind = ServiceKind::Stream;
+
+  // Invoked once per stream before we start processing
+  // They are all guaranteed to be invoked before the PreRun
+  // function terminates.
+  // Notice this will mean that a StreamService which has
+  // a start callback might be created upfront.
+  void preStartStreamCallbacks(ServiceRegistryRef);
+
+  void preProcessingCallbacks(ProcessingContext& pcx);
+  void postProcessingCallbacks(ProcessingContext& pcx);
+
+  /// Invoke callbacks to be executed before every EOS user callback invokation
+  void preEOSCallbacks(EndOfStreamContext& eosContext);
+  /// Invoke callbacks to be executed after every EOS user callback invokation
+  void postEOSCallbacks(EndOfStreamContext& eosContext);
+
+  /// Callbacks for services to be executed before every process method invokation
+  std::vector<ServiceProcessingHandle> preProcessingHandles;
+  /// Callbacks for services to be executed after every process method invokation
+  std::vector<ServiceProcessingHandle> postProcessingHandles;
+
+  /// Callbacks for services to be executed before every EOS user callback invokation
+  std::vector<ServiceEOSHandle> preEOSHandles;
+  /// Callbacks for services to be executed after every EOS user callback invokation
+  std::vector<ServiceEOSHandle> postEOSHandles;
+
+  // Callbacks for services to be executed before a stream starts processing
+  // Notice that in such a case all the services will be created upfront, so
+  // the callback will be called for all of them.
+  std::vector<ServiceStartStreamHandle> preStartStreamHandles;
+};
+
+} // namespace o2::framework
+
+#endif // O2_FRAMEWORK_DATAPROCESSINGCONTEXT_H_

--- a/Framework/Core/include/Framework/StringContext.h
+++ b/Framework/Core/include/Framework/StringContext.h
@@ -29,6 +29,8 @@ namespace o2::framework
 class StringContext
 {
  public:
+  constexpr static ServiceKind service_kind = ServiceKind::Stream;
+
   StringContext(FairMQDeviceProxy& proxy)
     : mProxy(proxy)
   {

--- a/Framework/Core/src/CommonMessageBackends.cxx
+++ b/Framework/Core/src/CommonMessageBackends.cxx
@@ -70,6 +70,7 @@ o2::framework::ServiceSpec CommonMessageBackends::fairMQBackendSpec()
 {
   return ServiceSpec{
     .name = "fairmq-backend",
+    .uniqueId = CommonServices::simpleServiceId<MessageContext>(),
     .init = [](ServiceRegistryRef services, DeviceState&, fair::mq::ProgOptions&) -> ServiceHandle {
       auto& proxy = services.get<FairMQDeviceProxy>();
       auto context = new MessageContext(proxy);
@@ -90,42 +91,42 @@ o2::framework::ServiceSpec CommonMessageBackends::fairMQBackendSpec()
       if (spec.dispatchPolicy.action == DispatchPolicy::DispatchOp::WhenReady) {
         context->init(DispatchControl{dispatcher, matcher});
       }
-      return ServiceHandle{.hash = TypeIdHelpers::uniqueId<MessageContext>(), .instance = context, .kind = ServiceKind::Serial};
+      return ServiceHandle{.hash = TypeIdHelpers::uniqueId<MessageContext>(), .instance = context, .kind = ServiceKind::Stream};
     },
     .configure = CommonServices::noConfiguration(),
     .preProcessing = CommonMessageBackendsHelpers<MessageContext>::clearContext(),
     .postProcessing = CommonMessageBackendsHelpers<MessageContext>::sendCallback(),
     .preEOS = CommonMessageBackendsHelpers<MessageContext>::clearContextEOS(),
     .postEOS = CommonMessageBackendsHelpers<MessageContext>::sendCallbackEOS(),
-    .kind = ServiceKind::Serial};
+    .kind = ServiceKind::Stream};
 }
 
 o2::framework::ServiceSpec CommonMessageBackends::stringBackendSpec()
 {
   return ServiceSpec{
     .name = "string-backend",
+    .uniqueId = CommonServices::simpleServiceId<StringContext>(),
     .init = CommonMessageBackendsHelpers<StringContext>::createCallback(),
     .configure = CommonServices::noConfiguration(),
     .preProcessing = CommonMessageBackendsHelpers<StringContext>::clearContext(),
     .postProcessing = CommonMessageBackendsHelpers<StringContext>::sendCallback(),
     .preEOS = CommonMessageBackendsHelpers<StringContext>::clearContextEOS(),
     .postEOS = CommonMessageBackendsHelpers<StringContext>::sendCallbackEOS(),
-    .kind = ServiceKind::Serial};
+    .kind = ServiceKind::Stream};
 }
 
 o2::framework::ServiceSpec CommonMessageBackends::rawBufferBackendSpec()
 {
   return ServiceSpec{
     .name = "raw-backend",
+    .uniqueId = CommonServices::simpleServiceId<RawBufferContext>(),
     .init = CommonMessageBackendsHelpers<RawBufferContext>::createCallback(),
     .configure = CommonServices::noConfiguration(),
     .preProcessing = CommonMessageBackendsHelpers<RawBufferContext>::clearContext(),
     .postProcessing = CommonMessageBackendsHelpers<RawBufferContext>::sendCallback(),
     .preEOS = CommonMessageBackendsHelpers<RawBufferContext>::clearContextEOS(),
     .postEOS = CommonMessageBackendsHelpers<RawBufferContext>::sendCallbackEOS(),
-    .kind = ServiceKind::Serial};
+    .kind = ServiceKind::Stream};
 }
 
 } // namespace o2::framework
-
-#pragma GCC diagnostic pop

--- a/Framework/Core/src/CommonMessageBackendsHelpers.h
+++ b/Framework/Core/src/CommonMessageBackendsHelpers.h
@@ -31,7 +31,7 @@ struct CommonMessageBackendsHelpers {
   {
     return [](ServiceRegistryRef services, DeviceState&, fair::mq::ProgOptions& options) {
       auto& proxy = services.get<FairMQDeviceProxy>();
-      return ServiceHandle{TypeIdHelpers::uniqueId<T>(), new T(proxy)};
+      return ServiceHandle{TypeIdHelpers::uniqueId<T>(), new T(proxy), ServiceKind::Stream};
     };
   }
 

--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -321,6 +321,16 @@ o2::framework::ServiceSpec CommonServices::dataSender()
                            new DataSender(services, spec.sendingPolicy)};
     },
     .configure = noConfiguration(),
+    .preProcessing = [](ProcessingContext&, void* service) {
+      auto& dataSender = *reinterpret_cast<DataSender*>(service);
+      dataSender.reset(); },
+    .postDispatching = [](ProcessingContext& ctx, void* service) {
+      auto& dataSender = *reinterpret_cast<DataSender*>(service);
+      // If the quit was requested, the post dispatching can still happen
+      // but with an empty set of data.
+      if (ctx.services().get<DeviceState>().quitRequested == false) {
+        dataSender.verifyMissingSporadic();
+      } },
     .kind = ServiceKind::Serial};
 }
 

--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -37,6 +37,7 @@
 #include "Framework/Plugins.h"
 #include "Framework/DeviceContext.h"
 #include "Framework/DataProcessingContext.h"
+#include "Framework/StreamContext.h"
 #include "TextDriverClient.h"
 #include "WSDriverClient.h"
 #include "HTTPParser.h"
@@ -105,11 +106,14 @@ o2::framework::ServiceSpec CommonServices::monitoringSpec()
     },
     .configure = noConfiguration(),
     .start = [](ServiceRegistryRef services, void* service) {
-      auto* monitoring = (o2::monitoring::Monitoring *) service;
-      auto& context = services.get<DataTakingContext>();
+      auto* monitoring = (o2::monitoring::Monitoring*)service;
 
+      auto extRunNumber = services.get<RawDeviceService>().device()->fConfig->GetProperty<std::string>("runNumber", "unspecified");
+      if (extRunNumber == "unspecified") {
+        return;
+      }
       try {
-        monitoring->setRunNumber(std::stoul(context.runNumber.c_str()));
+        monitoring->setRunNumber(std::stoul(extRunNumber));
       } catch (...) {
       } },
     .exit = [](ServiceRegistryRef registry, void* service) {
@@ -141,11 +145,22 @@ o2::framework::ServiceSpec CommonServices::timingInfoSpec()
     .kind = ServiceKind::Stream};
 }
 
+o2::framework::ServiceSpec CommonServices::streamContextSpec()
+{
+  return ServiceSpec{
+    .name = "stream-context",
+    .uniqueId = simpleServiceId<StreamContext>(),
+    .init = simpleServiceInit<StreamContext, StreamContext, ServiceKind::Stream>(),
+    .configure = noConfiguration(),
+    .kind = ServiceKind::Stream};
+}
+
 o2::framework::ServiceSpec CommonServices::datatakingContextSpec()
 {
   return ServiceSpec{
     .name = "datataking-contex",
-    .init = simpleServiceInit<DataTakingContext, DataTakingContext>(),
+    .uniqueId = simpleServiceId<DataTakingContext>(),
+    .init = simpleServiceInit<DataTakingContext, DataTakingContext, ServiceKind::Stream>(),
     .configure = noConfiguration(),
     .preProcessing = [](ProcessingContext& processingContext, void* service) {
       auto& context = processingContext.services().get<DataTakingContext>();
@@ -158,6 +173,7 @@ o2::framework::ServiceSpec CommonServices::datatakingContextSpec()
         context.runNumber = fmt::format("{}", dh->runNumber);
         break;
       } },
+    // Notice this will be executed only once, because the service is declared upfront.
     .start = [](ServiceRegistryRef services, void* service) {
       auto& context = services.get<DataTakingContext>();
       auto extRunNumber = services.get<RawDeviceService>().device()->fConfig->GetProperty<std::string>("runNumber", "unspecified");
@@ -191,7 +207,7 @@ o2::framework::ServiceSpec CommonServices::datatakingContextSpec()
       context.forcedRaw = forcedRaw == "true";
 
       context.nOrbitsPerTF = services.get<RawDeviceService>().device()->fConfig->GetProperty<uint64_t>("Norbits_per_TF", 128); },
-    .kind = ServiceKind::Serial};
+    .kind = ServiceKind::Stream};
 }
 
 struct MissingService {
@@ -699,23 +715,23 @@ o2::framework::ServiceSpec CommonServices::dataProcessingStats()
   return ServiceSpec{
     .name = "data-processing-stats",
     .init = [](ServiceRegistryRef services, DeviceState&, fair::mq::ProgOptions& options) -> ServiceHandle {
-      DataProcessingStats* stats = new DataProcessingStats();
+      auto* stats = new DataProcessingStats();
       return ServiceHandle{TypeIdHelpers::uniqueId<DataProcessingStats>(), stats};
     },
     .configure = noConfiguration(),
     .postProcessing = [](ProcessingContext& context, void* service) {
-      DataProcessingStats* stats = (DataProcessingStats*)service;
+      auto* stats = (DataProcessingStats*)service;
       stats->performedComputations++; },
     .preDangling = [](DanglingContext& context, void* service) {
-      DataProcessingStats* stats = (DataProcessingStats*)service;
+      auto* stats = (DataProcessingStats*)service;
       sendRelayerMetrics(context.services(), *stats);
       flushMetrics(context.services(), *stats); },
     .postDangling = [](DanglingContext& context, void* service) {
-      DataProcessingStats* stats = (DataProcessingStats*)service;
+      auto* stats = (DataProcessingStats*)service;
       sendRelayerMetrics(context.services(), *stats);
       flushMetrics(context.services(), *stats); },
     .preEOS = [](EndOfStreamContext& context, void* service) {
-      DataProcessingStats* stats = (DataProcessingStats*)service;
+      auto* stats = (DataProcessingStats*)service;
       sendRelayerMetrics(context.services(), *stats);
       flushMetrics(context.services(), *stats); },
     .kind = ServiceKind::Serial};
@@ -729,7 +745,7 @@ o2::framework::ServiceSpec CommonServices::guiMetricsSpec()
   return ServiceSpec{
     .name = "gui-metrics",
     .init = [](ServiceRegistryRef services, DeviceState&, fair::mq::ProgOptions& options) -> ServiceHandle {
-      GUIMetrics* stats = new GUIMetrics();
+      auto* stats = new GUIMetrics();
       auto& monitoring = services.get<Monitoring>();
       auto& spec = services.get<DeviceSpec const>();
       monitoring.send({(int)spec.inputChannels.size(), fmt::format("oldest_possible_timeslice/h"), o2::monitoring::Verbosity::Debug});
@@ -811,6 +827,7 @@ std::vector<ServiceSpec> CommonServices::defaultServices(int numThreads)
 {
   std::vector<ServiceSpec> specs{
     dataProcessorContextSpec(),
+    streamContextSpec(),
     dataAllocatorSpec(),
     asyncQueue(),
     timingInfoSpec(),

--- a/Framework/Core/src/ContextHelpers.h
+++ b/Framework/Core/src/ContextHelpers.h
@@ -1,0 +1,101 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef O2_FRAMEWORK_CONTEXTHELPERS_H_
+#define O2_FRAMEWORK_CONTEXTHELPERS_H_
+
+#include "Framework/StreamContext.h"
+#include "Framework/DataProcessingContext.h"
+#include "Framework/ServiceSpec.h"
+
+namespace o2::framework
+{
+struct ContextHelpers {
+  static void bindStreamService(DataProcessorContext& dpContext, StreamContext& stream, ServiceSpec const& spec, void* service);
+  static void bindProcessorService(DataProcessorContext& dpContext, ServiceSpec const& spec, void* service);
+};
+
+void ContextHelpers::bindStreamService(DataProcessorContext& dpContext, StreamContext& context, ServiceSpec const& spec, void* service)
+{
+  assert(spec.preDangling == nullptr);
+  assert(spec.postDangling == nullptr);
+  assert(spec.postDispatching == nullptr);
+  assert(spec.postForwarding == nullptr);
+  assert(spec.stop == nullptr);
+  assert(spec.exit == nullptr);
+  assert(spec.domainInfoUpdated == nullptr);
+  assert(spec.preSendingMessages == nullptr);
+  assert(spec.postRenderGUI == nullptr);
+  // Notice that this will mean that stream services will execute the start
+  // callback once per stream, not once per dataprocessor.
+  if (spec.start) {
+    context.preStartStreamHandles.push_back(ServiceStartStreamHandle{spec, spec.start, service});
+  }
+  if (spec.preProcessing) {
+    context.preProcessingHandles.push_back(ServiceProcessingHandle{spec, spec.preProcessing, service});
+  }
+  if (spec.postProcessing) {
+    context.postProcessingHandles.push_back(ServiceProcessingHandle{spec, spec.postProcessing, service});
+  }
+  // We need to call the preEOS also on a per stream basis, not only on a per
+  // data processor basis.
+  if (spec.preEOS) {
+    dpContext.preEOSHandles.push_back(ServiceEOSHandle{spec, spec.preEOS, service});
+  }
+  if (spec.postEOS) {
+    dpContext.postEOSHandles.push_back(ServiceEOSHandle{spec, spec.postEOS, service});
+  }
+}
+
+void ContextHelpers::bindProcessorService(DataProcessorContext& dataProcessorContext, ServiceSpec const& spec, void* service)
+{
+  if (spec.preProcessing) {
+    dataProcessorContext.preProcessingHandlers.push_back(ServiceProcessingHandle{spec, spec.preProcessing, service});
+  }
+  if (spec.postProcessing) {
+    dataProcessorContext.postProcessingHandlers.push_back(ServiceProcessingHandle{spec, spec.postProcessing, service});
+  }
+  if (spec.preDangling) {
+    dataProcessorContext.preDanglingHandles.push_back(ServiceDanglingHandle{spec, spec.preDangling, service});
+  }
+  if (spec.postDangling) {
+    dataProcessorContext.postDanglingHandles.push_back(ServiceDanglingHandle{spec, spec.postDangling, service});
+  }
+  if (spec.preEOS) {
+    dataProcessorContext.preEOSHandles.push_back(ServiceEOSHandle{spec, spec.preEOS, service});
+  }
+  if (spec.postEOS) {
+    dataProcessorContext.postEOSHandles.push_back(ServiceEOSHandle{spec, spec.postEOS, service});
+  }
+  if (spec.postDispatching) {
+    dataProcessorContext.postDispatchingHandles.push_back(ServiceDispatchingHandle{spec, spec.postDispatching, service});
+  }
+  if (spec.postForwarding) {
+    dataProcessorContext.postForwardingHandles.push_back(ServiceForwardingHandle{spec, spec.postForwarding, service});
+  }
+  if (spec.start) {
+    dataProcessorContext.preStartHandles.push_back(ServiceStartHandle{spec, spec.start, service});
+  }
+  if (spec.stop) {
+    dataProcessorContext.postStopHandles.push_back(ServiceStopHandle{spec, spec.stop, service});
+  }
+  if (spec.exit) {
+    dataProcessorContext.preExitHandles.push_back(ServiceExitHandle{spec, spec.exit, service});
+  }
+  if (spec.domainInfoUpdated) {
+    dataProcessorContext.domainInfoHandles.push_back(ServiceDomainInfoHandle{spec, spec.domainInfoUpdated, service});
+  }
+  if (spec.preSendingMessages) {
+    dataProcessorContext.preSendingMessagesHandles.push_back(ServicePreSendingMessagesHandle{spec, spec.preSendingMessages, service});
+  }
+}
+
+} // namespace o2::framework
+#endif // O2_FRAMEWORK_CONTEXTHELPERS_H_

--- a/Framework/Core/src/DataProcessingContext.cxx
+++ b/Framework/Core/src/DataProcessingContext.cxx
@@ -1,0 +1,134 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/DataProcessingContext.h"
+
+namespace o2::framework
+{
+/// Invoke callbacks to be executed before every dangling check
+void DataProcessorContext::preProcessingCallbacks(ProcessingContext& ctx)
+{
+  for (auto& handle : preProcessingHandlers) {
+    LOGP(debug, "Invoking preDanglingCallback for service {}", handle.spec.name);
+    handle.callback(ctx, handle.service);
+  }
+}
+
+/// Invoke callbacks to be executed before every dangling check
+void DataProcessorContext::postProcessingCallbacks(ProcessingContext& ctx)
+{
+  for (auto& handle : postProcessingHandlers) {
+    LOGP(debug, "Invoking postProcessingCallback for service {}", handle.spec.name);
+    handle.callback(ctx, handle.service);
+  }
+}
+
+/// Invoke callbacks to be executed before every dangling check
+void DataProcessorContext::preDanglingCallbacks(DanglingContext& danglingContext)
+{
+  for (auto& handle : preDanglingHandles) {
+    LOGP(debug, "Invoking preDanglingCallback for service {}", handle.spec.name);
+    handle.callback(danglingContext, handle.service);
+  }
+}
+
+/// Invoke callbacks to be executed after every dangling check
+void DataProcessorContext::postDanglingCallbacks(DanglingContext& danglingContext)
+{
+  for (auto& handle : postDanglingHandles) {
+    LOGP(debug, "Invoking postDanglingCallback for service {} {}", handle.spec.name);
+    handle.callback(danglingContext, handle.service);
+  }
+}
+
+/// Invoke callbacks to be executed before every EOS user callback invokation
+void DataProcessorContext::preEOSCallbacks(EndOfStreamContext& eosContext)
+{
+  for (auto& handle : preEOSHandles) {
+    LOGP(detail, "Invoking preEosCallback for service {}", handle.spec.name);
+    handle.callback(eosContext, handle.service);
+  }
+}
+
+/// Invoke callbacks to be executed after every EOS user callback invokation
+void DataProcessorContext::postEOSCallbacks(EndOfStreamContext& eosContext)
+{
+  for (auto& handle : postEOSHandles) {
+    LOGP(detail, "Invoking postEoSCallback for service {}", handle.spec.name);
+    handle.callback(eosContext, handle.service);
+  }
+}
+
+/// Invoke callbacks to be executed after every data Dispatching
+void DataProcessorContext::postDispatchingCallbacks(ProcessingContext& processContext)
+{
+  for (auto& handle : postDispatchingHandles) {
+    LOGP(debug, "Invoking postDispatchingCallback for service {}", handle.spec.name);
+    handle.callback(processContext, handle.service);
+  }
+}
+
+/// Invoke callbacks to be executed after every data Dispatching
+void DataProcessorContext::postForwardingCallbacks(ProcessingContext& processContext)
+{
+  for (auto& handle : postForwardingHandles) {
+    LOGP(debug, "Invoking postForwardingCallback for service {}", handle.spec.name);
+    handle.callback(processContext, handle.service);
+  }
+}
+
+/// Callbacks to be called in fair::mq::Device::PreRun()
+void DataProcessorContext::preStartCallbacks(ServiceRegistryRef ref)
+{
+  for (auto& handle : preStartHandles) {
+    LOGP(detail, "Invoking preStartCallback for service {}", handle.spec.name);
+    handle.callback(ref, handle.service);
+  }
+}
+
+void DataProcessorContext::postStopCallbacks(ServiceRegistryRef ref)
+{
+  // FIXME: we need to call the callback only once for the global services
+  /// I guess...
+  for (auto& handle : postStopHandles) {
+    LOGP(detail, "Invoking postStopCallback for service {}", handle.spec.name);
+    handle.callback(ref, handle.service);
+  }
+}
+
+/// Invoke callback to be executed on exit, in reverse order.
+void DataProcessorContext::preExitCallbacks(std::vector<ServiceExitHandle> handles, ServiceRegistryRef ref)
+{
+  // FIXME: we need to call the callback only once for the global services
+  /// I guess...
+  for (auto handle = handles.rbegin(); handle != handles.rend(); ++handle) {
+    LOGP(detail, "Invoking preExitCallback for service {}", handle->spec.name);
+    handle->callback(ref, handle->service);
+  }
+}
+
+void DataProcessorContext::domainInfoUpdatedCallback(ServiceRegistryRef ref, size_t oldestPossibleTimeslice, ChannelIndex channelIndex)
+{
+  for (auto& handle : domainInfoHandles) {
+    LOGP(debug, "Invoking domainInfoHandles for service {}", handle.spec.name);
+    handle.callback(ref, oldestPossibleTimeslice, channelIndex);
+  }
+}
+
+void DataProcessorContext::preSendingMessagesCallbacks(ServiceRegistryRef ref, fair::mq::Parts& parts, ChannelIndex channelIndex)
+{
+  for (auto& handle : preSendingMessagesHandles) {
+    LOGP(debug, "Invoking preSending for service {}", handle.spec.name);
+    handle.callback(ref, parts, channelIndex);
+  }
+}
+
+} // namespace o2::framework

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -961,12 +961,30 @@ void DataProcessingDevice::PreRun()
   mServiceRegistry.preStartCallbacks();
   ref.get<CallbackService>()(CallbackService::Id::Start);
   startPollers();
+
+  // Raise to 1 when we are ready to start processing
+  using o2::monitoring::Metric;
+  using o2::monitoring::Monitoring;
+  using o2::monitoring::tags::Key;
+  using o2::monitoring::tags::Value;
+
+  auto& monitoring = ref.get<Monitoring>();
+  monitoring.send(Metric{(uint64_t)1, "device_state"}.addTag(Key::Subsystem, Value::DPL));
 }
 
 void DataProcessingDevice::PostRun()
 {
-  stopPollers();
   ServiceRegistryRef ref{mServiceRegistry};
+  // Raise to 1 when we are ready to start processing
+  using o2::monitoring::Metric;
+  using o2::monitoring::Monitoring;
+  using o2::monitoring::tags::Key;
+  using o2::monitoring::tags::Value;
+
+  auto& monitoring = ref.get<Monitoring>();
+  monitoring.send(Metric{(uint64_t)0, "device_state"}.addTag(Key::Subsystem, Value::DPL));
+
+  stopPollers();
   ref.get<CallbackService>()(CallbackService::Id::Stop);
   mServiceRegistry.postStopCallbacks();
 }

--- a/Framework/Core/src/DataSender.cxx
+++ b/Framework/Core/src/DataSender.cxx
@@ -82,7 +82,8 @@ std::unique_ptr<fair::mq::Message> DataSender::create(RouteIndex routeIndex)
 void DataSender::send(fair::mq::Parts& parts, ChannelIndex channelIndex)
 {
   O2DataModelHelpers::updateMissingSporadic(parts, mOutputs, mPresent);
-  mRegistry.preSendingMessagesCallbacks(parts, channelIndex);
+  auto& dataProcessorContext = mRegistry.get<DataProcessorContext>();
+  dataProcessorContext.preSendingMessagesCallbacks(mRegistry, parts, channelIndex);
   mPolicy.send(mProxy, parts, channelIndex, mRegistry);
 }
 

--- a/Framework/Core/src/DataSender.cxx
+++ b/Framework/Core/src/DataSender.cxx
@@ -20,6 +20,8 @@
 #include "Framework/TimesliceIndex.h"
 #include "Framework/DataProcessingHelpers.h"
 #include "Framework/CommonServices.h"
+#include "Framework/DataProcessingContext.h"
+#include "Framework/O2DataModelHelpers.h"
 
 using namespace o2::monitoring;
 
@@ -66,6 +68,10 @@ DataSender::DataSender(ServiceRegistryRef registry,
     DataSpecUtils::describe(buffer, 127, mOutputs.back());
     monitoring.send({fmt::format("{} ({})", buffer, (int)mOutputs.back().lifetime), mQueriesMetricsNames[i], Verbosity::Debug});
   }
+  /// Fill the mPresents with the outputs which are not timeframes.
+  for (size_t i = 0; i < mOutputs.size(); ++i) {
+    mPresentDefaults.push_back(mOutputs[i].lifetime != Lifetime::Timeframe);
+  }
 }
 
 std::unique_ptr<fair::mq::Message> DataSender::create(RouteIndex routeIndex)
@@ -75,8 +81,24 @@ std::unique_ptr<fair::mq::Message> DataSender::create(RouteIndex routeIndex)
 
 void DataSender::send(fair::mq::Parts& parts, ChannelIndex channelIndex)
 {
+  O2DataModelHelpers::updateMissingSporadic(parts, mOutputs, mPresent);
   mRegistry.preSendingMessagesCallbacks(parts, channelIndex);
   mPolicy.send(mProxy, parts, channelIndex, mRegistry);
+}
+
+void DataSender::reset()
+{
+  mPresent = mPresentDefaults;
+}
+
+void DataSender::verifyMissingSporadic() const
+{
+  for (auto present : mPresent) {
+    if (!present) {
+      LOGP(warning, O2DataModelHelpers::describeMissingOutputs(mOutputs, mPresent).c_str());
+      return;
+    }
+  }
 }
 
 } // namespace o2::framework

--- a/Framework/Core/src/O2DataModelHelpers.cxx
+++ b/Framework/Core/src/O2DataModelHelpers.cxx
@@ -14,9 +14,8 @@
 
 namespace o2::framework
 {
-bool O2DataModelHelpers::checkForMissingSporadic(fair::mq::Parts& parts, std::vector<OutputSpec> const& specs, std::vector<bool>& present)
+void O2DataModelHelpers::updateMissingSporadic(fair::mq::Parts& parts, std::vector<OutputSpec> const& specs, std::vector<bool>& present)
 {
-  std::fill(present.begin(), present.end(), false);
   // Mark as present anything which is not of Lifetime timeframe.
   for (size_t i = 0; i < specs.size(); ++i) {
     if (specs[i].lifetime != Lifetime::Timeframe) {
@@ -41,7 +40,6 @@ bool O2DataModelHelpers::checkForMissingSporadic(fair::mq::Parts& parts, std::ve
     }
   };
   O2DataModelHelpers::for_each_header(parts, timeframeDataExists);
-  return std::all_of(present.begin(), present.end(), [](auto const& p) { return p; });
 }
 
 std::string O2DataModelHelpers::describeMissingOutputs(std::vector<OutputSpec> const& specs, std::vector<bool> const& present)
@@ -60,6 +58,23 @@ std::string O2DataModelHelpers::describeMissingOutputs(std::vector<OutputSpec> c
     }
   }
   error += ". If this is expected, please change its lifetime to Sporadic / QA.";
+  first = true;
+  for (size_t i = 0; i < specs.size(); ++i) {
+    if (present[i] == true) {
+      if (first) {
+        error += " Present outputs are: ";
+        first = false;
+      } else {
+        error += ", ";
+      }
+      error += DataSpecUtils::describe(specs[i]);
+    }
+  }
+  if (first) {
+    error += " No output was present.";
+  } else {
+    error += ".";
+  }
   return error;
 }
 } // namespace o2::framework

--- a/Framework/Core/src/StreamContext.cxx
+++ b/Framework/Core/src/StreamContext.cxx
@@ -1,0 +1,71 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/StreamContext.h"
+
+namespace o2::framework
+{
+
+void StreamContext::preStartStreamCallbacks(ServiceRegistryRef ref)
+{
+  for (auto& handle : preStartStreamHandles) {
+    LOG(detail) << "Invoking preStartStreamCallbacks for " << handle.spec.name;
+    assert(handle.callback);
+    // The service must be nullptr because we have not created it yet at this
+    // point.
+    handle.callback(ref, nullptr);
+  }
+}
+/// Invoke callbacks to be executed before every process method invokation
+void StreamContext::preProcessingCallbacks(ProcessingContext& pcx)
+{
+  for (auto& handle : preProcessingHandles) {
+    LOG(debug) << "Invoking preProcessingCallbacks for" << handle.service;
+    assert(handle.service);
+    assert(handle.callback);
+    handle.callback(pcx, handle.service);
+  }
+}
+
+/// Invoke callbacks to be executed after every process method invokation
+void StreamContext::postProcessingCallbacks(ProcessingContext& pcx)
+{
+  for (auto& handle : postProcessingHandles) {
+    LOG(debug) << "Invoking postProcessingCallbacks for " << handle.service;
+    assert(handle.service);
+    assert(handle.callback);
+    handle.callback(pcx, handle.service);
+  }
+}
+
+/// Invoke callbacks to be executed before every EOS user callback invokation
+void StreamContext::preEOSCallbacks(EndOfStreamContext& eosContext)
+{
+  for (auto& eosHandle : preEOSHandles) {
+    LOG(detail) << "Invoking preEOSCallbacks for" << eosHandle.service;
+    assert(eosHandle.service);
+    assert(eosHandle.callback);
+    eosHandle.callback(eosContext, eosHandle.service);
+  }
+}
+
+/// Invoke callbacks to be executed after every EOS user callback invokation
+void StreamContext::postEOSCallbacks(EndOfStreamContext& eosContext)
+{
+  for (auto& eosHandle : postEOSHandles) {
+    LOG(detail) << "Invoking postEOSCallbacks for " << eosHandle.service;
+    assert(eosHandle.service);
+    assert(eosHandle.callback);
+    eosHandle.callback(eosContext, eosHandle.service);
+  }
+}
+
+} // namespace o2::framework

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -20,6 +20,7 @@
 #include "Framework/ComputingQuotaEvaluator.h"
 #include "CommonDriverServices.h"
 #include "Framework/DataProcessingDevice.h"
+#include "Framework/DataProcessingContext.h"
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Plugins.h"
 #include "Framework/DeviceControl.h"
@@ -1150,7 +1151,9 @@ int doChild(int argc, char** argv, ServiceRegistry& serviceRegistry,
   runner.AddHook<fair::mq::hooks::InstantiateDevice>(afterConfigParsingCallback);
 
   auto result = runner.Run();
-  serviceRegistry.preExitCallbacks();
+  ServiceRegistryRef serviceRef = {serviceRegistry};
+  auto& context = serviceRef.get<DataProcessorContext>();
+  DataProcessorContext::preExitCallbacks(context.preExitHandles, serviceRef);
   return result;
 }
 

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -1217,6 +1217,7 @@ std::vector<std::regex> getDumpableMetrics()
   dumpableMetrics.emplace_back("^aod-file-read-info$");
   dumpableMetrics.emplace_back("^table-bytes-.*");
   dumpableMetrics.emplace_back("^total-timeframes.*");
+  dumpableMetrics.emplace_back("^device_state.*");
   return dumpableMetrics;
 }
 

--- a/Framework/Core/test/test_O2DataModelHelpers.cxx
+++ b/Framework/Core/test/test_O2DataModelHelpers.cxx
@@ -166,6 +166,7 @@ BOOST_AUTO_TEST_CASE(TestTimeframeMissing)
   present.resize(outputs.size());
   O2DataModelHelpers::updateMissingSporadic(inputs, outputs, present);
   BOOST_CHECK(O2DataModelHelpers::validateOutputs(present) == false);
+
   BOOST_CHECK_EQUAL(O2DataModelHelpers::describeMissingOutputs(outputs, present),
                     "This timeframe has a missing output of lifetime timeframe: ITS/CLUSTERS/0. If this is expected, please change its lifetime to Sporadic / QA. Present outputs are: TPC/CLUSTERS/0.");
 }

--- a/Framework/Core/test/test_O2DataModelHelpers.cxx
+++ b/Framework/Core/test/test_O2DataModelHelpers.cxx
@@ -136,7 +136,8 @@ BOOST_AUTO_TEST_CASE(TestTimeframePresent)
   };
   std::vector<bool> present;
   present.resize(outputs.size());
-  BOOST_CHECK(O2DataModelHelpers::checkForMissingSporadic(inputs, outputs, present));
+  O2DataModelHelpers::updateMissingSporadic(inputs, outputs, present);
+  BOOST_CHECK(O2DataModelHelpers::validateOutputs(present) == true);
 }
 
 BOOST_AUTO_TEST_CASE(TestTimeframeMissing)
@@ -163,9 +164,10 @@ BOOST_AUTO_TEST_CASE(TestTimeframeMissing)
   };
   std::vector<bool> present;
   present.resize(outputs.size());
-  BOOST_CHECK(O2DataModelHelpers::checkForMissingSporadic(inputs, outputs, present) == false);
+  O2DataModelHelpers::updateMissingSporadic(inputs, outputs, present);
+  BOOST_CHECK(O2DataModelHelpers::validateOutputs(present) == false);
   BOOST_CHECK_EQUAL(O2DataModelHelpers::describeMissingOutputs(outputs, present),
-                    "This timeframe has a missing output of lifetime timeframe: ITS/CLUSTERS/0. If this is expected, please change its lifetime to Sporadic / QA.");
+                    "This timeframe has a missing output of lifetime timeframe: ITS/CLUSTERS/0. If this is expected, please change its lifetime to Sporadic / QA. Present outputs are: TPC/CLUSTERS/0.");
 }
 
 BOOST_AUTO_TEST_CASE(TestTimeframeSporadic)
@@ -192,5 +194,6 @@ BOOST_AUTO_TEST_CASE(TestTimeframeSporadic)
   };
   std::vector<bool> present;
   present.resize(outputs.size());
-  BOOST_CHECK(O2DataModelHelpers::checkForMissingSporadic(inputs, outputs, present) == true);
+  O2DataModelHelpers::updateMissingSporadic(inputs, outputs, present);
+  BOOST_CHECK(O2DataModelHelpers::validateOutputs(present) == true);
 }

--- a/Framework/GUISupport/src/Plugin.cxx
+++ b/Framework/GUISupport/src/Plugin.cxx
@@ -21,6 +21,7 @@
 #include "Framework/ServiceSpec.h"
 #include "Framework/CommonServices.h"
 #include "Framework/GuiCallbackContext.h"
+#include "Framework/DataProcessingContext.h"
 #include "SpyService.h"
 #include "SpyServiceHelpers.h"
 #include <fairmq/Channel.h>


### PR DESCRIPTION
* Introduce a StreamContext:
  * Used to hold Stream specific state and information
  * Used to hold callbacks which need to be executed on a per stream basis
  * I had to change the DataTakingContext to be a stream service since it implements a per stream callback
* Move callbacks which are intended to be executed on a per dataprocessor basis to the DataProcessorContext.