### PR TITLE
[ITS, ITS3] Create topology-dictionary routine for ITS3

### DIFF
--- a/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TopologyDictionary.h
+++ b/DataFormats/Detectors/ITSMFT/common/include/DataFormatsITSMFT/TopologyDictionary.h
@@ -72,6 +72,13 @@ class TopologyDictionary
   /// Constructor
   TopologyDictionary(const std::string& fileName);
   TopologyDictionary& operator=(const TopologyDictionary& dict) = default;
+
+  static constexpr int STopoSize = 8 * 255 + 1;
+  std::unordered_map<unsigned long, int> mCommonMap; ///< Map of pair <hash, position in mVectorOfIDs>
+  std::unordered_map<int, int> mGroupMap;            ///< Map of pair <groudID, position in mVectorOfIDs>
+  int mSmallTopologiesLUT[STopoSize];                ///< Look-Up Table for the topologies with 1-byte linearised matrix
+  std::vector<GroupStruct> mVectorOfIDs;             ///< Vector of topologies and groups
+
   /// constexpr for the definition of the groups of rare topologies.
   /// The attritbution of the group ID is stringly dependent on the following parameters: it must be a power of 2.
   static constexpr int RowClassSpan = 4;                                                            ///< Row span of the classes of rare topologies
@@ -179,13 +186,6 @@ class TopologyDictionary
   friend BuildTopologyDictionary;
   friend LookUp;
   friend TopologyFastSimulation;
-
- private:
-  static constexpr int STopoSize = 8 * 255 + 1;
-  std::unordered_map<unsigned long, int> mCommonMap; ///< Map of pair <hash, position in mVectorOfIDs>
-  std::unordered_map<int, int> mGroupMap;            ///< Map of pair <groudID, position in mVectorOfIDs>
-  int mSmallTopologiesLUT[STopoSize];                ///< Look-Up Table for the topologies with 1-byte linearised matrix
-  std::vector<GroupStruct> mVectorOfIDs;             ///< Vector of topologies and groups
 
   ClassDefNV(TopologyDictionary, 4);
 }; // namespace itsmft

--- a/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/BuildTopologyDictionary.h
+++ b/Detectors/ITSMFT/common/reconstruction/include/ITSMFTReconstruction/BuildTopologyDictionary.h
@@ -73,7 +73,7 @@ class BuildTopologyDictionary
   int getNotInGroups() const { return mNCommonTopologies; }
   TopologyDictionary getDictionary() const { return mDictionary; }
 
- private:
+ protected:
   TopologyDictionary mDictionary;                                          ///< Dictionary of topologies
   std::map<unsigned long, TopoStat> mTopologyMap;                          //! Temporary map of type <hash,TopStat>
   std::vector<std::pair<unsigned long, unsigned long>> mTopologyFrequency; //! <freq,hash>, needed to define threshold

--- a/Detectors/Upgrades/ITS3/macros/test/CMakeLists.txt
+++ b/Detectors/Upgrades/ITS3/macros/test/CMakeLists.txt
@@ -32,6 +32,18 @@ o2_add_test_root_macro(CheckClustersITS3.C
                                              O2::DetectorsBase
                        LABELS its3)
 
+o2_add_test_root_macro(CreateDictionariesITS3.C
+                       PUBLIC_LINK_LIBRARIES O2::ITSBase
+                                             O2::ITS3Base
+                                             O2::ITSMFTBase
+                                             O2::ITSMFTSimulation
+                                             O2::ITS3Simulation
+                                             O2::ITS3Reconstruction
+                                             O2::MathUtils
+                                             O2::SimulationDataFormat
+                                             O2::DetectorsBase
+                       LABELS its3)
+
                        # o2_add_test_root_macro(CheckSquasherITS3.C
 #                        PUBLIC_LINK_LIBRARIES O2::ITSBase
 #                                              O2::ITS3Base

--- a/Detectors/Upgrades/ITS3/macros/test/CMakeLists.txt
+++ b/Detectors/Upgrades/ITS3/macros/test/CMakeLists.txt
@@ -25,6 +25,7 @@ o2_add_test_root_macro(CheckClustersITS3.C
                                              O2::ITS3Base
                                              O2::ITSMFTBase
                                              O2::ITSMFTSimulation
+                                             O2::DataFormatsITS3
                                              O2::ITS3Simulation
                                              O2::ITS3Reconstruction
                                              O2::MathUtils
@@ -37,12 +38,13 @@ o2_add_test_root_macro(CreateDictionariesITS3.C
                                              O2::ITS3Base
                                              O2::ITSMFTBase
                                              O2::ITSMFTSimulation
+                                             O2::DataFormatsITS3
                                              O2::ITS3Simulation
                                              O2::ITS3Reconstruction
                                              O2::MathUtils
                                              O2::SimulationDataFormat
                                              O2::DetectorsBase
-                       LABELS its3)
+                       LABELS its3 COMPILE_ONLY)
 
                        # o2_add_test_root_macro(CheckSquasherITS3.C
 #                        PUBLIC_LINK_LIBRARIES O2::ITSBase

--- a/Detectors/Upgrades/ITS3/macros/test/CheckClustersITS3.C
+++ b/Detectors/Upgrades/ITS3/macros/test/CheckClustersITS3.C
@@ -28,7 +28,6 @@
 #include "ITS3Base/SegmentationSuperAlpide.h"
 #include "ITSBase/GeometryTGeo.h"
 #include "DataFormatsITS3/CompCluster.h"
-#include "DataFormatsITSMFT/TopologyDictionary.h"
 #include "ITS3Reconstruction/TopologyDictionary.h"
 #include "ITSMFTSimulation/Hit.h"
 #include "DataFormatsITSMFT/ROFRecord.h"
