### PR TITLE
ITS-GPU: remove synchronisation point

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
@@ -607,14 +607,17 @@ void VertexerTraitsGPU::computeTracklets()
     return;
   }
   std::vector<std::thread> threads(mTimeFrameGPU->getNChunks());
-  size_t offset{0};
-  do {
-    for (size_t chunkId{0}; chunkId < mTimeFrameGPU->getNChunks() && offset < mTimeFrameGPU->mNrof - 1; ++chunkId) {
-      mTimeFrameGPU->getVerticesInChunks()[chunkId].clear();
-      mTimeFrameGPU->getNVerticesInChunks()[chunkId].clear();
-      mTimeFrameGPU->getLabelsInChunks()[chunkId].clear();
-      auto rofs = mTimeFrameGPU->loadChunkData<gpu::Task::Vertexer>(chunkId, offset);
-      auto doVertexReconstruction = [&, chunkId, offset, rofs]() -> void {
+  for (int chunkId{0}; chunkId < mTimeFrameGPU->getNChunks(); ++chunkId) {
+    int rofPerChunk{mTimeFrameGPU->mNrof / (int)mTimeFrameGPU->getNChunks()};
+    mTimeFrameGPU->getVerticesInChunks()[chunkId].clear();
+    mTimeFrameGPU->getNVerticesInChunks()[chunkId].clear();
+    mTimeFrameGPU->getLabelsInChunks()[chunkId].clear();
+    auto doVertexReconstruction = [&, chunkId, rofPerChunk]() -> void {
+      auto offset = chunkId * rofPerChunk;
+      auto maxROF = offset + rofPerChunk;
+      // LOGP(info, "chid: {} start: {} end: {}", chunkId, offset, maxROF);
+      while (offset < maxROF) {
+        auto rofs = mTimeFrameGPU->loadChunkData<gpu::Task::Vertexer>(chunkId, offset, maxROF);
         RANGE("chunk_gpu_processing", 1);
         gpu::trackleterKernelMultipleRof<TrackletMode::Layer0Layer1><<<rofs, 1024, 0, mTimeFrameGPU->getStream(chunkId).get()>>>(
           mTimeFrameGPU->getChunk(chunkId).getDeviceClusters(0),         // const Cluster* clustersNextLayer,    // 0 2
@@ -712,17 +715,14 @@ void VertexerTraitsGPU::computeTracklets()
         checkGPUError(cudaStreamSynchronize(mTimeFrameGPU->getStream(chunkId).get()));
 
         // Compute vertices
-        int counter{0};
         std::vector<ClusterLines> clusterLines;
         std::vector<bool> usedLines;
-        for (int iRof{0}; iRof < rofs; ++iRof) {
-          auto rof = offset + iRof;
+        for (int rofId{0}; rofId < rofs; ++rofId) {
+          auto rof = offset + rofId;
           auto clustersL1offsetRof = mTimeFrameGPU->getROframeClusters(1)[rof] - mTimeFrameGPU->getROframeClusters(1)[offset]; // starting cluster offset for this ROF
           auto nClustersL1Rof = mTimeFrameGPU->getROframeClusters(1)[rof + 1] - mTimeFrameGPU->getROframeClusters(1)[rof];     // number of clusters for this ROF
           auto linesOffsetRof = exclusiveFoundLinesHost[clustersL1offsetRof];                                                  // starting line offset for this ROF
           auto nLinesRof = exclusiveFoundLinesHost[clustersL1offsetRof + nClustersL1Rof] - linesOffsetRof;
-          counter += nLinesRof;
-
           gsl::span<const o2::its::Line> linesInRof(lines.data() + linesOffsetRof, static_cast<gsl::span<o2::its::Line>::size_type>(nLinesRof));
 
           usedLines.resize(linesInRof.size(), false);
@@ -738,32 +738,176 @@ void VertexerTraitsGPU::computeTracklets()
                                mTimeFrameGPU->getNVerticesInChunks()[chunkId],
                                mTimeFrameGPU->hasMCinformation() ? mTimeFrameGPU : nullptr,
                                mTimeFrameGPU->hasMCinformation() ? &mTimeFrameGPU->getLabelsInChunks()[chunkId] : nullptr);
+          LOGP(info, "chid: {} rof: {} vertices: {}", chunkId, rof, mTimeFrameGPU->getNVerticesInChunks()[chunkId].back());
         }
-      };
+        offset += rofs;
+      }
+      // LOGP(info, "chunk: {} vertices: {}", chunkId, mTimeFrameGPU->getVerticesInChunks()[chunkId].size());
+    };
+    // Do work
+    threads[chunkId] = std::thread(doVertexReconstruction);
+  }
+  for (auto& thread : threads) {
+    thread.join();
+  }
+  // size_t offset{0};
+  // do {
+  //   for (size_t chunkId{0}; chunkId < mTimeFrameGPU->getNChunks() && offset < mTimeFrameGPU->mNrof - 1; ++chunkId) {
+  //     mTimeFrameGPU->getVerticesInChunks()[chunkId].clear();
+  //     mTimeFrameGPU->getNVerticesInChunks()[chunkId].clear();
+  //     mTimeFrameGPU->getLabelsInChunks()[chunkId].clear();
+  //     auto rofs = mTimeFrameGPU->loadChunkData<gpu::Task::Vertexer>(chunkId, offset);
+  //     auto doVertexReconstruction = [&, chunkId, offset, rofs]() -> void {
+  //       RANGE("chunk_gpu_processing", 1);
+  //       gpu::trackleterKernelMultipleRof<TrackletMode::Layer0Layer1><<<rofs, 1024, 0, mTimeFrameGPU->getStream(chunkId).get()>>>(
+  //         mTimeFrameGPU->getChunk(chunkId).getDeviceClusters(0),         // const Cluster* clustersNextLayer,    // 0 2
+  //         mTimeFrameGPU->getChunk(chunkId).getDeviceClusters(1),         // const Cluster* clustersCurrentLayer, // 1 1
+  //         mTimeFrameGPU->getDeviceROframesClusters(0),                   // const int* sizeNextLClusters,
+  //         mTimeFrameGPU->getDeviceROframesClusters(1),                   // const int* sizeCurrentLClusters,
+  //         mTimeFrameGPU->getChunk(chunkId).getDeviceIndexTables(0),      // const int* nextIndexTables,
+  //         mTimeFrameGPU->getChunk(chunkId).getDeviceTracklets(0),        // Tracklet* Tracklets,
+  //         mTimeFrameGPU->getChunk(chunkId).getDeviceNTrackletCluster(0), // int* foundTracklets,
+  //         mTimeFrameGPU->getDeviceIndexTableUtils(),                     // const IndexTableUtils* utils,
+  //         offset,                                                        // const unsigned int startRofId,
+  //         rofs,                                                          // const unsigned int rofSize,
+  //         mVrtParams.phiCut,                                             // const float phiCut,
+  //         mVrtParams.maxTrackletsPerCluster);                            // const size_t maxTrackletsPerCluster = 1e2
+  //       gpu::trackleterKernelMultipleRof<TrackletMode::Layer1Layer2><<<rofs, 1024, 0, mTimeFrameGPU->getStream(chunkId).get()>>>(
+  //         mTimeFrameGPU->getChunk(chunkId).getDeviceClusters(2),         // const Cluster* clustersNextLayer,    // 0 2
+  //         mTimeFrameGPU->getChunk(chunkId).getDeviceClusters(1),         // const Cluster* clustersCurrentLayer, // 1 1
+  //         mTimeFrameGPU->getDeviceROframesClusters(2),                   // const int* sizeNextLClusters,
+  //         mTimeFrameGPU->getDeviceROframesClusters(1),                   // const int* sizeCurrentLClusters,
+  //         mTimeFrameGPU->getChunk(chunkId).getDeviceIndexTables(2),      // const int* nextIndexTables,
+  //         mTimeFrameGPU->getChunk(chunkId).getDeviceTracklets(1),        // Tracklet* Tracklets,
+  //         mTimeFrameGPU->getChunk(chunkId).getDeviceNTrackletCluster(1), // int* foundTracklets,
+  //         mTimeFrameGPU->getDeviceIndexTableUtils(),                     // const IndexTableUtils* utils,
+  //         offset,                                                        // const unsigned int startRofId,
+  //         rofs,                                                          // const unsigned int rofSize,
+  //         mVrtParams.phiCut,                                             // const float phiCut,
+  //         mVrtParams.maxTrackletsPerCluster);                            // const size_t maxTrackletsPerCluster = 1e2
 
-      // Do work
-      threads[chunkId] = std::thread(doVertexReconstruction);
-      offset += rofs;
-    }
-    for (auto& thread : threads) {
-      if (thread.joinable()) { // in case not all partitions were fed with data
-        thread.join();
-      }
-    }
-    for (int chunkId{0}; chunkId < mTimeFrameGPU->getNChunks(); ++chunkId) {
-      int start{0};
-      for (int iRof{0}; iRof < mTimeFrameGPU->getNVerticesInChunks()[chunkId].size(); ++iRof) {
-        gsl::span<const Vertex> rofVerts{mTimeFrameGPU->getVerticesInChunks()[chunkId].data() + start, static_cast<gsl::span<Vertex>::size_type>(mTimeFrameGPU->getNVerticesInChunks()[chunkId][iRof])};
-        mTimeFrameGPU->addPrimaryVertices(rofVerts);
-        if (mTimeFrameGPU->hasMCinformation()) {
-          mTimeFrameGPU->getVerticesLabels().emplace_back();
-          // TODO: add MC labels
-        }
-        start += mTimeFrameGPU->getNVerticesInChunks()[chunkId][iRof];
-      }
-    }
-  } while (offset < mTimeFrameGPU->mNrof - 1); // offset is referring to the ROF id
-  mTimeFrameGPU->wipe(3);
+  //       // Tracklet selection
+  //       gpu::trackletSelectionKernelMultipleRof<true><<<rofs, 1024, 0, mTimeFrameGPU->getStream(chunkId).get()>>>(
+  //         mTimeFrameGPU->getChunk(chunkId).getDeviceClusters(0),            // const Cluster* clusters0,               // Clusters on layer 0
+  //         mTimeFrameGPU->getChunk(chunkId).getDeviceClusters(1),            // const Cluster* clusters1,               // Clusters on layer 1
+  //         mTimeFrameGPU->getDeviceROframesClusters(0),                      // const int* sizeClustersL0,              // Number of clusters on layer 0 per ROF
+  //         mTimeFrameGPU->getDeviceROframesClusters(1),                      // const int* sizeClustersL1,              // Number of clusters on layer 1 per ROF
+  //         mTimeFrameGPU->getChunk(chunkId).getDeviceTracklets(0),           // Tracklet* tracklets01,                  // Tracklets on layer 0-1
+  //         mTimeFrameGPU->getChunk(chunkId).getDeviceTracklets(1),           // Tracklet* tracklets12,                  // Tracklets on layer 1-2
+  //         mTimeFrameGPU->getChunk(chunkId).getDeviceNTrackletCluster(0),    // const int* nFoundTracklets01,           // Number of tracklets found on layers 0-1
+  //         mTimeFrameGPU->getChunk(chunkId).getDeviceNTrackletCluster(1),    // const int* nFoundTracklet12,            // Number of tracklets found on layers 1-2
+  //         mTimeFrameGPU->getChunk(chunkId).getDeviceUsedTracklets(),        // unsigned char* usedTracklets,           // Used tracklets
+  //         mTimeFrameGPU->getChunk(chunkId).getDeviceLines(),                // Line* lines,                            // Lines
+  //         mTimeFrameGPU->getChunk(chunkId).getDeviceNFoundLines(),          // int* nFoundLines,                       // Number of found lines
+  //         mTimeFrameGPU->getChunk(chunkId).getDeviceNExclusiveFoundLines(), // int* nExclusiveFoundLines,              // Number of found lines exclusive scan
+  //         offset,                                                           // const unsigned int startRofId,          // Starting ROF ID
+  //         rofs,                                                             // const unsigned int rofSize,             // Number of ROFs to consider
+  //         mVrtParams.maxTrackletsPerCluster,                                // const int maxTrackletsPerCluster = 1e2, // Maximum number of tracklets per cluster
+  //         mVrtParams.tanLambdaCut,                                          // const float tanLambdaCut = 0.025f,      // Cut on tan lambda
+  //         mVrtParams.phiCut);                                               // const float phiCut = 0.002f)            // Cut on phi
+
+  //       discardResult(cub::DeviceScan::ExclusiveSum(mTimeFrameGPU->getChunk(chunkId).getDeviceCUBTmpBuffer(),
+  //                                                   mTimeFrameGPU->getChunk(chunkId).getTimeFrameGPUParameters()->tmpCUBBufferSize,
+  //                                                   mTimeFrameGPU->getChunk(chunkId).getDeviceNFoundLines(),
+  //                                                   mTimeFrameGPU->getChunk(chunkId).getDeviceNExclusiveFoundLines() /*+ 1*/,
+  //                                                   mTimeFrameGPU->getTotalClustersPerROFrange(offset, rofs, 1),
+  //                                                   mTimeFrameGPU->getStream(chunkId).get()));
+
+  //       // Reset used tracklets
+  //       checkGPUError(cudaMemsetAsync(mTimeFrameGPU->getChunk(chunkId).getDeviceUsedTracklets(),
+  //                                     false,
+  //                                     sizeof(unsigned char) * mVrtParams.maxTrackletsPerCluster * mTimeFrameGPU->getTotalClustersPerROFrange(offset, rofs, 1),
+  //                                     mTimeFrameGPU->getStream(chunkId).get()),
+  //                     __FILE__, __LINE__);
+
+  //       gpu::trackletSelectionKernelMultipleRof<false><<<rofs, 1024, 0, mTimeFrameGPU->getStream(chunkId).get()>>>(
+  //         mTimeFrameGPU->getChunk(chunkId).getDeviceClusters(0),            // const Cluster* clusters0,               // Clusters on layer 0
+  //         mTimeFrameGPU->getChunk(chunkId).getDeviceClusters(1),            // const Cluster* clusters1,               // Clusters on layer 1
+  //         mTimeFrameGPU->getDeviceROframesClusters(0),                      // const int* sizeClustersL0,              // Number of clusters on layer 0 per ROF
+  //         mTimeFrameGPU->getDeviceROframesClusters(1),                      // const int* sizeClustersL1,              // Number of clusters on layer 1 per ROF
+  //         mTimeFrameGPU->getChunk(chunkId).getDeviceTracklets(0),           // Tracklet* tracklets01,                  // Tracklets on layer 0-1
+  //         mTimeFrameGPU->getChunk(chunkId).getDeviceTracklets(1),           // Tracklet* tracklets12,                  // Tracklets on layer 1-2
+  //         mTimeFrameGPU->getChunk(chunkId).getDeviceNTrackletCluster(0),    // const int* nFoundTracklets01,           // Number of tracklets found on layers 0-1
+  //         mTimeFrameGPU->getChunk(chunkId).getDeviceNTrackletCluster(1),    // const int* nFoundTracklet12,            // Number of tracklets found on layers 1-2
+  //         mTimeFrameGPU->getChunk(chunkId).getDeviceUsedTracklets(),        // unsigned char* usedTracklets,           // Used tracklets
+  //         mTimeFrameGPU->getChunk(chunkId).getDeviceLines(),                // Line* lines,                            // Lines
+  //         mTimeFrameGPU->getChunk(chunkId).getDeviceNFoundLines(),          // int* nFoundLines,                       // Number of found lines
+  //         mTimeFrameGPU->getChunk(chunkId).getDeviceNExclusiveFoundLines(), // int* nExclusiveFoundLines,              // Number of found lines exclusive scan
+  //         offset,                                                           // const unsigned int startRofId,          // Starting ROF ID
+  //         rofs,                                                             // const unsigned int rofSize,             // Number of ROFs to consider
+  //         mVrtParams.maxTrackletsPerCluster,                                // const int maxTrackletsPerCluster = 1e2, // Maximum number of tracklets per cluster
+  //         mVrtParams.tanLambdaCut,                                          // const float tanLambdaCut = 0.025f,      // Cut on tan lambda
+  //         mVrtParams.phiCut);                                               // const float phiCut = 0.002f)            // Cut on phi
+
+  //       int nClusters = mTimeFrameGPU->getTotalClustersPerROFrange(offset, rofs, 1);
+  //       int lastFoundLines;
+  //       std::vector<int> exclusiveFoundLinesHost(nClusters + 1);
+
+  //       // Obtain whole exclusive sum including nCluster+1 element  (nCluster+1)th element is the total number of found lines.
+  //       checkGPUError(cudaMemcpyAsync(exclusiveFoundLinesHost.data(), mTimeFrameGPU->getChunk(chunkId).getDeviceNExclusiveFoundLines(), (nClusters) * sizeof(int), cudaMemcpyDeviceToHost, mTimeFrameGPU->getStream(chunkId).get()));
+  //       checkGPUError(cudaMemcpyAsync(&lastFoundLines, mTimeFrameGPU->getChunk(chunkId).getDeviceNFoundLines() + nClusters - 1, sizeof(int), cudaMemcpyDeviceToHost, mTimeFrameGPU->getStream(chunkId).get()));
+  //       exclusiveFoundLinesHost[nClusters] = exclusiveFoundLinesHost[nClusters - 1] + lastFoundLines;
+
+  //       std::vector<Line> lines(exclusiveFoundLinesHost[nClusters]);
+  //       // LOGP(info, "rof: {} found {} lines", exclusiveFoundLinesHost[nClusters]);
+
+  //       checkGPUError(cudaMemcpyAsync(lines.data(), mTimeFrameGPU->getChunk(chunkId).getDeviceLines(), sizeof(Line) * lines.size(), cudaMemcpyDeviceToHost, mTimeFrameGPU->getStream(chunkId).get()));
+  //       checkGPUError(cudaStreamSynchronize(mTimeFrameGPU->getStream(chunkId).get()));
+
+  //       // Compute vertices
+  //       int counter{0};
+  //       std::vector<ClusterLines> clusterLines;
+  //       std::vector<bool> usedLines;
+  //       for (int iRof{0}; iRof < rofs; ++iRof) {
+  //         auto rof = offset + iRof;
+  //         auto clustersL1offsetRof = mTimeFrameGPU->getROframeClusters(1)[rof] - mTimeFrameGPU->getROframeClusters(1)[offset]; // starting cluster offset for this ROF
+  //         auto nClustersL1Rof = mTimeFrameGPU->getROframeClusters(1)[rof + 1] - mTimeFrameGPU->getROframeClusters(1)[rof];     // number of clusters for this ROF
+  //         auto linesOffsetRof = exclusiveFoundLinesHost[clustersL1offsetRof];                                                  // starting line offset for this ROF
+  //         auto nLinesRof = exclusiveFoundLinesHost[clustersL1offsetRof + nClustersL1Rof] - linesOffsetRof;
+  //         counter += nLinesRof;
+
+  //         gsl::span<const o2::its::Line> linesInRof(lines.data() + linesOffsetRof, static_cast<gsl::span<o2::its::Line>::size_type>(nLinesRof));
+
+  //         usedLines.resize(linesInRof.size(), false);
+  //         usedLines.assign(linesInRof.size(), false);
+  //         clusterLines.clear();
+  //         clusterLines.reserve(nClustersL1Rof);
+  //         computeVerticesInRof(rof,
+  //                              linesInRof,
+  //                              usedLines,
+  //                              clusterLines,
+  //                              mTimeFrameGPU->getBeamXY(),
+  //                              mTimeFrameGPU->getVerticesInChunks()[chunkId],
+  //                              mTimeFrameGPU->getNVerticesInChunks()[chunkId],
+  //                              mTimeFrameGPU->hasMCinformation() ? mTimeFrameGPU : nullptr,
+  //                              mTimeFrameGPU->hasMCinformation() ? &mTimeFrameGPU->getLabelsInChunks()[chunkId] : nullptr);
+  //         LOGP(info, "chid: {} rofid: {} vertices: {}", chunkId, iRof, mTimeFrameGPU->getNVerticesInChunks()[chunkId][iRof].size());
+  //       }
+  //     };
+
+  //     // Do work
+  //     threads[chunkId] = std::thread(doVertexReconstruction);
+  //     offset += rofs;
+  //   }
+  //   for (auto& thread : threads) {
+  //     if (thread.joinable()) { // in case not all partitions were fed with data
+  //       thread.join();
+  //     }
+  //   }
+  //   for (int chunkId{0}; chunkId < mTimeFrameGPU->getNChunks(); ++chunkId) {
+  //     int start{0};
+  //     for (int iRof{0}; iRof < mTimeFrameGPU->getNVerticesInChunks()[chunkId].size(); ++iRof) {
+  //       gsl::span<const Vertex> rofVerts{mTimeFrameGPU->getVerticesInChunks()[chunkId].data() + start, static_cast<gsl::span<Vertex>::size_type>(mTimeFrameGPU->getNVerticesInChunks()[chunkId][iRof])};
+  //       mTimeFrameGPU->addPrimaryVertices(rofVerts);
+  //       if (mTimeFrameGPU->hasMCinformation()) {
+  //         mTimeFrameGPU->getVerticesLabels().emplace_back();
+  //         // TODO: add MC labels
+  //       }
+  //       start += mTimeFrameGPU->getNVerticesInChunks()[chunkId][iRof];
+  //     }
+  //   }
+  // } while (offset < mTimeFrameGPU->mNrof - 1); // offset is referring to the ROF id
+  // mTimeFrameGPU->wipe(3);
 }
 
 void VertexerTraitsGPU::computeTrackletMatching()

