### PR TITLE
ITS: Use a single TimeFrame for reco instance

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Vertexer.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Vertexer.h
@@ -89,11 +89,6 @@ class Vertexer
   TimeFrame* mTimeFrame = nullptr;   /// Observer pointer, not owned by this class
 };
 
-// inline void Vertexer::filterMCTracklets()
-// {
-//   mTraits->computeMCFiltering();
-// }
-
 template <typename... T>
 void Vertexer::initialiseVertexer(T&&... args)
 {
@@ -124,16 +119,6 @@ inline void Vertexer::dumpTraits()
 inline void Vertexer::validateTracklets()
 {
   mTraits->computeTrackletMatching();
-}
-
-inline std::vector<Vertex> Vertexer::exportVertices()
-{
-  std::vector<Vertex> vertices;
-  for (auto& vertex : mTraits->getVertices()) {
-    vertices.emplace_back(o2::math_utils::Point3D<float>(vertex.mX, vertex.mY, vertex.mZ), vertex.mRMS2, vertex.mContributors, vertex.mAvgDistance2);
-    vertices.back().setTimeStamp(vertex.mTimeStamp);
-  }
-  return vertices;
 }
 
 template <typename... T>

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/VertexerTraits.h
@@ -68,13 +68,11 @@ class VertexerTraits
   virtual void computeVertices();
   virtual void adoptTimeFrame(TimeFrame* tf);
   virtual void updateVertexingParameters(const VertexingParameters& vrtPar);
-  // virtual void computeHistVertices();
 
   VertexingParameters getVertexingParameters() const { return mVrtParams; }
   static const std::vector<std::pair<int, int>> selectClusters(const int* indexTable,
                                                                const std::array<int, 4>& selectedBinsRect,
                                                                const IndexTableUtils& utils);
-  std::vector<lightVertex> getVertices() const { return mVertices; }
 
   // utils
   VertexingParameters& getVertexingParameters() { return mVrtParams; }

--- a/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
@@ -158,6 +158,17 @@ int TimeFrame::loadROFrameData(gsl::span<o2::itsmft::ROFRecord> rofs,
                                const itsmft::TopologyDictionary* dict,
                                const dataformats::MCTruthContainer<MCCompLabel>* mcLabels)
 {
+  for (int iLayer{0}; iLayer < mUnsortedClusters.size(); ++iLayer) {
+    mUnsortedClusters[iLayer].clear();
+    mTrackingFrameInfo[iLayer].clear();
+    mClusterExternalIndices[iLayer].clear();
+    mROframesClusters[iLayer].resize(1, 0);
+
+    if (iLayer < 2) {
+      mTrackletsIndexROf[iLayer].clear();
+    }
+  }
+
   GeometryTGeo* geom = GeometryTGeo::Instance();
   geom->fillMatrixCache(o2::math_utils::bit2Mask(o2::math_utils::TransformType::T2L, o2::math_utils::TransformType::L2G));
 
@@ -227,6 +238,10 @@ int TimeFrame::getTotalClusters() const
 void TimeFrame::initialise(const int iteration, const TrackingParameters& trkParam, const int maxLayers)
 {
   if (iteration == 0) {
+    if (maxLayers < trkParam.NLayers) {
+      mROframesPV.resize(1, 0);
+    }
+    mPrimaryVertices.clear();
     mTracks.clear();
     mTracksLabel.clear();
     mLinesLabels.clear();

--- a/Detectors/ITSMFT/ITS/tracking/src/Vertexer.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/Vertexer.cxx
@@ -87,7 +87,7 @@ void Vertexer::adoptTimeFrame(TimeFrame& tf)
 
 void Vertexer::printEpilog(std::function<void(std::string s)> logger, const float total)
 {
-  logger(fmt::format(" - Timeframe {} vertexing completed in: {}ms, using {} thread(s).", mTimeFrameCounter++, total, mTraits->getNThreads()));
+  logger(fmt::format(" - Timeframe {} vertexing completed in: {} ms, using {} thread(s).", mTimeFrameCounter++, total, mTraits->getNThreads()));
 }
 
 } // namespace its

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -336,6 +336,7 @@ void VertexerTraits::computeTrackletMatching()
 
 void VertexerTraits::computeVertices()
 {
+  std::vector<Vertex> vertices;
 #ifdef VTX_DEBUG
   std::vector<std::vector<ClusterLines>> dbg_clusLines(mTimeFrame->getNrof());
 #endif
@@ -412,8 +413,8 @@ void VertexerTraits::computeVertices()
       }
     }
   }
-
   for (int rofId{0}; rofId < mTimeFrame->getNrof(); ++rofId) {
+    vertices.clear();
     std::sort(mTimeFrame->getTrackletClusters(rofId).begin(), mTimeFrame->getTrackletClusters(rofId).end(),
               [](ClusterLines& cluster1, ClusterLines& cluster2) { return cluster1.getSize() > cluster2.getSize(); }); // ensure clusters are ordered by contributors, so that we can cat after the first.
 #ifdef VTX_DEBUG
@@ -437,14 +438,15 @@ void VertexerTraits::computeVertices()
       float rXY{std::hypot(mTimeFrame->getTrackletClusters(rofId)[iCluster].getVertex()[0], mTimeFrame->getTrackletClusters(rofId)[iCluster].getVertex()[1])};
       if (rXY < 1.98 && std::abs(mTimeFrame->getTrackletClusters(rofId)[iCluster].getVertex()[2]) < mVrtParams.maxZPositionAllowed) {
         atLeastOneFound = true;
-        mVertices.emplace_back(mTimeFrame->getTrackletClusters(rofId)[iCluster].getVertex()[0],
-                               mTimeFrame->getTrackletClusters(rofId)[iCluster].getVertex()[1],
-                               mTimeFrame->getTrackletClusters(rofId)[iCluster].getVertex()[2],
-                               mTimeFrame->getTrackletClusters(rofId)[iCluster].getRMS2(),         // Symm matrix. Diagonal: RMS2 components,
+        vertices.emplace_back(o2::math_utils::Point3D<float>(mTimeFrame->getTrackletClusters(rofId)[iCluster].getVertex()[0],
+                                                             mTimeFrame->getTrackletClusters(rofId)[iCluster].getVertex()[1],
+                                                             mTimeFrame->getTrackletClusters(rofId)[iCluster].getVertex()[2]),
+                              mTimeFrame->getTrackletClusters(rofId)[iCluster].getRMS2(),          // Symm matrix. Diagonal: RMS2 components,
                                                                                                    // off-diagonal: square mean of projections on planes.
-                               mTimeFrame->getTrackletClusters(rofId)[iCluster].getSize(),         // Contributors
-                               mTimeFrame->getTrackletClusters(rofId)[iCluster].getAvgDistance2(), // In place of chi2
-                               rofId);
+                              mTimeFrame->getTrackletClusters(rofId)[iCluster].getSize(),          // Contributors
+                              mTimeFrame->getTrackletClusters(rofId)[iCluster].getAvgDistance2()); // In place of chi2
+
+        vertices.back().setTimeStamp(rofId);
         if (mTimeFrame->hasMCinformation()) {
           mTimeFrame->getVerticesLabels().emplace_back();
           for (auto& index : mTimeFrame->getTrackletClusters(rofId)[iCluster].getLabels()) {
@@ -453,13 +455,7 @@ void VertexerTraits::computeVertices()
         }
       }
     }
-    std::vector<Vertex> vertices;
-    for (auto& vertex : mVertices) {
-      vertices.emplace_back(o2::math_utils::Point3D<float>(vertex.mX, vertex.mY, vertex.mZ), vertex.mRMS2, vertex.mContributors, vertex.mAvgDistance2);
-      vertices.back().setTimeStamp(vertex.mTimeStamp);
-    }
     mTimeFrame->addPrimaryVertices(vertices);
-    mVertices.clear();
   }
 #ifdef VTX_DEBUG
   TFile* dbg_file = TFile::Open("artefacts_tf.root", "update");

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -441,7 +441,7 @@ void VertexerTraits::computeVertices()
         vertices.emplace_back(o2::math_utils::Point3D<float>(mTimeFrame->getTrackletClusters(rofId)[iCluster].getVertex()[0],
                                                              mTimeFrame->getTrackletClusters(rofId)[iCluster].getVertex()[1],
                                                              mTimeFrame->getTrackletClusters(rofId)[iCluster].getVertex()[2]),
-                              mTimeFrame->getTrackletClusters(rofId)[iCluster].getRMS2(),          // Symm matrix. Diagonal: RMS2 components,
+                              mTimeFrame->getTrackletClusters(rofId)[iCluster].getRMS2(),          // Symmetric matrix. Diagonal: RMS2 components,
                                                                                                    // off-diagonal: square mean of projections on planes.
                               mTimeFrame->getTrackletClusters(rofId)[iCluster].getSize(),          // Contributors
                               mTimeFrame->getTrackletClusters(rofId)[iCluster].getAvgDistance2()); // In place of chi2

--- a/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/TrackerSpec.h
+++ b/Detectors/ITSMFT/ITS/workflow/include/ITSWorkflow/TrackerSpec.h
@@ -77,6 +77,7 @@ class TrackerDPL : public framework::Task
   std::unique_ptr<o2::gpu::GPUChainITS> mChainITS = nullptr;
   std::unique_ptr<Tracker> mTracker = nullptr;
   std::unique_ptr<Vertexer> mVertexer = nullptr;
+  TimeFrame* mTimeFrame = nullptr;
   const o2::dataformats::MeanVertexObject* mMeanVertex;
   TStopwatch mTimer;
 };


### PR DESCRIPTION
We get TimeFrame object/ptr only once from GPUChain. Then we reset it at each TF processing.
To be carefully evaluated, I tested it locally, it works.
I will do some more tests (e.g. w/w.out meanvertex override).

cc-ing @mpuccio for review.

Edit: as a second minor change, I removed some intermediate translation of the found vertices into lightVertex ones. 
It will save some resources.
