### PR TITLE
DPL Analysis: Introduce slice cache service

### DIFF
--- a/Framework/Core/CMakeLists.txt
+++ b/Framework/Core/CMakeLists.txt
@@ -12,6 +12,7 @@
 o2_add_library(Framework
                SOURCES src/AODReaderHelpers.cxx
                        src/ArrowSupport.cxx
+                       src/ArrowTableSlicingCache.cxx
                        src/AnalysisDataModel.cxx
                        src/ASoA.cxx
                        src/AsyncQueue.cxx
@@ -251,7 +252,7 @@ set_property(TARGET o2-test-framework-core PROPERTY RUNTIME_OUTPUT_DIRECTORY ${o
 
 add_test(NAME framework:core COMMAND o2-test-framework-core)
 
-o2_add_test(AlgorithmWrapper NAME test_Framework_test_AlgorithmWrapper  
+o2_add_test(AlgorithmWrapper NAME test_Framework_test_AlgorithmWrapper
             SOURCES test/test_AlgorithmWrapper.cxx
             COMPONENT_NAME Framework
             LABELS framework

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1041,7 +1041,7 @@ static auto hasColumnForKey(framework::pack<C...>, std::string const& key)
 template <typename T>
 static std::pair<bool, std::string> hasKey(std::string const& key)
 {
-  return{hasColumnForKey(typename T::persistent_columns_t{}, key), getLabelFromType<T>()};
+  return {hasColumnForKey(typename T::persistent_columns_t{}, key), getLabelFromType<T>()};
 }
 
 template <typename... C>
@@ -1056,7 +1056,7 @@ static std::string getLabelFromTypeForKey(std::string const& key)
   if constexpr (soa::is_type_with_originals_v<std::decay_t<T>>) {
     using Os = typename std::decay_t<T>::originals;
     auto locate = haveKey(Os{}, key);
-    return std::find_if(locate.begin(), locate.end(), [](auto const& x){ return x.first; })->second;
+    return std::find_if(locate.begin(), locate.end(), [](auto const& x) { return x.first; })->second;
   } else {
     auto locate = hasKey<std::decay_t<T>>(key);
     return locate.second;

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -23,6 +23,7 @@
 #include "Framework/RuntimeError.h"
 #include "Framework/Kernels.h"
 #include "Framework/ArrowTableSlicingCache.h"
+#include "Framework/SliceCache.h"
 #include <arrow/table.h>
 #include <arrow/array.h>
 #include <arrow/util/config.h>
@@ -1387,6 +1388,15 @@ class Table
       o2::framework::throw_error(o2::framework::runtime_error("Failed to slice table"));
     }
     auto t = table_t({result}, offset);
+    copyIndexBindings(t);
+    return t;
+  }
+
+  auto sliceByCached(framework::expressions::BindingNode const& node, int value, o2::framework::SliceCache& cache)
+  {
+    auto localCache = cache.ptr->getCacheFor({o2::soa::getLabelFromType<decltype(*this)>(), node.name});
+    auto [offset, count] = localCache.getSliceFor(value);
+    auto t = table_t({this->asArrowTable()->Slice(static_cast<uint64_t>(offset), count)}, static_cast<uint64_t>(offset));
     copyIndexBindings(t);
     return t;
   }

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -3037,4 +3037,9 @@ template <typename T>
 constexpr bool is_smallgroups_v = is_smallgroups_t<T>::value;
 } // namespace o2::soa
 
+namespace o2::framework
+{
+std::string cutString(std::string&& str);
+}
+
 #endif // O2_FRAMEWORK_ASOA_H_

--- a/Framework/Core/include/Framework/ASoA.h
+++ b/Framework/Core/include/Framework/ASoA.h
@@ -1001,23 +1001,15 @@ struct is_binding_compatible : std::conditional_t<is_binding_compatible_v<T, typ
 template <typename T>
 static std::string getLabelFromType()
 {
-  auto cutString = [](std::string&& str) -> std::string {
-    auto pos = str.find('_');
-    if (pos != std::string::npos) {
-      str.erase(pos);
-    }
-    return str;
-  };
-
   if constexpr (soa::is_index_table_v<std::decay_t<T>>) {
     using TT = typename std::decay_t<T>::first_t;
     if constexpr (soa::is_type_with_originals_v<std::decay_t<TT>>) {
       using O = typename framework::pack_head_t<typename std::decay_t<TT>::originals>;
       using groupingMetadata = typename aod::MetadataTrait<O>::metadata;
-      return cutString(std::string{groupingMetadata::tableLabel()});
+      return std::string{groupingMetadata::tableLabel()};
     } else {
       using groupingMetadata = typename aod::MetadataTrait<TT>::metadata;
-      return cutString(std::string{groupingMetadata::tableLabel()});
+      return std::string{groupingMetadata::tableLabel()};
     }
   } else if constexpr (soa::is_type_with_originals_v<std::decay_t<T>>) {
     using TT = typename framework::pack_head_t<typename std::decay_t<T>::originals>;
@@ -1026,7 +1018,7 @@ static std::string getLabelFromType()
       return getLabelFromType<TTT>();
     } else {
       using groupingMetadata = typename aod::MetadataTrait<TT>::metadata;
-      return cutString(std::string{groupingMetadata::tableLabel()});
+      return std::string{groupingMetadata::tableLabel()};
     }
   } else {
     if constexpr (soa::is_with_base_table_v<typename aod::MetadataTrait<T>::metadata>) {
@@ -1034,7 +1026,7 @@ static std::string getLabelFromType()
       return getLabelFromType<TT>();
     } else {
       using groupingMetadata = typename aod::MetadataTrait<std::decay_t<T>>::metadata;
-      return cutString(std::string{groupingMetadata::tableLabel()});
+      return std::string{groupingMetadata::tableLabel()};
     }
   }
 }

--- a/Framework/Core/include/Framework/AnalysisDataModel.h
+++ b/Framework/Core/include/Framework/AnalysisDataModel.h
@@ -28,7 +28,8 @@ namespace aod
 {
 // This is required to register SOA_TABLEs inside
 // the o2::aod namespace.
-DECLARE_SOA_STORE();
+// DECLARE_SOA_METADATA();
+DECLARE_SOA_VERSIONING();
 
 namespace bc
 {

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -646,7 +646,7 @@ struct PresliceManager {
     return false;
   }
 
-  static bool updateSliceInfo(T&, SliceInfoPtr&&)
+  static bool updateSliceInfo(T&, ArrowTableSlicingCache&)
   {
     return false;
   }
@@ -663,9 +663,9 @@ struct PresliceManager<Preslice<T>> {
     return true;
   }
 
-  static bool updateSliceInfo(Preslice<T>& container, SliceInfoPtr&& si)
+  static bool updateSliceInfo(Preslice<T>& container, ArrowTableSlicingCache& cache)
   {
-    container.updateSliceInfo(std::forward<SliceInfoPtr>(si));
+    container.updateSliceInfo(cache.getCacheFor(container.getBindingKey()));
     return true;
   }
 };

--- a/Framework/Core/include/Framework/AnalysisManagers.h
+++ b/Framework/Core/include/Framework/AnalysisManagers.h
@@ -492,6 +492,35 @@ struct ServiceManager<Service<T>> {
 };
 
 template <typename T>
+struct CacheManager {
+  template <typename ANY>
+  static bool initialize(InitContext&, ANY&)
+  {
+    return false;
+  }
+  template <typename ANY>
+  static bool initialize(ProcessingContext&, ANY&)
+  {
+    return false;
+  }
+};
+
+template <>
+struct CacheManager<SliceCache> {
+  static bool initialize(InitContext&, SliceCache&)
+  {
+    return false;
+  }
+  static bool initialize(ProcessingContext& pc, SliceCache& cache)
+  {
+    if (cache.ptr == nullptr) {
+      cache.ptr = &pc.services().get<ArrowTableSlicingCache>();
+    }
+    return true;
+  }
+};
+
+template <typename T>
 struct OptionManager {
   template <typename ANY>
   static bool appendOption(std::vector<ConfigParamSpec>& options, ANY& x)
@@ -617,7 +646,10 @@ struct PresliceManager {
     return false;
   }
 
-  static bool updateSliceInfo(T&, SliceInfoPtr&&);
+  static bool updateSliceInfo(T&, SliceInfoPtr&&)
+  {
+    return false;
+  }
 };
 
 template <typename T>

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -685,7 +685,7 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
       // reset pre-slice for the next dataframe
       auto slices = pc.services().get<ArrowTableSlicingCache>();
       homogeneous_apply_refs([&pc, &slices](auto& x) {
-        return PresliceManager<std::decay_t<decltype(x)>>::updateSliceInfo(x, slices.getCacheFor(x.getBindingKey()));
+        return PresliceManager<std::decay_t<decltype(x)>>::updateSliceInfo(x, slices);
       },
                              *(task.get()));
       // initialize local caches

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -173,7 +173,14 @@ struct AnalysisDataProcessorBuilder {
   template <typename G, typename... Args>
   static void appendGroupingCandidates(std::vector<std::pair<std::string, std::string>>& bk, framework::pack<G, Args...>)
   {
-    auto key = std::string{"fIndex"} + soa::getLabelFromType<std::decay_t<G>>();
+    auto cutString = [](std::string&& str) -> std::string {
+      auto pos = str.find('_');
+      if (pos != std::string::npos) {
+        str.erase(pos);
+      }
+      return str;
+    };
+    auto key = std::string{"fIndex"} + cutString(soa::getLabelFromType<std::decay_t<G>>());
     (appendGroupingCandidate<G, Args>(bk, key), ...);
   }
 

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -165,7 +165,7 @@ struct AnalysisDataProcessorBuilder {
   static void appendGroupingCandidate(std::vector<std::pair<std::string, std::string>>& bk, std::string& key)
   {
     if constexpr (soa::relatedByIndex<std::decay_t<G>, std::decay_t<Arg>>() && !o2::soa::is_smallgroups_v<std::decay_t<Arg>>) {
-      auto binding = soa::getLabelFromType<std::decay_t<Arg>>();
+      auto binding = soa::getLabelFromTypeForKey<std::decay_t<Arg>>(key);
       if (std::find_if(bk.begin(), bk.end(), [&binding, &key](auto const& entry) { return (entry.first == binding) && (entry.second == key); }) == bk.end()) {
         bk.emplace_back(binding, key);
       }

--- a/Framework/Core/include/Framework/AnalysisTask.h
+++ b/Framework/Core/include/Framework/AnalysisTask.h
@@ -30,6 +30,7 @@
 #include "Framework/VariantHelpers.h"
 #include "Framework/RuntimeError.h"
 #include "Framework/TypeIdHelpers.h"
+#include "Framework/ArrowTableSlicingCache.h"
 
 #include <arrow/compute/kernel.h>
 #include <arrow/table.h>
@@ -160,11 +161,30 @@ struct AnalysisDataProcessorBuilder {
     }
   }
 
+  template <typename G, typename Arg>
+  static void appendGroupingCandidate(std::vector<std::pair<std::string, std::string>>& bk, std::string& key)
+  {
+    if constexpr (soa::relatedByIndex<std::decay_t<G>, std::decay_t<Arg>>()) {
+      auto binding = soa::getLabelFromType<std::decay_t<Arg>>();
+      bk.emplace_back(binding, key);
+    }
+  }
+
+  template <typename G, typename... Args>
+  static void appendGroupingCandidates(std::vector<std::pair<std::string, std::string>>& bk, framework::pack<G, Args...>)
+  {
+    auto key = std::string{"fIndex"} + soa::getLabelFromType<std::decay_t<G>>();
+    (appendGroupingCandidate<G, Args>(bk, key), ...);
+  }
+
   template <typename R, typename C, typename... Args>
-  static void inputsFromArgs(R (C::*)(Args...), const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eInfos)
+  static void inputsFromArgs(R (C::*)(Args...), const char* name, bool value, std::vector<InputSpec>& inputs, std::vector<ExpressionInfo>& eInfos, std::vector<std::pair<std::string, std::string>>& bk)
   {
     int ai = 0;
     auto hash = typeHash<R (C::*)(Args...)>();
+    if constexpr (soa::is_soa_iterator_v<std::decay_t<framework::pack_element_t<0, framework::pack<Args...>>>>) {
+      appendGroupingCandidates(bk, framework::pack<Args...>{});
+    }
     (appendSomethingWithMetadata<Args>(ai++, name, value, inputs, eInfos, hash), ...);
   }
 
@@ -302,9 +322,6 @@ struct AnalysisDataProcessorBuilder {
       },
                              task);
     };
-    // pre-slice grouping table if required
-    presliceTable(groupingTable);
-
     // set filtered tables for partitions with grouping
     homogeneous_apply_refs([&groupingTable](auto& x) {
       PartitionManager<std::decay_t<decltype(x)>>::setPartition(x, groupingTable);
@@ -335,7 +352,7 @@ struct AnalysisDataProcessorBuilder {
       static_assert(((soa::is_soa_iterator_v<std::decay_t<Associated>> == false) && ...),
                     "Associated arguments of process() should not be iterators");
       auto associatedTables = AnalysisDataProcessorBuilder::bindAssociatedTables(inputs, processingFunction, infos);
-      //pre-bind self indices
+      // pre-bind self indices
       std::apply(
         [&](auto&... t) {
           (homogeneous_apply_refs(
@@ -374,13 +391,6 @@ struct AnalysisDataProcessorBuilder {
                              task);
 
       if constexpr (soa::is_soa_iterator_v<std::decay_t<G>>) {
-        // grouping case
-        // pre-slice associated tables
-        std::apply([&presliceTable](auto&... x) {
-          (presliceTable(x), ...);
-        },
-                   associatedTables);
-
         auto slicer = GroupSlicer(groupingTable, associatedTables);
         for (auto& slice : slicer) {
           auto associatedSlices = slice.associatedTables();
@@ -401,13 +411,6 @@ struct AnalysisDataProcessorBuilder {
           invokeProcessWithArgsGeneric(task, processingFunction, slice.groupingElement(), associatedSlices);
         }
       } else {
-        // non-grouping case
-        // pre-slice associated tables
-        std::apply([&presliceTable](auto&... x) {
-          (presliceTable(x), ...);
-        },
-                   associatedTables);
-
         overwriteInternalIndices(associatedTables, associatedTables);
         // bind partitions and grouping table
         homogeneous_apply_refs([&groupingTable](auto& x) {
@@ -589,6 +592,7 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
   std::vector<InputSpec> inputs;
   std::vector<ConfigParamSpec> options;
   std::vector<ExpressionInfo> expressionInfos;
+  std::vector<std::pair<std::string, std::string>> bindingsKeys;
 
   /// make sure options and configurables are set before expression infos are created
   homogeneous_apply_refs([&options, &hash](auto& x) { return OptionManager<std::decay_t<decltype(x)>>::appendOption(options, x); }, *task.get());
@@ -597,19 +601,22 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
 
   /// parse process functions defined by corresponding configurables
   if constexpr (has_process_v<T>) {
-    AnalysisDataProcessorBuilder::inputsFromArgs(&T::process, "default", true, inputs, expressionInfos);
+    AnalysisDataProcessorBuilder::inputsFromArgs(&T::process, "default", true, inputs, expressionInfos, bindingsKeys);
   }
   homogeneous_apply_refs(
-    [name = name_str, &expressionInfos, &inputs](auto& x) {
+    [name = name_str, &expressionInfos, &inputs, &bindingsKeys](auto& x) {
       using D = std::decay_t<decltype(x)>;
       if constexpr (is_base_of_template_v<ProcessConfigurable, D>) {
         // this pushes (argumentIndex,processHash,schemaPtr,nullptr) into expressionInfos for arguments that are Filtered/filtered_iterators
-        AnalysisDataProcessorBuilder::inputsFromArgs(x.process, (name + "/" + x.name).c_str(), x.value, inputs, expressionInfos);
+        AnalysisDataProcessorBuilder::inputsFromArgs(x.process, (name + "/" + x.name).c_str(), x.value, inputs, expressionInfos, bindingsKeys);
         return true;
       }
       return false;
     },
     *task.get());
+
+  // add preslice declarations to slicing cache definition
+  homogeneous_apply_refs([&bindingsKeys](auto& x) { return PresliceManager<std::decay_t<decltype(x)>>::registerCache(x, bindingsKeys); }, *task.get());
 
   // request base tables for spawnable extended tables
   // this checks for duplications
@@ -618,7 +625,7 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
   },
                          *task.get());
 
-  //request base tables for indices to be built
+  // request base tables for indices to be built
   homogeneous_apply_refs([&inputs](auto& x) {
     return IndexManager<std::decay_t<decltype(x)>>::requestInputs(inputs, x);
   },
@@ -631,10 +638,12 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
 
   homogeneous_apply_refs([&outputs, &hash](auto& x) { return OutputManager<std::decay_t<decltype(x)>>::appendOutput(outputs, x, hash); }, *task.get());
 
-  std::vector<ServiceSpec> requiredServices = CommonServices::defaultServices();
+  auto requiredServices = CommonServices::defaultServices();
+  auto arrowServices = CommonServices::arrowServices();
+  requiredServices.insert(requiredServices.end(), arrowServices.begin(), arrowServices.end());
   homogeneous_apply_refs([&requiredServices](auto& x) { return ServiceManager<std::decay_t<decltype(x)>>::add(requiredServices, x); }, *task.get());
 
-  auto algo = AlgorithmSpec::InitCallback{[task = task, expressionInfos](InitContext& ic) mutable {
+  auto algo = AlgorithmSpec::InitCallback{[task = task, expressionInfos, bindingsKeys](InitContext& ic) mutable {
     homogeneous_apply_refs([&ic](auto&& x) { return OptionManager<std::decay_t<decltype(x)>>::prepare(ic, x); }, *task.get());
     homogeneous_apply_refs([&ic](auto&& x) { return ServiceManager<std::decay_t<decltype(x)>>::prepare(ic, x); }, *task.get());
 
@@ -668,6 +677,8 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
       task->init(ic);
     }
 
+    ic.services().get<ArrowTableSlicingCacheDef>().setCaches(std::move(bindingsKeys));
+
     return [task, expressionInfos](ProcessingContext& pc) mutable {
       // load the ccdb object from their cache
       homogeneous_apply_refs([&pc](auto&& x) { return ConditionManager<std::decay_t<decltype(x)>>::newDataframe(pc.inputs(), x); }, *task.get());
@@ -678,14 +689,21 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
         info.resetSelection = true;
       }
       // reset pre-slice for the next dataframe
-      homogeneous_apply_refs([](auto& x) { return PresliceManager<std::decay_t<decltype(x)>>::setNewDF(x); }, *(task.get()));
+      auto slices = pc.services().get<ArrowTableSlicingCache>();
+      homogeneous_apply_refs([&pc, &slices](auto& x) {
+        if constexpr (framework::is_base_of_template_v<Preslice, std::decay_t<decltype(x)>>) {
+          return PresliceManager<std::decay_t<decltype(x)>>::updateSliceInfo(x, slices.getCacheFor(x.getBindingKey()));
+        }
+        return false;
+      }, //
+                             *(task.get()));
       // prepare outputs
       homogeneous_apply_refs([&pc](auto&& x) { return OutputManager<std::decay_t<decltype(x)>>::prepare(pc, x); }, *task.get());
       // execute run()
       if constexpr (has_run_v<T>) {
         task->run(pc);
       }
-      // execture process()
+      // execute process()
       if constexpr (has_process_v<T>) {
         AnalysisDataProcessorBuilder::invokeProcess(*(task.get()), pc.inputs(), &T::process, expressionInfos);
       }
@@ -706,7 +724,7 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
     };
   }};
 
-  DataProcessorSpec spec{
+  return {
     name,
     // FIXME: For the moment we hardcode this. We could build
     // this list from the list of methods actually implemented in the
@@ -716,7 +734,6 @@ DataProcessorSpec adaptAnalysisTask(ConfigContext const& ctx, Args&&... args)
     algo,
     options,
     requiredServices};
-  return spec;
 }
 
 } // namespace o2::framework

--- a/Framework/Core/include/Framework/ArrowTableSlicingCache.h
+++ b/Framework/Core/include/Framework/ArrowTableSlicingCache.h
@@ -46,7 +46,7 @@ struct ArrowTableSlicingCache {
   void setCaches(std::vector<std::pair<std::string, std::string>>&& bsks);
 
   // update slicing info cache entry (assumes it is already present)
-  arrow::Status updateCacheEntry(int pos, std::shared_ptr<arrow::Table>&& table);
+  arrow::Status updateCacheEntry(int pos, std::shared_ptr<arrow::Table> table);
 
   // get slice from cache for a given value
   SliceInfoPtr getCacheFor(std::pair<std::string, std::string> const& bindingKey) const;

--- a/Framework/Core/include/Framework/ArrowTableSlicingCache.h
+++ b/Framework/Core/include/Framework/ArrowTableSlicingCache.h
@@ -1,0 +1,56 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ARROWTABLESLICINGCACHE_H
+#define ARROWTABLESLICINGCACHE_H
+
+#include "Framework/ServiceHandle.h"
+#include <arrow/array.h>
+#include <string_view>
+#include <gsl/span>
+
+namespace o2::framework
+{
+struct SliceInfoPtr {
+  gsl::span<int const> values;
+  gsl::span<int64_t const> counts;
+
+  std::pair<int64_t, int64_t> getSliceFor(int value) const;
+};
+
+struct ArrowTableSlicingCacheDef {
+  constexpr static ServiceKind service_kind = ServiceKind::Global;
+  std::vector<std::pair<std::string, std::string>> bindingsKeys;
+
+  void setCaches(std::vector<std::pair<std::string, std::string>>&& bsks);
+};
+
+struct ArrowTableSlicingCache {
+  constexpr static ServiceKind service_kind = ServiceKind::Stream;
+
+  std::vector<std::pair<std::string, std::string>> bindingsKeys;
+  std::vector<std::shared_ptr<arrow::NumericArray<arrow::Int32Type>>> values;
+  std::vector<std::shared_ptr<arrow::NumericArray<arrow::Int64Type>>> counts;
+
+  ArrowTableSlicingCache(std::vector<std::pair<std::string, std::string>>&& bsks);
+
+  // set caching information externally
+  void setCaches(std::vector<std::pair<std::string, std::string>>&& bsks);
+
+  // update slicing info cache entry (assumes it is already present)
+  arrow::Status updateCacheEntry(int pos, std::shared_ptr<arrow::Table>&& table);
+
+  // get slice from cache for a given value
+  SliceInfoPtr getCacheFor(std::pair<std::string, std::string> const& bindingKey) const;
+};
+} // namespace o2::framework
+
+#endif // ARROWTABLESLICINGCACHE_H

--- a/Framework/Core/include/Framework/ArrowTableSlicingCache.h
+++ b/Framework/Core/include/Framework/ArrowTableSlicingCache.h
@@ -46,7 +46,7 @@ struct ArrowTableSlicingCache {
   void setCaches(std::vector<std::pair<std::string, std::string>>&& bsks);
 
   // update slicing info cache entry (assumes it is already present)
-  arrow::Status updateCacheEntry(int pos, std::shared_ptr<arrow::Table> table);
+  arrow::Status updateCacheEntry(int pos, std::shared_ptr<arrow::Table> const& table);
 
   // get slice from cache for a given value
   SliceInfoPtr getCacheFor(std::pair<std::string, std::string> const& bindingKey) const;

--- a/Framework/Core/include/Framework/CommonServices.h
+++ b/Framework/Core/include/Framework/CommonServices.h
@@ -84,6 +84,7 @@ struct CommonServices {
   static ServiceSpec streamContextSpec();
 
   static std::vector<ServiceSpec> defaultServices(int numWorkers = 0);
+  static std::vector<ServiceSpec> arrowServices();
   static std::vector<ServiceSpec> requiredServices();
 };
 

--- a/Framework/Core/include/Framework/GroupSlicer.h
+++ b/Framework/Core/include/Framework/GroupSlicer.h
@@ -14,6 +14,7 @@
 
 #include "Framework/Pack.h"
 #include "Framework/Kernels.h"
+#include "Framework/ASoA.h"
 
 #include <arrow/util/config.h>
 #include <arrow/util/key_value_metadata.h>
@@ -26,9 +27,9 @@ namespace o2::framework
 template <typename G, typename... A>
 struct GroupSlicer {
   using grouping_t = std::decay_t<G>;
-  GroupSlicer(G& gt, std::tuple<A...>& at)
+  GroupSlicer(G& gt, std::tuple<A...>& at, ArrowTableSlicingCache& slices)
     : max{gt.size()},
-      mBegin{GroupSlicerIterator(gt, at)}
+      mBegin{GroupSlicerIterator(gt, at, slices)}
   {
   }
 
@@ -45,68 +46,25 @@ struct GroupSlicer {
     GroupSlicerIterator& operator=(GroupSlicerIterator const&) = default;
     GroupSlicerIterator& operator=(GroupSlicerIterator&&) = default;
 
-    template <typename Z>
-    std::string getLabelFromType()
-    {
-      auto cutString = [](std::string&& str) -> std::string {
-        auto pos = str.find('_');
-        if (pos != std::string::npos) {
-          str.erase(pos);
-        }
-        return str;
-      };
-
-      if constexpr (soa::is_soa_index_table_v<std::decay_t<Z>>) {
-        using T = typename std::decay_t<Z>::first_t;
-        if constexpr (soa::is_type_with_originals_v<std::decay_t<T>>) {
-          using O = typename framework::pack_element_t<0, typename std::decay_t<Z>::originals>;
-          using groupingMetadata = typename aod::MetadataTrait<O>::metadata;
-          return cutString(std::string{groupingMetadata::tableLabel()});
-        } else {
-          using groupingMetadata = typename aod::MetadataTrait<T>::metadata;
-          return cutString(std::string{groupingMetadata::tableLabel()});
-        }
-      } else if constexpr (soa::is_type_with_originals_v<std::decay_t<Z>>) {
-        using T = typename framework::pack_element_t<0, typename std::decay_t<Z>::originals>;
-        using groupingMetadata = typename aod::MetadataTrait<T>::metadata;
-        return cutString(std::string{groupingMetadata::tableLabel()});
-      } else {
-        using groupingMetadata = typename aod::MetadataTrait<std::decay_t<Z>>::metadata;
-        return cutString(std::string{groupingMetadata::tableLabel()});
-      }
-    }
-
     template <typename T>
     auto splittingFunction(T&& table)
     {
       constexpr auto index = framework::has_type_at_v<std::decay_t<T>>(associated_pack_t{});
-      if constexpr (relatedByIndex<std::decay_t<G>, std::decay_t<T>>()) {
-        auto name = getLabelFromType<std::decay_t<T>>();
+      if constexpr (o2::soa::relatedByIndex<std::decay_t<G>, std::decay_t<T>>()) {
+        auto binding = o2::soa::getLabelFromType<std::decay_t<T>>();
         if constexpr (!o2::soa::is_smallgroups_v<std::decay_t<T>>) {
           if (table.size() == 0) {
             return;
           }
-          // use presorted splitting approach
-          auto result = o2::framework::sliceByColumn(mIndexColumnName.c_str(),
-                                                     name.c_str(),
-                                                     table.asArrowTable(),
-                                                     static_cast<int32_t>(mGt->tableSize()),
-                                                     &groups[index],
-                                                     &offsets[index],
-                                                     &sizes[index]);
-          if (result.ok() == false) {
-            throw runtime_error("Cannot split collection");
-          }
-          if (groups[index].size() > mGt->tableSize()) {
-            throw runtime_error_f("Splitting collection %s resulted in a larger group number (%d) than there is rows in the grouping table (%d).", name.c_str(), groups[index].size(), mGt->tableSize());
-          };
+          auto bk = std::make_pair(binding, mIndexColumnName);
+          sliceInfos[index] = mSlices->getCacheFor(bk);
         } else {
           if (table.tableSize() == 0) {
             return;
           }
           // use generic splitting approach
           o2::framework::sliceByColumnGeneric(mIndexColumnName.c_str(),
-                                              name.c_str(),
+                                              binding.c_str(),
                                               table.asArrowTable(),
                                               static_cast<int32_t>(mGt->tableSize()),
                                               &filterGroups[index]);
@@ -121,16 +79,16 @@ struct GroupSlicer {
         constexpr auto index = framework::has_type_at_v<std::decay_t<T>>(associated_pack_t{});
         selections[index] = &table.getSelectedRows();
         starts[index] = selections[index]->begin();
-        offsets[index].push_back(table.tableSize());
       }
     }
 
-    GroupSlicerIterator(G& gt, std::tuple<A...>& at)
-      : mIndexColumnName{std::string("fIndex") + getLabelFromType<G>()},
+    GroupSlicerIterator(G& gt, std::tuple<A...>& at, ArrowTableSlicingCache& slices)
+      : mIndexColumnName{std::string("fIndex") + o2::framework::cutString(o2::soa::getLabelFromType<G>())},
         mGt{&gt},
         mAt{&at},
         mGroupingElement{gt.begin()},
-        position{0}
+        position{0},
+        mSlices{&slices}
     {
       if constexpr (soa::is_soa_filtered_v<std::decay_t<G>>) {
         groupSelection = mGt->getSelectedRows();
@@ -150,30 +108,6 @@ struct GroupSlicer {
           (extractingFunction(x), ...);
         },
         at);
-    }
-
-    template <typename B, typename... C>
-    constexpr static bool hasIndexTo(framework::pack<C...>&&)
-    {
-      return (o2::soa::is_binding_compatible_v<B, typename C::binding_t>() || ...);
-    }
-
-    template <typename B, typename... C>
-    constexpr static bool hasSortedIndexTo(framework::pack<C...>&&)
-    {
-      return ((C::sorted && o2::soa::is_binding_compatible_v<B, typename C::binding_t>()) || ...);
-    }
-
-    template <typename B, typename Z>
-    constexpr static bool relatedByIndex()
-    {
-      return hasIndexTo<B>(typename Z::table_t::external_index_columns_t{});
-    }
-
-    template <typename B, typename Z>
-    constexpr static bool relatedBySortedIndex()
-    {
-      return hasSortedIndexTo<B>(typename Z::table_t::external_index_columns_t{});
     }
 
     GroupSlicerIterator& operator++()
@@ -229,7 +163,7 @@ struct GroupSlicer {
       constexpr auto index = framework::has_type_at_v<A1>(associated_pack_t{});
       auto& originalTable = std::get<A1>(*mAt);
 
-      if constexpr (relatedByIndex<std::decay_t<G>, std::decay_t<A1>>()) {
+      if constexpr (o2::soa::relatedByIndex<std::decay_t<G>, std::decay_t<A1>>()) {
         uint64_t pos;
         if constexpr (soa::is_soa_filtered_v<std::decay_t<G>>) {
           pos = groupSelection[position];
@@ -242,40 +176,37 @@ struct GroupSlicer {
           if (originalTable.size() == 0) {
             return originalTable;
           }
+          auto oc = sliceInfos[index].getSliceFor(pos);
+          uint64_t offset = oc.first;
+          auto count = oc.second;
           if constexpr (soa::is_soa_filtered_v<std::decay_t<A1>>) {
-            if (groups[index].empty()) {
+            if (count == 0) {
               return std::decay_t<A1>{{makeEmptyTable<A1>("empty")}, soa::SelectionVector{}};
             }
-#if ARROW_VERSION_MAJOR < 10
-            auto groupedElementsTable = arrow::util::get<std::shared_ptr<arrow::Table>>(((groups[index])[pos]).value);
-#else
-            auto groupedElementsTable = ((groups[index])[pos]).table();
-#endif
+
+            auto groupedElementsTable = originalTable.asArrowTable()->Slice(offset, count);
 
             // for each grouping element we need to slice the selection vector
-            auto start_iterator = std::lower_bound(starts[index], selections[index]->end(), (offsets[index])[pos]);
-            auto stop_iterator = std::lower_bound(start_iterator, selections[index]->end(), (offsets[index])[pos] + (sizes[index])[pos]);
+            auto start_iterator = std::lower_bound(starts[index], selections[index]->end(), offset);
+            auto stop_iterator = std::lower_bound(start_iterator, selections[index]->end(), offset + count);
             starts[index] = stop_iterator;
             soa::SelectionVector slicedSelection{start_iterator, stop_iterator};
             std::transform(slicedSelection.begin(), slicedSelection.end(), slicedSelection.begin(),
-                           [&](int64_t idx) {
-                             return idx - static_cast<int64_t>((offsets[index])[pos]);
+                           [&offset](int64_t idx) {
+                             return idx - static_cast<int64_t>(offset);
                            });
 
-            std::decay_t<A1> typedTable{{groupedElementsTable}, std::move(slicedSelection), (offsets[index])[pos]};
+            std::decay_t<A1> typedTable{{groupedElementsTable}, std::move(slicedSelection), offset};
             typedTable.bindInternalIndicesTo(&originalTable);
             return typedTable;
 
           } else {
-            if (groups[index].empty()) {
+            if (count == 0) {
               return std::decay_t<A1>{{makeEmptyTable<A1>("empty")}};
             }
-#if ARROW_VERSION_MAJOR < 10
-            auto groupedElementsTable = arrow::util::get<std::shared_ptr<arrow::Table>>(((groups[index])[pos]).value);
-#else
-            auto groupedElementsTable = ((groups[index])[pos]).table();
-#endif
-            std::decay_t<A1> typedTable{{groupedElementsTable}, (offsets[index])[pos]};
+
+            auto groupedElementsTable = originalTable.asArrowTable()->Slice(offset, count);
+            std::decay_t<A1> typedTable{{groupedElementsTable}, offset};
             typedTable.bindInternalIndicesTo(&originalTable);
             return typedTable;
           }
@@ -316,12 +247,12 @@ struct GroupSlicer {
     typename grouping_t::iterator mGroupingElement;
     uint64_t position = 0;
     gsl::span<int64_t const> groupSelection;
-    std::array<std::vector<arrow::Datum>, sizeof...(A)> groups;
     std::array<ListVector, sizeof...(A)> filterGroups;
-    std::array<std::vector<uint64_t>, sizeof...(A)> offsets;
-    std::array<std::vector<int>, sizeof...(A)> sizes;
     std::array<gsl::span<int64_t const> const*, sizeof...(A)> selections;
     std::array<gsl::span<int64_t const>::iterator, sizeof...(A)> starts;
+
+    std::array<SliceInfoPtr, sizeof...(A)> sliceInfos;
+    ArrowTableSlicingCache* mSlices;
   };
 
   GroupSlicerIterator& begin()

--- a/Framework/Core/include/Framework/GroupSlicer.h
+++ b/Framework/Core/include/Framework/GroupSlicer.h
@@ -51,7 +51,7 @@ struct GroupSlicer {
     {
       constexpr auto index = framework::has_type_at_v<std::decay_t<T>>(associated_pack_t{});
       if constexpr (o2::soa::relatedByIndex<std::decay_t<G>, std::decay_t<T>>()) {
-        auto binding = o2::soa::getLabelFromType<std::decay_t<T>>();
+        auto binding = o2::soa::getLabelFromTypeForKey<std::decay_t<T>>(mIndexColumnName);
         if constexpr (!o2::soa::is_smallgroups_v<std::decay_t<T>>) {
           if (table.size() == 0) {
             return;

--- a/Framework/Core/include/Framework/SliceCache.h
+++ b/Framework/Core/include/Framework/SliceCache.h
@@ -1,0 +1,28 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef SLICECACHE_H
+#define SLICECACHE_H
+
+#include "Framework/ServiceHandle.h"
+#include "Framework/ArrowTableSlicingCache.h"
+#include <arrow/array.h>
+#include <string_view>
+#include <gsl/span>
+
+namespace o2::framework
+{
+struct SliceCache {
+  ArrowTableSlicingCache* ptr = nullptr;
+};
+} // namespace o2::framework
+
+#endif // SLICECACHE_H

--- a/Framework/Core/src/ASoA.cxx
+++ b/Framework/Core/src/ASoA.cxx
@@ -116,3 +116,15 @@ void notBoundTable(const char* tableName)
 }
 
 } // namespace o2::soa
+
+namespace o2::framework
+{
+std::string cutString(std::string&& str)
+{
+  auto pos = str.find('_');
+  if (pos != std::string::npos) {
+    str.erase(pos);
+  }
+  return str;
+}
+} // namespace o2::framework

--- a/Framework/Core/src/ArrowSupport.cxx
+++ b/Framework/Core/src/ArrowSupport.cxx
@@ -13,6 +13,7 @@
 #include "Framework/AODReaderHelpers.h"
 #include "Framework/ArrowContext.h"
 #include "Framework/ArrowTableSlicingCache.h"
+#include "Framework/SliceCache.h"
 #include "Framework/DataProcessor.h"
 #include "Framework/ServiceRegistry.h"
 #include "Framework/ConfigContext.h"

--- a/Framework/Core/src/ArrowSupport.cxx
+++ b/Framework/Core/src/ArrowSupport.cxx
@@ -12,6 +12,7 @@
 
 #include "Framework/AODReaderHelpers.h"
 #include "Framework/ArrowContext.h"
+#include "Framework/ArrowTableSlicingCache.h"
 #include "Framework/DataProcessor.h"
 #include "Framework/ServiceRegistry.h"
 #include "Framework/ConfigContext.h"
@@ -127,7 +128,7 @@ o2::framework::ServiceSpec ArrowSupport::arrowBackendSpec()
                        auto &allDeviceMetrics = sm.deviceMetricsInfos;
                        auto &specs = sm.deviceSpecs;
                        auto &infos = sm.deviceInfos;
-                       
+
                        static auto stateMetric = DeviceMetricsHelper::createNumericMetric<uint64_t>(driverMetrics, "rate-limit-state");
                        static auto totalBytesCreatedMetric = DeviceMetricsHelper::createNumericMetric<uint64_t>(driverMetrics, "total-arrow-bytes-created");
                        static auto shmOfferConsumedMetric = DeviceMetricsHelper::createNumericMetric<uint64_t>(driverMetrics, "total-shm-offer-bytes-consumed");
@@ -390,10 +391,10 @@ o2::framework::ServiceSpec ArrowSupport::arrowBackendSpec()
                        } },
     .adjustTopology = [](WorkflowSpecNode& node, ConfigContext const& ctx) {
       auto& workflow = node.specs;
-      auto spawner = std::find_if(workflow.begin(), workflow.end(), [](DataProcessorSpec& spec) { return spec.name == "internal-dpl-aod-spawner"; });
-      auto builder = std::find_if(workflow.begin(), workflow.end(), [](DataProcessorSpec& spec) { return spec.name == "internal-dpl-aod-index-builder"; });
-      auto reader = std::find_if(workflow.begin(), workflow.end(), [](DataProcessorSpec& spec) { return spec.name == "internal-dpl-aod-reader"; });
-      auto writer = std::find_if(workflow.begin(), workflow.end(), [](DataProcessorSpec& spec) { return spec.name == "internal-dpl-aod-writer"; });
+      auto spawner = std::find_if(workflow.begin(), workflow.end(), [](DataProcessorSpec const& spec) { return spec.name == "internal-dpl-aod-spawner"; });
+      auto builder = std::find_if(workflow.begin(), workflow.end(), [](DataProcessorSpec const& spec) { return spec.name == "internal-dpl-aod-index-builder"; });
+      auto reader = std::find_if(workflow.begin(), workflow.end(), [](DataProcessorSpec const& spec) { return spec.name == "internal-dpl-aod-reader"; });
+      auto writer = std::find_if(workflow.begin(), workflow.end(), [](DataProcessorSpec const& spec) { return spec.name == "internal-dpl-aod-writer"; });
       std::vector<InputSpec> requestedAODs;
       std::vector<InputSpec> requestedDYNs;
       std::vector<OutputSpec> providedDYNs;
@@ -506,11 +507,39 @@ o2::framework::ServiceSpec ArrowSupport::arrowBackendSpec()
         // file sink for any AOD output
         if (!outputsInputsAOD.empty()) {
           // add TFNumber and TFFilename as input to the writer
-          outputsInputsAOD.emplace_back(InputSpec{"tfn", "TFN", "TFNumber"});
-          outputsInputsAOD.emplace_back(InputSpec{"tff", "TFF", "TFFilename"});
+          outputsInputsAOD.emplace_back("tfn", "TFN", "TFNumber");
+          outputsInputsAOD.emplace_back("tff", "TFF", "TFFilename");
           workflow.push_back(CommonDataProcessors::getGlobalAODSink(dod, outputsInputsAOD));
         } },
     .kind = ServiceKind::Global};
+}
+
+o2::framework::ServiceSpec ArrowSupport::arrowTableSlicingCacheDefSpec()
+{
+  return ServiceSpec{
+    .name = "arrow-slicing-cache-def",
+    .uniqueId = CommonServices::simpleServiceId<ArrowTableSlicingCacheDef>(),
+    .init = CommonServices::simpleServiceInit<ArrowTableSlicingCacheDef, ArrowTableSlicingCacheDef, ServiceKind::Global>(),
+    .kind = ServiceKind::Global};
+}
+
+o2::framework::ServiceSpec ArrowSupport::arrowTableSlicingCacheSpec()
+{
+  return ServiceSpec{
+    .name = "arrow-slicing-cache",
+    .uniqueId = CommonServices::simpleServiceId<ArrowTableSlicingCache>(),
+    .init = [](ServiceRegistryRef services, DeviceState&, fair::mq::ProgOptions&) { return ServiceHandle{TypeIdHelpers::uniqueId<ArrowTableSlicingCache>(), new ArrowTableSlicingCache(std::vector<std::pair<std::string, std::string>>{services.get<ArrowTableSlicingCacheDef>().bindingsKeys}), ServiceKind::Stream, typeid(ArrowTableSlicingCache).name()}; },
+    .preProcessing = [](ProcessingContext& pc, void* service_ptr) {
+      auto service = static_cast<ArrowTableSlicingCache*>(service_ptr);
+      auto& caches = service->bindingsKeys;
+      for (auto i = 0; i < caches.size(); ++i) {
+        auto status = service->updateCacheEntry(i, pc.inputs().get<TableConsumer>(caches[i].first.c_str())->asArrowTable());
+        if (!status.ok()) {
+          throw runtime_error_f("Failed to update slice cache for %s/%s", caches[i].first.c_str(), caches[i].second.c_str());
+        }
+      } },
+    .configure = CommonServices::noConfiguration(),
+    .kind = ServiceKind::Stream};
 }
 
 } // namespace o2::framework

--- a/Framework/Core/src/ArrowSupport.cxx
+++ b/Framework/Core/src/ArrowSupport.cxx
@@ -530,6 +530,7 @@ o2::framework::ServiceSpec ArrowSupport::arrowTableSlicingCacheSpec()
     .name = "arrow-slicing-cache",
     .uniqueId = CommonServices::simpleServiceId<ArrowTableSlicingCache>(),
     .init = [](ServiceRegistryRef services, DeviceState&, fair::mq::ProgOptions&) { return ServiceHandle{TypeIdHelpers::uniqueId<ArrowTableSlicingCache>(), new ArrowTableSlicingCache(std::vector<std::pair<std::string, std::string>>{services.get<ArrowTableSlicingCacheDef>().bindingsKeys}), ServiceKind::Stream, typeid(ArrowTableSlicingCache).name()}; },
+    .configure = CommonServices::noConfiguration(),
     .preProcessing = [](ProcessingContext& pc, void* service_ptr) {
       auto* service = static_cast<ArrowTableSlicingCache*>(service_ptr);
       auto& caches = service->bindingsKeys;
@@ -541,7 +542,6 @@ o2::framework::ServiceSpec ArrowSupport::arrowTableSlicingCacheSpec()
           }
         }
       } },
-    .configure = CommonServices::noConfiguration(),
     .kind = ServiceKind::Stream};
 }
 

--- a/Framework/Core/src/ArrowSupport.h
+++ b/Framework/Core/src/ArrowSupport.h
@@ -21,6 +21,8 @@ namespace o2::framework
 struct ArrowSupport {
   // Create spec for backend used to send Arrow messages
   static ServiceSpec arrowBackendSpec();
+  static ServiceSpec arrowTableSlicingCacheDefSpec();
+  static ServiceSpec arrowTableSlicingCacheSpec();
 };
 
 } // namespace o2::framework

--- a/Framework/Core/src/ArrowTableSlicingCache.cxx
+++ b/Framework/Core/src/ArrowTableSlicingCache.cxx
@@ -1,0 +1,89 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "Framework/ArrowTableSlicingCache.h"
+#include "Framework/RuntimeError.h"
+
+#include <arrow/compute/api_aggregate.h>
+#include <arrow/compute/kernel.h>
+#include <arrow/table.h>
+
+namespace o2::framework
+{
+
+std::pair<int64_t, int64_t> SliceInfoPtr::getSliceFor(int value) const
+{
+  int64_t offset = 0;
+  if (values.empty()) {
+    return {offset, 0};
+  }
+  for (auto i = 0; i < values.size(); ++i) {
+    if (values[i] == value) {
+      return {offset, counts[i]};
+    }
+    offset += counts[i];
+  }
+  return {offset, 0};
+}
+
+void ArrowTableSlicingCacheDef::setCaches(std::vector<std::pair<std::string, std::string>>&& bsks)
+{
+  bindingsKeys = bsks;
+}
+
+ArrowTableSlicingCache::ArrowTableSlicingCache(std::vector<std::pair<std::string, std::string>>&& bsks)
+  : bindingsKeys{bsks}
+{
+  values.resize(bindingsKeys.size());
+  counts.resize(bindingsKeys.size());
+}
+
+void ArrowTableSlicingCache::setCaches(std::vector<std::pair<std::string, std::string>>&& bsks)
+{
+  bindingsKeys = bsks;
+  values.clear();
+  values.resize(bindingsKeys.size());
+  counts.clear();
+  counts.resize(bindingsKeys.size());
+}
+
+arrow::Status ArrowTableSlicingCache::updateCacheEntry(int pos, std::shared_ptr<arrow::Table>&& table)
+{
+  if (table->num_rows() == 0) {
+    values[pos] = std::make_shared<arrow::NumericArray<arrow::Int32Type>>();
+    counts[pos] = std::make_shared<arrow::NumericArray<arrow::Int64Type>>();
+    return arrow::Status::OK();
+  }
+  arrow::Datum value_counts;
+  auto options = arrow::compute::ScalarAggregateOptions::Defaults();
+  ARROW_ASSIGN_OR_RAISE(value_counts,
+                        arrow::compute::CallFunction("value_counts", {table->GetColumnByName(bindingsKeys[pos].second)},
+                                                     &options));
+  auto pair = static_cast<arrow::StructArray>(value_counts.array());
+  values[pos] = std::make_shared<arrow::NumericArray<arrow::Int32Type>>(pair.field(0)->data());
+  counts[pos] = std::make_shared<arrow::NumericArray<arrow::Int64Type>>(pair.field(1)->data());
+  return arrow::Status::OK();
+}
+
+SliceInfoPtr ArrowTableSlicingCache::getCacheFor(std::pair<std::string, std::string> const& bindingKey) const
+{
+  auto locate = std::find_if(bindingsKeys.begin(), bindingsKeys.end(), [&](std::pair<std::string, std::string> const& bk) { return (bindingKey.first == bk.first) && (bindingKey.second == bk.second); });
+  if (locate == bindingsKeys.end()) {
+    throw runtime_error_f("Slicing cache miss for %s/%s", bindingKey.first.c_str(), bindingKey.second.c_str());
+  }
+  auto i = std::distance(bindingsKeys.begin(), locate);
+
+  return {
+    {reinterpret_cast<int const*>(values[i]->values()->data()), static_cast<size_t>(values[i]->length())},
+    {reinterpret_cast<int64_t const*>(counts[i]->values()->data()), static_cast<size_t>(counts[i]->length())} //
+  };
+}
+} // namespace o2::framework

--- a/Framework/Core/src/ArrowTableSlicingCache.cxx
+++ b/Framework/Core/src/ArrowTableSlicingCache.cxx
@@ -55,7 +55,7 @@ void ArrowTableSlicingCache::setCaches(std::vector<std::pair<std::string, std::s
   counts.resize(bindingsKeys.size());
 }
 
-arrow::Status ArrowTableSlicingCache::updateCacheEntry(int pos, std::shared_ptr<arrow::Table>&& table)
+arrow::Status ArrowTableSlicingCache::updateCacheEntry(int pos, std::shared_ptr<arrow::Table> table)
 {
   if (table->num_rows() == 0) {
     values[pos] = std::make_shared<arrow::NumericArray<arrow::Int32Type>>();

--- a/Framework/Core/src/CommonServices.cxx
+++ b/Framework/Core/src/CommonServices.cxx
@@ -935,8 +935,8 @@ std::vector<ServiceSpec> CommonServices::defaultServices(int numThreads)
     dataSender(),
     objectCache(),
     ccdbSupportSpec(),
-    CommonMessageBackends::fairMQBackendSpec(),
     ArrowSupport::arrowBackendSpec(),
+    CommonMessageBackends::fairMQBackendSpec(),
     CommonMessageBackends::stringBackendSpec(),
     decongestionSpec()};
 
@@ -965,6 +965,14 @@ std::vector<ServiceSpec> CommonServices::defaultServices(int numThreads)
     specs.push_back(threadPool(numThreads));
   }
   return specs;
+}
+
+std::vector<ServiceSpec> CommonServices::arrowServices()
+{
+  return {
+    ArrowSupport::arrowTableSlicingCacheDefSpec(),
+    ArrowSupport::arrowTableSlicingCacheSpec() //
+  };
 }
 
 } // namespace o2::framework

--- a/Framework/Core/src/InputRecord.cxx
+++ b/Framework/Core/src/InputRecord.cxx
@@ -179,6 +179,7 @@ size_t InputRecord::countValidInputs() const
       ss << ", ";
     }
     ss << route.matcher.binding;
+    first = false;
   }
   return ss.str();
 }

--- a/Framework/Core/test/benchmark_ASoA.cxx
+++ b/Framework/Core/test/benchmark_ASoA.cxx
@@ -20,7 +20,8 @@ using namespace o2::framework;
 using namespace arrow;
 using namespace o2::soa;
 
-DECLARE_SOA_STORE();
+DECLARE_SOA_METADATA();
+DECLARE_SOA_VERSIONING();
 namespace test
 {
 DECLARE_SOA_COLUMN_FULL(X, x, float, "x");

--- a/Framework/Core/test/benchmark_EventMixing.cxx
+++ b/Framework/Core/test/benchmark_EventMixing.cxx
@@ -78,6 +78,10 @@ static void BM_EventMixingTraditional(benchmark::State& state)
   auto tableTrack = trackBuilder.finalize();
   o2::aod::StoredTracks tracks{tableTrack};
 
+  ArrowTableSlicingCache atscache({{getLabelFromType<o2::aod::StoredTracks>(), "fIndex" + cutString(getLabelFromType<o2::aod::Collisions>())}});
+  auto s = atscache.updateCacheEntry(0, tableTrack);
+  SliceCache cache{&atscache};
+
   int64_t count = 0;
   int64_t colCount = 0;
   int nBinsTot = (xBins.size() - 2) * (yBins.size() - 2);
@@ -99,9 +103,9 @@ static void BM_EventMixingTraditional(benchmark::State& state)
       auto& mixingBuffer = mixingBufferVector[bin];
 
       if (mixingBuffer.size() > 0) {
-        auto tracks1 = tracks.sliceByCached(o2::aod::track::collisionId, col1.globalIndex());
+        auto tracks1 = tracks.sliceByCached(o2::aod::track::collisionId, col1.globalIndex(), cache);
         for (auto& col2 : mixingBuffer) {
-          auto tracks2 = tracks.sliceByCached(o2::aod::track::collisionId, col2.globalIndex());
+          auto tracks2 = tracks.sliceByCached(o2::aod::track::collisionId, col2.globalIndex(), cache);
           for (auto& [t1, t2] : combinations(CombinationsFullIndexPolicy(tracks1, tracks2))) {
             count++;
           }

--- a/Framework/Core/test/test_ASoA.cxx
+++ b/Framework/Core/test/test_ASoA.cxx
@@ -24,7 +24,8 @@ using namespace o2::framework;
 using namespace arrow;
 using namespace o2::soa;
 
-DECLARE_SOA_STORE();
+DECLARE_SOA_METADATA();
+DECLARE_SOA_VERSIONING();
 namespace test
 {
 DECLARE_SOA_COLUMN_FULL(X, x, int32_t, "x");
@@ -940,39 +941,39 @@ TEST_CASE("TestListColumns")
   }
 }
 
-TEST_CASE("TestSliceBy")
-{
-  o2::framework::Preslice<References> slices = test::originId;
-  slices.setNewDF();
-  TableBuilder b;
-  auto writer = b.cursor<Origins>();
-  for (auto i = 0; i < 20; ++i) {
-    writer(0, i, i % 3 == 0);
-  }
-  auto origins = b.finalize();
-  Origins o{origins};
+// TEST_CASE("TestSliceBy")
+//{
+//   o2::framework::Preslice<References> slices = test::originId;
+//   slices.setNewDF();
+//   TableBuilder b;
+//   auto writer = b.cursor<Origins>();
+//   for (auto i = 0; i < 20; ++i) {
+//     writer(0, i, i % 3 == 0);
+//   }
+//   auto origins = b.finalize();
+//   Origins o{origins};
 
-  TableBuilder w;
-  auto writer_w = w.cursor<References>();
-  auto step = -1;
-  for (auto i = 0; i < 5 * 20; ++i) {
-    if (i % 5 == 0) {
-      ++step;
-    }
-    writer_w(0, step);
-  }
-  auto refs = w.finalize();
-  References r{refs};
-  auto status = slices.processTable(refs);
+//  TableBuilder w;
+//  auto writer_w = w.cursor<References>();
+//  auto step = -1;
+//  for (auto i = 0; i < 5 * 20; ++i) {
+//    if (i % 5 == 0) {
+//      ++step;
+//    }
+//    writer_w(0, step);
+//  }
+//  auto refs = w.finalize();
+//  References r{refs};
+//  auto status = slices.processTable(refs);
 
-  for (auto& oi : o) {
-    auto cachedSlice = r.sliceBy(slices, oi.globalIndex());
-    REQUIRE(cachedSlice.size() == 5);
-    for (auto& ri : cachedSlice) {
-      REQUIRE(ri.originId() == oi.globalIndex());
-    }
-  }
-}
+//  for (auto& oi : o) {
+//    auto cachedSlice = r.sliceBy(slices, oi.globalIndex());
+//    REQUIRE(cachedSlice.size() == 5);
+//    for (auto& ri : cachedSlice) {
+//      REQUIRE(ri.originId() == oi.globalIndex());
+//    }
+//  }
+//}
 
 TEST_CASE("TestIndexUnboundExceptions")
 {

--- a/Framework/Core/test/test_ASoA.cxx
+++ b/Framework/Core/test/test_ASoA.cxx
@@ -24,15 +24,15 @@ using namespace o2::framework;
 using namespace arrow;
 using namespace o2::soa;
 
-DECLARE_SOA_METADATA();
-DECLARE_SOA_VERSIONING();
+namespace o2::aod
+{
 namespace test
 {
-DECLARE_SOA_COLUMN_FULL(X, x, int32_t, "x");
-DECLARE_SOA_COLUMN_FULL(Y, y, int32_t, "y");
-DECLARE_SOA_COLUMN_FULL(Z, z, int32_t, "z");
-DECLARE_SOA_DYNAMIC_COLUMN(Sum, sum, [](int32_t x, int32_t y) { return x + y; });
-DECLARE_SOA_EXPRESSION_COLUMN(ESum, esum, int32_t, test ::x + test::y);
+DECLARE_SOA_COLUMN(X, x, int);
+DECLARE_SOA_COLUMN(Y, y, int);
+DECLARE_SOA_COLUMN(Z, z, int);
+DECLARE_SOA_DYNAMIC_COLUMN(Sum, sum, [](int x, int y) { return x + y; });
+DECLARE_SOA_EXPRESSION_COLUMN(ESum, esum, int, test::x + test::y);
 } // namespace test
 
 DECLARE_SOA_TABLE(Points, "TST", "POINTS", test::X, test::Y);
@@ -69,20 +69,21 @@ DECLARE_SOA_COLUMN(L2, l2, std::vector<int>);
 } // namespace test
 
 DECLARE_SOA_TABLE(Lists, "TST", "LISTS", o2::soa::Index<>, test::L1, test::L2);
+} // namespace o2::aod
 
 TEST_CASE("TestMarkers")
 {
   TableBuilder b1;
-  auto pwriter = b1.cursor<Points3Ds>();
+  auto pwriter = b1.cursor<o2::aod::Points3Ds>();
   for (auto i = 0; i < 20; ++i) {
     pwriter(0, -1 * i, (int)(i / 2), 2 * i);
   }
   auto t1 = b1.finalize();
 
-  auto pt = Points3Ds{t1};
-  auto pt1 = Points3DsMk1{t1};
-  auto pt2 = Points3DsMk2{t1};
-  auto pt3 = Points3DsMk3{t1};
+  auto pt = o2::aod::Points3Ds{t1};
+  auto pt1 = o2::aod::Points3DsMk1{t1};
+  auto pt2 = o2::aod::Points3DsMk2{t1};
+  auto pt3 = o2::aod::Points3DsMk3{t1};
   REQUIRE(pt1.begin().mark() == (size_t)1);
   REQUIRE(pt2.begin().mark() == (size_t)2);
   REQUIRE(pt3.begin().mark() == (size_t)3);
@@ -91,7 +92,7 @@ TEST_CASE("TestMarkers")
 TEST_CASE("TestTableIteration")
 {
   TableBuilder builder;
-  auto rowWriter = builder.persist<int32_t, int32_t>({"x", "y"});
+  auto rowWriter = builder.persist<int32_t, int32_t>({"fX", "fY"});
   rowWriter(0, 0, 0);
   rowWriter(0, 0, 1);
   rowWriter(0, 0, 2);
@@ -124,13 +125,13 @@ TEST_CASE("TestTableIteration")
   arrow::ChunkedArray* chunks[2] = {
     table->column(0).get(),
     table->column(1).get()};
-  Points::iterator tests(chunks, {table->num_rows(), 0});
+  o2::aod::Points::iterator tests(chunks, {table->num_rows(), 0});
   REQUIRE(tests.x() == 0);
   REQUIRE(tests.y() == 0);
   ++tests;
   REQUIRE(tests.x() == 0);
   REQUIRE(tests.y() == 1);
-  using Test = o2::soa::Table<test::X, test::Y>;
+  using Test = o2::soa::Table<o2::aod::test::X, o2::aod::test::Y>;
   Test tests2{table};
   size_t value = 0;
   auto b = tests2.begin();
@@ -169,7 +170,7 @@ TEST_CASE("TestTableIteration")
 TEST_CASE("TestDynamicColumns")
 {
   TableBuilder builder;
-  auto rowWriter = builder.persist<int32_t, int32_t>({"x", "y"});
+  auto rowWriter = builder.persist<int32_t, int32_t>({"fX", "fY"});
   rowWriter(0, 0, 0);
   rowWriter(0, 0, 1);
   rowWriter(0, 0, 2);
@@ -180,14 +181,14 @@ TEST_CASE("TestDynamicColumns")
   rowWriter(0, 1, 7);
   auto table = builder.finalize();
 
-  using Test = o2::soa::Table<test::X, test::Y, test::Sum<test::X, test::Y>>;
+  using Test = o2::soa::Table<o2::aod::test::X, o2::aod::test::Y, o2::aod::test::Sum<o2::aod::test::X, o2::aod::test::Y>>;
 
   Test tests{table};
   for (auto& test : tests) {
     REQUIRE(test.sum() == test.x() + test.y());
   }
 
-  using Test2 = o2::soa::Table<test::X, test::Y, test::Sum<test::Y, test::Y>>;
+  using Test2 = o2::soa::Table<o2::aod::test::X, o2::aod::test::Y, o2::aod::test::Sum<o2::aod::test::Y, o2::aod::test::Y>>;
 
   Test2 tests2{table};
   for (auto& test : tests2) {
@@ -198,7 +199,7 @@ TEST_CASE("TestDynamicColumns")
 TEST_CASE("TestColumnIterators")
 {
   TableBuilder builder;
-  auto rowWriter = builder.persist<int32_t, int32_t>({"x", "y"});
+  auto rowWriter = builder.persist<int32_t, int32_t>({"fX", "fY"});
   rowWriter(0, 0, 0);
   rowWriter(0, 0, 1);
   rowWriter(0, 0, 2);
@@ -232,7 +233,7 @@ TEST_CASE("TestColumnIterators")
 TEST_CASE("TestJoinedTables")
 {
   TableBuilder builderX;
-  auto rowWriterX = builderX.persist<int32_t>({"x"});
+  auto rowWriterX = builderX.persist<int32_t>({"fX"});
   rowWriterX(0, 0);
   rowWriterX(0, 1);
   rowWriterX(0, 2);
@@ -244,7 +245,7 @@ TEST_CASE("TestJoinedTables")
   auto tableX = builderX.finalize();
 
   TableBuilder builderY;
-  auto rowWriterY = builderY.persist<int32_t>({"y"});
+  auto rowWriterY = builderY.persist<int32_t>({"fY"});
   rowWriterY(0, 7);
   rowWriterY(0, 6);
   rowWriterY(0, 5);
@@ -256,7 +257,7 @@ TEST_CASE("TestJoinedTables")
   auto tableY = builderY.finalize();
 
   TableBuilder builderZ;
-  auto rowWriterZ = builderZ.persist<int32_t>({"z"});
+  auto rowWriterZ = builderZ.persist<int32_t>({"fZ"});
   rowWriterZ(0, 8);
   rowWriterZ(0, 8);
   rowWriterZ(0, 8);
@@ -267,9 +268,9 @@ TEST_CASE("TestJoinedTables")
   rowWriterZ(0, 8);
   auto tableZ = builderZ.finalize();
 
-  using TestX = o2::soa::Table<test::X>;
-  using TestY = o2::soa::Table<test::Y>;
-  using TestZ = o2::soa::Table<test::Z>;
+  using TestX = o2::soa::Table<o2::aod::test::X>;
+  using TestY = o2::soa::Table<o2::aod::test::Y>;
+  using TestZ = o2::soa::Table<o2::aod::test::Z>;
   using Test = Join<TestX, TestY>;
 
   REQUIRE(Test::contains<TestX>());
@@ -308,7 +309,7 @@ TEST_CASE("TestJoinedTables")
 TEST_CASE("TestConcatTables")
 {
   TableBuilder builderA;
-  auto rowWriterA = builderA.persist<int32_t, int32_t>({"x", "y"});
+  auto rowWriterA = builderA.persist<int32_t, int32_t>({"fX", "fY"});
   rowWriterA(0, 0, 0);
   rowWriterA(0, 1, 0);
   rowWriterA(0, 2, 0);
@@ -321,7 +322,7 @@ TEST_CASE("TestConcatTables")
   REQUIRE(tableA->num_rows() == 8);
 
   TableBuilder builderB;
-  auto rowWriterB = builderB.persist<int32_t>({"x"});
+  auto rowWriterB = builderB.persist<int32_t>({"fX"});
   rowWriterB(0, 8);
   rowWriterB(0, 9);
   rowWriterB(0, 10);
@@ -333,7 +334,7 @@ TEST_CASE("TestConcatTables")
   auto tableB = builderB.finalize();
 
   TableBuilder builderC;
-  auto rowWriterC = builderC.persist<int32_t>({"z"});
+  auto rowWriterC = builderC.persist<int32_t>({"fZ"});
   rowWriterC(0, 8);
   rowWriterC(0, 9);
   rowWriterC(0, 10);
@@ -345,7 +346,7 @@ TEST_CASE("TestConcatTables")
   auto tableC = builderC.finalize();
 
   TableBuilder builderD;
-  auto rowWriterD = builderD.persist<int32_t, int32_t>({"x", "z"});
+  auto rowWriterD = builderD.persist<int32_t, int32_t>({"fX", "fZ"});
   rowWriterD(0, 16, 8);
   rowWriterD(0, 17, 9);
   rowWriterD(0, 18, 10);
@@ -356,37 +357,37 @@ TEST_CASE("TestConcatTables")
   rowWriterD(0, 23, 15);
   auto tableD = builderD.finalize();
 
-  using TestA = o2::soa::Table<o2::soa::Index<>, test::X, test::Y>;
-  using TestB = o2::soa::Table<o2::soa::Index<>, test::X>;
-  using TestC = o2::soa::Table<test::Z>;
-  using TestD = o2::soa::Table<test::X, test::Z>;
+  using TestA = o2::soa::Table<o2::soa::Index<>, o2::aod::test::X, o2::aod::test::Y>;
+  using TestB = o2::soa::Table<o2::soa::Index<>, o2::aod::test::X>;
+  using TestC = o2::soa::Table<o2::aod::test::Z>;
+  using TestD = o2::soa::Table<o2::aod::test::X, o2::aod::test::Z>;
   using ConcatTest = Concat<TestA, TestB>;
   using JoinedTest = Join<TestA, TestC>;
   using NestedJoinTest = Join<JoinedTest, TestD>;
   using NestedConcatTest = Concat<Join<TestA, TestB>, TestD>;
 
-  static_assert(std::is_same_v<NestedJoinTest::table_t, o2::soa::Table<o2::soa::Index<>, test::Y, test::X, test::Z>>, "Bad nested join");
+  static_assert(std::is_same_v<NestedJoinTest::table_t, o2::soa::Table<o2::soa::Index<>, o2::aod::test::Y, o2::aod::test::X, o2::aod::test::Z>>, "Bad nested join");
 
-  static_assert(std::is_same_v<ConcatTest::table_t, o2::soa::Table<o2::soa::Index<>, test::X>>, "Bad intersection of columns");
+  static_assert(std::is_same_v<ConcatTest::table_t, o2::soa::Table<o2::soa::Index<>, o2::aod::test::X>>, "Bad intersection of columns");
   ConcatTest tests{tableA, tableB};
   REQUIRE(16 == tests.size());
   for (auto& test : tests) {
     REQUIRE(test.index() == test.x());
   }
 
-  static_assert(std::is_same_v<NestedConcatTest::table_t, o2::soa::Table<test::X>>, "Bad nested concat");
+  static_assert(std::is_same_v<NestedConcatTest::table_t, o2::soa::Table<o2::aod::test::X>>, "Bad nested concat");
 
   // Hardcode a selection for the first 5 odd numbers
   using FilteredTest = Filtered<TestA>;
   using namespace o2::framework;
-  expressions::Filter testf = (test::x == 1) || (test::x == 3);
+  expressions::Filter testf = (o2::aod::test::x == 1) || (o2::aod::test::x == 3);
   gandiva::Selection selection;
   auto status = gandiva::SelectionVector::MakeInt64(tests.size(), arrow::default_memory_pool(), &selection);
   REQUIRE(status.ok());
 
-  auto fptr = tableA->schema()->GetFieldByName("x");
+  auto fptr = tableA->schema()->GetFieldByName("fX");
   REQUIRE(fptr != nullptr);
-  REQUIRE(fptr->name() == "x");
+  REQUIRE(fptr->name() == "fX");
   REQUIRE(fptr->type()->id() == arrow::Type::INT32);
 
   auto node_x = gandiva::TreeExprBuilder::MakeField(fptr);
@@ -396,7 +397,7 @@ TEST_CASE("TestConcatTables")
   auto equals_to_3 = gandiva::TreeExprBuilder::MakeFunction("equal", {node_x, literal_3}, arrow::boolean());
   auto node_or = gandiva::TreeExprBuilder::MakeOr({equals_to_1, equals_to_3});
   auto condition = gandiva::TreeExprBuilder::MakeCondition(node_or);
-  REQUIRE(condition->ToString() == "bool equal((int32) x, (const int32) 1) || bool equal((int32) x, (const int32) 3)");
+  REQUIRE(condition->ToString() == "bool equal((int32) fX, (const int32) 1) || bool equal((int32) fX, (const int32) 3)");
   std::shared_ptr<gandiva::Filter> filter;
   status = gandiva::Filter::Make(tableA->schema(), condition, &filter);
   REQUIRE(status.ToString() == "OK");
@@ -481,20 +482,20 @@ TEST_CASE("TestConcatTables")
 TEST_CASE("TestDereference")
 {
   TableBuilder builderA;
-  auto pointsWriter = builderA.cursor<Points>();
+  auto pointsWriter = builderA.cursor<o2::aod::Points>();
   pointsWriter(0, 0, 0);
   pointsWriter(0, 3, 4);
   auto pointsT = builderA.finalize();
-  Points points{pointsT};
+  o2::aod::Points points{pointsT};
   REQUIRE(pointsT->num_rows() == 2);
 
   TableBuilder builderA2;
-  auto infoWriter = builderA2.cursor<Infos>();
+  auto infoWriter = builderA2.cursor<o2::aod::Infos>();
   infoWriter(0, 0, true);
   infoWriter(0, 1, false);
   infoWriter(0, 4, true);
   auto infosT = builderA2.finalize();
-  Infos infos{infosT};
+  o2::aod::Infos infos{infosT};
   REQUIRE(infos.begin().someBool() == true);
   REQUIRE((infos.begin() + 1).someBool() == false);
   REQUIRE((infos.begin() + 2).someBool() == true);
@@ -502,22 +503,22 @@ TEST_CASE("TestDereference")
   REQUIRE(infosT->num_rows() == 3);
 
   TableBuilder builderB;
-  auto segmentsWriter = builderB.cursor<Segments>();
+  auto segmentsWriter = builderB.cursor<o2::aod::Segments>();
   segmentsWriter(0, 10, 0, 1, 2);
   auto segmentsT = builderB.finalize();
-  Segments segments{segmentsT};
+  o2::aod::Segments segments{segmentsT};
   REQUIRE(segmentsT->num_rows() == 1);
 
   TableBuilder builderC;
-  auto segmentsExtraWriter = builderC.cursor<SegmentsExtras>();
+  auto segmentsExtraWriter = builderC.cursor<o2::aod::SegmentsExtras>();
   segmentsExtraWriter(0, 1);
   auto segmentsExtraT = builderC.finalize();
-  SegmentsExtras segmentsExtras{segmentsExtraT};
+  o2::aod::SegmentsExtras segmentsExtras{segmentsExtraT};
   REQUIRE(segmentsExtraT->num_rows() == 1);
 
   REQUIRE(segments.begin().pointAId() == 0);
   REQUIRE(segments.begin().pointBId() == 1);
-  static_assert(std::is_same_v<decltype(segments.begin().pointA()), Points::iterator>);
+  static_assert(std::is_same_v<decltype(segments.begin().pointA()), o2::aod::Points::iterator>);
   auto i = segments.begin();
   using namespace o2::framework;
   i.bindExternalIndices(&points, &infos);
@@ -553,16 +554,16 @@ TEST_CASE("TestDereference")
 
 TEST_CASE("TestSchemaCreation")
 {
-  auto schema = std::make_shared<arrow::Schema>(createFieldsFromColumns(Points::persistent_columns_t{}));
+  auto schema = std::make_shared<arrow::Schema>(createFieldsFromColumns(o2::aod::Points::persistent_columns_t{}));
   REQUIRE(schema->num_fields() == 2);
-  REQUIRE(schema->field(0)->name() == "x");
-  REQUIRE(schema->field(1)->name() == "y");
+  REQUIRE(schema->field(0)->name() == "fX");
+  REQUIRE(schema->field(1)->name() == "fY");
 }
 
 TEST_CASE("TestFilteredOperators")
 {
   TableBuilder builderA;
-  auto rowWriterA = builderA.persist<int32_t, int32_t>({"x", "y"});
+  auto rowWriterA = builderA.persist<int32_t, int32_t>({"fX", "fY"});
   rowWriterA(0, 0, 8);
   rowWriterA(0, 1, 9);
   rowWriterA(0, 2, 10);
@@ -574,13 +575,13 @@ TEST_CASE("TestFilteredOperators")
   auto tableA = builderA.finalize();
   REQUIRE(tableA->num_rows() == 8);
 
-  using TestA = o2::soa::Table<o2::soa::Index<>, test::X, test::Y>;
+  using TestA = o2::soa::Table<o2::soa::Index<>, o2::aod::test::X, o2::aod::test::Y>;
   using FilteredTest = Filtered<TestA>;
   using NestedFilteredTest = Filtered<Filtered<TestA>>;
   using namespace o2::framework;
 
-  expressions::Filter f1 = test::x < 4;
-  expressions::Filter f2 = test::y > 13;
+  expressions::Filter f1 = o2::aod::test::x < 4;
+  expressions::Filter f2 = o2::aod::test::y > 13;
 
   TestA testA{tableA};
   auto s1 = expressions::createSelection(testA.asArrowTable(), f1);
@@ -616,7 +617,7 @@ TEST_CASE("TestFilteredOperators")
   }
   REQUIRE(i == 0);
 
-  expressions::Filter f3 = test::x < 3;
+  expressions::Filter f3 = o2::aod::test::x < 3;
   auto s3 = expressions::createSelection(testA.asArrowTable(), f3);
   FilteredTest filtered3{{testA.asArrowTable()}, s3};
   REQUIRE(3 == filtered3.size());
@@ -638,7 +639,7 @@ TEST_CASE("TestFilteredOperators")
 TEST_CASE("TestNestedFiltering")
 {
   TableBuilder builderA;
-  auto rowWriterA = builderA.persist<int32_t, int32_t>({"x", "y"});
+  auto rowWriterA = builderA.persist<int32_t, int32_t>({"fX", "fY"});
   rowWriterA(0, 0, 8);
   rowWriterA(0, 1, 9);
   rowWriterA(0, 2, 10);
@@ -650,15 +651,15 @@ TEST_CASE("TestNestedFiltering")
   auto tableA = builderA.finalize();
   REQUIRE(tableA->num_rows() == 8);
 
-  using TestA = o2::soa::Table<o2::soa::Index<>, test::X, test::Y>;
+  using TestA = o2::soa::Table<o2::soa::Index<>, o2::aod::test::X, o2::aod::test::Y>;
   using FilteredTest = Filtered<TestA>;
   using NestedFilteredTest = Filtered<Filtered<TestA>>;
   using TripleNestedFilteredTest = Filtered<Filtered<Filtered<TestA>>>;
   using namespace o2::framework;
 
-  expressions::Filter f1 = test::x < 4;
-  expressions::Filter f2 = test::y > 9;
-  expressions::Filter f3 = test::x < 3;
+  expressions::Filter f1 = o2::aod::test::x < 4;
+  expressions::Filter f2 = o2::aod::test::y > 9;
+  expressions::Filter f3 = o2::aod::test::x < 3;
 
   TestA testA{tableA};
   auto s1 = expressions::createSelection(testA.asArrowTable(), f1);
@@ -694,60 +695,63 @@ TEST_CASE("TestNestedFiltering")
 TEST_CASE("TestEmptyTables")
 {
   TableBuilder bPoints;
-  auto pwriter = bPoints.cursor<Points>();
+  auto pwriter = bPoints.cursor<o2::aod::Points>();
   auto pempty = bPoints.finalize();
 
   TableBuilder bInfos;
-  auto iwriter = bInfos.cursor<Infos>();
+  auto iwriter = bInfos.cursor<o2::aod::Infos>();
   auto iempty = bInfos.finalize();
 
-  Points p{pempty};
-  Infos i{iempty};
+  o2::aod::Points p{pempty};
+  o2::aod::Infos i{iempty};
 
-  using PI = Join<Points, Infos>;
+  using PI = Join<o2::aod::Points, o2::aod::Infos>;
   PI pi{0, pempty, iempty};
   REQUIRE(pi.size() == 0);
-  auto spawned = Extend<Points, test::ESum>(p);
+  auto spawned = Extend<o2::aod::Points, o2::aod::test::ESum>(p);
   REQUIRE(spawned.size() == 0);
 }
 
-DECLARE_SOA_TABLE(Origins, "TST", "ORIG", o2::soa::Index<>, test::X, test::SomeBool);
+namespace o2::aod
+{
+DECLARE_SOA_TABLE(Origints, "TST", "ORIG", o2::soa::Index<>, test::X, test::SomeBool);
 namespace test
 {
-DECLARE_SOA_INDEX_COLUMN(Origin, origin);
+DECLARE_SOA_INDEX_COLUMN(Origint, origint);
 }
-DECLARE_SOA_TABLE(References, "TST", "REFS", o2::soa::Index<>, test::OriginId);
-
+DECLARE_SOA_TABLE(References, "TST", "REFS", o2::soa::Index<>, test::OrigintId);
+} // namespace o2::aod
 TEST_CASE("TestIndexToFiltered")
 {
   TableBuilder b;
-  auto writer = b.cursor<Origins>();
+  auto writer = b.cursor<o2::aod::Origints>();
   for (auto i = 0; i < 20; ++i) {
     writer(0, i, i % 3 == 0);
   }
   auto origins = b.finalize();
-  Origins o{origins};
+  o2::aod::Origints o{origins};
 
   TableBuilder w;
-  auto writer_w = w.cursor<References>();
+  auto writer_w = w.cursor<o2::aod::References>();
   for (auto i = 0; i < 5 * 20; ++i) {
     writer_w(0, i % 20);
   }
   auto refs = w.finalize();
-  References r{refs};
-  expressions::Filter flt = test::someBool == true;
-  using Flt = o2::soa::Filtered<Origins>;
+  o2::aod::References r{refs};
+  expressions::Filter flt = o2::aod::test::someBool == true;
+  using Flt = o2::soa::Filtered<o2::aod::Origints>;
   Flt f{{o.asArrowTable()}, expressions::createSelection(o.asArrowTable(), flt)};
   r.bindExternalIndices(&f);
   auto it = r.begin();
   it.moveByIndex(23);
-  REQUIRE(it.origin().globalIndex() == 3);
+  REQUIRE(it.origint().globalIndex() == 3);
   it++;
-  REQUIRE(it.origin().globalIndex() == 4);
+  REQUIRE(it.origint().globalIndex() == 4);
   it++;
-  REQUIRE(it.origin().globalIndex() == 5);
+  REQUIRE(it.origint().globalIndex() == 5);
 }
-
+namespace o2::aod
+{
 namespace test
 {
 DECLARE_SOA_INDEX_COLUMN_FULL(SinglePoint, singlePoint, int32_t, Points3Ds, "");
@@ -762,18 +766,19 @@ DECLARE_SOA_TABLE(PointsRef, "TST", "PTSREF", test::Points3DIdSlice, test::Point
 DECLARE_SOA_TABLE(PointsRefF, "TST", "PTSREFF", test::SinglePointId, test::Points3DIdSlice, test::Points3DIds);
 DECLARE_SOA_TABLE(PointsSelfIndex, "TST", "PTSSLF", o2::soa::Index<>, test::X, test::Y, test::Z, test::OtherPointId,
                   test::PointSeqIdSlice, test::PointSetIds);
+} // namespace o2::aod
 
 TEST_CASE("TestAdvancedIndices")
 {
   TableBuilder b1;
-  auto pwriter = b1.cursor<Points3Ds>();
+  auto pwriter = b1.persist<int, int, int>({"fX", "fY", "fZ"});
   for (auto i = 0; i < 20; ++i) {
     pwriter(0, -1 * i, (int)(i / 2), 2 * i);
   }
-  auto t1 = b1.finalize();
+  auto tpts1 = b1.finalize();
 
   TableBuilder b2;
-  auto prwriter = b2.cursor<PointsRef>();
+  auto prwriter = b2.cursor<o2::aod::PointsRef>();
   auto a = std::array{0, 1};
   auto aa = std::vector{2, 3, 4};
   prwriter(0, &a[0], aa);
@@ -782,14 +787,14 @@ TEST_CASE("TestAdvancedIndices")
   prwriter(0, &a[0], aa);
   auto t2 = b2.finalize();
 
-  auto pt = Points3Ds{t1};
-  auto prt = PointsRef{t2};
+  auto pt = o2::aod::Points3Ds{tpts1};
+  auto prt = o2::aod::PointsRef{t2};
   prt.bindExternalIndices(&pt);
 
   auto it = prt.begin();
   auto s1 = it.pointSlice();
   auto g1 = it.pointGroup();
-  auto bb = std::is_same_v<decltype(s1), Points3Ds>;
+  auto bb = std::is_same_v<decltype(s1), o2::aod::Points3Ds>;
   REQUIRE(bb);
   REQUIRE(s1.size() == 2);
   aa = {2, 3, 4};
@@ -799,7 +804,7 @@ TEST_CASE("TestAdvancedIndices")
 
   // Check the X coordinate of the points in the pointGroup
   // for the first point.
-  for (auto& p : it.pointGroup_as<Points3Ds>()) {
+  for (auto& p : it.pointGroup_as<o2::aod::Points3Ds>()) {
     REQUIRE(p.x() == -1 * p.globalIndex());
   }
 
@@ -812,9 +817,9 @@ TEST_CASE("TestAdvancedIndices")
     REQUIRE(g2[i].globalIndex() == aa[i]);
   }
 
-  using Flt = o2::soa::Filtered<Points3Ds>;
-  expressions::Filter flt = test::x <= -6;
-  Flt f{{pt.asArrowTable()}, expressions::createSelection(pt.asArrowTable(), flt)};
+  using Flt = o2::soa::Filtered<o2::aod::Points3Ds>;
+  expressions::Filter fltx = (o2::aod::test::x <= -6);
+  Flt f{{tpts1}, expressions::createSelection(tpts1, fltx)};
   prt.bindExternalIndices(&f);
 
   auto it2 = prt.begin();
@@ -836,7 +841,7 @@ TEST_CASE("TestAdvancedIndices")
   }
 
   TableBuilder b3;
-  auto pswriter = b3.cursor<PointsSelfIndex>();
+  auto pswriter = b3.cursor<o2::aod::PointsSelfIndex>();
   int references[] = {19, 2, 0, 13, 4, 6, 5, 5, 11, 9, 3, 8, 16, 14, 1, 18, 12, 18, 2, 7};
   int slice[2] = {-1, -1};
   std::vector<int> pset;
@@ -863,18 +868,18 @@ TEST_CASE("TestAdvancedIndices")
     pswriter(0, -1 * i, 0.5 * i, 2 * i, references[i], slice, pset);
   }
   auto t3 = b3.finalize();
-  auto pst = PointsSelfIndex{t3};
+  auto pst = o2::aod::PointsSelfIndex{t3};
   pst.bindInternalIndicesTo(&pst);
   auto i = 0;
   c1 = 0;
   c2 = 0;
   for (auto& p : pst) {
-    auto op = p.otherPoint_as<PointsSelfIndex>();
-    auto bbb = std::is_same_v<decltype(op), PointsSelfIndex::iterator>;
+    auto op = p.otherPoint_as<o2::aod::PointsSelfIndex>();
+    auto bbb = std::is_same_v<decltype(op), o2::aod::PointsSelfIndex::iterator>;
     REQUIRE(bbb);
     REQUIRE(op.globalIndex() == references[i]);
 
-    auto ops = p.pointSeq_as<PointsSelfIndex>();
+    auto ops = p.pointSeq_as<o2::aod::PointsSelfIndex>();
     if (i == withSlices[c1]) {
       auto it = ops.begin();
       REQUIRE(ops.size() == 2);
@@ -885,7 +890,7 @@ TEST_CASE("TestAdvancedIndices")
     } else {
       REQUIRE(ops.size() == 0);
     }
-    auto opss = p.pointSet_as<PointsSelfIndex>();
+    auto opss = p.pointSet_as<o2::aod::PointsSelfIndex>();
     auto opss_ids = p.pointSetIds();
     if (c2 < withSets.size() && i == withSets[c2]) {
       REQUIRE(opss.size() == sizes[c2]);
@@ -907,7 +912,7 @@ TEST_CASE("TestAdvancedIndices")
 TEST_CASE("TestListColumns")
 {
   TableBuilder b;
-  auto writer = b.cursor<Lists>();
+  auto writer = b.cursor<o2::aod::Lists>();
   std::vector<float> floats;
   std::vector<int> ints;
   for (auto i = 1; i < 11; ++i) {
@@ -921,7 +926,7 @@ TEST_CASE("TestListColumns")
     writer(0, floats, ints);
   }
   auto lt = b.finalize();
-  Lists tbl{lt};
+  o2::aod::Lists tbl{lt};
   int s = 1;
   for (auto& row : tbl) {
     auto f = row.l1();
@@ -941,44 +946,45 @@ TEST_CASE("TestListColumns")
   }
 }
 
-// TEST_CASE("TestSliceBy")
-//{
-//   o2::framework::Preslice<References> slices = test::originId;
-//   slices.setNewDF();
-//   TableBuilder b;
-//   auto writer = b.cursor<Origins>();
-//   for (auto i = 0; i < 20; ++i) {
-//     writer(0, i, i % 3 == 0);
-//   }
-//   auto origins = b.finalize();
-//   Origins o{origins};
+TEST_CASE("TestSliceByCached")
+{
+  TableBuilder b;
+  auto writer = b.cursor<o2::aod::Origints>();
+  for (auto i = 0; i < 20; ++i) {
+    writer(0, i, i % 3 == 0);
+  }
+  auto origins = b.finalize();
+  o2::aod::Origints o{origins};
 
-//  TableBuilder w;
-//  auto writer_w = w.cursor<References>();
-//  auto step = -1;
-//  for (auto i = 0; i < 5 * 20; ++i) {
-//    if (i % 5 == 0) {
-//      ++step;
-//    }
-//    writer_w(0, step);
-//  }
-//  auto refs = w.finalize();
-//  References r{refs};
-//  auto status = slices.processTable(refs);
+  TableBuilder w;
+  auto writer_w = w.cursor<o2::aod::References>();
+  auto step = -1;
+  for (auto i = 0; i < 5 * 20; ++i) {
+    if (i % 5 == 0) {
+      ++step;
+    }
+    writer_w(0, step);
+  }
+  auto refs = w.finalize();
+  o2::aod::References r{refs};
 
-//  for (auto& oi : o) {
-//    auto cachedSlice = r.sliceBy(slices, oi.globalIndex());
-//    REQUIRE(cachedSlice.size() == 5);
-//    for (auto& ri : cachedSlice) {
-//      REQUIRE(ri.originId() == oi.globalIndex());
-//    }
-//  }
-//}
+  ArrowTableSlicingCache atscache({{o2::soa::getLabelFromType<o2::aod::References>(), "fIndex" + o2::framework::cutString(o2::soa::getLabelFromType<o2::aod::Origints>())}});
+  auto s = atscache.updateCacheEntry(0, refs);
+  SliceCache cache{&atscache};
+
+  for (auto& oi : o) {
+    auto cachedSlice = r.sliceByCached(o2::aod::test::origintId, oi.globalIndex(), cache);
+    REQUIRE(cachedSlice.size() == 5);
+    for (auto& ri : cachedSlice) {
+      REQUIRE(ri.origintId() == oi.globalIndex());
+    }
+  }
+}
 
 TEST_CASE("TestIndexUnboundExceptions")
 {
   TableBuilder b;
-  auto prwriter = b.cursor<PointsRefF>();
+  auto prwriter = b.cursor<o2::aod::PointsRefF>();
   auto a = std::array{0, 1};
   auto aa = std::vector{2, 3, 4};
   prwriter(0, 0, &a[0], aa);
@@ -986,7 +992,7 @@ TEST_CASE("TestIndexUnboundExceptions")
   aa = {12, 2, 19};
   prwriter(0, 1, &a[0], aa);
   auto t = b.finalize();
-  auto prt = PointsRefF{t};
+  auto prt = o2::aod::PointsRefF{t};
 
   for (auto& row : prt) {
     try {

--- a/Framework/Core/test/test_AnalysisDataModel.cxx
+++ b/Framework/Core/test/test_AnalysisDataModel.cxx
@@ -20,7 +20,8 @@
 using namespace o2::framework;
 using namespace arrow;
 
-DECLARE_SOA_STORE();
+DECLARE_SOA_METADATA();
+DECLARE_SOA_VERSIONING();
 
 namespace col
 {

--- a/Framework/Core/test/test_GroupSlicer.cxx
+++ b/Framework/Core/test/test_GroupSlicer.cxx
@@ -11,6 +11,7 @@
 
 #include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
+#include "Framework/ArrowTableSlicingCache.h"
 #include <arrow/util/config.h>
 
 #include <catch_amalgamated.hpp>
@@ -106,7 +107,9 @@ TEST_CASE("GroupSlicerOneAssociated")
   REQUIRE(t.size() == 10 * 20);
 
   auto tt = std::make_tuple(t);
-  o2::framework::GroupSlicer g(e, tt);
+  ArrowTableSlicingCache slices({{soa::getLabelFromType<aod::TrksX>(), "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>())}});
+  auto s = slices.updateCacheEntry(0, trkTable);
+  o2::framework::GroupSlicer g(e, tt, slices);
 
   unsigned int count = 0;
   for (auto& slice : g) {
@@ -177,7 +180,14 @@ TEST_CASE("GroupSlicerSeveralAssociated")
   REQUIRE(tu.size() == 10 * 20);
 
   auto tt = std::make_tuple(tx, ty, tz, tu);
-  o2::framework::GroupSlicer g(e, tt);
+  auto key = "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>());
+  ArrowTableSlicingCache slices({{soa::getLabelFromType<aod::TrksX>(), key},
+                                 {soa::getLabelFromType<aod::TrksY>(), key},
+                                 {soa::getLabelFromType<aod::TrksZ>(), key}});
+  auto s = slices.updateCacheEntry(0, {trkTableX});
+  s = slices.updateCacheEntry(1, {trkTableY});
+  s = slices.updateCacheEntry(2, {trkTableZ});
+  o2::framework::GroupSlicer g(e, tt, slices);
 
   unsigned int count = 0;
   for (auto& slice : g) {
@@ -236,7 +246,9 @@ TEST_CASE("GroupSlicerMismatchedGroups")
   REQUIRE(t.size() == 10 * (20 - 5));
 
   auto tt = std::make_tuple(t);
-  o2::framework::GroupSlicer g(e, tt);
+  ArrowTableSlicingCache slices({{soa::getLabelFromType<aod::TrksX>(), "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>())}});
+  auto s = slices.updateCacheEntry(0, trkTable);
+  o2::framework::GroupSlicer g(e, tt, slices);
 
   unsigned int count = 0;
   for (auto& slice : g) {
@@ -292,7 +304,9 @@ TEST_CASE("GroupSlicerMismatchedUnassignedGroups")
   REQUIRE(t.size() == (30 + 10 * (20 - 5)));
 
   auto tt = std::make_tuple(t);
-  o2::framework::GroupSlicer g(e, tt);
+  ArrowTableSlicingCache slices({{soa::getLabelFromType<aod::TrksX>(), "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>())}});
+  auto s = slices.updateCacheEntry(0, trkTable);
+  o2::framework::GroupSlicer g(e, tt, slices);
 
   unsigned int count = 0;
   for (auto& slice : g) {
@@ -340,7 +354,9 @@ TEST_CASE("GroupSlicerMismatchedFilteredGroups")
   REQUIRE(t.size() == 10 * (20 - 4));
 
   auto tt = std::make_tuple(t);
-  o2::framework::GroupSlicer g(e, tt);
+  ArrowTableSlicingCache slices({{soa::getLabelFromType<aod::TrksX>(), "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>())}});
+  auto s = slices.updateCacheEntry(0, trkTable);
+  o2::framework::GroupSlicer g(e, tt, slices);
 
   unsigned int count = 0;
 
@@ -399,8 +415,9 @@ TEST_CASE("GroupSlicerMismatchedUnsortedFilteredGroups")
   REQUIRE(t.size() == 10 * (20 - 4));
 
   auto tt = std::make_tuple(t);
-
-  o2::framework::GroupSlicer g(e, tt);
+  ArrowTableSlicingCache slices({{soa::getLabelFromType<aod::TrksXU>(), "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>())}});
+  auto s = slices.updateCacheEntry(0, trkTable);
+  o2::framework::GroupSlicer g(e, tt, slices);
 
   unsigned int count = 0;
 
@@ -423,7 +440,8 @@ TEST_CASE("GroupSlicerMismatchedUnsortedFilteredGroups")
   std::vector<int64_t> sele;
   soa::SmallGroups<aod::TrksXU> te{{trkTableE}, std::move(sele)};
   auto tte = std::make_tuple(te);
-  o2::framework::GroupSlicer ge(e, tte);
+  s = slices.updateCacheEntry(0, trkTableE);
+  o2::framework::GroupSlicer ge(e, tte, slices);
 
   count = 0;
   for (auto& slice : ge) {
@@ -437,7 +455,8 @@ TEST_CASE("GroupSlicerMismatchedUnsortedFilteredGroups")
 
   soa::SmallGroupsUnfiltered<aod::TrksXU> tu{{trkTable}, std::vector<int64_t>{}};
   auto ttu = std::make_tuple(tu);
-  o2::framework::GroupSlicer gu(e, ttu);
+  s = slices.updateCacheEntry(0, trkTable);
+  o2::framework::GroupSlicer gu(e, ttu, slices);
 
   count = 0;
   for (auto& slice : gu) {
@@ -473,7 +492,9 @@ TEST_CASE("EmptySliceables")
   REQUIRE(t.size() == 0);
 
   auto tt = std::make_tuple(t);
-  o2::framework::GroupSlicer g(e, tt);
+  ArrowTableSlicingCache slices({{soa::getLabelFromType<aod::TrksX>(), "fIndex" + o2::framework::cutString(soa::getLabelFromType<aod::Events>())}});
+  auto s = slices.updateCacheEntry(0, trkTable);
+  o2::framework::GroupSlicer g(e, tt, slices);
 
   unsigned int count = 0;
   for (auto& slice : g) {

--- a/Framework/Core/test/test_IndexBuilder.cxx
+++ b/Framework/Core/test/test_IndexBuilder.cxx
@@ -17,7 +17,8 @@ using namespace o2::framework;
 using namespace arrow;
 using namespace o2::soa;
 
-DECLARE_SOA_STORE();
+DECLARE_SOA_METADATA();
+DECLARE_SOA_VERSIONING();
 namespace coords
 {
 DECLARE_SOA_COLUMN_FULL(X, x, float, "x");

--- a/Framework/Core/test/test_Root2ArrowTable.cxx
+++ b/Framework/Core/test/test_Root2ArrowTable.cxx
@@ -121,7 +121,7 @@ BOOST_AUTO_TEST_CASE(RootTree2Table)
 
 namespace o2::aod
 {
-DECLARE_SOA_STORE();
+DECLARE_SOA_VERSIONING();
 namespace test
 {
 DECLARE_SOA_COLUMN_FULL(Px, px, float, "px");

--- a/Framework/Core/test/test_TreeToTable.cxx
+++ b/Framework/Core/test/test_TreeToTable.cxx
@@ -157,7 +157,7 @@ TEST_CASE("TreeToTableConversion")
 
 namespace o2::aod
 {
-DECLARE_SOA_STORE();
+DECLARE_SOA_VERSIONING();
 namespace cols
 {
 DECLARE_SOA_COLUMN(Ivec, ivec, std::vector<int>);


### PR DESCRIPTION
Framework service that keeps slicing information of arrow tables used by the task.
* Introduces new API for analysis tasks using generic `SliceCache` pointer to the cache service
* Replaces the grouping and Preslice backends with the cache service

 