### PR TITLE
TRD: Adding PID

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/PID.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/PID.h
@@ -1,0 +1,74 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file  PID.h
+/// @author Felix Schlepper
+
+#ifndef TRD_PID_H
+#define TRD_PID_H
+
+#include <array>
+#include <unordered_map>
+#include <string>
+
+namespace o2
+{
+namespace trd
+{
+
+/// Option for available PID policies.
+enum class PIDPolicy : unsigned int {
+  // Classical Algorithms
+  LQ1D = 0, ///< 1-Dimensional Likelihood model
+  LQ3D,     ///< 3-Dimensional Likelihood model
+
+  // ML models
+  XGB, ///< XGBOOST
+
+  // Do not add anything after this!
+  NMODELS,         ///< Count of all models
+  Test,            ///< Load object for testing
+  Dummy,           ///< Dummy object outputting -1.f
+  DEFAULT = Dummy, ///< The default option
+};
+
+/// Transform PID policy from string to enum.
+static const std::unordered_map<std::string, PIDPolicy> PIDPolicyString{
+  // Classical Algorithms
+  {"LQ1D", PIDPolicy::LQ1D},
+  {"LQ3D", PIDPolicy::LQ3D},
+
+  // ML models
+  {"XGB", PIDPolicy::XGB},
+
+  // General
+  {"TEST", PIDPolicy::Test},
+  {"DUMMY", PIDPolicy::Dummy},
+  // Default
+  {"default", PIDPolicy::DEFAULT},
+};
+
+/// Transform PID policy from string to enum.
+static const char* PIDPolicyEnum[] = {
+  "LQ1D",
+  "LQ3D",
+  "XGBoost",
+  "NMODELS",
+  "Test",
+  "Dummy",
+  "default(=TODO)"};
+
+using PIDValue = float;
+
+} // namespace trd
+} // namespace o2
+
+#endif

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -1204,6 +1204,12 @@ uint8_t AODProducerWorkflowDPL::getTRDPattern(const o2::trd::TrackTRD& track)
       pattern |= 0x1 << il;
     }
   }
+  if (track.getHasNeighbor()) {
+    pattern |= 0x1 << 6;
+  }
+  if (track.getHasPadrowCrossing()) {
+    pattern |= 0x1 << 7;
+  }
   return pattern;
 }
 

