### PR TITLE
[EMCAL-830] Handling of MC labels

### DIFF
--- a/Detectors/EMCAL/calib/include/EMCALCalib/CellRecalibrator.h
+++ b/Detectors/EMCAL/calib/include/EMCALCalib/CellRecalibrator.h
@@ -163,21 +163,26 @@ class CellRecalibrator
   /// are available are applied.
   ///
   /// \param inputcells Collection of input cells
-  /// \return vector of calibrated cells.
+  /// \return Tuple with vector of calibrated cells and vector of kept indices.
   template <typename T>
-  std::vector<T> getCalibratedCells(const gsl::span<const T> inputcells)
+  std::tuple<std::vector<T>, std::vector<int>> getCalibratedCells(const gsl::span<const T> inputcells)
   {
     std::vector<T> result;
+    std::vector<int> indices;
+    int currentindex = 0;
     for (const auto& cellToCalibrate : inputcells) {
       if (!(cellToCalibrate.getHighGain() || cellToCalibrate.getLowGain())) {
+        currentindex++;
         continue;
       }
       auto calibrated = getCalibratedCell(cellToCalibrate);
       if (calibrated) {
         result.push_back(calibrated.value());
+        indices.emplace_back(currentindex);
       }
+      currentindex++;
     }
-    return result;
+    return std::make_tuple(result, indices);
   }
 
   /// \brief Print settings to the stream

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/CellRecalibratorSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/CellRecalibratorSpec.h
@@ -12,11 +12,13 @@
 #include <bitset>
 #include <cstdint>
 #include <optional>
+#include "DataFormatsEMCAL/MCLabel.h"
 #include "EMCALCalib/CellRecalibrator.h"
 #include "EMCALWorkflow/CalibLoader.h"
 #include "Framework/ConcreteDataMatcher.h"
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
+#include "SimulationDataFormat/MCTruthContainer.h"
 
 namespace o2
 {
@@ -63,9 +65,10 @@ class CellRecalibratorSpec : public framework::Task
   /// \param ledsettings Handling of cells from LED events
   /// \param badChannelCalib If true the bad channel calibration is enabled
   /// \param timeCalib If true the time calibration is enabled
-  /// \param gainCalib If true the fain calibration is enabled
+  /// \param gainCalib If true the gain calibration is enabled
+  /// \param isMC If true the MCLabelContainer is adapted
   /// \param calibHandler Handler for calibration object loading
-  CellRecalibratorSpec(uint32_t outputspec, LEDEventSettings ledsettings, bool badChannelCalib, bool timeCalib, bool gainCalib, std::shared_ptr<CalibLoader>(calibHandler));
+  CellRecalibratorSpec(uint32_t outputspec, LEDEventSettings ledsettings, bool badChannelCalib, bool timeCalib, bool gainCalib, bool isMC, std::shared_ptr<CalibLoader>(calibHandler));
 
   /// \brief Destructor
   ~CellRecalibratorSpec() final = default;
@@ -126,6 +129,8 @@ class CellRecalibratorSpec : public framework::Task
   /// \param outputtriggers Output trigger records
   void writeTrigger(const gsl::span<const o2::emcal::Cell> selectedCells, const o2::emcal::TriggerRecord& eventtrigger, std::vector<o2::emcal::Cell>& outputcontainer, std::vector<o2::emcal::TriggerRecord>& outputtriggers);
 
+  void writeMCLabels(const o2::dataformats::MCTruthContainer<o2::emcal::MCLabel>& inputlabels, o2::dataformats::MCTruthContainer<o2::emcal::MCLabel>& outputContainer, const std::vector<int>& keptIndices, int firstindex);
+
   /// \enum CalibrationType_t
   /// \brief Calibrations handled by the recalibration workflow
   enum CalibrationType_t {
@@ -135,6 +140,7 @@ class CellRecalibratorSpec : public framework::Task
   };
 
   uint32_t mOutputSubspec = 0;                            ///< output subspecification;
+  bool mIsMC = false;                                     ///< MC mode
   LEDEventSettings mLEDsettings = LEDEventSettings::KEEP; ///< Handling of LED events
   std::bitset<8> mCalibrationSettings;                    ///< Recalibration settings (which calibration to be applied)
   std::shared_ptr<CalibLoader> mCalibrationHandler;       ///< Handler loading calibration objects
@@ -148,7 +154,8 @@ class CellRecalibratorSpec : public framework::Task
 /// \param badChannelCalib If true the bad channel calibration is enabled
 /// \param timeCalib If true the time calibration is enabled
 /// \param gainCalib If true the gain (energy) calibration is enabled
-framework::DataProcessorSpec getCellRecalibratorSpec(uint32_t inputSubspec, uint32_t outputSubspec, uint32_t ledsettings, bool badChannelCalib, bool timeCalib, bool gainCalib);
+/// \param isMC If true also the MC label container is adapted (relevant only for bad channel masking)
+framework::DataProcessorSpec getCellRecalibratorSpec(uint32_t inputSubspec, uint32_t outputSubspec, uint32_t ledsettings, bool badChannelCalib, bool timeCalib, bool gainCalib, bool isMC);
 
 } // namespace emcal
 

--- a/Detectors/EMCAL/workflow/src/cell-recalibrator-workflow.cxx
+++ b/Detectors/EMCAL/workflow/src/cell-recalibrator-workflow.cxx
@@ -31,6 +31,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
   std::vector<ConfigParamSpec> options{{"input-subspec", VariantType::UInt32, 1U, {"Subspecification for input objects"}},
                                        {"output-subspec", VariantType::UInt32, 0U, {"Subspecification for output objects"}},
+                                       {"isMC", VariantType::Bool, false, {"Monte-Carlo mode"}},
                                        {"no-badchannelcalib", VariantType::Bool, false, {"Disable bad channel calibration"}},
                                        {"no-timecalib", VariantType::Bool, false, {"Disable time calibration"}},
                                        {"no-gaincalib", VariantType::Bool, false, {"Disable gain calibration"}},
@@ -72,7 +73,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
 
   WorkflowSpec specs;
-  specs.emplace_back(o2::emcal::getCellRecalibratorSpec(inputsubspec, outputsubspec, ledsetting, !disableBadchannels, !disableTime, !disableEnergy));
+  specs.emplace_back(o2::emcal::getCellRecalibratorSpec(inputsubspec, outputsubspec, ledsetting, !disableBadchannels, !disableTime, !disableEnergy, cfgc.options().get<bool>("isMC")));
 
   // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit
   o2::raw::HBFUtilsInitializer hbfIni(cfgc, specs);


### PR DESCRIPTION
MC labels need to be adapted when applying
bad channel masking in case of simulation:
- CellRecalibrator must return the indices of
  kept cells (assume range-based iterator to
  keep order)
- Labels are filled with the same index as
  corresponding cells, therefore the labels
  with the relative kept indices are added to the
  output MC container