### PR TITLE
ITS Pulse length scan + new run type IDs + new CDW versions

### DIFF
--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdCalibratorSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdCalibratorSpec.h
@@ -24,6 +24,7 @@
 
 #include <iostream>
 #include <fstream>
+#include <sstream>
 
 // Boost library for easy access of host name
 #include <boost/asio/ip/host_name.hpp>
@@ -51,6 +52,7 @@
 #include "TTree.h"
 #include "TH1F.h"
 #include "TF1.h"
+#include "TFile.h"
 
 using namespace o2::framework;
 using namespace o2::itsmft;
@@ -64,23 +66,24 @@ int nInj = 50;
 
 // List of the possible run types for reference
 enum RunTypes {
-  THR_SCAN = 42,
-  THR_SCAN_SHORT = 43,
-  THR_SCAN_SHORT_33 = 45,
-  THR_SCAN_SHORT_2_10HZ = 46,
-  THR_SCAN_SHORT_100HZ = 101,
-  THR_SCAN_SHORT_200HZ = 102,
-  VCASN150 = 61,
-  VCASN100 = 81,
-  VCASN100_100HZ = 103,
-  VCASN130 = 135,
-  ITHR150 = 62,
-  ITHR100 = 82,
-  ITHR100_100HZ = 104,
-  ITHR130 = 136,
-  DIGITAL_SCAN = 44,
-  DIGITAL_SCAN_100HZ = 105,
-  ANALOGUE_SCAN = 63,
+  THR_SCAN = 15,
+  THR_SCAN_SHORT = 2,
+  THR_SCAN_SHORT_33 = 16,
+  THR_SCAN_SHORT_2_10HZ = 18,
+  THR_SCAN_SHORT_100HZ = 19,
+  THR_SCAN_SHORT_200HZ = 20,
+  VCASN150 = 23,
+  VCASN100 = 10,
+  VCASN100_100HZ = 21,
+  VCASN130 = 22,
+  ITHR150 = 27,
+  ITHR100 = 11,
+  ITHR100_100HZ = 25,
+  ITHR130 = 26,
+  DIGITAL_SCAN = 13,
+  DIGITAL_SCAN_100HZ = 31,
+  ANALOGUE_SCAN = 14,
+  PULSELENGTH_SCAN = 32,
   END_RUN = 0
 };
 
@@ -152,6 +155,7 @@ class ITSThresholdCalibrator : public Task
   short int vThreshold[N_COL];
   bool vSuccess[N_COL];
   unsigned char vNoise[N_COL];
+  short int vStrobeDel[N_COL];
 
   // Initialize pointers for doing error function fits
   TH1F* mFitHist = nullptr;
@@ -160,6 +164,7 @@ class ITSThresholdCalibrator : public Task
   // Some private helper functions
   // Helper functions related to the running over data
   void extractAndUpdate(const short int&, const short int&);
+  void calculatePulseParams(const short int&, const short int&);
   void extractThresholdRow(const short int&, const short int&);
   void finalizeOutput();
 
@@ -168,8 +173,8 @@ class ITSThresholdCalibrator : public Task
   // Helper functions related to threshold extraction
   void initThresholdTree(bool recreate = true);
   bool findUpperLower(const unsigned short int*, const short int&, short int&, short int&, bool);
-  bool findThreshold(const unsigned short int*, const float*, short int&, float&, float&);
-  bool findThresholdFit(const unsigned short int*, const float*, const short int&, float&, float&);
+  bool findThreshold(const short int&, const unsigned short int*, const float*, short int&, float&, float&);
+  bool findThresholdFit(const short int&, const unsigned short int*, const float*, const short int&, float&, float&);
   bool findThresholdDerivative(const unsigned short int*, const float*, const short int&, float&, float&);
   bool findThresholdHitcounting(const unsigned short int*, const float*, const short int&, float&);
   bool isScanFinished(const short int&, const short int&, const short int&);
@@ -180,6 +185,9 @@ class ITSThresholdCalibrator : public Task
   void addDatabaseEntry(const short int&, const char*, const float&,
                         const float&, const float&, const float&, const float&, bool);
   void sendToAggregator(EndOfStreamContext*);
+
+  // Utils
+  std::vector<short int> getIntegerVect(std::string&);
 
   std::string mSelfName;
   std::string mDictName;
@@ -205,6 +213,8 @@ class ITSThresholdCalibrator : public Task
   // Either "T" for threshold, "V" for VCASN, or "I" for ITHR
   char mScanType = '\0';
   short int mMin = -1, mMax = -1;
+  short int mStep = 1;
+  short int mStrobeWindow = 5; // 5 means 5*25ns = 125 ns
 
   // Get threshold method (fit == 1, derivative == 0, or hitcounting == 2)
   char mFitType = -1;
@@ -220,6 +230,9 @@ class ITSThresholdCalibrator : public Task
   o2::dcs::DCSconfigObject_t mPixStat;
   // DCS config object shipped only to QC to know when scan is done
   o2::dcs::DCSconfigObject_t mChipDoneQc;
