### PR TITLE
[EMCAL-830] Options to drop or redirect cells from LED events

### DIFF
--- a/Detectors/EMCAL/workflow/src/CellRecalibratorSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/CellRecalibratorSpec.cxx
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <filesystem>
 #include <gsl/span>
+#include "CommonConstants/Triggers.h"
 #include "DataFormatsEMCAL/Cell.h"
 #include "DataFormatsEMCAL/TriggerRecord.h"
 #include "EMCALCalib/BadChannelMap.h"
@@ -19,11 +20,10 @@
 #include "EMCALCalib/GainCalibrationFactors.h"
 #include "EMCALWorkflow/CellRecalibratorSpec.h"
 #include "Framework/CCDBParamSpec.h"
-#include <TFile.h>
 
 using namespace o2::emcal;
 
-CellRecalibratorSpec::CellRecalibratorSpec(uint32_t outputspec, bool badChannelCalib, bool timeCalib, bool gainCalib, std::shared_ptr<o2::emcal::CalibLoader> calibHandler) : mOutputSubspec(outputspec), mCalibrationHandler(calibHandler)
+CellRecalibratorSpec::CellRecalibratorSpec(uint32_t outputspec, LEDEventSettings ledsettings, bool badChannelCalib, bool timeCalib, bool gainCalib, std::shared_ptr<o2::emcal::CalibLoader> calibHandler) : mOutputSubspec(outputspec), mLEDsettings(ledsettings), mCalibrationHandler(calibHandler)
 {
   setRunBadChannelCalibration(badChannelCalib);
   setRunTimeCalibration(timeCalib);
@@ -36,6 +36,19 @@ void CellRecalibratorSpec::init(framework::InitContext& ctx)
   LOG(info) << "Bad channel calibration: " << (isRunBadChannlCalibration() ? "enabled" : "disabled");
   LOG(info) << "Time calibration:        " << (isRunTimeCalibration() ? "enabled" : "disabled");
   LOG(info) << "Gain calibration:        " << (isRunGainCalibration() ? "enabled" : "disabled");
+  std::string ledsettingstitle;
+  switch (mLEDsettings) {
+    case LEDEventSettings::KEEP:
+      ledsettingstitle = "keep";
+      break;
+    case LEDEventSettings::DROP:
+      ledsettingstitle = "drop";
+      break;
+    case LEDEventSettings::REDIRECT:
+      ledsettingstitle = "redirect to EMC/CELLS/10";
+      break;
+  };
+  LOG(info) << "Handling of LED events: " << ledsettingstitle;
 }
 
 void CellRecalibratorSpec::run(framework::ProcessingContext& ctx)
@@ -50,25 +63,58 @@ void CellRecalibratorSpec::run(framework::ProcessingContext& ctx)
   std::vector<o2::emcal::Cell> outputcells;
   std::vector<o2::emcal::TriggerRecord> outputtriggers;
 
-  uint32_t currentfirst = outputcells.size();
+  // Prepare containers for LED triggers (in case they should be redirected to a different output)
+  std::vector<o2::emcal::Cell> ledcells;
+  std::vector<o2::emcal::TriggerRecord> ledtriggers;
+
+  uint32_t currentfirst = outputcells.size(),
+           currentledfirst = ledcells.size();
   for (const auto& trg : intputtriggers) {
+    if (trg.getTriggerBits() & o2::trigger::Cal) {
+      switch (mLEDsettings) {
+        case LEDEventSettings::KEEP:
+          // LED events stay always uncalibrated
+          writeTrigger(inputcells.subspan(trg.getFirstEntry(), trg.getNumberOfObjects()), trg, outputcells, outputtriggers);
+          continue;
+        case LEDEventSettings::DROP:
+          // LED events will be dropped, simply discard them
+          continue;
+        case LEDEventSettings::REDIRECT: {
+          // LED events stay always uncalibrated
+          writeTrigger(inputcells.subspan(trg.getFirstEntry(), trg.getNumberOfObjects()), trg, ledcells, ledtriggers);
+          continue;
+        }
+      };
+    }
     if (!trg.getNumberOfObjects()) {
-      outputtriggers.emplace_back(trg.getBCData(), currentfirst, trg.getNumberOfObjects()).setTriggerBits(trg.getTriggerBits());
+      outputtriggers.emplace_back(trg.getBCData(), outputcells.size(), trg.getNumberOfObjects()).setTriggerBits(trg.getTriggerBits());
       continue;
     }
     auto calibratedCells = mCellRecalibrator.getCalibratedCells(gsl::span<const o2::emcal::Cell>(inputcells.data() + trg.getFirstEntry(), trg.getNumberOfObjects()));
-    if (calibratedCells.size()) {
-      std::copy(calibratedCells.begin(), calibratedCells.end(), std::back_insert_iterator(outputcells));
-    }
-    outputtriggers.emplace_back(trg.getBCData(), currentfirst, calibratedCells.size()).setTriggerBits(trg.getTriggerBits());
-    currentfirst = outputcells.size();
+    writeTrigger(calibratedCells, trg, outputcells, outputtriggers);
   }
 
   LOG(info) << "Timeframe: " << inputcells.size() << " cells read, " << outputcells.size() << " cells kept";
