### PR TITLE
add general/static methods to deal with matching pair candidate

### DIFF
--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/MatchInfoTOFReco.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/MatchInfoTOFReco.h
@@ -39,12 +39,17 @@ class MatchInfoTOFReco : public MatchInfoTOF
 
   MatchInfoTOFReco() = default;
 
+  void setFakeMatch() { mFakeMC = true; }
+  void resetFakeMatch() { mFakeMC = false; }
+  bool isFake() const { return mFakeMC; }
+
   void setTrackType(TrackType value) { mTrackType = value; }
   TrackType getTrackType() const { return mTrackType; }
 
  private:
   TrackType mTrackType; ///< track type (TPC, ITSTPC, TPCTRD, ITSTPCTRD)
-  ClassDefNV(MatchInfoTOFReco, 2);
+  bool mFakeMC = false;
+  ClassDefNV(MatchInfoTOFReco, 3);
 };
 } // namespace dataformats
 } // namespace o2

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTOF.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTOF.h
@@ -171,7 +171,7 @@ class MatchTOF
   }
 
   void setFIT(bool value = true) { mIsFIT = value; }
-  int findFITIndex(int bc);
+  static int findFITIndex(int bc, const gsl::span<const o2::ft0::RecPoints>& FITRecPoints);
 
   void checkRefitter();
   bool makeConstrainedTPCTrack(int matchedID, o2::dataformats::TrackTPCTOF& trConstr);
@@ -194,6 +194,9 @@ class MatchTOF
   void setTS(unsigned long creationTime) { mTimestamp = creationTime; }
   unsigned long getTS() const { return mTimestamp; }
 
+  static void grouppingMatch(std::vector<o2::dataformats::MatchInfoTOFReco> origin, std::vector<std::vector<o2::dataformats::MatchInfoTOFReco>>& groupped);
+  static void printGroupping(const std::vector<o2::dataformats::MatchInfoTOFReco>& origin, const std::vector<std::vector<o2::dataformats::MatchInfoTOFReco>>& groupped);
+
  private:
   bool prepareFITData();
   int prepareInteractionTimes();
@@ -209,7 +212,8 @@ class MatchTOF
   void doMatching(int sec);
   void doMatchingForTPC(int sec);
   void selectBestMatches();
-  void selectBestMatchesHP();
+  static void BestMatches(std::vector<o2::dataformats::MatchInfoTOFReco>& matchedTracksPairs, std::vector<o2::dataformats::MatchInfoTOF>* matchedTracks, std::vector<int>* matchedTracksIndex, int* matchedClustersIndex, const gsl::span<const o2::ft0::RecPoints>& FITRecPoints, const std::vector<Cluster>& TOFClusWork, const std::vector<matchTrack>* TracksWork, std::vector<o2::dataformats::CalibInfoTOF>& CalibInfoTOF, unsigned long Timestamp, bool MCTruthON, const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* TOFClusLabels, const std::vector<o2::MCCompLabel>* TracksLblWork, std::vector<o2::MCCompLabel>* OutTOFLabels, float calibMaxChi2);
+  static void BestMatchesHP(std::vector<o2::dataformats::MatchInfoTOFReco>& matchedTracksPairs, std::vector<o2::dataformats::MatchInfoTOF>* matchedTracks, std::vector<int>* matchedTracksIndex, int* matchedClustersIndex, const gsl::span<const o2::ft0::RecPoints>& FITRecPoints, const std::vector<Cluster>& TOFClusWork, std::vector<o2::dataformats::CalibInfoTOF>& CalibInfoTOF, unsigned long Timestamp, bool MCTruthON, const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* TOFClusLabels, const std::vector<o2::MCCompLabel>* TracksLblWork, std::vector<o2::MCCompLabel>* OutTOFLabels);
   bool propagateToRefX(o2::track::TrackParCov& trc, float xRef /*in cm*/, float stepInCm /*in cm*/, o2::track::TrackLTIntegral& intLT);
   bool propagateToRefXWithoutCov(o2::track::TrackParCov& trc, float xRef /*in cm*/, float stepInCm /*in cm*/, float bz);
 

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTOF.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTOF.h
@@ -147,6 +147,8 @@ class MatchTOF
   std::vector<o2::dataformats::MatchInfoTOF>& getMatchedTrackVector(trkType index) { return mMatchedTracks[index]; }
   std::vector<o2::dataformats::CalibInfoTOF>& getCalibVector() { return mCalibInfoTOF; }
 
+  std::vector<o2::dataformats::MatchInfoTOFReco>& getMatchedTracksPair(int sec) { return mMatchedTracksPairsSec[sec]; }
+
   std::vector<o2::MCCompLabel>& getMatchedTOFLabelsVector(trkType index) { return mOutTOFLabels[index]; } ///< get vector of TOF labels of matched tracks
 
   void setTPCVDrift(const o2::tpc::VDriftCorrFact& v);
@@ -194,8 +196,10 @@ class MatchTOF
   void setTS(unsigned long creationTime) { mTimestamp = creationTime; }
   unsigned long getTS() const { return mTimestamp; }
 
-  static void grouppingMatch(std::vector<o2::dataformats::MatchInfoTOFReco> origin, std::vector<std::vector<o2::dataformats::MatchInfoTOFReco>>& groupped);
-  static void printGroupping(const std::vector<o2::dataformats::MatchInfoTOFReco>& origin, const std::vector<std::vector<o2::dataformats::MatchInfoTOFReco>>& groupped);
+  static void groupingMatch(std::vector<o2::dataformats::MatchInfoTOFReco> origin, std::vector<std::vector<o2::dataformats::MatchInfoTOFReco>>& grouped, std::vector<std::vector<int>>& firstEls, std::vector<std::vector<int>>& secondEls);
+  static void printGrouping(const std::vector<o2::dataformats::MatchInfoTOFReco>& origin, const std::vector<std::vector<o2::dataformats::MatchInfoTOFReco>>& grouped);
+
+  void storeMatchable(bool val = true) { mStoreMatchable = val; }
 
  private:
   bool prepareFITData();
