### PR TITLE
DPL Analysis: fix unit tests

### DIFF
--- a/Framework/Core/test/test_ASoA.cxx
+++ b/Framework/Core/test/test_ASoA.cxx
@@ -815,8 +815,8 @@ BOOST_AUTO_TEST_CASE(TestAdvancedIndices)
   int references[] = {19, 2, 0, 13, 4, 6, 5, 5, 11, 9, 3, 8, 16, 14, 1, 18, 12, 18, 2, 7};
   int slice[2] = {-1, -1};
   std::vector<int> pset;
-  int withSlices[] = {3, 13, 19};
-  int withSets[] = {0, 1, 13, 14};
+  std::array<int, 3> withSlices = {3, 13, 19};
+  std::array<int, 4> withSets = {0, 1, 13, 14};
   int sizes[] = {3, 1, 5, 4};
   int c1 = 0;
   int c2 = 0;
@@ -824,12 +824,12 @@ BOOST_AUTO_TEST_CASE(TestAdvancedIndices)
     pset.clear();
     slice[0] = -1;
     slice[1] = -1;
-    if (i == withSlices[c1]) {
+    if (c1 < withSlices.size() && i == withSlices[c1]) {
       slice[0] = i - 2;
       slice[1] = i - 1;
       ++c1;
     }
-    if (i == withSets[c2]) {
+    if (c2 < withSets.size() && i == withSets[c2]) {
       for (auto z = 0; z < sizes[c2]; ++z) {
         pset.push_back(i + 1 + z);
       }
@@ -862,7 +862,7 @@ BOOST_AUTO_TEST_CASE(TestAdvancedIndices)
     }
     auto opss = p.pointSet_as<PointsSelfIndex>();
     auto opss_ids = p.pointSetIds();
-    if (i == withSets[c2]) {
+    if (c2 < withSets.size() && i == withSets[c2]) {
       BOOST_CHECK_EQUAL(opss.size(), sizes[c2]);
       BOOST_CHECK_EQUAL(opss.begin()->globalIndex(), i + 1);
       BOOST_CHECK_EQUAL(opss.back().globalIndex(), i + sizes[c2]);

--- a/Framework/Core/test/test_TreeToTable.cxx
+++ b/Framework/Core/test/test_TreeToTable.cxx
@@ -23,6 +23,7 @@
 #include <TTree.h>
 #include <TRandom.h>
 #include <arrow/table.h>
+#include <array>
 
 using namespace o2::framework;
 
@@ -181,14 +182,14 @@ BOOST_AUTO_TEST_CASE(VariableLists)
   std::vector<double> dv;
   std::vector<uint8_t> ui;
 
-  int empty[] = {3, 7, 10};
+  std::array<int, 3> empty = {3, 7, 10};
   auto count = 0;
   for (auto i = 1; i < 1000; ++i) {
     iv.clear();
     fv.clear();
     dv.clear();
     ui.clear();
-    if (i != empty[count]) {
+    if (count < empty.size() && i != empty[count]) {
       for (auto j = 0; j < i % 10 + 1; ++j) {
         iv.push_back(j + 2);
         fv.push_back((j + 2) * 0.2134f);
@@ -222,7 +223,7 @@ BOOST_AUTO_TEST_CASE(VariableLists)
     auto fvr = row.fvec();
     auto dvr = row.dvec();
     auto uvr = row.uivec();
-    if (i != empty[count]) {
+    if (count < empty.size() && i != empty[count]) {
       for (auto j = 0; j < i % 10 + 1; ++j) {
         BOOST_CHECK_EQUAL(ivr[j], j + 2);
         BOOST_CHECK_EQUAL(fvr[j], (j + 2) * 0.2134f);


### PR DESCRIPTION
The test logic did not account for the fact the loop continues even after the last filled row was found. It worked accidentally because empty[count] and alikes where filled with garbage which was unlikely to be equal to the index from 1 - 1000.