+  if (mLEDsettings == LEDEventSettings::REDIRECT) {
+    LOG(info) << "Redirecting " << ledcells.size() << " LED cells from " << ledtriggers.size() << " LED triggers";
+  }
 
   // send recalibrated objects
   ctx.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginEMC, "CELLS", mOutputSubspec, o2::framework::Lifetime::Timeframe}, outputcells);
   ctx.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginEMC, "CELLSTRGR", mOutputSubspec, o2::framework::Lifetime::Timeframe}, outputtriggers);
+  if (mLEDsettings == LEDEventSettings::REDIRECT) {
+    ctx.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginEMC, "CELLS", 10, o2::framework::Lifetime::Timeframe}, ledcells);
+    ctx.outputs().snapshot(o2::framework::Output{o2::header::gDataOriginEMC, "CELLSTRGR", 10, o2::framework::Lifetime::Timeframe}, ledtriggers);
+  }
+}
+
+void CellRecalibratorSpec::writeTrigger(const gsl::span<const o2::emcal::Cell> selectedCells, const o2::emcal::TriggerRecord& currenttrigger, std::vector<o2::emcal::Cell>& outputcontainer, std::vector<o2::emcal::TriggerRecord>& outputtriggers)
+{
+  std::size_t currentfirst = outputcontainer.size();
+  if (selectedCells.size()) {
+    std::copy(selectedCells.begin(), selectedCells.end(), std::back_inserter(outputcontainer));
+  }
+  outputtriggers.emplace_back(currenttrigger.getBCData(), currentfirst, selectedCells.size()).setTriggerBits(currenttrigger.getTriggerBits());
 }
 
 void CellRecalibratorSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)
@@ -101,7 +147,7 @@ void CellRecalibratorSpec::updateCalibObjects()
   }
 }
 
