### PR TITLE
Temporary revert recent MFT tracking changes to check if they are responsible for fullCI failures

### DIFF
--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/Constants.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/Constants.h
@@ -55,13 +55,13 @@ constexpr Int_t MaxCellsInRoad{100};
 
 namespace index_table
 {
-constexpr std::array<Float_t, o2::mft::constants::mft::LayersNumber> RMin{2.1, 2.1, 2.1, 2.1, 2.1, 2.1, 3.1, 3.1, 3.5, 3.5}; // [cm]
-constexpr std::array<Float_t, o2::mft::constants::mft::LayersNumber> RMax{12.5, 12.5, 12.5, 12.5, 14.0, 14.0, 17.0, 17.0, 17.5, 17.5};
+constexpr Float_t RMin{1.0}; // [cm]
+constexpr Float_t RMax{20.0};
 
 constexpr Float_t PhiMin{0.};
 constexpr Float_t PhiMax{o2::constants::math::TwoPI}; // [rad]
 
-constexpr Int_t MaxRPhiBins{200 * 200 + 1};
+constexpr Int_t MaxRPhiBins{100 * 100};
 } // namespace index_table
 
 } // namespace constants

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/MFTTrackingParam.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/MFTTrackingParam.h
@@ -53,13 +53,13 @@ struct MFTTrackingParam : public o2::conf::ConfigurableParamHelper<MFTTrackingPa
   /// maximum distance for a cluster to be attached to a seed line (CA road)
   Float_t ROADclsRCut = 0.0400;
   /// number of bins in r-direction
-  Int_t RBins = 30;
+  Int_t RBins = 50;
   /// number of bins in phi-direction
-  Int_t PhiBins = 120;
+  Int_t PhiBins = 50;
   /// Minimum z vertex position for conical search bin optimization
-  Float_t ZVtxMin = -13.f; // cm
+  Float_t ZVtxMin = -15.f; // cm
   /// Maximum z vertex position for conical search bin optimization
-  Float_t ZVtxMax = 13.f; // cm
+  Float_t ZVtxMax = 15.f; // cm
   /// Radial vertex position cut at ZVtxMin
   Float_t rCutAtZmin = 0.1; // cm
   /// Special version for TED shots and cosmics, with full scan of the clusters

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/MFTTrackingParam.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/MFTTrackingParam.h
@@ -56,20 +56,16 @@ struct MFTTrackingParam : public o2::conf::ConfigurableParamHelper<MFTTrackingPa
   Int_t RBins = 50;
   /// number of bins in phi-direction
   Int_t PhiBins = 50;
-  /// Minimum z vertex position for conical search bin optimization
-  Float_t ZVtxMin = -15.f; // cm
-  /// Maximum z vertex position for conical search bin optimization
-  Float_t ZVtxMax = 15.f; // cm
-  /// Radial vertex position cut at ZVtxMin
-  Float_t rCutAtZmin = 0.1; // cm
+  /// RPhi search window bin width for the second point of a seed (LTF and CA)
+  Int_t LTFseed2BinWin = 3;
+  /// RPhi search window bin width for the intermediate points
+  Int_t LTFinterBinWin = 3;
   /// Special version for TED shots and cosmics, with full scan of the clusters
   bool FullClusterScan = false;
   /// road for LTF algo : cylinder or cone (default)
   Bool_t LTFConeRadius = kFALSE;
   /// road for CA algo : cylinder or cone (default)
   Bool_t CAConeRadius = kFALSE;
-  /// Minimum fraction of correct clusters MC labels to set True MC tracks
-  Float_t TrueTrackMCThreshold = 0.8;
 
   // cuts to reject to low or too high mult events, or externally provided IRFrames
   float cutMultClusLow = 0;   /// reject ROF with estimated cluster mult. below this value (no cut if <0)

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/ROframe.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/ROframe.h
@@ -56,6 +56,8 @@ class ROframe
 
   const MCCompLabel& getClusterLabels(Int_t layerId, const Int_t clusterId) const { return mClusterLabels[layerId][clusterId]; }
 
