### PR TITLE
Re-indexing "working" copies of MCH tracks (and correct ROF entries for MFT tracks)

### DIFF
--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchGlobalFwd.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchGlobalFwd.h
@@ -306,6 +306,7 @@ class MatchGlobalFwd
   gsl::span<const o2::mch::ROFRecord> mMCHTrackROFRec;                  ///< MCH tracks ROFRecords
   gsl::span<const o2::mft::TrackMFT> mMFTTracks;                        ///< input MFT tracks
   gsl::span<const o2::itsmft::ROFRecord> mMFTTrackROFRec;               ///< MFT tracks ROFRecords
+  gsl::span<const o2::itsmft::ROFRecord> mMFTTrackROFRecCopyUp;         ///< MFT tracks ROFRecords copy for next ROF
   gsl::span<const o2::dataformats::TrackMCHMID> mMCHMIDMatches;         ///< input MCH MID Matches
   gsl::span<const int> mMFTTrackClusIdx;                                ///< input MFT track cluster indices span
   gsl::span<const o2::itsmft::ROFRecord> mMFTClusterROFRec;             ///< input MFT clusters ROFRecord span
@@ -315,6 +316,7 @@ class MatchGlobalFwd
 
   std::vector<BracketF> mMCHROFTimes;                          ///< min/max times of MCH ROFs in \mus
   std::vector<TrackLocMCH> mMCHWork;                           ///< MCH track params prepared for matching
+  std::vector<int> mMCHID2Work;                                ///< MCH track id to ensure correct indexing for matching
   std::vector<BracketF> mMFTROFTimes;                          ///< min/max times of MFT ROFs in \mus
   std::vector<TrackLocMFT> mMFTWork;                           ///< MFT track params prepared for matching
   std::vector<MFTCluster> mMFTClusters;                        ///< input MFT clusters

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchGlobalFwd.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchGlobalFwd.h
@@ -306,7 +306,6 @@ class MatchGlobalFwd
   gsl::span<const o2::mch::ROFRecord> mMCHTrackROFRec;                  ///< MCH tracks ROFRecords
   gsl::span<const o2::mft::TrackMFT> mMFTTracks;                        ///< input MFT tracks
   gsl::span<const o2::itsmft::ROFRecord> mMFTTrackROFRec;               ///< MFT tracks ROFRecords
-  gsl::span<const o2::itsmft::ROFRecord> mMFTTrackROFRecCopyUp;         ///< MFT tracks ROFRecords copy for next ROF
   gsl::span<const o2::dataformats::TrackMCHMID> mMCHMIDMatches;         ///< input MCH MID Matches
   gsl::span<const int> mMFTTrackClusIdx;                                ///< input MFT track cluster indices span
   gsl::span<const o2::itsmft::ROFRecord> mMFTClusterROFRec;             ///< input MFT clusters ROFRecord span

--- a/Detectors/GlobalTracking/src/MatchGlobalFwd.cxx
+++ b/Detectors/GlobalTracking/src/MatchGlobalFwd.cxx
@@ -257,8 +257,9 @@ bool MatchGlobalFwd::prepareMFTData()
   for (int irof = 0; irof < nROFs; irof++) {
     const auto& rofRec = mMFTTrackROFRec[irof];
     int irofUp = irof + 1;
-    if (irofUp == nROFs)
+    if (irofUp == nROFs) {
       irofUp = irof;
+    }
     const auto& rofRecCopyUp = mMFTTrackROFRecCopyUp[irofUp];
     int nBC = rofRec.getBCData().differenceInBC(mStartIR);
     if (nBC < 0) {

--- a/Detectors/GlobalTracking/src/MatchGlobalFwd.cxx
+++ b/Detectors/GlobalTracking/src/MatchGlobalFwd.cxx
@@ -310,7 +310,6 @@ void MatchGlobalFwd::loadMatches()
     LOG(debug) << "     ==> MFTId = " << MFTId << " MCHId =  " << MCHId << std::endl;
 
     auto& thisMCHTrack = mMCHWork[mMCHID2Work[MCHId]];
-    LOG(info) << " MFTId: " << MFTId << " MCHId: " << MCHId << " --> mMCHID2Work[MCHId]:" << mMCHID2Work[MCHId];
     thisMCHTrack.setMatchInfo(match);
     mMatchedTracks.emplace_back(thisMCHTrack);
     if (mMCTruthON) {

--- a/Detectors/GlobalTracking/src/MatchGlobalFwd.cxx
+++ b/Detectors/GlobalTracking/src/MatchGlobalFwd.cxx
@@ -240,7 +240,6 @@ bool MatchGlobalFwd::prepareMFTData()
   // Load MFT tracks
   mMFTTracks = inp.getMFTTracks();
   mMFTTrackROFRec = inp.getMFTTracksROFRecords();
-  mMFTTrackROFRecCopyUp = inp.getMFTTracksROFRecords();
   if (mMCTruthON) {
     mMFTTrkLabels = inp.getMFTTracksMCLabels();
   }
@@ -256,11 +255,6 @@ bool MatchGlobalFwd::prepareMFTData()
 
   for (int irof = 0; irof < nROFs; irof++) {
     const auto& rofRec = mMFTTrackROFRec[irof];
-    int irofUp = irof + 1;
-    if (irofUp == nROFs) {
-      irofUp = irof;
-    }
-    const auto& rofRecCopyUp = mMFTTrackROFRecCopyUp[irofUp];
     int nBC = rofRec.getBCData().differenceInBC(mStartIR);
     if (nBC < 0) {
       if (BCDiffErrCount++ < MAXBCDiffErrCount) {
@@ -280,8 +274,7 @@ bool MatchGlobalFwd::prepareMFTData()
     mMFTROFTimes.emplace_back(tMin, tMax); // MFT ROF min/max time
     LOG(debug) << "MFT ROF # " << irof << " " << rofRec.getBCData() << " [tMin;tMax] = [" << tMin << ";" << tMax << "]";
 
-    // int trlim = rofRec.getFirstEntry() + rofRec.getNEntries();
-    int trlim = rofRec.getFirstEntry() + (rofRecCopyUp.getFirstEntry() - rofRec.getFirstEntry());
+    int trlim = rofRec.getFirstEntry() + rofRec.getNEntries();
     for (int it = rofRec.getFirstEntry(); it < trlim; it++) {
       const auto& trcOrig = mMFTTracks[it];
 


### PR DESCRIPTION
To follow https://alice.its.cern.ch/jira/browse/O2-3572 @shahor02:
- re-indexing of "working" copies of MCH tracks (mMCHWork) using `std::vector<int> mMCHID2Work` 
- (could be suggestion) fixing the ROF entries for a loop which is producing mMFTWork.size() with zero, using copy of mMFTTrackROFRec with `gsl::span<const o2::itsmft::ROFRecord> mMFTTrackROFRecCopyUp` 