### PR TITLE
[MFT] Use residual instead of measurement to make Mille records

### DIFF
--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/Aligner.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/Aligner.h
@@ -54,6 +54,9 @@ class Aligner
   void setAllowedVariationDeltaRz(const double value) { mAllowVar[2] = value; }
   void setChi2CutFactor(const double value) { mStartFac = value; }
 
+  /// \brief return the number of DOF per sensor
+  int getNDofPerSensor() const { return mNDofPerSensor; }
+
  protected:
   static constexpr int mNumberOfTrackParam = 4;                                  ///< Number of track (= local) parameters (X0, Tx, Y0, Ty)
   static constexpr int mNDofPerSensor = 4;                                       ///< translation in global x, y, z, and rotation Rz around global z-axis

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/MatrixSparse.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/MatrixSparse.h
@@ -77,7 +77,7 @@ class MatrixSparse : public MatrixSq
  protected:
   VectorSparse** fVecs = nullptr;
 
-  ClassDef(MatrixSparse, 0);
+  ClassDefOverride(MatrixSparse, 0);
 };
 
 //___________________________________________________

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/MatrixSq.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/MatrixSq.h
@@ -144,7 +144,7 @@ class MatrixSq : public TMatrixDBase
  protected:
   Bool_t fSymmetric; ///< is the matrix symmetric? Only lower triangle is filled
 
-  ClassDef(MatrixSq, 1);
+  ClassDefOverride(MatrixSq, 1);
 };
 
 //___________________________________________________________

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/MillePede2.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/MillePede2.h
@@ -181,7 +181,9 @@ class MillePede2
   void SetSigmaPar(int i, double par);
 
   /// \brief performs a requested number of global iterations
-  int GlobalFit(double* par = nullptr, double* error = nullptr, double* pull = nullptr);
+  int GlobalFit(std::vector<double>& par,
+                std::vector<double>& error,
+                std::vector<double>& pull);
 
   /// \brief perform global parameters fit once all the local equations have been fitted
   int GlobalFitIteration();

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/MillePedeRecord.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/MillePedeRecord.h
@@ -127,7 +127,7 @@ class MillePedeRecord : public TObject
   Double32_t* fValue; ///< [fSize] array of values: derivs,residuals
   Double32_t fWeight; ///< global weight for the record
 
-  ClassDef(MillePedeRecord, 3);
+  ClassDefOverride(MillePedeRecord, 3);
 };
 
 //_____________________________________________________________________________

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/MinResSolve.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/MinResSolve.h
@@ -132,7 +132,7 @@ class MinResSolve : public TObject
   MatrixSparse* fMatU; // aux. space
   SymBDMatrix* fMatBD; // aux. space
 
-  ClassDef(MinResSolve, 0);
+  ClassDefOverride(MinResSolve, 0);
 };
 
 } // namespace mft

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/RecordsToAlignParams.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/RecordsToAlignParams.h
@@ -81,7 +81,7 @@ class RecordsToAlignParams : public Aligner
   std::vector<double> mPedeOutParamsErrors;            ///< Vector to store the outputs (errors on the alignement corrections) of the MillePede simulatenous fit
   std::vector<double> mPedeOutParamsPulls;             ///< Vector to store the outputs (pulls on the alignement corrections) of the MillePede simulatenous fit
 
-  ClassDef(RecordsToAlignParams, 0);
+  ClassDefOverride(RecordsToAlignParams, 0);
 };
 
 } // namespace mft

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/RecordsToAlignParams.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/RecordsToAlignParams.h
@@ -16,6 +16,7 @@
 #ifndef ALICEO2_MFT_RECORDS_TO_ALIGN_PARAMS_H
 #define ALICEO2_MFT_RECORDS_TO_ALIGN_PARAMS_H
 
+#include <vector>
 #include <TChain.h>
 
 #include "MFTAlignment/MillePede2.h"
@@ -53,6 +54,15 @@ class RecordsToAlignParams : public Aligner
   /// \brief provide access to the AlignParam vector
   void getAlignParams(std::vector<o2::detectors::AlignParam>& alignParams) { alignParams = mAlignParams; }
 
