### PR TITLE
[EMCAL-798] Add gain calib flag to offline calibrator

### DIFF
--- a/Detectors/EMCAL/workflow/src/OfflineCalibSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/OfflineCalibSpec.cxx
@@ -95,9 +95,9 @@ void OfflineCalibSpec::run(framework::ProcessingContext& pc)
         LOG(debug) << "[EMCALOfflineSpec - run] IsLowGain: " << c.getLowGain();
         float cellE = c.getEnergy();
         if (mGainCalibFactors && mCalibrationHandler->hasGainCalib()) {
-          LOG(info) << "gain calib factor " << mGainCalibFactors->getGainCalibFactors(c.getTower());
+          LOG(debug) << "gain calib factor " << mGainCalibFactors->getGainCalibFactors(c.getTower());
           cellE *= mGainCalibFactors->getGainCalibFactors(c.getTower());
-          LOG(info) << "[EMCALOfflineSpec - run] corrected Energy: " << cellE;
+          LOG(debug) << "[EMCALOfflineSpec - run] corrected Energy: " << cellE;
         }
         mCellAmplitude->Fill(cellE, c.getTower());
         if (cellE > 0.5) {

--- a/prodtests/full-system-test/calib-workflow.sh
+++ b/prodtests/full-system-test/calib-workflow.sh
@@ -28,7 +28,7 @@ if [[ $CALIB_TPC_RESPADGAIN == 1 ]]; then add_W o2-tpc-calib-gainmap-tracks "--p
 if [[ $CALIB_ZDC_TDC == 1 ]]; then add_W o2-zdc-tdccalib-epn-workflow "" "" 0; fi
 if [[ $CALIB_FT0_TIMEOFFSET == 1 ]]; then add_W o2-calibration-ft0-time-spectra-processor; fi
 # for async calibrations
-if [[ $CALIB_EMC_ASYNC_RECALIB == 1 ]]; then add_W o2-emcal-emc-offline-calib-workflow "--input-subspec 1"; fi
+if [[ $CALIB_EMC_ASYNC_RECALIB == 1 ]]; then add_W o2-emcal-emc-offline-calib-workflow "--input-subspec 1 --applyGainCalib"; fi
 
 # output-proxy for aggregator
 if workflow_has_parameter CALIB_PROXIES; then


### PR DESCRIPTION
- EMCal energy calibration should be applied during filling of histograms in offline calibrator. Therefore, added workflow argument introduced in pull/10446
- Fix: Change Log(info) to LOG(debug)