### PR TITLE
DPL: have separate include for RootMessageContext

### DIFF
--- a/Framework/Core/include/Framework/AODReaderHelpers.h
+++ b/Framework/Core/include/Framework/AODReaderHelpers.h
@@ -15,6 +15,7 @@
 #include "Framework/TableBuilder.h"
 #include "Framework/AlgorithmSpec.h"
 #include "Framework/Logger.h"
+#include "Framework/RootMessageContext.h"
 #include <uv.h>
 
 namespace o2::framework::readers

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -29,6 +29,7 @@
 #include "Framework/ExpressionHelpers.h"
 #include "Framework/CommonServices.h"
 #include "Framework/Plugins.h"
+#include "Framework/RootMessageContext.h"
 
 namespace o2::framework
 {

--- a/Framework/Core/include/Framework/DataAllocator.h
+++ b/Framework/Core/include/Framework/DataAllocator.h
@@ -12,6 +12,7 @@
 #define FRAMEWORK_DATAALLOCATOR_H
 
 #include "Framework/MessageContext.h"
+#include "Framework/RootMessageContext.h"
 #include "Framework/StringContext.h"
 #include "Framework/RawBufferContext.h"
 #include "Framework/Output.h"
@@ -20,7 +21,6 @@
 #include "Framework/DataChunk.h"
 #include "Framework/FairMQDeviceProxy.h"
 #include "Framework/TimingInfo.h"
-#include "Framework/TMessageSerializer.h"
 #include "Framework/TypeTraits.h"
 #include "Framework/Traits.h"
 #include "Framework/SerializationMethods.h"
@@ -132,10 +132,14 @@ class DataAllocator
       auto& timingInfo = mRegistry.get<TimingInfo>();
       auto routeIndex = matchDataHeader(spec, timingInfo.timeslice);
       auto& context = mRegistry.get<MessageContext>();
+      if constexpr (enable_root_serialization<T>::value) {
+        fair::mq::MessagePtr headerMessage = headerMessageFromOutput(spec, routeIndex, o2::header::gSerializationMethodROOT, 0);
 
+        return context.add<typename enable_root_serialization<T>::object_type>(std::move(headerMessage), routeIndex, std::forward<Args>(args)...).get();
+      } else {
+        static_assert(enable_root_serialization<T>::value, "Please make sure you include RootMessageContext.h");
+      }
       // Note: initial payload size is 0 and will be set by the context before sending
-      fair::mq::MessagePtr headerMessage = headerMessageFromOutput(spec, routeIndex, o2::header::gSerializationMethodROOT, 0);
-      return context.add<MessageContext::RootSerializedObject<T>>(std::move(headerMessage), routeIndex, std::forward<Args>(args)...).get();
     } else if constexpr (std::is_base_of_v<std::string, T>) {
       auto* s = new std::string(args...);
       adopt(spec, s);
@@ -317,9 +321,9 @@ class DataAllocator
                                   typeid(WrappedType).name());
           }
         }
