### PR TITLE
Adapt EMC, PHS and CPV to RDHv7

### DIFF
--- a/Detectors/CPV/reconstruction/src/RawReaderMemory.cxx
+++ b/Detectors/CPV/reconstruction/src/RawReaderMemory.cxx
@@ -33,15 +33,11 @@ void RawReaderMemory::setRawMemory(const gsl::span<const char> rawmemory)
 o2::header::RDHAny RawReaderMemory::decodeRawHeader(const void* payloadwords)
 {
   auto headerversion = RDHDecoder::getVersion(payloadwords);
-  if (headerversion == 4) {
-    return o2::header::RDHAny(*reinterpret_cast<const o2::header::RAWDataHeaderV4*>(payloadwords));
-  } else if (headerversion == 5) {
-    return o2::header::RDHAny(*reinterpret_cast<const o2::header::RAWDataHeaderV5*>(payloadwords));
-  } else if (headerversion == 6) {
-    return o2::header::RDHAny(*reinterpret_cast<const o2::header::RAWDataHeaderV6*>(payloadwords));
+  if (headerversion < RDHDecoder::getVersion<o2::header::RDHLowest>() || headerversion > RDHDecoder::getVersion<o2::header::RDHHighest>()) {
+    LOG(error) << "Wrong header version " << headerversion;
+    throw RawErrorType_t::kRDH_DECODING;
   }
-  LOG(error) << "RawReaderMemory::decodeRawHeader() : Unknown RDH version";
-  throw RawErrorType_t::kRDH_DECODING;
+  return {*reinterpret_cast<const o2::header::RDHAny*>(payloadwords)};
 }
 
 void RawReaderMemory::init()

--- a/Detectors/EMCAL/reconstruction/src/RawReaderMemory.cxx
+++ b/Detectors/EMCAL/reconstruction/src/RawReaderMemory.cxx
@@ -33,14 +33,10 @@ void RawReaderMemory::setRawMemory(const gsl::span<const char> rawmemory)
 o2::header::RDHAny RawReaderMemory::decodeRawHeader(const void* payloadwords)
 {
   auto headerversion = RDHDecoder::getVersion(payloadwords);
-  if (headerversion == 4) {
-    return o2::header::RDHAny(*reinterpret_cast<const o2::header::RAWDataHeaderV4*>(payloadwords));
-  } else if (headerversion == 5) {
-    return o2::header::RDHAny(*reinterpret_cast<const o2::header::RAWDataHeaderV5*>(payloadwords));
-  } else if (headerversion == 6) {
-    return o2::header::RDHAny(*reinterpret_cast<const o2::header::RAWDataHeaderV6*>(payloadwords));
+  if (headerversion < RDHDecoder::getVersion<o2::header::RDHLowest>() || headerversion > RDHDecoder::getVersion<o2::header::RDHHighest>()) {
+    throw RawDecodingError(RawDecodingError::ErrorType_t::HEADER_DECODING, mCurrentFEE);
   }
-  throw RawDecodingError(RawDecodingError::ErrorType_t::HEADER_DECODING, mCurrentFEE);
+  return {*reinterpret_cast<const o2::header::RDHAny*>(payloadwords)};
 }
 
 void RawReaderMemory::init()

--- a/Detectors/PHOS/reconstruction/src/RawReaderMemory.cxx
+++ b/Detectors/PHOS/reconstruction/src/RawReaderMemory.cxx
@@ -34,15 +34,11 @@ void RawReaderMemory::setRawMemory(const gsl::span<const char> rawmemory)
 o2::header::RDHAny RawReaderMemory::decodeRawHeader(const void* payloadwords)
 {
   auto headerversion = RDHDecoder::getVersion(payloadwords);
-  if (headerversion == 4) {
-    return o2::header::RDHAny(*reinterpret_cast<const o2::header::RAWDataHeaderV4*>(payloadwords));
-  } else if (headerversion == 5) {
-    return o2::header::RDHAny(*reinterpret_cast<const o2::header::RAWDataHeaderV5*>(payloadwords));
-  } else if (headerversion == 6) {
-    return o2::header::RDHAny(*reinterpret_cast<const o2::header::RAWDataHeaderV6*>(payloadwords));
+  if (headerversion < RDHDecoder::getVersion<o2::header::RDHLowest>() || headerversion > RDHDecoder::getVersion<o2::header::RDHHighest>()) {
+    LOG(error) << "Wrong header version " << headerversion;
+    throw RawDecodingError::ErrorType_t::HEADER_DECODING;
   }
-  LOG(error) << "Wrong header version " << int(headerversion);
-  throw RawDecodingError::ErrorType_t::HEADER_DECODING;
+  return {*reinterpret_cast<const o2::header::RDHAny*>(payloadwords)};
 }
 
 void RawReaderMemory::init()


### PR DESCRIPTION
This just makes decoders to accept RDHv7 and optimizes the way RDH is extracted. 

@sevdokim, since the CPV is a CRU detector, it has to implement also the processing of the data w/o 128-bit padding. This is NOT handled by this PR.