### PR TITLE
ZDC: Inclusion of data-driven model for free nucleon spectators

### DIFF
--- a/Detectors/ZDC/base/CMakeLists.txt
+++ b/Detectors/ZDC/base/CMakeLists.txt
@@ -10,8 +10,8 @@
 # or submit itself to any jurisdiction.
 
 o2_add_library(ZDCBase
-               SOURCES src/Geometry.cxx src/ModuleConfig.cxx src/Helpers.cxx
+               SOURCES src/Geometry.cxx src/ModuleConfig.cxx src/FragmentParam.cxx src/Helpers.cxx
                PUBLIC_LINK_LIBRARIES O2::CommonConstants ROOT::MathCore FairRoot::Base O2::FrameworkLogger)
 
-o2_target_root_dictionary(ZDCBase HEADERS include/ZDCBase/Geometry.h include/ZDCBase/Constants.h
-                                          include/ZDCBase/ModuleConfig.h)
+  o2_target_root_dictionary(ZDCBase HEADERS include/ZDCBase/Geometry.h include/ZDCBase/Constants.h
+                                            include/ZDCBase/ModuleConfig.h include/ZDCBase/FragmentParam.h)

--- a/Detectors/ZDC/base/include/ZDCBase/FragmentParam.h
+++ b/Detectors/ZDC/base/include/ZDCBase/FragmentParam.h
@@ -1,0 +1,72 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef ALICEO2_ZDC_FRAGMENTPARAM_H_
+#define ALICEO2_ZDC_FRAGMENTPARAM_H_
+
+#include <Rtypes.h>
+#include <array>
+#include <TF1.h>
+
+namespace o2
+{
+namespace zdc
+{
+
+class FragmentParam
+{
+
+ public:
+  static constexpr int POLDEG = 4;           // degree of polyomial for spectator parametrization function
+  static constexpr int NCOEFFS = POLDEG + 1; // number of coefficients
+
+  FragmentParam();
+  FragmentParam(std::array<double, NCOEFFS> const& fn, std::array<double, NCOEFFS> const& fp,
+                std::array<double, NCOEFFS> const& sigman, std::array<double, NCOEFFS> const& sigmap);
+
+  void print() const;
+
+  std::array<double, NCOEFFS> const& getParamsfn() const { return mParamfn; }
+  std::array<double, NCOEFFS> const& getParamsfp() const { return mParamfp; }
+  std::array<double, NCOEFFS> const& getParamssigman() const { return mParamsigman; }
+  std::array<double, NCOEFFS> const& getParamssigmap() const { return mParamsigmap; }
+  //
+  TF1 const& getfNeutrons() const { return *mFNeutrons.get(); }
+  TF1 const& getsigmaNeutrons() const { return *mFSigmaNeutrons.get(); }
+  TF1 const& getfProtons() const { return *mFProtons.get(); }
+  TF1 const& getsigmaProtons() const { return *mFSigmaProtons.get(); }
+  //
+  void setParamsfn(std::array<double, NCOEFFS> const& arrvalues);
+  void setParamsfp(std::array<double, NCOEFFS> const& arrvalues);
+  void setParamssigman(std::array<double, NCOEFFS> const& arrvalues);
+  void setParamssigmap(std::array<double, NCOEFFS> const& arrvalues);
+
+ private:
+  std::array<double, NCOEFFS> mParamfn{8.536764, -0.841422, 1.403253, -0.117200, 0.002091};
+  std::array<double, NCOEFFS> mParamsigman{0.689335, -0.238903, 0.044252, -0.003913, 0.000133};
+  std::array<double, NCOEFFS> mParamfp{1.933857, -1.285600, 0.670891, -0.064681, 0.001718};
+  std::array<double, NCOEFFS> mParamsigmap{1.456359, -0.505661, 0.088046, -0.007115, 0.000225};
+
+  // functions
+  void initFunctions();
+
+  std::unique_ptr<TF1> mFNeutrons;
+  std::unique_ptr<TF1> mFSigmaNeutrons;
+  std::unique_ptr<TF1> mFProtons;
+  std::unique_ptr<TF1> mFSigmaProtons;
+
+  ClassDefNV(FragmentParam, 1);
+};
+
+} // namespace zdc
+} // namespace o2
+
+#endif /* ALICEO2_ZDC_FRAGMENTPARAM_H_ */

