### PR TITLE
DPL: specify balancing in the CompletionPolicy

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -333,6 +333,7 @@ foreach(w
         ParallelPipeline
         ParallelProducer
         SlowConsumer
+        SlowProducerWithWildCard
         SimpleDataProcessingDevice01
         SimpleStatefulProcessing01
         SimpleStringProcessing

--- a/Framework/Core/include/Framework/CompletionPolicy.h
+++ b/Framework/Core/include/Framework/CompletionPolicy.h
@@ -16,6 +16,7 @@
 
 #include <functional>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace o2::framework
@@ -68,12 +69,12 @@ struct CompletionPolicy {
 
   /// Constructor
   CompletionPolicy()
-    : name(), matcher(), callback() {}
+    : name{}, matcher{}, callback{} {}
   /// Constructor for emplace_back
-  CompletionPolicy(std::string _name, Matcher _matcher, Callback _callback)
-    : name(_name), matcher(_matcher), callback(_callback), callbackFull{nullptr} {}
-  CompletionPolicy(std::string _name, Matcher _matcher, CallbackFull _callback)
-    : name(_name), matcher(_matcher), callback(nullptr), callbackFull{_callback} {}
+  CompletionPolicy(std::string _name, Matcher _matcher, Callback _callback, bool _balanceChannels = true)
+    : name(std::move(_name)), matcher(std::move(_matcher)), callback(std::move(_callback)), callbackFull{nullptr}, balanceChannels{_balanceChannels} {}
+  CompletionPolicy(std::string _name, Matcher _matcher, CallbackFull _callback, bool _balanceChannels = true)
+    : name(std::move(_name)), matcher(std::move(_matcher)), callback(nullptr), callbackFull{std::move(_callback)}, balanceChannels{_balanceChannels} {}
 
   /// Name of the policy itself.
   std::string name = "";
@@ -87,6 +88,12 @@ struct CompletionPolicy {
   /// A callback which allows you to configure the behavior of the data relayer associated
   /// to the matching device.
   CallbackConfigureRelayer configureRelayer = nullptr;
+  /// Wether or not the policy requires queues to be balanced
+  /// Set to false if the policy does not require that the upstream
+  /// producers are more or less balanced. Most notably, this is
+  /// not needed if the policy always happens to consume / discard
+  /// data.
+  bool balanceChannels = true;
 
   /// Helper to create the default configuration.
   static std::vector<CompletionPolicy> createDefaultPolicies();

--- a/Framework/Core/src/CompletionPolicyHelpers.cxx
+++ b/Framework/Core/src/CompletionPolicyHelpers.cxx
@@ -92,7 +92,7 @@ CompletionPolicy CompletionPolicyHelpers::defineByName(std::string const& name, 
       return CompletionPolicy{"always-wait", matcher, callback};
       break;
     case CompletionPolicy::CompletionOp::Discard:
-      return CompletionPolicy{"always-discard", matcher, callback};
+      return CompletionPolicy{"always-discard", matcher, callback, false};
       break;
     case CompletionPolicy::CompletionOp::ConsumeAndRescan:
       return CompletionPolicy{"always-rescan", matcher, callback};
@@ -206,7 +206,7 @@ CompletionPolicy CompletionPolicyHelpers::consumeWhenAny(const char* name, Compl
     }
     return CompletionPolicy::CompletionOp::Wait;
   };
-  return CompletionPolicy{name, matcher, callback};
+  return CompletionPolicy{name, matcher, callback, false};
 }
 
 CompletionPolicy CompletionPolicyHelpers::consumeWhenAny(std::string matchName)

--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -879,12 +879,14 @@ void DataProcessingDevice::fillContext(DataProcessorContext& context, DeviceCont
   context.wasActive = &mWasActive;
 
   context.isSink = false;
-  context.balancingInputs = true;
   // If nothing is a sink, the rate limiting simply does not trigger.
   bool enableRateLimiting = std::stoi(fConfig->GetValue<std::string>("timeframes-rate-limit"));
 
   auto ref = ServiceRegistryRef{mServiceRegistry};
   auto& spec = ref.get<DeviceSpec const>();
+
+  // The policy is now allowed to state the default.
+  context.balancingInputs = spec.completionPolicy.balanceChannels;
   // This is needed because the internal injected dummy sink should not
   // try to balance inputs unless the rate limiting is requested.
   if (enableRateLimiting == false && spec.name == "internal-dpl-injected-dummy-sink") {

--- a/Framework/Core/test/test_SlowProducerWithWildCard.cxx
+++ b/Framework/Core/test/test_SlowProducerWithWildCard.cxx
@@ -1,0 +1,94 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
+#include "Framework/DeviceSpec.h"
+#include "Framework/RawDeviceService.h"
+#include "Framework/ControlService.h"
+#include <fairmq/Device.h>
+
+#include <chrono>
+#include <thread>
+#include <vector>
+
+using namespace o2::framework;
+void customize(std::vector<o2::framework::CompletionPolicy>& policies)
+{
+  policies.push_back(CompletionPolicyHelpers::defineByName("Publisher.*", CompletionPolicy::CompletionOp::Consume));
+}
+
+#include "Framework/runDataProcessing.h"
+using namespace o2::framework;
+
+// This is how you can define your processing in a declarative way
+WorkflowSpec defineDataProcessing(ConfigContext const& specs)
+{
+  return WorkflowSpec{
+    {.name = "A1",
+     .outputs = {OutputSpec{{"a"}, "CLP", "D0", 0, Lifetime::Timeframe},
+                 OutputSpec{{"b"}, "CLW", "D0", 0, Lifetime::Timeframe}},
+     .algorithm = AlgorithmSpec{adaptStateful([]() { return adaptStateless(
+                                                       [](DataAllocator& outputs, RawDeviceService& device, ControlService& control) {
+                                                         static int count = 0;
+                                                         auto& aData = outputs.make<int>(OutputRef{"a"});
+                                                         auto& bData = outputs.make<int>(OutputRef{"b"});
+                                                         aData = 1;
+                                                         (void)bData;
+                                                         LOG(info) << count++;
+                                                         device.device()->WaitFor(std::chrono::milliseconds(100));
+                                                         if (count > 100) {
+                                                           LOGP(info, "Done sending 100 messages on the fast path");
+                                                           control.endOfStream();
+                                                           control.readyToQuit(QuitRequest::Me);
+                                                         }
+                                                       }); })}},
+    {.name = "A2",
+     .outputs = {OutputSpec{{"a"}, "CLP", "D1", 1, Lifetime::Timeframe},
+                 OutputSpec{{"b"}, "CLW", "D1", 1, Lifetime::Timeframe}},
+     .algorithm = AlgorithmSpec{adaptStateful([]() { return adaptStateless(
+                                                       [](DataAllocator& outputs, RawDeviceService& device, ControlService& control) {
+                                                         static int count = 0;
+                                                         auto& aData = outputs.make<int>(OutputRef{"a", 1});
+                                                         auto& bData = outputs.make<int>(OutputRef{"b", 1});
+                                                         aData = 2;
+                                                         (void)bData;
+                                                         LOG(info) << count++;
+                                                         device.device()->WaitFor(std::chrono::milliseconds(1000));
+                                                         if (count > 10) {
+                                                           LOGP(info, "Done sending 10 messages on the slow path");
+                                                           control.endOfStream();
+                                                           control.readyToQuit(QuitRequest::Me);
+                                                         }
+                                                       }); })}},
+    {.name = "Publisher",
+     .inputs = {{"x", "CLP", Lifetime::Sporadic},
+                {"y", "CLW", Lifetime::Sporadic}},
+     .algorithm = AlgorithmSpec{adaptStateful([]() { return adaptStateless(
+                                                       [](InputRecord& inputs, RawDeviceService& device, ControlService& control) {
+                                                         static int a1Count = 0;
+                                                         static int a2Count = 0;
+
+                                                         auto& x = inputs.get<int>("x");
+                                                         if (x == 1) {
+                                                           LOGP(info, "Received from A1 {}", a1Count++);
+                                                         } else if (x == 2) {
+                                                           LOGP(info, "Received from A2 {}", a2Count++);
+                                                         } else {
+                                                           LOGP(fatal, "Unexpected value {}", x);
+                                                         }
+                                                         LOGP(info, "Count is {} {}", a1Count, a2Count);
+                                                         if (a1Count == 101 && a2Count == 11) {
+                                                           LOGP(info, "Done receiving all messages");
+                                                           control.endOfStream();
+                                                           control.readyToQuit(QuitRequest::Me);
+                                                         }
+                                                       }); })}}};
+}


### PR DESCRIPTION
Some completion policies, e.g. Discard or Consume, do not need to have the input channels balanced because they do not starve the queues in any case. For these cases, we allow disabling at the policy level the balancing.

By default the behaviour is unchanged.

As part of this commit I add a test which reproduces the behavior of the SACs / IDCs race condition, which gets corrected by the fact the Consume policy is now set to have balanceChannels = false.