### PR TITLE
[EMCAL-798] Apply gain calibration to cell energies in offline calib

### DIFF
--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/OfflineCalibSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/OfflineCalibSpec.h
@@ -11,6 +11,8 @@
 
 #include <string>
 #include "Framework/DataProcessorSpec.h"
+#include "EMCALWorkflow/CalibLoader.h"
+#include "EMCALCalib/GainCalibrationFactors.h"
 #include "Framework/Task.h"
 
 #include "TFile.h"
@@ -37,7 +39,7 @@ class OfflineCalibSpec : public framework::Task
   /// \brief Constructor
   /// \param makeCellIDTimeEnergy If true the THnSparseF of cell ID, time, and energy is made
   /// \param rejectCalibTriggers if true, only events which have the o2::trigger::PhT flag will be taken into account
-  OfflineCalibSpec(bool makeCellIDTimeEnergy, bool rejectCalibTriggers) : mMakeCellIDTimeEnergy(makeCellIDTimeEnergy), mRejectCalibTriggers(rejectCalibTriggers){};
+  OfflineCalibSpec(bool makeCellIDTimeEnergy, bool rejectCalibTriggers, std::shared_ptr<o2::emcal::CalibLoader> calibHandler) : mMakeCellIDTimeEnergy(makeCellIDTimeEnergy), mRejectCalibTriggers(rejectCalibTriggers), mCalibrationHandler(calibHandler){};
 
   /// \brief Destructor
   ~OfflineCalibSpec() override = default;
@@ -45,6 +47,11 @@ class OfflineCalibSpec : public framework::Task
   /// \brief Initializing the offline calib task
   /// \param ctx Init context
   void init(framework::InitContext& ctx) final;
+
+  /// Loading CCDB object into internal cache for the 3 supported CCDB entries (bad
+  /// channel map, time calibration params, gain calibration params). Objects are only
+  /// loaded in case the calibration type was enabled.
+  void finaliseCCDB(framework::ConcreteDataMatcher& matcher, void* obj) final;
 
   /// \brief Fill histograms needed for the offline calibration
   /// \param ctx Processing context
@@ -57,20 +64,25 @@ class OfflineCalibSpec : public framework::Task
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
 
  private:
-  std::unique_ptr<TH2> mCellAmplitude;         ///< Cell energy vs. cell ID
-  std::unique_ptr<TH2> mCellTime;              ///< Cell time vs. cell ID
-  std::unique_ptr<TH2> mCellTimeLG;            ///< Cell time vs. cell ID for low gain cells
-  std::unique_ptr<TH2> mCellTimeHG;            ///< Cell time vs. cell ID for high gain cells
-  std::unique_ptr<TH1> mNevents;               ///< Number of events
-  std::unique_ptr<THnSparseF> mCellTimeEnergy; ///< ID, time, energy
-  bool mMakeCellIDTimeEnergy = true;           ///< Switch whether or not to make a THnSparseF of cell ID, time, and energy
-  bool mRejectCalibTriggers = true;            ///< Switch to select if calib triggerred events should be rejected
+  /// \brief Update calibration objects (if changed)
+  void updateCalibObjects();
+  std::unique_ptr<TH2> mCellAmplitude;              ///< Cell energy vs. cell ID
+  std::unique_ptr<TH2> mCellTime;                   ///< Cell time vs. cell ID
+  std::unique_ptr<TH2> mCellTimeLG;                 ///< Cell time vs. cell ID for low gain cells
+  std::unique_ptr<TH2> mCellTimeHG;                 ///< Cell time vs. cell ID for high gain cells
+  std::unique_ptr<TH1> mNevents;                    ///< Number of events
+  std::unique_ptr<THnSparseF> mCellTimeEnergy;      ///< ID, time, energy
+  std::shared_ptr<CalibLoader> mCalibrationHandler; ///< Handler loading calibration objects
+  GainCalibrationFactors* mGainCalibFactors;        ///< cell gain calibration factors
+  bool mMakeCellIDTimeEnergy = true;                ///< Switch whether or not to make a THnSparseF of cell ID, time, and energy
+  bool mRejectCalibTriggers = true;                 ///< Switch to select if calib triggerred events should be rejected
+  bool mEnableGainCalib = false;                    ///< Switch weather gain calibration should be applied or not when filling the hsitograms
 };
 
 /// \brief Creating offline calib spec
 /// \ingroup EMCALworkflow
 ///
-o2::framework::DataProcessorSpec getEmcalOfflineCalibSpec(bool makeCellIDTimeEnergy, bool rejectCalibTriggers, uint32_t inputsubspec);
+o2::framework::DataProcessorSpec getEmcalOfflineCalibSpec(bool makeCellIDTimeEnergy, bool rejectCalibTriggers, uint32_t inputsubspec, bool enableGainCalib);
 
 } // namespace emcal
 

--- a/Detectors/EMCAL/workflow/src/emc-offline-calib-workflow.cxx
+++ b/Detectors/EMCAL/workflow/src/emc-offline-calib-workflow.cxx
@@ -24,6 +24,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   std::vector<ConfigParamSpec> options{{"makeCellIDTimeEnergy", VariantType::Bool, false, {"list whether or not to make the cell ID, time, energy THnSparse"}},
                                        {"no-rejectCalibTrigg", VariantType::Bool, false, {"if set to true, all events, including calibration triggered events, will be accepted"}},
                                        {"input-subspec", VariantType::UInt32, 0U, {"Subspecification for input objects"}},
+                                       {"applyGainCalib", VariantType::Bool, false, {"Apply the gain calibration parameters for the bad channel calibration"}},
                                        {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
   workflowOptions.insert(workflowOptions.end(), options.begin(), options.end());
 }
@@ -38,11 +39,12 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   // Update the (declared) parameters if changed from the command line
   bool makeCellIDTimeEnergy = cfgc.options().get<bool>("makeCellIDTimeEnergy");
   bool rejectCalibTrigg = !cfgc.options().get<bool>("no-rejectCalibTrigg");
+  bool doApplyGainCalib = cfgc.options().get<bool>("applyGainCalib");
 
   // subpsecs for input
   auto inputsubspec = cfgc.options().get<uint32_t>("input-subspec");
 
   o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
-  wf.emplace_back(o2::emcal::getEmcalOfflineCalibSpec(makeCellIDTimeEnergy, rejectCalibTrigg, inputsubspec));
+  wf.emplace_back(o2::emcal::getEmcalOfflineCalibSpec(makeCellIDTimeEnergy, rejectCalibTrigg, inputsubspec, doApplyGainCalib));
   return wf;
 }


### PR DESCRIPTION
- Energy calibration shifts cell energies. This can influence the final result of the bad channel calibration as it cuts on the mean cell energy for each cell
- application of the energy calibration can be switched on with the worflow argument applyGainCalib
- Similar implementation to what was one in the emcal cell recalibration workflow