### PR TITLE
Remove DCAFitter from DetectorsVertexing

### DIFF
--- a/Detectors/StrangenessTracking/macros/CMakeLists.txt
+++ b/Detectors/StrangenessTracking/macros/CMakeLists.txt
@@ -6,6 +6,6 @@ o2_add_test_root_macro(XiTrackingStudy.C
                                              O2::DataFormatsITSMFT
                                              O2::DataFormatsITS
                                              O2::SimulationDataFormat
-					     O2::StrangenessTracking
+                                             O2::StrangenessTracking
                                              O2::DCAFitter
                        LABELS strangeness-tracking)

--- a/Detectors/StrangenessTracking/macros/CMakeLists.txt
+++ b/Detectors/StrangenessTracking/macros/CMakeLists.txt
@@ -6,6 +6,6 @@ o2_add_test_root_macro(XiTrackingStudy.C
                                              O2::DataFormatsITSMFT
                                              O2::DataFormatsITS
                                              O2::SimulationDataFormat
-                                             O2::StrangenessTracking
-					     O2::DCAFitter
+					     O2::StrangenessTracking
+                                             O2::DCAFitter
                        LABELS strangeness-tracking)

--- a/Detectors/StrangenessTracking/macros/CMakeLists.txt
+++ b/Detectors/StrangenessTracking/macros/CMakeLists.txt
@@ -7,4 +7,5 @@ o2_add_test_root_macro(XiTrackingStudy.C
                                              O2::DataFormatsITS
                                              O2::SimulationDataFormat
                                              O2::StrangenessTracking
+					     O2::DCAFitter
                        LABELS strangeness-tracking)

--- a/Detectors/StrangenessTracking/macros/XiTrackingStudy.C
+++ b/Detectors/StrangenessTracking/macros/XiTrackingStudy.C
@@ -39,7 +39,7 @@
 #include "TTree.h"
 #include "TLegend.h"
 #include "CommonDataFormat/RangeReference.h"
-#include "DetectorsVertexing/DCAFitterN.h"
+#include "DCAFitter/DCAFitterN.h"
 #include "StrangenessTracking/StrangenessTracker.h"
 
 #endif

