### PR TITLE
[EMCAL-889] Add filling of McCaloLabels in AODProducerWorkflowSpec

### DIFF
--- a/DataFormats/Detectors/PHOS/include/DataFormatsPHOS/EventData.h
+++ b/DataFormats/Detectors/PHOS/include/DataFormatsPHOS/EventData.h
@@ -13,10 +13,11 @@
 #define ALICEO2_PHOS_EVENTDATA_H_
 
 #include <gsl/span>
+#include <vector>
 #include "CommonDataFormat/InteractionRecord.h"
 #include "DataFormatsPHOS/Cell.h"
 #include "DataFormatsPHOS/Cluster.h"
-
+#include "DataFormatsPHOS/MCLabel.h"
 namespace o2
 {
 
@@ -25,10 +26,11 @@ namespace phos
 
 template <class InputType>
 struct EventData {
-  InteractionRecord mInteractionRecord; ///< Interaction record for the trigger corresponding to this event
-  gsl::span<const Cluster> mClusters;   ///< PHOS clusters
-  gsl::span<const InputType> mCells;    ///< PHOS cells / digits
-  gsl::span<const int> mCellIndices;    ///< Cell indices in cluster
+  InteractionRecord mInteractionRecord;                          ///< Interaction record for the trigger corresponding to this event
+  gsl::span<const Cluster> mClusters;                            ///< PHOS clusters
+  gsl::span<const InputType> mCells;                             ///< PHOS cells / digits
+  gsl::span<const int> mCellIndices;                             ///< Cell indices in cluster
+  std::vector<gsl::span<const o2::phos::MCLabel>> mMCCellLabels; ///< span of MC labels for each cell
 
   /// \brief Reset event structure with empty interaction record and ranges
   void reset()
@@ -37,9 +39,10 @@ struct EventData {
     mClusters = gsl::span<const Cluster>();
     mCells = gsl::span<const InputType>();
     mCellIndices = gsl::span<const int>();
+    mMCCellLabels = std::vector<gsl::span<const o2::phos::MCLabel>>();
   }
 
-  ClassDefNV(EventData, 1);
+  ClassDefNV(EventData, 2);
 };
 
 } // namespace phos

--- a/DataFormats/Detectors/PHOS/include/DataFormatsPHOS/EventHandler.h
+++ b/DataFormats/Detectors/PHOS/include/DataFormatsPHOS/EventHandler.h
@@ -15,13 +15,16 @@
 #include <exception>
 #include <iterator>
 #include <gsl/span>
+#include <vector>
 #include "Rtypes.h"
 #include "fmt/format.h"
 #include "DataFormatsPHOS/Cell.h"
 #include "DataFormatsPHOS/Cluster.h"
 #include "DataFormatsPHOS/Digit.h"
 #include "DataFormatsPHOS/EventData.h"
+#include "DataFormatsPHOS/MCLabel.h"
 #include "DataFormatsPHOS/TriggerRecord.h"
+#include "SimulationDataFormat/MCTruthContainer.h"
 
 namespace o2
 {
@@ -259,6 +262,13 @@ class EventHandler
   /// \throw NotInitializedException in case the event handler is not initialized for cell
   const CellRange getCellsForEvent(int eventID) const;
 
+  /// \brief Get vector of MC labels belonging to the given event
+  /// \param eventID ID of the event
+  /// \return vector of MC labels for the event
+  /// \throw RangeException in case the required event ID exceeds the maximum number of events
+  /// \throw NotInitializedException in case the event handler is not initialized for cell
+  std::vector<gsl::span<const o2::phos::MCLabel>> getCellMCLabelForEvent(int eventID) const;
+
   /// \brief Get range of cluster cell indices belonging to the given event
   /// \param eventID ID of the event
   /// \return Cluster cell index range for the event
@@ -300,6 +310,13 @@ class EventHandler
     mTriggerRecordsCells = triggers;
   }
 
+  /// \brief Setting the pointer for the MCTruthContainer for cells
+  /// \param mclabels Pointer to the MCTruthContainer for cells in timeframe
+  void setCellMCTruthContainer(const o2::dataformats::MCTruthContainer<o2::phos::MCLabel>* mclabels)
+  {
+    mCellLabels = mclabels;
+  }
+
   /// \brief Reset containers with empty ranges
   void reset();
 
