### PR TITLE
DPL: allow driver to run under DDS control

### DIFF
--- a/Framework/Core/include/Framework/DriverControl.h
+++ b/Framework/Core/include/Framework/DriverControl.h
@@ -20,9 +20,7 @@
 #include "Framework/DeviceSpec.h"
 #include "Framework/DeviceExecution.h"
 
-namespace o2
-{
-namespace framework
+namespace o2::framework
 {
 
 /// These are the possible states for the driver controller
@@ -53,7 +51,6 @@ struct DriverControl {
   bool defaultStopped;
 };
 
-} // namespace framework
 } // namespace o2
 
 #endif

--- a/Framework/Core/include/Framework/DriverInfo.h
+++ b/Framework/Core/include/Framework/DriverInfo.h
@@ -164,6 +164,8 @@ struct DriverInfo {
 
   /// The last error reported by the driver itself
   std::string lastError;
+  /// Driver mode
+  DriverMode mode = DriverMode::STANDALONE;
 };
 
 struct DriverInfoHelper {

--- a/Framework/Core/include/Framework/ProcessingPolicies.h
+++ b/Framework/Core/include/Framework/ProcessingPolicies.h
@@ -34,6 +34,16 @@ struct ProcessingPolicies {
   enum EarlyForwardPolicy earlyForward;
 };
 
+/// The mode in which the driver is running. Should be MASTER when running locally,
+/// EMBEDDED when running under a control system.
+enum struct DriverMode {
+  /// Default mode. The master is responsible for spawning and controlling the devices.
+  STANDALONE,
+  /// The master is also running under a control system, so it does not control the devices, however, it does
+  /// receive metrics and information from them and displays it via the RemoteGUI.
+  EMBEDDED
+};
+
 } // namespace o2::framework
 
 #endif // O2_FRAMEWORK_PROCESSING_POLICIES_H_

