### PR TITLE
TPC: adding workflow for integrated cluster currents

### DIFF
--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCFactorization.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCFactorization.h
@@ -62,7 +62,8 @@ class IDCFactorization : public IDCGroupHelperSector
   /// calculate I_1(t) = <I(r,\phi,t) / I_0(r,\phi)>_{r,\phi}
   /// calculate \Delta I(r,\phi,t) = I(r,\phi,t) / ( I_0(r,\phi) * I_1(t) )
   /// \param norm normalize IDCs to pad size
-  void factorizeIDCs(const bool norm);
+  /// \param calcDeltas calculate the \Delta I(r,\phi,t) currents
+  void factorizeIDCs(const bool norm, const bool calcDeltas);
 
   /// calculate I_0(r,\phi) = <I(r,\phi,t)>_t
   void calcIDCZero(const bool norm);

--- a/Detectors/TPC/calibration/src/IDCFactorization.cxx
+++ b/Detectors/TPC/calibration/src/IDCFactorization.cxx
@@ -598,7 +598,7 @@ std::vector<unsigned int> o2::tpc::IDCFactorization::getAllIntegrationIntervalsP
   return integrationIntervalsPerTF;
 }
 
-void o2::tpc::IDCFactorization::factorizeIDCs(const bool norm)
+void o2::tpc::IDCFactorization::factorizeIDCs(const bool norm, const bool calcDeltas)
 {
   using timer = std::chrono::high_resolution_clock;
 
@@ -637,13 +637,15 @@ void o2::tpc::IDCFactorization::factorizeIDCs(const bool norm)
   LOGP(info, "IDC1 time: {}", time.count());
   totalTime += time.count();
 
-  LOGP(info, "Calculating IDCDelta");
-  start = timer::now();
-  calcIDCDelta();
-  stop = timer::now();
-  time = stop - start;
-  LOGP(info, "IDCDelta time: {}", time.count());
-  totalTime += time.count();
+  if (calcDeltas) {
+    LOGP(info, "Calculating IDCDelta");
+    start = timer::now();
+    calcIDCDelta();
+    stop = timer::now();
+    time = stop - start;
+    LOGP(info, "IDCDelta time: {}", time.count());
+    totalTime += time.count();
+  }
 
   LOGP(info, "Factorization done. Total time: {}", totalTime);
 }

--- a/Detectors/TPC/workflow/CMakeLists.txt
+++ b/Detectors/TPC/workflow/CMakeLists.txt
@@ -200,6 +200,11 @@ o2_add_executable(calib-gainmap-tracks
                   SOURCES src/tpc-calib-gainmap-tracks.cxx
                   PUBLIC_LINK_LIBRARIES O2::TPCWorkflow O2::GlobalTracking)
 
