### PR TITLE
Possibility to trigger endOfStream/shutdown from within data converter

### DIFF
--- a/Detectors/CTP/workflowScalers/src/ctp-proxy.cxx
+++ b/Detectors/CTP/workflowScalers/src/ctp-proxy.cxx
@@ -51,7 +51,7 @@ InjectorFunction dcs2dpl(std::string& ccdbhost)
   auto runMgr = std::make_shared<o2::ctp::CTPRunManager>();
   runMgr->setCCDBHost(ccdbhost);
   runMgr->init();
-  return [runMgr](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever, size_t newTimesliceId) {
+  return [runMgr](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever, size_t newTimesliceId, bool& stop) {
     // FIXME: Why isn't this function using the timeslice index?
     // make sure just 2 messages received
     if (parts.Size() != 2) {

--- a/Detectors/CTP/workflowScalers/src/ctp-qc-proxy.cxx
+++ b/Detectors/CTP/workflowScalers/src/ctp-qc-proxy.cxx
@@ -45,7 +45,7 @@ using DetID = o2::detectors::DetID;
 InjectorFunction dcs2dpl()
 // InjectorFunction dcs2dpl()
 {
-  return [](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever, size_t newTimesliceId) {
+  return [](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever, size_t newTimesliceId, bool&) {
     // make sure just 2 messages received
     if (parts.Size() != 2) {
       LOG(error) << "received " << parts.Size() << " instead of 2 expected";

--- a/Detectors/DCS/testWorkflow/src/DCStoDPLconverter.h
+++ b/Detectors/DCS/testWorkflow/src/DCStoDPLconverter.h
@@ -54,7 +54,7 @@ using DPCOM = o2::dcs::DataPointCompositeObject;
 o2f::InjectorFunction dcs2dpl(std::unordered_map<DPID, o2h::DataDescription>& dpid2group, bool fbiFirst, bool verbose = false, int FBIPerInterval = 1)
 {
 
-  return [dpid2group, fbiFirst, verbose, FBIPerInterval](o2::framework::TimingInfo& tinfo, fair::mq::Device& device, fair::mq::Parts& parts, o2f::ChannelRetriever channelRetriever, size_t newTimesliceId) {
+  return [dpid2group, fbiFirst, verbose, FBIPerInterval](o2::framework::TimingInfo& tinfo, fair::mq::Device& device, fair::mq::Parts& parts, o2f::ChannelRetriever channelRetriever, size_t newTimesliceId, bool& stop) {
     static std::unordered_map<DPID, DPCOM> cache; // will keep only the latest measurement in the 1-second wide window for each DPID
     static std::unordered_map<std::string, int> sentToChannel;
     static auto timer = std::chrono::high_resolution_clock::now();

--- a/Detectors/DCS/testWorkflow/src/dcs-config-proxy.cxx
+++ b/Detectors/DCS/testWorkflow/src/dcs-config-proxy.cxx
@@ -66,7 +66,7 @@ auto getDataOriginFromFilename(const std::string& filename)
 
 InjectorFunction dcs2dpl(const std::string& acknowledge)
 {
-  return [acknowledge](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever, size_t newTimesliceId) {
+  return [acknowledge](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever, size_t newTimesliceId, bool&) {
     if (parts.Size() == 0) { // received at ^c, ignore
       LOG(info) << "ignoring empty message";
       return;

--- a/Framework/Core/include/Framework/ExternalFairMQDeviceProxy.h
+++ b/Framework/Core/include/Framework/ExternalFairMQDeviceProxy.h
@@ -24,7 +24,7 @@ namespace o2::framework
 /// A callback function to retrieve the fair::mq::Channel name to be used for sending
 /// messages of the specified OutputSpec
 using ChannelRetriever = std::function<std::string(OutputSpec const&, DataProcessingHeader::StartTime)>;
-using InjectorFunction = std::function<void(TimingInfo&, fair::mq::Device& device, fair::mq::Parts& inputs, ChannelRetriever, size_t newTimesliceId)>;
+using InjectorFunction = std::function<void(TimingInfo&, fair::mq::Device& device, fair::mq::Parts& inputs, ChannelRetriever, size_t newTimesliceId, bool& stop)>;
 using ChannelSelector = std::function<std::string(InputSpec const& input, const std::unordered_map<std::string, std::vector<fair::mq::Channel>>& channels)>;
 
 struct InputChannelSpec;

--- a/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
+++ b/Framework/Core/src/ExternalFairMQDeviceProxy.cxx
@@ -175,7 +175,7 @@ void sendOnChannel(fair::mq::Device& device, fair::mq::MessagePtr&& headerMessag
 
 InjectorFunction o2DataModelAdaptor(OutputSpec const& spec, uint64_t startTime, uint64_t /*step*/)
 {
-  return [spec](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever, size_t newTimesliceId) {
+  return [spec](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever, size_t newTimesliceId, bool& stop) {
     for (int i = 0; i < parts.Size() / 2; ++i) {
       auto dh = o2::header::get<DataHeader*>(parts.At(i * 2)->GetData());
 
@@ -222,7 +222,7 @@ InjectorFunction dplModelAdaptor(std::vector<OutputSpec> const& filterSpecs, DPL
     std::string descriptions;
   };
 
-  return [filterSpecs = std::move(filterSpecs), throwOnUnmatchedInputs, droppedDataSpecs = std::make_shared<DroppedDataSpecs>()](TimingInfo& timingInfo, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever, size_t newTimesliceId) {
+  return [filterSpecs = std::move(filterSpecs), throwOnUnmatchedInputs, droppedDataSpecs = std::make_shared<DroppedDataSpecs>()](TimingInfo& timingInfo, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever, size_t newTimesliceId, bool& stop) {
     // FIXME: this in not thread safe, but better than an alloc of a map per message...
     std::unordered_map<std::string, fair::mq::Parts> outputs;
     std::vector<std::string> unmatchedDescriptions;
@@ -362,13 +362,14 @@ InjectorFunction dplModelAdaptor(std::vector<OutputSpec> const& filterSpecs, DPL
         }
       }
     }
+    return;
   };
 }
 
 InjectorFunction incrementalConverter(OutputSpec const& spec, o2::header::SerializationMethod method, uint64_t startTime, uint64_t step)
 {
   auto timesliceId = std::make_shared<size_t>(startTime);
-  return [timesliceId, spec, step, method](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever, size_t newTimesliceId) {
+  return [timesliceId, spec, step, method](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever, size_t newTimesliceId, bool&) {
     // We iterate on all the parts and we send them two by two,
     // adding the appropriate O2 header.
     for (int i = 0; i < parts.Size(); ++i) {
@@ -545,7 +546,8 @@ DataProcessorSpec specifyExternalFairMQDeviceProxy(char const* name,
         eosPeersCount[ci] = std::max<int>(eosPeersCount[ci], device->GetNumberOfConnectedPeers(channel));
       }
       // For reference, the oldest possible timeframe passed as newTimesliceId here comes from LifetimeHelpers::enumDrivenCreation()
-      converter(timingInfo, *device, inputs, channelRetriever, timesliceIndex->getOldestPossibleOutput().timeslice.value);
+      bool shouldstop = false;
+      converter(timingInfo, *device, inputs, channelRetriever, timesliceIndex->getOldestPossibleOutput().timeslice.value, shouldstop);
 
       // If we have enough EoS messages, we can stop the device
       // Notice that this has a number of failure modes:
@@ -553,7 +555,7 @@ DataProcessorSpec specifyExternalFairMQDeviceProxy(char const* name,
       // * If a connection sends two EoS.
       // * If a connection sends an end of stream closes and another one opens.
       // Finally, if we didn't receive an EoS this time, out counting of the connected peers is off, so the best thing we can do is delay the EoS reporting
-      bool everyEoS = numberOfEoS[ci] >= eosPeersCount[ci] && nEos;
+      bool everyEoS = shouldstop || (numberOfEoS[ci] >= eosPeersCount[ci] && nEos);
 
       if (everyEoS) {
         // Mark all input channels as closed

--- a/Framework/Core/src/ReadoutAdapter.cxx
+++ b/Framework/Core/src/ReadoutAdapter.cxx
@@ -23,7 +23,7 @@ using DataHeader = o2::header::DataHeader;
 
 InjectorFunction readoutAdapter(OutputSpec const& spec)
 {
-  return [spec](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever, size_t newTimesliceId) {
+  return [spec](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever, size_t newTimesliceId, bool& stop) {
     for (size_t i = 0; i < parts.Size(); ++i) {
       DataHeader dh;
       // FIXME: this will have to change and extract the actual subspec from

--- a/Framework/Core/test/benchmark_ExternalFairMQDeviceProxies.cxx
+++ b/Framework/Core/test/benchmark_ExternalFairMQDeviceProxies.cxx
@@ -469,7 +469,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const& config)
   // reads the messages from the output proxy via the out-of-band channel
 
   // converter callback for the external FairMQ device proxy ProcessorSpec generator
-  auto converter = [](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& inputs, ChannelRetriever channelRetriever, size_t newTimesliceId) {
+  auto converter = [](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& inputs, ChannelRetriever channelRetriever, size_t newTimesliceId, bool&) {
     ASSERT_ERROR(inputs.Size() >= 2);
     if (inputs.Size() < 2) {
       return;

--- a/Framework/Core/test/test_ExternalFairMQDeviceWorkflow.cxx
+++ b/Framework/Core/test/test_ExternalFairMQDeviceWorkflow.cxx
@@ -349,7 +349,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const& config)
   // reads the messages from the output proxy via the out-of-band channel
 
   // converter callback for the external FairMQ device proxy ProcessorSpec generator
-  auto converter = [](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& inputs, ChannelRetriever channelRetriever, size_t newTimesliceId) {
+  auto converter = [](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& inputs, ChannelRetriever channelRetriever, size_t newTimesliceId, bool&) {
     ASSERT_ERROR(inputs.Size() >= 2);
     if (inputs.Size() < 2) {
       return;
@@ -401,6 +401,7 @@ std::vector<DataProcessorSpec> defineDataProcessing(ConfigContext const& config)
       }
     }
     o2::framework::sendOnChannel(device, output, channelName, (size_t)-1);
+    return;
   };
 
   // we use the same spec to build the configuration string, ideally we would have some helpers

--- a/Utilities/DataSampling/src/DataSamplingReadoutAdapter.cxx
+++ b/Utilities/DataSampling/src/DataSamplingReadoutAdapter.cxx
@@ -23,7 +23,7 @@ using DataHeader = o2::header::DataHeader;
 
 InjectorFunction dataSamplingReadoutAdapter(OutputSpec const& spec)
 {
-  return [spec](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever, size_t newTimesliceId) {
+  return [spec](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever, size_t newTimesliceId, bool& stop) {
     for (size_t i = 0; i < parts.Size(); ++i) {
 
       DataHeader dh;

--- a/run/SimExamples/MCTrackToDPL/run.sh
+++ b/run/SimExamples/MCTrackToDPL/run.sh
@@ -2,17 +2,16 @@
 
 set -x
 
+NEVENTS=100
 # launch generator process (for 100 min bias Pythia8 events; no Geant; no geometry)
-o2-sim -j 1 -g pythia8pp -n 100 --noDiscOutput --forwardKine --noGeant -m CAVE -e TGeant3 &> sim.log &
+o2-sim -j 1 -g pythia8pp -n ${NEVENTS} --noDiscOutput --forwardKine --noGeant -m CAVE -e TGeant3 &> sim.log &
 SIMPROC=$!
 
 # launch a DPL process (having the right proxy configuration)
 # (Note that the option --o2sim-pid is not strictly necessary when only one o2-sim process is running.
 #  The socket will than be auto-determined.)
-o2-sim-mctracks-proxy --enable-test-consumer --o2sim-pid ${SIMPROC} &> out_mcanalysis.log &
+o2-sim-mctracks-proxy --enable-test-consumer --nevents ${NEVENTS} --o2sim-pid ${SIMPROC} &
 TRACKANAPROC=$!
 
 wait ${SIMPROC}
-sleep 5
-kill ${TRACKANAPROC}
 wait ${TRACKANAPROC}

--- a/run/o2sim_mctracks_proxy.cxx
+++ b/run/o2sim_mctracks_proxy.cxx
@@ -35,6 +35,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   workflowOptions.push_back(ConfigParamSpec{"enable-test-consumer", o2::framework::VariantType::Bool, false, {"enable a simple test consumer for injected MC tracks"}});
   workflowOptions.push_back(ConfigParamSpec{"o2sim-pid", o2::framework::VariantType::Int, -1, {"The process id of the source o2-sim"}});
+  workflowOptions.push_back(ConfigParamSpec{"nevents", o2::framework::VariantType::Int, -1, {"The number of events expected to arrive on the proxy"}});
 }
 
 #include "Framework/runDataProcessing.h"
@@ -61,13 +62,15 @@ class ConsumerTask
 
 /// Function converting raw input data to DPL data format. Uses knowledge of how MCTracks and MCEventHeaders
 /// are sent from the o2sim side.
-InjectorFunction o2simKinematicsConverter(std::vector<OutputSpec> const& specs, uint64_t startTime, uint64_t step)
+InjectorFunction o2simKinematicsConverter(std::vector<OutputSpec> const& specs, uint64_t startTime, uint64_t step, int nevents)
 {
   auto timesliceId = std::make_shared<size_t>(startTime);
 
-  return [timesliceId, specs, step](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever, size_t newTimesliceId) {
+  return [timesliceId, specs, step, nevents](TimingInfo&, fair::mq::Device& device, fair::mq::Parts& parts, ChannelRetriever channelRetriever, size_t newTimesliceId, bool& stop) {
     // We iterate on all the parts and we send them two by two,
     // adding the appropriate O2 header.
+    static int eventcounter = 0;
+
     for (int i = 0; i < parts.Size(); ++i) {
       DataHeader dh;
       ConcreteDataMatcher matcher = DataSpecUtils::asConcreteDataMatcher(specs[i]);
@@ -89,6 +92,12 @@ InjectorFunction o2simKinematicsConverter(std::vector<OutputSpec> const& specs, 
       sendOnChannel(device, std::move(headerStack), std::move(parts.At(i)), specs[i], channelRetriever);
     }
     *timesliceId += step;
+    eventcounter++;
+    if (eventcounter == nevents) {
+      // I am done (I don't expect more events to convert); so tell the proxy device to shut-down
+      stop = true;
+    }
+    return;
   };
 }
 
@@ -101,7 +110,10 @@ WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
   std::vector<OutputSpec> outputs;
   outputs.emplace_back("MC", "MCHEADER", 0, Lifetime::Timeframe);
   outputs.emplace_back("MC", "MCTRACKS", 0, Lifetime::Timeframe);
-  o2::framework::InjectorFunction f = o2simKinematicsConverter(outputs, 0, 1);
+
+  // fetch the number of events to expect
+  auto nevents = configcontext.options().get<int>("nevents");
+  o2::framework::InjectorFunction f = o2simKinematicsConverter(outputs, 0, 1, nevents);
 
   // construct the input channel to listen on
   // use given pid


### PR DESCRIPTION
This provides the possibility to initiate shutdown of the ExternalFairMQDeviceProxy from within the InjectorFunction.

This is useful when the InjectorFunction knows how much data it wants to pass along and can facilitate decisions to stop the DPL part independently on the external source sending EOS.

This used in the MCTrackToDPL proxy which will send endOfStream after a given number of events have been treated. So far, this proxy needed an external entity to kill it. Now this is no longer necessary.

Changes have been made minimally invasive and backward compatibility is ensured.