### PR TITLE
MCH: add option to disable writing of all clusters

### DIFF
--- a/Detectors/MUON/MCH/Workflow/src/reco-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/reco-workflow.cxx
@@ -52,6 +52,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
     {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input reader"}},
     {"disable-root-output", o2::framework::VariantType::Bool, false, {"do not write output root files"}},
     {"disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation even if available"}},
+    {"enable-clusters-root-output", o2::framework::VariantType::Bool, false, {"write output root file containing all clusters"}},
     {"disable-clustering", o2::framework::VariantType::Bool, false, {"disable clustering (and tracking) steps (for debug)"}},
     {"disable-tracking", o2::framework::VariantType::Bool, false, {"disable tracking step (for debug)"}},
     {"digits", VariantType::Bool, false, {"Write digits associated to tracks"}},
@@ -74,6 +75,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   auto useMC = !configcontext.options().get<bool>("disable-mc");
   auto disableClustering = configcontext.options().get<bool>("disable-clustering");
   auto disableTracking = disableClustering || configcontext.options().get<bool>("disable-tracking");
+  auto disableAllClustersRootOutput = !configcontext.options().get<bool>("enable-clusters-root-output");
 
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
 
@@ -109,7 +111,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
       specs.emplace_back(o2::mch::getClusterFinderGEMSpec("mch-cluster-finder"));
     }
     specs.emplace_back(o2::mch::getClusterTransformerSpec("mch-cluster-transformer", false));
-    if (!disableRootOutput) {
+    if (!disableRootOutput && !disableAllClustersRootOutput) {
       specs.emplace_back(o2::mch::getClusterWriterSpec(false, "mch-global-cluster-writer", true, true));
     }
     if (!disableTracking) {


### PR DESCRIPTION
Intent is to write only mchtracks by default when asking for root output, while retaining the ability to write also all clusters if need be