### PR TITLE
[MRRTF-163] Reject bad channels in DigitFiltering

### DIFF
--- a/DataFormats/Detectors/MUON/MCH/CMakeLists.txt
+++ b/DataFormats/Detectors/MUON/MCH/CMakeLists.txt
@@ -16,11 +16,13 @@ o2_add_library(DataFormatsMCH
                        src/ROFRecord.cxx
                        src/Cluster.cxx
                        src/DsChannelId.cxx
+                       src/DsChannelDetId.cxx
             PUBLIC_LINK_LIBRARIES O2::CommonDataFormat
                                      O2::DetectorsCommonDataFormats)
 
 o2_target_root_dictionary(DataFormatsMCH
                           HEADERS include/DataFormatsMCH/Digit.h
+                                  include/DataFormatsMCH/DsChannelDetId.h
                                   include/DataFormatsMCH/DsChannelGroup.h
                                   include/DataFormatsMCH/ROFRecord.h
                                   include/DataFormatsMCH/TrackMCH.h
@@ -34,6 +36,12 @@ o2_add_executable(convert-bad-channels
 
 o2_add_test(digit
             SOURCES src/testDigit.cxx
+            PUBLIC_LINK_LIBRARIES O2::MCHBase
+            COMPONENT_NAME mch
+            LABELS muon;mch)
+
+o2_add_test(dschannelid
+            SOURCES src/testDsChannelId.cxx
             PUBLIC_LINK_LIBRARIES O2::MCHBase
             COMPONENT_NAME mch
             LABELS muon;mch)

--- a/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/DsChannelDetId.h
+++ b/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/DsChannelDetId.h
@@ -1,0 +1,75 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_DATAFORMATS_MCH_DS_CHANNEL_DET_ID_H_
+#define O2_DATAFORMATS_MCH_DS_CHANNEL_DET_ID_H_
+
+#include <cstdint>
+#include <string>
+#include "Rtypes.h"
+
+namespace o2::mch
+{
+/** Unique 32-bit identifier of a DualSampa channel. The ID is generated from the following indexes:
+ * - the detection element id
+ * - the dual sampa id
+ * - the channel number, from 0 to 63
+ *
+ * This class serves the same purposes as @ref DsChannelId, but using a different
+ * "coordinate system" to reference the elements within the spectrometer.
+ * @ref DsChannelId is more readout/online oriented,
+ * while DsChannelDetId is more reconstruction/offline oriented.
+ * Note that the actual underlying integer value of the two ids are *not*
+ * and thus cannot be intermixed.
+ */
+class DsChannelDetId
+{
+ public:
+  DsChannelDetId() = default;
+  DsChannelDetId(uint32_t channelId) : mChannelDetId(channelId) {}
+  DsChannelDetId(uint16_t detId, uint16_t dsId, uint8_t channel)
+  {
+    set(detId, dsId, channel);
+  }
+
+  static uint32_t make(uint16_t deId, uint16_t dsId, uint8_t channel)
+  {
+    uint32_t id = (static_cast<uint32_t>(deId) << 17) +
+                  (static_cast<uint32_t>(dsId) << 6) + channel;
+    return id;
+  }
+
+  void set(uint16_t deId, uint16_t dsId, uint8_t channel)
+  {
+    mChannelDetId = DsChannelDetId::make(deId, dsId, channel);
+  }
+
+  uint16_t getDeId() const { return static_cast<uint16_t>((mChannelDetId >> 17) & 0x7FF); }
+  uint16_t getDsId() const { return static_cast<uint16_t>((mChannelDetId >> 6) & 0x7FF); }
+  uint8_t getChannel() const { return static_cast<uint8_t>(mChannelDetId & 0x3F); }
+
+  std::string asString() const;
+
+  uint32_t value() const { return mChannelDetId; }
+
+  bool isValid() const { return (mChannelDetId != 0); }
+
+  bool operator==(const DsChannelDetId& chId) const { return mChannelDetId == chId.mChannelDetId; }
+  bool operator!=(const DsChannelDetId& chId) const { return mChannelDetId != chId.mChannelDetId; }
+  bool operator<(const DsChannelDetId& chId) const { return mChannelDetId < chId.mChannelDetId; }
+
+ private:
+  uint32_t mChannelDetId{0};
+
+  ClassDefNV(DsChannelDetId, 1); // An identifier for a MCH channel (detector oriented)
+};
+} // namespace o2::mch
+#endif

--- a/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/DsChannelId.h
+++ b/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/DsChannelId.h
@@ -46,8 +46,6 @@ class DsChannelId
 
   uint16_t getSolarId() const { return static_cast<uint16_t>((mChannelId >> 16) & 0xFFFF); }
   uint8_t getElinkId() const { return static_cast<uint8_t>((mChannelId >> 8) & 0xFF); }
-
-  [[deprecated("use getElinkId instead which better reflects what it is and avoid confusion with dsId from DsDetId")]] uint8_t getDsId() const { return getElinkId(); }
   uint8_t getChannel() const { return static_cast<uint8_t>(mChannelId & 0xFF); }
 
   std::string asString() const;
@@ -56,10 +54,14 @@ class DsChannelId
 
   bool isValid() const { return (mChannelId != 0); }
 
+  bool operator==(const DsChannelId& chId) const { return mChannelId == chId.mChannelId; }
+  bool operator!=(const DsChannelId& chId) const { return mChannelId != chId.mChannelId; }
+  bool operator<(const DsChannelId& chId) const { return mChannelId < chId.mChannelId; }
+
  private:
   uint32_t mChannelId{0};
 
-  ClassDefNV(DsChannelId, 1); // class for MCH readout channel
+  ClassDefNV(DsChannelId, 1); // An identifier for a MCH channel (readout oriented)
 };
 } // namespace o2::mch
 #endif

--- a/DataFormats/Detectors/MUON/MCH/src/DataFormatsMCHLinkDef.h
+++ b/DataFormats/Detectors/MUON/MCH/src/DataFormatsMCHLinkDef.h
@@ -23,6 +23,8 @@
 #pragma link C++ class o2::mch::DsChannelId + ;
 #pragma link C++ class o2::mch::DsChannelGroup + ;
 #pragma link C++ class std::vector < o2::mch::DsChannelId> + ;
+#pragma link C++ class o2::mch::DsChannelDetId + ;
+#pragma link C++ class std::vector < o2::mch::DsChannelDetId> + ;
 #pragma link C++ class o2::mch::Digit + ;
 #pragma link C++ class std::vector < o2::mch::Digit> + ;
 #pragma link C++ struct o2::mch::CTFHeader + ;

