### PR TITLE
Another fix for CCDB server detection

### DIFF
--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -138,7 +138,7 @@ void CcdbApi::init(std::string const& host)
     snapshotReport += ')';
   }
 
-  mNeedAlienToken = (host.find("https://") == 0) || (host.find("http://alice-ccdb.cern.ch") == 0);
+  mNeedAlienToken = (host.find("https://") != std::string::npos) || (host.find("alice-ccdb.cern.ch") != std::string::npos);
 
   LOGP(info, "Init CcdApi with UserAgentID: {}, Host: {}{}", mUniqueAgentID, host,
        mInSnapshotMode ? "(snapshot readonly mode)" : snapshotReport.c_str());


### PR DESCRIPTION
@shahor02 : I think we might need to relax the check even more, otherwise it might fail for e.g. https://github.com/AliceO2Group/O2DPG/blob/master/DATA/production/qc-async/qc-global.json when the `http://` is not in the URL