### PR TITLE
Optionally do not process CTF which was completely skimmed out

### DIFF
--- a/Detectors/CTF/workflow/include/CTFWorkflow/CTFReaderSpec.h
+++ b/Detectors/CTF/workflow/include/CTFWorkflow/CTFReaderSpec.h
@@ -32,6 +32,7 @@ struct CTFReaderInp {
   std::string metricChannel{};
   std::string fileIRFrames{};
   std::vector<int> ctfIDs{};
+  bool skipSkimmedOutTF = false;
   bool allowMissingDetectors = false;
   bool sup0xccdb = false;
   int maxFileCache = 1;

--- a/Detectors/CTF/workflow/src/CTFWriterSpec.cxx
+++ b/Detectors/CTF/workflow/src/CTFWriterSpec.cxx
@@ -293,7 +293,7 @@ size_t CTFWriterSpec::processDet(o2::framework::ProcessingContext& pc, DetID det
   const o2::ctf::BufferType* bdata = ctfBuffer.data();
   if (bdata) {
     if (warnedEmpty) {
-      throw std::runtime_error(fmt::format("Non-empty input was seen at {}-th TF after empty one for {}, this will lead misalignment of detectors in CTF", mNCTF, det.getName()));
+      throw std::runtime_error(fmt::format("Non-empty input was seen at {}-th TF after empty one for {}, this will lead to misalignment of detectors in CTF", mNCTF, det.getName()));
     }
     const auto ctfImage = C::getImage(bdata);
     ctfImage.print(o2::utils::Str::concat_string(det.getName(), ": "), mVerbosity);
@@ -324,7 +324,7 @@ size_t CTFWriterSpec::processDet(o2::framework::ProcessingContext& pc, DetID det
                   try {
                     freq.addFrequencies(bl.getDict(), bl.getDict() + bl.getNDict(), md.min);
                   } catch (const std::overflow_error& e) {
-                    LOGP(warning, "unable to frequency table for {}, block {} due to overflow", det.getName(), ib);
+                    LOGP(warning, "unable to add frequency table for {}, block {} due to overflow", det.getName(), ib);
                     mIsSaturatedFrequencyTable[det][ib] = true;
                     return false;
                   }
@@ -341,7 +341,7 @@ size_t CTFWriterSpec::processDet(o2::framework::ProcessingContext& pc, DetID det
   } else {
     if (!warnedEmpty) {
       if (mNCTF) {
-        throw std::runtime_error(fmt::format("Empty input was seen at {}-th TF after non-empty one for {}, this will lead misalignment of detectors in CTF", mNCTF, det.getName()));
+        throw std::runtime_error(fmt::format("Empty input was seen at {}-th TF after non-empty one for {}, this will lead to misalignment of detectors in CTF", mNCTF, det.getName()));
       }
       LOGP(important, "Empty CTF provided for {}, skipping and will not report anymore", det.getName());
       warnedEmpty = true;

--- a/Detectors/CTF/workflow/src/ctf-reader-workflow.cxx
+++ b/Detectors/CTF/workflow/src/ctf-reader-workflow.cxx
@@ -63,6 +63,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
   options.push_back(ConfigParamSpec{"ctf-data-subspec", VariantType::Int, 0, {"subspec to use for decoded CTF messages (use non-0 if CTF writer will be attached downstream)"}});
   options.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}});
   options.push_back(ConfigParamSpec{"ir-frames-files", VariantType::String, "", {"If non empty, inject selected IRFrames from this file"}});
+  options.push_back(ConfigParamSpec{"skip-skimmed-out-tf", VariantType::Bool, false, {"Do not process TFs with empty IR-Frame coverage"}});
   //
   options.push_back(ConfigParamSpec{"its-digits", VariantType::Bool, false, {"convert ITS clusters to digits"}});
   options.push_back(ConfigParamSpec{"mft-digits", VariantType::Bool, false, {"convert MFT clusters to digits"}});
@@ -122,6 +123,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   ctfInput.sup0xccdb = !configcontext.options().get<bool>("send-diststf-0xccdb");
   ctfInput.minSHM = std::stoul(configcontext.options().get<std::string>("timeframes-shm-limit"));
   ctfInput.fileIRFrames = configcontext.options().get<std::string>("ir-frames-files");
+  ctfInput.skipSkimmedOutTF = configcontext.options().get<bool>("skip-skimmed-out-tf");
   int verbosity = configcontext.options().get<int>("ctf-reader-verbosity");
 
   int rateLimitingIPCID = std::stoi(configcontext.options().get<std::string>("timeframes-rate-limit-ipcid"));


### PR DESCRIPTION
With option --skip-skimmed-out-tf the ctf-reader will not process the TF in the skimming mode if no IRFrame overlaps with it. Otherwise an empty entry will appear in the skimmed CTF tree