### PR TITLE
DPL: Fix problem with input-proxy not sending DISTSTF for dpl ccdb backend, yielding incomplete TFs, and thus the error messages "Dropping..." + related fixes

### DIFF
--- a/Framework/Core/src/DataRelayer.cxx
+++ b/Framework/Core/src/DataRelayer.cxx
@@ -293,7 +293,7 @@ void DataRelayer::setOldestPossibleInput(TimesliceId proposed, ChannelIndex chan
       auto& element = mCache[si * mInputs.size() + mi];
       if (element.size() != 0) {
         if (input.lifetime != Lifetime::Condition && mCompletionPolicy.name != "internal-dpl-injected-dummy-sink") {
-          LOGP(error, "Dropping {} Lifetime::{} data in slot {} with timestamp {} < {}.", DataSpecUtils::describe(input), (int)input.lifetime, si, timestamp.value, newOldest.timeslice.value);
+          LOGP(error, "Dropping incomplete {} Lifetime::{} data in slot {} with timestamp {} < {} as it can never be completed.", DataSpecUtils::describe(input), (int)input.lifetime, si, timestamp.value, newOldest.timeslice.value);
         } else {
           LOGP(debug,
                "Silently dropping data {} in pipeline slot {} because it has timeslice {} < {} after receiving data from channel {}."


### PR DESCRIPTION
@ktf : Basically, the 2 fixes we did along the line this afternoon mostly did it. I added one more fix on top that catches one more case.

Basically, what happened is that peers disconnected, which made the peer count too low, and then a single received EoS is enough to make the input-proxy signal the EoS as soon as only one peer remains connected, even if that peer didn't send EoS yet.

For me, this fully fixes the problem with the "Dropping... " messages (I also made the message itself more clear).
Now, checking the dplCounter in the ExternalFMQDeviceProcey, I see that it can indeed go out of sync with the oldestPossibleTimeframe when I manually increment it, i.e. the oldestPossibleTimeframe is not derrived from the propaged dplCounter in the DataRelayer matrix.
This is not breaking at the moment, but I am sure this will cause more failures in the future, so I am working for a fix also for this.
In any case, this should be ready to be merged already and should significantly improve the situation.