### PR TITLE
ITS noise calibr: correct counting of total number of strobes in Norm mode

### DIFF
--- a/Detectors/ITSMFT/ITS/calibration/include/ITSCalibration/NoiseCalibrator.h
+++ b/Detectors/ITSMFT/ITS/calibration/include/ITSCalibration/NoiseCalibrator.h
@@ -71,6 +71,7 @@ class NoiseCalibrator
   auto getInstanceID() const { return mInstanceID; }
   auto getNInstances() const { return mNInstances; }
   auto getNStrobes() const { return mNumberOfStrobes; }
+  auto setNStrobes(unsigned int s) { mNumberOfStrobes = s; }
 
  private:
   const o2::itsmft::TopologyDictionary* mDict = nullptr;

--- a/Detectors/ITSMFT/ITS/calibration/include/ITSCalibration/NoiseCalibratorSpec.h
+++ b/Detectors/ITSMFT/ITS/calibration/include/ITSCalibration/NoiseCalibratorSpec.h
@@ -65,6 +65,7 @@ class NoiseCalibratorSpec : public Task
   void updateTimeDependentParams(ProcessingContext& pc);
   std::unique_ptr<CALIBRATOR> mCalibrator = nullptr;
   std::shared_ptr<o2::base::GRPGeomRequest> mCCDBRequest;
+  unsigned int mStrobeCounter = 0;
   size_t mDataSizeStat = 0;
   size_t mNClustersProc = 0;
   int mValidityDays = 3;

--- a/Detectors/ITSMFT/ITS/calibration/src/NoiseCalibratorSpec.cxx
+++ b/Detectors/ITSMFT/ITS/calibration/src/NoiseCalibratorSpec.cxx
@@ -92,7 +92,9 @@ void NoiseCalibratorSpec::run(ProcessingContext& pc)
     gsl::span<const int> partInfo = pc.inputs().get<gsl::span<int>>("mapspartInfo");
     mCalibrator->addMap(*extMap.get());
     done = (++mNPartsDone == partInfo[1]);
-    LOGP(info, "Received accumulated map with {} of {}, total number of maps = {}", partInfo[0], partInfo[1], mNPartsDone);
+    mStrobeCounter += partInfo[2];
+    mCalibrator->setNStrobes(mStrobeCounter);
+    LOGP(info, "Received accumulated map {} of {} with {} ROFs, total number of maps = {} and strobes = {}", partInfo[0] + 1, partInfo[1], partInfo[2], mNPartsDone, mCalibrator->getNStrobes());
   }
   if (done) {
     LOG(info) << "Minimum number of noise counts has been reached !";
@@ -119,6 +121,7 @@ void NoiseCalibratorSpec::sendAccumulatedMap(DataAllocator& output)
   std::vector<int> outInf;
   outInf.push_back(mCalibrator->getInstanceID());
   outInf.push_back(mCalibrator->getNInstances());
+  outInf.push_back(mCalibrator->getNStrobes());
   output.snapshot(Output{"ITS", "NOISEMAPPARTINF", (unsigned int)mCalibrator->getInstanceID()}, outInf);
   LOGP(info, "Sending accumulated map with {} ROFs processed", mCalibrator->getNStrobes());
 }


### PR DESCRIPTION
Before, the workflow in `Norm` mode did not know (i.e. was 0) the total number of strobes processed by the accumulators. 