### PR TITLE
[FOCAL-10] Add PAD trigger information in reconstruction

### DIFF
--- a/DataFormats/Detectors/FOCAL/include/DataFormatsFOCAL/Constants.h
+++ b/DataFormats/Detectors/FOCAL/include/DataFormatsFOCAL/Constants.h
@@ -17,6 +17,7 @@ constexpr int PADLAYER_MODULE_NCHANNELS = 72;
 constexpr int PADLAYER_MODULE_NHALVES = 2;
 constexpr int PADS_NLAYERS = 20;
 constexpr int PIXELS_NLAYERS = 2;
+constexpr int PADLAYER_WINDOW_LENGTH = 20;
 
 } // namespace o2::focal::constants
 

--- a/DataFormats/Detectors/FOCAL/include/DataFormatsFOCAL/ErrorHandling.h
+++ b/DataFormats/Detectors/FOCAL/include/DataFormatsFOCAL/ErrorHandling.h
@@ -23,7 +23,8 @@ class IndexExceptionEvent : public std::exception
     PAD_LAYER,
     PAD_NHALVES,
     PAD_CHANNEL,
-    PIXEL_LAYER
+    PIXEL_LAYER,
+    TRIGGER_WINDOW
   };
   IndexExceptionEvent(unsigned int index, unsigned int maxindex, IndexType_t source);
   ~IndexExceptionEvent() noexcept final = default;

--- a/DataFormats/Detectors/FOCAL/include/DataFormatsFOCAL/Event.h
+++ b/DataFormats/Detectors/FOCAL/include/DataFormatsFOCAL/Event.h
@@ -38,16 +38,23 @@ class PadLayerEvent
     uint16_t mTOA;
     uint16_t mTOT;
   };
+  struct TriggerWindow {
+    uint32_t mHeader0;
+    uint32_t mHeader1;
+    std::array<uint8_t, 8> mTriggers;
+  };
 
   void setHeader(unsigned int half, uint8_t header, uint8_t bc, uint8_t wadd, uint8_t fourbits, uint8_t trialer);
   void setChannel(unsigned int channel, uint16_t adc, uint16_t toa, uint16_t tot);
   void setCMN(unsigned int half, uint16_t adc, uint16_t toa, uint16_t tot);
   void setCalib(unsigned int half, uint16_t adc, uint16_t toa, uint16_t tot);
+  void setTrigger(unsigned int window, uint32_t header0, uint32_t header1, const gsl::span<uint8_t> triggers);
 
   const Header& getHeader(unsigned int half) const;
   const Channel& getChannel(unsigned int channel) const;
   const Channel& getCMN(unsigned int half) const;
   const Channel& getCalib(unsigned int half) const;
+  const TriggerWindow& getTrigger(unsigned int window) const;
 
   std::array<uint16_t, constants::PADLAYER_MODULE_NCHANNELS> getADCs() const;
   std::array<uint16_t, constants::PADLAYER_MODULE_NCHANNELS> getTOAs() const;
@@ -63,6 +70,7 @@ class PadLayerEvent
   std::array<Channel, constants::PADLAYER_MODULE_NCHANNELS> mChannels;
   std::array<Channel, constants::PADLAYER_MODULE_NHALVES> mCMN;
   std::array<Channel, constants::PADLAYER_MODULE_NHALVES> mCalib;
+  std::array<TriggerWindow, constants::PADLAYER_WINDOW_LENGTH> mTriggers;
   ClassDefNV(PadLayerEvent, 1);
 };
 