+  const std::array<std::pair<Int_t, Int_t>, constants::index_table::MaxRPhiBins>& getClusterBinIndexRange(Int_t layerId) const { return mClusterBinIndexRange[layerId]; }
+
   const Int_t getClusterExternalIndex(Int_t layerId, const Int_t clusterId) const { return mClusterExternalIndices[layerId][clusterId]; }
 
   std::vector<T>& getTracks() { return mTracks; }
@@ -78,6 +80,8 @@ class ROframe
 
   void addRoad() { mRoads.emplace_back(); }
 
+  void initialize(bool fullClusterScan = false);
+
   void sortClusters();
 
   void clear()
@@ -87,6 +91,9 @@ class ROframe
       mClusters[iLayer].clear();
       mClusterLabels[iLayer].clear();
       mClusterExternalIndices[iLayer].clear();
+      for (Int_t iBin = 0; iBin < constants::index_table::MaxRPhiBins; ++iBin) {
+        mClusterBinIndexRange[iLayer][iBin] = std::pair<Int_t, Int_t>(0, -1);
+      }
     }
     mTracks.clear();
     mRoads.clear();
@@ -98,6 +105,7 @@ class ROframe
   std::array<std::vector<Cluster>, constants::mft::LayersNumber> mClusters;
   std::array<std::vector<MCCompLabel>, constants::mft::LayersNumber> mClusterLabels;
   std::array<std::vector<Int_t>, constants::mft::LayersNumber> mClusterExternalIndices;
+  std::array<std::array<std::pair<Int_t, Int_t>, constants::index_table::MaxRPhiBins>, constants::mft::LayersNumber> mClusterBinIndexRange;
   std::vector<T> mTracks;
   std::vector<Road> mRoads;
 };

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/Tracker.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/Tracker.h
@@ -62,25 +62,15 @@ class Tracker : public TrackerConfig
     mTrackLabels.clear();
   }
 
-  void findTracks(ROframe<T>& rofData)
-  {
-    if (!mFullClusterScan) {
-      clearSorting();
-      sortClusters(rofData);
-    }
-    findLTFTracks(rofData);
-    findCATracks(rofData);
-  };
-
   void findLTFTracks(ROframe<T>&);
   void findCATracks(ROframe<T>&);
   bool fitTracks(ROframe<T>&);
   void computeTracksMClabels(const std::vector<T>&);
 
-  void configure(const MFTTrackingParam& trkParam, bool firstTracker);
-  void initializeFinder();
+  void configure(const MFTTrackingParam& trkParam, bool printConfig = false);
 
  private:
+  void initializeFinder();
   void findTracksLTF(ROframe<T>&);
   void findTracksCA(ROframe<T>&);
   void findTracksLTFfcs(ROframe<T>&);
@@ -90,51 +80,6 @@ class Tracker : public TrackerConfig
   void runBackwardInRoad(ROframe<T>&);
   void updateCellStatusInRoad();
 
