### PR TITLE
[RFC] TRD: adding PID workflow

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/PID.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/PID.h
@@ -1,0 +1,71 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file  PID.h
+/// @author Felix Schlepper
+
+#ifndef TRD_PID_H
+#define TRD_PID_H
+
+#include <array>
+#include <unordered_map>
+#include <string>
+
+namespace o2
+{
+namespace trd
+{
+
+/// Option for available PID policies.
+enum class PIDPolicy : unsigned int {
+  // Classical Algorithms
+  LQ1D = 0, ///< 1-Dimensional Likelihood model
+  LQ3D,     ///< 3-Dimensional Likelihood model
+
+  // ML models
+  XGB, ///< XGBOOST
+
+  // Do not anything after this!
+  NMODELS,        ///< Count of all models
+  Test,           ///< Load object for testing
+  DEFAULT = Test, ///< The default option
+};
+
+/// Transform PID policy from string to enum.
+static const std::unordered_map<std::string, PIDPolicy> PIDPolicyString{
+  // Classical Algorithms
+  {"LQ1D", PIDPolicy::LQ1D},
+  {"LQ3D", PIDPolicy::LQ3D},
+
+  // ML models
+  {"XGB", PIDPolicy::XGB},
+
+  // General
+  {"TEST", PIDPolicy::Test},
+  // Default
+  {"default", PIDPolicy::DEFAULT},
+};
+
+/// Transform PID policy from string to enum.
+static const char* PIDPolicyEnum[] = {
+  "LQ1D",
+  "LQ3D",
+  "XGBoost",
+  "SIZE",
+  "Test",
+  "default(=TODO)"};
+
+using PIDValue = float;
+
+} // namespace trd
+} // namespace o2
+
+#endif

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -1204,6 +1204,12 @@ uint8_t AODProducerWorkflowDPL::getTRDPattern(const o2::trd::TrackTRD& track)
       pattern |= 0x1 << il;
     }
   }
+  if (track.getHasNeighbor()) {
+    pattern |= 0x1 << 6;
+  }
+  if (track.getHasPadrowCrossing()) {
+    pattern |= 0x1 << 7;
+  }
   return pattern;
 }
 

--- a/Detectors/AOD/src/aod-producer-workflow.cxx
+++ b/Detectors/AOD/src/aod-producer-workflow.cxx
@@ -36,6 +36,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writer"}},
     {"disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation"}},
     {"disable-secondary-vertices", o2::framework::VariantType::Bool, false, {"disable filling secondary vertices"}},
+    {"disable-trd-pid", o2::framework::VariantType::Bool, true, {"disable trd pid"}},
     {"info-sources", VariantType::String, std::string{GID::ALL}, {"comma-separated list of sources to use"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}},
     {"combine-source-devices", o2::framework::VariantType::Bool, false, {"merge DPL source devices"}},
@@ -73,6 +74,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   o2::globaltracking::InputHelper::addInputSpecsPVertex(configcontext, inputspecs, useMC);
   if (enableSV) {
     o2::globaltracking::InputHelper::addInputSpecsSVertex(configcontext, inputspecs);
+  }
+  if (enableTRDPID) {
+    o2::globaltracking::InputHelper::addInputSpecsTRDPID(configcontext, inputspecs, srcMtc, useMC);
   }
   if (configcontext.options().get<bool>("combine-source-devices")) {
     std::vector<DataProcessorSpec> unmerged;

--- a/Detectors/AOD/src/aod-producer-workflow.cxx
+++ b/Detectors/AOD/src/aod-producer-workflow.cxx
@@ -51,6 +51,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
   auto useMC = !configcontext.options().get<bool>("disable-mc");
   bool enableSV = !configcontext.options().get<bool>("disable-secondary-vertices");
+  bool enableTRDPID = !configcontext.options().get<bool>("disable-trd-pid");
   bool ctpcfgperrun = configcontext.options().get<bool>("ctpconfig-per-run");
 
   GID::mask_t allowedSrc = GID::getSourcesMask("ITS,MFT,MCH,MID,MCH-MID,TPC,TRD,ITS-TPC,TPC-TOF,TPC-TRD,ITS-TPC-TOF,ITS-TPC-TRD,TPC-TRD-TOF,ITS-TPC-TRD-TOF,MFT-MCH,FT0,FV0,FDD,ZDC,EMC,CTP,PHS,CPV");

--- a/Detectors/GlobalTrackingWorkflow/helpers/include/GlobalTrackingWorkflowHelpers/InputHelper.h
+++ b/Detectors/GlobalTrackingWorkflow/helpers/include/GlobalTrackingWorkflowHelpers/InputHelper.h
@@ -40,6 +40,7 @@ class InputHelper
   static int addInputSpecsSVertex(const o2::framework::ConfigContext& configcontext, o2::framework::WorkflowSpec& specs);
   static int addInputSpecsCosmics(const o2::framework::ConfigContext& configcontext, o2::framework::WorkflowSpec& specs, bool mc);
   static int addInputSpecsIRFramesITS(const o2::framework::ConfigContext& configcontext, o2::framework::WorkflowSpec& specs);
+  static int addInputSpecsTRDPID(const o2::framework::ConfigContext& configcontext, o2::framework::WorkflowSpec& specs, GID::mask_t maskMatches, bool mc);
 };
 
 } // namespace globaltracking

--- a/Detectors/GlobalTrackingWorkflow/helpers/src/InputHelper.cxx
+++ b/Detectors/GlobalTrackingWorkflow/helpers/src/InputHelper.cxx
@@ -35,6 +35,7 @@
 #include "ZDCWorkflow/RecEventReaderSpec.h"
 #include "TRDWorkflowIO/TRDTrackletReaderSpec.h"
 #include "TRDWorkflowIO/TRDTrackReaderSpec.h"
+#include "TRDWorkflowIO/TRDPIDReaderSpec.h"
 #include "CTPWorkflowIO/DigitReaderSpec.h"
 #include "MCHWorkflow/TrackReaderSpec.h"
 #include "MCHWorkflow/ClusterReaderSpec.h"
@@ -205,5 +206,20 @@ int InputHelper::addInputSpecsIRFramesITS(const o2::framework::ConfigContext& co
     return 0;
   }
   specs.emplace_back(o2::globaltracking::getIRFrameReaderSpec("ITS", 0, "its-irframe-reader", "o2_its_irframe.root"));
+  return 0;
+}
+
+// attach trd pid reader
+int InputHelper::addInputSpecsTRDPID(const o2::framework::ConfigContext& configcontext, o2::framework::WorkflowSpec& specs, GID::mask_t maskMatches, bool mc)
+{
+  if (configcontext.options().get<bool>("disable-root-input")) {
+    return 0;
+  }
+  if (maskMatches[GID::TPCTRD]) {
+    specs.emplace_back(o2::trd::getTRDPIDTPCReaderSpec(mc));
+  }
+  if (maskMatches[GID::ITSTPCTRD]) {
+    specs.emplace_back(o2::trd::getTRDPIDGlobalReaderSpec(mc));
+  }
   return 0;
 }

--- a/Detectors/TRD/pid/CMakeLists.txt
+++ b/Detectors/TRD/pid/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# All rights not expressly granted are reserved.
+#
+# This software is distributed under the terms of the GNU General Public
+# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+o2_add_library(TRDPID
+               SOURCES src/PIDBase.cxx
+               SOURCES src/ML.cxx
+               SOURCES src/PIDParameters.cxx
+               PRIVATE_LINK_LIBRARIES O2::TRDBase
+                                     O2::DataFormatsTRD
+                                     O2::DataFormatsGlobalTracking
+                                     O2::DetectorsBase
+                                     O2::MathUtils
+                                     O2::GPUTracking
+                                     O2::Framework
+                                     O2::ReconstructionDataFormats
+                                     fmt::fmt
+                                     ONNXRuntime::ONNXRuntime)
+
+o2_target_root_dictionary(TRDPID
+                          HEADERS include/TRDPID/PIDBase.h
+                                  include/TRDPID/PIDParameters.h
+                                  include/TRDPID/ML.h)
+
+add_subdirectory(macros)

