### PR TITLE
Revert "DPL GUI: only keep two strings for the string metrics"

### DIFF
--- a/Framework/Core/include/Framework/DeviceMetricsInfo.h
+++ b/Framework/Core/include/Framework/DeviceMetricsInfo.h
@@ -106,7 +106,7 @@ inline constexpr size_t metricStorageSize()
   } else if constexpr (std::is_same_v<T, uint64_t>) {
     return 1024;
   } else if constexpr (std::is_same_v<T, StringMetric>) {
-    return 2;
+    return 32;
   } else if constexpr (std::is_same_v<T, float>) {
     return 1024;
   } else if constexpr (std::is_same_v<T, int8_t>) {
@@ -126,7 +126,7 @@ static inline constexpr size_t metricStorageSize(enum MetricType type)
     case MetricType::Float:
       return 1024;
     case MetricType::String:
-      return 2;
+      return 32;
     case MetricType::Enum:
       return 8;
     case MetricType::Unknown:


### PR DESCRIPTION
AliceO2Group/AliceO2#11007 breaks the Hyperloop throughput measurements which rely on aod-file-read-info to see how much data was processed. We need to revert asap.