### PR TITLE
[FOCAL-10] Skip empty HBFs in decoding

### DIFF
--- a/Detectors/FOCAL/workflow/include/FOCALWorkflow/RawDecoderSpec.h
+++ b/Detectors/FOCAL/workflow/include/FOCALWorkflow/RawDecoderSpec.h
@@ -73,6 +73,7 @@ class RawDecoderSpec : public framework::Task
   void fillPixelEventHBFCount(const std::unordered_map<int, std::vector<int>>& counters);
 
   bool mDebugMode = false;
+  bool mDisplayInconsistent = false;
   bool mUsePadData = true;
   bool mUsePixelData = true;
   bool mFilterIncomplete = false;


### PR DESCRIPTION
- Skip emtpy HBFs in decoding (relevant for
  uncompressed raw files)
- Make printouts for incomplete pixel events a
  debug option (default: off) reducing verbosity