### PR TITLE
[EMCAL-688] Remove old container init functions

### DIFF
--- a/Detectors/EMCAL/base/include/EMCALBase/ClusterFactory.h
+++ b/Detectors/EMCAL/base/include/EMCALBase/ClusterFactory.h
@@ -331,21 +331,6 @@ class ClusterFactory
   bool getUseWeightExotic() const { return mUseWeightExotic; }
   void setUseWeightExotic(float useWeightExotic) { mUseWeightExotic = useWeightExotic; }
 
-  void setClustersContainer(gsl::span<const o2::emcal::Cluster> clusterContainer)
-  {
-    mClustersContainer = clusterContainer;
-  }
-
-  void setCellsContainer(gsl::span<const InputType> cellContainer)
-  {
-    mInputsContainer = cellContainer;
-  }
-
-  void setCellsIndicesContainer(gsl::span<const int> indicesContainer)
-  {
-    mCellsIndices = indicesContainer;
-  }
-
   void setContainer(gsl::span<const o2::emcal::Cluster> clusterContainer, gsl::span<const InputType> cellContainer, gsl::span<const int> indicesContainer)
   {
     mClustersContainer = clusterContainer;

--- a/Detectors/EMCAL/workflow/src/AnalysisClusterSpec.cxx
+++ b/Detectors/EMCAL/workflow/src/AnalysisClusterSpec.cxx
@@ -138,9 +138,7 @@ void AnalysisClusterSpec<InputType>::run(framework::ProcessingContext& ctx)
     auto inputEvent = mEventHandler->buildEvent(iev);
 
     mClusterFactory->reset();
-    mClusterFactory->setClustersContainer(inputEvent.mClusters);
-    mClusterFactory->setCellsContainer(Inputs);
-    mClusterFactory->setCellsIndicesContainer(inputEvent.mCellIndices);
+    mClusterFactory->setContainer(inputEvent.mClusters, Inputs, inputEvent.mCellIndices);
 
     //for (const auto& analysisCluster : mClusterFactory) {
     for (int icl = 0; icl < mClusterFactory->getNumberOfClusters(); icl++) {


### PR DESCRIPTION
- Remove the old init functions for the cluster, cell and index container
- Change to the new init function in AnalysisClusterSpec.cxx