### PR TITLE
[MCH] load mag field from CCDB

### DIFF
--- a/Detectors/MUON/MCH/Tracking/include/MCHTracking/TrackFinder.h
+++ b/Detectors/MUON/MCH/Tracking/include/MCHTracking/TrackFinder.h
@@ -46,7 +46,8 @@ class TrackFinder
   TrackFinder(TrackFinder&&) = delete;
   TrackFinder& operator=(TrackFinder&&) = delete;
 
-  void init(float l3Current, float dipoleCurrent);
+  void init();
+  void initField(float l3Current, float dipoleCurrent);
 
   const std::list<Track>& findTracks(const std::unordered_map<int, std::list<const Cluster*>>& clusters);
 

--- a/Detectors/MUON/MCH/Tracking/include/MCHTracking/TrackFinderOriginal.h
+++ b/Detectors/MUON/MCH/Tracking/include/MCHTracking/TrackFinderOriginal.h
@@ -40,7 +40,9 @@ class TrackFinderOriginal
   TrackFinderOriginal(TrackFinderOriginal&&) = delete;
   TrackFinderOriginal& operator=(TrackFinderOriginal&&) = delete;
 
-  void init(float l3Current, float dipoleCurrent);
+  void init();
+  void initField(float l3Current, float dipoleCurrent);
+
   const std::list<Track>& findTracks(const std::array<std::list<const Cluster*>, 10>& clusters);
 
   /// set the debug level defining the verbosity

--- a/Detectors/MUON/MCH/Tracking/src/TrackFinder.cxx
+++ b/Detectors/MUON/MCH/Tracking/src/TrackFinder.cxx
@@ -41,12 +41,9 @@ constexpr double TrackFinder::SChamberThicknessInX0[10];
 constexpr int TrackFinder::SNDE[10];
 
 //_________________________________________________________________________________________________
-void TrackFinder::init(float l3Current, float dipoleCurrent)
+void TrackFinder::init()
 {
   /// Prepare to run the algorithm
-
-  // create the magnetic field map if not already done
-  mTrackFitter.initField(l3Current, dipoleCurrent);
 
   // Set the parameters used for fitting the tracks during the tracking
   const auto& trackerParam = TrackerParam::Instance();
@@ -138,6 +135,13 @@ void TrackFinder::init(float l3Current, float dipoleCurrent)
     mClusters[8 + 4 * (iCh - 4) + 3].emplace_back(100 * (iCh + 1) + 17, nullptr);
     mClusters[8 + 4 * (iCh - 4) + 3].emplace_back(100 * (iCh + 1) + 19, nullptr);
   }
+}
+
+//_________________________________________________________________________________________________
+void TrackFinder::initField(float l3Current, float dipoleCurrent)
+{
+  /// create the magnetic field map if not already done
+  mTrackFitter.initField(l3Current, dipoleCurrent);
 }
 
 //_________________________________________________________________________________________________

--- a/Detectors/MUON/MCH/Tracking/src/TrackFinderOriginal.cxx
+++ b/Detectors/MUON/MCH/Tracking/src/TrackFinderOriginal.cxx
@@ -38,12 +38,9 @@ constexpr double TrackFinderOriginal::SDefaultChamberZ[10];
 constexpr double TrackFinderOriginal::SChamberThicknessInX0[10];
 
 //_________________________________________________________________________________________________
-void TrackFinderOriginal::init(float l3Current, float dipoleCurrent)
+void TrackFinderOriginal::init()
 {
   /// Prepare to run the algorithm
-
-  // Create the magnetic field map if not already done
-  mTrackFitter.initField(l3Current, dipoleCurrent);
 
   // Set the parameters used for fitting the tracks during the tracking
   const auto& trackerParam = TrackerParam::Instance();
@@ -65,6 +62,13 @@ void TrackFinderOriginal::init(float l3Current, float dipoleCurrent)
   for (int iCh = 0; iCh < 10; ++iCh) {
     mMaxMCSAngle2[iCh] = TrackExtrap::getMCSAngle2(param, SChamberThicknessInX0[iCh], 1.);
   }
+}
+
+//_________________________________________________________________________________________________
+void TrackFinderOriginal::initField(float l3Current, float dipoleCurrent)
+{
+  /// create the magnetic field map if not already done
+  mTrackFitter.initField(l3Current, dipoleCurrent);
 }
 
 //_________________________________________________________________________________________________