+o2_add_executable(integrate-clusters
+                  COMPONENT_NAME tpc
+                  SOURCES src/tpc-integrate-cluster-currents
+                  PUBLIC_LINK_LIBRARIES O2::TPCWorkflow)
+
 o2_add_test(workflow
             COMPONENT_NAME tpc
             LABELS tpc workflow

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCDistributeIDCSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCDistributeIDCSpec.h
@@ -26,6 +26,7 @@
 #include "Headers/DataHeader.h"
 #include "Framework/ConfigParamRegistry.h"
 #include "TPCWorkflow/TPCFLPIDCSpec.h"
+#include "TPCWorkflow/TPCIntegrateClusterCurrent.h"
 #include "TPCBase/CRU.h"
 #include "MemoryResources/MemoryResources.h"
 #include "TPCWorkflow/ProcessingHelpers.h"
@@ -42,13 +43,13 @@ namespace o2::tpc
 class TPCDistributeIDCSpec : public o2::framework::Task
 {
  public:
-  TPCDistributeIDCSpec(const std::vector<uint32_t>& crus, const unsigned int timeframes, const int nTFsBuffer, const unsigned int outlanes, const int firstTF, std::shared_ptr<o2::base::GRPGeomRequest> req)
-    : mCRUs{crus}, mTimeFrames{timeframes}, mNTFsBuffer{nTFsBuffer}, mOutLanes{outlanes}, mProcessedCRU{{std::vector<unsigned int>(timeframes), std::vector<unsigned int>(timeframes)}}, mTFStart{{firstTF, firstTF + timeframes}}, mTFEnd{{firstTF + timeframes - 1, mTFStart[1] + timeframes - 1}}, mCCDBRequest(req), mSendCCDBOutput(outlanes)
+  TPCDistributeIDCSpec(const std::vector<uint32_t>& crus, const unsigned int timeframes, const int nTFsBuffer, const unsigned int outlanes, const int firstTF, std::shared_ptr<o2::base::GRPGeomRequest> req, const bool processClusters)
+    : mCRUs{crus}, mTimeFrames{timeframes}, mNTFsBuffer{nTFsBuffer}, mOutLanes{outlanes}, mProcessedCRU{{std::vector<unsigned int>(timeframes), std::vector<unsigned int>(timeframes)}}, mTFStart{{firstTF, firstTF + timeframes}}, mTFEnd{{firstTF + timeframes - 1, mTFStart[1] + timeframes - 1}}, mCCDBRequest(req), mSendCCDBOutput(outlanes), mProcessClusters{processClusters}
   {
     // pre calculate data description for output
     mDataDescrOut.reserve(mOutLanes);
     for (unsigned int i = 0; i < mOutLanes; ++i) {
-      mDataDescrOut.emplace_back(getDataDescriptionIDC(i));
+      mDataDescrOut.emplace_back(getDataDescriptionIDC(i, mProcessClusters));
     }
 
     // sort vector for binary_search
@@ -64,10 +65,14 @@ class TPCDistributeIDCSpec : public o2::framework::Task
       }
     }
 
-    const auto sides = IDCFactorization::getSides(mCRUs);
-    for (auto side : sides) {
-      const std::string name = (side == Side::A) ? "idcsgroupa" : "idcsgroupc";
-      mFilter.emplace_back(InputSpec{name.data(), ConcreteDataTypeMatcher{o2::header::gDataOriginTPC, TPCFLPIDCDevice::getDataDescriptionIDCGroup(side)}, Lifetime::Timeframe});
+    if (!mProcessClusters) {
+      const auto sides = IDCFactorization::getSides(mCRUs);
+      for (auto side : sides) {
+        const std::string name = (side == Side::A) ? "idcsgroupa" : "idcsgroupc";
+        mFilter.emplace_back(InputSpec{name.data(), ConcreteDataTypeMatcher{o2::header::gDataOriginTPC, TPCFLPIDCDevice::getDataDescriptionIDCGroup(side)}, Lifetime::Timeframe});
+      }
+    } else {
+      mFilter.emplace_back(InputSpec{"iccs", ConcreteDataTypeMatcher{o2::header::gDataOriginTPC, TPCIntegrateClustersDevice::getDataDescription()}, Lifetime::Timeframe});
     }
   };
 
@@ -194,9 +199,9 @@ class TPCDistributeIDCSpec : public o2::framework::Task
   void endOfStream(o2::framework::EndOfStreamContext& ec) final { ec.services().get<ControlService>().readyToQuit(QuitRequest::Me); }
 
   /// return data description for aggregated IDCs for given lane
-  static header::DataDescription getDataDescriptionIDC(const unsigned int lane)
+  static header::DataDescription getDataDescriptionIDC(const unsigned int lane, const bool icc)
   {
-    const std::string name = fmt::format("IDCAGG{}", lane).data();
+    const std::string name = icc ? fmt::format("ICCAGG{}", lane).data() : fmt::format("IDCAGG{}", lane).data();
     header::DataDescription description;
     description.runtimeInit(name.substr(0, 16).c_str());
     return description;
@@ -218,6 +223,7 @@ class TPCDistributeIDCSpec : public o2::framework::Task
   std::array<bool, 2> mSendOutputStartInfo{true, true};                                ///< flag for sending the info for the start of the aggregation interval
   std::shared_ptr<o2::base::GRPGeomRequest> mCCDBRequest;                              ///< info for CCDB request
   std::vector<bool> mSendCCDBOutput{};                                                 ///< flag for sending CCDB output
+  const bool mProcessClusters{false};                                                  ///< processing ICCs instead of IDCs
   unsigned int mCurrentOutLane{0};                                                     ///< index for keeping track of the current output lane
   bool mBuffer{false};                                                                 ///< buffer index
   int mNFactorTFs{0};                                                                  ///< Number of TFs to skip for sending oldest TF
@@ -322,19 +328,23 @@ class TPCDistributeIDCSpec : public o2::framework::Task
   }
 };
 
