### PR TITLE
Fix skimming when IRframes come from AO2Ds

### DIFF
--- a/Common/Utils/include/CommonUtils/IRFrameSelector.h
+++ b/Common/Utils/include/CommonUtils/IRFrameSelector.h
@@ -32,8 +32,8 @@ class IRFrameSelector
   void setSelectedIRFrames(const SPAN& sp, size_t bwd = 0, size_t fwd = 0, bool removeOverlaps = true)
   {
     mFrames = gsl::span<const o2::dataformats::IRFrame>(sp.data(), sp.size());
-    mIsSet = true;
     applyMargins(bwd, fwd, removeOverlaps);
+    mIsSet = true;
     mLastIRFrameChecked.getMin().clear(); // invalidate
     mLastBoundID = -1;
   }

--- a/Common/Utils/src/IRFrameSelector.cxx
+++ b/Common/Utils/src/IRFrameSelector.cxx
@@ -149,13 +149,10 @@ size_t IRFrameSelector::loadIRFrames(const std::string& fname)
       bcRanges->SetBranchAddress("fBCend", &maxBC);
       for (int i = 0; i < (int)bcRanges->GetEntries(); i++) {
         bcRanges->GetEntry(i);
-        if (mOwnList.size()) {
-          auto& last = mOwnList.back();
-          toBeSorted |= last.getMin() < minBC;
-        }
         mOwnList.emplace_back(InteractionRecord::long2IR(minBC), InteractionRecord::long2IR(maxBC));
       }
       done = true;
+      toBeSorted = true;
     }
   }
 

--- a/Common/Utils/src/IRFrameSelector.cxx
+++ b/Common/Utils/src/IRFrameSelector.cxx
@@ -207,5 +207,5 @@ void IRFrameSelector::applyMargins(size_t bwd, size_t fwd, bool removeOverlaps)
     }
   }
   mOwnList.swap(lst);
-  setSelectedIRFrames(mOwnList);
+  mFrames = gsl::span<const o2::dataformats::IRFrame>(mOwnList.data(), mOwnList.size());
 }


### PR DESCRIPTION
Hi @shahor02,

the issue with the skimming was that the IRFrames in the TTree were not sorted and the check I had was considering only the cases of continuous unsorted IRFrames.
Now, if we read from the AO2D output, std::sort is run and the skimming sees the correct amount of frames.
Sorry for the inconvenience.
Cheers,
Max
