### PR TITLE
uniformize MCH digits i/o for data and MC

### DIFF
--- a/Detectors/MUON/MCH/DevIO/Digits/digits-writer-workflow.cxx
+++ b/Detectors/MUON/MCH/DevIO/Digits/digits-writer-workflow.cxx
@@ -198,8 +198,8 @@ WorkflowSpec defineDataProcessing(const ConfigContext& cc)
     DataProcessorSpec producer = MakeRootTreeWriterSpec(specName,
                                                         "mchdigits.root",
                                                         MakeRootTreeWriterSpec::TreeAttributes{"o2sim", "Tree MCH Digits"},
-                                                        BranchDefinition<std::vector<ROFRecord>>{InputSpec{*rofs}, "rofs"},
-                                                        BranchDefinition<std::vector<Digit>>{InputSpec{*digits}, "digits"})();
+                                                        BranchDefinition<std::vector<ROFRecord>>{InputSpec{*rofs}, "MCHROFRecords"},
+                                                        BranchDefinition<std::vector<Digit>>{InputSpec{*digits}, "MCHDigit"})();
     specs.push_back(producer);
   }
 

--- a/Detectors/MUON/MCH/Workflow/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Workflow/CMakeLists.txt
@@ -91,7 +91,7 @@ o2_add_executable(
         sim-digits-reader-workflow
         SOURCES src/DigitReaderSpec.cxx src/sim-digits-reader-workflow.cxx
         COMPONENT_NAME mch
-        PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::DataFormatsMCH O2::MCHBase O2::SimulationDataFormat)
+        PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsRaw O2::DPLUtils O2::DataFormatsMCH O2::SimulationDataFormat)
 
 o2_add_executable(
         preclusters-sink-workflow

--- a/Detectors/MUON/MCH/Workflow/src/sim-digits-reader-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/sim-digits-reader-workflow.cxx
@@ -31,7 +31,8 @@ void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
 void customize(std::vector<ConfigParamSpec>& workflowOptions)
 {
   std::vector<ConfigParamSpec> options{
-    {"disable-mc", VariantType::Bool, false, {"Do not propagate MC info"}}};
+    {"disable-mc", VariantType::Bool, false, {"Do not propagate MC info"}},
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}}};
   workflowOptions.insert(workflowOptions.end(), options.begin(), options.end());
   o2::raw::HBFUtilsInitializer::addConfigOption(workflowOptions);
 }

--- a/Detectors/MUON/MCH/Workflow/src/sim-digits-reader-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/sim-digits-reader-workflow.cxx
@@ -14,17 +14,18 @@
 /// \author Michael Winn <Michael.Winn at cern.ch>
 /// \date   17 April 2021
 
-#include <string>
 #include <vector>
-#include "Framework/Variant.h"
+#include "Framework/CallbacksPolicy.h"
 #include "Framework/ConfigParamSpec.h"
-#include "SimulationDataFormat/MCCompLabel.h"
-#include "SimulationDataFormat/MCTruthContainer.h"
-#include "DataFormatsMCH/Digit.h"
-#include "DataFormatsMCH/ROFRecord.h"
+#include "DetectorsRaw/HBFUtilsInitializer.h"
 #include "DigitReaderSpec.h"
 
 using namespace o2::framework;
+
+void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
+{
+  o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
 
 // we need to add workflow options before including Framework/runDataProcessing
 void customize(std::vector<ConfigParamSpec>& workflowOptions)
@@ -32,6 +33,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
   std::vector<ConfigParamSpec> options{
     {"disable-mc", VariantType::Bool, false, {"Do not propagate MC info"}}};
   workflowOptions.insert(workflowOptions.end(), options.begin(), options.end());
+  o2::raw::HBFUtilsInitializer::addConfigOption(workflowOptions);
 }
 
 #include "Framework/runDataProcessing.h"
@@ -42,6 +44,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 
   WorkflowSpec specs;
   specs.emplace_back(o2::mch::getDigitReaderSpec(useMC));
+
+  o2::raw::HBFUtilsInitializer hbfIni(cfgc, specs);
 
   return specs;
 }


### PR DESCRIPTION
- use the same branch name for data and MC, which should allow to use sim-digits-reader-workflow also for data.
- add HBFUtils stuff in sim-digits-reader-workflow, which I suppose is needed to use it.

@aphecetche this is what we discussed. I open the PR to see if it passes the tests.
@davidrohr, this should fix the problem for the digit QC by replacing o2-mch-digits-reader-workflow (which only accept binary files) by:
o2-mch-sim-digits-reader-workflow --hbfutils-config o2_tfidinfo.root --disable-mc