### PR TITLE
DPL: Fix backpressure for late timeslice stalls processing of oldestPossibleTimeslice of earlier timeslices, making full processing chain stuck

### DIFF
--- a/Framework/Core/src/DataProcessingDevice.cxx
+++ b/Framework/Core/src/DataProcessingDevice.cxx
@@ -1616,6 +1616,7 @@ void DataProcessingDevice::handleData(ServiceRegistryRef ref, InputChannelInfo& 
     // We relay execution to make sure we have a complete set of parts
     // available.
     bool hasBackpressure = false;
+    size_t minBackpressureTimeslice = -1;
     bool hasData = false;
     size_t oldestPossibleTimeslice = -1;
     static std::vector<int> ordering;
@@ -1676,6 +1677,7 @@ void DataProcessingDevice::handleData(ServiceRegistryRef ref, InputChannelInfo& 
               }
               policy.backpressure(info);
               hasBackpressure = true;
+              minBackpressureTimeslice = std::min<size_t>(minBackpressureTimeslice, relayed.timeslice.value);
               break;
             case DataRelayer::RelayChoice::Type::Dropped:
             case DataRelayer::RelayChoice::Type::Invalid:
@@ -1710,9 +1712,6 @@ void DataProcessingDevice::handleData(ServiceRegistryRef ref, InputChannelInfo& 
         case InputType::DomainInfo: {
           /// We have back pressure, therefore we do not process DomainInfo anymore.
           /// until the previous message are processed.
-          if (hasBackpressure) {
-            break;
-          }
           auto &context = ref.get<DataProcessorContext>();
           *context.wasActive = true;
           auto headerIndex = input.position;
@@ -1722,6 +1721,9 @@ void DataProcessingDevice::handleData(ServiceRegistryRef ref, InputChannelInfo& 
           //        split parts.
 
           auto dih = o2::header::get<DomainInfoHeader*>(parts.At(headerIndex)->GetData());
+          if (hasBackpressure && dih->oldestPossibleTimeslice >= minBackpressureTimeslice) {
+            break;
+          }
           oldestPossibleTimeslice = std::min(oldestPossibleTimeslice, dih->oldestPossibleTimeslice);
           LOGP(debug, "Got DomainInfoHeader, new oldestPossibleTimeslice {} on channel {}", oldestPossibleTimeslice, info.id.value);
           parts.At(headerIndex).reset(nullptr);


### PR DESCRIPTION
@ktf : This fixes the problem with the framework getting stuck.
The background is: If there is backpressure for later timeslices on a channel, it sets the `hasBackpressure` here, irrespective of the timeslice that created the backpressure: https://github.com/AliceO2Group/AliceO2/blob/60b5d6640f93d2a0f0b7c5729b6c41c8bf18b398/Framework/Core/src/DataProcessingDevice.cxx#L1678

This completely disables the handling of the domaininfoheader here: https://github.com/AliceO2Group/AliceO2/blob/60b5d6640f93d2a0f0b7c5729b6c41c8bf18b398/Framework/Core/src/DataProcessingDevice.cxx#L1713, leading to the stuck situation.

Although my PR seems to fully fix it, we should find a better solution, and not introduce the stupid global static variable, but I didn't manage to do so without digging a log in the code. I just opened this PR to illustrate what should be done.

I believe what we should do for a proper fix is:
- In addition to the `hasBackpressure` flag, we need a variable that stores the minimum timeslice that is backpressured.
- When setting hasBackpressure in line 1678, we should also update this variable.
- In the check in line 1713, we should check that variable, instead of my global variable.