### PR TITLE
TRD: CalibratorVdExB: Fix minimal entries init

### DIFF
--- a/Detectors/TRD/calibration/include/TRDCalibration/CalibratorVdExB.h
+++ b/Detectors/TRD/calibration/include/TRDCalibration/CalibratorVdExB.h
@@ -22,6 +22,7 @@
 #include "DataFormatsTRD/AngularResidHistos.h"
 #include "CCDB/CcdbObjectInfo.h"
 #include "DataFormatsTRD/CalVdriftExB.h"
+#include "TRDCalibration/CalibrationParams.h"
 
 #include "Rtypes.h"
 #include "TProfile.h"
@@ -85,19 +86,20 @@ class CalibratorVdExB final : public o2::calibration::TimeSlotCalibration<o2::tr
   void retrievePrev(o2::framework::ProcessingContext& pc);
 
  private:
-  bool mInitDone{false};                             ///< flag to avoid creating the TProfiles multiple times
-  size_t mMinEntriesTotal;                           ///< minimum total number of angular deviations (on average ~3 entries per bin for each TRD chamber)
-  size_t mMinEntriesChamber;                         ///< minimum number of angular deviations per chamber for accepting refitted value (~3 per bin)
-  bool mEnableOutput;                                ///< enable output of calibration fits and tprofiles in a root file instead of the ccdb
-  std::unique_ptr<TFile> mOutFile{nullptr};          ///< output file
-  std::unique_ptr<TTree> mOutTree{nullptr};          ///< output tree
-  FitFunctor mFitFunctor;                            ///< used for minimization procedure
-  std::vector<o2::ccdb::CcdbObjectInfo> mInfoVector; ///< vector of CCDB infos; each element is filled with CCDB description of accompanying CCDB calibration object
-  std::vector<o2::trd::CalVdriftExB> mObjectVector;  ///< vector of CCDB calibration objects; the extracted vDrift and ExB per chamber for given slot
-  ROOT::Fit::Fitter mFitter;                         ///< Fitter object will be reused across slots
-  double mParamsStart[2];                            ///< Start fit parameter
+  bool mInitDone{false};                                     ///< flag to avoid creating the TProfiles multiple times
+  const TRDCalibParams& mParams{TRDCalibParams::Instance()}; ///< reference to calibration parameters
+  size_t mMinEntriesTotal{mParams.minEntriesChamber};        ///< minimum total number of angular deviations (on average ~3 entries per bin for each TRD chamber)
+  size_t mMinEntriesChamber{mParams.minEntriesTotal};        ///< minimum number of angular deviations per chamber for accepting refitted value (~3 per bin)
+  bool mEnableOutput;                                        ///< enable output of calibration fits and tprofiles in a root file instead of the ccdb
+  std::unique_ptr<TFile> mOutFile{nullptr};                  ///< output file
+  std::unique_ptr<TTree> mOutTree{nullptr};                  ///< output tree
+  FitFunctor mFitFunctor;                                    ///< used for minimization procedure
+  std::vector<o2::ccdb::CcdbObjectInfo> mInfoVector;         ///< vector of CCDB infos; each element is filled with CCDB description of accompanying CCDB calibration object
+  std::vector<o2::trd::CalVdriftExB> mObjectVector;          ///< vector of CCDB calibration objects; the extracted vDrift and ExB per chamber for given slot
+  ROOT::Fit::Fitter mFitter;                                 ///< Fitter object will be reused across slots
+  double mParamsStart[2];                                    ///< Start fit parameter
 
-  ClassDefOverride(CalibratorVdExB, 4);
+  ClassDefOverride(CalibratorVdExB, 5);
 };
 
 } // namespace trd

--- a/Detectors/TRD/calibration/src/CalibratorVdExB.cxx
+++ b/Detectors/TRD/calibration/src/CalibratorVdExB.cxx
@@ -14,7 +14,6 @@
 /// \author Ole Schmidt
 
 #include "TRDCalibration/CalibratorVdExB.h"
-#include "TRDCalibration/CalibrationParams.h"
 #include "Framework/ProcessingContext.h"
 #include "Framework/TimingInfo.h"
 #include "Framework/InputRecord.h"
@@ -134,11 +133,6 @@ void CalibratorVdExB::initProcessing()
       mOutTree->Branch(fmt::format("residuals_{:d}", iDet).c_str(), mFitFunctor.profiles[iDet].get());
     }
   }
-
-  // get parameters
-  auto& params = TRDCalibParams::Instance();
-  mMinEntriesChamber = params.minEntriesChamber;
-  mMinEntriesTotal = params.minEntriesTotal;
 
   mInitDone = true;
 }


### PR DESCRIPTION
Fixes a bug, which was introduced in PR #10053, where both fields for minimal entries were not properly initialized. initProcessing would only be called once hasEnoughData evaluates to true, hence minEntriesTotal would never be properly set. While running locally these probably init to 0. However this caused problems while running on the grid.

I tested it by inspecting the values for both after initialization of CalibratorVdExB in VdAndExBCalibSpec::init(). Now whenever the device is created the calibration parameters are immediately initialized.

Signed-off-by: Felix Schlepper <f3sch.git@outlook.com>