### PR TITLE
Optionally ask ccdb-populator to validate upload

### DIFF
--- a/CCDB/include/CCDB/CcdbObjectInfo.h
+++ b/CCDB/include/CCDB/CcdbObjectInfo.h
@@ -44,8 +44,8 @@ class CcdbObjectInfo
   }
   CcdbObjectInfo(std::string path, std::string objType, std::string flName,
                  std::map<std::string, std::string> metadata,
-                 long startValidityTimestamp, long endValidityTimestamp, bool adjustableEOV = true)
-    : mObjType(std::move(objType)), mFileName(std::move(flName)), mPath(std::move(path)), mMD(std::move(metadata)), mStart(startValidityTimestamp), mEnd(endValidityTimestamp)
+                 long startValidityTimestamp, long endValidityTimestamp, bool adjustableEOV = true, bool validateUpload = false)
+    : mObjType(std::move(objType)), mFileName(std::move(flName)), mPath(std::move(path)), mMD(std::move(metadata)), mStart(startValidityTimestamp), mEnd(endValidityTimestamp), mValidateUpload(validateUpload)
   {
     if (adjustableEOV) {
       setAdjustableEOV();
@@ -82,7 +82,10 @@ class CcdbObjectInfo
     }
   }
 
+  void setValidateUpload(bool v) { mValidateUpload = v; }
+
   bool isAdjustableEOV() const { return mAdjustableEOV; }
+  bool getValidateUpload() const { return mValidateUpload; }
 
   [[nodiscard]] long getStartValidityTimestamp() const { return mStart; }
   void setStartValidityTimestamp(long start) { mStart = start; }
@@ -98,7 +101,8 @@ class CcdbObjectInfo
   long mStart = 0;                        // start of the validity of the object
   long mEnd = 0;                          // end of the validity of the object
   bool mAdjustableEOV = false;            // each new object may override EOV of object it overrides to its own SOV
-  ClassDefNV(CcdbObjectInfo, 2);
+  bool mValidateUpload = false;           // request to validate the upload by querying its header
+  ClassDefNV(CcdbObjectInfo, 3);
 };
 
 } // namespace o2::ccdb


### PR DESCRIPTION
If the `ccdb-populator` is called with the command line option `--validate-upload`, or the `CcdbObjectInfo` for the object was prepared with `setValidateUpload(true)`, then for every uploaded object it will read back its headers and will make sure that they correspond to an object with requested validity ranges and uploaded < 3 seconds ago. 

In case of failure an `ERROR` (or a `FATAL` if `--fatal-on-failure` was passed on the command line) will be logged, 
on success: an `IMPORTANT` (`INFO` in the logger) level message `Validated upload ...` will be logged.

@jotwinow e.g. the messages logged to infologger will be 
```
[FATAL] failed on uploading to http://ccdb-test.cern.ch:8081 / TOF/Calib/LVStatus for [1679660165298:1682252165298]
```
(or `[ERROR]...` if no `--fatal-on-failure` was selected) on failure and 
```
[INFO] Validated upload to http://ccdb-test.cern.ch:8080 / TOF/Calib/DCSDPs for [1679660278052:1679919478052]
```
on success.