### PR TITLE
More equivalency declarations

### DIFF
--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -1029,6 +1029,8 @@ namespace soa
 DECLARE_EQUIVALENT_FOR_INDEX(aod::Collisions_000, aod::Collisions_001);
 DECLARE_EQUIVALENT_FOR_INDEX(aod::StoredMcParticles_000, aod::StoredMcParticles_001);
 DECLARE_EQUIVALENT_FOR_INDEX(aod::StoredTracks, aod::StoredTracksIU);
+DECLARE_EQUIVALENT_FOR_INDEX(aod::StoredTracks, aod::StoredTracksExtra);
+DECLARE_EQUIVALENT_FOR_INDEX(aod::StoredTracksIU, aod::StoredTracksExtra);
 } // namespace soa
 
 namespace aod
@@ -1200,6 +1202,8 @@ DECLARE_SOA_INDEX_TABLE(Run2MatchedToBCSparse, BCs, "MA_RN2_BC_SP", //!
 } // namespace aod
 namespace soa
 {
+DECLARE_EQUIVALENT_FOR_INDEX(aod::StoredTracks, aod::McTrackLabels);
+DECLARE_EQUIVALENT_FOR_INDEX(aod::StoredTracksIU, aod::McTrackLabels);
 extern template struct Join<aod::Collisions, aod::Run2MatchedSparse>;
 extern template struct Join<aod::Collisions, aod::Run3MatchedSparse>;
 } // namespace soa


### PR DESCRIPTION
This is a suggested change following a conversation with @aalkin (thanks a lot!)

These equivalency declarations have an important role in avoiding that track pre-selections and MC pre-selections depend unnecessarily on the track propagation workflow (or on the data being from Run 2 or Run 3). By declaring `TracksExtra` and `McTrackLabels` to be equivalent to the base `Tracks`/`TracksIU` tables for indexing purposes, one can de-reference an index to the base track tables straight to the `TracksExtra` or `McTrackLabels` tables without going through the `Tracks` or `TracksIU` tables and populate other tables that can still be joined with the base `Tracks`/`TracksIU` tables later on and filtered out as necessary. 

As an example use case, this will greatly simplify the V0 and cascade candidate pre-selectors, effectively keeping the number of `process` functions down to only four (instead of 8 or more to account for various combinations of `Tracks`/`TracksIU`). This has already been tested to work very well locally. 