### PR TITLE
[ITS, ITS3] Restore build level for material budget studies

### DIFF
--- a/Detectors/ITSMFT/ITS/base/include/ITSBase/DescriptorInnerBarrel.h
+++ b/Detectors/ITSMFT/ITS/base/include/ITSBase/DescriptorInnerBarrel.h
@@ -56,10 +56,12 @@ class DescriptorInnerBarrel : public TObject
   double mWrapperZSpan{70.};
 
   // layer properties
-  double mSensorLayerThickness{};           // sensor thickness
-  std::vector<double> mLayerRadii{};        // Vector of layer radius
-  std::vector<double> mDetectorThickness{}; // Vector of detector thickness
+  double mSensorLayerThickness{};           //! sensor thickness
+  std::vector<double> mLayerRadii{};        //! Vector of layer radius
+  std::vector<double> mDetectorThickness{}; //! Vector of detector thickness
   std::vector<int> mChipTypeID{};           //! Vector of unique chip ID
+
+  std::vector<int> mBuildLevel;             //! Vector of Material Budget Studies
 
   /// \cond CLASSIMP
   ClassDef(DescriptorInnerBarrel, 1); /// ITS inner barrel geometry descriptor

--- a/Detectors/ITSMFT/ITS/base/include/ITSBase/DescriptorInnerBarrel.h
+++ b/Detectors/ITSMFT/ITS/base/include/ITSBase/DescriptorInnerBarrel.h
@@ -61,7 +61,7 @@ class DescriptorInnerBarrel : public TObject
   std::vector<double> mDetectorThickness{}; //! Vector of detector thickness
   std::vector<int> mChipTypeID{};           //! Vector of unique chip ID
 
-  std::vector<int> mBuildLevel;             //! Vector of Material Budget Studies
+  std::vector<int> mBuildLevel; //! Vector of Material Budget Studies
 
   /// \cond CLASSIMP
   ClassDef(DescriptorInnerBarrel, 1); /// ITS inner barrel geometry descriptor

--- a/Detectors/ITSMFT/ITS/base/include/ITSBase/ITSBaseParam.h
+++ b/Detectors/ITSMFT/ITS/base/include/ITSBase/ITSBaseParam.h
@@ -27,6 +27,7 @@ struct ITSBaseParam : public o2::conf::ConfigurableParamHelper<ITSBaseParam> {
   // Geometry Builder parameters
   bool buildCYSSAssembly = true;
   bool buildEndWheels = true;
+  int buildLevel = 0;
   O2ParamDef(ITSBaseParam, "ITSBase");
 };
 

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/DescriptorInnerBarrelITS2.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/DescriptorInnerBarrelITS2.h
@@ -40,7 +40,7 @@ class DescriptorInnerBarrelITS2 : public o2::its::DescriptorInnerBarrel
   DescriptorInnerBarrelITS2(const DescriptorInnerBarrelITS2& src) = delete;
   DescriptorInnerBarrelITS2& operator=(const DescriptorInnerBarrelITS2& geom) = delete;
 
-  void configure();
+  void configure(int buildLevel = 0);
 
   V3Layer* createLayer(int idLayer, TGeoVolume* dest);
   void createServices(TGeoVolume* dest);
@@ -62,7 +62,6 @@ class DescriptorInnerBarrelITS2 : public o2::its::DescriptorInnerBarrel
   std::vector<double> mChipThickness{}; //! Vector of chip thicknesses
   std::vector<double> mStaveWidth{};    //! Vector of stave width (only used for turbo)
   std::vector<double> mStaveTilt{};     //! Vector of stave tilt (only used for turbo)
-  std::vector<int> mBuildLevel{};       //! Vector of build level
   std::vector<V3Layer*> mLayer{};       //! Vector of layers
 
   /// \cond CLASSIMP

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
@@ -95,7 +95,7 @@ class Detector : public o2::base::DetImpl<Detector>
   void Register() override;
 
   /// We need this as a method to access members
-  void configOuterBarrelITS(int nInnerBarrelLayers);
+  void configOuterBarrelITS(int nInnerBarrelLayers, int buildLevel=0);
 
   /// Gets the produced collections
   std::vector<o2::itsmft::Hit>* getHits(Int_t iColl) const

