### PR TITLE
o2-sim: Generalized vertex sampling

### DIFF
--- a/DataFormats/Calibration/include/DataFormatsCalibration/MeanVertexObject.h
+++ b/DataFormats/Calibration/include/DataFormatsCalibration/MeanVertexObject.h
@@ -69,6 +69,9 @@ class MeanVertexObject : public VertexBase
   void print() const;
   std::string asString() const;
 
+  /// sample a vertex from the MeanVertex parameters
+  math_utils::Point3D<float> sample() const;
+
   VertexBase getMeanVertex(float z) const
   {
     // set z-dependent x,z, assuming that the cov.matrix is already set

--- a/DataFormats/Calibration/src/MeanVertexObject.cxx
+++ b/DataFormats/Calibration/src/MeanVertexObject.cxx
@@ -10,6 +10,7 @@
 // or submit itself to any jurisdiction.
 
 #include "DataFormatsCalibration/MeanVertexObject.h"
+#include "TRandom.h"
 
 namespace o2
 {
@@ -57,6 +58,16 @@ std::ostream& operator<<(std::ostream& os, const o2::dataformats::MeanVertexObje
 void MeanVertexObject::print() const
 {
   std::cout << *this << std::endl;
+}
+
+math_utils::Point3D<float> MeanVertexObject::sample() const
+{
+  // this assumes gaussian sampling
+  // first determine z; then x and y
+  const auto z = gRandom->Gaus(getZ(), getSigmaZ());
+  const auto x = gRandom->Gaus(getXAtZ(z), getSigmaX());
+  const auto y = gRandom->Gaus(getYAtZ(z), getSigmaY());
+  return math_utils::Point3D<float>(x, y, z);
 }
 
 } // namespace dataformats

--- a/DataFormats/simulation/CMakeLists.txt
+++ b/DataFormats/simulation/CMakeLists.txt
@@ -23,6 +23,7 @@ o2_add_library(SimulationDataFormat
                                      FairRoot::Base
                                      O2::DetectorsCommonDataFormats
                                      O2::DataFormatsParameters
+                                     O2::DataFormatsCalibration
                                      O2::GPUCommon
                                      ROOT::TreePlayer)
 

--- a/DataFormats/simulation/include/SimulationDataFormat/DigitizationContext.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/DigitizationContext.h
@@ -21,6 +21,8 @@
 #include "DataFormatsParameters/GRPObject.h"
 #include <GPUCommonLogger.h>
 #include <unordered_map>
+#include <MathUtils/Cartesian.h>
+#include <DataFormatsCalibration/MeanVertexObject.h>
 
 namespace o2
 {
@@ -122,6 +124,10 @@ class DigitizationContext
   // finalize timeframe structure (fixes the indices in mTimeFrameStartIndex)
   void finalizeTimeframeStructure(long startOrbit, long orbitsPerTF);
 
+  // Sample and fix interaction vertices (according to some distribution). Makes sure that same event id
+  // have to have same vertex.
+  void sampleInteractionVertices(o2::dataformats::MeanVertexObject const& v);
+
   // helper functions to save and load a context
   void saveToFile(std::string_view filename) const;
 
@@ -137,6 +143,9 @@ class DigitizationContext
   std::vector<o2::InteractionTimeRecord> mEventRecords;
   // for each collision we record the constituents (which shall not exceed mMaxPartNumber)
   std::vector<std::vector<o2::steer::EventPart>> mEventParts;
+
+  // for each collision we may record/fix the interaction vertex (to be used in event generation)
+  std::vector<math_utils::Point3D<float>> mInteractionVertices;
 
   // the collision records _with_ QED interleaved;
   std::vector<o2::InteractionTimeRecord> mEventRecordsWithQED;

--- a/Generators/include/Generators/InteractionDiamondParam.h
+++ b/Generators/include/Generators/InteractionDiamondParam.h
@@ -36,6 +36,8 @@ enum class EVertexDistribution {
 struct InteractionDiamondParam : public o2::conf::ConfigurableParamHelper<InteractionDiamondParam> {
   double position[3] = {0., 0., 0.};
   double width[3] = {0., 0., 0.};
+  double slopeX = 0.; // z-dependent x pos (see MeanVertexObject)
+  double slopeY = 0.; // z-dependent y pos (see MeanVertexObject)
   EVertexDistribution distribution = EVertexDistribution::kGaus;
   O2ParamDef(InteractionDiamondParam, "Diamond");
 };

--- a/Generators/include/Generators/PrimaryGenerator.h
+++ b/Generators/include/Generators/PrimaryGenerator.h
@@ -71,6 +71,8 @@ class PrimaryGenerator : public FairPrimaryGenerator
   /** Public embedding methods **/
   Bool_t embedInto(TString fname);
 
+  void setExternalVertexForNextEvent(double x, double y, double z);
+
  protected:
   /** copy constructor **/
   PrimaryGenerator(const PrimaryGenerator&) = default;
@@ -82,6 +84,12 @@ class PrimaryGenerator : public FairPrimaryGenerator
 
   /** set interaction vertex position **/
   void setInteractionVertex(const o2::dataformats::MCEventHeader* event);
+
+  /** generate and fix interaction vertex **/
+  void fixInteractionVertex();
+
+  float mExternalVertexX = 0, mExternalVertexY = 0, mExternalVertexZ = 0; // holding vertex fixed from outside
+  bool mHaveExternalVertex = false;                                       // true of user fixed external vertex from outside for next event
 
   /** embedding members **/
   TFile* mEmbedFile = nullptr;

--- a/Steer/src/CollisionContextTool.cxx
+++ b/Steer/src/CollisionContextTool.cxx
@@ -16,12 +16,15 @@
 #include <regex>
 #include "Steer/InteractionSampler.h"
 #include "CommonDataFormat/InteractionRecord.h"
+#include "DataFormatsCalibration/MeanVertexObject.h"
 #include "SimulationDataFormat/DigitizationContext.h"
+#include "Generators/InteractionDiamondParam.h"
 #include <cmath>
 #include <TRandom.h>
 #include <numeric>
 #include <fairlogger/Logger.h>
 #include "Steer/MCKinematicsReader.h"
+#include "CommonUtils/ConfigurableParam.h"
 
 //
 // Created by Sandro Wenzel on 13.07.21.
@@ -43,6 +46,8 @@ struct Options {
   bool useexistingkinematics = false;
   bool noEmptyTF = false; // prevent empty timeframes; the first interaction will be shifted backwards to fall within the range given by Options.orbits
   int maxCollsPerTF = -1; // the maximal number of hadronic collisions per TF (can be used to constrain number of collisions per timeframe to some maximal value)
+  bool genVertices = false;         // whether to assign vertices to collisions
+  std::string configKeyValues = ""; // string to init config key values
 };
 
 enum class InteractionLockMode {
@@ -185,7 +190,7 @@ bool parseOptions(int argc, char* argv[], Options& optvalues)
     "use-existing-kine", "Read existing kinematics to adjust event counts")(
     "timeframeID", bpo::value<int>(&optvalues.tfid)->default_value(0), "Timeframe id of the first timeframe int this context. Allows to generate contexts for different start orbits")(
     "maxCollsPerTF", bpo::value<int>(&optvalues.maxCollsPerTF)->default_value(-1), "Maximal number of MC collisions to put into one timeframe. By default no constraint.")(
-    "noEmptyTF", bpo::bool_switch(&optvalues.noEmptyTF), "Enforce to have at least one collision");
+    "noEmptyTF", bpo::bool_switch(&optvalues.noEmptyTF), "Enforce to have at least one collision")("configKeyValues", bpo::value<std::string>(&optvalues.configKeyValues)->default_value(""), "Semicolon separated key=value strings (e.g.: 'TPC.gasDensity=1;...')")("with-vertices", "Assign vertices to collisions.");
 
   options.add_options()("help,h", "Produce help message.");
 
@@ -205,7 +210,9 @@ bool parseOptions(int argc, char* argv[], Options& optvalues)
     if (vm.count("use-existing-kine")) {
       optvalues.useexistingkinematics = true;
     }
-
+    if (vm.count("with-vertices")) {
+      optvalues.genVertices = true;
+    }
   } catch (const bpo::error& e) {
     std::cerr << e.what() << "\n\n";
     std::cerr << "Error parsing options; Available options:\n";
@@ -221,6 +228,9 @@ int main(int argc, char* argv[])
   if (!parseOptions(argc, argv, options)) {
     exit(1);
   }
+
+  // init params
+  o2::conf::ConfigurableParam::updateFromString(options.configKeyValues);
 
   // init random generator
   gRandom->SetSeed(options.seed);
@@ -394,12 +404,22 @@ int main(int argc, char* argv[])
   }
   digicontext.setSimPrefixes(prefixes);
 
-  digicontext.printCollisionSummary();
-
   // apply max collision per timeframe filters + reindexing of event id (linearisation and compactification)
   digicontext.applyMaxCollisionFilter(options.tfid * options.orbitsPerTF, options.orbitsPerTF, options.maxCollsPerTF);
 
   digicontext.finalizeTimeframeStructure(options.tfid * options.orbitsPerTF, options.orbitsPerTF);
+
+  if (options.genVertices) {
+    // TODO: offer option taking meanVertex directly from CCDB !
+
+    // sample interaction vertices
+
+    // init this vertex from CCDB or InteractionDiamond parameter
+    const auto& dparam = o2::eventgen::InteractionDiamondParam::Instance();
+    o2::dataformats::MeanVertexObject meanv(dparam.position[0], dparam.position[1], dparam.position[2], dparam.width[0], dparam.width[1], dparam.width[2], dparam.slopeX, dparam.slopeY);
+    digicontext.sampleInteractionVertices(meanv);
+  }
+
   if (options.printContext) {
     digicontext.printCollisionSummary();
   }


### PR DESCRIPTION
This commits brings 2 important new features:

a) Ability to sample an interaction vertex with
   z-dependent x and y positions according to
   MeanVertexObject.

   This is achieved by decoupling the vertex smearing
   process from FairPrimaryGenerator and by generating
   it in our space before calling FairPrimaryGenerator::generateEvent.

b) The ability to (pre-)fix interation vertices in the timeframe
   collision context. This will allow much more consistent application
   of vertices to all parts of a collision (background, signal) and scale
   better to many signal parts. It is a foundation to simplify embedding
   treatment later on.

https://alice.its.cern.ch/jira/browse/O2-3318