@@ -261,6 +265,7 @@ class MatchTOF
   bool mIsTPCTRDused = false;
   bool mIsITSTPCTRDused = false;
   bool mSetHighPurity = false;
+  bool mStoreMatchable = false;
 
   unsigned long mTimestamp = 0; ///< in ms
 
@@ -305,6 +310,7 @@ class MatchTOF
 
   ///<array of track-TOFCluster pairs from the matching
   std::vector<o2::dataformats::MatchInfoTOFReco> mMatchedTracksPairs;
+  std::vector<o2::dataformats::MatchInfoTOFReco> mMatchedTracksPairsSec[o2::constants::math::NSectors];
 
   ///<array of TOFChannel calibration info
   std::vector<o2::dataformats::CalibInfoTOF> mCalibInfoTOF;

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTOF.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTOF.h
@@ -196,7 +196,7 @@ class MatchTOF
   void setTS(unsigned long creationTime) { mTimestamp = creationTime; }
   unsigned long getTS() const { return mTimestamp; }
 
-  static void groupingMatch(std::vector<o2::dataformats::MatchInfoTOFReco> origin, std::vector<std::vector<o2::dataformats::MatchInfoTOFReco>>& grouped, std::vector<std::vector<int>>& firstEls, std::vector<std::vector<int>>& secondEls);
+  static void groupingMatch(const std::vector<o2::dataformats::MatchInfoTOFReco>& origin, std::vector<std::vector<o2::dataformats::MatchInfoTOFReco>>& grouped, std::vector<std::vector<int>>& firstEls, std::vector<std::vector<int>>& secondEls);
   static void printGrouping(const std::vector<o2::dataformats::MatchInfoTOFReco>& origin, const std::vector<std::vector<o2::dataformats::MatchInfoTOFReco>>& grouped);
 
   void storeMatchable(bool val = true) { mStoreMatchable = val; }

--- a/Detectors/GlobalTracking/src/MatchTOF.cxx
+++ b/Detectors/GlobalTracking/src/MatchTOF.cxx
@@ -208,6 +208,84 @@ int MatchTOF::prepareInteractionTimes()
   return 0;
 }
 //______________________________________________
+void MatchTOF::printGroupping(const std::vector<o2::dataformats::MatchInfoTOFReco>& origin, const std::vector<std::vector<o2::dataformats::MatchInfoTOFReco>>& groupped)
+{
+  printf("Original vector\n");
+  for (const auto& seed : origin) {
+    printf("Pair: track=%d TOFcl=%d\n", seed.getIdLocal(), seed.getTOFClIndex());
+  }
+
+  printf("\nGroups\n");
+  int ngroups = 0;
+  for (const auto& gr : groupped) {
+    ngroups++;
+    printf("Group %d\n", ngroups);
+    for (const auto& seed : gr) {
+      printf("Pair: track=%d TOFcl=%d\n", seed.getIdLocal(), seed.getTOFClIndex());
+    }
+  }
+}
+//______________________________________________
+void MatchTOF::grouppingMatch(std::vector<o2::dataformats::MatchInfoTOFReco> origin, std::vector<std::vector<o2::dataformats::MatchInfoTOFReco>>& groupped)
+{
+  groupped.clear();
+
+  std::vector<o2::dataformats::MatchInfoTOFReco> dummy;
+
+  // lists of elements in the group
+  std::vector<int> firstEls;
+  std::vector<int> secondEls;
+
+  int pos = 0;
+  while (origin.size()) { // go ahead if there are elements
+    bool found = true;
+    groupped.push_back(dummy);
+    firstEls.clear();
+    secondEls.clear();
+    // first element is the seed
+    const auto& seed = origin[0];
+    firstEls.push_back(seed.getIdLocal());
+    secondEls.push_back(seed.getTOFClIndex());
+    // remove element added to the current group
+    groupped[pos].push_back(seed);
+    origin.erase(origin.begin());
+
+    while (found) {
+      found = false;
+      for (int i = 0; i < origin.size(); i++) {
+        const auto& seed = origin[i];
+        int matchFirst = -1;
+        int matchSecond = -1;
+        for (const int& ind : firstEls) {
+          if (seed.getIdLocal() == ind) {
+            matchFirst = ind;
+            break;
+          }
+        }
+        for (const int& ind : secondEls) {
+          if (seed.getTOFClIndex() == ind) {
+            matchSecond = ind;
+            break;
+          }
+        }
+
+        if (matchFirst >= 0 || matchSecond >= 0) { // belong to this group
+          if (matchFirst < 0)
+            firstEls.push_back(seed.getIdLocal());
+          if (matchSecond < 0)
+            secondEls.push_back(seed.getTOFClIndex());
+          groupped[pos].push_back(seed);
+          origin.erase(origin.begin() + i);
+          found = true;
+          break;
+        }
+      }
+    }
+    pos++; // move to the next group
+  }
+}
+
+//______________________________________________
 bool MatchTOF::prepareTPCData()
 {
   mNotPropagatedToTOF[trkType::UNCONS] = 0;
@@ -1065,17 +1143,17 @@ void MatchTOF::doMatchingForTPC(int sec)
   return;
 }
 //______________________________________________