--- a/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
+++ b/Detectors/ITSMFT/ITS/simulation/include/ITSSimulation/Detector.h
@@ -95,7 +95,7 @@ class Detector : public o2::base::DetImpl<Detector>
   void Register() override;
 
   /// We need this as a method to access members
-  void configOuterBarrelITS(int nInnerBarrelLayers, int buildLevel=0);
+  void configOuterBarrelITS(int nInnerBarrelLayers, int buildLevel = 0);
 
   /// Gets the produced collections
   std::vector<o2::itsmft::Hit>* getHits(Int_t iColl) const

--- a/Detectors/ITSMFT/ITS/simulation/src/DescriptorInnerBarrelITS2.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/DescriptorInnerBarrelITS2.cxx
@@ -59,7 +59,7 @@ DescriptorInnerBarrelITS2::DescriptorInnerBarrelITS2(int nlayers) : DescriptorIn
 }
 
 //________________________________________________________________
-void DescriptorInnerBarrelITS2::configure()
+void DescriptorInnerBarrelITS2::configure(int buildLevel)
 {
   // build ITS2 upgrade detector
   mTurboLayer.resize(mNumLayers);
@@ -92,7 +92,7 @@ void DescriptorInnerBarrelITS2::configure()
     mStaveTilt[idLayer] = radii2Turbo(IBdat[idLayer][0], IBdat[idLayer][1], IBdat[idLayer][2], o2::itsmft::SegmentationAlpide::SensorSizeRows);
     mDetectorThickness[idLayer] = mSensorLayerThickness;
     mChipTypeID[idLayer] = 0;
-    mBuildLevel[idLayer] = 0;
+    mBuildLevel[idLayer] = buildLevel;
 
     LOG(info) << "L# " << idLayer << " Phi:" << mLayerPhi0[idLayer] << " R:" << mLayerRadii[idLayer] << " Nst:" << mStavePerLayer[idLayer] << " Nunit:" << mUnitPerStave[idLayer]
               << " W:" << mStaveWidth[idLayer] << " Tilt:" << mStaveTilt[idLayer] << " Lthick:" << mChipThickness[idLayer] << " Dthick:" << mDetectorThickness[idLayer]

--- a/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
+++ b/Detectors/ITSMFT/ITS/simulation/src/Detector.cxx
@@ -15,6 +15,7 @@
 #include "ITSMFTBase/SegmentationAlpide.h"
 #include "ITSMFTSimulation/Hit.h"
 #include "ITSBase/GeometryTGeo.h"
+#include "ITSBase/ITSBaseParam.h"
 #include "ITSSimulation/Detector.h"
 #include "ITSSimulation/V3Layer.h"
 #include "ITSSimulation/V3Services.h"
@@ -79,11 +80,10 @@ Detector::Detector()
   mNumberLayers = mNumberInnerLayers + sNumberOuterLayers;
 }
 
-void Detector::configOuterBarrelITS(int nInnerBarrelLayers)
+void Detector::configOuterBarrelITS(int nInnerBarrelLayers, int buildLevel)
 {
   // build ITS outer barrel detector
   const int kNLr = 4;
-  const int kBuildLevel = 0;
   const int kSensTypeID = 0; // dummy id for Alpide sensor
 
   const double ChipThicknessOB = 100.e-4;
@@ -122,7 +122,7 @@ void Detector::configOuterBarrelITS(int nInnerBarrelLayers)
     nStaveLr = TMath::Nint(tdr5dat[idLr][kNStave]);
     nModPerStaveLr = TMath::Nint(tdr5dat[idLr][kNModPerStave]);
     defineLayer(idLr + nInnerBarrelLayers, phi0, rLr, nStaveLr, nModPerStaveLr, ChipThicknessOB, Segmentation::SensorLayerThickness,
-                kSensTypeID, kBuildLevel);
+                kSensTypeID, buildLevel);
   }
 }
 
@@ -154,9 +154,12 @@ Detector::Detector(Bool_t active, TString name, TString its3Version)
     LOG(fatal) << "Detector name not supported (options ITS and ITS3)";
   }
 
