### PR TITLE
Possibility to use CCDBDownloader in CcdbApi

### DIFF
--- a/CCDB/CMakeLists.txt
+++ b/CCDB/CMakeLists.txt
@@ -85,3 +85,9 @@ o2_add_test(CcdbDownloader
             COMPONENT_NAME ccdb
             PUBLIC_LINK_LIBRARIES O2::CCDB
             LABELS ccdb)
+
+# extra CcdbApi test which dispatches to CCDBDownloader (tmp until full move done)
+o2_add_test_command(NAME CcdbApi-MultiHandle
+                    WORKING_DIRECTORY ${SIMTESTDIR}
+                    COMMAND ${CMAKE_BINARY_DIR}/stage/tests/o2-test-ccdb-CcdbApi
+                    ENVIRONMENT "ALICEO2_ENABLE_MULTIHANDLE_CCDBAPI=1")

--- a/CCDB/include/CCDB/CCDBDownloader.h
+++ b/CCDB/include/CCDB/CCDBDownloader.h
@@ -60,7 +60,12 @@ curl_socket_t opensocketCallback(void* clientp, curlsocktype purpose, struct cur
  */
 void onUVClose(uv_handle_t* handle);
 
-/// A class encapsulating and performing CURL requests. Adds functionality on top
+/// A class encapsulating and performing simple CURL requests in terms of a so-called CURL multi-handle.
+/// A multi-handle allows to use a connection pool (connection cache) in the CURL layer even
+/// with short-lived CURL easy-handles. Thereby the overhead of connection to servers can be
+/// significantly reduced. For more info, see for instance https://everything.curl.dev/libcurl/connectionreuse.
+///
+/// Further, this class adds functionality on top
 /// of simple CURL (aysync requests, timeout handling, event loop, etc).
 class CCDBDownloader
 {
@@ -105,20 +110,20 @@ class CCDBDownloader
    *
    * @param handles Handles to be performed on.
    */
-  std::vector<CURLcode>* asynchBatchPerformWithCallback(std::vector<CURL*> handles, bool* completionFlag, void (*cbFun)(void*), void* cbData);
+  std::vector<CURLcode>* asynchBatchPerformWithCallback(std::vector<CURL*> const& handles, bool* completionFlag, void (*cbFun)(void*), void* cbData);
 
   /**
    * Perform on a batch of handles in a blocking manner. Has the same effect as calling curl_easy_perform() on all handles in the vector.
    * @param handleVector Handles to be performed on.
    */
-  std::vector<CURLcode> batchBlockingPerform(std::vector<CURL*> handleVector);
+  std::vector<CURLcode> batchBlockingPerform(std::vector<CURL*> const& handleVector);
 
   /**
    * Perform on a batch of handles. Completion flag will be set to true when all handles finish their transfers.
    * @param handleVector Handles to be performed on.
    * @param completionFlag Should be set to false before passing it to this function. Will be set to true after all transfers finish.
    */
-  std::vector<CURLcode>* batchAsynchPerform(std::vector<CURL*> handleVector, bool* completionFlag);
+  std::vector<CURLcode>* batchAsynchPerform(std::vector<CURL*> const& handleVector, bool* completionFlag);
 
   /**
    * Limits the number of parallel connections. Should be used only if no transfers are happening.

--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -24,6 +24,7 @@
 #include <TObject.h>
 #include <TMessage.h>
 #include "CCDB/CcdbObjectInfo.h"
+#include "CCDB/CCDBDownloader.h"
 #include <CommonUtils/ConfigurableParam.h>
 #include <type_traits>
 #include <vector>
@@ -519,6 +520,12 @@ class CcdbApi //: public DatabaseInterface
   {
     return getSnapshotDir(topdir, path) + '/' + sfile;
   }
+
+  // tmp helper and single point of entry for a CURL perform call
+  // helps to switch between easy handle perform and multi handles in a single place
+  CURLcode CURL_perform(CURL* handle) const;
+
+  mutable CCDBDownloader mDownloader; //! the multi-handle (async) CURL downloader
   /// Base URL of the CCDB (with port)
   std::string mUniqueAgentID{}; // Unique User-Agent ID communicated to server for logging
   std::string mUrl{};

--- a/CCDB/src/CCDBDownloader.cxx
+++ b/CCDB/src/CCDBDownloader.cxx
@@ -408,7 +408,7 @@ CURLcode CCDBDownloader::perform(CURL* handle)
   return batchBlockingPerform(handleVector).back();
 }
 
-std::vector<CURLcode>* CCDBDownloader::batchAsynchPerform(std::vector<CURL*> handleVector, bool* completionFlag)
+std::vector<CURLcode>* CCDBDownloader::batchAsynchPerform(std::vector<CURL*> const& handleVector, bool* completionFlag)
 {
   auto codeVector = new std::vector<CURLcode>(handleVector.size());
   size_t* requestsLeft = new size_t();
@@ -433,7 +433,7 @@ std::vector<CURLcode>* CCDBDownloader::batchAsynchPerform(std::vector<CURL*> han
   return codeVector;
 }
 
-std::vector<CURLcode> CCDBDownloader::batchBlockingPerform(std::vector<CURL*> handleVector)
+std::vector<CURLcode> CCDBDownloader::batchBlockingPerform(std::vector<CURL*> const& handleVector)
 {
   std::condition_variable cv;
   std::mutex cv_m;
@@ -461,7 +461,7 @@ std::vector<CURLcode> CCDBDownloader::batchBlockingPerform(std::vector<CURL*> ha
   return codeVector;
 }
 
-std::vector<CURLcode>* CCDBDownloader::asynchBatchPerformWithCallback(std::vector<CURL*> handleVector, bool* completionFlag, void (*cbFun)(void*), void* cbData)
+std::vector<CURLcode>* CCDBDownloader::asynchBatchPerformWithCallback(std::vector<CURL*> const& handleVector, bool* completionFlag, void (*cbFun)(void*), void* cbData)
 {
   auto codeVector = new std::vector<CURLcode>(handleVector.size());
   size_t* requestsLeft = new size_t();


### PR DESCRIPTION
This commit introduces a new function CURL_perform in CcdbApi, with the purpose to have a single place where we can take the decision to dispatch CURL perform requests to "curl_easy_perform" or the new "CCDBDownloader".

The most important curl_easy_perform have been replaced to go via this new function.

In turn, with this commit we can make experimental use of CCDBDownloader within CcdbApi whenever an environment variable ALICEO2_ENABLE_MULTIHANDLE_CCDBAPI is defined. (Later on we can make this the default route). This new multi-handle route is tested via new unit test.

Further changes are:
* clarification in doxygen documentation
* some optimization by using const& instead of vector copy