### PR TITLE
account for pileup in TRD timing estimate

### DIFF
--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h
@@ -195,8 +195,8 @@ void o2::globaltracking::RecoContainer::createTracksVariadic(T creator, GTrackID
             flagUsed(trc.getRefGlobalTrackId()); // flag seeding ITS-TPC track
             continue;
           }
-          float t0 = t0Trig, t0Err = 1.e-3; // 1ns nominal error
-          if (trc.getPileUpDistance()) {    // distance to farthest collision within the pileup integration time
+          float t0 = t0Trig, t0Err = 5.e-3; // 5ns nominal error
+          if (trc.hasPileUpInfo()) {        // distance to farthest collision within the pileup integration time
             t0 += trc.getPileUpTimeShiftMUS();
             t0Err += trc.getPileUpTimeErrorMUS();
           }
@@ -242,15 +242,14 @@ void o2::globaltracking::RecoContainer::createTracksVariadic(T creator, GTrackID
         const auto& trig = trigTPCTRD[itr];
         auto bcdiff = getBCDiff(trig.getBCData());
         float t0Trig = bcdiff * o2::constants::lhc::LHCBunchSpacingMUS;
-        float t0 = bcdiff * o2::constants::lhc::LHCBunchSpacingNS * 1e-3, t0Err = 1.e-3;
         for (unsigned int i = trig.getTrackRefs().getFirstEntry(); i < (unsigned int)trig.getTrackRefs().getEntriesBound(); i++) {
           const auto& trc = tracksTPCTRD[i];
           if (isUsed2(i, currentSource)) {
             flagUsed(trc.getRefGlobalTrackId()); // flag seeding TPC track
             continue;
           }
-          float t0 = t0Trig, t0Err = 1.e-3; // 1ns nominal error
-          if (trc.getPileUpDistance()) {    // distance to farthest collision within the pileup integration time
+          float t0 = t0Trig, t0Err = 5.e-3; // 5ns nominal error
+          if (trc.hasPileUpInfo()) {        // distance to farthest collision within the pileup integration time
             t0 += trc.getPileUpTimeShiftMUS();
             t0Err += trc.getPileUpTimeErrorMUS();
           }

--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h
@@ -188,14 +188,19 @@ void o2::globaltracking::RecoContainer::createTracksVariadic(T creator, GTrackID
       for (unsigned itr = 0; itr < trigITSTPCTRD.size(); itr++) {
         const auto& trig = trigITSTPCTRD[itr];
         auto bcdiff = getBCDiff(trig.getBCData());
-        float t0 = bcdiff * o2::constants::lhc::LHCBunchSpacingNS * 1e-3;
+        float t0Trig = bcdiff * o2::constants::lhc::LHCBunchSpacingMUS;
         for (unsigned int i = trig.getTrackRefs().getFirstEntry(); i < (unsigned int)trig.getTrackRefs().getEntriesBound(); i++) {
           const auto& trc = tracksITSTPCTRD[i];
           if (isUsed2(i, currentSource)) {
             flagUsed(trc.getRefGlobalTrackId()); // flag seeding ITS-TPC track
             continue;
           }
-          if (creator(trc, {i, currentSource}, t0, 1e-3)) { // assign 1ns error to BC
+          float t0 = t0Trig, t0Err = 1.e-3; // 1ns nominal error
+          if (trc.getPileUpDistance()) {    // distance to farthest collision within the pileup integration time
+            t0 += trc.getPileUpTimeShiftMUS();
+            t0Err += trc.getPileUpTimeErrorMUS();
+          }
+          if (creator(trc, {i, currentSource}, t0, t0Err)) { // assign 1ns error to BC
             flagUsed(trc.getRefGlobalTrackId());            // flag seeding ITS-TPC track
           }
         }
@@ -236,14 +241,20 @@ void o2::globaltracking::RecoContainer::createTracksVariadic(T creator, GTrackID
       for (unsigned itr = 0; itr < trigTPCTRD.size(); itr++) {
         const auto& trig = trigTPCTRD[itr];
         auto bcdiff = getBCDiff(trig.getBCData());
-        float t0 = bcdiff * o2::constants::lhc::LHCBunchSpacingNS * 1e-3;
+        float t0Trig = bcdiff * o2::constants::lhc::LHCBunchSpacingMUS;
+        float t0 = bcdiff * o2::constants::lhc::LHCBunchSpacingNS * 1e-3, t0Err = 1.e-3;
         for (unsigned int i = trig.getTrackRefs().getFirstEntry(); i < (unsigned int)trig.getTrackRefs().getEntriesBound(); i++) {
           const auto& trc = tracksTPCTRD[i];
           if (isUsed2(i, currentSource)) {
             flagUsed(trc.getRefGlobalTrackId()); // flag seeding TPC track
             continue;
           }
-          if (creator(trc, {i, currentSource}, t0, 1e-3)) { // assign 1ns error to BC
+          float t0 = t0Trig, t0Err = 1.e-3; // 1ns nominal error
+          if (trc.getPileUpDistance()) {    // distance to farthest collision within the pileup integration time
+            t0 += trc.getPileUpTimeShiftMUS();
+            t0Err += trc.getPileUpTimeErrorMUS();
+          }
+          if (creator(trc, {i, currentSource}, t0, t0Err)) { // assign 1ns error to BC
             flagUsed(trc.getRefGlobalTrackId());            // flag seeding TPC track
           }
         }

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTOFParams.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTOFParams.h
@@ -24,6 +24,7 @@ namespace globaltracking
 
 struct MatchTOFParams : public o2::conf::ConfigurableParamHelper<MatchTOFParams> {
   float calibMaxChi2 = 3.0;
+  float nsigmaTimeCut = 4.; // number of sigmas for non-TPC track time resolution to consider
 
   O2ParamDef(MatchTOFParams, "MatchTOF");
 };

--- a/Detectors/GlobalTracking/src/MatchTOF.cxx
+++ b/Detectors/GlobalTracking/src/MatchTOF.cxx
@@ -59,6 +59,7 @@ void MatchTOF::run(const o2::globaltracking::RecoContainer& inp)
 {
   if (!mMatchParams) {
     mMatchParams = &o2::globaltracking::MatchTOFParams::Instance();
+    mSigmaTimeCut = mMatchParams->nsigmaTimeCut;
   }
 
   ///< running the matching

--- a/Detectors/TRD/workflow/CMakeLists.txt
+++ b/Detectors/TRD/workflow/CMakeLists.txt
@@ -26,7 +26,27 @@ o2_add_library(TRDWorkflow
                        include/TRDWorkflow/TRDGlobalTrackingQCSpec.h
                        include/TRDWorkflow/NoiseCalibSpec.h
                        include/TRDWorkflow/NoiseCalibAggregatorSpec.h
-               PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::Steer O2::Algorithm O2::DataFormatsTRD O2::TRDSimulation O2::TRDReconstruction O2::TRDQC O2::DetectorsBase O2::SimulationDataFormat O2::TRDBase O2::TRDCalibration O2::GPUTracking O2::GlobalTrackingWorkflowHelpers O2::GlobalTrackingWorkflowReaders O2::GPUWorkflowHelper O2::ReconstructionDataFormats O2::ITSWorkflow O2::TPCWorkflow O2::TRDWorkflowIO O2::TRDPID)
+               PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils
+                                     O2::Steer
+                                     O2::Algorithm
+                                     O2::DataFormatsTRD
+                                     O2::TRDSimulation
+                                     O2::TRDReconstruction
+                                     O2::TRDQC
+                                     O2::DetectorsBase
+                                     O2::SimulationDataFormat
+                                     O2::TRDBase
+                                     O2::TRDCalibration
+                                     O2::GPUTracking
+                                     O2::GlobalTrackingWorkflowHelpers
+                                     O2::GlobalTrackingWorkflowReaders
+                                     O2::GPUWorkflowHelper
+                                     O2::ReconstructionDataFormats
+                                     O2::ITSWorkflow
+                                     O2::TPCWorkflow
+                                     O2::TRDWorkflowIO
+                                     O2::TRDPID
+                                     O2::DataFormatsFT0)
 
 o2_add_executable(trap-sim
                   COMPONENT_NAME trd

--- a/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDGlobalTrackingSpec.cxx
@@ -507,8 +507,8 @@ bool TRDGlobalTracking::refitITSTPCTRDTrack(TrackTRD& trk, float timeTRD, o2::gl
   auto detRefs = recoCont->getSingleDetectorRefs(trk.getRefGlobalTrackId());
   int nCl = -1, clEntry = -1, nClRefit = 0, clRefs[14];
   float chi2Out = 0, timeZErr = 0.;
-  int pileUpDist = trk.getPileUpDistance(); // distance to farthest collision within the pileup integration time
-  if (pileUpDist) {
+  bool pileUpOn = trk.hasPileUpInfo(); // distance to farthest collision within the pileup integration time is set
+  if (pileUpOn) {
     timeTRD += trk.getPileUpTimeShiftMUS(); // shift to average pileup position
   }
   auto geom = o2::its::GeometryTGeo::Instance();
@@ -623,8 +623,8 @@ bool TRDGlobalTracking::refitTPCTRDTrack(TrackTRD& trk, float timeTRD, o2::globa
   auto detRefs = recoCont->getSingleDetectorRefs(trk.getRefGlobalTrackId());
   outerParam = trk;
   float chi2Out = 0, timeZErr = 0.;
-  int pileUpDist = trk.getPileUpDistance(); // distance to farthest collision within the pileup integration time
-  if (pileUpDist) {
+  bool pileUpOn = trk.hasPileUpInfo(); // distance to farthest collision within the pileup integration time is set
+  if (pileUpOn) {
     timeTRD += trk.getPileUpTimeShiftMUS(); // shift to average pileup position
   }
   int retVal = mTPCRefitter->RefitTrackAsTrackParCov(outerParam, mTPCTracksArray[detRefs[GTrackID::TPC]].getClusterRef(), timeTRD * mTPCTBinMUSInv, &chi2Out, true, false); // outward refit
@@ -632,7 +632,7 @@ bool TRDGlobalTracking::refitTPCTRDTrack(TrackTRD& trk, float timeTRD, o2::globa
     LOG(debug) << "TPC refit outwards failed";
     return false;
   }
-  if (pileUpDist) { // account pileup time uncertainty in Z errors
+  if (pileUpOn) { // account pileup time uncertainty in Z errors
     timeZErr = mTPCVdrift * trk.getPileUpTimeErrorMUS();
     outerParam.updateCov(timeZErr, o2::track::CovLabels::kSigZ2);
   }
@@ -653,7 +653,7 @@ bool TRDGlobalTracking::refitTPCTRDTrack(TrackTRD& trk, float timeTRD, o2::globa
     LOG(debug) << "TPC refit inwards failed";
     return false;
   }
-  if (pileUpDist) { // account pileup time uncertainty in Z errors
+  if (pileUpOn) { // account pileup time uncertainty in Z errors
     trk.updateCov(timeZErr, o2::track::CovLabels::kSigZ2);
   }
 

--- a/Detectors/TRD/workflow/src/trd-tracking-workflow.cxx
+++ b/Detectors/TRD/workflow/src/trd-tracking-workflow.cxx
@@ -52,6 +52,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"track-sources", VariantType::String, std::string{GTrackID::ALL}, {"comma-separated list of sources to use for tracking"}},
     {"filter-trigrec", VariantType::Bool, false, {"ignore interaction records without ITS data"}},
     {"strict-matching", VariantType::Bool, false, {"High purity preliminary matching"}},
+    {"disable-ft0-pileup-tagging", VariantType::Bool, false, {"Do not request FT0 for pile-up determination"}},
     {"policy", VariantType::String, "default", {"Pick PID policy (=default)"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
@@ -78,7 +79,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
     LOGP(warning, "In strict matching mode only TPC source allowed, {} asked, redefining", GTrackID::getSourcesNames(srcTRD));
     srcTRD = GTrackID::getSourcesMask("TPC");
   }
-
+  if (!configcontext.options().get<bool>("disable-ft0-pileup-tagging")) {
+    srcTRD |= GTrackID::getSourcesMask("FT0");
+  }
   // Parse PID policy string
   o2::trd::PIDPolicy policy{o2::trd::PIDPolicy::DEFAULT};
   if (pid) {

--- a/Detectors/Vertexing/include/DetectorsVertexing/PVertexer.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/PVertexer.h
@@ -37,7 +37,7 @@
 #include <TFile.h>
 #include <TStopwatch.h>
 
-#define _PV_DEBUG_TREE_ // if enabled, produce dbscan and vertex comparison dump
+//#define _PV_DEBUG_TREE_ // if enabled, produce dbscan and vertex comparison dump
 
 namespace o2
 {

--- a/GPU/GPUTracking/DataTypes/GPUTRDInterfaceO2Track.h
+++ b/GPU/GPUTracking/DataTypes/GPUTRDInterfaceO2Track.h
@@ -36,6 +36,7 @@ struct GPUTPCOuterParam;
 #include "DataFormatsTPC/TrackTPC.h"
 #include "ReconstructionDataFormats/GlobalTrackID.h"
 #include "ReconstructionDataFormats/TrackLTIntegral.h"
+#include "CommonConstants/LHCConstants.h"
 
 namespace GPUCA_NAMESPACE
 {
@@ -73,6 +74,15 @@ class trackInterface<o2::track::TrackParCov> : public o2::track::TrackParCov
   GPUdi() const float* getPar() const { return getParams(); }
 
   GPUdi() bool CheckNumericalQuality() const { return true; }
+
+  GPUdi() void setPileUpDistance(unsigned char bwd, unsigned char fwd) { setUserField((((unsigned short)bwd) << 8) | fwd); }
+  GPUdi() bool hasPileUpInfo() const { return getUserField() != 0; }
+  GPUdi() unsigned char getPileUpDistanceBwd() const { return ((unsigned char)getUserField()) >> 8; }
+  GPUdi() unsigned char getPileUpDistanceFwd() const { return ((unsigned char)getUserField()) & 255; }
+  GPUdi() unsigned short getPileUpSpan() const { return ((unsigned short)getPileUpDistanceBwd()) + getPileUpDistanceFwd(); }
+  GPUdi() float getPileUpMean() const { return 0.5 * ((float)getPileUpDistanceFwd()) - ((float)getPileUpDistanceBwd()); }
+  GPUdi() float getPileUpTimeShiftMUS() const { return getPileUpMean() * o2::constants::lhc::LHCBunchSpacingMUS; }
+  GPUdi() float getPileUpTimeErrorMUS() const { return getPileUpSpan() * o2::constants::lhc::LHCBunchSpacingMUS / 3.4641016; }
 
   typedef o2::track::TrackParCov baseClass;
 

--- a/GPU/GPUTracking/Definitions/GPUSettingsList.h
+++ b/GPU/GPUTracking/Definitions/GPUSettingsList.h
@@ -101,6 +101,8 @@ AddOptionRTC(stopTrkAfterNMissLy, unsigned char, 6, "", 0, "Abandon track follow
 AddOptionRTC(nTrackletsMin, unsigned char, 3, "", 0, "Tracks with less attached tracklets are discarded after the tracking")
 AddOptionRTC(useExternalO2DefaultPropagator, unsigned char, 0, "", 0, "Use the default instance of the o2::Propagator, instead of the GPU Reconstruciton one with GPU B field")
 AddOptionRTC(matCorrType, unsigned char, 2, "", 0, "Material correction to use: 0 - none, 1 - TGeo, 2 - matLUT")
+AddOptionRTC(pileupFwdNBC, unsigned char, 60, "", 0, "Post-trigger Pile-up integration time in BCs")
+AddOptionRTC(pileupBwdNBC, unsigned char, 80, "", 0, "Pre-trigger Pile-up integration time in BCs")
 AddHelp("help", 'h')
 EndConfig()
 

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -136,6 +136,7 @@ fi
 
 
 workflow_has_parameter CALIB && [[ $CALIB_TRD_VDRIFTEXB == 1 ]] && TRD_CONFIG+=" --enable-trackbased-calib"
+! has_detector FT0 && TRD_CONFIG+=" --disable-ft0-pileup-tagging"
 
 workflow_has_parameter CALIB && [[ $CALIB_TPC_VDRIFTTGL == 1 ]] && SEND_ITSTPC_DTGL="--produce-calibration-data"
 


### PR DESCRIPTION
Effect of closest pile-up interaction vs distance to it (from the trigger) on the TRD tracklet multiplicity:
![trd_pileup](https://user-images.githubusercontent.com/7382029/213535090-29d203f6-684d-4038-9372-be61aecc9931.png)


Original results (blue) of [Nov.17 sample](https://alice.its.cern.ch/jira/browse/O2-2761?focusedCommentId=295224&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-295224) and 
![accTRDPileup60](https://user-images.githubusercontent.com/7382029/213534580-06257138-747c-456a-96b2-6a9f792b66b1.png) and the same data reconstructed with TRD pileup accounted in at most 60 BCs after trigger (red).
