### PR TITLE
Use ColumnDataHandler in MID digits merger to avoid code duplication

### DIFF
--- a/Detectors/MUON/MID/Base/include/MIDBase/ColumnDataHandler.h
+++ b/Detectors/MUON/MID/Base/include/MIDBase/ColumnDataHandler.h
@@ -30,31 +30,40 @@ namespace mid
 class ColumnDataHandler
 {
  public:
-  /// Add single strip
-  /// \param deId Detection element ID
-  /// \param columnId Column ID
-  /// \param lineId Local board line in the column
-  /// \param strip Strip number
-  /// \param cathode Anode or cathode
+  /// @brief Add single strip
+  /// @param deId Detection element ID
+  /// @param columnId Column ID
+  /// @param lineId Local board line in the column
+  /// @param strip Strip number
+  /// @param cathode Anode or cathode
   void add(uint8_t deId, uint8_t columnId, int lineId, int strip, int cathode);
 
-  /// Merges digit
-  /// \param col input digit
-  /// \returns true if this is the first added digit
-  bool merge(const ColumnData& col);
+  /// @brief Merges digit
+  /// @param col input digit
+  /// @param idx index of col in the vector. Useful to keep track of what digit was merged
+  /// @returns true if this is the first added digit
+  bool merge(const ColumnData& col, size_t idx = 0);
 
-  /// Merges digits
-  /// \param colVec span of column data
-  void merge(gsl::span<const ColumnData> colVec);
+  /// @brief Merges digits
+  /// @param colVec span of column data
+  /// @param idx Offset index of the first ColumnData in the vector. It can be different from 0 if we are merging a subspan.
+  void merge(gsl::span<const ColumnData> colVec, size_t idx = 0);
 
-  /// Clears the data
-  void clear() { mData.clear(); }
+  /// @brief Clears inner maps
+  void clear();
 
-  /// Returns the merged data
+  /// @brief Returns the merged data
+  /// @return Vector of merged ColumnData
   std::vector<ColumnData> getMerged() const;
 
+  /// @brief Returns the indexes of the ColumnData merged into this one
+  /// @param col Merged ColumnData
+  /// @return Vector of the indexes of the ColumnData merged into this one
+  std::vector<size_t> getMergedIndexes(const ColumnData& col) const;
+
  private:
-  std::unordered_map<uint16_t, ColumnData> mData{}; // ColumnData
+  std::unordered_map<uint16_t, ColumnData> mData{};                  /// Map of ColumnData
+  std::unordered_map<uint16_t, std::vector<size_t>> mCorrespondence; /// Correspondence between input and merged ColumnData
 };
 
 } // namespace mid

--- a/Detectors/MUON/MID/Simulation/include/MIDSimulation/DigitsMerger.h
+++ b/Detectors/MUON/MID/Simulation/include/MIDSimulation/DigitsMerger.h
@@ -21,6 +21,7 @@
 #include "DataFormatsMID/ROFRecord.h"
 #include "DataFormatsMID/ColumnData.h"
 #include "DataFormatsMID/MCLabel.h"
+#include "MIDBase/ColumnDataHandler.h"
 
 namespace o2
 {
@@ -29,21 +30,25 @@ namespace mid
 class DigitsMerger
 {
  public:
+  /// @brief Merges the MC digits that are provided per hit into the format that we expect from data
+  /// @param inDigitStore Vector of input MC digits
+  /// @param inMCContainer Container with MC labels for input MC digits
+  /// @param inROFRecords Vector with RO frame records
+  /// @param mergeInBunchPileup Merge the digits coming from in-bunch pileup
   void process(const std::vector<ColumnData>& inDigitStore, const o2::dataformats::MCTruthContainer<MCLabel>& inMCContainer, const std::vector<ROFRecord>& inROFRecords, bool mergeInBunchPileup = true);
 
-  /// Gets the merged column data
+  /// @brief Gets the merged column data
   const std::vector<ColumnData>& getColumnData() const { return mDigitStore; }
-  /// Gets the merged MC labels
+  /// @brief Gets the merged MC labels
   const o2::dataformats::MCTruthContainer<MCLabel>& getMCContainer() const { return mMCContainer; }
-  /// Gets the merged RO frame records
+  /// @brief Gets the merged RO frame records
   const std::vector<ROFRecord>& getROFRecords() const { return mROFRecords; }
 
  private:
-  void mergeDigit(size_t idigit, const std::vector<ColumnData>& inDigitStore);
-  std::vector<std::pair<ColumnData, std::vector<size_t>>> mDigitsLabels{}; //! Temporary digits store
-  std::vector<ColumnData> mDigitStore{};                                   ///< Digit store
-  o2::dataformats::MCTruthContainer<MCLabel> mMCContainer{};               ///< MC Container
-  std::vector<ROFRecord> mROFRecords{};                                    ///< RO frame records
+  ColumnDataHandler mHandler;                                ///! Column data handler
+  std::vector<ColumnData> mDigitStore{};                     ///< Digit store
+  o2::dataformats::MCTruthContainer<MCLabel> mMCContainer{}; ///< MC Container
+  std::vector<ROFRecord> mROFRecords{};                      ///< RO frame records
 };
 
 } // namespace mid

--- a/Detectors/MUON/MID/Simulation/include/MIDSimulation/DigitsMerger.h
+++ b/Detectors/MUON/MID/Simulation/include/MIDSimulation/DigitsMerger.h
@@ -17,6 +17,7 @@
 #define O2_MID_DIGITSMERGER_H
 
 #include <vector>