--- a/DataFormats/Detectors/FOCAL/src/ErrorHandling.cxx
+++ b/DataFormats/Detectors/FOCAL/src/ErrorHandling.cxx
@@ -16,6 +16,26 @@ using namespace o2::focal;
 
 IndexExceptionEvent::IndexExceptionEvent(unsigned int index, unsigned int maxindex, IndexType_t source)
 {
+  std::string nameIndexType;
+  switch (source) {
+    case IndexType_t::PAD_CHANNEL:
+      nameIndexType = "channel";
+      break;
+    case IndexType_t::PAD_LAYER:
+      nameIndexType = "pad layer";
+      break;
+    case IndexType_t::PAD_NHALVES:
+      nameIndexType = "pad half stave";
+      break;
+    case IndexType_t::PIXEL_LAYER:
+      nameIndexType = "pixel layer";
+      break;
+    case IndexType_t::TRIGGER_WINDOW:
+      nameIndexType = "trigger window";
+    default:
+      break;
+  }
+  mMessageBuffer = "Accessing invalid entry of type " + nameIndexType + ": " + std::to_string(index) + " ( max " + std::to_string(maxindex) + ")";
 }
 
 const char* IndexExceptionEvent::what() const noexcept

--- a/DataFormats/Detectors/FOCAL/src/Event.cxx
+++ b/DataFormats/Detectors/FOCAL/src/Event.cxx
@@ -148,6 +148,17 @@ void PadLayerEvent::setCalib(unsigned int channel, uint16_t adc, uint16_t toa, u
   calib.mTOT = tot;
 }
 
+void PadLayerEvent::setTrigger(unsigned int window, uint32_t header0, uint32_t header1, const gsl::span<uint8_t> triggers)
+{
+  if (window >= constants::PADLAYER_WINDOW_LENGTH) {
+    throw IndexExceptionEvent(window, constants::PADLAYER_WINDOW_LENGTH, IndexExceptionEvent::IndexType_t::TRIGGER_WINDOW);
+  }
+  auto& currenttrigger = mTriggers[window];
+  currenttrigger.mHeader0 = header0;
+  currenttrigger.mHeader1 = header1;
+  std::copy(triggers.begin(), triggers.end(), currenttrigger.mTriggers.begin());
+}
+
 const PadLayerEvent::Header& PadLayerEvent::getHeader(unsigned int half) const
 {
   check_halfs(half);
@@ -168,6 +179,14 @@ const PadLayerEvent::Channel& PadLayerEvent::getCalib(unsigned int half) const
 {
   check_halfs(half);
   return mCalib[half];
+}
+
+const PadLayerEvent::TriggerWindow& PadLayerEvent::getTrigger(unsigned int window) const
+{
+  if (window >= constants::PADLAYER_WINDOW_LENGTH) {
+    throw IndexExceptionEvent(window, constants::PADLAYER_WINDOW_LENGTH, IndexExceptionEvent::IndexType_t::TRIGGER_WINDOW);
+  }
+  return mTriggers[window];
 }
 
 std::array<uint16_t, constants::PADLAYER_MODULE_NCHANNELS> PadLayerEvent::getADCs() const
@@ -218,6 +237,11 @@ void PadLayerEvent::reset()
     cmn.mADC = 0;
     cmn.mTOA = 0;
     cmn.mTOT = 0;
+  }
+  for (auto& trg : mTriggers) {
+    trg.mHeader0 = 0;
+    trg.mHeader1 = 0;
+    std::fill(trg.mTriggers.begin(), trg.mTriggers.end(), 0);
   }
 }
 

