### PR TITLE
tof digitizer reads params from ccdb and cleanup

### DIFF
--- a/Detectors/GlobalTracking/CMakeLists.txt
+++ b/Detectors/GlobalTracking/CMakeLists.txt
@@ -21,6 +21,7 @@ o2_add_library(GlobalTracking
                        src/MatchITSTPCQC.cxx
                        src/ITSTPCMatchingQCParams.cxx
                        src/MatchGlobalFwdParam.cxx
+                       src/MatchTOFParams.cxx
   PUBLIC_LINK_LIBRARIES O2::Framework
                         O2::DataFormatsTPC
                         O2::DataFormatsITSMFT

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTOF.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTOF.h
@@ -40,6 +40,7 @@
 #include "TPCFastTransform.h"
 #include "CommonDataFormat/InteractionRecord.h"
 #include "CorrectionMapsHelper.h"
+#include "GlobalTracking/MatchTOFParams.h"
 
 // from FIT
 #include "DataFormatsFT0/RecPoints.h"
@@ -220,6 +221,9 @@ class MatchTOF
   const o2::globaltracking::RecoContainer* mRecoCont = nullptr;
   o2::InteractionRecord mStartIR{0, 0}; ///< IR corresponding to the start of the TF
 
+  // TOF matching params (work in progress)
+  const MatchTOFParams* mMatchParams = nullptr;
+
   // for derived class
   int mCurrTracksTreeEntry = 0; ///< current tracks tree entry loaded to memory
 
@@ -321,7 +325,7 @@ class MatchTOF
   TStopwatch mTimerMatchITSTPC;
   TStopwatch mTimerMatchTPC;
   TStopwatch mTimerDBG;
-  ClassDefNV(MatchTOF, 4);
+  ClassDefNV(MatchTOF, 5);
 };
 } // namespace globaltracking
 } // namespace o2

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTOFParams.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTOFParams.h
@@ -1,0 +1,34 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author fnoferin@cern.ch
+
+#ifndef ALICEO2_MATCHTOF_PARAMS_H
+#define ALICEO2_MATCHTOF_PARAMS_H
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "CommonUtils/ConfigurableParamHelper.h"
+
+namespace o2
+{
+namespace globaltracking
+{
+
+struct MatchTOFParams : public o2::conf::ConfigurableParamHelper<MatchTOFParams> {
+  float calibMaxChi2 = 3.0;
+
+  O2ParamDef(MatchTOFParams, "MatchTOF");
+};
+
+} // namespace globaltracking
+} // end namespace o2
+
+#endif

--- a/Detectors/GlobalTracking/src/GlobalTrackingLinkDef.h
+++ b/Detectors/GlobalTracking/src/GlobalTrackingLinkDef.h
@@ -25,6 +25,9 @@
 #pragma link C++ class o2::globaltracking::MatchCosmicsParams + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::globaltracking::MatchCosmicsParams> + ;
 
+#pragma link C++ class o2::globaltracking::MatchTOFParams + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::globaltracking::MatchTOFParams> + ;
+
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::globaltracking::ITSTPCMatchingQCParams> + ;
 
 #pragma link C++ class o2::globaltracking::GloFwdAssessment + ;

--- a/Detectors/GlobalTracking/src/MatchTOF.cxx
+++ b/Detectors/GlobalTracking/src/MatchTOF.cxx
@@ -57,6 +57,10 @@ ClassImp(MatchTOF);
 //______________________________________________
 void MatchTOF::run(const o2::globaltracking::RecoContainer& inp)
 {
+  if (!mMatchParams) {
+    mMatchParams = &o2::globaltracking::MatchTOFParams::Instance();
+  }
+
   ///< running the matching
   mRecoCont = &inp;
   mStartIR = inp.startIR;
@@ -1160,7 +1164,7 @@ void MatchTOF::selectBestMatches()
       flags = flags | o2::dataformats::CalibInfoTOF::kMultiHit;
     }
 
