### PR TITLE
[MCH] normalize the propagation of digits along the reconstruction chain

### DIFF
--- a/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h
+++ b/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h
@@ -33,12 +33,13 @@ namespace mch
 class TrackMCH
 {
   using ClusRef = o2::dataformats::RangeRefComp<5>;
-  using Time = o2::dataformats::TimeStampWithError<float, float>;
 
  public:
+  using Time = o2::dataformats::TimeStampWithError<float, float>;
+
   TrackMCH() = default;
   TrackMCH(double z, const TMatrixD& param, const TMatrixD& cov, double chi2, int firstClIdx, int nClusters,
-           double zAtMID, const TMatrixD& paramAtMID, const TMatrixD& covAtMID);
+           double zAtMID, const TMatrixD& paramAtMID, const TMatrixD& covAtMID, const Time& time);
   ~TrackMCH() = default;
 
   TrackMCH(const TrackMCH& track) = default;

--- a/DataFormats/Detectors/MUON/MCH/src/TrackMCH.cxx
+++ b/DataFormats/Detectors/MUON/MCH/src/TrackMCH.cxx
@@ -29,8 +29,8 @@ namespace mch
 
 //__________________________________________________________________________
 TrackMCH::TrackMCH(double z, const TMatrixD& param, const TMatrixD& cov, double chi2, int firstClIdx, int nClusters,
-                   double zAtMID, const TMatrixD& paramAtMID, const TMatrixD& covAtMID)
-  : mZ(z), mChi2(chi2), mClusRef(firstClIdx, nClusters), mZAtMID(zAtMID)
+                   double zAtMID, const TMatrixD& paramAtMID, const TMatrixD& covAtMID, const Time& time)
+  : mZ(z), mChi2(chi2), mClusRef(firstClIdx, nClusters), mZAtMID(zAtMID), mTimeMUS(time)
 {
   /// constructor
   setParameters(param);

--- a/Detectors/MUON/MCH/Workflow/README.md
+++ b/Detectors/MUON/MCH/Workflow/README.md
@@ -188,9 +188,17 @@ Converts the clusters coordinates from local (2D within detection element plane)
 o2-mch-clusters-to-tracks-original-workflow
 ```
 
-Take as input the list of all clusters ([Cluster](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Cluster.h)) in the current time frame, with the data description "CLUSTERS", and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the clusters associated to each interaction, with the data description "CLUSTERROFS". Send the list of all MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)) in the time frame, the list of all associated clusters ([Cluster](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Cluster.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the tracks associated to each interaction in three separate messages with the data description "TRACKS", "TRACKCLUSTERS" and "TRACKROFS", respectively.
+Take as input the list of all clusters ([Cluster](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Cluster.h)) in the current time frame, with the data description "CLUSTERS", and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the clusters associated to each interaction, with the data description "CLUSTERROFS". Send the list of all MCH tracks ([TrackMCH](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/TrackMCH.h)) in the time frame, the list of all associated clusters ([Cluster](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Cluster.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the tracks associated to each interaction in three separate messages with the data description "TRACKS", "TRACKCLUSTERS" and "TRACKROFS", respectively. Depending on the options, it may also need as input the list of digits ([Digit](/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h)) associated to clusters, with the data description "CLUSTERDIGITS", and send the list of digits ([Digit](/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h)) associated to tracks, with the data description "TRACKDIGITS".
+
+Option `--disable-magfield-from-ccdb` allows to disable the loading of the magnetic field from the CCDB. In this case, the magnetic field is loaded from the GRP file if available. Otherwise, it is created using the provided currents in L3 and in the dipole.
+
+Option `--grp-file` allows to set the name of the GRP file containing the magnetic field.
 
 Options `--l3Current xxx` and `--dipoleCurrent yyy` allow to specify the current in L3 and in the dipole to be used to set the magnetic field.
+
+Option `--disable-time-computation` allows to disable the computation of the track time from the associated digits. Instead, the track time is set to cover the ROF duration.
+
+Option `--digits` allows to send the list of digits associated to the tracks.
 
 Option `--debug x` allows to enable the debug level x (0 = no debug, 1 or 2).
 
@@ -296,20 +304,22 @@ where `clusters.in` is a binary file containing for each event:
 * list of clusters ([Cluster](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Cluster.h))
 * list of associated digits ([Digit](/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h))
 
-Send the list of all clusters ([Cluster](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Cluster.h)) in the current time frame, with the data description "CLUSTERS" (or "GLOBALCLUSTERS" if `--global` option is used), and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the clusters associated to each interaction, with the data description "CLUSTERROFS".
+Send the list of all clusters ([Cluster](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Cluster.h)) in the current time frame, with the data description "CLUSTERS" (or "GLOBALCLUSTERS" if `--global` option is used), the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the clusters associated to each interaction, with the data description "CLUSTERROFS", and the list of digits ([Digit](/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h)) associated to clusters, with the data description "CLUSTERDIGITS".
 
 Option `--nEventsPerTF xxx` allows to set the number of events (i.e. ROF records) to send per time frame (default = 1).
+
+Option `--no-digits` allows to do not send the associated digits.
 
 ### Cluster reader
 
 ```
-o2-mch-clusters-reader-workflow --infile mchclusters.root [--enable-mc] [--local] [--digits]
+o2-mch-clusters-reader-workflow --infile mchclusters.root [--enable-mc] [--local] [--no-digits]
 ```
-Send the list of all clusters ([Cluster](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Cluster.h)) in the current time frame, with the data description "GLOBALCLUSTERS", and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the clusters associated to each interaction, with the data description "CLUSTERROFS".
+Send the list of all clusters ([Cluster](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Cluster.h)) in the current time frame, with the data description "GLOBALCLUSTERS", the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the clusters associated to each interaction, with the data description "CLUSTERROFS", and the list of digits ([Digit](/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h)) associated to clusters, with the data description "CLUSTERDIGITS".
 
 Option `--local` assumes that clusters are in the local coordinate system and send them with the description "CLUSTERS".
 
-Option `--digits` allows to also send the associated digits ([Digit](/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h)) with the data description "CLUSTERDIGITS".
+Option `--no-digits` allows to do not send the associated digits.
 
 Option `--enable-mc` allows to also send the cluster MC labels with the data description "CLUSTERLABELS".
 
@@ -335,6 +345,12 @@ o2-mch-tracks-reader-workflow --infile mchtracks.root
 
 Does the same work as the [Track sampler](#track-sampler) but starting from a Root file (`mchtracks.root`)  containing `TRACKS`, `TRACKROFS` and `TRACKCLUSTERS` containers written e.g. by the [o2-mch-tracks-writer-workflow](#track-writer).
 Note that a very basic utility also exists to get a textual dump of a Root tracks file : `o2-mch-tracks-file-dumper`.
+
+Option `--input-dir` allows to set the name of the directory containing the input file (default = current directory).
+
+Option `--digits` allows to also read the associated digits ([Digit](/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h)) and send them with the data description "TRACKDIGITS".
+
+Option `--enable-mc` allows to also read the track MC labels and send them with the data description "TRACKLABELS".
 
 ### Vertex sampler
 
@@ -378,12 +394,12 @@ Option `--useRun2DigitUID` allows to convert the run3 pad ID stored in the digit
 o2-mch-clusters-sink-workflow --outfile "clusters.out" [--txt] [--no-digits] [--global]
 ```
 
-Take as input the list of all clusters ([Cluster](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Cluster.h)) in the current time frame, and, optionnally, the list of all associated digits ([Digit](/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h)) and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the clusters associated to each interaction, with the data description "CLUSTERS" (or "GLOBALCLUSTERS" if `--global` option is used), "CLUSTERDIGITS" (unless `--no-digits` option is used) and "CLUSTERROFS", respectively, and write them event-by-event in the binary file `clusters.out` with the following format for each event:
+Take as input the list of all clusters ([Cluster](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Cluster.h)) in the current time frame, the list of all associated digits ([Digit](/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h)), unless `--no-digits` option is used, and the list of ROF records ([ROFRecord](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/ROFRecord.h)) pointing to the clusters associated to each interaction, with the data description "CLUSTERS" (or "GLOBALCLUSTERS" if `--global` option is used), "CLUSTERDIGITS" and "CLUSTERROFS", respectively, and write them event-by-event in the binary file `clusters.out` with the following format for each event:
 
 * number of clusters (int)
 * number of associated digits (int) (= 0 if `--no-digits` is used)
 * list of clusters ([Cluster](../../../../DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Cluster.h))
-* list of associated digits ([Digit](/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h))(unless option `--no-digits` is used)
+* list of associated digits ([Digit](/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h)) (unless option `--no-digits` is used)
 
 Option `--txt` allows to write the clusters in the output file in text format.
 
@@ -428,3 +444,7 @@ o2-mch-tracks-writer-workflow --outfile "mchtracks.root"
 ```
 
 Does the same kind of work as the [track sink](#track-sink) but the output is in Root format instead of custom binary one. It is implemented using the generic [MakeRootTreeWriterSpec](/DPLUtils/MakeRootTreeWriterSpec.h) and thus offers the same options.
+
+Option `--digits` allows to also write the associated digits ([Digit](/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/Digit.h)) from the input message with the data description "TRACKDIGITS".
+
+Option `--enable-mc` allows to also write the track MC labels from the input message with the data description "TRACKLABELS".

--- a/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/TrackReaderSpec.h
+++ b/Detectors/MUON/MCH/Workflow/include/MCHWorkflow/TrackReaderSpec.h
@@ -16,7 +16,8 @@
 
 namespace o2::mch
 {
-o2::framework::DataProcessorSpec getTrackReaderSpec(bool useMC, const char* specName = "mch-tracks-reader");
+o2::framework::DataProcessorSpec getTrackReaderSpec(bool useMC, const char* specName = "mch-tracks-reader",
+                                                    bool digits = false);
 }
 
 #endif

--- a/Detectors/MUON/MCH/Workflow/src/TrackFinderOriginalSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackFinderOriginalSpec.cxx
@@ -41,6 +41,7 @@
 #include "DataFormatsMCH/ROFRecord.h"
 #include "DataFormatsMCH/TrackMCH.h"
 #include "DataFormatsMCH/Cluster.h"
+#include "DataFormatsMCH/Digit.h"
 #include "DataFormatsParameters/GRPObject.h"
 #include "DetectorsBase/GRPGeomHelper.h"
 #include "DetectorsBase/Propagator.h"
@@ -61,7 +62,8 @@ class TrackFinderTask
 {
  public:
   //_________________________________________________________________________________________________
-  TrackFinderTask(std::shared_ptr<base::GRPGeomRequest> req) : mCCDBRequest(req) {}
+  TrackFinderTask(bool computeTime, bool digits, std::shared_ptr<base::GRPGeomRequest> req)
+    : mComputeTime(computeTime), mDigits(digits), mCCDBRequest(req) {}
 
   //_________________________________________________________________________________________________
   void init(framework::InitContext& ic)
@@ -122,21 +124,29 @@ class TrackFinderTask
       base::GRPGeomHelper::instance().checkUpdates(pc);
     }
 
-    // get the input messages with clusters
+    uint32_t firstTForbit = pc.services().get<o2::framework::TimingInfo>().firstTForbit;
+
+    // get the input messages with clusters and associated digits if needed
     auto clusterROFs = pc.inputs().get<gsl::span<ROFRecord>>("clusterrofs");
     auto clustersIn = pc.inputs().get<gsl::span<Cluster>>("clusters");
+    gsl::span<const Digit> digitsIn{};
+    if (mComputeTime || mDigits) {
+      digitsIn = pc.inputs().get<gsl::span<Digit>>("clusterdigits");
+    }
 
-    // LOG(info) << "received time frame with " << clusterROFs.size() << " interactions";
-
-    // create the output messages for tracks and attached clusters
+    // create the output messages for tracks, attached clusters and associated digits if requested
     auto& trackROFs = pc.outputs().make<std::vector<ROFRecord>>(OutputRef{"trackrofs"});
     auto& mchTracks = pc.outputs().make<std::vector<TrackMCH>>(OutputRef{"tracks"});
     auto& usedClusters = pc.outputs().make<std::vector<Cluster>>(OutputRef{"trackclusters"});
+    std::vector<Digit, o2::pmr::polymorphic_allocator<Digit>>* usedDigits(nullptr);
+    if (mDigits) {
+      usedDigits = &pc.outputs().make<std::vector<Digit>>(OutputRef{"trackdigits"});
+    }
 
     trackROFs.reserve(clusterROFs.size());
-    for (const auto& clusterROF : clusterROFs) {
+    auto timeStart = std::chrono::high_resolution_clock::now();
 
-      // LOG(info) << "processing interaction: " << clusterROF.getBCData() << "...";
+    for (const auto& clusterROF : clusterROFs) {
 
       // sort the input clusters of the current event per chamber
       std::array<std::list<const Cluster*>, 10> clusters{};
@@ -152,19 +162,61 @@ class TrackFinderTask
 
       // fill the ouput messages
       int trackOffset(mchTracks.size());
-      writeTracks(tracks, mchTracks, usedClusters);
+      writeTracks(tracks, digitsIn, clusterROF, firstTForbit, mchTracks, usedClusters, usedDigits);
       trackROFs.emplace_back(clusterROF.getBCData(), trackOffset, mchTracks.size() - trackOffset,
                              clusterROF.getBCWidth());
     }
+
+    auto timeEnd = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double, std::milli> elapsed = timeEnd - timeStart;
+    LOGP(info, "Found {:3d} MCH tracks from {:4d} clusters in {:2d} ROFs in {:8.0f} ms",
+         mchTracks.size(), clustersIn.size(), clusterROFs.size(), elapsed.count());
   }
 
  private:
   //_________________________________________________________________________________________________
-  void writeTracks(const std::list<Track>& tracks,
-                   std::vector<TrackMCH, o2::pmr::polymorphic_allocator<TrackMCH>>& mchTracks,
-                   std::vector<Cluster, o2::pmr::polymorphic_allocator<Cluster>>& usedClusters) const
+  TrackMCH::Time computeTrackTime(const Track& track, const gsl::span<const Digit>& digitsIn,
+                                  const ROFRecord& clusterROF, uint32_t firstTForbit) const
   {
-    /// fill the output messages with tracks and attached clusters
+    /// compute the track time
+
+    double trackBCinTF = 0.;
+    int nDigits = 0;
+
+    // loop over associated digits and compute the average digits time
+    for (const auto& param : track) {
+      for (const auto& digit : digitsIn.subspan(param.getClusterPtr()->firstDigit, param.getClusterPtr()->nDigits)) {
+        nDigits += 1;
+        trackBCinTF += (double(digit.getTime()) - trackBCinTF) / nDigits;
+      }
+    }
+
+    // set the track time from the computed average digits time
+    if (nDigits > 0) {
+      // convert the average digit time from bunch-crossing units to microseconds
+      // add 1.5 BC to account for the fact that the actual digit time in BC units
+      // can be between t and t+3, hence t+1.5 in average
+      float tMean = o2::constants::lhc::LHCBunchSpacingMUS * (trackBCinTF + 1.5);
+      float tErr = o2::constants::lhc::LHCBunchSpacingMUS * mTrackTime3Sigma;
+      return TrackMCH::Time(tMean, tErr);
+    }
+
+    // if no digits are found, compute the time directly from the cluster's ROF
+    LOG(fatal) << "MCH: no digits found when computing the track mean time";
+    return clusterROF.getTimeMUS({0, firstTForbit}).first;
+  }
+
+  //_________________________________________________________________________________________________
+  void writeTracks(const std::list<Track>& tracks, const gsl::span<const Digit>& digitsIn,
+                   const ROFRecord& clusterROF, uint32_t firstTForbit,
+                   std::vector<TrackMCH, o2::pmr::polymorphic_allocator<TrackMCH>>& mchTracks,
+                   std::vector<Cluster, o2::pmr::polymorphic_allocator<Cluster>>& usedClusters,
+                   std::vector<Digit, o2::pmr::polymorphic_allocator<Digit>>* usedDigits) const
+  {
+    /// fill the output messages with tracks and attached clusters and digits if requested
+
+    // map the location of the attached digits between the digitsIn and the usedDigits lists
+    std::unordered_map<uint32_t, uint32_t> digitLocMap{};
 
     for (const auto& track : tracks) {
 
@@ -174,33 +226,64 @@ class TrackFinderTask
         continue;
       }
 
+      const auto time = mComputeTime ? computeTrackTime(track, digitsIn, clusterROF, firstTForbit)
+                                     : clusterROF.getTimeMUS({0, firstTForbit}).first;
+
       const auto& param = track.first();
       mchTracks.emplace_back(param.getZ(), param.getParameters(), param.getCovariances(),
                              param.getTrackChi2(), usedClusters.size(), track.getNClusters(),
-                             paramAtMID.getZ(), paramAtMID.getParameters(), paramAtMID.getCovariances());
+                             paramAtMID.getZ(), paramAtMID.getParameters(), paramAtMID.getCovariances(),
+                             time);
 
       for (const auto& param : track) {
+
         usedClusters.emplace_back(*param.getClusterPtr());
+
+        if (mDigits) {
+
+          // map the location of the digits associated to this cluster in the usedDigits list, if not already done
+          auto& cluster = usedClusters.back();
+          auto digitLoc = digitLocMap.emplace(cluster.firstDigit, usedDigits->size());
+
+          // add the digits associated to this cluster if not already there
+          if (digitLoc.second) {
+            auto itFirstDigit = digitsIn.begin() + cluster.firstDigit;
+            usedDigits->insert(usedDigits->end(), itFirstDigit, itFirstDigit + cluster.nDigits);
+          }
+
+          // make the cluster point to the associated digits in the usedDigits list
+          cluster.firstDigit = digitLoc.first->second;
+        }
       }
     }
   }
 
+  bool mComputeTime = false;                            ///< compute the track time from the associated digits
+  bool mDigits = false;                                 ///< send to associated digits
   std::shared_ptr<base::GRPGeomRequest> mCCDBRequest{}; ///< pointer to the CCDB requests
+  float mTrackTime3Sigma{6.0};                          ///< three times the digit time resolution, in BC units
   TrackFinderOriginal mTrackFinder{};                   ///< track finder
   std::chrono::duration<double> mElapsedTime{};         ///< timer
 };
 
 //_________________________________________________________________________________________________
-o2::framework::DataProcessorSpec getTrackFinderOriginalSpec(const char* specName, bool disableCCDBMagField)
+o2::framework::DataProcessorSpec getTrackFinderOriginalSpec(const char* specName, bool computeTime, bool digits,
+                                                            bool disableCCDBMagField)
 {
   std::vector<InputSpec> inputSpecs{};
   inputSpecs.emplace_back(InputSpec{"clusterrofs", "MCH", "CLUSTERROFS", 0, Lifetime::Timeframe});
   inputSpecs.emplace_back(InputSpec{"clusters", "MCH", "GLOBALCLUSTERS", 0, Lifetime::Timeframe});
+  if (computeTime || digits) {
+    inputSpecs.emplace_back(InputSpec{"clusterdigits", "MCH", "CLUSTERDIGITS", 0, Lifetime::Timeframe});
+  }
 
   std::vector<OutputSpec> outputSpecs{};
   outputSpecs.emplace_back(OutputSpec{{"trackrofs"}, "MCH", "TRACKROFS", 0, Lifetime::Timeframe});
   outputSpecs.emplace_back(OutputSpec{{"tracks"}, "MCH", "TRACKS", 0, Lifetime::Timeframe});
   outputSpecs.emplace_back(OutputSpec{{"trackclusters"}, "MCH", "TRACKCLUSTERS", 0, Lifetime::Timeframe});
+  if (digits) {
+    outputSpecs.emplace_back(OutputSpec{{"trackdigits"}, "MCH", "TRACKDIGITS", 0, Lifetime::Timeframe});
+  }
 
   auto ccdbRequest = disableCCDBMagField ? nullptr
                                          : std::make_shared<base::GRPGeomRequest>(false,                      // orbitResetTime
@@ -215,7 +298,7 @@ o2::framework::DataProcessorSpec getTrackFinderOriginalSpec(const char* specName
     specName,
     inputSpecs,
     outputSpecs,
-    AlgorithmSpec{adaptFromTask<TrackFinderTask>(ccdbRequest)},
+    AlgorithmSpec{adaptFromTask<TrackFinderTask>(computeTime, digits, ccdbRequest)},
     Options{{"l3Current", VariantType::Float, -30000.0f, {"L3 current"}},
             {"dipoleCurrent", VariantType::Float, -6000.0f, {"Dipole current"}},
             {"grp-file", VariantType::String, o2::base::NameConf::getGRPFileName(), {"Name of the grp file"}},

--- a/Detectors/MUON/MCH/Workflow/src/TrackFinderOriginalSpec.h
+++ b/Detectors/MUON/MCH/Workflow/src/TrackFinderOriginalSpec.h
@@ -25,6 +25,7 @@ namespace mch
 {
 
 o2::framework::DataProcessorSpec getTrackFinderOriginalSpec(const char* specName = "mch-track-finder-original",
+                                                            bool computeTime = true, bool digits = false,
                                                             bool disableCCDBMagField = false);
 
 } // end namespace mch

--- a/Detectors/MUON/MCH/Workflow/src/TrackFinderSpec.h
+++ b/Detectors/MUON/MCH/Workflow/src/TrackFinderSpec.h
@@ -24,7 +24,7 @@ namespace o2
 namespace mch
 {
 
-o2::framework::DataProcessorSpec getTrackFinderSpec(const char* specName = "mch-track-finder",
+o2::framework::DataProcessorSpec getTrackFinderSpec(const char* specName = "mch-track-finder", bool computeTime = true,
                                                     bool digits = false, bool disableCCDBMagField = false);
 
 } // end namespace mch

--- a/Detectors/MUON/MCH/Workflow/src/TrackFitterSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackFitterSpec.cxx
@@ -111,7 +111,8 @@ class TrackFitterTask
         const auto& param = track.first();
         tracksOut.emplace_back(param.getZ(), param.getParameters(), param.getCovariances(),
                                param.getTrackChi2(), clustersOut.size(), track.getNClusters(),
-                               paramAtMID.getZ(), paramAtMID.getParameters(), paramAtMID.getCovariances());
+                               paramAtMID.getZ(), paramAtMID.getParameters(), paramAtMID.getCovariances(),
+                               mchTrack.getTimeMUS());
         clustersOut.insert(clustersOut.end(), trackClusters.begin(), trackClusters.end());
       }
 

--- a/Detectors/MUON/MCH/Workflow/src/TrackReaderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/TrackReaderSpec.cxx
@@ -14,6 +14,8 @@
 #include "DPLUtils/RootTreeReader.h"
 #include "CommonUtils/StringUtils.h"
 #include "SimulationDataFormat/MCCompLabel.h"
+#include "DataFormatsMCH/Cluster.h"
+#include "DataFormatsMCH/Digit.h"
 #include "DataFormatsMCH/ROFRecord.h"
 #include "DataFormatsMCH/TrackMCH.h"
 #include "Framework/ConfigParamRegistry.h"
@@ -21,7 +23,6 @@
 #include "Framework/Lifetime.h"
 #include "Framework/Logger.h"
 #include "Framework/Task.h"
-#include "DataFormatsMCH/Cluster.h"
 #include <iostream>
 #include <vector>
 
@@ -48,6 +49,9 @@ RootTreeReader::SpecialPublishHook logging{
     if (name == "tracks") {
       printBranch<TrackMCH>(data, "TRACKS");
     }
+    if (name == "trackdigits") {
+      printBranch<Digit>(data, "DIGITS");
+    }
     if (name == "tracklabels") {
       auto tdata = reinterpret_cast<std::vector<o2::MCCompLabel>*>(data);
       LOGP(info, "MCH {:d} {:s}", tdata->size(), "LABELS");
@@ -58,7 +62,8 @@ RootTreeReader::SpecialPublishHook logging{
 struct TrackReader {
   std::unique_ptr<RootTreeReader> mTreeReader;
   bool mUseMC = false;
-  TrackReader(bool useMC = false) : mUseMC(useMC) {}
+  bool mDigits = false;
+  TrackReader(bool useMC, bool digits) : mUseMC(useMC), mDigits(digits) {}
   void init(InitContext& ic)
   {
     if (!mUseMC) {
@@ -68,26 +73,53 @@ struct TrackReader {
     auto fileName = o2::utils::Str::concat_string(o2::utils::Str::rectifyDirectory(ic.options().get<std::string>("input-dir")), ic.options().get<std::string>("infile"));
     auto nofEntries{-1};
     if (mUseMC) {
-      mTreeReader = std::make_unique<RootTreeReader>(
-        treeName,
-        fileName.c_str(),
-        nofEntries,
-        RootTreeReader::PublishingMode::Single,
-        RootTreeReader::BranchDefinition<std::vector<TrackMCH>>{Output{"MCH", "TRACKS", 0}, "tracks"},
-        RootTreeReader::BranchDefinition<std::vector<ROFRecord>>{Output{"MCH", "TRACKROFS", 0}, "trackrofs"},
-        RootTreeReader::BranchDefinition<std::vector<Cluster>>{Output{"MCH", "TRACKCLUSTERS", 0}, "trackclusters"},
-        RootTreeReader::BranchDefinition<std::vector<o2::MCCompLabel>>{Output{"MCH", "TRACKLABELS", 0}, "tracklabels"},
-        &logging);
+      if (mDigits) {
+        mTreeReader = std::make_unique<RootTreeReader>(
+          treeName,
+          fileName.c_str(),
+          nofEntries,
+          RootTreeReader::PublishingMode::Single,
+          RootTreeReader::BranchDefinition<std::vector<ROFRecord>>{Output{"MCH", "TRACKROFS", 0}, "trackrofs"},
+          RootTreeReader::BranchDefinition<std::vector<TrackMCH>>{Output{"MCH", "TRACKS", 0}, "tracks"},
+          RootTreeReader::BranchDefinition<std::vector<Cluster>>{Output{"MCH", "TRACKCLUSTERS", 0}, "trackclusters"},
+          RootTreeReader::BranchDefinition<std::vector<Digit>>{Output{"MCH", "TRACKDIGITS", 0}, "trackdigits"},
+          RootTreeReader::BranchDefinition<std::vector<o2::MCCompLabel>>{Output{"MCH", "TRACKLABELS", 0}, "tracklabels"},
+          &logging);
+      } else {
+        mTreeReader = std::make_unique<RootTreeReader>(
+          treeName,
+          fileName.c_str(),
+          nofEntries,
+          RootTreeReader::PublishingMode::Single,
+          RootTreeReader::BranchDefinition<std::vector<ROFRecord>>{Output{"MCH", "TRACKROFS", 0}, "trackrofs"},
+          RootTreeReader::BranchDefinition<std::vector<TrackMCH>>{Output{"MCH", "TRACKS", 0}, "tracks"},
+          RootTreeReader::BranchDefinition<std::vector<Cluster>>{Output{"MCH", "TRACKCLUSTERS", 0}, "trackclusters"},
+          RootTreeReader::BranchDefinition<std::vector<o2::MCCompLabel>>{Output{"MCH", "TRACKLABELS", 0}, "tracklabels"},
+          &logging);
+      }
     } else {
-      mTreeReader = std::make_unique<RootTreeReader>(
-        treeName,
-        fileName.c_str(),
-        nofEntries,
-        RootTreeReader::PublishingMode::Single,
-        RootTreeReader::BranchDefinition<std::vector<TrackMCH>>{Output{"MCH", "TRACKS", 0}, "tracks"},
-        RootTreeReader::BranchDefinition<std::vector<ROFRecord>>{Output{"MCH", "TRACKROFS", 0}, "trackrofs"},
-        RootTreeReader::BranchDefinition<std::vector<Cluster>>{Output{"MCH", "TRACKCLUSTERS", 0}, "trackclusters"},
-        &logging);
+      if (mDigits) {
+        mTreeReader = std::make_unique<RootTreeReader>(
+          treeName,
+          fileName.c_str(),
+          nofEntries,
+          RootTreeReader::PublishingMode::Single,
+          RootTreeReader::BranchDefinition<std::vector<ROFRecord>>{Output{"MCH", "TRACKROFS", 0}, "trackrofs"},
+          RootTreeReader::BranchDefinition<std::vector<TrackMCH>>{Output{"MCH", "TRACKS", 0}, "tracks"},
+          RootTreeReader::BranchDefinition<std::vector<Cluster>>{Output{"MCH", "TRACKCLUSTERS", 0}, "trackclusters"},
+          RootTreeReader::BranchDefinition<std::vector<Digit>>{Output{"MCH", "TRACKDIGITS", 0}, "trackdigits"},
+          &logging);
+      } else {
+        mTreeReader = std::make_unique<RootTreeReader>(
+          treeName,
+          fileName.c_str(),
+          nofEntries,
+          RootTreeReader::PublishingMode::Single,
+          RootTreeReader::BranchDefinition<std::vector<ROFRecord>>{Output{"MCH", "TRACKROFS", 0}, "trackrofs"},
+          RootTreeReader::BranchDefinition<std::vector<TrackMCH>>{Output{"MCH", "TRACKS", 0}, "tracks"},
+          RootTreeReader::BranchDefinition<std::vector<Cluster>>{Output{"MCH", "TRACKCLUSTERS", 0}, "trackclusters"},
+          &logging);
+      }
     }
   }
 
@@ -102,12 +134,15 @@ struct TrackReader {
   }
 };
 
-DataProcessorSpec getTrackReaderSpec(bool useMC, const char* specName)
+DataProcessorSpec getTrackReaderSpec(bool useMC, const char* specName, bool digits)
 {
   std::vector<OutputSpec> outputSpecs;
   outputSpecs.emplace_back(OutputSpec{{"tracks"}, "MCH", "TRACKS", 0, Lifetime::Timeframe});
   outputSpecs.emplace_back(OutputSpec{{"trackrofs"}, "MCH", "TRACKROFS", 0, Lifetime::Timeframe});
   outputSpecs.emplace_back(OutputSpec{{"trackclusters"}, "MCH", "TRACKCLUSTERS", 0, Lifetime::Timeframe});
+  if (digits) {
+    outputSpecs.emplace_back(OutputSpec{{"trackdigits"}, "MCH", "TRACKDIGITS", 0, Lifetime::Timeframe});
+  }
   if (useMC) {
     outputSpecs.emplace_back(OutputSpec{{"tracklabels"}, "MCH", "TRACKLABELS", 0, Lifetime::Timeframe});
   }
@@ -120,7 +155,7 @@ DataProcessorSpec getTrackReaderSpec(bool useMC, const char* specName)
     specName,
     Inputs{},
     outputSpecs,
-    adaptFromTask<TrackReader>(useMC),
+    adaptFromTask<TrackReader>(useMC, digits),
     options};
 }
 } // namespace o2::mch

--- a/Detectors/MUON/MCH/Workflow/src/TrackTreeReader.h
+++ b/Detectors/MUON/MCH/Workflow/src/TrackTreeReader.h
@@ -13,6 +13,7 @@
 #define O2_MCH_WORKFLOW_TRACK_TREE_READER_H
 
 #include "DataFormatsMCH/Cluster.h"
+#include "DataFormatsMCH/Digit.h"
 #include "DataFormatsMCH/TrackMCH.h"
 #include "DataFormatsMCH/ROFRecord.h"
 #include "SimulationDataFormat/MCCompLabel.h"
@@ -31,8 +32,10 @@ class TrackTreeReader
   bool next(ROFRecord& rof,
             std::vector<TrackMCH>& tracks,
             std::vector<Cluster>& clusters,
+            std::vector<Digit>& digits,
             std::vector<o2::MCCompLabel>& labels);
 
+  bool hasDigits() { return mDigits.get() != nullptr; }
   bool hasLabels() { return mLabels.get() != nullptr; }
 
  private:
@@ -40,6 +43,7 @@ class TrackTreeReader
   TTreeReaderValue<std::vector<o2::mch::TrackMCH>> mTracks = {mTreeReader, "tracks"};
   TTreeReaderValue<std::vector<o2::mch::ROFRecord>> mRofs = {mTreeReader, "trackrofs"};
   TTreeReaderValue<std::vector<o2::mch::Cluster>> mClusters = {mTreeReader, "trackclusters"};
+  std::unique_ptr<TTreeReaderValue<std::vector<o2::mch::Digit>>> mDigits{};
   std::unique_ptr<TTreeReaderValue<std::vector<o2::MCCompLabel>>> mLabels{};
   size_t mCurrentRof;
 };

--- a/Detectors/MUON/MCH/Workflow/src/clusters-reader-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/clusters-reader-workflow.cxx
@@ -28,7 +28,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
   workflowOptions.emplace_back("enable-mc", VariantType::Bool, false, ConfigParamSpec::HelpString{"Propagate MC info"});
   workflowOptions.emplace_back("local", VariantType::Bool, false, ConfigParamSpec::HelpString{"Read clusters in local reference frame"});
-  workflowOptions.emplace_back("digits", VariantType::Bool, false, ConfigParamSpec::HelpString{"Read the associated digits"});
+  workflowOptions.emplace_back("no-digits", VariantType::Bool, false, ConfigParamSpec::HelpString{"Do not read associated digits"});
   o2::raw::HBFUtilsInitializer::addConfigOption(workflowOptions);
 }
 
@@ -38,7 +38,7 @@ WorkflowSpec defineDataProcessing(const ConfigContext& config)
 {
   bool useMC = config.options().get<bool>("enable-mc");
   bool global = !config.options().get<bool>("local");
-  bool digits = config.options().get<bool>("digits");
+  bool digits = !config.options().get<bool>("no-digits");
   WorkflowSpec wf{o2::mch::getClusterReaderSpec(useMC, "mch-cluster-reader", global, digits)};
   o2::raw::HBFUtilsInitializer hbfIni(config, wf);
   return wf;

--- a/Detectors/MUON/MCH/Workflow/src/clusters-to-tracks-original-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/clusters-to-tracks-original-workflow.cxx
@@ -24,9 +24,12 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
   workflowOptions.emplace_back("configKeyValues", VariantType::String, "",
                                ConfigParamSpec::HelpString{"Semicolon separated key=value strings"});
-  workflowOptions.emplace_back("disable-magfield-from-ccdb",
-                               o2::framework::VariantType::Bool, false,
-                               o2::framework::ConfigParamSpec::HelpString{"do not read magnetic field from ccdb"});
+  workflowOptions.emplace_back("disable-time-computation", VariantType::Bool, false,
+                               ConfigParamSpec::HelpString{"disable track time computation from associated digits"});
+  workflowOptions.emplace_back("digits", VariantType::Bool, false,
+                               ConfigParamSpec::HelpString{"Send associated digits"});
+  workflowOptions.emplace_back("disable-magfield-from-ccdb", VariantType::Bool, false,
+                               ConfigParamSpec::HelpString{"do not read magnetic field from ccdb"});
 }
 
 #include "Framework/runDataProcessing.h"
@@ -34,6 +37,9 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 WorkflowSpec defineDataProcessing(const ConfigContext& configcontext)
 {
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
+  bool computeTime = !configcontext.options().get<bool>("disable-time-computation");
+  bool digits = configcontext.options().get<bool>("digits");
   bool disableCCDBMagField = configcontext.options().get<bool>("disable-magfield-from-ccdb");
-  return WorkflowSpec{o2::mch::getTrackFinderOriginalSpec("mch-track-finder-original", disableCCDBMagField)};
+  return WorkflowSpec{o2::mch::getTrackFinderOriginalSpec("mch-track-finder-original",
+                                                          computeTime, digits, disableCCDBMagField)};
 }

--- a/Detectors/MUON/MCH/Workflow/src/clusters-to-tracks-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/clusters-to-tracks-workflow.cxx
@@ -24,11 +24,12 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
   workflowOptions.emplace_back("configKeyValues", VariantType::String, "",
                                ConfigParamSpec::HelpString{"Semicolon separated key=value strings"});
+  workflowOptions.emplace_back("disable-time-computation", VariantType::Bool, false,
+                               ConfigParamSpec::HelpString{"disable track time computation from associated digits"});
   workflowOptions.emplace_back("digits", VariantType::Bool, false,
                                ConfigParamSpec::HelpString{"Send associated digits"});
-  workflowOptions.emplace_back("disable-magfield-from-ccdb",
-                               o2::framework::VariantType::Bool, false,
-                               o2::framework::ConfigParamSpec::HelpString{"do not read magnetic field from ccdb"});
+  workflowOptions.emplace_back("disable-magfield-from-ccdb", VariantType::Bool, false,
+                               ConfigParamSpec::HelpString{"do not read magnetic field from ccdb"});
 }
 
 #include "Framework/runDataProcessing.h"
@@ -36,7 +37,8 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 WorkflowSpec defineDataProcessing(const ConfigContext& configcontext)
 {
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
+  bool computeTime = !configcontext.options().get<bool>("disable-time-computation");
   bool digits = configcontext.options().get<bool>("digits");
   bool disableCCDBMagField = configcontext.options().get<bool>("disable-magfield-from-ccdb");
-  return WorkflowSpec{o2::mch::getTrackFinderSpec("mch-track-finder", digits, disableCCDBMagField)};
+  return WorkflowSpec{o2::mch::getTrackFinderSpec("mch-track-finder", computeTime, digits, disableCCDBMagField)};
 }

--- a/Detectors/MUON/MCH/Workflow/src/reco-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/reco-workflow.cxx
@@ -103,10 +103,10 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     specs.emplace_back(o2::mch::getClusterFinderOriginalSpec("mch-cluster-finder"));
     specs.emplace_back(o2::mch::getClusterTransformerSpec("mch-cluster-transformer", false));
     if (!disableRootOutput) {
-      specs.emplace_back(o2::mch::getClusterWriterSpec(false, "mch-global-cluster-writer", true, digits)); // RS cannot find who produces MCH/CLUSTERLABELS/0
+      specs.emplace_back(o2::mch::getClusterWriterSpec(false, "mch-global-cluster-writer", true, true));
     }
     if (!disableTracking) {
-      specs.emplace_back(o2::mch::getTrackFinderSpec("mch-track-finder", digits));
+      specs.emplace_back(o2::mch::getTrackFinderSpec("mch-track-finder", true, digits, false));
       if (useMC) {
         specs.emplace_back(o2::mch::getTrackMCLabelFinderSpec("mch-track-mc-label-finder",
                                                               triggered ? "E-F-DIGITROFS" : "F-DIGITROFS",

--- a/Detectors/MUON/MCH/Workflow/src/tracks-file-dumper.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/tracks-file-dumper.cxx
@@ -10,6 +10,7 @@
 // or submit itself to any jurisdiction.
 
 #include "DataFormatsMCH/Cluster.h"
+#include "DataFormatsMCH/Digit.h"
 #include "DataFormatsMCH/ROFRecord.h"
 #include "DataFormatsMCH/TrackMCH.h"
 #include "MCHBase/TrackBlock.h"
@@ -31,6 +32,7 @@ namespace po = boost::program_options;
 namespace fs = std::filesystem;
 
 using o2::mch::Cluster;
+using o2::mch::Digit;
 using o2::mch::ROFRecord;
 using o2::mch::TrackAtVtxStruct;
 using o2::mch::TrackMCH;
@@ -136,9 +138,10 @@ int dumpRoot(std::string inputFile)
   ROFRecord rof;
   std::vector<TrackMCH> tracks;
   std::vector<Cluster> clusters;
+  std::vector<Digit> digits;
   std::vector<o2::MCCompLabel> labels;
 
-  while (tr.next(rof, tracks, clusters, labels)) {
+  while (tr.next(rof, tracks, clusters, digits, labels)) {
     std::cout << rof << "\n";
     if (tr.hasLabels() && labels.size() != tracks.size()) {
       std::cerr << "the number of labels do not match the number of tracks\n";

--- a/Detectors/MUON/MCH/Workflow/src/tracks-reader-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/tracks-reader-workflow.cxx
@@ -19,6 +19,7 @@ using namespace o2::framework;
 void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
   workflowOptions.emplace_back("enable-mc", VariantType::Bool, false, ConfigParamSpec::HelpString{"Propagate MC info"});
+  workflowOptions.emplace_back("digits", VariantType::Bool, false, ConfigParamSpec::HelpString{"Read associated digits"});
 }
 
 #include "Framework/runDataProcessing.h"
@@ -26,5 +27,6 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 WorkflowSpec defineDataProcessing(const ConfigContext& config)
 {
   bool useMC = config.options().get<bool>("enable-mc");
-  return WorkflowSpec{o2::mch::getTrackReaderSpec(useMC)};
+  bool digits = config.options().get<bool>("digits");
+  return WorkflowSpec{o2::mch::getTrackReaderSpec(useMC, "mch-tracks-reader", digits)};
 }


### PR DESCRIPTION
The digits are now needed in the tracking workflows to compute the track time. Therefore I changed a bit the decision of propagating (or not) the digits along the reconstruction chain and in the output files, and I tried to make it more consistent between the various devices:

- by default, the digits associated to the clusters are written to / read from the cluster output files, unless the option --no-digits is specified in the corresponding workflows.

- by default, the track time is explicitly computed from the associated digits time (and thus the cluster digits are needed as input) in the tracking workflows, unless the option --disable-time-computation is specified (in which case the ROF time is used).

- by default, the digits associated to tracks are not written to / read from the track output root file, unless the option --digits is specified in the corresponding workflows.

I updated the README accordingly.