### PR TITLE
[EMCAL-842, EMCAL-912] Add more calibration objects to CalibLoader, use calib loader in reco workflow

### DIFF
--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/CalibLoader.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/CalibLoader.h
@@ -21,8 +21,13 @@ namespace o2
 namespace emcal
 {
 class BadChannelMap;
+class FeeDCS;
+class EMCALChannelScaleFactors;
 class TimeCalibrationParams;
 class GainCalibrationFactors;
+class TempCalibrationParams;
+class SimParam;
+class RecoParam;
 
 /// \class CalibLoader
 /// \brief Handler for EMCAL calibration objects in DPL workflows
@@ -51,6 +56,14 @@ class CalibLoader
   /// \return Current bad channel map (nullptr if not loaded)
   BadChannelMap* getBadChannelMap() const { return mBadChannelMap; }
 
+  /// \brief Access to current BCM Scale factors
+  /// \return Current BCM scale factors (nullptr if not loaded)
+  EMCALChannelScaleFactors* getBCMScaleFactors() const { return mBCMScaleFactors; }
+
+  /// \brief Access to current FEE DCS params
+  /// \return Current FEE DCS params (nullptr if not loaded)
+  FeeDCS* getFEEDCS() const { return mFeeDCS; }
+
   /// \brief Access to current time calibration params
   /// \return Current time calibration params
   TimeCalibrationParams* getTimeCalibration() const { return mTimeCalibParams; }
@@ -59,50 +72,129 @@ class CalibLoader
   /// \return Current gain calibration factors
   GainCalibrationFactors* getGainCalibration() const { return mGainCalibParams; }
 
+  /// \brief Access to current temperature calibration params
+  /// \return Current temperature calibration factors
+  TempCalibrationParams* getTemperatureCalibration() const { return mTempCalibParams; }
+
   /// \brief Check whether the bad channel map is handled
   /// \return True if the bad channel map is handled, false otherwise
-  bool hasBadChannelMap() const { return mEnableBadChannelMap; }
+  bool hasBadChannelMap() const { return mEnableStatus.test(OBJ_BADCHANNELMAP); }
+
+  /// \brief Check whether the BCM scale factors are handled
+  /// \return True if the BCM scale factors are handled, false otherwise
+  bool hasBCMScaleFactors() const { return mEnableStatus.test(OBJ_BCMSCALEFACTORS); }
+
+  /// \brief Check whether the FEE DCS params are handled
+  /// \return True if the FEE DCS params are handled, false otherwise
+  bool hasFEEDCS() const { return mEnableStatus.test(OBJ_FEEDCS); }
 
   /// \brief Check whether the time calibration params are handled
   /// \return True if the time calibration params are handled, false otherwise
-  bool hasTimeCalib() const { return mEnableTimeCalib; }
+  bool hasTimeCalib() const { return mEnableStatus.test(OBJ_TIMECALIB); }
 
   /// \brief Check whether the gain calibration factors are handled
   /// \return True if the gain calibration factors are handled, false otherwise
-  bool hasGainCalib() const { return mEnableGainCalib; }
+  bool hasGainCalib() const { return mEnableStatus.test(OBJ_GAINCALIB); }
+
+  /// \brief Check whether the temperature calibration params are handled
+  /// \return True if the temperature calibration params are handled, false otherwise
+  bool hasTemperatureCalib() const { return mEnableStatus.test(OBJ_TEMPCALIB); }
+
+  /// \brief Check whether the reconstruction params are handled
+  /// \return True if the reconstruction params are handled, false otherwise
+  bool hasRecoParams() const { return mEnableStatus.test(OBJ_RECOPARAM); }
+
+  /// \brief Check whether the reconstruction params are handled
+  /// \return True if the reconstruction params are handled, false otherwise
+  bool hasSimParams() const { return mEnableStatus.test(OBJ_SIMPARAM); }
 
   /// \brief Check whether the bad channel map has been updated
   /// \return True if the bad channel map has been updated, false otherwise
   bool hasUpdateBadChannelMap() const { return mUpdateStatus.test(OBJ_BADCHANNELMAP); }
+
+  /// \brief Check whether the BCM scale factors have been updated
+  /// \return True if the bad channel map has been updated, false otherwise
+  bool hasUpdateBCMScaleFactors() const { return mUpdateStatus.test(OBJ_BCMSCALEFACTORS); }
+
+  /// \brief Check whether the FEE DCS params have been updated
+  /// \return True if the FEE DCS params have been updated, false otherwise
+  bool hasUpdateFEEDCS() const { return mUpdateStatus.test(OBJ_FEEDCS); }
 
   /// \brief Check whether the time calibration params have been updated
   /// \return True if the time calibration params have been updated, false otherwise
   bool hasUpdateTimeCalib() const { return mUpdateStatus.test(OBJ_TIMECALIB); }
 
   /// \brief Check whether the gain calibration params have been updated
-  /// \return True if the gain calibration params have been updated, false  otherwise
+  /// \return True if the gain calibration params have been updated, false otherwise
   bool hasUpdateGainCalib() const { return mUpdateStatus.test(OBJ_GAINCALIB); }
+
+  /// \brief Check whether the temperature calibration params have been updated
+  /// \return True if the temperature calibration params have been updated, false otherwise
+  bool hasUpdateTemperatureCalib() const { return mUpdateStatus.test(OBJ_TEMPCALIB); }
+
+  /// \brief Check whether the reconstruction params have been updated
+  /// \return True if the reconstruction params have been updated, false otherwise
+  bool hasUpdateRecoParam() const { return mUpdateStatus.test(OBJ_RECOPARAM); }
+
+  /// \brief Check whether the simulation params have been updated
+  /// \return True if the simulation params have been updated, false otherwise
+  bool hasUpdateSimParam() const { return mUpdateStatus.test(OBJ_SIMPARAM); }
 
   /// \brief Enable loading of the bad channel map
   /// \param doEnable If true the bad channel map is loaded (per default from CCDB)
-  void enableBadChannelMap(bool doEnable) { mEnableBadChannelMap = doEnable; }
+  void enableBadChannelMap(bool doEnable) { mEnableStatus.set(OBJ_BADCHANNELMAP, doEnable); }
+
+  /// \brief Enable loading of the BCM scale factors
+  /// \param doEnable If true the BCM scale factors are loaded (per default from CCDB)
+  void enableBCMScaleFactors(bool doEnable) { mEnableStatus.set(OBJ_BCMSCALEFACTORS, doEnable); }
+
+  /// \brief Enable loading of the FEE DCS params
+  /// \param doEnable If true the FEE DCS params are loaded (per default from CCDB)
+  void enableFEEDCS(bool doEnable) { mEnableStatus.set(OBJ_FEEDCS, doEnable); }
 
   /// \brief Enable loading of the time calibration params
   /// \param doEnable If true the time calibration params are loaded (per default from CCDB)
-  void enableTimeCalib(bool doEnable) { mEnableTimeCalib = doEnable; }
+  void enableTimeCalib(bool doEnable) { mEnableStatus.set(OBJ_TIMECALIB, doEnable); }
 
   /// \brief Enable loading of the gain calibration factors
   /// \param doEnable If true the gain calibration factors are loaded (per default from CCDB)
-  void enableGainCalib(bool doEnable) { mEnableGainCalib = doEnable; }
+  void enableGainCalib(bool doEnable) { mEnableStatus.set(OBJ_GAINCALIB, doEnable); }
+
+  /// \brief Enable loading of the temperature calibration params
+  /// \param doEnable If true the temperature calibration params are loaded (per default from CCDB)
+  void enableTemperatureCalib(bool doEnable) { mEnableStatus.set(OBJ_TEMPCALIB, doEnable); }
+
+  /// \brief Enable loading of the reconstruction params
+  /// \param doEnable If true the reconstruction params are loaded (per default from CCDB)
+  void enableRecoParams(bool doEnable) { mEnableStatus.set(OBJ_RECOPARAM, doEnable); }
+
+  /// \brief Enable loading of the simulation params
+  /// \param doEnable If true the simulation params are loaded (per default from CCDB)
+  void enableSimParams(bool doEnable) { mEnableStatus.set(OBJ_SIMPARAM, doEnable); }
 
   /// \brief Mark bad channel map as updated
   void setUpdateBadChannelMap() { mUpdateStatus.set(OBJ_BADCHANNELMAP, true); }
+
+  /// \brief Mark BCM scale factors as updated
+  void setUpdateBCMScaleFactors() { mUpdateStatus.set(OBJ_BCMSCALEFACTORS, true); }
+
+  /// \brief Mark FEE DCS params as updated
+  void setUpdateFEEDCS() { mUpdateStatus.set(OBJ_FEEDCS, true); }
 
   /// \brief Mark time calibration params as updated
   void setUpdateTimeCalib() { mUpdateStatus.set(OBJ_TIMECALIB, true); }
 
   /// \brief Mark gain calibration params as updated
   void setUpdateGainCalib() { mUpdateStatus.set(OBJ_GAINCALIB, true); }
+
+  /// \brief Mark temperature calibration params as updated
+  void setUpdateTemperatureCalib() { mUpdateStatus.set(OBJ_TEMPCALIB, true); }
+
+  /// \brief Mark reconstruction params as updated
+  void setUpdateRecoParams() { mUpdateStatus.set(OBJ_RECOPARAM, true); }
+
+  /// \brief Mark simulation params as updated
+  void setUpdateSimParams() { mUpdateStatus.set(OBJ_SIMPARAM, true); }
 
   /// \brief Reset the update status (all objects marked as false)
   void resetUpdateStatus() { mUpdateStatus.reset(); }
@@ -130,17 +222,27 @@ class CalibLoader
 
  private:
   enum CalibObject_t {
-    OBJ_BADCHANNELMAP,
-    OBJ_TIMECALIB,
-    OBJ_GAINCALIB
+    OBJ_BADCHANNELMAP,   ///< Bad channel map
+    OBJ_TIMECALIB,       ///< Time calibration params
+    OBJ_GAINCALIB,       ///< Energy calibration params
+    OBJ_TEMPCALIB,       ///< Temperature calibration params
+    OBJ_TIMSLEWINGCORR,  ///< Time slewing correction
+    OBJ_BCMSCALEFACTORS, ///< BCM scale factors
+    OBJ_FEEDCS,          ///< FEE DCS params
+    OBJ_SIMPARAM,        ///< Simulation params
+    OBJ_RECOPARAM,       ///< Reco params
+    OBJ_CALIBPARAM       ///< Calibration params
   };
-  bool mEnableBadChannelMap;                                     ///< Switch for enabling / disabling loading of the bad channel map
-  bool mEnableTimeCalib;                                         ///< Switch for enabling / disabling loading of the time calibration params
-  bool mEnableGainCalib;                                         ///< Switch for enabling / disabling loading of the gain calibration params
-  o2::emcal::BadChannelMap* mBadChannelMap = nullptr;            ///< Container of current bad channel map
-  o2::emcal::TimeCalibrationParams* mTimeCalibParams = nullptr;  ///< Container of current time calibration object
-  o2::emcal::GainCalibrationFactors* mGainCalibParams = nullptr; ///< Container of current gain calibration object
-  std::bitset<16> mUpdateStatus;                                 ///< Object update status
+  o2::emcal::BadChannelMap* mBadChannelMap = nullptr;              ///< Container of current bad channel map
+  o2::emcal::FeeDCS* mFeeDCS = nullptr;                            ///< Container of current FEE DCS params
+  o2::emcal::TimeCalibrationParams* mTimeCalibParams = nullptr;    ///< Container of current time calibration object
+  o2::emcal::GainCalibrationFactors* mGainCalibParams = nullptr;   ///< Container of current gain calibration object
+  o2::emcal::TempCalibrationParams* mTempCalibParams = nullptr;    ///< Container of current temperature calibration object
+  o2::emcal::EMCALChannelScaleFactors* mBCMScaleFactors = nullptr; ///< Container of current bad channel scale factors
+  o2::emcal::RecoParam* mRecoParam;                                ///< Current reconstruction parameters
+  o2::emcal::SimParam* mSimParam;                                  ///< Current simulation parameters
+  std::bitset<16> mEnableStatus;                                   ///< Object enable status
+  std::bitset<16> mUpdateStatus;                                   ///< Object update status
 };
 
 } // namespace emcal

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/RawToCellConverterSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/RawToCellConverterSpec.h
@@ -24,6 +24,7 @@
 #include "EMCALReconstruction/CaloRawFitter.h"
 #include "EMCALReconstruction/RecoContainer.h"
 #include "EMCALReconstruction/ReconstructionErrors.h"