@@ -329,11 +346,12 @@ class EventHandler
   TriggerRange mTriggerRecordsCellIndices; ///< trigger record for cluster cell index type
   TriggerRange mTriggerRecordsCells;       ///< Trigger record for cell type
 
-  ClusterRange mClusters;             /// container for clusters in timeframe
-  CellIndexRange mClusterCellIndices; /// container for cell indices in timeframe
-  CellRange mCells;                   /// container for cells in timeframe
+  ClusterRange mClusters;                                                            /// container for clusters in timeframe
+  CellIndexRange mClusterCellIndices;                                                /// container for cell indices in timeframe
+  CellRange mCells;                                                                  /// container for cells in timeframe
+  const o2::dataformats::MCTruthContainer<o2::phos::MCLabel>* mCellLabels = nullptr; /// pointer to the MCTruthContainer for cells in timeframe
 
-  ClassDefNV(EventHandler, 1);
+  ClassDefNV(EventHandler, 2);
 };
 
 } // namespace phos

--- a/DataFormats/Detectors/PHOS/include/DataFormatsPHOS/MCLabel.h
+++ b/DataFormats/Detectors/PHOS/include/DataFormatsPHOS/MCLabel.h
@@ -23,7 +23,7 @@ namespace phos
 class MCLabel : public o2::MCCompLabel
 {
  private:
-  float mEdep = 0; //deposited energy
+  float mEdep = 0; // deposited energy
 
  public:
   MCLabel() = default;
@@ -44,7 +44,9 @@ class MCLabel : public o2::MCCompLabel
 
   float getEdep() const { return mEdep; }
 
-  ClassDefNV(MCLabel, 1);
+  double getAmplitudeFraction() const { return mEdep; }
+
+  ClassDefNV(MCLabel, 2);
 };
 } // namespace phos
 } // namespace o2

--- a/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
+++ b/Detectors/AOD/include/AODProducerWorkflow/AODProducerWorkflowSpec.h
@@ -246,6 +246,7 @@ class AODProducerWorkflowDPL : public Task
   TString mAnchorProd{""};
   TString mRecoPass{""};
   TStopwatch mTimer;
+  bool mEMCselectLeading{false};
 
   // unordered map connects global indices and table indices of barrel tracks
   std::unordered_map<GIndex, int> mGIDToTableID;
@@ -521,13 +522,13 @@ class AODProducerWorkflowDPL : public Task
   // helper for trd pattern
   uint8_t getTRDPattern(const o2::trd::TrackTRD& track);
 
-  template <typename TCaloHandler, typename TCaloCursor, typename TCaloTRGCursor>
+  template <typename TCaloHandler, typename TCaloCursor, typename TCaloTRGCursor, typename TMCCaloLabelCursor>
   void addToCaloTable(const TCaloHandler& caloHandler, const TCaloCursor& caloCellCursor, const TCaloTRGCursor& caloTRGCursor,
-                      int eventID, int bcID, int8_t caloType);
+                      const TMCCaloLabelCursor& mcCaloCellLabelCursor, int eventID, int bcID, int8_t caloType);
 
-  template <typename TCaloCursor, typename TCaloTRGCursor>
+  template <typename TCaloCursor, typename TCaloTRGCursor, typename TMCCaloLabelCursor>
   void fillCaloTable(const TCaloCursor& caloCellCursor, const TCaloTRGCursor& caloTRGCursor,
-                     const std::map<uint64_t, int>& bcsMap,
+                     const TMCCaloLabelCursor& mcCaloCellLabelCursor, const std::map<uint64_t, int>& bcsMap,
                      const o2::globaltracking::RecoContainer& data);
 };
 

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/CellConverterSpec.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/CellConverterSpec.h
@@ -47,8 +47,9 @@ class CellConverterSpec : public framework::Task
   /// \brief Constructor
   /// \param propagateMC If true the MCTruthContainer is propagated to the output
   /// \param useccdb If true the TecoParams
+  /// \param inputSubsepc Subsepc of input objects
   /// \param outputSubspec Subspec of output objects
