### PR TITLE
TPC fast transform: Add user defined number of knots

### DIFF
--- a/Detectors/TPC/reconstruction/include/TPCReconstruction/TPCFastTransformHelperO2.h
+++ b/Detectors/TPC/reconstruction/include/TPCReconstruction/TPCFastTransformHelperO2.h
@@ -86,7 +86,7 @@ class TPCFastTransformHelperO2
     std::function<void(int roc, int irow, double y, double z, double& dx, double& dy, double& dz)> correctionLocal);
 
   /// creates TPCFastTransform object
-  std::unique_ptr<TPCFastTransform> create(Long_t TimeStamp);
+  std::unique_ptr<TPCFastTransform> create(Long_t TimeStamp, const int nKnotsY = 10, const int nKnotsZ = 20);
 
   /// Updates the transformation with the new time stamp
   int updateCalibration(TPCFastTransform& transform, Long_t TimeStamp, float vDriftFactor = 1.f, float vDriftRef = 0.f);

--- a/Detectors/TPC/reconstruction/src/TPCFastTransformHelperO2.cxx
+++ b/Detectors/TPC/reconstruction/src/TPCFastTransformHelperO2.cxx
@@ -90,7 +90,7 @@ void TPCFastTransformHelperO2::init()
   mIsInitialized = 1;
 }
 
-std::unique_ptr<TPCFastTransform> TPCFastTransformHelperO2::create(Long_t TimeStamp)
+std::unique_ptr<TPCFastTransform> TPCFastTransformHelperO2::create(Long_t TimeStamp, const int nKnotsY, const int nKnotsZ)
 {
   /// initializes TPCFastTransform object
 
@@ -135,10 +135,10 @@ std::unique_ptr<TPCFastTransform> TPCFastTransformHelperO2::create(Long_t TimeSt
       int row = scenario * 10;
       TPCFastSpaceChargeCorrection::SplineType spline;
       if (!mCorrectionMap.isInitialized() || row >= nRows) {
-        spline.recreate(8, 20);
+        spline.recreate(nKnotsY, nKnotsZ);
       } else {
         // TODO: update the calibrator
-        spline.recreate(8, 20);
+        spline.recreate(nKnotsY, nKnotsZ);
         /*
         // create the input function
         for (int knot = 0; knot < raster.getNumberOfKnots(); knot++) {

--- a/GPU/TPCFastTransformation/macro/TPCFastTransformInit.C
+++ b/GPU/TPCFastTransformation/macro/TPCFastTransformInit.C
@@ -39,7 +39,7 @@
 using namespace o2::tpc;
 using namespace o2::gpu;
 
-void TPCFastTransformInit(const char* fileName = "debugVoxRes.root", const char* outFileName = "TPCFastTransform_VoxRes.root")
+void TPCFastTransformInit(const int nKnotsY = 10, const int nKnotsZ = 20, const char* fileName = "debugVoxRes.root", const char* outFileName = "TPCFastTransform_VoxRes.root")
 {
   // Initialise TPCFastTransform object from "voxRes" tree of
   // o2::tpc::TrackResiduals::VoxRes track residual voxels
@@ -98,7 +98,7 @@ void TPCFastTransformInit(const char* fileName = "debugVoxRes.root", const char*
     //    << " dx dy dz " << correctionX << " " << correctionY << " " << correctionZ << endl;
   }
 
-  std::unique_ptr<o2::gpu::TPCFastTransform> fastTransform(helper->create(0));
+  std::unique_ptr<o2::gpu::TPCFastTransform> fastTransform(helper->create(0, nKnotsY, nKnotsZ));
   o2::gpu::TPCFastSpaceChargeCorrection& corr = fastTransform->getCorrection();
 
   // check the difference


### PR DESCRIPTION
Setting default to 10 knots in dY, since it seems to perform better:

For Run 526529, IR 10kHz

10 knots in Y
```
Max difference in x,y,z :  -23.2312 12.716 -2.54799
Mean difference in x,y,z : 0.000355557 0.000121685 6.49824e-05
```

8 knots in Y
```
Max difference in x,y,z :  1777.18 65.3879 -70.6322
Mean difference in x,y,z : 0.0077482 0.000421966 0.000431358
```