### PR TITLE
TPC interpolation with additional ITS-TPC tracks

### DIFF
--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/SpacePointsCalibConfParam.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/SpacePointsCalibConfParam.h
@@ -26,6 +26,7 @@ namespace tpc
 struct SpacePointsCalibConfParam : public o2::conf::ConfigurableParamHelper<SpacePointsCalibConfParam> {
 
   int maxTracksPerCalibSlot = 3'500'000; ///< the number of tracks which is required to obtain an average correction map
+  int additionalTracksITSTPC = 2'000'000; ///< will be added to maxTracksPerCalibSlot for track sample with uniform acceptance (no PHOS hole)
 
   // define track cuts for track interpolation
   int minTPCNCls = 70;             ///< min number of TPC clusters

--- a/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackInterpolation.h
+++ b/Detectors/TPC/calibration/SpacePoints/include/SpacePoints/TrackInterpolation.h
@@ -218,6 +218,9 @@ class TrackInterpolation
   /// Sets the maximum number of tracks to be processed (successfully) per TF
   void setMaxTracksPerTF(int n) { mMaxTracksPerTF = n; }
 
+  /// In addition to mMaxTracksPerTF up to the set number of ITS-TPC only tracks can be processed
+  void setAddITSTPCTracksPerTF(int n) { mAddTracksITSTPC = n; }
+
   // --------------------------------- output ---------------------------------------------
   std::vector<UnbinnedResid>& getClusterResiduals() { return mClRes; }
   std::vector<TrackDataCompact>& getTrackDataCompact() { return mTrackDataCompact; }
@@ -236,6 +239,7 @@ class TrackInterpolation
   float mTPCDriftTimeOffsetRef = 0.;                 ///< TPC nominal (e.g. at the start of run) drift time bias in cm/mus
   MatCorrType mMatCorr{MatCorrType::USEMatCorrNONE}; ///< if material correction should be done
   int mMaxTracksPerTF{-1};                           ///< max number of tracks to be processed per TF (-1 means there is no limit)
+  int mAddTracksITSTPC{0};                           ///< number of ITS-TPC tracks which can be processed in addition to mMaxTracksPerTF
 
   // input
   const o2::globaltracking::RecoContainer* mRecoCont = nullptr;                            ///< input reco container

--- a/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
+++ b/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
@@ -109,8 +109,15 @@ void TrackInterpolation::process(const o2::globaltracking::RecoContainer& inp, c
   std::shuffle(trackIndices.begin() + nTracks, trackIndices.begin() + nTracks + trkCounters.at(GTrackID::Source::ITSTPC), g);
 
   std::vector<int> globalTracksToCheck;
+  bool maxTracksReached = false;
   for (int iSeed = trkCounters.at(GTrackID::Source::ITSTPCTRDTOF); iSeed < nSeeds; ++iSeed) {
-    if (mMaxTracksPerTF >= 0 && mTrackDataCompact.size() >= mMaxTracksPerTF) {
+    if (!maxTracksReached && mMaxTracksPerTF >= 0 && mTrackDataCompact.size() >= mMaxTracksPerTF) {
+      maxTracksReached = true;
+      // if mAddTracksITSTPC > 0 we will still process up to mAddTracksITSTPC tracks,
+      // otherwise the following if statement is also true and we break
+      iSeed = nSeeds - trkCounters.at(GTrackID::Source::ITSTPC);
+    }
+    if (mMaxTracksPerTF >= 0 && mTrackDataCompact.size() >= mMaxTracksPerTF + mAddTracksITSTPC) {
       LOG(info) << "Maximum number of tracks per TF reached. Skipping the remaining " << nSeeds - iSeed << " tracks.";
       break;
     }
@@ -120,6 +127,7 @@ void TrackInterpolation::process(const o2::globaltracking::RecoContainer& inp, c
         // process the ITS-TPC-TRD-TOF track later, in addition to the ITS-TPC-TRD track
         globalTracksToCheck.push_back(search->second);
       } else {
+        // process the ITS-TPC-TRD-TOF track and skip its ITS-TPC-TRD track seed
         interpolateTrack(search->second);
         continue;
       }


### PR DESCRIPTION
In order to process a configurable amount of ITS-TPC tracks in addition to the preferred global barrel tracks per TF in order to cover the PHOS hole.