### PR TITLE
Fix bin initialization for MFT tracker

### DIFF
--- a/Detectors/ITSMFT/MFT/tracking/src/Tracker.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/Tracker.cxx
@@ -110,11 +110,6 @@ void Tracker<T>::configure(const MFTTrackingParam& trkParam, bool firstTracker)
 template <typename T>
 void Tracker<T>::initializeFinder()
 {
-
-  if (mFullClusterScan) {
-    return;
-  }
-
   // The lock will prevent executing the code below at the same time for different tracker copes (one will wait for other)
   std::lock_guard<std::mutex> guard(TrackerConfig::sTCMutex);
   if (mBins) {


### PR DESCRIPTION
@shahor02 
in our tests `mFullClusterScan` is set to false, but at P2 its set to true. That's why the CI did not catch it. 