### PR TITLE
Adopt FairRoot 18.8

### DIFF
--- a/Common/Field/CMakeLists.txt
+++ b/Common/Field/CMakeLists.txt
@@ -16,7 +16,10 @@ o2_add_library(Field
                        src/MagFieldParam.cxx
                        src/MagneticField.cxx
                        src/MagneticWrapperChebyshev.cxx
-                       PUBLIC_LINK_LIBRARIES O2::MathUtils FairRoot::Base)
+               PUBLIC_LINK_LIBRARIES O2::MathUtils
+                                     FairRoot::Base
+               PRIVATE_COMPILE_DEFINITIONS
+               $<$<VERSION_LESS:${FairRoot_VERSION},18.8>:ALICEO2_HAS_FAIRFIELDFACTORY_FCREATOR>)
 
 o2_target_root_dictionary(Field
                           HEADERS include/Field/MagneticWrapperChebyshev.h

--- a/Common/Field/src/MagFieldFact.cxx
+++ b/Common/Field/src/MagFieldFact.cxx
@@ -27,7 +27,13 @@ ClassImp(MagFieldFact);
 
 static MagFieldFact gMagFieldFact;
 
-MagFieldFact::MagFieldFact() : FairFieldFactory(), mFieldPar(nullptr) { fCreator = this; }
+MagFieldFact::MagFieldFact() : FairFieldFactory(), mFieldPar(nullptr)
+{
+#ifdef ALICEO2_HAS_FAIRFIELDFACTORY_FCREATOR
+  fCreator = this;
+#endif
+}
+
 MagFieldFact::~MagFieldFact() = default;
 
 void MagFieldFact::SetParm()

--- a/Detectors/ITSMFT/test/HitAnalysis/src/HitAnalysis.cxx
+++ b/Detectors/ITSMFT/test/HitAnalysis/src/HitAnalysis.cxx
@@ -21,6 +21,8 @@
 
 #include <fairlogger/Logger.h> // for LOG
 
+#include <FairRootManager.h>
+
 #include <TH1.h> // for TH1, TH1D, TH1F
 #include <TFile.h>
 

--- a/cmake/O2AddLibrary.cmake
+++ b/cmake/O2AddLibrary.cmake
@@ -53,6 +53,10 @@ include(O2NameTarget)
 #   (e.g. by protobuf). Note that if you do specify this parameter it replaces
 #   the default, it does not add to them.
 #
+# * PRIVATE_COMPILE_DEFINITIONS (not needed in most cases) : the list of compile
+#   definitions (i.e. `-D` args to the compiler, see
+#   https://cmake.org/cmake/help/latest/command/target_compile_definitions.html)
+#
 function(o2_add_library baseTargetName)
 
   cmake_parse_arguments(
@@ -61,7 +65,7 @@ function(o2_add_library baseTargetName)
     A
     ""
     "TARGETVARNAME"
-    "SOURCES;PUBLIC_INCLUDE_DIRECTORIES;PUBLIC_LINK_LIBRARIES;PRIVATE_INCLUDE_DIRECTORIES;PRIVATE_LINK_LIBRARIES"
+    "SOURCES;PUBLIC_INCLUDE_DIRECTORIES;PUBLIC_LINK_LIBRARIES;PRIVATE_INCLUDE_DIRECTORIES;PRIVATE_LINK_LIBRARIES;PRIVATE_COMPILE_DEFINITIONS"
     )
 
   if(A_UNPARSED_ARGUMENTS)
@@ -149,6 +153,10 @@ function(o2_add_library baseTargetName)
         ${target}
         PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src>)
     endif()
+  endif()
+
+  if(A_PRIVATE_COMPILE_DEFINITIONS)
+    target_compile_definitions(${target} PRIVATE ${A_PRIVATE_COMPILE_DEFINITIONS})
   endif()
 
   if(EXISTS ${CMAKE_CURRENT_LIST_DIR}/include/${baseTargetName})

--- a/dependencies/FindFairRoot.cmake
+++ b/dependencies/FindFairRoot.cmake
@@ -27,17 +27,32 @@ find_library(FairRoot_ParBase ParBase)
 find_library(FairRoot_GeoBase GeoBase)
 find_library(FairRoot_Base Base)
 find_library(FairRoot_Gen Gen)
+find_program(FairRoot_CONFIG_EXECUTABLE NAMES fairroot-config)
 
 set(CMAKE_PREFIX_PATH ${OLD_CMAKE_PREFIX_PATH})
 
+if(FairRoot_CONFIG_EXECUTABLE)
+  execute_process(COMMAND ${FairRoot_CONFIG_EXECUTABLE} --major_version
+                  OUTPUT_VARIABLE FairRoot_VERSION_MAJOR
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+  execute_process(COMMAND ${FairRoot_CONFIG_EXECUTABLE} --minor_version
+                  OUTPUT_VARIABLE FairRoot_VERSION_MINOR
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+  execute_process(COMMAND ${FairRoot_CONFIG_EXECUTABLE} --patch_version
+                  OUTPUT_VARIABLE FairRoot_VERSION_PATCH
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+  set(FairRoot_VERSION "${FairRoot_VERSION_MAJOR}.${FairRoot_VERSION_MINOR}.${FairRoot_VERSION_PATCH}")
+endif()
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(FairRoot
-                                  DEFAULT_MSG FairRoot_Base
-                                              FairRoot_Tools
-                                              FairRoot_ParBase
-                                              FairRoot_GeoBase
-                                              FairRoot_Gen
-                                              FairRoot_INC)
+                                  REQUIRED_VARS FairRoot_Base
+                                                FairRoot_Tools
+                                                FairRoot_ParBase
+                                                FairRoot_GeoBase
+                                                FairRoot_Gen
+                                                FairRoot_INC
+                                  VERSION_VAR FairRoot_VERSION)
 
 if(NOT TARGET FairRoot::Tools)
   add_library(FairRoot::Tools IMPORTED INTERFACE)


### PR DESCRIPTION
To prepare O2 for the upcoming FairRoot v18.8 release (probably this year still). (See also [alisw/alidist@4687](https://github.com/alisw/alidist/pull/4687))

Preliminary Changelog: https://github.com/FairRootGroup/FairRoot/blob/v18.8_patches/CHANGELOG.md

Although we will release a first CMake package in v18.8, I prefer to keep O2's `FindFairRoot.cmake` for now and remove it earliest with the adoption of FairRoot v19 (probably early next year) to give the CMake package another iteration to mature (I will propose another PR then).