--- a/DataFormats/Detectors/MUON/MCH/src/DsChannelDetId.cxx
+++ b/DataFormats/Detectors/MUON/MCH/src/DsChannelDetId.cxx
@@ -9,24 +9,14 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifndef O2_MCH_DIGITFILTERING_DIGITFILTER_H_
-#define O2_MCH_DIGITFILTERING_DIGITFILTER_H_
-
-#include "DataFormatsMCH/Digit.h"
-#include "MCHConditions/StatusMap.h"
-#include <functional>
+#include "DataFormatsMCH/DsChannelDetId.h"
+#include <fmt/core.h>
 
 namespace o2::mch
 {
-
-typedef std::function<bool(const Digit&)> DigitFilter;
-
-DigitFilter createDigitFilter(uint32_t minADC,
-                              bool rejectBackground,
-                              bool selectSignal,
-                              const StatusMap& statusMap = {},
-                              uint32_t statusMask = 0);
-
+std::string DsChannelDetId::asString() const
+{
+  return fmt::format("deid {:4d} dsid {:4d} ch {:2d}",
+                     getDeId(), getDsId(), getChannel());
+}
 } // namespace o2::mch
-
-#endif

--- a/DataFormats/Detectors/MUON/MCH/src/testDsChannelId.cxx
+++ b/DataFormats/Detectors/MUON/MCH/src/testDsChannelId.cxx
@@ -1,0 +1,40 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <boost/test/tools/old/interface.hpp>
+#include <type_traits>
+#define BOOST_TEST_MODULE MCH DsChannelId
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include <boost/test/data/test_case.hpp>
+#include <boost/test/data/monomorphic.hpp>
+
+#include "DataFormatsMCH/DsChannelId.h"
+#include "DataFormatsMCH/DsChannelDetId.h"
+#include "Framework/TypeTraits.h"
+
+BOOST_AUTO_TEST_CASE(DsChannelIdIsTriviallyCopyable)
+{
+  BOOST_CHECK_EQUAL(std::is_trivially_copyable<o2::mch::DsChannelId>::value, true);
+}
+
+BOOST_AUTO_TEST_CASE(DsChannelIdIsMessageable)
+{
+  BOOST_CHECK_EQUAL(o2::framework::is_messageable<o2::mch::DsChannelId>::value, true);
+}
+
+BOOST_AUTO_TEST_CASE(DsChannelDetIdEncode)
+{
+  o2::mch::DsChannelDetId id(1025, 1361, 63);
+  BOOST_CHECK_EQUAL(id.getDeId(), 1025);
+  BOOST_CHECK_EQUAL(id.getDsId(), 1361);
+  BOOST_CHECK_EQUAL(id.getChannel(), 63);
+}

