### PR TITLE
tof-reco-workflow: If input are upstream digits not from a ROOT file, we max actually write them to a ROOT file

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-reco-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tofworkflow/src/tof-reco-workflow.cxx
@@ -180,7 +180,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     specs.emplace_back(o2::tof::getCompressedDecodingSpec(inputDesc, conetmode, !ignoreDistStf));
     useMC = 0;
   }
-  if (!dgtinput && writedigit && !disableRootOutput) {
+  if ((!dgtinput || disableRootInput) && writedigit && !disableRootOutput) {
     // add TOF digit writer without mc labels
     LOG(debug) << "Insert TOF Digit Writer";
     specs.emplace_back(o2::tof::getTOFDigitWriterSpec(0, writeerr));


### PR DESCRIPTION
@noferini : This fixes again what we changed in the last PR.
The pure `!dgtinput` is unfortunately not correct, in case digits are coming from upstream, but we want to store them to a root file. So I changed it to `(!dgtinput || disableRootInput)`. This works for the split workflow. Hope I didn't overlook something this time... :)