### PR TITLE
Provide trivial MC engine and application

### DIFF
--- a/Common/SimConfig/src/SimConfig.cxx
+++ b/Common/SimConfig/src/SimConfig.cxx
@@ -180,9 +180,20 @@ bool SimConfig::resetFromParsedMap(boost::program_options::variables_map const& 
 {
   using o2::detectors::DetID;
   mConfigData.mMCEngine = vm["mcEngine"].as<std::string>();
+  mConfigData.mNoGeant = vm["noGeant"].as<bool>();
 
   // get final set of active Modules
   determineActiveModules(vm["modules"].as<std::vector<std::string>>(), vm["skipModules"].as<std::vector<std::string>>(), mConfigData.mActiveModules, mConfigData.mIsRun5);
+  if (mConfigData.mNoGeant) {
+    // CAVE is all that's needed (and that will be built either way), so clear all modules and set the O2TrivialMCEngine
+    mConfigData.mActiveModules.clear();
+    // force usage of O2TrivialMCEngine, no overhead from actual transport engine initialisation
+    mConfigData.mMCEngine = "O2TrivialMCEngine";
+  } else if (mConfigData.mMCEngine.compare("O2TrivialMCEngine") == 0) {
+    LOG(error) << "The O2TrivialMCEngine engine can only be used with --noGeant option";
+    return false;
+  }
+
   const auto& activeModules = mConfigData.mActiveModules;
 
   // get final set of detectors which are readout
@@ -215,7 +226,6 @@ bool SimConfig::resetFromParsedMap(boost::program_options::variables_map const& 
   mConfigData.mRunNumber = vm["run"].as<int>();
   mConfigData.mCCDBUrl = vm["CCDBUrl"].as<std::string>();
   mConfigData.mAsService = vm["asservice"].as<bool>();
-  mConfigData.mNoGeant = vm["noGeant"].as<bool>();
   mConfigData.mForwardKine = vm["forwardKine"].as<bool>();
   mConfigData.mWriteToDisc = !vm["noDiscOutput"].as<bool>();
   if (vm.count("noemptyevents")) {

--- a/Detectors/CMakeLists.txt
+++ b/Detectors/CMakeLists.txt
@@ -53,6 +53,10 @@ if(BUILD_SIMULATION)
   o2_data_file(COPY gconfig DESTINATION Detectors)
 endif()
 
+if(BUILD_SIMULATION)
+  add_subdirectory(O2TrivialMC)
+endif()
+
 o2_data_file(COPY Geometry DESTINATION Detectors)
 
 if(ENABLE_UPGRADES)

--- a/Detectors/O2TrivialMC/CMakeLists.txt
+++ b/Detectors/O2TrivialMC/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# All rights not expressly granted are reserved.
+#
+# This software is distributed under the terms of the GNU General Public
+# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+o2_add_library(O2TrivialMC
+               PUBLIC_LINK_LIBRARIES MC::VMC)
+
+o2_target_root_dictionary(O2TrivialMC
+                          HEADERS include/O2TrivialMC/O2TrivialMCEngine.h
+                          include/O2TrivialMC/O2TrivialMCApplication.h)

--- a/Detectors/O2TrivialMC/include/O2TrivialMC/O2TrivialMCApplication.h
+++ b/Detectors/O2TrivialMC/include/O2TrivialMC/O2TrivialMCApplication.h
@@ -1,0 +1,65 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+// An absolut minimal implementation of a TVirtualMCApplication for studies and code that e.g. only depends on the presence of a VMC.
+
+#ifndef ALICEO2_MC_TRIVIALMCAPPLICATION_H_
+#define ALICEO2_MC_TRIVIALMCAPPLICATION_H_
+
+#include "TGeoManager.h"
+#include "TGeoBBox.h"
+#include "TGeoMaterial.h"
+#include "TGeoMedium.h"
+
+#include "TVirtualMCApplication.h"
+
+namespace o2
+{
+
+namespace mc
+{
+
+class O2TrivialMCApplication : public TVirtualMCApplication
+{
+ public:
+  O2TrivialMCApplication() : TVirtualMCApplication("O2TrivialMCApplication", "O2TrivialMCApplication") {}
+  ~O2TrivialMCApplication() override = default;
+  O2TrivialMCApplication(O2TrivialMCApplication const& app) {}
+  void ConstructGeometry() override
+  {
+    auto geoMgr = gGeoManager;
+    // we need some dummies, any material and medium will do
+    auto mat = new TGeoMaterial("vac", 0, 0, 0);
+    auto med = new TGeoMedium("vac", 1, mat);
+    auto vol = geoMgr->MakeBox("cave", med, 1, 1, 1);
+    geoMgr->SetTopVolume(vol);
+    geoMgr->CloseGeometry();
+  }
+  void InitGeometry() override {}
+  void GeneratePrimaries() override {}
+  void BeginEvent() override {}
+  void BeginPrimary() override {}
+  void PreTrack() override {}
+  void Stepping() override {}
+  void PostTrack() override {}
+  void FinishPrimary() override {}
+  void FinishEvent() override {}
+  TVirtualMCApplication* CloneForWorker() const override
+  {
+    return new O2TrivialMCApplication(*this);
+  }
+};
+
+} // namespace mc
+
+} // namespace o2
+
+#endif

--- a/Detectors/O2TrivialMC/include/O2TrivialMC/O2TrivialMCEngine.h
+++ b/Detectors/O2TrivialMC/include/O2TrivialMC/O2TrivialMCEngine.h
@@ -1,0 +1,956 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+// An absolut minimal implementation of a TVirtualMC.
+
+#ifndef ALICEO2_MC_TRIVIALMCENGINE_H_
+#define ALICEO2_MC_TRIVIALMCENGINE_H_
+
+#include <TVector3.h>
+#include <TLorentzVector.h>
+
+#include <TMCProcess.h>
+
+#include <TVirtualMC.h>
+#include <TParticle.h>
+#include <TVirtualMCStack.h>
+#include <TMCManager.h>
+
+namespace o2
+{
+
+namespace mc
+{
+
+class O2TrivialMCEngine : public TVirtualMC
+{
+
+ public:
+  O2TrivialMCEngine()
+    : TVirtualMC("O2TrivialMCEngine", "O2TrivialMCEngine")
+  {
+    fApplication->ConstructGeometry();
+  }
+
+  /// For now just default destructor
+  ~O2TrivialMCEngine() override = default;
+
+  //
+  // All the derived stuff
+  //
+
+  Bool_t IsRootGeometrySupported() const override
+  {
+    return kTRUE;
+  }
+
+  //
+  // functions from GCONS
+  // ------------------------------------------------
+  //
+
+  void Material(Int_t& kmat, const char* name, Double_t a,
+                Double_t z, Double_t dens, Double_t radl, Double_t absl,
+                Float_t* buf, Int_t nwbuf) override
+  {
+    Warning("Material", "Not implemented in this trivial engine");
+  }
+
+  void Material(Int_t& kmat, const char* name, Double_t a,
+                Double_t z, Double_t dens, Double_t radl, Double_t absl,
+                Double_t* buf, Int_t nwbuf) override
+  {
+    Warning("Material", "Not implemented in this trivial engine");
+  }
+
+  void Mixture(Int_t& kmat, const char* name, Float_t* a,
+               Float_t* z, Double_t dens, Int_t nlmat, Float_t* wmat) override
+  {
+    Warning("Mixture", "Not implemented in this trivial engine");
+  }
+
+  void Mixture(Int_t& kmat, const char* name, Double_t* a,
+               Double_t* z, Double_t dens, Int_t nlmat, Double_t* wmat) override
+  {
+    Warning("Mixture", "Not implemented in this trivial engine");
+  }
+
+  void Medium(Int_t& kmed, const char* name, Int_t nmat,
+              Int_t isvol, Int_t ifield, Double_t fieldm, Double_t tmaxfd,
+              Double_t stemax, Double_t deemax, Double_t epsil,
+              Double_t stmin, Float_t* ubuf, Int_t nbuf) override
+  {
+    Warning("Medium", "Not implemented in this trivial engine");
+  }
+
+  void Medium(Int_t& kmed, const char* name, Int_t nmat,
+              Int_t isvol, Int_t ifield, Double_t fieldm, Double_t tmaxfd,
+              Double_t stemax, Double_t deemax, Double_t epsil,
+              Double_t stmin, Double_t* ubuf, Int_t nbuf) override
+  {
+    Warning("Medium", "Not implemented in this trivial engine");
+  }
+
+  void Matrix(Int_t& krot, Double_t thetaX, Double_t phiX,
+              Double_t thetaY, Double_t phiY, Double_t thetaZ,
+              Double_t phiZ) override
+  {
+    Warning("Matrix", "Not implemented in this trivial engine");
+  }
+
+  void Gstpar(Int_t itmed, const char* param, Double_t parval) override
+  {
+    Warning("Gstpar", "Not implemented in this trivial engine");
+  }
+
+  //
+  // functions from GGEOM
+  // ------------------------------------------------
+  //
+
+  Int_t Gsvolu(const char* name, const char* shape, Int_t nmed,
+               Float_t* upar, Int_t np) override
+  {
+    Warning("Gsvolu", "Not implemented in this trivial engine");
+    return -1;
+  }
+
+  Int_t Gsvolu(const char* name, const char* shape, Int_t nmed,
+               Double_t* upar, Int_t np) override
+  {
+    Warning("Gsvolu", "Not implemented in this trivial engine");
+    return -1;
+  }
+
+  void Gsdvn(const char* name, const char* mother, Int_t ndiv,
+             Int_t iaxis) override
+  {
+    Warning("Gsdvn", "Not implemented in this trivial engine");
+  }
+
+  void Gsdvn2(const char* name, const char* mother, Int_t ndiv,
+              Int_t iaxis, Double_t c0i, Int_t numed) override
+  {
+    Warning("Gsdvn2", "Not implemented in this trivial engine");
+  }
+
+  void Gsdvt(const char* name, const char* mother, Double_t step,
+             Int_t iaxis, Int_t numed, Int_t ndvmx) override
+  {
+    Warning("Gsdvt", "Not implemented in this trivial engine");
+  }
+
+  void Gsdvt2(const char* name, const char* mother, Double_t step,
+              Int_t iaxis, Double_t c0, Int_t numed, Int_t ndvmx) override
+  {
+    Warning("Gsdvt2", "Not implemented in this trivial engine");
+  }
+
+  void Gsord(const char* name, Int_t iax) override
+  {
+    Warning("Gsord", "Not implemented in this trivial engine");
+  }
+
+  void Gspos(const char* name, Int_t nr, const char* mother,
+             Double_t x, Double_t y, Double_t z, Int_t irot,
+             const char* konly = "ONLY") override
+  {
+    Warning("Gspos", "Not implemented in this trivial engine");
+  }
+
+  void Gsposp(const char* name, Int_t nr, const char* mother,
+              Double_t x, Double_t y, Double_t z, Int_t irot,
+              const char* konly, Float_t* upar, Int_t np) override
+  {
+    Warning("Gsposp", "Not implemented in this trivial engine");
+  }
+
+  void Gsposp(const char* name, Int_t nr, const char* mother,
+              Double_t x, Double_t y, Double_t z, Int_t irot,
+              const char* konly, Double_t* upar, Int_t np) override
+  {
+    Warning("Gsposp", "Not implemented in this trivial engine");
+  }
+
+  void Gsbool(const char* onlyVolName, const char* manyVolName) override
+  {
+    Warning("Gsbool", "Not implemented in this trivial engine");
+  }
+
+  //
+  // functions for definition of surfaces
+  // and material properties for optical physics
+  // ------------------------------------------------
+  //
+
+  void SetCerenkov(Int_t itmed, Int_t npckov, Float_t* ppckov, Float_t* absco, Float_t* effic, Float_t* rindex, Bool_t aspline = false, Bool_t rspline = false) override
+  {
+    Warning("SetCerenkov", "Not implemented in this trivial engine");
+  }
+
+  void SetCerenkov(Int_t itmed, Int_t npckov, Double_t* ppckov, Double_t* absco, Double_t* effic, Double_t* rindex, Bool_t aspline = false, Bool_t rspline = false) override
+  {
+    Warning("SetCerenkov", "Not implemented in this trivial engine");
+  }
+
+  void DefineOpSurface(const char* name,
+                       EMCOpSurfaceModel model,
+                       EMCOpSurfaceType surfaceType,
+                       EMCOpSurfaceFinish surfaceFinish,
+                       Double_t sigmaAlpha) override
+  {
+    Warning("DefineOpSurface", "Not implemented in this trivial engine");
+  }
+
+  void SetBorderSurface(const char* name,
+                        const char* vol1Name, int vol1CopyNo,
+                        const char* vol2Name, int vol2CopyNo,
+                        const char* opSurfaceName) override
+  {
+    Warning("SetBorderSurface", "Not implemented in this trivial engine");
+  }
+
+  void SetSkinSurface(const char* name,
+                      const char* volName,
+                      const char* opSurfaceName) override
+  {
+    Warning("SetSkinSurface", "Not implemented in this trivial engine");
+  }
+
+  void SetMaterialProperty(Int_t itmed, const char* propertyName, Int_t np, Double_t* pp, Double_t* values, Bool_t createNewKey = false, Bool_t spline = false) override
+  {
+    Warning("SetMaterialProperty", "Not implemented in this trivial engine");
+  }
+  void SetMaterialProperty(Int_t itmed, const char* propertyName, Double_t value) override
+  {
+    Warning("SetMaterialProperty", "Not implemented in this trivial engine");
+  }
+  void SetMaterialProperty(const char* surfaceName, const char* propertyName, Int_t np, Double_t* pp, Double_t* values, Bool_t createNewKey = false, Bool_t spline = false) override
+  {
+    Warning("SetMaterialProperty", "Not implemented in this trivial engine");
+  }
+
+  //
+  // functions for access to geometry
+  // ------------------------------------------------
+  //
+
+  Bool_t GetTransformation(const TString& volumePath,
+                           TGeoHMatrix& matrix) override
+  {
+    Warning("GetTransformation", "Not implemented in this trivial engine");
+    return kFALSE;
+  }
+
+  Bool_t GetShape(const TString& volumePath,
+                  TString& shapeType, TArrayD& par) override
+  {
+    Warning("GetShape", "Not implemented in this trivial engine");
+    return kFALSE;
+  }
+
+  Bool_t GetMaterial(Int_t imat, TString& name,
+                     Double_t& a, Double_t& z, Double_t& density,
+                     Double_t& radl, Double_t& inter, TArrayD& par) override
+  {
+    Warning("GetMaterial", "Not implemented in this trivial engine");
+    return kFALSE;
+  }
+
+  Bool_t GetMaterial(const TString& volumeName,
+                     TString& name, Int_t& imat,
+                     Double_t& a, Double_t& z, Double_t& density,
+                     Double_t& radl, Double_t& inter, TArrayD& par) override
+  {
+    Warning("GetMaterial", "Not implemented in this trivial engine");
+    return kFALSE;
+  }
+
+  Bool_t GetMedium(const TString& volumeName,
+                   TString& name, Int_t& imed,
+                   Int_t& nmat, Int_t& isvol, Int_t& ifield,
+                   Double_t& fieldm, Double_t& tmaxfd, Double_t& stemax,
+                   Double_t& deemax, Double_t& epsil, Double_t& stmin,
+                   TArrayD& par) override
+  {
+    Warning("GetMedium", "Not implemented in this trivial engine");
+    return kFALSE;
+  }
+
+  void WriteEuclid(const char* filnam, const char* topvol,
+                   Int_t number, Int_t nlevel) override
+  {
+    Warning("WriteEuclid", "Not implemented in this trivial engine");
+  }
+
+  void SetRootGeometry() override {}
+
+  void SetUserParameters(Bool_t isUserParameters) override
+  {
+    Warning("SetUserParameters", "Not implemented in this trivial engine");
+  }
+
+  //
+  // get methods
+  // ------------------------------------------------
+  //
+
+  Int_t VolId(const char* volName) const override
+  {
+    Warning("VolId", "Not implemented in this trivial engine");
+    return -1;
+  }
+
+  const char* VolName(Int_t id) const override
+  {
+    Warning("VolName", "Not implemented in this trivial engine");
+    return "";
+  }
+
+  Int_t MediumId(const char* mediumName) const override
+  {
+    Warning("MediumId", "Not implemented in this trivial engine");
+    return -1;
+  }
+
+  Int_t NofVolumes() const override
+  {
+    Warning("NofVolumes", "Not implemented in this trivial engine");
+    return -1;
+  }
+
+  Int_t VolId2Mate(Int_t id) const override
+  {
+    Warning("VolId2Mate", "Not implemented in this trivial engine");
+    return -1;
+  }
+
+  Int_t NofVolDaughters(const char* volName) const override
+  {
+    Warning("NofVolDaughters", "Not implemented in this trivial engine");
+    return -1;
+  }
+
+  const char* VolDaughterName(const char* volName, Int_t i) const override
+  {
+    Warning("VolDaughterName", "Not implemented in this trivial engine");
+    return "";
+  }
+
+  Int_t VolDaughterCopyNo(const char* volName, Int_t i) const override
+  {
+    Warning("VolDaughterCopyNo", "Not implemented in this trivial engine");
+    return -1;
+  }
+
+  //
+  // ------------------------------------------------
+  // methods for sensitive detectors
+  // ------------------------------------------------
+  //
+
+  // Set a sensitive detector to a volume
+  // - volName - the volume name
+  // - sd - the user sensitive detector
+  void SetSensitiveDetector(const TString& volName, TVirtualMCSensitiveDetector* sd) override
+  {
+    Warning("SetSensitiveDetector", "Not implemented in this trivial engine");
+  }
+
+  // Get a sensitive detector of a volume
+  // - volName - the volume name
+  TVirtualMCSensitiveDetector* GetSensitiveDetector(const TString& volName) const override
+  {
+    Warning("GetSensitiveDetector", "Not implemented in this trivial engine");
+    return nullptr;
+  }
+
+  // The scoring option:
+  // if true, scoring is performed only via user defined sensitive detectors and
+  // MCApplication::Stepping is not called
+  void SetExclusiveSDScoring(Bool_t exclusiveSDScoring) override
+  {
+    Warning("SetExclusiveSDScoring", "Not implemented in this trivial engine");
+  }
+
+  //
+  // ------------------------------------------------
+  // methods for physics management
+  // ------------------------------------------------
+  //
+
+  //
+  // set methods
+  // ------------------------------------------------
+  //
+
+  Bool_t SetCut(const char* cutName, Double_t cutValue) override
+  {
+    Warning("SetCut", "Not implemented in this trivial engine");
+    return kFALSE;
+  }
+
+  Bool_t SetProcess(const char* flagName, Int_t flagValue) override
+  {
+    Warning("SetProcess", "Not implemented in this trivial engine");
+    return kFALSE;
+  }
+
+  Bool_t DefineParticle(Int_t pdg, const char* name,
+                        TMCParticleType mcType,
+                        Double_t mass, Double_t charge, Double_t lifetime) override
+  {
+    Warning("DefineParticle", "Not implemented in this trivial engine");
+    return kFALSE;
+  }
+
+  Bool_t DefineParticle(Int_t pdg, const char* name,
+                        TMCParticleType mcType,
+                        Double_t mass, Double_t charge, Double_t lifetime,
+                        const TString& pType, Double_t width,
+                        Int_t iSpin, Int_t iParity, Int_t iConjugation,
+                        Int_t iIsospin, Int_t iIsospinZ, Int_t gParity,
+                        Int_t lepton, Int_t baryon,
+                        Bool_t stable, Bool_t shortlived = kFALSE,
+                        const TString& subType = "",
+                        Int_t antiEncoding = 0, Double_t magMoment = 0.0,
+                        Double_t excitation = 0.0) override
+  {
+    Warning("DefineParticle", "Not implemented in this trivial engine");
+    return kFALSE;
+  }
+
+  Bool_t DefineIon(const char* name, Int_t Z, Int_t A,
+                   Int_t Q, Double_t excEnergy, Double_t mass = 0.) override
+  {
+    Warning("DefineIon", "Not implemented in this trivial engine");
+    return kFALSE;
+  }
+
+  Bool_t SetDecayMode(Int_t pdg, Float_t bratio[6], Int_t mode[6][3]) override
+  {
+    Warning("SetDecayMode", "Not implemented in this trivial engine");
+    return kFALSE;
+  }
+
+  Double_t Xsec(char*, Double_t, Int_t, Int_t) override
+  {
+    Warning("Xsec", "Not implemented in this trivial engine");
+    return -1.;
+  }
+
+  //
+  // particle table usage
+  // ------------------------------------------------
+  //
+
+  Int_t IdFromPDG(Int_t pdg) const override
+  {
+    Warning("IdFromPDG", "Not implemented in this trivial engine");
+    return -1;
+  }
+
+  Int_t PDGFromId(Int_t id) const override
+  {
+    Warning("PDGFromId", "Not implemented in this trivial engine");
+    return -1;
+  }
+
+  //
+  // get methods
+  // ------------------------------------------------
+  //
+
+  TString ParticleName(Int_t pdg) const override
+  {
+    Warning("ParticleName", "Not implemented in this trivial engine");
+    return TString();
+  }
+
+  Double_t ParticleMass(Int_t pdg) const override
+  {
+    Warning("ParticleMass", "Not implemented in this trivial engine");
+    return -1.;
+  }
+
+  Double_t ParticleCharge(Int_t pdg) const override
+  {
+    Warning("ParticleCharge", "Not implemented in this trivial engine");
+    return -1.;
+  }
+
+  Double_t ParticleLifeTime(Int_t pdg) const override
+  {
+    Warning("ParticleLifeTime", "Not implemented in this trivial engine");
+    return -1.;
+  }
+
+  TMCParticleType ParticleMCType(Int_t pdg) const override
+  {
+    Warning("ParticleMCType", "Not implemented in this trivial engine");
+    return TMCParticleType();
+  }
+  //
+  // ------------------------------------------------
+  // methods for step management
+  // ------------------------------------------------
+  //
+
+  //
+  // action methods
+  // ------------------------------------------------
+  //
+
+  void StopTrack() override
+  {
+    Warning("StopTrack", "Not implemented in this trivial engine");
+  }
+
+  void StopEvent() override
+  {
+    Warning("StopEvent", "Not implemented in this trivial engine");
+  }
+
+  void StopRun() override
+  {
+    Warning("StopRun", "Not implemented in this trivial engine");
+  }
+
+  //
+  // set methods
+  // ------------------------------------------------
+  //
+
+  void SetMaxStep(Double_t) override
+  {
+    Warning("SetMaxStep", "Not implemented in this trivial engine");
+  }
+
+  void SetMaxNStep(Int_t) override
+  {
+    Warning("SetMaxNStep", "Not implemented in this trivial engine");
+  }
+
+  void SetUserDecay(Int_t pdg) override
+  {
+    Warning("SetUserDecay", "Not implemented in this trivial engine");
+  }
+
+  void ForceDecayTime(Float_t) override
+  {
+    Warning("ForceDecayTime", "Not implemented in this trivial engine");
+  }
+
+  //
+  // tracking volume(s)
+  // ------------------------------------------------
+  //
+
+  Int_t CurrentVolID(Int_t& copyNo) const override
+  {
+    Warning("CurrentVolID", "Not implemented in this trivial engine");
+    return -1;
+  }
+
+  Int_t CurrentVolOffID(Int_t off, Int_t& copyNo) const override
+  {
+    Warning("CurrentVolOffID", "Not implemented in this trivial engine");
+    return -1;
+  }
+
+  const char* CurrentVolName() const override
+  {
+    Warning("CurrentVolName", "Not implemented in this trivial engine");
+    return "";
+  }
+
+  const char* CurrentVolOffName(Int_t off) const override
+  {
+    Warning("CurrentVolOffName", "Not implemented in this trivial engine");
+    return "";
+  }
+
+  const char* CurrentVolPath() override
+  {
+    Warning("CurrentVolPath", "Not implemented in this trivial engine");
+    return "";
+  }
+
+  Bool_t CurrentBoundaryNormal(
+    Double_t& x, Double_t& y, Double_t& z) const override
+  {
+    Warning("CurrentBoundaryNormal", "Not implemented in this trivial engine");
+    return kFALSE;
+  }
+
+  Int_t CurrentMaterial(Float_t& a, Float_t& z,
+                        Float_t& dens, Float_t& radl, Float_t& absl) const override
+  {
+    Warning("CurrentMaterial", "Not implemented in this trivial engine");
+    return -1;
+  }
+
+  Int_t CurrentMedium() const override
+  {
+    Warning("CurrentMedium", "Not implemented in this trivial engine");
+    return -1;
+  }
+
+  Int_t CurrentEvent() const override
+  {
+    Warning("CurrentEvent", "Not implemented in this trivial engine");
+    return -1;
+  }
+
+  void Gmtod(Float_t* xm, Float_t* xd, Int_t iflag) override
+  {
+    Warning("Gmtod", "Not implemented in this trivial engine");
+  }
+
+  void Gmtod(Double_t* xm, Double_t* xd, Int_t iflag) override
+  {
+    Warning("Gmtod", "Not implemented in this trivial engine");
+  }
+
+  void Gdtom(Float_t* xd, Float_t* xm, Int_t iflag) override
+  {
+    Warning("Gdtom", "Not implemented in this trivial engine");
+  }
+
+  void Gdtom(Double_t* xd, Double_t* xm, Int_t iflag) override
+  {
+    Warning("Gdtom", "Not implemented in this trivial engine");
+  }
+
+  Double_t MaxStep() const override
+  {
+    Warning("MaxStep", "Not implemented in this trivial engine");
+    return -1.;
+  }
+
+  Int_t GetMaxNStep() const override
+  {
+    Warning("GetMaxNStep", "Not implemented in this trivial engine");
+    return -1;
+  }
+
+  //
+  // get methods
+  // tracking particle
+  // dynamic properties
+  // ------------------------------------------------
+  //
+
+  void TrackPosition(TLorentzVector& position) const override
+  {
+    Warning("TrackPosition", "Not implemented in this trivial engine");
+  }
+
+  void TrackPosition(Double_t& x, Double_t& y, Double_t& z) const override
+  {
+    Warning("TrackPosition", "Not implemented in this trivial engine");
+  }
+
+  void TrackPosition(Float_t& x, Float_t& y, Float_t& z) const override
+  {
+    Warning("TrackPosition", "Not implemented in this trivial engine");
+  }
+
+  void TrackMomentum(TLorentzVector& momentum) const override
+  {
+    Warning("TrackMomentum", "Not implemented in this trivial engine");
+  }
+
+  void TrackMomentum(Double_t& px, Double_t& py, Double_t& pz, Double_t& etot) const override
+  {
+    Warning("TrackMomentum", "Not implemented in this trivial engine");
+  }
+
+  void TrackMomentum(Float_t& px, Float_t& py, Float_t& pz, Float_t& etot) const override
+  {
+    Warning("TrackMomentum", "Not implemented in this trivial engine");
+  }
+
+  Double_t TrackStep() const override
+  {
+    Warning("TrackStep", "Not implemented in this trivial engine");
+    return -1.;
+  }
+
+  Double_t TrackLength() const override
+  {
+    Warning("TrackLength", "Not implemented in this trivial engine");
+    return -1.;
+  }
+
+  Double_t TrackTime() const override
+  {
+    Warning("TrackTime", "Not implemented in this trivial engine");
+    return -1.;
+  }
+
+  Double_t Edep() const override
+  {
+    Warning("Edep", "Not implemented in this trivial engine");
+    return -1.;
+  }
+
+  Double_t NIELEdep() const override
+  {
+    Warning("NIELEdep", "Not implemented in this trivial engine");
+    return -1.;
+  }
+
+  Int_t StepNumber() const override
+  {
+    Warning("StepNumber", "Not implemented in this trivial engine");
+    return -1;
+  }
+
+  Double_t TrackWeight() const override
+  {
+    Warning("TrackWeight", "Not implemented in this trivial engine");
+    return -1.;
+  }
+
+  void TrackPolarization(Double_t& polX, Double_t& polY, Double_t& polZ) const override
+  {
+    Warning("TrackPolarization", "Not implemented in this trivial engine");
+  }
+
+  void TrackPolarization(TVector3& pol) const override
+  {
+    Warning("TrackPolarization", "Not implemented in this trivial engine");
+  }
+
+  //
+  // get methods
+  // tracking particle
+  // static properties
+  // ------------------------------------------------
+  //
+
+  Int_t TrackPid() const override
+  {
+    Warning("TrackPid", "Not implemented in this trivial engine");
+    return -1;
+  }
+
+  Double_t TrackCharge() const override
+  {
+    Warning("TrackCharge", "Not implemented in this trivial engine");
+    return -1.;
+  }
+
+  Double_t TrackMass() const override
+  {
+    Warning("TrackMass", "Not implemented in this trivial engine");
+    return -1.;
+  }
+
+  Double_t Etot() const override
+  {
+    Warning("Etot", "Not implemented in this trivial engine");
+    return -1.;
+  }
+
+  //
+  // get methods - track status
+  // ------------------------------------------------
+  //
+
+  Bool_t IsNewTrack() const override
+  {
+    Warning("IsNewTrack", "Not implemented in this trivial engine");
+    return kFALSE;
+  }
+
+  Bool_t IsTrackInside() const override
+  {
+    Warning("IsTrackInside", "Not implemented in this trivial engine");
+    return kFALSE;
+  }
+
+  Bool_t IsTrackEntering() const override
+  {
+    Warning("IsTrackEntering", "Not implemented in this trivial engine");
+    return kFALSE;
+  }
+
+  Bool_t IsTrackExiting() const override
+  {
+    Warning("IsTrackExiting", "Not implemented in this trivial engine");
+    return kFALSE;
+  }
+
+  Bool_t IsTrackOut() const override
+  {
+    Warning("IsTrackOut", "Not implemented in this trivial engine");
+    return kFALSE;
+  }
+
+  Bool_t IsTrackDisappeared() const override
+  {
+    Warning("IsTrackDisappeared", "Not implemented in this trivial engine");
+    return kFALSE;
+  }
+
+  Bool_t IsTrackStop() const override
+  {
+    Warning("IsTrackStop", "Not implemented in this trivial engine");
+    return kFALSE;
+  }
+
+  Bool_t IsTrackAlive() const override
+  {
+    Warning("IsTrackAlive", "Not implemented in this trivial engine");
+    return kFALSE;
+  }
+
+  //
+  // get methods - secondaries
+  // ------------------------------------------------
+  //
+
+  Int_t NSecondaries() const override
+  {
+    Warning("NSecondaries", "Not implemented in this trivial engine");
+    return -1;
+  }
+
+  void GetSecondary(Int_t isec, Int_t& particleId,
+                    TLorentzVector& position, TLorentzVector& momentum) override
+  {
+    Warning("GetSecondary", "Not implemented in this trivial engine");
+  }
+
+  TMCProcess ProdProcess(Int_t isec) const override
+  {
+    Warning("ProdProcess", "Not implemented in this trivial engine");
+    return TMCProcess();
+  }
+
+  Int_t StepProcesses(TArrayI& proc) const override
+  {
+    Warning("StepProcesses", "Not implemented in this trivial engine");
+    return -1;
+  }
+
+  Bool_t SecondariesAreOrdered() const override
+  {
+    Warning("SecondariesAreOrdered", "Not implemented in this trivial engine");
+    return kFALSE;
+  }
+
+  //
+  // ------------------------------------------------
+  // Control methods
+  // ------------------------------------------------
+  //
+
+  void Init() override
+  {
+    fApplication->InitGeometry();
+    Warning("Init", "Not implemented in this trivial engine");
+  }
+
+  void BuildPhysics() override
+  {
+    Warning("BuildPhysics", "Not implemented in this trivial engine");
+  }
+
+  void ProcessEvent(Int_t eventId) override
+  {
+    processEventImpl();
+  }
+
+  void ProcessEvent(Int_t eventId, Bool_t isInterruptible) override
+  {
+    Warning("ProcessEvent", "Not implemented in this trivial engine");
+  }
+
+  void ProcessEvent() override
+  {
+    processEventImpl();
+  }
+
+  void InterruptTrack() override
+  {
+    Info("InterruptTrack", "Not implemented in this trivial engine");
+  }
+
+  Bool_t ProcessRun(Int_t nevent) override
+  {
+    if (nevent <= 0) {
+      return kFALSE;
+    }
+
+    for (Int_t i = 0; i < nevent; i++) {
+      ProcessEvent(i);
+    }
+    return kTRUE;
+  }
+
+  void TerminateRun() override
+  {
+    Warning("TerminateRun", "Not implemented in this trivial engine");
+  }
+
+  void InitLego() override
+  {
+    Warning("InitLego", "Not implemented in this trivial engine");
+  }
+
+  void SetCollectTracks(Bool_t collectTracks) override
+  {
+    Warning("SetCollectTracks", "Not implemented in this trivial engine");
+  }
+
+  Bool_t IsCollectTracks() const override
+  {
+    Warning("IsCollectTracks", "Not implemented in this trivial engine");
+    return kFALSE;
+  }
+
+  Bool_t IsMT() const override { return kFALSE; }
+
+ private:
+  O2TrivialMCEngine(O2TrivialMCEngine const&);
+  O2TrivialMCEngine& operator=(O2TrivialMCEngine const&);
+  void processEventImpl()
+  {
+    auto stack = GetStack();
+    if (!TMCManager::Instance()) {
+      fApplication->GeneratePrimaries();
+    }
+    Int_t nPopped{};
+    Int_t itrack;
+    fApplication->BeginEvent();
+    while (true) {
+      if (!stack->PopNextTrack(itrack)) {
+        break;
+      }
+      nPopped++;
+      fApplication->BeginPrimary();
+      fApplication->PreTrack();
+      fApplication->PostTrack();
+      fApplication->FinishPrimary();
+    }
+    fApplication->FinishEvent();
+    Info("processEventImpl", "Popped %d primaries", nPopped);
+  }
+};
+
+} // namespace mc
+
+} // namespace o2
+
+#endif

--- a/Detectors/O2TrivialMC/src/O2TrivialMCLinkDef.h
+++ b/Detectors/O2TrivialMC/src/O2TrivialMCLinkDef.h
@@ -1,0 +1,18 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifdef __CLING__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#endif

--- a/Detectors/gconfig/CMakeLists.txt
+++ b/Detectors/gconfig/CMakeLists.txt
@@ -22,15 +22,22 @@ o2_add_library(G4Setup
 o2_add_library(FLUKASetup
                SOURCES src/FlukaConfig.cxx
                PUBLIC_LINK_LIBRARIES FairRoot::Base O2::SimulationDataFormat O2::Generators ROOT::EGPythia6 O2::SimSetup
-	      )
+)
+
 o2_add_library(MCReplaySetup
                SOURCES src/MCReplayConfig.cxx
                PUBLIC_LINK_LIBRARIES MC::MCReplay FairRoot::Base O2::SimulationDataFormat O2::Generators O2::SimSetup
 )
+
+o2_add_library(O2TrivialMCEngineSetup
+               SOURCES src/O2TrivialMCConfig.cxx
+               PUBLIC_LINK_LIBRARIES O2::O2TrivialMC FairRoot::Base O2::SimulationDataFormat O2::Generators O2::SimSetup
+)
+
 o2_add_library(SimSetup
                SOURCES  src/GlobalProcessCutSimParam.cxx src/SimSetup.cxx src/SetCuts.cxx src/FlukaParam.cxx src/MCReplayParam.cxx
-	       PUBLIC_LINK_LIBRARIES O2::CommonUtils O2::DetectorsBase O2::SimConfig
-              )
+               PUBLIC_LINK_LIBRARIES O2::CommonUtils O2::DetectorsBase O2::SimConfig
+)
 
 o2_target_root_dictionary(SimSetup
                           HEADERS include/SimSetup/SimSetup.h

--- a/Detectors/gconfig/src/O2TrivialMCConfig.cxx
+++ b/Detectors/gconfig/src/O2TrivialMCConfig.cxx
@@ -1,0 +1,43 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "FairRunSim.h"
+#include "O2TrivialMC/O2TrivialMCEngine.h"
+#include "DetectorsBase/Stack.h"
+#include "SimulationDataFormat/StackParam.h"
+#include <fairlogger/Logger.h>
+#include "FairModule.h"
+#include "Generators/DecayerPythia8.h"
+#include "../commonConfig.C"
+
+// these are used in commonConfig.C
+using o2::eventgen::DecayerPythia8;
+
+namespace o2
+{
+namespace o2trivialmcengineconfig
+{
+
+void Config()
+{
+  // TString* gModel = run->GetGeoModel();
+  FairRunSim* run = FairRunSim::Instance();
+  auto* replay = new mc::O2TrivialMCEngine();
+  stackSetup(replay, run);
+}
+
+void O2TrivialMCEngineConfig()
+{
+  LOG(info) << "Setting up O2TrivialMCEngine sim from library code";
+  Config();
+}
+
+} // namespace o2trivialmcengineconfig
+} // namespace o2

--- a/Detectors/gconfig/src/SimSetup.cxx
+++ b/Detectors/gconfig/src/SimSetup.cxx
@@ -58,6 +58,8 @@ void SimSetup::setup(const char* engine)
     setupFromPlugin("libO2FLUKASetup", "_ZN2o211flukaconfig11FlukaConfigEv");
   } else if (strcmp(engine, "MCReplay") == 0) {
     setupFromPlugin("libO2MCReplaySetup", "_ZN2o214mcreplayconfig14MCReplayConfigEv");
+  } else if (strcmp(engine, "O2TrivialMCEngine") == 0) {
+    setupFromPlugin("libO2O2TrivialMCEngineSetup", "_ZN2o223o2trivialmcengineconfig23O2TrivialMCEngineConfigEv");
   } else {
     LOG(fatal) << "Unsupported engine " << engine;
   }

--- a/macro/o2sim.C
+++ b/macro/o2sim.C
@@ -53,7 +53,6 @@ void check_notransport()
     LOG(info) << "Initializing without Geant transport by applying very tight geometry cuts";
     o2::conf::ConfigurableParam::setValue("SimCutParams", "maxRTracking", 0.0000001);    // 1 nanometer of tracking
     o2::conf::ConfigurableParam::setValue("SimCutParams", "maxAbsZTracking", 0.0000001); // 1 nanometer of tracking
-    // TODO: disable physics processes for material sitting at the vertex
   }
 }
 
