### PR TITLE
FileFetcher run alien_cp in debug mode

### DIFF
--- a/Common/Utils/include/CommonUtils/FileFetcher.h
+++ b/Common/Utils/include/CommonUtils/FileFetcher.h
@@ -58,10 +58,12 @@ class FileFetcher
   ~FileFetcher();
 
   const auto& getFileRef(size_t i) const { return mInputFiles[i]; }
-
+  void setFailThreshold(float f) { mFailThreshold = f; }
+  float getFailThreshold() const { return mFailThreshold; }
   void setMaxFilesInQueue(size_t s) { mMaxInQueue = s > 0 ? s : 1; }
   void setMaxLoops(size_t v) { mMaxLoops = v; }
   bool isRunning() const { return mRunning; }
+  bool isFailed() const { return mFailure; }
   void start();
   void stop();
   void cleanup();
@@ -100,10 +102,12 @@ class FileFetcher
   size_t mMaxInQueue{5};
   bool mRunning = false;
   bool mNoRemoteCopy = false;
+  bool mFailure = false;
   size_t mMaxLoops = 0;
   size_t mNLoops = 0;
   size_t mNFilesProc = 0;
   size_t mNFilesProcOK = 0;
+  float mFailThreshold = 0.f; // throw if too many failed fetches (>0 : fraction to total, <0 abs number)
   mutable std::mutex mMtx;
   std::mutex mMtxStop;
   std::thread mFetcherThread{};

