### PR TITLE
Several fixes and add readers/writers to dpl-workflow.sh that are needed for QC tasks, when workflow is split in multiple invocations

### DIFF
--- a/Detectors/FIT/FV0/workflow/src/digits-reader-workflow.cxx
+++ b/Detectors/FIT/FV0/workflow/src/digits-reader-workflow.cxx
@@ -49,7 +49,7 @@ WorkflowSpec defineDataProcessing(const ConfigContext& ctx)
 {
   WorkflowSpec specs;
   o2::conf::ConfigurableParam::updateFromString(ctx.options().get<std::string>("configKeyValues"));
-  DataProcessorSpec producer = o2::fv0::getDigitReaderSpec(ctx.options().get<bool>("disable-mc"), ctx.options().get<bool>("disable-trigger-input"));
+  DataProcessorSpec producer = o2::fv0::getDigitReaderSpec(!ctx.options().get<bool>("disable-mc"), ctx.options().get<bool>("disable-trigger-input"));
   specs.push_back(producer);
 
   // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit

--- a/Detectors/MUON/MCH/Workflow/src/digits-reader-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/digits-reader-workflow.cxx
@@ -15,7 +15,6 @@
 /// \author Philippe Pillot, Subatech
 /// \author Andrea Ferrero, CEA
 
-#include "Framework/runDataProcessing.h"
 #include "CommonUtils/ConfigurableParam.h"
 #include "DetectorsRaw/HBFUtilsInitializer.h"
 #include "Framework/CallbacksPolicy.h"

--- a/Detectors/MUON/MID/Workflow/src/decoded-digits-writer-workflow.cxx
+++ b/Detectors/MUON/MID/Workflow/src/decoded-digits-writer-workflow.cxx
@@ -27,7 +27,8 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
   std::vector<ConfigParamSpec>
     options{
-      {"output-filename", VariantType::String, "mid-digits-decoded.root", {"Decoded digits output file"}}};
+      {"output-filename", VariantType::String, "mid-digits-decoded.root", {"Decoded digits output file"}},
+      {"mid-digits-tree-name", VariantType::String, "middigits", {"Name of tree in digits file"}}};
   workflowOptions.insert(workflowOptions.end(), options.begin(), options.end());
 }
 
@@ -45,13 +46,14 @@ void customize(std::vector<o2::framework::CompletionPolicy>& policies)
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   auto outputFilename = cfgc.options().get<std::string>("output-filename");
+  auto treeFilename = cfgc.options().get<std::string>("mid-digits-tree-name");
   WorkflowSpec specs;
   specs.emplace_back(MakeRootTreeWriterSpec("MIDDigitWriter",
                                             outputFilename.c_str(),
-                                            "middigits",
+                                            treeFilename.c_str(),
                                             -1,
                                             MakeRootTreeWriterSpec::BranchDefinition<std::vector<o2::mid::ColumnData>>{InputSpec{"mid_data", o2::header::gDataOriginMID, "DATA"}, "MIDDigit"},
-                                            MakeRootTreeWriterSpec::BranchDefinition<std::vector<o2::mid::ROFRecord>>{InputSpec{"mid_data_rof", o2::header::gDataOriginMID, "DATAROF"}, "MIDDigitROF"})());
+                                            MakeRootTreeWriterSpec::BranchDefinition<std::vector<o2::mid::ROFRecord>>{InputSpec{"mid_data_rof", o2::header::gDataOriginMID, "DATAROF"}, "MIDROFRecords"})());
 
   return specs;
 }

--- a/Detectors/TRD/workflow/io/CMakeLists.txt
+++ b/Detectors/TRD/workflow/io/CMakeLists.txt
@@ -24,6 +24,10 @@ o2_add_library(TRDWorkflowIO
                PUBLIC_LINK_LIBRARIES O2::DataFormatsTRD O2::SimulationDataFormat O2::DPLUtils O2::GPUDataTypeHeaders O2::DataFormatsTPC)
 
 