+#include <gsl/span>
 #include "SimulationDataFormat/MCTruthContainer.h"
 #include "DataFormatsMID/ROFRecord.h"
 #include "DataFormatsMID/ColumnData.h"
@@ -36,6 +37,13 @@ class DigitsMerger
   /// @param inROFRecords Vector with RO frame records
   /// @param mergeInBunchPileup Merge the digits coming from in-bunch pileup
   void process(const std::vector<ColumnData>& inDigitStore, const o2::dataformats::MCTruthContainer<MCLabel>& inMCContainer, const std::vector<ROFRecord>& inROFRecords, bool mergeInBunchPileup = true);
+
+  /// @brief Merges the MC digits that are provided per hit into the format that we expect from data
+  /// @param inDigitStore Vector of input MC digits
+  /// @param inROFRecords Vector with RO frame records
+  /// @param inMCContainer Pointer to a container with MC labels for input MC digits (can be null)
+  /// @param mergeInBunchPileup Merge the digits coming from in-bunch pileup
+  void process(gsl::span<const ColumnData> inDigitStore, gsl::span<const ROFRecord> inROFRecords, const o2::dataformats::MCTruthContainer<MCLabel>* inMCContainer = nullptr, bool mergeInBunchPileup = true);
 
   /// @brief Gets the merged column data
   const std::vector<ColumnData>& getColumnData() const { return mDigitStore; }

--- a/Detectors/MUON/MID/Simulation/src/DigitsMerger.cxx
+++ b/Detectors/MUON/MID/Simulation/src/DigitsMerger.cxx
@@ -19,40 +19,19 @@ namespace o2
 {
 namespace mid
 {
-void DigitsMerger::mergeDigit(size_t idigit, const std::vector<ColumnData>& inDigitStore)
-{
-  /// Merges the current digit
-  for (auto& pair : mDigitsLabels) {
-    auto& outCol = pair.first;
-    if (outCol.deId == inDigitStore[idigit].deId && outCol.columnId == inDigitStore[idigit].columnId) {
-      outCol |= (inDigitStore[idigit]);
-      pair.second.emplace_back(idigit);
-      return;
-    }
-  }
-  std::vector<size_t> vec = {idigit};
-  mDigitsLabels.emplace_back(std::make_pair(inDigitStore[idigit], vec));
-}
 
 void DigitsMerger::process(const std::vector<ColumnData>& inDigitStore, const o2::dataformats::MCTruthContainer<MCLabel>& inMCContainer, const std::vector<ROFRecord>& inROFRecords, bool mergeInBunchPileup)
 {
-  /// Merges the MC digits that are provided per hit
-  /// into the format that we expect from data
-  /// \param inDigitStore Vector of input MC digits
-  /// \param inMCContainer Container with MC labels for input MC digits
-  /// \param inROFRecords Vector with RO frame records
-  /// \param mergeInBunchPileup Merge the digits coming from in-bunch pileup
   mDigitStore.clear();
   mMCContainer.clear();
   mROFRecords.clear();
-  mDigitsLabels.clear();
 
   for (auto rofIt = inROFRecords.begin(); rofIt != inROFRecords.end(); ++rofIt) {
     auto nextRofIt = rofIt + 1;
     bool mergeInteractions = mergeInBunchPileup && nextRofIt != inROFRecords.end() && rofIt->interactionRecord == nextRofIt->interactionRecord;
 
-    for (size_t idigit = rofIt->firstEntry; idigit < rofIt->firstEntry + rofIt->nEntries; ++idigit) {
-      mergeDigit(idigit, inDigitStore);
+    for (size_t idigit = rofIt->firstEntry, end = rofIt->getEndIndex(); idigit < end; ++idigit) {
+      mHandler.merge(inDigitStore[idigit], idigit);
     }
 
     if (mergeInteractions) {
@@ -60,15 +39,17 @@ void DigitsMerger::process(const std::vector<ColumnData>& inDigitStore, const o2
     }
 
     auto firstEntry = mDigitStore.size();
-    mROFRecords.emplace_back(rofIt->interactionRecord, rofIt->eventType, firstEntry, mDigitsLabels.size());
+    auto digits = mHandler.getMerged();
+    mROFRecords.emplace_back(rofIt->interactionRecord, rofIt->eventType, firstEntry, digits.size());
 
-    for (auto pair : mDigitsLabels) {
-      mDigitStore.emplace_back(pair.first);
-      for (auto labelIdx : pair.second) {
+    for (auto& dig : digits) {
+      auto indexes = mHandler.getMergedIndexes(dig);
+      mDigitStore.emplace_back(dig);
+      for (auto labelIdx : indexes) {
         mMCContainer.addElements(mDigitStore.size() - 1, inMCContainer.getLabels(labelIdx));
       }
     }
-    mDigitsLabels.clear();
+    mHandler.clear();
   }
 }
 } // namespace mid


### PR DESCRIPTION
In the simulations, the MID patterns are produced for each particle and then merged together, by the DigitMerger.
The core functionality of the merger was later extracted in a separate class, ColumnDataHandler, to improve the merging of masks.
In this PR we improve the ColumnDataHandler, so that it keeps track of the merged digits (useful for MC labelling purposes).
In this way we can use it inside DigitMerger, with the aim of reducing code duplication.

The commits are meant to be atomic, but, since they are closely related, they might be merged as well.