+  /// \brief provide access to the vector of alignment corrections
+  void getPedeOutParams(std::vector<double>& output) { output = mPedeOutParams; }
+
+  /// \brief provide access to the vector of errors on the alignement corrections
+  void getPedeOutParamsErrors(std::vector<double>& output) { output = mPedeOutParamsErrors; }
+
+  /// \brief provide access to the vector of pulls on the alignement corrections
+  void getPedeOutParamsPulls(std::vector<double>& output) { output = mPedeOutParamsPulls; }
+
   /// \brief connect data record reader to input TChain of records
   void connectRecordReaderToChain(TChain* ch);
 
@@ -67,6 +77,9 @@ class RecordsToAlignParams : public Aligner
   bool mWithConstraintsRecReader;                      ///< boolean to set to true if one wants to also read constraints records
   o2::mft::MilleRecordReader* mConstraintsRecReader;   ///< utility that handles the reading of the constraints records
   o2::mft::MillePede2* mMillepede;                     ///< Millepede2 implementation copied from AliROOT
+  std::vector<double> mPedeOutParams;                  ///< Vector to store the outputs (alignment corrections) of the MillePede simulatenous fit
+  std::vector<double> mPedeOutParamsErrors;            ///< Vector to store the outputs (errors on the alignement corrections) of the MillePede simulatenous fit
+  std::vector<double> mPedeOutParamsPulls;             ///< Vector to store the outputs (pulls on the alignement corrections) of the MillePede simulatenous fit
 
   ClassDef(RecordsToAlignParams, 0);
 };

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/RectMatrix.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/RectMatrix.h
@@ -67,7 +67,7 @@ class RectMatrix : public TObject
   Int_t fNCols;     ///< Number of columns
   Double_t** fRows; ///< pointers on rows
 
-  ClassDef(RectMatrix, 0);
+  ClassDefOverride(RectMatrix, 0);
 };
 
 //___________________________________________________________

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/SymBDMatrix.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/SymBDMatrix.h
@@ -106,7 +106,7 @@ class SymBDMatrix : public MatrixSq
  protected:
   Double_t* fElems; ///< Elements booked by constructor
 
-  ClassDef(SymBDMatrix, 0);
+  ClassDefOverride(SymBDMatrix, 0);
 };
 
 //___________________________________________________________

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/SymMatrix.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/SymMatrix.h
@@ -215,7 +215,7 @@ class SymMatrix : public MatrixSq
   static SymMatrix* fgBuffer; ///< buffer for fast solution
   static Int_t fgCopyCnt;     ///< matrix copy counter
 
-  ClassDef(SymMatrix, 0);
+  ClassDefOverride(SymMatrix, 0);
 };
 
 //___________________________________________________________

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/TracksToRecords.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/TracksToRecords.h
@@ -144,7 +144,7 @@ class TracksToRecords : public Aligner
   /// \brief set the last component of the local equation vector for a given alignment point
   bool setLocalEquationZ();
 
-  ClassDef(TracksToRecords, 0);
+  ClassDefOverride(TracksToRecords, 0);
 };
 
 } // namespace mft

--- a/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/VectorSparse.h
+++ b/Detectors/ITSMFT/MFT/alignment/include/MFTAlignment/VectorSparse.h
@@ -82,7 +82,7 @@ class VectorSparse : public TObject
   UShort_t* fIndex; ///< Index of stored elems
   Double_t* fElems; ///< pointer on elements
 
-  ClassDef(VectorSparse, 0);
+  ClassDefOverride(VectorSparse, 0);
 };
 
 //___________________________________________________

--- a/Detectors/ITSMFT/MFT/alignment/src/MillePede2.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/MillePede2.cxx
@@ -875,7 +875,9 @@ int MillePede2::LocalFit(std::vector<double>& localParams)
 }
 
 //_____________________________________________________________________________