--- a/Detectors/MUON/MCH/Conditions/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Conditions/CMakeLists.txt
@@ -11,18 +11,59 @@
 
 o2_add_library(
   MCHConditions
-  SOURCES src/Cathode.cxx
-          src/Chamber.cxx
-          src/DCSAliases.cxx
-          src/DetectionElement.cxx
-          src/HVAliases.cxx
-          src/LVAliases.cxx
-          src/MeasurementType.cxx
-          src/Number.cxx
-          src/Plane.cxx
-          src/Side.cxx
-          src/SolarCrate.cxx
-  PUBLIC_LINK_LIBRARIES fmt::fmt O2::MCHConstants)
+  SOURCES
+    src/Cathode.cxx
+    src/Chamber.cxx
+    src/DCSAliases.cxx
+    src/DetectionElement.cxx
+    src/HVAliases.cxx
+    src/LVAliases.cxx
+    src/MeasurementType.cxx
+    src/Number.cxx
+    src/Plane.cxx
+    src/Side.cxx
+    src/SolarCrate.cxx
+    src/StatusMap.cxx
+    src/StatusMapCreatorParam.cxx
+    src/StatusMapCreatorSpec.cxx
+  PUBLIC_LINK_LIBRARIES
+    O2::CommonUtils
+    O2::DataFormatsMCH
+    O2::MCHConstants
+    O2::MCHMappingImpl4
+    O2::MCHRawElecMap
+    fmt::fmt
+    )
+
+o2_add_executable(
+  bad-channels-ccdb
+  COMPONENT_NAME mch
+  SOURCES src/bad-channels-ccdb.cxx
+  PUBLIC_LINK_LIBRARIES
+    O2::CCDB
+    O2::DataFormatsMCH
+    O2::Framework
+    O2::MCHMappingImpl4
+    O2::MCHRawElecMap
+    )
+
+o2_target_root_dictionary(MCHConditions
+  HEADERS
+    include/MCHConditions/StatusMap.h
+    include/MCHConditions/StatusMapCreatorParam.h)
+
+
+o2_add_executable(
+  statusmap-creator-workflow
+  COMPONENT_NAME mch
+  SOURCES src/statusmap-creator-workflow.cxx src/StatusMapCreatorSpec.cxx
+  PUBLIC_LINK_LIBRARIES
+    O2::CCDB
+    O2::Framework
+    O2::MCHConditions
+    O2::MCHMappingImpl4
+    O2::MCHRawElecMap
+    )
 
 if(BUILD_TESTING)
   o2_add_test(

--- a/Detectors/MUON/MCH/Conditions/README.md
+++ b/Detectors/MUON/MCH/Conditions/README.md
@@ -4,5 +4,63 @@
 
 # MCH Conditions
 
-So far the only "condition" data we have are the DCS datapoints.
+The condition data we have are :
 
+- the DCS datapoints (for HV and LV)
+- the Bad Channel list (obtained from pedestal calibration runs)
+- the Reject list (manual input)
+
+Those objects are stored at the following CCDB paths :
+
+- MCH/Calib/HV
+- MCH/Calib/LV
+- MCH/Calib/BadChannel
+- MCH/Calib/RejectList
+
+The BadChannel and RejectList objects can be uploaded, e.g. for debug purposes, using the `o2-mch-bad-channels-ccdb` program :
+
+```shell
+$ o2-mch-bad-channels-ccdb --help
+This program dump MCH bad channels CCDB object
+Usage:
+  -h [ --help ]                         produce help message
+  -c [ --ccdb ] arg (=http://localhost:6464)
+                                        ccdb url
+  --starttimestamp arg (=1677687518645) timestamp for query or put -
+                                        (default=now)
+  --endtimestamp arg (=1677773918645)   end of validity (for put) - default=1
+                                        day from now
+  -p [ --put ]                          upload bad channel default object
+  -u [ --upload-default-values ]        upload default values
+  -t [ --type ] arg (=BadChannel)       type of bad channel (BadChannel or
+                                        RejectList)
+  -q [ --query ]                        dump bad channel object from CCDB
+  -v [ --verbose ]                      verbose output
+  -s [ --solar ] arg                    solar ids to reject
+
+```
+
+For instance, to create a debug RejectList object which declares solar number 32 as bad within a local CCDB, from Tuesday 1 November 2022 00:00:01 UTC to Saturday 31 December 2022 23:59:59, use :
+
+```shell
+$ o2-mch-bad-channels-ccdb -p -s 32 -t RejectList --starttimestamp 1667260801000 --endtimestamp 1672531199000
+storing default MCH bad channels (valid from 1667260801000to 1672531199000) to MCH/Calib/RejectList
+```
+
+## Statusmap generation
+
+The status map is an object that list all pads that are not perfect, for some reason. Each such pad gets ascribed a `uint32_t` integer mask, representing the source of information that was used to decide that pad is bad.
+
+The gathering of all the sources of information is performed by the [StatusMapCreatorSpec](src/StatusMapCreatorSpec.cxx), either in standalone [o2-mch-statusmap-creator-workflow](src/statusmap-creator-workflow.cxx) device, or, most probably, as part of the regular `o2-mch-reco-workflow`.
+
+So far only we have only implemented the bad channel list from pedestal runs the manual reject list. Next in line will be the usage of the HV and LV values.
+
+## Statusmap usage
+
+The statusmap, once computed by the statusmap creator, can then be used by the digit filtering, e.g. during reconstruction. To that end some options (by means of the `--configKeyValues` option) must be passed to the statusmap creator and the digit filtering. For instance, to use the information from both the pedestal runs and the rejectlist to compute the statusmap, and to reject pads that are in the resulting statusmap, use :
+
+```c++
+MCHStatusMap.useBadChannels=true;MCHStatusMap.useRejectList=true;MCHDigitFilter.statusMask=3
+```
+
+where the `statusMask=3` comes from `1 | 2` (see `kBadPedestals | kRejectList` from [StatusMap.h](include/MCHConditions/StatusMap.h])

--- a/Detectors/MUON/MCH/Conditions/include/MCHConditions/StatusMap.h
+++ b/Detectors/MUON/MCH/Conditions/include/MCHConditions/StatusMap.h
@@ -1,0 +1,97 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_MCH_CONDITIONS_STATUSMAP_H
+#define O2_MCH_CONDITIONS_STATUSMAP_H
+
+#include "DataFormatsMCH/DsChannelDetId.h"
+#include "DataFormatsMCH/DsChannelId.h"
+#include <cstdint>
+#include <gsl/span>
+#include <map>
+#include <utility>
+#include <vector>
+
+namespace o2::mch
+{
+
+/** The StatusMap contains the list of MCH channels that are not nominal.
+ * Said otherwise, it's a list of potential bad channels.
+ * Each potentially bad channel is ascribed a 32-bits mask that indicate
+ * the source of information used to incriminate it. So far only two sources
+ * exist :
+ * - kBadPedestal : the list generated at each pedestal run at Pt2
+ * - kRejectList : a (manual) list
+ *
+ * In the future (based on our experience during Run1,2), we'll most probably
+ * need to add information from the DCS HV (and possibly LV) values as well.
+ *
+ */
+class StatusMap
+{
+ public:
+  enum Status : uint32_t {
+    kOK = 0,
+    kBadPedestal = 1 << 0,
+    kRejectList = 1 << 1
+  };
+
+  using iterator = std::map<DsChannelDetId, uint32_t>::iterator;
+  using const_iterator = std::map<DsChannelDetId, uint32_t>::const_iterator;
+
+  iterator begin() { return mStatus.begin(); }
+  iterator end() { return mStatus.end(); }
+  const_iterator begin() const { return mStatus.begin(); }
+  const_iterator end() const { return mStatus.end(); }
+
+  /** add all the badchannels referenced using DsChannelId (aka readout
+   * channel id, aka (solar,group,index)) to this status map,
+   * assigning them the corresponding mask.
+   */
+  void add(gsl::span<const DsChannelId> badchannels, uint32_t mask);
+
+  /** add all the badchannels referenced using DsChannelDetId (aka detector
+   * channel id, aka (de,ds,channel)) to this status map,
+   * assigning them the corresponding mask.
+   */
+  void add(gsl::span<const DsChannelDetId> badchannels, uint32_t mask);
+
+  /** whether or not this statusmap contains no (potentially) bad channels */
+  bool empty() const { return mStatus.empty(); }
+
+  /** clear the content of the statusmap (after clear the statusmap is thus empty) */
+  void clear() { mStatus.clear(); }
+
+  /** return the status of a given channel
+   * the channel is referenced using detector numbering (de,ds,channel)
+   */
+  uint32_t status(const DsChannelDetId& id) const;
+
+ private:
+  std::map<DsChannelDetId, uint32_t> mStatus;
+
+  ClassDefNV(StatusMap, 1);
+};
+
+/** convert a pair {StatusMap,mask} to a map deid->[vector of bad channel's padids]
+ * where the meaning of bad is defined by the mask.
+ *
+ * Note that if the mask==0 then the output map is empty by construction
+ * (as all pads are considered good then).
+ *
+ * Note also that we do make sure that the output map only contains
+ * actually connected pads.
+ */
+std::map<int, std::vector<int>> applyMask(const o2::mch::StatusMap& statusMap, uint32_t mask);
+
+} // namespace o2::mch
+
+#endif

--- a/Detectors/MUON/MCH/Conditions/include/MCHConditions/StatusMapCreatorParam.h
+++ b/Detectors/MUON/MCH/Conditions/include/MCHConditions/StatusMapCreatorParam.h
@@ -1,0 +1,35 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_MCH_CONDITIONS_STATUSMAP_CREATOR_PARAM_H_
+#define O2_MCH_CONDITIONS_STATUSMAP_CREATOR_PARAM_H_
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "CommonUtils/ConfigurableParamHelper.h"
+
+namespace o2::mch
+{
+
+/**
+ * @class StatusMapCreatorParam
+ * @brief Configurable parameters for the statusmap creator
+ */
+struct StatusMapCreatorParam : public o2::conf::ConfigurableParamHelper<StatusMapCreatorParam> {
+
+  bool useBadChannels = false; ///< reject bad channels (obtained during pedestal calibration runs)
+  bool useRejectList = false;  ///< use extra (relative to bad channels above) rejection list
+
+  O2ParamDef(StatusMapCreatorParam, "MCHStatusMap");
+};
+
+} // namespace o2::mch
+
+#endif

--- a/Detectors/MUON/MCH/Conditions/include/MCHConditions/StatusMapCreatorSpec.h
+++ b/Detectors/MUON/MCH/Conditions/include/MCHConditions/StatusMapCreatorSpec.h
@@ -9,24 +9,15 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifndef O2_MCH_DIGITFILTERING_DIGITFILTER_H_
-#define O2_MCH_DIGITFILTERING_DIGITFILTER_H_
+#ifndef O2_MCH_CONDITIONS_STATUSMAP_CREATOR_SPEC_H
+#define O2_MCH_CONDITIONS_STATUSMAP_CREATOR_SPEC_H
 
-#include "DataFormatsMCH/Digit.h"
-#include "MCHConditions/StatusMap.h"
-#include <functional>
+#include "Framework/DataProcessorSpec.h"
 
 namespace o2::mch
 {
 
-typedef std::function<bool(const Digit&)> DigitFilter;
+o2::framework::DataProcessorSpec getStatusMapCreatorSpec(std::string_view specName = "mch-statusmap-creator");
 
-DigitFilter createDigitFilter(uint32_t minADC,
-                              bool rejectBackground,
-                              bool selectSignal,
-                              const StatusMap& statusMap = {},
-                              uint32_t statusMask = 0);
-
-} // namespace o2::mch
-
+}
 #endif

