### PR TITLE
TRD tracking fix pad row crossing check

### DIFF
--- a/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
+++ b/GPU/GPUTracking/TRDTracking/GPUTRDTracker.cxx
@@ -821,9 +821,6 @@ GPUd() bool GPUTRDTracker_t<TRDTRK, PROP>::FollowProlongation(PROP* prop, TRDTRK
       trkWork->setChi2(mHypothesis[iUpdate + hypothesisIdxOffset].mChi2);
       trkWork->setIsFindable(iLayer);
       trkWork->setCollisionId(collisionId);
-      if (iUpdate == 0 && mNCandidates > 1) {
-        *t = mCandidates[2 * iUpdate + nextIdx];
-      }
       // check if track crosses padrows
       float projZEntry, projYEntry;
       // Get Z for Entry of Track
@@ -852,6 +849,9 @@ GPUd() bool GPUTRDTracker_t<TRDTRK, PROP>::FollowProlongation(PROP* prop, TRDTRK
           trkWork->setHasNeighbor();
           break;
         }
+      }
+      if (iUpdate == 0 && mNCandidates > 1) {
+        *t = mCandidates[2 * iUpdate + nextIdx];
       }
     } // end update loop
 


### PR DESCRIPTION
@f3sch found the problem: when using multiple candidates I use the `mCandidates` array as scratch space for the different track parameter hypothesis. This block where I am copying back the track from that array into `t` which points to the output track needs to be at the end of the update loop.
Otherwise setting whether or not the track is pad row crossing is not taken into account. That's why you never saw pad row crossings in the last layer. And I am not sure if the information in the lower layers is reliable unfortunately. 