-  CellConverterSpec(bool propagateMC, bool useccdb, int outputSubspec) : framework::Task(), mPropagateMC(propagateMC), mLoadRecoParamFromCCDB(useccdb), mSubspecification(outputSubspec){};
+  CellConverterSpec(bool propagateMC, bool useccdb, int inputSubsepc, int outputSubspec) : framework::Task(), mPropagateMC(propagateMC), mLoadRecoParamFromCCDB(useccdb), mSubspecificationIn(inputSubsepc), mSubspecificationOut(outputSubspec){};
 
   /// \brief Destructor
   ~CellConverterSpec() override = default;
@@ -89,7 +90,8 @@ class CellConverterSpec : public framework::Task
  private:
   bool mPropagateMC = false;                                           ///< Switch whether to process MC true labels
   bool mLoadRecoParamFromCCDB = false;                                 ///< Flag to load the the SimParams from CCDB
-  bool mSubspecification = 0;                                          ///< Output subspecification
+  unsigned int mSubspecificationIn = 0;                                ///< Input subspecification
+  unsigned int mSubspecificationOut = 0;                               ///< Output subspecification
   o2::emcal::Geometry* mGeometry = nullptr;                            ///!<! Geometry pointer
   std::unique_ptr<o2::emcal::CaloRawFitter> mRawFitter;                ///!<! Raw fitter
   std::vector<o2::emcal::Cell> mOutputCells;                           ///< Container with output cells
@@ -101,10 +103,11 @@ class CellConverterSpec : public framework::Task
 /// \ingroup EMCALworkflow
 /// \param propagateMC If true the MC truth container is propagated to the output
 /// \param useccdb If true the RecoParams are loaded from the CCDB
+/// \param inputSubsepc Subspec of input objects
 /// \param outputSubspec Subspec of output objects
 ///
 /// Refer to CellConverterSpec::run for input and output specs
-framework::DataProcessorSpec getCellConverterSpec(bool propagateMC, bool useccdb = false, int outputSubspec = 0);
+framework::DataProcessorSpec getCellConverterSpec(bool propagateMC, bool useccdb = false, int inputSubsepc = 0, int outputSubspec = 0);
 
 } // namespace reco_workflow
 

--- a/Detectors/EMCAL/workflow/include/EMCALWorkflow/RecoWorkflow.h
+++ b/Detectors/EMCAL/workflow/include/EMCALWorkflow/RecoWorkflow.h
@@ -48,7 +48,8 @@ enum struct OutputType { Digits,          ///< EMCAL digits
 /// \param propagateMC If true MC labels are propagated to the output files
 /// \param askDISTSTF If true the Raw->Cell converter subscribes to FLP/DISTSUBTIMEFRAME
 /// \param enableDigitsPrinter If true then the simple digits printer is added as dummy task
-/// \param subspecification Subspecification in case of running on different FLPs
+/// \param subspecificationIn Subspecification of input in case of running on different FLPs
+/// \param subspecificationOut Subspecification if output in case of running on different FLPs
 /// \param cfgInput Input objects processed in the workflow
 /// \param cfgOutput Output objects created in the workflow
 /// \param loadRecoParamsFromCCDB Load the reco params from the CCDB
@@ -57,7 +58,8 @@ enum struct OutputType { Digits,          ///< EMCAL digits
 framework::WorkflowSpec getWorkflow(bool propagateMC = true,
                                     bool askDISTSTF = true,
                                     bool enableDigitsPrinter = false,
-                                    int subspecification = 0,
+                                    int subspecificationIn = 0,
+                                    int subspecificationOut = 0,
                                     std::string const& cfgInput = "digits",
                                     std::string const& cfgOutput = "clusters",
                                     bool disableRootInput = false,

--- a/Detectors/EMCAL/workflow/src/CellConverterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/CellConverterSpec.cxx
@@ -163,10 +163,10 @@ void CellConverterSpec::run(framework::ProcessingContext& ctx)
     ncellsTrigger = 0;
   }
   LOG(debug) << "[EMCALCellConverter - run] Writing " << mOutputCells.size() << " cells ...";
-  ctx.outputs().snapshot(o2::framework::Output{"EMC", "CELLS", mSubspecification, o2::framework::Lifetime::Timeframe}, mOutputCells);
-  ctx.outputs().snapshot(o2::framework::Output{"EMC", "CELLSTRGR", mSubspecification, o2::framework::Lifetime::Timeframe}, mOutputTriggers);
+  ctx.outputs().snapshot(o2::framework::Output{"EMC", "CELLS", mSubspecificationOut, o2::framework::Lifetime::Timeframe}, mOutputCells);
+  ctx.outputs().snapshot(o2::framework::Output{"EMC", "CELLSTRGR", mSubspecificationOut, o2::framework::Lifetime::Timeframe}, mOutputTriggers);
   if (mPropagateMC) {
-    ctx.outputs().snapshot(o2::framework::Output{"EMC", "CELLSMCTR", mSubspecification, o2::framework::Lifetime::Timeframe}, mOutputLabels);
+    ctx.outputs().snapshot(o2::framework::Output{"EMC", "CELLSMCTR", mSubspecificationOut, o2::framework::Lifetime::Timeframe}, mOutputLabels);
   }
 }
 
@@ -449,25 +449,25 @@ void CellConverterSpec::finaliseCCDB(o2::framework::ConcreteDataMatcher& matcher
   }
 }
 
