### PR TITLE
Do not get B field from external file anymore, but from CCDB - O2

### DIFF
--- a/Detectors/GlobalTracking/include/GlobalTracking/MatchITSTPCQC.h
+++ b/Detectors/GlobalTracking/include/GlobalTracking/MatchITSTPCQC.h
@@ -92,8 +92,6 @@ class MatchITSTPCQC
   void setUseMC(bool b) { mUseMC = b; }
   bool getUseMC() const { return mUseMC; }
   void deleteHistograms();
-  void setGRPFileName(std::string fn) { mGRPFileName = fn; }
-  void setGeomFileName(std::string fn) { mGeomFileName = fn; }
   void setBz(float bz) { mBz = bz; }
 
   // track selection
@@ -119,8 +117,6 @@ class MatchITSTPCQC
   // ITS-TPC
   gsl::span<const o2::dataformats::TrackTPCITS> mITSTPCTracks;
   bool mUseMC = false;
-  std::string mGRPFileName = "o2sim_grp.root";
-  std::string mGeomFileName = "o2sim_geometry-aligned.root";
   float mBz = 0;                                              ///< nominal Bz
   std::unordered_map<o2::MCCompLabel, LblInfo> mMapLabels;    // map with labels that have been found for the matched ITSTPC tracks; key is the label,
                                                               // value is the LbLinfo with the id of the track with the highest pT found with that label so far,

--- a/Detectors/GlobalTracking/src/MatchITSTPCQC.cxx
+++ b/Detectors/GlobalTracking/src/MatchITSTPCQC.cxx
@@ -15,7 +15,6 @@
 #include "Framework/InputSpec.h"
 #include "ReconstructionDataFormats/TrackParametrization.h"
 #include "DetectorsBase/Propagator.h"
-#include "DetectorsBase/GeometryManager.h"
 #include "SimulationDataFormat/MCUtils.h"
 #include <algorithm>
 #include "TGraphAsymmErrors.h"
@@ -167,10 +166,6 @@ bool MatchITSTPCQC::init()
   mChi2Refit->GetYaxis()->SetTitleOffset(1.4);
   mTimeResVsPt->GetYaxis()->SetTitleOffset(1.4);
 
-  o2::base::GeometryManager::loadGeometry(mGeomFileName);
-  o2::base::Propagator::initFieldFromGRP(mGRPFileName);
-  mBz = o2::base::Propagator::Instance()->getNominalBz();
-
   if (mUseMC) {
     mcReader.initFromDigitContext("collisioncontext.root");
   }
@@ -199,6 +194,10 @@ void MatchITSTPCQC::initDataRequest()
 
 void MatchITSTPCQC::run(o2::framework::ProcessingContext& ctx)
 {
+
+  // Getting the B field
+  mBz = o2::base::Propagator::Instance()->getNominalBz();
+
   static int evCount = 0;
   mRecoCont.collectData(ctx, *mDataRequest.get());
   mTPCTracks = mRecoCont.getTPCTracks();

--- a/Detectors/GlobalTracking/src/MatchITSTPCQC.cxx
+++ b/Detectors/GlobalTracking/src/MatchITSTPCQC.cxx
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include "TGraphAsymmErrors.h"
 #include "GlobalTracking/TrackCuts.h"
+#include <DetectorsBase/GRPGeomHelper.h>
 
 using namespace o2::globaltracking;
 using namespace o2::mcutils;

--- a/Detectors/GlobalTrackingWorkflow/qc/include/GlobalTrackingWorkflowQC/ITSTPCMatchingQCSpec.h
+++ b/Detectors/GlobalTrackingWorkflow/qc/include/GlobalTrackingWorkflowQC/ITSTPCMatchingQCSpec.h
@@ -18,6 +18,7 @@
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/Task.h"
 #include "GlobalTracking/MatchITSTPCQC.h"
+#include "DetectorsBase/GRPGeomHelper.h"
 
 using namespace o2::framework;
 
@@ -28,15 +29,17 @@ namespace globaltracking
 class ITSTPCMatchingQCDevice : public Task
 {
  public:
-  ITSTPCMatchingQCDevice(std::shared_ptr<DataRequest> dr, bool useMC) : mDataRequest(dr), mUseMC(useMC){};
+  ITSTPCMatchingQCDevice(std::shared_ptr<DataRequest> dr, std::shared_ptr<o2::base::GRPGeomRequest> req, bool useMC) : mDataRequest(dr), mCCDBRequest(req), mUseMC(useMC){};
   void init(o2::framework::InitContext& ic) final;
   void run(o2::framework::ProcessingContext& pc) final;
   void endOfStream(o2::framework::EndOfStreamContext& ec) final;
+  void finaliseCCDB(ConcreteDataMatcher& matcher, void* obj) final;
 
  private:
   void sendOutput(DataAllocator& output);
   std::unique_ptr<o2::globaltracking::MatchITSTPCQC> mMatchITSTPCQC;
   std::shared_ptr<DataRequest> mDataRequest;
+  std::shared_ptr<o2::base::GRPGeomRequest> mCCDBRequest;
   bool mUseMC = true;
 };
 

--- a/Detectors/GlobalTrackingWorkflow/qc/src/ITSTPCMatchingQCSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/qc/src/ITSTPCMatchingQCSpec.cxx
@@ -17,6 +17,8 @@
 #include "GlobalTrackingWorkflowQC/ITSTPCMatchingQCSpec.h"
 #include "GlobalTracking/ITSTPCMatchingQCParams.h"
 #include "DataFormatsGlobalTracking/RecoContainer.h"
+#include "DetectorsBase/Propagator.h"
+
 #include "CommonUtils/NameConf.h"
 #include <TFile.h>
 
@@ -39,6 +41,7 @@ void ITSTPCMatchingQCDevice::init(InitContext& ic)
   mMatchITSTPCQC->setMinNTPCClustersCut(params->minNTPCClustersCut);
   mMatchITSTPCQC->setMinDCAtoBeamPipeDistanceCut(params->minDCACut);
   mMatchITSTPCQC->setMinDCAtoBeamPipeYCut(params->minDCACutY);
+  o2::base::GRPGeomHelper::instance().setRequest(mCCDBRequest);
   if (mUseMC) {
     mMatchITSTPCQC->setUseMC(mUseMC);
   }
@@ -48,7 +51,7 @@ void ITSTPCMatchingQCDevice::init(InitContext& ic)
 
 void ITSTPCMatchingQCDevice::run(o2::framework::ProcessingContext& pc)
 {
-
+  o2::base::GRPGeomHelper::instance().checkUpdates(pc);
   mMatchITSTPCQC->run(pc);
 }
 
@@ -74,6 +77,13 @@ void ITSTPCMatchingQCDevice::sendOutput(DataAllocator& output)
   objar.Write("ObjArray", TObject::kSingleKey);
   f->Close();
 }