--- a/Detectors/TRD/pid/include/TRDPID/ML.h
+++ b/Detectors/TRD/pid/include/TRDPID/ML.h
@@ -1,0 +1,97 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file ML.h
+/// \brief This file provides the base for ML policies.
+/// \author Felix Schlepper
+
+#ifndef O2_TRD_ML_H
+#define O2_TRD_ML_H
+
+#include "Rtypes.h"
+#include "TRDPID/PIDBase.h"
+#include "DataFormatsTRD/PID.h"
+#include "Framework/ProcessingContext.h"
+#include "Framework/InputRecord.h"
+#include <onnxruntime/core/session/experimental_onnxruntime_cxx_api.h>
+#include <memory>
+#include <vector>
+#include <array>
+#include <string>
+
+namespace o2
+{
+namespace trd
+{
+
+/// This is the ML Base class which defines the interface all machine learning
+/// models.
+class ML : public PIDBase
+{
+  using PIDBase::PIDBase;
+
+ private:
+  void init(o2::framework::ProcessingContext& pc) final;
+  void run() final;
+
+  /// Return the electron likelihood.
+  /// Different models have different ways to return the probability.
+  virtual PIDValue getELikelihood(const std::vector<Ort::Value>& tensorData) const noexcept = 0;
+
+  /// Fetch a ML model from the ccdb via its binding
+  std::string fetchModelCCDB(o2::framework::ProcessingContext& pc, const char* binding) const;
+
+  /// Calculate pid value
+  template <bool isTPCTRD>
+  PIDValue calculate(const TrackTRD& trkTRD);
+
+  /// Prepare model input
+  /// Collect track properties in vector as flat array
+  template <bool isTPCTRD>
+  std::vector<float> prepareModelInput(const TrackTRD& trkTRD);
+
+  /// Pretty print model shape
+  std::string printShape(const std::vector<int64_t>& v) const noexcept;
+
+  //  Internal Variables
+  bool mInitDone{false}; ///< Has initialization been finalized
+
+  // ONNX runtime
+  Ort::Env mEnv{ORT_LOGGING_LEVEL_WARNING, "TRD-PID",
+                // integrate ORT logging into Fairlogger
+                [](void* param, OrtLoggingLevel severity, const char* category, const char* logid, const char* code_location, const char* message) {
+                  LOG(warn) << "Ort " << severity << ": [" << logid << "|" << category << "|" << code_location << "]: " << message << ((intptr_t)param == 3 ? " [valid]" : " [error]");
+                },
+                (void*)3};                              ///< ONNX enviroment
+  const OrtApi& mApi{Ort::GetApi()};                    ///< ONNX api
+  std::unique_ptr<Ort::Experimental::Session> mSession; ///< ONNX session
+  Ort::SessionOptions mSessionOptions;                  ///< ONNX session options
+
+  // Input/Output
+  std::vector<std::string> mInputNames;            ///< model input names
+  std::vector<std::vector<int64_t>> mInputShapes;  ///< input shape
+  std::vector<std::string> mOutputNames;           ///< model output names
+  std::vector<std::vector<int64_t>> mOutputShapes; ///< output shape
+
+  ClassDefNV(ML, 1);
+};
+
+/// XGBoost Model
+class XGB : public ML
+{
+  using ML::ML;
+  PIDValue getELikelihood(const std::vector<Ort::Value>& tensorData) const noexcept;
+};
+
+} // namespace trd
+} // namespace o2
+
+#endif

--- a/Detectors/TRD/pid/include/TRDPID/PIDBase.h
+++ b/Detectors/TRD/pid/include/TRDPID/PIDBase.h
@@ -1,0 +1,93 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file PIDBase.h
+/// \brief This file provides the base interface for pid policies.
+/// \author Felix Schlepper
+
+#ifndef O2_TRD_PIDBASE_H
+#define O2_TRD_PIDBASE_H
+
+#include "Rtypes.h"
+#include "DataFormatsTRD/PID.h"
+#include "DataFormatsGlobalTracking/RecoContainer.h"
+#include "DataFormatsTRD/TrackTRD.h"
+#include "DataFormatsTRD/Tracklet64.h"
+#include "Framework/ProcessingContext.h"
+#include "TRDPID/PIDParameters.h"
+
+#include <gsl/span>
+#include <memory>
+
+namespace o2
+{
+namespace trd
+{
+
+/// This is the PID Base class which defines the interface all other models
+/// must provide.
+///
+/// In the most basic sense all that is needed to get a reference to the
+/// (ITS-)TPC-TRD tracks and output a corresponding vector containing the
+/// electron likelihood (float; < 0.f meaning that no PID is available). This
+/// can than be subscribed by the aod-producer.
+class PIDBase
+{
+ public:
+  PIDBase(PIDPolicy policy) : mPolicy(policy) {}
+
+  /// Calculate pid values.
+  void process(o2::framework::ProcessingContext& pc)
+  {
+    init(pc);
+    run();
+  }
+
+  /// Set the reference to the tracks and tracklets.
+  void setInput(const o2::globaltracking::RecoContainer& input);
+
+  /// Return PID value for ITS-TPC-TRD tracks
+  auto getPIDITSTPC() const noexcept { return mPIDITSTPC; }
+
+  /// Return PID value for TPC-TRD tracks
+  auto getPIDTPC() const noexcept { return mPIDTPC; }
+
+ protected:
+  const TRDPIDParams& mParams{TRDPIDParams::Instance()}; ///< parameters
+  PIDPolicy mPolicy;                                     ///< policy
+
+  // Output
+  std::vector<PIDValue> mPIDITSTPC; ///< PID for ITS-TPC-TRD tracks
+  std::vector<PIDValue> mPIDTPC;    ///< PID for TPC-TRD tracks
+
+  // Input
+  gsl::span<const TrackTRD> mTracksInITSTPCTRD; ///< TRD tracks reconstructed from TPC or ITS-TPC seeds
+  gsl::span<const TrackTRD> mTracksInTPCTRD;    ///< TRD tracks reconstructed from TPC or TPC seeds
+  gsl::span<const Tracklet64> mTrackletsRaw;    ///< array of raw tracklets for TRD PID
+
+ private:
+  /// Initialize the policy.
+  virtual void init(o2::framework::ProcessingContext& pc) = 0;
+
+  /// Calculate for each Track the electron likelihood and place the
+  /// results in the output vectors.
+  virtual void run() = 0;
+
+  ClassDefNV(PIDBase, 1);
+};
+
+/// Factory function to create a PID policy.
+std::unique_ptr<PIDBase> getTRDPIDBase(PIDPolicy policy);
+
+} // namespace trd
+} // namespace o2
+
+#endif

--- a/Detectors/TRD/pid/include/TRDPID/PIDParameters.h
+++ b/Detectors/TRD/pid/include/TRDPID/PIDParameters.h
@@ -1,0 +1,38 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+// \brief Collect all possible configurable parameters for the PID task
+
+#ifndef O2_TRD_PID_PARAMS_H
+#define O2_TRD_PID_PARAMS_H
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "CommonUtils/ConfigurableParamHelper.h"
+
+namespace o2
+{
+namespace trd
+{
+
+/// PID parameters.
+struct TRDPIDParams : public o2::conf::ConfigurableParamHelper<TRDPIDParams> {
+  unsigned int numOrtThreads = 1;           ///< ONNX Session threads
+  unsigned int graphOptimizationLevel = 99; ///< ONNX GraphOptimization Level
+                                            /// 0=Disable All, 1=Enable Basic, 2=Enable Extended, 99=Enable ALL
+
+  // boilerplate
+  O2ParamDef(TRDPIDParams, "TRDPIDParams");
+};
+
+} // namespace trd
+} // namespace o2
+
+#endif