-o2::framework::DataProcessorSpec o2::emcal::reco_workflow::getCellConverterSpec(bool propagateMC, bool useccdb, int outputSubspec)
+o2::framework::DataProcessorSpec o2::emcal::reco_workflow::getCellConverterSpec(bool propagateMC, bool useccdb, int inputSubspec, int outputSubspec)
 {
   std::vector<o2::framework::InputSpec> inputs;
   std::vector<o2::framework::OutputSpec> outputs;
-  inputs.emplace_back("digits", o2::header::gDataOriginEMC, "DIGITS", 0, o2::framework::Lifetime::Timeframe);
+  inputs.emplace_back("digits", o2::header::gDataOriginEMC, "DIGITS", inputSubspec, o2::framework::Lifetime::Timeframe);
   if (useccdb) {
     inputs.emplace_back("EMC_RecoParam", o2::header::gDataOriginEMC, "RECOPARAM", 0, o2::framework::Lifetime::Condition, o2::framework::ccdbParamSpec("EMC/Config/RecoParam"));
   }
-  inputs.emplace_back("triggers", "EMC", "DIGITSTRGR", 0, o2::framework::Lifetime::Timeframe);
-  outputs.emplace_back("EMC", "CELLS", 0, o2::framework::Lifetime::Timeframe);
-  outputs.emplace_back("EMC", "CELLSTRGR", 0, o2::framework::Lifetime::Timeframe);
+  inputs.emplace_back("triggers", "EMC", "DIGITSTRGR", inputSubspec, o2::framework::Lifetime::Timeframe);
+  outputs.emplace_back("EMC", "CELLS", outputSubspec, o2::framework::Lifetime::Timeframe);
+  outputs.emplace_back("EMC", "CELLSTRGR", outputSubspec, o2::framework::Lifetime::Timeframe);
   if (propagateMC) {
-    inputs.emplace_back("digitsmctr", "EMC", "DIGITSMCTR", outputSubspec, o2::framework::Lifetime::Timeframe);
+    inputs.emplace_back("digitsmctr", "EMC", "DIGITSMCTR", inputSubspec, o2::framework::Lifetime::Timeframe);
     outputs.emplace_back("EMC", "CELLSMCTR", outputSubspec, o2::framework::Lifetime::Timeframe);
   }
   return o2::framework::DataProcessorSpec{"EMCALCellConverterSpec",
                                           inputs,
                                           outputs,
-                                          o2::framework::adaptFromTask<o2::emcal::reco_workflow::CellConverterSpec>(propagateMC, useccdb, outputSubspec),
+                                          o2::framework::adaptFromTask<o2::emcal::reco_workflow::CellConverterSpec>(propagateMC, useccdb, inputSubspec, outputSubspec),
                                           o2::framework::Options{
                                             {"fitmethod", o2::framework::VariantType::String, "gamma2", {"Fit method (standard or gamma2)"}}}};
 }

--- a/Detectors/EMCAL/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/EMCAL/workflow/src/RecoWorkflow.cxx
@@ -47,7 +47,8 @@ namespace reco_workflow
 o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
                                         bool askDISTSTF,
                                         bool enableDigitsPrinter,
-                                        int subspecification,
+                                        int subspecificationIn,
+                                        int subspecificationOut,
                                         std::string const& cfgInput,
                                         std::string const& cfgOutput,
                                         bool disableRootInput,
