### PR TITLE
[EMCAL-688] Fix check if lookup table is initialised

### DIFF
--- a/Detectors/EMCAL/base/src/ClusterFactory.cxx
+++ b/Detectors/EMCAL/base/src/ClusterFactory.cxx
@@ -598,7 +598,7 @@ bool ClusterFactory<InputType>::isExoticCell(short towerId, float ecell, float c
   }
 
   // if the look up table is not set yet (mostly due to a reset call) then set it up now.
-  if (getLookUpInit()) {
+  if (!getLookUpInit()) {
     throw UninitLookUpTableException();
   }
 


### PR DESCRIPTION
- `if (!getLookUpInit())` was `if (getLookUpInit())` in isExoticCell, which lead to throwing errors of uninitialised lookup table when the table was in fact initialised.
- Connected to PR #11062