### PR TITLE
[QC-898] Rename RAW channel type into RAWFMQ

### DIFF
--- a/Framework/Core/include/Framework/ChannelInfo.h
+++ b/Framework/Core/include/Framework/ChannelInfo.h
@@ -39,7 +39,7 @@ enum struct ChannelAccountingType {
   /// The channel is a normal input channel
   DPL,
   /// A raw FairMQ channel which is not accounted by the framework
-  RAW
+  RAWFMQ
 };
 
 /// This represent the current state of an input channel.  Its values can be

--- a/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
+++ b/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
@@ -453,7 +453,7 @@ DataProcessorSpec specifyExternalFairMQDeviceProxy(char const* name,
           .readPolled = false,
           .channel = nullptr,
           .id = {ChannelIndex::INVALID},
-          .channelType = ChannelAccountingType::RAW,
+          .channelType = ChannelAccountingType::RAWFMQ,
         });
       }
       numberOfEoS.resize(channels.size(), 0);

--- a/Framework/Core/src/FairMQDeviceProxy.cxx
+++ b/Framework/Core/src/FairMQDeviceProxy.cxx
@@ -239,7 +239,7 @@ void FairMQDeviceProxy::bind(std::vector<OutputRoute> const& outputs, std::vecto
 
       if (channelPos == channelNameToChannel.end()) {
         channelIndex = ChannelIndex{(int)mOutputChannelInfos.size()};
-        ChannelAccountingType dplChannel = (route.channel.rfind("from_", 0) == 0) ? ChannelAccountingType::DPL : ChannelAccountingType::RAW;
+        ChannelAccountingType dplChannel = (route.channel.rfind("from_", 0) == 0) ? ChannelAccountingType::DPL : ChannelAccountingType::RAWFMQ;
         OutputChannelInfo info{
           .name = route.channel,
           .channelType = dplChannel,
@@ -315,7 +315,7 @@ void FairMQDeviceProxy::bind(std::vector<OutputRoute> const& outputs, std::vecto
       if (channelPos == channelNameToChannel.end()) {
         channelIndex = ChannelIndex{(int)mForwardChannelInfos.size()};
         auto& channel = device.fChannels.at(route.channel).at(0);
-        ChannelAccountingType dplChannel = (route.channel.rfind("from_", 0) == 0) ? ChannelAccountingType::DPL : ChannelAccountingType::RAW;
+        ChannelAccountingType dplChannel = (route.channel.rfind("from_", 0) == 0) ? ChannelAccountingType::DPL : ChannelAccountingType::RAWFMQ;
         mForwardChannelInfos.push_back(ForwardChannelInfo{route.channel, dplChannel, channel});
         mForwardChannelStates.push_back(ForwardChannelState{0});
         channelNameToChannel[route.channel] = channelIndex;


### PR DESCRIPTION
RAW was clashing with ioctl_compat.h on Mac, in certain cases.

If you try to open the file I attach with a `TBrowser` and navigate down inside the detector directory, it crashes on Mac.
[results.root.zip](https://github.com/AliceO2Group/AliceO2/files/10267051/results.root.zip)