@@ -100,15 +99,14 @@ void CheckClustersITS3(int nITS3layers = 3, std::string clusfile = "o2clus_it3.r
   if (dictfile.empty()) {
     dictfile = o2::base::DetectorNameConf::getAlpideClusterDictionaryFileName(o2::detectors::DetID::IT3, "", ".bin");
   }
-  o2::itsmft::TopologyDictionary dict2;
+  o2::its3::TopologyDictionary dict;
   std::ifstream file(dictfile.c_str());
   if (file.good()) {
     LOG(info) << "Running with dictionary: " << dictfile.c_str();
-    dict2.readFromFile(dictfile);
+    dict.readFromFile(dictfile);
   } else {
     LOG(info) << "Running without dictionary !";
   }
-  o2::its3::TopologyDictionary dict = dict2;
 
   // ROFrecords
   std::vector<ROFRec> rofRecVec, *rofRecVecP = &rofRecVec;
@@ -189,6 +187,13 @@ void CheckClustersITS3(int nITS3layers = 3, std::string clusfile = "o2clus_it3.r
         locC = dict.getClusterCoordinates(cluster);
         errX = dict.getErrX(pattID);
         errZ = dict.getErrZ(pattID);
+        if (chipID / nChipsPerLayer >= nITS3layers) {
+          errX *= Segmentation::PitchRow;
+          errZ *= Segmentation::PitchCol;
+        } else {
+          errX *= segs[chipID].mPitchRow;
+          errZ *= segs[chipID].mPitchCol;
+        }
         npix = dict.getNpixels(pattID);
         LOGP(info, "I am invalid and I am on chip {}", chipID);
       }

--- a/Detectors/Upgrades/ITS3/macros/test/CreateDictionariesITS3.C
+++ b/Detectors/Upgrades/ITS3/macros/test/CreateDictionariesITS3.C
@@ -29,17 +29,19 @@
 #include <TTree.h>
 #include <TStopwatch.h>
 
-#include "MathUtils/Utils.h"
+#include "DetectorsCommonDataFormats/DetID.h"
 #include "ITSBase/GeometryTGeo.h"
-#include "ITS3Reconstruction/BuildTopologyDictionary.h"
-#include "ITS3Reconstruction/TopologyDictionary.h"
+#include "ITSMFTBase/SegmentationAlpide.h"
 #include "ITS3Base/SegmentationSuperAlpide.h"
-#include "DataFormatsITSMFT/CompCluster.h"
 #include "DataFormatsITS3/CompCluster.h"
 #include "DataFormatsITSMFT/ClusterTopology.h"
+#include "ITS3Reconstruction/TopologyDictionary.h"
+#include "ITS3Reconstruction/BuildTopologyDictionary.h"
 #include "DataFormatsITSMFT/ROFRecord.h"
+
 #include "ITSMFTSimulation/Hit.h"
 #include "MathUtils/Cartesian.h"
+#include "MathUtils/Utils.h"
 #include "SimulationDataFormat/MCCompLabel.h"
 #include "SimulationDataFormat/MCTruthContainer.h"
 #include "DetectorsCommonDataFormats/DetectorNameConf.h"

--- a/Detectors/Upgrades/ITS3/macros/test/CreateDictionariesITS3.C
+++ b/Detectors/Upgrades/ITS3/macros/test/CreateDictionariesITS3.C
@@ -13,6 +13,7 @@
 /// \brief Macros to test the generation of a dictionary of topologies. Three dictionaries are generated: one with signal-cluster only, one with noise-clusters only and one with all the clusters.
 
 #if !defined(__CLING__) || defined(__ROOTCLING__)
+#define ENABLE_UPGRADES
 
 #include <string>
 #include <unordered_map>
@@ -311,7 +312,7 @@ void CreateDictionariesITS3(bool saveDeltas = false,
       }
     }
   }
-  auto dID = o2::detectors::DetID::ITS;
+  auto dID = o2::detectors::DetID::IT3;
 
   completeDictionary.setThreshold(probThreshold);
   completeDictionary.groupRareTopologies();

