### PR TITLE
Fix error introduced by adding FOCAL to DetID

### DIFF
--- a/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/SimTraits.h
+++ b/DataFormats/Detectors/Common/include/DetectorsCommonDataFormats/SimTraits.h
@@ -88,7 +88,8 @@ class SimTraits
       /*FV0*/ VS{ "FV0Hit" },
       /*FDD*/ VS{ "FDDHit" },
       /*TST*/ VS{ "TSTHit" }, // former ACO
-      /*CTP*/ VS{ "CTPHit" }
+      /*CTP*/ VS{ "CTPHit" },
+      /*FOC*/ VS{ "FOCHit" }
 #ifdef ENABLE_UPGRADES
       ,
       /*IT3*/ VS{ "IT3Hit" },


### PR DESCRIPTION
This PR fixes the modification introduced in https://github.com/AliceO2Group/AliceO2/pull/10946, which breaks the simulation of upgrade detectors (the DetID has been shifted by 1 unity, but not in the Hit names). @mfasDa could you please have a look that it is fine with you?