### PR TITLE
Ability to use pre-fixed collision vertices in simulation

### DIFF
--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -34,7 +34,7 @@ void SimConfig::initOptions(boost::program_options::options_description& options
     "skipModules", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>({""}), ""), "list of modules excluded in geometry (precendence over -m")(
     "readoutDetectors", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>(), ""), "list of detectors creating hits, all if not given; added to to active modules")(
     "skipReadoutDetectors", bpo::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>(), ""), "list of detectors to skip hit creation (precendence over --readoutDetectors")(
-    "nEvents,n", bpo::value<unsigned int>()->default_value(1), "number of events")(
+    "nEvents,n", bpo::value<unsigned int>()->default_value(0), "number of events")(
     "startEvent", bpo::value<unsigned int>()->default_value(0), "index of first event to be used (when applicable)")(
     "extKinFile", bpo::value<std::string>()->default_value("Kinematics.root"),
     "name of kinematics file for event generator from file (when applicable)")(
@@ -306,7 +306,7 @@ void SimConfig::adjustFromCollContext()
         // we take what is specified in the context
         mConfigData.mNEvents = collisionmap.size();
       } else {
-        LOG(warning) << "The number of events on the command line and in the collision context differ. Taking the min of the 2";
+        LOG(warning) << "The number of events on the command line " << mConfigData.mNEvents << " and in the collision context differ. Taking the min of the 2";
         mConfigData.mNEvents = std::min((size_t)mConfigData.mNEvents, collisionmap.size());
       }
       LOG(info) << "Setting number of events to simulate to " << mConfigData.mNEvents;

--- a/DataFormats/simulation/include/SimulationDataFormat/DigitizationContext.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/DigitizationContext.h
@@ -124,14 +124,19 @@ class DigitizationContext
   // finalize timeframe structure (fixes the indices in mTimeFrameStartIndex)
   void finalizeTimeframeStructure(long startOrbit, long orbitsPerTF);
 
-  // Sample and fix interaction vertices (according to some distribution). Makes sure that same event id
-  // have to have same vertex.
+  // Sample and fix interaction vertices (according to some distribution). Makes sure that same event ids
+  // have to have same vertex, as well as event ids associated to same collision.
   void sampleInteractionVertices(o2::dataformats::MeanVertexObject const& v);
 
   // helper functions to save and load a context
   void saveToFile(std::string_view filename) const;
 
-  static DigitizationContext const* loadFromFile(std::string_view filename = "");
+  // Return the vector of interaction vertices associated with collisions
+  // The vector is empty if no vertices were provided or sampled. In this case, one
+  // may call "sampleInteractionVertices".
+  std::vector<math_utils::Point3D<float>> const& getInteractionVertices() const { return mInteractionVertices; }
+
+  static DigitizationContext* loadFromFile(std::string_view filename = "");
 
  private:
   int mNofEntries = 0;

--- a/DataFormats/simulation/src/DigitizationContext.cxx
+++ b/DataFormats/simulation/src/DigitizationContext.cxx
@@ -200,7 +200,7 @@ void DigitizationContext::saveToFile(std::string_view filename) const
   file.Close();
 }
 
-DigitizationContext const* DigitizationContext::loadFromFile(std::string_view filename)
+DigitizationContext* DigitizationContext::loadFromFile(std::string_view filename)
 {
   std::string tmpFile;
   if (filename == "") {


### PR DESCRIPTION
This commit makes it possible to use pre-determined collision vertices in the simulation. They can now be read from the collision context and injected into the simulation. This simplifies a lot the assignment and bookkeeping of vertices in embedding procedures.

A workflow in which this is useful is this:

```
o2-steer-colcontexttool -i bkg,1000,10:r4 sgn,@0:e2,10:10 --with-vertices --configKeyValues "Diamond.width[2]=10;Diamond.slopeX=2"

o2-sim --fromCollContext collisioncontext.root -g pythia8pp ... -o bkg

o2-sim --fromCollContext collisioncontext.root -g signalgen ... -o sgn
```

minor fixes in event generation server:
 - do not launch one extra event generation when already done