--- a/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
+++ b/Detectors/AOD/src/AODProducerWorkflowSpec.cxx
@@ -2066,6 +2066,7 @@ AODProducerWorkflowDPL::TrackExtraInfo AODProducerWorkflowDPL::processBarrelTrac
   if (contributorsGID[GIndex::Source::TRD].isIndexSet()) {                                        // ITS-TPC-TRD-TOF, TPC-TRD-TOF, TPC-TRD, ITS-TPC-TRD
     const auto& trdOrig = data.getTrack<o2::trd::TrackTRD>(contributorsGID[GIndex::Source::TRD]); // refitted TRD trac
     extraInfoHolder.trdChi2 = trdOrig.getChi2();
+    extraInfoHolder.trdSignal = trdOrig.getSignal();
     extraInfoHolder.trdPattern = getTRDPattern(trdOrig);
     if (extraInfoHolder.trackTimeRes < 0.) { // time is not set yet, this is possible only for TPC-TRD and ITS-TPC-TRD tracks, since those with TOF are set upstream
       // TRD is triggered: time uncertainty is within a BC

--- a/Detectors/TRD/pid/CMakeLists.txt
+++ b/Detectors/TRD/pid/CMakeLists.txt
@@ -1,0 +1,33 @@
+# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# All rights not expressly granted are reserved.
+#
+# This software is distributed under the terms of the GNU General Public
+# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+#
+# In applying this license CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+o2_add_library(TRDPID
+               SOURCES src/PIDBase.cxx
+                       src/ML.cxx
+                       src/PIDParameters.cxx
+               PRIVATE_LINK_LIBRARIES O2::TRDBase
+                                     O2::DataFormatsTRD
+                                     O2::DataFormatsGlobalTracking
+                                     O2::DetectorsBase
+                                     O2::MathUtils
+                                     O2::GPUTracking
+                                     O2::Framework
+                                     O2::ReconstructionDataFormats
+                                     fmt::fmt
+                                     ONNXRuntime::ONNXRuntime)
+
+o2_target_root_dictionary(TRDPID
+                          HEADERS include/TRDPID/PIDBase.h
+                                  include/TRDPID/PIDParameters.h
+                                  include/TRDPID/ML.h
+                                  include/TRDPID/Dummy.h)
+
+add_subdirectory(macros)

--- a/Detectors/TRD/pid/include/TRDPID/Dummy.h
+++ b/Detectors/TRD/pid/include/TRDPID/Dummy.h
@@ -1,0 +1,55 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file Dummy.h
+/// \brief This file provides a dummy model, which only outputs -1.f
+/// \author Felix Schlepper
+
+#ifndef O2_TRD_DUMMY_H
+#define O2_TRD_DUMMY_H
+
+#include "Rtypes.h"
+#include "TRDPID/PIDBase.h"
+#include "DataFormatsTRD/TrackTRD.h"
+#include "Framework/ProcessingContext.h"
+#include "DataFormatsGlobalTracking/RecoContainer.h"
+
+namespace o2
+{
+namespace trd
+{
+
+/// This is the ML Base class which defines the interface all machine learning
+/// models.
+class Dummy final : public PIDBase
+{
+  using PIDBase::PIDBase;
+
+ public:
+  ~Dummy() final = default;
+
+  /// Do absolutely nothing.
+  void init(o2::framework::ProcessingContext& pc) final{};
+
+  /// Everything below 0.f indicates nothing available.
+  PIDValue process(const TrackTRD& trk, const o2::globaltracking::RecoContainer& input, bool isTPC) final
+  {
+    return -1.f;
+  };
+
+ private:
+  ClassDefNV(Dummy, 1);
+};
+
+} // namespace trd
+} // namespace o2
+
+#endif

--- a/Detectors/TRD/pid/include/TRDPID/ML.h
+++ b/Detectors/TRD/pid/include/TRDPID/ML.h
@@ -1,0 +1,102 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file ML.h
+/// \brief This file provides the base for ML policies.
+/// \author Felix Schlepper
+
+#ifndef O2_TRD_ML_H
+#define O2_TRD_ML_H
+
+#include "Rtypes.h"
+#include "TRDPID/PIDBase.h"
+#include "DataFormatsTRD/PID.h"
+#include "Framework/ProcessingContext.h"
+#include "Framework/InputRecord.h"
+#include <onnxruntime/core/session/experimental_onnxruntime_cxx_api.h>
+#include <memory>
+#include <vector>
+#include <array>
+#include <string>
+
+namespace o2
+{
+namespace trd
+{
+
+/// This is the ML Base class which defines the interface all machine learning
+/// models.
+class ML : public PIDBase
+{
+  using PIDBase::PIDBase;
+
+ public:
+  void init(o2::framework::ProcessingContext& pc) final;
+  PIDValue process(const TrackTRD& trk, const o2::globaltracking::RecoContainer& input, bool isTPC) final;
+
+ private:
+  /// Return the electron likelihood.
+  /// Different models have different ways to return the probability.
+  virtual PIDValue getELikelihood(const std::vector<Ort::Value>& tensorData) const noexcept = 0;
+
+  /// Fetch a ML model from the ccdb via its binding
+  std::string fetchModelCCDB(o2::framework::ProcessingContext& pc, const char* binding) const;
+
+  /// Calculate pid value
+  template <bool isTPCTRD>
+  PIDValue calculate(const TrackTRD& trkTRD, const o2::globaltracking::RecoContainer& inputTracks);
+
+  /// Prepare model input
+  /// Collect track properties in vector as flat array
+  template <bool isTPCTRD>
+  std::vector<float> prepareModelInput(const TrackTRD& trkTRD, const o2::globaltracking::RecoContainer& inputTracks);
+
+  /// Pretty print model shape
+  std::string printShape(const std::vector<int64_t>& v) const noexcept;
+
+  // ONNX runtime
+  Ort::Env mEnv{ORT_LOGGING_LEVEL_WARNING, "TRD-PID",
+                // integrate ORT logging into Fairlogger
+                [](void* param, OrtLoggingLevel severity, const char* category, const char* logid, const char* code_location, const char* message) {
+                  LOG(warn) << "Ort " << severity << ": [" << logid << "|" << category << "|" << code_location << "]: " << message << ((intptr_t)param == 3 ? " [valid]" : " [error]");
+                },
+                (void*)3};                              ///< ONNX enviroment
+  const OrtApi& mApi{Ort::GetApi()};                    ///< ONNX api
+  std::unique_ptr<Ort::Experimental::Session> mSession; ///< ONNX session
+  Ort::SessionOptions mSessionOptions;                  ///< ONNX session options
+
+  // Input/Output
+  std::vector<std::string> mInputNames;            ///< model input names
+  std::vector<std::vector<int64_t>> mInputShapes;  ///< input shape
+  std::vector<std::string> mOutputNames;           ///< model output names
+  std::vector<std::vector<int64_t>> mOutputShapes; ///< output shape
+
+  ClassDefNV(ML, 1);
+};
+
+/// XGBoost Model
+class XGB final : public ML
+{
+  using ML::ML;
+
+ public:
+  ~XGB() final = default;
+
+ private:
+  PIDValue getELikelihood(const std::vector<Ort::Value>& tensorData) const noexcept final;
+
+  ClassDefNV(XGB, 1);
+};
+
+} // namespace trd
+} // namespace o2
+
+#endif

--- a/Detectors/TRD/pid/include/TRDPID/PIDBase.h
+++ b/Detectors/TRD/pid/include/TRDPID/PIDBase.h
@@ -1,0 +1,71 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file PIDBase.h
+/// \brief This file provides the base interface for pid policies.
+/// \author Felix Schlepper
+
+#ifndef O2_TRD_PIDBASE_H
+#define O2_TRD_PIDBASE_H
+
+#include "Rtypes.h"
+#include "DataFormatsTRD/PID.h"
+#include "DataFormatsTRD/TrackTRD.h"
+#include "TRDPID/PIDParameters.h"
+#include "Framework/ProcessingContext.h"
+#include "DataFormatsGlobalTracking/RecoContainer.h"
+
+#include <gsl/span>
+#include <memory>
+
+namespace o2
+{
+namespace trd
+{
+
+/// This is the PID Base class which defines the interface all other models
+/// must provide.
+///
+/// A 'policy' describes how a PID value (PIDValue) should be
+/// calculated. For the classical algorithms there is no
+/// initialization needed since these work off LUTs. However, for ML
+/// models some initialization is needed, e.g. creating the
+/// ONNXRuntime Session.
+///
+/// Afterwards, a PID value can be calculated via the given policy for
+/// each TrackTRD.
+class PIDBase
+{
+ public:
+  virtual ~PIDBase() = default;
+  PIDBase(PIDPolicy policy) : mPolicy(policy) {}
+
+  /// Initialize the policy.
+  virtual void init(o2::framework::ProcessingContext& pc) = 0;
+
+  /// Calculate a PID for a given track.
+  virtual PIDValue process(const TrackTRD& trk, const o2::globaltracking::RecoContainer& input, bool isTPC) = 0;
+
+ protected:
+  const TRDPIDParams& mParams{TRDPIDParams::Instance()}; ///< parameters
+  PIDPolicy mPolicy;                                     ///< policy
+
+ private:
+  ClassDefNV(PIDBase, 1);
+};
+
+/// Factory function to create a PID policy.
+std::unique_ptr<PIDBase> getTRDPIDBase(PIDPolicy policy);
+
+} // namespace trd
+} // namespace o2
+
+#endif

--- a/Detectors/TRD/pid/include/TRDPID/PIDParameters.h
+++ b/Detectors/TRD/pid/include/TRDPID/PIDParameters.h
@@ -1,0 +1,38 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+// \brief Collect all possible configurable parameters for the PID task
+
+#ifndef O2_TRD_PID_PARAMS_H
+#define O2_TRD_PID_PARAMS_H
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "CommonUtils/ConfigurableParamHelper.h"
+
+namespace o2
+{
+namespace trd
+{
+
+/// PID parameters.
+struct TRDPIDParams : public o2::conf::ConfigurableParamHelper<TRDPIDParams> {
+  unsigned int numOrtThreads = 1;           ///< ONNX Session threads
+  unsigned int graphOptimizationLevel = 99; ///< ONNX GraphOptimization Level
+                                            /// 0=Disable All, 1=Enable Basic, 2=Enable Extended, 99=Enable ALL
+
+  // boilerplate
+  O2ParamDef(TRDPIDParams, "TRDPIDParams");
+};
+
+} // namespace trd
+} // namespace o2
+
+#endif

--- a/Detectors/TRD/pid/macros/CMakeLists.txt
+++ b/Detectors/TRD/pid/macros/CMakeLists.txt
@@ -9,11 +9,6 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-add_subdirectory(base)
-add_subdirectory(calibration)
-add_subdirectory(simulation)
-add_subdirectory(pid)
-add_subdirectory(reconstruction)
-add_subdirectory(macros)
-add_subdirectory(qc)
-add_subdirectory(workflow)
+o2_add_test_root_macro(ccdbModelUpload.C
+                       PUBLIC_LINK_LIBRARIES O2::TRDPID
+                       LABELS trd)

--- a/Detectors/TRD/pid/macros/ccdbModelUpload.C
+++ b/Detectors/TRD/pid/macros/ccdbModelUpload.C
@@ -1,0 +1,82 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+// ROOT header
+#include <TFile.h>
+// O2 header
+#include "CCDB/CcdbApi.h"
+#include "CCDB/BasicCCDBManager.h"
+#include "CCDB/CcdbObjectInfo.h"
+
+#include <map>
+#include <string>
+#include <vector>
+#include <chrono>
+#include <fstream>
+#include <ios>
+#include <iostream>
+
+#endif
+
+/// Upload an ONNX model to the ccdb.
+/// This reads the file as a binary file and stores it as such.
+void ccdbModelUpload(std::string inFileName, std::string ccdbPath = "TRD_test/PID/xgb")
+{
+
+  o2::ccdb::CcdbApi ccdb;
+  // ccdb.init("http://alice-ccdb.cern.ch");
+  // ccdb.init("http://localhost:8080");
+  ccdb.init("http://ccdb-test.cern.ch:8080");
+  // ccdb.init("http://o2-ccdb.internal");
+  std::map<std::string, std::string> metadata;
+  metadata["UploadedBy"] = "Felix Schlepper";
+  metadata["EMail"] = "felix.schlepper@cern.ch";
+  metadata["Description"] = "ONNX model for TRD PID";
+  metadata["default"] = "false"; // tag default objects
+  metadata["Created"] = "1";     // tag default objects
+
+  std::vector<unsigned char> input;
+  std::ifstream inFile(inFileName, std::ios::binary);
+  if (!inFile.is_open()) {
+    std::cout << "Could not load file!" << std::endl;
+    return;
+  }
+  inFile.seekg(0, std::ios_base::end);
+  auto length = inFile.tellg();
+  inFile.seekg(0, std::ios_base::beg);
+  input.resize(static_cast<size_t>(length));
+  inFile.read(reinterpret_cast<char*>(input.data()), length);
+  auto success = !inFile.fail() && length == inFile.gcount();
+  if (!success) {
+    std::cout << "File loading went wrong!" << std::endl;
+    return;
+  }
+  inFile.close();
+
+  // for default objects:
+  // long timeStampStart = 0;
+  uint64_t timeStampStart = 1577833200000UL; // 1.1.2020
+  uint64_t timeStampEnd = 2208985200000UL;   // 1.1.2040
+
+  auto res = ccdb.storeAsBinaryFile(reinterpret_cast<char*>(input.data()), length, inFileName, "ONNX Model", ccdbPath, metadata, timeStampStart, timeStampEnd);
+
+  if (res == 0) {
+    std::cout << "OK" << std::endl;
+  } else if (res == -1) {
+    std::cout << "ERROR: object bigger than maxSize" << std::endl;
+  } else if (res == -2) {
+    std::cout << "ERROR: curl initialization error" << std::endl;
+  } else {
+    std::cout << "ERROR: see curl error codes: " << res << std::endl;
+  }
+  return;
+}

--- a/Detectors/TRD/pid/src/ML.cxx
+++ b/Detectors/TRD/pid/src/ML.cxx
@@ -1,0 +1,202 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file ML.cxx
+/// \author Felix Schlepper
+
+#include "TRDPID/ML.h"
+#include "DataFormatsTRD/Constants.h"
+#include "DataFormatsTRD/Tracklet64.h"
+#include "ReconstructionDataFormats/TrackTPCITS.h"
+#include "ReconstructionDataFormats/GlobalTrackID.h"
+#include "ReconstructionDataFormats/TrackParametrizationWithError.h"
+#include "DataFormatsTPC/TrackTPC.h"
+#include "Framework/ProcessingContext.h"
+#include "Framework/InputRecord.h"
+#include "Framework/Logger.h"
+
+#include <fmt/format.h>
+#include <onnxruntime/core/session/experimental_onnxruntime_cxx_api.h>
+#include <boost/range.hpp>
+
+#include <array>
+#include <algorithm>
+#include <stdexcept>
+#include <sstream>
+#include <string>
+
+using namespace o2::trd::constants;
+
+namespace o2
+{
+namespace trd
+{
+
+void ML::init(o2::framework::ProcessingContext& pc)
+{
+  LOG(info) << "Finializing model initialization";
+
+  // fetch the onnx model from the ccdb
+  std::string model_data;
+  switch (mPolicy) {
+    case PIDPolicy::Test:
+      model_data = fetchModelCCDB(pc, "mlTest");
+      break;
+    default:
+      throw std::runtime_error("Could not load ML model from ccdb!");
+  }
+
+  // disable telemtry events
+  mEnv.DisableTelemetryEvents();
+  LOG(info) << "Disabled Telemetry Events";
+
+  // create session options
+  mSessionOptions.SetIntraOpNumThreads(mParams.numOrtThreads);
+  LOG(info) << "Set number of threads to " << mParams.numOrtThreads;
+
+  // Sets graph optimization level
+  mSessionOptions.SetGraphOptimizationLevel(static_cast<GraphOptimizationLevel>(mParams.graphOptimizationLevel));
+  LOG(info) << "Set GraphOptimizationLevel to " << mParams.graphOptimizationLevel;
+
+  // create actual session
+  mSession = std::make_unique<Ort::Experimental::Session>(mEnv, reinterpret_cast<void*>(model_data.data()), model_data.size(), mSessionOptions);
+  LOG(info) << "ONNX runtime session created";
+
+  // print name/shape of inputs
+  mInputNames = mSession->GetInputNames();
+  mInputShapes = mSession->GetInputShapes();
+  LOG(info) << "Input Node Name/Shape (" << mInputNames.size() << "):";
+  for (size_t i = 0; i < mInputNames.size(); i++) {
+    LOG(info) << "\t" << mInputNames[i] << " : " << printShape(mInputShapes[i]);
+  }
+
+  // print name/shape of outputs
+  mOutputNames = mSession->GetOutputNames();
+  mOutputShapes = mSession->GetOutputShapes();
+  LOG(info) << "Output Node Name/Shape (" << mOutputNames.size() << "):";
+  for (size_t i = 0; i < mOutputNames.size(); i++) {
+    LOG(info) << "\t" << mOutputNames[i] << " : " << printShape(mOutputShapes[i]);
+  }
+
+  LOG(info) << "Finalization done";
+}
+
+PIDValue ML::process(const TrackTRD& trk, const o2::globaltracking::RecoContainer& input, bool isTPC)
+{
+  if (isTPC) {
+    return calculate<true>(trk, input);
+  } else {
+    return calculate<false>(trk, input);
+  }
+}
+
+std::string ML::fetchModelCCDB(o2::framework::ProcessingContext& pc, const char* binding) const
+{
+  auto policyInt = static_cast<unsigned int>(mPolicy);
+  // sanity checks
+  auto ref = pc.inputs().get(binding);
+  if (!ref.spec || !ref.payload) {
+    throw std::runtime_error(fmt::format("A ML model({}) with '{}' as binding does not exist!", PIDPolicyEnum[policyInt], binding));
+  }
+
+  // the model is in binary string format
+  auto model_data = pc.inputs().get<std::string>(binding);
+  if (model_data.empty()) {
+    throw std::runtime_error(fmt::format("Did not get any data for {} model({}) from ccdb!", binding, PIDPolicyEnum[policyInt]));
+  }
+  return model_data;
+}
+
+template <bool isTPCTRD>
+PIDValue ML::calculate(const TrackTRD& trkTRD, const o2::globaltracking::RecoContainer& inputTracks)
+{
+  try {
+    auto input = prepareModelInput<isTPCTRD>(trkTRD, inputTracks);
+    // create memory mapping to vector above
+    auto inputTensor = Ort::Experimental::Value::CreateTensor<float>(input.data(), input.size(),
+                                                                     {static_cast<int64_t>(input.size()) / mInputShapes[0][1], mInputShapes[0][1]});
+    std::vector<Ort::Value> ortTensor;
+    ortTensor.push_back(std::move(inputTensor));
+    auto outTensor = mSession->Run(mInputNames, ortTensor, mOutputNames);
+    // every model defines its own output
+    return getELikelihood(outTensor);
+  } catch (const Ort::Exception& e) {
+    LOG(error) << "Error running model inference, using defaults: " << e.what();
+    // fill with negative elikelihood means no information
+    return -1.f;
+  }
+}
+
+template <bool isTPCTRD>
+std::vector<float> ML::prepareModelInput(const TrackTRD& trkTRD, const o2::globaltracking::RecoContainer& inputTracks)
+{
+  // input is [slope0, slope1, ..., slope5, charge0.0, charge0.1, charge0.2, charge1.0, ..., charge5.2, p]
+  std::vector<float> in(mInputShapes[0][1]);
+  const auto& trackletsRaw = inputTracks.getTRDTracklets();
+  // std::fill(in.begin(), in.end(), 1.f);
+  auto id = trkTRD.getRefGlobalTrackId();
+  in.back() = trkTRD.getP();
+  // const auto& trkSeed = [&]() {
+  //   if constexpr (isTPCTRD) {
+  //     return mTracksInTPCTRD[id].getParamOut();
+  //   } else {
+  //     return mTracksInITSTPCTRD[id].getParamOut();
+  //   }
+  // };
+
+  for (int iLayer = 0; iLayer < NLAYER; ++iLayer) {
+    int trkltId = trkTRD.getTrackletIndex(iLayer);
+    if (trkltId < 0) {
+      /// easy fill with default values e.g. charge=-1., slope=0.
+      in[iLayer] = 0.f;
+      in[NLAYER + iLayer * NCHARGES + 0] = -1.f;
+      in[NLAYER + iLayer * NCHARGES + 1] = -1.f;
+      in[NLAYER + iLayer * NCHARGES + 2] = -1.f;
+      continue;
+    }
+
+    auto trklt = trackletsRaw[trkltId];
+    auto slope = trackletsRaw[trkltId].getSlopeBinSigned();
+    auto q0 = trackletsRaw[trkltId].getQ0();
+    auto q1 = trackletsRaw[trkltId].getQ1();
+    auto q2 = trackletsRaw[trkltId].getQ2();
+
+    // TODO handel padrow crossing e.g. z-row merging
+
+    in[iLayer] = slope;
+    in[NLAYER + iLayer * 3 + 0] = q0;
+    in[NLAYER + iLayer * 3 + 1] = q1;
+    in[NLAYER + iLayer * 3 + 2] = q2;
+  }
+
+  return in;
+}
+
+// pretty prints a shape dimension vector
+std::string ML::printShape(const std::vector<int64_t>& v) const noexcept
+{
+  std::stringstream ss("");
+  for (size_t i = 0; i < v.size() - 1; i++) {
+    ss << v[i] << "x";
+  }
+  ss << v[v.size() - 1];
+  return ss.str();
+}
+
+/// XGBoost export is like this:
+/// (label|eprob, 1-eprob).
+PIDValue XGB::getELikelihood(const std::vector<Ort::Value>& tensorData) const noexcept
+{
+  return tensorData[1].GetTensorData<PIDValue>()[1];
+}
+
+} // namespace trd
+} // namespace o2

--- a/Detectors/TRD/pid/src/PIDBase.cxx
+++ b/Detectors/TRD/pid/src/PIDBase.cxx
@@ -1,0 +1,43 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file PIDBase.cxx
+/// \author Felix Schlepper
+
+#include "TRDPID/PIDBase.h"
+#include "DataFormatsTRD/PID.h"
+#include "TRDPID/ML.h"
+#include "TRDPID/Dummy.h"
+#include "Framework/Logger.h"
+#include "fmt/format.h"
+
+namespace o2
+{
+namespace trd
+{
+
+std::unique_ptr<PIDBase> getTRDPIDBase(PIDPolicy policy)
+{
+  auto policyInt = static_cast<unsigned int>(policy);
+  LOG(info) << "Creating PID policy. Loading model " << PIDPolicyEnum[policyInt];
+  switch (policy) {
+    case PIDPolicy::Test:
+      return std::make_unique<XGB>(PIDPolicy::Test);
+    case PIDPolicy::Dummy:
+      return std::make_unique<Dummy>(PIDPolicy::Dummy);
+    default:
+      throw std::invalid_argument(fmt::format("Cannot create this PID policy {}({})", PIDPolicyEnum[policyInt], policyInt));
+  }
+  return nullptr; // cannot be reached
+}
+
+} // namespace trd
+} // namespace o2

--- a/Detectors/TRD/pid/src/PIDParameters.cxx
+++ b/Detectors/TRD/pid/src/PIDParameters.cxx
@@ -1,0 +1,13 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "TRDPID/PIDParameters.h"
+O2ParamImpl(o2::trd::TRDPIDParams);

--- a/Detectors/TRD/pid/src/TRDPIDLinkDef.h
+++ b/Detectors/TRD/pid/src/TRDPIDLinkDef.h
@@ -1,0 +1,24 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifdef __CLING__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class o2::trd::PIDBase + ;
+#pragma link C++ class o2::trd::ML + ;
+#pragma link C++ class o2::trd::Dummy + ;
+#pragma link C++ class o2::trd::TRDPIDParams + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::trd::TRDPIDParams> + ;
+
+#endif

--- a/Detectors/TRD/workflow/CMakeLists.txt
+++ b/Detectors/TRD/workflow/CMakeLists.txt
@@ -26,7 +26,7 @@ o2_add_library(TRDWorkflow
                        include/TRDWorkflow/TRDGlobalTrackingQCSpec.h
                        include/TRDWorkflow/NoiseCalibSpec.h
                        include/TRDWorkflow/NoiseCalibAggregatorSpec.h
-               PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::Steer O2::Algorithm O2::DataFormatsTRD O2::TRDSimulation O2::TRDReconstruction O2::TRDQC O2::DetectorsBase O2::SimulationDataFormat O2::TRDBase O2::TRDCalibration O2::GPUTracking O2::GlobalTrackingWorkflowHelpers O2::GlobalTrackingWorkflowReaders O2::GPUWorkflowHelper O2::ReconstructionDataFormats O2::ITSWorkflow O2::TPCWorkflow O2::TRDWorkflowIO)
+               PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::Steer O2::Algorithm O2::DataFormatsTRD O2::TRDSimulation O2::TRDReconstruction O2::TRDQC O2::DetectorsBase O2::SimulationDataFormat O2::TRDBase O2::TRDCalibration O2::GPUTracking O2::GlobalTrackingWorkflowHelpers O2::GlobalTrackingWorkflowReaders O2::GPUWorkflowHelper O2::ReconstructionDataFormats O2::ITSWorkflow O2::TPCWorkflow O2::TRDWorkflowIO O2::TRDPID)
 
 o2_add_executable(trap-sim
                   COMPONENT_NAME trd

--- a/Detectors/TRD/workflow/include/TRDWorkflow/TRDGlobalTrackingSpec.h
+++ b/Detectors/TRD/workflow/include/TRDWorkflow/TRDGlobalTrackingSpec.h
@@ -24,6 +24,8 @@
 #include "DataFormatsGlobalTracking/RecoContainer.h"
 #include "DataFormatsTRD/TrackTRD.h"
 #include "DataFormatsTRD/TrackTriggerRecord.h"
+#include "DataFormatsTRD/PID.h"
+#include "TRDPID/PIDBase.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/ConstMCTruthContainer.h"
 #include <memory>
@@ -46,7 +48,7 @@ namespace trd
 class TRDGlobalTracking : public o2::framework::Task
 {
  public:
-  TRDGlobalTracking(bool useMC, std::shared_ptr<o2::globaltracking::DataRequest> dataRequest, std::shared_ptr<o2::base::GRPGeomRequest> gr, o2::dataformats::GlobalTrackID::mask_t src, bool trigRecFilterActive, bool strict) : mUseMC(useMC), mDataRequest(dataRequest), mGGCCDBRequest(gr), mTrkMask(src), mTrigRecFilter(trigRecFilterActive), mStrict(strict) {}
+  TRDGlobalTracking(bool useMC, bool withPID, PIDPolicy policy, std::shared_ptr<o2::globaltracking::DataRequest> dataRequest, std::shared_ptr<o2::base::GRPGeomRequest> gr, o2::dataformats::GlobalTrackID::mask_t src, bool trigRecFilterActive, bool strict) : mUseMC(useMC), mWithPID(withPID), mDataRequest(dataRequest), mGGCCDBRequest(gr), mTrkMask(src), mTrigRecFilter(trigRecFilterActive), mStrict(strict), mPolicy(policy) {}
   ~TRDGlobalTracking() override = default;
   void init(o2::framework::InitContext& ic) final;
   void fillMCTruthInfo(const TrackTRD& trk, o2::MCCompLabel lblSeed, std::vector<o2::MCCompLabel>& lblContainerTrd, std::vector<o2::MCCompLabel>& lblContainerMatch, const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* trkltLabels) const;
@@ -61,21 +63,22 @@ class TRDGlobalTracking : public o2::framework::Task
  private:
   void updateTimeDependentParams(o2::framework::ProcessingContext& pc);
 
-  o2::gpu::GPUTRDTracker* mTracker{nullptr};          ///< TRD tracking engine
-  o2::gpu::GPUReconstruction* mRec{nullptr};          ///< GPU reconstruction pointer, handles memory for the tracker
-  o2::gpu::GPUChainTracking* mChainTracking{nullptr}; ///< TRD tracker is run in the tracking chain
-  std::unique_ptr<GeometryFlat> mFlatGeo{nullptr};    ///< flat TRD geometry
-  bool mUseMC{false};                                 ///< MC flag
-  float mTPCTBinMUS{.2f};                             ///< width of a TPC time bin in us
-  float mTPCTBinMUSInv{1.f / mTPCTBinMUS};            ///< inverse width of a TPC time bin in 1/us
-  float mTPCVdrift{2.58f};                            ///< TPC drift velocity (for shifting TPC tracks along Z)
+  o2::gpu::GPUTRDTracker* mTracker{nullptr};                     ///< TRD tracking engine
+  o2::gpu::GPUReconstruction* mRec{nullptr};                     ///< GPU reconstruction pointer, handles memory for the tracker
+  o2::gpu::GPUChainTracking* mChainTracking{nullptr};            ///< TRD tracker is run in the tracking chain
+  std::unique_ptr<GeometryFlat> mFlatGeo{nullptr};               ///< flat TRD geometry
+  bool mUseMC{false};                                            ///< MC flag
+  bool mWithPID{false};                                          ///< PID flag
+  float mTPCTBinMUS{.2f};                                        ///< width of a TPC time bin in us
+  float mTPCTBinMUSInv{1.f / mTPCTBinMUS};                       ///< inverse width of a TPC time bin in 1/us
+  float mTPCVdrift{2.58f};                                       ///< TPC drift velocity (for shifting TPC tracks along Z)
   std::shared_ptr<o2::globaltracking::DataRequest> mDataRequest; ///< seeding input (TPC-only, ITS-TPC or both)
   std::shared_ptr<o2::base::GRPGeomRequest> mGGCCDBRequest;
   o2::tpc::VDriftHelper mTPCVDriftHelper{};
   o2::tpc::CorrectionMapsLoader mTPCCorrMapsLoader{};
-  o2::dataformats::GlobalTrackID::mask_t mTrkMask;               ///< seeding track sources (TPC, ITS-TPC)
-  bool mTrigRecFilter{false};                                    ///< if true, TRD trigger records without matching ITS IR are filtered out
-  bool mStrict{false};                                           ///< preliminary matching in strict mode
+  o2::dataformats::GlobalTrackID::mask_t mTrkMask; ///< seeding track sources (TPC, ITS-TPC)
+  bool mTrigRecFilter{false};                      ///< if true, TRD trigger records without matching ITS IR are filtered out
+  bool mStrict{false};                             ///< preliminary matching in strict mode
   TStopwatch mTimer;
   // temporary members -> should go into processor (GPUTRDTracker or additional refit processor?)
   std::unique_ptr<o2::gpu::GPUO2InterfaceRefit> mTPCRefitter;         ///< TPC refitter used for TPC tracks refit during the reconstruction
@@ -90,10 +93,14 @@ class TRDGlobalTracking : public o2::framework::Task
   gsl::span<const int> mITSABTrackClusIdx;                            ///< input ITSAB track cluster indices span
   std::vector<o2::BaseCluster<float>> mITSClustersArray;              ///< ITS clusters created in run() method from compact clusters
   const o2::itsmft::TopologyDictionary* mITSDict = nullptr;           ///< cluster patterns dictionary
+
+  // PID
+  PIDPolicy mPolicy{PIDPolicy::DEFAULT}; ///< Model to load an evaluate
+  std::unique_ptr<PIDBase> mBase;        ///< PID engine
 };
 
 /// create a processor spec
-framework::DataProcessorSpec getTRDGlobalTrackingSpec(bool useMC, o2::dataformats::GlobalTrackID::mask_t src, bool trigRecFilterActive, bool strict = false);
+framework::DataProcessorSpec getTRDGlobalTrackingSpec(bool useMC, o2::dataformats::GlobalTrackID::mask_t src, bool trigRecFilterActive, bool strict = false, bool withPID = false, PIDPolicy policy = PIDPolicy::DEFAULT);
 
 } // namespace trd
 } // namespace o2

