### PR TITLE
Workflow for the study of TPC tracks moving effects

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/CMakeLists.txt
+++ b/Detectors/GlobalTrackingWorkflow/CMakeLists.txt
@@ -107,3 +107,5 @@ add_subdirectory(helpers)
 add_subdirectory(readers)
 add_subdirectory(writers)
 add_subdirectory(qc)
+
+add_subdirectory(study)

--- a/Detectors/GlobalTrackingWorkflow/study/CMakeLists.txt
+++ b/Detectors/GlobalTrackingWorkflow/study/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# All rights not expressly granted are reserved.
+#
+# This software is distributed under the terms of the GNU General Public
+# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+o2_add_library(GlobalTrackingStudy
+               SOURCES src/TPCTrackStudy.cxx
+               PUBLIC_LINK_LIBRARIES O2::GlobalTracking
+                                     O2::GlobalTrackingWorkflowReaders
+                                     O2::GlobalTrackingWorkflowHelpers
+                                     O2::DataFormatsGlobalTracking
+                                     O2::SimulationDataFormat)
+
+o2_target_root_dictionary(GlobalTrackingStudy
+                          HEADERS include/GlobalTrackingStudy/TPCTrackStudy.h)
+
+o2_add_executable(study-workflow
+                  COMPONENT_NAME tpc-track
+                  SOURCES src/tpc-track-study-workflow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::GlobalTrackingStudy)

--- a/Detectors/GlobalTrackingWorkflow/study/include/GlobalTrackingStudy/TPCTrackStudy.h
+++ b/Detectors/GlobalTrackingWorkflow/study/include/GlobalTrackingStudy/TPCTrackStudy.h
@@ -1,0 +1,41 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TPCTRACK_STUDY_H
+#define O2_TPCTRACK_STUDY_H
+
+#include "ReconstructionDataFormats/GlobalTrackID.h"
+#include "Framework/Task.h"
+#include "Framework/DataProcessorSpec.h"
+#include "ReconstructionDataFormats/Track.h"
+#include "MathUtils/detail/Bracket.h"
+#include "DataFormatsTPC/ClusterNative.h"
+
+namespace o2::trackstudy
+{
+
+using TBracket = o2::math_utils::Bracketf_t;
+using GTrackID = o2::dataformats::GlobalTrackID;
+
+struct TrackTB {
+  TBracket tBracket{}; ///< bracketing time in \mus
+  float time0{};
+  GTrackID origID{}; ///< track origin id
+  o2::track::TrackParCov trc;
+  ClassDefNV(TrackTB, 1);
+};
+
+/// create a processor spec
+o2::framework::DataProcessorSpec getTPCTrackStudySpec(o2::dataformats::GlobalTrackID::mask_t srcTracks, o2::dataformats::GlobalTrackID::mask_t srcClus, bool useMC);
+
+} // namespace o2::trackstudy
+
+#endif

--- a/Detectors/GlobalTrackingWorkflow/study/src/GlobalTrackingStudyLinkDef.h
+++ b/Detectors/GlobalTrackingWorkflow/study/src/GlobalTrackingStudyLinkDef.h
@@ -1,0 +1,18 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifdef __CLING__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#endif

