### PR TITLE
TPC: Add option to shift TPC clusters during decoding

### DIFF
--- a/GPU/GPUTracking/DataCompression/TPCClusterDecompressor.cxx
+++ b/GPU/GPUTracking/DataCompression/TPCClusterDecompressor.cxx
@@ -86,6 +86,19 @@ int TPCClusterDecompressor::decompress(const CompressedClusters* clustersCompres
       ClusterNative* cl = buffer + clusters[i][j].size();
       unsigned int end = offsets[i][j] + ((i * GPUCA_ROW_COUNT + j >= clustersCompressed->nSliceRows) ? 0 : clustersCompressed->nSliceRowClusters[i * GPUCA_ROW_COUNT + j]);
       decompressHits(clustersCompressed, offsets[i][j], end, cl);
+      if (param.rec.tpc.clustersShiftTimebins != 0.f) {
+        for (unsigned int k = 0; k < clustersNative.nClusters[i][j]; k++) {
+          auto& cl = buffer[k];
+          float t = cl.getTime() + param.rec.tpc.clustersShiftTimebins;
+          if (t < 0) {
+            t = 0;
+          }
+          if (param.par.continuousMaxTimeBin > 0 && t > param.par.continuousMaxTimeBin) {
+            t = param.par.continuousMaxTimeBin;
+          }
+          cl.setTime(t);
+        }
+      }
       std::sort(buffer, buffer + clustersNative.nClusters[i][j]);
     }
   }

--- a/GPU/GPUTracking/Definitions/GPUSettingsList.h
+++ b/GPU/GPUTracking/Definitions/GPUSettingsList.h
@@ -47,6 +47,7 @@ AddOptionRTC(trackReferenceX, float, 1000.f, "", 0, "Transport all tracks to thi
 AddOptionRTC(zsThreshold, float, 2.0f, "", 0, "Zero-Suppression threshold")
 AddOptionRTC(tubeChi2, float, 5.f * 5.f, "", 0, "Max chi2 to mark cluster adjacent to track")
 AddOptionRTC(tubeMaxSize2, float, 2.5f * 2.5f, "", 0, "Square of max tube size (normally derrived from tpcTubeChi2)")
+AddOptionRTC(clustersShiftTimebins, float, 0, "", 0, "Shift of TPC clusters (applied during CTF cluster decoding)")
 AddOptionRTC(maxTimeBinAboveThresholdIn1000Bin, unsigned short, 500, "", 0, "Except pad from cluster finding if total number of charges in a fragment is above this baseline (disable = 0)")
 AddOptionRTC(maxConsecTimeBinAboveThreshold, unsigned short, 200, "", 0, "Except pad from cluster finding if number of consecutive charges in a fragment is above this baseline (disable = 0)")
 AddOptionRTC(noisyPadSaturationThreshold, unsigned short, 700, "", 0, "Threshold where a timebin is considered saturated, disabling the noisy pad check for that pad")


### PR DESCRIPTION
@shahor02 : as written on Mattermost, didn't compile it, but logic should be correct.
To set the option, use `--configKeyValues "GPU_rec_tpc.clustersShiftTimebins"`