-        TMessageSerializer().Serialize(*payloadMessage, &object(), cl);
+        typename root_serializer<T>::serializer().Serialize(*payloadMessage, &object(), cl);
       } else {
-        TMessageSerializer().Serialize(*payloadMessage, &object, TClass::GetClass(typeid(T)));
+        typename root_serializer<T>::serializer().Serialize(*payloadMessage, &object, TClass::GetClass(typeid(T)));
       }
       serializationType = o2::header::gSerializationMethodROOT;
     } else {

--- a/Framework/Core/include/Framework/RootMessageContext.h
+++ b/Framework/Core/include/Framework/RootMessageContext.h
@@ -1,0 +1,107 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef O2_FRAMEWORK_ROOTMESSAGECONTEXT_H_
+#define O2_FRAMEWORK_ROOTMESSAGECONTEXT_H_
+
+#include "Framework/DispatchControl.h"
+#include "Framework/FairMQDeviceProxy.h"
+#include "Framework/OutputRoute.h"
+#include "Framework/RouteState.h"
+#include "Framework/RoutingIndices.h"
+#include "Framework/RuntimeError.h"
+#include "Framework/TMessageSerializer.h"
+#include "Framework/DataProcessingHeader.h"
+#include "Framework/SerializationMethods.h"
+#include "Framework/TypeTraits.h"
+#include "Framework/MessageContext.h"
+
+#include "Headers/DataHeader.h"
+#include "Headers/Stack.h"
+#include "MemoryResources/MemoryResources.h"
+
+#include <fairmq/Message.h>
+#include <fairmq/Parts.h>
+
+#include <cassert>
+#include <functional>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <vector>
+
+#include <fairmq/FwdDecls.h>
+
+namespace o2::framework
+{
+
+struct Output;
+
+/// RootSerializedObject keeps ownership to an object which can be Root-serialized
+/// TODO: this should maybe be a separate header file to avoid including TMessageSerializer
+/// in this header file, but we can always change this without affecting to much code.
+template <typename T>
+class RootSerializedObject : public MessageContext::ContextObject
+{
+ public:
+  // Note: we strictly require the type to implement the ROOT ClassDef interface in order to be
+  // able to check for the existence of the dirctionary for this type. Could be dropped if any
+  // use case for a type having the dictionary at runtime pops up
+  static_assert(has_root_dictionary<T>::value == true, "unconsistent type: needs to implement ROOT ClassDef interface");
+  using value_type = T;
+  /// default constructor forbidden, object alwasy has to control messages
+  RootSerializedObject() = delete;
+  /// constructor taking header message by move and creating the object from variadic argument list
+  template <typename ContextType, typename... Args>
+  RootSerializedObject(ContextType* context, fair::mq::MessagePtr&& headerMsg, RouteIndex routeIndex, Args&&... args)
+    : ContextObject(std::forward<fair::mq::MessagePtr>(headerMsg), routeIndex)
+  {
+    mObject = std::make_unique<value_type>(std::forward<Args>(args)...);
+    mPayloadMsg = context->proxy().createOutputMessage(routeIndex);
+  }
+  ~RootSerializedObject() override = default;
+
+  /// @brief Finalize object and return parts by move
+  /// This retrieves the actual message from the vector object and moves it to the parts
+  fair::mq::Parts finalize() final
+  {
+    assert(mParts.Size() == 1);
+    TMessageSerializer::Serialize(*mPayloadMsg, mObject.get(), nullptr);
+    mParts.AddPart(std::move(mPayloadMsg));
+    return ContextObject::finalize();
+  }
+
+  operator value_type&()
+  {
+    return *mObject;
+  }
+
+  value_type& get()
+  {
+    return *mObject;
+  }
+
+ private:
+  std::unique_ptr<value_type> mObject;
+  fair::mq::MessagePtr mPayloadMsg;
+};
+
+template <typename T>
+struct enable_root_serialization<T, std::enable_if_t<has_root_dictionary<T>::value && is_messageable<T>::value == false>> : std::true_type {
+  using object_type = RootSerializedObject<T>;
+};
+
+template <typename T>
+struct root_serializer<T, std::enable_if_t<has_root_dictionary<T>::value || is_specialization<T, ROOTSerialized>::value == true>> : std::true_type {
+  using serializer = TMessageSerializer;
+};
+
+} // namespace o2::framework
+#endif // O2_FRAMEWORK_MESSAGECONTEXT_H_

--- a/Framework/Core/test/test_DataAllocator.cxx
+++ b/Framework/Core/test/test_DataAllocator.cxx
@@ -12,6 +12,7 @@
 #include "Framework/RootSerializationSupport.h"
 #include "Framework/WorkflowSpec.h"
 #include "Framework/DataProcessorSpec.h"
+#include "Framework/RootMessageContext.h"
 #include "Framework/runDataProcessing.h"
 #include "Framework/DataAllocator.h"
 #include "Framework/InputRecord.h"
@@ -69,6 +70,7 @@ constexpr o2::header::HeaderType MetaHeader::sHeaderType = "MetaHead";
 
 DataProcessorSpec getSourceSpec()
 {
+  static_assert(enable_root_serialization<o2::test::Polymorphic>::value, "enable_root_serialization<o2::test::Polymorphic> must be true");
   auto processingFct = [](ProcessingContext& pc) {
     static int counter = 0;
     o2::test::TriviallyCopyable a(42, 23, 0xdead);

--- a/Framework/Core/test/test_SimpleWildcard.cxx
+++ b/Framework/Core/test/test_SimpleWildcard.cxx
@@ -10,6 +10,7 @@
 // or submit itself to any jurisdiction.
 
 #include "Framework/RootSerializationSupport.h"
+#include "Framework/RootMessageContext.h"
 #include "Framework/runDataProcessing.h"
 #include "Framework/CallbackService.h"
 #include "Framework/ControlService.h"

--- a/Framework/Core/test/test_SimpleWildcard02.cxx
+++ b/Framework/Core/test/test_SimpleWildcard02.cxx
@@ -13,6 +13,7 @@
 #include "Framework/runDataProcessing.h"
 #include "Framework/CallbackService.h"
 #include "Framework/ControlService.h"
+#include "Framework/RootMessageContext.h"
 #include "Framework/EndOfStreamContext.h"
 #include "Framework/Logger.h"
 #include "Framework/DataRefUtils.h"

--- a/Framework/TestWorkflows/src/test_o2RootMessageWorkflow.cxx
+++ b/Framework/TestWorkflows/src/test_o2RootMessageWorkflow.cxx
@@ -9,6 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 #include "Framework/RootSerializationSupport.h"
+#include "Framework/RootMessageContext.h"
 #include "Framework/DataRefUtils.h"
 #include "Framework/ServiceRegistry.h"
 #include "Framework/runDataProcessing.h"

--- a/Framework/TestWorkflows/test/test_MakeDPLObjects.cxx
+++ b/Framework/TestWorkflows/test/test_MakeDPLObjects.cxx
@@ -9,6 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 #include "Framework/RootSerializationSupport.h"
+#include "Framework/RootMessageContext.h"
 #include "Framework/runDataProcessing.h"
 #include "Framework/DataRefUtils.h"
 #include "Framework/ControlService.h"

--- a/Framework/Utils/include/DPLUtils/RootTreeReader.h
+++ b/Framework/Utils/include/DPLUtils/RootTreeReader.h
@@ -20,6 +20,7 @@
 #include "Framework/Output.h"
 #include "Framework/ProcessingContext.h"
 #include "Framework/DataAllocator.h"
+#include "Framework/RootMessageContext.h"
 #include "Framework/Logger.h"
 #include "Headers/DataHeader.h"
 #include <TChain.h>

--- a/Framework/Utils/test/test_RootTreeWriterWorkflow.cxx
+++ b/Framework/Utils/test/test_RootTreeWriterWorkflow.cxx
@@ -10,6 +10,7 @@
 // or submit itself to any jurisdiction.
 
 #include "Framework/RootSerializationSupport.h"
+#include "Framework/RootMessageContext.h"
 #include "Framework/WorkflowSpec.h"
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/DataAllocator.h"


### PR DESCRIPTION
This means that we can now spot all the messages which are serialised via ROOT by simply removing

 #include "Framework/RootMessageContext.h"

from DataAllocator.h