+  auto& param = ITSBaseParam::Instance();
+  int buildLevelITS = param.buildLevel;
+
   TString detName = GetName();
   if (detName == "ITS") {
-    ((DescriptorInnerBarrelITS2*)mDescriptorIB.get())->configure();
+    ((DescriptorInnerBarrelITS2*)mDescriptorIB.get())->configure(buildLevelITS);
   } else if (detName == "IT3") {
 #ifdef ENABLE_UPGRADES
     ((DescriptorInnerBarrelITS3*)mDescriptorIB.get())->configure();
@@ -210,7 +213,7 @@ Detector::Detector(Bool_t active, TString name, TString its3Version)
     mWrapperMinRadius[i] = mWrapperMaxRadius[i] = mWrapperZSpan[i] = -1;
   }
 
-  configOuterBarrelITS(mNumberInnerLayers);
+  configOuterBarrelITS(mNumberInnerLayers, buildLevelITS);
 }
 
 Detector::Detector(const Detector& rhs)

--- a/Detectors/Upgrades/ITS3/simulation/include/ITS3Simulation/DescriptorInnerBarrelITS3Param.h
+++ b/Detectors/Upgrades/ITS3/simulation/include/ITS3Simulation/DescriptorInnerBarrelITS3Param.h
@@ -39,6 +39,7 @@ enum class ITS3Version {
 
 struct DescriptorInnerBarrelITS3Param : public o2::conf::ConfigurableParamHelper<DescriptorInnerBarrelITS3Param> {
   ITS3Version mVersion = ITS3Version::None;
+  int mBuildLevel{0};
   std::string const& getITS3LayerConfigString() const;
   O2ParamDef(DescriptorInnerBarrelITS3Param, "DescriptorInnerBarrelITS3");
 };

--- a/Detectors/Upgrades/ITS3/simulation/include/ITS3Simulation/ITS3Layer.h
+++ b/Detectors/Upgrades/ITS3/simulation/include/ITS3Simulation/ITS3Layer.h
@@ -61,6 +61,7 @@ class ITS3Layer : public TObject
   void setLengthSemiCircleFoam(double lengthSemiCircleFoam) { mLengthSemiCircleFoam = lengthSemiCircleFoam; }
   void setThickGluedFoam(double thickGluedFoam) { mThickGluedFoam = thickGluedFoam; }
   void setGapXDirection(double gapXDirection) { mGapXDirection = gapXDirection; }
+  void setBuildLevel(int buildLevel) { mBuildLevel = buildLevel; }
 
  private:
   int mLayerNumber{0};              //! layer number

--- a/Detectors/Upgrades/ITS3/simulation/include/ITS3Simulation/ITS3Layer.h
+++ b/Detectors/Upgrades/ITS3/simulation/include/ITS3Simulation/ITS3Layer.h
@@ -76,6 +76,7 @@ class ITS3Layer : public TObject
   double mLengthSemiCircleFoam{0.}; //! semi-circle foam length
   double mThickGluedFoam{0.};       //! glued foam thickness
   double mGapXDirection{0.};        //! gap between quarter layer(only for layer 4)
+  int mBuildLevel{0};               //! build level for material budget studies
 
   ClassDefOverride(ITS3Layer, 0); // ITS3 geometry
 };                                // namespace its3

--- a/Detectors/Upgrades/ITS3/simulation/src/DescriptorInnerBarrelITS3.cxx
+++ b/Detectors/Upgrades/ITS3/simulation/src/DescriptorInnerBarrelITS3.cxx
@@ -183,6 +183,7 @@ ITS3Layer* DescriptorInnerBarrelITS3::createLayer(int idLayer, TGeoVolume* dest)
   mLayer[idLayer]->setHeightStripFoam(mHeightStripFoam[idLayer]);
   mLayer[idLayer]->setLengthSemiCircleFoam(mLengthSemiCircleFoam[idLayer]);
   mLayer[idLayer]->setThickGluedFoam(mThickGluedFoam[idLayer]);