+
+  // CDW version
+  short int mCdwVersion = 0; // for now: v0, v1
 
   // Flag to check if endOfStream is available
   bool mCheckEos = false;
@@ -253,7 +266,9 @@ class ITSThresholdCalibrator : public Task
   bool saveTree;
   short int manualMin;
   short int manualMax;
+  short int manualStep = 1;
   std::string manualScanType;
+  short int manualStrobeWindow = 5;
 
   // for CRU_ITS data processing
   bool isCRUITS = false;
@@ -261,6 +276,14 @@ class ITSThresholdCalibrator : public Task
   // map to get confDB id
   std::vector<int>* mConfDBmap;
   short int mConfDBv;
+
+  // Parameters useful to dump s-scurves on disk + file
+  bool isDumpS = false;                // dump or not dump
+  int maxDumpS = -1;                   // maximum number of s-curves to be dumped, default -1 = dump all
+  std::string chipDumpS = "";          // list of comma-separated O2 chipIDs to be dumped, default is empty = dump all
+  int dumpCounterS[24120] = {0};       // count dumps for every chip
+  TFile* fileDumpS;                    // file where to store the s-curves on disk
+  std::vector<short int> chipDumpList; // vector of chips to dump
 };
 
 // Create a processor spec

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdCalibratorSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/ThresholdCalibratorSpec.h
@@ -76,6 +76,7 @@ enum RunTypes {
   VCASN100 = 10,
   VCASN100_100HZ = 21,
   VCASN130 = 22,
+  VCASNBB = 24,
   ITHR150 = 27,
   ITHR100 = 11,
   ITHR100_100HZ = 25,

--- a/Detectors/ITSMFT/ITS/workflow/src/ThresholdAggregatorSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ThresholdAggregatorSpec.cxx
@@ -123,7 +123,7 @@ void ITSThresholdAggregator::finalize(EndOfStreamContext* ec)
   std::string ft = this->mFitType == 0 ? "derivative" : this->mFitType == 1 ? "fit"
                                                       : this->mFitType == 2 ? "hitcounting"
                                                                             : "null";
-  if (mScanType == 'D' || mScanType == 'A') {
+  if (mScanType == 'D' || mScanType == 'A' || mScanType == 'P') {
     ft = "null";
   }
 
@@ -144,6 +144,7 @@ void ITSThresholdAggregator::finalize(EndOfStreamContext* ec)
                                                     : mScanType == 'D' ? "DIG"
                                                     : mScanType == 'A' ? "ANA"
                                                     : mScanType == 'T' ? "THR"
+                                                    : mScanType == 'P' ? "PULSELENGTH"
                                                                        : "NULL";
   o2::ccdb::CcdbObjectInfo info((path + name_str), "threshold_map", "calib_scan.root", md, tstart, tend);
   o2::ccdb::CcdbObjectInfo info_pixtyp((path + name_str), "threshold_map", "calib_scan.root", md, tstart, tend);
@@ -182,8 +183,11 @@ void ITSThresholdAggregator::finalize(EndOfStreamContext* ec)
       ec->outputs().snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "ANA", 0}, *image);
       ec->outputs().snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "ANA", 0}, info);
 
-      ec->outputs().snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "ANA", 0}, *image_pixtyp);
-      ec->outputs().snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "ANA", 0}, info_pixtyp);
+      ec->outputs().snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "ANA", 1}, *image_pixtyp);
+      ec->outputs().snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "ANA", 1}, info_pixtyp);
+    } else if (this->mScanType == 'P') {
+      ec->outputs().snapshot(Output{o2::calibration::Utils::gDataOriginCDBPayload, "PULSELENGTH", 0}, *image);
+      ec->outputs().snapshot(Output{o2::calibration::Utils::gDataOriginCDBWrapper, "PULSELENGTH", 0}, info);
     } else {
       LOG(error) << "Nothing sent to ccdb-populator, mScanType" << mScanType << "does not match any known scan type";
     }
@@ -283,6 +287,9 @@ DataProcessorSpec getITSThresholdAggregatorSpec()
 
   outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "ANA"});
   outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "ANA"});
+
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "PULSELENGTH"});
+  outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "PULSELENGTH"});
 
   return DataProcessorSpec{
     "its-aggregator",

--- a/Detectors/ITSMFT/ITS/workflow/src/ThresholdCalibratorSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ThresholdCalibratorSpec.cxx
@@ -713,9 +713,10 @@ void ITSThresholdCalibrator::setRunType(const short int& runtype)
     this->N_RANGE = 51;
     this->mCheckExactRow = true;
 
-  } else if (runtype == VCASN150 || runtype == VCASN100 || runtype == VCASN100_100HZ || runtype == VCASN130) {
+  } else if (runtype == VCASN150 || runtype == VCASN100 || runtype == VCASN100_100HZ || runtype == VCASN130 || runtype == VCASNBB) {
     // VCASN tuning for different target thresholds
     // Store average VCASN for each chip into CCDB
+    // ATTENTION: with back bias (VCASNBB) put max vcasn to 130 (default is 80)
     // 4 rows per chip
     this->mScanType = 'V';
     this->mMin = inMinVcasn; // 30 is the default

--- a/Detectors/ITSMFT/ITS/workflow/src/ThresholdCalibratorSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/ThresholdCalibratorSpec.cxx
@@ -171,6 +171,12 @@ void ITSThresholdCalibrator::init(InitContext& ic)
     } catch (std::exception const& e) {
       throw std::runtime_error("Please specify if you want to save the ROOT trees, mandatory in manual mode");
     }