+#include "EMCALWorkflow/CalibLoader.h"
 
 namespace o2
 {
@@ -46,7 +47,8 @@ class RawToCellConverterSpec : public framework::Task
   /// \param subspecification Output subspecification for parallel running on multiple nodes
   /// \param hasDecodingErrors Option to swich on/off creating raw decoding error objects for later monitoring
   /// \param loadRecoParamsFromCCDB Option to load the RecoParams from the CCDB
-  RawToCellConverterSpec(int subspecification, bool hasDecodingErrors) : framework::Task(), mSubspecification(subspecification), mCreateRawDataErrors(hasDecodingErrors){};
+  /// \param calibhandler Calibration object handler
+  RawToCellConverterSpec(int subspecification, bool hasDecodingErrors, std::shared_ptr<CalibLoader> calibhandler) : framework::Task(), mSubspecification(subspecification), mCreateRawDataErrors(hasDecodingErrors), mCalibHandler(calibhandler){};
 
   /// \brief Destructor
   ~RawToCellConverterSpec() override;
@@ -169,6 +171,9 @@ class RawToCellConverterSpec : public framework::Task
   /// and a message in FLP/DISTSUBTIMEFRAME
   bool isLostTimeframe(framework::ProcessingContext& ctx) const;
 
+  /// \brief Update calibration objects
+  void updateCalibrationObjects();
+
   /// \brief Select cells and put them on the output container
   /// \param cells Cells to select
   /// \param isLEDMON Distinction whether input is cell or LEDMON
@@ -223,6 +228,7 @@ class RawToCellConverterSpec : public framework::Task
   std::chrono::time_point<std::chrono::system_clock> mReferenceTime; ///< Reference time for muting messages
   Geometry* mGeometry = nullptr;                                     ///!<! Geometry pointer
   RecoContainer mCellHandler;                                        ///< Manager for reconstructed cells
+  std::shared_ptr<CalibLoader> mCalibHandler;                        ///< Handler for calibration objects
   std::unique_ptr<MappingHandler> mMapper = nullptr;                 ///!<! Mapper
   std::unique_ptr<CaloRawFitter> mRawFitter;                         ///!<! Raw fitter
   std::vector<Cell> mOutputCells;                                    ///< Container with output cells

--- a/Detectors/EMCAL/workflow/src/CalibLoader.cxx
+++ b/Detectors/EMCAL/workflow/src/CalibLoader.cxx
@@ -13,8 +13,13 @@
 #include <fairlogger/Logger.h>
 #include "EMCALCalib/CalibDB.h"
 #include "EMCALCalib/BadChannelMap.h"
+#include "EMCALCalib/FeeDCS.h"
+#include "EMCALCalib/EMCALChannelScaleFactors.h"
+#include "EMCALCalib/TempCalibrationParams.h"
 #include "EMCALCalib/TimeCalibrationParams.h"
 #include "EMCALCalib/GainCalibrationFactors.h"
+#include "EMCALReconstruction/RecoParam.h"
+#include "EMCALSimulation/SimParam.h"
 #include "EMCALWorkflow/CalibLoader.h"
 #include "Framework/CCDBParamSpec.h"
 #include "Framework/InputRecord.h"
@@ -27,11 +32,26 @@ void CalibLoader::defineInputSpecs(std::vector<o2::framework::InputSpec>& inputs
   if (hasBadChannelMap()) {
     inputs.push_back({"badChannelMap", o2::header::gDataOriginEMC, "BADCHANNELMAP", 0, o2::framework::Lifetime::Condition, o2::framework::ccdbParamSpec(CalibDB::getCDBPathBadChannelMap())});
   }
+  if (hasBCMScaleFactors()) {
+    inputs.push_back({"bcmScaleFactors", o2::header::gDataOriginEMC, "BCMSCALEFACTORS", 0, o2::framework::Lifetime::Condition, o2::framework::ccdbParamSpec(CalibDB::getCDBPathChannelScaleFactors())});
+  }
+  if (hasFEEDCS()) {
+    inputs.push_back({"feeDCS", o2::header::gDataOriginEMC, "FEEDCS", 0, o2::framework::Lifetime::Condition, o2::framework::ccdbParamSpec(CalibDB::getCDBPathFeeDCS())});
+  }
   if (hasTimeCalib()) {
     inputs.push_back({"timeCalibParams", o2::header::gDataOriginEMC, "TIMECALIBPARAMS", 0, o2::framework::Lifetime::Condition, o2::framework::ccdbParamSpec(CalibDB::getCDBPathTimeCalibrationParams())});
   }
   if (hasGainCalib()) {
     inputs.push_back({"gainCalibParams", o2::header::gDataOriginEMC, "GAINCALIBPARAMS", 0, o2::framework::Lifetime::Condition, o2::framework::ccdbParamSpec(CalibDB::getCDBPathGainCalibrationParams())});
+  }
+  if (hasTemperatureCalib()) {
+    inputs.push_back({"tempCalibParams", o2::header::gDataOriginEMC, "TEMPCALIBPARAMS", 0, o2::framework::Lifetime::Condition, o2::framework::ccdbParamSpec(CalibDB::getCDBPathTemperatureCalibrationParams())});
+  }
+  if (hasRecoParams()) {
+    inputs.push_back({"recoParams", o2::header::gDataOriginEMC, "RECOPARAM", 0, o2::framework::Lifetime::Condition, o2::framework::ccdbParamSpec("EMC/Config/RecoParam")});
+  }
+  if (hasSimParams()) {
+    inputs.push_back({"simParams", o2::header::gDataOriginEMC, "SIMPARAM", 0, o2::framework::Lifetime::Condition, o2::framework::ccdbParamSpec("EMC/Config/SimParam")});
   }
 }
 
@@ -41,11 +61,26 @@ void CalibLoader::checkUpdates(o2::framework::ProcessingContext& ctx)
   if (hasBadChannelMap()) {
     ctx.inputs().get<o2::emcal::BadChannelMap*>("badChannelMap");
   }
+  if (hasBCMScaleFactors()) {
+    ctx.inputs().get<o2::emcal::EMCALChannelScaleFactors*>("bcmScaleFactors");
+  }
+  if (hasFEEDCS()) {
+    ctx.inputs().get<o2::emcal::FeeDCS*>("feeDCS");
+  }
   if (hasTimeCalib()) {
     ctx.inputs().get<o2::emcal::TimeCalibrationParams*>("timeCalibParams");
   }
   if (hasGainCalib()) {
     ctx.inputs().get<o2::emcal::GainCalibrationFactors*>("gainCalibParams");
+  }
+  if (hasTemperatureCalib()) {
+    ctx.inputs().get<o2::emcal::TempCalibrationParams*>("tempCalibParams");
+  }
+  if (hasRecoParams()) {
+    ctx.inputs().get<o2::emcal::RecoParam*>("recoParams");
+  }
+  if (hasSimParams()) {
+    ctx.inputs().get<o2::emcal::SimParam*>("simParams");
   }
 }
 
