### PR TITLE
[FOCAL-10] Enable pixel mapping in build

### DIFF
--- a/Detectors/FOCAL/reconstruction/CMakeLists.txt
+++ b/Detectors/FOCAL/reconstruction/CMakeLists.txt
@@ -16,6 +16,7 @@ o2_add_library(FOCALReconstruction
         src/PadMapper.cxx
         src/PixelLaneData.cxx
         src/PixelDecoder.cxx
+        src/PixelMapper.cxx
         PUBLIC_LINK_LIBRARIES O2::CommonDataFormat O2::Headers O2::DataFormatsFOCAL O2::ITSMFTReconstruction
         AliceO2::InfoLogger
         Microsoft.GSL::GSL)

--- a/Detectors/FOCAL/reconstruction/src/PixelMapper.cxx
+++ b/Detectors/FOCAL/reconstruction/src/PixelMapper.cxx
@@ -184,7 +184,7 @@ const PixelMapping& PixelMapper::getMapping(unsigned int feeID) const
   return *(mMappings[feeID % 2]);
 }
 
-std::ostream& o2::xfocal::operator<<(std::ostream& stream, const PixelMapping::InvalidChipException& error)
+std::ostream& o2::focal::operator<<(std::ostream& stream, const PixelMapping::InvalidChipException& error)
 {
   error.print(stream);
   return stream;


### PR DESCRIPTION
Pixel mapper provides the mapping between
pixel chip identifier and position in pixel layer
of the two testbeam setups used in the SPS
testbeam Nov 22.