### PR TITLE
TPC: adding number of clusters as type for integration

### DIFF
--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCFactorization.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCFactorization.h
@@ -60,6 +60,9 @@ class IDCFactorization : public IDCGroupHelperSector
   /// destructor
   ~IDCFactorization();
 
+  /// default move constructor
+  IDCFactorization(IDCFactorization&&) = default;
+
   /// returns sides for CRUs
   /// \param crus crus which will be checked for their side
   static std::vector<o2::tpc::Side> getSides(const std::vector<uint32_t>& crus);


### PR DESCRIPTION
- Using the number of clusters instead of the cluster charge, the resulting factorized currents are independent of the gain (possible gain fluctuations)

- setting severity to debug

- adding default move constructor