### PR TITLE
MFTTracker: fix initialization of precalculated arrays

### DIFF
--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/Tracker.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/Tracker.h
@@ -77,8 +77,9 @@ class Tracker : public TrackerConfig
   bool fitTracks(ROframe<T>&);
   void computeTracksMClabels(const std::vector<T>&);
 
-  void configure(const MFTTrackingParam& trkParam, bool firstTracker);
+  void configure(const MFTTrackingParam& trkParam, int trackerID);
   void initializeFinder();
+  int getTrackerID() const { return mTrackerID; }
 
  private:
   void findTracksLTF(ROframe<T>&);
@@ -143,6 +144,7 @@ class Tracker : public TrackerConfig
   void addCellToCurrentTrackCA(const Int_t, const Int_t, ROframe<T>&);
   void addCellToCurrentRoad(ROframe<T>&, const Int_t, const Int_t, const Int_t, const Int_t, Int_t&);
 
+  int mTrackerID = 0;
   Float_t mBz;
   std::vector<MCCompLabel> mTrackLabels;
   std::unique_ptr<o2::mft::TrackFitter<T>> mTrackFitter = nullptr;

--- a/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/TrackerConfig.h
+++ b/Detectors/ITSMFT/MFT/tracking/include/MFTTracking/TrackerConfig.h
@@ -28,7 +28,6 @@ using namespace constants::mft;
 using BinContainer = std::array<std::array<std::array<std::vector<Int_t>, constants::index_table::MaxRPhiBins>, (constants::mft::LayersNumber - 1)>, (constants::mft::LayersNumber - 1)>;
 using RArray = std::array<Float_t, constants::mft::LayersNumber>;
 using PhiArray = std::array<Int_t, constants::mft::LayersNumber>;
-using InverseRArray = std::array<Float_t, constants::mft::LayersNumber>;
 
 class TrackerConfig
 {
@@ -49,37 +48,38 @@ class TrackerConfig
 
  protected:
   // tracking configuration parameters
-  Int_t mMinTrackPointsLTF;
-  Int_t mMinTrackPointsCA;
-  Int_t mMinTrackStationsLTF;
-  Int_t mMinTrackStationsCA;
-  Float_t mLTFclsRCut;
-  Float_t mLTFclsR2Cut;
-  Float_t mROADclsRCut;
-  Float_t mROADclsR2Cut;
-  Int_t mRBins;
-  Int_t mPhiBins;
-  Int_t mRPhiBins;
-  Float_t mZVtxMin;
-  Float_t mZVtxMax;
-  Float_t mRCutAtZmin;
-  Bool_t mLTFConeRadius;
-  Bool_t mCAConeRadius;
+  Int_t mMinTrackPointsLTF{};
+  Int_t mMinTrackPointsCA{};
+  Int_t mMinTrackStationsLTF{};
+  Int_t mMinTrackStationsCA{};
+  Float_t mLTFclsRCut{};
+  Float_t mLTFclsR2Cut{};
+  Float_t mROADclsRCut{};
+  Float_t mROADclsR2Cut{};
+  Int_t mRBins{};
+  Int_t mPhiBins{};
+  Int_t mRPhiBins{};
+  Float_t mZVtxMin{};
+  Float_t mZVtxMax{};
+  Float_t mRCutAtZmin{};
+  Bool_t mLTFConeRadius{};
+  Bool_t mCAConeRadius{};
   /// Special track finder for TED shots and cosmics, with full scan of the clusters
   bool mFullClusterScan = false;
-  Float_t mTrueTrackMCThreshold; // Minimum fraction of correct MC labels to tag True tracks
+  Float_t mTrueTrackMCThreshold{}; // Minimum fraction of correct MC labels to tag True tracks
 
   static std::mutex sTCMutex;
 
   static Float_t mPhiBinSize;
   static Float_t mInversePhiBinSize;
 
-  static std::unique_ptr<InverseRArray> mInverseRBinSize;
-  static std::unique_ptr<PhiArray> mPhiBinWin;
-  static std::unique_ptr<RArray> mRBinSize;
+  static RArray mInverseRBinSize;
+  static RArray mRBinSize;
+  static PhiArray mPhiBinWin;
+
   static std::unique_ptr<BinContainer> mBins;
   static std::unique_ptr<BinContainer> mBinsS;
-  std::array<std::array<std::pair<Int_t, Int_t>, constants::index_table::MaxRPhiBins>, constants::mft::LayersNumber> mClusterBinIndexRange;
+  std::array<std::array<std::pair<Int_t, Int_t>, constants::index_table::MaxRPhiBins>, constants::mft::LayersNumber> mClusterBinIndexRange{};
 
   ClassDefNV(TrackerConfig, 3);
 };
