### PR TITLE
Fix TPC digi time comparison

### DIFF
--- a/Detectors/TPC/simulation/src/DigitContainer.cxx
+++ b/Detectors/TPC/simulation/src/DigitContainer.cxx
@@ -82,7 +82,7 @@ void DigitContainer::fillOutputContainer(std::vector<Digit>& output,
       time = new DigitTime;
     }
 
-    if (maxTimeBinForTimeFrame != -1 && timeBin > maxTimeBinForTimeFrame) {
+    if (maxTimeBinForTimeFrame != -1 && timeBin >= maxTimeBinForTimeFrame) {
       LOG(warn) << "Timebin going beyond timeframe limit .. truncating flush " << timeBin;
       break;
     }


### PR DESCRIPTION
It appears that it needs to be >= and not >
since we were still seeing failures in the clusterizer otherwise.

Believe this fixes bug reported here: https://alice.its.cern.ch/jira/browse/O2-3392