-DataProcessorSpec getTPCDistributeIDCSpec(const int ilane, const std::vector<uint32_t>& crus, const unsigned int timeframes, const unsigned int outlanes, const int firstTF, const bool sendPrecisetimeStamp = false, const int nTFsBuffer = 1)
+DataProcessorSpec getTPCDistributeIDCSpec(const int ilane, const std::vector<uint32_t>& crus, const unsigned int timeframes, const unsigned int outlanes, const int firstTF, const bool sendPrecisetimeStamp = false, const int nTFsBuffer = 1, const bool processClusters = false)
 {
   std::vector<InputSpec> inputSpecs;
-  const auto sides = IDCFactorization::getSides(crus);
-  for (auto side : sides) {
-    const std::string name = (side == Side::A) ? "idcsgroupa" : "idcsgroupc";
-    inputSpecs.emplace_back(InputSpec{name.data(), ConcreteDataTypeMatcher{gDataOriginTPC, TPCFLPIDCDevice::getDataDescriptionIDCGroup(side)}, Lifetime::Sporadic});
+  if (!processClusters) {
+    const auto sides = IDCFactorization::getSides(crus);
+    for (auto side : sides) {
+      const std::string name = (side == Side::A) ? "idcsgroupa" : "idcsgroupc";
+      inputSpecs.emplace_back(InputSpec{name.data(), ConcreteDataTypeMatcher{gDataOriginTPC, TPCFLPIDCDevice::getDataDescriptionIDCGroup(side)}, Lifetime::Sporadic});
+    }
+  } else {
+    inputSpecs.emplace_back(InputSpec{"iccs", ConcreteDataTypeMatcher{gDataOriginTPC, TPCIntegrateClustersDevice::getDataDescription()}, Lifetime::Sporadic});
   }
 
   std::vector<OutputSpec> outputSpecs;
   outputSpecs.reserve(outlanes);
   for (unsigned int lane = 0; lane < outlanes; ++lane) {
-    outputSpecs.emplace_back(ConcreteDataTypeMatcher{gDataOriginTPC, TPCDistributeIDCSpec::getDataDescriptionIDC(lane)}, Lifetime::Sporadic);
+    outputSpecs.emplace_back(ConcreteDataTypeMatcher{gDataOriginTPC, TPCDistributeIDCSpec::getDataDescriptionIDC(lane, processClusters)}, Lifetime::Sporadic);
     outputSpecs.emplace_back(ConcreteDataMatcher{gDataOriginTPC, TPCDistributeIDCSpec::getDataDescriptionIDCFirstTF(), header::DataHeader::SubSpecificationType{lane}}, Lifetime::Sporadic);
   }
 
@@ -354,12 +364,13 @@ DataProcessorSpec getTPCDistributeIDCSpec(const int ilane, const std::vector<uin
                                                                 o2::base::GRPGeomRequest::None, // geometry
                                                                 inputSpecs);
 
-  const auto id = fmt::format("tpc-distribute-idc-{:02}", ilane);
+  const std::string type = processClusters ? "icc" : "idc";
+  const auto id = fmt::format("tpc-distribute-{}-{:02}", type, ilane);
   DataProcessorSpec spec{
     id.data(),
     inputSpecs,
     outputSpecs,
-    AlgorithmSpec{adaptFromTask<TPCDistributeIDCSpec>(crus, timeframes, nTFsBuffer, outlanes, firstTF, ccdbRequest)},
+    AlgorithmSpec{adaptFromTask<TPCDistributeIDCSpec>(crus, timeframes, nTFsBuffer, outlanes, firstTF, ccdbRequest, processClusters)},
     Options{{"drop-data-after-nTFs", VariantType::Int, 0, {"Number of TFs after which to drop the data."}},
             {"check-data-every-n", VariantType::Int, 0, {"Number of run function called after which to check for missing data (-1 for no checking, 0 for default checking)."}},
             {"nFactorTFs", VariantType::Int, 1000, {"Number of TFs to skip for sending oldest TF."}}}}; // end DataProcessorSpec

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCIntegrateClusterCurrent.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCIntegrateClusterCurrent.h
@@ -1,0 +1,150 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   TPCIntegrateClusterCurrent.h
+/// \author Matthias Kleiner, mkleiner@ikf.uni-frankfurt.de
+
+#ifndef O2_CALIBRATION_TPCINTEGRATECLUSTERCURRENT_H
+#define O2_CALIBRATION_TPCINTEGRATECLUSTERCURRENT_H
+
+#include "Framework/Task.h"
+#include "Framework/Logger.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/DataProcessorSpec.h"
+#include "DataFormatsTPC/WorkflowHelper.h"
+#include "TPCWorkflow/ProcessingHelpers.h"
+#include "TPCBase/Mapper.h"
+#include "DetectorsBase/GRPGeomHelper.h"
+
+using namespace o2::framework;
+using o2::header::gDataOriginTPC;
+using namespace o2::tpc;
+
+namespace o2
+{
+namespace tpc
+{
+
+class TPCIntegrateClustersDevice : public o2::framework::Task
+{
+ public:
+  TPCIntegrateClustersDevice(std::shared_ptr<o2::base::GRPGeomRequest> req) : mCCDBRequest(req) {}
+
+  void init(o2::framework::InitContext& ic) final
+  {
+    o2::base::GRPGeomHelper::instance().setRequest(mCCDBRequest);
+    mNSlicesTF = ic.options().get<int>("nSlicesTF");
+  }
+
+  void finaliseCCDB(ConcreteDataMatcher& matcher, void* obj) final { o2::base::GRPGeomHelper::instance().finaliseCCDB(matcher, obj); }
+
+  void run(o2::framework::ProcessingContext& pc) final
+  {
+    // fetch only once
+    if (mContinuousMaxTimeBin < 0) {
+      o2::base::GRPGeomHelper::instance().checkUpdates(pc);
+      mContinuousMaxTimeBin = (base::GRPGeomHelper::instance().getGRPECS()->getNHBFPerTF() * o2::constants::lhc::LHCMaxBunches + 2 * o2::tpc::constants::LHCBCPERTIMEBIN - 2) / o2::tpc::constants::LHCBCPERTIMEBIN;
+    }
+
+    const auto& clusters = getWorkflowTPCInput(pc);
+    const o2::tpc::ClusterNativeAccess& clIndex = clusters->clusterIndex;
+    const auto nCL = clIndex.nClustersTotal;
+    LOGP(info, "Processing TF {} with {} clusters", processing_helpers::getCurrentTF(pc), nCL);
+
+    // init only once
+    if (mInitICCBuffer) {
+      mNTSPerSlice = mContinuousMaxTimeBin / mNSlicesTF;
+      for (unsigned int i = 0; i < o2::tpc::CRU::MaxCRU; ++i) {
+        mICCS[i].resize(mNSlicesTF * Mapper::PADSPERREGION[CRU(i).region()]);
+      }
+      mInitICCBuffer = false;
+    }
+
+    // loop over clusters and integrate
+    for (int isector = 0; isector < constants::MAXSECTOR; ++isector) {
+      for (int irow = 0; irow < constants::MAXGLOBALPADROW; ++irow) {
+        const int nClusters = clIndex.nClusters[isector][irow];
+        if (!nClusters) {
+          continue;
+        }
+        const CRU cru(Sector(isector), Mapper::REGION[irow]);
+
+        for (int icl = 0; icl < nClusters; ++icl) {
+          const auto& cl = *(clIndex.clusters[isector][irow] + icl);
+          const float time = cl.getTime();
+          const unsigned int sliceInTF = time / mNTSPerSlice;
+          if (sliceInTF < mNSlicesTF) {
+            const float qMax = cl.getQmax();
+            const unsigned int padInCRU = Mapper::OFFSETCRUGLOBAL[irow] + static_cast<int>(cl.getPad() + 0.5f);
+            mICCS[cru][sliceInTF * Mapper::PADSPERREGION[cru.region()] + padInCRU] += qMax;
+          } else {
+            LOGP(info, "slice in TF of ICC {} is larger than max slice {} with nTSPerSlice {}", sliceInTF, mNSlicesTF, mNTSPerSlice);
+          }
+        }
+      }
+    }
+    sendOutput(pc.outputs());
+  }
+
+  static constexpr header::DataDescription getDataDescription() { return header::DataDescription{"ICC"}; }
+
+ private:
+  std::shared_ptr<o2::base::GRPGeomRequest> mCCDBRequest;     ///< for accessing the b-field
+  int mNSlicesTF{1};                                          ///< number of slices the TFs are divided into for integration of clusters currents
+  int mContinuousMaxTimeBin{-1};                              ///< max time bin of clusters
+  std::array<std::vector<float>, o2::tpc::CRU::MaxCRU> mICCS; ///< buffer for ICCs
+  bool mInitICCBuffer{true};                                  ///< flag for initializing ICCs only once
+  int mNTSPerSlice{1};                                        ///< number of time stamps per slice
+
+  void sendOutput(DataAllocator& output)
+  {
+    for (unsigned int i = 0; i < o2::tpc::CRU::MaxCRU; ++i) {
+      // normalize ICCs
+      const float norm = 1. / float(mNTSPerSlice);
+      std::transform(mICCS[i].begin(), mICCS[i].end(), mICCS[i].begin(), [norm](float& val) { return val * norm; });
+
+      output.snapshot(Output{gDataOriginTPC, getDataDescription(), o2::header::DataHeader::SubSpecificationType{i << 7}, Lifetime::Timeframe}, mICCS[i]);
+      std::fill(mICCS[i].begin(), mICCS[i].end(), 0);
+    }
+  }
+};
+
+DataProcessorSpec getTPCIntegrateClustersSpec()
+{
+  std::vector<InputSpec> inputs;
+  inputs.emplace_back("clusTPC", ConcreteDataTypeMatcher{gDataOriginTPC, "CLUSTERNATIVE"}, Lifetime::Timeframe);
+
+  std::vector<OutputSpec> outputs;
+  for (unsigned int i = 0; i < o2::tpc::CRU::MaxCRU; ++i) {
+    outputs.emplace_back(gDataOriginTPC, TPCIntegrateClustersDevice::getDataDescription(), header::DataHeader::SubSpecificationType{i << 7}, o2::framework::Lifetime::Sporadic);
+  }
+
+  auto ccdbRequest = std::make_shared<o2::base::GRPGeomRequest>(false,                          // orbitResetTime
+                                                                true,                           // GRPECS=true
+                                                                false,                          // GRPLHCIF
+                                                                false,                          // GRPMagField
+                                                                false,                          // askMatLUT
+                                                                o2::base::GRPGeomRequest::None, // geometry
+                                                                inputs);
+
+  return DataProcessorSpec{
+    "integrate-tpc-clusters",
+    inputs,
+    outputs,
+    AlgorithmSpec{adaptFromTask<TPCIntegrateClustersDevice>(ccdbRequest)},
+    Options{
+      {"nSlicesTF", VariantType::Int, 2, {"Divide the TF into n slices"}}}}; // end DataProcessorSpec
+}
+
+} // namespace tpc
+} // namespace o2
+
+#endif

--- a/Detectors/TPC/workflow/src/tpc-distribute-idc.cxx
+++ b/Detectors/TPC/workflow/src/tpc-distribute-idc.cxx
@@ -40,7 +40,8 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"lanes", VariantType::Int, 1, {"Number of lanes of this device (CRUs are split per lane)"}},
     {"send-precise-timestamp", VariantType::Bool, false, {"Send precise timestamp which can be used for writing to CCDB"}},
     {"n-TFs-buffer", VariantType::Int, 1, {"Buffer which was defined in the TPCFLPIDCSpec."}},
-    {"output-lanes", VariantType::Int, 2, {"Number of parallel pipelines which will be used in the factorization device."}}};
+    {"output-lanes", VariantType::Int, 2, {"Number of parallel pipelines which will be used in the factorization device."}},
+    {"processClusters", VariantType::Bool, false, {"Processing clusters as input instead of IDCs"}}};
 
   std::swap(workflowOptions, options);
 }
