### PR TITLE
Add default copy assignment to prevent compiler warnings

### DIFF
--- a/DataFormats/common/include/CommonDataFormat/InteractionRecord.h
+++ b/DataFormats/common/include/CommonDataFormat/InteractionRecord.h
@@ -46,6 +46,7 @@ struct InteractionRecord {
   }
 
   InteractionRecord(const InteractionRecord& src) = default;
+  InteractionRecord& operator=(const InteractionRecord& src) = default;
 
   void clear()
   {


### PR DESCRIPTION
When the InteractionRecord copy assignment is used inside another class, cling issues a warning on Mac OS 13.2.
Since the copy constructor is explicitly defined as the default one, the compiler expects that the copy assignment is defined as well.
This PR removes the warning.