### PR TITLE
Mem leak fixes for client side CCDB

### DIFF
--- a/CCDB/include/CCDB/CCDBDownloader.h
+++ b/CCDB/include/CCDB/CCDBDownloader.h
@@ -113,7 +113,7 @@ class CCDBDownloader
    *
    * @param handles Handles to be performed on.
    */
-  std::vector<CURLcode>* asynchBatchPerformWithCallback(std::vector<CURL*> const& handles, bool* completionFlag, void (*cbFun)(void*), void* cbData);
+  std::vector<CURLcode> asynchBatchPerformWithCallback(std::vector<CURL*> const& handles, bool* completionFlag, void (*cbFun)(void*), void* cbData);
 
   /**
    * Perform on a batch of handles in a blocking manner. Has the same effect as calling curl_easy_perform() on all handles in the vector.
@@ -126,7 +126,7 @@ class CCDBDownloader
    * @param handleVector Handles to be performed on.
    * @param completionFlag Should be set to false before passing it to this function. Will be set to true after all transfers finish.
    */
-  std::vector<CURLcode>* batchAsynchPerform(std::vector<CURL*> const& handleVector, bool* completionFlag);
+  std::vector<CURLcode> batchAsynchPerform(std::vector<CURL*> const& handleVector, bool* completionFlag);
 
   /**
    * Limits the number of parallel connections. Should be used only if no transfers are happening.
@@ -210,6 +210,8 @@ class CCDBDownloader
     CCDBDownloader* CD;
     CURLM* curlm;
   } DataForSocket;
+
+  DataForSocket mSocketData;
 
   /**
    * Structure which is stored in a easy_handle. It carries information about the request which the easy_handle is part of.

--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -486,8 +486,8 @@ class CcdbApi //: public DatabaseInterface
 
   void initCurlOptionsForRetrieve(CURL* curlHandle, void* pointer, CurlWriteCallback writeCallback, bool followRedirect = true) const;
 
-  void initHeadersForRetrieve(CURL* curlHandle, long timestamp, std::map<std::string, std::string>* headers, std::string const& etag,
-                              const std::string& createdNotAfter, const std::string& createdNotBefore) const;
+  /// initialize HTTPS header information for the CURL handle. Needs to be given an existing curl_slist* pointer to work with (may be nullptr), which needs to be free by the caller.
+  void initCurlHTTPHeaderOptionsForRetrieve(CURL* curlHandle, curl_slist*& option_list, long timestamp, std::map<std::string, std::string>* headers, std::string const& etag, const std::string& createdNotAfter, const std::string& createdNotBefore) const;
 
   bool receiveToFile(FILE* fileHandle, std::string const& path, std::map<std::string, std::string> const& metadata,
                      long timestamp, std::map<std::string, std::string>* headers = nullptr, std::string const& etag = "",

--- a/CCDB/test/testCcdbApiDownloader.cxx
+++ b/CCDB/test/testCcdbApiDownloader.cxx
@@ -141,7 +141,7 @@ BOOST_AUTO_TEST_CASE(asynch_batch_test)
     sleep(1);
   }
 
-  for (CURLcode code : (*curlCodes)) {
+  for (CURLcode code : curlCodes) {
     BOOST_CHECK(code == CURLE_OK);
     if (code != CURLE_OK) {
       std::cout << "CURL Code: " << code << "\n";
@@ -250,7 +250,7 @@ BOOST_AUTO_TEST_CASE(asynch_batch_callback)
 
   BOOST_CHECK(testValue == 46);
 
-  for (CURLcode code : (*curlCodes)) {
+  for (CURLcode code : curlCodes) {
     BOOST_CHECK(code == CURLE_OK);
     if (code != CURLE_OK) {
       std::cout << "CURL Code: " << code << "\n";


### PR DESCRIPTION
Some (minor) mem leak fixes. Complements mem leak fixes on the JAliEn-ROOT (https://gitlab.cern.ch/jalien/jalien-root/-/merge_requests/70) side to have much more stable fetching of CCDB objects.