### PR TITLE
[MCH] skip local chi2 calculation if not requested or not needed

### DIFF
--- a/Detectors/MUON/MCH/Tracking/include/MCHTracking/TrackFitter.h
+++ b/Detectors/MUON/MCH/Tracking/include/MCHTracking/TrackFitter.h
@@ -56,7 +56,8 @@ class TrackFitter
   void setChamberResolution(double ex, double ey);
 
   void fit(Track& track, bool smooth = true, bool finalize = true,
-           std::list<TrackParam>::reverse_iterator* itStartingParam = nullptr);
+           std::list<TrackParam>::reverse_iterator* itStartingParam = nullptr,
+           bool skipLocalChi2Calculation = false);
 
   void runKalmanFilter(TrackParam& trackParam);
 
@@ -66,8 +67,8 @@ class TrackFitter
  private:
   void initTrack(const Cluster& cl1, const Cluster& cl2, TrackParam& param);
   void addCluster(const TrackParam& startingParam, const Cluster& cl, TrackParam& param);
-  void smoothTrack(Track& track, bool finalize);
-  void runSmoother(const TrackParam& previousParam, TrackParam& param);
+  void smoothTrack(Track& track, bool finalize, bool skipLocalChi2Calculation);
+  void runSmoother(const TrackParam& previousParam, TrackParam& param, bool skipLocalChi2Calculation);
 
   static constexpr double SMaxChi2 = 2.e10; ///< maximum chi2 above which the track can be considered as abnormal
   /// z position of the chambers

--- a/Detectors/MUON/MCH/Tracking/src/TrackFinder.cxx
+++ b/Detectors/MUON/MCH/Tracking/src/TrackFinder.cxx
@@ -1447,7 +1447,7 @@ void TrackFinder::prepareForwardTracking(std::list<Track>::iterator& itTrack, bo
 
   if (runSmoother) {
     auto itStartingParam = std::prev(itTrack->rend());
-    mTrackFitter.fit(*itTrack, true, false, &itStartingParam);
+    mTrackFitter.fit(*itTrack, true, false, &itStartingParam, true);
   }
 
   setCurrentParam(*itTrack, itTrack->last(), itTrack->last().getClusterPtr()->getChamberId(), runSmoother);


### PR DESCRIPTION
This should solve the problem in the tracking behind the error message "Error in <TDecompLU::DecomposeLUCrout>: matrix is singular" when reconstructing B OFF data.
The problem was in the calculation of the local chi2 when there are only 2 clusters attached to the track. In this case the chi2 is 0 but the way it is computed in the smoother resulted in producing a singular matrix.
I added a protection plus a switch to disable the chi2 computation when it is not used.