+o2_add_executable(digit-reader-workflow
+                 COMPONENT_NAME trd
+                 SOURCES src/digit-reader-workflow.cxx
+                 PUBLIC_LINK_LIBRARIES O2::TRDWorkflowIO)
 o2_add_executable(track-reader
                  COMPONENT_NAME trd
                  SOURCES src/trd-track-reader-workflow.cxx

--- a/Detectors/TRD/workflow/io/src/digit-reader-workflow.cxx
+++ b/Detectors/TRD/workflow/io/src/digit-reader-workflow.cxx
@@ -1,0 +1,45 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "Framework/ConfigParamSpec.h"
+#include "TRDWorkflowIO/TRDDigitReaderSpec.h"
+#include "DetectorsRaw/HBFUtilsInitializer.h"
+
+using namespace o2::framework;
+
+// ------------------------------------------------------------------
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  std::vector<o2::framework::ConfigParamSpec> options{
+    {"disable-mc", o2::framework::VariantType::Bool, true, {"disable MC propagation"}},
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
+  o2::raw::HBFUtilsInitializer::addConfigOption(options);
+  std::swap(workflowOptions, options);
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  // Update the (declared) parameters if changed from the command line
+  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
+
+  auto useMC = !configcontext.options().get<bool>("disable-mc");
+  WorkflowSpec specs;
+  specs.emplace_back(o2::trd::getTRDDigitReaderSpec(useMC));
+  return specs;
+}

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -263,6 +263,8 @@ if [[ ! -z $WORKFLOW_DETECTORS_USE_GLOBAL_READER ]]; then
   add_W o2-global-track-cluster-reader "--cluster-types $WORKFLOW_DETECTORS_USE_GLOBAL_READER --track-types $WORKFLOW_DETECTORS_USE_GLOBAL_READER $GLOBAL_READER_OPTIONS $DISABLE_MC --hbfutils-config o2_tfidinfo.root"
   has_detector FV0 && has_detector_from_global_reader FV0 && add_W o2-fv0-digit-reader-workflow "$DISABLE_MC --hbfutils-config o2_tfidinfo.root --fv0-digit-infile o2_fv0digits.root"
   has_detector MID && has_detector_from_global_reader MID && add_W o2-mid-digits-reader-workflow "$DISABLE_MC --hbfutils-config o2_tfidinfo.root --mid-digit-infile mid-digits-decoded.root"
+  has_detector MCH && has_detector_from_global_reader MCH && add_W o2-mch-digits-reader-workflow " --hbfutils-config o2_tfidinfo.root --infile mchdigits.root"
+  has_detector TRD && has_detector_from_global_reader TRD && add_W o2-trd-digit-reader-workflow " --hbfutils-config o2_tfidinfo.root"
 fi
 
 if [[ ! -z $INPUT_DETECTOR_LIST ]]; then
@@ -395,19 +397,21 @@ has_detectors_reco MFT MCH && has_detector_matching MFTMCH && add_W o2-globalfwd
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Reconstruction workflows applying detector-specific calibrations
-( workflow_has_parameter AOD || [[ -z "$DISABLE_ROOT_OUTPUT" ]] || needs_root_output o2-emcal-cell-writer-workflow ) && has_detector EMC && add_W o2-emcal-cell-recalibrator-workflow "--input-subspec 1 --output-subspec 0 --redirect-led"
+( workflow_has_parameter AOD || [[ -z "$DISABLE_ROOT_OUTPUT" ]] || needs_root_output o2-emcal-cell-writer-workflow ) && ! has_detector_from_global_reader EMC && has_detector EMC && add_W o2-emcal-cell-recalibrator-workflow "--input-subspec 1 --output-subspec 0 --redirect-led"
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Writers for detectors whose reco workflow cannot write the output
 has_detector_reco TRD && ( [[ -z "$DISABLE_ROOT_OUTPUT" ]] || needs_root_output o2-trd-digittracklet-writer ) && add_W o2-trd-digittracklet-writer
 has_detector_reco TPC && [[ "0$TPC_CONVERT_LINKZS_TO_RAW" == "01" ]] && ( [[ -z "$DISABLE_ROOT_OUTPUT" ]] || needs_root_output o2-gpu-reco-workflow ) && add_W o2-tpc-reco-workflow "--input-type digitizer --output-type digits $DISABLE_MC"
 has_detector_reco CPV && ( [[ -z "$DISABLE_ROOT_OUTPUT" ]] || needs_root_output o2-cpv-cluster-writer-workflow ) && add_W o2-cpv-cluster-writer-workflow "$DISABLE_MC"
-( workflow_has_parameter AOD || [[ -z "$DISABLE_ROOT_OUTPUT" ]] || needs_root_output o2-emcal-cell-writer-workflow ) && has_detector EMC && add_W o2-emcal-cell-writer-workflow "--disable-mc --subspec 10 --cell-writer-name emcal-led-cells-writer --emcal-led-cells-writer \"--outfile emcledcells.root\""
+( workflow_has_parameter AOD || [[ -z "$DISABLE_ROOT_OUTPUT" ]] || needs_root_output o2-emcal-cell-writer-workflow ) && ! has_detector_from_global_reader EMC && has_detector EMC && add_W o2-emcal-cell-writer-workflow "--disable-mc --subspec 10 --cell-writer-name emcal-led-cells-writer --emcal-led-cells-writer \"--outfile emcledcells.root\""
 CTFINPUT==1 && has_detector CTP && ! has_detector_from_global_reader CTP && ( [[ -z "$DISABLE_ROOT_OUTPUT" ]] || needs_root_output o2-ctp-digit-writer ) && add_W o2-ctp-digit-writer "$DISABLE_ROOT_OUTPUT"
 has_detector_reco EMC && ( [[ -z "$DISABLE_ROOT_OUTPUT" ]] || needs_root_output o2-emcal-cell-writer-workflow ) && add_W o2-emcal-cell-writer-workflow "$DISABLE_MC"
 has_detector_reco PHS && ( [[ -z "$DISABLE_ROOT_OUTPUT" ]] || needs_root_output o2-phos-cell-writer-workflow ) && add_W o2-phos-cell-writer-workflow "$DISABLE_MC"
 has_detector_reco FV0 && ( [[ -z "$DISABLE_ROOT_OUTPUT" ]] || needs_root_output o2-fv0-digits-writer-workflow ) && add_W o2-fv0-digits-writer-workflow "$DISABLE_MC"
 has_detector_reco MID && ( [[ -z "$DISABLE_ROOT_OUTPUT" ]] || needs_root_output o2-mid-decoded-digits-writer-workflow ) && add_W o2-mid-decoded-digits-writer-workflow "--mid-digits-tree-name o2sim" "" 0
+has_detector_reco MCH && ( [[ -z "$DISABLE_ROOT_OUTPUT" ]] || needs_root_output o2-mch-digits-writer-workflow ) && add_W o2-mch-digits-writer-workflow "--outfile mchdigits.root" "" 0
+has_detector_reco MCH && ( [[ -z "$DISABLE_ROOT_OUTPUT" ]] || needs_root_output o2-mch-preclusters-sink-workflow ) && add_W o2-mch-preclusters-sink-workflow "--outfile mchpreclusters.out" "" 0
 
 # always run vertexing if requested and if there are some sources, but in cosmic mode we work in pass-trough mode (create record for non-associated tracks)
 ( [[ $BEAMTYPE == "cosmic" ]] || ! has_detector_reco ITS) && PVERTEX_CONFIG+=" --skip"

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -261,6 +261,8 @@ if [[ ! -z $WORKFLOW_DETECTORS_USE_GLOBAL_READER ]]; then
   GLOBAL_READER_OPTIONS=
   has_detector ITS && SYNCMODE==1 && GLOBAL_READER_OPTIONS+=" --ir-frames-its"
   add_W o2-global-track-cluster-reader "--cluster-types $WORKFLOW_DETECTORS_USE_GLOBAL_READER --track-types $WORKFLOW_DETECTORS_USE_GLOBAL_READER $GLOBAL_READER_OPTIONS $DISABLE_MC --hbfutils-config o2_tfidinfo.root"
+  has_detector FV0 && has_detector_from_global_reader FV0 && add_W o2-fv0-digit-reader-workflow "$DISABLE_MC --hbfutils-config o2_tfidinfo.root --fv0-digit-infile o2_fv0digits.root"
+  has_detector MID && has_detector_from_global_reader MID && add_W o2-mid-digits-reader-workflow "$DISABLE_MC --hbfutils-config o2_tfidinfo.root --mid-digit-infile mid-digits-decoded.root"
 fi
 
 if [[ ! -z $INPUT_DETECTOR_LIST ]]; then
@@ -404,6 +406,8 @@ has_detector_reco CPV && ( [[ -z "$DISABLE_ROOT_OUTPUT" ]] || needs_root_output 
 CTFINPUT==1 && has_detector CTP && ! has_detector_from_global_reader CTP && ( [[ -z "$DISABLE_ROOT_OUTPUT" ]] || needs_root_output o2-ctp-digit-writer ) && add_W o2-ctp-digit-writer "$DISABLE_ROOT_OUTPUT"
 has_detector_reco EMC && ( [[ -z "$DISABLE_ROOT_OUTPUT" ]] || needs_root_output o2-emcal-cell-writer-workflow ) && add_W o2-emcal-cell-writer-workflow "$DISABLE_MC"
 has_detector_reco PHS && ( [[ -z "$DISABLE_ROOT_OUTPUT" ]] || needs_root_output o2-phos-cell-writer-workflow ) && add_W o2-phos-cell-writer-workflow "$DISABLE_MC"
+has_detector_reco FV0 && ( [[ -z "$DISABLE_ROOT_OUTPUT" ]] || needs_root_output o2-fv0-digits-writer-workflow ) && add_W o2-fv0-digits-writer-workflow "$DISABLE_MC"
+has_detector_reco MID && ( [[ -z "$DISABLE_ROOT_OUTPUT" ]] || needs_root_output o2-mid-decoded-digits-writer-workflow ) && add_W o2-mid-decoded-digits-writer-workflow "--mid-digits-tree-name o2sim" "" 0
 
 # always run vertexing if requested and if there are some sources, but in cosmic mode we work in pass-trough mode (create record for non-associated tracks)
 ( [[ $BEAMTYPE == "cosmic" ]] || ! has_detector_reco ITS) && PVERTEX_CONFIG+=" --skip"


### PR DESCRIPTION
@chiarazampolli : This makes the workflow start up with QC in the split fashion, except for MCH and TOF QC which are not working:
- MCH QC needs a data type called PRECLUSTERDIGITS. They have a writer for it (which doesn't create a root file though), but no reader.
- TOF QC needs calib data of type DIAFREQ. There is no binary for a writer, but there is a class TOFCalibWriterSpec. I made a standalone binary to try to write the DIAFREQ to a root file, but this needs additional TOF calib data which is only created by the tof-matcher workflow. Not sure what to do, probably one would need to split the TOF calib writer in stuff that comes from the matching, and stuff that comes from before... This gets quite convoluted.

The workflow still crashes anyway due to the framework problem with the global-track-cluster-reader, but independent from that I have seen that also some QC tasks are crashing. So probably something is not correct still, but didn't look into it further, and not sure one can debug it properly before the framework problem is fixed.