### PR TITLE
ITS3: Base: SegmentationSuperAlpide: Add Constructor for ROOT macros

### DIFF
--- a/Detectors/Upgrades/ITS3/base/include/ITS3Base/SegmentationSuperAlpide.h
+++ b/Detectors/Upgrades/ITS3/base/include/ITS3Base/SegmentationSuperAlpide.h
@@ -30,41 +30,28 @@ namespace its3
 class SegmentationSuperAlpide
 {
  public:
-  SegmentationSuperAlpide(int layer = 0) : mLayer{layer},
-                                           mPitchCol{SuperAlpideParams::Instance().pitchCol},
-                                           mPitchRow{SuperAlpideParams::Instance().pitchRow},
-                                           mNCols{static_cast<int>(mLength / mPitchCol)},
-                                           mNRows{static_cast<int>(double(mRadii[layer] + mSensorLayerThickness / 2) * double(constants::math::PI) / double(mPitchRow) + 1)},
-                                           mNPixels{mNRows * mNCols},
-                                           mActiveMatrixSizeCols{mPitchCol * mNCols},
-                                           mActiveMatrixSizeRows{mPitchRow * mNRows},
-                                           mSensorSizeCols{mActiveMatrixSizeCols + mPassiveEdgeSide + mPassiveEdgeSide},
-                                           mSensorSizeRows{mActiveMatrixSizeRows + mPassiveEdgeTop + mPassiveEdgeReadOut}
-  {
-    LOGP(info, "SegmentationSuperAlpide:");
-    LOGP(info, "PitchCol={} PitchRow={}", mPitchCol, mPitchRow);
-    LOGP(info, "Layer {}: ActiveMatrixSizeRows={} ActiveMatrixSizeCols={}", mLayer, mActiveMatrixSizeCols, mActiveMatrixSizeRows);
-    LOGP(info, "Rows={} Cols={} NPixels={}", mNRows, mNCols, mNPixels);
-  }
-  static constexpr std::array<float, 10> mRadii = {1.8f, 2.4f, 3.0f, 7.0f, 10.f}; ///< radii for different layers
-  static constexpr float mLength = 27.15f;                                        ///< chip length
-  const float mPitchCol;                                                          ///< pixel column size
-  const float mPitchRow;                                                          ///< pixel row size
-  const int mNCols;                                                               ///< number of columns
-  const int mNRows;                                                               ///< number of rows
-  const int mNPixels;                                                             ///< total number of pixels
-  const int mLayer;                                                               ///< chip layer
-  static constexpr float mPassiveEdgeReadOut = 0.;                                ///< width of the readout edge (Passive bottom)
-  static constexpr float mPassiveEdgeTop = 0.;                                    ///< Passive area on top
-  static constexpr float mPassiveEdgeSide = 0.;                                   ///< width of Passive area on left/right of the sensor
-  const float mActiveMatrixSizeCols;                                              ///< Active size along columns
-  const float mActiveMatrixSizeRows;                                              ///< Active size along rows
+  SegmentationSuperAlpide(int layer, float pitchCol, float pitchRow) : mLayer{layer}, mPitchCol{pitchCol}, mPitchRow{pitchRow} { print(); }
+  SegmentationSuperAlpide(int layer = 0) : SegmentationSuperAlpide(layer, SuperAlpideParams::Instance().pitchCol, SuperAlpideParams::Instance().pitchRow) {}
+
+  static constexpr std::array<float, 10> mRadii = {1.8f, 2.4f, 3.0f, 7.0f, 10.f};                                                               ///< radii for different layers
+  static constexpr float mLength = 27.15f;                                                                                                      ///< chip length
+  const int mLayer;                                                                                                                             ///< chip layer
+  const float mPitchCol;                                                                                                                        ///< pixel column size
+  const float mPitchRow;                                                                                                                        ///< pixel row size
+  const int mNCols{static_cast<int>(mLength / mPitchCol)};                                                                                      ///< number of columns
+  const int mNRows{static_cast<int>(double(mRadii[mLayer] + mSensorLayerThickness / 2) * double(constants::math::PI) / double(mPitchRow) + 1)}; ///< number of rows
+  const int mNPixels{mNRows * mNCols};                                                                                                          ///< total number of pixels
+  static constexpr float mPassiveEdgeReadOut = 0.;                                                                                              ///< width of the readout edge (Passive bottom)
+  static constexpr float mPassiveEdgeTop = 0.;                                                                                                  ///< Passive area on top
+  static constexpr float mPassiveEdgeSide = 0.;                                                                                                 ///< width of Passive area on left/right of the sensor
+  const float mActiveMatrixSizeCols{mPitchCol * mNCols};                                                                                        ///< Active size along columns
+  const float mActiveMatrixSizeRows{mPitchRow * mNRows};                                                                                        ///< Active size along rows
 
   // effective thickness of sensitive layer, accounting for charge collection non-uniformity, https://alice.its.cern.ch/jira/browse/AOC-46
-  static constexpr float mSensorLayerThicknessEff = 28.e-4; ///< effective thickness of sensitive part
-  static constexpr float mSensorLayerThickness = 30.e-4;    ///< physical thickness of sensitive part
-  const float mSensorSizeCols;                              ///< SensorSize along columns
-  const float mSensorSizeRows;                              ///< SensorSize along rows
+  static constexpr float mSensorLayerThicknessEff = 28.e-4;                                   ///< effective thickness of sensitive part
+  static constexpr float mSensorLayerThickness = 30.e-4;                                      ///< physical thickness of sensitive part
+  const float mSensorSizeCols{mActiveMatrixSizeCols + mPassiveEdgeSide + mPassiveEdgeSide};   ///< SensorSize along columns
+  const float mSensorSizeRows{mActiveMatrixSizeRows + mPassiveEdgeTop + mPassiveEdgeReadOut}; ///< SensorSize along rows
 
   ~SegmentationSuperAlpide() = default;
 

--- a/Detectors/Upgrades/ITS3/base/src/SegmentationSuperAlpide.cxx
+++ b/Detectors/Upgrades/ITS3/base/src/SegmentationSuperAlpide.cxx
@@ -13,17 +13,14 @@
 /// \brief Implementation of the SegmentationSuperAlpide class
 
 #include "ITS3Base/SegmentationSuperAlpide.h"
-#include <cstdio>
+#include <Framework/Logger.h>
 
 ClassImp(o2::its3::SegmentationSuperAlpide);
 
-using namespace o2::its3;
-
-void SegmentationSuperAlpide::print()
+void o2::its3::SegmentationSuperAlpide::print()
 {
-  printf("Pixel size: %.2f (along %d rows) %.2f (along %d columns) microns\n", mPitchRow * 1e4, mNRows, mPitchCol * 1e4, mNCols);
-  printf("Passive edges: bottom: %.2f, top: %.2f, left/right: %.2f microns\n",
-         mPassiveEdgeReadOut * 1e4, mPassiveEdgeTop * 1e4, mPassiveEdgeSide * 1e4);
-  printf("Active/Total size: %.6f/%.6f (rows) %.6f/%.6f (cols) cm\n", mActiveMatrixSizeRows, mSensorSizeRows,
-         mActiveMatrixSizeCols, mSensorSizeCols);
+  LOGP(info, "SegmentationSuperAlpide:");
+  LOGP(info, "Layer {}: Active/Total size {:.2f}/{:.2f} (rows) x {:.2f}/{:.2f}", mLayer, mActiveMatrixSizeRows, mSensorSizeRows, mActiveMatrixSizeCols, mSensorSizeCols);
+  LOGP(info, "Pixel size: {:.2f} (along {} rows) {:.2f} (along {} columns) microns", mPitchRow * 1e4, mNRows, mPitchCol * 1e4, mNCols);
+  LOGP(info, "Passive edges: bottom: {:.6f}, top: {:.6f}, left/right: {:.6f} microns", mPassiveEdgeReadOut * 1e4, mPassiveEdgeTop * 1e4, mPassiveEdgeSide * 1e4);
 }


### PR DESCRIPTION
In ROOT macros the size for SegmenationSuperAlpide cannot be retrieved from the simulation hence adding a constructor which allows constructing chips of variable pitches.
Also cleaned up the constructed a bit.

Signed-off-by: Felix Schlepper <f3sch.git@outlook.com>