### PR TITLE
Simplify TRD tracking QC and avoid crash in synch mode

### DIFF
--- a/Detectors/TRD/qc/include/TRDQC/Tracking.h
+++ b/Detectors/TRD/qc/include/TRDQC/Tracking.h
@@ -47,51 +47,22 @@ namespace trd
 {
 
 struct TrackQC {
-  int type;                          ///< 0 TPC-TRD track; 1 ITS-TPC-TRD track
+
   GTrackID refGlobalTrackId;         ///< GlobalTrackID of the seeding track (either ITS-TPC or TPC)
-  int nTracklets;                    ///< number of attached TRD tracklets
-  int nLayers;                       //< Number of Layers of a Track in which the track extrapolation was in geometrical acceptance of the TRD
-  float chi2;                        ///< total chi2 value for the track
-  float reducedChi2;                 ///< chi2 total divided by number of layers in which track is inside TRD geometrical acceptance
-  float p;                           ///< the total momentum of the track at the point of the innermost ITS cluster (ITS-TPC-TRD) or at the inner TPC radius (TPC-TRD)
-  float pt;                          ///< the transverse momentum of the track at the point of the innermost ITS cluster (ITS-TPC-TRD) or at the inner TPC radius (TPC-TRD)
-  float ptSigma2;                    ///< Sigma2 of pt
+  TrackTRD trackTRD;                 ///< the found TRD track
+  o2::track::TrackParCov trackSeed;  ///< outer param of the seeding track
   float dEdxTotTPC;                  ///< raw total dEdx information for seeding track in TPC
-  std::bitset<6> isCrossingNeighbor; ///< indicate if track crossed a padrow and/or had a neighboring tracklet in that layer
-  bool hasNeighbor;                  ///< indicate if a track had a tracklet with a neighboring one e.g. potentailly split tracklet
-  bool hasPadrowCrossing;            ///< indicate if track crossed a padrow
 
-  // layer-wise information for seeding track and assigned tracklet (if available)
-  std::array<bool, constants::NLAYER> findable{};  ///< flag if track was in geometrical acceptance
-  std::array<float, constants::NLAYER> trackX{};   ///< x-position of seeding track (sector coordinates)
-  std::array<float, constants::NLAYER> trackY{};   ///< y-position of seeding track (sector coordinates)
-  std::array<float, constants::NLAYER> trackZ{};   ///< z-position of seeding track (sector coordinates)
-  std::array<float, constants::NLAYER> trackSnp{}; ///< sin(phi) of seeding track (sector coordinates -> local inclination in r-phi)
-  std::array<float, constants::NLAYER> trackTgl{}; ///< tan(lambda) of seeding track (inclination in s_xy-z plane)
-  std::array<float, constants::NLAYER> trackQpt{}; ///< q/pt of seeding track
-  std::array<float, constants::NLAYER> trackPhi{}; //< Phi 0:2Pi value of Track
-  std::array<float, constants::NLAYER> trackEta{}; //< Eta value of Track
+  std::array<o2::track::TrackPar, constants::NLAYER> trackProp{}; ///< the track parameters stored at the radius where the track is updated with TRD info
+  std::array<Tracklet64, constants::NLAYER> trklt64{};            ///< the raw tracklet used for the update (includes uncorrected charges)
+  std::array<CalibratedTracklet, constants::NLAYER> trkltCalib{}; ///< the TRD space point used for the update (not yet tilt-corrected and z-shift corrected)
 
-  // tracklet position is also given in sector coordinates
-  std::array<float, constants::NLAYER> trackletYraw{};         ///< y-position of tracklet without tilt correction
-  std::array<float, constants::NLAYER> trackletZraw{};         ///< z-position of tracklet without tilt correction
   std::array<float, constants::NLAYER> trackletY{};            ///< y-position of tracklet used for track update (including correction)
   std::array<float, constants::NLAYER> trackletZ{};            ///< z-position of tracklet used for track update (including correction)
-  std::array<float, constants::NLAYER> trackletDy{};           ///< tracklet deflection over drift length obtained from CalibratedTracklet
-  std::array<int, constants::NLAYER> trackletSlope{};          ///< the raw slope from Tracklet64
-  std::array<int, constants::NLAYER> trackletSlopeSigned{};    ///< the raw slope from Tracklet64 (signed integer)
-  std::array<int, constants::NLAYER> trackletPosition{};       ///< the raw position from Tracklet64
-  std::array<int, constants::NLAYER> trackletPositionSigned{}; ///< the raw position from Tracklet64 (signed integer)
-  std::array<int, constants::NLAYER> trackletDet{};            ///< the chamber of the tracklet
-  // some tracklet details to identify its global MCM number to check if it is from noisy MCM
-  std::array<int, constants::NLAYER> trackletHCId{};                                          ///< the half-chamber ID of the tracklet
-  std::array<int, constants::NLAYER> trackletRob{};                                           ///< the ROB number of the tracklet
-  std::array<int, constants::NLAYER> trackletMcm{};                                           ///< the MCM number of the tracklet
-  std::array<float, constants::NLAYER> trackletChi2{};                                        ///< estimated chi2 for the update of the track with the given tracklet
-  std::array<std::array<int, constants::NCHARGES>, constants::NLAYER> trackletCharges{};      ///< charges of tracklets
+  std::array<float, constants::NLAYER> trackletChi2{};         ///< estimated chi2 for the update of the track with the given tracklet
   std::array<std::array<float, constants::NCHARGES>, constants::NLAYER> trackletCorCharges{}; ///< corrected charges of tracklets
 
-  ClassDefNV(TrackQC, 5);
+  ClassDefNV(TrackQC, 6);
 };
 
 class Tracking
@@ -118,6 +89,9 @@ class Tracking
   /// Check track QC
   void checkTrack(const TrackTRD& trk, bool isTPCTRD);
 
+  /// Disable TPC dEdx information
+  void disablePID() { mPID = false; }
+
   // Make output accessible to DPL processor
   std::vector<TrackQC>& getTrackQC() { return mTrackQC; }
 
@@ -132,6 +106,7 @@ class Tracking
   float mMaxStep{o2::base::Propagator::MAX_STEP};    ///< maximum step for propagation
   MatCorrType mMatCorr{MatCorrType::USEMatCorrNONE}; ///< if material correction should be done
   RecoParam mRecoParam;                              ///< parameters required for TRD reconstruction
+  bool mPID{true};                                   ///< if TPC only tracks are not available we don't fill PID info
 
   // QA results
   std::vector<TrackQC> mTrackQC;


### PR DESCRIPTION
@f3sch with this change I try to simplify a bit the tracking QC dataformat. Please check that all the relevant information you need is still available (it should). For example the eta angle does not need to be stored when we keep the full track parameters. Then you can simply get it from e.g. `trackTRD.getEta()`.
In the beginning I wanted to have this class compatible to what was done in AliRoot, but now I anyhow have to redo the scripts I used back then and therefore I wanted to clean up.
Also it is now possible to disable the PID information, because the workflow otherwise crashes if only ITS-TPC-TRD tracks are used as input (like it is done in the synchronous mode for example).