@@ -62,6 +63,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
   const auto nLanes = static_cast<unsigned int>(config.options().get<int>("lanes"));
   const auto firstTF = static_cast<unsigned int>(config.options().get<int>("firstTF"));
   const bool sendPrecisetimeStamp = config.options().get<bool>("send-precise-timestamp");
+  const bool processClusters = config.options().get<bool>("processClusters");
   int nTFsBuffer = config.options().get<int>("n-TFs-buffer");
   if (nTFsBuffer <= 0) {
     nTFsBuffer = 1;
@@ -78,7 +80,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
     }
     const auto last = std::min(tpcCRUs.end(), first + crusPerLane);
     const std::vector<uint32_t> rangeCRUs(first, last);
-    workflow.emplace_back(getTPCDistributeIDCSpec(ilane, rangeCRUs, timeframes, outlanes, firstTF, sendPrecisetimeStamp, nTFsBuffer));
+    workflow.emplace_back(getTPCDistributeIDCSpec(ilane, rangeCRUs, timeframes, outlanes, firstTF, sendPrecisetimeStamp, nTFsBuffer, processClusters));
   }
 
   return workflow;

--- a/Detectors/TPC/workflow/src/tpc-factorize-idc.cxx
+++ b/Detectors/TPC/workflow/src/tpc-factorize-idc.cxx
@@ -51,7 +51,8 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"use-precise-timestamp", VariantType::Bool, false, {"Use precise timestamp from distribute when writing to CCDB"}},
     {"enable-CCDB-output", VariantType::Bool, false, {"send output for ccdb populator"}},
     {"n-TFs-buffer", VariantType::Int, 1, {"Buffer which was defined in the TPCFLPIDCSpec."}},
