### PR TITLE
[FOCAL-11] Drop empty timeframes in reader

### DIFF
--- a/DataFormats/Detectors/FOCAL/include/DataFormatsFOCAL/Event.h
+++ b/DataFormats/Detectors/FOCAL/include/DataFormatsFOCAL/Event.h
@@ -104,6 +104,8 @@ class Event
 
   void construct(const o2::InteractionRecord& interaction, gsl::span<const PadLayerEvent> pads, gsl::span<const PixelChipRecord> eventPixels, gsl::span<const PixelHit> pixelHits);
 
+  bool isInitialized() const { return mInitialized; }
+
  private:
   void check_pad_layers(unsigned int index) const;
   void check_pixel_layers(unsigned int index) const;
@@ -111,6 +113,7 @@ class Event
   InteractionRecord mInteractionRecord;
   std::array<PadLayerEvent, constants::PADS_NLAYERS> mPadLayers;
   std::array<PixelLayerEvent, constants::PIXELS_NLAYERS> mPixelLayers;
+  bool mInitialized = false;
 
   ClassDefNV(Event, 1);
 };

--- a/DataFormats/Detectors/FOCAL/src/Event.cxx
+++ b/DataFormats/Detectors/FOCAL/src/Event.cxx
@@ -52,6 +52,7 @@ void Event::setPixelLayerEvent(unsigned int layer, const PixelLayerEvent& event)
 
 void Event::reset()
 {
+  mInitialized = false;
   for (auto& padlayer : mPadLayers) {
     padlayer.reset();
   }
@@ -87,6 +88,7 @@ void Event::construct(const o2::InteractionRecord& interaction, gsl::span<const 
       mPixelLayers[chip.getLayerID()].addChip(chip.getLaneID(), chip.getChipID(), pixelHits.subspan(chip.getFirstHit(), chip.getNumberOfHits()));
     }
   }
+  mInitialized = true;
 }
 
 void Event::check_pad_layers(unsigned int index) const

--- a/Detectors/FOCAL/base/src/TestbeamAnalysis.cxx
+++ b/Detectors/FOCAL/base/src/TestbeamAnalysis.cxx
@@ -34,8 +34,10 @@ void TestbeamAnalysis::run()
     if (mVerbose) {
       LOG(info) << "Processing event " << mCurrentEventNumber;
     }
-    process(currentevent);
-    mCurrentEventNumber++;
+    if (currentevent.isInitialized()) {
+      process(currentevent);
+      mCurrentEventNumber++;
+    }
   }
 
   terminate();


### PR DESCRIPTION
In case of uncompressed data the empty timeframes
must be ignored in the reader, otherwise it leads to a crash. The data can however also close with empty
timeframes. In this case the reader would at the end return an empty event, for which an initialize flag is used to determine the init status. Uninitialized events are discarded by the analysis manager.