-    if (matchingPair.getChi2() < 3) { // extra cut in Chi2 for storing calib info
+    if (matchingPair.getChi2() < mMatchParams->calibMaxChi2) { // extra cut in ChiSquare for storing calib info
       mCalibInfoTOF.emplace_back(mTOFClusWork[matchingPair.getTOFClIndex()].getMainContributingChannel(),
                                  mTimestamp / 1000 + int(mTOFClusWork[matchingPair.getTOFClIndex()].getTimeRaw() * 1E-12), // add time stamp
                                  deltat,

--- a/Detectors/GlobalTracking/src/MatchTOF.cxx
+++ b/Detectors/GlobalTracking/src/MatchTOF.cxx
@@ -1160,7 +1160,7 @@ void MatchTOF::selectBestMatches()
       flags = flags | o2::dataformats::CalibInfoTOF::kMultiHit;
     }
 
-    if (matchingPair.getChi2() < 3) { // extra cut in Chi2
+    if (matchingPair.getChi2() < 3) { // extra cut in Chi2 for storing calib info
       mCalibInfoTOF.emplace_back(mTOFClusWork[matchingPair.getTOFClIndex()].getMainContributingChannel(),
                                  mTimestamp / 1000 + int(mTOFClusWork[matchingPair.getTOFClIndex()].getTimeRaw() * 1E-12), // add time stamp
                                  deltat,

--- a/Detectors/GlobalTracking/src/MatchTOF.cxx
+++ b/Detectors/GlobalTracking/src/MatchTOF.cxx
@@ -1160,10 +1160,12 @@ void MatchTOF::selectBestMatches()
       flags = flags | o2::dataformats::CalibInfoTOF::kMultiHit;
     }
 
-    mCalibInfoTOF.emplace_back(mTOFClusWork[matchingPair.getTOFClIndex()].getMainContributingChannel(),
-                               mTimestamp / 1000 + int(mTOFClusWork[matchingPair.getTOFClIndex()].getTimeRaw() * 1E-12), // add time stamp
-                               deltat,
-                               mTOFClusWork[matchingPair.getTOFClIndex()].getTot(), mask, flags);
+    if (matchingPair.getChi2() < 3) { // extra cut in Chi2
+      mCalibInfoTOF.emplace_back(mTOFClusWork[matchingPair.getTOFClIndex()].getMainContributingChannel(),
+                                 mTimestamp / 1000 + int(mTOFClusWork[matchingPair.getTOFClIndex()].getTimeRaw() * 1E-12), // add time stamp
+                                 deltat,
+                                 mTOFClusWork[matchingPair.getTOFClIndex()].getTot(), mask, flags);
+    }
 
     if (mMCTruthON) {
       const auto& labelsTOF = mTOFClusLabels->getLabels(matchingPair.getTOFClIndex());

--- a/Detectors/GlobalTracking/src/MatchTOFParams.cxx
+++ b/Detectors/GlobalTracking/src/MatchTOFParams.cxx
@@ -1,0 +1,17 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file MatchTOFParams.h
+/// \brief Configurable params for TOF matching
+/// \author fnoferin@cern.ch
+
+#include "GlobalTracking/MatchTOFParams.h"
+O2ParamImpl(o2::globaltracking::MatchTOFParams);

--- a/Detectors/TOF/simulation/include/TOFSimulation/Digitizer.h
+++ b/Detectors/TOF/simulation/include/TOFSimulation/Digitizer.h
@@ -71,6 +71,17 @@ class Digitizer : public WindowFiller
   void test(const char* geo = "");
   void testFromHits(const char* geo = "", const char* hits = "AliceO2_TGeant3.tof.mc_10_event.root");
 
+  void setShowerSmearing();
+  void setResolution(float val)
+  {
+    mTOFresolution = val;
+    setShowerSmearing();
+  }
+  void setEffCenter(float val) { mEffCenter = val; }
+  void setEffBoundary1(float val) { mEffBoundary1 = val; }
+  void setEffBoundary2(float val) { mEffBoundary2 = val; }
+  void setEffBoundary3(float val) { mEffBoundary3 = val; }
+
  private:
   // parameters
   Int_t mMode;

--- a/Detectors/TOF/simulation/src/Digitizer.cxx
+++ b/Detectors/TOF/simulation/src/Digitizer.cxx
@@ -518,6 +518,17 @@ Float_t Digitizer::getEffZ(Float_t z)
 //______________________________________________________________________
 Float_t Digitizer::getFractionOfCharge(Float_t x, Float_t z) { return 1; }
 //______________________________________________________________________
+void Digitizer::setShowerSmearing()
+{
+  mShowerResolution = 50; // smearing correlated for all digits of the same hit
+  if (mTOFresolution > mShowerResolution) {
+    mDigitResolution = TMath::Sqrt(mTOFresolution * mTOFresolution - mShowerResolution * mShowerResolution); // independent smearing for each digit
+  } else {
+    mShowerResolution = mTOFresolution;
+    mDigitResolution = 0;
+  }
+}
+//______________________________________________________________________
 void Digitizer::initParameters()
 {
   // boundary references for interpolation of efficiency and resolution
@@ -528,14 +539,7 @@ void Digitizer::initParameters()
 
   // resolution parameters
   mTOFresolution = TOFSimParams::Instance().time_resolution; // TOF global resolution in ps
-  mShowerResolution = 50; // smearing correlated for all digits of the same hit
-  if (mTOFresolution > mShowerResolution) {
-    mDigitResolution = TMath::Sqrt(mTOFresolution * mTOFresolution -
-                                   mShowerResolution * mShowerResolution); // independent smearing for each digit
-  } else {
-    mShowerResolution = mTOFresolution;
-    mDigitResolution = 0;
-  }
+  setShowerSmearing();
 
   mTimeSlope = 100;     // ps/cm extra smearing if hit out of pad propto the distance from the border
   mTimeDelay = 70;      // time delay if hit out of pad

--- a/Detectors/TOF/workflowIO/include/TOFWorkflowIO/DigitReaderSpec.h
+++ b/Detectors/TOF/workflowIO/include/TOFWorkflowIO/DigitReaderSpec.h
@@ -43,6 +43,7 @@ class DigitReader : public Task
   int mState = 0;
   int mCurrentEntry = 0;
   bool mUseMC = true;
+  int mDelayInMuSec1TF = 0;
   WindowFiller mFiller;
   std::unique_ptr<TFile> mFile = nullptr;
   std::vector<o2::tof::Digit> mDigits, *mPdigits = &mDigits;

--- a/Detectors/TOF/workflowIO/src/DigitReaderSpec.cxx
+++ b/Detectors/TOF/workflowIO/src/DigitReaderSpec.cxx
@@ -35,6 +35,8 @@ void DigitReader::init(InitContext& ic)
   LOG(debug) << "Init Digit reader!";
   auto filename = o2::utils::Str::concat_string(o2::utils::Str::rectifyDirectory(ic.options().get<std::string>("input-dir")),
                                                 ic.options().get<std::string>("tof-digit-infile"));
+  mDelayInMuSec1TF = atoi(ic.options().get<std::string>("delay-1st-tf").c_str()) * 1E6;
+
   mFile.reset(TFile::Open(filename.c_str()));
   if (!mFile->IsOpen()) {
     LOG(error) << "Cannot open the " << filename.c_str() << " file !";
@@ -46,6 +48,12 @@ void DigitReader::init(InitContext& ic)
 
 void DigitReader::run(ProcessingContext& pc)
 {
+  static bool firstCall = true;
+  if (firstCall) {
+    usleep(mDelayInMuSec1TF);
+  }
+  firstCall = false;
+
   if (mState != 1) {
     return;
   }
@@ -118,6 +126,7 @@ DataProcessorSpec getDigitReaderSpec(bool useMC)
     AlgorithmSpec{adaptFromTask<DigitReader>(useMC)},
     Options{
       {"tof-digit-infile", VariantType::String, "tofdigits.root", {"Name of the input file"}},
+      {"delay-1st-tf", VariantType::String, "none", {"delay in seconds before 1st TF"}},
       {"input-dir", VariantType::String, "none", {"Input directory"}}}};
 }
 

--- a/Detectors/TOF/workflowIO/src/DigitReaderSpec.cxx
+++ b/Detectors/TOF/workflowIO/src/DigitReaderSpec.cxx
@@ -35,7 +35,7 @@ void DigitReader::init(InitContext& ic)
   LOG(debug) << "Init Digit reader!";
   auto filename = o2::utils::Str::concat_string(o2::utils::Str::rectifyDirectory(ic.options().get<std::string>("input-dir")),
                                                 ic.options().get<std::string>("tof-digit-infile"));
-  mDelayInMuSec1TF = atoi(ic.options().get<std::string>("delay-1st-tf").c_str()) * 1E6;
+  mDelayInMuSec1TF = atof(ic.options().get<std::string>("delay-1st-tf").c_str()) * 1E6;
 
   mFile.reset(TFile::Open(filename.c_str()));
   if (!mFile->IsOpen()) {

--- a/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
+++ b/Steer/DigitizerWorkflow/src/SimpleDigitizerWorkflow.cxx
@@ -189,7 +189,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 
   // option to use/not use CCDB for TOF
   workflowOptions.push_back(ConfigParamSpec{"use-ccdb-tof", o2::framework::VariantType::Bool, false, {"enable access to ccdb tof calibration objects"}});
-  workflowOptions.push_back(ConfigParamSpec{"ccdb-tof-sa", o2::framework::VariantType::Bool, false, {"enable access to ccdb tof calibration objects via CCDBManager (standalone)"}});
+  workflowOptions.push_back(ConfigParamSpec{"ccdb-tof-sa", o2::framework::VariantType::Bool, false, {"enable access to ccdb tof calibration objects via CCDBManager (obsolete remap to use-ccdb-tof)"}});
 
   // option to use/not use CCDB for FT0
   workflowOptions.push_back(ConfigParamSpec{"use-ccdb-ft0", o2::framework::VariantType::Bool, true, {"enable access to ccdb ft0 calibration objects"}});
@@ -613,17 +613,14 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   // the TOF part
   if (isEnabled(o2::detectors::DetID::TOF)) {
     auto useCCDB = configcontext.options().get<bool>("use-ccdb-tof");
-    auto CCDBsa = configcontext.options().get<bool>("ccdb-tof-sa");
+    useCCDB |= configcontext.options().get<bool>("ccdb-tof-sa");
     auto ccdb_url_tof = o2::base::NameConf::getCCDBServer();
     auto timestamp = o2::raw::HBFUtils::Instance().startTime / 1000;
     detList.emplace_back(o2::detectors::DetID::TOF);
     // connect the TOF digitization
     // printf("TOF Setting: use-ccdb = %d ---- ccdb url=%s  ----   timestamp=%ld\n", useCCDB, ccdb_url_tof.c_str(), timestamp);
 
-    if (CCDBsa) {
-      useCCDB = true;
-    }
-    digitizerSpecs.emplace_back(o2::tof::getTOFDigitizerSpec(fanoutsize++, useCCDB, mctruth, ccdb_url_tof.c_str(), timestamp, CCDBsa));
+    digitizerSpecs.emplace_back(o2::tof::getTOFDigitizerSpec(fanoutsize++, useCCDB, mctruth, ccdb_url_tof.c_str(), timestamp));
     // add TOF digit writer
     writerSpecs.emplace_back(o2::tof::getTOFDigitWriterSpec(mctruth));
   }

--- a/Steer/DigitizerWorkflow/src/TOFDigitizerSpec.h
+++ b/Steer/DigitizerWorkflow/src/TOFDigitizerSpec.h
@@ -19,7 +19,7 @@ namespace o2
 namespace tof
 {
 
-o2::framework::DataProcessorSpec getTOFDigitizerSpec(int channel, bool useCCDB, bool mctruth, std::string ccdb_url, int timestamp, bool ccdbSA = false);
+o2::framework::DataProcessorSpec getTOFDigitizerSpec(int channel, bool useCCDB, bool mctruth, std::string ccdb_url, int timestamp);
 
 } // end namespace tof
 } // end namespace o2


### PR DESCRIPTION
Digitization parameters are updated from ccdb

--ccdb-tof-sa flag was already obsolete -> some cleanup (param left for consistency with the script -> remapped in use-ccdb-tof)