@@ -87,15 +87,15 @@ class TrackerConfig
 inline Float_t TrackerConfig::mPhiBinSize;
 inline Float_t TrackerConfig::mInversePhiBinSize;
 
-inline std::unique_ptr<InverseRArray> TrackerConfig::mInverseRBinSize;
-inline std::unique_ptr<PhiArray> TrackerConfig::mPhiBinWin;
-inline std::unique_ptr<RArray> TrackerConfig::mRBinSize;
+inline RArray TrackerConfig::mInverseRBinSize;
+inline RArray TrackerConfig::mRBinSize;
+inline PhiArray TrackerConfig::mPhiBinWin;
 inline std::unique_ptr<BinContainer> TrackerConfig::mBins;
 inline std::unique_ptr<BinContainer> TrackerConfig::mBinsS;
 
 inline const Int_t TrackerConfig::getRBinIndex(const Float_t r, const Int_t layer) const
 {
-  return (Int_t)((r - constants::index_table::RMin[layer]) * (*mInverseRBinSize)[layer]);
+  return (Int_t)((r - constants::index_table::RMin[layer]) * mInverseRBinSize[layer]);
 }
 
 inline const Int_t TrackerConfig::getPhiBinIndex(const Float_t phi) const

--- a/Detectors/ITSMFT/MFT/tracking/src/TrackerConfig.cxx
+++ b/Detectors/ITSMFT/MFT/tracking/src/TrackerConfig.cxx
@@ -53,13 +53,4 @@ void o2::mft::TrackerConfig::initBinContainers()
   if (!mBinsS) {
     mBinsS = std::make_unique<BinContainer>();
   }
-  if (!mRBinSize) {
-    mRBinSize = std::make_unique<RArray>();
-  }
-  if (!mPhiBinWin) {
-    mPhiBinWin = std::make_unique<PhiArray>();
-  }
-  if (!mInverseRBinSize) {
-    mInverseRBinSize = std::make_unique<InverseRArray>();
-  }
 }


### PR DESCRIPTION
Hi @robincaron13 
I've made some of small static arrays non-pointers and decoupled their initialization from the [check](https://github.com/shahor02/AliceO2/blob/4b02a90d8b588415cc5149282e74a726812a0682/Detectors/ITSMFT/MFT/tracking/src/Tracker.cxx#L143) since they are always needed.
But testing the reconstruction with `--configKeyValues "MFTTracking.FullClusterScan=true"` in lhc22m (500 kHz) I find it tremendously slow. With the timing benchmarking I added (need [this](https://github.com/shahor02/AliceO2/blob/4b02a90d8b588415cc5149282e74a726812a0682/Detectors/ITSMFT/MFT/workflow/src/TrackerSpec.cxx#L47 ) uncommented) I get:
```
 o2-ctf-reader-workflow --loop 2 --ctf-input ctf/o2_ctf_run00523308_orbit0363341084_tf0000345682_epn015.root --onlyDet MFT --shm-segment-size 16000000000 | o2-mft-reco-workflow   --shm-segment-size 16000000000 --clusters-from-upstream --disable-mc --nThreads 1 --pipeline mft-tracker:1  --configKeyValues "MFTTracking.FullClusterScan=true"
```
[2044635:mft-tracker]: [15:20:58][INFO] launchTrackFinder| tracker:0 did 1-th ROF in 620802 mus: 338 clusters -> 7 tracks
[2044635:mft-tracker]: [15:20:59][INFO] launchTrackFinder| tracker:0 did 2-th ROF in 326679 mus: 276 clusters -> 4 tracks
...
[2044635:mft-tracker]: [15:21:15][INFO] launchTrackFinder| tracker:0 did 54-th ROF in 224566 mus: 226 clusters -> 0 tracks
[2044635:mft-tracker]: [15:21:15][INFO] launchTrackFinder| tracker:0 did 55-th ROF in 283832 mus: 247 clusters -> 2 tracks
[2044635:mft-tracker]: [15:21:16][INFO] launchTrackFinder| tracker:0 did 56-th ROF in 1040722 mus: 395 clusters -> 5 tracks
[2044635:mft-tracker]: [15:21:20][INFO] launchTrackFinder| tracker:0 did 57-th ROF in 3220702 mus: 579 clusters -> 6 tracks
...
```
More than 1 s per ROF with a few 100 clusters is too much. At the moment, the FullClusterScan is used for cosmic only, but even in this case some noisy event may make the workflow to stuck. Is it possible to optimize the combinatorics?