### PR TITLE
Fix invalid read bug during destructor

### DIFF
--- a/CCDB/src/CCDBDownloader.cxx
+++ b/CCDB/src/CCDBDownloader.cxx
@@ -81,6 +81,9 @@ CCDBDownloader::~CCDBDownloader()
     uv_timer_stop(socketTimerPair.second);
     uv_close((uv_handle_t*)socketTimerPair.second, onUVClose);
   }
+  // all timers have been closed --> so clear this map (otherwise it may get accessed in different callbacks again
+  // ... for instance when called from within curl_multi_cleanup)
+  mSocketTimerMap.clear();
 
   // Close loop thread
   mCloseLoop = true;
@@ -172,7 +175,6 @@ void CCDBDownloader::closeSocketByTimer(uv_timer_t* handle)
     uv_timer_stop(CD->mSocketTimerMap[sock]);
     CD->mSocketTimerMap.erase(sock);
     close(sock);
-    return;
   }
 }
 


### PR DESCRIPTION
Fixing the following bug (observed in the CCDBDownloader unit test):
```
==12389== Invalid read of size 4
==12389==    at 0x6B92360: uv_timer_stop (in /home/aliperf/aliperf_workspace/sw/slc7_x86-64/libuv/v1.40.0-31/lib/libuv.so.1.0.0)
==12389==    by 0x4083ECD: o2::ccdb::CCDBDownloader::closesocketCallback(void*, int) (in /home/aliperf/aliperf_workspace/sw/BUILD/0c9f272b0a884bf8744badd83e88682db7912acd/O2/stage/lib64/libO2CCDB.so)
==12389==    by 0x417687D: Curl_closesocket (in /home/aliperf/aliperf_workspace/sw/slc7_x86-64/curl/7.70.0-60/lib/libcurl.so.4.6.0)
==12389==    by 0x4187F6A: Curl_disconnect (in /home/aliperf/aliperf_workspace/sw/slc7_x86-64/curl/7.70.0-60/lib/libcurl.so.4.6.0)
==12389==    by 0x4175FF3: Curl_conncache_close_all_connections (in /home/aliperf/aliperf_workspace/sw/slc7_x86-64/curl/7.70.0-60/lib/libcurl.so.4.6.0)
==12389==    by 0x419FA76: curl_multi_cleanup (in /home/aliperf/aliperf_workspace/sw/slc7_x86-64/curl/7.70.0-60/lib/libcurl.so.4.6.0)
==12389==    by 0x40828C9: o2::ccdb::CCDBDownloader::~CCDBDownloader() (in /home/aliperf/aliperf_workspace/sw/BUILD/0c9f272b0a884bf8744badd83e88682db7912acd/O2/stage/lib64/libO2CCDB.so)
==12389==    by 0x404BA2: o2::ccdb::perform_test::test_method() (in /home/aliperf/aliperf_workspace/sw/BUILD/0c9f272b0a884bf8744badd83e88682db7912acd/O2/stage/tests/o2-test-ccdb-CcdbDownloader)
==12389==    by 0x40676A: o2::ccdb::perform_test_invoker() (in /home/aliperf/aliperf_workspace/sw/BUILD/0c9f272b0a884bf8744badd83e88682db7912acd/O2/stage/tests/o2-test-ccdb-CcdbDownloader)
==12389==    by 0x40E7B9D: boost::detail::function::function_obj_invoker0<boost::detail::forward, int>::invoke(boost::detail::function::function_buffer&) (in /home/aliperf/aliperf_workspace/sw/slc7_x86-64/boost/v1.75.0-101/lib/
libboost_unit_test_framework.so.1.75.0)
==12389==    by 0x40E6334: boost::execution_monitor::catch_signals(boost::function<int ()> const&) (in /home/aliperf/aliperf_workspace/sw/slc7_x86-64/boost/v1.75.0-101/lib/libboost_unit_test_framework.so.1.75.0)
==12389==    by 0x40E63A0: boost::execution_monitor::execute(boost::function<int ()> const&) (in /home/aliperf/aliperf_workspace/sw/slc7_x86-64/boost/v1.75.0-101/lib/libboost_unit_test_framework.so.1.75.0)
==12389==  Address 0x8698b78 is 88 bytes inside a block of size 152 free'd
==12389==    at 0x4C2B6DF: operator delete(void*, unsigned long) (vg_replace_malloc.c:595)
==12389==    by 0x6B95FD8: uv_run (in /home/aliperf/aliperf_workspace/sw/slc7_x86-64/libuv/v1.40.0-31/lib/libuv.so.1.0.0)
==12389==    by 0x7804B62: execute_native_thread_routine (in /home/aliperf/aliperf_workspace/sw/slc7_x86-64/GCC-Toolchain/v12.2.0-alice1-5/lib64/libstdc++.so.6.0.30)
==12389==    by 0x7513EA4: start_thread (in /usr/lib64/libpthread-2.17.so)
==12389==    by 0x7D6DB0C: clone (in /usr/lib64/libc-2.17.so)
```