### PR TITLE
TRD pileup simulation fix

### DIFF
--- a/Detectors/TRD/simulation/src/PileupTool.cxx
+++ b/Detectors/TRD/simulation/src/PileupTool.cxx
@@ -31,7 +31,7 @@ SignalContainer PileupTool::addSignals(std::deque<std::array<SignalContainer, co
         if (signalArray.firstTBtime < triggerTime) {
           pileupSignalBecomesObsolete = true;
           if ((triggerTime - signalArray.firstTBtime) > TRDSimParams::Instance().readoutTimeNS) { // OS: READOUT_TIME should actually be drift time (we want to ignore signals which don't contribute signal anymore at triggerTime)
-            continue;                                                              // ignore the signal if it  is too old.
+            continue;                                                                             // ignore the signal if it  is too old.
           }
           // add only what's leftover from this signal
           // 0.01 = samplingRate/1000, 1/1000 to go from ns to micro-s, the sampling rate is in 1/micro-s

--- a/Detectors/TRD/simulation/src/PileupTool.cxx
+++ b/Detectors/TRD/simulation/src/PileupTool.cxx
@@ -26,6 +26,7 @@ SignalContainer PileupTool::addSignals(std::deque<std::array<SignalContainer, co
       for (const auto& signal : signalMap) {   // loop over active pads only, if there is any
         const int& key = signal.first;
         const SignalArray& signalArray = signal.second;
+        bool signalContributed = false;
         // check if the signal is from a previous event
         if (signalArray.firstTBtime < triggerTime) {
           pileupSignalBecomesObsolete = true;
@@ -41,6 +42,7 @@ SignalContainer PileupTool::addSignals(std::deque<std::array<SignalContainer, co
             *it1 += *it0;
             it0++;
             it1++;
+            signalContributed = true;
           }
         } else {
           // the signal is from a subsequent event
@@ -51,12 +53,14 @@ SignalContainer PileupTool::addSignals(std::deque<std::array<SignalContainer, co
             *it1 += *it0;
             it0++;
             it1++;
+            signalContributed = true;
           }
         }
         // keep the labels
-        for (const auto& label : signalArray.labels) {
-          // do we want to keep all labels? what about e.g. a TR signal which does not contribute to the pileup of a previous event since the signal arrives too late, but then we will have its label?
-          (addedSignalsMap[key].labels).push_back(label); // maybe check if the label already exists? is that even possible?
+        if (signalContributed) {
+          for (const auto& label : signalArray.labels) {
+            (addedSignalsMap[key].labels).push_back(label);
+          }
         }
       } // loop over active pads in detector
     }   // loop over detectors

--- a/Detectors/TRD/workflow/src/TRDDigitizerSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDDigitizerSpec.cxx
@@ -139,7 +139,7 @@ class TRDDPLDigitizerTask : public o2::base::BaseDPLDigitizer
         }
       }
 
-      mDigitizer.setEventTime(triggerTime.getTimeNS());
+      mDigitizer.setEventTime(currentTime.getTimeNS());
       if (isNewTrigger) {
         mDigitizer.setTriggerTime(triggerTime.getTimeNS());
         currTrig = collID;

--- a/Detectors/TRD/workflow/src/TRDDigitizerSpec.cxx
+++ b/Detectors/TRD/workflow/src/TRDDigitizerSpec.cxx
@@ -83,14 +83,14 @@ class TRDDPLDigitizerTask : public o2::base::BaseDPLDigitizer
     o2::dataformats::MCTruthContainer<o2::MCCompLabel> labelsAccum;
     std::vector<TriggerRecord> triggers;
 
-    std::vector<o2::trd::Digit> digits;                         // digits which get filled
-    o2::dataformats::MCTruthContainer<o2::MCCompLabel> labels;  // labels which get filled
+    std::vector<o2::trd::Digit> digits;                        // digits which get filled
+    o2::dataformats::MCTruthContainer<o2::MCCompLabel> labels; // labels which get filled
 
-    o2::InteractionTimeRecord currentTime; // the current time
+    o2::InteractionTimeRecord currentTime;  // the current time
     o2::InteractionTimeRecord previousTime; // the time of the previous collision
-    o2::InteractionTimeRecord triggerTime; // the time at which the TRD start reading out a signal
-    size_t currTrig = 0;                   // from which collision is the current TRD trigger (only needed for debug information)
-    bool firstEvent = true;                // Flag for the first event processed
+    o2::InteractionTimeRecord triggerTime;  // the time at which the TRD start reading out a signal
+    size_t currTrig = 0;                    // from which collision is the current TRD trigger (only needed for debug information)
+    bool firstEvent = true;                 // Flag for the first event processed
 
     TStopwatch timer;
     timer.Start();


### PR DESCRIPTION
- for each collision the TRD trigger time instead of the actual collision time was set
- for pileup collisions which occured within the dead time of the TRD the labels of each signal were added to the digits even if there was no actual signal contribution

When @shahor02 is back from vacation I will check with his macros if this observes all the issues he had seen. The checks I was doing are all passing fine now.