--- a/Detectors/Upgrades/ITS3/macros/test/CreateDictionariesITS3.C
+++ b/Detectors/Upgrades/ITS3/macros/test/CreateDictionariesITS3.C
@@ -1,0 +1,361 @@
+/// \file CreateDictionaries.C
+/// Macros to test the generation of a dictionary of topologies. Three dictionaries are generated: one with signal-cluster only, one with noise-clusters only and one with all the clusters.
+
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+
+#include <string>
+#include <unordered_map>
+
+#include <TAxis.h>
+#include <TCanvas.h>
+#include <TSystem.h>
+#include <TFile.h>
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TNtuple.h>
+#include <TString.h>
+#include <TStyle.h>
+#include <TTree.h>
+#include <TStopwatch.h>
+
+#include "MathUtils/Utils.h"
+#include "ITSBase/GeometryTGeo.h"
+#include "ITS3Reconstruction/BuildTopologyDictionary.h"
+#include "ITS3Reconstruction/TopologyDictionary.h"
+#include "ITS3Base/SegmentationSuperAlpide.h"
+#include "DataFormatsITSMFT/CompCluster.h"
+#include "DataFormatsITS3/CompCluster.h"
+#include "DataFormatsITSMFT/ClusterTopology.h"
+#include "DataFormatsITSMFT/ROFRecord.h"
+#include "ITSMFTSimulation/Hit.h"
+#include "MathUtils/Cartesian.h"
+#include "SimulationDataFormat/MCCompLabel.h"
+#include "SimulationDataFormat/MCTruthContainer.h"
+#include "DetectorsCommonDataFormats/DetectorNameConf.h"
+#include "SimulationDataFormat/DigitizationContext.h"
+#include "Framework/Logger.h"
+
+#endif
+
+void CreateDictionariesITS3(bool saveDeltas = false,
+                            float probThreshold = 1e-6,
+                            std::string clusDictFile = "",
+                            std::string clusfile = "o2clus_it3.root",
+                            std::string hitfile = "o2sim_HitsIT3.root",
+                            std::string collContextfile = "collisioncontext.root",
+                            std::string inputGeom = "",
+                            float checkOutliers = 2., // reject outliers (MC dX or dZ exceeds row/col span by a factor above the threshold)
+                            float minPtMC = 0.01)     // account only MC hits with pT above threshold
+{
+  const int QEDSourceID = 99; // Clusters from this MC source correspond to QED electrons
+
+  using namespace o2::base;
+  using namespace o2::its;
+
+  using o2::its3::SegmentationSuperAlpide;
+  using Segmentation = o2::itsmft::SegmentationAlpide;
+  using o2::its3::BuildTopologyDictionary;
+  using o2::its3::CompClusterExt;
+  using o2::itsmft::ClusterTopology;
+  using o2::itsmft::CompCluster;
+  using o2::itsmft::Hit;
+  using ROFRec = o2::itsmft::ROFRecord;
+  using MC2ROF = o2::itsmft::MC2ROFRecord;
+  using HitVec = std::vector<Hit>;
+  using MC2HITS_map = std::unordered_map<uint64_t, int>; // maps (track_ID<<16 + chip_ID) to entry in the hit vector
+  std::unordered_map<int, int> hadronicMCMap;            // mapping from MC event entry to hadronic event ID
+  std::vector<HitVec*> hitVecPool;
+  std::vector<MC2HITS_map> mc2hitVec;
+  o2::itsmft::TopologyDictionary clusDictOld;
+  if (!clusDictFile.empty()) {
+    clusDictOld.readFromFile(clusDictFile);
+    LOGP(info, "Loaded external cluster dictionary with {} entries from {}", clusDictOld.getSize(), clusDictFile);
+  }
+
+  static SegmentationSuperAlpide segmentations[6]{SegmentationSuperAlpide(0),
+                                                  SegmentationSuperAlpide(0),
+                                                  SegmentationSuperAlpide(1),
+                                                  SegmentationSuperAlpide(1),
+                                                  SegmentationSuperAlpide(2),
+                                                  SegmentationSuperAlpide(2)}; // TODO: fix NLayers
+
+  TFile* fout = nullptr;
+  TNtuple* nt = nullptr;
+  if (saveDeltas) {
+    fout = TFile::Open("CreateDictionaries.root", "recreate");
+    nt = new TNtuple("nt", "hashes ntuple", "hash:dx:dz");
+  }
+
+  const o2::steer::DigitizationContext* digContext = nullptr;
+  TStopwatch sw;
+  sw.Start();
+  float minPtMC2 = minPtMC > 0 ? minPtMC * minPtMC : -1;
+  // Geometry
+  o2::base::GeometryManager::loadGeometry(inputGeom);
+  auto gman = o2::its::GeometryTGeo::Instance();
+  gman->fillMatrixCache(o2::math_utils::bit2Mask(o2::math_utils::TransformType::T2L, o2::math_utils::TransformType::T2GRot,
+                                                 o2::math_utils::TransformType::L2G)); // request cached transforms
+
+  // Hits
+  TFile* fileH = nullptr;
+  TTree* hitTree = nullptr;
+
+  if (!hitfile.empty() && !collContextfile.empty() && !gSystem->AccessPathName(hitfile.c_str()) && !gSystem->AccessPathName(collContextfile.c_str())) {
+    fileH = TFile::Open(hitfile.data());
+    hitTree = (TTree*)fileH->Get("o2sim");
+    mc2hitVec.resize(hitTree->GetEntries());
+    hitVecPool.resize(hitTree->GetEntries(), nullptr);
+    digContext = o2::steer::DigitizationContext::loadFromFile(collContextfile);
+
+    auto& intGlo = digContext->getEventParts(digContext->isQEDProvided());
+    int hadrID = -1, nGlo = intGlo.size(), nHadro = 0;
+    for (int iglo = 0; iglo < nGlo; iglo++) {
+      const auto& parts = intGlo[iglo];
+      bool found = false;
+      for (auto& part : parts) {
+        if (part.sourceID == 0) { // we use underlying background
+          hadronicMCMap[iglo] = part.entryID;
+          found = true;
+          nHadro++;
+          break;
+        }
+      }
+      if (!found) {
+        hadronicMCMap[iglo] = -1;
+      }
+    }
+    if (nHadro < hitTree->GetEntries()) {
+      LOG(fatal) << "N=" << nHadro << " hadronic events < "
+                 << " N=" << hitTree->GetEntries() << " Hit enties.";
+    }
+  }
+
+  // Clusters
+  TFile* fileCl = TFile::Open(clusfile.data());
+  TTree* clusTree = (TTree*)fileCl->Get("o2sim");
+  std::vector<CompClusterExt>* clusArr = nullptr;
+  clusTree->SetBranchAddress("IT3ClusterComp", &clusArr);
+  std::vector<unsigned char>* patternsPtr = nullptr;
+  auto pattBranch = clusTree->GetBranch("IT3ClusterPatt");
+  if (pattBranch) {
+    pattBranch->SetAddress(&patternsPtr);
+  }
+
+  // ROFrecords
+  std::vector<ROFRec> rofRecVec, *rofRecVecP = &rofRecVec;
+  clusTree->SetBranchAddress("IT3ClustersROF", &rofRecVecP);
+
+  // Cluster MC labels
+  o2::dataformats::MCTruthContainer<o2::MCCompLabel>* clusLabArr = nullptr;
+  std::vector<MC2ROF> mc2rofVec, *mc2rofVecP = &mc2rofVec;
+  if (hitTree && clusTree->GetBranch("IT3ClusterMCTruth")) {
+    clusTree->SetBranchAddress("IT3ClusterMCTruth", &clusLabArr);
+    clusTree->SetBranchAddress("IT3ClustersMC2ROF", &mc2rofVecP);
+  }
+  clusTree->GetEntry(0);
+  if (clusTree->GetEntries() > 1 && !hitfile.empty()) {
+    LOGP(error, "Hits are provided but the cluster tree containes {} entries, looks like real data");
+    return;
+  }
+
+  // Topologies dictionaries: 1) all clusters 2) signal clusters only 3) noise clusters only
+  BuildTopologyDictionary completeDictionary;
+  BuildTopologyDictionary signalDictionary;
+  BuildTopologyDictionary noiseDictionary;
+
+  int nROFRec = (int)rofRecVec.size();
+  std::vector<int> mcEvMin, mcEvMax;
+
+  if (clusLabArr) { // >> build min and max MC events used by each ROF
+    mcEvMin.resize(nROFRec, hitTree->GetEntries());
+    mcEvMax.resize(nROFRec, -1);
+    for (int imc = mc2rofVec.size(); imc--;) {
+      int hadrID = hadronicMCMap[imc];
+      if (hadrID < 0) {
+        continue;
+      }
+      const auto& mc2rof = mc2rofVec[imc];
+      if (mc2rof.rofRecordID < 0) {
+        continue; // this MC event did not contribute to any ROF
+      }
+      for (int irfd = mc2rof.maxROF - mc2rof.minROF + 1; irfd--;) {
+        int irof = mc2rof.rofRecordID + irfd;
+        if (mcEvMin[irof] > hadrID) {
+          mcEvMin[irof] = hadrID;
+        }
+        if (mcEvMax[irof] < hadrID) {
+          mcEvMax[irof] = hadrID;
+        }
+      }
+    }
+  } // << build min and max MC events used by each ROF
+
+  for (Long64_t ient = 0; ient < clusTree->GetEntries(); ient++) {
+    clusTree->GetEntry(ient);
+    nROFRec = (int)rofRecVec.size();
+    LOGP(info, "Processing TF {} with {} ROFs and {} clusters", ient, nROFRec, clusArr->size());
+    auto pattIdx = patternsPtr->cbegin();
+    for (int irof = 0; irof < nROFRec; irof++) {
+      const auto& rofRec = rofRecVec[irof];
+
+      // rofRec.print();
+
+      if (clusLabArr) { // >> read and map MC events contributing to this ROF
+        for (int im = mcEvMin[irof]; im <= mcEvMax[irof]; im++) {
+          if (!hitVecPool[im]) {
+            hitTree->SetBranchAddress("IT3Hit", &hitVecPool[im]);
+            hitTree->GetEntry(im);
+            auto& mc2hit = mc2hitVec[im];
+            const auto* hitArray = hitVecPool[im];
+            for (int ih = hitArray->size(); ih--;) {
+              const auto& hit = (*hitArray)[ih];
+              uint64_t key = (uint64_t(hit.GetTrackID()) << 32) + hit.GetDetectorID();
+              mc2hit.emplace(key, ih);
+            }
+          }
+        }
+      } // << cache MC events contributing to this ROF
+
+      for (int icl = 0; icl < rofRec.getNEntries(); icl++) {
+        int clEntry = rofRec.getFirstEntry() + icl; // entry of icl-th cluster of this ROF in the vector of clusters
+        // do we read MC data?
+
+        const auto& cluster = (*clusArr)[clEntry];
+        o2::itsmft::ClusterPattern pattern;
+
+        if (cluster.getPatternID() != CompCluster::InvalidPatternID) {
+          if (clusDictOld.getSize() == 0) {
+            LOG(error) << "Encountered patternID = " << cluster.getPatternID() << " != " << CompCluster::InvalidPatternID;
+            LOG(error) << "Clusters have already been generated with a dictionary which was not provided";
+            return;
+          }
+          if (clusDictOld.isGroup(cluster.getPatternID())) {
+            pattern.acquirePattern(pattIdx);
+          } else {
+            pattern = clusDictOld.getPattern(cluster.getPatternID());
+          }
+        } else {
+          pattern.acquirePattern(pattIdx);
+        }
+        ClusterTopology topology;
+        topology.setPattern(pattern);
+
+        float dX = BuildTopologyDictionary::IgnoreVal, dZ = BuildTopologyDictionary::IgnoreVal;
+        if (clusLabArr) {
+          const auto& lab = (clusLabArr->getLabels(clEntry))[0];
+          auto srcID = lab.getSourceID();
+          if (lab.isValid() && srcID != QEDSourceID) { // use MC truth info only for non-QED and non-noise clusters
+            auto trID = lab.getTrackID();
+            const auto& mc2hit = mc2hitVec[lab.getEventID()];
+            const auto* hitArray = hitVecPool[lab.getEventID()];
+            Int_t chipID = cluster.getSensorID();
+            uint64_t key = (uint64_t(trID) << 32) + chipID;
+            auto hitEntry = mc2hit.find(key);
+            if (hitEntry != mc2hit.end()) {
+              const auto& hit = (*hitArray)[hitEntry->second];
+              if (minPtMC < 0.f || hit.GetMomentum().Perp2() > minPtMC2) {
+                auto locH = gman->getMatrixL2G(chipID) ^ (hit.GetPos()); // inverse conversion from global to local
+                auto locHsta = gman->getMatrixL2G(chipID) ^ (hit.GetPosStart());
+                locH.SetXYZ(0.5 * (locH.X() + locHsta.X()), 0.5 * (locH.Y() + locHsta.Y()), 0.5 * (locH.Z() + locHsta.Z()));
+                const auto locC = o2::its3::TopologyDictionary::getClusterCoordinates(cluster, pattern, false);
+                float locXflat, locYflat;
+                if (cluster.getSensorID() < 6)
+                  segmentations[cluster.getSensorID()].curvedToFlat(locC.X(), locC.Y(), locXflat, locYflat);
+                dX = locH.X() - locC.X();
+                dZ = locH.Z() - locC.Z();
+                dX /= (cluster.getSensorID() < 6) ? segmentations[cluster.getSensorID()].mPitchRow : o2::itsmft::SegmentationAlpide::PitchRow;
+                dZ /= (cluster.getSensorID() < 6) ? segmentations[cluster.getSensorID()].mPitchCol : o2::itsmft::SegmentationAlpide::PitchCol;
+                if (saveDeltas) {
+                  nt->Fill(topology.getHash(), dX, dZ);
+                }
+                if (checkOutliers > 0.) {
+                  if (std::abs(dX) > topology.getRowSpan() * checkOutliers ||
+                      std::abs(dZ) > topology.getColumnSpan() * checkOutliers) { // ignore outlier
+                    dX = dZ = BuildTopologyDictionary::IgnoreVal;
+                  }
+                }
+              }
+            } else {
+              LOGP(info, "  Failed to find MC hit entry for Tr: {} chipID: {}", trID, chipID);
+              lab.print();
+            }
+            signalDictionary.accountTopology(topology, dX, dZ);
+          } else {
+            noiseDictionary.accountTopology(topology, dX, dZ);
+          }
+        }
+        completeDictionary.accountTopology(topology, dX, dZ);
+      }
+      // clean MC cache for events which are not needed anymore
+      if (clusLabArr) {
+        int irfNext = irof;
+        int limMC = irfNext == nROFRec ? hitVecPool.size() : mcEvMin[irfNext]; // can clean events up to this
+        for (int imc = mcEvMin[irof]; imc < limMC; imc++) {
+          delete hitVecPool[imc];
+          hitVecPool[imc] = nullptr;
+          mc2hitVec[imc].clear();
+        }
+      }
+    }
+  }
+  auto dID = o2::detectors::DetID::ITS;
+
+  completeDictionary.setThreshold(probThreshold);
+  completeDictionary.groupRareTopologies();
+  completeDictionary.printDictionaryBinary(o2::base::DetectorNameConf::getAlpideClusterDictionaryFileName(dID, ""));
+  completeDictionary.printDictionary(o2::base::DetectorNameConf::getAlpideClusterDictionaryFileName(dID, "", "txt"));
+  completeDictionary.saveDictionaryRoot(o2::base::DetectorNameConf::getAlpideClusterDictionaryFileName(dID, "", "root"));
+
+  TFile histogramOutput("histograms.root", "recreate");
+  TCanvas* cComplete = new TCanvas("cComplete", "Distribution of all the topologies");
+  cComplete->cd();
+  cComplete->SetLogy();
+  TH1F* hComplete = nullptr;
+  o2::itsmft::TopologyDictionary::getTopologyDistribution(completeDictionary.getDictionary(), hComplete, "hComplete");
+  hComplete->SetDirectory(0);
+  hComplete->Draw("hist");
+  hComplete->Write();
+  cComplete->Write();
+
+  TCanvas* cNoise = nullptr;
+  TCanvas* cSignal = nullptr;
+  TH1F* hNoise = nullptr;
+  TH1F* hSignal = nullptr;
+
+  if (clusLabArr) {
+    noiseDictionary.setThreshold(0.0001);
+    noiseDictionary.groupRareTopologies();
+    noiseDictionary.printDictionaryBinary(o2::base::DetectorNameConf::getAlpideClusterDictionaryFileName(dID, "noiseClusTopo"));
+    noiseDictionary.printDictionary(o2::base::DetectorNameConf::getAlpideClusterDictionaryFileName(dID, "noiseClusTopo", "txt"));
+    noiseDictionary.saveDictionaryRoot(o2::base::DetectorNameConf::getAlpideClusterDictionaryFileName(dID, "noiseClusTopo", "root"));
+    signalDictionary.setThreshold(0.0001);
+    signalDictionary.groupRareTopologies();
+    signalDictionary.printDictionaryBinary(o2::base::DetectorNameConf::getAlpideClusterDictionaryFileName(dID, "signal"));
+    signalDictionary.printDictionary(o2::base::DetectorNameConf::getAlpideClusterDictionaryFileName(dID, "signal", "txt"));
+    signalDictionary.saveDictionaryRoot(o2::base::DetectorNameConf::getAlpideClusterDictionaryFileName(dID, "signal", "root"));
+    cNoise = new TCanvas("cNoise", "Distribution of noise topologies");
+    cNoise->cd();
+    cNoise->SetLogy();
+    o2::itsmft::TopologyDictionary::getTopologyDistribution(noiseDictionary.getDictionary(), hNoise, "hNoise");
+    hNoise->SetDirectory(0);
+    hNoise->Draw("hist");
+    histogramOutput.cd();
+    hNoise->Write();
+    cNoise->Write();
+    cSignal = new TCanvas("cSignal", "cSignal");
+    cSignal->cd();
+    cSignal->SetLogy();
+    o2::itsmft::TopologyDictionary::getTopologyDistribution(signalDictionary.getDictionary(), hSignal, "hSignal");
+    hSignal->SetDirectory(0);
+    hSignal->Draw("hist");
+    histogramOutput.cd();
+    hSignal->Write();
+    cSignal->Write();
+    sw.Stop();
+    sw.Print();
+  }
+  if (saveDeltas) {
+    fout->cd();
+    nt->Write();
+  }
+}