@@ -58,6 +93,26 @@ bool CalibLoader::finalizeCCDB(o2::framework::ConcreteDataMatcher& matcher, void
       setUpdateBadChannelMap();
     } else {
       LOG(error) << "New bad channel map available even though bad channel calibration was not enabled, not loading";
+    }
+    return true;
+  }
+  if (matcher == o2::framework::ConcreteDataMatcher("EMC", "BCMSCALEFACTORS", 0)) {
+    if (hasBCMScaleFactors()) {
+      LOG(info) << "New BCM scale factors loaded";
+      mBCMScaleFactors = reinterpret_cast<o2::emcal::EMCALChannelScaleFactors*>(obj);
+      setUpdateBCMScaleFactors();
+    } else {
+      LOG(error) << "New BCSM scale factors available even though not enabled, not loading";
+    }
+    return true;
+  }
+  if (matcher == o2::framework::ConcreteDataMatcher("EMC", "FEEDCS", 0)) {
+    if (hasFEEDCS()) {
+      LOG(info) << "New FEE DCS params loaded";
+      mFeeDCS = reinterpret_cast<o2::emcal::FeeDCS*>(obj);
+      setUpdateFEEDCS();
+    } else {
+      LOG(error) << "New FEE DCS params available even though FEE DCS was not enabled, not loading";
     }
     return true;
   }