--- a/Detectors/ZDC/base/src/FragmentParam.cxx
+++ b/Detectors/ZDC/base/src/FragmentParam.cxx
@@ -1,0 +1,90 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#include "ZDCBase/FragmentParam.h"
+
+using namespace o2::zdc;
+
+//______________________________________________________________________________
+FragmentParam::FragmentParam()
+{
+  // default constructor
+  initFunctions();
+}
+
+//______________________________________________________________________________
+FragmentParam::FragmentParam(std::array<double, NCOEFFS> const& fn, std::array<double, NCOEFFS> const& fp,
+                             std::array<double, NCOEFFS> const& sigman, std::array<double, NCOEFFS> const& sigmap)
+{
+  setParamsfn(fn);
+  setParamsfp(fp);
+  setParamssigman(sigman);
+  setParamssigmap(sigmap);
+  initFunctions();
+}
+
+void FragmentParam::initFunctions()
+{
+  // lambda helper
+  auto makeFct = [](auto name, auto params, double limit) {
+    const char* polynomstr = "[0]+[1]*x+[2]*x*x+[3]*x*x*x+[4]*x*x*x*x";
+    auto f = new TF1(name, polynomstr, 0., limit);
+    for (int j = 0; j < NCOEFFS; ++j) {
+      f->SetParameter(j, params[j]);
+    }
+    return f;
+  };
+
+  // the proton function
+  mFNeutrons.reset(makeFct("fneutrons", mParamfn, 126));
+
+  // the proton function
+  mFProtons.reset(makeFct("fprotons", mParamfp, 82));
+
+  // the neutron sigma function
+  mFSigmaNeutrons.reset(makeFct("fsigman", mParamsigman, 126));
+
+  // the proton sigma function
+  mFSigmaProtons.reset(makeFct("fsigmap", mParamsigmap, 82));
+}
+
+//______________________________________________________________________________
+void FragmentParam::print() const
+{
+  printf(" Parameters fn: %1.6f %1.6f %1.6f %1.6f %1.6f \n", mParamfn[0], mParamfn[1], mParamfn[2], mParamfn[3], mParamfn[4]);
+  printf(" Parameters fp: %1.6f %1.6f %1.6f %1.6f %1.6f \n", mParamfp[0], mParamfp[1], mParamfp[2], mParamfp[3], mParamfp[4]);
+  printf(" Parameters sigman: %1.6f %1.6f %1.6f %1.6f %1.6f \n", mParamsigman[0], mParamsigman[1], mParamsigman[2], mParamsigman[3], mParamsigman[4]);
+  printf(" Parameters sigmap: %1.6f %1.6f %1.6f %1.6f %1.6f \n", mParamsigmap[0], mParamsigmap[1], mParamsigmap[2], mParamsigmap[3], mParamsigmap[4]);
+}
+
+//______________________________________________________________________________
+void FragmentParam::setParamsfn(std::array<double, NCOEFFS> const& arrvalues)
+{
+  mParamfn = arrvalues;
+}
+
+//______________________________________________________________________________
+void FragmentParam::setParamsfp(std::array<double, NCOEFFS> const& arrvalues)
+{
+  mParamfp = arrvalues;
+}
+
+//______________________________________________________________________________
+void FragmentParam::setParamssigman(std::array<double, NCOEFFS> const& arrvalues)
+{
+  mParamsigman = arrvalues;
+}
+
+//______________________________________________________________________________
+void FragmentParam::setParamssigmap(std::array<double, NCOEFFS> const& arrvalues)
+{
+  mParamsigmap = arrvalues;
+}