--- a/Detectors/TRD/pid/macros/CMakeLists.txt
+++ b/Detectors/TRD/pid/macros/CMakeLists.txt
@@ -9,11 +9,6 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-add_subdirectory(base)
-add_subdirectory(calibration)
-add_subdirectory(simulation)
-add_subdirectory(pid)
-add_subdirectory(reconstruction)
-add_subdirectory(macros)
-add_subdirectory(qc)
-add_subdirectory(workflow)
+o2_add_test_root_macro(ccdbModelUpload.C
+                       PUBLIC_LINK_LIBRARIES O2::TRDPID
+                       LABELS trd)

--- a/Detectors/TRD/pid/macros/ccdbModelUpload.C
+++ b/Detectors/TRD/pid/macros/ccdbModelUpload.C
@@ -1,0 +1,81 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+// ROOT header
+#include <TFile.h>
+// O2 header
+#include "CCDB/CcdbApi.h"
+#include "CCDB/BasicCCDBManager.h"
+#include "CCDB/CcdbObjectInfo.h"
+
+#include <map>
+#include <string>
+#include <vector>
+#include <chrono>
+#include <fstream>
+#include <ios>
+#include <iostream>
+
+#endif
+
+/// Upload an ONNX model to the ccdb.
+/// This reads the file as a binary file and stores it as such.
+void ccdbModelUpload(std::string inFileName, std::string ccdbPath = "TRD_test/PID/xgb")
+{
+
+  o2::ccdb::CcdbApi ccdb;
+  // ccdb.init("http://alice-ccdb.cern.ch");
+  // ccdb.init("http://localhost:8080");
+  ccdb.init("http://ccdb-test.cern.ch:8080");
+  // ccdb.init("http://o2-ccdb.internal");
+  std::map<std::string, std::string> metadata;
+  metadata["UploadedBy"] = "felix";
+  metadata["Description"] = "onnx model for trd pid";
+  metadata["default"] = "true"; // tag default objects
+  metadata["Created"] = "1";    // tag default objects
+
+  std::vector<unsigned char> input;
+  std::ifstream inFile(inFileName, std::ios::binary);
+  if (!inFile.is_open()) {
+    std::cout << "Could not load file!" << std::endl;
+    return;
+  }
+  inFile.seekg(0, std::ios_base::end);
+  auto length = inFile.tellg();
+  inFile.seekg(0, std::ios_base::beg);
+  input.resize(static_cast<size_t>(length));
+  inFile.read(reinterpret_cast<char*>(input.data()), length);
+  auto success = !inFile.fail() && length == inFile.gcount();
+  if (!success) {
+    std::cout << "File loading went wrong!" << std::endl;
+    return;
+  }
+  inFile.close();
+
+  // for default objects:
+  // long timeStampStart = 0;
+  uint64_t timeStampStart = 1577833200000UL; // 1.1.2020
+  uint64_t timeStampEnd = 2208985200000UL;   // 1.1.2040
+
+  auto res = ccdb.storeAsBinaryFile(reinterpret_cast<char*>(input.data()), length, inFileName, "ONNX Model", ccdbPath, metadata, timeStampStart, timeStampEnd);
+
+  if (res == 0) {
+    std::cout << "OK" << std::endl;
+  } else if (res == -1) {
+    std::cout << "ERROR: object bigger than maxSize" << std::endl;
+  } else if (res == -2) {
+    std::cout << "ERROR: curl initialization error" << std::endl;
+  } else {
+    std::cout << "ERROR: see curl error codes: " << res << std::endl;
+  }
+  return;
+}