--- a/Detectors/MUON/MCH/Conditions/src/MCHConditionsLinkDef.h
+++ b/Detectors/MUON/MCH/Conditions/src/MCHConditionsLinkDef.h
@@ -1,0 +1,22 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifdef __CLING__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class o2::mch::StatusMapCreatorParam + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::mch::StatusMapCreatorParam> + ;
+#pragma link C++ class o2::mch::StatusMap + ;
+
+#endif

--- a/Detectors/MUON/MCH/Conditions/src/StatusMap.cxx
+++ b/Detectors/MUON/MCH/Conditions/src/StatusMap.cxx
@@ -1,0 +1,77 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "MCHConditions/StatusMap.h"
+
+#include "Framework/Logger.h"
+#include "MCHMappingInterface/Segmentation.h"
+#include "MCHRawElecMap/DsDetId.h"
+#include "MCHRawElecMap/Mapper.h"
+
+ClassImp(o2::mch::StatusMap);
+
+namespace o2::mch
+{
+
+void StatusMap::add(gsl::span<const DsChannelId> badchannels, uint32_t mask)
+{
+  for (auto id : badchannels) {
+    mStatus[raw::convert(id)] |= mask;
+  }
+}
+
+void StatusMap::add(gsl::span<const DsChannelDetId> badchannels, uint32_t mask)
+{
+  for (auto id : badchannels) {
+    mStatus[id] |= mask;
+  }
+}
+
+uint32_t StatusMap::status(const DsChannelDetId& id) const
+{
+  auto s = mStatus.find(id);
+  if (s != mStatus.end()) {
+    return s->second;
+  }
+  return 0;
+}
+
+std::map<int, std::vector<int>> applyMask(const o2::mch::StatusMap& statusMap,
+                                          uint32_t mask)
+{
+  std::map<int, std::vector<int>> rejectList;
+
+  std::unique_ptr<o2::mch::mapping::Segmentation> seg{nullptr};
+  int previousDeId{-1};
+
+  for (const auto& status : statusMap) {
+    auto channelId = status.first;
+    auto deId = channelId.getDeId();
+    if (deId != previousDeId) {
+      previousDeId = deId;
+      seg = std::make_unique<o2::mch::mapping::Segmentation>(deId);
+    }
+    auto dsId = channelId.getDsId();
+    auto channel = channelId.getChannel();
+    auto padId = seg->findPadByFEE(dsId, channel);
+    if (seg->isValid(padId)) {
+      if (mask && (mask & status.second)) {
+        rejectList[deId].emplace_back(padId);
+      }
+    } else {
+      LOGP(warning, "Got an invalid pad in bad channel map DE {} DS {} CH {} !",
+           deId, dsId, channel);
+    }
+  }
+  return rejectList;
+}
+
+} // namespace o2::mch

--- a/Detectors/MUON/MCH/Conditions/src/StatusMapCreatorParam.cxx
+++ b/Detectors/MUON/MCH/Conditions/src/StatusMapCreatorParam.cxx
@@ -1,0 +1,15 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "MCHConditions/StatusMapCreatorParam.h"
+#include "CommonUtils/ConfigurableParam.h"
+
+O2ParamImpl(o2::mch::StatusMapCreatorParam)

