### PR TITLE
treat SIGABRT; fix header

### DIFF
--- a/run/O2SimDeviceRunner.cxx
+++ b/run/O2SimDeviceRunner.cxx
@@ -256,7 +256,7 @@ int main(int argc, char* argv[])
   act.sa_sigaction = &sigaction_handler;
   act.sa_flags = SA_SIGINFO; // <--- enable sigaction
 
-  std::vector<int> handledsignals = {SIGTERM, SIGINT, SIGQUIT, SIGSEGV, SIGBUS, SIGFPE}; // <--- may need to be completed
+  std::vector<int> handledsignals = {SIGTERM, SIGINT, SIGQUIT, SIGSEGV, SIGBUS, SIGFPE, SIGABRT}; // <--- may need to be completed
   // remember that SIGKILL can't be handled
   for (auto s : handledsignals) {
     if (sigaction(s, &act, nullptr)) {

--- a/run/o2sim_parallel.cxx
+++ b/run/o2sim_parallel.cxx
@@ -17,7 +17,7 @@
 
 #include <cstdlib>
 #include <unistd.h>
-#include <time.h>
+#include <ctime>
 #include <sstream>
 #include <iostream>
 #include <cstdio>


### PR DESCRIPTION
This should prevent o2sim to hang
when one of the internal simulation workers exhibits an error inside libc (double free or corruption) which sends SIGABRT.

Related to https://alice.its.cern.ch/jira/browse/O2-3045 but does not solve it.