### PR TITLE
Better memory handling for sparse pp

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
@@ -96,7 +96,7 @@ struct VertexingParameters {
   bool allowSingleContribClusters = false;
   std::vector<float> LayerZ = {16.333f + 1, 16.333f + 1, 16.333f + 1, 42.140f + 1, 42.140f + 1, 73.745f + 1, 73.745f + 1};
   std::vector<float> LayerRadii = {2.33959f, 3.14076f, 3.91924f, 19.6213f, 24.5597f, 34.388f, 39.3329f};
-  int ZBins{256};
+  int ZBins{1};
   int PhiBins{128};
 
   float zCut = 0.002f;   // 0.002f

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/TrackingConfigParam.h
@@ -38,6 +38,8 @@ struct VertexerParamConfig : public o2::conf::ConfigurableParamHelper<VertexerPa
   int maxTrackletsPerCluster = 1e2;
   int phiSpan = -1;
   int zSpan = -1;
+  int ZBins = 1;
+  int PhiBins = 128;
 
   int nThreads = 1;
 

--- a/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
@@ -253,6 +253,7 @@ void TimeFrame::initialise(const int iteration, const TrackingParameters& trkPar
       mUsedClusters[iLayer].resize(mUnsortedClusters[iLayer].size(), false);
       mPositionResolution[iLayer] = std::sqrt(0.5 * (trkParam.SystErrorZ2[iLayer] + trkParam.SystErrorY2[iLayer]) + trkParam.LayerResolution[iLayer] * trkParam.LayerResolution[iLayer]);
     }
+    mIndexTables.clear();
     mIndexTables.resize(mClusters.size(), std::vector<int>(mNrof * (trkParam.ZBins * trkParam.PhiBins + 1), 0));
     mLines.resize(mNrof);
     mTrackletClusters.resize(mNrof);

--- a/Detectors/ITSMFT/ITS/tracking/src/Vertexer.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Vertexer.cxx
@@ -40,6 +40,8 @@ float Vertexer::clustersToVertices(std::function<void(std::string s)> logger)
 {
   float total{0.f};
   TrackingParameters trkPars;
+  trkPars.PhiBins = mTraits->getVertexingParameters().PhiBins;
+  trkPars.ZBins = mTraits->getVertexingParameters().ZBins;
   total += evaluateTask(&Vertexer::initialiseVertexer, "Vertexer initialisation", logger, trkPars);
   total += evaluateTask(&Vertexer::findTracklets, "Vertexer tracklet finding", logger);
   total += evaluateTask(&Vertexer::validateTracklets, "Vertexer adjacent tracklets validation", logger);
@@ -71,6 +73,8 @@ void Vertexer::getGlobalConfiguration()
   verPar.maxTrackletsPerCluster = vc.maxTrackletsPerCluster;
   verPar.phiSpan = vc.phiSpan;
   verPar.nThreads = vc.nThreads;
+  verPar.ZBins = vc.ZBins;
+  verPar.PhiBins = vc.PhiBins;
 
   mTraits->updateVertexingParameters(verPar);
 }

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -80,6 +80,10 @@ void TrackerDPL::init(InitContext& ic)
   if (mMode == "async") {
 
     trackParams.resize(3);
+    for (auto& param : trackParams) {
+      param.ZBins = 64;
+      param.PhiBins = 32;
+    }
     trackParams[1].TrackletMinPt = 0.2f;
     trackParams[1].CellDeltaTanLambdaSigma *= 2.;
     trackParams[2].TrackletMinPt = 0.1f;


### PR DESCRIPTION
Dear @shahor02

This should fix the issue with the timing you found on the grid.
We were over-allocating for the LUTs﻿.
In the sparse dataset you pointed out, this brings factor 300 speedup to the vertexer and factor 8 for the tracker.
It needs to be checked for a pp high rate sample, as there is a trade-off with higher occupancies, at least for the tracker with these new settings.
I open the PR for the checks anyway.

Cheers,
Max
