### PR TITLE
MCH: rename output of error merger to avoid duplicate name

### DIFF
--- a/Detectors/MUON/MCH/Workflow/README.md
+++ b/Detectors/MUON/MCH/Workflow/README.md
@@ -204,7 +204,7 @@ Refit the tracks to their associated clusters. [more...](/Detectors/MUON/MCH/Tra
 o2-mch-errors-merger-workflow
 ```
 
-Take as input the list of all MCH preclustering, clustering and tracking errors ([Error](../Base/include/MCHBase/Error.h)) in the current time frame, with the data description "PRECLUSTERERRORS", "CLUSTERERRORS" and "TRACKERRORS", respectively. Send the merged list of all MCH processing errors ([Error](../Base/include/MCHBase/Error.h)) in the time frame, with the data description "ERRORS".
+Take as input the list of all MCH preclustering, clustering and tracking errors ([Error](../Base/include/MCHBase/Error.h)) in the current time frame, with the data description "PRECLUSTERERRORS", "CLUSTERERRORS" and "TRACKERRORS", respectively. Send the merged list of all MCH processing errors ([Error](../Base/include/MCHBase/Error.h)) in the time frame, with the data description "PROCERRORS".
 
 Options `--disable-preclustering-errors` allows to skip the preclustering errors.
 

--- a/Detectors/MUON/MCH/Workflow/README.md
+++ b/Detectors/MUON/MCH/Workflow/README.md
@@ -226,7 +226,7 @@ binary format(s). [more...](/Detectors/MUON/MCH/DevIO/README.md)
 o2-mch-errors-reader-workflow --infile mcherrors.root
 ```
 
-Send the list of all MCH processing errors ([Error](../Base/include/MCHBase/Error.h)) in the current time frame, with the data description "ERRORS".
+Send the list of all MCH processing errors ([Error](../Base/include/MCHBase/Error.h)) in the current time frame, with the data description "PROCERRORS".
 
 Option `--input-dir` allows to set the name of the directory containing the input file (default = current directory).
 
@@ -253,4 +253,4 @@ If no binary file is provided, the vertex is always set to (0,0,0).
 o2-mch-errors-writer-workflow
 ```
 
-Take as input the list of all MCH processing errors ([Error](../Base/include/MCHBase/Error.h)) in the current time frame, with the data description "ERRORS", and write it in the root file "mcherrors.root".
+Take as input the list of all MCH processing errors ([Error](../Base/include/MCHBase/Error.h)) in the current time frame, with the data description "PROCERRORS", and write it in the root file "mcherrors.root".

--- a/Detectors/MUON/MCH/Workflow/src/ErrorMergerSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/ErrorMergerSpec.cxx
@@ -97,7 +97,7 @@ DataProcessorSpec getErrorMergerSpec(const char* specName, bool preclustering, b
   return DataProcessorSpec{
     specName,
     inputSpecs,
-    Outputs{OutputSpec{{"errors"}, "MCH", "ERRORS", 0, Lifetime::Timeframe}},
+    Outputs{OutputSpec{{"errors"}, "MCH", "PROCERRORS", 0, Lifetime::Timeframe}},
     adaptFromTask<ErrorMergerTask>(preclustering, clustering, tracking),
     Options{}};
 }

--- a/Detectors/MUON/MCH/Workflow/src/ErrorReaderSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/ErrorReaderSpec.cxx
@@ -44,7 +44,7 @@ struct ErrorReader {
       fileName.c_str(),
       -1,
       RootTreeReader::PublishingMode::Single,
-      RootTreeReader::BranchDefinition<std::vector<Error>>{Output{"MCH", "ERRORS", 0}, "errors"});
+      RootTreeReader::BranchDefinition<std::vector<Error>>{Output{"MCH", "PROCERRORS", 0}, "errors"});
   }
 
   void run(ProcessingContext& pc)
@@ -62,7 +62,7 @@ DataProcessorSpec getErrorReaderSpec(const char* specName)
   return DataProcessorSpec{
     specName,
     Inputs{},
-    Outputs{OutputSpec{{"errors"}, "MCH", "ERRORS", 0, Lifetime::Timeframe}},
+    Outputs{OutputSpec{{"errors"}, "MCH", "PROCERRORS", 0, Lifetime::Timeframe}},
     adaptFromTask<ErrorReader>(),
     Options{{"infile", VariantType::String, "mcherrors.root", {"name of the input error file"}},
             {"input-dir", VariantType::String, "none", {"Input directory"}}}};

--- a/Detectors/MUON/MCH/Workflow/src/ErrorWriterSpec.cxx
+++ b/Detectors/MUON/MCH/Workflow/src/ErrorWriterSpec.cxx
@@ -28,7 +28,7 @@ DataProcessorSpec getErrorWriterSpec(const char* specName)
   return MakeRootTreeWriterSpec(specName,
                                 "mcherrors.root",
                                 MakeRootTreeWriterSpec::TreeAttributes{"o2sim", "Tree MCH Errors"},
-                                BranchDefinition<std::vector<Error>>{InputSpec{"errors", "MCH", "ERRORS"}, "errors"})();
+                                BranchDefinition<std::vector<Error>>{InputSpec{"errors", "MCH", "PROCERRORS"}, "errors"})();
 }
 
 } // namespace o2::mch


### PR DESCRIPTION
Otherwise MCH/ERROR/0 is used both by the error merger and the data decoder(s).