--- a/Detectors/TRD/pid/src/ML.cxx
+++ b/Detectors/TRD/pid/src/ML.cxx
@@ -1,0 +1,202 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file ML.cxx
+/// \author Felix Schlepper
+
+#include "TRDPID/ML.h"
+#include "DataFormatsTRD/Constants.h"
+#include "ReconstructionDataFormats/TrackTPCITS.h"
+#include "ReconstructionDataFormats/GlobalTrackID.h"
+#include "ReconstructionDataFormats/TrackParametrizationWithError.h"
+#include "DataFormatsTPC/TrackTPC.h"
+#include "Framework/ProcessingContext.h"
+#include "Framework/InputRecord.h"
+#include "Framework/Logger.h"
+
+#include <fmt/format.h>
+#include <onnxruntime/core/session/experimental_onnxruntime_cxx_api.h>
+#include <boost/range.hpp>
+
+#include <array>
+#include <algorithm>
+#include <stdexcept>
+#include <sstream>
+#include <string>
+
+using namespace o2::trd::constants;
+
+namespace o2
+{
+namespace trd
+{
+
+void ML::init(o2::framework::ProcessingContext& pc)
+{
+  // do only once
+  if (mInitDone) {
+    return;
+  }
+  mInitDone = true;
+  LOG(info) << "Finializing model initialization";
+
+  // fetch the onnx model from the ccdb
+  std::string model_data;
+  switch (mPolicy) {
+    case PIDPolicy::Test:
+      model_data = fetchModelCCDB(pc, "mlTest");
+      break;
+    default:
+      throw std::runtime_error("Could not load ML model from ccdb!");
+  }
+
+  // disable telemtry events
+  mEnv.DisableTelemetryEvents();
+  LOG(info) << "Disabled Telemetry Events";
+
+  // create session options
+  mSessionOptions.SetIntraOpNumThreads(mParams.numOrtThreads);
+  LOG(info) << "Set number of threads to " << mParams.numOrtThreads;
+
+  // Sets graph optimization level
+  mSessionOptions.SetGraphOptimizationLevel(static_cast<GraphOptimizationLevel>(mParams.graphOptimizationLevel));
+  LOG(info) << "Set GraphOptimizationLevel to " << mParams.graphOptimizationLevel;
+
+  // create actual session
+  mSession = std::make_unique<Ort::Experimental::Session>(mEnv, reinterpret_cast<void*>(model_data.data()), model_data.size(), mSessionOptions);
+  LOG(info) << "ONNX runtime session created";
+
+  // print name/shape of inputs
+  mInputNames = mSession->GetInputNames();
+  mInputShapes = mSession->GetInputShapes();
+  LOG(info) << "Input Node Name/Shape (" << mInputNames.size() << "):";
+  for (size_t i = 0; i < mInputNames.size(); i++) {
+    LOG(info) << "\t" << mInputNames[i] << " : " << printShape(mInputShapes[i]);
+  }
+
+  // print name/shape of outputs
+  mOutputNames = mSession->GetOutputNames();
+  mOutputShapes = mSession->GetOutputShapes();
+  LOG(info) << "Output Node Name/Shape (" << mOutputNames.size() << "):";
+  for (size_t i = 0; i < mOutputNames.size(); i++) {
+    LOG(info) << "\t" << mOutputNames[i] << " : " << printShape(mOutputShapes[i]);
+  }
+
+  LOG(info) << "Finalization done";
+}
+
+void ML::run()
+{
+  std::transform(mTracksInTPCTRD.begin(), mTracksInTPCTRD.end(), std::back_inserter(mPIDTPC), [&](const TrackTRD& track) { return calculate<true>(track); });
+
+  std::transform(mTracksInITSTPCTRD.begin(), mTracksInITSTPCTRD.end(), std::back_inserter(mPIDITSTPC), [&](const TrackTRD& track) { return calculate<false>(track); });
+}
+
+std::string ML::fetchModelCCDB(o2::framework::ProcessingContext& pc, const char* binding) const
+{
+  auto policyInt = static_cast<unsigned int>(mPolicy);
+  // sanity checks
+  auto ref = pc.inputs().get(binding);
+  if (!ref.spec || !ref.payload) {
+    throw std::runtime_error(fmt::format("A ML model({}) with '{}' as binding does not exist!", PIDPolicyEnum[policyInt], binding));
+  }
+
+  // the model is in binary string format
+  auto model_data = pc.inputs().get<std::string>(binding);
+  if (model_data.empty()) {
+    throw std::runtime_error(fmt::format("Did not get any data for {} model({}) from ccdb!", binding, PIDPolicyEnum[policyInt]));
+  }
+  return model_data;
+}
+
+template <bool isTPCTRD>
+PIDValue ML::calculate(const TrackTRD& trkTRD)
+{
+  try {
+    auto input = prepareModelInput<isTPCTRD>(trkTRD);
+    // create memory mapping to vector above
+    auto inputTensor = Ort::Experimental::Value::CreateTensor<float>(input.data(), input.size(),
+                                                                     {static_cast<int64_t>(input.size()) / mInputShapes[0][1], mInputShapes[0][1]});
+    std::vector<Ort::Value> ortTensor;
+    ortTensor.push_back(std::move(inputTensor));
+    auto outTensor = mSession->Run(mInputNames, ortTensor, mOutputNames);
+    // every model defines its own output
+    return getELikelihood(outTensor);
+  } catch (const Ort::Exception& e) {
+    LOG(error) << "Error running model inference, using defaults: " << e.what();
+    // fill with negative elikelihood means no information
+    return -1.f;
+  }
+}
+
+template <bool isTPCTRD>
+std::vector<float> ML::prepareModelInput(const TrackTRD& trkTRD)
+{
+  // input is [slope0, slope1, ..., slope5, charge0.0, charge0.1, charge0.2, charge1.0, ..., charge5.3, p]
+  std::vector<float> in(mInputShapes[0][1]);
+  // std::fill(in.begin(), in.end(), 1.f);
+  auto id = trkTRD.getRefGlobalTrackId();
+  in[24] = trkTRD.getP();
+  // const auto& trkSeed = [&]() {
+  //   if constexpr (isTPCTRD) {
+  //     return mTracksInTPCTRD[id].getParamOut();
+  //   } else {
+  //     return mTracksInITSTPCTRD[id].getParamOut();
+  //   }
+  // };
+
+  for (int iLayer = 0; iLayer < NLAYER; ++iLayer) {
+    int trkltId = trkTRD.getTrackletIndex(iLayer);
+    if (trkltId < 0) {
+      /// easy fill with default values e.g. charge=-1., slope=0.
+      in[iLayer] = 0.f;
+      in[NLAYER + iLayer * 3 + 0] = -1.f;
+      in[NLAYER + iLayer * 3 + 1] = -1.f;
+      in[NLAYER + iLayer * 3 + 2] = -1.f;
+      continue;
+    }
+
+    auto trklt = mTrackletsRaw[trkltId];
+    auto slope = mTrackletsRaw[trkltId].getSlopeBinSigned();
+    auto q0 = mTrackletsRaw[trkltId].getQ0();
+    auto q1 = mTrackletsRaw[trkltId].getQ1();
+    auto q2 = mTrackletsRaw[trkltId].getQ2();
+
+    // TODO handel padrow crossing e.g. z-row merging
+
+    in[iLayer] = slope;
+    in[NLAYER + iLayer * 3 + 0] = q0;
+    in[NLAYER + iLayer * 3 + 1] = q1;
+    in[NLAYER + iLayer * 3 + 2] = q2;
+  }
+
+  return in;
+}
+
+// pretty prints a shape dimension vector
+std::string ML::printShape(const std::vector<int64_t>& v) const noexcept
+{
+  std::stringstream ss("");
+  for (size_t i = 0; i < v.size() - 1; i++)
+    ss << v[i] << "x";
+  ss << v[v.size() - 1];
+  return ss.str();
+}
+
+/// XGBoost export is like this:
+/// (label|eprob, 1-eprob).
+PIDValue XGB::getELikelihood(const std::vector<Ort::Value>& tensorData) const noexcept
+{
+  return tensorData[1].GetTensorData<PIDValue>()[1];
+}
+
+} // namespace trd
+} // namespace o2

--- a/Detectors/TRD/pid/src/PIDBase.cxx
+++ b/Detectors/TRD/pid/src/PIDBase.cxx
@@ -1,0 +1,56 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file PIDBase.cxx
+/// \author Felix Schlepper
+
+#include "TRDPID/PIDBase.h"
+#include "DataFormatsTRD/PID.h"
+#include "TRDPID/ML.h"
+#include "Framework/Logger.h"
+#include "fmt/format.h"
+
+namespace o2
+{
+namespace trd
+{
+
+void PIDBase::setInput(const o2::globaltracking::RecoContainer& input)
+{
+  // Get new inputs
+  mTracksInITSTPCTRD = input.getITSTPCTRDTracks<TrackTRD>();
+  mTracksInTPCTRD = input.getTPCTRDTracks<TrackTRD>();
+  mTrackletsRaw = input.getTRDTracklets();
+
+  // Reset old values
+  mPIDITSTPC.clear();
+  mPIDTPC.clear();
+
+  // Reserve space for pid values
+  mPIDITSTPC.reserve(mTracksInITSTPCTRD.size());
+  mPIDTPC.reserve(mTracksInTPCTRD.size());
+}
+
+std::unique_ptr<PIDBase> getTRDPIDBase(PIDPolicy policy)
+{
+  auto policyInt = static_cast<unsigned int>(policy);
+  LOG(info) << "Creating PID policy. Loading model " << PIDPolicyEnum[policyInt];
+  switch (policy) {
+    case PIDPolicy::Test:
+      return std::make_unique<XGB>(PIDPolicy::Test);
+    default:
+      throw std::invalid_argument(fmt::format("Cannot create this PID policy {}({})", PIDPolicyEnum[policyInt], policyInt));
+  }
+  return nullptr; // cannot be reached
+}
+
+} // namespace trd
+} // namespace o2

--- a/Detectors/TRD/pid/src/PIDParameters.cxx
+++ b/Detectors/TRD/pid/src/PIDParameters.cxx
@@ -1,0 +1,13 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "TRDPID/PIDParameters.h"
+O2ParamImpl(o2::trd::TRDPIDParams);

--- a/Detectors/TRD/pid/src/TRDPIDLinkDef.h
+++ b/Detectors/TRD/pid/src/TRDPIDLinkDef.h
@@ -1,0 +1,22 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifdef __CLING__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class o2::trd::PIDBase + ;
+#pragma link C++ class o2::trd::TRDPIDParams + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::trd::TRDPIDParams> + ;
+
+#endif

