### PR TITLE
Dump debugging information for global tracking from interpolation workflow

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCInterpolationSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCInterpolationSpec.h
@@ -22,6 +22,7 @@
 #include "ReconstructionDataFormats/GlobalTrackID.h"
 #include "DetectorsBase/GRPGeomHelper.h"
 #include "TPCCalibration/VDriftHelper.h"
+#include "DataFormatsITSMFT/TopologyDictionary.h"
 
 using namespace o2::framework;
 
@@ -37,7 +38,7 @@ namespace tpc
 class TPCInterpolationDPL : public Task
 {
  public:
-  TPCInterpolationDPL(std::shared_ptr<o2::globaltracking::DataRequest> dr, std::shared_ptr<o2::base::GRPGeomRequest> gr, bool useMC, bool processITSTPConly, bool sendTrackData) : mDataRequest(dr), mGGCCDBRequest(gr), mUseMC(useMC), mProcessITSTPConly(processITSTPConly), mSendTrackData(sendTrackData) {}
+  TPCInterpolationDPL(std::shared_ptr<o2::globaltracking::DataRequest> dr, std::shared_ptr<o2::base::GRPGeomRequest> gr, bool useMC, bool processITSTPConly, bool sendTrackData, bool debugOutput) : mDataRequest(dr), mGGCCDBRequest(gr), mUseMC(useMC), mProcessITSTPConly(processITSTPConly), mSendTrackData(sendTrackData), mDebugOutput(debugOutput) {}
   ~TPCInterpolationDPL() override = default;
   void init(InitContext& ic) final;
   void run(ProcessingContext& pc) final;
@@ -50,16 +51,18 @@ class TPCInterpolationDPL : public Task
   std::shared_ptr<o2::globaltracking::DataRequest> mDataRequest; ///< steers the input
   std::shared_ptr<o2::base::GRPGeomRequest> mGGCCDBRequest;
   o2::tpc::VDriftHelper mTPCVDriftHelper{};
+  const o2::itsmft::TopologyDictionary* mITSDict = nullptr; ///< cluster patterns dictionary
   bool mUseMC{false}; ///< MC flag
   bool mProcessITSTPConly{false}; ///< should also tracks without outer point (ITS-TPC only) be processed?
   bool mProcessSeeds{false};      ///< process not only most complete track, but also its shorter parts
+  bool mDebugOutput{false};       ///< add more information to the output (track points of ITS, TRD and TOF)
   bool mSendTrackData{false};     ///< if true, not only the clusters but also corresponding track data will be sent
   uint32_t mSlotLength{600u};     ///< the length of one calibration slot required to calculate max number of tracks per TF
   TStopwatch mTimer;
 };
 
 /// create a processor spec
-framework::DataProcessorSpec getTPCInterpolationSpec(o2::dataformats::GlobalTrackID::mask_t src, bool useMC, bool processITSTPConly, bool sendTrackData);
+framework::DataProcessorSpec getTPCInterpolationSpec(o2::dataformats::GlobalTrackID::mask_t src, bool useMC, bool processITSTPConly, bool sendTrackData, bool debugOutput);
 
 } // namespace tpc
 } // namespace o2

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCResidualWriterSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/include/TPCInterpolationWorkflow/TPCResidualWriterSpec.h
@@ -22,7 +22,7 @@ namespace tpc
 {
 
 /// create a processor spec
-framework::DataProcessorSpec getTPCResidualWriterSpec(bool writeTrackData);
+framework::DataProcessorSpec getTPCResidualWriterSpec(bool writeTrackData, bool debugOutput);
 
 } // namespace tpc
 } // namespace o2

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCResidualWriterSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/TPCResidualWriterSpec.cxx
@@ -29,7 +29,7 @@ namespace tpc
 template <typename T>
 using BranchDefinition = MakeRootTreeWriterSpec::BranchDefinition<T>;
 
