### PR TITLE
TPC IDC: optimizing outlier filtering

### DIFF
--- a/Detectors/TPC/base/include/TPCBase/Mapper.h
+++ b/Detectors/TPC/base/include/TPCBase/Mapper.h
@@ -405,7 +405,7 @@ class Mapper
   static constexpr unsigned short getPadsInOROC() { return mPadsInOROC; }
   static constexpr unsigned short getPadsInSector() { return mPadsInSector; }
 
-  unsigned short getNumberOfPads(const GEMstack gemStack) const
+  static constexpr unsigned short getNumberOfPads(const GEMstack gemStack)
   {
     switch (gemStack) {
       case IROCgem: {

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCContainer.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCContainer.h
@@ -449,7 +449,9 @@ enum class PadFlags : unsigned short {
   flagSaturatedPad = 1 << 3, ///< flag for saturated status binary 0100
   flagHighPad = 1 << 4,      ///< flag for pad with extremly high IDC value
   flagLowPad = 1 << 5,       ///< flag for pad with extremly low IDC value
-  flagSkip = 1 << 6          ///< flag for defining a pad which is just ignored during the calculation of I1 and IDCDelta
+  flagSkip = 1 << 6,         ///< flag for defining a pad which is just ignored during the calculation of I1 and IDCDelta
+  flagFEC = 1 << 7,          ///< flag for a whole masked FEC
+  flagNeighbour = 1 << 8     ///< flag if n neighbouring pads are outlier
 };
 
 inline PadFlags operator&(PadFlags a, PadFlags b) { return static_cast<PadFlags>(static_cast<int>(a) & static_cast<int>(b)); }

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCFactorization.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCFactorization.h
@@ -75,13 +75,28 @@ class IDCFactorization : public IDCGroupHelperSector
   void factorizeIDCs(const bool norm, const bool calcDeltas);
 
   /// calculate I_0(r,\phi) = <I(r,\phi,t)>_t
+  /// \param norm normalize IDCs to pad area
   void calcIDCZero(const bool norm);
 
   /// fill I_0 values in case of dead pads,FECs etc.
   void fillIDCZeroDeadPads();
 
   /// create status map for pads which are dead or delivering extremly high values (static outliers will be mapped)
+  /// \param debug create debug output
+  void createStatusMapOutlier(const bool debug = false);
+
+  /// 1. createStatusMap, 2. checkFECs, 3. checkNeighbourOutliers
   void createStatusMap();
+
+  /// after the pad-by-pad status map has been created it can be used to mark FECs which deliver wrong values
+  /// \param maxOutliersPerFEC  if the ratio n_outliers_per_FEC / n_pads_per_FEC is larger than this value, the whole FEC is masked
+  void checkFECs(const float maxOutliersPerFEC = 0.7);
+
+  /// check for each pad where there is no outlier found the neighbouring pads for outliers. If more than n neighbours contains outliers this pad is also marked as an outlier pad
+  /// +- one pad in row direction and +- two pads in pad direction are considered
+  /// \param maxIter maximum number of iterations of the procedure
+  /// \param nOutliersNeighbours minimum number of outliers of the neighbouring pads which are required to mask a pad as outlier
+  void checkNeighbourOutliers(const int maxIter = 10, const int nOutliersNeighbours = 8);
 
   /// calculate I_1(t) = <I(r,\phi,t) / I_0(r,\phi)>_{r,\phi}
   void calcIDCOne();
@@ -312,12 +327,15 @@ class IDCFactorization : public IDCGroupHelperSector
 
   /// \param integrationIntervals number of integration intervals which will be dumped to the tree (-1: all integration intervalls)
   /// \param outFileName name of the output file
-  void dumpToTree(int integrationIntervals = -1, const char* outFileName = "IDCTree.root") const;
+  void dumpToTree(const Side side, const char* outFileName = "IDCTree.root");
 
   /// dumping the IDC1 to a TTree including the timestamps (the start time stamp in ms should be set with setTimeStamp())
   /// \param integrationTimeOrbits integration time in orbits
   /// \param outFileName name of the output file
   void dumpToTreeIDC1(const float integrationTimeOrbits = 12, const char* outFileName = "IDC1Tree.root") const;
+
+  /// dump IDCDelta to a TTree
+  void dumpIDCDeltaToTree(const Side side, const int chunk = 0, const char* outFileName = "IDCDeltaTree.root");
 
   /// \returns vector containing the number of integration intervals for each stored TF (dropped TFs not taken into account)
   /// \param cru cru which is used for the lookup (cru=-1: automatic cru lookup)
@@ -371,6 +389,21 @@ class IDCFactorization : public IDCGroupHelperSector
   /// set the IDCOne
   void setIDCOne(const Side side, const IDCOne& idcOne) { mIDCOne[mSideIndex[side]] = idcOne; }
 
+  /// set the IDCDelta
+  void setIDCDelta(const Side side, const IDCDelta<float>& idcDelta, const int index = 0) { mIDCDelta[mSideIndex[side]][index] = idcDelta; }
+
+  /// \return returns mean of IDC0 for given side
+  float getMeanZ(const Side side) const;
+
+  /// normalize IDC0 with the set gain map
+  void normIDCZeroGain() { normIDCZero(0); }
+
+  /// normalize IDC0 with the median per stack
+  void normIDCZeroStackMedian() { normIDCZero(1); }
+
+  /// \return returns median of IDC0 per stack for all stacks
+  std::array<float, o2::tpc::GEMSTACKS> getStackMedian() const;
+
  private:
   const unsigned int mTimeFrames{};                                 ///< number of timeframes which are stored
   const unsigned int mTimeFramesDeltaIDC{};                         ///< number of timeframes of which Delta IDCs are stored
@@ -400,7 +433,7 @@ class IDCFactorization : public IDCGroupHelperSector
   void drawIDCZeroHelper(const bool type, const Sector sector, const std::string filename, const float minZ, const float maxZ) const;
 
   /// get time frame and index of integrationInterval in the TF
-  void getTF(const unsigned int region, unsigned int integrationInterval, unsigned int& timeFrame, unsigned int& interval) const;
+  void getTF(unsigned int integrationInterval, unsigned int& timeFrame, unsigned int& interval) const;
 
   /// \returns chunk from timeframe
   unsigned int getChunk(const unsigned int timeframe) const;
@@ -410,6 +443,9 @@ class IDCFactorization : public IDCGroupHelperSector
 
   /// helper function for drawing
   void drawPadFlagMap(const bool type, const Sector sector, const std::string filename, const PadFlags flag) const;
+
+  /// normalize IDC0
+  void normIDCZero(const int type);
 
   ClassDefNV(IDCFactorization, 2)
 };

--- a/Detectors/TPC/calibration/include/TPCCalibration/IDCGroupingParameter.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/IDCGroupingParameter.h
@@ -45,10 +45,9 @@ struct ParameterIDCGroup : public o2::conf::ConfigurableParamHelper<ParameterIDC
   unsigned int groupPadsSectorEdges{0};                                                 ///< decoded number of pads at the sector edges which are grouped differently. First digit specifies the EdgePadGroupingMethod  (example: 0: no pads are grouped, 110: first two pads are not grouped, 3210: first pad is not grouped, second + third pads are grouped, fourth + fifth + sixth pads are grouped)
   AveragingMethod method = AveragingMethod::FAST;                                       ///< method which is used for averaging
   float sigma = 3.f;                                                                    ///< sigma cut which can be used during the grouping for outlier filtering
-  float minIDC0Median = 6;                                                              ///< this value is used for identifying outliers (pads with high IDC0 values): "accepted IDC 0 values > median_IDC0 + stdDev * minIDC0Median"
-  float maxIDC0Median = 6;                                                              ///< this value is used for identifying outliers (pads with high IDC0 values): "accepted IDC 0 values < median_IDC0 + stdDev * maxIDC0Median"
-  int minIDC0Val = 1;                                                                   ///< minimum accepted IDC0 value (should be larger than 0 in case of real data)
-  int maxIDC0Val = 150;                                                                 ///< maximum accepted IDC0 value (max IDC0 for 3MHz pp ~30)
+  float minIDC0Median = 8;                                                              ///< this value is used for identifying outliers (pads with low IDC0 values): "accepted IDC 0 values > median_IDC0 + stdDev * minIDC0Median"
+  float maxIDC0Median = 15;                                                             ///< this value is used for identifying outliers (pads with high IDC0 values): "accepted IDC 0 values < median_IDC0 + stdDev * maxIDC0Median"
+  float minmaxIDC0MedianCentreEdge = 20;                                                ///< this value is used for identifying outliers at the centre of the cross and the edges of the sector i.e. where the gain is significantly lower (cross) and sometimes higher at the edges"
 
   /// Helper function for setting the groupimg parameters from a string (can be "X": parameters in all regions are "X" or can be "1,2,3,4,5,6,7,8,9,10" for setting individual regions)
   /// \param sgroupPads string for grouping parameter in pad direction

--- a/Detectors/TPC/calibration/include/TPCCalibration/RobustAverage.h
+++ b/Detectors/TPC/calibration/include/TPCCalibration/RobustAverage.h
@@ -71,7 +71,8 @@ class RobustAverage
 
   /// returns the filtered average value
   /// \param sigma maximum accepted standard deviation: sigma*stdev
-  float getFilteredAverage(const float sigma = 3);
+  ///\param interQuartileRange number of points in inner quartile to consider
+  std::pair<float, float> getFilteredAverage(const float sigma = 3, const float interQuartileRange = 0.9);
 
   /// \return returns mean of stored values
   float getMean() const { return mValues.empty() ? 0 : getMean(mValues.begin(), mValues.end()); }
@@ -83,7 +84,10 @@ class RobustAverage
   float getWeightedMean() const { return getWeightedMean(mValues.begin(), mValues.end(), mWeights.begin(), mWeights.end()); }
 
   /// \return returns standard deviation of stored values
-  float getStdDev() { return getStdDev(getMean()); }
+  float getStdDev() { return getStdDev(getMean(), mValues.begin(), mValues.end()); }
+
+  /// \return returns stored values
+  const auto& getValues() { return mValues; }
 
   /// values which will be averaged and filtered
   void print() const;
@@ -99,13 +103,13 @@ class RobustAverage
 
   /// \return returns standard deviation of stored values
   /// \param mean mean of stored values
-  float getStdDev(const float mean);
+  float getStdDev(const float mean, std::vector<float>::const_iterator begin, std::vector<float>::const_iterator end);
 
   /// performing outlier filtering of the stored values by defining range of included values in terms of standard deviation
   /// \param mean mean of the stored values
   /// \param stdev standard deviation of the values
   /// \param sigma maximum accepted standard deviation: sigma*stdev
-  float getFilteredMean(const float mean, const float stdev, const float sigma);
+  float getFilteredMean(const float mean, const float stdev, const float sigma) const;
 };
 
 } // namespace o2::tpc