--- a/Detectors/GlobalTrackingWorkflow/study/src/TPCTrackStudy.cxx
+++ b/Detectors/GlobalTrackingWorkflow/study/src/TPCTrackStudy.cxx
@@ -1,0 +1,295 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <vector>
+#include <TStopwatch.h>
+#include "DataFormatsGlobalTracking/RecoContainer.h"
+#include "DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h"
+#include "TPCCalibration/VDriftHelper.h"
+#include "TPCCalibration/CorrectionMapsLoader.h"
+#include "ReconstructionDataFormats/GlobalTrackID.h"
+#include "DetectorsBase/Propagator.h"
+#include "DetectorsBase/GeometryManager.h"
+#include "SimulationDataFormat/MCEventLabel.h"
+#include "SimulationDataFormat/MCUtils.h"
+#include "CommonUtils/NameConf.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/CCDBParamSpec.h"
+#include "DetectorsCommonDataFormats/DetID.h"
+#include "DetectorsBase/GRPGeomHelper.h"
+#include "GlobalTrackingStudy/TPCTrackStudy.h"
+#include "GPUO2InterfaceRefit.h"
+#include "TPCBase/ParameterElectronics.h"
+#include "CommonUtils/TreeStreamRedirector.h"
+#include "Steer/MCKinematicsReader.h"
+
+namespace o2::trackstudy
+{
+
+using namespace o2::framework;
+using DetID = o2::detectors::DetID;
+using DataRequest = o2::globaltracking::DataRequest;
+
+using PVertex = o2::dataformats::PrimaryVertex;
+using V2TRef = o2::dataformats::VtxTrackRef;
+using VTIndex = o2::dataformats::VtxTrackIndex;
+using GTrackID = o2::dataformats::GlobalTrackID;
+using TBracket = o2::math_utils::Bracketf_t;
+
+using timeEst = o2::dataformats::TimeStampWithError<float, float>;
+
+class TPCTrackStudySpec : public Task
+{
+ public:
+  TPCTrackStudySpec(std::shared_ptr<DataRequest> dr, std::shared_ptr<o2::base::GRPGeomRequest> gr, GTrackID::mask_t src, bool useMC)
+    : mDataRequest(dr), mGGCCDBRequest(gr), mTracksSrc(src), mUseMC(useMC)
+  {
+  }
+  ~TPCTrackStudySpec() final = default;
+  void init(InitContext& ic) final;
+  void run(ProcessingContext& pc) final;
+  void endOfStream(EndOfStreamContext& ec) final;
+  void finaliseCCDB(ConcreteDataMatcher& matcher, void* obj) final;
+  void process(o2::globaltracking::RecoContainer& recoData);
+
+ private:
+  void updateTimeDependentParams(ProcessingContext& pc);
+  std::shared_ptr<DataRequest> mDataRequest;
+  std::shared_ptr<o2::base::GRPGeomRequest> mGGCCDBRequest;
+  o2::tpc::VDriftHelper mTPCVDriftHelper{};
+  o2::tpc::CorrectionMapsLoader mTPCCorrMapsLoader{};
+  bool mUseMC{false}; ///< MC flag
+  float mRRef = 0.;
+  std::unique_ptr<o2::utils::TreeStreamRedirector> mDBGOut;
+  float mITSROFrameLengthMUS = 0.;
+  GTrackID::mask_t mTracksSrc{};
+  o2::steer::MCKinematicsReader mcReader; // reader of MC information
+  //
+  // TPC data
+  gsl::span<const o2::tpc::TPCClRefElem> mTPCTrackClusIdx;            ///< input TPC track cluster indices span
+  gsl::span<const o2::tpc::TrackTPC> mTPCTracksArray;                 ///< input TPC tracks span
+  gsl::span<const unsigned char> mTPCRefitterShMap;                   ///< externally set TPC clusters sharing map
+  const o2::tpc::ClusterNativeAccess* mTPCClusterIdxStruct = nullptr; ///< struct holding the TPC cluster indices
+  gsl::span<const o2::MCCompLabel> mTPCTrkLabels;                     ///< input TPC Track MC labels
+  std::unique_ptr<o2::gpu::GPUO2InterfaceRefit> mTPCRefitter;         ///< TPC refitter used for TPC tracks refit during the reconstruction
+};
+
+void TPCTrackStudySpec::init(InitContext& ic)
+{
+  o2::base::GRPGeomHelper::instance().setRequest(mGGCCDBRequest);
+  mRRef = ic.options().get<float>("target-radius");
+  if (mRRef < 0.) {
+    mRRef = 0.;
+  }
+  mDBGOut = std::make_unique<o2::utils::TreeStreamRedirector>("tpc-trackStudy.root", "recreate");
+}
+
+void TPCTrackStudySpec::run(ProcessingContext& pc)
+{
+  o2::globaltracking::RecoContainer recoData;
+  recoData.collectData(pc, *mDataRequest.get()); // select tracks of needed type, with minimal cuts, the real selected will be done in the vertexer
+  updateTimeDependentParams(pc);                 // Make sure this is called after recoData.collectData, which may load some conditions
+  process(recoData);
+}
+
+void TPCTrackStudySpec::updateTimeDependentParams(ProcessingContext& pc)
+{
+  o2::base::GRPGeomHelper::instance().checkUpdates(pc);
+  o2::tpc::VDriftHelper::extractCCDBInputs(pc);
+  o2::tpc::CorrectionMapsLoader::extractCCDBInputs(pc);
+  static bool initOnceDone = false;
+  if (!initOnceDone) { // this params need to be queried only once
+    initOnceDone = true;
+    // none at the moment
+  }
+  // we may have other params which need to be queried regularly
+  bool updateMaps = false;
+  if (mTPCCorrMapsLoader.isUpdated()) {
+    mTPCCorrMapsLoader.acknowledgeUpdate();
+    updateMaps = true;
+  }
+  if (mTPCVDriftHelper.isUpdated()) {
+    LOGP(info, "Updating TPC fast transform map with new VDrift factor of {} wrt reference {} from source {}",
+         mTPCVDriftHelper.getVDriftObject().corrFact, mTPCVDriftHelper.getVDriftObject().refVDrift, mTPCVDriftHelper.getSourceName());
+    mTPCVDriftHelper.acknowledgeUpdate();
+    updateMaps = true;
+  }
+  if (updateMaps) {
+    mTPCCorrMapsLoader.updateVDrift(mTPCVDriftHelper.getVDriftObject().corrFact, mTPCVDriftHelper.getVDriftObject().refVDrift);
+  }
+}
+
+void TPCTrackStudySpec::process(o2::globaltracking::RecoContainer& recoData)
+{
+  if (mUseMC) { // extract MC tracks
+    auto prop = o2::base::Propagator::Instance();
+
+    const o2::steer::DigitizationContext* digCont = nullptr;
+    if (!mcReader.initFromDigitContext("collisioncontext.root")) {
+      throw std::invalid_argument("initialization of MCKinematicsReader failed");
+    }
+    digCont = mcReader.getDigitizationContext();
+    const auto& intRecs = digCont->getEventRecords();
+
+    mTPCTracksArray = recoData.getTPCTracks();
+    mTPCTrackClusIdx = recoData.getTPCTracksClusterRefs();
+    mTPCClusterIdxStruct = &recoData.inputsTPCclusters->clusterIndex;
+    mTPCRefitterShMap = recoData.clusterShMapTPC;
+    mTPCTrkLabels = recoData.getTPCTracksMCLabels();
+
+    mTPCRefitter = std::make_unique<o2::gpu::GPUO2InterfaceRefit>(mTPCClusterIdxStruct, &mTPCCorrMapsLoader, prop->getNominalBz(), mTPCTrackClusIdx.data(), mTPCRefitterShMap.data(), nullptr, o2::base::Propagator::Instance());
+
+    float vdriftTB = mTPCVDriftHelper.getVDriftObject().getVDrift() * o2::tpc::ParameterElectronics::Instance().ZbinWidth; // VDrift expressed in cm/TimeBin
+
+    float RRef2 = mRRef * mRRef;
+    const o2::MCTrack* mcTrack = nullptr;
+    for (size_t itr = 0; itr < mTPCTracksArray.size(); itr++) {
+      auto tr = mTPCTracksArray[itr]; // create track copy
+
+      // create refitted copy
+      auto trf = tr.getOuterParam(); // we refit inward
+      float chi2Out = 0;
+      // impose MC time in TPC timebin and refit inward after resetted covariance
+      int retVal = mTPCRefitter->RefitTrackAsTrackParCov(trf, mTPCTracksArray[itr].getClusterRef(), tr.getTime0(), &chi2Out, false, true);
+      if (retVal < 0) {
+        LOGP(warn, "Refit failed ({}) with originaltime0: {} : {}", retVal, tr.getTime0(), ((const o2::track::TrackPar&)tr.getOuterParam()).asString());
+        continue;
+      }
+      // propagate original track
+      if (!tr.rotate(tr.getPhi())) {
+        continue;
+      }
+      float curR2 = tr.getX() * tr.getX() + tr.getY() * tr.getY();
+      if (curR2 > RRef2) { // try to propagate as close as possible to target radius
+        float xtgt = 0;
+        if (!tr.getXatLabR(mRRef, xtgt, prop->getNominalBz(), o2::track::DirInward)) {
+          xtgt = 0;
+        }
+        prop->PropagateToXBxByBz(tr, xtgt); // propagation will not necessarilly converge, but we don't care
+        if (!tr.rotate(tr.getPhi())) {
+          continue;
+        }
+      }
+      // propagate original/refitted track
+      if (!trf.rotate(tr.getPhi())) {
+        continue;
+      }
+      curR2 = trf.getX() * trf.getX() + trf.getY() * trf.getY();
+      if (curR2 > RRef2) { // try to propagate as close as possible to target radius
+        float xtgt = 0;
+        if (!trf.getXatLabR(mRRef, xtgt, prop->getNominalBz(), o2::track::DirInward)) {
+          xtgt = 0;
+        }
+        prop->PropagateToXBxByBz(trf, xtgt); // propagation will not necessarilly converge, but we don't care
+        // propagate to the same alpha/X as the original track
+        if (!trf.rotate(tr.getAlpha()) || !prop->PropagateToXBxByBz(trf, tr.getX())) {
+          continue;
+        }
+      }
+
+      // extract MC truth
+      auto lbl = mTPCTrkLabels[itr];
+      if (!lbl.isValid() || !(mcTrack = mcReader.getTrack(lbl))) {
+        continue;
+      }
+      long bc = intRecs[lbl.getEventID()].toLong(); // bunch crossing of the interaction
+      float bcTB = bc / 8.;                         // the same in TPC timebins
+      // create MC truth track in O2 format
+      std::array<float, 3> xyz{(float)mcTrack->GetStartVertexCoordinatesX(), (float)mcTrack->GetStartVertexCoordinatesY(), (float)mcTrack->GetStartVertexCoordinatesZ()},
+        pxyz{(float)mcTrack->GetStartVertexMomentumX(), (float)mcTrack->GetStartVertexMomentumY(), (float)mcTrack->GetStartVertexMomentumZ()};
+      TParticlePDG* pPDG = TDatabasePDG::Instance()->GetParticle(mcTrack->GetPdgCode());
+      if (!pPDG) {
+        continue;
+      }
+      o2::track::TrackPar mctrO2(xyz, pxyz, (pPDG->Charge() + 0.1) / 3, false);
+      //
+      // propagate it to the alpha/X of the reconstructed track
+      if (!mctrO2.rotate(tr.getAlpha()) || !prop->PropagateToXBxByBz(mctrO2, tr.getX())) {
+        continue;
+      }
+      //
+      // now create a properly refitted track with correct time and distortions correction
+      auto trackRefit = tr.getOuterParam(); // we refit inward
+      chi2Out = 0;
+      // impose MC time in TPC timebin and refit inward after resetted covariance
+      retVal = mTPCRefitter->RefitTrackAsTrackParCov(trackRefit, mTPCTracksArray[itr].getClusterRef(), bcTB, &chi2Out, false, true);
+      if (retVal < 0) {
+        LOGP(warn, "Refit failed ({}), imposed time0: {} conventional time0: \n{}", retVal, bcTB, tr.getTime0(), ((o2::track::TrackPar&)trackRefit).asString());
+        continue;
+      }
+      // propagate the refitted track to the same X/alpha as original track
+      if (!trackRefit.rotate(tr.getAlpha()) || !prop->PropagateToXBxByBz(trackRefit, tr.getX())) {
+        LOGP(warn, "Failed to propagate refitted track [{}] to X/alpha of original track [{}]", trackRefit.asString(), tr.asString());
+        continue;
+      }
+      // estimate Z shift in case of no-distortions
+      float dz = (tr.getTime0() - bcTB) * vdriftTB;
+      if (tr.hasCSideClustersOnly()) {
+        dz = -dz;
+      } else if (tr.hasBothSidesClusters()) {
+        dz = 0; // CE crossing tracks should not be shifted
+      }
+      // store results
+      (*mDBGOut) << "tpc"
+                 << "iniTrack=" << tr
+                 << "intTrackRef=" << trf
+                 << "movTrackRef=" << trackRefit
+                 << "mcTrack=" << mctrO2
+                 << "imposedTB=" << bcTB << "dz=" << dz << "\n";
+    }
+  }
+}
+
+void TPCTrackStudySpec::endOfStream(EndOfStreamContext& ec)
+{
+  mDBGOut.reset();
+}
+
+void TPCTrackStudySpec::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
+{
+  if (o2::base::GRPGeomHelper::instance().finaliseCCDB(matcher, obj)) {
+    return;
+  }
+  if (mTPCVDriftHelper.accountCCDBInputs(matcher, obj)) {
+    return;
+  }
+  if (mTPCCorrMapsLoader.accountCCDBInputs(matcher, obj)) {
+    return;
+  }
+}
+
+DataProcessorSpec getTPCTrackStudySpec(GTrackID::mask_t srcTracks, GTrackID::mask_t srcClusters, bool useMC)
+{
+  std::vector<OutputSpec> outputs;
+  auto dataRequest = std::make_shared<DataRequest>();
+
+  dataRequest->requestTracks(srcTracks, useMC);
+  dataRequest->requestClusters(srcClusters, useMC);
+  auto ggRequest = std::make_shared<o2::base::GRPGeomRequest>(false,                             // orbitResetTime
+                                                              true,                              // GRPECS=true
+                                                              false,                             // GRPLHCIF
+                                                              true,                              // GRPMagField
+                                                              true,                              // askMatLUT
+                                                              o2::base::GRPGeomRequest::Aligned, // geometry
+                                                              dataRequest->inputs,
+                                                              true);
+  o2::tpc::VDriftHelper::requestCCDBInputs(dataRequest->inputs);
+  o2::tpc::CorrectionMapsLoader::requestCCDBInputs(dataRequest->inputs);
+
+  return DataProcessorSpec{
+    "tpc-track-study",
+    dataRequest->inputs,
+    outputs,
+    AlgorithmSpec{adaptFromTask<TPCTrackStudySpec>(dataRequest, ggRequest, srcTracks, useMC)},
+    Options{{"target-radius", VariantType::Float, 70.f, {"Try to propagate to this radius"}}}};
+}
+
+} // namespace o2::trackstudy

