### PR TITLE
TRD add reading/usage of T0 calibration value

### DIFF
--- a/Detectors/TRD/base/include/TRDBase/TrackletTransformer.h
+++ b/Detectors/TRD/base/include/TRDBase/TrackletTransformer.h
@@ -16,6 +16,7 @@
 #include "DataFormatsTRD/Tracklet64.h"
 #include "DataFormatsTRD/CalibratedTracklet.h"
 #include "DataFormatsTRD/CalVdriftExB.h"
+#include "DataFormatsTRD/CalT0.h"
 
 namespace o2
 {
@@ -43,13 +44,15 @@ class TrackletTransformer
   void setCalVdriftExB(const CalVdriftExB* cal) { mCalVdriftExB = cal; };
   void setApplyXOR() { mApplyXOR = true; }
 
+  void setCalT0(const CalT0* cal) { mCalT0 = cal; }
+
   float calculateY(int hcid, int column, int position, const PadPlane* padPlane) const;
 
   float calculateZ(int padrow, const PadPlane* padPlane) const;
 
   float calculateDy(int hcid, int slope, const PadPlane* padPlane) const;
 
-  float calibrateX(double x) const;
+  float calibrateX(int detector, float x) const;
 
   std::array<float, 3> transformL2T(int hcid, std::array<double, 3> spacePoint) const;
 
@@ -67,6 +70,7 @@ class TrackletTransformer
   float mXtb0;
 
   const CalVdriftExB* mCalVdriftExB{nullptr};
+  const CalT0* mCalT0{nullptr};
 };
 
 } // namespace trd

--- a/Detectors/TRD/base/src/TrackletTransformer.cxx
+++ b/Detectors/TRD/base/src/TrackletTransformer.cxx
@@ -75,10 +75,11 @@ float TrackletTransformer::calculateDy(int detector, int slope, const PadPlane* 
   return calibratedDy;
 }
 
-float TrackletTransformer::calibrateX(double x) const
+float TrackletTransformer::calibrateX(int detector, float x) const
 {
-  // Hard-coded value will be replaced once t0 calibration is available from CCDB
-  float t0Correction = -0.279;
+  // NOTE: Calibration value is average over all chambers, stored in PHOS hole (chamber 435)
+  //       option to use chamber-wise values will be implemented in the future
+  float t0Correction = mCalT0->getT0(435);
   return x += t0Correction;
 }
 
@@ -123,7 +124,7 @@ CalibratedTracklet TrackletTransformer::transformTracklet(Tracklet64 tracklet, b
 
   float dy = calculateDy(detector, slope, padPlane);
 
-  float calibratedX = calibrateX(x);
+  float calibratedX = calibrateX(detector, x);
 
   // NOTE: Correction to y position based on x calibration NOT YET implemented. Need t0.
   if (trackingFrame) {

--- a/Detectors/TRD/workflow/src/TRDTrackletTransformerSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDTrackletTransformerSpec.cxx
@@ -127,6 +127,8 @@ void TRDTrackletTransformerSpec::updateTimeDependentParams(ProcessingContext& pc
     mTransformer.init();
   }
   pc.inputs().get<o2::trd::CalVdriftExB*>("calvdexb"); // just to trigger the finaliseCCDB
+
+  pc.inputs().get<o2::trd::CalT0*>("calt0"); // just to trigger the finaliseCCDB, added for T0 calibration
 }
 
 void TRDTrackletTransformerSpec::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
@@ -137,6 +139,11 @@ void TRDTrackletTransformerSpec::finaliseCCDB(ConcreteDataMatcher& matcher, void
   if (matcher == ConcreteDataMatcher("TRD", "CALVDRIFTEXB", 0)) {
     LOG(info) << "CalVdriftExB object has been updated";
     mTransformer.setCalVdriftExB((const o2::trd::CalVdriftExB*)obj);
+    return;
+  }
+  if (matcher == ConcreteDataMatcher("TRD", "CALT0", 0)) {
+    LOG(info) << "CalT0 object has been updatet";
+    mTransformer.setCalT0((const o2::trd::CalT0*)obj);
     return;
   }
 }
@@ -151,6 +158,7 @@ o2::framework::DataProcessorSpec getTRDTrackletTransformerSpec(bool trigRecFilte
   inputs.emplace_back("trdtracklets", "TRD", "TRACKLETS", 0, Lifetime::Timeframe);
   inputs.emplace_back("trdtriggerrec", "TRD", "TRKTRGRD", 0, Lifetime::Timeframe);
   inputs.emplace_back("calvdexb", "TRD", "CALVDRIFTEXB", 0, Lifetime::Condition, ccdbParamSpec("TRD/Calib/CalVdriftExB"));
+  inputs.emplace_back("calt0", "TRD", "CALT0", 0, Lifetime::Condition, ccdbParamSpec("TRD/Calib/CalT0"));
   auto ggRequest = std::make_shared<o2::base::GRPGeomRequest>(false,                             // orbitResetTime
                                                               false,                             // GRPECS=true
                                                               false,                             // GRPLHCIF


### PR DESCRIPTION
To read and use the (average) TRD T0 calibration value in the TRD Tracklet Transformer from the (test-)CCDB.