### PR TITLE
DPL Analysis: Update combinations to use slice cache

### DIFF
--- a/Framework/Core/test/benchmark_EventMixing.cxx
+++ b/Framework/Core/test/benchmark_EventMixing.cxx
@@ -171,13 +171,16 @@ static void BM_EventMixingCombinations(benchmark::State& state)
 
   int64_t count = 0;
   int64_t colCount = 0;
+  ArrowTableSlicingCache atscache{{{getLabelFromType<o2::aod::StoredTracks>(), "fIndex" + getLabelFromType<o2::aod::Collisions>()}}};
+  auto s = atscache.updateCacheEntry(0, tableTrack);
+  SliceCache cache{&atscache};
 
   for (auto _ : state) {
     count = 0;
     colCount = 0;
 
     auto tracksTuple = std::make_tuple(tracks);
-    SameKindPair<o2::aod::Collisions, o2::aod::StoredTracks, BinningType> pair{binningOnPositions, numEventsToMix - 1, -1, collisions, tracksTuple};
+    SameKindPair<o2::aod::Collisions, o2::aod::StoredTracks, BinningType> pair{binningOnPositions, numEventsToMix - 1, -1, collisions, tracksTuple, &cache};
     for (auto& [c1, tracks1, c2, tracks2] : pair) {
       int bin = binningOnPositions.getBin({c1.posX(), c1.posY()});
       for (auto& [t1, t2] : combinations(CombinationsFullIndexPolicy(tracks1, tracks2))) {


### PR DESCRIPTION
@saganatt this should make the combinations compatible with both old and new API, so that O2Physics can be adapted without interruption. 