### PR TITLE
Revert "Add metadata to AOD writer inputs (#10531)"

### DIFF
--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -614,11 +614,7 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
   // ATTENTION: if there are dangling outputs the getGlobalAODSink
   // has to be created in any case!
   std::vector<InputSpec> outputsInputsAOD;
-  auto isAOD = [](InputSpec const& spec) {
-    return (DataSpecUtils::partialMatch(spec, header::DataOrigin("AOD")) ||
-            DataSpecUtils::partialMatch(spec, header::DataOrigin("DYN")) ||
-            DataSpecUtils::partialMatch(spec, header::DataOrigin("AMD")));
-  };
+  auto isAOD = [](InputSpec const& spec) { return (DataSpecUtils::partialMatch(spec, header::DataOrigin("AOD")) || DataSpecUtils::partialMatch(spec, header::DataOrigin("DYN"))); };
   for (auto ii = 0u; ii < outputsInputs.size(); ii++) {
     if (isAOD(outputsInputs[ii])) {
       auto ds = dod->getDataOutputDescriptors(outputsInputs[ii]);


### PR DESCRIPTION
This reverts commit f779caf4b986834174514fe310d26e62b3b1477b.
@nburmaso , the AOD producer gets stuck with the PR above. I also tried to include https://github.com/AliceO2Group/AliceO2/pull/10556, but unless I made a mistake, nothing changed. Since we need to use the latest tag for apass2, I think we should revert for now f779caf4b986834174514fe310d26e62b3b1477b, then we can check better for apass3. 

@shahor02 , can you please take a look?