### PR TITLE
Few improvements for stdout

### DIFF
--- a/Detectors/FIT/FV0/workflow/src/ReconstructionSpec.cxx
+++ b/Detectors/FIT/FV0/workflow/src/ReconstructionSpec.cxx
@@ -52,7 +52,6 @@ void ReconstructionDPL::run(ProcessingContext& pc)
   if (mUpdateCCDB) {
     auto caliboffsets = pc.inputs().get<o2::fv0::FV0ChannelTimeCalibrationObject*>("fv0offsets");
     mReco.SetChannelOffset(caliboffsets.get());
-    LOG(info) << "RecoSpec  mReco.SetChannelOffset(&caliboffsets)";
   }
 
   int nDig = digits.size();

--- a/Detectors/GlobalTracking/src/MatchTOF.cxx
+++ b/Detectors/GlobalTracking/src/MatchTOF.cxx
@@ -121,6 +121,7 @@ void MatchTOF::run(const o2::globaltracking::RecoContainer& inp)
   LOGF(info, "Timing prepare FIT data: Cpu: %.3e s Real: %.3e s in %d slots", mTimerTot.CpuTime(), mTimerTot.RealTime(), mTimerTot.Counter() - 1);
 
   mTimerTot.Start();
+  std::array<uint32_t, 18> nMatches = {0};
   for (int sec = o2::constants::math::NSectors; sec--;) {
     mMatchedTracksPairs.clear(); // new sector
     LOG(debug) << "Doing matching for sector " << sec << "...";
@@ -135,9 +136,14 @@ void MatchTOF::run(const o2::globaltracking::RecoContainer& inp)
       mTimerMatchTPC.Stop();
     }
     LOG(debug) << "...done. Now check the best matches";
+    nMatches[sec] = mMatchedTracksPairs.size();
     selectBestMatches();
   }
-
+  std::string nMatchesStr = "Number of pairs matched per sector: ";
+  for (int sec = o2::constants::math::NSectors; sec--;) {
+    nMatchesStr += fmt::format("{} : {} ; ", sec, nMatches[sec]);
+  }
+  LOG(info) << nMatchesStr;
   // re-arrange outputs from constrained/unconstrained to the 4 cases (TPC, ITS-TPC, TPC-TRD, ITS-TPC-TRD) to be implemented as soon as TPC-TRD and ITS-TPC-TRD tracks available
 
   mIsTPCused = false;
@@ -1092,8 +1098,6 @@ void MatchTOF::selectBestMatches()
   }
   ///< define the track-TOFcluster pair per sector
 
-  LOG(info) << "Number of pair matched = " << mMatchedTracksPairs.size();
-
   // first, we sort according to the chi2
   std::sort(mMatchedTracksPairs.begin(), mMatchedTracksPairs.end(), [this](o2::dataformats::MatchInfoTOFReco& a, o2::dataformats::MatchInfoTOFReco& b) { return (a.getChi2() < b.getChi2()); });
   int i = 0;
@@ -1202,8 +1206,6 @@ void MatchTOF::selectBestMatchesHP()
   ///< define the track-TOFcluster pair per sector
   float chi2SeparationCut = 2;
   float chi2S = 3;
-
-  LOG(info) << "Number of pair matched = " << mMatchedTracksPairs.size();
 
   std::vector<o2::dataformats::MatchInfoTOFReco> tmpMatch;
 

--- a/Detectors/MUON/MCH/DigitFiltering/src/DigitFilteringSpec.cxx
+++ b/Detectors/MUON/MCH/DigitFiltering/src/DigitFilteringSpec.cxx
@@ -126,7 +126,7 @@ class DigitFilteringTask
 
     auto labelMsg = mUseMC ? fmt::format("| {} labels (out of {})", oLabels->getNElements(), iLabels->getNElements()) : "";
 
-    LOGP(info, "Kept after filtering : {} rofs (out of {}) | {} digits (out of {}) {}\n",
+    LOGP(info, "Kept after filtering : {} rofs (out of {}) | {} digits (out of {}) {}",
          oRofs.size(), iRofs.size(),
          oDigits.size(), iDigits.size(),
          labelMsg);


### PR DESCRIPTION
@noferini : the new log would be:
```
[1410722:tof-matcher]: [14:30:45][INFO] Number of pairs matched per sector: 17 : 3431 ; 16 : 3640 ; 15 : 3820 ; 14 : 2238 ; 13 : 3940 ; 12 : 4559 ; 11 : 3191 ; 10 : 2986 ; 9 : 4931 ; 8 : 2351 ; 7 : 5450 ; 6 : 5077 ; 5 : 5291 ; 4 : 5109 ; 3 : 4665 ; 2 : 5309 ; 1 : 5705 ; 0 : 4931
```
which is more compact then:
```
[1397752:tof-matcher]: [14:25:04][INFO] Number of pair matched = 3433
[1397752:tof-matcher]: [14:25:05][INFO] Number of pair matched = 3640
[1397752:tof-matcher]: [14:25:05][INFO] Number of pair matched = 3820
[1397752:tof-matcher]: [14:25:05][INFO] Number of pair matched = 2241
[1397752:tof-matcher]: [14:25:05][INFO] Number of pair matched = 3940
[1397752:tof-matcher]: [14:25:06][INFO] Number of pair matched = 4559
[1397752:tof-matcher]: [14:25:06][INFO] Number of pair matched = 3191
[1397752:tof-matcher]: [14:25:06][INFO] Number of pair matched = 2986
[1397752:tof-matcher]: [14:25:07][INFO] Number of pair matched = 4935
[1397752:tof-matcher]: [14:25:07][INFO] Number of pair matched = 2351
[1397752:tof-matcher]: [14:25:07][INFO] Number of pair matched = 5451
[1397752:tof-matcher]: [14:25:07][INFO] Number of pair matched = 5081
[1397752:tof-matcher]: [14:25:08][INFO] Number of pair matched = 5291
[1397752:tof-matcher]: [14:25:08][INFO] Number of pair matched = 5117
[1397752:tof-matcher]: [14:25:08][INFO] Number of pair matched = 4665
[1397752:tof-matcher]: [14:25:09][INFO] Number of pair matched = 5309
[1397752:tof-matcher]: [14:25:09][INFO] Number of pair matched = 5704
[1397752:tof-matcher]: [14:25:09][INFO] Number of pair matched = 4931
```
@aphecetche : I just removed an empty line that is printed.
@jotwinow : the printout from:
```
LOG(info) << "RecoSpec  mReco.SetChannelOffset(&caliboffsets)";
```
was not useful, so I removed it.