### PR TITLE
Changes for CRU suppression of zeroes

### DIFF
--- a/Detectors/TOF/compression/include/TOFCompression/Compressor.h
+++ b/Detectors/TOF/compression/include/TOFCompression/Compressor.h
@@ -74,6 +74,11 @@ class Compressor
     mDecoderCONET = val;
     mDecoderNextWordStep = val ? 0 : 2;
   };
+ 
+  void setDecoderCRUZEROES(bool val)
+  {
+    mDecoderNextWordStep = val ? 2 : 0;
+  };
 
   void setDecoderVerbose(bool val) { mDecoderVerbose = val; };
   void setEncoderVerbose(bool val) { mEncoderVerbose = val; };
@@ -119,7 +124,7 @@ class Compressor
   const uint32_t* mDecoderPointerMax = nullptr;
   const uint32_t* mDecoderPointerNext = nullptr;
   uint8_t mDecoderNextWord = 1;
-  uint8_t mDecoderNextWordStep = 2;
+  uint8_t mDecoderNextWordStep = 0;
   const RDH* mDecoderRDH;
   bool mDecoderCONET = false;
   bool mDecoderVerbose = false;


### PR DESCRIPTION
by default the decoder does not expect to have zeroes in words 2 and 3 of the CRU payload. this is going to be the future mode for the readout. a function is defined to restore the old behaviour.