### PR TITLE
PHOS calibrations check file path in device init

### DIFF
--- a/Detectors/PHOS/calib/src/PHOSEnergyCalibDevice.cxx
+++ b/Detectors/PHOS/calib/src/PHOSEnergyCalibDevice.cxx
@@ -38,6 +38,13 @@ void PHOSEnergyCalibDevice::init(o2::framework::InitContext& ic)
   mEDigMin = ic.options().get<float>("ecalibdigitmin");
   mECluMin = ic.options().get<float>("ecalibclumin");
 
+  if (mOutputDir.compare("/dev/null")) {
+    mOutputDir = o2::utils::Str::rectifyDirectory(mOutputDir);
+  }
+  if (mMetaFileDir.compare("/dev/null")) {
+    mMetaFileDir = o2::utils::Str::rectifyDirectory(mMetaFileDir);
+  }
+
   LOG(info) << "Energy calibration options";
   LOG(info) << " output-dif=" << mOutputDir;
   bool toFillDigits = mOutputDir.compare("/dev/null");

--- a/Detectors/PHOS/calib/src/PHOSRunbyrunCalibDevice.cxx
+++ b/Detectors/PHOS/calib/src/PHOSRunbyrunCalibDevice.cxx
@@ -27,6 +27,13 @@ void PHOSRunbyrunCalibDevice::init(o2::framework::InitContext& ic)
   o2::base::GRPGeomHelper::instance().setRequest(mCCDBRequest);
   mCalibrator.reset(new PHOSRunbyrunCalibrator());
 
+  if (mOutputDir.compare("/dev/null")) {
+    mOutputDir = o2::utils::Str::rectifyDirectory(mOutputDir);
+  }
+  if (mMetaFileDir.compare("/dev/null")) {
+    mMetaFileDir = o2::utils::Str::rectifyDirectory(mMetaFileDir);
+  }
+
   // mCalibrator->setSlotLength(slotL);
   // mCalibrator->setMaxSlotsDelay(delay);
   mCalibrator->setUpdateAtTheEndOfRunOnly();

--- a/Detectors/PHOS/calib/src/phos-calib-workflow.cxx
+++ b/Detectors/PHOS/calib/src/phos-calib-workflow.cxx
@@ -68,15 +68,10 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 
   bool writeRootOutput = !configcontext.options().get<bool>("disable-root-output");
   std::string outputDir = configcontext.options().get<std::string>("phoscalib-output-dir");
-  if (outputDir.compare("/dev/null")) {
-    outputDir = o2::utils::Str::rectifyDirectory(outputDir);
-  } else {
+  if (!outputDir.compare("/dev/null")) {
     writeRootOutput = false;
   }
   std::string metaFileDir = configcontext.options().get<std::string>("phoscalib-meta-output-dir");
-  if (metaFileDir.compare("/dev/null")) {
-    metaFileDir = o2::utils::Str::rectifyDirectory(metaFileDir);
-  }
 
   if (doPedestals && doHgLgRatio) {
     LOG(fatal) << "Can not run pedestal and HG/LG calibration simulteneously";


### PR DESCRIPTION
We should not check file paths in the `defineDataProcessing` method. Otherwise we fail to create a topology on the infrastructure EPNs where the directories in `/data` are not available.
Therefore I moved the calls to `rectifyDirecetory` into the `init` function of the devices.