### PR TITLE
[MID] require 3/4 chambers hit for both cathodes separately

### DIFF
--- a/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/Track.h
+++ b/DataFormats/Detectors/MUON/MID/include/DataFormatsMID/Track.h
@@ -176,6 +176,15 @@ class Track
   /// \li \c 3 track can be used to estimate local board efficiency
   int getEfficiencyFlag() const { return (mEfficiencyWord >> 24) & 0xF; }
 
+  /// record that the track misses information on that cathode
+  void setIncomplete(int cathode) { mIncomplete |= 1 << cathode; }
+
+  /// reset the flag for missing cathode information
+  void resetIncomplete() { mIncomplete = 0; }
+
+  /// return true is the track misses information on that cathode
+  bool isIncomplete(int cathode) const { return mIncomplete & (1 << cathode); }
+
   /// Overload ostream operator for MID track
   friend std::ostream& operator<<(std::ostream& stream, const Track& track);
 
@@ -192,8 +201,9 @@ class Track
   float mChi2 = 0.;                                ///< Chi2 of track
   int mNDF = 0;                                    ///< Number of chi2 degrees of freedom
   uint32_t mEfficiencyWord = 0;                    ///< Efficiency word
+  uint8_t mIncomplete = 0;                         //!< Flag for missing cathode information
 
-  ClassDefNV(Track, 1);
+  ClassDefNV(Track, 2);
 };
 } // namespace mid
 } // namespace o2

--- a/Detectors/MUON/MID/Tracking/include/MIDTracking/Tracker.h
+++ b/Detectors/MUON/MID/Tracking/include/MIDTracking/Tracker.h
@@ -57,20 +57,21 @@ class Tracker
   const std::vector<ROFRecord>& getClusterROFRecords() { return mClusterROFRecords; }
 
  private:
-  bool processSide(bool isRight, bool isInward);
-  bool tryAddTrack(const Track& track);
-  bool followTrackKeepAll(const Track& track, bool isRight, bool isInward);
+  void processSide(bool isRight, bool isInward);
+  void tryAddTrack(const Track& track);
+  void followTrackKeepAll(Track& track, bool isRight, bool isInward);
   bool findAllClusters(const Track& track, bool isRight, int chamber, int firstRPC, int lastRPC, int nextChamber,
                        std::unordered_set<int>& excludedClusters, bool excludeClusters);
-  bool followTrackKeepBest(const Track& track, bool isRight, bool isInward);
-  bool findNextCluster(const Track& track, bool isRight, bool isInward, int chamber, int firstRPC, int lastRPC, Track& bestTrack) const;
+  void followTrackKeepBest(Track& track, bool isRight, bool isInward);
+  void findNextCluster(const Track& track, bool isRight, bool isInward, int chamber, int firstRPC, int lastRPC, Track& bestTrack) const;
   int getFirstNeighbourRPC(int rpc) const;
   int getLastNeighbourRPC(int rpc) const;
   bool loadClusters(gsl::span<const Cluster>& clusters);
   bool makeTrackSeed(Track& track, const Cluster& cl1, const Cluster& cl2) const;
   void runKalmanFilter(Track& track, const Cluster& cluster) const;
   bool tryOneCluster(const Track& track, int chamber, int clIdx, Track& newTrack) const;
-  void excludeUsedClusters(const Track& track, int ch1, int ch2, std::unordered_set<int>& excludedClusters);
+  void excludeUsedClusters(const Track& track, int ch1, int ch2, std::unordered_set<int>& excludedClusters) const;
+  bool skipOneChamber(Track& track) const;
 
   static constexpr float SMT11Z = -1603.5; ///< Position of the first MID chamber (cm)
 
@@ -90,8 +91,8 @@ class Tracker
 
   GeometryTransformer mTransformer{}; ///< Geometry transformer
 
-  typedef bool (Tracker::*TrackerMemFn)(const Track&, bool, bool);
-  TrackerMemFn mFollowTrack{&Tracker::followTrackKeepBest}; ///! Choice of the function to follow the track
+  typedef void (Tracker::*TrackerMemFn)(Track&, bool, bool);
+  TrackerMemFn mFollowTrack{&Tracker::followTrackKeepAll}; ///! Choice of the function to follow the track
 };
 } // namespace mid
 } // namespace o2


### PR DESCRIPTION
@dstocco here are the changes to enforce the 3/4 condition for both cathodes separately.
I made the changes for the 2 algorithms and the effect in term of loss of efficiency is similar for both.
I also did a bit of clean up at the same time.