### PR TITLE
DPL: add check for missing outputs

### DIFF
--- a/Framework/Core/include/Framework/DataSender.h
+++ b/Framework/Core/include/Framework/DataSender.h
@@ -37,6 +37,16 @@ class DataSender
              SendingPolicy const& policy);
   void send(fair::mq::Parts&, ChannelIndex index);
   std::unique_ptr<fair::mq::Message> create(RouteIndex index);
+  /// Reset the datasender to a clean state
+  /// so that we can track what whill be sent in the next
+  /// iteration and eventually complain if one of the
+  /// Lifetime::Timeframe is not create / sent.
+  void reset();
+  /// Actually verify if all the selected outputs have been sent.
+  /// Notice how I think there are a few cases in which we might
+  /// have a false positive, since I one could have a completion policy
+  /// which creates two required messages in two different iterations.
+  void verifyMissingSporadic() const;
 
  private:
   FairMQDeviceProxy& mProxy;
@@ -51,6 +61,8 @@ class DataSender
   std::vector<std::string> mMetricsNames;
   std::vector<std::string> mVariablesMetricsNames;
   std::vector<std::string> mQueriesMetricsNames;
+  std::vector<bool> mPresent;
+  std::vector<bool> mPresentDefaults;
 
   TracyLockableN(std::recursive_mutex, mMutex, "data relayer mutex");
 };

--- a/Framework/Core/include/Framework/O2DataModelHelpers.h
+++ b/Framework/Core/include/Framework/O2DataModelHelpers.h
@@ -70,7 +70,16 @@ struct O2DataModelHelpers {
     }
     return true;
   }
-  static bool checkForMissingSporadic(fair::mq::Parts& parts, std::vector<OutputSpec> const& specs, std::vector<bool>& present);
+  static void updateMissingSporadic(fair::mq::Parts& parts, std::vector<OutputSpec> const& specs, std::vector<bool>& present);
+  static bool validateOutputs(std::vector<bool>& present)
+  {
+    for (auto p : present) {
+      if (!p) {
+        return false;
+      }
+    }
+    return true;
+  }
   static std::string describeMissingOutputs(std::vector<OutputSpec> const& specs, std::vector<bool> const& present);
 };
 } // namespace o2::framework

--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -321,6 +321,16 @@ o2::framework::ServiceSpec CommonServices::dataSender()
                            new DataSender(services, spec.sendingPolicy)};
     },
     .configure = noConfiguration(),
+    .preProcessing = [](ProcessingContext&, void* service) {
+      auto& dataSender = *reinterpret_cast<DataSender*>(service);
+      dataSender.reset(); },
+    .postDispatching = [](ProcessingContext& ctx, void* service) {
+      auto& dataSender = *reinterpret_cast<DataSender*>(service);
+      // If the quit was requested, the post dispatching can still happen
+      // but with an empty set of data.
+      if (ctx.services().get<DeviceState>().quitRequested == false) {
+        dataSender.verifyMissingSporadic();
+      } },
     .kind = ServiceKind::Serial};
 }
 

--- a/Framework/Core/src/DataSender.cxx
+++ b/Framework/Core/src/DataSender.cxx
@@ -20,6 +20,8 @@
 #include "Framework/TimesliceIndex.h"
 #include "Framework/DataProcessingHelpers.h"
 #include "Framework/CommonServices.h"
+#include "Framework/DataProcessingContext.h"
+#include "Framework/O2DataModelHelpers.h"
 
 using namespace o2::monitoring;
 
@@ -66,6 +68,10 @@ DataSender::DataSender(ServiceRegistryRef registry,
     DataSpecUtils::describe(buffer, 127, mOutputs.back());
     monitoring.send({fmt::format("{} ({})", buffer, (int)mOutputs.back().lifetime), mQueriesMetricsNames[i], Verbosity::Debug});
   }
+  /// Fill the mPresents with the outputs which are not timeframes.
+  for (size_t i = 0; i < mOutputs.size(); ++i) {
+    mPresentDefaults.push_back(mOutputs[i].lifetime != Lifetime::Timeframe);
+  }
 }
 
 std::unique_ptr<fair::mq::Message> DataSender::create(RouteIndex routeIndex)
@@ -75,8 +81,24 @@ std::unique_ptr<fair::mq::Message> DataSender::create(RouteIndex routeIndex)
 
 void DataSender::send(fair::mq::Parts& parts, ChannelIndex channelIndex)
 {
+  O2DataModelHelpers::updateMissingSporadic(parts, mOutputs, mPresent);
   mRegistry.preSendingMessagesCallbacks(parts, channelIndex);
   mPolicy.send(mProxy, parts, channelIndex, mRegistry);
+}
+
+void DataSender::reset()
+{
+  mPresent = mPresentDefaults;
+}
+
+void DataSender::verifyMissingSporadic() const
+{
+  for (auto present : mPresent) {
+    if (!present) {
+      LOGP(warning, O2DataModelHelpers::describeMissingOutputs(mOutputs, mPresent).c_str());
+      return;
+    }
+  }
 }
 
 } // namespace o2::framework

