### PR TITLE
dpl-workflow: Add optional TOF/MCH readers / writers + some fixes

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-reco-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-reco-workflow.cxx
@@ -179,12 +179,11 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     auto inputDesc = cfgc.options().get<std::string>("input-desc");
     specs.emplace_back(o2::tof::getCompressedDecodingSpec(inputDesc, conetmode, !ignoreDistStf));
     useMC = 0;
-
-    if (writedigit && !disableRootOutput) {
-      // add TOF digit writer without mc labels
-      LOG(debug) << "Insert TOF Digit Writer";
-      specs.emplace_back(o2::tof::getTOFDigitWriterSpec(0, writeerr));
-    }
+  }
+  if (!dgtinput && writedigit && !disableRootOutput) {
+    // add TOF digit writer without mc labels
+    LOG(debug) << "Insert TOF Digit Writer";
+    specs.emplace_back(o2::tof::getTOFDigitWriterSpec(0, writeerr));
   }
 
   if (!clusterinput && writecluster) {

--- a/Detectors/TOF/workflow/CMakeLists.txt
+++ b/Detectors/TOF/workflow/CMakeLists.txt
@@ -30,7 +30,7 @@ o2_add_executable(entropy-encoder-workflow
                   COMPONENT_NAME tof
                   PUBLIC_LINK_LIBRARIES O2::TOFWorkflowUtils)
 
-o2_add_executable(digit-writer-workflow
+o2_add_executable(digit-writer-splitted-workflow
                   SOURCES src/digit-writer-commissioning.cxx
                   COMPONENT_NAME tof
                   PUBLIC_LINK_LIBRARIES O2::TOFWorkflowUtils)

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -266,6 +266,8 @@ if [[ ! -z $WORKFLOW_DETECTORS_USE_GLOBAL_READER ]]; then
   has_detector FV0 && has_detector_from_global_reader FV0 && add_W o2-fv0-digit-reader-workflow "$DISABLE_MC --hbfutils-config o2_tfidinfo.root --fv0-digit-infile o2_fv0digits.root"
   has_detector MID && has_detector_from_global_reader MID && add_W o2-mid-digits-reader-workflow "$DISABLE_MC --hbfutils-config o2_tfidinfo.root --mid-digit-infile mid-digits-decoded.root"
   has_detector MCH && has_detector_from_global_reader MCH && add_W o2-mch-digits-reader-workflow "--hbfutils-config o2_tfidinfo.root --infile mchdigits.root"
+  has_detector MCH && has_detector_from_global_reader MCH && add_W o2-mch-clusters-reader-workflow "--hbfutils-config o2_tfidinfo.root" "" 0
+  has_detector MCH && has_detector_from_global_reader MCH && add_W o2-mch-preclusters-reader-workflow "--hbfutils-config o2_tfidinfo.root" "" 0
   has_detector TRD && has_detector_from_global_reader TRD && add_W o2-trd-digit-reader-workflow "--hbfutils-config o2_tfidinfo.root"
   has_detector TOF && has_detector_from_global_reader TOF && add_W o2-tof-reco-workflow "--input-type digits --output-type NONE --hbfutils-config o2_tfidinfo.root"
 fi

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -213,6 +213,8 @@ fi
 
 if ! has_detector_reco TOF; then
   TOF_OUTPUT=digits
+elif has_detector_reco TOF && ! has_detector_from_global_reader TOF; then
+  TOF_OUTPUT+=",digits"
 fi
 
 if has_detector_calib PHS && workflow_has_parameter CALIB; then
@@ -263,8 +265,9 @@ if [[ ! -z $WORKFLOW_DETECTORS_USE_GLOBAL_READER ]]; then
   add_W o2-global-track-cluster-reader "--cluster-types $WORKFLOW_DETECTORS_USE_GLOBAL_READER --track-types $WORKFLOW_DETECTORS_USE_GLOBAL_READER $GLOBAL_READER_OPTIONS $DISABLE_MC --hbfutils-config o2_tfidinfo.root"
   has_detector FV0 && has_detector_from_global_reader FV0 && add_W o2-fv0-digit-reader-workflow "$DISABLE_MC --hbfutils-config o2_tfidinfo.root --fv0-digit-infile o2_fv0digits.root"
   has_detector MID && has_detector_from_global_reader MID && add_W o2-mid-digits-reader-workflow "$DISABLE_MC --hbfutils-config o2_tfidinfo.root --mid-digit-infile mid-digits-decoded.root"
-  has_detector MCH && has_detector_from_global_reader MCH && add_W o2-mch-digits-reader-workflow " --hbfutils-config o2_tfidinfo.root --infile mchdigits.root"
-  has_detector TRD && has_detector_from_global_reader TRD && add_W o2-trd-digit-reader-workflow " --hbfutils-config o2_tfidinfo.root"
+  has_detector MCH && has_detector_from_global_reader MCH && add_W o2-mch-digits-reader-workflow "--hbfutils-config o2_tfidinfo.root --infile mchdigits.root"
+  has_detector TRD && has_detector_from_global_reader TRD && add_W o2-trd-digit-reader-workflow "--hbfutils-config o2_tfidinfo.root"
+  has_detector TOF && has_detector_from_global_reader TOF && add_W o2-tof-reco-workflow "--input-type digits --output-type NONE --hbfutils-config o2_tfidinfo.root"
 fi
 
 if [[ ! -z $INPUT_DETECTOR_LIST ]]; then


### PR DESCRIPTION
works more or less, but dumping goes to multiple files, while the reader expects everything from tofdigits.root, so this must still be fixed