### PR TITLE
o2-sim: Support for (ALICE3) field prototyping

### DIFF
--- a/Common/Field/CMakeLists.txt
+++ b/Common/Field/CMakeLists.txt
@@ -16,7 +16,8 @@ o2_add_library(Field
                        src/MagFieldParam.cxx
                        src/MagneticField.cxx
                        src/MagneticWrapperChebyshev.cxx
-                       PUBLIC_LINK_LIBRARIES O2::MathUtils FairRoot::Base)
+                       src/ALICE3MagneticField.cxx
+                       PUBLIC_LINK_LIBRARIES O2::MathUtils FairRoot::Base O2::CommonUtils)
 
 o2_target_root_dictionary(Field
                           HEADERS include/Field/MagneticWrapperChebyshev.h
@@ -24,7 +25,8 @@ o2_target_root_dictionary(Field
                                   include/Field/MagFieldParam.h
                                   include/Field/MagFieldContFact.h
                                   include/Field/MagFieldFast.h
-                                  include/Field/MagFieldFact.h)
+                                  include/Field/MagFieldFact.h
+                                  include/Field/ALICE3MagneticField.h)
 
 o2_add_test(MagneticField
             SOURCES test/testMagneticField.cxx

--- a/Common/Field/include/Field/ALICE3MagneticField.h
+++ b/Common/Field/include/Field/ALICE3MagneticField.h
@@ -1,0 +1,83 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file ALICE3MagneticField.h
+/// \brief A simple magnetic field class for ALICE3 R&D
+/// \author sandro.wenzel@cern.ch
+
+#ifndef ALICEO2_FIELD_ALICE3MAGNETICFIELD_H_
+#define ALICEO2_FIELD_ALICE3MAGNETICFIELD_H_
+
+#include "FairField.h" // for FairField
+#include "Rtypes.h"    // for ClassDef
+
+namespace o2
+{
+namespace field
+{
+
+/// A simple magnetic field class for ALICE3 R&D. Can easily
+/// be used in Virtual Monte Carlo simulations.
+class ALICE3MagneticField : public FairField
+{
+ public:
+  ALICE3MagneticField() : FairField()
+  {
+    fType = 2;
+    init();
+  }
+
+  ~ALICE3MagneticField() override = default;
+
+  /// X component, avoid using since slow
+  Double_t GetBx(Double_t x, Double_t y, Double_t z) override
+  {
+    double xyz[3] = {x, y, z}, b[3];
+    ALICE3MagneticField::Field(xyz, b);
+    return b[0];
+  }
+
+  /// Y component, avoid using since slow
+  Double_t GetBy(Double_t x, Double_t y, Double_t z) override
+  {
+    double xyz[3] = {x, y, z}, b[3];
+    ALICE3MagneticField::Field(xyz, b);
+    return b[1];
+  }
+
+  /// Z component
+  Double_t GetBz(Double_t x, Double_t y, Double_t z) override
+  {
+    double xyz[3] = {x, y, z}, b[3];
+    ALICE3MagneticField::Field(xyz, b);
+    return b[2];
+  }
+
+  /// Method to calculate the field at point xyz
+  /// Main interface from TVirtualMagField used in simulation
+  void Field(const Double_t* __restrict__ point, Double_t* __restrict__ bField) override;
+
+ private:
+  // defining a function type, that could be initialized during runtime from a ROOT macro
+  // to ease fast R&D prototyping
+  typedef std::function<void(const double* __restrict__, double* __restrict__)> FieldEvalFcn;
+  FieldEvalFcn mJITFieldFunction; //!
+
+  void init();
+  void initJITFieldFunction();
+
+  //  ClassDefOverride(o2::field::ALICE3MagneticField, 1)
+};
+
+} // end namespace field
+} // end namespace o2
+
+#endif

--- a/Common/Field/src/ALICE3MagneticField.cxx
+++ b/Common/Field/src/ALICE3MagneticField.cxx
@@ -1,0 +1,57 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file ALICE3MagneticField.cxx
+/// \brief Implementation of the ALICE3 MagF class
+/// \author sandro.wenzel@cern.ch
+
+#include <Field/ALICE3MagneticField.h>
+#include <fairlogger/Logger.h>                    // for FairLogger
+#include <CommonUtils/ConfigurationMacroHelper.h> // for just-in-time compilation of macros
+#include <filesystem>
+
+using namespace o2::field;
+// ClassImp(ALICE3MagneticField)
+
+// initializes the just-in-time implementation of the field function
+void ALICE3MagneticField::initJITFieldFunction()
+{
+  // for now we check if there is an env variable, pointing to a macro file
+  auto filename = getenv("ALICE3_MAGFIELD_MACRO");
+  if (filename) {
+    LOG(info) << "Taking ALICE3 magnetic field implementation from macro (just in time)";
+    if (std::filesystem::exists(filename)) {
+      // if this file exists we will compile the hook on the fly
+      mJITFieldFunction = o2::conf::GetFromMacro<FieldEvalFcn>(filename, "field()", "function<void(const double*,double*)>", "o2mc_alice3_field_hook");
+      LOG(info) << "Hook initialized from file " << filename;
+    } else {
+      LOG(error) << "Did not find file " << filename;
+    }
+  }
+}
+
+void ALICE3MagneticField::init()
+{
+  LOG(info) << "Initializing ALICE3 magnetic field";
+  initJITFieldFunction();
+}
+
+void ALICE3MagneticField::Field(const Double_t* __restrict__ xyz, Double_t* __restrict__ b)
+{
+  if (mJITFieldFunction) {
+    mJITFieldFunction(xyz, b);
+  } else {
+    // TODO: These values are just toy; Real implementation should go here
+    b[0] = 0.;
+    b[1] = 0.;
+    b[2] = -10.; // -10 kGauss
+  }
+}

--- a/Common/Field/src/FieldLinkDef.h
+++ b/Common/Field/src/FieldLinkDef.h
@@ -20,5 +20,6 @@
 #pragma link C++ class o2::field::MagFieldContFact + ;
 #pragma link C++ class o2::field::MagFieldFact + ;
 #pragma link C++ class o2::field::MagFieldFast + ;
+#pragma link C++ class o2::field::ALICE3MagneticField + ;
 
 #endif

--- a/Common/Utils/include/CommonUtils/ConfigurationMacroHelper.h
+++ b/Common/Utils/include/CommonUtils/ConfigurationMacroHelper.h
@@ -55,8 +55,9 @@ T GetFromMacro(const std::string& file, const std::string& funcname, const std::
   }
 
   /** check the return type matches the required one **/
-  if (strcmp(gROOT->GetGlobalFunction(gfunc.c_str())->GetReturnTypeName(), type.c_str())) {
-    LOG(info) << "Global function '" << gfunc << "' does not return a '" << type << "' type";
+  auto returnedtype = gROOT->GetGlobalFunction(gfunc.c_str())->GetReturnTypeName();
+  if (strcmp(returnedtype, type.c_str())) {
+    LOG(info) << "Global function '" << gfunc << "' does not return a '" << type << "' type ( but " << returnedtype << " )";
     return nullptr;
   }
 

--- a/Detectors/Base/include/DetectorsBase/SimFieldUtils.h
+++ b/Detectors/Base/include/DetectorsBase/SimFieldUtils.h
@@ -15,12 +15,15 @@
 #ifndef ALICEO2_BASE_SIMFIELDUTILS_H_
 #define ALICEO2_BASE_SIMFIELDUTILS_H_
 
+class FairField;
+
 namespace o2
 {
-namespace field
-{
-class MagneticField;
-}
+// namespace field
+
+//{
+// class MagneticField;
+//}
 
 namespace base
 {
@@ -30,7 +33,7 @@ class SimFieldUtils
  public:
   // a common entry point to create the mag field for simulation
   // based on the simulation configuration in SimConfig
-  static o2::field::MagneticField* const createMagField();
+  static FairField* const createMagField();
 };
 
 } // namespace base

--- a/Detectors/Base/src/SimFieldUtils.cxx
+++ b/Detectors/Base/src/SimFieldUtils.cxx
@@ -11,14 +11,19 @@
 
 #include <DetectorsBase/SimFieldUtils.h>
 #include <Field/MagneticField.h>
+#include <Field/ALICE3MagneticField.h>
 #include <SimConfig/SimConfig.h>
 #include <CCDB/BasicCCDBManager.h>
 #include <DataFormatsParameters/GRPMagField.h>
 
 using namespace o2::base;
 
-o2::field::MagneticField* const SimFieldUtils::createMagField()
+FairField* const SimFieldUtils::createMagField()
 {
+  if (getenv("ALICE3_SIM_FIELD")) {
+    return new o2::field::ALICE3MagneticField();
+  }
+
   auto& confref = o2::conf::SimConfig::Instance();
   // a) take field from CDDB
   const auto fieldmode = confref.getConfigData().mFieldMode;

--- a/macro/o2sim.C
+++ b/macro/o2sim.C
@@ -34,6 +34,7 @@
 #include <CommonUtils/NameConf.h>
 #include "DetectorsBase/Aligner.h"
 #include <FairRootFileSink.h>
+#include <FairField.h>
 #include <unistd.h>
 #include <sstream>
 #endif
@@ -249,17 +250,25 @@ FairRunSim* o2sim_init(bool asservice, bool evalmat = false)
     o2::parameters::GRPMagField grp;
     auto field = dynamic_cast<o2::field::MagneticField*>(run->GetField());
     if (!field) {
-      LOGP(fatal, "Failed to get magnetic field from the FairRunSim");
-    }
-    o2::units::Current_t currDip = field->getCurrentDipole();
-    o2::units::Current_t currL3 = field->getCurrentSolenoid();
-    grp.setL3Current(currL3);
-    grp.setDipoleCurrent(currDip);
-    grp.setFieldUniformity(field->IsUniform());
+      // this is not the ordinary Run3 MagneticField
+      // Let's see if it is another FairField implementation.
+      LOG(warn) << "No o2::field::MagneticField instance available; Not writing GRP - beware that propagation to other tasks may not work. Checking if it is at least a FairFied...";
+      if (!dynamic_cast<FairField*>(run->GetField())) {
+        LOGP(fatal, "Failed to get magnetic field from the FairRunSim");
+      } else {
+        LOG(warn) << " ... FairField found";
+      }
+    } else {
+      o2::units::Current_t currDip = field->getCurrentDipole();
+      o2::units::Current_t currL3 = field->getCurrentSolenoid();
+      grp.setL3Current(currL3);
+      grp.setDipoleCurrent(currDip);
+      grp.setFieldUniformity(field->IsUniform());
 
-    std::string grpfilename = o2::base::NameConf::getGRPMagFieldFileName(confref.getOutPrefix());
-    TFile grpF(grpfilename.c_str(), "recreate");
-    grpF.WriteObjectAny(&grp, grp.Class(), o2::base::NameConf::CCDBOBJECT.data());
+      std::string grpfilename = o2::base::NameConf::getGRPMagFieldFileName(confref.getOutPrefix());
+      TFile grpF(grpfilename.c_str(), "recreate");
+      grpF.WriteObjectAny(&grp, grp.Class(), o2::base::NameConf::CCDBOBJECT.data());
+    }
   }
   // create GRPLHCIF object (just a placeholder, bunch filling will be set in digitization)
   {


### PR DESCRIPTION
Possibility to instantiate a field class during
simulation that differs from o2::field::MagneticField.

This should allow to play with configurations for ALICE3, or other, without disturbing Run3.

Activate this with `export ALICE3_SIM_FIELD=ON`.

Moreover, this commit gives the possibility to take the actual TVirtualMagField field implementation from a ROOT macro with just-in-time compilation. Use this via:

`export ALICE3_MAGFIELD_MACRO=field.C`

where field.C, contains code returning a lambda, for instance

```
std::function<void(const double*, double*)> field() {
  return [](const double*, double* b) {
    static int count=0;
    if (count < 5) {
      std::cerr << "field call\n";
      count += 1;
    }
    b[0] = 1.;
    b[1] = 1.;
    b[2] = 2.;
  };
}
```

This allows to change the field setup without recompiling O2.