### PR TITLE
Increase TRD dead time from 0.2 to 11 us

### DIFF
--- a/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
+++ b/DataFormats/Detectors/TRD/include/DataFormatsTRD/Constants.h
@@ -70,11 +70,6 @@ constexpr int NBINSANGLEDIFF = 25;      ///< the number of bins for the track an
 constexpr double VDRIFTDEFAULT = 1.546; ///< default value for vDrift
 constexpr double EXBDEFAULT = 0.0;      ///< default value for LorentzAngle
 
-// Trigger parameters
-constexpr double READOUT_TIME = 3000;                  ///< the time the readout takes, as 30 TB = 3 micro-s.
-constexpr double DEAD_TIME = 200;                      ///< trigger deadtime, 2 micro-s
-constexpr double BUSY_TIME = READOUT_TIME + DEAD_TIME; ///< the time for which no new trigger can be received in nanoseconds
-
 // array size to store incoming half cru payload.
 constexpr int HBFBUFFERMAX = 1048576;                 ///< max buffer size for data read from a half cru, (all events)
 constexpr unsigned int CRUPADDING32 = 0xeeeeeeee;     ///< padding word used in the cru.

--- a/Detectors/TRD/simulation/README.md
+++ b/Detectors/TRD/simulation/README.md
@@ -80,4 +80,4 @@ A        B
 ```
 In this example, we consider a trigger at `t=A`. The second signal contributes with `(B-C)*samplingRate` bins from its head onto the tail of the first signal. A third signal arrives at `t=E`, with `E>A+BUSY_TIME`, which can trigger the detector and be readout. The third signal will have `(D-E)*samplingRate` from the tail of the second signal onto its head. So, the requirement for a signal to be too old, and be dropped, is:
 - new trigger arrives, and
-- the time difference between the first time bin of the previous signal and the new trigger is greater than `READOUT_TIME`.
+- the time difference between the first time bin of the previous signal and the new trigger is greater than `TRDSimParams.readoutTimeNS`.

--- a/Detectors/TRD/simulation/include/TRDSimulation/TRDSimParams.h
+++ b/Detectors/TRD/simulation/include/TRDSimulation/TRDSimParams.h
@@ -28,10 +28,15 @@ namespace trd
   See https://github.com/AliceO2Group/AliceO2/blob/dev/Common/SimConfig/doc/ConfigurableParam.md
 */
 struct TRDSimParams : public o2::conf::ConfigurableParamHelper<TRDSimParams> {
-  int digithreads = 4;       // number of digitizer threads
-  float maxMCStepSize = 0.1; // maximum size of MC steps
-  bool doTR = true;          // switch for transition radiation
-  SimParam::GasMixture gas = SimParam::GasMixture::Xenon; // the gas mixture in the TRD
+  // Trigger parameters
+  float readoutTimeNS = 3000;                    ///< the time the readout takes in ns (default 30 time bins = 3 us)
+  float deadTimeNS = 11000;                      ///< trigger deadtime in ns (default 11 us)
+  float busyTimeNS = readoutTimeNS + deadTimeNS; ///< the time for which no new trigger can be received in nanoseconds
+  // digitization settings
+  int digithreads = 4;                                    ///< number of digitizer threads
+  float maxMCStepSize = 0.1;                              ///< maximum size of MC steps
+  bool doTR = true;                                       ///< switch for transition radiation
+  SimParam::GasMixture gas = SimParam::GasMixture::Xenon; ///< the gas mixture in the TRD
   O2ParamDef(TRDSimParams, "TRDSimParams");
 };
 

--- a/Detectors/TRD/simulation/src/PileupTool.cxx
+++ b/Detectors/TRD/simulation/src/PileupTool.cxx
@@ -10,6 +10,7 @@
 // or submit itself to any jurisdiction.
 
 #include "TRDSimulation/PileupTool.h"
+#include "TRDSimulation/TRDSimParams.h"
 
 using namespace o2::trd;
 using namespace o2::trd::constants;
@@ -28,7 +29,7 @@ SignalContainer PileupTool::addSignals(std::deque<std::array<SignalContainer, co
         // check if the signal is from a previous event
         if (signalArray.firstTBtime < triggerTime) {
           pileupSignalBecomesObsolete = true;
-          if ((triggerTime - signalArray.firstTBtime) > constants::READOUT_TIME) { // OS: READOUT_TIME should actually be drift time (we want to ignore signals which don't contribute signal anymore at triggerTime)
+          if ((triggerTime - signalArray.firstTBtime) > TRDSimParams::Instance().readoutTimeNS) { // OS: READOUT_TIME should actually be drift time (we want to ignore signals which don't contribute signal anymore at triggerTime)
             continue;                                                              // ignore the signal if it  is too old.
           }
           // add only what's leftover from this signal


### PR DESCRIPTION
Hi @tdietel and @pachmay 
the currently implemented hard-coded busy time of the TRD is 3.2 micro seconds. This means that in MC simulations the TRD is read out with more than 300kHz which is not what we have in reality. In 2022 the readout rate was something between 60 and 70 kHz max. With this change it would be limited to ~70kHz also for simulations.

This should maybe be changed to be a configurable parameter in the future, not sure if we can still improve the readout rate by masking some slow chambers for example.