### PR TITLE
DPL: Make sure that DPL proxy ready fast channels fast-enough in multi-channel setup

### DIFF
--- a/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
+++ b/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
@@ -547,23 +547,32 @@ DataProcessorSpec specifyExternalFairMQDeviceProxy(char const* name,
 
       for (size_t ci = 0; ci < channels.size(); ++ci) {
         std::string const& channel = channels[ci];
-        fair::mq::Parts parts;
-        device->Receive(parts, channel, 0, channels.size() == 1 ? -1 : 1);
-        // Populate TimingInfo from the first message
-        if (parts.Size() != 0) {
-          auto const dh = o2::header::get<DataHeader*>(parts.At(0)->GetData());
-          auto& timingInfo = ctx.services().get<TimingInfo>();
-          if (dh != nullptr) {
-            timingInfo.runNumber = dh->runNumber;
-            timingInfo.firstTForbit = dh->firstTForbit;
-            timingInfo.tfCounter = dh->tfCounter;
+        int waitTime = channels.size() == 1 ? -1 : 1;
+        int maxRead = 1000;
+        while (maxRead-- > 0) {
+          fair::mq::Parts parts;
+          device->Receive(parts, channel, 0, waitTime);
+          // Populate TimingInfo from the first message
+          unsigned int nReceived = parts.Size();
+          if (nReceived != 0) {
+            auto const dh = o2::header::get<DataHeader*>(parts.At(0)->GetData());
+            auto& timingInfo = ctx.services().get<TimingInfo>();
+            if (dh != nullptr) {
+              timingInfo.runNumber = dh->runNumber;
+              timingInfo.firstTForbit = dh->firstTForbit;
+              timingInfo.tfCounter = dh->tfCounter;
+            }
+            auto const dph = o2::header::get<DataProcessingHeader*>(parts.At(0)->GetData());
+            if (dph != nullptr) {
+              timingInfo.timeslice = dph->startTime;
+              timingInfo.creation = dph->creation;
+            }
+            dataHandler(timingInfo, parts, 0, ci);
           }
-          auto const dph = o2::header::get<DataProcessingHeader*>(parts.At(0)->GetData());
-          if (dph != nullptr) {
-            timingInfo.timeslice = dph->startTime;
-            timingInfo.creation = dph->creation;
+          if (nReceived == 0 || channels.size() == 1) {
+            break;
           }
-          dataHandler(timingInfo, parts, 0, ci);
+          waitTime = 0;
         }
       }
     };


### PR DESCRIPTION
@ktf : Could you check and comment what you think of this?
It doesn't change the behavior for one input channel at all, so it affects only those calib workflows that have multiple input channels (TPC digital / analog currents).
The idea is that if we have different channels sending at different rate, we make sure to always drain the faster channel, and not spend the 1ms sleeping while waiting for other channels.
Worked in my tests.

Initially I wanted to make it more configurable, since I thought this breaks the lifetime::timeframe paradigm, that we will have exactly one (multi-part) message per channel per timeframe. But then I realized this is anyway not true for multiple input channels, since they cannot be synchronized by design.
Only way we could enfore it is synchronizing them in the proxy, i.e. enforcing we have exactly one message per channel, and only then restart the loop. That would be setting the wait time to -1. That could become such an option in the future, but I think for the calibration we don't need it anyway, since it is lifetime sporadic.

Thus now I am kind of convinced we can leave it as is. But if you want to implement it in a different way, also fine for me of course.