+
+    // this is not mandatory since it's 1 by default
+    manualStep = ic.options().get<short int>("manual-step");
+
+    // this is not mandatory since it's 5 by default
+    manualStrobeWindow = ic.options().get<short int>("manual-strobewindow");
   }
 
   // Flag to enable the analysis of CRU_ITS data
@@ -189,7 +195,44 @@ void ITSThresholdCalibrator::init(InitContext& ic)
   mgr.setTimestamp(ts);
   mConfDBmap = mgr.get<std::vector<int>>("ITS/Calib/Confdbmap");
 
+  // Parameters to dump s-curves on disk
+  isDumpS = ic.options().get<bool>("dump-scurves");
+  maxDumpS = ic.options().get<int>("max-dump");
+  chipDumpS = ic.options().get<std::string>("chip-dump"); // comma-separated list of chips
+  chipDumpList = getIntegerVect(chipDumpS);
+  if (isDumpS && mFitType != FIT) {
+    LOG(error) << "S-curve dump enabled but `fittype` is not fit. Please check";
+  }
+  if (isDumpS) {
+    fileDumpS = TFile::Open(Form("s-curves_%d.root", mChipModSel), "RECREATE"); // in case of multiple processes, every process will have it's own file
+    if (maxDumpS < 0) {
+      LOG(info) << "`max-dump` " << maxDumpS << ". Dumping all s-curves";
+    } else {
+      LOG(info) << "`max-dump` " << maxDumpS << ". Dumping " << maxDumpS << " s-curves";
+    }
+    if (!chipDumpList.size()) {
+      LOG(info) << "Dumping s-curves for all chips";
+    } else {
+      LOG(info) << "Dumping s-curves for chips: " << chipDumpS;
+    }
+  }
+
   return;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Convert comma-separated list of integers to a vector of int
+std::vector<short int> ITSThresholdCalibrator::getIntegerVect(std::string& s)
+{
+  std::stringstream ss(s);
+  std::vector<short int> result;
+  char ch;
+  short int tmp;
+  while (ss >> tmp) {
+    result.push_back(tmp);
+    ss >> ch;
+  }
+  return result;
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -224,8 +267,11 @@ void ITSThresholdCalibrator::initThresholdTree(bool recreate /*=true*/)
     this->mThresholdTree->Branch("thr", &vThreshold, "vThreshold[1024]/S");
     this->mThresholdTree->Branch("noise", &vNoise, "vNoise[1024]/b");
     this->mThresholdTree->Branch("success", &vSuccess, "vSuccess[1024]/O");
-  } else { // this->mScanType == 'D' and this->mScanType == 'A'
+  } else if (mScanType == 'D' || mScanType == 'A') { // this->mScanType == 'D' and this->mScanType == 'A'
     this->mThresholdTree->Branch("n_hits", &vThreshold, "vThreshold[1024]/S");
+  } else if (mScanType == 'P') {
+    this->mThresholdTree->Branch("n_hits", &vThreshold, "vThreshold[1024]/S");
+    this->mThresholdTree->Branch("strobedel", &vStrobeDel, "vStrobeDel[1024]/S");
   }
 
   return;
