### PR TITLE
Add possibility to filter the collision BCs and merge digits in adjacent BCs

### DIFF
--- a/Detectors/MUON/MID/Filtering/CMakeLists.txt
+++ b/Detectors/MUON/MID/Filtering/CMakeLists.txt
@@ -12,8 +12,11 @@
 o2_add_library(
   MIDFiltering
   SOURCES src/ChannelMasksHandler.cxx src/ChannelScalers.cxx src/FetToDead.cxx
-          src/MaskMaker.cxx src/FiltererBC.cxx
+          src/MaskMaker.cxx src/FiltererBC.cxx src/FiltererBCParam.cxx
   PUBLIC_LINK_LIBRARIES O2::CommonDataFormat O2::DataFormatsMID O2::MIDBase O2::MIDRaw Microsoft.GSL::GSL)
+
+o2_target_root_dictionary(MIDFiltering
+  HEADERS include/MIDFiltering/FiltererBCParam.h)
 
 add_subdirectory(exe)
 

--- a/Detectors/MUON/MID/Filtering/CMakeLists.txt
+++ b/Detectors/MUON/MID/Filtering/CMakeLists.txt
@@ -1,19 +1,19 @@
-# Copyright CERN and copyright holders of ALICE O2. This software is distributed
-# under the terms of the GNU General Public License v3 (GPL Version 3), copied
-# verbatim in the file "COPYING".
+# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# All rights not expressly granted are reserved.
 #
-# See http://alice-o2.web.cern.ch/license for full licensing information.
+# This software is distributed under the terms of the GNU General Public
+# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 #
 # In applying this license CERN does not waive the privileges and immunities
-# granted to it by virtue of its status as an Intergovernmental Organization or
-# submit itself to any jurisdiction.
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
 
 o2_add_library(
   MIDFiltering
   SOURCES src/ChannelMasksHandler.cxx src/ChannelScalers.cxx src/FetToDead.cxx
-          src/MaskMaker.cxx
-  PUBLIC_LINK_LIBRARIES O2::DataFormatsMID O2::MIDBase O2::MIDRaw
-                        Microsoft.GSL::GSL)
+          src/MaskMaker.cxx src/FiltererBC.cxx
+  PUBLIC_LINK_LIBRARIES O2::CommonDataFormat O2::DataFormatsMID O2::MIDBase O2::MIDRaw Microsoft.GSL::GSL)
 
 add_subdirectory(exe)
 

--- a/Detectors/MUON/MID/Filtering/exe/CMakeLists.txt
+++ b/Detectors/MUON/MID/Filtering/exe/CMakeLists.txt
@@ -1,12 +1,14 @@
-# Copyright CERN and copyright holders of ALICE O2. This software is distributed
-# under the terms of the GNU General Public License v3 (GPL Version 3), copied
-# verbatim in the file "COPYING".
+# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# All rights not expressly granted are reserved.
 #
-# See http://alice-o2.web.cern.ch/license for full licensing information.
+# This software is distributed under the terms of the GNU General Public
+# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 #
 # In applying this license CERN does not waive the privileges and immunities