--- a/Detectors/MUON/MCH/Conditions/src/StatusMapCreatorSpec.cxx
+++ b/Detectors/MUON/MCH/Conditions/src/StatusMapCreatorSpec.cxx
@@ -1,0 +1,132 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "MCHConditions/StatusMapCreatorSpec.h"
+
+#include "DataFormatsMCH/DsChannelId.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/DataSpecUtils.h"
+#include "Framework/Logger.h"
+#include "Framework/OutputSpec.h"
+#include "Framework/Task.h"
+#include "Framework/WorkflowSpec.h"
+#include "MCHConditions/StatusMap.h"
+#include "MCHConditions/StatusMapCreatorParam.h"
+#include <fmt/format.h>
+#include <functional>
+#include <iostream>
+#include <map>
+#include <string>
+#include <vector>
+
+using namespace o2::framework;
+
+namespace o2::mch
+{
+
+class StatusMapCreatorTask
+{
+ public:
+  StatusMapCreatorTask() = default;
+
+  void updateStatusMap()
+  {
+    mStatusMap.clear();
+    mStatusMap.add(mBadChannels, StatusMap::kBadPedestal);
+    mStatusMap.add(mRejectList, StatusMap::kRejectList);
+  }
+
+  void
+    init(InitContext& ic)
+  {
+    mUseBadChannels = StatusMapCreatorParam::Instance().useBadChannels;
+    mUseRejectList = StatusMapCreatorParam::Instance().useRejectList;
+    mBadChannels.clear();
+    mRejectList.clear();
+  }
+
+  void finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
+  {
+    std::vector<o2::mch::DsChannelId>* bad{nullptr};
+    std::vector<o2::mch::DsChannelId>* rl{nullptr};
+
+    if (matcher == ConcreteDataMatcher("MCH", "BADCHANNELS", 0)) {
+      auto bad = static_cast<std::vector<o2::mch::DsChannelId>*>(obj);
+      mBadChannels = *bad;
+      updateStatusMap();
+    }
+    if (matcher == ConcreteDataMatcher("MCH", "REJECTLIST", 0)) {
+      auto rl = static_cast<std::vector<o2::mch::DsChannelId>*>(obj);
+      mRejectList = *rl;
+      updateStatusMap();
+    }
+  }
+
+  void run(ProcessingContext& pc)
+  {
+    if (mUseBadChannels) {
+      // to trigger call to finaliseCCDB
+      pc.inputs().get<std::vector<o2::mch::DsChannelId>*>("badchannels");
+    }
+    if (mUseRejectList) {
+      // to trigger call to finaliseCCDB
+      pc.inputs().get<std::vector<o2::mch::DsChannelId>*>("rejectlist");
+    }
+
+    // create the output message
+    pc.outputs().snapshot(OutputRef{"statusmap"}, mStatusMap);
+  }
+
+ private:
+  bool mUseBadChannels{false};
+  bool mUseRejectList{false};
+  std::vector<o2::mch::DsChannelId> mBadChannels;
+  std::vector<o2::mch::DsChannelId> mRejectList;
+  StatusMap mStatusMap;
+};
+
+framework::DataProcessorSpec getStatusMapCreatorSpec(std::string_view specName)
+{
+  std::string input;
+
+  if (StatusMapCreatorParam::Instance().useBadChannels) {
+    input = "badchannels:MCH/BADCHANNELS/0?lifetime=condition&ccdb-path=MCH/Calib/BadChannel";
+  }
+  if (StatusMapCreatorParam::Instance().useRejectList) {
+    if (!input.empty()) {
+      input += ";";
+    }
+    input += "rejectlist:MCH/REJECTLIST/0?lifetime=condition&ccdb-path=MCH/Calib/RejectList";
+  }
+
+  if (input.empty()) {
+    return {"mch-dummy-statusmap-creator",
+            {},
+            {},
+            AlgorithmSpec::dummyAlgorithm()};
+  }
+
+  std::string output = "statusmap:MCH/STATUSMAP/0";
+
+  std::vector<OutputSpec> outputs;
+  auto matchers = select(output.c_str());
+  for (auto& matcher : matchers) {
+    outputs.emplace_back(DataSpecUtils::asOutputSpec(matcher));
+  }
+
+  return DataProcessorSpec{
+    specName.data(),
+    Inputs{select(input.c_str())},
+    outputs,
+    AlgorithmSpec{adaptFromTask<StatusMapCreatorTask>()},
+    Options{}};
+}
+} // namespace o2::mch

--- a/Detectors/MUON/MCH/Conditions/src/bad-channels-ccdb.cxx
+++ b/Detectors/MUON/MCH/Conditions/src/bad-channels-ccdb.cxx
@@ -1,0 +1,161 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "CCDB/CcdbApi.h"
+#include <boost/program_options.hpp>
+#include <ctime>
+#include <numeric>
+#include <regex>
+#include <string>
+#include <vector>
+#include "DataFormatsMCH/DsChannelId.h"
+#include "MCHRawElecMap/Mapper.h"
+#include "MCHMappingInterface/Segmentation.h"
+
+namespace po = boost::program_options;
+
+using BadChannelsVector = std::vector<o2::mch::DsChannelId>;
+
+std::string ccdbPath(const std::string badChannelType)
+{
+  return fmt::format("MCH/Calib/{}", badChannelType);
+}
+
+void queryBadChannels(const std::string ccdbUrl,
+                      const std::string badChannelType, uint64_t timestamp, bool verbose)
+{
+  o2::ccdb::CcdbApi api;
+  api.init(ccdbUrl);
+  std::map<std::string, std::string> metadata;
+  auto source = ccdbPath(badChannelType);
+  auto* badChannels = api.retrieveFromTFileAny<BadChannelsVector>(source.c_str(), metadata, timestamp);
+  std::cout << "number of bad channels = " << badChannels->size() << std::endl;
+  if (verbose) {
+    for (const auto& badChannel : *badChannels) {
+      std::cout << badChannel.asString() << "\n";
+    }
+  }
+}
+
+void uploadBadChannels(const std::string ccdbUrl,
+                       const std::string badChannelType,
+                       uint64_t startTimestamp,
+                       uint64_t endTimestamp,
+                       std::vector<uint16_t> solarsToReject,
+                       bool makeDefault)
+{
+  BadChannelsVector bv;
+
+  auto det2elec = o2::mch::raw::createDet2ElecMapper<o2::mch::raw::ElectronicMapperGenerated>();
+
+  for (auto solar : solarsToReject) {
+    auto ds = o2::mch::raw::getDualSampas<o2::mch::raw::ElectronicMapperGenerated>(solar);
+    for (const auto& dsDetId : ds) {
+      o2::mch::mapping::Segmentation seg(dsDetId.deId());
+      for (uint8_t channel = 0; channel < 64; channel++) {
+        auto dsElecId = det2elec(dsDetId);
+        auto padId = seg.findPadByFEE(dsDetId.dsId(), channel);
+        if (seg.isValid(padId)) {
+          const auto c = o2::mch::DsChannelId(solar, dsElecId->elinkId(), channel);
+          bv.emplace_back(c);
+        }
+      }
+    }
+  }
+
+  o2::ccdb::CcdbApi api;
+  api.init(ccdbUrl);
+  std::map<std::string, std::string> md;
+  auto dest = ccdbPath(badChannelType);
+  std::cout << "storing default MCH bad channels (valid from "
+            << startTimestamp << "to " << endTimestamp << ") to "
+            << dest << "\n";
+
+  if (makeDefault) {
+    md["default"] = true;
+  }
+  api.storeAsTFileAny(&bv, dest, md, startTimestamp, endTimestamp);
+}
+
+int main(int argc, char** argv)
+{
+  po::variables_map vm;
+  po::options_description usage("Usage");
+
+  std::string ccdbUrl;
+  std::string dpConfName;
+  std::string badChannelType;
+  uint64_t startTimestamp;
+  uint64_t endTimestamp;
+  bool put;
+  bool query;
+  bool verbose;
+  bool uploadDefault;
+
+  auto tnow = std::chrono::system_clock::now().time_since_epoch();
+  using namespace std::chrono_literals;
+  auto tend = tnow + 24h;
+
+  uint64_t now = std::chrono::duration_cast<std::chrono::milliseconds>(tnow).count();
+  uint64_t end = std::chrono::duration_cast<std::chrono::milliseconds>(tend).count();
+
+  // clang-format off
+  usage.add_options()
+      ("help,h", "produce help message")
+      ("ccdb,c",po::value<std::string>(&ccdbUrl)->default_value("http://localhost:6464"),"ccdb url")
+      ("starttimestamp,st",po::value<uint64_t>(&startTimestamp)->default_value(now),"timestamp for query or put - (default=now)")
+      ("endtimestamp,et", po::value<uint64_t>(&endTimestamp)->default_value(end), "end of validity (for put) - default=1 day from now")
+      ("put,p",po::bool_switch(&put),"upload bad channel default object")
+      ("upload-default-values,u",po::bool_switch(&uploadDefault),"upload default values")
+      ("type,t",po::value<std::string>(&badChannelType)->default_value("BadChannel"),"type of bad channel (BadChannel or RejectList)")
+      ("query,q",po::bool_switch(&query),"dump bad channel object from CCDB")
+      ("verbose,v",po::bool_switch(&verbose),"verbose output")
+      ("solar,s",po::value<std::vector<uint16_t>>()->multitoken(),"solar ids to reject")
+      ;
+  // clang-format on
+
+  po::options_description cmdline;
+  cmdline.add(usage);
+
+  po::store(po::command_line_parser(argc, argv).options(cmdline).run(), vm);
+
+  if (vm.count("help")) {
+    std::cout << "This program dump MCH bad channels CCDB object\n";
+    std::cout << usage << "\n";
+    return 2;
+  }
+
+  try {
+    po::notify(vm);
+  } catch (boost::program_options::error& e) {
+    std::cout << "Error: " << e.what() << "\n";
+    exit(1);
+  }
+
+  if (badChannelType != "BadChannel" && badChannelType != "RejectList") {
+    std::cout << "Error: badChannelType " << badChannelType << " is invalid. Only BadChannel or RejectList are legit\n";
+    exit(2);
+  }
+
+  if (query) {
+    queryBadChannels(ccdbUrl, badChannelType, startTimestamp, verbose);
+  }
+
+  if (put) {
+    std::vector<uint16_t> solarsToReject;
+    if (vm.count("solar")) {
+      solarsToReject = vm["solar"].as<std::vector<uint16_t>>();
+    }
+
+    uploadBadChannels(ccdbUrl, badChannelType, startTimestamp, endTimestamp, solarsToReject, uploadDefault);
+  }
+  return 0;
+}