--- a/Detectors/ZDC/base/src/ZDCBaseLinkDef.h
+++ b/Detectors/ZDC/base/src/ZDCBaseLinkDef.h
@@ -20,6 +20,7 @@
 #pragma link C++ class o2::zdc::Module + ;
 #pragma link C++ class o2::zdc::ModuleConfig + ;
 #pragma link C++ class o2::zdc::TriggerChannelConfig + ;
+#pragma link C++ class o2::zdc::FragmentParam + ;
 #pragma link C++ function o2::zdc::removeNamespace + ;
 #pragma link C++ function o2::zdc::endsWith + ;
 #pragma link C++ function o2::zdc::ccdbShortcuts + ;

--- a/Generators/CMakeLists.txt
+++ b/Generators/CMakeLists.txt
@@ -23,8 +23,8 @@ endif()
 
 o2_add_library(Generators
                SOURCES src/Generator.cxx
-	       	       src/Trigger.cxx
-	       	       src/TriggerParticle.cxx
+                       src/Trigger.cxx
+                       src/TriggerParticle.cxx
                        src/GeneratorTGenerator.cxx
                        src/GeneratorExternalParam.cxx
                        src/GeneratorFromFile.cxx
@@ -33,7 +33,7 @@ o2_add_library(Generators
                        src/TriggerExternalParam.cxx
                        src/TriggerParticleParam.cxx
                        src/BoxGunParam.cxx
-		       src/QEDGenParam.cxx
+                       src/QEDGenParam.cxx
                        src/GenCosmicsParam.cxx
                        src/GeneratorFactory.cxx
                        src/GeneratorGeantinos.cxx
@@ -45,7 +45,7 @@ o2_add_library(Generators
                        $<$<BOOL:${pythia_FOUND}>:src/DecayerPythia8Param.cxx>
                        $<$<BOOL:${HepMC3_FOUND}>:src/GeneratorHepMC.cxx>
                        $<$<BOOL:${HepMC3_FOUND}>:src/GeneratorHepMCParam.cxx>
-               PUBLIC_LINK_LIBRARIES FairRoot::Base O2::SimConfig O2::CommonUtils O2::DetectorsBase
+               PUBLIC_LINK_LIBRARIES FairRoot::Base O2::SimConfig O2::CommonUtils O2::DetectorsBase O2::ZDCBase
                                      O2::SimulationDataFormat ${pythia6Target} ${pythiaTarget} ${hepmcTarget}
                                      FairRoot::Gen
                TARGETVARNAME targetName)

--- a/Generators/include/Generators/GeneratorPythia8.h
+++ b/Generators/include/Generators/GeneratorPythia8.h
@@ -77,6 +77,10 @@ class GeneratorPythia8 : public Generator
   {
     getNremn(mPythia.event, nProtonProj, nNeutronProj, nProtonTarg, nNeutronTarg);
   };
+  void getNfreeSpec(int& nFreenProj, int& nFreepProj, int& nFreenTarg, int& nFreepTarg)
+  {
+    getNfreeSpec(mPythia.info, nFreenProj, nFreepProj, nFreenTarg, nFreepTarg);
+  };
 
  protected:
   /** copy constructor **/
@@ -96,6 +100,7 @@ class GeneratorPythia8 : public Generator
   void getNpart(const Pythia8::Info& info, int& nPart);
   void getNpart(const Pythia8::Info& info, int& nProtonProj, int& nNeutronProj, int& nProtonTarg, int& nNeutronTarg);
   void getNremn(const Pythia8::Event& event, int& nProtonProj, int& nNeutronProj, int& nProtonTarg, int& nNeutronTarg);
+  void getNfreeSpec(const Pythia8::Info& info, int& nFreenProj, int& nFreepProj, int& nFreenTarg, int& nFreepTarg);
 
   /** Pythia8 **/
   Pythia8::Pythia mPythia; //!


### PR DESCRIPTION
* A new class encapsulation a parametrized model to calculate free spectators given an impact parameter

* Use of class in Pythia8HI generator. Free spectators are put as part of the MCHeader information.

This is a first step towards having fast parametrized digitization for ZDC such as we already did in AliRoot/Run2.

Co-author: chiara.oppedisano@to.infn.it