### PR TITLE
[MRRTF-216] new ChannelCode class

### DIFF
--- a/Detectors/MUON/MCH/GlobalMapping/CMakeLists.txt
+++ b/Detectors/MUON/MCH/GlobalMapping/CMakeLists.txt
@@ -10,16 +10,22 @@
 # or submit itself to any jurisdiction.
 
 o2_add_library(MCHGlobalMapping
-        SOURCES src/DsIndex.cxx
-                src/HV.cxx
-                src/LV.cxx
-                src/Mapper.cxx
-                src/Quadrant.cxx
-                src/Slat.cxx
+        SOURCES
+          src/ChannelCode.cxx
+          src/DsIndex.cxx
+          src/HV.cxx
+          src/LV.cxx
+          src/Mapper.cxx
+          src/Quadrant.cxx
+          src/Slat.cxx
         PUBLIC_LINK_LIBRARIES O2::MCHRawElecMap
                               O2::MCHMappingInterface
                               O2::MCHConditions
         PRIVATE_LINK_LIBRARIES O2::MCHConstants)
+
+o2_target_root_dictionary(MCHGlobalMapping
+                          HEADERS
+                            include/MCHGlobalMapping/ChannelCode.h)
 
 o2_add_executable(
         global-mapper
@@ -32,11 +38,20 @@ o2_add_executable(
                               RapidJSON::RapidJSON)
 
 if(BUILD_TESTING)
+
   o2_add_test(
     global-mapper
     SOURCES src/testGlobalMapper.cxx
     COMPONENT_NAME mch
     LABELS "muon;mch;dcs"
     PUBLIC_LINK_LIBRARIES O2::MCHGlobalMapping O2::MCHMappingImpl4)
+
+  o2_add_test(
+    channelcode
+    SOURCES src/testChannelCode.cxx
+    COMPONENT_NAME mch
+    LABELS muon;mch
+    PUBLIC_LINK_LIBRARIES O2::MCHGlobalMapping O2::MCHMappingImpl4)
+
 endif()
 

--- a/Detectors/MUON/MCH/GlobalMapping/include/MCHGlobalMapping/ChannelCode.h
+++ b/Detectors/MUON/MCH/GlobalMapping/include/MCHGlobalMapping/ChannelCode.h
@@ -1,0 +1,129 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_DATAFORMATS_MCH_CHANNEL_CODE_H_
+#define O2_DATAFORMATS_MCH_CHANNEL_CODE_H_
+
+#include <cstdint>
+#include <string>
+#include "Rtypes.h"
+
+namespace o2::mch
+{
+/** 64-bits identifier of a MCH channel.
+ *
+ * The ChannelCode class encodes in a 64 bits integer the following
+ * information about a MCH channel :
+ *
+ *  - detection element identifier (and index)
+ *  - pad index within the detection element
+ *  - dual sampa identifier (and index)
+ *  - solar identifier (and index)
+ *  - elink identifier (or index, those are the same)
+ *  - channel number
+ *
+ * This class serves the same purposes as @ref DsChannelId, but using
+ * two different "coordinate systems" to reference the elements
+ * within the spectrometer, while DsChannelId uses only one.
+ * @ref DsChannelId is readout/online oriented,
+ * while ChannelCode is both reconstruction/offline _and_
+ * readout/online oriented.
+ * But at a cost of twice the size.
+ *
+ * Note that while this class is internal storing _indices-,
+ * it also offer getters for _identifiers_ (Ids).
+ *
+ */
+class ChannelCode
+{
+ public:
+  ChannelCode() = default;
+  /** Ctor using "detector oriented" numbering.
+   *
+   * @param deId detection element identifier (e.g. 100, 502, 1025)
+   * @param dePadIndex pad index within the detection element [0..(npads in DE)-1]
+   *
+   * @throw runtime_error if (deId,dePadIndex) is not a valid combination
+   */
+  ChannelCode(uint16_t deId, uint16_t dePadIndex);
+  /** Ctor using "electronics oriented" numbering.
+   *
+   * @param solarId solar identifier
+   * @param elinkIndex elink index 0..39
+   * @param channel channel number 0..63
+   *
+   * @throw runtime_error if (solarId,elinkIndex,channel) is not a valid combination
+   *
+   * Note that elinkIndex is also called elinkId equivalently
+   * in some other parts of the code, as for elink the id is the index.
+   */
+  ChannelCode(uint16_t solarId, uint8_t elinkIndex, uint8_t channel);
+
+  /** return the detection element _identifier_ */
+  uint16_t getDeId() const;
+  /** return the pad _index_ within the detection element.
+   * It's in the range 0..(npads in DE)-1) */
+  uint16_t getDePadIndex() const;
+  /** return the dual sampa _identifier_ */
+  uint16_t getDsId() const;
+  /** return the dual sampa _index_ (0..16819) */
+  uint16_t getDsIndex() const;
+  /** return the solar _identifier_ */
+  uint16_t getSolarId() const;
+  /** return the solar _index_ (0..623) */
+  uint16_t getSolarIndex() const;
+  /** return the dual sampa channel (0..63) */
+  uint8_t getChannel() const;
+  /** return the detection element _index_ (0..155) */
+  uint8_t getDeIndex() const;
+  /** return the elink identifier = index (0..39) */
+  uint8_t getElinkId() const;
+  /** return the elink index = identifier (0..39) */
+  uint8_t getElinkIndex() const { return getElinkId(); }
+
+  /* get the actual code */
+  uint64_t value() const { return mValue; }
+
+ private:
+  void set(uint8_t deIndex,
+           uint16_t dePadIndex,
+           uint16_t dsIndex,
+           uint16_t solarIndex,
+           uint8_t elinkIndex,
+           uint8_t channel);
+
+ private:
+  /** mValue content :
+   *
+   * - deIndex (0..155) -----------  8 bits
+   * - dePadIndex (0..28671) ------ 15 bits
+   * - DsIndex (0..16819) --------- 15 bits
+   * - solarIndex (0..623) -------- 10 bits
+   * - elinkIndex (0..39) ---------  6 bits
+   * - channel number (0..63) -----  6 bits
+   */
+  uint64_t mValue{0};
+
+  ClassDefNV(ChannelCode, 1); // An identifier for a MCH channel
+};
+
+/** return a string representation */
+inline std::string asString(const ChannelCode& cc);
+
+inline bool operator==(const ChannelCode& a, const ChannelCode& b) { return a.value() == b.value(); }
+inline bool operator!=(const ChannelCode& a, const ChannelCode& b) { return a.value() != b.value(); }
+inline bool operator<(const ChannelCode& a, const ChannelCode& b) { return a.value() < b.value(); }
+inline bool operator>(const ChannelCode& a, const ChannelCode& b) { return a.value() > b.value(); }
+inline bool operator<=(const ChannelCode& a, const ChannelCode& b) { return a.value() <= b.value(); }
+inline bool operator>=(const ChannelCode& a, const ChannelCode& b) { return a.value() >= b.value(); }
+
+} // namespace o2::mch
+#endif

--- a/Detectors/MUON/MCH/GlobalMapping/include/MCHGlobalMapping/DsIndex.h
+++ b/Detectors/MUON/MCH/GlobalMapping/include/MCHGlobalMapping/DsIndex.h
@@ -30,7 +30,7 @@ constexpr uint16_t NumberOfDualSampas = 16820;
 /** getDsIndex returns the unique index of one dual sampa. */
 DsIndex getDsIndex(const o2::mch::raw::DsDetId& dsDetId);
 
-/** decodeDsIndex converts a unique dual sampa index into a pair (deId,dsId). */
+/** getDsDetId converts a unique dual sampa index into a pair (deId,dsId). */
 o2::mch::raw::DsDetId getDsDetId(DsIndex dsIndex);
 
 /** get the number of channels for a given dual sampa (will be 64 in most of the cases. */

--- a/Detectors/MUON/MCH/GlobalMapping/src/ChannelCode.cxx
+++ b/Detectors/MUON/MCH/GlobalMapping/src/ChannelCode.cxx
@@ -1,0 +1,171 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "MCHGlobalMapping/ChannelCode.h"
+
+#include "MCHConstants/DetectionElements.h"
+#include "MCHGlobalMapping/DsIndex.h"
+#include "MCHMappingInterface/Segmentation.h"
+#include "MCHRawElecMap/Mapper.h"
+#include <fmt/format.h>
+
+namespace o2::mch
+{
+ChannelCode::ChannelCode(uint16_t deId, uint16_t dePadIndex)
+{
+  auto deIndexOpt = constants::deId2DeIndex(deId);
+  if (deIndexOpt == std::nullopt) {
+    throw std::runtime_error(fmt::format("invalid deId {}", deId));
+  }
+  auto deIndex = deIndexOpt.value();
+  const auto& seg = o2::mch::mapping::segmentation(deId);
+  if (!seg.isValid(dePadIndex)) {
+    throw std::runtime_error(fmt::format("invalid dePadIndex {} for deId {}",
+                                         dePadIndex, deId));
+  }
+  auto dsId = seg.padDualSampaId(dePadIndex);
+  o2::mch::raw::DsDetId dsDetId(deId, dsId);
+  auto dsIndex = o2::mch::getDsIndex(dsDetId);
+  uint8_t channel = seg.padDualSampaChannel(dePadIndex);
+
+  static auto det2elec = raw::createDet2ElecMapper<raw::ElectronicMapperGenerated>();
+
+  auto elec = det2elec(dsDetId);
+  if (elec == std::nullopt) {
+    throw std::runtime_error(fmt::format("could not get solar,elink for {}",
+                                         raw::asString(dsDetId)));
+  }
+  uint16_t solarId = elec->solarId();
+  auto solarIndex = raw::solarId2Index<raw::ElectronicMapperGenerated>(solarId);
+  if (solarIndex == std::nullopt) {
+    throw std::runtime_error(fmt::format("could not get index from solarId {}",
+                                         solarId));
+  }
+  uint8_t elinkIndex = elec->elinkId();
+  set(deIndex, dePadIndex, dsIndex, solarIndex.value(), elinkIndex, channel);
+}
+
+ChannelCode::ChannelCode(uint16_t solarId, uint8_t elinkId, uint8_t channel)
+{
+  auto solarIndexOpt = raw::solarId2Index<raw::ElectronicMapperGenerated>(solarId);
+  if (solarIndexOpt == std::nullopt) {
+    throw std::runtime_error(fmt::format("invalid solarId {}", solarId));
+  }
+  static auto elec2det = raw::createElec2DetMapper<raw::ElectronicMapperGenerated>();
+  auto group = raw::groupFromElinkId(elinkId);
+  auto index = raw::indexFromElinkId(elinkId);
+  raw::DsElecId dsElecId{solarId, group.value(), index.value()};
+  auto dsDetIdOpt = elec2det(dsElecId);
+  if (dsDetIdOpt == std::nullopt) {
+    throw std::runtime_error(fmt::format("invalid solarid {} elinkid {}",
+                                         solarId, elinkId));
+  }
+  auto deId = dsDetIdOpt->deId();
+  auto deIndexOpt = constants::deId2DeIndex(deId);
+  if (deIndexOpt == std::nullopt) {
+    throw std::runtime_error(fmt::format("invalid deId {}", deId));
+  }
+  const auto& seg = o2::mch::mapping::segmentation(deId);
+  auto dsId = dsDetIdOpt->dsId();
+  int dePadIndex = seg.findPadByFEE(dsId, channel);
+  if (!seg.isValid(dePadIndex)) {
+    throw std::runtime_error(fmt::format("invalid dePadIndex {} for deId {}",
+                                         dePadIndex, deId));
+  }
+  auto dsIndex = o2::mch::getDsIndex(dsDetIdOpt.value());
+  auto solarIndex = solarIndexOpt.value();
+  set(deIndexOpt.value(), dePadIndex, dsIndex, solarIndex, elinkId, channel);
+}
+
+/** build a 64 bits integer from the various indices.
+ *
+ * - deIndex (0..155) -----------  8 bits -- left shift 52
+ * - dePadIndex (0..28671) ------ 15 bits --            37
+ * - DsIndex (0..16819) --------- 15 bits --            22
+ * - solarIndex (0..623) -------- 10 bits --            12
+ * - elinkId (0..39) ------------  6 bits --             6
+ * - channel number (0..63) -----  6 bits --             0
+ */
+void ChannelCode::set(uint8_t deIndex,
+                      uint16_t dePadIndex,
+                      uint16_t dsIndex,
+                      uint16_t solarIndex,
+                      uint8_t elinkIndex,
+                      uint8_t channel)
+{
+  mValue = (static_cast<uint64_t>(deIndex & 0xFF) << 52) +
+           (static_cast<uint64_t>(dePadIndex & 0x7FFF) << 37) +
+           (static_cast<uint64_t>(dsIndex & 0x7FFF) << 22) +
+           (static_cast<uint64_t>(solarIndex & 0x3FF) << 12) +
+           (static_cast<uint64_t>(elinkIndex & 0x3F) << 6) +
+           (static_cast<uint64_t>(channel & 0x3F));
+}
+
+uint8_t ChannelCode::getDeIndex() const
+{
+  return static_cast<uint8_t>((mValue >> 52) & 0xFF);
+}
+
+uint16_t ChannelCode::getDePadIndex() const
+{
+  return static_cast<uint16_t>((mValue >> 37) & 0x7FFF);
+}
+
+uint16_t ChannelCode::getDsIndex() const
+{
+  return static_cast<uint16_t>((mValue >> 22) & 0x7FFF);
+}
+
+uint16_t ChannelCode::getSolarIndex() const
+{
+  return static_cast<uint16_t>((mValue >> 12) & 0x3FF);
+}
+
+uint8_t ChannelCode::getElinkId() const
+{
+  return static_cast<uint8_t>((mValue >> 6) & 0x3F);
+}
+
+uint8_t ChannelCode::getChannel() const
+{
+  return static_cast<uint8_t>(mValue & 0x3F);
+}
+
+uint16_t ChannelCode::getDeId() const
+{
+  auto deIndex = getDeIndex();
+  return o2::mch::constants::deIdsForAllMCH[deIndex];
+}
+
+uint16_t ChannelCode::getDsId() const
+{
+  auto dsIndex = getDsIndex();
+  o2::mch::raw::DsDetId dsDetId = getDsDetId(dsIndex);
+  return dsDetId.dsId();
+}
+
+uint16_t ChannelCode::getSolarId() const
+{
+  auto solarIndex = getSolarIndex();
+  return raw::solarIndex2Id<raw::ElectronicMapperGenerated>(solarIndex).value();
+}
+
+std::string asString(const ChannelCode& cc)
+{
+  return fmt::format("deid {:4d} dsid {:4d} ch {:2d} depadindex {:5d} solarid {:4d} elink {:2d}",
+                     cc.getDeId(),
+                     cc.getDsId(),
+                     cc.getChannel(),
+                     cc.getDePadIndex(),
+                     cc.getSolarId(),
+                     cc.getElinkId());
+}
+} // namespace o2::mch

--- a/Detectors/MUON/MCH/GlobalMapping/src/MCHGlobalMappingLinkDef.h
+++ b/Detectors/MUON/MCH/GlobalMapping/src/MCHGlobalMappingLinkDef.h
@@ -1,0 +1,21 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifdef __CLING__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class o2::mch::ChannelCode + ;
+#pragma link C++ class std::vector < o2::mch::ChannelCode> + ;
+
+#endif

--- a/Detectors/MUON/MCH/GlobalMapping/src/testChannelCode.cxx
+++ b/Detectors/MUON/MCH/GlobalMapping/src/testChannelCode.cxx
@@ -1,0 +1,75 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <boost/test/tools/old/interface.hpp>
+#include <type_traits>
+#define BOOST_TEST_MODULE MCH ChannelCode
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#include <boost/test/data/test_case.hpp>
+#include <boost/test/data/monomorphic.hpp>
+
+#include "MCHGlobalMapping/ChannelCode.h"
+
+BOOST_AUTO_TEST_CASE(CtorShowThrowForInvalidDeId)
+{
+  BOOST_CHECK_THROW(o2::mch::ChannelCode(42, 0), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(CtorShowThrowForInvalidDePadIndex)
+{
+  BOOST_CHECK_THROW(o2::mch::ChannelCode(1002, 7616), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(CtorShowThrowForInvalidSolarId)
+{
+  BOOST_CHECK_THROW(o2::mch::ChannelCode(0, 0, 0), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(Ctor1)
+{
+  // same pad expressed two different ways
+  std::array<o2::mch::ChannelCode, 2> ids = {
+    o2::mch::ChannelCode(1002, 7615),
+    o2::mch::ChannelCode(557, 7, 60)};
+
+  for (const auto& id : ids) {
+    BOOST_CHECK_EQUAL(id.getDeId(), 1002);
+    BOOST_CHECK_EQUAL(id.getDsId(), 1361);
+    BOOST_CHECK_EQUAL(id.getChannel(), 60);
+    BOOST_CHECK_EQUAL(id.getSolarId(), 557);
+    BOOST_CHECK_EQUAL(id.getElinkId(), 7);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(Ctor2)
+{
+  // same pad expressed two different ways
+  std::array<o2::mch::ChannelCode, 2> ids = {
+    o2::mch::ChannelCode(100, 28626),
+    o2::mch::ChannelCode(325, 39, 63)};
+
+  for (const auto& id : ids) {
+    BOOST_CHECK_EQUAL(id.getDeId(), 100);
+    BOOST_CHECK_EQUAL(id.getDsId(), 1267);
+    BOOST_CHECK_EQUAL(id.getChannel(), 63);
+    BOOST_CHECK_EQUAL(id.getSolarId(), 325);
+    BOOST_CHECK_EQUAL(id.getElinkId(), 39);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(ChannelCodeCanBeUsedAsMapKey)
+{
+  std::map<o2::mch::ChannelCode, int> maptest;
+  o2::mch::ChannelCode cc(1002, 7615);
+  maptest[cc] = 42;
+  BOOST_CHECK_EQUAL(maptest[cc], 42);
+}


### PR DESCRIPTION
The ChannelCode class encodes in a 64 bits integer the following information about a MCH channel :

- detection element identifier (and index)
- pad index within the detection element
- dual sampa identifier (and index)
- solar identifier (and index)
- elink identifier (or index, those are the same)
- channel number

This class serves the same purposes as DsChannelId, but using two different "coordinate systems" to reference the elements within the spectrometer, while DsChannelId uses only one.  DsChannelId is readout/online oriented, while ChannelCode is both reconstruction/offline _and_ readout/online oriented. But at a cost of wice the size.