### PR TITLE
[EMCAL-645] Add Cell MC Label information and handling

### DIFF
--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/EventData.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/EventData.h
@@ -12,9 +12,11 @@
 #define ALICEO2_EMCAL_EVENTDATA_H_
 #include <cstdint>
 #include <gsl/span>
+#include <vector>
 #include "CommonDataFormat/InteractionRecord.h"
 #include "DataFormatsEMCAL/Cell.h"
 #include "DataFormatsEMCAL/Cluster.h"
+#include "DataFormatsEMCAL/MCLabel.h"
 
 namespace o2
 {
@@ -34,11 +36,12 @@ namespace emcal
 /// objects are not filled when creating the event structure.
 template <class InputType>
 struct EventData {
-  InteractionRecord mInteractionRecord; ///< Interaction record for the trigger corresponding to this event
-  gsl::span<const Cluster> mClusters;   ///< EMCAL clusters
-  gsl::span<const InputType> mCells;    ///< EMCAL cells / digits
-  gsl::span<const int> mCellIndices;    ///< Cell indices in cluster
-  uint64_t mTriggerBits;                ///< Trigger bits for the event
+  InteractionRecord mInteractionRecord;                           ///< Interaction record for the trigger corresponding to this event
+  gsl::span<const Cluster> mClusters;                             ///< EMCAL clusters
+  gsl::span<const InputType> mCells;                              ///< EMCAL cells / digits
+  gsl::span<const int> mCellIndices;                              ///< Cell indices in cluster
+  std::vector<gsl::span<const o2::emcal::MCLabel>> mMCCellLabels; ///< span of MC labels for each cell
+  uint64_t mTriggerBits;                                          ///< Trigger bits for the event
 
   /// \brief Reset event structure with empty interaction record and ranges
   void reset()
@@ -47,6 +50,7 @@ struct EventData {
     mClusters = gsl::span<const Cluster>();
     mCells = gsl::span<const InputType>();
     mCellIndices = gsl::span<const int>();
+    mMCCellLabels = std::vector<gsl::span<const o2::emcal::MCLabel>>();
     mTriggerBits = 0;
   }
 

--- a/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/EventHandler.h
+++ b/DataFormats/Detectors/EMCAL/include/DataFormatsEMCAL/EventHandler.h
@@ -15,13 +15,16 @@
 #include <exception>
 #include <iterator>
 #include <gsl/span>
+#include <vector>
 #include "Rtypes.h"
 #include "fmt/format.h"
 #include "DataFormatsEMCAL/Cell.h"
 #include "DataFormatsEMCAL/Cluster.h"
 #include "DataFormatsEMCAL/Digit.h"
 #include "DataFormatsEMCAL/EventData.h"
+#include "DataFormatsEMCAL/MCLabel.h"
 #include "DataFormatsEMCAL/TriggerRecord.h"
+#include "SimulationDataFormat/MCTruthContainer.h"
 
 namespace o2
 {
@@ -363,6 +366,13 @@ class EventHandler
   /// \throw NotInitializedException in case the event handler is not initialized for cell
   const CellRange getCellsForEvent(int eventID) const;
 
+  /// \brief Get vector of MC labels belonging to the given event
+  /// \param eventID ID of the event
+  /// \return vector of MC labels for the event
+  /// \throw RangeException in case the required event ID exceeds the maximum number of events
+  /// \throw NotInitializedException in case the event handler is not initialized for cell
+  std::vector<gsl::span<const o2::emcal::MCLabel>> getCellMCLabelForEvent(int eventID) const;
+
   /// \brief Get range of cluster cell indices belonging to the given event
   /// \param eventID ID of the event
   /// \return Cluster cell index range for the event
@@ -404,6 +414,13 @@ class EventHandler
     mTriggerRecordsCells = triggers;
   }
 
+  /// \brief Setting the pointer for the MCTruthContainer for cells
+  /// \param mclabels Pointer to the MCTruthContainer for cells in timeframe
+  void setCellMCTruthContainer(const o2::dataformats::MCTruthContainer<o2::emcal::MCLabel>* mclabels)
+  {
+    mCellLabels = mclabels;
+  }
+
   /// \brief Reset containers with empty ranges
   void reset();
 
@@ -433,9 +450,10 @@ class EventHandler
   TriggerRange mTriggerRecordsCellIndices; ///< trigger record for cluster cell index type
   TriggerRange mTriggerRecordsCells;       ///< Trigger record for cell type
 
-  ClusterRange mClusters;             /// container for clusters in timeframe
-  CellIndexRange mClusterCellIndices; /// container for cell indices in timeframe
-  CellRange mCells;                   /// container for cells in timeframe
+  ClusterRange mClusters;                                                             /// container for clusters in timeframe
+  CellIndexRange mClusterCellIndices;                                                 /// container for cell indices in timeframe
+  CellRange mCells;                                                                   /// container for cells in timeframe
+  const o2::dataformats::MCTruthContainer<o2::emcal::MCLabel>* mCellLabels = nullptr; /// pointer to the MCTruthContainer for cells in timeframe
 
   ClassDefNV(EventHandler, 1);
 };

--- a/DataFormats/Detectors/EMCAL/src/EventHandler.cxx
+++ b/DataFormats/Detectors/EMCAL/src/EventHandler.cxx
@@ -139,6 +139,23 @@ const typename EventHandler<CellInputType>::CellRange EventHandler<CellInputType
 }
 
 template <class CellInputType>
+std::vector<gsl::span<const o2::emcal::MCLabel>> EventHandler<CellInputType>::getCellMCLabelForEvent(int eventID) const
+{
+  if (mCellLabels && mTriggerRecordsCells.size()) {
+    if (eventID >= mTriggerRecordsCells.size()) {
+      throw RangeException(eventID, mTriggerRecordsCells.size());
+    }
+    auto& trgrecord = mTriggerRecordsCells[eventID];
+    std::vector<gsl::span<const o2::emcal::MCLabel>> eventlabels(trgrecord.getNumberOfObjects());
+    for (int index = 0; index < trgrecord.getNumberOfObjects(); index++) {
+      eventlabels[index] = mCellLabels->getLabels(trgrecord.getFirstEntry() + index);
+    }
+    return eventlabels;
+  }
+  throw NotInitializedException();
+}
+
+template <class CellInputType>
 const typename EventHandler<CellInputType>::CellIndexRange EventHandler<CellInputType>::getClusterCellIndicesForEvent(int eventID) const
 {
   if (mTriggerRecordsCellIndices.size()) {
@@ -160,6 +177,7 @@ void EventHandler<CellInputType>::reset()
   mClusters = ClusterRange();
   mClusterCellIndices = CellIndexRange();
   mCells = CellRange();
+  mCellLabels = nullptr;
 }
 
 template <class CellInputType>
@@ -176,6 +194,9 @@ EventData<CellInputType> EventHandler<CellInputType>::buildEvent(int eventID) co
   }
   if (hasCells()) {
     outputEvent.mCells = getCellsForEvent(eventID);
+  }
+  if (mCellLabels) {
+    outputEvent.mMCCellLabels = getCellMCLabelForEvent(eventID);
   }
 
   return outputEvent;


### PR DESCRIPTION
- mCellLabels as private member to store the MCTruthContainer for cells
- setCellMCTruthContainer to set previous
- getCellMCLabelForEvent to get a vector of MC Labels for the given event