--- a/Framework/Core/src/O2DataModelHelpers.cxx
+++ b/Framework/Core/src/O2DataModelHelpers.cxx
@@ -14,9 +14,8 @@
 
 namespace o2::framework
 {
-bool O2DataModelHelpers::checkForMissingSporadic(fair::mq::Parts& parts, std::vector<OutputSpec> const& specs, std::vector<bool>& present)
+void O2DataModelHelpers::updateMissingSporadic(fair::mq::Parts& parts, std::vector<OutputSpec> const& specs, std::vector<bool>& present)
 {
-  std::fill(present.begin(), present.end(), false);
   // Mark as present anything which is not of Lifetime timeframe.
   for (size_t i = 0; i < specs.size(); ++i) {
     if (specs[i].lifetime != Lifetime::Timeframe) {
@@ -41,7 +40,6 @@ bool O2DataModelHelpers::checkForMissingSporadic(fair::mq::Parts& parts, std::ve
     }
   };
   O2DataModelHelpers::for_each_header(parts, timeframeDataExists);
-  return std::all_of(present.begin(), present.end(), [](auto const& p) { return p; });
 }
 
 std::string O2DataModelHelpers::describeMissingOutputs(std::vector<OutputSpec> const& specs, std::vector<bool> const& present)
@@ -60,6 +58,23 @@ std::string O2DataModelHelpers::describeMissingOutputs(std::vector<OutputSpec> c
     }
   }
   error += ". If this is expected, please change its lifetime to Sporadic / QA.";
+  first = true;
+  for (size_t i = 0; i < specs.size(); ++i) {
+    if (present[i] == true) {
+      if (first) {
+        error += " Present outputs are: ";
+        first = false;
+      } else {
+        error += ", ";
+      }
+      error += DataSpecUtils::describe(specs[i]);
+    }
+  }
+  if (first) {
+    error += " No output was present.";
+  } else {
+    error += ".";
+  }
   return error;
 }
 } // namespace o2::framework

--- a/Framework/Core/test/test_O2DataModelHelpers.cxx
+++ b/Framework/Core/test/test_O2DataModelHelpers.cxx
@@ -136,7 +136,8 @@ BOOST_AUTO_TEST_CASE(TestTimeframePresent)
   };
   std::vector<bool> present;
   present.resize(outputs.size());
-  BOOST_CHECK(O2DataModelHelpers::checkForMissingSporadic(inputs, outputs, present));
+  O2DataModelHelpers::updateMissingSporadic(inputs, outputs, present);
+  BOOST_CHECK(O2DataModelHelpers::validateOutputs(present) == true);
 }
 
 BOOST_AUTO_TEST_CASE(TestTimeframeMissing)
@@ -163,9 +164,10 @@ BOOST_AUTO_TEST_CASE(TestTimeframeMissing)
   };
   std::vector<bool> present;
   present.resize(outputs.size());
-  BOOST_CHECK(O2DataModelHelpers::checkForMissingSporadic(inputs, outputs, present) == false);
+  O2DataModelHelpers::updateMissingSporadic(inputs, outputs, present);
+  BOOST_CHECK(O2DataModelHelpers::validateOutputs(present) == false);
   BOOST_CHECK_EQUAL(O2DataModelHelpers::describeMissingOutputs(outputs, present),
-                    "This timeframe has a missing output of lifetime timeframe: ITS/CLUSTERS/0. If this is expected, please change its lifetime to Sporadic / QA.");
+                    "This timeframe has a missing output of lifetime timeframe: ITS/CLUSTERS/0. If this is expected, please change its lifetime to Sporadic / QA. Present outputs are: TPC/CLUSTERS/0.");
 }
 
 BOOST_AUTO_TEST_CASE(TestTimeframeSporadic)
@@ -192,5 +194,6 @@ BOOST_AUTO_TEST_CASE(TestTimeframeSporadic)
   };
   std::vector<bool> present;
   present.resize(outputs.size());
-  BOOST_CHECK(O2DataModelHelpers::checkForMissingSporadic(inputs, outputs, present) == true);
+  O2DataModelHelpers::updateMissingSporadic(inputs, outputs, present);
+  BOOST_CHECK(O2DataModelHelpers::validateOutputs(present) == true);
 }


### PR DESCRIPTION
This will check for missing outputs of lifetime Timeframe and complain if that's actually the case. While this should work as expected and across outputs sent over multiple channels, there might still be some false positives. In particular:

* With a custom completion policy, it might be ok to consume input as they come and produce only the outputs associated to those inputs.
* You could be producing QA data with a timer and timeframe data on real inputs. When creating the QA data, this will complain.