--- a/Detectors/StrangenessTracking/tracking/CMakeLists.txt
+++ b/Detectors/StrangenessTracking/tracking/CMakeLists.txt
@@ -21,7 +21,7 @@ o2_add_library(StrangenessTracking
                                              O2::SimulationDataFormat
                                              O2::DetectorsVertexing
 					     O2::ReconstructionDataFormats
-					     O2::DCAFitter
+                                             O2::DCAFitter
                )
 
 o2_target_root_dictionary(StrangenessTracking

--- a/Detectors/StrangenessTracking/tracking/CMakeLists.txt
+++ b/Detectors/StrangenessTracking/tracking/CMakeLists.txt
@@ -20,7 +20,7 @@ o2_add_library(StrangenessTracking
                                              O2::DataFormatsITS
                                              O2::SimulationDataFormat
                                              O2::DetectorsVertexing
-					     O2::ReconstructionDataFormats
+                                             O2::ReconstructionDataFormats
                                              O2::DCAFitter
                )
 

--- a/Detectors/StrangenessTracking/tracking/CMakeLists.txt
+++ b/Detectors/StrangenessTracking/tracking/CMakeLists.txt
@@ -20,7 +20,8 @@ o2_add_library(StrangenessTracking
                                              O2::DataFormatsITS
                                              O2::SimulationDataFormat
                                              O2::DetectorsVertexing
-                                             O2::ReconstructionDataFormats
+					     O2::ReconstructionDataFormats
+					     O2::DCAFitter
                )
 
 o2_target_root_dictionary(StrangenessTracking

--- a/Detectors/StrangenessTracking/tracking/include/StrangenessTracking/StrangenessTracker.h
+++ b/Detectors/StrangenessTracking/tracking/include/StrangenessTracking/StrangenessTracker.h
@@ -34,7 +34,7 @@
 #include "DataFormatsITSMFT/CompCluster.h"
 #include "DataFormatsGlobalTracking/RecoContainer.h"
 
-#include "DetectorsVertexing/DCAFitterN.h"
+#include "DCAFitter/DCAFitterN.h"
 #include "DetectorsBase/Propagator.h"
 
 namespace o2

--- a/Detectors/StrangenessTracking/workflow/CMakeLists.txt
+++ b/Detectors/StrangenessTracking/workflow/CMakeLists.txt
@@ -30,8 +30,8 @@ o2_add_library(StrangenessTrackingWorkflow
                                      O2::ITSMFTWorkflow
                                      O2::DetectorsCalibration
                                      O2::GlobalTrackingWorkflowWriters
-				     O2::DCAFitter
-				     O2::CCDB)
+                                     O2::DCAFitter
+                                     O2::CCDB)
 
 o2_add_executable(strangeness-tracking-workflow
                   SOURCES src/strangeness-tracking-workflow.cxx

--- a/Detectors/StrangenessTracking/workflow/CMakeLists.txt
+++ b/Detectors/StrangenessTracking/workflow/CMakeLists.txt
@@ -30,7 +30,8 @@ o2_add_library(StrangenessTrackingWorkflow
                                      O2::ITSMFTWorkflow
                                      O2::DetectorsCalibration
                                      O2::GlobalTrackingWorkflowWriters
-                                     O2::CCDB)
+				     O2::DCAFitter
+				     O2::CCDB)
 
 o2_add_executable(strangeness-tracking-workflow
                   SOURCES src/strangeness-tracking-workflow.cxx

--- a/Detectors/Vertexing/CMakeLists.txt
+++ b/Detectors/Vertexing/CMakeLists.txt
@@ -30,14 +30,14 @@ o2_add_library(DetectorsVertexing
                                      O2::FT0Reconstruction
                                      O2::DataFormatsFT0
                                      O2::GlobalTracking
-				     O2::DCAFitter
+                                     O2::DCAFitter
                                      Microsoft.GSL::GSL)
 
 o2_target_root_dictionary(DetectorsVertexing
                           HEADERS include/DetectorsVertexing/PVertexerHelpers.h
                                   include/DetectorsVertexing/PVertexerParams.h
                                   include/DetectorsVertexing/SVertexerParams.h
-				  include/DetectorsVertexing/SVertexHypothesis.h)
+                                  include/DetectorsVertexing/SVertexHypothesis.h)
 
 if (OpenMP_CXX_FOUND)
     target_compile_definitions(${targetName} PRIVATE WITH_OPENMP)

--- a/Detectors/Vertexing/CMakeLists.txt
+++ b/Detectors/Vertexing/CMakeLists.txt
@@ -11,15 +11,13 @@
 
 o2_add_library(DetectorsVertexing
                TARGETVARNAME targetName
-               SOURCES src/DCAFitterN.cxx
-                       src/PVertexer.cxx
+               SOURCES src/PVertexer.cxx
                        src/PVertexerHelpers.cxx
                        src/PVertexerParams.cxx
                        src/VertexTrackMatcher.cxx
                        src/SVertexer.cxx
                        src/SVertexerParams.cxx
                        src/SVertexHypothesis.cxx
-                       src/FwdDCAFitterN.cxx
                PUBLIC_LINK_LIBRARIES ROOT::Core
                                      O2::CommonUtils
                                      O2::ReconstructionDataFormats
@@ -32,31 +30,19 @@ o2_add_library(DetectorsVertexing
                                      O2::FT0Reconstruction
                                      O2::DataFormatsFT0
                                      O2::GlobalTracking
+				     O2::DCAFitter
                                      Microsoft.GSL::GSL)
 
 o2_target_root_dictionary(DetectorsVertexing
-                          HEADERS include/DetectorsVertexing/HelixHelper.h
-                                  include/DetectorsVertexing/PVertexerHelpers.h
+                          HEADERS include/DetectorsVertexing/PVertexerHelpers.h
                                   include/DetectorsVertexing/PVertexerParams.h
-                                  include/DetectorsVertexing/DCAFitterN.h
-                                  include/DetectorsVertexing/FwdDCAFitterN.h
                                   include/DetectorsVertexing/SVertexerParams.h
-                                  include/DetectorsVertexing/SVertexHypothesis.h)
+				  include/DetectorsVertexing/SVertexHypothesis.h)
 
 if (OpenMP_CXX_FOUND)
     target_compile_definitions(${targetName} PRIVATE WITH_OPENMP)
     target_link_libraries(${targetName} PRIVATE OpenMP::OpenMP_CXX)
 endif()
-
-
-o2_add_test(
-  DCAFitterN
-  SOURCES test/testDCAFitterN.cxx
-  COMPONENT_NAME DetectorsVertexing
-  PUBLIC_LINK_LIBRARIES O2::DetectorsVertexing ROOT::Core ROOT::Physics
-  LABELS vertexing
-  ENVIRONMENT O2_ROOT=${CMAKE_BINARY_DIR}/stage
-  VMCWORKDIR=${CMAKE_BINARY_DIR}/stage/${CMAKE_INSTALL_DATADIR})
 
 o2_add_test_root_macro(test/PVFromPool.C
                        PUBLIC_LINK_LIBRARIES O2::DetectorsVertexing

--- a/Detectors/Vertexing/include/DetectorsVertexing/SVertexer.h
+++ b/Detectors/Vertexing/include/DetectorsVertexing/SVertexer.h
@@ -24,7 +24,7 @@
 #include "ReconstructionDataFormats/VtxTrackIndex.h"
 #include "ReconstructionDataFormats/VtxTrackRef.h"
 #include "CommonDataFormat/RangeReference.h"
-#include "DetectorsVertexing/DCAFitterN.h"
+#include "DCAFitter/DCAFitterN.h"
 #include "DetectorsVertexing/SVertexerParams.h"
 #include "DetectorsVertexing/SVertexHypothesis.h"
 #include "DataFormatsTPC/TrackTPC.h"

--- a/Detectors/Vertexing/src/DetectorsVertexingLinkDef.h
+++ b/Detectors/Vertexing/src/DetectorsVertexingLinkDef.h
@@ -15,21 +15,12 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
-#pragma link C++ class o2::vertexing::DCAFitterN < 2, o2::track::TrackParCov> + ;
-#pragma link C++ class o2::vertexing::DCAFitterN < 3, o2::track::TrackParCov> + ;
-
 #pragma link C++ class o2::vertexing::PVertexerParams + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::vertexing::PVertexerParams> + ;
 
 #pragma link C++ class o2::vertexing::SVertexHypothesis + ;
 #pragma link C++ class o2::vertexing::SVertexerParams + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::vertexing::SVertexerParams> + ;
-
-#pragma link C++ class o2::track::TrackAuxPar + ;
-#pragma link C++ class o2::track::CrossInfo + ;
-
-#pragma link C++ function o2::vertexing::DCAFitter2::process(const o2::track::TrackParCov&, const o2::track::TrackParCov&);
-#pragma link C++ function o2::vertexing::DCAFitter3::process(const o2::track::TrackParCov&, const o2::track::TrackParCov&, const o2::track::TrackParCov&);
 
 #pragma link C++ class o2::vertexing::TrackVFDump + ;
 #pragma link C++ class std::vector < o2::vertexing::TrackVFDump> + ;


### PR DESCRIPTION
Final step in cleaning up libraries: removes DCAFitter entirely from DetectorsVertexing. Should suppress ROOT warning of duplication.