--- a/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
+++ b/Detectors/ITSMFT/ITS/tracking/GPU/cuda/VertexerTraitsGPU.cu
@@ -615,7 +615,6 @@ void VertexerTraitsGPU::computeTracklets()
     auto doVertexReconstruction = [&, chunkId, rofPerChunk]() -> void {
       auto offset = chunkId * rofPerChunk;
       auto maxROF = offset + rofPerChunk;
-      // LOGP(info, "chid: {} start: {} end: {}", chunkId, offset, maxROF);
       while (offset < maxROF) {
         auto rofs = mTimeFrameGPU->loadChunkData<gpu::Task::Vertexer>(chunkId, offset, maxROF);
         RANGE("chunk_gpu_processing", 1);
@@ -709,7 +708,6 @@ void VertexerTraitsGPU::computeTracklets()
         exclusiveFoundLinesHost[nClusters] = exclusiveFoundLinesHost[nClusters - 1] + lastFoundLines;
 
         std::vector<Line> lines(exclusiveFoundLinesHost[nClusters]);
-        // LOGP(info, "rof: {} found {} lines", exclusiveFoundLinesHost[nClusters]);
 
         checkGPUError(cudaMemcpyAsync(lines.data(), mTimeFrameGPU->getChunk(chunkId).getDeviceLines(), sizeof(Line) * lines.size(), cudaMemcpyDeviceToHost, mTimeFrameGPU->getStream(chunkId).get()));
         checkGPUError(cudaStreamSynchronize(mTimeFrameGPU->getStream(chunkId).get()));
@@ -738,11 +736,9 @@ void VertexerTraitsGPU::computeTracklets()
                                mTimeFrameGPU->getNVerticesInChunks()[chunkId],
                                mTimeFrameGPU->hasMCinformation() ? mTimeFrameGPU : nullptr,
                                mTimeFrameGPU->hasMCinformation() ? &mTimeFrameGPU->getLabelsInChunks()[chunkId] : nullptr);
-          LOGP(info, "chid: {} rof: {} vertices: {}", chunkId, rof, mTimeFrameGPU->getNVerticesInChunks()[chunkId].back());
         }
         offset += rofs;
       }
