### PR TITLE
TPC SCD calib: Ues time stamps for filenames and some fixes for mergi…

### DIFF
--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/ResidualAggregator.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/ResidualAggregator.h
@@ -49,7 +49,7 @@ struct ResidualsContainer {
   void fillStatisticsBranches();
   uint64_t getNEntries() const { return nResidualsTotal; }
 
-  void fill(const o2::dataformats::TFIDInfo& ti, const gsl::span<const UnbinnedResid> resid, const gsl::span<const o2::tpc::TrackDataCompact> trkRefsIn, const gsl::span<const o2::tpc::TrackData>* trkDataIn, const o2::ctp::LumiInfo* lumiInput);
+  void fill(const o2::dataformats::TFIDInfo& ti, const gsl::span<const UnbinnedResid> resid, const gsl::span<const o2::tpc::TrackDataCompact> trkRefsIn, long orbitResetTime, const gsl::span<const o2::tpc::TrackData>* trkDataIn, const o2::ctp::LumiInfo* lumiInput);
   void merge(ResidualsContainer* prev);
   void print();
   void writeToFile(bool closeFileAfterwards);
@@ -59,7 +59,6 @@ struct ResidualsContainer {
   std::array<std::vector<TrackResiduals::LocalResid>*, SECTORSPERSIDE * SIDES> residualsPtr{};
   std::array<std::vector<TrackResiduals::VoxStats>, SECTORSPERSIDE * SIDES> stats{}; ///< voxel statistics sent to the aggregator
   std::array<std::vector<TrackResiduals::VoxStats>*, SECTORSPERSIDE * SIDES> statsPtr{};
-  uint32_t runNumber;                                                        ///< run number (required for meta data file)
   std::vector<uint32_t> tfOrbits, *tfOrbitsPtr{&tfOrbits};                   ///< first TF orbit
   std::vector<uint32_t> sumOfResiduals, *sumOfResidualsPtr{&sumOfResiduals}; ///< sum of residuals for each TF
   std::vector<o2::ctp::LumiInfo> lumi, *lumiPtr{&lumi};                      ///< luminosity information from CTP per TF
@@ -68,9 +67,6 @@ struct ResidualsContainer {
   std::vector<TrackDataCompact> trackInfo, *trackInfoPtr{&trackInfo};        ///< allows to obtain track type for each binned residual downstream
 
   std::string fileName{"o2tpc_residuals"};
-  std::string treeNameResiduals{"resid"};
-  std::string treeNameStats{"stats"};
-  std::string treeNameRecords{"records"};
   std::unique_ptr<TFile> fileOut{nullptr};
   std::unique_ptr<TTree> treeOutResidualsUnbinned{nullptr};
   std::unique_ptr<TTree> treeOutTrackData{nullptr};
@@ -86,11 +82,13 @@ struct ResidualsContainer {
   int autosaveInterval{0};            ///< if > 0, then the output written to file for every n-th TF
 
   // additional info
+  long orbitReset{0};                               ///< current orbit reset time in ms
+  uint32_t firstTForbit{0};                         ///< stored for the first seen TF to allow conversion to time stamp
   TFType firstSeenTF{o2::calibration::INFINITE_TF}; ///< the first TF which was added to this container
   TFType lastSeenTF{0};                             ///< the last TF which was added to this container
   uint64_t nResidualsTotal{0};                      ///< the total number of residuals for this container
 
-  ClassDefNV(ResidualsContainer, 4);
+  ClassDefNV(ResidualsContainer, 5);
 };
 
 class ResidualAggregator final : public o2::calibration::TimeSlotCalibration<ResidualsContainer>

--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackInterpolation.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackInterpolation.h
@@ -173,7 +173,7 @@ class TrackInterpolation
   void init();
 
   /// Main processing function
-  void process(const o2::globaltracking::RecoContainer& inp, const std::vector<o2::dataformats::GlobalTrackID>& gids, const std::vector<o2::globaltracking::RecoContainer::GlobalIDSet>& gidTables, std::vector<o2::track::TrackParCov>& seeds, const std::vector<float>& trkTimes);
+  void process(const o2::globaltracking::RecoContainer& inp, const std::vector<o2::dataformats::GlobalTrackID>& gids, const std::vector<o2::globaltracking::RecoContainer::GlobalIDSet>& gidTables, std::vector<o2::track::TrackParCov>& seeds, const std::vector<float>& trkTimes, const std::unordered_map<int, int>& trkCounters);
 
   /// Extrapolate ITS-only track through TPC and store residuals to TPC clusters along the way
   /// \param seed index

--- a/Detectors/TPC/calibration/SpacePoints/src/ResidualAggregator.cxx
+++ b/Detectors/TPC/calibration/SpacePoints/src/ResidualAggregator.cxx
@@ -27,12 +27,14 @@ using namespace o2::tpc;
 ResidualsContainer::~ResidualsContainer()
 {
   // trees must be deleted before the file is closed, otherwise segfaults
+  LOGP(debug, "Deleting ResidualsContainer with {} entries. File name is {}", getNEntries(), fileName);
   treeOutResidualsUnbinned.reset();
   treeOutTrackData.reset();
   treeOutResiduals.reset();
   treeOutStats.reset();
   treeOutRecords.reset();
   if (fileOut) {
+    LOG(debug) << "Removing output file of discarded slot";
     // this slot was not finalized, need to close and remove the file
     fileOut->Close();
     fileOut.reset();
@@ -52,6 +54,7 @@ ResidualsContainer::ResidualsContainer(const ResidualsContainer& rhs)
 
 ResidualsContainer::ResidualsContainer(ResidualsContainer&& rhs)
 {
+  LOGP(debug, "Move operator called for rhs with {} entries", rhs.nResidualsTotal);
   trackResiduals = rhs.trackResiduals;
   fileOut = std::move(rhs.fileOut);
   fileName = std::move(rhs.fileName);
@@ -59,19 +62,22 @@ ResidualsContainer::ResidualsContainer(ResidualsContainer&& rhs)
   treeOutTrackData = std::move(rhs.treeOutTrackData);
   treeOutResiduals = std::move(rhs.treeOutResiduals);
   treeOutStats = std::move(rhs.treeOutStats);
+  treeOutRecords = std::move(rhs.treeOutRecords);
   for (int iSec = 0; iSec < SECTORSPERSIDE * SIDES; ++iSec) {
     residuals[iSec] = std::move(rhs.residuals[iSec]);
     stats[iSec] = std::move(rhs.stats[iSec]);
   }
-  runNumber = rhs.runNumber;
   tfOrbits = std::move(rhs.tfOrbits);
   sumOfResiduals = std::move(rhs.sumOfResiduals);
   lumi = std::move(rhs.lumi);
   unbinnedRes = std::move(rhs.unbinnedRes);
   trackInfo = std::move(rhs.trackInfo);
   trkData = std::move(rhs.trkData);
+  orbitReset = rhs.orbitReset;
+  firstTForbit = rhs.firstTForbit;
   firstSeenTF = rhs.firstSeenTF;
   lastSeenTF = rhs.lastSeenTF;
+  nResidualsTotal = rhs.nResidualsTotal;
 }
 
 void ResidualsContainer::init(const TrackResiduals* residualsEngine, std::string outputDir, bool wFile, bool wBinnedResid, bool wUnbinnedResid, bool wTrackData, int autosave, int compression)
@@ -98,9 +104,9 @@ void ResidualsContainer::init(const TrackResiduals* residualsEngine, std::string
     treeOutTrackData->Branch("trk", &trkDataPtr);
   }
   if (writeBinnedResid) {
-    treeOutResiduals = std::make_unique<TTree>(treeNameResiduals.c_str(), "TPC binned residuals");
-    treeOutStats = std::make_unique<TTree>(treeNameStats.c_str(), "Voxel statistics mean position and nEntries");
-    treeOutRecords = std::make_unique<TTree>(treeNameRecords.c_str(), "Statistics per TF slot");
+    treeOutResiduals = std::make_unique<TTree>("resid", "TPC binned residuals");
+    treeOutStats = std::make_unique<TTree>("stats", "Voxel statistics mean position and nEntries");
+    treeOutRecords = std::make_unique<TTree>("records", "Statistics per TF slot");
     for (int iSec = 0; iSec < SECTORSPERSIDE * SIDES; ++iSec) {
       residualsPtr[iSec] = &residuals[iSec];
       statsPtr[iSec] = &stats[iSec];
@@ -122,6 +128,7 @@ void ResidualsContainer::init(const TrackResiduals* residualsEngine, std::string
     treeOutRecords->Branch("sumOfResiduals", &sumOfResidualsPtr);
     treeOutRecords->Branch("lumi", &lumiPtr);
   }
+  LOG(debug) << "Done initializing residuals container for file named " << fileName;
 }
 
 void ResidualsContainer::fillStatisticsBranches()
@@ -135,7 +142,7 @@ void ResidualsContainer::fillStatisticsBranches()
   }
 }
 
-void ResidualsContainer::fill(const o2::dataformats::TFIDInfo& ti, const gsl::span<const UnbinnedResid> resid, const gsl::span<const o2::tpc::TrackDataCompact> trkRefsIn, const gsl::span<const o2::tpc::TrackData>* trkDataIn, const o2::ctp::LumiInfo* lumiInput)
+void ResidualsContainer::fill(const o2::dataformats::TFIDInfo& ti, const gsl::span<const UnbinnedResid> resid, const gsl::span<const o2::tpc::TrackDataCompact> trkRefsIn, long orbitResetTime, const gsl::span<const o2::tpc::TrackData>* trkDataIn, const o2::ctp::LumiInfo* lumiInput)
 {
   // receives large vector of unbinned residuals and fills the sector-wise vectors
   // with binned residuals and statistics
@@ -145,6 +152,8 @@ void ResidualsContainer::fill(const o2::dataformats::TFIDInfo& ti, const gsl::sp
     lastSeenTF = ti.tfCounter;
   }
   if (ti.tfCounter < firstSeenTF) {
+    orbitReset = orbitResetTime;
+    firstTForbit = ti.firstTForbit;
     firstSeenTF = ti.tfCounter;
   }
   for (const auto& residIn : resid) {
@@ -206,7 +215,6 @@ void ResidualsContainer::fill(const o2::dataformats::TFIDInfo& ti, const gsl::sp
     treeOutResidualsUnbinned->Fill();
     unbinnedRes.clear();
   }
-  runNumber = ti.runNumber;
   tfOrbits.push_back(ti.firstTForbit);
   if (lumiInput) {
     lumi.push_back(*lumiInput);
@@ -255,7 +263,7 @@ void ResidualsContainer::merge(ResidualsContainer* prev)
 {
   // the previous slot is merged to this one and afterwards
   // the previous one will be deleted
-  LOG(info) << "Merging previous slot into current one";
+  LOGP(debug, "Merging previous slot with {} entries into current one with {} entries", prev->getNEntries(), getNEntries());
   if (writeBinnedResid) {
     for (int iSec = 0; iSec < SECTORSPERSIDE * SIDES; ++iSec) {
       // merge statistics
@@ -275,8 +283,9 @@ void ResidualsContainer::merge(ResidualsContainer* prev)
         stat.nEntries += statPrev.nEntries;
       }
       // prepare merging of residuals
-      prev->treeOutResiduals->SetBranchAddress(Form("sec%d", iSec), &residualsPtr);
+      prev->treeOutResiduals->SetBranchAddress(Form("sec%d", iSec), &residualsPtr[iSec]);
     }
+    prev->treeOutResiduals->SetBranchAddress("trackInfo", &trackInfoPtr);
     // We append the entries of the tree of the following slot to the
     // previous slot and afterwards move the merged tree to this slot.
     // This way the order of the entries is preserved
@@ -305,6 +314,12 @@ void ResidualsContainer::merge(ResidualsContainer* prev)
   treeOutTrackData = std::move(prev->treeOutTrackData);
   treeOutResidualsUnbinned = std::move(prev->treeOutResidualsUnbinned);
 
+  // since we want to continue using the TTrees of the previous slot, we must
+  // avoid that ROOT deletes them when the TFile of the previous slot is erased
+  treeOutResiduals->SetDirectory(fileOut.get());
+  treeOutTrackData->SetDirectory(fileOut.get());
+  treeOutResidualsUnbinned->SetDirectory(fileOut.get());
+
   nResidualsTotal += prev->nResidualsTotal;
 
   // append the current vector to the vector of the previous container and afterwards swap them,
@@ -317,6 +332,7 @@ void ResidualsContainer::merge(ResidualsContainer* prev)
   std::swap(prev->lumi, lumi);
 
   firstSeenTF = prev->firstSeenTF;
+  LOGP(debug, "Done with the merge. Current slot has {} entries", getNEntries());
 }
 
 void ResidualsContainer::print()
@@ -334,8 +350,9 @@ ResidualAggregator::~ResidualAggregator()
 
 bool ResidualAggregator::hasEnoughData(const Slot& slot) const
 {
-  LOG(debug) << "There are " << slot.getContainer()->getNEntries() << " entries currently. Min entries prt voxel: " << mMinEntries;
+  LOG(debug) << "There are " << slot.getContainer()->getNEntries() << " entries currently. Min entries per voxel: " << mMinEntries;
   auto entriesPerVoxel = slot.getContainer()->getNEntries() / (mTrackResiduals.getNVoxelsPerSector() * SECTORSPERSIDE * SIDES);
+  LOGP(debug, "Slot has {} entries per voxel, at least {} are required", entriesPerVoxel, mMinEntries);
   return entriesPerVoxel >= mMinEntries;
 }
 
@@ -350,13 +367,17 @@ void ResidualAggregator::finalizeSlot(Slot& slot)
   auto finalizeStartTime = std::chrono::high_resolution_clock::now();
   auto cont = slot.getContainer();
   cont->print();
-  if (!mWriteOutput) {
-    LOG(info) << "Skip writing output, since file output is disabled";
+  if (!mWriteOutput || cont->getNEntries() == 0) {
+    LOGP(info, "Skip writing output with {} entries, since file output is disabled or slot is empty", cont->getNEntries());
     return;
   }
   cont->writeToFile(true);
 
-  auto fileName = fmt::format("o2tpc_residuals_{}_{}_{}_{}.root", slot.getTFStart(), slot.getTFEnd(), cont->firstSeenTF, cont->lastSeenTF);
+  long orbitOffsetStart = (cont->firstSeenTF - slot.getTFStart()) * o2::base::GRPGeomHelper::getNHBFPerTF();
+  long orbitOffsetEnd = (slot.getTFEnd() - cont->firstSeenTF) * o2::base::GRPGeomHelper::getNHBFPerTF();
+  long timeStartMS = cont->orbitReset + (cont->firstTForbit - orbitOffsetStart) * o2::constants::lhc::LHCOrbitMUS * 1.e-3;
+  long timeEndMS = cont->orbitReset + (cont->firstTForbit + orbitOffsetEnd) * o2::constants::lhc::LHCOrbitMUS * 1.e-3;
+  auto fileName = fmt::format("o2tpc_residuals_{}_{}_{}_{}.root", timeStartMS, timeEndMS, slot.getTFStart(), slot.getTFEnd());
   auto fileNameWithPath = mOutputDir + fileName;
   std::filesystem::rename(o2::utils::Str::concat_string(mOutputDir, cont->fileName, ".part"), fileNameWithPath);
   if (mStoreMetaData) {

--- a/Detectors/TPC/calibration/SpacePoints/src/ResidualAggregator.cxx
+++ b/Detectors/TPC/calibration/SpacePoints/src/ResidualAggregator.cxx
@@ -98,6 +98,7 @@ void ResidualsContainer::init(const TrackResiduals* residualsEngine, std::string
   if (writeUnbinnedResiduals) {
     treeOutResidualsUnbinned = std::make_unique<TTree>("unbinnedResid", "TPC unbinned residuals");
     treeOutResidualsUnbinned->Branch("res", &unbinnedResPtr);
+    treeOutResidualsUnbinned->Branch("trackInfo", &trackInfoPtr);
   }
   if (writeTrackData) {
     treeOutTrackData = std::make_unique<TTree>("trackData", "Track information incl cluster range ref");
@@ -123,7 +124,6 @@ void ResidualsContainer::init(const TrackResiduals* residualsEngine, std::string
       treeOutResiduals->Branch(Form("sec%d", iSec), &residualsPtr[iSec]);
       treeOutStats->Branch(Form("sec%d", iSec), &statsPtr[iSec]);
     }
-    treeOutResiduals->Branch("trackInfo", &trackInfoPtr);
     treeOutRecords->Branch("firstTForbit", &tfOrbitsPtr);
     treeOutRecords->Branch("sumOfResiduals", &sumOfResidualsPtr);
     treeOutRecords->Branch("lumi", &lumiPtr);
@@ -198,7 +198,6 @@ void ResidualsContainer::fill(const o2::dataformats::TFIDInfo& ti, const gsl::sp
   }
   if (writeBinnedResid) {
     treeOutResiduals->Fill();
-    trackInfo.clear();
     sumOfResiduals.push_back(nResidualsInTF);
   }
   for (auto& residVecOut : residuals) {
@@ -214,6 +213,7 @@ void ResidualsContainer::fill(const o2::dataformats::TFIDInfo& ti, const gsl::sp
   if (writeUnbinnedResiduals) {
     treeOutResidualsUnbinned->Fill();
     unbinnedRes.clear();
+    trackInfo.clear();
   }
   tfOrbits.push_back(ti.firstTForbit);
   if (lumiInput) {
@@ -285,7 +285,6 @@ void ResidualsContainer::merge(ResidualsContainer* prev)
       // prepare merging of residuals
       prev->treeOutResiduals->SetBranchAddress(Form("sec%d", iSec), &residualsPtr[iSec]);
     }
-    prev->treeOutResiduals->SetBranchAddress("trackInfo", &trackInfoPtr);
     // We append the entries of the tree of the following slot to the
     // previous slot and afterwards move the merged tree to this slot.
     // This way the order of the entries is preserved
@@ -304,6 +303,7 @@ void ResidualsContainer::merge(ResidualsContainer* prev)
   }
   if (writeUnbinnedResiduals) {
     prev->treeOutResidualsUnbinned->SetBranchAddress("res", &unbinnedResPtr);
+    prev->treeOutResidualsUnbinned->SetBranchAddress("trackInfo", &trackInfoPtr);
     for (int i = 0; i < treeOutResidualsUnbinned->GetEntries(); ++i) {
       treeOutResidualsUnbinned->GetEntry(i);
       prev->treeOutResidualsUnbinned->Fill();

--- a/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
+++ b/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
@@ -27,6 +27,8 @@
 #include "DataFormatsTPC/VDriftCorrFact.h"
 #include <fairlogger/Logger.h>
 #include <set>
+#include <algorithm>
+#include <random>
 
 using namespace o2::tpc;
 using GTrackID = o2::dataformats::GlobalTrackID;
@@ -55,7 +57,7 @@ void TrackInterpolation::init()
   LOG(info) << "Done initializing TrackInterpolation";
 }
 
-void TrackInterpolation::process(const o2::globaltracking::RecoContainer& inp, const std::vector<GTrackID>& gids, const std::vector<o2::globaltracking::RecoContainer::GlobalIDSet>& gidTables, std::vector<o2::track::TrackParCov>& seeds, const std::vector<float>& trkTimes)
+void TrackInterpolation::process(const o2::globaltracking::RecoContainer& inp, const std::vector<GTrackID>& gids, const std::vector<o2::globaltracking::RecoContainer::GlobalIDSet>& gidTables, std::vector<o2::track::TrackParCov>& seeds, const std::vector<float>& trkTimes, const std::unordered_map<int, int>& trkCounters)
 {
   // main processing function
 
@@ -80,11 +82,29 @@ void TrackInterpolation::process(const o2::globaltracking::RecoContainer& inp, c
   mTrackData.reserve(nSeeds);
   mClRes.reserve(nSeeds * param::NPadRows);
 
+  // In case we have more input tracks available than are required per TF
+  // we want to sample them. But we still prefer global ITS-TPC-TRD-TOF tracks
+  // over ITS-TPC-TRD tracks and so on. So we have to shuffle the indices
+  // in blocks.
+  // The input GIDs are sorted. ITS-TPC-TRD-TOF are first followed by ITS-TPC-TRD,
+  // ITS-TPC-TOF and ITS-TPC
+  std::random_device rd;
+  std::mt19937 g(rd());
+  std::vector<int> trackIndices(nSeeds);
+  std::iota(trackIndices.begin(), trackIndices.end(), 0);
+  std::shuffle(trackIndices.begin(), trackIndices.begin() + trkCounters.at(GTrackID::Source::ITSTPCTRDTOF), g);
+  int nTracks = trkCounters.at(GTrackID::Source::ITSTPCTRDTOF);
+  std::shuffle(trackIndices.begin() + nTracks, trackIndices.begin() + nTracks + trkCounters.at(GTrackID::Source::ITSTPCTRD), g);
+  nTracks += trkCounters.at(GTrackID::Source::ITSTPCTRD);
+  std::shuffle(trackIndices.begin() + nTracks, trackIndices.begin() + nTracks + trkCounters.at(GTrackID::Source::ITSTPCTOF), g);
+  nTracks += trkCounters.at(GTrackID::Source::ITSTPCTOF);
+  std::shuffle(trackIndices.begin() + nTracks, trackIndices.begin() + nTracks + trkCounters.at(GTrackID::Source::ITSTPC), g);
+
   for (int iSeed = 0; iSeed < nSeeds; ++iSeed) {
-    if (gids[iSeed].includesDet(DetID::TRD) || gids[iSeed].includesDet(DetID::TOF)) {
-      interpolateTrack(iSeed);
+    if (gids[trackIndices[iSeed]].includesDet(DetID::TRD) || gids[trackIndices[iSeed]].includesDet(DetID::TOF)) {
+      interpolateTrack(trackIndices[iSeed]);
     } else {
-      extrapolateTrack(iSeed);
+      extrapolateTrack(trackIndices[iSeed]);
     }
     if (mMaxTracksPerTF >= 0 && mTrackDataCompact.size() >= mMaxTracksPerTF) {
       LOG(info) << "Maximum number of tracks per TF reached. Skipping the remaining " << nSeeds - iSeed << " tracks.";
@@ -276,14 +296,6 @@ void TrackInterpolation::interpolateTrack(int iSeed)
   trackData.nClsITS = trkITS.getNumberOfClusters();
   trackData.nTrkltsTRD = gidTable[GTrackID::TRD].isIndexSet() ? mRecoCont->getITSTPCTRDTrack<o2::trd::TrackTRD>(gidTable[GTrackID::ITSTPCTRD]).getNtracklets() : 0;
   trackData.clAvailTOF = gidTable[GTrackID::TOF].isIndexSet() ? 1 : 0;
-
-  /*
-  // FIXME
-
-  Calculate number of tracks required per TF based on calibration slot length
-  In case too many tracks available, use std::sample algorithm to take random sample of input tracks
-  (make sure to use first most global tracks, then ITS-TPC-TRD, then ITS-TPC-TOF)
-  */
 
   TrackParams params; // for refitted track parameters and flagging rejected clusters
   if (validateTrack(trackData, params, clusterResiduals)) {


### PR DESCRIPTION
…ng slots

For async processing the fix for merging slots is not important, since here we want to have a fixed slot length and rather merge afterwards the output files. But for synch. processing this is important of course.

Output file has the format
`o2tpc_residuals_1667421310532_1667421910519_263565_316277.root`
The first two numbers are the time stamps of the beginning and end of the slot in ms, the last two numbers are the slot boundaries in number of TFs for the given run.