### PR TITLE
Workflow to filter out specific TPC tracks and clusters

### DIFF
--- a/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
+++ b/DataFormats/Detectors/GlobalTracking/src/RecoContainer.cxx
@@ -1383,6 +1383,10 @@ GTrackID RecoContainer::getTPCContributorGID(GTrackID gidx) const
   } else if (src == GTrackID::TPCTOF) {
     const auto& parent0 = getTPCTOFMatch(gidx); // TPC : TOF
     return parent0.getTrackRef();
+  } else if (src == GTrackID::TPCTRDTOF) {
+    const auto& parent0 = getTOFMatch(gidx); // TPC/TRD : TOF
+    const auto& parent1 = getTPCTRDTrack<o2::trd::TrackTRD>(parent0.getTrackRef());
+    return parent1.getRefGlobalTrackId();
   } else if (src == GTrackID::TPCTRD) {
     const auto& parent0 = getTPCTRDTrack<o2::trd::TrackTRD>(gidx);
     return parent0.getRefGlobalTrackId();

--- a/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrizationWithError.h
+++ b/DataFormats/Reconstruction/include/ReconstructionDataFormats/TrackParametrizationWithError.h
@@ -413,7 +413,7 @@ GPUdi() void TrackParametrizationWithError<value_T>::updateCovCorr(const value_t
     auto diagI = DiagMap[i];
     oldDiag[i] = mC[diagI];
     mC[diagI] += delta2[i];
-    for (int j = 0; j < i; i++) {
+    for (int j = 0; j < i; j++) {
       mC[CovarMap[i][j]] *= gpu::CAMath::Sqrt(mC[diagI] * mC[DiagMap[j]] / (oldDiag[i] * oldDiag[j]));
     }
   }

--- a/Detectors/GlobalTracking/src/MatchTPCITS.cxx
+++ b/Detectors/GlobalTracking/src/MatchTPCITS.cxx
@@ -450,7 +450,7 @@ bool MatchTPCITS::prepareTPCData()
     }
     if constexpr (isTPCTrack<decltype(trk)>()) {
       // unconstrained TPC track, with t0 = TrackTPC.getTime0+0.5*(DeltaFwd-DeltaBwd) and terr = 0.5*(DeltaFwd+DeltaBwd) in TimeBins
-      if (!this->mSkipTPCOnly) {
+      if (!this->mSkipTPCOnly && trk.getNClusters() > 0) {
         this->addTPCSeed(trk, this->tpcTimeBin2MUS(time0) - this->mTPCDriftTimeOffset, this->tpcTimeBin2MUS(terr), gid, gid.getIndex());
       }
     }

--- a/Detectors/GlobalTrackingWorkflow/study/CMakeLists.txt
+++ b/Detectors/GlobalTrackingWorkflow/study/CMakeLists.txt
@@ -11,16 +11,13 @@
 
 o2_add_library(GlobalTrackingStudy
                SOURCES src/TPCTrackStudy.cxx
-               SOURCES src/TrackingStudy.cxx
+                       src/TrackingStudy.cxx
+                       src/TPCDataFilter.cxx
                PUBLIC_LINK_LIBRARIES O2::GlobalTracking
                                      O2::GlobalTrackingWorkflowReaders
                                      O2::GlobalTrackingWorkflowHelpers
                                      O2::DataFormatsGlobalTracking
                                      O2::SimulationDataFormat)
-
-o2_target_root_dictionary(GlobalTrackingStudy
-                          HEADERS include/GlobalTrackingStudy/TPCTrackStudy.h
-                                  include/GlobalTrackingStudy/TrackingStudy.h)
 
 o2_add_executable(study-workflow
                   COMPONENT_NAME tpc-track
@@ -30,4 +27,9 @@ o2_add_executable(study-workflow
 o2_add_executable(study-workflow
                   COMPONENT_NAME tracking
                   SOURCES src/tracking-study-workflow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::GlobalTrackingStudy)
+
+o2_add_executable(filter-workflow
+                  COMPONENT_NAME tpc-data
+                  SOURCES src/tpc-data-filter-workflow.cxx
                   PUBLIC_LINK_LIBRARIES O2::GlobalTrackingStudy)

--- a/Detectors/GlobalTrackingWorkflow/study/include/GlobalTrackingStudy/TPCDataFilter.h
+++ b/Detectors/GlobalTrackingWorkflow/study/include/GlobalTrackingStudy/TPCDataFilter.h
@@ -9,21 +9,20 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-#ifndef O2_TPC_DATA_FILTER_H
-#define O2_TPC_DATA_FILTER_H
+#ifndef O2_TRACKING_STUDY_H
+#define O2_TRACKING_STUDY_H
 
 #include "ReconstructionDataFormats/GlobalTrackID.h"
 #include "Framework/Task.h"
 #include "Framework/DataProcessorSpec.h"
 #include "ReconstructionDataFormats/Track.h"
-#include "MathUtils/detail/Bracket.h"
 #include "DataFormatsTPC/ClusterNative.h"
 
-namespace o2::trackstudy
+namespace o2::global
 {
 /// create a processor spec
-o2::framework::DataProcessorSpec getTPCTrackStudySpec(o2::dataformats::GlobalTrackID::mask_t srcTracks, o2::dataformats::GlobalTrackID::mask_t srcClus, bool useMC);
+o2::framework::DataProcessorSpec getTPCDataFilter(o2::dataformats::GlobalTrackID::mask_t srcTracks, o2::dataformats::GlobalTrackID::mask_t srcClusters, bool useMC);
 
-} // namespace o2::trackstudy
+} // namespace o2::global
 
 #endif

--- a/Detectors/GlobalTrackingWorkflow/study/src/TPCDataFilter.cxx
+++ b/Detectors/GlobalTrackingWorkflow/study/src/TPCDataFilter.cxx
@@ -1,0 +1,314 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include <vector>
+#include <TStopwatch.h>
+#include "DataFormatsTPC/Constants.h"
+#include "ReconstructionDataFormats/PrimaryVertex.h"
+#include "ReconstructionDataFormats/VtxTrackRef.h"
+#include "DataFormatsGlobalTracking/RecoContainer.h"
+#include "DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h"
+#include "ReconstructionDataFormats/GlobalTrackID.h"
+#include "DetectorsBase/GeometryManager.h"
+#include "SimulationDataFormat/MCEventLabel.h"
+#include "SimulationDataFormat/MCUtils.h"
+#include "CommonUtils/NameConf.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/CCDBParamSpec.h"
+#include "DetectorsCommonDataFormats/DetID.h"
+#include "DetectorsBase/GRPGeomHelper.h"
+#include "GlobalTrackingStudy/TPCDataFilter.h"
+#include "TPCBase/ParameterElectronics.h"
+#include "CommonUtils/TreeStreamRedirector.h"
+#include "Steer/MCKinematicsReader.h"
+
+namespace o2::global
+{
+
+using namespace o2::framework;
+using DetID = o2::detectors::DetID;
+using DataRequest = o2::globaltracking::DataRequest;
+
+using PVertex = o2::dataformats::PrimaryVertex;
+using V2TRef = o2::dataformats::VtxTrackRef;
+using VTIndex = o2::dataformats::VtxTrackIndex;
+using GTrackID = o2::dataformats::GlobalTrackID;
+using TBracket = o2::math_utils::Bracketf_t;
+
+using timeEst = o2::dataformats::TimeStampWithError<float, float>;
+
+class TPCDataFilter : public Task
+{
+ public:
+  enum TrackDecision : char { NA,
+                              REMOVE,
+                              REDUCE,
+                              KEEP };
+
+  TPCDataFilter(std::shared_ptr<DataRequest> dr, GTrackID::mask_t src, bool useMC)
+    : mDataRequest(dr), mTracksSrc(src), mUseMC(useMC)
+  {
+  }
+  ~TPCDataFilter() final = default;
+  void init(InitContext& ic) final;
+  void run(ProcessingContext& pc) final;
+  void finaliseCCDB(ConcreteDataMatcher& matcher, void* obj) final;
+  void process(o2::globaltracking::RecoContainer& recoData);
+  void sendOutput(ProcessingContext& pc);
+
+ private:
+  void updateTimeDependentParams(ProcessingContext& pc){};
+  std::shared_ptr<DataRequest> mDataRequest;
+  bool mUseMC{false}; ///< MC flag
+  char mRemMode = TrackDecision::KEEP;
+  GTrackID::mask_t mTracksSrc{};
+  o2::steer::MCKinematicsReader mcReader; // reader of MC information
+  //
+  // TPC data
+  std::vector<o2::tpc::ClusterNative> mClustersLinearFiltered;
+  std::vector<unsigned int> mClustersLinearStatus;
+  std::vector<char> mTrackStatus;
+  std::vector<o2::tpc::TrackTPC> mTracksFiltered;
+  std::vector<o2::tpc::TPCClRefElem> mTrackClusIdxFiltered;
+  std::vector<o2::MCCompLabel> mTPCTrkLabelsFiltered;
+  o2::tpc::ClusterNativeAccess mClusFiltered;
+  GTrackID::mask_t mAccTrackSources;
+  float mMinAbsTgl = 0.;
+  int mMinTPCClusters = 0;
+};
+
+void TPCDataFilter::init(InitContext& ic)
+{
+  mRemMode = ic.options().get<bool>("suppress-rejected") ? TrackDecision::REMOVE : TrackDecision::REDUCE;
+  GTrackID::mask_t acceptSourcesTrc = GTrackID::getSourcesMask("ITS,TPC,ITS-TPC,TPC-TOF,TPC-TRD,ITS-TPC-TRD,TPC-TRD-TOF,ITS-TPC-TOF,ITS-TPC-TRD-TOF");
+  mAccTrackSources = acceptSourcesTrc & GTrackID::getSourcesMask(ic.options().get<std::string>("accept-track-sources"));
+  mMinAbsTgl = ic.options().get<float>("min-abs-tgl");
+  mMinTPCClusters = ic.options().get<int>("min-tpc-clusters");
+}
+
+void TPCDataFilter::run(ProcessingContext& pc)
+{
+  o2::globaltracking::RecoContainer recoData;
+  recoData.collectData(pc, *mDataRequest.get()); // select tracks of needed type, with minimal cuts, the real selected will be done in the vertexer
+  updateTimeDependentParams(pc);                 // Make sure this is called after recoData.collectData, which may load some conditions
+  process(recoData);
+
+  sendOutput(pc);
+}
+
+void TPCDataFilter::sendOutput(ProcessingContext& pc)
+{
+
+  pc.outputs().snapshot(Output{"TPC", "TRACKSF", 0, Lifetime::Timeframe}, mTracksFiltered);
+  pc.outputs().snapshot(Output{"TPC", "CLUSREFSF", 0, Lifetime::Timeframe}, mTrackClusIdxFiltered);
+  if (mUseMC) {
+    pc.outputs().snapshot(Output{"TPC", "TRACKSMCLBLF", 0, Lifetime::Timeframe}, mTPCTrkLabelsFiltered);
+  }
+
+  o2::tpc::TPCSectorHeader clusterOutputSectorHeader{0};
+  clusterOutputSectorHeader.activeSectors = (1ul << o2::tpc::constants::MAXSECTOR) - 1;
+  for (int i = 0; i < o2::tpc::constants::MAXSECTOR; i++) {
+    clusterOutputSectorHeader.sectorBits = (1ul << i);
+    o2::header::DataHeader::SubSpecificationType subspec = i;
+    char* buffer = pc.outputs().make<char>({o2::header::gDataOriginTPC, "CLUSTERNATIVEF", subspec, Lifetime::Timeframe, {clusterOutputSectorHeader}},
+                                           mClusFiltered.nClustersSector[i] * sizeof(*mClusFiltered.clustersLinear) + sizeof(o2::tpc::ClusterCountIndex))
+                     .data();
+    o2::tpc::ClusterCountIndex* outIndex = reinterpret_cast<o2::tpc::ClusterCountIndex*>(buffer);
+    memset(outIndex, 0, sizeof(*outIndex));
+    for (int j = 0; j < o2::tpc::constants::MAXGLOBALPADROW; j++) {
+      outIndex->nClusters[i][j] = mClusFiltered.nClusters[i][j];
+    }
+    memcpy(buffer + sizeof(*outIndex), mClusFiltered.clusters[i][0], mClusFiltered.nClustersSector[i] * sizeof(*mClusFiltered.clustersLinear));
+
+    if (mUseMC && mClusFiltered.clustersMCTruth) {
+      o2::dataformats::MCLabelContainer cont;
+      for (unsigned int j = 0; j < mClusFiltered.nClustersSector[i]; j++) {
+        const auto& labels = mClusFiltered.clustersMCTruth->getLabels(mClusFiltered.clusterOffset[i][0] + j);
+        for (const auto& label : labels) {
+          cont.addElement(j, label);
+        }
+      }
+      o2::dataformats::ConstMCLabelContainer contflat;
+      cont.flatten_to(contflat);
+      pc.outputs().snapshot({o2::header::gDataOriginTPC, "CLNATIVEMCLBLF", subspec, Lifetime::Timeframe, {clusterOutputSectorHeader}}, contflat);
+    }
+  }
+}
+
+void TPCDataFilter::process(o2::globaltracking::RecoContainer& recoData)
+{
+  auto tpcTracks = recoData.getTPCTracks();
+  auto tpcTrackClusIdx = recoData.getTPCTracksClusterRefs();
+  auto tpcClusterIdxStruct = &recoData.inputsTPCclusters->clusterIndex;
+  gsl::span<const o2::MCCompLabel> tpcTrkLabels;
+  if (mUseMC) {
+    tpcTrkLabels = recoData.getTPCTracksMCLabels();
+    mTPCTrkLabelsFiltered.clear();
+  }
+  const unsigned int DISCARD = -1U;
+
+  mTracksFiltered.clear();
+  mTrackClusIdxFiltered.clear();
+  mClustersLinearFiltered.clear();
+  mTrackStatus.clear();
+  mTrackStatus.resize(tpcTracks.size());
+  mClustersLinearStatus.clear();
+  mClustersLinearStatus.resize(tpcClusterIdxStruct->nClustersTotal, DISCARD);
+
+  size_t nSelTracks = 0;
+  auto selTPCTrack = [this, tpcTracks, tpcTrackClusIdx, tpcClusterIdxStruct, &nSelTracks](int itpc, char stat) {
+    this->mTrackStatus[itpc] = stat;
+    if (stat != TrackDecision::KEEP) {
+      return;
+    }
+    nSelTracks++;
+    const auto& trc = tpcTracks[itpc];
+    int count = trc.getNClusters();
+    const o2::tpc::ClusterNative* cl = nullptr;
+    for (int ic = count; ic--;) {
+      const auto cl = &trc.getCluster(tpcTrackClusIdx, ic, *tpcClusterIdxStruct);
+      size_t offs = std::distance(tpcClusterIdxStruct->clustersLinear, cl);
+      this->mClustersLinearStatus[offs] = 0;
+    }
+  };
+
+  auto trackIndex = recoData.getPrimaryVertexMatchedTracks(); // Global ID's for associated tracks
+  auto vtxRefs = recoData.getPrimaryVertexMatchedTrackRefs(); // references from vertex to these track IDs
+  int nv = vtxRefs.size();
+  for (int iv = 0; iv < nv; iv++) {
+    const auto& vtref = vtxRefs[iv];
+    for (int is = 0; is < GTrackID::NSources; is++) {
+      auto dmask = GTrackID::getSourceDetectorsMask(is);
+      if (!GTrackID::getSourceDetectorsMask(is)[GTrackID::TPC]) {
+        continue;
+      }
+      char decisionSource = mAccTrackSources[is] ? KEEP : mRemMode;
+      int idMin = vtxRefs[iv].getFirstEntryOfSource(is), idMax = idMin + vtxRefs[iv].getEntriesOfSource(is);
+      for (int i = idMin; i < idMax; i++) {
+        auto decision = decisionSource;
+        auto vid = trackIndex[i];
+        auto tpcID = recoData.getTPCContributorGID(vid);
+        if (vid.isAmbiguous() && mTrackStatus[tpcID] != TrackDecision::NA) { // already processed
+          continue;
+        }
+        if (decisionSource == KEEP) {
+          const auto& tpcTr = tpcTracks[tpcID.getIndex()];
+          if (std::abs(tpcTr.getTgl()) < mMinAbsTgl || tpcTr.getNClusters() < mMinTPCClusters) {
+            decision = mRemMode;
+          }
+        }
+        selTPCTrack(tpcID, decision);
+      }
+    }
+  }
+
+  // copy filtered clusters and register them in the filtered access struct
+  int offset = 0;
+  for (unsigned int i = 0; i < o2::tpc::constants::MAXSECTOR; i++) {
+    for (unsigned int j = 0; j < o2::tpc::constants::MAXGLOBALPADROW; j++) {
+      mClusFiltered.nClusters[i][j] = 0;
+      for (unsigned int ic = 0; ic < tpcClusterIdxStruct->nClusters[i][j]; ic++) {
+        if (mClustersLinearStatus[offset] != DISCARD) {
+          mClustersLinearStatus[offset] = mClustersLinearFiltered.size();
+          mClustersLinearFiltered.push_back(tpcClusterIdxStruct->clustersLinear[offset]);
+          mClusFiltered.nClusters[i][j]++;
+        }
+        offset++;
+      }
+    }
+  }
+  mClusFiltered.clustersLinear = mClustersLinearFiltered.data();
+  mClusFiltered.setOffsetPtrs();
+
+  LOGP(info, "Accepted {} tracks out of {} and {} clusters out of {}", nSelTracks, tpcTracks.size(), mClusFiltered.nClustersTotal, tpcClusterIdxStruct->nClustersTotal);
+
+  // register new tracks with updated cluster references
+  for (size_t itr = 0; itr < tpcTracks.size(); itr++) {
+    if (mTrackStatus[itr] == REMOVE) { // track is discarded
+      continue;
+    } else if (mTrackStatus[itr] == REDUCE) { // fill track by 0s, discard clusters
+      auto& t = mTracksFiltered.emplace_back();
+      memset(&t, 0, sizeof(o2::tpc::TrackTPC));
+      if (mUseMC) {
+        mTPCTrkLabelsFiltered.emplace_back();
+      }
+    } else { // track is accepted
+      const auto& tor = tpcTracks[itr];
+      const auto& cref = tor.getClusterRef();
+      mTracksFiltered.push_back(tor);
+      mTracksFiltered.back().shiftFirstClusterRef(int(mTrackClusIdxFiltered.size()) - tor.getClusterRef().getFirstEntry());
+      size_t idx0 = mTrackClusIdxFiltered.size();
+      int nclTrack = cref.getEntries();
+      mTrackClusIdxFiltered.resize(mTrackClusIdxFiltered.size() + nclTrack + (nclTrack + 1) / 2);
+
+      // see explanations in the TrackTPC::getClusterReference
+      uint32_t* clIndArr = reinterpret_cast<uint32_t*>(&mTrackClusIdxFiltered[idx0]);
+      uint8_t* srIndArr = reinterpret_cast<uint8_t*>(clIndArr + nclTrack);
+      for (int ic = 0; ic < nclTrack; ic++) {
+        uint8_t sectorIndex, rowIndex;
+        const auto cl = &tor.getCluster(tpcTrackClusIdx, ic, *tpcClusterIdxStruct, sectorIndex, rowIndex);
+        unsigned int oldLinear = std::distance(tpcClusterIdxStruct->clustersLinear, cl);
+        unsigned int newLinear = mClustersLinearStatus[oldLinear];
+        if (newLinear == DISCARD) {
+          LOGP(fatal, "discarded cluster {} is selected", oldLinear);
+        }
+        clIndArr[ic] = newLinear - mClusFiltered.clusterOffset[sectorIndex][rowIndex];
+        srIndArr[ic] = sectorIndex;
+        srIndArr[ic + nclTrack] = rowIndex;
+      }
+      if (mUseMC) {
+        mTPCTrkLabelsFiltered.emplace_back(tpcTrkLabels[itr]);
+      }
+    }
+  }
+}
+
+void TPCDataFilter::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
+{
+  if (o2::base::GRPGeomHelper::instance().finaliseCCDB(matcher, obj)) {
+    return;
+  }
+}
+
+DataProcessorSpec getTPCDataFilter(GTrackID::mask_t srcTracks, GTrackID::mask_t srcClusters, bool useMC)
+{
+  std::vector<OutputSpec> outputs;
+  for (int i = 0; i < o2::tpc::constants::MAXSECTOR; i++) {
+    outputs.emplace_back(o2::header::gDataOriginTPC, "CLUSTERNATIVEF", i, Lifetime::Timeframe);
+    if (useMC) {
+      outputs.emplace_back(o2::header::gDataOriginTPC, "CLNATIVEMCLBLF", i, Lifetime::Timeframe);
+    }
+  }
+  outputs.emplace_back("TPC", "TRACKSF", 0, Lifetime::Timeframe);
+  outputs.emplace_back("TPC", "CLUSREFSF", 0, Lifetime::Timeframe);
+  if (useMC) {
+    outputs.emplace_back("TPC", "TRACKSMCLBLF", 0, Lifetime::Timeframe);
+  }
+
+  auto dataRequest = std::make_shared<DataRequest>();
+
+  dataRequest->requestTracks(srcTracks, useMC);
+  dataRequest->requestClusters(srcClusters, useMC);
+  dataRequest->requestPrimaryVertertices(useMC);
+
+  return DataProcessorSpec{
+    "tpc-data-filter",
+    dataRequest->inputs,
+    outputs,
+    AlgorithmSpec{adaptFromTask<TPCDataFilter>(dataRequest, srcTracks, useMC)},
+    Options{
+      {"suppress-rejected", VariantType::Bool, false, {"Remove suppressed tracks instead of reducing them"}},
+      {"min-abs-tgl", VariantType::Float, 0.0f, {"suppress tracks with abs tgL less that this threshold (e.g. noise tracks)"}},
+      {"min-tpc-clusters", VariantType::Int, 0, {"suppress tracks less clusters that this threshold (e.g. noise tracks)"}},
+      {"accept-track-sources", VariantType::String, std::string{GTrackID::ALL}, {"comma-separated list of track sources to accept"}}}};
+}
+
+} // namespace o2::global

--- a/Detectors/GlobalTrackingWorkflow/study/src/tpc-data-filter-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/study/src/tpc-data-filter-workflow.cxx
@@ -1,0 +1,75 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "GlobalTrackingStudy/TPCDataFilter.h"
+#include "ReconstructionDataFormats/GlobalTrackID.h"
+#include "DetectorsCommonDataFormats/DetID.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "Framework/CompletionPolicy.h"
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
+#include "Framework/CallbacksPolicy.h"
+#include "DetectorsBase/DPLWorkflowUtils.h"
+#include "GlobalTrackingWorkflowHelpers/InputHelper.h"
+#include "DetectorsRaw/HBFUtilsInitializer.h"
+
+using namespace o2::framework;
+
+using GID = o2::dataformats::GlobalTrackID;
+using DetID = o2::detectors::DetID;
+
+// ------------------------------------------------------------------
+void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
+{
+  o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  std::vector<o2::framework::ConfigParamSpec> options{
+    {"disable-mc", o2::framework::VariantType::Bool, false, {"disable MC propagation"}},
+    {"track-sources", VariantType::String, std::string{GID::ALL}, {"comma-separated list of track sources to use"}},
+    {"cluster-sources", VariantType::String, std::string{GID::ALL}, {"comma-separated list of cluster sources to use"}},
+    {"disable-root-input", VariantType::Bool, false, {"disable root-files input reader"}},
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
+  o2::raw::HBFUtilsInitializer::addConfigOption(options);
+  std::swap(workflowOptions, options);
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  WorkflowSpec specs;
+
+  GID::mask_t allowedSourcesTrc = GID::getSourcesMask("TPC,ITS-TPC,TPC-TOF,TPC-TRD,ITS-TPC-TRD,TPC-TRD-TOF,ITS-TPC-TOF,ITS-TPC-TRD-TOF");
+  GID::mask_t allowedSourcesClus = GID::getSourcesMask("TPC");
+
+  // Update the (declared) parameters if changed from the command line
+  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
+
+  auto useMC = !configcontext.options().get<bool>("disable-mc");
+
+  GID::mask_t srcTrc = allowedSourcesTrc & GID::getSourcesMask(configcontext.options().get<std::string>("track-sources"));
+  GID::mask_t srcCls = allowedSourcesClus & GID::getSourcesMask(configcontext.options().get<std::string>("cluster-sources"));
+  o2::globaltracking::InputHelper::addInputSpecs(configcontext, specs, srcCls, srcTrc, srcTrc, useMC);
+  o2::globaltracking::InputHelper::addInputSpecsPVertex(configcontext, specs, useMC);
+  specs.emplace_back(o2::global::getTPCDataFilter(srcTrc, srcCls, useMC));
+
+  // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit
+  o2::raw::HBFUtilsInitializer hbfIni(configcontext, specs);
+
+  return std::move(specs);
+}

--- a/Detectors/TPC/workflow/include/TPCWorkflow/RecoWorkflow.h
+++ b/Detectors/TPC/workflow/include/TPCWorkflow/RecoWorkflow.h
@@ -81,7 +81,8 @@ framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData,           
                                     int caClusterer = 0,                          //
                                     int zsOnTheFly = 0,
                                     bool askDISTSTF = true,
-                                    bool selIR = false);
+                                    bool selIR = false,
+                                    bool filteredInp = false);
 
 void cleanupCallback();
 

--- a/Detectors/TPC/workflow/readers/src/TrackReaderSpec.cxx
+++ b/Detectors/TPC/workflow/readers/src/TrackReaderSpec.cxx
@@ -50,17 +50,20 @@ void TrackReader::run(ProcessingContext& pc)
       (trackTune.useTPCInnerCorr || trackTune.useTPCOuterCorr ||
        trackTune.tpcCovInnerType != TrackTunePar::AddCovType::Disable || trackTune.tpcCovOuterType != TrackTunePar::AddCovType::Disable)) {
     for (auto& trc : mTracksOut) {
+      if (trc.getNClusters() == 0) {
+        continue; // filtered/reduced track
+      }
       if (trackTune.useTPCInnerCorr) {
         trc.updateParams(trackTune.tpcParInner);
       }
       if (trackTune.tpcCovInnerType != TrackTunePar::AddCovType::Disable) {
-        trc.updateCov(trackTune.tpcCovInner, trackTune.tpcCovInnerType);
+        trc.updateCov(trackTune.tpcCovInner, trackTune.tpcCovInnerType == TrackTunePar::AddCovType::WithCorrelations);
       }
       if (trackTune.useTPCOuterCorr) {
         trc.getParamOut().updateParams(trackTune.tpcParOuter);
       }
       if (trackTune.tpcCovOuterType != TrackTunePar::AddCovType::Disable) {
-        trc.getParamOut().updateCov(trackTune.tpcCovOuter, trackTune.tpcCovOuterType);
+        trc.getParamOut().updateCov(trackTune.tpcCovOuter, trackTune.tpcCovOuterType == TrackTunePar::AddCovType::WithCorrelations);
       }
     }
   }

--- a/Detectors/TPC/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/TPC/workflow/src/RecoWorkflow.cxx
@@ -95,7 +95,7 @@ const std::unordered_map<std::string, OutputType> OutputMap{
 
 framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData, std::vector<int> const& tpcSectors, unsigned long tpcSectorMask, std::vector<int> const& laneConfiguration,
                                     bool propagateMC, unsigned nLanes, std::string const& cfgInput, std::string const& cfgOutput, bool disableRootInput,
-                                    int caClusterer, int zsOnTheFly, bool askDISTSTF, bool selIR)
+                                    int caClusterer, int zsOnTheFly, bool askDISTSTF, bool selIR, bool filteredInp)
 {
   InputType inputType;
   try {
@@ -112,6 +112,10 @@ framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData, std::vecto
   auto isEnabled = [&outputTypes](OutputType type) {
     return std::find(outputTypes.begin(), outputTypes.end(), type) != outputTypes.end();
   };
+
+  if (filteredInp && !(inputType == InputType::PassThrough && isEnabled(OutputType::Tracks) && isEnabled(OutputType::Clusters) && isEnabled(OutputType::SendClustersPerSector))) {
+    throw std::invalid_argument("filtered-input option must be provided only with pass-through input and clusters,tracks,send-clusters-per-sector output");
+  }
 
   bool decompressTPC = inputType == InputType::CompClustersCTF || inputType == InputType::CompClusters;
   // Disable not applicable settings depending on TPC input, no need to disable manually
@@ -397,13 +401,13 @@ framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData, std::vecto
   if (isEnabled(OutputType::Clusters) && !isEnabled(OutputType::DisableWriter)) {
     // if the caClusterer is enabled, only one data set with the full TPC is produced, and the writer
     // is configured to write one single branch
-    specs.push_back(makeWriterSpec("tpc-native-cluster-writer",
-                                   inputType == InputType::Clusters ? "tpc-filtered-native-clusters.root" : "tpc-native-clusters.root",
+    specs.push_back(makeWriterSpec(filteredInp ? "tpc-native-cluster-writer_filtered" : "tpc-native-cluster-writer",
+                                   (inputType == InputType::Clusters || inputType == InputType::PassThrough) ? "tpc-filtered-native-clusters.root" : "tpc-native-clusters.root",
                                    "tpcrec",
-                                   BranchDefinition<const char*>{InputSpec{"data", ConcreteDataTypeMatcher{"TPC", "CLUSTERNATIVE"}},
+                                   BranchDefinition<const char*>{InputSpec{"data", ConcreteDataTypeMatcher{"TPC", inputType == InputType::PassThrough ? o2::header::DataDescription("CLUSTERNATIVEF") : o2::header::DataDescription("CLUSTERNATIVE")}},
                                                                  "TPCClusterNative",
                                                                  "databranch"},
-                                   BranchDefinition<std::vector<char>>{InputSpec{"mc", ConcreteDataTypeMatcher{"TPC", "CLNATIVEMCLBL"}},
+                                   BranchDefinition<std::vector<char>>{InputSpec{"mc", ConcreteDataTypeMatcher{"TPC", inputType == InputType::PassThrough ? o2::header::DataDescription("CLNATIVEMCLBLF") : o2::header::DataDescription("CLNATIVEMCLBL")}},
                                                                        "TPCClusterNativeMCTruth",
                                                                        "mcbranch", fillLabels},
                                    (caClusterer || decompressTPC || inputType == InputType::PassThrough) && !isEnabled(OutputType::SendClustersPerSector)));
@@ -472,8 +476,8 @@ framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData, std::vecto
     // defining the track writer process using the generic RootTreeWriter and generator tool
     //
     // defaults
-    const char* processName = "tpc-track-writer";
-    const char* defaultFileName = "tpctracks.root";
+    const char* processName = filteredInp ? "tpc-track-writer_filtered" : "tpc-track-writer";
+    const char* defaultFileName = filteredInp ? "tpctracks_filtered.root" : "tpctracks.root";
     const char* defaultTreeName = "tpcrec";
 
     //branch definitions for RootTreeWriter spec
@@ -485,16 +489,16 @@ framework::WorkflowSpec getWorkflow(CompletionPolicyData* policyData, std::vecto
     auto logger = BranchDefinition<TrackOutputType>::Spectator([](TrackOutputType const& tracks) {
       LOG(info) << "writing " << tracks.size() << " track(s)";
     });
-    auto tracksdef = BranchDefinition<TrackOutputType>{InputSpec{"inputTracks", "TPC", "TRACKS", 0},           //
-                                                       "TPCTracks", "track-branch-name",                       //
-                                                       1,                                                      //
-                                                       logger};                                                //
-    auto clrefdef = BranchDefinition<ClusRefsOutputType>{InputSpec{"inputClusRef", "TPC", "CLUSREFS", 0},      //
-                                                         "ClusRefs", "trackclusref-branch-name"};              //
-    auto mcdef = BranchDefinition<std::vector<o2::MCCompLabel>>{InputSpec{"mcinput", "TPC", "TRACKSMCLBL", 0}, //
-                                                                "TPCTracksMCTruth",                            //
-                                                                (propagateMC ? 1 : 0),                         //
-                                                                "trackmc-branch-name"};                        //
+    auto tracksdef = BranchDefinition<TrackOutputType>{InputSpec{"inputTracks", "TPC", filteredInp ? o2::header::DataDescription("TRACKSF") : o2::header::DataDescription("TRACKS"), 0},                //
+                                                       "TPCTracks", "track-branch-name",                                                                                                                //
+                                                       1,                                                                                                                                               //
+                                                       logger};                                                                                                                                         //
+    auto clrefdef = BranchDefinition<ClusRefsOutputType>{InputSpec{"inputClusRef", "TPC", filteredInp ? o2::header::DataDescription("CLUSREFSF") : o2::header::DataDescription("CLUSREFS"), 0},         //
+                                                         "ClusRefs", "trackclusref-branch-name"};                                                                                                       //
+    auto mcdef = BranchDefinition<std::vector<o2::MCCompLabel>>{InputSpec{"mcinput", "TPC", filteredInp ? o2::header::DataDescription("TRACKSMCLBLF") : o2::header::DataDescription("TRACKSMCLBL"), 0}, //
+                                                                "TPCTracksMCTruth",                                                                                                                     //
+                                                                (propagateMC ? 1 : 0),                                                                                                                  //
+                                                                "trackmc-branch-name"};                                                                                                                 //
 
     // depending on the MC propagation flag, branch definition for MC labels is disabled
     specs.push_back(MakeRootTreeWriterSpec(processName, defaultFileName, defaultTreeName,

--- a/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
+++ b/Detectors/TPC/workflow/src/tpc-reco-workflow.cxx
@@ -67,6 +67,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"ignore-dist-stf", VariantType::Bool, false, {"do not subscribe to FLP/DISTSUBTIMEFRAME/0 message (no lost TF recovery)"}},
     {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings (e.g.: 'TPCHwClusterer.peakChargeThreshold=4;...')"}},
     {"configFile", VariantType::String, "", {"configuration file for configurable parameters"}},
+    {"filtered-input", VariantType::Bool, false, {"Filtered tracks, clusters input, prefix dataDescriptors with F"}},
     {"select-ir-frames", VariantType::Bool, false, {"Subscribe and filter according to external IR Frames"}}};
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
   std::swap(workflowOptions, options);
@@ -175,7 +176,8 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
                                                 !cfgc.options().get<bool>("no-ca-clusterer"),      //
                                                 !cfgc.options().get<bool>("no-tpc-zs-on-the-fly"), //
                                                 !cfgc.options().get<bool>("ignore-dist-stf"),      //
-                                                cfgc.options().get<bool>("select-ir-frames"));
+                                                cfgc.options().get<bool>("select-ir-frames"),
+                                                cfgc.options().get<bool>("filtered-input"));
 
   // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit
   o2::raw::HBFUtilsInitializer hbfIni(cfgc, wf);

--- a/prodtests/full-system-test/dpl-workflow.sh
+++ b/prodtests/full-system-test/dpl-workflow.sh
@@ -392,7 +392,7 @@ has_detector_reco TRD && ! has_detector_from_global_reader TRD && add_W o2-trd-t
 has_detectors_reco ITS TPC && has_detector_matching ITSTPC && add_W o2-tpcits-match-workflow "$DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $DISABLE_MC $SEND_ITSTPC_DTGL --nthreads $ITSTPC_THREADS --pipeline $(get_N itstpc-track-matcher MATCH REST $ITSTPC_THREADS TPCITS)" "$ITSMFT_STROBES"
 has_detector_reco TRD && [[ ! -z "$TRD_SOURCES" ]] && add_W o2-trd-global-tracking "$DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $DISABLE_MC $TRD_CONFIG $TRD_FILTER_CONFIG --track-sources $TRD_SOURCES --pipeline $(get_N trd-globaltracking_TPC_ITS-TPC_ TRD REST 1 TRDTRK),$(get_N trd-globaltracking_TPC_FT0_ITS-TPC_ TRD REST 1 TRDTRK)" "$TRD_CONFIG_KEY;$ITSMFT_STROBES"
 has_detector_reco TOF && [[ ! -z "$TOF_SOURCES" ]] && add_W o2-tof-matcher-workflow "$DISABLE_DIGIT_ROOT_INPUT $DISABLE_ROOT_OUTPUT $DISABLE_MC --track-sources $TOF_SOURCES --pipeline $(get_N tof-matcher TOF REST 1 TOFMATCH)" "$ITSMFT_STROBES"
-has_detectors TPC && [ -z "$DISABLE_ROOT_OUTPUT" ] && add_W o2-tpc-reco-workflow "--input-type pass-through --output-type clusters,tracks,send-clusters-per-sector $DISABLE_MC"
+has_detectors TPC && [[ -z "$DISABLE_ROOT_OUTPUT" && -z "$SKIP_TPC_CLUSTERSTRACKS_OUTPUT" ]] && add_W o2-tpc-reco-workflow "--input-type pass-through --output-type clusters,tracks,send-clusters-per-sector $DISABLE_MC"
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Reconstruction workflows normally active only in async mode in async mode ($LIST_OF_ASYNC_RECO_STEPS), but can be forced via $WORKFLOW_EXTRA_PROCESSING_STEPS


### PR DESCRIPTION
Example of running:
```
o2-tpc-data-filter-workflow --disable-mc --hbfutils-config o2_tfidinfo.root  --shm-segment-size 16000000000 --accept-track-sources ITS-TPC,ITS-TPC-TRD,TPC-TRD-TOF,ITS-TPC-TOF,ITS-TPC-TRD-TOF | \
o2-tpc-reco-workflow  --disable-mc  --shm-segment-size 16000000000  --input-type pass-through --output-type clusters,tracks,send-clusters-per-sector --filtered-input
```

Additional options to `--min-abs-tgl <> --min-tpc-clusters <>` useful to clean up the cosmic. 
Only clusters of selected tracks will be send to the output and the cluster references of the validated tracks will be redone. 
The "discarded" tracks are not really removed from the output vector (unless `--suppress-rejected` option is passed) in order to not break the references of the global tracks. Instead, they are filled by 0s to be better compressible. When read back they will e.g. return `getNClusters() == 0`.

The output by default is written to `tpctracks_filtered.root` and `tpc-filtered-native-clusters.root` to not overwrite original data.