### PR TITLE
[ITS] Implement ITSBase configurable parameters

### DIFF
--- a/Detectors/ITSMFT/ITS/base/CMakeLists.txt
+++ b/Detectors/ITSMFT/ITS/base/CMakeLists.txt
@@ -13,9 +13,11 @@ o2_add_library(ITSBase
                SOURCES src/GeometryTGeo.cxx src/ContainerFactory.cxx
                        src/MisalignmentParameter.cxx
                        src/DescriptorInnerBarrel.cxx
+                       src/ITSBaseParam.cxx
                PUBLIC_LINK_LIBRARIES O2::DetectorsBase O2::ITSMFTBase $<$<BOOL:${ENABLE_UPGRADES}>:O2::ITS3Base>)
 o2_target_root_dictionary(ITSBase
                           HEADERS include/ITSBase/GeometryTGeo.h
                                   include/ITSBase/ContainerFactory.h
                                   include/ITSBase/MisalignmentParameter.h
-                                  include/ITSBase/DescriptorInnerBarrel.h)
+                                  include/ITSBase/DescriptorInnerBarrel.h
+                                  include/ITSBase/ITSBaseParam.h)

--- a/Detectors/ITSMFT/ITS/base/include/ITSBase/ITSBaseParam.h
+++ b/Detectors/ITSMFT/ITS/base/include/ITSBase/ITSBaseParam.h
@@ -1,0 +1,36 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_ITS_BASEPARAM_H_
+#define ALICEO2_ITS_BASEPARAM_H_
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "CommonUtils/ConfigurableParamHelper.h"
+
+namespace o2
+{
+namespace its
+{
+
+// **
+// ** Parameters for ITS base configuration
+// **
+struct ITSBaseParam : public o2::conf::ConfigurableParamHelper<ITSBaseParam> {
+  // Geometry Builder parameters
+  bool buildCYSSAssembly = true;
+  bool buildEndWheels = true;
+  O2ParamDef(ITSBaseParam, "ITSBase");
+};
+
+} // end namespace its
+} // end namespace o2
+
+#endif // ALICEO2_ITS_BASEPARAM_H_

--- a/Detectors/ITSMFT/ITS/base/src/ITSBaseParam.cxx
+++ b/Detectors/ITSMFT/ITS/base/src/ITSBaseParam.cxx
@@ -9,17 +9,5 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifdef __CLING__
-
-#pragma link off all globals;
-#pragma link off all classes;
-#pragma link off all functions;
-
-#pragma link C++ class o2::its::GeometryTGeo;
-#pragma link C++ class o2::its::ContainerFactory;
-#pragma link C++ class o2::its::MisalignmentParameter + ;
-#pragma link C++ class o2::its::DescriptorInnerBarrel + ;
-#pragma link C++ class o2::its::ITSBaseParam + ;
-#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::its::ITSBaseParam> + ;
-
-#endif
+#include "ITSBase/ITSBaseParam.h"
+O2ParamImpl(o2::its::ITSBaseParam);

--- a/Detectors/ITSMFT/ITS/simulation/src/DescriptorInnerBarrelITS2.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/DescriptorInnerBarrelITS2.cxx
@@ -27,6 +27,7 @@
 
 #include "ITSMFTBase/SegmentationAlpide.h"
 #include "ITSBase/GeometryTGeo.h"
+#include "ITSBase/ITSBaseParam.h"
 #include "ITSSimulation/DescriptorInnerBarrelITS2.h"
 #include "ITSSimulation/V3Services.h"
 #include "ITSSimulation/V3Layer.h"
@@ -159,20 +160,24 @@ void DescriptorInnerBarrelITS2::createServices(TGeoVolume* dest)
   // Updated:      21 Oct 2019  Mario Sitta  CYSS added
   //
 
+  auto& itsBaseParam = ITSBaseParam::Instance();
+
   std::unique_ptr<V3Services> mServicesGeometry(new V3Services("ITS"));
 
-  // Create the End Wheels on Side A
-  TGeoVolume* endWheelsA = mServicesGeometry.get()->createIBEndWheelsSideA();
-  dest->AddNode(endWheelsA, 1, nullptr);
+  if (itsBaseParam.buildEndWheels) {
+    // Create the End Wheels on Side A
+    TGeoVolume* endWheelsA = mServicesGeometry.get()->createIBEndWheelsSideA();
+    dest->AddNode(endWheelsA, 1, nullptr);
 
-  // Create the End Wheels on Side C
-  TGeoVolume* endWheelsC = mServicesGeometry.get()->createIBEndWheelsSideC();
-  dest->AddNode(endWheelsC, 1, nullptr);
-
-  // Create the CYSS Assembly (i.e. the supporting half cylinder and cone)
-  TGeoVolume* cyss = mServicesGeometry.get()->createCYSSAssembly();
-  dest->AddNode(cyss, 1, nullptr);
-
+    // Create the End Wheels on Side C
+    TGeoVolume* endWheelsC = mServicesGeometry.get()->createIBEndWheelsSideC();
+    dest->AddNode(endWheelsC, 1, nullptr);
+  }
+  if (itsBaseParam.buildCYSSAssembly) {
+    // Create the CYSS Assembly (i.e. the supporting half cylinder and cone)
+    TGeoVolume* cyss = mServicesGeometry.get()->createCYSSAssembly();
+    dest->AddNode(cyss, 1, nullptr);
+  }
   mServicesGeometry.get()->createIBGammaConvWire(dest);
 }
 


### PR DESCRIPTION
Configurable parameter to enable/disable parts of ITS geometry in simulations.

Use:
>  `o2-sim -n 1 -m ITS --configKeyValues "ITSBase.buildCYSSAssembly=0;ITSBase.buildEndWheels=0"`