### PR TITLE
DPL: move parseConfig / parseControl API to use std::string_view

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -184,6 +184,7 @@ foreach(t
         CompletionPolicy
         ComputingResourceHelpers
         ComputingQuotaEvaluator
+        ControlServiceHelpers
         ConfigParamStore
         ConfigParamRegistry
         DataDescriptorMatcher

--- a/Framework/Core/src/ControlServiceHelpers.cxx
+++ b/Framework/Core/src/ControlServiceHelpers.cxx
@@ -15,21 +15,21 @@
 #include <string>
 #include <string_view>
 #include <regex>
-#include <iostream>
 
 namespace o2::framework
 {
 
-bool ControlServiceHelpers::parseControl(std::string const& s, std::smatch& match)
+bool ControlServiceHelpers::parseControl(std::string_view const& s, std::match_results<std::string_view::const_iterator>& match)
 {
-  char const* action = strstr(s.data(), "CONTROL_ACTION:");
-  if (action == nullptr) {
+  size_t pos = s.find("CONTROL_ACTION: ");
+  if (pos == std::string::npos) {
     return false;
   }
-  const static std::regex controlRE1(".*CONTROL_ACTION: READY_TO_(QUIT)_(ME|ALL)", std::regex::optimize);
-  const static std::regex controlRE2(".*CONTROL_ACTION: (NOTIFY_STREAMING_STATE) (IDLE|STREAMING|EOS)", std::regex::optimize);
-  const static std::regex controlRE3(".*CONTROL_ACTION: (NOTIFY_DEVICE_STATE) ([A-Z ]*)", std::regex::optimize);
-  return std::regex_search(s, match, controlRE1) || std::regex_search(s, match, controlRE2) || std::regex_search(s, match, controlRE3);
+  const static std::regex controlRE1("^READY_TO_(QUIT)_(ME|ALL)", std::regex::optimize);
+  const static std::regex controlRE2("^(NOTIFY_STREAMING_STATE) (IDLE|STREAMING|EOS)", std::regex::optimize);
+  const static std::regex controlRE3("^(NOTIFY_DEVICE_STATE) ([A-Z ]*)", std::regex::optimize);
+  std::string_view sv = s.substr(pos + strlen("CONTROL_ACTION: "));
+  return std::regex_search(sv.begin(), sv.end(), match, controlRE1) || std::regex_search(sv.begin(), sv.end(), match, controlRE2) || std::regex_search(sv.begin(), sv.end(), match, controlRE3);
 }
 
 void ControlServiceHelpers::processCommand(std::vector<DeviceInfo>& infos,

--- a/Framework/Core/src/ControlServiceHelpers.h
+++ b/Framework/Core/src/ControlServiceHelpers.h
@@ -16,12 +16,13 @@
 #include <unistd.h>
 #include <vector>
 #include <string>
+#include <string_view>
 #include <regex>
 
 namespace o2::framework
 {
 struct ControlServiceHelpers {
-  static bool parseControl(std::string const& s, std::smatch& match);
+  static bool parseControl(std::string_view const& s, std::match_results<std::string_view::const_iterator>& match);
   static void processCommand(std::vector<DeviceInfo>& infos,
                              pid_t pid,
                              std::string const& command,

--- a/Framework/Core/src/ControlWebSocketHandler.cxx
+++ b/Framework/Core/src/ControlWebSocketHandler.cxx
@@ -35,9 +35,8 @@ void ControlWebSocketHandler::frame(char const* frame, size_t s)
   std::string_view tokenSV(frame, s);
   ParsedMetricMatch metricMatch;
 
-  auto doParseConfig = [](std::string const& token, ParsedConfigMatch& configMatch, DeviceInfo& info) -> bool {
-    auto ts = "                 " + token;
-    if (DeviceConfigHelper::parseConfig(ts, configMatch)) {
+  auto doParseConfig = [](std::string_view const& token, ParsedConfigMatch& configMatch, DeviceInfo& info) -> bool {
+    if (DeviceConfigHelper::parseConfig(token, configMatch)) {
       DeviceConfigHelper::processConfig(configMatch, info);
       return true;
     }
@@ -55,7 +54,7 @@ void ControlWebSocketHandler::frame(char const* frame, size_t s)
   }
 
   ParsedConfigMatch configMatch;
-  std::string token(frame, s);
+  std::string_view const token(frame, s);
   std::match_results<std::string_view::const_iterator> match;
 
   if (ControlServiceHelpers::parseControl(token, match) && mContext.infos) {

--- a/Framework/Core/src/ControlWebSocketHandler.cxx
+++ b/Framework/Core/src/ControlWebSocketHandler.cxx
@@ -56,7 +56,7 @@ void ControlWebSocketHandler::frame(char const* frame, size_t s)
 
   ParsedConfigMatch configMatch;
   std::string token(frame, s);
-  std::smatch match;
+  std::match_results<std::string_view::const_iterator> match;
 
   if (ControlServiceHelpers::parseControl(token, match) && mContext.infos) {
     ControlServiceHelpers::processCommand(*mContext.infos, mPid, match[1].str(), match[2].str());

--- a/Framework/Core/src/DeviceConfigInfo.cxx
+++ b/Framework/Core/src/DeviceConfigInfo.cxx
@@ -28,7 +28,6 @@ bool DeviceConfigHelper::parseConfig(std::string_view s, ParsedConfigMatch& matc
   const char* cur = s.data();
   const char* next = cur;
   enum struct ParserState {
-    IN_START,
     IN_PREAMBLE,
     IN_KEY,
     IN_VALUE,
@@ -42,19 +41,13 @@ bool DeviceConfigHelper::parseConfig(std::string_view s, ParsedConfigMatch& matc
   // to be able to parse the timestamp and tags.
   char const* lastSpace = nullptr;
   char const* previousLastSpace = nullptr;
-  ParserState state = ParserState::IN_START;
+  ParserState state = ParserState::IN_PREAMBLE;
 
   while (true) {
     auto previousState = state;
     state = ParserState::IN_ERROR;
     err = nullptr;
     switch (previousState) {
-      case ParserState::IN_START:
-        if (s.size() > 16) {
-          next = next + 16;
-          state = ParserState::IN_PREAMBLE;
-        }
-        break;
       case ParserState::IN_PREAMBLE:
         if (s.data() + s.size() - cur < 9) {
         } else if (strncmp("[CONFIG] ", cur, 9) == 0) {

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -476,9 +476,8 @@ struct ControlWebSocketHandler : public WebSocketHandler {
     ParsedConfigMatch configMatch;
     ParsedMetricMatch metricMatch;
 
-    auto doParseConfig = [](std::string const& token, ParsedConfigMatch& configMatch, DeviceInfo& info) -> bool {
-      auto ts = "                 " + token;
-      if (DeviceConfigHelper::parseConfig(ts, configMatch)) {
+    auto doParseConfig = [](std::string_view const& token, ParsedConfigMatch& configMatch, DeviceInfo& info) -> bool {
+      if (DeviceConfigHelper::parseConfig(token, configMatch)) {
         DeviceConfigHelper::processConfig(configMatch, info);
         return true;
       }
@@ -923,7 +922,7 @@ LogProcessingState processChildrenOutput(DriverInfo& driverInfo,
       } else if (logLevel == LogParsingHelpers::LogLevel::Info && ControlServiceHelpers::parseControl(token, match)) {
         ControlServiceHelpers::processCommand(infos, info.pid, match[1].str(), match[2].str());
         result.didProcessControl = true;
-      } else if (logLevel == LogParsingHelpers::LogLevel::Info && DeviceConfigHelper::parseConfig(token, configMatch)) {
+      } else if (logLevel == LogParsingHelpers::LogLevel::Info && DeviceConfigHelper::parseConfig(token.substr(16), configMatch)) {
         DeviceConfigHelper::processConfig(configMatch, info);
         result.didProcessConfig = true;
       } else if (!control.quiet && (token.find(control.logFilter) != std::string::npos) &&

--- a/Framework/Core/src/runDataProcessing.cxx
+++ b/Framework/Core/src/runDataProcessing.cxx
@@ -472,7 +472,7 @@ struct ControlWebSocketHandler : public WebSocketHandler {
       hasNewMetric = true;
     };
     std::string token(frame, s);
-    std::smatch match;
+    std::match_results<std::string_view::const_iterator> match;
     ParsedConfigMatch configMatch;
     ParsedMetricMatch metricMatch;
 
@@ -870,7 +870,7 @@ LogProcessingState processChildrenOutput(DriverInfo& driverInfo,
   // TODO: have multiple display modes
   // TODO: graphical view of the processing?
   assert(infos.size() == controls.size());
-  std::smatch match;
+  std::match_results<std::string_view::const_iterator> match;
   ParsedMetricMatch metricMatch;
   ParsedConfigMatch configMatch;
   const std::string delimiter("\n");

--- a/Framework/Core/test/test_ControlServiceHelpers.cxx
+++ b/Framework/Core/test/test_ControlServiceHelpers.cxx
@@ -1,0 +1,51 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#define BOOST_TEST_MODULE Test Framework DeviceMetricsInfo
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_DYN_LINK
+
+#include "../src/ControlServiceHelpers.h"
+#include <boost/test/unit_test.hpp>
+#include <iostream>
+#include <regex>
+#include <string_view>
+
+BOOST_AUTO_TEST_CASE(TestControlServiceHelper)
+{
+  using namespace o2::framework;
+  std::match_results<std::string_view::const_iterator> match;
+  BOOST_REQUIRE_EQUAL(ControlServiceHelpers::parseControl("foo", match), false);
+  std::match_results<std::string_view::const_iterator> match2;
+  std::string sv = "CONTROL_ACTION: READY_TO_QUIT_ME";
+  BOOST_REQUIRE_EQUAL(ControlServiceHelpers::parseControl(sv, match2), true);
+  BOOST_REQUIRE_EQUAL(match2[1].str(), "QUIT");
+  BOOST_REQUIRE_EQUAL(match2[2].str(), "ME");
+  std::string sv2 = "   dsca  CONTROL_ACTION: READY_TO_QUIT_ME";
+  BOOST_REQUIRE_EQUAL(ControlServiceHelpers::parseControl(sv2, match2), true);
+  BOOST_REQUIRE_EQUAL(match2[1].str(), "QUIT");
+  BOOST_REQUIRE_EQUAL(match2[2].str(), "ME");
+  const static std::regex controlRE2("^(NOTIFY_STREAMING_STATE) (IDLE|STREAMING|EOS)", std::regex::optimize);
+  const static std::regex controlRE3("^(NOTIFY_DEVICE_STATE) ([A-Z ]*)", std::regex::optimize);
+  std::string sv3 = "   dsca  CONTROL_ACTION: NOTIFY_STREAMING_STATE IDLE";
+  BOOST_REQUIRE_EQUAL(ControlServiceHelpers::parseControl(sv3, match2), true);
+  BOOST_REQUIRE_EQUAL(match2[1].str(), "NOTIFY_STREAMING_STATE");
+  BOOST_REQUIRE_EQUAL(match2[2].str(), "IDLE");
+  std::string_view sv4 = "   dsca  CONTROL_ACTION: NOTIFY_STREAMING_STATE IDLE";
+  BOOST_REQUIRE_EQUAL(ControlServiceHelpers::parseControl(sv4, match2), true);
+  BOOST_REQUIRE_EQUAL(match2[1].str(), "NOTIFY_STREAMING_STATE");
+  BOOST_REQUIRE_EQUAL(match2[2].str(), "IDLE");
+  std::string_view sv5 = "   asdsca  CONTROL_ACTION: NOTIFY_DEVICE_STATE STOP";
+  BOOST_REQUIRE_EQUAL(ControlServiceHelpers::parseControl(sv5, match2), true);
+  BOOST_REQUIRE_EQUAL(match2[1].str(), "NOTIFY_DEVICE_STATE");
+  BOOST_REQUIRE_EQUAL(match2[2].str(), "STOP");
+  std::string_view sv6 = "   asdsca  CONTROL_ACTION: ";
+  BOOST_REQUIRE_EQUAL(ControlServiceHelpers::parseControl(sv6, match2), false);
+}

--- a/Framework/Core/test/test_DeviceConfigInfo.cxx
+++ b/Framework/Core/test/test_DeviceConfigInfo.cxx
@@ -54,39 +54,39 @@ BOOST_AUTO_TEST_CASE(TestDeviceConfigInfo)
   BOOST_REQUIRE_EQUAL(result, false);
 
   // Something which does not match
-  configString = "foo[XX:XX:XX][INFO] [CONFIG] foobar 1789372894\n";
+  configString = "foo[CONFIG] foobar 1789372894\n";
   std::string_view config2{configString.data() + 3, configString.size() - 4};
   result = DeviceConfigHelper::parseConfig(config2, match);
   BOOST_REQUIRE_EQUAL(result, false);
 
   // Something which does not match
-  configString = "foo[XX:XX:XX][INFO] [CONFIG] foo=bar1789372894\n";
+  configString = "foo[CONFIG] foo=bar1789372894\n";
   std::string_view config3{configString.data() + 3, configString.size() - 4};
   result = DeviceConfigHelper::parseConfig(config3, match);
   BOOST_REQUIRE_EQUAL(result, false);
 
   // Something which does not match
-  configString = "foo[XX:XX:XX][INFO] [CONFIG] foo=bar\n";
+  configString = "foo[CONFIG] foo=bar\n";
   std::string_view config4{configString.data() + 3, configString.size() - 4};
   result = DeviceConfigHelper::parseConfig(config4, match);
   BOOST_REQUIRE_EQUAL(result, false);
 
   // Something which does not match
-  configString = "foo[XX:XX:XX][INFO] [CONFIG] foo=bar 1789372894t\n";
+  configString = "foo[CONFIG] foo=bar 1789372894t\n";
   std::string_view config5{configString.data() + 3, configString.size() - 4};
   result = DeviceConfigHelper::parseConfig(config5, match);
   BOOST_REQUIRE_EQUAL(result, false);
 
   // Parse a simple configuration bit
-  configString = "foo[XX:XX:XX][INFO] [CONFIG] foo=bar 1789372894\n";
+  configString = "foo[CONFIG] foo=bar 1789372894\n";
   std::string_view config6{configString.data() + 3, configString.size() - 4};
   result = DeviceConfigHelper::parseConfig(config6, match);
   BOOST_REQUIRE_EQUAL(result, false);
 
   // Parse a simple configuration bit
-  configString = "foo[XX:XX:XX][INFO] [CONFIG] foo=bar 1789372894 prov\n";
+  configString = "foo[CONFIG] foo=bar 1789372894 prov\n";
   std::string_view config{configString.data() + 3, configString.size() - 4};
-  BOOST_REQUIRE_EQUAL(config, std::string("[XX:XX:XX][INFO] [CONFIG] foo=bar 1789372894 prov"));
+  BOOST_REQUIRE_EQUAL(config, std::string("[CONFIG] foo=bar 1789372894 prov"));
   result = DeviceConfigHelper::parseConfig(config, match);
   BOOST_REQUIRE_EQUAL(result, true);
   BOOST_CHECK(strncmp(match.beginKey, "foo", 3) == 0);
@@ -95,9 +95,9 @@ BOOST_AUTO_TEST_CASE(TestDeviceConfigInfo)
   BOOST_CHECK(strncmp(match.beginProvenance, "prov", 4) == 0);
 
   // Parse a simple configuration bit with a space in the value
-  configString = "foo[XX:XX:XX][INFO] [CONFIG] foo=bar and foo 1789372894 prov\n";
+  configString = "foo[CONFIG] foo=bar and foo 1789372894 prov\n";
   std::string_view configWithSpace{configString.data() + 3, configString.size() - 4};
-  BOOST_REQUIRE_EQUAL(configWithSpace, std::string("[XX:XX:XX][INFO] [CONFIG] foo=bar and foo 1789372894 prov"));
+  BOOST_REQUIRE_EQUAL(configWithSpace, std::string("[CONFIG] foo=bar and foo 1789372894 prov"));
   result = DeviceConfigHelper::parseConfig(configWithSpace, match);
   BOOST_REQUIRE_EQUAL(result, true);
   BOOST_CHECK(strncmp(match.beginKey, "foo", 3) == 0);
@@ -112,7 +112,7 @@ BOOST_AUTO_TEST_CASE(TestDeviceConfigInfo)
   BOOST_CHECK_EQUAL(info.currentProvenance.get<std::string>("foo"), "prov");
 
   // Parse an array
-  configString = "foo[XX:XX:XX][INFO] [CONFIG] array={\"\":\"1\",\"\":\"2\",\"\":\"3\",\"\":\"4\",\"\":\"5\"} 1789372894 prov\n";
+  configString = "foo[CONFIG] array={\"\":\"1\",\"\":\"2\",\"\":\"3\",\"\":\"4\",\"\":\"5\"} 1789372894 prov\n";
   std::string_view configa{configString.data() + 3, configString.size() - 4};
   result = DeviceConfigHelper::parseConfig(configa, match);
   auto valueString = std::string(match.beginValue, match.endValue - match.beginValue);


### PR DESCRIPTION
This provides better experience when running the remote GUI with very large workflows like the one running on the EPNs.