### PR TITLE
Add CTP start/end time to GRPECS and its creator

### DIFF
--- a/DataFormats/Parameters/include/DataFormatsParameters/GRPECSObject.h
+++ b/DataFormats/Parameters/include/DataFormatsParameters/GRPECSObject.h
@@ -52,6 +52,14 @@ class GRPECSObject
   timePoint getTimeEnd() const { return mTimeEnd; }
   void setTimeEnd(timePoint t) { mTimeEnd = t; }
 
+  timePoint getTimeStartCTPasSet() const { return mTimeStartCTP; }
+  timePoint getTimeStartCTP() const { return mTimeStartCTP ? mTimeStartCTP : mTimeStart; }
+  void setTimeStartCTP(timePoint t) { mTimeStartCTP = t; }
+
+  timePoint getTimeEndCTPasSet() const { return mTimeEndCTP; }
+  timePoint getTimeEndCTP() const { return mTimeEndCTP ? mTimeEndCTP : mTimeEnd; }
+  void setTimeEndCTP(timePoint t) { mTimeEndCTP = t; }
+
   void setNHBFPerTF(uint32_t n) { mNHBFPerTF = n; }
   uint32_t getNHBFPerTF() const { return mNHBFPerTF; }
 
@@ -129,8 +137,10 @@ class GRPECSObject
   static constexpr bool alwaysTriggeredRO(DetID::ID det) { return DefTriggeredDets[det]; }
 
  private:
-  timePoint mTimeStart = 0; ///< DAQ_time_start entry from DAQ logbook
-  timePoint mTimeEnd = 0;   ///< DAQ_time_end entry from DAQ logbook
+  timePoint mTimeStart = 0;    ///< ECS start time
+  timePoint mTimeEnd = 0;      ///< ECS end time
+  timePoint mTimeStartCTP = 0; ///< CTP start time
+  timePoint mTimeEndCTP = 0;   ///< CTP end time
 
   uint32_t mNHBFPerTF = 128; /// Number of HBFrames per TF
 
@@ -146,7 +156,7 @@ class GRPECSObject
   // detectors which are always readout in triggered mode. Others are continuous by default but exceptionally can be triggered
   static constexpr DetID::mask_t DefTriggeredDets = DetID::getMask(DetID::TRD) | DetID::getMask(DetID::PHS) | DetID::getMask(DetID::CPV) | DetID::getMask(DetID::EMC) | DetID::getMask(DetID::HMP);
 
-  ClassDefNV(GRPECSObject, 5);
+  ClassDefNV(GRPECSObject, 6);
 };
 
 } // namespace parameters

--- a/DataFormats/Parameters/src/GRPECSObject.cxx
+++ b/DataFormats/Parameters/src/GRPECSObject.cxx
@@ -41,7 +41,8 @@ void GRPECSObject::print() const
   };
   std::string rtypName = int(mRunType) < GRPECS::RunType::NRUNTYPES ? GRPECS::RunTypeNames[int(mRunType)].data() : "INVALID";
   printf("Run %d of type %s, period %s, isMC: %d\n", mRun, rtypName.c_str(), mDataPeriod.c_str(), isMC());
-  printf("Start: %s | End: %s\n", timeStr(mTimeStart).c_str(), timeStr(mTimeEnd).c_str());
+  printf("ECS/CTP Start: %s/%s | End: %s/%s\n", timeStr(mTimeStart).c_str(), timeStr(mTimeStartCTP).c_str(),
+         timeStr(mTimeEnd).c_str(), timeStr(mTimeEndCTP).c_str());
   printf("Number of HBF per timframe: %d\n", mNHBFPerTF);
   printf("Detectors: Cont.RO Triggers\n");
   for (auto i = DetID::First; i <= DetID::Last; i++) {

--- a/Detectors/GRP/workflows/src/create-grp-ecs.cxx
+++ b/Detectors/GRP/workflows/src/create-grp-ecs.cxx
@@ -39,6 +39,8 @@ void createGRPECSObject(const std::string& dataPeriod,
                         const std::string& flpList,
                         long tstart,
                         long tend,
+                        long tstartCTP,
+                        long tendCTP,
                         long marginAtSOR,
                         long marginAtEOR,
                         const std::string& ccdbServer = "",
@@ -74,6 +76,9 @@ void createGRPECSObject(const std::string& dataPeriod,
   GRPECSObject grpecs;
   grpecs.setTimeStart(tstart);
   grpecs.setTimeEnd(tend);
+  grpecs.setTimeStartCTP(tstartCTP);
+  grpecs.setTimeEndCTP(tendCTP);
+
   if (runType == GRPECSObject::RunType::LASER && detMask[DetID::TPC] && detMaskCont[DetID::TPC]) {
     LOGP(important, "Overriding TPC readout mode to triggered for runType={}", o2::parameters::GRPECS::RunTypeNames[runTypeI]);
     detMaskCont.reset(DetID::TPC);
@@ -183,8 +188,10 @@ int main(int argc, char** argv)
     add_option("continuous,c", bpo::value<string>()->default_value("ITS,TPC,TOF,MFT,MCH,MID,ZDC,FT0,FV0,FDD,CTP"), "comma separated list of detectors in continuous readout mode");
     add_option("triggering,g", bpo::value<string>()->default_value("FT0,FV0"), "comma separated list of detectors providing a trigger");
     add_option("flps,f", bpo::value<string>()->default_value(""), "comma separated list of FLPs in the data taking");
-    add_option("start-time,s", bpo::value<long>()->default_value(0), "run start time in ms, now() if 0");
-    add_option("end-time,e", bpo::value<long>()->default_value(0), "run end time in ms, start-time+3days is used if 0");
+    add_option("start-time,s", bpo::value<long>()->default_value(0), "ECS run start time in ms, now() if 0");
+    add_option("end-time,e", bpo::value<long>()->default_value(0), "ECS run end time in ms, start-time+3days is used if 0");
+    add_option("start-time-ctp", bpo::value<long>()->default_value(0), "run start CTP time in ms, same as ECS if not set or 0");
+    add_option("end-time-ctp", bpo::value<long>()->default_value(0), "run end CTP time in ms, same as ECS if not set or 0");
     add_option("ccdb-server", bpo::value<std::string>()->default_value("http://alice-ccdb.cern.ch"), "CCDB server for upload, local file if empty");
     add_option("meta-data,m", bpo::value<std::string>()->default_value("")->implicit_value(""), "metadata as key1=value1;key2=value2;..");
     add_option("refresh", bpo::value<string>()->default_value("")->implicit_value("async"), R"(refresh server cache after upload: "none" (or ""), "async" (non-blocking) and "sync" (blocking))");
@@ -243,6 +250,8 @@ int main(int argc, char** argv)
     vm["flps"].as<std::string>(),
     vm["start-time"].as<long>(),
     vm["end-time"].as<long>(),
+    vm["start-time-ctp"].as<long>(),
+    vm["end-time-ctp"].as<long>(),
     vm["marginSOR"].as<long>(),
     vm["marginEOR"].as<long>(),
     vm["ccdb-server"].as<std::string>(),


### PR DESCRIPTION
If not set (or set to 0), the getter will return the ole (ECS) start/end times. To get the exact data member use getTimeStartCTPasSet and getTimeEndCTPasSet getters.

`o2-ecs-grp-create` gets new options `--start-time-ctp` and `--end-time-ctp`.