### PR TITLE
[FOCAL-11] Provide simple base analysis task for TB events

### DIFF
--- a/Detectors/FOCAL/base/CMakeLists.txt
+++ b/Detectors/FOCAL/base/CMakeLists.txt
@@ -11,10 +11,12 @@
 
 o2_add_library(FOCALBase
     SOURCES src/EventReader.cxx
+    src/TestbeamAnalysis.cxx
     PUBLIC_LINK_LIBRARIES O2::DataFormatsFOCAL ROOT::RIO ROOT::Tree ROOT::TreePlayer
     Microsoft.GSL::GSL)
 
 o2_target_root_dictionary(
     FOCALBase
     HEADERS include/FOCALBase/EventReader.h
+    include/FOCALBase/TestbeamAnalysis.h
 )

--- a/Detectors/FOCAL/base/include/FOCALBase/TestbeamAnalysis.h
+++ b/Detectors/FOCAL/base/include/FOCALBase/TestbeamAnalysis.h
@@ -1,0 +1,52 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef ALICEO2_FOCAL_TESTBEAMANALYSIS_H
+#define ALICEO2_FOCAL_TESTBEAMANALYSIS_H
+
+#include <memory>
+#include <string>
+#include <string_view>
+#include <TFile.h>
+#include <DataFormatsFOCAL/Event.h>
+#include <FOCALBase/EventReader.h>
+
+namespace o2::focal
+{
+
+class TestbeamAnalysis
+{
+ public:
+  TestbeamAnalysis() = default;
+  virtual ~TestbeamAnalysis() = default;
+
+  void run();
+  void setInputFile(const std::string_view inputfile) { mInputFilename = inputfile.data(); }
+  void setVerbose(bool doVerbose) { mVerbose = doVerbose; }
+
+ protected:
+  virtual void init() {}
+  virtual void process(const Event& event) {}
+  virtual void terminate() {}
+
+  int getCurrentEventNumber() const { return mCurrentEventNumber; }
+
+ private:
+  std::unique_ptr<EventReader> mEventReader;
+  std::unique_ptr<TFile> mCurrentFile;
+  std::string mInputFilename;
+  int mCurrentEventNumber = 0;
+  bool mVerbose = false;
+
+  ClassDefNV(TestbeamAnalysis, 1);
+};
+
+} // namespace o2::focal
+#endif // ALICEO2_FOCAL_TESTBEAMANALYSIS_H

--- a/Detectors/FOCAL/base/src/FOCALBaseLinkDef.h
+++ b/Detectors/FOCAL/base/src/FOCALBaseLinkDef.h
@@ -16,4 +16,5 @@
 #pragma link off all functions;
 
 #pragma link C++ class o2::focal::EventReader + ;
+#pragma link C++ class o2::focal::TestbeamAnalysis + ;
 #endif

--- a/Detectors/FOCAL/base/src/TestbeamAnalysis.cxx
+++ b/Detectors/FOCAL/base/src/TestbeamAnalysis.cxx
@@ -1,0 +1,42 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include <TTree.h>
+#include <TROOT.h>
+#include <fairlogger/Logger.h>
+#include <FOCALBase/TestbeamAnalysis.h>
+
+using namespace o2::focal;
+
+void TestbeamAnalysis::run()
+{
+
+  mCurrentFile = std::unique_ptr<TFile>(TFile::Open(mInputFilename.data(), "READ"));
+  if (!mCurrentFile || mCurrentFile->IsZombie()) {
+    LOG(error) << "Failed reading input file " << mInputFilename;
+  }
+
+  mEventReader = std::make_unique<EventReader>(mCurrentFile->Get<TTree>("o2sim"));
+  mCurrentEventNumber = 0;
+
+  gROOT->cd();
+  init();
+
+  while (mEventReader->hasNext()) {
+    auto currentevent = mEventReader->readNextEvent();
+    if (mVerbose) {
+      LOG(info) << "Processing event " << mCurrentEventNumber;
+    }
+    process(currentevent);
+    mCurrentEventNumber++;
+  }
+
+  terminate();
+}


### PR DESCRIPTION
Simple analysis base task for analysis of o2::focal::Event created in the reconstruction of FOCAL-E data. Internally iterating over events using the o2::focal::EventReader. Users need to implement the functions
- init
- process
- terminate Functionality will stay limited considering the conditions of TB data (i.e. runs will be in the same event tree - no need for chaining, no train infrastructure).