### PR TITLE
Update TRD codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -39,7 +39,7 @@
 /DataFormats/Detectors/Passive                 @sawenzel @benedikt-voelkel
 /DataFormats/Detectors/TOF                     @noferini
 /DataFormats/Detectors/TPC                     @davidrohr @wiechula @shahor02
-/DataFormats/Detectors/TRD                     @f3sch @bazinski @tdietel @martenole
+/DataFormats/Detectors/TRD                     @f3sch @bazinski @tdietel @martenole @pachmay
 /DataFormats/Detectors/Upgrades                @qgp @marcovanleeuwen @mconcas
 /DataFormats/Detectors/Upgrades/ITS3           @fgrosa @arossi81
 /DataFormats/Detectors/ZDC                     @coppedis
@@ -69,7 +69,7 @@
 /Detectors/Passive                 @sawenzel @benedikt-voelkel
 /Detectors/TOF                     @noferini
 /Detectors/TPC                     @davidrohr @wiechula @shahor02
-/Detectors/TRD                     @f3sch @bazinski @tdietel @martenole
+/Detectors/TRD                     @f3sch @bazinski @tdietel @martenole @pachmay
 /Detectors/Upgrades                @qgp @marcovanleeuwen @mconcas
 /Detectors/Upgrades/ITS3           @fgrosa @arossi81
 /Detectors/ZDC                     @coppedis


### PR DESCRIPTION
Hi @pachmay 
with this change you are added to the codeowners of the TRD part in O2. With the default notification settings of github you should then receive an email any time there is a PR touching TRD code. If not, you find your general notification settings in https://github.com/settings/notifications and the notification settings specific for O2 if you go to https://github.com/AliceO2Group/AliceO2 and click on the down arrow next to the "Watch/Unwatch" button with the eye symbol in the upper right corner.
In addition, PRs with your approval and which have passed the automatic CI tests can be merged into the upstream repo.
Cheers,
Ole