-int MatchTOF::findFITIndex(int bc)
+int MatchTOF::findFITIndex(int bc, const gsl::span<const o2::ft0::RecPoints>& FITRecPoints)
 {
-  if (mFITRecPoints.size() == 0) {
+  if (FITRecPoints.size() == 0) {
     return -1;
   }
 
   int index = -1;
   int distMax = 5; // require bc distance below 5
 
-  for (int i = 0; i < mFITRecPoints.size(); i++) {
-    const o2::InteractionRecord ir = mFITRecPoints[i].getInteractionRecord();
+  for (int i = 0; i < FITRecPoints.size(); i++) {
+    const o2::InteractionRecord ir = FITRecPoints[i].getInteractionRecord();
     int bct0 = ir.orbit * o2::constants::lhc::LHCMaxBunches + ir.bc;
     int dist = bc - bct0;
 
@@ -1093,29 +1171,34 @@ int MatchTOF::findFITIndex(int bc)
 void MatchTOF::selectBestMatches()
 {
   if (mSetHighPurity) {
-    selectBestMatchesHP();
+    BestMatchesHP(mMatchedTracksPairs, mMatchedTracks, mMatchedTracksIndex, mMatchedClustersIndex, mFITRecPoints, mTOFClusWork, mCalibInfoTOF, mTimestamp, mMCTruthON, mTOFClusLabels, mTracksLblWork, mOutTOFLabels);
     return;
   }
+  BestMatches(mMatchedTracksPairs, mMatchedTracks, mMatchedTracksIndex, mMatchedClustersIndex, mFITRecPoints, mTOFClusWork, mTracksWork, mCalibInfoTOF, mTimestamp, mMCTruthON, mTOFClusLabels, mTracksLblWork, mOutTOFLabels, mMatchParams->calibMaxChi2);
+}
+//______________________________________________
+void MatchTOF::BestMatches(std::vector<o2::dataformats::MatchInfoTOFReco>& matchedTracksPairs, std::vector<o2::dataformats::MatchInfoTOF>* matchedTracks, std::vector<int>* matchedTracksIndex, int* matchedClustersIndex, const gsl::span<const o2::ft0::RecPoints>& FITRecPoints, const std::vector<Cluster>& TOFClusWork, const std::vector<matchTrack>* TracksWork, std::vector<o2::dataformats::CalibInfoTOF>& CalibInfoTOF, unsigned long Timestamp, bool MCTruthON, const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* TOFClusLabels, const std::vector<o2::MCCompLabel>* TracksLblWork, std::vector<o2::MCCompLabel>* OutTOFLabels, float calibMaxChi2)
+{
   ///< define the track-TOFcluster pair per sector
 
   // first, we sort according to the chi2
-  std::sort(mMatchedTracksPairs.begin(), mMatchedTracksPairs.end(), [this](o2::dataformats::MatchInfoTOFReco& a, o2::dataformats::MatchInfoTOFReco& b) { return (a.getChi2() < b.getChi2()); });
+  std::sort(matchedTracksPairs.begin(), matchedTracksPairs.end(), [](o2::dataformats::MatchInfoTOFReco& a, o2::dataformats::MatchInfoTOFReco& b) { return (a.getChi2() < b.getChi2()); });
   int i = 0;
 
   // then we take discard the pairs if their track or cluster was already matched (since they are ordered in chi2, we will take the best matching)
-  for (const o2::dataformats::MatchInfoTOFReco& matchingPair : mMatchedTracksPairs) {
+  for (const o2::dataformats::MatchInfoTOFReco& matchingPair : matchedTracksPairs) {
     int trkType = (int)matchingPair.getTrackType();
 
     int itrk = matchingPair.getIdLocal();
 
-    if (mMatchedTracksIndex[trkType][itrk] != -1) { // the track was already filled
+    if (matchedTracksIndex[trkType][itrk] != -1) { // the track was already filled
       continue;
     }
-    if (mMatchedClustersIndex[matchingPair.getTOFClIndex()] != -1) { // the cluster was already filled
+    if (matchedClustersIndex[matchingPair.getTOFClIndex()] != -1) { // the cluster was already filled
       continue;
     }
-    mMatchedTracksIndex[trkType][itrk] = mMatchedTracks[trkType].size();                                              // index of the MatchInfoTOF correspoding to this track
-    mMatchedClustersIndex[matchingPair.getTOFClIndex()] = mMatchedTracksIndex[trkType][itrk];                         // index of the track that was matched to this cluster
+    matchedTracksIndex[trkType][itrk] = matchedTracks[trkType].size();                      // index of the MatchInfoTOF correspoding to this track
+    matchedClustersIndex[matchingPair.getTOFClIndex()] = matchedTracksIndex[trkType][itrk]; // index of the track that was matched to this cluster
 
     int trkTypeSplitted = trkType;
     auto sourceID = matchingPair.getTrackRef().getSource();
@@ -1124,22 +1207,22 @@ void MatchTOF::selectBestMatches()
     } else if (sourceID == o2::dataformats::GlobalTrackID::ITSTPCTRD) {
       trkTypeSplitted = (int)trkType::ITSTPCTRD;
     }
-    mMatchedTracks[trkTypeSplitted].push_back(matchingPair); // array of MatchInfoTOF
+    matchedTracks[trkTypeSplitted].push_back(matchingPair); // array of MatchInfoTOF
 
     // get fit info
     double t0info = 0;
 
     const o2::track::TrackLTIntegral& intLT = matchingPair.getLTIntegralOut();
 
-    if (mFITRecPoints.size() > 0) {
-      int index = findFITIndex(mTOFClusWork[matchingPair.getTOFClIndex()].getBC());
+    if (FITRecPoints.size() > 0) {
+      int index = findFITIndex(TOFClusWork[matchingPair.getTOFClIndex()].getBC(), FITRecPoints);
 
       if (index > -1) {
-        o2::InteractionRecord ir = mFITRecPoints[index].getInteractionRecord();
+        o2::InteractionRecord ir = FITRecPoints[index].getInteractionRecord();
         t0info = ir.bc2ns() * 1E3;
       }
     } else { // move time to time in orbit to avoid loss of precision when truncating from double to float
-      int bcStarOrbit = int((mTOFClusWork[matchingPair.getTOFClIndex()].getTimeRaw() - intLT.getTOF(o2::track::PID::Pion)) * o2::tof::Geo::BC_TIME_INPS_INV);
+      int bcStarOrbit = int((TOFClusWork[matchingPair.getTOFClIndex()].getTimeRaw() - intLT.getTOF(o2::track::PID::Pion)) * o2::tof::Geo::BC_TIME_INPS_INV);
       bcStarOrbit = (bcStarOrbit / o2::constants::lhc::LHCMaxBunches) * o2::constants::lhc::LHCMaxBunches; // truncation
       t0info = bcStarOrbit * o2::tof::Geo::BC_TIME_INPS;
     }
@@ -1157,9 +1240,9 @@ void MatchTOF::selectBestMatches()
     }
 
     int mask = 0;
-    float deltat = o2::tof::Utils::subtractInteractionBC(mTOFClusWork[matchingPair.getTOFClIndex()].getTimeRaw() - t0info - intLT.getTOF(o2::track::PID::Pion), mask, true);
+    float deltat = o2::tof::Utils::subtractInteractionBC(TOFClusWork[matchingPair.getTOFClIndex()].getTimeRaw() - t0info - intLT.getTOF(o2::track::PID::Pion), mask, true);
 
-    const o2::track::TrackParCov& trc = mTracksWork[trkType][itrk].first;
+    const o2::track::TrackParCov& trc = TracksWork[trkType][itrk].first;
     float pt = trc.getPt(); // from outer parameters!
 
     if (pt > 1.5) {
@@ -1174,20 +1257,20 @@ void MatchTOF::selectBestMatches()
       flags = flags | o2::dataformats::CalibInfoTOF::kNoBC;
     }
 
-    if (mTOFClusWork[matchingPair.getTOFClIndex()].getNumOfContributingChannels() != 1) {
+    if (TOFClusWork[matchingPair.getTOFClIndex()].getNumOfContributingChannels() != 1) {
       flags = flags | o2::dataformats::CalibInfoTOF::kMultiHit;
     }
 
-    if (matchingPair.getChi2() < mMatchParams->calibMaxChi2) { // extra cut in ChiSquare for storing calib info
-      mCalibInfoTOF.emplace_back(mTOFClusWork[matchingPair.getTOFClIndex()].getMainContributingChannel(),
-                                 mTimestamp / 1000 + int(mTOFClusWork[matchingPair.getTOFClIndex()].getTimeRaw() * 1E-12), // add time stamp
-                                 deltat,
-                                 mTOFClusWork[matchingPair.getTOFClIndex()].getTot(), mask, flags);
+    if (matchingPair.getChi2() < calibMaxChi2) { // extra cut in ChiSquare for storing calib info
+      CalibInfoTOF.emplace_back(TOFClusWork[matchingPair.getTOFClIndex()].getMainContributingChannel(),
+                                Timestamp / 1000 + int(TOFClusWork[matchingPair.getTOFClIndex()].getTimeRaw() * 1E-12), // add time stamp
+                                deltat,
+                                TOFClusWork[matchingPair.getTOFClIndex()].getTot(), mask, flags);
     }
 
-    if (mMCTruthON) {
-      const auto& labelsTOF = mTOFClusLabels->getLabels(matchingPair.getTOFClIndex());
-      auto& labelTrack = mTracksLblWork[trkType][itrk];
+    if (MCTruthON) {
+      const auto& labelsTOF = TOFClusLabels->getLabels(matchingPair.getTOFClIndex());
+      auto& labelTrack = TracksLblWork[trkType][itrk];
       // we have not found the track label among those associated to the TOF cluster --> fake match! We will associate the label of the main channel, but negative
       bool fake = true;
       for (auto& lbl : labelsTOF) {
@@ -1195,13 +1278,13 @@ void MatchTOF::selectBestMatches()
           fake = false;
         }
       }
-      mOutTOFLabels[trkTypeSplitted].emplace_back(labelTrack).setFakeFlag(fake);
+      OutTOFLabels[trkTypeSplitted].emplace_back(labelTrack).setFakeFlag(fake);
     }
     i++;
   }
 }
 //______________________________________________
-void MatchTOF::selectBestMatchesHP()
+void MatchTOF::BestMatchesHP(std::vector<o2::dataformats::MatchInfoTOFReco>& matchedTracksPairs, std::vector<o2::dataformats::MatchInfoTOF>* matchedTracks, std::vector<int>* matchedTracksIndex, int* matchedClustersIndex, const gsl::span<const o2::ft0::RecPoints>& FITRecPoints, const std::vector<Cluster>& TOFClusWork, std::vector<o2::dataformats::CalibInfoTOF>& CalibInfoTOF, unsigned long Timestamp, bool MCTruthON, const o2::dataformats::MCTruthContainer<o2::MCCompLabel>* TOFClusLabels, const std::vector<o2::MCCompLabel>* TracksLblWork, std::vector<o2::MCCompLabel>* OutTOFLabels)
 {
   ///< define the track-TOFcluster pair per sector
   float chi2SeparationCut = 2;
@@ -1210,41 +1293,41 @@ void MatchTOF::selectBestMatchesHP()
   std::vector<o2::dataformats::MatchInfoTOFReco> tmpMatch;
 
   // first, we sort according to the chi2
-  std::sort(mMatchedTracksPairs.begin(), mMatchedTracksPairs.end(), [this](o2::dataformats::MatchInfoTOFReco& a, o2::dataformats::MatchInfoTOFReco& b) { return (a.getChi2() < b.getChi2()); });
+  std::sort(matchedTracksPairs.begin(), matchedTracksPairs.end(), [](o2::dataformats::MatchInfoTOFReco& a, o2::dataformats::MatchInfoTOFReco& b) { return (a.getChi2() < b.getChi2()); });
   int i = 0;
   // then we take discard the pairs if their track or cluster was already matched (since they are ordered in chi2, we will take the best matching)
-  for (const o2::dataformats::MatchInfoTOFReco& matchingPair : mMatchedTracksPairs) {
+  for (const o2::dataformats::MatchInfoTOFReco& matchingPair : matchedTracksPairs) {
     int trkType = (int)matchingPair.getTrackType();
 
     int itrk = matchingPair.getIdLocal();
 
     bool discard = matchingPair.getChi2() > chi2S;
 
-    if (mMatchedTracksIndex[trkType][itrk] != -1) { // the track was already filled, check if this competitor is not too close
-      auto winnerChi = tmpMatch[mMatchedTracksIndex[trkType][itrk]].getChi2();
+    if (matchedTracksIndex[trkType][itrk] != -1) { // the track was already filled, check if this competitor is not too close
+      auto winnerChi = tmpMatch[matchedTracksIndex[trkType][itrk]].getChi2();
       if (winnerChi < 0) { // the winner was already discarded as ambiguous
         continue;
       }
       if (matchingPair.getChi2() - winnerChi < chi2SeparationCut) { // discard previously validated winner and it has too close competitor
-        tmpMatch[mMatchedTracksIndex[trkType][itrk]].setChi2(-1);
+        tmpMatch[matchedTracksIndex[trkType][itrk]].setChi2(-1);
       }
       continue;
     }
 
-    if (mMatchedClustersIndex[matchingPair.getTOFClIndex()] != -1) { // the cluster was already filled, check if this competitor is not too close
-      auto winnerChi = tmpMatch[mMatchedClustersIndex[matchingPair.getTOFClIndex()]].getChi2();
+    if (matchedClustersIndex[matchingPair.getTOFClIndex()] != -1) { // the cluster was already filled, check if this competitor is not too close
+      auto winnerChi = tmpMatch[matchedClustersIndex[matchingPair.getTOFClIndex()]].getChi2();
       if (winnerChi < 0) { // the winner was already discarded as ambiguous
         continue;
       }
       if (matchingPair.getChi2() - winnerChi < chi2SeparationCut) { // discard previously validated winner and it has too close competitor
-        tmpMatch[mMatchedClustersIndex[matchingPair.getTOFClIndex()]].setChi2(-1);
+        tmpMatch[matchedClustersIndex[matchingPair.getTOFClIndex()]].setChi2(-1);
       }
       continue;
     }
 
     if (!discard) {
-      mMatchedTracksIndex[trkType][itrk] = tmpMatch.size();                                     // index of the MatchInfoTOF correspoding to this track
-      mMatchedClustersIndex[matchingPair.getTOFClIndex()] = mMatchedTracksIndex[trkType][itrk]; // index of the track that was matched to this clus
+      matchedTracksIndex[trkType][itrk] = tmpMatch.size();                                    // index of the MatchInfoTOF correspoding to this track
+      matchedClustersIndex[matchingPair.getTOFClIndex()] = matchedTracksIndex[trkType][itrk]; // index of the track that was matched to this clus
       tmpMatch.push_back(matchingPair);
     }
   }
@@ -1264,37 +1347,37 @@ void MatchTOF::selectBestMatchesHP()
     } else if (sourceID == o2::dataformats::GlobalTrackID::ITSTPCTRD) {
       trkTypeSplitted = (int)trkType::ITSTPCTRD;
     }
-    mMatchedTracks[trkTypeSplitted].push_back(matchingPair); // array of MatchInfoTOF
+    matchedTracks[trkTypeSplitted].push_back(matchingPair); // array of MatchInfoTOF
 
     const o2::track::TrackLTIntegral& intLT = matchingPair.getLTIntegralOut();
 
     // get fit info
     double t0info = 0;
 
-    if (mFITRecPoints.size() > 0) {
-      int index = findFITIndex(mTOFClusWork[matchingPair.getTOFClIndex()].getBC());
+    if (FITRecPoints.size() > 0) {
+      int index = findFITIndex(TOFClusWork[matchingPair.getTOFClIndex()].getBC(), FITRecPoints);
 
       if (index > -1) {
-        o2::InteractionRecord ir = mFITRecPoints[index].getInteractionRecord();
+        o2::InteractionRecord ir = FITRecPoints[index].getInteractionRecord();
         t0info = ir.bc2ns() * 1E3;
       }
     } else { // move time to time in orbit to avoid loss of precision when truncating from double to float
-      int bcStarOrbit = int((mTOFClusWork[matchingPair.getTOFClIndex()].getTimeRaw() - intLT.getTOF(o2::track::PID::Pion)) * o2::tof::Geo::BC_TIME_INPS_INV);
+      int bcStarOrbit = int((TOFClusWork[matchingPair.getTOFClIndex()].getTimeRaw() - intLT.getTOF(o2::track::PID::Pion)) * o2::tof::Geo::BC_TIME_INPS_INV);
       bcStarOrbit = (bcStarOrbit / o2::constants::lhc::LHCMaxBunches) * o2::constants::lhc::LHCMaxBunches; // truncation
       t0info = bcStarOrbit * o2::tof::Geo::BC_TIME_INPS;
     }
 
     // add also calibration infos
     if (sourceID == o2::dataformats::GlobalTrackID::ITSTPC) {
-      mCalibInfoTOF.emplace_back(mTOFClusWork[matchingPair.getTOFClIndex()].getMainContributingChannel(),
-                                 mTimestamp / 1000 + int(mTOFClusWork[matchingPair.getTOFClIndex()].getTimeRaw() * 1E-12), // add time stamp
-                                 mTOFClusWork[matchingPair.getTOFClIndex()].getTimeRaw() - t0info - intLT.getTOF(o2::track::PID::Pion),
-                                 mTOFClusWork[matchingPair.getTOFClIndex()].getTot(), 0);
+      CalibInfoTOF.emplace_back(TOFClusWork[matchingPair.getTOFClIndex()].getMainContributingChannel(),
+                                Timestamp / 1000 + int(TOFClusWork[matchingPair.getTOFClIndex()].getTimeRaw() * 1E-12), // add time stamp
+                                TOFClusWork[matchingPair.getTOFClIndex()].getTimeRaw() - t0info - intLT.getTOF(o2::track::PID::Pion),
+                                TOFClusWork[matchingPair.getTOFClIndex()].getTot(), 0);
     }
 
-    if (mMCTruthON) {
-      const auto& labelsTOF = mTOFClusLabels->getLabels(matchingPair.getTOFClIndex());
-      auto& labelTrack = mTracksLblWork[trkType][itrk];
+    if (MCTruthON) {
+      const auto& labelsTOF = TOFClusLabels->getLabels(matchingPair.getTOFClIndex());
+      auto& labelTrack = TracksLblWork[trkType][itrk];
       // we have not found the track label among those associated to the TOF cluster --> fake match! We will associate the label of the main channel, but negative
       bool fake = true;
       for (auto& lbl : labelsTOF) {
@@ -1302,7 +1385,7 @@ void MatchTOF::selectBestMatchesHP()
           fake = false;
         }
       }
-      mOutTOFLabels[trkTypeSplitted].emplace_back(labelTrack).setFakeFlag(fake);
+      OutTOFLabels[trkTypeSplitted].emplace_back(labelTrack).setFakeFlag(fake);
     }
   }
 }

--- a/Detectors/GlobalTrackingWorkflow/src/tof-matcher-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/src/tof-matcher-workflow.cxx
@@ -20,6 +20,7 @@
 #include "GlobalTrackingWorkflow/TOFMatcherSpec.h"
 #include "TOFWorkflowIO/TOFMatchedWriterSpec.h"
 #include "TOFWorkflowIO/TOFCalibWriterSpec.h"
+#include "TOFWorkflowIO/TOFMatchableWriterSpec.h"
 #include "ReconstructionDataFormats/GlobalTrackID.h"
 #include "DetectorsCommonDataFormats/DetID.h"
 #include "GlobalTrackingWorkflowReaders/TrackTPCITSReaderSpec.h"
@@ -62,6 +63,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"output-type", o2::framework::VariantType::String, "matching-info", {"matching-info, calib-info"}},
     {"enable-dia", o2::framework::VariantType::Bool, false, {"to require diagnostic freq and then write to calib outputs (obsolete since now default)"}},
     {"trd-extra-tolerance", o2::framework::VariantType::Float, 500.0f, {"Extra time tolerance for TRD tracks in ns"}},
+    {"write-matchable", o2::framework::VariantType::Bool, false, {"write all matchable pairs in a file (o2matchable_tof.root)"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}},
     {"combine-devices", o2::framework::VariantType::Bool, false, {"merge DPL source/writer devices"}}};
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
@@ -89,6 +91,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   auto strict = configcontext.options().get<bool>("strict-matching");
   auto diagnostic = configcontext.options().get<bool>("enable-dia");
   auto extratolerancetrd = configcontext.options().get<float>("trd-extra-tolerance");
+  auto writeMatchable = configcontext.options().get<bool>("write-matchable");
 
   bool writematching = 0;
   bool writecalib = 0;
@@ -118,6 +121,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   LOG(debug) << "TOF disable-root-output = " << disableRootOut;
   LOG(debug) << "TOF matching in strict mode = " << strict;
   LOG(debug) << "TOF extra time tolerance for TRD tracks = " << extratolerancetrd;
+  LOG(debug) << "Store all matchables = " << writeMatchable;
 
   //GID::mask_t alowedSources = GID::getSourcesMask("TPC,ITS-TPC");
   GID::mask_t alowedSources = GID::getSourcesMask("TPC,ITS-TPC,TPC-TRD,ITS-TPC-TRD");
@@ -152,7 +156,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     }
   }
 
-  specs.emplace_back(o2::globaltracking::getTOFMatcherSpec(src, useMC, useFIT, false, strict, extratolerancetrd)); // doTPCrefit not yet supported (need to load TPC clusters?)
+  specs.emplace_back(o2::globaltracking::getTOFMatcherSpec(src, useMC, useFIT, false, strict, extratolerancetrd, writeMatchable)); // doTPCrefit not yet supported (need to load TPC clusters?)
 
   if (!disableRootOut) {
     std::vector<DataProcessorSpec> writers;
@@ -172,6 +176,10 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     }
     if (writecalib) {
       writers.emplace_back(o2::tof::getTOFCalibWriterSpec("o2calib_tof.root", 0, diagnostic));
+    }
+
+    if (writeMatchable) {
+      specs.emplace_back(o2::tof::getTOFMatchableWriterSpec("o2matchable_tof.root"));
     }
 
     if (configcontext.options().get<bool>("combine-devices")) {

--- a/Detectors/TOF/workflowIO/CMakeLists.txt
+++ b/Detectors/TOF/workflowIO/CMakeLists.txt
@@ -19,6 +19,7 @@ o2_add_library(TOFWorkflowIO
                        src/CalibClusReaderSpec.cxx
                        src/TOFMatchedWriterSpec.cxx
                        src/TOFCalibWriterSpec.cxx
+                       src/TOFMatchableWriterSpec.cxx
                        src/TOFMatchedReaderSpec.cxx
                        src/CalibInfoReaderSpec.cxx
                        src/TOFIntegrateClusterWriterSpec.cxx

--- a/Detectors/TOF/workflowIO/include/TOFWorkflowIO/ClusterReaderSpec.h
+++ b/Detectors/TOF/workflowIO/include/TOFWorkflowIO/ClusterReaderSpec.h
@@ -47,6 +47,7 @@ class ClusterReader : public Task
   std::string mFileName = "";
 
   std::vector<Cluster> mClusters, *mClustersPtr = &mClusters;
+  std::vector<int> mClustersMult, *mClustersMultPtr = &mClustersMult;
   o2::dataformats::MCTruthContainer<o2::MCCompLabel> mLabels, *mLabelsPtr = &mLabels;
 };
 

--- a/Detectors/TOF/workflowIO/include/TOFWorkflowIO/TOFMatchableWriterSpec.h
+++ b/Detectors/TOF/workflowIO/include/TOFWorkflowIO/TOFMatchableWriterSpec.h
@@ -9,25 +9,25 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// @file   TOFMatcherSpec.h
+/// @file   TOFMatchableWriterSpec.h
 
-#ifndef O2_TOF_MATCHER_SPEC
-#define O2_TOF_MATCHER_SPEC
+#ifndef TOFWORKFLOW_TOFMATCHABLEWRITER_H_
+#define TOFWORKFLOW_TOFMATCHABLEWRITER_H_
 
 #include "Framework/DataProcessorSpec.h"
-#include "ReconstructionDataFormats/MatchInfoTOFReco.h"
 
 using namespace o2::framework;
 
 namespace o2
 {
-namespace globaltracking
+namespace tof
 {
 
 /// create a processor spec
-framework::DataProcessorSpec getTOFMatcherSpec(o2::dataformats::GlobalTrackID::mask_t src, bool useMC, bool useFIT, bool tpcRefit, bool strict, float extratolerancetrd = 0., bool pushMatchable = 0);
+/// write TOF calbi info in a root file
+o2::framework::DataProcessorSpec getTOFMatchableWriterSpec(const char* outdef = "o2matchable_tof.root");
 
-} // namespace globaltracking
+} // namespace tof
 } // namespace o2
 
-#endif /* O2_TOF_MATCHER_SPEC */
+#endif /* TOFWORKFLOW_TOFMATCHABLEWRITER_H_ */

--- a/Detectors/TOF/workflowIO/src/TOFClusterWriterSpec.cxx
+++ b/Detectors/TOF/workflowIO/src/TOFClusterWriterSpec.cxx
@@ -26,6 +26,7 @@ namespace tof
 template <typename T>
 using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
 using OutputType = std::vector<o2::tof::Cluster>;
+using MultType = std::vector<int>;
 using LabelsType = o2::dataformats::MCTruthContainer<o2::MCCompLabel>;
 using namespace o2::header;
 
@@ -34,6 +35,9 @@ DataProcessorSpec getTOFClusterWriterSpec(bool useMC)
   // Spectators for logging
   auto logger = [](OutputType const& indata) {
     LOG(debug) << "RECEIVED CLUSTERS SIZE " << indata.size();
+  };
+  auto loggerMult = [](MultType const& inmult) {
+    LOG(debug) << "RECEIVED N BC SIZE " << inmult.size();
   };
   auto loggerMCLabels = [](LabelsType const& labeldata) {
     LOG(debug) << "TOF GOT " << labeldata.getNElements() << " LABELS ";
@@ -46,6 +50,11 @@ DataProcessorSpec getTOFClusterWriterSpec(bool useMC)
                                                              "tofclusters-branch-name",
                                                              1,
                                                              logger},
+                                BranchDefinition<MultType>{InputSpec{"clustersMult", gDataOriginTOF, "CLUSTERSMULT", 0},
+                                                           "TOFClusterMult",
+                                                           "tofclustersmult-branch-name",
+                                                           1,
+                                                           loggerMult},
                                 BranchDefinition<LabelsType>{InputSpec{"labels", gDataOriginTOF, "CLUSTERSMCTR", 0},
                                                              "TOFClusterMCTruth",
                                                              "clusterlabels-branch-name",

--- a/Detectors/TOF/workflowIO/src/TOFMatchableWriterSpec.cxx
+++ b/Detectors/TOF/workflowIO/src/TOFMatchableWriterSpec.cxx
@@ -1,0 +1,83 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// @file   TOFMatchableWriterSpec.cxx
+
+#include "TOFWorkflowIO/TOFMatchableWriterSpec.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/ControlService.h"
+#include "DPLUtils/MakeRootTreeWriterSpec.h"
+#include "Headers/DataHeader.h"
+#include "TTree.h"
+#include "TBranch.h"
+#include "TFile.h"
+#include "ReconstructionDataFormats/MatchInfoTOFReco.h"
+
+using namespace o2::framework;
+
+namespace o2
+{
+namespace tof
+{
+
+template <typename T>
+using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
+using MatchableType = std::vector<o2::dataformats::MatchInfoTOFReco>;
+
+DataProcessorSpec getTOFMatchableWriterSpec(const char* outdef)
+{
+  // A spectator for logging
+  auto logger = [](MatchableType const& indata) {
+    LOG(debug) << "RECEIVED MATCHABLE SIZE " << indata.size();
+  };
+  o2::header::DataDescription ddMatchable0{"MATCHABLES_0"};
+  o2::header::DataDescription ddMatchable1{"MATCHABLES_1"};
+  o2::header::DataDescription ddMatchable2{"MATCHABLES_2"};
+  o2::header::DataDescription ddMatchable3{"MATCHABLES_3"};
+  o2::header::DataDescription ddMatchable4{"MATCHABLES_4"};
+  o2::header::DataDescription ddMatchable5{"MATCHABLES_5"};
+  o2::header::DataDescription ddMatchable6{"MATCHABLES_6"};
+  o2::header::DataDescription ddMatchable7{"MATCHABLES_7"};
+  o2::header::DataDescription ddMatchable8{"MATCHABLES_8"};
+  o2::header::DataDescription ddMatchable9{"MATCHABLES_9"};
+  o2::header::DataDescription ddMatchable10{"MATCHABLES_10"};
+  o2::header::DataDescription ddMatchable11{"MATCHABLES_11"};
+  o2::header::DataDescription ddMatchable12{"MATCHABLES_12"};
+  o2::header::DataDescription ddMatchable13{"MATCHABLES_13"};
+  o2::header::DataDescription ddMatchable14{"MATCHABLES_14"};
+  o2::header::DataDescription ddMatchable15{"MATCHABLES_15"};
+  o2::header::DataDescription ddMatchable16{"MATCHABLES_16"};
+  o2::header::DataDescription ddMatchable17{"MATCHABLES_17"};
+  return MakeRootTreeWriterSpec("TOFMatchableWriter",
+                                outdef,
+                                "matchableTOF",
+                                BranchDefinition<MatchableType>{InputSpec{"input0", o2::header::gDataOriginTOF, ddMatchable0, 0}, "TOFMatchableInfo0", "matchableinfo0-branch-name", 1, logger},
+                                BranchDefinition<MatchableType>{InputSpec{"input1", o2::header::gDataOriginTOF, ddMatchable1, 0}, "TOFMatchableInfo1", "matchableinfo1-branch-name", 1, logger},
+                                BranchDefinition<MatchableType>{InputSpec{"input2", o2::header::gDataOriginTOF, ddMatchable2, 0}, "TOFMatchableInfo2", "matchableinfo2-branch-name", 1, logger},
+                                BranchDefinition<MatchableType>{InputSpec{"input3", o2::header::gDataOriginTOF, ddMatchable3, 0}, "TOFMatchableInfo3", "matchableinfo3-branch-name", 1, logger},
+                                BranchDefinition<MatchableType>{InputSpec{"input4", o2::header::gDataOriginTOF, ddMatchable4, 0}, "TOFMatchableInfo4", "matchableinfo4-branch-name", 1, logger},
+                                BranchDefinition<MatchableType>{InputSpec{"input5", o2::header::gDataOriginTOF, ddMatchable5, 0}, "TOFMatchableInfo5", "matchableinfo5-branch-name", 1, logger},
+                                BranchDefinition<MatchableType>{InputSpec{"input6", o2::header::gDataOriginTOF, ddMatchable6, 0}, "TOFMatchableInfo6", "matchableinfo6-branch-name", 1, logger},
+                                BranchDefinition<MatchableType>{InputSpec{"input7", o2::header::gDataOriginTOF, ddMatchable7, 0}, "TOFMatchableInfo7", "matchableinfo7-branch-name", 1, logger},
+                                BranchDefinition<MatchableType>{InputSpec{"input8", o2::header::gDataOriginTOF, ddMatchable8, 0}, "TOFMatchableInfo8", "matchableinfo8-branch-name", 1, logger},
+                                BranchDefinition<MatchableType>{InputSpec{"input9", o2::header::gDataOriginTOF, ddMatchable9, 0}, "TOFMatchableInfo9", "matchableinfo9-branch-name", 1, logger},
+                                BranchDefinition<MatchableType>{InputSpec{"input10", o2::header::gDataOriginTOF, ddMatchable10, 0}, "TOFMatchableInfo10", "matchableinfo10-branch-name", 1, logger},
+                                BranchDefinition<MatchableType>{InputSpec{"input11", o2::header::gDataOriginTOF, ddMatchable11, 0}, "TOFMatchableInfo11", "matchableinfo11-branch-name", 1, logger},
+                                BranchDefinition<MatchableType>{InputSpec{"input12", o2::header::gDataOriginTOF, ddMatchable12, 0}, "TOFMatchableInfo12", "matchableinfo12-branch-name", 1, logger},
+                                BranchDefinition<MatchableType>{InputSpec{"input13", o2::header::gDataOriginTOF, ddMatchable13, 0}, "TOFMatchableInfo13", "matchableinfo13-branch-name", 1, logger},
+                                BranchDefinition<MatchableType>{InputSpec{"input14", o2::header::gDataOriginTOF, ddMatchable14, 0}, "TOFMatchableInfo14", "matchableinfo14-branch-name", 1, logger},
+                                BranchDefinition<MatchableType>{InputSpec{"input15", o2::header::gDataOriginTOF, ddMatchable15, 0}, "TOFMatchableInfo15", "matchableinfo15-branch-name", 1, logger},
+                                BranchDefinition<MatchableType>{InputSpec{"input16", o2::header::gDataOriginTOF, ddMatchable16, 0}, "TOFMatchableInfo16", "matchableinfo16-branch-name", 1, logger},
+                                BranchDefinition<MatchableType>{InputSpec{"input17", o2::header::gDataOriginTOF, ddMatchable17, 0}, "TOFMatchableInfo17", "matchableinfo17-branch-name", 1, logger})();
+}
+
+} // namespace tof
+} // namespace o2


### PR DESCRIPTION
3 methods moved to static to be used also outside for development studies (in principle no changes in the current workflow).
2 new static metods added (mainly grouppingMatch) but not yet used.

The purpose is to provide some tools to investigate potential optimization in the matching fot a high occupancy environment: not selecting only accordingly to the Chi2 of a single matching pair (track, TOF cluster) but also considering correlation between tracks (clusters) sharing different matchable clusters(tracks).

WIP till the reconstruction for skimming is frozen...