--- a/Detectors/MUON/MCH/Conditions/src/statusmap-creator-workflow.cxx
+++ b/Detectors/MUON/MCH/Conditions/src/statusmap-creator-workflow.cxx
@@ -1,0 +1,39 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "CommonUtils/ConfigurableParam.h"
+#include "Framework/CallbackService.h"
+#include "Framework/ControlService.h"
+#include "Framework/Task.h"
+#include "MCHConditions/StatusMapCreatorParam.h"
+#include "MCHConditions/StatusMapCreatorSpec.h"
+
+using namespace o2;
+using namespace o2::framework;
+
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  workflowOptions.push_back(ConfigParamSpec{"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings"}});
+}
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(const ConfigContext& cc)
+{
+  o2::conf::ConfigurableParam::updateFromString(cc.options().get<std::string>("configKeyValues"));
+
+  if (o2::mch::StatusMapCreatorParam::Instance().useBadChannels ||
+      o2::mch::StatusMapCreatorParam::Instance().useRejectList) {
+    return {o2::mch::getStatusMapCreatorSpec("mch-statusmap-creator")};
+  } else {
+    return {};
+  }
+}

--- a/Detectors/MUON/MCH/DigitFiltering/CMakeLists.txt
+++ b/Detectors/MUON/MCH/DigitFiltering/CMakeLists.txt
@@ -11,7 +11,7 @@
 
 o2_add_library(MCHDigitFiltering
         SOURCES src/DigitFilter.cxx src/DigitFilterParam.cxx src/DigitFilteringSpec.cxx
-        PUBLIC_LINK_LIBRARIES O2::MCHBase O2::Framework O2::SimulationDataFormat)
+        PUBLIC_LINK_LIBRARIES O2::MCHBase O2::MCHConditions O2::Framework O2::SimulationDataFormat)
 
 o2_add_executable(
         digits-filtering-workflow

--- a/Detectors/MUON/MCH/DigitFiltering/include/MCHDigitFiltering/DigitFilterParam.h
+++ b/Detectors/MUON/MCH/DigitFiltering/include/MCHDigitFiltering/DigitFilterParam.h
@@ -29,6 +29,7 @@ struct DigitFilterParam : public o2::conf::ConfigurableParamHelper<DigitFilterPa
   bool rejectBackground = true; ///< attempts to reject background (loose background selection, don't kill signal)
   bool selectSignal = false;    ///< attempts to select only signal (strict background selection, might loose signal)
   int timeOffset = 0;           ///< digit time calibration offset
+  uint32_t statusMask = 0;      ///< mask to reject digits based on the statusmap (0=no rejection)
 
   O2ParamDef(DigitFilterParam, "MCHDigitFilter");
 };

--- a/Detectors/MUON/MCH/DigitFiltering/src/DigitFilter.cxx
+++ b/Detectors/MUON/MCH/DigitFiltering/src/DigitFilter.cxx
@@ -12,10 +12,12 @@
 #include "MCHDigitFiltering/DigitFilter.h"
 
 #include "DataFormatsMCH/Digit.h"
+#include "Framework/Logger.h"
 #include "MCHDigitFiltering/DigitFilterParam.h"
-#include <vector>
+#include "MCHMappingInterface/Segmentation.h"
 #include <functional>
 #include <gsl/span>
