### PR TITLE
MCH: added message with bad channels map for QC processing

### DIFF
--- a/Detectors/MUON/MCH/Calibration/src/BadChannelCalibrationDevice.cxx
+++ b/Detectors/MUON/MCH/Calibration/src/BadChannelCalibrationDevice.cxx
@@ -200,5 +200,11 @@ void BadChannelCalibrationDevice::sendOutput(o2::framework::DataAllocator& outpu
   // this is sent also if statistics is too low, for diagnostics purposes
   output.snapshot(o2::framework::Output{"MCH", "PEDESTALS", 0},
                   mCalibrator->getPedestalsVector());
+  if (mHasEnoughStat) {
+    output.snapshot(o2::framework::Output{"MCH", "BADCHAN", 0},
+                    mCalibrator->getBadChannelsVector());
+  } else {
+    output.cookDeadBeef(o2::framework::Output{"MCH", "BADCHAN"});
+  }
 }
 } // namespace o2::mch::calibration

--- a/Detectors/MUON/MCH/Calibration/src/badchannel-calib-workflow.cxx
+++ b/Detectors/MUON/MCH/Calibration/src/badchannel-calib-workflow.cxx
@@ -38,6 +38,7 @@ DataProcessorSpec getBadChannelCalibratorSpec(const char* specName, const std::s
   outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBPayload, "MCH_BADCHAN"}, Lifetime::Sporadic);
   outputs.emplace_back(ConcreteDataTypeMatcher{o2::calibration::Utils::gDataOriginCDBWrapper, "MCH_BADCHAN"}, Lifetime::Sporadic);
   outputs.emplace_back(OutputSpec{"MCH", "PEDESTALS", 0, Lifetime::Sporadic});
+  outputs.emplace_back(OutputSpec(ConcreteDataTypeMatcher{"MCH", "BADCHAN"}, Lifetime::Sporadic));
   std::vector<InputSpec> inputs = o2::framework::select(fmt::format("digits:MCH/{}", inputSpec.data()).c_str());
   auto ccdbRequest = std::make_shared<o2::base::GRPGeomRequest>(true,                           // orbitResetTime
                                                                 true,                           // GRPECS=true


### PR DESCRIPTION
The bad channels map produced by the pedestals calibrator is sent to an additional DPL channel such that it can be processed and visualized in the QualityControl, along with the pedestals values.

A dummy message with "DeadBeef" sub-specification is sent if the bad channels map is not produced by the calibrator (for example because not enough statistics is reached). This allows the QC tasks to alert the shifter about the missing bad channels map.