### PR TITLE
MC: Improvements for consistent MeanVertex handling

### DIFF
--- a/CCDB/include/CCDB/BasicCCDBManager.h
+++ b/CCDB/include/CCDB/BasicCCDBManager.h
@@ -169,6 +169,11 @@ class CCDBManagerInstance
   /// On error it fatals (if fatal == true) or else returns the pair -1, -1.
   std::pair<int64_t, int64_t> getRunDuration(int runnumber, bool fatal = true) const;
 
+  /// A convenience function for MC to fetch
+  /// valid start and end timestamps given an ALICE run number.
+  /// On error it fatals (if fatal == true) or else returns the pair -1, -1.
+  static std::pair<int64_t, int64_t> getRunDuration(o2::ccdb::CcdbApi const& api, int runnumber, bool fatal = true);
+
   std::string getSummaryString() const;
 
   void endOfStream();

--- a/CCDB/src/BasicCCDBManager.cxx
+++ b/CCDB/src/BasicCCDBManager.cxx
@@ -32,9 +32,9 @@ void CCDBManagerInstance::reportFatal(std::string_view err)
   LOG(fatal) << err;
 }
 
-std::pair<int64_t, int64_t> CCDBManagerInstance::getRunDuration(int runnumber, bool fatal) const
+std::pair<int64_t, int64_t> CCDBManagerInstance::getRunDuration(o2::ccdb::CcdbApi const& api, int runnumber, bool fatal)
 {
-  auto response = mCCDBAccessor.retrieveHeaders("RCT/Info/RunInformation", std::map<std::string, std::string>(), runnumber);
+  auto response = api.retrieveHeaders("RCT/Info/RunInformation", std::map<std::string, std::string>(), runnumber);
   if (response.size() == 0 || response.find("SOR") == response.end() || response.find("EOR") == response.end()) {
     if (fatal) {
       LOG(fatal) << "Empty or missing response from query to RCT/Info/RunInformation for run " << runnumber;
@@ -45,6 +45,11 @@ std::pair<int64_t, int64_t> CCDBManagerInstance::getRunDuration(int runnumber, b
   auto sor = boost::lexical_cast<int64_t>(response["SOR"]);
   auto eor = boost::lexical_cast<int64_t>(response["EOR"]);
   return std::make_pair(sor, eor);
+}
+
+std::pair<int64_t, int64_t> CCDBManagerInstance::getRunDuration(int runnumber, bool fatal) const
+{
+  return CCDBManagerInstance::getRunDuration(mCCDBAccessor, runnumber, fatal);
 }
 
 std::string CCDBManagerInstance::getSummaryString() const

--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -711,8 +711,12 @@ bool CcdbApi::retrieveBlob(std::string const& path, std::string const& targetdir
     TFile snapshotfile(targetpath.c_str(), "UPDATE");
     // The assumption is that the blob is a ROOT file
     if (!snapshotfile.IsZombie()) {
-      snapshotfile.WriteObjectAny(&querysummary, TClass::GetClass(typeid(querysummary)), CCDBQUERY_ENTRY);
-      snapshotfile.WriteObjectAny(&headers, TClass::GetClass(typeid(metadata)), CCDBMETA_ENTRY);
+      if (!snapshotfile.Get(CCDBQUERY_ENTRY)) {
+        snapshotfile.WriteObjectAny(&querysummary, TClass::GetClass(typeid(querysummary)), CCDBQUERY_ENTRY);
+      }
+      if (!snapshotfile.Get(CCDBMETA_ENTRY)) {
+        snapshotfile.WriteObjectAny(&headers, TClass::GetClass(typeid(metadata)), CCDBMETA_ENTRY);
+      }
       snapshotfile.Close();
     }
     gErrorIgnoreLevel = oldlevel;

--- a/Common/SimConfig/CMakeLists.txt
+++ b/Common/SimConfig/CMakeLists.txt
@@ -15,6 +15,7 @@ o2_add_library(SimConfig
                        src/SimUserDecay.cxx
                        src/DigiParams.cxx src/G4Params.cxx
                        src/MatMapParams.cxx
+                       src/InteractionDiamondParam.cxx
                PUBLIC_LINK_LIBRARIES O2::CommonUtils
                                      O2::DetectorsCommonDataFormats O2::SimulationDataFormat
                                      FairRoot::Base Boost::program_options)
@@ -24,7 +25,8 @@ o2_target_root_dictionary(SimConfig
                           HEADERS include/SimConfig/SimConfig.h
                                   include/SimConfig/SimParams.h
                                   include/SimConfig/SimUserDecay.h
-		include/SimConfig/DigiParams.h
+                                  include/SimConfig/InteractionDiamondParam.h
+		                  include/SimConfig/DigiParams.h
                                   include/SimConfig/G4Params.h
                                   include/SimConfig/MatMapParams.h)
 

--- a/Common/SimConfig/include/SimConfig/InteractionDiamondParam.h
+++ b/Common/SimConfig/include/SimConfig/InteractionDiamondParam.h
@@ -30,8 +30,8 @@ enum class EVertexDistribution {
 
 /**
  ** a parameter class/struct to keep the settings of
- ** the interaction diamond (position and width) and 
- ** allow the user to modify them 
+ ** the interaction diamond (position and width) and
+ ** allow the user to modify them
  **/
 struct InteractionDiamondParam : public o2::conf::ConfigurableParamHelper<InteractionDiamondParam> {
   double position[3] = {0., 0., 0.};

--- a/Common/SimConfig/include/SimConfig/SimConfig.h
+++ b/Common/SimConfig/include/SimConfig/SimConfig.h
@@ -20,13 +20,19 @@ namespace o2
 namespace conf
 {
 
-enum SimFieldMode {
+enum class SimFieldMode {
   kDefault = 0,
   kUniform = 1,
   kCCDB = 2
 };
 
-enum TimeStampMode {
+enum class VertexMode {
+  kNoVertex = 0,     // no vertexing should be applied in the generator
+  kDiamondParam = 1, // Diamond param will influence vertexing
+  kCCDB = 2          // vertex should be taken from CCDB (Calib/MeanVertex object)
+};
+
+enum class TimeStampMode {
   kNow = 0,
   kManual = 1,
   kRun = 2
@@ -61,16 +67,17 @@ struct SimConfigData {
   bool mFilterNoHitEvents = false;            // whether to filter out events not leaving any response
   std::string mCCDBUrl;                       // the URL where to find CCDB
   uint64_t mTimestamp;                        // timestamp in ms to anchor transport simulation to
-  TimeStampMode mTimestampMode = kNow;        // telling of timestamp was given as option or defaulted to now
+  TimeStampMode mTimestampMode = TimeStampMode::kNow; // telling of timestamp was given as option or defaulted to now
   int mRunNumber = -1;                        // ALICE run number (if set != -1); the timestamp should be compatible
   int mField;                                 // L3 field setting in kGauss: +-2,+-5 and 0
-  SimFieldMode mFieldMode = kDefault;         // uniform magnetic field
+  SimFieldMode mFieldMode = SimFieldMode::kDefault; // uniform magnetic field
   bool mAsService = false;                    // if simulation should be run as service/deamon (does not exit after run)
   bool mNoGeant = false;                      // if Geant transport should be turned off (when one is only interested in the generated events)
   bool mIsRun5 = false;                       // true if the simulation is for Run 5
   std::string mFromCollisionContext = "";     // string denoting a collision context file; If given, this file will be used to determine number of events
   bool mForwardKine = false;                  // true if tracks and event headers are to be published on a FairMQ channel (for reading by other consumers)
   bool mWriteToDisc = true;                   // whether we write simulation products (kine, hits) to disc
+  VertexMode mVertexMode = VertexMode::kDiamondParam; // by default we should use die InteractionDiamond parameter
 
   ClassDefNV(SimConfigData, 4);
 };
@@ -129,6 +136,8 @@ class SimConfig
 
   // helper to parse field option
   static bool parseFieldString(std::string const& fieldstring, int& fieldvalue, o2::conf::SimFieldMode& mode);
+  // helper to parse vertex option; returns true if parsing ok, false if failure
+  static bool parseVertexModeString(std::string const& vertexstring, o2::conf::VertexMode& mode);
 
   // get selected generator (to be used to select a genconfig)
   std::string getGenerator() const { return mConfigData.mGenerator; }
@@ -157,6 +166,7 @@ class SimConfig
   void setRun5(bool value = true) { mConfigData.mIsRun5 = value; }
   bool forwardKine() const { return mConfigData.mForwardKine; }
   bool writeToDisc() const { return mConfigData.mWriteToDisc; }
+  VertexMode getVertexMode() const { return mConfigData.mVertexMode; }
 
  private:
   SimConfigData mConfigData; //!

--- a/Common/SimConfig/src/InteractionDiamondParam.cxx
+++ b/Common/SimConfig/src/InteractionDiamondParam.cxx
@@ -11,5 +11,5 @@
 
 /// \author R+Preghenella - October 2018
 
-#include "Generators/InteractionDiamondParam.h"
+#include "SimConfig/InteractionDiamondParam.h"
 O2ParamImpl(o2::eventgen::InteractionDiamondParam);

--- a/Common/SimConfig/src/SimConfigLinkDef.h
+++ b/Common/SimConfig/src/SimConfigLinkDef.h
@@ -36,4 +36,7 @@
 #pragma link C++ struct o2::conf::MatMapParams + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::conf::MatMapParams> + ;
 
+#pragma link C++ class o2::eventgen::InteractionDiamondParam + ;
+#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::eventgen::InteractionDiamondParam> + ;
+
 #endif

--- a/Generators/CMakeLists.txt
+++ b/Generators/CMakeLists.txt
@@ -30,7 +30,6 @@ o2_add_library(Generators
                        src/GeneratorFromFile.cxx
                        src/GeneratorFromO2KineParam.cxx
                        src/PrimaryGenerator.cxx
-                       src/InteractionDiamondParam.cxx
                        src/TriggerExternalParam.cxx
                        src/TriggerParticleParam.cxx
                        src/BoxGunParam.cxx
@@ -72,7 +71,6 @@ set(headers
     include/Generators/GeneratorFromFile.h
     include/Generators/GeneratorFromO2KineParam.h
     include/Generators/PrimaryGenerator.h
-    include/Generators/InteractionDiamondParam.h
     include/Generators/TriggerExternalParam.h
     include/Generators/TriggerParticleParam.h
     include/Generators/BoxGunParam.h

--- a/Generators/include/Generators/PrimaryGenerator.h
+++ b/Generators/include/Generators/PrimaryGenerator.h
@@ -15,6 +15,8 @@
 #define ALICEO2_EVENTGEN_PRIMARYGENERATOR_H_
 
 #include "FairPrimaryGenerator.h"
+#include "DataFormatsCalibration/MeanVertexObject.h"
+#include "SimConfig/SimConfig.h"
 
 class TFile;
 class TTree;
@@ -80,11 +82,14 @@ class PrimaryGenerator : public FairPrimaryGenerator
 
   void setExternalVertexForNextEvent(double x, double y, double z);
 
+  // sets the vertex mode; if mode is kCCDB, a valid MeanVertexObject pointer must be given at the same time
+  void setVertexMode(o2::conf::VertexMode const& mode, o2::dataformats::MeanVertexObject const* obj = nullptr);
+
  protected:
   /** copy constructor **/
-  PrimaryGenerator(const PrimaryGenerator&) = default;
+  // PrimaryGenerator(const PrimaryGenerator&) = default;
   /** operator= **/
-  PrimaryGenerator& operator=(const PrimaryGenerator&) = default;
+  // PrimaryGenerator& operator=(const PrimaryGenerator&) = default;
 
   /** set interaction diamond position **/
   void setInteractionDiamond(const Double_t* xyz, const Double_t* sigmaxyz);
@@ -104,6 +109,9 @@ class PrimaryGenerator : public FairPrimaryGenerator
   Int_t mEmbedEntries = 0;
   Int_t mEmbedIndex = 0;
   o2::dataformats::MCEventHeader* mEmbedEvent = nullptr;
+
+  o2::conf::VertexMode mVertexMode = o2::conf::VertexMode::kDiamondParam; // !vertex mode
+  std::unique_ptr<o2::dataformats::MeanVertexObject> mMeanVertex;
 
   ClassDefOverride(PrimaryGenerator, 2);
 

--- a/Generators/src/GeneratorsLinkDef.h
+++ b/Generators/src/GeneratorsLinkDef.h
@@ -56,8 +56,6 @@
 #pragma link C++ class o2::eventgen::PrimaryGenerator + ;
 
 #pragma link C++ enum o2::eventgen::EVertexDistribution;
-#pragma link C++ class o2::eventgen::InteractionDiamondParam + ;
-#pragma link C++ class o2::conf::ConfigurableParamHelper < o2::eventgen::InteractionDiamondParam> + ;
 #pragma link C++ class o2::eventgen::TriggerExternalParam + ;
 #pragma link C++ class o2::conf::ConfigurableParamHelper < o2::eventgen::TriggerExternalParam> + ;
 #pragma link C++ class o2::eventgen::TriggerParticleParam + ;

--- a/Steer/include/Steer/O2MCApplication.h
+++ b/Steer/include/Steer/O2MCApplication.h
@@ -63,7 +63,6 @@ class O2MCApplication : public O2MCApplicationBase
       det->EndOfEvent();
     }
     fStack->Reset();
-    LOG(info) << "This event/chunk did " << mStepCounter << " steps";
   }
 
   /** Define actions at the end of run */

--- a/Steer/src/CollisionContextTool.cxx
+++ b/Steer/src/CollisionContextTool.cxx
@@ -18,7 +18,7 @@
 #include "CommonDataFormat/InteractionRecord.h"
 #include "DataFormatsCalibration/MeanVertexObject.h"
 #include "SimulationDataFormat/DigitizationContext.h"
-#include "Generators/InteractionDiamondParam.h"
+#include "SimConfig/InteractionDiamondParam.h"
 #include <cmath>
 #include <TRandom.h>
 #include <numeric>
@@ -132,6 +132,7 @@ InteractionSpec parseInteractionSpec(std::string const& specifier, std::vector<I
       collisionsavail = mcreader.getNEvents(0);
     }
   }
+  LOG(info) << "Collisions avail for " << name << " " << collisionsavail;
 
   // extract interaction rate ... or locking
   auto& interactionToken = tokens[1];

--- a/run/O2SimDevice.h
+++ b/run/O2SimDevice.h
@@ -248,6 +248,7 @@ class O2SimDevice final : public fair::mq::Device
             LOG(info) << workerStr() << " Processing " << chunk->mParticles.size() << " primary particles "
                       << "for event " << info.eventID << "/" << info.maxEvents << " "
                       << "part " << info.part << "/" << info.nparts;
+            LOG(info) << "Setting seed for this sub-event to " << chunk->mSubEventInfo.seed;
             gRandom->SetSeed(chunk->mSubEventInfo.seed);
 
             // Process one event

--- a/run/o2sim_parallel.cxx
+++ b/run/o2sim_parallel.cxx
@@ -369,12 +369,12 @@ std::vector<char*> checkArgs(int argc, char* argv[])
       auto& ccdbmgr = o2::ccdb::BasicCCDBManager::instance();
       auto soreor = ccdbmgr.getRunDuration(conf.getRunNumber());
       auto timestamp = conf.getTimestamp();
-      if (conf.getConfigData().mTimestampMode == o2::conf::kNow) {
+      if (conf.getConfigData().mTimestampMode == o2::conf::TimeStampMode::kNow) {
         timestamp = soreor.first;
         LOG(info) << "Fixing timestamp to " << timestamp << " based on run number";
         modifiedArgs.push_back("--timestamp");
         modifiedArgs.push_back(std::to_string(timestamp));
-      } else if (conf.getConfigData().mTimestampMode == o2::conf::kManual && (timestamp < soreor.first || timestamp > soreor.second)) {
+      } else if (conf.getConfigData().mTimestampMode == o2::conf::TimeStampMode::kManual && (timestamp < soreor.first || timestamp > soreor.second)) {
         LOG(fatal) << "The given timestamp is incompatible with the given run number";
       }
     }


### PR DESCRIPTION
This commit provides the foundation to anchor Monte Carlo jobs against a CCDB GLO/Calib/MeanVertex object consistently, or to engineer such objects for MC studies.

The list of changes is the following:

* new option for o2-sim to pick up Vertex from CCDB (instead of Diamond ConfigValues)

* changes in PrimaryGenerator to use GLO/Calib/MeanVertex object

* move of InteractionDiamondParam to a different module (so that GRPTool can more easily link against it)

* add feature to GRPTool to setup/engineer a MeanVertex object for the Monte Carlo chain

* unrelated stability fix in CcdbApi preventing that meta-information is added more than once

* code improvements in GRPTool (reuse CcdbApi)

* some changes of enum --> enum class for better isolation