### PR TITLE
ITS3: Sim: Fix calculation of sensor width

### DIFF
--- a/Detectors/Upgrades/ITS3/simulation/src/ITS3Layer.cxx
+++ b/Detectors/Upgrades/ITS3/simulation/src/ITS3Layer.cxx
@@ -112,7 +112,7 @@ void ITS3Layer::createLayerWithDeadZones(TGeoVolume* motherVolume)
   double rmax = rmin + mSensorThickness;
   double rmed = (rmax + rmin) / 2;
   // width of sensors of layers is calculated from r and chips' widths
-  double widthSensor = (TMath::Pi() * rmed - (mNumSubSensorsHalfLayer - 2) * mMiddleChipWidth - 2 * mFringeChipWidth) / mNumSubSensorsHalfLayer;
+  double widthSensor = (TMath::Pi() * rmed - (mNumSubSensorsHalfLayer - 1) * mMiddleChipWidth - 2 * mFringeChipWidth) / mNumSubSensorsHalfLayer;
   double radiusBetweenLayer = 0.6 - mSensorThickness; // FIXME: hard coded distance between layers
 
   const int nElements = 7;


### PR DESCRIPTION
There are #(n-1) middle chips, where n represents the number of chips.
As discussed with @fgrosa.

Signed-off-by: Felix Schlepper <f3sch.git@outlook.com>