-# granted to it by virtue of its status as an Intergovernmental Organization or
-# submit itself to any jurisdiction.
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
 
 o2_add_executable(
   mask-maker

--- a/Detectors/MUON/MID/Filtering/include/MIDFiltering/FiltererBC.h
+++ b/Detectors/MUON/MID/Filtering/include/MIDFiltering/FiltererBC.h
@@ -1,0 +1,68 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDFiltering/FiltererBC.h
+/// \brief  BC filterer for MID
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   23 January 2023
+
+#ifndef O2_MID_FILTERERBC_H
+#define O2_MID_FILTERERBC_H
+
+#include <vector>
+#include <gsl/gsl>
+#include "CommonDataFormat/BunchFilling.h"
+#include "DataFormatsMID/ROFRecord.h"
+
+namespace o2
+{
+namespace mid
+{
+/// Filtering algorithm for MID
+class FiltererBC
+{
+ public:
+  /// @brief Filters the data BC
+  /// @param rofRecords ROF records
+  /// @returns Vector of filtered ROF records
+  std::vector<ROFRecord> process(gsl::span<const ROFRecord> rofRecords);
+
+  /// @brief Set the maximum BC diff in the lower side
+  /// @param bcDiffLow maximum BC diff in the lower side (negative value)
+  void setBCDiffLow(int bcDiffLow) { mBCDiffLow = bcDiffLow; }
+
+  /// @brief Set the maximum BC diff in the upper side
+  /// @param bcDiffHigh maximum BC diff in the upper side (positive value)
+  void setBCDiffHigh(int bcDiffHigh) { mBCDiffHigh = bcDiffHigh; }
+
+  /// @brief Only selects BCs but do not merge them
+  /// @param selectOnly Flag to only select BCs without merging events
+  void setSelectOnly(bool selectOnly) { mSelectOnly = selectOnly; }
+
+  /// @brief Sets the bunch filling scheme
+  /// @param bunchFilling Bunch filling scheme
+  void setBunchFilling(const BunchFilling& bunchFilling) { mBunchFilling = bunchFilling; }
+
+ private:
+  /// @brief Returns the matched collision BC
+  /// @param bc BC to be checked
+  /// @return The BC of the matched collision or -1 if there is no match
+  int matchedCollision(int bc);
+
+  int mBCDiffLow = 0;         /// Maximum BC diff on the lower side
+  int mBCDiffHigh = 0;        /// Maximum BC diff on the higher side
+  bool mSelectOnly = false;   /// Flag to only select BCs without merging digits
+  BunchFilling mBunchFilling; /// Bunch filling scheme
+};
+} // namespace mid
+} // namespace o2
+
+#endif /* O2_MID_FILTERERBC_H */

--- a/Detectors/MUON/MID/Filtering/include/MIDFiltering/FiltererBCParam.h
+++ b/Detectors/MUON/MID/Filtering/include/MIDFiltering/FiltererBCParam.h
@@ -1,0 +1,38 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_MID_FILTERERBCPARAM_H
+#define O2_MID_FILTERERBCPARAM_H
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "CommonUtils/ConfigurableParamHelper.h"
+
+namespace o2
+{
+namespace mid
+{
+
+/**
+ * @class FiltererBCParam
+ * @brief Configurable parameters for the BC filterer
+ */
+struct FiltererBCParam : public o2::conf::ConfigurableParamHelper<FiltererBCParam> {
+
+  int maxBCDiffLow = -1;   ///< Maximum BC diff in the lower side
+  int maxBCDiffHigh = 1;   ///< Maximum BC diff in the upper side
+  bool selectOnly = false; ///< Selects BCs but does not merge them
+
+  O2ParamDef(FiltererBCParam, "MIDFiltererBC");
+};
+} // namespace mid
+} // namespace o2
+
+#endif

--- a/Detectors/MUON/MID/Filtering/src/FiltererBC.cxx
+++ b/Detectors/MUON/MID/Filtering/src/FiltererBC.cxx
@@ -1,0 +1,113 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Filtering/src/FiltererBC.cxx
+/// \brief  BC filterer for MID
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   23 January 2023
+
+#include "MIDFiltering/FiltererBC.h"
+
+namespace o2
+{
+namespace mid
+{
+
+int FiltererBC::matchedCollision(int bc)
+{
+  // First we check the simple case to save time
+  if (mBunchFilling.testInteractingBC(bc)) {
+    return bc;
+  }
+
+  // Then we check for neighbor BCs
+  // We split the check in two so that we start the check from the input bc
+  // and we move farther from it.
+
+  int matchedBC = std::numeric_limits<int>::max();
+
+  // We start on the upper direction
+
+  // The allowed BC are o2::constants::lhc::LHCMaxBunches.
+  // Numeration starts from 0, so o2::constants::lhc::LHCMaxBunches is not allowed.
+  // This ensures that we do not check out of boundaries
+  int end = bc + mBCDiffHigh;
+  if (end >= o2::constants::lhc::LHCMaxBunches) {
+    end = o2::constants::lhc::LHCMaxBunches - 1;
+  }
+  // We exclude the input BC since it was already checked before
+  for (int ibc = bc + 1; ibc <= end; ++ibc) {
+    if (mBunchFilling.testInteractingBC(ibc)) {
+      // We do not stop here because we want first to check that there is no closer matching in the other direction
+      matchedBC = ibc;
+      break;
+    }
+  }
+
+  // We then check the lower direction
+  end = bc + mBCDiffLow;
+  if (end < 0) {
+    end = 0;
+  }
+  // We exclude the input BC since it was already checked before
+  for (int ibc = bc - 1; ibc >= end; --ibc) {
+    if (mBunchFilling.testInteractingBC(ibc)) {
+      if (bc - ibc < matchedBC - bc) {
+        // This collision BC is closer to the input BC than the one found in the upper side
+        return ibc;
+      }
+      break;
+    }
+  }
+
+  return matchedBC;
+}
+
+std::vector<ROFRecord> FiltererBC::process(gsl::span<const ROFRecord> rofRecords)
+{
+  std::vector<ROFRecord> filteredROFs;
+  auto rofIt = rofRecords.begin();
+  auto end = rofRecords.end();
+  // Loop on ROFs
+  for (; rofIt != end; ++rofIt) {
+    // Check if BC matches a collision BC
+    auto matchedColl = matchedCollision(rofIt->interactionRecord.bc);
+    if (matchedColl < o2::constants::lhc::LHCMaxBunches) {
+      // Add this ROF to the filtered ones
+      filteredROFs.emplace_back(*rofIt);
+      if (mSelectOnly) {
+        continue;
+      }
+      // Use the BC of the matching collision
+      filteredROFs.back().interactionRecord.bc = matchedColl;
+      // Search for neighbor BCs
+      for (auto auxIt = rofIt + 1; auxIt != end; ++auxIt) {
+        // We assume that data are time-ordered
+        if (auxIt->interactionRecord.orbit != rofIt->interactionRecord.orbit) {
+          // Orbit does not match
+          break;
+        }
+        int bcDiff = auxIt->interactionRecord.bc - matchedColl;
+        if (bcDiff < mBCDiffLow || bcDiff > mBCDiffHigh) {
+          // BC is not in the allowed window
+          break;
+        }
+        filteredROFs.back().nEntries += auxIt->nEntries;
+        // CAVEAT: we are updating rofIt here. Do not use it in the following
+        rofIt = auxIt;
+      }
+    }
+  }
+  return filteredROFs;
+}
+
+} // namespace mid
+} // namespace o2

--- a/Detectors/MUON/MID/Filtering/src/FiltererBCParam.cxx
+++ b/Detectors/MUON/MID/Filtering/src/FiltererBCParam.cxx
@@ -1,0 +1,14 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "MIDFiltering/FiltererBCParam.h"
+
+O2ParamImpl(o2::mid::FiltererBCParam);

--- a/Detectors/MUON/MID/Filtering/src/MIDFilteringLinkDef.h
+++ b/Detectors/MUON/MID/Filtering/src/MIDFilteringLinkDef.h
@@ -1,0 +1,20 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifdef __CLING__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class o2::mid::FiltererBCParam + ;
+
+#endif

--- a/Detectors/MUON/MID/Filtering/test/CMakeLists.txt
+++ b/Detectors/MUON/MID/Filtering/test/CMakeLists.txt
@@ -1,12 +1,13 @@
-# Copyright CERN and copyright holders of ALICE O2. This software is distributed
-# under the terms of the GNU General Public License v3 (GPL Version 3), copied
-# verbatim in the file "COPYING".
+# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# All rights not expressly granted are reserved.
 #
-# See http://alice-o2.web.cern.ch/license for full licensing information.
+# This software is distributed under the terms of the GNU General Public
+# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 #
 # In applying this license CERN does not waive the privileges and immunities
-# granted to it by virtue of its status as an Intergovernmental Organization or
-# submit itself to any jurisdiction.
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
 
 o2_add_test(
   Filtering

--- a/Detectors/MUON/MID/Workflow/CMakeLists.txt
+++ b/Detectors/MUON/MID/Workflow/CMakeLists.txt
@@ -1,13 +1,13 @@
-# Copyright 2019-2020 CERN and copyright holders of ALICE O2. See
-# https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+# Copyright 2019-2022 CERN and copyright holders of ALICE O2.
+# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 # All rights not expressly granted are reserved.
 #
-# This software is distributed under the terms of the GNU General Public License
-# v3 (GPL Version 3), copied verbatim in the file "COPYING".
+# This software is distributed under the terms of the GNU General Public
+# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
 #
 # In applying this license CERN does not waive the privileges and immunities
-# granted to it by virtue of its status as an Intergovernmental Organization or
-# submit itself to any jurisdiction.
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
 
 o2_add_library(
   MIDWorkflow
@@ -21,6 +21,7 @@ o2_add_library(
           src/EntropyDecoderSpec.cxx
           src/EntropyEncoderSpec.cxx
           src/FilteringSpec.cxx
+          src/FilteringBCSpec.cxx
           src/MaskHandlerSpec.cxx
           src/MaskMakerSpec.cxx
           src/ChannelCalibratorSpec.cxx

--- a/Detectors/MUON/MID/Workflow/README.md
+++ b/Detectors/MUON/MID/Workflow/README.md
@@ -117,6 +117,32 @@ o2-mid-reco-workflow --change-local-to-BC <value>
 
 where `<value>` is the chosen offset in number of BCs (can be negative).
 
+## MID BC filtering
+
+The MID time resolution is better than 25 ns, allowing it to distinguish between different BCs.
+However, a spread of the signal was observed, probably due an insufficient equalization of the delays across the various detection element.
+In order to study and possibly correct for any inefficiency arising from this spread, it is possible to select the BCs corresponding to a collision and merge the digits in a configurable window around this BC.
+To this aim, it is enough to run the reconstruction with the option:
+
+```bash
+o2-mid-reco-workflow --enable-filter-BC
+```
+
+The time window can be tuned with:
+
+```bash
+--configKeyValues="MIDFiltererBC.maxBCDiffLow=-1;MIDFiltererBC.maxBCDiffHigh=1"
+```
+
+Notice that the `maxBCDiffLow` has to be a negative value.
+
+It is also possible to only select the collision BC, without merging the digits in the corresponding window.
+This can be done adding the option:
+
+```bash
+--configKeyValues="MIDFiltererBC.selectOnly=1"
+```
+
 ### Reconstruction options
 
 By default, the reconstruction produces clusters and tracks that are written on file.

--- a/Detectors/MUON/MID/Workflow/include/MIDWorkflow/FilteringBCSpec.h
+++ b/Detectors/MUON/MID/Workflow/include/MIDWorkflow/FilteringBCSpec.h
@@ -1,0 +1,32 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MIDWorkflow/FilteringBCSpec.h
+/// \brief  MID filtering spec
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   16 March 2022
+
+#ifndef O2_MID_FILTERINGBCSPEC_H
+#define O2_MID_FILTERINGBCSPEC_H
+
+#include "Framework/DataProcessorSpec.h"
+
+#include <string_view>
+
+namespace o2
+{
+namespace mid
+{
+framework::DataProcessorSpec getFilteringBCSpec(bool useMC = true, std::string_view inDesc = "FDATA");
+}
+} // namespace o2
+
+#endif // O2_MID_FILTERINGBCSPEC_H

--- a/Detectors/MUON/MID/Workflow/src/FilteringBCSpec.cxx
+++ b/Detectors/MUON/MID/Workflow/src/FilteringBCSpec.cxx
@@ -1,0 +1,122 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file   MID/Workflow/src/FilteringBCSpec.cxx
+/// \brief  MID filtering spec
+/// \author Diego Stocco <Diego.Stocco at cern.ch>
+/// \date   16 March 2022
+
+#include "MIDWorkflow/FilteringBCSpec.h"
+
+#include <vector>
+#include <gsl/gsl>
+#include <fmt/format.h>
+#include "Framework/CCDBParamSpec.h"
+#include "Framework/Output.h"
+#include "Framework/Task.h"
+#include "Framework/WorkflowSpec.h"
+#include "DataFormatsMID/ColumnData.h"
+#include "DataFormatsMID/ROFRecord.h"
+#include "DataFormatsMID/MCLabel.h"
+#include "DetectorsBase/GRPGeomHelper.h"
+#include "SimulationDataFormat/MCTruthContainer.h"
+#include "MIDFiltering/FiltererBC.h"
+#include "MIDFiltering/FiltererBCParam.h"
+#include "MIDSimulation/DigitsMerger.h"
+#include "MIDWorkflow/ColumnDataSpecsUtils.h"
+
+namespace of = o2::framework;
+
+namespace o2
+{
+namespace mid
+{
+
+class FilteringBCDeviceDPL
+{
+ public:
+  FilteringBCDeviceDPL(std::shared_ptr<o2::base::GRPGeomRequest> gr, bool useMC, std::vector<of::OutputSpec> outputSpecs) : mGGCCDBRequest(gr), mUseMC(useMC)
+  {
+    mOutputs = specs::buildOutputs(outputSpecs);
+  }
+
+  void init(of::InitContext& ic)
+  {
+    o2::base::GRPGeomHelper::instance().setRequest(mGGCCDBRequest);
+    mFiltererBC.setBCDiffLow(FiltererBCParam::Instance().maxBCDiffLow);
+    mFiltererBC.setBCDiffHigh(FiltererBCParam::Instance().maxBCDiffHigh);
+    mFiltererBC.setSelectOnly(FiltererBCParam::Instance().selectOnly);
+  }
+
+  void finaliseCCDB(of::ConcreteDataMatcher matcher, void* obj)
+  {
+    if (o2::base::GRPGeomHelper::instance().finaliseCCDB(matcher, obj)) {
+      LOG(info) << "Update Bunch Filling for MID";
+      mFiltererBC.setBunchFilling(o2::base::GRPGeomHelper::instance().getGRPLHCIF()->getBunchFilling());
+    }
+  }
+
+  void run(of::ProcessingContext& pc)
+  {
+    updateTimeDependentParams(pc);
+
+    auto data = specs::getData(pc, "mid_filter_BC_in", EventType::Standard);
+    auto inROFRecords = specs::getRofs(pc, "mid_filter_BC_in", EventType::Standard);
+
+    auto inMCContainer = mUseMC ? specs::getLabels(pc, "mid_filter_BC_in") : nullptr;
+
+    auto filteredROFs = mFiltererBC.process(inROFRecords);
+    mDigitsMerger.process(data, filteredROFs, inMCContainer.get());
+
+    pc.outputs().snapshot(mOutputs[0], mDigitsMerger.getColumnData());
+    pc.outputs().snapshot(mOutputs[1], mDigitsMerger.getROFRecords());
+    if (mUseMC) {
+      pc.outputs().snapshot(mOutputs[2], mDigitsMerger.getMCContainer());
+    }
+  }
+
+ private:
+  void updateTimeDependentParams(o2::framework::ProcessingContext& pc)
+  {
+    // Triggers finalizeCCDB
+    o2::base::GRPGeomHelper::instance().checkUpdates(pc);
+  }
+
+  std::shared_ptr<o2::base::GRPGeomRequest> mGGCCDBRequest;
+  bool mUseMC{false};
+  FiltererBC mFiltererBC;
+  DigitsMerger mDigitsMerger;
+  std::vector<of::Output> mOutputs;
+};
+
+of::DataProcessorSpec getFilteringBCSpec(bool useMC, std::string_view inDesc)
+{
+
+  auto inputSpecs = specs::buildInputSpecs("mid_filter_BC_in", inDesc, useMC);
+  auto ggRequest = std::make_shared<o2::base::GRPGeomRequest>(false,                          // orbitResetTime
+                                                              false,                          // GRPECS=true
+                                                              true,                           // GRPLHCIF
+                                                              false,                          // GRPMagField
+                                                              false,                          // askMatLUT
+                                                              o2::base::GRPGeomRequest::None, // geometry
+                                                              inputSpecs,
+                                                              false);
+
+  auto outputSpecs = specs::buildStandardOutputSpecs("mid_filter_BC_out", "BDATA", useMC);
+
+  return of::DataProcessorSpec{
+    "MIDFilteringBC",
+    {inputSpecs},
+    {outputSpecs},
+    of::AlgorithmSpec{of::adaptFromTask<o2::mid::FilteringBCDeviceDPL>(ggRequest, useMC, outputSpecs)}};
+}
+} // namespace mid
+} // namespace o2


### PR DESCRIPTION
The filtering is not activated by default. This possibility is mainly useful for testing purposes.
The commits are meant to be atomic: please do not squash