--- a/Detectors/FOCAL/reconstruction/include/FOCALReconstruction/PadWord.h
+++ b/Detectors/FOCAL/reconstruction/include/FOCALReconstruction/PadWord.h
@@ -40,7 +40,8 @@ struct PadASICWord {
 struct TriggerWord {
   union {
     struct {
-      uint64_t mHeader : 8;
+      uint64_t mHeader0 : 4;
+      uint64_t mHeader1 : 4;
       uint64_t mTrigger0 : 7;
       uint64_t mTrigger1 : 7;
       uint64_t mTrigger2 : 7;

--- a/Detectors/FOCAL/reconstruction/include/FOCALReconstruction/PadWord.h
+++ b/Detectors/FOCAL/reconstruction/include/FOCALReconstruction/PadWord.h
@@ -40,16 +40,16 @@ struct PadASICWord {
 struct TriggerWord {
   union {
     struct {
-      uint64_t mHeader0 : 4;
-      uint64_t mHeader1 : 4;
-      uint64_t mTrigger0 : 7;
-      uint64_t mTrigger1 : 7;
-      uint64_t mTrigger2 : 7;
-      uint64_t mTrigger3 : 7;
-      uint64_t mTrigger4 : 7;
-      uint64_t mTrigger5 : 7;
-      uint64_t mTrigger6 : 7;
       uint64_t mTrigger7 : 7;
+      uint64_t mTrigger6 : 7;
+      uint64_t mTrigger5 : 7;
+      uint64_t mTrigger4 : 7;
+      uint64_t mTrigger3 : 7;
+      uint64_t mTrigger2 : 7;
+      uint64_t mTrigger1 : 7;
+      uint64_t mTrigger0 : 7;
+      uint64_t mHeader1 : 4;
+      uint64_t mHeader0 : 4;
     };
     uint64_t mData = 0;
   };
@@ -106,6 +106,7 @@ struct PadGBTWord {
   };
 
   const TriggerWord& getTriggerData() const { return reinterpret_cast<const TriggerWord&>(mTriggerWords[0]); }
+  const TriggerWord& getTriggerPadding() const { return reinterpret_cast<const TriggerWord&>(mTriggerWords[1]); }
 
   template <typename T>
   gsl::span<const T> getASICData() const

--- a/Detectors/FOCAL/reconstruction/run/rawReaderPadRootify.cxx
+++ b/Detectors/FOCAL/reconstruction/run/rawReaderPadRootify.cxx
@@ -233,6 +233,7 @@ int main(int argc, char** argv)
 
   std::vector<std::string> inputfiles;
   if (rawfilename.find(",") != std::string::npos) {
+    // Multiple input file mode
     std::stringstream parser(rawfilename);
     std::string buffer;
     while (std::getline(parser, buffer, ',')) {
@@ -240,6 +241,10 @@ int main(int argc, char** argv)
       inputfiles.push_back(buffer);
     }
     LOG(info) << "Found " << inputfiles.size() << " input files to process";
+  } else {
+    // Processing just a single input file
+    LOG(info) << "Adding " << rawfilename;
+    inputfiles.push_back(rawfilename);
   }
 
   o2::raw::RawFileReader::ReadoutCardType readout = o2::raw::RawFileReader::RORC;
@@ -259,6 +264,7 @@ int main(int argc, char** argv)
   reader.setDefaultDataDescription(o2::header::gDataDescriptionRawData);
   reader.setDefaultReadoutCardType(readout);
   for (auto rawfile : inputfiles) {
+    LOG(debug) << "Adding " << rawfile << " to raw reader";
     reader.addFile(rawfile);
   }
   reader.init();

--- a/Detectors/FOCAL/reconstruction/run/rawReaderPadRootify.cxx
+++ b/Detectors/FOCAL/reconstruction/run/rawReaderPadRootify.cxx
@@ -143,8 +143,8 @@ struct PadTreeData {
       }
       auto triggerdata = asicdata.getTriggerWords();
       for (auto iwin = 0; iwin < WINDUR; iwin++) {
-        mTriggerhead0[iasic][iwin] = triggerdata[iwin].mHeader;
-        mTriggerhead1[iasic][iwin] = triggerdata[iwin].mHeader;
+        mTriggerhead0[iasic][iwin] = triggerdata[iwin].mHeader0;
+        mTriggerhead1[iasic][iwin] = triggerdata[iwin].mHeader1;
         mTriggerdata[iasic][0][iwin] = triggerdata[iwin].mTrigger0;
         mTriggerdata[iasic][1][iwin] = triggerdata[iwin].mTrigger1;
         mTriggerdata[iasic][2][iwin] = triggerdata[iwin].mTrigger2;

--- a/Detectors/FOCAL/reconstruction/src/PadDecoder.cxx
+++ b/Detectors/FOCAL/reconstruction/src/PadDecoder.cxx
@@ -34,7 +34,7 @@ void PadDecoder::decodeEvent(gsl::span<const PadGBTWord> gbtdata)
   // Other words: Trigger data
   std::size_t asicsize = 39 * PadData::NASICS;
   auto asicwords = gbtdata.subspan(0, asicsize);
-  auto triggerwords = gbtdata.subspan(39, gbtdata.size() - asicsize);
+  auto triggerwords = gbtdata.subspan(asicsize, gbtdata.size() - asicsize);
   for (int iasic = 0; iasic < PadData::NASICS; iasic++) {
     // First part: ASIC words
     auto& asicdata = mData[iasic].getASIC();

--- a/Detectors/FOCAL/reconstruction/src/PadWord.cxx
+++ b/Detectors/FOCAL/reconstruction/src/PadWord.cxx
@@ -27,6 +27,6 @@ std::ostream& o2::focal::operator<<(std::ostream& stream, const ASICHeader& head
 
 std::ostream& o2::focal::operator<<(std::ostream& stream, const TriggerWord& trigger)
 {
-  stream << "(HEADER) 0x" << std::hex << trigger.mHeader << std::dec << ": " << trigger.mTrigger0 << ", " << trigger.mTrigger1 << ", " << trigger.mTrigger2 << ", " << trigger.mTrigger3 << ", " << trigger.mTrigger4 << ", " << trigger.mTrigger5 << ", " << trigger.mTrigger6 << ", " << trigger.mTrigger7;
+  stream << "(HEADER0) 0x" << std::hex << trigger.mHeader0 << ", (HEADER1) 0x" << trigger.mHeader1 << std::dec << ": " << trigger.mTrigger0 << ", " << trigger.mTrigger1 << ", " << trigger.mTrigger2 << ", " << trigger.mTrigger3 << ", " << trigger.mTrigger4 << ", " << trigger.mTrigger5 << ", " << trigger.mTrigger6 << ", " << trigger.mTrigger7;
   return stream;
 }

--- a/Detectors/FOCAL/workflow/src/RawDecoderSpec.cxx
+++ b/Detectors/FOCAL/workflow/src/RawDecoderSpec.cxx
@@ -355,6 +355,7 @@ int RawDecoderSpec::decodePixelData(const gsl::span<const char> pixelWords, o2::
 std::array<o2::focal::PadLayerEvent, o2::focal::constants::PADS_NLAYERS> RawDecoderSpec::createPadLayerEvent(const o2::focal::PadData& data) const
 {
   std::array<PadLayerEvent, constants::PADS_NLAYERS> result;
+  std::array<uint8_t, 8> triggertimes;
   for (std::size_t ilayer = 0; ilayer < constants::PADS_NLAYERS; ilayer++) {
     auto& asic = data.getDataForASIC(ilayer).getASIC();
     int bc[2];
@@ -370,6 +371,19 @@ std::array<o2::focal::PadLayerEvent, o2::focal::constants::PADS_NLAYERS> RawDeco
     for (std::size_t ichannel = 0; ichannel < constants::PADLAYER_MODULE_NCHANNELS; ichannel++) {
       auto channel = asic.getChannel(ichannel);
       result[ilayer].setChannel(ichannel, channel.getADC(), channel.getTOA(), channel.getTOT());
+    }
+    auto triggers = data.getDataForASIC(ilayer).getTriggerWords();
+    for (std::size_t window = 0; window < constants::PADLAYER_WINDOW_LENGTH; window++) {
+      std::fill(triggertimes.begin(), triggertimes.end(), 0);
+      triggertimes[0] = triggers[window].mTrigger0;
+      triggertimes[1] = triggers[window].mTrigger1;
+      triggertimes[2] = triggers[window].mTrigger2;
+      triggertimes[3] = triggers[window].mTrigger3;
+      triggertimes[4] = triggers[window].mTrigger4;
+      triggertimes[5] = triggers[window].mTrigger5;
+      triggertimes[6] = triggers[window].mTrigger6;
+      triggertimes[7] = triggers[window].mTrigger7;
+      result[ilayer].setTrigger(window, triggers[window].mHeader0, triggers[window].mHeader1, triggertimes);
     }
   }
 


### PR DESCRIPTION
- Add structure for pad trigger words to Event structure
- Change decoding header word of PAD triggers 1 header, 8 bits -> 2 headers, each 4 bits
- Fill trigger words in PadLayerEvent in reconstruction
- Fix headers in pad rootifier