### PR TITLE
[O2-3655] ITS-Vertexing: protect vertexing against variable number of ROF per TF

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/TimeFrame.cxx
@@ -225,7 +225,6 @@ int TimeFrame::loadROFrameData(gsl::span<o2::itsmft::ROFRecord> rofs,
   if (mcLabels) {
     mClusterLabels = mcLabels;
   }
-
   return mNrof;
 }
 
@@ -274,7 +273,10 @@ void TimeFrame::initialise(const int iteration, const TrackingParameters& trkPar
     mIndexTables.resize(mClusters.size(), std::vector<int>(mNrof * (trkParam.ZBins * trkParam.PhiBins + 1), 0));
     mLines.resize(mNrof);
     mTrackletClusters.resize(mNrof);
-    mNTrackletsPerROf.resize(2, std::vector<int>(mNrof + 1, 0));
+    mNTrackletsPerROf.resize(2);
+    for (auto& v : mNTrackletsPerROf) {
+      v = std::vector<int>(mNrof + 1, 0);
+    }
 
     std::vector<ClusterHelper> cHelper;
     std::vector<int> clsPerBin(trkParam.PhiBins * trkParam.ZBins, 0);


### PR DESCRIPTION
Fixes yet another improper usage of `vector::resize()` from my side.
Thanks @martenole for spotting this.