### PR TITLE
GLO QC: Switch to TH1D for pT and extend Chi2 range

### DIFF
--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchITSTPCQC.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchITSTPCQC.h
@@ -55,8 +55,8 @@ class MatchITSTPCQC
   void finalize();
   void reset();
 
-  TH1F* getHistoPt() const { return mPt; }
-  TH1F* getHistoPtTPC() const { return mPtTPC; }
+  TH1D* getHistoPt() const { return mPt; }
+  TH1D* getHistoPtTPC() const { return mPtTPC; }
   TEfficiency* getFractionITSTPCmatch() const { return mFractionITSTPCmatch; }
 
   TH1F* getHistoPhi() const { return mPhi; }
@@ -130,8 +130,8 @@ class MatchITSTPCQC
   o2::steer::MCKinematicsReader mcReader;                     // reader of MC information
 
   // Pt
-  TH1F* mPt = nullptr;
-  TH1F* mPtTPC = nullptr;
+  TH1D* mPt = nullptr;
+  TH1D* mPtTPC = nullptr;
   TEfficiency* mFractionITSTPCmatch = nullptr;
   TH1F* mPtPhysPrim = nullptr;
   TH1F* mPtTPCPhysPrim = nullptr;

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchITSTPCQC.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchITSTPCQC.h
@@ -130,7 +130,7 @@ class MatchITSTPCQC
                                                               // with that label so far, and the flag to say if it is a physical primary or not
   o2::steer::MCKinematicsReader mcReader;                     // reader of MC information
 
-  // Pt
+  // Pt.
   TH1D* mPt = nullptr;
   TH1D* mPtTPC = nullptr;
   TEfficiency* mFractionITSTPCmatch = nullptr;

--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchITSTPCQC.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchITSTPCQC.h
@@ -16,6 +16,7 @@
 #ifndef ALICEO2_GLOBTRACKING_MATCHTPCITS_QC_
 #define ALICEO2_GLOBTRACKING_MATCHTPCITS_QC_
 
+#include <TH1D.h>
 #include <TH1F.h>
 #include <TH2F.h>
 #include <TEfficiency.h>

--- a/Detectors/GlobalTracking/src/MatchITSTPCQC.cxx
+++ b/Detectors/GlobalTracking/src/MatchITSTPCQC.cxx
@@ -100,9 +100,9 @@ void MatchITSTPCQC::reset()
 bool MatchITSTPCQC::init()
 {
 
-  mPtTPC = new TH1F("mPtTPC", "Pt distribution of TPC tracks; Pt [GeV/c]; dNdPt", 100, 0.f, 20.f);
+  mPtTPC = new TH1D("mPtTPC", "Pt distribution of TPC tracks; Pt [GeV/c]; dNdPt", 100, 0.f, 20.f);
   mFractionITSTPCmatch = new TEfficiency("mFractionITSTPCmatch", "Fraction of ITSTPC matched tracks vs Pt; Pt [GeV/c]; Eff", 100, 0.f, 20.f);
-  mPt = new TH1F("mPt", "Pt distribution of matched tracks; Pt [GeV/c]; dNdPt", 100, 0.f, 20.f);
+  mPt = new TH1D("mPt", "Pt distribution of matched tracks; Pt [GeV/c]; dNdPt", 100, 0.f, 20.f);
   mPhiTPC = new TH1F("mPhiTPC", "Phi distribution of TPC tracks; Phi [rad]; dNdPhi", 100, 0.f, 2 * TMath::Pi());
   mFractionITSTPCmatchPhi = new TEfficiency("mFractionITSTPCmatchPhi", "Fraction of ITSTPC matched tracks vs Phi; Phi [rad]; Eff", 100, 0.f, 2 * TMath::Pi());
   mPhi = new TH1F("mPhi", "Phi distribution of matched tracks; Phi [rad]; dNdPhi", 100, 0.f, 2 * TMath::Pi());
@@ -121,8 +121,8 @@ bool MatchITSTPCQC::init()
   mResidualPt = new TH2F("mResidualPt", "Residuals of ITS-TPC matching in #it{p}_{T}; #it{p}_{T}^{ITS-TPC} [GeV/c]; #it{p}_{T}^{ITS-TPC} - #it{p}_{T}^{TPC} [GeV/c]", 100, 0.f, 20.f, 100, -1.f, 1.f);
   mResidualPhi = new TH2F("mResidualPhi", "Residuals of ITS-TPC matching in #it{#phi}; #it{#phi}^{ITS-TPC} [rad]; #it{#phi}^{ITS-TPC} - #it{#phi}^{TPC} [rad]", 100, 0.f, 2 * TMath::Pi(), 100, -1.f, 1.f);
   mResidualEta = new TH2F("mResidualEta", "Residuals of ITS-TPC matching in #it{#eta}; #it{#eta}^{ITS-TPC}; #it{#eta}^{ITS-TPC} - #it{#eta}^{TPC}", 100, -2.f, 2.f, 100, -1.f, 1.f);
-  mChi2Matching = new TH1F("mChi2Matching", "Chi2 of matching; chi2", 100, 0, 30);
-  mChi2Refit = new TH1F("mChi2Refit", "Chi2 of refit; chi2", 200, 0, 100);
+  mChi2Matching = new TH1F("mChi2Matching", "Chi2 of matching; chi2", 300, 0, 300);
+  mChi2Refit = new TH1F("mChi2Refit", "Chi2 of refit; chi2", 200, 0, 200);
 
   // log binning for pT
   const Int_t nbinsPt = 100;


### PR DESCRIPTION
I fixed the merge conflicts and reduced the PR to the very important changes (TH1F to TH1D for pT plots and Chi2 range).
The previous issues from setEfficiency are gone as I excluded that part !