-      // LOGP(info, "chunk: {} vertices: {}", chunkId, mTimeFrameGPU->getVerticesInChunks()[chunkId].size());
     };
     // Do work
     threads[chunkId] = std::thread(doVertexReconstruction);
@@ -750,164 +746,19 @@ void VertexerTraitsGPU::computeTracklets()
   for (auto& thread : threads) {
     thread.join();
   }
-  // size_t offset{0};
-  // do {
-  //   for (size_t chunkId{0}; chunkId < mTimeFrameGPU->getNChunks() && offset < mTimeFrameGPU->mNrof - 1; ++chunkId) {
-  //     mTimeFrameGPU->getVerticesInChunks()[chunkId].clear();
-  //     mTimeFrameGPU->getNVerticesInChunks()[chunkId].clear();
-  //     mTimeFrameGPU->getLabelsInChunks()[chunkId].clear();
-  //     auto rofs = mTimeFrameGPU->loadChunkData<gpu::Task::Vertexer>(chunkId, offset);
-  //     auto doVertexReconstruction = [&, chunkId, offset, rofs]() -> void {
-  //       RANGE("chunk_gpu_processing", 1);
-  //       gpu::trackleterKernelMultipleRof<TrackletMode::Layer0Layer1><<<rofs, 1024, 0, mTimeFrameGPU->getStream(chunkId).get()>>>(
-  //         mTimeFrameGPU->getChunk(chunkId).getDeviceClusters(0),         // const Cluster* clustersNextLayer,    // 0 2
-  //         mTimeFrameGPU->getChunk(chunkId).getDeviceClusters(1),         // const Cluster* clustersCurrentLayer, // 1 1
-  //         mTimeFrameGPU->getDeviceROframesClusters(0),                   // const int* sizeNextLClusters,
-  //         mTimeFrameGPU->getDeviceROframesClusters(1),                   // const int* sizeCurrentLClusters,
-  //         mTimeFrameGPU->getChunk(chunkId).getDeviceIndexTables(0),      // const int* nextIndexTables,
-  //         mTimeFrameGPU->getChunk(chunkId).getDeviceTracklets(0),        // Tracklet* Tracklets,
-  //         mTimeFrameGPU->getChunk(chunkId).getDeviceNTrackletCluster(0), // int* foundTracklets,
-  //         mTimeFrameGPU->getDeviceIndexTableUtils(),                     // const IndexTableUtils* utils,
-  //         offset,                                                        // const unsigned int startRofId,
-  //         rofs,                                                          // const unsigned int rofSize,
-  //         mVrtParams.phiCut,                                             // const float phiCut,
-  //         mVrtParams.maxTrackletsPerCluster);                            // const size_t maxTrackletsPerCluster = 1e2
-  //       gpu::trackleterKernelMultipleRof<TrackletMode::Layer1Layer2><<<rofs, 1024, 0, mTimeFrameGPU->getStream(chunkId).get()>>>(
-  //         mTimeFrameGPU->getChunk(chunkId).getDeviceClusters(2),         // const Cluster* clustersNextLayer,    // 0 2
-  //         mTimeFrameGPU->getChunk(chunkId).getDeviceClusters(1),         // const Cluster* clustersCurrentLayer, // 1 1
-  //         mTimeFrameGPU->getDeviceROframesClusters(2),                   // const int* sizeNextLClusters,
-  //         mTimeFrameGPU->getDeviceROframesClusters(1),                   // const int* sizeCurrentLClusters,
-  //         mTimeFrameGPU->getChunk(chunkId).getDeviceIndexTables(2),      // const int* nextIndexTables,
-  //         mTimeFrameGPU->getChunk(chunkId).getDeviceTracklets(1),        // Tracklet* Tracklets,
-  //         mTimeFrameGPU->getChunk(chunkId).getDeviceNTrackletCluster(1), // int* foundTracklets,
-  //         mTimeFrameGPU->getDeviceIndexTableUtils(),                     // const IndexTableUtils* utils,
-  //         offset,                                                        // const unsigned int startRofId,
-  //         rofs,                                                          // const unsigned int rofSize,
-  //         mVrtParams.phiCut,                                             // const float phiCut,
-  //         mVrtParams.maxTrackletsPerCluster);                            // const size_t maxTrackletsPerCluster = 1e2
-
-  //       // Tracklet selection
-  //       gpu::trackletSelectionKernelMultipleRof<true><<<rofs, 1024, 0, mTimeFrameGPU->getStream(chunkId).get()>>>(
-  //         mTimeFrameGPU->getChunk(chunkId).getDeviceClusters(0),            // const Cluster* clusters0,               // Clusters on layer 0
-  //         mTimeFrameGPU->getChunk(chunkId).getDeviceClusters(1),            // const Cluster* clusters1,               // Clusters on layer 1
-  //         mTimeFrameGPU->getDeviceROframesClusters(0),                      // const int* sizeClustersL0,              // Number of clusters on layer 0 per ROF
-  //         mTimeFrameGPU->getDeviceROframesClusters(1),                      // const int* sizeClustersL1,              // Number of clusters on layer 1 per ROF
-  //         mTimeFrameGPU->getChunk(chunkId).getDeviceTracklets(0),           // Tracklet* tracklets01,                  // Tracklets on layer 0-1
-  //         mTimeFrameGPU->getChunk(chunkId).getDeviceTracklets(1),           // Tracklet* tracklets12,                  // Tracklets on layer 1-2
-  //         mTimeFrameGPU->getChunk(chunkId).getDeviceNTrackletCluster(0),    // const int* nFoundTracklets01,           // Number of tracklets found on layers 0-1
-  //         mTimeFrameGPU->getChunk(chunkId).getDeviceNTrackletCluster(1),    // const int* nFoundTracklet12,            // Number of tracklets found on layers 1-2
-  //         mTimeFrameGPU->getChunk(chunkId).getDeviceUsedTracklets(),        // unsigned char* usedTracklets,           // Used tracklets
-  //         mTimeFrameGPU->getChunk(chunkId).getDeviceLines(),                // Line* lines,                            // Lines
-  //         mTimeFrameGPU->getChunk(chunkId).getDeviceNFoundLines(),          // int* nFoundLines,                       // Number of found lines
-  //         mTimeFrameGPU->getChunk(chunkId).getDeviceNExclusiveFoundLines(), // int* nExclusiveFoundLines,              // Number of found lines exclusive scan
-  //         offset,                                                           // const unsigned int startRofId,          // Starting ROF ID
-  //         rofs,                                                             // const unsigned int rofSize,             // Number of ROFs to consider
-  //         mVrtParams.maxTrackletsPerCluster,                                // const int maxTrackletsPerCluster = 1e2, // Maximum number of tracklets per cluster
-  //         mVrtParams.tanLambdaCut,                                          // const float tanLambdaCut = 0.025f,      // Cut on tan lambda
-  //         mVrtParams.phiCut);                                               // const float phiCut = 0.002f)            // Cut on phi
-
-  //       discardResult(cub::DeviceScan::ExclusiveSum(mTimeFrameGPU->getChunk(chunkId).getDeviceCUBTmpBuffer(),
-  //                                                   mTimeFrameGPU->getChunk(chunkId).getTimeFrameGPUParameters()->tmpCUBBufferSize,
-  //                                                   mTimeFrameGPU->getChunk(chunkId).getDeviceNFoundLines(),
-  //                                                   mTimeFrameGPU->getChunk(chunkId).getDeviceNExclusiveFoundLines() /*+ 1*/,
-  //                                                   mTimeFrameGPU->getTotalClustersPerROFrange(offset, rofs, 1),
-  //                                                   mTimeFrameGPU->getStream(chunkId).get()));
-
-  //       // Reset used tracklets
-  //       checkGPUError(cudaMemsetAsync(mTimeFrameGPU->getChunk(chunkId).getDeviceUsedTracklets(),
-  //                                     false,
-  //                                     sizeof(unsigned char) * mVrtParams.maxTrackletsPerCluster * mTimeFrameGPU->getTotalClustersPerROFrange(offset, rofs, 1),
-  //                                     mTimeFrameGPU->getStream(chunkId).get()),
-  //                     __FILE__, __LINE__);
-
-  //       gpu::trackletSelectionKernelMultipleRof<false><<<rofs, 1024, 0, mTimeFrameGPU->getStream(chunkId).get()>>>(
-  //         mTimeFrameGPU->getChunk(chunkId).getDeviceClusters(0),            // const Cluster* clusters0,               // Clusters on layer 0
-  //         mTimeFrameGPU->getChunk(chunkId).getDeviceClusters(1),            // const Cluster* clusters1,               // Clusters on layer 1
-  //         mTimeFrameGPU->getDeviceROframesClusters(0),                      // const int* sizeClustersL0,              // Number of clusters on layer 0 per ROF
-  //         mTimeFrameGPU->getDeviceROframesClusters(1),                      // const int* sizeClustersL1,              // Number of clusters on layer 1 per ROF
-  //         mTimeFrameGPU->getChunk(chunkId).getDeviceTracklets(0),           // Tracklet* tracklets01,                  // Tracklets on layer 0-1
-  //         mTimeFrameGPU->getChunk(chunkId).getDeviceTracklets(1),           // Tracklet* tracklets12,                  // Tracklets on layer 1-2
-  //         mTimeFrameGPU->getChunk(chunkId).getDeviceNTrackletCluster(0),    // const int* nFoundTracklets01,           // Number of tracklets found on layers 0-1
-  //         mTimeFrameGPU->getChunk(chunkId).getDeviceNTrackletCluster(1),    // const int* nFoundTracklet12,            // Number of tracklets found on layers 1-2
-  //         mTimeFrameGPU->getChunk(chunkId).getDeviceUsedTracklets(),        // unsigned char* usedTracklets,           // Used tracklets
-  //         mTimeFrameGPU->getChunk(chunkId).getDeviceLines(),                // Line* lines,                            // Lines
-  //         mTimeFrameGPU->getChunk(chunkId).getDeviceNFoundLines(),          // int* nFoundLines,                       // Number of found lines
-  //         mTimeFrameGPU->getChunk(chunkId).getDeviceNExclusiveFoundLines(), // int* nExclusiveFoundLines,              // Number of found lines exclusive scan
-  //         offset,                                                           // const unsigned int startRofId,          // Starting ROF ID
-  //         rofs,                                                             // const unsigned int rofSize,             // Number of ROFs to consider
-  //         mVrtParams.maxTrackletsPerCluster,                                // const int maxTrackletsPerCluster = 1e2, // Maximum number of tracklets per cluster
-  //         mVrtParams.tanLambdaCut,                                          // const float tanLambdaCut = 0.025f,      // Cut on tan lambda
-  //         mVrtParams.phiCut);                                               // const float phiCut = 0.002f)            // Cut on phi
-
-  //       int nClusters = mTimeFrameGPU->getTotalClustersPerROFrange(offset, rofs, 1);
-  //       int lastFoundLines;
-  //       std::vector<int> exclusiveFoundLinesHost(nClusters + 1);
-
-  //       // Obtain whole exclusive sum including nCluster+1 element  (nCluster+1)th element is the total number of found lines.
-  //       checkGPUError(cudaMemcpyAsync(exclusiveFoundLinesHost.data(), mTimeFrameGPU->getChunk(chunkId).getDeviceNExclusiveFoundLines(), (nClusters) * sizeof(int), cudaMemcpyDeviceToHost, mTimeFrameGPU->getStream(chunkId).get()));
-  //       checkGPUError(cudaMemcpyAsync(&lastFoundLines, mTimeFrameGPU->getChunk(chunkId).getDeviceNFoundLines() + nClusters - 1, sizeof(int), cudaMemcpyDeviceToHost, mTimeFrameGPU->getStream(chunkId).get()));
-  //       exclusiveFoundLinesHost[nClusters] = exclusiveFoundLinesHost[nClusters - 1] + lastFoundLines;
-
-  //       std::vector<Line> lines(exclusiveFoundLinesHost[nClusters]);
-  //       // LOGP(info, "rof: {} found {} lines", exclusiveFoundLinesHost[nClusters]);
-
-  //       checkGPUError(cudaMemcpyAsync(lines.data(), mTimeFrameGPU->getChunk(chunkId).getDeviceLines(), sizeof(Line) * lines.size(), cudaMemcpyDeviceToHost, mTimeFrameGPU->getStream(chunkId).get()));
-  //       checkGPUError(cudaStreamSynchronize(mTimeFrameGPU->getStream(chunkId).get()));
-
-  //       // Compute vertices
-  //       int counter{0};
-  //       std::vector<ClusterLines> clusterLines;
-  //       std::vector<bool> usedLines;
-  //       for (int iRof{0}; iRof < rofs; ++iRof) {
-  //         auto rof = offset + iRof;
-  //         auto clustersL1offsetRof = mTimeFrameGPU->getROframeClusters(1)[rof] - mTimeFrameGPU->getROframeClusters(1)[offset]; // starting cluster offset for this ROF
-  //         auto nClustersL1Rof = mTimeFrameGPU->getROframeClusters(1)[rof + 1] - mTimeFrameGPU->getROframeClusters(1)[rof];     // number of clusters for this ROF
-  //         auto linesOffsetRof = exclusiveFoundLinesHost[clustersL1offsetRof];                                                  // starting line offset for this ROF
-  //         auto nLinesRof = exclusiveFoundLinesHost[clustersL1offsetRof + nClustersL1Rof] - linesOffsetRof;
-  //         counter += nLinesRof;
-
-  //         gsl::span<const o2::its::Line> linesInRof(lines.data() + linesOffsetRof, static_cast<gsl::span<o2::its::Line>::size_type>(nLinesRof));
-
-  //         usedLines.resize(linesInRof.size(), false);
-  //         usedLines.assign(linesInRof.size(), false);
-  //         clusterLines.clear();
-  //         clusterLines.reserve(nClustersL1Rof);
-  //         computeVerticesInRof(rof,
-  //                              linesInRof,
-  //                              usedLines,
-  //                              clusterLines,
-  //                              mTimeFrameGPU->getBeamXY(),
-  //                              mTimeFrameGPU->getVerticesInChunks()[chunkId],
-  //                              mTimeFrameGPU->getNVerticesInChunks()[chunkId],
-  //                              mTimeFrameGPU->hasMCinformation() ? mTimeFrameGPU : nullptr,
-  //                              mTimeFrameGPU->hasMCinformation() ? &mTimeFrameGPU->getLabelsInChunks()[chunkId] : nullptr);
-  //         LOGP(info, "chid: {} rofid: {} vertices: {}", chunkId, iRof, mTimeFrameGPU->getNVerticesInChunks()[chunkId][iRof].size());
-  //       }
-  //     };
-
-  //     // Do work
-  //     threads[chunkId] = std::thread(doVertexReconstruction);
-  //     offset += rofs;
-  //   }
-  //   for (auto& thread : threads) {
-  //     if (thread.joinable()) { // in case not all partitions were fed with data
-  //       thread.join();
-  //     }
-  //   }
-  //   for (int chunkId{0}; chunkId < mTimeFrameGPU->getNChunks(); ++chunkId) {
-  //     int start{0};
-  //     for (int iRof{0}; iRof < mTimeFrameGPU->getNVerticesInChunks()[chunkId].size(); ++iRof) {
-  //       gsl::span<const Vertex> rofVerts{mTimeFrameGPU->getVerticesInChunks()[chunkId].data() + start, static_cast<gsl::span<Vertex>::size_type>(mTimeFrameGPU->getNVerticesInChunks()[chunkId][iRof])};
-  //       mTimeFrameGPU->addPrimaryVertices(rofVerts);
-  //       if (mTimeFrameGPU->hasMCinformation()) {
-  //         mTimeFrameGPU->getVerticesLabels().emplace_back();
-  //         // TODO: add MC labels
-  //       }
-  //       start += mTimeFrameGPU->getNVerticesInChunks()[chunkId][iRof];
-  //     }
-  //   }
-  // } while (offset < mTimeFrameGPU->mNrof - 1); // offset is referring to the ROF id
-  // mTimeFrameGPU->wipe(3);
+  for (int chunkId{0}; chunkId < mTimeFrameGPU->getNChunks(); ++chunkId) {
+    int start{0};
+    for (int rofId{0}; rofId < mTimeFrameGPU->getNVerticesInChunks()[chunkId].size(); ++rofId) {
+      gsl::span<const Vertex> rofVerts{mTimeFrameGPU->getVerticesInChunks()[chunkId].data() + start, static_cast<gsl::span<Vertex>::size_type>(mTimeFrameGPU->getNVerticesInChunks()[chunkId][rofId])};
+      mTimeFrameGPU->addPrimaryVertices(rofVerts);
+      if (mTimeFrameGPU->hasMCinformation()) {
+        mTimeFrameGPU->getVerticesLabels().emplace_back();
+        // TODO: add MC labels
+      }
+      start += mTimeFrameGPU->getNVerticesInChunks()[chunkId][rofId];
+    }
+  }
+  mTimeFrameGPU->wipe(3);
 }
 
 void VertexerTraitsGPU::computeTrackletMatching()

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -343,6 +343,7 @@ void VertexerTraits::computeVertices()
   std::vector<int> noClustersVec(mTimeFrame->getNrof(), 0);
   for (int rofId{0}; rofId < mTimeFrame->getNrof(); ++rofId) {
     const int numTracklets{static_cast<int>(mTimeFrame->getLines(rofId).size())};
+    // LOGP(info, "rof: {} lines: {}", rofId, numTracklets);
     std::vector<bool> usedTracklets(numTracklets, false);
     for (int line1{0}; line1 < numTracklets; ++line1) {
       if (usedTracklets[line1]) {
@@ -457,6 +458,7 @@ void VertexerTraits::computeVertices()
       }
     }
     mTimeFrame->addPrimaryVertices(vertices);
+    LOGP(info, "rof: {} vertices: {}", rofId, vertices.size());
   }
 #ifdef VTX_DEBUG
   TFile* dbg_file = TFile::Open("artefacts_tf.root", "update");
