### PR TITLE
[FOCAL-10, FOCAL-11] Fixes in pixel decoding

### DIFF
--- a/DataFormats/Detectors/FOCAL/include/DataFormatsFOCAL/Event.h
+++ b/DataFormats/Detectors/FOCAL/include/DataFormatsFOCAL/Event.h
@@ -73,7 +73,7 @@ class PixelLayerEvent
   ~PixelLayerEvent() = default;
 
   void addChip(const PixelChip& chip);
-  void addChip(int laneID, int chipID, gsl::span<const PixelHit> hits);
+  void addChip(int feeID, int laneID, int chipID, uint16_t statusCode, gsl::span<const PixelHit> hits);
   const std::vector<PixelChip>& getChips() const { return mChips; }
 
   void reset();

--- a/DataFormats/Detectors/FOCAL/include/DataFormatsFOCAL/PixelChip.h
+++ b/DataFormats/Detectors/FOCAL/include/DataFormatsFOCAL/PixelChip.h
@@ -21,21 +21,90 @@ namespace o2::focal
 {
 
 struct PixelChip {
+  static constexpr uint16_t DATAFRAME = 0x1 << 0;
+  static constexpr uint16_t EMPTYFRAME = 0x1 << 1;
+  static constexpr uint16_t BUSY_ON = 0x1 << 2;
+  static constexpr uint16_t BUSY_OFF = 0x1 << 3;
+
+  uint8_t mFeeID;
   uint8_t mLaneID;
   uint8_t mChipID;
+  uint16_t mStatusCode;
   std::vector<PixelHit> mHits;
 
-  bool operator==(const PixelChip& other) const { return mChipID == other.mChipID && mLaneID == other.mLaneID; }
+  bool operator==(const PixelChip& other) const { return mChipID == other.mChipID && mLaneID == other.mLaneID && mFeeID == other.mFeeID; }
   bool operator<(const PixelChip& other) const
   {
-    if (mLaneID < other.mLaneID) {
+    if (mFeeID < other.mFeeID) {
       return true;
-    } else if ((mLaneID == other.mLaneID) && (mChipID < other.mChipID)) {
-      return true;
+    } else if (mFeeID == other.mFeeID) {
+      if (mLaneID < other.mLaneID) {
+        return true;
+      } else if ((mLaneID == other.mLaneID) && (mChipID < other.mChipID)) {
+        return true;
+      } else {
+        return false;
+      }
     } else {
       return false;
     }
   }
+
+  void setDataframe()
+  {
+    mStatusCode |= DATAFRAME;
+  }
+
+  void setEmptyframe()
+  {
+    mStatusCode |= EMPTYFRAME;
+  }
+
+  void setBusyOn()
+  {
+    mStatusCode |= BUSY_ON;
+  }
+
+  void removeDataframe()
+  {
+    mStatusCode &= ~(DATAFRAME);
+  }
+
+  void removeEmptyframe()
+  {
+    mStatusCode &= ~(EMPTYFRAME);
+  }
+
+  void removeBusyOn()
+  {
+    mStatusCode &= ~(BUSY_ON);
+  }
+
+  void removeBusyOff()
+  {
+    mStatusCode &= ~(BUSY_ON);
+  }
+
+  bool isDataframe() const
+  {
+    return mStatusCode & DATAFRAME;
+  }
+
+  bool isEmptyframe() const
+  {
+    return mStatusCode & EMPTYFRAME;
+  }
+
+  bool isBusyOn() const
+  {
+    return mStatusCode & BUSY_ON;
+  }
+
+  bool isBusyOff() const
+  {
+    return mStatusCode & BUSY_OFF;
+  }
+
   ClassDefNV(PixelChip, 1);
 };
 

--- a/DataFormats/Detectors/FOCAL/include/DataFormatsFOCAL/PixelChipRecord.h
+++ b/DataFormats/Detectors/FOCAL/include/DataFormatsFOCAL/PixelChipRecord.h
@@ -24,18 +24,22 @@ class PixelChipRecord
 
  public:
   PixelChipRecord() = default;
-  PixelChipRecord(int layerID, int laneID, int chipID, int firsthit, int nhits) : mLayerID(layerID), mLaneID(laneID), mChipID(chipID), mHitIndexRange(firsthit, nhits) {}
+  PixelChipRecord(int layerID, int feeID, int laneID, int chipID, uint32_t statusCode, int firsthit, int nhits) : mLayerID(layerID), mLaneID(laneID), mChipID(chipID), mFeeID(feeID), mStatusCode(statusCode), mHitIndexRange(firsthit, nhits) {}
   ~PixelChipRecord() = default;
 
   void setLayerID(int layerID) { mLayerID = layerID; }
   void setLaneID(int laneID) { mLaneID = laneID; }
   void setChipID(int chipID) { mChipID = chipID; }
+  void setFeeID(int feeID) { mFeeID = feeID; }
+  void setStatusCode(uint16_t statusCode) { mStatusCode = statusCode; }
   void setIndexFirstHit(int firsthit) { mHitIndexRange.setFirstEntry(firsthit); }
   void setNumberOfHits(int nhits) { mHitIndexRange.setEntries(nhits); }
 
   int getLayerID() const { return mLayerID; }
   int getLaneID() const { return mLaneID; }
   int getChipID() const { return mChipID; }
+  int getFeeID() const { return mFeeID; }
+  uint16_t getStatusCode() const { return mStatusCode; }
   int getFirstHit() const { return mHitIndexRange.getFirstEntry(); }
   int getNumberOfHits() const { return mHitIndexRange.getEntries(); }
 
@@ -45,6 +49,8 @@ class PixelChipRecord
   int mLayerID = -1;        /// Layer index
   int mLaneID = -1;         /// Lane index
   int mChipID = -1;         /// Chip index
+  int mFeeID = -1;          /// FEE ID
+  uint16_t mStatusCode = 0; /// status codes
   DataRange mHitIndexRange; /// Index range of hits belonging to theh chip
 
   ClassDefNV(PixelChipRecord, 1);

--- a/DataFormats/Detectors/FOCAL/src/PixelChip.cxx
+++ b/DataFormats/Detectors/FOCAL/src/PixelChip.cxx
@@ -16,6 +16,6 @@ using namespace o2::focal;
 
 std::ostream& o2::focal::operator<<(std::ostream& stream, const PixelChip& chip)
 {
-  stream << "Chip " << static_cast<int>(chip.mChipID) << " (lane " << static_cast<uint8_t>(chip.mLaneID) << "), found " << chip.mHits.size() << " hits";
+  stream << "Chip " << static_cast<int>(chip.mChipID) << " (lane " << static_cast<uint8_t>(chip.mLaneID) << ", fee " << chip.mFeeID << "), found " << chip.mHits.size() << " hits";
   return stream;
 }

--- a/Detectors/FOCAL/workflow/include/FOCALWorkflow/RawDecoderSpec.h
+++ b/Detectors/FOCAL/workflow/include/FOCALWorkflow/RawDecoderSpec.h
@@ -61,7 +61,7 @@ class RawDecoderSpec : public framework::Task
   void decodePadEvent(const gsl::span<const char> padWords, o2::InteractionRecord& hbIR);
   int decodePixelData(const gsl::span<const char> pixelWords, o2::InteractionRecord& hbIR, int fecID);
   std::array<PadLayerEvent, constants::PADS_NLAYERS> createPadLayerEvent(const o2::focal::PadData& data) const;
-  void fillChipsToLayer(PixelLayerEvent& pixellayer, const gsl::span<const PixelChip>& chipData);
+  void fillChipsToLayer(PixelLayerEvent& pixellayer, const gsl::span<const PixelChip>& chipData, int feeID);
   void fillEventPixeHitContainer(std::vector<PixelHit>& eventHits, std::vector<PixelChipRecord>& eventChips, const PixelLayerEvent& pixelLayer, int layerIndex);
   int filterIncompletePixelsEventsHBF(HBFData& data, const std::vector<int>& expectFEEs);
   void buildEvents();


### PR DESCRIPTION
- Typo in payload size determination was leading to
  chopped payload sent to the pixel decoder
- New fileds added in PixelChip (and corresponding
  record):
  + feeID, needed to distinguish chips with same
    lane and chip ID
  + status code for propagating busy status