### PR TITLE
Allow to run the MID chamber efficiency workflow with matched MCH-MID tracks

### DIFF
--- a/Detectors/MUON/MID/Workflow/CMakeLists.txt
+++ b/Detectors/MUON/MID/Workflow/CMakeLists.txt
@@ -17,7 +17,6 @@ o2_add_library(
           src/ColumnDataSpecsUtils.cxx
           src/DecodedDataAggregatorSpec.cxx
           src/DigitReaderSpec.cxx
-          src/EfficiencySpec.cxx
           src/EntropyDecoderSpec.cxx
           src/EntropyEncoderSpec.cxx
           src/FilteringSpec.cxx
@@ -48,7 +47,6 @@ o2_add_library(
     O2::MIDCalibration
     O2::MIDClustering
     O2::MIDCTF
-    O2::MIDEfficiency
     O2::MIDFiltering
     O2::MIDQC
     O2::MIDRaw
@@ -114,13 +112,6 @@ o2_add_executable(
   COMPONENT_NAME mid
   SOURCES src/calibration-workflow.cxx
   PUBLIC_LINK_LIBRARIES O2::MIDWorkflow)
-
-o2_add_executable(
-  efficiency-workflow
-  COMPONENT_NAME mid
-  SOURCES src/EfficiencySpec.cxx src/efficiency-workflow.cxx
-  PUBLIC_LINK_LIBRARIES O2::MIDWorkflow)
-
 
 o2_add_executable(
   raw-dump-workflow

--- a/Detectors/MUON/MID/Workflow/README.md
+++ b/Detectors/MUON/MID/Workflow/README.md
@@ -9,7 +9,6 @@
 3. [MID calibration](#mid-calibration)
 4. [MID digits writer](#mid-digits-writer)
 5. [MID raw data dumper](#mid-raw-data-dumper)
-6. [MID efficiency](#mid-efficiency)
 
 ## MID reconstruction workflow
 
@@ -242,14 +241,3 @@ o2-raw-tf-reader-workflow --onlyDet MID --input-data o2_rawtf_run00505645_tf0000
 ```
 
 If option `--decode` is added, the decoded digits are dumped instead.
-
-# MID efficiency
-
-This workflow allows to compute the MID chamber efficiency.
-This is just an example since, eventually, the workflow should be rewritten in order to be able to run on AODs.
-
-Usage:
-
-```bash
-o2-ctf-reader-workflow --ctf-input o2_ctf_0000000000.root --onlyDet MID | o2-mid-reco-workflow --disable-mc | o2-mid-efficiency-workflow
-```

--- a/Detectors/MUON/Workflow/CMakeLists.txt
+++ b/Detectors/MUON/Workflow/CMakeLists.txt
@@ -20,3 +20,9 @@ o2_add_executable(
         SOURCES src/TrackWriterSpec.cxx src/tracks-writer-workflow.cxx
         COMPONENT_NAME muon
         PUBLIC_LINK_LIBRARIES O2::Framework O2::DPLUtils O2::ReconstructionDataFormats O2::SimulationDataFormat)
+
+o2_add_executable(
+        chamber-efficiency-workflow
+        SOURCES src/ChamberEfficiencySpec.cxx src/chamber-efficiency-workflow.cxx
+        COMPONENT_NAME mid
+        PUBLIC_LINK_LIBRARIES O2::Framework O2::ReconstructionDataFormats O2::DataFormatsMID O2::MIDEfficiency)

--- a/Detectors/MUON/Workflow/README.md
+++ b/Detectors/MUON/Workflow/README.md
@@ -8,6 +8,7 @@
 
 * [Matching](#matching)
 * [Track writer](#track-writer)
+* [MID chamber efficiency](#mid-chamber-efficiency)
 
 <!-- vim-markdown-toc -->
 
@@ -28,6 +29,7 @@ Option `--disable-mc` disables the reading, processing and writing of the MC lab
 Option `--config "file.json"` or `--config "file.ini"` allows to change the matching parameters from a configuration file. This file can be either in JSON or in INI format, as described below:
 
 * Example of configuration file in JSON format:
+
 ```json
 {
     "MUONMatching": {
@@ -35,7 +37,9 @@ Option `--config "file.json"` or `--config "file.ini"` allows to change the matc
     }
 }
 ```
+
 * Example of configuration file in INI format:
+
 ```ini
 [MUONMatching]
 sigmaCut=4.
@@ -44,6 +48,7 @@ sigmaCut=4.
 Option `--configKeyValues "key1=value1;key2=value2;..."` allows to change the matching parameters from the command line. The parameters changed from the command line will supersede the ones changed from a configuration file.
 
 * Example of parameters changed from the command line:
+
 ```shell
 --configKeyValues "MUONMatching.sigmaCut=4."
 ```
@@ -55,3 +60,20 @@ o2-muon-tracks-writer-workflow --outfile "muontracks.root"
 ```
 
 Take as input the list of matched tracks ([TrackMCHMID](../../../DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackMCHMID.h)) in the current time frame, with the data description "GLO/MTC_MCHMID", and write them in a root file. It is implemented using the generic [MakeRootTreeWriterSpec](../../../Framework/Utils/include/DPLUtils/MakeRootTreeWriterSpec.h) and thus offers the same options.
+
+# MID chamber efficiency
+
+This workflow allows to compute the MID chamber efficiency.
+This is just an example since, eventually, the workflow should be rewritten in order to be able to run on AODs.
+
+Usage:
+
+```shell
+o2-ctf-reader-workflow --ctf-input o2_ctf_0000000000.root --onlyDet MID | o2-mid-reco-workflow --disable-mc | o2-mid-chamber-efficiency-workflow
+```
+
+The chamber efficiency can be estimated using only MID tracks that match MCH tracks:
+
+```shell
+o2-ctf-reader-workflow --ctf-input o2_ctf_0000000000.root --onlyDet MCH,MID | o2-mid-reco-workflow --disable-mc | o2-mch-reco-workflow --disable-mc --disable-root-input --configKeyValues "MCHDigitFilter.timeOffset=126" | o2-muon-tracks-matcher-workflow --disable-mc --disable-root-input | o2-mid-chamber-efficiency-workflow --select-matched
+```

--- a/Detectors/MUON/Workflow/src/ChamberEfficiencySpec.h
+++ b/Detectors/MUON/Workflow/src/ChamberEfficiencySpec.h
@@ -9,13 +9,13 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file   MIDWorkflow/EfficiencySpec.h
+/// \file   MUONWorkflow/ChamberEfficiencySpec.h
 /// \brief  Device that computes the MID chamber efficiency
 /// \author Livia Terlizzi <Livia.Terlizzi at cern.ch>
 /// \date   20 September 2022
 
-#ifndef O2_MID_EFFICIENCYSPEC_H
-#define O2_MID_EFFICIENCYSPEC_H
+#ifndef O2_MID_CHAMBEREFFICIENCYSPEC_H
+#define O2_MID_CHAMBEREFFICIENCYSPEC_H
 
 #include "Framework/DataProcessorSpec.h"
 
@@ -24,9 +24,9 @@ namespace o2
 namespace mid
 {
 
-framework::DataProcessorSpec getEfficiencySpec();
+framework::DataProcessorSpec getChamberEfficiencySpec(bool selectMatched);
 
 } // namespace mid
 } // namespace o2
 
-#endif // O2_MID_EfficiencySpec_H
+#endif // O2_MID_CHAMBEREFFICIENCYSPEC_H

--- a/Detectors/MUON/Workflow/src/chamber-efficiency-workflow.cxx
+++ b/Detectors/MUON/Workflow/src/chamber-efficiency-workflow.cxx
@@ -9,7 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file   MID/Workflow/src/efficiency-workflow.cxx
+/// \file   MUON/Workflow/src/efficiency-workflow.cxx
 /// \brief  Workflow to compute the MID chamber efficiency
 /// \author Livia Terlizzi <Livia.Terlizzi at cern.ch>
 /// \date   20 September 2022
@@ -20,8 +20,7 @@
 #include "Framework/ConfigContext.h"
 #include "Framework/WorkflowSpec.h"
 #include "CommonUtils/ConfigurableParam.h"
-#include "DetectorsRaw/HBFUtilsInitializer.h"
-#include "MIDWorkflow/EfficiencySpec.h"
+#include "ChamberEfficiencySpec.h"
 
 using namespace o2::framework;
 
@@ -31,6 +30,7 @@ void customize(std::vector<ConfigParamSpec>& workflowOptions)
   // option allowing to set parameters
   workflowOptions.emplace_back("configKeyValues", VariantType::String, "",
                                ConfigParamSpec::HelpString{"Semicolon separated key=value strings"});
+  workflowOptions.emplace_back("select-matched", VariantType::Bool, false, ConfigParamSpec::HelpString{"Select matched tracks"});
 }
 
 #include "Framework/runDataProcessing.h"
@@ -41,7 +41,9 @@ WorkflowSpec defineDataProcessing(const ConfigContext& configcontext)
 
   o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
 
-  effspecs.emplace_back(o2::mid::getEfficiencySpec());
+  bool selectMatched = configcontext.options().get<bool>("select-matched");
+
+  effspecs.emplace_back(o2::mid::getChamberEfficiencySpec(selectMatched));
 
   // write the configuration used for the workflow
   o2::conf::ConfigurableParam::writeINI("o2mideff-workflow_configuration.ini");


### PR DESCRIPTION
The workdflow was moved to Workflow/MUON since it also depends on the matching now.
Notice that one can run on all MID tracks as before if no option is provided