### PR TITLE
Fix outlier rejection for B=0 data

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCInterpolationSpec.cxx
@@ -179,7 +179,9 @@ void TPCInterpolationDPL::run(ProcessingContext& pc)
     }
   };
   recoData.createTracksVariadic(creator); // create track sample considered for interpolation
-  LOG(info) << "Created " << seeds.size() << " seeds.";
+  LOGP(info, "Created {} seeds. {} ITS-TPC-TRD-TOF, {} ITS-TPC-TRD, {} ITS-TPC-TOF, {} ITS-TPC",
+       seeds.size(), trkCounters.at(GTrackID::Source::ITSTPCTRDTOF), trkCounters.at(GTrackID::Source::ITSTPCTRD),
+       trkCounters.at(GTrackID::Source::ITSTPCTOF), trkCounters.at(GTrackID::Source::ITSTPC));
 
   if (mUseMC) {
     // possibly MC labels will be used to check filtering procedure performance before interpolation

--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/SpacePointsCalibConfParam.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/SpacePointsCalibConfParam.h
@@ -54,6 +54,7 @@ struct SpacePointsCalibConfParam : public o2::conf::ConfigurableParamHelper<Spac
   float maxDCA = 10.f;            ///< DCA cut value in cm
 
   // parameters for outlier rejection
+  bool skipOutlierFiltering{false};      ///< if set, the outlier filtering will not be applied at all
   bool writeUnfiltered{false};           ///< if set, all residuals and track parameters will be aggregated and dumped additionally without outlier rejection
   int nMALong{15};                       ///< number of points to be used for moving average (long range)
   int nMAShort{3};                       ///< number of points to be used for estimation of distance from local line (short range)

--- a/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
+++ b/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
@@ -321,7 +321,7 @@ void TrackInterpolation::interpolateTrack(int iSeed)
   trackData.clAvailTOF = gidTable[GTrackID::TOF].isIndexSet() ? 1 : 0;
 
   TrackParams params; // for refitted track parameters and flagging rejected clusters
-  if (validateTrack(trackData, params, clusterResiduals)) {
+  if (mParams->skipOutlierFiltering || validateTrack(trackData, params, clusterResiduals)) {
     // track is good
     int nClValidated = 0;
     int iRow = 0;
@@ -396,7 +396,7 @@ void TrackInterpolation::extrapolateTrack(int iSeed)
   trackData.clIdx.setEntries(nMeasurements);
 
   TrackParams params; // for refitted track parameters and flagging rejected clusters
-  if (validateTrack(trackData, params, clusterResiduals)) {
+  if (mParams->skipOutlierFiltering || validateTrack(trackData, params, clusterResiduals)) {
     // track is good
     int nClValidated = 0;
     int iRow = 0;
@@ -437,7 +437,7 @@ bool TrackInterpolation::validateTrack(const TrackData& trk, TrackParams& params
     LOG(debug) << "Skipping track too far from helix approximation";
     return false;
   }
-  if (fabsf(params.qpt) > mParams->maxQ2Pt) {
+  if (fabsf(mBz) > 0.01 && fabsf(params.qpt) > mParams->maxQ2Pt) {
     LOG(debug) << "Skipping track with too high q/pT: " << params.qpt;
     return false;
   }
@@ -499,6 +499,10 @@ bool TrackInterpolation::compareToHelix(const TrackData& trk, TrackParams& param
       }
       sPath[iP] = sPath[iP - 1] + ds;
     }
+  }
+  if (fabsf(mBz) < 0.01) {
+    // for B=0 we don't need to try a circular fit...
+    return true;
   }
   float xcSec = 0.f;
   float ycSec = 0.f;


### PR DESCRIPTION
- optionally allow skipping outlier rejection completely

@wiechula I tested this for run 520495 and with that most tracks can be interpolated successfully