@@ -121,8 +120,8 @@ FairRunSim* o2sim_init(bool asservice, bool evalmat = false)
 
   std::string outputfilename = s.str();
   run->SetSink(new FairRootFileSink(outputfilename.c_str())); // Output file
-  run->SetName(confref.getMCEngine().c_str()); // Transport engine
-  run->SetIsMT(confref.getIsMT());             // MT mode
+  run->SetName(confref.getMCEngine().c_str());                // Transport engine
+  run->SetIsMT(confref.getIsMT());                            // MT mode
 
   /** set event header **/
   auto header = new o2::dataformats::MCEventHeader();

--- a/run/CMakeLists.txt
+++ b/run/CMakeLists.txt
@@ -94,7 +94,7 @@ o2_add_executable(hit-merger-runner
 o2_add_executable(g4-determine-unknown-pdg-properties
                   COMPONENT_NAME sim
                   SOURCES g4DetermineUnknownPdgProperties.cxx
-                  PUBLIC_LINK_LIBRARIES MC::Geant4 MC::Geant4VMC internal::allsim)
+                  PUBLIC_LINK_LIBRARIES O2::O2TrivialMC MC::Geant4 MC::Geant4VMC O2::SimConfig)
 
 o2_add_executable(mctracks-proxy
                   COMPONENT_NAME sim

--- a/run/O2SimDevice.h
+++ b/run/O2SimDevice.h
@@ -252,7 +252,7 @@ class O2SimDevice final : public fair::mq::Device
 
             // Process one event
             auto& conf = o2::conf::SimConfig::Instance();
-            if (strcmp(conf.getMCEngine().c_str(), "TGeant4") == 0) {
+            if (strcmp(conf.getMCEngine().c_str(), "TGeant4") == 0 || strcmp(conf.getMCEngine().c_str(), "O2TrivialMCEngine") == 0) {
               // this is preferred and necessary for Geant4
               // since repeated "ProcessRun" might have significant overheads
               mVMC->ProcessEvent();

--- a/run/g4DetermineUnknownPdgProperties.cxx
+++ b/run/g4DetermineUnknownPdgProperties.cxx
@@ -17,51 +17,13 @@
 #include "G4ParticleTable.hh"
 #include "G4IonTable.hh"
 
-#include "TGeoManager.h"
-#include "TGeoBBox.h"
-#include "TGeoMaterial.h"
-#include "TGeoMedium.h"
-
-#include "TVirtualMCApplication.h"
 #include "TGeant4.h"
 #include "TG4RunConfiguration.h"
 #include "TG4G3Units.h"
 
 #include "SimConfig/G4Params.h"
 #include "SimulationDataFormat/O2DatabasePDG.h"
-
-// That is an absolut minimal implementation of a TVirtualMCApplication
-// Required to instantiate VMC (see below)
-class MCAppDummy : public TVirtualMCApplication
-{
- public:
-  MCAppDummy() : TVirtualMCApplication("MCAppDummy", "MCAppDummy") {}
-  ~MCAppDummy() override = default;
-  MCAppDummy(MCAppDummy const& app) {}
-  void ConstructGeometry() override
-  {
-    auto geoMgr = gGeoManager;
-    // we need some dummies, any material and medium will do
-    auto mat = new TGeoMaterial("vac", 0, 0, 0);
-    auto med = new TGeoMedium("vac", 1, mat);
-    auto vol = geoMgr->MakeBox("cave", med, 1, 1, 1);
-    geoMgr->SetTopVolume(vol);
-    geoMgr->CloseGeometry();
-  }
-  void InitGeometry() override {}
-  void GeneratePrimaries() override {}
-  void BeginEvent() override {}
-  void BeginPrimary() override {}
-  void PreTrack() override {}
-  void Stepping() override {}
-  void PostTrack() override {}
-  void FinishPrimary() override {}
-  void FinishEvent() override {}
-  TVirtualMCApplication* CloneForWorker() const override
-  {
-    return new MCAppDummy(*this);
-  }
-};
+#include "O2TrivialMC/O2TrivialMCApplication.h"
 
 void removeDuplicates(std::vector<int>& vec)
 {
@@ -86,7 +48,7 @@ int main(int argc, char** argv)
 
   // We use our O2 VMC setup to make sure we are in line with our physics definition.
   // need a dummy VMC App
-  new MCAppDummy();
+  new o2::mc::O2TrivialMCApplication();
   // setup G4 as we usually do
   auto& physicsSetup = ::o2::conf::G4Params::Instance().getPhysicsConfigString();
   auto runConfiguration = new TG4RunConfiguration("geomRoot", physicsSetup);


### PR DESCRIPTION
* O2TrivialMC VMC engine with a minimal implementation of interfaces. It does simply calls the hook for primary generation and pops them for consistency. They are not transported.

  Useful, when only generator level (aka MCKinematics) are needed since it has minimal initialisation overhead.

  Cannot be used for physics simulation, o2-sim will abort.

* O2TrivialMCApplciation VMC application with minimal implementation of interfaces. For the geometry it only constructs a simple box with a vacuum. Non primary generation or anything else.

* o2-sim --noGeant automatically runs with the O2trivialMC engine to ensure minimal initialisation overhead. Only CAVE is constructed, all other modules are omitted.