### PR TITLE
EMCAL fix segfault in raw decoder

### DIFF
--- a/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/RawToCellConverterSpec.cxx
@@ -548,7 +548,7 @@ void RawToCellConverterSpec::run(framework::ProcessingContext& ctx)
     if (cells->size()) {
       LOG(debug) << "Event has " << cells->size() << " cells";
       // Sort cells according to cell ID
-      std::sort(cells->begin(), cells->end(), [](const RecCellInfo& lhs, const RecCellInfo& rhs) { return lhs.mCellData.getTower() < rhs.mCellData.getTower(); });
+      std::sort(cells->begin(), cells->end(), [](const RecCellInfo lhs, const RecCellInfo rhs) { return lhs.mCellData.getTower() < rhs.mCellData.getTower(); });
       for (const auto& cell : *cells) {
         if (cell.mIsLGnoHG) {
           // Treat error only in case the LG is above the noise threshold


### PR DESCRIPTION
Hi @mfasDa and @shahor02 
Unfortunately, I don't fully understand the reason for the crash observed on Monday. But with this patch the decoding of the raw data for run 531419 goes through and valgrind does not show any invalid read/write anymore. The invalid reads were pointing to this lambda, but I don't know why it makes a problem now, since the decoder was not changed for some time. Is it possible that this appears now that we have switched to gcc 12?
I also tried changing `DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/Cell.h` to make sure it is move assignable and move constructible as required by std::sort https://en.cppreference.com/w/cpp/algorithm/sort, but that did not help. Only removing the references worked for me.
Maybe someone has a better understanding of what is going on?
Cheers,
Ole