### PR TITLE
DPL: Fixes for error handling in oldest possible timeslice sending

### DIFF
--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -513,7 +513,7 @@ o2::framework::ServiceSpec CommonServices::decongestionSpec()
       auto &queue = services.get<AsyncQueue>();
       auto& spec = services.get<DeviceSpec const>();
       auto *device = services.get<RawDeviceService>().device();
-      /// We use the oldest possible timeslice to debuounce, so that only the latest one
+      /// We use the oldest possible timeslice to debounce, so that only the latest one
       /// at the end of one iteration is sent.
       LOGP(debug, "Queueing oldest possible timeslice {} propagation for execution.", oldestPossibleOutput.timeslice.value);
       AsyncQueueHelpers::post(

--- a/Framework/Core/src/DataProcessingHelpers.cxx
+++ b/Framework/Core/src/DataProcessingHelpers.cxx
@@ -59,8 +59,9 @@ void DataProcessingHelpers::sendOldestPossibleTimeframe(fair::mq::Channel& chann
     LOGP(warning, "Timed out sending oldest possible timeslice after {}s. Downstream backpressure detected on {}.", timeout / 1000, channel.GetName());
     channel.Send(parts);
     LOGP(info, "Downstream backpressure on {} recovered.", channel.GetName());
-  } else if (res == (size_t)fair::mq::TransferCode::error) {
-    LOGP(fatal, "Error while sending on channel {}", channel.GetName());
+  }
+  if (res < (size_t)fair::mq::TransferCode::success) {
+    LOGP(fatal, "Error sending oldest possible timeframe {} on channel {} (code {})", timeslice, channel.GetName(), res);
   }
 }
 

--- a/Framework/Core/src/TimesliceIndex.cxx
+++ b/Framework/Core/src/TimesliceIndex.cxx
@@ -125,7 +125,9 @@ bool TimesliceIndex::didReceiveData() const
 TimesliceIndex::OldestInputInfo TimesliceIndex::setOldestPossibleInput(TimesliceId timestamp, ChannelIndex channel)
 {
   // Each channel oldest possible input must be monotoically increasing.
-  assert(mChannels[channel.value].oldestForChannel.value <= timestamp.value);
+  if (timestamp.value < mChannels[channel.value].oldestForChannel.value <= timestamp.value) {
+    LOG(error) << "Received bogus oldest possible timeslice " << timestamp.value << " for channel " << channel.value << " Excpected >= " << mChannels[channel.value].oldestForChannel.value;
+  }
   mChannels[channel.value].oldestForChannel = timestamp;
   OldestInputInfo result{timestamp, channel};
   bool changed = false;


### PR DESCRIPTION
Doesn't fix anything, since these situations do not occur, but I think it is still better to have it.