-DataProcessorSpec getTPCResidualWriterSpec(bool writeTrackData)
+DataProcessorSpec getTPCResidualWriterSpec(bool writeTrackData, bool debugOutput)
 {
   bool writeUnfiltered = SpacePointsCalibConfParam::Instance().writeUnfiltered;
   return MakeRootTreeWriterSpec("tpc-residuals-writer",
@@ -39,7 +39,8 @@ DataProcessorSpec getTPCResidualWriterSpec(bool writeTrackData)
                                 BranchDefinition<std::vector<TPCClusterResiduals>>{InputSpec{"residualsUnfiltered", "GLO", "TPCINT_RES", 0}, "residualsUnfiltered", (writeUnfiltered ? 1 : 0)},
                                 BranchDefinition<std::vector<UnbinnedResid>>{InputSpec{"residuals", "GLO", "UNBINNEDRES"}, "residuals"},
                                 BranchDefinition<std::vector<TrackDataCompact>>{InputSpec{"trackRefs", "GLO", "TRKREFS"}, "trackRefs"},
-                                BranchDefinition<std::vector<TrackData>>{InputSpec{"tracks", "GLO", "TRKDATA"}, "tracks", (writeTrackData ? 1 : 0)})();
+                                BranchDefinition<std::vector<TrackData>>{InputSpec{"tracks", "GLO", "TRKDATA"}, "tracks", (writeTrackData ? 1 : 0)},
+                                BranchDefinition<std::vector<TrackDataExtended>>{InputSpec{"trackExt", "GLO", "TRKDATAEXT"}, "trackExt", (debugOutput ? 1 : 0)})();
 }
 
 } // namespace tpc

--- a/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/tpc-interpolation-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/tpcinterpolationworkflow/src/tpc-interpolation-workflow.cxx
@@ -40,6 +40,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"enable-itsonly", VariantType::Bool, false, {"process tracks without outer point (ITS-TPC only)"}},
     {"tracking-sources", VariantType::String, std::string{GID::ALL}, {"comma-separated list of sources to use for tracking"}},
     {"send-track-data", VariantType::Bool, false, {"Send also the track information to the aggregator"}},
