### PR TITLE
Fix O2 build using arrow v11

### DIFF
--- a/dependencies/O2Dependencies.cmake
+++ b/dependencies/O2Dependencies.cmake
@@ -34,6 +34,14 @@ find_package(Gandiva CONFIG)
 set_package_properties(Arrow PROPERTIES TYPE REQUIRED)
 set_package_properties(Gandiva PROPERTIES TYPE REQUIRED)
 
+if (NOT TARGET Arrow::arrow_shared)
+ add_library(Arrow::arrow_shared ALIAS arrow_shared)
+endif()
+
+if (NOT TARGET Arrow::gandiva_shared)
+  add_library(Gandiva::gandiva_shared ALIAS gandiva_shared)
+endif()
+
 find_package(Vc)
 set_package_properties(Vc PROPERTIES TYPE REQUIRED)
 

--- a/dependencies/O2Dependencies.cmake
+++ b/dependencies/O2Dependencies.cmake
@@ -30,7 +30,7 @@ include(FeatureSummary)
 include(FindThreads)
 
 find_package(Arrow CONFIG)
-if(${Arrow_VERSION} VERSION_LESS 11.0.0)
+if(${Arrow_VERSION} VERSION_LESS 11)
 find_package(Gandiva CONFIG PATHS ${Arrow_DIR} QUIET)
 else()
 find_package(Gandiva CONFIG)

--- a/dependencies/O2Dependencies.cmake
+++ b/dependencies/O2Dependencies.cmake
@@ -30,7 +30,11 @@ include(FeatureSummary)
 include(FindThreads)
 
 find_package(Arrow CONFIG)
+if(${Arrow_VERSION} VERSION_LESS 11.0.0)
+find_package(Gandiva CONFIG PATHS ${Arrow_DIR} QUIET)
+else()
 find_package(Gandiva CONFIG)
+endif()
 set_package_properties(Arrow PROPERTIES TYPE REQUIRED)
 set_package_properties(Gandiva PROPERTIES TYPE REQUIRED)
 

--- a/dependencies/O2Dependencies.cmake
+++ b/dependencies/O2Dependencies.cmake
@@ -29,16 +29,10 @@ include(FeatureSummary)
 
 include(FindThreads)
 
-find_package(Arrow CONFIG QUIET)
-find_package(Gandiva CONFIG PATHS ${Arrow_DIR} QUIET)
+find_package(Arrow CONFIG)
+find_package(Gandiva CONFIG)
 set_package_properties(Arrow PROPERTIES TYPE REQUIRED)
 set_package_properties(Gandiva PROPERTIES TYPE REQUIRED)
-
-# FIXME: remove once we move to arrow 10.0.0
-if (NOT TARGET Arrow::arrow_shared)
-add_library(Arrow::arrow_shared ALIAS arrow_shared)
-add_library(Gandiva::gandiva_shared ALIAS gandiva_shared)
-endif()
 
 find_package(Vc)
 set_package_properties(Vc PROPERTIES TYPE REQUIRED)


### PR DESCRIPTION
This fixes https://github.com/alisw/alidist/pull/4797, since in Arrow v11, Gandiva's CMake files are now installed in a separate directory from the Arrow ones.