--- a/Detectors/MUON/MCH/Workflow/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Workflow/CMakeLists.txt
@@ -135,13 +135,13 @@ o2_add_executable(
         clusters-to-tracks-original-workflow
         SOURCES src/TrackFinderOriginalSpec.cxx src/clusters-to-tracks-original-workflow.cxx
         COMPONENT_NAME mch
-        PUBLIC_LINK_LIBRARIES O2::Framework O2::DataFormatsMCH O2::MCHTracking)
+        PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2::DataFormatsMCH O2::MCHTracking O2::DataFormatsParameters)
 
 o2_add_executable(
         clusters-to-tracks-workflow
         SOURCES src/TrackFinderSpec.cxx src/clusters-to-tracks-workflow.cxx
         COMPONENT_NAME mch
-        PUBLIC_LINK_LIBRARIES O2::DataFormatsParameters O2::Framework O2::DataFormatsMCH O2::MCHTracking O2::DataFormatsParameters)
+        PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2::DataFormatsMCH O2::MCHTracking O2::DataFormatsParameters)
 
 o2_add_executable(
         vertex-sampler-workflow

--- a/Detectors/MUON/MCH/Workflow/src/TrackFinderOriginalSpec.h
+++ b/Detectors/MUON/MCH/Workflow/src/TrackFinderOriginalSpec.h
@@ -24,7 +24,8 @@ namespace o2
 namespace mch
 {
 
-o2::framework::DataProcessorSpec getTrackFinderOriginalSpec(const char* specName = "mch-track-finder-original");
+o2::framework::DataProcessorSpec getTrackFinderOriginalSpec(const char* specName = "mch-track-finder-original",
+                                                            bool disableCCDBMagField = false);
 
 } // end namespace mch
 } // end namespace o2

--- a/Detectors/MUON/MCH/Workflow/src/TrackFinderSpec.h
+++ b/Detectors/MUON/MCH/Workflow/src/TrackFinderSpec.h
@@ -24,7 +24,8 @@ namespace o2
 namespace mch
 {
 
-o2::framework::DataProcessorSpec getTrackFinderSpec(const char* specName = "mch-track-finder", bool digits = false);
+o2::framework::DataProcessorSpec getTrackFinderSpec(const char* specName = "mch-track-finder",
+                                                    bool digits = false, bool disableCCDBMagField = false);
 
 } // end namespace mch
 } // end namespace o2

--- a/Detectors/MUON/MCH/Workflow/src/clusters-to-tracks-original-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/clusters-to-tracks-original-workflow.cxx
@@ -24,6 +24,9 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
   workflowOptions.emplace_back("configKeyValues", VariantType::String, "",
                                ConfigParamSpec::HelpString{"Semicolon separated key=value strings"});
+  workflowOptions.emplace_back("disable-magfield-from-ccdb",
+                               o2::framework::VariantType::Bool, false,
+                               o2::framework::ConfigParamSpec::HelpString{"do not read magnetic field from ccdb"});
 }
 
 #include "Framework/runDataProcessing.h"
@@ -31,5 +34,6 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 WorkflowSpec defineDataProcessing(const ConfigContext& configcontext)
 {
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
-  return WorkflowSpec{o2::mch::getTrackFinderOriginalSpec()};
+  bool disableCCDBMagField = configcontext.options().get<bool>("disable-magfield-from-ccdb");
+  return WorkflowSpec{o2::mch::getTrackFinderOriginalSpec("mch-track-finder-original", disableCCDBMagField)};
 }

--- a/Detectors/MUON/MCH/Workflow/src/clusters-to-tracks-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/clusters-to-tracks-workflow.cxx
@@ -26,6 +26,9 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
                                ConfigParamSpec::HelpString{"Semicolon separated key=value strings"});
   workflowOptions.emplace_back("digits", VariantType::Bool, false,
                                ConfigParamSpec::HelpString{"Send associated digits"});
+  workflowOptions.emplace_back("disable-magfield-from-ccdb",
+                               o2::framework::VariantType::Bool, false,
+                               o2::framework::ConfigParamSpec::HelpString{"do not read magnetic field from ccdb"});
 }
 
 #include "Framework/runDataProcessing.h"
@@ -34,5 +37,6 @@ WorkflowSpec defineDataProcessing(const ConfigContext& configcontext)
 {
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
   bool digits = configcontext.options().get<bool>("digits");
-  return WorkflowSpec{o2::mch::getTrackFinderSpec("mch-track-finder", digits)};
+  bool disableCCDBMagField = configcontext.options().get<bool>("disable-magfield-from-ccdb");
+  return WorkflowSpec{o2::mch::getTrackFinderSpec("mch-track-finder", digits, disableCCDBMagField)};
 }


### PR DESCRIPTION
By default the magnetic field used for the tracking is now loaded from the CCDB.

It is still possible to get back to the previous settings, i.e. loading the field from the GRP file or creating it with the provided currents if the GRP file is not available, by using the option --disable-magfield-from-ccdb in the tracking workflows.