+
+void ITSTPCMatchingQCDevice::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
+{
+  if (o2::base::GRPGeomHelper::instance().finaliseCCDB(matcher, obj)) {
+    return;
+  }
+}
 } // namespace globaltracking
 
 namespace framework
@@ -88,11 +98,18 @@ DataProcessorSpec getITSTPCMatchingQCDevice(bool useMC)
   auto dataRequest = std::make_shared<o2::globaltracking::DataRequest>();
   GID::mask_t mSrc = GID::getSourcesMask("TPC,ITS-TPC");
   dataRequest->requestTracks(mSrc, useMC);
+  auto ccdbRequest = std::make_shared<o2::base::GRPGeomRequest>(false,                          // orbitResetTime
+                                                                false,                          // GRPECS=true
+                                                                false,                          // GRPLHCIF
+                                                                true,                           // GRPMagField
+                                                                false,                          // askMatLUT
+                                                                o2::base::GRPGeomRequest::None, // geometry
+                                                                dataRequest->inputs);
   return DataProcessorSpec{
     "itstpc-matching-qc",
     dataRequest->inputs,
     outputs,
-    AlgorithmSpec{adaptFromTask<o2::globaltracking::ITSTPCMatchingQCDevice>(dataRequest, useMC)},
+    AlgorithmSpec{adaptFromTask<o2::globaltracking::ITSTPCMatchingQCDevice>(dataRequest, ccdbRequest, useMC)},
     Options{{}}};
 }
 

--- a/Detectors/GlobalTrackingWorkflow/qc/src/ITSTPCMatchingQCSpec.cxx
+++ b/Detectors/GlobalTrackingWorkflow/qc/src/ITSTPCMatchingQCSpec.cxx
@@ -42,8 +42,6 @@ void ITSTPCMatchingQCDevice::init(InitContext& ic)
   if (mUseMC) {
     mMatchITSTPCQC->setUseMC(mUseMC);
   }
-  mMatchITSTPCQC->setGRPFileName(o2::base::NameConf::getGRPFileName());
-  mMatchITSTPCQC->setGeomFileName(o2::base::NameConf::getGeomFileName());
 }
 
 //_____________________________________________________________


### PR DESCRIPTION
@knopers8 , @shahor02 goes with:
https://github.com/AliceO2Group/QualityControl/pull/1692
https://github.com/AliceO2Group/O2DPG/pull/977

Tested within async reco and also as standalone with:
``` 
o2-global-track-cluster-reader --track-types "TPC,ITS-TPC" --hbfutils-config o2_tfidinfo.root --disable-mc | o2-itstpc-match-qc --disable-mc -b
```