--- a/Detectors/Upgrades/ITS3/macros/test/CreateDictionariesITS3.C
+++ b/Detectors/Upgrades/ITS3/macros/test/CreateDictionariesITS3.C
@@ -1,5 +1,16 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 /// \file CreateDictionaries.C
-/// Macros to test the generation of a dictionary of topologies. Three dictionaries are generated: one with signal-cluster only, one with noise-clusters only and one with all the clusters.
+/// \brief Macros to test the generation of a dictionary of topologies. Three dictionaries are generated: one with signal-cluster only, one with noise-clusters only and one with all the clusters.
 
 #if !defined(__CLING__) || defined(__ROOTCLING__)
 

--- a/Detectors/Upgrades/ITS3/reconstruction/CMakeLists.txt
+++ b/Detectors/Upgrades/ITS3/reconstruction/CMakeLists.txt
@@ -13,6 +13,7 @@ o2_add_library(ITS3Reconstruction
                TARGETVARNAME targetName
                SOURCES src/Clusterer.cxx
                        src/TopologyDictionary.cxx
+                       src/BuildTopologyDictionary.cxx
                        src/IOUtils.cxx
                 #        src/FastMultEst.cxx
                PUBLIC_LINK_LIBRARIES O2::ITSMFTBase
@@ -32,6 +33,7 @@ o2_target_root_dictionary(
   ITS3Reconstruction
   HEADERS include/ITS3Reconstruction/Clusterer.h
           include/ITS3Reconstruction/TopologyDictionary.h
+          include/ITS3Reconstruction/BuildTopologyDictionary.h
 )
 
 if (OpenMP_CXX_FOUND)

--- a/Detectors/Upgrades/ITS3/reconstruction/include/ITS3Reconstruction/BuildTopologyDictionary.h
+++ b/Detectors/Upgrades/ITS3/reconstruction/include/ITS3Reconstruction/BuildTopologyDictionary.h
@@ -15,7 +15,7 @@
 #ifndef ALICEO2_ITS3_BUILDTOPOLOGYDICTIONARY_H
 #define ALICEO2_ITS3_BUILDTOPOLOGYDICTIONARY_H
 
-#include "DataFormatsITSMFT/BuildTopologyDictionary.h"
+#include "ITSMFTReconstruction/BuildTopologyDictionary.h"
 #include "DataFormatsITSMFT/ClusterTopology.h"
 #include "ITS3Base/SuperAlpideParams.h"
 namespace o2
@@ -23,17 +23,17 @@ namespace o2
 namespace its3
 {
 
-class BuildTopologyDictionary : public itsmft::BuildTopologyDictionary
+class BuildTopologyDictionary : protected itsmft::BuildTopologyDictionary
 {
  public:
   /// Updates the information of the found cluster topology
   /// \param cluster cluster topology whose information is updatet
   /// \param dX hit - COG positions along x, expressed in fraction of pixel pitches
   /// \param dZ hit - COG positions along z, expressed in fraction of pixel pitches
-  void accountTopology(const ClusterTopology& cluster, float dX = IgnoreVal, float dZ = IgnoreVal);
+  void accountTopology(const itsmft::ClusterTopology& cluster, float dX = IgnoreVal, float dZ = IgnoreVal);
 
   /// Creates entries for common topologies and groups of rare topologies
-  void BuildTopologyDictionary::groupRareTopologies();
+  void groupRareTopologies();
 };
 } // namespace its3
 } // namespace o2