@@ -504,6 +506,7 @@ void VertexerTraits::computeVerticesInRof(int rofId,
 {
   int foundVertices{0};
   const int numTracklets{static_cast<int>(lines.size())};
+  // LOGP(info, "rof: {} lines: {}", rofId, numTracklets);
   for (int line1{0}; line1 < numTracklets; ++line1) {
     if (usedLines[line1]) {
       continue;

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -343,7 +343,7 @@ void VertexerTraits::computeVertices()
   std::vector<int> noClustersVec(mTimeFrame->getNrof(), 0);
   for (int rofId{0}; rofId < mTimeFrame->getNrof(); ++rofId) {
     const int numTracklets{static_cast<int>(mTimeFrame->getLines(rofId).size())};
-    // LOGP(info, "rof: {} lines: {}", rofId, numTracklets);
+
     std::vector<bool> usedTracklets(numTracklets, false);
     for (int line1{0}; line1 < numTracklets; ++line1) {
       if (usedTracklets[line1]) {
@@ -458,7 +458,6 @@ void VertexerTraits::computeVertices()
       }
     }
     mTimeFrame->addPrimaryVertices(vertices);
-    LOGP(info, "rof: {} vertices: {}", rofId, vertices.size());
   }
 #ifdef VTX_DEBUG
   TFile* dbg_file = TFile::Open("artefacts_tf.root", "update");
@@ -506,7 +505,6 @@ void VertexerTraits::computeVerticesInRof(int rofId,
 {
   int foundVertices{0};
   const int numTracklets{static_cast<int>(lines.size())};
-  // LOGP(info, "rof: {} lines: {}", rofId, numTracklets);
   for (int line1{0}; line1 < numTracklets; ++line1) {
     if (usedLines[line1]) {
       continue;

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -255,6 +255,7 @@ void TrackerDPL::run(ProcessingContext& pc)
   }
   LOG(info) << fmt::format(" - rejected {}/{} ROFs: random/mult.sel:{} (seed {}), vtx.sel:{}", cutRandomMult + cutVertexMult, rofspan.size(), cutRandomMult, multEst.lastRandomSeed, cutVertexMult);
   LOG(info) << fmt::format(" - Vertex seeding total elapsed time: {} ms for {} vertices found in {} ROFs", vertexerElapsedTime, mTimeFrame->getPrimaryVerticesNum(), rofspan.size());
+  // LOGP(fatal, "fatalising here.");
   if (mOverrideBeamEstimation) {
     LOG(info) << fmt::format(" - Beam position set to: {}, {} from meanvertex object", mTimeFrame->getBeamX(), mTimeFrame->getBeamY());
   } else {

--- a/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
+++ b/Detectors/ITSMFT/ITS/workflow/src/TrackerSpec.cxx
@@ -255,7 +255,7 @@ void TrackerDPL::run(ProcessingContext& pc)
   }
   LOG(info) << fmt::format(" - rejected {}/{} ROFs: random/mult.sel:{} (seed {}), vtx.sel:{}", cutRandomMult + cutVertexMult, rofspan.size(), cutRandomMult, multEst.lastRandomSeed, cutVertexMult);
   LOG(info) << fmt::format(" - Vertex seeding total elapsed time: {} ms for {} vertices found in {} ROFs", vertexerElapsedTime, mTimeFrame->getPrimaryVerticesNum(), rofspan.size());
-  // LOGP(fatal, "fatalising here.");
+
   if (mOverrideBeamEstimation) {
     LOG(info) << fmt::format(" - Beam position set to: {}, {} from meanvertex object", mTimeFrame->getBeamX(), mTimeFrame->getBeamY());
   } else {


### PR DESCRIPTION
- Remove synchronisation at the end of chunk processing
- Restore vertex saving

In previous approach we had the three threads to be joined after they terminated to process a chunk.
Usually we have more than one chunk to process per TF, this then caused all threads to be as slow as 
the slowest one.

Now the synchronisation happens outside the re-scheduling of chunks data, hence it happen only once
