### PR TITLE
Fix SCD calib maxTracksPerCalibSlot=-1 option

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
@@ -61,11 +61,14 @@ void TPCInterpolationDPL::updateTimeDependentParams(ProcessingContext& pc)
     // other init-once stuff
     mInterpolation.init();
     int nTfs = mSlotLength / (o2::base::GRPGeomHelper::getNHBFPerTF() * o2::constants::lhc::LHCOrbitMUS * 1e-6);
-    int nTracksPerTfMax = (nTfs > 0) ? SpacePointsCalibConfParam::Instance().maxTracksPerCalibSlot / nTfs : -1;
-    if (nTracksPerTfMax >= 0) {
+    bool limitTracks = (SpacePointsCalibConfParam::Instance().maxTracksPerCalibSlot < 0) ? true : false;
+    int nTracksPerTfMax = (nTfs > 0 && !limitTracks) ? SpacePointsCalibConfParam::Instance().maxTracksPerCalibSlot / nTfs : -1;
+    if (nTracksPerTfMax > 0) {
       LOGP(info, "We will stop processing tracks after validating {} tracks per TF", nTracksPerTfMax);
-    } else {
+    } else if (nTracksPerTfMax < 0) {
       LOG(info) << "The number of processed tracks per TF is not limited";
+    } else {
+      LOG(error) << "No tracks will be processed. maxTracksPerCalibSlot must be greater than slot length in TFs";
     }
     mInterpolation.setMaxTracksPerTF(nTracksPerTfMax);
   }

--- a/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
+++ b/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
@@ -101,14 +101,14 @@ void TrackInterpolation::process(const o2::globaltracking::RecoContainer& inp, c
   std::shuffle(trackIndices.begin() + nTracks, trackIndices.begin() + nTracks + trkCounters.at(GTrackID::Source::ITSTPC), g);
 
   for (int iSeed = 0; iSeed < nSeeds; ++iSeed) {
+    if (mMaxTracksPerTF >= 0 && mTrackDataCompact.size() >= mMaxTracksPerTF) {
+      LOG(info) << "Maximum number of tracks per TF reached. Skipping the remaining " << nSeeds - iSeed << " tracks.";
+      break;
+    }
     if (gids[trackIndices[iSeed]].includesDet(DetID::TRD) || gids[trackIndices[iSeed]].includesDet(DetID::TOF)) {
       interpolateTrack(trackIndices[iSeed]);
     } else {
       extrapolateTrack(trackIndices[iSeed]);
-    }
-    if (mMaxTracksPerTF >= 0 && mTrackDataCompact.size() >= mMaxTracksPerTF) {
-      LOG(info) << "Maximum number of tracks per TF reached. Skipping the remaining " << nSeeds - iSeed << " tracks.";
-      break;
     }
   }
 


### PR DESCRIPTION
When set to -1 (for unlimited number of tracks) it would currently just process 1 track per TF.

With the current software one would need to set `maxTracksPerCalibSlot` to a very high number to avoid the sampling.