@@ -293,7 +339,7 @@ bool ITSThresholdCalibrator::findUpperLower(
 //////////////////////////////////////////////////////////////////////////////
 // Main findThreshold function which calls one of the three methods
 bool ITSThresholdCalibrator::findThreshold(
-  const unsigned short int* data, const float* x, short int& NPoints,
+  const short int& chipID, const unsigned short int* data, const float* x, short int& NPoints,
   float& thresh, float& noise)
 {
   bool success = false;
@@ -304,7 +350,7 @@ bool ITSThresholdCalibrator::findThreshold(
       break;
 
     case FIT: // Fit method
-      success = this->findThresholdFit(data, x, NPoints, thresh, noise);
+      success = this->findThresholdFit(chipID, data, x, NPoints, thresh, noise);
       break;
 
     case HITCOUNTING: // Hit-counting method
@@ -323,7 +369,7 @@ bool ITSThresholdCalibrator::findThreshold(
 // NPoints is the length of both arrays.
 // thresh, noise, chi2 pointers are updated with results from the fit
 bool ITSThresholdCalibrator::findThresholdFit(
-  const unsigned short int* data, const float* x, const short int& NPoints,
+  const short int& chipID, const unsigned short int* data, const float* x, const short int& NPoints,
   float& thresh, float& noise)
 {
   // Find lower & upper values of the S-curve region
@@ -334,6 +380,18 @@ bool ITSThresholdCalibrator::findThresholdFit(
       LOG(warning) << "Start-finding unsuccessful: (lower, upper) = ("
                    << lower << ", " << upper << ")";
     }
+
+    if (isDumpS && (dumpCounterS[chipID] < maxDumpS || maxDumpS < 0)) { // save bad s-curves
+      for (int i = 0; i < NPoints; i++) {
+        this->mFitHist->SetBinContent(i + 1, data[i]);
+      }
+      fileDumpS->cd();
+      mFitHist->Write();
+    }
+    if (isDumpS) {
+      dumpCounterS[chipID]++;
+    }
+
     return false;
   }
   float start = (this->mX[upper] + this->mX[lower]) / 2;
@@ -354,6 +412,13 @@ bool ITSThresholdCalibrator::findThresholdFit(
   this->mFitFunction->SetParameter(1, 8);
 
   this->mFitHist->Fit("mFitFunction", "RQL");
+  if (isDumpS && (dumpCounterS[chipID] < maxDumpS || maxDumpS < 0)) { // save good s-curves
+    fileDumpS->cd();
+    mFitHist->Write();
+  }
+  if (isDumpS) {
+    dumpCounterS[chipID]++;
+  }
 
   noise = this->mFitFunction->GetParameter(1);
   thresh = this->mFitFunction->GetParameter(0);
@@ -466,7 +531,18 @@ void ITSThresholdCalibrator::extractThresholdRow(const short int& chipID, const 
         this->mDeadPixID[chipID].push_back(col_i * 1000 + row);
       }
     }
-  } else {
+  } else if (this->mScanType == 'P') {
+    // Loop over all columns (pixels) in the row
+    for (short int sdel_i = 0; sdel_i < this->N_RANGE; sdel_i++) {
+      for (short int col_i = 0; col_i < this->N_COL; col_i++) {
+        vChipid[col_i] = chipID;
+        vRow[col_i] = row;
+        vThreshold[col_i] = this->mPixelHits[chipID][row][col_i][sdel_i];
+        vStrobeDel[col_i] = (sdel_i * this->mStep) + 1; // +1 because a delay of n correspond to a real delay of n+1 (from ALPIDE manual)
+      }
+      this->saveThreshold();
+    }
+  } else { // threshold, vcasn, ithr
 
 #ifdef WITH_OPENMP
     omp_set_num_threads(mNThreads);
@@ -478,7 +554,10 @@ void ITSThresholdCalibrator::extractThresholdRow(const short int& chipID, const 
       // Do the threshold fit
       float thresh = 0., noise = 0.;
       bool success = false;
-      success = this->findThreshold(&(this->mPixelHits[chipID][row][col_i][0]),
+      if (isDumpS) { // already protected for multi-thread in the init
+        mFitHist->SetName(Form("scurve_chip%d_row%d_col%d", chipID, row, col_i));
+      }
+      success = this->findThreshold(chipID, &(this->mPixelHits[chipID][row][col_i][0]),
                                     this->mX, N_RANGE, thresh, noise);
 
       vChipid[col_i] = chipID;
@@ -490,18 +569,20 @@ void ITSThresholdCalibrator::extractThresholdRow(const short int& chipID, const 
   }
 
   // Saves threshold information to internal memory
-  this->saveThreshold();
+  if (mScanType != 'P') {
+    this->saveThreshold();
+  }
 }
 
 //////////////////////////////////////////////////////////////////////////////
 void ITSThresholdCalibrator::saveThreshold()
 {
   // In the case of a full threshold scan, write to TTree
-  if (this->mScanType == 'T' || this->mScanType == 'D' || this->mScanType == 'A') {
+  if (this->mScanType == 'T' || this->mScanType == 'D' || this->mScanType == 'A' || this->mScanType == 'P') {
     this->mThresholdTree->Fill();
   }
 
-  if (this->mScanType != 'D' && this->mScanType != 'A') {
+  if (this->mScanType != 'D' && this->mScanType != 'A' && this->mScanType != 'P') {
     // Save info in a map for later averaging
     int sumT = 0, sumSqT = 0, sumN = 0, sumSqN = 0;
     int countSuccess = 0, countUnsuccess = 0;
@@ -667,12 +748,22 @@ void ITSThresholdCalibrator::setRunType(const short int& runtype)
     this->mScanType = 'A';
     this->initThresholdTree();
     this->mFitType = NO_FIT;
-    this->mScanType = 'A';
     this->mMin = 0;
     this->mMax = 0;
     this->N_RANGE = mMax - mMin + 1;
     this->mCheckExactRow = false;
 
+  } else if (runtype == PULSELENGTH_SCAN) {
+    // Pulse length scan
+    this->mScanType = 'P';
+    this->initThresholdTree();
+    this->mFitType = NO_FIT;
+    this->mMin = 0;
+    this->mMax = 400; // strobe delay goes from 0 to 400 (included) in steps of 4
+    this->mStep = 4;
+    this->mStrobeWindow = 5;
+    this->N_RANGE = (mMax - mMin) / mStep + 1;
+    this->mCheckExactRow = true;
   } else {
     // No other run type recognized by this workflow
     LOG(warning) << "Runtype " << runtype << " not recognized by calibration workflow.";
@@ -681,11 +772,13 @@ void ITSThresholdCalibrator::setRunType(const short int& runtype)
       this->mScanType = manualScanType[0];
       this->mMin = manualMin;
       this->mMax = manualMax;
-      this->N_RANGE = mMax - mMin + 1;
+      this->mStep = manualStep;                 // 1 by default
+      this->mStrobeWindow = manualStrobeWindow; // 5 = 125 ns by default
+      this->N_RANGE = (mMax - mMin) / mStep + 1;
       if (saveTree) {
         this->initThresholdTree();
       }
-      this->mFitType = (mScanType == 'D' || mScanType == 'A') ? NO_FIT : mFitType;
+      this->mFitType = (mScanType == 'D' || mScanType == 'A' || mScanType == 'P') ? NO_FIT : mFitType;
       this->mCheckExactRow = (mScanType == 'D' || mScanType == 'A') ? false : true;
     } else {
       throw runtype;
@@ -693,7 +786,7 @@ void ITSThresholdCalibrator::setRunType(const short int& runtype)
   }
 
   this->mX = new float[N_RANGE];
-  for (short int i = this->mMin; i <= this->mMax; i++) {
+  for (short int i = this->mMin; i <= this->mMax / mStep; i++) {
     this->mX[i - this->mMin] = (float)i + 0.5;
   }
 
@@ -706,8 +799,8 @@ void ITSThresholdCalibrator::setRunType(const short int& runtype)
 
     // Initialize correct fit function for the scan type
     this->mFitFunction = (this->mScanType == 'I')
-                           ? new TF1("mFitFunction", erf_ithr, 0, 1500, 2)
-                           : new TF1("mFitFunction", erf, 3, 1500, 2);
+                           ? new TF1("mFitFunction", erf_ithr, mMin, mMax, 2)
+                           : new TF1("mFitFunction", erf, mScanType == 'T' ? 3 : mMin, mMax, 2);
     this->mFitFunction->SetParName(0, "Threshold");
     this->mFitFunction->SetParName(1, "Noise");
   }
@@ -728,11 +821,69 @@ bool ITSThresholdCalibrator::isScanFinished(const short int& chipID, const short
 }
 
 //////////////////////////////////////////////////////////////////////////////
+// Calculate pulse parameters: time over threshold, rise time, ...
+void ITSThresholdCalibrator::calculatePulseParams(const short int& chipID, const short int& row)
+{
+
+  int rt_mindel = -1, rt_maxdel = -1, tot_mindel = -1, tot_maxdel = -1;
+  int sumRt = 0, sumSqRt = 0, countRt = 0, sumTot = 0, sumSqTot = 0, countTot = 0;
+  for (short int col_i = 0; col_i < this->N_COL; col_i++) {
+    for (short int sdel_i = 0; sdel_i < this->N_RANGE; sdel_i++) {
+      if (mPixelHits[chipID][row][col_i][sdel_i] > 0 && mPixelHits[chipID][row][col_i][sdel_i] < nInj && rt_mindel < 0) { // from left, the last bin with 0 hits or the first with some hits
+        rt_mindel = sdel_i > 0 ? ((sdel_i - 1) * mStep) + 1 : (sdel_i * mStep) + 1;                                       // + 1 because if delay = n, we get n+1 in reality (ALPIDE feature)
+      }
+      if (mPixelHits[chipID][row][col_i][sdel_i] == nInj) {
+        rt_maxdel = (sdel_i * mStep) + 1;
+        tot_mindel = (sdel_i * mStep) + 1;
+        break;
+      }
+    }
+
+    for (short int sdel_i = N_RANGE - 1; sdel_i >= 0; sdel_i--) { // from right, the first bin with nInj hits
+      if (mPixelHits[chipID][row][col_i][sdel_i] == nInj) {
+        tot_maxdel = (sdel_i * mStep) + 1;
+        break;
+      }
+    }
+
+    if (tot_maxdel > tot_mindel && tot_mindel >= 0 && tot_maxdel >= 0) {
+      sumTot += tot_maxdel - tot_mindel - (int)(mStrobeWindow / 2);
+      sumSqTot += (tot_maxdel - tot_mindel - (int)(mStrobeWindow / 2)) * (tot_maxdel - tot_mindel - (int)(mStrobeWindow / 2));
+      countTot++;
+    }
+
+    if (rt_maxdel > rt_mindel && rt_maxdel > 0) {
+      if (rt_mindel < 0) {
+        sumRt += mStep + (int)(mStrobeWindow / 2); // resolution -> in case the rise is "instantaneous"
+        sumSqRt += (mStep + (int)(mStrobeWindow / 2)) * (mStep + (int)(mStrobeWindow / 2));
+      } else {
+        sumRt += rt_maxdel - rt_mindel + (int)(mStrobeWindow / 2);
+        sumSqRt += (rt_maxdel - rt_mindel + (int)(mStrobeWindow / 2)) * (rt_maxdel - rt_mindel + (int)(mStrobeWindow / 2));
+      }
+      countRt++;
+    }
+
+    rt_mindel = -1;
+    rt_maxdel = -1;
+    tot_maxdel = -1;
+    tot_mindel = -1;
+  }
+  // Store the sums and counters
+  std::array<long int, 6> dataSum{{sumRt, sumSqRt, sumTot, sumSqTot, countRt, countTot}};
+  if (!(this->mThresholds.count(chipID))) {
+    this->mThresholds[chipID] = dataSum;
+  } else {
+    std::array<long int, 6> dataAll{{this->mThresholds[chipID][0] + dataSum[0], this->mThresholds[chipID][1] + dataSum[1], this->mThresholds[chipID][2] + dataSum[2], this->mThresholds[chipID][3] + dataSum[3], this->mThresholds[chipID][4] + dataSum[4], this->mThresholds[chipID][5] + dataSum[5]}};
+    this->mThresholds[chipID] = dataAll;
+  }
+}
+
+//////////////////////////////////////////////////////////////////////////////
 // Extract thresholds and update memory
 void ITSThresholdCalibrator::extractAndUpdate(const short int& chipID, const short int& row)
 {
   // In threshold scan case, reset mThresholdTree before writing to a new file
-  if ((this->mScanType == 'T' || this->mScanType == 'D' || this->mScanType == 'A') && ((this->mRowCounter)++ == N_ROWS_PER_FILE)) {
+  if ((this->mScanType == 'T' || this->mScanType == 'D' || this->mScanType == 'A' || this->mScanType == 'P') && ((this->mRowCounter)++ == N_ROWS_PER_FILE)) {
     // Finalize output and create a new TTree and ROOT file
     this->finalizeOutput();
     this->initThresholdTree();
@@ -761,7 +912,6 @@ void ITSThresholdCalibrator::run(ProcessingContext& pc)
 
   // Store some lengths for convenient looping
   const unsigned int nROF = (unsigned int)ROFs.size();
-
   // Loop over readout frames (usually only 1, sometimes 2)
   for (unsigned int iROF = 0; iROF < nROF; iROF++) {
 
@@ -784,8 +934,11 @@ void ITSThresholdCalibrator::run(ProcessingContext& pc)
         }
 
         if (this->mRunType == -1) {
-          short int runtype = isCRUITS ? -2 : ((short int)(calib.calibUserField >> 24)) & 0xff;
-          mConfDBv = ((short int)(calib.calibUserField >> 32)) & 0xffff; // confDB version
+          mCdwVersion = isCRUITS ? 0 : ((short int)(calib.calibUserField >> 45)) & 0x7;
+          LOG(info) << "CDW version: " << mCdwVersion;
+          short int runtype = isCRUITS ? -2 : !mCdwVersion ? ((short int)(calib.calibUserField >> 24)) & 0xff
+                                                           : ((short int)(calib.calibUserField >> 9)) & 0x7f;
+          mConfDBv = !mCdwVersion ? ((short int)(calib.calibUserField >> 32)) & 0xffff : ((short int)(calib.calibUserField >> 32)) & 0x1fff; // confDB version
           this->setRunType(runtype);
           LOG(info) << "Calibrator will ship these run parameters to aggregator:";
           LOG(info) << "Run type  : " << mRunType;
@@ -793,19 +946,22 @@ void ITSThresholdCalibrator::run(ProcessingContext& pc)
           LOG(info) << "Fit type  : " << std::to_string(mFitType);
           LOG(info) << "DB version: " << mConfDBv;
         }
-        this->mRunTypeUp = isCRUITS ? -1 : ((short int)(calib.calibUserField >> 24)) & 0xff;
+        this->mRunTypeUp = isCRUITS ? -1 : !mCdwVersion ? ((short int)(calib.calibUserField >> 24)) & 0xff
+                                                        : ((short int)(calib.calibUserField >> 9)) & 0x7f;
+        ;
         // Divide calibration word (24-bit) by 2^16 to get the first 8 bits
         if (this->mScanType == 'T') {
           // For threshold scan have to subtract from 170 to get charge value
-          charge = isCRUITS ? (short int)((calib.calibUserField >> 16) & 0xff) : (short int)(170 - (calib.calibUserField >> 16) & 0xff);
+          charge = isCRUITS ? (short int)((calib.calibUserField >> 16) & 0xff) : !mCdwVersion ? (short int)(170 - (calib.calibUserField >> 16) & 0xff)
+                                                                                              : (short int)(170 - (calib.calibUserField >> 16) & 0xffff);
         } else if (this->mScanType == 'D' || this->mScanType == 'A') { // Digital scan
           charge = 0;
-        } else { // VCASN or ITHR tuning
-          charge = (short int)((calib.calibUserField >> 16) & 0xff);
+        } else { // VCASN / ITHR tuning and Pulse length scan
+          charge = !mCdwVersion ? (short int)((calib.calibUserField >> 16) & 0xff) : (short int)((calib.calibUserField >> 16) & 0xffff);
         }
 
         // Last 16 bits should be the row (only uses up to 9 bits)
-        row = (short int)(calib.calibUserField & 0xffff);
+        row = !mCdwVersion ? (short int)(calib.calibUserField & 0xffff) : (short int)(calib.calibUserField & 0x1ff);
         // cw counter
         cwcnt = (short int)(calib.calibCounter);
 
@@ -831,7 +987,7 @@ void ITSThresholdCalibrator::run(ProcessingContext& pc)
 
     if (charge > this->mMax || charge < this->mMin) {
       if (this->mVerboseOutput) {
-        LOG(warning) << "CW missing - charge value " << charge << " out of range for min " << this->mMin
+        LOG(warning) << "CW missing - charge/dac/delay value " << charge << " out of range for min " << this->mMin
                      << " and max " << this->mMax << " (range: " << N_RANGE << ")";
       }
     } else {
@@ -882,7 +1038,7 @@ void ITSThresholdCalibrator::run(ProcessingContext& pc)
       }
 
       // loop to count hits from digits
-      short int chgPoint = charge - this->mMin;
+      short int chgPoint = (charge - this->mMin) / mStep;
       for (unsigned int idig = rofIndex; idig < rofIndex + rofNEntries; idig++) {
         auto& d = digits[idig];
         short int chipID = (short int)d.getChipIndex();
@@ -908,7 +1064,17 @@ void ITSThresholdCalibrator::run(ProcessingContext& pc)
           continue;
         }
 
-        if (mScanType != 'D' && mScanType != 'A' && this->isScanFinished(chipID, row, cwcnt)) { // for D and A we do it at the end in finalize()
+        bool passCondition = false;
+        if (isDumpS) {
+          auto fndVal = std::find(chipDumpList.begin(), chipDumpList.end(), chipID);
+          int checkR = (mScanType == 'I') ? mMin : mMax;
+          passCondition = (cwcnt == nInj - 1) && (charge == checkR) && (fndVal != chipDumpList.end() || !chipDumpList.size()); // in this way we dump any s-curve, bad and good
+          LOG(info) << "checkR: " << charge << " counter: " << cwcnt << " checkR: " << checkR << " chipID: " << chipID << " pass: " << passCondition;
+        } else {
+          passCondition = isScanFinished(chipID, row, cwcnt);
+        }
+
+        if (mScanType != 'D' && mScanType != 'A' && mScanType != 'P' && passCondition) { // for D,A,P we do it at the end in finalize()
           this->extractAndUpdate(chipID, row);
           // remove entry for this row whose scan is completed
           mPixelHits[chipID].erase(row);
@@ -987,7 +1153,7 @@ void ITSThresholdCalibrator::addDatabaseEntry(
   this->mp.expandChipInfoHW(chipID, lay, sta, ssta, mod, chipInMod);
 
   char stave[6];
-  snprintf(stave, 6, "L%d_%02d", lay, sta);
+  sprintf(stave, "L%d_%02d", lay, sta);
 
   if (isQC) {
     o2::dcs::addConfigItem(this->mChipDoneQc, "O2ChipID", std::to_string(chipID));
@@ -1099,7 +1265,7 @@ void ITSThresholdCalibrator::addDatabaseEntry(
       o2::dcs::addConfigItem(this->mPixStat, "DcolNos", nDcols);
     }
   }
-  if (this->mScanType != 'D' && this->mScanType != 'A') {
+  if (this->mScanType != 'D' && this->mScanType != 'A' && this->mScanType != 'P') {
     o2::dcs::addConfigItem(this->mTuning, "O2ChipID", std::to_string(chipID));
     o2::dcs::addConfigItem(this->mTuning, "ChipDbID", std::to_string(confDBid));
     o2::dcs::addConfigItem(this->mTuning, name, (strcmp(name, "ITHR") == 0 || strcmp(name, "VCASN") == 0) ? std::to_string((int)avgT) : std::to_string(avgT));
@@ -1109,6 +1275,15 @@ void ITSThresholdCalibrator::addDatabaseEntry(
   if (this->mScanType == 'T') {
     o2::dcs::addConfigItem(this->mTuning, "Noise", std::to_string(avgN));
     o2::dcs::addConfigItem(this->mTuning, "NoiseRms", std::to_string(rmsN));
+  }
+
+  if (this->mScanType == 'P') {
+    o2::dcs::addConfigItem(this->mTuning, "O2ChipID", std::to_string(chipID));
+    o2::dcs::addConfigItem(this->mTuning, "ChipDbID", std::to_string(confDBid));
+    o2::dcs::addConfigItem(this->mTuning, "Tot", std::to_string(avgN));    // time over threshold
+    o2::dcs::addConfigItem(this->mTuning, "TotRms", std::to_string(rmsN)); // time over threshold rms
+    o2::dcs::addConfigItem(this->mTuning, "Rt", std::to_string(avgT));     // rise time
+    o2::dcs::addConfigItem(this->mTuning, "RtRms", std::to_string(rmsT));  // rise time rms
   }
 
   return;
@@ -1280,6 +1455,50 @@ void ITSThresholdCalibrator::finalize(EndOfStreamContext* ec)
         ++it_ineff;
       }
     }
+  } else if (this->mScanType == 'P') { // pulse length scan
+    name = "Pulse";
+    // extract hits for the available row(s)
+    auto itchip = this->mPixelHits.cbegin();
+    while (itchip != mPixelHits.cend()) {
+      if (!this->mCheckEos && this->mRunTypeChip[itchip->first] < nInj) {
+        ++itchip;
+        continue;
+      }
+      LOG(info) << "Extracting hits from strobe delay scan, chip " << itchip->first;
+      auto itrow = this->mPixelHits[itchip->first].cbegin();
+      while (itrow != mPixelHits[itchip->first].cend()) { // in case there are multiple rows, for now it's 1 row
+        this->extractAndUpdate(itchip->first, itrow->first);
+        this->calculatePulseParams(itchip->first, itrow->first);
+        ++itrow;
+      }
+      if (this->mVerboseOutput) {
+        LOG(info) << "Chip " << itchip->first << " hits extracted";
+      }
+      ++itchip;
+    }
+
+    // save averages: create ccdb strings
+    auto it = this->mThresholds.cbegin();
+    while (it != this->mThresholds.cend()) {
+      if (!this->mCheckEos && this->mRunTypeChip[it->first] < nInj) {
+        ++it;
+        continue;
+      }
+      float avgRt, rmsRt, avgTot, rmsTot;
+      avgRt = (!it->second[4]) ? 0. : (float)it->second[0] / (float)it->second[4];
+      rmsRt = (!it->second[4]) ? 0. : (std::sqrt((float)it->second[1] / (float)it->second[4] - avgRt * avgRt)) * 25.;
+      avgRt *= 25.; // times 25ns
+      avgTot = (!it->second[5]) ? 0. : (float)it->second[2] / (float)it->second[5];
+      rmsTot = (!it->second[5]) ? 0. : (std::sqrt((float)it->second[3] / (float)it->second[5] - avgTot * avgTot)) * 25.;
+      avgTot *= 25.; // times 25ns
+      this->addDatabaseEntry(it->first, name, avgRt, rmsRt, avgTot, rmsTot, 1, false);
+      if (!this->mCheckEos) {
+        this->mRunTypeChip[it->first] = 0; // so that this chip will never appear again in the DCSconfigObject_t
+        it = this->mThresholds.erase(it);
+      } else {
+        ++it;
+      }
+    }
   }
 
   if (this->mCheckEos) { // in case of missing EoS, the finalizeOutput is done in stop()
@@ -1357,11 +1576,16 @@ DataProcessorSpec getITSThresholdCalibratorSpec(const ITSCalibInpConf& inpConf)
             {"manual-mode", VariantType::Bool, false, {"Flag to activate the manual mode in case run type is not recognized"}},
             {"manual-min", VariantType::Int, 0, {"Min value of the variable used for the scan: use only in manual mode"}},
             {"manual-max", VariantType::Int, 50, {"Max value of the variable used for the scan: use only in manual mode"}},
+            {"manual-step", VariantType::Int, 1, {"Step value: defines the steps between manual-min and manual-max. Default is 1. Use only in manual mode"}},
             {"manual-scantype", VariantType::String, "T", {"scan type, can be D, T, I, V: use only in manual mode"}},
+            {"manual-strobewindow", VariantType::Int, 5, {"strobe duration in clock cycles, default is 5 = 125 ns: use only in manual mode"}},
             {"save-tree", VariantType::Bool, false, {"Flag to save ROOT tree on disk: use only in manual mode"}},
             {"enable-mpv", VariantType::Bool, false, {"Flag to enable calculation of most-probable value in vcasn/ithr scans"}},
             {"enable-cru-its", VariantType::Bool, false, {"Flag to enable the analysis of raw data on disk produced by CRU_ITS IB commissioning tools"}},
-            {"ninj", VariantType::Int, 50, {"Number of injections per change, default is 50"}}}};
+            {"ninj", VariantType::Int, 50, {"Number of injections per change, default is 50"}},
+            {"dump-scurves", VariantType::Bool, false, {"Dump any s-curve to disk in ROOT file. Works only with fit option."}},
+            {"max-dump", VariantType::Int, -1, {"Maximum number of s-curves to dump in ROOT file per chip. Works with fit option and dump-scurves flag enabled. Default: dump all"}},
+            {"chip-dump", VariantType::String, "", {"Dump s-curves only for these Chip IDs (0 to 24119). If multiple IDs, write them separated by comma. Default is empty string: dump all"}}}};
 }
 } // namespace its
 } // namespace o2


### PR DESCRIPTION
This PR includes mainly

- Pulse length scan in 1D (strobe delay variation)
- New run type IDs
- New CDW (2 versions allowed now)
- few small bugs in analog scan fixed 
- Possibility to dump s-curves + fit on disk for debugging (only for local usage --> no P2)

cc @shahor02 @chiarazampolli: this includes the pulse length scan discussed via email. 