### PR TITLE
Upgrade MFT track finder

### DIFF
--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/Constants.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/Constants.h
@@ -55,13 +55,13 @@ constexpr Int_t MaxCellsInRoad{100};
 
 namespace index_table
 {
-constexpr Float_t RMin{1.0}; // [cm]
-constexpr Float_t RMax{20.0};
+constexpr std::array<Float_t, o2::mft::constants::mft::LayersNumber> RMin{2.1, 2.1, 2.1, 2.1, 2.1, 2.1, 3.1, 3.1, 3.5, 3.5}; // [cm]
+constexpr std::array<Float_t, o2::mft::constants::mft::LayersNumber> RMax{12.5, 12.5, 12.5, 12.5, 14.0, 14.0, 17.0, 17.0, 17.5, 17.5};
 
 constexpr Float_t PhiMin{0.};
 constexpr Float_t PhiMax{o2::constants::math::TwoPI}; // [rad]
 
-constexpr Int_t MaxRPhiBins{100 * 100};
+constexpr Int_t MaxRPhiBins{200 * 200 + 1};
 } // namespace index_table
 
 } // namespace constants

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/MFTTrackingParam.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/MFTTrackingParam.h
@@ -56,16 +56,20 @@ struct MFTTrackingParam : public o2::conf::ConfigurableParamHelper<MFTTrackingPa
   Int_t RBins = 50;
   /// number of bins in phi-direction
   Int_t PhiBins = 50;
-  /// RPhi search window bin width for the second point of a seed (LTF and CA)
-  Int_t LTFseed2BinWin = 3;
-  /// RPhi search window bin width for the intermediate points
-  Int_t LTFinterBinWin = 3;
+  /// Minimum z vertex position for conical search bin optimization
+  Float_t ZVtxMin = -15.f; // cm
+  /// Maximum z vertex position for conical search bin optimization
+  Float_t ZVtxMax = 15.f; // cm
+  /// Radial vertex position cut at ZVtxMin
+  Float_t rCutAtZmin = 0.1; // cm
   /// Special version for TED shots and cosmics, with full scan of the clusters
   bool FullClusterScan = false;
   /// road for LTF algo : cylinder or cone (default)
   Bool_t LTFConeRadius = kFALSE;
   /// road for CA algo : cylinder or cone (default)
   Bool_t CAConeRadius = kFALSE;
+  /// Minimum fraction of correct clusters MC labels to set True MC tracks
+  Float_t TrueTrackMCThreshold = 0.8;
 
   // cuts to reject to low or too high mult events, or externally provided IRFrames
   float cutMultClusLow = 0;   /// reject ROF with estimated cluster mult. below this value (no cut if <0)

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/MFTTrackingParam.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/MFTTrackingParam.h
@@ -53,13 +53,13 @@ struct MFTTrackingParam : public o2::conf::ConfigurableParamHelper<MFTTrackingPa
   /// maximum distance for a cluster to be attached to a seed line (CA road)
   Float_t ROADclsRCut = 0.0400;
   /// number of bins in r-direction
-  Int_t RBins = 50;
+  Int_t RBins = 30;
   /// number of bins in phi-direction
-  Int_t PhiBins = 50;
+  Int_t PhiBins = 120;
   /// Minimum z vertex position for conical search bin optimization
-  Float_t ZVtxMin = -15.f; // cm
+  Float_t ZVtxMin = -13.f; // cm
   /// Maximum z vertex position for conical search bin optimization
-  Float_t ZVtxMax = 15.f; // cm
+  Float_t ZVtxMax = 13.f; // cm
   /// Radial vertex position cut at ZVtxMin
   Float_t rCutAtZmin = 0.1; // cm
   /// Special version for TED shots and cosmics, with full scan of the clusters

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/ROframe.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/ROframe.h
@@ -56,8 +56,6 @@ class ROframe
 
   const MCCompLabel& getClusterLabels(Int_t layerId, const Int_t clusterId) const { return mClusterLabels[layerId][clusterId]; }
 
-  const std::array<std::pair<Int_t, Int_t>, constants::index_table::MaxRPhiBins>& getClusterBinIndexRange(Int_t layerId) const { return mClusterBinIndexRange[layerId]; }
-
   const Int_t getClusterExternalIndex(Int_t layerId, const Int_t clusterId) const { return mClusterExternalIndices[layerId][clusterId]; }
 
   std::vector<T>& getTracks() { return mTracks; }
@@ -80,8 +78,6 @@ class ROframe
 
   void addRoad() { mRoads.emplace_back(); }
 
-  void initialize(bool fullClusterScan = false);
-
   void sortClusters();
 
   void clear()
@@ -91,9 +87,6 @@ class ROframe
       mClusters[iLayer].clear();
       mClusterLabels[iLayer].clear();
       mClusterExternalIndices[iLayer].clear();
-      for (Int_t iBin = 0; iBin < constants::index_table::MaxRPhiBins; ++iBin) {
-        mClusterBinIndexRange[iLayer][iBin] = std::pair<Int_t, Int_t>(0, -1);
-      }
     }
     mTracks.clear();
     mRoads.clear();