+    {"debug-output", VariantType::Bool, false, {"Dump extended tracking information for debugging"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
   std::swap(workflowOptions, options);
@@ -74,12 +75,13 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   useMC = false; // force disabling MC as long as it is not implemented
   auto processITSTPConly = configcontext.options().get<bool>("enable-itsonly");
   auto sendTrackData = configcontext.options().get<bool>("send-track-data");
+  auto debugOutput = configcontext.options().get<bool>("debug-output");
   GID::mask_t src = allowedSources & GID::getSourcesMask(configcontext.options().get<std::string>("tracking-sources"));
   LOG(info) << "Data sources: " << GID::getSourcesNames(src);
 
-  specs.emplace_back(o2::tpc::getTPCInterpolationSpec(src, useMC, processITSTPConly, sendTrackData));
+  specs.emplace_back(o2::tpc::getTPCInterpolationSpec(src, useMC, processITSTPConly, sendTrackData, debugOutput));
   if (!configcontext.options().get<bool>("disable-root-output")) {
-    specs.emplace_back(o2::tpc::getTPCResidualWriterSpec(sendTrackData));
+    specs.emplace_back(o2::tpc::getTPCResidualWriterSpec(sendTrackData, debugOutput));
   }
 
   o2::globaltracking::InputHelper::addInputSpecs(configcontext, specs, src, src, src, useMC);

--- a/Detectors/TPC/calibration/SpacePoints/CMakeLists.txt
+++ b/Detectors/TPC/calibration/SpacePoints/CMakeLists.txt
@@ -21,6 +21,7 @@ o2_add_library(SpacePoints
                                      O2::TRDBase
                                      O2::TPCReconstruction
                                      O2::TPCFastTransformation
+                                     O2::ITStracking
                                      O2::DetectorsCalibration
                                      O2::DataFormatsITS
                                      O2::DataFormatsITSMFT

--- a/Detectors/TPC/calibration/SpacePoints/src/SpacePointCalibLinkDef.h
+++ b/Detectors/TPC/calibration/SpacePoints/src/SpacePointCalibLinkDef.h
@@ -21,6 +21,8 @@
 #pragma link C++ class std::vector < o2::tpc::TrackDataCompact> + ;
 #pragma link C++ class o2::tpc::TrackData + ;
 #pragma link C++ class std::vector < o2::tpc::TrackData> + ;
+#pragma link C++ class o2::tpc::TrackDataExtended + ;
+#pragma link C++ class std::vector < o2::tpc::TrackDataExtended> + ;
 #pragma link C++ class o2::tpc::TPCClusterResiduals + ;
 #pragma link C++ class std::vector < o2::tpc::TPCClusterResiduals> + ;
 #pragma link C++ class o2::tpc::TrackResiduals::LocalResid + ;

--- a/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
+++ b/Detectors/TPC/calibration/SpacePoints/src/TrackInterpolation.cxx
@@ -17,6 +17,7 @@
 
 #include "SpacePoints/TrackInterpolation.h"
 #include "SpacePoints/TrackResiduals.h"
+#include "ITStracking/IOUtils.h"
 #include "TPCBase/ParameterElectronics.h"
 #include "DataFormatsTPC/TrackTPC.h"
 #include "DataFormatsTPC/Defs.h"
@@ -77,6 +78,20 @@ void TrackInterpolation::process(const o2::globaltracking::RecoContainer& inp, c
   mTrackTimes = &trkTimes;
   mTPCTracksClusIdx = mRecoCont->getTPCTracksClusterRefs();
   mTPCClusterIdxStruct = &mRecoCont->getTPCClusters();
+  if (mDumpTrackPoints) {
+    if (!mITSDict) {
+      LOG(error) << "No ITS dictionary available";
+      return;
+    }
+    mITSTrackClusIdx = mRecoCont->getITSTracksClusterRefs();
+    const auto clusITS = mRecoCont->getITSClusters();
+    const auto patterns = mRecoCont->getITSClustersPatterns();
+    auto pattIt = patterns.begin();
+    mITSClustersArray.clear();
+    mITSClustersArray.reserve(clusITS.size());
+    LOGP(info, "We have {} ITS clusters and the number of patterns is {}", clusITS.size(), patterns.size());
+    o2::its::ioutils::convertCompactClusters(clusITS, pattIt, mITSClustersArray, mITSDict);
+  }
 
   int nSeeds = mSeeds->size();
   mTrackData.reserve(nSeeds);
@@ -157,12 +172,26 @@ void TrackInterpolation::process(const o2::globaltracking::RecoContainer& inp, c
 
 void TrackInterpolation::interpolateTrack(int iSeed)
 {
+  LOGP(debug, "Starting track interpolation for seed {}", iSeed);
   TrackData trackData;
+  std::unique_ptr<TrackDataExtended> trackDataExtended;
   std::vector<TPCClusterResiduals> clusterResiduals;
   auto propagator = o2::base::Propagator::Instance();
   const auto& gidTable = (*mGIDtables)[iSeed];
   const auto& trkTPC = mRecoCont->getTPCTrack(gidTable[GTrackID::TPC]);
   const auto& trkITS = mRecoCont->getITSTrack(gidTable[GTrackID::ITS]);
+  if (mDumpTrackPoints) {
+    trackDataExtended = std::make_unique<TrackDataExtended>();
+    (*trackDataExtended).gid = (*mGIDs)[iSeed];
+    (*trackDataExtended).clIdx.setFirstEntry(mClRes.size());
+    (*trackDataExtended).trkITS = trkITS;
+    auto nCl = trkITS.getNumberOfClusters();
+    auto clEntry = trkITS.getFirstClusterEntry();
+    for (int iCl = nCl - 1; iCl >= 0; iCl--) { // clusters are stored from outer to inner layers
+      const auto& clsITS = mITSClustersArray[mITSTrackClusIdx[clEntry + iCl]];
+      (*trackDataExtended).clsITS.push_back(clsITS);
+    }
+  }
   auto& trkWork = (*mSeeds)[iSeed];
   // reset the cache array (sufficient to set cluster available to zero)
   for (auto& elem : mCache) {
@@ -212,6 +241,10 @@ void TrackInterpolation::interpolateTrack(int iSeed)
   if (gidTable[GTrackID::TOF].isIndexSet()) {
     LOG(debug) << "TOF point available";
     const auto& clTOF = mRecoCont->getTOFClusters()[gidTable[GTrackID::TOF]];
+    if (mDumpTrackPoints) {
+      (*trackDataExtended).clsTOF = clTOF;
+      (*trackDataExtended).matchTOF = mRecoCont->getTOFMatch((*mGIDs)[iSeed]);
+    }
     const int clTOFSec = clTOF.getCount();
     const float clTOFAlpha = o2::math_utils::sector2Angle(clTOFSec);
     if (!trkWork.rotate(clTOFAlpha)) {
@@ -235,6 +268,9 @@ void TrackInterpolation::interpolateTrack(int iSeed)
   if (gidTable[GTrackID::TRD].isIndexSet()) {
     LOG(debug) << "TRD available";
     const auto& trkTRD = mRecoCont->getITSTPCTRDTrack<o2::trd::TrackTRD>(gidTable[GTrackID::ITSTPCTRD]);
+    if (mDumpTrackPoints) {
+      (*trackDataExtended).trkTRD = trkTRD;
+    }
     for (int iLayer = o2::trd::constants::NLAYER - 1; iLayer >= 0; --iLayer) {
       int trkltIdx = trkTRD.getTrackletIndex(iLayer);
       if (trkltIdx < 0) {
@@ -243,6 +279,10 @@ void TrackInterpolation::interpolateTrack(int iSeed)
       }
       const auto& trdSP = mRecoCont->getTRDCalibratedTracklets()[trkltIdx];
       const auto& trdTrklt = mRecoCont->getTRDTracklets()[trkltIdx];
+      if (mDumpTrackPoints) {
+        (*trackDataExtended).trkltTRD.push_back(trdTrklt);
+        (*trackDataExtended).clsTRD.push_back(trdSP);
+      }
       auto trkltDet = trdTrklt.getDetector();
       auto trkltSec = trkltDet / (o2::trd::constants::NLAYER * o2::trd::constants::NSTACK);
       if (trkltSec != o2::math_utils::angle2Sector(trkWork.getAlpha())) {
@@ -272,6 +312,10 @@ void TrackInterpolation::interpolateTrack(int iSeed)
         return;
       }
     }
+  }
+
+  if (mDumpTrackPoints) {
+    (*trackDataExtended).trkOuter = trkWork;
   }
 
   // go back through the TPC and store updated track positions
@@ -350,6 +394,10 @@ void TrackInterpolation::interpolateTrack(int iSeed)
     }
     trackData.clIdx.setEntries(nClValidated);
     mTrackData.push_back(std::move(trackData));
+    if (mDumpTrackPoints) {
+      (*trackDataExtended).clIdx.setEntries(nClValidated);
+      mTrackDataExtended.push_back(std::move(*trackDataExtended));
+    }
     mGIDsSuccess.push_back((*mGIDs)[iSeed]);
     mTrackDataCompact.emplace_back(mClRes.size() - nClValidated, nClValidated, (*mGIDs)[iSeed].getSource());
   }
@@ -815,6 +863,7 @@ void TrackInterpolation::reset()
 {
   mTrackData.clear();
   mTrackDataCompact.clear();
+  mTrackDataExtended.clear();
   mClRes.clear();
   mTrackDataUnfiltered.clear();
   mClResUnfiltered.clear();


### PR DESCRIPTION
Opening a draft PR for discussion.

@shahor02 when I have the ITS clusters stored inside `mITSClustersArray` which is of the type `std::vector<o2::BaseCluster<float>>` how can I convert the position into the global coordinate frame? In BaseCluster.h it says the position is stored in tracking frame so I think it is rotated to the angle of the stave which I can get from the Sensor ID, right?
My goal is to dump (optionally) all the relevant global tracking information into a single output file of the TPC interpolation workflow, so all track points and the different track parameterizations (ITS, ITS-TPC, ITS-TPC-TRD, ...).