@@ -170,10 +171,10 @@ o2::framework::WorkflowSpec getWorkflow(bool propagateMC,
   if (isEnabled(OutputType::Cells)) {
     // add converter for cells
     if (inputType == InputType::Digits) {
-      specs.emplace_back(o2::emcal::reco_workflow::getCellConverterSpec(propagateMC, useccdb, subspecification));
+      specs.emplace_back(o2::emcal::reco_workflow::getCellConverterSpec(propagateMC, useccdb, subspecificationIn, subspecificationOut));
     } else if (inputType == InputType::Raw) {
       // raw data will come from upstream
-      specs.emplace_back(o2::emcal::reco_workflow::getRawToCellConverterSpec(askDISTSTF, disableDecodingErrors, subspecification));
+      specs.emplace_back(o2::emcal::reco_workflow::getRawToCellConverterSpec(askDISTSTF, disableDecodingErrors, subspecificationOut));
     }
   }
 

--- a/Detectors/EMCAL/workflow/src/emc-reco-workflow.cxx
+++ b/Detectors/EMCAL/workflow/src/emc-reco-workflow.cxx
@@ -55,7 +55,8 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
     {"disable-decoding-errors", o2::framework::VariantType::Bool, false, {"disable propagating decoding errors"}},
     {"ignore-dist-stf", o2::framework::VariantType::Bool, false, {"do not subscribe to FLP/DISTSUBTIMEFRAME/0 message (no lost TF recovery)"}},
     {"use-ccdb", o2::framework::VariantType::Bool, false, {"enable access to ccdb EMCAL simulation objects"}},
-    {"subspecification", o2::framework::VariantType::Int, 0, {"Subspecification in case the workflow runs in parallel on multiple nodes (i.e. different FLPs)"}}};
+    {"subspecificationIn", o2::framework::VariantType::Int, 0, {"Subspecification for input in case the workflow runs in parallel on multiple nodes (i.e. different FLPs)"}},
+    {"subspecificationOut", o2::framework::VariantType::Int, 0, {"Subspecification for output in case the workflow runs in parallel on multiple nodes (i.e. different FLPs)"}}};
   o2::raw::HBFUtilsInitializer::addConfigOption(options);
   std::swap(workflowOptions, options);
 }
@@ -80,7 +81,8 @@ o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext co
   auto wf = o2::emcal::reco_workflow::getWorkflow(!cfgc.options().get<bool>("disable-mc"),
                                                   !cfgc.options().get<bool>("ignore-dist-stf"),
                                                   cfgc.options().get<bool>("enable-digits-printer"),
-                                                  cfgc.options().get<int>("subspecification"),
+                                                  cfgc.options().get<int>("subspecificationIn"),
+                                                  cfgc.options().get<int>("subspecificationOut"),
                                                   cfgc.options().get<std::string>("input-type"),
                                                   cfgc.options().get<std::string>("output-type"),
                                                   cfgc.options().get<bool>("disable-root-input"),


### PR DESCRIPTION
**AODProducerWorkflowSpec**:
- Add TMCCaloLabelCursor to addToCaloTable and fillCaloTable to fill the McCaloLabels
- Add new ConfigParamSpec `emc-select-leading` which will set the member variable `mEMCselectLeading`. If this flag is set to true, we will only save the MC Particle with the largest AmplitudeFraction for each cell. Otherwise we will save all MC Particles inside the table, except noise which we will never save.
- Moved fillCaloTable function call down after the fillMCParticlesTable so the MCParticlesTable are filled
- Moved `bcsMap.clear();` behind the filling of the MCParticle table

**DataFormatsPHOS/EventData**, **DataFormatsPHOS/EventHandler** and **DataFormatsPHOS/MCLabel**:
- Adjusted PHOS EventData class and MCLabel class to contain the needed members and functionalities, so that this will compile. Compare to https://github.com/AliceO2Group/AliceO2/pull/11117 where this was done for the EMCal.
- Increment ClassDefNV

**AnalysisDataModel**:
- Remove of Mask column for McCaloLabel table. After careful consideration we concluded that we do not need the mask column in Run3 and thus we decided to drop it.

**emc-reco-workflow**:
- Addition of inputsubspec option for emc-reco-workflow. Before the subspec could only be set for in AND output, now this is separate, which was needed to test the AODProducer chain with the recalib workflow.


- Connected to PR #11117 and PR #10670