--- a/Detectors/Upgrades/ITS3/reconstruction/include/ITS3Reconstruction/BuildTopologyDictionary.h
+++ b/Detectors/Upgrades/ITS3/reconstruction/include/ITS3Reconstruction/BuildTopologyDictionary.h
@@ -1,0 +1,41 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TopologyDictionary.h
+/// \brief Definition of the BuildTopologyDictionary class for ITS3
+
+#ifndef ALICEO2_ITS3_BUILDTOPOLOGYDICTIONARY_H
+#define ALICEO2_ITS3_BUILDTOPOLOGYDICTIONARY_H
+
+#include "DataFormatsITSMFT/BuildTopologyDictionary.h"
+#include "DataFormatsITSMFT/ClusterTopology.h"
+#include "ITS3Base/SuperAlpideParams.h"
+namespace o2
+{
+namespace its3
+{
+
+class BuildTopologyDictionary : public itsmft::BuildTopologyDictionary
+{
+ public:
+  /// Updates the information of the found cluster topology
+  /// \param cluster cluster topology whose information is updatet
+  /// \param dX hit - COG positions along x, expressed in fraction of pixel pitches
+  /// \param dZ hit - COG positions along z, expressed in fraction of pixel pitches
+  void accountTopology(const ClusterTopology& cluster, float dX = IgnoreVal, float dZ = IgnoreVal);
+
+  /// Creates entries for common topologies and groups of rare topologies
+  void BuildTopologyDictionary::groupRareTopologies();
+};
+} // namespace its3
+} // namespace o2
+
+#endif

