### PR TITLE
MCH: add (empty) error map to new clustering

### DIFF
--- a/Detectors/MUON/MCH/Clustering/include/MCHClustering/ClusterConfig.h
+++ b/Detectors/MUON/MCH/Clustering/include/MCHClustering/ClusterConfig.h
@@ -62,7 +62,7 @@ struct ClusterConfig {
     debug = 0x3   ///< Ful details
   };
   VerboseMode fittingLog = no;
-  VerboseMode processingLog = info; // Global
+  VerboseMode processingLog = no;
   VerboseMode padMappingLog = no;
   VerboseMode groupsLog = no;
   VerboseMode EMLocalMaxLog = no;


### PR DESCRIPTION
@grasseau the ErrorMap message is now required, following #10716, so this PR adds it the new clustering, but does not actually fill it. 

I also decreased back the default logging level of the clustering, to get quieter logs ;-)
 