-  void sortClusters(ROframe<T>& rof)
-  {
-    Int_t nClsInLayer, binPrevIndex, clsMinIndex, clsMaxIndex, jClsLayer;
-    // sort the clusters in R-Phi
-    for (Int_t iLayer = 0; iLayer < constants::mft::LayersNumber; ++iLayer) {
-      if (rof.getClustersInLayer(iLayer).size() == 0) {
-        continue;
-      }
-      // sort clusters in layer according to the bin index
-      sort(rof.getClustersInLayer(iLayer).begin(), rof.getClustersInLayer(iLayer).end(),
-           [](Cluster& c1, Cluster& c2) { return c1.indexTableBin < c2.indexTableBin; });
-      // find the cluster local index range in each bin
-      // index = element position in the vector
-      nClsInLayer = rof.getClustersInLayer(iLayer).size();
-      binPrevIndex = rof.getClustersInLayer(iLayer).at(0).indexTableBin;
-      clsMinIndex = 0;
-      for (jClsLayer = 1; jClsLayer < nClsInLayer; ++jClsLayer) {
-        if (rof.getClustersInLayer(iLayer).at(jClsLayer).indexTableBin == binPrevIndex) {
-          continue;
-        }
-
-        clsMaxIndex = jClsLayer - 1;
-
-        mClusterBinIndexRange[iLayer][binPrevIndex] = std::pair<Int_t, Int_t>(clsMinIndex, clsMaxIndex);
-
-        binPrevIndex = rof.getClustersInLayer(iLayer).at(jClsLayer).indexTableBin;
-        clsMinIndex = jClsLayer;
-      } // clusters
-
-      // last cluster
-      clsMaxIndex = jClsLayer - 1;
-
-      mClusterBinIndexRange[iLayer][binPrevIndex] = std::pair<Int_t, Int_t>(clsMinIndex, clsMaxIndex);
-    } // layers
-  }
-
-  void clearSorting()
-  {
-    for (Int_t iLayer = 0; iLayer < constants::mft::LayersNumber; ++iLayer) {
-      for (Int_t iBin = 0; iBin <= mRPhiBins + 1; ++iBin) {
-        mClusterBinIndexRange[iLayer][iBin] = std::pair<Int_t, Int_t>(0, -1);
-      }
-    }
-  }
-
   const Int_t isDiskFace(Int_t layer) const { return (layer % 2); }
   const Float_t getDistanceToSeed(const Cluster&, const Cluster&, const Cluster&) const;
   void getBinClusterRange(const ROframe<T>&, const Int_t, const Int_t, Int_t&, Int_t&) const;
@@ -143,13 +88,16 @@ class Tracker : public TrackerConfig
   void addCellToCurrentTrackCA(const Int_t, const Int_t, ROframe<T>&);
   void addCellToCurrentRoad(ROframe<T>&, const Int_t, const Int_t, const Int_t, const Int_t, Int_t&);
 
-  Float_t mBz;
+  Float_t mBz = 5.f;
   std::vector<MCCompLabel> mTrackLabels;
   std::unique_ptr<o2::mft::TrackFitter<T>> mTrackFitter = nullptr;
 
   Int_t mMaxCellLevel = 0;
 
   bool mUseMC = false;
