### PR TITLE
Require alien token for all https URLs and for alice-ccdb.cern.ch, throw fatal if not present

### DIFF
--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -63,6 +63,8 @@ class CcdbApi //: public DatabaseInterface
 
   const std::string getUniqueAgentID() const { return mUniqueAgentID; }
 
+  static bool checkAlienToken();
+
   /**
    * Initialize connection to CCDB
    *

--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -63,6 +63,25 @@ CcdbApi::~CcdbApi()
   curl_global_cleanup();
 }
 
+bool CcdbApi::checkAlienToken()
+{
+#ifdef __APPLE__
+  LOG(debug) << "On macOS we simply rely on TGrid::Connect(\"alien\").";
+  return true;
+#endif
+  if (getenv("ALICEO2_CCDB_NOTOKENCHECK") && atoi(getenv("ALICEO2_CCDB_NOTOKENCHECK"))) {
+    return true;
+  }
+  if (getenv("JALIEN_TOKEN_CERT")) {
+    return true;
+  }
+  auto returncode = system("alien-token-info &> /dev/nulll");
+  if (returncode == -1) {
+    LOG(error) << "...";
+  }
+  return returncode == 0;
+}
+
 void CcdbApi::curlInit()
 {
   // todo : are there other things to initialize globally for curl ?
@@ -120,7 +139,7 @@ void CcdbApi::init(std::string const& host)
   }
 
   const std::string httpsprefix = "https://";
-  mNeedAlienToken = host.substr(0, httpsprefix.size()) == httpsprefix) || host == "http://alice-ccdb.cern.ch";
+  mNeedAlienToken = host.substr(0, httpsprefix.size()) == httpsprefix || host == "http://alice-ccdb.cern.ch";
 
   LOGP(info, "Init CcdApi with UserAgentID: {}, Host: {}{}", mUniqueAgentID, host,
        mInSnapshotMode ? "(snapshot readonly mode)" : snapshotReport.c_str());
@@ -754,10 +773,13 @@ void* CcdbApi::extractFromLocalFile(std::string const& filename, std::type_info 
 bool CcdbApi::initTGrid() const
 {
   if (mNeedAlienToken && !mAlienInstance) {
+    static bool allowNoToken = getenv("ALICEO2_CCDB_NOTOKENCHECK") && atoi(getenv("ALICEO2_CCDB_NOTOKENCHECK"));
+    if (!allowNoToken && !checkAlienToken()) {
+      LOG(fatal) << "Alien Token Check failed - Please get an alien token before running with https CCDB endpoint, or alice-ccdb.cern.ch!";
+    }
     mAlienInstance = TGrid::Connect("alien");
     static bool errorShown = false;
     if (!mAlienInstance && errorShown == false) {
-      bool allowNoToken = getenv("O2_CCDB_ALLOW_NO_TOKEN") && atoi(getenv("O2_CCDB_ALLOW_NO_TOKEN"));
       if (allowNoToken) {
         LOG(error) << "TGrid::Connect returned nullptr. May be due to missing alien token";
       } else {


### PR DESCRIPTION
@shahor02 @sawenzel @costing : How about this check in the ccdb API?