### PR TITLE
Change to using Collisions = Collisions_001

### DIFF
--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -90,7 +90,7 @@ DECLARE_SOA_TABLE_VERSIONED(Collisions_001, "AOD", "COLLISION", 1, //! Time and 
                             collision::Flags, collision::Chi2, collision::NumContrib,
                             collision::CollisionTime, collision::CollisionTimeRes);
 
-using Collisions = Collisions_000; // current version
+using Collisions = Collisions_001; // current version
 using Collision = Collisions::iterator;
 
 // NOTE Relation between Collisions and BC table

--- a/Framework/Core/test/test_AnalysisTask.cxx
+++ b/Framework/Core/test/test_AnalysisTask.cxx
@@ -168,11 +168,11 @@ BOOST_AUTO_TEST_CASE(AdaptorCompilation)
   BOOST_CHECK_EQUAL(task2.inputs[7].binding, "AmbiguousTracks");
   BOOST_CHECK_EQUAL(task2.inputs[8].binding, "Calos");
   BOOST_CHECK_EQUAL(task2.inputs[9].binding, "CaloTriggers");
-  BOOST_CHECK_EQUAL(task2.inputs[0].binding, "Collisions_000");
+  BOOST_CHECK_EQUAL(task2.inputs[0].binding, "Collisions_001");
 
   auto task3 = adaptAnalysisTask<CTask>(*cfgc, TaskName{"test3"});
   BOOST_CHECK_EQUAL(task3.inputs.size(), 3);
-  BOOST_CHECK_EQUAL(task3.inputs[0].binding, "Collisions_000");
+  BOOST_CHECK_EQUAL(task3.inputs[0].binding, "Collisions_001");
   BOOST_CHECK_EQUAL(task3.inputs[2].binding, "Tracks");
   BOOST_CHECK_EQUAL(task3.inputs[1].binding, "TracksExtension");
 


### PR DESCRIPTION
* this commit changes to the collision table with the correct CovYY and CovXZ elements, following the [discussion in the monday meeting](https://indico.cern.ch/event/1219192/contributions/5128952/attachments/2542060/4376840/DDChinellato-MondayMeeting-7Nov2022-1.pdf)
* All other changes are in place for this: the converter exists and has been [merged 4 days](https://github.com/AliceO2Group/O2Physics/blob/master/Common/TableProducer/collisionConverter.cxx) ago in O2Physics
* once this PR is merged, a general announcement will follow and all users must add the `collision-converter` workflow (with no parameters required) to use any current AO2D