### PR TITLE
GPUTRDTrack move getter method to header

### DIFF
--- a/GPU/GPUTracking/DataTypes/GPUTRDTrack.cxx
+++ b/GPU/GPUTracking/DataTypes/GPUTRDTrack.cxx
@@ -160,19 +160,6 @@ GPUd() int GPUTRDTrack_t<T>::getNlayersFindable() const
 }
 
 template <typename T>
-GPUd() int GPUTRDTrack_t<T>::getNtracklets() const
-{
-  // returns number of tracklets attached to this track
-  int retVal = 0;
-  for (int iLy = 0; iLy < kNLayers; ++iLy) {
-    if (mAttachedTracklets[iLy] >= 0) {
-      ++retVal;
-    }
-  }
-  return retVal;
-}
-
-template <typename T>
 GPUd() int GPUTRDTrack_t<T>::getNmissingConsecLayers(int iLayer) const
 {
   // returns number of consecutive layers in which the track was

--- a/GPU/GPUTracking/DataTypes/GPUTRDTrack.h
+++ b/GPU/GPUTracking/DataTypes/GPUTRDTrack.h
@@ -84,7 +84,18 @@ class GPUTRDTrack_t : public T
   // This method is only defined in TrackTRD.h and is intended to be used only with that TRD track type
   GPUd() o2::dataformats::GlobalTrackID getRefGlobalTrackId() const;
   GPUd() short getCollisionId() const { return mCollisionId; }
-  GPUd() int getNtracklets() const;
+  GPUd() int getNtracklets() const
+  {
+    // returns number of tracklets attached to this track
+    int retVal = 0;
+    for (int iLy = 0; iLy < kNLayers; ++iLy) {
+      if (mAttachedTracklets[iLy] >= 0) {
+        ++retVal;
+      }
+    }
+    return retVal;
+  }
+
   GPUd() float getChi2() const { return mChi2; }
   GPUd() unsigned char getIsCrossingNeighbor() const { return mIsCrossingNeighbor; }
   GPUd() bool getIsCrossingNeighbor(int iLayer) const { return mIsCrossingNeighbor & (1 << iLayer); }


### PR DESCRIPTION
Otherwise, when trying to use `TrackTRD::getNtracklets()` in QualityControl we have an undefined symbol `o2::gpu::GPUTRDTrack_t<o2::gpu::trackInterface<o2::track::TrackParametrizationWithError<float> > >::getNtracklets() const`.