+
+  std::array<std::array<std::array<std::vector<Int_t>, constants::index_table::MaxRPhiBins>, (constants::mft::LayersNumber - 1)>, (constants::mft::LayersNumber - 1)> mBinsS;
+  std::array<std::array<std::array<std::vector<Int_t>, constants::index_table::MaxRPhiBins>, (constants::mft::LayersNumber - 1)>, (constants::mft::LayersNumber - 1)> mBins;
 
   /// helper to store points of a track candidate
   struct TrackElement {
@@ -189,7 +137,7 @@ inline const Float_t Tracker<T>::getDistanceToSeed(const Cluster& cluster1, cons
 template <typename T>
 inline void Tracker<T>::getBinClusterRange(const ROframe<T>& event, const Int_t layer, const Int_t bin, Int_t& clsMinIndex, Int_t& clsMaxIndex) const
 {
-  const auto& pair = getClusterBinIndexRange(layer, bin);
+  const auto& pair = event.getClusterBinIndexRange(layer)[bin];
   clsMinIndex = pair.first;
   clsMaxIndex = pair.second;
 }
@@ -264,7 +212,8 @@ inline void Tracker<T>::computeTracksMClabels(const std::vector<T>& tracks)
     }
 
     auto labelratio = 1.0 * count / nClusters;
-    if (labelratio < mTrueTrackMCThreshold) {
+    if (labelratio >= 0.8) {
+    } else {
       isFakeTrack = true;
       maxOccurrencesValue.setFakeFlag();
     }

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/TrackerConfig.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/TrackerConfig.h
@@ -23,9 +23,6 @@ namespace o2
 {
 namespace mft
 {
-
-using namespace constants::mft;
-
 class TrackerConfig
 {
  public:
@@ -35,15 +32,9 @@ class TrackerConfig
 
   void initialize(const MFTTrackingParam& trkParam);
 
-  const Int_t getRBinIndex(const Float_t r, const Int_t layer) const;
+  const Int_t getRBinIndex(const Float_t r) const;
   const Int_t getPhiBinIndex(const Float_t phi) const;
   const Int_t getBinIndex(const Int_t rIndex, const Int_t phiIndex) const;
-
-  // tracking configuration parameters
-  const auto& getBinsS() { return mBinsS; }
-  const auto& getBins() { return mBins; }
-
-  const std::pair<Int_t, Int_t>& getClusterBinIndexRange(Int_t layerId, Int_t bin) const { return mClusterBinIndexRange[layerId][bin]; }
 
  protected:
   // tracking configuration parameters
@@ -55,41 +46,27 @@ class TrackerConfig
   Float_t mLTFclsR2Cut;
   Float_t mROADclsRCut;
   Float_t mROADclsR2Cut;
+  Int_t mLTFseed2BinWin;
+  Int_t mLTFinterBinWin;
   Int_t mRBins;
   Int_t mPhiBins;
   Int_t mRPhiBins;
-  Float_t mZVtxMin;
-  Float_t mZVtxMax;
-  Float_t mRCutAtZmin;
+  Float_t mRBinSize;
+  Float_t mPhiBinSize;
+  Float_t mInverseRBinSize;
+  Float_t mInversePhiBinSize;
   Bool_t mLTFConeRadius;
   Bool_t mCAConeRadius;
+
   /// Special track finder for TED shots and cosmics, with full scan of the clusters
   bool mFullClusterScan = false;
-  Float_t mTrueTrackMCThreshold; // Minimum fraction of correct MC labels to tag True tracks
 
-  static Float_t mPhiBinSize;
-  static Float_t mInversePhiBinSize;
-  static std::array<Int_t, constants::mft::LayersNumber> mPhiBinWin;
-  static std::array<Float_t, constants::mft::LayersNumber> mRBinSize;
-  static std::array<Float_t, constants::mft::LayersNumber> mInverseRBinSize;
-  static std::array<std::array<std::array<std::vector<Int_t>, constants::index_table::MaxRPhiBins>, (constants::mft::LayersNumber - 1)>, (constants::mft::LayersNumber - 1)> mBins;
-  static std::array<std::array<std::array<std::vector<Int_t>, constants::index_table::MaxRPhiBins>, (constants::mft::LayersNumber - 1)>, (constants::mft::LayersNumber - 1)> mBinsS;
-  std::array<std::array<std::pair<Int_t, Int_t>, constants::index_table::MaxRPhiBins>, constants::mft::LayersNumber> mClusterBinIndexRange;
-
-  ClassDefNV(TrackerConfig, 3);
+  ClassDefNV(TrackerConfig, 2);
 };
 
-inline Float_t TrackerConfig::mPhiBinSize;
-inline Float_t TrackerConfig::mInversePhiBinSize;
-inline std::array<Int_t, constants::mft::LayersNumber> TrackerConfig::mPhiBinWin;
-inline std::array<Float_t, constants::mft::LayersNumber> TrackerConfig::mRBinSize;
-inline std::array<Float_t, constants::mft::LayersNumber> TrackerConfig::mInverseRBinSize;
-inline std::array<std::array<std::array<std::vector<Int_t>, constants::index_table::MaxRPhiBins>, (constants::mft::LayersNumber - 1)>, (constants::mft::LayersNumber - 1)> TrackerConfig::mBins;
-inline std::array<std::array<std::array<std::vector<Int_t>, constants::index_table::MaxRPhiBins>, (constants::mft::LayersNumber - 1)>, (constants::mft::LayersNumber - 1)> TrackerConfig::mBinsS;
-
-inline const Int_t TrackerConfig::getRBinIndex(const Float_t r, const Int_t layer) const
+inline const Int_t TrackerConfig::getRBinIndex(const Float_t r) const
 {
-  return (Int_t)((r - constants::index_table::RMin[layer]) * mInverseRBinSize[layer]);
+  return (Int_t)((r - constants::index_table::RMin) * mInverseRBinSize);
 }
 
 inline const Int_t TrackerConfig::getPhiBinIndex(const Float_t phi) const
@@ -99,7 +76,8 @@ inline const Int_t TrackerConfig::getPhiBinIndex(const Float_t phi) const
 
 inline const Int_t TrackerConfig::getBinIndex(const Int_t rIndex, const Int_t phiIndex) const
 {
-  if (0 <= rIndex && rIndex < mRBins && 0 <= phiIndex && phiIndex < mPhiBins) {
+  if (0 <= rIndex && rIndex < mRBins &&
+      0 <= phiIndex && phiIndex < mPhiBins) {
     return (phiIndex * mRBins + rIndex);
   }
   return (mRBins * mPhiBins);

--- a/Detectors/ITSMFT/MFT/tracking/src/IOUtils.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/IOUtils.cxx
@@ -88,7 +88,7 @@ int ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe<T>& event
     Float_t rCoord = clsPoint2D.R();
     Float_t phiCoord = clsPoint2D.Phi();
     o2::math_utils::bringTo02PiGen(phiCoord);
-    int rBinIndex = tracker->getRBinIndex(rCoord, layer);
+    int rBinIndex = tracker->getRBinIndex(rCoord);
     int phiBinIndex = tracker->getPhiBinIndex(phiCoord);
     int binIndex = tracker->getBinIndex(rBinIndex, phiBinIndex);
     event.addClusterToLayer(layer, gloXYZ.x(), gloXYZ.y(), gloXYZ.z(), phiCoord, rCoord, event.getClustersInLayer(layer).size(), binIndex, sigmaX2, sigmaY2, sensorID);

--- a/Detectors/ITSMFT/MFT/tracking/src/ROframe.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/ROframe.cxx
@@ -31,6 +31,51 @@ Int_t ROframe<T>::getTotalClusters() const
   return Int_t(totalClusters);
 }
 
+template <typename T>
+void ROframe<T>::initialize(bool fullClusterScan)
+{
+  if (!fullClusterScan) {
+    sortClusters();
+  }
+}
+
+template <typename T>
+void ROframe<T>::sortClusters()
+{
+  Int_t nClsInLayer, binPrevIndex, clsMinIndex, clsMaxIndex, jClsLayer;
+  // sort the clusters in R-Phi
+  for (Int_t iLayer = 0; iLayer < constants::mft::LayersNumber; ++iLayer) {
+    if (mClusters[iLayer].size() == 0) {
+      continue;
+    }
+    // sort clusters in layer according to the bin index
+    sort(mClusters[iLayer].begin(), mClusters[iLayer].end(),
+         [](Cluster& c1, Cluster& c2) { return c1.indexTableBin < c2.indexTableBin; });
+    // find the cluster local index range in each bin
+    // index = element position in the vector
+    nClsInLayer = mClusters[iLayer].size();
+    binPrevIndex = mClusters[iLayer].at(0).indexTableBin;
+    clsMinIndex = 0;
+    for (jClsLayer = 1; jClsLayer < nClsInLayer; ++jClsLayer) {
+      if (mClusters[iLayer].at(jClsLayer).indexTableBin == binPrevIndex) {
+        continue;
+      }
+
+      clsMaxIndex = jClsLayer - 1;
+
+      mClusterBinIndexRange[iLayer][binPrevIndex] = std::pair<Int_t, Int_t>(clsMinIndex, clsMaxIndex);
+
+      binPrevIndex = mClusters[iLayer].at(jClsLayer).indexTableBin;
+      clsMinIndex = jClsLayer;
+    } // clusters
+
+    // last cluster
+    clsMaxIndex = jClsLayer - 1;
+
+    mClusterBinIndexRange[iLayer][binPrevIndex] = std::pair<Int_t, Int_t>(clsMinIndex, clsMaxIndex);
+  } // layers
+}
+
 template class ROframe<o2::mft::TrackLTF>;
 template class ROframe<o2::mft::TrackLTFL>;
 

--- a/Detectors/ITSMFT/MFT/tracking/src/TrackerConfig.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/TrackerConfig.cxx
@@ -22,6 +22,7 @@ void o2::mft::TrackerConfig::initialize(const MFTTrackingParam& trkParam)
 {
   /// initialize from MFTTrackingParam (command line configuration parameters)
 
+  mFullClusterScan = trkParam.FullClusterScan;
   mMinTrackPointsLTF = trkParam.MinTrackPointsLTF;
   mMinTrackPointsCA = trkParam.MinTrackPointsCA;
   mMinTrackStationsLTF = trkParam.MinTrackStationsLTF;
@@ -30,16 +31,20 @@ void o2::mft::TrackerConfig::initialize(const MFTTrackingParam& trkParam)
   mLTFclsR2Cut = mLTFclsRCut * mLTFclsRCut;
   mROADclsRCut = trkParam.ROADclsRCut;
   mROADclsR2Cut = mROADclsRCut * mROADclsRCut;
+  mLTFseed2BinWin = trkParam.LTFseed2BinWin;
+  mLTFinterBinWin = trkParam.LTFinterBinWin;
+  mLTFConeRadius = trkParam.LTFConeRadius;
+  mCAConeRadius = trkParam.CAConeRadius;
+
   mRBins = trkParam.RBins;
   mPhiBins = trkParam.PhiBins;
   mRPhiBins = trkParam.RBins * trkParam.PhiBins;
-  mZVtxMin = trkParam.ZVtxMin;
-  mZVtxMax = trkParam.ZVtxMax;
-  mRCutAtZmin = trkParam.rCutAtZmin;
-  mLTFConeRadius = trkParam.LTFConeRadius;
-  mCAConeRadius = trkParam.CAConeRadius;
-  mFullClusterScan = trkParam.FullClusterScan;
-  mTrueTrackMCThreshold = trkParam.TrueTrackMCThreshold;
 
-  assert(mRPhiBins < constants::index_table::MaxRPhiBins && "Track finder binning overflow");
+  assert(mRPhiBins < constants::index_table::MaxRPhiBins);
+
+  mRBinSize = (constants::index_table::RMax - constants::index_table::RMin) / mRBins;
+  mPhiBinSize = (constants::index_table::PhiMax - constants::index_table::PhiMin) / mPhiBins;
+
+  mInverseRBinSize = 1.0 / mRBinSize;
+  mInversePhiBinSize = 1.0 / mPhiBinSize;
 }

--- a/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/TrackerSpec.h
+++ b/Detectors/ITSMFT/MFT/workflow/include/MFTWorkflow/TrackerSpec.h
@@ -65,13 +65,15 @@ class TrackerDPL : public o2::framework::Task
 
   enum TimerIDs { SWTot,
                   SWLoadData,
-                  SWFindMFTTracks,
+                  SWFindLTFTracks,
+                  SWFindCATracks,
                   SWFitTracks,
                   SWComputeLabels,
                   NStopWatches };
   static constexpr std::string_view TimerName[] = {"TotalProcessing",
                                                    "LoadData",
-                                                   "FindTracks",
+                                                   "FindLTFTracks",
+                                                   "FindCATracks",
                                                    "FitTracks",
                                                    "ComputeLabels"};
   TStopwatch mTimer[NStopWatches];


### PR DESCRIPTION
@rpezzi there is an [indication](https://alice.its.cern.ch/jira/browse/O2-3520) that https://github.com/AliceO2Group/AliceO2/pull/10559 actually increases the memory consumption by 1 GB which makes fullCI to fail due to the OOM on the builder (as you remember, it was merged only after your private test). 
Could you please fix this large memory allocation?

I've spent ~2 h trying to remove the dependence of the `o2-sim-digitizer-workflow` on the `O2::MFTTracking` but failed. please check https://alice.its.cern.ch/jira/browse/O2-3521