### PR TITLE
Fix in the VDrift selection logic

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/src/CosmicsMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/CosmicsMatchingSpec.cxx
@@ -108,7 +108,7 @@ void CosmicsMatchingSpec::run(ProcessingContext& pc)
 void CosmicsMatchingSpec::updateTimeDependentParams(ProcessingContext& pc)
 {
   o2::base::GRPGeomHelper::instance().checkUpdates(pc);
-  o2::tpc::VDriftHelper::extractCCDBInputs(pc);
+  mTPCVDriftHelper.extractCCDBInputs(pc);
   o2::tpc::CorrectionMapsLoader::extractCCDBInputs(pc);
   static bool initOnceDone = false;
   if (!initOnceDone) { // this params need to be queried only once

--- a/Detectors/GlobalTrackingWorkflow/src/SecondaryVertexingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/SecondaryVertexingSpec.cxx
@@ -129,7 +129,7 @@ void SecondaryVertexingSpec::finaliseCCDB(ConcreteDataMatcher& matcher, void* ob
 void SecondaryVertexingSpec::updateTimeDependentParams(ProcessingContext& pc)
 {
   o2::base::GRPGeomHelper::instance().checkUpdates(pc);
-  o2::tpc::VDriftHelper::extractCCDBInputs(pc);
+  mTPCVDriftHelper.extractCCDBInputs(pc);
   o2::tpc::CorrectionMapsLoader::extractCCDBInputs(pc);
   static bool initOnceDone = false;
   if (!initOnceDone) { // this params need to be queried only once

--- a/Detectors/GlobalTrackingWorkflow/src/TOFMatcherSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TOFMatcherSpec.cxx
@@ -94,7 +94,7 @@ void TOFMatcherSpec::init(InitContext& ic)
 void TOFMatcherSpec::updateTimeDependentParams(ProcessingContext& pc)
 {
   o2::base::GRPGeomHelper::instance().checkUpdates(pc);
-  o2::tpc::VDriftHelper::extractCCDBInputs(pc);
+  mTPCVDriftHelper.extractCCDBInputs(pc);
   o2::tpc::CorrectionMapsLoader::extractCCDBInputs(pc);
   static bool initOnceDone = false;
   if (!initOnceDone) { // this params need to be queried only once

--- a/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/TPCITSMatchingSpec.cxx
@@ -150,7 +150,7 @@ void TPCITSMatchingDPL::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
 void TPCITSMatchingDPL::updateTimeDependentParams(ProcessingContext& pc)
 {
   o2::base::GRPGeomHelper::instance().checkUpdates(pc);
-  o2::tpc::VDriftHelper::extractCCDBInputs(pc);
+  mTPCVDriftHelper.extractCCDBInputs(pc);
   o2::tpc::CorrectionMapsLoader::extractCCDBInputs(pc);
   static bool initOnceDone = false;
   if (!initOnceDone) { // this params need to be queried only once

--- a/Detectors/GlobalTrackingWorkflow/src/VertexTrackMatcherSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/VertexTrackMatcherSpec.cxx
@@ -89,7 +89,7 @@ void VertexTrackMatcherSpec::run(ProcessingContext& pc)
 void VertexTrackMatcherSpec::updateTimeDependentParams(ProcessingContext& pc)
 {
   o2::base::GRPGeomHelper::instance().checkUpdates(pc);
-  o2::tpc::VDriftHelper::extractCCDBInputs(pc);
+  mTPCVDriftHelper.extractCCDBInputs(pc);
   static bool initOnceDone = false;
   if (!initOnceDone) { // this params need to be queried only once
     initOnceDone = true;

--- a/Detectors/GlobalTrackingWorkflow/study/src/TPCTrackStudy.cxx
+++ b/Detectors/GlobalTrackingWorkflow/study/src/TPCTrackStudy.cxx
@@ -103,7 +103,7 @@ void TPCTrackStudySpec::run(ProcessingContext& pc)
 void TPCTrackStudySpec::updateTimeDependentParams(ProcessingContext& pc)
 {
   o2::base::GRPGeomHelper::instance().checkUpdates(pc);
-  o2::tpc::VDriftHelper::extractCCDBInputs(pc);
+  mTPCVDriftHelper.extractCCDBInputs(pc);
   o2::tpc::CorrectionMapsLoader::extractCCDBInputs(pc);
   static bool initOnceDone = false;
   if (!initOnceDone) { // this params need to be queried only once

--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/RecoWorkflowSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/RecoWorkflowSpec.cxx
@@ -114,7 +114,7 @@ class TOFDPLRecoWorkflowTask
   void updateTimeDependentParams(ProcessingContext& pc)
   {
     o2::base::GRPGeomHelper::instance().checkUpdates(pc);
-    o2::tpc::VDriftHelper::extractCCDBInputs(pc);
+    mTPCVDriftHelper.extractCCDBInputs(pc);
     static bool initOnceDone = false;
     if (!initOnceDone) { // this params need to be queried only once
       initOnceDone = true;

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
@@ -54,7 +54,7 @@ void TPCInterpolationDPL::init(InitContext& ic)
 void TPCInterpolationDPL::updateTimeDependentParams(ProcessingContext& pc)
 {
   o2::base::GRPGeomHelper::instance().checkUpdates(pc);
-  o2::tpc::VDriftHelper::extractCCDBInputs(pc);
+  mTPCVDriftHelper.extractCCDBInputs(pc);
   static bool initOnceDone = false;
   if (!initOnceDone) { // this params need to be queried only once
     initOnceDone = true;

--- a/Detectors/TPC/calibration/include/TPCCalibration/VDriftHelper.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/VDriftHelper.h
@@ -57,15 +57,17 @@ class VDriftHelper
   std::string_view getSourceName() const { return SourceNames[mSource]; }
 
   bool accountCCDBInputs(const o2::framework::ConcreteDataMatcher& matcher, void* obj);
+  void extractCCDBInputs(o2::framework::ProcessingContext& pc, bool laser = true, bool itstpcTgl = true);
   static void requestCCDBInputs(std::vector<o2::framework::InputSpec>& inputs, bool laser = true, bool itstpcTgl = true);
-  static void extractCCDBInputs(o2::framework::ProcessingContext& pc, bool laser = true, bool itstpcTgl = true);
 
  protected:
   static void addInput(std::vector<o2::framework::InputSpec>& inputs, o2::framework::InputSpec&& isp);
-
+  VDriftCorrFact mVDLaser{};
+  VDriftCorrFact mVDTPCITSTgl{};
   VDriftCorrFact mVD{};
-  Source mSource{};       // update source
+  Source mSource{Source::GasParam}; // update source
   bool mUpdated = false;  // signal update, must be reset once new value is fetched
+  bool mForceGasParam = false;         // enforce vdrift from gasParam
   uint32_t mMayRenormSrc = 0xffffffff; // if starting VDrift correction != 1, we will renorm reference in such a way that initial correction is 1.0, flag per source
 
   ClassDefNV(VDriftHelper, 1);

--- a/Detectors/TPC/calibration/src/VDriftHelper.cxx
+++ b/Detectors/TPC/calibration/src/VDriftHelper.cxx
@@ -31,6 +31,7 @@ VDriftHelper::VDriftHelper()
   // was it imposed from the command line?
   if (o2::conf::ConfigurableParam::getProvenance("TPCGasParam.DriftV") == o2::conf::ConfigurableParam::EParamProvenance::kRT) { // we stick to this value
     mVD.creationTime = std::numeric_limits<long>::max();
+    mForceGasParam = true;
     LOGP(info, "TPC VDrift was set from command line to {}, will neglect update from CCDB", mVD.refVDrift);
   } else {
     mVD.creationTime = 1; // just to be above 0
@@ -42,34 +43,32 @@ VDriftHelper::VDriftHelper()
 //________________________________________________________
 void VDriftHelper::accountLaserCalibration(const LtrCalibData* calib, long fallBackTimeStamp)
 {
-  if (!calib) {
+  if (!calib || mForceGasParam) {
     return;
   }
   // old entries of laser calib have no update time assigned
   long updateTS = calib->creationTime > 0 ? calib->creationTime : fallBackTimeStamp;
-  LOG(info) << "accountLaserCalibration " << calib->getDriftVCorrection() << " t " << updateTS << " vs " << mVD.creationTime;
-  if (updateTS < mVD.creationTime) { // prefer current value
-    return;
-  }
+  LOG(info) << "accountLaserCalibration " << calib->getDriftVCorrection() << " t " << updateTS << " vs " << mVDLaser.creationTime;
   // old entries of laser calib have no reference assigned
   float ref = calib->refVDrift > 0. ? calib->refVDrift : o2::tpc::ParameterGas::Instance().DriftV;
   float corr = calib->getDriftVCorrection();
   if (corr > 0.) { // laser correction is inverse multiplicative
     static bool firstCall = true;
-    auto prevRef = mVD.refVDrift;
-    mVD.refVDrift = ref;
-    mVD.corrFact = 1. / corr;
+    auto prevRef = mVDLaser.refVDrift;
+    mVDLaser.refVDrift = ref;
+    mVDLaser.corrFact = 1. / corr;
+    mVDLaser.creationTime = calib->creationTime;
     mUpdated = true;
     mSource = Source::Laser;
     if (mMayRenormSrc & (0x1U << Source::Laser)) { // this was 1st setting?
       if (corr != 1.f) { // this may happen if old-style (non-normalized) standalone or non-normalized run-time laset calibration is used
-        LOGP(warn, "VDriftHelper: renorming initinal TPC refVDrift={}/correction={} to {}/1.0, source: {}", mVD.refVDrift, mVD.corrFact, mVD.getVDrift(), getSourceName());
-        mVD.normalize(); // renorm reference to have correction = 1.
+        LOGP(warn, "VDriftHelper: renorming initinal TPC refVDrift={}/correction={} to {}/1.0, source: {}", mVDLaser.refVDrift, mVDLaser.corrFact, mVDLaser.getVDrift(), getSourceName());
+        mVDLaser.normalize(); // renorm reference to have correction = 1.
       }
       mMayRenormSrc &= ~(0x1U << Source::Laser); // unset MayRenorm
     } else if (ref != prevRef) {                 // we want to keep the same reference over the run, this may happen if run-time laser calibration is supplied
-      LOGP(warn, "VDriftHelper: renorming updated TPC refVDrift={}/correction={} previous refVDrift {}, source: {}", mVD.refVDrift, mVD.corrFact, prevRef, getSourceName());
-      mVD.normalize(prevRef);
+      LOGP(warn, "VDriftHelper: renorming updated TPC refVDrift={}/correction={} previous refVDrift {}, source: {}", mVDLaser.refVDrift, mVDLaser.corrFact, prevRef, getSourceName());
+      mVDLaser.normalize(prevRef);
     }
   }
 }
@@ -77,34 +76,46 @@ void VDriftHelper::accountLaserCalibration(const LtrCalibData* calib, long fallB
 //________________________________________________________
 void VDriftHelper::accountDriftCorrectionITSTPCTgl(const VDriftCorrFact* calib)
 {
-  LOG(info) << "accountDriftCorrectionITSTPCTgl " << calib->corrFact << " t " << calib->creationTime << " vs " << mVD.creationTime;
-  if (!calib || calib->creationTime < mVD.creationTime) { // prefer current value
+  if (!calib || mForceGasParam) {
     return;
   }
-  auto prevRef = mVD.refVDrift;
-  mVD = *calib;
+  LOG(info) << "accountDriftCorrectionITSTPCTgl " << calib->corrFact << " t " << calib->creationTime << " vs " << mVDTPCITSTgl.creationTime;
+  auto prevRef = mVDTPCITSTgl.refVDrift;
+  mVDTPCITSTgl = *calib;
   mUpdated = true;
   mSource = Source::ITSTPCTgl;
   if (mMayRenormSrc & (0x1U << Source::ITSTPCTgl)) { // this was 1st setting?
-    if (mVD.corrFact != 1.f) { // this may happen if calibration from prevous run is used
-      LOGP(warn, "VDriftHelper: renorming initinal TPC refVDrift={}/correction={} to {}/1.0, source: {}", mVD.refVDrift, mVD.corrFact, mVD.getVDrift(), getSourceName());
-      mVD.normalize(); // renorm reference to have correction = 1.
+    if (mVDTPCITSTgl.corrFact != 1.f) {              // this may happen if calibration from prevous run is used
+      LOGP(warn, "VDriftHelper: renorming initinal TPC refVDrift={}/correction={} to {}/1.0, source: {}", mVDTPCITSTgl.refVDrift, mVDTPCITSTgl.corrFact, mVDTPCITSTgl.getVDrift(), getSourceName());
+      mVDTPCITSTgl.normalize(); // renorm reference to have correction = 1.
     }
     mMayRenormSrc &= ~(0x1U << Source::ITSTPCTgl); // unset MayRenorm
-  } else if (mVD.refVDrift != prevRef) {           // we want to keep the same reference over the run, this should not happen!
-    LOGP(alarm, "VDriftHelper: renorming updated TPC refVDrift={}/correction={} previous refVDrift {}, source: {}", mVD.refVDrift, mVD.corrFact, prevRef, getSourceName());
-    mVD.normalize(prevRef);
+  } else if (mVDTPCITSTgl.refVDrift != prevRef) {  // we want to keep the same reference over the run, this should not happen!
+    LOGP(warn, "VDriftHelper: renorming updated TPC refVDrift={}/correction={} previous refVDrift {}, source: {}", mVDTPCITSTgl.refVDrift, mVDTPCITSTgl.corrFact, prevRef, getSourceName());
+    mVDTPCITSTgl.normalize(prevRef);
   }
 }
 
 //________________________________________________________
 void VDriftHelper::extractCCDBInputs(ProcessingContext& pc, bool laser, bool itstpcTgl)
 {
+  if (mForceGasParam) { // fixed from the command line
+    return;
+  }
   if (laser) {
     pc.inputs().get<o2::tpc::LtrCalibData*>("laserCalib");
   }
   if (itstpcTgl) {
     pc.inputs().get<o2::tpc::VDriftCorrFact*>("vdriftTgl");
+  }
+  if (mUpdated) { // there was a change
+    // prefer among laser and tgl VDrift the one with the latest update time
+    mVD = mVDTPCITSTgl.creationTime < mVDLaser.creationTime ? mVDLaser : mVDTPCITSTgl;
+    mSource = mVDTPCITSTgl.creationTime < mVDLaser.creationTime ? Source::Laser : Source::ITSTPCTgl;
+    LOGP(info, "Will prefer VDrift from {} with time {} to {} with time {}",
+         SourceNames[int(mSource)], mVD.creationTime,
+         mSource == Source::Laser ? SourceNames[int(Source::ITSTPCTgl)] : SourceNames[int(Source::Laser)],
+         mSource == Source::Laser ? mVDTPCITSTgl.creationTime : mVDLaser.creationTime);
   }
 }
 

--- a/Detectors/TPC/workflow/include/TPCWorkflow/TPCCalibPadGainTracksSpec.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/TPCCalibPadGainTracksSpec.h
@@ -181,7 +181,7 @@ class TPCCalibPadGainTracksDevice : public o2::framework::Task
       LOGP(info, "fetching residual gain map");
       pc.inputs().get<std::unordered_map<std::string, o2::tpc::CalDet<float>>*>("tpcresidualgainmap");
     }
-    o2::tpc::VDriftHelper::extractCCDBInputs(pc);
+    mTPCVDriftHelper.extractCCDBInputs(pc);
     o2::tpc::CorrectionMapsLoader::extractCCDBInputs(pc);
     bool updateMaps = false;
     if (mTPCCorrMapsLoader.isUpdated()) {

--- a/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
@@ -71,7 +71,7 @@ void TRDGlobalTracking::init(InitContext& ic)
 void TRDGlobalTracking::updateTimeDependentParams(ProcessingContext& pc)
 {
   o2::base::GRPGeomHelper::instance().checkUpdates(pc);
-  o2::tpc::VDriftHelper::extractCCDBInputs(pc);
+  mTPCVDriftHelper.extractCCDBInputs(pc);
   o2::tpc::CorrectionMapsLoader::extractCCDBInputs(pc);
   // pc.inputs().get<TopologyDictionary*>("cldict"); // called by the RecoContainer to trigger finaliseCCDB
   static bool initOnceDone = false;

--- a/GPU/Workflow/src/GPUWorkflowSpec.cxx
+++ b/GPU/Workflow/src/GPUWorkflowSpec.cxx
@@ -1123,7 +1123,7 @@ bool GPURecoWorkflowSpec::fetchCalibsCCDBTPC(ProcessingContext& pc, T& newCalibO
       }
 
       if (mSpecConfig.outputTracks) {
-        o2::tpc::VDriftHelper::extractCCDBInputs(pc);
+        mTPCVDriftHelper->extractCCDBInputs(pc);
         o2::tpc::CorrectionMapsLoader::extractCCDBInputs(pc);
       }
       if (mTPCVDriftHelper->isUpdated() || mFastTransformHelper->isUpdated()) {

--- a/Steer/DigitizerWorkflow/src/TPCDigitizerSpec.cxx
+++ b/Steer/DigitizerWorkflow/src/TPCDigitizerSpec.cxx
@@ -245,7 +245,7 @@ class TPCDPLDigitizerTask : public BaseDPLDigitizer
     auto& cdb = o2::tpc::CDBInterface::instance();
     cdb.setUseDefaults(!mUseCalibrationsFromCCDB);
     // whatever are global settings for CCDB usage, we have to extract the TPC vdrift from CCDB for anchored simulations
-    //    o2::tpc::VDriftHelper::extractCCDBInputs(pc);
+    //    mTPCVDriftHelper.extractCCDBInputs(pc);
     if (mTPCVDriftHelper.isUpdated()) {
       const auto& vd = mTPCVDriftHelper.getVDriftObject();
       LOGP(info, "Updating TPC VDrift with factor of {} wrt reference {} from source {}", vd.corrFact, vd.refVDrift, mTPCVDriftHelper.getSourceName());


### PR DESCRIPTION
In case the current TF timestamp is < then that of the previous TF (e.g. due to loading another CTF file), the vdrift of the previous one was used even if another object was supplied by the CCDB fetcher (since the creation time of the previous object is > than that of the newly supplied one).

This PR ensures the proper selection of updated object among different VDrift sources.