-    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings (e.g. for pp 50kHz: 'TPCIDCCompressionParam.maxIDCDeltaValue=15;')"}}};
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings (e.g. for pp 50kHz: 'TPCIDCCompressionParam.maxIDCDeltaValue=15;')"}},
+    {"processClusters", VariantType::Bool, false, {"Processing clusters as input instead of IDCs"}}};
 
   std::swap(workflowOptions, options);
 }
@@ -66,6 +67,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
   const std::string sgroupRows = config.options().get<std::string>("groupRows");
   const std::string sgroupLastRowsThreshold = config.options().get<std::string>("groupLastRowsThreshold");
   const std::string sgroupLastPadsThreshold = config.options().get<std::string>("groupLastPadsThreshold");
+  const bool processClusters = config.options().get<bool>("processClusters");
   ParameterIDCGroup::setGroupingParameterFromString(sgroupPads, sgroupRows, sgroupLastRowsThreshold, sgroupLastPadsThreshold);
 
   // set up configuration
@@ -114,7 +116,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& config)
   WorkflowSpec workflow;
   workflow.reserve(nLanes);
   for (int ilane = 0; ilane < nLanes; ++ilane) {
-    workflow.emplace_back(getTPCFactorizeIDCSpec(ilane, rangeCRUs, timeframes, timeframesDeltaIDC, compression, usePrecisetimeStamp, sendOutputFFT, sendCCDB, nTFsBuffer));
+    workflow.emplace_back(getTPCFactorizeIDCSpec(ilane, rangeCRUs, timeframes, timeframesDeltaIDC, compression, usePrecisetimeStamp, sendOutputFFT, sendCCDB, nTFsBuffer, processClusters));
   }
   return workflow;
 }

