### PR TITLE
STDERR monitor: filter TInterpreter warnings

### DIFF
--- a/Utilities/EPNMonitoring/src/EPNstderrMonitor.cxx
+++ b/Utilities/EPNMonitoring/src/EPNstderrMonitor.cxx
@@ -90,6 +90,7 @@ EPNMonitor::EPNMonitor(std::string path, bool infoLogger, int runNumber, std::st
   mFilters.emplace_back("^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{6}");
   mFilters.emplace_back("^Warning in <Fit");
   mFilters.emplace_back("^Warning in <TGraph");
+  mFilters.emplace_back("^Warning in <TInterpreter");
   mInfoLoggerActive = infoLogger;
   mPath = path;
   mRunNumber = runNumber;


### PR DESCRIPTION
Hoping to avoid flooding of the infologger with these messages:
![Screenshot from 2023-02-03 13-56-20](https://user-images.githubusercontent.com/26281793/216612049-6614545f-c0f1-414e-a5b9-bb6da6d5d05e.png)
