### PR TITLE
[WIP] Prepare TPC residual aggregator for production

### DIFF
--- a/Detectors/CPV/calib/include/CPVCalibration/GainCalibrator.h
+++ b/Detectors/CPV/calib/include/CPVCalibration/GainCalibrator.h
@@ -70,7 +70,7 @@ class GainCalibData
 }; // end GainCalibData
 //=============================================================================
 using GainTimeSlot = o2::calibration::TimeSlot<GainCalibData>;
-class GainCalibrator final : public o2::calibration::TimeSlotCalibration<Digit, GainCalibData>
+class GainCalibrator final : public o2::calibration::TimeSlotCalibration<GainCalibData>
 {
  public:
   GainCalibrator();

--- a/Detectors/CPV/calib/include/CPVCalibration/NoiseCalibrator.h
+++ b/Detectors/CPV/calib/include/CPVCalibration/NoiseCalibrator.h
@@ -40,7 +40,7 @@ struct NoiseCalibData {
 //=========================================================================
 
 using NoiseTimeSlot = o2::calibration::TimeSlot<o2::cpv::NoiseCalibData>;
-class NoiseCalibrator final : public o2::calibration::TimeSlotCalibration<o2::cpv::Digit, o2::cpv::NoiseCalibData>
+class NoiseCalibrator final : public o2::calibration::TimeSlotCalibration<o2::cpv::NoiseCalibData>
 {
  public:
   NoiseCalibrator();

--- a/Detectors/CPV/calib/include/CPVCalibration/PedestalCalibrator.h
+++ b/Detectors/CPV/calib/include/CPVCalibration/PedestalCalibrator.h
@@ -71,7 +71,7 @@ struct PedestalCalibData {
 
 using PedestalTimeSlot = o2::calibration::TimeSlot<o2::cpv::PedestalCalibData>;
 //===================================================================
-class PedestalCalibrator final : public o2::calibration::TimeSlotCalibration<o2::cpv::Digit, o2::cpv::PedestalCalibData>
+class PedestalCalibrator final : public o2::calibration::TimeSlotCalibration<o2::cpv::PedestalCalibData>
 {
  public:
   PedestalCalibrator();

--- a/Detectors/CPV/calib/src/CPVCalibrationLinkDef.h
+++ b/Detectors/CPV/calib/src/CPVCalibrationLinkDef.h
@@ -18,18 +18,18 @@
 #pragma link C++ class o2::cpv::PedestalSpectrum + ;
 #pragma link C++ class o2::cpv::PedestalCalibData + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::cpv::PedestalCalibData> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::cpv::Digit, o2::cpv::PedestalCalibData> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::cpv::PedestalCalibData> + ;
 #pragma link C++ class o2::cpv::PedestalCalibrator + ;
 
 #pragma link C++ class o2::cpv::NoiseCalibData + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::cpv::NoiseCalibData> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::cpv::Digit, o2::cpv::NoiseCalibData> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::cpv::NoiseCalibData> + ;
 #pragma link C++ class o2::cpv::NoiseCalibrator + ;
 
 #pragma link C++ class o2::cpv::AmplitudeSpectrum + ;
 #pragma link C++ class o2::cpv::GainCalibData + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::cpv::GainCalibData> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::cpv::Digit, o2::cpv::GainCalibData> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::cpv::GainCalibData> + ;
 #pragma link C++ class o2::cpv::GainCalibrator + ;
 
 #endif

--- a/Detectors/Calibration/include/DetectorsCalibration/MeanVertexCalibrator.h
+++ b/Detectors/Calibration/include/DetectorsCalibration/MeanVertexCalibrator.h
@@ -26,7 +26,7 @@ namespace o2
 namespace calibration
 {
 
-class MeanVertexCalibrator final : public o2::calibration::TimeSlotCalibration<o2::dataformats::PrimaryVertex, o2::calibration::MeanVertexData>
+class MeanVertexCalibrator final : public o2::calibration::TimeSlotCalibration<o2::calibration::MeanVertexData>
 {
   using PVertex = o2::dataformats::PrimaryVertex;
   using MeanVertexData = o2::calibration::MeanVertexData;

--- a/Detectors/Calibration/include/DetectorsCalibration/TimeSlot.h
+++ b/Detectors/Calibration/include/DetectorsCalibration/TimeSlot.h
@@ -35,17 +35,8 @@ class TimeSlot
  public:
   TimeSlot() = default;
   TimeSlot(TFType tfS, TFType tfE) : mTFStart(tfS), mTFEnd(tfE) {}
-  TimeSlot(const TimeSlot& src) : mTFStart(src.mTFStart), mTFEnd(src.mTFEnd), mContainer(std::make_unique<Container>(*src.getContainer())) {}
-  TimeSlot& operator=(const TimeSlot& src)
-  {
-    if (&src != this) {
-      mTFStart = src.mTFStart;
-      mTFEnd = src.mTFEnd;
-      mTFStartMS = src.mTFStartMS;
-      mContainer = std::make_unique<Container>(*src.getContainer());
-    }
-    return *this;
-  }
+  TimeSlot(const TimeSlot& src) { std::move(src); }
+  TimeSlot& operator=(TimeSlot&& src) = default;
 
   ~TimeSlot() = default;
 

--- a/Detectors/Calibration/include/DetectorsCalibration/TimeSlotCalibration.h
+++ b/Detectors/Calibration/include/DetectorsCalibration/TimeSlotCalibration.h
@@ -36,7 +36,7 @@ class ProcessingContext;
 namespace calibration
 {
 
-template <typename Input, typename Container = Input>
+template <typename Container>
 class TimeSlotCalibration
 {
  public:
@@ -106,7 +106,7 @@ class TimeSlotCalibration
 
   template <typename... DATA>
   bool process(const DATA&... data);
-  virtual void checkSlotsToFinalize(TFType tf, int maxDelay = 0);
+  virtual void checkSlotsToFinalize(TFType tf = INFINITE_TF, int maxDelay = 0);
   virtual void finalizeOldestSlot();
 
   // Methods to be implemented by the derived user class
@@ -226,9 +226,9 @@ class TimeSlotCalibration
 };
 
 //_________________________________________________
-template <typename Input, typename Container>
+template <typename Container>
 template <typename... DATA>
-bool TimeSlotCalibration<Input, Container>::process(const DATA&... data)
+bool TimeSlotCalibration<Container>::process(const DATA&... data)
 {
   static bool firstCall = true;
   if (firstCall) {
@@ -268,8 +268,8 @@ bool TimeSlotCalibration<Input, Container>::process(const DATA&... data)
 }
 
 //_________________________________________________
-template <typename Input, typename Container>
-void TimeSlotCalibration<Input, Container>::checkSlotsToFinalize(TFType tf, int maxDelay)
+template <typename Container>
+void TimeSlotCalibration<Container>::checkSlotsToFinalize(TFType tf, int maxDelay)
 {
   // Check which slots can be finalized, provided the newly arrived TF is tf
 
@@ -337,8 +337,8 @@ void TimeSlotCalibration<Input, Container>::checkSlotsToFinalize(TFType tf, int 
 }
 
 //_________________________________________________
-template <typename Input, typename Container>
-void TimeSlotCalibration<Input, Container>::finalizeOldestSlot()
+template <typename Container>
+void TimeSlotCalibration<Container>::finalizeOldestSlot()
 {
   // Enforce finalization and removal of the oldest slot
   if (mSlots.empty()) {
@@ -351,8 +351,8 @@ void TimeSlotCalibration<Input, Container>::finalizeOldestSlot()
 }
 
 //________________________________________
-template <typename Input, typename Container>
-inline TFType TimeSlotCalibration<Input, Container>::tf2SlotMin(TFType tf) const
+template <typename Container>
+inline TFType TimeSlotCalibration<Container>::tf2SlotMin(TFType tf) const
 {
 
   // returns the min TF of the slot to which "tf" belongs
@@ -368,8 +368,8 @@ inline TFType TimeSlotCalibration<Input, Container>::tf2SlotMin(TFType tf) const
 }
 
 //_________________________________________________
-template <typename Input, typename Container>
-TimeSlot<Container>& TimeSlotCalibration<Input, Container>::getSlotForTF(TFType tf)
+template <typename Container>
+TimeSlot<Container>& TimeSlotCalibration<Container>::getSlotForTF(TFType tf)
 {
 
   LOG(debug) << "Getting slot for TF " << tf;
@@ -423,8 +423,8 @@ TimeSlot<Container>& TimeSlotCalibration<Input, Container>::getSlotForTF(TFType 
 }
 
 //_________________________________________________
-template <typename Input, typename Container>
-void TimeSlotCalibration<Input, Container>::print() const
+template <typename Container>
+void TimeSlotCalibration<Container>::print() const
 {
   for (int i = 0; i < getNSlots(); i++) {
     LOG(info) << "Slot #" << i << " of " << getNSlots();
@@ -433,8 +433,8 @@ void TimeSlotCalibration<Input, Container>::print() const
 }
 
 //_________________________________________________
-template <typename Input, typename Container>
-bool TimeSlotCalibration<Input, Container>::updateSaveMetaData()
+template <typename Container>
+bool TimeSlotCalibration<Container>::updateSaveMetaData()
 {
   if (mSlots.empty()) {
     LOG(warn) << "Nothing to save, no TimeSlots defined";
@@ -452,8 +452,8 @@ bool TimeSlotCalibration<Input, Container>::updateSaveMetaData()
 }
 
 //_________________________________________________
-template <typename Input, typename Container>
-bool TimeSlotCalibration<Input, Container>::saveLastSlot()
+template <typename Container>
+bool TimeSlotCalibration<Container>::saveLastSlot()
 {
   if (!getSavedSlotAllowed()) {
     LOG(info) << "Slot saving is disabled";
@@ -483,8 +483,8 @@ bool TimeSlotCalibration<Input, Container>::saveLastSlot()
 }
 
 //_________________________________________________
-template <typename Input, typename Container>
-bool TimeSlotCalibration<Input, Container>::loadSavedSlot()
+template <typename Container>
+bool TimeSlotCalibration<Container>::loadSavedSlot()
 {
   if (!getSavedSlotAllowed()) {
     LOG(info) << "Saved slot usage is disabled";
@@ -517,8 +517,8 @@ bool TimeSlotCalibration<Input, Container>::loadSavedSlot()
 }
 
 //_________________________________________________
-template <typename Input, typename Container>
-std::string TimeSlotCalibration<Input, Container>::getSaveFilePath() const
+template <typename Container>
+std::string TimeSlotCalibration<Container>::getSaveFilePath() const
 {
   if (mSaveFileName.empty()) {
     LOGP(fatal, "Save file name was not set");

--- a/Detectors/Calibration/src/DetectorsCalibrationLinkDef.h
+++ b/Detectors/Calibration/src/DetectorsCalibrationLinkDef.h
@@ -18,7 +18,7 @@
 #pragma link C++ class o2::calibration::MeanVertexData + ;
 #pragma link C++ class o2::calibration::TimeSlotMetaData + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::calibration::MeanVertexData> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::dataformats::PrimaryVertex, o2::calibration::MeanVertexData> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::calibration::MeanVertexData> + ;
 #pragma link C++ class o2::calibration::MeanVertexCalibrator + ;
 #pragma link C++ class o2::calibration::MeanVertexParams + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::calibration::MeanVertexParams> + ;

--- a/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelCalibrator.h
+++ b/Detectors/EMCAL/calibration/include/EMCALCalibration/EMCALChannelCalibrator.h
@@ -50,7 +50,7 @@ namespace emcal
 /// \brief class used for managment of bad channel and time calibration
 /// template DataInput can be ChannelData or TimeData   // o2::emcal::EMCALChannelData, o2::emcal::EMCALTimeCalibData
 template <typename DataInput, typename DataOutput>
-class EMCALChannelCalibrator : public o2::calibration::TimeSlotCalibration<o2::emcal::Cell, DataInput>
+class EMCALChannelCalibrator : public o2::calibration::TimeSlotCalibration<DataInput>
 {
   using TFType = o2::calibration::TFType;
   using Slot = o2::calibration::TimeSlot<DataInput>;
@@ -187,7 +187,7 @@ void EMCALChannelCalibrator<DataInput, DataOutput>::finalizeSlot(o2::calibration
 template <typename DataInput, typename DataOutput>
 o2::calibration::TimeSlot<DataInput>& EMCALChannelCalibrator<DataInput, DataOutput>::emplaceNewSlot(bool front, TFType tstart, TFType tend)
 {
-  auto& cont = o2::calibration::TimeSlotCalibration<o2::emcal::Cell, DataInput>::getSlots();
+  auto& cont = o2::calibration::TimeSlotCalibration<DataInput>::getSlots();
   auto& slot = front ? cont.emplace_front(tstart, tend) : cont.emplace_back(tstart, tend);
   slot.setContainer(std::make_unique<DataInput>());
   return slot;

--- a/Detectors/EMCAL/calibration/src/EMCALCalibrationLinkDef.h
+++ b/Detectors/EMCAL/calibration/src/EMCALCalibrationLinkDef.h
@@ -17,11 +17,11 @@
 
 #pragma link C++ class o2::emcal::EMCALChannelCalibrator < o2::emcal::EMCALChannelData, o2::emcal::BadChannelMap> + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::emcal::EMCALChannelData> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::emcal::Cell, o2::emcal::EMCALChannelData> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::emcal::EMCALChannelData> + ;
 
 #pragma link C++ class o2::emcal::EMCALChannelCalibrator < o2::emcal::EMCALTimeCalibData, o2::emcal::TimeCalibrationParams> + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::emcal::EMCALTimeCalibData> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::emcal::Cell, o2::emcal::EMCALTimeCalibData> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::emcal::EMCALTimeCalibData> + ;
 
 #pragma link C++ class o2::emcal::EMCALCalibParams + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::emcal::EMCALCalibParams> + ;

--- a/Detectors/FIT/FT0/calibration/include/FT0Calibration/FT0CalibCollector.h
+++ b/Detectors/FIT/FT0/calibration/include/FT0Calibration/FT0CalibCollector.h
@@ -60,7 +60,7 @@ class FT0CalibInfoSlot
   ClassDefNV(FT0CalibInfoSlot, 1);
 };
 
-class FT0CalibCollector final : public o2::calibration::TimeSlotCalibration<o2::ft0::FT0CalibrationInfoObject, o2::ft0::FT0CalibInfoSlot>
+class FT0CalibCollector final : public o2::calibration::TimeSlotCalibration<o2::ft0::FT0CalibInfoSlot>
 {
   using TFType = o2::calibration::TFType;
   using Slot = o2::calibration::TimeSlot<o2::ft0::FT0CalibInfoSlot>;

--- a/Detectors/FIT/FT0/calibration/src/FT0CalibrationLinkDef.h
+++ b/Detectors/FIT/FT0/calibration/src/FT0CalibrationLinkDef.h
@@ -21,9 +21,13 @@
 #pragma link C++ class o2::ft0::GlobalOffsetsContainer + ;
 #pragma link C++ class o2::ft0::FT0CalibTimeSlewing + ;
 #pragma link C++ class o2::ft0::FT0CalibCollector + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::ft0::FT0CalibrationInfoObject, o2::ft0::FT0CalibInfoSlot>;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < float, o2::ft0::FT0TimeOffsetSlotContainer>;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::ft0::FT0CalibrationInfoObject, o2::ft0::FT0ChannelTimeOffsetSlotContainer>;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::ft0::GlobalOffsetsInfoObject, o2::ft0::GlobalOffsetsContainer>;
+#pragma link C++ class o2::calibration::TimeSlot < o2::ft0::FT0CalibInfoSlot>;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::ft0::FT0CalibInfoSlot>;
+#pragma link C++ class o2::calibration::TimeSlot < o2::ft0::FT0TimeOffsetSlotContainer>;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::ft0::FT0TimeOffsetSlotContainer>;
+#pragma link C++ class o2::calibration::TimeSlot < o2::ft0::FT0ChannelTimeOffsetSlotContainer>;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::ft0::FT0ChannelTimeOffsetSlotContainer>;
+#pragma link C++ class o2::calibration::TimeSlot < o2::ft0::GlobalOffsetsContainer>;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::ft0::GlobalOffsetsContainer>;
 
 #endif

--- a/Detectors/FIT/FV0/calibration/include/FV0Calibration/FV0CalibCollector.h
+++ b/Detectors/FIT/FV0/calibration/include/FV0Calibration/FV0CalibCollector.h
@@ -58,7 +58,7 @@ class FV0CalibInfoSlot
   ClassDefNV(FV0CalibInfoSlot, 1);
 };
 
-class FV0CalibCollector final : public o2::calibration::TimeSlotCalibration<o2::fv0::FV0CalibrationInfoObject, o2::fv0::FV0CalibInfoSlot>
+class FV0CalibCollector final : public o2::calibration::TimeSlotCalibration<o2::fv0::FV0CalibInfoSlot>
 {
   using TFType = o2::calibration::TFType;
   using Slot = o2::calibration::TimeSlot<o2::fv0::FV0CalibInfoSlot>;

--- a/Detectors/FIT/FV0/calibration/src/FV0CalibrationLinkDef.h
+++ b/Detectors/FIT/FV0/calibration/src/FV0CalibrationLinkDef.h
@@ -17,7 +17,9 @@
 
 #pragma link C++ class o2::fv0::FV0ChannelTimeOffsetSlotContainer + ;
 #pragma link C++ class o2::fv0::FV0CalibCollector + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::fv0::FV0CalibrationInfoObject, o2::fv0::FV0CalibInfoSlot>;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::fv0::FV0CalibrationInfoObject, o2::fv0::FV0ChannelTimeOffsetSlotContainer>;
+#pragma link C++ class o2::calibration::TimeSlot < o2::fv0::FV0CalibInfoSlot>;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::fv0::FV0CalibInfoSlot>;
+#pragma link C++ class o2::calibration::TimeSlot < o2::fv0::FV0ChannelTimeOffsetSlotContainer>;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::fv0::FV0ChannelTimeOffsetSlotContainer>;
 
 #endif

--- a/Detectors/FIT/common/calibration/include/FITCalibration/FITCalibrationDevice.h
+++ b/Detectors/FIT/common/calibration/include/FITCalibration/FITCalibrationDevice.h
@@ -32,7 +32,7 @@ class FITCalibrationDevice : public o2::framework::Task
 {
   static constexpr const char* DEFAULT_INPUT_DATA_LABEL = "calib";
   static constexpr const char* sDEFAULT_CCDB_URL = "http://localhost:8080";
-  using CalibratorType = FITCalibrator<InputCalibrationInfoType, TimeSlotStorageType, CalibrationObjectType>;
+  using CalibratorType = FITCalibrator<TimeSlotStorageType, CalibrationObjectType>;
 
  public:
   explicit FITCalibrationDevice(std::string inputDataLabel = DEFAULT_INPUT_DATA_LABEL, std::shared_ptr<o2::base::GRPGeomRequest> req = {})

--- a/Detectors/FIT/common/calibration/include/FITCalibration/FITCalibrator.h
+++ b/Detectors/FIT/common/calibration/include/FITCalibration/FITCalibrator.h
@@ -27,8 +27,8 @@
 namespace o2::fit
 {
 
-template <typename InputCalibrationInfoType, typename TimeSlotStorageType, typename CalibrationObjectType>
-class FITCalibrator final : public o2::calibration::TimeSlotCalibration<InputCalibrationInfoType, TimeSlotStorageType>
+template <typename TimeSlotStorageType, typename CalibrationObjectType>
+class FITCalibrator final : public o2::calibration::TimeSlotCalibration<TimeSlotStorageType>
 {
 
   // probably will be set via run parameter
@@ -80,7 +80,7 @@ class FITCalibrator final : public o2::calibration::TimeSlotCalibration<InputCal
   {
     LOG(info) << "FIT_CALIBRATOR_TYPE::emplaceNewSlot "
               << " start " << tstart << " end " << tend;
-    auto& cont = o2::calibration::TimeSlotCalibration<InputCalibrationInfoType, TimeSlotStorageType>::getSlots();
+    auto& cont = o2::calibration::TimeSlotCalibration<TimeSlotStorageType>::getSlots();
     auto& slot = front ? cont.emplace_front(tstart, tend) : cont.emplace_back(tstart, tend);
     slot.setContainer(std::make_unique<TimeSlotStorageType>(mMinEntries));
     return slot;

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCInterpolationSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCInterpolationSpec.h
@@ -53,6 +53,7 @@ class TPCInterpolationDPL : public Task
   bool mUseMC{false}; ///< MC flag
   bool mProcessITSTPConly{false}; ///< should also tracks without outer point (ITS-TPC only) be processed?
   bool mSendTrackData{false};     ///< if true, not only the clusters but also corresponding track data will be sent
+  uint32_t mSlotLength{600u};     ///< the length of one calibration slot required to calculate max number of tracks per TF
   TStopwatch mTimer;
 };
 

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCInterpolationSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCInterpolationSpec.h
@@ -16,7 +16,6 @@
 
 #include "DataFormatsTPC/Constants.h"
 #include "SpacePoints/TrackInterpolation.h"
-#include "SpacePoints/TrackResiduals.h"
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
 #include "TStopwatch.h"
@@ -38,7 +37,7 @@ namespace tpc
 class TPCInterpolationDPL : public Task
 {
  public:
-  TPCInterpolationDPL(std::shared_ptr<o2::globaltracking::DataRequest> dr, std::shared_ptr<o2::base::GRPGeomRequest> gr, bool useMC, bool processITSTPConly, bool writeUnfiltered, bool sendTrackData) : mDataRequest(dr), mGGCCDBRequest(gr), mUseMC(useMC), mProcessITSTPConly(processITSTPConly), mWriteUnfiltered(writeUnfiltered), mSendTrackData(sendTrackData) {}
+  TPCInterpolationDPL(std::shared_ptr<o2::globaltracking::DataRequest> dr, std::shared_ptr<o2::base::GRPGeomRequest> gr, bool useMC, bool processITSTPConly, bool sendTrackData) : mDataRequest(dr), mGGCCDBRequest(gr), mUseMC(useMC), mProcessITSTPConly(processITSTPConly), mSendTrackData(sendTrackData) {}
   ~TPCInterpolationDPL() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
@@ -48,19 +47,17 @@ class TPCInterpolationDPL : public Task
  private:
   void updateTimeDependentParams(ProcessingContext& pc);
   o2::tpc::TrackInterpolation mInterpolation;                    ///< track interpolation engine
-  o2::tpc::TrackResiduals mResidualProcessor;                    ///< conversion and avg. distortion map creation engine
   std::shared_ptr<o2::globaltracking::DataRequest> mDataRequest; ///< steers the input
   std::shared_ptr<o2::base::GRPGeomRequest> mGGCCDBRequest;
   o2::tpc::VDriftHelper mTPCVDriftHelper{};
   bool mUseMC{false}; ///< MC flag
   bool mProcessITSTPConly{false}; ///< should also tracks without outer point (ITS-TPC only) be processed?
-  bool mWriteUnfiltered{false};   ///< whether or not the unfiltered residuals should be sent out in addition to filtered ones
   bool mSendTrackData{false};     ///< if true, not only the clusters but also corresponding track data will be sent
   TStopwatch mTimer;
 };
 
 /// create a processor spec
-framework::DataProcessorSpec getTPCInterpolationSpec(o2::dataformats::GlobalTrackID::mask_t src, bool useMC, bool processITSTPConly, bool writeResiduals, bool sendTrackData);
+framework::DataProcessorSpec getTPCInterpolationSpec(o2::dataformats::GlobalTrackID::mask_t src, bool useMC, bool processITSTPConly, bool sendTrackData);
 
 } // namespace tpc
 } // namespace o2

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCResidualAggregatorSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCResidualAggregatorSpec.h
@@ -111,6 +111,8 @@ class ResidualAggregatorDevice : public o2::framework::Task
     std::chrono::duration<double, std::milli> ccdbUpdateTime = std::chrono::high_resolution_clock::now() - runStartTime;
 
     auto residualsData = pc.inputs().get<gsl::span<o2::tpc::UnbinnedResid>>("unbinnedRes");
+    auto trackRefs = pc.inputs().get<gsl::span<o2::tpc::TrackDataCompact>>("trackRefs");
+
     // track data input is optional
     const gsl::span<const o2::tpc::TrackData>* trkDataPtr = nullptr;
     using trkDataType = std::decay_t<decltype(pc.inputs().get<gsl::span<o2::tpc::TrackData>>(""))>;
@@ -129,10 +131,9 @@ class ResidualAggregatorDevice : public o2::framework::Task
       lumi = &lumiInput.value();
     }
 
-    auto data = std::make_pair<gsl::span<const o2::tpc::TrackData>, gsl::span<const o2::tpc::UnbinnedResid>>(std::move(*trkData), std::move(residualsData));
     o2::base::TFIDInfoHelper::fillTFIDInfo(pc, mAggregator->getCurrentTFInfo());
     LOG(info) << "Processing TF " << mAggregator->getCurrentTFInfo().tfCounter << " with " << trkData->size() << " tracks and " << residualsData.size() << " unbinned residuals associated to them";
-    mAggregator->process(data, lumi);
+    mAggregator->process(residualsData, trackRefs, trkDataPtr, lumi);
     std::chrono::duration<double, std::milli> runDuration = std::chrono::high_resolution_clock::now() - runStartTime;
     LOGP(info, "Duration for run method: {} ms. From this taken for time dependent param update: {} ms",
          std::chrono::duration_cast<std::chrono::milliseconds>(runDuration).count(),
@@ -179,6 +180,7 @@ DataProcessorSpec getTPCResidualAggregatorSpec(bool trackInput, bool ctpInput, b
   }
   auto& inputs = dataRequest->inputs;
   inputs.emplace_back("unbinnedRes", "GLO", "UNBINNEDRES");
+  inputs.emplace_back("trackRefs", "GLO", "TRKREFS");
   if (trackInput) {
     inputs.emplace_back("trkData", "GLO", "TRKDATA");
   }

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCResidualAggregatorSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCResidualAggregatorSpec.h
@@ -142,7 +142,7 @@ class ResidualAggregatorDevice : public o2::framework::Task
   void endOfStream(o2::framework::EndOfStreamContext& ec) final
   {
     LOG(info) << "Finalizing calibration for end of stream";
-    mAggregator->checkSlotsToFinalize(o2::calibration::INFINITE_TF);
+    mAggregator->checkSlotsToFinalize();
     mAggregator.reset(); // must invoke destructor manually here, otherwise we get a segfault
   }
 
@@ -195,7 +195,7 @@ DataProcessorSpec getTPCResidualAggregatorSpec(bool trackInput, bool ctpInput, b
     Outputs{},
     AlgorithmSpec{adaptFromTask<o2::calibration::ResidualAggregatorDevice>(ccdbRequest, trackInput, ctpInput, writeUnbinnedResiduals, writeBinnedResiduals, writeTrackData, dataRequest)},
     Options{
-      {"sec-per-slot", VariantType::UInt32, 60u, {"number of seconds per calibration time slot (put 0 for infinite slot length)"}},
+      {"sec-per-slot", VariantType::UInt32, 600u, {"number of seconds per calibration time slot (put 0 for infinite slot length)"}},
       {"updateInterval", VariantType::UInt32, 6'000u, {"update interval in number of TFs (only used in case slot length is infinite)"}},
       {"max-delay", VariantType::UInt32, 1u, {"number of slots in past to consider"}},
       {"min-entries", VariantType::Int, 0, {"minimum number of entries on average per voxel"}},

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCResidualAggregatorSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCResidualAggregatorSpec.h
@@ -46,9 +46,10 @@ class ResidualAggregatorDevice : public o2::framework::Task
   {
     o2::base::GRPGeomHelper::instance().setRequest(mCCDBRequest);
     int minEnt = ic.options().get<int>("min-entries");
-    auto slotLength = ic.options().get<uint32_t>("tf-per-slot");
+    auto slotLength = ic.options().get<uint32_t>("sec-per-slot");
+    bool useInfiniteSlotLength = false;
     if (slotLength == 0) {
-      slotLength = o2::calibration::INFINITE_TF;
+      useInfiniteSlotLength = true;
     }
     auto updateInterval = ic.options().get<uint32_t>("updateInterval");
     auto delay = ic.options().get<uint32_t>("max-delay");
@@ -83,9 +84,13 @@ class ResidualAggregatorDevice : public o2::framework::Task
     int autosave = ic.options().get<int>("autosave-interval");
     mAggregator->setAutosaveInterval(autosave);
     // TODO mAggregator should get an option to set the binning externally (expose TrackResiduals::setBinning methods to user? as command line option?)
-    mAggregator->setSlotLength(slotLength);
     mAggregator->setMaxSlotsDelay(delay);
-    mAggregator->setCheckIntervalInfiniteSlot(updateInterval);
+    if (useInfiniteSlotLength) {
+      mAggregator->setSlotLength(o2::calibration::INFINITE_TF);
+      mAggregator->setCheckIntervalInfiniteSlot(updateInterval);
+    } else {
+      mAggregator->setSlotLengthInSeconds(slotLength);
+    }
     mAggregator->setWriteBinnedResiduals(mWriteBinnedResiduals);
     mAggregator->setWriteUnbinnedResiduals(mWriteUnbinnedResiduals);
     mAggregator->setWriteTrackData(mWriteTrackData);
@@ -190,11 +195,11 @@ DataProcessorSpec getTPCResidualAggregatorSpec(bool trackInput, bool ctpInput, b
     Outputs{},
     AlgorithmSpec{adaptFromTask<o2::calibration::ResidualAggregatorDevice>(ccdbRequest, trackInput, ctpInput, writeUnbinnedResiduals, writeBinnedResiduals, writeTrackData, dataRequest)},
     Options{
-      {"tf-per-slot", VariantType::UInt32, 6'000u, {"number of TFs per calibration time slot (put 0 for infinite slot length)"}},
-      {"updateInterval", VariantType::UInt32, 6'000u, {"update interval in number of TFs in case slot length is infinite"}},
+      {"sec-per-slot", VariantType::UInt32, 60u, {"number of seconds per calibration time slot (put 0 for infinite slot length)"}},
+      {"updateInterval", VariantType::UInt32, 6'000u, {"update interval in number of TFs (only used in case slot length is infinite)"}},
       {"max-delay", VariantType::UInt32, 1u, {"number of slots in past to consider"}},
       {"min-entries", VariantType::Int, 0, {"minimum number of entries on average per voxel"}},
-      {"compression", VariantType::Int, 101, {"ROOT compression setting for output file (see TFile documentation for meaning of this number)"}},
+      {"compression", VariantType::Int, 505, {"ROOT compression setting for output file (see TFile documentation for meaning of this number)"}},
       {"output-dir", VariantType::String, "none", {"Output directory for residuals. Defaults to current working directory. Output is disabled in case set to /dev/null"}},
       {"meta-output-dir", VariantType::String, "/dev/null", {"Residuals metadata output directory, must exist (if not /dev/null)"}},
       {"autosave-interval", VariantType::Int, 0, {"Write output to file for every n-th TF. 0 means this feature is OFF"}}}};

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCUnbinnedResidualReaderSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCUnbinnedResidualReaderSpec.h
@@ -44,6 +44,7 @@ class TPCUnbinnedResidualReader : public o2::framework::Task
   std::string mInTreeName;
   std::vector<UnbinnedResid> mUnbinnedResid, *mUnbinnedResidPtr = &mUnbinnedResid;
   std::vector<TrackData> mTrackData, *mTrackDataPtr = &mTrackData;
+  std::vector<TrackDataCompact> mTrackDataCompact, *mTrackDataCompactPtr = &mTrackDataCompact;
 };
 
 /// read unbinned TPC residuals and reference tracks from a root file

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
@@ -156,6 +156,7 @@ void TPCInterpolationDPL::run(ProcessingContext& pc)
     }
   }
   pc.outputs().snapshot(Output{"GLO", "UNBINNEDRES", 0, Lifetime::Timeframe}, mInterpolation.getClusterResiduals());
+  pc.outputs().snapshot(Output{"GLO", "TRKREFS", 0, Lifetime::Timeframe}, mInterpolation.getTrackDataCompact());
   if (mSendTrackData) {
     pc.outputs().snapshot(Output{"GLO", "TRKDATA", 0, Lifetime::Timeframe}, mInterpolation.getReferenceTracks());
   }
@@ -192,10 +193,15 @@ DataProcessorSpec getTPCInterpolationSpec(GTrackID::mask_t src, bool useMC, bool
   o2::tpc::VDriftHelper::requestCCDBInputs(dataRequest->inputs);
   if (SpacePointsCalibConfParam::Instance().writeUnfiltered) {
     outputs.emplace_back("GLO", "TPCINT_TRK", 0, Lifetime::Timeframe);
-    outputs.emplace_back("GLO", "TPCINT_RES", 0, Lifetime::Timeframe);
+    if (sendTrackData) {
+      outputs.emplace_back("GLO", "TPCINT_RES", 0, Lifetime::Timeframe);
+    }
   }
   outputs.emplace_back("GLO", "UNBINNEDRES", 0, Lifetime::Timeframe);
-  outputs.emplace_back("GLO", "TRKDATA", 0, Lifetime::Timeframe);
+  outputs.emplace_back("GLO", "TRKREFS", 0, Lifetime::Timeframe);
+  if (sendTrackData) {
+    outputs.emplace_back("GLO", "TRKDATA", 0, Lifetime::Timeframe);
+  }
 
   return DataProcessorSpec{
     "tpc-track-interpolation",

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCResidualWriterSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCResidualWriterSpec.cxx
@@ -15,6 +15,7 @@
 
 #include "SpacePoints/TrackInterpolation.h"
 #include "SpacePoints/TrackResiduals.h"
+#include "SpacePoints/SpacePointsCalibConfParam.h"
 #include "TPCInterpolationWorkflow/TPCResidualWriterSpec.h"
 #include "DataFormatsCTP/LumiInfo.h"
 #include "DPLUtils/MakeRootTreeWriterSpec.h"
@@ -28,9 +29,9 @@ namespace tpc
 template <typename T>
 using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
 
-DataProcessorSpec getTPCResidualWriterSpec(bool writeUnfiltered, bool writeTrackData)
+DataProcessorSpec getTPCResidualWriterSpec(bool writeTrackData)
 {
-
+  bool writeUnfiltered = SpacePointsCalibConfParam::Instance().writeUnfiltered;
   return MakeRootTreeWriterSpec("tpc-residuals-writer",
                                 "o2residuals_tpc.root",
                                 "residualsTPC",

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCResidualWriterSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCResidualWriterSpec.cxx
@@ -38,6 +38,7 @@ DataProcessorSpec getTPCResidualWriterSpec(bool writeTrackData)
                                 BranchDefinition<std::vector<TrackData>>{InputSpec{"tracksUnfiltered", "GLO", "TPCINT_TRK", 0}, "tracksUnfiltered", ((writeUnfiltered && writeTrackData) ? 1 : 0)},
                                 BranchDefinition<std::vector<TPCClusterResiduals>>{InputSpec{"residualsUnfiltered", "GLO", "TPCINT_RES", 0}, "residualsUnfiltered", (writeUnfiltered ? 1 : 0)},
                                 BranchDefinition<std::vector<UnbinnedResid>>{InputSpec{"residuals", "GLO", "UNBINNEDRES"}, "residuals"},
+                                BranchDefinition<std::vector<TrackDataCompact>>{InputSpec{"trackRefs", "GLO", "TRKREFS"}, "trackRefs"},
                                 BranchDefinition<std::vector<TrackData>>{InputSpec{"tracks", "GLO", "TRKDATA"}, "tracks", (writeTrackData ? 1 : 0)})();
 }
 

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCUnbinnedResidualReaderSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCUnbinnedResidualReaderSpec.cxx
@@ -43,6 +43,7 @@ void TPCUnbinnedResidualReader::connectTree()
   mTreeIn.reset((TTree*)mFileIn->Get(mInTreeName.c_str()));
   assert(mTreeIn);
   mTreeIn->SetBranchAddress("residuals", &mUnbinnedResidPtr);
+  mTreeIn->SetBranchAddress("trackRefs", &mTrackDataCompactPtr);
   if (mTrackInput) {
     mTreeIn->SetBranchAddress("tracks", &mTrackDataPtr);
   }
@@ -56,6 +57,7 @@ void TPCUnbinnedResidualReader::run(ProcessingContext& pc)
   mTreeIn->GetEntry(currEntry);
   LOG(info) << "Pushing " << mUnbinnedResid.size() << " unbinned residuals at entry " << currEntry;
   pc.outputs().snapshot(Output{"GLO", "UNBINNEDRES", 0, Lifetime::Timeframe}, mUnbinnedResid);
+  pc.outputs().snapshot(Output{"GLO", "TRKREFS", 0, Lifetime::Timeframe}, mTrackDataCompact);
   if (mTrackInput) {
     LOG(info) << "Pushing " << mTrackData.size() << " reference tracks for these residuals";
     pc.outputs().snapshot(Output{"GLO", "TRKDATA", 0, Lifetime::Timeframe}, mTrackData);
@@ -71,6 +73,7 @@ DataProcessorSpec getUnbinnedTPCResidualsReaderSpec(bool trkInput)
 {
   std::vector<OutputSpec> outputs;
   outputs.emplace_back("GLO", "UNBINNEDRES", 0, Lifetime::Timeframe);
+  outputs.emplace_back("GLO", "TRKREFS", 0, Lifetime::Timeframe);
   if (trkInput) {
     outputs.emplace_back("GLO", "TRKDATA", 0, Lifetime::Timeframe);
   }

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/tpc-interpolation-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/tpc-interpolation-workflow.cxx
@@ -39,7 +39,6 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"disable-mc", VariantType::Bool, false, {"disable MC propagation even if available"}},
     {"enable-itsonly", VariantType::Bool, false, {"process tracks without outer point (ITS-TPC only)"}},
     {"tracking-sources", VariantType::String, std::string{GID::ALL}, {"comma-separated list of sources to use for tracking"}},
-    {"write-unfiltered", VariantType::Bool, false, {"write unfiltered residuals"}},
     {"send-track-data", VariantType::Bool, false, {"Send also the track information to the aggregator"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
@@ -74,14 +73,13 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   auto useMC = !configcontext.options().get<bool>("disable-mc");
   useMC = false; // force disabling MC as long as it is not implemented
   auto processITSTPConly = configcontext.options().get<bool>("enable-itsonly");
-  auto writeUnfilteredResiduals = configcontext.options().get<bool>("write-unfiltered");
   auto sendTrackData = configcontext.options().get<bool>("send-track-data");
   GID::mask_t src = allowedSources & GID::getSourcesMask(configcontext.options().get<std::string>("tracking-sources"));
   LOG(info) << "Data sources: " << GID::getSourcesNames(src);
 
-  specs.emplace_back(o2::tpc::getTPCInterpolationSpec(src, useMC, processITSTPConly, writeUnfilteredResiduals, sendTrackData));
+  specs.emplace_back(o2::tpc::getTPCInterpolationSpec(src, useMC, processITSTPConly, sendTrackData));
   if (!configcontext.options().get<bool>("disable-root-output")) {
-    specs.emplace_back(o2::tpc::getTPCResidualWriterSpec(writeUnfilteredResiduals, sendTrackData));
+    specs.emplace_back(o2::tpc::getTPCResidualWriterSpec(sendTrackData));
   }
 
   o2::globaltracking::InputHelper::addInputSpecs(configcontext, specs, src, src, src, useMC);

--- a/Detectors/ITSMFT/ITS/calibration/include/ITSCalibration/NoiseSlotCalibrator.h
+++ b/Detectors/ITSMFT/ITS/calibration/include/ITSCalibration/NoiseSlotCalibrator.h
@@ -35,7 +35,7 @@ class ROFRecord;
 namespace its
 {
 
-class NoiseSlotCalibrator : public o2::calibration::TimeSlotCalibration<o2::itsmft::CompClusterExt, o2::itsmft::NoiseMap>
+class NoiseSlotCalibrator : public o2::calibration::TimeSlotCalibration<o2::itsmft::NoiseMap>
 {
   using Slot = calibration::TimeSlot<o2::itsmft::NoiseMap>;
 

--- a/Detectors/ITSMFT/ITS/calibration/src/ITSCalibrationLinkDef.h
+++ b/Detectors/ITSMFT/ITS/calibration/src/ITSCalibrationLinkDef.h
@@ -16,7 +16,7 @@
 #pragma link off all functions;
 
 #pragma link C++ class o2::calibration::TimeSlot < o2::itsmft::CompClusterExt > +;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::itsmft::CompClusterExt, o2::itsmft::NoiseMap > +;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::itsmft::NoiseMap> + ;
 #pragma link C++ class o2::its::NoiseCalibrator + ;
 
 #endif

--- a/Detectors/ITSMFT/ITS/calibration/src/NoiseSlotCalibrator.cxx
+++ b/Detectors/ITSMFT/ITS/calibration/src/NoiseSlotCalibrator.cxx
@@ -108,7 +108,7 @@ bool NoiseSlotCalibrator::processTimeFrame(gsl::span<const o2::itsmft::CompClust
 bool NoiseSlotCalibrator::process(const gsl::span<const o2::itsmft::CompClusterExt> data)
 {
   LOG(warning) << "Only 1-pix noise calibraton is possible !";
-  return calibration::TimeSlotCalibration<o2::itsmft::CompClusterExt, o2::itsmft::NoiseMap>::process(data);
+  return calibration::TimeSlotCalibration<o2::itsmft::NoiseMap>::process(data);
 }
 
 // Functions required by the calibration framework

--- a/Detectors/ITSMFT/MFT/calibration/include/MFTCalibration/NoiseSlotCalibrator.h
+++ b/Detectors/ITSMFT/MFT/calibration/include/MFTCalibration/NoiseSlotCalibrator.h
@@ -35,7 +35,7 @@ class ROFRecord;
 namespace mft
 {
 
-class NoiseSlotCalibrator : public o2::calibration::TimeSlotCalibration<o2::itsmft::CompClusterExt, o2::itsmft::NoiseMap>
+class NoiseSlotCalibrator : public o2::calibration::TimeSlotCalibration<o2::itsmft::NoiseMap>
 {
   using Slot = calibration::TimeSlot<o2::itsmft::NoiseMap>;
 

--- a/Detectors/MUON/MCH/Calibration/include/MCHCalibration/BadChannelCalibrator.h
+++ b/Detectors/MUON/MCH/Calibration/include/MCHCalibration/BadChannelCalibrator.h
@@ -37,8 +37,7 @@ namespace o2::mch::calibration
  * considered bad/noisy and they are stored into a
  * "bad channels" list that is sent to the CDDB populator(s).
  */
-class BadChannelCalibrator final : public o2::calibration::TimeSlotCalibration<o2::mch::calibration::PedestalDigit,
-                                                                               o2::mch::calibration::PedestalData>
+class BadChannelCalibrator final : public o2::calibration::TimeSlotCalibration<o2::mch::calibration::PedestalData>
 {
   using TFType = o2::calibration::TFType;
   using Slot = o2::calibration::TimeSlot<o2::mch::calibration::PedestalData>;

--- a/Detectors/MUON/MCH/Calibration/src/MCHCalibrationLinkDef.h
+++ b/Detectors/MUON/MCH/Calibration/src/MCHCalibrationLinkDef.h
@@ -22,6 +22,6 @@
 #pragma link C++ class o2::mch::calibration::PedestalData + ;
 #pragma link C++ class o2::mch::calibration::BadChannelCalibrator + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::mch::calibration::PedestalData> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::mch::calibration::PedestalDigit, o2::mch::calibration::PedestalData> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::mch::calibration::PedestalData> + ;
 
 #endif

--- a/Detectors/MUON/MID/Calibration/include/MIDCalibration/ChannelCalibrator.h
+++ b/Detectors/MUON/MID/Calibration/include/MIDCalibration/ChannelCalibrator.h
@@ -56,7 +56,7 @@ class CalibData
   ClassDefNV(CalibData, 1);
 };
 
-class ChannelCalibrator final : public o2::calibration::TimeSlotCalibration<ColumnData, CalibData>
+class ChannelCalibrator final : public o2::calibration::TimeSlotCalibration<CalibData>
 {
   using TFType = o2::calibration::TFType;
   using Slot = o2::calibration::TimeSlot<CalibData>;

--- a/Detectors/MUON/MID/Calibration/src/MIDCalibrationLinkDef.h
+++ b/Detectors/MUON/MID/Calibration/src/MIDCalibrationLinkDef.h
@@ -19,6 +19,6 @@
 #pragma link C++ class o2::mid::CalibData + ;
 #pragma link C++ class o2::mid::ChannelCalibrator + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::mid::CalibData> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::mid::ColumnData, o2::mid::CalibData> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::mid::CalibData> + ;
 
 #endif

--- a/Detectors/PHOS/calib/include/PHOSCalibWorkflow/PHOSEnergyCalibrator.h
+++ b/Detectors/PHOS/calib/include/PHOSCalibWorkflow/PHOSEnergyCalibrator.h
@@ -112,7 +112,7 @@ class PHOSEnergySlot
   std::vector<uint32_t> mDigits; /// list of calibration digits
 };
 
-class PHOSEnergyCalibrator final : public o2::calibration::TimeSlotCalibration<o2::phos::Cluster, o2::phos::PHOSEnergySlot>
+class PHOSEnergyCalibrator final : public o2::calibration::TimeSlotCalibration<o2::phos::PHOSEnergySlot>
 {
   using Slot = o2::calibration::TimeSlot<o2::phos::PHOSEnergySlot>;
 

--- a/Detectors/PHOS/calib/include/PHOSCalibWorkflow/PHOSL1phaseCalibrator.h
+++ b/Detectors/PHOS/calib/include/PHOSCalibWorkflow/PHOSL1phaseCalibrator.h
@@ -65,7 +65,7 @@ class PHOSL1phaseSlot
 };
 
 //==========================================================================================
-class PHOSL1phaseCalibrator final : public o2::calibration::TimeSlotCalibration<o2::phos::Cell, o2::phos::PHOSL1phaseSlot>
+class PHOSL1phaseCalibrator final : public o2::calibration::TimeSlotCalibration<o2::phos::PHOSL1phaseSlot>
 {
   using Slot = o2::calibration::TimeSlot<o2::phos::PHOSL1phaseSlot>;
 

--- a/Detectors/PHOS/calib/include/PHOSCalibWorkflow/PHOSRunbyrunCalibrator.h
+++ b/Detectors/PHOS/calib/include/PHOSCalibWorkflow/PHOSRunbyrunCalibrator.h
@@ -69,7 +69,7 @@ class PHOSRunbyrunSlot
 };
 
 //==========================================================================================
-class PHOSRunbyrunCalibrator final : public o2::calibration::TimeSlotCalibration<o2::phos::Cluster, o2::phos::PHOSRunbyrunSlot>
+class PHOSRunbyrunCalibrator final : public o2::calibration::TimeSlotCalibration<o2::phos::PHOSRunbyrunSlot>
 {
   using Slot = o2::calibration::TimeSlot<o2::phos::PHOSRunbyrunSlot>;
 

--- a/Detectors/PHOS/calib/include/PHOSCalibWorkflow/PHOSTurnonCalibrator.h
+++ b/Detectors/PHOS/calib/include/PHOSCalibWorkflow/PHOSTurnonCalibrator.h
@@ -67,7 +67,7 @@ class PHOSTurnonSlot
 };
 
 //==========================================================================================
-class PHOSTurnonCalibrator final : public o2::calibration::TimeSlotCalibration<o2::phos::Cluster, o2::phos::PHOSTurnonSlot>
+class PHOSTurnonCalibrator final : public o2::calibration::TimeSlotCalibration<o2::phos::PHOSTurnonSlot>
 {
   using Slot = o2::calibration::TimeSlot<o2::phos::PHOSTurnonSlot>;
 

--- a/Detectors/PHOS/calib/src/PHOSCalibWorkflowLinkDef.h
+++ b/Detectors/PHOS/calib/src/PHOSCalibWorkflowLinkDef.h
@@ -20,23 +20,23 @@
 #pragma link C++ class o2::phos::PHOSBadMapCalibDevice + ;
 #pragma link C++ class o2::phos::ETCalibHistos + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::phos::PHOSEnergySlot> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::phos::Cluster, o2::phos::PHOSEnergySlot> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::phos::PHOSEnergySlot> + ;
 #pragma link C++ class o2::phos::TurnOnHistos + ;
 #pragma link C++ class o2::phos::PHOSTurnonSlot + ;
 #pragma link C++ class o2::phos::PHOSTurnonCalibrator + ;
 #pragma link C++ class o2::phos::PHOSTurnonCalibDevice + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::phos::PHOSTurnonSlot> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::phos::Cluster, o2::phos::PHOSTurnonSlot> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::phos::PHOSTurnonSlot> + ;
 #pragma link C++ class o2::phos::PHOSRunbyrunSlot + ;
 #pragma link C++ class o2::phos::PHOSRunbyrunCalibrator + ;
 #pragma link C++ class o2::phos::PHOSRunbyrunCalibDevice + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::phos::PHOSRunbyrunSlot> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::phos::Cluster, o2::phos::PHOSRunbyrunSlot> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::phos::PHOSRunbyrunSlot> + ;
 #pragma link C++ class o2::phos::PHOSL1phaseSlot + ;
 #pragma link C++ class o2::phos::PHOSL1phaseCalibrator + ;
 #pragma link C++ class o2::phos::PHOSL1phaseCalibDevice + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::phos::PHOSL1phaseSlot> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::phos::Cell, o2::phos::PHOSL1phaseSlot> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::phos::PHOSL1phaseSlot> + ;
 #pragma link C++ class vector < int> + ;
 
 #endif

--- a/Detectors/TOF/calibration/include/TOFCalibration/LHCClockCalibrator.h
+++ b/Detectors/TOF/calibration/include/TOFCalibration/LHCClockCalibrator.h
@@ -69,7 +69,7 @@ struct LHCClockDataHisto {
   ClassDefNV(LHCClockDataHisto, 1);
 };
 
-class LHCClockCalibrator final : public o2::calibration::TimeSlotCalibration<o2::dataformats::CalibInfoTOF, o2::tof::LHCClockDataHisto>
+class LHCClockCalibrator final : public o2::calibration::TimeSlotCalibration<o2::tof::LHCClockDataHisto>
 {
   using TFType = o2::calibration::TFType;
   using Slot = o2::calibration::TimeSlot<o2::tof::LHCClockDataHisto>;

--- a/Detectors/TOF/calibration/include/TOFCalibration/TOFCalibCollector.h
+++ b/Detectors/TOF/calibration/include/TOFCalibration/TOFCalibCollector.h
@@ -65,7 +65,7 @@ class TOFCalibInfoSlot
   ClassDefNV(TOFCalibInfoSlot, 1);
 };
 
-class TOFCalibCollector final : public o2::calibration::TimeSlotCalibration<o2::dataformats::CalibInfoTOF, o2::tof::TOFCalibInfoSlot>
+class TOFCalibCollector final : public o2::calibration::TimeSlotCalibration<o2::tof::TOFCalibInfoSlot>
 {
   using TFType = o2::calibration::TFType;
   using Slot = o2::calibration::TimeSlot<o2::tof::TOFCalibInfoSlot>;

--- a/Detectors/TOF/calibration/include/TOFCalibration/TOFChannelCalibrator.h
+++ b/Detectors/TOF/calibration/include/TOFCalibration/TOFChannelCalibrator.h
@@ -139,7 +139,7 @@ class TOFChannelData
 };
 
 template <class T>
-class TOFChannelCalibrator final : public o2::calibration::TimeSlotCalibration<T, o2::tof::TOFChannelData>
+class TOFChannelCalibrator final : public o2::calibration::TimeSlotCalibration<o2::tof::TOFChannelData>
 {
   using TFType = o2::calibration::TFType;
   using Slot = o2::calibration::TimeSlot<o2::tof::TOFChannelData>;
@@ -155,7 +155,7 @@ class TOFChannelCalibrator final : public o2::calibration::TimeSlotCalibration<T
 #endif
 
  protected:
-  std::deque<o2::calibration::TimeSlot<o2::tof::TOFChannelData>>& getSlots() { return o2::calibration::TimeSlotCalibration<T, o2::tof::TOFChannelData>::getSlots(); }
+  std::deque<o2::calibration::TimeSlot<o2::tof::TOFChannelData>>& getSlots() { return o2::calibration::TimeSlotCalibration<o2::tof::TOFChannelData>::getSlots(); }
 
  public:
   void doPerStrip(bool val = true) { mPerStrip = val; }

--- a/Detectors/TOF/calibration/include/TOFCalibration/TOFDiagnosticCalibrator.h
+++ b/Detectors/TOF/calibration/include/TOFCalibration/TOFDiagnosticCalibrator.h
@@ -22,7 +22,7 @@ namespace o2
 namespace tof
 {
 
-class TOFDiagnosticCalibrator final : public o2::calibration::TimeSlotCalibration<o2::tof::Diagnostic, o2::tof::Diagnostic>
+class TOFDiagnosticCalibrator final : public o2::calibration::TimeSlotCalibration<o2::tof::Diagnostic>
 {
   using TFType = o2::calibration::TFType;
   using Slot = o2::calibration::TimeSlot<o2::tof::Diagnostic>;

--- a/Detectors/TOF/calibration/src/TOFCalibrationLinkDef.h
+++ b/Detectors/TOF/calibration/src/TOFCalibrationLinkDef.h
@@ -20,21 +20,21 @@
 
 #pragma link C++ class o2::tof::LHCClockDataHisto + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::tof::LHCClockDataHisto> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::dataformats::CalibInfoTOF, o2::tof::LHCClockDataHisto> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tof::LHCClockDataHisto> + ;
 #pragma link C++ class o2::tof::LHCClockCalibrator + ;
 
 #pragma link C++ class o2::tof::TOFChannelData + ;
 #pragma link C++ class o2::tof::TOFChannelCalibrator < o2::dataformats::CalibInfoTOF> + ;
 #pragma link C++ class o2::tof::TOFChannelCalibrator < o2::tof::CalibInfoCluster> + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::tof::TOFChannelData> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::dataformats::CalibInfoTOF, o2::tof::TOFChannelData> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tof::CalibInfoCluster, o2::tof::TOFChannelData> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tof::TOFChannelData> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tof::TOFChannelData> + ;
 
 #pragma link C++ class o2::tof::TOFCalibInfoSlot + ;
 #pragma link C++ class o2::tof::TOFCalibCollector + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::tof::TOFCalibInfoSlot> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::dataformats::CalibInfoTOF, o2::tof::TOFCalibInfoSlot> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tof::CalibInfoCluster, o2::tof::TOFCalibInfoSlot> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tof::TOFCalibInfoSlot> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tof::TOFCalibInfoSlot> + ;
 
 #pragma link C++ class std::bitset < o2::tof::Geo::NCHANNELS> + ;
 #pragma link C++ struct std::pair < uint64_t, double> + ;
@@ -48,7 +48,7 @@
 #pragma link C++ struct TOFFEElightReader + ;
 
 #pragma link C++ class o2::calibration::TimeSlot < o2::tof::Diagnostic> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tof::Diagnostic, o2::tof::Diagnostic> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tof::Diagnostic> + ;
 #pragma link C++ class o2::tof::TOFDiagnosticCalibrator + ;
 
 #endif

--- a/Detectors/TPC/calibration/SpacePoints/CMakeLists.txt
+++ b/Detectors/TPC/calibration/SpacePoints/CMakeLists.txt
@@ -14,6 +14,7 @@ o2_add_library(SpacePoints
                        src/TrackResiduals.cxx
                        src/TrackInterpolation.cxx
                        src/ResidualAggregator.cxx
+                       src/SpacePointsCalibConfParam.cxx
                PUBLIC_LINK_LIBRARIES O2::DataFormatsTPC
                                      O2::CommonUtils
                                      O2::TPCBase
@@ -31,4 +32,5 @@ o2_target_root_dictionary(SpacePoints
                           HEADERS include/SpacePoints/TrackResiduals.h
                                   include/SpacePoints/TrackInterpolation.h
                                   include/SpacePoints/ResidualAggregator.h
+                                  include/SpacePoints/SpacePointsCalibConfParam.h
                           LINKDEF src/SpacePointCalibLinkDef.h)

--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/ResidualAggregator.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/ResidualAggregator.h
@@ -37,6 +37,8 @@ namespace tpc
 
 struct ResidualsContainer {
 
+  using TFType = o2::calibration::TFType;
+
   ResidualsContainer() = default;
   ResidualsContainer(ResidualsContainer&& rhs);
   ResidualsContainer(const ResidualsContainer&); // no copying allowed, this will yield an error message
@@ -80,10 +82,12 @@ struct ResidualsContainer {
   bool writeUnbinnedResiduals{false};
   bool writeTrackData{false};
   int autosaveInterval{0};
+  TFType firstSeenTF{o2::calibration::INFINITE_TF};
+  TFType lastSeenTF{0};
 
   uint64_t nResidualsTotal{0};
 
-  ClassDefNV(ResidualsContainer, 3);
+  ClassDefNV(ResidualsContainer, 4);
 };
 
 class ResidualAggregator final : public o2::calibration::TimeSlotCalibration<ResidualsContainer>

--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/ResidualAggregator.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/ResidualAggregator.h
@@ -86,7 +86,7 @@ struct ResidualsContainer {
   ClassDefNV(ResidualsContainer, 3);
 };
 
-class ResidualAggregator final : public o2::calibration::TimeSlotCalibration<UnbinnedResid, ResidualsContainer>
+class ResidualAggregator final : public o2::calibration::TimeSlotCalibration<ResidualsContainer>
 {
   using Slot = o2::calibration::TimeSlot<ResidualsContainer>;
 

--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/ResidualAggregator.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/ResidualAggregator.h
@@ -49,7 +49,7 @@ struct ResidualsContainer {
   void fillStatisticsBranches();
   uint64_t getNEntries() const { return nResidualsTotal; }
 
-  void fill(const o2::dataformats::TFIDInfo& ti, const std::pair<gsl::span<const o2::tpc::TrackData>, gsl::span<const UnbinnedResid>> data, const o2::ctp::LumiInfo* lumiInput);
+  void fill(const o2::dataformats::TFIDInfo& ti, const gsl::span<const UnbinnedResid> resid, const gsl::span<const o2::tpc::TrackDataCompact> trkRefsIn, const gsl::span<const o2::tpc::TrackData>* trkDataIn, const o2::ctp::LumiInfo* lumiInput);
   void merge(ResidualsContainer* prev);
   void print();
   void writeToFile(bool closeFileAfterwards);
@@ -63,8 +63,9 @@ struct ResidualsContainer {
   std::vector<uint32_t> tfOrbits, *tfOrbitsPtr{&tfOrbits};                   ///< first TF orbit
   std::vector<uint32_t> sumOfResiduals, *sumOfResidualsPtr{&sumOfResiduals}; ///< sum of residuals for each TF
   std::vector<o2::ctp::LumiInfo> lumi, *lumiPtr{&lumi};                      ///< luminosity information from CTP per TF
-  std::vector<UnbinnedResid> unbinnedRes, *unbinnedResPtr{&unbinnedRes};     // unbinned residuals
-  std::vector<TrackData> trkData, *trkDataPtr{&trkData};                                 // track data and cluster ranges
+  std::vector<UnbinnedResid> unbinnedRes, *unbinnedResPtr{&unbinnedRes};     ///< unbinned residuals
+  std::vector<TrackData> trkData, *trkDataPtr{&trkData};                     ///< track data and cluster ranges
+  std::vector<TrackDataCompact> trackInfo, *trackInfoPtr{&trackInfo};        ///< allows to obtain track type for each binned residual downstream
 
   std::string fileName{"o2tpc_residuals"};
   std::string treeNameResiduals{"resid"};
@@ -77,15 +78,17 @@ struct ResidualsContainer {
   std::unique_ptr<TTree> treeOutStats{nullptr};
   std::unique_ptr<TTree> treeOutRecords{nullptr};
 
-  bool writeToRootFile{true};
-  bool writeBinnedResid{false};
-  bool writeUnbinnedResiduals{false};
-  bool writeTrackData{false};
-  int autosaveInterval{0};
-  TFType firstSeenTF{o2::calibration::INFINITE_TF};
-  TFType lastSeenTF{0};
+  // settings
+  bool writeToRootFile{true};         ///< set to false to avoid that any output file is produced
+  bool writeBinnedResid{false};       ///< flag, whether binned residuals should be written out
+  bool writeUnbinnedResiduals{false}; ///< flag, whether unbinned residuals should be written out
+  bool writeTrackData{false};         ///< flag, whether full seeding track information should be written out
+  int autosaveInterval{0};            ///< if > 0, then the output written to file for every n-th TF
 
-  uint64_t nResidualsTotal{0};
+  // additional info
+  TFType firstSeenTF{o2::calibration::INFINITE_TF}; ///< the first TF which was added to this container
+  TFType lastSeenTF{0};                             ///< the last TF which was added to this container
+  uint64_t nResidualsTotal{0};                      ///< the total number of residuals for this container
 
   ClassDefNV(ResidualsContainer, 4);
 };

--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/SpacePointsCalibConfParam.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/SpacePointsCalibConfParam.h
@@ -1,0 +1,75 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author ole.schmidt@cern.ch
+
+#ifndef ALICEO2_SCDCALIB_PARAMS_H
+#define ALICEO2_SCDCALIB_PARAMS_H
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "CommonUtils/ConfigurableParamHelper.h"
+
+namespace o2
+{
+namespace tpc
+{
+
+// These are configurable params for Primary Vertexer
+struct SpacePointsCalibConfParam : public o2::conf::ConfigurableParamHelper<SpacePointsCalibConfParam> {
+
+  // define track cuts for track interpolation
+  int minTPCNCls = 70;             ///< min number of TPC clusters
+  int minTPCNClsNoOuterPoint = 50; ///< min number of TPC clusters if no hit in TRD or TOF exists
+  float maxTPCChi2 = 4.f;          ///< cut on TPC reduced chi2
+  int minITSNCls = 4;              ///< min number of ITS clusters
+  int minITSNClsNoOuterPoint = 6;  ///< min number of ITS clusters if no hit in TRD or TOF exists
+  float maxITSChi2 = 20.f;         ///< cut on ITS reduced chi2
+
+  // other settings for track interpolation
+  float sigYZ2TOF{.75f}; ///< for now assume cluster error for TOF equal for all clusters in both Y and Z
+  float maxSnp{.85f};    ///< max snp when propagating tracks
+  float maxStep{2.f};    ///< maximum step for propagation
+
+  // parameters for outlier rejection
+  bool writeUnfiltered{false};           ///< if set, all residuals and track parameters will be aggregated and dumped additionally without outlier rejection
+  int nMALong{15};                       ///< number of points to be used for moving average (long range)
+  int nMAShort{3};                       ///< number of points to be used for estimation of distance from local line (short range)
+  float maxRejFrac{.15f};                ///< if the fraction of rejected clusters of a track is higher, the full track is invalidated
+  float maxRMSLong{.8f};                 ///< maximum variance of the cluster residuals wrt moving avarage for a track to be considered
+  int minNCl = 30;                       ///< min number of clusters in a track to be used for calibration
+  float maxQ2Pt = 3.f;                   ///< max fitted q/pt for a track to be used for calibration
+  float maxDevHelixY = .3f;              ///< max deviation in Y for clusters wrt helix fit
+  float maxDevHelixZ = .3f;              ///< max deviation in Z for clusters wrt helix fit
+  int minNumberOfAcceptedResiduals = 30; ///< min number of accepted residuals for
+  float maxStdDevMA = 25.f;              ///< max cluster std. deviation (Y^2 + Z^2) wrt moving average to accept
+
+  // settings for voxel residuals extraction
+  int minEntriesPerVoxel = 15;         ///< minimum number of points in voxel for processing
+  float LTMCut = .75f;                 ///< fraction op points to keep when trimming input data
+  float minFracLTM = .5f;              ///< minimum fraction of points to keep when trimming data to fit expected sigma
+  float minValidVoxFracDrift = .5f;    ///< if more than this fraction of bins are bad for one pad row the whole pad row is declared bad
+  int minGoodXBinsToCover = 3;         ///< minimum number of consecutive good bins, otherwise bins are declared bad
+  int maxBadXBinsToCover = 4;          ///< a lower number of consecutive bad X bins will not be declared bad
+  float maxFracBadRowsPerSector = .4f; ///< maximum fraction of bad rows before whole sector is masked
+  float maxFitErrY2 = 1.f;             ///< maximum fit error for Y2
+  float maxFitErrX2 = 9.f;             ///< maximum fit error for X2
+  float maxFitCorrXY = .95f;           ///< maximum fit correlation for x and y
+  float maxSigY = 1.1f;                ///< maximum sigma for y of the voxel
+  float maxSigZ = .7f;                 ///< maximum sigma for z of the voxel
+  float maxGaussStdDev = 5.f;          ///< maximum number of sigmas to be considered for gaussian kernel smoothing
+
+  O2ParamDef(SpacePointsCalibConfParam, "scdcalib");
+};
+
+} // namespace tpc
+} // end namespace o2
+
+#endif // ALICEO2_SCDCALIB_PARAMS_H

--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/SpacePointsCalibConfParam.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/SpacePointsCalibConfParam.h
@@ -25,6 +25,8 @@ namespace tpc
 // These are configurable params for Primary Vertexer
 struct SpacePointsCalibConfParam : public o2::conf::ConfigurableParamHelper<SpacePointsCalibConfParam> {
 
+  int maxTracksPerCalibSlot = 3'500'000; ///< the number of tracks which is required to obtain an average correction map
+
   // define track cuts for track interpolation
   int minTPCNCls = 70;             ///< min number of TPC clusters
   int minTPCNClsNoOuterPoint = 50; ///< min number of TPC clusters if no hit in TRD or TOF exists

--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/SpacePointsCalibParam.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/SpacePointsCalibParam.h
@@ -61,25 +61,6 @@ static constexpr float MaxTgSlp = 1.f;  ///< max value for phi and lambda angles
 // miscellaneous
 static constexpr float sEps = 1e-6f; ///< small number for float comparisons
 
-// define track cuts for track interpolation
-static constexpr int MinTPCNCls = 70;             ///< min number of TPC clusters
-static constexpr int MinTPCNClsNoOuterPoint = 50; ///< min number of TPC clusters if no hit in TRD or TOF exists
-static constexpr float MaxTPCChi2 = 4.f;          ///< cut on TPC reduced chi2
-static constexpr int MinITSNCls = 4;              ///< min number of ITS clusters
-static constexpr int MinITSNClsNoOuterPoint = 6;  ///< min number of ITS clusters if no hit in TRD or TOF exists
-static constexpr float MaxITSChi2 = 4.f;          ///< cut on ITS reduced chi2
-
-// parameters for conversion of Run 2 residual trees
-static constexpr float InvalidR = 10.f;                 ///< clusters with a radius smaller than this are neglected
-static constexpr float InvalidRes = -900.f;             ///< clusters with a residual smaller than this are neglected
-static constexpr int MinNCl = 30;                       ///< min number of clusters in a track to be used for calibration
-static constexpr float MaxQ2Pt = 3.f;                   ///< max fitted q/pt for a track to be used for calibration
-static constexpr float Bz = -5.0077936f;                ///< hard-coded B-field for the moment to compare with results from AliRoot
-static constexpr float MaxDevHelixY = .3f;              ///< max deviation in Y for clusters wrt helix fit
-static constexpr float MaxDevHelixZ = .3f;              ///< max deviation in Z for clusters wrt helix fit
-static constexpr int MinNumberOfAcceptedResiduals = 30; ///< min number of accepted residuals for
-static constexpr float mMaxStdDevMA = 25.f;             ///< max cluster std. deviation (Y^2 + Z^2) wrt moving average to accept
-
 } // namespace param
 } // namespace tpc
 } // namespace o2

--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackInterpolation.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackInterpolation.h
@@ -33,6 +33,7 @@
 #include "DataFormatsTRD/Tracklet64.h"
 #include "DataFormatsTRD/CalibratedTracklet.h"
 #include "SpacePoints/SpacePointsCalibParam.h"
+#include "SpacePoints/SpacePointsCalibConfParam.h"
 #include "TPCReconstruction/TPCFastTransformHelperO2.h"
 #include "DetectorsBase/Propagator.h"
 #include "DataFormatsGlobalTracking/RecoContainer.h"
@@ -195,22 +196,15 @@ class TrackInterpolation
   /// First a circular fit in the azimuthal plane is performed and subsequently a linear fit in the transversal plane
   bool compareToHelix(const TrackData& trk, TrackParams& params, const std::vector<TPCClusterResiduals>& clsRes) const;
 
-  /// For a given set of points, calculate the differences from each point to the fitted lines from all other points in their neighbourhoods (+- mNMAShort points)
+  /// For a given set of points, calculate the differences from each point to the fitted lines from all other points in their neighbourhoods (+- nMAShort points)
   void diffToLocLine(const int np, int idxOffset, const std::array<float, param::NPadRows>& x, const std::array<float, param::NPadRows>& y, std::array<float, param::NPadRows>& diffY) const;
 
-  /// For a given set of points, calculate their deviation from the moving average (build from the neighbourhood +- mNMALong points)
+  /// For a given set of points, calculate their deviation from the moving average (build from the neighbourhood +- nMALong points)
   void diffToMA(const int np, const std::array<float, param::NPadRows>& y, std::array<float, param::NPadRows>& diffMA) const;
 
   // -------------------------------------- settings --------------------------------------------------
   void setTPCVDrift(const o2::tpc::VDriftCorrFact& v);
 
-  /// Enables storage and sending of residuals and track parameters without outlier rejection
-  void setWriteUnfiltered() { mWriteUnfiltered = true; }
-
-  /// Sets the maximum phi angle at which track extrapolation is aborted
-  void setMaxSnp(float snp) { mMaxSnp = snp; }
-  /// Sets the maximum step length for track extrapolation
-  void setMaxStep(float step) { mMaxStep = step; }
   /// Sets the flag if material correction should be applied when extrapolating the tracks
   void setMatCorr(MatCorrType matCorr) { mMatCorr = matCorr; }
 
@@ -223,18 +217,11 @@ class TrackInterpolation
  private:
   static constexpr float sFloatEps{1.e-7f}; ///< float epsilon for robust linear fitting
   // parameters + settings
-  float mTPCTimeBinMUS{.2f}; ///< TPC time bin duration in us
-  float mSigYZ2TOF{.75f};    ///< for now assume cluster error for TOF equal for all clusters in both Y and Z
-  float mMaxSnp{.85f};          ///< max snp when propagating ITS tracks
-  float mMaxStep{2.f};          ///< maximum step for propagation
+  const SpacePointsCalibConfParam* mParams = nullptr;
+  float mTPCTimeBinMUS{.2f};    ///< TPC time bin duration in us
   float mTPCVDriftRef = -1.;    ///< TPC nominal drift speed in cm/microseconds
   float mTPCVDrift = -1.;       ///< TPC drift speed in cm/microseconds
   MatCorrType mMatCorr{MatCorrType::USEMatCorrNONE}; ///< if material correction should be done
-  int mNMALong{15};                                  ///< number of points to be used for moving average (long range)
-  int mNMAShort{3};                                  ///< number of points to be used for estimation of distance from local line (short range)
-  float mMaxRejFrac{.15f};                           ///< if the fraction of rejected clusters of a track is higher, the full track is invalidated
-  float mMaxRMSLong{.8f};                            ///< maximum variance of the cluster residuals wrt moving avarage for a track to be considered
-  bool mWriteUnfiltered{false};                      ///< if set, all residuals and track parameters will be aggregated and dumped without outlier rejection
 
   // input
   const o2::globaltracking::RecoContainer* mRecoCont = nullptr;                            ///< input reco container

--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackInterpolation.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackInterpolation.h
@@ -218,6 +218,9 @@ class TrackInterpolation
   /// Sets the flag if material correction should be applied when extrapolating the tracks
   void setMatCorr(MatCorrType matCorr) { mMatCorr = matCorr; }
 
+  /// Sets the maximum number of tracks to be processed (successfully) per TF
+  void setMaxTracksPerTF(int n) { mMaxTracksPerTF = n; }
+
   // --------------------------------- output ---------------------------------------------
   std::vector<UnbinnedResid>& getClusterResiduals() { return mClRes; }
   std::vector<TrackDataCompact>& getTrackDataCompact() { return mTrackDataCompact; }
@@ -233,6 +236,7 @@ class TrackInterpolation
   float mTPCVDriftRef = -1.;    ///< TPC nominal drift speed in cm/microseconds
   float mTPCVDrift = -1.;       ///< TPC drift speed in cm/microseconds
   MatCorrType mMatCorr{MatCorrType::USEMatCorrNONE}; ///< if material correction should be done
+  int mMaxTracksPerTF{-1};                           ///< max number of tracks to be processed per TF (-1 means there is no limit)
 
   // input
   const o2::globaltracking::RecoContainer* mRecoCont = nullptr;                            ///< input reco container

--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackInterpolation.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackInterpolation.h
@@ -87,6 +87,16 @@ struct UnbinnedResid {
   ClassDefNV(UnbinnedResid, 1);
 };
 
+/// Structure for the information required to associate each residual with a given track type (ITS-TPC-TRD-TOF, etc)
+struct TrackDataCompact {
+  TrackDataCompact() = default;
+  TrackDataCompact(uint32_t idx, uint8_t nRes, uint8_t source) : idxFirstResidual(idx), nResiduals(nRes), sourceId(source) {}
+  uint32_t idxFirstResidual; ///< the index of the first residual from this track
+  uint8_t nResiduals;        ///< total number of residuals associated to this track
+  uint8_t sourceId;          ///< source ID obtained from the global track ID
+  ClassDefNV(TrackDataCompact, 1);
+};
+
 /// Structure filled for each track with track quality information and a vector with TPCClusterResiduals
 struct TrackData {
   o2::dataformats::GlobalTrackID gid{}; ///< global track ID for seeding track
@@ -210,6 +220,7 @@ class TrackInterpolation
 
   // --------------------------------- output ---------------------------------------------
   std::vector<UnbinnedResid>& getClusterResiduals() { return mClRes; }
+  std::vector<TrackDataCompact>& getTrackDataCompact() { return mTrackDataCompact; }
   std::vector<TrackData>& getReferenceTracks() { return mTrackData; }
   std::vector<TPCClusterResiduals>& getClusterResidualsUnfiltered() { return mClResUnfiltered; }
   std::vector<TrackData>& getReferenceTracksUnfiltered() { return mTrackDataUnfiltered; }
@@ -234,6 +245,7 @@ class TrackInterpolation
 
   // output
   std::vector<TrackData> mTrackData{};                 ///< this vector is used to store the track quality information on a per track basis
+  std::vector<TrackDataCompact> mTrackDataCompact{};   ///< required to connect each residual to a global track
   std::vector<UnbinnedResid> mClRes{};                 ///< residuals for each available TPC cluster of all tracks
   std::vector<TrackData> mTrackDataUnfiltered{};       ///< same as mTrackData, but for all tracks before outlier filtering
   std::vector<TPCClusterResiduals> mClResUnfiltered{}; ///< same as mClRes, but for all residuals before outlier filtering

--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackResiduals.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackResiduals.h
@@ -26,6 +26,7 @@
 
 #include "DataFormatsTPC/Defs.h"
 #include "SpacePoints/SpacePointsCalibParam.h"
+#include "SpacePoints/SpacePointsCalibConfParam.h"
 #include "SpacePoints/TrackInterpolation.h"
 
 #include "TTree.h"
@@ -115,8 +116,7 @@ class TrackResiduals
   // -------------------------------------- initialization --------------------------------------------------
   /// Steers the initialization (binning, default settings for smoothing, container for the results).
   /// \param initBinning Binning does not need to be initialized in case only outlier filtering is performed
-  /// \param bz The nominal magnetic field along Z in kG
-  void init(bool doBinning = true, float bz = param::Bz);
+  void init(bool doBinning = true);
   /// Initializes the binning in X, Y/X and Z.
   void initBinning();
   /// Initializes the results structure for given sector.
@@ -405,38 +405,6 @@ class TrackResiduals
   /// \return Inverse of the distance between bins
   float getDZ2XI(int iz = 0) const;
 
-  // -------------------------------------- settings --------------------------------------------------
-
-  void setMaxPointsPerSector(int nPoints) { mMaxPointsPerSector = nPoints; }
-  void setMinEntriesPerVoxel(int nEntries) { mMinEntriesPerVoxel = nEntries; }
-  void setLTMCut(float ltmCut) { mLTMCut = ltmCut; }
-  void setMinFracLTM(float ltmCut) { mMinFracLTM = ltmCut; }
-  void setMinValidVoxFracDrift(float frac) { mMinValidVoxFracDrift = frac; }
-  void setMinGoodXBinsToCover(int n) { mMinGoodXBinsToCover = n; }
-  void setMaxBadXBinsToCover(int n) { mMaxBadXBinsToCover = n; }
-  void setMaxFracBadRowsPerSector(float frac) { mMaxFracBadRowsPerSector = frac; }
-  void setMaxFitErrY2(float err) { mMaxFitErrY2 = err; }
-  void setMaxFitErrX2(float err) { mMaxFitErrX2 = err; }
-  void setMaxFitCorrXY(float corr) { mMaxFitCorrXY = corr; }
-  void setMaxSigY(float sigY) { mMaxSigY = sigY; }
-  void setMaxSigZ(float sigZ) { mMaxSigZ = sigZ; }
-  void setMaxGaussStdDev(float sigmas) { mMaxGaussStdDev = sigmas; }
-
-  int getMaxPointsPerSector() const { return mMaxPointsPerSector; }
-  int getMinEntriesPerVoxel() const { return mMinEntriesPerVoxel; }
-  float getLTMCut() const { return mLTMCut; }
-  float getMinFracLTM() const { return mMinFracLTM; }
-  float getMinValidVoxFracDrift() const { return mMinValidVoxFracDrift; }
-  int getMinGoodXBinsToCover() const { return mMinGoodXBinsToCover; }
-  int getMaxBadXBinsToCover() const { return mMaxBadXBinsToCover; }
-  float getMaxFracBadRowsPerSector() const { return mMaxFracBadRowsPerSector; }
-  float getMaxFitErrY2() const { return mMaxFitErrY2; }
-  float getMaxFitErrX2() const { return mMaxFitErrX2; }
-  float getMaxFitCorrXY() const { return mMaxFitCorrXY; }
-  float getMaxSigY() const { return mMaxSigY; }
-  float getMaxSigZ() const { return mMaxSigZ; }
-  float getMaxGaussStdDev() const { return mMaxGaussStdDev; }
-
   // -------------------------------------- debugging --------------------------------------------------
 
   /// Prints the current memory usage
@@ -459,6 +427,9 @@ class TrackResiduals
   static constexpr float sMaxZ2X{1.f};      ///< max value for Z2X
   static constexpr int sSmtLinDim{4};       ///< max matrix size for smoothing (pol1)
   static constexpr int sMaxSmtDim{7};       ///< max matrix size for smoothing (pol2)
+
+  // settings
+  const SpacePointsCalibConfParam* mParams = nullptr;
 
   // input data
   std::vector<LocalResid> mLocalResidualsIn;            ///< binned local residuals from aggregator
@@ -489,22 +460,6 @@ class TrackResiduals
   std::vector<float> mZ2XBinsCenter{};     ///< bin center in z/x within the interval [0..1]
   float mMaxZ2X{1.f};                      ///< max z/x value
   std::array<bool, VoxDim> mUniformBins{true, true, true}; ///< if binning is uniform for each dimension
-  // settings
-  float mBz{param::Bz};                          ///< nominal magnetic field along Z
-  int mMaxPointsPerSector{30'000'000};           ///< maximum number of accepted points per sector
-  int mMinEntriesPerVoxel{15};                   ///< minimum number of points in voxel for processing
-  float mLTMCut{.75f};                           ///< fraction op points to keep when trimming input data
-  float mMinFracLTM{.5f};                        ///< minimum fraction of points to keep when trimming data to fit expected sigma
-  float mMinValidVoxFracDrift{.5f};              ///< if more than this fraction of bins are bad for one pad row the whole pad row is declared bad
-  int mMinGoodXBinsToCover{3};                   ///< minimum number of consecutive good bins, otherwise bins are declared bad
-  int mMaxBadXBinsToCover{4};                    ///< a lower number of consecutive bad X bins will not be declared bad
-  float mMaxFracBadRowsPerSector{.4f};           ///< maximum fraction of bad rows before whole sector is masked
-  float mMaxFitErrY2{1.f};                       ///< maximum fit error for Y2
-  float mMaxFitErrX2{9.f};                       ///< maximum fit error for X2
-  float mMaxFitCorrXY{.95f};                     ///< maximum fit correlation for x and y
-  float mMaxSigY{1.1f};                          ///< maximum sigma for y of the voxel
-  float mMaxSigZ{.7f};                           ///< maximum sigma for z of the voxel
-  float mMaxGaussStdDev{5.f};                    ///< maximum number of sigmas to be considered for gaussian kernel smoothing
   // smoothing
   KernelType mKernelType{KernelType::Epanechnikov};                ///< kernel type (Epanechnikov / Gaussian)
   bool mUseErrInSmoothing{true};                                   ///< weight kernel by point error

--- a/Detectors/TPC/calibration/SpacePoints/src/ResidualAggregator.cxx
+++ b/Detectors/TPC/calibration/SpacePoints/src/ResidualAggregator.cxx
@@ -67,6 +67,8 @@ ResidualsContainer::ResidualsContainer(ResidualsContainer&& rhs)
   tfOrbits = std::move(rhs.tfOrbits);
   sumOfResiduals = std::move(rhs.sumOfResiduals);
   lumi = std::move(rhs.lumi);
+  firstSeenTF = rhs.firstSeenTF;
+  lastSeenTF = rhs.lastSeenTF;
 }
 
 void ResidualsContainer::init(const TrackResiduals* residualsEngine, std::string outputDir, bool wFile, bool wBinnedResid, bool wUnbinnedResid, bool wTrackData, int autosave, int compression)
@@ -135,6 +137,12 @@ void ResidualsContainer::fill(const o2::dataformats::TFIDInfo& ti, const std::pa
   // with binned residuals and statistics
   LOG(debug) << "Filling ResidualsContainer with vector of size " << data.second.size();
   uint32_t nResidualsInTF = 0;
+  if (ti.tfCounter > lastSeenTF) {
+    lastSeenTF = ti.tfCounter;
+  }
+  if (ti.tfCounter < firstSeenTF) {
+    firstSeenTF = ti.tfCounter;
+  }
   for (const auto& residIn : data.second) {
     bool counterIncremented = false;
     if (writeUnbinnedResiduals) {
@@ -299,6 +307,8 @@ void ResidualsContainer::merge(ResidualsContainer* prev)
   std::swap(prev->sumOfResiduals, sumOfResiduals);
   prev->lumi.insert(prev->lumi.end(), lumi.begin(), lumi.end());
   std::swap(prev->lumi, lumi);
+
+  firstSeenTF = prev->firstSeenTF;
 }
 
 void ResidualsContainer::print()
@@ -337,15 +347,18 @@ void ResidualAggregator::finalizeSlot(Slot& slot)
     return;
   }
   cont->writeToFile(true);
-  std::filesystem::rename(o2::utils::Str::concat_string(mOutputDir, cont->fileName, ".part"), mOutputDir + cont->fileName);
+
+  auto fileName = fmt::format("o2tpc_residuals_{}_{}_{}_{}.root", slot.getTFStart(), slot.getTFEnd(), cont->firstSeenTF, cont->lastSeenTF);
+  auto fileNameWithPath = mOutputDir + fileName;
+  std::filesystem::rename(o2::utils::Str::concat_string(mOutputDir, cont->fileName, ".part"), fileNameWithPath);
   if (mStoreMetaData) {
     o2::dataformats::FileMetaData fileMetaData; // object with information for meta data file
-    fileMetaData.fillFileData(mOutputDir + cont->fileName);
+    fileMetaData.fillFileData(fileNameWithPath);
     fileMetaData.setDataTakingContext(mDataTakingContext);
     fileMetaData.type = "calib";
     fileMetaData.priority = "high";
-    auto metaFileNameTmp = fmt::format("{}{}.tmp", mMetaOutputDir, cont->fileName);
-    auto metaFileName = fmt::format("{}{}.done", mMetaOutputDir, cont->fileName);
+    auto metaFileNameTmp = fmt::format("{}{}.tmp", mMetaOutputDir, fileName);
+    auto metaFileName = fmt::format("{}{}.done", mMetaOutputDir, fileName);
     try {
       std::ofstream metaFileOut(metaFileNameTmp);
       metaFileOut << fileMetaData;

--- a/Detectors/TPC/calibration/SpacePoints/src/SpacePointCalibLinkDef.h
+++ b/Detectors/TPC/calibration/SpacePoints/src/SpacePointCalibLinkDef.h
@@ -17,6 +17,8 @@
 
 #pragma link C++ class o2::tpc::TrackInterpolation + ;
 #pragma link C++ class o2::tpc::TrackResiduals + ;
+#pragma link C++ class o2::tpc::TrackDataCompact + ;
+#pragma link C++ class std::vector < o2::tpc::TrackDataCompact> + ;
 #pragma link C++ class o2::tpc::TrackData + ;
 #pragma link C++ class std::vector < o2::tpc::TrackData> + ;
 #pragma link C++ class o2::tpc::TPCClusterResiduals + ;

--- a/Detectors/TPC/calibration/SpacePoints/src/SpacePointCalibLinkDef.h
+++ b/Detectors/TPC/calibration/SpacePoints/src/SpacePointCalibLinkDef.h
@@ -31,5 +31,6 @@
 #pragma link C++ class o2::tpc::ResidualAggregator + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::tpc::ResidualsContainer> + ;
 #pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tpc::ResidualsContainer> + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::tpc::SpacePointsCalibConfParam> + ;
 
 #endif

--- a/Detectors/TPC/calibration/SpacePoints/src/SpacePointCalibLinkDef.h
+++ b/Detectors/TPC/calibration/SpacePoints/src/SpacePointCalibLinkDef.h
@@ -30,6 +30,6 @@
 #pragma link C++ class std::vector < o2::tpc::TrackResiduals::VoxStats> + ;
 #pragma link C++ class o2::tpc::ResidualAggregator + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::tpc::ResidualsContainer> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tpc::UnbinnedResid, o2::tpc::ResidualsContainer> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tpc::ResidualsContainer> + ;
 
 #endif

--- a/Detectors/TPC/calibration/SpacePoints/src/SpacePointsCalibConfParam.cxx
+++ b/Detectors/TPC/calibration/SpacePoints/src/SpacePointsCalibConfParam.cxx
@@ -9,22 +9,10 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifndef O2_TPC_RESIDUAL_WRITER_H
-#define O2_TPC_RESIDUAL_WRITER_H
+/// \file SpacePointsCalibConfParam.cxx
+/// \brief Configurable params for average space charge distortion correction
+/// \author ole.schmidt@cern.ch
 
-/// @file   TPCResidualWriterSpec.h
+#include "SpacePoints/SpacePointsCalibConfParam.h"
 
-#include "Framework/DataProcessorSpec.h"
-
-namespace o2
-{
-namespace tpc
-{
-
-/// create a processor spec
-framework::DataProcessorSpec getTPCResidualWriterSpec(bool writeTrackData);
-
-} // namespace tpc
-} // namespace o2
-
-#endif
+O2ParamImpl(o2::tpc::SpacePointsCalibConfParam);

--- a/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
+++ b/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
@@ -299,6 +299,7 @@ void TrackInterpolation::interpolateTrack(int iSeed)
     trackData.clIdx.setEntries(nClValidated);
     mTrackData.push_back(std::move(trackData));
     mGIDsSuccess.push_back((*mGIDs)[iSeed]);
+    mTrackDataCompact.emplace_back(mClRes.size() - nClValidated, nClValidated, (*mGIDs)[iSeed].getSource());
   }
   if (mParams->writeUnfiltered) {
     TrackData trkDataTmp = trackData;
@@ -751,6 +752,7 @@ void TrackInterpolation::diffToMA(const int np, const std::array<float, param::N
 void TrackInterpolation::reset()
 {
   mTrackData.clear();
+  mTrackDataCompact.clear();
   mClRes.clear();
   mTrackDataUnfiltered.clear();
   mClResUnfiltered.clear();

--- a/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
+++ b/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
@@ -86,6 +86,10 @@ void TrackInterpolation::process(const o2::globaltracking::RecoContainer& inp, c
     } else {
       extrapolateTrack(iSeed);
     }
+    if (mMaxTracksPerTF >= 0 && mTrackDataCompact.size() >= mMaxTracksPerTF) {
+      LOG(info) << "Maximum number of tracks per TF reached. Skipping the remaining " << nSeeds - iSeed << " tracks.";
+      break;
+    }
   }
 
   LOG(info) << "Could process " << mTrackData.size() << " tracks successfully";
@@ -378,6 +382,7 @@ void TrackInterpolation::extrapolateTrack(int iSeed)
     trackData.clIdx.setEntries(nClValidated);
     mTrackData.push_back(std::move(trackData));
     mGIDsSuccess.push_back((*mGIDs)[iSeed]);
+    mTrackDataCompact.emplace_back(mClRes.size() - nClValidated, nClValidated, (*mGIDs)[iSeed].getSource());
   }
   if (mParams->writeUnfiltered) {
     TrackData trkDataTmp = trackData;

--- a/Detectors/TPC/calibration/include/TPCCalibration/CalibratorPadGainTracks.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/CalibratorPadGainTracks.h
@@ -24,7 +24,7 @@
 namespace o2::tpc
 {
 /// \brief calibrator class for the residual gain map extraction used on an aggregator node
-class CalibratorPadGainTracks : public o2::calibration::TimeSlotCalibration<CalibPadGainTracksBase::DataTHistos, CalibPadGainTracksBase>
+class CalibratorPadGainTracks : public o2::calibration::TimeSlotCalibration<CalibPadGainTracksBase>
 {
   using TFType = o2::calibration::TFType;
   using Slot = o2::calibration::TimeSlot<CalibPadGainTracksBase>;

--- a/Detectors/TPC/calibration/include/TPCCalibration/CalibratordEdx.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/CalibratordEdx.h
@@ -34,7 +34,7 @@ namespace o2::tpc
 {
 
 /// dE/dx calibrator class
-class CalibratordEdx final : public o2::calibration::TimeSlotCalibration<o2::tpc::TrackTPC, o2::tpc::CalibdEdx>
+class CalibratordEdx final : public o2::calibration::TimeSlotCalibration<o2::tpc::CalibdEdx>
 {
   using TFType = o2::calibration::TFType;
   using Slot = o2::calibration::TimeSlot<CalibdEdx>;

--- a/Detectors/TPC/calibration/include/TPCCalibration/LaserTracksCalibrator.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/LaserTracksCalibrator.h
@@ -24,7 +24,7 @@
 namespace o2::tpc
 {
 
-class LaserTracksCalibrator : public o2::calibration::TimeSlotCalibration<TrackTPC, CalibLaserTracks>
+class LaserTracksCalibrator : public o2::calibration::TimeSlotCalibration<CalibLaserTracks>
 {
   using TFType = o2::calibration::TFType;
   using Slot = o2::calibration::TimeSlot<o2::tpc::CalibLaserTracks>;

--- a/Detectors/TPC/calibration/include/TPCCalibration/TPCVDriftTglCalibration.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/TPCVDriftTglCalibration.h
@@ -81,7 +81,7 @@ struct TPCVDTglContainer {
   ClassDefNV(TPCVDTglContainer, 1);
 };
 
-class TPCVDriftTglCalibration : public o2::calibration::TimeSlotCalibration<o2::dataformats::Pair<float, float>, TPCVDTglContainer>
+class TPCVDriftTglCalibration : public o2::calibration::TimeSlotCalibration<TPCVDTglContainer>
 {
   using Slot = o2::calibration::TimeSlot<TPCVDTglContainer>;
 

--- a/Detectors/TPC/calibration/src/TPCCalibrationLinkDef.h
+++ b/Detectors/TPC/calibration/src/TPCCalibrationLinkDef.h
@@ -32,7 +32,7 @@
 #pragma link C++ class o2::tpc::CalibLaserTracks + ;
 #pragma link C++ class o2::tpc::LaserTracksCalibrator + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::tpc::CalibLaserTracks> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tpc::TrackTPC, o2::tpc::CalibLaserTracks> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tpc::CalibLaserTracks> + ;
 #pragma link C++ class o2::tpc::TimePair + ;
 #pragma link C++ class std::vector < o2::tpc::TimePair> + ;
 #pragma link C++ class o2::tpc::IDCGroup + ;
@@ -71,7 +71,7 @@
 #pragma link C++ class o2::tpc::CalibdEdx + ;
 #pragma link C++ class o2::tpc::CalibratordEdx + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::tpc::CalibdEdx> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tpc::TrackTPC, o2::tpc::CalibdEdx> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tpc::CalibdEdx> + ;
 #pragma link C++ class o2::tpc::TrackDump + ;
 #pragma link C++ class o2::tpc::TrackDump::ClusterNativeAdd + ;
 #pragma link C++ class o2::tpc::TrackDump::ClusterGlobal + ;
@@ -85,7 +85,7 @@
 #pragma link C++ class o2::tpc::CalibPadGainTracksBase + ;
 #pragma link C++ class o2::tpc::CalDet < o2::tpc::FastHisto < unsigned int>> + ;
 #pragma link C++ class o2::calibration::TimeSlot < o2::tpc::CalibPadGainTracksBase> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tpc::CalDet < o2::tpc::FastHisto < unsigned int>>, o2::tpc::CalibPadGainTracksBase> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tpc::CalibPadGainTracksBase> + ;
 #pragma link C++ class o2::tpc::CalibratorPadGainTracks + ;
 #pragma link C++ class o2::tpc::sac::DataPoint + ;
 #pragma link C++ class o2::tpc::sac::DecodedData + ;
@@ -102,7 +102,7 @@
 #pragma link C++ class o2::tpc::SACCCDBHelper < unsigned char> + ;
 
 #pragma link C++ class o2::calibration::TimeSlot < o2::tpc::TPCVDTglContainer> + ;
-#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::dataformats::Pair < float, float>, o2::tpc::TPCVDTglContainer> + ;
+#pragma link C++ class o2::calibration::TimeSlotCalibration < o2::tpc::TPCVDTglContainer> + ;
 #pragma link C++ class o2::tpc::TPCVDriftTglCalibration + ;
 #pragma link C++ class o2::tpc::VDriftHelper + ;
 #endif

--- a/prodtests/full-system-test/aggregator-workflow.sh
+++ b/prodtests/full-system-test/aggregator-workflow.sh
@@ -85,6 +85,7 @@ fi
 # special settings for aggregator workflows
 if [[ "0$CALIB_TPC_SCDCALIB_SENDTRKDATA" == "01" ]]; then ENABLE_TRACK_INPUT="--enable-track-input"; fi
 if [[ -z "$RESIDUAL_AGGREGATOR_AUTOSAVE" ]]; then RESIDUAL_AGGREGATOR_AUTOSAVE=0; fi
+[[ -z $CALIB_TPC_SCDCALIB_SLOTLENGTH ]] && TPCSCD_CONFIG="--sec-per-slot $CALIB_TPC_SCDCALIB_SLOTLENGTH"
 
 # Calibration workflows
 if ! workflow_has_parameter CALIB_LOCAL_INTEGRATED_AGGREGATOR; then
@@ -183,7 +184,7 @@ if [[ $AGGREGATOR_TASKS == BARREL_TF ]] || [[ $AGGREGATOR_TASKS == ALL ]]; then
   fi
   # TPC
   if [[ $CALIB_TPC_SCDCALIB == 1 ]]; then
-    add_W o2-calibration-residual-aggregator "--disable-root-input $ENABLE_TRACK_INPUT $CALIB_TPC_SCDCALIB_CTP_INPUT --output-dir $CALIB_DIR --meta-output-dir $EPN2EOS_METAFILES_DIR --autosave-interval $RESIDUAL_AGGREGATOR_AUTOSAVE"
+    add_W o2-calibration-residual-aggregator "--disable-root-input $TPCSCD_CONFIG $ENABLE_TRACK_INPUT $CALIB_TPC_SCDCALIB_CTP_INPUT --output-dir $CALIB_DIR --meta-output-dir $EPN2EOS_METAFILES_DIR --autosave-interval $RESIDUAL_AGGREGATOR_AUTOSAVE"
   fi
   if [[ $CALIB_TPC_VDRIFTTGL == 1 ]]; then
     # options available via ARGS_EXTRA_PROCESS_o2_tpc_vdrift_tgl_calibration_workflow="--nbins-tgl 20 --nbins-dtgl 50 --max-tgl-its 2. --max-dtgl-itstpc 0.15 --min-entries-per-slot 1000 --time-slot-seconds 600 <--vdtgl-histos-file-name name> "

--- a/prodtests/full-system-test/calib-workflow.sh
+++ b/prodtests/full-system-test/calib-workflow.sh
@@ -15,9 +15,10 @@ if workflow_has_parameters CALIB_LOCAL_INTEGRATED_AGGREGATOR CALIB_PROXIES; then
 fi
 
 if [[ "0$CALIB_TPC_SCDCALIB_SENDTRKDATA" == "01" ]]; then ENABLE_TRKDATA_OUTPUT="--send-track-data"; fi
+[[ -z $CALIB_TPC_SCDCALIB_SLOTLENGTH ]] && TPCSCD_CONFIG="--sec-per-slot $CALIB_TPC_SCDCALIB_SLOTLENGTH"
 
 # specific calibration workflows
-if [[ $CALIB_TPC_SCDCALIB == 1 ]]; then add_W o2-tpc-scdcalib-interpolation-workflow "$ENABLE_TRKDATA_OUTPUT $DISABLE_ROOT_OUTPUT --disable-root-input --pipeline $(get_N tpc-track-interpolation TPC REST)" "$ITSMFT_FILES"; fi
+if [[ $CALIB_TPC_SCDCALIB == 1 ]]; then add_W o2-tpc-scdcalib-interpolation-workflow "$TPCSCD_CONFIG $ENABLE_TRKDATA_OUTPUT $DISABLE_ROOT_OUTPUT --disable-root-input --pipeline $(get_N tpc-track-interpolation TPC REST)" "$ITSMFT_FILES"; fi
 if [[ $CALIB_TPC_TIMEGAIN == 1 ]]; then
   if [[ -z $SCALEEVENTS_TPC_TIMEGAIN ]]; then SCALEEVENTS_TPC_TIMEGAIN=10; fi
   if [[ -z $SCALETRACKS_TPC_TIMEGAIN ]]; then SCALETRACKS_TPC_TIMEGAIN=1000; fi


### PR DESCRIPTION
Will merge this only after https://github.com/AliceO2Group/AliceO2/pull/10397 as the changes here are on top of that.

Main changes:
- allow configuration of the calibration via configKeyValues @ehellbar this I should have done earlier. Now you can set e.g. the cuts for voxel validation more easily via `--configKeyValues "scdcalib.maxSigY=1.5;scdcalib.maxSigZ=1."`
- add the slot boundaries and first and last processed TF of each slot to the output file name
- add branch with information on the reference tracks to the binned residuals. This allows to select e.g. only ITS-TPC-TRD-TOF tracks also afterwards when the map is created
- prepare limiting the maximum number of processed tracks per TF. This is still WIP. In case there are more tracks available then needed I will implement a sampling to avoid processing only a certain eta range for example