### PR TITLE
Set RDHv7 as default + related fixes

### DIFF
--- a/DataFormats/Headers/include/Headers/RAWDataHeader.h
+++ b/DataFormats/Headers/include/Headers/RAWDataHeader.h
@@ -521,7 +521,7 @@ struct RAWDataHeaderV2 {
   };
 };
 
-using RAWDataHeader = RAWDataHeaderV6; // default version
+using RAWDataHeader = RAWDataHeaderV7; // default version
 using RDHLowest = RAWDataHeaderV4;     // link this to lowest version
 using RDHHighest = RAWDataHeaderV7;    // link this to highest version
 

--- a/Detectors/FIT/FDD/workflow/include/FDDWorkflow/RawDataReaderSpec.h
+++ b/Detectors/FIT/FDD/workflow/include/FDDWorkflow/RawDataReaderSpec.h
@@ -25,6 +25,7 @@
 #include "Framework/WorkflowSpec.h"
 #include "Framework/SerializationMethods.h"
 #include "DPLUtils/DPLRawParser.h"
+#include "DetectorsRaw/RDHUtils.h"
 
 #include <iostream>
 #include <vector>
@@ -52,9 +53,9 @@ class RawDataReaderSpec : public Task
     for (auto it = parser.begin(), end = parser.end(); it != end; ++it) {
       //Proccessing each page
       count++;
-      auto rdhPtr = it.get_if<o2::header::RAWDataHeader>();
+      auto rdhPtr = reinterpret_cast<const o2::header::RDHAny*>(it.raw());
       gsl::span<const uint8_t> payload(it.data(), it.size());
-      mRawReader.process(payload, rdhPtr->linkID, int(0));
+      mRawReader.process(payload, o2::raw::RDHUtils::getLinkID(rdhPtr), int(0));
     }
     LOG(info) << "Pages: " << count;
     mRawReader.accumulateDigits();

--- a/Detectors/FIT/FT0/workflow/CMakeLists.txt
+++ b/Detectors/FIT/FT0/workflow/CMakeLists.txt
@@ -35,6 +35,7 @@ o2_add_library(FT0Decoder
                        PUBLIC_LINK_LIBRARIES O2::DataFormatsFT0
                                      O2::Framework
                                      O2::DetectorsCommonDataFormats
+                                     O2::DetectorsRaw
                                      O2::DPLUtils
                                      TARGETVARNAME targetDecoderAVX512)
 target_compile_options(${targetDecoderAVX512} PRIVATE -mavx512f -mavx512vl -mavx512bw -mavx512dq)

--- a/Detectors/FIT/FT0/workflow/include/FT0Workflow/FT0DataReaderDPLSpec.h
+++ b/Detectors/FIT/FT0/workflow/include/FT0Workflow/FT0DataReaderDPLSpec.h
@@ -74,9 +74,9 @@ class FT0DataReaderDPLSpec : public Task
     for (auto it = parser.begin(), end = parser.end(); it != end; ++it) {
       //Proccessing each page
       count++;
-      auto rdhPtr = it.get_if<o2::header::RAWDataHeader>();
+      auto rdhPtr = reinterpret_cast<const o2::header::RDHAny*>(it.raw());
       gsl::span<const uint8_t> payload(it.data(), it.size());
-      mRawReader.process(payload, rdhPtr->linkID, rdhPtr->endPointID);
+      mRawReader.process(payload, o2::raw::RDHUtils::getLinkID(rdhPtr), o2::raw::RDHUtils::getEndPointID(rdhPtr));
     }
     LOG(info) << "Pages: " << count;
     mRawReader.accumulateDigits();

--- a/Detectors/ITSMFT/common/reconstruction/src/GBTLink.cxx
+++ b/Detectors/ITSMFT/common/reconstruction/src/GBTLink.cxx
@@ -382,7 +382,7 @@ uint8_t GBTLink::checkErrorsGBTDataID(const GBTData* gbtD)
     } else if (gbtD->isStatus()) {
       printCableStatus((GBTCableStatus*)gbtD);
     }
-    gbtD->printX(true);
+    gbtD->printX(expectPadding);
     LOG(info) << describe() << ' ' << irHBF << ' ' << statistics.ErrNames[GBTLinkDecodingStat::ErrGBTWordNotRecognized];
     err |= uint8_t(ErrorPrinted);
   }

--- a/Detectors/ITSMFT/common/simulation/src/MC2RawEncoder.cxx
+++ b/Detectors/ITSMFT/common/simulation/src/MC2RawEncoder.cxx
@@ -286,6 +286,7 @@ int MC2RawEncoder<Mapping>::carryOverMethod(const header::RDHAny* rdh, const gsl
   // During the carry-over ITS needs to repeat the GBTTrigger and GBTDataTrailer words.
   // Also the GBTDataHeader needs to be repeated right after continuation RDH, but it will be provided in the newRDHMethod
   const int wordSize = RDHUtils::getDataFormat(rdh) == 0 ? o2::itsmft::GBTPaddedWordLength : o2::itsmft::GBTWordLength;
+  uint feed = RDHUtils::getFEEID(rdh);
 
   int offs = ptr - &data[0]; // offset wrt the head of the payload
   // make sure ptr and end of the suggested block are within the payload
@@ -293,6 +294,9 @@ int MC2RawEncoder<Mapping>::carryOverMethod(const header::RDHAny* rdh, const gsl
 
   // this is where we would usually split: account for the trailer to add
   int actualSize = maxSize - wordSize;
+  // make sure we don't split the GBT word
+  actualSize -= actualSize % wordSize;
+
   char* trailPtr = &data[data.size() - wordSize]; // pointer on the payload trailer
 
   if ((maxSize <= 2 * wordSize)) {   // we cannot split trigger+header
@@ -303,6 +307,8 @@ int MC2RawEncoder<Mapping>::carryOverMethod(const header::RDHAny* rdh, const gsl
   } else {
     if (ptr + actualSize >= trailPtr) { // we need to split at least 1 GBT word before the trailer
       actualSize = trailPtr - ptr - wordSize;
+      // make sure we don't split the GBT word
+      actualSize -= actualSize % wordSize;
     }
   }
   // copy the GBTTrigger and GBTHeader from the head of the payload

--- a/Detectors/TPC/workflow/src/LinkZSToDigitsSpec.cxx
+++ b/Detectors/TPC/workflow/src/LinkZSToDigitsSpec.cxx
@@ -151,7 +151,7 @@ o2::framework::DataProcessorSpec getLinkZSToDigitsSpec(int channel, const std::s
           o2::framework::RawParser parser(input.payload, payloadSize);
 
           for (auto it = parser.begin(), end = parser.end(); it != end; ++it) {
-            auto* rdhPtr = it.get_if<o2::header::RAWDataHeader>();
+            auto* rdhPtr = reinterpret_cast<const o2::header::RDHAny*>(it.raw());
             if (!rdhPtr) {
               break;
             }


### PR DESCRIPTION
@afurs @lietava [this](https://github.com/AliceO2Group/AliceO2/commit/fa7d3b67498d75493cb5dc9063c63e431c209b36) allows to FIT and CTP decoders to work with RDHv6 data while having RDHv7 as default. Please rebase your development for unpadded RDHv7 to this.