### PR TITLE
Option to fowards MC tracks from O2-sim to external (DPL) consumer

### DIFF
--- a/Common/SimConfig/include/SimConfig/SimConfig.h
+++ b/Common/SimConfig/include/SimConfig/SimConfig.h
@@ -69,6 +69,8 @@ struct SimConfigData {
   bool mNoGeant = false;                      // if Geant transport should be turned off (when one is only interested in the generated events)
   bool mIsRun5 = false;                       // true if the simulation is for Run 5
   std::string mFromCollisionContext = "";     // string denoting a collision context file; If given, this file will be used to determine number of events
+  bool mForwardKine = false;                  // true if tracks and event headers are to be published on a FairMQ channel (for reading by other consumers)
+  bool mWriteToDisc = true;                   // whether we write simulation products (kine, hits) to disc
 
   ClassDefNV(SimConfigData, 4);
 };
@@ -147,6 +149,8 @@ class SimConfig
   int getRunNumber() const { return mConfigData.mRunNumber; }
   bool isNoGeant() const { return mConfigData.mNoGeant; }
   void setRun5(bool value = true) { mConfigData.mIsRun5 = value; }
+  bool forwardKine() const { return mConfigData.mForwardKine; }
+  bool writeToDisc() const { return mConfigData.mWriteToDisc; }
 
  private:
   SimConfigData mConfigData; //!

--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -57,7 +57,9 @@ void SimConfig::initOptions(boost::program_options::options_description& options
     "timestamp", bpo::value<uint64_t>(), "global timestamp value in ms (for anchoring) - default is now ... or beginning of run if ALICE run number was given")(
     "run", bpo::value<int>()->default_value(-1), "ALICE run number")(
     "asservice", bpo::value<bool>()->default_value(false), "run in service/server mode")(
-    "noGeant", bpo::bool_switch(), "prohibits any Geant transport/physics (by using tight cuts)");
+    "noGeant", bpo::bool_switch(), "prohibits any Geant transport/physics (by using tight cuts)")(
+    "forwardKine", bpo::bool_switch(), "forward kinematics on a FairMQ channel")(
+    "noDiscOutput", bpo::bool_switch(), "switch off writing sim results to disc (useful in combination with forwardKine)");
   options.add_options()("fromCollContext", bpo::value<std::string>()->default_value(""), "Use a pregenerated collision context to infer number of events to simulate, how to embedd them, the vertex position etc. Takes precedence of other options such as \"--nEvents\".");
 }
 
