### PR TITLE
Fixes in the order of alignment application + for the barrel allignment

### DIFF
--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/AlignParam.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/AlignParam.h
@@ -112,6 +112,8 @@ class AlignParam
 
   void print() const;
 
+  int rectify(double zero = 1e-13);
+
  protected:
   bool matrixToAngles(const double* rot, double& psi, double& theta, double& phi) const;
   void anglesToMatrix(double psi, double theta, double phi, double* rot) const;

--- a/DataFormats/Detectors/Common/src/AlignParam.cxx
+++ b/DataFormats/Detectors/Common/src/AlignParam.cxx
@@ -118,7 +118,6 @@ bool AlignParam::matrixToAngles(const double* rot, double& psi, double& theta, d
   /// Returns false in case the rotation angles can not be
   /// extracted from the matrix
   //
-  constexpr double ZERO = 1e-14;
   if (std::abs(rot[0]) < 1e-7 || std::abs(rot[8]) < 1e-7) {
     LOG(error) << "Failed to extract roll-pitch-yall angles!";
     return false;
@@ -126,15 +125,6 @@ bool AlignParam::matrixToAngles(const double* rot, double& psi, double& theta, d
   psi = std::atan2(-rot[5], rot[8]);
   theta = std::asin(rot[2]);
   phi = std::atan2(-rot[1], rot[0]);
-  if (std::abs(psi) < ZERO) {
-    psi = 0.;
-  }
-  if (std::abs(theta) < ZERO) {
-    theta = 0.;
-  }
-  if (std::abs(phi) < ZERO) {
-    phi = 0.;
-  }
   return true;
 }
 
@@ -457,4 +447,34 @@ bool AlignParam::setLocalRotation(const TGeoMatrix& m)
   TGeoHMatrix rotm;
   rotm.SetRotation(m.GetRotationMatrix());
   return setLocalParams(rotm);
+}
+
+//_____________________________________________________________________________
+int AlignParam::rectify(double zero)
+{
+  int nonZero = 6;
+  if (std::abs(mX) < zero) {
+    mX = 0.;
+  }
+  if (std::abs(mY) < zero) {
+    mY = 0.;
+    nonZero--;
+  }
+  if (std::abs(mZ) < zero) {
+    mZ = 0.;
+    nonZero--;
+  }
+  if (std::abs(mPsi) < zero) {
+    mPsi = 0.;
+    nonZero--;
+  }
+  if (std::abs(mTheta) < zero) {
+    mTheta = 0.;
+    nonZero--;
+  }
+  if (std::abs(mPhi) < zero) {
+    mPhi = 0.;
+    nonZero--;
+  }
+  return nonZero;
 }

--- a/Detectors/Align/include/Align/AlignConfig.h
+++ b/Detectors/Align/include/Align/AlignConfig.h
@@ -49,9 +49,9 @@ struct AlignConfig : public o2::conf::ConfigurableParamHelper<AlignConfig> {
   int minPointTotal = 4; // total min number of alignment point to account track
   int minDetectors = 1;  // min number of detectors per track
 
-  float maxDCAforVC[2]; // DCA cut in R,Z to allow track be subjected to vertex constraint
-  float maxChi2forVC;   // track-vertex chi2 cut to allow the track be subjected to vertex constraint
-
+  float maxDCAforVC[2] = {-1, -1}; // DCA cut in R,Z to allow track be subjected to vertex constraint
+  float maxChi2forVC = -1;         // track-vertex chi2 cut to allow the track be subjected to vertex constraint
+  float alignParamZero = 1e-13;    // assign 0 to final alignment parameter if its abs val is below this threshold
   float controlFraction = 1.; // fraction for which control output is requested
   bool MilleOut = true;       // Mille output
   bool MPRecOut = true;       // compact Millepede2Record

--- a/Detectors/Align/include/Align/AlignableVolume.h
+++ b/Detectors/Align/include/Align/AlignableVolume.h
@@ -173,8 +173,8 @@ class AlignableVolume : public DOFSet
   void getDeltaT2LmodTRA(TGeoHMatrix& matMod, const double* delta, const TGeoHMatrix& relMat) const;
   //
   // creation of global matrices for storage
-  void createGloDeltaMatrix(TGeoHMatrix& deltaM) const;
-  void createLocDeltaMatrix(TGeoHMatrix& deltaM) const;
+  bool createGloDeltaMatrix(TGeoHMatrix& deltaM) const;
+  bool createLocDeltaMatrix(TGeoHMatrix& deltaM) const; // return true if the matrix is not unity
   void createPreGloDeltaMatrix(TGeoHMatrix& deltaM) const;
   void createPreLocDeltaMatrix(TGeoHMatrix& deltaM) const;
   void createAlignmenMatrix(TGeoHMatrix& alg) const;

--- a/Detectors/Align/include/Align/Controller.h
+++ b/Detectors/Align/include/Align/Controller.h
@@ -308,8 +308,7 @@ class Controller : public TObject
   std::vector<float> mGloParVal; // parameters for DOFs
   std::vector<float> mGloParErr; // errors for DOFs
   std::vector<int> mGloParLab;   // labels for DOFs
-  std::vector<int> mOrderedLbl;  //ordered labels
-  std::vector<int> mLbl2ID;      //Label order in mOrderedLbl -> parID
+  std::unordered_map<int, int> mLbl2ID; // Labels mapping to parameter ID
   //
   std::unique_ptr<AlignmentPoint> mRefPoint; //! reference point for track definition
   //

--- a/Detectors/Base/src/GeometryManager.cxx
+++ b/Detectors/Base/src/GeometryManager.cxx
@@ -252,7 +252,7 @@ bool GeometryManager::applyAlignment(const std::vector<o2::detectors::AlignParam
   int nvols = algPars.size();
   std::vector<int> ord(nvols);
   std::iota(std::begin(ord), std::end(ord), 0); // sort to apply alignment in correct hierarchy
-  std::sort(std::begin(ord), std::end(ord), [&algPars](int a, int b) { return algPars[a].getLevel() > algPars[b].getLevel(); });
+  std::sort(std::begin(ord), std::end(ord), [&algPars](int a, int b) { return algPars[a].getLevel() < algPars[b].getLevel(); });
 
   bool res = true;
   for (int i = 0; i < nvols; i++) {


### PR DESCRIPTION
* Fix order of alignment objects application

This is potentially a very severe error: alignment objects were applied in from the highest to the lowest level while it should have been the opposite.
Verified that for current ITS alignment, with no highest (module/chip) corrections the effect is
at most at the level of 1-2 microns, but one should verify it for other detectors!

* Fix label->parameter ID mapping
Minimize matrix manipulations for non-modified objects AignParam creation