### PR TITLE
MCTrack proxy: option to pass source PID or to find socketfile

### DIFF
--- a/run/SimExamples/MCTrackToDPL/run.sh
+++ b/run/SimExamples/MCTrackToDPL/run.sh
@@ -7,7 +7,7 @@ o2-sim -j 1 -g pythia8pp -n 100 --noDiscOutput --forwardKine --noGeant -m CAVE -
 SIMPROC=$!
 
 # launch a DPL process (having the right proxy configuration)
-o2-sim-mctracks-proxy --enable-test-consumer &> out_mcanalysis.log &
+o2-sim-mctracks-proxy --enable-test-consumer --o2sim-pid ${SIMPROC} &> out_mcanalysis.log &
 TRACKANAPROC=$!
 
 wait ${SIMPROC}


### PR DESCRIPTION
This makes the connection between o2-sim and MCTrack DPL proxy more error resilient. We can now specify the pid to connect to which will help in case multiple o2-sim are running at the same time.

In future this might become obsolete with a pipelining mechanism.