@@ -105,7 +98,6 @@ class ROframe
   std::array<std::vector<Cluster>, constants::mft::LayersNumber> mClusters;
   std::array<std::vector<MCCompLabel>, constants::mft::LayersNumber> mClusterLabels;
   std::array<std::vector<Int_t>, constants::mft::LayersNumber> mClusterExternalIndices;
-  std::array<std::array<std::pair<Int_t, Int_t>, constants::index_table::MaxRPhiBins>, constants::mft::LayersNumber> mClusterBinIndexRange;
   std::vector<T> mTracks;
   std::vector<Road> mRoads;
 };

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/Tracker.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/Tracker.h
@@ -62,15 +62,25 @@ class Tracker : public TrackerConfig
     mTrackLabels.clear();
   }
 
+  void findTracks(ROframe<T>& rofData)
+  {
+    if (!mFullClusterScan) {
+      clearSorting();
+      sortClusters(rofData);
+    }
+    findLTFTracks(rofData);
+    findCATracks(rofData);
+  };
+
   void findLTFTracks(ROframe<T>&);
   void findCATracks(ROframe<T>&);
   bool fitTracks(ROframe<T>&);
   void computeTracksMClabels(const std::vector<T>&);
 
-  void configure(const MFTTrackingParam& trkParam, bool printConfig = false);
+  void configure(const MFTTrackingParam& trkParam, bool firstTracker);
+  void initializeFinder();
 
  private:
-  void initializeFinder();
   void findTracksLTF(ROframe<T>&);
   void findTracksCA(ROframe<T>&);
   void findTracksLTFfcs(ROframe<T>&);
@@ -80,6 +90,51 @@ class Tracker : public TrackerConfig
   void runBackwardInRoad(ROframe<T>&);
   void updateCellStatusInRoad();
 
+  void sortClusters(ROframe<T>& rof)
+  {
+    Int_t nClsInLayer, binPrevIndex, clsMinIndex, clsMaxIndex, jClsLayer;
+    // sort the clusters in R-Phi
+    for (Int_t iLayer = 0; iLayer < constants::mft::LayersNumber; ++iLayer) {
+      if (rof.getClustersInLayer(iLayer).size() == 0) {
+        continue;
+      }
+      // sort clusters in layer according to the bin index
+      sort(rof.getClustersInLayer(iLayer).begin(), rof.getClustersInLayer(iLayer).end(),
+           [](Cluster& c1, Cluster& c2) { return c1.indexTableBin < c2.indexTableBin; });
+      // find the cluster local index range in each bin
+      // index = element position in the vector
+      nClsInLayer = rof.getClustersInLayer(iLayer).size();
+      binPrevIndex = rof.getClustersInLayer(iLayer).at(0).indexTableBin;
+      clsMinIndex = 0;
+      for (jClsLayer = 1; jClsLayer < nClsInLayer; ++jClsLayer) {
+        if (rof.getClustersInLayer(iLayer).at(jClsLayer).indexTableBin == binPrevIndex) {
+          continue;
+        }
+
+        clsMaxIndex = jClsLayer - 1;
+
+        mClusterBinIndexRange[iLayer][binPrevIndex] = std::pair<Int_t, Int_t>(clsMinIndex, clsMaxIndex);
+
+        binPrevIndex = rof.getClustersInLayer(iLayer).at(jClsLayer).indexTableBin;
+        clsMinIndex = jClsLayer;
+      } // clusters
+
+      // last cluster
+      clsMaxIndex = jClsLayer - 1;
+
+      mClusterBinIndexRange[iLayer][binPrevIndex] = std::pair<Int_t, Int_t>(clsMinIndex, clsMaxIndex);
+    } // layers
+  }
+
+  void clearSorting()
+  {
+    for (Int_t iLayer = 0; iLayer < constants::mft::LayersNumber; ++iLayer) {
+      for (Int_t iBin = 0; iBin <= mRPhiBins + 1; ++iBin) {
+        mClusterBinIndexRange[iLayer][iBin] = std::pair<Int_t, Int_t>(0, -1);
+      }
+    }
+  }
+
   const Int_t isDiskFace(Int_t layer) const { return (layer % 2); }
   const Float_t getDistanceToSeed(const Cluster&, const Cluster&, const Cluster&) const;
   void getBinClusterRange(const ROframe<T>&, const Int_t, const Int_t, Int_t&, Int_t&) const;
@@ -88,16 +143,13 @@ class Tracker : public TrackerConfig
   void addCellToCurrentTrackCA(const Int_t, const Int_t, ROframe<T>&);
   void addCellToCurrentRoad(ROframe<T>&, const Int_t, const Int_t, const Int_t, const Int_t, Int_t&);
 
-  Float_t mBz = 5.f;
+  Float_t mBz;
   std::vector<MCCompLabel> mTrackLabels;
   std::unique_ptr<o2::mft::TrackFitter<T>> mTrackFitter = nullptr;
 
   Int_t mMaxCellLevel = 0;
 
   bool mUseMC = false;
