### PR TITLE
ZDC fix formatting of log message

### DIFF
--- a/Detectors/ZDC/calib/src/TDCCalib.cxx
+++ b/Detectors/ZDC/calib/src/TDCCalib.cxx
@@ -73,7 +73,7 @@ int TDCCalib::endOfRun()
       LOGF(info, "Processed RUN3 data for ih = %d: %s", ih, TDCCalibData::CTDC[ih]);
       assign(ih, true);
     } else {
-      LOGF(info, "FAILED processing RUN3 data for ih = %d: %s: TOO FEW EVENTS: %d", ih, TDCCalibData::CTDC[ih], 5); //instead of 5 put number of events
+      LOGF(info, "FAILED processing RUN3 data for ih = %d: %s: TOO FEW EVENTS: %d", ih, TDCCalibData::CTDC[ih], 5); // instead of 5 put number of events
       assign(ih, false);
     }
   }

--- a/Detectors/ZDC/calib/src/TDCCalib.cxx
+++ b/Detectors/ZDC/calib/src/TDCCalib.cxx
@@ -73,7 +73,7 @@ int TDCCalib::endOfRun()
       LOGF(info, "Processed RUN3 data for ih = %d: %s", ih, TDCCalibData::CTDC[ih]);
       assign(ih, true);
     } else {
-      LOGF(info, "FAILED processing RUN3 data for ih = %d: %s: TOO FEW EVENTS: %g", ih, TDCCalibData::CTDC[ih], 5); //instead of 5 put number of events
+      LOGF(info, "FAILED processing RUN3 data for ih = %d: %s: TOO FEW EVENTS: %d", ih, TDCCalibData::CTDC[ih], 5); //instead of 5 put number of events
       assign(ih, false);
     }
   }


### PR DESCRIPTION
ZDC calibration is crashing due to this, see e.g.

```
E | 3 | 06/04/2023 | 20:40:56.459 | epn-calib1 |   | STDERR | stderr/zdc-tdc-calib_calib10_20 | 2eXRdx6XZ13 | 534169 |   |   | stderr: terminate called after throwing an instance of 'fmt::v9::format_error'
```
In general `LOGP(info, "Message {} with number {}", foo, bar)` might be less error prone than the printf syntax `LOGF` which requires type specifiers