--- a/Framework/Core/src/DDSConfigHelpers.cxx
+++ b/Framework/Core/src/DDSConfigHelpers.cxx
@@ -112,6 +112,7 @@ std::string xmlEncode(std::string const& source)
 }
 
 void DDSConfigHelpers::dumpDeviceSpec2DDS(std::ostream& out,
+                                          DriverMode driverMode,
                                           std::string const& workflowSuffix,
                                           std::vector<DataProcessorSpec> const& workflow,
                                           std::vector<DataProcessorInfo> const& dataProcessorInfos,
@@ -167,6 +168,19 @@ void DDSConfigHelpers::dumpDeviceSpec2DDS(std::ostream& out,
       out << "   "
           << fmt::format("<property name=\"fmqchan_{}\" />\n", rewriter.properties[rewriter.names[ci]].value);
     }
+  }
+
+  if (driverMode == DriverMode::EMBEDDED) {
+    out << "   "
+        << fmt::format("<decltask name=\"{}{}\">\n", "dplDriver", workflowSuffix);
+    out << "       "
+        << fmt::format(R"(<assets><name>dpl_json{}</name></assets>)", workflowSuffix) << "\n";
+    out << "       "
+        << R"(<exe reachable="true">)";
+    out << fmt::format("cat ${{DDS_LOCATION}}/dpl_json{}.asset | o2-dpl-run --driver-mode embedded", workflowSuffix);
+    out << R"(</exe>)"
+        << "\n";
+    out << "</decltask>";
   }
 
   for (size_t di = 0; di < specs.size(); ++di) {

--- a/Framework/Core/src/DDSConfigHelpers.h
+++ b/Framework/Core/src/DDSConfigHelpers.h
@@ -16,6 +16,7 @@
 #include "Framework/CommandInfo.h"
 #include "Framework/DataProcessorSpec.h"
 #include "Framework/DataProcessorInfo.h"
+#include "Framework/ProcessingPolicies.h"
 #include <vector>
 #include <iosfwd>
 #include <string>
@@ -26,6 +27,7 @@ namespace o2::framework
 /// Helper to dump DDS configuration to run in a deployed
 /// manner.
 /// @a out is a stream where the configuration will be printed
+/// @a mode is the mode in which the workflow is being run
 /// @a workflow is the workflow to dump
 /// @a metadata is the metadata to dump
 /// @a workflowSuffix a suffix to add to all the ids in the workflow
@@ -36,6 +38,7 @@ namespace o2::framework
 /// @a the full command being used
 struct DDSConfigHelpers {
   static void dumpDeviceSpec2DDS(std::ostream& out,
+                                 DriverMode mode,
                                  std::string const& workflowSuffix,
                                  std::vector<DataProcessorSpec> const& workflow,
                                  std::vector<DataProcessorInfo> const& metadata,

--- a/Framework/Core/src/ProcessingPoliciesHelpers.cxx
+++ b/Framework/Core/src/ProcessingPoliciesHelpers.cxx
@@ -29,6 +29,32 @@ std::istream& operator>>(std::istream& in, enum TerminationPolicy& policy)
   return in;
 }
 
+std::ostream& operator<<(std::ostream& out, const enum DriverMode& mode)
+{
+  if (mode == DriverMode::STANDALONE) {
+    out << "standalone";
+  } else if (mode == DriverMode::EMBEDDED) {
+    out << "embedded";
+  } else {
+    out.setstate(std::ios_base::failbit);
+  }
+  return out;
+}
+
+std::istream& operator>>(std::istream& in, enum DriverMode& mode)
+{
+  std::string token;
+  in >> token;
+  if (token == "standalone") {
+    mode = DriverMode::STANDALONE;
+  } else if (token == "embedded") {
+    mode = DriverMode::EMBEDDED;
+  } else {
+    in.setstate(std::ios_base::failbit);
+  }
+  return in;
+}
+
 std::ostream& operator<<(std::ostream& out, const enum TerminationPolicy& policy)
 {
   if (policy == TerminationPolicy::QUIT) {

--- a/Framework/Core/src/ProcessingPoliciesHelpers.h
+++ b/Framework/Core/src/ProcessingPoliciesHelpers.h
@@ -25,6 +25,8 @@ std::istream& operator>>(std::istream& in, enum EarlyForwardPolicy& policy);
 std::ostream& operator<<(std::ostream& out, const enum EarlyForwardPolicy& policy);
 std::istream& operator>>(std::istream& in, enum LogParsingHelpers::LogLevel& level);
 std::ostream& operator<<(std::ostream& out, const enum LogParsingHelpers::LogLevel& level);
+std::istream& operator>>(std::istream& in, enum DriverMode& level);
+std::ostream& operator<<(std::ostream& out, const enum DriverMode& level);
 } // namespace o2::framework
 
 #endif // O2_FRAMEWORK_PROCESSINGPOLICIESHELPERS_H_

--- a/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
+++ b/Framework/Core/test/test_FrameworkDataFlowToDDS.cxx
@@ -151,7 +151,7 @@ TEST_CASE("TestDDS")
                                       devices, executions, controls,
                                       "workflow-id");
   CommandInfo command{"foo"};
-  DDSConfigHelpers::dumpDeviceSpec2DDS(ss, "", workflow, dataProcessorInfos, devices, executions, command);
+  DDSConfigHelpers::dumpDeviceSpec2DDS(ss, DriverMode::STANDALONE, "", workflow, dataProcessorInfos, devices, executions, command);
   auto expected = R"EXPECTED(<topology name="o2-dataflow">
 <asset name="dpl_json" type="inline" visibility="global" value="{
     &quot;workflow&quot;: [
@@ -406,7 +406,7 @@ TEST_CASE("TestDDSExpendable")
                                       devices, executions, controls,
                                       "workflow-id");
   CommandInfo command{"foo"};
-  DDSConfigHelpers::dumpDeviceSpec2DDS(ss, "", workflow, dataProcessorInfos, devices, executions, command);
+  DDSConfigHelpers::dumpDeviceSpec2DDS(ss, DriverMode::STANDALONE, "", workflow, dataProcessorInfos, devices, executions, command);
   auto expected = R"EXPECTED(<topology name="o2-dataflow">
 <declrequirement name="odc_expendable_task" type="custom" value="true" />
 <asset name="dpl_json" type="inline" visibility="global" value="{


### PR DESCRIPTION
This introduces a new --driver-mode flag which can be used to modify the DDS configuration so that the dpl driver is part of the topology, communicates with the children via websocket and takes care of the metrics.