### PR TITLE
MCH: properly configure the slot finalization

### DIFF
--- a/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/DsChannelId.h
+++ b/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/DsChannelId.h
@@ -54,6 +54,8 @@ class DsChannelId
 
   uint32_t value() const { return mChannelId; }
 
+  bool isValid() const { return (mChannelId != 0); }
+
  private:
   uint32_t mChannelId{0};
 

--- a/Detectors/MUON/MCH/Calibration/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Calibration/CMakeLists.txt
@@ -17,7 +17,7 @@ o2_add_library(MCHCalibration
            src/PedestalChannel.cxx
            src/PedestalData.cxx
            src/PedestalDigit.cxx
-           PUBLIC_LINK_LIBRARIES Microsoft.GSL::GSL O2::DetectorsCalibration O2::CCDB O2::MCHBase O2::MCHRawDecoder O2::DataFormatsMCH)
+           PUBLIC_LINK_LIBRARIES Microsoft.GSL::GSL O2::DetectorsCalibration O2::CCDB O2::MCHBase O2::MCHRawDecoder O2::DataFormatsMCH O2::MCHMappingImpl4)
 
 o2_target_root_dictionary(MCHCalibration HEADERS include/MCHCalibration/BadChannelCalibrator.h
                                                  include/MCHCalibration/BadChannelCalibratorParam.h

--- a/Detectors/MUON/MCH/Calibration/include/MCHCalibration/BadChannelCalibrator.h
+++ b/Detectors/MUON/MCH/Calibration/include/MCHCalibration/BadChannelCalibrator.h
@@ -63,6 +63,8 @@ class BadChannelCalibrator final : public o2::calibration::TimeSlotCalibration<o
 
   bool readyToSend(std::string& reason) const;
 
+  void finalize();
+
   const BadChannelsVector& getBadChannelsVector() const { return mBadChannelsVector; }
   const PedestalsVector& getPedestalsVector() const { return mPedestalsVector; }
 

--- a/Detectors/MUON/MCH/Calibration/include/MCHCalibration/PedestalChannel.h
+++ b/Detectors/MUON/MCH/Calibration/include/MCHCalibration/PedestalChannel.h
@@ -16,21 +16,23 @@
 
 namespace o2::mch::calibration
 {
-/** 
- * @class PedestalChannel 
+/**
+ * @class PedestalChannel
  * @brief Pedestal mean and sigma for one channel
  *
  * A PedestalChannel stores the mean and sigma of the pedestal of one MCH channel,
  * as well as the number of entries (digits) used to compute those values.
  */
 struct PedestalChannel {
-  int mEntries{0};         // number of entries used so far for the mean and variance
-  double mPedestal{0};     // mean
-  double mVariance{0};     // variance
-  DsChannelId dsChannelId; // identifier of the channel
+  int mEntries{0};         ///< number of entries used so far for the mean and variance
+  double mPedestal{0};     ///< mean
+  double mVariance{0};     ///< variance
+  DsChannelId dsChannelId; ///< identifier of the channel
 
   /** return the RMS of the pedestal */
   double getRms() const;
+
+  bool isValid() const; ///< true if the channel is associated to a detector pad
 
   std::string asString() const;
   friend std::ostream& operator<<(std::ostream&, const PedestalChannel&);

--- a/Detectors/MUON/MCH/Calibration/include/MCHCalibration/PedestalData.h
+++ b/Detectors/MUON/MCH/Calibration/include/MCHCalibration/PedestalData.h
@@ -133,25 +133,36 @@ class PedestalDataIterator
     return &mMapIt->second[mRow][mCol];
   }
 
-  PedestalDataIterator& operator++()
+  bool advance()
   {
     if (mMapIt != mData->mPedestals.end()) {
       if (mCol < PedestalData::MAXCHANNEL - 1) {
         mCol++;
-        return *this;
+        return true;
       }
       if (mRow < PedestalData::MAXDS - 1) {
         mCol = 0;
         mRow++;
-        return *this;
+        return true;
       }
       ++mMapIt;
       mCol = 0;
       mRow = 0;
       if (mMapIt != mData->mPedestals.end()) {
-        return *this;
+        return true;
       }
       mData = nullptr;
+    }
+    // undefined behavior here (should not increment an end iterator)
+    return false;
+  }
+
+  PedestalDataIterator& operator++()
+  {
+    while (advance()) {
+      if ((*this)->isValid()) {
+        break;
+      }
     }
     // undefined behavior here (should not increment an end iterator)
     return *this;

--- a/Detectors/MUON/MCH/Calibration/include/MCHCalibration/PedestalData.h
+++ b/Detectors/MUON/MCH/Calibration/include/MCHCalibration/PedestalData.h
@@ -14,6 +14,7 @@
 
 #include "MCHCalibration/PedestalChannel.h"
 #include "MCHCalibration/PedestalDigit.h"
+#include "MCHRawElecMap/Mapper.h"
 #include "Rtypes.h"
 #include <array>
 #include <gsl/span>
@@ -32,7 +33,7 @@ class PedestalDataIterator;
 }
 
 /**
- * @class PedestalData 
+ * @class PedestalData
  * @brief Compute and store the mean and RMS of the pedestal digit amplitudes
  *
  * To extract the values from PedestalData, use the provided iterator(s).
@@ -57,7 +58,7 @@ class PedestalData
   const_iterator cbegin() const;
   const_iterator cend() const;
 
-  PedestalData() = default;
+  PedestalData();
   ~PedestalData() = default;
 
   void reset();
@@ -70,14 +71,14 @@ class PedestalData
   /** a map from solarIds to PedestalMatrix */
   using PedestalsMap = std::unordered_map<int, PedestalMatrix>;
 
-  /** function to update the pedestal values from the data 
+  /** function to update the pedestal values from the data
    * @param digits a span of pedestal digits for a single TimeFrame
-  */
+   */
   void fill(const gsl::span<const PedestalDigit> digits);
 
   /** merge this object with other
-  * FIXME: not yet implemented.
-  */
+   * FIXME: not yet implemented.
+   */
   void merge(const PedestalData* other);
 
   /** dump this object. */
@@ -86,7 +87,13 @@ class PedestalData
   uint32_t size() const;
 
  private:
+  PedestalData::PedestalMatrix initPedestalMatrix(uint16_t solarId);
+
+  o2::mch::raw::Solar2FeeLinkMapper mSolar2FeeLinkMapper;
+  o2::mch::raw::Elec2DetMapper mElec2DetMapper;
+
   PedestalsMap mPedestals{}; ///< internal storage of all PedestalChannel values
+  uint32_t mSize{0};         ///< total number of valid channels in the pedestals map
 
   ClassDefNV(PedestalData, 1)
 };

--- a/Detectors/MUON/MCH/Calibration/include/MCHCalibration/PedestalDigit.h
+++ b/Detectors/MUON/MCH/Calibration/include/MCHCalibration/PedestalDigit.h
@@ -24,9 +24,9 @@
 namespace o2::mch::calibration
 {
 
-/** 
- * @class PedestalDigit 
- * @brief "Fat" digit for pedestal data. 
+/**
+ * @class PedestalDigit
+ * @brief "Fat" digit for pedestal data.
  *
  * In contrast to a "regular" digit, a PedestalDigit stores ADC samples
  * (up to `MCH_PEDESTALS_MAX_SAMPLES` samples)

--- a/Detectors/MUON/MCH/Calibration/src/BadChannelCalibrationDevice.h
+++ b/Detectors/MUON/MCH/Calibration/src/BadChannelCalibrationDevice.h
@@ -57,7 +57,11 @@ class BadChannelCalibrationDevice : public o2::framework::Task
   std::shared_ptr<o2::base::GRPGeomRequest> mCCDBRequest;
   uint64_t mTimeStamp;
 
-  int mLoggingInterval = {0}; /// time interval between statistics logging messages
+  bool mHasEnoughStat = {false};
+
+  bool mSkipData = {false}; ///< when true the input pedestal digits are skipped
+
+  int mLoggingInterval = {0}; ///< time interval between statistics logging messages
 };
 
 } // namespace o2::mch::calibration

--- a/Detectors/MUON/MCH/Calibration/src/BadChannelCalibrator.cxx
+++ b/Detectors/MUON/MCH/Calibration/src/BadChannelCalibrator.cxx
@@ -71,7 +71,7 @@ bool BadChannelCalibrator::hasEnoughData(const Slot& slot) const
   const int requiredChannels = static_cast<int>(BadChannelCalibratorParam::Instance().minRequiredCalibratedFraction * nofChannels);
 
   auto nofCalibrated = std::count_if(pedData->cbegin(), pedData->cend(),
-                                     [&](const PedestalChannel& c) { return (c.isValid() && (c.mEntries > minNofEntries)); });
+                                     [&](const PedestalChannel& c) { return c.mEntries > minNofEntries; });
 
   bool hasEnough = nofCalibrated > requiredChannels;
 
@@ -100,7 +100,7 @@ void BadChannelCalibrator::finalizeSlot(Slot& slot)
   }
 
   for (const auto& ped : *pedestalData) {
-    if (!ped.isValid() || ped.mEntries == 0) {
+    if (ped.mEntries == 0) {
       continue;
     }
     mPedestalsVector.emplace_back(ped);

--- a/Detectors/MUON/MCH/Calibration/src/PedestalChannel.cxx
+++ b/Detectors/MUON/MCH/Calibration/src/PedestalChannel.cxx
@@ -27,7 +27,6 @@ bool PedestalChannel::isValid() const
   return dsChannelId.isValid();
 }
 
-
 std::string PedestalChannel::asString() const
 {
   return fmt::format("{} entries {:8d} mean {:7.2f} mVariance {:7.2f} rms {:7.2f}",

--- a/Detectors/MUON/MCH/Calibration/src/PedestalChannel.cxx
+++ b/Detectors/MUON/MCH/Calibration/src/PedestalChannel.cxx
@@ -22,10 +22,16 @@ double PedestalChannel::getRms() const
   return mEntries > 0 ? std::sqrt(mVariance / mEntries) : std::numeric_limits<double>::max();
 }
 
+bool PedestalChannel::isValid() const
+{
+  return dsChannelId.isValid();
+}
+
+
 std::string PedestalChannel::asString() const
 {
-  return fmt::format("{} entries {:8d} mean {:7.2f} mVariance {:7.2f}",
-                     dsChannelId.asString(), mEntries, mPedestal, mVariance);
+  return fmt::format("{} entries {:8d} mean {:7.2f} mVariance {:7.2f} rms {:7.2f}",
+                     dsChannelId.asString(), mEntries, mPedestal, mVariance, getRms());
 }
 
 std::ostream& operator<<(std::ostream& os, const PedestalChannel& c)

--- a/Detectors/MUON/MCH/Calibration/src/PedestalData.cxx
+++ b/Detectors/MUON/MCH/Calibration/src/PedestalData.cxx
@@ -13,6 +13,7 @@
 #include "DataFormatsMCH/DsChannelId.h"
 #include "MCHCalibration/PedestalData.h"
 #include "MCHCalibration/PedestalDigit.h"
+#include "MCHMappingInterface/Segmentation.h"
 #include "fairlogger/Logger.h"
 #include <cmath>
 #include <iostream>
@@ -22,17 +23,44 @@
 namespace o2::mch::calibration
 {
 
+PedestalData::PedestalData()
+{
+  mSolar2FeeLinkMapper = o2::mch::raw::createSolar2FeeLinkMapper<o2::mch::raw::ElectronicMapperGenerated>();
+  mElec2DetMapper = o2::mch::raw::createElec2DetMapper<o2::mch::raw::ElectronicMapperGenerated>();
+}
+
 void PedestalData::reset()
 {
   mPedestals.clear();
 }
 
-PedestalData::PedestalMatrix initPedestalMatrix(uint16_t solarId)
+PedestalData::PedestalMatrix PedestalData::initPedestalMatrix(uint16_t solarId)
 {
   PedestalData::PedestalMatrix m;
-  for (uint8_t c = 0; c < PedestalData::MAXCHANNEL; c++) {
-    for (uint8_t d = 0; d < PedestalData::MAXDS; d++) {
-      m[d][c].dsChannelId = DsChannelId{solarId, d, c};
+  for (uint8_t d = 0; d < PedestalData::MAXDS; d++) {
+    // apply the mapping from SOLAR to detector
+    int deId = -1;
+    int dsIddet = -1;
+
+    o2::mch::raw::DsElecId dsElecId(solarId, d / 5, d % 5);
+    std::optional<o2::mch::raw::DsDetId> dsDetId = mElec2DetMapper(dsElecId);
+    if (dsDetId) {
+      deId = dsDetId->deId();
+      dsIddet = dsDetId->dsId();
+    }
+
+    for (uint8_t c = 0; c < PedestalData::MAXCHANNEL; c++) {
+
+      // check if the channel is associated to a detector pad
+      int padId = -1;
+      if (deId >= 0 && dsIddet >= 0) {
+        const o2::mch::mapping::Segmentation& segment = o2::mch::mapping::segmentation(deId);
+        padId = segment.findPadByFEE(dsIddet, int(c));
+      }
+      if (padId >= 0) {
+        m[d][c].dsChannelId = DsChannelId{solarId, d, c};
+        mSize += 1;
+      }
     }
   }
   return m;
@@ -55,13 +83,12 @@ void PedestalData::fill(gsl::span<const PedestalDigit> digits)
     }
 
     if (iPedestal == mPedestals.end()) {
-      std::cout << "[PedestalData::process] failed to insert new element\n";
+      LOGP(fatal, "failed to insert new element in padestals map");
       break;
     }
 
     auto& ped = iPedestal->second[dsId][channel];
-
-    ped.dsChannelId = DsChannelId{solarId, dsId, channel};
+    //ped.dsChannelId = DsChannelId{solarId, dsId, channel};
 
     for (uint16_t i = 0; i < d.nofSamples(); i++) {
       auto s = d.getSample(i);
@@ -79,8 +106,8 @@ void PedestalData::fill(gsl::span<const PedestalDigit> digits)
     }
 
     if (mDebug) {
-      std::cout << "solarId " << (int)solarId << "  dsId " << (int)dsId << "  ch " << (int)channel << "  nsamples " << d.nofSamples()
-                << "  entries " << ped.mEntries << "  ped " << ped.mPedestal << "  mVariance " << ped.mVariance << std::endl;
+      LOGP(info, "solarId {}  dsId {}  ch {}  nsamples {}  entries{}  mean {}  variance {}",
+           (int)solarId, (int)dsId, (int)channel, d.nofSamples(), ped.mEntries, ped.mPedestal, ped.mVariance);
     }
   }
 }
@@ -100,7 +127,7 @@ void PedestalData::print() const
 
 uint32_t PedestalData::size() const
 {
-  return mPedestals.size() * MAXCHANNEL * MAXDS;
+  return mSize;
 }
 
 PedestalData::iterator PedestalData::begin()

--- a/Detectors/MUON/MCH/Calibration/src/PedestalData.cxx
+++ b/Detectors/MUON/MCH/Calibration/src/PedestalData.cxx
@@ -88,7 +88,6 @@ void PedestalData::fill(gsl::span<const PedestalDigit> digits)
     }
 
     auto& ped = iPedestal->second[dsId][channel];
-    //ped.dsChannelId = DsChannelId{solarId, dsId, channel};
 
     for (uint16_t i = 0; i < d.nofSamples(); i++) {
       auto s = d.getSample(i);

--- a/Detectors/MUON/MCH/Calibration/test/example-mch-pedestal-calibration.sh
+++ b/Detectors/MUON/MCH/Calibration/test/example-mch-pedestal-calibration.sh
@@ -1,7 +1,10 @@
+date
+
 o2-raw-tf-reader-workflow --input-data \
-    $HOME/alice/data/2022/MAY/514781/raw/1100 --onlyDet MCH --max-tf 10 | \
+    $HOME/alice/data/2022/LHC22t_MCH/529437/calib/1140 --onlyDet MCH --max-tf 1000 | \
 o2-mch-pedestal-decoding-workflow | \
-o2-calibration-mch-badchannel-calib-workflow | \
+o2-calibration-mch-badchannel-calib-workflow \
+  --configKeyValues="MCHBadChannelCalibratorParam.minRequiredNofEntriesPerChannel=10;MCHBadChannelCalibratorParam.minRequiredCalibratedFraction=0.5;MCHBadChannelCalibratorParam.onlyAtEndOfStream=true" | \
 o2-calibration-ccdb-populator-workflow \
     --ccdb-path http://localhost:6464 \
     --sspec-min 0 --sspec-max 0 | \
@@ -9,3 +12,4 @@ o2-calibration-ccdb-populator-workflow \
     --ccdb-path localhost:8484 --sspec-max 1 --sspec-min 1 --name-extention dcs | \
 o2-dpl-run --run -b
 
+date

--- a/Detectors/MUON/MCH/Calibration/test/testPedestalData.cxx
+++ b/Detectors/MUON/MCH/Calibration/test/testPedestalData.cxx
@@ -13,10 +13,13 @@
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
 
-#include "MCHCalibration/PedestalDigit.h"
 #include "MCHCalibration/PedestalData.h"
-#include <vector>
+#include "MCHCalibration/PedestalDigit.h"
+#include "MCHConstants/DetectionElements.h"
+#include "MCHMappingInterface/Segmentation.h"
+#include "MCHRawElecMap/Mapper.h"
 #include <random>
+#include <vector>
 
 std::vector<uint16_t> samples(int n)
 {
@@ -35,14 +38,53 @@ using o2::mch::calibration::PedestalDigit;
 struct PedestalDigits {
   PedestalDigits()
   {
+    // non existing DS : that channel should not appear when iterating on pedestal data
     digits.emplace_back(721, 23, 13, 1234, 43, samples(13));
+
+    // solarId 721 groupId 5 indexId 1
+    // S721-J5-DS1 (elinkId 26) [ FEE30-LINK1 ] DE708-DS102
     digits.emplace_back(721, 26, 16, 2345, 46, samples(16));
-    digits.emplace_back(328, 28, 18, 3456, 48, samples(18));
+
+    // solarId 328 groupId 5 indexId 2
+    // S328-J5-DS2 (elinkId 27) [ FEE32-LINK6 ] DE714-DS108 channel 18
+    digits.emplace_back(328, 27, 18, 3456, 48, samples(18));
   }
   std::vector<PedestalDigit> digits;
 };
 
 BOOST_FIXTURE_TEST_SUITE(PedestalDataIterator, PedestalDigits)
+
+BOOST_AUTO_TEST_CASE(TestIteratorOnCompletePedestalData)
+{
+  // build a vector of all possible digits
+  std::vector<PedestalDigit> allDigits;
+
+  auto det2elec = o2::mch::raw::createDet2ElecMapper<o2::mch::raw::ElectronicMapperGenerated>();
+
+  for (auto deId : o2::mch::constants::deIdsForAllMCH) {
+    const auto& seg = o2::mch::mapping::segmentation(deId);
+    seg.forEachPad([&](int padID) {
+      if (seg.isValid(padID)) {
+        auto dsId = seg.padDualSampaId(padID);
+        auto ch = seg.padDualSampaChannel(padID);
+        o2::mch::raw::DsDetId det(deId, dsId);
+        auto elec = det2elec(det).value();
+        auto solarId = elec.solarId();
+        allDigits.emplace_back(solarId, elec.elinkId(), ch, 42, 42, samples(15));
+      }
+    });
+  }
+
+  PedestalData pd;
+  pd.fill(allDigits);
+
+  BOOST_REQUIRE(allDigits.size() == 1063528);
+  int n{0};
+  for (const auto& ped : pd) {
+    ++n;
+  }
+  BOOST_TEST(n == allDigits.size());
+}
 
 BOOST_AUTO_TEST_CASE(TestIteratorEquality)
 {
@@ -70,7 +112,23 @@ BOOST_AUTO_TEST_CASE(TestIteratorPreIncrementable)
   for (auto rec : pd) {
     n++;
   }
-  BOOST_TEST(n == PedestalData::MAXDS * PedestalData::MAXCHANNEL * 2);
+  BOOST_TEST(n == 2768);
+  // 2768 = 1856 pads in solar 328 + 721 pads in solar 721
+  // Note that solar 328 has 29 dual sampas
+  // solar 721 has 15 dual sampas
+  // But 2768 < (29+15)*64 (=2816) because not all pads are valid ones.
+}
+
+BOOST_AUTO_TEST_CASE(TestIteratorAllReturnedPadAreValidByConstruction)
+{
+  PedestalData pd;
+  pd.fill(digits);
+  auto n = std::count_if(pd.begin(), pd.end(), [](o2::mch::calibration::PedestalChannel& c) {
+    return c.isValid();
+  });
+  auto n1 = std::distance(pd.begin(), pd.end());
+  BOOST_TEST(n == 2768);
+  BOOST_CHECK(n == n1);
 }
 
 BOOST_AUTO_TEST_CASE(TestIteratorInCountIfAlgorithm)
@@ -80,7 +138,7 @@ BOOST_AUTO_TEST_CASE(TestIteratorInCountIfAlgorithm)
   auto n = std::count_if(pd.begin(), pd.end(), [](o2::mch::calibration::PedestalChannel& c) {
     return c.mEntries > 0;
   });
-  BOOST_TEST(n == 3);
+  BOOST_TEST(n == 2); // 2 and not 3 because one of the digit is on a pad that is not connected (hence invalid, hence not part of the iteration)
 }
 
 BOOST_AUTO_TEST_CASE(IterationOnEmptyDataShouldNotBeAnInfiniteLoop, *boost::unit_test::timeout(10))


### PR DESCRIPTION
The call to `setSlotLength(o2::calibration::INFINITE_TF)` does not seem to be appropriate in order to trigger the slot finalization at EoS, because it does not set the `mFinalizeWhenReady` data member of the `TimeSlotCalibration` base class. This is needed in order to properly trigger the slot finalization when calling `checkSlotsToFinalize(o2::calibration::INFINITE_TF)`.

An explicit call to `setFinalizeWhenReady()` is instead needed. Internally this also calls `setSlotLength(o2::calibration::INFINITE_TF)`.