--- a/Detectors/TPC/workflow/src/tpc-integrate-cluster-currents.cxx
+++ b/Detectors/TPC/workflow/src/tpc-integrate-cluster-currents.cxx
@@ -1,0 +1,57 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   tpc-integrate-cluster-currents.cxx
+/// \author Matthias Kleiner, mkleiner@ikf.uni-frankfurt.de
+
+#include <vector>
+#include <string>
+#include "Framework/WorkflowSpec.h"
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicy.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "TPCWorkflow/TPCIntegrateClusterCurrent.h"
+#include "TPCReaderWorkflow/TPCSectorCompletionPolicy.h"
+
+using namespace o2::framework;
+
+// customize the completion policy
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  policies.push_back(o2::tpc::TPCSectorCompletionPolicy("calib-tpc-gainmap-tracks",
+                                                        o2::tpc::TPCSectorCompletionPolicy::Config::RequireAll,
+                                                        InputSpec{"cluster", ConcreteDataTypeMatcher{"TPC", "CLUSTERNATIVE"}})());
+}
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  std::vector<ConfigParamSpec> options{
+    {"configFile", VariantType::String, "", {"configuration file for configurable parameters"}},
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
+
+  std::swap(workflowOptions, options);
+}
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& config)
+{
+  using namespace o2::tpc;
+
+  // set up configuration
+  o2::conf::ConfigurableParam::updateFromFile(config.options().get<std::string>("configFile"));
+  o2::conf::ConfigurableParam::updateFromString(config.options().get<std::string>("configKeyValues"));
+  o2::conf::ConfigurableParam::writeINI("o2tpcintegrateclusters_configuration.ini");
+
+  WorkflowSpec workflow{getTPCIntegrateClustersSpec()};
+  return workflow;
+}


### PR DESCRIPTION
Adding workflow for integrating the cluster charge qMax. The integrated cluster charges (ICCs) are similar to the IDCs and can be used for QA, validation of IDCs and/or for calibration in case IDCs are not available.
The format of the ICCs is currently the same as for the IDCs (`std::vector<float>` per CRU), which allows to use the same workflows for processing of the ICCs. The writing of the ICCs to CCDB is disabled for now.

Example from pp MC:
ICCs for A Side: [ICC_A.pdf](https://github.com/AliceO2Group/AliceO2/files/10143385/ICC_A.pdf)
IDCs for A Side: [IDC_A.pdf](https://github.com/AliceO2Group/AliceO2/files/10143397/IDC_A.pdf)