--- a/Common/Utils/src/FileFetcher.cxx
+++ b/Common/Utils/src/FileFetcher.cxx
@@ -303,17 +303,40 @@ void FileFetcher::discardFile(const std::string& fname)
 bool FileFetcher::copyFile(size_t id)
 {
   // copy remote file to local setCopyDirName. Adaptation for Gvozden's code from SubTimeFrameFileSource::DataFetcherThread()
+  bool aliencpMode = false;
+  std::string uuid{};
+  std::vector<std::string> logsToClean;
   if (mCopyCmd.find("alien") != std::string::npos) {
     if (!gGrid && !TGrid::Connect("alien://")) {
       LOG(error) << "Copy command refers to alien but connection to Grid failed";
     }
+    uuid = mInputFiles[id].getOrigName();
+    for (auto& c : uuid) {
+      if (!std::isalnum(c) && c != '-') {
+        c = '_';
+      }
+    }
+    gSystem->Setenv("ALIENPY_DEBUG", "1");
+    logsToClean.push_back(fmt::format("log_alienpy_{}.txt", uuid));
+    gSystem->Setenv("ALIENPY_DEBUG_FILE", logsToClean.back().c_str());
+    gSystem->Setenv("XRD_LOGLEVEL", "Dump");
+    logsToClean.push_back(fmt::format("log_xrd_{}.txt", uuid));
+    gSystem->Setenv("XRD_LOGFILE", logsToClean.back().c_str());
   }
-  auto realCmd = std::regex_replace(std::regex_replace(mCopyCmd, std::regex("\\?src"), mInputFiles[id].getOrigName()), std::regex("\\?dst"), mInputFiles[id].getLocalName());
-  auto fullCmd = fmt::format("sh -c \"{}\" >> {}  2>&1", realCmd, mCopyCmdLogFile);
+  auto realCmd = std::regex_replace(std::regex_replace(mCopyCmd, std::regex(R"(\?src)"), mInputFiles[id].getOrigName()), std::regex(R"(\?dst)"), mInputFiles[id].getLocalName());
+  auto fullCmd = fmt::format(R"(sh -c "{}" >> {}  2>&1)", realCmd, mCopyCmdLogFile);
   LOG(info) << "Executing " << fullCmd;
   const auto sysRet = gSystem->Exec(fullCmd.c_str());
   if (sysRet != 0) {
     LOGP(warning, "FileFetcher: non-zero exit code {} for cmd={}", sysRet, realCmd);
+    std::string logCmd = fmt::format(R"(sh -c "cp {} log_aliencp_{}.txt")", mCopyCmdLogFile, uuid);
+    gSystem->Exec(logCmd.c_str());
+  } else { // on success cleanup debug log files
+    for (const auto& log : logsToClean) {
+      if (fs::exists(log)) {
+        fs::remove(log);
+      }
+    }
   }
   if (!fs::is_regular_file(mInputFiles[id].getLocalName()) || fs::is_empty(mInputFiles[id].getLocalName())) {
     LOGP(alarm, "FileFetcher: failed for copy command {}", realCmd);

--- a/Detectors/CTF/workflow/src/CTFReaderSpec.cxx
+++ b/Detectors/CTF/workflow/src/CTFReaderSpec.cxx
@@ -147,6 +147,7 @@ void CTFReaderSpec::init(InitContext& ic)
   mFileFetcher = std::make_unique<o2::utils::FileFetcher>(mInput.inpdata, mInput.tffileRegex, mInput.remoteRegex, mInput.copyCmd);
   mFileFetcher->setMaxFilesInQueue(mInput.maxFileCache);
   mFileFetcher->setMaxLoops(mInput.maxLoops);
+  mFileFetcher->setFailThreshold(ic.options().get<float>("fetch-failure-threshold"));
   mFileFetcher->start();
   if (!mInput.fileIRFrames.empty()) {
     mIRFrameSelector.loadIRFrames(mInput.fileIRFrames);
@@ -429,6 +430,7 @@ DataProcessorSpec getCTFReaderSpec(const CTFReaderInp& inp)
   options.emplace_back(ConfigParamSpec{"select-ctf-ids", VariantType::String, "", {"comma-separated list CTF IDs to inject (from cumulative counter of CTFs seen)"}});
   options.emplace_back(ConfigParamSpec{"impose-run-start-timstamp", VariantType::Int64, 0L, {"impose run start time stamp (ms), ignored if 0"}});
   options.emplace_back(ConfigParamSpec{"local-tf-counter", VariantType::Bool, false, {"reassign header.tfCounter from local TF counter"}});
+  options.emplace_back(ConfigParamSpec{"fetch-failure-threshold", VariantType::Float, 0.f, {"Fatil if too many failures( >0: fraction, <0: abs number, 0: no threshold)"}});
   if (!inp.metricChannel.empty()) {
     options.emplace_back(ConfigParamSpec{"channel-config", VariantType::String, inp.metricChannel, {"Out-of-band channel config for TF throttling"}});
   }

--- a/Detectors/Raw/TFReaderDD/src/TFReaderSpec.cxx
+++ b/Detectors/Raw/TFReaderDD/src/TFReaderSpec.cxx
@@ -96,6 +96,7 @@ void TFReaderSpec::init(o2f::InitContext& ic)
   mFileFetcher = std::make_unique<o2::utils::FileFetcher>(mInput.inpdata, mInput.tffileRegex, mInput.remoteRegex, mInput.copyCmd);
   mFileFetcher->setMaxFilesInQueue(mInput.maxFileCache);
   mFileFetcher->setMaxLoops(mInput.maxLoops);
+  mFileFetcher->setFailThreshold(ic.options().get<float>("fetch-failure-threshold"));
   mFileFetcher->start();
 }
 
@@ -458,7 +459,7 @@ o2f::DataProcessorSpec o2::rawdd::getTFReaderSpec(o2::rawdd::TFReaderInp& rinp)
       LOGP(alarm, R"(To avoid reader filling shm buffer use "--shm-throw-bad-alloc 0 --shm-segment-id 2")");
     }
   }
-
+  spec.options.emplace_back(o2f::ConfigParamSpec{"fetch-failure-threshold", o2f::VariantType::Float, 0.f, {"Fatil if too many failures( >0: fraction, <0: abs number, 0: no threshold)"}});
   spec.algorithm = o2f::adaptFromTask<TFReaderSpec>(rinp);
 
   return spec;


### PR DESCRIPTION
* Set debug env.vars for alien_cp.

* Option `--fetch-failure-threshold <float>` of o2-ctf-reader and o2-raw-tf-reader allows to produce fatal if
abs. number (option value <0) or fraction of fetches wrt total number of files (value > 0) have failed.
E.g. `--fetch-failure-threshold -2.5` will produce fatal on 3rd fetch failure, while `--fetch-failure-threshold 0.1`
will produce fatal after the failure of 10% of input files fetches.

