### PR TITLE
[EMCAL-688] Add exception for uninitilised lookup table

### DIFF
--- a/Detectors/EMCAL/base/include/EMCALBase/ClusterFactory.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/ClusterFactory.h
@@ -312,7 +312,6 @@ class ClusterFactory
   Double_t tMaxInCm(const Double_t e = 0.0, const int key = 0) const;
 
   bool getLookUpInit() const { return mLookUpInit; }
-  void setLookUpInit(bool lookUpInit) { mLookUpInit = lookUpInit; }
 
   bool getCoreRadius() const { return mCoreRadius; }
   void setCoreRadius(float radius) { mCoreRadius = radius; }
@@ -363,7 +362,7 @@ class ClusterFactory
     for (auto iCellIndex : mCellsIndices) {
       mLoolUpTowerToIndex[mInputsContainer[iCellIndex].getTower()] = iCellIndex;
     }
-    setLookUpInit(true);
+    mLookUpInit = true;
   }
 
   int getNumberOfClusters() const

--- a/Detectors/EMCAL/base/include/EMCALBase/ClusterFactory.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/ClusterFactory.h
@@ -311,6 +311,9 @@ class ClusterFactory
   /// \param  key: = 0(gamma, default); !=  0(electron)
   Double_t tMaxInCm(const Double_t e = 0.0, const int key = 0) const;
 
+  bool getLookUpInit() const { return mLookUpInit; }
+  void setLookUpInit(bool lookUpInit) { mLookUpInit = lookUpInit; }
+
   bool getCoreRadius() const { return mCoreRadius; }
   void setCoreRadius(float radius) { mCoreRadius = radius; }
 
@@ -343,12 +346,24 @@ class ClusterFactory
   {
     mCellsIndices = indicesContainer;
   }
+
+  void setContainer(gsl::span<const o2::emcal::Cluster> clusterContainer, gsl::span<const InputType> cellContainer, gsl::span<const int> indicesContainer)
+  {
+    mClustersContainer = clusterContainer;
+    mInputsContainer = cellContainer;
+    mCellsIndices = indicesContainer;
+    if (!getLookUpInit()) {
+      setLookUpTable();
+    }
+  }
+
   void setLookUpTable(void)
   {
     mLoolUpTowerToIndex.fill(-1);
     for (auto iCellIndex : mCellsIndices) {
       mLoolUpTowerToIndex[mInputsContainer[iCellIndex].getTower()] = iCellIndex;
     }
+    setLookUpInit(true);
   }
 
   int getNumberOfClusters() const
@@ -359,6 +374,21 @@ class ClusterFactory
   /// \brief Initialize Cluster Factory with geometry
   /// \param geometry EMCAL geometry
   void setGeometry(o2::emcal::Geometry* geometry) { mGeomPtr = geometry; }
+
+  /// \class UninitLookUpTableException
+  /// \brief Exception handling uninitialized look up table
+  class UninitLookUpTableException final : public std::exception
+  {
+   public:
+    /// \brief constructor
+    UninitLookUpTableException() = default;
+
+    /// \brief Destructor
+    ~UninitLookUpTableException() noexcept final = default;
+
+    /// \brief Access to error message of the exception
+    const char* what() const noexcept final { return "Lookup table not initialized, exotics evaluation not possible!"; }
+  };
 
  protected:
   ///
@@ -400,6 +430,7 @@ class ClusterFactory
   float mLogWeight = 4.5; ///<  logarithmic weight for the cluster center of gravity calculation
 
   bool mJustCluster = kFALSE; ///< Flag to evaluates local to "tracking" c.s. transformation (B.P.).
+  bool mLookUpInit = false;   ///< Flag to check if the mLoolUpTowerToIndex is currently set. Will be checked when needed and created if not set!
 
   mutable int mSuperModuleNumber = 0;         ///<  number identifying supermodule containing cluster, reference is cell with maximum energy.
   float mDistToBadTower = -1;                 ///<  Distance to nearest bad tower
@@ -413,7 +444,7 @@ class ClusterFactory
   gsl::span<const o2::emcal::Cluster> mClustersContainer; ///< Container for all the clusters in the event
   gsl::span<const InputType> mInputsContainer;            ///< Container for all the cells/digits in the event
   gsl::span<const int> mCellsIndices;                     ///< Container for cells indices in the event
-  std::array<short, 17664> mLoolUpTowerToIndex;           ///< Lookup table to match tower id with and cell index, needed for exotic check
+  std::array<short, 17664> mLoolUpTowerToIndex;           ///< Lookup table to match tower id with cell index, needed for exotic check
 
   ClassDefNV(ClusterFactory, 2);
 };

--- a/Detectors/EMCAL/base/src/ClusterFactory.cxx
+++ b/Detectors/EMCAL/base/src/ClusterFactory.cxx
@@ -36,10 +36,7 @@ ClusterFactory<InputType>::ClusterFactory(gsl::span<const o2::emcal::Cluster> cl
 {
   mGeomPtr = o2::emcal::Geometry::GetInstance();
 
-  setClustersContainer(clustersContainer);
-  setCellsContainer(inputsContainer);
-  setCellsIndicesContainer(cellsIndices);
-  setLookUpTable();
+  setContainer(clustersContainer, inputsContainer, cellsIndices);
 }
 
 template <class InputType>
@@ -48,6 +45,7 @@ void ClusterFactory<InputType>::reset()
   mClustersContainer = gsl::span<const o2::emcal::Cluster>();
   mInputsContainer = gsl::span<const InputType>();
   mCellsIndices = gsl::span<int>();
+  mLookUpInit = false;
 }
 
 ///
@@ -80,7 +78,11 @@ o2::emcal::AnalysisCluster ClusterFactory<InputType>::buildCluster(int clusterIn
 
   float exoticTime = mInputsContainer[inputIndMax].getTimeStamp();
 
-  clusterAnalysis.setIsExotic(isExoticCell(towerId, inputEnergyMax, exoticTime));
+  try {
+    clusterAnalysis.setIsExotic(isExoticCell(towerId, inputEnergyMax, exoticTime));
+  } catch (UninitLookUpTableException& e) {
+    LOG(error) << e.what();
+  }
 
   clusterAnalysis.setIndMaxInput(inputIndMax);
 
@@ -593,6 +595,11 @@ bool ClusterFactory<InputType>::isExoticCell(short towerId, float ecell, float c
 {
   if (ecell < mExoticCellMinAmplitude) {
     return false; // do not reject low energy cells
+  }
+
+  // if the look up table is not set yet (mostly due to a reset call) then set it up now.
+  if (getLookUpInit()) {
+    throw UninitLookUpTableException();
   }
 
   float eCross = getECross(towerId, ecell, exoticTime);


### PR DESCRIPTION
- Add exception class to throw when trying to determine exotic clusters but the neeed look up table is not initilised
	- The class UninitLookUpTableException is neseted within the cluster factory class
	- throw will happen inside of setIsExotic function which is called inside buildCluster function
	- throw will only happen if ecell < mExoticCellMinAmplitude is false
- Add first step to merge set up function for the cluster, cell and index container together with the look up table
	- new setContainer function expects all three objects as span and will set them
	- next step would be to change the current calls of the three (four) setter everywhere with this one