### PR TITLE
MCH: fix for nm calls

### DIFF
--- a/Detectors/MUON/check_nof_exported_symbols.sh
+++ b/Detectors/MUON/check_nof_exported_symbols.sh
@@ -4,11 +4,11 @@
 library=$1
 expected=$2
 
-nlibs=$(/usr/bin/nm -m -extern-only -defined-only $library -s __TEXT __text | grep mch | wc -l)
+nlibs=$(/usr/bin/nm -m --extern-only --defined-only $library -s __TEXT __text | grep mch | wc -l)
 
 if [ $nlibs -ne $expected ]; then
   echo "bad: check number of exported symbols in $library"
-  /usr/bin/nm -m -extern-only -defined-only $library -s __TEXT __text
+  /usr/bin/nm -m --extern-only --defined-only $library -s __TEXT __text
 else
   echo "good: $library contains the expected $expected exported symbols"
 fi


### PR DESCRIPTION
With recent XCode updates on macOS nm no longer supports single dash options for nm.