@@ -78,6 +133,36 @@ bool CalibLoader::finalizeCCDB(o2::framework::ConcreteDataMatcher& matcher, void
       setUpdateGainCalib();
     } else {
       LOG(error) << "New gain calibration paramset available even though the gain calibration was not enabled, not loading";
+    }
+    return true;
+  }
+  if (matcher == o2::framework::ConcreteDataMatcher("EMC", "TEMPCALIBPARAMS", 0)) {
+    if (hasTemperatureCalib()) {
+      LOG(info) << "New temperature calibration paramset loaded";
+      mTempCalibParams = reinterpret_cast<o2::emcal::TempCalibrationParams*>(obj);
+      setUpdateTemperatureCalib();
+    } else {
+      LOG(error) << "New temperature calibration paramset available even though the temperature calibration was not enabled, not loading";
+    }
+    return true;
+  }
+  if (matcher == o2::framework::ConcreteDataMatcher("EMC", "RECOPARAM", 0)) {
+    if (hasRecoParams()) {
+      LOG(info) << "New reconstruction parameters loaded";
+      mRecoParam = reinterpret_cast<o2::emcal::RecoParam*>(obj);
+      setUpdateRecoParams();
+    } else {
+      LOG(error) << "New reconstruction parameters available even though reconstruction parameters were not requested, not loading";
+    }
+    return true;
+  }
+  if (matcher == o2::framework::ConcreteDataMatcher("EMC", "SIMPARAM", 0)) {
+    if (hasSimParams()) {
+      LOG(info) << "New simulation parameters loaded";
+      mSimParam = reinterpret_cast<o2::emcal::SimParam*>(obj);
+      setUpdateSimParams();
+    } else {
+      LOG(error) << "New simulation parameters available even though simulation parameters were not requested, not loading";
     }
     return true;
   }


### PR DESCRIPTION
Added support for calibration objects:
- Temperature calibration
- Time slewing correction (not yet implemented)
- FEE DCS parameters
- BCM scale factors
Added support for CCDB-based configurable params:
- Calibration params (not yet implemented)
- Reconstruction params
- Simulation params

Use CalibLoader in reco workflow for CCDB access of
- RecoParams

Access in the reco workflow is prepared for
- FeeDCS