### PR TITLE
Updated TimeSlotCalibration interface

### DIFF
--- a/Detectors/CPV/calib/include/CPVCalibration/GainCalibrator.h
+++ b/Detectors/CPV/calib/include/CPVCalibration/GainCalibrator.h
@@ -70,7 +70,7 @@ class GainCalibData
 }; // end GainCalibData
 //=============================================================================
 using GainTimeSlot = o2::calibration::TimeSlot<GainCalibData>;
-class GainCalibrator final : public o2::calibration::TimeSlotCalibration<Digit, GainCalibData>
+class GainCalibrator final : public o2::calibration::TimeSlotCalibration<GainCalibData>
 {
  public:
   GainCalibrator();

--- a/Detectors/CPV/calib/include/CPVCalibration/NoiseCalibrator.h
+++ b/Detectors/CPV/calib/include/CPVCalibration/NoiseCalibrator.h
@@ -40,7 +40,7 @@ struct NoiseCalibData {
 //=========================================================================
 
 using NoiseTimeSlot = o2::calibration::TimeSlot<o2::cpv::NoiseCalibData>;
-class NoiseCalibrator final : public o2::calibration::TimeSlotCalibration<o2::cpv::Digit, o2::cpv::NoiseCalibData>
+class NoiseCalibrator final : public o2::calibration::TimeSlotCalibration<o2::cpv::NoiseCalibData>
 {
  public:
   NoiseCalibrator();

--- a/Detectors/CPV/calib/include/CPVCalibration/PedestalCalibrator.h
+++ b/Detectors/CPV/calib/include/CPVCalibration/PedestalCalibrator.h
@@ -71,7 +71,7 @@ struct PedestalCalibData {
 
 using PedestalTimeSlot = o2::calibration::TimeSlot<o2::cpv::PedestalCalibData>;
 //===================================================================
-class PedestalCalibrator final : public o2::calibration::TimeSlotCalibration<o2::cpv::Digit, o2::cpv::PedestalCalibData>
+class PedestalCalibrator final : public o2::calibration::TimeSlotCalibration<o2::cpv::PedestalCalibData>
 {
  public:
   PedestalCalibrator();

--- a/Detectors/CPV/calib/src/CPVCalibrationLinkDef.h
+++ b/Detectors/CPV/calib/src/CPVCalibrationLinkDef.h
@@ -18,18 +18,18 @@
 #pragma link C++ class o2::cpv::PedestalSpectrum + ;
 #pragma link C++ class o2::cpv::PedestalCalibData + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::cpv::PedestalCalibData> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::cpv::Digit, o2::cpv::PedestalCalibData> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::cpv::PedestalCalibData> + ;
 #pragma link C++ class o2::cpv::PedestalCalibrator + ;
 
 #pragma link C++ class o2::cpv::NoiseCalibData + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::cpv::NoiseCalibData> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::cpv::Digit, o2::cpv::NoiseCalibData> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::cpv::NoiseCalibData> + ;
 #pragma link C++ class o2::cpv::NoiseCalibrator + ;
 
 #pragma link C++ class o2::cpv::AmplitudeSpectrum + ;
 #pragma link C++ class o2::cpv::GainCalibData + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::cpv::GainCalibData> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::cpv::Digit, o2::cpv::GainCalibData> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::cpv::GainCalibData> + ;
 #pragma link C++ class o2::cpv::GainCalibrator + ;
 
 #endif

--- a/Detectors/Calibration/include/DetectorsCalibration/MeanVertexCalibrator.h
+++ b/Detectors/Calibration/include/DetectorsCalibration/MeanVertexCalibrator.h
@@ -26,7 +26,7 @@ namespace o2
 namespace calibration
 {
 
-class MeanVertexCalibrator final : public o2::calibration::TimeSlotCalibration<o2::dataformats::PrimaryVertex, o2::calibration::MeanVertexData>
+class MeanVertexCalibrator final : public o2::calibration::TimeSlotCalibration<o2::calibration::MeanVertexData>
 {
   using PVertex = o2::dataformats::PrimaryVertex;
   using MeanVertexData = o2::calibration::MeanVertexData;

--- a/Detectors/Calibration/include/DetectorsCalibration/TimeSlot.h
+++ b/Detectors/Calibration/include/DetectorsCalibration/TimeSlot.h
@@ -35,17 +35,8 @@ class TimeSlot
  public:
   TimeSlot() = default;
   TimeSlot(TFType tfS, TFType tfE) : mTFStart(tfS), mTFEnd(tfE) {}
-  TimeSlot(const TimeSlot& src) : mTFStart(src.mTFStart), mTFEnd(src.mTFEnd), mContainer(std::make_unique<Container>(*src.getContainer())) {}
-  TimeSlot& operator=(const TimeSlot& src)
-  {
-    if (&src != this) {
-      mTFStart = src.mTFStart;
-      mTFEnd = src.mTFEnd;
-      mTFStartMS = src.mTFStartMS;
-      mContainer = std::make_unique<Container>(*src.getContainer());
-    }
-    return *this;
-  }
+  TimeSlot(const TimeSlot& src) { std::move(src); }
+  TimeSlot& operator=(TimeSlot&& src) = default;
 
   ~TimeSlot() = default;
 

--- a/Detectors/Calibration/include/DetectorsCalibration/TimeSlotCalibration.h
+++ b/Detectors/Calibration/include/DetectorsCalibration/TimeSlotCalibration.h
@@ -36,7 +36,7 @@ class ProcessingContext;
 namespace calibration
 {
 
-template <typename Input, typename Container = Input>
+template <typename Container>
 class TimeSlotCalibration
 {
  public:
@@ -106,7 +106,7 @@ class TimeSlotCalibration
 
   template <typename... DATA>
   bool process(const DATA&... data);
-  virtual void checkSlotsToFinalize(TFType tf, int maxDelay = 0);
+  virtual void checkSlotsToFinalize(TFType tf = INFINITE_TF, int maxDelay = 0);
   virtual void finalizeOldestSlot();
 
   // Methods to be implemented by the derived user class
@@ -226,9 +226,9 @@ class TimeSlotCalibration
 };
 
 //_________________________________________________
-template <typename Input, typename Container>
+template <typename Container>
 template <typename... DATA>
-bool TimeSlotCalibration<Input, Container>::process(const DATA&... data)
+bool TimeSlotCalibration<Container>::process(const DATA&... data)
 {
   static bool firstCall = true;
   if (firstCall) {
@@ -268,8 +268,8 @@ bool TimeSlotCalibration<Input, Container>::process(const DATA&... data)
 }
 
 //_________________________________________________
-template <typename Input, typename Container>
-void TimeSlotCalibration<Input, Container>::checkSlotsToFinalize(TFType tf, int maxDelay)
+template <typename Container>
+void TimeSlotCalibration<Container>::checkSlotsToFinalize(TFType tf, int maxDelay)
 {
   // Check which slots can be finalized, provided the newly arrived TF is tf
 
@@ -337,8 +337,8 @@ void TimeSlotCalibration<Input, Container>::checkSlotsToFinalize(TFType tf, int 
 }
 
 //_________________________________________________
-template <typename Input, typename Container>
-void TimeSlotCalibration<Input, Container>::finalizeOldestSlot()
+template <typename Container>
+void TimeSlotCalibration<Container>::finalizeOldestSlot()
 {
   // Enforce finalization and removal of the oldest slot
   if (mSlots.empty()) {
@@ -351,8 +351,8 @@ void TimeSlotCalibration<Input, Container>::finalizeOldestSlot()
 }
 
 //________________________________________
-template <typename Input, typename Container>
-inline TFType TimeSlotCalibration<Input, Container>::tf2SlotMin(TFType tf) const
+template <typename Container>
+inline TFType TimeSlotCalibration<Container>::tf2SlotMin(TFType tf) const
 {
 
   // returns the min TF of the slot to which "tf" belongs
@@ -368,8 +368,8 @@ inline TFType TimeSlotCalibration<Input, Container>::tf2SlotMin(TFType tf) const
 }
 
 //_________________________________________________
-template <typename Input, typename Container>
-TimeSlot<Container>& TimeSlotCalibration<Input, Container>::getSlotForTF(TFType tf)
+template <typename Container>
+TimeSlot<Container>& TimeSlotCalibration<Container>::getSlotForTF(TFType tf)
 {
 
   LOG(debug) << "Getting slot for TF " << tf;
@@ -423,8 +423,8 @@ TimeSlot<Container>& TimeSlotCalibration<Input, Container>::getSlotForTF(TFType 
 }
 
 //_________________________________________________
-template <typename Input, typename Container>
-void TimeSlotCalibration<Input, Container>::print() const
+template <typename Container>
+void TimeSlotCalibration<Container>::print() const
 {
   for (int i = 0; i < getNSlots(); i++) {
     LOG(info) << "Slot #" << i << " of " << getNSlots();
@@ -433,8 +433,8 @@ void TimeSlotCalibration<Input, Container>::print() const
 }
 
 //_________________________________________________
-template <typename Input, typename Container>
-bool TimeSlotCalibration<Input, Container>::updateSaveMetaData()
+template <typename Container>
+bool TimeSlotCalibration<Container>::updateSaveMetaData()
 {
   if (mSlots.empty()) {
     LOG(warn) << "Nothing to save, no TimeSlots defined";
@@ -452,8 +452,8 @@ bool TimeSlotCalibration<Input, Container>::updateSaveMetaData()
 }
 
 //_________________________________________________
-template <typename Input, typename Container>
-bool TimeSlotCalibration<Input, Container>::saveLastSlot()
+template <typename Container>
+bool TimeSlotCalibration<Container>::saveLastSlot()
 {
   if (!getSavedSlotAllowed()) {
     LOG(info) << "Slot saving is disabled";
@@ -483,8 +483,8 @@ bool TimeSlotCalibration<Input, Container>::saveLastSlot()
 }
 
 //_________________________________________________
-template <typename Input, typename Container>
-bool TimeSlotCalibration<Input, Container>::loadSavedSlot()
+template <typename Container>
+bool TimeSlotCalibration<Container>::loadSavedSlot()
 {
   if (!getSavedSlotAllowed()) {
     LOG(info) << "Saved slot usage is disabled";
@@ -517,8 +517,8 @@ bool TimeSlotCalibration<Input, Container>::loadSavedSlot()
 }
 
 //_________________________________________________
-template <typename Input, typename Container>
-std::string TimeSlotCalibration<Input, Container>::getSaveFilePath() const
+template <typename Container>
+std::string TimeSlotCalibration<Container>::getSaveFilePath() const
 {
   if (mSaveFileName.empty()) {
     LOGP(fatal, "Save file name was not set");

--- a/Detectors/Calibration/src/DetectorsCalibrationLinkDef.h
+++ b/Detectors/Calibration/src/DetectorsCalibrationLinkDef.h
@@ -18,7 +18,7 @@
 #pragma link C++ class o2::calibration::MeanVertexData + ;
 #pragma link C++ class o2::calibration::TimeSlotMetaData + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::calibration::MeanVertexData> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::dataformats::PrimaryVertex, o2::calibration::MeanVertexData> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::calibration::MeanVertexData> + ;
 #pragma link C++ class o2::calibration::MeanVertexCalibrator + ;
 #pragma link C++ class o2::calibration::MeanVertexParams + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::calibration::MeanVertexParams> + ;

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelCalibrator.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelCalibrator.h
@@ -50,7 +50,7 @@ namespace emcal
 /// \brief class used for managment of bad channel and time calibration
 /// template DataInput can be ChannelData or TimeData   // o2::emcal::EMCALChannelData, o2::emcal::EMCALTimeCalibData
 template <typename DataInput, typename DataOutput>
-class EMCALChannelCalibrator : public o2::calibration::TimeSlotCalibration<o2::emcal::Cell, DataInput>
+class EMCALChannelCalibrator : public o2::calibration::TimeSlotCalibration<DataInput>
 {
   using TFType = o2::calibration::TFType;
   using Slot = o2::calibration::TimeSlot<DataInput>;
@@ -187,7 +187,7 @@ void EMCALChannelCalibrator<DataInput, DataOutput>::finalizeSlot(o2::calibration
 template <typename DataInput, typename DataOutput>
 o2::calibration::TimeSlot<DataInput>& EMCALChannelCalibrator<DataInput, DataOutput>::emplaceNewSlot(bool front, TFType tstart, TFType tend)
 {
-  auto& cont = o2::calibration::TimeSlotCalibration<o2::emcal::Cell, DataInput>::getSlots();
+  auto& cont = o2::calibration::TimeSlotCalibration<DataInput>::getSlots();
   auto& slot = front ? cont.emplace_front(tstart, tend) : cont.emplace_back(tstart, tend);
   slot.setContainer(std::make_unique<DataInput>());
   return slot;

--- a/Detectors/EMCAL/calibration/src/EMCALCalibrationLinkDef.h
+++ b/Detectors/EMCAL/calibration/src/EMCALCalibrationLinkDef.h
@@ -17,11 +17,11 @@
 
 #pragma link C++ class o2::emcal::EMCALChannelCalibrator < o2::emcal::EMCALChannelData, o2::emcal::BadChannelMap> + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::emcal::EMCALChannelData> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::emcal::Cell, o2::emcal::EMCALChannelData> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::emcal::EMCALChannelData> + ;
 
 #pragma link C++ class o2::emcal::EMCALChannelCalibrator < o2::emcal::EMCALTimeCalibData, o2::emcal::TimeCalibrationParams> + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::emcal::EMCALTimeCalibData> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::emcal::Cell, o2::emcal::EMCALTimeCalibData> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::emcal::EMCALTimeCalibData> + ;
 
 #pragma link C++ class o2::emcal::EMCALCalibParams + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::emcal::EMCALCalibParams> + ;

--- a/Detectors/FIT/FT0/calibration/include/FT0Calibration/FT0CalibCollector.h
+++ b/Detectors/FIT/FT0/calibration/include/FT0Calibration/FT0CalibCollector.h
@@ -60,7 +60,7 @@ class FT0CalibInfoSlot
   ClassDefNV(FT0CalibInfoSlot, 1);
 };
 
-class FT0CalibCollector final : public o2::calibration::TimeSlotCalibration<o2::ft0::FT0CalibrationInfoObject, o2::ft0::FT0CalibInfoSlot>
+class FT0CalibCollector final : public o2::calibration::TimeSlotCalibration<o2::ft0::FT0CalibInfoSlot>
 {
   using TFType = o2::calibration::TFType;
   using Slot = o2::calibration::TimeSlot<o2::ft0::FT0CalibInfoSlot>;

--- a/Detectors/FIT/FT0/calibration/src/FT0CalibrationLinkDef.h
+++ b/Detectors/FIT/FT0/calibration/src/FT0CalibrationLinkDef.h
@@ -21,9 +21,13 @@
 #pragma link C++ class o2::ft0::GlobalOffsetsContainer + ;
 #pragma link C++ class o2::ft0::FT0CalibTimeSlewing + ;
 #pragma link C++ class o2::ft0::FT0CalibCollector + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::ft0::FT0CalibrationInfoObject, o2::ft0::FT0CalibInfoSlot>;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < float, o2::ft0::FT0TimeOffsetSlotContainer>;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::ft0::FT0CalibrationInfoObject, o2::ft0::FT0ChannelTimeOffsetSlotContainer>;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::ft0::GlobalOffsetsInfoObject, o2::ft0::GlobalOffsetsContainer>;
+#pragma link C++ class o2::calibration::TimeSlot < o2::ft0::FT0CalibInfoSlot>;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::ft0::FT0CalibInfoSlot>;
+#pragma link C++ class o2::calibration::TimeSlot < o2::ft0::FT0TimeOffsetSlotContainer>;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::ft0::FT0TimeOffsetSlotContainer>;
+#pragma link C++ class o2::calibration::TimeSlot < o2::ft0::FT0ChannelTimeOffsetSlotContainer>;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::ft0::FT0ChannelTimeOffsetSlotContainer>;
+#pragma link C++ class o2::calibration::TimeSlot < o2::ft0::GlobalOffsetsContainer>;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::ft0::GlobalOffsetsContainer>;
 
 #endif

--- a/Detectors/FIT/FV0/calibration/include/FV0Calibration/FV0CalibCollector.h
+++ b/Detectors/FIT/FV0/calibration/include/FV0Calibration/FV0CalibCollector.h
@@ -58,7 +58,7 @@ class FV0CalibInfoSlot
   ClassDefNV(FV0CalibInfoSlot, 1);
 };
 
-class FV0CalibCollector final : public o2::calibration::TimeSlotCalibration<o2::fv0::FV0CalibrationInfoObject, o2::fv0::FV0CalibInfoSlot>
+class FV0CalibCollector final : public o2::calibration::TimeSlotCalibration<o2::fv0::FV0CalibInfoSlot>
 {
   using TFType = o2::calibration::TFType;
   using Slot = o2::calibration::TimeSlot<o2::fv0::FV0CalibInfoSlot>;

--- a/Detectors/FIT/FV0/calibration/src/FV0CalibrationLinkDef.h
+++ b/Detectors/FIT/FV0/calibration/src/FV0CalibrationLinkDef.h
@@ -17,7 +17,9 @@
 
 #pragma link C++ class o2::fv0::FV0ChannelTimeOffsetSlotContainer + ;
 #pragma link C++ class o2::fv0::FV0CalibCollector + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::fv0::FV0CalibrationInfoObject, o2::fv0::FV0CalibInfoSlot>;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::fv0::FV0CalibrationInfoObject, o2::fv0::FV0ChannelTimeOffsetSlotContainer>;
+#pragma link C++ class o2::calibration::TimeSlot < o2::fv0::FV0CalibInfoSlot>;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::fv0::FV0CalibInfoSlot>;
+#pragma link C++ class o2::calibration::TimeSlot < o2::fv0::FV0ChannelTimeOffsetSlotContainer>;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::fv0::FV0ChannelTimeOffsetSlotContainer>;
 
 #endif

--- a/Detectors/FIT/common/calibration/include/FITCalibration/FITCalibrationDevice.h
+++ b/Detectors/FIT/common/calibration/include/FITCalibration/FITCalibrationDevice.h
@@ -32,7 +32,7 @@ class FITCalibrationDevice : public o2::framework::Task
 {
   static constexpr const char* DEFAULT_INPUT_DATA_LABEL = "calib";
   static constexpr const char* sDEFAULT_CCDB_URL = "http://localhost:8080";
-  using CalibratorType = FITCalibrator<InputCalibrationInfoType, TimeSlotStorageType, CalibrationObjectType>;
+  using CalibratorType = FITCalibrator<TimeSlotStorageType, CalibrationObjectType>;
 
  public:
   explicit FITCalibrationDevice(std::string inputDataLabel = DEFAULT_INPUT_DATA_LABEL, std::shared_ptr<o2::base::GRPGeomRequest> req = {})

--- a/Detectors/FIT/common/calibration/include/FITCalibration/FITCalibrator.h
+++ b/Detectors/FIT/common/calibration/include/FITCalibration/FITCalibrator.h
@@ -27,8 +27,8 @@
 namespace o2::fit
 {
 
-template <typename InputCalibrationInfoType, typename TimeSlotStorageType, typename CalibrationObjectType>
-class FITCalibrator final : public o2::calibration::TimeSlotCalibration<InputCalibrationInfoType, TimeSlotStorageType>
+template <typename TimeSlotStorageType, typename CalibrationObjectType>
+class FITCalibrator final : public o2::calibration::TimeSlotCalibration<TimeSlotStorageType>
 {
 
   // probably will be set via run parameter
@@ -80,7 +80,7 @@ class FITCalibrator final : public o2::calibration::TimeSlotCalibration<InputCal
   {
     LOG(info) << "FIT_CALIBRATOR_TYPE::emplaceNewSlot "
               << " start " << tstart << " end " << tend;
-    auto& cont = o2::calibration::TimeSlotCalibration<InputCalibrationInfoType, TimeSlotStorageType>::getSlots();
+    auto& cont = o2::calibration::TimeSlotCalibration<TimeSlotStorageType>::getSlots();
     auto& slot = front ? cont.emplace_front(tstart, tend) : cont.emplace_back(tstart, tend);
     slot.setContainer(std::make_unique<TimeSlotStorageType>(mMinEntries));
     return slot;

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCResidualAggregatorSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCResidualAggregatorSpec.h
@@ -46,9 +46,10 @@ class ResidualAggregatorDevice : public o2::framework::Task
   {
     o2::base::GRPGeomHelper::instance().setRequest(mCCDBRequest);
     int minEnt = ic.options().get<int>("min-entries");
-    auto slotLength = ic.options().get<uint32_t>("tf-per-slot");
+    auto slotLength = ic.options().get<uint32_t>("sec-per-slot");
+    bool useInfiniteSlotLength = false;
     if (slotLength == 0) {
-      slotLength = o2::calibration::INFINITE_TF;
+      useInfiniteSlotLength = true;
     }
     auto updateInterval = ic.options().get<uint32_t>("updateInterval");
     auto delay = ic.options().get<uint32_t>("max-delay");
@@ -83,9 +84,13 @@ class ResidualAggregatorDevice : public o2::framework::Task
     int autosave = ic.options().get<int>("autosave-interval");
     mAggregator->setAutosaveInterval(autosave);
     // TODO mAggregator should get an option to set the binning externally (expose TrackResiduals::setBinning methods to user? as command line option?)
-    mAggregator->setSlotLength(slotLength);
     mAggregator->setMaxSlotsDelay(delay);
-    mAggregator->setCheckIntervalInfiniteSlot(updateInterval);
+    if (useInfiniteSlotLength) {
+      mAggregator->setSlotLength(o2::calibration::INFINITE_TF);
+      mAggregator->setCheckIntervalInfiniteSlot(updateInterval);
+    } else {
+      mAggregator->setSlotLengthInSeconds(slotLength);
+    }
     mAggregator->setWriteBinnedResiduals(mWriteBinnedResiduals);
     mAggregator->setWriteUnbinnedResiduals(mWriteUnbinnedResiduals);
     mAggregator->setWriteTrackData(mWriteTrackData);
@@ -190,11 +195,11 @@ DataProcessorSpec getTPCResidualAggregatorSpec(bool trackInput, bool ctpInput, b
     Outputs{},
     AlgorithmSpec{adaptFromTask<o2::calibration::ResidualAggregatorDevice>(ccdbRequest, trackInput, ctpInput, writeUnbinnedResiduals, writeBinnedResiduals, writeTrackData, dataRequest)},
     Options{
-      {"tf-per-slot", VariantType::UInt32, 6'000u, {"number of TFs per calibration time slot (put 0 for infinite slot length)"}},
-      {"updateInterval", VariantType::UInt32, 6'000u, {"update interval in number of TFs in case slot length is infinite"}},
+      {"sec-per-slot", VariantType::UInt32, 60u, {"number of seconds per calibration time slot (put 0 for infinite slot length)"}},
+      {"updateInterval", VariantType::UInt32, 6'000u, {"update interval in number of TFs (only used in case slot length is infinite)"}},
       {"max-delay", VariantType::UInt32, 1u, {"number of slots in past to consider"}},
       {"min-entries", VariantType::Int, 0, {"minimum number of entries on average per voxel"}},
-      {"compression", VariantType::Int, 101, {"ROOT compression setting for output file (see TFile documentation for meaning of this number)"}},
+      {"compression", VariantType::Int, 505, {"ROOT compression setting for output file (see TFile documentation for meaning of this number)"}},
       {"output-dir", VariantType::String, "none", {"Output directory for residuals. Defaults to current working directory. Output is disabled in case set to /dev/null"}},
       {"meta-output-dir", VariantType::String, "/dev/null", {"Residuals metadata output directory, must exist (if not /dev/null)"}},
       {"autosave-interval", VariantType::Int, 0, {"Write output to file for every n-th TF. 0 means this feature is OFF"}}}};

--- a/Detectors/ITSMFT/ITS/calibration/include/ITSCalibration/NoiseSlotCalibrator.h
+++ b/Detectors/ITSMFT/ITS/calibration/include/ITSCalibration/NoiseSlotCalibrator.h
@@ -35,7 +35,7 @@ class ROFRecord;
 namespace its
 {
 
-class NoiseSlotCalibrator : public o2::calibration::TimeSlotCalibration<o2::itsmft::CompClusterExt, o2::itsmft::NoiseMap>
+class NoiseSlotCalibrator : public o2::calibration::TimeSlotCalibration<o2::itsmft::NoiseMap>
 {
   using Slot = calibration::TimeSlot<o2::itsmft::NoiseMap>;
 

--- a/Detectors/ITSMFT/ITS/calibration/src/ITSCalibrationLinkDef.h
+++ b/Detectors/ITSMFT/ITS/calibration/src/ITSCalibrationLinkDef.h
@@ -16,7 +16,7 @@
 #pragma link off all functions;
 
 #pragma link C++ class o2::calibration::TimeSlot < o2::itsmft::CompClusterExt > +;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::itsmft::CompClusterExt, o2::itsmft::NoiseMap > +;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::itsmft::NoiseMap> + ;
 #pragma link C++ class o2::its::NoiseCalibrator + ;
 
 #endif

--- a/Detectors/ITSMFT/ITS/calibration/src/NoiseSlotCalibrator.cxx
+++ b/Detectors/ITSMFT/ITS/calibration/src/NoiseSlotCalibrator.cxx
@@ -108,7 +108,7 @@ bool NoiseSlotCalibrator::processTimeFrame(gsl::span<const o2::itsmft::CompClust
 bool NoiseSlotCalibrator::process(const gsl::span<const o2::itsmft::CompClusterExt> data)
 {
   LOG(warning) << "Only 1-pix noise calibraton is possible !";
-  return calibration::TimeSlotCalibration<o2::itsmft::CompClusterExt, o2::itsmft::NoiseMap>::process(data);
+  return calibration::TimeSlotCalibration<o2::itsmft::NoiseMap>::process(data);
 }
 
 // Functions required by the calibration framework

--- a/Detectors/ITSMFT/MFT/calibration/include/MFTCalibration/NoiseSlotCalibrator.h
+++ b/Detectors/ITSMFT/MFT/calibration/include/MFTCalibration/NoiseSlotCalibrator.h
@@ -35,7 +35,7 @@ class ROFRecord;
 namespace mft
 {
 
-class NoiseSlotCalibrator : public o2::calibration::TimeSlotCalibration<o2::itsmft::CompClusterExt, o2::itsmft::NoiseMap>
+class NoiseSlotCalibrator : public o2::calibration::TimeSlotCalibration<o2::itsmft::NoiseMap>
 {
   using Slot = calibration::TimeSlot<o2::itsmft::NoiseMap>;
 

--- a/Detectors/MUON/MCH/Calibration/include/MCHCalibration/BadChannelCalibrator.h
+++ b/Detectors/MUON/MCH/Calibration/include/MCHCalibration/BadChannelCalibrator.h
@@ -37,8 +37,7 @@ namespace o2::mch::calibration
  * considered bad/noisy and they are stored into a
  * "bad channels" list that is sent to the CDDB populator(s).
  */
-class BadChannelCalibrator final : public o2::calibration::TimeSlotCalibration<o2::mch::calibration::PedestalDigit,
-                                                                               o2::mch::calibration::PedestalData>
+class BadChannelCalibrator final : public o2::calibration::TimeSlotCalibration<o2::mch::calibration::PedestalData>
 {
   using TFType = o2::calibration::TFType;
   using Slot = o2::calibration::TimeSlot<o2::mch::calibration::PedestalData>;

--- a/Detectors/MUON/MCH/Calibration/src/MCHCalibrationLinkDef.h
+++ b/Detectors/MUON/MCH/Calibration/src/MCHCalibrationLinkDef.h
@@ -22,6 +22,6 @@
 #pragma link C++ class o2::mch::calibration::PedestalData + ;
 #pragma link C++ class o2::mch::calibration::BadChannelCalibrator + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::mch::calibration::PedestalData> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::mch::calibration::PedestalDigit, o2::mch::calibration::PedestalData> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::mch::calibration::PedestalData> + ;
 
 #endif

--- a/Detectors/MUON/MID/Calibration/include/MIDCalibration/ChannelCalibrator.h
+++ b/Detectors/MUON/MID/Calibration/include/MIDCalibration/ChannelCalibrator.h
@@ -56,7 +56,7 @@ class CalibData
   ClassDefNV(CalibData, 1);
 };
 
-class ChannelCalibrator final : public o2::calibration::TimeSlotCalibration<ColumnData, CalibData>
+class ChannelCalibrator final : public o2::calibration::TimeSlotCalibration<CalibData>
 {
   using TFType = o2::calibration::TFType;
   using Slot = o2::calibration::TimeSlot<CalibData>;

--- a/Detectors/MUON/MID/Calibration/src/MIDCalibrationLinkDef.h
+++ b/Detectors/MUON/MID/Calibration/src/MIDCalibrationLinkDef.h
@@ -19,6 +19,6 @@
 #pragma link C++ class o2::mid::CalibData + ;
 #pragma link C++ class o2::mid::ChannelCalibrator + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::mid::CalibData> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::mid::ColumnData, o2::mid::CalibData> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::mid::CalibData> + ;
 
 #endif

--- a/Detectors/PHOS/calib/include/PHOSCalibWorkflow/PHOSEnergyCalibrator.h
+++ b/Detectors/PHOS/calib/include/PHOSCalibWorkflow/PHOSEnergyCalibrator.h
@@ -112,7 +112,7 @@ class PHOSEnergySlot
   std::vector<uint32_t> mDigits; /// list of calibration digits
 };
 
-class PHOSEnergyCalibrator final : public o2::calibration::TimeSlotCalibration<o2::phos::Cluster, o2::phos::PHOSEnergySlot>
+class PHOSEnergyCalibrator final : public o2::calibration::TimeSlotCalibration<o2::phos::PHOSEnergySlot>
 {
   using Slot = o2::calibration::TimeSlot<o2::phos::PHOSEnergySlot>;
 

--- a/Detectors/PHOS/calib/include/PHOSCalibWorkflow/PHOSL1phaseCalibrator.h
+++ b/Detectors/PHOS/calib/include/PHOSCalibWorkflow/PHOSL1phaseCalibrator.h
@@ -65,7 +65,7 @@ class PHOSL1phaseSlot
 };
 
 //==========================================================================================
-class PHOSL1phaseCalibrator final : public o2::calibration::TimeSlotCalibration<o2::phos::Cell, o2::phos::PHOSL1phaseSlot>
+class PHOSL1phaseCalibrator final : public o2::calibration::TimeSlotCalibration<o2::phos::PHOSL1phaseSlot>
 {
   using Slot = o2::calibration::TimeSlot<o2::phos::PHOSL1phaseSlot>;
 

--- a/Detectors/PHOS/calib/include/PHOSCalibWorkflow/PHOSRunbyrunCalibrator.h
+++ b/Detectors/PHOS/calib/include/PHOSCalibWorkflow/PHOSRunbyrunCalibrator.h
@@ -69,7 +69,7 @@ class PHOSRunbyrunSlot
 };
 
 //==========================================================================================
-class PHOSRunbyrunCalibrator final : public o2::calibration::TimeSlotCalibration<o2::phos::Cluster, o2::phos::PHOSRunbyrunSlot>
+class PHOSRunbyrunCalibrator final : public o2::calibration::TimeSlotCalibration<o2::phos::PHOSRunbyrunSlot>
 {
   using Slot = o2::calibration::TimeSlot<o2::phos::PHOSRunbyrunSlot>;
 

--- a/Detectors/PHOS/calib/include/PHOSCalibWorkflow/PHOSTurnonCalibrator.h
+++ b/Detectors/PHOS/calib/include/PHOSCalibWorkflow/PHOSTurnonCalibrator.h
@@ -67,7 +67,7 @@ class PHOSTurnonSlot
 };
 
 //==========================================================================================
-class PHOSTurnonCalibrator final : public o2::calibration::TimeSlotCalibration<o2::phos::Cluster, o2::phos::PHOSTurnonSlot>
+class PHOSTurnonCalibrator final : public o2::calibration::TimeSlotCalibration<o2::phos::PHOSTurnonSlot>
 {
   using Slot = o2::calibration::TimeSlot<o2::phos::PHOSTurnonSlot>;
 

--- a/Detectors/PHOS/calib/src/PHOSCalibWorkflowLinkDef.h
+++ b/Detectors/PHOS/calib/src/PHOSCalibWorkflowLinkDef.h
@@ -20,23 +20,23 @@
 #pragma link C++ class o2::phos::PHOSBadMapCalibDevice + ;
 #pragma link C++ class o2::phos::ETCalibHistos + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::phos::PHOSEnergySlot> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::phos::Cluster, o2::phos::PHOSEnergySlot> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::phos::PHOSEnergySlot> + ;
 #pragma link C++ class o2::phos::TurnOnHistos + ;
 #pragma link C++ class o2::phos::PHOSTurnonSlot + ;
 #pragma link C++ class o2::phos::PHOSTurnonCalibrator + ;
 #pragma link C++ class o2::phos::PHOSTurnonCalibDevice + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::phos::PHOSTurnonSlot> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::phos::Cluster, o2::phos::PHOSTurnonSlot> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::phos::PHOSTurnonSlot> + ;
 #pragma link C++ class o2::phos::PHOSRunbyrunSlot + ;
 #pragma link C++ class o2::phos::PHOSRunbyrunCalibrator + ;
 #pragma link C++ class o2::phos::PHOSRunbyrunCalibDevice + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::phos::PHOSRunbyrunSlot> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::phos::Cluster, o2::phos::PHOSRunbyrunSlot> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::phos::PHOSRunbyrunSlot> + ;
 #pragma link C++ class o2::phos::PHOSL1phaseSlot + ;
 #pragma link C++ class o2::phos::PHOSL1phaseCalibrator + ;
 #pragma link C++ class o2::phos::PHOSL1phaseCalibDevice + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::phos::PHOSL1phaseSlot> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::phos::Cell, o2::phos::PHOSL1phaseSlot> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::phos::PHOSL1phaseSlot> + ;
 #pragma link C++ class vector < int> + ;
 
 #endif

--- a/Detectors/TOF/calibration/include/TOFCalibration/LHCClockCalibrator.h
+++ b/Detectors/TOF/calibration/include/TOFCalibration/LHCClockCalibrator.h
@@ -69,7 +69,7 @@ struct LHCClockDataHisto {
   ClassDefNV(LHCClockDataHisto, 1);
 };
 
-class LHCClockCalibrator final : public o2::calibration::TimeSlotCalibration<o2::dataformats::CalibInfoTOF, o2::tof::LHCClockDataHisto>
+class LHCClockCalibrator final : public o2::calibration::TimeSlotCalibration<o2::tof::LHCClockDataHisto>
 {
   using TFType = o2::calibration::TFType;
   using Slot = o2::calibration::TimeSlot<o2::tof::LHCClockDataHisto>;

--- a/Detectors/TOF/calibration/include/TOFCalibration/TOFCalibCollector.h
+++ b/Detectors/TOF/calibration/include/TOFCalibration/TOFCalibCollector.h
@@ -65,7 +65,7 @@ class TOFCalibInfoSlot
   ClassDefNV(TOFCalibInfoSlot, 1);
 };
 
-class TOFCalibCollector final : public o2::calibration::TimeSlotCalibration<o2::dataformats::CalibInfoTOF, o2::tof::TOFCalibInfoSlot>
+class TOFCalibCollector final : public o2::calibration::TimeSlotCalibration<o2::tof::TOFCalibInfoSlot>
 {
   using TFType = o2::calibration::TFType;
   using Slot = o2::calibration::TimeSlot<o2::tof::TOFCalibInfoSlot>;

--- a/Detectors/TOF/calibration/include/TOFCalibration/TOFChannelCalibrator.h
+++ b/Detectors/TOF/calibration/include/TOFCalibration/TOFChannelCalibrator.h
@@ -139,7 +139,7 @@ class TOFChannelData
 };
 
 template <class T>
-class TOFChannelCalibrator final : public o2::calibration::TimeSlotCalibration<T, o2::tof::TOFChannelData>
+class TOFChannelCalibrator final : public o2::calibration::TimeSlotCalibration<o2::tof::TOFChannelData>
 {
   using TFType = o2::calibration::TFType;
   using Slot = o2::calibration::TimeSlot<o2::tof::TOFChannelData>;
@@ -155,7 +155,7 @@ class TOFChannelCalibrator final : public o2::calibration::TimeSlotCalibration<T
 #endif
 
  protected:
-  std::deque<o2::calibration::TimeSlot<o2::tof::TOFChannelData>>& getSlots() { return o2::calibration::TimeSlotCalibration<T, o2::tof::TOFChannelData>::getSlots(); }
+  std::deque<o2::calibration::TimeSlot<o2::tof::TOFChannelData>>& getSlots() { return o2::calibration::TimeSlotCalibration<o2::tof::TOFChannelData>::getSlots(); }
 
  public:
   void doPerStrip(bool val = true) { mPerStrip = val; }

--- a/Detectors/TOF/calibration/include/TOFCalibration/TOFDiagnosticCalibrator.h
+++ b/Detectors/TOF/calibration/include/TOFCalibration/TOFDiagnosticCalibrator.h
@@ -22,7 +22,7 @@ namespace o2
 namespace tof
 {
 
-class TOFDiagnosticCalibrator final : public o2::calibration::TimeSlotCalibration<o2::tof::Diagnostic, o2::tof::Diagnostic>
+class TOFDiagnosticCalibrator final : public o2::calibration::TimeSlotCalibration<o2::tof::Diagnostic>
 {
   using TFType = o2::calibration::TFType;
   using Slot = o2::calibration::TimeSlot<o2::tof::Diagnostic>;

--- a/Detectors/TOF/calibration/src/TOFCalibrationLinkDef.h
+++ b/Detectors/TOF/calibration/src/TOFCalibrationLinkDef.h
@@ -20,21 +20,21 @@
 
 #pragma link C++ class o2::tof::LHCClockDataHisto + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::tof::LHCClockDataHisto> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::dataformats::CalibInfoTOF, o2::tof::LHCClockDataHisto> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tof::LHCClockDataHisto> + ;
 #pragma link C++ class o2::tof::LHCClockCalibrator + ;
 
 #pragma link C++ class o2::tof::TOFChannelData + ;
 #pragma link C++ class o2::tof::TOFChannelCalibrator < o2::dataformats::CalibInfoTOF> + ;
 #pragma link C++ class o2::tof::TOFChannelCalibrator < o2::tof::CalibInfoCluster> + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::tof::TOFChannelData> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::dataformats::CalibInfoTOF, o2::tof::TOFChannelData> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tof::CalibInfoCluster, o2::tof::TOFChannelData> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tof::TOFChannelData> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tof::TOFChannelData> + ;
 
 #pragma link C++ class o2::tof::TOFCalibInfoSlot + ;
 #pragma link C++ class o2::tof::TOFCalibCollector + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::tof::TOFCalibInfoSlot> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::dataformats::CalibInfoTOF, o2::tof::TOFCalibInfoSlot> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tof::CalibInfoCluster, o2::tof::TOFCalibInfoSlot> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tof::TOFCalibInfoSlot> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tof::TOFCalibInfoSlot> + ;
 
 #pragma link C++ class std::bitset < o2::tof::Geo::NCHANNELS> + ;
 #pragma link C++ struct std::pair < uint64_t, double> + ;
@@ -48,7 +48,7 @@
 #pragma link C++ struct TOFFEElightReader + ;
 
 #pragma link C++ class o2::calibration::TimeSlot < o2::tof::Diagnostic> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tof::Diagnostic, o2::tof::Diagnostic> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tof::Diagnostic> + ;
 #pragma link C++ class o2::tof::TOFDiagnosticCalibrator + ;
 
 #endif

--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/ResidualAggregator.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/ResidualAggregator.h
@@ -86,7 +86,7 @@ struct ResidualsContainer {
   ClassDefNV(ResidualsContainer, 3);
 };
 
-class ResidualAggregator final : public o2::calibration::TimeSlotCalibration<UnbinnedResid, ResidualsContainer>
+class ResidualAggregator final : public o2::calibration::TimeSlotCalibration<ResidualsContainer>
 {
   using Slot = o2::calibration::TimeSlot<ResidualsContainer>;
 

--- a/Detectors/TPC/calibration/SpacePoints/src/SpacePointCalibLinkDef.h
+++ b/Detectors/TPC/calibration/SpacePoints/src/SpacePointCalibLinkDef.h
@@ -30,6 +30,6 @@
 #pragma link C++ class std::vector < o2::tpc::TrackResiduals::VoxStats> + ;
 #pragma link C++ class o2::tpc::ResidualAggregator + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::tpc::ResidualsContainer> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tpc::UnbinnedResid, o2::tpc::ResidualsContainer> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tpc::ResidualsContainer> + ;
 
 #endif

--- a/Detectors/TPC/calibration/include/TPCCalibration/CalibratorPadGainTracks.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/CalibratorPadGainTracks.h
@@ -24,7 +24,7 @@
 namespace o2::tpc
 {
 /// \brief calibrator class for the residual gain map extraction used on an aggregator node
-class CalibratorPadGainTracks : public o2::calibration::TimeSlotCalibration<CalibPadGainTracksBase::DataTHistos, CalibPadGainTracksBase>
+class CalibratorPadGainTracks : public o2::calibration::TimeSlotCalibration<CalibPadGainTracksBase>
 {
   using TFType = o2::calibration::TFType;
   using Slot = o2::calibration::TimeSlot<CalibPadGainTracksBase>;

--- a/Detectors/TPC/calibration/include/TPCCalibration/CalibratordEdx.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/CalibratordEdx.h
@@ -34,7 +34,7 @@ namespace o2::tpc
 {
 
 /// dE/dx calibrator class
-class CalibratordEdx final : public o2::calibration::TimeSlotCalibration<o2::tpc::TrackTPC, o2::tpc::CalibdEdx>
+class CalibratordEdx final : public o2::calibration::TimeSlotCalibration<o2::tpc::CalibdEdx>
 {
   using TFType = o2::calibration::TFType;
   using Slot = o2::calibration::TimeSlot<CalibdEdx>;

--- a/Detectors/TPC/calibration/include/TPCCalibration/LaserTracksCalibrator.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/LaserTracksCalibrator.h
@@ -24,7 +24,7 @@
 namespace o2::tpc
 {
 
-class LaserTracksCalibrator : public o2::calibration::TimeSlotCalibration<TrackTPC, CalibLaserTracks>
+class LaserTracksCalibrator : public o2::calibration::TimeSlotCalibration<CalibLaserTracks>
 {
   using TFType = o2::calibration::TFType;
   using Slot = o2::calibration::TimeSlot<o2::tpc::CalibLaserTracks>;

--- a/Detectors/TPC/calibration/include/TPCCalibration/TPCVDriftTglCalibration.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/TPCVDriftTglCalibration.h
@@ -81,7 +81,7 @@ struct TPCVDTglContainer {
   ClassDefNV(TPCVDTglContainer, 1);
 };
 
-class TPCVDriftTglCalibration : public o2::calibration::TimeSlotCalibration<o2::dataformats::Pair<float, float>, TPCVDTglContainer>
+class TPCVDriftTglCalibration : public o2::calibration::TimeSlotCalibration<TPCVDTglContainer>
 {
   using Slot = o2::calibration::TimeSlot<TPCVDTglContainer>;
 

--- a/Detectors/TPC/calibration/src/TPCCalibrationLinkDef.h
+++ b/Detectors/TPC/calibration/src/TPCCalibrationLinkDef.h
@@ -32,7 +32,7 @@
 #pragma link C++ class o2::tpc::CalibLaserTracks + ;
 #pragma link C++ class o2::tpc::LaserTracksCalibrator + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::tpc::CalibLaserTracks> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tpc::TrackTPC, o2::tpc::CalibLaserTracks> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tpc::CalibLaserTracks> + ;
 #pragma link C++ class o2::tpc::TimePair + ;
 #pragma link C++ class std::vector < o2::tpc::TimePair> + ;
 #pragma link C++ class o2::tpc::IDCGroup + ;
@@ -71,7 +71,7 @@
 #pragma link C++ class o2::tpc::CalibdEdx + ;
 #pragma link C++ class o2::tpc::CalibratordEdx + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::tpc::CalibdEdx> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tpc::TrackTPC, o2::tpc::CalibdEdx> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tpc::CalibdEdx> + ;
 #pragma link C++ class o2::tpc::TrackDump + ;
 #pragma link C++ class o2::tpc::TrackDump::ClusterNativeAdd + ;
 #pragma link C++ class o2::tpc::TrackDump::ClusterGlobal + ;
@@ -85,7 +85,7 @@
 #pragma link C++ class o2::tpc::CalibPadGainTracksBase + ;
 #pragma link C++ class o2::tpc::CalDet < o2::tpc::FastHisto < unsigned int>> + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::tpc::CalibPadGainTracksBase> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tpc::CalDet < o2::tpc::FastHisto < unsigned int>>, o2::tpc::CalibPadGainTracksBase> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tpc::CalibPadGainTracksBase> + ;
 #pragma link C++ class o2::tpc::CalibratorPadGainTracks + ;
 #pragma link C++ class o2::tpc::sac::DataPoint + ;
 #pragma link C++ class o2::tpc::sac::DecodedData + ;
@@ -102,7 +102,7 @@
 #pragma link C++ class o2::tpc::SACCCDBHelper < unsigned char> + ;
 
 #pragma link C++ class o2::calibration::TimeSlot < o2::tpc::TPCVDTglContainer> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::dataformats::Pair < float, float>, o2::tpc::TPCVDTglContainer> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tpc::TPCVDTglContainer> + ;
 #pragma link C++ class o2::tpc::TPCVDriftTglCalibration + ;
 #pragma link C++ class o2::tpc::VDriftHelper + ;
 #endif


### PR DESCRIPTION
Since we do not require to specify the Input type anymore for the TimeSlot-based calibrations I removed it from the interface. In the past the Input type was used for the `fill()` method of the container which was handling the input, but by now this has been changed to achieve a better flexibility (see https://github.com/AliceO2Group/AliceO2/commit/00ca6ef5c32b5fbca9be7d37777b8b6f535dc478#diff-a347bacc31898ff9b134e8e454419707090f8ba2a195ff25044d1a472938b990 and some subsequent commits which changed that class).
The `fill()` method accepts an arbitrary number of inputs now and they do not have to be specified as template parameter for the calibration class itself.
I have updated `Detectors/Calibration/README.md` with more details.
