### PR TITLE
CCDBManager: Set condition-not-after in constructor when env variable…

### DIFF
--- a/CCDB/include/CCDB/BasicCCDBManager.h
+++ b/CCDB/include/CCDB/BasicCCDBManager.h
@@ -23,6 +23,7 @@
 #include <map>
 #include <unordered_map>
 #include <memory>
+#include <cstdlib>
 
 class TGeoManager; // we need to forward-declare those classes which should not be cleaned up
 
@@ -265,6 +266,17 @@ class BasicCCDBManager : public CCDBManagerInstance
 
  private:
   using CCDBManagerInstance::CCDBManagerInstance;
+  BasicCCDBManager(std::string const& url) : CCDBManagerInstance(url)
+  {
+    const char* t = getenv("ALICEO2_CCDB_CONDITION_NOT_AFTER");
+    if (t) {
+      auto timeaslong = strtol(t, nullptr, 10);
+      if (timeaslong != 0L) {
+        LOG(info) << "CCDB Time-machine constrained detected. Setting condition-not-after constrained to timestamp " << timeaslong;
+        setCreatedNotAfter(timeaslong);
+      }
+    }
+  }
 };
 
 } // namespace o2::ccdb


### PR DESCRIPTION
… is set

Provides possibility to apply CCDB time-machine feature (condition-not-after) globally to all places where BasicCCDBManager is used.