### PR TITLE
treat MC QED background labels as not valid

### DIFF
--- a/DataFormats/simulation/include/SimulationDataFormat/MCCompLabel.h
+++ b/DataFormats/simulation/include/SimulationDataFormat/MCCompLabel.h
@@ -65,8 +65,10 @@ class MCCompLabel
   bool isSet() const { return mLabel != NotSet; }
   // check if label was not assigned
   bool isEmpty() const { return mLabel == NotSet; }
-  // check if label corresponds to real particle
-  bool isNoise() const { return mLabel == Noise; }
+  // check if label comes from QED contrib
+  bool isQED() const { return getSourceID() == 99; }
+  // check if label corresponds to real particle (for the moment QED is not included)
+  bool isNoise() const { return mLabel == Noise || isQED(); }
   // check if label was assigned as for correctly identified particle
   bool isValid() const { return isSet() && !isNoise(); }
 


### PR DESCRIPTION
Currently the AOD conversion crashes when encountering QED labels. I believe we can simply treat them as noise and therefore invalid labels in the true MC sense.

This commit then fixes the crash in the AOD conversation https://alice.its.cern.ch/jira/browse/O2-3508.

In case, special QED information needs to be included into AODs, we would need to adjust the AOD converter.