### PR TITLE
Workflow to study the ITS ROF bias wrt start of the TF

### DIFF
--- a/Detectors/GlobalTrackingWorkflow/study/CMakeLists.txt
+++ b/Detectors/GlobalTrackingWorkflow/study/CMakeLists.txt
@@ -13,6 +13,7 @@ o2_add_library(GlobalTrackingStudy
                SOURCES src/TPCTrackStudy.cxx
                        src/TrackingStudy.cxx
                        src/TPCDataFilter.cxx
+                       src/ITSOffsStudy.cxx
                PUBLIC_LINK_LIBRARIES O2::GlobalTracking
                                      O2::GlobalTrackingWorkflowReaders
                                      O2::GlobalTrackingWorkflowHelpers
@@ -32,4 +33,10 @@ o2_add_executable(study-workflow
 o2_add_executable(filter-workflow
                   COMPONENT_NAME tpc-data
                   SOURCES src/tpc-data-filter-workflow.cxx
+                  PUBLIC_LINK_LIBRARIES O2::GlobalTrackingStudy)
+
+
+o2_add_executable(study-workflow
+                  COMPONENT_NAME its-offset
+                  SOURCES src/its-offset-study-workflow.cxx
                   PUBLIC_LINK_LIBRARIES O2::GlobalTrackingStudy)

--- a/Detectors/GlobalTrackingWorkflow/study/include/GlobalTrackingStudy/ITSOffsStudy.h
+++ b/Detectors/GlobalTrackingWorkflow/study/include/GlobalTrackingStudy/ITSOffsStudy.h
@@ -1,0 +1,27 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef O2_TRACKING_STUDY_H
+#define O2_TRACKING_STUDY_H
+
+#include "ReconstructionDataFormats/GlobalTrackID.h"
+#include "Framework/Task.h"
+#include "Framework/DataProcessorSpec.h"
+#include "ReconstructionDataFormats/Track.h"
+
+namespace o2::trackstudy
+{
+/// create a processor spec
+o2::framework::DataProcessorSpec getITSOffsStudy(o2::dataformats::GlobalTrackID::mask_t srcTracks, o2::dataformats::GlobalTrackID::mask_t srcClus);
+
+} // namespace o2::trackstudy
+
+#endif

--- a/Detectors/GlobalTrackingWorkflow/study/src/ITSOffsStudy.cxx
+++ b/Detectors/GlobalTrackingWorkflow/study/src/ITSOffsStudy.cxx
@@ -1,0 +1,171 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "GlobalTrackingStudy/ITSOffsStudy.h"
+
+#include <vector>
+#include <TStopwatch.h>
+#include "DataFormatsGlobalTracking/RecoContainer.h"
+#include "DataFormatsGlobalTracking/RecoContainerCreateTracksVariadic.h"
+#include "ReconstructionDataFormats/GlobalTrackID.h"
+#include "CommonDataFormat/BunchFilling.h"
+#include "CommonUtils/NameConf.h"
+#include "Framework/ConfigParamRegistry.h"
+#include "Framework/CCDBParamSpec.h"
+#include "DetectorsCommonDataFormats/DetID.h"
+#include "ReconstructionDataFormats/PrimaryVertex.h"
+#include "CommonUtils/TreeStreamRedirector.h"
+#include "ReconstructionDataFormats/VtxTrackRef.h"
+#include <TH1F.h>
+
+namespace o2::trackstudy
+{
+
+using namespace o2::framework;
+using DetID = o2::detectors::DetID;
+using DataRequest = o2::globaltracking::DataRequest;
+
+using PVertex = o2::dataformats::PrimaryVertex;
+using V2TRef = o2::dataformats::VtxTrackRef;
+using VTIndex = o2::dataformats::VtxTrackIndex;
+using GTrackID = o2::dataformats::GlobalTrackID;
+
+using timeEst = o2::dataformats::TimeStampWithError<float, float>;
+
+class ITSOffsStudy : public Task
+{
+ public:
+  ITSOffsStudy(std::shared_ptr<DataRequest> dr, GTrackID::mask_t src) : mDataRequest(dr), mTracksSrc(src) {}
+  ~ITSOffsStudy() final = default;
+  void init(InitContext& ic) final;
+  void run(ProcessingContext& pc) final;
+  void endOfStream(EndOfStreamContext& ec) final;
+  void finaliseCCDB(ConcreteDataMatcher& matcher, void* obj) final;
+  void process(o2::globaltracking::RecoContainer& recoData);
+
+ private:
+  void updateTimeDependentParams(ProcessingContext& pc);
+  std::shared_ptr<DataRequest> mDataRequest;
+  std::unique_ptr<o2::utils::TreeStreamRedirector> mDBGOut;
+  GTrackID::mask_t mTracksSrc{};
+  std::unique_ptr<TH1F> mDTHisto{};
+  const std::string mOutName{"its_offset_Study.root"};
+};
+
+void ITSOffsStudy::init(InitContext& ic)
+{
+  mDBGOut = std::make_unique<o2::utils::TreeStreamRedirector>(mOutName.c_str(), "recreate");
+  mDTHisto = std::make_unique<TH1F>("dT", "T_{TOF} - T_{ITS-ROF}, #mus", 1000, 1, -1);
+  mDTHisto->SetDirectory(nullptr);
+}
+
+void ITSOffsStudy::run(ProcessingContext& pc)
+{
+  o2::globaltracking::RecoContainer recoData;
+  recoData.collectData(pc, *mDataRequest.get()); // select tracks of needed type, with minimal cuts, the real selected will be done in the vertexer
+  updateTimeDependentParams(pc);                 // Make sure this is called after recoData.collectData, which may load some conditions
+  process(recoData);
+}
+
+void ITSOffsStudy::updateTimeDependentParams(ProcessingContext& pc)
+{
+  static bool initOnceDone = false;
+  if (!initOnceDone) { // this params need to be queried only once
+    initOnceDone = true;
+  }
+}
+
+void ITSOffsStudy::process(o2::globaltracking::RecoContainer& recoData)
+{
+  constexpr float PS2MUS = 1e-6;
+  auto trackIndex = recoData.getPrimaryVertexMatchedTracks(); // Global ID's for associated tracks
+  auto vtxRefs = recoData.getPrimaryVertexMatchedTrackRefs(); // references from vertex to these track IDs
+  auto tofClusters = recoData.getTOFClusters();
+  auto itsROFs = recoData.getITSTracksROFRecords();
+  std::vector<int> itsTr2ROFID;
+  std::unordered_map<GTrackID, char> ambigMap;
+
+  int cntROF = 0;
+  for (const auto& rof : itsROFs) {
+    size_t maxE = rof.getFirstEntry() + rof.getNEntries();
+    if (itsTr2ROFID.size() < maxE) {
+      itsTr2ROFID.resize(maxE, cntROF);
+    }
+    cntROF++;
+  }
+
+  int nv = vtxRefs.size();
+  for (int iv = 0; iv < nv; iv++) {
+    const auto& vtref = vtxRefs[iv];
+    for (int is = 0; is < GTrackID::NSources; is++) {
+      if (!mTracksSrc[is] || !(GTrackID::getSourceDetectorsMask(is)[GTrackID::ITS] && GTrackID::getSourceDetectorsMask(is)[GTrackID::TOF])) {
+        continue;
+      }
+      int idMin = vtxRefs[iv].getFirstEntryOfSource(is), idMax = idMin + vtxRefs[iv].getEntriesOfSource(is);
+      for (int i = idMin; i < idMax; i++) {
+        auto vid = trackIndex[i];
+        if (vid.isAmbiguous()) {
+          auto& ambEntry = ambigMap[vid];
+          if (ambEntry > 0) {
+            continue;
+          }
+          ambEntry = 1;
+        }
+        auto refs = recoData.getSingleDetectorRefs(vid);
+        if (!refs[GTrackID::ITS].isIndexSet()) { // might be an afterburner track
+          continue;
+        }
+        const auto& tofCl = tofClusters[refs[GTrackID::TOF]];
+        float timeTOFMUS = (tofCl.getTime() - recoData.getTOFMatch(vid).getLTIntegralOut().getTOF(o2::track::PID::Pion)) * PS2MUS;
+
+        int itsTrackID = refs[GTrackID::ITS].getIndex();
+        // find the ROF corresponding to this track
+        const auto& rof = itsROFs[itsTr2ROFID[itsTrackID]];
+        auto tsROF = rof.getBCData().differenceInBC(recoData.startIR) * o2::constants::lhc::LHCBunchSpacingMUS;
+        (*mDBGOut) << "itstof"
+                   << "gid=" << vid << "ttof=" << timeTOFMUS << "tits=" << tsROF << "itsROFID=" << itsTr2ROFID[itsTrackID] << "\n";
+        mDTHisto->Fill(timeTOFMUS - tsROF);
+      }
+    }
+  }
+}
+
+void ITSOffsStudy::endOfStream(EndOfStreamContext& ec)
+{
+  mDBGOut.reset();
+  TFile fout(mOutName.c_str(), "update");
+  fout.WriteTObject(mDTHisto.get());
+  LOGP(info, "Stored time differences histogram {} and tree {} into {}", mDTHisto->GetName(), "itstof", mOutName.c_str());
+  fout.Close();
+}
+
+void ITSOffsStudy::finaliseCCDB(ConcreteDataMatcher& matcher, void* obj)
+{
+}
+
+DataProcessorSpec getITSOffsStudy(GTrackID::mask_t srcTracks, GTrackID::mask_t srcClusters)
+{
+  std::vector<OutputSpec> outputs;
+  auto dataRequest = std::make_shared<DataRequest>();
+  bool useMC = false;
+  dataRequest->requestTracks(srcTracks, useMC);
+  dataRequest->requestClusters(srcClusters, useMC);
+  dataRequest->requestPrimaryVertertices(useMC);
+
+  return DataProcessorSpec{
+    "its-offset-study",
+    dataRequest->inputs,
+    outputs,
+    AlgorithmSpec{adaptFromTask<ITSOffsStudy>(dataRequest, srcTracks)},
+    Options{}};
+}
+
+} // namespace o2::trackstudy

--- a/Detectors/GlobalTrackingWorkflow/study/src/its-offset-study-workflow.cxx
+++ b/Detectors/GlobalTrackingWorkflow/study/src/its-offset-study-workflow.cxx
@@ -1,0 +1,72 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "GlobalTrackingStudy/ITSOffsStudy.h"
+#include "ReconstructionDataFormats/GlobalTrackID.h"
+#include "DetectorsCommonDataFormats/DetID.h"
+#include "CommonUtils/ConfigurableParam.h"
+#include "Framework/CompletionPolicy.h"
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/CompletionPolicyHelpers.h"
+#include "Framework/CallbacksPolicy.h"
+#include "DetectorsBase/DPLWorkflowUtils.h"
+#include "GlobalTrackingWorkflowHelpers/InputHelper.h"
+#include "DetectorsRaw/HBFUtilsInitializer.h"
+
+using namespace o2::framework;
+using GID = o2::dataformats::GlobalTrackID;
+using DetID = o2::detectors::DetID;
+
+// ------------------------------------------------------------------
+void customize(std::vector<o2::framework::CallbacksPolicy>& policies)
+{
+  o2::raw::HBFUtilsInitializer::addNewTimeSliceCallback(policies);
+}
+
+// we need to add workflow options before including Framework/runDataProcessing
+void customize(std::vector<ConfigParamSpec>& workflowOptions)
+{
+  // option allowing to set parameters
+  std::vector<o2::framework::ConfigParamSpec> options{
+    {"track-sources", VariantType::String, std::string{"ITS,ITS-TPC-TRD-TOF,ITS-TPC-TOF,ITS-TPC,ITS-TPC-TRD"}, {"comma-separated list of track sources to use"}},
+    {"disable-root-input", VariantType::Bool, false, {"disable root-files input reader"}},
+    {"configKeyValues", VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
+  o2::raw::HBFUtilsInitializer::addConfigOption(options, "o2_tfidinfo.root");
+  std::swap(workflowOptions, options);
+}
+
+// ------------------------------------------------------------------
+
+#include "Framework/runDataProcessing.h"
+
+WorkflowSpec defineDataProcessing(ConfigContext const& configcontext)
+{
+  WorkflowSpec specs;
+
+  GID::mask_t allowedSourcesTrc = GID::getSourcesMask("ITS,ITS-TPC-TRD-TOF,ITS-TPC-TOF,ITS-TPC,ITS-TPC-TRD");
+  GID::mask_t allowedSourcesClus = GID::getSourcesMask("TOF");
+
+  // Update the (declared) parameters if changed from the command line
+  o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));
+
+  GID::mask_t srcTrc = allowedSourcesTrc & GID::getSourcesMask(configcontext.options().get<std::string>("track-sources"));
+  srcTrc |= GID::getSourcesMask("ITS");
+  GID::mask_t srcCls = allowedSourcesClus;
+
+  o2::globaltracking::InputHelper::addInputSpecs(configcontext, specs, srcCls, srcTrc, srcTrc, false);
+  o2::globaltracking::InputHelper::addInputSpecsPVertex(configcontext, specs, false); // P-vertex is always needed
+  specs.emplace_back(o2::trackstudy::getITSOffsStudy(srcTrc, srcCls));
+
+  // configure dpl timer to inject correct firstTForbit: start from the 1st orbit of TF containing 1st sampled orbit
+  o2::raw::HBFUtilsInitializer hbfIni(configcontext, specs);
+
+  return std::move(specs);
+}


### PR DESCRIPTION
Run e.g. as 
```
o2-its-offset-study-workflow --shm-segment-size 16000000000
```
in the directory containing the output files from the reconstruction with at least ITS, ITS-TPC, ITS-TPC-(TRD)-TOF tracking enabled. An output file `its_offset_Study.root` is created with

1) `TTree itstof`, containing branches
`gid`: GlobalTrackID of used track
`ttof`: TOF-matched track time estimate in mus (wrt TF start) 
`tits`: time of the nominal ROF start (wrt TF start) the matched ITS tracks belongs to
`itsROFID`: corresponding ROF ID (counted from the TF start)

2) `TH1F dT` : histogram of `ttof` - `tits`.
In absence of ROF bias, the entries should start at 0.