### PR TITLE
Optionally expand TPC tracks cov.matrix in global tracking/refits

### DIFF
--- a/DataFormats/Detectors/GlobalTracking/CMakeLists.txt
+++ b/DataFormats/Detectors/GlobalTracking/CMakeLists.txt
@@ -13,6 +13,7 @@ o2_add_library(
   DataFormatsGlobalTracking
   SOURCES src/RecoContainer.cxx
           src/FilteredRecoTF.cxx
+          src/TrackTuneParams.cxx
   PUBLIC_LINK_LIBRARIES
     O2::DataFormatsTPC
     O2::DataFormatsITSMFT
@@ -40,4 +41,5 @@ o2_add_library(
 o2_target_root_dictionary(
   DataFormatsGlobalTracking
   HEADERS include/DataFormatsGlobalTracking/FilteredRecoTF.h
+          include/DataFormatsGlobalTracking/TrackTuneParams.h
 )

--- a/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/TrackTuneParams.h
+++ b/DataFormats/Detectors/GlobalTracking/include/DataFormatsGlobalTracking/TrackTuneParams.h
@@ -1,0 +1,44 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \author ruben.shahoyan@cern.ch
+
+#ifndef ALICEO2_TRACK_TUNE_PARAMS_H
+#define ALICEO2_TRACK_TUNE_PARAMS_H
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "CommonUtils/ConfigurableParamHelper.h"
+
+namespace o2
+{
+namespace globaltracking
+{
+
+// There are configurable params for tracks ad hoc tuning
+
+struct TrackTuneParams : public o2::conf::ConfigurableParamHelper<TrackTuneParams> {
+  enum AddCovType {  // how to add covariances to tracks
+    Disable,         // do not add
+    NoCorrelations,  // add ignoring correlations (i.e. to diagonal elements only)
+    WithCorrelations // add adjusting non-diagonal elements to preserve correlation coefficients
+  };
+  AddCovType tpcCovInnerType = AddCovType::Disable;
+  AddCovType tpcCovOuterType = AddCovType::Disable;
+  float tpcCovInner[5] = {}; // ad hoc errors to be added to TPC cov.matrix at the inner XRef
+  float tpcCovOuter[5] = {}; // ad hoc errors to be added to TPC outer param at the outer XRef
+
+  O2ParamDef(TrackTuneParams, "trackTuneParams");
+};
+
+} // namespace globaltracking
+} // end namespace o2
+
+#endif

--- a/DataFormats/Detectors/GlobalTracking/src/TrackTuneParams.cxx
+++ b/DataFormats/Detectors/GlobalTracking/src/TrackTuneParams.cxx
@@ -9,16 +9,9 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifdef __CLING__
+/// \file TrackTuneParams.h
+/// \brief Configurable params for tracks ad hoc tuning
+/// \author ruben.shahoyan@cern.ch
 
-#pragma link off all globals;
-#pragma link off all classes;
-#pragma link off all functions;
-
-#pragma link C++ class o2::dataformats::FilteredRecoTF + ;
-#pragma link C++ class o2::dataformats::FilteredRecoTF::Header + ;
-#pragma link C++ class std::vector < o2::dataformats::FilteredRecoTF> + ;
-
-#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::globaltracking::TrackTuneParams> + ;
-
-#endif
+#include "DataFormatsGlobalTracking/TrackTuneParams.h"
+O2ParamImpl(o2::globaltracking::TrackTuneParams);

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITS.h
@@ -297,9 +297,6 @@ class MatchTPCITS
   MatchTPCITS(); // std::unique_ptr to forward declared type needs constructor / destructor in .cxx
   ~MatchTPCITS();
 
-  static constexpr float XMatchingRef = 70.0;                            ///< reference radius to propage tracks for matching
-  static constexpr float YMaxAtXMatchingRef = XMatchingRef * 0.17632698; ///< max Y in the sector at reference X
-
   static constexpr int MaxUpDnLadders = 3;                     // max N ladders to check up and down from selected one
   static constexpr int MaxLadderCand = 2 * MaxUpDnLadders + 1; // max ladders to check for matching clusters
   static constexpr int MaxSeedsPerLayer = 50;                  // TODO
@@ -539,6 +536,8 @@ class MatchTPCITS
 
   ///< do we use track Z difference to reject fake matches? makes sense for triggered mode only
   bool mCompareTracksDZ = false;
+
+  float YMaxAtXMatchingRef = 999.; ///< max Y in the sector at reference X
 
   float mSectEdgeMargin2 = 0.; ///< crude check if ITS track should be matched also in neighbouring sector
 

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITSParams.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchTPCITSParams.h
@@ -35,6 +35,8 @@ struct MatchTPCITSParams : public o2::conf::ConfigurableParamHelper<MatchTPCITSP
   float crudeAbsDiffCut[o2::track::kNParams] = {2.f, 2.f, 0.2f, 0.2f, 4.f};
   float crudeNSigma2Cut[o2::track::kNParams] = {49.f, 49.f, 49.f, 49.f, 49.f};
 
+  float XMatchingRef = 70.f; ///< reference radius to propagate tracks for matching
+
   float minTPCTrackR = 50.; ///< cut on minimal TPC tracks radius to consider for matching, 666*pt_gev*B_kgaus/5
   float minITSTrackR = 50.; ///< cut on minimal ITS tracks radius to consider for matching, 666*pt_gev*B_kgaus/5
   int minTPCClusters = 25; ///< minimum number of clusters to consider

--- a/Detectors/GlobalTracking/src/MatchTOF.cxx
+++ b/Detectors/GlobalTracking/src/MatchTOF.cxx
@@ -34,6 +34,7 @@
 #include "DataFormatsParameters/GRPObject.h"
 #include "ReconstructionDataFormats/PID.h"
 #include "ReconstructionDataFormats/TrackLTIntegral.h"
+#include "DataFormatsGlobalTracking/TrackTuneParams.h"
 
 #include "GlobalTracking/MatchTOF.h"
 
@@ -282,7 +283,10 @@ void MatchTOF::addITSTPCSeed(const o2::dataformats::TrackTPCITS& _tr, o2::datafo
   o2::track::TrackLTIntegral intLT0 = _tr.getLTIntegralOut();
 
   timeEst ts(time0, terr);
-
+  const auto& trackTune = o2::globaltracking::TrackTuneParams::Instance();
+  if (trackTune.tpcCovOuterType != o2::globaltracking::TrackTuneParams::AddCovType::Disable) { // only TRD-refitted track have cov.matrix already manipulated
+    trc.updateCov(trackTune.tpcCovOuter, trackTune.tpcCovOuterType == o2::globaltracking::TrackTuneParams::AddCovType::WithCorrelations);
+  }
   addConstrainedSeed(trc, srcGID, intLT0, ts);
 }
 //______________________________________________
@@ -368,7 +372,10 @@ void MatchTOF::addTPCSeed(const o2::tpc::TrackTPC& _tr, o2::dataformats::GlobalT
   }
 
   auto trc = _tr.getOuterParam();
-
+  const auto& trackTune = o2::globaltracking::TrackTuneParams::Instance();
+  if (trackTune.tpcCovOuterType != o2::globaltracking::TrackTuneParams::AddCovType::Disable) { // only TRD-refitted track have cov.matrix already manipulated
+    trc.updateCov(trackTune.tpcCovOuter, trackTune.tpcCovOuterType == o2::globaltracking::TrackTuneParams::AddCovType::WithCorrelations);
+  }
   if (!propagateToRefXWithoutCov(trc, mXRef, 10, mBz)) { // we first propagate to 371 cm without considering the covariance matri
     mNotPropagatedToTOF[trkType::UNCONS]++;
     return;


### PR DESCRIPTION
New configurable param TrackTuneParams allows expanding cov.matrix of TPC track used in global tracking.
If `trackTuneParams.tpcCovInnerType` and `trackTuneParams.tpcCovOuterType` is not `TrackTuneParams::AddCovType::Disable`, then the content of float[5] arrays `trackTuneParams.tpcCovInner` and `trackTuneParams.tpcCovOuterType` respectively will be used to augment TPC inner or outer param before matching to ITS, TRD, TOF. The addition will preserve the cov. matrix correlations if the `tpcCovXXXType` is set to WithCorrelations, otherwise just the diagonal elements will be augmented, see [updateCovCorr](https://github.com/shahor02/AliceO2/blob/5ffee6555a0cbbb32aa8680c849ddccae1c45bd7/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrizationWithError.h#L406) and [updateCov](https://github.com/shahor02/AliceO2/blob/5ffee6555a0cbbb32aa8680c849ddccae1c45bd7/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrizationWithError.h#L388) methods respectively.
Modification of TPC tracks cov.matrix is done when creating matching seed and also when the TPC tracks needs to be refitted (with constrained time) for the following refit in external detector, i.e. 
1) TPC-ITS matching : in the inward refit of TPC track is refitted and its cov. matrix augmented at the TPC inner radius
2) TRD matching: in the outward refit TPC tracks is augmented before refit in the TRD.

The configurable param can be provided to `o2-tpcits-match-workflow`, `o2-trd-global-tracking` and `o2-tof-matcher-workflow`