### PR TITLE
ITS-vertexer: fix deltaphi calculation in tracklet selection

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -35,6 +35,12 @@ namespace its
 using boost::histogram::indexed;
 using constants::math::TwoPi;
 
+float smallestAngleDifference(float a, float b)
+{
+  float diff = fmod(b - a + constants::math::Pi, constants::math::TwoPi) - constants::math::Pi;
+  return (diff < -constants::math::Pi) ? diff + constants::math::TwoPi : ((diff > constants::math::Pi) ? diff - constants::math::TwoPi : diff);
+}
+
 template <TrackletMode Mode, bool DryRun>
 void trackleterKernelHost(
   const gsl::span<const Cluster>& clustersNextLayer,    // 0 2
@@ -113,7 +119,7 @@ void trackletSelectionKernelHost(
     for (int iTracklet12{offset12}; iTracklet12 < offset12 + foundTracklets12[iCurrentLayerClusterIndex]; ++iTracklet12) {
       for (int iTracklet01{offset01}; iTracklet01 < offset01 + foundTracklets01[iCurrentLayerClusterIndex]; ++iTracklet01) {
         const float deltaTanLambda{o2::gpu::GPUCommonMath::Abs(tracklets01[iTracklet01].tanLambda - tracklets12[iTracklet12].tanLambda)};
-        const float deltaPhi{o2::gpu::GPUCommonMath::Abs(tracklets01[iTracklet01].phi - tracklets12[iTracklet12].phi)};
+        const float deltaPhi{o2::gpu::GPUCommonMath::Abs(smallestAngleDifference(tracklets01[iTracklet01].phi, tracklets12[iTracklet12].phi))};
         if (!usedTracklets[iTracklet01] && deltaTanLambda < tanLambdaCut && deltaPhi < phiCut && validTracklets != maxTracklets) {
           usedTracklets[iTracklet01] = true;
           destTracklets.emplace_back(tracklets01[iTracklet01], clusters0.data(), clusters1.data());


### PR DESCRIPTION
@shahor02 
Concerning the bug found in tracklet selection.
The cut is: `deltaphi < cutphi`.
This fixes the obvious cases where difference hops across TwoPi periodicity.

before:
![pre](https://user-images.githubusercontent.com/4990252/230629336-503a0714-b368-46c1-8a59-453d525f0ed1.jpg)

after:
![post](https://user-images.githubusercontent.com/4990252/230629559-c754ce2f-b9b0-4f84-9866-0d22a309c105.jpg)

Will fix also for GPU at next iteration.
