### PR TITLE
ITS: Add protection from bogus vtx coordinate

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
@@ -106,7 +106,7 @@ struct VertexingParameters {
   float tanLambdaCut = 0.002f; // tanLambda = deltaZ/deltaR
   float lowMultXYcut2 = 0.01f; // XY cut for low-multiplicity pile up
   float baseBeamError = 0.005f;
-  float maxZPositionAllowed = 100.f;
+  float maxZPositionAllowed = 25.f;
   int clusterContributorsCut = 16;
   int maxTrackletsPerCluster = 2e3;
   int phiSpan = -1;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
@@ -106,6 +106,7 @@ struct VertexingParameters {
   float tanLambdaCut = 0.002f; // tanLambda = deltaZ/deltaR
   float lowMultXYcut2 = 0.01f; // XY cut for low-multiplicity pile up
   float baseBeamError = 0.005f;
+  float maxZPositionAllowed = 100.f;
   int clusterContributorsCut = 16;
   int maxTrackletsPerCluster = 2e3;
   int phiSpan = -1;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
@@ -33,6 +33,7 @@ struct VertexerParamConfig : public o2::conf::ConfigurableParamHelper<VertexerPa
   float tanLambdaCut = 0.002f; // tanLambda = deltaZ/deltaR
   float lowMultXYcut2 = 0.25f; // XY cut for low-multiplicity pile up
   float baseBeamError = 0.005f;
+  float maxZPositionAllowed = 100.f;
   int clusterContributorsCut = 16;
   int maxTrackletsPerCluster = 1e2;
   int phiSpan = -1;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
@@ -33,7 +33,7 @@ struct VertexerParamConfig : public o2::conf::ConfigurableParamHelper<VertexerPa
   float tanLambdaCut = 0.002f; // tanLambda = deltaZ/deltaR
   float lowMultXYcut2 = 0.25f; // XY cut for low-multiplicity pile up
   float baseBeamError = 0.005f;
-  float maxZPositionAllowed = 100.f;
+  float maxZPositionAllowed = 25.f; // 4x sZ of the beam
   int clusterContributorsCut = 16;
   int maxTrackletsPerCluster = 1e2;
   int phiSpan = -1;

--- a/Detectors/ITSMFT/ITS/tracking/src/Vertexer.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Vertexer.cxx
@@ -66,6 +66,7 @@ void Vertexer::getGlobalConfiguration()
   verPar.histPairCut = vc.histPairCut;
   verPar.tanLambdaCut = vc.tanLambdaCut;
   verPar.lowMultXYcut2 = vc.lowMultXYcut2;
+  verPar.maxZPositionAllowed = vc.maxZPositionAllowed;
   verPar.clusterContributorsCut = vc.clusterContributorsCut;
   verPar.maxTrackletsPerCluster = vc.maxTrackletsPerCluster;
   verPar.phiSpan = vc.phiSpan;

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -435,7 +435,7 @@ void VertexerTraits::computeVertices()
         }
       }
       float rXY{std::hypot(mTimeFrame->getTrackletClusters(rofId)[iCluster].getVertex()[0], mTimeFrame->getTrackletClusters(rofId)[iCluster].getVertex()[1])};
-      if (rXY < 1.98) {
+      if (rXY < 1.98 && std::abs(mTimeFrame->getTrackletClusters(rofId)[iCluster].getVertex()[2]) < mVrtParams.maxZPositionAllowed) {
         atLeastOneFound = true;
         mVertices.emplace_back(mTimeFrame->getTrackletClusters(rofId)[iCluster].getVertex()[0],
                                mTimeFrame->getTrackletClusters(rofId)[iCluster].getVertex()[1],


### PR DESCRIPTION
@chiarazampolli @mpuccio 
This is obviously a temporary workaround while I investigate the source of that weird vertex.
Testing the rebase offline, I'll update this asap