### PR TITLE
[MCH] adapt to variable TF size (for MC)

### DIFF
--- a/Detectors/MUON/MCH/TimeClustering/include/MCHTimeClustering/ROFTimeClusterFinder.h
+++ b/Detectors/MUON/MCH/TimeClustering/include/MCHTimeClustering/ROFTimeClusterFinder.h
@@ -63,7 +63,7 @@ class ROFTimeClusterFinder
 
     TimeBin() = default;
 
-    bool empty() { return mNDigits == 0; }
+    bool empty() { return mNDigitsPS == 0; }
 
     bool operator<(const TimeBin& other) { return (mNDigitsPS < other.mNDigitsPS); }
     bool operator>(const TimeBin& other) { return (mNDigitsPS > other.mNDigitsPS); }
@@ -72,13 +72,9 @@ class ROFTimeClusterFinder
   };
 
   // peak search parameters
-  static constexpr uint32_t sMaxOrbitsInTF = 256;                              ///< upper limit of the time frame size
-  static constexpr uint32_t sBcInOneOrbit = o2::constants::lhc::LHCMaxBunches; ///< number of bunch-crossings in one orbit
-  static constexpr uint32_t sBcInOneTF = sBcInOneOrbit * sMaxOrbitsInTF;       ///< maximum number of bunch-crossings in one time frame
-
   uint32_t mTimeClusterSize;  ///< maximum size of one time cluster, in bunch crossings
   uint32_t mNbinsInOneWindow; ///< number of time bins considered for the peak search
-  double mBinWidth;           ///< width of one time bin in the peak search algorithm, in bunch crossings
+  uint32_t mBinWidth;         ///< width of one time bin in the peak search algorithm, in bunch crossings
   uint32_t mNbinsInOneTF;     ///< maximum number of peak search bins in one time frame
   DigitFilter mIsGoodDigit;   ///< function to select only digits that are likely signal
   bool mImprovePeakSearch;    ///< whether to only use signal-like digits in the peak search

--- a/Detectors/MUON/MCH/TimeClustering/include/MCHTimeClustering/ROFTimeClusterFinder.h
+++ b/Detectors/MUON/MCH/TimeClustering/include/MCHTimeClustering/ROFTimeClusterFinder.h
@@ -55,10 +55,8 @@ class ROFTimeClusterFinder
  private:
   /// structure representing one bin in the time histogram used for the peak search algorithm
   struct TimeBin {
-    int32_t mFirstIdx{-1}; ///< index of the first digit ROF in the bin
-    int32_t mLastIdx{-1};  ///< index of the last digit ROF in the bin
-    uint32_t mSize{0};     ///< number of digit ROFs in the bin
-    uint32_t mNDigits{0};  ///< number of digits in the bin
+    int32_t mFirstIdx{-1};  ///< index of the first digit ROF in the bin
+    int32_t mLastIdx{-1};   ///< index of the last digit ROF in the bin
     uint32_t mNDigitsPS{0}; ///< number of digits in the bin for the peak search step
 
     TimeBin() = default;


### PR DESCRIPTION
This allows the time clustering to run in MC, where the TF has not a fixed number of orbits.
The algorithm itself is not changed and I checked that it gives the same results in data.
@aferrero2707 can you have a look please?