--- a/Detectors/TRD/workflow/CMakeLists.txt
+++ b/Detectors/TRD/workflow/CMakeLists.txt
@@ -16,6 +16,7 @@ o2_add_library(TRDWorkflow
                SOURCES src/TRDDigitizerSpec.cxx
                        src/TRDTrapSimulatorSpec.cxx
                        src/TRDTrackletTransformerSpec.cxx
+                       src/TRDPIDSpec.cxx
                        src/TRDEventDisplayFeedSpec.cxx
                        src/TRDGlobalTrackingSpec.cxx
                        src/EntropyDecoderSpec.cxx
@@ -26,7 +27,7 @@ o2_add_library(TRDWorkflow
                        include/TRDWorkflow/TRDGlobalTrackingQCSpec.h
                        include/TRDWorkflow/NoiseCalibSpec.h
                        include/TRDWorkflow/NoiseCalibAggregatorSpec.h
-               PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::Steer O2::Algorithm O2::DataFormatsTRD O2::TRDSimulation O2::TRDReconstruction O2::TRDQC O2::DetectorsBase O2::SimulationDataFormat O2::TRDBase O2::TRDCalibration O2::GPUTracking O2::GlobalTrackingWorkflowHelpers O2::GlobalTrackingWorkflowReaders O2::GPUWorkflowHelper O2::ReconstructionDataFormats O2::ITSWorkflow O2::TPCWorkflow O2::TRDWorkflowIO)
+               PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::Steer O2::Algorithm O2::DataFormatsTRD O2::TRDSimulation O2::TRDReconstruction O2::TRDQC O2::DetectorsBase O2::SimulationDataFormat O2::TRDBase O2::TRDCalibration O2::GPUTracking O2::GlobalTrackingWorkflowHelpers O2::GlobalTrackingWorkflowReaders O2::GPUWorkflowHelper O2::ReconstructionDataFormats O2::ITSWorkflow O2::TPCWorkflow O2::TRDWorkflowIO O2::TRDPID)
 
 o2_add_executable(trap-sim
                   COMPONENT_NAME trd
@@ -46,6 +47,11 @@ o2_add_executable(global-tracking
 o2_add_executable(tracklet-transformer
                   COMPONENT_NAME trd
                   SOURCES src/TRDTrackletTransformerWorkflow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::TRDWorkflow)
+
+o2_add_executable(pid-workflow
+                  COMPONENT_NAME trd
+                  SOURCES src/trd-pid-workflow.cxx
                   PUBLIC_LINK_LIBRARIES O2::TRDWorkflow)
 
 o2_add_executable(event-display-feed

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDPIDSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDPIDSpec.h
@@ -1,0 +1,60 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TRDPIDSpec.h
+/// \brief This file provides the specification for the trd pid workflow.
+/// \author Felix Schlepper
+
+#ifndef O2_TRD_PIDSPEC_H
+#define O2_TRD_PIDSPEC_H
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+#include "DetectorsBase/GRPGeomHelper.h"
+#include "DataFormatsGlobalTracking/RecoContainer.h"
+#include "DataFormatsTRD/PID.h"
+#include "ReconstructionDataFormats/GlobalTrackID.h"
+#include "TRDPID/PIDBase.h"
+#include "TStopwatch.h"
+
+#include <memory>
+
+namespace o2
+{
+namespace trd
+{
+
+class TRDPIDSpec : public o2::framework::Task
+{
+ public:
+  TRDPIDSpec(bool useMC, o2::dataformats::GlobalTrackID::mask_t src, std::shared_ptr<o2::globaltracking::DataRequest> dataRequest, std::shared_ptr<o2::base::GRPGeomRequest> gr, enum PIDPolicy policy) : mUseMC(useMC), mTrkMask(src), mDataRequest(dataRequest), mGGCCDBRequest(gr), mPolicy(policy){};
+  ~TRDPIDSpec() override = default;
+  void init(o2::framework::InitContext& ic) final;
+  void run(o2::framework::ProcessingContext& pc) final;
+  void endOfStream(framework::EndOfStreamContext& ec) final;
+
+ private:
+  bool mUseMC{false};                                            ///< Use MC
+  o2::dataformats::GlobalTrackID::mask_t mTrkMask;               ///< track sources (TPC-TRD, ITS-TPC-TRD)
+  std::shared_ptr<o2::globaltracking::DataRequest> mDataRequest; ///< Data Request
+  std::shared_ptr<o2::base::GRPGeomRequest> mGGCCDBRequest;      ///< Geometry Requests
+  bool mInitDone{false};                                         ///< Initialization should only run once
+  PIDPolicy mPolicy;                                             ///< Model to load an evaluate
+  std::unique_ptr<PIDBase> mBase;                                ///< PID interface
+  TStopwatch mTimer;                                             ///< Timer for performance measurement
+};
+
+o2::framework::DataProcessorSpec getTRDPIDSpec(bool useMC, PIDPolicy policy, o2::dataformats::GlobalTrackID::mask_t src);
+
+} // end namespace trd
+} // end namespace o2
+
+#endif

--- a/Detectors/TRD/workflow/io/CMakeLists.txt
+++ b/Detectors/TRD/workflow/io/CMakeLists.txt
@@ -19,6 +19,8 @@ o2_add_library(TRDWorkflowIO
                        src/TRDCalibratedTrackletWriterSpec.cxx
                        src/TRDTrackWriterSpec.cxx
                        src/TRDTrackReaderSpec.cxx
+                       src/TRDPIDWriterSpec.cxx
+                       src/TRDPIDReaderSpec.cxx
                        src/TRDCalibWriterSpec.cxx
                        src/KrClusterWriterSpec.cxx
                PUBLIC_LINK_LIBRARIES O2::DataFormatsTRD O2::SimulationDataFormat O2::DPLUtils O2::GPUDataTypeHeaders O2::DataFormatsTPC)

--- a/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDPIDReaderSpec.h
+++ b/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDPIDReaderSpec.h
@@ -1,0 +1,73 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TRD_PID_READER_H
+#define O2_TRD_PID_READER_H
+
+/// @file   TRDPIDReaderSpec.h
+
+#include "DataFormatsTRD/PID.h"
+#include "DataFormatsTRD/TrackTriggerRecord.h"
+#include "SimulationDataFormat/MCCompLabel.h"
+
+#include "Framework/DataProcessorSpec.h"
+#include "Framework/Task.h"
+
+#include "TFile.h"
+#include "TTree.h"
+
+#include <vector>
+#include <string>
+#include <memory>
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace trd
+{
+
+class TRDPIDReader : public Task
+{
+ public:
+  enum class Mode : unsigned {
+    ITSTPCTRD,
+    TPCTRD
+  };
+
+  TRDPIDReader(bool useMC, Mode mode) : mUseMC(useMC), mMode(mode){}
+  ~TRDPIDReader() override = default;
+  void init(InitContext& ic) final;
+  void run(ProcessingContext& pc) final;
+
+ private:
+  void connectTree(const std::string& filename);
+  bool mUseMC{false};
+  Mode mMode;
+  std::unique_ptr<TFile> mFile;
+  std::unique_ptr<TTree> mTree;
+  std::string mFileName = "";
+  std::vector<o2::trd::PIDValue> mPID, *mPIDPtr = &mPID;
+  std::vector<o2::trd::TrackTriggerRecord> mTrigRec, *mTrigRecPtr = &mTrigRec;
+  std::vector<o2::MCCompLabel> mLabelsMatch, *mLabelsMatchPtr = &mLabelsMatch;
+  std::vector<o2::MCCompLabel> mLabelsTrd, *mLabelsTrdPtr = &mLabelsTrd;
+};
+
+/// read TPC-TRD matched tracks from a root file
+framework::DataProcessorSpec getTRDPIDTPCReaderSpec(bool useMC);
+
+/// read ITS-TPC-TRD matched tracks from a root file
+framework::DataProcessorSpec getTRDPIDGlobalReaderSpec(bool useMC);
+
+} // namespace trd
+} // namespace o2
+
+#endif

--- a/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDPIDWriterSpec.h
+++ b/Detectors/TRD/workflow/io/include/TRDWorkflowIO/TRDPIDWriterSpec.h
@@ -1,0 +1,34 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TRD_PID_WRITER_H
+#define O2_TRD_PID_WRITER_H
+
+/// @file   TRDPIDWriterSpec.h
+/// @author Felix Schlepper
+
+#include "Framework/DataProcessorSpec.h"
+
+namespace o2
+{
+namespace trd
+{
+
+/// writer for pid to ITS-TPC-TRD tracks
+o2::framework::DataProcessorSpec getTRDPIDGlobalWriterSpec(bool useMC);
+
+/// writer for pid with TPC-TRD tracks
+o2::framework::DataProcessorSpec getTRDPIDTPCWriterSpec(bool useMC);
+
+} // namespace trd
+} // namespace o2
+
+#endif

--- a/Detectors/TRD/workflow/io/src/TRDPIDReaderSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDPIDReaderSpec.cxx
@@ -1,0 +1,134 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file  TRDPIDReaderSpec.cxx
+
+#include "TRDWorkflowIO/TRDPIDReaderSpec.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "Framework/SerializationMethods.h"
+#include "CommonUtils/StringUtils.h"
+#include "ReconstructionDataFormats/MatchingType.h"
+#include "ReconstructionDataFormats/GlobalTrackID.h"
+
+using GTrackID = o2::dataformats::GlobalTrackID;
+
+namespace o2
+{
+namespace trd
+{
+
+void TRDPIDReader::init(InitContext& ic)
+{
+
+  mFileName = o2::utils::Str::concat_string(o2::utils::Str::rectifyDirectory(ic.options().get<std::string>("input-dir")),
+                                            ic.options().get<std::string>("pid-infile"));
+
+  connectTree(mFileName);
+}
+
+void TRDPIDReader::run(ProcessingContext& pc)
+{
+  auto ent = mTree->GetReadEntry() + 1;
+  assert(ent < mTree->GetEntries()); // this should not happen
+  mTree->GetEntry(ent);
+  LOG(info) << "Pushing " << mPID.size() << " PIDs and " << mTrigRec.size() << " trigger records at entry " << ent;
+  if (mUseMC) {
+    if (mLabelsTrd.size() != mLabelsMatch.size()) {
+      LOG(error) << "The number of labels for matches and for TRD tracks is different. " << mLabelsTrd.size() << " TRD labels vs. " << mLabelsMatch.size() << " match labels";
+    }
+    LOG(info) << "Pushing " << mLabelsTrd.size() << " MC labels at entry " << ent;
+  }
+
+  switch (mMode) {
+    case Mode::TPCTRD:
+      pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRDPID_TPC", 0, Lifetime::Timeframe}, mPID);
+      pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRGREC_TPC", 0, Lifetime::Timeframe}, mTrigRec);
+      if (mUseMC) {
+        pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MCLB_TPC", 0, Lifetime::Timeframe}, mLabelsMatch);
+        pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MCLB_TPC_TRD", 0, Lifetime::Timeframe}, mLabelsTrd);
+      }
+      break;
+
+    case Mode::ITSTPCTRD:
+      pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRDPID_ITSTPC", 0, Lifetime::Timeframe}, mPID);
+      pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRGREC_ITSTPC", 0, Lifetime::Timeframe}, mTrigRec);
+      if (mUseMC) {
+        pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MCLB_ITSTPC", 0, Lifetime::Timeframe}, mLabelsMatch);
+        pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MCLB_ITSTPC_TRD", 0, Lifetime::Timeframe}, mLabelsTrd);
+      }
+  }
+
+  if (mTree->GetReadEntry() + 1 >= mTree->GetEntries()) {
+    pc.services().get<ControlService>().endOfStream();
+    pc.services().get<ControlService>().readyToQuit(QuitRequest::Me);
+  }
+}
+
+void TRDPIDReader::connectTree(const std::string& filename)
+{
+  mTree.reset(nullptr); // in case it was already loaded
+  mFile.reset(TFile::Open(filename.c_str()));
+  assert(mFile && !mFile->IsZombie());
+  mTree.reset((TTree*)mFile->Get("pidTRD"));
+  assert(mTree);
+  mTree->SetBranchAddress("pid", &mPIDPtr);
+  mTree->SetBranchAddress("trgrec", &mTrigRecPtr);
+  if (mUseMC) {
+    mTree->SetBranchAddress("labels", &mLabelsMatchPtr);
+    mTree->SetBranchAddress("labelsTRD", &mLabelsTrdPtr);
+  }
+  LOG(info) << "Loaded tree from " << filename << " with " << mTree->GetEntries() << " entries";
+}
+
+DataProcessorSpec getTRDPIDTPCReaderSpec(bool useMC)
+{
+  std::vector<OutputSpec> outputs;
+  outputs.emplace_back(o2::header::gDataOriginTRD, "TRDPID_TPC", 0, Lifetime::Timeframe);
+  outputs.emplace_back(o2::header::gDataOriginTRD, "TRGREC_TPC", 0, Lifetime::Timeframe);
+
+  if (useMC) {
+    outputs.emplace_back(o2::header::gDataOriginTRD, "MCLB_TPC", 0, Lifetime::Timeframe);
+    outputs.emplace_back(o2::header::gDataOriginTRD, "MCLB_TPC_TRD", 0, Lifetime::Timeframe);
+  }
+  return DataProcessorSpec{
+    "trdpid-tpc-reader",
+    Inputs{},
+    outputs,
+    AlgorithmSpec{adaptFromTask<TRDPIDReader>(useMC, TRDPIDReader::Mode::TPCTRD)},
+    Options{
+      {"pid-infile", VariantType::String, "trdpid_tpc.root", {"Name of the input file for TPC-TRD pid"}},
+      {"input-dir", VariantType::String, "none", {"Input directory"}}}};
+}
+
+DataProcessorSpec getTRDPIDGlobalReaderSpec(bool useMC)
+{
+  std::vector<OutputSpec> outputs;
+  outputs.emplace_back(o2::header::gDataOriginTRD, "TRDPID_ITSTPC", 0, Lifetime::Timeframe);
+  outputs.emplace_back(o2::header::gDataOriginTRD, "TRGREC_ITSTPC", 0, Lifetime::Timeframe);
+
+  if (useMC) {
+    outputs.emplace_back(o2::header::gDataOriginTRD, "MCLB_ITSTPC", 0, Lifetime::Timeframe);
+    outputs.emplace_back(o2::header::gDataOriginTRD, "MCLB_ITSTPC_TRD", 0, Lifetime::Timeframe);
+  }
+
+  return DataProcessorSpec{
+    "trdpid-itstpc-reader",
+    Inputs{},
+    outputs,
+    AlgorithmSpec{adaptFromTask<TRDPIDReader>(useMC, TRDPIDReader::Mode::ITSTPCTRD)},
+    Options{
+      {"pid-infile", VariantType::String, "trdpid_itstpc.root", {"Name of the input file for ITS-TPC-TRD pid"}},
+      {"input-dir", VariantType::String, "none", {"Input directory"}}}};
+}
+
+} // namespace trd
+} // namespace o2

--- a/Detectors/TRD/workflow/io/src/TRDPIDWriterSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDPIDWriterSpec.cxx
@@ -1,0 +1,96 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file  TRDPIDWriterSpec.cxx
+/// @author Felix Schlepper
+
+#include <vector>
+#include "DPLUtils/MakeRootTreeWriterSpec.h"
+#include "SimulationDataFormat/MCCompLabel.h"
+#include "DataFormatsTRD/TrackTriggerRecord.h"
+#include "DataFormatsTRD/PID.h"
+#include "TRDWorkflowIO/TRDPIDWriterSpec.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace trd
+{
+
+using LabelsType = std::vector<o2::MCCompLabel>;
+
+template <typename T>
+using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
+
+DataProcessorSpec getTRDPIDGlobalWriterSpec(bool useMC)
+{
+  // A spectator to store the size of the data array for the logger below
+  auto pidSize = std::make_shared<size_t>();
+  auto pidLogger = [pidSize](std::vector<o2::trd::PIDValue> const& def) {
+    *pidSize = def.size();
+  };
+
+  return MakeRootTreeWriterSpec("trd-pid-writer-itstpc",
+                                "trdpid_itstpc.root",
+                                "pidTRD",
+                                BranchDefinition<std::vector<o2::trd::PIDValue>>{InputSpec{"pid", o2::header::gDataOriginTRD, "TRDPID_ITSTPC", 0},
+                                                                                 "pid",
+                                                                                 "pid-branch-name",
+                                                                                 1,
+                                                                                 pidLogger},
+                                BranchDefinition<std::vector<o2::trd::TrackTriggerRecord>>{InputSpec{"trackTrig", o2::header::gDataOriginTRD, "TRGREC_ITSTPC", 0},
+                                                                                           "trgrec",
+                                                                                           "trgrec-branch-name",
+                                                                                           1},
+                                BranchDefinition<LabelsType>{InputSpec{"trdlabels", o2::header::gDataOriginTRD, "MCLB_ITSTPC_TRD", 0},
+                                                             "labelsTRD",
+                                                             (useMC ? 1 : 0), // one branch if mc labels enabled
+                                                             "trdlabels-branch-name"},
+                                BranchDefinition<LabelsType>{InputSpec{"matchitstpclabels", o2::header::gDataOriginTRD, "MCLB_ITSTPC", 0},
+                                                             "labels",
+                                                             (useMC ? 1 : 0), // one branch if mc labels enabled
+                                                             "labels-branch-name"})();
+}
+
+DataProcessorSpec
+  getTRDPIDTPCWriterSpec(bool useMC)
+{
+  // A spectator to store the size of the data array for the logger below
+  auto pidSize = std::make_shared<size_t>();
+  auto pidLogger = [pidSize](std::vector<o2::trd::PIDValue> const& def) {
+    *pidSize = def.size();
+  };
+
+  return MakeRootTreeWriterSpec("trd-pid-writer-tpc",
+                                "trdpid_tpc.root",
+                                "pidTRD",
+                                BranchDefinition<std::vector<o2::trd::PIDValue>>{InputSpec{"pid", o2::header::gDataOriginTRD, "TRDPID_TPC", 0},
+                                                                                 "pid",
+                                                                                 "pid-branch-name",
+                                                                                 1,
+                                                                                 pidLogger},
+                                BranchDefinition<std::vector<o2::trd::TrackTriggerRecord>>{InputSpec{"trackTrig", o2::header::gDataOriginTRD, "TRGREC_TPC", 0},
+                                                                                           "trgrec",
+                                                                                           "trgrec-branch-name",
+                                                                                           1},
+                                BranchDefinition<LabelsType>{InputSpec{"trdlabels", o2::header::gDataOriginTRD, "MCLB_TPC_TRD", 0},
+                                                             "labelsTRD",
+                                                             (useMC ? 1 : 0), // one branch if mc labels enabled
+                                                             "trdlabels-branch-name"},
+                                BranchDefinition<LabelsType>{InputSpec{"matchtpclabels", o2::header::gDataOriginTRD, "MCLB_TPC", 0},
+                                                             "labels",
+                                                             (useMC ? 1 : 0), // one branch if mc labels enabled
+                                                             "labels-branch-name"})();
+}
+
+} // namespace trd
+} // namespace o2

--- a/Detectors/TRD/workflow/src/TRDPIDSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDPIDSpec.cxx
@@ -1,0 +1,146 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TRDPIDSpec.cxx
+/// \brief This file provides the specification for calculating the pid value.
+/// \author Felix Schlepper
+
+#include "TRDWorkflow/TRDPIDSpec.h"
+#include "CommonDataFormat/IRFrame.h"
+#include "DataFormatsGlobalTracking/RecoContainer.h"
+#include "DataFormatsTRD/PID.h"
+#include "TRDPID/PIDBase.h"
+#include "DataFormatsParameters/GRPObject.h"
+#include "ReconstructionDataFormats/GlobalTrackID.h"
+#include "Framework/CCDBParamSpec.h"
+
+#include <gsl/span>
+
+using namespace o2::framework;
+using namespace o2::globaltracking;
+using GTrackID = o2::dataformats::GlobalTrackID;
+
+namespace o2
+{
+namespace trd
+{
+
+void TRDPIDSpec::init(o2::framework::InitContext& ic)
+{
+  o2::base::GRPGeomHelper::instance().setRequest(mGGCCDBRequest);
+  mTimer.Stop();
+  mTimer.Reset();
+  if (!mInitDone) {
+    mBase = getTRDPIDBase(mPolicy);
+
+    mInitDone = true;
+  }
+}
+
+void TRDPIDSpec::run(o2::framework::ProcessingContext& pc)
+{
+  // resume timer
+  mTimer.Start(false);
+
+  // get tracks
+  RecoContainer recoData;
+  recoData.collectData(pc, *mDataRequest.get());
+
+  // set tracks as input then we can iterate over them
+  mBase->setInput(recoData);
+
+  // calculate pid values
+  mBase->process(pc);
+
+  // Output
+  if (GTrackID::includesSource(GTrackID::Source::ITSTPCTRD, mTrkMask)) {
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRDPID_ITSTPC", 0, Lifetime::Timeframe}, mBase->getPIDITSTPC());
+    if (mUseMC) {
+      // pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MCLB_ITSTPC", 0, Lifetime::Timeframe}, matchLabelsITSTPC);
+      // pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MCLB_ITSTPC_TRD", 0, Lifetime::Timeframe}, trdLabelsITSTPC);
+    }
+  }
+  if (GTrackID::includesSource(GTrackID::Source::TPCTRD, mTrkMask)) {
+    pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "TRDPID_TPC", 0, Lifetime::Timeframe}, mBase->getPIDTPC());
+    if (mUseMC) {
+      // pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MCLB_TPC", 0, Lifetime::Timeframe}, matchLabelsTPC);
+      // pc.outputs().snapshot(Output{o2::header::gDataOriginTRD, "MCLB_TPC_TRD", 0, Lifetime::Timeframe}, trdLabelsTPC);
+    }
+  }
+
+  // Stop
+  mTimer.Stop();
+}
+
+void TRDPIDSpec::endOfStream(EndOfStreamContext& ec)
+{
+  LOGF(info, "TRD PID total timing: Cpu: %.3e Real: %.3e s in %d slots",
+       mTimer.CpuTime(), mTimer.RealTime(), mTimer.Counter() - 1);
+}
+
+o2::framework::DataProcessorSpec getTRDPIDSpec(bool useMC, PIDPolicy policy, GTrackID::mask_t src)
+{
+  std::shared_ptr<DataRequest> dataRequest = std::make_shared<DataRequest>();
+  GTrackID::mask_t srcClu = GTrackID::getSourcesMask("TRD");
+  dataRequest->requestTracks(src, false);      // Request ITS-TPC-TRD and TPC-TRD tracks
+  dataRequest->requestClusters(srcClu, false); // Cluster = tracklets for trd
+  auto& inputs = dataRequest->inputs;
+
+  // Request correct PID policy data
+  switch (policy) {
+    case PIDPolicy::LQ1D:
+      // inputs.emplace_back("LQ1D", "TRD", "LQ1D", 0, Lifetime::Condition, ccdbParamSpec("TRD/ppPID/LQ1D"));
+      break;
+    case PIDPolicy::LQ3D:
+      // inputs.emplace_back("LQ3D", "TRD", "LQ3D", 0, Lifetime::Condition, ccdbParamSpec("TRD/ppPID/LQ3D"));
+      break;
+    case PIDPolicy::Test:
+      inputs.emplace_back("mlTest", "TRD", "MLTEST", 0, Lifetime::Condition, ccdbParamSpec("TRD_test/pid/xgb1"));
+      break;
+    default:
+      throw std::runtime_error("Unable to load requested PID policy data!");
+  }
+
+  auto ggRequest = std::make_shared<o2::base::GRPGeomRequest>(false,                             // orbitResetTime
+                                                              false,                             // GRPECS=true
+                                                              false,                             // GRPLHCIF
+                                                              true,                              // GRPMagField
+                                                              false,                             // askMatLUT
+                                                              o2::base::GRPGeomRequest::Aligned, // geometry
+                                                              inputs,
+                                                              true);
+
+  std::vector<OutputSpec> outputs;
+  if (GTrackID::includesSource(GTrackID::Source::TPCTRD, src)) {
+    outputs.emplace_back(o2::header::gDataOriginTRD, "TRDPID_TPC", 0, Lifetime::Timeframe);
+    if (useMC) {
+      outputs.emplace_back(o2::header::gDataOriginTRD, "MCLB_TPC", 0, Lifetime::Timeframe);
+      outputs.emplace_back(o2::header::gDataOriginTRD, "MCLB_TPC_TRD", 0, Lifetime::Timeframe);
+    }
+  }
+  if (GTrackID::includesSource(GTrackID::Source::ITSTPCTRD, src)) {
+    outputs.emplace_back(o2::header::gDataOriginTRD, "TRDPID_ITSTPC", 0, Lifetime::Timeframe);
+    if (useMC) {
+      outputs.emplace_back(o2::header::gDataOriginTRD, "MCLB_ITSTPC", 0, Lifetime::Timeframe);
+      outputs.emplace_back(o2::header::gDataOriginTRD, "MCLB_ITSTPC_TRD", 0, Lifetime::Timeframe);
+    }
+  }
+
+  return DataProcessorSpec{
+    "TRDPID",
+    inputs,
+    outputs,
+    AlgorithmSpec{adaptFromTask<TRDPIDSpec>(useMC, src, dataRequest, ggRequest, policy)},
+    Options{}};
+}
+
+} // end namespace trd
+} // end namespace o2