--- a/Detectors/TPC/calibration/src/IDCAverageGroupHelper.cxx
+++ b/Detectors/TPC/calibration/src/IDCAverageGroupHelper.cxx
@@ -20,7 +20,7 @@ float o2::tpc::IDCAverageGroupHelper<o2::tpc::IDCAverageGroupCRU>::getGroupedIDC
   switch (paramIDCGroup.method) {
     case o2::tpc::AveragingMethod::SLOW:
     default:
-      return mRobustAverage[mThreadNum].getFilteredAverage(paramIDCGroup.sigma);
+      return mRobustAverage[mThreadNum].getFilteredAverage(paramIDCGroup.sigma).first;
       break;
     case o2::tpc::AveragingMethod::FAST:
       return withweights ? mRobustAverage[mThreadNum].getWeightedMean() : mRobustAverage[mThreadNum].getMean();
@@ -80,7 +80,7 @@ float o2::tpc::IDCAverageGroupHelper<o2::tpc::IDCAverageGroupTPC>::getGroupedIDC
   switch (paramIDCGroup.method) {
     case o2::tpc::AveragingMethod::SLOW:
     default:
-      return mRobustAverage[mThreadNum].getFilteredAverage(paramIDCGroup.sigma);
+      return mRobustAverage[mThreadNum].getFilteredAverage(paramIDCGroup.sigma).first;
       break;
     case o2::tpc::AveragingMethod::FAST:
       return withweights ? mRobustAverage[mThreadNum].getWeightedMean() : mRobustAverage[mThreadNum].getMean();

--- a/Detectors/TPC/calibration/src/IDCCCDBHelper.cxx
+++ b/Detectors/TPC/calibration/src/IDCCCDBHelper.cxx
@@ -13,6 +13,7 @@
 #include "TPCCalibration/IDCDrawHelper.h"
 #include "TPCCalibration/IDCGroupHelperSector.h"
 #include "TPCCalibration/IDCContainer.h"
+#include "TPCCalibration/RobustAverage.h"
 
 #include "TPCBase/CalDet.h"
 #include "TPCBase/Mapper.h"
@@ -134,7 +135,7 @@ void o2::tpc::IDCCCDBHelper<DataT>::drawPadFlagMap(const bool type, const Sector
 }
 
 template <typename DataT>
-unsigned int o2::tpc::IDCCCDBHelper<DataT>::getUngroupedIndexGlobal(const unsigned int sector, const unsigned int region, unsigned int urow, unsigned int upad, unsigned int integrationInterval) const
+unsigned int o2::tpc::IDCCCDBHelper<DataT>::getUngroupedIndexGlobal(const unsigned int sector, const unsigned int region, unsigned int urow, unsigned int upad, unsigned int integrationInterval)
 {
   return IDCGroupHelperSector::getUngroupedIndexGlobal(sector, region, urow, upad, integrationInterval);
 }
@@ -434,13 +435,11 @@ TCanvas* o2::tpc::IDCCCDBHelper<DataT>::drawFourierCoeff(TCanvas* outputCanvas, 
 }
 
 template <typename DataT>
-void o2::tpc::IDCCCDBHelper<DataT>::dumpToTree(const char* outFileName) const
+void o2::tpc::IDCCCDBHelper<DataT>::dumpToTree(const Side side, const char* outFileName) const
 {
   const Mapper& mapper = Mapper::instance();
   o2::utils::TreeStreamRedirector pcstream(outFileName, "RECREATE");
   pcstream.GetFile()->cd();
-
-  const int integrationInterval = 0; // std::min(mIDCOne->getNIDCs(Side::A), mIDCOne->getNIDCs(Side::C));
 
   const unsigned int nIDCsSector = Mapper::getPadsInSector() * Mapper::NSECTORS;
   std::vector<int> vRow(nIDCsSector);
@@ -449,13 +448,21 @@ void o2::tpc::IDCCCDBHelper<DataT>::dumpToTree(const char* outFileName) const
   std::vector<float> vYPos(nIDCsSector);
   std::vector<float> vGlobalXPos(nIDCsSector);
   std::vector<float> vGlobalYPos(nIDCsSector);
-  std::vector<float> idcs(nIDCsSector);
   std::vector<float> idcsZero(nIDCsSector);
-  std::vector<float> idcsDelta(nIDCsSector);
   std::vector<unsigned int> sectorv(nIDCsSector);
+  std::vector<int> outlier(nIDCsSector);
+  std::vector<float> stackMedian(nIDCsSector);
 
+  if (!mIDCZero[side]) {
+    LOGP(info, "IDC0 not set. returning");
+    return;
+  }
+  auto stacksMedianTmp = getStackMedian(*mIDCZero[side], side);
+  const std::array<int, Mapper::NREGIONS> stackInSector{0, 0, 0, 0, 1, 1, 2, 2, 3, 3};
   unsigned int index = 0;
-  for (unsigned int sector = 0; sector < Mapper::NSECTORS; ++sector) {
+  const unsigned int secStart = (side == Side::A) ? 0 : SECTORSPERSIDE;
+  const unsigned int secEnd = (side == Side::A) ? SECTORSPERSIDE : Mapper::NSECTORS;
+  for (unsigned int sector = secStart; sector < secEnd; ++sector) {
     for (unsigned int region = 0; region < Mapper::NREGIONS; ++region) {
       for (unsigned int irow = 0; irow < Mapper::ROWSPERREGION[region]; ++irow) {
         for (unsigned int ipad = 0; ipad < Mapper::PADSPERROW[region][irow]; ++ipad) {
@@ -466,65 +473,63 @@ void o2::tpc::IDCCCDBHelper<DataT>::dumpToTree(const char* outFileName) const
           vPad[index] = padPosLocal.getPad();
           vXPos[index] = mapper.getPadCentre(padPosLocal).X();
           vYPos[index] = mapper.getPadCentre(padPosLocal).Y();
-          const GlobalPosition2D globalPos = mapper.LocalToGlobal(LocalPosition2D(vXPos[index], vYPos[index]), Sector(sector));
+          const GlobalPosition2D globalPos = mapper.LocalToGlobal(LocalPosition2D(vXPos[index], -vYPos[index]), Sector(sector));
           vGlobalXPos[index] = globalPos.X();
           vGlobalYPos[index] = globalPos.Y();
-          idcs[index] = getIDCVal(sector, region, irow, padTmp, integrationInterval);
           idcsZero[index] = getIDCZeroVal(sector, region, irow, padTmp);
-          idcsDelta[index] = getIDCDeltaVal(sector, region, irow, padTmp, integrationInterval);
+          if (mPadFlagsMap) {
+            const unsigned int padInRegion = Mapper::OFFSETCRULOCAL[region][irow] + padTmp;
+            outlier[index] = static_cast<int>(mPadFlagsMap->getCalArray(region + sector * Mapper::NREGIONS).getValue(padInRegion));
+          }
+          stackMedian[index] = stacksMedianTmp[(sector - secStart) * GEMSTACKSPERSECTOR + stackInSector[region]];
           sectorv[index++] = sector;
         }
       }
     }
   }
-  std::vector<float> idcOneA = !mIDCOne[Side::A] ? std::vector<float>() : mIDCOne[Side::A]->mIDCOne;
-  std::vector<float> idcOneC = !mIDCOne[Side::C] ? std::vector<float>() : mIDCOne[Side::C]->mIDCOne;
+  std::vector<float> idcOne = !mIDCOne[side] ? std::vector<float>() : mIDCOne[side]->mIDCOne;
 
   pcstream << "tree"
-           << "IDC.=" << idcs
            << "IDC0.=" << idcsZero
-           << "IDC1A=" << idcOneA
-           << "IDC1C=" << idcOneC
-           << "IDCDelta.=" << idcsDelta
+           << "IDC1=" << idcOne
            << "pad.=" << vPad
            << "row.=" << vRow
            << "lx.=" << vXPos
            << "ly.=" << vYPos
            << "gx.=" << vGlobalXPos
            << "gy.=" << vGlobalYPos
+           << "outlier.=" << outlier
            << "sector.=" << sectorv
+           << "stacksMedian=" << stackMedian
            << "\n";
   pcstream.Close();
 }
 
 template <typename DataT>
-void o2::tpc::IDCCCDBHelper<DataT>::dumpToTreeIDCDelta(const char* outFileName) const
+void o2::tpc::IDCCCDBHelper<DataT>::dumpToTreeIDCDelta(const Side side, const char* outFileName) const
 {
-  const Mapper& mapper = Mapper::instance();
   o2::utils::TreeStreamRedirector pcstream(outFileName, "RECREATE");
   pcstream.GetFile()->cd();
-  const unsigned int nIDCsSector = Mapper::getPadsInSector() * Mapper::NSECTORS;
+  const unsigned int nIDCsSector = Mapper::getPadsInSector() * SECTORSPERSIDE;
   std::vector<float> idcsDelta(nIDCsSector);
-  for (int integrationInterval = 0; integrationInterval < std::min(getNIntegrationIntervalsIDCDelta(Side::A), getNIntegrationIntervalsIDCDelta(Side::C)); ++integrationInterval) {
+  for (int integrationInterval = 0; integrationInterval < getNIntegrationIntervalsIDCDelta(side); ++integrationInterval) {
     unsigned int index = 0;
-    for (unsigned int sector = 0; sector < Mapper::NSECTORS; ++sector) {
+    const unsigned int secStart = (side == Side::A) ? 0 : SECTORSPERSIDE;
+    const unsigned int secEnd = (side == Side::A) ? SECTORSPERSIDE : Mapper::NSECTORS;
+    for (unsigned int sector = secStart; sector < secEnd; ++sector) {
       for (unsigned int region = 0; region < Mapper::NREGIONS; ++region) {
         for (unsigned int irow = 0; irow < Mapper::ROWSPERREGION[region]; ++irow) {
           for (unsigned int ipad = 0; ipad < Mapper::PADSPERROW[region][irow]; ++ipad) {
-            const auto padNum = Mapper::getGlobalPadNumber(irow, ipad, region);
             const auto padTmp = (sector < SECTORSPERSIDE) ? ipad : (Mapper::PADSPERROW[region][irow] - ipad - 1); // C-Side is mirrored
-            const auto& padPosLocal = mapper.padPos(padNum);
             idcsDelta[index++] = getIDCDeltaVal(sector, region, irow, padTmp, integrationInterval);
           }
         }
       }
     }
-    float idcOneA = getIDCOneVal(o2::tpc::Side::A, integrationInterval);
-    float idcOneC = getIDCOneVal(o2::tpc::Side::C, integrationInterval);
+    float idcOne = getIDCOneVal(side, integrationInterval);
 
     pcstream << "tree"
-             << "IDC1A=" << idcOneA
-             << "IDC1C=" << idcOneC
+             << "IDC1=" << idcOne
              << "IDCDelta.=" << idcsDelta
              << "\n";
   }
@@ -651,43 +656,135 @@ void o2::tpc::IDCCCDBHelper<DataT>::createOutlierMap()
 }
 
 template <typename DataT>
-float o2::tpc::IDCCCDBHelper<DataT>::scaleIDC0(const Side side, const bool rejectOutlier)
+void o2::tpc::IDCCCDBHelper<DataT>::scaleIDC0(const float factor, const Side side)
 {
   if (!mIDCZero[side]) {
     LOGP(info, "IDC0 not set. returning");
-    return -1;
+    return;
   }
 
-  // calculate sum of IDCs over working channels
-  double idc0Sum = 0;
-  unsigned int idcChannelsCount = 0;
+  *mIDCZero[side] /= factor;
+}
+
+template <typename DataT>
+void o2::tpc::IDCCCDBHelper<DataT>::setIDCZeroScale(const bool rejectOutlier)
+{
+  if (rejectOutlier) {
+    createOutlierMap();
+  }
+
+  if (mIDCZero[Side::A]) {
+    mScaleIDC0Aside = getMeanIDC0(Side::A, *mIDCZero[Side::A], rejectOutlier ? mPadFlagsMap.get() : nullptr);
+    scaleIDC0(mScaleIDC0Aside, Side::A);
+  } else {
+    mScaleIDC0Aside = 0;
+  }
+
+  if (mIDCZero[Side::C]) {
+    mScaleIDC0Cside = getMeanIDC0(Side::C, *mIDCZero[Side::C], rejectOutlier ? mPadFlagsMap.get() : nullptr);
+    scaleIDC0(mScaleIDC0Cside, Side::C);
+  } else {
+    mScaleIDC0Cside = 0;
+  }
+
+  /// check if IDC0 total is not zero, in that case no scalling is applied
+  if (mScaleIDC0Aside == 0.0 || mScaleIDC0Cside == 0.0) {
+    LOGP(error, "Please check the IDC0 total A side {} and C side {}, is zero, therefore no scaling applied!", mScaleIDC0Aside, mScaleIDC0Cside);
+    mScaleIDC0Aside = 1.0;
+    mScaleIDC0Cside = 1.0;
+  }
+}
+
+template <typename DataT>
+float o2::tpc::IDCCCDBHelper<DataT>::getMeanIDC0(const Side side, const IDCZero& idcZero, const CalDet<PadFlags>* outlierMap)
+{
+  // 1. calculate mean per row
+  std::vector<double> idc0Sum(Mapper::PADROWS);
+  std::vector<unsigned int> idcChannelsCount(Mapper::PADROWS);
   const unsigned int firstCRU = (side == Side::A) ? 0 : CRU::MaxCRU / 2;
   for (unsigned int cru = firstCRU; cru < firstCRU + CRU::MaxCRU / 2; ++cru) {
     const o2::tpc::CRU cruTmp(cru);
     const int region = cruTmp.region();
     const int sector = cruTmp.sector();
     for (unsigned int lrow = 0; lrow < Mapper::ROWSPERREGION[region]; ++lrow) {
-      const unsigned int integrationInterval = 0;
+      const unsigned int glRow = lrow + Mapper::ROWOFFSET[region];
       for (unsigned int pad = 0; pad < Mapper::PADSPERROW[region][lrow]; ++pad) {
         const unsigned int padInRegion = Mapper::OFFSETCRULOCAL[region][lrow] + pad;
-        const o2::tpc::PadFlags flag = (mPadFlagsMap && rejectOutlier) ? mPadFlagsMap->getCalArray(cru).getValue(padInRegion) : o2::tpc::PadFlags::flagGoodPad;
-        const auto index = getUngroupedIndexGlobal(sector, region, lrow, pad, 0);
-        if ((flag & PadFlags::flagSkip) == PadFlags::flagSkip) {
-          continue;
+        if (outlierMap) {
+          const o2::tpc::PadFlags flag = outlierMap->getCalArray(cru).getValue(padInRegion);
+          if ((flag & PadFlags::flagSkip) == PadFlags::flagSkip) {
+            continue;
+          }
         }
-        ++idcChannelsCount;
-        idc0Sum += getIDCZeroVal(sector, region, lrow, pad);
+        const auto index = getUngroupedIndexGlobal(sector, region, lrow, pad, 0);
+        idc0Sum[glRow] += idcZero.getValueIDCZero(index);
+        ++idcChannelsCount[glRow];
       }
     }
   }
 
-  if (idcChannelsCount == 0) {
-    return idc0Sum;
+  // 2. calculate mean of means
+  double idc0SumGlobal = 0;
+  unsigned int idc0CountGlobal = 0;
+  for (unsigned int i = 0; i < Mapper::PADROWS; ++i) {
+    if (idcChannelsCount[i]) {
+      idc0SumGlobal += idc0Sum[i] / idcChannelsCount[i];
+      ++idc0CountGlobal;
+    }
   }
 
-  idc0Sum /= idcChannelsCount;
-  *mIDCZero[side] /= idc0Sum;
-  return idc0Sum;
+  if (idc0CountGlobal == 0) {
+    return -1;
+  }
+
+  return idc0SumGlobal /= idc0CountGlobal;
+}
+
+template <typename DataT>
+float o2::tpc::IDCCCDBHelper<DataT>::getStackMedian(const IDCZero& idczero, const Sector sector, const GEMstack stack)
+{
+  int cruStart = sector * CRU::CRUperSector;
+  if (stack == GEMstack::OROC1gem) {
+    cruStart += CRU::CRUperIROC;
+  } else if (stack == GEMstack::OROC2gem) {
+    cruStart += CRU::CRUperIROC + CRU::CRUperPartition;
+  } else if (stack == GEMstack::OROC3gem) {
+    cruStart += CRU::CRUperIROC + 2 * CRU::CRUperPartition;
+  }
+  int cruEnd = (stack == GEMstack::IROCgem) ? (cruStart + CRU::CRUperIROC) : (cruStart + CRU::CRUperPartition);
+
+  RobustAverage average;
+  average.reserve(Mapper::getNumberOfPads(stack));
+  for (int cru = cruStart; cru < cruEnd; ++cru) {
+    const o2::tpc::CRU cruTmp(cru);
+    const int region = cruTmp.region();
+    for (unsigned int lrow = 0; lrow < Mapper::ROWSPERREGION[region]; ++lrow) {
+      const unsigned int integrationInterval = 0;
+      for (unsigned int pad = 0; pad < Mapper::PADSPERROW[region][lrow]; ++pad) {
+        const auto index = getUngroupedIndexGlobal(sector, region, lrow, pad, integrationInterval);
+        const float idcZero = idczero.mIDCZero[index];
+        if ((idcZero != -1) && (idcZero != 0)) {
+          average.addValue(idcZero);
+        }
+      }
+    }
+  }
+  return average.getMedian();
+}
+
+template <typename DataT>
+std::array<float, o2::tpc::GEMSTACKSPERSECTOR * o2::tpc::SECTORSPERSIDE> o2::tpc::IDCCCDBHelper<DataT>::getStackMedian(const IDCZero& idczero, const Side side)
+{
+  const int stacksPerSide = o2::tpc::GEMSTACKSPERSECTOR * o2::tpc::SECTORSPERSIDE;
+  std::array<float, stacksPerSide> median;
+  unsigned int sectorStart = (side == Side::A) ? 0 : o2::tpc::SECTORSPERSIDE;
+  unsigned int sectorEnd = (side == Side::A) ? o2::tpc::SECTORSPERSIDE : Mapper::NSECTORS;
+  for (unsigned int sector = sectorStart; sector < sectorEnd; ++sector) {
+    for (int stackInSector = 0; stackInSector < GEMSTACKSPERSECTOR; ++stackInSector) {
+      median[(sector * GEMSTACKSPERSECTOR + stackInSector) % stacksPerSide] = IDCCCDBHelper<>::getStackMedian(idczero, Sector(sector), static_cast<GEMstack>(stackInSector));
+    }
+  }
+  return median;
 }
 
 template class o2::tpc::IDCCCDBHelper<float>;

--- a/Detectors/TPC/calibration/src/IDCDrawHelper.cxx
+++ b/Detectors/TPC/calibration/src/IDCDrawHelper.cxx
@@ -18,6 +18,7 @@
 #include "TGraphErrors.h"
 #include "TMultiGraph.h"
 #include <fmt/format.h>
+#include "TROOT.h"
 
 unsigned int o2::tpc::IDCDrawHelper::getPad(const unsigned int pad, const unsigned int region, const unsigned int row, const Side side)
 {
@@ -79,11 +80,12 @@ void o2::tpc::IDCDrawHelper::drawSide(const IDCDraw& idc, const o2::tpc::Side si
     poly->SetMaximum(maxZ);
   }
 
-  TCanvas* can = new TCanvas("can", "can", 650, 600);
+  TCanvas* can = ((TVirtualPad*)gROOT->GetSelectedPad()) ? ((TCanvas*)((TVirtualPad*)gROOT->GetSelectedPad()->GetCanvas())) : new TCanvas("can", "can", 650, 600);
   can->SetTopMargin(0.04f);
   can->SetRightMargin(0.14f);
   can->SetLeftMargin(0.1f);
   poly->Draw("colz");
+  o2::tpc::painter::drawSectorsXY(side);
 
   std::string sideName = (side == Side::A) ? "A-Side" : "C-Side";
   TLatex latex;

--- a/Detectors/TPC/calibration/src/RobustAverage.cxx
+++ b/Detectors/TPC/calibration/src/RobustAverage.cxx
@@ -13,30 +13,56 @@
 #include "Framework/Logger.h"
 #include <numeric>
 
-float o2::tpc::RobustAverage::getFilteredAverage(const float sigma)
+std::pair<float, float> o2::tpc::RobustAverage::getFilteredAverage(const float sigma, const float interQuartileRange)
 {
   if (mValues.empty()) {
-    return 0;
+    return std::pair<float, float>(0, 0);
   }
 
-  const float mean = getMean();
-  const float stdev = getStdDev(mean);
-  return getFilteredMean(mean, stdev, sigma);
+  /*
+    1. Sort the values
+    2. Use only the values in the Interquartile Range
+    3. Get the median
+    4. Calculate the std dev of the selected values with the median as reference
+    5. Get mean of the selected points which are in the range of the std dev
+  */
+
+  // 1.  Sort the values
+  std::sort(mValues.begin(), mValues.end());
+
+  // 2. Use only the values in the Interquartile Range (inner n%)
+  const auto upper = mValues.begin() + mValues.size() * interQuartileRange;
+  const auto lower = mValues.begin() + mValues.size() * (1 - interQuartileRange);
+
+  // 3. Get the median
+  const float median = mValues[mValues.size() / 2];
+
+  if (upper == lower) {
+    return std::pair<float, float>(median, 0);
+  }
+
+  // 4. Calculate the std dev of the selected values with the median
+  const float stdev = getStdDev(median, lower, upper);
+
+  // 5. Get mean of the selected points which are in the range of the std dev
+  return std::pair<float, float>(getFilteredMean(median, stdev, sigma), stdev);
 }
 
-float o2::tpc::RobustAverage::getStdDev(const float mean)
+float o2::tpc::RobustAverage::getStdDev(const float mean, std::vector<float>::const_iterator begin, std::vector<float>::const_iterator end)
 {
-  const auto size = mValues.size();
+  const auto size = std::distance(begin, end);
+  if (size == 0) {
+    return 0;
+  }
   mTmpValues.resize(size);
-  std::transform(mValues.begin(), mValues.end(), mTmpValues.begin(), [mean](const float val) { return val - mean; });
+  std::transform(begin, end, mTmpValues.begin(), [mean](const float val) { return val - mean; });
   const float sqsum = std::inner_product(mTmpValues.begin(), mTmpValues.end(), mTmpValues.begin(), decltype(mTmpValues)::value_type(0));
   const float stdev = std::sqrt(sqsum / size);
   return stdev;
 }
 
-float o2::tpc::RobustAverage::getFilteredMean(const float mean, const float stdev, const float sigma)
+float o2::tpc::RobustAverage::getFilteredMean(const float mean, const float stdev, const float sigma) const
 {
-  std::sort(mValues.begin(), mValues.end());
   const float sigmastddev = sigma * stdev;
   const float minVal = mean - sigmastddev;
   const float maxVal = mean + sigmastddev;


### PR DESCRIPTION
Outlier map:
- 1. check for obvious outlier (IDCs around median +- nSigma)
- 2. check FECs: masking FECs which are out of sync
- 3. check neighbouring outliers (in case not all outlier for larger areas are recognized)

Other changes

IDCCCDBHelper
- add function to get the mean value for IDC0

IDC Drawing
- draw plots in current canvas if one is created
- draw sector informations

IDCFactorize
- parallelize loading of large objects from file
- add function to normalize IDCZero by gain map and/or median per stack
- Moving dump to TTree functionality to CCDBHelper implementation

TPC Mapper
- mapper make function constexpr