### PR TITLE
ITS-GPU: Fix missing reset for buffer.

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
@@ -726,6 +726,7 @@ void VertexerTraitsGPU::computeTracklets()
           gsl::span<const o2::its::Line> linesInRof(lines.data() + linesOffsetRof, static_cast<gsl::span<o2::its::Line>::size_type>(nLinesRof));
 
           usedLines.resize(linesInRof.size(), false);
+          usedLines.assign(linesInRof.size(), false);
           clusterLines.clear();
           clusterLines.reserve(nClustersL1Rof);
           computeVerticesInRof(rof,


### PR DESCRIPTION
Now it really resets the buffer to `{false, ..., false}` so we have the same vertices found on GPU and CPU.