### PR TITLE
TRD: allow compilation w/o ONNXRuntime

### DIFF
--- a/Detectors/TRD/pid/CMakeLists.txt
+++ b/Detectors/TRD/pid/CMakeLists.txt
@@ -11,23 +11,33 @@
 
 o2_add_library(TRDPID
                SOURCES src/PIDBase.cxx
-                       src/ML.cxx
                        src/PIDParameters.cxx
                PRIVATE_LINK_LIBRARIES O2::TRDBase
-                                     O2::DataFormatsTRD
-                                     O2::DataFormatsGlobalTracking
-                                     O2::DetectorsBase
-                                     O2::MathUtils
-                                     O2::GPUTracking
-                                     O2::Framework
-                                     O2::ReconstructionDataFormats
-                                     fmt::fmt
-                                     ONNXRuntime::ONNXRuntime)
+                                      O2::DataFormatsTRD
+                                      O2::DataFormatsGlobalTracking
+                                      O2::DetectorsBase
+                                      O2::MathUtils
+                                      O2::GPUTracking
+                                      O2::Framework
+                                      O2::ReconstructionDataFormats
+                                      fmt::fmt
+              TARGETVARNAME libname)
 
-o2_target_root_dictionary(TRDPID
-                          HEADERS include/TRDPID/PIDBase.h
-                                  include/TRDPID/PIDParameters.h
-                                  include/TRDPID/ML.h
-                                  include/TRDPID/Dummy.h)
+if(ONNXRuntime_FOUND)
+  target_compile_definitions(${libname} PRIVATE TRDPID_WITH_ONNX)
+  target_link_libraries(${libname} ONNXRuntime::ONNXRuntime)
+  target_sources(${libname} src/ML.cxx)
+  o2_target_root_dictionary(TRDPID
+                            HEADERS include/TRDPID/PIDBase.h
+                                    include/TRDPID/PIDParameters.h
+                                    include/TRDPID/ML.h
+                                    include/TRDPID/Dummy.h)
+else()
+  o2_target_root_dictionary(TRDPID
+                            HEADERS include/TRDPID/PIDBase.h
+                                    include/TRDPID/PIDParameters.h
+                                    include/TRDPID/Dummy.h
+                            LINKDEF src/TRDPIDNoMLLinkDef.h)
+endif()
 
 add_subdirectory(macros)

--- a/Detectors/TRD/pid/src/PIDBase.cxx
+++ b/Detectors/TRD/pid/src/PIDBase.cxx
@@ -14,7 +14,9 @@
 
 #include "TRDPID/PIDBase.h"
 #include "DataFormatsTRD/PID.h"
+#ifdef TRDPID_WITH_ONNX
 #include "TRDPID/ML.h"
+#endif
 #include "TRDPID/Dummy.h"
 #include "Framework/Logger.h"
 #include "fmt/format.h"
@@ -29,8 +31,10 @@ std::unique_ptr<PIDBase> getTRDPIDBase(PIDPolicy policy)
   auto policyInt = static_cast<unsigned int>(policy);
   LOG(info) << "Creating PID policy. Loading model " << PIDPolicyEnum[policyInt];
   switch (policy) {
+#ifdef TRDPID_WITH_ONNX
     case PIDPolicy::Test:
       return std::make_unique<XGB>(PIDPolicy::Test);
+#endif
     case PIDPolicy::Dummy:
       return std::make_unique<Dummy>(PIDPolicy::Dummy);
     default:

--- a/Detectors/TRD/pid/src/TRDPIDNoMLLinkDef.h
+++ b/Detectors/TRD/pid/src/TRDPIDNoMLLinkDef.h
@@ -1,0 +1,23 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifdef __CLING__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class o2::trd::PIDBase + ;
+#pragma link C++ class o2::trd::Dummy + ;
+#pragma link C++ class o2::trd::TRDPIDParams + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::trd::TRDPIDParams> + ;
+
+#endif


### PR DESCRIPTION
This is a proposal to allow compilation of the TRD libs even with the ONNXRunTime library is not available. 

Another option (simpler maybe but less convenient IMHO) is to make it actually required in the `find_package(ONNXRuntime CONFIG)` statement in the top level O2 `CMakeLists.txt`, where currently it is not.

Full disclosure : I've not tested that the built library actually makes complete sense w/o ONNXRuntime, but at least it does not prevent O2 to compile and others libs to used (tested only the MCH reco though...)