+#include <vector>
 
 namespace
 {
@@ -96,7 +98,39 @@ o2::mch::DigitFilter createSelectSignal()
 
 namespace o2::mch
 {
-DigitFilter createDigitFilter(uint32_t minADC, bool rejectBackground, bool selectSignal)
+void report(const std::map<int, std::vector<int>>& rejectList, uint32_t statusMask)
+{
+  int nbad{0};
+  for (const auto it : rejectList) {
+    nbad += it.second.size();
+  }
+  LOGP(info, "Got {} bad channels in {} detection element{} (using statusMask=0x{:x})", nbad,
+       rejectList.size(), rejectList.size() > 1 ? "s" : "", statusMask);
+}
+
+DigitFilter createBadChannelFilter(const StatusMap& statusMap,
+                                   uint32_t statusMask)
+{
+  auto rejectList = applyMask(statusMap, statusMask);
+  report(rejectList, statusMask);
+
+  return [rejectList, statusMask](const o2::mch::Digit& digit) -> bool {
+    bool goodChannel{true};
+    auto deID = digit.getDetID();
+    auto it = rejectList.find(digit.getDetID());
+    if (it != rejectList.end()) {
+      // channel is good if it's not found in the rejectlist
+      goodChannel = std::find(it->second.begin(), it->second.end(), digit.getPadID()) == it->second.end();
+    }
+    return goodChannel;
+  };
+}
+
+DigitFilter createDigitFilter(uint32_t minADC,
+                              bool rejectBackground,
+                              bool selectSignal,
+                              const StatusMap& statusMap,
+                              uint32_t statusMask)
 {
   std::vector<DigitFilter> parts;
 
@@ -108,6 +142,9 @@ DigitFilter createDigitFilter(uint32_t minADC, bool rejectBackground, bool selec
   }
   if (selectSignal) {
     parts.emplace_back(createSelectSignal());
+  }
+  if (!statusMap.empty() && statusMask) {
+    parts.emplace_back(createBadChannelFilter(statusMap, statusMask));
   }
   return [parts](const Digit& digit) {
     for (const auto& p : parts) {

--- a/Detectors/MUON/MCH/GlobalMapping/include/MCHGlobalMapping/DsIndex.h
+++ b/Detectors/MUON/MCH/GlobalMapping/include/MCHGlobalMapping/DsIndex.h
@@ -30,7 +30,7 @@ constexpr uint16_t NumberOfDualSampas = 16820;
 /** getDsIndex returns the unique index of one dual sampa. */
 DsIndex getDsIndex(const o2::mch::raw::DsDetId& dsDetId);
 
-/** decodeDsIndex converts a unique dual sampa index into a pair (deId,dsId). */
+/** getDsDetId converts a unique dual sampa index into a pair (deId,dsId). */
 o2::mch::raw::DsDetId getDsDetId(DsIndex dsIndex);
 
 /** get the number of channels for a given dual sampa (will be 64 in most of the cases. */

--- a/Detectors/MUON/MCH/GlobalMapping/src/DsIndex.cxx
+++ b/Detectors/MUON/MCH/GlobalMapping/src/DsIndex.cxx
@@ -11,9 +11,11 @@
 
 #include "MCHGlobalMapping/DsIndex.h"
 
+#include "MCHMappingInterface/Segmentation.h"
+#include "MCHRawElecMap/DsElecId.h"
+#include "MCHRawElecMap/Mapper.h"
 #include <map>
 #include <vector>
-#include "MCHMappingInterface/Segmentation.h"
 
 namespace o2::mch
 {

--- a/Detectors/MUON/MCH/Mapping/test/src/Segmentation.cxx
+++ b/Detectors/MUON/MCH/Mapping/test/src/Segmentation.cxx
@@ -507,6 +507,22 @@ BOOST_AUTO_TEST_CASE(CheckAssignment)
   BOOST_TEST(copy.nofPads() == seg.nofPads());
 }
 
+BOOST_AUTO_TEST_CASE(RangeOfDualSampaIdIs1To1361)
+{
+  int minDsId{std::numeric_limits<int>::max()};
+  int maxDsId{std::numeric_limits<int>::min()};
+
+  forOneDetectionElementOfEachSegmentationType([&](int detElemId) {
+    const auto& seg = o2::mch::mapping::segmentation(detElemId);
+    seg.forEachDualSampa([&](int dualSampaId) {
+      minDsId = std::min(minDsId, dualSampaId);
+      maxDsId = std::max(maxDsId, dualSampaId);
+    });
+  });
+  BOOST_CHECK_EQUAL(minDsId, 1);
+  BOOST_CHECK_EQUAL(maxDsId, 1361);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()

--- a/Detectors/MUON/MCH/Raw/ElecMap/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Raw/ElecMap/CMakeLists.txt
@@ -41,7 +41,10 @@ o2_add_library(MCHRawElecMap
         src/MapFEC.cxx
         src/Mapper.cxx
         src/dslist.cxx
-        PUBLIC_LINK_LIBRARIES O2::MCHRawImplHelpers Microsoft.GSL::GSL
+        PUBLIC_LINK_LIBRARIES
+          Microsoft.GSL::GSL
+          O2::DataFormatsMCH
+          O2::MCHRawImplHelpers
         PRIVATE_LINK_LIBRARIES O2::MCHConstants)
 
 

--- a/Detectors/MUON/MCH/Raw/ElecMap/include/MCHRawElecMap/Mapper.h
+++ b/Detectors/MUON/MCH/Raw/ElecMap/include/MCHRawElecMap/Mapper.h
@@ -12,6 +12,8 @@
 #ifndef O2_MCH_RAW_ELECMAP_MAPPER_H
 #define O2_MCH_RAW_ELECMAP_MAPPER_H
 
+#include "DataFormatsMCH/DsChannelId.h"
+#include "DataFormatsMCH/DsChannelDetId.h"
 #include "MCHRawElecMap/DsDetId.h"
 #include "MCHRawElecMap/DsElecId.h"
 #include "MCHRawElecMap/FeeLinkId.h"
@@ -124,6 +126,10 @@ extern std::array<int, 13> deIdsOfCH10L;
 // @returns vector of error messages. If empty the check is ok
 template <typename T>
 std::vector<std::string> solar2FeeLinkConsistencyCheck();
+
+/** converts a DsChannelId (aka {solar,group,index}) into a DetChannelDetId (aka {de,ds,channel})
+ */
+DsChannelDetId convert(const DsChannelId& id);
 
 } // namespace o2::mch::raw
 

--- a/Detectors/MUON/MCH/Raw/ElecMap/src/Mapper.cxx
+++ b/Detectors/MUON/MCH/Raw/ElecMap/src/Mapper.cxx
@@ -35,4 +35,14 @@ std::array<int, 13> deIdsOfCH9L{907, 908, 909, 910, 911, 912, 913, 914, 915, 916
 std::array<int, 13> deIdsOfCH10R{1006, 1005, 1004, 1003, 1002, 1001, 1000, 1025, 1024, 1023, 1022, 1021, 1020}; // from top to bottom
 std::array<int, 13> deIdsOfCH10L{1007, 1008, 1009, 1010, 1011, 1012, 1013, 1014, 1015, 1016, 1017, 1018, 1019}; // from top to bottom
 
+DsChannelDetId convert(const DsChannelId& id)
+{
+  static auto det2elec = createElec2DetMapper<raw::ElectronicMapperGenerated>();
+  auto group = raw::groupFromElinkId(id.getElinkId());
+  auto index = raw::indexFromElinkId(id.getElinkId());
+  raw::DsElecId dsElecId{id.getSolarId(), group.value(), index.value()};
+  auto dsDetId = det2elec(dsElecId).value();
+  return DsChannelDetId(dsDetId.deId(), dsDetId.dsId(), id.getChannel());
+}
+
 } // namespace o2::mch::raw

--- a/Detectors/MUON/MCH/Workflow/CMakeLists.txt
+++ b/Detectors/MUON/MCH/Workflow/CMakeLists.txt
@@ -126,15 +126,16 @@ o2_add_executable(
             src/reco-workflow.cxx
         COMPONENT_NAME mch
         PUBLIC_LINK_LIBRARIES
+            O2::MCHConditions
             O2::MCHDigitFiltering
             O2::MCHGeometryTransformer
             O2::MCHIO
+            O2::MCHIO
             O2::MCHMappingImpl4
             O2::MCHTimeClustering
-            O2::MCHTriggering
             O2::MCHTracking
+            O2::MCHTriggering
             O2::MCHWorkflow
-            O2::MCHIO
             O2::SimulationDataFormat
             O2::Steer
         TARGETVARNAME mch-reco-workflow)

--- a/Detectors/MUON/MCH/Workflow/src/reco-workflow.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/reco-workflow.cxx
@@ -12,7 +12,6 @@
 #include "ClusterFinderGEMSpec.h"
 #include "CommonUtils/ConfigurableParam.h"
 #include "DetectorsRaw/HBFUtilsInitializer.h"
-#include "MCHIO/DigitReaderSpec.h"
 #include "ErrorMergerSpec.h"
 #include "EventFinderSpec.h"
 #include "Framework/CallbacksPolicy.h"
@@ -22,15 +21,17 @@
 #include "Framework/Variant.h"
 #include "Framework/WorkflowSpec.h"
 #include "MCHClustering/ClusterizerParam.h"
+#include "MCHConditions/StatusMapCreatorSpec.h"
 #include "MCHDigitFiltering/DigitFilteringSpec.h"
 #include "MCHGeometryTransformer/ClusterTransformerSpec.h"
+#include "MCHIO/ClusterWriterSpec.h"
+#include "MCHIO/DigitReaderSpec.h"
+#include "MCHIO/TrackWriterSpec.h"
 #include "MCHPreClustering/PreClusterFinderSpec.h"
 #include "MCHTimeClustering/TimeClusterFinderSpec.h"
 #include "MCHTracking/TrackFinderSpec.h"
 #include "MCHWorkflow/ClusterFinderOriginalSpec.h"
-#include "MCHIO/ClusterWriterSpec.h"
 #include "MCHWorkflow/ErrorWriterSpec.h"
-#include "MCHIO/TrackWriterSpec.h"
 #include "TrackMCLabelFinderSpec.h"
 
 using namespace o2::framework;
@@ -82,6 +83,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   if (!disableRootInput) {
     specs.emplace_back(o2::mch::getDigitReaderSpec(useMC, "mch-digit-reader"));
   }
+
+  specs.emplace_back(o2::mch::getStatusMapCreatorSpec("mch-statusmap-creator"));
 
   specs.emplace_back(o2::mch::getDigitFilteringSpec(useMC, "mch-digit-filtering",
                                                     "DIGITS", "F-DIGITS",


### PR DESCRIPTION
This PR contains a few things needed to actually reject bad channels during digit filtering :   

- a [statusMap creator workflow](https://github.com/aphecetche/AliceO2/blob/mrrtf-163-ter/Detectors/MUON/MCH/Conditions/src/StatusMapCreatorSpec.cxx) that emits a `MCH/STATUSMAP/0` message (containing a ... [StatusMap](https://github.com/aphecetche/AliceO2/blob/mrrtf-163-ter/Detectors/MUON/MCH/Conditions/include/MCHConditions/StatusMap.h) object). 
- a new [DigitFilter](https://github.com/aphecetche/AliceO2/blob/6dc35b989fd8735336018f11770530963042977e/Detectors/MUON/MCH/DigitFiltering/src/DigitFilter.cxx#L111) to reject pads based on a mask applied to the statusMap

Note that the creator can for the moment use information from `MCH/Calib/BadChannel` (produced during pedestal runs, existing) and/or `MCH/Calib/RejectList` ("manual" reject list, to be added to the CCDB). Usage of HV/LV values will be done later.

Configurable params are used to steer both the  [statusmap creator](https://github.com/aphecetche/AliceO2/blob/mrrtf-163-ter/Detectors/MUON/MCH/Conditions/include/MCHConditions/StatusMapCreatorParam.h) and the [digit filter](https://github.com/aphecetche/AliceO2/blob/6dc35b989fd8735336018f11770530963042977e/Detectors/MUON/MCH/DigitFiltering/include/MCHDigitFiltering/DigitFilterParam.h#L32).

Note also the introduction of a new class to identify a pad : `DsChannelDetId`, in addition to the existing `DsChannelId`. Both are fitting the relevant ids to `uint32_t`, but one is more readout oriented (the existing [DsChannelId](https://github.com/aphecetche/AliceO2/blob/mrrtf-163-ter/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/DsChannelId.h) ~ {solar,group,index}), while the other (the new [DsChannelDetId](https://github.com/aphecetche/AliceO2/blob/mrrtf-163-ter/DataFormats/Detectors/MUON/MCH/include/DataFormatsMCH/DsChannelDetId.h) ~ {de,ds,channel}) is more detector oriented.

Some doc has been added to [MCHConditions](https://github.com/aphecetche/AliceO2/blob/mrrtf-163-ter/Detectors/MUON/MCH/Conditions/README.md) directory.