### PR TITLE
DPL: allow users to specify multiple timers

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -138,6 +138,7 @@ o2_add_library(Framework
                        src/StepTHn.cxx
                        src/Base64.cxx
                        src/DPLWebSocket.cxx
+                       src/TimerParamSpec.cxx
                        test/TestClasses.cxx
                TARGETVARNAME targetName
                PRIVATE_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_LIST_DIR}/src
@@ -229,6 +230,7 @@ foreach(t
         TMessageSerializer
         TableBuilder
         TimeParallelPipelining
+        Timers
         TimesliceIndex
         TypeTraits
         Variants

--- a/Framework/Core/include/Framework/LifetimeHelpers.h
+++ b/Framework/Core/include/Framework/LifetimeHelpers.h
@@ -40,7 +40,7 @@ struct LifetimeHelpers {
   /// Callback which creates a new timeslice when timer
   /// expires and there is not a compatible datadriven callback
   /// available.
-  static ExpirationHandler::Creator timeDrivenCreation(std::chrono::microseconds period, std::function<bool(void)> hasTimerFired, std::function<void(uint64_t, uint64_t)> updateTimerPeriod);
+  static ExpirationHandler::Creator timeDrivenCreation(std::vector<std::chrono::microseconds> periods, std::vector<std::chrono::seconds> intervals, std::function<bool(void)> hasTimerFired, std::function<void(uint64_t, uint64_t)> updateTimerPeriod);
 
   /// Callback which  creates a new timeslice whenever some libuv event happens
   static ExpirationHandler::Creator uvDrivenCreation(int loopReason, DeviceState& state);

--- a/Framework/Core/include/Framework/TimerParamSpec.h
+++ b/Framework/Core/include/Framework/TimerParamSpec.h
@@ -1,0 +1,35 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_FRAMEWORK_TIMERPARAMSPEC_H_
+#define O2_FRAMEWORK_TIMERPARAMSPEC_H_
+
+#include "Framework/ConfigParamSpec.h"
+#include <cstddef>
+#include <vector>
+
+namespace o2::framework
+{
+struct TimerSpec {
+  /// The period of the timer in microseconds
+  size_t period;
+  /// The validity of the timer in seconds from the previous validity (
+  /// or the start of the processing).
+  /// Notice that if you specify more than one TimerSpec, only
+  /// the first one will be active until valid.
+  size_t validity;
+};
+
+std::vector<ConfigParamSpec> timerSpecs(std::vector<TimerSpec> intervals);
+
+} // namespace o2::framework
+
+#endif // O2_FRAMEWORK_TIMERPARAMSPEC_H_

--- a/Framework/Core/src/TimerParamSpec.cxx
+++ b/Framework/Core/src/TimerParamSpec.cxx
@@ -1,0 +1,26 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/TimerParamSpec.h"
+#include <fmt/format.h>
+
+namespace o2::framework
+{
+std::vector<ConfigParamSpec> timerSpecs(std::vector<TimerSpec> timers)
+{
+  std::vector<o2::framework::ConfigParamSpec> specs;
+  for (auto& timer : timers) {
+    specs.push_back({fmt::format("period-{}", timer.validity).c_str(), o2::framework::VariantType::UInt64, timer.period, {"Timer period in milliseconds"}});
+  }
+  return specs;
+}
+
+} // namespace o2::framework

--- a/Framework/Core/src/TimesliceIndex.cxx
+++ b/Framework/Core/src/TimesliceIndex.cxx
@@ -144,6 +144,8 @@ TimesliceIndex::OldestInputInfo TimesliceIndex::setOldestPossibleInput(Timeslice
   mOldestPossibleInput = result;
   if (changed) {
     LOG(debug) << "Success: Oldest possible input is " << mOldestPossibleInput.timeslice.value << " due to channel " << mOldestPossibleInput.channel.value;
+  } else {
+    LOG(debug) << "No change in oldest possible input";
   }
   return mOldestPossibleInput;
 }

--- a/Framework/Core/src/WorkflowHelpers.cxx
+++ b/Framework/Core/src/WorkflowHelpers.cxx
@@ -374,7 +374,7 @@ void WorkflowHelpers::injectServiceDevices(WorkflowSpec& workflow, ConfigContext
           auto concrete = DataSpecUtils::asConcreteDataMatcher(input);
           auto hasOption = std::any_of(processor.options.begin(), processor.options.end(), [&input](auto const& option) { return (option.name == "period-" + input.binding); });
           if (hasOption == false) {
-            processor.options.push_back(ConfigParamSpec{"period-" + input.binding, VariantType::Int, 1000, {"period of the timer"}});
+            processor.options.push_back(ConfigParamSpec{"period-" + input.binding, VariantType::Int, 1000, {"period of the timer in milliseconds"}});
           }
           timer.outputs.emplace_back(OutputSpec{concrete.origin, concrete.description, concrete.subSpec, Lifetime::Timer});
         } break;

--- a/Framework/Core/test/test_Timers.cxx
+++ b/Framework/Core/test/test_Timers.cxx
@@ -1,0 +1,68 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/InputSpec.h"
+#include "Framework/TimerParamSpec.h"
+#include "Framework/runDataProcessing.h"
+#include "Framework/ControlService.h"
+#include <uv.h>
+
+using namespace o2::framework;
+
+// This is how you can define your processing in a declarative way
+WorkflowSpec defineDataProcessing(ConfigContext const& ctx)
+{
+  // every 2 second for the first 10s, then every second for 5 seconds.
+  std::vector<TimerSpec> timers{{TimerSpec{2000000000, 10},
+                                 TimerSpec{1000000000, 5}}};
+
+  std::vector<InputSpec> inputs = {{{"timer"}, "TST", "TIMER", 0, Lifetime::Timer, timerSpecs(timers)}};
+
+  return WorkflowSpec{
+    {
+      .name = "test-timer",
+      .inputs = inputs,
+      .outputs = {OutputSpec{"TST", "A", 0}},
+      .algorithm = AlgorithmSpec{adaptStateless(
+        [](DataAllocator& outputs, ControlService& control) {
+          LOGP(info, "Processing callback invoked");
+          outputs.make<int>(Output{"TST", "A", 0}, 1);
+          static int64_t counter = 0;
+          static int64_t counterA = 0;
+          static int64_t start = uv_hrtime();
+          int64_t lastTime = uv_hrtime();
+          auto elapsed = lastTime - start;
+
+          LOGP(info, "Elapsed time: {} ns", elapsed);
+          if ((lastTime - start) < 10000000000) {
+            auto diff = (counter * 2000000000) - (lastTime - start);
+            if (diff > 100000000) {
+              LOGP(fatal, "2s timer is not accurate enough: {}, count {}", diff, counter);
+            }
+            counter++;
+            counterA++;
+          } else {
+            if (counterA != 5) {
+              LOGP(fatal, "2s timer did not do all the expected iterations {} != 5", counterA);
+            }
+            int64_t diff = 2000000000LL * 5 + 1000000000 * (counter - 5) - (lastTime - start);
+            if (diff > 10000000) {
+              LOGP(fatal, "1s timer is not accurate enough: {}, count ", diff, counter);
+            }
+            counter++;
+          }
+          LOGP(info, "Counter: {}", counter);
+          if (counter == 15) {
+            control.readyToQuit(QuitRequest::All);
+          }
+        })},
+    }};
+}


### PR DESCRIPTION
The idea is that the user attaches as metadata to the timer inputs something like:

  InputSpec{... ,  Lifetime::Timer, timerIntervals({{<timer period>, <time duration>}, {<timer period>, <timer duration>}})}

For example:

  timerIntervals({{1000000, 10}, {10000000, -1}})

to have a timer expiring every 1'000'000 microseconds for the first 10 seconds and then every 10'000'000 microseconds for the rest of the time.