### PR TITLE
ITS Calib: compatibility with data produced with IB commissioning tools

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdCalibratorSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdCalibratorSpec.h
@@ -60,7 +60,7 @@ namespace o2
 namespace its
 {
 
-constexpr int N_INJ = 50;
+int nInj = 50;
 
 // List of the possible run types for reference
 enum RunTypes {
@@ -254,6 +254,9 @@ class ITSThresholdCalibrator : public Task
   short int manualMin;
   short int manualMax;
   std::string manualScanType;
+
+  // for CRU_ITS data processing
+  bool isCRUITS = false;
 
   // map to get confDB id
   std::vector<int>* mConfDBmap;


### PR DESCRIPTION
This PR allows to process data on disk obtained with CRU_ITS -> IB commissioning tools (https://gitlab.cern.ch/alice-its-wp10-firmware/CRU_ITS/-/blob/production/software/py/ib_tools/README.md). 

The main changes here are due to the different format of the calibration word which is generated with those tools and to the different number of injections per charge (25). 

Flag `--enable-cru-its` allow to activate the processing of this data while the option `--ninj` allow to set the number of injections per charge point which is 50 by default.  