+  mLayer[idLayer]->setBuildLevel(mBuildLevel[idLayer]);
   if (mVersion == "ThreeLayersNoDeadZones") {
     mLayer[idLayer]->createLayer(dest);
   } else if (mVersion == "ThreeLayers") {

--- a/Detectors/Upgrades/ITS3/simulation/src/DescriptorInnerBarrelITS3.cxx
+++ b/Detectors/Upgrades/ITS3/simulation/src/DescriptorInnerBarrelITS3.cxx
@@ -42,14 +42,14 @@ void DescriptorInnerBarrelITS3::configure()
 {
   // set version
   auto& param = DescriptorInnerBarrelITS3Param::Instance();
+  int buildLevel = param.mBuildLevel; // 0 by default
   if (param.getITS3LayerConfigString() != "") {
-    LOG(info) << "Instance \'DescriptorInnerBarrelITS3\' class with following parameters";
-    LOG(info) << param;
     setVersion(param.getITS3LayerConfigString());
-  } else {
-    LOG(info) << "Instance \'DescriptorInnerBarrelITS3\' class with following parameters";
-    LOG(info) << "DescriptorInnerBarrelITS3.mVersion : " << mVersion;
   }
+
+  LOG(info) << "Instance \'DescriptorInnerBarrelITS3\' class with following parameters";
+  LOG(info) << "DescriptorInnerBarrelITS3.mVersion : " << mVersion;
+  LOG(info) << "DescriptorInnerBarrelITS3.mBuildLevel : " << buildLevel;
 
   if (mVersion == "ThreeLayersNoDeadZones") {
     mNumLayers = 3;
@@ -76,6 +76,7 @@ void DescriptorInnerBarrelITS3::configure()
   mHeightStripFoam.resize(mNumLayers);
   mLengthSemiCircleFoam.resize(mNumLayers);
   mThickGluedFoam.resize(mNumLayers);
+  mBuildLevel.resize(mNumLayers);
 
   const double safety = 0.5;
 
@@ -99,6 +100,7 @@ void DescriptorInnerBarrelITS3::configure()
       mHeightStripFoam[idLayer] = IBtdr5dat[idLayer][6];
       mLengthSemiCircleFoam[idLayer] = IBtdr5dat[idLayer][7];
       mThickGluedFoam[idLayer] = IBtdr5dat[idLayer][8];
+      mBuildLevel[idLayer] = buildLevel;
       LOGP(info, "ITS3 L# {} R:{} Dthick:{} Gap:{} StripFoamHeight:{} SemiCircleFoamLength:{} ThickGluedFoam:{}",
            idLayer, mLayerRadii[idLayer], mDetectorThickness[idLayer], mGap[idLayer],
            mHeightStripFoam[idLayer], mLengthSemiCircleFoam[idLayer], mThickGluedFoam[idLayer]);
@@ -119,6 +121,7 @@ void DescriptorInnerBarrelITS3::configure()
       mHeightStripFoam[idLayer] = IBtdr5dat[idLayer][6];
       mLengthSemiCircleFoam[idLayer] = IBtdr5dat[idLayer][7];
       mThickGluedFoam[idLayer] = IBtdr5dat[idLayer][8];
+      mBuildLevel[idLayer] = buildLevel;
       LOGP(info, "ITS3 L# {} R:{} Dthick:{} Gap:{} NSubSensors:{} FringeChipWidth:{} MiddleChipWidth:{} StripFoamHeight:{} SemiCircleFoamLength:{} ThickGluedFoam:{}",
            idLayer, mLayerRadii[idLayer], mDetectorThickness[idLayer], mGap[idLayer],
            mNumSubSensorsHalfLayer[idLayer], mFringeChipWidth[idLayer], mMiddleChipWidth[idLayer],
@@ -140,6 +143,7 @@ void DescriptorInnerBarrelITS3::configure()
       mHeightStripFoam[idLayer] = IBtdr5dat[idLayer][6];
       mLengthSemiCircleFoam[idLayer] = IBtdr5dat[idLayer][7];
       mThickGluedFoam[idLayer] = IBtdr5dat[idLayer][8];
+      mBuildLevel[idLayer] = buildLevel;
       if (idLayer == 3) {
         mGapXDirection4thLayer = IBtdr5dat[idLayer][9];
         LOGP(info, "ITS3 L# {} R:{} Dthick:{} Gap:{} NSubSensors:{} FringeChipWidth:{} MiddleChipWidth:{} StripFoamHeight:{} SemiCircleFoamLength:{} ThickGluedFoam:{}, GapXDirection4thLayer:{}",

--- a/Detectors/Upgrades/ITS3/simulation/src/DescriptorInnerBarrelITS3.cxx
+++ b/Detectors/Upgrades/ITS3/simulation/src/DescriptorInnerBarrelITS3.cxx
@@ -42,14 +42,16 @@ void DescriptorInnerBarrelITS3::configure()
 {
   // set version
   auto& param = DescriptorInnerBarrelITS3Param::Instance();
-  int buildLevel = param.mBuildLevel; // 0 by default
+  int buildLevel = param.mBuildLevel;
   if (param.getITS3LayerConfigString() != "") {
+    LOG(info) << "Instance \'DescriptorInnerBarrelITS3\' class with following parameters";
+    LOG(info) << param;
     setVersion(param.getITS3LayerConfigString());
+  } else {
+    LOG(info) << "Instance \'DescriptorInnerBarrelITS3\' class with following parameters";
+    LOG(info) << "DescriptorInnerBarrelITS3.mVersion : " << mVersion;
+    LOG(info) << "DescriptorInnerBarrelITS3.mBuildLevel : " << buildLevel;
   }
-
-  LOG(info) << "Instance \'DescriptorInnerBarrelITS3\' class with following parameters";
-  LOG(info) << "DescriptorInnerBarrelITS3.mVersion : " << mVersion;
-  LOG(info) << "DescriptorInnerBarrelITS3.mBuildLevel : " << buildLevel;
 
   if (mVersion == "ThreeLayersNoDeadZones") {
     mNumLayers = 3;

--- a/Detectors/Upgrades/ITS3/simulation/src/ITS3Layer.cxx
+++ b/Detectors/Upgrades/ITS3/simulation/src/ITS3Layer.cxx
@@ -131,7 +131,7 @@ void ITS3Layer::createLayerWithDeadZones(TGeoVolume* motherVolume)
   TGeoVolume* volHalfLayer[nElements - 1];
 
   for (int iEl{0}; iEl < nElements - 1; ++iEl) {
-    TGeoMedium* med = (iEl == 0) ? medSi : medAir;
+    TGeoMedium* med = (iEl <= 1) ? medSi : medAir;
 
     for (int iObj{0}; iObj < nObjPerElement[iEl]; ++iObj) {
       if (iEl == 0) { // subsensors (mNumSubSensorsHalfLayer sectors with dead zones)
@@ -142,6 +142,8 @@ void ITS3Layer::createLayerWithDeadZones(TGeoVolume* motherVolume)
         } else {
           halfLayer[iEl].push_back(new TGeoTubeSeg(Form("subsens%dlayer%d", iObj, mLayerNumber), rmin, rmax, mZLen / 2, TMath::RadToDeg() * (mFringeChipWidth + iObj * widthSensor + iObj * mMiddleChipWidth) / rmed, TMath::RadToDeg() * (mFringeChipWidth + (iObj + 1) * widthSensor + iObj * mMiddleChipWidth) / rmed));
         }
+      } else if (iEl == 1) { 
+        halfLayer[iEl].push_back(new TGeoTubeSeg(rmin, rmax, mZLen / 2, 0., TMath::RadToDeg() * TMath::Pi()));
       } else { // all the others are simply half cylinders filling all the space
         halfLayer[iEl].push_back(new TGeoTubeSeg(rmin, rmax + radiusBetweenLayer, mZLen / 2, 0., TMath::RadToDeg() * TMath::Pi()));
       }
@@ -218,7 +220,7 @@ void ITS3Layer::create4thLayer(TGeoVolume* motherVolume)
   TGeoVolume* volQuarterLayer[nElements - 1];
 
   for (int iEl{0}; iEl < nElements - 1; ++iEl) {
-    TGeoMedium* med = (iEl == 0) ? medSi : medAir;
+    TGeoMedium* med = (iEl <= 1) ? medSi : medAir;
 
     for (int iObj{0}; iObj < nObjPerElement[iEl]; ++iObj) {
       if (iEl == 0) { // subsensors (mNumSubSensorsHalfLayer sectors with dead zones)

--- a/Detectors/Upgrades/ITS3/simulation/src/ITS3Layer.cxx
+++ b/Detectors/Upgrades/ITS3/simulation/src/ITS3Layer.cxx
@@ -287,7 +287,7 @@ void ITS3Layer::create4thLayer(TGeoVolume* motherVolume)
 void ITS3Layer::createCarbonFoamStructure(TGeoVolume* motherVolume)
 {
   TGeoMedium* medCarbonFoam = (mBuildLevel < 1) ? gGeoManager->GetMedium("IT3_ERGDUOCEL$") : gGeoManager->GetMedium("IT3_AIR$"); // if build level >= 1 we do not put carbon foam but air
-  TGeoMedium* medGlue = (mBuildLevel < 2) ? gGeoManager->GetMedium("IT3_IMPREG_FLEECE$") : gGeoManager->GetMedium("IT3_AIR$"); // if build level >= 2 we do not put glue but air
+  TGeoMedium* medGlue = (mBuildLevel < 2) ? gGeoManager->GetMedium("IT3_IMPREG_FLEECE$") : gGeoManager->GetMedium("IT3_AIR$");   // if build level >= 2 we do not put glue but air
 
   double rmax = mRadius + mSensorThickness;
   double radiusBetweenLayer = 0.6 - mSensorThickness; // FIXME: hard coded distance between layers

--- a/Detectors/Upgrades/ITS3/simulation/src/ITS3Layer.cxx
+++ b/Detectors/Upgrades/ITS3/simulation/src/ITS3Layer.cxx
@@ -286,8 +286,8 @@ void ITS3Layer::create4thLayer(TGeoVolume* motherVolume)
 
 void ITS3Layer::createCarbonFoamStructure(TGeoVolume* motherVolume)
 {
-  TGeoMedium* medCarbonFoam = gGeoManager->GetMedium("IT3_ERGDUOCEL$");
-  TGeoMedium* medGlue = gGeoManager->GetMedium("IT3_IMPREG_FLEECE$");
+  TGeoMedium* medCarbonFoam = (mBuildLevel < 1) ? gGeoManager->GetMedium("IT3_ERGDUOCEL$") : gGeoManager->GetMedium("IT3_AIR$"); // if build level >= 1 we do not put carbon foam but air
+  TGeoMedium* medGlue = (mBuildLevel < 2) ? gGeoManager->GetMedium("IT3_IMPREG_FLEECE$") : gGeoManager->GetMedium("IT3_AIR$"); // if build level >= 2 we do not put glue but air
 
   double rmax = mRadius + mSensorThickness;
   double radiusBetweenLayer = 0.6 - mSensorThickness; // FIXME: hard coded distance between layers

--- a/Detectors/Upgrades/ITS3/simulation/src/ITS3Layer.cxx
+++ b/Detectors/Upgrades/ITS3/simulation/src/ITS3Layer.cxx
@@ -142,7 +142,7 @@ void ITS3Layer::createLayerWithDeadZones(TGeoVolume* motherVolume)
         } else {
           halfLayer[iEl].push_back(new TGeoTubeSeg(Form("subsens%dlayer%d", iObj, mLayerNumber), rmin, rmax, mZLen / 2, TMath::RadToDeg() * (mFringeChipWidth + iObj * widthSensor + iObj * mMiddleChipWidth) / rmed, TMath::RadToDeg() * (mFringeChipWidth + (iObj + 1) * widthSensor + iObj * mMiddleChipWidth) / rmed));
         }
-      } else if (iEl == 1) { 
+      } else if (iEl == 1) {
         halfLayer[iEl].push_back(new TGeoTubeSeg(rmin, rmax, mZLen / 2, 0., TMath::RadToDeg() * TMath::Pi()));
       } else { // all the others are simply half cylinders filling all the space
         halfLayer[iEl].push_back(new TGeoTubeSeg(rmin, rmax + radiusBetweenLayer, mZLen / 2, 0., TMath::RadToDeg() * TMath::Pi()));


### PR DESCRIPTION
As agreed with @mario6829 I restored the possibility to set the `buildLevel` for the ITS(3) inner barrel for material budget studies. It can be now also set at runtime via
- ITS: `--configKeyValues "ITSBaseParam.buildLevel=value"`
- ITS3: `--configKeyValues "DescriptorInnerBarrelITS3.mBuildLevel=value"`