### PR TITLE
CTP: trigger offsets

### DIFF
--- a/DataFormats/common/include/CommonDataFormat/InteractionRecord.h
+++ b/DataFormats/common/include/CommonDataFormat/InteractionRecord.h
@@ -198,7 +198,7 @@ struct InteractionRecord {
     // bc self-addition operator, no check for orbit wrap
     auto l = toLong() + dbc;
     if (l < 0) {
-      l += InteractionRecord(3564, 0xffffffff).toLong();
+      l += InteractionRecord(DummyBC, MaxGlobalBCs + 1ll).toLong();
     }
     bc = l % o2::constants::lhc::LHCMaxBunches;
     orbit = l / o2::constants::lhc::LHCMaxBunches;

--- a/DataFormats/common/include/CommonDataFormat/InteractionRecord.h
+++ b/DataFormats/common/include/CommonDataFormat/InteractionRecord.h
@@ -197,6 +197,9 @@ struct InteractionRecord {
   {
     // bc self-addition operator, no check for orbit wrap
     auto l = toLong() + dbc;
+    if(l < 0) {
+      l += InteractionRecord(3564,0xffffffff).toLong();
+    }
     bc = l % o2::constants::lhc::LHCMaxBunches;
     orbit = l / o2::constants::lhc::LHCMaxBunches;
     return *this;

--- a/DataFormats/common/include/CommonDataFormat/InteractionRecord.h
+++ b/DataFormats/common/include/CommonDataFormat/InteractionRecord.h
@@ -198,7 +198,7 @@ struct InteractionRecord {
     // bc self-addition operator, no check for orbit wrap
     auto l = toLong() + dbc;
     if (l < 0) {
-      l += InteractionRecord(DummyBC, MaxGlobalBCs + 1ll).toLong();
+      l += MaxGlobalBCs;
     }
     bc = l % o2::constants::lhc::LHCMaxBunches;
     orbit = l / o2::constants::lhc::LHCMaxBunches;

--- a/DataFormats/common/include/CommonDataFormat/InteractionRecord.h
+++ b/DataFormats/common/include/CommonDataFormat/InteractionRecord.h
@@ -197,8 +197,8 @@ struct InteractionRecord {
   {
     // bc self-addition operator, no check for orbit wrap
     auto l = toLong() + dbc;
-    if(l < 0) {
-      l += InteractionRecord(3564,0xffffffff).toLong();
+    if (l < 0) {
+      l += InteractionRecord(3564, 0xffffffff).toLong();
     }
     bc = l % o2::constants::lhc::LHCMaxBunches;
     orbit = l / o2::constants::lhc::LHCMaxBunches;

--- a/Detectors/Base/include/DetectorsBase/CTFCoderBase.h
+++ b/Detectors/Base/include/DetectorsBase/CTFCoderBase.h
@@ -34,7 +34,7 @@
 
 namespace o2
 {
-namespace frameworkT
+namespace framework
 {
 class ProcessingContext;
 }

--- a/Detectors/Base/include/DetectorsBase/CTFCoderBase.h
+++ b/Detectors/Base/include/DetectorsBase/CTFCoderBase.h
@@ -34,7 +34,7 @@
 
 namespace o2
 {
-namespace framework
+namespace frameworkT
 {
 class ProcessingContext;
 }

--- a/Detectors/CTP/workflow/include/CTPWorkflow/RawDecoderSpec.h
+++ b/Detectors/CTP/workflow/include/CTPWorkflow/RawDecoderSpec.h
@@ -19,6 +19,7 @@
 #include "Framework/Task.h"
 #include "DataFormatsCTP/Digits.h"
 #include "DataFormatsCTP/LumiInfo.h"
+#include "DataFormatsCTP/TriggerOffsetsParam.h"
 
 namespace o2
 {

--- a/Detectors/CTP/workflow/src/RawDecoderSpec.cxx
+++ b/Detectors/CTP/workflow/src/RawDecoderSpec.cxx
@@ -259,7 +259,7 @@ int RawDecoderSpec::addCTPDigit(uint32_t linkCRU, uint32_t triggerOrbit, gbtword
   const gbtword80_t bcidmask = 0xfff;
   uint16_t bcid = (diglet & bcidmask).to_ulong();
   // LOG(info) << bcid << "    pld:" << pld;
-  o2::InteractionRecord ir = {bcid,triggerOrbit};
+  o2::InteractionRecord ir = {bcid, triggerOrbit};
   int32_t BCShiftCorrection = o2::ctp::TriggerOffsetsParam::Instance().customOffset[o2::detectors::DetID::CTP];
   if (linkCRU == o2::ctp::GBTLinkIDIntRec) {
     LOG(info) << "ir ori:" << ir;

--- a/Detectors/CTP/workflow/src/RawDecoderSpec.cxx
+++ b/Detectors/CTP/workflow/src/RawDecoderSpec.cxx
@@ -263,13 +263,19 @@ int RawDecoderSpec::addCTPDigit(uint32_t linkCRU, uint32_t triggerOrbit, gbtword
   int32_t BCShiftCorrection = o2::ctp::TriggerOffsetsParam::Instance().customOffset[o2::detectors::DetID::CTP];
   if (linkCRU == o2::ctp::GBTLinkIDIntRec) {
     LOG(debug) << "InputMaskCount:" << digits[ir].CTPInputMask.count();
-    if (bcid > BCShiftCorrection) {
-      ir.bc = bcid - BCShiftCorrection;
-      ir.orbit = triggerOrbit;
-    } else {
-      ir.bc = (bcid + 3564) - BCShiftCorrection;
-      ir.orbit = triggerOrbit - 1;
+    bcid = bcid - BCShiftCorrection;
+    int32_t orbitCorrection = 0;
+    if(bcid < 0) {
+      bcid = bcid % 3564;
+      bcid += 3564;
+      orbitCorrection = -1;
     }
+    if(bcid > 3564) {
+      bcid = bcid % 3564;
+      orbitCorrection = 1;
+    }
+    ir.bc = bcid;
+    ir.orbit = triggerOrbit + orbitCorrection;
     digit.intRecord = ir;
     LOG(debug) << "IR bcid:" << ir.bc << " orbit:" << ir.orbit << " pld:" << pld;
     if (digits.count(ir) == 0) {
@@ -288,13 +294,20 @@ int RawDecoderSpec::addCTPDigit(uint32_t linkCRU, uint32_t triggerOrbit, gbtword
     }
   } else if (linkCRU == o2::ctp::GBTLinkIDClassRec) {
     uint32_t offset = BCShiftCorrection + o2::ctp::TriggerOffsetsParam::Instance().LM_L0 + o2::ctp::TriggerOffsetsParam::Instance().L0_L1 - 1;
-    if (bcid > offset) {
-      ir.bc = bcid - offset;
-      ir.orbit = triggerOrbit;
-    } else {
-      ir.bc = (bcid + 3564) - offset;
-      ir.orbit = triggerOrbit - 1;
+    bcid = bcid - offset;
+    int32_t orbitCorrection = 0;
+    if(bcid < 0) {
+      bcid = bcid % 3564;
+      bcid += 3564;
+      orbitCorrection = -1;
     }
+    if(bcid > 3564) {
+      bcid = bcid % 3564;
+      orbitCorrection = 1;
+    }
+    ir.bc = bcid;
+    ir.orbit = triggerOrbit + orbitCorrection;
+    LOG(debug) << "bc ori:" << (diglet & bcidmask).to_ulong() << " corrected:" << ir.bc << " orbit correction:" << orbitCorrection;
     digit.intRecord = ir;
     if (digits.count(ir) == 0) {
       digit.setClassMask(pld);

--- a/Detectors/CTP/workflow/src/RawDecoderSpec.cxx
+++ b/Detectors/CTP/workflow/src/RawDecoderSpec.cxx
@@ -257,25 +257,15 @@ int RawDecoderSpec::addCTPDigit(uint32_t linkCRU, uint32_t triggerOrbit, gbtword
   pld >>= 12;
   CTPDigit digit;
   const gbtword80_t bcidmask = 0xfff;
-  int32_t bcid = (diglet & bcidmask).to_ulong();
+  uint16_t bcid = (diglet & bcidmask).to_ulong();
   // LOG(info) << bcid << "    pld:" << pld;
-  o2::InteractionRecord ir;
+  o2::InteractionRecord ir = {bcid,triggerOrbit};
   int32_t BCShiftCorrection = o2::ctp::TriggerOffsetsParam::Instance().customOffset[o2::detectors::DetID::CTP];
   if (linkCRU == o2::ctp::GBTLinkIDIntRec) {
+    LOG(info) << "ir ori:" << ir;
     LOG(debug) << "InputMaskCount:" << digits[ir].CTPInputMask.count();
-    bcid = bcid - BCShiftCorrection;
-    int32_t orbitCorrection = 0;
-    if (bcid < 0) {
-      bcid = bcid % 3564;
-      bcid += 3564;
-      orbitCorrection = -1;
-    }
-    if (bcid > 3564) {
-      bcid = bcid % 3564;
-      orbitCorrection = 1;
-    }
-    ir.bc = bcid;
-    ir.orbit = triggerOrbit + orbitCorrection;
+    ir -= BCShiftCorrection;
+    LOG(info) << "ir corrected:" << ir;
     digit.intRecord = ir;
     LOG(debug) << "IR bcid:" << ir.bc << " orbit:" << ir.orbit << " pld:" << pld;
     if (digits.count(ir) == 0) {
@@ -294,20 +284,9 @@ int RawDecoderSpec::addCTPDigit(uint32_t linkCRU, uint32_t triggerOrbit, gbtword
     }
   } else if (linkCRU == o2::ctp::GBTLinkIDClassRec) {
     uint32_t offset = BCShiftCorrection + o2::ctp::TriggerOffsetsParam::Instance().LM_L0 + o2::ctp::TriggerOffsetsParam::Instance().L0_L1 - 1;
-    bcid = bcid - offset;
-    int32_t orbitCorrection = 0;
-    if (bcid < 0) {
-      bcid = bcid % 3564;
-      bcid += 3564;
-      orbitCorrection = -1;
-    }
-    if (bcid > 3564) {
-      bcid = bcid % 3564;
-      orbitCorrection = 1;
-    }
-    ir.bc = bcid;
-    ir.orbit = triggerOrbit + orbitCorrection;
-    LOG(debug) << "bc ori:" << (diglet & bcidmask).to_ulong() << " corrected:" << ir.bc << " orbit correction:" << orbitCorrection;
+    LOG(info) << "ir ori:" << ir;
+    ir -= offset;
+    LOG(info) << "ir corrected:" << ir;
     digit.intRecord = ir;
     if (digits.count(ir) == 0) {
       digit.setClassMask(pld);

--- a/Detectors/CTP/workflow/src/RawDecoderSpec.cxx
+++ b/Detectors/CTP/workflow/src/RawDecoderSpec.cxx
@@ -263,9 +263,9 @@ int RawDecoderSpec::addCTPDigit(uint32_t linkCRU, uint32_t triggerOrbit, gbtword
   int32_t BCShiftCorrection = o2::ctp::TriggerOffsetsParam::Instance().customOffset[o2::detectors::DetID::CTP];
   if (linkCRU == o2::ctp::GBTLinkIDIntRec) {
     LOG(debug) << "InputMaskCount:" << digits[ir].CTPInputMask.count();
-    if(bcid > BCShiftCorrection) {
-       ir.bc = bcid - BCShiftCorrection;
-       ir.orbit = triggerOrbit;
+    if (bcid > BCShiftCorrection) {
+      ir.bc = bcid - BCShiftCorrection;
+      ir.orbit = triggerOrbit;
     } else {
       ir.bc = (bcid + 3564) - BCShiftCorrection;
       ir.orbit = triggerOrbit - 1;
@@ -288,9 +288,9 @@ int RawDecoderSpec::addCTPDigit(uint32_t linkCRU, uint32_t triggerOrbit, gbtword
     }
   } else if (linkCRU == o2::ctp::GBTLinkIDClassRec) {
     uint32_t offset = BCShiftCorrection + o2::ctp::TriggerOffsetsParam::Instance().LM_L0 + o2::ctp::TriggerOffsetsParam::Instance().L0_L1 - 1;
-    if(bcid > offset) {
-       ir.bc = bcid - offset;
-       ir.orbit = triggerOrbit;
+    if (bcid > offset) {
+      ir.bc = bcid - offset;
+      ir.orbit = triggerOrbit;
     } else {
       ir.bc = (bcid + 3564) - offset;
       ir.orbit = triggerOrbit - 1;

--- a/Detectors/CTP/workflow/src/RawDecoderSpec.cxx
+++ b/Detectors/CTP/workflow/src/RawDecoderSpec.cxx
@@ -265,12 +265,12 @@ int RawDecoderSpec::addCTPDigit(uint32_t linkCRU, uint32_t triggerOrbit, gbtword
     LOG(debug) << "InputMaskCount:" << digits[ir].CTPInputMask.count();
     bcid = bcid - BCShiftCorrection;
     int32_t orbitCorrection = 0;
-    if(bcid < 0) {
+    if (bcid < 0) {
       bcid = bcid % 3564;
       bcid += 3564;
       orbitCorrection = -1;
     }
-    if(bcid > 3564) {
+    if (bcid > 3564) {
       bcid = bcid % 3564;
       orbitCorrection = 1;
     }
@@ -296,12 +296,12 @@ int RawDecoderSpec::addCTPDigit(uint32_t linkCRU, uint32_t triggerOrbit, gbtword
     uint32_t offset = BCShiftCorrection + o2::ctp::TriggerOffsetsParam::Instance().LM_L0 + o2::ctp::TriggerOffsetsParam::Instance().L0_L1 - 1;
     bcid = bcid - offset;
     int32_t orbitCorrection = 0;
-    if(bcid < 0) {
+    if (bcid < 0) {
       bcid = bcid % 3564;
       bcid += 3564;
       orbitCorrection = -1;
     }
-    if(bcid > 3564) {
+    if (bcid > 3564) {
       bcid = bcid % 3564;
       orbitCorrection = 1;
     }

--- a/Detectors/CTP/workflowScalers/py/createCnts.py
+++ b/Detectors/CTP/workflowScalers/py/createCnts.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import zmq
 import random
 import sys
@@ -12,17 +13,6 @@ run = "527345"
 path = "/home/rl/counters/"
 filename = path + "20221014.cc"
 filecfg = path + run + ".rcfg"
-#
-if len(sys.argv) == 2:
-  run =  sys.argv[1]
-  int(run)
-elif len(sys.argv) == 3:
-  port =  sys.argv[1]
-  int(port)
-  print("port:", port)
-print("run:", run)
-#
-
 # CTP Config
 def sendctpconfig(starttime):
   print("starttime:",starttime)
@@ -46,14 +36,16 @@ def senddata(header, messagedata):
   socket.send_multipart(msg)
   time.sleep(1)
 ##########################
-#
-f = open(filename,"r")
-#
-n = 0
-start = time.time()
-runcnts = []
-runactive = 0
-while True:
+def getRunCounters():
+  print("searching for run:",run," in ",filename)
+  #
+  f = open(filename,"r")
+  #
+  n = 0
+  start = time.time()
+  runcnts = []
+  runactive = 0
+  while True:
     line = f.readline()
     if not line:
       break
@@ -71,16 +63,76 @@ while True:
       runcnts.append(line)
       runactive = 0
       print("0:",line[0:20])
-
-print("runcnts size:", len(runcnts))
-starttime = runcnts[0].split(" ",1)[0]
-#
-sendctpconfig(starttime)
-time.sleep(5)
-senddata("sox",runcnts[0])
-for line in runcnts[1:-1]:
-  senddata("ctpd",line)
-senddata("eox",runcnts[-1])
-
-
+  print("runcnts size:", len(runcnts))
+  return runcnts
+def replyScalers():
+  runcnts = getRunCounters()
+  starttime = runcnts[0].split(" ",1)[0]
+  #
+  sendctpconfig(starttime)
+  time.sleep(5)
+  senddata("sox",runcnts[0])
+  for line in runcnts[1:-1]:
+    senddata("ctpd",line)
+  senddata("eox",runcnts[-1])
+def getIndexesForScalers(scalers):
+  fileinpnames = "scalersCTP_v2.txt"
+  f = open(fileinpnames,"r")
+  lines = []
+  while True:
+    line = f.readline()
+    l=line[8:].split('"')
+    #print(l)
+    lines.append(l[0])
+    if not line:
+      break
+  #for l in lines: print(l)
+  indeces = []
+  for s in scalers:
+    i = lines.index(s)
+    print(i,lines[i])
+    indeces.append(i)
+  return indeces
+def getInputs(run):
+  global path,filename
+  dd=1
+  filename = path+"20221118.cc"
+  #filename = path+"20221119.cc"
+  rcnts = getRunCounters()
+  inputs = ['inp3','inp4','inp5','inp25','inp26']
+  indeces = getIndexesForScalers(inputs)
+  inpcnts = {}
+  overflow = {}
+  scals0 = rcnts[0].split()
+  #print(scals0[indeces[0]])
+  #print(rcnts[0])
+  #return
+  for i in indeces:
+    inpcnts[i] = [int(scals0[i+dd])] # +1 due to time
+    overflow[i] = 0
+  for ii in range(1,len(rcnts)):
+    for i in indeces:
+      scals = rcnts[ii].split()
+      scal = int(scals[i+dd])
+      if inpcnts[i][ii-1] > scal:
+        overflow[i] += 1
+        print("overflow in ",i, " at ",ii)
+      inpcnts[i].append(scal +overflow[i])
+  for i in indeces:
+    print(i,":",inpcnts[i][len(inpcnts[i])-1]-inpcnts[i][0])
+  #print(inpcnts)
+if __name__ == "__main__":
+  #
+  if len(sys.argv) == 2:
+    run =  sys.argv[1]
+    #int(run)
+    print("run:",run)
+  elif len(sys.argv) == 3:
+    port =  sys.argv[1]
+    int(port)
+    print("port:", port)
+    print("run:", run)
+  #
+  #replyScalers()
+  getInputs(run)
 


### PR DESCRIPTION
Trigger offsets are to be applied both for interaction record (inputs) and trigger class record.
For LM inputs offset should be zero (although in PbPB some inputs eg TVX were shifted by 1)
For L0/L1 inputs we need to agree if to shift them to LM or do nothing , e.g. leave it for analysers
For trigger class to be shifted to LM , the shift should be LM-L0 + L0-L1 + internal offset.
Internal offsets is due s to CTP firmware . It is couple of BC - I will find it.

For test run:
o2-raw-tf-reader-workflow -b --onlyDet CTP --input-data list0_19.txt  | o2-ctp-reco-workflow -b  --use-verbose-mode  --configKeyValues "TriggerOffsetsParam.customOffset[16]=-1"