-int MillePede2::GlobalFit(double* par, double* error, double* pull)
+int MillePede2::GlobalFit(std::vector<double>& par,
+                          std::vector<double>& error,
+                          std::vector<double>& pull)
 {
   if (fRecordReader == nullptr) {
     LOG(fatal) << "MillePede2::GlobalFit() - aborted, input record reader is a null pointer";
@@ -911,19 +913,19 @@ int MillePede2::GlobalFit(double* par, double* error, double* pull)
     return 0;
   }
 
-  if (par) {
+  if (par.size()) {
     for (int i = fNGloParIni; i--;) {
       par[i] = GetFinalParam(i);
     }
   }
 
   if (fGloSolveStatus == kInvert) { // errors on params are available
-    if (error) {
+    if (error.size()) {
       for (int i = fNGloParIni; i--;) {
         error[i] = GetFinalError(i);
       }
     }
-    if (pull) {
+    if (pull.size()) {
       for (int i = fNGloParIni; i--;) {
         pull[i] = GetPull(i);
       }

--- a/Detectors/ITSMFT/MFT/alignment/src/TracksToRecords.cxx
+++ b/Detectors/ITSMFT/MFT/alignment/src/TracksToRecords.cxx
@@ -568,13 +568,13 @@ bool TracksToRecords::setLocalEquationX()
            mGlobalDerivatives[chipId * mNDofPerSensor + 1],
            mGlobalDerivatives[chipId * mNDofPerSensor + 2],
            mGlobalDerivatives[chipId * mNDofPerSensor + 3],
-           mAlignPoint->getLocalMeasuredPosition().X(),
+           mAlignPoint->getLocalResidual().X(),
            mAlignPoint->getLocalMeasuredPositionSigma().X());
     }
     mMillepede->SetLocalEquation(
       mGlobalDerivatives,
       mLocalDerivatives,
-      mAlignPoint->getLocalMeasuredPosition().X(),
+      mAlignPoint->getLocalResidual().X(),
       mAlignPoint->getLocalMeasuredPositionSigma().X());
   } else {
     mCounterLocalEquationFailed++;
@@ -632,13 +632,13 @@ bool TracksToRecords::setLocalEquationY()
            mGlobalDerivatives[chipId * mNDofPerSensor + 1],
            mGlobalDerivatives[chipId * mNDofPerSensor + 2],
            mGlobalDerivatives[chipId * mNDofPerSensor + 3],
-           mAlignPoint->getLocalMeasuredPosition().Y(),
+           mAlignPoint->getLocalResidual().Y(),
            mAlignPoint->getLocalMeasuredPositionSigma().Y());
     }
     mMillepede->SetLocalEquation(
       mGlobalDerivatives,
       mLocalDerivatives,
-      mAlignPoint->getLocalMeasuredPosition().Y(),
+      mAlignPoint->getLocalResidual().Y(),
       mAlignPoint->getLocalMeasuredPositionSigma().Y());
   } else {
     mCounterLocalEquationFailed++;
@@ -696,13 +696,13 @@ bool TracksToRecords::setLocalEquationZ()
            mGlobalDerivatives[chipId * mNDofPerSensor + 1],
            mGlobalDerivatives[chipId * mNDofPerSensor + 2],
            mGlobalDerivatives[chipId * mNDofPerSensor + 3],
-           mAlignPoint->getLocalMeasuredPosition().Z(),
+           mAlignPoint->getLocalResidual().Z(),
            mAlignPoint->getLocalMeasuredPositionSigma().Z());
     }
     mMillepede->SetLocalEquation(
       mGlobalDerivatives,
       mLocalDerivatives,
-      mAlignPoint->getLocalMeasuredPosition().Z(),
+      mAlignPoint->getLocalResidual().Z(),
       mAlignPoint->getLocalMeasuredPositionSigma().Z());
   } else {
     mCounterLocalEquationFailed++;


### PR DESCRIPTION
This PR is hijacked to also bring the following modifications:

- store and provide access to MillePede alignment corrections, errors and pulls
- use ClassDefOverride instead of ClassDef to avoid countless warnings by ROOT interpreter when running macro calling MillePede devoted classes