@@ -214,6 +216,8 @@ bool SimConfig::resetFromParsedMap(boost::program_options::variables_map const& 
   mConfigData.mCCDBUrl = vm["CCDBUrl"].as<std::string>();
   mConfigData.mAsService = vm["asservice"].as<bool>();
   mConfigData.mNoGeant = vm["noGeant"].as<bool>();
+  mConfigData.mForwardKine = vm["forwardKine"].as<bool>();
+  mConfigData.mWriteToDisc = !vm["noDiscOutput"].as<bool>();
   if (vm.count("noemptyevents")) {
     mConfigData.mFilterNoHitEvents = true;
   }

--- a/run/CMakeLists.txt
+++ b/run/CMakeLists.txt
@@ -96,6 +96,11 @@ o2_add_executable(g4-determine-unknown-pdg-properties
                   SOURCES g4DetermineUnknownPdgProperties.cxx
                   PUBLIC_LINK_LIBRARIES MC::Geant4 MC::Geant4VMC internal::allsim)
 
+o2_add_executable(mctracks-proxy
+                  COMPONENT_NAME sim
+                  SOURCES o2sim_mctracks_proxy.cxx
+                  PUBLIC_LINK_LIBRARIES O2::Framework O2::SimulationDataFormat)
+
 o2_data_file(COPY o2simtopology_template.json DESTINATION config)
 
 # * # add a complex simulation as a unit test (if simulation was enabled)

--- a/run/SimExamples/MCTrackToDPL/README.md
+++ b/run/SimExamples/MCTrackToDPL/README.md
@@ -1,0 +1,6 @@
+<!-- doxy
+\page refrunSimExamplesMCTrackToDPL Example MCTrackToDPL
+/doxy -->
+
+This is a simulation example demonstrates how to use o2-sim as an on-the-fly generator
+for DPL (analysis) tasks.

--- a/run/SimExamples/MCTrackToDPL/run.sh
+++ b/run/SimExamples/MCTrackToDPL/run.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -x
+
+# launch generator process (for 100 min bias Pythia8 events)
+o2-sim -j 1 -g pythia8pp -n 100 --noWriteToDisc --forwardKine &> sim.log &
+SIMPROC=$!
+
+# launch a DPL process (having the right proxy configuration)
+o2-sim-mctracks-proxy --enable-test-consumer &> out_mcanalysis.log &
+TRACKANAPROC=$!
+
+wait ${SIMPROC}
+sleep 5
+wait ${TRACKANAPROC}

--- a/run/SimExamples/README.md
+++ b/run/SimExamples/README.md
@@ -19,4 +19,5 @@
 * \subpage refrunSimExamplesSelective_Transport
 * \subpage refrunSimExamplesSelective_Transport_pi0
 * \subpage refrunSimExamplesCustom_EventInfo
+* \subpage refrunSimExamplesMCTrackToDPL
 /doxy -->

--- a/run/o2sim_mctracks_proxy.cxx
+++ b/run/o2sim_mctracks_proxy.cxx
@@ -1,0 +1,117 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <boost/program_options.hpp>
+
+#include "Framework/WorkflowSpec.h"
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicy.h"
+#include "Framework/CompletionPolicyHelpers.h"
+#include "Framework/DeviceSpec.h"
+#include "Framework/ExternalFairMQDeviceProxy.h"
+#include "Framework/Task.h"
+#include "Framework/DataRef.h"
+#include "Framework/InputRecordWalker.h"
+#include "Headers/DataHeader.h"
+#include "Headers/Stack.h"
+#include "SimulationDataFormat/MCTrack.h"
+#include "SimulationDataFormat/MCEventHeader.h"
+#include "Framework/DataProcessingHeader.h"
+
+using namespace o2::framework;
+using namespace o2::header;
+
+void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
+{
+  workflowOptions.push_back(ConfigParamSpec{"enable-test-consumer", o2::framework::VariantType::Bool, false, {"enable a simple test consumer for injected MC tracks"}});
+}
+
+#include "Framework/runDataProcessing.h"
+
+// a simple (test) consumer task for MCTracks and MCEventHeaders injected from
+// the proxy
+class ConsumerTask
+{
+ public:
+  void init(o2::framework::InitContext& ic) {}
+  void run(o2::framework::ProcessingContext& pc)
+  {
+    LOG(debug) << "Running simple kinematics consumer client";
+    for (const DataRef& ref : InputRecordWalker(pc.inputs())) {
+      auto const* dh = DataRefUtils::getHeader<o2::header::DataHeader*>(ref);
+      LOG(debug) << "Payload size " << dh->payloadSize << " method " << dh->payloadSerializationMethod.as<std::string>();
+    }
+    auto tracks = pc.inputs().get<std::vector<o2::MCTrack>>("mctracks");
+    auto eventheader = pc.inputs().get<o2::dataformats::MCEventHeader*>("mcheader");
+    LOG(info) << "Got " << tracks.size() << " tracks";
+    LOG(info) << "Got " << eventheader->GetB() << " as impact parameter in the event header";
+  }
+};
+
+/// Function converting raw input data to DPL data format. Uses knowledge of how MCTracks and MCEventHeaders
+/// are sent from the o2sim side.
+InjectorFunction o2simKinematicsConverter(std::vector<OutputSpec> const& specs, uint64_t startTime, uint64_t step)
+{
+  auto timesliceId = std::make_shared<size_t>(startTime);
+
+  return [timesliceId, specs, step](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever) {
+    // We iterate on all the parts and we send them two by two,
+    // adding the appropriate O2 header.
+    for (int i = 0; i < parts.Size(); ++i) {
+      DataHeader dh;
+      ConcreteDataMatcher matcher = DataSpecUtils::asConcreteDataMatcher(specs[i]);
+      dh.dataOrigin = matcher.origin;
+      dh.dataDescription = matcher.description;
+      dh.subSpecification = matcher.subSpec;
+      dh.payloadSize = parts.At(i)->GetSize();
+      if (i == 0) {
+        dh.payloadSerializationMethod = gSerializationMethodROOT;
+      } else if (i == 1) {
+        dh.payloadSerializationMethod = gSerializationMethodROOT;
+      }
+      DataProcessingHeader dph{*timesliceId, 0};
+      // we have to move the incoming data
+      o2::header::Stack headerStack{dh, dph};
+      sendOnChannel(device, std::move(headerStack), std::move(parts.At(i)), specs[i], channelRetriever);
+    }
+    *timesliceId += step;
+  };
+}
+
+/// Describe the DPL workflow
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  WorkflowSpec specs;
+
+  // make a proxy (connecting to an external channel) and forwarding in DPL speak
+  std::vector<OutputSpec> outputs;
+  outputs.emplace_back("MC", "MCHEADER", 0, Lifetime::Timeframe);
+  outputs.emplace_back("MC", "MCTRACKS", 0, Lifetime::Timeframe);
+  o2::framework::InjectorFunction f = o2simKinematicsConverter(outputs, 0, 1);
+
+  specs.emplace_back(specifyExternalFairMQDeviceProxy("o2sim-mctrack-proxy",
+                                                      outputs,
+                                                      "type=sub,method=connect,address=ipc:///tmp/o2sim-hitmerger-kineforward,rateLogging=100", f));
+
+  if (configcontext.options().get<bool>("enable-test-consumer")) {
+    // connect a test consumer
+    std::vector<InputSpec> inputs;
+    inputs.emplace_back("mctracks", "MC", "MCTRACKS", 0., Lifetime::Timeframe);
+    inputs.emplace_back("mcheader", "MC", "MCHEADER", 0., Lifetime::Timeframe);
+    specs.emplace_back(DataProcessorSpec{"sample-MCTrack-consumer",
+                                         inputs,
+                                         {},
+                                         AlgorithmSpec{adaptFromTask<ConsumerTask>()},
+                                         {}});
+  }
+
+  return specs;
+}

