### PR TITLE
CcdbApi: code reuse; more consistent header treatment for snapshots

### DIFF
--- a/CCDB/include/CCDB/CcdbApi.h
+++ b/CCDB/include/CCDB/CcdbApi.h
@@ -366,6 +366,9 @@ class CcdbApi //: public DatabaseInterface
 #endif
 
  private:
+  // internal helper function to update a CCDB file with meta information
+  static void updateMetaInformationInLocalFile(std::string const& filename, std::map<std::string, std::string> const* headers, CCDBQuery const* querysummary = nullptr);
+
   // report what file is read and for which purpose
   void logReading(const std::string& path, long ts, const std::map<std::string, std::string>* headers, const std::string& comment) const;
 

--- a/CCDB/src/CcdbApi.cxx
+++ b/CCDB/src/CcdbApi.cxx
@@ -164,6 +164,27 @@ void CcdbApi::init(std::string const& host)
        mInSnapshotMode ? "(snapshot readonly mode)" : snapshotReport.c_str());
 }
 
+// A helper function used in a few places. Updates a ROOT file with meta/header information.
+void CcdbApi::updateMetaInformationInLocalFile(std::string const& filename, std::map<std::string, std::string> const* headers, CCDBQuery const* querysummary)
+{
+  std::lock_guard<std::mutex> guard(gIOMutex);
+  auto oldlevel = gErrorIgnoreLevel;
+  gErrorIgnoreLevel = 6001; // ignoring error messages here (since we catch with IsZombie)
+  TFile snapshotfile(filename.c_str(), "UPDATE");
+  // The assumption is that the blob is a ROOT file
+  if (!snapshotfile.IsZombie()) {
+    if (querysummary && !snapshotfile.Get(CCDBQUERY_ENTRY)) {
+      snapshotfile.WriteObjectAny(querysummary, TClass::GetClass(typeid(*querysummary)), CCDBQUERY_ENTRY);
+    }
+    if (headers && !snapshotfile.Get(CCDBMETA_ENTRY)) {
+      snapshotfile.WriteObjectAny(headers, TClass::GetClass(typeid(*headers)), CCDBMETA_ENTRY);
+    }
+    snapshotfile.Write();
+    snapshotfile.Close();
+  }
+  gErrorIgnoreLevel = oldlevel;
+}
+
 /**
  * Keep only the alphanumeric characters plus '_' plus '/' plus '.' from the string passed in argument.
  * @param objectName
@@ -255,6 +276,11 @@ int CcdbApi::storeAsBinaryFile(const char* buffer, size_t size, const std::strin
     if (!outf.good()) {
       throw std::runtime_error(fmt::format("Failed to write local CCDB file {}", flLoc));
     } else {
+      std::map<std::string, std::string> metaheader(metadata);
+      // add time validity information
+      metaheader["Valid-From"] = std::to_string(startValidityTimestamp);
+      metaheader["Valid-Until"] = std::to_string(endValidityTimestamp);
+      updateMetaInformationInLocalFile(flLoc.c_str(), &metaheader);
       std::string metaStr{};
       for (const auto& mentry : metadata) {
         metaStr += fmt::format("{}={};", mentry.first, mentry.second);
@@ -704,23 +730,8 @@ bool CcdbApi::retrieveBlob(std::string const& path, std::string const& targetdir
     }
   }
   CCDBQuery querysummary(path, metadata, timestamp);
-  {
-    std::lock_guard<std::mutex> guard(gIOMutex);
-    auto oldlevel = gErrorIgnoreLevel;
-    gErrorIgnoreLevel = 6001; // ignoring error messages here (since we catch with IsZombie)
-    TFile snapshotfile(targetpath.c_str(), "UPDATE");
-    // The assumption is that the blob is a ROOT file
-    if (!snapshotfile.IsZombie()) {
-      if (!snapshotfile.Get(CCDBQUERY_ENTRY)) {
-        snapshotfile.WriteObjectAny(&querysummary, TClass::GetClass(typeid(querysummary)), CCDBQUERY_ENTRY);
-      }
-      if (!snapshotfile.Get(CCDBMETA_ENTRY)) {
-        snapshotfile.WriteObjectAny(&headers, TClass::GetClass(typeid(metadata)), CCDBMETA_ENTRY);
-      }
-      snapshotfile.Close();
-    }
-    gErrorIgnoreLevel = oldlevel;
-  }
+
+  updateMetaInformationInLocalFile(targetpath.c_str(), &headers, &querysummary);
   return true;
 }
 
@@ -1525,18 +1536,7 @@ void CcdbApi::loadFileToMemory(o2::pmr::vector<char>& dest, std::string const& p
         std::copy(dest.begin(), dest.end(), std::ostreambuf_iterator<char>(objFile));
       }
       // now open the same file as root file and store metadata
-      std::lock_guard<std::mutex> guard(gIOMutex);
-      auto oldlevel = gErrorIgnoreLevel;
-      gErrorIgnoreLevel = 6001;                       // ignoring error messages here (since we catch with IsZombie)
-      TFile snapshot(snapshotpath.c_str(), "UPDATE"); // the assumption is that the blob is a ROOT file
-      if (!snapshot.IsZombie()) {
-        snapshot.WriteObjectAny(&querysummary, TClass::GetClass(typeid(querysummary)), CCDBQUERY_ENTRY);
-        if (headers) {
-          snapshot.WriteObjectAny(headers, TClass::GetClass(typeid(metadata)), CCDBMETA_ENTRY);
-        }
-      }
-      snapshot.Close();
-      gErrorIgnoreLevel = oldlevel;
+      updateMetaInformationInLocalFile(snapshotpath, headers, &querysummary);
     }
   }
   sem_release();


### PR DESCRIPTION
* a single place to update meta information for local snapshot files

* also put meta information when local file is created through storeAsBinaryFile API --> this is important so that queries to the local snapshot can correctly read back the header information