### PR TITLE
Optionally apply fixed BC shift to CTP data decoded from CTF

### DIFF
--- a/Detectors/CTP/workflow/src/EntropyDecoderSpec.cxx
+++ b/Detectors/CTP/workflow/src/EntropyDecoderSpec.cxx
@@ -30,6 +30,7 @@ EntropyDecoderSpec::EntropyDecoderSpec(int verbosity) : mCTFCoder(o2::ctf::CTFCo
   mTimer.Stop();
   mTimer.Reset();
   mCTFCoder.setVerbosity(verbosity);
+  mCTFCoder.setSupportBCShifts(true);
 }
 
 void EntropyDecoderSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher, void* obj)


### PR DESCRIPTION
e.g. 
```
o2-ctf-reader-workflow --ctf-input ... --configKeyValues "TriggerOffsetsParam.customOffset[16]=293"
```

Note that if the shifted trigger becomes prior to TF 1st orbit then it is discarded