### PR TITLE
[FOCAL-10] Add missing streamer

### DIFF
--- a/DataFormats/Detectors/FOCAL/src/DataFormatsFOCALLinkDef.h
+++ b/DataFormats/Detectors/FOCAL/src/DataFormatsFOCALLinkDef.h
@@ -19,6 +19,7 @@
 #pragma link C++ class o2::focal::PadLayerEvent + ;
 #pragma link C++ class o2::focal::PadLayerEvent::Header + ;
 #pragma link C++ class o2::focal::PadLayerEvent::Channel + ;
+#pragma link C++ class o2::focal::PadLayerEvent::TriggerWindow + ;
 #pragma link C++ class o2::focal::PixelLayerEvent + ;
 #pragma link C++ class o2::focal::PixelHit + ;
 #pragma link C++ class o2::focal::PixelChip + ;


### PR DESCRIPTION
Streamer for new class TriggerWindow for the PAD trigger data was missing in order to stream it as part of the PAD event to the FOCAL event tree.