--- a/run/o2sim_parallel.cxx
+++ b/run/o2sim_parallel.cxx
@@ -122,6 +122,9 @@ int checkresult()
   // We can put more or less complex things
   // here.
   auto& conf = o2::conf::SimConfig::Instance();
+  if (!conf.writeToDisc()) {
+    return 0;
+  }
   // easy check: see if we have number of entries in output tree == number of events asked
   std::string filename = o2::base::NameConf::getMCKinematicsFileName(conf.getOutPrefix().c_str());
   TFile f(filename.c_str(), "OPEN");
@@ -626,11 +629,12 @@ int main(int argc, char* argv[])
     // later stages (digitization).
 
     auto& conf = o2::conf::SimConfig::Instance();
-    // easy check: see if we have number of entries in output tree == number of events asked
-    std::string kinefilename = o2::base::NameConf::getMCKinematicsFileName(conf.getOutPrefix().c_str());
-    std::string headerfilename = o2::base::NameConf::getMCHeadersFileName(conf.getOutPrefix().c_str());
-    o2::dataformats::MCEventHeader::extractFileFromKinematics(kinefilename, headerfilename);
-
+    if (conf.writeToDisc()) {
+      // easy check: see if we have number of entries in output tree == number of events asked
+      std::string kinefilename = o2::base::NameConf::getMCKinematicsFileName(conf.getOutPrefix().c_str());
+      std::string headerfilename = o2::base::NameConf::getMCHeadersFileName(conf.getOutPrefix().c_str());
+      o2::dataformats::MCEventHeader::extractFileFromKinematics(kinefilename, headerfilename);
+    }
     LOG(info) << "SIMULATION RETURNED SUCCESFULLY";
   }
 