-o2::framework::DataProcessorSpec o2::emcal::getCellRecalibratorSpec(uint32_t inputSubspec, uint32_t outputSubspec, bool badChannelCalib, bool timeCalib, bool gainCalib)
+o2::framework::DataProcessorSpec o2::emcal::getCellRecalibratorSpec(uint32_t inputSubspec, uint32_t outputSubspec, uint32_t ledsettings, bool badChannelCalib, bool timeCalib, bool gainCalib)
 {
   auto calibhandler = std::make_shared<o2::emcal::CalibLoader>();
   calibhandler->enableBadChannelMap(badChannelCalib);
@@ -110,12 +156,30 @@ o2::framework::DataProcessorSpec o2::emcal::getCellRecalibratorSpec(uint32_t inp
   std::vector<o2::framework::InputSpec>
     inputs = {{"cells", o2::header::gDataOriginEMC, "CELLS", inputSubspec, o2::framework::Lifetime::Timeframe},
               {"triggerrecords", o2::header::gDataOriginEMC, "CELLSTRGR", inputSubspec, o2::framework::Lifetime::Timeframe}};
+  CellRecalibratorSpec::LEDEventSettings taskledsettings = CellRecalibratorSpec::LEDEventSettings::KEEP;
+  switch (ledsettings) {
+    case 0:
+      taskledsettings = CellRecalibratorSpec::LEDEventSettings::KEEP;
+      break;
+    case 1:
+      taskledsettings = CellRecalibratorSpec::LEDEventSettings::DROP;
+      break;
+    case 2:
+      taskledsettings = CellRecalibratorSpec::LEDEventSettings::REDIRECT;
+      break;
+    default:
+      LOG(fatal) << "Undefined handling of LED events";
+  }
   std::vector<o2::framework::OutputSpec> outputs = {{o2::header::gDataOriginEMC, "CELLS", outputSubspec, o2::framework::Lifetime::Timeframe},
                                                     {o2::header::gDataOriginEMC, "CELLSTRGR", outputSubspec, o2::framework::Lifetime::Timeframe}};
+  if (taskledsettings == CellRecalibratorSpec::LEDEventSettings::REDIRECT) {
+    outputs.push_back({o2::header::gDataOriginEMC, "CELLS", 10, o2::framework::Lifetime::Timeframe});
+    outputs.push_back({o2::header::gDataOriginEMC, "CELLSTRGR", 10, o2::framework::Lifetime::Timeframe});
+  }
   calibhandler->defineInputSpecs(inputs);
 
   return o2::framework::DataProcessorSpec{"EMCALCellRecalibrator",
                                           inputs,
                                           outputs,
-                                          o2::framework::adaptFromTask<o2::emcal::CellRecalibratorSpec>(outputSubspec, badChannelCalib, timeCalib, gainCalib, calibhandler)};
+                                          o2::framework::adaptFromTask<o2::emcal::CellRecalibratorSpec>(outputSubspec, taskledsettings, badChannelCalib, timeCalib, gainCalib, calibhandler)};
 }

--- a/Detectors/EMCAL/workflow/src/cell-recalibrator-workflow.cxx
+++ b/Detectors/EMCAL/workflow/src/cell-recalibrator-workflow.cxx
@@ -34,6 +34,8 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
                                        {"no-badchannelcalib", VariantType::Bool, false, {"Disable bad channel calibration"}},
                                        {"no-timecalib", VariantType::Bool, false, {"Disable time calibration"}},
                                        {"no-gaincalib", VariantType::Bool, false, {"Disable gain calibration"}},
+                                       {"drop-led", VariantType::Bool, false, {"Drop LED events"}},
+                                       {"redirect-led", VariantType::Bool, false, {"Redirect LED events"}},
                                        {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
   workflowOptions.insert(workflowOptions.end(), options.begin(), options.end());
@@ -52,10 +54,25 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   auto inputsubspec = cfgc.options().get<uint32_t>("input-subspec"),
        outputsubspec = cfgc.options().get<uint32_t>("output-subspec");
 
+  // LED event handling
+  auto dropled = cfgc.options().get<bool>("drop-led"),
+       redirectled = cfgc.options().get<bool>("redirect-led");
+
+  if (dropled && redirectled) {
+    LOG(fatal) << "Ambiguous handling of LED events";
+  }
+  uint32_t ledsetting = 0;
+  if (dropled) {
+    ledsetting = 1;
+  }
+  if (redirectled) {
+    ledsetting = 2;
+  }
+
   o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
 
   WorkflowSpec specs;
-  specs.emplace_back(o2::emcal::getCellRecalibratorSpec(inputsubspec, outputsubspec, !disableBadchannels, !disableTime, !disableEnergy));
+  specs.emplace_back(o2::emcal::getCellRecalibratorSpec(inputsubspec, outputsubspec, ledsetting, !disableBadchannels, !disableTime, !disableEnergy));
 
   // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit
   o2::raw::HBFUtilsInitializer hbfIni(cfgc, specs);


### PR DESCRIPTION
Recalibrator can either keep LED events in
the standard cell output, drop them entirely
or redirect them to EMC/CELLS and
EMC/CELLSTRGR on subspec 10