### PR TITLE
DPL: avoid regex recompilation

### DIFF
--- a/Framework/Core/src/DeviceMetricsHelper.cxx
+++ b/Framework/Core/src/DeviceMetricsHelper.cxx
@@ -18,7 +18,6 @@
 #include <cstdlib>
 
 #include <algorithm>
-#include <regex>
 #include <string_view>
 #include <tuple>
 #include <iostream>

--- a/Framework/Core/src/ResourcesMonitoringHelper.h
+++ b/Framework/Core/src/ResourcesMonitoringHelper.h
@@ -19,6 +19,7 @@
 
 #include <vector>
 #include <type_traits>
+#include <regex>
 
 namespace o2::framework
 {
@@ -29,7 +30,7 @@ struct ResourcesMonitoringHelper {
   static bool dumpMetricsToJSON(std::vector<DeviceMetricsInfo> const& metrics,
                                 DeviceMetricsInfo const& driverMetrics,
                                 std::vector<DeviceSpec> const& specs,
-                                std::vector<std::string> const& metricsToDump) noexcept;
+                                std::vector<std::regex> const& metricsToDump) noexcept;
   static bool isResourcesMonitoringEnabled(unsigned short interval) noexcept { return interval > 0; }
 };
 


### PR DESCRIPTION
The fact that the regex was created in the lambda caused its optimization to be done on a per invokation basis. While this is not a big deal when the metrics are dumped at the end or for small workflows, in case of processing on the EPN with the remote GUI enabled, the sheer amount of metrics which are collected are enough to cause unrecoverable latency in the GUI, making it feel sluggish.