### PR TITLE
[EMCAL-798] Add input subspecification to offline calib workflow

### DIFF
--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/OfflineCalibSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/OfflineCalibSpec.h
@@ -70,7 +70,7 @@ class OfflineCalibSpec : public framework::Task
 /// \brief Creating offline calib spec
 /// \ingroup EMCALworkflow
 ///
-o2::framework::DataProcessorSpec getEmcalOfflineCalibSpec(bool makeCellIDTimeEnergy, bool rejectCalibTriggers);
+o2::framework::DataProcessorSpec getEmcalOfflineCalibSpec(bool makeCellIDTimeEnergy, bool rejectCalibTriggers, uint32_t inputsubspec);
 
 } // namespace emcal
 

--- a/Detectors/EMCAL/workflow/src/OfflineCalibSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/OfflineCalibSpec.cxx
@@ -108,11 +108,11 @@ void OfflineCalibSpec::endOfStream(o2::framework::EndOfStreamContext& ec)
   outputFile->Close();
 }
 
-o2::framework::DataProcessorSpec o2::emcal::getEmcalOfflineCalibSpec(bool makeCellIDTimeEnergy, bool rejectCalibTriggers)
+o2::framework::DataProcessorSpec o2::emcal::getEmcalOfflineCalibSpec(bool makeCellIDTimeEnergy, bool rejectCalibTriggers, uint32_t inputsubspec)
 {
   return o2::framework::DataProcessorSpec{"EMCALOfflineCalib",
-                                          {{"cells", o2::header::gDataOriginEMC, "CELLS", 0, o2::framework::Lifetime::Timeframe},
-                                           {"triggerrecord", o2::header::gDataOriginEMC, "CELLSTRGR", 0, o2::framework::Lifetime::Timeframe}},
+                                          {{"cells", o2::header::gDataOriginEMC, "CELLS", inputsubspec, o2::framework::Lifetime::Timeframe},
+                                           {"triggerrecord", o2::header::gDataOriginEMC, "CELLSTRGR", inputsubspec, o2::framework::Lifetime::Timeframe}},
                                           {},
                                           o2::framework::adaptFromTask<o2::emcal::OfflineCalibSpec>(makeCellIDTimeEnergy, rejectCalibTriggers)};
 }

--- a/Detectors/EMCAL/workflow/src/emc-offline-calib-workflow.cxx
+++ b/Detectors/EMCAL/workflow/src/emc-offline-calib-workflow.cxx
@@ -21,8 +21,9 @@ using namespace o2::framework;
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   // option allowing to set parameters
-  std::vector<ConfigParamSpec> options{{"makeCellIDTimeEnergy", VariantType::Bool, true, {"list whether or not to make the cell ID, time, energy THnSparse"}},
+  std::vector<ConfigParamSpec> options{{"makeCellIDTimeEnergy", VariantType::Bool, false, {"list whether or not to make the cell ID, time, energy THnSparse"}},
                                        {"no-rejectCalibTrigg", VariantType::Bool, false, {"if set to true, all events, including calibration triggered events, will be accepted"}},
+                                       {"input-subspec", VariantType::UInt32, 0U, {"Subspecification for input objects"}},
                                        {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
   workflowOptions.insert(workflowOptions.end(), options.begin(), options.end());
 }
@@ -37,7 +38,11 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   // Update the (declared) parameters if changed from the command line
   bool makeCellIDTimeEnergy = cfgc.options().get<bool>("makeCellIDTimeEnergy");
   bool rejectCalibTrigg = !cfgc.options().get<bool>("no-rejectCalibTrigg");
+
+  // subpsecs for input
+  auto inputsubspec = cfgc.options().get<uint32_t>("input-subspec");
+
   o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
-  wf.emplace_back(o2::emcal::getEmcalOfflineCalibSpec(makeCellIDTimeEnergy, rejectCalibTrigg));
+  wf.emplace_back(o2::emcal::getEmcalOfflineCalibSpec(makeCellIDTimeEnergy, rejectCalibTrigg, inputsubspec));
   return wf;
 }

--- a/prodtests/full-system-test/calib-workflow.sh
+++ b/prodtests/full-system-test/calib-workflow.sh
@@ -27,7 +27,7 @@ if [[ $CALIB_TPC_RESPADGAIN == 1 ]]; then add_W o2-tpc-calib-gainmap-tracks "--p
 if [[ $CALIB_ZDC_TDC == 1 ]]; then add_W o2-zdc-tdccalib-epn-workflow "" "" 0; fi
 if [[ $CALIB_FT0_TIMEOFFSET == 1 ]]; then add_W o2-calibration-ft0-time-spectra-processor; fi
 # for async calibrations
-if [[ $CALIB_EMC_ASYNC_RECALIB == 1 ]]; then add_W o2-emcal-emc-offline-calib-workflow; fi
+if [[ $CALIB_EMC_ASYNC_RECALIB == 1 ]]; then add_W o2-emcal-emc-offline-calib-workflow --input-subspec 1; fi
 
 # output-proxy for aggregator
 if workflow_has_parameter CALIB_PROXIES; then


### PR DESCRIPTION
- During reconstruction, the offline calibrator needs to get uncalibrated cells. Therefore it needs to listen to subspecification 1 instead of 0
- Additionally changed the makeCellIDTimeEnergy default argument to false, as it is a bool and cannot be set to false in the workflow options