--- a/Detectors/TRD/workflow/io/src/TRDTrackReaderSpec.cxx
+++ b/Detectors/TRD/workflow/io/src/TRDTrackReaderSpec.cxx
@@ -113,7 +113,6 @@ DataProcessorSpec getTRDGlobalTrackReaderSpec(bool useMC)
   std::vector<OutputSpec> outputs;
   outputs.emplace_back(o2::header::gDataOriginTRD, "MATCH_ITSTPC", 0, Lifetime::Timeframe);
   outputs.emplace_back(o2::header::gDataOriginTRD, "TRGREC_ITSTPC", 0, Lifetime::Timeframe);
-
   if (useMC) {
     outputs.emplace_back(o2::header::gDataOriginTRD, "MCLB_ITSTPC", 0, Lifetime::Timeframe);
     outputs.emplace_back(o2::header::gDataOriginTRD, "MCLB_ITSTPC_TRD", 0, Lifetime::Timeframe);

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -217,7 +217,7 @@ DECLARE_SOA_COLUMN(TPCNClsFindable, tpcNClsFindable, uint8_t);                  
 DECLARE_SOA_COLUMN(TPCNClsFindableMinusFound, tpcNClsFindableMinusFound, int8_t);             //! TPC Clusters: Findable - Found
 DECLARE_SOA_COLUMN(TPCNClsFindableMinusCrossedRows, tpcNClsFindableMinusCrossedRows, int8_t); //! TPC Clusters: Findable - crossed rows
 DECLARE_SOA_COLUMN(TPCNClsShared, tpcNClsShared, uint8_t);                                    //! Number of shared TPC clusters
-DECLARE_SOA_COLUMN(TRDPattern, trdPattern, uint8_t);                                          //! Contributor to the track on TRD layer in bits 0-5, starting from the innermost
+DECLARE_SOA_COLUMN(TRDPattern, trdPattern, uint8_t);                                          //! Contributor to the track on TRD layer in bits 0-5, starting from the innermost, bit 6 indicates a potentially split tracklet, bit 7 if the track crossed a padrow
 DECLARE_SOA_COLUMN(ITSChi2NCl, itsChi2NCl, float);                                            //! Chi2 / cluster for the ITS track segment
 DECLARE_SOA_COLUMN(TPCChi2NCl, tpcChi2NCl, float);                                            //! Chi2 / cluster for the TPC track segment
 DECLARE_SOA_COLUMN(TRDChi2, trdChi2, float);                                                  //! Chi2 for the TRD track segment

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -223,7 +223,7 @@ DECLARE_SOA_COLUMN(TPCChi2NCl, tpcChi2NCl, float);                              
 DECLARE_SOA_COLUMN(TRDChi2, trdChi2, float);                                                  //! Chi2 for the TRD track segment
 DECLARE_SOA_COLUMN(TOFChi2, tofChi2, float);                                                  //! Chi2 for the TOF track segment
 DECLARE_SOA_COLUMN(TPCSignal, tpcSignal, float);                                              //! dE/dx signal in the TPC
-DECLARE_SOA_COLUMN(TRDSignal, trdSignal, float);                                              //! dE/dx signal in the TRD
+DECLARE_SOA_COLUMN(TRDSignal, trdSignal, float);                                              //! PID signal in the TRD
 DECLARE_SOA_COLUMN(Length, length, float);                                                    //! Track length
 DECLARE_SOA_COLUMN(TOFExpMom, tofExpMom, float);                                              //! TOF expected momentum obtained in tracking, used to compute the expected times
 DECLARE_SOA_COLUMN(TrackEtaEMCAL, trackEtaEmcal, float);                                      //!

--- a/GPU/GPUTracking/DataTypes/GPUTRDTrack.cxx
+++ b/GPU/GPUTracking/DataTypes/GPUTRDTrack.cxx
@@ -31,6 +31,7 @@ GPUd() void GPUTRDTrack_t<T>::initialize()
 {
   // set all members to their default values (needed since in-class initialization not possible with AliRoot)
   mChi2 = 0.f;
+  mSignal = -1.f;
   mRefGlobalTrackId = 0;
   mCollisionId = -1;
   mFlags = 0;
@@ -82,6 +83,7 @@ GPUd() void GPUTRDTrack_t<T>::ConvertFrom(const GPUTRDTrackDataRecord& t)
   T::set(t.fX, t.mAlpha, &(t.fY), t.fC);
   setRefGlobalTrackIdRaw(t.fTPCTrackID);
   mChi2 = 0.f;
+  mSignal = -1.f;
   mFlags = 0;
   mIsCrossingNeighbor = 0;
   mCollisionId = -1;
@@ -112,7 +114,7 @@ GPUd() GPUTRDTrack_t<T>::GPUTRDTrack_t(const o2::tpc::TrackTPC& t) : T(t)
 
 template <typename T>
 GPUd() GPUTRDTrack_t<T>::GPUTRDTrack_t(const GPUTRDTrack_t<T>& t)
-  : T(t), mChi2(t.mChi2), mRefGlobalTrackId(t.mRefGlobalTrackId), mCollisionId(t.mCollisionId), mFlags(t.mFlags), mIsCrossingNeighbor(t.mIsCrossingNeighbor)
+  : T(t), mChi2(t.mChi2), mSignal(t.mSignal), mRefGlobalTrackId(t.mRefGlobalTrackId), mCollisionId(t.mCollisionId), mFlags(t.mFlags), mIsCrossingNeighbor(t.mIsCrossingNeighbor)
 {
   // copy constructor
   for (int i = 0; i < kNLayers; ++i) {
@@ -136,6 +138,7 @@ GPUd() GPUTRDTrack_t<T>& GPUTRDTrack_t<T>::operator=(const GPUTRDTrack_t<T>& t)
   }
   *(T*)this = t;
   mChi2 = t.mChi2;
+  mSignal = t.mSignal;
   mRefGlobalTrackId = t.mRefGlobalTrackId;
   mCollisionId = t.mCollisionId;
   mFlags = t.mFlags;

--- a/GPU/GPUTracking/DataTypes/GPUTRDTrack.h
+++ b/GPU/GPUTracking/DataTypes/GPUTRDTrack.h
@@ -97,6 +97,7 @@ class GPUTRDTrack_t : public T
   }
 
   GPUd() float getChi2() const { return mChi2; }
+  GPUd() float getSignal() const { return mSignal; }
   GPUd() unsigned char getIsCrossingNeighbor() const { return mIsCrossingNeighbor; }
   GPUd() bool getIsCrossingNeighbor(int iLayer) const { return mIsCrossingNeighbor & (1 << iLayer); }
   GPUd() bool getHasNeighbor() const { return mIsCrossingNeighbor & (1 << 6); }
@@ -121,6 +122,7 @@ class GPUTRDTrack_t : public T
   GPUd() void setIsStopped() { mFlags |= (1U << kStopFlag); }
   GPUd() void setIsAmbiguous() { mFlags |= (1U << kAmbiguousFlag); }
   GPUd() void setChi2(float chi2) { mChi2 = chi2; }
+  GPUd() void setSignal(float signal) { mSignal = signal; }
   GPUd() void setIsCrossingNeighbor(int iLayer) { mIsCrossingNeighbor |= (1U << iLayer); }
   GPUd() void setHasNeighbor() { mIsCrossingNeighbor |= (1U << 6); }
   GPUd() void setHasPadrowCrossing() { mIsCrossingNeighbor |= (1U << 7); }
@@ -131,6 +133,7 @@ class GPUTRDTrack_t : public T
 
  protected:
   float mChi2;                       // total chi2.
+  float mSignal{-1.f};               // electron Likelihood for track
   unsigned int mRefGlobalTrackId;    // raw GlobalTrackID of the seeding track (either ITS-TPC or TPC)
   int mAttachedTracklets[kNLayers];  // indices of the tracklets attached to this track; -1 means no tracklet in that layer
   short mCollisionId;                // the collision ID of the tracklets attached to this track; is used to retrieve the BC information for this track after the tracking is done
@@ -140,7 +143,7 @@ class GPUTRDTrack_t : public T
  private:
   GPUd() void initialize();
 #if !defined(GPUCA_STANDALONE) && !defined(GPUCA_ALIROOT_LIB)
-  ClassDefNV(GPUTRDTrack_t, 3);
+  ClassDefNV(GPUTRDTrack_t, 4);
 #endif
 };
 


### PR DESCRIPTION

This adds PID calculations directly to the trd-tracking workflow without creating other DPL devices.
As discussed with @shahor02 the PID value is now part of TrackTRD.
A Dummy object is provided which returns always -1.f as suggested by @martenole.
This is currently the default since no objects are currently in alice-ccdb.

Supersedes #10501 