### PR TITLE
[O2-3661] Get O2 compiling on M2 Macs

### DIFF
--- a/Detectors/DCS/include/DetectorsDCS/DCSDataPointHint.h
+++ b/Detectors/DCS/include/DetectorsDCS/DCSDataPointHint.h
@@ -33,7 +33,7 @@ using HintType = std::variant<DataPointHint<double>,
                               DataPointHint<float>,
                               DataPointHint<uint32_t>,
                               DataPointHint<int32_t>,
-                              DataPointHint<char>,
+                              DataPointHint<short>,
                               DataPointHint<bool>,
                               DataPointHint<std::string>>;
 

--- a/Detectors/DCS/include/DetectorsDCS/DataPointCompositeObject.h
+++ b/Detectors/DCS/include/DetectorsDCS/DataPointCompositeObject.h
@@ -225,7 +225,7 @@ struct alignas(128) DataPointCompositeObject final {
       double double_value;
       uint32_t uint_value;
       int32_t int_value;
-      char char_value;
+      short char_value;
       bool bool_value;
     } converter;
     converter.raw_data = dpcom.data.payload_pt1;

--- a/Detectors/DCS/include/DetectorsDCS/DataPointGenerator.h
+++ b/Detectors/DCS/include/DetectorsDCS/DataPointGenerator.h
@@ -22,7 +22,7 @@ namespace o2::dcs
 * Generate random data points, uniformly distributed between two values.
 *
 * @tparam T the type of value of the data points to be generated. Only
-*  a few types are supported : double, float, uint32_t, int32_t, char, bool
+*  a few types are supported : double, float, uint32_t, int32_t, short, bool
 *
 * @param aliases the list of aliases to be generated. Those can use
 *   patterns that will be expanded, @see AliasExpander

--- a/Detectors/DCS/src/DataPointCreator.cxx
+++ b/Detectors/DCS/src/DataPointCreator.cxx
@@ -58,7 +58,7 @@ DataPointCompositeObject createDataPointCompositeObject(const std::string& alias
 }
 
 template <>
-DataPointCompositeObject createDataPointCompositeObject(const std::string& alias, char val, uint32_t seconds, uint16_t msec, uint16_t flags)
+DataPointCompositeObject createDataPointCompositeObject(const std::string& alias, short val, uint32_t seconds, uint16_t msec, uint16_t flags)
 {
   return createDPCOM(alias, reinterpret_cast<const uint64_t*>(&val), seconds, msec, flags, DeliveryType::DPVAL_CHAR);
 }

--- a/Detectors/DCS/src/DataPointGenerator.cxx
+++ b/Detectors/DCS/src/DataPointGenerator.cxx
@@ -93,7 +93,7 @@ std::vector<o2::dcs::DataPointCompositeObject>
 // - float
 // - uint32_t
 // - int32_t
-// - char
+// - short
 // - bool
 //
 // - std::string
@@ -106,7 +106,7 @@ template std::vector<o2::dcs::DataPointCompositeObject> generateRandomDataPoints
 
 template std::vector<o2::dcs::DataPointCompositeObject> generateRandomDataPoints<int32_t>(const std::vector<std::string>& aliases, int32_t minValue, int32_t maxValue, std::string);
 
-template std::vector<o2::dcs::DataPointCompositeObject> generateRandomDataPoints<char>(const std::vector<std::string>& aliases, char minValue, char maxValue, std::string);
+template std::vector<o2::dcs::DataPointCompositeObject> generateRandomDataPoints<short>(const std::vector<std::string>& aliases, short minValue, short maxValue, std::string);
 
 /** Need a specific specialization for bool as got into trouble compiling uniform_int_distribution<bool>
   * on some platform (e.g. CC7).

--- a/Detectors/DCS/src/StringUtils.cxx
+++ b/Detectors/DCS/src/StringUtils.cxx
@@ -34,8 +34,8 @@ using namespace std;
 
 random_device dev;
 default_random_engine gen(dev());
-uniform_int_distribution<char> uniform_dist(32, 126);
-geometric_distribution<char> geom_dist(0.1);
+uniform_int_distribution<short> uniform_dist(32, 126);
+geometric_distribution<short> geom_dist(0.1);
 
 constexpr char ALPHABET[39]{
   'E', 'T', 'A', 'O', 'I', '_', 'N', 'S', 'H', 'R',


### PR DESCRIPTION
This patch is unfortunately not pretty, and may not be valid since it modifies DataPointCompositeObject.h, which is copied from DCS.

The problem on M2 Macs is that we need to use LLVM 15, which has started to throw compiler errors for `std::uniform_int_distribution<char>`.

According to <https://en.cppreference.com/w/cpp/numeric/random/uniform_int_distribution>, the shortest integral type that is defined as valid for use is `short` (which is typically 16 bits, as opposed to `char`'s 8 bits).

Cc: @shahor02 @ktf @pzhristov 