### PR TITLE
DPL: Do not count up timeslice indices in all InjectorFunctions separately, but take oldestPossible timeslice from TimesliceIndexDev pull request2

### DIFF
--- a/Detectors/CTP/workflowScalers/src/ctp-proxy.cxx
+++ b/Detectors/CTP/workflowScalers/src/ctp-proxy.cxx
@@ -48,11 +48,11 @@ using DetID = o2::detectors::DetID;
 InjectorFunction dcs2dpl(std::string& ccdbhost)
 // InjectorFunction dcs2dpl()
 {
-  auto timesliceId = std::make_shared<size_t>(0);
   auto runMgr = std::make_shared<o2::ctp::CTPRunManager>();
   runMgr->setCCDBHost(ccdbhost);
   runMgr->init();
-  return [timesliceId, runMgr](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever) {
+  return [runMgr](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever, size_t newTimesliceId) {
+    // FIXME: Why isn't this function using the timeslice index?
     // make sure just 2 messages received
     if (parts.Size() != 2) {
       LOG(error) << "received " << parts.Size() << " instead of 2 expected";

--- a/Detectors/CTP/workflowScalers/src/ctp-qc-proxy.cxx
+++ b/Detectors/CTP/workflowScalers/src/ctp-qc-proxy.cxx
@@ -45,8 +45,7 @@ using DetID = o2::detectors::DetID;
 InjectorFunction dcs2dpl()
 // InjectorFunction dcs2dpl()
 {
-  auto timesliceId = std::make_shared<size_t>(0);
-  return [timesliceId](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever) {
+  return [](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever, size_t newTimesliceId) {
     // make sure just 2 messages received
     if (parts.Size() != 2) {
       LOG(error) << "received " << parts.Size() << " instead of 2 expected";
@@ -58,12 +57,12 @@ InjectorFunction dcs2dpl()
     LOG(info) << "received message " << messageHeader << " of size " << dataSize; // << " Payload:" << messageData;
     o2::header::DataHeader hdrF("CTP_COUNTERS", o2::header::gDataOriginCTP, 0);
     OutputSpec outsp{hdrF.dataOrigin, hdrF.dataDescription, hdrF.subSpecification};
-    auto channel = channelRetriever(outsp, *timesliceId);
+    auto channel = channelRetriever(outsp, newTimesliceId);
     if (channel.empty()) {
       LOG(error) << "No output channel found for OutputSpec " << outsp;
       return;
     }
-    hdrF.tfCounter = *timesliceId; // this also
+    hdrF.tfCounter = newTimesliceId; // this also
     hdrF.payloadSerializationMethod = o2::header::gSerializationMethodNone;
     hdrF.splitPayloadParts = 1;
     hdrF.splitPayloadIndex = 0;
@@ -72,7 +71,7 @@ InjectorFunction dcs2dpl()
 
     auto fmqFactory = device.GetChannel(channel).Transport();
 
-    o2::header::Stack headerStackF{hdrF, DataProcessingHeader{*timesliceId, 1}};
+    o2::header::Stack headerStackF{hdrF, DataProcessingHeader{newTimesliceId, 1}};
     auto hdMessageF = fmqFactory->CreateMessage(headerStackF.size(), fair::mq::Alignment{64});
     auto plMessageF = fmqFactory->CreateMessage(hdrF.payloadSize, fair::mq::Alignment{64});
     memcpy(hdMessageF->GetData(), headerStackF.data(), headerStackF.size());
@@ -93,7 +92,7 @@ InjectorFunction dcs2dpl()
     fair::mq::Parts outParts;
     outParts.AddPart(std::move(hdMessageF));
     outParts.AddPart(std::move(plMessageF));
-    sendOnChannel(device, outParts, channel, *timesliceId);
+    sendOnChannel(device, outParts, channel, newTimesliceId);
     LOG(info) << "Sent CTP counters DPL message" << std::flush;
   };
 }

--- a/Detectors/DCS/testWorkflow/src/DCStoDPLconverter.h
+++ b/Detectors/DCS/testWorkflow/src/DCStoDPLconverter.h
@@ -54,7 +54,7 @@ using DPCOM = o2::dcs::DataPointCompositeObject;
 o2f::InjectorFunction dcs2dpl(std::unordered_map<DPID, o2h::DataDescription>& dpid2group, bool fbiFirst, bool verbose = false, int FBIPerInterval = 1)
 {
 
-  return [dpid2group, fbiFirst, verbose, FBIPerInterval](o2::framework::TimingInfo& tinfo, fair::mq::Device& device, fair::mq::Parts& parts, o2f::ChannelRetriever channelRetriever) {
+  return [dpid2group, fbiFirst, verbose, FBIPerInterval](o2::framework::TimingInfo& tinfo, fair::mq::Device& device, fair::mq::Parts& parts, o2f::ChannelRetriever channelRetriever, size_t newTimesliceId) {
     static std::unordered_map<DPID, DPCOM> cache; // will keep only the latest measurement in the 1-second wide window for each DPID
     static std::unordered_map<std::string, int> sentToChannel;
     static auto timer = std::chrono::high_resolution_clock::now();

--- a/Detectors/DCS/testWorkflow/src/dcs-config-proxy.cxx
+++ b/Detectors/DCS/testWorkflow/src/dcs-config-proxy.cxx
@@ -66,10 +66,7 @@ auto getDataOriginFromFilename(const std::string& filename)
 
 InjectorFunction dcs2dpl(const std::string& acknowledge)
 {
-
-  auto timesliceId = std::make_shared<size_t>(0);
-
-  return [acknowledge, timesliceId](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever) {
+  return [acknowledge](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever, size_t newTimesliceId) {
     if (parts.Size() == 0) { // received at ^c, ignore
       LOG(info) << "ignoring empty message";
       return;
@@ -93,21 +90,21 @@ InjectorFunction dcs2dpl(const std::string& acknowledge)
     o2::header::DataHeader hdrF("DCS_CONFIG_FILE", dataOrigin, 0);
     o2::header::DataHeader hdrN("DCS_CONFIG_NAME", dataOrigin, 0);
     OutputSpec outsp{hdrF.dataOrigin, hdrF.dataDescription, hdrF.subSpecification};
-    auto channel = channelRetriever(outsp, *timesliceId);
+    auto channel = channelRetriever(outsp, newTimesliceId);
     if (channel.empty()) {
       LOG(error) << "No output channel found for OutputSpec " << outsp;
       sendAnswer(fmt::format("{}:error2: no channel to send", filename), acknowledge, device);
       return;
     }
 
-    hdrF.tfCounter = *timesliceId;
+    hdrF.tfCounter = newTimesliceId;
     hdrF.payloadSerializationMethod = o2::header::gSerializationMethodNone;
     hdrF.splitPayloadParts = 1;
     hdrF.splitPayloadIndex = 0;
     hdrF.payloadSize = filesize;
     hdrF.firstTForbit = 0; // this should be irrelevant for DCS
 
-    hdrN.tfCounter = *timesliceId;
+    hdrN.tfCounter = newTimesliceId;
     hdrN.payloadSerializationMethod = o2::header::gSerializationMethodNone;
     hdrN.splitPayloadParts = 1;
     hdrN.splitPayloadIndex = 0;
@@ -117,13 +114,13 @@ InjectorFunction dcs2dpl(const std::string& acknowledge)
     auto fmqFactory = device.GetChannel(channel).Transport();
     std::uint64_t creation = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::system_clock::now()).time_since_epoch().count();
 
-    o2::header::Stack headerStackF{hdrF, DataProcessingHeader{*timesliceId, 1, creation}};
+    o2::header::Stack headerStackF{hdrF, DataProcessingHeader{newTimesliceId, 1, creation}};
     auto hdMessageF = fmqFactory->CreateMessage(headerStackF.size(), fair::mq::Alignment{64});
     auto plMessageF = fmqFactory->CreateMessage(hdrF.payloadSize, fair::mq::Alignment{64});
     memcpy(hdMessageF->GetData(), headerStackF.data(), headerStackF.size());
     memcpy(plMessageF->GetData(), parts.At(1)->GetData(), hdrF.payloadSize);
 
-    o2::header::Stack headerStackN{hdrN, DataProcessingHeader{*timesliceId, 1, creation}};
+    o2::header::Stack headerStackN{hdrN, DataProcessingHeader{newTimesliceId, 1, creation}};
     auto hdMessageN = fmqFactory->CreateMessage(headerStackN.size(), fair::mq::Alignment{64});
     auto plMessageN = fmqFactory->CreateMessage(hdrN.payloadSize, fair::mq::Alignment{64});
     memcpy(hdMessageN->GetData(), headerStackN.data(), headerStackN.size());
@@ -137,11 +134,10 @@ InjectorFunction dcs2dpl(const std::string& acknowledge)
     fair::mq::Parts outPartsN;
     outPartsN.AddPart(std::move(hdMessageN));
     outPartsN.AddPart(std::move(plMessageN));
-    sendOnChannel(device, outPartsN, channel, *timesliceId);
+    sendOnChannel(device, outPartsN, channel, newTimesliceId);
 
     sendAnswer(fmt::format("{}:ok", filename), acknowledge, device);
     LOG(info) << "Sent DPL message and acknowledgment for file " << filename;
-    (*timesliceId)++;
   };
 }
 

--- a/Framework/Core/include/Framework/ExternalFairMQDeviceProxy.h
+++ b/Framework/Core/include/Framework/ExternalFairMQDeviceProxy.h
@@ -24,7 +24,7 @@ namespace o2::framework
 /// A callback function to retrieve the fair::mq::Channel name to be used for sending
 /// messages of the specified OutputSpec
 using ChannelRetriever = std::function<std::string(OutputSpec const&, DataProcessingHeader::StartTime)>;
-using InjectorFunction = std::function<void(TimingInfo&, fair::mq::Device& device, fair::mq::Parts& inputs, ChannelRetriever)>;
+using InjectorFunction = std::function<void(TimingInfo&, fair::mq::Device& device, fair::mq::Parts& inputs, ChannelRetriever, size_t newTimesliceId)>;
 using ChannelSelector = std::function<std::string(InputSpec const& input, const std::unordered_map<std::string, std::vector<fair::mq::Channel>>& channels)>;
 
 struct InputChannelSpec;

--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -473,9 +473,9 @@ o2::framework::ServiceSpec CommonServices::decongestionSpec()
         return;
       }
 
-      LOGP(debug, "Broadcasting possible output {} due to {} ({})", oldestPossibleOutput.timeslice.value,
+      LOGP(debug, "Broadcasting oldest possible output {} due to {} ({})", oldestPossibleOutput.timeslice.value,
            oldestPossibleOutput.slot.index == -1 ? "channel" : "slot",
-           oldestPossibleOutput.slot.index == -1 ? oldestPossibleOutput.channel.value: oldestPossibleOutput.slot.index);
+           oldestPossibleOutput.slot.index == -1 ? oldestPossibleOutput.channel.value : oldestPossibleOutput.slot.index);
       DataProcessingHelpers::broadcastOldestPossibleTimeslice(proxy, oldestPossibleOutput.timeslice.value);
 
       for (int fi = 0; fi < proxy.getNumForwardChannels(); fi++) {

--- a/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
+++ b/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
@@ -175,15 +175,13 @@ void sendOnChannel(fair::mq::Device& device, fair::mq::MessagePtr&& headerMessag
 
 InjectorFunction o2DataModelAdaptor(OutputSpec const& spec, uint64_t startTime, uint64_t /*step*/)
 {
-  auto timesliceId = std::make_shared<size_t>(startTime);
-  return [timesliceId, spec](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever) {
+  return [spec](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever, size_t newTimesliceId) {
     for (int i = 0; i < parts.Size() / 2; ++i) {
       auto dh = o2::header::get<DataHeader*>(parts.At(i * 2)->GetData());
 
-      DataProcessingHeader dph{*timesliceId, 0};
+      DataProcessingHeader dph{newTimesliceId, 0};
       o2::header::Stack headerStack{*dh, dph};
       sendOnChannel(device, std::move(headerStack), std::move(parts.At(i * 2 + 1)), spec, channelRetriever);
-      *timesliceId += 1;
     }
   };
 }
@@ -224,13 +222,11 @@ InjectorFunction dplModelAdaptor(std::vector<OutputSpec> const& filterSpecs, DPL
     std::string descriptions;
   };
 
-  return [filterSpecs = std::move(filterSpecs), throwOnUnmatchedInputs, droppedDataSpecs = std::make_shared<DroppedDataSpecs>()](TimingInfo& timingInfo, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever) {
+  return [filterSpecs = std::move(filterSpecs), throwOnUnmatchedInputs, droppedDataSpecs = std::make_shared<DroppedDataSpecs>()](TimingInfo& timingInfo, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever, size_t newTimesliceId) {
     // FIXME: this in not thread safe, but better than an alloc of a map per message...
     std::unordered_map<std::string, fair::mq::Parts> outputs;
     std::vector<std::string> unmatchedDescriptions;
 
-    static int64_t dplCounter = -1;
-    dplCounter++;
     static bool override_creation_env = getenv("DPL_RAWPROXY_OVERRIDE_ORBITRESET");
     bool override_creation = false;
     uint64_t creationVal = 0;
@@ -265,13 +261,7 @@ InjectorFunction dplModelAdaptor(std::vector<OutputSpec> const& filterSpecs, DPL
         LOG(error) << "data on input " << msgidx << " does not follow the O2 data model, DataProcessingHeader missing";
         continue;
       }
-      static size_t currentRunNumber = -1;
-      if (dh->runNumber != currentRunNumber) {
-        LOGP(detail, "Run number changed from {} to {}. Resetting DPL timeslice counter", currentRunNumber, dh->runNumber);
-        currentRunNumber = dh->runNumber;
-        dplCounter = 0;
-      }
-      const_cast<DataProcessingHeader*>(dph)->startTime = dplCounter;
+      const_cast<DataProcessingHeader*>(dph)->startTime = newTimesliceId;
       if (override_creation) {
         const_cast<DataProcessingHeader*>(dph)->creation = creationVal + (dh->firstTForbit * o2::constants::lhc::LHCOrbitNS * 0.000001f);
       }
@@ -348,7 +338,7 @@ InjectorFunction dplModelAdaptor(std::vector<OutputSpec> const& filterSpecs, DPL
       if (channelParts.Size() == 0) {
         continue;
       }
-      sendOnChannel(device, channelParts, channelName, dplCounter);
+      sendOnChannel(device, channelParts, channelName, newTimesliceId);
     }
     if (not unmatchedDescriptions.empty()) {
       if (throwOnUnmatchedInputs) {
@@ -378,8 +368,7 @@ InjectorFunction dplModelAdaptor(std::vector<OutputSpec> const& filterSpecs, DPL
 InjectorFunction incrementalConverter(OutputSpec const& spec, o2::header::SerializationMethod method, uint64_t startTime, uint64_t step)
 {
   auto timesliceId = std::make_shared<size_t>(startTime);
-
-  return [timesliceId, spec, step, method](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever) {
+  return [timesliceId, spec, step, method](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever, size_t newTimesliceId) {
     // We iterate on all the parts and we send them two by two,
     // adding the appropriate O2 header.
     for (int i = 0; i < parts.Size(); ++i) {
@@ -393,7 +382,10 @@ InjectorFunction incrementalConverter(OutputSpec const& spec, o2::header::Serial
       dh.subSpecification = matcher.subSpec;
       dh.payloadSize = parts.At(i)->GetSize();
 
-      DataProcessingHeader dph{*timesliceId, 0};
+      DataProcessingHeader dph{newTimesliceId, 0};
+      if (*timesliceId != newTimesliceId) {
+        LOG(fatal) << "Time slice ID provided from oldestPossible mechanism " << newTimesliceId << " is out of sync with expected value " << *timesliceId;
+      }
       *timesliceId += step;
       // we have to move the incoming data
       o2::header::Stack headerStack{dh, dph};
@@ -406,11 +398,7 @@ InjectorFunction incrementalConverter(OutputSpec const& spec, o2::header::Serial
 DataProcessorSpec specifyExternalFairMQDeviceProxy(char const* name,
                                                    std::vector<OutputSpec> const& outputs,
                                                    char const* defaultChannelConfig,
-                                                   std::function<void(TimingInfo&,
-                                                                      fair::mq::Device&,
-                                                                      fair::mq::Parts&,
-                                                                      ChannelRetriever)>
-                                                     converter,
+                                                   InjectorFunction converter,
                                                    uint64_t minSHM)
 {
   DataProcessorSpec spec;
@@ -531,6 +519,7 @@ DataProcessorSpec specifyExternalFairMQDeviceProxy(char const* name,
                         outputRoutes = std::move(outputRoutes),
                         control = &ctx.services().get<ControlService>(),
                         deviceState = &ctx.services().get<DeviceState>(),
+                        timesliceIndex = &ctx.services().get<TimesliceIndex>(),
                         outputChannels = std::move(outputChannels)](TimingInfo& timingInfo, fair::mq::Parts& inputs, int, size_t ci) {
       // pass a copy of the outputRoutes
       auto channelRetriever = [&outputRoutes](OutputSpec const& query, DataProcessingHeader::StartTime timeslice) -> std::string {
@@ -555,7 +544,8 @@ DataProcessorSpec specifyExternalFairMQDeviceProxy(char const* name,
       if (numberOfEoS[ci]) {
         eosPeersCount[ci] = std::max<int>(eosPeersCount[ci], device->GetNumberOfConnectedPeers(channel));
       }
-      converter(timingInfo, *device, inputs, channelRetriever);
+      // For reference, the oldest possible timeframe passed as newTimesliceId here comes from LifetimeHelpers::enumDrivenCreation()
+      converter(timingInfo, *device, inputs, channelRetriever, timesliceIndex->getOldestPossibleOutput().timeslice.value);
 
       // If we have enough EoS messages, we can stop the device
       // Notice that this has a number of failure modes:

--- a/Framework/Core/src/ReadoutAdapter.cxx
+++ b/Framework/Core/src/ReadoutAdapter.cxx
@@ -23,9 +23,7 @@ using DataHeader = o2::header::DataHeader;
 
 InjectorFunction readoutAdapter(OutputSpec const& spec)
 {
-  auto counter = std::make_shared<uint64_t>(0);
-
-  return [spec, counter](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever) {
+  return [spec](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever, size_t newTimesliceId) {
     for (size_t i = 0; i < parts.Size(); ++i) {
       DataHeader dh;
       // FIXME: this will have to change and extract the actual subspec from
@@ -37,8 +35,7 @@ InjectorFunction readoutAdapter(OutputSpec const& spec)
       dh.payloadSize = parts.At(i)->GetSize();
       dh.payloadSerializationMethod = o2::header::gSerializationMethodNone;
 
-      DataProcessingHeader dph{*counter, 0};
-      (*counter) += 1UL;
+      DataProcessingHeader dph{newTimesliceId, 0};
       o2::header::Stack headerStack{dh, dph};
       sendOnChannel(device, std::move(headerStack), std::move(parts.At(i)), spec, channelRetriever);
     }

--- a/Framework/Core/test/benchmark_ExternalFairMQDeviceProxies.cxx
+++ b/Framework/Core/test/benchmark_ExternalFairMQDeviceProxies.cxx
@@ -469,7 +469,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const& config)
   // reads the messages from the output proxy via the out-of-band channel
 
   // converter callback for the external FairMQ device proxy ProcessorSpec generator
-  auto converter = [](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& inputs, ChannelRetriever channelRetriever) {
+  auto converter = [](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& inputs, ChannelRetriever channelRetriever, size_t newTimesliceId) {
     ASSERT_ERROR(inputs.Size() >= 2);
     if (inputs.Size() < 2) {
       return;

--- a/Framework/Core/test/test_ExternalFairMQDeviceWorkflow.cxx
+++ b/Framework/Core/test/test_ExternalFairMQDeviceWorkflow.cxx
@@ -349,7 +349,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const& config)
   // reads the messages from the output proxy via the out-of-band channel
 
   // converter callback for the external FairMQ device proxy ProcessorSpec generator
-  auto converter = [](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& inputs, ChannelRetriever channelRetriever) {
+  auto converter = [](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& inputs, ChannelRetriever channelRetriever, size_t newTimesliceId) {
     ASSERT_ERROR(inputs.Size() >= 2);
     if (inputs.Size() < 2) {
       return;

--- a/Utilities/DataSampling/src/DataSamplingReadoutAdapter.cxx
+++ b/Utilities/DataSampling/src/DataSamplingReadoutAdapter.cxx
@@ -21,11 +21,9 @@ namespace o2::utilities
 
 using DataHeader = o2::header::DataHeader;
 
-static std::atomic<unsigned int> blockId = 0;
-
 InjectorFunction dataSamplingReadoutAdapter(OutputSpec const& spec)
 {
-  return [spec](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever) {
+  return [spec](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever, size_t newTimesliceId) {
     for (size_t i = 0; i < parts.Size(); ++i) {
 
       DataHeader dh;
@@ -36,7 +34,7 @@ InjectorFunction dataSamplingReadoutAdapter(OutputSpec const& spec)
       dh.payloadSize = parts.At(i)->GetSize();
       dh.payloadSerializationMethod = o2::header::gSerializationMethodNone;
 
-      DataProcessingHeader dph{++blockId, 0};
+      DataProcessingHeader dph{newTimesliceId, 0};
       o2::header::Stack headerStack{dh, dph};
       sendOnChannel(device, std::move(headerStack), std::move(parts.At(i)), spec, channelRetriever);
     }


### PR DESCRIPTION
Contains #10940 and should be rebased once that is merged.

I found out that the dplCounter static variable in the input-proxy is not actively kept in sync with the oldestPossibleTimeframe id that is injected, which originates from `LifetimeHelpers::enumDrivenCreation`. They are basically in sync by chance, and one has to make sure to reset them in sync e.g. for endOfStream.

And there were O(10) similar cases from various source devices. Some were apparently broken, since they were not counting up the timeslice at all.

This unifies all of this by adding a newTimesliceId parameter to the InjectorFunction callback, such that the proxy can forward the newly created oldestPossibleTimeframe to the lambda that injects the actual data.
I.e. we use the `LifetimeHelpers::enumDrivenCreation`, `LifetimeHelpers::timeDrivenCreation` as ground truth for the ID of everything. In that way it must always be in sync.

What we need to guarantee, and what I think is totally missing at the moment, is resetting the counters in these LifetimeHelpers at endOfStream.

Not sure that I pached all places correctly, but I think we have to do something like this anyway, so better sooner than later...