### PR TITLE
TPC SCD map creation from unbinned residuals

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCResidualReaderSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCResidualReaderSpec.h
@@ -15,8 +15,10 @@
 #define O2_TPC_RESIDUALREADER
 
 #include "Framework/DataProcessorSpec.h"
+#include "ReconstructionDataFormats/GlobalTrackID.h"
 
 using namespace o2::framework;
+using GID = o2::dataformats::GlobalTrackID;
 
 namespace o2
 {
@@ -24,7 +26,7 @@ namespace tpc
 {
 
 /// create a processor spec
-framework::DataProcessorSpec getTPCResidualReaderSpec();
+framework::DataProcessorSpec getTPCResidualReaderSpec(bool doBinning, GID::mask_t src);
 
 } // namespace tpc
 } // namespace o2

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
@@ -64,7 +64,8 @@ void TPCInterpolationDPL::updateTimeDependentParams(ProcessingContext& pc)
     bool limitTracks = (SpacePointsCalibConfParam::Instance().maxTracksPerCalibSlot < 0) ? true : false;
     int nTracksPerTfMax = (nTfs > 0 && !limitTracks) ? SpacePointsCalibConfParam::Instance().maxTracksPerCalibSlot / nTfs : -1;
     if (nTracksPerTfMax > 0) {
-      LOGP(info, "We will stop processing tracks after validating {} tracks per TF", nTracksPerTfMax);
+      LOGP(info, "We will stop processing tracks after validating {} tracks per TF, since we want to accumulate {} tracks for a slot with {} TFs",
+           nTracksPerTfMax, SpacePointsCalibConfParam::Instance().maxTracksPerCalibSlot, nTfs);
     } else if (nTracksPerTfMax < 0) {
       LOG(info) << "The number of processed tracks per TF is not limited";
     } else {

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCResidualReaderSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCResidualReaderSpec.cxx
@@ -23,6 +23,7 @@
 #include "Framework/ControlService.h"
 #include "DataFormatsTPC/Defs.h"
 #include "SpacePoints/TrackResiduals.h"
+#include "SpacePoints/TrackInterpolation.h"
 #include "DetectorsBase/Propagator.h"
 #include "CommonUtils/StringUtils.h"
 #include "TPCInterpolationWorkflow/TPCResidualReaderSpec.h"
@@ -38,7 +39,7 @@ namespace tpc
 class TPCResidualReader : public Task
 {
  public:
-  TPCResidualReader() = default;
+  TPCResidualReader(bool doBinning, GID::mask_t src) : mDoBinning(doBinning), mSources(src) {}
   ~TPCResidualReader() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
@@ -53,10 +54,18 @@ class TPCResidualReader : public Task
   std::unique_ptr<TFile> mFile;
   std::unique_ptr<TTree> mTreeResiduals;
   std::unique_ptr<TTree> mTreeStats;
+  std::unique_ptr<TTree> mTreeUnbinnedResiduals;
+  bool mDoBinning{false};
+  GID::mask_t mSources;
   TrackResiduals mTrackResiduals;
   std::vector<std::string> mFileNames{""};  ///< input files
   std::string mOutfile{"debugVoxRes.root"}; ///< output file name
-  std::vector<o2::tpc::TrackResiduals::LocalResid> mResiduals, *mResidualsPtr = &mResiduals;
+  std::vector<TrackResiduals::LocalResid> mResiduals, *mResidualsPtr = &mResiduals;                 ///< binned residuals input
+  std::array<std::vector<TrackResiduals::LocalResid>, SECTORSPERSIDE * SIDES> mResidualsSector;     ///< binned residuals generated on-the-fly
+  std::array<std::vector<TrackResiduals::LocalResid>*, SECTORSPERSIDE * SIDES> mResidualsSectorPtr; ///< for setting branch addresses
+  std::array<std::vector<TrackResiduals::VoxStats>, SECTORSPERSIDE * SIDES> mVoxStatsSector;        ///< voxel statistics generated on-the-fly
+  std::vector<UnbinnedResid> mUnbinnedResiduals, *mUnbinnedResidualsPtr = &mUnbinnedResiduals;      ///< unbinned residuals input
+  std::vector<TrackDataCompact> mTrackData, *mTrackDataPtr = &mTrackData;                           ///< the track references for unbinned residuals
 };
 
 void TPCResidualReader::fillResiduals(const int iSec)
@@ -111,15 +120,87 @@ void TPCResidualReader::run(ProcessingContext& pc)
 {
   mTrackResiduals.createOutputFile(mOutfile.data()); // FIXME remove when map output is handled properly
 
-  for (int iSec = 0; iSec < SECTORSPERSIDE * SIDES; ++iSec) {
+  if (mDoBinning) {
+    // initialize the trees for the binned residuals and the statistics
+    LOG(info) << "Preparing the binning of residuals";
+    mTreeResiduals = std::make_unique<TTree>("resid", "TPC binned residuals");
+    for (int iSec = 0; iSec < SECTORSPERSIDE * SIDES; ++iSec) {
+      mResidualsSectorPtr[iSec] = &mResidualsSector[iSec];
+      mVoxStatsSector[iSec].resize(mTrackResiduals.getNVoxelsPerSector());
+      for (int ix = 0; ix < mTrackResiduals.getNXBins(); ++ix) {
+        for (int ip = 0; ip < mTrackResiduals.getNY2XBins(); ++ip) {
+          for (int iz = 0; iz < mTrackResiduals.getNZ2XBins(); ++iz) {
+            auto& statsVoxel = mVoxStatsSector[iSec][mTrackResiduals.getGlbVoxBin(ix, ip, iz)];
+            // COG estimates are set to the bin center by default
+            mTrackResiduals.getVoxelCoordinates(iSec, ix, ip, iz, statsVoxel.meanPos[TrackResiduals::VoxX], statsVoxel.meanPos[TrackResiduals::VoxF], statsVoxel.meanPos[TrackResiduals::VoxZ]);
+          }
+        }
+      }
+      mTreeResiduals->Branch(Form("sec%d", iSec), &mResidualsSectorPtr[iSec]);
+    }
+    // now go through all input files, apply the track selection and fill the binned residuals
     for (const auto& file : mFileNames) {
       LOGP(info, "Processing residuals from file {}", file);
-
-      // set up the tree from the input file
       connectTree(file);
+      for (int iEntry = 0; iEntry < mTreeUnbinnedResiduals->GetEntries(); ++iEntry) {
+        mTreeUnbinnedResiduals->GetEntry(iEntry);
+        for (const auto& trkInfo : mTrackData) {
+          if (!GID::includesSource(trkInfo.sourceId, mSources)) {
+            continue;
+          }
+          for (int i = trkInfo.idxFirstResidual; i < trkInfo.idxFirstResidual + trkInfo.nResiduals; ++i) {
+            const auto& residIn = mUnbinnedResiduals[i];
+            int sec = residIn.sec;
+            auto& residVecOut = mResidualsSector[sec];
+            auto& statVecOut = mVoxStatsSector[sec];
+            std::array<unsigned char, TrackResiduals::VoxDim> bvox;
+            float xPos = param::RowX[residIn.row];
+            float yPos = residIn.y * param::MaxY / 0x7fff;
+            float zPos = residIn.z * param::MaxZ / 0x7fff;
+            if (!mTrackResiduals.findVoxelBin(sec, xPos, yPos, zPos, bvox)) {
+              // we are not inside any voxel
+              LOGF(debug, "Dropping residual in sec(%i), x(%f), y(%f), z(%f)", sec, xPos, yPos, zPos);
+              continue;
+            }
+            residVecOut.emplace_back(residIn.dy, residIn.dz, residIn.tgSlp, bvox);
+            auto& stat = statVecOut[mTrackResiduals.getGlbVoxBin(bvox)];
+            float& binEntries = stat.nEntries;
+            float oldEntries = binEntries++;
+            float norm = 1.f / binEntries;
+            // update COG for voxel bvox (update for X only needed in case binning is not per pad row)
+            float xPosInv = 1.f / xPos;
+            stat.meanPos[TrackResiduals::VoxX] = (stat.meanPos[TrackResiduals::VoxX] * oldEntries + xPos) * norm;
+            stat.meanPos[TrackResiduals::VoxF] = (stat.meanPos[TrackResiduals::VoxF] * oldEntries + yPos * xPosInv) * norm;
+            stat.meanPos[TrackResiduals::VoxZ] = (stat.meanPos[TrackResiduals::VoxZ] * oldEntries + zPos * xPosInv) * norm;
+          }
+        }
+      }
+      mTreeResiduals->Fill();
+      for (auto& residuals : mResidualsSector) {
+        residuals.clear();
+      }
+    }
+  }
 
-      // fill the residuals for one sector
-      fillResiduals(iSec);
+  for (int iSec = 0; iSec < SECTORSPERSIDE * SIDES; ++iSec) {
+    if (mDoBinning) {
+      // for each sector fill the vector of local residuals from the respective branch
+      auto brResid = mTreeResiduals->GetBranch(Form("sec%d", iSec));
+      brResid->SetAddress(&mResidualsPtr);
+      for (int iEntry = 0; iEntry < brResid->GetEntries(); ++iEntry) {
+        brResid->GetEntry(iEntry);
+        mTrackResiduals.getLocalResVec().insert(mTrackResiduals.getLocalResVec().end(), mResiduals.begin(), mResiduals.end());
+      }
+      mTrackResiduals.setStats(mVoxStatsSector[iSec], iSec);
+    } else {
+      // we read the binned residuals directly from the input files
+      for (const auto& file : mFileNames) {
+        LOGP(info, "Processing residuals from file {}", file);
+        // set up the tree from the input file
+        connectTree(file);
+        // fill the residuals for one sector
+        fillResiduals(iSec);
+      }
     }
 
     // do processing
@@ -139,19 +220,34 @@ void TPCResidualReader::run(ProcessingContext& pc)
 
 void TPCResidualReader::connectTree(const std::string& filename)
 {
-  mTreeResiduals.reset(nullptr); // in case it was already loaded
-  mTreeStats.reset(nullptr);     // in case it was already loaded
+  if (!mDoBinning) {
+    // in case we do the binning on-the-fly, we fill these trees manually
+    // and don't want to delete them in between
+    mTreeResiduals.reset(nullptr); // in case it was already loaded
+    mTreeStats.reset(nullptr);     // in case it was already loaded
+  }
+  mTreeUnbinnedResiduals.reset(nullptr); // in case it was already loaded
   mFile.reset(TFile::Open(filename.c_str()));
   assert(mFile && !mFile->IsZombie());
-  mTreeResiduals.reset((TTree*)mFile->Get("resid"));
-  assert(mTreeResiduals);
-  mTreeStats.reset((TTree*)mFile->Get("stats"));
-  assert(mTreeStats);
-
-  LOG(info) << "Loaded tree from " << filename << " with " << mTreeResiduals->GetEntries() << " entries";
+  if (!mDoBinning) {
+    // we load the already binned residuals and the voxel statistics
+    mTreeResiduals.reset((TTree*)mFile->Get("resid"));
+    assert(mTreeResiduals);
+    mTreeStats.reset((TTree*)mFile->Get("stats"));
+    assert(mTreeStats);
+    LOG(info) << "Loaded tree from " << filename << " with " << mTreeResiduals->GetEntries() << " entries";
+  } else {
+    // we load the unbinned residuals
+    LOG(info) << "Loading the binned residuals";
+    mTreeUnbinnedResiduals.reset((TTree*)mFile->Get("unbinnedResid"));
+    assert(mTreeUnbinnedResiduals);
+    mTreeUnbinnedResiduals->SetBranchAddress("res", &mUnbinnedResidualsPtr);
+    mTreeUnbinnedResiduals->SetBranchAddress("trackInfo", &mTrackDataPtr);
+    LOG(info) << "Loaded tree from " << filename << " with " << mTreeUnbinnedResiduals->GetEntries() << " entries";
+  }
 }
 
-DataProcessorSpec getTPCResidualReaderSpec()
+DataProcessorSpec getTPCResidualReaderSpec(bool doBinning, GID::mask_t src)
 {
   std::vector<InputSpec> inputs;
   std::vector<OutputSpec> outputs;
@@ -160,7 +256,7 @@ DataProcessorSpec getTPCResidualReaderSpec()
     "tpc-residual-reader",
     inputs,
     outputs,
-    AlgorithmSpec{adaptFromTask<TPCResidualReader>()},
+    AlgorithmSpec{adaptFromTask<TPCResidualReader>(doBinning, src)},
     Options{
       {"residuals-infiles", VariantType::String, "o2tpc_residuals.root", {"comma-separated list of input files or .txt file containing list of input files"}},
       {"input-dir", VariantType::String, "none", {"Input directory"}},

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/tpc-map-creator.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/tpc-map-creator.cxx
@@ -11,14 +11,18 @@
 
 #include "Framework/DataProcessorSpec.h"
 #include "TPCInterpolationWorkflow/TPCResidualReaderSpec.h"
+#include "ReconstructionDataFormats/GlobalTrackID.h"
 #include "CommonUtils/ConfigurableParam.h"
 
 using namespace o2::framework;
+using GID = o2::dataformats::GlobalTrackID;
 
 // we need to add workflow options before including Framework/runDataProcessing
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   std::vector<o2::framework::ConfigParamSpec> options{
+    {"track-sources", VariantType::String, std::string{GID::ALL}, {"comma-separated list of sources to use for tracking"}},
+    {"start-from-unbinned", VariantType::Bool, false, {"Do the binning of the residuals on-the-fly (taking into account allowed track-sources)"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
   std::swap(workflowOptions, options);
 }
@@ -31,7 +35,13 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
 {
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
   o2::conf::ConfigurableParam::writeINI("o2tpcmapcreator-workflow_configuration.ini");
+
+  GID::mask_t allowedSources = GID::getSourcesMask("ITS-TPC,ITS-TPC-TRD,ITS-TPC-TOF,ITS-TPC-TRD-TOF");
+  GID::mask_t src = allowedSources & GID::getSourcesMask(configcontext.options().get<std::string>("track-sources"));
+
+  auto doBinning = configcontext.options().get<bool>("start-from-unbinned");
+
   WorkflowSpec specs;
-  specs.emplace_back(o2::tpc::getTPCResidualReaderSpec());
+  specs.emplace_back(o2::tpc::getTPCResidualReaderSpec(doBinning, src));
   return specs;
 }

--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/ResidualAggregator.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/ResidualAggregator.h
@@ -55,16 +55,16 @@ struct ResidualsContainer {
   void writeToFile(bool closeFileAfterwards);
 
   const TrackResiduals* trackResiduals{nullptr};
-  std::array<std::vector<TrackResiduals::LocalResid>, SECTORSPERSIDE * SIDES> residuals{}; ///< local residuals per sector which are sent to the aggregator
+  std::array<std::vector<TrackResiduals::LocalResid>, SECTORSPERSIDE * SIDES> residuals{}; ///< local (binned) residuals per sector
   std::array<std::vector<TrackResiduals::LocalResid>*, SECTORSPERSIDE * SIDES> residualsPtr{};
-  std::array<std::vector<TrackResiduals::VoxStats>, SECTORSPERSIDE * SIDES> stats{}; ///< voxel statistics sent to the aggregator
+  std::array<std::vector<TrackResiduals::VoxStats>, SECTORSPERSIDE * SIDES> stats{}; ///< voxel statistics per sector
   std::array<std::vector<TrackResiduals::VoxStats>*, SECTORSPERSIDE * SIDES> statsPtr{};
   std::vector<uint32_t> tfOrbits, *tfOrbitsPtr{&tfOrbits};                   ///< first TF orbit
   std::vector<uint32_t> sumOfResiduals, *sumOfResidualsPtr{&sumOfResiduals}; ///< sum of residuals for each TF
   std::vector<o2::ctp::LumiInfo> lumi, *lumiPtr{&lumi};                      ///< luminosity information from CTP per TF
-  std::vector<UnbinnedResid> unbinnedRes, *unbinnedResPtr{&unbinnedRes};     ///< unbinned residuals
+  std::vector<UnbinnedResid> unbinnedRes, *unbinnedResPtr{&unbinnedRes};     ///< unbinned residuals which are sent to the aggregator
   std::vector<TrackData> trkData, *trkDataPtr{&trkData};                     ///< track data and cluster ranges
-  std::vector<TrackDataCompact> trackInfo, *trackInfoPtr{&trackInfo};        ///< allows to obtain track type for each binned residual downstream
+  std::vector<TrackDataCompact> trackInfo, *trackInfoPtr{&trackInfo};        ///< allows to obtain track type for each unbinned residual downstream
 
   std::string fileName{"o2tpc_residuals"};
   std::unique_ptr<TFile> fileOut{nullptr};

--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackResiduals.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackResiduals.h
@@ -420,6 +420,9 @@ class TrackResiduals
   /// Closes the file with the debug output.
   void closeOutputFile();
 
+  /// Set the voxel statistics directly from outside
+  void setStats(const std::vector<TrackResiduals::VoxStats>& statsIn, int iSec);
+
   /// Fill statistics from TTree
   void fillStats(int iSec);
 
@@ -427,7 +430,7 @@ class TrackResiduals
   void clear();
 
  private:
-  bool mInitResultsContainer{false};
+  std::bitset<SECTORSPERSIDE * SIDES> mInitResultsContainer{};
 
   // some constants
   static constexpr float sFloatEps{1.e-7f}; ///< float epsilon for robust linear fitting

--- a/Detectors/TPC/calibration/SpacePoints/src/TrackResiduals.cxx
+++ b/Detectors/TPC/calibration/SpacePoints/src/TrackResiduals.cxx
@@ -173,10 +173,10 @@ void TrackResiduals::initBinning()
 //______________________________________________________________________________
 void TrackResiduals::initResultsContainer(int iSec)
 {
-  if (mInitResultsContainer) {
+  if (mInitResultsContainer.test(iSec)) {
     return;
   }
-  mInitResultsContainer = true;
+  mInitResultsContainer.set(iSec);
   mVoxelResults[iSec].resize(mNVoxPerSector);
   for (int ix = 0; ix < mNXBins; ++ix) {
     for (int ip = 0; ip < mNY2XBins; ++ip) {
@@ -299,6 +299,18 @@ void TrackResiduals::setKernelType(KernelType kernel, float bwX, float bwP, floa
 /// processing functions
 ///
 ///////////////////////////////////////////////////////////////////////////////
+
+void TrackResiduals::setStats(const std::vector<TrackResiduals::VoxStats>& statsIn, int iSec)
+{
+  initResultsContainer(iSec);
+  std::vector<VoxRes>& secDataTmp = mVoxelResults[iSec];
+  for (int iVox = 0; iVox < mNVoxPerSector; ++iVox) {
+    secDataTmp[iVox].stat[VoxX] = statsIn[iVox].meanPos[VoxX];
+    secDataTmp[iVox].stat[VoxF] = statsIn[iVox].meanPos[VoxF];
+    secDataTmp[iVox].stat[VoxZ] = statsIn[iVox].meanPos[VoxZ];
+    secDataTmp[iVox].stat[VoxDim] = statsIn[iVox].nEntries;
+  }
+}
 
 void TrackResiduals::fillStats(int iSec)
 {
@@ -1452,5 +1464,5 @@ void TrackResiduals::printMem() const
 void TrackResiduals::clear()
 {
   getLocalResVec().clear();
-  mInitResultsContainer = false;
+  mInitResultsContainer.reset();
 }

--- a/Detectors/TPC/calibration/SpacePoints/src/TrackResiduals.cxx
+++ b/Detectors/TPC/calibration/SpacePoints/src/TrackResiduals.cxx
@@ -480,8 +480,8 @@ void TrackResiduals::processVoxelResiduals(std::vector<float>& dy, std::vector<f
   resVox.D[ResD] = resVox.dYSigMAD = sigMAD; // later will be overwritten by real dispersion
   resVox.dZSigLTM = zResults[2];
 
-  LOGF(debug, "D[0]=%.2f, D[1]=%.2f, D[2]=%.2f, E[0]=%.2f, E[1]=%.2f, E[2]=%.2f, EXYCorr=%.4f",
-       resVox.D[0], resVox.D[1], resVox.D[2], resVox.E[0], resVox.E[1], resVox.E[2], resVox.EXYCorr);
+  LOGF(debug, "D[0]=%.2f, D[1]=%.2f, D[2]=%.2f, E[0]=%.2f, E[1]=%.2f, E[2]=%.2f, EXYCorr=%.4f, dYSigMAD=%.3f, dZSigLTM=%.3f",
+       resVox.D[0], resVox.D[1], resVox.D[2], resVox.E[0], resVox.E[1], resVox.E[2], resVox.EXYCorr, resVox.dYSigMAD, resVox.dZSigLTM);
 
   resVox.flags |= DistDone;
 
@@ -551,7 +551,8 @@ int TrackResiduals::validateVoxels(int iSec)
       } // loop over Z
     }   // loop over Y/X
     mValidFracXBins[iSec][ix] = static_cast<float>(cntValid) / (mNY2XBins * mNZ2XBins);
-    LOG(debug) << "sector " << iSec << ": xBin " << ix << " has " << mValidFracXBins[iSec][ix] * 100 << "% of voxels valid";
+    LOGP(debug, "Sector {}: xBin {} has {} % of voxels valid. Total masked due to fit: {} ,and sigma: {}",
+         iSec, ix, mValidFracXBins[iSec][ix] * 100., cntMaskedFit, cntMaskedSigma);
   } // loop over X
 
   // mask X-bins which cannot be smoothed


### PR DESCRIPTION
This allows to specify the track type(s) which should be used for the extraction of the distortion map by e.g.

```
o2-tpc-static-map-creator -b --start-from-unbinned --track-sources ITS-TPC-TRD --residuals-infiles o2tpc_residuals.root
```

I have tested this with an input file with around 500k tracks which was not sufficient to create a map since most bins were masked. Will try tomorrow with the most recent output from Catalin.

Pinging @ehellbar and @matthias-kleiner 