--- a/Detectors/GlobalTrackingWorkflow/study/src/tpc-track-study-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/study/src/tpc-track-study-workflow.cxx
@@ -1,0 +1,78 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "GlobalTrackingStudy/TPCTrackStudy.h"
+#include "ReconstructionDataFormats/GlobalTrackID.h"
+#include "DetectorsCommonDataFormats/DetID.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "Framework/CompletionPolicy.h"
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
+#include "Framework/CallbacksPolicy.h"
+#include "DetectorsBase/DPLWorkflowUtils.h"
+#include "GlobalTrackingWorkflowHelpers/InputHelper.h"
+#include "DetectorsRaw/HBFUtilsInitializer.h"
+
+using namespace o2::framework;
+using GID = o2::dataformats::GlobalTrackID;
+using DetID = o2::detectors::DetID;
+
+// ------------------------------------------------------------------
+void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
+{
+  o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  std::vector<o2::framework::ConfigParamSpec> options{
+    {"disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation"}},
+    {"track-sources", VariantType::String, std::string{GID::ALL}, {"comma-separated list of track sources to use"}},
+    {"cluster-sources", VariantType::String, std::string{GID::ALL}, {"comma-separated list of cluster sources to use"}},
+    {"disable-root-input", VariantType::Bool, false, {"disable root-files input reader"}},
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
+  o2::raw::HBFUtilsInitializer::addConfigOption(options);
+  std::swap(workflowOptions, options);
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  WorkflowSpec specs;
+
+  GID::mask_t allowedSourcesTrc = GID::getSourcesMask("TPC");
+  GID::mask_t allowedSourcesClus = GID::getSourcesMask("TPC");
+
+  // Update the (declared) parameters if changed from the command line
+  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
+
+  auto useMC = !configcontext.options().get<bool>("disable-mc");
+  if (!useMC) {
+    LOG(info) << "this task requires MC info, enforcing it";
+    useMC = true;
+  }
+  GID::mask_t srcTrc = allowedSourcesTrc & GID::getSourcesMask(configcontext.options().get<std::string>("track-sources"));
+  GID::mask_t srcCls = allowedSourcesClus & GID::getSourcesMask(configcontext.options().get<std::string>("cluster-sources"));
+
+  o2::globaltracking::InputHelper::addInputSpecs(configcontext, specs, srcCls, srcTrc, srcTrc, useMC);
+  o2::globaltracking::InputHelper::addInputSpecsPVertex(configcontext, specs, useMC); // P-vertex is always needed
+  specs.emplace_back(o2::trackstudy::getTPCTrackStudySpec(srcTrc, srcCls, useMC));
+
+  // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit
+  o2::raw::HBFUtilsInitializer hbfIni(configcontext, specs);
+
+  return std::move(specs);
+}


### PR DESCRIPTION
Read TPC tracks produced in MC and write a tree with the 3 versions of the same TPC track: 

1) iniTrack: track produced in reconstruction and propagated as close as possible to some reference X. At the point reached after the propagation, the track is rotated to the alpha corresponding to its pT direction

2) mcTrack: MC track corresponding to reconstructed track converted to the O2 TrackPar (no covariance) format and propagated to the alpha and X of the iniTrack.

3) iniTrack refitted with the time corresponding to MC-truth track time and rotated/propagated to alpha and X of the iniTrack

4) Write also the distance by which Z of the iniTrack would be changed when imposed true time in the absence of distortions.