### PR TITLE
O2-3580: Add byproducts and custom target force response generation

### DIFF
--- a/Detectors/ITSMFT/common/data/AlpideResponseData/CMakeLists.txt
+++ b/Detectors/ITSMFT/common/data/AlpideResponseData/CMakeLists.txt
@@ -28,7 +28,15 @@ endif()
 
 add_custom_command(TARGET O2exe-alpide-response-generator POST_BUILD
                    COMMAND ${CMAKE_BINARY_DIR}/stage/bin/o2-alpide-response-generator -i ${ITSRESPONSE_DIR}/response/AlpideResponseData/ -o ${CMAKE_CURRENT_BINARY_DIR}/
-                   DEPENDS ${CMAKE_SOURCE_DIR}/Detectors/ITSMFT/common/data/AlpideResponseData/AlpideResponse.cxx
+                   BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/AlpideResponseData.root
+                   DEPENDS alpide-response-generator
+                   COMMENT "Generating AlpideResponseData.root"
+)
+
+# # Add a target that depends on the custom command output
+add_custom_target(
+  GenerateAlpideResponse ALL
+  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/AlpideResponseData.root
 )
 
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/AlpideResponseData.root" DESTINATION "${CMAKE_INSTALL_PREFIX}/share/Detectors/ITSMFT/data/AlpideResponseData/")


### PR DESCRIPTION
@ktf, cc-ing: @Barthelemy.

I manage to reproduce a failure that resembles, e.g. https://github.com/AliceO2Group/QualityControl/pull/1652
To do that, I just removed the `AlpideResponseData.root` from the `BUILD` directory after a successful build.
Then I gave `ninja install -j12`, and it broke with:
```bash
CMake Error at Detectors/ITSMFT/common/data/AlpideResponseData/cmake_install.cmake:74 (file):
  file INSTALL cannot find
  "/ssd_data/builds/developments/sw/BUILD/O2-latest-pr-install-alpide/O2/Detectors/ITSMFT/common/data/AlpideResponseData/AlpideResponseData.root":
  No such file or directory.
Call Stack (most recent call first):
  Detectors/ITSMFT/common/data/cmake_install.cmake:47 (include)
  Detectors/ITSMFT/common/cmake_install.cmake:67 (include)
  Detectors/ITSMFT/cmake_install.cmake:47 (include)
  Detectors/cmake_install.cmake:107 (include)
  cmake_install.cmake:87 (include)
  ```
Adding the `BYPRODUCTS` clause in the `add_custom_command` now found a way to generate it even if I remove it.
I also added a custom target that requires the specific output file, hoping to trigger the rebuild and generation in the CI builders. 