### PR TITLE
[FOCAL-10] Fixes for merging pad and pixel data

### DIFF
--- a/DataFormats/Detectors/FOCAL/include/DataFormatsFOCAL/PixelChipRecord.h
+++ b/DataFormats/Detectors/FOCAL/include/DataFormatsFOCAL/PixelChipRecord.h
@@ -37,7 +37,7 @@ class PixelChipRecord
   int getLaneID() const { return mLaneID; }
   int getChipID() const { return mChipID; }
   int getFirstHit() const { return mHitIndexRange.getFirstEntry(); }
-  int getNumberOfHits() const { return mHitIndexRange.getFirstEntry(); }
+  int getNumberOfHits() const { return mHitIndexRange.getEntries(); }
 
   void printStream(std::ostream& stream) const;
 

--- a/DataFormats/Detectors/FOCAL/src/Event.cxx
+++ b/DataFormats/Detectors/FOCAL/src/Event.cxx
@@ -11,6 +11,8 @@
 #include <algorithm>
 #include <DataFormatsFOCAL/ErrorHandling.h>
 #include <DataFormatsFOCAL/Event.h>
+#include <iostream>
+
 using namespace o2::focal;
 
 PadLayerEvent& Event::getPadLayer(unsigned int index)
@@ -69,7 +71,21 @@ void Event::construct(const o2::InteractionRecord& interaction, gsl::span<const 
   }
 
   for (auto& chip : eventPixels) {
-    mPixelLayers[chip.getLayerID()].addChip(chip.getLaneID(), chip.getChipID(), pixelHits.subspan(chip.getFirstHit(), chip.getNumberOfHits()));
+    if (chip.getLayerID() > 1) {
+      std::cerr << "Invalid layer ID chip " << chip.getChipID() << ": " << chip.getLayerID() << std::endl;
+      continue;
+    }
+    if (chip.getNumberOfHits()) {
+      if (chip.getFirstHit() >= pixelHits.size()) {
+        std::cerr << "First hit index " << chip.getFirstHit() << " exceeding hit contiainer " << pixelHits.size() << std::endl;
+        continue;
+      }
+      if (chip.getFirstHit() + chip.getNumberOfHits() - 1 >= pixelHits.size()) {
+        std::cerr << "First hit index " << chip.getFirstHit() + chip.getNumberOfHits() - 1 << " exceeding hit contiainer " << pixelHits.size() << std::endl;
+        continue;
+      }
+      mPixelLayers[chip.getLayerID()].addChip(chip.getLaneID(), chip.getChipID(), pixelHits.subspan(chip.getFirstHit(), chip.getNumberOfHits()));
+    }
   }
 }
 

--- a/Detectors/FOCAL/base/include/FOCALBase/EventReader.h
+++ b/Detectors/FOCAL/base/include/FOCALBase/EventReader.h
@@ -44,6 +44,8 @@ class EventReader
   std::unique_ptr<TTreeReaderValue<std::vector<PixelHit>>> mPixelHitBranch;
   std::unique_ptr<TTreeReaderValue<std::vector<PixelChipRecord>>> mPixelChipBranch;
   std::unique_ptr<TTreeReaderValue<std::vector<TriggerRecord>>> mTriggerBranch;
+
+  ClassDefNV(EventReader, 1);
 };
 
 } // namespace o2::focal

--- a/Detectors/FOCAL/workflow/include/FOCALWorkflow/RawDecoderSpec.h
+++ b/Detectors/FOCAL/workflow/include/FOCALWorkflow/RawDecoderSpec.h
@@ -42,6 +42,7 @@ class RawDecoderSpec : public framework::Task
     std::vector<std::array<PadLayerEvent, constants::PADS_NLAYERS>> mPadEvents;
     std::vector<std::array<PixelLayerEvent, constants::PIXELS_NLAYERS>> mPixelEvent;
     std::vector<o2::InteractionRecord> mPixelTriggers;
+    std::vector<std::vector<int>> mFEEs;
   };
   RawDecoderSpec() = default;
   RawDecoderSpec(uint32_t outputSubspec, bool usePadData, bool usePixelData, bool debug) : mDebugMode(debug), mUsePadData(usePadData), mUsePixelData(usePixelData), mOutputSubspec(outputSubspec) {}
@@ -56,12 +57,13 @@ class RawDecoderSpec : public framework::Task
  private:
   void sendOutput(framework::ProcessingContext& ctx);
   void resetContainers();
-  int decodePadData(const gsl::span<const char> padWords, o2::InteractionRecord& interaction);
-  void decodePadEvent(const gsl::span<const char> padWords, o2::InteractionRecord& interaction);
-  int decodePixelData(const gsl::span<const char> pixelWords, o2::InteractionRecord& interaction, int fecID);
+  int decodePadData(const gsl::span<const char> padWords, o2::InteractionRecord& hbIR);
+  void decodePadEvent(const gsl::span<const char> padWords, o2::InteractionRecord& hbIR);
+  int decodePixelData(const gsl::span<const char> pixelWords, o2::InteractionRecord& hbIR, int fecID);
   std::array<PadLayerEvent, constants::PADS_NLAYERS> createPadLayerEvent(const o2::focal::PadData& data) const;
   void fillChipsToLayer(PixelLayerEvent& pixellayer, const gsl::span<const PixelChip>& chipData);
   void fillEventPixeHitContainer(std::vector<PixelHit>& eventHits, std::vector<PixelChipRecord>& eventChips, const PixelLayerEvent& pixelLayer, int layerIndex);
+  int filterIncompletePixelsEventsHBF(HBFData& data, const std::vector<int>& expectFEEs);
   void buildEvents();
   bool consistencyCheckPixelFEE(const std::unordered_map<int, int>& counters) const;
   int maxCounter(const std::unordered_map<int, int>& counters) const;
@@ -73,6 +75,7 @@ class RawDecoderSpec : public framework::Task
   bool mDebugMode = false;
   bool mUsePadData = true;
   bool mUsePixelData = true;
+  bool mFilterIncomplete = false;
   uint32_t mOutputSubspec = 0;
   PadDecoder mPadDecoder;
   PixelDecoder mPixelDecoder;


### PR DESCRIPTION
- Simplify iteration over HBF and unify for pad and
  pixel
- Use HBIR for lookup in map of HBFs
- Filter spurious triggers in pixels (pixels with different
  orbit than HB orbit)
- Add option to remove incomplete pixel events (data
  from at least 1 FEE missing)
- Fix consistency check between number of pixel
  events, pad events and triggers