### PR TITLE
DPL: adapt to new version of c++filt

### DIFF
--- a/Framework/Foundation/src/RuntimeError.cxx
+++ b/Framework/Foundation/src/RuntimeError.cxx
@@ -154,7 +154,18 @@ void demangled_backtrace_symbols(void** stackTrace, unsigned int stackDepth, int
       if (stackTrace[i] && hasExe) {
         char syscom[4096 + PATH_MAX];
 
-        snprintf(syscom, 4096, "addr2line %p -p -s -f -e %.*s 2>/dev/null | c++filt -r ", stackTrace[i], exeSize, exe); // last parameter is the name of this app
+        // Find c++filt from the environment
+        // This is needed for platforms where we still need c++filt -r
+        char const* cxxfilt = getenv("CXXFILT");
+        if (cxxfilt == nullptr) {
+          cxxfilt = "c++filt";
+        }
+        // Do the same for addr2line, just in case we wanted to pass some options
+        char const* addr2line = getenv("ADDR2LINE");
+        if (addr2line == nullptr) {
+          addr2line = "addr2line";
+        }
+        snprintf(syscom, 4096, "%s %p -p -s -f -e %.*s 2>/dev/null | %s ", addr2line, stackTrace[i], exeSize, exe, cxxfilt); // last parameter is the name of this app
 
         FILE* fp;
         char path[1024];


### PR DESCRIPTION
Apparently no supported distribution (apart from ubuntu) ships with a c++filt which needs -r.