--- a/Detectors/TRD/workflow/src/trd-pid-workflow.cxx
+++ b/Detectors/TRD/workflow/src/trd-pid-workflow.cxx
@@ -1,0 +1,103 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file trd-pid-workflow.cxx
+/// \brief This file defines the workflow for the pid signal.
+/// \author Felix Schlepper
+
+#include "TRDWorkflow/TRDPIDSpec.h"
+#include "TRDWorkflowIO/TRDPIDWriterSpec.h"
+#include "ReconstructionDataFormats/GlobalTrackID.h"
+#include "GlobalTrackingWorkflowHelpers/InputHelper.h"
+#include "DetectorsRaw/HBFUtilsInitializer.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "Framework/CompletionPolicy.h"
+#include "Framework/CompletionPolicyHelpers.h"
+#include "DataFormatsTRD/PID.h"
+#include "Framework/Logger.h"
+
+using namespace o2::framework;
+using GTrackID = o2::dataformats::GlobalTrackID;
+
+void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
+{
+  o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
+
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  policies.push_back(CompletionPolicyHelpers::consumeWhenAllOrdered(".*(?:TRD|trd).*[W,w]riter.*"));
+}
+
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  std::vector<o2::framework::ConfigParamSpec> options{
+    {"disable-mc", VariantType::Bool, false, {"Disable MC labels"}},
+    {"disable-root-input", VariantType::Bool, false, {"disable root-files input reader"}},
+    {"disable-root-output", VariantType::Bool, false, {"disable root-files output writer"}},
+    {"track-sources", VariantType::String, std::string{GTrackID::ALL}, {"comma-separated list of sources to use for tracking"}},
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}},
+    {"policy", VariantType::String, std::string{"default"}, {"Policy for PID evaluation"}},
+  };
+  o2::raw::HBFUtilsInitializer::addConfigOption(options);
+  std::swap(workflowOptions, options);
+}
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  // Update the (declared) parameters if changed from the command line
+  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
+  // write the configuration used for the workflow
+  o2::conf::ConfigurableParam::writeINI("o2trdpid-workflow_configuration.ini");
+  GTrackID::mask_t allowedSources = GTrackID::getSourcesMask("ITS-TPC-TRD,TPC-TRD");
+  GTrackID::mask_t srcTRD = allowedSources & GTrackID::getSourcesMask(configcontext.options().get<std::string>("track-sources"));
+
+  // Parse policy string
+  auto policyStr = configcontext.options().get<std::string>("policy");
+  auto policyIt = o2::trd::PIDPolicyString.find(policyStr);
+  if (policyIt == o2::trd::PIDPolicyString.end()) {
+    throw std::runtime_error(fmt::format("No PID model named {:s} available!", policyStr));
+  }
+  o2::trd::PIDPolicy policy = policyIt->second;
+  LOGF(info, "Using PID policy %s(%u)", policyStr, static_cast<unsigned int>(policy));
+
+  // MC labels are passed through for the global tracking downstream
+  // in case ROOT output is requested the tracklet labels are duplicated
+  bool useMC = !configcontext.options().get<bool>("disable-mc");
+
+  WorkflowSpec specs;
+  specs.emplace_back(o2::trd::getTRDPIDSpec(useMC, policy, srcTRD));
+
+  if (!configcontext.options().get<bool>("disable-root-output")) {
+    if (GTrackID::includesSource(GTrackID::Source::ITSTPCTRD, srcTRD)) {
+      specs.emplace_back(o2::trd::getTRDPIDGlobalWriterSpec(useMC));
+    }
+    if (GTrackID::includesSource(GTrackID::Source::TPCTRD, srcTRD)) {
+      specs.emplace_back(o2::trd::getTRDPIDTPCWriterSpec(useMC));
+    }
+  }
+
+  // input
+  auto maskClusters = GTrackID::getSourcesMask("TRD");
+  auto maskTracks = srcTRD | GTrackID::getSourcesMask("TPC-TRD"); // minimum TRD track
+  if (GTrackID::includesDet(GTrackID::DetID::ITS, srcTRD)) {
+    maskTracks |= GTrackID::getSourcesMask("ITS-TPC-TRD");
+  }
+  auto maskMatches = GTrackID::getSourcesMask(GTrackID::NONE);
+  o2::globaltracking::InputHelper::addInputSpecs(configcontext, specs, maskClusters, maskMatches, maskTracks, useMC);
+
+  // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit
+  o2::raw::HBFUtilsInitializer hbfIni(configcontext, specs);
+
+  return specs;
+}

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -217,7 +217,7 @@ DECLARE_SOA_COLUMN(TPCNClsFindable, tpcNClsFindable, uint8_t);                  
 DECLARE_SOA_COLUMN(TPCNClsFindableMinusFound, tpcNClsFindableMinusFound, int8_t);             //! TPC Clusters: Findable - Found
 DECLARE_SOA_COLUMN(TPCNClsFindableMinusCrossedRows, tpcNClsFindableMinusCrossedRows, int8_t); //! TPC Clusters: Findable - crossed rows
 DECLARE_SOA_COLUMN(TPCNClsShared, tpcNClsShared, uint8_t);                                    //! Number of shared TPC clusters
-DECLARE_SOA_COLUMN(TRDPattern, trdPattern, uint8_t);                                          //! Contributor to the track on TRD layer in bits 0-5, starting from the innermost
+DECLARE_SOA_COLUMN(TRDPattern, trdPattern, uint8_t);                                          //! Contributor to the track on TRD layer in bits 0-5, starting from the innermost, bit 6 indicates a potentially split tracklet, bit 7 if the track crossed a padrow
 DECLARE_SOA_COLUMN(ITSChi2NCl, itsChi2NCl, float);                                            //! Chi2 / cluster for the ITS track segment
 DECLARE_SOA_COLUMN(TPCChi2NCl, tpcChi2NCl, float);                                            //! Chi2 / cluster for the TPC track segment
 DECLARE_SOA_COLUMN(TRDChi2, trdChi2, float);                                                  //! Chi2 for the TRD track segment


### PR DESCRIPTION
This introduces a new workflow 'o2-trd-pid-workflow', which provides PID information based currently on ML models using the ONNXRuntime.

Should not get merged before at least the default model is in the ccdb.