--- a/run/o2simtopology_template.json
+++ b/run/o2simtopology_template.json
@@ -1,151 +1,164 @@
 {
-    "fairMQOptions":{
-        "devices":[
-            {
-                "id":"worker",
-                "channels":[
-                    {
-                        "name":"primary-get",
-                        "sockets":[
-                            {
-                                "type":"req",
-                                "method":"connect",
-                                "address":"ipc:///tmp/o2sim-primary-get-#PID#",
-                                "sndBufSize":"100000",
-                                "rcvBufSize":"100000",
-                                "rateLogging":"0"
-                            }
-                        ]
-                    },
-                    {
-                        "name":"o2sim-primserv-info",
-                        "sockets":[
-                            {
-                                "type":"req",
-                                "method":"connect",
-                                "address":"ipc:///tmp/o2sim-primserv-info-#PID#",
-                                "sndBufSize":"1000",
-                                "rcvBufSize":"1000",
-                                "rateLogging":"0"
-                            }
-                        ]
-                    },
-                    {
-                        "name":"simdata",
-                        "sockets":[
-                            {
-                                "type":"push",
-                                "method":"connect",
-                                "address":"ipc:///tmp/o2sim-hitmerger-simdata-#PID#",
-                                "sndBufSize":1000,
-                                "rcvBufSize":1000,
-                                "rateLogging":0
-                            }
-                        ]
-                    }
-                ]
-            },
-            {
-                "id":"primary-server",
-                "channels":[
-                    {
-                        "name":"primary-get",
-                        "sockets":[
-                            {
-                                "type":"rep",
-                                "method":"bind",
-                                "address":"ipc:///tmp/o2sim-primary-get-#PID#",
-                                "sndBufSize":100000,
-                                "rcvBufSize":100000,
-                                "rateLogging":0
-                            }
-                        ]
-                    },
-                    {
-                        "name":"o2sim-primserv-info",
-                        "sockets":[
-                            {
-                                "type":"rep",
-                                "method":"bind",
-                                "address":"ipc:///tmp/o2sim-primserv-info-#PID#",
-                                "sndBufSize":1000,
-                                "rcvBufSize":1000,
-                                "rateLogging":0
-                            }
-                        ]
-                    },
-                    {
-                        "name":"primary-notifications",
-                        "sockets":[
-                            {
-                                "type":"pub",
-                                "method":"bind",
-                                "address":"ipc:///tmp/o2sim-primary-notifications-#PID#",
-                                "sndBufSize":1000,
-                                "rcvBufSize":1000,
-                                "rateLogging":0
-                            }
-                        ]
-                    }
-                ]
-            },
-            {
-                "id":"hitmerger",
-                "channels":[
-                    {
-                        "name":"primary-get",
-                        "sockets":[
-                            {
-                                "type":"req",
-                                "method":"connect",
-                                "address":"ipc:///tmp/o2sim-primary-get-#PID#",
-                                "sndBufSize":"1000",
-                                "rcvBufSize":"1000",
-                                "rateLogging":"0"
-                            }
-                        ]
-                    },
-                    {
-                        "name":"o2sim-primserv-info",
-                        "sockets":[
-                            {
-                                "type":"req",
-                                "method":"connect",
-                                "address":"ipc:///tmp/o2sim-primserv-info-#PID#",
-                                "sndBufSize":"1000",
-                                "rcvBufSize":"1000",
-                                "rateLogging":"0"
-                            }
-                        ]
-                    },
-                    {
-                        "name":"simdata",
-                        "sockets":[
-                            {
-                                "type":"pull",
-                                "method":"bind",
-                                "address":"ipc:///tmp/o2sim-hitmerger-simdata-#PID#",
-                                "sndBufSize":1000,
-                                "rcvBufSize":1000,
-                                "rateLogging":0
-                            }
-                        ]
-                    },
-                    {
-                        "name":"merger-notifications",
-                        "sockets":[
-                            {
-                                "type":"pub",
-                                "method":"bind",
-                                "address":"ipc:///tmp/o2sim-merger-notifications-#PID#",
-                                "sndBufSize":1000,
-                                "rcvBufSize":1000,
-                                "rateLogging":0
-                            }
-                        ]
-                    }
-                ]
-            }
+  "fairMQOptions": {
+    "devices": [
+      {
+        "id": "worker",
+        "channels": [
+          {
+            "name": "primary-get",
+            "sockets": [
+              {
+                "type": "req",
+                "method": "connect",
+                "address": "ipc:///tmp/o2sim-primary-get-#PID#",
+                "sndBufSize": "100000",
+                "rcvBufSize": "100000",
+                "rateLogging": "0"
+              }
+            ]
+          },
+          {
+            "name": "o2sim-primserv-info",
+            "sockets": [
+              {
+                "type": "req",
+                "method": "connect",
+                "address": "ipc:///tmp/o2sim-primserv-info-#PID#",
+                "sndBufSize": "1000",
+                "rcvBufSize": "1000",
+                "rateLogging": "0"
+              }
+            ]
+          },
+          {
+            "name": "simdata",
+            "sockets": [
+              {
+                "type": "push",
+                "method": "connect",
+                "address": "ipc:///tmp/o2sim-hitmerger-simdata-#PID#",
+                "sndBufSize": 1000,
+                "rcvBufSize": 1000,
+                "rateLogging": 0
+              }
+            ]
+          }
         ]
-    }
+      },
+      {
+        "id": "primary-server",
+        "channels": [
+          {
+            "name": "primary-get",
+            "sockets": [
+              {
+                "type": "rep",
+                "method": "bind",
+                "address": "ipc:///tmp/o2sim-primary-get-#PID#",
+                "sndBufSize": 100000,
+                "rcvBufSize": 100000,
+                "rateLogging": 0
+              }
+            ]
+          },
+          {
+            "name": "o2sim-primserv-info",
+            "sockets": [
+              {
+                "type": "rep",
+                "method": "bind",
+                "address": "ipc:///tmp/o2sim-primserv-info-#PID#",
+                "sndBufSize": 1000,
+                "rcvBufSize": 1000,
+                "rateLogging": 0
+              }
+            ]
+          },
+          {
+            "name": "primary-notifications",
+            "sockets": [
+              {
+                "type": "pub",
+                "method": "bind",
+                "address": "ipc:///tmp/o2sim-primary-notifications-#PID#",
+                "sndBufSize": 1000,
+                "rcvBufSize": 1000,
+                "rateLogging": 0
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "hitmerger",
+        "channels": [
+          {
+            "name": "primary-get",
+            "sockets": [
+              {
+                "type": "req",
+                "method": "connect",
+                "address": "ipc:///tmp/o2sim-primary-get-#PID#",
+                "sndBufSize": "1000",
+                "rcvBufSize": "1000",
+                "rateLogging": "0"
+              }
+            ]
+          },
+          {
+            "name": "o2sim-primserv-info",
+            "sockets": [
+              {
+                "type": "req",
+                "method": "connect",
+                "address": "ipc:///tmp/o2sim-primserv-info-#PID#",
+                "sndBufSize": "1000",
+                "rcvBufSize": "1000",
+                "rateLogging": "0"
+              }
+            ]
+          },
+          {
+            "name": "simdata",
+            "sockets": [
+              {
+                "type": "pull",
+                "method": "bind",
+                "address": "ipc:///tmp/o2sim-hitmerger-simdata-#PID#",
+                "sndBufSize": 1000,
+                "rcvBufSize": 1000,
+                "rateLogging": 0
+              }
+            ]
+          },
+          {
+            "name": "kineforward",
+            "sockets": [
+              {
+                "type": "pub",
+                "method": "bind",
+                "address": "ipc:///tmp/o2sim-hitmerger-kineforward",
+                "sndBufSize": 1000,
+                "rcvBufSize": 1000,
+                "rateLogging": 0
+              }
+            ]
+          },
+          {
+            "name": "merger-notifications",
+            "sockets": [
+              {
+                "type": "pub",
+                "method": "bind",
+                "address": "ipc:///tmp/o2sim-merger-notifications-#PID#",
+                "sndBufSize": 1000,
+                "rcvBufSize": 1000,
+                "rateLogging": 0
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
The hit merger can now optionally forward kinematics (MCEventHeaders, MCTracks) on a FairMQ channel. This is useful for on-the-fly processing of tracks in analysis or other (DPL) consumers.

On the DPL side, a new proxy device is offered to pickup and forward MCTracks and MCEventHeaders on DPL channels.

This PR offers prototype status to play with the new feature. See the new SimExample for instructions.

A couple of things remain to be done:
a) configuration of the FairMQ channel on which mctracks are sent
   (currently works for one instance of o2-sim only)
b) ability to use pipes to connect o2-sim, the proxy, and further consumers:
   `o2-sim ... | o2-sim-mctracks-proxy | some-analysis`

https://alice.its.cern.ch/jira/browse/O2-3319