--- a/Detectors/Upgrades/ITS3/reconstruction/include/ITS3Reconstruction/BuildTopologyDictionary.h
+++ b/Detectors/Upgrades/ITS3/reconstruction/include/ITS3Reconstruction/BuildTopologyDictionary.h
@@ -23,7 +23,7 @@ namespace o2
 namespace its3
 {
 
-class BuildTopologyDictionary : protected itsmft::BuildTopologyDictionary
+class BuildTopologyDictionary : public itsmft::BuildTopologyDictionary
 {
  public:
   /// Updates the information of the found cluster topology

--- a/Detectors/Upgrades/ITS3/reconstruction/include/ITS3Reconstruction/TopologyDictionary.h
+++ b/Detectors/Upgrades/ITS3/reconstruction/include/ITS3Reconstruction/TopologyDictionary.h
@@ -25,6 +25,8 @@ namespace o2
 namespace its3
 {
 
+class BuildTopologyDictionary;
+
 class TopologyDictionary : public itsmft::TopologyDictionary
 {
  public:
@@ -38,6 +40,8 @@ class TopologyDictionary : public itsmft::TopologyDictionary
   math_utils::Point3D<float> getClusterCoordinates(const its3::CompClusterExt& cl) const;
   /// Returns the local position of a compact cluster
   static math_utils::Point3D<float> getClusterCoordinates(const its3::CompClusterExt& cl, const itsmft::ClusterPattern& patt, bool isGroup = true);
+
+  friend BuildTopologyDictionary;
 };
 } // namespace its3
 } // namespace o2

--- a/Detectors/Upgrades/ITS3/reconstruction/include/ITS3Reconstruction/TopologyDictionary.h
+++ b/Detectors/Upgrades/ITS3/reconstruction/include/ITS3Reconstruction/TopologyDictionary.h
@@ -10,7 +10,7 @@
 // or submit itself to any jurisdiction.
 
 /// \file TopologyDictionary.h
-/// \brief Definition of the ClusterTopology class for ITS3
+/// \brief Definition of the TopologyDictionary class for ITS3
 
 #ifndef ALICEO2_ITS3_TOPOLOGYDICTIONARY_H
 #define ALICEO2_ITS3_TOPOLOGYDICTIONARY_H
@@ -18,6 +18,7 @@
 #include "DataFormatsITSMFT/TopologyDictionary.h"
 #include "DataFormatsITSMFT/ClusterPattern.h"
 #include "DataFormatsITS3/CompCluster.h"
+#include "ITS3Base/SegmentationSuperAlpide.h"
 
 namespace o2
 {
@@ -27,8 +28,12 @@ namespace its3
 class TopologyDictionary : public itsmft::TopologyDictionary
 {
  public:
-  TopologyDictionary(itsmft::TopologyDictionary top) : itsmft::TopologyDictionary{top} {}
-
+  // array version of getClusterCoordinates
+  template <typename T = float>
+  std::array<T, 3> getClusterCoordinatesA(const its3::CompClusterExt& cl) const;
+  /// Returns the local position of a compact cluster
+  template <typename T = float>
+  static std::array<T, 3> getClusterCoordinatesA(const its3::CompClusterExt& cl, const itsmft::ClusterPattern& patt, bool isGroup = true);
   /// Returns the local position of a compact cluster
   math_utils::Point3D<float> getClusterCoordinates(const its3::CompClusterExt& cl) const;
   /// Returns the local position of a compact cluster

--- a/Detectors/Upgrades/ITS3/reconstruction/src/BuildTopologyDictionary.cxx
+++ b/Detectors/Upgrades/ITS3/reconstruction/src/BuildTopologyDictionary.cxx
@@ -1,0 +1,188 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file TopologyDictionary.cxx
+
+#include "ITS3Reconstruction/BuildTopologyDictionary.h"
+#include "ITS3Base/SegmentationSuperAlpide.h"
+#include "ITSMFTBase/SegmentationAlpide.h"
+
+namespace o2::its3
+{
+
+void BuildTopologyDictionary::accountTopology(const ClusterTopology& cluster, float dX, float dZ)
+{
+  mTotClusters++;
+  bool useDf = dX < IgnoreVal / 2; // we may need to account the frequency but to not update the centroid
+  // std::pair<unordered_map<unsigned long, TopoStat>::iterator,bool> ret;
+  //       auto ret = mTopologyMap.insert(std::make_pair(cluster.getHash(), std::make_pair(cluster, 1)));
+
+  auto& topoStat = mTopologyMap[cluster.getHash()];
+  topoStat.countsTotal++;
+  if (topoStat.countsTotal == 1) { // a new topology is inserted
+    topoStat.topology = cluster;
+    //___________________DEFINING_TOPOLOGY_CHARACTERISTICS__________________
+    TopologyInfo topInf;
+    topInf.mPattern.setPattern(cluster.getPattern().data());
+    int& rs = topInf.mSizeX = cluster.getRowSpan();
+    int& cs = topInf.mSizeZ = cluster.getColumnSpan();
+    //__________________COG_Determination_____________
+    topInf.mNpixels = cluster.getClusterPattern().getCOG(topInf.mCOGx, topInf.mCOGz);
+    if (useDf) {
+      topInf.mXmean = dX;
+      topInf.mZmean = dZ;
+      topoStat.countsWithBias = 1;
+    } else { // assign expected sigmas from the pixel X, Z sizes
+      topInf.mXsigma2 = 1 / 12. / std::min(10, topInf.mSizeX);
+      topInf.mZsigma2 = 1 / 12. / std::min(10, topInf.mSizeZ);
+    }
+    mMapInfo.insert(std::make_pair(cluster.getHash(), topInf));
+  } else {
+    if (useDf) {
+      auto num = topoStat.countsWithBias++;
+      auto ind = mMapInfo.find(cluster.getHash());
+      float tmpxMean = ind->second.mXmean;
+      float newxMean = ind->second.mXmean = ((tmpxMean)*num + dX) / (num + 1);
+      float tmpxSigma2 = ind->second.mXsigma2;
+      ind->second.mXsigma2 = (num * tmpxSigma2 + (dX - tmpxMean) * (dX - newxMean)) / (num + 1); // online variance algorithm
+      float tmpzMean = ind->second.mZmean;
+      float newzMean = ind->second.mZmean = ((tmpzMean)*num + dZ) / (num + 1);
+      float tmpzSigma2 = ind->second.mZsigma2;
+      ind->second.mZsigma2 = (num * tmpzSigma2 + (dZ - tmpzMean) * (dZ - newzMean)) / (num + 1); // online variance algorithm
+    }
+  }
+}
+
+void BuildTopologyDictionary::groupRareTopologies()
+{
+  std::cout << "Dictionary finalisation" << std::endl;
+  std::cout << "Number of clusters: " << mTotClusters << std::endl;
+
+  double totFreq = 0.;
+  for (int j = 0; j < mNCommonTopologies; j++) {
+    GroupStruct gr;
+    gr.mHash = mTopologyFrequency[j].second;
+    gr.mFrequency = ((double)(mTopologyFrequency[j].first)) / mTotClusters;
+    totFreq += gr.mFrequency;
+    // rough estimation for the error considering a8 uniform distribution
+    gr.mErrX = std::sqrt(mMapInfo.find(gr.mHash)->second.mXsigma2);
+    gr.mErrZ = std::sqrt(mMapInfo.find(gr.mHash)->second.mZsigma2);
+    gr.mErr2X = mMapInfo.find(gr.mHash)->second.mXsigma2;
+    gr.mErr2Z = mMapInfo.find(gr.mHash)->second.mZsigma2;
+    gr.mXCOG = -1 * mMapInfo.find(gr.mHash)->second.mCOGx;
+    gr.mZCOG = mMapInfo.find(gr.mHash)->second.mCOGz;
+    gr.mNpixels = mMapInfo.find(gr.mHash)->second.mNpixels;
+    gr.mPattern = mMapInfo.find(gr.mHash)->second.mPattern;
+    gr.mIsGroup = false;
+    mDictionary.mVectorOfIDs.push_back(gr);
+    if (j == int(CompCluster::InvalidPatternID - 1)) {
+      LOGP(warning, "Limiting N unique topologies to {}, threshold freq. to {}, cumulative freq. to {} to be below InvalidPatternID", j, gr.mFrequency, totFreq);
+      mNCommonTopologies = j;
+      mFrequencyThreshold = gr.mFrequency;
+      break;
+    }
+  }
+  // groupRareTopologies based on binning over number of rows and columns (TopologyDictionary::NumberOfRowClasses *
+  // NumberOfColClasses)
+
+  std::unordered_map<int, std::pair<GroupStruct, unsigned long>> tmp_GroupMap; //<group ID, <Group struct, counts>>
+
+  int grNum = 0;
+  int rowBinEdge = 0;
+  int colBinEdge = 0;
+  for (int iRowClass = 0; iRowClass < TopologyDictionary::MaxNumberOfRowClasses; iRowClass++) {
+    for (int iColClass = 0; iColClass < TopologyDictionary::MaxNumberOfColClasses; iColClass++) {
+      rowBinEdge = (iRowClass + 1) * TopologyDictionary::RowClassSpan;
+      colBinEdge = (iColClass + 1) * TopologyDictionary::ColClassSpan;
+      grNum = LookUp::groupFinder(rowBinEdge, colBinEdge);
+      // Create a structure for a group of rare topologies
+      GroupStruct gr;
+      gr.mHash = (((unsigned long)(grNum)) << 32) & 0xffffffff00000000;
+      gr.mErrX = TopologyDictionary::RowClassSpan / std::sqrt(12 * std::min(10, rowBinEdge));
+      gr.mErrZ = TopologyDictionary::ColClassSpan / std::sqrt(12 * std::min(10, colBinEdge));
+      gr.mErr2X = gr.mErrX * gr.mErrX;
+      gr.mErr2Z = gr.mErrZ * gr.mErrZ;
+      gr.mXCOG = 0;
+      gr.mZCOG = 0;
+      gr.mNpixels = rowBinEdge * colBinEdge;
+      gr.mIsGroup = true;
+      gr.mFrequency = 0.;
+      /// A dummy pattern with all fired pixels in the bounding box is assigned to groups of rare topologies.
+      unsigned char dummyPattern[ClusterPattern::kExtendedPatternBytes] = {0};
+      dummyPattern[0] = (unsigned char)rowBinEdge;
+      dummyPattern[1] = (unsigned char)colBinEdge;
+      int nBits = rowBinEdge * colBinEdge;
+      int nBytes = nBits / 8;
+      for (int iB = 2; iB < nBytes + 2; iB++) {
+        dummyPattern[iB] = (unsigned char)255;
+      }
+      int residualBits = nBits % 8;
+      if (residualBits) {
+        unsigned char tempChar = 0;
+        while (residualBits > 0) {
+          residualBits--;
+          tempChar |= 1 << (7 - residualBits);
+        }
+        dummyPattern[nBytes + 2] = tempChar;
+      }
+      gr.mPattern.setPattern(dummyPattern);
+      // Filling the map for groups
+      tmp_GroupMap[grNum] = std::make_pair(gr, 0);
+    }
+  }
+  int rs;
+  int cs;
+  int index;
+
+  // Updating the counts for the groups of rare topologies
+  for (unsigned int j = (unsigned int)mNCommonTopologies; j < mTopologyFrequency.size(); j++) {
+    unsigned long hash1 = mTopologyFrequency[j].second;
+    rs = mTopologyMap.find(hash1)->second.topology.getRowSpan();
+    cs = mTopologyMap.find(hash1)->second.topology.getColumnSpan();
+    index = LookUp::groupFinder(rs, cs);
+    tmp_GroupMap[index].second += mTopologyFrequency[j].first;
+  }
+
+  for (auto&& p : tmp_GroupMap) {
+    GroupStruct& group = p.second.first;
+    group.mFrequency = ((double)p.second.second) / mTotClusters;
+    mDictionary.mVectorOfIDs.push_back(group);
+  }
+
+  // Sorting the dictionary preserving all unique topologies
+  std::sort(mDictionary.mVectorOfIDs.begin(), mDictionary.mVectorOfIDs.end(), [](const GroupStruct& a, const GroupStruct& b) {
+    return (!a.mIsGroup) && b.mIsGroup ? true : (a.mIsGroup && (!b.mIsGroup) ? false : (a.mFrequency > b.mFrequency));
+  });
+  if (mDictionary.mVectorOfIDs.size() >= CompCluster::InvalidPatternID - 1) {
+    LOGP(warning, "Max allowed {} patterns is reached, stopping", CompCluster::InvalidPatternID - 1);
+    mDictionary.mVectorOfIDs.resize(CompCluster::InvalidPatternID - 1);
+  }
+  // Sorting the dictionary to final form
+  std::sort(mDictionary.mVectorOfIDs.begin(), mDictionary.mVectorOfIDs.end(), [](const GroupStruct& a, const GroupStruct& b) { return a.mFrequency > b.mFrequency; });
+  // Creating the map for common topologies
+  for (int iKey = 0; iKey < mDictionary.getSize(); iKey++) {
+    GroupStruct& gr = mDictionary.mVectorOfIDs[iKey];
+    if (!gr.mIsGroup) {
+      mDictionary.mCommonMap.insert(std::make_pair(gr.mHash, iKey));
+      if (gr.mPattern.getUsedBytes() == 1) {
+        mDictionary.mSmallTopologiesLUT[(gr.mPattern.getColumnSpan() - 1) * 255 + (int)gr.mPattern.mBitmap[2]] = iKey;
+      }
+    } else {
+      mDictionary.mGroupMap.insert(std::make_pair((int)(gr.mHash >> 32) & 0x00000000ffffffff, iKey));
+    }
+  }
+  std::cout << "Dictionay finalised" << std::endl;
+  std::cout << "Number of keys: " << mDictionary.getSize() << std::endl;
+  std::cout << "Number of common topologies: " << mDictionary.mCommonMap.size() << std::endl;
+  std::cout << "Number of groups of rare topologies: " << mDictionary.mGroupMap.size() << std::endl;
+}
+
+} // namespace o2::its3

--- a/Detectors/Upgrades/ITS3/workflow/include/ITS3Workflow/TrackerSpec.h
+++ b/Detectors/Upgrades/ITS3/workflow/include/ITS3Workflow/TrackerSpec.h
@@ -47,7 +47,7 @@ class TrackerDPL : public framework::Task
   void run(framework::ProcessingContext& pc) final;
   void endOfStream(framework::EndOfStreamContext& ec) final;
   void finaliseCCDB(framework::ConcreteDataMatcher& matcher, void* obj) final;
-  void setClusterDictionary(const o2::itsmft::TopologyDictionary* d) { mDict = static_cast<const o2::its3::TopologyDictionary*>(d); } //TODO: remove casting from Run3 to RUn2 dictionary
+  void setClusterDictionary(const o2::itsmft::TopologyDictionary* d) { mDict = static_cast<const o2::its3::TopologyDictionary*>(d); } // TODO: remove casting from Run3 to RUn2 dictionary
 
  private:
   void updateTimeDependentParams(framework::ProcessingContext& pc);

--- a/Detectors/Upgrades/ITS3/workflow/include/ITS3Workflow/TrackerSpec.h
+++ b/Detectors/Upgrades/ITS3/workflow/include/ITS3Workflow/TrackerSpec.h
@@ -47,7 +47,7 @@ class TrackerDPL : public framework::Task
   void run(framework::ProcessingContext& pc) final;
   void endOfStream(framework::EndOfStreamContext& ec) final;
   void finaliseCCDB(framework::ConcreteDataMatcher& matcher, void* obj) final;
-  void setClusterDictionary(const o2::itsmft::TopologyDictionary* d) { mDict = static_cast<const o2::its3::TopologyDictionary*>(d); } // TODO: remove casting from Run3 to RUn2 dictionary
+  void setClusterDictionary(const o2::its3::TopologyDictionary* d) { mDict = d; }
 
  private:
   void updateTimeDependentParams(framework::ProcessingContext& pc);

--- a/Detectors/Upgrades/ITS3/workflow/include/ITS3Workflow/TrackerSpec.h
+++ b/Detectors/Upgrades/ITS3/workflow/include/ITS3Workflow/TrackerSpec.h
@@ -47,7 +47,7 @@ class TrackerDPL : public framework::Task
   void run(framework::ProcessingContext& pc) final;
   void endOfStream(framework::EndOfStreamContext& ec) final;
   void finaliseCCDB(framework::ConcreteDataMatcher& matcher, void* obj) final;
-  void setClusterDictionary(const o2::itsmft::TopologyDictionary* d) { mDict = static_cast<const o2::its3::TopologyDictionary*>(d); }
+  void setClusterDictionary(const o2::itsmft::TopologyDictionary* d) { mDict = static_cast<const o2::its3::TopologyDictionary*>(d); } //TODO: remove casting from Run3 to RUn2 dictionary
 
  private:
   void updateTimeDependentParams(framework::ProcessingContext& pc);

--- a/Detectors/Upgrades/ITS3/workflow/src/TrackerSpec.cxx
+++ b/Detectors/Upgrades/ITS3/workflow/src/TrackerSpec.cxx
@@ -322,7 +322,7 @@ void TrackerDPL::updateTimeDependentParams(ProcessingContext& pc)
   static bool initOnceDone = false;
   if (!initOnceDone) { // this params need to be queried only once
     initOnceDone = true;
-    pc.inputs().get<o2::itsmft::TopologyDictionary*>("cldict"); // just to trigger the finaliseCCDB
+    pc.inputs().get<o2::its3::TopologyDictionary*>("cldict"); // just to trigger the finaliseCCDB
     pc.inputs().get<o2::itsmft::DPLAlpideParam<o2::detectors::DetID::ITS>*>("alppar");
     o2::its::GeometryTGeo* geom = o2::its::GeometryTGeo::Instance();
     geom->fillMatrixCache(o2::math_utils::bit2Mask(o2::math_utils::TransformType::T2L, o2::math_utils::TransformType::T2GRot, o2::math_utils::TransformType::T2G));
@@ -339,7 +339,7 @@ void TrackerDPL::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
   }
   if (matcher == ConcreteDataMatcher("ITS", "CLUSDICT", 0)) {
     LOG(info) << "cluster dictionary updated";
-    setClusterDictionary((const o2::itsmft::TopologyDictionary*)obj);
+    setClusterDictionary((const o2::its3::TopologyDictionary*)obj);
     return;
   }
   // Note: strictly speaking, for Configurable params we don't need finaliseCCDB check, the singletons are updated at the CCDB fetcher level


### PR DESCRIPTION
All the new classes inherit from ITS2 version.

Main points:
- in the new dictionary format, the position of the COG within the bounding box is given in pixels and not in cm. This change is needed because the same topology can be in the inner barrel or in the outer barrel, which have different segemtations.
- `its3::BuildTopologyDictionary` fills the entries of the dictionary with coordinates in pixels.
- In `its3::TopologyDictionary`, the `GetClusterCoordinates` method returns the position of the cluster in cm (conversion is made internally).
-  It was necessaty to make `itsmft::TopologyDictionary` private data members public, to make them accessible to `its3::BuildTopologyDictionary` (different namespace and `itsmft::BuildTopologyDictionary` already present). This is compatible with previous versions of the code.
- A macro for creating the dictionaries was added in `Detectors/Upgrades/ITS3/macros/test`. It was modulated from the its2 version.

The routine, up to the creation of the ITS3 dictionary, has been tested on simulated Pb-Pb collisions