-
-  std::array<std::array<std::array<std::vector<Int_t>, constants::index_table::MaxRPhiBins>, (constants::mft::LayersNumber - 1)>, (constants::mft::LayersNumber - 1)> mBinsS;
-  std::array<std::array<std::array<std::vector<Int_t>, constants::index_table::MaxRPhiBins>, (constants::mft::LayersNumber - 1)>, (constants::mft::LayersNumber - 1)> mBins;
 
   /// helper to store points of a track candidate
   struct TrackElement {
@@ -137,7 +189,7 @@ inline const Float_t Tracker<T>::getDistanceToSeed(const Cluster& cluster1, cons
 template <typename T>
 inline void Tracker<T>::getBinClusterRange(const ROframe<T>& event, const Int_t layer, const Int_t bin, Int_t& clsMinIndex, Int_t& clsMaxIndex) const
 {
-  const auto& pair = event.getClusterBinIndexRange(layer)[bin];
+  const auto& pair = getClusterBinIndexRange(layer, bin);
   clsMinIndex = pair.first;
   clsMaxIndex = pair.second;
 }
@@ -212,8 +264,7 @@ inline void Tracker<T>::computeTracksMClabels(const std::vector<T>& tracks)
     }
 
     auto labelratio = 1.0 * count / nClusters;
-    if (labelratio >= 0.8) {
-    } else {
+    if (labelratio < mTrueTrackMCThreshold) {
       isFakeTrack = true;
       maxOccurrencesValue.setFakeFlag();
     }

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/TrackerConfig.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/TrackerConfig.h
@@ -23,6 +23,9 @@ namespace o2
 {
 namespace mft
 {
+
+using namespace constants::mft;
+
 class TrackerConfig
 {
  public:
@@ -32,9 +35,15 @@ class TrackerConfig
 
   void initialize(const MFTTrackingParam& trkParam);
 
-  const Int_t getRBinIndex(const Float_t r) const;
+  const Int_t getRBinIndex(const Float_t r, const Int_t layer) const;
   const Int_t getPhiBinIndex(const Float_t phi) const;
   const Int_t getBinIndex(const Int_t rIndex, const Int_t phiIndex) const;
+
+  // tracking configuration parameters
+  const auto& getBinsS() { return mBinsS; }
+  const auto& getBins() { return mBins; }
+
+  const std::pair<Int_t, Int_t>& getClusterBinIndexRange(Int_t layerId, Int_t bin) const { return mClusterBinIndexRange[layerId][bin]; }
 
  protected:
   // tracking configuration parameters
@@ -46,27 +55,41 @@ class TrackerConfig
   Float_t mLTFclsR2Cut;
   Float_t mROADclsRCut;
   Float_t mROADclsR2Cut;
-  Int_t mLTFseed2BinWin;
-  Int_t mLTFinterBinWin;
   Int_t mRBins;
   Int_t mPhiBins;
   Int_t mRPhiBins;
-  Float_t mRBinSize;
-  Float_t mPhiBinSize;
-  Float_t mInverseRBinSize;
-  Float_t mInversePhiBinSize;
+  Float_t mZVtxMin;
+  Float_t mZVtxMax;
+  Float_t mRCutAtZmin;
   Bool_t mLTFConeRadius;
   Bool_t mCAConeRadius;
-
   /// Special track finder for TED shots and cosmics, with full scan of the clusters
   bool mFullClusterScan = false;
+  Float_t mTrueTrackMCThreshold; // Minimum fraction of correct MC labels to tag True tracks
 
-  ClassDefNV(TrackerConfig, 2);
+  static Float_t mPhiBinSize;
+  static Float_t mInversePhiBinSize;
+  static std::array<Int_t, constants::mft::LayersNumber> mPhiBinWin;
+  static std::array<Float_t, constants::mft::LayersNumber> mRBinSize;
+  static std::array<Float_t, constants::mft::LayersNumber> mInverseRBinSize;
+  static std::array<std::array<std::array<std::vector<Int_t>, constants::index_table::MaxRPhiBins>, (constants::mft::LayersNumber - 1)>, (constants::mft::LayersNumber - 1)> mBins;
+  static std::array<std::array<std::array<std::vector<Int_t>, constants::index_table::MaxRPhiBins>, (constants::mft::LayersNumber - 1)>, (constants::mft::LayersNumber - 1)> mBinsS;
+  std::array<std::array<std::pair<Int_t, Int_t>, constants::index_table::MaxRPhiBins>, constants::mft::LayersNumber> mClusterBinIndexRange;
+
+  ClassDefNV(TrackerConfig, 3);
 };
 
-inline const Int_t TrackerConfig::getRBinIndex(const Float_t r) const
+inline Float_t TrackerConfig::mPhiBinSize;
+inline Float_t TrackerConfig::mInversePhiBinSize;
+inline std::array<Int_t, constants::mft::LayersNumber> TrackerConfig::mPhiBinWin;
+inline std::array<Float_t, constants::mft::LayersNumber> TrackerConfig::mRBinSize;
+inline std::array<Float_t, constants::mft::LayersNumber> TrackerConfig::mInverseRBinSize;
+inline std::array<std::array<std::array<std::vector<Int_t>, constants::index_table::MaxRPhiBins>, (constants::mft::LayersNumber - 1)>, (constants::mft::LayersNumber - 1)> TrackerConfig::mBins;
+inline std::array<std::array<std::array<std::vector<Int_t>, constants::index_table::MaxRPhiBins>, (constants::mft::LayersNumber - 1)>, (constants::mft::LayersNumber - 1)> TrackerConfig::mBinsS;
+
+inline const Int_t TrackerConfig::getRBinIndex(const Float_t r, const Int_t layer) const
 {
-  return (Int_t)((r - constants::index_table::RMin) * mInverseRBinSize);
+  return (Int_t)((r - constants::index_table::RMin[layer]) * mInverseRBinSize[layer]);
 }
 
 inline const Int_t TrackerConfig::getPhiBinIndex(const Float_t phi) const
@@ -76,8 +99,7 @@ inline const Int_t TrackerConfig::getPhiBinIndex(const Float_t phi) const
 
 inline const Int_t TrackerConfig::getBinIndex(const Int_t rIndex, const Int_t phiIndex) const
 {
-  if (0 <= rIndex && rIndex < mRBins &&
-      0 <= phiIndex && phiIndex < mPhiBins) {
+  if (0 <= rIndex && rIndex < mRBins && 0 <= phiIndex && phiIndex < mPhiBins) {
     return (phiIndex * mRBins + rIndex);
   }
   return (mRBins * mPhiBins);

--- a/Detectors/ITSMFT/MFT/tracking/src/IOUtils.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/IOUtils.cxx
@@ -88,7 +88,7 @@ int ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe<T>& event
     Float_t rCoord = clsPoint2D.R();
     Float_t phiCoord = clsPoint2D.Phi();
     o2::math_utils::bringTo02PiGen(phiCoord);
-    int rBinIndex = tracker->getRBinIndex(rCoord);
+    int rBinIndex = tracker->getRBinIndex(rCoord, layer);
     int phiBinIndex = tracker->getPhiBinIndex(phiCoord);
     int binIndex = tracker->getBinIndex(rBinIndex, phiBinIndex);
     event.addClusterToLayer(layer, gloXYZ.x(), gloXYZ.y(), gloXYZ.z(), phiCoord, rCoord, event.getClustersInLayer(layer).size(), binIndex, sigmaX2, sigmaY2, sensorID);

--- a/Detectors/ITSMFT/MFT/tracking/src/ROframe.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/ROframe.cxx
@@ -31,51 +31,6 @@ Int_t ROframe<T>::getTotalClusters() const
   return Int_t(totalClusters);
 }
 
-template <typename T>
-void ROframe<T>::initialize(bool fullClusterScan)
-{
-  if (!fullClusterScan) {
-    sortClusters();
-  }
-}
-
-template <typename T>
-void ROframe<T>::sortClusters()
-{
-  Int_t nClsInLayer, binPrevIndex, clsMinIndex, clsMaxIndex, jClsLayer;
-  // sort the clusters in R-Phi
-  for (Int_t iLayer = 0; iLayer < constants::mft::LayersNumber; ++iLayer) {
-    if (mClusters[iLayer].size() == 0) {
-      continue;
-    }
-    // sort clusters in layer according to the bin index
-    sort(mClusters[iLayer].begin(), mClusters[iLayer].end(),
-         [](Cluster& c1, Cluster& c2) { return c1.indexTableBin < c2.indexTableBin; });
-    // find the cluster local index range in each bin
-    // index = element position in the vector
-    nClsInLayer = mClusters[iLayer].size();
-    binPrevIndex = mClusters[iLayer].at(0).indexTableBin;
-    clsMinIndex = 0;
-    for (jClsLayer = 1; jClsLayer < nClsInLayer; ++jClsLayer) {
-      if (mClusters[iLayer].at(jClsLayer).indexTableBin == binPrevIndex) {
-        continue;
-      }
-
-      clsMaxIndex = jClsLayer - 1;
-
-      mClusterBinIndexRange[iLayer][binPrevIndex] = std::pair<Int_t, Int_t>(clsMinIndex, clsMaxIndex);
-
-      binPrevIndex = mClusters[iLayer].at(jClsLayer).indexTableBin;
-      clsMinIndex = jClsLayer;
-    } // clusters
-
-    // last cluster
-    clsMaxIndex = jClsLayer - 1;
-
-    mClusterBinIndexRange[iLayer][binPrevIndex] = std::pair<Int_t, Int_t>(clsMinIndex, clsMaxIndex);
-  } // layers
-}
-
 template class ROframe<o2::mft::TrackLTF>;
 template class ROframe<o2::mft::TrackLTFL>;
 

--- a/Detectors/ITSMFT/MFT/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/Tracker.cxx
@@ -43,11 +43,10 @@ void Tracker<T>::setBz(Float_t bz)
 
 //_________________________________________________________________________________________________
 template <typename T>
-void Tracker<T>::configure(const MFTTrackingParam& trkParam, bool printConfig)
+void Tracker<T>::configure(const MFTTrackingParam& trkParam, bool firstTracker)
 {
   /// initialize from MFTTrackingParam (command line configuration parameters)
   initialize(trkParam);
-  initializeFinder();
 
   mTrackFitter->setMFTRadLength(trkParam.MFTRadLength);
   mTrackFitter->setVerbosity(trkParam.verbose);
@@ -58,7 +57,7 @@ void Tracker<T>::configure(const MFTTrackingParam& trkParam, bool printConfig)
     mTrackFitter->setTrackModel(trkParam.trackmodel);
   }
 
-  if (printConfig) {
+  if (firstTracker) {
     LOG(info) << "Configurable tracker parameters:";
     switch (mTrackFitter->getTrackModel()) {
       case o2::mft::MFTTrackModel::Helix:
@@ -85,8 +84,12 @@ void Tracker<T>::configure(const MFTTrackingParam& trkParam, bool printConfig)
     LOG(info) << "ROADclsRCut         = " << mROADclsRCut;
     LOG(info) << "RBins               = " << mRBins;
     LOG(info) << "PhiBins             = " << mPhiBins;
-    LOG(info) << "LTFseed2BinWin      = " << mLTFseed2BinWin;
-    LOG(info) << "LTFinterBinWin      = " << mLTFinterBinWin;
+    LOG(info) << "ZVtxMin             = " << mZVtxMin;
+    LOG(info) << "ZVtxMax             = " << mZVtxMax;
+    LOG(info) << "RCutAtZmin          = " << mRCutAtZmin;
+    if (mUseMC) {
+      LOG(info) << "TrueTrackMCThreshold          = " << mTrueTrackMCThreshold;
+    }
     LOG(info) << "FullClusterScan     = " << (trkParam.FullClusterScan ? "true" : "false");
     LOG(info) << "forceZeroField      = " << (trkParam.forceZeroField ? "true" : "false");
     LOG(info) << "MFTRadLength        = " << trkParam.MFTRadLength;
@@ -96,14 +99,15 @@ void Tracker<T>::configure(const MFTTrackingParam& trkParam, bool printConfig)
       LOG(info) << "cutMultClusLow      = " << trkParam.cutMultClusLow;
       LOG(info) << "cutMultClusHigh     = " << trkParam.cutMultClusHigh;
     }
+    initializeFinder();
   }
+  mRoad.initialize();
 }
 
 //_________________________________________________________________________________________________
 template <typename T>
 void Tracker<T>::initializeFinder()
 {
-  mRoad.initialize();
 
   if (mFullClusterScan) {
     return;
@@ -111,17 +115,36 @@ void Tracker<T>::initializeFinder()
 
   /// calculate Look-Up-Table of the R-Phi bins projection from one layer to another
   /// layer1 + global R-Phi bin index ---> layer2 + R bin index + Phi bin index
+  /// To be executed by the first tracker in case of multiple threads
 
-  Float_t dz, x, y, r, phi, x_proj, y_proj, r_proj, phi_proj;
+  for (auto layer = 0; layer < constants::mft::LayersNumber; layer++) {
+    // Conical track-finder binning.
+    // Needs to be executed only once since it is filling static data members used by all tracker threads
+    mPhiBinSize = (constants::index_table::PhiMax - constants::index_table::PhiMin) / mPhiBins;
+    mInversePhiBinSize = 1.0 / mPhiBinSize;
+    mRBinSize[layer] = (constants::index_table::RMax[layer] - constants::index_table::RMin[layer]) / mRBins;
+    mInverseRBinSize[layer] = 1.0 / mRBinSize[layer];
+    auto ZL0 = LayerZCoordinate()[0];
+    auto deltaZ = (abs(LayerZCoordinate()[layer]) - abs(ZL0));
+    auto binArcLenght = constants::index_table::RMin[layer] * o2::constants::math::TwoPI / mPhiBins;
+    Float_t NconicalBins = 2.0 * deltaZ * mRCutAtZmin / (abs(ZL0) + mZVtxMin) / binArcLenght;
+    mPhiBinWin[layer] = std::max(3, int(ceil(NconicalBins)));
+    LOG(debug) << "mPhiBinWin[" << layer << "] = " << mPhiBinWin[layer] << std::endl;
+  }
+
+  Float_t dz, x, y, r, phi, x_proj, y_proj, r_proj, phi_proj, zLayer1, zLayer2;
   Int_t binIndex1, binIndex2, binIndex2S, binR_proj, binPhi_proj;
 
   for (Int_t layer1 = 0; layer1 < (constants::mft::LayersNumber - 1); ++layer1) {
+    zLayer1 = constants::mft::LayerZCoordinate()[layer1];
 
     for (Int_t iRBin = 0; iRBin < mRBins; ++iRBin) {
+      bool isFirstPhiBin = true;
 
-      r = (iRBin + 0.5) * mRBinSize + constants::index_table::RMin;
+      r = (iRBin + 0.5) * mRBinSize[layer1] + constants::index_table::RMin[layer1];
 
       for (Int_t iPhiBin = 0; iPhiBin < mPhiBins; ++iPhiBin) {
+        isFirstPhiBin = !iPhiBin;
 
         phi = (iPhiBin + 0.5) * mPhiBinSize + constants::index_table::PhiMin;
 
@@ -131,8 +154,9 @@ void Tracker<T>::initializeFinder()
         y = r * TMath::Sin(phi);
 
         for (Int_t layer2 = (layer1 + 1); layer2 < constants::mft::LayersNumber; ++layer2) {
+          zLayer2 = constants::mft::LayerZCoordinate()[layer2];
 
-          dz = constants::mft::LayerZCoordinate()[layer2] - constants::mft::LayerZCoordinate()[layer1];
+          dz = zLayer2 - zLayer1;
           x_proj = x + dz * x * constants::mft::InverseLayerZCoordinate()[layer1];
           y_proj = y + dz * y * constants::mft::InverseLayerZCoordinate()[layer1];
           auto clsPoint2D = math_utils::Point2D<Float_t>(x_proj, y_proj);
@@ -140,50 +164,48 @@ void Tracker<T>::initializeFinder()
           phi_proj = clsPoint2D.Phi();
           o2::math_utils::bringTo02PiGen(phi_proj);
 
-          binR_proj = getRBinIndex(r_proj);
+          binR_proj = getRBinIndex(r_proj, layer2);
           binPhi_proj = getPhiBinIndex(phi_proj);
 
-          int binRS, binPhiS;
-
-          int binwRS = mLTFseed2BinWin;
-          int binhwRS = binwRS / 2;
-
-          int binwPhiS = mLTFseed2BinWin;
+          int binwPhiS = mPhiBinWin[layer2];
           int binhwPhiS = binwPhiS / 2;
 
-          for (Int_t iR = 0; iR < binwRS; ++iR) {
-            binRS = binR_proj + (iR - binhwRS);
-            if (binRS < 0) {
-              continue;
-            }
+          float rMin = r * (mZVtxMax + abs(zLayer2)) / (mZVtxMax + abs(zLayer1));
+          float rMax = r * (abs(zLayer2) + mZVtxMin) / (abs(zLayer1) + mZVtxMin);
+
+          int rBinMin = getRBinIndex(rMin, layer2);
+          int rBinMax = getRBinIndex(rMax, layer2);
+          if (rBinMin == binR_proj) {
+            rBinMin--;
+          }
+          if (rBinMax == binR_proj) {
+            rBinMax++;
+          }
+          rBinMin = TMath::Range(0, mRBins - 1, rBinMin);
+          rBinMax = TMath::Range(0, mRBins - 1, rBinMax);
+          if (isFirstPhiBin) {
+            LOG(debug) << "Layer1 = " << layer1 << "  Layer2 = " << layer2 << "  iRBin = " << iRBin << "  r = " << r << "  r_proj = " << r_proj << "  rBinMin = " << rBinMin << "  rBinMax = " << rBinMax;
+          }
+          for (Int_t binR = rBinMin; binR <= rBinMax; ++binR) {
 
             for (Int_t iPhi = 0; iPhi < binwPhiS; ++iPhi) {
-              binPhiS = binPhi_proj + (iPhi - binhwPhiS);
+              int binPhiS = binPhi_proj + (iPhi - binhwPhiS);
               if (binPhiS < 0) {
                 continue;
               }
 
-              binIndex2S = getBinIndex(binRS, binPhiS);
+              binIndex2S = getBinIndex(binR, binPhiS);
               mBinsS[layer1][layer2 - 1][binIndex1].emplace_back(binIndex2S);
             }
           }
 
-          int binR, binPhi;
-
-          int binwR = mLTFinterBinWin;
-          int binhwR = binwR / 2;
-
-          int binwPhi = mLTFinterBinWin;
+          int binwPhi = mPhiBinWin[layer2];
           int binhwPhi = binwPhi / 2;
 
-          for (Int_t iR = 0; iR < binwR; ++iR) {
-            binR = binR_proj + (iR - binhwR);
-            if (binR < 0) {
-              continue;
-            }
+          for (Int_t binR = rBinMin; binR <= rBinMax; ++binR) {
 
             for (Int_t iPhi = 0; iPhi < binwPhi; ++iPhi) {
-              binPhi = binPhi_proj + (iPhi - binhwPhi);
+              int binPhi = binPhi_proj + (iPhi - binhwPhi);
               if (binPhi < 0) {
                 continue;
               }
@@ -266,7 +288,7 @@ void Tracker<T>::findTracksLTF(ROframe<T>& event)
       clsInLayer1 = it1 - event.getClustersInLayer(layer1).begin();
 
       // loop over the bins in the search window
-      for (auto& binS : mBinsS[layer1][layer2 - 1][cluster1.indexTableBin]) {
+      for (const auto& binS : getBinsS()[layer1][layer2 - 1][cluster1.indexTableBin]) {
 
         getBinClusterRange(event, layer2, binS, clsMinIndexS, clsMaxIndexS);
 
@@ -296,7 +318,7 @@ void Tracker<T>::findTracksLTF(ROframe<T>& event)
 
             // loop over the bins in the search window
             dR2min = mLTFConeRadius ? dR2cut * dRCone * dRCone : dR2cut;
-            for (auto& bin : mBins[layer1][layer - 1][cluster1.indexTableBin]) {
+            for (const auto& bin : getBins()[layer1][layer - 1][cluster1.indexTableBin]) {
 
               getBinClusterRange(event, layer, bin, clsMinIndex, clsMaxIndex);
 
@@ -545,7 +567,7 @@ void Tracker<T>::findTracksCA(ROframe<T>& event)
         clsInLayer1 = it1 - event.getClustersInLayer(layer1).begin();
 
         // loop over the bins in the search window
-        for (auto& binS : mBinsS[layer1][layer2 - 1][cluster1.indexTableBin]) {
+        for (const auto& binS : getBinsS()[layer1][layer2 - 1][cluster1.indexTableBin]) {
 
           getBinClusterRange(event, layer2, binS, clsMinIndexS, clsMaxIndexS);
 
@@ -571,7 +593,7 @@ void Tracker<T>::findTracksCA(ROframe<T>& event)
               dR2min = mLTFConeRadius ? dR2cut * dRCone * dRCone : dR2cut;
 
               // loop over the bins in the search window
-              for (auto& bin : mBins[layer1][layer - 1][cluster1.indexTableBin]) {
+              for (const auto& bin : getBins()[layer1][layer - 1][cluster1.indexTableBin]) {
 
                 getBinClusterRange(event, layer, bin, clsMinIndex, clsMaxIndex);
 

--- a/Detectors/ITSMFT/MFT/tracking/src/TrackerConfig.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/TrackerConfig.cxx
@@ -22,7 +22,6 @@ void o2::mft::TrackerConfig::initialize(const MFTTrackingParam& trkParam)
 {
   /// initialize from MFTTrackingParam (command line configuration parameters)
 
-  mFullClusterScan = trkParam.FullClusterScan;
   mMinTrackPointsLTF = trkParam.MinTrackPointsLTF;
   mMinTrackPointsCA = trkParam.MinTrackPointsCA;
   mMinTrackStationsLTF = trkParam.MinTrackStationsLTF;
@@ -31,20 +30,16 @@ void o2::mft::TrackerConfig::initialize(const MFTTrackingParam& trkParam)
   mLTFclsR2Cut = mLTFclsRCut * mLTFclsRCut;
   mROADclsRCut = trkParam.ROADclsRCut;
   mROADclsR2Cut = mROADclsRCut * mROADclsRCut;
-  mLTFseed2BinWin = trkParam.LTFseed2BinWin;
-  mLTFinterBinWin = trkParam.LTFinterBinWin;
-  mLTFConeRadius = trkParam.LTFConeRadius;
-  mCAConeRadius = trkParam.CAConeRadius;
-
   mRBins = trkParam.RBins;
   mPhiBins = trkParam.PhiBins;
   mRPhiBins = trkParam.RBins * trkParam.PhiBins;
+  mZVtxMin = trkParam.ZVtxMin;
+  mZVtxMax = trkParam.ZVtxMax;
+  mRCutAtZmin = trkParam.rCutAtZmin;
+  mLTFConeRadius = trkParam.LTFConeRadius;
+  mCAConeRadius = trkParam.CAConeRadius;
+  mFullClusterScan = trkParam.FullClusterScan;
+  mTrueTrackMCThreshold = trkParam.TrueTrackMCThreshold;
 
-  assert(mRPhiBins < constants::index_table::MaxRPhiBins);
-
-  mRBinSize = (constants::index_table::RMax - constants::index_table::RMin) / mRBins;
-  mPhiBinSize = (constants::index_table::PhiMax - constants::index_table::PhiMin) / mPhiBins;
-
-  mInverseRBinSize = 1.0 / mRBinSize;
-  mInversePhiBinSize = 1.0 / mPhiBinSize;
+  assert(mRPhiBins < constants::index_table::MaxRPhiBins && "Track finder binning overflow");
 }

--- a/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/TrackerSpec.h
+++ b/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/TrackerSpec.h
@@ -65,15 +65,13 @@ class TrackerDPL : public o2::framework::Task
 
   enum TimerIDs { SWTot,
                   SWLoadData,
-                  SWFindLTFTracks,
-                  SWFindCATracks,
+                  SWFindMFTTracks,
                   SWFitTracks,
                   SWComputeLabels,
                   NStopWatches };
   static constexpr std::string_view TimerName[] = {"TotalProcessing",
                                                    "LoadData",
-                                                   "FindLTFTracks",
-                                                   "FindCATracks",
+                                                   "FindTracks",
                                                    "FitTracks",
                                                    "ComputeLabels"};
   TStopwatch mTimer[NStopWatches];

--- a/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx
@@ -125,21 +125,16 @@ void TrackerDPL::run(ProcessingContext& pc)
       int worker = std::min(int(iROF / rofsPerWorker), mNThreads - 1);
       auto& roFrameData = roFrameDataVec[worker].emplace_back();
       int nclUsed = ioutils::loadROFrameData(rof, roFrameData, compClusters, pattIt, mDict, labels, tracker.get(), filter);
-      roFrameData.initialize(trackingParam.FullClusterScan);
       LOG(debug) << "ROframeId: " << iROF << ", clusters loaded : " << nclUsed << " on worker " << worker;
       iROF++;
     }
   };
 
-  auto launchLTF = [](auto* tracker, auto* workerROFs) {
+  auto launchTrackFinder = [](auto* tracker, auto* workerROFs) {
     for (auto& rofData : *workerROFs) {
-      tracker->findLTFTracks(rofData);
-    }
-  };
-
-  auto launchCA = [](auto* tracker, auto* workerROFs) {
-    for (auto& rofData : *workerROFs) {
-      tracker->findCATracks(rofData);
+      {
+        tracker->findTracks(rofData);
+      }
     }
   };
 
@@ -149,26 +144,12 @@ void TrackerDPL::run(ProcessingContext& pc)
     }
   };
 
-  auto runLTFTrackFinder = [&, this](auto& trackerVec, auto& roFrameDataVec) {
+  auto runMFTTrackFinder = [&, this](auto& trackerVec, auto& roFrameDataVec) {
     std::vector<std::future<void>> finder;
     for (int i = 0; i < mNThreads; i++) {
       auto& tracker = trackerVec[i];
       auto& workerData = roFrameDataVec[i];
-      auto f = std::async(std::launch::async, launchLTF, tracker.get(), &workerData);
-      finder.push_back(std::move(f));
-    }
-
-    for (int i = 0; i < mNThreads; i++) {
-      finder[i].wait();
-    }
-  };
-
-  auto runCATrackFinder = [&, this](auto& trackerVec, auto& roFrameDataVec) {
-    std::vector<std::future<void>> finder;
-    for (int i = 0; i < mNThreads; i++) {
-      auto& tracker = trackerVec[i];
-      auto& workerData = roFrameDataVec[i];
-      auto f = std::async(std::launch::async, launchCA, tracker.get(), &workerData);
+      auto f = std::async(std::launch::async, launchTrackFinder, tracker.get(), &workerData);
       finder.push_back(std::move(f));
     }
 
@@ -218,17 +199,11 @@ void TrackerDPL::run(ProcessingContext& pc)
     loadData(mTrackerVec, roFrameVec);
     mTimer[SWLoadData].Stop();
 
-    LOG(debug) << "Running LTF Finder.";
+    LOG(debug) << "Running MFT Track finder.";
 
-    mTimer[SWFindLTFTracks].Start(false);
-    runLTFTrackFinder(mTrackerVec, roFrameVec);
-    mTimer[SWFindLTFTracks].Stop();
-
-    LOG(debug) << "Running CA finder.";
-
-    mTimer[SWFindCATracks].Start(false);
-    runCATrackFinder(mTrackerVec, roFrameVec);
-    mTimer[SWFindCATracks].Stop();
+    mTimer[SWFindMFTTracks].Start(false);
+    runMFTTrackFinder(mTrackerVec, roFrameVec);
+    mTimer[SWFindMFTTracks].Stop();
 
     LOG(debug) << "Runnig track fitter.";
 
@@ -279,13 +254,9 @@ void TrackerDPL::run(ProcessingContext& pc)
     loadData(mTrackerLVec, roFrameVec);
     mTimer[SWLoadData].Stop();
 
-    mTimer[SWFindLTFTracks].Start(false);
-    runLTFTrackFinder(mTrackerLVec, roFrameVec);
-    mTimer[SWFindLTFTracks].Stop();
-
-    mTimer[SWFindCATracks].Start(false);
-    runCATrackFinder(mTrackerLVec, roFrameVec);
-    mTimer[SWFindCATracks].Stop();
+    mTimer[SWFindMFTTracks].Start(false);
+    runMFTTrackFinder(mTrackerLVec, roFrameVec);
+    mTimer[SWFindMFTTracks].Stop();
 
     mTimer[SWFitTracks].Start(false);
     runTrackFitter(mTrackerLVec, roFrameVec);


### PR DESCRIPTION
This commit improves the geometrical considerations used to sort clusters in R,Phi bins on each layer and related allocation of memory.

Geometry optimization changes:
- Cluster sorting binning defined by a cylindrical volume around Z axis, configurable by tracking parameters
- Variable radial bin size for each layer

Memory and CPU optimization changes:
- Move cluster sorting information from ROFrame to tracker class
- Reduce memory footprint of MFT tracker
- Cluster sorting moved to individual threads
- Combines LTF and CA track finding for each ROF (was TF)
- Relations between cluster bins now static member of tracker
- Single stopwatch for track-finding (LTF and CA now run together)

Other changes:
- Configurable parameter for true/fake track flag threshold