### PR TITLE
Removing /dev/shm files for current session.

### DIFF
--- a/prodtests/full-system-test/run-workflow-on-inputlist.sh
+++ b/prodtests/full-system-test/run-workflow-on-inputlist.sh
@@ -30,6 +30,9 @@ LOG_PREFIX="log_$(date +%Y%m%d-%H%M%S)_"
 [[ -z $OVERRIDE_SESSION ]] && export OVERRIDE_SESSION=default_$$_$RANDOM
 [[ -z $INRAWCHANNAME ]] && export INRAWCHANNAME=tf-builder-$$-$RANDOM
 
+SESSION_ID=`fairmq-shmmonitor --get-shmid --session $OVERRIDE_SESSION | cut -d':' -f2 | sed 's/^ *//'`
+echo "SESSION_ID is $SESSION_ID"
+rm -rf /dev/shm/fmq_$SESSION_ID*
 if [[ "0$IGNORE_EXISTING_SHMFILES" != "01" && `ls /dev/shm/*fmq* 2> /dev/null | wc -l` -ne 0 ]]; then
   echo "ERROR: Existing SHM files (you can set IGNORE_EXISTING_SHMFILES=1 to ignore and allow multiple parallel reconstruction sessions)"
   exit 1


### PR DESCRIPTION
Needed in case an old session with the same ID as the current was left uncleaned.